### PR TITLE
[COMCTL32][MSHTML][QCAP][MSGINA][UXTHEME][MSHTML_WINETEST][NTGDI][NTUSER] DeleteObject(hdc...) are wrong!

### DIFF
--- a/dll/directx/wine/qcap/v4l.c
+++ b/dll/directx/wine/qcap/v4l.c
@@ -555,8 +555,13 @@ static void Resize(const Capture * capBox, LPBYTE output, const BYTE *input)
             inoffset += ow;
         }
         CoTaskMemFree(myarray);
+#ifdef __REACTOS__
+        DeleteDC(dc_s);
+        DeleteDC(dc_d);
+#else
         DeleteObject(dc_s);
         DeleteObject(dc_d);
+#endif
         DeleteObject(bmp_s);
         DeleteObject(bmp_d);
     }

--- a/dll/win32/comctl32/trackbar.c
+++ b/dll/win32/comctl32/trackbar.c
@@ -918,7 +918,9 @@ TRACKBAR_Refresh (TRACKBAR_INFO *infoPtr, HDC hdcDst)
         if (hOffScreenBmp) {
 	    hOldBmp = SelectObject(hdc, hOffScreenBmp);
 	} else {
+#ifndef __REACTOS__
 	    DeleteObject(hdc);
+#endif
 	    hdc = hdcDst;
 	}
     } else {
@@ -1014,7 +1016,11 @@ cleanup:
 	BitBlt(hdcDst, 0, 0, rcClient.right, rcClient.bottom, hdc, 0, 0, SRCCOPY);
 	SelectObject(hdc, hOldBmp);
 	DeleteObject(hOffScreenBmp);
+#ifdef __REACTOS__
+	DeleteDC(hdc);
+#else
 	DeleteObject(hdc);
+#endif
     }
 }
 

--- a/dll/win32/msgina/dimmedwindow.cpp
+++ b/dll/win32/msgina/dimmedwindow.cpp
@@ -94,7 +94,11 @@ public:
         if (m_hbitmap)
             DeleteObject(m_hbitmap);
         if (m_hdc)
+#ifdef __REACTOS__
+            DeleteDC(m_hdc);
+#else
             DeleteObject(m_hdc);
+#endif
         if (m_bytes)
             delete[] m_bytes;
     }

--- a/dll/win32/mshtml/main.c
+++ b/dll/win32/mshtml/main.c
@@ -101,7 +101,11 @@ static void process_detach(void)
     if(mshtml_tls != TLS_OUT_OF_INDEXES)
         TlsFree(mshtml_tls);
     if(display_dc)
+#ifdef __REACTOS__
+        DeleteDC(display_dc);
+#else
         DeleteObject(display_dc);
+#endif
     if(mlang)
         IMultiLanguage2_Release(mlang);
 

--- a/dll/win32/mshtml/main.c
+++ b/dll/win32/mshtml/main.c
@@ -179,7 +179,11 @@ HDC get_display_dc(void)
 
         hdc = CreateICW(displayW, NULL, NULL, NULL);
         if(InterlockedCompareExchangePointer((void**)&display_dc, hdc, NULL))
+#ifdef __REACTOS__
+            DeleteDC(hdc);
+#else
             DeleteObject(hdc);
+#endif
     }
 
     return display_dc;

--- a/dll/win32/uxtheme/draw.c
+++ b/dll/win32/uxtheme/draw.c
@@ -1599,7 +1599,11 @@ static HBITMAP UXTHEME_DrawThemePartToDib(HTHEME hTheme, HDC hdc, int iPartId, i
 
     DeleteObject(hbrBack);
     SelectObject(hdcMem, hbmpOld);
+#ifdef __REACTOS__
+    DeleteDC(hdcMem);
+#else
     DeleteObject(hdcMem);
+#endif
 
     return hbmp;
 }

--- a/dll/win32/uxtheme/nonclient.c
+++ b/dll/win32/uxtheme/nonclient.c
@@ -204,7 +204,11 @@ ThemeEndBufferedPaint(PDRAW_CONTEXT pcontext, int x, int y, int cx, int cy)
     HBITMAP hbmp;
     BitBlt(pcontext->hDCScreen, 0, 0, cx, cy, pcontext->hDC, x, y, SRCCOPY);
     hbmp = (HBITMAP) SelectObject(pcontext->hDC, pcontext->hbmpOld);
+#ifdef __REACTOS__
+    DeleteDC(pcontext->hDC);
+#else
     DeleteObject(pcontext->hDC);
+#endif
     DeleteObject(hbmp);
 
     pcontext->hDC = pcontext->hDCScreen;

--- a/modules/rostests/dibtests/icontest/icontest.c
+++ b/modules/rostests/dibtests/icontest/icontest.c
@@ -185,7 +185,7 @@ LRESULT CALLBACK MainWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 
       SelectObject(hMemDC, hOld);
 
-      DeleteObject(hMemDC);
+      DeleteDC(hMemDC);
       EndPaint(hWnd, &ps);
     break;
 

--- a/modules/rostests/winetests/mshtml/dom.c
+++ b/modules/rostests/winetests/mshtml/dom.c
@@ -6055,7 +6055,11 @@ static void test_screen(IHTMLWindow2 *window)
     ok(hres == S_OK, "get_height failed: %08x\n", hres);
     ok(l == exl, "height = %d, expected %d\n", l, exl);
 
+#ifdef __REACTOS__
+    DeleteDC(hdc);
+#else
     DeleteObject(hdc);
+#endif
 
     SystemParametersInfoW(SPI_GETWORKAREA, 0, &work_area, 0);
 

--- a/win32ss/gdi/ntgdi/dclife.c
+++ b/win32ss/gdi/ntgdi/dclife.c
@@ -930,7 +930,7 @@ IntGdiDeleteDC(HDC hDC, BOOL Force)
 
     if (GreIsHandleValid(hDC))
     {
-        if (!IntGdiDeleteDC(hDC, FALSE))
+        if (!GreDeleteObject(hDC))
         {
             DPRINT1("DC_FreeDC failed\n");
             return FALSE;

--- a/win32ss/gdi/ntgdi/dclife.c
+++ b/win32ss/gdi/ntgdi/dclife.c
@@ -930,7 +930,7 @@ IntGdiDeleteDC(HDC hDC, BOOL Force)
 
     if (GreIsHandleValid(hDC))
     {
-        if (!GreDeleteObject(hDC))
+        if (!IntGdiDeleteDC(hDC, FALSE))
         {
             DPRINT1("DC_FreeDC failed\n");
             return FALSE;

--- a/win32ss/gdi/ntgdi/dcstate.c
+++ b/win32ss/gdi/ntgdi/dcstate.c
@@ -200,7 +200,7 @@ DC_vRestoreDC(
         /* Unlock it */
         DC_UnlockDc(pdcSave);
         /* Delete the saved dc */
-        GreDeleteObject(hdcSave);
+        IntGdiDeleteDC(hdcSave, FALSE);
     }
 
     DPRINT("Leave DC_vRestoreDC()\n");

--- a/win32ss/user/ntuser/caret.c
+++ b/win32ss/user/ntuser/caret.c
@@ -69,7 +69,7 @@ co_IntDrawCaret(PWND pWnd, PTHRDCARETINFO CaretInfo)
                                 0,
                                 0);
             NtGdiSelectBitmap(hdcMem, hbmOld);
-            GreDeleteObject(hdcMem);
+            IntGdiDeleteDC(hdcMem, FALSE);
         }
     }
 


### PR DESCRIPTION
## Purpose

Using `DeleteObject` against a DC is totally wrong. Use `DeleteDC` instead to delete a DC.

JIRA issue: N/A

## Proposed changes

- Use `DeleteDC` instead of `DeleteObject` against DCs.

## TODO

- [x] Build.
- [ ] Big tests.