### PR TITLE
[SHELL32][SDK] Implement SHLimitInputCombo

### DIFF
--- a/dll/win32/shell32/stubs.cpp
+++ b/dll/win32/shell32/stubs.cpp
@@ -51,6 +51,10 @@ static BOOL CALLBACK _FindTheEditBox(HWND hwndEdit, LPARAM lParam)
 
 /*************************************************************************
  *  SHLimitInputCombo [SHELL32.748]
+ *
+ * Sets limits on valid characters for a combobox control.
+ * This function works like SHLimitInputEdit, but the target is a combobox
+ * instead of a textbox.
  */
 EXTERN_C BOOL
 WINAPI

--- a/dll/win32/shell32/stubs.cpp
+++ b/dll/win32/shell32/stubs.cpp
@@ -36,19 +36,6 @@ SHFindComputer(LPCITEMIDLIST pidl1, LPCITEMIDLIST pidl2)
     return FALSE;
 }
 
-struct LIMIT_INPUT_COMBO
-{
-    HRESULT hr;
-    IShellFolder *psf;
-};
-
-static BOOL CALLBACK _FindTheEditBox(HWND hwndEdit, LPARAM lParam)
-{
-    LIMIT_INPUT_COMBO *pLimitInput = (LIMIT_INPUT_COMBO *)lParam;
-    pLimitInput->hr = SHLimitInputEdit(hwndEdit, pLimitInput->psf);
-    return FALSE;
-}
-
 /*************************************************************************
  *  SHLimitInputCombo [SHELL32.748]
  *
@@ -60,9 +47,12 @@ EXTERN_C BOOL
 WINAPI
 SHLimitInputCombo(HWND hWnd, IShellFolder *psf)
 {
-    LIMIT_INPUT_COMBO LimitInput = { E_FAIL, psf };
-    EnumChildWindows(hWnd, _FindTheEditBox, (LPARAM)&LimitInput);
-    return LimitInput.hr;
+    TRACE("%p %p\n", hWnd, psf);
+    HWND hwndEdit = GetTopWindow(hWnd);
+    if (!hwndEdit)
+        return E_FAIL;
+
+    return SHLimitInputEdit(hwndEdit, psf);
 }
 
 /*

--- a/dll/win32/shell32/stubs.cpp
+++ b/dll/win32/shell32/stubs.cpp
@@ -44,7 +44,7 @@ struct LIMIT_INPUT_COMBO
 
 static BOOL CALLBACK _FindTheEditBox(HWND hwndEdit, LPARAM lParam)
 {
-    LIMIT_INPUT_COMBO *pLimitInput = (LIMIT_INPUT *)lParam;
+    LIMIT_INPUT_COMBO *pLimitInput = (LIMIT_INPUT_COMBO *)lParam;
     pLimitInput->hr = SHLimitInputEdit(hwndEdit, pLimitInput->psf);
     return FALSE;
 }

--- a/dll/win32/shell32/stubs.cpp
+++ b/dll/win32/shell32/stubs.cpp
@@ -36,15 +36,29 @@ SHFindComputer(LPCITEMIDLIST pidl1, LPCITEMIDLIST pidl2)
     return FALSE;
 }
 
-/*
- * Unimplemented
+struct LIMIT_INPUT_COMBO
+{
+    HRESULT hr;
+    IShellFolder *psf;
+};
+
+static BOOL CALLBACK _FindTheEditBox(HWND hwndEdit, LPARAM lParam)
+{
+    LIMIT_INPUT_COMBO *pLimitInput = (LIMIT_INPUT *)lParam;
+    pLimitInput->hr = SHLimitInputEdit(hwndEdit, pLimitInput->psf);
+    return FALSE;
+}
+
+/*************************************************************************
+ *  SHLimitInputCombo [SHELL32.748]
  */
 EXTERN_C BOOL
 WINAPI
-SHLimitInputCombo(HWND hWnd, LPVOID lpUnknown)
+SHLimitInputCombo(HWND hWnd, IShellFolder *psf)
 {
-    FIXME("SHLimitInputCombo() stub\n");
-    return FALSE;
+    LIMIT_INPUT_COMBO LimitInput = { E_FAIL, psf };
+    EnumChildWindows(hWnd, _FindTheEditBox, (LPARAM)&LimitInput);
+    return LimitInput.hr;
 }
 
 /*

--- a/dll/win32/shell32/stubs.cpp
+++ b/dll/win32/shell32/stubs.cpp
@@ -36,25 +36,6 @@ SHFindComputer(LPCITEMIDLIST pidl1, LPCITEMIDLIST pidl2)
     return FALSE;
 }
 
-/*************************************************************************
- *  SHLimitInputCombo [SHELL32.748]
- *
- * Sets limits on valid characters for a combobox control.
- * This function works like SHLimitInputEdit, but the target is a combobox
- * instead of a textbox.
- */
-EXTERN_C BOOL
-WINAPI
-SHLimitInputCombo(HWND hWnd, IShellFolder *psf)
-{
-    TRACE("%p %p\n", hWnd, psf);
-    HWND hwndEdit = GetTopWindow(hWnd);
-    if (!hwndEdit)
-        return E_FAIL;
-
-    return SHLimitInputEdit(hwndEdit, psf);
-}
-
 /*
  * Unimplemented
  */

--- a/dll/win32/shell32/wine/shellord.c
+++ b/dll/win32/shell32/wine/shellord.c
@@ -2824,8 +2824,7 @@ SHLimitInputEdit(HWND hWnd, IShellFolder *psf)
  * This function works like SHLimitInputEdit, but the target is a combobox
  * instead of a textbox.
  */
-EXTERN_C BOOL
-WINAPI
+HRESULT WINAPI
 SHLimitInputCombo(HWND hWnd, IShellFolder *psf)
 {
     HWND hwndEdit;

--- a/dll/win32/shell32/wine/shellord.c
+++ b/dll/win32/shell32/wine/shellord.c
@@ -2815,3 +2815,27 @@ SHLimitInputEdit(HWND hWnd, IShellFolder *psf)
 
     return hr;
 }
+
+#ifdef __REACTOS__
+/*************************************************************************
+ *  SHLimitInputCombo [SHELL32.748]
+ *
+ * Sets limits on valid characters for a combobox control.
+ * This function works like SHLimitInputEdit, but the target is a combobox
+ * instead of a textbox.
+ */
+EXTERN_C BOOL
+WINAPI
+SHLimitInputCombo(HWND hWnd, IShellFolder *psf)
+{
+    HWND hwndEdit;
+
+    TRACE("%p %p\n", hWnd, psf);
+
+    hwndEdit = GetTopWindow(hWnd);
+    if (!hwndEdit)
+        return E_FAIL;
+
+    return SHLimitInputEdit(hwndEdit, psf);
+}
+#endif

--- a/sdk/include/reactos/undocshell.h
+++ b/sdk/include/reactos/undocshell.h
@@ -644,7 +644,7 @@ BOOL WINAPI SHInitRestricted(LPCVOID unused, LPCVOID inpRegKey);
 #define SMC_EXEC 4
 INT WINAPI Shell_GetCachedImageIndex(LPCWSTR szPath, INT nIndex, UINT bSimulateDoc);
 
-BOOL WINAPI SHLimitInputCombo(HWND hWnd, IShellFolder *psf);
+HRESULT WINAPI SHLimitInputCombo(HWND hWnd, IShellFolder *psf);
 
 HRESULT WINAPI SHGetImageList(int iImageList, REFIID riid, void **ppv);
 

--- a/sdk/include/reactos/undocshell.h
+++ b/sdk/include/reactos/undocshell.h
@@ -644,6 +644,8 @@ BOOL WINAPI SHInitRestricted(LPCVOID unused, LPCVOID inpRegKey);
 #define SMC_EXEC 4
 INT WINAPI Shell_GetCachedImageIndex(LPCWSTR szPath, INT nIndex, UINT bSimulateDoc);
 
+BOOL WINAPI SHLimitInputCombo(HWND hWnd, IShellFolder *psf);
+
 HRESULT WINAPI SHGetImageList(int iImageList, REFIID riid, void **ppv);
 
 BOOL WINAPI GUIDFromStringW(


### PR DESCRIPTION
## Purpose
Implementing missing features...
JIRA issue: [CORE-9277](https://jira.reactos.org/browse/CORE-9277)

## Overview

`SHLimitInputCombo` function sets limits on valid characters for a combobox control.
This function works like `SHLimitInputEdit`, but the target is a combobox instead of a textbox.

## Proposed changes

- Implement `SHLimitInputCombo` function.
