### PR TITLE
[CMAKE][MVDM] Fix CMAKE_ASM16_COMPILER for non-x86 MSVC builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,6 +182,9 @@ jobs:
     - name: Build rosapps
       if: ${{ matrix.arch == 'arm' }}
       run: cmake --build build --target modules/rosapps/all
+    - name: Build subsystems
+      if: ${{ matrix.arch == 'arm' }}
+      run: cmake --build build --target subsystems/all
     - name: Build some applications (arm64)
       if: ${{ matrix.arch == 'arm64' }}
       run: cmake --build build --target calc magnify mstsc notepad osk regedit taskmgr winmine wordpad base/applications/screensavers/all -- -k0
@@ -193,6 +196,7 @@ jobs:
           build/base
           build/dll/cpl
           build/modules/rosapps
+          build/subsystems
           !**/CMakeFiles
           !**/cmake_install.cmake
           !**/*.asm

--- a/sdk/cmake/msvc.cmake
+++ b/sdk/cmake/msvc.cmake
@@ -409,21 +409,15 @@ endmacro()
 # PSEH workaround
 set(PSEH_LIB "pseh")
 
-# Use a full path for the x86 version of ml when using x64 VS.
-# It's not a problem when using the DDK/WDK because, in x64 mode,
-# both the x86 and x64 versions of ml are available.
-if(ARCH STREQUAL "amd64")
+# Setup MASM/ML for compiling 16-bit x86 ASM code on x86 or non-x86 ports.
+if(NOT ARCH STREQUAL "i386")
     if((MSVC_VERSION LESS_EQUAL 1900) AND (DEFINED ENV{VCINSTALLDIR}))
         set(CMAKE_ASM16_COMPILER $ENV{VCINSTALLDIR}/bin/ml.exe)
     elseif(DEFINED ENV{VCToolsInstallDir})
-        set(CMAKE_ASM16_COMPILER $ENV{VCToolsInstallDir}/bin/HostX86/x86/ml.exe)
+        set(CMAKE_ASM16_COMPILER $ENV{VCToolsInstallDir}/bin/Host$ENV{VSCMD_ARG_HOST_ARCH}/x86/ml.exe)
     else()
         set(CMAKE_ASM16_COMPILER ml.exe)
     endif()
-elseif(ARCH STREQUAL "arm")
-    set(CMAKE_ASM16_COMPILER armasm.exe)
-elseif(ARCH STREQUAL "arm64")
-    set(CMAKE_ASM16_COMPILER armasm64.exe)
 else()
     set(CMAKE_ASM16_COMPILER ml.exe)
 endif()
@@ -446,11 +440,7 @@ function(CreateBootSectorTarget _target_name _asm_file _binary_file _base_addres
         COMMAND ${CMAKE_C_COMPILER} /nologo ${_no_std_includes_flag} /I${REACTOS_SOURCE_DIR}/sdk/include/asm /I${REACTOS_BINARY_DIR}/sdk/include/asm ${_includes} ${_defines} /D__ASM__ /D_USE_ML /EP /c ${_asm_file} > ${_temp_file}
         DEPENDS ${_asm_file})
 
-    if(ARCH STREQUAL "arm" OR ARCH STREQUAL "arm64")
-        set(_asm16_command ${CMAKE_ASM16_COMPILER} -nologo -o ${_object_file} ${_temp_file})
-    else()
-        set(_asm16_command ${CMAKE_ASM16_COMPILER} /nologo /Cp /Fo${_object_file} /c /Ta ${_temp_file})
-    endif()
+    set(_asm16_command ${CMAKE_ASM16_COMPILER} /nologo /Cp /Fo${_object_file} /c /Ta ${_temp_file})
 
     add_custom_command(
         OUTPUT ${_object_file}

--- a/subsystems/mvdm/asm16.cmake
+++ b/subsystems/mvdm/asm16.cmake
@@ -112,11 +112,7 @@ function(add_asm16_bin _target _binary_file _base_address)
         COMMAND cl /nologo /X /I${REACTOS_SOURCE_DIR}/sdk/include/asm /I${REACTOS_BINARY_DIR}/sdk/include/asm ${_directory_includes} ${_source_file_defines} ${_directory_defines} /D__ASM__ /D_USE_ML /EP /c ${_concatenated_asm_file} > ${_preprocessed_asm_file}
         DEPENDS ${_concatenated_asm_file})
 
-    if(ARCH STREQUAL "arm")
-        set(_pp_asm16_compile_command ${CMAKE_ASM16_COMPILER} -nologo -o ${_object_file} ${_preprocessed_asm_file})
-    else()
-        set(_pp_asm16_compile_command ${CMAKE_ASM16_COMPILER} /nologo /Cp /Fo${_object_file} /c /Ta ${_preprocessed_asm_file})
-    endif()
+    set(_pp_asm16_compile_command ${CMAKE_ASM16_COMPILER} /nologo /Cp /Fo${_object_file} /c /Ta ${_preprocessed_asm_file})
 
     add_custom_command(
         OUTPUT ${_object_file}


### PR DESCRIPTION
Ensure that CMAKE_ASM16_COMPILER is 32-bit MASM on all build targets as it currently is used only for compiling 16-bit x86 ASM code on non-x86 builds. This fixes NTVDM build for ARM. 

Also include subsystems folder in ARM builder.


JIRA issue: [CORE-10452](https://jira.reactos.org/browse/CORE-10452)


