### PR TITLE
[BROWSEUI] Discard pidlLastParsed on address edit box WM_NOTIFY. CORE-19019

### DIFF
--- a/dll/win32/browseui/addresseditbox.cpp
+++ b/dll/win32/browseui/addresseditbox.cpp
@@ -291,14 +291,7 @@ HRESULT STDMETHODCALLTYPE CAddressEditBox::Execute(long paramC)
         if (hr == HRESULT_FROM_WIN32(ERROR_INVALID_DRIVE) || hr == HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND))
         {
             if (ExecuteCommandLine())
-            {
-                if (pidlLastParsed)
-                {
-                    ILFree(pidlLastParsed);
-                    pidlLastParsed = NULL;
-                }
                 return S_OK;
-            }
 
             return ShowFileNotFoundError(hr);
         }

--- a/dll/win32/browseui/addresseditbox.cpp
+++ b/dll/win32/browseui/addresseditbox.cpp
@@ -291,7 +291,14 @@ HRESULT STDMETHODCALLTYPE CAddressEditBox::Execute(long paramC)
         if (hr == HRESULT_FROM_WIN32(ERROR_INVALID_DRIVE) || hr == HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND))
         {
             if (ExecuteCommandLine())
+            {
+                if (pidlLastParsed)
+                {
+                    ILFree(pidlLastParsed);
+                    pidlLastParsed = NULL;
+                }
                 return S_OK;
+            }
 
             return ShowFileNotFoundError(hr);
         }
@@ -386,6 +393,13 @@ HRESULT STDMETHODCALLTYPE CAddressEditBox::OnWinEvent(
             if (hdr->code == CBEN_ENDEDIT)
             {
                 NMCBEENDEDITW *endEdit = (NMCBEENDEDITW*) lParam;
+
+                if (pidlLastParsed)
+                {
+                    ILFree(pidlLastParsed);
+                    pidlLastParsed = NULL;
+                }
+
                 if (endEdit->iWhy == CBENF_RETURN)
                 {
                     Execute(0);


### PR DESCRIPTION
## Purpose

Fix address edit box breaking when the same path is navigated two times in a row.

JIRA issue: [CORE-19019](https://jira.reactos.org/browse/CORE-19019)

## Proposed changes

Discard `pidlLastParsed` on edit box WM_NOTIFY message.

## TODO

- [ ] Do more testing 
- [ ] Investigate why `pidlLastParsed` is not freed before getting overwritten in some places in the code (potential memory leak?)
