### PR TITLE
[ADVAPI32] "Minimally" improve the SaferComputeTokenFromLevel() stub.

### DIFF
--- a/dll/win32/advapi32/sec/safer.c
+++ b/dll/win32/advapi32/sec/safer.c
@@ -155,8 +155,8 @@ SaferComputeTokenFromLevel(
     _Inout_opt_ PVOID pReserved)
 {
     FIXME("(%p, %p, %p, 0x%lx, %p) stub\n", LevelHandle, InAccessToken, OutAccessToken, dwFlags, pReserved);
-    SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
-    return FALSE;
+    *OutAccessToken = (dwFlags & SAFER_TOKEN_NULL_IF_EQUAL) ? NULL : UlongToHandle(0xdeadf00d);
+    return TRUE;
 }
 
 


### PR DESCRIPTION
JIRA issues: [CORE-14015](https://jira.reactos.org/browse/CORE-14015), [CORE-6942](https://jira.reactos.org/browse/CORE-6942)

This makes Windows 2003 CMD.EXE to start batch files again. Addendum to commit 17d42ae2a (r58868).

Replaces PR #3084 by freely importing and adapting Wine patch
https://github.com/wine-mirror/wine/commit/17110a0a890d2bacb5b348bd9bb3cef10d144e19
```
advapi32: Improve the SaferComputeTokenFromLevel stub.
Wine-Bug: https://bugs.winehq.org/show_bug.cgi?id=47274
Signed-off-by: Hans Leidekker <hans@codeweavers.com>
Signed-off-by: Alexandre Julliard <julliard@winehq.org>
```

BEFORE:
![image](https://github.com/reactos/reactos/assets/1969829/333aa9df-7e65-4d8a-aee9-66771c77b7ad)

AFTER:
![image](https://github.com/reactos/reactos/assets/1969829/cd8a46a0-045b-4d90-85e0-7bb0ce27a580)
