### PR TITLE
[SHELL32] CD-ROM drive shouldn't be renamed

### DIFF
--- a/dll/win32/shell32/folders/CDrivesFolder.cpp
+++ b/dll/win32/shell32/folders/CDrivesFolder.cpp
@@ -607,6 +607,14 @@ HRESULT WINAPI CDrivesFolder::FinalConstruct()
     return hr;
 }
 
+// Is it a CD-ROM drive?
+bool _ILIsCDRomDrive(LPCITEMIDLIST pidl)
+{
+    char szDrive[8];
+    return (_ILGetDrive(pidl, szDrive, sizeof(szDrive)) &&
+            ::GetDriveTypeA(szDrive) == DRIVE_CDROM);
+}
+
 /**************************************************************************
 *    CDrivesFolder::ParseDisplayName
 */
@@ -663,13 +671,8 @@ HRESULT WINAPI CDrivesFolder::ParseDisplayName(HWND hwndOwner, LPBC pbc, LPOLEST
             {
                 *pdwAttributes &= dwDriveAttributes;
 
-                // CD-ROM cannot rename
-                char szDrive[8];
-                if (_ILGetDrive(pidlTemp, szDrive, sizeof(szDrive)) &&
-                    GetDriveTypeA(szDrive) == DRIVE_CDROM)
-                {
-                    *pdwAttributes &= ~SFGAO_CANRENAME;
-                }
+                if (_ILIsCDRomDrive(pidlTemp))
+                    *pdwAttributes &= ~SFGAO_CANRENAME; // CD-ROM drive cannot rename
             }
             else if (_ILIsSpecialFolder(pidlTemp))
                 m_regFolder->GetAttributesOf(1, &pidlTemp, pdwAttributes);
@@ -890,13 +893,8 @@ HRESULT WINAPI CDrivesFolder::GetAttributesOf(UINT cidl, PCUITEMID_CHILD_ARRAY a
             {
                 *rgfInOut &= dwDriveAttributes;
 
-                // CD-ROM cannot rename
-                char szDrive[8];
-                if (_ILGetDrive(apidl[0], szDrive, sizeof(szDrive)) &&
-                    GetDriveTypeA(szDrive) == DRIVE_CDROM)
-                {
-                    *rgfInOut &= ~SFGAO_CANRENAME;
-                }
+                if (_ILIsCDRomDrive(apidl[i]))
+                    *rgfInOut &= ~SFGAO_CANRENAME; // CD-ROM drive cannot rename
             }
             else if (_ILIsControlPanel(apidl[i]))
                 *rgfInOut &= dwControlPanelAttributes;

--- a/dll/win32/shell32/folders/CDrivesFolder.cpp
+++ b/dll/win32/shell32/folders/CDrivesFolder.cpp
@@ -611,7 +611,7 @@ HRESULT WINAPI CDrivesFolder::FinalConstruct()
 bool _ILIsCDRomDrive(LPCITEMIDLIST pidl)
 {
     char szDrive[8];
-    return (_ILGetDrive(pidl, szDrive, sizeof(szDrive)) &&
+    return (_ILGetDrive(pidl, szDrive, _countof(szDrive)) &&
             ::GetDriveTypeA(szDrive) == DRIVE_CDROM);
 }
 

--- a/dll/win32/shell32/folders/CDrivesFolder.cpp
+++ b/dll/win32/shell32/folders/CDrivesFolder.cpp
@@ -660,7 +660,17 @@ HRESULT WINAPI CDrivesFolder::ParseDisplayName(HWND hwndOwner, LPBC pbc, LPOLEST
         if (pdwAttributes && *pdwAttributes)
         {
             if (_ILIsDrive(pidlTemp))
+            {
                 *pdwAttributes &= dwDriveAttributes;
+
+                // CD-ROM cannot rename
+                char szDrive[8];
+                if (_ILGetDrive(pidlTemp, szDrive, sizeof(szDrive)) &&
+                    GetDriveTypeA(szDrive) == DRIVE_CDROM)
+                {
+                    *pdwAttributes &= ~SFGAO_CANRENAME;
+                }
+            }
             else if (_ILIsSpecialFolder(pidlTemp))
                 m_regFolder->GetAttributesOf(1, &pidlTemp, pdwAttributes);
             else
@@ -877,7 +887,17 @@ HRESULT WINAPI CDrivesFolder::GetAttributesOf(UINT cidl, PCUITEMID_CHILD_ARRAY a
         for (UINT i = 0; i < cidl; ++i)
         {
             if (_ILIsDrive(apidl[i]))
+            {
                 *rgfInOut &= dwDriveAttributes;
+
+                // CD-ROM cannot rename
+                char szDrive[8];
+                if (_ILGetDrive(apidl[0], szDrive, sizeof(szDrive)) &&
+                    GetDriveTypeA(szDrive) == DRIVE_CDROM)
+                {
+                    *rgfInOut &= ~SFGAO_CANRENAME;
+                }
+            }
             else if (_ILIsControlPanel(apidl[i]))
                 *rgfInOut &= dwControlPanelAttributes;
             else if (_ILIsSpecialFolder(*apidl))


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-18272](https://jira.reactos.org/browse/CORE-18272)

## Proposed changes

- Add `_ILGetDriveType` helper function.
- Use `_ILGetDrive` and `GetDriveType` functions to determine the drive type.
- If it was a CD-ROM drive, then remove `SFGAO_CANRENAME` flag.

## Comparison

BEFORE:
![before](https://github.com/reactos/reactos/assets/2107452/2a7c5734-6ada-4253-a4e7-477f9d93a90d)
It can rename.

AFTER:
![after](https://github.com/reactos/reactos/assets/2107452/70da973b-b386-4775-94a4-cd881dc73218)
It cannot rename by F2 key nor menu.

## TODO

- [x] Do tests.