### PR TITLE
[BROWSEUI] Add locked toolbar state persistence

### DIFF
--- a/dll/win32/browseui/internettoolbar.cpp
+++ b/dll/win32/browseui/internettoolbar.cpp
@@ -607,33 +607,10 @@ HRESULT STDMETHODCALLTYPE CMenuCallback::CallbackSM(LPSMDATA psmd, UINT uMsg, WP
 
 CInternetToolbar::CInternetToolbar()
 {
-    HKEY hKey;
-
-    // Set the toolbar to locked by default if the registry key is missing.
-    fLocked = true;
-    if (RegOpenKeyExW(HKEY_CURRENT_USER,
-                      L"Software\\Microsoft\\Internet Explorer\\Toolbar",
-                      0,
-                      KEY_READ,
-                      &hKey) == ERROR_SUCCESS)
-    {
-        DWORD dwLocked;
-        DWORD dwSize;
-        DWORD dwType;
-        if (RegQueryValueExW(hKey,
-                             L"Locked",
-                             NULL,
-                             &dwType,
-                             (LPBYTE)&dwLocked,
-                             &dwSize) == ERROR_SUCCESS)
-        {
-            if (dwType == REG_DWORD && dwSize == sizeof(dwLocked))
-            {
-                fLocked = (dwLocked != 0);
-            }
-        }
-    }
-    RegCloseKey(hKey);
+    fLocked = SHRegGetBoolUSValueW(L"Software\\Microsoft\\Internet Explorer\\Toolbar",
+                                   L"Locked",
+                                   FALSE,
+                                   TRUE);
 
     fMainReBar = NULL;
     fMenuBandWindow = NULL;

--- a/dll/win32/browseui/internettoolbar.cpp
+++ b/dll/win32/browseui/internettoolbar.cpp
@@ -610,17 +610,26 @@ CInternetToolbar::CInternetToolbar()
     HKEY hKey;
     // Sets the toolbar to locked by default if the registry key is missing.
     fLocked = true;
-    if(RegOpenKeyEx(HKEY_CURRENT_USER,
-                    _T("Software\\Microsoft\\Internet Explorer\\Toolbar"),
-                    0, KEY_READ, &hKey) == ERROR_SUCCESS)
+    if (RegOpenKeyExW(HKEY_CURRENT_USER,
+                      L"Software\\Microsoft\\Internet Explorer\\Toolbar",
+                      0,
+                      KEY_READ,
+                      &hKey) == ERROR_SUCCESS)
     {
         DWORD dwLocked;
         DWORD dwSize;
-        if(RegQueryValueEx(hKey,
-                        _T("Locked"),
-                        NULL, NULL, (LPBYTE)&dwLocked, &dwSize) == ERROR_SUCCESS)
+        DWORD dwType;
+        if (RegQueryValueExW(hKey,
+                             L"Locked",
+                             NULL,
+                             &dwType,
+                             (LPBYTE)&dwLocked,
+                             &dwSize) == ERROR_SUCCESS)
         {
-            fLocked = (dwLocked != 0);
+            if (dwType == REG_DWORD && dwSize == sizeof(dwLocked))
+            {
+                fLocked = (dwLocked != 0);
+            }
         }
     }
     RegCloseKey(hKey);
@@ -735,15 +744,23 @@ HRESULT CInternetToolbar::LockUnlockToolbars(bool locked)
 
     if (locked != fLocked)
     {
-        if(RegCreateKeyEx(HKEY_CURRENT_USER, 
-                        _T("Software\\Microsoft\\Internet Explorer\\Toolbar"), 
-                        0, NULL, REG_OPTION_NON_VOLATILE, 
-                        KEY_WRITE, NULL, &hKey, NULL) == ERROR_SUCCESS)
+        if (RegCreateKeyExW(HKEY_CURRENT_USER, 
+                            L"Software\\Microsoft\\Internet Explorer\\Toolbar", 
+                            0,
+                            NULL,
+                            REG_OPTION_NON_VOLATILE, 
+                            KEY_WRITE,
+                            NULL,
+                            &hKey,
+                            NULL) == ERROR_SUCCESS)
         {
             DWORD dwLocked = (locked ? 1 : 0);
-            RegSetValueEx(hKey, 
-                        _T("Locked"), 
-                        0, REG_DWORD, (const BYTE*)&dwLocked, sizeof(dwLocked));
+            RegSetValueExW(hKey, 
+                           L"Locked", 
+                           0,
+                           REG_DWORD,
+                           (const BYTE*)&dwLocked,
+                           sizeof(dwLocked));
         }
         RegCloseKey(hKey);
         fLocked = locked;

--- a/dll/win32/browseui/internettoolbar.cpp
+++ b/dll/win32/browseui/internettoolbar.cpp
@@ -761,7 +761,7 @@ HRESULT CInternetToolbar::LockUnlockToolbars(bool locked)
                            L"Locked",
                            0,
                            REG_DWORD,
-                           (const BYTE*)&dwLocked,
+                           (LPBYTE)&dwLocked,
                            sizeof(dwLocked));
         }
         RegCloseKey(hKey);

--- a/dll/win32/browseui/internettoolbar.cpp
+++ b/dll/win32/browseui/internettoolbar.cpp
@@ -744,7 +744,7 @@ HRESULT CInternetToolbar::LockUnlockToolbars(bool locked)
 
     if (locked != fLocked)
     {
-        if (RegCreateKeyExW(HKEY_CURRENT_USER, 
+        if (RegCreateKeyExW(HKEY_CURRENT_USER,
                             L"Software\\Microsoft\\Internet Explorer\\Toolbar", 
                             0,
                             NULL,

--- a/dll/win32/browseui/internettoolbar.cpp
+++ b/dll/win32/browseui/internettoolbar.cpp
@@ -755,7 +755,7 @@ HRESULT CInternetToolbar::LockUnlockToolbars(bool locked)
                             NULL) == ERROR_SUCCESS)
         {
             DWORD dwLocked = (locked ? 1 : 0);
-            RegSetValueExW(hKey, 
+            RegSetValueExW(hKey,
                            L"Locked", 
                            0,
                            REG_DWORD,

--- a/dll/win32/browseui/internettoolbar.cpp
+++ b/dll/win32/browseui/internettoolbar.cpp
@@ -745,7 +745,7 @@ HRESULT CInternetToolbar::LockUnlockToolbars(bool locked)
     if (locked != fLocked)
     {
         if (RegCreateKeyExW(HKEY_CURRENT_USER,
-                            L"Software\\Microsoft\\Internet Explorer\\Toolbar", 
+                            L"Software\\Microsoft\\Internet Explorer\\Toolbar",
                             0,
                             NULL,
                             REG_OPTION_NON_VOLATILE, 

--- a/dll/win32/browseui/internettoolbar.cpp
+++ b/dll/win32/browseui/internettoolbar.cpp
@@ -608,7 +608,8 @@ HRESULT STDMETHODCALLTYPE CMenuCallback::CallbackSM(LPSMDATA psmd, UINT uMsg, WP
 CInternetToolbar::CInternetToolbar()
 {
     HKEY hKey;
-    // Sets the toolbar to locked by default if the registry key is missing.
+
+    // Set the toolbar to locked by default if the registry key is missing.
     fLocked = true;
     if (RegOpenKeyExW(HKEY_CURRENT_USER,
                       L"Software\\Microsoft\\Internet Explorer\\Toolbar",
@@ -633,6 +634,7 @@ CInternetToolbar::CInternetToolbar()
         }
     }
     RegCloseKey(hKey);
+
     fMainReBar = NULL;
     fMenuBandWindow = NULL;
     fNavigationWindow = NULL;
@@ -764,6 +766,7 @@ HRESULT CInternetToolbar::LockUnlockToolbars(bool locked)
         }
         RegCloseKey(hKey);
         fLocked = locked;
+
         rebarBandInfo.cbSize = sizeof(rebarBandInfo);
         rebarBandInfo.fMask = RBBIM_STYLE | RBBIM_LPARAM;
         bandCount = (int)SendMessage(fMainReBar, RB_GETBANDCOUNT, 0, 0);

--- a/dll/win32/browseui/internettoolbar.cpp
+++ b/dll/win32/browseui/internettoolbar.cpp
@@ -750,7 +750,7 @@ HRESULT CInternetToolbar::LockUnlockToolbars(bool locked)
                             L"Software\\Microsoft\\Internet Explorer\\Toolbar",
                             0,
                             NULL,
-                            REG_OPTION_NON_VOLATILE, 
+                            REG_OPTION_NON_VOLATILE,
                             KEY_WRITE,
                             NULL,
                             &hKey,
@@ -758,7 +758,7 @@ HRESULT CInternetToolbar::LockUnlockToolbars(bool locked)
         {
             DWORD dwLocked = (locked ? 1 : 0);
             RegSetValueExW(hKey,
-                           L"Locked", 
+                           L"Locked",
                            0,
                            REG_DWORD,
                            (const BYTE*)&dwLocked,

--- a/dll/win32/browseui/internettoolbar.cpp
+++ b/dll/win32/browseui/internettoolbar.cpp
@@ -719,29 +719,16 @@ HRESULT CInternetToolbar::LockUnlockToolbars(bool locked)
     int                                     bandCount;
     CDockSite                               *dockSite;
     HRESULT                                 hResult;
-    HKEY                                    hKey;
 
     if (locked != fLocked)
     {
-        if (RegCreateKeyExW(HKEY_CURRENT_USER,
-                            L"Software\\Microsoft\\Internet Explorer\\Toolbar",
-                            0,
-                            NULL,
-                            REG_OPTION_NON_VOLATILE,
-                            KEY_WRITE,
-                            NULL,
-                            &hKey,
-                            NULL) == ERROR_SUCCESS)
-        {
-            DWORD dwLocked = (locked ? 1 : 0);
-            RegSetValueExW(hKey,
-                           L"Locked",
-                           0,
-                           REG_DWORD,
-                           (LPBYTE)&dwLocked,
-                           sizeof(dwLocked));
-        }
-        RegCloseKey(hKey);
+        DWORD dwLocked = locked ? 1 : 0;
+        SHRegSetUSValueW(L"Software\\Microsoft\\Internet Explorer\\Toolbar",
+                         L"Locked",
+                         REG_DWORD,
+                         &dwLocked,
+                         sizeof(DWORD),
+                         SHREGSET_FORCE_HKCU);
         fLocked = locked;
 
         rebarBandInfo.cbSize = sizeof(rebarBandInfo);

--- a/dll/win32/browseui/internettoolbar.cpp
+++ b/dll/win32/browseui/internettoolbar.cpp
@@ -727,7 +727,7 @@ HRESULT CInternetToolbar::LockUnlockToolbars(bool locked)
                          L"Locked",
                          REG_DWORD,
                          &dwLocked,
-                         sizeof(DWORD),
+                         sizeof(dwLocked),
                          SHREGSET_FORCE_HKCU);
         fLocked = locked;
 


### PR DESCRIPTION
## Purpose
Store the state of the explorer toolbar, locked or unlocked, in the proper registry location and set the proper toolbar state when initialized.

JIRA issue: [CORE-9094](https://jira.reactos.org/browse/CORE-9094)

## Proposed changes
- Set ```HKEY_CURRENT_USER\Software\Microsoft\Internet Explorer\Toolbar\Locked``` to 1 when the explorer toolbar is locked, 0 when the toolbar is unlocked.
- Query ```HKEY_CURRENT_USER\Software\Microsoft\Internet Explorer\Toolbar\Locked``` when the toolbar is initialized to set the correct locked state.
- Set the default state of the toolbar to locked if the registry key does not exist, matching the behavior of Windows Server 2003.