### PR TITLE
[IP] Don't reference uninitialized pcb to avoid BSOD. CORE-18982

### DIFF
--- a/drivers/network/tcpip/ip/transport/tcp/tcp.c
+++ b/drivers/network/tcpip/ip/transport/tcp/tcp.c
@@ -411,7 +411,7 @@ NTSTATUS TCPConnect
                                                 &connaddr,
                                                 RemotePort));
     if (!NT_SUCCESS(Status))
-    { 
+    {
         LockObject(Connection);
         RemoveEntryList(&Bucket->Entry);
         UnlockObject(Connection);

--- a/drivers/network/tcpip/ip/transport/tcp/tcp.c
+++ b/drivers/network/tcpip/ip/transport/tcp/tcp.c
@@ -410,7 +410,7 @@ NTSTATUS TCPConnect
     Status = TCPTranslateError(LibTCPConnect(Connection,
                                                 &connaddr,
                                                 RemotePort));
-    if (Status != STATUS_SUCCESS && Status != STATUS_PENDING)
+    if (!NT_SUCCESS(Status)) // Status != STATUS_SUCCESS && Status != STATUS_PENDING
     { 
     	TI_DbgPrint(DEBUG_TCP,
                     ("No pcb from LibTCPConnect, clear ConnectRequest\n")); 

--- a/drivers/network/tcpip/ip/transport/tcp/tcp.c
+++ b/drivers/network/tcpip/ip/transport/tcp/tcp.c
@@ -410,8 +410,8 @@ NTSTATUS TCPConnect
     Status = TCPTranslateError(LibTCPConnect(Connection,
                                                 &connaddr,
                                                 RemotePort));
-    
-    if ((Status != STATUS_SUCCESS) && (Status != STATUS_PENDING)) { 
+    if (Status != STATUS_SUCCESS && Status != STATUS_PENDING)
+    { 
     	TI_DbgPrint(DEBUG_TCP,
                     ("no pcb from LibTCPConnect, clear ConnectRequest.\n")); 
     	LockObject(Connection);

--- a/drivers/network/tcpip/ip/transport/tcp/tcp.c
+++ b/drivers/network/tcpip/ip/transport/tcp/tcp.c
@@ -410,7 +410,17 @@ NTSTATUS TCPConnect
     Status = TCPTranslateError(LibTCPConnect(Connection,
                                                 &connaddr,
                                                 RemotePort));
-
+    
+    if ((Status != STATUS_SUCCESS) && (Status != STATUS_PENDING)) { 
+    	TI_DbgPrint(DEBUG_TCP,
+                    ("no pcb from LibTCPConnect, clear ConnectRequest.\n")); 
+    	LockObject(Connection);
+    	RemoveTailList( &Connection->ConnectRequest); 
+	    // DLB - re-check, not sure this part is correct
+	    ExFreeToNPagedLookasideList( &TdiBucketLookasideList, Bucket );
+    	UnlockObject(Connection);
+    }
+    
     TI_DbgPrint(DEBUG_TCP,("[IP, TCPConnect] Leaving. Status = 0x%x\n", Status));
 
     return Status;

--- a/drivers/network/tcpip/ip/transport/tcp/tcp.c
+++ b/drivers/network/tcpip/ip/transport/tcp/tcp.c
@@ -417,7 +417,6 @@ NTSTATUS TCPConnect
         UnlockObject(Connection);
         ExFreeToNPagedLookasideList(&TdiBucketLookasideList, Bucket);
     }
-    
     TI_DbgPrint(DEBUG_TCP,("[IP, TCPConnect] Leaving. Status = 0x%x\n", Status));
 
     return Status;

--- a/drivers/network/tcpip/ip/transport/tcp/tcp.c
+++ b/drivers/network/tcpip/ip/transport/tcp/tcp.c
@@ -415,7 +415,7 @@ NTSTATUS TCPConnect
     	TI_DbgPrint(DEBUG_TCP,
                     ("No pcb from LibTCPConnect, clear ConnectRequest\n")); 
     	LockObject(Connection);
-    	RemoveTailList(&Connection->ConnectRequest); 
+    	RemoveEntryList(&Bucket->Entry);
     	UnlockObject(Connection);
 	    ExFreeToNPagedLookasideList(&TdiBucketLookasideList, Bucket);
     }

--- a/drivers/network/tcpip/ip/transport/tcp/tcp.c
+++ b/drivers/network/tcpip/ip/transport/tcp/tcp.c
@@ -410,10 +410,8 @@ NTSTATUS TCPConnect
     Status = TCPTranslateError(LibTCPConnect(Connection,
                                                 &connaddr,
                                                 RemotePort));
-    if (!NT_SUCCESS(Status)) // Status != STATUS_SUCCESS && Status != STATUS_PENDING
+    if (!NT_SUCCESS(Status))
     { 
-        TI_DbgPrint(DEBUG_TCP,
-                    ("No pcb from LibTCPConnect, clear ConnectRequest\n")); 
         LockObject(Connection);
         RemoveEntryList(&Bucket->Entry);
         UnlockObject(Connection);

--- a/drivers/network/tcpip/ip/transport/tcp/tcp.c
+++ b/drivers/network/tcpip/ip/transport/tcp/tcp.c
@@ -413,7 +413,7 @@ NTSTATUS TCPConnect
     if (Status != STATUS_SUCCESS && Status != STATUS_PENDING)
     { 
     	TI_DbgPrint(DEBUG_TCP,
-                    ("no pcb from LibTCPConnect, clear ConnectRequest.\n")); 
+                    ("No pcb from LibTCPConnect, clear ConnectRequest\n")); 
     	LockObject(Connection);
     	RemoveTailList(&Connection->ConnectRequest); 
     	UnlockObject(Connection);

--- a/drivers/network/tcpip/ip/transport/tcp/tcp.c
+++ b/drivers/network/tcpip/ip/transport/tcp/tcp.c
@@ -412,12 +412,12 @@ NTSTATUS TCPConnect
                                                 RemotePort));
     if (!NT_SUCCESS(Status)) // Status != STATUS_SUCCESS && Status != STATUS_PENDING
     { 
-    	TI_DbgPrint(DEBUG_TCP,
+        TI_DbgPrint(DEBUG_TCP,
                     ("No pcb from LibTCPConnect, clear ConnectRequest\n")); 
-    	LockObject(Connection);
-    	RemoveEntryList(&Bucket->Entry);
-    	UnlockObject(Connection);
-	    ExFreeToNPagedLookasideList(&TdiBucketLookasideList, Bucket);
+        LockObject(Connection);
+        RemoveEntryList(&Bucket->Entry);
+        UnlockObject(Connection);
+        ExFreeToNPagedLookasideList(&TdiBucketLookasideList, Bucket);
     }
     
     TI_DbgPrint(DEBUG_TCP,("[IP, TCPConnect] Leaving. Status = 0x%x\n", Status));

--- a/drivers/network/tcpip/ip/transport/tcp/tcp.c
+++ b/drivers/network/tcpip/ip/transport/tcp/tcp.c
@@ -415,7 +415,7 @@ NTSTATUS TCPConnect
     	TI_DbgPrint(DEBUG_TCP,
                     ("no pcb from LibTCPConnect, clear ConnectRequest.\n")); 
     	LockObject(Connection);
-    	RemoveTailList( &Connection->ConnectRequest); 
+    	RemoveTailList(&Connection->ConnectRequest); 
     	UnlockObject(Connection);
 	    ExFreeToNPagedLookasideList(&TdiBucketLookasideList, Bucket);
     }

--- a/drivers/network/tcpip/ip/transport/tcp/tcp.c
+++ b/drivers/network/tcpip/ip/transport/tcp/tcp.c
@@ -416,9 +416,8 @@ NTSTATUS TCPConnect
                     ("no pcb from LibTCPConnect, clear ConnectRequest.\n")); 
     	LockObject(Connection);
     	RemoveTailList( &Connection->ConnectRequest); 
-	    // DLB - re-check, not sure this part is correct
-	    ExFreeToNPagedLookasideList( &TdiBucketLookasideList, Bucket );
     	UnlockObject(Connection);
+	    ExFreeToNPagedLookasideList(&TdiBucketLookasideList, Bucket);
     }
     
     TI_DbgPrint(DEBUG_TCP,("[IP, TCPConnect] Leaving. Status = 0x%x\n", Status));


### PR DESCRIPTION
transport calls to LibTCPConnect that suffer certain early failures like parameter errors or early route lookup failures return without initializing the pcb. In order to avoid later BSOD's this change clears the ConnectionRequest bucket in those cases.

JIRA issue: [CORE-18982](https://jira.reactos.org/browse/CORE-18982)

## Proposed changes

On return from LibTCPConnect clear ConnectionRequest bucket if status returned is not STATUS_SUCCESS or STATUS_PENDING
note: this addresses the BSOD, but not the address triplet reuse problem [TODO]