### PR TITLE
[SHELL32] Fix error code for GetDisplayNameOf for the Control Panel

### DIFF
--- a/dll/win32/shell32/folders/CControlPanelFolder.cpp
+++ b/dll/win32/shell32/folders/CControlPanelFolder.cpp
@@ -488,8 +488,8 @@ HRESULT WINAPI CControlPanelFolder::GetUIObjectOf(HWND hwndOwner,
 */
 HRESULT WINAPI CControlPanelFolder::GetDisplayNameOf(PCUITEMID_CHILD pidl, DWORD dwFlags, LPSTRRET strRet)
 {
-    if (!pidl)
-        return S_FALSE;
+    if (!strRet || !pidl)
+        return E_INVALIDARG;
 
     PIDLCPanelStruct *pCPanel = _ILGetCPanelPointer(pidl);
 


### PR DESCRIPTION
S_False is a success response, but was being used as a fail condition. It just isn't right to do that.

## Purpose

I noticed (and I think others may have as well) that the response from the control panel was deceptive.

https://learn.microsoft.com/en-us/windows/win32/api/shobjidl_core/nf-shobjidl_core-ishellfolder-getdisplaynameof

JIRA issue: [CORE-18841](https://jira.reactos.org/browse/CORE-18841)

## Proposed changes

Just fix the response code