### PR TITLE
[NETSTAT] Optimize a bit

### DIFF
--- a/base/applications/network/netstat/lang/en-US.rc
+++ b/base/applications/network/netstat/lang/en-US.rc
@@ -104,7 +104,7 @@ END
 
 STRINGTABLE
 BEGIN
-    IDS_ERROR_WSA_START "ERROR: WSAStartup() failed : %d\n"
+    IDS_ERROR_WSA_START "ERROR: WSAStartup() failed: %d\n"
     IDS_ERROR_ROUTE "ERROR: Cannot find 'route.exe'\n"
     IDS_ERROR_TCP_SNAPSHOT "ERROR: Failed to snapshot TCP endpoints.\n"
     IDS_ERROR_UDP_ENDPOINT "ERROR: Failed to snapshot UDP endpoints.\n"

--- a/base/applications/network/netstat/lang/pl-PL.rc
+++ b/base/applications/network/netstat/lang/pl-PL.rc
@@ -106,7 +106,7 @@ END
 
 STRINGTABLE
 BEGIN
-    IDS_ERROR_WSA_START "BŁĄD: Procedura WSAStartup() nie powiodła się : %d\n"
+    IDS_ERROR_WSA_START "BŁĄD: Procedura WSAStartup() nie powiodła się: %d\n"
     IDS_ERROR_ROUTE "BŁĄD: Nie można odnaleźć pliku 'route.exe'\n"
     IDS_ERROR_TCP_SNAPSHOT "BŁĄD: Nie powiodło się utworzenie migawki dla punktów końcowych TCP.\n"
     IDS_ERROR_UDP_ENDPOINT "BŁĄD: Nie powiodło się utworzenie migawki dla punktów końcowych UDP.\n"

--- a/base/applications/network/netstat/lang/zh-TW.rc
+++ b/base/applications/network/netstat/lang/zh-TW.rc
@@ -110,7 +110,7 @@ END
 
 STRINGTABLE
 BEGIN
-    IDS_ERROR_WSA_START "錯誤: WSAStartup() 失敗 : %d\n"
+    IDS_ERROR_WSA_START "錯誤: WSAStartup() 失敗: %d\n"
     IDS_ERROR_ROUTE "錯誤: 找不到 'route.exe'\n"
     IDS_ERROR_TCP_SNAPSHOT "錯誤: 無法取得 TCP 端點快照。\n"
     IDS_ERROR_UDP_ENDPOINT "錯誤: 無法取得 UDP 端點快照。\n"

--- a/base/applications/network/netstat/netstat.c
+++ b/base/applications/network/netstat/netstat.c
@@ -63,6 +63,7 @@ VOID DoFormatMessage(DWORD ErrorCode)
  */
 VOID DisplayTableHeader(VOID)
 {
+    ConResPuts(StdOut, IDS_ACTIVE_CONNECT);
     ConResPuts(StdOut, IDS_DISPLAY_THEADER);
     if (bDoShowProcessId)
         ConResPuts(StdOut, IDS_DISPLAY_PROCESS);
@@ -115,7 +116,6 @@ BOOL ParseCmdline(int argc, wchar_t* argv[])
                         bDoShowProtoCons = TRUE;
                         if (i+1 >= argc)
                         {
-                            ConResPuts(StdOut, IDS_ACTIVE_CONNECT);
                             DisplayTableHeader();
                             return TRUE;
                         }
@@ -173,7 +173,6 @@ BOOL DisplayOutput(VOID)
 {
     if (bNoOptions)
     {
-        ConResPuts(StdOut, IDS_ACTIVE_CONNECT);
         DisplayTableHeader();
         return ShowTcpTable();
     }
@@ -209,13 +208,11 @@ BOOL DisplayOutput(VOID)
             case TCP:
                 if (bDoShowProtoStats)
                     ShowTcpStatistics();
-                ConResPuts(StdOut, IDS_ACTIVE_CONNECT);
                 DisplayTableHeader();
                 return ShowTcpTable();
             case UDP:
                 if (bDoShowProtoStats)
                     ShowUdpStatistics();
-                ConResPuts(StdOut, IDS_ACTIVE_CONNECT);
                 DisplayTableHeader();
                 return (bDoShowAllCons ? ShowUdpTable() : TRUE);
             default:
@@ -232,7 +229,6 @@ BOOL DisplayOutput(VOID)
     }
     else
     {
-        ConResPuts(StdOut, IDS_ACTIVE_CONNECT);
         DisplayTableHeader();
         if (ShowTcpTable() && bDoShowAllCons)
             ShowUdpTable();


### PR DESCRIPTION
in netstat.c 100% of the calls to
    DisplayTableHeader();
have in the exact line beforehand a call to
    ConResPuts(StdOut, IDS_ACTIVE_CONNECT);

So let's fuse them.


Also fix a superfluous space in the *.rc files before it will get duplicated a thousand times.

