### PR TITLE
[APPWIZ] Add title caption to 'Browse for Folder'

### DIFF
--- a/dll/cpl/appwiz/createlink.c
+++ b/dll/cpl/appwiz/createlink.c
@@ -234,6 +234,7 @@ WelcomeDlgProc(HWND hwndDlg,
     LPPSHNOTIFY lppsn;
     WCHAR szPath[MAX_PATH * 2];
     WCHAR szDesc[100];
+    WCHAR szTitle[100];
     BROWSEINFOW brws;
     LPITEMIDLIST pidllist;
     LPWSTR pch;
@@ -265,10 +266,12 @@ WelcomeDlgProc(HWND hwndDlg,
             switch(LOWORD(wParam))
             {
                 case IDC_SHORTCUT_BROWSE:
+                    LoadStringW(hApplet, IDS_BROWSE_FOR_TARGET, szTitle, _countof(szTitle));
                     ZeroMemory(&brws, sizeof(brws));
                     brws.hwndOwner = hwndDlg;
                     brws.pidlRoot = NULL;
                     brws.pszDisplayName = szPath;
+                    brws.lpszTitle = szTitle;
                     brws.ulFlags = BIF_BROWSEINCLUDEFILES | BIF_RETURNONLYFSDIRS |
                                    BIF_NEWDIALOGSTYLE | BIF_SHAREABLE;
                     brws.lpfn = NULL;

--- a/dll/cpl/appwiz/lang/bg-BG.rc
+++ b/dll/cpl/appwiz/lang/bg-BG.rc
@@ -86,4 +86,5 @@ BEGIN
     IDS_NO_DIRECTORY "No directory given!"
     IDS_INVALID_PATH "The given path is invalid!"
     IDS_INVALID_NAME "The shortcut name you entered either contained characters that are invalid for file names or was too long."
+    IDS_BROWSE_FOR_TARGET "Please select the target of the shortcut below:"
 END

--- a/dll/cpl/appwiz/lang/cs-CZ.rc
+++ b/dll/cpl/appwiz/lang/cs-CZ.rc
@@ -91,4 +91,5 @@ BEGIN
     IDS_NO_DIRECTORY "No directory given!"
     IDS_INVALID_PATH "The given path is invalid!"
     IDS_INVALID_NAME "The shortcut name you entered either contained characters that are invalid for file names or was too long."
+    IDS_BROWSE_FOR_TARGET "Please select the target of the shortcut below:"
 END

--- a/dll/cpl/appwiz/lang/de-DE.rc
+++ b/dll/cpl/appwiz/lang/de-DE.rc
@@ -86,4 +86,5 @@ BEGIN
     IDS_NO_DIRECTORY "No directory given!"
     IDS_INVALID_PATH "The given path is invalid!"
     IDS_INVALID_NAME "The shortcut name you entered either contained characters that are invalid for file names or was too long."
+    IDS_BROWSE_FOR_TARGET "Please select the target of the shortcut below:"
 END

--- a/dll/cpl/appwiz/lang/el-GR.rc
+++ b/dll/cpl/appwiz/lang/el-GR.rc
@@ -86,4 +86,5 @@ BEGIN
     IDS_NO_DIRECTORY "No directory given!"
     IDS_INVALID_PATH "The given path is invalid!"
     IDS_INVALID_NAME "The shortcut name you entered either contained characters that are invalid for file names or was too long."
+    IDS_BROWSE_FOR_TARGET "Please select the target of the shortcut below:"
 END

--- a/dll/cpl/appwiz/lang/en-US.rc
+++ b/dll/cpl/appwiz/lang/en-US.rc
@@ -86,4 +86,5 @@ BEGIN
     IDS_NO_DIRECTORY "No directory given!"
     IDS_INVALID_PATH "The given path is invalid!"
     IDS_INVALID_NAME "The shortcut name you entered either contained characters that are invalid for file names or was too long."
+    IDS_BROWSE_FOR_TARGET "Please select the target of the shortcut below:"
 END

--- a/dll/cpl/appwiz/lang/es-ES.rc
+++ b/dll/cpl/appwiz/lang/es-ES.rc
@@ -96,4 +96,5 @@ BEGIN
     IDS_NO_DIRECTORY "No se ha especificado directorio alguno"
     IDS_INVALID_PATH "La ruta proporcionada es inválida"
     IDS_INVALID_NAME "El nombre del acceso directo que has introducido contiene o bien caracteres inválidos, o su nombre es demasiado largo."
+    IDS_BROWSE_FOR_TARGET "Please select the target of the shortcut below:"
 END

--- a/dll/cpl/appwiz/lang/et-EE.rc
+++ b/dll/cpl/appwiz/lang/et-EE.rc
@@ -93,4 +93,5 @@ BEGIN
     IDS_NO_DIRECTORY "No directory given!"
     IDS_INVALID_PATH "The given path is invalid!"
     IDS_INVALID_NAME "The shortcut name you entered either contained characters that are invalid for file names or was too long."
+    IDS_BROWSE_FOR_TARGET "Please select the target of the shortcut below:"
 END

--- a/dll/cpl/appwiz/lang/fr-FR.rc
+++ b/dll/cpl/appwiz/lang/fr-FR.rc
@@ -86,4 +86,5 @@ BEGIN
     IDS_NO_DIRECTORY "No directory given!"
     IDS_INVALID_PATH "The given path is invalid!"
     IDS_INVALID_NAME "The shortcut name you entered either contained characters that are invalid for file names or was too long."
+    IDS_BROWSE_FOR_TARGET "Please select the target of the shortcut below:"
 END

--- a/dll/cpl/appwiz/lang/he-IL.rc
+++ b/dll/cpl/appwiz/lang/he-IL.rc
@@ -87,4 +87,5 @@ BEGIN
     IDS_NO_DIRECTORY "No directory given!"
     IDS_INVALID_PATH "The given path is invalid!"
     IDS_INVALID_NAME "The shortcut name you entered either contained characters that are invalid for file names or was too long."
+    IDS_BROWSE_FOR_TARGET "Please select the target of the shortcut below:"
 END

--- a/dll/cpl/appwiz/lang/hu-HU.rc
+++ b/dll/cpl/appwiz/lang/hu-HU.rc
@@ -90,4 +90,5 @@ BEGIN
     IDS_NO_DIRECTORY "Nincs megadva mappa!"
     IDS_INVALID_PATH "A megadott mappa érvénytelen!"
     IDS_INVALID_NAME "A megadott parancsikon név érvénytelen fájlnév karaktereket tartalmaz, vagy túl hosszú."
+    IDS_BROWSE_FOR_TARGET "Please select the target of the shortcut below:"
 END

--- a/dll/cpl/appwiz/lang/id-ID.rc
+++ b/dll/cpl/appwiz/lang/id-ID.rc
@@ -86,4 +86,5 @@ BEGIN
     IDS_NO_DIRECTORY "Direktori belum diberi!"
     IDS_INVALID_PATH "Jalur yang diberikan tidak sah!"
     IDS_INVALID_NAME "The shortcut name you entered either contained characters that are invalid for file names or was too long."
+    IDS_BROWSE_FOR_TARGET "Please select the target of the shortcut below:"
 END

--- a/dll/cpl/appwiz/lang/it-IT.rc
+++ b/dll/cpl/appwiz/lang/it-IT.rc
@@ -86,4 +86,5 @@ BEGIN
     IDS_NO_DIRECTORY "No directory given!"
     IDS_INVALID_PATH "The given path is invalid!"
     IDS_INVALID_NAME "The shortcut name you entered either contained characters that are invalid for file names or was too long."
+    IDS_BROWSE_FOR_TARGET "Please select the target of the shortcut below:"
 END

--- a/dll/cpl/appwiz/lang/ja-JP.rc
+++ b/dll/cpl/appwiz/lang/ja-JP.rc
@@ -86,4 +86,5 @@ BEGIN
     IDS_NO_DIRECTORY "ディレクトリが与えられてません!"
     IDS_INVALID_PATH "与えられたパスは無効です!"
     IDS_INVALID_NAME "入力したショートカット名にファイル名としては無効な文字が含まれているか長すぎます。"
+    IDS_BROWSE_FOR_TARGET "Please select the target of the shortcut below:"
 END

--- a/dll/cpl/appwiz/lang/no-NO.rc
+++ b/dll/cpl/appwiz/lang/no-NO.rc
@@ -86,4 +86,5 @@ BEGIN
     IDS_NO_DIRECTORY "No directory given!"
     IDS_INVALID_PATH "The given path is invalid!"
     IDS_INVALID_NAME "The shortcut name you entered either contained characters that are invalid for file names or was too long."
+    IDS_BROWSE_FOR_TARGET "Please select the target of the shortcut below:"
 END

--- a/dll/cpl/appwiz/lang/pl-PL.rc
+++ b/dll/cpl/appwiz/lang/pl-PL.rc
@@ -97,4 +97,5 @@ BEGIN
     IDS_NO_DIRECTORY "Nie podano ścieżki!"
     IDS_INVALID_PATH "Podana ścieżka jest niepoprawna!"
     IDS_INVALID_NAME "Wprowadzona nazwa skrótu zawiera nieprawidłowe znaki lub jest za długa."
+    IDS_BROWSE_FOR_TARGET "Please select the target of the shortcut below:"
 END

--- a/dll/cpl/appwiz/lang/pt-BR.rc
+++ b/dll/cpl/appwiz/lang/pt-BR.rc
@@ -88,4 +88,5 @@ BEGIN
     IDS_NO_DIRECTORY "Sem diretoria!"
     IDS_INVALID_PATH "O caminho é invalido!"
     IDS_INVALID_NAME "The shortcut name you entered either contained characters that are invalid for file names or was too long."
+    IDS_BROWSE_FOR_TARGET "Please select the target of the shortcut below:"
 END

--- a/dll/cpl/appwiz/lang/pt-PT.rc
+++ b/dll/cpl/appwiz/lang/pt-PT.rc
@@ -88,4 +88,5 @@ BEGIN
     IDS_NO_DIRECTORY "Sem directoria!"
     IDS_INVALID_PATH "O caminho é invalido!"
     IDS_INVALID_NAME "O nome do atalho contém caracteres inválidos para nomes de ficheiro ou é muito longo."
+    IDS_BROWSE_FOR_TARGET "Please select the target of the shortcut below:"
 END

--- a/dll/cpl/appwiz/lang/ro-RO.rc
+++ b/dll/cpl/appwiz/lang/ro-RO.rc
@@ -94,4 +94,5 @@ BEGIN
     IDS_NO_DIRECTORY "Nu a fost dat niciun director!"
     IDS_INVALID_PATH "Calea dată este nevalidă!"
     IDS_INVALID_NAME "Numele comenzii rapide pe care l-ați introdus conținea fie caractere nevalide pentru numele fișierelor, fie era prea lung."
+    IDS_BROWSE_FOR_TARGET "Please select the target of the shortcut below:"
 END

--- a/dll/cpl/appwiz/lang/ru-RU.rc
+++ b/dll/cpl/appwiz/lang/ru-RU.rc
@@ -86,4 +86,5 @@ BEGIN
     IDS_NO_DIRECTORY "Не указано ни одного каталога!"
     IDS_INVALID_PATH "Указанный путь неверен!"
     IDS_INVALID_NAME "The shortcut name you entered either contained characters that are invalid for file names or was too long."
+    IDS_BROWSE_FOR_TARGET "Please select the target of the shortcut below:"
 END

--- a/dll/cpl/appwiz/lang/sk-SK.rc
+++ b/dll/cpl/appwiz/lang/sk-SK.rc
@@ -90,4 +90,5 @@ BEGIN
     IDS_NO_DIRECTORY "No directory given!"
     IDS_INVALID_PATH "The given path is invalid!"
     IDS_INVALID_NAME "The shortcut name you entered either contained characters that are invalid for file names or was too long."
+    IDS_BROWSE_FOR_TARGET "Please select the target of the shortcut below:"
 END

--- a/dll/cpl/appwiz/lang/sq-AL.rc
+++ b/dll/cpl/appwiz/lang/sq-AL.rc
@@ -90,4 +90,5 @@ BEGIN
     IDS_NO_DIRECTORY "No directory given!"
     IDS_INVALID_PATH "The given path is invalid!"
     IDS_INVALID_NAME "The shortcut name you entered either contained characters that are invalid for file names or was too long."
+    IDS_BROWSE_FOR_TARGET "Please select the target of the shortcut below:"
 END

--- a/dll/cpl/appwiz/lang/tr-TR.rc
+++ b/dll/cpl/appwiz/lang/tr-TR.rc
@@ -88,4 +88,5 @@ BEGIN
     IDS_NO_DIRECTORY "Hiç dizin verilmedi!"
     IDS_INVALID_PATH "Verilen yol geçersiz!"
     IDS_INVALID_NAME "Girdiğiniz kısayol adı, ya geçersiz karakterler içeriyor ya dosya adları için geçersiz ya da çok uzun."
+    IDS_BROWSE_FOR_TARGET "Please select the target of the shortcut below:"
 END

--- a/dll/cpl/appwiz/lang/uk-UA.rc
+++ b/dll/cpl/appwiz/lang/uk-UA.rc
@@ -94,4 +94,5 @@ BEGIN
     IDS_NO_DIRECTORY "Не вказано жодного каталогу!"
     IDS_INVALID_PATH "Вказаний шлях недійсний!"
     IDS_INVALID_NAME "The shortcut name you entered either contained characters that are invalid for file names or was too long."
+    IDS_BROWSE_FOR_TARGET "Please select the target of the shortcut below:"
 END

--- a/dll/cpl/appwiz/lang/zh-CN.rc
+++ b/dll/cpl/appwiz/lang/zh-CN.rc
@@ -95,4 +95,5 @@ BEGIN
     IDS_NO_DIRECTORY "没有指定路径。"
     IDS_INVALID_PATH "指定的路径无效。"
     IDS_INVALID_NAME "您输入的快捷方式名称过长，或含有不能在文件名中使用的字符。"
+    IDS_BROWSE_FOR_TARGET "Please select the target of the shortcut below:"
 END

--- a/dll/cpl/appwiz/lang/zh-HK.rc
+++ b/dll/cpl/appwiz/lang/zh-HK.rc
@@ -94,4 +94,5 @@ BEGIN
     IDS_NO_DIRECTORY "沒有指定路徑。"
     IDS_INVALID_PATH "指定的路徑無效。"
     IDS_INVALID_NAME "您輸入的捷徑名稱太長，或包含不能在檔案名稱中使用的字元。"
+    IDS_BROWSE_FOR_TARGET "Please select the target of the shortcut below:"
 END

--- a/dll/cpl/appwiz/lang/zh-TW.rc
+++ b/dll/cpl/appwiz/lang/zh-TW.rc
@@ -95,4 +95,5 @@ BEGIN
     IDS_NO_DIRECTORY "沒有指定路徑。"
     IDS_INVALID_PATH "指定的路徑無效。"
     IDS_INVALID_NAME "您輸入的捷徑名稱過長，或包含不能在檔案名稱中使用的字元。"
+    IDS_BROWSE_FOR_TARGET "Please select the target of the shortcut below:"
 END

--- a/dll/cpl/appwiz/resource.h
+++ b/dll/cpl/appwiz/resource.h
@@ -29,6 +29,7 @@
 #define IDS_NO_DIRECTORY            2027
 #define IDS_INVALID_PATH            2028
 #define IDS_INVALID_NAME            2029
+#define IDS_BROWSE_FOR_TARGET       2030
 
 #define IDS_DOWNLOADING        14
 #define IDS_INSTALLING         15


### PR DESCRIPTION
## Purpose

Improve UI/UX.
JIRA issue: [CORE-5866](https://jira.reactos.org/browse/CORE-5866)

## Proposed changes

- Add `IDS_BROWSE_FOR_TARGET` resource string.
- Use it in setting the title caption of `"Browse for Folder"` dialog.

## Comparison

Win2k3:
![image](https://github.com/reactos/reactos/assets/2107452/7fd7c987-0cae-4e38-96aa-ef52cb2b9829)
Win2k3 dialog has the title caption.

BEFORE:
![image](https://github.com/reactos/reactos/assets/2107452/b7252c15-060f-48b7-bcf2-8e870e7864ee)
No title caption.

AFTER:
![image](https://github.com/reactos/reactos/assets/2107452/30d25a7d-a963-48ad-889a-08409e9cf3bb)
The dialog  got a title caption.

## TODO

- [x] Do tests.