### PR TITLE
[SHLWAPI][SHLWAPI_APITEST][SDK] Implement SHPropertyBag_ReadGUID etc.

### DIFF
--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -5356,7 +5356,7 @@ BOOL VariantToBuffer(const VARIANT *varIn, void *pvDest, UINT cb)
     LONG LowerBound, UpperBound;
     SAFEARRAY *pArray;
 
-    if (varIn && V_VT(varIn) == (VT_ARRAY | VT_UI1))
+    if (varIn && V_VT(varIn) == (VT_ARRAY | VT_UI1)) /* Byte Array */
     {
         pArray = V_ARRAY(varIn);
         if (SafeArrayGetDim(pArray) == 1 &&

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -5350,6 +5350,37 @@ DoDefault:
     return hr;
 }
 
+BOOL VariantToBuffer(const VARIANT *varIn, void *pv, UINT cb)
+{
+    void *pvData;
+    LONG lBound, uBound;
+
+    if (!varIn || V_VT(varIn) != (VT_ARRAY | VT_UI1) ||
+        SafeArrayGetDim(V_ARRAY(varIn)) != 1 ||
+        FAILED(SafeArrayGetLBound(V_ARRAY(varIn), 1, &lBound)) ||
+        FAILED(SafeArrayGetUBound(V_ARRAY(varIn), 1, &uBound)) ||
+        (uBound - lBound + 1 < cb) ||
+        FAILED(SafeArrayAccessData(V_ARRAY(varIn), &pvData)))
+    {
+        return FALSE;
+    }
+
+    CopyMemory(pv, pvData, cb);
+    SafeArrayUnaccessData(V_ARRAY(varIn));
+    return TRUE;
+}
+
+BOOL VariantToGUID(const VARIANT *varIn, GUID *pguid)
+{
+    if (VariantToBuffer(varIn, pguid, sizeof(*pguid)))
+        return TRUE;
+
+    if (varIn && V_VT(varIn) == VT_BSTR && V_BSTR(varIn))
+        return GUIDFromStringW(V_BSTR(varIn), pguid);
+
+    return FALSE;
+}
+
 /**************************************************************************
  *  SHPropertyBag_ReadType (SHLWAPI.493)
  */

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -5671,6 +5671,54 @@ HRESULT WINAPI SHPropertyBag_ReadRECTL(IPropertyBag *ppb, LPCWSTR pszPropName, R
 }
 
 /**************************************************************************
+ *  SHPropertyBag_ReadGUID (SHLWAPI.505)
+ */
+HRESULT WINAPI SHPropertyBag_ReadGUID(IPropertyBag *ppb, LPCWSTR pszPropName, GUID *pguid)
+{
+    HRESULT hr;
+    BOOL bRet;
+    VARIANT vari;
+
+    if (!ppb || !pszPropName || !pguid)
+        return E_INVALIDARG;
+
+    hr = SHPropertyBag_ReadType(ppb, pszPropName, &vari, VT_EMPTY);
+    if (FAILED(hr))
+        return hr;
+
+    if (V_VT(&vari) == (VT_UI1 | VT_ARRAY)) /* Byte Array */
+        bRet = VariantToGUID(&vari, pguid);
+    else if (V_VT(&vari) == VT_BSTR)
+        bRet = GUIDFromStringW(V_BSTR(&vari), pguid);
+    else
+        bRet = TRUE;
+
+    VariantClear(&vari);
+    return (bRet ? S_OK : E_FAIL);
+}
+
+/**************************************************************************
+ *  SHPropertyBag_ReadStream (SHLWAPI.531)
+ */
+HRESULT WINAPI SHPropertyBag_ReadStream(IPropertyBag *ppb, LPCWSTR pszPropName, IStream **ppStream)
+{
+    HRESULT hr;
+    VARIANT vari;
+
+    if (!ppb || !pszPropName || !ppStream)
+        return E_INVALIDARG;
+
+    hr = SHPropertyBag_ReadType(ppb, pszPropName, &vari, VT_UNKNOWN);
+    if (FAILED(hr))
+        return hr;
+
+    hr = IUnknown_QueryInterface(V_UNKNOWN(&vari), &IID_IStream, (void **)ppStream);
+    IUnknown_Release(V_UNKNOWN(&vari));
+
+    return hr;
+}
+
+/**************************************************************************
  *  SHPropertyBag_Delete (SHLWAPI.535)
  */
 HRESULT WINAPI SHPropertyBag_Delete(IPropertyBag *ppb, LPCWSTR pszPropName)

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -5728,7 +5728,7 @@ HRESULT WINAPI SHPropertyBag_ReadGUID(IPropertyBag *ppb, LPCWSTR pszPropName, GU
     else if (V_VT(&vari) == VT_BSTR)
         bRet = GUIDFromStringW(V_BSTR(&vari), pguid);
     else
-        bRet = TRUE; /* This is by design */
+        bRet = TRUE; /* This is by design in WinXP/Win2k3. FALSE in Win10. */
 
     if (!bRet)
         ERR("%p %s %p\n", ppb, debugstr_w(pszPropName), pguid);

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -5350,7 +5350,7 @@ DoDefault:
     return hr;
 }
 
-BOOL VariantToBuffer(const VARIANT *varIn, void *pv, UINT cb)
+BOOL VariantToBuffer(const VARIANT *varIn, void *pvDest, UINT cb)
 {
     void *pvData;
     LONG LowerBound, UpperBound;
@@ -5365,7 +5365,7 @@ BOOL VariantToBuffer(const VARIANT *varIn, void *pv, UINT cb)
             (cb <= UpperBound - LowerBound + 1) &&
             SUCCEEDED(SafeArrayAccessData(pArray, &pvData)))
         {
-            CopyMemory(pv, pvData, cb);
+            CopyMemory(pvDest, pvData, cb);
             SafeArrayUnaccessData(pArray);
             return TRUE;
         }

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -5353,7 +5353,7 @@ DoDefault:
 BOOL
 VariantToBuffer(
     _In_ const VARIANT *varIn,
-    _Out_writes_(cb) LPVOID pvDest,
+    _Out_writes_(cbSize) LPVOID pvDest,
     _In_ SIZE_T cbSize)
 {
     LPVOID pvData;

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -5729,7 +5729,11 @@ HRESULT WINAPI SHPropertyBag_ReadGUID(IPropertyBag *ppb, LPCWSTR pszPropName, GU
     else if (V_VT(&vari) == VT_BSTR)
         bRet = GUIDFromStringW(V_BSTR(&vari), pguid);
     else
-        bRet = TRUE; /* This is by design in WinXP/Win2k3. FALSE in Win10. */
+#if (_WIN32_WINNT >= _WIN32_WINNT_VISTA)
+        bRet = FALSE;
+#else
+        bRet = TRUE; /* This is by design in WinXP/Win2k3. */
+#endif
 
     if (!bRet)
         ERR("%p %s %p\n", ppb, debugstr_w(pszPropName), pguid);

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -5354,22 +5354,22 @@ BOOL
 VariantToBuffer(
     _In_ const VARIANT *varIn,
     _Out_writes_(cb) void *pvDest,
-    _In_ UINT cb)
+    _In_ SIZE_T cbSize)
 {
     void *pvData;
     LONG LowerBound, UpperBound;
     SAFEARRAY *pArray;
 
-    if (varIn && V_VT(varIn) == (VT_ARRAY | VT_UI1)) /* Byte Array */
+    if (varIn && V_VT(varIn) == (VT_UI1 | VT_ARRAY)) /* Byte Array */
     {
         pArray = V_ARRAY(varIn);
         if (SafeArrayGetDim(pArray) == 1 &&
             SUCCEEDED(SafeArrayGetLBound(pArray, 1, &LowerBound)) &&
             SUCCEEDED(SafeArrayGetUBound(pArray, 1, &UpperBound)) &&
-            (cb <= UpperBound - LowerBound + 1) &&
+            ((LONG)cbSize <= UpperBound - LowerBound + 1) &&
             SUCCEEDED(SafeArrayAccessData(pArray, &pvData)))
         {
-            CopyMemory(pvDest, pvData, cb);
+            CopyMemory(pvDest, pvData, cbSize);
             SafeArrayUnaccessData(pArray);
             return TRUE;
         }

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -5353,16 +5353,16 @@ DoDefault:
 BOOL VariantToBuffer(const VARIANT *varIn, void *pv, UINT cb)
 {
     void *pvData;
-    LONG lBound, uBound;
+    LONG LowerBound, UpperBound;
     SAFEARRAY *pArray;
 
     if (varIn && V_VT(varIn) == (VT_ARRAY | VT_UI1))
     {
         pArray = V_ARRAY(varIn);
         if (SafeArrayGetDim(pArray) == 1 &&
-            SUCCEEDED(SafeArrayGetLBound(pArray, 1, &lBound)) &&
-            SUCCEEDED(SafeArrayGetUBound(pArray, 1, &uBound)) &&
-            (cb <= uBound - lBound + 1) &&
+            SUCCEEDED(SafeArrayGetLBound(pArray, 1, &LowerBound)) &&
+            SUCCEEDED(SafeArrayGetUBound(pArray, 1, &UpperBound)) &&
+            (cb <= UpperBound - LowerBound + 1) &&
             SUCCEEDED(SafeArrayAccessData(pArray, &pvData)))
         {
             CopyMemory(pv, pvData, cb);

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -5714,12 +5714,20 @@ HRESULT WINAPI SHPropertyBag_ReadGUID(IPropertyBag *ppb, LPCWSTR pszPropName, GU
     BOOL bRet;
     VARIANT vari;
 
+    TRACE("%p %s %p\n", ppb, debugstr_w(pszPropName), pguid);
+
     if (!ppb || !pszPropName || !pguid)
+    {
+        ERR("%p %s %p\n", ppb, debugstr_w(pszPropName), pguid);
         return E_INVALIDARG;
+    }
 
     hr = SHPropertyBag_ReadType(ppb, pszPropName, &vari, VT_EMPTY);
     if (FAILED(hr))
+    {
+        ERR("%p %s %p\n", ppb, debugstr_w(pszPropName), pguid);
         return hr;
+    }
 
     if (V_VT(&vari) == (VT_UI1 | VT_ARRAY)) /* Byte Array */
         bRet = VariantToGUID(&vari, pguid);
@@ -5727,6 +5735,9 @@ HRESULT WINAPI SHPropertyBag_ReadGUID(IPropertyBag *ppb, LPCWSTR pszPropName, GU
         bRet = GUIDFromStringW(V_BSTR(&vari), pguid);
     else
         bRet = TRUE;
+
+    if (!bRet)
+        ERR("%p %s %p\n", ppb, debugstr_w(pszPropName), pguid);
 
     VariantClear(&vari);
     return (bRet ? S_OK : E_FAIL);
@@ -5740,8 +5751,13 @@ HRESULT WINAPI SHPropertyBag_ReadStream(IPropertyBag *ppb, LPCWSTR pszPropName, 
     HRESULT hr;
     VARIANT vari;
 
+    TRACE("%p %s %p\n", ppb, debugstr_w(pszPropName), ppStream);
+
     if (!ppb || !pszPropName || !ppStream)
+    {
+        ERR("%p %s %p\n", ppb, debugstr_w(pszPropName), ppStream);
         return E_INVALIDARG;
+    }
 
     hr = SHPropertyBag_ReadType(ppb, pszPropName, &vari, VT_UNKNOWN);
     if (FAILED(hr))

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -5362,6 +5362,7 @@ VariantToBuffer(
 
     if (varIn && V_VT(varIn) == (VT_UI1 | VT_ARRAY)) /* Byte Array */
     {
+        /* Boundary check and access */
         pArray = V_ARRAY(varIn);
         if (SafeArrayGetDim(pArray) == 1 &&
             SUCCEEDED(SafeArrayGetLBound(pArray, 1, &LowerBound)) &&
@@ -5371,11 +5372,11 @@ VariantToBuffer(
         {
             CopyMemory(pvDest, pvData, cbSize);
             SafeArrayUnaccessData(pArray);
-            return TRUE;
+            return TRUE; /* Success */
         }
     }
 
-    return FALSE;
+    return FALSE; /* Failure */
 }
 
 /**************************************************************************

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -5374,17 +5374,6 @@ BOOL VariantToBuffer(const VARIANT *varIn, void *pvDest, UINT cb)
     return FALSE;
 }
 
-BOOL VariantToGUID(const VARIANT *varIn, GUID *pguid)
-{
-    if (VariantToBuffer(varIn, pguid, sizeof(*pguid)))
-        return TRUE;
-
-    if (varIn && V_VT(varIn) == VT_BSTR && V_BSTR(varIn))
-        return GUIDFromStringW(V_BSTR(varIn), pguid);
-
-    return FALSE;
-}
-
 /**************************************************************************
  *  SHPropertyBag_ReadType (SHLWAPI.493)
  */

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -5353,12 +5353,12 @@ DoDefault:
 BOOL
 VariantToBuffer(
     _In_ const VARIANT *varIn,
-    _Out_writes_(cb) void *pvDest,
+    _Out_writes_(cb) LPVOID pvDest,
     _In_ SIZE_T cbSize)
 {
-    void *pvData;
+    LPVOID pvData;
     LONG LowerBound, UpperBound;
-    SAFEARRAY *pArray;
+    LPSAFEARRAY pArray;
 
     if (varIn && V_VT(varIn) == (VT_UI1 | VT_ARRAY)) /* Byte Array */
     {

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -5362,7 +5362,7 @@ BOOL VariantToBuffer(const VARIANT *varIn, void *pv, UINT cb)
         if (SafeArrayGetDim(pArray) == 1 &&
             SUCCEEDED(SafeArrayGetLBound(pArray, 1, &lBound)) &&
             SUCCEEDED(SafeArrayGetUBound(pArray, 1, &uBound)) &&
-            (uBound - lBound + 1 >= cb) &&
+            (cb <= uBound - lBound + 1) &&
             SUCCEEDED(SafeArrayAccessData(pArray, &pvData)))
         {
             CopyMemory(pv, pvData, cb);

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -5360,8 +5360,9 @@ VariantArrayToBuffer(
     LONG LowerBound, UpperBound;
     LPSAFEARRAY pArray;
 
-    if (!pvarIn || V_VT(pvarIn) != (VT_UI1 | VT_ARRAY)) /* Not a Byte Array? */
-        return FALSE; /* Failure */
+    /* Only supports byte array */
+    if (!pvarIn || V_VT(pvarIn) != (VT_UI1 | VT_ARRAY))
+        return FALSE;
 
     /* Boundary check and access */
     pArray = V_ARRAY(pvarIn);

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -5730,7 +5730,7 @@ HRESULT WINAPI SHPropertyBag_ReadGUID(IPropertyBag *ppb, LPCWSTR pszPropName, GU
     }
 
     if (V_VT(&vari) == (VT_UI1 | VT_ARRAY)) /* Byte Array */
-        bRet = VariantToGUID(&vari, pguid);
+        bRet = VariantToBuffer(&vari, pguid, sizeof(*pguid));
     else if (V_VT(&vari) == VT_BSTR)
         bRet = GUIDFromStringW(V_BSTR(&vari), pguid);
     else

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -5350,7 +5350,11 @@ DoDefault:
     return hr;
 }
 
-BOOL VariantToBuffer(const VARIANT *varIn, void *pvDest, UINT cb)
+BOOL
+VariantToBuffer(
+    _In_ const VARIANT *varIn,
+    _Out_writes_(cb) void *pvDest,
+    _In_ UINT cb)
 {
     void *pvData;
     LONG LowerBound, UpperBound;

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -5727,7 +5727,7 @@ HRESULT WINAPI SHPropertyBag_ReadGUID(IPropertyBag *ppb, LPCWSTR pszPropName, GU
     else if (V_VT(&vari) == VT_BSTR)
         bRet = GUIDFromStringW(V_BSTR(&vari), pguid);
     else
-        bRet = TRUE;
+        bRet = TRUE; /* This is by design */
 
     if (!bRet)
         ERR("%p %s %p\n", ppb, debugstr_w(pszPropName), pguid);

--- a/dll/win32/shlwapi/shlwapi.spec
+++ b/dll/win32/shlwapi/shlwapi.spec
@@ -502,7 +502,7 @@
 502 stdcall AssocQueryKeyA(long long str str ptr)
 503 stdcall AssocQueryKeyW(long long wstr wstr ptr)
 504 stdcall AssocQueryStringA(long long str str ptr ptr)
-505 stub -noname SHPropertyBag_ReadGUID
+505 stdcall -noname SHPropertyBag_ReadGUID(ptr wstr ptr)
 506 stdcall -noname SHPropertyBag_WriteGUID(ptr wstr ptr)
 507 stdcall -noname SHPropertyBag_ReadDWORD(ptr wstr ptr)
 508 stdcall -noname SHPropertyBag_WriteDWORD(ptr wstr long)
@@ -528,7 +528,7 @@
 528 stdcall -noname SHPropertyBag_WriteSHORT(ptr wstr long)
 529 stdcall -noname SHPropertyBag_ReadInt(ptr wstr ptr) SHPropertyBag_ReadLONG
 530 stdcall -noname SHPropertyBag_WriteInt(ptr wstr long) SHPropertyBag_WriteLONG
-531 stub -noname SHPropertyBag_ReadStream
+531 stdcall -noname SHPropertyBag_ReadStream(ptr wstr ptr)
 532 stdcall -noname SHPropertyBag_WriteStream(ptr wstr ptr)
 533 stub -noname SHGetPerScreenResName
 534 stdcall -noname SHPropertyBag_ReadBOOL(ptr wstr ptr)

--- a/modules/rostests/apitests/shlwapi/CMakeLists.txt
+++ b/modules/rostests/apitests/shlwapi/CMakeLists.txt
@@ -24,7 +24,7 @@ add_rc_deps(testdata.rc ${CMAKE_CURRENT_BINARY_DIR}/shlwapi_resource_dll/shlwapi
 
 add_executable(shlwapi_apitest ${SOURCE})
 set_module_type(shlwapi_apitest win32cui)
-target_link_libraries(shlwapi_apitest ${PSEH_LIB})
+target_link_libraries(shlwapi_apitest ${PSEH_LIB} uuid)
 add_importlibs(shlwapi_apitest shlwapi oleaut32 user32 advapi32 msvcrt kernel32)
 add_dependencies(shlwapi_apitest shlwapi_resource_dll)
 add_rostests_file(TARGET shlwapi_apitest)

--- a/modules/rostests/apitests/shlwapi/CMakeLists.txt
+++ b/modules/rostests/apitests/shlwapi/CMakeLists.txt
@@ -25,6 +25,6 @@ add_rc_deps(testdata.rc ${CMAKE_CURRENT_BINARY_DIR}/shlwapi_resource_dll/shlwapi
 add_executable(shlwapi_apitest ${SOURCE})
 set_module_type(shlwapi_apitest win32cui)
 target_link_libraries(shlwapi_apitest ${PSEH_LIB} uuid)
-add_importlibs(shlwapi_apitest shlwapi oleaut32 user32 advapi32 msvcrt kernel32)
+add_importlibs(shlwapi_apitest shlwapi oleaut32 ole32 user32 advapi32 msvcrt kernel32)
 add_dependencies(shlwapi_apitest shlwapi_resource_dll)
 add_rostests_file(TARGET shlwapi_apitest)

--- a/modules/rostests/apitests/shlwapi/SHPropertyBag.cpp
+++ b/modules/rostests/apitests/shlwapi/SHPropertyBag.cpp
@@ -102,9 +102,11 @@ public:
 
                 if (lstrcmpiW(pszPropName, L"GUID2") == 0)
                 {
+                    WCHAR szText[50];
+                    StringFromGUID2(IID_IUnknown, szText, _countof(szText));
+
                     V_VT(pvari) = VT_BSTR;
-                    V_BSTR(pvari) =
-                        SysAllocString(L"{00000000-0000-0000-C000-000000000046}"); // IID_IUnknown
+                    V_BSTR(pvari) = SysAllocString(szText);
                     return S_OK;
                 }
 

--- a/modules/rostests/apitests/shlwapi/SHPropertyBag.cpp
+++ b/modules/rostests/apitests/shlwapi/SHPropertyBag.cpp
@@ -250,7 +250,7 @@ static void SHPropertyBag_ReadTest(void)
     BOOL bEqual = TRUE;
     for (DWORD i = 0; i < sizeof(guid); ++i)
     {
-        if (LPBYTE(&guid)[i] != 0x55)
+        if (((LPBYTE)&guid)[i] != 0x55)
         {
             bEqual = FALSE;
             break;

--- a/modules/rostests/apitests/shlwapi/SHPropertyBag.cpp
+++ b/modules/rostests/apitests/shlwapi/SHPropertyBag.cpp
@@ -64,17 +64,17 @@ public:
     // IUnknown
     STDMETHODIMP QueryInterface(REFIID riid, void **ppvObject) override
     {
-        ok_int(0, 1);
+        ok_int(0, 1); // Failure
         return S_OK;
     }
     STDMETHODIMP_(ULONG) AddRef() override
     {
-        ok_int(0, 1);
+        ok_int(0, 1); // Failure
         return S_OK;
     }
     STDMETHODIMP_(ULONG) Release() override
     {
-        ok_int(0, 1);
+        ok_int(0, 1); // Failure
         return S_OK;
     }
 
@@ -118,7 +118,7 @@ public:
                 goto Skip1;
             }
         }
-        ok_int(0, 1);
+        ok_int(0, 1); // Failure
 Skip1:
         return S_OK;
     }
@@ -143,7 +143,7 @@ Skip1:
                 goto Skip2;
             }
         }
-        ok_int(0, 1);
+        ok_int(0, 1); // Failure
 Skip2:
         return S_OK;
     }

--- a/modules/rostests/apitests/shlwapi/SHPropertyBag.cpp
+++ b/modules/rostests/apitests/shlwapi/SHPropertyBag.cpp
@@ -30,7 +30,7 @@ static void ResetTest(VARTYPE vt,
     s_pszPropNames[3] = pszName3;
 }
 
-static SAFEARRAY* CreateByteArray(LPCVOID pvData, DWORD cbSize)
+static SAFEARRAY* CreateByteArray(LPCVOID pvSrc, DWORD cbSize)
 {
     SAFEARRAYBOUND Bound;
     Bound.lLbound = 0;
@@ -40,18 +40,15 @@ static SAFEARRAY* CreateByteArray(LPCVOID pvData, DWORD cbSize)
     if (!pArray)
         return NULL;
 
-    BYTE HUGEP *pb;
-    HRESULT hr = SafeArrayAccessData(pArray, (void HUGEP **)&pb);
+    void HUGEP *pvData;
+    HRESULT hr = SafeArrayAccessData(pArray, &pvData);
     if (FAILED(hr))
     {
         SafeArrayDestroy(pArray);
         return NULL;
     }
 
-    for (DWORD i = 0; i < cbSize; i++)
-    {
-        pb[i] = ((const BYTE*)pvData)[i];
-    }
+    CopyMemory(pvData, pvSrc, cbSize);
     SafeArrayUnaccessData(pArray);
 
     return pArray;

--- a/modules/rostests/apitests/shlwapi/SHPropertyBag.cpp
+++ b/modules/rostests/apitests/shlwapi/SHPropertyBag.cpp
@@ -64,8 +64,16 @@ public:
             {
                 ok_wstr(pszPropName, s_pszPropNames[i]);
                 s_pszPropNames[i] = NULL;
+
                 if (lstrcmpiW(pszPropName, L"RECTL2.top") == 0)
                     return E_FAIL;
+
+                if (lstrcmpiW(pszPropName, L"GUID1") == 0)
+                {
+                    V_VT(pvari) = VT_BSTR;
+                    V_BSTR(pvari) = SysAllocString(L"{00000000-0000-0000-C000-000000000046}");
+                    return S_OK;
+                }
 
                 goto Skip1;
             }
@@ -113,6 +121,7 @@ static void SHPropertyBag_ReadTest(void)
     POINTL ptl = { 0xEEEE, 0xDDDD };
     POINTS pts = { 0x2222, 0x3333 };
     RECTL rcl = { 123, 456, 789, 101112 };
+    GUID guid = { 0 };
 
     ResetTest(VT_BOOL, L"BOOL1");
     hr = SHPropertyBag_ReadBOOL(&dummy, s_pszPropNames[0], &bValue);
@@ -167,6 +176,12 @@ static void SHPropertyBag_ReadTest(void)
     hr = SHPropertyBag_ReadRECTL(&dummy, L"RECTL2", &rcl);
     ok_long(hr, E_FAIL);
     ok_int(s_cRead, 2);
+    ok_int(s_cWrite, 0);
+
+    ResetTest(VT_EMPTY, L"GUID1");
+    hr = SHPropertyBag_ReadGUID(&dummy, L"GUID1", &guid);
+    ok_long(hr, S_OK);
+    ok_int(s_cRead, 1);
     ok_int(s_cWrite, 0);
 }
 

--- a/modules/rostests/apitests/shlwapi/SHPropertyBag.cpp
+++ b/modules/rostests/apitests/shlwapi/SHPropertyBag.cpp
@@ -64,17 +64,17 @@ public:
     // IUnknown
     STDMETHODIMP QueryInterface(REFIID riid, void **ppvObject) override
     {
-        ok_int(0, 1); // Failure
+        ok(FALSE, "Unexpected call\n");
         return S_OK;
     }
     STDMETHODIMP_(ULONG) AddRef() override
     {
-        ok_int(0, 1); // Failure
+        ok(FALSE, "Unexpected call\n");
         return S_OK;
     }
     STDMETHODIMP_(ULONG) Release() override
     {
-        ok_int(0, 1); // Failure
+        ok(FALSE, "Unexpected call\n");
         return S_OK;
     }
 
@@ -118,7 +118,7 @@ public:
                 goto Skip1;
             }
         }
-        ok_int(0, 1); // Failure
+        ok(FALSE, "Unexpected call\n");
 Skip1:
         return S_OK;
     }
@@ -143,7 +143,7 @@ Skip1:
                 goto Skip2;
             }
         }
-        ok_int(0, 1); // Failure
+        ok(FALSE, "Unexpected call\n");
 Skip2:
         return S_OK;
     }

--- a/modules/rostests/apitests/shlwapi/SHPropertyBag.cpp
+++ b/modules/rostests/apitests/shlwapi/SHPropertyBag.cpp
@@ -223,14 +223,14 @@ static void SHPropertyBag_ReadTest(void)
     ok_long(hr, S_OK);
     ok_int(s_cRead, 1);
     ok_int(s_cWrite, 0);
-    ok(IsEqualGUID(guid, IID_IShellLink), "guid was wrong.\n");
+    ok_int(IsEqualGUID(guid, IID_IShellLink), TRUE);
 
     ResetTest(VT_EMPTY, L"GUID2");
     hr = SHPropertyBag_ReadGUID(&dummy, L"GUID2", &guid);
     ok_long(hr, S_OK);
     ok_int(s_cRead, 1);
     ok_int(s_cWrite, 0);
-    ok(IsEqualGUID(guid, IID_IUnknown), "guid was wrong.\n");
+    ok_int(IsEqualGUID(guid, IID_IUnknown), TRUE);
 
     ResetTest(VT_EMPTY, L"GUID3");
     guid = IID_IExtractIcon;
@@ -243,7 +243,7 @@ static void SHPropertyBag_ReadTest(void)
 
     ok_int(s_cRead, 1);
     ok_int(s_cWrite, 0);
-    ok(IsEqualGUID(guid, IID_IExtractIcon), "guid was wrong.\n");
+    ok_int(IsEqualGUID(guid, IID_IExtractIcon), TRUE);
 }
 
 static void SHPropertyBag_WriteTest(void)

--- a/modules/rostests/apitests/shlwapi/SHPropertyBag.cpp
+++ b/modules/rostests/apitests/shlwapi/SHPropertyBag.cpp
@@ -233,7 +233,7 @@ static void SHPropertyBag_ReadTest(void)
     ok(IsEqualGUID(guid, IID_IUnknown), "guid was wrong.\n");
 
     ResetTest(VT_EMPTY, L"GUID3");
-    FillMemory(&guid, sizeof(guid), 0x55);
+    guid = IID_IExtractIcon;
     hr = SHPropertyBag_ReadGUID(&dummy, L"GUID3", &guid);
 
     if (IsWindowsVistaOrGreater())
@@ -243,17 +243,7 @@ static void SHPropertyBag_ReadTest(void)
 
     ok_int(s_cRead, 1);
     ok_int(s_cWrite, 0);
-
-    BOOL bEqual = TRUE;
-    for (DWORD i = 0; i < sizeof(guid); ++i)
-    {
-        if (((LPBYTE)&guid)[i] != 0x55)
-        {
-            bEqual = FALSE;
-            break;
-        }
-    }
-    ok_int(bEqual, TRUE);
+    ok(IsEqualGUID(guid, IID_IExtractIcon), "guid was wrong.\n");
 }
 
 static void SHPropertyBag_WriteTest(void)

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -103,12 +103,13 @@ HRESULT WINAPI SHPropertyBag_ReadStr(IPropertyBag *ppb, LPCWSTR pszPropName, LPW
 HRESULT WINAPI SHPropertyBag_ReadPOINTL(IPropertyBag *ppb, LPCWSTR pszPropName, POINTL *pptl);
 HRESULT WINAPI SHPropertyBag_ReadPOINTS(IPropertyBag *ppb, LPCWSTR pszPropName, POINTS *ppts);
 HRESULT WINAPI SHPropertyBag_ReadRECTL(IPropertyBag *ppb, LPCWSTR pszPropName, RECTL *prcl);
+HRESULT WINAPI SHPropertyBag_ReadGUID(IPropertyBag *ppb, LPCWSTR pszPropName, GUID *pguid);
+HRESULT WINAPI SHPropertyBag_ReadStream(IPropertyBag *ppb, LPCWSTR pszPropName, IStream **ppStream);
 
 HRESULT WINAPI SHGetPerScreenResName(OUT LPWSTR lpResName,
                                      IN INT cchResName,
                                      IN DWORD dwReserved);
 
-HRESULT WINAPI SHPropertyBag_ReadStream(IPropertyBag*,LPCWSTR,IStream**);
 HRESULT WINAPI SHPropertyBag_Delete(IPropertyBag *ppb, LPCWSTR pszPropName);
 HRESULT WINAPI SHPropertyBag_WriteBOOL(IPropertyBag *ppb, LPCWSTR pszPropName, BOOL bValue);
 HRESULT WINAPI SHPropertyBag_WriteSHORT(IPropertyBag *ppb, LPCWSTR pszPropName, SHORT sValue);


### PR DESCRIPTION
## Purpose
Implementing missing features...
JIRA issue: [CORE-9283](https://jira.reactos.org/browse/CORE-9283)

## Proposed changes

- Add `VariantArrayToBuffer` helper function.
- Implement `SHPropertyBag_ReadGUID` and `SHPropertyBag_ReadStream` functions.
- Modify `shlwapi.spec`.
- Modify `shlwapi_undoc.h`.
- Strengthen `SHPropertyBag` testcase in `shlwapi_apitest.exe`.
- Link `uuid.dll` and `ole32.dll` to `shlwapi_apitest.exe`.

## TODO

- [x] Do tests.

## Comparison

WinXP:
![WinXP](https://github.com/reactos/reactos/assets/2107452/c5715148-de67-49de-b248-2599bc12843f)
Successful.

Win2k3:
![Win2k3](https://github.com/reactos/reactos/assets/2107452/379b73a1-0f59-459b-ad10-fc58f485c868)
Successful.

Win10:
![Win10](https://github.com/reactos/reactos/assets/2107452/5664c0f4-7f35-484e-91a1-bf6f22930858)
Successful.

ReactOS:
![after](https://github.com/reactos/reactos/assets/2107452/63f41ae7-6a8a-4737-a3b0-cb3e1287e006)
Successful.