### PR TITLE
[WINHLP32] Enlarge the buffer for the titlebar

### DIFF
--- a/base/applications/winhlp32/hlpfile.h
+++ b/base/applications/winhlp32/hlpfile.h
@@ -28,7 +28,7 @@ typedef struct
 {
     char        type[10];
     char        name[9];
-    char        caption[51];
+    char        caption[300];
     POINT       origin;
     SIZE        size;
     int         style;


### PR DESCRIPTION
## Purpose

The buffer in the titlebar was small and the file path was truncated.
Therefore, the buffer in the titlebar was expanded from 51 to 300.

JIRA issue: [CORE-18679](https://jira.reactos.org/browse/CORE-18679)
