### PR TITLE
[SHLWAPI][SDK] Implement SHPropertyBag_WriteDWORD etc.

### DIFF
--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -5323,22 +5323,83 @@ HRESULT WINAPI SHPropertyBag_ReadLONG(IPropertyBag *ppb, LPCWSTR pszPropName, LP
 
 #ifdef __REACTOS__
 /**************************************************************************
- *  SHPropertyBag_WriteLONG (SHLWAPI.497)
- *
- * This function asks a property bag to write a named property as a LONG.
- *
- * PARAMS
- *  ppb: a IPropertyBag interface
- *  pszPropName:  Unicode string that names the property
- *  lValue: address to receive the property value as a 32-bit signed integer
- *
- * RETURNS
- *  HRESULT codes
+ *  SHPropertyBag_WriteBOOL (SHLWAPI.499)
  */
-HRESULT WINAPI SHPropertyBag_WriteLONG(IPropertyBag *ppb, LPCWSTR pszPropName, LONG lValue)
+HRESULT WINAPI SHPropertyBag_WriteBOOL(IPropertyBag *ppb, LPCOLESTR pszPropName, BOOL bValue)
 {
-	UNIMPLEMENTED;
-	return E_NOTIMPL;
+    VARIANT vari;
+
+    TRACE("%p %s %d\n", ppb, debugstr_w(pszPropName), bValue);
+
+    if (!ppb || !pszPropName)
+    {
+        ERR("%p %s\n", ppb, debugstr_w(pszPropName));
+        return E_INVALIDARG;
+    }
+
+    V_VT(&vari) = VT_BOOL;
+    V_BOOL(&vari) = (VARIANT_BOOL)-bValue;
+    return ppb->lpVtbl->Write(ppb, pszPropName, &vari);
+}
+
+/**************************************************************************
+ *  SHPropertyBag_WriteSHORT (SHLWAPI.528)
+ */
+HRESULT WINAPI SHPropertyBag_WriteSHORT(IPropertyBag *ppb, LPCOLESTR pszPropName, SHORT sValue)
+{
+    VARIANT vari;
+
+    TRACE("%p %s %d\n", ppb, debugstr_w(pszPropName), sValue);
+
+    if (!ppb || !pszPropName)
+    {
+        ERR("%p %s\n", ppb, debugstr_w(pszPropName));
+        return E_INVALIDARG;
+    }
+
+    V_VT(&vari) = VT_UI2;
+    V_UI2(&vari) = sValue;
+    return ppb->lpVtbl->Write(ppb, pszPropName, &vari);
+}
+
+/**************************************************************************
+ *  SHPropertyBag_WriteLONG (SHLWAPI.497)
+ */
+HRESULT WINAPI SHPropertyBag_WriteLONG(IPropertyBag *ppb, LPCOLESTR pszPropName, LONG lValue)
+{
+    VARIANT vari;
+
+    TRACE("%p %s %ld\n", ppb, debugstr_w(pszPropName), lValue);
+
+    if (!ppb || !pszPropName)
+    {
+        ERR("%p %s\n", ppb, debugstr_w(pszPropName));
+        return E_INVALIDARG;
+    }
+
+    V_VT(&vari) = VT_I4;
+    V_I4(&vari) = lValue;
+    return ppb->lpVtbl->Write(ppb, pszPropName, &vari);
+}
+
+/**************************************************************************
+ *  SHPropertyBag_WriteDWORD (SHLWAPI.508)
+ */
+HRESULT WINAPI SHPropertyBag_WriteDWORD(IPropertyBag *ppb, LPCOLESTR pszPropName, DWORD dwValue)
+{
+    VARIANT vari;
+
+    TRACE("%p %s %lu\n", ppb, debugstr_w(pszPropName), dwValue);
+
+    if (!ppb || !pszPropName)
+    {
+        ERR("%p %s\n", ppb, debugstr_w(pszPropName));
+        return E_INVALIDARG;
+    }
+
+    V_VT(&vari) = VT_UI4;
+    V_UI4(&vari) = dwValue;
+    return ppb->lpVtbl->Write(ppb, pszPropName, &vari);
 }
 
 /**************************************************************************

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -5444,7 +5444,7 @@ HRESULT WINAPI SHPropertyBag_WriteGUID(IPropertyBag *ppb, LPCWSTR pszPropName, c
 
     if (!ppb || !pszPropName || !pguid)
     {
-        ERR("%p %s\n", ppb, debugstr_w(pszPropName));
+        ERR("%p %s %p\n", ppb, debugstr_w(pszPropName), pguid);
         return E_INVALIDARG;
     }
 

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -5438,7 +5438,7 @@ HRESULT WINAPI SHPropertyBag_WriteStr(IPropertyBag *ppb, LPCWSTR pszPropName, LP
  */
 HRESULT WINAPI SHPropertyBag_WriteGUID(IPropertyBag *ppb, LPCWSTR pszPropName, const GUID *pguid)
 {
-    OLECHAR szBuff[64];
+    WCHAR szBuff[64];
 
     TRACE("%p %s %p\n", ppb, debugstr_w(pszPropName), pguid);
 

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -5448,7 +5448,7 @@ HRESULT WINAPI SHPropertyBag_WriteGUID(IPropertyBag *ppb, LPCWSTR pszPropName, c
         return E_INVALIDARG;
     }
 
-    SHStringFromGUIDW(pguid, szBuff, 64);
+    SHStringFromGUIDW(pguid, szBuff, _countof(szBuff));
     return SHPropertyBag_WriteStr(ppb, pszPropName, szBuff);
 }
 

--- a/dll/win32/shlwapi/shlwapi.spec
+++ b/dll/win32/shlwapi/shlwapi.spec
@@ -496,7 +496,7 @@
 496 stdcall -noname SHPropertyBag_ReadLONG(ptr wstr ptr)
 497 stdcall -noname SHPropertyBag_WriteLONG(ptr wstr long)
 498 stub -noname SHPropertyBag_ReadBOOLOld
-499 stub -noname SHPropertyBag_WriteBOOL
+499 stdcall -noname SHPropertyBag_WriteBOOL(ptr wstr long)
 500 stdcall AssocGetPerceivedType(wstr ptr ptr ptr)
 501 stdcall AssocIsDangerous(wstr)
 502 stdcall AssocQueryKeyA(long long str str ptr)
@@ -505,7 +505,7 @@
 505 stub -noname SHPropertyBag_ReadGUID
 506 stub -noname SHPropertyBag_WriteGUID
 507 stdcall -stub -noname SHPropertyBag_ReadDWORD(ptr ptr ptr)
-508 stub -noname SHPropertyBag_WriteDWORD
+508 stdcall -noname SHPropertyBag_WriteDWORD(ptr wstr long)
 509 stdcall -noname IUnknown_OnFocusChangeIS(ptr ptr long)
 510 stdcall -noname SHLockSharedEx(ptr long long)
 511 stdcall -stub -noname PathFileExistsDefExtAndAttributesW(wstr long ptr)
@@ -525,7 +525,7 @@
 525 stub -noname SHPropertyBag_ReadPOINTS
 526 stub -noname SHPropertyBag_WritePOINTS
 527 stub -noname SHPropertyBag_ReadSHORT
-528 stub -noname SHPropertyBag_WriteSHORT
+528 stdcall -noname SHPropertyBag_WriteSHORT(ptr wstr long)
 529 stub -noname SHPropertyBag_ReadInt
 530 stub -noname SHPropertyBag_WriteInt
 531 stub -noname SHPropertyBag_ReadStream

--- a/dll/win32/shlwapi/shlwapi.spec
+++ b/dll/win32/shlwapi/shlwapi.spec
@@ -503,7 +503,7 @@
 503 stdcall AssocQueryKeyW(long long wstr wstr ptr)
 504 stdcall AssocQueryStringA(long long str str ptr ptr)
 505 stub -noname SHPropertyBag_ReadGUID
-506 stub -noname SHPropertyBag_WriteGUID
+506 stdcall -noname SHPropertyBag_WriteGUID(ptr wstr ptr)
 507 stdcall -stub -noname SHPropertyBag_ReadDWORD(ptr ptr ptr)
 508 stdcall -noname SHPropertyBag_WriteDWORD(ptr wstr long)
 509 stdcall -noname IUnknown_OnFocusChangeIS(ptr ptr long)
@@ -529,7 +529,7 @@
 529 stub -noname SHPropertyBag_ReadInt
 530 stub -noname SHPropertyBag_WriteInt
 531 stub -noname SHPropertyBag_ReadStream
-532 stub -noname SHPropertyBag_WriteStream
+532 stdcall -noname SHPropertyBag_WriteStream(ptr wstr ptr)
 533 stub -noname SHGetPerScreenResName
 534 stub -noname SHPropertyBag_ReadBOOL
 535 stub -noname SHPropertyBag_Delete

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -99,6 +99,13 @@ HRESULT WINAPI SHGetPerScreenResName(OUT LPWSTR lpResName,
                                      IN DWORD dwReserved);
 
 HRESULT WINAPI SHPropertyBag_ReadStream(IPropertyBag*,LPCWSTR,IStream**);
+HRESULT WINAPI SHPropertyBag_WriteBOOL(IPropertyBag *ppb, LPCOLESTR pszPropName, BOOL bValue);
+HRESULT WINAPI SHPropertyBag_WriteSHORT(IPropertyBag *ppb, LPCOLESTR pszPropName, SHORT sValue);
+HRESULT WINAPI SHPropertyBag_WriteLONG(IPropertyBag *ppb, LPCOLESTR pszPropName, LONG lValue);
+HRESULT WINAPI SHPropertyBag_WriteDWORD(IPropertyBag *ppb, LPCOLESTR pszPropName, DWORD dwValue);
+HRESULT WINAPI SHPropertyBag_WriteStr(IPropertyBag *ppb, LPCOLESTR pszPropName, LPCWSTR pszValue);
+HRESULT WINAPI SHPropertyBag_WriteGUID(IPropertyBag *ppb, LPCOLESTR pszPropName, const GUID *pguid);
+HRESULT WINAPI SHPropertyBag_WriteStream(IPropertyBag *ppb, LPCOLESTR pszPropName, IStream *pStream);
 
 HWND WINAPI SHCreateWorkerWindowA(WNDPROC wndProc, HWND hWndParent, DWORD dwExStyle,
                                   DWORD dwStyle, HMENU hMenu, LONG_PTR wnd_extra);

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -99,13 +99,13 @@ HRESULT WINAPI SHGetPerScreenResName(OUT LPWSTR lpResName,
                                      IN DWORD dwReserved);
 
 HRESULT WINAPI SHPropertyBag_ReadStream(IPropertyBag*,LPCWSTR,IStream**);
-HRESULT WINAPI SHPropertyBag_WriteBOOL(IPropertyBag *ppb, LPCOLESTR pszPropName, BOOL bValue);
-HRESULT WINAPI SHPropertyBag_WriteSHORT(IPropertyBag *ppb, LPCOLESTR pszPropName, SHORT sValue);
-HRESULT WINAPI SHPropertyBag_WriteLONG(IPropertyBag *ppb, LPCOLESTR pszPropName, LONG lValue);
-HRESULT WINAPI SHPropertyBag_WriteDWORD(IPropertyBag *ppb, LPCOLESTR pszPropName, DWORD dwValue);
-HRESULT WINAPI SHPropertyBag_WriteStr(IPropertyBag *ppb, LPCOLESTR pszPropName, LPCWSTR pszValue);
-HRESULT WINAPI SHPropertyBag_WriteGUID(IPropertyBag *ppb, LPCOLESTR pszPropName, const GUID *pguid);
-HRESULT WINAPI SHPropertyBag_WriteStream(IPropertyBag *ppb, LPCOLESTR pszPropName, IStream *pStream);
+HRESULT WINAPI SHPropertyBag_WriteBOOL(IPropertyBag *ppb, LPCWSTR pszPropName, BOOL bValue);
+HRESULT WINAPI SHPropertyBag_WriteSHORT(IPropertyBag *ppb, LPCWSTR pszPropName, SHORT sValue);
+HRESULT WINAPI SHPropertyBag_WriteLONG(IPropertyBag *ppb, LPCWSTR pszPropName, LONG lValue);
+HRESULT WINAPI SHPropertyBag_WriteDWORD(IPropertyBag *ppb, LPCWSTR pszPropName, DWORD dwValue);
+HRESULT WINAPI SHPropertyBag_WriteStr(IPropertyBag *ppb, LPCWSTR pszPropName, LPCWSTR pszValue);
+HRESULT WINAPI SHPropertyBag_WriteGUID(IPropertyBag *ppb, LPCWSTR pszPropName, const GUID *pguid);
+HRESULT WINAPI SHPropertyBag_WriteStream(IPropertyBag *ppb, LPCWSTR pszPropName, IStream *pStream);
 
 HWND WINAPI SHCreateWorkerWindowA(WNDPROC wndProc, HWND hWndParent, DWORD dwExStyle,
                                   DWORD dwStyle, HMENU hMenu, LONG_PTR wnd_extra);


### PR DESCRIPTION
## Purpose
Implementing missing features...
JIRA issue: [CORE-9283](https://jira.reactos.org/browse/CORE-9283)

## Proposed changes

- Implement `SHPropertyBag_WriteBOOL`, `SHPropertyBag_WriteSHORT`, `SHPropertyBag_WriteLONG`, `SHPropertyBag_WriteDWORD`, `SHPropertyBag_WriteStr`, `SHPropertyBag_WriteGUID`, and `SHPropertyBag_WriteStream` functions.
- Modify `dll/win32/shlwapi/shlwapi.spec`.
- Modify `sdk/include/reactos/shlwapi_undoc.h`.

## TODO

- [x] Do big tests.