### PR TITLE
[SHELL32] Fix detail view in My Computer showing Comment in 'Total Size' column

### DIFF
--- a/dll/win32/shell32/folders/CDrivesFolder.cpp
+++ b/dll/win32/shell32/folders/CDrivesFolder.cpp
@@ -798,6 +798,7 @@ HRESULT WINAPI CDrivesFolder::CompareIDs(LPARAM lParam, PCUIDLIST_RELATIVE pidl1
         case IDS_SHV_COLUMN_COMMENTS:
             hres = MAKE_COMPARE_HRESULT(0);
             break;
+        DEFAULT_UNREACHABLE;
     }
 
     if (HRESULT_CODE(hres) == 0)
@@ -1150,9 +1151,10 @@ HRESULT WINAPI CDrivesFolder::GetDetailsOf(PCUITEMID_CHILD pidl, UINT iColumn, S
                 return m_regFolder->GetDetailsOf(pidl, iColumn, psd);
             case IDS_SHV_COLUMN_DISK_CAPACITY:
             case IDS_SHV_COLUMN_DISK_AVAILABLE:
-                return SHSetStrRet(&psd->str, "");               /* blank col */
+                return SHSetStrRet(&psd->str, ""); /* blank col */
             case IDS_SHV_COLUMN_COMMENTS:
-                return m_regFolder->GetDetailsOf(pidl, 2, psd);  /* 2 = comments */
+                return m_regFolder->GetDetailsOf(pidl, 2, psd); /* 2 = comments */
+            DEFAULT_UNREACHABLE;
         }
     }
     else
@@ -1189,8 +1191,9 @@ HRESULT WINAPI CDrivesFolder::GetDetailsOf(PCUITEMID_CHILD pidl, UINT iColumn, S
                 hr = S_OK;
                 break;
             case IDS_SHV_COLUMN_COMMENTS:
-                hr = SHSetStrRet(&psd->str, "");   /* FIXME: comments */
+                hr = SHSetStrRet(&psd->str, ""); /* FIXME: comments */
                 break;
+            DEFAULT_UNREACHABLE;
         }
     }
 

--- a/dll/win32/shell32/folders/CDrivesFolder.cpp
+++ b/dll/win32/shell32/folders/CDrivesFolder.cpp
@@ -1146,6 +1146,10 @@ HRESULT WINAPI CDrivesFolder::GetDetailsOf(PCUITEMID_CHILD pidl, UINT iColumn, S
     }
     else if (!_ILIsDrive(pidl))
     {
+        if (iColumn == 2 || iColumn == 3)
+            return SHSetStrRet(&psd->str, "");
+        if (iColumn == 4)
+            iColumn = 2;
         return m_regFolder->GetDetailsOf(pidl, iColumn, psd);
     }
     else


### PR DESCRIPTION
## Purpose

_Fix regression of [4c25af5b](https://github.com/reactos/reactos/commit/4c25af5bd4ac8ea3bdfb855478683980922ed32b)_

JIRA issue: [CORE-19000](https://jira.reactos.org/browse/CORE-19000)

## Proposed changes

_Commit Number 1 (Old Line Number 1149 replacement)._
_For the Drives Detailed View of Explorer, change comments to show in column 4 instead of 2._
_Commit Number 2_
_While working in this file, replace some magic numbers._

Note: This is made more confusing by the fact that the 'Folder->GetDetailsOf' function has its column numbers and the Explorer details view has its column numbers and these do not always agree.

![CORE-19000_Fixed](https://github.com/reactos/reactos/assets/32620577/c9f84089-d1b1-4d19-9df6-8f1c23707d03)
