### PR TITLE
[ADVAPI32] Don't treat a structure pointer as a simple string pointer. CORE-18996

### DIFF
--- a/dll/win32/advapi32/sec/lsa.c
+++ b/dll/win32/advapi32/sec/lsa.c
@@ -23,7 +23,7 @@ LsapIsLocalComputer(PLSA_UNICODE_STRING ServerName)
     DWORD dwSize = MAX_COMPUTERNAME_LENGTH + 1;
     BOOL Result;
     LPWSTR buf;
-    PCWSTR pSrvName; 
+    PCWSTR pSrvName;
 
     if (ServerName == NULL || ServerName->Length == 0 || ServerName->Buffer == NULL)
         return TRUE;

--- a/dll/win32/advapi32/sec/lsa.c
+++ b/dll/win32/advapi32/sec/lsa.c
@@ -23,7 +23,7 @@ LsapIsLocalComputer(PLSA_UNICODE_STRING ServerName)
     DWORD dwSize = MAX_COMPUTERNAME_LENGTH + 1;
     BOOL Result;
     LPWSTR buf;
-    PCWSTR pSrvName;
+    PCWSTR pSrvName; 
 
     if (ServerName == NULL || ServerName->Length == 0 || ServerName->Buffer == NULL)
         return TRUE;

--- a/dll/win32/advapi32/sec/lsa.c
+++ b/dll/win32/advapi32/sec/lsa.c
@@ -23,19 +23,16 @@ LsapIsLocalComputer(PLSA_UNICODE_STRING ServerName)
     DWORD dwSize = MAX_COMPUTERNAME_LENGTH + 1;
     BOOL Result;
     LPWSTR buf;
+    PCWSTR pSrvName = ServerName->Buffer;
 
     if (ServerName == NULL || ServerName->Length == 0 || ServerName->Buffer == NULL)
         return TRUE;
 
     buf = HeapAlloc(GetProcessHeap(), 0, dwSize * sizeof(WCHAR));
     Result = GetComputerNameW(buf, &dwSize);
-    if (Result)
-    {
-        PCWSTR pSrvName = ServerName->Buffer;
-        if (pSrvName[0] == '\\' && pSrvName[1] == '\\')
-            pSrvName += 2;
-        Result = !lstrcmpW(pSrvName, buf);
-    }
+    if (Result && (pSrvName[0] == L'\\') && (pSrvName[1] == L'\\'))
+        pSrvName += 2;
+    Result = Result && !lstrcmpW(pSrvName, buf);
     HeapFree(GetProcessHeap(), 0, buf);
 
     return Result;

--- a/dll/win32/advapi32/sec/lsa.c
+++ b/dll/win32/advapi32/sec/lsa.c
@@ -23,11 +23,12 @@ LsapIsLocalComputer(PLSA_UNICODE_STRING ServerName)
     DWORD dwSize = MAX_COMPUTERNAME_LENGTH + 1;
     BOOL Result;
     LPWSTR buf;
-    PCWSTR pSrvName = ServerName->Buffer;
+    PCWSTR pSrvName;
 
     if (ServerName == NULL || ServerName->Length == 0 || ServerName->Buffer == NULL)
         return TRUE;
 
+    pSrvName = ServerName->Buffer;
     buf = HeapAlloc(GetProcessHeap(), 0, dwSize * sizeof(WCHAR));
     Result = GetComputerNameW(buf, &dwSize);
     if (Result && (pSrvName[0] == L'\\') && (pSrvName[1] == L'\\'))

--- a/dll/win32/advapi32/sec/lsa.c
+++ b/dll/win32/advapi32/sec/lsa.c
@@ -29,9 +29,11 @@ LsapIsLocalComputer(PLSA_UNICODE_STRING ServerName)
 
     buf = HeapAlloc(GetProcessHeap(), 0, dwSize * sizeof(WCHAR));
     Result = GetComputerNameW(buf, &dwSize);
-    if (Result && (ServerName->Buffer[0] == '\\') && (ServerName->Buffer[1] == '\\'))
-        ServerName += 2;
-    Result = Result && !lstrcmpW(ServerName->Buffer, buf);
+    if (Result && (ServerName->Buffer[0] == '\\') && (ServerName->Buffer[1] == '\\')) {
+		Result = Result && !lstrcmpW((LPCWSTR)&ServerName->Buffer[2], buf); 
+	} else {
+		Result = Result && !lstrcmpW(ServerName->Buffer, buf); 
+	} 
     HeapFree(GetProcessHeap(), 0, buf);
 
     return Result;

--- a/dll/win32/advapi32/sec/lsa.c
+++ b/dll/win32/advapi32/sec/lsa.c
@@ -29,12 +29,13 @@ LsapIsLocalComputer(PLSA_UNICODE_STRING ServerName)
 
     buf = HeapAlloc(GetProcessHeap(), 0, dwSize * sizeof(WCHAR));
     Result = GetComputerNameW(buf, &dwSize);
-    if (Result) {
-        if (ServerName->Buffer[0] == '\\' && ServerName->Buffer[1] == '\\')
-	    	Result = !lstrcmpW((LPCWSTR)&ServerName->Buffer[2], buf); 
-    	else
-	    	Result = !lstrcmpW(ServerName->Buffer, buf); 
-	} 
+    if (Result)
+    {
+        PCWSTR pSrvName = ServerName->Buffer;
+        if (pSrvName[0] == '\\' && pSrvName[1] == '\\')
+            pSrvName += 2;
+        Result = !lstrcmpW(pSrvName, buf); 
+    } 
     HeapFree(GetProcessHeap(), 0, buf);
 
     return Result;

--- a/dll/win32/advapi32/sec/lsa.c
+++ b/dll/win32/advapi32/sec/lsa.c
@@ -34,8 +34,8 @@ LsapIsLocalComputer(PLSA_UNICODE_STRING ServerName)
         PCWSTR pSrvName = ServerName->Buffer;
         if (pSrvName[0] == '\\' && pSrvName[1] == '\\')
             pSrvName += 2;
-        Result = !lstrcmpW(pSrvName, buf); 
-    } 
+        Result = !lstrcmpW(pSrvName, buf);
+    }
     HeapFree(GetProcessHeap(), 0, buf);
 
     return Result;

--- a/dll/win32/advapi32/sec/lsa.c
+++ b/dll/win32/advapi32/sec/lsa.c
@@ -29,10 +29,11 @@ LsapIsLocalComputer(PLSA_UNICODE_STRING ServerName)
 
     buf = HeapAlloc(GetProcessHeap(), 0, dwSize * sizeof(WCHAR));
     Result = GetComputerNameW(buf, &dwSize);
-    if (Result && (ServerName->Buffer[0] == '\\') && (ServerName->Buffer[1] == '\\')) {
-		Result = Result && !lstrcmpW((LPCWSTR)&ServerName->Buffer[2], buf); 
-	} else {
-		Result = Result && !lstrcmpW(ServerName->Buffer, buf); 
+    if (Result) {
+        if (ServerName->Buffer[0] == '\\' && ServerName->Buffer[1] == '\\')
+	    	Result = !lstrcmpW((LPCWSTR)&ServerName->Buffer[2], buf); 
+    	else
+	    	Result = !lstrcmpW(ServerName->Buffer, buf); 
 	} 
     HeapFree(GetProcessHeap(), 0, buf);
 


### PR DESCRIPTION
Current code incorrectly treats a structure pointer as a simple string pointer.

JIRA issue: [CORE-18996](https://jira.reactos.org/browse/CORE-18996)

Replace code incrementing unicode string pointer incorrectly with structure appropriate code. This should eliminate an exception and make the function operate correctly.

