### PR TITLE
[BROWSEUI] Add status bar view state persistence

### DIFF
--- a/dll/win32/browseui/shellbrowser.cpp
+++ b/dll/win32/browseui/shellbrowser.cpp
@@ -3667,11 +3667,11 @@ LRESULT CShellBrowser::OnToggleStatusBarVisible(WORD wNotifyCode, WORD wID, HWND
     
     DWORD dwStatusBarVisible = fStatusBarVisible;
     SHRegSetUSValueW(L"Software\\Microsoft\\Internet Explorer\\Main",
-                         L"StatusBarOther",
-                         REG_DWORD,
-                         &dwStatusBarVisible,
-                         sizeof(dwStatusBarVisible),
-                         SHREGSET_FORCE_HKCU);
+                     L"StatusBarOther",
+                     REG_DWORD,
+                     &dwStatusBarVisible,
+                     sizeof(dwStatusBarVisible),
+                     SHREGSET_FORCE_HKCU);
     
     return 0;
 }

--- a/dll/win32/browseui/shellbrowser.cpp
+++ b/dll/win32/browseui/shellbrowser.cpp
@@ -709,7 +709,10 @@ CShellBrowser::CShellBrowser()
     fCurrentShellViewWindow = NULL;
     fCurrentDirectoryPIDL = NULL;
     fStatusBar = NULL;
-    fStatusBarVisible = true;
+    fStatusBarVisible = SHRegGetBoolUSValueW(L"Software\\Microsoft\\Internet Explorer\\Main",
+                                             L"StatusBarOther",
+                                             FALSE,
+                                             FALSE);
     fCurrentMenuBar = NULL;
     fHistoryObject = NULL;
     fHistoryStream = NULL;
@@ -788,8 +791,6 @@ HRESULT CShellBrowser::Initialize()
     fStatusBar = CreateWindow(STATUSCLASSNAMEW, NULL, WS_CHILD | WS_VISIBLE | WS_CLIPSIBLINGS |
                     SBT_NOBORDERS | SBT_TOOLTIPS, 0, 0, 500, 20, m_hWnd, (HMENU)0xa001,
                     _AtlBaseModule.GetModuleInstance(), 0);
-    fStatusBarVisible = true;
-
 
     ShowWindow(SW_SHOWNORMAL);
     UpdateWindow();
@@ -3663,6 +3664,15 @@ LRESULT CShellBrowser::OnToggleStatusBarVisible(WORD wNotifyCode, WORD wID, HWND
         ::ShowWindow(fStatusBar, fStatusBarVisible ? SW_SHOW : SW_HIDE);
         RepositionBars();
     }
+    
+    DWORD dwStatusBarVisible = fStatusBarVisible;
+    SHRegSetUSValueW(L"Software\\Microsoft\\Internet Explorer\\Main",
+                         L"StatusBarOther",
+                         REG_DWORD,
+                         &dwStatusBarVisible,
+                         sizeof(dwStatusBarVisible),
+                         SHREGSET_FORCE_HKCU);
+    
     return 0;
 }
 


### PR DESCRIPTION
## Purpose

Store the view state of the status bar in the proper registry location and set the proper state when initialized.

JIRA issue: [CORE-19010](https://jira.reactos.org/browse/CORE-19010)

## Proposed changes

- Set ```HKCU\Software\Microsoft\Internet Explorer\Main\StatusBarOther``` to 1 when the status bar is visible, 0 when the status bar is hidden.
- Query ```HKCU\Software\Microsoft\Internet Explorer\Main\StatusBarOther``` when the file browser is initialized to set the correct view state for the status bar.
- Set the default state of the status bar to hidden if the registry key does not exist, matching the behavior of Windows Server 2003.