### PR TITLE
[SHLWAPI] Fix version control (_WIN32_WINNT)

### DIFF
--- a/dll/win32/shlwapi/CMakeLists.txt
+++ b/dll/win32/shlwapi/CMakeLists.txt
@@ -1,9 +1,6 @@
 
 project(SHELL)
 
-remove_definitions(-D_WIN32_WINNT=0x502)
-add_definitions(-D_WIN32_WINNT=0x600)
-
 add_definitions(
     -D__WINESRC__
     -D_SHLWAPI_)

--- a/dll/win32/shlwapi/CMakeLists.txt
+++ b/dll/win32/shlwapi/CMakeLists.txt
@@ -8,7 +8,6 @@ add_definitions(
 spec2def(shlwapi.dll shlwapi.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
-    assoc.c
     clist.c
     istream.c
     msgbox.c
@@ -24,6 +23,7 @@ list(APPEND SOURCE
     url.c)
 
 list(APPEND PCH_SKIP_SOURCE
+    assoc.c
     wsprintf.c
     ${CMAKE_CURRENT_BINARY_DIR}/shlwapi_stubs.c)
 

--- a/dll/win32/shlwapi/assoc.c
+++ b/dll/win32/shlwapi/assoc.c
@@ -17,6 +17,10 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
+#ifdef __REACTOS__
+    #undef _WIN32_WINNT
+    #define _WIN32_WINNT 0x600
+#endif
 #include <stdarg.h>
 #include <assert.h>
 

--- a/dll/win32/shlwapi/assoc.c
+++ b/dll/win32/shlwapi/assoc.c
@@ -19,7 +19,7 @@
  */
 #ifdef __REACTOS__
     #undef _WIN32_WINNT
-    #define _WIN32_WINNT 0x600
+    #define _WIN32_WINNT _WIN32_WINNT_VISTA /* for RegGetValueW */
 #endif
 #include <stdarg.h>
 #include <assert.h>

--- a/dll/win32/shlwapi/path.c
+++ b/dll/win32/shlwapi/path.c
@@ -2249,7 +2249,7 @@ BOOL WINAPI PathIsUNCA(LPCSTR lpszPath)
  * considered UNC, while on Windows Vista+ this is not the case anymore.
  */
 // #ifdef __REACTOS__
-#if (WINVER >= _WIN32_WINNT_VISTA)
+#if (_WIN32_WINNT >= _WIN32_WINNT_VISTA)
   if (lpszPath && (lpszPath[0]=='\\') && (lpszPath[1]=='\\') && (lpszPath[2]!='?'))
 #else
   if (lpszPath && (lpszPath[0]=='\\') && (lpszPath[1]=='\\'))
@@ -2272,7 +2272,7 @@ BOOL WINAPI PathIsUNCW(LPCWSTR lpszPath)
  * considered UNC, while on Windows Vista+ this is not the case anymore.
  */
 // #ifdef __REACTOS__
-#if (WINVER >= _WIN32_WINNT_VISTA)
+#if (_WIN32_WINNT >= _WIN32_WINNT_VISTA)
   if (lpszPath && (lpszPath[0]=='\\') && (lpszPath[1]=='\\') && (lpszPath[2]!='?'))
 #else
   if (lpszPath && (lpszPath[0]=='\\') && (lpszPath[1]=='\\'))


### PR DESCRIPTION
## Purpose

`_WIN32_WINNT` had wrong value to do workaround on Vista+ `RegGetValueW`.
JIRA issue: [CORE-9283](https://jira.reactos.org/browse/CORE-9283)

## Proposed changes

- Do `#undef` and `#define` `_WIN32_WINNT` `_WIN32_WINNT_VISTA` in `assoc.c`.
- Delete `_WIN32_WINNT` hack in `CMakeLists.txt`.

## TODO

- [x] Do big tests.
