### PR TITLE
[ATL] CImage: Hack fix for getting filter string

### DIFF
--- a/sdk/lib/atl/atlimage.h
+++ b/sdk/lib/atl/atlimage.h
@@ -811,7 +811,7 @@ public:
         DWORD dwExclude = excludeDefaultLoad,
         TCHAR chSeparator = TEXT('|'))
     {
-        CImage dummy; // Initialize common
+        CImage dummy; // HACK: Initialize common
         UINT cDecoders = 0;
         Gdiplus::ImageCodecInfo* pDecoders = _getAllDecoders(cDecoders);
         HRESULT hr = BuildCodecFilterString(pDecoders,
@@ -832,7 +832,7 @@ public:
         DWORD dwExclude = excludeDefaultSave,
         TCHAR chSeparator = TEXT('|'))
     {
-        CImage dummy; // Initialize common
+        CImage dummy; // HACK: Initialize common
         UINT cEncoders = 0;
         Gdiplus::ImageCodecInfo* pEncoders = _getAllEncoders(cEncoders);
         HRESULT hr = BuildCodecFilterString(pEncoders,
@@ -1059,7 +1059,7 @@ protected:
     // Deprecated. Don't use this
     static const GUID *FileTypeFromExtension(LPCTSTR dotext)
     {
-        CImage dummy; // Initialize common
+        CImage dummy; // HACK: Initialize common
 
         UINT cEncoders = 0;
         Gdiplus::ImageCodecInfo* pEncoders = _getAllEncoders(cEncoders);
@@ -1115,7 +1115,7 @@ protected:
     // Deprecated. Don't use this
     static bool GetClsidFromFileType(CLSID *clsid, const GUID *guid)
     {
-        CImage dummy; // Initialize common
+        CImage dummy; // HACK: Initialize common
         UINT cEncoders = 0;
         Gdiplus::ImageCodecInfo* pEncoders = _getAllEncoders(cEncoders);
         *clsid = FindCodecForFileType(*guid, pEncoders, cEncoders);

--- a/sdk/lib/atl/atlimage.h
+++ b/sdk/lib/atl/atlimage.h
@@ -1060,7 +1060,6 @@ protected:
     static const GUID *FileTypeFromExtension(LPCTSTR dotext)
     {
         CImage dummy; // HACK: Initialize common
-
         UINT cEncoders = 0;
         Gdiplus::ImageCodecInfo* pEncoders = _getAllEncoders(cEncoders);
 

--- a/sdk/lib/atl/atlimage.h
+++ b/sdk/lib/atl/atlimage.h
@@ -811,6 +811,7 @@ public:
         DWORD dwExclude = excludeDefaultLoad,
         TCHAR chSeparator = TEXT('|'))
     {
+        CImage dummy; // Initialize common
         UINT cDecoders = 0;
         Gdiplus::ImageCodecInfo* pDecoders = _getAllDecoders(cDecoders);
         HRESULT hr = BuildCodecFilterString(pDecoders,
@@ -831,6 +832,7 @@ public:
         DWORD dwExclude = excludeDefaultSave,
         TCHAR chSeparator = TEXT('|'))
     {
+        CImage dummy; // Initialize common
         UINT cEncoders = 0;
         Gdiplus::ImageCodecInfo* pEncoders = _getAllEncoders(cEncoders);
         HRESULT hr = BuildCodecFilterString(pEncoders,
@@ -1057,6 +1059,8 @@ protected:
     // Deprecated. Don't use this
     static const GUID *FileTypeFromExtension(LPCTSTR dotext)
     {
+        CImage dummy; // Initialize common
+
         UINT cEncoders = 0;
         Gdiplus::ImageCodecInfo* pEncoders = _getAllEncoders(cEncoders);
 
@@ -1111,6 +1115,7 @@ protected:
     // Deprecated. Don't use this
     static bool GetClsidFromFileType(CLSID *clsid, const GUID *guid)
     {
+        CImage dummy; // Initialize common
         UINT cEncoders = 0;
         Gdiplus::ImageCodecInfo* pEncoders = _getAllEncoders(cEncoders);
         *clsid = FindCodecForFileType(*guid, pEncoders, cEncoders);
@@ -1120,8 +1125,6 @@ protected:
 
     static Gdiplus::ImageCodecInfo* _getAllEncoders(UINT& cEncoders)
     {
-        CImage image; // Initialize common
-
         UINT total_size = 0;
         GetCommon().GetImageEncodersSize(&cEncoders, &total_size);
         if (total_size == 0)
@@ -1141,8 +1144,6 @@ protected:
 
     static Gdiplus::ImageCodecInfo* _getAllDecoders(UINT& cDecoders)
     {
-        CImage image; // Initialize common
-
         UINT total_size = 0;
         GetCommon().GetImageDecodersSize(&cDecoders, &total_size);
         if (total_size == 0)


### PR DESCRIPTION
## Purpose

Fix the crash on opening/saving file.
To retrieve the filename extension info from CODECs, we have to keep `gdiplus.dll` loaded.
The perfect fix will take time.
JIRA issue: [CORE-19093](https://jira.reactos.org/browse/CORE-19093), [CORE-19094](https://jira.reactos.org/browse/CORE-19094)

## Proposed changes

- By adding `CImage dummy` local variables, ensure keeping loaded the `gdiplus.dll`.

## TODO

- [x] Do tests.
- [ ] Make `CImage` compatible (in the future).

## Comparison

BEFORE:
![0 4 15-dev-6416-g2d7ff7e-FAILED](https://github.com/reactos/reactos/assets/2107452/cc665441-cbcc-4476-b5b2-0a8ca3b0c786)
Crashed!

AFTER:
![after](https://github.com/reactos/reactos/assets/2107452/7a9192ec-5b27-461e-b4ef-070ded1e4c3b)
Successful.