### PR TITLE
[SHELL32] Move SheRemoveQuotesA/W to iconcache.cpp

### DIFF
--- a/dll/win32/shell32/iconcache.cpp
+++ b/dll/win32/shell32/iconcache.cpp
@@ -988,6 +988,54 @@ HICON WINAPI ExtractAssociatedIconW(HINSTANCE hInst, LPWSTR lpIconPath, LPWORD l
 }
 
 /*************************************************************************
+ *                SheRemoveQuotesA (SHELL32.@)
+ */
+EXTERN_C LPSTR
+WINAPI
+SheRemoveQuotesA(LPSTR psz)
+{
+    PCHAR pch;
+
+    if (*psz == '"')
+    {
+        for (pch = psz + 1; *pch && *pch != '"'; ++pch)
+        {
+            *(pch - 1) = *pch;
+        }
+
+        if (*pch == '"')
+            *(pch - 1) = ANSI_NULL;
+    }
+
+    return psz;
+}
+
+/*************************************************************************
+ *                SheRemoveQuotesW (SHELL32.@)
+ *
+ * ExtractAssociatedIconExW uses this function.
+ */
+EXTERN_C LPWSTR
+WINAPI
+SheRemoveQuotesW(LPWSTR psz)
+{
+    PWCHAR pch;
+
+    if (*psz == L'"')
+    {
+        for (pch = psz + 1; *pch && *pch != L'"'; ++pch)
+        {
+            *(pch - 1) = *pch;
+        }
+
+        if (*pch == L'"')
+            *(pch - 1) = UNICODE_NULL;
+    }
+
+    return psz;
+}
+
+/*************************************************************************
  *                ExtractAssociatedIconExW (SHELL32.@)
  *
  * Return icon for given file (either from file itself or from associated

--- a/dll/win32/shell32/stubs.cpp
+++ b/dll/win32/shell32/stubs.cpp
@@ -440,46 +440,6 @@ SheSetCurDrive(INT iIndex)
     return 1;
 }
 
-EXTERN_C LPWSTR
-WINAPI
-SheRemoveQuotesW(LPWSTR psz)
-{
-    PWCHAR pch;
-
-    if (*psz == L'"')
-    {
-        for (pch = psz + 1; *pch && *pch != L'"'; ++pch)
-        {
-            *(pch - 1) = *pch;
-        }
-
-        if (*pch == L'"')
-            *(pch - 1) = UNICODE_NULL;
-    }
-
-    return psz;
-}
-
-EXTERN_C LPSTR
-WINAPI
-SheRemoveQuotesA(LPSTR psz)
-{
-    PCHAR pch;
-
-    if (*psz == '"')
-    {
-        for (pch = psz + 1; *pch && *pch != '"'; ++pch)
-        {
-            *(pch - 1) = *pch;
-        }
-
-        if (*pch == '"')
-            *(pch - 1) = ANSI_NULL;
-    }
-
-    return psz;
-}
-
 /*
  * Unimplemented
  */


### PR DESCRIPTION
## Purpose

Follow-up to #5517 (https://github.com/reactos/reactos/commit/358e45d33a80a8db868324cf1f477c9e24408e53). `stubs.cpp` is for stub functions only.
JIRA issue: [CORE-9277](https://jira.reactos.org/browse/CORE-9277)

## Proposed changes

- Move `SheRemoveQuotesA` and `SheRemoveQuotesW` into `iconcache.cpp`.
