### PR TITLE
[NTOS:PNP] Assert the presence of a device extension when handling PnP root power IRPs

### DIFF
--- a/ntoskrnl/io/pnpmgr/pnproot.c
+++ b/ntoskrnl/io/pnpmgr/pnproot.c
@@ -1473,6 +1473,12 @@ PnpRootPowerControl(
     Status = Irp->IoStatus.Status;
     IrpSp = IoGetCurrentIrpStackLocation(Irp);
 
+    /*
+     * We must handle power IRPs based on whether it is a function driver
+     * or not from the device extension, so it cannot be NULL.
+     */
+    ASSERT(DeviceExtension);
+
     if (DeviceExtension->Common.IsFDO)
     {
         ASSERT(!DeviceExtension->Common.IsFDO);


### PR DESCRIPTION
Handling PnP root driver power IRPs requires that a device object must come up with a device extension to determine whether it is a function driver and if so, handle the IRP accordingly.

**JIRA Issue:** [CORE-18989](https://jira.reactos.org/browse/CORE-18989)
