### PR TITLE
[CMD] Correctly honour the "short" path flag in %~var enhanced variables expansion.

### DIFF
--- a/base/shell/cmd/cmd.c
+++ b/base/shell/cmd/cmd.c
@@ -1158,11 +1158,9 @@ GetEnhancedVar(
         if (hFind != INVALID_HANDLE_VALUE)
         {
             PTSTR FixedComponent = w32fd.cFileName;
-            if (*w32fd.cAlternateFileName &&
-                ((Modifiers & M_SHORT) || !_tcsicmp(In, w32fd.cAlternateFileName)))
-            {
+            if ((Modifiers & M_SHORT) && *w32fd.cAlternateFileName)
                 FixedComponent = w32fd.cAlternateFileName;
-            }
+
             FindClose(hFind);
 
             if (Out + _tcslen(FixedComponent) + 1 >= &FixedPath[ARRAYSIZE(FixedPath)])


### PR DESCRIPTION
JIRA issue: [CORE-14096](https://jira.reactos.org/browse/CORE-14096)

Patch based on an earlier fix attempt by Doug Lyons.

This bug has always been present since the implementation of this feature in commit a1eb1f6ba (r40024).

The expansion of %~dpX ennhanced variables used to incorrectly show some directories in uppercase. For example:

```batch
:: testcmd.cmd
echo '%~dp0'
echo '%~dps0'
echo '%~s0'
```

would show:

```
P:\Documents and Settings\Administrator\Desktop>echo 'P:\Documents and Settings\Administrator\DESKTOP\'
'P:\Documents and Settings\Administrator\DESKTOP\'

P:\Documents and Settings\Administrator\Desktop>echo 'P:\DOCUME~1\ADMINI~1\DESKTOP\'
'P:\DOCUME~1\ADMINI~1\DESKTOP\'

P:\Documents and Settings\Administrator\Desktop>echo 'P:\DOCUME~1\ADMINI~1\DESKTOP\testcmd.cmd'
'P:\DOCUME~1\ADMINI~1\DESKTOP\testcmd.cmd'
```

instead of the correct:

```
P:\Documents and Settings\Administrator\Desktop>echo 'P:\Documents and Settings\Administrator\Desktop\'
'P:\Documents and Settings\Administrator\Desktop\'

P:\Documents and Settings\Administrator\Desktop>echo 'P:\DOCUME~1\ADMINI~1\DESKTOP\'
'P:\DOCUME~1\ADMINI~1\DESKTOP\'

P:\Documents and Settings\Administrator\Desktop>echo 'P:\DOCUME~1\ADMINI~1\DESKTOP\testcmd.cmd'
'P:\DOCUME~1\ADMINI~1\DESKTOP\testcmd.cmd'
```

The reason was a wrong handling of the presence (or absence) of the "short" path format specifier 's' in those enhanced variables. In the examples above, the "Desktop" sub-directory has a short-path name available (because it is in a FAT partition). The short-path name was used some times also even with the 's' specifier absent.
