### PR TITLE
[SHELL32] Move SheRemoveQuotesA/W to utils.cpp

### DIFF
--- a/dll/win32/shell32/CMakeLists.txt
+++ b/dll/win32/shell32/CMakeLists.txt
@@ -40,6 +40,7 @@ list(APPEND SOURCE
     folders.cpp
     iconcache.cpp
     shell32.cpp
+    utils.cpp
     CShellItem.cpp
     CShellLink.cpp
     CFolderOptions.cpp

--- a/dll/win32/shell32/iconcache.cpp
+++ b/dll/win32/shell32/iconcache.cpp
@@ -988,54 +988,6 @@ HICON WINAPI ExtractAssociatedIconW(HINSTANCE hInst, LPWSTR lpIconPath, LPWORD l
 }
 
 /*************************************************************************
- *                SheRemoveQuotesA (SHELL32.@)
- */
-EXTERN_C LPSTR
-WINAPI
-SheRemoveQuotesA(LPSTR psz)
-{
-    PCHAR pch;
-
-    if (*psz == '"')
-    {
-        for (pch = psz + 1; *pch && *pch != '"'; ++pch)
-        {
-            *(pch - 1) = *pch;
-        }
-
-        if (*pch == '"')
-            *(pch - 1) = ANSI_NULL;
-    }
-
-    return psz;
-}
-
-/*************************************************************************
- *                SheRemoveQuotesW (SHELL32.@)
- *
- * ExtractAssociatedIconExW uses this function.
- */
-EXTERN_C LPWSTR
-WINAPI
-SheRemoveQuotesW(LPWSTR psz)
-{
-    PWCHAR pch;
-
-    if (*psz == L'"')
-    {
-        for (pch = psz + 1; *pch && *pch != L'"'; ++pch)
-        {
-            *(pch - 1) = *pch;
-        }
-
-        if (*pch == L'"')
-            *(pch - 1) = UNICODE_NULL;
-    }
-
-    return psz;
-}
-
-/*************************************************************************
  *                ExtractAssociatedIconExW (SHELL32.@)
  *
  * Return icon for given file (either from file itself or from associated

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -1,0 +1,54 @@
+/*
+ * PROJECT:     shell32
+ * LICENSE:     LGPL-2.1+ (https://spdx.org/licenses/LGPL-2.1+)
+ * PURPOSE:     Utility functions
+ * COPYRIGHT:   Copyright 2023 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ */
+
+/*************************************************************************
+ *                SheRemoveQuotesA (SHELL32.@)
+ */
+EXTERN_C LPSTR
+WINAPI
+SheRemoveQuotesA(LPSTR psz)
+{
+    PCHAR pch;
+
+    if (*psz == '"')
+    {
+        for (pch = psz + 1; *pch && *pch != '"'; ++pch)
+        {
+            *(pch - 1) = *pch;
+        }
+
+        if (*pch == '"')
+            *(pch - 1) = ANSI_NULL;
+    }
+
+    return psz;
+}
+
+/*************************************************************************
+ *                SheRemoveQuotesW (SHELL32.@)
+ *
+ * ExtractAssociatedIconExW uses this function.
+ */
+EXTERN_C LPWSTR
+WINAPI
+SheRemoveQuotesW(LPWSTR psz)
+{
+    PWCHAR pch;
+
+    if (*psz == L'"')
+    {
+        for (pch = psz + 1; *pch && *pch != L'"'; ++pch)
+        {
+            *(pch - 1) = *pch;
+        }
+
+        if (*pch == L'"')
+            *(pch - 1) = UNICODE_NULL;
+    }
+
+    return psz;
+}

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -5,6 +5,10 @@
  * COPYRIGHT:   Copyright 2023 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  */
 
+#include "precomp.h"
+
+WINE_DEFAULT_DEBUG_CHANNEL(shell);
+
 /*************************************************************************
  *                SheRemoveQuotesA (SHELL32.@)
  */


### PR DESCRIPTION
## Purpose
Follow-up to #5529 (7100fa8).
JIRA issue: [CORE-9277](https://jira.reactos.org/browse/CORE-9277)

## Proposed changes

- Move `SheRemoveQuotesA` and `SheRemoveQuotesW` into newly created `utils.cpp`.