### PR TITLE
[SHELL32] Fix 'Attempt to free an invalid HEAP address'

### DIFF
--- a/dll/win32/shell32/droptargets/CFSDropTarget.cpp
+++ b/dll/win32/shell32/droptargets/CFSDropTarget.cpp
@@ -72,7 +72,7 @@ HRESULT CFSDropTarget::_CopyItems(IShellFolder * pSFFrom, UINT cidl,
 
     TRACE ("(%p)->(%p,%u,%p)\n", this, pSFFrom, cidl, apidl);
 
-    STRRET strretFrom;
+    STRRET strretFrom = { 0 }; // Initialize strretFrom.pOleStr to NULL
     hr = pSFFrom->GetDisplayNameOf(NULL, SHGDN_FORPARSING, &strretFrom);
     if (FAILED_UNEXPECTEDLY(hr))
         return hr;

--- a/dll/win32/shell32/droptargets/CFSDropTarget.cpp
+++ b/dll/win32/shell32/droptargets/CFSDropTarget.cpp
@@ -74,7 +74,7 @@ HRESULT CFSDropTarget::_CopyItems(IShellFolder * pSFFrom, UINT cidl,
 
     STRRET strretFrom;
     hr = pSFFrom->GetDisplayNameOf(NULL, SHGDN_FORPARSING, &strretFrom);
-    if (FAILED_UNEXPECTEDLY(hr))
+    if (hr != S_OK)
         return hr;
 
     pszSrcList = BuildPathsList(strretFrom.pOleStr, cidl, apidl);

--- a/dll/win32/shell32/droptargets/CFSDropTarget.cpp
+++ b/dll/win32/shell32/droptargets/CFSDropTarget.cpp
@@ -72,7 +72,7 @@ HRESULT CFSDropTarget::_CopyItems(IShellFolder * pSFFrom, UINT cidl,
 
     TRACE ("(%p)->(%p,%u,%p)\n", this, pSFFrom, cidl, apidl);
 
-    STRRET strretFrom = { 0 }; // Initialize strretFrom.pOleStr to NULL
+    STRRET strretFrom;
     hr = pSFFrom->GetDisplayNameOf(NULL, SHGDN_FORPARSING, &strretFrom);
     if (FAILED_UNEXPECTEDLY(hr))
         return hr;

--- a/dll/win32/shell32/folders/CControlPanelFolder.cpp
+++ b/dll/win32/shell32/folders/CControlPanelFolder.cpp
@@ -489,7 +489,12 @@ HRESULT WINAPI CControlPanelFolder::GetUIObjectOf(HWND hwndOwner,
 HRESULT WINAPI CControlPanelFolder::GetDisplayNameOf(PCUITEMID_CHILD pidl, DWORD dwFlags, LPSTRRET strRet)
 {
     if (!pidl)
+    {
+        /* Take care of setting return value even with bad input. */
+        *strRet = { 0 };
+        TRACE("PIDL is NULL.\n");
         return S_FALSE;
+    }
 
     PIDLCPanelStruct *pCPanel = _ILGetCPanelPointer(pidl);
 

--- a/dll/win32/shell32/folders/CControlPanelFolder.cpp
+++ b/dll/win32/shell32/folders/CControlPanelFolder.cpp
@@ -411,7 +411,7 @@ HRESULT WINAPI CControlPanelFolder::GetAttributesOf(UINT cidl, PCUITEMID_CHILD_A
             else if (_ILIsSpecialFolder(*apidl))
                 m_regFolder->GetAttributesOf(1, apidl, rgfInOut);
             else
-                ERR("Got an unkown pidl here!\n");
+                ERR("Got an unknown pidl here!\n");
             apidl++;
             cidl--;
         }
@@ -489,12 +489,7 @@ HRESULT WINAPI CControlPanelFolder::GetUIObjectOf(HWND hwndOwner,
 HRESULT WINAPI CControlPanelFolder::GetDisplayNameOf(PCUITEMID_CHILD pidl, DWORD dwFlags, LPSTRRET strRet)
 {
     if (!pidl)
-    {
-        /* Take care of setting return value even with bad input. */
-        *strRet = { 0 };
-        TRACE("PIDL is NULL.\n");
         return S_FALSE;
-    }
 
     PIDLCPanelStruct *pCPanel = _ILGetCPanelPointer(pidl);
 


### PR DESCRIPTION
## Purpose

_Fix uninitialized variable use in CFSDropTarget.cpp._

JIRA issue: [CORE-18841](https://jira.reactos.org/browse/CORE-18841)

## Proposed changes

_Initialize STRRET strretFrom to all zeroes { 0 } to initialize strretFrom.pOleStr._
_This eventually propagates to heap.c:2304 which causes the error message in the title._