### PR TITLE
[IEXPLORE][IEFRAME][SHELL32] Add Internet icon on Desktop

### DIFF
--- a/base/applications/iexplore/CMakeLists.txt
+++ b/base/applications/iexplore/CMakeLists.txt
@@ -1,5 +1,7 @@
 
-add_rc_deps(iexplore.rc ${CMAKE_CURRENT_SOURCE_DIR}/iexplore.ico)
+add_rc_deps(iexplore.rc
+    ${CMAKE_CURRENT_SOURCE_DIR}/iexplore.ico
+    ${CMAKE_CURRENT_SOURCE_DIR}/iexplore.inf)
 add_executable(iexplore main.c iexplore.rc)
 target_link_libraries(iexplore wine)
 set_module_type(iexplore win32gui UNICODE)

--- a/base/applications/iexplore/iexplore.inf
+++ b/base/applications/iexplore/iexplore.inf
@@ -18,7 +18,7 @@ HKCR,"CLSID\%CLSID_InternetExplorer%\VersionIndependentProgID",,,"InternetExplor
 
 ; FIXME: Implement CLSID_Internet in ieframe.dll (see CORE-18625)
 ; https://git.reactos.org/?p=reactos.git;a=blob;f=modules/rostests/apitests/com/ieframe.c;hb=bf2cec186cc7655e062ec0e53ccfac860bcae70d#l35
-HKCR,"CLSID\%CLSID_Internet%",,,"Internet Browser"
+HKCR,"CLSID\%CLSID_Internet%",,,"Internet"
 HKCR,"CLSID\%CLSID_Internet%","InfoTip",0x00020000,"@%SystemRoot%\system32\ieframe.dll,-881"
 HKCR,"CLSID\%CLSID_Internet%","LocalizedString",0x00020000,"@%SystemRoot%\system32\ieframe.dll,-880"
 HKCR,"CLSID\%CLSID_Internet%\DefaultIcon",,0x00020000,"%SystemRoot%\system32\shell32.dll,-14"

--- a/base/applications/iexplore/iexplore.inf
+++ b/base/applications/iexplore/iexplore.inf
@@ -18,7 +18,7 @@ HKCR,"CLSID\%CLSID_InternetExplorer%\VersionIndependentProgID",,,"InternetExplor
 
 ; FIXME: Implement CLSID_Internet in ieframe.dll (see CORE-18625)
 ; https://git.reactos.org/?p=reactos.git;a=blob;f=modules/rostests/apitests/com/ieframe.c;hb=bf2cec186cc7655e062ec0e53ccfac860bcae70d#l35
-HKCR,"CLSID\%CLSID_Internet%",,,"Internet"
+HKCR,"CLSID\%CLSID_Internet%",,,"Internet Browser"
 HKCR,"CLSID\%CLSID_Internet%","InfoTip",0x00020000,"@%SystemRoot%\system32\ieframe.dll,-881"
 HKCR,"CLSID\%CLSID_Internet%","LocalizedString",0x00020000,"@%SystemRoot%\system32\ieframe.dll,-880"
 HKCR,"CLSID\%CLSID_Internet%\DefaultIcon",,0x00020000,"%SystemRoot%\system32\shell32.dll,-512"

--- a/base/applications/iexplore/iexplore.inf
+++ b/base/applications/iexplore/iexplore.inf
@@ -16,12 +16,18 @@ HKCR,"CLSID\%CLSID_InternetExplorer%\LocalServer32",,,"""%16422%\Internet Explor
 HKCR,"CLSID\%CLSID_InternetExplorer%\ProgID",,,"InternetExplorer.Application.1"
 HKCR,"CLSID\%CLSID_InternetExplorer%\VersionIndependentProgID",,,"InternetExplorer.Application"
 
-HKCR,"CLSID\%CLSID_Internet%\DefaultIcon",,,"shdoclc.dll,-190"
-HKCR,"CLSID\%CLSID_Internet%\Shell",,,"OpenHomePage"
-HKCR,"CLSID\%CLSID_Internet%\Shell\OpenHomePage",,,"Open &Home Page"
-HKCR,"CLSID\%CLSID_Internet%\Shell\OpenHomePage\Command",,,"""%16422%\Internet Explorer\iexplore.exe"""
-HKCR,"CLSID\%CLSID_Internet%\ShellFolder",,2,"0x24"
+; FIXME: Implement CLSID_Internet in ieframe.dll (see CORE-18625)
+; https://git.reactos.org/?p=reactos.git;a=blob;f=modules/rostests/apitests/com/ieframe.c;hb=bf2cec186cc7655e062ec0e53ccfac860bcae70d#l35
+HKCR,"CLSID\%CLSID_Internet%",,,"Internet Browser"
+HKCR,"CLSID\%CLSID_Internet%","InfoTip",0x00020000,"@%SystemRoot%\system32\ieframe.dll,-881"
+HKCR,"CLSID\%CLSID_Internet%","LocalizedString",0x00020000,"@%SystemRoot%\system32\ieframe.dll,-880"
+HKCR,"CLSID\%CLSID_Internet%\DefaultIcon",,0x00020000,"%SystemRoot%\system32\shell32.dll,-14"
+; FIXME: should be "OpenHomePage" action
+HKCR,"CLSID\%CLSID_Internet%\Shell",,,"open"
+HKCR,"CLSID\%CLSID_Internet%\Shell\open",,,""
+HKCR,"CLSID\%CLSID_Internet%\Shell\open\Command",,,"rundll32.exe url,OpenURL https://www.google.com"
 
+HKCR,"CLSID\%CLSID_Internet%\ShellFolder",,2,"0x24"
 HKCR,"CLSID\%CLSID_InternetExplorerManager%\LocalServer32",,,"""%16422%\Internet Explorer\iexplore.exe"" -startmanager"
 
 

--- a/base/applications/iexplore/iexplore.inf
+++ b/base/applications/iexplore/iexplore.inf
@@ -25,9 +25,9 @@ HKCR,"CLSID\%CLSID_Internet%\DefaultIcon",,0x00020000,"%SystemRoot%\system32\she
 ; FIXME: should be "OpenHomePage" action
 HKCR,"CLSID\%CLSID_Internet%\Shell",,,"open"
 HKCR,"CLSID\%CLSID_Internet%\Shell\open",,,""
-HKCR,"CLSID\%CLSID_Internet%\Shell\open\Command",,,"rundll32.exe url,OpenURL https://www.google.com"
-
+HKCR,"CLSID\%CLSID_Internet%\Shell\open\Command",,,"rundll32.exe url,OpenURL https://google.com"
 HKCR,"CLSID\%CLSID_Internet%\ShellFolder",,2,"0x24"
+
 HKCR,"CLSID\%CLSID_InternetExplorerManager%\LocalServer32",,,"""%16422%\Internet Explorer\iexplore.exe"" -startmanager"
 
 

--- a/base/applications/iexplore/iexplore.inf
+++ b/base/applications/iexplore/iexplore.inf
@@ -21,7 +21,7 @@ HKCR,"CLSID\%CLSID_InternetExplorer%\VersionIndependentProgID",,,"InternetExplor
 HKCR,"CLSID\%CLSID_Internet%",,,"Internet"
 HKCR,"CLSID\%CLSID_Internet%","InfoTip",0x00020000,"@%SystemRoot%\system32\ieframe.dll,-881"
 HKCR,"CLSID\%CLSID_Internet%","LocalizedString",0x00020000,"@%SystemRoot%\system32\ieframe.dll,-880"
-HKCR,"CLSID\%CLSID_Internet%\DefaultIcon",,0x00020000,"%SystemRoot%\system32\shell32.dll,-14"
+HKCR,"CLSID\%CLSID_Internet%\DefaultIcon",,0x00020000,"%SystemRoot%\system32\shell32.dll,-512"
 ; FIXME: should be "OpenHomePage" action
 HKCR,"CLSID\%CLSID_Internet%\Shell",,,"open"
 HKCR,"CLSID\%CLSID_Internet%\Shell\open",,,""

--- a/dll/win32/ieframe/CMakeLists.txt
+++ b/dll/win32/ieframe/CMakeLists.txt
@@ -35,6 +35,8 @@ add_typelib(ieframe_v1.idl)
 list(APPEND ieframe_rc_deps
     ${CMAKE_CURRENT_SOURCE_DIR}/ieframe.rgs
     ${CMAKE_CURRENT_SOURCE_DIR}/ieframe_v1.rgs
+    ${CMAKE_CURRENT_SOURCE_DIR}/resources/ietoolbar.bmp
+    ${CMAKE_CURRENT_SOURCE_DIR}/resources/pages.ico
     ${CMAKE_CURRENT_BINARY_DIR}/ieframe_v1.tlb)
 
 set_source_files_properties(ieframe.rc PROPERTIES OBJECT_DEPENDS "${ieframe_rc_deps}")

--- a/dll/win32/ieframe/ieframe_v1.rgs
+++ b/dll/win32/ieframe/ieframe_v1.rgs
@@ -5,9 +5,21 @@ HKCR
     }
     NoRemove CLSID
     {
-        '{871C5380-42A0-1069-A2EA-08002B30309D}' = s 'Internet'
+        '{871C5380-42A0-1069-A2EA-08002B30309D}' = s 'Internet Browser'
         {
             InprocServer32 = s '%MODULE%' { val ThreadingModel = s 'Apartment' }
+            Shellex = s ''
+            {
+                ContextMenuHandlers = s ''
+                {
+                    ieframe = s '{871C5380-42A0-1069-A2EA-08002B30309D}'
+                    {
+                    }
+                }
+                MayChangeDefaultMenu = s ''
+                {
+                }
+            }
         }
         '{3C374A40-BAE4-11CF-BF7D-00AA006946EE}' = s 'Microsoft Url History Service'
         {

--- a/dll/win32/ieframe/lang/cs-CZ.rc
+++ b/dll/win32/ieframe/lang/cs-CZ.rc
@@ -45,6 +45,9 @@ IDR_BROWSE_MAIN_MENU MENU
 
 STRINGTABLE
 {
+    IDS_INTERNET "Internet Browser"
+    IDS_INTERNET_DESCRIPTION "Opens a Web browser and displays information on the Internet."
+
     IDS_TB_BACK             "Zpět"
     IDS_TB_FORWARD          "Vpřed"
     IDS_TB_STOP             "Stop"

--- a/dll/win32/ieframe/lang/cs-CZ.rc
+++ b/dll/win32/ieframe/lang/cs-CZ.rc
@@ -45,7 +45,7 @@ IDR_BROWSE_MAIN_MENU MENU
 
 STRINGTABLE
 {
-    IDS_INTERNET "Internet"
+    IDS_INTERNET "Internet Browser"
     IDS_INTERNET_DESCRIPTION "Opens a Web browser and displays information on the Internet."
 
     IDS_TB_BACK             "Zpět"

--- a/dll/win32/ieframe/lang/cs-CZ.rc
+++ b/dll/win32/ieframe/lang/cs-CZ.rc
@@ -45,7 +45,7 @@ IDR_BROWSE_MAIN_MENU MENU
 
 STRINGTABLE
 {
-    IDS_INTERNET "Internet Browser"
+    IDS_INTERNET "Internet"
     IDS_INTERNET_DESCRIPTION "Opens a Web browser and displays information on the Internet."
 
     IDS_TB_BACK             "Zpět"

--- a/dll/win32/ieframe/lang/de-DE.rc
+++ b/dll/win32/ieframe/lang/de-DE.rc
@@ -40,6 +40,9 @@ IDR_BROWSE_MAIN_MENU MENU
 
 STRINGTABLE
 {
+    IDS_INTERNET "Internet Browser"
+    IDS_INTERNET_DESCRIPTION "Opens a Web browser and displays information on the Internet."
+
     IDS_TB_BACK             "Zurück"
     IDS_TB_FORWARD          "Vorwärts"
     IDS_TB_STOP             "Stop"

--- a/dll/win32/ieframe/lang/de-DE.rc
+++ b/dll/win32/ieframe/lang/de-DE.rc
@@ -40,7 +40,7 @@ IDR_BROWSE_MAIN_MENU MENU
 
 STRINGTABLE
 {
-    IDS_INTERNET "Internet Browser"
+    IDS_INTERNET "Internet"
     IDS_INTERNET_DESCRIPTION "Opens a Web browser and displays information on the Internet."
 
     IDS_TB_BACK             "Zurück"

--- a/dll/win32/ieframe/lang/de-DE.rc
+++ b/dll/win32/ieframe/lang/de-DE.rc
@@ -40,7 +40,7 @@ IDR_BROWSE_MAIN_MENU MENU
 
 STRINGTABLE
 {
-    IDS_INTERNET "Internet"
+    IDS_INTERNET "Internet Browser"
     IDS_INTERNET_DESCRIPTION "Opens a Web browser and displays information on the Internet."
 
     IDS_TB_BACK             "Zurück"

--- a/dll/win32/ieframe/lang/en-US.rc
+++ b/dll/win32/ieframe/lang/en-US.rc
@@ -40,6 +40,9 @@ IDR_BROWSE_MAIN_MENU MENU
 
 STRINGTABLE
 {
+    IDS_INTERNET "Internet Browser"
+    IDS_INTERNET_DESCRIPTION "Opens a Web browser and displays information on the Internet."
+
     IDS_TB_BACK             "Back"
     IDS_TB_FORWARD          "Forward"
     IDS_TB_STOP             "Stop"

--- a/dll/win32/ieframe/lang/en-US.rc
+++ b/dll/win32/ieframe/lang/en-US.rc
@@ -40,7 +40,7 @@ IDR_BROWSE_MAIN_MENU MENU
 
 STRINGTABLE
 {
-    IDS_INTERNET "Internet"
+    IDS_INTERNET "Internet Browser"
     IDS_INTERNET_DESCRIPTION "Opens a Web browser and displays information on the Internet."
 
     IDS_TB_BACK             "Back"

--- a/dll/win32/ieframe/lang/en-US.rc
+++ b/dll/win32/ieframe/lang/en-US.rc
@@ -40,7 +40,7 @@ IDR_BROWSE_MAIN_MENU MENU
 
 STRINGTABLE
 {
-    IDS_INTERNET "Internet Browser"
+    IDS_INTERNET "Internet"
     IDS_INTERNET_DESCRIPTION "Opens a Web browser and displays information on the Internet."
 
     IDS_TB_BACK             "Back"

--- a/dll/win32/ieframe/lang/es-ES.rc
+++ b/dll/win32/ieframe/lang/es-ES.rc
@@ -42,6 +42,9 @@ IDR_BROWSE_MAIN_MENU MENU
 
 STRINGTABLE
 {
+    IDS_INTERNET "Internet Browser"
+    IDS_INTERNET_DESCRIPTION "Opens a Web browser and displays information on the Internet."
+
     IDS_TB_BACK             "Atrás"
     IDS_TB_FORWARD          "Adelante"
     IDS_TB_STOP             "Detener"

--- a/dll/win32/ieframe/lang/es-ES.rc
+++ b/dll/win32/ieframe/lang/es-ES.rc
@@ -42,7 +42,7 @@ IDR_BROWSE_MAIN_MENU MENU
 
 STRINGTABLE
 {
-    IDS_INTERNET "Internet Browser"
+    IDS_INTERNET "Internet"
     IDS_INTERNET_DESCRIPTION "Opens a Web browser and displays information on the Internet."
 
     IDS_TB_BACK             "Atrás"

--- a/dll/win32/ieframe/lang/es-ES.rc
+++ b/dll/win32/ieframe/lang/es-ES.rc
@@ -42,7 +42,7 @@ IDR_BROWSE_MAIN_MENU MENU
 
 STRINGTABLE
 {
-    IDS_INTERNET "Internet"
+    IDS_INTERNET "Internet Browser"
     IDS_INTERNET_DESCRIPTION "Opens a Web browser and displays information on the Internet."
 
     IDS_TB_BACK             "Atrás"

--- a/dll/win32/ieframe/lang/fr-FR.rc
+++ b/dll/win32/ieframe/lang/fr-FR.rc
@@ -40,6 +40,9 @@ IDR_BROWSE_MAIN_MENU MENU
 
 STRINGTABLE
 {
+    IDS_INTERNET "Internet Browser"
+    IDS_INTERNET_DESCRIPTION "Opens a Web browser and displays information on the Internet."
+
     IDS_TB_BACK             "Précédent"
     IDS_TB_FORWARD          "Suivant"
     IDS_TB_STOP             "Arrêter"

--- a/dll/win32/ieframe/lang/fr-FR.rc
+++ b/dll/win32/ieframe/lang/fr-FR.rc
@@ -40,7 +40,7 @@ IDR_BROWSE_MAIN_MENU MENU
 
 STRINGTABLE
 {
-    IDS_INTERNET "Internet"
+    IDS_INTERNET "Internet Browser"
     IDS_INTERNET_DESCRIPTION "Opens a Web browser and displays information on the Internet."
 
     IDS_TB_BACK             "Précédent"

--- a/dll/win32/ieframe/lang/fr-FR.rc
+++ b/dll/win32/ieframe/lang/fr-FR.rc
@@ -40,7 +40,7 @@ IDR_BROWSE_MAIN_MENU MENU
 
 STRINGTABLE
 {
-    IDS_INTERNET "Internet Browser"
+    IDS_INTERNET "Internet"
     IDS_INTERNET_DESCRIPTION "Opens a Web browser and displays information on the Internet."
 
     IDS_TB_BACK             "Précédent"

--- a/dll/win32/ieframe/lang/hu-HU.rc
+++ b/dll/win32/ieframe/lang/hu-HU.rc
@@ -40,6 +40,9 @@ IDR_BROWSE_MAIN_MENU MENU
 
 STRINGTABLE
 {
+    IDS_INTERNET "Internet Browser"
+    IDS_INTERNET_DESCRIPTION "Opens a Web browser and displays information on the Internet."
+
     IDS_TB_BACK             "Vissza"
     IDS_TB_FORWARD          "Előre"
     IDS_TB_STOP             "Leállítás"

--- a/dll/win32/ieframe/lang/hu-HU.rc
+++ b/dll/win32/ieframe/lang/hu-HU.rc
@@ -40,7 +40,7 @@ IDR_BROWSE_MAIN_MENU MENU
 
 STRINGTABLE
 {
-    IDS_INTERNET "Internet"
+    IDS_INTERNET "Internet Browser"
     IDS_INTERNET_DESCRIPTION "Opens a Web browser and displays information on the Internet."
 
     IDS_TB_BACK             "Vissza"

--- a/dll/win32/ieframe/lang/hu-HU.rc
+++ b/dll/win32/ieframe/lang/hu-HU.rc
@@ -40,7 +40,7 @@ IDR_BROWSE_MAIN_MENU MENU
 
 STRINGTABLE
 {
-    IDS_INTERNET "Internet Browser"
+    IDS_INTERNET "Internet"
     IDS_INTERNET_DESCRIPTION "Opens a Web browser and displays information on the Internet."
 
     IDS_TB_BACK             "Vissza"

--- a/dll/win32/ieframe/lang/id-ID.rc
+++ b/dll/win32/ieframe/lang/id-ID.rc
@@ -40,6 +40,9 @@ IDR_BROWSE_MAIN_MENU MENU
 
 STRINGTABLE
 {
+    IDS_INTERNET "Internet Browser"
+    IDS_INTERNET_DESCRIPTION "Opens a Web browser and displays information on the Internet."
+
     IDS_TB_BACK             "Kembali"
     IDS_TB_FORWARD          "Maju"
     IDS_TB_STOP             "Berhenti"

--- a/dll/win32/ieframe/lang/id-ID.rc
+++ b/dll/win32/ieframe/lang/id-ID.rc
@@ -40,7 +40,7 @@ IDR_BROWSE_MAIN_MENU MENU
 
 STRINGTABLE
 {
-    IDS_INTERNET "Internet Browser"
+    IDS_INTERNET "Internet"
     IDS_INTERNET_DESCRIPTION "Opens a Web browser and displays information on the Internet."
 
     IDS_TB_BACK             "Kembali"

--- a/dll/win32/ieframe/lang/id-ID.rc
+++ b/dll/win32/ieframe/lang/id-ID.rc
@@ -40,7 +40,7 @@ IDR_BROWSE_MAIN_MENU MENU
 
 STRINGTABLE
 {
-    IDS_INTERNET "Internet"
+    IDS_INTERNET "Internet Browser"
     IDS_INTERNET_DESCRIPTION "Opens a Web browser and displays information on the Internet."
 
     IDS_TB_BACK             "Kembali"

--- a/dll/win32/ieframe/lang/it-IT.rc
+++ b/dll/win32/ieframe/lang/it-IT.rc
@@ -40,6 +40,9 @@ IDR_BROWSE_MAIN_MENU MENU
 
 STRINGTABLE
 {
+    IDS_INTERNET "Internet Browser"
+    IDS_INTERNET_DESCRIPTION "Opens a Web browser and displays information on the Internet."
+
     IDS_TB_BACK             "Indietro"
     IDS_TB_FORWARD          "Avanti"
     IDS_TB_STOP             "Interrompi"

--- a/dll/win32/ieframe/lang/it-IT.rc
+++ b/dll/win32/ieframe/lang/it-IT.rc
@@ -40,7 +40,7 @@ IDR_BROWSE_MAIN_MENU MENU
 
 STRINGTABLE
 {
-    IDS_INTERNET "Internet"
+    IDS_INTERNET "Internet Browser"
     IDS_INTERNET_DESCRIPTION "Opens a Web browser and displays information on the Internet."
 
     IDS_TB_BACK             "Indietro"

--- a/dll/win32/ieframe/lang/it-IT.rc
+++ b/dll/win32/ieframe/lang/it-IT.rc
@@ -40,7 +40,7 @@ IDR_BROWSE_MAIN_MENU MENU
 
 STRINGTABLE
 {
-    IDS_INTERNET "Internet Browser"
+    IDS_INTERNET "Internet"
     IDS_INTERNET_DESCRIPTION "Opens a Web browser and displays information on the Internet."
 
     IDS_TB_BACK             "Indietro"

--- a/dll/win32/ieframe/lang/ja-JP.rc
+++ b/dll/win32/ieframe/lang/ja-JP.rc
@@ -40,6 +40,9 @@ IDR_BROWSE_MAIN_MENU MENU
 
 STRINGTABLE
 {
+    IDS_INTERNET "Internet Browser"
+    IDS_INTERNET_DESCRIPTION "Opens a Web browser and displays information on the Internet."
+
     IDS_TB_BACK             "戻る"
     IDS_TB_FORWARD          "進む"
     IDS_TB_STOP             "停止"

--- a/dll/win32/ieframe/lang/ja-JP.rc
+++ b/dll/win32/ieframe/lang/ja-JP.rc
@@ -40,7 +40,7 @@ IDR_BROWSE_MAIN_MENU MENU
 
 STRINGTABLE
 {
-    IDS_INTERNET "Internet"
+    IDS_INTERNET "Internet Browser"
     IDS_INTERNET_DESCRIPTION "Opens a Web browser and displays information on the Internet."
 
     IDS_TB_BACK             "戻る"

--- a/dll/win32/ieframe/lang/ja-JP.rc
+++ b/dll/win32/ieframe/lang/ja-JP.rc
@@ -40,7 +40,7 @@ IDR_BROWSE_MAIN_MENU MENU
 
 STRINGTABLE
 {
-    IDS_INTERNET "Internet Browser"
+    IDS_INTERNET "Internet"
     IDS_INTERNET_DESCRIPTION "Opens a Web browser and displays information on the Internet."
 
     IDS_TB_BACK             "戻る"

--- a/dll/win32/ieframe/lang/pl-PL.rc
+++ b/dll/win32/ieframe/lang/pl-PL.rc
@@ -40,6 +40,9 @@ IDR_BROWSE_MAIN_MENU MENU
 
 STRINGTABLE
 {
+    IDS_INTERNET "Internet Browser"
+    IDS_INTERNET_DESCRIPTION "Opens a Web browser and displays information on the Internet."
+
     IDS_TB_BACK             "Wstecz"
     IDS_TB_FORWARD          "Dalej"
     IDS_TB_STOP             "Zatrzymaj"

--- a/dll/win32/ieframe/lang/pl-PL.rc
+++ b/dll/win32/ieframe/lang/pl-PL.rc
@@ -40,7 +40,7 @@ IDR_BROWSE_MAIN_MENU MENU
 
 STRINGTABLE
 {
-    IDS_INTERNET "Internet"
+    IDS_INTERNET "Internet Browser"
     IDS_INTERNET_DESCRIPTION "Opens a Web browser and displays information on the Internet."
 
     IDS_TB_BACK             "Wstecz"

--- a/dll/win32/ieframe/lang/pl-PL.rc
+++ b/dll/win32/ieframe/lang/pl-PL.rc
@@ -40,7 +40,7 @@ IDR_BROWSE_MAIN_MENU MENU
 
 STRINGTABLE
 {
-    IDS_INTERNET "Internet Browser"
+    IDS_INTERNET "Internet"
     IDS_INTERNET_DESCRIPTION "Opens a Web browser and displays information on the Internet."
 
     IDS_TB_BACK             "Wstecz"

--- a/dll/win32/ieframe/lang/pt-PT.rc
+++ b/dll/win32/ieframe/lang/pt-PT.rc
@@ -40,6 +40,9 @@ IDR_BROWSE_MAIN_MENU MENU
 
 STRINGTABLE
 {
+    IDS_INTERNET "Internet Browser"
+    IDS_INTERNET_DESCRIPTION "Opens a Web browser and displays information on the Internet."
+
     IDS_TB_BACK             "Retroceder"
     IDS_TB_FORWARD          "Avançar"
     IDS_TB_STOP             "Parar"

--- a/dll/win32/ieframe/lang/pt-PT.rc
+++ b/dll/win32/ieframe/lang/pt-PT.rc
@@ -40,7 +40,7 @@ IDR_BROWSE_MAIN_MENU MENU
 
 STRINGTABLE
 {
-    IDS_INTERNET "Internet Browser"
+    IDS_INTERNET "Internet"
     IDS_INTERNET_DESCRIPTION "Opens a Web browser and displays information on the Internet."
 
     IDS_TB_BACK             "Retroceder"

--- a/dll/win32/ieframe/lang/pt-PT.rc
+++ b/dll/win32/ieframe/lang/pt-PT.rc
@@ -40,7 +40,7 @@ IDR_BROWSE_MAIN_MENU MENU
 
 STRINGTABLE
 {
-    IDS_INTERNET "Internet"
+    IDS_INTERNET "Internet Browser"
     IDS_INTERNET_DESCRIPTION "Opens a Web browser and displays information on the Internet."
 
     IDS_TB_BACK             "Retroceder"

--- a/dll/win32/ieframe/lang/ro-RO.rc
+++ b/dll/win32/ieframe/lang/ro-RO.rc
@@ -42,6 +42,9 @@ IDR_BROWSE_MAIN_MENU MENU
 
 STRINGTABLE
 {
+    IDS_INTERNET "Internet Browser"
+    IDS_INTERNET_DESCRIPTION "Opens a Web browser and displays information on the Internet."
+
     IDS_TB_BACK             "Înapoi"
     IDS_TB_FORWARD          "Înainte"
     IDS_TB_STOP             "Oprește"

--- a/dll/win32/ieframe/lang/ro-RO.rc
+++ b/dll/win32/ieframe/lang/ro-RO.rc
@@ -42,7 +42,7 @@ IDR_BROWSE_MAIN_MENU MENU
 
 STRINGTABLE
 {
-    IDS_INTERNET "Internet"
+    IDS_INTERNET "Internet Browser"
     IDS_INTERNET_DESCRIPTION "Opens a Web browser and displays information on the Internet."
 
     IDS_TB_BACK             "Înapoi"

--- a/dll/win32/ieframe/lang/ro-RO.rc
+++ b/dll/win32/ieframe/lang/ro-RO.rc
@@ -42,7 +42,7 @@ IDR_BROWSE_MAIN_MENU MENU
 
 STRINGTABLE
 {
-    IDS_INTERNET "Internet Browser"
+    IDS_INTERNET "Internet"
     IDS_INTERNET_DESCRIPTION "Opens a Web browser and displays information on the Internet."
 
     IDS_TB_BACK             "Înapoi"

--- a/dll/win32/ieframe/lang/ru-RU.rc
+++ b/dll/win32/ieframe/lang/ru-RU.rc
@@ -42,6 +42,9 @@ IDR_BROWSE_MAIN_MENU MENU
 
 STRINGTABLE
 {
+    IDS_INTERNET "Internet Browser"
+    IDS_INTERNET_DESCRIPTION "Opens a Web browser and displays information on the Internet."
+
     IDS_TB_BACK             "Назад"
     IDS_TB_FORWARD          "Вперед"
     IDS_TB_STOP             "Остановить"

--- a/dll/win32/ieframe/lang/ru-RU.rc
+++ b/dll/win32/ieframe/lang/ru-RU.rc
@@ -42,7 +42,7 @@ IDR_BROWSE_MAIN_MENU MENU
 
 STRINGTABLE
 {
-    IDS_INTERNET "Internet"
+    IDS_INTERNET "Internet Browser"
     IDS_INTERNET_DESCRIPTION "Opens a Web browser and displays information on the Internet."
 
     IDS_TB_BACK             "Назад"

--- a/dll/win32/ieframe/lang/ru-RU.rc
+++ b/dll/win32/ieframe/lang/ru-RU.rc
@@ -42,7 +42,7 @@ IDR_BROWSE_MAIN_MENU MENU
 
 STRINGTABLE
 {
-    IDS_INTERNET "Internet Browser"
+    IDS_INTERNET "Internet"
     IDS_INTERNET_DESCRIPTION "Opens a Web browser and displays information on the Internet."
 
     IDS_TB_BACK             "Назад"

--- a/dll/win32/ieframe/lang/tr-TR.rc
+++ b/dll/win32/ieframe/lang/tr-TR.rc
@@ -42,6 +42,9 @@ IDR_BROWSE_MAIN_MENU MENU
 
 STRINGTABLE
 {
+    IDS_INTERNET "Internet Browser"
+    IDS_INTERNET_DESCRIPTION "Opens a Web browser and displays information on the Internet."
+
     IDS_TB_BACK             "Geri"
     IDS_TB_FORWARD          "İleri"
     IDS_TB_STOP             "Dur"

--- a/dll/win32/ieframe/lang/tr-TR.rc
+++ b/dll/win32/ieframe/lang/tr-TR.rc
@@ -42,7 +42,7 @@ IDR_BROWSE_MAIN_MENU MENU
 
 STRINGTABLE
 {
-    IDS_INTERNET "Internet Browser"
+    IDS_INTERNET "Internet"
     IDS_INTERNET_DESCRIPTION "Opens a Web browser and displays information on the Internet."
 
     IDS_TB_BACK             "Geri"

--- a/dll/win32/ieframe/lang/tr-TR.rc
+++ b/dll/win32/ieframe/lang/tr-TR.rc
@@ -42,7 +42,7 @@ IDR_BROWSE_MAIN_MENU MENU
 
 STRINGTABLE
 {
-    IDS_INTERNET "Internet"
+    IDS_INTERNET "Internet Browser"
     IDS_INTERNET_DESCRIPTION "Opens a Web browser and displays information on the Internet."
 
     IDS_TB_BACK             "Geri"

--- a/dll/win32/ieframe/lang/zh-CN.rc
+++ b/dll/win32/ieframe/lang/zh-CN.rc
@@ -43,6 +43,9 @@ IDR_BROWSE_MAIN_MENU MENU
 
 STRINGTABLE
 {
+    IDS_INTERNET "Internet Browser"
+    IDS_INTERNET_DESCRIPTION "Opens a Web browser and displays information on the Internet."
+
     IDS_TB_BACK             "后退"
     IDS_TB_FORWARD          "前进"
     IDS_TB_STOP             "停止"

--- a/dll/win32/ieframe/lang/zh-CN.rc
+++ b/dll/win32/ieframe/lang/zh-CN.rc
@@ -43,7 +43,7 @@ IDR_BROWSE_MAIN_MENU MENU
 
 STRINGTABLE
 {
-    IDS_INTERNET "Internet"
+    IDS_INTERNET "Internet Browser"
     IDS_INTERNET_DESCRIPTION "Opens a Web browser and displays information on the Internet."
 
     IDS_TB_BACK             "后退"

--- a/dll/win32/ieframe/lang/zh-CN.rc
+++ b/dll/win32/ieframe/lang/zh-CN.rc
@@ -43,7 +43,7 @@ IDR_BROWSE_MAIN_MENU MENU
 
 STRINGTABLE
 {
-    IDS_INTERNET "Internet Browser"
+    IDS_INTERNET "Internet"
     IDS_INTERNET_DESCRIPTION "Opens a Web browser and displays information on the Internet."
 
     IDS_TB_BACK             "后退"

--- a/dll/win32/ieframe/lang/zh-TW.rc
+++ b/dll/win32/ieframe/lang/zh-TW.rc
@@ -49,6 +49,9 @@ IDR_BROWSE_MAIN_MENU MENU
 
 STRINGTABLE
 {
+    IDS_INTERNET "Internet Browser"
+    IDS_INTERNET_DESCRIPTION "Opens a Web browser and displays information on the Internet."
+
     IDS_TB_BACK             "上一頁"
     IDS_TB_FORWARD          "下一頁"
     IDS_TB_STOP             "停止"

--- a/dll/win32/ieframe/lang/zh-TW.rc
+++ b/dll/win32/ieframe/lang/zh-TW.rc
@@ -49,7 +49,7 @@ IDR_BROWSE_MAIN_MENU MENU
 
 STRINGTABLE
 {
-    IDS_INTERNET "Internet"
+    IDS_INTERNET "Internet Browser"
     IDS_INTERNET_DESCRIPTION "Opens a Web browser and displays information on the Internet."
 
     IDS_TB_BACK             "上一頁"

--- a/dll/win32/ieframe/lang/zh-TW.rc
+++ b/dll/win32/ieframe/lang/zh-TW.rc
@@ -49,7 +49,7 @@ IDR_BROWSE_MAIN_MENU MENU
 
 STRINGTABLE
 {
-    IDS_INTERNET "Internet Browser"
+    IDS_INTERNET "Internet"
     IDS_INTERNET_DESCRIPTION "Opens a Web browser and displays information on the Internet."
 
     IDS_TB_BACK             "上一頁"

--- a/dll/win32/ieframe/resource.h
+++ b/dll/win32/ieframe/resource.h
@@ -55,6 +55,9 @@
 #define ID_BROWSE_GOTOFAV_FIRST        2000
 #define ID_BROWSE_GOTOFAV_MAX          65000
 
+#define IDS_INTERNET                   880
+#define IDS_INTERNET_DESCRIPTION       881
+
 #define IDS_TB_BACK                    1100
 #define IDS_TB_FORWARD                 1101
 #define IDS_TB_STOP                    1102

--- a/dll/win32/shell32/folders/CDesktopFolder.cpp
+++ b/dll/win32/shell32/folders/CDesktopFolder.cpp
@@ -129,6 +129,7 @@ class CDesktopFolderEnum :
             LPITEMIDLIST pidl;
 
             static const WCHAR MyDocumentsClassString[] = L"{450D8FBA-AD25-11D0-98A8-0800361B1103}";
+            static const WCHAR InternetClassString[] = L"{871C5380-42A0-1069-A2EA-08002B30309D}";
 
             TRACE("(%p)->(flags=0x%08x)\n", this, dwFlags);
 
@@ -138,6 +139,8 @@ class CDesktopFolderEnum :
                 AddToEnumList(_ILCreateMyComputer());
                 if (IsNamespaceExtensionHidden(MyDocumentsClassString) < 1)
                     AddToEnumList(_ILCreateMyDocuments());
+                if (IsNamespaceExtensionHidden(InternetClassString) < 1)
+                    AddToEnumList(_ILCreateIExplore());
 
                 DWORD dwFetched;
                 while((S_OK == pRegEnumerator->Next(1, &pidl, &dwFetched)) && dwFetched)

--- a/dll/win32/shell32/folders/CRegFolder.cpp
+++ b/dll/win32/shell32/folders/CRegFolder.cpp
@@ -185,12 +185,15 @@ HRESULT CGuidItemExtractIcon_CreateInstance(LPCITEMIDLIST pidl, REFIID iid, LPVO
     }
     else
     {
+        // FIXME: Delete these hacks and make HCR_GetIconW and registry working
         if (IsEqualGUID(*riid, CLSID_MyComputer))
             initIcon->SetNormalIcon(swShell32Name, -IDI_SHELL_MY_COMPUTER);
         else if (IsEqualGUID(*riid, CLSID_MyDocuments))
             initIcon->SetNormalIcon(swShell32Name, -IDI_SHELL_MY_DOCUMENTS);
         else if (IsEqualGUID(*riid, CLSID_NetworkPlaces))
             initIcon->SetNormalIcon(swShell32Name, -IDI_SHELL_MY_NETWORK_PLACES);
+        else if (IsEqualGUID(*riid, CLSID_Internet))
+            initIcon->SetNormalIcon(swShell32Name, -IDI_SHELL_ENTIRE_NETWORK);
         else
             initIcon->SetNormalIcon(swShell32Name, -IDI_SHELL_FOLDER);
     }

--- a/dll/win32/shell32/folders/CRegFolder.cpp
+++ b/dll/win32/shell32/folders/CRegFolder.cpp
@@ -193,7 +193,7 @@ HRESULT CGuidItemExtractIcon_CreateInstance(LPCITEMIDLIST pidl, REFIID iid, LPVO
         else if (IsEqualGUID(*riid, CLSID_NetworkPlaces))
             initIcon->SetNormalIcon(swShell32Name, -IDI_SHELL_MY_NETWORK_PLACES);
         else if (IsEqualGUID(*riid, CLSID_Internet))
-            initIcon->SetNormalIcon(swShell32Name, -IDI_SHELL_ENTIRE_NETWORK);
+            initIcon->SetNormalIcon(swShell32Name, -IDI_SHELL_WEB_BROWSER);
         else
             initIcon->SetNormalIcon(swShell32Name, -IDI_SHELL_FOLDER);
     }


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-18625](https://jira.reactos.org/browse/CORE-18625)
relies on https://github.com/reactos/reactos/commit/1c91b0b61ddb893e7fb52e84c8d415fe426915de to work properly

## Proposed changes

- Add Internet icon on Desktop.
- Modify `"HKCR\CLSID\%CLSID_Internet%"` registry key.
- Add `IDS_INTERNET` and `IDS_INTERNET_DESCRITION` resource strings into `ieframe.dll`.
- Modify `dll/win32/shell32/folders/CDesktopFolder.cpp` and `dll/win32/shell32/folders/CRegFolder.cpp` to add the icon.

## Comparison

BEFORE:
![before](https://github.com/reactos/reactos/assets/2107452/3b54d9e0-e2d4-4483-8848-34bf00458fa9)
No internet icon.

AFTER:
![after](https://github.com/reactos/reactos/assets/2107452/0d3c8f22-ccff-4abf-9724-253cdde1ecde)
There is the Internet icon. You can hide/show the icon from Desktop's customization.

## TODO

- [x] Do tests.
