### PR TITLE
[CONSRV] Fix extra buggy WM_MOUSEMOVE events received when VBox Mouse Integration is enabled.

### DIFF
--- a/win32ss/user/winsrv/consrv/frontends/gui/conwnd.c
+++ b/win32ss/user/winsrv/consrv/frontends/gui/conwnd.c
@@ -1778,6 +1778,29 @@ OnMouse(PGUI_CONSOLE_DATA GuiData, UINT msg, WPARAM wParam, LPARAM lParam)
                 DoDefault = TRUE; // FALSE;
                 break;
         }
+
+        /*
+         * HACK FOR CORE-8394 (Part 1):
+         *
+         * It appears that when running ReactOS on VBox with Mouse Integration
+         * enabled, the next mouse event coming after a button-down action is
+         * a mouse-move. However it is NOT always a rule, so that we cannot use
+         * the IgnoreNextMouseEvent flag to just "ignore" the next mouse event,
+         * thinking it would always be a mouse-move event.
+         *
+         * To work around this problem (that should really be fixed in Win32k),
+         * we use a second flag to ignore this possible next mouse move event.
+         */
+        switch (msg)
+        {
+            case WM_LBUTTONDOWN:
+            case WM_MBUTTONDOWN:
+            case WM_RBUTTONDOWN:
+            case WM_XBUTTONDOWN:
+                GuiData->HackCORE8394IgnoreNextMove = TRUE;
+            default:
+                break;
+        }
     }
     else if (GetConsoleInputBufferMode(Console) & ENABLE_MOUSE_INPUT)
     {
@@ -1920,15 +1943,14 @@ OnMouse(PGUI_CONSOLE_DATA GuiData, UINT msg, WPARAM wParam, LPARAM lParam)
         /*
          * HACK FOR CORE-8394 (Part 1):
          *
-         * It appears that depending on which VM ReactOS runs, the next mouse
-         * signal coming after a button-down action can be a mouse-move (e.g.
-         * on VBox, whereas on QEMU it is not the case). However it is NOT a
-         * rule, so that we cannot use the IgnoreNextMouseSignal flag to just
-         * "ignore" the next mouse event, thinking it would always be a mouse-
-         * move signal.
+         * It appears that when running ReactOS on VBox with Mouse Integration
+         * enabled, the next mouse event coming after a button-down action is
+         * a mouse-move. However it is NOT always a rule, so that we cannot use
+         * the IgnoreNextMouseEvent flag to just "ignore" the next mouse event,
+         * thinking it would always be a mouse-move event.
          *
          * To work around this problem (that should really be fixed in Win32k),
-         * we use a second flag to ignore this possible next mouse move signal.
+         * we use a second flag to ignore this possible next mouse move event.
          */
         switch (msg)
         {


### PR DESCRIPTION
## Purpose

Work-around extra buggy WM_MOUSEMOVE events received when VBox Mouse Integration is enabled.
Those caused the "Ignore-next-mouse-event" mechanism of the console (used e.g. in QuickEdit mode for not triggering the appearance of the context menu, etc.) to not work.
Please note that those buggy events, that arise when testing ReactOS in VirtualBox with Mouse Integration is enabled, do not show up when running instead Windows (2003, ...) in the same configured VM.

Addendum to commits ac51557c0 (r63792) and 33d8a4b74 (r67218).

"Better" fix for the one reported and attempted in PR #5406 by @whindsaks , as it keeps the separation between the flag that manages the working-around of the bug, and the other flag that is used for ignoring the genuine next mouse event that follows mouse-button-down events.

JIRA issue: [CORE-8394](https://jira.reactos.org/browse/CORE-8394)

## Proposed changes

The work-around fix is to just copy-paste the existing `HACK FOR CORE-8394 (Part 1)` block found in the `if (GetConsoleInputBufferMode(Console) & ENABLE_MOUSE_INPUT)` block, into the first `if`-block that handles the selection-in-progress/QuickEdit mode.

## Tests: Diffs without / with patch

### QuickEDIT OFF

- **Without Mouse Integration:** No change in observed usage behaviour.
```diff
 < Opening Context Menu and selecting "Mark" >

 OnMouse: 512 ; 0x00000000 ; 0x0076018B - HackCORE8394: FALSE, INME: FALSE
 OnMouse: 516 ; 0x00000002 ; 0x0076018B - HackCORE8394: FALSE, INME: FALSE
 OnMouse: 517 ; 0x00000000 ; 0x0076018B - HackCORE8394: FALSE, INME: FALSE
 OnMouse: 512 ; 0x00000000 ; 0x007C0192 - HackCORE8394: FALSE, INME: FALSE

 < Going to the area to select >

 **** SEL/QEdit ON: got WM_MOUSEMOVE
 OnMouse: 512 ; 0x00000000 ; 0x0078018E - HackCORE8394: FALSE, INME: FALSE
 [...]
 OnMouse: 512 ; 0x00000000 ; 0x00450116 - HackCORE8394: FALSE, INME: FALSE
 **** SEL/QEdit ON: got WM_MOUSEMOVE

 < Selecting the area >

 OnMouse: 513 ; 0x00000001 ; 0x00450116 - HackCORE8394: FALSE, INME: FALSE
+**** TEST TEST!! SEL/QEdit ON: setting HackCORE8394IgnoreNextMove
+OnMouse: 512 ; 0x00000001 ; 0x0046010F - HackCORE8394: TRUE, INME: FALSE
+**** Resetting HackCORE8394IgnoreNextMove and ignoring WM_MOUSEMOVE
 OnMouse: 512 ; 0x00000001 ; 0x00440116 - HackCORE8394: FALSE, INME: FALSE
 **** SEL/QEdit ON: got WM_MOUSEMOVE
 [...]
 OnMouse: 512 ; 0x00000001 ; 0x0045016F - HackCORE8394: FALSE, INME: FALSE
 **** SEL/QEdit ON: got WM_MOUSEMOVE

 < Releasing selection >

 OnMouse: 514 ; 0x00000000 ; 0x0045016F - HackCORE8394: FALSE, INME: FALSE
 OnMouse: 512 ; 0x00000000 ; 0x0045016F - HackCORE8394: FALSE, INME: FALSE
 **** SEL/QEdit ON: got WM_MOUSEMOVE

 < Right-click to Copy the selected area >

 OnMouse: 516 ; 0x00000002 ; 0x0045016F - HackCORE8394: FALSE, INME: FALSE
 **** SEL/QEdit ON: WM_RBUTTONDOWN/DBLCLK: setting IgnoreNextMouseEvent
-OnMouse: 517 ; 0x00000000 ; 0x0045016F - HackCORE8394: FALSE, INME: TRUE
+**** TEST TEST!! SEL/QEdit ON: setting HackCORE8394IgnoreNextMove
+OnMouse: 517 ; 0x00000000 ; 0x0045016F - HackCORE8394: TRUE, INME: TRUE
 **** Resetting IgnoreNextMouseEvent and ignoring WM_xBUTTONDOWN
 OnMouse: 512 ; 0x00000000 ; 0x00460171 - HackCORE8394: FALSE, INME: FALSE
 OnMouse: 512 ; 0x00000000 ; 0x004A0176 - HackCORE8394: FALSE, INME: FALSE
```

Here, the mouse event 517 (WM_RBUTTONUP) gets ignored (INME: TRUE) in both cases (patch or no-patch).

- **With Mouse Integration:** _**Fixed**_ observed usage behaviour.
```diff
 < Opening Context Menu and selecting "Mark" >

 OnMouse: 512 ; 0x00000000 ; 0x00500151 - HackCORE8394: FALSE, INME: FALSE
 OnMouse: 516 ; 0x00000002 ; 0x00500151 - HackCORE8394: FALSE, INME: FALSE
 OnMouse: 512 ; 0x00000002 ; 0x00500151 - HackCORE8394: FALSE, INME: FALSE
 OnMouse: 517 ; 0x00000000 ; 0x00500151 - HackCORE8394: FALSE, INME: FALSE
 OnMouse: 512 ; 0x00000000 ; 0x00560157 - HackCORE8394: FALSE, INME: FALSE

 < Going to the area to select >

 **** SEL/QEdit ON: got WM_MOUSEMOVE
 OnMouse: 512 ; 0x00000000 ; 0x00550156 - HackCORE8394: FALSE, INME: FALSE
 [...]
 OnMouse: 512 ; 0x00000000 ; 0x0046014D - HackCORE8394: FALSE, INME: FALSE
 **** SEL/QEdit ON: got WM_MOUSEMOVE

 < Selecting the area >

 OnMouse: 513 ; 0x00000001 ; 0x0046014D - HackCORE8394: FALSE, INME: FALSE
-OnMouse: 512 ; 0x00000001 ; 0x0046014A - HackCORE8394: FALSE, INME: FALSE
-**** SEL/QEdit ON: got WM_MOUSEMOVE
+**** TEST TEST!! SEL/QEdit ON: setting HackCORE8394IgnoreNextMove
+OnMouse: 512 ; 0x00000001 ; 0x00470101 - HackCORE8394: TRUE, INME: FALSE
+**** Resetting HackCORE8394IgnoreNextMove and ignoring WM_MOUSEMOVE
 OnMouse: 512 ; 0x00000001 ; 0x00460148 - HackCORE8394: FALSE, INME: FALSE
 **** SEL/QEdit ON: got WM_MOUSEMOVE
 [...]
 OnMouse: 512 ; 0x00000001 ; 0x004500F2 - HackCORE8394: FALSE, INME: FALSE
 **** SEL/QEdit ON: got WM_MOUSEMOVE

 < Releasing selection >

 OnMouse: 514 ; 0x00000000 ; 0x004500F2 - HackCORE8394: FALSE, INME: FALSE
 OnMouse: 512 ; 0x00000000 ; 0x004500F2 - HackCORE8394: FALSE, INME: FALSE
 **** SEL/QEdit ON: got WM_MOUSEMOVE
 OnMouse: 512 ; 0x00000000 ; 0x004500F2 - HackCORE8394: FALSE, INME: FALSE
 **** SEL/QEdit ON: got WM_MOUSEMOVE

 < Right-click to Copy the selected area >

 OnMouse: 516 ; 0x00000002 ; 0x004500F2 - HackCORE8394: FALSE, INME: FALSE
 **** SEL/QEdit ON: WM_RBUTTONDOWN/DBLCLK: setting IgnoreNextMouseEvent
-OnMouse: 512 ; 0x00000002 ; 0x004500F2 - HackCORE8394: FALSE, INME: TRUE
-**** Resetting IgnoreNextMouseEvent and ignoring WM_xBUTTONDOWN
-OnMouse: 517 ; 0x00000000 ; 0x004500F2 - HackCORE8394: FALSE, INME: FALSE
+**** TEST TEST!! SEL/QEdit ON: setting HackCORE8394IgnoreNextMove
+OnMouse: 512 ; 0x00000002 ; 0x0045017B - HackCORE8394: TRUE, INME: TRUE
+**** Resetting HackCORE8394IgnoreNextMove and ignoring WM_MOUSEMOVE
+OnMouse: 517 ; 0x00000000 ; 0x0045017B - HackCORE8394: FALSE, INME: TRUE
+**** Resetting IgnoreNextMouseEvent and ignoring WM_xBUTTONDOWN
 OnMouse: 512 ; 0x00000000 ; 0x004500F2 - HackCORE8394: FALSE, INME: FALSE
 OnMouse: 512 ; 0x00000000 ; 0x004600F2 - HackCORE8394: FALSE, INME: FALSE
```

There, the mouse event 517 (WM_RBUTTONUP) gets ignored with the patch (INME stays to TRUE), together with the erroneous event 512 (WM_MOUSEMOVE) that preceded it:
```diff
+**** TEST TEST!! SEL/QEdit ON: setting HackCORE8394IgnoreNextMove
+OnMouse: 512 ; 0x00000002 ; 0x0045017B - HackCORE8394: TRUE, INME: TRUE
+**** Resetting HackCORE8394IgnoreNextMove and ignoring WM_MOUSEMOVE
+OnMouse: 517 ; 0x00000000 ; 0x0045017B - HackCORE8394: FALSE, INME: TRUE
+**** Resetting IgnoreNextMouseEvent and ignoring WM_xBUTTONDOWN
```
while it was previously not ignored (INME reset to FALSE prematurely) without the patch:
```diff
-OnMouse: 512 ; 0x00000002 ; 0x004500F2 - HackCORE8394: FALSE, INME: TRUE
-**** Resetting IgnoreNextMouseEvent and ignoring WM_xBUTTONDOWN
-OnMouse: 517 ; 0x00000000 ; 0x004500F2 - HackCORE8394: FALSE, INME: FALSE
```

### QuickEDIT ON

- **Without Mouse Integration:** No change in observed usage behaviour.
```diff
 < Going to the area to select >

 OnMouse: 512 ; 0x00000000 ; 0x004700EE - HackCORE8394: FALSE, INME: FALSE
 **** SEL/QEdit ON: got WM_MOUSEMOVE
 OnMouse: 512 ; 0x00000000 ; 0x004600ED - HackCORE8394: FALSE, INME: FALSE
 **** SEL/QEdit ON: got WM_MOUSEMOVE

 < Selecting the area >

 OnMouse: 513 ; 0x00000001 ; 0x004600ED - HackCORE8394: FALSE, INME: FALSE
-OnMouse: 512 ; 0x00000001 ; 0x004300ED - HackCORE8394: FALSE, INME: FALSE
-**** SEL/QEdit ON: got WM_MOUSEMOVE
+**** TEST TEST!! SEL/QEdit ON: setting HackCORE8394IgnoreNextMove
+OnMouse: 512 ; 0x00000001 ; 0x00410101 - HackCORE8394: TRUE, INME: FALSE
+**** Resetting HackCORE8394IgnoreNextMove and ignoring WM_MOUSEMOVE
 OnMouse: 512 ; 0x00000001 ; 0x003E00FB - HackCORE8394: FALSE, INME: FALSE
 **** SEL/QEdit ON: got WM_MOUSEMOVE
 [...]
 OnMouse: 512 ; 0x00000001 ; 0x0048016D - HackCORE8394: FALSE, INME: FALSE
 **** SEL/QEdit ON: got WM_MOUSEMOVE

 < Releasing selection >

 OnMouse: 514 ; 0x00000000 ; 0x0048016D - HackCORE8394: FALSE, INME: FALSE
 OnMouse: 512 ; 0x00000000 ; 0x0048016D - HackCORE8394: FALSE, INME: FALSE
 **** SEL/QEdit ON: got WM_MOUSEMOVE

 < Right-click to Copy the selected area >

 OnMouse: 516 ; 0x00000002 ; 0x0048016D - HackCORE8394: FALSE, INME: FALSE
 **** SEL/QEdit ON: WM_RBUTTONDOWN/DBLCLK: setting IgnoreNextMouseEvent
-OnMouse: 517 ; 0x00000000 ; 0x0048016D - HackCORE8394: FALSE, INME: TRUE
+**** TEST TEST!! SEL/QEdit ON: setting HackCORE8394IgnoreNextMove
+OnMouse: 517 ; 0x00000000 ; 0x00470177 - HackCORE8394: TRUE, INME: TRUE
 **** Resetting IgnoreNextMouseEvent and ignoring WM_xBUTTONDOWN
 OnMouse: 512 ; 0x00000000 ; 0x0049016D - HackCORE8394: FALSE, INME: FALSE
 **** SEL/QEdit ON: got WM_MOUSEMOVE
 OnMouse: 512 ; 0x00000000 ; 0x004B016D - HackCORE8394: FALSE, INME: FALSE
 **** SEL/QEdit ON: got WM_MOUSEMOVE
```

Here again, the mouse event 517 (WM_RBUTTONUP) gets ignored (INME: TRUE) in both cases (patch or no-patch).

- **With Mouse Integration:** _**Fixed**_ observed usage behaviour.
```diff
 < Going to the area to select >

 OnMouse: 512 ; 0x00000000 ; 0x00470101 - HackCORE8394: FALSE, INME: FALSE
 **** SEL/QEdit ON: got WM_MOUSEMOVE
 OnMouse: 512 ; 0x00000000 ; 0x00470101 - HackCORE8394: FALSE, INME: FALSE
 **** SEL/QEdit ON: got WM_MOUSEMOVE

 < Selecting the area >

 OnMouse: 513 ; 0x00000001 ; 0x00470101 - HackCORE8394: FALSE, INME: FALSE
-OnMouse: 512 ; 0x00000001 ; 0x00460101 - HackCORE8394: FALSE, INME: FALSE
-**** SEL/QEdit ON: got WM_MOUSEMOVE
+**** TEST TEST!! SEL/QEdit ON: setting HackCORE8394IgnoreNextMove
+OnMouse: 512 ; 0x00000001 ; 0x004600FF - HackCORE8394: TRUE, INME: FALSE
+**** Resetting HackCORE8394IgnoreNextMove and ignoring WM_MOUSEMOVE
 OnMouse: 512 ; 0x00000001 ; 0x00460106 - HackCORE8394: FALSE, INME: FALSE
 **** SEL/QEdit ON: got WM_MOUSEMOVE
 [...]
 OnMouse: 512 ; 0x00000001 ; 0x00480170 - HackCORE8394: FALSE, INME: FALSE
 **** SEL/QEdit ON: got WM_MOUSEMOVE

 < Releasing selection >

 OnMouse: 514 ; 0x00000000 ; 0x00480170 - HackCORE8394: FALSE, INME: FALSE
 OnMouse: 512 ; 0x00000000 ; 0x00480170 - HackCORE8394: FALSE, INME: FALSE
 **** SEL/QEdit ON: got WM_MOUSEMOVE
 OnMouse: 512 ; 0x00000000 ; 0x00480170 - HackCORE8394: FALSE, INME: FALSE
 **** SEL/QEdit ON: got WM_MOUSEMOVE

 < Right-click to Copy the selected area >

 OnMouse: 516 ; 0x00000002 ; 0x00480170 - HackCORE8394: FALSE, INME: FALSE
 **** SEL/QEdit ON: WM_RBUTTONDOWN/DBLCLK: setting IgnoreNextMouseEvent
-OnMouse: 512 ; 0x00000002 ; 0x00480170 - HackCORE8394: FALSE, INME: TRUE
-**** Resetting IgnoreNextMouseEvent and ignoring WM_xBUTTONDOWN
-OnMouse: 517 ; 0x00000000 ; 0x00480170 - HackCORE8394: FALSE, INME: FALSE
+**** TEST TEST!! SEL/QEdit ON: setting HackCORE8394IgnoreNextMove
+OnMouse: 512 ; 0x00000002 ; 0x00460172 - HackCORE8394: TRUE, INME: TRUE
+**** Resetting HackCORE8394IgnoreNextMove and ignoring WM_MOUSEMOVE
+OnMouse: 517 ; 0x00000000 ; 0x00460172 - HackCORE8394: FALSE, INME: TRUE
+**** Resetting IgnoreNextMouseEvent and ignoring WM_xBUTTONDOWN
 OnMouse: 512 ; 0x00000000 ; 0x00480170 - HackCORE8394: FALSE, INME: FALSE
 **** SEL/QEdit ON: got WM_MOUSEMOVE
 OnMouse: 512 ; 0x00000000 ; 0x004C0171 - HackCORE8394: FALSE, INME: FALSE
 **** SEL/QEdit ON: got WM_MOUSEMOVE
```

There again, the mouse event 517 (WM_RBUTTONUP) gets ignored with the patch (INME stays to TRUE), together with the erroneous event 512 (WM_MOUSEMOVE) that preceded it:
```diff
+**** TEST TEST!! SEL/QEdit ON: setting HackCORE8394IgnoreNextMove
+OnMouse: 512 ; 0x00000002 ; 0x00460172 - HackCORE8394: TRUE, INME: TRUE
+**** Resetting HackCORE8394IgnoreNextMove and ignoring WM_MOUSEMOVE
+OnMouse: 517 ; 0x00000000 ; 0x00460172 - HackCORE8394: FALSE, INME: TRUE
+**** Resetting IgnoreNextMouseEvent and ignoring WM_xBUTTONDOWN
```
while it was previously not ignored (INME reset to FALSE prematurely) without the patch:
```diff
-OnMouse: 512 ; 0x00000002 ; 0x00480170 - HackCORE8394: FALSE, INME: TRUE
-**** Resetting IgnoreNextMouseEvent and ignoring WM_xBUTTONDOWN
-OnMouse: 517 ; 0x00000000 ; 0x00480170 - HackCORE8394: FALSE, INME: FALSE
```
