### PR TITLE
[BROWSEUI] Add an option to use full folder path in the window title

### DIFF
--- a/boot/bootdata/hivedef.inf
+++ b/boot/bootdata/hivedef.inf
@@ -1898,6 +1898,8 @@ HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced","PreferDateOv
 HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced","StartMenuLogoff",0x00010003,0x00000001
 ; "Hidden" to be changed to 2 if we later want to have "Hide hidden files by default"
 HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced","Hidden",0x00010003,1
+HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CabinetState",,0x00000012
+HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CabinetState","FullPath",0x00010003,0
 HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced","ShowSuperHidden",0x00010003,0
 HKCU,"SOFTWARE\Microsoft\Internet Explorer\Main","StatusBarOther",0x00010003,1
 

--- a/boot/bootdata/hivedef.inf
+++ b/boot/bootdata/hivedef.inf
@@ -1898,9 +1898,9 @@ HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced","PreferDateOv
 HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced","StartMenuLogoff",0x00010003,0x00000001
 ; "Hidden" to be changed to 2 if we later want to have "Hide hidden files by default"
 HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced","Hidden",0x00010003,1
+HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced","ShowSuperHidden",0x00010003,0
 HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CabinetState",,0x00000012
 HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CabinetState","FullPath",0x00010003,0
-HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced","ShowSuperHidden",0x00010003,0
 HKCU,"SOFTWARE\Microsoft\Internet Explorer\Main","StatusBarOther",0x00010003,1
 
 ; ComDlg32

--- a/dll/win32/browseui/shellbrowser.cpp
+++ b/dll/win32/browseui/shellbrowser.cpp
@@ -350,6 +350,7 @@ public:
     HRESULT UpdateUpState();
     void UpdateGotoMenu(HMENU theMenu);
     void UpdateViewMenu(HMENU theMenu);
+    void LoadSettings();
 
 /*    // *** IDockingWindowFrame methods ***
     virtual HRESULT STDMETHODCALLTYPE AddToolbar(IUnknown *punkSrc, LPCWSTR pwszItem, DWORD dwAddFlags);
@@ -709,10 +710,6 @@ CShellBrowser::CShellBrowser()
     fCurrentShellViewWindow = NULL;
     fCurrentDirectoryPIDL = NULL;
     fStatusBar = NULL;
-    fStatusBarVisible = SHRegGetBoolUSValueW(L"Software\\Microsoft\\Internet Explorer\\Main",
-                                             L"StatusBarOther",
-                                             FALSE,
-                                             FALSE);
     fCurrentMenuBar = NULL;
     fHistoryObject = NULL;
     fHistoryStream = NULL;
@@ -786,6 +783,7 @@ HRESULT CShellBrowser::Initialize()
 
     fToolbarProxy.Initialize(m_hWnd, clientBar);
 
+    LoadSettings();
 
     // create status bar
     DWORD dwStatusStyle = WS_CHILD | WS_CLIPSIBLINGS | SBARS_SIZEGRIP | SBARS_TOOLTIPS;
@@ -1508,6 +1506,19 @@ void CShellBrowser::RepositionBars()
     ::SetWindowPos(fCurrentShellViewWindow, NULL, clientRect.left, clientRect.top,
                         clientRect.right - clientRect.left,
                         clientRect.bottom - clientRect.top, SWP_NOOWNERZORDER | SWP_NOZORDER);
+}
+
+void CShellBrowser::LoadSettings()
+{
+    fStatusBarVisible = SHRegGetBoolUSValueW(L"Software\\Microsoft\\Internet Explorer\\Main",
+                                             L"StatusBarOther",
+                                             FALSE,
+                                             FALSE);
+
+    fCabinetState.fFullPathTitle = SHRegGetBoolUSValueW(L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\CabinetState",
+                                                        L"FullPath",
+                                                        FALSE,
+                                                        FALSE);
 }
 
 HRESULT CShellBrowser::FireEvent(DISPID dispIdMember, int argCount, VARIANT *arguments)


### PR DESCRIPTION
## Purpose
Adds an option to set the full folder path in the window title for the file explorer.

JIRA issue: [CORE-19046](https://jira.reactos.org/browse/CORE-19046)

![image](https://github.com/reactos/reactos/assets/16692240/d7487223-8220-4c70-ab24-f7c46f09ba25)

## Proposed changes
- Set ```HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CabinetState\FullPath``` to 0 by default. Including this registry value also enables the "Display the full path in the title bar" option in our folder options window.
- Query this same registry key when the file explorer is started to determine whether to use the full path or the display name as the window title.

## TODO (in a future PR)
- Refresh the window title and window title settings after applying changes from folder options, instead of having to restart the file browser.