### PR TITLE
[SHLWAPI][SHLWAPI_APITEST][SDK] Implement SHPropertyBag_ReadDWORD etc.

### DIFF
--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -5293,26 +5293,26 @@ HRESULT WINAPI IUnknown_QueryServiceForWebBrowserApp(IUnknown* lpUnknown,
 HRESULT VariantChangeTypeForRead(IN OUT VARIANTARG *pvarg, IN VARTYPE vt)
 {
     HRESULT hr;
-    VARIANTARG varg;
-    VARIANT vari;
+    VARIANTARG vargTemp;
+    VARIANT variTemp;
 
     if (V_VT(pvarg) == vt || vt == VT_EMPTY)
         return S_OK;
 
-    varg = *pvarg;
+    vargTemp = *pvarg;
 
-    if (V_VT(&varg) != VT_BSTR || vt <= VT_NULL)
+    if (V_VT(&vargTemp) != VT_BSTR || vt <= VT_NULL)
         goto DoDefault;
 
     if (vt == VT_I1 || vt == VT_I2 || vt == VT_I4)
     {
-        if (!StrToIntExW(V_BSTR(&varg), STIF_SUPPORT_HEX, &V_I4(&vari)))
+        if (!StrToIntExW(V_BSTR(&vargTemp), STIF_SUPPORT_HEX, &V_I4(&variTemp)))
             goto DoDefault;
 
-        V_VT(&vari) = VT_INT;
+        V_VT(&variTemp) = VT_INT;
         VariantInit(pvarg);
-        hr = VariantChangeType(pvarg, &vari, 0, vt);
-        VariantClear(&varg);
+        hr = VariantChangeType(pvarg, &variTemp, 0, vt);
+        VariantClear(&vargTemp);
         return hr;
     }
 
@@ -5321,32 +5321,32 @@ HRESULT VariantChangeTypeForRead(IN OUT VARIANTARG *pvarg, IN VARTYPE vt)
 
     if (vt == VT_UI1 || vt == VT_UI2 || vt == VT_UI4)
     {
-        if (!StrToIntExW(V_BSTR(&varg), STIF_SUPPORT_HEX, (LPINT)&V_UI4(&vari)))
+        if (!StrToIntExW(V_BSTR(&vargTemp), STIF_SUPPORT_HEX, (LPINT)&V_UI4(&variTemp)))
             goto DoDefault;
 
-        V_VT(&vari) = VT_UINT;
+        V_VT(&variTemp) = VT_UINT;
         VariantInit(pvarg);
-        hr = VariantChangeType(pvarg, &vari, 0, vt);
-        VariantClear(&varg);
+        hr = VariantChangeType(pvarg, &variTemp, 0, vt);
+        VariantClear(&vargTemp);
         return hr;
     }
 
     if (vt == VT_INT || vt == VT_UINT)
     {
-        if (!StrToIntExW(V_BSTR(&varg), STIF_SUPPORT_HEX, &V_INT(&vari)))
+        if (!StrToIntExW(V_BSTR(&vargTemp), STIF_SUPPORT_HEX, &V_INT(&variTemp)))
             goto DoDefault;
 
-        V_VT(&vari) = VT_UINT;
+        V_VT(&variTemp) = VT_UINT;
         VariantInit(pvarg);
-        hr = VariantChangeType(pvarg, &vari, 0, vt);
-        VariantClear(&varg);
+        hr = VariantChangeType(pvarg, &variTemp, 0, vt);
+        VariantClear(&vargTemp);
         return hr;
     }
 
 DoDefault:
     VariantInit(pvarg);
-    hr = VariantChangeType(pvarg, &varg, 0, vt);
-    VariantClear(&varg);
+    hr = VariantChangeType(pvarg, &vargTemp, 0, vt);
+    VariantClear(&vargTemp);
     return hr;
 }
 

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -5289,6 +5289,152 @@ HRESULT WINAPI IUnknown_QueryServiceForWebBrowserApp(IUnknown* lpUnknown,
     return IUnknown_QueryService(lpUnknown,&IID_IWebBrowserApp,riid,lppOut);
 }
 
+#ifdef __REACTOS__
+HRESULT VariantChangeTypeForRead(IN OUT VARIANTARG *pvarg, IN VARTYPE vt)
+{
+    HRESULT hr;
+    VARIANTARG varg;
+    VARIANT vari;
+
+    if (V_VT(pvarg) == vt || vt == VT_EMPTY)
+        return S_OK;
+
+    varg = *pvarg;
+
+    if (V_VT(&varg) != VT_BSTR || vt <= VT_NULL)
+        goto DoDefault;
+
+    if (vt == VT_I1 || vt == VT_I2 || vt == VT_I4)
+    {
+        if (!StrToIntExW(V_BSTR(&varg), STIF_SUPPORT_HEX, &V_I4(&vari)))
+            goto DoDefault;
+
+        V_VT(&vari) = VT_INT;
+        VariantInit(pvarg);
+        hr = VariantChangeType(pvarg, &vari, 0, vt);
+        VariantClear(&varg);
+        return hr;
+    }
+
+    if (vt <= VT_DECIMAL)
+        goto DoDefault;
+
+    if (vt == VT_UI1 || vt == VT_UI2 || vt == VT_UI4)
+    {
+        if (!StrToIntExW(V_BSTR(&varg), STIF_SUPPORT_HEX, (LPINT)&V_UI4(&vari)))
+            goto DoDefault;
+
+        V_VT(&vari) = VT_UINT;
+        VariantInit(pvarg);
+        hr = VariantChangeType(pvarg, &vari, 0, vt);
+        VariantClear(&varg);
+        return hr;
+    }
+
+    if (vt == VT_INT || vt == VT_UINT)
+    {
+        if (!StrToIntExW(V_BSTR(&varg), STIF_SUPPORT_HEX, &V_INT(&vari)))
+            goto DoDefault;
+
+        V_VT(&vari) = VT_UINT;
+        VariantInit(pvarg);
+        hr = VariantChangeType(pvarg, &vari, 0, vt);
+        VariantClear(&varg);
+        return hr;
+    }
+
+DoDefault:
+    VariantInit(pvarg);
+    hr = VariantChangeType(pvarg, &varg, 0, vt);
+    VariantClear(&varg);
+    return hr;
+}
+
+/**************************************************************************
+ *  SHPropertyBag_ReadType (SHLWAPI.493)
+ */
+HRESULT WINAPI
+SHPropertyBag_ReadType(IPropertyBag *ppb, LPCWSTR pszPropName, VARIANTARG *pvarg, VARTYPE vt)
+{
+    HRESULT hr;
+
+    VariantInit(pvarg);
+    V_VT(pvarg) = vt;
+
+    hr = IPropertyBag_Read(ppb, pszPropName, pvarg, NULL);
+    if (FAILED(hr))
+    {
+        ERR("%p %s\n", ppb, debugstr_w(pszPropName));
+        VariantInit(pvarg);
+        return hr;
+    }
+
+    return VariantChangeTypeForRead(pvarg, vt);
+}
+
+/**************************************************************************
+ *  SHPropertyBag_ReadBOOL (SHLWAPI.534)
+ */
+HRESULT WINAPI SHPropertyBag_ReadBOOL(IPropertyBag *ppb, LPCWSTR pszPropName, BOOL *pbValue)
+{
+    HRESULT hr;
+    VARIANTARG varg;
+
+    TRACE("%p %s %p\n", ppb, debugstr_w(pszPropName), pbValue);
+
+    if (!ppb || !pszPropName || !pbValue)
+    {
+        ERR("%p %s %p\n", ppb, debugstr_w(pszPropName), pbValue);
+        return E_INVALIDARG;
+    }
+
+    hr = SHPropertyBag_ReadType(ppb, pszPropName, &varg, VT_BOOL);
+    if (SUCCEEDED(hr))
+        *pbValue = (V_BOOL(&varg) == VARIANT_TRUE);
+
+    return hr;
+}
+
+/**************************************************************************
+ *  SHPropertyBag_ReadBOOLOld (SHLWAPI.498)
+ */
+BOOL WINAPI SHPropertyBag_ReadBOOLOld(IPropertyBag *ppb, LPCWSTR pszPropName, BOOL bDefValue)
+{
+    VARIANTARG varg;
+    HRESULT hr;
+
+    TRACE("%p %s %d\n", ppb, debugstr_w(pszPropName), bDefValue);
+
+    hr = SHPropertyBag_ReadType(ppb, pszPropName, &varg, VT_BOOL);
+    if (FAILED(hr))
+        return bDefValue;
+
+    return V_BOOL(&varg) == VARIANT_TRUE;
+}
+
+/**************************************************************************
+ *  SHPropertyBag_ReadSHORT (SHLWAPI.527)
+ */
+HRESULT WINAPI SHPropertyBag_ReadSHORT(IPropertyBag *ppb, LPCWSTR pszPropName, SHORT *psValue)
+{
+    HRESULT hr;
+    VARIANTARG varg;
+
+    TRACE("%p %s %p\n", ppb, debugstr_w(pszPropName), psValue);
+
+    if (!ppb || !pszPropName || !psValue)
+    {
+        ERR("%p %s %p\n", ppb, debugstr_w(pszPropName), psValue);
+        return E_INVALIDARG;
+    }
+
+    hr = SHPropertyBag_ReadType(ppb, pszPropName, &varg, VT_UI2);
+    if (SUCCEEDED(hr))
+        *psValue = V_UI2(&varg);
+
+    return hr;
+}
+#endif
 /**************************************************************************
  *  SHPropertyBag_ReadLONG (SHLWAPI.496)
  *
@@ -5304,6 +5450,22 @@ HRESULT WINAPI IUnknown_QueryServiceForWebBrowserApp(IUnknown* lpUnknown,
  */
 HRESULT WINAPI SHPropertyBag_ReadLONG(IPropertyBag *ppb, LPCWSTR pszPropName, LPLONG pValue)
 {
+#ifdef __REACTOS__
+    HRESULT hr;
+    VARIANTARG varg;
+
+    TRACE("%p %s %p\n", ppb, debugstr_w(pszPropName), pValue);
+
+    if (!ppb || !pszPropName || !pValue)
+    {
+        ERR("%p %s %p\n", ppb, debugstr_w(pszPropName), pValue);
+        return E_INVALIDARG;
+    }
+
+    hr = SHPropertyBag_ReadType(ppb, pszPropName, &varg, VT_I4);
+    if (SUCCEEDED(hr))
+        *pValue = V_I4(&varg);
+#else
     VARIANT var;
     HRESULT hr;
     TRACE("%p %s %p\n", ppb,debugstr_w(pszPropName),pValue);
@@ -5318,10 +5480,34 @@ HRESULT WINAPI SHPropertyBag_ReadLONG(IPropertyBag *ppb, LPCWSTR pszPropName, LP
         else
             hr = DISP_E_BADVARTYPE;
     }
+#endif
     return hr;
 }
 
 #ifdef __REACTOS__
+/**************************************************************************
+ *  SHPropertyBag_ReadDWORD (SHLWAPI.507)
+ */
+HRESULT WINAPI SHPropertyBag_ReadDWORD(IPropertyBag *ppb, LPCWSTR pszPropName, DWORD *pdwValue)
+{
+    HRESULT hr;
+    VARIANTARG varg;
+
+    TRACE("%p %s %p\n", ppb, debugstr_w(pszPropName), pdwValue);
+
+    if (!ppb || !pszPropName || !pdwValue)
+    {
+        ERR("%p %s %p\n", ppb, debugstr_w(pszPropName), pdwValue);
+        return E_INVALIDARG;
+    }
+
+    hr = SHPropertyBag_ReadType(ppb, pszPropName, &varg, VT_UI4);
+    if (SUCCEEDED(hr))
+        *pdwValue = V_UI4(&varg);
+
+    return hr;
+}
+
 /**************************************************************************
  *  SHPropertyBag_Delete (SHLWAPI.535)
  */

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -5435,6 +5435,7 @@ HRESULT WINAPI SHPropertyBag_ReadSHORT(IPropertyBag *ppb, LPCWSTR pszPropName, S
     return hr;
 }
 #endif
+
 /**************************************************************************
  *  SHPropertyBag_ReadLONG (SHLWAPI.496)
  *

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -5290,7 +5290,7 @@ HRESULT WINAPI IUnknown_QueryServiceForWebBrowserApp(IUnknown* lpUnknown,
 }
 
 #ifdef __REACTOS__
-HRESULT VariantChangeTypeForRead(IN OUT VARIANTARG *pvarg, IN VARTYPE vt)
+HRESULT VariantChangeTypeForRead(_Inout_ VARIANTARG *pvarg, _In_ VARTYPE vt)
 {
     HRESULT hr;
     VARIANTARG vargTemp;

--- a/dll/win32/shlwapi/precomp.h
+++ b/dll/win32/shlwapi/precomp.h
@@ -30,4 +30,6 @@
 
 #include "resource.h"
 
+HRESULT VariantChangeTypeForRead(IN OUT VARIANTARG *pvarg, IN VARTYPE vt);
+
 #endif /* !_SHLWAPI_PCH_ */

--- a/dll/win32/shlwapi/precomp.h
+++ b/dll/win32/shlwapi/precomp.h
@@ -30,6 +30,4 @@
 
 #include "resource.h"
 
-HRESULT VariantChangeTypeForRead(IN OUT VARIANTARG *pvarg, IN VARTYPE vt);
-
 #endif /* !_SHLWAPI_PCH_ */

--- a/dll/win32/shlwapi/shlwapi.spec
+++ b/dll/win32/shlwapi/shlwapi.spec
@@ -490,12 +490,12 @@
 490 stdcall -noname GlobalFindAtomWrapW(wstr) kernel32.GlobalFindAtomW
 491 stdcall -noname SHGetShellKey(long long long)
 492 stub -noname PrettifyFileDescriptionW
-493 stub -noname SHPropertyBag_ReadType
+493 stdcall -noname SHPropertyBag_ReadType(ptr wstr ptr long)
 494 stub -noname SHPropertyBag_ReadStr
 495 stdcall -noname SHPropertyBag_WriteStr(ptr wstr wstr)
 496 stdcall -noname SHPropertyBag_ReadLONG(ptr wstr ptr)
 497 stdcall -noname SHPropertyBag_WriteLONG(ptr wstr long)
-498 stub -noname SHPropertyBag_ReadBOOLOld
+498 stdcall -noname SHPropertyBag_ReadBOOLOld(ptr wstr long)
 499 stdcall -noname SHPropertyBag_WriteBOOL(ptr wstr long)
 500 stdcall AssocGetPerceivedType(wstr ptr ptr ptr)
 501 stdcall AssocIsDangerous(wstr)
@@ -504,7 +504,7 @@
 504 stdcall AssocQueryStringA(long long str str ptr ptr)
 505 stub -noname SHPropertyBag_ReadGUID
 506 stdcall -noname SHPropertyBag_WriteGUID(ptr wstr ptr)
-507 stdcall -stub -noname SHPropertyBag_ReadDWORD(ptr ptr ptr)
+507 stdcall -noname SHPropertyBag_ReadDWORD(ptr wstr ptr)
 508 stdcall -noname SHPropertyBag_WriteDWORD(ptr wstr long)
 509 stdcall -noname IUnknown_OnFocusChangeIS(ptr ptr long)
 510 stdcall -noname SHLockSharedEx(ptr long long)
@@ -524,14 +524,14 @@
 524 stdcall -noname SHPropertyBag_WriteRECTL(ptr wstr ptr)
 525 stub -noname SHPropertyBag_ReadPOINTS
 526 stdcall -noname SHPropertyBag_WritePOINTS(ptr wstr ptr)
-527 stub -noname SHPropertyBag_ReadSHORT
+527 stdcall -noname SHPropertyBag_ReadSHORT(ptr wstr ptr)
 528 stdcall -noname SHPropertyBag_WriteSHORT(ptr wstr long)
 529 stub -noname SHPropertyBag_ReadInt
 530 stdcall -noname SHPropertyBag_WriteInt(ptr wstr long) SHPropertyBag_WriteLONG
 531 stub -noname SHPropertyBag_ReadStream
 532 stdcall -noname SHPropertyBag_WriteStream(ptr wstr ptr)
 533 stub -noname SHGetPerScreenResName
-534 stub -noname SHPropertyBag_ReadBOOL
+534 stdcall -noname SHPropertyBag_ReadBOOL(ptr wstr ptr)
 535 stdcall -noname SHPropertyBag_Delete(ptr wstr)
 536 stdcall -stub -noname IUnknown_QueryServicePropertyBag(ptr long ptr ptr)
 537 stub -noname SHBoolSystemParametersInfo

--- a/dll/win32/shlwapi/shlwapi.spec
+++ b/dll/win32/shlwapi/shlwapi.spec
@@ -526,7 +526,7 @@
 526 stdcall -noname SHPropertyBag_WritePOINTS(ptr wstr ptr)
 527 stdcall -noname SHPropertyBag_ReadSHORT(ptr wstr ptr)
 528 stdcall -noname SHPropertyBag_WriteSHORT(ptr wstr long)
-529 stub -noname SHPropertyBag_ReadInt
+529 stdcall -noname SHPropertyBag_ReadInt(ptr wstr ptr) SHPropertyBag_ReadLONG
 530 stdcall -noname SHPropertyBag_WriteInt(ptr wstr long) SHPropertyBag_WriteLONG
 531 stub -noname SHPropertyBag_ReadStream
 532 stdcall -noname SHPropertyBag_WriteStream(ptr wstr ptr)

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -92,6 +92,14 @@ BOOL WINAPI SHExpandEnvironmentStringsForUserW(HANDLE, LPCWSTR, LPWSTR, DWORD);
 
 BOOL WINAPI SHIsEmptyStream(IStream*);
 HRESULT WINAPI SHInvokeDefaultCommand(HWND,IShellFolder*,LPCITEMIDLIST);
+HRESULT VariantChangeTypeForRead(IN OUT VARIANTARG *pvarg, IN VARTYPE vt);
+HRESULT WINAPI
+SHPropertyBag_ReadType(IPropertyBag *ppb, LPCWSTR pszPropName, VARIANTARG *pvarg, VARTYPE vt);
+HRESULT WINAPI SHPropertyBag_ReadBOOL(IPropertyBag *ppb, LPCWSTR pszPropName, BOOL *pbValue);
+BOOL WINAPI SHPropertyBag_ReadBOOLOld(IPropertyBag *ppb, LPCWSTR pszPropName, BOOL bDefValue);
+HRESULT WINAPI SHPropertyBag_ReadSHORT(IPropertyBag *ppb, LPCWSTR pszPropName, SHORT *psValue);
+HRESULT WINAPI SHPropertyBag_ReadLONG(IPropertyBag *ppb, LPCWSTR pszPropName, LPLONG pValue);
+HRESULT WINAPI SHPropertyBag_ReadDWORD(IPropertyBag *ppb, LPCWSTR pszPropName, DWORD *pdwValue);
 HRESULT WINAPI SHPropertyBag_ReadPOINTL(IPropertyBag*,LPCWSTR,POINTL*);
 
 HRESULT WINAPI SHGetPerScreenResName(OUT LPWSTR lpResName,

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -92,8 +92,7 @@ BOOL WINAPI SHExpandEnvironmentStringsForUserW(HANDLE, LPCWSTR, LPWSTR, DWORD);
 
 BOOL WINAPI SHIsEmptyStream(IStream*);
 HRESULT WINAPI SHInvokeDefaultCommand(HWND,IShellFolder*,LPCITEMIDLIST);
-HRESULT WINAPI
-SHPropertyBag_ReadType(IPropertyBag *ppb, LPCWSTR pszPropName, VARIANTARG *pvarg, VARTYPE vt);
+HRESULT WINAPI SHPropertyBag_ReadType(IPropertyBag *ppb, LPCWSTR pszPropName, VARIANTARG *pvarg, VARTYPE vt);
 HRESULT WINAPI SHPropertyBag_ReadBOOL(IPropertyBag *ppb, LPCWSTR pszPropName, BOOL *pbValue);
 BOOL WINAPI SHPropertyBag_ReadBOOLOld(IPropertyBag *ppb, LPCWSTR pszPropName, BOOL bDefValue);
 HRESULT WINAPI SHPropertyBag_ReadSHORT(IPropertyBag *ppb, LPCWSTR pszPropName, SHORT *psValue);

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -92,7 +92,6 @@ BOOL WINAPI SHExpandEnvironmentStringsForUserW(HANDLE, LPCWSTR, LPWSTR, DWORD);
 
 BOOL WINAPI SHIsEmptyStream(IStream*);
 HRESULT WINAPI SHInvokeDefaultCommand(HWND,IShellFolder*,LPCITEMIDLIST);
-HRESULT VariantChangeTypeForRead(IN OUT VARIANTARG *pvarg, IN VARTYPE vt);
 HRESULT WINAPI
 SHPropertyBag_ReadType(IPropertyBag *ppb, LPCWSTR pszPropName, VARIANTARG *pvarg, VARTYPE vt);
 HRESULT WINAPI SHPropertyBag_ReadBOOL(IPropertyBag *ppb, LPCWSTR pszPropName, BOOL *pbValue);


### PR DESCRIPTION
## Purpose
Implementing missing features...
JIRA issue: [CORE-9283](https://jira.reactos.org/browse/CORE-9283)

## Proposed changes

- Add `VariantChangeTypeForRead` helper function.
- Implement `SHPropertyBag_ReadType`, `SHPropertyBag_ReadBOOL`, `SHPropertyBag_ReadBOOLOld`, `SHPropertyBag_ReadSHORT`, `SHPropertyBag_ReadLONG`, and `SHPropertyBag_ReadDWORD` functions.
- `SHPropertyBag_ReadInt` is an alias to `SHPropertyBag_ReadLONG`.
- Modify `shlwapi.spec`.
- Modify `<shlwapi_undoc.h>`.
- Strengthen `SHPropertyBag` testcase of `shlwapi_apitest.exe`.

## TODO

- [x] Add tests.
- [x] Do tests.

## Comparison

WinXP:
![WinXP](https://github.com/reactos/reactos/assets/2107452/ec47bba0-3812-448c-9618-2529505bd53f)
Successful.

Win2k3:
![Win2k3](https://github.com/reactos/reactos/assets/2107452/bd60942b-dc47-41d3-97f9-5ce8f3042388)
Successful.

Win10:
![Win10](https://github.com/reactos/reactos/assets/2107452/2d877b1f-fe9a-421a-a210-096384a951e0)
Successful.

ReactOS:
![Ros](https://github.com/reactos/reactos/assets/2107452/3ac4f063-a708-463c-acd2-070431e96f21)
Successful.