### PR TITLE
[APPWIZ] Release download_binding from client after abort

### DIFF
--- a/dll/cpl/appwiz/addons.c
+++ b/dll/cpl/appwiz/addons.c
@@ -413,8 +413,8 @@ static INT_PTR CALLBACK installer_proc(HWND hwnd, UINT msg, WPARAM wParam, LPARA
                 /*
                  * https://learn.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/platform-apis/ms775068(v=vs.85)
                  *
-                 * > After it aborts the bind operation, the client must release any pointers that
-                 * > were obtained during the binding.
+                 * > After it aborts the bind operation, the client must release
+                 * > any pointers that were obtained during the binding.
                  *
                  * OnStopBinding is not the client.
                  */


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-15786](https://jira.reactos.org/browse/CORE-15786)

## Proposed changes

- Don't release binding `OnStopBinding`.
- After abort, release `download_binding` set `NULL`.

## TODO

- [ ] Do tests.
