### PR TITLE
[MSPAINT] Use CF_DIB instead of CF_BITMAP

### DIFF
--- a/base/applications/mspaint/dib.cpp
+++ b/base/applications/mspaint/dib.cpp
@@ -334,19 +334,13 @@ HBITMAP SkewDIB(HDC hDC1, HBITMAP hbm, INT nDegree, BOOL bVertical)
     return hbmNew;
 }
 
-typedef struct tagBITMAPINFODX
-{
-    BITMAPINFOHEADER bmiHeader;
-    RGBQUAD          bmiColors[256];
-} BITMAPINFODX, *LPBITMAPINFODX;
-
 HGLOBAL BitmapToClipboardDIB(HBITMAP hBitmap)
 {
     BITMAP bm;
     if (!GetObject(hBitmap, sizeof(BITMAP), &bm))
         return NULL;
 
-    BITMAPINFODX bmi;
+    BITMAPINFO bmi;
     ZeroMemory(&bmi, sizeof(bmi));
     bmi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
     bmi.bmiHeader.biWidth = bm.bmWidth;
@@ -364,10 +358,11 @@ HGLOBAL BitmapToClipboardDIB(HBITMAP hBitmap)
 
     HDC hDC = CreateCompatibleDC(NULL);
 
+    RGBQUAD ColorTable[256];
     if (cColors)
     {
         HGDIOBJ hbmOld = SelectObject(hDC, hBitmap);
-        cColors = GetDIBColorTable(hDC, 0, cColors, bmi.bmiColors);
+        cColors = GetDIBColorTable(hDC, 0, cColors, ColorTable);
         SelectObject(hDC, hbmOld);
     }
 
@@ -382,7 +377,7 @@ HGLOBAL BitmapToClipboardDIB(HBITMAP hBitmap)
             CopyMemory(pb, &bmi, sizeof(BITMAPINFOHEADER));
             pb += sizeof(BITMAPINFOHEADER);
 
-            CopyMemory(pb, &bmi.bmiColors, cbColors);
+            CopyMemory(pb, &ColorTable, cbColors);
             pb += cbColors;
 
             if (cColors)

--- a/base/applications/mspaint/dib.cpp
+++ b/base/applications/mspaint/dib.cpp
@@ -334,11 +334,10 @@ HBITMAP SkewDIB(HDC hDC1, HBITMAP hbm, INT nDegree, BOOL bVertical)
     return hbmNew;
 }
 
-typedef struct tagBITMAPINFODX
+struct BITMAPINFODX : BITMAPINFO
 {
-    BITMAPINFOHEADER bmiHeader;
-    RGBQUAD bmiColors[256];
-} BITMAPINFODX, *LPBITMAPINFODX;
+    RGBQUAD bmiColorsAdditional[256 - 1];
+};
 
 HGLOBAL BitmapToClipboardDIB(HBITMAP hBitmap)
 {
@@ -385,7 +384,7 @@ HGLOBAL BitmapToClipboardDIB(HBITMAP hBitmap)
             CopyMemory(pb, bmi.bmiColors, cbColors);
             pb += cbColors;
 
-            GetDIBits(hDC, hBitmap, 0, bm.bmHeight, pb, (LPBITMAPINFO)&bmi, DIB_RGB_COLORS);
+            GetDIBits(hDC, hBitmap, 0, bm.bmHeight, pb, &bmi, DIB_RGB_COLORS);
 
             GlobalUnlock(hGlobal);
         }

--- a/base/applications/mspaint/dib.cpp
+++ b/base/applications/mspaint/dib.cpp
@@ -448,3 +448,24 @@ HBITMAP BitmapFromClipboardDIB(HGLOBAL hGlobal)
 
     return hBitmap;
 }
+
+HBITMAP BitmapFromHEMF(HENHMETAFILE hEMF)
+{
+    ENHMETAHEADER header;
+    if (!GetEnhMetaFileHeader(hEMF, sizeof(header), &header))
+        return NULL;
+
+    CRect rc = *(LPRECT)&header.rclBounds;
+    INT cx = rc.Width(), cy = rc.Height();
+    HBITMAP hbm = CreateColorDIB(cx, cy, RGB(255, 255, 255));
+    if (!hbm)
+        return NULL;
+
+    HDC hDC = CreateCompatibleDC(NULL);
+    HGDIOBJ hbmOld = SelectObject(hDC, hbm);
+    PlayEnhMetaFile(hDC, hEMF, &rc);
+    SelectObject(hDC, hbmOld);
+    DeleteDC(hDC);
+
+    return hbm;
+}

--- a/base/applications/mspaint/dib.cpp
+++ b/base/applications/mspaint/dib.cpp
@@ -371,10 +371,7 @@ HGLOBAL BitmapToClipboardDIB(HBITMAP hBitmap)
         if (pb)
         {
             CopyMemory(pb, &bmi, sizeof(BITMAPINFOHEADER));
-            pb += sizeof(BITMAPINFOHEADER);
-
-            CopyMemory(pb, bmi.bmiColors, cbColors);
-            pb += cbColors;
+            pb += sizeof(BITMAPINFOHEADER) + cbColors;
 
             HDC hDC = GetDC(NULL);
             GetDIBits(hDC, hBitmap, 0, bm.bmHeight, pb, (LPBITMAPINFO)&bmi, DIB_RGB_COLORS);

--- a/base/applications/mspaint/dib.cpp
+++ b/base/applications/mspaint/dib.cpp
@@ -380,10 +380,7 @@ HGLOBAL BitmapToClipboardDIB(HBITMAP hBitmap)
             CopyMemory(pb, &ColorTable, cbColors);
             pb += cbColors;
 
-            if (cColors)
-                GetDIBits(hDC, hBitmap, 0, bm.bmHeight, pb, (LPBITMAPINFO)&bmi, DIB_PAL_COLORS);
-            else
-                GetDIBits(hDC, hBitmap, 0, bm.bmHeight, pb, (LPBITMAPINFO)&bmi, DIB_RGB_COLORS);
+            GetDIBits(hDC, hBitmap, 0, bm.bmHeight, pb, (LPBITMAPINFO)&bmi, DIB_RGB_COLORS);
 
             GlobalUnlock(hGlobal);
         }

--- a/base/applications/mspaint/dib.cpp
+++ b/base/applications/mspaint/dib.cpp
@@ -391,16 +391,3 @@ HGLOBAL BitmapToClipboardDIB(HBITMAP hBitmap)
 
     return hGlobal;
 }
-
-HBITMAP BitmapFromClipboardDIB(HGLOBAL hGlobal)
-{
-    LPBITMAPINFO pBitmapInfo = (LPBITMAPINFO)GlobalLock(hGlobal);
-    if (!pBitmapInfo)
-        return NULL;
-    LPVOID pPixels = ((LPBYTE)pBitmapInfo) + pBitmapInfo->bmiHeader.biSize;
-    HDC hDC = GetDC(NULL);
-    HBITMAP hbm = CreateDIBitmap(hDC, &(pBitmapInfo->bmiHeader), CBM_INIT, pPixels, pBitmapInfo, DIB_RGB_COLORS);
-    ReleaseDC(NULL, hDC);
-    GlobalUnlock(hGlobal);
-    return hbm;
-}

--- a/base/applications/mspaint/dib.cpp
+++ b/base/applications/mspaint/dib.cpp
@@ -334,11 +334,11 @@ HBITMAP SkewDIB(HDC hDC1, HBITMAP hbm, INT nDegree, BOOL bVertical)
     return hbmNew;
 }
 
-typedef struct tagBITMAPINFOEX
+typedef struct tagBITMAPINFODX
 {
     BITMAPINFOHEADER bmiHeader;
     RGBQUAD          bmiColors[256];
-} BITMAPINFOEX, FAR * LPBITMAPINFOEX;
+} BITMAPINFODX, *LPBITMAPINFODX;
 
 HGLOBAL BitmapToClipboardDIB(HBITMAP hBitmap)
 {
@@ -346,7 +346,7 @@ HGLOBAL BitmapToClipboardDIB(HBITMAP hBitmap)
     if (!GetObject(hBitmap, sizeof(BITMAP), &bm))
         return NULL;
 
-    BITMAPINFOEX bmi;
+    BITMAPINFODX bmi;
     ZeroMemory(&bmi, sizeof(bmi));
     bmi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
     bmi.bmiHeader.biWidth = bm.bmWidth;

--- a/base/applications/mspaint/dib.h
+++ b/base/applications/mspaint/dib.h
@@ -36,3 +36,6 @@ HBITMAP SkewDIB(HDC hDC1, HBITMAP hbm, INT nDegree, BOOL bVertical);
 float PpcmFromDpi(float dpi);
 
 #define ROUND(x) (INT)((x) + 0.5)
+
+HGLOBAL BitmapToClipboardDIB(HBITMAP hBitmap);
+HBITMAP BitmapFromClipboardDIB(HGLOBAL hGlobal);

--- a/base/applications/mspaint/dib.h
+++ b/base/applications/mspaint/dib.h
@@ -38,3 +38,4 @@ float PpcmFromDpi(float dpi);
 #define ROUND(x) (INT)((x) + 0.5)
 
 HGLOBAL BitmapToClipboardDIB(HBITMAP hBitmap);
+HBITMAP BitmapFromClipboardDIB(HGLOBAL hGlobal);

--- a/base/applications/mspaint/dib.h
+++ b/base/applications/mspaint/dib.h
@@ -39,3 +39,4 @@ float PpcmFromDpi(float dpi);
 
 HGLOBAL BitmapToClipboardDIB(HBITMAP hBitmap);
 HBITMAP BitmapFromClipboardDIB(HGLOBAL hGlobal);
+HBITMAP BitmapFromHEMF(HENHMETAFILE hEMF);

--- a/base/applications/mspaint/dib.h
+++ b/base/applications/mspaint/dib.h
@@ -38,4 +38,3 @@ float PpcmFromDpi(float dpi);
 #define ROUND(x) (INT)((x) + 0.5)
 
 HGLOBAL BitmapToClipboardDIB(HBITMAP hBitmap);
-HBITMAP BitmapFromClipboardDIB(HGLOBAL hGlobal);

--- a/base/applications/mspaint/lang/bg-BG.rc
+++ b/base/applications/mspaint/lang/bg-BG.rc
@@ -242,5 +242,5 @@ BEGIN
     IDS_UNDERLINE "Подчертан"
     IDS_VERTICAL "Вертикален"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/bg-BG.rc
+++ b/base/applications/mspaint/lang/bg-BG.rc
@@ -242,5 +242,5 @@ BEGIN
     IDS_UNDERLINE "Подчертан"
     IDS_VERTICAL "Вертикален"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, I cannot paste this data."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/bg-BG.rc
+++ b/base/applications/mspaint/lang/bg-BG.rc
@@ -242,4 +242,5 @@ BEGIN
     IDS_UNDERLINE "Подчертан"
     IDS_VERTICAL "Вертикален"
     IDS_PRINTRES "%d x %d pixel/cm"
+    IDS_CANTPASTE "Sorry, I cannot paste this data."
 END

--- a/base/applications/mspaint/lang/cs-CZ.rc
+++ b/base/applications/mspaint/lang/cs-CZ.rc
@@ -242,4 +242,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
+    IDS_CANTPASTE "Sorry, I cannot paste this data."
 END

--- a/base/applications/mspaint/lang/cs-CZ.rc
+++ b/base/applications/mspaint/lang/cs-CZ.rc
@@ -242,5 +242,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, I cannot paste this data."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/cs-CZ.rc
+++ b/base/applications/mspaint/lang/cs-CZ.rc
@@ -242,5 +242,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/de-DE.rc
+++ b/base/applications/mspaint/lang/de-DE.rc
@@ -242,4 +242,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
+    IDS_CANTPASTE "Sorry, I cannot paste this data."
 END

--- a/base/applications/mspaint/lang/de-DE.rc
+++ b/base/applications/mspaint/lang/de-DE.rc
@@ -242,5 +242,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, I cannot paste this data."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/de-DE.rc
+++ b/base/applications/mspaint/lang/de-DE.rc
@@ -242,5 +242,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/en-GB.rc
+++ b/base/applications/mspaint/lang/en-GB.rc
@@ -242,5 +242,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d dots per inch"
-    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/en-GB.rc
+++ b/base/applications/mspaint/lang/en-GB.rc
@@ -242,5 +242,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d dots per inch"
-    IDS_CANTPASTE "Sorry, I cannot paste this data."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/en-GB.rc
+++ b/base/applications/mspaint/lang/en-GB.rc
@@ -242,4 +242,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d dots per inch"
+    IDS_CANTPASTE "Sorry, I cannot paste this data."
 END

--- a/base/applications/mspaint/lang/en-US.rc
+++ b/base/applications/mspaint/lang/en-US.rc
@@ -242,5 +242,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d dots per inch"
-    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/en-US.rc
+++ b/base/applications/mspaint/lang/en-US.rc
@@ -242,5 +242,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d dots per inch"
-    IDS_CANTPASTE "Sorry, I cannot paste this data."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/en-US.rc
+++ b/base/applications/mspaint/lang/en-US.rc
@@ -242,4 +242,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d dots per inch"
+    IDS_CANTPASTE "Sorry, I cannot paste this data."
 END

--- a/base/applications/mspaint/lang/es-ES.rc
+++ b/base/applications/mspaint/lang/es-ES.rc
@@ -244,5 +244,5 @@ BEGIN
     IDS_UNDERLINE "Subrayado"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, I cannot paste this data."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/es-ES.rc
+++ b/base/applications/mspaint/lang/es-ES.rc
@@ -244,4 +244,5 @@ BEGIN
     IDS_UNDERLINE "Subrayado"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
+    IDS_CANTPASTE "Sorry, I cannot paste this data."
 END

--- a/base/applications/mspaint/lang/es-ES.rc
+++ b/base/applications/mspaint/lang/es-ES.rc
@@ -244,5 +244,5 @@ BEGIN
     IDS_UNDERLINE "Subrayado"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/et-EE.rc
+++ b/base/applications/mspaint/lang/et-EE.rc
@@ -242,4 +242,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
+    IDS_CANTPASTE "Sorry, I cannot paste this data."
 END

--- a/base/applications/mspaint/lang/et-EE.rc
+++ b/base/applications/mspaint/lang/et-EE.rc
@@ -242,5 +242,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, I cannot paste this data."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/et-EE.rc
+++ b/base/applications/mspaint/lang/et-EE.rc
@@ -242,5 +242,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/eu-ES.rc
+++ b/base/applications/mspaint/lang/eu-ES.rc
@@ -234,5 +234,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/eu-ES.rc
+++ b/base/applications/mspaint/lang/eu-ES.rc
@@ -234,4 +234,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
+    IDS_CANTPASTE "Sorry, I cannot paste this data."
 END

--- a/base/applications/mspaint/lang/eu-ES.rc
+++ b/base/applications/mspaint/lang/eu-ES.rc
@@ -234,5 +234,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, I cannot paste this data."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/fr-FR.rc
+++ b/base/applications/mspaint/lang/fr-FR.rc
@@ -234,5 +234,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/fr-FR.rc
+++ b/base/applications/mspaint/lang/fr-FR.rc
@@ -234,4 +234,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
+    IDS_CANTPASTE "Sorry, I cannot paste this data."
 END

--- a/base/applications/mspaint/lang/fr-FR.rc
+++ b/base/applications/mspaint/lang/fr-FR.rc
@@ -234,5 +234,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, I cannot paste this data."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/he-IL.rc
+++ b/base/applications/mspaint/lang/he-IL.rc
@@ -237,5 +237,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/he-IL.rc
+++ b/base/applications/mspaint/lang/he-IL.rc
@@ -237,4 +237,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
+    IDS_CANTPASTE "Sorry, I cannot paste this data."
 END

--- a/base/applications/mspaint/lang/he-IL.rc
+++ b/base/applications/mspaint/lang/he-IL.rc
@@ -237,5 +237,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, I cannot paste this data."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/hu-HU.rc
+++ b/base/applications/mspaint/lang/hu-HU.rc
@@ -234,5 +234,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/hu-HU.rc
+++ b/base/applications/mspaint/lang/hu-HU.rc
@@ -234,4 +234,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
+    IDS_CANTPASTE "Sorry, I cannot paste this data."
 END

--- a/base/applications/mspaint/lang/hu-HU.rc
+++ b/base/applications/mspaint/lang/hu-HU.rc
@@ -234,5 +234,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, I cannot paste this data."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/id-ID.rc
+++ b/base/applications/mspaint/lang/id-ID.rc
@@ -242,4 +242,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
+    IDS_CANTPASTE "Sorry, I cannot paste this data."
 END

--- a/base/applications/mspaint/lang/id-ID.rc
+++ b/base/applications/mspaint/lang/id-ID.rc
@@ -242,5 +242,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, I cannot paste this data."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/id-ID.rc
+++ b/base/applications/mspaint/lang/id-ID.rc
@@ -242,5 +242,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/it-IT.rc
+++ b/base/applications/mspaint/lang/it-IT.rc
@@ -242,4 +242,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
+    IDS_CANTPASTE "Sorry, I cannot paste this data."
 END

--- a/base/applications/mspaint/lang/it-IT.rc
+++ b/base/applications/mspaint/lang/it-IT.rc
@@ -242,5 +242,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, I cannot paste this data."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/it-IT.rc
+++ b/base/applications/mspaint/lang/it-IT.rc
@@ -242,5 +242,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/ja-JP.rc
+++ b/base/applications/mspaint/lang/ja-JP.rc
@@ -242,5 +242,5 @@ BEGIN
     IDS_UNDERLINE "下線"
     IDS_VERTICAL "縦書き"
     IDS_PRINTRES "%d x %d ピクセル/cm"
-    IDS_CANTPASTE "申し訳ありませんが、このデータを貼り付けできません。"
+    IDS_CANTPASTE "申し訳ありませんが、このデータを貼り付けできません。指定されたデータ形式が間違っているか、対応していません。"
 END

--- a/base/applications/mspaint/lang/ja-JP.rc
+++ b/base/applications/mspaint/lang/ja-JP.rc
@@ -242,5 +242,5 @@ BEGIN
     IDS_UNDERLINE "下線"
     IDS_VERTICAL "縦書き"
     IDS_PRINTRES "%d x %d ピクセル/cm"
-    IDS_CANTPASTE "申し訳ありませんが、このデータを貼り付けできません。指定されたデータ形式が間違っているか、対応していません。"
+    IDS_CANTPASTE "申し訳ありませんが、このデータを貼り付けできません。データ形式が間違っているか、対応していません。"
 END

--- a/base/applications/mspaint/lang/ja-JP.rc
+++ b/base/applications/mspaint/lang/ja-JP.rc
@@ -242,4 +242,5 @@ BEGIN
     IDS_UNDERLINE "下線"
     IDS_VERTICAL "縦書き"
     IDS_PRINTRES "%d x %d ピクセル/cm"
+    IDS_CANTPASTE "申し訳ありませんが、このデータを貼り付けできません。"
 END

--- a/base/applications/mspaint/lang/nl-NL.rc
+++ b/base/applications/mspaint/lang/nl-NL.rc
@@ -242,4 +242,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
+    IDS_CANTPASTE "Sorry, I cannot paste this data."
 END

--- a/base/applications/mspaint/lang/nl-NL.rc
+++ b/base/applications/mspaint/lang/nl-NL.rc
@@ -242,5 +242,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, I cannot paste this data."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/nl-NL.rc
+++ b/base/applications/mspaint/lang/nl-NL.rc
@@ -242,5 +242,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/no-NO.rc
+++ b/base/applications/mspaint/lang/no-NO.rc
@@ -242,4 +242,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
+    IDS_CANTPASTE "Sorry, I cannot paste this data."
 END

--- a/base/applications/mspaint/lang/no-NO.rc
+++ b/base/applications/mspaint/lang/no-NO.rc
@@ -242,5 +242,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, I cannot paste this data."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/no-NO.rc
+++ b/base/applications/mspaint/lang/no-NO.rc
@@ -242,5 +242,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/pl-PL.rc
+++ b/base/applications/mspaint/lang/pl-PL.rc
@@ -243,5 +243,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/pl-PL.rc
+++ b/base/applications/mspaint/lang/pl-PL.rc
@@ -243,4 +243,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
+    IDS_CANTPASTE "Sorry, I cannot paste this data."
 END

--- a/base/applications/mspaint/lang/pl-PL.rc
+++ b/base/applications/mspaint/lang/pl-PL.rc
@@ -243,5 +243,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, I cannot paste this data."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/pt-BR.rc
+++ b/base/applications/mspaint/lang/pt-BR.rc
@@ -242,4 +242,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
+    IDS_CANTPASTE "Sorry, I cannot paste this data."
 END

--- a/base/applications/mspaint/lang/pt-BR.rc
+++ b/base/applications/mspaint/lang/pt-BR.rc
@@ -242,5 +242,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, I cannot paste this data."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/pt-BR.rc
+++ b/base/applications/mspaint/lang/pt-BR.rc
@@ -242,5 +242,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/pt-PT.rc
+++ b/base/applications/mspaint/lang/pt-PT.rc
@@ -242,5 +242,5 @@ BEGIN
     IDS_UNDERLINE "Sublinhado"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, I cannot paste this data."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/pt-PT.rc
+++ b/base/applications/mspaint/lang/pt-PT.rc
@@ -242,5 +242,5 @@ BEGIN
     IDS_UNDERLINE "Sublinhado"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/pt-PT.rc
+++ b/base/applications/mspaint/lang/pt-PT.rc
@@ -242,4 +242,5 @@ BEGIN
     IDS_UNDERLINE "Sublinhado"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
+    IDS_CANTPASTE "Sorry, I cannot paste this data."
 END

--- a/base/applications/mspaint/lang/ro-RO.rc
+++ b/base/applications/mspaint/lang/ro-RO.rc
@@ -243,5 +243,5 @@ BEGIN
     IDS_UNDERLINE "Subliniat"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, I cannot paste this data."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/ro-RO.rc
+++ b/base/applications/mspaint/lang/ro-RO.rc
@@ -243,4 +243,5 @@ BEGIN
     IDS_UNDERLINE "Subliniat"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
+    IDS_CANTPASTE "Sorry, I cannot paste this data."
 END

--- a/base/applications/mspaint/lang/ro-RO.rc
+++ b/base/applications/mspaint/lang/ro-RO.rc
@@ -243,5 +243,5 @@ BEGIN
     IDS_UNDERLINE "Subliniat"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/ru-RU.rc
+++ b/base/applications/mspaint/lang/ru-RU.rc
@@ -234,5 +234,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/ru-RU.rc
+++ b/base/applications/mspaint/lang/ru-RU.rc
@@ -234,4 +234,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
+    IDS_CANTPASTE "Sorry, I cannot paste this data."
 END

--- a/base/applications/mspaint/lang/ru-RU.rc
+++ b/base/applications/mspaint/lang/ru-RU.rc
@@ -234,5 +234,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, I cannot paste this data."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/sk-SK.rc
+++ b/base/applications/mspaint/lang/sk-SK.rc
@@ -243,5 +243,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/sk-SK.rc
+++ b/base/applications/mspaint/lang/sk-SK.rc
@@ -243,4 +243,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
+    IDS_CANTPASTE "Sorry, I cannot paste this data."
 END

--- a/base/applications/mspaint/lang/sk-SK.rc
+++ b/base/applications/mspaint/lang/sk-SK.rc
@@ -243,5 +243,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, I cannot paste this data."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/sq-AL.rc
+++ b/base/applications/mspaint/lang/sq-AL.rc
@@ -242,4 +242,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
+    IDS_CANTPASTE "Sorry, I cannot paste this data."
 END

--- a/base/applications/mspaint/lang/sq-AL.rc
+++ b/base/applications/mspaint/lang/sq-AL.rc
@@ -242,5 +242,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, I cannot paste this data."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/sq-AL.rc
+++ b/base/applications/mspaint/lang/sq-AL.rc
@@ -242,5 +242,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/sv-SE.rc
+++ b/base/applications/mspaint/lang/sv-SE.rc
@@ -234,5 +234,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/sv-SE.rc
+++ b/base/applications/mspaint/lang/sv-SE.rc
@@ -234,4 +234,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
+    IDS_CANTPASTE "Sorry, I cannot paste this data."
 END

--- a/base/applications/mspaint/lang/sv-SE.rc
+++ b/base/applications/mspaint/lang/sv-SE.rc
@@ -234,5 +234,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, I cannot paste this data."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/tr-TR.rc
+++ b/base/applications/mspaint/lang/tr-TR.rc
@@ -242,5 +242,5 @@ BEGIN
     IDS_UNDERLINE "Altı Çizgili"
     IDS_VERTICAL "Düşey"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, I cannot paste this data."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/tr-TR.rc
+++ b/base/applications/mspaint/lang/tr-TR.rc
@@ -242,4 +242,5 @@ BEGIN
     IDS_UNDERLINE "Altı Çizgili"
     IDS_VERTICAL "Düşey"
     IDS_PRINTRES "%d x %d pixel/cm"
+    IDS_CANTPASTE "Sorry, I cannot paste this data."
 END

--- a/base/applications/mspaint/lang/tr-TR.rc
+++ b/base/applications/mspaint/lang/tr-TR.rc
@@ -242,5 +242,5 @@ BEGIN
     IDS_UNDERLINE "Altı Çizgili"
     IDS_VERTICAL "Düşey"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/uk-UA.rc
+++ b/base/applications/mspaint/lang/uk-UA.rc
@@ -242,4 +242,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
+    IDS_CANTPASTE "Sorry, I cannot paste this data."
 END

--- a/base/applications/mspaint/lang/uk-UA.rc
+++ b/base/applications/mspaint/lang/uk-UA.rc
@@ -242,5 +242,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, I cannot paste this data."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/uk-UA.rc
+++ b/base/applications/mspaint/lang/uk-UA.rc
@@ -242,5 +242,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/vi-VN.rc
+++ b/base/applications/mspaint/lang/vi-VN.rc
@@ -242,4 +242,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
+    IDS_CANTPASTE "Sorry, I cannot paste this data."
 END

--- a/base/applications/mspaint/lang/vi-VN.rc
+++ b/base/applications/mspaint/lang/vi-VN.rc
@@ -242,5 +242,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, I cannot paste this data."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/vi-VN.rc
+++ b/base/applications/mspaint/lang/vi-VN.rc
@@ -242,5 +242,5 @@ BEGIN
     IDS_UNDERLINE "Underline"
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/zh-CN.rc
+++ b/base/applications/mspaint/lang/zh-CN.rc
@@ -244,4 +244,5 @@ BEGIN
     IDS_UNDERLINE "下划线"
     IDS_VERTICAL "垂直"
     IDS_PRINTRES "%d x %d pixel/cm"
+    IDS_CANTPASTE "Sorry, I cannot paste this data."
 END

--- a/base/applications/mspaint/lang/zh-CN.rc
+++ b/base/applications/mspaint/lang/zh-CN.rc
@@ -244,5 +244,5 @@ BEGIN
     IDS_UNDERLINE "下划线"
     IDS_VERTICAL "垂直"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, I cannot paste this data."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/zh-CN.rc
+++ b/base/applications/mspaint/lang/zh-CN.rc
@@ -244,5 +244,5 @@ BEGIN
     IDS_UNDERLINE "下划线"
     IDS_VERTICAL "垂直"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/zh-HK.rc
+++ b/base/applications/mspaint/lang/zh-HK.rc
@@ -242,5 +242,5 @@ BEGIN
     IDS_UNDERLINE "底線"
     IDS_VERTICAL "垂直"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/zh-HK.rc
+++ b/base/applications/mspaint/lang/zh-HK.rc
@@ -242,5 +242,5 @@ BEGIN
     IDS_UNDERLINE "底線"
     IDS_VERTICAL "垂直"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, I cannot paste this data."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/zh-HK.rc
+++ b/base/applications/mspaint/lang/zh-HK.rc
@@ -242,4 +242,5 @@ BEGIN
     IDS_UNDERLINE "底線"
     IDS_VERTICAL "垂直"
     IDS_PRINTRES "%d x %d pixel/cm"
+    IDS_CANTPASTE "Sorry, I cannot paste this data."
 END

--- a/base/applications/mspaint/lang/zh-TW.rc
+++ b/base/applications/mspaint/lang/zh-TW.rc
@@ -242,5 +242,5 @@ BEGIN
     IDS_UNDERLINE "底線"
     IDS_VERTICAL "垂直"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/zh-TW.rc
+++ b/base/applications/mspaint/lang/zh-TW.rc
@@ -242,5 +242,5 @@ BEGIN
     IDS_UNDERLINE "底線"
     IDS_VERTICAL "垂直"
     IDS_PRINTRES "%d x %d pixel/cm"
-    IDS_CANTPASTE "Sorry, I cannot paste this data."
+    IDS_CANTPASTE "Sorry, this application cannot paste this data. The data format you specified is either incorrect or not supported."
 END

--- a/base/applications/mspaint/lang/zh-TW.rc
+++ b/base/applications/mspaint/lang/zh-TW.rc
@@ -242,4 +242,5 @@ BEGIN
     IDS_UNDERLINE "底線"
     IDS_VERTICAL "垂直"
     IDS_PRINTRES "%d x %d pixel/cm"
+    IDS_CANTPASTE "Sorry, I cannot paste this data."
 END

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -547,7 +547,6 @@ struct TextTool : ToolBase
 
         // Draw the text
         INT style = (toolsModel.IsBackgroundTransparent() ? 0 : 1);
-        imageModel.PushImageForUndo();
         Text(hdc, rc.left, rc.top, rc.right, rc.bottom, m_fg, m_bg, szText,
              textEditWindow.GetFont(), style);
     }
@@ -568,14 +567,10 @@ struct TextTool : ToolBase
         BOOL bTextBoxShown = ::IsWindowVisible(textEditWindow);
         if (bTextBoxShown && textEditWindow.GetWindowTextLength() > 0)
         {
+            imageModel.PushImageForUndo();
             draw(m_hdc);
-
-            if (selectionModel.m_rc.IsRectEmpty())
-            {
-                textEditWindow.ShowWindow(SW_HIDE);
-                textEditWindow.SetWindowText(NULL);
-                return;
-            }
+            quit();
+            return;
         }
 
         if (registrySettings.ShowTextTool)
@@ -613,6 +608,7 @@ struct TextTool : ToolBase
 
     void OnFinishDraw() override
     {
+        imageModel.PushImageForUndo();
         draw(m_hdc);
         quit();
         ToolBase::OnFinishDraw();

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -569,8 +569,11 @@ struct TextTool : ToolBase
         {
             imageModel.PushImageForUndo();
             draw(m_hdc);
-            quit();
-            return;
+            if (::IsRectEmpty(&selectionModel.m_rc))
+            {
+                quit();
+                return;
+            }
         }
 
         if (registrySettings.ShowTextTool)

--- a/base/applications/mspaint/resource.h
+++ b/base/applications/mspaint/resource.h
@@ -219,3 +219,4 @@
 #define IDS_UNDERLINE   937
 #define IDS_VERTICAL    938
 #define IDS_PRINTRES    939
+#define IDS_CANTPASTE   940

--- a/base/applications/mspaint/selectionmodel.cpp
+++ b/base/applications/mspaint/selectionmodel.cpp
@@ -208,7 +208,7 @@ void SelectionModel::InsertFromHBITMAP(HBITMAP hBm, INT x, INT y)
     m_rc.right = m_rc.left + GetDIBWidth(hBm);
     m_rc.bottom = m_rc.top + GetDIBHeight(hBm);
 
-    // Unless two rectangles were different, it cannot land to the canvas.
+    // Unless two rectangles were different, the image cannot be pasted to the canvas.
     // See SelectionModel::Landing
     ::SetRect(&m_rcOld, -2, -2, -1, -1); // Outside of image
 

--- a/base/applications/mspaint/selectionmodel.cpp
+++ b/base/applications/mspaint/selectionmodel.cpp
@@ -205,11 +205,11 @@ void SelectionModel::InsertFromHBITMAP(HBITMAP hBm, INT x, INT y)
 
     m_rc.left = x;
     m_rc.top = y;
-    m_rc.right = m_rc.left + GetDIBWidth(hBm);
-    m_rc.bottom = m_rc.top + GetDIBHeight(hBm);
+    m_rc.right = x + GetDIBWidth(hBm);
+    m_rc.bottom = y + GetDIBHeight(hBm);
 
-    // Unless two rectangles were different, the image cannot be pasted to the canvas.
-    // See SelectionModel::Landing
+    // If m_rc and m_rcOld were same, the image cannot be pasted to the canvas.
+    // See also SelectionModel::Landing
     ::SetRect(&m_rcOld, -2, -2, -1, -1); // Outside of image
 
     ClearMask();

--- a/base/applications/mspaint/selectionmodel.cpp
+++ b/base/applications/mspaint/selectionmodel.cpp
@@ -207,6 +207,9 @@ void SelectionModel::InsertFromHBITMAP(HBITMAP hBm, INT x, INT y)
     m_rc.top = y;
     m_rc.right = m_rc.left + GetDIBWidth(hBm);
     m_rc.bottom = m_rc.top + GetDIBHeight(hBm);
+
+    // Unless two rectangles were different, it cannot land to the canvas.
+    // See SelectionModel::Landing
     ::SetRect(&m_rcOld, -2, -2, -1, -1); // Outside of image
 
     ClearMask();

--- a/base/applications/mspaint/selectionmodel.cpp
+++ b/base/applications/mspaint/selectionmodel.cpp
@@ -207,6 +207,7 @@ void SelectionModel::InsertFromHBITMAP(HBITMAP hBm, INT x, INT y)
     m_rc.top = y;
     m_rc.right = m_rc.left + GetDIBWidth(hBm);
     m_rc.bottom = m_rc.top + GetDIBHeight(hBm);
+    ::SetRect(&m_rcOld, -1, -1, 0, 0);
 
     ClearMask();
 }

--- a/base/applications/mspaint/selectionmodel.cpp
+++ b/base/applications/mspaint/selectionmodel.cpp
@@ -207,7 +207,7 @@ void SelectionModel::InsertFromHBITMAP(HBITMAP hBm, INT x, INT y)
     m_rc.top = y;
     m_rc.right = m_rc.left + GetDIBWidth(hBm);
     m_rc.bottom = m_rc.top + GetDIBHeight(hBm);
-    ::SetRect(&m_rcOld, -1, -1, 0, 0);
+    ::SetRect(&m_rcOld, -2, -2, -1, -1); // Outside of image
 
     ClearMask();
 }

--- a/base/applications/mspaint/textedit.cpp
+++ b/base/applications/mspaint/textedit.cpp
@@ -433,3 +433,10 @@ LRESULT CTextEditWindow::OnMouseWheel(UINT nMsg, WPARAM wParam, LPARAM lParam, B
 {
     return ::SendMessage(GetParent(), nMsg, wParam, lParam);
 }
+
+LRESULT CTextEditWindow::OnPaste(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
+{
+    LRESULT ret = DefWindowProc(nMsg, wParam, lParam);
+    Invalidate(TRUE); // Redraw
+    return ret;
+}

--- a/base/applications/mspaint/textedit.cpp
+++ b/base/applications/mspaint/textedit.cpp
@@ -434,9 +434,23 @@ LRESULT CTextEditWindow::OnMouseWheel(UINT nMsg, WPARAM wParam, LPARAM lParam, B
     return ::SendMessage(GetParent(), nMsg, wParam, lParam);
 }
 
+LRESULT CTextEditWindow::OnCut(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
+{
+    LRESULT ret = DefWindowProc(nMsg, wParam, lParam);
+    Invalidate(TRUE); // Redraw
+    return ret;
+}
+
 LRESULT CTextEditWindow::OnPaste(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
     LRESULT ret = DefWindowProc(nMsg, wParam, lParam);
     FixEditPos(NULL);
+    return ret;
+}
+
+LRESULT CTextEditWindow::OnClear(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
+{
+    LRESULT ret = DefWindowProc(nMsg, wParam, lParam);
+    Invalidate(TRUE); // Redraw
     return ret;
 }

--- a/base/applications/mspaint/textedit.cpp
+++ b/base/applications/mspaint/textedit.cpp
@@ -410,12 +410,6 @@ void CTextEditWindow::Reposition()
     CRect rcImage;
     canvasWindow.GetImageRect(rcImage);
 
-    if (rc.bottom > rcImage.bottom)
-        ::OffsetRect(&rc, 0, rcImage.Height());
-
-    if (rc.right > rcImage.right)
-        ::OffsetRect(&rc, rcImage.Width(), 0);
-
     if (rc.left < 0)
         ::OffsetRect(&rc, -rc.left, 0);
 

--- a/base/applications/mspaint/textedit.cpp
+++ b/base/applications/mspaint/textedit.cpp
@@ -410,9 +410,9 @@ void CTextEditWindow::Reposition()
     CRect rcImage;
     canvasWindow.GetImageRect(rcImage);
 
+    // FIXME: Smartly restrict the position and size by using WM_WINDOWPOSCHANGING
     if (rc.left < 0)
         ::OffsetRect(&rc, -rc.left, 0);
-
     if (rc.top < 0)
         ::OffsetRect(&rc, 0, -rc.top);
 

--- a/base/applications/mspaint/textedit.cpp
+++ b/base/applications/mspaint/textedit.cpp
@@ -437,6 +437,6 @@ LRESULT CTextEditWindow::OnMouseWheel(UINT nMsg, WPARAM wParam, LPARAM lParam, B
 LRESULT CTextEditWindow::OnPaste(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
     LRESULT ret = DefWindowProc(nMsg, wParam, lParam);
-    Invalidate(TRUE); // Redraw
+    FixEditPos(NULL);
     return ret;
 }

--- a/base/applications/mspaint/textedit.h
+++ b/base/applications/mspaint/textedit.h
@@ -45,6 +45,7 @@ public:
         MESSAGE_HANDLER(WM_LBUTTONDOWN, OnLButtonDown);
         MESSAGE_HANDLER(EM_SETSEL, OnSetSel);
         MESSAGE_HANDLER(WM_MOUSEWHEEL, OnMouseWheel);
+        MESSAGE_HANDLER(WM_PASTE, OnPaste);
     END_MSG_MAP()
 
     LRESULT OnCreate(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
@@ -66,6 +67,7 @@ public:
     LRESULT OnSize(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
     LRESULT OnSetSel(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
     LRESULT OnMouseWheel(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
+    LRESULT OnPaste(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
 
 protected:
     HWND m_hwndParent;

--- a/base/applications/mspaint/textedit.h
+++ b/base/applications/mspaint/textedit.h
@@ -45,7 +45,9 @@ public:
         MESSAGE_HANDLER(WM_LBUTTONDOWN, OnLButtonDown);
         MESSAGE_HANDLER(EM_SETSEL, OnSetSel);
         MESSAGE_HANDLER(WM_MOUSEWHEEL, OnMouseWheel);
+        MESSAGE_HANDLER(WM_CUT, OnCut);
         MESSAGE_HANDLER(WM_PASTE, OnPaste);
+        MESSAGE_HANDLER(WM_CLEAR, OnClear);
     END_MSG_MAP()
 
     LRESULT OnCreate(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
@@ -67,7 +69,9 @@ public:
     LRESULT OnSize(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
     LRESULT OnSetSel(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
     LRESULT OnMouseWheel(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
+    LRESULT OnCut(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
     LRESULT OnPaste(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
+    LRESULT OnClear(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
 
 protected:
     HWND m_hwndParent;

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -724,7 +724,7 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
             if (!OpenClipboard())
                 break;
 
-            // In many cases, EMF provides a better image than CF_DIB
+            // In many cases, CF_ENHMETAFILE provides a better image than CF_DIB
             if (::IsClipboardFormatAvailable(CF_ENHMETAFILE))
             {
                 HENHMETAFILE hEMF = (HENHMETAFILE)::GetClipboardData(CF_ENHMETAFILE);

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -700,6 +700,7 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
             if (!OpenClipboard())
                 break;
 
+            // In many cases, EMF provides a better image than CF_DIB.
             if (::IsClipboardFormatAvailable(CF_ENHMETAFILE))
             {
                 HENHMETAFILE hEMF = (HENHMETAFILE)::GetClipboardData(CF_ENHMETAFILE);

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -700,8 +700,7 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
             OpenClipboard();
             if (IsClipboardFormatAvailable(CF_BITMAP))
             {
-                HBITMAP hbm = (HBITMAP)::GetClipboardData(CF_BITMAP);
-                InsertSelectionFromHBITMAP(hbm, m_hWnd);
+                InsertSelectionFromHBITMAP((HBITMAP) GetClipboardData(CF_BITMAP), m_hWnd);
             }
             CloseClipboard();
             break;

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -434,7 +434,7 @@ LRESULT CMainWindow::OnInitMenuPopup(UINT nMsg, WPARAM wParam, LPARAM lParam, BO
             EnableMenuItem(menu, IDM_EDITREDO, ENABLED_IF(imageModel.CanRedo() || textShown));
             EnableMenuItem(menu, IDM_EDITCUT,  ENABLED_IF(trueSelection || textShown));
             EnableMenuItem(menu, IDM_EDITCOPY, ENABLED_IF(trueSelection || textShown));
-            EnableMenuItem(menu, IDM_EDITDELETESELECTION, ENABLED_IF(trueSelection));
+            EnableMenuItem(menu, IDM_EDITDELETESELECTION, ENABLED_IF(trueSelection || textShown));
             EnableMenuItem(menu, IDM_EDITINVERTSELECTION, ENABLED_IF(trueSelection));
             EnableMenuItem(menu, IDM_EDITCOPYTO, ENABLED_IF(trueSelection));
             EnableMenuItem(menu, IDM_EDITPASTE,

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -698,20 +698,22 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
             SendMessage(WM_COMMAND, IDM_EDITDELETESELECTION, 0);
             break;
         case IDM_EDITPASTE:
-            OpenClipboard();
-            if (IsClipboardFormatAvailable(CF_ENHMETAFILE))
+            if (OpenClipboard())
             {
-                HENHMETAFILE hEMF = (HENHMETAFILE)::GetClipboardData(CF_ENHMETAFILE);
-                HBITMAP hbm = BitmapFromHEMF(hEMF);
-                ::DeleteEnhMetaFile(hEMF);
-                InsertSelectionFromHBITMAP(hbm, m_hWnd);
+                if (IsClipboardFormatAvailable(CF_ENHMETAFILE))
+                {
+                    HENHMETAFILE hEMF = (HENHMETAFILE)::GetClipboardData(CF_ENHMETAFILE);
+                    HBITMAP hbm = BitmapFromHEMF(hEMF);
+                    ::DeleteEnhMetaFile(hEMF);
+                    InsertSelectionFromHBITMAP(hbm, m_hWnd);
+                }
+                else if (IsClipboardFormatAvailable(CF_DIB))
+                {
+                    HBITMAP hbm = BitmapFromClipboardDIB(GetClipboardData(CF_DIB));
+                    InsertSelectionFromHBITMAP(hbm, m_hWnd);
+                }
+                CloseClipboard();
             }
-            else if (IsClipboardFormatAvailable(CF_DIB))
-            {
-                HBITMAP hbm = BitmapFromClipboardDIB(GetClipboardData(CF_DIB));
-                InsertSelectionFromHBITMAP(hbm, m_hWnd);
-            }
-            CloseClipboard();
             break;
         case IDM_EDITDELETESELECTION:
         {

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -698,9 +698,10 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
             break;
         case IDM_EDITPASTE:
             OpenClipboard();
-            if (IsClipboardFormatAvailable(CF_BITMAP))
+            if (IsClipboardFormatAvailable(CF_DIB))
             {
-                InsertSelectionFromHBITMAP((HBITMAP) GetClipboardData(CF_BITMAP), m_hWnd);
+                HBITMAP hbm = BitmapFromClipboardDIB(GetClipboardData(CF_DIB));
+                InsertSelectionFromHBITMAP(hbm, m_hWnd);
             }
             CloseClipboard();
             break;

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -436,7 +436,7 @@ LRESULT CMainWindow::OnInitMenuPopup(UINT nMsg, WPARAM wParam, LPARAM lParam, BO
             EnableMenuItem(menu, IDM_EDITDELETESELECTION, ENABLED_IF(trueSelection));
             EnableMenuItem(menu, IDM_EDITINVERTSELECTION, ENABLED_IF(trueSelection));
             EnableMenuItem(menu, IDM_EDITCOPYTO, ENABLED_IF(trueSelection));
-            EnableMenuItem(menu, IDM_EDITPASTE, ENABLED_IF(IsClipboardFormatAvailable(CF_DIB)));
+            EnableMenuItem(menu, IDM_EDITPASTE, ENABLED_IF(IsClipboardFormatAvailable(CF_BITMAP)));
             break;
         case 2: /* View menu */
             CheckMenuItem(menu, IDM_VIEWTOOLBOX, CHECKED_IF(::IsWindowVisible(toolBoxContainer)));
@@ -698,9 +698,9 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
             break;
         case IDM_EDITPASTE:
             OpenClipboard();
-            if (IsClipboardFormatAvailable(CF_DIB))
+            if (IsClipboardFormatAvailable(CF_BITMAP))
             {
-                HBITMAP hbm = BitmapFromClipboardDIB(GetClipboardData(CF_DIB));
+                HBITMAP hbm = (HBITMAP)::GetClipboardData(CF_BITMAP);
                 InsertSelectionFromHBITMAP(hbm, m_hWnd);
             }
             CloseClipboard();

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -774,9 +774,10 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
 
             // Failed to paste
             {
-                CString strText;
+                CString strText, strTitle;
                 strText.LoadString(IDS_CANTPASTE);
-                MessageBox(strText, NULL, MB_ICONERROR);
+                strTitle.LoadString(IDS_PROGRAMNAME);
+                MessageBox(strText, strTitle, MB_ICONINFORMATION);
             }
 
             CloseClipboard();

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -753,6 +753,7 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
                 }
             }
 
+            // Last resort
             if (::IsClipboardFormatAvailable(CF_BITMAP))
             {
                 HBITMAP hbm = (HBITMAP)::GetClipboardData(CF_BITMAP);
@@ -762,6 +763,13 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
                     CloseClipboard();
                     break;
                 }
+            }
+
+            // Failed
+            {
+                CString strText;
+                strText.LoadString(IDS_CANTPASTE);
+                MessageBox(strText, NULL, MB_ICONINFORMATION);
             }
 
             CloseClipboard();

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -720,21 +720,48 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
                 textEditWindow.SendMessage(WM_PASTE);
                 break;
             }
+
             if (!OpenClipboard())
                 break;
 
-            // In many cases, EMF provides a better image than CF_DIB.
+            // In many cases, EMF provides a better image than CF_DIB
             if (::IsClipboardFormatAvailable(CF_ENHMETAFILE))
             {
                 HENHMETAFILE hEMF = (HENHMETAFILE)::GetClipboardData(CF_ENHMETAFILE);
-                HBITMAP hbm = BitmapFromHEMF(hEMF);
-                ::DeleteEnhMetaFile(hEMF);
-                InsertSelectionFromHBITMAP(hbm, m_hWnd);
+                if (hEMF)
+                {
+                    HBITMAP hbm = BitmapFromHEMF(hEMF);
+                    ::DeleteEnhMetaFile(hEMF);
+                    if (hbm)
+                    {
+                        InsertSelectionFromHBITMAP(hbm, m_hWnd);
+                        CloseClipboard();
+                        break;
+                    }
+                }
             }
-            else if (::IsClipboardFormatAvailable(CF_DIB))
+
+            // In many cases, CF_DIB provides a better image than CF_BITMAP
+            if (::IsClipboardFormatAvailable(CF_DIB))
             {
                 HBITMAP hbm = BitmapFromClipboardDIB(::GetClipboardData(CF_DIB));
-                InsertSelectionFromHBITMAP(hbm, m_hWnd);
+                if (hbm)
+                {
+                    InsertSelectionFromHBITMAP(hbm, m_hWnd);
+                    CloseClipboard();
+                    break;
+                }
+            }
+
+            if (::IsClipboardFormatAvailable(CF_BITMAP))
+            {
+                HBITMAP hbm = (HBITMAP)::GetClipboardData(CF_BITMAP);
+                if (hbm)
+                {
+                    InsertSelectionFromHBITMAP(hbm, m_hWnd);
+                    CloseClipboard();
+                    break;
+                }
             }
 
             CloseClipboard();

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -436,7 +436,8 @@ LRESULT CMainWindow::OnInitMenuPopup(UINT nMsg, WPARAM wParam, LPARAM lParam, BO
             EnableMenuItem(menu, IDM_EDITDELETESELECTION, ENABLED_IF(trueSelection));
             EnableMenuItem(menu, IDM_EDITINVERTSELECTION, ENABLED_IF(trueSelection));
             EnableMenuItem(menu, IDM_EDITCOPYTO, ENABLED_IF(trueSelection));
-            EnableMenuItem(menu, IDM_EDITPASTE, ENABLED_IF(IsClipboardFormatAvailable(CF_BITMAP)));
+            EnableMenuItem(menu, IDM_EDITPASTE,
+                ENABLED_IF(IsClipboardFormatAvailable(CF_DIB) || IsClipboardFormatAvailable(CF_ENHMETAFILE)));
             break;
         case 2: /* View menu */
             CheckMenuItem(menu, IDM_VIEWTOOLBOX, CHECKED_IF(::IsWindowVisible(toolBoxContainer)));
@@ -698,7 +699,14 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
             break;
         case IDM_EDITPASTE:
             OpenClipboard();
-            if (IsClipboardFormatAvailable(CF_DIB))
+            if (IsClipboardFormatAvailable(CF_ENHMETAFILE))
+            {
+                HENHMETAFILE hEMF = (HENHMETAFILE)::GetClipboardData(CF_ENHMETAFILE);
+                HBITMAP hbm = BitmapFromHEMF(hEMF);
+                ::DeleteEnhMetaFile(hEMF);
+                InsertSelectionFromHBITMAP(hbm, m_hWnd);
+            }
+            else if (IsClipboardFormatAvailable(CF_DIB))
             {
                 HBITMAP hbm = BitmapFromClipboardDIB(GetClipboardData(CF_DIB));
                 InsertSelectionFromHBITMAP(hbm, m_hWnd);

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -753,7 +753,7 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
                 }
             }
 
-            // Last resort
+            // The last resort
             if (::IsClipboardFormatAvailable(CF_BITMAP))
             {
                 HBITMAP hbm = (HBITMAP)::GetClipboardData(CF_BITMAP);
@@ -765,11 +765,11 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
                 }
             }
 
-            // Failed
+            // Failed to paste
             {
                 CString strText;
                 strText.LoadString(IDS_CANTPASTE);
-                MessageBox(strText, NULL, MB_ICONINFORMATION);
+                MessageBox(strText, NULL, MB_ICONERROR);
             }
 
             CloseClipboard();


### PR DESCRIPTION
## Purpose
`CF_BITMAP` is not recommended format for copying. In fact, Win10 won't accept it.
JIRA issue: [CORE-18867](https://jira.reactos.org/browse/CORE-18867)

## Proposed changes

- Use `CF_DIB` clipboard format instead of `CF_BITMAP` in copying.
- Use `CF_ENHMETAFILE`, `CF_DIB`, or `CF_BITMAP` in pasting.
- Add `BitmapToClipboardDIB`, `BitmapFromClipboardDIB`, and `BitmapFromHEMF` helper functions to `dib.cpp`.
- Re-enable paste by fixing the bug that is embugged in the previous commit.
- Enable Cut, Copy, Paste, and Delete on text editing box by modifying `OnInitMenuPopup`.
- Add `IDS_CANTPASTE` resource string to show message on paste failure.

## TODO

- [x] Able to paste from our Paint to our Paint.
- [x] Able to paste from our Paint to Win10 Paint.
- [x] Able to paste from Win10 Paint to our Paint.
- [x] Able to Cut, Copy, Paste, and Delete on Text Editing Box.