### PR TITLE
[BROWSEUI] Don't forget to CoInitializeEx on COM thread

### DIFF
--- a/dll/win32/browseui/shellfind/CFindFolder.cpp
+++ b/dll/win32/browseui/shellfind/CFindFolder.cpp
@@ -455,6 +455,8 @@ DWORD WINAPI CFindFolder::SearchThreadProc(LPVOID lpParameter)
 {
     _SearchData *data = static_cast<_SearchData*>(lpParameter);
 
+    HRESULT hrCoInit = CoInitializeEx(NULL, COINIT_MULTITHREADED);
+
     data->pFindFolder->NotifyConnections(DISPID_SEARCHSTART);
 
     UINT uTotalFound = RecursiveFind(data->szPath, data);
@@ -468,6 +470,9 @@ DWORD WINAPI CFindFolder::SearchThreadProc(LPVOID lpParameter)
 
     CloseHandle(data->hStopEvent);
     delete data;
+
+    if (SUCCEEDED(hrCoInit))
+        CoUninitialize();
 
     return 0;
 }


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-19110](https://jira.reactos.org/browse/CORE-19110)

## Proposed changes

- Use `CoInitializeEx` and `CoUninitialize` in `CFindFolder::SearchThreadProc`.
