### PR TITLE
[MSPAINT] Fix CMainWindow::GetSaveFileName

### DIFF
--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -123,13 +123,18 @@ BOOL CMainWindow::GetSaveFileName(IN OUT LPTSTR pszFile, INT cchMaxFile)
         sfn.lpfnHook    = OFNHookProc;
         sfn.lpstrDefExt = L"png";
 
-        // Choose PNG
-        for (INT i = 0; i < aguidFileTypesE.GetSize(); ++i)
+        LPWSTR pchDotExt = PathFindExtensionW(pszFile);
+        if (*pchDotExt == UNICODE_NULL)
         {
-            if (aguidFileTypesE[i] == Gdiplus::ImageFormatPNG)
+            // Choose PNG
+            wcscat(pszFile, L".png");
+            for (INT i = 0; i < aguidFileTypesE.GetSize(); ++i)
             {
-                sfn.nFilterIndex = i + 1;
-                break;
+                if (aguidFileTypesE[i] == Gdiplus::ImageFormatPNG)
+                {
+                    sfn.nFilterIndex = i + 1;
+                    break;
+                }
             }
         }
     }


### PR DESCRIPTION
## Purpose
Fix filename extension cases and "File Type" field.
JIRA issue: [CORE-18867](https://jira.reactos.org/browse/CORE-18867)

## Proposed changes

- If no filename extension on save, then append `.png` to the filename.

## TODO

- [x] Do tests.

## Comparison

Tested on Win10.

BEFORE:
![before](https://github.com/reactos/reactos/assets/2107452/44b92257-022d-42bb-b4ec-5f0e5d426c63)
AFTER:
![after](https://github.com/reactos/reactos/assets/2107452/69332843-2198-4253-b5b3-13229a380a96)