### PR TITLE
[MSPAINT] Add CMainWindow::CanUndo/CanRedo

### DIFF
--- a/base/applications/mspaint/winproc.h
+++ b/base/applications/mspaint/winproc.h
@@ -35,6 +35,8 @@ public:
     BOOL GetSaveFileName(IN OUT LPTSTR pszFile, INT cchMaxFile);
     BOOL ChooseColor(IN OUT COLORREF *prgbColor);
     VOID TrackPopupMenu(POINT ptScreen, INT iSubMenu);
+    BOOL CanUndo() const;
+    BOOL CanRedo() const;
 
 private:
     HMENU m_hMenu;


### PR DESCRIPTION
## Purpose
Bug fix on Undo/Redo actions and refactoring.
JIRA issue: [CORE-18867](https://jira.reactos.org/browse/CORE-18867)

## Proposed changes

- Add `CMainWindow::CanUndo` and `CMainWindow::CanRedo` and use them.
- Fix wrongly-disabled Undo/Redo in some cases.

## TODO

- [x] Do tests.