### PR TITLE
[APPWIZ] 'Create Shortcut' wizard: Accept arguments

### DIFF
--- a/dll/cpl/appwiz/appwiz.h
+++ b/dll/cpl/appwiz/appwiz.h
@@ -27,9 +27,10 @@ WINE_DEFAULT_DEBUG_CHANNEL(appwiz);
 
 typedef struct
 {
-   WCHAR szTarget[MAX_PATH];
+   WCHAR szTarget[2 * MAX_PATH];
    WCHAR szWorkingDirectory[MAX_PATH];
    WCHAR szDescription[MAX_PATH];
+   WCHAR szArguments[2 * MAX_PATH];
    WCHAR szOrigin[MAX_PATH];
    WCHAR szOldFile[MAX_PATH];
    WCHAR szLinkName[MAX_PATH];

--- a/dll/cpl/appwiz/createlink.c
+++ b/dll/cpl/appwiz/createlink.c
@@ -15,7 +15,6 @@
 #include <shellapi.h>
 #include <strsafe.h>
 #include <shlwapi_undoc.h>
-#include <undocshell.h>
 
 BOOL
 IsShortcut(HKEY hKey)

--- a/dll/cpl/appwiz/createlink.c
+++ b/dll/cpl/appwiz/createlink.c
@@ -327,25 +327,22 @@ WelcomeDlgProc(HWND hwndDlg,
                 /* Find the file */
                 WCHAR szFound[MAX_PATH];
                 StringCchCopyW(szFound, _countof(szFound), szPath);
-                if (!PathFindOnPathExW(szFound, NULL, WHICH_DEFAULT))
+                if (!PathFindOnPathExW(szFound, NULL, WHICH_DEFAULT) &&
+                    FindExecutableW(szPath, NULL, szFound) <= (HINSTANCE)(INT_PTR)32)
                 {
-                    /* Find by using "App Paths" registry */
-                    if (FindExecutableW(szPath, NULL, szFound) <= (HINSTANCE)(INT_PTR)32)
-                    {
-                        /* Not found */
-                        SendDlgItemMessageW(hwndDlg, IDC_SHORTCUT_LOCATION, EM_SETSEL, 0, -1);
+                    /* Not found */
+                    SendDlgItemMessageW(hwndDlg, IDC_SHORTCUT_LOCATION, EM_SETSEL, 0, -1);
 
-                        LoadStringW(hApplet, IDS_CREATE_SHORTCUT, szDesc, _countof(szDesc));
-                        LoadStringW(hApplet, IDS_ERROR_NOT_FOUND, szPath, _countof(szPath));
+                    LoadStringW(hApplet, IDS_CREATE_SHORTCUT, szDesc, _countof(szDesc));
+                    LoadStringW(hApplet, IDS_ERROR_NOT_FOUND, szPath, _countof(szPath));
 
-                        WCHAR szError[MAX_PATH + 100];
-                        StringCchPrintfW(szError, _countof(szError), szPath, pContext->szTarget);
-                        MessageBoxW(hwndDlg, szError, szDesc, MB_ICONERROR);
+                    WCHAR szError[MAX_PATH + 100];
+                    StringCchPrintfW(szError, _countof(szError), szPath, pContext->szTarget);
+                    MessageBoxW(hwndDlg, szError, szDesc, MB_ICONERROR);
 
-                        /* Prevent the wizard to go next */
-                        SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, -1);
-                        return TRUE;
-                    }
+                    /* Prevent the wizard to go next */
+                    SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, -1);
+                    return TRUE;
                 }
 
                 /* Rebuild target */

--- a/dll/cpl/appwiz/createlink.c
+++ b/dll/cpl/appwiz/createlink.c
@@ -14,7 +14,7 @@
 #include <commctrl.h>
 #include <shellapi.h>
 #include <strsafe.h>
-#include <shlwapi_undoc.h>
+#include <shlwapi_undoc.h> // for PathFindOnPathExW
 
 BOOL
 IsShortcut(HKEY hKey)
@@ -328,7 +328,7 @@ WelcomeDlgProc(HWND hwndDlg,
                 WCHAR szFound[MAX_PATH];
                 StringCchCopyW(szFound, _countof(szFound), szPath);
                 if (!PathFindOnPathExW(szFound, NULL, WHICH_DEFAULT) &&
-                    FindExecutableW(szPath, NULL, szFound) <= (HINSTANCE)(INT_PTR)32)
+                    ::FindExecutableW(szPath, NULL, szFound) <= (HINSTANCE)(INT_PTR)32)
                 {
                     /* Not found */
                     SendDlgItemMessageW(hwndDlg, IDC_SHORTCUT_LOCATION, EM_SETSEL, 0, -1);

--- a/dll/cpl/appwiz/createlink.c
+++ b/dll/cpl/appwiz/createlink.c
@@ -328,7 +328,7 @@ WelcomeDlgProc(HWND hwndDlg,
                 WCHAR szFound[MAX_PATH];
                 StringCchCopyW(szFound, _countof(szFound), szPath);
                 if (!PathFindOnPathExW(szFound, NULL, WHICH_DEFAULT) &&
-                    ::FindExecutableW(szPath, NULL, szFound) <= (HINSTANCE)(INT_PTR)32)
+                    FindExecutableW(szPath, NULL, szFound) <= (HINSTANCE)(INT_PTR)32)
                 {
                     /* Not found */
                     SendDlgItemMessageW(hwndDlg, IDC_SHORTCUT_LOCATION, EM_SETSEL, 0, -1);

--- a/sdk/include/reactos/undocshell.h
+++ b/sdk/include/reactos/undocshell.h
@@ -453,6 +453,7 @@ VOID WINAPI PathQualifyAW(LPVOID path);
 BOOL WINAPI PathResolveA(LPSTR path, LPCSTR *dirs, DWORD flags);
 BOOL WINAPI PathResolveW(LPWSTR path, LPCWSTR *dirs, DWORD flags);
 BOOL WINAPI PathResolveAW(LPVOID lpszPath, LPCVOID *alpszPaths, DWORD dwFlags);
+BOOL WINAPI PathResolve(LPVOID lpszPath, LPCVOID *alpszPaths, DWORD dwFlags);
 
 VOID WINAPI PathSetDlgItemPathAW(HWND hDlg, int nIDDlgItem, LPCVOID lpszPath);
 

--- a/sdk/include/reactos/undocshell.h
+++ b/sdk/include/reactos/undocshell.h
@@ -453,7 +453,6 @@ VOID WINAPI PathQualifyAW(LPVOID path);
 BOOL WINAPI PathResolveA(LPSTR path, LPCSTR *dirs, DWORD flags);
 BOOL WINAPI PathResolveW(LPWSTR path, LPCWSTR *dirs, DWORD flags);
 BOOL WINAPI PathResolveAW(LPVOID lpszPath, LPCVOID *alpszPaths, DWORD dwFlags);
-BOOL WINAPI PathResolve(LPVOID lpszPath, LPCVOID *alpszPaths, DWORD dwFlags);
 
 VOID WINAPI PathSetDlgItemPathAW(HWND hDlg, int nIDDlgItem, LPCVOID lpszPath);
 


### PR DESCRIPTION
## Purpose
Allow command line as `Create Shortcut` wizard's target.
JIRA issue: [CORE-5866](https://jira.reactos.org/browse/CORE-5866)

## Proposed changes

- Add `szArguments` member to `CREATE_LINK_CONTEXT` structure.
- Use `IShellLink::SetArguments`.
- Split arguments from command line text by using `PathGetArgsW` and `PathRemoveArgsW`.
- Find the first parameter by using `PathFindOnPathExW` and `FindExecutableW` and use the found file path.

## TODO

- [x] Do tests.

## Comparison

Win2k3:
![win2k3](https://github.com/reactos/reactos/assets/2107452/4cf49e4e-8c3f-4f42-9297-b50e904a20db)
The Win2k3 wizard accepts command line and creates shortcut files.

BEFORE:
![before](https://github.com/reactos/reactos/assets/2107452/ee63fefc-199b-434f-96b8-3c813bf49b2e)
The wizard won't accept command line.

![after](https://github.com/reactos/reactos/assets/2107452/181da451-75f2-459f-bb8c-906146431fea)
The wizard accepts command line and creates shortcut files.