### PR TITLE
[BROWSEUI] Fix position of taskbar toolbar right-click menu

### DIFF
--- a/dll/win32/browseui/shellbars/CISFBand.cpp
+++ b/dll/win32/browseui/shellbars/CISFBand.cpp
@@ -353,7 +353,7 @@ HRESULT CISFBand::CreateSimpleToolbar(HWND hWndParent)
                     case NM_RCLICK:
                     {
                         HRESULT hr;
-                        POINT pt = ((LPNMMOUSE)lParam)->pt;
+                        POINT pt = ((LPNMMOUSE)lParam)->pt; // Already in screen coordinates
                         CComPtr<IContextMenu> picm;
                         HMENU fmenu = CreatePopupMenu();
                         TBBUTTON tb;
@@ -363,7 +363,6 @@ HRESULT CISFBand::CreateSimpleToolbar(HWND hWndParent)
 
                         if (chk)
                         {
-                            ClientToScreen(&pt);
                             hr = m_pISF->GetUIObjectOf(m_hWnd, 1, &pidl, IID_NULL_PPV_ARG(IContextMenu, &picm));
                             if (FAILED_UNEXPECTEDLY(hr))
                                 return hr;


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-18966](https://jira.reactos.org/browse/CORE-18966)

## Proposed changes

- Don't call `ClientToScreen` in handling `NM_RCLICK` message because `NMMOUSE.pt` is already in screen coordinates.

## TODO

- [x] Do tests.

## Comparison

BEFORE:
![before](https://github.com/reactos/reactos/assets/2107452/cd58799a-2ead-4605-96ad-24c5546efc1a)
AFTER:
![after](https://github.com/reactos/reactos/assets/2107452/fcba3bfb-43b4-43a7-a42a-b3dc532248fe)