### PR TITLE
[CMD] Tweak comment for %TIME% format

### DIFF
--- a/base/shell/cmd/locale.c
+++ b/base/shell/cmd/locale.c
@@ -68,7 +68,7 @@ GetDateString(VOID)
     return szDate;
 }
 
-/* Return time in hh:mm:ss.xx format. Used for $T in prompt and %TIME% */
+/* Return time in H:mm:ss.SS format. Used for $T in prompt and %TIME% */
 LPTSTR
 GetTimeString(VOID)
 {


### PR DESCRIPTION
## Purpose

- Precisely describe `time` format, based on [CLDR](http://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table) standard.
- Having spent time verifying the behaviour on Windows and ROS, this strict definition may be helpful to future researchers.

## Proposed changes

- Non-code change. Comments only. 

\#Enhancement, \#TrivialFix
