### PR TITLE
[MSPAINT] Move selection by arrow keys

### DIFF
--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -777,6 +777,16 @@ VOID CCanvasWindow::EndSelectionDrag(POINT ptImage)
     Invalidate(FALSE);
 }
 
+VOID CCanvasWindow::MoveSelection(INT xDelta, INT yDelta)
+{
+    if (!selectionModel.m_bShow)
+        return;
+
+    selectionModel.TakeOff();
+    ::OffsetRect(&selectionModel.m_rc, xDelta, yDelta);
+    Invalidate(FALSE);
+}
+
 LRESULT CCanvasWindow::OnCtlColorEdit(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
     SetTextColor((HDC)wParam, paletteModel.GetFgColor());

--- a/base/applications/mspaint/canvas.h
+++ b/base/applications/mspaint/canvas.h
@@ -48,6 +48,7 @@ public:
     VOID CanvasToImage(POINT& pt, BOOL bZoomed = FALSE);
     VOID CanvasToImage(RECT& rc, BOOL bZoomed = FALSE);
     VOID GetImageRect(RECT& rc);
+    VOID MoveSelection(INT xDelta, INT yDelta);
 
 protected:
     CANVAS_HITTEST m_hitSelection;

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -493,17 +493,39 @@ LRESULT CMainWindow::OnGetMinMaxInfo(UINT nMsg, WPARAM wParam, LPARAM lParam, BO
 
 LRESULT CMainWindow::OnKeyDown(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
-    if (wParam == VK_ESCAPE)
+    HWND hwndCapture;
+    switch (wParam)
     {
-        HWND hwndCapture = GetCapture();
-        if (hwndCapture)
-        {
-            if (canvasWindow.m_hWnd == hwndCapture ||
-                fullscreenWindow.m_hWnd == hwndCapture)
+        case VK_ESCAPE:
+            hwndCapture = GetCapture();
+            if (hwndCapture)
             {
-                SendMessage(hwndCapture, nMsg, wParam, lParam);
+                if (canvasWindow.m_hWnd == hwndCapture ||
+                    fullscreenWindow.m_hWnd == hwndCapture)
+                {
+                    SendMessage(hwndCapture, nMsg, wParam, lParam);
+                }
             }
-        }
+            else if (selectionModel.m_bShow)
+            {
+                selectionModel.Landing();
+                selectionModel.m_bShow = FALSE;
+                canvasWindow.Invalidate(FALSE);
+            }
+            break;
+
+        case VK_LEFT:
+            canvasWindow.MoveSelection(-1, 0);
+            break;
+        case VK_RIGHT:
+            canvasWindow.MoveSelection(+1, 0);
+            break;
+        case VK_UP:
+            canvasWindow.MoveSelection(0, -1);
+            break;
+        case VK_DOWN:
+            canvasWindow.MoveSelection(0, +1);
+            break;
     }
     return 0;
 }


### PR DESCRIPTION
## Purpose

Improve keyboard usability.
JIRA issue: [CORE-18867](https://jira.reactos.org/browse/CORE-18867)

## Proposed changes

- Add `CCanvasWindow::MoveSelection` function.
- Modify `CMainWindow::OnKeyDown` function.
- If `Esc` key is pressed, then the selection will land to canvas if any.
- If any arrow key is pressed, then the selection will move a bit if any.

## Movie

https://github.com/reactos/reactos/assets/2107452/1e49502b-c158-48df-9210-78891e3a0b33

## TODO

- [x] Do tests.