### PR TITLE
[AFD] Add UDP vectored I/O capability - packet assembly in Afd*SocketWriteData, scatter code in SatisfyPacketRecvRequest. CORE-17526

### DIFF
--- a/drivers/network/afd/afd/read.c
+++ b/drivers/network/afd/afd/read.c
@@ -115,11 +115,13 @@ static NTSTATUS TryToSatisfyRecvRequestFromBuffer( PAFD_FCB FCB,
          RecvReq->BufferArray &&
              BytesAvailable &&
              i < RecvReq->BufferCount;
-         i++ ) {
+         i++ )
+    {
         BytesToCopy =
             MIN( RecvReq->BufferArray[i].len, BytesAvailable );
 
-        if( Map[i].Mdl ) {
+        if( Map[i].Mdl )
+        {
             Map[i].BufferAddress = MmMapLockedPages( Map[i].Mdl, KernelMode );
 
             AFD_DbgPrint(MID_TRACE,("Buffer %u: %p:%u\n",
@@ -161,11 +163,13 @@ static NTSTATUS ReceiveActivity( PAFD_FCB FCB, PIRP Irp ) {
     AFD_DbgPrint(MID_TRACE,("FCB %p Receive data waiting %u\n",
                             FCB, FCB->Recv.Content));
 
-    if( CantReadMore( FCB ) ) {
+    if( CantReadMore( FCB ) )
+    {
         /* Success here means that we got an EOF.  Complete a pending read
          * with zero bytes if we haven't yet overread, then kill the others.
          */
-        while( !IsListEmpty( &FCB->PendingIrpList[FUNCTION_RECV] ) ) {
+        while( !IsListEmpty( &FCB->PendingIrpList[FUNCTION_RECV] ) )
+        {
             NextIrpEntry = RemoveHeadList(&FCB->PendingIrpList[FUNCTION_RECV]);
             NextIrp = CONTAINING_RECORD(NextIrpEntry, IRP, Tail.Overlay.ListEntry);
             NextIrpSp = IoGetCurrentIrpStackLocation( NextIrp );
@@ -195,7 +199,8 @@ static NTSTATUS ReceiveActivity( PAFD_FCB FCB, PIRP Irp ) {
         /*OskitDumpBuffer( FCB->Recv.Window, FCB->Recv.Content );*/
 
         /* Try to clear some requests */
-        while( !IsListEmpty( &FCB->PendingIrpList[FUNCTION_RECV] ) ) {
+        while( !IsListEmpty( &FCB->PendingIrpList[FUNCTION_RECV] ) )
+        {
             NextIrpEntry = RemoveHeadList(&FCB->PendingIrpList[FUNCTION_RECV]);
             NextIrp = CONTAINING_RECORD(NextIrpEntry, IRP, Tail.Overlay.ListEntry);
             NextIrpSp = IoGetCurrentIrpStackLocation( NextIrp );
@@ -206,7 +211,8 @@ static NTSTATUS ReceiveActivity( PAFD_FCB FCB, PIRP Irp ) {
             Status = TryToSatisfyRecvRequestFromBuffer
             ( FCB, RecvReq, &TotalBytesCopied );
 
-            if( Status == STATUS_PENDING ) {
+            if( Status == STATUS_PENDING )
+            {
                 AFD_DbgPrint(MID_TRACE,("Ran out of data for %p\n", NextIrp));
                 InsertHeadList(&FCB->PendingIrpList[FUNCTION_RECV],
                                &NextIrp->Tail.Overlay.ListEntry);
@@ -218,7 +224,8 @@ static NTSTATUS ReceiveActivity( PAFD_FCB FCB, PIRP Irp ) {
                                RecvReq->BufferCount, FALSE );
                 NextIrp->IoStatus.Status = Status;
                 NextIrp->IoStatus.Information = TotalBytesCopied;
-                if( NextIrp == Irp ) {
+                if( NextIrp == Irp )
+                {
                     RetStatus = Status;
                 }
                 if( NextIrp->MdlAddress ) UnlockRequest( NextIrp, IoGetCurrentIrpStackLocation( NextIrp ) );
@@ -229,7 +236,8 @@ static NTSTATUS ReceiveActivity( PAFD_FCB FCB, PIRP Irp ) {
     }
 
     if( FCB->Recv.Content - FCB->Recv.BytesUsed &&
-        IsListEmpty(&FCB->PendingIrpList[FUNCTION_RECV]) ) {
+        IsListEmpty(&FCB->PendingIrpList[FUNCTION_RECV]) )
+    {
         FCB->PollState |= AFD_EVENT_RECEIVE;
         FCB->PollStatus[FD_READ_BIT] = STATUS_SUCCESS;
         PollReeval( FCB->DeviceExt, FCB->FileObject );
@@ -279,9 +287,11 @@ NTSTATUS NTAPI ReceiveComplete
     ASSERT(FCB->ReceiveIrp.InFlightRequest == Irp);
     FCB->ReceiveIrp.InFlightRequest = NULL;
 
-    if( FCB->State == SOCKET_STATE_CLOSED ) {
+    if( FCB->State == SOCKET_STATE_CLOSED )
+    {
         /* Cleanup our IRP queue because the FCB is being destroyed */
-        while( !IsListEmpty( &FCB->PendingIrpList[FUNCTION_RECV] ) ) {
+        while( !IsListEmpty( &FCB->PendingIrpList[FUNCTION_RECV] ) )
+        {
             NextIrpEntry = RemoveHeadList(&FCB->PendingIrpList[FUNCTION_RECV]);
             NextIrp = CONTAINING_RECORD(NextIrpEntry, IRP, Tail.Overlay.ListEntry);
             NextIrpSp = IoGetCurrentIrpStackLocation(NextIrp);
@@ -335,12 +345,15 @@ SatisfyPacketRecvRequest( PAFD_FCB FCB, PIRP Irp,
         AFD_DbgPrint(MID_TRACE,("BytesToCopy: %u len %u\n", BytesToCopy,
                             RecvReq->BufferArray[i].len));
 
-        if( Map[0].Mdl ) {
+        if( Map[0].Mdl )
+        {
             /* Copy the address */
-            if( ExtraBuffers && Map[RecvReq->BufferCount].Mdl && Map[RecvReq->BufferCount + 1].Mdl && i == 0 ) {
+            if( ExtraBuffers && Map[RecvReq->BufferCount].Mdl && Map[RecvReq->BufferCount + 1].Mdl && i == 0 )
+            {
                 AFD_DbgPrint(MID_TRACE,("Checking TAAddressCount\n"));
 
-                if( DatagramRecv->Address->TAAddressCount != 1 ) {
+                if( DatagramRecv->Address->TAAddressCount != 1 )
+                {
                     AFD_DbgPrint
                     (MIN_TRACE,
                      ("Wierd address count %d\n",
@@ -441,7 +454,8 @@ AfdConnectedSocketReadData(PDEVICE_OBJECT DeviceObject, PIRP Irp,
 
     if( !(FCB->Flags & AFD_ENDPOINT_CONNECTIONLESS) &&
         FCB->State != SOCKET_STATE_CONNECTED &&
-        FCB->State != SOCKET_STATE_CONNECTING ) {
+        FCB->State != SOCKET_STATE_CONNECTING )
+    {
         AFD_DbgPrint(MIN_TRACE,("Called recv on wrong kind of socket (s%x)\n",
                                 FCB->State));
         return UnlockAndMaybeComplete( FCB, STATUS_INVALID_PARAMETER,
@@ -459,7 +473,8 @@ AfdConnectedSocketReadData(PDEVICE_OBJECT DeviceObject, PIRP Irp,
                                        NULL, NULL,
                                        TRUE, FALSE, LockMode );
 
-    if( !RecvReq->BufferArray ) {
+    if( !RecvReq->BufferArray )
+    {
         return UnlockAndMaybeComplete( FCB, STATUS_ACCESS_VIOLATION,
                                       Irp, 0 );
     }
@@ -520,7 +535,8 @@ AfdConnectedSocketReadData(PDEVICE_OBJECT DeviceObject, PIRP Irp,
 
     if( Status == STATUS_PENDING &&
         !(RecvReq->AfdFlags & AFD_OVERLAPPED) &&
-        ((RecvReq->AfdFlags & AFD_IMMEDIATE) || (FCB->NonBlocking))) {
+        ((RecvReq->AfdFlags & AFD_IMMEDIATE) || (FCB->NonBlocking)))
+    {
         AFD_DbgPrint(MID_TRACE,("Nonblocking\n"));
         Status = STATUS_CANT_WAIT;
         TotalBytesCopied = 0;
@@ -565,9 +581,11 @@ PacketSocketRecvComplete(
     ASSERT(FCB->ReceiveIrp.InFlightRequest == Irp);
     FCB->ReceiveIrp.InFlightRequest = NULL;
 
-    if( FCB->State == SOCKET_STATE_CLOSED ) {
+    if( FCB->State == SOCKET_STATE_CLOSED )
+    {
         /* Cleanup our IRP queue because the FCB is being destroyed */
-        while( !IsListEmpty( &FCB->PendingIrpList[FUNCTION_RECV] ) ) {
+        while( !IsListEmpty( &FCB->PendingIrpList[FUNCTION_RECV] ) )
+        {
             NextIrpEntry = RemoveHeadList(&FCB->PendingIrpList[FUNCTION_RECV]);
             NextIrp = CONTAINING_RECORD(NextIrpEntry, IRP, Tail.Overlay.ListEntry);
             NextIrpSp = IoGetCurrentIrpStackLocation( NextIrp );
@@ -581,7 +599,8 @@ PacketSocketRecvComplete(
         }
 
         /* Free all items on the datagram list */
-        while( !IsListEmpty( &FCB->DatagramList ) ) {
+        while( !IsListEmpty( &FCB->DatagramList ) )
+        {
                DatagramRecvEntry = RemoveHeadList(&FCB->DatagramList);
                DatagramRecv = CONTAINING_RECORD(DatagramRecvEntry, AFD_STORED_DATAGRAM, ListEntry);
                ExFreePoolWithTag(DatagramRecv->Address, TAG_AFD_TRANSPORT_ADDRESS);
@@ -608,7 +627,8 @@ PacketSocketRecvComplete(
                                          DGSize,
                                          TAG_AFD_STORED_DATAGRAM);
 
-    if( DatagramRecv ) {
+    if( DatagramRecv )
+    {
         DatagramRecv->Len = Irp->IoStatus.Information;
         RtlCopyMemory( DatagramRecv->Buffer, FCB->Recv.Window,
                        DatagramRecv->Len );
@@ -621,7 +641,8 @@ PacketSocketRecvComplete(
 
     } else Status = STATUS_NO_MEMORY;
 
-    if( !NT_SUCCESS( Status ) ) {
+    if( !NT_SUCCESS( Status ) )
+    {
 
         if (DatagramRecv)
         {
@@ -638,7 +659,8 @@ PacketSocketRecvComplete(
     /* Satisfy as many requests as we can */
 
     while( !IsListEmpty( &FCB->DatagramList ) &&
-           !IsListEmpty( &FCB->PendingIrpList[FUNCTION_RECV] ) ) {
+           !IsListEmpty( &FCB->PendingIrpList[FUNCTION_RECV] ) )
+    {
         AFD_DbgPrint(MID_TRACE,("Looping trying to satisfy request\n"));
         ListEntry = RemoveHeadList( &FCB->DatagramList );
         DatagramRecv = CONTAINING_RECORD( ListEntry, AFD_STORED_DATAGRAM,
@@ -673,7 +695,8 @@ PacketSocketRecvComplete(
         IoCompleteRequest( NextIrp, IO_NETWORK_INCREMENT );
     }
 
-    if( !IsListEmpty( &FCB->DatagramList ) && IsListEmpty(&FCB->PendingIrpList[FUNCTION_RECV]) ) {
+    if( !IsListEmpty( &FCB->DatagramList ) && IsListEmpty(&FCB->PendingIrpList[FUNCTION_RECV]) )
+    {
         AFD_DbgPrint(MID_TRACE,("Signalling\n"));
         FCB->PollState |= AFD_EVENT_RECEIVE;
         FCB->PollStatus[FD_READ_BIT] = STATUS_SUCCESS;
@@ -681,7 +704,8 @@ PacketSocketRecvComplete(
     } else
         FCB->PollState &= ~AFD_EVENT_RECEIVE;
 
-    if( NT_SUCCESS(Irp->IoStatus.Status) && FCB->Recv.Content < FCB->Recv.Size ) {
+    if( NT_SUCCESS(Irp->IoStatus.Status) && FCB->Recv.Content < FCB->Recv.Size )
+    {
         /* Now relaunch the datagram request */
         Status = TdiReceiveDatagram
             ( &FCB->ReceiveIrp.InFlightRequest,
@@ -742,7 +766,8 @@ AfdPacketSocketReadData(PDEVICE_OBJECT DeviceObject, PIRP Irp,
                                         RecvReq->AddressLength,
                                         TRUE, TRUE, LockMode );
 
-    if( !RecvReq->BufferArray ) { /* access violation in userspace */
+    if( !RecvReq->BufferArray )
+    { /* access violation in userspace */
         return UnlockAndMaybeComplete(FCB, STATUS_ACCESS_VIOLATION, Irp, 0);
     }
 

--- a/drivers/network/afd/afd/write.c
+++ b/drivers/network/afd/afd/write.c
@@ -50,9 +50,11 @@ static NTSTATUS NTAPI SendComplete
     FCB->SendIrp.InFlightRequest = NULL;
     /* Request is not in flight any longer */
 
-    if( FCB->State == SOCKET_STATE_CLOSED ) {
+    if( FCB->State == SOCKET_STATE_CLOSED )
+    {
         /* Cleanup our IRP queue because the FCB is being destroyed */
-        while( !IsListEmpty( &FCB->PendingIrpList[FUNCTION_SEND] ) ) {
+        while( !IsListEmpty( &FCB->PendingIrpList[FUNCTION_SEND] ) )
+        {
             NextIrpEntry = RemoveHeadList(&FCB->PendingIrpList[FUNCTION_SEND]);
             NextIrp = CONTAINING_RECORD(NextIrpEntry, IRP, Tail.Overlay.ListEntry);
             NextIrpSp = IoGetCurrentIrpStackLocation( NextIrp );
@@ -71,10 +73,12 @@ static NTSTATUS NTAPI SendComplete
         return STATUS_FILE_CLOSED;
     }
 
-    if( !NT_SUCCESS(Status) ) {
+    if( !NT_SUCCESS(Status) )
+    {
         /* Complete all following send IRPs with error */
 
-        while( !IsListEmpty( &FCB->PendingIrpList[FUNCTION_SEND] ) ) {
+        while( !IsListEmpty( &FCB->PendingIrpList[FUNCTION_SEND] ) )
+        {
             NextIrpEntry =
                 RemoveHeadList(&FCB->PendingIrpList[FUNCTION_SEND]);
             NextIrp =
@@ -108,7 +112,8 @@ static NTSTATUS NTAPI SendComplete
     TotalBytesProcessed = 0;
     SendLength = Irp->IoStatus.Information;
     HaltSendQueue = FALSE;
-    while (!IsListEmpty(&FCB->PendingIrpList[FUNCTION_SEND]) && SendLength > 0) {
+    while (!IsListEmpty(&FCB->PendingIrpList[FUNCTION_SEND]) && SendLength > 0)
+    {
         NextIrpEntry = RemoveHeadList(&FCB->PendingIrpList[FUNCTION_SEND]);
         NextIrp = CONTAINING_RECORD(NextIrpEntry, IRP, Tail.Overlay.ListEntry);
         NextIrpSp = IoGetCurrentIrpStackLocation( NextIrp );
@@ -158,7 +163,8 @@ static NTSTATUS NTAPI SendComplete
 
     ASSERT(SendLength == 0);
 
-   if ( !HaltSendQueue && !IsListEmpty( &FCB->PendingIrpList[FUNCTION_SEND] ) ) {
+   if ( !HaltSendQueue && !IsListEmpty( &FCB->PendingIrpList[FUNCTION_SEND] ) )
+   {
         NextIrpEntry = FCB->PendingIrpList[FUNCTION_SEND].Flink;
         NextIrp = CONTAINING_RECORD(NextIrpEntry, IRP, Tail.Overlay.ListEntry);
         NextIrpSp = IoGetCurrentIrpStackLocation( NextIrp );
@@ -202,7 +208,8 @@ static NTSTATUS NTAPI SendComplete
 
         if (NextIrp != NULL)
         {
-            for( i = 0; i < SendReq->BufferCount; i++ ) {
+            for( i = 0; i < SendReq->BufferCount; i++ )
+            {
                 BytesCopied = MIN(SendReq->BufferArray[i].len, SpaceAvail);
 
                 Map[i].BufferAddress =
@@ -282,9 +289,11 @@ static NTSTATUS NTAPI PacketSocketSendComplete
     FCB->SendIrp.InFlightRequest = NULL;
     /* Request is not in flight any longer */
 
-    if( FCB->State == SOCKET_STATE_CLOSED ) {
+    if( FCB->State == SOCKET_STATE_CLOSED )
+    {
         /* Cleanup our IRP queue because the FCB is being destroyed */
-        while( !IsListEmpty( &FCB->PendingIrpList[FUNCTION_SEND] ) ) {
+        while( !IsListEmpty( &FCB->PendingIrpList[FUNCTION_SEND] ) )
+        {
             NextIrpEntry = RemoveHeadList(&FCB->PendingIrpList[FUNCTION_SEND]);
             NextIrp = CONTAINING_RECORD(NextIrpEntry, IRP, Tail.Overlay.ListEntry);
             SendReq = GetLockedData(NextIrp, IoGetCurrentIrpStackLocation(NextIrp));
@@ -370,25 +379,29 @@ AfdConnectedSocketWriteData(PDEVICE_OBJECT DeviceObject, PIRP Irp,
                                             NULL, NULL,
                                             FALSE, FALSE, LockMode );
 
-        if( !SendReq->BufferArray ) {
+        if( !SendReq->BufferArray )
+        {
             return UnlockAndMaybeComplete( FCB, STATUS_ACCESS_VIOLATION,
                                            Irp, 0 );
         }
 
         Status = TdiBuildConnectionInfo( &TargetAddress, FCB->RemoteAddress );
 
-        if( NT_SUCCESS(Status) ) {
+        if( NT_SUCCESS(Status) )
+        {
             FCB->PollState &= ~AFD_EVENT_SEND;
 
             Status = QueueUserModeIrp(FCB, Irp, FUNCTION_SEND);
             if (Status == STATUS_PENDING)
             {
-                if (SendReq->BufferCount > 1) {
+                if (SendReq->BufferCount > 1)
+                {
                     AFD_DbgPrint(MID_TRACE,("Assembling packet buffer from %u elements\n",
                                             SendReq->BufferCount));
                     RtlZeroMemory((&pktbuf[0]), PAD_BUFFER);
                     FullSendLen = 0;
-                    for (LoopIdx = 0; LoopIdx < SendReq->BufferCount; LoopIdx++) {
+                    for (LoopIdx = 0; LoopIdx < SendReq->BufferCount; LoopIdx++)
+                    {
                         _SEH2_TRY {
                             RtlCopyMemory((PCHAR)((&pktbuf[0]) + FullSendLen),
                                           SendReq->BufferArray[LoopIdx].buf,
@@ -488,14 +501,16 @@ AfdConnectedSocketWriteData(PDEVICE_OBJECT DeviceObject, PIRP Irp,
                                         NULL, NULL,
                                         FALSE, FALSE, LockMode );
 
-    if( !SendReq->BufferArray ) {
+    if( !SendReq->BufferArray )
+    {
         return UnlockAndMaybeComplete( FCB, STATUS_ACCESS_VIOLATION,
                                        Irp, 0 );
     }
 
     AFD_DbgPrint(MID_TRACE,("Socket state %u\n", FCB->State));
 
-    if( FCB->State != SOCKET_STATE_CONNECTED ) {
+    if( FCB->State != SOCKET_STATE_CONNECTED )
+    {
         AFD_DbgPrint(MID_TRACE,("Socket not connected\n"));
         UnlockBuffers( SendReq->BufferArray, SendReq->BufferCount, FALSE );
         return UnlockAndMaybeComplete( FCB, STATUS_INVALID_CONNECTION, Irp, 0 );
@@ -566,7 +581,8 @@ AfdConnectedSocketWriteData(PDEVICE_OBJECT DeviceObject, PIRP Irp,
 
     Irp->IoStatus.Information = TotalBytesCopied;
 
-    if( TotalBytesCopied == 0 ) {
+    if( TotalBytesCopied == 0 )
+    {
         AFD_DbgPrint(MID_TRACE,("Empty send\n"));
         UnlockBuffers( SendReq->BufferArray, SendReq->BufferCount, FALSE );
         return UnlockAndMaybeComplete
@@ -652,7 +668,8 @@ AfdPacketSocketWriteData(PDEVICE_OBJECT DeviceObject, PIRP Irp,
         TaBuildNullTransportAddress( ((PTRANSPORT_ADDRESS)SendReq->TdiConnection.RemoteAddress)->
                                       Address[0].AddressType );
 
-        if( FCB->LocalAddress ) {
+        if( FCB->LocalAddress )
+        {
             Status = WarmSocketForBind( FCB, AFD_SHARE_WILDCARD );
 
             if( NT_SUCCESS(Status) )
@@ -685,13 +702,15 @@ AfdPacketSocketWriteData(PDEVICE_OBJECT DeviceObject, PIRP Irp,
 
     /* Check the size of the Address given ... */
 
-    if(NT_SUCCESS(Status)) {
+    if(NT_SUCCESS(Status))
+    {
         FCB->PollState &= ~AFD_EVENT_SEND;
 
         Status = QueueUserModeIrp(FCB, Irp, FUNCTION_SEND);
         if (Status == STATUS_PENDING)
         {
-            if (SendReq->BufferCount > 1) {
+            if (SendReq->BufferCount > 1)
+            {
                 AFD_DbgPrint(MID_TRACE,("Assembling packet buffer from %u elements\n",
                                         SendReq->BufferCount));
                 RtlZeroMemory((&pktbuf[0]), PAD_BUFFER);

--- a/drivers/network/afd/afd/write.c
+++ b/drivers/network/afd/afd/write.c
@@ -50,11 +50,9 @@ static NTSTATUS NTAPI SendComplete
     FCB->SendIrp.InFlightRequest = NULL;
     /* Request is not in flight any longer */
 
-    if( FCB->State == SOCKET_STATE_CLOSED )
-    {
+    if( FCB->State == SOCKET_STATE_CLOSED ) {
         /* Cleanup our IRP queue because the FCB is being destroyed */
-        while( !IsListEmpty( &FCB->PendingIrpList[FUNCTION_SEND] ) )
-        {
+        while( !IsListEmpty( &FCB->PendingIrpList[FUNCTION_SEND] ) ) {
             NextIrpEntry = RemoveHeadList(&FCB->PendingIrpList[FUNCTION_SEND]);
             NextIrp = CONTAINING_RECORD(NextIrpEntry, IRP, Tail.Overlay.ListEntry);
             NextIrpSp = IoGetCurrentIrpStackLocation( NextIrp );
@@ -73,12 +71,10 @@ static NTSTATUS NTAPI SendComplete
         return STATUS_FILE_CLOSED;
     }
 
-    if( !NT_SUCCESS(Status) )
-    {
+    if( !NT_SUCCESS(Status) ) {
         /* Complete all following send IRPs with error */
 
-        while( !IsListEmpty( &FCB->PendingIrpList[FUNCTION_SEND] ) )
-        {
+        while( !IsListEmpty( &FCB->PendingIrpList[FUNCTION_SEND] ) ) {
             NextIrpEntry =
                 RemoveHeadList(&FCB->PendingIrpList[FUNCTION_SEND]);
             NextIrp =
@@ -112,8 +108,7 @@ static NTSTATUS NTAPI SendComplete
     TotalBytesProcessed = 0;
     SendLength = Irp->IoStatus.Information;
     HaltSendQueue = FALSE;
-    while (!IsListEmpty(&FCB->PendingIrpList[FUNCTION_SEND]) && SendLength > 0)
-    {
+    while (!IsListEmpty(&FCB->PendingIrpList[FUNCTION_SEND]) && SendLength > 0) {
         NextIrpEntry = RemoveHeadList(&FCB->PendingIrpList[FUNCTION_SEND]);
         NextIrp = CONTAINING_RECORD(NextIrpEntry, IRP, Tail.Overlay.ListEntry);
         NextIrpSp = IoGetCurrentIrpStackLocation( NextIrp );
@@ -163,8 +158,7 @@ static NTSTATUS NTAPI SendComplete
 
     ASSERT(SendLength == 0);
 
-   if ( !HaltSendQueue && !IsListEmpty( &FCB->PendingIrpList[FUNCTION_SEND] ) )
-   {
+   if ( !HaltSendQueue && !IsListEmpty( &FCB->PendingIrpList[FUNCTION_SEND] ) ) {
         NextIrpEntry = FCB->PendingIrpList[FUNCTION_SEND].Flink;
         NextIrp = CONTAINING_RECORD(NextIrpEntry, IRP, Tail.Overlay.ListEntry);
         NextIrpSp = IoGetCurrentIrpStackLocation( NextIrp );
@@ -208,8 +202,7 @@ static NTSTATUS NTAPI SendComplete
 
         if (NextIrp != NULL)
         {
-            for( i = 0; i < SendReq->BufferCount; i++ )
-            {
+            for( i = 0; i < SendReq->BufferCount; i++ ) {
                 BytesCopied = MIN(SendReq->BufferArray[i].len, SpaceAvail);
 
                 Map[i].BufferAddress =
@@ -289,11 +282,9 @@ static NTSTATUS NTAPI PacketSocketSendComplete
     FCB->SendIrp.InFlightRequest = NULL;
     /* Request is not in flight any longer */
 
-    if( FCB->State == SOCKET_STATE_CLOSED )
-    {
+    if( FCB->State == SOCKET_STATE_CLOSED ) {
         /* Cleanup our IRP queue because the FCB is being destroyed */
-        while( !IsListEmpty( &FCB->PendingIrpList[FUNCTION_SEND] ) )
-        {
+        while( !IsListEmpty( &FCB->PendingIrpList[FUNCTION_SEND] ) ) {
             NextIrpEntry = RemoveHeadList(&FCB->PendingIrpList[FUNCTION_SEND]);
             NextIrp = CONTAINING_RECORD(NextIrpEntry, IRP, Tail.Overlay.ListEntry);
             SendReq = GetLockedData(NextIrp, IoGetCurrentIrpStackLocation(NextIrp));
@@ -379,16 +370,14 @@ AfdConnectedSocketWriteData(PDEVICE_OBJECT DeviceObject, PIRP Irp,
                                             NULL, NULL,
                                             FALSE, FALSE, LockMode );
 
-        if( !SendReq->BufferArray )
-        {
+        if( !SendReq->BufferArray ) {
             return UnlockAndMaybeComplete( FCB, STATUS_ACCESS_VIOLATION,
                                            Irp, 0 );
         }
 
         Status = TdiBuildConnectionInfo( &TargetAddress, FCB->RemoteAddress );
 
-        if( NT_SUCCESS(Status) )
-        {
+        if( NT_SUCCESS(Status) ) {
             FCB->PollState &= ~AFD_EVENT_SEND;
 
             Status = QueueUserModeIrp(FCB, Irp, FUNCTION_SEND);
@@ -501,16 +490,14 @@ AfdConnectedSocketWriteData(PDEVICE_OBJECT DeviceObject, PIRP Irp,
                                         NULL, NULL,
                                         FALSE, FALSE, LockMode );
 
-    if( !SendReq->BufferArray )
-    {
+    if( !SendReq->BufferArray ) {
         return UnlockAndMaybeComplete( FCB, STATUS_ACCESS_VIOLATION,
                                        Irp, 0 );
     }
 
     AFD_DbgPrint(MID_TRACE,("Socket state %u\n", FCB->State));
 
-    if( FCB->State != SOCKET_STATE_CONNECTED )
-    {
+    if( FCB->State != SOCKET_STATE_CONNECTED ) {
         AFD_DbgPrint(MID_TRACE,("Socket not connected\n"));
         UnlockBuffers( SendReq->BufferArray, SendReq->BufferCount, FALSE );
         return UnlockAndMaybeComplete( FCB, STATUS_INVALID_CONNECTION, Irp, 0 );
@@ -581,8 +568,7 @@ AfdConnectedSocketWriteData(PDEVICE_OBJECT DeviceObject, PIRP Irp,
 
     Irp->IoStatus.Information = TotalBytesCopied;
 
-    if( TotalBytesCopied == 0 )
-    {
+    if( TotalBytesCopied == 0 ) {
         AFD_DbgPrint(MID_TRACE,("Empty send\n"));
         UnlockBuffers( SendReq->BufferArray, SendReq->BufferCount, FALSE );
         return UnlockAndMaybeComplete
@@ -668,8 +654,7 @@ AfdPacketSocketWriteData(PDEVICE_OBJECT DeviceObject, PIRP Irp,
         TaBuildNullTransportAddress( ((PTRANSPORT_ADDRESS)SendReq->TdiConnection.RemoteAddress)->
                                       Address[0].AddressType );
 
-        if( FCB->LocalAddress )
-        {
+        if( FCB->LocalAddress ) {
             Status = WarmSocketForBind( FCB, AFD_SHARE_WILDCARD );
 
             if( NT_SUCCESS(Status) )
@@ -702,8 +687,7 @@ AfdPacketSocketWriteData(PDEVICE_OBJECT DeviceObject, PIRP Irp,
 
     /* Check the size of the Address given ... */
 
-    if(NT_SUCCESS(Status))
-    {
+    if( NT_SUCCESS(Status) ) {
         FCB->PollState &= ~AFD_EVENT_SEND;
 
         Status = QueueUserModeIrp(FCB, Irp, FUNCTION_SEND);

--- a/drivers/network/afd/afd/write.c
+++ b/drivers/network/afd/afd/write.c
@@ -663,7 +663,7 @@ AfdPacketSocketWriteData(PDEVICE_OBJECT DeviceObject, PIRP Irp,
                 AFD_DbgPrint(MID_TRACE,("local packet buffer ready, Data length is %u\n", FullSendLen));
                 Status = TdiSendDatagram(&FCB->SendIrp.InFlightRequest,
                                          FCB->AddressFile.Object,
-                                         &pktbuf[0], 
+                                         &pktbuf[0],
                                          FullSendLen,
                                          TargetAddress,
                                          PacketSocketSendComplete,
@@ -677,8 +677,8 @@ AfdPacketSocketWriteData(PDEVICE_OBJECT DeviceObject, PIRP Irp,
                     UnlockBuffers(SendReq->BufferArray, SendReq->BufferCount, FALSE);
                     UnlockRequest(Irp, IoGetCurrentIrpStackLocation(Irp));
                     IoCompleteRequest(Irp, IO_NETWORK_INCREMENT);
-                }                        
-            } else {            
+                }
+            } else {
                 Status = TdiSendDatagram(&FCB->SendIrp.InFlightRequest,
                                          FCB->AddressFile.Object,
                                          SendReq->BufferArray[0].buf,

--- a/drivers/network/afd/afd/write.c
+++ b/drivers/network/afd/afd/write.c
@@ -337,7 +337,7 @@ AfdConnectedSocketWriteData(PDEVICE_OBJECT DeviceObject, PIRP Irp,
     UINT TotalBytesCopied = 0, i, SpaceAvail = 0, BytesCopied, SendLength;
     KPROCESSOR_MODE LockMode;
     INT FullSendLen, LoopIdx; // accumulator for full packet length
-    char pktbuf[PAD_BUFFER];  // local packet assembly buffer   
+    char pktbuf[PAD_BUFFER];  // local packet assembly buffer
 
     UNREFERENCED_PARAMETER(DeviceObject);
     UNREFERENCED_PARAMETER(Short);

--- a/drivers/network/afd/afd/write.c
+++ b/drivers/network/afd/afd/write.c
@@ -337,7 +337,7 @@ AfdConnectedSocketWriteData(PDEVICE_OBJECT DeviceObject, PIRP Irp,
     UINT TotalBytesCopied = 0, i, SpaceAvail = 0, BytesCopied, SendLength;
     KPROCESSOR_MODE LockMode;
     INT FullSendLen, LoopIdx; // accumulator for full packet length
-    char pktbuf[PAD_BUFFER];  // local packet assembly buffer
+    char pktbuf[PAD_BUFFER]; // local packet assembly buffer
 
     UNREFERENCED_PARAMETER(DeviceObject);
     UNREFERENCED_PARAMETER(Short);
@@ -384,25 +384,25 @@ AfdConnectedSocketWriteData(PDEVICE_OBJECT DeviceObject, PIRP Irp,
             if (Status == STATUS_PENDING)
             {
                 if (SendReq->BufferCount > 1) {
-                    AFD_DbgPrint(MID_TRACE,("Assembling packet buffer from %u elements\n", 
+                    AFD_DbgPrint(MID_TRACE,("Assembling packet buffer from %u elements\n",
                                             SendReq->BufferCount));
                     RtlZeroMemory((&pktbuf[0]), PAD_BUFFER);
                     FullSendLen = 0;
                     for (LoopIdx = 0; LoopIdx < SendReq->BufferCount; LoopIdx++) {
                         _SEH2_TRY {
-                            RtlCopyMemory((PCHAR)((&pktbuf[0]) + FullSendLen), 
-                                          SendReq->BufferArray[LoopIdx].buf, 
+                            RtlCopyMemory((PCHAR)((&pktbuf[0]) + FullSendLen),
+                                          SendReq->BufferArray[LoopIdx].buf,
                                           SendReq->BufferArray[LoopIdx].len);
                         } _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER) {
                             AFD_DbgPrint(MIN_TRACE,(
-                                         "Access violation copying userland data (%p %p)\n", 
-                                         SendReq->BufferArray[LoopIdx].buf, 
+                                         "Access violation copying userland data (%p %p)\n",
+                                         SendReq->BufferArray[LoopIdx].buf,
                                          SendReq->BufferArray[LoopIdx].len));
                             _SEH2_YIELD(return STATUS_NO_MEMORY);
                         } _SEH2_END;
                         FullSendLen = FullSendLen + SendReq->BufferArray[LoopIdx].len;
                     }
-                    AFD_DbgPrint(MID_TRACE,("local packet buffer ready, length is %u\n", 
+                    AFD_DbgPrint(MID_TRACE,("local packet buffer ready, length is %u\n",
                                             FullSendLen));
                     Status = TdiSendDatagram(&FCB->SendIrp.InFlightRequest,
                                              FCB->AddressFile.Object,
@@ -614,7 +614,7 @@ AfdPacketSocketWriteData(PDEVICE_OBJECT DeviceObject, PIRP Irp,
     PAFD_SEND_INFO_UDP SendReq;
     KPROCESSOR_MODE LockMode;
     INT FullSendLen, LoopIdx; // accumulator for full packet length
-    char pktbuf[PAD_BUFFER];  // local packet assembly buffer
+    char pktbuf[PAD_BUFFER]; // local packet assembly buffer
 
     UNREFERENCED_PARAMETER(DeviceObject);
 
@@ -692,25 +692,25 @@ AfdPacketSocketWriteData(PDEVICE_OBJECT DeviceObject, PIRP Irp,
         if (Status == STATUS_PENDING)
         {
             if (SendReq->BufferCount > 1) {
-                AFD_DbgPrint(MID_TRACE,("Assembling packet buffer from %u elements\n", 
+                AFD_DbgPrint(MID_TRACE,("Assembling packet buffer from %u elements\n",
                                         SendReq->BufferCount));
                 RtlZeroMemory((&pktbuf[0]), PAD_BUFFER);
                 FullSendLen = 0;
                 for (LoopIdx = 0; LoopIdx < SendReq->BufferCount; LoopIdx++) {
                     _SEH2_TRY {
-                        RtlCopyMemory((PCHAR)((&pktbuf[0]) + FullSendLen), 
-                                      SendReq->BufferArray[LoopIdx].buf, 
+                        RtlCopyMemory((PCHAR)((&pktbuf[0]) + FullSendLen),
+                                      SendReq->BufferArray[LoopIdx].buf,
                                       SendReq->BufferArray[LoopIdx].len);
                     } _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER) {
                         AFD_DbgPrint(MIN_TRACE,(
-                                     "Access violation copying userland data (%p %p)\n", 
-                                     SendReq->BufferArray[LoopIdx].buf, 
+                                     "Access violation copying userland data (%p %p)\n",
+                                     SendReq->BufferArray[LoopIdx].buf,
                                      SendReq->BufferArray[LoopIdx].len));
                         _SEH2_YIELD(return STATUS_NO_MEMORY);
                     } _SEH2_END;
                     FullSendLen = FullSendLen + SendReq->BufferArray[LoopIdx].len;
                 }
-                AFD_DbgPrint(MID_TRACE,("local packet buffer ready, length is %u\n", 
+                AFD_DbgPrint(MID_TRACE,("local packet buffer ready, length is %u\n",
                                         FullSendLen));
                 Status = TdiSendDatagram(&FCB->SendIrp.InFlightRequest,
                                          FCB->AddressFile.Object,

--- a/drivers/network/afd/afd/write.c
+++ b/drivers/network/afd/afd/write.c
@@ -10,7 +10,7 @@
 
 #include "afd.h"
 
-#define PAD_BUFFER 2048;
+#define PAD_BUFFER 2048
 
 static IO_COMPLETION_ROUTINE SendComplete;
 static NTSTATUS NTAPI SendComplete

--- a/drivers/network/afd/afd/write.c
+++ b/drivers/network/afd/afd/write.c
@@ -10,6 +10,8 @@
 
 #include "afd.h"
 
+#define PAD_BUFFER 2048;
+
 static IO_COMPLETION_ROUTINE SendComplete;
 static NTSTATUS NTAPI SendComplete
 ( PDEVICE_OBJECT DeviceObject,
@@ -570,7 +572,7 @@ AfdPacketSocketWriteData(PDEVICE_OBJECT DeviceObject, PIRP Irp,
     PAFD_SEND_INFO_UDP SendReq;
     KPROCESSOR_MODE LockMode;
     INT FullSendLen, LoopIdx; // accumulator for full packet length
-    char pktbuf[4096];  // local packet assembly buffer
+    char pktbuf[PAD_BUFFER];  // local packet assembly buffer
 
     UNREFERENCED_PARAMETER(DeviceObject);
 
@@ -641,7 +643,7 @@ AfdPacketSocketWriteData(PDEVICE_OBJECT DeviceObject, PIRP Irp,
 
     /* Check the size of the Address given ... */
 
-    if( NT_SUCCESS(Status) ) {
+    if(NT_SUCCESS(Status)) {
         FCB->PollState &= ~AFD_EVENT_SEND;
 
         Status = QueueUserModeIrp(FCB, Irp, FUNCTION_SEND);
@@ -650,7 +652,7 @@ AfdPacketSocketWriteData(PDEVICE_OBJECT DeviceObject, PIRP Irp,
             if (SendReq->BufferCount > 1) {
                 AFD_DbgPrint(MID_TRACE,("Assembling packet buffer from %u elements\n", 
                                         SendReq->BufferCount));
-                RtlZeroMemory((&pktbuf[0]), 4096 );
+                RtlZeroMemory((&pktbuf[0]), PAD_BUFFER);
                 FullSendLen = 0;
                 for (LoopIdx = 0; LoopIdx < SendReq->BufferCount; LoopIdx++) {
                     _SEH2_TRY {


### PR DESCRIPTION
## Purpose

When afd gets a request to send or receive a UDP packet based on multiple parts (vectored i/o scatter/gather) using the request array, the parts must be combined before packet can be sent, but current code sends only the first buffer. Similar issue exists for UDP receive, it lacks code for scattering buffers and simply returns buffer overflow error if multiple array elements are used because it only processes first element. NOTE: this is a bugfix, UDP vectored I/O works in Windows

JIRA issue: [CORE-17526](https://jira.reactos.org/browse/CORE-17526)

Added a local buffer and loop to assemble packet data, copying the elements from userland in AfdPacketSocketWriteData and AfdConnectedSocketWriteData to bugfix the ReactOS functions to work like windows does. Added a loop to handle buffer scatter in SatisfyPacketRecvRequest as well. These changes add support for vectored i/o in UDP to ReactOS
