### PR TITLE
[RTL][ADVAPI32_APITEST] RtlIsTextUnicode: Don't change weight unless lead-byte flag

### DIFF
--- a/modules/rostests/apitests/advapi32/IsTextUnicode.c
+++ b/modules/rostests/apitests/advapi32/IsTextUnicode.c
@@ -128,6 +128,9 @@ START_TEST(IsTextUnicode)
     };
 
     const char japanese_with_lead[] = "ABC" "\x83\x40" "D";
+    const char japanese_sjis[] = "\x93\xFA\x96\x7B\x8C\xEA\x31\x32\x33\x93\xFA\x96\x7B\x8C\xEA";
+    const char japanese_utf8[] = "\xE6\x97\xA5\xE6\x9C\xAC\xE8\xAA\x9E\x31\x32\x33\xE6\x97\xA5"
+                                 "\xE6\x9C\xAC\xE8\xAA\x9E";
     const char simplfied_chinese_with_lead[] = "ABC" "\xC5\xC5" "D";
     const char korean_with_lead[] = "ABC" "\xBF\xAD" "D";
     const char traditional_chinese_with_lead[] = "ABC" "\xB1\xC1" "D";
@@ -151,6 +154,24 @@ START_TEST(IsTextUnicode)
     Result = IS_TEXT_UNICODE_DBCS_LEADBYTE;
     ok(!IsTextUnicode(japanese_with_lead, sizeof(japanese_with_lead), &Result), "IsTextUnicode() returned TRUE, expected FALSE\n");
     ok(Result == IS_TEXT_UNICODE_DBCS_LEADBYTE, "Result returned 0x%x, expected 0x%x\n", Result, IS_TEXT_UNICODE_DBCS_LEADBYTE);
+
+    Result = IS_TEXT_UNICODE_STATISTICS | IS_TEXT_UNICODE_REVERSE_STATISTICS;
+    ok(!IsTextUnicode(japanese_sjis, sizeof(japanese_sjis) - 1, &Result), "IsTextUnicode() returned TRUE, expected FALSE\n");
+    ok(Result == 0, "Result returned 0x%x, expected 0x%x\n", Result, 0);
+
+    Result = IS_TEXT_UNICODE_STATISTICS | IS_TEXT_UNICODE_REVERSE_STATISTICS | IS_TEXT_UNICODE_DBCS_LEADBYTE;
+    ok(!IsTextUnicode(japanese_sjis, sizeof(japanese_sjis) - 1, &Result), "IsTextUnicode() returned TRUE, expected FALSE\n");
+    ok(Result == (IS_TEXT_UNICODE_DBCS_LEADBYTE | IS_TEXT_UNICODE_REVERSE_STATISTICS),
+       "Result returned 0x%x, expected 0x%x\n", Result, IS_TEXT_UNICODE_DBCS_LEADBYTE | IS_TEXT_UNICODE_REVERSE_STATISTICS);
+
+    Result = IS_TEXT_UNICODE_STATISTICS | IS_TEXT_UNICODE_REVERSE_STATISTICS;
+    ok(!IsTextUnicode(japanese_utf8, sizeof(japanese_utf8) - 1, &Result), "IsTextUnicode() returned TRUE, expected FALSE\n");
+    ok(Result == 0, "Result returned 0x%x, expected 0x%x\n", Result, 0);
+
+    Result = IS_TEXT_UNICODE_STATISTICS | IS_TEXT_UNICODE_REVERSE_STATISTICS | IS_TEXT_UNICODE_DBCS_LEADBYTE;
+    ok(!IsTextUnicode(japanese_utf8, sizeof(japanese_utf8) - 1, &Result), "IsTextUnicode() returned TRUE, expected FALSE\n");
+    ok(Result == (IS_TEXT_UNICODE_DBCS_LEADBYTE | IS_TEXT_UNICODE_STATISTICS),
+       "Result returned 0x%x, expected 0x%x\n", Result, IS_TEXT_UNICODE_DBCS_LEADBYTE | IS_TEXT_UNICODE_STATISTICS);
 
     /* Simplified Chinese */
     SetupLocale(936, 936, -1);

--- a/modules/rostests/apitests/advapi32/IsTextUnicode.c
+++ b/modules/rostests/apitests/advapi32/IsTextUnicode.c
@@ -157,7 +157,7 @@ START_TEST(IsTextUnicode)
 
     Result = IS_TEXT_UNICODE_STATISTICS | IS_TEXT_UNICODE_REVERSE_STATISTICS;
     ok(!IsTextUnicode(japanese_sjis, sizeof(japanese_sjis) - 1, &Result), "IsTextUnicode() returned TRUE, expected FALSE\n");
-    ok(Result == 0, "Result returned 0x%x, expected 0x%x\n", Result, 0);
+    ok(Result == 0, "Result returned 0x%x, expected 0\n", Result);
 
     Result = IS_TEXT_UNICODE_STATISTICS | IS_TEXT_UNICODE_REVERSE_STATISTICS | IS_TEXT_UNICODE_DBCS_LEADBYTE;
     ok(!IsTextUnicode(japanese_sjis, sizeof(japanese_sjis) - 1, &Result), "IsTextUnicode() returned TRUE, expected FALSE\n");

--- a/modules/rostests/apitests/advapi32/IsTextUnicode.c
+++ b/modules/rostests/apitests/advapi32/IsTextUnicode.c
@@ -4,6 +4,7 @@
  * PURPOSE:         Tests for (Rtl)IsTextUnicode.
  * PROGRAMMERS:     Hermes Belusca-Maito
  *                  Dmitry Chapyshev
+ *                  Katayama Hirofumi MZ
  */
 
 #include "precomp.h"

--- a/modules/rostests/apitests/advapi32/IsTextUnicode.c
+++ b/modules/rostests/apitests/advapi32/IsTextUnicode.c
@@ -152,26 +152,26 @@ START_TEST(IsTextUnicode)
     SetupLocale(932, 932, -1);
 
     Result = IS_TEXT_UNICODE_DBCS_LEADBYTE;
-    ok(!IsTextUnicode(japanese_with_lead, sizeof(japanese_with_lead), &Result), "IsTextUnicode() returned TRUE, expected FALSE\n");
-    ok(Result == IS_TEXT_UNICODE_DBCS_LEADBYTE, "Result returned 0x%x, expected 0x%x\n", Result, IS_TEXT_UNICODE_DBCS_LEADBYTE);
+    ok_int(IsTextUnicode(japanese_with_lead, sizeof(japanese_with_lead), &Result), FALSE);
+    ok_int(Result, IS_TEXT_UNICODE_DBCS_LEADBYTE);
 
     Result = IS_TEXT_UNICODE_STATISTICS | IS_TEXT_UNICODE_REVERSE_STATISTICS;
-    ok(!IsTextUnicode(japanese_sjis, sizeof(japanese_sjis) - 1, &Result), "IsTextUnicode() returned TRUE, expected FALSE\n");
-    ok(Result == 0, "Result returned 0x%x, expected 0\n", Result);
+    ok_int(IsTextUnicode(japanese_sjis, sizeof(japanese_sjis) - 1, &Result), FALSE);
+    ok_int(Result, 0);
 
-    Result = IS_TEXT_UNICODE_STATISTICS | IS_TEXT_UNICODE_REVERSE_STATISTICS | IS_TEXT_UNICODE_DBCS_LEADBYTE;
-    ok(!IsTextUnicode(japanese_sjis, sizeof(japanese_sjis) - 1, &Result), "IsTextUnicode() returned TRUE, expected FALSE\n");
-    ok(Result == (IS_TEXT_UNICODE_DBCS_LEADBYTE | IS_TEXT_UNICODE_REVERSE_STATISTICS),
-       "Result returned 0x%x, expected 0x%x\n", Result, IS_TEXT_UNICODE_DBCS_LEADBYTE | IS_TEXT_UNICODE_REVERSE_STATISTICS);
+    Result = IS_TEXT_UNICODE_STATISTICS | IS_TEXT_UNICODE_REVERSE_STATISTICS |
+             IS_TEXT_UNICODE_DBCS_LEADBYTE;
+    ok_int(IsTextUnicode(japanese_sjis, sizeof(japanese_sjis) - 1, &Result), FALSE);
+    ok_int(Result, (IS_TEXT_UNICODE_DBCS_LEADBYTE | IS_TEXT_UNICODE_REVERSE_STATISTICS));
 
     Result = IS_TEXT_UNICODE_STATISTICS | IS_TEXT_UNICODE_REVERSE_STATISTICS;
-    ok(!IsTextUnicode(japanese_utf8, sizeof(japanese_utf8) - 1, &Result), "IsTextUnicode() returned TRUE, expected FALSE\n");
-    ok(Result == 0, "Result returned 0x%x, expected 0x%x\n", Result, 0);
+    ok_int(IsTextUnicode(japanese_utf8, sizeof(japanese_utf8) - 1, &Result), FALSE);
+    ok_int(Result, 0);
 
-    Result = IS_TEXT_UNICODE_STATISTICS | IS_TEXT_UNICODE_REVERSE_STATISTICS | IS_TEXT_UNICODE_DBCS_LEADBYTE;
-    ok(!IsTextUnicode(japanese_utf8, sizeof(japanese_utf8) - 1, &Result), "IsTextUnicode() returned TRUE, expected FALSE\n");
-    ok(Result == (IS_TEXT_UNICODE_DBCS_LEADBYTE | IS_TEXT_UNICODE_STATISTICS),
-       "Result returned 0x%x, expected 0x%x\n", Result, IS_TEXT_UNICODE_DBCS_LEADBYTE | IS_TEXT_UNICODE_STATISTICS);
+    Result = IS_TEXT_UNICODE_STATISTICS | IS_TEXT_UNICODE_REVERSE_STATISTICS |
+             IS_TEXT_UNICODE_DBCS_LEADBYTE;
+    ok_int(IsTextUnicode(japanese_utf8, sizeof(japanese_utf8) - 1, &Result), FALSE);
+    ok_int(Result, (IS_TEXT_UNICODE_DBCS_LEADBYTE | IS_TEXT_UNICODE_STATISTICS));
 
     /* Simplified Chinese */
     SetupLocale(936, 936, -1);

--- a/modules/rostests/apitests/advapi32/IsTextUnicode.c
+++ b/modules/rostests/apitests/advapi32/IsTextUnicode.c
@@ -156,6 +156,8 @@ START_TEST(IsTextUnicode)
     ok_int(IsTextUnicode(japanese_with_lead, sizeof(japanese_with_lead), &Result), FALSE);
     ok_int(Result, IS_TEXT_UNICODE_DBCS_LEADBYTE);
 
+    ok_int(IsTextUnicode(japanese_sjis, sizeof(japanese_sjis) - 1, NULL), FALSE);
+
     Result = IS_TEXT_UNICODE_STATISTICS | IS_TEXT_UNICODE_REVERSE_STATISTICS;
     ok_int(IsTextUnicode(japanese_sjis, sizeof(japanese_sjis) - 1, &Result), FALSE);
     ok_int(Result, 0);
@@ -164,6 +166,8 @@ START_TEST(IsTextUnicode)
              IS_TEXT_UNICODE_DBCS_LEADBYTE;
     ok_int(IsTextUnicode(japanese_sjis, sizeof(japanese_sjis) - 1, &Result), FALSE);
     ok_int(Result, (IS_TEXT_UNICODE_DBCS_LEADBYTE | IS_TEXT_UNICODE_REVERSE_STATISTICS));
+
+    ok_int(IsTextUnicode(japanese_utf8, sizeof(japanese_utf8) - 1, NULL), FALSE);
 
     Result = IS_TEXT_UNICODE_STATISTICS | IS_TEXT_UNICODE_REVERSE_STATISTICS;
     ok_int(IsTextUnicode(japanese_utf8, sizeof(japanese_utf8) - 1, &Result), FALSE);

--- a/sdk/lib/rtl/unicode.c
+++ b/sdk/lib/rtl/unicode.c
@@ -1356,7 +1356,7 @@ RtlIsTextUnicode(CONST VOID* buf, INT len, INT* pf)
         }
     }
 
-    if (NlsMbCodePageTag)
+    if (NlsMbCodePageTag && pf && (*pf & IS_TEXT_UNICODE_DBCS_LEADBYTE))
     {
         for (i = 0; i < len; i++)
         {
@@ -1367,7 +1367,7 @@ RtlIsTextUnicode(CONST VOID* buf, INT len, INT* pf)
             }
         }
 
-        if (lead_byte && pf && (*pf & IS_TEXT_UNICODE_DBCS_LEADBYTE))
+        if (lead_byte)
         {
             weight = (len / 2) - 1;
 

--- a/sdk/lib/rtl/unicode.c
+++ b/sdk/lib/rtl/unicode.c
@@ -1367,7 +1367,7 @@ RtlIsTextUnicode(CONST VOID* buf, INT len, INT* pf)
             }
         }
 
-        if (lead_byte)
+        if (lead_byte && pf && (*pf & IS_TEXT_UNICODE_DBCS_LEADBYTE))
         {
             weight = (len / 2) - 1;
 
@@ -1378,8 +1378,7 @@ RtlIsTextUnicode(CONST VOID* buf, INT len, INT* pf)
             else
                 weight = 1;
 
-            if (pf && (*pf & IS_TEXT_UNICODE_DBCS_LEADBYTE))
-                out_flags |= IS_TEXT_UNICODE_DBCS_LEADBYTE;
+            out_flags |= IS_TEXT_UNICODE_DBCS_LEADBYTE;
         }
     }
 


### PR DESCRIPTION
## Purpose

Fix the garbled characters (a.k.a. mojibake) in some Japanese text files.

JIRA issue: [CORE-19016](https://jira.reactos.org/browse/CORE-19016)

## Proposed changes

- `weight` will remain `3` unless `IS_TEXT_UNICODE_DBCS_LEADBYTE` flag is set.
- Strengthen `advapi32_apitest IsTextUnicode` testcase.

## TODO

- [x] Do small tests.
- [x] Do big tests.

## Comparison

BEFORE:
![before](https://github.com/reactos/reactos/assets/2107452/93494272-3c77-4766-9961-7a6425dcbad9)

AFTER:
![after](https://github.com/reactos/reactos/assets/2107452/cc1eba26-dc61-40cf-a4b4-232eb2689a7c)

BEFORE:
![before](https://github.com/reactos/reactos/assets/2107452/f3747a43-5399-45ea-8565-261160f01132)

AFTER:
![after](https://github.com/reactos/reactos/assets/2107452/1d17c67f-7fcf-4e0b-bbd9-de7f7a4a487d)