### PR TITLE
[SHLWAPI][SHLWAPI_APITEST][SDK] SHGetIniStringW/SHSetIniStringW

### DIFF
--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -47,6 +47,9 @@
 #include "commdlg.h"
 #include "mlang.h"
 #include "mshtmhst.h"
+#ifdef __REACTOS__
+    #include "shlwapi_undoc.h"
+#endif
 #include "wine/unicode.h"
 #include "wine/debug.h"
 
@@ -3288,6 +3291,32 @@ BOOL WINAPI PlaySoundWrapW(LPCWSTR pszSound, HMODULE hmod, DWORD fdwSound)
 DWORD WINAPI SHGetIniStringW(LPCWSTR appName, LPCWSTR keyName, LPWSTR out,
         DWORD outLen, LPCWSTR filename)
 {
+#ifdef __REACTOS__
+    WCHAR szSection[MAX_PATH + 2];
+    WCHAR szBuffW[512];
+    CHAR szBuffA[512];
+
+    TRACE("(%s,%s,%p,%08x,%s)\n", debugstr_w(appName), debugstr_w(keyName),
+          out, outLen, debugstr_w(filename));
+
+    if (outLen == 0)
+        return 0;
+
+    lstrcpynW(szSection, appName, _countof(szSection) - 2);
+    lstrcatW(szSection, L".W");
+
+    GetPrivateProfileStringW(szSection, keyName, L"\xFFFF", szBuffW, _countof(szBuffW), filename);
+    if (szBuffW[0] == 0xFFFF)
+        return GetPrivateProfileStringW(appName, keyName, NULL, out, outLen, filename);
+
+    /* szBuffW --> szBuffA */
+    SHUnicodeToAnsiCP(CP_ACP, szBuffW, szBuffA, _countof(szBuffA));
+    szBuffA[_countof(szBuffA) - 1] = ANSI_NULL;
+
+    /* szBuffA --> out */
+    SHAnsiToUnicodeCP(CP_UTF7, szBuffA, out, outLen);
+    out[outLen - 1] = UNICODE_NULL;
+#else
     INT ret;
     WCHAR *buf;
 
@@ -3310,9 +3339,23 @@ DWORD WINAPI SHGetIniStringW(LPCWSTR appName, LPCWSTR keyName, LPWSTR out,
         *out = 0;
 
     HeapFree(GetProcessHeap(), 0, buf);
+#endif
 
     return strlenW(out);
 }
+
+#ifdef __REACTOS__
+static BOOL Is7BitClean(LPCWSTR psz)
+{
+    while (*psz)
+    {
+        if (*psz > 0x7F)
+            return FALSE;
+        ++psz;
+    }
+    return TRUE;
+}
+#endif
 
 /*************************************************************************
  *      @	[SHLWAPI.295]
@@ -3333,10 +3376,59 @@ DWORD WINAPI SHGetIniStringW(LPCWSTR appName, LPCWSTR keyName, LPWSTR out,
 BOOL WINAPI SHSetIniStringW(LPCWSTR appName, LPCWSTR keyName, LPCWSTR str,
         LPCWSTR filename)
 {
+#ifdef __REACTOS__
+    WCHAR szSection[MAX_PATH + 2];
+    WCHAR szBuffW[512];
+    CHAR szBuffA[512];
+
+    TRACE("(%s, %p, %s, %s)\n", debugstr_w(appName), keyName, debugstr_w(str),
+          debugstr_w(filename));
+
+    if (!WritePrivateProfileStringW(appName, keyName, str, filename))
+        return FALSE;
+
+    if (!str || Is7BitClean(str))
+    {
+        /* Delete .A */
+        lstrcpynW(szSection, appName, _countof(szSection) - 2);
+        lstrcatW(szSection, L".A");
+        WritePrivateProfileStringW(szSection, keyName, NULL, filename);
+
+        /* Delete .W */
+        lstrcpynW(szSection, appName, _countof(szSection) - 2);
+        lstrcatW(szSection, L".W");
+        WritePrivateProfileStringW(szSection, keyName, NULL, filename);
+
+        return TRUE;
+    }
+
+    /* str --> szBuffA */
+    SHUnicodeToAnsiCP(CP_UTF7, str, szBuffA, _countof(szBuffA));
+    szBuffA[_countof(szBuffA) - 1] = ANSI_NULL;
+
+    /* szBuffA --> szBuffW */
+    SHAnsiToUnicodeCP(CP_ACP, szBuffA, szBuffW, _countof(szBuffW));
+    szBuffW[_countof(szBuffW) - 1] = UNICODE_NULL;
+
+    /* Write .A */
+    lstrcpynW(szSection, appName, _countof(szSection) - 2);
+    lstrcatW(szSection, L".A");
+    if (!WritePrivateProfileStringW(szSection, keyName, str, filename))
+        return FALSE;
+
+    /* Write .W */
+    lstrcpynW(szSection, appName, _countof(szSection) - 2);
+    lstrcatW(szSection, L".W");
+    if (!WritePrivateProfileStringW(szSection, keyName, szBuffW, filename))
+        return FALSE;
+
+    return TRUE;
+#else
     TRACE("(%s, %p, %s, %s)\n", debugstr_w(appName), keyName, debugstr_w(str),
             debugstr_w(filename));
 
     return WritePrivateProfileStringW(appName, keyName, str, filename);
+#endif
 }
 
 /*************************************************************************

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -3408,7 +3408,7 @@ BOOL WINAPI SHSetIniStringW(LPCWSTR appName, LPCWSTR keyName, LPCWSTR str,
         return TRUE;
     }
 
-    /* This is not 7-bit clean. It needs UTF-7 encoding.
+    /* This is not 7-bit clean. It needs UTF-7 encoding in UTF-16.
        We write ".A" and ".W"-appended sections. */
 
     /* str --> szBuffA */

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -3408,7 +3408,7 @@ BOOL WINAPI SHSetIniStringW(LPCWSTR appName, LPCWSTR keyName, LPCWSTR str,
         return TRUE;
     }
 
-    /* Now str was not 7-bit clean. It needs UTF-7 encoding in UTF-16.
+    /* Now str is not 7-bit clean. It needs UTF-7 encoding in UTF-16.
        We write ".A" and ".W"-appended sections. */
 
     /* str --> szBuffA */

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -3389,7 +3389,7 @@ BOOL WINAPI SHSetIniStringW(LPCWSTR appName, LPCWSTR keyName, LPCWSTR str,
     TRACE("(%s, %p, %s, %s)\n", debugstr_w(appName), keyName, debugstr_w(str),
           debugstr_w(filename));
 
-    /* Write a normal profile string. If str was empty, then key will be deleted */
+    /* Write a normal profile string. If str was `NULL`, then key will be deleted */
     if (!WritePrivateProfileStringW(appName, keyName, str, filename))
         return FALSE;
 

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -3408,7 +3408,7 @@ BOOL WINAPI SHSetIniStringW(LPCWSTR appName, LPCWSTR keyName, LPCWSTR str,
         return TRUE;
     }
 
-    /* This is not 7-bit clean. It needs UTF-7 encoding in UTF-16.
+    /* str is not 7-bit clean. It needs UTF-7 encoding in UTF-16.
        We write ".A" and ".W"-appended sections. */
 
     /* str --> szBuffA */

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -48,7 +48,7 @@
 #include "mlang.h"
 #include "mshtmhst.h"
 #ifdef __REACTOS__
-    #include "shlwapi_undoc.h"
+    #include <shlwapi_undoc.h>
 #endif
 #include "wine/unicode.h"
 #include "wine/debug.h"

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -3389,7 +3389,7 @@ BOOL WINAPI SHSetIniStringW(LPCWSTR appName, LPCWSTR keyName, LPCWSTR str,
     TRACE("(%s, %p, %s, %s)\n", debugstr_w(appName), keyName, debugstr_w(str),
           debugstr_w(filename));
 
-    /* Write a normal profile string. If str was `NULL`, then key will be deleted */
+    /* Write a normal profile string. If str was NULL, then key will be deleted */
     if (!WritePrivateProfileStringW(appName, keyName, str, filename))
         return FALSE;
 

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -3408,7 +3408,7 @@ BOOL WINAPI SHSetIniStringW(LPCWSTR appName, LPCWSTR keyName, LPCWSTR str,
         return TRUE;
     }
 
-    /* str is not 7-bit clean. It needs UTF-7 encoding in UTF-16.
+    /* Now str was not 7-bit clean. It needs UTF-7 encoding in UTF-16.
        We write ".A" and ".W"-appended sections. */
 
     /* str --> szBuffA */

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -179,6 +179,12 @@ HRESULT WINAPI SHLoadRegUIStringW(HKEY hkey, LPCWSTR value, LPWSTR buf, DWORD si
 #define SHLoadRegUIString  SHLoadRegUIStringA
 #endif
 
+DWORD WINAPI
+SHGetIniStringW(LPCWSTR appName, LPCWSTR keyName, LPWSTR out, DWORD outLen, LPCWSTR filename);
+
+BOOL WINAPI
+SHSetIniStringW(LPCWSTR appName, LPCWSTR keyName, LPCWSTR str, LPCWSTR filename);
+
 int
 WINAPIV
 ShellMessageBoxWrapW(


### PR DESCRIPTION
## Purpose

Follow-up to #5531. These two functions are necessary for INI file property bag support.
JIRA issue: [CORE-9283](https://jira.reactos.org/browse/CORE-9283)

## Proposed changes

- Implement `SHGetIniStringW` and `SHSetIniStringW`.
- Strengthen `SHPropertyBag` testcase of `shlwapi_apitest.exe`.

## TODO

- [x] Do tests.

## Comparison

WinXP:
![WinXP](https://github.com/reactos/reactos/assets/2107452/f499d8fe-159a-413b-8a2f-4710a6cbe414)
Successful.

Win2k3:
![Win2k3](https://github.com/reactos/reactos/assets/2107452/c7d05534-6074-4297-af1d-69db6ae4dc70)
Successful.

Win10:
![Win10](https://github.com/reactos/reactos/assets/2107452/ac3946d4-0392-4897-995e-e9ae63be5ba6)
Successful.

ReactOS (AFTER):
![after](https://github.com/reactos/reactos/assets/2107452/2e881567-94a5-4a55-9b04-68bf0e40882d)
Successful.