### PR TITLE
[MUP] Mute DPRINT1's that slow down shared folder accesses

### DIFF
--- a/drivers/filesystems/mup/mup.c
+++ b/drivers/filesystems/mup/mup.c
@@ -1306,7 +1306,7 @@ MupRerouteOpen(PFILE_OBJECT FileObject,
     PWSTR FullPath;
     ULONG TotalLength;
 
-    DPRINT1("Rerouting %wZ with %wZ\n", &FileObject->FileName, &UncProvider->DeviceName);
+    DPRINT("Rerouting %wZ with %wZ\n", &FileObject->FileName, &UncProvider->DeviceName);
 
     /* Get the full path name (device name first, and requested file name appended) */
     TotalLength = UncProvider->DeviceName.Length + FileObject->FileName.Length;
@@ -1778,7 +1778,7 @@ QueryPathCompletionRoutine(PDEVICE_OBJECT DeviceObject,
                 Prefix->ExternalAlloc = TRUE;
 
                 /* Insert the accepted prefix in the table of known prefixes */
-                DPRINT1("%wZ accepted %wZ\n", &Prefix->UncProvider->DeviceName, &Prefix->AcceptedPrefix);
+                DPRINT("%wZ accepted %wZ\n", &Prefix->UncProvider->DeviceName, &Prefix->AcceptedPrefix);
                 ExAcquireResourceExclusiveLite(&MupPrefixTableLock, TRUE);
                 if (RtlInsertUnicodePrefix(&MupPrefixTable, &Prefix->AcceptedPrefix, &Prefix->PrefixTableEntry))
                 {
@@ -1897,7 +1897,7 @@ CreateRedirectedFile(PIRP Irp,
         return STATUS_INVALID_DEVICE_REQUEST;
     }
 
-    DPRINT1("Request for opening: %wZ\n", &FileObject->FileName);
+    DPRINT("Request for opening: %wZ\n", &FileObject->FileName);
 
     Referenced = FALSE;
     BreakOnFirst = TRUE;
@@ -2104,7 +2104,7 @@ CreateRedirectedFile(PIRP Irp,
                     ExReleaseResourceLite(&MasterQueryContext->QueryPathListLock);
 
                     /* Query the provider !*/
-                    DPRINT1("Requesting UNC provider: %wZ\n", &UncProvider->DeviceName);
+                    DPRINT("Requesting UNC provider: %wZ\n", &UncProvider->DeviceName);
                     DPRINT("Calling: %wZ\n", &UncProvider->DeviceObject->DriverObject->DriverName);
                     Status = IoCallDriver(UncProvider->DeviceObject, QueryIrp);
                 }


### PR DESCRIPTION
## Purpose

`drivers/filesystems/mup/mup.c` generated too heavy traces. We can make it 3 times faster.

JIRA issue: [CORE-19105](https://jira.reactos.org/browse/CORE-19105)

## Proposed changes

- Make some `DPRINT1`'s `DPRINT`'s.

## TODO

- [x] Do tests.

## Movies

BEFORE:
https://github.com/reactos/reactos/assets/2107452/71121a51-4f92-43c2-9032-1316c728b03e
Too slow.

AFTER:
https://github.com/reactos/reactos/assets/2107452/751f4a05-5450-4c80-9f20-fa4fc104d438
It's faster.