### PR TITLE
[TASKMGR] Remove CRTDBG

### DIFF
--- a/base/applications/taskmgr/precomp.h
+++ b/base/applications/taskmgr/precomp.h
@@ -16,11 +16,6 @@
 #include <stdlib.h>
 #include <stdarg.h>
 
-#ifdef _DEBUG
-    #define _CRTDBG_MAP_ALLOC
-    #include <crtdbg.h>
-#endif
-
 #define WIN32_NO_STATUS
 
 #include <windef.h>

--- a/base/applications/taskmgr/taskmgr.c
+++ b/base/applications/taskmgr/taskmgr.c
@@ -101,11 +101,6 @@ int APIENTRY wWinMain(HINSTANCE hInstance,
     TOKEN_PRIVILEGES tkp;
     HANDLE hMutex;
 
-#ifdef _DEBUG
-    // Report any memory leaks on exit
-    _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
-#endif
-
     /* check wether we're already running or not */
     hMutex = CreateMutexW(NULL, TRUE, L"taskmgrros");
     if (hMutex && GetLastError() == ERROR_ALREADY_EXISTS)


### PR DESCRIPTION
## Purpose
taskmgr doesn't use any CRT allocation. I don't see the point of using it.

This reverts commit [2441e86](https://github.com/reactos/reactos/commit/2441e869638da86106470f51a166acebdb3b3be0)

[CORE-18991](https://jira.reactos.org/browse/CORE-18991)