### PR TITLE
[EXPLORER][SHELL32] Fix taskbar large icon for CPLs and some apps

### DIFF
--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -512,11 +512,11 @@ public:
         }
 #undef GET_ICON
 
-        hIcon = (HICON)GetClassLongPtr(hwnd, GCLP_HICONSM);
+        hIcon = (HICON)GetClassLongPtr(hwnd, g_TaskbarSettings.bSmallIcons ? GCLP_HICONSM : GCLP_HICON);
         if (hIcon)
             return hIcon;
 
-        return (HICON)GetClassLongPtr(hwnd, GCLP_HICON);
+        return (HICON)GetClassLongPtr(hwnd, g_TaskbarSettings.bSmallIcons ? GCLP_HICON : GCLP_HICONSM);
     }
 
     INT UpdateTaskItemButton(IN PTASK_ITEM TaskItem)

--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -490,6 +490,8 @@ public:
     HICON GetWndIcon(HWND hwnd)
     {
         HICON hIcon = NULL;
+
+        /* Retrieve icon by sending a message */
 #define GET_ICON(type) \
     SendMessageTimeout(hwnd, WM_GETICON, (type), 0, SMTO_NOTIMEOUTIFNOTHUNG, 100, (PDWORD_PTR)&hIcon)
 
@@ -512,6 +514,7 @@ public:
         }
 #undef GET_ICON
 
+        /* If we failed, retrieve icon from the window class */
         hIcon = (HICON)GetClassLongPtr(hwnd, g_TaskbarSettings.bSmallIcons ? GCLP_HICONSM : GCLP_HICON);
         if (hIcon)
             return hIcon;

--- a/dll/win32/shell32/wine/control.c
+++ b/dll/win32/shell32/wine/control.c
@@ -815,6 +815,12 @@ Control_ShowAppletInTaskbar(CPlApplet* applet, UINT index)
 
     SetWindowTextW(applet->hWnd, applet->info[index].name);
 
+    /* Set large icon for the taskbar button */
+    if (applet->info[index].icon)
+    {
+        SendMessageW(applet->hWnd, WM_SETICON, ICON_BIG, (LPARAM)applet->info[index].icon);
+    }
+
     /* Try loading the small icon for the taskbar button */
     hSmallIcon = (HICON)LoadImageW(applet->hModule,
                                    MAKEINTRESOURCEW(applet->info[index].idIcon),


### PR DESCRIPTION
## Purpose
Control panel applets and some apps don't display taskbar icon correctly when enabling large taskbar icons.

Addendum to 0e8cf6ffd58 (#5465).

Jira issue: [CORE-11698](https://jira.reactos.org/browse/CORE-11698)

Before:
![ROS_Taskbar_Before](https://github.com/reactos/reactos/assets/86486978/d9d96b8f-aacc-40fd-aa11-8723712bd8ef)

After:
![ROS_Taskbar_After](https://github.com/reactos/reactos/assets/86486978/a789621f-92d7-4b73-8305-86d357d86a09)