### PR TITLE
[NTUSER] Fix SPI_SETFONTSMOOTHING behavior

### DIFF
--- a/win32ss/user/ntuser/sysparams.c
+++ b/win32ss/user/ntuser/sysparams.c
@@ -1404,7 +1404,7 @@ SpiGetSet(UINT uiAction, UINT uiParam, PVOID pvParam, FLONG fl)
             return SpiGetInt(pvParam, &gspv.bFontSmoothing, fl);
 
         case SPI_SETFONTSMOOTHING:
-            gspv.bFontSmoothing = uiParam;
+            gspv.bFontSmoothing = !!uiParam;
             if (fl & SPIF_UPDATEINIFILE)
             {
                 SpiStoreSzInt(KEY_DESKTOP, VAL_FONTSMOOTHING, gspv.bFontSmoothing ? 2 : 0);

--- a/win32ss/user/ntuser/sysparams.c
+++ b/win32ss/user/ntuser/sysparams.c
@@ -1404,10 +1404,10 @@ SpiGetSet(UINT uiAction, UINT uiParam, PVOID pvParam, FLONG fl)
             return SpiGetInt(pvParam, &gspv.bFontSmoothing, fl);
 
         case SPI_SETFONTSMOOTHING:
-            gspv.bFontSmoothing = (uiParam == 2);
+            gspv.bFontSmoothing = uiParam;
             if (fl & SPIF_UPDATEINIFILE)
             {
-                SpiStoreSz(KEY_DESKTOP, VAL_FONTSMOOTHING, (uiParam == 2) ? L"2" : L"0");
+                SpiStoreSzInt(KEY_DESKTOP, VAL_FONTSMOOTHING, gspv.bFontSmoothing ? 2 : 0);
             }
             return (UINT_PTR)KEY_DESKTOP;
 


### PR DESCRIPTION
## Purpose

Fixes the behavior of the `SPI_SETFONTSMOOTHING` system parameter. This also fixes a bug when trying to select "Use the following method to smooth edges of screen fonts" in `desk.cpl`.

JIRA issue: [CORE-19092](https://jira.reactos.org/browse/CORE-19092)

## Proposed changes
- Instead of checking if `uiParam` is equal to two, treat `uiParam` as a Boolean that sets font smoothing on or off. This is the correct behavior according to [Microsoft documentation](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-systemparametersinfow#SPI_SETFONTSMOOTHING).
- Use `SpiStoreSzInt` method instead of `SpiStoreSz` to store the value in the registry.

## TODO
- Get font smoothing working in more windows