### PR TITLE
[ZIPFLDR] Support UTF-8 Zip extraction

### DIFF
--- a/dll/shellext/zipfldr/CConfirmReplace.cpp
+++ b/dll/shellext/zipfldr/CConfirmReplace.cpp
@@ -3,6 +3,7 @@
  * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
  * PURPOSE:     Ask the user to replace a file
  * COPYRIGHT:   Copyright 2017-2019 Mark Jansen (mark.jansen@reactos.org)
+ *              Copyright 2023 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
  */
 
 #include "precomp.h"

--- a/dll/shellext/zipfldr/CConfirmReplace.cpp
+++ b/dll/shellext/zipfldr/CConfirmReplace.cpp
@@ -13,7 +13,7 @@ class CConfirmReplace : public CDialogImpl<CConfirmReplace>
 private:
     CStringW m_Filename;
 public:
-    CConfirmReplace(LPCWSTR filename)
+    CConfirmReplace(PCWSTR filename)
         : m_Filename(filename)
     {
     }
@@ -50,7 +50,7 @@ public:
     END_MSG_MAP()
 };
 
-eZipConfirmResponse _CZipAskReplace(HWND hDlg, LPCWSTR FullPath)
+eZipConfirmResponse _CZipAskReplace(HWND hDlg, PCWSTR FullPath)
 {
     PCWSTR Filename = PathFindFileNameW(FullPath);
     CConfirmReplace confirm(Filename);

--- a/dll/shellext/zipfldr/CConfirmReplace.cpp
+++ b/dll/shellext/zipfldr/CConfirmReplace.cpp
@@ -10,10 +10,9 @@
 class CConfirmReplace : public CDialogImpl<CConfirmReplace>
 {
 private:
-    CStringA m_Filename;
+    CStringW m_Filename;
 public:
-
-    CConfirmReplace(const char* filename)
+    CConfirmReplace(LPCWSTR filename)
         : m_Filename(filename)
     {
     }
@@ -25,9 +24,9 @@ public:
         HICON hIcon = LoadIcon(NULL, IDI_EXCLAMATION);
         SendDlgItemMessage(IDC_EXCLAMATION_ICON, STM_SETICON, (WPARAM)hIcon);
 
-        CStringA message;
+        CStringW message;
         message.FormatMessage(IDS_OVERWRITEFILE_TEXT, m_Filename.GetString());
-        ::SetDlgItemTextA(m_hWnd, IDC_MESSAGE, message);
+        ::SetDlgItemTextW(m_hWnd, IDC_MESSAGE, message);
 
         return TRUE;
     }
@@ -50,10 +49,9 @@ public:
     END_MSG_MAP()
 };
 
-
-eZipConfirmResponse _CZipAskReplace(HWND hDlg, PCSTR FullPath)
+eZipConfirmResponse _CZipAskReplaceW(HWND hDlg, LPCWSTR FullPath)
 {
-    PCSTR Filename = PathFindFileNameA(FullPath);
+    PCWSTR Filename = PathFindFileNameW(FullPath);
     CConfirmReplace confirm(Filename);
     INT_PTR Result = confirm.DoModal(hDlg);
     switch (Result)

--- a/dll/shellext/zipfldr/CConfirmReplace.cpp
+++ b/dll/shellext/zipfldr/CConfirmReplace.cpp
@@ -49,7 +49,7 @@ public:
     END_MSG_MAP()
 };
 
-eZipConfirmResponse _CZipAskReplaceW(HWND hDlg, LPCWSTR FullPath)
+eZipConfirmResponse _CZipAskReplace(HWND hDlg, LPCWSTR FullPath)
 {
     PCWSTR Filename = PathFindFileNameW(FullPath);
     CConfirmReplace confirm(Filename);

--- a/dll/shellext/zipfldr/CEnumZipContents.cpp
+++ b/dll/shellext/zipfldr/CEnumZipContents.cpp
@@ -14,14 +14,14 @@ class CEnumZipContents :
 private:
     CZipEnumerator mEnumerator;
     DWORD dwFlags;
-    CStringA m_Prefix;
+    CStringW m_Prefix;
 public:
     CEnumZipContents()
         :dwFlags(0)
     {
     }
 
-    STDMETHODIMP Initialize(IZip* zip, DWORD flags, const char* prefix)
+    STDMETHODIMP Initialize(IZip* zip, DWORD flags, LPCWSTR prefix)
     {
         dwFlags = flags;
         m_Prefix = prefix;
@@ -41,7 +41,7 @@ public:
         if (celt != 1)
             return E_FAIL;
 
-        CStringA name;
+        CStringW name;
         bool dir;
         unz_file_info64 info;
         if (mEnumerator.next_unique(m_Prefix, name, dir, info))
@@ -55,7 +55,7 @@ public:
     }
     STDMETHODIMP Skip(ULONG celt)
     {
-        CStringA name;
+        CStringW name;
         bool dir;
         unz_file_info64 info;
         while (celt--)
@@ -88,7 +88,7 @@ public:
 };
 
 
-HRESULT _CEnumZipContents_CreateInstance(IZip* zip, DWORD flags, const char* prefix, REFIID riid, LPVOID * ppvOut)
+HRESULT _CEnumZipContents_CreateInstance(IZip* zip, DWORD flags, LPCWSTR prefix, REFIID riid, LPVOID * ppvOut)
 {
     return ShellObjectCreatorInit<CEnumZipContents>(zip, flags, prefix, riid, ppvOut);
 }

--- a/dll/shellext/zipfldr/CEnumZipContents.cpp
+++ b/dll/shellext/zipfldr/CEnumZipContents.cpp
@@ -22,7 +22,7 @@ public:
     {
     }
 
-    STDMETHODIMP Initialize(IZip* zip, DWORD flags, LPCWSTR prefix)
+    STDMETHODIMP Initialize(IZip* zip, DWORD flags, PCWSTR prefix)
     {
         dwFlags = flags;
         m_Prefix = prefix;
@@ -89,7 +89,7 @@ public:
 };
 
 
-HRESULT _CEnumZipContents_CreateInstance(IZip* zip, DWORD flags, LPCWSTR prefix, REFIID riid, LPVOID * ppvOut)
+HRESULT _CEnumZipContents_CreateInstance(IZip* zip, DWORD flags, PCWSTR prefix, REFIID riid, LPVOID * ppvOut)
 {
     return ShellObjectCreatorInit<CEnumZipContents>(zip, flags, prefix, riid, ppvOut);
 }

--- a/dll/shellext/zipfldr/CEnumZipContents.cpp
+++ b/dll/shellext/zipfldr/CEnumZipContents.cpp
@@ -3,6 +3,7 @@
  * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
  * PURPOSE:     CEnumZipContents
  * COPYRIGHT:   Copyright 2017 Mark Jansen (mark.jansen@reactos.org)
+ *              Copyright 2023 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
  */
 
 #include "precomp.h"

--- a/dll/shellext/zipfldr/CExplorerCommand.cpp
+++ b/dll/shellext/zipfldr/CExplorerCommand.cpp
@@ -23,17 +23,17 @@ public:
     }
 
     // *** IExplorerCommand methods ***
-    STDMETHODIMP GetTitle(IShellItemArray *psiItemArray, LPWSTR *ppszName)
+    STDMETHODIMP GetTitle(IShellItemArray *psiItemArray, PWSTR *ppszName)
     {
         CStringW Title(MAKEINTRESOURCEW(IDS_MENUITEM));
         return SHStrDup(Title, ppszName);
     }
-    STDMETHODIMP GetIcon(IShellItemArray *psiItemArray, LPWSTR *ppszIcon)
+    STDMETHODIMP GetIcon(IShellItemArray *psiItemArray, PWSTR *ppszIcon)
     {
         CStringW IconName = L"zipfldr.dll,-1";
         return SHStrDup(IconName, ppszIcon);
     }
-    STDMETHODIMP GetToolTip(IShellItemArray *psiItemArray, LPWSTR *ppszInfotip)
+    STDMETHODIMP GetToolTip(IShellItemArray *psiItemArray, PWSTR *ppszInfotip)
     {
         CStringW HelpText(MAKEINTRESOURCEW(IDS_HELPTEXT));
         return SHStrDup(HelpText, ppszInfotip);

--- a/dll/shellext/zipfldr/CZipCreator.cpp
+++ b/dll/shellext/zipfldr/CZipCreator.cpp
@@ -12,7 +12,7 @@
 #include "minizip/iowin32.h"
 #include <process.h>
 
-static CStringW DoGetZipName(LPCWSTR filename)
+static CStringW DoGetZipName(PCWSTR filename)
 {
     WCHAR szPath[MAX_PATH];
     StringCbCopyW(szPath, sizeof(szPath), filename);
@@ -34,14 +34,14 @@ static CStringW DoGetZipName(LPCWSTR filename)
     return ret;
 }
 
-static CStringA DoGetAnsiName(LPCWSTR filename)
+static CStringA DoGetAnsiName(PCWSTR filename)
 {
     CHAR buf[MAX_PATH];
     WideCharToMultiByte(CP_ACP, 0, filename, -1, buf, _countof(buf), NULL, NULL);
     return buf;
 }
 
-static CStringW DoGetBaseName(LPCWSTR filename)
+static CStringW DoGetBaseName(PCWSTR filename)
 {
     WCHAR szBaseName[MAX_PATH];
     StringCbCopyW(szBaseName, sizeof(szBaseName), filename);
@@ -69,7 +69,7 @@ DoGetNameInZip(const CStringW& basename, const CStringW& filename)
 }
 
 static BOOL
-DoReadAllOfFile(LPCWSTR filename, CSimpleArray<BYTE>& contents,
+DoReadAllOfFile(PCWSTR filename, CSimpleArray<BYTE>& contents,
                 zip_fileinfo *pzi)
 {
     contents.RemoveAll();
@@ -124,7 +124,7 @@ DoReadAllOfFile(LPCWSTR filename, CSimpleArray<BYTE>& contents,
 }
 
 static void
-DoAddFilesFromItem(CSimpleArray<CStringW>& files, LPCWSTR item)
+DoAddFilesFromItem(CSimpleArray<CStringW>& files, PCWSTR item)
 {
     if (!PathIsDirectoryW(item))
     {
@@ -208,7 +208,7 @@ BOOL CZipCreator::runThread(CZipCreator *pCreator)
     return FALSE;
 }
 
-void CZipCreator::DoAddItem(LPCWSTR pszFile)
+void CZipCreator::DoAddItem(PCWSTR pszFile)
 {
     // canonicalize path
     WCHAR szPath[MAX_PATH];
@@ -247,7 +247,7 @@ unsigned CZipCreatorImpl::JustDoIt()
 
         CStringW strTitle(MAKEINTRESOURCEW(IDS_ERRORTITLE));
         CStringW strText;
-        strText.Format(IDS_NOFILES, static_cast<LPCWSTR>(m_items[0]));
+        strText.Format(IDS_NOFILES, static_cast<PCWSTR>(m_items[0]));
         MessageBoxW(NULL, strText, strTitle, MB_ICONERROR);
 
         return CZCERR_NOFILES;
@@ -266,7 +266,7 @@ unsigned CZipCreatorImpl::JustDoIt()
 
         CStringW strTitle(MAKEINTRESOURCEW(IDS_ERRORTITLE));
         CStringW strText;
-        strText.Format(IDS_CANTCREATEZIP, static_cast<LPCWSTR>(strZipName), err);
+        strText.Format(IDS_CANTCREATEZIP, static_cast<PCWSTR>(strZipName), err);
         MessageBoxW(NULL, strText, strTitle, MB_ICONERROR);
 
         return err;
@@ -347,9 +347,9 @@ unsigned CZipCreatorImpl::JustDoIt()
 
         CStringW strText;
         if (err < 0)
-            strText.Format(IDS_CANTCREATEZIP, static_cast<LPCWSTR>(strZipName), err);
+            strText.Format(IDS_CANTCREATEZIP, static_cast<PCWSTR>(strZipName), err);
         else
-            strText.Format(IDS_CANTREADFILE, static_cast<LPCWSTR>(strTarget));
+            strText.Format(IDS_CANTREADFILE, static_cast<PCWSTR>(strTarget));
 
         MessageBoxW(NULL, strText, strTitle, MB_ICONERROR);
     }

--- a/dll/shellext/zipfldr/CZipCreator.hpp
+++ b/dll/shellext/zipfldr/CZipCreator.hpp
@@ -22,7 +22,7 @@ public:
         return new CZipCreator();
     }
 
-    virtual void DoAddItem(LPCWSTR pszFile);
+    virtual void DoAddItem(PCWSTR pszFile);
     static BOOL runThread(CZipCreator* pCreator);
 
 protected:

--- a/dll/shellext/zipfldr/CZipEnumerator.hpp
+++ b/dll/shellext/zipfldr/CZipEnumerator.hpp
@@ -3,6 +3,7 @@
  * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
  * PURPOSE:     CZipEnumerator
  * COPYRIGHT:   Copyright 2017 Mark Jansen (mark.jansen@reactos.org)
+ *              Copyright 2023 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
  */
 
 struct CZipEnumerator

--- a/dll/shellext/zipfldr/CZipEnumerator.hpp
+++ b/dll/shellext/zipfldr/CZipEnumerator.hpp
@@ -93,7 +93,7 @@ public:
             if (info.flag & MINIZIP_UTF8_FLAG)
                 Utf8ToWide(nameA, name);
             else
-                AnsiToWide(nameA, name);
+                name = CStringW(nameA);
         }
         return err == UNZ_OK;
     }

--- a/dll/shellext/zipfldr/CZipEnumerator.hpp
+++ b/dll/shellext/zipfldr/CZipEnumerator.hpp
@@ -90,12 +90,10 @@ public:
             nameA.ReleaseBuffer(info.size_filename);
             nameA.Replace('\\', '/');
 
-            WCHAR wide_name[MAX_PATH];
             if (info.flag & MINIZIP_UTF8_FLAG)
-                MultiByteToWideChar(CP_UTF8, 0, nameA, -1, wide_name, _countof(wide_name));
+                Utf8ToWide(nameA, name);
             else
-                MultiByteToWideChar(CP_ACP, 0, nameA, -1, wide_name, _countof(wide_name));
-            name = wide_name;
+                AnsiToWide(nameA, name);
         }
         return err == UNZ_OK;
     }

--- a/dll/shellext/zipfldr/CZipEnumerator.hpp
+++ b/dll/shellext/zipfldr/CZipEnumerator.hpp
@@ -34,7 +34,7 @@ public:
         return true;
     }
 
-    bool next_unique(LPCWSTR prefix, CStringW& name, bool& folder, unz_file_info64& info)
+    bool next_unique(PCWSTR prefix, CStringW& name, bool& folder, unz_file_info64& info)
     {
         size_t len = wcslen(prefix);
         CStringW tmp;

--- a/dll/shellext/zipfldr/CZipEnumerator.hpp
+++ b/dll/shellext/zipfldr/CZipEnumerator.hpp
@@ -36,29 +36,29 @@ public:
     bool next_unique(LPCWSTR prefix, CStringW& name, bool& folder, unz_file_info64& info)
     {
         size_t len = wcslen(prefix);
-        CStringW tmpW;
-        while (next(tmpW, info))
+        CStringW tmp;
+        while (next(tmp, info))
         {
-            if (!_wcsnicmp(tmpW, prefix, len))
+            if (!_wcsnicmp(tmp, prefix, len))
             {
-                int pos = tmpW.Find(L'/', len);
+                int pos = tmp.Find(L'/', len);
                 if (pos < 0)
                 {
-                    name = tmpW.Mid(len);
+                    name = tmp.Mid(len);
                     folder = false;
                 }
                 else
                 {
-                    name = tmpW.Mid(len, pos - len);
+                    name = tmp.Mid(len, pos - len);
                     folder = true;
                 }
-                tmpW = name;
-                tmpW.MakeLower();
+                tmp = name;
+                tmp.MakeLower();
 
-                POSITION it = m_Returned.Find(tmpW);
+                POSITION it = m_Returned.Find(tmp);
                 if (!name.IsEmpty() && !it)
                 {
-                    m_Returned.AddTail(tmpW);
+                    m_Returned.AddTail(tmp);
                     return true;
                 }
             }

--- a/dll/shellext/zipfldr/CZipExtract.cpp
+++ b/dll/shellext/zipfldr/CZipExtract.cpp
@@ -257,7 +257,7 @@ public:
         LRESULT OnPassword(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL& bHandled)
         {
             CStringA Password;
-            if (_CZipAskPasswordW(m_hWnd, NULL, Password) == eAccept)
+            if (_CZipAskPassword(m_hWnd, NULL, Password) == eAccept)
             {
                 *m_pPassword = Password;
             }
@@ -415,7 +415,7 @@ public:
                         }
                     }
                 }
-                Response = _CZipAskPasswordW(hDlg, Name, Password);
+                Response = _CZipAskPassword(hDlg, Name, Password);
             } while (Response == eAccept);
 
             if (Response == eSkip)
@@ -439,8 +439,7 @@ public:
             return eOpenError;
         }
 
-        HANDLE hFile;
-        hFile = CreateFileW(FullPath, GENERIC_WRITE, 0, NULL, CREATE_NEW, FILE_ATTRIBUTE_NORMAL, NULL);
+        HANDLE hFile = CreateFileW(FullPath, GENERIC_WRITE, 0, NULL, CREATE_NEW, FILE_ATTRIBUTE_NORMAL, NULL);
         if (hFile == INVALID_HANDLE_VALUE)
         {
             DWORD dwErr = GetLastError();
@@ -450,7 +449,7 @@ public:
                 if (!*bOverwriteAll)
                 {
                     eZipConfirmResponse Result;
-                    Result = _CZipAskReplaceW(hDlg, FullPath);
+                    Result = _CZipAskReplace(hDlg, FullPath);
                     switch (Result)
                     {
                     case eYesToAll:

--- a/dll/shellext/zipfldr/CZipExtract.cpp
+++ b/dll/shellext/zipfldr/CZipExtract.cpp
@@ -592,10 +592,19 @@ public:
 
             bool is_dir = Name.GetLength() > 0 && Name[Name.GetLength()-1] == '/';
 
-            WCHAR CombinedPath[MAX_PATH * 2] = { 0 };
-            PathCombineW(CombinedPath, BaseDirectory, Name);
-            CStringW FullPath = CombinedPath;
-            FullPath.Replace(L'/', L'\\');    /* SHPathPrepareForWrite does not handle '/' */
+            // Get combined path
+            CStringW CombinedPath = BaseDirectory;
+            if (CombinedPath.GetLength() == 0 || CombinedPath[CombinedPath.GetLength() - 1] != L'\\')
+                CombinedPath += L'\\';
+            CombinedPath += Name;
+
+            // Get full path
+            CStringW FullPath;
+            DWORD cchFullPath = ::GetFullPathName(CombinedPath, 0, NULL, NULL);
+            ::GetFullPathName(CombinedPath, cchFullPath, FullPath.GetBuffer(cchFullPath), NULL);
+            FullPath.ReleaseBuffer();
+
+            FullPath.Replace(L'/', L'\\'); // SHPathPrepareForWrite does not handle '/'
         Retry:
             eZipExtractError Result = ExtractSingle(hDlg, FullPath, is_dir, &Info, Name, Password, &bOverwriteAll, bCancel, &err);
             if (Result != eDirectoryError)

--- a/dll/shellext/zipfldr/CZipExtract.cpp
+++ b/dll/shellext/zipfldr/CZipExtract.cpp
@@ -597,7 +597,9 @@ public:
             CPathW FullPath(BaseDirectory);
             FullPath += Name;
 
-            // SHPathPrepareForWrite does not handle '/', even on MS Windows
+            // We use SHPathPrepareForWrite for this path.
+            // SHPathPrepareForWrite will prepare the necessary directories.
+            // Windows and ReactOS SHPathPrepareForWrite do not support '/'.
             FullPath.m_strPath.Replace(L'/', L'\\');
 
         Retry:

--- a/dll/shellext/zipfldr/CZipExtract.cpp
+++ b/dll/shellext/zipfldr/CZipExtract.cpp
@@ -595,7 +595,7 @@ public:
 
             // Build a combined path
             CPathW CombinedPath = BaseDirectory;
-            BaseDirectory += Name;
+            CombinedPath += Name;
 
             // SHPathPrepareForWrite does not handle '/', even on MS Windows
             CombinedPath.m_strPath.Replace(L'/', L'\\');

--- a/dll/shellext/zipfldr/CZipExtract.cpp
+++ b/dll/shellext/zipfldr/CZipExtract.cpp
@@ -594,12 +594,11 @@ public:
             bool is_dir = Name.GetLength() > 0 && Name[Name.GetLength()-1] == '/';
 
             // Build a combined path
-            CPathW CombinedPath;
-            CombinedPath.Combine(BaseDirectory, Name);
+            CPathW CombinedPath = BaseDirectory;
+            BaseDirectory += Name;
 
             // SHPathPrepareForWrite does not handle '/', even on MS Windows
-            CStringW& FullPath = CombinedPath.m_strPath;
-            FullPath.Replace(L'/', L'\\');
+            CombinedPath.m_strPath.Replace(L'/', L'\\');
 
         Retry:
             eZipExtractError Result = ExtractSingle(hDlg, FullPath, is_dir, &Info, Name, Password, &bOverwriteAll, bCancel, &err);

--- a/dll/shellext/zipfldr/CZipExtract.cpp
+++ b/dll/shellext/zipfldr/CZipExtract.cpp
@@ -448,8 +448,7 @@ public:
                 bool bOverwrite = *bOverwriteAll;
                 if (!*bOverwriteAll)
                 {
-                    eZipConfirmResponse Result;
-                    Result = _CZipAskReplace(hDlg, FullPath);
+                    eZipConfirmResponse Result = _CZipAskReplace(hDlg, FullPath);
                     switch (Result)
                     {
                     case eYesToAll:

--- a/dll/shellext/zipfldr/CZipExtract.cpp
+++ b/dll/shellext/zipfldr/CZipExtract.cpp
@@ -605,6 +605,7 @@ public:
             DWORD cchFullPath = ::GetFullPathName(CombinedPath, 0, NULL, NULL);
             ::GetFullPathName(CombinedPath, cchFullPath, FullPath.GetBuffer(cchFullPath), NULL);
             FullPath.ReleaseBuffer();
+
         Retry:
             eZipExtractError Result = ExtractSingle(hDlg, FullPath, is_dir, &Info, Name, Password, &bOverwriteAll, bCancel, &err);
             if (Result != eDirectoryError)

--- a/dll/shellext/zipfldr/CZipExtract.cpp
+++ b/dll/shellext/zipfldr/CZipExtract.cpp
@@ -598,7 +598,7 @@ public:
             CombinedPath.Combine(BaseDirectory, Name);
 
             // SHPathPrepareForWrite does not handle '/', even on MS Windows
-            CStringW& FullPath = static_cast<CStringW&>(CombinedPath);
+            CStringW& FullPath = CombinedPath.m_strPath;
             FullPath.Replace(L'/', L'\\');
 
         Retry:

--- a/dll/shellext/zipfldr/CZipExtract.cpp
+++ b/dll/shellext/zipfldr/CZipExtract.cpp
@@ -598,7 +598,7 @@ public:
             CombinedPath.Combine(BaseDirectory, Name);
 
             // SHPathPrepareForWrite does not handle '/'
-            CStringW strCombined = CombinedPath;
+            CStringW& strCombined = static_cast<CStringW&>(CombinedPath);
             strCombined.Replace(L'/', L'\\');
 
             // Build a full path

--- a/dll/shellext/zipfldr/CZipExtract.cpp
+++ b/dll/shellext/zipfldr/CZipExtract.cpp
@@ -592,13 +592,13 @@ public:
 
             bool is_dir = Name.GetLength() > 0 && Name[Name.GetLength()-1] == '/';
 
-            // Get combined path
+            // Build a combined path
             CStringW CombinedPath = BaseDirectory;
-            if (CombinedPath.GetLength() == 0 || CombinedPath[CombinedPath.GetLength() - 1] != L'\\')
+            if (CombinedPath.GetLength() > 0 && CombinedPath[CombinedPath.GetLength() - 1] != L'\\')
                 CombinedPath += L'\\';
             CombinedPath += Name;
 
-            // Get full path
+            // Build a full path
             CStringW FullPath;
             DWORD cchFullPath = ::GetFullPathName(CombinedPath, 0, NULL, NULL);
             ::GetFullPathName(CombinedPath, cchFullPath, FullPath.GetBuffer(cchFullPath), NULL);

--- a/dll/shellext/zipfldr/CZipExtract.cpp
+++ b/dll/shellext/zipfldr/CZipExtract.cpp
@@ -598,13 +598,13 @@ public:
                 CombinedPath += L'\\';
             CombinedPath += Name;
 
+            CombinedPath.Replace(L'/', L'\\'); // SHPathPrepareForWrite does not handle '/'
+
             // Build a full path
             CStringW FullPath;
             DWORD cchFullPath = ::GetFullPathName(CombinedPath, 0, NULL, NULL);
             ::GetFullPathName(CombinedPath, cchFullPath, FullPath.GetBuffer(cchFullPath), NULL);
             FullPath.ReleaseBuffer();
-
-            FullPath.Replace(L'/', L'\\'); // SHPathPrepareForWrite does not handle '/'
         Retry:
             eZipExtractError Result = ExtractSingle(hDlg, FullPath, is_dir, &Info, Name, Password, &bOverwriteAll, bCancel, &err);
             if (Result != eDirectoryError)

--- a/dll/shellext/zipfldr/CZipExtract.cpp
+++ b/dll/shellext/zipfldr/CZipExtract.cpp
@@ -594,14 +594,14 @@ public:
             bool is_dir = Name.GetLength() > 0 && Name[Name.GetLength()-1] == '/';
 
             // Build a combined path
-            CPathW CombinedPath(BaseDirectory);
-            CombinedPath += Name;
+            CPathW FullPath(BaseDirectory);
+            FullPath += Name;
 
             // SHPathPrepareForWrite does not handle '/', even on MS Windows
-            CombinedPath.m_strPath.Replace(L'/', L'\\');
+            FullPath.m_strPath.Replace(L'/', L'\\');
 
         Retry:
-            eZipExtractError Result = ExtractSingle(hDlg, CombinedPath, is_dir, &Info, Name, Password, &bOverwriteAll, bCancel, &err);
+            eZipExtractError Result = ExtractSingle(hDlg, FullPath, is_dir, &Info, Name, Password, &bOverwriteAll, bCancel, &err);
             if (Result != eDirectoryError)
                 CurrentFile++;
             switch (Result)
@@ -620,7 +620,7 @@ public:
                 {
                     WCHAR StrippedPath[MAX_PATH] = { 0 };
 
-                    StrCpyNW(StrippedPath, CombinedPath, _countof(StrippedPath));
+                    StrCpyNW(StrippedPath, FullPath, _countof(StrippedPath));
                     if (!is_dir)
                         PathRemoveFileSpecW(StrippedPath);
                     PathStripPathW(StrippedPath);
@@ -632,7 +632,7 @@ public:
 
                 case eFileError:
                 {
-                    int Result = ShowExtractError(hDlg, CombinedPath, err, eFileError);
+                    int Result = ShowExtractError(hDlg, FullPath, err, eFileError);
                     switch (Result)
                     {
                     case IDABORT:
@@ -654,7 +654,7 @@ public:
                         Info.compression_method != Z_DEFLATED &&
                         Info.compression_method != Z_BZIP2ED)
                     {
-                        if (ShowExtractError(hDlg, CombinedPath, Info.compression_method, eOpenError) == IDYES)
+                        if (ShowExtractError(hDlg, FullPath, Info.compression_method, eOpenError) == IDYES)
                             break;
                     }
                     Close();

--- a/dll/shellext/zipfldr/CZipExtract.cpp
+++ b/dll/shellext/zipfldr/CZipExtract.cpp
@@ -598,14 +598,8 @@ public:
             CombinedPath.Combine(BaseDirectory, Name);
 
             // SHPathPrepareForWrite does not handle '/'
-            CStringW& strCombined = static_cast<CStringW&>(CombinedPath);
-            strCombined.Replace(L'/', L'\\');
-
-            // Build a full path
-            CStringW FullPath;
-            DWORD cchFullPath = ::GetFullPathName(strCombined, 0, NULL, NULL);
-            ::GetFullPathName(CombinedPath, cchFullPath, FullPath.GetBuffer(cchFullPath), NULL);
-            FullPath.ReleaseBuffer();
+            CStringW& FullPath = static_cast<CStringW&>(CombinedPath);
+            FullPath.Replace(L'/', L'\\');
 
         Retry:
             eZipExtractError Result = ExtractSingle(hDlg, FullPath, is_dir, &Info, Name, Password, &bOverwriteAll, bCancel, &err);

--- a/dll/shellext/zipfldr/CZipExtract.cpp
+++ b/dll/shellext/zipfldr/CZipExtract.cpp
@@ -205,7 +205,7 @@ public:
         struct browse_info
         {
             HWND hWnd;
-            LPCWSTR Directory;
+            PCWSTR Directory;
         };
 
         static INT CALLBACK s_BrowseCallbackProc(HWND hWnd, UINT uMsg, LPARAM lp, LPARAM pData)
@@ -371,7 +371,7 @@ public:
 
     eZipExtractError ExtractSingle(
         HWND hDlg,
-        LPCWSTR FullPath,
+        PCWSTR FullPath,
         bool is_dir,
         unz_file_info64* Info,
         CStringW Name,
@@ -666,7 +666,7 @@ public:
         return true;
     }
 
-    int ShowExtractError(HWND hDlg, LPCWSTR path, int Error, eZipExtractError ErrorType)
+    int ShowExtractError(HWND hDlg, PCWSTR path, int Error, eZipExtractError ErrorType)
     {
         CStringW strTitle(MAKEINTRESOURCEW(IDS_ERRORTITLE));
         CStringW strErr, strText;

--- a/dll/shellext/zipfldr/CZipExtract.cpp
+++ b/dll/shellext/zipfldr/CZipExtract.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "precomp.h"
+#include <atlpath.h>
 
 class CZipExtract :
     public IZip
@@ -593,16 +594,16 @@ public:
             bool is_dir = Name.GetLength() > 0 && Name[Name.GetLength()-1] == '/';
 
             // Build a combined path
-            CStringW CombinedPath = BaseDirectory;
-            if (CombinedPath.GetLength() > 0 && CombinedPath[CombinedPath.GetLength() - 1] != L'\\')
-                CombinedPath += L'\\';
-            CombinedPath += Name;
+            CPathW CombinedPath;
+            CombinedPath.Combine(BaseDirectory, Name);
 
-            CombinedPath.Replace(L'/', L'\\'); // SHPathPrepareForWrite does not handle '/'
+            // SHPathPrepareForWrite does not handle '/'
+            CStringW strCombined = CombinedPath;
+            strCombined.Replace(L'/', L'\\');
 
             // Build a full path
             CStringW FullPath;
-            DWORD cchFullPath = ::GetFullPathName(CombinedPath, 0, NULL, NULL);
+            DWORD cchFullPath = ::GetFullPathName(strCombined, 0, NULL, NULL);
             ::GetFullPathName(CombinedPath, cchFullPath, FullPath.GetBuffer(cchFullPath), NULL);
             FullPath.ReleaseBuffer();
 

--- a/dll/shellext/zipfldr/CZipExtract.cpp
+++ b/dll/shellext/zipfldr/CZipExtract.cpp
@@ -597,7 +597,7 @@ public:
             CPathW CombinedPath;
             CombinedPath.Combine(BaseDirectory, Name);
 
-            // SHPathPrepareForWrite does not handle '/'
+            // SHPathPrepareForWrite does not handle '/', even on MS Windows
             CStringW& FullPath = static_cast<CStringW&>(CombinedPath);
             FullPath.Replace(L'/', L'\\');
 

--- a/dll/shellext/zipfldr/CZipExtract.cpp
+++ b/dll/shellext/zipfldr/CZipExtract.cpp
@@ -3,6 +3,7 @@
  * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
  * PURPOSE:     Zip extraction
  * COPYRIGHT:   Copyright 2017-2019 Mark Jansen (mark.jansen@reactos.org)
+ *              Copyright 2023 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
  */
 
 #include "precomp.h"

--- a/dll/shellext/zipfldr/CZipExtract.cpp
+++ b/dll/shellext/zipfldr/CZipExtract.cpp
@@ -594,14 +594,14 @@ public:
             bool is_dir = Name.GetLength() > 0 && Name[Name.GetLength()-1] == '/';
 
             // Build a combined path
-            CPathW CombinedPath = BaseDirectory;
+            CPathW CombinedPath(BaseDirectory);
             CombinedPath += Name;
 
             // SHPathPrepareForWrite does not handle '/', even on MS Windows
             CombinedPath.m_strPath.Replace(L'/', L'\\');
 
         Retry:
-            eZipExtractError Result = ExtractSingle(hDlg, FullPath, is_dir, &Info, Name, Password, &bOverwriteAll, bCancel, &err);
+            eZipExtractError Result = ExtractSingle(hDlg, CombinedPath, is_dir, &Info, Name, Password, &bOverwriteAll, bCancel, &err);
             if (Result != eDirectoryError)
                 CurrentFile++;
             switch (Result)
@@ -620,7 +620,7 @@ public:
                 {
                     WCHAR StrippedPath[MAX_PATH] = { 0 };
 
-                    StrCpyNW(StrippedPath, FullPath, _countof(StrippedPath));
+                    StrCpyNW(StrippedPath, CombinedPath, _countof(StrippedPath));
                     if (!is_dir)
                         PathRemoveFileSpecW(StrippedPath);
                     PathStripPathW(StrippedPath);
@@ -632,7 +632,7 @@ public:
 
                 case eFileError:
                 {
-                    int Result = ShowExtractError(hDlg, FullPath, err, eFileError);
+                    int Result = ShowExtractError(hDlg, CombinedPath, err, eFileError);
                     switch (Result)
                     {
                     case IDABORT:
@@ -654,7 +654,7 @@ public:
                         Info.compression_method != Z_DEFLATED &&
                         Info.compression_method != Z_BZIP2ED)
                     {
-                        if (ShowExtractError(hDlg, FullPath, Info.compression_method, eOpenError) == IDYES)
+                        if (ShowExtractError(hDlg, CombinedPath, Info.compression_method, eOpenError) == IDYES)
                             break;
                     }
                     Close();

--- a/dll/shellext/zipfldr/CZipFolder.hpp
+++ b/dll/shellext/zipfldr/CZipFolder.hpp
@@ -100,7 +100,7 @@ public:
         return E_NOTIMPL;
     }
     // Adapted from CFileDefExt::GetFileTimeString
-    BOOL _GetFileTimeString(LPFILETIME lpFileTime, LPWSTR pwszResult, UINT cchResult)
+    BOOL _GetFileTimeString(LPFILETIME lpFileTime, PWSTR pwszResult, UINT cchResult)
     {
         SYSTEMTIME st;
 
@@ -108,7 +108,7 @@ public:
             return FALSE;
 
         size_t cchRemaining = cchResult;
-        LPWSTR pwszEnd = pwszResult;
+        PWSTR pwszEnd = pwszResult;
         int cchWritten = GetDateFormatW(LOCALE_USER_DEFAULT, DATE_SHORTDATE, &st, NULL, pwszEnd, cchRemaining);
         if (cchWritten)
             --cchWritten; // GetDateFormatW returns count with terminating zero
@@ -474,7 +474,7 @@ public:
         case GCS_VERBA:
             return StringCchCopyA(pszName, cchMax, EXTRACT_VERBA);
         case GCS_VERBW:
-            return StringCchCopyW((LPWSTR)pszName, cchMax, EXTRACT_VERBW);
+            return StringCchCopyW((PWSTR)pszName, cchMax, EXTRACT_VERBW);
         case GCS_HELPTEXTA:
         {
             CStringA helpText(MAKEINTRESOURCEA(IDS_HELPTEXT));
@@ -483,7 +483,7 @@ public:
         case GCS_HELPTEXTW:
         {
             CStringW helpText(MAKEINTRESOURCEA(IDS_HELPTEXT));
-            return StringCchCopyW((LPWSTR)pszName, cchMax, helpText);
+            return StringCchCopyW((PWSTR)pszName, cchMax, helpText);
         }
         case GCS_VALIDATEA:
         case GCS_VALIDATEW:

--- a/dll/shellext/zipfldr/CZipFolder.hpp
+++ b/dll/shellext/zipfldr/CZipFolder.hpp
@@ -3,6 +3,7 @@
  * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
  * PURPOSE:     Main class
  * COPYRIGHT:   Copyright 2017 Mark Jansen (mark.jansen@reactos.org)
+ *              Copyright 2023 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
  */
 
 struct FolderViewColumns

--- a/dll/shellext/zipfldr/CZipPassword.cpp
+++ b/dll/shellext/zipfldr/CZipPassword.cpp
@@ -64,7 +64,7 @@ public:
     END_MSG_MAP()
 };
 
-eZipPasswordResponse _CZipAskPasswordW(HWND hDlg, LPCWSTR filename, CStringA& Password)
+eZipPasswordResponse _CZipAskPassword(HWND hDlg, LPCWSTR filename, CStringA& Password)
 {
     if (filename)
         filename = PathFindFileNameW(filename);

--- a/dll/shellext/zipfldr/CZipPassword.cpp
+++ b/dll/shellext/zipfldr/CZipPassword.cpp
@@ -14,7 +14,7 @@ private:
     CStringW m_Filename;
     CStringA* m_pPassword;
 public:
-    CZipPassword(LPCWSTR filename, CStringA* Password)
+    CZipPassword(PCWSTR filename, CStringA* Password)
         :m_pPassword(Password)
     {
         if (filename != NULL)
@@ -65,7 +65,7 @@ public:
     END_MSG_MAP()
 };
 
-eZipPasswordResponse _CZipAskPassword(HWND hDlg, LPCWSTR filename, CStringA& Password)
+eZipPasswordResponse _CZipAskPassword(HWND hDlg, PCWSTR filename, CStringA& Password)
 {
     if (filename)
         filename = PathFindFileNameW(filename);

--- a/dll/shellext/zipfldr/CZipPassword.cpp
+++ b/dll/shellext/zipfldr/CZipPassword.cpp
@@ -10,10 +10,10 @@
 class CZipPassword : public CDialogImpl<CZipPassword>
 {
 private:
-    CStringA m_Filename;
+    CStringW m_Filename;
     CStringA* m_pPassword;
 public:
-    CZipPassword(const char* filename, CStringA* Password)
+    CZipPassword(LPCWSTR filename, CStringA* Password)
         :m_pPassword(Password)
     {
         if (filename != NULL)
@@ -27,15 +27,15 @@ public:
         /* No filename, so this is the question before starting to extract */
         if (m_Filename.IsEmpty())
         {
-            CStringA message(MAKEINTRESOURCE(IDS_PASSWORD_ZIP_TEXT));
-            ::SetDlgItemTextA(m_hWnd, IDC_MESSAGE, message);
+            CStringW message(MAKEINTRESOURCE(IDS_PASSWORD_ZIP_TEXT));
+            ::SetDlgItemTextW(m_hWnd, IDC_MESSAGE, message);
             ::ShowWindow(GetDlgItem(IDSKIP), SW_HIDE);
         }
         else
         {
-            CStringA message;
+            CStringW message;
             message.FormatMessage(IDS_PASSWORD_FILE_TEXT, m_Filename.GetString());
-            ::SetDlgItemTextA(m_hWnd, IDC_MESSAGE, message);
+            ::SetDlgItemTextW(m_hWnd, IDC_MESSAGE, message);
         }
         return TRUE;
     }
@@ -64,10 +64,10 @@ public:
     END_MSG_MAP()
 };
 
-eZipPasswordResponse _CZipAskPassword(HWND hDlg, const char* filename, CStringA& Password)
+eZipPasswordResponse _CZipAskPasswordW(HWND hDlg, LPCWSTR filename, CStringA& Password)
 {
     if (filename)
-        filename = PathFindFileNameA(filename);
+        filename = PathFindFileNameW(filename);
     CZipPassword password(filename, &Password);
     INT_PTR Result = password.DoModal(hDlg);
     switch (Result)

--- a/dll/shellext/zipfldr/CZipPassword.cpp
+++ b/dll/shellext/zipfldr/CZipPassword.cpp
@@ -27,7 +27,7 @@ public:
         /* No filename, so this is the question before starting to extract */
         if (m_Filename.IsEmpty())
         {
-            CStringW message(MAKEINTRESOURCE(IDS_PASSWORD_ZIP_TEXT));
+            CStringW message(MAKEINTRESOURCEW(IDS_PASSWORD_ZIP_TEXT));
             ::SetDlgItemTextW(m_hWnd, IDC_MESSAGE, message);
             ::ShowWindow(GetDlgItem(IDSKIP), SW_HIDE);
         }

--- a/dll/shellext/zipfldr/CZipPassword.cpp
+++ b/dll/shellext/zipfldr/CZipPassword.cpp
@@ -3,6 +3,7 @@
  * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
  * PURPOSE:     Ask the user for a password
  * COPYRIGHT:   Copyright 2019 Mark Jansen (mark.jansen@reactos.org)
+ *              Copyright 2023 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
  */
 
 #include "precomp.h"

--- a/dll/shellext/zipfldr/precomp.h
+++ b/dll/shellext/zipfldr/precomp.h
@@ -41,6 +41,7 @@ WCHAR* guid2string(REFCLSID iid);
 
 
 #define MINIZIP_PASSWORD_FLAG   1
+#define MINIZIP_UTF8_FLAG       (1 << 11)
 
 #include "minizip/unzip.h"
 #include "minizip/ioapi.h"
@@ -52,7 +53,7 @@ extern zlib_filefunc64_def g_FFunc;
 #include "zippidl.hpp"
 #include "IZip.hpp"
 
-HRESULT _CEnumZipContents_CreateInstance(IZip* zip, DWORD flags, const char* prefix, REFIID riid, LPVOID * ppvOut);
+HRESULT _CEnumZipContents_CreateInstance(IZip* zip, DWORD flags, LPCWSTR prefix, REFIID riid, LPVOID * ppvOut);
 HRESULT _CExplorerCommandProvider_CreateInstance(IContextMenu* zipObject, REFIID riid, LPVOID * ppvOut);
 HRESULT _CFolderViewCB_CreateInstance(REFIID riid, LPVOID * ppvOut);
 void _CZipExtract_runWizard(PCWSTR Filename);
@@ -64,7 +65,7 @@ enum eZipPasswordResponse
     eAccept,
 };
 
-eZipPasswordResponse _CZipAskPassword(HWND hDlg, const char* filename, CStringA& Password);
+eZipPasswordResponse _CZipAskPasswordW(HWND hDlg, LPCWSTR filename, CStringA& Password);
 
 enum eZipConfirmResponse
 {
@@ -74,7 +75,7 @@ enum eZipConfirmResponse
     eCancel
 };
 
-eZipConfirmResponse _CZipAskReplace(HWND hDlg, const char* FullPath);
+eZipConfirmResponse _CZipAskReplaceW(HWND hDlg, LPCWSTR FullPath);
 
 enum eZipExtractError
 {

--- a/dll/shellext/zipfldr/precomp.h
+++ b/dll/shellext/zipfldr/precomp.h
@@ -53,7 +53,7 @@ extern zlib_filefunc64_def g_FFunc;
 #include "zippidl.hpp"
 #include "IZip.hpp"
 
-HRESULT _CEnumZipContents_CreateInstance(IZip* zip, DWORD flags, LPCWSTR prefix, REFIID riid, LPVOID * ppvOut);
+HRESULT _CEnumZipContents_CreateInstance(IZip* zip, DWORD flags, PCWSTR prefix, REFIID riid, LPVOID * ppvOut);
 HRESULT _CExplorerCommandProvider_CreateInstance(IContextMenu* zipObject, REFIID riid, LPVOID * ppvOut);
 HRESULT _CFolderViewCB_CreateInstance(REFIID riid, LPVOID * ppvOut);
 void _CZipExtract_runWizard(PCWSTR Filename);
@@ -65,7 +65,7 @@ enum eZipPasswordResponse
     eAccept,
 };
 
-eZipPasswordResponse _CZipAskPassword(HWND hDlg, LPCWSTR filename, CStringA& Password);
+eZipPasswordResponse _CZipAskPassword(HWND hDlg, PCWSTR filename, CStringA& Password);
 
 enum eZipConfirmResponse
 {
@@ -75,7 +75,7 @@ enum eZipConfirmResponse
     eCancel
 };
 
-eZipConfirmResponse _CZipAskReplace(HWND hDlg, LPCWSTR FullPath);
+eZipConfirmResponse _CZipAskReplace(HWND hDlg, PCWSTR FullPath);
 
 enum eZipExtractError
 {

--- a/dll/shellext/zipfldr/precomp.h
+++ b/dll/shellext/zipfldr/precomp.h
@@ -21,7 +21,8 @@
 #include <reactos/debug.h>
 #include <shellutils.h>
 
-
+void AnsiToWide(const CStringA& strAnsi, CStringW& strWide);
+void Utf8ToWide(const CStringA& strUtf8, CStringW& strWide);
 
 #define EXTRACT_VERBA "extract"
 #define EXTRACT_VERBW L"extract"

--- a/dll/shellext/zipfldr/precomp.h
+++ b/dll/shellext/zipfldr/precomp.h
@@ -65,7 +65,7 @@ enum eZipPasswordResponse
     eAccept,
 };
 
-eZipPasswordResponse _CZipAskPasswordW(HWND hDlg, LPCWSTR filename, CStringA& Password);
+eZipPasswordResponse _CZipAskPassword(HWND hDlg, LPCWSTR filename, CStringA& Password);
 
 enum eZipConfirmResponse
 {
@@ -75,7 +75,7 @@ enum eZipConfirmResponse
     eCancel
 };
 
-eZipConfirmResponse _CZipAskReplaceW(HWND hDlg, LPCWSTR FullPath);
+eZipConfirmResponse _CZipAskReplace(HWND hDlg, LPCWSTR FullPath);
 
 enum eZipExtractError
 {

--- a/dll/shellext/zipfldr/precomp.h
+++ b/dll/shellext/zipfldr/precomp.h
@@ -21,7 +21,6 @@
 #include <reactos/debug.h>
 #include <shellutils.h>
 
-void AnsiToWide(const CStringA& strAnsi, CStringW& strWide);
 void Utf8ToWide(const CStringA& strUtf8, CStringW& strWide);
 
 #define EXTRACT_VERBA "extract"

--- a/dll/shellext/zipfldr/zipfldr.cpp
+++ b/dll/shellext/zipfldr/zipfldr.cpp
@@ -55,7 +55,6 @@ void AnsiToWide(const CStringA& strAnsi, CStringW& strWide)
 void Utf8ToWide(const CStringA& strUtf8, CStringW& strWide)
 {
     WCHAR wide[MAX_PATH];
-    wide[0] = UNICODE_NULL;
     MultiByteToWideChar(CP_UTF8, 0, strUtf8, -1, wide, _countof(wide));
     wide[_countof(wide) - 1] = UNICODE_NULL;
     strWide = wide;

--- a/dll/shellext/zipfldr/zipfldr.cpp
+++ b/dll/shellext/zipfldr/zipfldr.cpp
@@ -57,7 +57,7 @@ void Utf8ToWide(const CStringA& strUtf8, CStringW& strWide)
 }
 
 static BOOL
-CreateEmptyFile(LPCWSTR pszFile)
+CreateEmptyFile(PCWSTR pszFile)
 {
     HANDLE hFile;
     hFile = CreateFileW(pszFile, GENERIC_WRITE, FILE_SHARE_READ, NULL,
@@ -71,7 +71,7 @@ CreateEmptyFile(LPCWSTR pszFile)
 }
 
 static HRESULT
-CreateSendToZip(LPCWSTR pszSendTo)
+CreateSendToZip(PCWSTR pszSendTo)
 {
     WCHAR szTarget[MAX_PATH], szSendToFile[MAX_PATH];
 
@@ -163,7 +163,7 @@ BOOL WINAPI
 RouteTheCall(
     IN HWND hWndOwner,
     IN HINSTANCE hInstance,
-    IN LPCWSTR lpStringArg,
+    IN PCWSTR lpStringArg,
     IN INT Show)
 {
     CStringW path = lpStringArg;

--- a/dll/shellext/zipfldr/zipfldr.cpp
+++ b/dll/shellext/zipfldr/zipfldr.cpp
@@ -3,6 +3,7 @@
  * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
  * PURPOSE:     zipfldr entrypoint
  * COPYRIGHT:   Copyright 2017 Mark Jansen (mark.jansen@reactos.org)
+ *              Copyright 2023 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
  */
 
 #include "precomp.h"

--- a/dll/shellext/zipfldr/zipfldr.cpp
+++ b/dll/shellext/zipfldr/zipfldr.cpp
@@ -47,11 +47,6 @@ static void init_zlib()
     fill_win32_filefunc64W(&g_FFunc);
 }
 
-void AnsiToWide(const CStringA& strAnsi, CStringW& strWide)
-{
-    strWide = CStringW(strAnsi);
-}
-
 void Utf8ToWide(const CStringA& strUtf8, CStringW& strWide)
 {
     WCHAR wide[MAX_PATH];

--- a/dll/shellext/zipfldr/zipfldr.cpp
+++ b/dll/shellext/zipfldr/zipfldr.cpp
@@ -89,7 +89,7 @@ CreateSendToZip(PCWSTR pszSendTo)
 }
 
 static HRESULT
-GetDefaultUserSendTo(LPWSTR pszPath)
+GetDefaultUserSendTo(PWSTR pszPath)
 {
     return SHGetFolderPathW(NULL, CSIDL_SENDTO, INVALID_HANDLE_VALUE,
                             SHGFP_TYPE_DEFAULT, pszPath);

--- a/dll/shellext/zipfldr/zipfldr.cpp
+++ b/dll/shellext/zipfldr/zipfldr.cpp
@@ -154,7 +154,7 @@ BOOL WINAPI
 RouteTheCall(
     IN HWND hWndOwner,
     IN HINSTANCE hInstance,
-    IN LPCSTR lpStringArg,
+    IN LPCWSTR lpStringArg,
     IN INT Show)
 {
     CStringW path = lpStringArg;

--- a/dll/shellext/zipfldr/zipfldr.cpp
+++ b/dll/shellext/zipfldr/zipfldr.cpp
@@ -47,6 +47,20 @@ static void init_zlib()
     fill_win32_filefunc64W(&g_FFunc);
 }
 
+void AnsiToWide(const CStringA& strAnsi, CStringW& strWide)
+{
+    strWide = CStringW(strAnsi);
+}
+
+void Utf8ToWide(const CStringA& strUtf8, CStringW& strWide)
+{
+    WCHAR wide[MAX_PATH];
+    wide[0] = UNICODE_NULL;
+    MultiByteToWideChar(CP_UTF8, 0, strUtf8, -1, wide, _countof(wide));
+    wide[_countof(wide) - 1] = UNICODE_NULL;
+    strWide = wide;
+}
+
 static BOOL
 CreateEmptyFile(LPCWSTR pszFile)
 {

--- a/dll/shellext/zipfldr/zipfldr.cpp
+++ b/dll/shellext/zipfldr/zipfldr.cpp
@@ -50,10 +50,9 @@ static void init_zlib()
 
 void Utf8ToWide(const CStringA& strUtf8, CStringW& strWide)
 {
-    WCHAR wide[MAX_PATH];
-    MultiByteToWideChar(CP_UTF8, 0, strUtf8, -1, wide, _countof(wide));
-    wide[_countof(wide) - 1] = UNICODE_NULL;
-    strWide = wide;
+    INT cchWide = MultiByteToWideChar(CP_UTF8, 0, strUtf8, -1, NULL, 0);
+    MultiByteToWideChar(CP_UTF8, 0, strUtf8, -1, strWide.GetBuffer(cchWide), cchWide);
+    strWide.ReleaseBuffer();
 }
 
 static BOOL

--- a/dll/shellext/zipfldr/zippidl.cpp
+++ b/dll/shellext/zipfldr/zippidl.cpp
@@ -3,6 +3,7 @@
  * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
  * PURPOSE:     zip pidl handling
  * COPYRIGHT:   Copyright 2017-2019 Mark Jansen (mark.jansen@reactos.org)
+ *              Copyright 2023 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
  */
 
 #include "precomp.h"

--- a/dll/shellext/zipfldr/zippidl.cpp
+++ b/dll/shellext/zipfldr/zippidl.cpp
@@ -8,7 +8,7 @@
 
 #include "precomp.h"
 
-LPITEMIDLIST _ILCreate(ZipPidlType Type, LPCWSTR lpString, unz_file_info64& info)
+LPITEMIDLIST _ILCreate(ZipPidlType Type, PCWSTR lpString, unz_file_info64& info)
 {
     size_t cbData = sizeof(ZipPidlEntry) + wcslen(lpString) * sizeof(WCHAR);
     if (cbData > MAXWORD)

--- a/dll/shellext/zipfldr/zippidl.cpp
+++ b/dll/shellext/zipfldr/zippidl.cpp
@@ -11,13 +11,16 @@
 LPITEMIDLIST _ILCreate(ZipPidlType Type, LPCWSTR lpString, unz_file_info64& info)
 {
     size_t cbData = sizeof(ZipPidlEntry) + wcslen(lpString) * sizeof(WCHAR);
+    if (cbData > MAXWORD)
+        return NULL;
+
     ZipPidlEntry* pidl = (ZipPidlEntry*)SHAlloc(cbData + sizeof(WORD));
     if (!pidl)
         return NULL;
 
     ZeroMemory(pidl, cbData + sizeof(WORD));
 
-    pidl->cb = cbData;
+    pidl->cb = (WORD)cbData;
     pidl->MagicType = 'z';
     pidl->ZipType = Type;
 

--- a/dll/shellext/zipfldr/zippidl.cpp
+++ b/dll/shellext/zipfldr/zippidl.cpp
@@ -20,7 +20,7 @@ LPITEMIDLIST _ILCreate(ZipPidlType Type, LPCWSTR lpString, unz_file_info64& info
 
     ZeroMemory(pidl, cbData + sizeof(WORD));
 
-    pidl->cb = (USHORT)cbData;
+    pidl->cb = (WORD)cbData;
     pidl->MagicType = 'z';
     pidl->ZipType = Type;
 
@@ -30,7 +30,6 @@ LPITEMIDLIST _ILCreate(ZipPidlType Type, LPCWSTR lpString, unz_file_info64& info
         pidl->UncompressedSize = info.uncompressed_size;
         pidl->DosDate = info.dosDate;
         pidl->Password = info.flag & MINIZIP_PASSWORD_FLAG;
-        pidl->Utf8 = !!(info.flag & MINIZIP_UTF8_FLAG);
     }
 
     wcscpy(pidl->Name, lpString);

--- a/dll/shellext/zipfldr/zippidl.cpp
+++ b/dll/shellext/zipfldr/zippidl.cpp
@@ -20,7 +20,7 @@ LPITEMIDLIST _ILCreate(ZipPidlType Type, LPCWSTR lpString, unz_file_info64& info
 
     ZeroMemory(pidl, cbData + sizeof(WORD));
 
-    pidl->cb = (WORD)cbData;
+    pidl->cb = (USHORT)cbData;
     pidl->MagicType = 'z';
     pidl->ZipType = Type;
 
@@ -34,7 +34,7 @@ LPITEMIDLIST _ILCreate(ZipPidlType Type, LPCWSTR lpString, unz_file_info64& info
     }
 
     wcscpy(pidl->Name, lpString);
-    *(WORD*)((char*)pidl + cbData) = 0;
+    *(WORD*)((char*)pidl + cbData) = 0; // The end of an ITEMIDLIST
 
     return (LPITEMIDLIST)pidl;
 }

--- a/dll/shellext/zipfldr/zippidl.cpp
+++ b/dll/shellext/zipfldr/zippidl.cpp
@@ -7,9 +7,9 @@
 
 #include "precomp.h"
 
-LPITEMIDLIST _ILCreate(ZipPidlType Type, LPCSTR lpString, unz_file_info64& info)
+LPITEMIDLIST _ILCreate(ZipPidlType Type, LPCWSTR lpString, unz_file_info64& info)
 {
-    int cbData = sizeof(ZipPidlEntry) + strlen(lpString);
+    int cbData = sizeof(ZipPidlEntry) + lstrlenW(lpString) * sizeof(WCHAR);
     ZipPidlEntry* pidl = (ZipPidlEntry*)SHAlloc(cbData + sizeof(WORD));
     if (!pidl)
         return NULL;
@@ -26,14 +26,14 @@ LPITEMIDLIST _ILCreate(ZipPidlType Type, LPCSTR lpString, unz_file_info64& info)
         pidl->UncompressedSize = info.uncompressed_size;
         pidl->DosDate = info.dosDate;
         pidl->Password = info.flag & MINIZIP_PASSWORD_FLAG;
+        pidl->Utf8 = !!(info.flag & MINIZIP_UTF8_FLAG);
     }
 
-    strcpy(pidl->Name, lpString);
+    lstrcpyW(pidl->Name, lpString);
     *(WORD*)((char*)pidl + cbData) = 0;
 
     return (LPITEMIDLIST)pidl;
 }
-
 
 const ZipPidlEntry* _ZipFromIL(LPCITEMIDLIST pidl)
 {

--- a/dll/shellext/zipfldr/zippidl.cpp
+++ b/dll/shellext/zipfldr/zippidl.cpp
@@ -10,7 +10,7 @@
 
 LPITEMIDLIST _ILCreate(ZipPidlType Type, LPCWSTR lpString, unz_file_info64& info)
 {
-    int cbData = sizeof(ZipPidlEntry) + lstrlenW(lpString) * sizeof(WCHAR);
+    size_t cbData = sizeof(ZipPidlEntry) + wcslen(lpString) * sizeof(WCHAR);
     ZipPidlEntry* pidl = (ZipPidlEntry*)SHAlloc(cbData + sizeof(WORD));
     if (!pidl)
         return NULL;
@@ -30,7 +30,7 @@ LPITEMIDLIST _ILCreate(ZipPidlType Type, LPCWSTR lpString, unz_file_info64& info
         pidl->Utf8 = !!(info.flag & MINIZIP_UTF8_FLAG);
     }
 
-    lstrcpyW(pidl->Name, lpString);
+    wcscpy(pidl->Name, lpString);
     *(WORD*)((char*)pidl + cbData) = 0;
 
     return (LPITEMIDLIST)pidl;

--- a/dll/shellext/zipfldr/zippidl.hpp
+++ b/dll/shellext/zipfldr/zippidl.hpp
@@ -16,7 +16,7 @@ enum ZipPidlType
 #include <pshpack1.h>
 struct ZipPidlEntry
 {
-    WORD cb; // This must be a USHORT for SHITEMID compatibility
+    USHORT cb; // This must be a USHORT for SHITEMID compatibility
     WORD MagicType;
     ZipPidlType ZipType;
 

--- a/dll/shellext/zipfldr/zippidl.hpp
+++ b/dll/shellext/zipfldr/zippidl.hpp
@@ -16,7 +16,7 @@ enum ZipPidlType
 #include <pshpack1.h>
 struct ZipPidlEntry
 {
-    WORD cb;
+    WORD cb; // This must be a USHORT for SHITEMID compatibility
     WORD MagicType;
     ZipPidlType ZipType;
 

--- a/dll/shellext/zipfldr/zippidl.hpp
+++ b/dll/shellext/zipfldr/zippidl.hpp
@@ -23,12 +23,12 @@ struct ZipPidlEntry
     ULONG64 UncompressedSize;
     ULONG DosDate;
     BYTE Password;
+    BYTE Utf8;
 
-    char Name[1];
+    WCHAR Name[1];
 };
 #include <poppack.h>
 
 
-LPITEMIDLIST _ILCreate(ZipPidlType Type, LPCSTR lpString, unz_file_info64& info);
+LPITEMIDLIST _ILCreate(ZipPidlType Type, LPCWSTR lpString, unz_file_info64& info);
 const ZipPidlEntry* _ZipFromIL(LPCITEMIDLIST pidl);
-

--- a/dll/shellext/zipfldr/zippidl.hpp
+++ b/dll/shellext/zipfldr/zippidl.hpp
@@ -17,13 +17,13 @@ enum ZipPidlType
 struct ZipPidlEntry
 {
     WORD cb; // This must be a WORD for SHITEMID compatibility
-    WORD MagicType;
+    BYTE MagicType;
+    BOOLEAN Password;
     ZipPidlType ZipType;
 
     ULONG64 CompressedSize;
     ULONG64 UncompressedSize;
     ULONG DosDate;
-    BYTE Password;
 
     WCHAR Name[1];
 };

--- a/dll/shellext/zipfldr/zippidl.hpp
+++ b/dll/shellext/zipfldr/zippidl.hpp
@@ -16,8 +16,8 @@ enum ZipPidlType
 #include <pshpack1.h>
 struct ZipPidlEntry
 {
-    WORD cb;
-    BYTE MagicType;
+    size_t cb;
+    DWORD MagicType;
     ZipPidlType ZipType;
 
     ULONG64 CompressedSize;

--- a/dll/shellext/zipfldr/zippidl.hpp
+++ b/dll/shellext/zipfldr/zippidl.hpp
@@ -16,7 +16,7 @@ enum ZipPidlType
 #include <pshpack1.h>
 struct ZipPidlEntry
 {
-    WORD cb; // This must be a WORD for SHITEMID compatibility
+    WORD cb; // This must be a WORD to keep compatibility to SHITEMID
     BYTE MagicType;
     BOOLEAN Password;
     ZipPidlType ZipType;

--- a/dll/shellext/zipfldr/zippidl.hpp
+++ b/dll/shellext/zipfldr/zippidl.hpp
@@ -16,8 +16,8 @@ enum ZipPidlType
 #include <pshpack1.h>
 struct ZipPidlEntry
 {
-    size_t cb;
-    DWORD MagicType;
+    WORD cb;
+    WORD MagicType;
     ZipPidlType ZipType;
 
     ULONG64 CompressedSize;

--- a/dll/shellext/zipfldr/zippidl.hpp
+++ b/dll/shellext/zipfldr/zippidl.hpp
@@ -30,5 +30,5 @@ struct ZipPidlEntry
 #include <poppack.h>
 
 
-LPITEMIDLIST _ILCreate(ZipPidlType Type, LPCWSTR lpString, unz_file_info64& info);
+LPITEMIDLIST _ILCreate(ZipPidlType Type, PCWSTR lpString, unz_file_info64& info);
 const ZipPidlEntry* _ZipFromIL(LPCITEMIDLIST pidl);

--- a/dll/shellext/zipfldr/zippidl.hpp
+++ b/dll/shellext/zipfldr/zippidl.hpp
@@ -16,7 +16,7 @@ enum ZipPidlType
 #include <pshpack1.h>
 struct ZipPidlEntry
 {
-    USHORT cb; // This must be a USHORT for SHITEMID compatibility
+    WORD cb; // This must be a WORD for SHITEMID compatibility
     WORD MagicType;
     ZipPidlType ZipType;
 
@@ -24,7 +24,6 @@ struct ZipPidlEntry
     ULONG64 UncompressedSize;
     ULONG DosDate;
     BYTE Password;
-    BYTE Utf8;
 
     WCHAR Name[1];
 };

--- a/dll/shellext/zipfldr/zippidl.hpp
+++ b/dll/shellext/zipfldr/zippidl.hpp
@@ -3,6 +3,7 @@
  * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
  * PURPOSE:     zip pidl handling
  * COPYRIGHT:   Copyright 2017 Mark Jansen (mark.jansen@reactos.org)
+ *              Copyright 2023 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
  */
 
 


### PR DESCRIPTION
## Purpose
A modern system should support UTF-8 for interoperability.
JIRA issue: [CORE-16668](https://jira.reactos.org/browse/CORE-16668)

## Proposed change

- Extend some Ansi strings to Wide strings. 
- Check the UTF-8 flag (`1 << 11`).
- If UTF-8, then use `CP_UTF8`.
- `s/LPCWSTR/PCWSTR/`.
- `s/LPWSTR/PWSTR/`.

## Screenshots

BEFORE:
![before](https://github.com/reactos/reactos/assets/2107452/f273117e-49ac-4c79-92df-3e3d4a8a4728)
AFTER:
![after1](https://github.com/reactos/reactos/assets/2107452/fe02a9ec-c2eb-45e9-bae7-bf0ee5e09af2)
AFTER:
![after2](https://github.com/reactos/reactos/assets/2107452/fef44361-5b33-4071-a797-2452458e94cb)

## TODO

- [x] Do tests.