### PR TITLE
[USER32] Show Debug Log Message when unhandled PNG found in ICO file

### DIFF
--- a/win32ss/user/user32/windows/cursoricon.c
+++ b/win32ss/user/user32/windows/cursoricon.c
@@ -179,6 +179,12 @@ static int bitmap_info_size( const BITMAPINFO * info, WORD coloruse )
 static int DIB_GetBitmapInfo( const BITMAPINFOHEADER *header, LONG *width,
                               LONG *height, WORD *bpp, DWORD *compr )
 {
+    #define CR 13
+    #define LF 10
+    #define EOFM 26 // DOS End Of File Marker
+    #define HighBitDetect 0x89 // Byte with high bit set to test if not 7-bit
+    /* wine's definition */
+    static const BYTE png_sig_pattern[] = { HighBitDetect, 'P', 'N', 'G', CR, LF, EOFM, LF };
     if (header->biSize == sizeof(BITMAPCOREHEADER))
     {
         const BITMAPCOREHEADER *core = (const BITMAPCOREHEADER *)header;
@@ -198,7 +204,15 @@ static int DIB_GetBitmapInfo( const BITMAPINFOHEADER *header, LONG *width,
         *compr  = header->biCompression;
         return 1;
     }
-    ERR("(%d): unknown/wrong size for header\n", header->biSize );
+    if (memcmp(&header->biSize, png_sig_pattern, sizeof(png_sig_pattern)) == 0)
+    {
+        ERR("Cannot yet display PNG icons\n");
+        /* for PNG format details see https://en.wikipedia.org/wiki/PNG */
+    }
+    else
+    {
+        ERR("Unknown/wrong size for header of 0x%x\n", header->biSize );
+    }
     return -1;
 }
 
@@ -1377,7 +1391,10 @@ CURSORICON_LoadFromFileW(
 
     /* Do the dance */
     if(!CURSORICON_GetCursorDataFromBMI(&cursorData, (BITMAPINFO*)(&bits[entry->dwDIBOffset])))
-        goto end;
+        {
+            ERR("Failing File is \n    '%S'.\n", lpszName);
+            goto end;
+        }
 
     hCurIcon = NtUserxCreateEmptyCurObject(FALSE);
     if(!hCurIcon)


### PR DESCRIPTION
## Purpose

_Current Debug Log shows bad header size when PNG found in ICO file._
_Now detect the condition and print an appropriate message to the Debug log._

JIRA issue: [CORE-19107](https://jira.reactos.org/browse/CORE-19107)

## Proposed changes

_Add code to detect PNG embed in ICO file and print appropriate message to debug log._
_Maybe this will lead to a more correct handling code being implemented._

Debug log Before:
```
err:(win32ss/user/user32/windows/cursoricon.c:201) (1196314761): unknown/wrong size for header
err:(win32ss/user/user32/windows/cursoricon.c:201) (1196314761): unknown/wrong size for header
err:(win32ss/user/user32/windows/cursoricon.c:201) (1196314761): unknown/wrong size for header
err:(win32ss/user/user32/windows/cursoricon.c:201) (1196314761): unknown/wrong size for header
err:(win32ss/user/user32/windows/cursoricon.c:201) (1196314761): unknown/wrong size for header
err:(win32ss/user/user32/windows/cursoricon.c:201) (1196314761): unknown/wrong size for header
```
Debug log After:
```
err:(win32ss/user/user32/windows/cursoricon.c:209) Cannot yet display PNG icons
err:(win32ss/user/user32/windows/cursoricon.c:1395) Failing File is
'C:\Documents and Settings\Administrator\Local Settings\Application Data\RApps\appdb\icons\jdk8.ico'.
err:(win32ss/user/user32/windows/cursoricon.c:209) Cannot yet display PNG icons
err:(win32ss/user/user32/windows/cursoricon.c:1395) Failing File is
'C:\Documents and Settings\Administrator\Local Settings\Application Data\RApps\appdb\icons\jdk8.ico'.
err:(win32ss/user/user32/windows/cursoricon.c:209) Cannot yet display PNG icons
err:(win32ss/user/user32/windows/cursoricon.c:1395) Failing File is
'C:\Documents and Settings\Administrator\Local Settings\Application Data\RApps\appdb\icons\codeblocks.ico'.
err:(win32ss/user/user32/windows/cursoricon.c:209) Cannot yet display PNG icons
err:(win32ss/user/user32/windows/cursoricon.c:1395) Failing File is
'C:\Documents and Settings\Administrator\Local Settings\Application Data\RApps\appdb\icons\jdk8.ico'.
err:(win32ss/user/user32/windows/cursoricon.c:209) Cannot yet display PNG icons
err:(win32ss/user/user32/windows/cursoricon.c:1395) Failing File is
'C:\Documents and Settings\Administrator\Local Settings\Application Data\RApps\appdb\icons\jdk8.ico'.
err:(win32ss/user/user32/windows/cursoricon.c:209) Cannot yet display PNG icons
err:(win32ss/user/user32/windows/cursoricon.c:1395) Failing File is
'C:\Documents and Settings\Administrator\Local Settings\Application Data\RApps\appdb\icons\flashplayer32.ico'.
```