### PR TITLE
[ATL] Make CImage thread-safe

### DIFF
--- a/sdk/lib/atl/atlimage.h
+++ b/sdk/lib/atl/atlimage.h
@@ -55,13 +55,13 @@ public:
         m_rgbTransColor = CLR_INVALID;
         ZeroMemory(&m_ds, sizeof(m_ds));
 
-        _gdiplus().IncreaseCImageCount();
+        s_gdiplus.IncreaseCImageCount();
     }
 
     virtual ~CImage() throw()
     {
         Destroy();
-        _gdiplus().DecreaseCImageCount();
+        s_gdiplus.DecreaseCImageCount();
     }
 
     operator HBITMAP() throw()
@@ -71,7 +71,7 @@ public:
 
     static void ReleaseGDIPlus()
     {
-        _gdiplus().ReleaseGDIPlus();
+        s_gdiplus.ReleaseGDIPlus();
     }
 
     void Attach(HBITMAP hBitmap, DIBOrientation eOrientation = DIBOR_DEFAULT) throw()
@@ -382,7 +382,7 @@ public:
         // create a GpBitmap object from file
         using namespace Gdiplus;
         GpBitmap *pBitmap = NULL;
-        if (_gdiplus().CreateBitmapFromFile(pszNameW, &pBitmap) != Ok)
+        if (s_gdiplus.CreateBitmapFromFile(pszNameW, &pBitmap) != Ok)
         {
             return E_FAIL;
         }
@@ -390,10 +390,10 @@ public:
         // get bitmap handle
         HBITMAP hbm = NULL;
         Color color(0xFF, 0xFF, 0xFF);
-        Status status = _gdiplus().CreateHBITMAPFromBitmap(pBitmap, &hbm, color.GetValue());
+        Status status = s_gdiplus.CreateHBITMAPFromBitmap(pBitmap, &hbm, color.GetValue());
 
         // delete GpBitmap
-        _gdiplus().DisposeImage(pBitmap);
+        s_gdiplus.DisposeImage(pBitmap);
 
         // attach it
         if (status == Ok)
@@ -408,7 +408,7 @@ public:
         // create GpBitmap from stream
         using namespace Gdiplus;
         GpBitmap *pBitmap = NULL;
-        if (_gdiplus().CreateBitmapFromStream(pStream, &pBitmap) != Ok)
+        if (s_gdiplus.CreateBitmapFromStream(pStream, &pBitmap) != Ok)
         {
             return E_FAIL;
         }
@@ -416,10 +416,10 @@ public:
         // get bitmap handle
         HBITMAP hbm = NULL;
         Color color(0xFF, 0xFF, 0xFF);
-        Status status = _gdiplus().CreateHBITMAPFromBitmap(pBitmap, &hbm, color.GetValue());
+        Status status = s_gdiplus.CreateHBITMAPFromBitmap(pBitmap, &hbm, color.GetValue());
 
         // delete Bitmap
-        _gdiplus().DisposeImage(pBitmap);
+        s_gdiplus.DisposeImage(pBitmap);
 
         // attach it
         if (status == Ok)
@@ -523,14 +523,14 @@ public:
 
         // create a GpBitmap from HBITMAP
         GpBitmap *pBitmap = NULL;
-        _gdiplus().CreateBitmapFromHBITMAP(m_hbm, NULL, &pBitmap);
+        s_gdiplus.CreateBitmapFromHBITMAP(m_hbm, NULL, &pBitmap);
 
         // save to stream
         Status status;
-        status = _gdiplus().SaveImageToStream(pBitmap, pStream, &clsid, NULL);
+        status = s_gdiplus.SaveImageToStream(pBitmap, pStream, &clsid, NULL);
 
         // destroy GpBitmap
-        _gdiplus().DisposeImage(pBitmap);
+        s_gdiplus.DisposeImage(pBitmap);
 
         return (status == Ok ? S_OK : E_FAIL);
     }
@@ -566,13 +566,13 @@ public:
 
         // create a GpBitmap from HBITMAP
         GpBitmap *pBitmap = NULL;
-        _gdiplus().CreateBitmapFromHBITMAP(m_hbm, NULL, &pBitmap);
+        s_gdiplus.CreateBitmapFromHBITMAP(m_hbm, NULL, &pBitmap);
 
         // save to file
-        Status status = _gdiplus().SaveImageToFile(pBitmap, pszNameW, &clsid, NULL);
+        Status status = s_gdiplus.SaveImageToFile(pBitmap, pszNameW, &clsid, NULL);
 
         // destroy GpBitmap
-        _gdiplus().DisposeImage(pBitmap);
+        s_gdiplus.DisposeImage(pBitmap);
 
         return (status == Ok ? S_OK : E_FAIL);
     }
@@ -1011,15 +1011,11 @@ private:
         }
     };
 
-    static CInitGDIPlus& _gdiplus() throw()
-    {
-        static CInitGDIPlus s_gdiplus;
-        return s_gdiplus;
-    }
+    static CInitGDIPlus s_gdiplus;
 
     static bool InitGDIPlus() throw()
     {
-        return _gdiplus().Init();
+        return s_gdiplus.Init();
     }
 
 private:
@@ -1100,7 +1096,7 @@ private:
     static Gdiplus::ImageCodecInfo* _getAllEncoders(UINT& cEncoders)
     {
         UINT total_size = 0;
-        _gdiplus().GetImageEncodersSize(&cEncoders, &total_size);
+        s_gdiplus.GetImageEncodersSize(&cEncoders, &total_size);
         if (total_size == 0)
             return NULL;  // failure
 
@@ -1112,14 +1108,14 @@ private:
             return NULL;  // failure
         }
 
-        _gdiplus().GetImageEncoders(cEncoders, total_size, ret);
+        s_gdiplus.GetImageEncoders(cEncoders, total_size, ret);
         return ret; // needs delete[]
     }
 
     static Gdiplus::ImageCodecInfo* _getAllDecoders(UINT& cDecoders)
     {
         UINT total_size = 0;
-        _gdiplus().GetImageDecodersSize(&cDecoders, &total_size);
+        s_gdiplus.GetImageDecodersSize(&cDecoders, &total_size);
         if (total_size == 0)
             return NULL;  // failure
 
@@ -1131,7 +1127,7 @@ private:
             return NULL;  // failure
         }
 
-        _gdiplus().GetImageDecoders(cDecoders, total_size, ret);
+        s_gdiplus.GetImageDecoders(cDecoders, total_size, ret);
         return ret; // needs delete[]
     }
 
@@ -1220,6 +1216,8 @@ private:
     CImage(const CImage&) = delete;
     CImage& operator=(const CImage&) = delete;
 };
+
+DECLSPEC_SELECTANY CImage::CInitGDIPlus CImage::s_gdiplus;
 
 }
 

--- a/sdk/lib/atl/atlimage.h
+++ b/sdk/lib/atl/atlimage.h
@@ -885,7 +885,7 @@ private:
         LONG m_nCImageObjects;
         DWORD m_dwLastError;
 
-        void ClearFUNs() throw()
+        void _clear_funs() throw()
         {
             Startup = NULL;
             Shutdown = NULL;
@@ -932,7 +932,7 @@ private:
             , m_nCImageObjects(0)
             , m_dwLastError(ERROR_SUCCESS)
         {
-            ClearFUNs();
+            _clear_funs();
             ::InitializeCriticalSection(&m_sect);
         }
 
@@ -994,7 +994,7 @@ private:
                 ::FreeLibrary(m_hInst);
                 m_hInst = NULL;
             }
-            ClearFUNs();
+            _clear_funs();
             ::LeaveCriticalSection(&m_sect);
         }
 

--- a/sdk/lib/atl/atlimage.h
+++ b/sdk/lib/atl/atlimage.h
@@ -12,8 +12,6 @@
 //       See rostest/apitests/atl/CImage_WIP.txt for test results.
 // !!!!
 
-// TODO: CImage::Load, CImage::Save
-
 #pragma once
 
 #include <atlcore.h>        // for ATL Core

--- a/sdk/lib/atl/atlimage.h
+++ b/sdk/lib/atl/atlimage.h
@@ -386,7 +386,7 @@ public:
         // create a GpBitmap object from file
         using namespace Gdiplus;
         GpBitmap *pBitmap = NULL;
-        if (_common().CreateBitmapFromFile(pszNameW, &pBitmap) != Ok)
+        if (_gdiplus().CreateBitmapFromFile(pszNameW, &pBitmap) != Ok)
         {
             return E_FAIL;
         }
@@ -394,10 +394,10 @@ public:
         // get bitmap handle
         HBITMAP hbm = NULL;
         Color color(0xFF, 0xFF, 0xFF);
-        Status status = _common().CreateHBITMAPFromBitmap(pBitmap, &hbm, color.GetValue());
+        Status status = _gdiplus().CreateHBITMAPFromBitmap(pBitmap, &hbm, color.GetValue());
 
         // delete GpBitmap
-        _common().DisposeImage(pBitmap);
+        _gdiplus().DisposeImage(pBitmap);
 
         // attach it
         if (status == Ok)
@@ -412,7 +412,7 @@ public:
         // create GpBitmap from stream
         using namespace Gdiplus;
         GpBitmap *pBitmap = NULL;
-        if (_common().CreateBitmapFromStream(pStream, &pBitmap) != Ok)
+        if (_gdiplus().CreateBitmapFromStream(pStream, &pBitmap) != Ok)
         {
             return E_FAIL;
         }
@@ -420,10 +420,10 @@ public:
         // get bitmap handle
         HBITMAP hbm = NULL;
         Color color(0xFF, 0xFF, 0xFF);
-        Status status = _common().CreateHBITMAPFromBitmap(pBitmap, &hbm, color.GetValue());
+        Status status = _gdiplus().CreateHBITMAPFromBitmap(pBitmap, &hbm, color.GetValue());
 
         // delete Bitmap
-        _common().DisposeImage(pBitmap);
+        _gdiplus().DisposeImage(pBitmap);
 
         // attach it
         if (status == Ok)
@@ -527,14 +527,14 @@ public:
 
         // create a GpBitmap from HBITMAP
         GpBitmap *pBitmap = NULL;
-        _common().CreateBitmapFromHBITMAP(m_hbm, NULL, &pBitmap);
+        _gdiplus().CreateBitmapFromHBITMAP(m_hbm, NULL, &pBitmap);
 
         // save to stream
         Status status;
-        status = _common().SaveImageToStream(pBitmap, pStream, &clsid, NULL);
+        status = _gdiplus().SaveImageToStream(pBitmap, pStream, &clsid, NULL);
 
         // destroy GpBitmap
-        _common().DisposeImage(pBitmap);
+        _gdiplus().DisposeImage(pBitmap);
 
         return (status == Ok ? S_OK : E_FAIL);
     }
@@ -570,13 +570,13 @@ public:
 
         // create a GpBitmap from HBITMAP
         GpBitmap *pBitmap = NULL;
-        _common().CreateBitmapFromHBITMAP(m_hbm, NULL, &pBitmap);
+        _gdiplus().CreateBitmapFromHBITMAP(m_hbm, NULL, &pBitmap);
 
         // save to file
-        Status status = _common().SaveImageToFile(pBitmap, pszNameW, &clsid, NULL);
+        Status status = _gdiplus().SaveImageToFile(pBitmap, pszNameW, &clsid, NULL);
 
         // destroy GpBitmap
-        _common().DisposeImage(pBitmap);
+        _gdiplus().DisposeImage(pBitmap);
 
         return (status == Ok ? S_OK : E_FAIL);
     }
@@ -1027,7 +1027,7 @@ private:
         return GetInitGDIPlusInstance()->Init();
     }
 
-    static CInitGDIPlus& _common() throw()
+    static CInitGDIPlus& _gdiplus() throw()
     {
         return *GetInitGDIPlusInstance();
     }
@@ -1110,7 +1110,7 @@ private:
     static Gdiplus::ImageCodecInfo* _getAllEncoders(UINT& cEncoders)
     {
         UINT total_size = 0;
-        _common().GetImageEncodersSize(&cEncoders, &total_size);
+        _gdiplus().GetImageEncodersSize(&cEncoders, &total_size);
         if (total_size == 0)
             return NULL;  // failure
 
@@ -1122,14 +1122,14 @@ private:
             return NULL;  // failure
         }
 
-        _common().GetImageEncoders(cEncoders, total_size, ret);
+        _gdiplus().GetImageEncoders(cEncoders, total_size, ret);
         return ret; // needs delete[]
     }
 
     static Gdiplus::ImageCodecInfo* _getAllDecoders(UINT& cDecoders)
     {
         UINT total_size = 0;
-        _common().GetImageDecodersSize(&cDecoders, &total_size);
+        _gdiplus().GetImageDecodersSize(&cDecoders, &total_size);
         if (total_size == 0)
             return NULL;  // failure
 
@@ -1141,7 +1141,7 @@ private:
             return NULL;  // failure
         }
 
-        _common().GetImageDecoders(cDecoders, total_size, ret);
+        _gdiplus().GetImageDecoders(cDecoders, total_size, ret);
         return ret; // needs delete[]
     }
 

--- a/sdk/lib/atl/atlimage.h
+++ b/sdk/lib/atl/atlimage.h
@@ -55,13 +55,13 @@ public:
         m_rgbTransColor = CLR_INVALID;
         ZeroMemory(&m_ds, sizeof(m_ds));
 
-        GetInitGDIPlusInstance()->IncreaseCImageCount();
+        _gdiplus().IncreaseCImageCount();
     }
 
     virtual ~CImage() throw()
     {
         Destroy();
-        GetInitGDIPlusInstance()->DecreaseCImageCount();
+        _gdiplus().DecreaseCImageCount();
     }
 
     operator HBITMAP() throw()
@@ -71,7 +71,7 @@ public:
 
     static void ReleaseGDIPlus()
     {
-        GetInitGDIPlusInstance()->ReleaseGDIPlus();
+        _gdiplus().ReleaseGDIPlus();
     }
 
     void Attach(HBITMAP hBitmap, DIBOrientation eOrientation = DIBOR_DEFAULT) throw()
@@ -1011,20 +1011,15 @@ private:
         }
     };
 
-    static CInitGDIPlus* GetInitGDIPlusInstance()
+    static CInitGDIPlus& _gdiplus() throw()
     {
         static CInitGDIPlus s_gdiplus;
-        return &s_gdiplus;
+        return s_gdiplus;
     }
 
     static bool InitGDIPlus() throw()
     {
-        return GetInitGDIPlusInstance()->Init();
-    }
-
-    static CInitGDIPlus& _gdiplus() throw()
-    {
-        return *GetInitGDIPlusInstance();
+        return _gdiplus().Init();
     }
 
 private:

--- a/sdk/lib/atl/atlimage.h
+++ b/sdk/lib/atl/atlimage.h
@@ -71,6 +71,11 @@ public:
         return m_hbm;
     }
 
+    static void ReleaseGDIPlus()
+    {
+        GetInitGDIPlusInstance()->ReleaseGDIPlus();
+    }
+
 public:
     void Attach(HBITMAP hBitmap, DIBOrientation eOrientation = DIBOR_DEFAULT)
     {

--- a/sdk/lib/atl/atlimage.h
+++ b/sdk/lib/atl/atlimage.h
@@ -74,8 +74,7 @@ public:
         GetInitGDIPlusInstance()->ReleaseGDIPlus();
     }
 
-public:
-    void Attach(HBITMAP hBitmap, DIBOrientation eOrientation = DIBOR_DEFAULT)
+    void Attach(HBITMAP hBitmap, DIBOrientation eOrientation = DIBOR_DEFAULT) throw()
     {
         AttachInternal(hBitmap, eOrientation, -1);
     }
@@ -118,7 +117,6 @@ public:
         m_hDC = NULL;
     }
 
-public:
     BOOL AlphaBlend(HDC hDestDC,
         int xDest, int yDest, int nDestWidth, int nDestHeight,
         int xSrc, int ySrc, int nSrcWidth, int nSrcHeight,
@@ -690,7 +688,6 @@ public:
             rectSrc.bottom - rectSrc.top, crTransparent);
     }
 
-public:
     static BOOL IsTransparencySupported() throw()
     {
         return TRUE;
@@ -1144,7 +1141,7 @@ private:
     }
 
     void AttachInternal(HBITMAP hBitmap, DIBOrientation eOrientation,
-                        LONG iTransColor)
+                        LONG iTransColor) throw()
     {
         Destroy();
 

--- a/sdk/lib/atl/atlimage.h
+++ b/sdk/lib/atl/atlimage.h
@@ -1018,8 +1018,8 @@ private:
 
     static CInitGDIPlus* GetInitGDIPlusInstance()
     {
-        static CInitGDIPlus s_init;
-        return &s_init;
+        static CInitGDIPlus s_gdiplus;
+        return &s_gdiplus;
     }
 
     static bool InitGDIPlus() throw()


### PR DESCRIPTION
## Purpose

Improve compatibility.
JIRA issue: [CORE-19008](https://jira.reactos.org/browse/CORE-19008)

## Proposed changes

- Add `CInitGDIPlus` subclass in `CImage`.
- Lock the `CInitGDIPlus` data by using a critical section.
- Add `CImage::InitGDIPlus` and use it.

## TODO

- [x] Do small tests.

## Screenshots

BEFORE:
![before](https://github.com/reactos/reactos/assets/2107452/40b9a506-bb8d-40de-9a27-f8b79704775c)

AFTER:
![after](https://github.com/reactos/reactos/assets/2107452/2adfb147-5efb-4f89-b4c4-37f0ba66042e)

![after-2](https://github.com/reactos/reactos/assets/2107452/c594bf61-1c39-4aa8-a5a6-886b27955e7d)