### PR TITLE
[USRMGR] Get text correctly even if the length is zero

### DIFF
--- a/dll/cpl/usrmgr/groupprops.c
+++ b/dll/cpl/usrmgr/groupprops.c
@@ -501,16 +501,9 @@ SetGeneralGroupData(HWND hwndDlg,
 
     /* Get the group description */
     nLength = GetWindowTextLength(GetDlgItem(hwndDlg, IDC_GROUP_GENERAL_DESCRIPTION));
-    if (nLength == 0)
-    {
-        groupInfo.lgrpi1_comment = NULL;
-    }
-    else
-    {
-        pszComment = HeapAlloc(GetProcessHeap(), 0, (nLength + 1) * sizeof(TCHAR));
-        GetDlgItemText(hwndDlg, IDC_GROUP_GENERAL_DESCRIPTION, pszComment, nLength + 1);
-        groupInfo.lgrpi1_comment = pszComment;
-    }
+    pszComment = HeapAlloc(GetProcessHeap(), 0, (nLength + 1) * sizeof(TCHAR));
+    GetDlgItemText(hwndDlg, IDC_GROUP_GENERAL_DESCRIPTION, pszComment, nLength + 1);
+    groupInfo.lgrpi1_comment = pszComment;
 
     status = NetLocalGroupSetInfo(NULL, pGroupData->szGroupName, 1, (LPBYTE)&groupInfo, &dwIndex);
     if (status != NERR_Success)

--- a/dll/cpl/usrmgr/groupprops.c
+++ b/dll/cpl/usrmgr/groupprops.c
@@ -506,8 +506,7 @@ SetGeneralGroupData(HWND hwndDlg,
         ERR("NetLocalGroupSetInfo failed. Status: %lu  Index: %lu", status, dwIndex);
     }
 
-    if (&groupInfo.lgrpi1_comment)
-        HeapFree(GetProcessHeap(), 0, &groupInfo.lgrpi1_comment);
+    HeapFree(GetProcessHeap(), 0, &groupInfo.lgrpi1_comment);
 
     return TRUE;
 }

--- a/dll/cpl/usrmgr/groupprops.c
+++ b/dll/cpl/usrmgr/groupprops.c
@@ -494,16 +494,11 @@ SetGeneralGroupData(HWND hwndDlg,
                     PGENERAL_GROUP_DATA pGroupData)
 {
     LOCALGROUP_INFO_1 groupInfo;
-    LPTSTR pszComment = NULL;
-    INT nLength;
     NET_API_STATUS status;
     DWORD dwIndex;
 
     /* Get the group description */
-    nLength = GetWindowTextLength(GetDlgItem(hwndDlg, IDC_GROUP_GENERAL_DESCRIPTION));
-    pszComment = HeapAlloc(GetProcessHeap(), 0, (nLength + 1) * sizeof(TCHAR));
-    GetDlgItemText(hwndDlg, IDC_GROUP_GENERAL_DESCRIPTION, pszComment, nLength + 1);
-    groupInfo.lgrpi1_comment = pszComment;
+    GetDlgItemTextAlloc(hwndDlg, IDC_GROUP_GENERAL_DESCRIPTION, &groupInfo.lgrpi1_comment);
 
     status = NetLocalGroupSetInfo(NULL, pGroupData->szGroupName, 1, (LPBYTE)&groupInfo, &dwIndex);
     if (status != NERR_Success)
@@ -511,8 +506,8 @@ SetGeneralGroupData(HWND hwndDlg,
         ERR("NetLocalGroupSetInfo failed. Status: %lu  Index: %lu", status, dwIndex);
     }
 
-    if (pszComment)
-        HeapFree(GetProcessHeap(), 0, pszComment);
+    if (&groupInfo.lgrpi1_comment)
+        HeapFree(GetProcessHeap(), 0, &groupInfo.lgrpi1_comment);
 
     return TRUE;
 }

--- a/dll/cpl/usrmgr/groupprops.c
+++ b/dll/cpl/usrmgr/groupprops.c
@@ -506,7 +506,7 @@ SetGeneralGroupData(HWND hwndDlg,
         ERR("NetLocalGroupSetInfo failed. Status: %lu  Index: %lu", status, dwIndex);
     }
 
-    HeapFree(GetProcessHeap(), 0, &groupInfo.lgrpi1_comment);
+    HeapFree(GetProcessHeap(), 0, groupInfo.lgrpi1_comment);
 
     return TRUE;
 }

--- a/dll/cpl/usrmgr/groupprops.c
+++ b/dll/cpl/usrmgr/groupprops.c
@@ -498,7 +498,7 @@ SetGeneralGroupData(HWND hwndDlg,
     DWORD dwIndex;
 
     /* Get the group description */
-    GetDlgItemTextAlloc(hwndDlg, IDC_GROUP_GENERAL_DESCRIPTION, &groupInfo.lgrpi1_comment);
+    groupInfo.lgrpi1_comment = GetDlgItemTextAlloc(hwndDlg, IDC_GROUP_GENERAL_DESCRIPTION);
 
     status = NetLocalGroupSetInfo(NULL, pGroupData->szGroupName, 1, (LPBYTE)&groupInfo, &dwIndex);
     if (status != NERR_Success)

--- a/dll/cpl/usrmgr/groups.c
+++ b/dll/cpl/usrmgr/groups.c
@@ -156,14 +156,10 @@ NewGroupDlgProc(HWND hwndDlg,
                     }
 
                     /* Get Name */
-                    nLength = SendDlgItemMessage(hwndDlg, IDC_GROUP_NEW_NAME, WM_GETTEXTLENGTH, 0, 0);
-                    groupInfo->lgrpi1_name = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, (nLength + 1) * sizeof(WCHAR));
-                    GetDlgItemText(hwndDlg, IDC_GROUP_NEW_NAME, groupInfo->lgrpi1_name, nLength + 1);
+                    GetDlgItemTextAlloc(hwndDlg, IDC_GROUP_NEW_NAME, &groupInfo->lgrpi1_name);
 
                     /* Get Description */
-                    nLength = SendDlgItemMessage(hwndDlg, IDC_GROUP_NEW_DESCRIPTION, WM_GETTEXTLENGTH, 0, 0);
-                    groupInfo->lgrpi1_comment = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, (nLength + 1) * sizeof(WCHAR));
-                    GetDlgItemText(hwndDlg, IDC_GROUP_NEW_DESCRIPTION, groupInfo->lgrpi1_comment, nLength + 1);
+                    GetDlgItemTextAlloc(hwndDlg, IDC_GROUP_NEW_DESCRIPTION, &groupInfo->lgrpi1_comment);
 
                     EndDialog(hwndDlg, IDOK);
                     break;

--- a/dll/cpl/usrmgr/groups.c
+++ b/dll/cpl/usrmgr/groups.c
@@ -220,11 +220,8 @@ GroupNew(HWND hwndDlg)
                              group.lgrpi1_comment);
     }
 
-    if (group.lgrpi1_name)
-        HeapFree(GetProcessHeap(), 0, group.lgrpi1_name);
-
-    if (group.lgrpi1_comment)
-        HeapFree(GetProcessHeap(), 0, group.lgrpi1_comment);
+    HeapFree(GetProcessHeap(), 0, group.lgrpi1_name);
+    HeapFree(GetProcessHeap(), 0, group.lgrpi1_comment);
 }
 
 

--- a/dll/cpl/usrmgr/groups.c
+++ b/dll/cpl/usrmgr/groups.c
@@ -155,19 +155,15 @@ NewGroupDlgProc(HWND hwndDlg,
                         break;
                     }
 
+                    /* Get Name */
                     nLength = SendDlgItemMessage(hwndDlg, IDC_GROUP_NEW_NAME, WM_GETTEXTLENGTH, 0, 0);
-                    if (nLength > 0)
-                    {
-                        groupInfo->lgrpi1_name = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, (nLength + 1) * sizeof(WCHAR));
-                        GetDlgItemText(hwndDlg, IDC_GROUP_NEW_NAME, groupInfo->lgrpi1_name, nLength + 1);
-                    }
+                    groupInfo->lgrpi1_name = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, (nLength + 1) * sizeof(WCHAR));
+                    GetDlgItemText(hwndDlg, IDC_GROUP_NEW_NAME, groupInfo->lgrpi1_name, nLength + 1);
 
+                    /* Get Description */
                     nLength = SendDlgItemMessage(hwndDlg, IDC_GROUP_NEW_DESCRIPTION, WM_GETTEXTLENGTH, 0, 0);
-                    if (nLength > 0)
-                    {
-                        groupInfo->lgrpi1_comment = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, (nLength + 1) * sizeof(WCHAR));
-                        GetDlgItemText(hwndDlg, IDC_GROUP_NEW_DESCRIPTION, groupInfo->lgrpi1_comment, nLength + 1);
-                    }
+                    groupInfo->lgrpi1_comment = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, (nLength + 1) * sizeof(WCHAR));
+                    GetDlgItemText(hwndDlg, IDC_GROUP_NEW_DESCRIPTION, groupInfo->lgrpi1_comment, nLength + 1);
 
                     EndDialog(hwndDlg, IDOK);
                     break;

--- a/dll/cpl/usrmgr/groups.c
+++ b/dll/cpl/usrmgr/groups.c
@@ -156,10 +156,10 @@ NewGroupDlgProc(HWND hwndDlg,
                     }
 
                     /* Get Name */
-                    GetDlgItemTextAlloc(hwndDlg, IDC_GROUP_NEW_NAME, &groupInfo->lgrpi1_name);
+                    groupInfo->lgrpi1_name = GetDlgItemTextAlloc(hwndDlg, IDC_GROUP_NEW_NAME);
 
                     /* Get Description */
-                    GetDlgItemTextAlloc(hwndDlg, IDC_GROUP_NEW_DESCRIPTION, &groupInfo->lgrpi1_comment);
+                    groupInfo->lgrpi1_comment = GetDlgItemTextAlloc(hwndDlg, IDC_GROUP_NEW_DESCRIPTION);
 
                     EndDialog(hwndDlg, IDOK);
                     break;

--- a/dll/cpl/usrmgr/userprops.c
+++ b/dll/cpl/usrmgr/userprops.c
@@ -128,17 +128,10 @@ SetUserProfileData(HWND hwndDlg,
         ERR("NetUserSetInfo failed. Status: %lu  Index: %lu", status, dwIndex);
     }
 
-    if (pUserInfo->usri3_profile)
-        HeapFree(GetProcessHeap(), 0, pUserInfo->usri3_profile);
-
-    if (pUserInfo->usri3_script_path)
-        HeapFree(GetProcessHeap(), 0, pUserInfo->usri3_script_path);
-
-    if (pUserInfo->usri3_home_dir)
-        HeapFree(GetProcessHeap(), 0, pUserInfo->usri3_home_dir);
-
-    if (pUserInfo->usri3_home_dir_drive)
-        HeapFree(GetProcessHeap(), 0, pUserInfo->usri3_home_dir_drive);
+    HeapFree(GetProcessHeap(), 0, pUserInfo->usri3_profile);
+    HeapFree(GetProcessHeap(), 0, pUserInfo->usri3_script_path);
+    HeapFree(GetProcessHeap(), 0, pUserInfo->usri3_home_dir);
+    HeapFree(GetProcessHeap(), 0, pUserInfo->usri3_home_dir_drive);
 
     NetApiBufferFree(pUserInfo);
 
@@ -724,11 +717,8 @@ SetUserGeneralData(HWND hwndDlg,
         ERR("NetUserSetInfo failed. Status: %lu  Index: %lu", status, dwIndex);
     }
 
-    if (pUserInfo->usri3_full_name)
-        HeapFree(GetProcessHeap(), 0, pUserInfo->usri3_full_name);
-
-    if (pUserInfo->usri3_comment)
-        HeapFree(GetProcessHeap(), 0, pUserInfo->usri3_comment);
+    HeapFree(GetProcessHeap(), 0, pUserInfo->usri3_full_name);
+    HeapFree(GetProcessHeap(), 0, pUserInfo->usri3_comment);
 
     NetApiBufferFree(pUserInfo);
 

--- a/dll/cpl/usrmgr/userprops.c
+++ b/dll/cpl/usrmgr/userprops.c
@@ -94,26 +94,26 @@ SetUserProfileData(HWND hwndDlg,
     NetUserGetInfo(NULL, pUserData->szUserName, 3, (LPBYTE*)&pUserInfo);
 
     /* Get the profile path */
-    GetDlgItemTextAlloc(hwndDlg, IDC_USER_PROFILE_PATH, &pUserInfo->usri3_profile);
+    pUserInfo->usri3_profile = GetDlgItemTextAlloc(hwndDlg, IDC_USER_PROFILE_PATH);
 
     /* Get the script path */
-    GetDlgItemTextAlloc(hwndDlg, IDC_USER_PROFILE_SCRIPT, &pUserInfo->usri3_script_path);
+    pUserInfo->usri3_script_path = GetDlgItemTextAlloc(hwndDlg, IDC_USER_PROFILE_SCRIPT);
 
     if (IsDlgButtonChecked(hwndDlg, IDC_USER_PROFILE_LOCAL) == BST_CHECKED)
     {
         /* Local home directory */
-        GetDlgItemTextAlloc(hwndDlg, IDC_USER_PROFILE_LOCAL_PATH, &pUserInfo->usri3_home_dir);
+        pUserInfo->usri3_home_dir = GetDlgItemTextAlloc(hwndDlg, IDC_USER_PROFILE_LOCAL_PATH);
     }
     else
     {
         /* Remote home directory */
-        GetDlgItemTextAlloc(hwndDlg, IDC_USER_PROFILE_REMOTE_PATH, &pUserInfo->usri3_home_dir);
+        pUserInfo->usri3_home_dir = GetDlgItemTextAlloc(hwndDlg, IDC_USER_PROFILE_REMOTE_PATH);
 
         nIndex = SendMessage(GetDlgItem(hwndDlg, IDC_USER_PROFILE_DRIVE), CB_GETCURSEL, 0, 0);
         if (nIndex != CB_ERR)
         {
-            GetComboBoxLBTextAlloc(hwndDlg, IDC_USER_PROFILE_DRIVE, nIndex,
-                                   &pUserInfo->usri3_home_dir_drive);
+            pUserInfo->usri3_home_dir_drive =
+                GetComboBoxLBTextAlloc(hwndDlg, IDC_USER_PROFILE_DRIVE, nIndex);
         }
         else
         {
@@ -713,10 +713,10 @@ SetUserGeneralData(HWND hwndDlg,
     pUserInfo->usri3_password_expired = pUserData->dwPasswordExpired;
 
     /* Get full name */
-    GetDlgItemTextAlloc(hwndDlg, IDC_USER_GENERAL_FULL_NAME, &pUserInfo->usri3_full_name);
+    pUserInfo->usri3_full_name = GetDlgItemTextAlloc(hwndDlg, IDC_USER_GENERAL_FULL_NAME);
 
     /* Get desciption */
-    GetDlgItemTextAlloc(hwndDlg, IDC_USER_GENERAL_DESCRIPTION, &pUserInfo->usri3_comment);
+    pUserInfo->usri3_comment = GetDlgItemTextAlloc(hwndDlg, IDC_USER_GENERAL_DESCRIPTION);
 
     status = NetUserSetInfo(NULL, pUserData->szUserName, 3, (LPBYTE)pUserInfo, &dwIndex);
     if (status != NERR_Success)

--- a/dll/cpl/usrmgr/userprops.c
+++ b/dll/cpl/usrmgr/userprops.c
@@ -100,59 +100,31 @@ SetUserProfileData(HWND hwndDlg,
 
     /* Get the profile path */
     nLength = GetWindowTextLength(GetDlgItem(hwndDlg, IDC_USER_PROFILE_PATH));
-    if (nLength == 0)
-    {
-        pUserInfo->usri3_profile = NULL;
-    }
-    else
-    {
-        pszProfilePath = HeapAlloc(GetProcessHeap(), 0, (nLength + 1) * sizeof(TCHAR));
-        GetDlgItemText(hwndDlg, IDC_USER_PROFILE_PATH, pszProfilePath, nLength + 1);
-        pUserInfo->usri3_profile = pszProfilePath;
-    }
+    pszProfilePath = HeapAlloc(GetProcessHeap(), 0, (nLength + 1) * sizeof(TCHAR));
+    GetDlgItemText(hwndDlg, IDC_USER_PROFILE_PATH, pszProfilePath, nLength + 1);
+    pUserInfo->usri3_profile = pszProfilePath;
 
     /* Get the script path */
     nLength = GetWindowTextLength(GetDlgItem(hwndDlg, IDC_USER_PROFILE_SCRIPT));
-    if (nLength == 0)
-    {
-        pUserInfo->usri3_script_path = NULL;
-    }
-    else
-    {
-        pszScriptPath = HeapAlloc(GetProcessHeap(), 0, (nLength + 1) * sizeof(TCHAR));
-        GetDlgItemText(hwndDlg, IDC_USER_PROFILE_SCRIPT, pszScriptPath, nLength + 1);
-        pUserInfo->usri3_script_path = pszScriptPath;
-    }
+    pszScriptPath = HeapAlloc(GetProcessHeap(), 0, (nLength + 1) * sizeof(TCHAR));
+    GetDlgItemText(hwndDlg, IDC_USER_PROFILE_SCRIPT, pszScriptPath, nLength + 1);
+    pUserInfo->usri3_script_path = pszScriptPath;
 
     if (IsDlgButtonChecked(hwndDlg, IDC_USER_PROFILE_LOCAL) == BST_CHECKED)
     {
         /* Local home directory */
         nLength = GetWindowTextLength(GetDlgItem(hwndDlg, IDC_USER_PROFILE_LOCAL_PATH));
-        if (nLength == 0)
-        {
-            pUserInfo->usri3_home_dir = NULL;
-        }
-        else
-        {
-            pszHomeDir = HeapAlloc(GetProcessHeap(), 0, (nLength + 1) * sizeof(TCHAR));
-            GetDlgItemText(hwndDlg, IDC_USER_PROFILE_LOCAL_PATH, pszHomeDir, nLength + 1);
-            pUserInfo->usri3_home_dir = pszHomeDir;
-        }
+        pszHomeDir = HeapAlloc(GetProcessHeap(), 0, (nLength + 1) * sizeof(TCHAR));
+        GetDlgItemText(hwndDlg, IDC_USER_PROFILE_LOCAL_PATH, pszHomeDir, nLength + 1);
+        pUserInfo->usri3_home_dir = pszHomeDir;
     }
     else
     {
         /* Remote home directory */
         nLength = GetWindowTextLength(GetDlgItem(hwndDlg, IDC_USER_PROFILE_REMOTE_PATH));
-        if (nLength == 0)
-        {
-            pUserInfo->usri3_home_dir = NULL;
-        }
-        else
-        {
-            pszHomeDir = HeapAlloc(GetProcessHeap(), 0, (nLength + 1) * sizeof(TCHAR));
-            GetDlgItemText(hwndDlg, IDC_USER_PROFILE_REMOTE_PATH, pszHomeDir, nLength + 1);
-            pUserInfo->usri3_home_dir = pszHomeDir;
-        }
+        pszHomeDir = HeapAlloc(GetProcessHeap(), 0, (nLength + 1) * sizeof(TCHAR));
+        GetDlgItemText(hwndDlg, IDC_USER_PROFILE_REMOTE_PATH, pszHomeDir, nLength + 1);
+        pUserInfo->usri3_home_dir = pszHomeDir;
 
         nIndex = SendMessage(GetDlgItem(hwndDlg, IDC_USER_PROFILE_DRIVE), CB_GETCURSEL, 0, 0);
         if (nIndex != CB_ERR)
@@ -757,29 +729,17 @@ SetUserGeneralData(HWND hwndDlg,
 
     pUserInfo->usri3_password_expired = pUserData->dwPasswordExpired;
 
+    /* Get full name */
     nLength = GetWindowTextLength(GetDlgItem(hwndDlg, IDC_USER_GENERAL_FULL_NAME));
-    if (nLength == 0)
-    {
-        pUserInfo->usri3_full_name = NULL;
-    }
-    else
-    {
-        pszFullName = HeapAlloc(GetProcessHeap(), 0, (nLength + 1) * sizeof(TCHAR));
-        GetDlgItemText(hwndDlg, IDC_USER_GENERAL_FULL_NAME, pszFullName, nLength + 1);
-        pUserInfo->usri3_full_name = pszFullName;
-    }
+    pszFullName = HeapAlloc(GetProcessHeap(), 0, (nLength + 1) * sizeof(TCHAR));
+    GetDlgItemText(hwndDlg, IDC_USER_GENERAL_FULL_NAME, pszFullName, nLength + 1);
+    pUserInfo->usri3_full_name = pszFullName;
 
+    /* Get desciption */
     nLength = GetWindowTextLength(GetDlgItem(hwndDlg, IDC_USER_GENERAL_DESCRIPTION));
-    if (nLength == 0)
-    {
-        pUserInfo->usri3_full_name = NULL;
-    }
-    else
-    {
-        pszComment = HeapAlloc(GetProcessHeap(), 0, (nLength + 1) * sizeof(TCHAR));
-        GetDlgItemText(hwndDlg, IDC_USER_GENERAL_DESCRIPTION, pszComment, nLength + 1);
-        pUserInfo->usri3_comment = pszComment;
-    }
+    pszComment = HeapAlloc(GetProcessHeap(), 0, (nLength + 1) * sizeof(TCHAR));
+    GetDlgItemText(hwndDlg, IDC_USER_GENERAL_DESCRIPTION, pszComment, nLength + 1);
+    pUserInfo->usri3_comment = pszComment;
 
     status = NetUserSetInfo(NULL, pUserData->szUserName, 3, (LPBYTE)pUserInfo, &dwIndex);
     if (status != NERR_Success)

--- a/dll/cpl/usrmgr/userprops.c
+++ b/dll/cpl/usrmgr/userprops.c
@@ -112,12 +112,13 @@ SetUserProfileData(HWND hwndDlg,
         nIndex = SendMessage(GetDlgItem(hwndDlg, IDC_USER_PROFILE_DRIVE), CB_GETCURSEL, 0, 0);
         if (nIndex != CB_ERR)
         {
-            GetComboBoxLBTextAlloc(hwndDlg, IDC_USER_PROFILE_DRIVE, nIndex, &pUserInfo->usri3_home_dir_drive);
+            GetComboBoxLBTextAlloc(hwndDlg, IDC_USER_PROFILE_DRIVE, nIndex,
+                                   &pUserInfo->usri3_home_dir_drive);
         }
         else
         {
-            HeapFree(GetProcessHeap(), 0, pUserInfo->usri3_home_dir_drive);
-            pUserInfo->usri3_home_dir_drive = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(TCHAR));;
+            pUserInfo->usri3_home_dir_drive = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY,
+                                                        sizeof(TCHAR));
         }
     }
 

--- a/dll/cpl/usrmgr/userprops.c
+++ b/dll/cpl/usrmgr/userprops.c
@@ -117,8 +117,8 @@ SetUserProfileData(HWND hwndDlg,
         }
         else
         {
-            pUserInfo->usri3_home_dir_drive = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY,
-                                                        sizeof(TCHAR));
+            pUserInfo->usri3_home_dir_drive =
+                HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(TCHAR));
         }
     }
 

--- a/dll/cpl/usrmgr/userprops.c
+++ b/dll/cpl/usrmgr/userprops.c
@@ -87,52 +87,37 @@ SetUserProfileData(HWND hwndDlg,
                    PPROFILE_USER_DATA pUserData)
 {
     PUSER_INFO_3 pUserInfo = NULL;
-    LPTSTR pszProfilePath = NULL;
-    LPTSTR pszScriptPath = NULL;
-    LPTSTR pszHomeDir = NULL;
-    LPTSTR pszHomeDrive = NULL;
     NET_API_STATUS status;
     DWORD dwIndex;
-    INT nLength;
     INT nIndex;
 
     NetUserGetInfo(NULL, pUserData->szUserName, 3, (LPBYTE*)&pUserInfo);
 
     /* Get the profile path */
-    nLength = GetWindowTextLength(GetDlgItem(hwndDlg, IDC_USER_PROFILE_PATH));
-    pszProfilePath = HeapAlloc(GetProcessHeap(), 0, (nLength + 1) * sizeof(TCHAR));
-    GetDlgItemText(hwndDlg, IDC_USER_PROFILE_PATH, pszProfilePath, nLength + 1);
-    pUserInfo->usri3_profile = pszProfilePath;
+    GetDlgItemTextAlloc(hwndDlg, IDC_USER_PROFILE_PATH, &pUserInfo->usri3_profile);
 
     /* Get the script path */
-    nLength = GetWindowTextLength(GetDlgItem(hwndDlg, IDC_USER_PROFILE_SCRIPT));
-    pszScriptPath = HeapAlloc(GetProcessHeap(), 0, (nLength + 1) * sizeof(TCHAR));
-    GetDlgItemText(hwndDlg, IDC_USER_PROFILE_SCRIPT, pszScriptPath, nLength + 1);
-    pUserInfo->usri3_script_path = pszScriptPath;
+    GetDlgItemTextAlloc(hwndDlg, IDC_USER_PROFILE_SCRIPT, &pUserInfo->usri3_script_path);
 
     if (IsDlgButtonChecked(hwndDlg, IDC_USER_PROFILE_LOCAL) == BST_CHECKED)
     {
         /* Local home directory */
-        nLength = GetWindowTextLength(GetDlgItem(hwndDlg, IDC_USER_PROFILE_LOCAL_PATH));
-        pszHomeDir = HeapAlloc(GetProcessHeap(), 0, (nLength + 1) * sizeof(TCHAR));
-        GetDlgItemText(hwndDlg, IDC_USER_PROFILE_LOCAL_PATH, pszHomeDir, nLength + 1);
-        pUserInfo->usri3_home_dir = pszHomeDir;
+        GetDlgItemTextAlloc(hwndDlg, IDC_USER_PROFILE_LOCAL_PATH, &pUserInfo->usri3_home_dir);
     }
     else
     {
         /* Remote home directory */
-        nLength = GetWindowTextLength(GetDlgItem(hwndDlg, IDC_USER_PROFILE_REMOTE_PATH));
-        pszHomeDir = HeapAlloc(GetProcessHeap(), 0, (nLength + 1) * sizeof(TCHAR));
-        GetDlgItemText(hwndDlg, IDC_USER_PROFILE_REMOTE_PATH, pszHomeDir, nLength + 1);
-        pUserInfo->usri3_home_dir = pszHomeDir;
+        GetDlgItemTextAlloc(hwndDlg, IDC_USER_PROFILE_REMOTE_PATH, &pUserInfo->usri3_home_dir);
 
         nIndex = SendMessage(GetDlgItem(hwndDlg, IDC_USER_PROFILE_DRIVE), CB_GETCURSEL, 0, 0);
         if (nIndex != CB_ERR)
         {
-            nLength = SendMessage(GetDlgItem(hwndDlg, IDC_USER_PROFILE_DRIVE), CB_GETLBTEXTLEN, nIndex, 0);
-            pszHomeDrive = HeapAlloc(GetProcessHeap(), 0, (nLength + 1) * sizeof(TCHAR));
-            SendMessage(GetDlgItem(hwndDlg, IDC_USER_PROFILE_DRIVE), CB_GETLBTEXT, nIndex, (LPARAM)pszHomeDrive);
-            pUserInfo->usri3_home_dir_drive = pszHomeDrive;
+            GetComboBoxLBTextAlloc(hwndDlg, IDC_USER_PROFILE_DRIVE, nIndex, &pUserInfo->usri3_home_dir_drive);
+        }
+        else
+        {
+            HeapFree(GetProcessHeap(), 0, pUserInfo->usri3_home_dir_drive);
+            pUserInfo->usri3_home_dir_drive = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(TCHAR));;
         }
     }
 
@@ -142,17 +127,17 @@ SetUserProfileData(HWND hwndDlg,
         ERR("NetUserSetInfo failed. Status: %lu  Index: %lu", status, dwIndex);
     }
 
-    if (pszProfilePath)
-        HeapFree(GetProcessHeap(), 0, pszProfilePath);
+    if (pUserInfo->usri3_profile)
+        HeapFree(GetProcessHeap(), 0, pUserInfo->usri3_profile);
 
-    if (pszScriptPath)
-        HeapFree(GetProcessHeap(), 0, pszScriptPath);
+    if (pUserInfo->usri3_script_path)
+        HeapFree(GetProcessHeap(), 0, pUserInfo->usri3_script_path);
 
-    if (pszHomeDir)
-        HeapFree(GetProcessHeap(), 0, pszHomeDir);
+    if (pUserInfo->usri3_home_dir)
+        HeapFree(GetProcessHeap(), 0, pUserInfo->usri3_home_dir);
 
-    if (pszHomeDrive)
-        HeapFree(GetProcessHeap(), 0, pszHomeDrive);
+    if (pUserInfo->usri3_home_dir_drive)
+        HeapFree(GetProcessHeap(), 0, pUserInfo->usri3_home_dir_drive);
 
     NetApiBufferFree(pUserInfo);
 
@@ -715,11 +700,8 @@ SetUserGeneralData(HWND hwndDlg,
                    PGENERAL_USER_DATA pUserData)
 {
     PUSER_INFO_3 pUserInfo = NULL;
-    LPTSTR pszFullName = NULL;
-    LPTSTR pszComment = NULL;
     NET_API_STATUS status;
     DWORD dwIndex;
-    INT nLength;
 
     NetUserGetInfo(NULL, pUserData->szUserName, 3, (LPBYTE*)&pUserInfo);
 
@@ -730,16 +712,10 @@ SetUserGeneralData(HWND hwndDlg,
     pUserInfo->usri3_password_expired = pUserData->dwPasswordExpired;
 
     /* Get full name */
-    nLength = GetWindowTextLength(GetDlgItem(hwndDlg, IDC_USER_GENERAL_FULL_NAME));
-    pszFullName = HeapAlloc(GetProcessHeap(), 0, (nLength + 1) * sizeof(TCHAR));
-    GetDlgItemText(hwndDlg, IDC_USER_GENERAL_FULL_NAME, pszFullName, nLength + 1);
-    pUserInfo->usri3_full_name = pszFullName;
+    GetDlgItemTextAlloc(hwndDlg, IDC_USER_GENERAL_FULL_NAME, &pUserInfo->usri3_full_name);
 
     /* Get desciption */
-    nLength = GetWindowTextLength(GetDlgItem(hwndDlg, IDC_USER_GENERAL_DESCRIPTION));
-    pszComment = HeapAlloc(GetProcessHeap(), 0, (nLength + 1) * sizeof(TCHAR));
-    GetDlgItemText(hwndDlg, IDC_USER_GENERAL_DESCRIPTION, pszComment, nLength + 1);
-    pUserInfo->usri3_comment = pszComment;
+    GetDlgItemTextAlloc(hwndDlg, IDC_USER_GENERAL_DESCRIPTION, &pUserInfo->usri3_comment);
 
     status = NetUserSetInfo(NULL, pUserData->szUserName, 3, (LPBYTE)pUserInfo, &dwIndex);
     if (status != NERR_Success)
@@ -747,11 +723,11 @@ SetUserGeneralData(HWND hwndDlg,
         ERR("NetUserSetInfo failed. Status: %lu  Index: %lu", status, dwIndex);
     }
 
-    if (pszFullName)
-        HeapFree(GetProcessHeap(), 0, pszFullName);
+    if (pUserInfo->usri3_full_name)
+        HeapFree(GetProcessHeap(), 0, pUserInfo->usri3_full_name);
 
-    if (pszComment)
-        HeapFree(GetProcessHeap(), 0, pszComment);
+    if (pUserInfo->usri3_comment)
+        HeapFree(GetProcessHeap(), 0, pUserInfo->usri3_comment);
 
     NetApiBufferFree(pUserInfo);
 

--- a/dll/cpl/usrmgr/users.c
+++ b/dll/cpl/usrmgr/users.c
@@ -141,8 +141,7 @@ UserChangePassword(HWND hwndDlg)
         }
     }
 
-    if (user.usri1003_password)
-        HeapFree(GetProcessHeap(), 0, user.usri1003_password);
+    HeapFree(GetProcessHeap(), 0, user.usri1003_password);
 }
 
 
@@ -325,17 +324,10 @@ UserNew(HWND hwndDlg)
                              user.usri3_comment);
     }
 
-    if (user.usri3_name)
-        HeapFree(GetProcessHeap(), 0, user.usri3_name);
-
-    if (user.usri3_full_name)
-        HeapFree(GetProcessHeap(), 0, user.usri3_full_name);
-
-    if (user.usri3_comment)
-        HeapFree(GetProcessHeap(), 0, user.usri3_comment);
-
-    if (user.usri3_password)
-        HeapFree(GetProcessHeap(), 0, user.usri3_password);
+    HeapFree(GetProcessHeap(), 0, user.usri3_name);
+    HeapFree(GetProcessHeap(), 0, user.usri3_full_name);
+    HeapFree(GetProcessHeap(), 0, user.usri3_comment);
+    HeapFree(GetProcessHeap(), 0, user.usri3_password);
 }
 
 

--- a/dll/cpl/usrmgr/users.c
+++ b/dll/cpl/usrmgr/users.c
@@ -60,7 +60,6 @@ ChangePasswordDlgProc(HWND hwndDlg,
                       LPARAM lParam)
 {
     PUSER_INFO_1003 userInfo;
-    INT nLength;
 
     UNREFERENCED_PARAMETER(wParam);
 
@@ -80,9 +79,7 @@ ChangePasswordDlgProc(HWND hwndDlg,
                     if (CheckPasswords(hwndDlg, IDC_EDIT_PASSWORD1, IDC_EDIT_PASSWORD2))
                     {
                         /* Store the password */
-                        nLength = SendDlgItemMessage(hwndDlg, IDC_EDIT_PASSWORD1, WM_GETTEXTLENGTH, 0, 0);
-                        userInfo->usri1003_password = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, (nLength + 1) * sizeof(WCHAR));
-                        GetDlgItemText(hwndDlg, IDC_EDIT_PASSWORD1, userInfo->usri1003_password, nLength + 1);
+                        GetDlgItemTextAlloc(hwndDlg, IDC_EDIT_PASSWORD1, &userInfo->usri1003_password);
 
                         EndDialog(hwndDlg, IDOK);
                     }
@@ -246,24 +243,16 @@ NewUserDlgProc(HWND hwndDlg,
                     }
 
                     /* Store the user name */
-                    nLength = SendDlgItemMessage(hwndDlg, IDC_USER_NEW_NAME, WM_GETTEXTLENGTH, 0, 0);
-                    userInfo->usri3_name = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, (nLength + 1) * sizeof(WCHAR));
-                    GetDlgItemText(hwndDlg, IDC_USER_NEW_NAME, userInfo->usri3_name, nLength + 1);
+                    GetDlgItemTextAlloc(hwndDlg, IDC_USER_NEW_NAME, &userInfo->usri3_name);
 
                     /* Store the full user name */
-                    nLength = SendDlgItemMessage(hwndDlg, IDC_USER_NEW_FULL_NAME, WM_GETTEXTLENGTH, 0, 0);
-                    userInfo->usri3_full_name = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, (nLength + 1) * sizeof(WCHAR));
-                    GetDlgItemText(hwndDlg, IDC_USER_NEW_FULL_NAME, userInfo->usri3_full_name, nLength + 1);
+                    GetDlgItemTextAlloc(hwndDlg, IDC_USER_NEW_FULL_NAME, &userInfo->usri3_full_name);
 
                     /* Store the description */
-                    nLength = SendDlgItemMessage(hwndDlg, IDC_USER_NEW_DESCRIPTION, WM_GETTEXTLENGTH, 0, 0);
-                    userInfo->usri3_comment = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, (nLength + 1) * sizeof(WCHAR));
-                    GetDlgItemText(hwndDlg, IDC_USER_NEW_DESCRIPTION, userInfo->usri3_comment, nLength + 1);
+                    GetDlgItemTextAlloc(hwndDlg, IDC_USER_NEW_DESCRIPTION, &userInfo->usri3_comment);
 
                     /* Store the password */
-                    nLength = SendDlgItemMessage(hwndDlg, IDC_USER_NEW_PASSWORD1, WM_GETTEXTLENGTH, 0, 0);
-                    userInfo->usri3_password = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, (nLength + 1) * sizeof(WCHAR));
-                    GetDlgItemText(hwndDlg, IDC_USER_NEW_PASSWORD1, userInfo->usri3_password, nLength + 1);
+                    GetDlgItemTextAlloc(hwndDlg, IDC_USER_NEW_PASSWORD1, &userInfo->usri3_password);
 
                     EndDialog(hwndDlg, IDOK);
                     break;

--- a/dll/cpl/usrmgr/users.c
+++ b/dll/cpl/usrmgr/users.c
@@ -79,7 +79,8 @@ ChangePasswordDlgProc(HWND hwndDlg,
                     if (CheckPasswords(hwndDlg, IDC_EDIT_PASSWORD1, IDC_EDIT_PASSWORD2))
                     {
                         /* Store the password */
-                        GetDlgItemTextAlloc(hwndDlg, IDC_EDIT_PASSWORD1, &userInfo->usri1003_password);
+                        userInfo->usri1003_password =
+                            GetDlgItemTextAlloc(hwndDlg, IDC_EDIT_PASSWORD1);
 
                         EndDialog(hwndDlg, IDOK);
                     }
@@ -243,16 +244,16 @@ NewUserDlgProc(HWND hwndDlg,
                     }
 
                     /* Store the user name */
-                    GetDlgItemTextAlloc(hwndDlg, IDC_USER_NEW_NAME, &userInfo->usri3_name);
+                    userInfo->usri3_name = GetDlgItemTextAlloc(hwndDlg, IDC_USER_NEW_NAME);
 
                     /* Store the full user name */
-                    GetDlgItemTextAlloc(hwndDlg, IDC_USER_NEW_FULL_NAME, &userInfo->usri3_full_name);
+                    userInfo->usri3_full_name = GetDlgItemTextAlloc(hwndDlg, IDC_USER_NEW_FULL_NAME);
 
                     /* Store the description */
-                    GetDlgItemTextAlloc(hwndDlg, IDC_USER_NEW_DESCRIPTION, &userInfo->usri3_comment);
+                    userInfo->usri3_comment = GetDlgItemTextAlloc(hwndDlg, IDC_USER_NEW_DESCRIPTION);
 
                     /* Store the password */
-                    GetDlgItemTextAlloc(hwndDlg, IDC_USER_NEW_PASSWORD1, &userInfo->usri3_password);
+                    userInfo->usri3_password = GetDlgItemTextAlloc(hwndDlg, IDC_USER_NEW_PASSWORD1);
 
                     EndDialog(hwndDlg, IDOK);
                     break;

--- a/dll/cpl/usrmgr/users.c
+++ b/dll/cpl/usrmgr/users.c
@@ -79,14 +79,10 @@ ChangePasswordDlgProc(HWND hwndDlg,
                 case IDOK:
                     if (CheckPasswords(hwndDlg, IDC_EDIT_PASSWORD1, IDC_EDIT_PASSWORD2))
                     {
-
                         /* Store the password */
                         nLength = SendDlgItemMessage(hwndDlg, IDC_EDIT_PASSWORD1, WM_GETTEXTLENGTH, 0, 0);
-                        if (nLength > 0)
-                        {
-                            userInfo->usri1003_password = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, (nLength + 1) * sizeof(WCHAR));
-                            GetDlgItemText(hwndDlg, IDC_EDIT_PASSWORD1, userInfo->usri1003_password, nLength + 1);
-                        }
+                        userInfo->usri1003_password = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, (nLength + 1) * sizeof(WCHAR));
+                        GetDlgItemText(hwndDlg, IDC_EDIT_PASSWORD1, userInfo->usri1003_password, nLength + 1);
 
                         EndDialog(hwndDlg, IDOK);
                     }
@@ -251,35 +247,23 @@ NewUserDlgProc(HWND hwndDlg,
 
                     /* Store the user name */
                     nLength = SendDlgItemMessage(hwndDlg, IDC_USER_NEW_NAME, WM_GETTEXTLENGTH, 0, 0);
-                    if (nLength > 0)
-                    {
-                        userInfo->usri3_name = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, (nLength + 1) * sizeof(WCHAR));
-                        GetDlgItemText(hwndDlg, IDC_USER_NEW_NAME, userInfo->usri3_name, nLength + 1);
-                    }
+                    userInfo->usri3_name = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, (nLength + 1) * sizeof(WCHAR));
+                    GetDlgItemText(hwndDlg, IDC_USER_NEW_NAME, userInfo->usri3_name, nLength + 1);
 
                     /* Store the full user name */
                     nLength = SendDlgItemMessage(hwndDlg, IDC_USER_NEW_FULL_NAME, WM_GETTEXTLENGTH, 0, 0);
-                    if (nLength > 0)
-                    {
-                        userInfo->usri3_full_name = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, (nLength + 1) * sizeof(WCHAR));
-                        GetDlgItemText(hwndDlg, IDC_USER_NEW_FULL_NAME, userInfo->usri3_full_name, nLength + 1);
-                    }
+                    userInfo->usri3_full_name = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, (nLength + 1) * sizeof(WCHAR));
+                    GetDlgItemText(hwndDlg, IDC_USER_NEW_FULL_NAME, userInfo->usri3_full_name, nLength + 1);
 
                     /* Store the description */
                     nLength = SendDlgItemMessage(hwndDlg, IDC_USER_NEW_DESCRIPTION, WM_GETTEXTLENGTH, 0, 0);
-                    if (nLength > 0)
-                    {
-                        userInfo->usri3_comment = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, (nLength + 1) * sizeof(WCHAR));
-                        GetDlgItemText(hwndDlg, IDC_USER_NEW_DESCRIPTION, userInfo->usri3_comment, nLength + 1);
-                    }
+                    userInfo->usri3_comment = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, (nLength + 1) * sizeof(WCHAR));
+                    GetDlgItemText(hwndDlg, IDC_USER_NEW_DESCRIPTION, userInfo->usri3_comment, nLength + 1);
 
                     /* Store the password */
                     nLength = SendDlgItemMessage(hwndDlg, IDC_USER_NEW_PASSWORD1, WM_GETTEXTLENGTH, 0, 0);
-                    if (nLength > 0)
-                    {
-                        userInfo->usri3_password = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, (nLength + 1) * sizeof(WCHAR));
-                        GetDlgItemText(hwndDlg, IDC_USER_NEW_PASSWORD1, userInfo->usri3_password, nLength + 1);
-                    }
+                    userInfo->usri3_password = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, (nLength + 1) * sizeof(WCHAR));
+                    GetDlgItemText(hwndDlg, IDC_USER_NEW_PASSWORD1, userInfo->usri3_password, nLength + 1);
 
                     EndDialog(hwndDlg, IDOK);
                     break;

--- a/dll/cpl/usrmgr/usrmgr.c
+++ b/dll/cpl/usrmgr/usrmgr.c
@@ -15,6 +15,22 @@ static LONG APIENTRY UsrmgrApplet(HWND hwnd, UINT uMsg, LPARAM wParam, LPARAM lP
 
 HINSTANCE hApplet = 0;
 
+VOID GetDlgItemTextAlloc(HWND hwndDlg, INT nDlgItem, LPTSTR *ppsz)
+{
+    INT nLength = GetWindowTextLength(GetDlgItem(hwndDlg, nDlgItem));
+    *ppsz = HeapAlloc(GetProcessHeap(), 0, (nLength + 1) * sizeof(TCHAR));
+    if (*ppsz)
+        GetDlgItemText(hwndDlg, nDlgItem, *ppsz, nLength + 1);
+}
+
+VOID GetComboBoxLBTextAlloc(HWND hwndDlg, INT nDlgItem, INT nIndex, LPTSTR *ppsz)
+{
+    INT nLength = (INT)SendDlgItemMessage(hwndDlg, nIndex, CB_GETLBTEXTLEN, nIndex, 0);
+    *ppsz = HeapAlloc(GetProcessHeap(), 0, (nLength + 1) * sizeof(TCHAR));
+    if (*ppsz)
+        SendDlgItemMessage(hwndDlg, nIndex, CB_GETLBTEXT, nIndex, (LPARAM)*ppsz);
+}
+
 /* Applets */
 APPLET Applets[NUM_APPLETS] =
 {
@@ -25,7 +41,6 @@ APPLET Applets[NUM_APPLETS] =
         UsrmgrApplet
     }
 };
-
 
 static VOID
 InitPropSheetPage(PROPSHEETPAGE *psp, WORD idDlg, DLGPROC DlgProc)

--- a/dll/cpl/usrmgr/usrmgr.c
+++ b/dll/cpl/usrmgr/usrmgr.c
@@ -26,10 +26,10 @@ VOID GetDlgItemTextAlloc(HWND hwndDlg, INT nDlgItem, LPTSTR *ppsz)
 
 VOID GetComboBoxLBTextAlloc(HWND hwndDlg, INT nDlgItem, INT nIndex, LPTSTR *ppsz)
 {
-    INT nLength = (INT)SendDlgItemMessage(hwndDlg, nIndex, CB_GETLBTEXTLEN, nIndex, 0);
+    INT nLength = (INT)SendDlgItemMessage(hwndDlg, nDlgItem, CB_GETLBTEXTLEN, nIndex, 0);
     *ppsz = HeapAlloc(GetProcessHeap(), 0, (nLength + 1) * sizeof(TCHAR));
     if (*ppsz)
-        SendDlgItemMessage(hwndDlg, nIndex, CB_GETLBTEXT, nIndex, (LPARAM)*ppsz);
+        SendDlgItemMessage(hwndDlg, nDlgItem, CB_GETLBTEXT, nIndex, (LPARAM)*ppsz);
 }
 
 /* Applets */

--- a/dll/cpl/usrmgr/usrmgr.c
+++ b/dll/cpl/usrmgr/usrmgr.c
@@ -16,20 +16,22 @@ static LONG APIENTRY UsrmgrApplet(HWND hwnd, UINT uMsg, LPARAM wParam, LPARAM lP
 
 HINSTANCE hApplet = 0;
 
-VOID GetDlgItemTextAlloc(HWND hwndDlg, INT nDlgItem, LPTSTR *ppsz)
+LPTSTR GetDlgItemTextAlloc(HWND hwndDlg, INT nDlgItem)
 {
     INT nLength = GetWindowTextLength(GetDlgItem(hwndDlg, nDlgItem));
-    *ppsz = HeapAlloc(GetProcessHeap(), 0, (nLength + 1) * sizeof(TCHAR));
-    if (*ppsz)
-        GetDlgItemText(hwndDlg, nDlgItem, *ppsz, nLength + 1);
+    LPTSTR psz = HeapAlloc(GetProcessHeap(), 0, (nLength + 1) * sizeof(TCHAR));
+    if (psz)
+        GetDlgItemText(hwndDlg, nDlgItem, psz, nLength + 1);
+    return psz;
 }
 
-VOID GetComboBoxLBTextAlloc(HWND hwndDlg, INT nDlgItem, INT nIndex, LPTSTR *ppsz)
+LPTSTR GetComboBoxLBTextAlloc(HWND hwndDlg, INT nDlgItem, INT nIndex)
 {
     INT nLength = (INT)SendDlgItemMessage(hwndDlg, nDlgItem, CB_GETLBTEXTLEN, nIndex, 0);
-    *ppsz = HeapAlloc(GetProcessHeap(), 0, (nLength + 1) * sizeof(TCHAR));
-    if (*ppsz)
-        SendDlgItemMessage(hwndDlg, nDlgItem, CB_GETLBTEXT, nIndex, (LPARAM)*ppsz);
+    LPTSTR psz = HeapAlloc(GetProcessHeap(), 0, (nLength + 1) * sizeof(TCHAR));
+    if (psz)
+        SendDlgItemMessage(hwndDlg, nDlgItem, CB_GETLBTEXT, nIndex, (LPARAM)psz);
+    return psz;
 }
 
 /* Applets */

--- a/dll/cpl/usrmgr/usrmgr.c
+++ b/dll/cpl/usrmgr/usrmgr.c
@@ -5,6 +5,7 @@
  * PURPOSE:         Main functions
  *
  * PROGRAMMERS:     Eric Kohl
+ *                  Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  */
 
 #include "usrmgr.h"

--- a/dll/cpl/usrmgr/usrmgr.h
+++ b/dll/cpl/usrmgr/usrmgr.h
@@ -39,8 +39,8 @@ INT_PTR CALLBACK UsersPageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lP
 INT_PTR CALLBACK GroupsPageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
 INT_PTR CALLBACK ExtraPageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
 
-VOID GetDlgItemTextAlloc(HWND hwndDlg, INT nDlgItem, LPTSTR *ppsz);
-VOID GetComboBoxLBTextAlloc(HWND hwndDlg, INT nDlgItem, INT nIndex, LPTSTR *ppsz);
+LPTSTR GetDlgItemTextAlloc(HWND hwndDlg, INT nDlgItem);
+LPTSTR GetComboBoxLBTextAlloc(HWND hwndDlg, INT nDlgItem, INT nIndex);
 
 /* groupprops.c */
 BOOL

--- a/dll/cpl/usrmgr/usrmgr.h
+++ b/dll/cpl/usrmgr/usrmgr.h
@@ -35,10 +35,12 @@ typedef struct _APPLET
 
 extern HINSTANCE hApplet;
 
-
 INT_PTR CALLBACK UsersPageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
 INT_PTR CALLBACK GroupsPageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
 INT_PTR CALLBACK ExtraPageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
+
+VOID GetDlgItemTextAlloc(HWND hwndDlg, INT nDlgItem, LPTSTR *ppsz);
+VOID GetComboBoxLBTextAlloc(HWND hwndDlg, INT nDlgItem, INT nIndex, LPTSTR *ppsz);
 
 /* groupprops.c */
 BOOL


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-18275](https://jira.reactos.org/browse/CORE-18275)

## Proposed changes

- Add `GetDlgItemTextAlloc` and `GetComboBoxLBTextAlloc` helper functions.
- Get the text data correctly even if the text length is zero.

## TODO

- [x] Do tests.

## Screenshots

BEFORE:
![before](https://github.com/reactos/reactos/assets/2107452/e2b234c4-2783-43a9-bcab-d6ddc73ee1b2)

AFTER:
![after](https://github.com/reactos/reactos/assets/2107452/354712d3-37fd-4a79-9bca-8e07bd397d22)