### PR TITLE
[ADVAPI32] Fix ordinals regression CORE-19039

### DIFF
--- a/dll/win32/advapi32/advapi32.spec
+++ b/dll/win32/advapi32/advapi32.spec
@@ -125,7 +125,7 @@
 @ stdcall CredUnmarshalCredentialA(str ptr ptr)
 @ stdcall CredUnmarshalCredentialW(wstr ptr ptr)
 @ stdcall CredWriteA(ptr long)
-# CredWriteDomainCredentialsA
+@ stub CredWriteDomainCredentialsA
 @ stub CredWriteDomainCredentialsW
 @ stdcall CredWriteW(ptr long)
 @ stub CredpConvertCredential


### PR DESCRIPTION
All ordinals > 128 regressed by
0.4.15-dev-305-g dd7fb63cd1b0c7f61d7503adefcfca8ce748cc60 and were off-by-one compared to 2k3sp2 and the ros-before-state.

Now all 684 ordinals seem to be fine again.

## Purpose

JIRA issue: [CORE-19039](https://jira.reactos.org/browse/CORE-19039)

Before and after pic: See the ticket.