### PR TITLE
[NTOS:KE] Implement KeFreezeExecution and KeThawExecution for SMP

### DIFF
--- a/ntoskrnl/include/internal/ke.h
+++ b/ntoskrnl/include/internal/ke.h
@@ -11,6 +11,11 @@ extern "C"
 
 /* INTERNAL KERNEL TYPES ****************************************************/
 
+/* Matches windbg expectation */
+#define IPI_FROZEN_RUNNING 0
+#define IPI_FROZEN_HALTED 2
+#define IPI_FROZEN_THAWING 3
+
 typedef struct _WOW64_PROCESS
 {
   PVOID Wow64;


### PR DESCRIPTION
## Purpose

Provide the functionality needed to get every other processor in the system to freeze and thaw when requested.
This PR requires one of the SMP HAL PRs to be merged and my IPI work which ill submit in separate request to work. I'll try to get that done and I'll updated the description here when I have time.

## Proposed changes
- Create KiFreezeTargetExecution which holds all the other cores in a specific state
- Implement the ability to freeze and thaw processors using the correct PRCB elements so it shows up in Windbg with the !ipi command.

## TODO

- [x]  Check how windows uses KiFreezeTargetExecution to handle context switching (Will be PRed at a later date for simplicity of just getting this done)
- [x]  Check to make sure this will work on x64 when that has it's bootup code implemented.