### PR TITLE
[BROWSEUI] Use details view by default

### DIFF
--- a/dll/win32/browseui/shellbrowser.cpp
+++ b/dll/win32/browseui/shellbrowser.cpp
@@ -815,8 +815,8 @@ HRESULT CShellBrowser::BrowseToPIDL(LPCITEMIDLIST pidl, long flags)
     if (FAILED_UNEXPECTEDLY(hResult))
         return hResult;
     IUnknown_GetClassID(newFolder, &clsid);
-    HasIconViewType = clsid == CLSID_MyComputer || clsid == CLSID_ControlPanel
-                      || clsid == CLSID_ShellDesktop;
+    HasIconViewType = clsid == CLSID_MyComputer || clsid == CLSID_ControlPanel ||
+                      clsid == CLSID_ShellDesktop;
 
     if (HasIconViewType)
         newFolderSettings.ViewMode = FVM_ICON;

--- a/dll/win32/browseui/shellbrowser.cpp
+++ b/dll/win32/browseui/shellbrowser.cpp
@@ -806,7 +806,7 @@ HRESULT CShellBrowser::BrowseToPIDL(LPCITEMIDLIST pidl, long flags)
     CComPtr<IShellFolder>                   newFolder;
     FOLDERSETTINGS                          newFolderSettings;
     HRESULT                                 hResult;
-    IPersist                                *pp;
+    CLSID                                   clsid;
     BOOL                                    HasIconViewType;
 
     // called by shell view to browse to new folder
@@ -814,15 +814,9 @@ HRESULT CShellBrowser::BrowseToPIDL(LPCITEMIDLIST pidl, long flags)
     hResult = SHBindToFolder(pidl, &newFolder);
     if (FAILED_UNEXPECTEDLY(hResult))
         return hResult;
-    hResult = newFolder->QueryInterface(IID_PPV_ARG(IPersist, &pp));
-    if (SUCCEEDED(hResult))
-    {
-        CLSID pclsid;
-        hResult = pp->GetClassID(&pclsid);
-        pp->Release();
-        HasIconViewType = pclsid == CLSID_MyComputer || pclsid == CLSID_ControlPanel
-                          || pclsid == CLSID_ShellDesktop;
-    }
+    IUnknown_GetClassID(newFolder, &clsid);
+    HasIconViewType = clsid == CLSID_MyComputer || clsid == CLSID_ControlPanel
+                      || clsid == CLSID_ShellDesktop;
 
     if (HasIconViewType)
         newFolderSettings.ViewMode = FVM_ICON;

--- a/dll/win32/browseui/shellbrowser.cpp
+++ b/dll/win32/browseui/shellbrowser.cpp
@@ -814,7 +814,6 @@ HRESULT CShellBrowser::BrowseToPIDL(LPCITEMIDLIST pidl, long flags)
     hResult = SHBindToFolder(pidl, &newFolder);
     if (FAILED_UNEXPECTEDLY(hResult))
         return hResult;
-    
     hResult = newFolder->QueryInterface(IID_PPV_ARG(IPersist, &pp));
     if (SUCCEEDED(hResult))
     {

--- a/dll/win32/browseui/shellbrowser.cpp
+++ b/dll/win32/browseui/shellbrowser.cpp
@@ -814,6 +814,7 @@ HRESULT CShellBrowser::BrowseToPIDL(LPCITEMIDLIST pidl, long flags)
     hResult = SHBindToFolder(pidl, &newFolder);
     if (FAILED_UNEXPECTEDLY(hResult))
         return hResult;
+    // HACK & FIXME: Get view mode from shellbag when fully implemented.
     IUnknown_GetClassID(newFolder, &clsid);
     HasIconViewType = clsid == CLSID_MyComputer || clsid == CLSID_ControlPanel ||
                       clsid == CLSID_ShellDesktop;


### PR DESCRIPTION
## Purpose
Use the details view by default in the file explorer, except in the Control Panel, My Computer, and Desktop folders. This follows the default behavior in Windows Vista+.

JIRA issue: [CORE-18904](https://jira.reactos.org/browse/CORE-18904)

## Proposed changes
- Use the icon view by default for My Computer, Control Panel, and Desktop
- Use the details view by default in all other folders

## TODO (in separate PRs)
- Call the "Start Navigation" sound event in ```CShellBrowser::BrowseToPIDL```
- Implement the "Display the full path in the title bar" option including setting persistence
- Properly implement ShellBags to allow the user to change the default view for each folder
- Implement ```Tiles``` view and set that view as the default for My Computer and Desktop