### PR TITLE
[NETSTAT] -b flag implies -o flag on Windows XP/2003. CORE-19006

### DIFF
--- a/base/applications/network/netstat/netstat.c
+++ b/base/applications/network/netstat/netstat.c
@@ -98,10 +98,9 @@ BOOL ParseCmdline(int argc, wchar_t* argv[])
                         // UNIMPLEMENTED.
                         ConPuts(StdErr, L"'b' option is FIXME (Accepted option though unimplemented feature).\n");
                         bDoShowProcName = TRUE;
-
-                        // 2k3sp2 and XPSP3: -b does imply -o (superior)
-                        // Win7 and 8.1: -b and -o were decoupled (inferior)
+#if _WIN32_WINNT < 0x600
                         bDoShowProcessId = TRUE;
+#endif
                         break;
                     case L'e':
                         bDoShowEthStats = TRUE;

--- a/base/applications/network/netstat/netstat.c
+++ b/base/applications/network/netstat/netstat.c
@@ -98,7 +98,7 @@ BOOL ParseCmdline(int argc, wchar_t* argv[])
                         // UNIMPLEMENTED.
                         ConPuts(StdErr, L"'b' option is FIXME (Accepted option though unimplemented feature).\n");
                         bDoShowProcName = TRUE;
-#if _WIN32_WINNT < 0x600
+#if (_WIN32_WINNT < _WIN32_WINNT_VISTA || TRUE) /* prefer the old behavior */
                         bDoShowProcessId = TRUE;
 #endif
                         break;

--- a/base/applications/network/netstat/netstat.c
+++ b/base/applications/network/netstat/netstat.c
@@ -98,6 +98,10 @@ BOOL ParseCmdline(int argc, wchar_t* argv[])
                         // UNIMPLEMENTED.
                         ConPuts(StdErr, L"'b' option is FIXME (Accepted option though unimplemented feature).\n");
                         bDoShowProcName = TRUE;
+
+                        // 2k3sp2 and XPSP3: -b does imply -o (superior)
+                        // Win7 and 8.1: -b and -o were decoupled (inferior)
+                        bDoShowProcessId = TRUE;
                         break;
                     case L'e':
                         bDoShowEthStats = TRUE;

--- a/base/applications/network/netstat/netstat.c
+++ b/base/applications/network/netstat/netstat.c
@@ -98,7 +98,7 @@ BOOL ParseCmdline(int argc, wchar_t* argv[])
                         // UNIMPLEMENTED.
                         ConPuts(StdErr, L"'b' option is FIXME (Accepted option though unimplemented feature).\n");
                         bDoShowProcName = TRUE;
-#if (_WIN32_WINNT < _WIN32_WINNT_VISTA || TRUE) /* prefer the old behavior */
+#if (_WIN32_WINNT < _WIN32_WINNT_VISTA)
                         bDoShowProcessId = TRUE;
 #endif
                         break;


### PR DESCRIPTION

When calling 'netstat -abn'
Win 2k3sp2 and XPSP3 do show both: the processes name and the PID.
Contrary Win 7 and Win 8.1 would show only the process name then without the PID.

The newer Windows versions would require you to explicitly pass -o if you want to see the PID also.

We do follow 2k3sp2 because it is our target, but also because that is a more sane default choice.
The process name is not of much use without having the PID as well,
especially if multiple processes with the same name
do run on a system, e.g.: multiple 'svchost.exe' processes.

JIRA issue: [CORE-19006](https://jira.reactos.org/browse/CORE-19006)

Attached is a picture of the fixed state:
![PID_shown](https://github.com/reactos/reactos/assets/33393466/ec8dec16-cb48-4c06-92f6-9ed5aa1d5b3f)

