### PR TITLE
[EXPLORER] Improve the minimize-condition on Win+D

### DIFF
--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -111,9 +111,9 @@ BOOL ShouldMinimize(HWND hwnd)
     if (::IsWindowVisible(hwnd) && !::IsIconic(hwnd) && ::IsWindowEnabled(hwnd))
     {
         DWORD style = static_cast<DWORD>(::GetWindowLongPtrW(hwnd, GWL_STYLE));
-        if (style & WS_MINIMIZEBOX)
+        if ((style & WS_MINIMIZEBOX) && (style & WS_CAPTION) == WS_CAPTION)
         {
-            if ((style & (WS_CAPTION | WS_SYSMENU)) == (WS_CAPTION | WS_SYSMENU))
+            if (style & WS_SYSMENU)
             {
                 HMENU hSysMenu = ::GetSystemMenu(hwnd, FALSE);
                 if (hSysMenu)

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -106,12 +106,9 @@ BOOL CanBeMinimized(HWND hwnd)
         if (::GetClassLongPtrW(hwnd, GCW_ATOM) == (ULONG_PTR)WC_DIALOG)
             return TRUE;
 
-        DWORD style = (DWORD)::GetWindowLongPtrW(hwnd, GWL_STYLE);
-        if (style & WS_MINIMIZEBOX)
-        {
-            if ((style & WS_CAPTION) == WS_CAPTION)
-                return TRUE;
-        }
+        DWORD exstyle = (DWORD)::GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
+        if (!(exstyle & WS_EX_TOPMOST))
+            return TRUE;
     }
     return FALSE;
 }

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -3289,7 +3289,7 @@ HandleTrayContextMenu:
 
             info->pMinimizedAll->Add(mwp);
 
-            ::ShowWindowAsync(hwnd, SW_MINIMIZE);
+            ::ShowWindowAsync(hwnd, SW_SHOWMINNOACTIVE);
         }
 
         return TRUE;

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -3338,9 +3338,7 @@ HandleTrayContextMenu:
         {
             HWND hwnd = g_MinimizedAll[i].hwnd;
             if (::IsWindowVisible(hwnd) && ::IsIconic(hwnd))
-            {
                 ::SetWindowPlacement(hwnd, &g_MinimizedAll[i].wndpl);
-            }
         }
 
         g_MinimizedAll.RemoveAll();

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -111,7 +111,7 @@ BOOL ShouldMinimize(HWND hwnd)
     if (::IsWindowVisible(hwnd) && !::IsIconic(hwnd) && ::IsWindowEnabled(hwnd))
     {
         DWORD style = (DWORD)::GetWindowLongPtrW(hwnd, GWL_STYLE);
-        if ((style & WS_MINIMIZEBOX) && (style & WS_CAPTION) == WS_CAPTION)
+        if ((style & WS_CAPTION) == WS_CAPTION)
         {
             if (style & WS_SYSMENU)
             {

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -99,7 +99,7 @@ VOID RestoreWindowPos()
     g_WindowPosBackup.RemoveAll();
 }
 
-BOOL HasToBeMinimized(HWND hwnd)
+BOOL CanBeMinimized(HWND hwnd)
 {
     if (::IsWindowVisible(hwnd) && !::IsIconic(hwnd) && ::IsWindowEnabled(hwnd))
     {
@@ -130,7 +130,7 @@ FindEffectiveProc(HWND hwnd, LPARAM lParam)
 {
     EFFECTIVE_INFO *pei = (EFFECTIVE_INFO *)lParam;
 
-    if (!HasToBeMinimized(hwnd))
+    if (!CanBeMinimized(hwnd))
         return TRUE;    // continue
 
     if (pei->hTrayWnd == hwnd || pei->hwndDesktop == hwnd ||
@@ -3272,7 +3272,7 @@ HandleTrayContextMenu:
                 return TRUE;
         }
 
-        if (HasToBeMinimized(hwnd))
+        if (CanBeMinimized(hwnd))
         {
             MINWNDPOS mwp = { hwnd, { sizeof(mwp.wndpl) } };
             if (::GetWindowPlacement(hwnd, &mwp.wndpl) && // Save the position and status

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -101,7 +101,7 @@ VOID RestoreWindowPos()
 
 BOOL CanDialogSysMinimize(HWND hwnd)
 {
-    if (::GetClassLongPtrW(hwnd, GCW_ATOM) != (ULONG_PTR)WC_DIALOG)
+    if (::GetClassLongPtrW(hwnd, GCW_ATOM) != reinterpret_cast<ULONG_PTR>(WC_DIALOG))
         return FALSE;
     return (::IsWindowVisible(hwnd) && !::IsIconic(hwnd) && ::IsWindowEnabled(hwnd));
 }
@@ -140,7 +140,7 @@ struct EFFECTIVE_INFO
 static BOOL CALLBACK
 FindEffectiveProc(HWND hwnd, LPARAM lParam)
 {
-    EFFECTIVE_INFO *pei = (EFFECTIVE_INFO *)lParam;
+    EFFECTIVE_INFO *pei = reinterpret_cast<EFFECTIVE_INFO*>(lParam);
 
     if (!ShouldMinimize(hwnd) && !CanDialogSysMinimize(hwnd))
         return TRUE;    // continue
@@ -3271,7 +3271,7 @@ HandleTrayContextMenu:
 
     static BOOL CALLBACK MinimizeWindowsProc(HWND hwnd, LPARAM lParam)
     {
-        MINIMIZE_INFO *info = (MINIMIZE_INFO *)lParam;
+        MINIMIZE_INFO *info = reinterpret_cast<MINIMIZE_INFO*>(lParam);
         if (hwnd == info->hwndDesktop || hwnd == info->hTrayWnd || hwnd == info->hwndProgman)
             return TRUE; // Ignore special windows
 

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -3287,19 +3287,19 @@ HandleTrayContextMenu:
         if (ShouldMinimize(hwnd))
         {
             MINWNDPOS mwp = { hwnd, { sizeof(mwp.wndpl) } };
-            if (::GetWindowPlacement(hwnd, &mwp.wndpl)) // Save the position and status
+            if (::GetWindowPlacement(hwnd, &mwp.wndpl) && // Save the position and status
+                ::ShowWindowAsync(hwnd, SW_SHOWMINNOACTIVE)) // Minimize
             {
                 info->pMinimizedAll->Add(mwp);
-                ::ShowWindowAsync(hwnd, SW_SHOWMINNOACTIVE);
             }
         }
         else if (CanDialogSysMinimize(hwnd))
         {
             MINWNDPOS mwp = { hwnd, { sizeof(mwp.wndpl) } };
-            if (::GetWindowPlacement(hwnd, &mwp.wndpl)) // Save the position and status
+            if (::GetWindowPlacement(hwnd, &mwp.wndpl) && // Save the position and status
+                ::PostMessageW(hwnd, WM_SYSCOMMAND, SC_MINIMIZE, -1)) // Minimize
             {
                 info->pMinimizedAll->Add(mwp);
-                ::SendMessageW(hwnd, WM_SYSCOMMAND, SC_MINIMIZE, -1);
             }
         }
 

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -101,7 +101,7 @@ VOID RestoreWindowPos()
 
 BOOL CanDialogSysMinimize(HWND hwnd)
 {
-    if (::GetClassLongPtrW(hwnd, GCW_ATOM) != reinterpret_cast<ULONG_PTR>(WC_DIALOG))
+    if (::GetClassLongPtrW(hwnd, GCW_ATOM) != (ULONG_PTR)WC_DIALOG)
         return FALSE;
     return (::IsWindowVisible(hwnd) && !::IsIconic(hwnd) && ::IsWindowEnabled(hwnd));
 }
@@ -110,7 +110,7 @@ BOOL ShouldMinimize(HWND hwnd)
 {
     if (::IsWindowVisible(hwnd) && !::IsIconic(hwnd) && ::IsWindowEnabled(hwnd))
     {
-        DWORD style = static_cast<DWORD>(::GetWindowLongPtrW(hwnd, GWL_STYLE));
+        DWORD style = (DWORD)::GetWindowLongPtrW(hwnd, GWL_STYLE);
         if ((style & WS_MINIMIZEBOX) && (style & WS_CAPTION) == WS_CAPTION)
         {
             if (style & WS_SYSMENU)
@@ -140,7 +140,7 @@ struct EFFECTIVE_INFO
 static BOOL CALLBACK
 FindEffectiveProc(HWND hwnd, LPARAM lParam)
 {
-    EFFECTIVE_INFO *pei = reinterpret_cast<EFFECTIVE_INFO*>(lParam);
+    EFFECTIVE_INFO *pei = (EFFECTIVE_INFO *)lParam;
 
     if (!ShouldMinimize(hwnd) && !CanDialogSysMinimize(hwnd))
         return TRUE;    // continue
@@ -2711,7 +2711,7 @@ ChangePos:
 
     LRESULT OnCopyData(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
     {
-        COPYDATASTRUCT *pCopyData = reinterpret_cast<COPYDATASTRUCT *>(lParam);
+        COPYDATASTRUCT *pCopyData = (COPYDATASTRUCT *)lParam;
         switch (pCopyData->dwData)
         {
             case TABDMC_APPBAR:
@@ -3271,7 +3271,7 @@ HandleTrayContextMenu:
 
     static BOOL CALLBACK MinimizeWindowsProc(HWND hwnd, LPARAM lParam)
     {
-        MINIMIZE_INFO *info = reinterpret_cast<MINIMIZE_INFO*>(lParam);
+        MINIMIZE_INFO *info = (MINIMIZE_INFO *)lParam;
         if (hwnd == info->hwndDesktop || hwnd == info->hTrayWnd || hwnd == info->hwndProgman)
             return TRUE; // Ignore special windows
 

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -116,6 +116,10 @@ FindEffectiveProc(HWND hwnd, LPARAM lParam)
     if (!IsWindowVisible(hwnd) || IsIconic(hwnd))
         return TRUE;    // continue
 
+    DWORD dwExStyle = ::GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
+    if (dwExStyle & WS_EX_TOPMOST)
+        return TRUE;    // continue
+
     if (pei->hTrayWnd == hwnd || pei->hwndDesktop == hwnd ||
         pei->hwndProgman == hwnd)
     {
@@ -159,13 +163,6 @@ IsThereAnyEffectiveWindow(BOOL bMustBeInMonitor)
     ei.bMustBeInMonitor = bMustBeInMonitor;
 
     EnumWindows(FindEffectiveProc, (LPARAM)&ei);
-    if (ei.hwndFound && FALSE)
-    {
-        WCHAR szClass[64], szText[64];
-        GetClassNameW(ei.hwndFound, szClass, _countof(szClass));
-        GetWindowTextW(ei.hwndFound, szText, _countof(szText));
-        MessageBoxW(NULL, szText, szClass, 0);
-    }
     return ei.hwndFound != NULL;
 }
 
@@ -3262,7 +3259,8 @@ HandleTrayContextMenu:
                 return TRUE;
         }
 
-        if (::IsWindowVisible(hwnd) && !::IsIconic(hwnd))
+        DWORD dwExStyle = (DWORD)::GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
+        if (::IsWindowVisible(hwnd) && !::IsIconic(hwnd) && !(dwExStyle & WS_EX_TOPMOST))
         {
             MINWNDPOS mwp;
             mwp.hwnd = hwnd;


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-18427](https://jira.reactos.org/browse/CORE-18427)

## Proposed changes

- Add `CanBeMinimized` helper function to determine whether the window should be minimized.
- Use them in `FindEffectiveProc` and `MinimizeWindowsProc` functions.
- Improve the Minimize code.

## TODO

- [x] Do tests.

## Comparison

BEFORE:
![before](https://github.com/reactos/reactos/assets/2107452/aa1005b6-a70c-4ca3-a8d6-c6c432b7a9b5)
Magnifier does minimize on `Win+D`.

AFTER:
![after](https://github.com/reactos/reactos/assets/2107452/cdf5ddfc-21ff-4ba5-a3a2-47b8147901f2)
Magnifier won't minimize on `Win+D`.

AFTER:
![after2](https://github.com/reactos/reactos/assets/2107452/120a8f62-9aca-401e-9249-1c79517db9bd)
Task Manager does minimize on `Win+D`.