### PR TITLE
[SHELL32] Fix Control_RunDLLW

### DIFF
--- a/dll/win32/shell32/wine/control.c
+++ b/dll/win32/shell32/wine/control.c
@@ -1022,13 +1022,13 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
             while (pchLastUnquotedSpace[nSpaces] == L' ')
                 nSpaces++;
 
-            StringCchCopyNW(buffer, nLen, wszCmd, pchLastUnquotedSpace - wszCmd);
-            StringCchCopyW(wszDialogBoxName, nLen, pchLastUnquotedSpace + nSpaces);
+            StringCchCopyNW(buffer, nLen + 1, wszCmd, pchLastUnquotedSpace - wszCmd);
+            StringCchCopyW(wszDialogBoxName, nLen + 1, pchLastUnquotedSpace + nSpaces);
         }
         /* No parameters were passed, the entire string is the CPL path. */
         else
         {
-            StringCchCopyW(buffer, nLen, wszCmd);
+            StringCchCopyW(buffer, nLen + 1, wszCmd);
         }
     }
     /* If an unquoted comma was found, there are at least two parts of the string:
@@ -1043,9 +1043,9 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
         if (pchSecondComma == NULL)
             pchSecondComma = wszCmd + nLen;
 
-        StringCchCopyNW(buffer, nLen, wszCmd, pchFirstComma - wszCmd);
+        StringCchCopyNW(buffer, nLen + 1, wszCmd, pchFirstComma - wszCmd);
         StringCchCopyNW(wszDialogBoxName,
-                        nLen,
+                        nLen + 1,
                         pchFirstComma + 1,
                         pchSecondComma - pchFirstComma - 1);
 

--- a/dll/win32/shell32/wine/control.c
+++ b/dll/win32/shell32/wine/control.c
@@ -1023,12 +1023,12 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
                 nSpaces++;
 
             StringCchCopyNW(buffer, nLen, wszCmd, pchLastUnquotedSpace - wszCmd);
-            lstrcpyW(wszDialogBoxName, pchLastUnquotedSpace + nSpaces);
+            StringCchCopyW(wszDialogBoxName, nLen, pchLastUnquotedSpace + nSpaces);
         }
         /* No parameters were passed, the entire string is the CPL path. */
         else
         {
-            lstrcpyW(buffer, wszCmd);
+            StringCchCopyW(buffer, nLen, wszCmd);
         }
     }
     /* If an unquoted comma was found, there are at least two parts of the string:
@@ -1064,7 +1064,7 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
 
     if (wszDialogBoxName[0] == L'@')
     {
-        sp = atoiW(wszDialogBoxName + 1);
+        sp = _wtoi(wszDialogBoxName + 1);
     }
 
     TRACE("cmd %s, extra %s, sp %d\n", debugstr_w(buffer), debugstr_w(extraPmts), sp);
@@ -1102,21 +1102,15 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
         {
             aCPLPath = GlobalFindAtomW(applet->cmd);
             if (!aCPLPath)
-            {
                 aCPLPath = GlobalAddAtomW(applet->cmd);
-            }
 
             aCPLName = GlobalFindAtomW(L"CPLName");
             if (!aCPLName)
-            {
                 aCPLName = GlobalAddAtomW(L"CPLName");
-            }
 
             aCPLFlags = GlobalFindAtomW(L"CPLFlags");
             if (!aCPLFlags)
-            {
                 aCPLFlags = GlobalAddAtomW(L"CPLFlags");
-            }
 
             findData.szAppFile = applet->cmd;
             findData.sAppletNo = (UINT_PTR)(sp + 1);

--- a/dll/win32/shell32/wine/control.c
+++ b/dll/win32/shell32/wine/control.c
@@ -1137,8 +1137,12 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
                 SetPropW(applet->hWnd, (LPTSTR)MAKEINTATOM(aCPLFlags), UlongToHandle(sp + 1));
                 Control_ShowAppletInTaskbar(applet, sp);
 
-                if (extraPmts[0] == L'\0' || !applet->proc(applet->hWnd, CPL_STARTWPARMSW, sp, (LPARAM)extraPmts))
-                applet->proc(applet->hWnd, CPL_DBLCLK, sp, applet->info[sp].data);
+                if (extraPmts[0] == L'\0' ||
+                    !applet->proc(applet->hWnd, CPL_STARTWPARMSW, sp, (LPARAM)extraPmts))
+                {
+                    applet->proc(applet->hWnd, CPL_DBLCLK, sp, applet->info[sp].data);
+                }
+
                 RemovePropW(applet->hWnd, applet->cmd);
                 GlobalDeleteAtom(aCPLPath);
             }

--- a/dll/win32/shell32/wine/control.c
+++ b/dll/win32/shell32/wine/control.c
@@ -974,8 +974,8 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
     LPCWSTR	extraPmts = L"";
     BOOL        quoted = FALSE;
     CPlApplet *applet;
-    LPCWSTR wszFirstCommaPosition = NULL, wszSecondCommaPosition = NULL;
-    LPCWSTR wszLastUnquotedSpacePosition = NULL;
+    LPCWSTR pchFirstComma = NULL, pchSecondComma = NULL;
+    LPCWSTR pchLastUnquotedSpace = NULL;
     LPWSTR wszDialogBoxName;
     int i = 0;
     SIZE_T nLen = lstrlenW(wszCmd);
@@ -998,32 +998,32 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
             quoted = !quoted;
         if (wszCmd[i] == ',' && !quoted)
         {
-            if (wszFirstCommaPosition == NULL)
-                wszFirstCommaPosition = &wszCmd[i];
-            else if (wszSecondCommaPosition == NULL)
-                wszSecondCommaPosition = &wszCmd[i];
+            if (pchFirstComma == NULL)
+                pchFirstComma = &wszCmd[i];
+            else if (pchSecondComma == NULL)
+                pchSecondComma = &wszCmd[i];
         }
         if (wszCmd[i] == ' ' && !quoted)
         {
-            wszLastUnquotedSpacePosition = &wszCmd[i];
+            pchLastUnquotedSpace = &wszCmd[i];
         }
     }
 
     /* If no unquoted commas are found, parameters are either space separated, or the entire string
      * is a CPL path. */
-    if (wszFirstCommaPosition == NULL)
+    if (pchFirstComma == NULL)
     {
         /* An unquoted space was found in the string. Assume the last word is the dialog box
          * name/number. */
-        if (wszLastUnquotedSpacePosition != NULL)
+        if (pchLastUnquotedSpace != NULL)
         {
             int nSpaces = 0;
 
-            while (wszLastUnquotedSpacePosition[nSpaces] == L' ')
+            while (pchLastUnquotedSpace[nSpaces] == L' ')
                 nSpaces++;
 
-            StringCchCopyNW(buffer, nLen, wszCmd, wszLastUnquotedSpacePosition - wszCmd);
-            lstrcpyW(wszDialogBoxName, wszLastUnquotedSpacePosition + nSpaces);
+            StringCchCopyNW(buffer, nLen, wszCmd, pchLastUnquotedSpace - wszCmd);
+            lstrcpyW(wszDialogBoxName, pchLastUnquotedSpace + nSpaces);
         }
         /* No parameters were passed, the entire string is the CPL path. */
         else
@@ -1040,18 +1040,18 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
     {
         /* If there was no second unquoted comma in the string, the CPL path ends at thes
           * null terminator. */
-        if (wszSecondCommaPosition == NULL)
-            wszSecondCommaPosition = wszCmd + nLen;
+        if (pchSecondComma == NULL)
+            pchSecondComma = wszCmd + nLen;
 
-        StringCchCopyNW(buffer, nLen, wszCmd, wszFirstCommaPosition - wszCmd);
+        StringCchCopyNW(buffer, nLen, wszCmd, pchFirstComma - wszCmd);
         StringCchCopyNW(wszDialogBoxName,
                         nLen,
-                        wszFirstCommaPosition + 1,
-                        wszSecondCommaPosition - wszFirstCommaPosition - 1);
+                        pchFirstComma + 1,
+                        pchSecondComma - pchFirstComma - 1);
 
-        if (wszSecondCommaPosition != wszCmd + nLen)
+        if (pchSecondComma != wszCmd + nLen)
         {
-            extraPmts = wszSecondCommaPosition + 1;
+            extraPmts = pchSecondComma + 1;
         }
     }
 

--- a/dll/win32/shell32/wine/control.c
+++ b/dll/win32/shell32/wine/control.c
@@ -994,18 +994,22 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
     /* Search for unquoted commas and spaces. */
     for (i = 0; i < nLen; i++)
     {
-        if (wszCmd[i] == '"')
-            quoted = !quoted;
-        if (wszCmd[i] == ',' && !quoted)
+        if (quoted && wszCmd[i] != L'"')
+            continue;
+        switch (wszCmd[i])
         {
-            if (pchFirstComma == NULL)
-                pchFirstComma = &wszCmd[i];
-            else if (pchSecondComma == NULL)
-                pchSecondComma = &wszCmd[i];
-        }
-        if (wszCmd[i] == ' ' && !quoted)
-        {
-            pchLastUnquotedSpace = &wszCmd[i];
+            case L'"':
+                quoted = !quoted;
+                break;
+            case L',':
+                if (!pchFirstComma) 
+                    pchFirstComma = &wszCmd[i];
+                else if (!pchSecondComma) 
+                    pchSecondComma = &wszCmd[i];
+                break;
+            case L' ': 
+                pchLastUnquotedSpace = &wszCmd[i];
+                break;
         }
     }
 

--- a/dll/win32/shell32/wine/control.c
+++ b/dll/win32/shell32/wine/control.c
@@ -1066,6 +1066,10 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
     while ((ptr = StrChrW(wszDialogBoxName, '"')))
         memmove(ptr, ptr+1, lstrlenW(ptr)*sizeof(WCHAR));
 
+    /* FIXME: required for "appwiz.cpl install_gecko" to work. */
+    if (wszDialogBoxName[0] != L'\0' && wszDialogBoxName[0] != L'@')
+            extraPmts = wszDialogBoxName;
+        
     if (wszDialogBoxName[0] == L'@')
     {
         sp = _wtoi(wszDialogBoxName + 1);
@@ -1102,7 +1106,11 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
 
         bActivated = (applet->hActCtx != INVALID_HANDLE_VALUE ? ActivateActCtx(applet->hActCtx, &cookie) : FALSE);
 
+        /* FIXME: required for "appwiz.cpl install_gecko" to work. 
+         * should be: 
         if (sp < applet->count)
+         */
+        if (sp <= applet->count)
         {
             aCPLPath = GlobalFindAtomW(applet->cmd);
             if (!aCPLPath)

--- a/dll/win32/shell32/wine/control.c
+++ b/dll/win32/shell32/wine/control.c
@@ -1066,10 +1066,6 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
     while ((ptr = StrChrW(wszDialogBoxName, '"')))
         memmove(ptr, ptr+1, lstrlenW(ptr)*sizeof(WCHAR));
 
-    /* FIXME: required for "appwiz.cpl install_gecko" to work. */
-    if (wszDialogBoxName[0] != L'\0' && wszDialogBoxName[0] != L'@')
-            extraPmts = wszDialogBoxName;
-        
     if (wszDialogBoxName[0] == L'@')
     {
         sp = _wtoi(wszDialogBoxName + 1);
@@ -1106,11 +1102,7 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
 
         bActivated = (applet->hActCtx != INVALID_HANDLE_VALUE ? ActivateActCtx(applet->hActCtx, &cookie) : FALSE);
 
-        /* FIXME: required for "appwiz.cpl install_gecko" to work. 
-         * should be: 
         if (sp < applet->count)
-         */
-        if (sp <= applet->count)
         {
             aCPLPath = GlobalFindAtomW(applet->cmd);
             if (!aCPLPath)

--- a/dll/win32/shell32/wine/control.c
+++ b/dll/win32/shell32/wine/control.c
@@ -1011,11 +1011,11 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
 
     /* If no unquoted commas are found, parameters are either space separated, or the entire string
      * is a CPL path. */
-    if (pchFirstComma == NULL)
+    if (!pchFirstComma)
     {
         /* An unquoted space was found in the string. Assume the last word is the dialog box
          * name/number. */
-        if (pchLastUnquotedSpace != NULL)
+        if (pchLastUnquotedSpace)
         {
             int nSpaces = 0;
 
@@ -1040,7 +1040,7 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
     {
         /* If there was no second unquoted comma in the string, the CPL path ends at thes
           * null terminator. */
-        if (pchSecondComma == NULL)
+        if (!pchSecondComma)
             pchSecondComma = wszCmd + nLen;
 
         StringCchCopyNW(buffer, nLen + 1, wszCmd, pchFirstComma - wszCmd);

--- a/dll/win32/shell32/wine/control.c
+++ b/dll/win32/shell32/wine/control.c
@@ -1051,7 +1051,6 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
     ATOM aCPLPath;
     AppDlgFindData findData;
 #endif
-
         /* we've been given a textual parameter (or none at all) */
         if (sp == -1) {
             while ((++sp) != applet->count) {
@@ -1138,6 +1137,7 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
     if (bActivated)
         DeactivateActCtx(0, cookie);
 #endif
+
     }
 
     HeapFree(GetProcessHeap(), 0, buffer);

--- a/dll/win32/shell32/wine/control.c
+++ b/dll/win32/shell32/wine/control.c
@@ -865,16 +865,26 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
     *   "a path\foo.cpl"
     */
 {
+    LPWSTR	buffer;
+    LPWSTR	beg = NULL;
+    LPWSTR	end;
+    WCHAR	ch;
+    LPWSTR       ptr;
+    signed 	sp = -1;
+    LPWSTR	extraPmtsBuf = NULL;
 #ifdef __REACTOS__
-    signed sp = -1;
+    LPWSTR	extraPmts = L"";
+#else
+    LPWSTR	extraPmts = NULL;
+#endif
+    BOOL        quoted = FALSE;
     CPlApplet *applet;
+
+#ifdef __REACTOS__
     LPCWSTR wszFirstCommaPosition = NULL, wszSecondCommaPosition = NULL;
     LPCWSTR wszLastUnquotedSpacePosition = NULL;
-    LPWSTR buffer, buffer2;
-    BOOL bQuoted = FALSE;
-    LPCWSTR extraPmts = L"";
+    LPWSTR buffer2;
     int i = 0;
-    LPWSTR ptr;
     SIZE_T nLen = lstrlenW(wszCmd);
 
     buffer = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(*buffer) * (nLen + 1));
@@ -892,15 +902,15 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
     for (i = 0; i < nLen; i++)
     {
         if (wszCmd[i] == '"')
-            bQuoted = !bQuoted;
-        if (wszCmd[i] == ',' && !bQuoted)
+            quoted = !quoted;
+        if (wszCmd[i] == ',' && !quoted)
         {
             if (wszFirstCommaPosition == NULL)
                 wszFirstCommaPosition = &wszCmd[i];
             else if (wszSecondCommaPosition == NULL)
                 wszSecondCommaPosition = &wszCmd[i];
         }
-        if (wszCmd[i] == ' ' && !bQuoted)
+        if (wszCmd[i] == ' ' && !quoted)
         {
             wszLastUnquotedSpacePosition = &wszCmd[i];
         }
@@ -964,17 +974,6 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
         sp = atoiW(buffer2 + 1);
     }
 #else
-    LPWSTR	buffer;
-    LPWSTR	beg = NULL;
-    LPWSTR	end;
-    WCHAR	ch;
-    LPWSTR       ptr;
-    signed 	sp = -1;
-    LPWSTR	extraPmtsBuf = NULL;
-    LPWSTR	extraPmts = NULL;
-    BOOL        quoted = FALSE;
-    CPlApplet *applet;
-
     buffer = HeapAlloc(GetProcessHeap(), 0, (lstrlenW(wszCmd) + 1) * sizeof(*wszCmd));
     if (!buffer) return;
 

--- a/dll/win32/shell32/wine/control.c
+++ b/dll/win32/shell32/wine/control.c
@@ -945,7 +945,7 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
                         nLen,
                         wszFirstCommaPosition + 1,
                         wszSecondCommaPosition - wszFirstCommaPosition - 1);
-                        
+
         if (wszSecondCommaPosition != wszCmd + nLen)
         {
             extraPmts = wszSecondCommaPosition + 1;
@@ -1045,13 +1045,12 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
     if (applet)
     {
 #ifdef __REACTOS__
-        ULONG_PTR cookie;
-        BOOL bActivated;
-        ATOM aCPLName;
-        ATOM aCPLFlags;
-        ATOM aCPLPath;
-        AppDlgFindData findData;
-        
+    ULONG_PTR cookie;
+    BOOL bActivated;
+    ATOM aCPLName;
+    ATOM aCPLFlags;
+    ATOM aCPLPath;
+    AppDlgFindData findData;
 #endif
 
         /* we've been given a textual parameter (or none at all) */
@@ -1085,60 +1084,60 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
 
         if (sp < applet->count)
         {
-            aCPLPath = GlobalFindAtomW(applet->cmd);
-            if (!aCPLPath)
-            {
-                aCPLPath = GlobalAddAtomW(applet->cmd);
-            }
-
-            aCPLName = GlobalFindAtomW(L"CPLName");
-            if (!aCPLName)
-            {
-                aCPLName = GlobalAddAtomW(L"CPLName");
-            }
-
-            aCPLFlags = GlobalFindAtomW(L"CPLFlags");
-            if (!aCPLFlags)
-            {
-                aCPLFlags = GlobalAddAtomW(L"CPLFlags");
-            }
-
-            findData.szAppFile = applet->cmd;
-            findData.sAppletNo = (UINT_PTR)(sp + 1);
-            findData.aCPLName = aCPLName;
-            findData.aCPLFlags = aCPLFlags;
-            findData.hRunDLL = applet->hWnd;
-            findData.hDlgResult = NULL;
-            // Find the dialog of this applet in the first instance.
-            // Note: The simpler functions "FindWindow" or "FindWindowEx" does not find this type of dialogs.
-            EnumWindows(Control_EnumWinProc, (LPARAM)&findData);
-            if (findData.hDlgResult)
-            {
-                BringWindowToTop(findData.hDlgResult);
-            }
-            else
-            {
-                SetPropW(applet->hWnd, (LPTSTR)MAKEINTATOM(aCPLName), (HANDLE)MAKEINTATOM(aCPLPath));
-                SetPropW(applet->hWnd, (LPTSTR)MAKEINTATOM(aCPLFlags), UlongToHandle(sp + 1));
-                Control_ShowAppletInTaskbar(applet, sp);
-
-                if (extraPmts[0] == L'\0' || !applet->proc(applet->hWnd, CPL_STARTWPARMSW, sp, (LPARAM)extraPmts))
-                    applet->proc(applet->hWnd, CPL_DBLCLK, sp, applet->info[sp].data);
-                RemovePropW(applet->hWnd, applet->cmd);
-                GlobalDeleteAtom(aCPLPath);
-            }
+        aCPLPath = GlobalFindAtomW(applet->cmd);
+        if (!aCPLPath)
+        {
+            aCPLPath = GlobalAddAtomW(applet->cmd);
         }
+
+        aCPLName = GlobalFindAtomW(L"CPLName");
+        if (!aCPLName)
+        {
+            aCPLName = GlobalAddAtomW(L"CPLName");
+        }
+
+        aCPLFlags = GlobalFindAtomW(L"CPLFlags");
+        if (!aCPLFlags)
+        {
+            aCPLFlags = GlobalAddAtomW(L"CPLFlags");
+        }
+
+        findData.szAppFile = applet->cmd;
+        findData.sAppletNo = (UINT_PTR)(sp + 1);
+        findData.aCPLName = aCPLName;
+        findData.aCPLFlags = aCPLFlags;
+        findData.hRunDLL = applet->hWnd;
+        findData.hDlgResult = NULL;
+        // Find the dialog of this applet in the first instance.
+        // Note: The simpler functions "FindWindow" or "FindWindowEx" does not find this type of dialogs.
+        EnumWindows(Control_EnumWinProc, (LPARAM)&findData);
+        if (findData.hDlgResult)
+        {
+            BringWindowToTop(findData.hDlgResult);
+        }
+        else
+        {
+            SetPropW(applet->hWnd, (LPTSTR)MAKEINTATOM(aCPLName), (HANDLE)MAKEINTATOM(aCPLPath));
+            SetPropW(applet->hWnd, (LPTSTR)MAKEINTATOM(aCPLFlags), UlongToHandle(sp + 1));
+            Control_ShowAppletInTaskbar(applet, sp);
+
+            if (extraPmts[0] == L'\0' || !applet->proc(applet->hWnd, CPL_STARTWPARMSW, sp, (LPARAM)extraPmts))
 #else
-        
         if (!applet->proc(applet->hWnd, CPL_STARTWPARMSW, sp, (LPARAM)extraPmts))
+#endif
             applet->proc(applet->hWnd, CPL_DBLCLK, sp, applet->info[sp].data);
+#ifdef __REACTOS__
+            RemovePropW(applet->hWnd, applet->cmd);
+            GlobalDeleteAtom(aCPLPath);
+        }
+        }
 #endif
 
         Control_UnloadApplet(applet);
 
 #ifdef __REACTOS__
-        if (bActivated)
-            DeactivateActCtx(0, cookie);
+    if (bActivated)
+        DeactivateActCtx(0, cookie);
 #endif
     }
 

--- a/dll/win32/shell32/wine/control.c
+++ b/dll/win32/shell32/wine/control.c
@@ -885,18 +885,18 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
 #ifdef __REACTOS__
     LPCWSTR wszFirstCommaPosition = NULL, wszSecondCommaPosition = NULL;
     LPCWSTR wszLastUnquotedSpacePosition = NULL;
-    LPWSTR wszDialogName;
+    LPWSTR wszDialogBoxName;
     int i = 0;
     SIZE_T nLen = lstrlenW(wszCmd);
 
     buffer = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(*buffer) * (nLen + 1));
-    wszDialogName = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(*wszDialogName) * (nLen + 1));
-    if (wszDialogName == NULL || buffer == NULL)
+    wszDialogBoxName = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(*wszDialogBoxName) * (nLen + 1));
+    if (wszDialogBoxName == NULL || buffer == NULL)
     {
         if (buffer != NULL)
             HeapFree(GetProcessHeap(), 0, buffer);
-        if (wszDialogName != NULL)
-            HeapFree(GetProcessHeap(), 0, wszDialogName);
+        if (wszDialogBoxName != NULL)
+            HeapFree(GetProcessHeap(), 0, wszDialogBoxName);
         return;
     }
 
@@ -922,8 +922,8 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
      * is a CPL path. */
     if (wszFirstCommaPosition == NULL)
     {
-        /* An unquoted space was found in the string. Assume the last word is the dialog
-         * name/index. */
+        /* An unquoted space was found in the string. Assume the last word is the dialog box
+         * name/number. */
         if (wszLastUnquotedSpacePosition != NULL)
         {
             int nSpaces = 0;
@@ -932,7 +932,7 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
                 nSpaces++;
 
             StringCchCopyNW(buffer, nLen, wszCmd, wszLastUnquotedSpacePosition - wszCmd);
-            lstrcpyW(wszDialogName, wszLastUnquotedSpacePosition + nSpaces);
+            lstrcpyW(wszDialogBoxName, wszLastUnquotedSpacePosition + nSpaces);
         }
         /* No parameters were passed, the entire string is the CPL path. */
         else
@@ -942,7 +942,7 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
     }
     /* If an unquoted comma was found, there are at least two parts of the string:
      * - the CPL path
-     * - either a dialog index preceeded by @, or a dialog name.
+     * - either a dialog box number preceeded by @, or a dialog box name.
      * If there was a second unqoted comma, there is another part of the string:
      * - the rest of the parameters. */
     else
@@ -953,7 +953,7 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
             wszSecondCommaPosition = wszCmd + nLen;
 
         StringCchCopyNW(buffer, nLen, wszCmd, wszFirstCommaPosition - wszCmd);
-        StringCchCopyNW(wszDialogName,
+        StringCchCopyNW(wszDialogBoxName,
                         nLen,
                         wszFirstCommaPosition + 1,
                         wszSecondCommaPosition - wszFirstCommaPosition - 1);
@@ -968,12 +968,12 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
     while ((ptr = StrChrW(buffer, '"')))
         memmove(ptr, ptr+1, lstrlenW(ptr)*sizeof(WCHAR));
 
-    while ((ptr = StrChrW(wszDialogName, '"')))
+    while ((ptr = StrChrW(wszDialogBoxName, '"')))
         memmove(ptr, ptr+1, lstrlenW(ptr)*sizeof(WCHAR));
 
-    if (wszDialogName[0] == L'@')
+    if (wszDialogBoxName[0] == L'@')
     {
-        sp = atoiW(wszDialogName + 1);
+        sp = atoiW(wszDialogBoxName + 1);
     }
 #else
     buffer = HeapAlloc(GetProcessHeap(), 0, (lstrlenW(wszCmd) + 1) * sizeof(*wszCmd));
@@ -1059,7 +1059,7 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
                 TRACE("sp %d, name %s\n", sp, debugstr_w(applet->info[sp].name));
 
 #ifdef __REACTOS__
-                if (StrCmpIW(wszDialogName, applet->info[sp].name) == 0)
+                if (StrCmpIW(wszDialogBoxName, applet->info[sp].name) == 0)
 #else
                 if (StrCmpIW(extraPmts, applet->info[sp].name) == 0)
 #endif
@@ -1068,7 +1068,7 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
         }
 
 #ifdef __REACTOS__
-        if (sp >= applet->count && wszDialogName[0] == L'\0')
+        if (sp >= applet->count && wszDialogBoxName[0] == L'\0')
         {
             sp = 0;
         }
@@ -1144,7 +1144,7 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
 
     HeapFree(GetProcessHeap(), 0, buffer);
 #ifdef __REACTOS__
-    HeapFree(GetProcessHeap(), 0, wszDialogName);
+    HeapFree(GetProcessHeap(), 0, wszDialogBoxName);
 #endif
 }
 

--- a/dll/win32/shell32/wine/control.c
+++ b/dll/win32/shell32/wine/control.c
@@ -866,15 +866,17 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
     */
 {
     LPWSTR	buffer;
+#ifndef __REACTOS__
     LPWSTR	beg = NULL;
     LPWSTR	end;
     WCHAR	ch;
+#endif
     LPWSTR       ptr;
     signed 	sp = -1;
-    LPWSTR	extraPmtsBuf = NULL;
 #ifdef __REACTOS__
-    LPWSTR	extraPmts = L"";
+    LPCWSTR	extraPmts = L"";
 #else
+    LPWSTR	extraPmtsBuf = NULL;
     LPWSTR	extraPmts = NULL;
 #endif
     BOOL        quoted = FALSE;

--- a/dll/win32/shell32/wine/control.c
+++ b/dll/win32/shell32/wine/control.c
@@ -922,7 +922,7 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
      * is a CPL path. */
     if (wszFirstCommaPosition == NULL)
     {
-        /* An unquoted space was found in the string. Assume the last word is the dialog 
+        /* An unquoted space was found in the string. Assume the last word is the dialog
          * name/index. */
         if (wszLastUnquotedSpacePosition != NULL)
         {
@@ -947,7 +947,7 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
      * - the rest of the parameters. */
     else
     {
-        /* If there was no second unquoted comma in the string, the CPL path ends at the 
+        /* If there was no second unquoted comma in the string, the CPL path ends at thes
           * null terminator. */
         if (wszSecondCommaPosition == NULL)
             wszSecondCommaPosition = wszCmd + nLen;
@@ -967,7 +967,7 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
     /* Remove the quotes from both buffers. */
     while ((ptr = StrChrW(buffer, '"')))
         memmove(ptr, ptr+1, lstrlenW(ptr)*sizeof(WCHAR));
-   
+
     while ((ptr = StrChrW(wszDialogName, '"')))
         memmove(ptr, ptr+1, lstrlenW(ptr)*sizeof(WCHAR));
 

--- a/dll/win32/shell32/wine/control.c
+++ b/dll/win32/shell32/wine/control.c
@@ -1052,10 +1052,6 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
         ATOM aCPLPath;
         AppDlgFindData findData;
         
-        if (sp == -1 && buffer2[0] == L'\0')
-        {
-            sp = 0;
-        }
 #endif
 
         /* we've been given a textual parameter (or none at all) */
@@ -1071,6 +1067,18 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
                     break;
             }
         }
+
+#ifdef __REACTOS__
+        if (sp >= applet->count && buffer2[0] == L'\0')
+        {
+            sp = 0;
+        }
+#else
+        if (sp >= applet->count) {
+            WARN("Out of bounds (%u >= %u), setting to 0\n", sp, applet->count);
+            sp = 0;
+        }
+#endif
 
 #ifdef __REACTOS__
         bActivated = (applet->hActCtx != INVALID_HANDLE_VALUE ? ActivateActCtx(applet->hActCtx, &cookie) : FALSE);
@@ -1121,10 +1129,6 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
             }
         }
 #else
-        if (sp >= applet->count) {
-            WARN("Out of bounds (%u >= %u), setting to 0\n", sp, applet->count);
-            sp = 0;
-        }
         
         if (!applet->proc(applet->hWnd, CPL_STARTWPARMSW, sp, (LPARAM)extraPmts))
             applet->proc(applet->hWnd, CPL_DBLCLK, sp, applet->info[sp].data);

--- a/dll/win32/shell32/wine/control.c
+++ b/dll/win32/shell32/wine/control.c
@@ -910,7 +910,7 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
      * is a path. */
     if (wszFirstCommaPosition == NULL)
     {
-        /* An unquoted space was found in the string. Assume the last word is the second 
+        /* An unquoted space was found in the string. Assume the last word is the second
          * parameter. */
         if (wszLastUnquotedSpacePosition != NULL)
         {
@@ -929,8 +929,8 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
         }
     }
     /* If an unquoted comma was found, there are at least two parts of the string:
-     * - the path 
-     * - either an index preceeded by @, or a name. 
+     * - the path
+     * - either an index preceeded by @, or a name.
      * If there was a second unqoted comma, there is another part of the string:
      * - the rest of the parameters. */
     else
@@ -941,9 +941,9 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
             wszSecondCommaPosition = wszCmd + nLen;
 
         StringCchCopyNW(buffer, nLen, wszCmd, (wszFirstCommaPosition - wszCmd));
-        StringCchCopyNW(buffer2, 
-                        nLen, 
-                        wszFirstCommaPosition + 1, 
+        StringCchCopyNW(buffer2,
+                        nLen,
+                        wszFirstCommaPosition + 1,
                         wszSecondCommaPosition - wszFirstCommaPosition - 1);
                         
         if (wszSecondCommaPosition != wszCmd + nLen)

--- a/dll/win32/syssetup/wizard.c
+++ b/dll/win32/syssetup/wizard.c
@@ -2467,7 +2467,7 @@ FinishDlgProc(HWND hwndDlg,
             if (!SetupData->UnattendSetup || !SetupData->DisableGeckoInst)
             {
                 /* Run the Wine Gecko prompt */
-                Control_RunDLLW(hwndDlg, 0, L"appwiz.cpl install_gecko", SW_SHOW);
+                Control_RunDLLW(hwndDlg, 0, L"appwiz.cpl,,install_gecko", SW_SHOW);
             }
 
             /* Set title font */


### PR DESCRIPTION
## Purpose

This pull request makes `Control_RunDLLW` pass all but one tests from rostests (the one test that fails is the first one, but it only fails if the path to the test program contains a space). It also hopefully fixes [CORE-8981](https://jira.reactos.org/browse/CORE-8981).

## Proposed changes
- Rework string parsing in the `Control_DoLaunch` routine
- Do not send the `CPL_STARTWPARMSW` message, if no extra parameters were specified (fixes the failing  `Got NULL lParam2!` and some `CPL_STARTWPARMSW: expected -1 got %d` tests)
- Do not resolve invalid dialog names to index zero, unless the name is empty (fixes some of the failing `CPL_DBLCLK: expected -1 got %d` tests)
- Handle quotes in the second part of `wszCmd`

## TODO
- [x] Add comments
- [x] Do more testing

## Note
The PR seems to fix [CORE-8981](https://jira.reactos.org/browse/CORE-8981). 
However, interestingly, the rostests for `Control_RunDLLW` fail on Windows XP, if the test program file path contains a space. 
Obviously XP is able to use CPLs with spaces in their paths in the control panel, so maybe it puts such paths in quotes in the control.exe, instead of passing "raw" paths with spaces? 
Nevertheless, this PR still makes the tests pass, and CPLs with spaces in paths work. I don't think having _more_ valid paths for CPLs is a problem, but I suppose I could try to break the code for such "feature" parity between Windows and ReactOS. Then [CORE-8981](https://jira.reactos.org/browse/CORE-8981) would have to be fixed elsewhere, maybe in `RunControlPanel` from `base/applications/control/control.c`.
Assuming no such action is necessary, I submit the PR for review. 