### PR TITLE
[SERVMAN] Respect the user-selected export format

### DIFF
--- a/base/applications/mscutils/servman/export.c
+++ b/base/applications/mscutils/servman/export.c
@@ -35,10 +35,15 @@ GetTextFromListView(PMAIN_WND_INFO Info,
 static BOOL
 SaveServicesToFile(PMAIN_WND_INFO Info,
                    LPCWSTR pszFileName,
-                   DWORD nIndex)
+                   DWORD nFormat)
 {
     HANDLE hFile;
     BOOL bSuccess = FALSE;
+
+    if (!nFormat || 2 < nFormat)
+    {
+        return bSuccess;
+    }
 
     hFile = CreateFileW(pszFileName,
                        GENERIC_WRITE,
@@ -76,11 +81,14 @@ SaveServicesToFile(PMAIN_WND_INFO Info,
                               NULL);
                 }
 
-                WriteFile(hFile,
-                          &seps[nIndex-1],
-                          sizeof(WCHAR),
-                          &dwWritten,
-                          NULL);
+                if (k != 4)
+                {
+                    WriteFile(hFile,
+                              &seps[nFormat-1],
+                              sizeof(WCHAR),
+                              &dwWritten,
+                              NULL);
+                }
             }
             WriteFile(hFile,
                       newl,

--- a/base/applications/mscutils/servman/export.c
+++ b/base/applications/mscutils/servman/export.c
@@ -74,13 +74,13 @@ SaveServicesToFile(PMAIN_WND_INFO Info,
                               sizeof(WCHAR) * dwTextLength,
                               &dwWritten,
                               NULL);
-
-                    WriteFile(hFile,
-                              &seps[nIndex-1],
-                              sizeof(WCHAR),
-                              &dwWritten,
-                              NULL);
                 }
+
+                WriteFile(hFile,
+                          &seps[nIndex-1],
+                          sizeof(WCHAR),
+                          &dwWritten,
+                          NULL);
             }
             WriteFile(hFile,
                       newl,

--- a/base/applications/mscutils/servman/export.c
+++ b/base/applications/mscutils/servman/export.c
@@ -34,7 +34,8 @@ GetTextFromListView(PMAIN_WND_INFO Info,
 
 static BOOL
 SaveServicesToFile(PMAIN_WND_INFO Info,
-                   LPCWSTR pszFileName)
+                   LPCWSTR pszFileName,
+                   DWORD nIndex)
 {
     HANDLE hFile;
     BOOL bSuccess = FALSE;
@@ -51,7 +52,7 @@ SaveServicesToFile(PMAIN_WND_INFO Info,
     {
         WCHAR LVText[500];
         WCHAR newl[2] = {L'\r', L'\n'};
-        WCHAR tab = L'\t';
+        WCHAR seps[2] = {L'\t', L','};
         DWORD dwTextLength, dwWritten;
         INT NumListedServ = 0;
         INT i, k;
@@ -75,7 +76,7 @@ SaveServicesToFile(PMAIN_WND_INFO Info,
                               NULL);
 
                     WriteFile(hFile,
-                              &tab,
+                              &seps[nIndex-1],
                               sizeof(WCHAR),
                               &dwWritten,
                               NULL);
@@ -113,7 +114,7 @@ VOID ExportFile(PMAIN_WND_INFO Info)
 
     if(GetSaveFileName(&ofn))
     {
-        if (SaveServicesToFile(Info, szFileName))
+        if (SaveServicesToFile(Info, szFileName, ofn.nFilterIndex))
             return;
     }
 

--- a/base/applications/mscutils/servman/export.c
+++ b/base/applications/mscutils/servman/export.c
@@ -40,7 +40,7 @@ SaveServicesToFile(PMAIN_WND_INFO Info,
     HANDLE hFile;
     BOOL bSuccess = FALSE;
 
-    if (!nFormat || 2 < nFormat)
+    if (!nFormat || nFormat > 2)
     {
         return bSuccess;
     }
@@ -66,7 +66,7 @@ SaveServicesToFile(PMAIN_WND_INFO Info,
 
         for (i=0; i < NumListedServ; i++)
         {
-            for (k=0; k<5; k++)
+            for (k=0; k < LVMAX; k++)
             {
                 dwTextLength = GetTextFromListView(Info,
                                                    LVText,
@@ -81,8 +81,9 @@ SaveServicesToFile(PMAIN_WND_INFO Info,
                               NULL);
                 }
 
-                if (k != 4)
+                if (k < LVMAX - 1)
                 {
+                    /* Do not add separator after the last table cell */
                     WriteFile(hFile,
                               &seps[nFormat-1],
                               sizeof(WCHAR),

--- a/base/applications/mscutils/servman/precomp.h
+++ b/base/applications/mscutils/servman/precomp.h
@@ -31,6 +31,7 @@
 #define LVSTATUS        2
 #define LVSTARTUP       3
 #define LVLOGONAS       4
+#define LVMAX           5
 
 #define IMAGE_UNKNOWN   0
 #define IMAGE_SERVICE   1


### PR DESCRIPTION
## Purpose

It was tab-delimited regardless of the user's selection.
Now, make either tab or comma separated depending on the selection.

JIRA issue: [CORE-19001](https://jira.reactos.org/browse/CORE-19001)
