### PR TITLE
[SHELL32] Add IDS_NEWITEMFORMAT and retry FCIDM_SHVIEW_NEW

### DIFF
--- a/dll/win32/shell32/CNewMenu.cpp
+++ b/dll/win32/shell32/CNewMenu.cpp
@@ -518,17 +518,14 @@ HRESULT CNewMenu::NewItemByCommand(SHELLNEW_ITEM *pItem, LPCWSTR wszPath)
 HRESULT CNewMenu::NewItemByNonCommand(SHELLNEW_ITEM *pItem, LPWSTR wszName,
                                       DWORD cchNameMax, LPCWSTR wszPath)
 {
-    WCHAR wszBuf[MAX_PATH];
-    WCHAR wszNewFile[MAX_PATH];
     BOOL bSuccess = TRUE;
 
-    if (!LoadStringW(shell32_hInstance, FCIDM_SHVIEW_NEW, wszBuf, _countof(wszBuf)))
-        return E_FAIL;
-
-    StringCchPrintfW(wszNewFile, _countof(wszNewFile), L"%s %s%s", wszBuf, pItem->pwszDesc, pItem->pwszExt);
+    CStringW strNewItem;
+    strNewItem.Format(IDS_NEWITEMFORMAT, pItem->pwszDesc);
+    strNewItem += pItem->pwszExt;
 
     /* Create the name of the new file */
-    if (!PathYetAnotherMakeUniqueName(wszName, wszPath, NULL, wszNewFile))
+    if (!PathYetAnotherMakeUniqueName(wszName, wszPath, NULL, strNewItem))
         return E_FAIL;
 
     /* Create new file */

--- a/dll/win32/shell32/lang/bg-BG.rc
+++ b/dll/win32/shell32/lang/bg-BG.rc
@@ -885,6 +885,7 @@ BEGIN
     IDS_NETWORKPLACE "Моята мрежа"
 
     IDS_NEWFOLDER "Нова папка"
+    IDS_NEWITEMFORMAT "New %s"
 
     IDS_DRIVE_FIXED "Местен диск"
     IDS_DRIVE_CDROM "КД четец"
@@ -901,7 +902,7 @@ BEGIN
 
     IDS_SHELL_ABOUT_AUTHORS "&Създатели"
     IDS_SHELL_ABOUT_BACK "< &Назад"
-    FCIDM_SHVIEW_NEW "Нови"
+    FCIDM_SHVIEW_NEW "Ne&w" /* A menu item with an ampersand */
     FCIDM_SHVIEW_NEWFOLDER "Нова &папка"
     FCIDM_SHVIEW_NEWLINK "Нова &връзка"
     IDS_FOLDER_OPTIONS "Настройки на папките"

--- a/dll/win32/shell32/lang/ca-ES.rc
+++ b/dll/win32/shell32/lang/ca-ES.rc
@@ -884,6 +884,7 @@ BEGIN
     IDS_NETWORKPLACE "My Network Places"
 
     IDS_NEWFOLDER "New Folder"
+    IDS_NEWITEMFORMAT "New %s"
 
     IDS_DRIVE_FIXED "Local Disk"
     IDS_DRIVE_CDROM "CD Drive"
@@ -900,7 +901,7 @@ BEGIN
 
     IDS_SHELL_ABOUT_AUTHORS "&Authors"
     IDS_SHELL_ABOUT_BACK "< &Back"
-    FCIDM_SHVIEW_NEW "New"
+    FCIDM_SHVIEW_NEW "Ne&w" /* A menu item with an ampersand */
     FCIDM_SHVIEW_NEWFOLDER "New &Folder"
     FCIDM_SHVIEW_NEWLINK "New &Link"
     IDS_FOLDER_OPTIONS "Folder Options"

--- a/dll/win32/shell32/lang/cs-CZ.rc
+++ b/dll/win32/shell32/lang/cs-CZ.rc
@@ -907,7 +907,7 @@ BEGIN
 
     IDS_SHELL_ABOUT_AUTHORS "&Autoři"
     IDS_SHELL_ABOUT_BACK "< &Zpět"
-    FCIDM_SHVIEW_NEW "Ne&w" /* A menu item with an ampersand */
+    FCIDM_SHVIEW_NEW "&Nový" /* A menu item with an ampersand */
     FCIDM_SHVIEW_NEWFOLDER "Nová &složka"
     FCIDM_SHVIEW_NEWLINK "Nový &zástupce"
     IDS_FOLDER_OPTIONS "Možnosti složky"

--- a/dll/win32/shell32/lang/cs-CZ.rc
+++ b/dll/win32/shell32/lang/cs-CZ.rc
@@ -890,6 +890,7 @@ BEGIN
     IDS_NETWORKPLACE "Místa v síti"
 
     IDS_NEWFOLDER "Nová složka"
+    IDS_NEWITEMFORMAT "New %s"
 
     IDS_DRIVE_FIXED "Místní disk"
     IDS_DRIVE_CDROM "Jednotka CD"
@@ -906,7 +907,7 @@ BEGIN
 
     IDS_SHELL_ABOUT_AUTHORS "&Autoři"
     IDS_SHELL_ABOUT_BACK "< &Zpět"
-    FCIDM_SHVIEW_NEW "&Nový"
+    FCIDM_SHVIEW_NEW "Ne&w" /* A menu item with an ampersand */
     FCIDM_SHVIEW_NEWFOLDER "Nová &složka"
     FCIDM_SHVIEW_NEWLINK "Nový &zástupce"
     IDS_FOLDER_OPTIONS "Možnosti složky"

--- a/dll/win32/shell32/lang/da-DK.rc
+++ b/dll/win32/shell32/lang/da-DK.rc
@@ -890,6 +890,7 @@ BEGIN
     IDS_NETWORKPLACE "My Network Places"
 
     IDS_NEWFOLDER "Ny Mappe"
+    IDS_NEWITEMFORMAT "New %s"
 
     IDS_DRIVE_FIXED "Local Disk"
     IDS_DRIVE_CDROM "CD Drive"
@@ -906,7 +907,7 @@ BEGIN
 
     IDS_SHELL_ABOUT_AUTHORS "&Authors"
     IDS_SHELL_ABOUT_BACK "< &Back"
-    FCIDM_SHVIEW_NEW "Ny"
+    FCIDM_SHVIEW_NEW "Ne&w" /* A menu item with an ampersand */
     FCIDM_SHVIEW_NEWFOLDER "Ny &Mappe"
     FCIDM_SHVIEW_NEWLINK "Nyt &Link"
     IDS_FOLDER_OPTIONS "Folder Options"

--- a/dll/win32/shell32/lang/de-DE.rc
+++ b/dll/win32/shell32/lang/de-DE.rc
@@ -885,6 +885,7 @@ BEGIN
     IDS_NETWORKPLACE "Netzwerkumgebung"
 
     IDS_NEWFOLDER "Neuer Ordner"
+    IDS_NEWITEMFORMAT "New %s"
 
     IDS_DRIVE_FIXED "Lokaler Datenträger"
     IDS_DRIVE_CDROM "CD-Laufwerk"
@@ -901,7 +902,7 @@ BEGIN
 
     IDS_SHELL_ABOUT_AUTHORS "&Autoren"
     IDS_SHELL_ABOUT_BACK "< &Zurück"
-    FCIDM_SHVIEW_NEW "Neu"
+    FCIDM_SHVIEW_NEW "Ne&w" /* A menu item with an ampersand */
     FCIDM_SHVIEW_NEWFOLDER "Neues Ver&zeichnis"
     FCIDM_SHVIEW_NEWLINK "Neuer Ver&weis"
     IDS_FOLDER_OPTIONS "Ordneroptionen"

--- a/dll/win32/shell32/lang/el-GR.rc
+++ b/dll/win32/shell32/lang/el-GR.rc
@@ -884,6 +884,7 @@ BEGIN
     IDS_NETWORKPLACE "My Network Places"
 
     IDS_NEWFOLDER "New Folder"
+    IDS_NEWITEMFORMAT "New %s"
 
     IDS_DRIVE_FIXED "Τοπικός δίσκος"
     IDS_DRIVE_CDROM "Μονάδα CD"
@@ -900,7 +901,7 @@ BEGIN
 
     IDS_SHELL_ABOUT_AUTHORS "&Προγραμματιστές"
     IDS_SHELL_ABOUT_BACK "< &Επιστροφή"
-    FCIDM_SHVIEW_NEW "Δημιουργία"
+    FCIDM_SHVIEW_NEW "Ne&w" /* A menu item with an ampersand */
     FCIDM_SHVIEW_NEWFOLDER "Νέος &Φάκελος"
     FCIDM_SHVIEW_NEWLINK "Νέα &Συντόμευση"
     IDS_FOLDER_OPTIONS "Folder Options"

--- a/dll/win32/shell32/lang/en-GB.rc
+++ b/dll/win32/shell32/lang/en-GB.rc
@@ -884,6 +884,7 @@ BEGIN
     IDS_NETWORKPLACE "My Network Places"
 
     IDS_NEWFOLDER "New Folder"
+    IDS_NEWITEMFORMAT "New %s"
 
     IDS_DRIVE_FIXED "Local Disk"
     IDS_DRIVE_CDROM "CD Drive"
@@ -900,7 +901,7 @@ BEGIN
 
     IDS_SHELL_ABOUT_AUTHORS "&Authors"
     IDS_SHELL_ABOUT_BACK "< &Back"
-    FCIDM_SHVIEW_NEW "New"
+    FCIDM_SHVIEW_NEW "Ne&w" /* A menu item with an ampersand */
     FCIDM_SHVIEW_NEWFOLDER "New &Folder"
     FCIDM_SHVIEW_NEWLINK "New &Link"
     IDS_FOLDER_OPTIONS "Folder Options"

--- a/dll/win32/shell32/lang/en-US.rc
+++ b/dll/win32/shell32/lang/en-US.rc
@@ -884,6 +884,7 @@ BEGIN
     IDS_NETWORKPLACE "My Network Places"
 
     IDS_NEWFOLDER "New Folder"
+    IDS_NEWITEMFORMAT "New %s"
 
     IDS_DRIVE_FIXED "Local Disk"
     IDS_DRIVE_CDROM "CD Drive"
@@ -900,7 +901,7 @@ BEGIN
 
     IDS_SHELL_ABOUT_AUTHORS "&Authors"
     IDS_SHELL_ABOUT_BACK "< &Back"
-    FCIDM_SHVIEW_NEW "New"
+    FCIDM_SHVIEW_NEW "Ne&w" /* A menu item with an ampersand */
     FCIDM_SHVIEW_NEWFOLDER "New &Folder"
     FCIDM_SHVIEW_NEWLINK "New &Link"
     IDS_FOLDER_OPTIONS "Folder Options"

--- a/dll/win32/shell32/lang/es-ES.rc
+++ b/dll/win32/shell32/lang/es-ES.rc
@@ -893,6 +893,7 @@ BEGIN
     IDS_NETWORKPLACE "Mis sitios de red"
 
     IDS_NEWFOLDER "Nueva carpeta"
+    IDS_NEWITEMFORMAT "New %s"
 
     IDS_DRIVE_FIXED "Disco local"
     IDS_DRIVE_CDROM "Unidad de CD"
@@ -909,7 +910,7 @@ BEGIN
 
     IDS_SHELL_ABOUT_AUTHORS "&Autores"
     IDS_SHELL_ABOUT_BACK "< A&trás"
-    FCIDM_SHVIEW_NEW "Nuevo"
+    FCIDM_SHVIEW_NEW "Ne&w" /* A menu item with an ampersand */
     FCIDM_SHVIEW_NEWFOLDER "Nueva &carpeta"
     FCIDM_SHVIEW_NEWLINK "Nuevo &acceso directo"
     IDS_FOLDER_OPTIONS "Opciones de carpeta"

--- a/dll/win32/shell32/lang/et-EE.rc
+++ b/dll/win32/shell32/lang/et-EE.rc
@@ -891,6 +891,7 @@ BEGIN
     IDS_NETWORKPLACE "Minu võrgukohad"
 
     IDS_NEWFOLDER "Uus kaust"
+    IDS_NEWITEMFORMAT "New %s"
 
     IDS_DRIVE_FIXED "Kohalik ketas"
     IDS_DRIVE_CDROM "CD-draiv"
@@ -907,7 +908,7 @@ BEGIN
 
     IDS_SHELL_ABOUT_AUTHORS "&Autorid"
     IDS_SHELL_ABOUT_BACK "< &Tagasi"
-    FCIDM_SHVIEW_NEW "Uus"
+    FCIDM_SHVIEW_NEW "Ne&w" /* A menu item with an ampersand */
     FCIDM_SHVIEW_NEWFOLDER "Uus &kaust"
     FCIDM_SHVIEW_NEWLINK "Uus &otsetee"
     IDS_FOLDER_OPTIONS "Kaustasuvandid"

--- a/dll/win32/shell32/lang/eu-ES.rc
+++ b/dll/win32/shell32/lang/eu-ES.rc
@@ -889,6 +889,7 @@ BEGIN
     IDS_NETWORKPLACE "Nire sarelekuak"
 
     IDS_NEWFOLDER "Karpeta berria"
+    IDS_NEWITEMFORMAT "New %s"
 
     IDS_DRIVE_FIXED "Disko lokala"
     IDS_DRIVE_CDROM "CD Unitatea"
@@ -905,7 +906,7 @@ BEGIN
 
     IDS_SHELL_ABOUT_AUTHORS "&Egileak"
     IDS_SHELL_ABOUT_BACK "< A&tzea"
-    FCIDM_SHVIEW_NEW "Berria"
+    FCIDM_SHVIEW_NEW "Ne&w" /* A menu item with an ampersand */
     FCIDM_SHVIEW_NEWFOLDER "Karpeta &berria"
     FCIDM_SHVIEW_NEWLINK "&Lasterbide berria"
     IDS_FOLDER_OPTIONS "Karpeta aukera"

--- a/dll/win32/shell32/lang/fi-FI.rc
+++ b/dll/win32/shell32/lang/fi-FI.rc
@@ -884,6 +884,7 @@ BEGIN
     IDS_NETWORKPLACE "My Network Places"
 
     IDS_NEWFOLDER "New Folder"
+    IDS_NEWITEMFORMAT "New %s"
 
     IDS_DRIVE_FIXED "Local Disk"
     IDS_DRIVE_CDROM "CD Drive"
@@ -900,7 +901,7 @@ BEGIN
 
     IDS_SHELL_ABOUT_AUTHORS "&Authors"
     IDS_SHELL_ABOUT_BACK "< &Back"
-    FCIDM_SHVIEW_NEW "Uusi"
+    FCIDM_SHVIEW_NEW "Ne&w" /* A menu item with an ampersand */
     FCIDM_SHVIEW_NEWFOLDER "Uusi &Kansio"
     FCIDM_SHVIEW_NEWLINK "Uusi &Linkki"
     IDS_FOLDER_OPTIONS "Folder Options"

--- a/dll/win32/shell32/lang/fr-FR.rc
+++ b/dll/win32/shell32/lang/fr-FR.rc
@@ -884,6 +884,7 @@ BEGIN
     IDS_NETWORKPLACE "Mes emplacements réseau"
 
     IDS_NEWFOLDER "Nouveau dossier"
+    IDS_NEWITEMFORMAT "New %s"
 
     IDS_DRIVE_FIXED "Disque local"
     IDS_DRIVE_CDROM "Lecteur CD"
@@ -900,7 +901,7 @@ BEGIN
 
     IDS_SHELL_ABOUT_AUTHORS "&Auteurs"
     IDS_SHELL_ABOUT_BACK "< Précédent"
-    FCIDM_SHVIEW_NEW "Nouveau"
+    FCIDM_SHVIEW_NEW "Ne&w" /* A menu item with an ampersand */
     FCIDM_SHVIEW_NEWFOLDER "Nouveau d&ossier"
     FCIDM_SHVIEW_NEWLINK "Nouveau &lien"
     IDS_FOLDER_OPTIONS "Options du dossier"

--- a/dll/win32/shell32/lang/he-IL.rc
+++ b/dll/win32/shell32/lang/he-IL.rc
@@ -886,6 +886,7 @@ BEGIN
     IDS_NETWORKPLACE "מיקומי הרשת שלי"
 
     IDS_NEWFOLDER "תיקיה חדשה"
+    IDS_NEWITEMFORMAT "New %s"
 
     IDS_DRIVE_FIXED "כונן מקומי"
     IDS_DRIVE_CDROM "כונן CD"
@@ -902,7 +903,7 @@ BEGIN
 
     IDS_SHELL_ABOUT_AUTHORS "&יוצרים"
     IDS_SHELL_ABOUT_BACK "< &חזרה"
-    FCIDM_SHVIEW_NEW "חדש"
+    FCIDM_SHVIEW_NEW "Ne&w" /* A menu item with an ampersand */
     FCIDM_SHVIEW_NEWFOLDER "תיקיה חדשה"
     FCIDM_SHVIEW_NEWLINK "&קישור חדש"
     IDS_FOLDER_OPTIONS "אפשרויות תיקיה"

--- a/dll/win32/shell32/lang/hi-IN.rc
+++ b/dll/win32/shell32/lang/hi-IN.rc
@@ -879,6 +879,7 @@ BEGIN
     IDS_NETWORKPLACE "मेरे नेटवर्क स्थान"
 
     IDS_NEWFOLDER "नया फोल्डर"
+    IDS_NEWITEMFORMAT "New %s"
 
     IDS_DRIVE_FIXED "लोकल डिस्क"
     IDS_DRIVE_CDROM "सीडी ड्राइव"
@@ -895,7 +896,7 @@ BEGIN
 
     IDS_SHELL_ABOUT_AUTHORS "&ऑथर"
     IDS_SHELL_ABOUT_BACK "< &पीछे"
-    FCIDM_SHVIEW_NEW "नया"
+    FCIDM_SHVIEW_NEW "Ne&w" /* A menu item with an ampersand */
     FCIDM_SHVIEW_NEWFOLDER "नया &फोल्डर"
     FCIDM_SHVIEW_NEWLINK "नया &लिंक"
     IDS_FOLDER_OPTIONS "फोल्डर विकल्प"

--- a/dll/win32/shell32/lang/hu-HU.rc
+++ b/dll/win32/shell32/lang/hu-HU.rc
@@ -883,6 +883,7 @@ BEGIN
     IDS_NETWORKPLACE "Hálózati helyek"
 
     IDS_NEWFOLDER "Új mappa"
+    IDS_NEWITEMFORMAT "New %s"
 
     IDS_DRIVE_FIXED "Helyi lemez"
     IDS_DRIVE_CDROM "CD-meghajtó"
@@ -899,7 +900,7 @@ BEGIN
 
     IDS_SHELL_ABOUT_AUTHORS "&Készítők"
     IDS_SHELL_ABOUT_BACK "< &Vissza"
-    FCIDM_SHVIEW_NEW "Új"
+    FCIDM_SHVIEW_NEW "Ne&w" /* A menu item with an ampersand */
     FCIDM_SHVIEW_NEWFOLDER "&Mappa"
     FCIDM_SHVIEW_NEWLINK "&Parancsikon"
     IDS_FOLDER_OPTIONS "Mappabeállítások"

--- a/dll/win32/shell32/lang/id-ID.rc
+++ b/dll/win32/shell32/lang/id-ID.rc
@@ -881,6 +881,7 @@ BEGIN
     IDS_NETWORKPLACE "Tempat Jaringan Saya"
 
     IDS_NEWFOLDER "Folder Baru"
+    IDS_NEWITEMFORMAT "New %s"
 
     IDS_DRIVE_FIXED "Disk Lokal"
     IDS_DRIVE_CDROM "CD Drive"
@@ -897,7 +898,7 @@ BEGIN
 
     IDS_SHELL_ABOUT_AUTHORS "Peng&arang"
     IDS_SHELL_ABOUT_BACK "< Kem&bali"
-    FCIDM_SHVIEW_NEW "Baru"
+    FCIDM_SHVIEW_NEW "Ne&w" /* A menu item with an ampersand */
     FCIDM_SHVIEW_NEWFOLDER "&Folder Baru"
     FCIDM_SHVIEW_NEWLINK "&Tautan Baru"
     IDS_FOLDER_OPTIONS "Opsi Folder"

--- a/dll/win32/shell32/lang/it-IT.rc
+++ b/dll/win32/shell32/lang/it-IT.rc
@@ -884,6 +884,7 @@ BEGIN
     IDS_NETWORKPLACE "Risorse di rete"
 
     IDS_NEWFOLDER "Nuova cartella"
+    IDS_NEWITEMFORMAT "New %s"
 
     IDS_DRIVE_FIXED "Disco locale"
     IDS_DRIVE_CDROM "CD Drive"
@@ -900,7 +901,7 @@ BEGIN
 
     IDS_SHELL_ABOUT_AUTHORS "&Autori"
     IDS_SHELL_ABOUT_BACK "< &Indietro"
-    FCIDM_SHVIEW_NEW "Nuovo"
+    FCIDM_SHVIEW_NEW "Ne&w" /* A menu item with an ampersand */
     FCIDM_SHVIEW_NEWFOLDER "Nuova &Cartella"
     FCIDM_SHVIEW_NEWLINK "Nuovo &Collegamento"
     IDS_FOLDER_OPTIONS "Opzioni della cartella"

--- a/dll/win32/shell32/lang/ja-JP.rc
+++ b/dll/win32/shell32/lang/ja-JP.rc
@@ -881,6 +881,7 @@ BEGIN
     IDS_NETWORKPLACE "マイ ネットワーク"
 
     IDS_NEWFOLDER "新しいフォルダ"
+    IDS_NEWITEMFORMAT "新しい%s"
 
     IDS_DRIVE_FIXED "ローカル ディスク"
     IDS_DRIVE_CDROM "CDドライブ"
@@ -897,7 +898,7 @@ BEGIN
 
     IDS_SHELL_ABOUT_AUTHORS "制作者(&A)"
     IDS_SHELL_ABOUT_BACK "< 戻る(&B)"
-    FCIDM_SHVIEW_NEW "新規作成"
+    FCIDM_SHVIEW_NEW "新規作成(&W)"
     FCIDM_SHVIEW_NEWFOLDER "フォルダ(&F)"
     FCIDM_SHVIEW_NEWLINK "ショートカット(&L)"
     IDS_FOLDER_OPTIONS "フォルダ オプション"

--- a/dll/win32/shell32/lang/ko-KR.rc
+++ b/dll/win32/shell32/lang/ko-KR.rc
@@ -891,6 +891,7 @@ BEGIN
     IDS_NETWORKPLACE "내 네트워크 환경"
 
     IDS_NEWFOLDER "New Folder"
+    IDS_NEWITEMFORMAT "New %s"
 
     IDS_DRIVE_FIXED "로컬 디스크"
     IDS_DRIVE_CDROM "CD 드라이브"
@@ -907,7 +908,7 @@ BEGIN
 
     IDS_SHELL_ABOUT_AUTHORS "&Authors"
     IDS_SHELL_ABOUT_BACK "< &Back"
-    FCIDM_SHVIEW_NEW "New"
+    FCIDM_SHVIEW_NEW "Ne&w" /* A menu item with an ampersand */
     FCIDM_SHVIEW_NEWFOLDER "New &Folder"
     FCIDM_SHVIEW_NEWLINK "New &Link"
     IDS_FOLDER_OPTIONS "폴더 옵션"

--- a/dll/win32/shell32/lang/nl-NL.rc
+++ b/dll/win32/shell32/lang/nl-NL.rc
@@ -884,6 +884,7 @@ BEGIN
     IDS_NETWORKPLACE "My Network Places"
 
     IDS_NEWFOLDER "New Folder"
+    IDS_NEWITEMFORMAT "New %s"
 
     IDS_DRIVE_FIXED "Local Disk"
     IDS_DRIVE_CDROM "CD Drive"
@@ -900,7 +901,7 @@ BEGIN
 
     IDS_SHELL_ABOUT_AUTHORS "&Authors"
     IDS_SHELL_ABOUT_BACK "< &Back"
-    FCIDM_SHVIEW_NEW "New"
+    FCIDM_SHVIEW_NEW "Ne&w" /* A menu item with an ampersand */
     FCIDM_SHVIEW_NEWFOLDER "New &Folder"
     FCIDM_SHVIEW_NEWLINK "New &Link"
     IDS_FOLDER_OPTIONS "Folder Options"

--- a/dll/win32/shell32/lang/no-NO.rc
+++ b/dll/win32/shell32/lang/no-NO.rc
@@ -884,6 +884,7 @@ BEGIN
     IDS_NETWORKPLACE "Mine nettverkssteder"
 
     IDS_NEWFOLDER "Ny mappe"
+    IDS_NEWITEMFORMAT "New %s"
 
     IDS_DRIVE_FIXED "Lokal Disk"
     IDS_DRIVE_CDROM "CD stasjon"
@@ -900,7 +901,7 @@ BEGIN
 
     IDS_SHELL_ABOUT_AUTHORS "&Forfatter"
     IDS_SHELL_ABOUT_BACK "< &Tilbake"
-    FCIDM_SHVIEW_NEW "Ny"
+    FCIDM_SHVIEW_NEW "Ne&w" /* A menu item with an ampersand */
     FCIDM_SHVIEW_NEWFOLDER "Ny &mappe"
     FCIDM_SHVIEW_NEWLINK "Ny &snarvei"
     IDS_FOLDER_OPTIONS "Mappe valg"

--- a/dll/win32/shell32/lang/pl-PL.rc
+++ b/dll/win32/shell32/lang/pl-PL.rc
@@ -890,6 +890,7 @@ BEGIN
     IDS_NETWORKPLACE "Moje miejsca sieciowe"
 
     IDS_NEWFOLDER "Nowy folder"
+    IDS_NEWITEMFORMAT "New %s"
 
     IDS_DRIVE_FIXED "Dysk lokalny"
     IDS_DRIVE_CDROM "Stacja dysków CD"
@@ -906,7 +907,7 @@ BEGIN
 
     IDS_SHELL_ABOUT_AUTHORS "&Autorzy"
     IDS_SHELL_ABOUT_BACK "< &Wstecz"
-    FCIDM_SHVIEW_NEW "&Nowy"
+    FCIDM_SHVIEW_NEW "&Nowy" /* A menu item with an ampersand */
     FCIDM_SHVIEW_NEWFOLDER "&Folder"
     FCIDM_SHVIEW_NEWLINK "&Skrót"
     IDS_FOLDER_OPTIONS "Opcje folderów"

--- a/dll/win32/shell32/lang/pt-BR.rc
+++ b/dll/win32/shell32/lang/pt-BR.rc
@@ -884,6 +884,7 @@ BEGIN
     IDS_NETWORKPLACE "Meus Locais de Rede"
 
     IDS_NEWFOLDER "Nova Pasta"
+    IDS_NEWITEMFORMAT "New %s"
 
     IDS_DRIVE_FIXED "Disco Local"
     IDS_DRIVE_CDROM "CD Drive"
@@ -900,7 +901,7 @@ BEGIN
 
     IDS_SHELL_ABOUT_AUTHORS "&Autores"
     IDS_SHELL_ABOUT_BACK "< &Voltar"
-    FCIDM_SHVIEW_NEW "Novo"
+    FCIDM_SHVIEW_NEW "Ne&w" /* A menu item with an ampersand */
     FCIDM_SHVIEW_NEWFOLDER "&Pasta"
     FCIDM_SHVIEW_NEWLINK "&Atalho"
     IDS_FOLDER_OPTIONS "Opções de Pasta"

--- a/dll/win32/shell32/lang/pt-PT.rc
+++ b/dll/win32/shell32/lang/pt-PT.rc
@@ -883,6 +883,7 @@ BEGIN
     IDS_NETWORKPLACE "Os Meus Locais na Rede"
 
     IDS_NEWFOLDER "Nova Pasta"
+    IDS_NEWITEMFORMAT "New %s"
 
     IDS_DRIVE_FIXED "Disco Local"
     IDS_DRIVE_CDROM "CD Drive"
@@ -899,7 +900,7 @@ BEGIN
 
     IDS_SHELL_ABOUT_AUTHORS "&Autores"
     IDS_SHELL_ABOUT_BACK "< &Retroceder"
-    FCIDM_SHVIEW_NEW "Novo"
+    FCIDM_SHVIEW_NEW "Ne&w" /* A menu item with an ampersand */
     FCIDM_SHVIEW_NEWFOLDER "&Pasta"
     FCIDM_SHVIEW_NEWLINK "&Atalho"
     IDS_FOLDER_OPTIONS "Opções das Pastas"

--- a/dll/win32/shell32/lang/ro-RO.rc
+++ b/dll/win32/shell32/lang/ro-RO.rc
@@ -887,6 +887,7 @@ BEGIN
     IDS_NETWORKPLACE "Locații în rețea"
 
     IDS_NEWFOLDER "Dosar nou"
+    IDS_NEWITEMFORMAT "New %s"
 
     IDS_DRIVE_FIXED "Disc local"
     IDS_DRIVE_CDROM "Unitate CD"
@@ -903,7 +904,7 @@ BEGIN
 
     IDS_SHELL_ABOUT_AUTHORS "&Autori"
     IDS_SHELL_ABOUT_BACK "< Înap&oi"
-    FCIDM_SHVIEW_NEW "&Crează"
+    FCIDM_SHVIEW_NEW "&Crează" /* A menu item with an ampersand */
     FCIDM_SHVIEW_NEWFOLDER "&Dosar"
     FCIDM_SHVIEW_NEWLINK "Sc&urtătură"
     IDS_FOLDER_OPTIONS "Opțiuni dosare"

--- a/dll/win32/shell32/lang/ru-RU.rc
+++ b/dll/win32/shell32/lang/ru-RU.rc
@@ -891,6 +891,7 @@ BEGIN
     IDS_NETWORKPLACE "Сетевое окружение"
 
     IDS_NEWFOLDER "Новая папка"
+    IDS_NEWITEMFORMAT "New %s"
 
     IDS_DRIVE_FIXED "Локальный диск"
     IDS_DRIVE_CDROM "CD-дисковод"
@@ -907,7 +908,7 @@ BEGIN
 
     IDS_SHELL_ABOUT_AUTHORS "&Авторы"
     IDS_SHELL_ABOUT_BACK "< &Назад"
-    FCIDM_SHVIEW_NEW "Создать"
+    FCIDM_SHVIEW_NEW "Ne&w" /* A menu item with an ampersand */
     FCIDM_SHVIEW_NEWFOLDER "&Папка"
     FCIDM_SHVIEW_NEWLINK "&Ярлык"
     IDS_FOLDER_OPTIONS "Свойства папки"

--- a/dll/win32/shell32/lang/sk-SK.rc
+++ b/dll/win32/shell32/lang/sk-SK.rc
@@ -884,6 +884,7 @@ BEGIN
     IDS_NETWORKPLACE "Miesta v sieti"
 
     IDS_NEWFOLDER "Nový priečinok"
+    IDS_NEWITEMFORMAT "New %s"
 
     IDS_DRIVE_FIXED "Lokálny disk"
     IDS_DRIVE_CDROM "Jednotka CD"
@@ -900,7 +901,7 @@ BEGIN
 
     IDS_SHELL_ABOUT_AUTHORS "&Autori"
     IDS_SHELL_ABOUT_BACK "< &Späť"
-    FCIDM_SHVIEW_NEW "&Nový"
+    FCIDM_SHVIEW_NEW "&Nový" /* A menu item with an ampersand */
     FCIDM_SHVIEW_NEWFOLDER "&Priečinok"
     FCIDM_SHVIEW_NEWLINK "&Odkaz"
     IDS_FOLDER_OPTIONS "Možnosti priečinka"

--- a/dll/win32/shell32/lang/sl-SI.rc
+++ b/dll/win32/shell32/lang/sl-SI.rc
@@ -884,6 +884,7 @@ BEGIN
     IDS_NETWORKPLACE "My Network Places"
 
     IDS_NEWFOLDER "New Folder"
+    IDS_NEWITEMFORMAT "New %s"
 
     IDS_DRIVE_FIXED "Local Disk"
     IDS_DRIVE_CDROM "CD Drive"
@@ -900,7 +901,7 @@ BEGIN
 
     IDS_SHELL_ABOUT_AUTHORS "&Authors"
     IDS_SHELL_ABOUT_BACK "< &Back"
-    FCIDM_SHVIEW_NEW "New"
+    FCIDM_SHVIEW_NEW "Ne&w" /* A menu item with an ampersand */
     FCIDM_SHVIEW_NEWFOLDER "New &Folder"
     FCIDM_SHVIEW_NEWLINK "New &Link"
     IDS_FOLDER_OPTIONS "Folder Options"

--- a/dll/win32/shell32/lang/sq-AL.rc
+++ b/dll/win32/shell32/lang/sq-AL.rc
@@ -888,6 +888,7 @@ BEGIN
     IDS_NETWORKPLACE "Vendi Rrjetit Tim"
 
     IDS_NEWFOLDER "Dosje e're"
+    IDS_NEWITEMFORMAT "New %s"
 
     IDS_DRIVE_FIXED "Disku Vendorë"
     IDS_DRIVE_CDROM "CD Drive"
@@ -904,7 +905,7 @@ BEGIN
 
     IDS_SHELL_ABOUT_AUTHORS "&Autorët"
     IDS_SHELL_ABOUT_BACK "< &Mbrapa"
-    FCIDM_SHVIEW_NEW "E're"
+    FCIDM_SHVIEW_NEW "Ne&w" /* A menu item with an ampersand */
     FCIDM_SHVIEW_NEWFOLDER "&Dosje E're"
     FCIDM_SHVIEW_NEWLINK "&Lidhje e Re"
     IDS_FOLDER_OPTIONS "Opsione Dosje"

--- a/dll/win32/shell32/lang/sv-SE.rc
+++ b/dll/win32/shell32/lang/sv-SE.rc
@@ -884,6 +884,7 @@ BEGIN
     IDS_NETWORKPLACE "Mina nätverksplatser"
 
     IDS_NEWFOLDER "Ny mapp"
+    IDS_NEWITEMFORMAT "New %s"
 
     IDS_DRIVE_FIXED "Lokal disk"
     IDS_DRIVE_CDROM "CD-enhet"
@@ -900,7 +901,7 @@ BEGIN
 
     IDS_SHELL_ABOUT_AUTHORS "&Upphovsinformation"
     IDS_SHELL_ABOUT_BACK "< &Bakåt"
-    FCIDM_SHVIEW_NEW "Ny(tt)"
+    FCIDM_SHVIEW_NEW "Ne&w" /* A menu item with an ampersand */
     FCIDM_SHVIEW_NEWFOLDER "Ny &mapp"
     FCIDM_SHVIEW_NEWLINK "Ny &genväg"
     IDS_FOLDER_OPTIONS "Mappalternativ"

--- a/dll/win32/shell32/lang/tr-TR.rc
+++ b/dll/win32/shell32/lang/tr-TR.rc
@@ -886,6 +886,7 @@ BEGIN
     IDS_NETWORKPLACE "Ağ Bağlantılarım"
 
     IDS_NEWFOLDER "Yeni Dizin"
+    IDS_NEWITEMFORMAT "New %s"
 
     IDS_DRIVE_FIXED "Yerel Disk"
     IDS_DRIVE_CDROM "CD-ROM"
@@ -902,7 +903,7 @@ BEGIN
 
     IDS_SHELL_ABOUT_AUTHORS "&Yazarlar"
     IDS_SHELL_ABOUT_BACK "< &Geri"
-    FCIDM_SHVIEW_NEW "Yeni"
+    FCIDM_SHVIEW_NEW "Ne&w" /* A menu item with an ampersand */
     FCIDM_SHVIEW_NEWFOLDER "Yeni &Dizin"
     FCIDM_SHVIEW_NEWLINK "Yeni &Kısayol"
     IDS_FOLDER_OPTIONS "Dizin Seçenekleri"

--- a/dll/win32/shell32/lang/uk-UA.rc
+++ b/dll/win32/shell32/lang/uk-UA.rc
@@ -884,6 +884,7 @@ BEGIN
     IDS_NETWORKPLACE "Мережне оточення"
 
     IDS_NEWFOLDER "Нова папка"
+    IDS_NEWITEMFORMAT "New %s"
 
     IDS_DRIVE_FIXED "Локальний диск"
     IDS_DRIVE_CDROM "Привід компакт-дисків"
@@ -900,7 +901,7 @@ BEGIN
 
     IDS_SHELL_ABOUT_AUTHORS "&Автори"
     IDS_SHELL_ABOUT_BACK "< &Назад"
-    FCIDM_SHVIEW_NEW "Створити"
+    FCIDM_SHVIEW_NEW "Ne&w" /* A menu item with an ampersand */
     FCIDM_SHVIEW_NEWFOLDER "&Папку"
     FCIDM_SHVIEW_NEWLINK "&Ярлик"
     IDS_FOLDER_OPTIONS "Властивості папки"

--- a/dll/win32/shell32/lang/zh-CN.rc
+++ b/dll/win32/shell32/lang/zh-CN.rc
@@ -911,7 +911,7 @@ BEGIN
 
     IDS_SHELL_ABOUT_AUTHORS "作者(&A)"
     IDS_SHELL_ABOUT_BACK "< 返回(&B)"
-    FCIDM_SHVIEW_NEW "Ne&w" /* A menu item with an ampersand */
+    FCIDM_SHVIEW_NEW "新建(&W)" /* A menu item with an ampersand */
     FCIDM_SHVIEW_NEWFOLDER "文件夹(&F)"
     FCIDM_SHVIEW_NEWLINK "快捷方式(&L)"
     IDS_FOLDER_OPTIONS "文件夹选项"

--- a/dll/win32/shell32/lang/zh-CN.rc
+++ b/dll/win32/shell32/lang/zh-CN.rc
@@ -894,6 +894,7 @@ BEGIN
     IDS_NETWORKPLACE "网上邻居"
 
     IDS_NEWFOLDER "新建文件夹"
+    IDS_NEWITEMFORMAT "New %s"
 
     IDS_DRIVE_FIXED "本地磁盘"
     IDS_DRIVE_CDROM "光盘驱动器"
@@ -910,7 +911,7 @@ BEGIN
 
     IDS_SHELL_ABOUT_AUTHORS "作者(&A)"
     IDS_SHELL_ABOUT_BACK "< 返回(&B)"
-    FCIDM_SHVIEW_NEW "新建"
+    FCIDM_SHVIEW_NEW "Ne&w" /* A menu item with an ampersand */
     FCIDM_SHVIEW_NEWFOLDER "文件夹(&F)"
     FCIDM_SHVIEW_NEWLINK "快捷方式(&L)"
     IDS_FOLDER_OPTIONS "文件夹选项"

--- a/dll/win32/shell32/lang/zh-HK.rc
+++ b/dll/win32/shell32/lang/zh-HK.rc
@@ -909,7 +909,7 @@ BEGIN
 
     IDS_SHELL_ABOUT_AUTHORS "作者(&A)"
     IDS_SHELL_ABOUT_BACK "< 返回(&B)"
-    FCIDM_SHVIEW_NEW "Ne&w" /* A menu item with an ampersand */
+    FCIDM_SHVIEW_NEW "新增(&W)" /* A menu item with an ampersand */
     FCIDM_SHVIEW_NEWFOLDER "新增資料夾(&F)"
     FCIDM_SHVIEW_NEWLINK "新增捷徑(&L)"
     IDS_FOLDER_OPTIONS "資料夾選項"

--- a/dll/win32/shell32/lang/zh-HK.rc
+++ b/dll/win32/shell32/lang/zh-HK.rc
@@ -892,6 +892,7 @@ BEGIN
     IDS_NETWORKPLACE "網絡上的芳鄰"
 
     IDS_NEWFOLDER "新資料夾"
+    IDS_NEWITEMFORMAT "New %s"
 
     IDS_DRIVE_FIXED "本機磁碟"
     IDS_DRIVE_CDROM "CD 光碟機"
@@ -908,7 +909,7 @@ BEGIN
 
     IDS_SHELL_ABOUT_AUTHORS "作者(&A)"
     IDS_SHELL_ABOUT_BACK "< 返回(&B)"
-    FCIDM_SHVIEW_NEW "新增"
+    FCIDM_SHVIEW_NEW "Ne&w" /* A menu item with an ampersand */
     FCIDM_SHVIEW_NEWFOLDER "新增資料夾(&F)"
     FCIDM_SHVIEW_NEWLINK "新增捷徑(&L)"
     IDS_FOLDER_OPTIONS "資料夾選項"

--- a/dll/win32/shell32/lang/zh-TW.rc
+++ b/dll/win32/shell32/lang/zh-TW.rc
@@ -893,6 +893,7 @@ BEGIN
     IDS_NETWORKPLACE "網路上的芳鄰"
 
     IDS_NEWFOLDER "新資料夾"
+    IDS_NEWITEMFORMAT "New %s"
 
     IDS_DRIVE_FIXED "本機磁碟"
     IDS_DRIVE_CDROM "CD 光碟機"
@@ -909,7 +910,7 @@ BEGIN
 
     IDS_SHELL_ABOUT_AUTHORS "作者(&A)"
     IDS_SHELL_ABOUT_BACK "< 上一步(&B)"
-    FCIDM_SHVIEW_NEW "新增"
+    FCIDM_SHVIEW_NEW "Ne&w" /* A menu item with an ampersand */
     FCIDM_SHVIEW_NEWFOLDER "新增資料夾(&F)"
     FCIDM_SHVIEW_NEWLINK "新增捷徑(&L)"
     IDS_FOLDER_OPTIONS "資料夾選項"

--- a/dll/win32/shell32/lang/zh-TW.rc
+++ b/dll/win32/shell32/lang/zh-TW.rc
@@ -910,7 +910,7 @@ BEGIN
 
     IDS_SHELL_ABOUT_AUTHORS "作者(&A)"
     IDS_SHELL_ABOUT_BACK "< 上一步(&B)"
-    FCIDM_SHVIEW_NEW "Ne&w" /* A menu item with an ampersand */
+    FCIDM_SHVIEW_NEW "新增(&W)" /* A menu item with an ampersand */
     FCIDM_SHVIEW_NEWFOLDER "新增資料夾(&F)"
     FCIDM_SHVIEW_NEWLINK "新增捷徑(&L)"
     IDS_FOLDER_OPTIONS "資料夾選項"

--- a/dll/win32/shell32/shresdef.h
+++ b/dll/win32/shell32/shresdef.h
@@ -140,6 +140,7 @@
 #define FCIDM_SHVIEW_NEW          146
 #define IDS_CONTROLPANEL          148
 #define IDS_NEWFOLDER             149
+#define IDS_NEWITEMFORMAT         150
 #define IDS_COLUMN_EXTENSION      151
 #define IDS_NO_EXTENSION          152
 #define IDS_RECYCLEBIN_LOCATION   153


### PR DESCRIPTION
## Purpose

The `FCIDM_SHVIEW_NEW` resource string has some problems in localization and keyboard usability.
JIRA issue: [CORE-18706](https://jira.reactos.org/browse/CORE-18706)

## Proposed changes

- Add `IDS_NEWITEMFORMAT` resource string (`"New %s"`) to format the new file item string.
- Modify `CNewMenu::NewItemByNonCommand` for `IDS_NEWITEMFORMAT`.
- `FCIDM_SHVIEW_NEW` is provided for `[New]` menu item, so it should have an ampersand. Add a comment for it and then retry the translation.

## TODO

- [x] Do build.
- [x] Do tests.