### PR TITLE
[SHELL32] Rename file on copy-paste path collision

### DIFF
--- a/dll/win32/shell32/droptargets/CFSDropTarget.cpp
+++ b/dll/win32/shell32/droptargets/CFSDropTarget.cpp
@@ -42,6 +42,7 @@ HRESULT CFSDropTarget::_CopyItems(IShellFolder * pSFFrom, UINT cidl,
     PWCHAR pwszListPos = pwszSrcPathsList;
     STRRET strretFrom;
     SHFILEOPSTRUCTW fop;
+    BOOL bRenameOnCollision = FALSE;
 
     /* Build a double null terminated list of C strings from source paths */
     for (UINT i = 0; i < cidl; i++)
@@ -64,7 +65,18 @@ HRESULT CFSDropTarget::_CopyItems(IShellFolder * pSFFrom, UINT cidl,
     if (FAILED(ret))
         goto cleanup;
 
-    wszDstPath[lstrlenW(wszDstPath) + 1] = L'\0';
+    wszDstPath[lstrlenW(wszDstPath) + 1] = UNICODE_NULL;
+
+    /* Set TRUE to bRenameOnCollision if necesssary */
+    if (bCopy)
+    {
+        WCHAR szPath1[MAX_PATH], szPath2[MAX_PATH];
+        GetFullPathNameW(pwszSrcPathsList, _countof(szPath1), szPath1, NULL);
+        GetFullPathNameW(wszDstPath, _countof(szPath2), szPath2, NULL);
+        PathRemoveFileSpecW(szPath1);
+        if (_wcsicmp(szPath1, szPath2) == 0)
+            bRenameOnCollision = TRUE;
+    }
 
     ZeroMemory(&fop, sizeof(fop));
     fop.hwnd = m_hwndSite;
@@ -72,6 +84,9 @@ HRESULT CFSDropTarget::_CopyItems(IShellFolder * pSFFrom, UINT cidl,
     fop.pFrom = pwszSrcPathsList;
     fop.pTo = wszDstPath;
     fop.fFlags = FOF_ALLOWUNDO | FOF_NOCONFIRMMKDIR;
+    if (bRenameOnCollision)
+        fop.fFlags |= FOF_RENAMEONCOLLISION;
+
     ret = S_OK;
 
     if (SHFileOperationW(&fop))

--- a/dll/win32/shell32/droptargets/CFSDropTarget.cpp
+++ b/dll/win32/shell32/droptargets/CFSDropTarget.cpp
@@ -67,7 +67,7 @@ HRESULT CFSDropTarget::_CopyItems(IShellFolder * pSFFrom, UINT cidl,
 
     wszDstPath[lstrlenW(wszDstPath) + 1] = UNICODE_NULL;
 
-    /* Set TRUE to bRenameOnCollision if necesssary */
+    /* Set bRenameOnCollision to TRUE if necesssary */
     if (bCopy)
     {
         WCHAR szPath1[MAX_PATH], szPath2[MAX_PATH];

--- a/dll/win32/shell32/shlfileop.cpp
+++ b/dll/win32/shell32/shlfileop.cpp
@@ -1940,11 +1940,7 @@ validate_operation(LPSHFILEOPSTRUCTW lpFileOp, FILE_LIST *flFrom, FILE_LIST *flT
             {
                 size_t cchFrom = PathAddBackslashW(szFrom) - szFrom;
                 size_t cchTo = PathAddBackslashW(szTo) - szTo;
-#ifdef __REACTOS__
                 if (cchFrom < cchTo)
-#else
-                if (cchFrom <= cchTo)
-#endif
                 {
                     WCHAR ch = szTo[cchFrom];
                     szTo[cchFrom] = 0;

--- a/dll/win32/shell32/shlfileop.cpp
+++ b/dll/win32/shell32/shlfileop.cpp
@@ -1940,7 +1940,11 @@ validate_operation(LPSHFILEOPSTRUCTW lpFileOp, FILE_LIST *flFrom, FILE_LIST *flT
             {
                 size_t cchFrom = PathAddBackslashW(szFrom) - szFrom;
                 size_t cchTo = PathAddBackslashW(szTo) - szTo;
+#ifdef __REACTOS__
+                if (cchFrom < cchTo)
+#else
                 if (cchFrom <= cchTo)
+#endif
                 {
                     WCHAR ch = szTo[cchFrom];
                     szTo[cchFrom] = 0;


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-18599](https://jira.reactos.org/browse/CORE-18599)

## Proposed changes

- If the source and destination of copying file are on the same directory, then enable `FOF_RENAMEONCOLLISION` flag. End if.
- Don't show error message `IDS_COPYERRORSUBFOLDER` or `IDS_MOVEERRORSUBFOLDER` if the source and the destination are the same.

## Comparison

Do `Ctrl+C` and `Ctrl+V` on same file.

BEFORE:
![before](https://github.com/reactos/reactos/assets/2107452/6d7e309e-ee91-4dac-b9c0-4826da2b178c)

AFTER:
![after](https://github.com/reactos/reactos/assets/2107452/b009b02b-aafc-434d-877d-f7f7950ca53c)

## TODO

- [x] Do tests.
