### PR TITLE
[NTUSER] NtUserWaitForInputIdle: Fix unhandled exception BSOD 0x1E

### DIFF
--- a/win32ss/user/ntuser/message.c
+++ b/win32ss/user/ntuser/message.c
@@ -3176,12 +3176,17 @@ NtUserWaitForInputIdle( IN HANDLE hProcess,
     while (TRUE);
 
 WaitExit:
+    KeStackAttachProcess(&Process->Pcb, &ApcState);
+
     for (pti = W32Process->ptiList; pti; pti = pti->ptiSibling)
     {
        pti->TIF_flags &= ~TIF_WAITFORINPUTIDLE;
        pti->pClientInfo->dwTIFlags = pti->TIF_flags;
     }
     W32Process->W32PF_flags &= ~W32PF_WAITFORINPUTIDLE;
+
+    KeUnstackDetachProcess(&ApcState);
+
     IntDereferenceProcessInfo(W32Process);
     ObDereferenceObject(Process);
     UserLeave();

--- a/win32ss/user/ntuser/message.c
+++ b/win32ss/user/ntuser/message.c
@@ -3110,14 +3110,12 @@ NtUserWaitForInputIdle( IN HANDLE hProcess,
        Timeout.QuadPart = (LONGLONG) dwMilliseconds * (LONGLONG) -10000;
 
     KeStackAttachProcess(&Process->Pcb, &ApcState);
-
     W32Process->W32PF_flags |= W32PF_WAITFORINPUTIDLE;
     for (pti = W32Process->ptiList; pti; pti = pti->ptiSibling)
     {
        pti->TIF_flags |= TIF_WAITFORINPUTIDLE;
        pti->pClientInfo->dwTIFlags = pti->TIF_flags;
     }
-
     KeUnstackDetachProcess(&ApcState);
 
     TRACE("WFII: ppi %p\n", W32Process);
@@ -3177,14 +3175,12 @@ NtUserWaitForInputIdle( IN HANDLE hProcess,
 
 WaitExit:
     KeStackAttachProcess(&Process->Pcb, &ApcState);
-
     for (pti = W32Process->ptiList; pti; pti = pti->ptiSibling)
     {
        pti->TIF_flags &= ~TIF_WAITFORINPUTIDLE;
        pti->pClientInfo->dwTIFlags = pti->TIF_flags;
     }
     W32Process->W32PF_flags &= ~W32PF_WAITFORINPUTIDLE;
-
     KeUnstackDetachProcess(&ApcState);
 
     IntDereferenceProcessInfo(W32Process);


### PR DESCRIPTION
## Purpose
Fix CLIENTINFO pointer access.
Based on a patch by Michael Fritscher from [CORE-10017](https://jira.reactos.org/browse/CORE-10017)
Addendum to 705228250741da (r68702).

JIRA issue:
[CORE-18728](https://jira.reactos.org/browse/CORE-18728)
[CORE-19014](https://jira.reactos.org/browse/CORE-19014) (duplicate)