### PR TITLE
[MSPAINT] Some bug fixes on loading/saving files

### DIFF
--- a/base/applications/mspaint/dialogs.cpp
+++ b/base/applications/mspaint/dialogs.cpp
@@ -22,6 +22,22 @@ CFontsDialog fontsDialog;
 
 /* FUNCTIONS ********************************************************/
 
+void ShowError(INT stringID, ...)
+{
+    va_list va;
+    va_start(va, stringID);
+
+    CStringW strFormat, strText;
+    strFormat.LoadString(stringID);
+    strText.FormatV(strFormat, va);
+
+    CStringW strProgramName;
+    strProgramName.LoadString(IDS_PROGRAMNAME);
+
+    mainWindow.MessageBox(strText, strProgramName, MB_ICONERROR);
+    va_end(va);
+}
+
 LRESULT CMirrorRotateDialog::OnInitDialog(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
     CheckDlgButton(IDD_MIRRORROTATERB1, BST_CHECKED);

--- a/base/applications/mspaint/dialogs.h
+++ b/base/applications/mspaint/dialogs.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+void ShowError(INT stringID, ...);
+
 class CMirrorRotateDialog : public CDialogImpl<CMirrorRotateDialog>
 {
 public:

--- a/base/applications/mspaint/dib.cpp
+++ b/base/applications/mspaint/dib.cpp
@@ -192,8 +192,10 @@ void SetFileInfo(LPCWSTR name, LPWIN32_FIND_DATAW pFound, BOOL isAFile)
     // update g_szFileName
     if (name && name[0])
     {
-        CStringW strFileName = name; // Be careful in case of name == g_szFileName
-        ::GetFullPathNameW(strFileName, _countof(g_szFileName), g_szFileName, NULL);
+        CStringW strName = name;
+        ::GetFullPathNameW(strName, _countof(g_szFileName), g_szFileName, NULL);
+        // The following code won't work correctly when (name == g_szFileName):
+        //   ::GetFullPathNameW(name, _countof(g_szFileName), g_szFileName, NULL);
     }
     else
     {

--- a/base/applications/mspaint/dib.h
+++ b/base/applications/mspaint/dib.h
@@ -20,17 +20,16 @@ static inline HBITMAP CopyDIBImage(HBITMAP hbm, INT cx = 0, INT cy = 0)
 }
 
 int GetDIBWidth(HBITMAP hbm);
-
 int GetDIBHeight(HBITMAP hbm);
 
-BOOL SaveDIBToFile(HBITMAP hBitmap, LPCTSTR FileName, BOOL fIsMainFile);
+BOOL SaveDIBToFile(HBITMAP hBitmap, LPCWSTR FileName, BOOL fIsMainFile);
 
-HBITMAP DoLoadImageFile(HWND hwnd, LPCTSTR name, BOOL fIsMainFile);
+HBITMAP DoLoadImageFile(HWND hwnd, LPCWSTR name, BOOL fIsMainFile);
 
-void ShowError(INT stringID, ...);
 void SetFileInfo(LPCWSTR name, LPWIN32_FIND_DATAW pFound, BOOL isAFile);
 
-HBITMAP SetBitmapAndInfo(HBITMAP hBitmap, LPCTSTR name, LPWIN32_FIND_DATAW pFound, BOOL isFile);
+HBITMAP InitializeImage(LPCWSTR name, LPWIN32_FIND_DATAW pFound, BOOL isFile);
+HBITMAP SetBitmapAndInfo(HBITMAP hBitmap, LPCWSTR name, LPWIN32_FIND_DATAW pFound, BOOL isFile);
 
 HBITMAP Rotate90DegreeBlt(HDC hDC1, INT cx, INT cy, BOOL bRight, BOOL bMono);
 

--- a/base/applications/mspaint/dib.h
+++ b/base/applications/mspaint/dib.h
@@ -23,13 +23,14 @@ int GetDIBWidth(HBITMAP hbm);
 
 int GetDIBHeight(HBITMAP hbm);
 
-BOOL SaveDIBToFile(HBITMAP hBitmap, LPCTSTR FileName, HDC hDC);
+BOOL SaveDIBToFile(HBITMAP hBitmap, LPCTSTR FileName, BOOL fIsMainFile);
 
 HBITMAP DoLoadImageFile(HWND hwnd, LPCTSTR name, BOOL fIsMainFile);
 
-void ShowFileLoadError(LPCTSTR name);
+void ShowError(INT stringID, ...);
+void SetFileInfo(LPCWSTR name, LPWIN32_FIND_DATAW pFound, BOOL isAFile);
 
-HBITMAP SetBitmapAndInfo(HBITMAP hBitmap, LPCTSTR name, DWORD dwFileSize, BOOL isFile);
+HBITMAP SetBitmapAndInfo(HBITMAP hBitmap, LPCTSTR name, LPWIN32_FIND_DATAW pFound, BOOL isFile);
 
 HBITMAP Rotate90DegreeBlt(HDC hDC1, INT cx, INT cy, BOOL bRight, BOOL bMono);
 

--- a/base/applications/mspaint/history.cpp
+++ b/base/applications/mspaint/history.cpp
@@ -159,7 +159,7 @@ void ImageModel::Crop(int nWidth, int nHeight, int nOffsetX, int nOffsetY)
 
 void ImageModel::SaveImage(LPCTSTR lpFileName)
 {
-    SaveDIBToFile(m_hBms[m_currInd], lpFileName, m_hDrawingDC);
+    SaveDIBToFile(m_hBms[m_currInd], lpFileName, TRUE);
 }
 
 BOOL ImageModel::IsImageSaved() const

--- a/base/applications/mspaint/lang/bg-BG.rc
+++ b/base/applications/mspaint/lang/bg-BG.rc
@@ -262,5 +262,5 @@ BEGIN
     IDS_VERTICAL "Вертикален"
     IDS_PRINTRES "%d x %d pixel/cm"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
-    IDS_SAVEERROR "Failed to save an image file %s."
+    IDS_SAVEERROR "Failed to save an image as the following file:\n\n%s"
 END

--- a/base/applications/mspaint/lang/bg-BG.rc
+++ b/base/applications/mspaint/lang/bg-BG.rc
@@ -262,4 +262,5 @@ BEGIN
     IDS_VERTICAL "Вертикален"
     IDS_PRINTRES "%d x %d pixel/cm"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
+    IDS_SAVEERROR "Failed to save an image file %s."
 END

--- a/base/applications/mspaint/lang/cs-CZ.rc
+++ b/base/applications/mspaint/lang/cs-CZ.rc
@@ -262,4 +262,5 @@ BEGIN
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
+    IDS_SAVEERROR "Failed to save an image file %s."
 END

--- a/base/applications/mspaint/lang/cs-CZ.rc
+++ b/base/applications/mspaint/lang/cs-CZ.rc
@@ -262,5 +262,5 @@ BEGIN
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
-    IDS_SAVEERROR "Failed to save an image file %s."
+    IDS_SAVEERROR "Failed to save an image as the following file:\n\n%s"
 END

--- a/base/applications/mspaint/lang/de-DE.rc
+++ b/base/applications/mspaint/lang/de-DE.rc
@@ -261,4 +261,5 @@ BEGIN
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
+    IDS_SAVEERROR "Failed to save an image file %s."
 END

--- a/base/applications/mspaint/lang/de-DE.rc
+++ b/base/applications/mspaint/lang/de-DE.rc
@@ -261,5 +261,5 @@ BEGIN
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
-    IDS_SAVEERROR "Failed to save an image file %s."
+    IDS_SAVEERROR "Failed to save an image as the following file:\n\n%s"
 END

--- a/base/applications/mspaint/lang/en-GB.rc
+++ b/base/applications/mspaint/lang/en-GB.rc
@@ -261,5 +261,5 @@ BEGIN
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d dots per inch"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
-    IDS_SAVEERROR "Failed to save an image file %s."
+    IDS_SAVEERROR "Failed to save an image as the following file:\n\n%s"
 END

--- a/base/applications/mspaint/lang/en-GB.rc
+++ b/base/applications/mspaint/lang/en-GB.rc
@@ -261,4 +261,5 @@ BEGIN
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d dots per inch"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
+    IDS_SAVEERROR "Failed to save an image file %s."
 END

--- a/base/applications/mspaint/lang/en-US.rc
+++ b/base/applications/mspaint/lang/en-US.rc
@@ -262,4 +262,5 @@ BEGIN
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d dots per inch"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
+    IDS_SAVEERROR "Failed to save an image file %s."
 END

--- a/base/applications/mspaint/lang/en-US.rc
+++ b/base/applications/mspaint/lang/en-US.rc
@@ -262,5 +262,5 @@ BEGIN
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d dots per inch"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
-    IDS_SAVEERROR "Failed to save an image file %s."
+    IDS_SAVEERROR "Failed to save an image as the following file:\n\n%s"
 END

--- a/base/applications/mspaint/lang/es-ES.rc
+++ b/base/applications/mspaint/lang/es-ES.rc
@@ -264,5 +264,5 @@ BEGIN
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
-    IDS_SAVEERROR "Failed to save an image file %s."
+    IDS_SAVEERROR "Failed to save an image as the following file:\n\n%s"
 END

--- a/base/applications/mspaint/lang/es-ES.rc
+++ b/base/applications/mspaint/lang/es-ES.rc
@@ -264,4 +264,5 @@ BEGIN
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
+    IDS_SAVEERROR "Failed to save an image file %s."
 END

--- a/base/applications/mspaint/lang/et-EE.rc
+++ b/base/applications/mspaint/lang/et-EE.rc
@@ -261,4 +261,5 @@ BEGIN
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
+    IDS_SAVEERROR "Failed to save an image file %s."
 END

--- a/base/applications/mspaint/lang/et-EE.rc
+++ b/base/applications/mspaint/lang/et-EE.rc
@@ -261,5 +261,5 @@ BEGIN
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
-    IDS_SAVEERROR "Failed to save an image file %s."
+    IDS_SAVEERROR "Failed to save an image as the following file:\n\n%s"
 END

--- a/base/applications/mspaint/lang/eu-ES.rc
+++ b/base/applications/mspaint/lang/eu-ES.rc
@@ -262,4 +262,5 @@ BEGIN
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
+    IDS_SAVEERROR "Failed to save an image file %s."
 END

--- a/base/applications/mspaint/lang/eu-ES.rc
+++ b/base/applications/mspaint/lang/eu-ES.rc
@@ -262,5 +262,5 @@ BEGIN
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
-    IDS_SAVEERROR "Failed to save an image file %s."
+    IDS_SAVEERROR "Failed to save an image as the following file:\n\n%s"
 END

--- a/base/applications/mspaint/lang/fr-FR.rc
+++ b/base/applications/mspaint/lang/fr-FR.rc
@@ -262,4 +262,5 @@ BEGIN
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
+    IDS_SAVEERROR "Failed to save an image file %s."
 END

--- a/base/applications/mspaint/lang/fr-FR.rc
+++ b/base/applications/mspaint/lang/fr-FR.rc
@@ -262,5 +262,5 @@ BEGIN
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
-    IDS_SAVEERROR "Failed to save an image file %s."
+    IDS_SAVEERROR "Failed to save an image as the following file:\n\n%s"
 END

--- a/base/applications/mspaint/lang/he-IL.rc
+++ b/base/applications/mspaint/lang/he-IL.rc
@@ -264,5 +264,5 @@ BEGIN
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
-    IDS_SAVEERROR "Failed to save an image file %s."
+    IDS_SAVEERROR "Failed to save an image as the following file:\n\n%s"
 END

--- a/base/applications/mspaint/lang/he-IL.rc
+++ b/base/applications/mspaint/lang/he-IL.rc
@@ -264,4 +264,5 @@ BEGIN
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
+    IDS_SAVEERROR "Failed to save an image file %s."
 END

--- a/base/applications/mspaint/lang/hu-HU.rc
+++ b/base/applications/mspaint/lang/hu-HU.rc
@@ -262,4 +262,5 @@ BEGIN
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
+    IDS_SAVEERROR "Failed to save an image file %s."
 END

--- a/base/applications/mspaint/lang/hu-HU.rc
+++ b/base/applications/mspaint/lang/hu-HU.rc
@@ -262,5 +262,5 @@ BEGIN
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
-    IDS_SAVEERROR "Failed to save an image file %s."
+    IDS_SAVEERROR "Failed to save an image as the following file:\n\n%s"
 END

--- a/base/applications/mspaint/lang/id-ID.rc
+++ b/base/applications/mspaint/lang/id-ID.rc
@@ -261,4 +261,5 @@ BEGIN
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
+    IDS_SAVEERROR "Failed to save an image file %s."
 END

--- a/base/applications/mspaint/lang/id-ID.rc
+++ b/base/applications/mspaint/lang/id-ID.rc
@@ -261,5 +261,5 @@ BEGIN
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
-    IDS_SAVEERROR "Failed to save an image file %s."
+    IDS_SAVEERROR "Failed to save an image as the following file:\n\n%s"
 END

--- a/base/applications/mspaint/lang/it-IT.rc
+++ b/base/applications/mspaint/lang/it-IT.rc
@@ -262,4 +262,5 @@ BEGIN
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
+    IDS_SAVEERROR "Failed to save an image file %s."
 END

--- a/base/applications/mspaint/lang/it-IT.rc
+++ b/base/applications/mspaint/lang/it-IT.rc
@@ -262,5 +262,5 @@ BEGIN
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
-    IDS_SAVEERROR "Failed to save an image file %s."
+    IDS_SAVEERROR "Failed to save an image as the following file:\n\n%s"
 END

--- a/base/applications/mspaint/lang/ja-JP.rc
+++ b/base/applications/mspaint/lang/ja-JP.rc
@@ -263,4 +263,5 @@ BEGIN
     IDS_VERTICAL "縦書き"
     IDS_PRINTRES "%d x %d ピクセル/cm"
     IDS_CANTPASTE "クリップボードからの貼り付けに失敗しました。データ形式が間違っているか、未対応です。"
+    IDS_SAVEERROR "Failed to save an image file %s."
 END

--- a/base/applications/mspaint/lang/ja-JP.rc
+++ b/base/applications/mspaint/lang/ja-JP.rc
@@ -263,5 +263,5 @@ BEGIN
     IDS_VERTICAL "縦書き"
     IDS_PRINTRES "%d x %d ピクセル/cm"
     IDS_CANTPASTE "クリップボードからの貼り付けに失敗しました。データ形式が間違っているか、未対応です。"
-    IDS_SAVEERROR "Failed to save an image file %s."
+    IDS_SAVEERROR "次のファイルとして画像を保存するのに失敗しました:\n\n%s"
 END

--- a/base/applications/mspaint/lang/nl-NL.rc
+++ b/base/applications/mspaint/lang/nl-NL.rc
@@ -261,4 +261,5 @@ BEGIN
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
+    IDS_SAVEERROR "Failed to save an image file %s."
 END

--- a/base/applications/mspaint/lang/nl-NL.rc
+++ b/base/applications/mspaint/lang/nl-NL.rc
@@ -261,5 +261,5 @@ BEGIN
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
-    IDS_SAVEERROR "Failed to save an image file %s."
+    IDS_SAVEERROR "Failed to save an image as the following file:\n\n%s"
 END

--- a/base/applications/mspaint/lang/no-NO.rc
+++ b/base/applications/mspaint/lang/no-NO.rc
@@ -261,4 +261,5 @@ BEGIN
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
+    IDS_SAVEERROR "Failed to save an image file %s."
 END

--- a/base/applications/mspaint/lang/no-NO.rc
+++ b/base/applications/mspaint/lang/no-NO.rc
@@ -261,5 +261,5 @@ BEGIN
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
-    IDS_SAVEERROR "Failed to save an image file %s."
+    IDS_SAVEERROR "Failed to save an image as the following file:\n\n%s"
 END

--- a/base/applications/mspaint/lang/pl-PL.rc
+++ b/base/applications/mspaint/lang/pl-PL.rc
@@ -264,4 +264,5 @@ BEGIN
     IDS_VERTICAL "Pionowe"
     IDS_PRINTRES "%d x %d piksel/cm"
     IDS_CANTPASTE "Nie można wkleić ze schowka. Format danych jest nieprawidłowy lub nieobsługiwany."
+    IDS_SAVEERROR "Failed to save an image file %s."
 END

--- a/base/applications/mspaint/lang/pl-PL.rc
+++ b/base/applications/mspaint/lang/pl-PL.rc
@@ -264,5 +264,5 @@ BEGIN
     IDS_VERTICAL "Pionowe"
     IDS_PRINTRES "%d x %d piksel/cm"
     IDS_CANTPASTE "Nie można wkleić ze schowka. Format danych jest nieprawidłowy lub nieobsługiwany."
-    IDS_SAVEERROR "Failed to save an image file %s."
+    IDS_SAVEERROR "Failed to save an image as the following file:\n\n%s"
 END

--- a/base/applications/mspaint/lang/pt-BR.rc
+++ b/base/applications/mspaint/lang/pt-BR.rc
@@ -262,4 +262,5 @@ BEGIN
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
+    IDS_SAVEERROR "Failed to save an image file %s."
 END

--- a/base/applications/mspaint/lang/pt-BR.rc
+++ b/base/applications/mspaint/lang/pt-BR.rc
@@ -262,5 +262,5 @@ BEGIN
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
-    IDS_SAVEERROR "Failed to save an image file %s."
+    IDS_SAVEERROR "Failed to save an image as the following file:\n\n%s"
 END

--- a/base/applications/mspaint/lang/pt-PT.rc
+++ b/base/applications/mspaint/lang/pt-PT.rc
@@ -262,4 +262,5 @@ BEGIN
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
+    IDS_SAVEERROR "Failed to save an image file %s."
 END

--- a/base/applications/mspaint/lang/pt-PT.rc
+++ b/base/applications/mspaint/lang/pt-PT.rc
@@ -262,5 +262,5 @@ BEGIN
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
-    IDS_SAVEERROR "Failed to save an image file %s."
+    IDS_SAVEERROR "Failed to save an image as the following file:\n\n%s"
 END

--- a/base/applications/mspaint/lang/ro-RO.rc
+++ b/base/applications/mspaint/lang/ro-RO.rc
@@ -263,5 +263,5 @@ BEGIN
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixeli/cm"
     IDS_CANTPASTE "Nu a putut fi lipit din clipboard. Formatul de date este fie incorect, fie nesuportat."
-    IDS_SAVEERROR "Failed to save an image file %s."
+    IDS_SAVEERROR "Failed to save an image as the following file:\n\n%s"
 END

--- a/base/applications/mspaint/lang/ro-RO.rc
+++ b/base/applications/mspaint/lang/ro-RO.rc
@@ -263,4 +263,5 @@ BEGIN
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixeli/cm"
     IDS_CANTPASTE "Nu a putut fi lipit din clipboard. Formatul de date este fie incorect, fie nesuportat."
+    IDS_SAVEERROR "Failed to save an image file %s."
 END

--- a/base/applications/mspaint/lang/ru-RU.rc
+++ b/base/applications/mspaint/lang/ru-RU.rc
@@ -265,5 +265,5 @@ BEGIN
     IDS_VERTICAL "Вертикальный"
     IDS_PRINTRES "%d x %d точек/см"
     IDS_CANTPASTE "Не удалось вставить из буфера обмена. Формат данных либо некорректный, либо не поддерживается."
-    IDS_SAVEERROR "Failed to save an image file %s."
+    IDS_SAVEERROR "Failed to save an image as the following file:\n\n%s"
 END

--- a/base/applications/mspaint/lang/ru-RU.rc
+++ b/base/applications/mspaint/lang/ru-RU.rc
@@ -265,4 +265,5 @@ BEGIN
     IDS_VERTICAL "Вертикальный"
     IDS_PRINTRES "%d x %d точек/см"
     IDS_CANTPASTE "Не удалось вставить из буфера обмена. Формат данных либо некорректный, либо не поддерживается."
+    IDS_SAVEERROR "Failed to save an image file %s."
 END

--- a/base/applications/mspaint/lang/sk-SK.rc
+++ b/base/applications/mspaint/lang/sk-SK.rc
@@ -261,4 +261,5 @@ BEGIN
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
+    IDS_SAVEERROR "Failed to save an image file %s."
 END

--- a/base/applications/mspaint/lang/sk-SK.rc
+++ b/base/applications/mspaint/lang/sk-SK.rc
@@ -261,5 +261,5 @@ BEGIN
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
-    IDS_SAVEERROR "Failed to save an image file %s."
+    IDS_SAVEERROR "Failed to save an image as the following file:\n\n%s"
 END

--- a/base/applications/mspaint/lang/sq-AL.rc
+++ b/base/applications/mspaint/lang/sq-AL.rc
@@ -261,4 +261,5 @@ BEGIN
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
+    IDS_SAVEERROR "Failed to save an image file %s."
 END

--- a/base/applications/mspaint/lang/sq-AL.rc
+++ b/base/applications/mspaint/lang/sq-AL.rc
@@ -261,5 +261,5 @@ BEGIN
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
-    IDS_SAVEERROR "Failed to save an image file %s."
+    IDS_SAVEERROR "Failed to save an image as the following file:\n\n%s"
 END

--- a/base/applications/mspaint/lang/sv-SE.rc
+++ b/base/applications/mspaint/lang/sv-SE.rc
@@ -262,4 +262,5 @@ BEGIN
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
+    IDS_SAVEERROR "Failed to save an image file %s."
 END

--- a/base/applications/mspaint/lang/sv-SE.rc
+++ b/base/applications/mspaint/lang/sv-SE.rc
@@ -262,5 +262,5 @@ BEGIN
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
-    IDS_SAVEERROR "Failed to save an image file %s."
+    IDS_SAVEERROR "Failed to save an image as the following file:\n\n%s"
 END

--- a/base/applications/mspaint/lang/tr-TR.rc
+++ b/base/applications/mspaint/lang/tr-TR.rc
@@ -262,4 +262,5 @@ BEGIN
     IDS_VERTICAL "Düşey"
     IDS_PRINTRES "%d x %d pixel/cm"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
+    IDS_SAVEERROR "Failed to save an image file %s."
 END

--- a/base/applications/mspaint/lang/tr-TR.rc
+++ b/base/applications/mspaint/lang/tr-TR.rc
@@ -262,5 +262,5 @@ BEGIN
     IDS_VERTICAL "Düşey"
     IDS_PRINTRES "%d x %d pixel/cm"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
-    IDS_SAVEERROR "Failed to save an image file %s."
+    IDS_SAVEERROR "Failed to save an image as the following file:\n\n%s"
 END

--- a/base/applications/mspaint/lang/uk-UA.rc
+++ b/base/applications/mspaint/lang/uk-UA.rc
@@ -263,4 +263,5 @@ BEGIN
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
+    IDS_SAVEERROR "Failed to save an image file %s."
 END

--- a/base/applications/mspaint/lang/uk-UA.rc
+++ b/base/applications/mspaint/lang/uk-UA.rc
@@ -263,5 +263,5 @@ BEGIN
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
-    IDS_SAVEERROR "Failed to save an image file %s."
+    IDS_SAVEERROR "Failed to save an image as the following file:\n\n%s"
 END

--- a/base/applications/mspaint/lang/vi-VN.rc
+++ b/base/applications/mspaint/lang/vi-VN.rc
@@ -261,4 +261,5 @@ BEGIN
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
+    IDS_SAVEERROR "Failed to save an image file %s."
 END

--- a/base/applications/mspaint/lang/vi-VN.rc
+++ b/base/applications/mspaint/lang/vi-VN.rc
@@ -261,5 +261,5 @@ BEGIN
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixel/cm"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
-    IDS_SAVEERROR "Failed to save an image file %s."
+    IDS_SAVEERROR "Failed to save an image as the following file:\n\n%s"
 END

--- a/base/applications/mspaint/lang/zh-CN.rc
+++ b/base/applications/mspaint/lang/zh-CN.rc
@@ -264,4 +264,5 @@ BEGIN
     IDS_VERTICAL "垂直"
     IDS_PRINTRES "%d x %d pixel/cm"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
+    IDS_SAVEERROR "Failed to save an image file %s."
 END

--- a/base/applications/mspaint/lang/zh-CN.rc
+++ b/base/applications/mspaint/lang/zh-CN.rc
@@ -264,5 +264,5 @@ BEGIN
     IDS_VERTICAL "垂直"
     IDS_PRINTRES "%d x %d pixel/cm"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
-    IDS_SAVEERROR "Failed to save an image file %s."
+    IDS_SAVEERROR "Failed to save an image as the following file:\n\n%s"
 END

--- a/base/applications/mspaint/lang/zh-HK.rc
+++ b/base/applications/mspaint/lang/zh-HK.rc
@@ -262,5 +262,5 @@ BEGIN
     IDS_VERTICAL "垂直"
     IDS_PRINTRES "%d x %d pixel/cm"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
-    IDS_SAVEERROR "Failed to save an image file %s."
+    IDS_SAVEERROR "Failed to save an image as the following file:\n\n%s"
 END

--- a/base/applications/mspaint/lang/zh-HK.rc
+++ b/base/applications/mspaint/lang/zh-HK.rc
@@ -262,4 +262,5 @@ BEGIN
     IDS_VERTICAL "垂直"
     IDS_PRINTRES "%d x %d pixel/cm"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
+    IDS_SAVEERROR "Failed to save an image file %s."
 END

--- a/base/applications/mspaint/lang/zh-TW.rc
+++ b/base/applications/mspaint/lang/zh-TW.rc
@@ -262,5 +262,5 @@ BEGIN
     IDS_VERTICAL "垂直"
     IDS_PRINTRES "%d x %d pixel/cm"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
-    IDS_SAVEERROR "Failed to save an image file %s."
+    IDS_SAVEERROR "Failed to save an image as the following file:\n\n%s"
 END

--- a/base/applications/mspaint/lang/zh-TW.rc
+++ b/base/applications/mspaint/lang/zh-TW.rc
@@ -262,4 +262,5 @@ BEGIN
     IDS_VERTICAL "垂直"
     IDS_PRINTRES "%d x %d pixel/cm"
     IDS_CANTPASTE "Failed to paste from the clipboard. The data format is either incorrect or not supported."
+    IDS_SAVEERROR "Failed to save an image file %s."
 END

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -209,10 +209,8 @@ _tWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPTSTR lpCmdLine, INT nC
     }
 
     // Initialize imageModel
-    if (__argc >= 2)
-        DoLoadImageFile(mainWindow, __targv[1], TRUE);
-    else
-        SetBitmapAndInfo(NULL, NULL, NULL, FALSE);
+    if (__argc < 2 || !DoLoadImageFile(mainWindow, __targv[1], TRUE))
+        InitializeImage(NULL, NULL, FALSE);
 
     // Make the window visible on the screen
     mainWindow.ShowWindow(registrySettings.WindowPlacement.showCmd);

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -209,10 +209,10 @@ _tWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPTSTR lpCmdLine, INT nC
     }
 
     // Initialize imageModel
-    imageModel.Crop(registrySettings.BMPWidth, registrySettings.BMPHeight);
     if (__argc >= 2)
         DoLoadImageFile(mainWindow, __targv[1], TRUE);
-    imageModel.ClearHistory();
+    else
+        SetBitmapAndInfo(NULL, NULL, NULL, FALSE);
 
     // Make the window visible on the screen
     mainWindow.ShowWindow(registrySettings.WindowPlacement.showCmd);

--- a/base/applications/mspaint/resource.h
+++ b/base/applications/mspaint/resource.h
@@ -220,3 +220,4 @@
 #define IDS_VERTICAL    938
 #define IDS_PRINTRES    939
 #define IDS_CANTPASTE   940
+#define IDS_SAVEERROR   941

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -607,7 +607,7 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
         case IDM_FILENEW:
             if (ConfirmSave())
             {
-                SetBitmapAndInfo(NULL, NULL, NULL, FALSE);
+                InitializeImage(NULL, NULL, FALSE);
             }
             break;
         case IDM_FILEOPEN:
@@ -845,7 +845,7 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
         }
         case IDM_EDITCOPYTO:
         {
-            TCHAR szFileName[MAX_LONG_PATH] = _T("");
+            WCHAR szFileName[MAX_LONG_PATH] = L"*.png";
             if (GetSaveFileName(szFileName, _countof(szFileName)))
             {
                 HBITMAP hbm = selectionModel.CopyBitmap();
@@ -857,7 +857,7 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
         }
         case IDM_EDITPASTEFROM:
         {
-            TCHAR szFileName[MAX_LONG_PATH] = _T("");
+            WCHAR szFileName[MAX_LONG_PATH] = L"";
             if (GetOpenFileName(szFileName, _countof(szFileName)))
             {
                 HBITMAP hbmNew = DoLoadImageFile(m_hWnd, szFileName, FALSE);


### PR DESCRIPTION
## Purpose

- Display a correct error message on failing to save a file.
- Don't confuse the main file info and the non-main file info.

JIRA issue: [CORE-18867](https://jira.reactos.org/browse/CORE-18867)

## Proposed changes

- Rename `ShowFileLoadError` as `ShowError`, and strengthen and move it to `dialogs.cpp`.
- Add `SetFileInfo` and `InitializeImage` helper functions.
- Add `IDS_SAVEERROR` resource string.
- Modify `SaveDIBToFile`, `SetBitmapAndInfo`, and `DoLoadImageFile` functions.

## TODO

- [x] Do tests.
