### PR TITLE
[REACTOS] Spelling fixes

### DIFF
--- a/base/shell/cmd/lang/cs-CZ.rc
+++ b/base/shell/cmd/lang/cs-CZ.rc
@@ -126,7 +126,7 @@ ERASE [/N /P /T /Q /S /W /Y /Z /A[[:]attributes]] file ...\n\n\
   /S    Delete file from all sub directory\n\
   /A    Select files to be deleted based on attributes.\n\
         attributes\n\
-        R     Read Only files\n\
+        R     Read-only files\n\
         S     System files\n\
         A     Archiveable files\n\
         H     Hidden Files\n\

--- a/base/shell/cmd/lang/en-US.rc
+++ b/base/shell/cmd/lang/en-US.rc
@@ -121,7 +121,7 @@ ERASE [/N /P /T /Q /S /W /Y /Z /A[[:]attributes]] file ...\n\n\
   /S    Delete file from all sub directory\n\
   /A    Select files to be deleted based on attributes.\n\
         attributes\n\
-        R     Read Only files\n\
+        R     Read-only files\n\
         S     System files\n\
         A     Archiveable files\n\
         H     Hidden Files\n\

--- a/base/shell/cmd/lang/sk-SK.rc
+++ b/base/shell/cmd/lang/sk-SK.rc
@@ -127,7 +127,7 @@ ERASE [/N /P /T /Q /S /W /Y /Z /A[[:]attributes]] file ...\n\n\
   /S    Delete file from all sub directory\n\
   /A    Select files to be deleted based on attributes.\n\
         attributes\n\
-        R     Read Only files\n\
+        R     Read-only files\n\
         S     System files\n\
         A     Archiveable files\n\
         H     Hidden Files\n\

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -3138,7 +3138,7 @@ HandleTrayContextMenu:
 
     LRESULT OnNcLButtonDblClick(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
     {
-        /* Let the clock handle the double click */
+        /* Let the clock handle the double-click */
         ::SendMessageW(m_TrayNotify, uMsg, wParam, lParam);
 
         /* We "handle" this message so users can't cause a weird maximize/restore

--- a/dll/cpl/main/mouse.c
+++ b/dll/cpl/main/mouse.c
@@ -382,7 +382,7 @@ ButtonProc(IN HWND hwndDlg,
                 /* Reset swap mouse button setting */
                 SystemParametersInfo(SPI_SETMOUSEBUTTONSWAP, pButtonData->g_OrigSwapMouseButtons, NULL, 0);
 
-                /* Reset double click speed setting */
+                /* Reset double-click speed setting */
                 SystemParametersInfo(SPI_SETDOUBLECLICKTIME, pButtonData->g_OrigDoubleClickSpeed, NULL, 0);
                 //SetDoubleClickTime(pButtonData->g_OrigDoubleClickSpeed);
             }

--- a/dll/win32/devmgr/devmgmt/DeviceView.cpp
+++ b/dll/win32/devmgr/devmgmt/DeviceView.cpp
@@ -135,7 +135,7 @@ CDeviceView::OnDoubleClick(
     GetCursorPos(&hitInfo.pt);
     ScreenToClient(m_hTreeView, &hitInfo.pt);
 
-    // Check if we are trying to double click an item
+    // Check if we are trying to double-click an item
     hItem = TreeView_HitTest(m_hTreeView, &hitInfo);
     if (hItem != NULL && (hitInfo.flags & (TVHT_ONITEM | TVHT_ONITEMICON)))
     {

--- a/dll/win32/shell32/lang/bg-BG.rc
+++ b/dll/win32/shell32/lang/bg-BG.rc
@@ -1012,7 +1012,7 @@ BEGIN
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"
     IDS_NEWEXT_NEW "<New>"
     IDS_NEWEXT_SPECIFY_EXT "You must specify an extension."
-    IDS_NEWEXT_ALREADY_ASSOC "Extension %s is already associated with File Type %s. Do you want to un-associate %s with %s and create a new File Type for it?"
+    IDS_NEWEXT_ALREADY_ASSOC "Extension %s is already associated with File Type %s. Do you want to unassociate %s with %s and create a new File Type for it?"
     IDS_NEWEXT_EXT_IN_USE "Extension is in use"
 
     IDS_REMOVE_EXT "If you remove a registered file name extension, you will not be able to open files with this extension by double-clicking their icons.\n\nAre you sure you want to remove this extension?"

--- a/dll/win32/shell32/lang/ca-ES.rc
+++ b/dll/win32/shell32/lang/ca-ES.rc
@@ -1012,7 +1012,7 @@ BEGIN
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"
     IDS_NEWEXT_NEW "<New>"
     IDS_NEWEXT_SPECIFY_EXT "You must specify an extension."
-    IDS_NEWEXT_ALREADY_ASSOC "Extension %s is already associated with File Type %s. Do you want to un-associate %s with %s and create a new File Type for it?"
+    IDS_NEWEXT_ALREADY_ASSOC "Extension %s is already associated with File Type %s. Do you want to unassociate %s with %s and create a new File Type for it?"
     IDS_NEWEXT_EXT_IN_USE "Extension is in use"
 
     IDS_REMOVE_EXT "If you remove a registered file name extension, you will not be able to open files with this extension by double-clicking their icons.\n\nAre you sure you want to remove this extension?"

--- a/dll/win32/shell32/lang/cs-CZ.rc
+++ b/dll/win32/shell32/lang/cs-CZ.rc
@@ -1018,7 +1018,7 @@ BEGIN
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"
     IDS_NEWEXT_NEW "<New>"
     IDS_NEWEXT_SPECIFY_EXT "You must specify an extension."
-    IDS_NEWEXT_ALREADY_ASSOC "Extension %s is already associated with File Type %s. Do you want to un-associate %s with %s and create a new File Type for it?"
+    IDS_NEWEXT_ALREADY_ASSOC "Extension %s is already associated with File Type %s. Do you want to unassociate %s with %s and create a new File Type for it?"
     IDS_NEWEXT_EXT_IN_USE "Extension is in use"
 
     IDS_REMOVE_EXT "If you remove a registered file name extension, you will not be able to open files with this extension by double-clicking their icons.\n\nAre you sure you want to remove this extension?"

--- a/dll/win32/shell32/lang/da-DK.rc
+++ b/dll/win32/shell32/lang/da-DK.rc
@@ -1018,7 +1018,7 @@ BEGIN
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"
     IDS_NEWEXT_NEW "<New>"
     IDS_NEWEXT_SPECIFY_EXT "You must specify an extension."
-    IDS_NEWEXT_ALREADY_ASSOC "Extension %s is already associated with File Type %s. Do you want to un-associate %s with %s and create a new File Type for it?"
+    IDS_NEWEXT_ALREADY_ASSOC "Extension %s is already associated with File Type %s. Do you want to unassociate %s with %s and create a new File Type for it?"
     IDS_NEWEXT_EXT_IN_USE "Extension is in use"
 
     IDS_REMOVE_EXT "If you remove a registered file name extension, you will not be able to open files with this extension by double-clicking their icons.\n\nAre you sure you want to remove this extension?"

--- a/dll/win32/shell32/lang/el-GR.rc
+++ b/dll/win32/shell32/lang/el-GR.rc
@@ -1012,7 +1012,7 @@ BEGIN
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"
     IDS_NEWEXT_NEW "<New>"
     IDS_NEWEXT_SPECIFY_EXT "You must specify an extension."
-    IDS_NEWEXT_ALREADY_ASSOC "Extension %s is already associated with File Type %s. Do you want to un-associate %s with %s and create a new File Type for it?"
+    IDS_NEWEXT_ALREADY_ASSOC "Extension %s is already associated with File Type %s. Do you want to unassociate %s with %s and create a new File Type for it?"
     IDS_NEWEXT_EXT_IN_USE "Extension is in use"
 
     IDS_REMOVE_EXT "If you remove a registered file name extension, you will not be able to open files with this extension by double-clicking their icons.\n\nAre you sure you want to remove this extension?"

--- a/dll/win32/shell32/lang/en-GB.rc
+++ b/dll/win32/shell32/lang/en-GB.rc
@@ -1012,7 +1012,7 @@ BEGIN
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"
     IDS_NEWEXT_NEW "<New>"
     IDS_NEWEXT_SPECIFY_EXT "You must specify an extension."
-    IDS_NEWEXT_ALREADY_ASSOC "Extension %s is already associated with File Type %s. Do you want to un-associate %s with %s and create a new File Type for it?"
+    IDS_NEWEXT_ALREADY_ASSOC "Extension %s is already associated with File Type %s. Do you want to unassociate %s with %s and create a new File Type for it?"
     IDS_NEWEXT_EXT_IN_USE "Extension is in use"
 
     IDS_REMOVE_EXT "If you remove a registered file name extension, you will not be able to open files with this extension by double-clicking their icons.\n\nAre you sure you want to remove this extension?"

--- a/dll/win32/shell32/lang/en-US.rc
+++ b/dll/win32/shell32/lang/en-US.rc
@@ -1012,7 +1012,7 @@ BEGIN
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"
     IDS_NEWEXT_NEW "<New>"
     IDS_NEWEXT_SPECIFY_EXT "You must specify an extension."
-    IDS_NEWEXT_ALREADY_ASSOC "Extension %s is already associated with File Type %s. Do you want to un-associate %s with %s and create a new File Type for it?"
+    IDS_NEWEXT_ALREADY_ASSOC "Extension %s is already associated with File Type %s. Do you want to unassociate %s with %s and create a new File Type for it?"
     IDS_NEWEXT_EXT_IN_USE "Extension is in use"
 
     IDS_REMOVE_EXT "If you remove a registered file name extension, you will not be able to open files with this extension by double-clicking their icons.\n\nAre you sure you want to remove this extension?"

--- a/dll/win32/shell32/lang/fi-FI.rc
+++ b/dll/win32/shell32/lang/fi-FI.rc
@@ -1012,7 +1012,7 @@ BEGIN
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"
     IDS_NEWEXT_NEW "<New>"
     IDS_NEWEXT_SPECIFY_EXT "You must specify an extension."
-    IDS_NEWEXT_ALREADY_ASSOC "Extension %s is already associated with File Type %s. Do you want to un-associate %s with %s and create a new File Type for it?"
+    IDS_NEWEXT_ALREADY_ASSOC "Extension %s is already associated with File Type %s. Do you want to unassociate %s with %s and create a new File Type for it?"
     IDS_NEWEXT_EXT_IN_USE "Extension is in use"
 
     IDS_REMOVE_EXT "If you remove a registered file name extension, you will not be able to open files with this extension by double-clicking their icons.\n\nAre you sure you want to remove this extension?"

--- a/dll/win32/shell32/lang/he-IL.rc
+++ b/dll/win32/shell32/lang/he-IL.rc
@@ -1014,7 +1014,7 @@ BEGIN
     IDS_NEWEXT_ADVANCED_RIGHT "&מתקדם >>"
     IDS_NEWEXT_NEW "<חדש>"
     IDS_NEWEXT_SPECIFY_EXT "עליך לציין סיומת."
-    IDS_NEWEXT_ALREADY_ASSOC "Extension %s is already associated with File Type %s. Do you want to un-associate %s with %s and create a new File Type for it?"
+    IDS_NEWEXT_ALREADY_ASSOC "Extension %s is already associated with File Type %s. Do you want to unassociate %s with %s and create a new File Type for it?"
     IDS_NEWEXT_EXT_IN_USE "סיומת בשימוש"
 
     IDS_REMOVE_EXT "If you remove a registered file name extension, you will not be able to open files with this extension by double-clicking their icons.\n\nAre you sure you want to remove this extension?"

--- a/dll/win32/shell32/lang/it-IT.rc
+++ b/dll/win32/shell32/lang/it-IT.rc
@@ -1012,7 +1012,7 @@ BEGIN
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"
     IDS_NEWEXT_NEW "<New>"
     IDS_NEWEXT_SPECIFY_EXT "You must specify an extension."
-    IDS_NEWEXT_ALREADY_ASSOC "Extension %s is already associated with File Type %s. Do you want to un-associate %s with %s and create a new File Type for it?"
+    IDS_NEWEXT_ALREADY_ASSOC "Extension %s is already associated with File Type %s. Do you want to unassociate %s with %s and create a new File Type for it?"
     IDS_NEWEXT_EXT_IN_USE "Extension is in use"
 
     IDS_REMOVE_EXT "If you remove a registered file name extension, you will not be able to open files with this extension by double-clicking their icons.\n\nAre you sure you want to remove this extension?"

--- a/dll/win32/shell32/lang/ko-KR.rc
+++ b/dll/win32/shell32/lang/ko-KR.rc
@@ -1019,7 +1019,7 @@ BEGIN
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"
     IDS_NEWEXT_NEW "<New>"
     IDS_NEWEXT_SPECIFY_EXT "You must specify an extension."
-    IDS_NEWEXT_ALREADY_ASSOC "Extension %s is already associated with File Type %s. Do you want to un-associate %s with %s and create a new File Type for it?"
+    IDS_NEWEXT_ALREADY_ASSOC "Extension %s is already associated with File Type %s. Do you want to unassociate %s with %s and create a new File Type for it?"
     IDS_NEWEXT_EXT_IN_USE "Extension is in use"
 
     IDS_REMOVE_EXT "If you remove a registered file name extension, you will not be able to open files with this extension by double-clicking their icons.\n\nAre you sure you want to remove this extension?"

--- a/dll/win32/shell32/lang/nl-NL.rc
+++ b/dll/win32/shell32/lang/nl-NL.rc
@@ -1012,7 +1012,7 @@ BEGIN
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"
     IDS_NEWEXT_NEW "<New>"
     IDS_NEWEXT_SPECIFY_EXT "You must specify an extension."
-    IDS_NEWEXT_ALREADY_ASSOC "Extension %s is already associated with File Type %s. Do you want to un-associate %s with %s and create a new File Type for it?"
+    IDS_NEWEXT_ALREADY_ASSOC "Extension %s is already associated with File Type %s. Do you want to unassociate %s with %s and create a new File Type for it?"
     IDS_NEWEXT_EXT_IN_USE "Extension is in use"
 
     IDS_REMOVE_EXT "If you remove a registered file name extension, you will not be able to open files with this extension by double-clicking their icons.\n\nAre you sure you want to remove this extension?"

--- a/dll/win32/shell32/lang/no-NO.rc
+++ b/dll/win32/shell32/lang/no-NO.rc
@@ -1012,7 +1012,7 @@ BEGIN
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"
     IDS_NEWEXT_NEW "<New>"
     IDS_NEWEXT_SPECIFY_EXT "You must specify an extension."
-    IDS_NEWEXT_ALREADY_ASSOC "Extension %s is already associated with File Type %s. Do you want to un-associate %s with %s and create a new File Type for it?"
+    IDS_NEWEXT_ALREADY_ASSOC "Extension %s is already associated with File Type %s. Do you want to unassociate %s with %s and create a new File Type for it?"
     IDS_NEWEXT_EXT_IN_USE "Extension is in use"
 
     IDS_REMOVE_EXT "If you remove a registered file name extension, you will not be able to open files with this extension by double-clicking their icons.\n\nAre you sure you want to remove this extension?"

--- a/dll/win32/shell32/lang/pt-BR.rc
+++ b/dll/win32/shell32/lang/pt-BR.rc
@@ -1012,7 +1012,7 @@ BEGIN
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"
     IDS_NEWEXT_NEW "<New>"
     IDS_NEWEXT_SPECIFY_EXT "You must specify an extension."
-    IDS_NEWEXT_ALREADY_ASSOC "Extension %s is already associated with File Type %s. Do you want to un-associate %s with %s and create a new File Type for it?"
+    IDS_NEWEXT_ALREADY_ASSOC "Extension %s is already associated with File Type %s. Do you want to unassociate %s with %s and create a new File Type for it?"
     IDS_NEWEXT_EXT_IN_USE "Extension is in use"
 
     IDS_REMOVE_EXT "If you remove a registered file name extension, you will not be able to open files with this extension by double-clicking their icons.\n\nAre you sure you want to remove this extension?"

--- a/dll/win32/shell32/lang/sk-SK.rc
+++ b/dll/win32/shell32/lang/sk-SK.rc
@@ -1012,7 +1012,7 @@ BEGIN
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"
     IDS_NEWEXT_NEW "<New>"
     IDS_NEWEXT_SPECIFY_EXT "You must specify an extension."
-    IDS_NEWEXT_ALREADY_ASSOC "Extension %s is already associated with File Type %s. Do you want to un-associate %s with %s and create a new File Type for it?"
+    IDS_NEWEXT_ALREADY_ASSOC "Extension %s is already associated with File Type %s. Do you want to unassociate %s with %s and create a new File Type for it?"
     IDS_NEWEXT_EXT_IN_USE "Extension is in use"
 
     IDS_REMOVE_EXT "If you remove a registered file name extension, you will not be able to open files with this extension by double-clicking their icons.\n\nAre you sure you want to remove this extension?"

--- a/dll/win32/shell32/lang/sl-SI.rc
+++ b/dll/win32/shell32/lang/sl-SI.rc
@@ -1012,7 +1012,7 @@ BEGIN
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"
     IDS_NEWEXT_NEW "<New>"
     IDS_NEWEXT_SPECIFY_EXT "You must specify an extension."
-    IDS_NEWEXT_ALREADY_ASSOC "Extension %s is already associated with File Type %s. Do you want to un-associate %s with %s and create a new File Type for it?"
+    IDS_NEWEXT_ALREADY_ASSOC "Extension %s is already associated with File Type %s. Do you want to unassociate %s with %s and create a new File Type for it?"
     IDS_NEWEXT_EXT_IN_USE "Extension is in use"
 
     IDS_REMOVE_EXT "If you remove a registered file name extension, you will not be able to open files with this extension by double-clicking their icons.\n\nAre you sure you want to remove this extension?"

--- a/dll/win32/shell32/lang/sq-AL.rc
+++ b/dll/win32/shell32/lang/sq-AL.rc
@@ -1016,7 +1016,7 @@ BEGIN
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"
     IDS_NEWEXT_NEW "<New>"
     IDS_NEWEXT_SPECIFY_EXT "You must specify an extension."
-    IDS_NEWEXT_ALREADY_ASSOC "Extension %s is already associated with File Type %s. Do you want to un-associate %s with %s and create a new File Type for it?"
+    IDS_NEWEXT_ALREADY_ASSOC "Extension %s is already associated with File Type %s. Do you want to unassociate %s with %s and create a new File Type for it?"
     IDS_NEWEXT_EXT_IN_USE "Extension is in use"
 
     IDS_REMOVE_EXT "If you remove a registered file name extension, you will not be able to open files with this extension by double-clicking their icons.\n\nAre you sure you want to remove this extension?"

--- a/dll/win32/shell32/lang/sv-SE.rc
+++ b/dll/win32/shell32/lang/sv-SE.rc
@@ -1012,7 +1012,7 @@ BEGIN
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"
     IDS_NEWEXT_NEW "<New>"
     IDS_NEWEXT_SPECIFY_EXT "You must specify an extension."
-    IDS_NEWEXT_ALREADY_ASSOC "Extension %s is already associated with File Type %s. Do you want to un-associate %s with %s and create a new File Type for it?"
+    IDS_NEWEXT_ALREADY_ASSOC "Extension %s is already associated with File Type %s. Do you want to unassociate %s with %s and create a new File Type for it?"
     IDS_NEWEXT_EXT_IN_USE "Extension is in use"
 
     IDS_REMOVE_EXT "If you remove a registered file name extension, you will not be able to open files with this extension by double-clicking their icons.\n\nAre you sure you want to remove this extension?"

--- a/modules/rosapps/applications/cmdutils/vfdcmd/vfdmsg.mc
+++ b/modules/rosapps/applications/cmdutils/vfdcmd/vfdmsg.mc
@@ -1226,7 +1226,7 @@ If the target drive does not have a drive letter, this command also
 assigns a local drive letter (see '%1!s!HELP LINK') using the first
 available letter.
 
-Read only files, NTFS encrypted/compressed files and ZIP compressed
+Read-only files, NTFS encrypted/compressed files and ZIP compressed
 image files (such as WinImage IMZ file) cannot be mounted directly
 and must be opened in RAM mode.
 
@@ -1374,7 +1374,7 @@ OPTIONS:
             The trailing ':' is optional.
             The drive 0 is used if not specified.
 
-  /ON       Enables the drive write protect - the drive becomes read only.
+  /ON       Enables the drive write protect - the drive becomes read-only.
 
   /OFF      Disables the drive write protect - the drive becomes writable.
 

--- a/modules/rosapps/applications/net/tsclient/rdesktop/uiports/qtewin.cpp
+++ b/modules/rosapps/applications/net/tsclient/rdesktop/uiports/qtewin.cpp
@@ -922,7 +922,7 @@ void QMyMainWindow::MemuClicked(int MenuID)
     rdp_send_input(0, RDP_INPUT_SCANCODE, RDP_KEYRELEASE, 0x1d, 0); // control
     rdp_send_input(0, RDP_INPUT_SCANCODE, RDP_KEYRELEASE, 0x38, 0); // alt
   }
-  else if (MenuID == 4) // double-click
+  else if (MenuID == 4) // double click
   {
     rdp_send_input(0, RDP_INPUT_MOUSE, MOUSE_FLAG_DOWN | MOUSE_FLAG_BUTTON1,
                    rd(c2sx(mx)), rd(c2sy(my)));

--- a/modules/rosapps/applications/net/tsclient/rdesktop/uiports/qtewin.cpp
+++ b/modules/rosapps/applications/net/tsclient/rdesktop/uiports/qtewin.cpp
@@ -922,7 +922,7 @@ void QMyMainWindow::MemuClicked(int MenuID)
     rdp_send_input(0, RDP_INPUT_SCANCODE, RDP_KEYRELEASE, 0x1d, 0); // control
     rdp_send_input(0, RDP_INPUT_SCANCODE, RDP_KEYRELEASE, 0x38, 0); // alt
   }
-  else if (MenuID == 4) // double click
+  else if (MenuID == 4) // double-click
   {
     rdp_send_input(0, RDP_INPUT_MOUSE, MOUSE_FLAG_DOWN | MOUSE_FLAG_BUTTON1,
                    rd(c2sx(mx)), rd(c2sy(my)));

--- a/sdk/include/reactos/mc/errcodes.mc
+++ b/sdk/include/reactos/mc/errcodes.mc
@@ -18781,16 +18781,16 @@ Severity=Success
 Facility=System
 SymbolicName=ERROR_WMI_READ_ONLY
 Language=English
-The WMI data item or data block is read only.
+The WMI data item or data block is read-only.
 .
 Language=Russian
-The WMI data item or data block is read only.
+The WMI data item or data block is read-only.
 .
 Language=Polish
 Element danych WMI lub blok danych są tylko do odczytu.
 .
 Language=Romanian
-The WMI data item or data block is read only.
+The WMI data item or data block is read-only.
 .
 
 MessageId=4214
@@ -21620,16 +21620,16 @@ Severity=Success
 Facility=System
 SymbolicName=ERROR_FILE_READ_ONLY
 Language=English
-The specified file is read only.
+The specified file is read-only.
 .
 Language=Russian
-The specified file is read only.
+The specified file is read-only.
 .
 Language=Polish
 Podany plik jest tylko do odczytu.
 .
 Language=Romanian
-The specified file is read only.
+The specified file is read-only.
 .
 
 MessageId=6010

--- a/sdk/include/reactos/mc/ntstatus.mc
+++ b/sdk/include/reactos/mc/ntstatus.mc
@@ -4100,7 +4100,7 @@ Severity=Error
 Facility=System
 SymbolicName=STATUS_WMI_READ_ONLY
 Language=English
-The WMI data item or data block is read only.
+The WMI data item or data block is read-only.
 .
 
 MessageId=0x2c7

--- a/sdk/lib/drivers/wdf/shared/inc/private/common/fxobject.hpp
+++ b/sdk/lib/drivers/wdf/shared/inc/private/common/fxobject.hpp
@@ -319,7 +319,7 @@ protected:
     union {
         //
         // This field is set when the object is being contructed or before
-        // Commit() and from then on is read only.
+        // Commit() and from then on is read-only.
         //
         // FxDeviceBase* is used by the core object state machine.  Derived
         // objects might need the fuller FxDevice* (and they can safely get at

--- a/sdk/lib/drivers/wdf/shared/inc/private/common/fxobject.hpp
+++ b/sdk/lib/drivers/wdf/shared/inc/private/common/fxobject.hpp
@@ -319,7 +319,7 @@ protected:
     union {
         //
         // This field is set when the object is being contructed or before
-        // Commit() and from then on is read-only.
+        // Commit() and from then on is read only.
         //
         // FxDeviceBase* is used by the core object state machine.  Derived
         // objects might need the fuller FxDevice* (and they can safely get at

--- a/win32ss/user/ntuser/msgqueue.c
+++ b/win32ss/user/ntuser/msgqueue.c
@@ -1564,7 +1564,7 @@ BOOL co_IntProcessMouseMessage(MSG* msg, BOOL* RemoveMessages, BOOL* NotForUs, L
     }
     msg->lParam = MAKELONG( pt.x, pt.y );
 
-    /* translate double clicks */
+    /* translate double-clicks */
 
     if ((msg->message == WM_LBUTTONDOWN) ||
         (msg->message == WM_RBUTTONDOWN) ||
@@ -1573,7 +1573,7 @@ BOOL co_IntProcessMouseMessage(MSG* msg, BOOL* RemoveMessages, BOOL* NotForUs, L
     {
         BOOL update = *RemoveMessages;
 
-        /* translate double clicks -
+        /* translate double-clicks -
          * note that ...MOUSEMOVEs can slip in between
          * ...BUTTONDOWN and ...BUTTONDBLCLK messages */
 
@@ -1592,7 +1592,7 @@ BOOL co_IntProcessMouseMessage(MSG* msg, BOOL* RemoveMessages, BOOL* NotForUs, L
                message += (WM_LBUTTONDBLCLK - WM_LBUTTONDOWN);
                if (update)
                {
-                   MessageQueue->msgDblClk.message = 0;  /* clear the double click conditions */
+                   MessageQueue->msgDblClk.message = 0;  /* clear the double-click conditions */
                    update = FALSE;
                }
            }
@@ -1604,7 +1604,7 @@ BOOL co_IntProcessMouseMessage(MSG* msg, BOOL* RemoveMessages, BOOL* NotForUs, L
             return FALSE;
         }
 
-        /* update static double click conditions */
+        /* update static double-click conditions */
         if (update) MessageQueue->msgDblClk = *msg;
     }
     else


### PR DESCRIPTION
## Purpose

Fix spellings for consistency in source code.
Replaces PR #5503 with a narrower scope. Checked it doesn't affect third-party files [(1)](https://github.com/reactos/reactos/blob/master/media/doc/3rd%20Party%20Files.txt),[(2)](https://github.com/reactos/reactos/blob/master/media/doc/WINESYNC.txt).

## Proposed changes

Fixes:
- Unassociate.
- Read-only.
- Double-click.