### PR TITLE
Fixed configure.cmd not always creating REACTOS_OUTPUT_PATH

### DIFF
--- a/configure.cmd
+++ b/configure.cmd
@@ -157,7 +157,7 @@ if "%VS_SOLUTION%" == "1" (
     set REACTOS_OUTPUT_PATH=%REACTOS_OUTPUT_PATH%-sln
 )
 
-if "%REACTOS_SOURCE_DIR%" == "%CD%\" (
+if /I "%REACTOS_SOURCE_DIR%" == "%CD%\" (
     set CD_SAME_AS_SOURCE=1
     echo Creating directories in %REACTOS_OUTPUT_PATH%
 


### PR DESCRIPTION


## Purpose

The configure batch does not always create the REACTOS_OUTPUT_PATH directory when configure is executed in the ROS source directory because it does a case-sensitive path comparison to detect this state.

## Proposed changes

- Perform a case-insensitive path comparison