### PR TITLE
[APPLICATIONS][DEVMGR] Do not free shared icon for ShellAbout() calls

### DIFF
--- a/base/applications/calc/winmain.c
+++ b/base/applications/calc/winmain.c
@@ -1945,9 +1945,9 @@ int WINAPI _tWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPTSTR lpCmdL
                     hInstance,
                     MAKEINTRESOURCE(IDI_CALC),
                     IMAGE_ICON,
-                    GetSystemMetrics(SM_CXICON),
-                    GetSystemMetrics(SM_CYICON),
-                    0);
+                    0,
+                    0,
+                    LR_DEFAULTSIZE | LR_SHARED);
 
     calc.hSmIcon = LoadImage(
                     hInstance,
@@ -1955,7 +1955,7 @@ int WINAPI _tWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPTSTR lpCmdL
                     IMAGE_ICON,
                     GetSystemMetrics(SM_CXSMICON),
                     GetSystemMetrics(SM_CYSMICON),
-                    0);
+                    LR_SHARED);
 
     do {
         /* ignore hwnd: dialogs are already visible! */
@@ -1984,12 +1984,6 @@ int WINAPI _tWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPTSTR lpCmdL
 
         save_config();
     } while (calc.action != IDC_STATIC);
-
-    if (calc.hBgIcon != NULL)
-        DestroyIcon(calc.hBgIcon);
-
-    if (calc.hSmIcon != NULL)
-        DestroyIcon(calc.hSmIcon);
 
     stop_rpn_engine();
 

--- a/base/applications/clipbrd/clipbrd.c
+++ b/base/applications/clipbrd/clipbrd.c
@@ -248,13 +248,11 @@ static int OnCommand(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
         case CMD_ABOUT:
         {
-            HICON hIcon;
             WCHAR szTitle[MAX_STRING_LEN];
 
-            hIcon = LoadIconW(Globals.hInstance, MAKEINTRESOURCE(CLIPBRD_ICON));
             LoadStringW(Globals.hInstance, STRING_CLIPBOARD, szTitle, ARRAYSIZE(szTitle));
-            ShellAboutW(Globals.hMainWnd, szTitle, NULL, hIcon);
-            DeleteObject(hIcon);
+            ShellAboutW(Globals.hMainWnd, szTitle, NULL,
+                        LoadIconW(Globals.hInstance, MAKEINTRESOURCEW(CLIPBRD_ICON)));
             break;
         }
 

--- a/base/applications/mplay32/mplay32.c
+++ b/base/applications/mplay32/mplay32.c
@@ -1439,9 +1439,8 @@ MainWndProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lParam)
 
                 case IDM_ABOUT:
                 {
-                    HICON mplayIcon = LoadIcon(hInstance, MAKEINTRESOURCE(IDI_MAIN));
-                    ShellAbout(hwnd, szAppTitle, NULL, mplayIcon);
-                    DeleteObject(mplayIcon);
+                    ShellAbout(hwnd, szAppTitle, NULL,
+                               LoadIcon(hInstance, MAKEINTRESOURCE(IDI_MAIN)));
                     break;
                 }
 

--- a/base/applications/mscutils/eventvwr/eventvwr.c
+++ b/base/applications/mscutils/eventvwr/eventvwr.c
@@ -3640,13 +3640,11 @@ WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
                 case IDM_ABOUT:
                 {
-                    HICON hIcon;
                     WCHAR szCopyright[MAX_LOADSTRING];
 
-                    hIcon = LoadIconW(hInst, MAKEINTRESOURCEW(IDI_EVENTVWR));
                     LoadStringW(hInst, IDS_COPYRIGHT, szCopyright, ARRAYSIZE(szCopyright));
-                    ShellAboutW(hWnd, szTitle, szCopyright, hIcon);
-                    DeleteObject(hIcon);
+                    ShellAboutW(hWnd, szTitle, szCopyright,
+                                LoadIconW(hInst, MAKEINTRESOURCEW(IDI_EVENTVWR)));
                     break;
                 }
 

--- a/base/applications/mscutils/servman/mainwnd.c
+++ b/base/applications/mscutils/servman/mainwnd.c
@@ -382,7 +382,6 @@ MainWndCommand(PMAIN_WND_INFO Info,
 {
     WCHAR szAppName[256];
     WCHAR szAppAuthors[256];
-    HICON hIcon;
 
     UNREFERENCED_PARAMETER(hControl);
 
@@ -597,9 +596,8 @@ MainWndCommand(PMAIN_WND_INFO Info,
             LoadStringW(hInstance, IDS_APPNAME, szAppName, _countof(szAppName));
             LoadStringW(hInstance, IDS_APPAUTHORS, szAppAuthors, _countof(szAppAuthors));
 
-            hIcon = LoadIconW(hInstance, MAKEINTRESOURCEW(IDI_SM_ICON));
-            ShellAboutW(Info->hMainWnd, szAppName, szAppAuthors, hIcon);
-            DestroyIcon(hIcon);
+            ShellAboutW(Info->hMainWnd, szAppName, szAppAuthors,
+                        LoadIconW(hInstance, MAKEINTRESOURCEW(IDI_SM_ICON)));
         break;
 
     }

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -589,13 +589,12 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
     {
         case IDM_HELPINFO:
         {
-            HICON paintIcon = LoadIcon(g_hinstExe, MAKEINTRESOURCE(IDI_APPICON));
             TCHAR infotitle[100];
             TCHAR infotext[200];
             LoadString(g_hinstExe, IDS_INFOTITLE, infotitle, _countof(infotitle));
             LoadString(g_hinstExe, IDS_INFOTEXT, infotext, _countof(infotext));
-            ShellAbout(m_hWnd, infotitle, infotext, paintIcon);
-            DeleteObject(paintIcon);
+            ShellAbout(m_hWnd, infotitle, infotext,
+                       LoadIcon(g_hinstExe, MAKEINTRESOURCE(IDI_APPICON)));
             break;
         }
         case IDM_HELPHELPTOPICS:

--- a/base/applications/osk/main.c
+++ b/base/applications/osk/main.c
@@ -138,19 +138,14 @@ DWORD WINAPI OSK_WarningDlgThread(LPVOID lpParameter)
 VOID OSK_About(VOID)
 {
     WCHAR szAuthors[MAX_PATH];
-    HICON OSKIcon;
-
-    /* Load the icon */
-    OSKIcon = LoadImageW(Globals.hInstance, MAKEINTRESOURCEW(IDI_OSK), IMAGE_ICON, 0, 0, LR_DEFAULTSIZE);
 
     /* Load the strings into the "About" dialog */
     LoadStringW(Globals.hInstance, IDS_AUTHORS, szAuthors, _countof(szAuthors));
 
+    /* Load the icon */
     /* Finally, execute the "About" dialog by using the Shell routine */
-    ShellAboutW(Globals.hMainWnd, Globals.szTitle, szAuthors, OSKIcon);
-
-    /* Once done, destroy the icon */
-    DestroyIcon(OSKIcon);
+    ShellAboutW(Globals.hMainWnd, Globals.szTitle, szAuthors,
+                LoadImageW(Globals.hInstance, MAKEINTRESOURCEW(IDI_OSK), IMAGE_ICON, 0, 0, LR_DEFAULTSIZE | LR_SHARED));
 }
 
 /***********************************************************************

--- a/base/applications/rapps/gui.cpp
+++ b/base/applications/rapps/gui.cpp
@@ -469,13 +469,11 @@ CMainWindow::ShowAboutDlg()
 {
     CStringW szApp;
     CStringW szAuthors;
-    HICON hIcon;
 
     szApp.LoadStringW(IDS_APPTITLE);
     szAuthors.LoadStringW(IDS_APP_AUTHORS);
-    hIcon = LoadIconW(hInst, MAKEINTRESOURCEW(IDI_MAIN));
-    ShellAboutW(m_hWnd, szApp, szAuthors, hIcon);
-    DestroyIcon(hIcon);
+    ShellAboutW(m_hWnd, szApp, szAuthors,
+                LoadIconW(hInst, MAKEINTRESOURCEW(IDI_MAIN)));
 }
 
 VOID

--- a/base/applications/sndrec32/sndrec32.cpp
+++ b/base/applications/sndrec32/sndrec32.cpp
@@ -432,7 +432,6 @@ WndProc(HWND hWnd,
     HFONT oldfont;
     long long slid_samp = 0;
     WCHAR szAppName[100];
-    HICON hIcon;
 
     /* Checking for global pointers to buffer and io audio devices */
     if ((!AUD_IN) || (!AUD_OUT) || (!AUD_BUF))
@@ -598,9 +597,8 @@ WndProc(HWND hWnd,
 
                 case ID_ABOUT:
                     LoadStringW(hInst, IDS_APP_TITLE, szAppName, _countof(szAppName));
-                    hIcon = LoadIconW(hInst, MAKEINTRESOURCEW(IDI_REACTOS_SNDREC32));
-                    ShellAboutW(hWnd, szAppName, NULL, hIcon);
-                    DestroyIcon(hIcon);
+                    ShellAboutW(hWnd, szAppName, NULL,
+                                LoadIconW(hInst, MAKEINTRESOURCEW(IDI_REACTOS_SNDREC32)));
                     break;
 
                 case ID_FILE_SAVEAS:

--- a/base/applications/taskmgr/about.c
+++ b/base/applications/taskmgr/about.c
@@ -10,9 +10,8 @@
 void OnAbout(void)
 {
     WCHAR szTaskmgr[128];
-    HICON taskmgrIcon = LoadIcon(hInst, MAKEINTRESOURCE(IDI_TASKMANAGER));
 
     LoadStringW(hInst, IDS_APP_TITLE, szTaskmgr, sizeof(szTaskmgr)/sizeof(WCHAR));
-    ShellAboutW(hMainWnd, szTaskmgr, NULL, taskmgrIcon);
-    DeleteObject(taskmgrIcon);
+    ShellAboutW(hMainWnd, szTaskmgr, NULL,
+                LoadIconW(hInst, MAKEINTRESOURCEW(IDI_TASKMANAGER)));
 }

--- a/dll/win32/devmgr/devmgmt/MainWindow.cpp
+++ b/dll/win32/devmgr/devmgmt/MainWindow.cpp
@@ -653,16 +653,13 @@ CDeviceManager::OnCommand(_In_ WPARAM wParam,
         {
             CAtlStringW szAppName;
             CAtlStringW szAppAuthors;
-            HICON hIcon;
 
             if (!szAppName.LoadStringW(g_hThisInstance, IDS_APPNAME))
                 szAppName = L"ReactOS Device Manager";
             if (!szAppAuthors.LoadStringW(g_hThisInstance, IDS_APP_AUTHORS))
                 szAppAuthors = L"";
-            hIcon = LoadIconW(g_hThisInstance, MAKEINTRESOURCEW(IDI_MAIN_ICON));
-            ShellAboutW(m_hMainWnd, szAppName, szAppAuthors, hIcon);
-            if (hIcon)
-                DestroyIcon(hIcon);
+            ShellAboutW(m_hMainWnd, szAppName, szAppAuthors,
+                        LoadIconW(g_hThisInstance, MAKEINTRESOURCEW(IDI_MAIN_ICON)));
 
             // Set focus back to the treeview
             m_DeviceView->SetFocus();


### PR DESCRIPTION
## Purpose

Do not free shared icons, ReactOS ShellAbout() calls part.

JIRA issue: [CORE-18369](https://jira.reactos.org/browse/CORE-18369)

## Proposed changes

- Remove unwanted `DeleteObject()` and `DestroyIcon(()` calls.

## TODO

Wine ieframe case will be handled separately/later.