### PR TITLE
[NETSTAT] Less heap allocations

### DIFF
--- a/base/applications/network/netstat/netstat.c
+++ b/base/applications/network/netstat/netstat.c
@@ -6,7 +6,7 @@
  */
 /*
  * TODO:
- * implement -b, -t and -v
+ * implement -b, -t, -v
  * clean up GetIpHostName
  */
 
@@ -58,9 +58,6 @@ VOID DoFormatMessage(DWORD ErrorCode)
                NULL, ErrorCode, LANG_USER_DEFAULT);
 }
 
-/*
- * Display table header
- */
 VOID DisplayTableHeader(VOID)
 {
     ConResPuts(StdOut, IDS_ACTIVE_CONNECT);
@@ -166,9 +163,6 @@ StopParsingAndShowUsageHelp:
     return TRUE;
 }
 
-/*
- * Simulate Microsofts netstat utility output
- */
 BOOL DisplayOutput(VOID)
 {
     if (bNoOptions)
@@ -239,84 +233,76 @@ BOOL DisplayOutput(VOID)
 
 VOID ShowIpStatistics(VOID)
 {
-    PMIB_IPSTATS pIpStats;
+    MIB_IPSTATS IpStats;
     DWORD dwRetVal;
 
-    pIpStats = (MIB_IPSTATS*)HeapAlloc(GetProcessHeap(), 0, sizeof(MIB_IPSTATS));
-
-    if ((dwRetVal = GetIpStatistics(pIpStats)) == NO_ERROR)
+    if ((dwRetVal = GetIpStatistics(&IpStats)) == NO_ERROR)
     {
         ConResPuts(StdOut, IDS_IP4_STAT_HEADER);
-        ConResPrintf(StdOut, IDS_IP_PACK_REC, pIpStats->dwInReceives);
-        ConResPrintf(StdOut, IDS_IP_HEAD_REC_ERROR, pIpStats->dwInHdrErrors);
-        ConResPrintf(StdOut, IDS_IP_ADDR_REC_ERROR, pIpStats->dwInAddrErrors);
-        ConResPrintf(StdOut, IDS_IP_DATAG_FWD, pIpStats->dwForwDatagrams);
-        ConResPrintf(StdOut, IDS_IP_UNKNOWN_PRO_REC, pIpStats->dwInUnknownProtos);
-        ConResPrintf(StdOut, IDS_IP_REC_PACK_DISCARD, pIpStats->dwInDiscards);
-        ConResPrintf(StdOut, IDS_IP_REC_PACK_DELIVER, pIpStats->dwInDelivers);
-        ConResPrintf(StdOut, IDS_IP_OUT_REQUEST, pIpStats->dwOutRequests);
-        ConResPrintf(StdOut, IDS_IP_ROUTE_DISCARD, pIpStats->dwRoutingDiscards);
-        ConResPrintf(StdOut, IDS_IP_DISCARD_OUT_PACK, pIpStats->dwOutDiscards);
-        ConResPrintf(StdOut, IDS_IP_OUT_PACKET_NO_ROUTE, pIpStats->dwOutNoRoutes);
-        ConResPrintf(StdOut, IDS_IP_REASSEMBLE_REQUIRED, pIpStats->dwReasmReqds);
-        ConResPrintf(StdOut, IDS_IP_REASSEMBLE_SUCCESS, pIpStats->dwReasmOks);
-        ConResPrintf(StdOut, IDS_IP_REASSEMBLE_FAILURE, pIpStats->dwReasmFails);
-        ConResPrintf(StdOut, IDS_IP_DATAG_FRAG_SUCCESS, pIpStats->dwFragOks);
-        ConResPrintf(StdOut, IDS_IP_DATAG_FRAG_FAILURE, pIpStats->dwFragFails);
-        ConResPrintf(StdOut, IDS_IP_DATAG_FRAG_CREATE, pIpStats->dwFragCreates);
+        ConResPrintf(StdOut, IDS_IP_PACK_REC, IpStats.dwInReceives);
+        ConResPrintf(StdOut, IDS_IP_HEAD_REC_ERROR, IpStats.dwInHdrErrors);
+        ConResPrintf(StdOut, IDS_IP_ADDR_REC_ERROR, IpStats.dwInAddrErrors);
+        ConResPrintf(StdOut, IDS_IP_DATAG_FWD, IpStats.dwForwDatagrams);
+        ConResPrintf(StdOut, IDS_IP_UNKNOWN_PRO_REC, IpStats.dwInUnknownProtos);
+        ConResPrintf(StdOut, IDS_IP_REC_PACK_DISCARD, IpStats.dwInDiscards);
+        ConResPrintf(StdOut, IDS_IP_REC_PACK_DELIVER, IpStats.dwInDelivers);
+        ConResPrintf(StdOut, IDS_IP_OUT_REQUEST, IpStats.dwOutRequests);
+        ConResPrintf(StdOut, IDS_IP_ROUTE_DISCARD, IpStats.dwRoutingDiscards);
+        ConResPrintf(StdOut, IDS_IP_DISCARD_OUT_PACK, IpStats.dwOutDiscards);
+        ConResPrintf(StdOut, IDS_IP_OUT_PACKET_NO_ROUTE, IpStats.dwOutNoRoutes);
+        ConResPrintf(StdOut, IDS_IP_REASSEMBLE_REQUIRED, IpStats.dwReasmReqds);
+        ConResPrintf(StdOut, IDS_IP_REASSEMBLE_SUCCESS, IpStats.dwReasmOks);
+        ConResPrintf(StdOut, IDS_IP_REASSEMBLE_FAILURE, IpStats.dwReasmFails);
+        ConResPrintf(StdOut, IDS_IP_DATAG_FRAG_SUCCESS, IpStats.dwFragOks);
+        ConResPrintf(StdOut, IDS_IP_DATAG_FRAG_FAILURE, IpStats.dwFragFails);
+        ConResPrintf(StdOut, IDS_IP_DATAG_FRAG_CREATE, IpStats.dwFragCreates);
     }
     else
     {
         DoFormatMessage(dwRetVal);
     }
-
-    HeapFree(GetProcessHeap(), 0, pIpStats);
 }
 
 VOID ShowIcmpStatistics(VOID)
 {
-    PMIB_ICMP pIcmpStats;
+    MIB_ICMP IcmpStats;
     DWORD dwRetVal;
 
-    pIcmpStats = (MIB_ICMP*)HeapAlloc(GetProcessHeap(), 0, sizeof(MIB_ICMP));
-
-    if ((dwRetVal = GetIcmpStatistics(pIcmpStats)) == NO_ERROR)
+    if ((dwRetVal = GetIcmpStatistics(&IcmpStats)) == NO_ERROR)
     {
         ConResPuts(StdOut, IDS_ICMP4_STAT_HEADER);
         ConResPuts(StdOut, IDS_ICMP_THEADER);
         ConResPrintf(StdOut, IDS_ICMP_MSG,
-            pIcmpStats->stats.icmpInStats.dwMsgs, pIcmpStats->stats.icmpOutStats.dwMsgs);
+            IcmpStats.stats.icmpInStats.dwMsgs, IcmpStats.stats.icmpOutStats.dwMsgs);
         ConResPrintf(StdOut, IDS_ICMP_ERROR,
-            pIcmpStats->stats.icmpInStats.dwErrors, pIcmpStats->stats.icmpOutStats.dwErrors);
+            IcmpStats.stats.icmpInStats.dwErrors, IcmpStats.stats.icmpOutStats.dwErrors);
         ConResPrintf(StdOut, IDS_ICMP_DEST_UNREACH,
-            pIcmpStats->stats.icmpInStats.dwDestUnreachs, pIcmpStats->stats.icmpOutStats.dwDestUnreachs);
+            IcmpStats.stats.icmpInStats.dwDestUnreachs, IcmpStats.stats.icmpOutStats.dwDestUnreachs);
         ConResPrintf(StdOut, IDS_ICMP_TIME_EXCEED,
-            pIcmpStats->stats.icmpInStats.dwTimeExcds, pIcmpStats->stats.icmpOutStats.dwTimeExcds);
+            IcmpStats.stats.icmpInStats.dwTimeExcds, IcmpStats.stats.icmpOutStats.dwTimeExcds);
         ConResPrintf(StdOut, IDS_ICMP_PARAM_PROBLEM,
-            pIcmpStats->stats.icmpInStats.dwParmProbs, pIcmpStats->stats.icmpOutStats.dwParmProbs);
+            IcmpStats.stats.icmpInStats.dwParmProbs, IcmpStats.stats.icmpOutStats.dwParmProbs);
         ConResPrintf(StdOut, IDS_ICMP_SRC_QUENCHES,
-            pIcmpStats->stats.icmpInStats.dwSrcQuenchs, pIcmpStats->stats.icmpOutStats.dwSrcQuenchs);
+            IcmpStats.stats.icmpInStats.dwSrcQuenchs, IcmpStats.stats.icmpOutStats.dwSrcQuenchs);
         ConResPrintf(StdOut, IDS_ICMP_REDIRECT,
-            pIcmpStats->stats.icmpInStats.dwRedirects, pIcmpStats->stats.icmpOutStats.dwRedirects);
+            IcmpStats.stats.icmpInStats.dwRedirects, IcmpStats.stats.icmpOutStats.dwRedirects);
         ConResPrintf(StdOut, IDS_ICMP_ECHO,
-            pIcmpStats->stats.icmpInStats.dwEchos, pIcmpStats->stats.icmpOutStats.dwEchos);
+            IcmpStats.stats.icmpInStats.dwEchos, IcmpStats.stats.icmpOutStats.dwEchos);
         ConResPrintf(StdOut, IDS_ICMP_ECHO_REPLY,
-            pIcmpStats->stats.icmpInStats.dwEchoReps, pIcmpStats->stats.icmpOutStats.dwEchoReps);
+            IcmpStats.stats.icmpInStats.dwEchoReps, IcmpStats.stats.icmpOutStats.dwEchoReps);
         ConResPrintf(StdOut, IDS_ICMP_TIMESTAMP,
-            pIcmpStats->stats.icmpInStats.dwTimestamps, pIcmpStats->stats.icmpOutStats.dwTimestamps);
+            IcmpStats.stats.icmpInStats.dwTimestamps, IcmpStats.stats.icmpOutStats.dwTimestamps);
         ConResPrintf(StdOut, IDS_ICMP_TIMESTAMP_REPLY,
-            pIcmpStats->stats.icmpInStats.dwTimestampReps, pIcmpStats->stats.icmpOutStats.dwTimestampReps);
+            IcmpStats.stats.icmpInStats.dwTimestampReps, IcmpStats.stats.icmpOutStats.dwTimestampReps);
         ConResPrintf(StdOut, IDS_ICMP_ADDRESSS_MASK,
-            pIcmpStats->stats.icmpInStats.dwAddrMasks, pIcmpStats->stats.icmpOutStats.dwAddrMasks);
+            IcmpStats.stats.icmpInStats.dwAddrMasks, IcmpStats.stats.icmpOutStats.dwAddrMasks);
         ConResPrintf(StdOut, IDS_ICMP_ADDRESSS_MASK_REPLY,
-            pIcmpStats->stats.icmpInStats.dwAddrMaskReps, pIcmpStats->stats.icmpOutStats.dwAddrMaskReps);
+            IcmpStats.stats.icmpInStats.dwAddrMaskReps, IcmpStats.stats.icmpOutStats.dwAddrMaskReps);
     }
     else
     {
         DoFormatMessage(dwRetVal);
     }
-
-    HeapFree(GetProcessHeap(), 0, pIcmpStats);
 }
 
 VOID ShowTcpStatistics(VOID)


### PR DESCRIPTION

- Avoid the heap in ShowIpStatistics() and ShowIcmpStatistics() to simplify the code, inspired by how we do it in ShowTcpStatistics() and ShowUdpStatistics() already
- Strip 2 Captain-Obvious-Comments

For the record: Retrieving ICMP-stats and IP-stats does not work properly in ReactOS yet, neither with nor without my changes. Lower layers are most likely wrong still somehow. But netstat itself can properly obtain ICMP-stats and IP-stats in Windows already.
