### PR TITLE
[SHELL32] Delayed statusbar update

### DIFF
--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -548,7 +548,7 @@ void CDefView::DelayedUpdateStatusbar()
 {
     KillTimer(TIMERID_DELAYED_UPDATE_STATUSBAR);
 
-    if (m_ListView.GetItemCount() >= 30)
+    if (m_ListView.GetItemCount() >= 50)
         SetTimer(TIMERID_DELAYED_UPDATE_STATUSBAR, 100, NULL);
     else
         UpdateStatusbar();

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -548,7 +548,7 @@ void CDefView::DelayedUpdateStatusbar()
 {
     KillTimer(TIMERID_DELAYED_UPDATE_STATUSBAR);
 
-    if (m_ListView.GetItemCount() >= 100)
+    if (m_ListView.GetItemCount() >= 30)
         SetTimer(TIMERID_DELAYED_UPDATE_STATUSBAR, 100, NULL);
     else
         UpdateStatusbar();


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-18663](https://jira.reactos.org/browse/CORE-18663)

## Proposed changes

- Add `CDefView::DelayedUpdateStatusbar`.
- Use a timer to delay update of statusbar.

## TODO

- [x] Do tests

## Comparison Movies

BEFORE:
https://github.com/reactos/reactos/assets/2107452/141642ea-34b2-4ba3-9b69-9697721415af
Too slow.

AFTER:
https://github.com/reactos/reactos/assets/2107452/3fab8583-0127-4a1a-a602-11759bc78515
Done quickly!