### PR TITLE
[SHELL32][SDK] Implement SHCreatePropertyBag

### DIFF
--- a/dll/win32/shell32/stubs.cpp
+++ b/dll/win32/shell32/stubs.cpp
@@ -185,18 +185,6 @@ SHMultiFileProperties(IDataObject *pDataObject, DWORD dwFlags)
  */
 EXTERN_C HRESULT
 WINAPI
-SHCreatePropertyBag(REFIID refIId, LPVOID *lpUnknown)
-{
-    /* Call SHCreatePropertyBagOnMemory() from shlwapi.dll */
-    FIXME("SHCreatePropertyBag() stub\n");
-    return E_FAIL;
-}
-
-/*
- * Unimplemented
- */
-EXTERN_C HRESULT
-WINAPI
 SHCopyMonikerToTemp(IMoniker *pMoniker, LPCWSTR lpInput, LPWSTR lpOutput, INT cchMax)
 {
     /* Unimplemented in XP SP3 */

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -14,7 +14,7 @@ WINE_DEFAULT_DEBUG_CHANNEL(shell);
  */
 EXTERN_C HRESULT
 WINAPI
-SHCreatePropertyBag(REFIID riid, void **ppvObj)
+SHCreatePropertyBag(_In_ REFIID riid, _Out_ void **ppvObj)
 {
     return SHCreatePropertyBagOnMemory(STGM_READWRITE, riid, ppvObj);
 }

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -10,6 +10,16 @@
 WINE_DEFAULT_DEBUG_CHANNEL(shell);
 
 /*************************************************************************
+ *                SHCreatePropertyBag (SHELL32.715)
+ */
+EXTERN_C HRESULT
+WINAPI
+SHCreatePropertyBag(REFIID riid, void **ppvObj)
+{
+    return SHCreatePropertyBagOnMemory(STGM_READWRITE, riid, ppvObj);
+}
+
+/*************************************************************************
  *                SheRemoveQuotesA (SHELL32.@)
  */
 EXTERN_C LPSTR

--- a/sdk/include/reactos/undocshell.h
+++ b/sdk/include/reactos/undocshell.h
@@ -646,7 +646,7 @@ BOOL WINAPI SHInitRestricted(LPCVOID unused, LPCVOID inpRegKey);
 #define SMC_EXEC 4
 INT WINAPI Shell_GetCachedImageIndex(LPCWSTR szPath, INT nIndex, UINT bSimulateDoc);
 
-HRESULT WINAPI SHCreatePropertyBag(REFIID riid, void **ppvObj);
+HRESULT WINAPI SHCreatePropertyBag(_In_ REFIID riid, _Out_ void **ppvObj);
 HRESULT WINAPI SHLimitInputCombo(HWND hWnd, IShellFolder *psf);
 HRESULT WINAPI SHGetImageList(int iImageList, REFIID riid, void **ppv);
 

--- a/sdk/include/reactos/undocshell.h
+++ b/sdk/include/reactos/undocshell.h
@@ -646,8 +646,8 @@ BOOL WINAPI SHInitRestricted(LPCVOID unused, LPCVOID inpRegKey);
 #define SMC_EXEC 4
 INT WINAPI Shell_GetCachedImageIndex(LPCWSTR szPath, INT nIndex, UINT bSimulateDoc);
 
+HRESULT WINAPI SHCreatePropertyBag(REFIID riid, void **ppvObj);
 HRESULT WINAPI SHLimitInputCombo(HWND hWnd, IShellFolder *psf);
-
 HRESULT WINAPI SHGetImageList(int iImageList, REFIID riid, void **ppv);
 
 BOOL WINAPI GUIDFromStringW(


### PR DESCRIPTION
## Purpose
Implementing missing features...
JIRA issue: [CORE-9283](https://jira.reactos.org/browse/CORE-9283)

## Proposed changes

- Implement `SHCreatePropertyBag` function in `utils.cpp`.
- Add its prototype to `<undocshell.h>`.
