### PR TITLE
[SHELL32][SHELL32_APITEST][SDK] Implement SheRemoveQuotesA/W

### DIFF
--- a/dll/win32/shell32/stubs.cpp
+++ b/dll/win32/shell32/stubs.cpp
@@ -460,7 +460,10 @@ SheRemoveQuotesW(LPWSTR psz)
     if (*psz == L'"')
     {
         for (pch = psz + 1; *pch && *pch != L'"'; ++pch)
+        {
             *(pch - 1) = *pch;
+        }
+
         if (*pch == L'"')
             *(pch - 1) = UNICODE_NULL;
     }
@@ -477,7 +480,10 @@ SheRemoveQuotesA(LPSTR psz)
     if (*psz == '"')
     {
         for (pch = psz + 1; *pch && *pch != '"'; ++pch)
+        {
             *(pch - 1) = *pch;
+        }
+
         if (*pch == '"')
             *(pch - 1) = ANSI_NULL;
     }

--- a/dll/win32/shell32/stubs.cpp
+++ b/dll/win32/shell32/stubs.cpp
@@ -451,26 +451,38 @@ SheSetCurDrive(INT iIndex)
     return 1;
 }
 
-/*
- * Unimplemented
- */
 EXTERN_C LPWSTR
 WINAPI
-SheRemoveQuotesW(LPWSTR lpInput)
+SheRemoveQuotesW(LPWSTR psz)
 {
-    FIXME("SheRemoveQuotesW() stub\n");
-    return NULL;
+    PWCHAR pch;
+
+    if (*psz == L'"')
+    {
+        for (pch = psz + 1; *pch && *pch != L'"'; ++pch)
+            *(pch - 1) = *pch;
+        if (*pch == L'"')
+            *(pch - 1) = UNICODE_NULL;
+    }
+
+    return psz;
 }
 
-/*
- * Unimplemented
- */
 EXTERN_C LPSTR
 WINAPI
-SheRemoveQuotesA(LPSTR lpInput)
+SheRemoveQuotesA(LPSTR psz)
 {
-    FIXME("SheRemoveQuotesA() stub\n");
-    return NULL;
+    PCHAR pch;
+
+    if (*psz == '"')
+    {
+        for (pch = psz + 1; *pch && *pch != '"'; ++pch)
+            *(pch - 1) = *pch;
+        if (*pch == '"')
+            *(pch - 1) = ANSI_NULL;
+    }
+
+    return psz;
 }
 
 /*

--- a/modules/rostests/apitests/shell32/CMakeLists.txt
+++ b/modules/rostests/apitests/shell32/CMakeLists.txt
@@ -23,8 +23,8 @@ list(APPEND SOURCE
     SHCreateDataObject.cpp
     SHCreateFileDataObject.cpp
     SHCreateFileExtractIconW.cpp
-    She.cpp
     SHParseDisplayName.cpp
+    She.cpp
     ShellExecCmdLine.cpp
     ShellExecuteEx.cpp
     ShellExecuteW.cpp

--- a/modules/rostests/apitests/shell32/CMakeLists.txt
+++ b/modules/rostests/apitests/shell32/CMakeLists.txt
@@ -23,6 +23,7 @@ list(APPEND SOURCE
     SHCreateDataObject.cpp
     SHCreateFileDataObject.cpp
     SHCreateFileExtractIconW.cpp
+    She.cpp
     SHParseDisplayName.cpp
     ShellExecCmdLine.cpp
     ShellExecuteEx.cpp

--- a/modules/rostests/apitests/shell32/She.cpp
+++ b/modules/rostests/apitests/shell32/She.cpp
@@ -6,7 +6,6 @@
  */
 
 #include "shelltest.h"
-#include <versionhelpers.h>
 #include <undocshell.h>
 
 typedef LPSTR (WINAPI *FN_SheRemoveQuotesA)(LPSTR psz);

--- a/modules/rostests/apitests/shell32/She.cpp
+++ b/modules/rostests/apitests/shell32/She.cpp
@@ -20,6 +20,18 @@ static void test_SheRemoveQuotesA(void)
     CHAR sz1[] = "\"Test\"";
     CHAR sz2[] = "\"Test\"123";
 
+    BOOL bGotException = FALSE;
+    _SEH2_TRY
+    {
+        pSheRemoveQuotesA(NULL);
+    }
+    _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+    {
+        bGotException = TRUE;
+    }
+    _SEH2_END;
+    ok_int(bGotException, TRUE);
+
     ok_ptr(pSheRemoveQuotesA(sz0), sz0);
     ok_str(sz0, "A\"Test\"");
 
@@ -35,6 +47,18 @@ static void test_SheRemoveQuotesW(void)
     WCHAR sz0[] = L"A\"Test\"";
     WCHAR sz1[] = L"\"Test\"";
     WCHAR sz2[] = L"\"Test\"123";
+
+    BOOL bGotException = FALSE;
+    _SEH2_TRY
+    {
+        pSheRemoveQuotesW(NULL);
+    }
+    _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+    {
+        bGotException = TRUE;
+    }
+    _SEH2_END;
+    ok_int(bGotException, TRUE);
 
     ok_ptr(pSheRemoveQuotesW(sz0), sz0);
     ok_wstr(sz0, L"A\"Test\"");

--- a/modules/rostests/apitests/shell32/She.cpp
+++ b/modules/rostests/apitests/shell32/She.cpp
@@ -1,0 +1,64 @@
+/*
+ * PROJECT:     ReactOS api tests
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Test for She* functions
+ * COPYRIGHT:   Copyright 2023 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ */
+
+#include "shelltest.h"
+#include <versionhelpers.h>
+#include <undocshell.h>
+
+typedef LPSTR (WINAPI *FN_SheRemoveQuotesA)(LPSTR psz);
+typedef LPWSTR (WINAPI *FN_SheRemoveQuotesW)(LPWSTR psz);
+
+static FN_SheRemoveQuotesA pSheRemoveQuotesA = NULL;
+static FN_SheRemoveQuotesW pSheRemoveQuotesW = NULL;
+
+static void test_SheRemoveQuotesA(void)
+{
+    CHAR sz0[] = "A\"Test\"";
+    CHAR sz1[] = "\"Test\"";
+    CHAR sz2[] = "\"Test\"123";
+
+    ok_ptr(pSheRemoveQuotesA(sz0), sz0);
+    ok_str(sz0, "A\"Test\"");
+
+    ok_ptr(pSheRemoveQuotesA(sz1), sz1);
+    ok_str(sz1, "Test");
+
+    ok_ptr(pSheRemoveQuotesA(sz2), sz2);
+    ok_str(sz2, "Test");
+}
+
+static void test_SheRemoveQuotesW(void)
+{
+    WCHAR sz0[] = L"A\"Test\"";
+    WCHAR sz1[] = L"\"Test\"";
+    WCHAR sz2[] = L"\"Test\"123";
+
+    ok_ptr(pSheRemoveQuotesW(sz0), sz0);
+    ok_wstr(sz0, L"A\"Test\"");
+
+    ok_ptr(pSheRemoveQuotesW(sz1), sz1);
+    ok_wstr(sz1, L"Test");
+
+    ok_ptr(pSheRemoveQuotesW(sz2), sz2);
+    ok_wstr(sz2, L"Test");
+}
+
+START_TEST(She)
+{
+    HINSTANCE hShell32 = GetModuleHandleW(L"shell32");
+    pSheRemoveQuotesA = (FN_SheRemoveQuotesA)GetProcAddress(hShell32, "SheRemoveQuotesA");
+    pSheRemoveQuotesW = (FN_SheRemoveQuotesW)GetProcAddress(hShell32, "SheRemoveQuotesW");
+
+    if (!pSheRemoveQuotesA || !pSheRemoveQuotesW)
+    {
+        skip("SheRemoveQuotes not found");
+        return;
+    }
+
+    test_SheRemoveQuotesA();
+    test_SheRemoveQuotesW();
+}

--- a/modules/rostests/apitests/shell32/testlist.c
+++ b/modules/rostests/apitests/shell32/testlist.c
@@ -25,6 +25,7 @@ extern void func_SHChangeNotify(void);
 extern void func_SHCreateDataObject(void);
 extern void func_SHCreateFileDataObject(void);
 extern void func_SHCreateFileExtractIconW(void);
+extern void func_She(void);
 extern void func_ShellExecCmdLine(void);
 extern void func_ShellExecuteEx(void);
 extern void func_ShellExecuteW(void);
@@ -58,6 +59,7 @@ const struct test winetest_testlist[] =
     { "SHCreateDataObject", func_SHCreateDataObject },
     { "SHCreateFileDataObject", func_SHCreateFileDataObject },
     { "SHCreateFileExtractIconW", func_SHCreateFileExtractIconW },
+    { "She", func_She },
     { "ShellExecCmdLine", func_ShellExecCmdLine },
     { "ShellExecuteEx", func_ShellExecuteEx },
     { "ShellExecuteW", func_ShellExecuteW },

--- a/sdk/include/reactos/undocshell.h
+++ b/sdk/include/reactos/undocshell.h
@@ -651,6 +651,9 @@ BOOL WINAPI GUIDFromStringW(
     _Out_  LPGUID pguid
     );
 
+LPSTR WINAPI SheRemoveQuotesA(LPSTR psz);
+LPWSTR WINAPI SheRemoveQuotesW(LPWSTR psz);
+
 /*****************************************************************************
  * Shell32 resources
  */


### PR DESCRIPTION
## Purpose
Implementing missing features...
JIRA issue: [CORE-9277](https://jira.reactos.org/browse/CORE-9277)

## Proposed changes

- Implement `SheRemoveQuotesA` and `SheRemoveQuotesW` functions.
- Add `She` testcase into `shell32_apitest.exe`.
- Add `SheRemoveQuotesA` and `SheRemoveQuotesW` prototypes into `undocshell.h`

## TODO

- [x] Do small tests.

## Comparison

WinXP:
![WinXP](https://github.com/reactos/reactos/assets/2107452/844cc964-df7a-4031-ad39-e9af3de50451)
Successful.

Win2k3:
![Win2k3](https://github.com/reactos/reactos/assets/2107452/01360ea1-512a-4b25-8b2e-5ceb12e3c6c9)
Successful.

Win10:
![Win10](https://github.com/reactos/reactos/assets/2107452/e9d225ae-4375-4610-bb46-2d18a0d0baac)
Skipped because there are no `SheRemoveQuotesA/W` functions.

ReactOS (AFTER):
![after](https://github.com/reactos/reactos/assets/2107452/603f8e9e-68ce-400d-b169-00075097675b)
Successful.