### PR TITLE
[ATL] CImage: Respect CODEC info

### DIFF
--- a/sdk/lib/atl/atlimage.h
+++ b/sdk/lib/atl/atlimage.h
@@ -558,7 +558,7 @@ public:
         CLSID clsid;
         if (::IsEqualGUID(guidFileType, GUID_NULL))
         {
-            CString strExt = GetFileExtension(pszNameW);
+            CString strExt(GetFileExtension(pszNameW));
             clsid = FindCodecForExtension(strExt, pEncoders, cEncoders);
         }
         else
@@ -786,7 +786,7 @@ protected:
             if (ShouldExcludeFormat(pCodecs[i].FormatID, dwExclude))
                 continue;
 
-            CString extensions = pCodecs[i].FilenameExtension;
+            CString extensions(pCodecs[i].FilenameExtension);
             extensions.MakeLower();
 
             CString desc(pCodecs[i].FormatDescription);
@@ -1028,11 +1028,11 @@ protected:
     {
         for (UINT i = 0; i < nCodecs; ++i)
         {
-            CString strSpecs = pCodecs[i].FilenameExtension;
+            CString strSpecs(pCodecs[i].FilenameExtension);
             int i0 = 0, i1;
             for (;;)
             {
-                i1 = strSpecs.Find(L';', i0);
+                i1 = strSpecs.Find(TEXT(';'), i0);
 
                 CString strSpec;
                 if (i1 < 0)
@@ -1064,11 +1064,11 @@ protected:
 
         for (UINT i = 0; i < cEncoders; ++i)
         {
-            CString strSpecs = pEncoders[i].FilenameExtension;
+            CString strSpecs(pEncoders[i].FilenameExtension);
             int i0 = 0, i1;
             for (;;)
             {
-                i1 = strSpecs.Find(L';', i0);
+                i1 = strSpecs.Find(TEXT(';'), i0);
 
                 CString strSpec;
                 if (i1 < 0)

--- a/sdk/lib/atl/atlimage.h
+++ b/sdk/lib/atl/atlimage.h
@@ -1029,16 +1029,16 @@ protected:
         for (UINT i = 0; i < nCodecs; ++i)
         {
             CString strSpecs(pCodecs[i].FilenameExtension);
-            int i0 = 0, i1;
+            int ichOld = 0, ichSep;
             for (;;)
             {
-                i1 = strSpecs.Find(TEXT(';'), i0);
+                ichSep = strSpecs.Find(TEXT(';'), ichOld);
 
                 CString strSpec;
-                if (i1 < 0)
-                    strSpec = strSpecs.Mid(i0);
+                if (ichSep < 0)
+                    strSpec = strSpecs.Mid(ichOld);
                 else
-                    strSpec = strSpecs.Mid(i0, i1 - i0);
+                    strSpec = strSpecs.Mid(ichOld, ichSep - ichOld);
 
                 int ichDot = strSpec.ReverseFind(TEXT('.'));
                 if (ichDot >= 0)
@@ -1047,10 +1047,10 @@ protected:
                 if (!dotext || strSpec.CompareNoCase(dotext) == 0)
                     return pCodecs[i].Clsid;
 
-                if (i1 < 0)
+                if (ichSep < 0)
                     break;
 
-                i0 = i1 + 1;
+                ichOld = ichSep + 1;
             }
         }
         return CLSID_NULL;
@@ -1065,16 +1065,16 @@ protected:
         for (UINT i = 0; i < cEncoders; ++i)
         {
             CString strSpecs(pEncoders[i].FilenameExtension);
-            int i0 = 0, i1;
+            int ichOld = 0, ichSep;
             for (;;)
             {
-                i1 = strSpecs.Find(TEXT(';'), i0);
+                ichSep = strSpecs.Find(TEXT(';'), ichOld);
 
                 CString strSpec;
-                if (i1 < 0)
-                    strSpec = strSpecs.Mid(i0);
+                if (ichSep < 0)
+                    strSpec = strSpecs.Mid(ichOld);
                 else
-                    strSpec = strSpecs.Mid(i0, i1 - i0);
+                    strSpec = strSpecs.Mid(ichOld, ichSep - ichOld);
 
                 int ichDot = strSpec.ReverseFind(TEXT('.'));
                 if (ichDot >= 0)
@@ -1088,10 +1088,10 @@ protected:
                     return &s_guid;
                 }
 
-                if (i1 < 0)
+                if (ichSep < 0)
                     break;
 
-                i0 = i1 + 1;
+                ichOld = ichSep + 1;
             }
         }
 

--- a/sdk/lib/atl/atlimage.h
+++ b/sdk/lib/atl/atlimage.h
@@ -558,8 +558,8 @@ public:
         CLSID clsid;
         if (::IsEqualGUID(guidFileType, GUID_NULL))
         {
-            LPCWSTR pszExt = GetFileExtension(pszNameW);
-            clsid = FindCodecForExtension(pszExt, pEncoders, cEncoders);
+            CString strExt = GetFileExtension(pszNameW);
+            clsid = FindCodecForExtension(strExt, pEncoders, cEncoders);
         }
         else
         {
@@ -572,8 +572,7 @@ public:
         GetCommon().CreateBitmapFromHBITMAP(m_hbm, NULL, &pBitmap);
 
         // save to file
-        Status status;
-        status = GetCommon().SaveImageToFile(pBitmap, pszNameW, &clsid, NULL);
+        Status status = GetCommon().SaveImageToFile(pBitmap, pszNameW, &clsid, NULL);
 
         // destroy GpBitmap
         GetCommon().DisposeImage(pBitmap);
@@ -760,7 +759,8 @@ protected:
                 else
                     extensions += TEXT(';');
 
-                extensions += pCodecs[i].FilenameExtension;
+                CString ext(pCodecs[i].FilenameExtension);
+                extensions += ext;
             }
             extensions.MakeLower();
 
@@ -783,7 +783,8 @@ protected:
             CString extensions = pCodecs[i].FilenameExtension;
             extensions.MakeLower();
 
-            strFilter += pCodecs[i].FormatDescription;
+            CString desc(pCodecs[i].FormatDescription);
+            strFilter += desc;
             strFilter += TEXT(" (");
             strFilter += extensions;
             strFilter += TEXT(")");
@@ -1022,19 +1023,19 @@ protected:
     {
         for (UINT i = 0; i < nCodecs; ++i)
         {
-            CStringW strSpecs = pCodecs[i].FilenameExtension;
+            CString strSpecs = pCodecs[i].FilenameExtension;
             int i0 = 0, i1;
             for (;;)
             {
                 i1 = strSpecs.Find(L';', i0);
 
-                CStringW strSpec;
+                CString strSpec;
                 if (i1 < 0)
                     strSpec = strSpecs.Mid(i0);
                 else
                     strSpec = strSpecs.Mid(i0, i1 - i0);
 
-                int ichDot = strSpec.ReverseFind(L'.');
+                int ichDot = strSpec.ReverseFind(TEXT('.'));
                 if (ichDot >= 0)
                     strSpec = strSpec.Mid(ichDot);
 
@@ -1051,26 +1052,26 @@ protected:
     }
 
     // Deprecated. Don't use this
-    static const GUID *FileTypeFromExtension(LPCWSTR dotext)
+    static const GUID *FileTypeFromExtension(LPCTSTR dotext)
     {
         UINT cEncoders = 0;
         Gdiplus::ImageCodecInfo* pEncoders = _getAllEncoders(cEncoders);
 
         for (UINT i = 0; i < cEncoders; ++i)
         {
-            CStringW strSpecs = pEncoders[i].FilenameExtension;
+            CString strSpecs = pEncoders[i].FilenameExtension;
             int i0 = 0, i1;
             for (;;)
             {
                 i1 = strSpecs.Find(L';', i0);
 
-                CStringW strSpec;
+                CString strSpec;
                 if (i1 < 0)
                     strSpec = strSpecs.Mid(i0);
                 else
                     strSpec = strSpecs.Mid(i0, i1 - i0);
 
-                int ichDot = strSpec.ReverseFind(L'.');
+                int ichDot = strSpec.ReverseFind(TEXT('.'));
                 if (ichDot >= 0)
                     strSpec = strSpec.Mid(ichDot);
 

--- a/sdk/lib/atl/atlimage.h
+++ b/sdk/lib/atl/atlimage.h
@@ -743,6 +743,12 @@ protected:
         DWORD dwExclude,
         TCHAR chSeparator)
     {
+        if (!pCodecs || !cCodecs)
+        {
+            strFilter += chSeparator;
+            return E_FAIL;
+        }
+
         if (pszAllFilesDescription)
         {
             strFilter += pszAllFilesDescription;
@@ -796,7 +802,6 @@ protected:
         }
 
         strFilter += chSeparator;
-
         return S_OK;
     }
 

--- a/sdk/lib/atl/atlimage.h
+++ b/sdk/lib/atl/atlimage.h
@@ -545,8 +545,6 @@ public:
         using namespace Gdiplus;
         ATLASSERT(m_hbm);
 
-        // TODO & FIXME: set parameters (m_rgbTransColor etc.)
-
         // convert the file name string into Unicode
         CStringW pszNameW(pszFileName);
 

--- a/sdk/lib/atl/atlimage.h
+++ b/sdk/lib/atl/atlimage.h
@@ -916,12 +916,12 @@ protected:
 
         // get procedure address of the DLL
         template <typename FUN_T>
-        bool _getFUN(FUN_T& fun, const char *name)
+        FUN_T _getFUN(FUN_T& fun, const char *name)
         {
             if (fun)
-                return true;
+                return fun;
             fun = reinterpret_cast<FUN_T>(::GetProcAddress(hinstGdiPlus, name));
-            return fun != NULL;
+            return fun;
         }
 
         HINSTANCE LoadLib()

--- a/sdk/lib/atl/atlimage.h
+++ b/sdk/lib/atl/atlimage.h
@@ -523,7 +523,7 @@ public:
 
         // Get Codec
         CLSID clsid = FindCodecForFileType(*guidFileType, pEncoders, cEncoders);
-        _free_mem(pEncoders);
+        delete[] pEncoders;
 
         // create a GpBitmap from HBITMAP
         GpBitmap *pBitmap = NULL;
@@ -565,7 +565,7 @@ public:
         {
             clsid = FindCodecForFileType(guidFileType, pEncoders, cEncoders);
         }
-        _free_mem(pEncoders);
+        delete[] pEncoders;
 
         // create a GpBitmap from HBITMAP
         GpBitmap *pBitmap = NULL;
@@ -822,7 +822,7 @@ public:
                                             pszAllFilesDescription,
                                             dwExclude,
                                             chSeparator);
-        _free_mem(pDecoders);
+        delete[] pDecoders;
         return hr;
     }
 
@@ -842,7 +842,7 @@ public:
                                             pszAllFilesDescription,
                                             dwExclude,
                                             chSeparator);
-        _free_mem(pEncoders);
+        delete[] pEncoders;
         return hr;
     }
 
@@ -1084,7 +1084,7 @@ protected:
                 {
                     static GUID s_guid;
                     s_guid = pEncoders[i].FormatID;
-                    _free_mem(pEncoders);
+                    delete[] pEncoders;
                     return &s_guid;
                 }
 
@@ -1095,7 +1095,7 @@ protected:
             }
         }
 
-        _free_mem(pEncoders);
+        delete[] pEncoders;
         return NULL;
     }
 
@@ -1116,7 +1116,7 @@ protected:
         UINT cEncoders = 0;
         Gdiplus::ImageCodecInfo* pEncoders = _getAllEncoders(cEncoders);
         *clsid = FindCodecForFileType(*guid, pEncoders, cEncoders);
-        _free_mem(pEncoders);
+        delete[] pEncoders;
         return true;
     }
 
@@ -1130,7 +1130,7 @@ protected:
             return NULL;  // failure
 
         Gdiplus::ImageCodecInfo *ret;
-        ret = reinterpret_cast<Gdiplus::ImageCodecInfo*>(_alloc_mem(total_size));
+        ret = new Gdiplus::ImageCodecInfo[total_size / sizeof(ret[0])];
         if (ret == NULL)
         {
             cEncoders = 0;
@@ -1138,7 +1138,7 @@ protected:
         }
 
         GetCommon().GetImageEncoders(cEncoders, total_size, ret);
-        return ret; // needs _free_mem()
+        return ret; // needs delete[]
     }
 
     static Gdiplus::ImageCodecInfo* _getAllDecoders(UINT& cDecoders)
@@ -1151,7 +1151,7 @@ protected:
             return NULL;  // failure
 
         Gdiplus::ImageCodecInfo *ret;
-        ret = reinterpret_cast<Gdiplus::ImageCodecInfo*>(_alloc_mem(total_size));
+        ret = new Gdiplus::ImageCodecInfo[total_size / sizeof(ret[0])];
         if (ret == NULL)
         {
             cDecoders = 0;
@@ -1159,7 +1159,7 @@ protected:
         }
 
         GetCommon().GetImageDecoders(cDecoders, total_size, ret);
-        return ret; // needs _free_mem()
+        return ret; // needs delete[]
     }
 
     void AttachInternal(HBITMAP hBitmap, DIBOrientation eOrientation,
@@ -1241,16 +1241,6 @@ protected:
         m_bHasAlphaCh = bHasAlphaCh;
 
         return hbm != NULL;
-    }
-
-    static void *_alloc_mem(size_t size)
-    {
-        return ::HeapAlloc(::GetProcessHeap(), 0, size);
-    }
-
-    static void _free_mem(void *ptr)
-    {
-        ::HeapFree(::GetProcessHeap(), 0, ptr);
     }
 
 private:


### PR DESCRIPTION
## Purpose
Refactor code for compatibility and respect the encoders and decoders info.

JIRA issue: [CORE-18867](https://jira.reactos.org/browse/CORE-18867), [CORE-19008](https://jira.reactos.org/browse/CORE-19008)

## Proposed changes

- Add `_getAllEncoders` and `_getAllDecoders` helper functions and use them in `GetImporterFilterString`, `GetExporterFilterString`, `FileTypeFromExtension` and `GetClsidFromFileType` functions.
- Add `ShouldExcludeFormat`, `FindCodecForFileType`, and `FindCodecForExtension` helper functions for compatibility.

## TODO

- [x] Do tests.