### PR TITLE
[SHLWAPI][SHLWAPI_APITEST][SDK] SHCreatePropertyBagOnRegKey

### DIFF
--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -5068,6 +5068,7 @@ free_sids:
     return psd;
 }
 
+#ifndef __REACTOS__ /* See propbag.cpp */
 /***********************************************************************
  *             SHCreatePropertyBagOnRegKey [SHLWAPI.471]
  *
@@ -5093,6 +5094,7 @@ HRESULT WINAPI SHCreatePropertyBagOnRegKey (HKEY hKey, LPCWSTR subkey,
 
     return E_NOTIMPL;
 }
+#endif
 
 /***********************************************************************
  *             SHGetViewStatePropertyBag [SHLWAPI.515]

--- a/dll/win32/shlwapi/precomp.h
+++ b/dll/win32/shlwapi/precomp.h
@@ -20,7 +20,6 @@
 #include <wingdi.h>
 #include <wincon.h>
 #include <winternl.h>
-#define NO_SHLWAPI_STREAM
 #define NO_SHLWAPI_USER
 #include <shlwapi.h>
 #include <shlobj.h>

--- a/dll/win32/shlwapi/propbag.cpp
+++ b/dll/win32/shlwapi/propbag.cpp
@@ -318,7 +318,7 @@ HRESULT CRegPropertyBag::_ReadDword(LPCWSTR pszPropName, VARIANT *pvari)
 
 HRESULT CRegPropertyBag::_ReadString(LPCWSTR pszPropName, VARIANTARG *pvarg, UINT len)
 {
-    BSTR bstr = ::SysAllocStringByteLen(0, len);
+    BSTR bstr = ::SysAllocStringByteLen(NULL, len);
     V_BSTR(pvarg) = bstr;
     if (!bstr)
         return E_OUTOFMEMORY;

--- a/dll/win32/shlwapi/propbag.cpp
+++ b/dll/win32/shlwapi/propbag.cpp
@@ -300,7 +300,7 @@ HRESULT CRegPropertyBag::Init(HKEY hKey, LPCWSTR lpSubKey)
         error = ::RegOpenKeyExW(hKey, lpSubKey, 0, nAccess, &m_hKey);
 
     if (error != ERROR_SUCCESS)
-        return (LOWORD(error) | 0x80070000); // FIXME: What is 0x80070000?
+        return HRESULT_FROM_WIN32(error);
 
     return S_OK;
 }

--- a/dll/win32/shlwapi/propbag.cpp
+++ b/dll/win32/shlwapi/propbag.cpp
@@ -300,7 +300,10 @@ HRESULT CRegPropertyBag::Init(HKEY hKey, LPCWSTR lpSubKey)
         error = ::RegOpenKeyExW(hKey, lpSubKey, 0, nAccess, &m_hKey);
 
     if (error != ERROR_SUCCESS)
+    {
+        ERR("%p %s 0x%08X\n", hKey, debugstr_w(lpSubKey), error);
         return HRESULT_FROM_WIN32(error);
+    }
 
     return S_OK;
 }
@@ -576,10 +579,7 @@ SHCreatePropertyBagOnRegKey(
 
     HRESULT hr = pRegBag->Init(hKey, pszSubKey);
     if (FAILED(hr))
-    {
-        ERR("0x%08X %s\n", hr, debugstr_guid(&riid));
         return hr;
-    }
 
     hr = pRegBag->QueryInterface(riid, ppvObj);
     if (FAILED(hr))

--- a/dll/win32/shlwapi/propbag.cpp
+++ b/dll/win32/shlwapi/propbag.cpp
@@ -498,6 +498,7 @@ CRegPropertyBag::Write(_In_z_ LPCWSTR pszPropName, _In_ VARIANT *pvari)
 
             ::VariantClear(&vargTemp);
             break;
+        }
 
         case VT_UNKNOWN:
         {

--- a/dll/win32/shlwapi/propbag.cpp
+++ b/dll/win32/shlwapi/propbag.cpp
@@ -324,7 +324,7 @@ HRESULT CRegPropertyBag::_ReadString(LPCWSTR pszPropName, VARIANTARG *pvarg, UIN
         return E_OUTOFMEMORY;
 
     V_VT(pvarg) = VT_BSTR;
-    LONG error = SHGetValueW(m_hKey, NULL, pszPropName, NULL, bstr, &len);
+    LONG error = SHGetValueW(m_hKey, NULL, pszPropName, NULL, bstr, (LPDWORD)&len);
     if (error)
     {
         ::VariantClear(pvarg);

--- a/dll/win32/shlwapi/propbag.cpp
+++ b/dll/win32/shlwapi/propbag.cpp
@@ -247,11 +247,7 @@ SHCreatePropertyBagOnMemory(_In_ DWORD dwMode, _In_ REFIID riid, _Out_ void **pp
 
     CComPtr<CMemPropertyBag> pMemBag(new CMemPropertyBag(dwMode));
 
-    HRESULT hr = pMemBag->QueryInterface(riid, ppvObj);
-    if (FAILED(hr))
-        ERR("0x%08X %s\n", hr, debugstr_guid(&riid));
-
-    return hr;
+    return pMemBag->QueryInterface(riid, ppvObj);
 }
 
 class CRegPropertyBag : public CBasePropertyBag

--- a/dll/win32/shlwapi/propbag.cpp
+++ b/dll/win32/shlwapi/propbag.cpp
@@ -487,6 +487,7 @@ CRegPropertyBag::Write(_In_z_ LPCWSTR pszPropName, _In_ VARIANT *pvari)
         case VT_UI4:
         case VT_INT:
         case VT_UINT:
+        {
             hr = ::VariantChangeType(&vargTemp, pvari, 0, VT_UI4);
             if (FAILED(hr))
                 return hr;

--- a/dll/win32/shlwapi/propbag.cpp
+++ b/dll/win32/shlwapi/propbag.cpp
@@ -555,7 +555,6 @@ CRegPropertyBag::Write(_In_z_ LPCWSTR pszPropName, _In_ VARIANT *pvari)
  * @param pszSubKey  The path of the sub-key.
  * @param dwMode     The combination of STGM_READ, STGM_WRITE, STGM_READWRITE, and STGM_CREATE.
  * @param riid       Specifies either IID_IUnknown, IID_IPropertyBag or IID_IPropertyBag2.
- *                   Vista+ rejects IID_IPropertyBag2.
  * @param ppvObj     Receives an IPropertyBag pointer.
  * @return           An HRESULT value. S_OK on success, non-zero on failure.
  * @see              https://source.winehq.org/WineAPI/SHCreatePropertyBagOnRegKey.html

--- a/dll/win32/shlwapi/propbag.cpp
+++ b/dll/win32/shlwapi/propbag.cpp
@@ -51,6 +51,8 @@ public:
             *ppvObject = static_cast<IPropertyBag*>(this);
             return S_OK;
         }
+
+        ERR("%p: %s: E_NOTIMPL\n", this, debugstr_guid(&riid));
         return E_NOTIMPL;
     }
     STDMETHODIMP_(ULONG) AddRef() override
@@ -581,9 +583,5 @@ SHCreatePropertyBagOnRegKey(
     if (FAILED(hr))
         return hr;
 
-    hr = pRegBag->QueryInterface(riid, ppvObj);
-    if (FAILED(hr))
-        ERR("0x%08X %s\n", hr, debugstr_guid(&riid));
-
-    return hr;
+    return pRegBag->QueryInterface(riid, ppvObj);
 }

--- a/dll/win32/shlwapi/propbag.cpp
+++ b/dll/win32/shlwapi/propbag.cpp
@@ -251,3 +251,323 @@ SHCreatePropertyBagOnMemory(_In_ DWORD dwMode, _In_ REFIID riid, _Out_ void **pp
 
     return hr;
 }
+
+class CRegPropertyBag : public CBasePropertyBag
+{
+protected:
+    HKEY m_hKey;
+
+    HRESULT _ReadDword(LPCWSTR pszPropName, VARIANT *pvari);
+    HRESULT _ReadString(LPCWSTR pszPropName, VARIANTARG *pvarg, UINT len);
+    HRESULT _ReadBinary(LPCWSTR pszPropName, VARIANT *pvari, VARTYPE vt, DWORD uBytes);
+    HRESULT _ReadStream(VARIANT *pvari, BYTE *pInit, UINT cbInit);
+    HRESULT _CopyStreamIntoBuff(IStream *pStream, void *pv, ULONG cb);
+    HRESULT _GetStreamSize(IStream *pStream, LPDWORD pcbSize);
+    HRESULT _WriteStream(LPCWSTR pszPropName, IStream *pStream);
+
+public:
+    CRegPropertyBag(DWORD dwMode)
+        : CBasePropertyBag(dwMode)
+        , m_hKey(NULL)
+    {
+    }
+
+    ~CRegPropertyBag() override
+    {
+        if (m_hKey)
+            ::RegCloseKey(m_hKey);
+    }
+
+    HRESULT Init(HKEY hKey, LPCWSTR lpSubKey);
+
+    STDMETHODIMP Read(_In_z_ LPCWSTR pszPropName, _Inout_ VARIANT *pvari,
+                      _Inout_opt_ IErrorLog *pErrorLog) override;
+    STDMETHODIMP Write(_In_z_ LPCWSTR pszPropName, _In_ VARIANT *pvari) override;
+};
+
+HRESULT CRegPropertyBag::Init(HKEY hKey, LPCWSTR lpSubKey)
+{
+    REGSAM nAccess = 0;
+    if ((m_dwMode & (STGM_READ | STGM_WRITE | STGM_READWRITE)) != STGM_WRITE)
+        nAccess |= KEY_READ;
+    if ((m_dwMode & (STGM_READ | STGM_WRITE | STGM_READWRITE)) != STGM_READ)
+        nAccess |= KEY_WRITE;
+
+    LONG error;
+    if (m_dwMode & STGM_CREATE)
+        error = ::RegCreateKeyExW(hKey, lpSubKey, 0, NULL, 0, nAccess, NULL, &m_hKey, NULL);
+    else
+        error = ::RegOpenKeyExW(hKey, lpSubKey, 0, nAccess, &m_hKey);
+
+    if (error != ERROR_SUCCESS)
+        return (LOWORD(error) | 0x80070000); // FIXME: What is 0x80070000?
+
+    return S_OK;
+}
+
+HRESULT CRegPropertyBag::_ReadDword(LPCWSTR pszPropName, VARIANT *pvari)
+{
+    DWORD cbData = sizeof(DWORD);
+    LONG error = SHGetValueW(m_hKey, NULL, pszPropName, NULL, &V_UI4(pvari), &cbData);
+    if (error)
+        return E_FAIL;
+
+    V_VT(pvari) = VT_UI4;
+    return S_OK;
+}
+
+HRESULT CRegPropertyBag::_ReadString(LPCWSTR pszPropName, VARIANTARG *pvarg, UINT len)
+{
+    BSTR bstr = ::SysAllocStringByteLen(0, len);
+    V_BSTR(pvarg) = bstr;
+    if (!bstr)
+        return E_OUTOFMEMORY;
+
+    V_VT(pvarg) = VT_BSTR;
+    LONG error = SHGetValueW(m_hKey, NULL, pszPropName, NULL, bstr, &len);
+    if (error)
+    {
+        ::VariantClear(pvarg);
+        return E_FAIL;
+    }
+
+    return S_OK;
+}
+
+HRESULT CRegPropertyBag::_ReadStream(VARIANT *pvari, BYTE *pInit, UINT cbInit)
+{
+    IStream *pStream = SHCreateMemStream(pInit, cbInit);
+    V_UNKNOWN(pvari) = pStream;
+    if (!pStream)
+        return E_OUTOFMEMORY;
+    V_VT(pvari) = VT_UNKNOWN;
+    return S_OK;
+}
+
+HRESULT
+CRegPropertyBag::_ReadBinary(
+    LPCWSTR pszPropName,
+    VARIANT *pvari,
+    VARTYPE vt,
+    DWORD uBytes)
+{
+    HRESULT hr = E_FAIL;
+    if (vt != VT_UNKNOWN || uBytes < sizeof(GUID))
+        return hr;
+
+    LPBYTE pbData = (LPBYTE)::LocalAlloc(LMEM_ZEROINIT, uBytes);
+    if (!pbData)
+        return hr;
+
+    if (!SHGetValueW(m_hKey, NULL, pszPropName, NULL, pbData, &uBytes) &&
+        memcmp(&GUID_NULL, pbData, sizeof(GUID)) == 0)
+    {
+        hr = _ReadStream(pvari, pbData + sizeof(GUID), uBytes - sizeof(GUID));
+    }
+
+    ::LocalFree(pbData);
+
+    return hr;
+}
+
+HRESULT CRegPropertyBag::_CopyStreamIntoBuff(IStream *pStream, void *pv, ULONG cb)
+{
+    LARGE_INTEGER li;
+    li.QuadPart = 0;
+    HRESULT hr = pStream->Seek(li, 0, NULL);
+    if (FAILED(hr))
+        return hr;
+    return pStream->Read(pv, cb, NULL);
+}
+
+HRESULT CRegPropertyBag::_GetStreamSize(IStream *pStream, LPDWORD pcbSize)
+{
+    *pcbSize = 0;
+
+    ULARGE_INTEGER ui;
+    HRESULT hr = IStream_Size(pStream, &ui);
+    if (FAILED(hr))
+        return hr;
+
+    if (ui.DUMMYSTRUCTNAME.HighPart)
+        return E_FAIL; /* 64-bit value is not supported */
+
+    *pcbSize = ui.DUMMYSTRUCTNAME.LowPart;
+    return hr;
+}
+
+STDMETHODIMP
+CRegPropertyBag::Read(
+    _In_z_ LPCWSTR pszPropName,
+    _Inout_ VARIANT *pvari,
+    _Inout_opt_ IErrorLog *pErrorLog)
+{
+    if ((m_dwMode & (STGM_READ | STGM_WRITE | STGM_READWRITE)) == STGM_WRITE)
+    {
+        ::VariantInit(pvari);
+        return E_ACCESSDENIED;
+    }
+
+    VARTYPE vt = V_VT(pvari);
+    VariantInit(pvari);
+
+    HRESULT hr;
+    DWORD dwType, cbValue;
+    LONG error = SHGetValueW(m_hKey, NULL, pszPropName, &dwType, NULL, &cbValue);
+    if (error != ERROR_SUCCESS)
+        hr = E_FAIL;
+    else if (dwType == REG_SZ)
+        hr = _ReadString(pszPropName, pvari, cbValue);
+    else if (dwType == REG_BINARY)
+        hr = _ReadBinary(pszPropName, pvari, vt, cbValue);
+    else if (dwType == REG_DWORD)
+        hr = _ReadDword(pszPropName, pvari);
+    else
+        hr = E_FAIL;
+
+    if (FAILED(hr))
+    {
+        ::VariantInit(pvari);
+        return hr;
+    }
+
+    hr = ::VariantChangeTypeForRead(pvari, vt);
+    if (FAILED(hr))
+        ::VariantInit(pvari);
+
+    return hr;
+}
+
+HRESULT
+CRegPropertyBag::_WriteStream(LPCWSTR pszPropName, IStream *pStream)
+{
+    DWORD cbData;
+    HRESULT hr = _GetStreamSize(pStream, &cbData);
+    if (FAILED(hr) || !cbData)
+        return hr;
+
+    DWORD cbBinary = cbData + sizeof(GUID);
+    LPBYTE pbBinary = (LPBYTE)::LocalAlloc(LMEM_ZEROINIT, cbBinary);
+    if (!pbBinary)
+        return E_OUTOFMEMORY;
+
+    hr = _CopyStreamIntoBuff(pStream, pbBinary + sizeof(GUID), cbData);
+    if (SUCCEEDED(hr))
+    {
+        if (SHSetValueW(m_hKey, NULL, pszPropName, REG_BINARY, pbBinary, cbBinary))
+            hr = E_FAIL;
+    }
+
+    ::LocalFree(pbBinary);
+    return hr;
+}
+
+STDMETHODIMP
+CRegPropertyBag::Write(_In_z_ LPCWSTR pszPropName, _In_ VARIANT *pvari)
+{
+    if ((m_dwMode & (STGM_READ | STGM_WRITE | STGM_READWRITE)) == STGM_READ)
+        return E_ACCESSDENIED;
+
+    HRESULT hr;
+    LONG error;
+    VARIANTARG vargTemp = { 0 };
+    switch (V_VT(pvari))
+    {
+        case VT_EMPTY:
+            SHDeleteValueW(m_hKey, NULL, pszPropName);
+            hr = S_OK;
+            break;
+
+        case VT_BOOL:
+        case VT_I1:
+        case VT_I2:
+        case VT_I4:
+        case VT_UI1:
+        case VT_UI2:
+        case VT_UI4:
+        case VT_INT:
+        case VT_UINT:
+            hr = ::VariantChangeType(&vargTemp, pvari, 0, VT_UI4);
+            if (FAILED(hr))
+                return hr;
+
+            error = SHSetValueW(m_hKey, NULL, pszPropName, REG_DWORD, &V_UI4(&vargTemp), sizeof(DWORD));
+            if (error)
+                hr = E_FAIL;
+
+            ::VariantClear(&vargTemp);
+            break;
+
+        case VT_UNKNOWN:
+        {
+            CComPtr<IStream> pStream;
+            hr = V_UNKNOWN(pvari)->QueryInterface(IID_IStream, (void **)&pStream);
+            if (FAILED(hr))
+                return hr;
+
+            hr = _WriteStream(pszPropName, pStream);
+            break;
+        }
+
+        default:
+        {
+            hr = ::VariantChangeType(&vargTemp, pvari, 0, VT_BSTR);
+            if (FAILED(hr))
+                return hr;
+
+            int cch = lstrlenW(V_BSTR(&vargTemp));
+            DWORD cb = (cch + 1) * sizeof(WCHAR);
+            error = SHSetValueW(m_hKey, NULL, pszPropName, REG_SZ, V_BSTR(&vargTemp), cb);
+            if (error)
+                hr = E_FAIL;
+
+            ::VariantClear(&vargTemp);
+            break;
+        }
+    }
+
+    return hr;
+}
+
+/**************************************************************************
+ *  SHCreatePropertyBagOnRegKey (SHLWAPI.471)
+ *
+ * Creates a property bag object on registry key.
+ *
+ * @param hKey       The registry key.
+ * @param pszSubKey  The path of the sub-key.
+ * @param dwMode     The combination of STGM_READ, STGM_WRITE, STGM_READWRITE, and STGM_CREATE.
+ * @param riid       Specifies either IID_IUnknown, IID_IPropertyBag or IID_IPropertyBag2.
+ *                   Vista+ rejects IID_IPropertyBag2.
+ * @param ppvObj     Receives an IPropertyBag pointer.
+ * @return           An HRESULT value. S_OK on success, non-zero on failure.
+ * @see              https://source.winehq.org/WineAPI/SHCreatePropertyBagOnRegKey.html
+ */
+EXTERN_C HRESULT WINAPI
+SHCreatePropertyBagOnRegKey(
+    _In_ HKEY hKey,
+    _In_z_ LPCWSTR pszSubKey,
+    _In_ DWORD dwMode,
+    _In_ REFIID riid,
+    _Out_ void **ppvObj)
+{
+    TRACE("%p, %s, 0x%08X, %s, %p\n", hKey, debugstr_w(pszSubKey), dwMode,
+          debugstr_guid(&riid), ppvObj);
+
+    *ppvObj = NULL;
+
+    CComPtr<CRegPropertyBag> pRegBag(new CRegPropertyBag(dwMode));
+
+    HRESULT hr = pRegBag->Init(hKey, pszSubKey);
+    if (FAILED(hr))
+    {
+        ERR("0x%08X %s\n", hr, debugstr_guid(&riid));
+        return hr;
+    }
+
+    hr = pRegBag->QueryInterface(riid, ppvObj);
+    if (FAILED(hr))
+        ERR("0x%08X %s\n", hr, debugstr_guid(&riid));
+
+    return hr;
+}

--- a/dll/win32/shlwapi/propbag.cpp
+++ b/dll/win32/shlwapi/propbag.cpp
@@ -402,8 +402,13 @@ CRegPropertyBag::Read(
     _Inout_ VARIANT *pvari,
     _Inout_opt_ IErrorLog *pErrorLog)
 {
+    UNREFERENCED_PARAMETER(pErrorLog);
+
+    TRACE("%p: %s %p %p\n", this, debugstr_w(pszPropName), pvari, pErrorLog);
+
     if ((m_dwMode & (STGM_READ | STGM_WRITE | STGM_READWRITE)) == STGM_WRITE)
     {
+        ERR("%p: 0x%X\n", this, m_dwMode);
         ::VariantInit(pvari);
         return E_ACCESSDENIED;
     }
@@ -427,13 +432,17 @@ CRegPropertyBag::Read(
 
     if (FAILED(hr))
     {
+        ERR("%p: 0x%08X %ld: %s %p\n", this, hr, dwType, debugstr_w(pszPropName), pvari);
         ::VariantInit(pvari);
         return hr;
     }
 
     hr = ::VariantChangeTypeForRead(pvari, vt);
     if (FAILED(hr))
+    {
+        ERR("%p: 0x%08X %ld: %s %p\n", this, hr, dwType, debugstr_w(pszPropName), pvari);
         ::VariantInit(pvari);
+    }
 
     return hr;
 }
@@ -465,8 +474,13 @@ CRegPropertyBag::_WriteStream(LPCWSTR pszPropName, IStream *pStream)
 STDMETHODIMP
 CRegPropertyBag::Write(_In_z_ LPCWSTR pszPropName, _In_ VARIANT *pvari)
 {
+    TRACE("%p: %s %p\n", this, debugstr_w(pszPropName), pvari);
+
     if ((m_dwMode & (STGM_READ | STGM_WRITE | STGM_READWRITE)) == STGM_READ)
+    {
+        ERR("%p: 0x%X\n", this, m_dwMode);
         return E_ACCESSDENIED;
+    }
 
     HRESULT hr;
     LONG error;

--- a/dll/win32/shlwapi/shlwapi.spec
+++ b/dll/win32/shlwapi/shlwapi.spec
@@ -468,7 +468,7 @@
 468 stub -noname RunIndirectRegCommand
 469 stub -noname RunRegCommand
 470 stub -noname IUnknown_ProfferServiceOld
-471 stdcall -noname SHCreatePropertyBagOnRegKey(long wstr long ptr ptr)
+471 stdcall -noname SHCreatePropertyBagOnRegKey(ptr wstr long ptr ptr)
 472 stub -noname SHCreatePropertyBagOnProfileSelection
 473 stub -noname SHGetIniStringUTF7W
 474 stub -noname SHSetIniStringUTF7W

--- a/modules/rostests/apitests/shlwapi/SHPropertyBag.cpp
+++ b/modules/rostests/apitests/shlwapi/SHPropertyBag.cpp
@@ -575,8 +575,24 @@ static void SHPropertyBag_OnRegKey(void)
                                      IID_IPropertyBag2, (void **)&pPropBag);
     ok_long(hr, S_OK);
 
-    if (pPropBag)
-        pPropBag->Release();
+    // Write UI4
+    VariantInit(&vari);
+    V_VT(&vari) = VT_UI4;
+    V_UI4(&vari) = 0xDEADFACE;
+    hr = pPropBag->Write(L"Name3", &vari);
+    ok_long(hr, E_NOTIMPL);
+    VariantClear(&vari);
+
+    // Read UI4
+    VariantInit(&vari);
+    V_UI4(&vari) = 0xFEEDF00D;
+    hr = pPropBag->Read(L"Name3", &vari, NULL);
+    ok_long(hr, E_NOTIMPL);
+    ok_long(V_VT(&vari), VT_EMPTY);
+    ok_long(V_UI4(&vari), 0xFEEDF00D);
+    VariantClear(&vari);
+
+    pPropBag->Release();
 
     // Clean up
     RegDeleteKeyW(hKey, L"PropBagTest");

--- a/modules/rostests/apitests/shlwapi/SHPropertyBag.cpp
+++ b/modules/rostests/apitests/shlwapi/SHPropertyBag.cpp
@@ -478,7 +478,7 @@ static void SHPropertyBag_OnRegKey(void)
     RegDeleteKeyW(hKey, L"PropBagTest");
     hr = SHCreatePropertyBagOnRegKey(hKey, L"PropBagTest", 0,
                                      IID_IPropertyBag, (void **)&pPropBag);
-    ok_long(hr, 0x80070002);
+    ok_long(hr, HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND));
 
     // Try to create new registry key
     RegDeleteKeyW(hKey, L"PropBagTest");

--- a/modules/rostests/apitests/shlwapi/SHPropertyBag.cpp
+++ b/modules/rostests/apitests/shlwapi/SHPropertyBag.cpp
@@ -545,13 +545,21 @@ static void SHPropertyBag_OnRegKey(void)
     VariantInit(&vari);
     V_VT(&vari) = VT_EMPTY;
     hr = pPropBag->Read(L"Name4", &vari, NULL);
-    ok_long(hr, S_OK);
-    ok_long(V_VT(&vari), VT_UNKNOWN);
-    pStream = (IStream*)V_UNKNOWN(&vari);
-    FillMemory(&guid, sizeof(guid), 0xEE);
-    hr = pStream->Read(&guid, sizeof(guid), NULL);
-    ok_long(hr, S_OK);
-    ok_int(::IsEqualGUID(guid, IID_IShellLinkW), TRUE);
+    if (IsWindowsVistaOrGreater())
+    {
+        ok_long(hr, S_OK);
+        ok_long(V_VT(&vari), VT_UNKNOWN);
+        pStream = (IStream*)V_UNKNOWN(&vari);
+        FillMemory(&guid, sizeof(guid), 0xEE);
+        hr = pStream->Read(&guid, sizeof(guid), NULL);
+        ok_long(hr, S_OK);
+        ok_int(::IsEqualGUID(guid, IID_IShellLinkW), TRUE);
+    }
+    else // XP/2k3 Read is buggy
+    {
+        ok_long(hr, E_FAIL);
+        ok_long(V_VT(&vari), VT_EMPTY);
+    }
     VariantClear(&vari);
 
     pPropBag->Release();

--- a/modules/rostests/apitests/shlwapi/SHPropertyBag.cpp
+++ b/modules/rostests/apitests/shlwapi/SHPropertyBag.cpp
@@ -484,7 +484,7 @@ static void SHPropertyBag_OnRegKey(void)
     RegDeleteKeyW(hKey, L"PropBagTest");
     hr = SHCreatePropertyBagOnRegKey(hKey, L"PropBagTest", STGM_READWRITE,
                                      IID_IPropertyBag, (void **)&pPropBag);
-    ok_long(hr, 0x80070002);
+    ok_long(hr, HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND));
 
     // Create new registry key
     RegDeleteKeyW(hKey, L"PropBagTest");

--- a/modules/rostests/apitests/shlwapi/SHPropertyBag.cpp
+++ b/modules/rostests/apitests/shlwapi/SHPropertyBag.cpp
@@ -570,6 +570,14 @@ static void SHPropertyBag_OnRegKey(void)
 
     pPropBag->Release();
 
+    // Create as write-only IPropertyBag2
+    hr = SHCreatePropertyBagOnRegKey(hKey, L"PropBagTest", STGM_WRITE,
+                                     IID_IPropertyBag2, (void **)&pPropBag);
+    ok_long(hr, S_OK);
+
+    if (pPropBag)
+        pPropBag->Release();
+
     // Clean up
     RegDeleteKeyW(hKey, L"PropBagTest");
     RegCloseKey(hKey);

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -91,6 +91,7 @@ BOOL WINAPI SHExpandEnvironmentStringsForUserW(HANDLE, LPCWSTR, LPWSTR, DWORD);
 
 
 BOOL WINAPI SHIsEmptyStream(IStream*);
+HRESULT WINAPI IStream_Size(IStream *lpStream, ULARGE_INTEGER* lpulSize);
 HRESULT WINAPI SHInvokeDefaultCommand(HWND,IShellFolder*,LPCITEMIDLIST);
 HRESULT WINAPI SHPropertyBag_ReadType(IPropertyBag *ppb, LPCWSTR pszPropName, VARIANTARG *pvarg, VARTYPE vt);
 HRESULT WINAPI SHPropertyBag_ReadBOOL(IPropertyBag *ppb, LPCWSTR pszPropName, BOOL *pbValue);
@@ -125,6 +126,14 @@ HRESULT WINAPI SHPropertyBag_WritePOINTS(IPropertyBag *ppb, LPCWSTR pszPropName,
 HRESULT WINAPI SHPropertyBag_WriteRECTL(IPropertyBag *ppb, LPCWSTR pszPropName, const RECTL *prcl);
 
 HRESULT WINAPI SHCreatePropertyBagOnMemory(_In_ DWORD dwMode, _In_ REFIID riid, _Out_ void **ppvObj);
+
+HRESULT WINAPI
+SHCreatePropertyBagOnRegKey(
+    _In_ HKEY hKey,
+    _In_z_ LPCWSTR pszSubKey,
+    _In_ DWORD dwMode,
+    _In_ REFIID riid,
+    _Out_ void **ppvObj);
 
 HWND WINAPI SHCreateWorkerWindowA(WNDPROC wndProc, HWND hWndParent, DWORD dwExStyle,
                                   DWORD dwStyle, HMENU hMenu, LONG_PTR wnd_extra);


### PR DESCRIPTION
## Purpose

Follow-up to #5511. Implementing missing features...
JIRA issue: [CORE-9283](https://jira.reactos.org/browse/CORE-9283)

## Proposed changes

- Add `CRegPropertyBag` class.
- Implement `SHCreatePropertyBagOnRegKey` function by using `CRegPropertyBag`.
- Strengthen `SHPropertyBag` testcase in `shlwapi_apitest`.

## TODO

- [x] Do small tests.

## Comparison

WinXP:
![WinXP](https://github.com/reactos/reactos/assets/2107452/9ee9baae-ebaa-4952-8590-4bab84f8dc9b)
Successful.

Win2k3:
![Win2k3](https://github.com/reactos/reactos/assets/2107452/ef51c998-4cf7-4e13-85aa-9ac3f2b54450)
Successful.

Win10:
![Win10](https://github.com/reactos/reactos/assets/2107452/1706360b-1477-4b2d-b121-28ed75d169e9)
Successful.

ReactOS (AFTER):
![after](https://github.com/reactos/reactos/assets/2107452/6b4df2e5-4314-4f28-a143-b2a81f95a483)
Successful.