### PR TITLE
[SHELL32] Communicate with GUI parts in non-main thread

### DIFF
--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -558,12 +558,12 @@ void CDefView::UpdateStatusbarWorker(HANDLE hThread)
         m_dwTotalSize = 0; // Don't calculate file size
         m_bIsOnlyFoldersSelected = false;
 
-        // It's a non-main thread. To communicate GUI parts, use posting message
+        // Here is in a non-main thread. To communicate GUI parts, use posting message
         PostMessage(SHV_UPDATE_STATUSBAR, 0, 0);
         return;
     }
 
-    // Sending message from a non-main thread to get the number of items
+    // Send a message from a non-main thread to get the number of items
     DWORD_PTR dwResult = 0;
     if (!::SendMessageTimeoutW(m_ListView, LVM_GETSELECTEDCOUNT, 0, 0,
                                SMTO_ABORTIFHUNG | SMTO_BLOCK, 500, &dwResult))
@@ -582,7 +582,7 @@ void CDefView::UpdateStatusbarWorker(HANDLE hThread)
         if (hThread != m_hUpdateStatusbarThread)
             return;
 
-        // Sending message from a non-main thread to get the next item
+        // Send a message from a non-main thread to get the next item
         dwResult = (DWORD)-1;
         if (!::SendMessageTimeoutW(m_ListView, LVM_GETNEXTITEM, nItem, uFileFlags,
                                    SMTO_ABORTIFHUNG | SMTO_BLOCK, 500, &dwResult))
@@ -605,7 +605,7 @@ void CDefView::UpdateStatusbarWorker(HANDLE hThread)
     m_dwTotalSize = uTotalFileSize;
     m_bIsOnlyFoldersSelected = bIsOnlyFoldersSelected;
 
-    // Here is a non-main thread. To communicate GUI parts, use posting message
+    // Here is in a non-main thread. To communicate GUI parts, use posting message
     PostMessage(SHV_UPDATE_STATUSBAR, 0, 0);
 }
 

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -2346,46 +2346,43 @@ LRESULT CDefView::OnUpdateStatusBar(UINT uMsg, WPARAM wParam, LPARAM lParam, BOO
 {
     // Here is in the main thread. We can operate GUI parts directly
     LRESULT lResult;
-    WCHAR szFormat[MAX_PATH], szPartText[MAX_PATH];
+    CStringW szFormat, szPartText;
     LPARAM pIcon = NULL;
 
     UINT cSelectedItems = m_ListView.GetSelectedCount();
     if (cSelectedItems > 0)
-    {
-        LoadStringW(shell32_hInstance, IDS_OBJECTS_SELECTED, szFormat, _countof(szFormat));
-        StringCchPrintfW(szPartText, _countof(szPartText), szFormat, cSelectedItems);
-    }
+        szFormat.Format(IDS_OBJECTS_SELECTED, cSelectedItems);
     else
-    {
-        LoadStringW(shell32_hInstance, IDS_OBJECTS, szFormat, _countof(szFormat));
-        StringCchPrintfW(szPartText, _countof(szPartText), szFormat, m_ListView.GetItemCount());
-    }
+        szFormat.Format(IDS_OBJECTS, m_ListView.GetItemCount());
 
     // Update statusbar index-0 part
-    m_pShellBrowser->SendControlMsg(FCW_STATUS, SB_SETTEXT, 0, (LPARAM)szPartText, &lResult);
+    m_pShellBrowser->SendControlMsg(FCW_STATUS, SB_SETTEXT, 0, (LPARAM)(LPCWSTR)szPartText, &lResult);
 
     if (!m_isParentFolderSpecial) // It's not a special folder
     {
         // Don't show the file size text if there is 0 bytes in the folder OR
         // we only have folders selected.
-        szPartText[0] = UNICODE_NULL;
+        szPartText.Empty();
         if ((cSelectedItems > 0 && !m_bIsOnlyFoldersSelected) || m_dwTotalSize > 0)
-            StrFormatByteSizeW(m_dwTotalSize, szPartText, _countof(szPartText));
+        {
+            StrFormatByteSizeW(m_dwTotalSize, szPartText.GetBuffer(MAX_PATH), MAX_PATH);
+            szPartText.ReleaseBuffer();
+        }
 
         // Update statusbar index-1 part
-        m_pShellBrowser->SendControlMsg(FCW_STATUS, SB_SETTEXT, 1, (LPARAM)szPartText, &lResult);
+        m_pShellBrowser->SendControlMsg(FCW_STATUS, SB_SETTEXT, 1, (LPARAM)(LPCWSTR)szPartText, &lResult);
 
         // If we are in a Recycle Bin folder then show no text for the location part.
-        szPartText[0] = UNICODE_NULL;
+        szPartText.Empty();
         if (!_ILIsBitBucket(m_pidlParent))
         {
-            LoadStringW(shell32_hInstance, IDS_MYCOMPUTER, szPartText, _countof(szPartText));
+            szPartText.LoadString(IDS_MYCOMPUTER);
             pIcon = (LPARAM)m_hMyComputerIcon;
         }
 
         // Update statusbar index-2 part
         m_pShellBrowser->SendControlMsg(FCW_STATUS, SB_SETICON, 2, pIcon, &lResult);
-        m_pShellBrowser->SendControlMsg(FCW_STATUS, SB_SETTEXT, 2, (LPARAM)szPartText, &lResult);
+        m_pShellBrowser->SendControlMsg(FCW_STATUS, SB_SETTEXT, 2, (LPARAM)(LPCWSTR)szPartText, &lResult);
     }
 
     return 0;

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -566,10 +566,10 @@ void CDefView::UpdateStatusbarWorker(HANDLE hThread)
         return;
     }
 
-    // Sending message from the different thread to get the number of items
+    // Sending message from a non-main thread to get the number of items
     DWORD_PTR dwResult = 0;
     if (!::SendMessageTimeoutW(m_ListView, LVM_GETSELECTEDCOUNT, 0, 0,
-                               SMTO_ABORTIFHUNG | SMTO_BLOCK, 1000, &dwResult))
+                               SMTO_ABORTIFHUNG | SMTO_BLOCK, 500, &dwResult))
     {
         return;
     }
@@ -585,10 +585,10 @@ void CDefView::UpdateStatusbarWorker(HANDLE hThread)
         if (hThread != m_hUpdateStatusbarThread)
             return;
 
-        // Sending message from the different thread to get the next item
+        // Sending message from a non-main thread to get the next item
         dwResult = (DWORD)-1;
         if (!::SendMessageTimeoutW(m_ListView, LVM_GETNEXTITEM, nItem, uFileFlags,
-                                   SMTO_ABORTIFHUNG | SMTO_BLOCK, 1000, &dwResult))
+                                   SMTO_ABORTIFHUNG | SMTO_BLOCK, 500, &dwResult))
         {
             return;
         }
@@ -608,7 +608,7 @@ void CDefView::UpdateStatusbarWorker(HANDLE hThread)
     m_dwTotalSize = uTotalFileSize;
     m_bIsOnlyFoldersSelected = bIsOnlyFoldersSelected;
 
-    // It's different from the main thread. To communicate GUI parts, use timer
+    // Here is a non-main thread. To communicate GUI parts, use timer
     SetTimer(TIMERID_UPDATE_STATUSBAR, UPDATE_STATUSBAR_DELAY, NULL);
 }
 

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -49,7 +49,7 @@ typedef struct
     INT     nLastHeaderID;
 } LISTVIEW_SORT_INFO, *LPLISTVIEW_SORT_INFO;
 
-#define SHV_CHANGE_NOTIFY (WM_USER + 0x1111)
+#define SHV_CHANGE_NOTIFY WM_USER + 0x1111
 
 #define TIMERID_UPDATE_STATUSBAR 9999
 #define UPDATE_STATUSBAR_DELAY 100
@@ -160,7 +160,6 @@ class CDefView :
         HANDLE                    m_hUpdateStatusbarThread;
         DWORD                     m_dwTotalSize;
         bool                      m_bIsOnlyFoldersSelected;
-
 
     private:
         HRESULT _MergeToolbar();

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -627,10 +627,11 @@ void CDefView::UpdateStatusbar()
                                                                 this, CREATE_SUSPENDED, NULL));
     if (hNewThread)
     {
-        // Clear some parts at beginning
+        // Clear parts at beginning
         LRESULT lResult;
         m_pShellBrowser->SendControlMsg(FCW_STATUS, SB_SETTEXT, 0, (LPARAM)L"", &lResult);
         m_pShellBrowser->SendControlMsg(FCW_STATUS, SB_SETTEXT, 1, (LPARAM)L"", &lResult);
+        m_pShellBrowser->SendControlMsg(FCW_STATUS, SB_SETTEXT, 2, (LPARAM)L"", &lResult);
 
         HANDLE hOldThread = ::InterlockedExchangePointer(&m_hUpdateStatusbarThread, hNewThread);
 
@@ -2670,7 +2671,8 @@ HRESULT WINAPI CDefView::DestroyViewWindow()
         hOldThread = ::InterlockedExchangePointer(&m_hUpdateStatusbarThread, hOldThread);
         ::WaitForSingleObject(hOldThread, 3000);
 
-        ::CloseHandle(hOldThread);
+        if (hOldThread)
+            ::CloseHandle(hOldThread);
     }
 
     /* Make absolutely sure all our UI is cleaned up */

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -156,9 +156,9 @@ class CDefView :
 
         HICON                     m_hMyComputerIcon;
         // NOTE: We cannot use std::atomic yet. std::atomic is better than volatile+Interlocked.
-        volatile HANDLE           m_hUpdateStatusbarThread; // Used to update statusbar
-        DWORD                     m_dwTotalSize;            // Used to update statusbar
-        bool                      m_bIsOnlyFoldersSelected; // Used to update statusbar
+        alignas(8) volatile HANDLE m_hUpdateStatusbarThread; // Used to update statusbar
+        DWORD                      m_dwTotalSize;            // Used to update statusbar
+        bool                       m_bIsOnlyFoldersSelected; // Used to update statusbar
 
     private:
         HRESULT _MergeToolbar();

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -2665,10 +2665,8 @@ HRESULT WINAPI CDefView::DestroyViewWindow()
 
     if (m_hUpdateStatusbarThread)
     {
-        HANDLE hOldThread = NULL;
-
         // Assigning NULL to m_hUpdateStatusbarThread will terminate the target thread
-        hOldThread = ::InterlockedExchangePointer(&m_hUpdateStatusbarThread, hOldThread);
+        HANDLE hOldThread = ::InterlockedExchangePointer(&m_hUpdateStatusbarThread, NULL);
         ::WaitForSingleObject(hOldThread, 3000);
 
         if (hOldThread)

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -2337,7 +2337,7 @@ static BOOL ILIsParentOrSpecialParent(PCIDLIST_ABSOLUTE pidl1, PCIDLIST_ABSOLUTE
 
 LRESULT CDefView::OnUpdateStatusBar(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled)
 {
-    // Here is the main thread. We can use GUI parts directly
+    // Here is in the main thread. We can operate GUI parts directly
     LRESULT lResult;
     WCHAR szFormat[MAX_PATH], szPartText[MAX_PATH];
     LPARAM pIcon = NULL;

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -157,9 +157,9 @@ class CDefView :
         SFVM_CUSTOMVIEWINFO_DATA  m_viewinfo_data;
 
         HICON                     m_hMyComputerIcon;
-        HANDLE                    m_hUpdateStatusbarThread;
-        DWORD                     m_dwTotalSize;
-        bool                      m_bIsOnlyFoldersSelected;
+        HANDLE                    m_hUpdateStatusbarThread; // Used to update statusbar
+        DWORD                     m_dwTotalSize;            // Used to update statusbar
+        bool                      m_bIsOnlyFoldersSelected; // Used to update statusbar
 
     private:
         HRESULT _MergeToolbar();
@@ -2340,6 +2340,7 @@ static BOOL ILIsParentOrSpecialParent(PCIDLIST_ABSOLUTE pidl1, PCIDLIST_ABSOLUTE
 
 LRESULT CDefView::OnTimer(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled)
 {
+    // Here is the main thread. We can use GUI parts directly
     LRESULT lResult;
     WCHAR szFormat[MAX_PATH], szPartText[MAX_PATH];
     LPARAM pIcon = NULL;
@@ -2360,7 +2361,7 @@ LRESULT CDefView::OnTimer(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandle
             StringCchPrintfW(szPartText, _countof(szPartText), szFormat, m_ListView.GetItemCount());
         }
 
-        // Update statusbar index 0 part
+        // Update statusbar index-0 part
         m_pShellBrowser->SendControlMsg(FCW_STATUS, SB_SETTEXT, 0, (LPARAM)szPartText, &lResult);
 
         if (!m_isParentFolderSpecial)
@@ -2371,6 +2372,7 @@ LRESULT CDefView::OnTimer(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandle
             if ((cSelectedItems > 0 && !m_bIsOnlyFoldersSelected) || m_dwTotalSize > 0)
                 StrFormatByteSizeW(m_dwTotalSize, szPartText, _countof(szPartText));
 
+            // Update statusbar index-1 part
             m_pShellBrowser->SendControlMsg(FCW_STATUS, SB_SETTEXT, 1, (LPARAM)szPartText, &lResult);
 
             // If we are in a Recycle Bin folder then show no text for the location part.
@@ -2381,7 +2383,7 @@ LRESULT CDefView::OnTimer(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandle
                 pIcon = (LPARAM)m_hMyComputerIcon;
             }
 
-            // Update statusbar index 2 part
+            // Update statusbar index-2 part
             m_pShellBrowser->SendControlMsg(FCW_STATUS, SB_SETICON, 2, pIcon, &lResult);
             m_pShellBrowser->SendControlMsg(FCW_STATUS, SB_SETTEXT, 2, (LPARAM)szPartText, &lResult);
         }

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -552,6 +552,7 @@ void CDefView::CheckToolbar()
     }
 }
 
+// This function is used in non-main thread.
 void CDefView::UpdateStatusbarWorker(HANDLE hThread)
 {
     KillTimer(TIMERID_UPDATE_STATUSBAR);
@@ -561,7 +562,7 @@ void CDefView::UpdateStatusbarWorker(HANDLE hThread)
         m_dwTotalSize = 0; // Don't calculate file size
         m_bIsOnlyFoldersSelected = false;
 
-        // It's different from the main thread. To communicate GUI parts, use timer
+        // It's a non-main thread. To communicate GUI parts, use timer
         SetTimer(TIMERID_UPDATE_STATUSBAR, UPDATE_STATUSBAR_DELAY, NULL);
         return;
     }

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -558,7 +558,7 @@ void CDefView::UpdateStatusbarWorker(HANDLE hThread)
         m_dwTotalSize = 0; // Don't calculate file size
         m_bIsOnlyFoldersSelected = false;
 
-        // Here is in a non-main thread. To communicate GUI parts, use posting message
+        // Here is in a non-main thread. To communicate with GUI parts, use posting message
         PostMessage(SHV_UPDATE_STATUSBAR, 0, 0);
         return;
     }
@@ -605,7 +605,7 @@ void CDefView::UpdateStatusbarWorker(HANDLE hThread)
     m_dwTotalSize = uTotalFileSize;
     m_bIsOnlyFoldersSelected = bIsOnlyFoldersSelected;
 
-    // Here is in a non-main thread. To communicate GUI parts, use posting message
+    // Here is in a non-main thread. To communicate with GUI parts, use posting message
     PostMessage(SHV_UPDATE_STATUSBAR, 0, 0);
 }
 

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -563,7 +563,7 @@ void CDefView::UpdateStatusbarWorker(HANDLE hThread)
         return;
     }
 
-    // Send a message from a non-main thread to get the number of items
+    // Sending a message from a non-main thread to get the number of selected items
     DWORD_PTR dwResult = 0;
     if (!::SendMessageTimeoutW(m_ListView, LVM_GETSELECTEDCOUNT, 0, 0,
                                SMTO_ABORTIFHUNG | SMTO_BLOCK, 500, &dwResult))
@@ -582,7 +582,7 @@ void CDefView::UpdateStatusbarWorker(HANDLE hThread)
         if (hThread != m_hUpdateStatusbarThread)
             return;
 
-        // Send a message from a non-main thread to get the next item
+        // Sending a message from a non-main thread to get the next item
         dwResult = (DWORD)-1;
         if (!::SendMessageTimeoutW(m_ListView, LVM_GETNEXTITEM, nItem, uFileFlags,
                                    SMTO_ABORTIFHUNG | SMTO_BLOCK, 500, &dwResult))

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -155,7 +155,8 @@ class CDefView :
         SFVM_CUSTOMVIEWINFO_DATA  m_viewinfo_data;
 
         HICON                     m_hMyComputerIcon;
-        HANDLE                    m_hUpdateStatusbarThread; // Used to update statusbar
+        // NOTE: We cannot use std::atomic yet. std::atomic is better than volatile+Interlocked.
+        volatile HANDLE           m_hUpdateStatusbarThread; // Used to update statusbar
         DWORD                     m_dwTotalSize;            // Used to update statusbar
         bool                      m_bIsOnlyFoldersSelected; // Used to update statusbar
 

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -612,7 +612,9 @@ void CDefView::UpdateStatusbarWorker(HANDLE hThread)
 unsigned __stdcall CDefView::_UpdateStatusbarProc(void *args)
 {
     CDefView* pView = static_cast<CDefView*>(args);
-    pView->UpdateStatusbarWorker(pView->m_hUpdateStatusbarThread);
+    HANDLE hThread = pView->m_hUpdateStatusbarThread;
+    if (hThread == pView->m_hUpdateStatusbarThread)
+        pView->UpdateStatusbarWorker(hThread);
     pView->Release();
     return 0;
 }

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -2364,7 +2364,7 @@ LRESULT CDefView::OnTimer(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandle
         // Update statusbar index-0 part
         m_pShellBrowser->SendControlMsg(FCW_STATUS, SB_SETTEXT, 0, (LPARAM)szPartText, &lResult);
 
-        if (!m_isParentFolderSpecial)
+        if (!m_isParentFolderSpecial) // It's not a special folder
         {
             // Don't show the file size text if there is 0 bytes in the folder OR
             // we only have folders selected.

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -566,7 +566,7 @@ void CDefView::UpdateStatusbarWorker(HANDLE hThread)
     // Sending a message from a non-main thread to get the number of selected items
     DWORD_PTR dwResult = 0;
     if (!::SendMessageTimeoutW(m_ListView, LVM_GETSELECTEDCOUNT, 0, 0,
-                               SMTO_ABORTIFHUNG | SMTO_BLOCK, 500, &dwResult))
+                               SMTO_ABORTIFHUNG | SMTO_BLOCK, 300, &dwResult))
     {
         return;
     }
@@ -585,7 +585,7 @@ void CDefView::UpdateStatusbarWorker(HANDLE hThread)
         // Sending a message from a non-main thread to get the next item
         dwResult = (DWORD)-1;
         if (!::SendMessageTimeoutW(m_ListView, LVM_GETNEXTITEM, nItem, uFileFlags,
-                                   SMTO_ABORTIFHUNG | SMTO_BLOCK, 500, &dwResult))
+                                   SMTO_ABORTIFHUNG | SMTO_BLOCK, 300, &dwResult))
         {
             return;
         }
@@ -627,7 +627,14 @@ void CDefView::UpdateStatusbar()
                                                                 this, CREATE_SUSPENDED, NULL));
     if (hNewThread)
     {
+        // Clear some parts at beginning
+        LRESULT lResult;
+        m_pShellBrowser->SendControlMsg(FCW_STATUS, SB_SETTEXT, 0, (LPARAM)L"", &lResult);
+        m_pShellBrowser->SendControlMsg(FCW_STATUS, SB_SETTEXT, 1, (LPARAM)L"", &lResult);
+
         HANDLE hOldThread = ::InterlockedExchangePointer(&m_hUpdateStatusbarThread, hNewThread);
+
+        // Restart the thread
         ::ResumeThread(hNewThread);
 
         if (hOldThread)

--- a/dll/win32/shell32/CMakeLists.txt
+++ b/dll/win32/shell32/CMakeLists.txt
@@ -110,6 +110,8 @@ add_library(shell32 MODULE
 if(MSVC)
     # error C4311: 'type cast': pointer truncation from 'HANDLE' to 'INT'
     remove_target_compile_option(shell32 "/we4311")
+    # volatile is MS volatile
+    target_compile_options(shell32 PRIVATE "/volatile:ms")
 endif()
 
 add_typelib(shell32_shldisp.idl)


### PR DESCRIPTION
## Purpose

#5420 (https://github.com/reactos/reactos/commit/9a1487f3a8997e3ea10328749dada70222868e54) causes regression. This PR will fix it.

JIRA issue: [CORE-19044](https://jira.reactos.org/browse/CORE-19044)

![after](https://github.com/reactos/reactos/assets/2107452/d202ad92-16ea-4528-96e6-539f74df1ea0)

## Proposed changes

- Use `InterlockedExchangePointer` to set the thread handle.
- Modify wait timeout as `3000` from `INFINITE`.
- Don't operate GUI parts from non-main thread. Use `PostMessage` and `SendMessageTimeout` to communicate with the GUI parts from non-main thread.

## TODO

- [x] Do small tests.
- [ ] Do big tests.