### PR TITLE
[SHELL32_APITEST] New regression test for Control Panel's GetDisplayNameOf

### DIFF
--- a/modules/rostests/apitests/shell32/CMakeLists.txt
+++ b/modules/rostests/apitests/shell32/CMakeLists.txt
@@ -15,6 +15,7 @@ list(APPEND SOURCE
     DragDrop.cpp
     ExtractIconEx.cpp
     FindExecutable.cpp
+    GetDisplayNameOf.cpp
     IShellFolderViewCB.cpp
     OpenAs_RunDLL.cpp
     PathResolve.cpp

--- a/modules/rostests/apitests/shell32/GetDisplayNameOf.cpp
+++ b/modules/rostests/apitests/shell32/GetDisplayNameOf.cpp
@@ -1,0 +1,40 @@
+/*
+ * PROJECT:         ReactOS API tests
+ * LICENSE:         LGPLv2.1+ - See COPYING.LIB in the top level directory
+ * PURPOSE:         Test for GetDisplayNameOf
+ * COPYRIGHT:       Copyright 2023 Mark Jansen <mark.jansen@reactos.org>
+ *                  Copyright 2023 Doug Lyons <douglyons@douglyons.com>
+ */
+
+#include "shelltest.h"
+#include <shellutils.h>
+
+START_TEST(GetDisplayNameOf)
+{
+    HRESULT hr;
+    CoInitializeEx(NULL, COINIT_APARTMENTTHREADED);
+
+    CComPtr<IShellFolder> spPanel;
+
+    hr = CoCreateInstance(CLSID_ControlPanel, NULL, CLSCTX_ALL,
+                          IID_PPV_ARG(IShellFolder, &spPanel));
+
+    ok_hr(hr, S_OK);
+    if (SUCCEEDED(hr))
+    {
+        /* We want to know if 'STRRET ret' data was changed when the first
+         * parameter of GetDisplayNameOf for the Control Panel is NULL */
+        STRRET ret, expected;
+        memset(&ret, 'a', sizeof(ret));
+        memset(&expected, 'a', sizeof(expected));
+        hr = spPanel->GetDisplayNameOf(NULL, SHGDN_NORMAL, &ret);
+        ok_hex(hr, S_FALSE);
+        ok(memcmp(&ret, &expected, sizeof(ret)) == 0, "Data was changed!\n");
+        memset(&ret, 'a', sizeof(ret));
+        memset(&expected, 'a', sizeof(expected));
+        hr = spPanel->GetDisplayNameOf(NULL, SHGDN_FORPARSING, &ret);
+        ok_hex(hr, S_FALSE);
+        ok(memcmp(&ret, &expected, sizeof(ret)) == 0, "Data was changed!\n");
+    }
+
+}

--- a/modules/rostests/apitests/shell32/GetDisplayNameOf.cpp
+++ b/modules/rostests/apitests/shell32/GetDisplayNameOf.cpp
@@ -7,7 +7,7 @@
  */
 
 #include "shelltest.h"
-#include <cstdio>
+#include <stdio.h>
 #include <shellutils.h>
 
 START_TEST(GetDisplayNameOf)

--- a/modules/rostests/apitests/shell32/GetDisplayNameOf.cpp
+++ b/modules/rostests/apitests/shell32/GetDisplayNameOf.cpp
@@ -1,9 +1,9 @@
 /*
- * PROJECT:         ReactOS API tests
- * LICENSE:         LGPLv2.1+ - See COPYING.LIB in the top level directory
- * PURPOSE:         Test for GetDisplayNameOf
- * COPYRIGHT:       Copyright 2023 Mark Jansen <mark.jansen@reactos.org>
- *                  Copyright 2023 Doug Lyons <douglyons@douglyons.com>
+ * PROJECT:     ReactOS API tests
+ * LICENSE:     LGPL-2.1+ (https://spdx.org/licenses/LGPL-2.1+)
+ * PURPOSE:     Test for GetDisplayNameOf
+ * COPYRIGHT:   Copyright 2023 Mark Jansen <mark.jansen@reactos.org>
+ *              Copyright 2023 Doug Lyons <douglyons@douglyons.com>
  */
 
 #include "shelltest.h"

--- a/modules/rostests/apitests/shell32/GetDisplayNameOf.cpp
+++ b/modules/rostests/apitests/shell32/GetDisplayNameOf.cpp
@@ -37,5 +37,4 @@ START_TEST(GetDisplayNameOf)
         ok_hex(hr, S_FALSE);
         ok(memcmp(&ret, &expected, sizeof(ret)) == 0, "Data was changed!\n");
     }
-
 }

--- a/modules/rostests/apitests/shell32/GetDisplayNameOf.cpp
+++ b/modules/rostests/apitests/shell32/GetDisplayNameOf.cpp
@@ -19,7 +19,6 @@ START_TEST(GetDisplayNameOf)
 
     hr = CoCreateInstance(CLSID_ControlPanel, NULL, CLSCTX_ALL,
                           IID_PPV_ARG(IShellFolder, &spPanel));
-
     ok_hr(hr, S_OK);
     if (SUCCEEDED(hr))
     {
@@ -29,6 +28,7 @@ START_TEST(GetDisplayNameOf)
         memset(&ret, 'a', sizeof(ret));
         memset(&expected, 'a', sizeof(expected));
         hr = spPanel->GetDisplayNameOf(NULL, SHGDN_NORMAL, &ret);
+        /* This verifies that the return value is 'S_FALSE' */
         ok_hex(hr, S_FALSE);
         ok(memcmp(&ret, &expected, sizeof(ret)) == 0, "Data was changed!\n");
         memset(&ret, 'a', sizeof(ret));

--- a/modules/rostests/apitests/shell32/GetDisplayNameOf.cpp
+++ b/modules/rostests/apitests/shell32/GetDisplayNameOf.cpp
@@ -7,6 +7,8 @@
  */
 
 #include "shelltest.h"
+#include <winnls.h>
+#include <strsafe.h>
 #include <shellutils.h>
 
 START_TEST(GetDisplayNameOf)

--- a/modules/rostests/apitests/shell32/GetDisplayNameOf.cpp
+++ b/modules/rostests/apitests/shell32/GetDisplayNameOf.cpp
@@ -22,18 +22,22 @@ START_TEST(GetDisplayNameOf)
     ok_hr(hr, S_OK);
     if (SUCCEEDED(hr))
     {
-        /* We want to know if 'STRRET ret' data was changed when the first
-         * parameter of GetDisplayNameOf for the Control Panel is NULL */
         STRRET ret, expected;
+
         memset(&ret, 'a', sizeof(ret));
         memset(&expected, 'a', sizeof(expected));
         hr = spPanel->GetDisplayNameOf(NULL, SHGDN_NORMAL, &ret);
-        /* This verifies that the return value is 'S_FALSE' */
+
+        /* Return value is expected to be 'S_FALSE', which is out-of-spec behavior.
+         * The data after function call is expected to be unchanged. */
         ok_hex(hr, S_FALSE);
         ok(memcmp(&ret, &expected, sizeof(ret)) == 0, "Data was changed!\n");
+
+        /* Repeat the same test with SHGDN_FORPARSING */
         memset(&ret, 'a', sizeof(ret));
         memset(&expected, 'a', sizeof(expected));
         hr = spPanel->GetDisplayNameOf(NULL, SHGDN_FORPARSING, &ret);
+
         ok_hex(hr, S_FALSE);
         ok(memcmp(&ret, &expected, sizeof(ret)) == 0, "Data was changed!\n");
     }

--- a/modules/rostests/apitests/shell32/GetDisplayNameOf.cpp
+++ b/modules/rostests/apitests/shell32/GetDisplayNameOf.cpp
@@ -7,8 +7,7 @@
  */
 
 #include "shelltest.h"
-#include <winnls.h>
-#include <strsafe.h>
+#include <cstdio>
 #include <shellutils.h>
 
 START_TEST(GetDisplayNameOf)

--- a/modules/rostests/apitests/shell32/testlist.c
+++ b/modules/rostests/apitests/shell32/testlist.c
@@ -16,6 +16,7 @@ extern void func_CUserNotification(void);
 extern void func_DragDrop(void);
 extern void func_ExtractIconEx(void);
 extern void func_FindExecutable(void);
+extern void func_GetDisplayNameOf(void);
 extern void func_IShellFolderViewCB(void);
 extern void func_menu(void);
 extern void func_OpenAs_RunDLL(void);
@@ -49,6 +50,7 @@ const struct test winetest_testlist[] =
     { "DragDrop", func_DragDrop },
     { "ExtractIconEx", func_ExtractIconEx },
     { "FindExecutable", func_FindExecutable },
+    { "GetDisplayNameOf", func_GetDisplayNameOf },
     { "IShellFolderViewCB", func_IShellFolderViewCB },
     { "menu", func_menu },
     { "OpenAs_RunDLL", func_OpenAs_RunDLL },


### PR DESCRIPTION
## Purpose

_Add new regression test for Control Panel's GetDisplayNameOf with a NULL first parameter._
_This shows that the return value of the function is 'S_FALSE'._
_Also, the return value of STRRET is not touched by this call._

JIRA issue: [CORE-18841](https://jira.reactos.org/browse/CORE-18841)

## Proposed changes

_Add new code for regression test of Control Panel's GetDisplayNameOf._

Results of running new test on Windows Server 2003 SP2:

![w2ksp3_CPL_GetDisplayNameOf](https://github.com/reactos/reactos/assets/32620577/6a2bca43-21e8-482b-9b28-11c9b58dd69e)
