### PR TITLE
[SHLWAPI][SHLWAPI_APITEST][SDK] Implement SHPropertyBag_WritePOINTL etc.

### DIFF
--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -5565,6 +5565,8 @@ HRESULT WINAPI SHPropertyBag_WriteRECTL(IPropertyBag *ppb, LPCWSTR pszPropName, 
     int cch, cch2;
     WCHAR *pch, szBuff[MAX_PATH];
 
+    TRACE("%p %s %p\n", ppb, debugstr_w(pszPropName), prcl);
+
     if (!ppb || !pszPropName || !prcl)
     {
         ERR("%p %s %p\n", ppb, debugstr_w(pszPropName), prcl);

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -5545,7 +5545,7 @@ HRESULT WINAPI SHPropertyBag_WritePOINTS(IPropertyBag *ppb, LPCWSTR pszPropName,
         ERR("%p %s %p\n", ppb, debugstr_w(pszPropName), pts);
         return E_INVALIDARG;
     }
-   
+
     pt.x = pts->x;
     pt.y = pts->y;
     return SHPropertyBag_WritePOINTL(ppb, pszPropName, &pt);

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -5561,7 +5561,7 @@ HRESULT WINAPI SHPropertyBag_WritePOINTS(IPropertyBag *ppb, LPCWSTR pszPropName,
  */
 HRESULT WINAPI SHPropertyBag_WriteRECTL(IPropertyBag *ppb, LPCWSTR pszPropName, const RECTL *prcl)
 {
-    HRESULT hr, hr2;
+    HRESULT hr;
     int cch, cch2;
     WCHAR *pch, szBuff[MAX_PATH];
 
@@ -5584,19 +5584,19 @@ HRESULT WINAPI SHPropertyBag_WriteRECTL(IPropertyBag *ppb, LPCWSTR pszPropName, 
     pch = &szBuff[cch];
 
     StrCpyNW(pch, L".left", cch2);
-    hr2 = hr = SHPropertyBag_WriteLONG(ppb, szBuff, prcl->left);
+    hr = SHPropertyBag_WriteLONG(ppb, szBuff, prcl->left);
     if (SUCCEEDED(hr))
     {
         StrCpyNW(pch, L".top", cch2);
-        hr2 = hr = SHPropertyBag_WriteLONG(ppb, szBuff, prcl->top);
+        hr = SHPropertyBag_WriteLONG(ppb, szBuff, prcl->top);
         if (SUCCEEDED(hr))
         {
             StrCpyNW(pch, L".right", cch2);
-            hr2 = hr = SHPropertyBag_WriteLONG(ppb, szBuff, prcl->right);
+            hr = SHPropertyBag_WriteLONG(ppb, szBuff, prcl->right);
             if (SUCCEEDED(hr))
             {
                 StrCpyNW(pch, L".bottom", cch2);
-                hr2 = hr = SHPropertyBag_WriteLONG(ppb, szBuff, prcl->bottom);
+                hr = SHPropertyBag_WriteLONG(ppb, szBuff, prcl->bottom);
                 if (SUCCEEDED(hr))
                     return hr; /* All successful */
 
@@ -5618,7 +5618,6 @@ HRESULT WINAPI SHPropertyBag_WriteRECTL(IPropertyBag *ppb, LPCWSTR pszPropName, 
             return hr;
     }
 
-    ERR("0x%08X: %p %s %p\n", hr2, ppb, debugstr_w(pszPropName), prcl);
     return hr;
 }
 #endif

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -5577,41 +5577,38 @@ HRESULT WINAPI SHPropertyBag_WriteRECTL(IPropertyBag *ppb, LPCWSTR pszPropName, 
 
     StrCpyNW(pch, L".left", cch2);
     hr = SHPropertyBag_WriteLONG(ppb, szBuff, prcl->left);
-    if (FAILED(hr))
-    {
-        ERR("0x%08X: %p %s %p\n", hr, ppb, debugstr_w(pszPropName), prcl);
-        return hr;
-    }
-
-    StrCpyNW(pch, L".top", cch2);
-    hr = SHPropertyBag_WriteLONG(ppb, szBuff, prcl->top);
     if (SUCCEEDED(hr))
     {
-        StrCpyNW(pch, L".right", cch2);
-        hr = SHPropertyBag_WriteLONG(ppb, szBuff, prcl->right);
+        StrCpyNW(pch, L".top", cch2);
+        hr = SHPropertyBag_WriteLONG(ppb, szBuff, prcl->top);
         if (SUCCEEDED(hr))
         {
-            StrCpyNW(pch, L".bottom", cch2);
-            hr = SHPropertyBag_WriteLONG(ppb, szBuff, prcl->bottom);
+            StrCpyNW(pch, L".right", cch2);
+            hr = SHPropertyBag_WriteLONG(ppb, szBuff, prcl->right);
             if (SUCCEEDED(hr))
-                return hr;
+            {
+                StrCpyNW(pch, L".bottom", cch2);
+                hr = SHPropertyBag_WriteLONG(ppb, szBuff, prcl->bottom);
+                if (SUCCEEDED(hr))
+                    return hr;
+
+                StrCpyNW(pch, L".right", cch2);
+                if (SUCCEEDED(SHPropertyBag_Delete(ppb, szBuff)))
+                    return S_OK;
+            }
+
+            StrCpyNW(pch, L".top", cch2);
+            if (SUCCEEDED(SHPropertyBag_Delete(ppb, szBuff)))
+                return S_OK;
         }
 
-        StrCpyNW(pch, L".right", cch2);
-        hr = SHPropertyBag_Delete(ppb, szBuff);
-        if (SUCCEEDED(hr))
-            return hr;
+        StrCpyNW(pch, L".left", cch2);
+        if (SUCCEEDED(SHPropertyBag_Delete(ppb, szBuff)))
+            return S_OK;
     }
 
     ERR("0x%08X: %p %s %p\n", hr, ppb, debugstr_w(pszPropName), prcl);
-
-    StrCpyNW(pch, L".top", cch2);
-    hr = SHPropertyBag_Delete(ppb, szBuff);
-    if (SUCCEEDED(hr))
-        return hr;
-
-    StrCpyNW(pch, L".left", cch2);
-    return SHPropertyBag_Delete(ppb, szBuff);
+    return hr;
 }
 #endif
 

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -5596,14 +5596,19 @@ HRESULT WINAPI SHPropertyBag_WriteRECTL(IPropertyBag *ppb, LPCWSTR pszPropName, 
             if (SUCCEEDED(hr))
                 return hr;
         }
+
         StrCpyNW(pch, L".right", cch2);
-        SHPropertyBag_Delete(ppb, szBuff);
+        hr = SHPropertyBag_Delete(ppb, szBuff);
+        if (SUCCEEDED(hr))
+            return hr;
     }
 
     ERR("0x%08X: %p %s %p\n", hr, ppb, debugstr_w(pszPropName), prcl);
 
     StrCpyNW(pch, L".top", cch2);
-    SHPropertyBag_Delete(ppb, szBuff);
+    hr = SHPropertyBag_Delete(ppb, szBuff);
+    if (SUCCEEDED(hr))
+        return hr;
 
     StrCpyNW(pch, L".left", cch2);
     return SHPropertyBag_Delete(ppb, szBuff);

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -5559,7 +5559,7 @@ HRESULT WINAPI SHPropertyBag_WritePOINTS(IPropertyBag *ppb, LPCWSTR pszPropName,
  */
 HRESULT WINAPI SHPropertyBag_WriteRECTL(IPropertyBag *ppb, LPCWSTR pszPropName, const RECTL *prcl)
 {
-    HRESULT hr;
+    HRESULT hr, hr2;
     int cch, cch2;
     WCHAR *pch, szBuff[MAX_PATH];
 
@@ -5582,38 +5582,41 @@ HRESULT WINAPI SHPropertyBag_WriteRECTL(IPropertyBag *ppb, LPCWSTR pszPropName, 
     pch = &szBuff[cch];
 
     StrCpyNW(pch, L".left", cch2);
-    hr = SHPropertyBag_WriteLONG(ppb, szBuff, prcl->left);
+    hr2 = hr = SHPropertyBag_WriteLONG(ppb, szBuff, prcl->left);
     if (SUCCEEDED(hr))
     {
         StrCpyNW(pch, L".top", cch2);
-        hr = SHPropertyBag_WriteLONG(ppb, szBuff, prcl->top);
+        hr2 = hr = SHPropertyBag_WriteLONG(ppb, szBuff, prcl->top);
         if (SUCCEEDED(hr))
         {
             StrCpyNW(pch, L".right", cch2);
-            hr = SHPropertyBag_WriteLONG(ppb, szBuff, prcl->right);
+            hr2 = hr = SHPropertyBag_WriteLONG(ppb, szBuff, prcl->right);
             if (SUCCEEDED(hr))
             {
                 StrCpyNW(pch, L".bottom", cch2);
-                hr = SHPropertyBag_WriteLONG(ppb, szBuff, prcl->bottom);
+                hr2 = hr = SHPropertyBag_WriteLONG(ppb, szBuff, prcl->bottom);
                 if (SUCCEEDED(hr))
-                    return hr;
+                    return hr; /* All successful */
 
                 StrCpyNW(pch, L".right", cch2);
-                if (SUCCEEDED(SHPropertyBag_Delete(ppb, szBuff)))
-                    return S_OK;
+                hr = SHPropertyBag_Delete(ppb, szBuff);
+                if (SUCCEEDED(hr))
+                    return hr;
             }
 
             StrCpyNW(pch, L".top", cch2);
-            if (SUCCEEDED(SHPropertyBag_Delete(ppb, szBuff)))
-                return S_OK;
+            hr = SHPropertyBag_Delete(ppb, szBuff);
+            if (SUCCEEDED(hr))
+                return hr;
         }
 
         StrCpyNW(pch, L".left", cch2);
-        if (SUCCEEDED(SHPropertyBag_Delete(ppb, szBuff)))
-            return S_OK;
+        hr = SHPropertyBag_Delete(ppb, szBuff);
+        if (SUCCEEDED(hr))
+            return hr;
     }
 
-    ERR("0x%08X: %p %s %p\n", hr, ppb, debugstr_w(pszPropName), prcl);
+    ERR("0x%08X: %p %s %p\n", hr2, ppb, debugstr_w(pszPropName), prcl);
     return hr;
 }
 #endif

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -5494,17 +5494,17 @@ HRESULT WINAPI SHPropertyBag_WriteStream(IPropertyBag *ppb, LPCWSTR pszPropName,
 /**************************************************************************
  *  SHPropertyBag_WritePOINTL (SHLWAPI.522)
  */
-HRESULT WINAPI SHPropertyBag_WritePOINTL(IPropertyBag *ppb, LPCWSTR pszPropName, const POINTL *ppt)
+HRESULT WINAPI SHPropertyBag_WritePOINTL(IPropertyBag *ppb, LPCWSTR pszPropName, const POINTL *pptl)
 {
     HRESULT hr;
     int cch, cch2;
     WCHAR *pch, szBuff[MAX_PATH];
 
-    TRACE("%p %s %p\n", ppb, debugstr_w(pszPropName), ppt);
+    TRACE("%p %s %p\n", ppb, debugstr_w(pszPropName), pptl);
 
-    if (!ppb || !pszPropName || !ppt)
+    if (!ppb || !pszPropName || !pptl)
     {
-        ERR("%p %s %p\n", ppb, debugstr_w(pszPropName), ppt);
+        ERR("%p %s %p\n", ppb, debugstr_w(pszPropName), pptl);
         return E_INVALIDARG;
     }
 
@@ -5521,12 +5521,12 @@ HRESULT WINAPI SHPropertyBag_WritePOINTL(IPropertyBag *ppb, LPCWSTR pszPropName,
     pch = &szBuff[cch];
 
     StrCpyNW(pch, L".x", cch2);
-    hr = SHPropertyBag_WriteLONG(ppb, szBuff, ppt->x);
+    hr = SHPropertyBag_WriteLONG(ppb, szBuff, pptl->x);
     if (FAILED(hr))
         return hr;
 
     StrCpyNW(pch, L".y", cch2);
-    hr = SHPropertyBag_WriteLONG(ppb, szBuff, ppt->y);
+    hr = SHPropertyBag_WriteLONG(ppb, szBuff, pptl->y);
     if (FAILED(hr))
     {
         StrCpyNW(pch, L".x", cch2);
@@ -5539,20 +5539,20 @@ HRESULT WINAPI SHPropertyBag_WritePOINTL(IPropertyBag *ppb, LPCWSTR pszPropName,
 /**************************************************************************
  *  SHPropertyBag_WritePOINTS (SHLWAPI.526)
  */
-HRESULT WINAPI SHPropertyBag_WritePOINTS(IPropertyBag *ppb, LPCWSTR pszPropName, const POINTS *pts)
+HRESULT WINAPI SHPropertyBag_WritePOINTS(IPropertyBag *ppb, LPCWSTR pszPropName, const POINTS *ppts)
 {
     POINTL pt;
 
-    TRACE("%p %s %p\n", ppb, debugstr_w(pszPropName), pts);
+    TRACE("%p %s %p\n", ppb, debugstr_w(pszPropName), ppts);
 
-    if (!ppb || !pszPropName || !pts)
+    if (!ppb || !pszPropName || !ppts)
     {
-        ERR("%p %s %p\n", ppb, debugstr_w(pszPropName), pts);
+        ERR("%p %s %p\n", ppb, debugstr_w(pszPropName), ppts);
         return E_INVALIDARG;
     }
 
-    pt.x = pts->x;
-    pt.y = pts->y;
+    pt.x = ppts->x;
+    pt.y = ppts->y;
     return SHPropertyBag_WritePOINTL(ppb, pszPropName, &pt);
 }
 

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -5494,7 +5494,7 @@ HRESULT WINAPI SHPropertyBag_WriteStream(IPropertyBag *ppb, LPCWSTR pszPropName,
 /**************************************************************************
  *  SHPropertyBag_WritePOINTL (SHLWAPI.522)
  */
-HRESULT WINAPI SHPropertyBag_WritePOINTL(IPropertyBag *ppb, LPCWSTR pszPropName, const POINT *ppt)
+HRESULT WINAPI SHPropertyBag_WritePOINTL(IPropertyBag *ppb, LPCWSTR pszPropName, const POINTL *ppt)
 {
     HRESULT hr;
     int cch, cch2;
@@ -5541,7 +5541,7 @@ HRESULT WINAPI SHPropertyBag_WritePOINTL(IPropertyBag *ppb, LPCWSTR pszPropName,
  */
 HRESULT WINAPI SHPropertyBag_WritePOINTS(IPropertyBag *ppb, LPCWSTR pszPropName, const POINTS *pts)
 {
-    POINT pt;
+    POINTL pt;
 
     TRACE("%p %s %p\n", ppb, debugstr_w(pszPropName), pts);
 

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -5512,7 +5512,7 @@ HRESULT WINAPI SHPropertyBag_WritePOINTL(IPropertyBag *ppb, LPCWSTR pszPropName,
 
     cch = lstrlenW(szBuff);
     cch2 = _countof(szBuff) - cch;
-    if (cch2 < 3)
+    if (cch2 < _countof(L".x"))
     {
         ERR("%s is too long\n", debugstr_w(pszPropName));
         return E_FAIL;
@@ -5573,7 +5573,7 @@ HRESULT WINAPI SHPropertyBag_WriteRECTL(IPropertyBag *ppb, LPCWSTR pszPropName, 
 
     cch = lstrlenW(szBuff);
     cch2 = _countof(szBuff) - cch;
-    if (cch2 < 8)
+    if (cch2 < _countof(L".bottom"))
     {
         ERR("%s is too long\n", debugstr_w(pszPropName));
         return E_FAIL;

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -5513,7 +5513,10 @@ HRESULT WINAPI SHPropertyBag_WritePOINTL(IPropertyBag *ppb, LPCWSTR pszPropName,
     cch = lstrlenW(szBuff);
     cch2 = _countof(szBuff) - cch;
     if (cch2 < 3)
+    {
+        ERR("%s is too long\n", debugstr_w(pszPropName));
         return E_FAIL;
+    }
 
     pch = &szBuff[cch];
 
@@ -5571,7 +5574,10 @@ HRESULT WINAPI SHPropertyBag_WriteRECTL(IPropertyBag *ppb, LPCWSTR pszPropName, 
     cch = lstrlenW(szBuff);
     cch2 = _countof(szBuff) - cch;
     if (cch2 < 8)
+    {
+        ERR("%s is too long\n", debugstr_w(pszPropName));
         return E_FAIL;
+    }
 
     pch = &szBuff[cch];
 

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -5527,11 +5527,13 @@ HRESULT WINAPI SHPropertyBag_WritePOINTL(IPropertyBag *ppb, LPCWSTR pszPropName,
 
     StrCpyNW(pch, L".y", cch2);
     hr = SHPropertyBag_WriteLONG(ppb, szBuff, ppt->y);
-    if (SUCCEEDED(hr))
-        return hr;
+    if (FAILED(hr))
+    {
+        StrCpyNW(pch, L".x", cch2);
+        return SHPropertyBag_Delete(ppb, szBuff);
+    }
 
-    StrCpyNW(pch, L".x", cch2);
-    return SHPropertyBag_Delete(ppb, szBuff);
+    return hr;
 }
 
 /**************************************************************************

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -5325,7 +5325,7 @@ HRESULT WINAPI SHPropertyBag_ReadLONG(IPropertyBag *ppb, LPCWSTR pszPropName, LP
 /**************************************************************************
  *  SHPropertyBag_Delete (SHLWAPI.535)
  */
-HRESULT WINAPI SHPropertyBag_Delete(IPropertyBag *ppb, LPCOLESTR pszPropName)
+HRESULT WINAPI SHPropertyBag_Delete(IPropertyBag *ppb, LPCWSTR pszPropName)
 {
     VARIANT vari;
 

--- a/dll/win32/shlwapi/shlwapi.spec
+++ b/dll/win32/shlwapi/shlwapi.spec
@@ -519,11 +519,11 @@
 519 stdcall -noname SKAllocValueW(long wstr wstr ptr ptr ptr)
 520 stub -noname SHPropertyBag_ReadBSTR
 521 stub -noname SHPropertyBag_ReadPOINTL
-522 stub -noname SHPropertyBag_WritePOINTL
+522 stdcall -noname SHPropertyBag_WritePOINTL(ptr wstr ptr)
 523 stub -noname SHPropertyBag_ReadRECTL
-524 stub -noname SHPropertyBag_WriteRECTL
+524 stdcall -noname SHPropertyBag_WriteRECTL(ptr wstr ptr)
 525 stub -noname SHPropertyBag_ReadPOINTS
-526 stub -noname SHPropertyBag_WritePOINTS
+526 stdcall -noname SHPropertyBag_WritePOINTS(ptr wstr ptr)
 527 stub -noname SHPropertyBag_ReadSHORT
 528 stdcall -noname SHPropertyBag_WriteSHORT(ptr wstr long)
 529 stub -noname SHPropertyBag_ReadInt
@@ -532,7 +532,7 @@
 532 stdcall -noname SHPropertyBag_WriteStream(ptr wstr ptr)
 533 stub -noname SHGetPerScreenResName
 534 stub -noname SHPropertyBag_ReadBOOL
-535 stub -noname SHPropertyBag_Delete
+535 stdcall -noname SHPropertyBag_Delete(ptr wstr)
 536 stdcall -stub -noname IUnknown_QueryServicePropertyBag(ptr long ptr ptr)
 537 stub -noname SHBoolSystemParametersInfo
 538 stdcall -noname IUnknown_QueryServiceForWebBrowserApp(ptr ptr ptr)

--- a/dll/win32/shlwapi/shlwapi.spec
+++ b/dll/win32/shlwapi/shlwapi.spec
@@ -527,7 +527,7 @@
 527 stub -noname SHPropertyBag_ReadSHORT
 528 stdcall -noname SHPropertyBag_WriteSHORT(ptr wstr long)
 529 stub -noname SHPropertyBag_ReadInt
-530 stdcall -noname SHPropertyBag_WriteInt(ptr wstr long) shlwapi.SHPropertyBag_WriteLong
+530 stdcall -noname SHPropertyBag_WriteInt(ptr wstr long) SHPropertyBag_WriteLONG
 531 stub -noname SHPropertyBag_ReadStream
 532 stdcall -noname SHPropertyBag_WriteStream(ptr wstr ptr)
 533 stub -noname SHGetPerScreenResName

--- a/dll/win32/shlwapi/shlwapi.spec
+++ b/dll/win32/shlwapi/shlwapi.spec
@@ -527,7 +527,7 @@
 527 stub -noname SHPropertyBag_ReadSHORT
 528 stdcall -noname SHPropertyBag_WriteSHORT(ptr wstr long)
 529 stub -noname SHPropertyBag_ReadInt
-530 stub -noname SHPropertyBag_WriteInt
+530 stdcall -noname SHPropertyBag_WriteInt(ptr wstr long) shlwapi.SHPropertyBag_WriteLong
 531 stub -noname SHPropertyBag_ReadStream
 532 stdcall -noname SHPropertyBag_WriteStream(ptr wstr ptr)
 533 stub -noname SHGetPerScreenResName

--- a/modules/rostests/apitests/shlwapi/CMakeLists.txt
+++ b/modules/rostests/apitests/shlwapi/CMakeLists.txt
@@ -14,6 +14,7 @@ list(APPEND SOURCE
     SHAreIconsEqual.c
     SHLoadIndirectString.c
     SHLoadRegUIString.c
+    SHPropertyBag.cpp
     StrFormatByteSizeW.c
     testdata.rc
     testlist.c)

--- a/modules/rostests/apitests/shlwapi/SHPropertyBag.cpp
+++ b/modules/rostests/apitests/shlwapi/SHPropertyBag.cpp
@@ -77,7 +77,7 @@ public:
     }
 };
 
-START_TEST(SHPropertyBag)
+static void SHPropertyBag_WriteTest(void)
 {
     HRESULT hr;
     CDummyWritePropertyBag dummy;
@@ -153,4 +153,9 @@ START_TEST(SHPropertyBag)
     hr = SHPropertyBag_WriteGUID(&dummy, s_pszPropName0, &guid);
     ok_long(hr, S_OK);
     ok_int(s_cWrite, 1);
+}
+
+START_TEST(SHPropertyBag)
+{
+    SHPropertyBag_WriteTest();
 }

--- a/modules/rostests/apitests/shlwapi/SHPropertyBag.cpp
+++ b/modules/rostests/apitests/shlwapi/SHPropertyBag.cpp
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2023 Katayama Hirofumi MZ
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#include <apitest.h>
+#include <shlwapi.h>
+#include <shlobj.h>
+#include <shlwapi_undoc.h>
+
+#include <pseh/pseh2.h>
+
+static LPCWSTR s_pszPropName0 = NULL;
+static LPCWSTR s_pszPropName1 = NULL;
+static VARTYPE s_vt;
+static INT s_cWrite = 0;
+
+class CDummyWritePropertyBag : public IPropertyBag
+{
+public:
+    CDummyWritePropertyBag()
+    {
+    }
+
+    // IUnknown
+    STDMETHODIMP QueryInterface(REFIID riid, void **ppvObject) override
+    {
+        ok_int(0, 1);
+        return S_OK;
+    }
+    STDMETHODIMP_(ULONG) AddRef() override
+    {
+        ok_int(0, 1);
+        return S_OK;
+    }
+    STDMETHODIMP_(ULONG) Release() override
+    {
+        ok_int(0, 1);
+        return S_OK;
+    }
+
+    // IPropertyBag
+    STDMETHODIMP Read(LPCWSTR pszPropName, VARIANT *pvari, IErrorLog *pErrorLog) override
+    {
+        ok_int(0, 1);
+        return S_OK;
+    }
+
+    STDMETHODIMP Write(LPCWSTR pszPropName, VARIANT *pvari) override
+    {
+        if (s_pszPropName0)
+        {
+            ok_wstr(pszPropName, s_pszPropName0);
+            s_pszPropName0 = NULL;
+        }
+        else if (s_pszPropName1)
+        {
+            ok_wstr(pszPropName, s_pszPropName1);
+            s_pszPropName1 = NULL;
+        }
+        ok_int(s_vt, V_VT(pvari));
+        ++s_cWrite;
+        return S_OK;
+    }
+};
+
+START_TEST(SHPropertyBag)
+{
+    HRESULT hr;
+    CDummyWritePropertyBag dummy;
+
+    s_cWrite = 0;
+    s_pszPropName0 = L"BOOL1";
+    s_vt = VT_BOOL;
+    hr = SHPropertyBag_WriteBOOL(&dummy, s_pszPropName0, TRUE);
+    ok_long(hr, S_OK);
+    ok_int(s_cWrite, 1);
+
+    s_cWrite = 0;
+    s_pszPropName0 = L"SHORT1";
+    s_vt = VT_UI2;
+    hr = SHPropertyBag_WriteSHORT(&dummy, s_pszPropName0, 1);
+    ok_long(hr, S_OK);
+    ok_int(s_cWrite, 1);
+
+    s_cWrite = 0;
+    s_pszPropName0 = L"LONG1";
+    s_vt = VT_I4;
+    hr = SHPropertyBag_WriteLONG(&dummy, s_pszPropName0, 1);
+    ok_long(hr, S_OK);
+    ok_int(s_cWrite, 1);
+
+    s_cWrite = 0;
+    s_pszPropName0 = L"DWORD1";
+    s_vt = VT_UI4;
+    hr = SHPropertyBag_WriteDWORD(&dummy, s_pszPropName0, 1);
+    ok_long(hr, S_OK);
+    ok_int(s_cWrite, 1);
+
+    s_cWrite = 0;
+    s_pszPropName0 = L"Str1";
+    s_vt = VT_BSTR;
+    hr = SHPropertyBag_WriteStr(&dummy, s_pszPropName0, L"1");
+    ok_long(hr, S_OK);
+    ok_int(s_cWrite, 1);
+
+    s_cWrite = 0;
+    s_pszPropName0 = L"POINTL1.x";
+    s_pszPropName1 = L"POINTL1.y";
+    s_vt = VT_I4;
+    POINTL ptl = { 0xEEEE, 0xDDDD };
+    hr = SHPropertyBag_WritePOINTL(&dummy, L"POINTL1", &ptl);
+    ok_long(hr, S_OK);
+    ok_int(s_cWrite, 2);
+
+    s_cWrite = 0;
+    s_pszPropName0 = L"POINTS1.x";
+    s_pszPropName1 = L"POINTS1.y";
+    s_vt = VT_I4;
+    POINTS pts = { 0x2222, 0x3333 };
+    hr = SHPropertyBag_WritePOINTS(&dummy, L"POINTS1", &pts);
+    ok_long(hr, S_OK);
+    ok_int(s_cWrite, 2);
+
+    s_cWrite = 0;
+    s_pszPropName0 = L"RECTL1.left";
+    s_pszPropName1 = L"RECTL1.top";
+    s_vt = VT_I4;
+    RECTL rcl = { 123, 456, 789, 101112 };
+    hr = SHPropertyBag_WriteRECTL(&dummy, L"RECTL1", &rcl);
+    ok_long(hr, S_OK);
+    ok_int(s_cWrite, 4);
+
+    s_cWrite = 0;
+    GUID guid;
+    ZeroMemory(&guid, sizeof(guid));
+    s_pszPropName0 = L"GUID1";
+    s_pszPropName1 = NULL;
+    s_vt = VT_BSTR;
+    hr = SHPropertyBag_WriteGUID(&dummy, s_pszPropName0, &guid);
+    ok_long(hr, S_OK);
+    ok_int(s_cWrite, 1);
+}

--- a/modules/rostests/apitests/shlwapi/SHPropertyBag.cpp
+++ b/modules/rostests/apitests/shlwapi/SHPropertyBag.cpp
@@ -16,7 +16,7 @@ static LPCWSTR s_pszPropNames[4] = { NULL, NULL, NULL, NULL };
 static VARTYPE s_vt;
 static INT s_cWrite = 0;
 
-static void Reset(VARTYPE vt,
+static void ResetTest(VARTYPE vt,
                   LPCWSTR pszName0 = NULL, LPCWSTR pszName1 = NULL,
                   LPCWSTR pszName2 = NULL, LPCWSTR pszName3 = NULL)
 {
@@ -88,62 +88,62 @@ static void SHPropertyBag_WriteTest(void)
     HRESULT hr;
     CDummyWritePropertyBag dummy;
 
-    Reset(VT_EMPTY, L"EMPTY1");
+    ResetTest(VT_EMPTY, L"EMPTY1");
     hr = SHPropertyBag_Delete(&dummy, s_pszPropNames[0]);
     ok_long(hr, S_OK);
     ok_int(s_cWrite, 1);
 
-    Reset(VT_BOOL, L"BOOL1");
+    ResetTest(VT_BOOL, L"BOOL1");
     hr = SHPropertyBag_WriteBOOL(&dummy, s_pszPropNames[0], TRUE);
     ok_long(hr, S_OK);
     ok_int(s_cWrite, 1);
 
-    Reset(VT_UI2, L"SHORT1");
+    ResetTest(VT_UI2, L"SHORT1");
     hr = SHPropertyBag_WriteSHORT(&dummy, s_pszPropNames[0], 1);
     ok_long(hr, S_OK);
     ok_int(s_cWrite, 1);
 
-    Reset(VT_I4, L"LONG1");
+    ResetTest(VT_I4, L"LONG1");
     hr = SHPropertyBag_WriteLONG(&dummy, s_pszPropNames[0], 1);
     ok_long(hr, S_OK);
     ok_int(s_cWrite, 1);
 
-    Reset(VT_UI4, L"DWORD1");
+    ResetTest(VT_UI4, L"DWORD1");
     hr = SHPropertyBag_WriteDWORD(&dummy, s_pszPropNames[0], 1);
     ok_long(hr, S_OK);
     ok_int(s_cWrite, 1);
 
-    Reset(VT_BSTR, L"Str1");
+    ResetTest(VT_BSTR, L"Str1");
     hr = SHPropertyBag_WriteStr(&dummy, s_pszPropNames[0], L"1");
     ok_long(hr, S_OK);
     ok_int(s_cWrite, 1);
 
-    Reset(VT_I4, L"POINTL1.x", L"POINTL1.y");
+    ResetTest(VT_I4, L"POINTL1.x", L"POINTL1.y");
     POINTL ptl = { 0xEEEE, 0xDDDD };
     hr = SHPropertyBag_WritePOINTL(&dummy, L"POINTL1", &ptl);
     ok_long(hr, S_OK);
     ok_int(s_cWrite, 2);
 
-    Reset(VT_I4, L"POINTS1.x", L"POINTS1.y");
+    ResetTest(VT_I4, L"POINTS1.x", L"POINTS1.y");
     POINTS pts = { 0x2222, 0x3333 };
     hr = SHPropertyBag_WritePOINTS(&dummy, L"POINTS1", &pts);
     ok_long(hr, S_OK);
     ok_int(s_cWrite, 2);
 
-    Reset(VT_I4, L"RECTL1.left", L"RECTL1.top", L"RECTL1.right", L"RECTL1.bottom");
+    ResetTest(VT_I4, L"RECTL1.left", L"RECTL1.top", L"RECTL1.right", L"RECTL1.bottom");
     RECTL rcl = { 123, 456, 789, 101112 };
     hr = SHPropertyBag_WriteRECTL(&dummy, L"RECTL1", &rcl);
     ok_long(hr, S_OK);
     ok_int(s_cWrite, 4);
 
-    Reset(VT_I4, L"RECTL2.left", L"RECTL2.top", L"RECTL2.right", L"RECTL2.bottom");
+    ResetTest(VT_I4, L"RECTL2.left", L"RECTL2.top", L"RECTL2.right", L"RECTL2.bottom");
     hr = SHPropertyBag_WriteRECTL(&dummy, L"RECTL2", &rcl);
     ok_long(hr, S_OK);
     ok_int(s_cWrite, 5);
 
     GUID guid;
     ZeroMemory(&guid, sizeof(guid));
-    Reset(VT_BSTR, L"GUID1");
+    ResetTest(VT_BSTR, L"GUID1");
     hr = SHPropertyBag_WriteGUID(&dummy, L"GUID1", &guid);
     ok_long(hr, S_OK);
     ok_int(s_cWrite, 1);

--- a/modules/rostests/apitests/shlwapi/SHPropertyBag.cpp
+++ b/modules/rostests/apitests/shlwapi/SHPropertyBag.cpp
@@ -67,6 +67,7 @@ public:
             {
                 ok_wstr(pszPropName, s_pszPropNames[i]);
                 s_pszPropNames[i] = NULL;
+                break;
             }
         }
         ok_int(s_vt, V_VT(pvari));

--- a/modules/rostests/apitests/shlwapi/SHPropertyBag.cpp
+++ b/modules/rostests/apitests/shlwapi/SHPropertyBag.cpp
@@ -1,19 +1,8 @@
 /*
- * Copyright 2023 Katayama Hirofumi MZ
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ * PROJECT:     ReactOS api tests
+ * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
+ * PURPOSE:     Tests for SHPropertyBag Read/Write
+ * COPYRIGHT:   Copyright 2023 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  */
 
 #include <apitest.h>

--- a/modules/rostests/apitests/shlwapi/testlist.c
+++ b/modules/rostests/apitests/shlwapi/testlist.c
@@ -10,6 +10,7 @@ extern void func_PathUnExpandEnvStringsForUser(void);
 extern void func_SHAreIconsEqual(void);
 extern void func_SHLoadIndirectString(void);
 extern void func_SHLoadRegUIString(void);
+extern void func_SHPropertyBag(void);
 extern void func_StrFormatByteSizeW(void);
 
 const struct test winetest_testlist[] =
@@ -23,6 +24,7 @@ const struct test winetest_testlist[] =
     { "SHAreIconsEqual", func_SHAreIconsEqual },
     { "SHLoadIndirectString", func_SHLoadIndirectString },
     { "SHLoadRegUIString", func_SHLoadRegUIString },
+    { "SHPropertyBag", func_SHPropertyBag },
     { "StrFormatByteSizeW", func_StrFormatByteSizeW },
     { 0, 0 }
 };

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -99,7 +99,7 @@ HRESULT WINAPI SHGetPerScreenResName(OUT LPWSTR lpResName,
                                      IN DWORD dwReserved);
 
 HRESULT WINAPI SHPropertyBag_ReadStream(IPropertyBag*,LPCWSTR,IStream**);
-HRESULT WINAPI SHPropertyBag_Delete(IPropertyBag *ppb, LPCOLESTR pszPropName);
+HRESULT WINAPI SHPropertyBag_Delete(IPropertyBag *ppb, LPCWSTR pszPropName);
 HRESULT WINAPI SHPropertyBag_WriteBOOL(IPropertyBag *ppb, LPCWSTR pszPropName, BOOL bValue);
 HRESULT WINAPI SHPropertyBag_WriteSHORT(IPropertyBag *ppb, LPCWSTR pszPropName, SHORT sValue);
 HRESULT WINAPI SHPropertyBag_WriteLONG(IPropertyBag *ppb, LPCWSTR pszPropName, LONG lValue);

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -107,8 +107,8 @@ HRESULT WINAPI SHPropertyBag_WriteDWORD(IPropertyBag *ppb, LPCWSTR pszPropName, 
 HRESULT WINAPI SHPropertyBag_WriteStr(IPropertyBag *ppb, LPCWSTR pszPropName, LPCWSTR pszValue);
 HRESULT WINAPI SHPropertyBag_WriteGUID(IPropertyBag *ppb, LPCWSTR pszPropName, const GUID *pguid);
 HRESULT WINAPI SHPropertyBag_WriteStream(IPropertyBag *ppb, LPCWSTR pszPropName, IStream *pStream);
-HRESULT WINAPI SHPropertyBag_WritePOINTL(IPropertyBag *ppb, LPCWSTR pszPropName, const POINTL *ppt);
-HRESULT WINAPI SHPropertyBag_WritePOINTS(IPropertyBag *ppb, LPCWSTR pszPropName, const POINTS *pts);
+HRESULT WINAPI SHPropertyBag_WritePOINTL(IPropertyBag *ppb, LPCWSTR pszPropName, const POINTL *pptl);
+HRESULT WINAPI SHPropertyBag_WritePOINTS(IPropertyBag *ppb, LPCWSTR pszPropName, const POINTS *ppts);
 HRESULT WINAPI SHPropertyBag_WriteRECTL(IPropertyBag *ppb, LPCWSTR pszPropName, const RECTL *prcl);
 
 HWND WINAPI SHCreateWorkerWindowA(WNDPROC wndProc, HWND hWndParent, DWORD dwExStyle,

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -99,6 +99,7 @@ HRESULT WINAPI SHGetPerScreenResName(OUT LPWSTR lpResName,
                                      IN DWORD dwReserved);
 
 HRESULT WINAPI SHPropertyBag_ReadStream(IPropertyBag*,LPCWSTR,IStream**);
+HRESULT WINAPI SHPropertyBag_Delete(IPropertyBag *ppb, LPCOLESTR pszPropName);
 HRESULT WINAPI SHPropertyBag_WriteBOOL(IPropertyBag *ppb, LPCWSTR pszPropName, BOOL bValue);
 HRESULT WINAPI SHPropertyBag_WriteSHORT(IPropertyBag *ppb, LPCWSTR pszPropName, SHORT sValue);
 HRESULT WINAPI SHPropertyBag_WriteLONG(IPropertyBag *ppb, LPCWSTR pszPropName, LONG lValue);
@@ -106,6 +107,9 @@ HRESULT WINAPI SHPropertyBag_WriteDWORD(IPropertyBag *ppb, LPCWSTR pszPropName, 
 HRESULT WINAPI SHPropertyBag_WriteStr(IPropertyBag *ppb, LPCWSTR pszPropName, LPCWSTR pszValue);
 HRESULT WINAPI SHPropertyBag_WriteGUID(IPropertyBag *ppb, LPCWSTR pszPropName, const GUID *pguid);
 HRESULT WINAPI SHPropertyBag_WriteStream(IPropertyBag *ppb, LPCWSTR pszPropName, IStream *pStream);
+HRESULT WINAPI SHPropertyBag_WritePOINTL(IPropertyBag *ppb, LPCWSTR pszPropName, const POINT *ppt);
+HRESULT WINAPI SHPropertyBag_WritePOINTS(IPropertyBag *ppb, LPCWSTR pszPropName, const POINTS *pts);
+HRESULT WINAPI SHPropertyBag_WriteRECTL(IPropertyBag *ppb, LPCWSTR pszPropName, const RECTL *prcl);
 
 HWND WINAPI SHCreateWorkerWindowA(WNDPROC wndProc, HWND hWndParent, DWORD dwExStyle,
                                   DWORD dwStyle, HMENU hMenu, LONG_PTR wnd_extra);

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -107,7 +107,7 @@ HRESULT WINAPI SHPropertyBag_WriteDWORD(IPropertyBag *ppb, LPCWSTR pszPropName, 
 HRESULT WINAPI SHPropertyBag_WriteStr(IPropertyBag *ppb, LPCWSTR pszPropName, LPCWSTR pszValue);
 HRESULT WINAPI SHPropertyBag_WriteGUID(IPropertyBag *ppb, LPCWSTR pszPropName, const GUID *pguid);
 HRESULT WINAPI SHPropertyBag_WriteStream(IPropertyBag *ppb, LPCWSTR pszPropName, IStream *pStream);
-HRESULT WINAPI SHPropertyBag_WritePOINTL(IPropertyBag *ppb, LPCWSTR pszPropName, const POINT *ppt);
+HRESULT WINAPI SHPropertyBag_WritePOINTL(IPropertyBag *ppb, LPCWSTR pszPropName, const POINTL *ppt);
 HRESULT WINAPI SHPropertyBag_WritePOINTS(IPropertyBag *ppb, LPCWSTR pszPropName, const POINTS *pts);
 HRESULT WINAPI SHPropertyBag_WriteRECTL(IPropertyBag *ppb, LPCWSTR pszPropName, const RECTL *prcl);
 


### PR DESCRIPTION
## Purpose

Implementing missing features...
JIRA issue: [CORE-9283](https://jira.reactos.org/browse/CORE-9283)

## Proposed changes

- Implement `SHPropertyBag_Delete`, `SHPropertyBag_WritePOINTL`, `SHPropertyBag_WritePOINTS`, and `SHPropertyBag_WriteRECTL` functions.
- `SHPropertyBag_WriteInt` is an alias to `SHPropertyBag_WriteLONG`.
- Modify `shlwapi.spec`.
- Modify `shlwapi_undoc.h`.
- Add `SHPropertyBag` testcase to `shlwapi_apitest.exe`.

## Comparison

WinXP:
![WinXP](https://github.com/reactos/reactos/assets/2107452/03d16bef-9841-419b-810e-de48581b9acd)
Successful.

Win2k3:
![Win2k3](https://github.com/reactos/reactos/assets/2107452/e201bf5d-fa79-4264-a58a-3896822270f5)
Successful.

Win10:
![Win10](https://github.com/reactos/reactos/assets/2107452/ea67de32-bfe6-4f14-bef9-59da1365808c)
Successful.

ReactOS:
![Ros](https://github.com/reactos/reactos/assets/2107452/c4894c65-0020-4c40-9e14-14fcea8a4d3a)
Successful.