### PR TITLE
[SHELL32] Strip leftover in CDefView::FillFileMenu()

### DIFF
--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -1348,8 +1348,6 @@ HRESULT CDefView::FillFileMenu()
             DeleteMenu(hFileMenu, i, MF_BYPOSITION);
     }
 
-    m_cidl = m_ListView.GetSelectedCount();
-
     /* In case we still have this left over, clean it up! */
     if (m_pFileMenu)
     {


### PR DESCRIPTION
## Purpose

In 0.4.14-dev-955-g 1cf564c25f532c32f9fae891f17a70e62d5c1c14 Katayama experimented with populating explorers file-menu when no object is selected.

Later we found out, that none of the new entries introduced by that commit really made sense and even created duplicates. So the commit was reverted by 0.4.15-dev-6039-g 0fa4edebd9125b9ca7a4256edbea7675e2152c7e 'Revert CDefView::FillFileMenu (#5278)' CORE-18429

But it seems that not all parts were properly reverted back then, maybe because 6 lines of new code were written between the two lines in the meantime.

Here is a video of the state with the PR applied
[this_is_the_after_PR_state_and_it_behaves_same_as_the_before_state.webm](https://github.com/reactos/reactos/assets/33393466/59af6c00-428b-4d5f-989f-75db883bdaee)
It behaves the same in my tests as without the PR applied.

JIRA issue: [CORE-18429](https://jira.reactos.org/browse/CORE-18429)

## TODO

Please wait with merging until Katayama expressed his consent. I do assume that leaving this code inside was an oopsie, but it may also be left inside intentionally as some future preparation.