### PR TITLE
[SHIMGVW] Display the file name in taskbar even if the file isn't loaded

### DIFF
--- a/dll/win32/shimgvw/shimgvw.c
+++ b/dll/win32/shimgvw/shimgvw.c
@@ -507,7 +507,7 @@ pLoadImageFromNode(SHIMGVW_FILENODE *node, HWND hwnd)
 {
     WCHAR szTitleBuf[800];
     WCHAR szResStr[512];
-    LPWSTR pchFileTitle;
+    LPWSTR pchFileTitle = NULL;
 
     if (image)
     {
@@ -524,9 +524,10 @@ pLoadImageFromNode(SHIMGVW_FILENODE *node, HWND hwnd)
     pLoadImage(node->FileName);
 
     LoadStringW(hInstance, IDS_APPTITLE, szResStr, _countof(szResStr));
-    if (image != NULL)
+
+    pchFileTitle = PathFindFileNameW(node->FileName);
+    if (pchFileTitle != NULL && wcsicmp(pchFileTitle, L"") != 0) 
     {
-        pchFileTitle = PathFindFileNameW(node->FileName);
         StringCbPrintfW(szTitleBuf, sizeof(szTitleBuf),
                         L"%ls%ls%ls", szResStr, L" - ", pchFileTitle);
         SetWindowTextW(hwnd, szTitleBuf);

--- a/dll/win32/shimgvw/shimgvw.c
+++ b/dll/win32/shimgvw/shimgvw.c
@@ -526,7 +526,7 @@ pLoadImageFromNode(SHIMGVW_FILENODE *node, HWND hwnd)
     LoadStringW(hInstance, IDS_APPTITLE, szResStr, _countof(szResStr));
 
     pchFileTitle = PathFindFileNameW(node->FileName);
-    if (pchFileTitle != NULL && wcsicmp(pchFileTitle, L"") != 0) 
+    if (pchFileTitle != NULL && wcsicmp(pchFileTitle, L"")) 
     {
         StringCbPrintfW(szTitleBuf, sizeof(szTitleBuf),
                         L"%ls%ls%ls", szResStr, L" - ", pchFileTitle);

--- a/dll/win32/shimgvw/shimgvw.c
+++ b/dll/win32/shimgvw/shimgvw.c
@@ -526,7 +526,7 @@ pLoadImageFromNode(SHIMGVW_FILENODE *node, HWND hwnd)
     LoadStringW(hInstance, IDS_APPTITLE, szResStr, _countof(szResStr));
 
     pchFileTitle = PathFindFileNameW(node->FileName);
-    if (pchFileTitle && wcsicmp(pchFileTitle, L"")) 
+    if (pchFileTitle && *pchFileTitle) 
     {
         StringCbPrintfW(szTitleBuf, sizeof(szTitleBuf),
                         L"%ls%ls%ls", szResStr, L" - ", pchFileTitle);

--- a/dll/win32/shimgvw/shimgvw.c
+++ b/dll/win32/shimgvw/shimgvw.c
@@ -507,7 +507,7 @@ pLoadImageFromNode(SHIMGVW_FILENODE *node, HWND hwnd)
 {
     WCHAR szTitleBuf[800];
     WCHAR szResStr[512];
-    LPWSTR pchFileTitle = NULL;
+    LPWSTR pchFileTitle;
 
     if (image)
     {
@@ -526,7 +526,7 @@ pLoadImageFromNode(SHIMGVW_FILENODE *node, HWND hwnd)
     LoadStringW(hInstance, IDS_APPTITLE, szResStr, _countof(szResStr));
 
     pchFileTitle = PathFindFileNameW(node->FileName);
-    if (pchFileTitle != NULL && wcsicmp(pchFileTitle, L"")) 
+    if (pchFileTitle && wcsicmp(pchFileTitle, L"")) 
     {
         StringCbPrintfW(szTitleBuf, sizeof(szTitleBuf),
                         L"%ls%ls%ls", szResStr, L" - ", pchFileTitle);


### PR DESCRIPTION
## Purpose

In win2k3, the file name was displayed in the title bar even if the file was not loaded.
However, in React OS, the file name was not displayed in the tie and river when the file was not loaded.
Therefore, the file name was displayed unless the file name could't to retrieved.

JIRA issue: [CORE-18954](https://jira.reactos.org/browse/CORE-18954)
