### PR TITLE
[NETSTAT] Fix crash when parsing the protocol CORE-19005

### DIFF
--- a/base/applications/network/netstat/netstat.c
+++ b/base/applications/network/netstat/netstat.c
@@ -59,9 +59,19 @@ VOID DoFormatMessage(DWORD ErrorCode)
 }
 
 /*
- *
+ * Display table header
+ */
+VOID DisplayTableHeader(VOID)
+{
+    ConResPuts(StdOut, IDS_DISPLAY_THEADER);
+    if (bDoShowProcessId)
+        ConResPuts(StdOut, IDS_DISPLAY_PROCESS);
+    else
+        ConPuts(StdOut, L"\n");
+}
+
+/*
  * Parse command line parameters and set any options
- *
  */
 BOOL ParseCmdline(int argc, wchar_t* argv[])
 {
@@ -101,7 +111,12 @@ BOOL ParseCmdline(int argc, wchar_t* argv[])
                     case L'p':
                         bDoShowProtoCons = TRUE;
                         if (i+1 >= argc)
-                            goto StopParsingAndShowUsageHelp;
+                        {
+                            ConResPuts(StdOut, IDS_ACTIVE_CONNECT);
+                            DisplayTableHeader();
+                            return TRUE;
+                        }
+
                         Proto = argv[i+1];
                         if (!_wcsicmp(L"IP", Proto))
                             Protocol = IP;
@@ -146,18 +161,6 @@ StopParsingAndShowUsageHelp:
     }
 
     return TRUE;
-}
-
-/*
- * Display table header
- */
-VOID DisplayTableHeader(VOID)
-{
-    ConResPuts(StdOut, IDS_DISPLAY_THEADER);
-    if (bDoShowProcessId)
-        ConResPuts(StdOut, IDS_DISPLAY_PROCESS);
-    else
-        ConPuts(StdOut, L"\n");
 }
 
 /*

--- a/base/applications/network/netstat/netstat.c
+++ b/base/applications/network/netstat/netstat.c
@@ -602,10 +602,8 @@ GetIpHostName(BOOL Local, UINT IpAddr, CHAR Name[], INT NameLen)
 }
 
 /*
- *
  * Parse command line parameters and set any options
- * Run display output, looping over set intervals if a number is given
- *
+ * Run display output, looping over set interval if a number is given
  */
 int wmain(int argc, wchar_t *argv[])
 {

--- a/base/applications/network/netstat/netstat.c
+++ b/base/applications/network/netstat/netstat.c
@@ -100,7 +100,7 @@ BOOL ParseCmdline(int argc, wchar_t* argv[])
                         break;
                     case L'p':
                         bDoShowProtoCons = TRUE;
-                        if(i+1 >= argc)
+                        if (i+1 >= argc)
                             goto StopParsingAndShowUsageHelp;
                         Proto = argv[i+1];
                         if (!_wcsicmp(L"IP", Proto))

--- a/base/applications/network/netstat/netstat.c
+++ b/base/applications/network/netstat/netstat.c
@@ -409,7 +409,7 @@ BOOL ShowTcpTable(VOID)
     CHAR PID[64];
 
     /* Get the table of TCP endpoints */
-    dwSize = sizeof (MIB_TCPTABLE_OWNER_PID);
+    dwSize = sizeof(MIB_TCPTABLE_OWNER_PID);
     /* Should also work when we get new connections between 2 GetTcpTable()
      * calls: */
     do

--- a/base/applications/network/netstat/netstat.c
+++ b/base/applications/network/netstat/netstat.c
@@ -1,16 +1,13 @@
 /*
  * PROJECT:     ReactOS netstat utility
  * LICENSE:     GPL - See COPYING in the top level directory
- * FILE:        base/applications/network/netstat/netstat.c
  * PURPOSE:     display IP stack statistics
  * COPYRIGHT:   Copyright 2005 Ged Murphy <gedmurphy@gmail.com>
  */
 /*
  * TODO:
- * sort function return values.
  * implement -b, -t and -v
  * clean up GetIpHostName
- * command line parser needs more work
  */
 
 #include <stdio.h>
@@ -103,6 +100,8 @@ BOOL ParseCmdline(int argc, wchar_t* argv[])
                         break;
                     case L'p':
                         bDoShowProtoCons = TRUE;
+                        if(i+1 >= argc)
+                            goto StopParsingAndShowUsageHelp;
                         Proto = argv[i+1];
                         if (!_wcsicmp(L"IP", Proto))
                             Protocol = IP;
@@ -113,10 +112,7 @@ BOOL ParseCmdline(int argc, wchar_t* argv[])
                         else if (!_wcsicmp(L"UDP", Proto))
                             Protocol = UDP;
                         else
-                        {
-                            ConResPuts(StdErr, IDS_USAGE);
-                            return FALSE;
-                        }
+                            goto StopParsingAndShowUsageHelp;
                         break;
                     case L'r':
                         bDoShowRouteTable = TRUE;
@@ -133,7 +129,8 @@ BOOL ParseCmdline(int argc, wchar_t* argv[])
                         ConPuts(StdErr, L"'v' option is FIXME (Accepted option though unimplemented feature).\n");
                         bDoDispSeqComp = TRUE;
                         break;
-                    default :
+                    default:
+StopParsingAndShowUsageHelp:
                         ConResPuts(StdErr, IDS_USAGE);
                         return FALSE;
                 }
@@ -146,11 +143,6 @@ BOOL ParseCmdline(int argc, wchar_t* argv[])
             else
                 return FALSE;
         }
-//        else
-//        {
-//            ConResPrintf(StdErr, IDS_USAGE);
-//            return FALSE;
-//        }
     }
 
     return TRUE;
@@ -511,7 +503,6 @@ BOOL ShowUdpTable(VOID)
     /* Dump the UDP table */
     for (i = 0; i < udpTable->dwNumEntries; i++)
     {
-
         /* I've split this up so it's easier to follow */
         GetIpHostName(TRUE, udpTable->table[i].dwLocalAddr, HostIp, sizeof(HostIp));
         GetPortName(udpTable->table[i].dwLocalPort, "udp", HostPort, sizeof(HostPort));

--- a/base/applications/network/netstat/netstat.c
+++ b/base/applications/network/netstat/netstat.c
@@ -240,7 +240,7 @@ VOID ShowIpStatistics(VOID)
     PMIB_IPSTATS pIpStats;
     DWORD dwRetVal;
 
-    pIpStats = (MIB_IPSTATS*) HeapAlloc(GetProcessHeap(), 0, sizeof(MIB_IPSTATS));
+    pIpStats = (MIB_IPSTATS*)HeapAlloc(GetProcessHeap(), 0, sizeof(MIB_IPSTATS));
 
     if ((dwRetVal = GetIpStatistics(pIpStats)) == NO_ERROR)
     {
@@ -276,7 +276,7 @@ VOID ShowIcmpStatistics(VOID)
     PMIB_ICMP pIcmpStats;
     DWORD dwRetVal;
 
-    pIcmpStats = (MIB_ICMP*) HeapAlloc(GetProcessHeap(), 0, sizeof(MIB_ICMP));
+    pIcmpStats = (MIB_ICMP*)HeapAlloc(GetProcessHeap(), 0, sizeof(MIB_ICMP));
 
     if ((dwRetVal = GetIcmpStatistics(pIcmpStats)) == NO_ERROR)
     {
@@ -315,7 +315,6 @@ VOID ShowIcmpStatistics(VOID)
     }
 
     HeapFree(GetProcessHeap(), 0, pIcmpStats);
-
 }
 
 VOID ShowTcpStatistics(VOID)
@@ -366,12 +365,12 @@ VOID ShowEthernetStatistics(VOID)
     DWORD dwSize = 0;
     DWORD dwRetVal = 0;
 
-    pIfTable = (MIB_IFTABLE*) HeapAlloc(GetProcessHeap(), 0, sizeof(MIB_IFTABLE));
+    pIfTable = (MIB_IFTABLE*)HeapAlloc(GetProcessHeap(), 0, sizeof(MIB_IFTABLE));
 
     if (GetIfTable(pIfTable, &dwSize, 0) == ERROR_INSUFFICIENT_BUFFER)
     {
         HeapFree(GetProcessHeap(), 0, pIfTable);
-        pIfTable = (MIB_IFTABLE*) HeapAlloc(GetProcessHeap(), 0, dwSize);
+        pIfTable = (MIB_IFTABLE*)HeapAlloc(GetProcessHeap(), 0, dwSize);
 
         if ((dwRetVal = GetIfTable(pIfTable, &dwSize, 0)) == NO_ERROR)
         {
@@ -415,12 +414,12 @@ BOOL ShowTcpTable(VOID)
      * calls: */
     do
     {
-        tcpTable = (PMIB_TCPTABLE_OWNER_PID) HeapAlloc(GetProcessHeap(), 0, dwSize);
+        tcpTable = (PMIB_TCPTABLE_OWNER_PID)HeapAlloc(GetProcessHeap(), 0, dwSize);
         error = GetExtendedTcpTable(tcpTable, &dwSize, TRUE, AF_INET, TCP_TABLE_OWNER_PID_ALL, 0);
-        if ( error != NO_ERROR )
+        if (error != NO_ERROR)
             HeapFree(GetProcessHeap(), 0, tcpTable);
     }
-    while  ( error == ERROR_INSUFFICIENT_BUFFER );
+    while (error == ERROR_INSUFFICIENT_BUFFER);
 
     if (error != NO_ERROR)
     {
@@ -490,7 +489,7 @@ BOOL ShowUdpTable(VOID)
         DoFormatMessage(error);
         return FALSE;
     }
-    udpTable = (PMIB_UDPTABLE_OWNER_PID) HeapAlloc(GetProcessHeap(), 0, dwSize);
+    udpTable = (PMIB_UDPTABLE_OWNER_PID)HeapAlloc(GetProcessHeap(), 0, dwSize);
     error = GetExtendedUdpTable(udpTable, &dwSize, TRUE, AF_INET, UDP_TABLE_OWNER_PID, 0);
     if (error)
     {
@@ -540,7 +539,7 @@ GetPortName(UINT Port, PCSTR Proto, CHAR Name[], INT NameLen)
     }
     /* Try to translate to a name */
     if ((pServent = getservbyport(Port, Proto)))
-        strcpy(Name, pServent->s_name );
+        strcpy(Name, pServent->s_name);
     else
         sprintf(Name, "%d", htons((WORD)Port));
     return Name;


### PR DESCRIPTION
## Purpose

Fix a crash that happens when accessing cmd args out of bounds and show usage help.

JIRA issue: [CORE-19005](https://jira.reactos.org/browse/CORE-19005)

The crash was a regression of 0.4.11-dev-814-g 2b5507336017cdea726f146a225823a932df54c2

Before my fix:
https://jira.reactos.org/secure/attachment/65929/65929_0.4.15-dev-6172-gc63489f_netstatCrash_abnop.png

After my quick fix: (I showed usage help then, no crash anymore. Wrong screen output, wrong error level)
https://jira.reactos.org/secure/attachment/65931/65931_quick_fix.webm

After my final fix: (no crash, proper screen output, proper error-level)
https://jira.reactos.org/secure/attachment/65933/65933_put_love_into_the_fix_to_exactly_match_windows_screenoutput_and_errorlevel.webm