### PR TITLE
[APPWIZ] Implement InstallCallback_GetBindInfo

### DIFF
--- a/dll/cpl/appwiz/addons.c
+++ b/dll/cpl/appwiz/addons.c
@@ -324,7 +324,7 @@ static HRESULT WINAPI InstallCallback_GetBindInfo(IBindStatusCallback *iface,
     DWORD cbSize;
 
     cbSize = pbindinfo->cbSize;
-    ZeroMemory(pbindinfo, sizeof(*pbindinfo));
+    ZeroMemory(pbindinfo, cbSize);
     pbindinfo->cbSize = cbSize;
 
     *grfBINDF = 0;

--- a/dll/cpl/appwiz/addons.c
+++ b/dll/cpl/appwiz/addons.c
@@ -321,12 +321,6 @@ static HRESULT WINAPI InstallCallback_OnStopBinding(IBindStatusCallback *iface,
 static HRESULT WINAPI InstallCallback_GetBindInfo(IBindStatusCallback *iface,
         DWORD* grfBINDF, BINDINFO* pbindinfo)
 {
-    DWORD cbSize = pbindinfo->cbSize;
-    ZeroMemory(pbindinfo, cbSize);
-    pbindinfo->cbSize = cbSize;
-
-    *grfBINDF = 0;
-
     return E_NOTIMPL;
 }
 

--- a/dll/cpl/appwiz/addons.c
+++ b/dll/cpl/appwiz/addons.c
@@ -321,26 +321,13 @@ static HRESULT WINAPI InstallCallback_OnStopBinding(IBindStatusCallback *iface,
 static HRESULT WINAPI InstallCallback_GetBindInfo(IBindStatusCallback *iface,
         DWORD* grfBINDF, BINDINFO* pbindinfo)
 {
-    DWORD cbSize;
-    BOOL bCanceled;
-
-    cbSize = pbindinfo->cbSize;
+    DWORD cbSize = pbindinfo->cbSize;
     ZeroMemory(pbindinfo, cbSize);
     pbindinfo->cbSize = cbSize;
 
     *grfBINDF = 0;
 
-    EnterCriticalSection(&csLock);
-    bCanceled = !download_binding;
-    LeaveCriticalSection(&csLock);
-
-    if (bCanceled)
-    {
-        ERR("Canceled\n");
-        return E_FAIL;
-    }
-
-    return S_OK;
+    return E_NOTIMPL;
 }
 
 static HRESULT WINAPI InstallCallback_OnDataAvailable(IBindStatusCallback *iface, DWORD grfBSCF,

--- a/dll/cpl/appwiz/addons.c
+++ b/dll/cpl/appwiz/addons.c
@@ -321,8 +321,23 @@ static HRESULT WINAPI InstallCallback_OnStopBinding(IBindStatusCallback *iface,
 static HRESULT WINAPI InstallCallback_GetBindInfo(IBindStatusCallback *iface,
         DWORD* grfBINDF, BINDINFO* pbindinfo)
 {
-    /* FIXME */
+    DWORD cbSize;
+
+    cbSize = pbindinfo->cbSize;
+    ZeroMemory(pbindinfo, sizeof(*pbindinfo));
+    pbindinfo->cbSize = cbSize;
+
     *grfBINDF = 0;
+
+    EnterCriticalSection(&csLock);
+    if (!download_binding)
+    {
+        LeaveCriticalSection(&csLock);
+        ERR("\n");
+        return E_NOTIMPL;
+    }
+    LeaveCriticalSection(&csLock);
+
     return S_OK;
 }
 

--- a/dll/cpl/appwiz/addons.c
+++ b/dll/cpl/appwiz/addons.c
@@ -322,6 +322,7 @@ static HRESULT WINAPI InstallCallback_GetBindInfo(IBindStatusCallback *iface,
         DWORD* grfBINDF, BINDINFO* pbindinfo)
 {
     DWORD cbSize;
+    BOOL bCanceled;
 
     cbSize = pbindinfo->cbSize;
     ZeroMemory(pbindinfo, cbSize);
@@ -330,13 +331,14 @@ static HRESULT WINAPI InstallCallback_GetBindInfo(IBindStatusCallback *iface,
     *grfBINDF = 0;
 
     EnterCriticalSection(&csLock);
-    if (!download_binding)
-    {
-        LeaveCriticalSection(&csLock);
-        ERR("\n");
-        return E_NOTIMPL;
-    }
+    bCanceled = !download_binding;
     LeaveCriticalSection(&csLock);
+
+    if (bCanceled)
+    {
+        ERR("Canceled\n");
+        return E_FAIL;
+    }
 
     return S_OK;
 }


### PR DESCRIPTION
## Purpose

Fix errors on 2nd stage setup epilogue.
JIRA issue: [CORE-15786](https://jira.reactos.org/browse/CORE-15786)

## Proposed changes

- Just return `E_NOTIMPL` in `InstallCallback_GetBindInfo` function. That's Okay.

## TODO

- [x] Can download.
- [x] Do tests.