### PR TITLE
[NTOSKRNL] Fix a double reference on client impersonation and refactor SeTokenCanImpersonate

### DIFF
--- a/ntoskrnl/se/token.c
+++ b/ntoskrnl/se/token.c
@@ -3,7 +3,7 @@
  * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
  * PURPOSE:     Security access token implementation base support routines
  * COPYRIGHT:   Copyright David Welch <welch@cwcom.net>
- *              Copyright 2021-2022 George Bișoc <george.bisoc@reactos.org>
+ *              Copyright 2021-2023 George Bișoc <george.bisoc@reactos.org>
  */
 
 /* INCLUDES *******************************************************************/
@@ -1752,16 +1752,13 @@ PTOKEN
 NTAPI
 SepCreateSystemProcessToken(VOID)
 {
-    LUID_AND_ATTRIBUTES Privileges[25];
     ULONG GroupAttributes, OwnerAttributes;
-    SID_AND_ATTRIBUTES Groups[32];
     LARGE_INTEGER Expiration;
     SID_AND_ATTRIBUTES UserSid;
     ULONG GroupsLength;
     PSID PrimaryGroup;
     OBJECT_ATTRIBUTES ObjectAttributes;
     PSID Owner;
-    ULONG i;
     PTOKEN Token;
     NTSTATUS Status;
 
@@ -1783,80 +1780,46 @@ SepCreateSystemProcessToken(VOID)
     Owner = SeAliasAdminsSid;
 
     /* Groups are Administrators, World, and Authenticated Users */
-    Groups[0].Sid = SeAliasAdminsSid;
-    Groups[0].Attributes = OwnerAttributes;
-    Groups[1].Sid = SeWorldSid;
-    Groups[1].Attributes = GroupAttributes;
-    Groups[2].Sid = SeAuthenticatedUsersSid;
-    Groups[2].Attributes = GroupAttributes;
+    SID_AND_ATTRIBUTES Groups[] =
+    {
+        {SeAliasAdminsSid, OwnerAttributes},
+        {SeWorldSid, GroupAttributes},
+        {SeAuthenticatedUsersSid, GroupAttributes}
+    };
     GroupsLength = sizeof(SID_AND_ATTRIBUTES) +
                    SeLengthSid(Groups[0].Sid) +
                    SeLengthSid(Groups[1].Sid) +
                    SeLengthSid(Groups[2].Sid);
-    ASSERT(GroupsLength <= sizeof(Groups));
+    ASSERT(GroupsLength <= (sizeof(Groups) * sizeof(ULONG)));
 
     /* Setup the privileges */
-    i = 0;
-    Privileges[i].Attributes = SE_PRIVILEGE_ENABLED_BY_DEFAULT | SE_PRIVILEGE_ENABLED;
-    Privileges[i++].Luid = SeTcbPrivilege;
-
-    Privileges[i].Attributes = 0;
-    Privileges[i++].Luid = SeCreateTokenPrivilege;
-
-    Privileges[i].Attributes = 0;
-    Privileges[i++].Luid = SeTakeOwnershipPrivilege;
-
-    Privileges[i].Attributes = SE_PRIVILEGE_ENABLED_BY_DEFAULT | SE_PRIVILEGE_ENABLED;
-    Privileges[i++].Luid = SeCreatePagefilePrivilege;
-
-    Privileges[i].Attributes = SE_PRIVILEGE_ENABLED_BY_DEFAULT | SE_PRIVILEGE_ENABLED;
-    Privileges[i++].Luid = SeLockMemoryPrivilege;
-
-    Privileges[i].Attributes = 0;
-    Privileges[i++].Luid = SeAssignPrimaryTokenPrivilege;
-
-    Privileges[i].Attributes = 0;
-    Privileges[i++].Luid = SeIncreaseQuotaPrivilege;
-
-    Privileges[i].Attributes = SE_PRIVILEGE_ENABLED_BY_DEFAULT | SE_PRIVILEGE_ENABLED;
-    Privileges[i++].Luid = SeIncreaseBasePriorityPrivilege;
-
-    Privileges[i].Attributes = SE_PRIVILEGE_ENABLED_BY_DEFAULT | SE_PRIVILEGE_ENABLED;
-    Privileges[i++].Luid = SeCreatePermanentPrivilege;
-
-    Privileges[i].Attributes = SE_PRIVILEGE_ENABLED_BY_DEFAULT | SE_PRIVILEGE_ENABLED;
-    Privileges[i++].Luid = SeDebugPrivilege;
-
-    Privileges[i].Attributes = SE_PRIVILEGE_ENABLED_BY_DEFAULT | SE_PRIVILEGE_ENABLED;
-    Privileges[i++].Luid = SeAuditPrivilege;
-
-    Privileges[i].Attributes = 0;
-    Privileges[i++].Luid = SeSecurityPrivilege;
-
-    Privileges[i].Attributes = 0;
-    Privileges[i++].Luid = SeSystemEnvironmentPrivilege;
-
-    Privileges[i].Attributes = SE_PRIVILEGE_ENABLED_BY_DEFAULT | SE_PRIVILEGE_ENABLED;
-    Privileges[i++].Luid = SeChangeNotifyPrivilege;
-
-    Privileges[i].Attributes = 0;
-    Privileges[i++].Luid = SeBackupPrivilege;
-
-    Privileges[i].Attributes = 0;
-    Privileges[i++].Luid = SeRestorePrivilege;
-
-    Privileges[i].Attributes = 0;
-    Privileges[i++].Luid = SeShutdownPrivilege;
-
-    Privileges[i].Attributes = 0;
-    Privileges[i++].Luid = SeLoadDriverPrivilege;
-
-    Privileges[i].Attributes = SE_PRIVILEGE_ENABLED_BY_DEFAULT | SE_PRIVILEGE_ENABLED;
-    Privileges[i++].Luid = SeProfileSingleProcessPrivilege;
-
-    Privileges[i].Attributes = 0;
-    Privileges[i++].Luid = SeSystemtimePrivilege;
-    ASSERT(i == 20);
+    LUID_AND_ATTRIBUTES Privileges[] =
+    {
+        {SeTcbPrivilege, SE_PRIVILEGE_ENABLED_BY_DEFAULT | SE_PRIVILEGE_ENABLED},
+        {SeCreateTokenPrivilege, 0},
+        {SeTakeOwnershipPrivilege, 0},
+        {SeCreatePagefilePrivilege, SE_PRIVILEGE_ENABLED_BY_DEFAULT | SE_PRIVILEGE_ENABLED},
+        {SeLockMemoryPrivilege, SE_PRIVILEGE_ENABLED_BY_DEFAULT | SE_PRIVILEGE_ENABLED},
+        {SeAssignPrimaryTokenPrivilege, 0},
+        {SeIncreaseQuotaPrivilege, 0},
+        {SeIncreaseBasePriorityPrivilege, SE_PRIVILEGE_ENABLED_BY_DEFAULT | SE_PRIVILEGE_ENABLED},
+        {SeCreatePermanentPrivilege, SE_PRIVILEGE_ENABLED_BY_DEFAULT | SE_PRIVILEGE_ENABLED},
+        {SeDebugPrivilege, SE_PRIVILEGE_ENABLED_BY_DEFAULT | SE_PRIVILEGE_ENABLED},
+        {SeAuditPrivilege, SE_PRIVILEGE_ENABLED_BY_DEFAULT | SE_PRIVILEGE_ENABLED},
+        {SeSecurityPrivilege, 0},
+        {SeSystemEnvironmentPrivilege, 0},
+        {SeChangeNotifyPrivilege, SE_PRIVILEGE_ENABLED_BY_DEFAULT | SE_PRIVILEGE_ENABLED},
+        {SeBackupPrivilege, 0},
+        {SeRestorePrivilege, 0},
+        {SeShutdownPrivilege, 0},
+        {SeLoadDriverPrivilege, 0},
+        {SeProfileSingleProcessPrivilege, SE_PRIVILEGE_ENABLED_BY_DEFAULT | SE_PRIVILEGE_ENABLED},
+        {SeSystemtimePrivilege, 0},
+        {SeUndockPrivilege, 0},
+        {SeManageVolumePrivilege, 0},
+        {SeImpersonatePrivilege, SE_PRIVILEGE_ENABLED_BY_DEFAULT | SE_PRIVILEGE_ENABLED},
+        {SeCreateGlobalPrivilege, SE_PRIVILEGE_ENABLED_BY_DEFAULT | SE_PRIVILEGE_ENABLED},
+    };
 
     /* Setup the object attributes */
     InitializeObjectAttributes(&ObjectAttributes, NULL, 0, NULL, NULL);
@@ -1872,10 +1835,10 @@ SepCreateSystemProcessToken(VOID)
                             &SeSystemAuthenticationId,
                             &Expiration,
                             &UserSid,
-                            3,
+                            RTL_NUMBER_OF(Groups),
                             Groups,
                             GroupsLength,
-                            20,
+                            RTL_NUMBER_OF(Privileges),
                             Privileges,
                             Owner,
                             PrimaryGroup,
@@ -1902,7 +1865,7 @@ CODE_SEG("INIT")
 PTOKEN
 SepCreateSystemAnonymousLogonToken(VOID)
 {
-    SID_AND_ATTRIBUTES Groups[32], UserSid;
+    SID_AND_ATTRIBUTES UserSid;
     PSID PrimaryGroup;
     PTOKEN Token;
     ULONG GroupsLength;
@@ -1921,11 +1884,13 @@ SepCreateSystemAnonymousLogonToken(VOID)
     PrimaryGroup = SeAnonymousLogonSid;
 
     /* The only group for the token is the World */
-    Groups[0].Sid = SeWorldSid;
-    Groups[0].Attributes = SE_GROUP_ENABLED | SE_GROUP_MANDATORY | SE_GROUP_ENABLED_BY_DEFAULT;
+    SID_AND_ATTRIBUTES Groups[] =
+    {
+        {SeWorldSid, SE_GROUP_ENABLED | SE_GROUP_MANDATORY | SE_GROUP_ENABLED_BY_DEFAULT}
+    };
     GroupsLength = sizeof(SID_AND_ATTRIBUTES) +
                    SeLengthSid(Groups[0].Sid);
-    ASSERT(GroupsLength <= sizeof(Groups));
+    ASSERT(GroupsLength <= (sizeof(Groups) * sizeof(ULONG)));
 
     /* Initialise the object attributes for the token */
     InitializeObjectAttributes(&ObjectAttributes, NULL, 0, NULL, NULL);
@@ -1941,7 +1906,7 @@ SepCreateSystemAnonymousLogonToken(VOID)
                             &SeAnonymousAuthenticationId,
                             &Expiration,
                             &UserSid,
-                            1,
+                            RTL_NUMBER_OF(Groups),
                             Groups,
                             GroupsLength,
                             0,

--- a/ntoskrnl/se/token.c
+++ b/ntoskrnl/se/token.c
@@ -2158,22 +2158,47 @@ SeTokenIsWriteRestricted(
 
 /**
  * @brief
- * Ensures that client impersonation can occur by checking if the token
- * we're going to assign as the impersonation token can be actually impersonated
- * in the first place. The routine is used primarily by PsImpersonateClient.
+ * Determines whether the server is allowed to impersonate on behalf
+ * of a client or not. For further details, see Remarks.
  *
  * @param[in] ProcessToken
- * Token from a process.
+ * A pointer to the primary access token of the server process
+ * that requests impersonation of the client target.
  *
  * @param[in] TokenToImpersonate
- * Token that we are going to impersonate.
+ * A pointer to an access token that represents a client that is to
+ * be impersonated.
  *
  * @param[in] ImpersonationLevel
- * Security impersonation level grade.
+ * The requested impersonation level.
  *
  * @return
  * Returns TRUE if the conditions checked are met for token impersonation,
  * FALSE otherwise.
+ *
+ * @remarks
+ * The server has to meet the following criteria in order to impersonate
+ * a client, that is:
+ *
+ * - The server must not impersonate a client beyond the level that
+ *   the client imposed on itself.
+ *
+ * - The server must be authenticated on the same logon session of
+ *   the target client.
+ *
+ * - IF NOT then the server's user ID has to match to that of the
+ *   target client.
+ *
+ * - The server must not be restricted in order to impersonate a
+ *   client that is not restricted.
+ *
+ * If the associated access token that represents the security properties
+ * of the server is granted the SeImpersonatePrivilege privilege the server
+ * is given immediate impersonation, regardless of the conditions above.
+ * If the client in question is associated with an anonymous token then
+ * the server is given immediate impersonation. Or if the server simply
+ * doesn't ask for impersonation but instead it wants to get the security
+ * identification of a client, the server is given immediate impersonation.
  */
 BOOLEAN
 NTAPI
@@ -2186,73 +2211,87 @@ SeTokenCanImpersonate(
     PAGED_CODE();
 
     /*
-     * SecurityAnonymous and SecurityIdentification levels do not
-     * allow impersonation.
+     * The server may want to obtain identification details of a client
+     * instead of impersonating so just give the server a pass.
      */
-    if (ImpersonationLevel == SecurityAnonymous ||
-        ImpersonationLevel == SecurityIdentification)
+    if (ImpersonationLevel < SecurityIdentification)
     {
-        return FALSE;
+        DPRINT("The server doesn't ask for impersonation\n");
+        return TRUE;
     }
 
     /* Time to lock our tokens */
     SepAcquireTokenLockShared(ProcessToken);
     SepAcquireTokenLockShared(TokenToImpersonate);
 
-    /* What kind of authentication ID does the token have? */
+    /*
+     * As the name implies, an anonymous token has invisible security
+     * identification details. By the general rule these tokens do not
+     * pose a danger in terms of power escalation so give the server a pass.
+     */
     if (RtlEqualLuid(&TokenToImpersonate->AuthenticationId,
                      &SeAnonymousAuthenticationId))
     {
-        /*
-         * OK, it looks like the token has an anonymous
-         * authentication. Is that token created by the system?
-         */
-        if (TokenToImpersonate->TokenSource.SourceName != SeSystemTokenSource.SourceName &&
-            !RtlEqualLuid(&TokenToImpersonate->TokenSource.SourceIdentifier, &SeSystemTokenSource.SourceIdentifier))
+        DPRINT("The token to impersonate has an anonymous authentication ID, allow impersonation either way\n");
+        CanImpersonate = TRUE;
+        goto Quit;
+    }
+
+    /* Allow impersonation for the process server if it's granted the impersonation privilege */
+    if ((ProcessToken->TokenFlags & TOKEN_HAS_IMPERSONATE_PRIVILEGE) != 0)
+    {
+        DPRINT("The process is granted the impersonation privilege, allow impersonation\n");
+        CanImpersonate = TRUE;
+        goto Quit;
+    }
+
+    /*
+     * Deny impersonation for the server if it wants to impersonate a client
+     * beyond what the impersonation level originally permits.
+     */
+    if (ImpersonationLevel > TokenToImpersonate->ImpersonationLevel)
+    {
+        DPRINT1("Cannot impersonate a client above the permitted impersonation level!\n");
+        CanImpersonate = FALSE;
+        goto Quit;
+    }
+
+    /* Is the server authenticated on the same client originating session? */
+    if (!RtlEqualLuid(&ProcessToken->AuthenticationId,
+                      &TokenToImpersonate->OriginatingLogonSession))
+    {
+        /* It's not, check that at least both the server and client are the same user */
+        if (!RtlEqualSid(ProcessToken->UserAndGroups[0].Sid,
+                         TokenToImpersonate->UserAndGroups[0].Sid))
         {
-            /* It isn't, we can't impersonate regular tokens */
-            DPRINT("SeTokenCanImpersonate(): Token has an anonymous authentication ID, can't impersonate!\n");
+            DPRINT1("Server and client aren't the same user!\n");
+            CanImpersonate = FALSE;
+            goto Quit;
+        }
+
+        /*
+         * Make sure the tokens haven't diverged in terms of restrictions
+         * that is one token is restricted but the other one isn't. If that
+         * would have been the case then the server would have impersonated
+         * a less restricted client thus potentially triggering an elevation,
+         * which is not what we want.
+         */
+        if (SeTokenIsRestricted(ProcessToken) !=
+            SeTokenIsRestricted(TokenToImpersonate))
+        {
+            DPRINT1("Attempting to impersonate a less restricted client token, bail out!\n");
             CanImpersonate = FALSE;
             goto Quit;
         }
     }
 
-    /* Are the SID values from both tokens equal? */
-    if (!RtlEqualSid(ProcessToken->UserAndGroups->Sid,
-                     TokenToImpersonate->UserAndGroups->Sid))
-    {
-        /* They aren't, bail out */
-        DPRINT("SeTokenCanImpersonate(): Tokens SIDs are not equal!\n");
-        CanImpersonate = FALSE;
-        goto Quit;
-    }
-
-    /*
-     * Make sure the tokens aren't diverged in terms of
-     * restrictions, that is, one token is restricted
-     * but the other one isn't.
-     */
-    if (SeTokenIsRestricted(ProcessToken) !=
-        SeTokenIsRestricted(TokenToImpersonate))
-    {
-        /*
-         * One token is restricted so we cannot
-         * continue further at this point, bail out.
-         */
-        DPRINT("SeTokenCanImpersonate(): One token is restricted, can't continue!\n");
-        CanImpersonate = FALSE;
-        goto Quit;
-    }
-
     /* If we've reached that far then we can impersonate! */
-    DPRINT("SeTokenCanImpersonate(): We can impersonate.\n");
+    DPRINT("We can impersonate\n");
     CanImpersonate = TRUE;
 
 Quit:
-    /* We're done, unlock the tokens now */
-    SepReleaseTokenLock(ProcessToken);
     SepReleaseTokenLock(TokenToImpersonate);
-
+    SepReleaseTokenLock(ProcessToken);
     return CanImpersonate;
 }
 


### PR DESCRIPTION
Back then I was working on #3605 that would determine if the server is allowed to impersonate a client's token or not, although after learning more about how impersonation works there are several issues concerning with `SeTokenCanImpersonate`, that is...

- `ImpersonationLevel` is basically what the server asks to impersonate a client based on that level, having there failing if the level was either given `SecurityAnonymous` or `SecurityIdentification` doesn't make much sense. If the server wants to identify the details of a client then let it do so.
- The function does not check for `SeImpersonatePrivilege`. Certain system components of the OS or the system process itself might need to impersonate on behalf of a client to do specific OS tasks, so give them leverage.
- The function does not check if the server is authenticated on the same logon session of the client, nor it checks if it requests an impersonation that is beyond the acceptable level that the client permits.
- The code path that looks for the client's token having an anonymous authentication doesn't make much sense, specifically where it fails impersonation if an anonymous token wasn't created by the system. On contrary, anonymous tokens are only created by the system and as their name imply, they have hidden security attributes with no privileges attached to them so one could freely impersonate such token.

In addition to that there are two bugs in `PsImpersonateClient`, that is, we're trying to reference a token after we filled out thread impersonation info. However we aren't taking into account that if impersonation is not possible we are making a copy of the client token and `SeCopyClientToken` already holds a reference which means we are gaining an extra reference count. Therefore if the server was to cancel impersonation the previously copied token still has an extra reference and the token won't go away, WHICH IS WRONG! 

Also, if impersonation fails we are assigning the impersonation level to the thread that is given by the caller, instead of assigning it as `SecurityIdentification`. This could lead to erratic behaviors or worse, as the token doesn't allow for impersonation yet the thread thinks it can actually impersonate as per its impersonation info.

Some interesting stuff:
https://www.youtube.com/watch?v=QRpfvmMbDMg
https://learn.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/impersonate-a-client-after-authentication
https://juggernaut-sec.com/seimpersonateprivilege/