### PR TITLE
[EXPLORER] Large taskbar icon support

### DIFF
--- a/base/shell/explorer/precomp.h
+++ b/base/shell/explorer/precomp.h
@@ -210,6 +210,7 @@ struct TaskbarSettings
     BOOL bShowSeconds;
     BOOL bPreferDate;
     BOOL bHideInactiveIcons;
+    BOOL bSmallIcons;
     TW_STRUCKRECTS2 sr;
 
     BOOL Load();

--- a/base/shell/explorer/settings.cpp
+++ b/base/shell/explorer/settings.cpp
@@ -32,6 +32,7 @@ BOOL TaskbarSettings::Save()
     SHSetValueW(hkExplorer, L"Advanced", L"TaskbarSizeMove", REG_DWORD, &bAllowSizeMove, sizeof(bAllowSizeMove));
     sr.cbSize = sizeof(sr);
     SHSetValueW(hkExplorer, L"StuckRects2", L"Settings", REG_BINARY, &sr, sizeof(sr));
+    SHSetValueW(hkExplorer, L"Advanced", L"TaskbarSmallIcons", REG_DWORD, &bSmallIcons, sizeof(bSmallIcons));
 
     /* TODO: AutoHide writes something to HKEY_CURRENT_USER\Software\Microsoft\Internet Explorer\Desktop\Components\0 figure out what and why */
     return TRUE;
@@ -59,6 +60,9 @@ BOOL TaskbarSettings::Load()
 
     cbSize = sizeof(sr);
     dwRet = SHGetValueW(hkExplorer, L"StuckRects2", L"Settings", NULL, &sr, &cbSize);
+
+    dwRet = SHGetValueW(hkExplorer, L"Advanced", L"TaskbarSmallIcons", NULL, &dwValue, &cbSize);
+    bSmallIcons = (dwRet == ERROR_SUCCESS) ? (dwValue != 0) : TRUE; /* This is an opt-out setting */
 
     /* Make sure we have correct values here */
     if (dwRet != ERROR_SUCCESS || sr.cbSize != sizeof(sr) || cbSize != sizeof(sr))

--- a/base/shell/explorer/settings.cpp
+++ b/base/shell/explorer/settings.cpp
@@ -62,7 +62,7 @@ BOOL TaskbarSettings::Load()
     dwRet = SHGetValueW(hkExplorer, L"StuckRects2", L"Settings", NULL, &sr, &cbSize);
 
     dwRet = SHGetValueW(hkExplorer, L"Advanced", L"TaskbarSmallIcons", NULL, &dwValue, &cbSize);
-    bSmallIcons = (dwRet == ERROR_SUCCESS) ? (dwValue != 0) : TRUE; /* This is an opt-out setting */
+    bSmallIcons = (dwRet == ERROR_SUCCESS) ? (dwValue != 0) : TRUE;
 
     /* Make sure we have correct values here */
     if (dwRet != ERROR_SUCCESS || sr.cbSize != sizeof(sr) || cbSize != sizeof(sr))

--- a/base/shell/explorer/settings.cpp
+++ b/base/shell/explorer/settings.cpp
@@ -31,8 +31,8 @@ BOOL TaskbarSettings::Save()
     BOOL bAllowSizeMove = !bLock;
     SHSetValueW(hkExplorer, L"Advanced", L"TaskbarSizeMove", REG_DWORD, &bAllowSizeMove, sizeof(bAllowSizeMove));
     sr.cbSize = sizeof(sr);
-    SHSetValueW(hkExplorer, L"StuckRects2", L"Settings", REG_BINARY, &sr, sizeof(sr));
     SHSetValueW(hkExplorer, L"Advanced", L"TaskbarSmallIcons", REG_DWORD, &bSmallIcons, sizeof(bSmallIcons));
+    SHSetValueW(hkExplorer, L"StuckRects2", L"Settings", REG_BINARY, &sr, sizeof(sr));
 
     /* TODO: AutoHide writes something to HKEY_CURRENT_USER\Software\Microsoft\Internet Explorer\Desktop\Components\0 figure out what and why */
     return TRUE;

--- a/base/shell/explorer/settings.cpp
+++ b/base/shell/explorer/settings.cpp
@@ -58,11 +58,11 @@ BOOL TaskbarSettings::Load()
     dwRet = SHGetValueW(hkExplorer, NULL, L"EnableAutotray", NULL, &dwValue, &cbSize);
     bHideInactiveIcons = (dwRet == ERROR_SUCCESS) ? (dwValue != 0) : FALSE;
 
-    cbSize = sizeof(sr);
-    dwRet = SHGetValueW(hkExplorer, L"StuckRects2", L"Settings", NULL, &sr, &cbSize);
-
     dwRet = SHGetValueW(hkExplorer, L"Advanced", L"TaskbarSmallIcons", NULL, &dwValue, &cbSize);
     bSmallIcons = (dwRet == ERROR_SUCCESS) ? (dwValue != 0) : TRUE;
+
+    cbSize = sizeof(sr);
+    dwRet = SHGetValueW(hkExplorer, L"StuckRects2", L"Settings", NULL, &sr, &cbSize);
 
     /* Make sure we have correct values here */
     if (dwRet != ERROR_SUCCESS || sr.cbSize != sizeof(sr) || cbSize != sizeof(sr))

--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -494,7 +494,7 @@ public:
 #define GET_ICON(type) \
     SendMessageTimeout(hwnd, WM_GETICON, (type), 0, SMTO_NOTIMEOUTIFNOTHUNG, 100, (PDWORD_PTR)&hIcon)
 
-        LRESULT bAlive = GET_ICON(ICON_SMALL2);
+        LRESULT bAlive = GET_ICON((g_TaskbarSettings.bSmallIcons) ? ICON_SMALL2 : ICON_BIG);
         if (hIcon)
             return hIcon;
 
@@ -507,7 +507,7 @@ public:
 
         if (bAlive)
         {
-            GET_ICON(ICON_BIG);
+            GET_ICON((g_TaskbarSettings.bSmallIcons) ? ICON_BIG : ICON_SMALL2);
             if (hIcon)
                 return hIcon;
         }
@@ -1262,9 +1262,12 @@ public:
         /* Update the size of the image list if needed */
         int cx, cy;
         ImageList_GetIconSize(m_ImageList, &cx, &cy);
-        if (cx != GetSystemMetrics(SM_CXSMICON) || cy != GetSystemMetrics(SM_CYSMICON))
+        if (cx != GetSystemMetrics((g_TaskbarSettings.bSmallIcons) ? SM_CXSMICON : SM_CXICON) ||
+            cy != GetSystemMetrics((g_TaskbarSettings.bSmallIcons) ? SM_CYSMICON : SM_CYICON))
         {
-            ImageList_SetIconSize(m_ImageList, GetSystemMetrics(SM_CXSMICON), GetSystemMetrics(SM_CYSMICON));
+            ImageList_SetIconSize(m_ImageList,
+                                  GetSystemMetrics((g_TaskbarSettings.bSmallIcons) ? SM_CXSMICON : SM_CXICON),
+                                  GetSystemMetrics((g_TaskbarSettings.bSmallIcons) ? SM_CYSMICON : SM_CYICON));
 
             /* SetIconSize removes all icons so we have to reinsert them */
             PTASK_ITEM TaskItem = m_TaskItems;
@@ -1430,7 +1433,9 @@ public:
 
         SetWindowTheme(m_TaskBar.m_hWnd, L"TaskBand", NULL);
 
-        m_ImageList = ImageList_Create(GetSystemMetrics(SM_CXSMICON), GetSystemMetrics(SM_CYSMICON), ILC_COLOR32 | ILC_MASK, 0, 1000);
+        m_ImageList = ImageList_Create(GetSystemMetrics((g_TaskbarSettings.bSmallIcons) ? SM_CXSMICON : SM_CXICON),
+                                       GetSystemMetrics((g_TaskbarSettings.bSmallIcons) ? SM_CYSMICON : SM_CYICON),
+                                       ILC_COLOR32 | ILC_MASK, 0, 1000);
         m_TaskBar.SetImageList(m_ImageList);
 
         /* Set proper spacing between buttons */

--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -494,7 +494,7 @@ public:
 #define GET_ICON(type) \
     SendMessageTimeout(hwnd, WM_GETICON, (type), 0, SMTO_NOTIMEOUTIFNOTHUNG, 100, (PDWORD_PTR)&hIcon)
 
-        LRESULT bAlive = GET_ICON((g_TaskbarSettings.bSmallIcons) ? ICON_SMALL2 : ICON_BIG);
+        LRESULT bAlive = GET_ICON(g_TaskbarSettings.bSmallIcons ? ICON_SMALL2 : ICON_BIG);
         if (hIcon)
             return hIcon;
 
@@ -507,7 +507,7 @@ public:
 
         if (bAlive)
         {
-            GET_ICON((g_TaskbarSettings.bSmallIcons) ? ICON_BIG : ICON_SMALL2);
+            GET_ICON(g_TaskbarSettings.bSmallIcons ? ICON_BIG : ICON_SMALL2);
             if (hIcon)
                 return hIcon;
         }
@@ -1262,12 +1262,12 @@ public:
         /* Update the size of the image list if needed */
         int cx, cy;
         ImageList_GetIconSize(m_ImageList, &cx, &cy);
-        if (cx != GetSystemMetrics((g_TaskbarSettings.bSmallIcons) ? SM_CXSMICON : SM_CXICON) ||
-            cy != GetSystemMetrics((g_TaskbarSettings.bSmallIcons) ? SM_CYSMICON : SM_CYICON))
+        if (cx != GetSystemMetrics(g_TaskbarSettings.bSmallIcons ? SM_CXSMICON : SM_CXICON) ||
+            cy != GetSystemMetrics(g_TaskbarSettings.bSmallIcons ? SM_CYSMICON : SM_CYICON))
         {
             ImageList_SetIconSize(m_ImageList,
-                                  GetSystemMetrics((g_TaskbarSettings.bSmallIcons) ? SM_CXSMICON : SM_CXICON),
-                                  GetSystemMetrics((g_TaskbarSettings.bSmallIcons) ? SM_CYSMICON : SM_CYICON));
+                                  GetSystemMetrics(g_TaskbarSettings.bSmallIcons ? SM_CXSMICON : SM_CXICON),
+                                  GetSystemMetrics(g_TaskbarSettings.bSmallIcons ? SM_CYSMICON : SM_CYICON));
 
             /* SetIconSize removes all icons so we have to reinsert them */
             PTASK_ITEM TaskItem = m_TaskItems;
@@ -1433,8 +1433,8 @@ public:
 
         SetWindowTheme(m_TaskBar.m_hWnd, L"TaskBand", NULL);
 
-        m_ImageList = ImageList_Create(GetSystemMetrics((g_TaskbarSettings.bSmallIcons) ? SM_CXSMICON : SM_CXICON),
-                                       GetSystemMetrics((g_TaskbarSettings.bSmallIcons) ? SM_CYSMICON : SM_CYICON),
+        m_ImageList = ImageList_Create(GetSystemMetrics(g_TaskbarSettings.bSmallIcons ? SM_CXSMICON : SM_CXICON),
+                                       GetSystemMetrics(g_TaskbarSettings.bSmallIcons ? SM_CYSMICON : SM_CYICON),
                                        ILC_COLOR32 | ILC_MASK, 0, 1000);
         m_TaskBar.SetImageList(m_ImageList);
 

--- a/dll/win32/browseui/shellbrowser.cpp
+++ b/dll/win32/browseui/shellbrowser.cpp
@@ -815,8 +815,8 @@ HRESULT CShellBrowser::BrowseToPIDL(LPCITEMIDLIST pidl, long flags)
     if (FAILED_UNEXPECTEDLY(hResult))
         return hResult;
     IUnknown_GetClassID(newFolder, &clsid);
-    HasIconViewType = clsid == CLSID_MyComputer || clsid == CLSID_ControlPanel
-                      || clsid == CLSID_ShellDesktop;
+    HasIconViewType = clsid == CLSID_MyComputer || clsid == CLSID_ControlPanel ||
+                      clsid == CLSID_ShellDesktop;
 
     if (HasIconViewType)
         newFolderSettings.ViewMode = FVM_ICON;

--- a/dll/win32/browseui/shellbrowser.cpp
+++ b/dll/win32/browseui/shellbrowser.cpp
@@ -806,7 +806,7 @@ HRESULT CShellBrowser::BrowseToPIDL(LPCITEMIDLIST pidl, long flags)
     CComPtr<IShellFolder>                   newFolder;
     FOLDERSETTINGS                          newFolderSettings;
     HRESULT                                 hResult;
-    IPersist                                *pp;
+    CLSID                                   clsid;
     BOOL                                    HasIconViewType;
 
     // called by shell view to browse to new folder
@@ -814,15 +814,9 @@ HRESULT CShellBrowser::BrowseToPIDL(LPCITEMIDLIST pidl, long flags)
     hResult = SHBindToFolder(pidl, &newFolder);
     if (FAILED_UNEXPECTEDLY(hResult))
         return hResult;
-    hResult = newFolder->QueryInterface(IID_PPV_ARG(IPersist, &pp));
-    if (SUCCEEDED(hResult))
-    {
-        CLSID pclsid;
-        hResult = pp->GetClassID(&pclsid);
-        pp->Release();
-        HasIconViewType = pclsid == CLSID_MyComputer || pclsid == CLSID_ControlPanel
-                          || pclsid == CLSID_ShellDesktop;
-    }
+    IUnknown_GetClassID(newFolder, &clsid);
+    HasIconViewType = clsid == CLSID_MyComputer || clsid == CLSID_ControlPanel
+                      || clsid == CLSID_ShellDesktop;
 
     if (HasIconViewType)
         newFolderSettings.ViewMode = FVM_ICON;

--- a/dll/win32/browseui/shellbrowser.cpp
+++ b/dll/win32/browseui/shellbrowser.cpp
@@ -814,7 +814,6 @@ HRESULT CShellBrowser::BrowseToPIDL(LPCITEMIDLIST pidl, long flags)
     hResult = SHBindToFolder(pidl, &newFolder);
     if (FAILED_UNEXPECTEDLY(hResult))
         return hResult;
-    
     hResult = newFolder->QueryInterface(IID_PPV_ARG(IPersist, &pp));
     if (SUCCEEDED(hResult))
     {

--- a/dll/win32/browseui/shellbrowser.cpp
+++ b/dll/win32/browseui/shellbrowser.cpp
@@ -806,22 +806,14 @@ HRESULT CShellBrowser::BrowseToPIDL(LPCITEMIDLIST pidl, long flags)
     CComPtr<IShellFolder>                   newFolder;
     FOLDERSETTINGS                          newFolderSettings;
     HRESULT                                 hResult;
-    CLSID                                   clsid;
-    BOOL                                    HasIconViewType;
 
     // called by shell view to browse to new folder
     // also called by explorer band to navigate to new folder
     hResult = SHBindToFolder(pidl, &newFolder);
     if (FAILED_UNEXPECTEDLY(hResult))
         return hResult;
-    IUnknown_GetClassID(newFolder, &clsid);
-    HasIconViewType = clsid == CLSID_MyComputer || clsid == CLSID_ControlPanel ||
-                      clsid == CLSID_ShellDesktop;
 
-    if (HasIconViewType)
-        newFolderSettings.ViewMode = FVM_ICON;
-    else
-        newFolderSettings.ViewMode = FVM_DETAILS;
+    newFolderSettings.ViewMode = FVM_ICON;
     newFolderSettings.fFlags = 0;
     hResult = BrowseToPath(newFolder, pidl, &newFolderSettings, flags);
     if (FAILED_UNEXPECTEDLY(hResult))


### PR DESCRIPTION
## Purpose

Adds large taskbar icon support. Small taskbar icons are set by default.

![image](https://github.com/reactos/reactos/assets/16692240/0011365d-a8e8-4fd7-8762-d1cc9b5c1b67)

Jira issue: [CORE-11698](https://jira.reactos.org/browse/CORE-11698)

## Proposed changes

- Query ```HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced\TaskbarSmallIcons``` to set the icon size for the taskbar. If the registry value is missing, it will use small icons. If the registry value is set to 1, it will also use small icons. Only if the value exists and is set to 0 will it use large icons. This allows us to use the same registry value as Windows 7, while also keeping the taskbar icons small in most cases, including running the shell on unmodified Windows Server 2003.