### PR TITLE
[AFD][WS2_32_APITEST] Store stream connection target in FCB allowing sendto() to re-use it. CORE-17521

### DIFF
--- a/drivers/network/afd/afd/connect.c
+++ b/drivers/network/afd/afd/connect.c
@@ -511,7 +511,7 @@ AfdStreamSocketConnect(PDEVICE_OBJECT DeviceObject, PIRP Irp,
                    	AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: calling TdiBuildconnectionInfo with RemoteAddress\n"));
                    	Status = TdiBuildConnectionInfo(&FCB->ConnectCallInfo, &ConnectReq->RemoteAddress);
                    	if( NT_SUCCESS(Status) ) {
-                   		AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: TdiBuildconnectionInfo succeeded, populating FCB.\n"));
+                   		AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: TdiBuildconnectionInfo succeeded, populating FCB\n"));
                    		FCB->ConnectCallInfo->UserData = FCB->ConnectData;
                 	    FCB->ConnectCallInfo->UserDataLength = FCB->ConnectDataSize;
                 	    FCB->ConnectCallInfo->Options = FCB->ConnectOptions;

--- a/drivers/network/afd/afd/connect.c
+++ b/drivers/network/afd/afd/connect.c
@@ -475,7 +475,7 @@ AfdStreamSocketConnect(PDEVICE_OBJECT DeviceObject, PIRP Irp,
            		    ExFreePoolWithTag(FCB->LocalAddress, TAG_AFD_TRANSPORT_ADDRESS);
            	    }
 
-           	    AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: setting FCB->LocalAddress.\n"));
+           	    AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: setting FCB->LocalAddress\n"));
 
            	    FCB->LocalAddress = TaBuildNullTransportAddress(ConnectReq->RemoteAddress.Address[0].AddressType);
 

--- a/drivers/network/afd/afd/connect.c
+++ b/drivers/network/afd/afd/connect.c
@@ -493,7 +493,7 @@ AfdStreamSocketConnect(PDEVICE_OBJECT DeviceObject, PIRP Irp,
             { // THIS CODE SECTION EXECUTES AND HANDLES STORING TARGET ADDRESS
 	     	    if (FCB->ConnectReturnInfo)
 	     	    {
-            		AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: ConnectReturnInfo set, dispose allocated obect\n"));
+            		AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: ConnectReturnInfo set, dispose allocated object\n"));
                 	ExFreePoolWithTag(FCB->ConnectReturnInfo, TAG_AFD_TDI_CONNECTION_INFORMATION);
 	         	}
 

--- a/drivers/network/afd/afd/connect.c
+++ b/drivers/network/afd/afd/connect.c
@@ -520,7 +520,7 @@ AfdStreamSocketConnect(PDEVICE_OBJECT DeviceObject, PIRP Irp,
                    	}
                	}
 	        } 
-            AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: FCB update code complete.\n"));
+            AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: FCB update code complete\n"));
             Status = STATUS_SUCCESS;
         }
         return UnlockAndMaybeComplete( FCB, Status, Irp, 0 );

--- a/drivers/network/afd/afd/connect.c
+++ b/drivers/network/afd/afd/connect.c
@@ -477,7 +477,7 @@ AfdStreamSocketConnect(PDEVICE_OBJECT DeviceObject, PIRP Irp,
 
            	    AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: setting FCB->LocalAddress.\n"));
 
-           	    FCB->LocalAddress = TaBuildNullTransportAddress( ConnectReq->RemoteAddress.Address[0].AddressType );
+           	    FCB->LocalAddress = TaBuildNullTransportAddress(ConnectReq->RemoteAddress.Address[0].AddressType);
 
            	    if( FCB->LocalAddress ) {
            		    AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: calling WarmSocketForBind.\n"));

--- a/drivers/network/afd/afd/connect.c
+++ b/drivers/network/afd/afd/connect.c
@@ -489,7 +489,7 @@ AfdStreamSocketConnect(PDEVICE_OBJECT DeviceObject, PIRP Irp,
 	            }    
 	        }
 
-	        if (FCB->State ==  SOCKET_STATE_BOUND) 
+	        if (FCB->State == SOCKET_STATE_BOUND)
             { // THIS CODE SECTION EXECUTES AND HANDLES STORING TARGET ADDRESS
 	     	    if (FCB->ConnectReturnInfo)
 	     	    {

--- a/drivers/network/afd/afd/connect.c
+++ b/drivers/network/afd/afd/connect.c
@@ -464,62 +464,62 @@ AfdStreamSocketConnect(PDEVICE_OBJECT DeviceObject, PIRP Irp,
             Status = STATUS_NO_MEMORY;
         else
         {
-	        /* original datagram code set STATUS_SUCCESS and exited here
+            /* original datagram code set STATUS_SUCCESS and exited here
             // THIS CODE WAS COPIED FROM STREAM CODE BELOW, IT SHOULD BE SAFE AND 'CORRECT', BUT MAY NOT BE OPTIMAL. */
             AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: calling WarmSocketConnection(FCB)\n"));
-	        if (FCB->State == SOCKET_STATE_CREATED)
+            if (FCB->State == SOCKET_STATE_CREATED)
             {
-        	    AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: SOCKET_STATE_CREATED is true\n"));
-           	    if (FCB->LocalAddress)
-           	    {
-           		    ExFreePoolWithTag(FCB->LocalAddress, TAG_AFD_TRANSPORT_ADDRESS);
-           	    }
+                AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: SOCKET_STATE_CREATED is true\n"));
+                if (FCB->LocalAddress)
+                {
+                    ExFreePoolWithTag(FCB->LocalAddress, TAG_AFD_TRANSPORT_ADDRESS);
+                }
 
-           	    AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: setting FCB->LocalAddress\n"));
+                AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: setting FCB->LocalAddress\n"));
 
-           	    FCB->LocalAddress = TaBuildNullTransportAddress(ConnectReq->RemoteAddress.Address[0].AddressType);
+                FCB->LocalAddress = TaBuildNullTransportAddress(ConnectReq->RemoteAddress.Address[0].AddressType);
 
-           	    if (FCB->LocalAddress) {
-           		    AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: calling WarmSocketForBind\n"));
-	       	        Status = WarmSocketForBind(FCB, AFD_SHARE_WILDCARD);
-           		    if (NT_SUCCESS(Status)) {
-           			    AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: setting SOCKET_STATE_BOUND\n"));
-               		    FCB->State = SOCKET_STATE_BOUND; // send REQUIRES THIS TO USE FCB->RemoteAddress
-	    	        }
-	            }
-	        }
+                if (FCB->LocalAddress) {
+                    AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: calling WarmSocketForBind\n"));
+                    Status = WarmSocketForBind(FCB, AFD_SHARE_WILDCARD);
+                    if (NT_SUCCESS(Status)) {
+                        AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: setting SOCKET_STATE_BOUND\n"));
+                        FCB->State = SOCKET_STATE_BOUND; // send REQUIRES THIS TO USE FCB->RemoteAddress
+                    }
+                }
+            }
 
-	        if (FCB->State == SOCKET_STATE_BOUND)
+            if (FCB->State == SOCKET_STATE_BOUND)
             { // THIS CODE SECTION EXECUTES AND HANDLES STORING TARGET ADDRESS
-	     	    if (FCB->ConnectReturnInfo)
-	     	    {
-            		AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: ConnectReturnInfo set, dispose allocated object\n"));
-                	ExFreePoolWithTag(FCB->ConnectReturnInfo, TAG_AFD_TDI_CONNECTION_INFORMATION);
-	         	}
+                if (FCB->ConnectReturnInfo)
+                {
+                    AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: ConnectReturnInfo set, dispose allocated object\n"));
+                    ExFreePoolWithTag(FCB->ConnectReturnInfo, TAG_AFD_TDI_CONNECTION_INFORMATION);
+                }
 
-               	AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: calling TdiBuildconnectionInfo with RemoteAddress\n"));
+                AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: calling TdiBuildconnectionInfo with RemoteAddress\n"));
                 Status = TdiBuildConnectionInfo(&FCB->ConnectReturnInfo, &ConnectReq->RemoteAddress);
 
-            	if (NT_SUCCESS(Status))
+                if (NT_SUCCESS(Status))
                 {
-                   	AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: ConnectReturnInfo placed in FCB\n"));
-                   	if (FCB->ConnectCallInfo)
-                   	{
-            		    AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: ConnectCallInfo set, dispose allocated object\n"));
-                    	ExFreePoolWithTag(FCB->ConnectCallInfo, TAG_AFD_TDI_CONNECTION_INFORMATION);
+                    AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: ConnectReturnInfo placed in FCB\n"));
+                    if (FCB->ConnectCallInfo)
+                    {
+                        AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: ConnectCallInfo set, dispose allocated object\n"));
+                        ExFreePoolWithTag(FCB->ConnectCallInfo, TAG_AFD_TDI_CONNECTION_INFORMATION);
                     }
-                   	AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: calling TdiBuildconnectionInfo with RemoteAddress\n"));
-                   	Status = TdiBuildConnectionInfo(&FCB->ConnectCallInfo, &ConnectReq->RemoteAddress);
-                   	if (NT_SUCCESS(Status)) {
-                   		AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: TdiBuildconnectionInfo succeeded, populating FCB\n"));
-                   		FCB->ConnectCallInfo->UserData = FCB->ConnectData;
-                	    FCB->ConnectCallInfo->UserDataLength = FCB->ConnectDataSize;
-                	    FCB->ConnectCallInfo->Options = FCB->ConnectOptions;
-                    	FCB->ConnectCallInfo->OptionsLength = FCB->ConnectOptionsSize;
-                   		AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: new ConnectCallInfo placed in FCB\n"));
-                   	}
-               	}
-	        }
+                    AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: calling TdiBuildconnectionInfo with RemoteAddress\n"));
+                    Status = TdiBuildConnectionInfo(&FCB->ConnectCallInfo, &ConnectReq->RemoteAddress);
+                    if (NT_SUCCESS(Status)) {
+                        AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: TdiBuildconnectionInfo succeeded, populating FCB\n"));
+                        FCB->ConnectCallInfo->UserData = FCB->ConnectData;
+                        FCB->ConnectCallInfo->UserDataLength = FCB->ConnectDataSize;
+                        FCB->ConnectCallInfo->Options = FCB->ConnectOptions;
+                        FCB->ConnectCallInfo->OptionsLength = FCB->ConnectOptionsSize;
+                        AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: new ConnectCallInfo placed in FCB\n"));
+                    }
+                }
+            }
             AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: FCB update code complete\n"));
             Status = STATUS_SUCCESS;
         }

--- a/drivers/network/afd/afd/connect.c
+++ b/drivers/network/afd/afd/connect.c
@@ -502,7 +502,7 @@ AfdStreamSocketConnect(PDEVICE_OBJECT DeviceObject, PIRP Irp,
 
             	if( NT_SUCCESS(Status) )
                 {
-                   	AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: ConnectReturnInfo placed in FCB.\n"));
+                   	AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: ConnectReturnInfo placed in FCB\n"));
                    	if (FCB->ConnectCallInfo)
                    	{
             		    AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: ConnectCallInfo set, dispose allocated obect.\n"));

--- a/drivers/network/afd/afd/connect.c
+++ b/drivers/network/afd/afd/connect.c
@@ -463,8 +463,66 @@ AfdStreamSocketConnect(PDEVICE_OBJECT DeviceObject, PIRP Irp,
         if( !FCB->RemoteAddress )
             Status = STATUS_NO_MEMORY;
         else
-            Status = STATUS_SUCCESS;
+        {
+	        /* original datagram code set STATUS_SUCCESS and exited here
+            // THIS CODE WAS COPIED FROM STREAM CODE BELOW, IT SHOULD BE SAFE AND 'CORRECT', BUT MAY NOT BE OPTIMAL. */
+            AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: calling WarmSocketConnection(FCB).\n"));
+	        if (FCB->State ==  SOCKET_STATE_CREATED) 
+            { 
+        	    AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: SOCKET_STATE_CREATED is true.\n"));
+           	    if (FCB->LocalAddress)
+           	    {
+           		    ExFreePoolWithTag(FCB->LocalAddress, TAG_AFD_TRANSPORT_ADDRESS);
+           	    }
 
+           	    AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: setting FCB->LocalAddress.\n"));
+
+           	    FCB->LocalAddress = TaBuildNullTransportAddress( ConnectReq->RemoteAddress.Address[0].AddressType );
+
+           	    if( FCB->LocalAddress ) {
+           		    AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: calling WarmSocketForBind.\n"));
+	       	        Status = WarmSocketForBind( FCB, AFD_SHARE_WILDCARD );
+           		    if( NT_SUCCESS(Status) ) {
+           			    AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: setting SOCKET_STATE_BOUND.\n"));
+               		    FCB->State = SOCKET_STATE_BOUND;  // <=== send REQUIRES THIS TO USE FCB->RemoteAddress
+	    	        }
+	            }    
+	        }
+
+	        if (FCB->State ==  SOCKET_STATE_BOUND) 
+            { // THIS CODE SECTION EXECUTES AND HANDLES STORING TARGET ADDRESS
+	     	    if (FCB->ConnectReturnInfo)
+	     	    {
+            		AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: ConnectReturnInfo set, dispose allocated obect.\n"));
+                	ExFreePoolWithTag(FCB->ConnectReturnInfo, TAG_AFD_TDI_CONNECTION_INFORMATION);
+	         	}
+
+               	AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: calling TdiBuildconnectionInfo with RemoteAddress.\n"));
+                Status = TdiBuildConnectionInfo( &FCB->ConnectReturnInfo, &ConnectReq->RemoteAddress );
+
+            	if( NT_SUCCESS(Status) )
+                {
+                   	AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: ConnectReturnInfo placed in FCB.\n"));
+                   	if (FCB->ConnectCallInfo)
+                   	{
+            		    AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: ConnectCallInfo set, dispose allocated obect.\n"));
+                    	ExFreePoolWithTag(FCB->ConnectCallInfo, TAG_AFD_TDI_CONNECTION_INFORMATION);
+                    }
+                   	AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: calling TdiBuildconnectionInfo with RemoteAddress.\n"));
+                   	Status = TdiBuildConnectionInfo(&FCB->ConnectCallInfo, &ConnectReq->RemoteAddress);
+                   	if( NT_SUCCESS(Status) ) {
+                   		AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: TdiBuildconnectionInfo succeeded, populating FCB.\n"));
+                   		FCB->ConnectCallInfo->UserData = FCB->ConnectData;
+                	    FCB->ConnectCallInfo->UserDataLength = FCB->ConnectDataSize;
+                	    FCB->ConnectCallInfo->Options = FCB->ConnectOptions;
+                    	FCB->ConnectCallInfo->OptionsLength = FCB->ConnectOptionsSize;
+                   		AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: new ConnectCallInfo placed in FCB.\n"));
+                   	}
+               	}
+	        } 
+            AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: FCB update code complete.\n"));
+            Status = STATUS_SUCCESS;
+        }
         return UnlockAndMaybeComplete( FCB, Status, Irp, 0 );
    }
 

--- a/drivers/network/afd/afd/connect.c
+++ b/drivers/network/afd/afd/connect.c
@@ -483,7 +483,7 @@ AfdStreamSocketConnect(PDEVICE_OBJECT DeviceObject, PIRP Irp,
            		    AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: calling WarmSocketForBind\n"));
 	       	        Status = WarmSocketForBind( FCB, AFD_SHARE_WILDCARD );
            		    if( NT_SUCCESS(Status) ) {
-           			    AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: setting SOCKET_STATE_BOUND.\n"));
+           			    AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: setting SOCKET_STATE_BOUND\n"));
                		    FCB->State = SOCKET_STATE_BOUND;  // <=== send REQUIRES THIS TO USE FCB->RemoteAddress
 	    	        }
 	            }    

--- a/drivers/network/afd/afd/connect.c
+++ b/drivers/network/afd/afd/connect.c
@@ -500,7 +500,7 @@ AfdStreamSocketConnect(PDEVICE_OBJECT DeviceObject, PIRP Irp,
                	AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: calling TdiBuildconnectionInfo with RemoteAddress\n"));
                 Status = TdiBuildConnectionInfo(&FCB->ConnectReturnInfo, &ConnectReq->RemoteAddress);
 
-            	if( NT_SUCCESS(Status) )
+            	if (NT_SUCCESS(Status))
                 {
                    	AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: ConnectReturnInfo placed in FCB\n"));
                    	if (FCB->ConnectCallInfo)

--- a/drivers/network/afd/afd/connect.c
+++ b/drivers/network/afd/afd/connect.c
@@ -505,7 +505,7 @@ AfdStreamSocketConnect(PDEVICE_OBJECT DeviceObject, PIRP Irp,
                    	AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: ConnectReturnInfo placed in FCB\n"));
                    	if (FCB->ConnectCallInfo)
                    	{
-            		    AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: ConnectCallInfo set, dispose allocated obect\n"));
+            		    AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: ConnectCallInfo set, dispose allocated object\n"));
                     	ExFreePoolWithTag(FCB->ConnectCallInfo, TAG_AFD_TDI_CONNECTION_INFORMATION);
                     }
                    	AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: calling TdiBuildconnectionInfo with RemoteAddress\n"));

--- a/drivers/network/afd/afd/connect.c
+++ b/drivers/network/afd/afd/connect.c
@@ -493,7 +493,7 @@ AfdStreamSocketConnect(PDEVICE_OBJECT DeviceObject, PIRP Irp,
             { // THIS CODE SECTION EXECUTES AND HANDLES STORING TARGET ADDRESS
 	     	    if (FCB->ConnectReturnInfo)
 	     	    {
-            		AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: ConnectReturnInfo set, dispose allocated obect.\n"));
+            		AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: ConnectReturnInfo set, dispose allocated obect\n"));
                 	ExFreePoolWithTag(FCB->ConnectReturnInfo, TAG_AFD_TDI_CONNECTION_INFORMATION);
 	         	}
 

--- a/drivers/network/afd/afd/connect.c
+++ b/drivers/network/afd/afd/connect.c
@@ -516,7 +516,7 @@ AfdStreamSocketConnect(PDEVICE_OBJECT DeviceObject, PIRP Irp,
                 	    FCB->ConnectCallInfo->UserDataLength = FCB->ConnectDataSize;
                 	    FCB->ConnectCallInfo->Options = FCB->ConnectOptions;
                     	FCB->ConnectCallInfo->OptionsLength = FCB->ConnectOptionsSize;
-                   		AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: new ConnectCallInfo placed in FCB.\n"));
+                   		AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: new ConnectCallInfo placed in FCB\n"));
                    	}
                	}
 	        } 

--- a/drivers/network/afd/afd/connect.c
+++ b/drivers/network/afd/afd/connect.c
@@ -484,7 +484,7 @@ AfdStreamSocketConnect(PDEVICE_OBJECT DeviceObject, PIRP Irp,
 	       	        Status = WarmSocketForBind(FCB, AFD_SHARE_WILDCARD);
            		    if (NT_SUCCESS(Status)) {
            			    AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: setting SOCKET_STATE_BOUND\n"));
-               		    FCB->State = SOCKET_STATE_BOUND;  // <=== send REQUIRES THIS TO USE FCB->RemoteAddress
+               		    FCB->State = SOCKET_STATE_BOUND; // send REQUIRES THIS TO USE FCB->RemoteAddress
 	    	        }
 	            }    
 	        }

--- a/drivers/network/afd/afd/connect.c
+++ b/drivers/network/afd/afd/connect.c
@@ -498,7 +498,7 @@ AfdStreamSocketConnect(PDEVICE_OBJECT DeviceObject, PIRP Irp,
 	         	}
 
                	AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: calling TdiBuildconnectionInfo with RemoteAddress\n"));
-                Status = TdiBuildConnectionInfo( &FCB->ConnectReturnInfo, &ConnectReq->RemoteAddress );
+                Status = TdiBuildConnectionInfo(&FCB->ConnectReturnInfo, &ConnectReq->RemoteAddress);
 
             	if( NT_SUCCESS(Status) )
                 {

--- a/drivers/network/afd/afd/connect.c
+++ b/drivers/network/afd/afd/connect.c
@@ -497,7 +497,7 @@ AfdStreamSocketConnect(PDEVICE_OBJECT DeviceObject, PIRP Irp,
                 	ExFreePoolWithTag(FCB->ConnectReturnInfo, TAG_AFD_TDI_CONNECTION_INFORMATION);
 	         	}
 
-               	AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: calling TdiBuildconnectionInfo with RemoteAddress.\n"));
+               	AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: calling TdiBuildconnectionInfo with RemoteAddress\n"));
                 Status = TdiBuildConnectionInfo( &FCB->ConnectReturnInfo, &ConnectReq->RemoteAddress );
 
             	if( NT_SUCCESS(Status) )

--- a/drivers/network/afd/afd/connect.c
+++ b/drivers/network/afd/afd/connect.c
@@ -480,7 +480,7 @@ AfdStreamSocketConnect(PDEVICE_OBJECT DeviceObject, PIRP Irp,
            	    FCB->LocalAddress = TaBuildNullTransportAddress(ConnectReq->RemoteAddress.Address[0].AddressType);
 
            	    if( FCB->LocalAddress ) {
-           		    AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: calling WarmSocketForBind.\n"));
+           		    AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: calling WarmSocketForBind\n"));
 	       	        Status = WarmSocketForBind( FCB, AFD_SHARE_WILDCARD );
            		    if( NT_SUCCESS(Status) ) {
            			    AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: setting SOCKET_STATE_BOUND.\n"));

--- a/drivers/network/afd/afd/connect.c
+++ b/drivers/network/afd/afd/connect.c
@@ -468,7 +468,7 @@ AfdStreamSocketConnect(PDEVICE_OBJECT DeviceObject, PIRP Irp,
             // THIS CODE WAS COPIED FROM STREAM CODE BELOW, IT SHOULD BE SAFE AND 'CORRECT', BUT MAY NOT BE OPTIMAL. */
             AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: calling WarmSocketConnection(FCB)\n"));
 	        if (FCB->State == SOCKET_STATE_CREATED)
-            { 
+            {
         	    AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: SOCKET_STATE_CREATED is true\n"));
            	    if (FCB->LocalAddress)
            	    {
@@ -486,7 +486,7 @@ AfdStreamSocketConnect(PDEVICE_OBJECT DeviceObject, PIRP Irp,
            			    AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: setting SOCKET_STATE_BOUND\n"));
                		    FCB->State = SOCKET_STATE_BOUND; // send REQUIRES THIS TO USE FCB->RemoteAddress
 	    	        }
-	            }    
+	            }
 	        }
 
 	        if (FCB->State == SOCKET_STATE_BOUND)
@@ -519,7 +519,7 @@ AfdStreamSocketConnect(PDEVICE_OBJECT DeviceObject, PIRP Irp,
                    		AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: new ConnectCallInfo placed in FCB\n"));
                    	}
                	}
-	        } 
+	        }
             AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: FCB update code complete\n"));
             Status = STATUS_SUCCESS;
         }

--- a/drivers/network/afd/afd/connect.c
+++ b/drivers/network/afd/afd/connect.c
@@ -481,7 +481,7 @@ AfdStreamSocketConnect(PDEVICE_OBJECT DeviceObject, PIRP Irp,
 
            	    if (FCB->LocalAddress) {
            		    AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: calling WarmSocketForBind\n"));
-	       	        Status = WarmSocketForBind( FCB, AFD_SHARE_WILDCARD );
+	       	        Status = WarmSocketForBind(FCB, AFD_SHARE_WILDCARD);
            		    if (NT_SUCCESS(Status)) {
            			    AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: setting SOCKET_STATE_BOUND\n"));
                		    FCB->State = SOCKET_STATE_BOUND;  // <=== send REQUIRES THIS TO USE FCB->RemoteAddress

--- a/drivers/network/afd/afd/connect.c
+++ b/drivers/network/afd/afd/connect.c
@@ -479,7 +479,7 @@ AfdStreamSocketConnect(PDEVICE_OBJECT DeviceObject, PIRP Irp,
 
            	    FCB->LocalAddress = TaBuildNullTransportAddress(ConnectReq->RemoteAddress.Address[0].AddressType);
 
-           	    if( FCB->LocalAddress ) {
+           	    if (FCB->LocalAddress) {
            		    AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: calling WarmSocketForBind\n"));
 	       	        Status = WarmSocketForBind( FCB, AFD_SHARE_WILDCARD );
            		    if( NT_SUCCESS(Status) ) {

--- a/drivers/network/afd/afd/connect.c
+++ b/drivers/network/afd/afd/connect.c
@@ -505,7 +505,7 @@ AfdStreamSocketConnect(PDEVICE_OBJECT DeviceObject, PIRP Irp,
                    	AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: ConnectReturnInfo placed in FCB\n"));
                    	if (FCB->ConnectCallInfo)
                    	{
-            		    AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: ConnectCallInfo set, dispose allocated obect.\n"));
+            		    AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: ConnectCallInfo set, dispose allocated obect\n"));
                     	ExFreePoolWithTag(FCB->ConnectCallInfo, TAG_AFD_TDI_CONNECTION_INFORMATION);
                     }
                    	AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: calling TdiBuildconnectionInfo with RemoteAddress.\n"));

--- a/drivers/network/afd/afd/connect.c
+++ b/drivers/network/afd/afd/connect.c
@@ -510,7 +510,7 @@ AfdStreamSocketConnect(PDEVICE_OBJECT DeviceObject, PIRP Irp,
                     }
                    	AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: calling TdiBuildconnectionInfo with RemoteAddress\n"));
                    	Status = TdiBuildConnectionInfo(&FCB->ConnectCallInfo, &ConnectReq->RemoteAddress);
-                   	if( NT_SUCCESS(Status) ) {
+                   	if (NT_SUCCESS(Status)) {
                    		AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: TdiBuildconnectionInfo succeeded, populating FCB\n"));
                    		FCB->ConnectCallInfo->UserData = FCB->ConnectData;
                 	    FCB->ConnectCallInfo->UserDataLength = FCB->ConnectDataSize;

--- a/drivers/network/afd/afd/connect.c
+++ b/drivers/network/afd/afd/connect.c
@@ -482,7 +482,7 @@ AfdStreamSocketConnect(PDEVICE_OBJECT DeviceObject, PIRP Irp,
            	    if (FCB->LocalAddress) {
            		    AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: calling WarmSocketForBind\n"));
 	       	        Status = WarmSocketForBind( FCB, AFD_SHARE_WILDCARD );
-           		    if( NT_SUCCESS(Status) ) {
+           		    if (NT_SUCCESS(Status)) {
            			    AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: setting SOCKET_STATE_BOUND\n"));
                		    FCB->State = SOCKET_STATE_BOUND;  // <=== send REQUIRES THIS TO USE FCB->RemoteAddress
 	    	        }

--- a/drivers/network/afd/afd/connect.c
+++ b/drivers/network/afd/afd/connect.c
@@ -466,7 +466,7 @@ AfdStreamSocketConnect(PDEVICE_OBJECT DeviceObject, PIRP Irp,
         {
 	        /* original datagram code set STATUS_SUCCESS and exited here
             // THIS CODE WAS COPIED FROM STREAM CODE BELOW, IT SHOULD BE SAFE AND 'CORRECT', BUT MAY NOT BE OPTIMAL. */
-            AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: calling WarmSocketConnection(FCB).\n"));
+            AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: calling WarmSocketConnection(FCB)\n"));
 	        if (FCB->State ==  SOCKET_STATE_CREATED) 
             { 
         	    AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: SOCKET_STATE_CREATED is true\n"));

--- a/drivers/network/afd/afd/connect.c
+++ b/drivers/network/afd/afd/connect.c
@@ -508,7 +508,7 @@ AfdStreamSocketConnect(PDEVICE_OBJECT DeviceObject, PIRP Irp,
             		    AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: ConnectCallInfo set, dispose allocated obect\n"));
                     	ExFreePoolWithTag(FCB->ConnectCallInfo, TAG_AFD_TDI_CONNECTION_INFORMATION);
                     }
-                   	AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: calling TdiBuildconnectionInfo with RemoteAddress.\n"));
+                   	AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: calling TdiBuildconnectionInfo with RemoteAddress\n"));
                    	Status = TdiBuildConnectionInfo(&FCB->ConnectCallInfo, &ConnectReq->RemoteAddress);
                    	if( NT_SUCCESS(Status) ) {
                    		AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: TdiBuildconnectionInfo succeeded, populating FCB.\n"));

--- a/drivers/network/afd/afd/connect.c
+++ b/drivers/network/afd/afd/connect.c
@@ -467,7 +467,7 @@ AfdStreamSocketConnect(PDEVICE_OBJECT DeviceObject, PIRP Irp,
 	        /* original datagram code set STATUS_SUCCESS and exited here
             // THIS CODE WAS COPIED FROM STREAM CODE BELOW, IT SHOULD BE SAFE AND 'CORRECT', BUT MAY NOT BE OPTIMAL. */
             AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: calling WarmSocketConnection(FCB)\n"));
-	        if (FCB->State ==  SOCKET_STATE_CREATED) 
+	        if (FCB->State == SOCKET_STATE_CREATED)
             { 
         	    AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: SOCKET_STATE_CREATED is true\n"));
            	    if (FCB->LocalAddress)

--- a/drivers/network/afd/afd/connect.c
+++ b/drivers/network/afd/afd/connect.c
@@ -469,7 +469,7 @@ AfdStreamSocketConnect(PDEVICE_OBJECT DeviceObject, PIRP Irp,
             AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: calling WarmSocketConnection(FCB).\n"));
 	        if (FCB->State ==  SOCKET_STATE_CREATED) 
             { 
-        	    AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: SOCKET_STATE_CREATED is true.\n"));
+        	    AFD_DbgPrint(MID_TRACE,("AfdStreamSocketConnect: SOCKET_STATE_CREATED is true\n"));
            	    if (FCB->LocalAddress)
            	    {
            		    ExFreePoolWithTag(FCB->LocalAddress, TAG_AFD_TRANSPORT_ADDRESS);

--- a/drivers/network/afd/afd/write.c
+++ b/drivers/network/afd/afd/write.c
@@ -639,7 +639,7 @@ AfdPacketSocketWriteData(PDEVICE_OBJECT DeviceObject, PIRP Irp,
 
     if( !NT_SUCCESS(Status) ) {
     	if (FCB->ConnectCallInfo) {
-    		AFD_DbgPrint(MID_TRACE,("AfdPacketSocketWriteData: setting TargetAddress from ConnectCallInfo->RemoteAddress.\n"));
+    		AFD_DbgPrint(MID_TRACE,("AfdPacketSocketWriteData: setting TargetAddress from ConnectCallInfo->RemoteAddress\n"));
 	    	Status = TdiBuildConnectionInfo(&TargetAddress, ((PTRANSPORT_ADDRESS)FCB->ConnectCallInfo->RemoteAddress));
 	    } else {
 		    if (FCB->ConnectReturnInfo) {

--- a/drivers/network/afd/afd/write.c
+++ b/drivers/network/afd/afd/write.c
@@ -377,11 +377,12 @@ AfdConnectedSocketWriteData(PDEVICE_OBJECT DeviceObject, PIRP Irp,
             if (FCB->ConnectCallInfo) {
                 AFD_DbgPrint(MID_TRACE,("AfdPacketSocketWriteData: setting TargetAddress from ConnectCallInfo->RemoteAddress\n"));
                 Status = TdiBuildConnectionInfo(&TargetAddress, ((PTRANSPORT_ADDRESS)FCB->ConnectCallInfo->RemoteAddress));
-            } else {
-                if (FCB->ConnectReturnInfo) {
-                    AFD_DbgPrint(MID_TRACE,("AfdPacketSocketWriteData: setting TargetAddress from ConnectReturnInfo->RemoteAddress\n"));
-                    Status = TdiBuildConnectionInfo(&TargetAddress, ((PTRANSPORT_ADDRESS)FCB->ConnectReturnInfo->RemoteAddress));
-                }
+            }
+        }                
+        if (!NT_SUCCESS(Status)) {
+            if (FCB->ConnectReturnInfo) {
+                AFD_DbgPrint(MID_TRACE,("AfdPacketSocketWriteData: setting TargetAddress from ConnectReturnInfo->RemoteAddress\n"));
+                Status = TdiBuildConnectionInfo(&TargetAddress, ((PTRANSPORT_ADDRESS)FCB->ConnectReturnInfo->RemoteAddress));
             }
         }
         
@@ -653,11 +654,12 @@ AfdPacketSocketWriteData(PDEVICE_OBJECT DeviceObject, PIRP Irp,
         if (FCB->ConnectCallInfo) {
             AFD_DbgPrint(MID_TRACE,("AfdPacketSocketWriteData: setting TargetAddress from ConnectCallInfo->RemoteAddress\n"));
             Status = TdiBuildConnectionInfo(&TargetAddress, ((PTRANSPORT_ADDRESS)FCB->ConnectCallInfo->RemoteAddress));
-        } else {
-            if (FCB->ConnectReturnInfo) {
-                AFD_DbgPrint(MID_TRACE,("AfdPacketSocketWriteData: setting TargetAddress from ConnectReturnInfo->RemoteAddress\n"));
-                Status = TdiBuildConnectionInfo(&TargetAddress, ((PTRANSPORT_ADDRESS)FCB->ConnectReturnInfo->RemoteAddress));
-            }
+        } 
+    }            
+    if (!NT_SUCCESS(Status)) {
+        if (FCB->ConnectReturnInfo) {
+            AFD_DbgPrint(MID_TRACE,("AfdPacketSocketWriteData: setting TargetAddress from ConnectReturnInfo->RemoteAddress\n"));
+            Status = TdiBuildConnectionInfo(&TargetAddress, ((PTRANSPORT_ADDRESS)FCB->ConnectReturnInfo->RemoteAddress));
         }
     }
 

--- a/drivers/network/afd/afd/write.c
+++ b/drivers/network/afd/afd/write.c
@@ -638,15 +638,15 @@ AfdPacketSocketWriteData(PDEVICE_OBJECT DeviceObject, PIRP Irp,
                             ((PTRANSPORT_ADDRESS)SendReq->TdiConnection.RemoteAddress) );
 
     if (!NT_SUCCESS(Status)) {
-    	if (FCB->ConnectCallInfo) {
-    		AFD_DbgPrint(MID_TRACE,("AfdPacketSocketWriteData: setting TargetAddress from ConnectCallInfo->RemoteAddress\n"));
-	    	Status = TdiBuildConnectionInfo(&TargetAddress, ((PTRANSPORT_ADDRESS)FCB->ConnectCallInfo->RemoteAddress));
-	    } else {
-		    if (FCB->ConnectReturnInfo) {
-    			AFD_DbgPrint(MID_TRACE,("AfdPacketSocketWriteData: setting TargetAddress from ConnectReturnInfo->RemoteAddress\n"));
-			    Status = TdiBuildConnectionInfo(&TargetAddress, ((PTRANSPORT_ADDRESS)FCB->ConnectReturnInfo->RemoteAddress));
-		    }
-	    }
+        if (FCB->ConnectCallInfo) {
+            AFD_DbgPrint(MID_TRACE,("AfdPacketSocketWriteData: setting TargetAddress from ConnectCallInfo->RemoteAddress\n"));
+            Status = TdiBuildConnectionInfo(&TargetAddress, ((PTRANSPORT_ADDRESS)FCB->ConnectCallInfo->RemoteAddress));
+        } else {
+            if (FCB->ConnectReturnInfo) {
+                AFD_DbgPrint(MID_TRACE,("AfdPacketSocketWriteData: setting TargetAddress from ConnectReturnInfo->RemoteAddress\n"));
+                Status = TdiBuildConnectionInfo(&TargetAddress, ((PTRANSPORT_ADDRESS)FCB->ConnectReturnInfo->RemoteAddress));
+            }
+        }
     }
 
     /* Check the size of the Address given ... */

--- a/drivers/network/afd/afd/write.c
+++ b/drivers/network/afd/afd/write.c
@@ -637,6 +637,18 @@ AfdPacketSocketWriteData(PDEVICE_OBJECT DeviceObject, PIRP Irp,
     Status = TdiBuildConnectionInfo( &TargetAddress,
                             ((PTRANSPORT_ADDRESS)SendReq->TdiConnection.RemoteAddress) );
 
+    if( !NT_SUCCESS(Status) ) {
+    	if (FCB->ConnectCallInfo) {
+    		AFD_DbgPrint(MID_TRACE,("AfdPacketSocketWriteData: setting TargetAddress from ConnectCallInfo->RemoteAddress.\n"));
+	    	Status = TdiBuildConnectionInfo( &TargetAddress, ((PTRANSPORT_ADDRESS)FCB->ConnectCallInfo->RemoteAddress) );
+	    } else {
+		    if (FCB->ConnectReturnInfo) {
+    			AFD_DbgPrint(MID_TRACE,("AfdPacketSocketWriteData: setting TargetAddress from ConnectReturnInfo->RemoteAddress.\n"));
+			    Status = TdiBuildConnectionInfo( &TargetAddress, ((PTRANSPORT_ADDRESS)FCB->ConnectReturnInfo->RemoteAddress) );
+		    }
+	    }
+    }
+    
     /* Check the size of the Address given ... */
 
     if( NT_SUCCESS(Status) ) {

--- a/drivers/network/afd/afd/write.c
+++ b/drivers/network/afd/afd/write.c
@@ -640,7 +640,7 @@ AfdPacketSocketWriteData(PDEVICE_OBJECT DeviceObject, PIRP Irp,
     if( !NT_SUCCESS(Status) ) {
     	if (FCB->ConnectCallInfo) {
     		AFD_DbgPrint(MID_TRACE,("AfdPacketSocketWriteData: setting TargetAddress from ConnectCallInfo->RemoteAddress.\n"));
-	    	Status = TdiBuildConnectionInfo( &TargetAddress, ((PTRANSPORT_ADDRESS)FCB->ConnectCallInfo->RemoteAddress) );
+	    	Status = TdiBuildConnectionInfo(&TargetAddress, ((PTRANSPORT_ADDRESS)FCB->ConnectCallInfo->RemoteAddress));
 	    } else {
 		    if (FCB->ConnectReturnInfo) {
     			AFD_DbgPrint(MID_TRACE,("AfdPacketSocketWriteData: setting TargetAddress from ConnectReturnInfo->RemoteAddress.\n"));

--- a/drivers/network/afd/afd/write.c
+++ b/drivers/network/afd/afd/write.c
@@ -373,6 +373,18 @@ AfdConnectedSocketWriteData(PDEVICE_OBJECT DeviceObject, PIRP Irp,
 
         Status = TdiBuildConnectionInfo( &TargetAddress, FCB->RemoteAddress );
 
+        if (!NT_SUCCESS(Status)) {
+            if (FCB->ConnectCallInfo) {
+                AFD_DbgPrint(MID_TRACE,("AfdPacketSocketWriteData: setting TargetAddress from ConnectCallInfo->RemoteAddress\n"));
+                Status = TdiBuildConnectionInfo(&TargetAddress, ((PTRANSPORT_ADDRESS)FCB->ConnectCallInfo->RemoteAddress));
+            } else {
+                if (FCB->ConnectReturnInfo) {
+                    AFD_DbgPrint(MID_TRACE,("AfdPacketSocketWriteData: setting TargetAddress from ConnectReturnInfo->RemoteAddress\n"));
+                    Status = TdiBuildConnectionInfo(&TargetAddress, ((PTRANSPORT_ADDRESS)FCB->ConnectReturnInfo->RemoteAddress));
+                }
+            }
+        }
+        
         if( NT_SUCCESS(Status) ) {
             FCB->PollState &= ~AFD_EVENT_SEND;
 

--- a/drivers/network/afd/afd/write.c
+++ b/drivers/network/afd/afd/write.c
@@ -637,7 +637,7 @@ AfdPacketSocketWriteData(PDEVICE_OBJECT DeviceObject, PIRP Irp,
     Status = TdiBuildConnectionInfo( &TargetAddress,
                             ((PTRANSPORT_ADDRESS)SendReq->TdiConnection.RemoteAddress) );
 
-    if( !NT_SUCCESS(Status) ) {
+    if (!NT_SUCCESS(Status)) {
     	if (FCB->ConnectCallInfo) {
     		AFD_DbgPrint(MID_TRACE,("AfdPacketSocketWriteData: setting TargetAddress from ConnectCallInfo->RemoteAddress\n"));
 	    	Status = TdiBuildConnectionInfo(&TargetAddress, ((PTRANSPORT_ADDRESS)FCB->ConnectCallInfo->RemoteAddress));

--- a/drivers/network/afd/afd/write.c
+++ b/drivers/network/afd/afd/write.c
@@ -644,7 +644,7 @@ AfdPacketSocketWriteData(PDEVICE_OBJECT DeviceObject, PIRP Irp,
 	    } else {
 		    if (FCB->ConnectReturnInfo) {
     			AFD_DbgPrint(MID_TRACE,("AfdPacketSocketWriteData: setting TargetAddress from ConnectReturnInfo->RemoteAddress.\n"));
-			    Status = TdiBuildConnectionInfo( &TargetAddress, ((PTRANSPORT_ADDRESS)FCB->ConnectReturnInfo->RemoteAddress) );
+			    Status = TdiBuildConnectionInfo(&TargetAddress, ((PTRANSPORT_ADDRESS)FCB->ConnectReturnInfo->RemoteAddress));
 		    }
 	    }
     }

--- a/drivers/network/afd/afd/write.c
+++ b/drivers/network/afd/afd/write.c
@@ -648,7 +648,7 @@ AfdPacketSocketWriteData(PDEVICE_OBJECT DeviceObject, PIRP Irp,
 		    }
 	    }
     }
-    
+
     /* Check the size of the Address given ... */
 
     if( NT_SUCCESS(Status) ) {

--- a/drivers/network/afd/afd/write.c
+++ b/drivers/network/afd/afd/write.c
@@ -643,7 +643,7 @@ AfdPacketSocketWriteData(PDEVICE_OBJECT DeviceObject, PIRP Irp,
 	    	Status = TdiBuildConnectionInfo(&TargetAddress, ((PTRANSPORT_ADDRESS)FCB->ConnectCallInfo->RemoteAddress));
 	    } else {
 		    if (FCB->ConnectReturnInfo) {
-    			AFD_DbgPrint(MID_TRACE,("AfdPacketSocketWriteData: setting TargetAddress from ConnectReturnInfo->RemoteAddress.\n"));
+    			AFD_DbgPrint(MID_TRACE,("AfdPacketSocketWriteData: setting TargetAddress from ConnectReturnInfo->RemoteAddress\n"));
 			    Status = TdiBuildConnectionInfo(&TargetAddress, ((PTRANSPORT_ADDRESS)FCB->ConnectReturnInfo->RemoteAddress));
 		    }
 	    }

--- a/modules/rostests/apitests/ws2_32/send.c
+++ b/modules/rostests/apitests/ws2_32/send.c
@@ -172,8 +172,8 @@ test_sendto(void)
     ret = sendto(sock, buffer, bufferSize, 0 , NULL, 0);
     error = WSAGetLastError();
     ok(ret == bufferSize, "sendto returned %d\n", ret);
-    ok(error == 0, "error = %d\n", error);  
-    
+    ok(error == 0, "error = %d\n", error);
+
     closesocket(sock);
 
     FreeReadOnly(buffer);

--- a/modules/rostests/apitests/ws2_32/send.c
+++ b/modules/rostests/apitests/ws2_32/send.c
@@ -162,6 +162,18 @@ test_sendto(void)
     ok(ret == bufferSize, "sendto returned %d\n", ret);
     ok(error == 0, "error = %d\n", error);
 
+    // case for testing sendto() with null target after initial connect CORE-17521
+    // it may seem an odd sequence, but yes connect call on UDP sockets are valid
+    ret = connect(sock, (const struct sockaddr *) &addr, sizeof(addr));
+    error = WSAGetLastError();
+    ok(ret == 0, "connect returned %d\n", ret);
+    ok(error == 0, "error = %d\n", error);
+
+    ret = sendto(sock, buffer, bufferSize, 0 , NULL, 0);
+    error = WSAGetLastError();
+    ok(ret == bufferSize, "sendto returned %d\n", ret);
+    ok(error == 0, "error = %d\n", error);  
+    
     closesocket(sock);
 
     FreeReadOnly(buffer);

--- a/sdk/include/reactos/drivers/afd/shared.h
+++ b/sdk/include/reactos/drivers/afd/shared.h
@@ -111,7 +111,7 @@ typedef struct _AFD_SEND_INFO_UDP {
     TDI_REQUEST_SEND_DATAGRAM		TdiRequest;
     TDI_CONNECTION_INFORMATION		TdiConnection;
     PVOID				Address; // for CORE-17521
-    PINT				AddressLength; // for CORE-1752
+    PINT				AddressLength; // for CORE-17521
 } AFD_SEND_INFO_UDP, *PAFD_SEND_INFO_UDP;
 
 C_ASSERT(sizeof(AFD_RECV_INFO) == sizeof(AFD_SEND_INFO));

--- a/sdk/include/reactos/drivers/afd/shared.h
+++ b/sdk/include/reactos/drivers/afd/shared.h
@@ -110,6 +110,8 @@ typedef struct _AFD_SEND_INFO_UDP {
     ULONG				AfdFlags;
     TDI_REQUEST_SEND_DATAGRAM		TdiRequest;
     TDI_CONNECTION_INFORMATION		TdiConnection;
+    PVOID				Address; // for CORE-17521
+    PINT				AddressLength; // for CORE-1752
 } AFD_SEND_INFO_UDP, *PAFD_SEND_INFO_UDP;
 
 C_ASSERT(sizeof(AFD_RECV_INFO) == sizeof(AFD_SEND_INFO));


### PR DESCRIPTION
Allow AFD stream packet sending routines to re-use the TargetAddress in subsequent sends when it is not specified again

JIRA issue: [CORE-17521](https://jira.reactos.org/browse/CORE-17521)

Alter connect functions to store target address in FCB->RemoteAddress so that it can be used by sendto() when sendto() it is called without specifying the target address after a connection is in place
