### PR TITLE
[SHELL32] Update the status bar asynchronously

### DIFF
--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -173,7 +173,7 @@ class CDefView :
         HRESULT IncludeObject(PCUITEMID_CHILD pidl);
         HRESULT OnDefaultCommand();
         HRESULT OnStateChange(UINT uFlags);
-        static unsigned __stdcall UpdateStatusbarProc(void *args);
+        static unsigned __stdcall _UpdateStatusbarProc(void *args);
         void UpdateStatusbarWorker(HANDLE hThread);
         void UpdateStatusbar();
         void CheckToolbar();
@@ -625,7 +625,7 @@ void CDefView::UpdateStatusbarWorker(HANDLE hThread)
     }
 }
 
-unsigned __stdcall CDefView::UpdateStatusbarProc(void *args)
+unsigned __stdcall CDefView::_UpdateStatusbarProc(void *args)
 {
     CDefView* pView = static_cast<CDefView*>(args);
     pView->UpdateStatusbarWorker(pView->m_hUpdateStatusbarThread);
@@ -639,7 +639,7 @@ void CDefView::UpdateStatusbar()
     // We have to initialize m_hUpdateStatusbarThread before the thread starts up.
     // Thus, we use CREATE_SUSPENDED.
     m_hUpdateStatusbarThread =
-        reinterpret_cast<HANDLE>(_beginthreadex(NULL, 0, UpdateStatusbarProc, this,
+        reinterpret_cast<HANDLE>(_beginthreadex(NULL, 0, _UpdateStatusbarProc, this,
                                                 CREATE_SUSPENDED, NULL));
     ::ResumeThread(m_hUpdateStatusbarThread);
 

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -545,7 +545,7 @@ void CDefView::CheckToolbar()
 
 void CDefView::UpdateStatusbarWorker(HANDLE hThread)
 {
-    WCHAR szFormat[MAX_PATH], szPartText[MAX_PATH], szPartText2[MAX_PATH];
+    WCHAR szFormat[MAX_PATH], szPartText[MAX_PATH];
     UINT cSelectedItems;
 
     cSelectedItems = m_ListView.GetSelectedCount();
@@ -591,29 +591,24 @@ void CDefView::UpdateStatusbarWorker(HANDLE hThread)
             }
         }
 
-        szPartText[0] = szPartText2[0] = UNICODE_NULL;
-
         /* Don't show the file size text if there is 0 bytes in the folder
          * OR we only have folders selected. */
+        szPartText[0] = UNICODE_NULL;
         if ((cSelectedItems && !bIsOnlyFoldersSelected) || uTotalFileSize)
             StrFormatByteSizeW(uTotalFileSize, szPartText, _countof(szPartText));
 
-        if (hThread != m_hUpdateStatusbarThread)
-            return;
+        m_pShellBrowser->SendControlMsg(FCW_STATUS, SB_SETTEXT, 1, (LPARAM)szPartText, &lResult);
 
         /* If we are in a Recycle Bin folder then show no text for the location part. */
+        szPartText[0] = UNICODE_NULL;
         if (!_ILIsBitBucket(m_pidlParent))
         {
-            LoadStringW(shell32_hInstance, IDS_MYCOMPUTER, szPartText2, _countof(szPartText2));
+            LoadStringW(shell32_hInstance, IDS_MYCOMPUTER, szPartText, _countof(szPartText));
             pIcon = (LPARAM)m_hMyComputerIcon;
         }
 
-        if (hThread != m_hUpdateStatusbarThread)
-            return;
-
-        m_pShellBrowser->SendControlMsg(FCW_STATUS, SB_SETTEXT, 1, (LPARAM)szPartText, &lResult);
         m_pShellBrowser->SendControlMsg(FCW_STATUS, SB_SETICON, 2, pIcon, &lResult);
-        m_pShellBrowser->SendControlMsg(FCW_STATUS, SB_SETTEXT, 2, (LPARAM)szPartText2, &lResult);
+        m_pShellBrowser->SendControlMsg(FCW_STATUS, SB_SETTEXT, 2, (LPARAM)szPartText, &lResult);
     }
 }
 

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -605,9 +605,6 @@ void CDefView::UpdateStatusbarWorker(HANDLE hThread)
             *szPartText = 0;
         }
 
-        if (hThread != m_hUpdateStatusbarThread)
-            return;
-
         m_pShellBrowser->SendControlMsg(FCW_STATUS, SB_SETTEXT, 1, (LPARAM)szPartText, &lResult);
 
         /* If we are in a Recycle Bin folder then show no text for the location part. */

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -175,7 +175,7 @@ class CDefView :
         HRESULT OnDefaultCommand();
         HRESULT OnStateChange(UINT uFlags);
         void UpdateStatusbarInner();
-        void UpdateStatusbarAsync();
+        void UpdateStatusbar();
         void CheckToolbar();
         BOOL CreateList();
         void UpdateListColors();
@@ -634,7 +634,7 @@ static unsigned __stdcall UpdateStatusProc(void *args)
     return 0;
 }
 
-void CDefView::UpdateStatusbarAsync()
+void CDefView::UpdateStatusbar()
 {
     HANDLE hOldThread = m_hUpdateStatusbarThread;
     m_hUpdateStatusbarThread = (HANDLE)_beginthreadex(NULL, 0, UpdateStatusProc, this, 0,
@@ -1334,7 +1334,7 @@ LRESULT CDefView::OnCreate(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandl
         _ForceStatusBarResize();
     }
 
-    UpdateStatusbarAsync();
+    UpdateStatusbar();
 
     return S_OK;
 }
@@ -1774,7 +1774,7 @@ LRESULT CDefView::OnSize(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled
     _DoFolderViewCB(SFVM_SIZE, 0, 0);
 
     _HandleStatusBarResize(wWidth);
-    UpdateStatusbarAsync();
+    UpdateStatusbar();
 
     return 0;
 }
@@ -2160,7 +2160,7 @@ LRESULT CDefView::OnNotify(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandl
         case LVN_ITEMCHANGED:
             TRACE("-- LVN_ITEMCHANGED %p\n", this);
             OnStateChange(CDBOSC_SELCHANGE);  /* the browser will get the IDataObject now */
-            UpdateStatusbarAsync();
+            UpdateStatusbar();
             _DoFolderViewCB(SFVM_SELECTIONCHANGED, NULL/* FIXME */, NULL/* FIXME */);
             break;
 
@@ -2585,7 +2585,7 @@ HRESULT WINAPI CDefView::UIActivate(UINT uState)
         _ForceStatusBarResize();
 
         /* Set the text for the status bar */
-        UpdateStatusbarAsync();
+        UpdateStatusbar();
     }
 
     return S_OK;

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -615,7 +615,6 @@ void CDefView::UpdateStatusbarWorker(HANDLE hThread)
 unsigned __stdcall CDefView::_UpdateStatusbarProc(void *args)
 {
     CDefView* pView = static_cast<CDefView*>(args);
-    pView->AddRef();
     pView->UpdateStatusbarWorker(pView->m_hUpdateStatusbarThread);
     pView->Release();
     return 0;
@@ -624,6 +623,8 @@ unsigned __stdcall CDefView::_UpdateStatusbarProc(void *args)
 void CDefView::UpdateStatusbar()
 {
     HANDLE hOldThread = m_hUpdateStatusbarThread;
+
+    AddRef();
 
     // We have to initialize m_hUpdateStatusbarThread before the target thread begins.
     // So, we use CREATE_SUSPENDED.
@@ -636,6 +637,10 @@ void CDefView::UpdateStatusbar()
 
         if (hOldThread)
             ::CloseHandle(hOldThread);
+    }
+    else
+    {
+        Release();
     }
 }
 

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -175,6 +175,7 @@ class CDefView :
         HRESULT IncludeObject(PCUITEMID_CHILD pidl);
         HRESULT OnDefaultCommand();
         HRESULT OnStateChange(UINT uFlags);
+        static unsigned __stdcall UpdateStatusbarProc(void *args);
         void UpdateStatusbarWorker(HANDLE hThread);
         void UpdateStatusbar();
         void CheckToolbar();
@@ -626,7 +627,7 @@ void CDefView::UpdateStatusbarWorker(HANDLE hThread)
     }
 }
 
-static unsigned __stdcall UpdateStatusbarProc(void *args)
+unsigned __stdcall CDefView::UpdateStatusbarProc(void *args)
 {
     CDefView* pView = static_cast<CDefView*>(args);
     HANDLE hThread = pView->m_hUpdateStatusbarThread;

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -638,7 +638,9 @@ void CDefView::UpdateStatusbar()
 {
     HANDLE hOldThread = m_hUpdateStatusbarThread;
     m_hUpdateStatusbarThread =
-        reinterpret_cast<HANDLE>(_beginthreadex(NULL, 0, UpdateStatusbarProc, this, 0, NULL));
+        reinterpret_cast<HANDLE>(_beginthreadex(NULL, 0, UpdateStatusbarProc, this,
+                                                CREATE_SUSPENDED, NULL));
+    ::ResumeThread(m_hUpdateStatusbarThread);
     if (hOldThread)
         ::CloseHandle(hOldThread);
 }

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -154,8 +154,6 @@ class CDefView :
         SFVM_CUSTOMVIEWINFO_DATA  m_viewinfo_data;
 
         HICON                     m_hMyComputerIcon;
-
-    public:
         HANDLE                    m_hUpdateStatusbarThread;
 
     private:

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -433,6 +433,7 @@ CDefView::CDefView() :
     m_isEditing(FALSE),
     m_isParentFolderSpecial(FALSE),
     m_Destroyed(FALSE),
+    m_hMyComputerIcon(::LoadIconW(shell32_hInstance, MAKEINTRESOURCEW(IDI_SHELL_COMPUTER_DESKTOP))),
     m_hUpdateStatusbarThread(NULL),
     m_uUpdateStatusbarThreadId(0)
 {
@@ -443,8 +444,6 @@ CDefView::CDefView() :
     m_viewinfo_data.clrText = GetSysColor(COLOR_WINDOWTEXT);
     m_viewinfo_data.clrTextBack = GetSysColor(COLOR_WINDOW);
     m_viewinfo_data.hbmBack = NULL;
-
-    m_hMyComputerIcon = LoadIconW(shell32_hInstance, MAKEINTRESOURCEW(IDI_SHELL_COMPUTER_DESKTOP));
 }
 
 CDefView::~CDefView()

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -634,14 +634,17 @@ void CDefView::UpdateStatusbar()
     HANDLE hOldThread = m_hUpdateStatusbarThread;
 
     // We have to initialize m_hUpdateStatusbarThread before the thread starts up.
-    // Thus, we use CREATE_SUSPENDED.
-    m_hUpdateStatusbarThread =
-        reinterpret_cast<HANDLE>(_beginthreadex(NULL, 0, _UpdateStatusbarProc, this,
-                                                CREATE_SUSPENDED, NULL));
-    ::ResumeThread(m_hUpdateStatusbarThread);
+    // So, we use CREATE_SUSPENDED.
+    HANDLE hNewThread = reinterpret_cast<HANDLE>(_beginthreadex(NULL, 0, _UpdateStatusbarProc,
+                                                                this, CREATE_SUSPENDED, NULL));
+    if (hNewThread)
+    {
+        m_hUpdateStatusbarThread = hNewThread;
+        ::ResumeThread(hNewThread);
 
-    if (hOldThread)
-        ::CloseHandle(hOldThread);
+        if (hOldThread)
+            ::CloseHandle(hOldThread);
+    }
 }
 
 /**********************************************************

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -545,9 +545,7 @@ void CDefView::CheckToolbar()
 
 void CDefView::UpdateStatusbarWorker(HANDLE hThread)
 {
-    WCHAR szFormat[MAX_PATH] = {0};
-    WCHAR szPartText[MAX_PATH] = {0};
-    WCHAR szPartText2[MAX_PATH] = {0};
+    WCHAR szFormat[MAX_PATH], szPartText[MAX_PATH], szPartText2[MAX_PATH];
     UINT cSelectedItems;
 
     cSelectedItems = m_ListView.GetSelectedCount();
@@ -576,9 +574,7 @@ void CDefView::UpdateStatusbarWorker(HANDLE hThread)
 
         /* If we have something selected then only count selected file sizes. */
         if (cSelectedItems)
-        {
             uFileFlags = LVNI_SELECTED;
-        }
 
         while ((nItem = m_ListView.GetNextItem(nItem, uFileFlags)) >= 0)
         {

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -630,8 +630,7 @@ void CDefView::UpdateStatusbarWorker(HANDLE hThread)
 unsigned __stdcall CDefView::UpdateStatusbarProc(void *args)
 {
     CDefView* pView = static_cast<CDefView*>(args);
-    HANDLE hThread = pView->m_hUpdateStatusbarThread;
-    pView->UpdateStatusbarWorker(hThread);
+    pView->UpdateStatusbarWorker(pView->m_hUpdateStatusbarThread);
     return 0;
 }
 

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -547,6 +547,7 @@ void CDefView::UpdateStatusbarWorker(HANDLE hThread)
 {
     WCHAR szFormat[MAX_PATH] = {0};
     WCHAR szPartText[MAX_PATH] = {0};
+    WCHAR szPartText2[MAX_PATH] = {0};
     UINT cSelectedItems;
 
     cSelectedItems = m_ListView.GetSelectedCount();
@@ -594,30 +595,29 @@ void CDefView::UpdateStatusbarWorker(HANDLE hThread)
             }
         }
 
+        szPartText[0] = szPartText2[0] = UNICODE_NULL;
+
         /* Don't show the file size text if there is 0 bytes in the folder
          * OR we only have folders selected. */
         if ((cSelectedItems && !bIsOnlyFoldersSelected) || uTotalFileSize)
             StrFormatByteSizeW(uTotalFileSize, szPartText, _countof(szPartText));
-        else
-            *szPartText = 0;
 
         if (hThread != m_hUpdateStatusbarThread)
             return;
 
-        m_pShellBrowser->SendControlMsg(FCW_STATUS, SB_SETTEXT, 1, (LPARAM)szPartText, &lResult);
-
         /* If we are in a Recycle Bin folder then show no text for the location part. */
         if (!_ILIsBitBucket(m_pidlParent))
         {
-            LoadStringW(shell32_hInstance, IDS_MYCOMPUTER, szPartText, _countof(szPartText));
+            LoadStringW(shell32_hInstance, IDS_MYCOMPUTER, szPartText2, _countof(szPartText2));
             pIcon = (LPARAM)m_hMyComputerIcon;
         }
 
         if (hThread != m_hUpdateStatusbarThread)
             return;
 
+        m_pShellBrowser->SendControlMsg(FCW_STATUS, SB_SETTEXT, 1, (LPARAM)szPartText, &lResult);
         m_pShellBrowser->SendControlMsg(FCW_STATUS, SB_SETICON, 2, pIcon, &lResult);
-        m_pShellBrowser->SendControlMsg(FCW_STATUS, SB_SETTEXT, 2, (LPARAM)szPartText, &lResult);
+        m_pShellBrowser->SendControlMsg(FCW_STATUS, SB_SETTEXT, 2, (LPARAM)szPartText2, &lResult);
     }
 }
 

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -627,7 +627,7 @@ void CDefView::UpdateStatusbarInner()
     }
 }
 
-static unsigned __stdcall UpdateStatusProc(void *args)
+static unsigned __stdcall UpdateStatusbarProc(void *args)
 {
     static_cast<CDefView*>(args)->UpdateStatusbarInner();
     return 0;
@@ -637,7 +637,7 @@ void CDefView::UpdateStatusbar()
 {
     HANDLE hOldThread = m_hUpdateStatusbarThread;
     m_hUpdateStatusbarThread = reinterpret_cast<HANDLE>(
-        _beginthreadex(NULL, 0, UpdateStatusProc, this, 0, &m_uUpdateStatusbarThreadId));
+        _beginthreadex(NULL, 0, UpdateStatusbarProc, this, 0, &m_uUpdateStatusbarThreadId));
     if (hOldThread)
         ::CloseHandle(hOldThread);
 }

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -2614,13 +2614,12 @@ HRESULT WINAPI CDefView::DestroyViewWindow()
 {
     TRACE("(%p)\n", this);
 
-    HANDLE hOldThread = m_hUpdateStatusbarThread;
-    m_hUpdateStatusbarThread = NULL;
     m_uUpdateStatusbarThreadId = 0;
-    if (hOldThread)
+    if (m_hUpdateStatusbarThread)
     {
-        ::WaitForSingleObject(hOldThread, INFINITE);
-        ::CloseHandle(hOldThread);
+        ::WaitForSingleObject(m_hUpdateStatusbarThread, INFINITE);
+        ::CloseHandle(m_hUpdateStatusbarThread);
+        m_hUpdateStatusbarThread = NULL;
     }
 
     /* Make absolutely sure all our UI is cleaned up */

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -155,7 +155,7 @@ class CDefView :
 
         HICON                     m_hMyComputerIcon;
         HANDLE                    m_hUpdateStatusbarThread;
-        unsigned                  m_uUpdateStatusbarThreadId;
+        unsigned int              m_uUpdateStatusbarThreadId;
 
     private:
         HRESULT _MergeToolbar();

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -597,13 +597,12 @@ void CDefView::UpdateStatusbarWorker(HANDLE hThread)
         /* Don't show the file size text if there is 0 bytes in the folder
          * OR we only have folders selected. */
         if ((cSelectedItems && !bIsOnlyFoldersSelected) || uTotalFileSize)
-        {
             StrFormatByteSizeW(uTotalFileSize, szPartText, _countof(szPartText));
-        }
         else
-        {
             *szPartText = 0;
-        }
+
+        if (hThread != m_hUpdateStatusbarThread)
+            return;
 
         m_pShellBrowser->SendControlMsg(FCW_STATUS, SB_SETTEXT, 1, (LPARAM)szPartText, &lResult);
 

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -2614,13 +2614,13 @@ HRESULT WINAPI CDefView::DestroyViewWindow()
 {
     TRACE("(%p)\n", this);
 
-    HANDLE hThread = m_hUpdateStatusbarThread;
+    HANDLE hOldThread = m_hUpdateStatusbarThread;
     m_hUpdateStatusbarThread = NULL;
     m_uUpdateStatusbarThreadId = 0;
-    if (hThread)
+    if (hOldThread)
     {
-        ::WaitForSingleObject(hThread, INFINITE);
-        ::CloseHandle(hThread);
+        ::WaitForSingleObject(hOldThread, INFINITE);
+        ::CloseHandle(hOldThread);
     }
 
     /* Make absolutely sure all our UI is cleaned up */

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -2620,8 +2620,11 @@ HRESULT WINAPI CDefView::DestroyViewWindow()
     if (m_hUpdateStatusbarThread)
     {
         HANDLE hOldThread = m_hUpdateStatusbarThread;
+
+        // Assigning NULL to m_hUpdateStatusbarThread will terminate the target thread immediately
         m_hUpdateStatusbarThread = NULL;
         ::WaitForSingleObject(hOldThread, INFINITE);
+
         ::CloseHandle(hOldThread);
     }
 

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -635,10 +635,14 @@ unsigned __stdcall CDefView::UpdateStatusbarProc(void *args)
 void CDefView::UpdateStatusbar()
 {
     HANDLE hOldThread = m_hUpdateStatusbarThread;
+
+    // We have to initialize m_hUpdateStatusbarThread before the thread starts up.
+    // Thus, we use CREATE_SUSPENDED.
     m_hUpdateStatusbarThread =
         reinterpret_cast<HANDLE>(_beginthreadex(NULL, 0, UpdateStatusbarProc, this,
                                                 CREATE_SUSPENDED, NULL));
     ::ResumeThread(m_hUpdateStatusbarThread);
+
     if (hOldThread)
         ::CloseHandle(hOldThread);
 }

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -633,7 +633,7 @@ void CDefView::UpdateStatusbar()
 {
     HANDLE hOldThread = m_hUpdateStatusbarThread;
 
-    // We have to initialize m_hUpdateStatusbarThread before the thread starts up.
+    // We have to initialize m_hUpdateStatusbarThread before the target thread begins.
     // So, we use CREATE_SUSPENDED.
     HANDLE hNewThread = reinterpret_cast<HANDLE>(_beginthreadex(NULL, 0, _UpdateStatusbarProc,
                                                                 this, CREATE_SUSPENDED, NULL));

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -615,7 +615,9 @@ void CDefView::UpdateStatusbarWorker(HANDLE hThread)
 unsigned __stdcall CDefView::_UpdateStatusbarProc(void *args)
 {
     CDefView* pView = static_cast<CDefView*>(args);
+    pView->AddRef();
     pView->UpdateStatusbarWorker(pView->m_hUpdateStatusbarThread);
+    pView->Release();
     return 0;
 }
 

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -629,16 +629,15 @@ void CDefView::UpdateStatusbarInner()
 
 static unsigned __stdcall UpdateStatusProc(void *args)
 {
-    CDefView* pDefView = (CDefView*)args;
-    pDefView->UpdateStatusbarInner();
+    static_cast<CDefView*>(args)->UpdateStatusbarInner();
     return 0;
 }
 
 void CDefView::UpdateStatusbar()
 {
     HANDLE hOldThread = m_hUpdateStatusbarThread;
-    m_hUpdateStatusbarThread = (HANDLE)_beginthreadex(NULL, 0, UpdateStatusProc, this, 0,
-                                                      &m_uUpdateStatusbarThreadId);
+    m_hUpdateStatusbarThread = reinterpret_cast<HANDLE>(
+        _beginthreadex(NULL, 0, UpdateStatusProc, this, 0, &m_uUpdateStatusbarThreadId));
     if (hOldThread)
         ::CloseHandle(hOldThread);
 }


### PR DESCRIPTION
## Purpose
Selecting all in `system32` was too slow.
JIRA issue: [CORE-18663](https://jira.reactos.org/browse/CORE-18663)

## Proposed changes

- Make `CDefView::UpdateStatusbar` function asynchronized by using a thread.
- It makes selecting all very quick (within one second).
- Add `m_hUpdateStatusbarThread` member variable in order to asynchronize.

![after](https://github.com/reactos/reactos/assets/2107452/0377bb18-0cd4-4731-833c-97029c47bddd)

## TODO

- [x] Do tests.