### PR TITLE
[TASKMGR] Report any memory leaks on exit

### DIFF
--- a/base/applications/taskmgr/precomp.h
+++ b/base/applications/taskmgr/precomp.h
@@ -9,6 +9,11 @@
 #include <stdlib.h>
 #include <stdarg.h>
 
+#ifdef _DEBUG
+    #define _CRTDBG_MAP_ALLOC
+    #include <crtdbg.h>
+#endif
+
 #define WIN32_NO_STATUS
 
 #include <windef.h>

--- a/base/applications/taskmgr/taskmgr.c
+++ b/base/applications/taskmgr/taskmgr.c
@@ -116,6 +116,11 @@ int APIENTRY wWinMain(HINSTANCE hInstance,
     TOKEN_PRIVILEGES tkp;
     HANDLE hMutex;
 
+#ifdef _DEBUG
+    // Report any memory leaks on exit
+    _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
+#endif
+
     /* check wether we're already running or not */
     hMutex = CreateMutexW(NULL, TRUE, L"taskmgrros");
     if (hMutex && GetLastError() == ERROR_ALREADY_EXISTS)


### PR DESCRIPTION
## Purpose
Use the power of CRT debug to detect memory leaks.
JIRA issue: [CORE-18014](https://jira.reactos.org/browse/CORE-18014)

## Proposed changes

- Define `_CRTDBG_MAP_ALLOC` and include `<crtdbg.h>` after `<stdlib.h>`.
- Call `_CrtSetDbgFlag` at prologue of `wWinMain`.

## TODO

- [x] Build.