### PR TITLE
[NTOS:PNP] Refactor remaining functions after PnP manager rewrite. CORE-18961

### DIFF
--- a/ntoskrnl/include/internal/io.h
+++ b/ntoskrnl/include/internal/io.h
@@ -1436,7 +1436,7 @@ NTSTATUS
 PiIrpQueryPnPDeviceId(
     _In_ PDEVICE_NODE DeviceNode,
     _In_ BUS_QUERY_ID_TYPE IdType,
-    _Out_ PWCHAR *Id);
+    _Out_ PZZWSTR *Id);
 
 //
 // Global I/O Data

--- a/ntoskrnl/include/internal/io.h
+++ b/ntoskrnl/include/internal/io.h
@@ -629,8 +629,9 @@ IopFreeDeviceNode(
 
 NTSTATUS
 NTAPI
-IopQueryDeviceCapabilities(PDEVICE_NODE DeviceNode,
-                           PDEVICE_CAPABILITIES DeviceCaps);
+PiSetDeviceCapabilities(
+    _In_ PDEVICE_NODE DeviceNode,
+    _Out_ PDEVICE_CAPABILITIES DeviceCaps);
 
 NTSTATUS
 IopSynchronousCall(
@@ -1425,6 +1426,11 @@ NTSTATUS
 PiIrpQueryPnPDeviceState(
     _In_ PDEVICE_NODE DeviceNode,
     _Out_ PPNP_DEVICE_STATE DeviceState);
+
+NTSTATUS
+PiIrpQueryPnPDeviceCapabilities(
+    _In_ PDEVICE_NODE DeviceNode,
+    _Out_ PDEVICE_CAPABILITIES DeviceCaps);
 
 //
 // Global I/O Data

--- a/ntoskrnl/include/internal/io.h
+++ b/ntoskrnl/include/internal/io.h
@@ -1432,6 +1432,12 @@ PiIrpQueryPnPDeviceCapabilities(
     _In_ PDEVICE_NODE DeviceNode,
     _Out_ PDEVICE_CAPABILITIES DeviceCaps);
 
+NTSTATUS
+PiIrpQueryPnPDeviceId(
+    _In_ PDEVICE_NODE DeviceNode,
+    _In_ BUS_QUERY_ID_TYPE IdType,
+    _Out_ PWCHAR *Id);
+
 //
 // Global I/O Data
 //

--- a/ntoskrnl/io/pnpmgr/devaction.c
+++ b/ntoskrnl/io/pnpmgr/devaction.c
@@ -1595,7 +1595,9 @@ PiStartDeviceFinal(
     if (NT_SUCCESS(Status))
     {
         PiSetDeviceCapabilities(DeviceNode, &DeviceCapabilities);
-    } else {
+    }
+    else
+    {
         DPRINT("PiIrpQueryPnPDeviceCapabilities() failed (Status 0x%08lx)\n", Status);
     }
 

--- a/ntoskrnl/io/pnpmgr/devaction.c
+++ b/ntoskrnl/io/pnpmgr/devaction.c
@@ -931,7 +931,7 @@ NTSTATUS
 IopQueryHardwareIds(PDEVICE_NODE DeviceNode,
                     HANDLE InstanceKey)
 {
-    PWCHAR HwId;
+    PZZWSTR HwIds;
     PWSTR Ptr;
     UNICODE_STRING ValueName;
     NTSTATUS Status;
@@ -940,10 +940,10 @@ IopQueryHardwareIds(PDEVICE_NODE DeviceNode,
 
     DPRINT("IopQueryHardwareIds() query BusQueryHardwareIDs from device stack\n");
 
-    Status = PiIrpQueryPnPDeviceId(DeviceNode, BusQueryHardwareIDs, &HwId);
+    Status = PiIrpQueryPnPDeviceId(DeviceNode, BusQueryHardwareIDs, &HwIds);
     if (NT_SUCCESS(Status))
     {
-        IsValidID = IopValidateID(HwId, BusQueryHardwareIDs);
+        IsValidID = IopValidateID(HwIds, BusQueryHardwareIDs);
 
         if (!IsValidID)
         {
@@ -952,7 +952,7 @@ IopQueryHardwareIds(PDEVICE_NODE DeviceNode,
 
         TotalLength = 0;
 
-        Ptr = (PWSTR)HwId;
+        Ptr = (PWSTR)HwIds;
         DPRINT("Hardware IDs:\n");
         while (*Ptr)
         {
@@ -970,15 +970,15 @@ IopQueryHardwareIds(PDEVICE_NODE DeviceNode,
                                &ValueName,
                                0,
                                REG_MULTI_SZ,
-                               (PVOID)HwId,
+                               (PVOID)HwIds,
                                (TotalLength + 1) * sizeof(WCHAR));
         if (!NT_SUCCESS(Status))
         {
             DPRINT1("ZwSetValueKey() failed (Status %lx)\n", Status);
         }
 
-        if (HwId)
-            ExFreePool(HwId);
+        if (HwIds)
+            ExFreePool(HwIds);
     }
     else
     {

--- a/ntoskrnl/io/pnpmgr/devaction.c
+++ b/ntoskrnl/io/pnpmgr/devaction.c
@@ -940,7 +940,6 @@ IopQueryHardwareIds(PDEVICE_NODE DeviceNode,
 
     DPRINT("IopQueryHardwareIds() query BusQueryHardwareIDs from device stack\n");
 
-     ;
     Status = PiIrpQueryPnPDeviceId(DeviceNode, BusQueryHardwareIDs, &HwId);
     if (NT_SUCCESS(Status))
     {

--- a/ntoskrnl/io/pnpmgr/pnpirp.c
+++ b/ntoskrnl/io/pnpmgr/pnpirp.c
@@ -338,10 +338,8 @@ NTSTATUS
 PiIrpQueryPnPDeviceId(
     _In_ PDEVICE_NODE DeviceNode,
     _In_ BUS_QUERY_ID_TYPE IdType,
-    _Out_ PWCHAR *Id)
+    _Out_ PZZWSTR *Id)
 {
-    NTSTATUS Status;
-    ULONG_PTR LongId;
     IO_STACK_LOCATION Stack = {
         .MajorFunction = IRP_MJ_PNP,
         .MinorFunction = IRP_MN_QUERY_ID
@@ -355,13 +353,6 @@ PiIrpQueryPnPDeviceId(
            IdType == BusQueryDeviceSerialNumber || IdType == BusQueryContainerID);
 
     Stack.Parameters.QueryId.IdType = IdType;
-    *Id = NULL;
 
-    Status = IopSynchronousCall(DeviceNode->PhysicalDeviceObject, &Stack, (PVOID)&LongId);
-    if (NT_SUCCESS(Status))
-    {
-        *Id = (PVOID)LongId;
-    }
-
-    return Status;
+    return IopSynchronousCall(DeviceNode->PhysicalDeviceObject, &Stack, (PVOID)Id);
 }

--- a/ntoskrnl/io/pnpmgr/pnpirp.c
+++ b/ntoskrnl/io/pnpmgr/pnpirp.c
@@ -306,3 +306,29 @@ PiIrpQueryPnPDeviceState(
 
     return status;
 }
+
+// IRP_MN_QUERY_CAPABILITIES (0x09)
+NTSTATUS
+PiIrpQueryPnPDeviceCapabilities(
+    _In_ PDEVICE_NODE DeviceNode,
+    _Out_ PDEVICE_CAPABILITIES DeviceCaps)
+{
+    PAGED_CODE();
+
+    ASSERT(DeviceNode);
+
+    IO_STACK_LOCATION stack = {
+        .MajorFunction = IRP_MJ_PNP,
+        .MinorFunction = IRP_MN_QUERY_CAPABILITIES
+    };
+
+    RtlZeroMemory(DeviceCaps, sizeof(DEVICE_CAPABILITIES));
+    DeviceCaps->Size = sizeof(DEVICE_CAPABILITIES);
+    DeviceCaps->Version = 1;
+    DeviceCaps->Address = -1;
+    DeviceCaps->UINumber = -1;
+    stack.Parameters.DeviceCapabilities.Capabilities = DeviceCaps;
+
+    PVOID Dummy;
+    return IopSynchronousCall(DeviceNode->PhysicalDeviceObject, &stack, &Dummy);
+}

--- a/ntoskrnl/io/pnpmgr/pnpirp.c
+++ b/ntoskrnl/io/pnpmgr/pnpirp.c
@@ -332,3 +332,35 @@ PiIrpQueryPnPDeviceCapabilities(
     PVOID Dummy;
     return IopSynchronousCall(DeviceNode->PhysicalDeviceObject, &stack, &Dummy);
 }
+
+// IRP_MN_QUERY_ID (0x13)
+NTSTATUS
+PiIrpQueryPnPDeviceId(
+    _In_ PDEVICE_NODE DeviceNode,
+    _In_ BUS_QUERY_ID_TYPE IdType,
+    _Out_ PWCHAR *Id)
+{
+    PAGED_CODE();
+
+    ASSERT(DeviceNode);
+    ASSERT(IdType == BusQueryDeviceID || IdType == BusQueryHardwareIDs ||
+           IdType == BusQueryCompatibleIDs || IdType == BusQueryInstanceID ||
+           IdType == BusQueryDeviceSerialNumber || IdType == BusQueryContainerID);
+
+    IO_STACK_LOCATION stack = {
+        .MajorFunction = IRP_MJ_PNP,
+        .MinorFunction = IRP_MN_QUERY_ID
+    };
+    stack.Parameters.QueryId.IdType = IdType;
+    *Id = NULL;
+
+    ULONG_PTR longId;
+    NTSTATUS status;
+    status = IopSynchronousCall(DeviceNode->PhysicalDeviceObject, &stack, (PVOID)&longId);
+    if (NT_SUCCESS(status))
+    {
+        *Id = (PVOID)longId;
+    }
+
+    return status;
+}

--- a/ntoskrnl/io/pnpmgr/pnpirp.c
+++ b/ntoskrnl/io/pnpmgr/pnpirp.c
@@ -307,7 +307,17 @@ PiIrpQueryPnPDeviceState(
     return status;
 }
 
-// IRP_MN_QUERY_CAPABILITIES (0x09)
+/**
+ * @brief      Query device capabilities via IRP_MN_QUERY_CAPABILITIES (0x09)
+ *
+ * @param[in]  DeviceNode
+ *     Pointer to the device node object.
+ *
+ * @param[out] DeviceCaps
+ *     Pointer to the device capabilities object which is gonna be initilized and filled out.
+ *
+ * @return     Status of the operation
+ */
 NTSTATUS
 PiIrpQueryPnPDeviceCapabilities(
     _In_ PDEVICE_NODE DeviceNode,
@@ -333,7 +343,20 @@ PiIrpQueryPnPDeviceCapabilities(
     return IopSynchronousCall(DeviceNode->PhysicalDeviceObject, &Stack, &Dummy);
 }
 
-// IRP_MN_QUERY_ID (0x13)
+/**
+ * @brief      Query device capabilities via IRP_MN_QUERY_ID (0x13)
+ *
+ * @param[in]  DeviceNode
+ *     Pointer to the device node object.
+ *
+ * @param[in]  IdType
+ *     This contains the requested id type.
+ *
+ * @param[out] Id
+ *     This parameter will contain the ID(s) of the device.
+ *
+ * @return     Status of the operation
+ */
 NTSTATUS
 PiIrpQueryPnPDeviceId(
     _In_ PDEVICE_NODE DeviceNode,

--- a/ntoskrnl/io/pnpmgr/pnpmgr.c
+++ b/ntoskrnl/io/pnpmgr/pnpmgr.c
@@ -1457,7 +1457,7 @@ IoGetDeviceProperty(IN PDEVICE_OBJECT DeviceObject,
         case DevicePropertyAddress:
 
             /* Query the device caps */
-            Status = IopQueryDeviceCapabilities(DeviceNode, &DeviceCaps);
+            Status = PiIrpQueryPnPDeviceCapabilities(DeviceNode, &DeviceCaps);
             if (!NT_SUCCESS(Status) || (DeviceCaps.Address == MAXULONG))
                 return STATUS_OBJECT_NAME_NOT_FOUND;
 


### PR DESCRIPTION
## Purpose

Not all IRP sending functions are refactored after PnP manager rewrite
namely, IopQueryDeviceCapabilities, IopQueryHardwareIds, IopQueryCompatibleIds
They should have a function in pnpirp.c file that sends an IRP, and other related code in devaction.c

JIRA issue: [CORE-18961](https://jira.reactos.org/browse/CORE-18961)

## Proposed changes

- Intruducing two new IRP functions to query HardwareIds, CompatibleIds and device node capabilities.
- Separate device_node capabilities query and set functionality. 
- Centralize storing device_node capabilities in the PiInitializeDevNode() when the device_node enumeration occurs.
- Also adapt function names to NT5.2-like schema.

## TODO

