### PR TITLE
[WIN32SS][NTDDRAW] Don't startup DirectX graphics each time on DirectDraw object creation

### DIFF
--- a/win32ss/reactx/ntddraw/intddraw.h
+++ b/win32ss/reactx/ntddraw/intddraw.h
@@ -8,7 +8,6 @@
 #include <reactos/drivers/directx/dxeng.h>
 
 /* From ddraw.c */
-BOOL intEnableReactXDriver(HDC);
 NTSTATUS APIENTRY DxDdStartupDxGraphics(ULONG, PDRVENABLEDATA, ULONG, PDRVENABLEDATA, PULONG, PEPROCESS);
 extern DRVFN gpDxFuncs[];
 


### PR DESCRIPTION
## Purpose

Do it at each system startup instead, same as in Windows.
Remove old DirectX initialization code. Now it's outdated and not needed anymore. The corresponding functionality is now implemented properly by changes from #4519 and #4551 PRs.
Previously, the corresponding hackish `intEnableReactXDriver` function did two things: load dxg.sys and enable DirectDraw. Now loading DirectX graphics is done during WINSRV initialization, and enabling DirectDraw is called during each (and also first) display mode switch, same as in Windows. As debug analysis proves, there are no any other calls in `NtGdiDdCreateDirectDrawObject`, besides the corresponding DXG function. So MS does not do the initialization there.

JIRA issue: [CORE-17561](https://jira.reactos.org/browse/CORE-17561), [CORE-17932](https://jira.reactos.org/browse/CORE-17932), [CORE-18221](https://jira.reactos.org/browse/CORE-18221)

## Proposed changes

- Remove hackish `intEnableReactXDriver`.