### PR TITLE
[NTOS:IO] Implement IoConnectInterruptEx for fully specific interrupt types

### DIFF
--- a/ntoskrnl/ntoskrnl.spec
+++ b/ntoskrnl/ntoskrnl.spec
@@ -362,6 +362,7 @@
 @ stdcall IoCheckShareAccess(long long ptr ptr long)
 @ stdcall IoCompleteRequest(ptr long)
 @ stdcall IoConnectInterrupt(ptr ptr ptr ptr long long long long long long long)
+@ stdcall -version=0x600+ IoConnectInterruptEx(ptr)
 @ stdcall IoCreateController(long)
 @ stdcall IoCreateDevice(ptr long ptr long long long ptr)
 @ stdcall IoCreateDisk(ptr ptr)
@@ -390,6 +391,7 @@
 @ extern IoDeviceHandlerObjectType
 @ extern IoDeviceObjectType
 @ stdcall IoDisconnectInterrupt(ptr)
+@ stdcall -version=0x600+ IoDisconnectInterruptEx(ptr)
 @ extern IoDriverObjectType
 @ stdcall IoEnqueueIrp(ptr)
 @ stdcall IoEnumerateDeviceObjectList(ptr ptr long ptr)


### PR DESCRIPTION
## Purpose

This gives ReactOS the ability to load various modern drivers that use IoConnectInterruptEx

various drivers work after this such as the serial.sys sample driver from MS and many more KMDF drivers from later windows versions

## Proposed changes

- IoConnectInterruptEx for CONNECT_FULLY_SPECIFIED

