### PR TITLE
[EXPLORER] Fix icon adjustment issue

### DIFF
--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -3528,7 +3528,7 @@ HandleTrayContextMenu:
             AlignControls(NULL);
         }
 
-        /* Forces taskbar to use one line when using small icons. */
+        /* Force taskbar to use one line when using small icons */
         if (g_TaskbarSettings.bSmallIcons)
             pTaskbarRect->top = pTaskbarRect->bottom;
 

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -3488,6 +3488,7 @@ HandleTrayContextMenu:
     LRESULT OnTaskbarSettingsChanged(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
     {
         TaskbarSettings* newSettings = (TaskbarSettings*)lParam;
+        RECT *pTaskbarRect = &m_TrayRects[m_Position];
 
         /* Propagate the new settings to the children */
         ::SendMessageW(m_TaskSwitch, uMsg, wParam, lParam);
@@ -3527,7 +3528,10 @@ HandleTrayContextMenu:
             AlignControls(NULL);
         }
 
-        /* Adjust taskbar size */
+        /* Forces taskbar to use one line when using small icons. */
+        if (g_TaskbarSettings.bSmallIcons)
+            pTaskbarRect->top = pTaskbarRect->bottom;
+
         CheckTrayWndPosition();
 
         g_TaskbarSettings.Save();


### PR DESCRIPTION
## Purpose
Fixes an issue where when toggling between large and small taskbar icons toolbars ends up on top of the task items. This is most easily seen using quick launch and toggling between large and small icons.

JIRA issue: [CORE-19112](https://jira.reactos.org/browse/CORE-19112)

## Proposed changes
- When setting the taskbar to use small icons, shrink the taskbar down to use only one line.