### PR TITLE
[GDI32] CreateDIBSection: Remove erroneous assignation.

### DIFF
--- a/win32ss/gdi/gdi32/objects/bitmap.c
+++ b/win32ss/gdi/gdi32/objects/bitmap.c
@@ -255,34 +255,36 @@ CreateDIBSection(
     HBITMAP hBitmap = NULL;
     PVOID bmBits = NULL;
 
-    pConvertedInfo = ConvertBitmapInfo(BitmapInfo, Usage, &ConvertedInfoSize,
-    FALSE);
-
+    pConvertedInfo = ConvertBitmapInfo(BitmapInfo,
+                                       Usage,
+                                       &ConvertedInfoSize,
+                                       FALSE);
     if (pConvertedInfo)
     {
         // Verify header due to converted may == info.
         if (pConvertedInfo->bmiHeader.biSize >= sizeof(BITMAPINFOHEADER))
         {
-            if (pConvertedInfo->bmiHeader.biCompression == BI_JPEG
-                || pConvertedInfo->bmiHeader.biCompression == BI_PNG)
+            if (pConvertedInfo->bmiHeader.biCompression == BI_JPEG ||
+                pConvertedInfo->bmiHeader.biCompression == BI_PNG)
             {
                 SetLastError(ERROR_INVALID_PARAMETER);
                 return NULL;
             }
         }
-        bmBits = Bits;
-        hBitmap = NtGdiCreateDIBSection(hDC, hSection, dwOffset, pConvertedInfo, Usage,
-            ConvertedInfoSize, 0, // fl
-            0, // dwColorSpace
-            &bmBits);
+        hBitmap = NtGdiCreateDIBSection(hDC,
+                                        hSection,
+                                        dwOffset,
+                                        pConvertedInfo,
+                                        Usage,
+                                        ConvertedInfoSize,
+                                        0, // fl
+                                        0, // dwColorSpace
+                                        &bmBits);
+        if (!hBitmap)
+            bmBits = NULL;
 
         if (BitmapInfo != pConvertedInfo)
             RtlFreeHeap(RtlGetProcessHeap(), 0, pConvertedInfo);
-
-        if (!hBitmap)
-        {
-            bmBits = NULL;
-        }
     }
 
     if (Bits)


### PR DESCRIPTION
## Purpose

bmBits is only used and assigned on output. It points (holds the address) to the array of DIB bit values. The "Bits" parameter is however a pointer to a variable that will receive the address of that array. So it makes no sense to initially assign bmBits to the value of the Bits parameter...
