### PR TITLE
[SHLWAPI][SHLWAPI_APITEST][SDK] Implement SHPropertyBag_ReadBSTR etc.

### DIFF
--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -5527,7 +5527,7 @@ HRESULT WINAPI SHPropertyBag_ReadBSTR(IPropertyBag *ppb, LPCWSTR pszPropName, BS
 
     hr = SHPropertyBag_ReadType(ppb, pszPropName, &varg, VT_BSTR);
     if (FAILED(hr))
-        *pbstr = 0;
+        *pbstr = NULL;
     else
         *pbstr = V_BSTR(&varg);
 

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -5510,6 +5510,167 @@ HRESULT WINAPI SHPropertyBag_ReadDWORD(IPropertyBag *ppb, LPCWSTR pszPropName, D
 }
 
 /**************************************************************************
+ *  SHPropertyBag_ReadBSTR (SHLWAPI.520)
+ */
+HRESULT WINAPI SHPropertyBag_ReadBSTR(IPropertyBag *ppb, LPCWSTR pszPropName, BSTR *pbstr)
+{
+    HRESULT hr;
+    VARIANTARG varg;
+
+    TRACE("%p %s %p\n", ppb, debugstr_w(pszPropName), pbstr);
+
+    if (!ppb || !pszPropName || !pbstr)
+    {
+        ERR("%p %s %p\n", ppb, debugstr_w(pszPropName), pbstr);
+        return E_INVALIDARG;
+    }
+
+    hr = SHPropertyBag_ReadType(ppb, pszPropName, &varg, VT_BSTR);
+    if (FAILED(hr))
+        *pbstr = 0;
+    else
+        *pbstr = V_BSTR(&varg);
+
+    return hr;
+}
+
+/**************************************************************************
+ *  SHPropertyBag_ReadStr (SHLWAPI.494)
+ */
+HRESULT WINAPI SHPropertyBag_ReadStr(IPropertyBag *ppb, LPCWSTR pszPropName, LPWSTR pszDst, int cchMax)
+{
+    HRESULT hr;
+    VARIANTARG varg;
+
+    TRACE("%p %s %p %d\n", ppb, debugstr_w(pszPropName), pszDst, cchMax);
+
+    if (!ppb || !pszPropName || !pszDst)
+    {
+        ERR("%p %s %p %d\n", ppb, debugstr_w(pszPropName), pszDst, cchMax);
+        return E_INVALIDARG;
+    }
+
+    hr = SHPropertyBag_ReadType(ppb, pszPropName, &varg, VT_BSTR);
+    if (FAILED(hr))
+        return E_FAIL;
+
+    StrCpyNW(pszDst, V_BSTR(&varg), cchMax);
+    VariantClear(&varg);
+    return hr;
+}
+
+/**************************************************************************
+ *  SHPropertyBag_ReadPOINTL (SHLWAPI.521)
+ */
+HRESULT WINAPI SHPropertyBag_ReadPOINTL(IPropertyBag *ppb, LPCWSTR pszPropName, POINTL *pptl)
+{
+    HRESULT hr;
+    int cch, cch2;
+    WCHAR *pch, szBuff[MAX_PATH];
+
+    TRACE("%p %s %p\n", ppb, debugstr_w(pszPropName), pptl);
+
+    if (!ppb || !pszPropName || !pptl)
+    {
+        ERR("%p %s %p\n", ppb, debugstr_w(pszPropName), pptl);
+        return E_INVALIDARG;
+    }
+
+    StrCpyNW(szBuff, pszPropName, _countof(szBuff));
+
+    cch = lstrlenW(szBuff);
+    cch2 = _countof(szBuff) - cch;
+    if (cch2 < _countof(L".x"))
+    {
+        ERR("%s is too long\n", debugstr_w(pszPropName));
+        return E_FAIL;
+    }
+
+    pch = &szBuff[cch];
+
+    StrCpyNW(pch, L".x", cch2);
+    hr = SHPropertyBag_ReadLONG(ppb, szBuff, &pptl->x);
+    if (FAILED(hr))
+        return hr;
+
+    StrCpyNW(pch, L".y", cch2);
+    return SHPropertyBag_ReadLONG(ppb, szBuff, &pptl->y);
+}
+
+/**************************************************************************
+ *  SHPropertyBag_ReadPOINTS (SHLWAPI.525)
+ */
+HRESULT WINAPI SHPropertyBag_ReadPOINTS(IPropertyBag *ppb, LPCWSTR pszPropName, POINTS *ppts)
+{
+    HRESULT hr;
+    POINTL ptl;
+
+    TRACE("%p %s %p\n", ppb, debugstr_w(pszPropName), ppts);
+
+    if (!ppb || !pszPropName || !ppts)
+    {
+        ERR("%p %s %p\n", ppb, debugstr_w(pszPropName), ppts);
+        return E_INVALIDARG;
+    }
+
+    hr = SHPropertyBag_ReadPOINTL(ppb, pszPropName, &ptl);
+    if (FAILED(hr))
+        return hr;
+
+    ppts->x = ptl.x;
+    ppts->y = ptl.y;
+    return hr;
+}
+
+/**************************************************************************
+ *  SHPropertyBag_ReadRECTL (SHLWAPI.523)
+ */
+HRESULT WINAPI SHPropertyBag_ReadRECTL(IPropertyBag *ppb, LPCWSTR pszPropName, RECTL *prcl)
+{
+    HRESULT hr;
+    int cch, cch2;
+    WCHAR *pch, szBuff[MAX_PATH];
+
+    TRACE("%p %s %p\n", ppb, debugstr_w(pszPropName), prcl);
+
+    if (!ppb || !pszPropName || !prcl)
+    {
+        ERR("%p %s %p\n", ppb, debugstr_w(pszPropName), prcl);
+        return E_INVALIDARG;
+    }
+
+    StrCpyNW(szBuff, pszPropName, _countof(szBuff));
+
+    cch = lstrlenW(szBuff);
+    cch2 = _countof(szBuff) - cch;
+    if (cch2 < _countof(L".bottom"))
+    {
+        ERR("%s is too long\n", debugstr_w(pszPropName));
+        return E_FAIL;
+    }
+
+    pch = &szBuff[cch];
+
+    StrCpyNW(pch, L".left", cch2);
+    hr = SHPropertyBag_ReadLONG(ppb, szBuff, &prcl->left);
+    if (FAILED(hr))
+        return hr;
+
+    StrCpyNW(pch, L".top", cch2);
+    hr = SHPropertyBag_ReadLONG(ppb, szBuff, &prcl->top);
+    if (FAILED(hr))
+        return hr;
+
+    StrCpyNW(pch, L".right", cch2);
+    hr = SHPropertyBag_ReadLONG(ppb, szBuff, &prcl->right);
+    if (FAILED(hr))
+        return hr;
+
+    StrCpyNW(pch, L".bottom", cch2);
+    return SHPropertyBag_ReadLONG(ppb, szBuff, &prcl->bottom);
+}
+
+/**************************************************************************
  *  SHPropertyBag_Delete (SHLWAPI.535)
  */
 HRESULT WINAPI SHPropertyBag_Delete(IPropertyBag *ppb, LPCWSTR pszPropName)

--- a/dll/win32/shlwapi/shlwapi.spec
+++ b/dll/win32/shlwapi/shlwapi.spec
@@ -491,7 +491,7 @@
 491 stdcall -noname SHGetShellKey(long long long)
 492 stub -noname PrettifyFileDescriptionW
 493 stdcall -noname SHPropertyBag_ReadType(ptr wstr ptr long)
-494 stub -noname SHPropertyBag_ReadStr
+494 stdcall -noname SHPropertyBag_ReadStr(ptr wstr ptr long)
 495 stdcall -noname SHPropertyBag_WriteStr(ptr wstr wstr)
 496 stdcall -noname SHPropertyBag_ReadLONG(ptr wstr ptr)
 497 stdcall -noname SHPropertyBag_WriteLONG(ptr wstr long)
@@ -517,12 +517,12 @@
 517 stdcall -noname SKSetValueW(long wstr wstr long ptr long)
 518 stdcall -noname SKDeleteValueW(long wstr wstr)
 519 stdcall -noname SKAllocValueW(long wstr wstr ptr ptr ptr)
-520 stub -noname SHPropertyBag_ReadBSTR
-521 stub -noname SHPropertyBag_ReadPOINTL
+520 stdcall -noname SHPropertyBag_ReadBSTR(ptr wstr ptr)
+521 stdcall -noname SHPropertyBag_ReadPOINTL(ptr wstr ptr)
 522 stdcall -noname SHPropertyBag_WritePOINTL(ptr wstr ptr)
-523 stub -noname SHPropertyBag_ReadRECTL
+523 stdcall -noname SHPropertyBag_ReadRECTL(ptr wstr ptr)
 524 stdcall -noname SHPropertyBag_WriteRECTL(ptr wstr ptr)
-525 stub -noname SHPropertyBag_ReadPOINTS
+525 stdcall -noname SHPropertyBag_ReadPOINTS(ptr wstr ptr)
 526 stdcall -noname SHPropertyBag_WritePOINTS(ptr wstr ptr)
 527 stdcall -noname SHPropertyBag_ReadSHORT(ptr wstr ptr)
 528 stdcall -noname SHPropertyBag_WriteSHORT(ptr wstr long)

--- a/modules/rostests/apitests/shlwapi/CMakeLists.txt
+++ b/modules/rostests/apitests/shlwapi/CMakeLists.txt
@@ -25,6 +25,6 @@ add_rc_deps(testdata.rc ${CMAKE_CURRENT_BINARY_DIR}/shlwapi_resource_dll/shlwapi
 add_executable(shlwapi_apitest ${SOURCE})
 set_module_type(shlwapi_apitest win32cui)
 target_link_libraries(shlwapi_apitest ${PSEH_LIB})
-add_importlibs(shlwapi_apitest shlwapi user32 advapi32 msvcrt kernel32)
+add_importlibs(shlwapi_apitest shlwapi oleaut32 user32 advapi32 msvcrt kernel32)
 add_dependencies(shlwapi_apitest shlwapi_resource_dll)
 add_rostests_file(TARGET shlwapi_apitest)

--- a/modules/rostests/apitests/shlwapi/SHPropertyBag.cpp
+++ b/modules/rostests/apitests/shlwapi/SHPropertyBag.cpp
@@ -65,9 +65,8 @@ public:
                 ok_wstr(pszPropName, s_pszPropNames[i]);
                 s_pszPropNames[i] = NULL;
                 if (lstrcmpiW(pszPropName, L"RECTL2.top") == 0)
-                {
                     return E_FAIL;
-                }
+
                 goto Skip1;
             }
         }
@@ -110,7 +109,7 @@ static void SHPropertyBag_ReadTest(void)
     SHORT sValue = 0xDEAD;
     LONG lValue = 0xDEADDEAD;
     DWORD dwValue = 0xFEEDF00D;
-    WCHAR szStr[MAX_PATH];
+    BSTR bstr = NULL;
     POINTL ptl = { 0xEEEE, 0xDDDD };
     POINTS pts = { 0x2222, 0x3333 };
     RECTL rcl = { 123, 456, 789, 101112 };
@@ -140,10 +139,11 @@ static void SHPropertyBag_ReadTest(void)
     ok_int(s_cWrite, 0);
 
     ResetTest(VT_BSTR, L"Str1");
-    hr = SHPropertyBag_ReadStr(&dummy, s_pszPropNames[0], szStr, _countof(szStr));
+    hr = SHPropertyBag_ReadBSTR(&dummy, s_pszPropNames[0], &bstr);
     ok_long(hr, S_OK);
     ok_int(s_cRead, 1);
     ok_int(s_cWrite, 0);
+    SysFreeString(bstr);
 
     ResetTest(VT_I4, L"POINTL1.x", L"POINTL1.y");
     hr = SHPropertyBag_ReadPOINTL(&dummy, L"POINTL1", &ptl);
@@ -164,8 +164,8 @@ static void SHPropertyBag_ReadTest(void)
     ok_int(s_cWrite, 0);
 
     ResetTest(VT_I4, L"RECTL2.left", L"RECTL2.top", L"RECTL2.right", L"RECTL2.bottom");
-    hr = SHPropertyBag_WriteRECTL(&dummy, L"RECTL2", &rcl);
-    ok_long(hr, S_OK);
+    hr = SHPropertyBag_ReadRECTL(&dummy, L"RECTL2", &rcl);
+    ok_long(hr, E_FAIL);
     ok_int(s_cRead, 2);
     ok_int(s_cWrite, 0);
 }

--- a/modules/rostests/apitests/shlwapi/SHPropertyBag.cpp
+++ b/modules/rostests/apitests/shlwapi/SHPropertyBag.cpp
@@ -64,6 +64,10 @@ public:
             {
                 ok_wstr(pszPropName, s_pszPropNames[i]);
                 s_pszPropNames[i] = NULL;
+                if (lstrcmpiW(pszPropName, L"RECTL2.top") == 0)
+                {
+                    return E_FAIL;
+                }
                 goto Skip1;
             }
         }
@@ -106,6 +110,10 @@ static void SHPropertyBag_ReadTest(void)
     SHORT sValue = 0xDEAD;
     LONG lValue = 0xDEADDEAD;
     DWORD dwValue = 0xFEEDF00D;
+    WCHAR szStr[MAX_PATH];
+    POINTL ptl = { 0xEEEE, 0xDDDD };
+    POINTS pts = { 0x2222, 0x3333 };
+    RECTL rcl = { 123, 456, 789, 101112 };
 
     ResetTest(VT_BOOL, L"BOOL1");
     hr = SHPropertyBag_ReadBOOL(&dummy, s_pszPropNames[0], &bValue);
@@ -129,6 +137,36 @@ static void SHPropertyBag_ReadTest(void)
     hr = SHPropertyBag_ReadDWORD(&dummy, s_pszPropNames[0], &dwValue);
     ok_long(hr, S_OK);
     ok_int(s_cRead, 1);
+    ok_int(s_cWrite, 0);
+
+    ResetTest(VT_BSTR, L"Str1");
+    hr = SHPropertyBag_ReadStr(&dummy, s_pszPropNames[0], szStr, _countof(szStr));
+    ok_long(hr, S_OK);
+    ok_int(s_cRead, 1);
+    ok_int(s_cWrite, 0);
+
+    ResetTest(VT_I4, L"POINTL1.x", L"POINTL1.y");
+    hr = SHPropertyBag_ReadPOINTL(&dummy, L"POINTL1", &ptl);
+    ok_long(hr, S_OK);
+    ok_int(s_cRead, 2);
+    ok_int(s_cWrite, 0);
+
+    ResetTest(VT_I4, L"POINTS1.x", L"POINTS1.y");
+    hr = SHPropertyBag_ReadPOINTS(&dummy, L"POINTS1", &pts);
+    ok_long(hr, S_OK);
+    ok_int(s_cRead, 2);
+    ok_int(s_cWrite, 0);
+
+    ResetTest(VT_I4, L"RECTL1.left", L"RECTL1.top", L"RECTL1.right", L"RECTL1.bottom");
+    hr = SHPropertyBag_ReadRECTL(&dummy, L"RECTL1", &rcl);
+    ok_long(hr, S_OK);
+    ok_int(s_cRead, 4);
+    ok_int(s_cWrite, 0);
+
+    ResetTest(VT_I4, L"RECTL2.left", L"RECTL2.top", L"RECTL2.right", L"RECTL2.bottom");
+    hr = SHPropertyBag_WriteRECTL(&dummy, L"RECTL2", &rcl);
+    ok_long(hr, S_OK);
+    ok_int(s_cRead, 2);
     ok_int(s_cWrite, 0);
 }
 

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -98,7 +98,11 @@ BOOL WINAPI SHPropertyBag_ReadBOOLOld(IPropertyBag *ppb, LPCWSTR pszPropName, BO
 HRESULT WINAPI SHPropertyBag_ReadSHORT(IPropertyBag *ppb, LPCWSTR pszPropName, SHORT *psValue);
 HRESULT WINAPI SHPropertyBag_ReadLONG(IPropertyBag *ppb, LPCWSTR pszPropName, LPLONG pValue);
 HRESULT WINAPI SHPropertyBag_ReadDWORD(IPropertyBag *ppb, LPCWSTR pszPropName, DWORD *pdwValue);
-HRESULT WINAPI SHPropertyBag_ReadPOINTL(IPropertyBag*,LPCWSTR,POINTL*);
+HRESULT WINAPI SHPropertyBag_ReadBSTR(IPropertyBag *ppb, LPCWSTR pszPropName, BSTR *pbstr);
+HRESULT WINAPI SHPropertyBag_ReadStr(IPropertyBag *ppb, LPCWSTR pszPropName, LPWSTR pszDst, int cchMax);
+HRESULT WINAPI SHPropertyBag_ReadPOINTL(IPropertyBag *ppb, LPCWSTR pszPropName, POINTL *pptl);
+HRESULT WINAPI SHPropertyBag_ReadPOINTS(IPropertyBag *ppb, LPCWSTR pszPropName, POINTS *ppts);
+HRESULT WINAPI SHPropertyBag_ReadRECTL(IPropertyBag *ppb, LPCWSTR pszPropName, RECTL *prcl);
 
 HRESULT WINAPI SHGetPerScreenResName(OUT LPWSTR lpResName,
                                      IN INT cchResName,


### PR DESCRIPTION
## Purpose
Implementing missing features...
JIRA issue: [CORE-9283](https://jira.reactos.org/browse/CORE-9283)

## Proposed changes

- Implement `SHPropertyBag_ReadBSTR`, `SHPropertyBag_ReadStr`, `SHPropertyBag_ReadPOINTL`, `SHPropertyBag_ReadPOINTS`, and `SHPropertyBag_ReadRECTL` functions.
- Modify `shlwapi.spec`
- Modify `shlwapi_undoc.h`.
- Strengthen `SHPropertyBag` testcase of `shlwapi_apitest.exe`.
- Add link to `oleaut32.dll` in `shlwapi_apitest.exe`.

## TODO

- [x] Do tests.

## Comparison

WinXP:
![WinXP](https://github.com/reactos/reactos/assets/2107452/bec142b1-e81d-430e-a1eb-e81e1f777496)
Successful.

Win2k3:
![Win2k3](https://github.com/reactos/reactos/assets/2107452/1ef8d2b3-2a30-45b3-bc69-19fd91abf4e1)
Successful.

Win10:
![image](https://github.com/reactos/reactos/assets/2107452/3f947a05-28cf-4109-8343-a1a50b739397)
Successful.

ReactOS:
![Ros](https://github.com/reactos/reactos/assets/2107452/33a9bc16-5217-403d-b4d2-33025536b935)
Successful.