### PR TITLE
[FREELDR] Implement bus mouse detection

### DIFF
--- a/boot/freeldr/freeldr/arch/i386/irqsup.S
+++ b/boot/freeldr/freeldr/arch/i386/irqsup.S
@@ -1,0 +1,33 @@
+/*
+ * PROJECT:     FreeLoader
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Interrupt handling
+ * COPYRIGHT:   Copyright 2023 Dmitry Borisov <di.sean@protonmail.com>
+ */
+
+#include <asm.inc>
+
+#define PIC1_CONTROL_PORT   HEX(20)
+#define PIC_EOI             HEX(20)
+
+.code32
+
+PUBLIC _HwIrqHandler
+_HwIrqHandler:
+    push ax
+
+    /* Increment the interrupt count */
+    inc dword ptr ds:[_HwIrqCount]
+
+    /* Dismiss the interrupt */
+    mov al, PIC_EOI
+    out PIC1_CONTROL_PORT, al
+
+    pop ax
+    iret
+
+PUBLIC _HwIrqCount
+_HwIrqCount:
+    .long 0
+
+END

--- a/boot/freeldr/freeldr/pcat.cmake
+++ b/boot/freeldr/freeldr/pcat.cmake
@@ -42,6 +42,7 @@ if(ARCH STREQUAL "i386")
         arch/i386/drvmap.S
         arch/i386/entry.S
         arch/i386/int386.S
+        arch/i386/irqsup.S
         arch/i386/pnpbios.S
         # arch/i386/i386trap.S
         arch/i386/linux.S)

--- a/drivers/input/inport/hardware.c
+++ b/drivers/input/inport/hardware.c
@@ -71,12 +71,13 @@
     #define INPORT_MODE_IRQ    0x01
     #define INPORT_MODE_BASE   0x10
     #define INPORT_MODE_HOLD   0x20
+    #define INPORT_HAS_MOVED   0x40
 
 #define MS_INPORT_SIGNATURE  0x02
 
-#define MS_BUTTON_MIDDLE   0x01
-#define MS_BUTTON_LEFT     0x02
-#define MS_BUTTON_RIGHT    0x04
+#define MS_BUTTON_RIGHT    0x01
+#define MS_BUTTON_MIDDLE   0x02
+#define MS_BUTTON_LEFT     0x04
 
 /*
  * Logitech
@@ -270,14 +271,23 @@ InPortIsr(
             WRITE_MOUSE(DeviceExtension, MS_INPORT_DATA,
                         INPORT_MODE_HOLD | INPORT_MODE_IRQ | INPORT_MODE_BASE);
 
-            WRITE_MOUSE(DeviceExtension, MS_INPORT_CONTROL, INPORT_REG_X);
-            DeltaX = READ_MOUSE(DeviceExtension, MS_INPORT_DATA);
-
-            WRITE_MOUSE(DeviceExtension, MS_INPORT_CONTROL, INPORT_REG_Y);
-            DeltaY = READ_MOUSE(DeviceExtension, MS_INPORT_DATA);
-
             WRITE_MOUSE(DeviceExtension, MS_INPORT_CONTROL, INPORT_REG_BTNS);
             Buttons = READ_MOUSE(DeviceExtension, MS_INPORT_DATA);
+
+            if (Buttons & INPORT_HAS_MOVED)
+            {
+                WRITE_MOUSE(DeviceExtension, MS_INPORT_CONTROL, INPORT_REG_X);
+                DeltaX = READ_MOUSE(DeviceExtension, MS_INPORT_DATA);
+
+                WRITE_MOUSE(DeviceExtension, MS_INPORT_CONTROL, INPORT_REG_Y);
+                DeltaY = READ_MOUSE(DeviceExtension, MS_INPORT_DATA);
+            }
+            else
+            {
+                DeltaX = 0;
+                DeltaY = 0;
+            }
+
             Buttons &= (MS_BUTTON_MIDDLE | MS_BUTTON_LEFT | MS_BUTTON_RIGHT);
 
             WRITE_MOUSE(DeviceExtension, MS_INPORT_CONTROL, INPORT_REG_MODE);


### PR DESCRIPTION
## Purpose

Automatically install the inport device driver. (this is possible since 7d5e1591313df39d0b2a81c20ab2af9e8d76252a). Besides, some people have reported PS/2 mouse issues with 86Box. For now, the best work around is to use the inport driver.

References:
https://raw.githubusercontent.com/86Box/86Box/master/src/device/mouse_bus.c
https://bochs.sourceforge.io/cgi-bin/lxr/source/iodev/busmouse.cc

![inp](https://github.com/reactos/reactos/assets/37072976/464ae089-e61b-4cad-8cfc-e770e4bc0df2)
