### PR TITLE
[SHELL32][SDK] Add SHPropertyBag_... helper functions

### DIFF
--- a/dll/win32/shell32/precomp.h
+++ b/dll/win32/shell32/precomp.h
@@ -153,4 +153,37 @@ public:
     END_MSG_MAP()
 };
 
+EXTERN_C VOID WINAPI
+SHPropertyBag_ReadIntDef(
+    IPropertyBag *ppb,
+    LPCWSTR pszPropName,
+    LPINT pnValue,
+    INT nDefaultValue);
+
+EXTERN_C VOID WINAPI
+SHPropertyBag_ReadDWORDDef(
+    IPropertyBag *ppb,
+    LPCWSTR pszPropName,
+    LPDWORD pdwValue,
+    DWORD dwDefaultValue);
+
+EXTERN_C VOID WINAPI
+SHPropertyBag_ReadBOOLDef(
+    IPropertyBag *ppb,
+    LPCWSTR pszPropName,
+    LPBOOL pbValue,
+    BOOL bDefaultValue);
+
+EXTERN_C BOOL WINAPI
+SHPropertyBag_ReadBOOLDefRet(
+    IPropertyBag *ppb,
+    LPCWSTR pszPropName,
+    BOOL bDefaultValue);
+
+EXTERN_C HRESULT WINAPI
+SHPropertyBag_WritePunk(
+    IPropertyBag *ppb,
+    LPCWSTR pszPropName,
+    IUnknown *punk);
+
 #endif /* _PRECOMP_H__ */

--- a/dll/win32/shell32/precomp.h
+++ b/dll/win32/shell32/precomp.h
@@ -153,33 +153,6 @@ public:
     END_MSG_MAP()
 };
 
-EXTERN_C VOID WINAPI
-SHPropertyBag_ReadIntDef(
-    IPropertyBag *ppb,
-    LPCWSTR pszPropName,
-    LPINT pnValue,
-    INT nDefaultValue);
-
-EXTERN_C VOID WINAPI
-SHPropertyBag_ReadDWORDDef(
-    IPropertyBag *ppb,
-    LPCWSTR pszPropName,
-    LPDWORD pdwValue,
-    DWORD dwDefaultValue);
-
-EXTERN_C VOID WINAPI
-SHPropertyBag_ReadBOOLDef(
-    IPropertyBag *ppb,
-    LPCWSTR pszPropName,
-    LPBOOL pbValue,
-    BOOL bDefaultValue);
-
-EXTERN_C BOOL WINAPI
-SHPropertyBag_ReadBOOLDefRet(
-    IPropertyBag *ppb,
-    LPCWSTR pszPropName,
-    BOOL bDefaultValue);
-
 EXTERN_C HRESULT WINAPI
 SHPropertyBag_WritePunk(
     IPropertyBag *ppb,

--- a/dll/win32/shell32/stubs.cpp
+++ b/dll/win32/shell32/stubs.cpp
@@ -214,60 +214,14 @@ SHCreatePropertyBag(REFIID refIId, LPVOID *lpUnknown)
     return E_FAIL;
 }
 
-EXTERN_C VOID WINAPI
-SHPropertyBag_ReadIntDef(
-    IPropertyBag *ppb,
-    LPCWSTR pszPropName,
-    LPINT pnValue,
-    INT nDefaultValue)
-{
-    HRESULT hr = SHPropertyBag_ReadInt(ppb, pszPropName, pnValue);
-    if (FAILED(hr))
-        *pnValue = nDefaultValue;
-}
-
-EXTERN_C VOID WINAPI
-SHPropertyBag_ReadDWORDDef(
-    IPropertyBag *ppb,
-    LPCWSTR pszPropName,
-    LPDWORD pdwValue,
-    DWORD dwDefaultValue)
-{
-    HRESULT hr = SHPropertyBag_ReadDWORD(ppb, pszPropName, pdwValue);
-    if (FAILED(hr))
-        *pdwValue = dwDefaultValue;
-}
-
-EXTERN_C VOID WINAPI
-SHPropertyBag_ReadBOOLDef(
-    IPropertyBag *ppb,
-    LPCWSTR pszPropName,
-    LPBOOL pbValue,
-    BOOL bDefaultValue)
-{
-    HRESULT hr = SHPropertyBag_ReadBOOL(ppb, pszPropName, pbValue);
-    if (FAILED(hr))
-        *pbValue = bDefaultValue;
-}
-
-EXTERN_C BOOL WINAPI
-SHPropertyBag_ReadBOOLDefRet(
-    IPropertyBag *ppb,
-    LPCWSTR pszPropName,
-    BOOL bDefaultValue)
-{
-    SHPropertyBag_ReadBOOLDef(ppb, pszPropName, &bDefaultValue, bDefaultValue);
-    return bDefaultValue;
-}
-
-EXTERN_C HRESULT WINAPI
+EXTERN_C HRESULT
+WINAPI
 SHPropertyBag_WritePunk(
     IPropertyBag *ppb,
     LPCWSTR pszPropName,
     IUnknown *punk)
 {
     VARIANT vari;
-
     if (!ppb || !pszPropName)
         return E_INVALIDARG;
 

--- a/dll/win32/shell32/stubs.cpp
+++ b/dll/win32/shell32/stubs.cpp
@@ -214,6 +214,68 @@ SHCreatePropertyBag(REFIID refIId, LPVOID *lpUnknown)
     return E_FAIL;
 }
 
+EXTERN_C VOID WINAPI
+SHPropertyBag_ReadIntDef(
+    IPropertyBag *ppb,
+    LPCWSTR pszPropName,
+    LPINT pnValue,
+    INT nDefaultValue)
+{
+    HRESULT hr = SHPropertyBag_ReadInt(ppb, pszPropName, pnValue);
+    if (FAILED(hr))
+        *pnValue = nDefaultValue;
+}
+
+EXTERN_C VOID WINAPI
+SHPropertyBag_ReadDWORDDef(
+    IPropertyBag *ppb,
+    LPCWSTR pszPropName,
+    LPDWORD pdwValue,
+    DWORD dwDefaultValue)
+{
+    HRESULT hr = SHPropertyBag_ReadDWORD(ppb, pszPropName, pdwValue);
+    if (FAILED(hr))
+        *pdwValue = dwDefaultValue;
+}
+
+EXTERN_C VOID WINAPI
+SHPropertyBag_ReadBOOLDef(
+    IPropertyBag *ppb,
+    LPCWSTR pszPropName,
+    LPBOOL pbValue,
+    BOOL bDefaultValue)
+{
+    HRESULT hr = SHPropertyBag_ReadBOOL(ppb, pszPropName, pbValue);
+    if (FAILED(hr))
+        *pbValue = bDefaultValue;
+}
+
+EXTERN_C BOOL WINAPI
+SHPropertyBag_ReadBOOLDefRet(
+    IPropertyBag *ppb,
+    LPCWSTR pszPropName,
+    BOOL bDefaultValue)
+{
+    SHPropertyBag_ReadBOOLDef(ppb, pszPropName, &bDefaultValue, bDefaultValue);
+    return bDefaultValue;
+}
+
+EXTERN_C HRESULT WINAPI
+SHPropertyBag_WritePunk(
+    IPropertyBag *ppb,
+    LPCWSTR pszPropName,
+    IUnknown *punk)
+{
+    VARIANT vari;
+
+    if (!ppb || !pszPropName)
+        return E_INVALIDARG;
+
+    V_VT(&vari) = VT_UNKNOWN;
+    V_UNKNOWN(&vari) = punk;
+    return ppb->Write(pszPropName, &vari);
+}
+
 /*
  * Unimplemented
  */

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -96,6 +96,7 @@ HRESULT WINAPI SHPropertyBag_ReadType(IPropertyBag *ppb, LPCWSTR pszPropName, VA
 HRESULT WINAPI SHPropertyBag_ReadBOOL(IPropertyBag *ppb, LPCWSTR pszPropName, BOOL *pbValue);
 BOOL WINAPI SHPropertyBag_ReadBOOLOld(IPropertyBag *ppb, LPCWSTR pszPropName, BOOL bDefValue);
 HRESULT WINAPI SHPropertyBag_ReadSHORT(IPropertyBag *ppb, LPCWSTR pszPropName, SHORT *psValue);
+HRESULT WINAPI SHPropertyBag_ReadInt(IPropertyBag *ppb, LPCWSTR pszPropName, LPINT pnValue);
 HRESULT WINAPI SHPropertyBag_ReadLONG(IPropertyBag *ppb, LPCWSTR pszPropName, LPLONG pValue);
 HRESULT WINAPI SHPropertyBag_ReadDWORD(IPropertyBag *ppb, LPCWSTR pszPropName, DWORD *pdwValue);
 HRESULT WINAPI SHPropertyBag_ReadBSTR(IPropertyBag *ppb, LPCWSTR pszPropName, BSTR *pbstr);
@@ -113,6 +114,7 @@ HRESULT WINAPI SHGetPerScreenResName(OUT LPWSTR lpResName,
 HRESULT WINAPI SHPropertyBag_Delete(IPropertyBag *ppb, LPCWSTR pszPropName);
 HRESULT WINAPI SHPropertyBag_WriteBOOL(IPropertyBag *ppb, LPCWSTR pszPropName, BOOL bValue);
 HRESULT WINAPI SHPropertyBag_WriteSHORT(IPropertyBag *ppb, LPCWSTR pszPropName, SHORT sValue);
+HRESULT WINAPI SHPropertyBag_WriteInt(IPropertyBag *ppb, LPCWSTR pszPropName, INT nValue);
 HRESULT WINAPI SHPropertyBag_WriteLONG(IPropertyBag *ppb, LPCWSTR pszPropName, LONG lValue);
 HRESULT WINAPI SHPropertyBag_WriteDWORD(IPropertyBag *ppb, LPCWSTR pszPropName, DWORD dwValue);
 HRESULT WINAPI SHPropertyBag_WriteStr(IPropertyBag *ppb, LPCWSTR pszPropName, LPCWSTR pszValue);

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -124,6 +124,56 @@ HRESULT WINAPI SHPropertyBag_WritePOINTL(IPropertyBag *ppb, LPCWSTR pszPropName,
 HRESULT WINAPI SHPropertyBag_WritePOINTS(IPropertyBag *ppb, LPCWSTR pszPropName, const POINTS *ppts);
 HRESULT WINAPI SHPropertyBag_WriteRECTL(IPropertyBag *ppb, LPCWSTR pszPropName, const RECTL *prcl);
 
+static inline
+VOID WINAPI
+SHPropertyBag_ReadIntDef(
+    IPropertyBag *ppb,
+    LPCWSTR pszPropName,
+    LPINT pnValue,
+    INT nDefaultValue)
+{
+    HRESULT hr = SHPropertyBag_ReadInt(ppb, pszPropName, pnValue);
+    if (FAILED(hr))
+        *pnValue = nDefaultValue;
+}
+
+static inline
+VOID WINAPI
+SHPropertyBag_ReadDWORDDef(
+    IPropertyBag *ppb,
+    LPCWSTR pszPropName,
+    LPDWORD pdwValue,
+    DWORD dwDefaultValue)
+{
+    HRESULT hr = SHPropertyBag_ReadDWORD(ppb, pszPropName, pdwValue);
+    if (FAILED(hr))
+        *pdwValue = dwDefaultValue;
+}
+
+static inline
+VOID WINAPI
+SHPropertyBag_ReadBOOLDef(
+    IPropertyBag *ppb,
+    LPCWSTR pszPropName,
+    LPBOOL pbValue,
+    BOOL bDefaultValue)
+{
+    HRESULT hr = SHPropertyBag_ReadBOOL(ppb, pszPropName, pbValue);
+    if (FAILED(hr))
+        *pbValue = bDefaultValue;
+}
+
+static inline
+BOOL WINAPI
+SHPropertyBag_ReadBOOLDefRet(
+    IPropertyBag *ppb,
+    LPCWSTR pszPropName,
+    BOOL bDefaultValue)
+{
+    SHPropertyBag_ReadBOOLDef(ppb, pszPropName, &bDefaultValue, bDefaultValue);
+    return bDefaultValue;
+}
+
 HWND WINAPI SHCreateWorkerWindowA(WNDPROC wndProc, HWND hWndParent, DWORD dwExStyle,
                                   DWORD dwStyle, HMENU hMenu, LONG_PTR wnd_extra);
 


### PR DESCRIPTION
## Purpose
Implementing missing features...
JIRA issue: [CORE-9283](https://jira.reactos.org/browse/CORE-9283)

## Proposed changes

- Add `SHPropertyBag_ReadIntDef`, `SHPropertyBag_ReadDWORDDef`, `SHPropertyBag_ReadBOOLDef`, `SHPropertyBag_ReadBOOLDefRet`, and `SHPropertyBag_WritePunk` helper functions.
- Add `SHPropertyBag_ReadInt` and `SHPropertyBag_WriteInt` function prototypes.