### PR TITLE
[COMCTL32] Fix balloon tooltips and system pager alerts

### DIFF
--- a/base/shell/explorer/syspager.cpp
+++ b/base/shell/explorer/syspager.cpp
@@ -21,6 +21,8 @@
 
 #include "precomp.h"
 
+#define BALLOON_MAXWIDTH 340
+
 struct InternalIconData : NOTIFYICONDATA
 {
     // Must keep a separate copy since the original is unioned with uTimeout.
@@ -617,19 +619,19 @@ void CBalloonQueue::Show(Info& info)
 
     // TODO: NIF_REALTIME, NIIF_NOSOUND, other Vista+ flags
 
-    const int index = IndexOf(info.pSource);
+    m_current = info.pSource;
     RECT rc;
-    m_toolbar->GetItemRect(index, &rc);
+    m_toolbar->GetItemRect(IndexOf(m_current), &rc);
     m_toolbar->ClientToScreen(&rc);
     const WORD x = (rc.left + rc.right) / 2;
     const WORD y = (rc.top + rc.bottom) / 2;
 
     m_tooltips->SetTitle(info.szInfoTitle, info.uIcon);
     m_tooltips->TrackPosition(x, y);
+    m_tooltips->SetMaxTipWidth(BALLOON_MAXWIDTH);
     m_tooltips->UpdateTipText(m_hwndParent, reinterpret_cast<LPARAM>(m_toolbar->m_hWnd), info.szInfo);
     m_tooltips->TrackActivate(m_hwndParent, reinterpret_cast<LPARAM>(m_toolbar->m_hWnd));
 
-    m_current = info.pSource;
     int timeout = info.uTimeout;
     if (timeout < MinTimeout) timeout = MinTimeout;
     if (timeout > MaxTimeout) timeout = MaxTimeout;


### PR DESCRIPTION
## Purpose

Before
![image](https://github.com/reactos/reactos/assets/16692240/037672ff-0742-43de-b534-4120342ef24a)

After
![image](https://github.com/reactos/reactos/assets/16692240/998ff6d0-3518-4fc5-a720-cc0c444b42d6)

JIRA issue: [CORE-19109](https://jira.reactos.org/browse/CORE-19109)

## Proposed changes
- Set a maximum width for balloons coming from the system pager.
- Limit balloon tooltips from extending past the edges of the monitor, not the edges of the work area.
- Instead of simply repositioning the main rectangle when the balloon is too far towards one edge of the screen, try flipping the balloon the other way. This is the same behavior as Windows Server 2003.
- Tweak some values used to draw the balloon tooltips to more closely follow the Windows balloon tooltip style.
- Removing trailing whitespace.
- While the new changes are guarded, consider cancelling our Wine sync for common controls. Our common controls are responsible for many graphical issues and lack of features throughout ReactOS.

## TODO (in future PRs)
- Add a close button for balloons that come from the system tray.
- Add options to use either NT6+ balloon styling or NT5.x balloon styling.
- Support NT6+ balloon flags.
- More system pager fixes. For example, there is a bug where if an application displays a notification immediately after being added to the pager the balloon is drawn in the wrong place. This existed in our explorer before this pull request.