### PR TITLE
[NETSTAT] pragma once, reorder, fix pl-PL.rc

### DIFF
--- a/base/applications/network/netstat/lang/pl-PL.rc
+++ b/base/applications/network/netstat/lang/pl-PL.rc
@@ -95,13 +95,13 @@ END
 STRINGTABLE
 BEGIN
     IDS_ETHERNET_INTERFACE_STAT     "Statystyki interfejsu\n\n"
-    IDS_ETHERNET_THEADER            "                           Odebrano          Wysłano\n\n"
-    IDS_ETHERNET_BYTES              "  Bajty                               %14lu %15lu\n"
-    IDS_ETHERNET_UNICAST_PACKET     "  Pakiety emisji pojedynczej          %14lu %15lu\n"
-    IDS_ETHERNET_NON_UNICAST_PACKET "  Pakiety inne niż emisji pojedynczej %14lu %15lu\n"
-    IDS_ETHERNET_DISCARD            "  Odrzucone                           %14lu %15lu\n"
-    IDS_ETHERNET_ERROR              "  Błędy                               %14lu %15lu\n"
-    IDS_ETHERNET_UNKNOWN            "  Nieznane protokoły                  %14lu\n"
+    IDS_ETHERNET_THEADER            "                                          Odebrano         Wysłano\n\n"
+    IDS_ETHERNET_BYTES              "Bajty                               %14lu %15lu\n"
+    IDS_ETHERNET_UNICAST_PACKET     "Pakiety emisji pojedynczej          %14lu %15lu\n"
+    IDS_ETHERNET_NON_UNICAST_PACKET "Pakiety inne niż emisji pojedynczej %14lu %15lu\n"
+    IDS_ETHERNET_DISCARD            "Odrzucone                           %14lu %15lu\n"
+    IDS_ETHERNET_ERROR              "Błędy                               %14lu %15lu\n"
+    IDS_ETHERNET_UNKNOWN            "Nieznane protokoły                  %14lu\n"
 END
 
 STRINGTABLE

--- a/base/applications/network/netstat/netstat.h
+++ b/base/applications/network/netstat/netstat.h
@@ -1,3 +1,4 @@
+#pragma once
 
 /* Maximum string lengths for ASCII ip address and port names */
 #define HOSTNAMELEN     256
@@ -10,10 +11,10 @@ BOOL bDoShowAllCons    = FALSE; // -a
 BOOL bDoShowProcName   = FALSE; // -b
 BOOL bDoShowEthStats   = FALSE; // -e
 BOOL bDoShowNumbers    = FALSE; // -n
+BOOL bDoShowProcessId  = FALSE; // -o
 BOOL bDoShowProtoCons  = FALSE; // -p
 BOOL bDoShowRouteTable = FALSE; // -r
 BOOL bDoShowProtoStats = FALSE; // -s
-BOOL bDoShowProcessId  = FALSE; // -o
 BOOL bDoDispSeqComp    = FALSE; // -v
 BOOL bLoopOutput       = FALSE; // interval
 


### PR DESCRIPTION

- add a pragma once into the header
- order -o option alphabetically also for the global variables, not only in usage-help
- pl-PL.rc: fix wrong alignment between IDS_ETHERNET_THEADER and its data
- pl-PL.rc: also don't pad the data with 2 spaces here in the beginning, which we don't do in any other locale, and MS netstat also doesn't do that here. pl-PL.rc most likely got this wrong because it was created while en-US wasn't finished yet.

here is a pic of the **fixed** polish, or let's better say: 'polished' state:
![netstat_polish_after](https://github.com/reactos/reactos/assets/33393466/f86d5c55-2d41-4f6d-8e42-0622859e9fcc)
