### PR TITLE
[ATL_APITEST][SDK] Fix failures of CImage testcase

### DIFF
--- a/modules/rostests/apitests/atl/CImage.cpp
+++ b/modules/rostests/apitests/atl/CImage.cpp
@@ -274,14 +274,23 @@ START_TEST(CImage)
     ok_int(IsEqualGUID(aguidFileTypes[7], Gdiplus::ImageFormatPNG), TRUE);
     ok_int(IsEqualGUID(aguidFileTypes[8], Gdiplus::ImageFormatIcon), TRUE);
 
+    static const char ImportFilter[] =
+        "All Image Files|*.BMP;*.DIB;*.RLE;*.JPG;*.JPEG;*.JPE;*.JFIF;*.GIF;*.EMF;*.WMF;*.TIF;*.TIFF;*.PNG;*.ICO|"
+        "BMP (*.BMP;*.DIB;*.RLE)|*.BMP;*.DIB;*.RLE|"
+        "JPEG (*.JPG;*.JPEG;*.JPE;*.JFIF)|*.JPG;*.JPEG;*.JPE;*.JFIF|"
+        "GIF (*.GIF)|*.GIF|"
+        "EMF (*.EMF)|*.EMF|"
+        "WMF (*.WMF)|*.WMF|"
+        "TIFF (*.TIF;*.TIFF)|*.TIF;*.TIFF|"
+        "PNG (*.PNG)|*.PNG|"
+        "ICO (*.ICO)|*.ICO||";
+
     psz = strImporters.GetString();
 #ifdef UNICODE
     WideCharToMultiByte(CP_ACP, 0, psz, -1, szBuff, _countof(szBuff), NULL, NULL);
-    ok(lstrcmpA(szBuff, "All Image Files|*.BMP;*.DIB;*.RLE;*.JPG;*.JPEG;*.JPE;*.JFIF;*.GIF;*.EMF;*.WMF;*.TIF;*.TIFF;*.PNG;*.ICO|BMP (*.BMP;*.DIB;*.RLE)|*.BMP;*.DIB;*.RLE|JPEG (*.JPG;*.JPEG;*.JPE;*.JFIF)|*.JPG;*.JPEG;*.JPE;*.JFIF|GIF (*.GIF)|*.GIF|EMF (*.EMF)|*.EMF|WMF (*.WMF)|*.WMF|TIFF (*.TIF;*.TIFF)|*.TIF;*.TIFF|PNG (*.PNG)|*.PNG|ICO (*.ICO)|*.ICO||") == 0,
-       "The importer filter string is bad, was: %s\n", szBuff);
+    ok_str(szBuff, ImportFilter);
 #else
-    ok(lstrcmpA(psz, "All Image Files|*.BMP;*.DIB;*.RLE;*.JPG;*.JPEG;*.JPE;*.JFIF;*.GIF;*.EMF;*.WMF;*.TIF;*.TIFF;*.PNG;*.ICO|BMP (*.BMP;*.DIB;*.RLE)|*.BMP;*.DIB;*.RLE|JPEG (*.JPG;*.JPEG;*.JPE;*.JFIF)|*.JPG;*.JPEG;*.JPE;*.JFIF|GIF (*.GIF)|*.GIF|EMF (*.EMF)|*.EMF|WMF (*.WMF)|*.WMF|TIFF (*.TIF;*.TIFF)|*.TIF;*.TIFF|PNG (*.PNG)|*.PNG|ICO (*.ICO)|*.ICO||") == 0,
-       "The importer filter string is bad, was: %s\n", psz);
+    ok_str(psz, ImportFilter);
 #endif
 
     CSimpleString strExporters(mgr);

--- a/modules/rostests/apitests/atl/CImage.cpp
+++ b/modules/rostests/apitests/atl/CImage.cpp
@@ -240,7 +240,7 @@ static void Test_LoadSaveImage(void)
     }
 }
 
-static INT find_guid(REFGUID rguid, const CSimpleArray<GUID>& guids)
+static INT FindGUID(REFGUID rguid, const CSimpleArray<GUID>& guids)
 {
     for (INT i = 0; i < guids.GetSize(); ++i)
     {
@@ -250,7 +250,7 @@ static INT find_guid(REFGUID rguid, const CSimpleArray<GUID>& guids)
     return -1;
 }
 
-static INT find_filter_item(const WCHAR *filter, const WCHAR *item)
+static INT FindFilterItem(const WCHAR *filter, const WCHAR *item)
 {
     INT iFilter = 0;
     size_t cbItem = wcslen(item) * sizeof(WCHAR);
@@ -283,14 +283,14 @@ static void Test_Importer(void)
     ok(aguidFileTypes.GetSize() >= 8,
        "Expected aguidFileTypes.GetSize() to be >= 8, was %d.", aguidFileTypes.GetSize());
 
-    iNULL = find_guid(GUID_NULL, aguidFileTypes);
-    iBMP = find_guid(Gdiplus::ImageFormatBMP, aguidFileTypes);
-    iJPEG = find_guid(Gdiplus::ImageFormatJPEG, aguidFileTypes);
-    iGIF = find_guid(Gdiplus::ImageFormatGIF, aguidFileTypes);
-    iPNG = find_guid(Gdiplus::ImageFormatPNG, aguidFileTypes);
-    iTIFF = find_guid(Gdiplus::ImageFormatTIFF, aguidFileTypes);
-    iEMF = find_guid(Gdiplus::ImageFormatEMF, aguidFileTypes);
-    iWMF = find_guid(Gdiplus::ImageFormatWMF, aguidFileTypes);
+    iNULL = FindGUID(GUID_NULL, aguidFileTypes);
+    iBMP = FindGUID(Gdiplus::ImageFormatBMP, aguidFileTypes);
+    iJPEG = FindGUID(Gdiplus::ImageFormatJPEG, aguidFileTypes);
+    iGIF = FindGUID(Gdiplus::ImageFormatGIF, aguidFileTypes);
+    iPNG = FindGUID(Gdiplus::ImageFormatPNG, aguidFileTypes);
+    iTIFF = FindGUID(Gdiplus::ImageFormatTIFF, aguidFileTypes);
+    iEMF = FindGUID(Gdiplus::ImageFormatEMF, aguidFileTypes);
+    iWMF = FindGUID(Gdiplus::ImageFormatWMF, aguidFileTypes);
 
     ok_int(iNULL, 0);
     ok(iBMP > 0, "iBMP was %d\n", iBMP);
@@ -302,11 +302,11 @@ static void Test_Importer(void)
     ok(iWMF > 0, "iWMF was %d\n", iWMF);
 
     ok_int(memcmp(strImporters, L"All Image Files|", sizeof(L"All Image Files|") - sizeof(UNICODE_NULL)), 0);
-    ok_int(iBMP, find_filter_item(strImporters, L"BMP (*.BMP;*.DIB;*.RLE)|*.BMP;*.DIB;*.RLE|"));
-    ok_int(iJPEG, find_filter_item(strImporters, L"JPEG (*.JPG;*.JPEG;*.JPE;*.JFIF)|*.JPG;*.JPEG;*.JPE;*.JFIF|"));
-    ok_int(iGIF, find_filter_item(strImporters, L"GIF (*.GIF)|*.GIF|"));
-    ok_int(iPNG, find_filter_item(strImporters, L"PNG (*.PNG)|*.PNG|"));
-    ok_int(iTIFF, find_filter_item(strImporters, L"TIFF (*.TIF;*.TIFF)|*.TIF;*.TIFF|"));
+    ok_int(iBMP, FindFilterItem(strImporters, L"BMP (*.BMP;*.DIB;*.RLE)|*.BMP;*.DIB;*.RLE|"));
+    ok_int(iJPEG, FindFilterItem(strImporters, L"JPEG (*.JPG;*.JPEG;*.JPE;*.JFIF)|*.JPG;*.JPEG;*.JPE;*.JFIF|"));
+    ok_int(iGIF, FindFilterItem(strImporters, L"GIF (*.GIF)|*.GIF|"));
+    ok_int(iPNG, FindFilterItem(strImporters, L"PNG (*.PNG)|*.PNG|"));
+    ok_int(iTIFF, FindFilterItem(strImporters, L"TIFF (*.TIF;*.TIFF)|*.TIF;*.TIFF|"));
 
     // Try importer without "All Image Files"
     aguidFileTypes.RemoveAll();
@@ -316,14 +316,14 @@ static void Test_Importer(void)
     ok(aguidFileTypes.GetSize() >= 7,
        "Expected aguidFileTypes.GetSize() to be >= 7, was %d.", aguidFileTypes.GetSize());
 
-    iNULL = find_guid(GUID_NULL, aguidFileTypes);
-    iBMP = find_guid(Gdiplus::ImageFormatBMP, aguidFileTypes);
-    iJPEG = find_guid(Gdiplus::ImageFormatJPEG, aguidFileTypes);
-    iGIF = find_guid(Gdiplus::ImageFormatGIF, aguidFileTypes);
-    iPNG = find_guid(Gdiplus::ImageFormatPNG, aguidFileTypes);
-    iTIFF = find_guid(Gdiplus::ImageFormatTIFF, aguidFileTypes);
-    iEMF = find_guid(Gdiplus::ImageFormatEMF, aguidFileTypes);
-    iWMF = find_guid(Gdiplus::ImageFormatWMF, aguidFileTypes);
+    iNULL = FindGUID(GUID_NULL, aguidFileTypes);
+    iBMP = FindGUID(Gdiplus::ImageFormatBMP, aguidFileTypes);
+    iJPEG = FindGUID(Gdiplus::ImageFormatJPEG, aguidFileTypes);
+    iGIF = FindGUID(Gdiplus::ImageFormatGIF, aguidFileTypes);
+    iPNG = FindGUID(Gdiplus::ImageFormatPNG, aguidFileTypes);
+    iTIFF = FindGUID(Gdiplus::ImageFormatTIFF, aguidFileTypes);
+    iEMF = FindGUID(Gdiplus::ImageFormatEMF, aguidFileTypes);
+    iWMF = FindGUID(Gdiplus::ImageFormatWMF, aguidFileTypes);
 
     ok_int(iNULL, -1);
     ok_int(iBMP, 0);
@@ -334,11 +334,11 @@ static void Test_Importer(void)
     ok(iEMF > 0, "iEMF was %d\n", iEMF);
     ok(iWMF > 0, "iWMF was %d\n", iWMF);
 
-    ok_int(iBMP, find_filter_item(strImporters, L"BMP (*.BMP;*.DIB;*.RLE)|*.BMP;*.DIB;*.RLE|"));
-    ok_int(iJPEG, find_filter_item(strImporters, L"JPEG (*.JPG;*.JPEG;*.JPE;*.JFIF)|*.JPG;*.JPEG;*.JPE;*.JFIF|"));
-    ok_int(iGIF, find_filter_item(strImporters, L"GIF (*.GIF)|*.GIF|"));
-    ok_int(iPNG, find_filter_item(strImporters, L"PNG (*.PNG)|*.PNG|"));
-    ok_int(iTIFF, find_filter_item(strImporters, L"TIFF (*.TIF;*.TIFF)|*.TIF;*.TIFF|"));
+    ok_int(iBMP, FindFilterItem(strImporters, L"BMP (*.BMP;*.DIB;*.RLE)|*.BMP;*.DIB;*.RLE|"));
+    ok_int(iJPEG, FindFilterItem(strImporters, L"JPEG (*.JPG;*.JPEG;*.JPE;*.JFIF)|*.JPG;*.JPEG;*.JPE;*.JFIF|"));
+    ok_int(iGIF, FindFilterItem(strImporters, L"GIF (*.GIF)|*.GIF|"));
+    ok_int(iPNG, FindFilterItem(strImporters, L"PNG (*.PNG)|*.PNG|"));
+    ok_int(iTIFF, FindFilterItem(strImporters, L"TIFF (*.TIF;*.TIFF)|*.TIF;*.TIFF|"));
 }
 
 static void Test_Exporter(void)
@@ -356,12 +356,12 @@ static void Test_Exporter(void)
     ok(aguidFileTypes.GetSize() >= 6,
        "Expected aguidFileTypes.GetSize() to be >= 6, was %d.", aguidFileTypes.GetSize());
 
-    iNULL = find_guid(GUID_NULL, aguidFileTypes);
-    iBMP = find_guid(Gdiplus::ImageFormatBMP, aguidFileTypes);
-    iJPEG = find_guid(Gdiplus::ImageFormatJPEG, aguidFileTypes);
-    iGIF = find_guid(Gdiplus::ImageFormatGIF, aguidFileTypes);
-    iPNG = find_guid(Gdiplus::ImageFormatPNG, aguidFileTypes);
-    iTIFF = find_guid(Gdiplus::ImageFormatTIFF, aguidFileTypes);
+    iNULL = FindGUID(GUID_NULL, aguidFileTypes);
+    iBMP = FindGUID(Gdiplus::ImageFormatBMP, aguidFileTypes);
+    iJPEG = FindGUID(Gdiplus::ImageFormatJPEG, aguidFileTypes);
+    iGIF = FindGUID(Gdiplus::ImageFormatGIF, aguidFileTypes);
+    iPNG = FindGUID(Gdiplus::ImageFormatPNG, aguidFileTypes);
+    iTIFF = FindGUID(Gdiplus::ImageFormatTIFF, aguidFileTypes);
 
     ok_int(iNULL, 0);
     ok(iBMP > 0, "iBMP was %d\n", iBMP);
@@ -370,11 +370,11 @@ static void Test_Exporter(void)
     ok(iPNG > 0, "iPNG was %d\n", iPNG);
     ok(iTIFF > 0, "iTIFF was %d\n", iTIFF);
 
-    ok_int(iBMP, find_filter_item(strExporters, L"BMP (*.BMP;*.DIB;*.RLE)|*.BMP;*.DIB;*.RLE|"));
-    ok_int(iJPEG, find_filter_item(strExporters, L"JPEG (*.JPG;*.JPEG;*.JPE;*.JFIF)|*.JPG;*.JPEG;*.JPE;*.JFIF|"));
-    ok_int(iGIF, find_filter_item(strExporters, L"GIF (*.GIF)|*.GIF|"));
-    ok_int(iPNG, find_filter_item(strExporters, L"PNG (*.PNG)|*.PNG|"));
-    ok_int(iTIFF, find_filter_item(strExporters, L"TIFF (*.TIF;*.TIFF)|*.TIF;*.TIFF|"));
+    ok_int(iBMP, FindFilterItem(strExporters, L"BMP (*.BMP;*.DIB;*.RLE)|*.BMP;*.DIB;*.RLE|"));
+    ok_int(iJPEG, FindFilterItem(strExporters, L"JPEG (*.JPG;*.JPEG;*.JPE;*.JFIF)|*.JPG;*.JPEG;*.JPE;*.JFIF|"));
+    ok_int(iGIF, FindFilterItem(strExporters, L"GIF (*.GIF)|*.GIF|"));
+    ok_int(iPNG, FindFilterItem(strExporters, L"PNG (*.PNG)|*.PNG|"));
+    ok_int(iTIFF, FindFilterItem(strExporters, L"TIFF (*.TIF;*.TIFF)|*.TIF;*.TIFF|"));
 
     // Try exporter without "All Image Files"
     strExporters.Empty();
@@ -384,12 +384,12 @@ static void Test_Exporter(void)
     ok(aguidFileTypes.GetSize() >= 5,
        "Expected aguidFileTypes.GetSize() to be >= 5, was %d.", aguidFileTypes.GetSize());
 
-    iNULL = find_guid(GUID_NULL, aguidFileTypes);
-    iBMP = find_guid(Gdiplus::ImageFormatBMP, aguidFileTypes);
-    iJPEG = find_guid(Gdiplus::ImageFormatJPEG, aguidFileTypes);
-    iGIF = find_guid(Gdiplus::ImageFormatGIF, aguidFileTypes);
-    iPNG = find_guid(Gdiplus::ImageFormatPNG, aguidFileTypes);
-    iTIFF = find_guid(Gdiplus::ImageFormatTIFF, aguidFileTypes);
+    iNULL = FindGUID(GUID_NULL, aguidFileTypes);
+    iBMP = FindGUID(Gdiplus::ImageFormatBMP, aguidFileTypes);
+    iJPEG = FindGUID(Gdiplus::ImageFormatJPEG, aguidFileTypes);
+    iGIF = FindGUID(Gdiplus::ImageFormatGIF, aguidFileTypes);
+    iPNG = FindGUID(Gdiplus::ImageFormatPNG, aguidFileTypes);
+    iTIFF = FindGUID(Gdiplus::ImageFormatTIFF, aguidFileTypes);
 
     ok_int(iNULL, -1);
     ok_int(iBMP, 0);
@@ -398,11 +398,11 @@ static void Test_Exporter(void)
     ok(iPNG > 0, "iPNG was %d\n", iPNG);
     ok(iTIFF > 0, "iTIFF was %d\n", iTIFF);
 
-    ok_int(iBMP, find_filter_item(strExporters, L"BMP (*.BMP;*.DIB;*.RLE)|*.BMP;*.DIB;*.RLE|"));
-    ok_int(iJPEG, find_filter_item(strExporters, L"JPEG (*.JPG;*.JPEG;*.JPE;*.JFIF)|*.JPG;*.JPEG;*.JPE;*.JFIF|"));
-    ok_int(iGIF, find_filter_item(strExporters, L"GIF (*.GIF)|*.GIF|"));
-    ok_int(iPNG, find_filter_item(strExporters, L"PNG (*.PNG)|*.PNG|"));
-    ok_int(iTIFF, find_filter_item(strExporters, L"TIFF (*.TIF;*.TIFF)|*.TIF;*.TIFF|"));
+    ok_int(iBMP, FindFilterItem(strExporters, L"BMP (*.BMP;*.DIB;*.RLE)|*.BMP;*.DIB;*.RLE|"));
+    ok_int(iJPEG, FindFilterItem(strExporters, L"JPEG (*.JPG;*.JPEG;*.JPE;*.JFIF)|*.JPG;*.JPEG;*.JPE;*.JFIF|"));
+    ok_int(iGIF, FindFilterItem(strExporters, L"GIF (*.GIF)|*.GIF|"));
+    ok_int(iPNG, FindFilterItem(strExporters, L"PNG (*.PNG)|*.PNG|"));
+    ok_int(iTIFF, FindFilterItem(strExporters, L"TIFF (*.TIF;*.TIFF)|*.TIF;*.TIFF|"));
 }
 
 START_TEST(CImage)

--- a/modules/rostests/apitests/atl/CImage.cpp
+++ b/modules/rostests/apitests/atl/CImage.cpp
@@ -261,7 +261,7 @@ static INT FindFilterItem(const TCHAR *filter, const TCHAR *item)
         if (bFoundSep && memcmp(item, filter, cbItem) == 0)
             return (iFilter + 1) / 2;
 
-        bFoundSep = (*filter == L'|');
+        bFoundSep = (*filter == TEXT('|'));
         if (bFoundSep)
             ++iFilter;
     }

--- a/modules/rostests/apitests/atl/CImage.cpp
+++ b/modules/rostests/apitests/atl/CImage.cpp
@@ -264,7 +264,7 @@ START_TEST(CImage)
                                          aguidFileTypes,
                                          TEXT("All Image Files"), 0);
     ok(hr == S_OK, "Expected hr to be S_OK, was: %ld\n", hr);
-    ok(aguidFileTypes.GetSize() == 9, "Expected aguidFileTypes.GetSize() to be 8, was %d.", aguidFileTypes.GetSize());
+    ok(aguidFileTypes.GetSize() == 9, "Expected aguidFileTypes.GetSize() to be 9, was %d.", aguidFileTypes.GetSize());
     ok(IsEqualGUID(aguidFileTypes[0], GUID_NULL), "Expected aguidFileTypes[0] to be GUID_NULL.\n");
     ok(IsEqualGUID(aguidFileTypes[1], Gdiplus::ImageFormatBMP), "Expected aguidFileTypes[1] to be Gdiplus::ImageFormatBMP.\n");
     ok(IsEqualGUID(aguidFileTypes[2], Gdiplus::ImageFormatJPEG), "Expected aguidFileTypes[2] to be Gdiplus::ImageFormatJPEG.\n");
@@ -291,24 +291,21 @@ START_TEST(CImage)
                                          aguidFileTypes,
                                          TEXT("All Image Files"), 0);
     ok(hr == S_OK, "Expected hr to be S_OK, was: %ld\n", hr);
-    ok(aguidFileTypes.GetSize() == 9, "Expected aguidFileTypes.GetSize() to be 8, was %d.", aguidFileTypes.GetSize());
+    ok(aguidFileTypes.GetSize() == 6, "Expected aguidFileTypes.GetSize() to be 6, was %d.", aguidFileTypes.GetSize());
     ok(IsEqualGUID(aguidFileTypes[0], GUID_NULL), "Expected aguidFileTypes[0] to be GUID_NULL.\n");
     ok(IsEqualGUID(aguidFileTypes[1], Gdiplus::ImageFormatBMP), "Expected aguidFileTypes[1] to be Gdiplus::ImageFormatBMP.\n");
     ok(IsEqualGUID(aguidFileTypes[2], Gdiplus::ImageFormatJPEG), "Expected aguidFileTypes[2] to be Gdiplus::ImageFormatJPEG.\n");
     ok(IsEqualGUID(aguidFileTypes[3], Gdiplus::ImageFormatGIF), "Expected aguidFileTypes[3] to be Gdiplus::ImageFormatGIF.\n");
-    ok(IsEqualGUID(aguidFileTypes[4], Gdiplus::ImageFormatEMF), "Expected aguidFileTypes[4] to be Gdiplus::ImageFormatEMF.\n");
-    ok(IsEqualGUID(aguidFileTypes[5], Gdiplus::ImageFormatWMF), "Expected aguidFileTypes[5] to be Gdiplus::ImageFormatWMF.\n");
-    ok(IsEqualGUID(aguidFileTypes[6], Gdiplus::ImageFormatTIFF), "Expected aguidFileTypes[6] to be Gdiplus::ImageFormatTIFF.\n");
-    ok(IsEqualGUID(aguidFileTypes[7], Gdiplus::ImageFormatPNG), "Expected aguidFileTypes[7] to be Gdiplus::ImageFormatPNG.\n");
-    ok(IsEqualGUID(aguidFileTypes[8], Gdiplus::ImageFormatIcon), "Expected aguidFileTypes[8] to be Gdiplus::ImageFormatIcon.\n");
+    ok(IsEqualGUID(aguidFileTypes[4], Gdiplus::ImageFormatTIFF), "Expected aguidFileTypes[6] to be Gdiplus::ImageFormatTIFF.\n");
+    ok(IsEqualGUID(aguidFileTypes[5], Gdiplus::ImageFormatPNG), "Expected aguidFileTypes[7] to be Gdiplus::ImageFormatPNG.\n");
 
     psz = strExporters.GetString();
 #ifdef UNICODE
     WideCharToMultiByte(CP_ACP, 0, psz, -1, szBuff, 512, NULL, NULL);
-    ok(lstrcmpA(szBuff, "All Image Files|*.BMP;*.DIB;*.RLE;*.JPG;*.JPEG;*.JPE;*.JFIF;*.GIF;*.EMF;*.WMF;*.TIF;*.TIFF;*.PNG;*.ICO|BMP (*.BMP;*.DIB;*.RLE)|*.BMP;*.DIB;*.RLE|JPEG (*.JPG;*.JPEG;*.JPE;*.JFIF)|*.JPG;*.JPEG;*.JPE;*.JFIF|GIF (*.GIF)|*.GIF|EMF (*.EMF)|*.EMF|WMF (*.WMF)|*.WMF|TIFF (*.TIF;*.TIFF)|*.TIF;*.TIFF|PNG (*.PNG)|*.PNG|ICO (*.ICO)|*.ICO||") == 0,
+    ok(lstrcmpA(szBuff, "All Image Files|*.BMP;*.DIB;*.RLE;*.JPG;*.JPEG;*.JPE;*.JFIF;*.GIF;*.TIF;*.TIFF;*.PNG|BMP (*.BMP;*.DIB;*.RLE)|*.BMP;*.DIB;*.RLE|JPEG (*.JPG;*.JPEG;*.JPE;*.JFIF)|*.JPG;*.JPEG;*.JPE;*.JFIF|GIF (*.GIF)|*.GIF|TIFF (*.TIF;*.TIFF)|*.TIF;*.TIFF|PNG (*.PNG)|*.PNG||") == 0,
        "The exporter filter string is bad, was: %s\n", szBuff);
 #else
-    ok(lstrcmpA(psz, "All Image Files|*.BMP;*.DIB;*.RLE;*.JPG;*.JPEG;*.JPE;*.JFIF;*.GIF;*.EMF;*.WMF;*.TIF;*.TIFF;*.PNG;*.ICO|BMP (*.BMP;*.DIB;*.RLE)|*.BMP;*.DIB;*.RLE|JPEG (*.JPG;*.JPEG;*.JPE;*.JFIF)|*.JPG;*.JPEG;*.JPE;*.JFIF|GIF (*.GIF)|*.GIF|EMF (*.EMF)|*.EMF|WMF (*.WMF)|*.WMF|TIFF (*.TIF;*.TIFF)|*.TIF;*.TIFF|PNG (*.PNG)|*.PNG|ICO (*.ICO)|*.ICO||") == 0,
+    ok(lstrcmpA(psz, "All Image Files|*.BMP;*.DIB;*.RLE;*.JPG;*.JPEG;*.JPE;*.JFIF;*.GIF;*.TIF;*.TIFF;*.PNG|BMP (*.BMP;*.DIB;*.RLE)|*.BMP;*.DIB;*.RLE|JPEG (*.JPG;*.JPEG;*.JPE;*.JFIF)|*.JPG;*.JPEG;*.JPE;*.JFIF|GIF (*.GIF)|*.GIF|TIFF (*.TIF;*.TIFF)|*.TIF;*.TIFF|PNG (*.PNG)|*.PNG||") == 0,
        "The exporter filter string is bad, was: %s\n", psz);
 #endif
 }

--- a/modules/rostests/apitests/atl/CImage.cpp
+++ b/modules/rostests/apitests/atl/CImage.cpp
@@ -254,15 +254,15 @@ static INT FindFilterItem(const TCHAR *filter, const TCHAR *item)
 {
     INT iFilter = 0;
     DWORD cbItem = lstrlen(item) * sizeof(TCHAR);
-    BOOL bFoundSep = TRUE;
+    BOOL bSep = TRUE;
 
     for (; *filter; ++filter)
     {
-        if (bFoundSep && memcmp(item, filter, cbItem) == 0)
+        if (bSep && memcmp(item, filter, cbItem) == 0)
             return (iFilter + 1) / 2;
 
-        bFoundSep = (*filter == TEXT('|'));
-        if (bFoundSep)
+        bSep = (*filter == TEXT('|'));
+        if (bSep)
             ++iFilter;
     }
 

--- a/modules/rostests/apitests/atl/CImage.cpp
+++ b/modules/rostests/apitests/atl/CImage.cpp
@@ -208,7 +208,7 @@ START_TEST(CImage)
     height = image2.GetHeight();
     ok_int(height, 48);
     bpp = image2.GetBPP();
-    ok_int(bpp, 32);
+    ok(bpp == 32 || bpp == 8, "bpp was %d\n", bpp);
 
     for (n = 0; n < _countof(szFiles); ++n)
     {
@@ -234,12 +234,11 @@ START_TEST(CImage)
         bpp = image2.GetBPP();
         if (n == 3)
         {
-            ok(bpp == 32, "Expected bpp to be 32, was: %d (for %i)\n", bpp, n);
+            ok(bpp == 24 || bpp == 32, "Expected bpp to be 24 or 32, was: %d (for %i)\n", bpp, n);
             determine_file_bpp(file, PixelFormat24bppRGB);
         }
         else
         {
-            ok(bpp == 32, "Expected bpp to be 32, was: %d (for %i)\n", bpp, n);
             determine_file_bpp(file, PixelFormat8bppIndexed);
         }
         color = image1.GetPixel(5, 5);
@@ -264,20 +263,20 @@ START_TEST(CImage)
                                          aguidFileTypes,
                                          TEXT("All Image Files"), 0);
     ok(hr == S_OK, "Expected hr to be S_OK, was: %ld\n", hr);
-    ok(aguidFileTypes.GetSize() == 9, "Expected aguidFileTypes.GetSize() to be 9, was %d.", aguidFileTypes.GetSize());
-    ok(IsEqualGUID(aguidFileTypes[0], GUID_NULL), "Expected aguidFileTypes[0] to be GUID_NULL.\n");
-    ok(IsEqualGUID(aguidFileTypes[1], Gdiplus::ImageFormatBMP), "Expected aguidFileTypes[1] to be Gdiplus::ImageFormatBMP.\n");
-    ok(IsEqualGUID(aguidFileTypes[2], Gdiplus::ImageFormatJPEG), "Expected aguidFileTypes[2] to be Gdiplus::ImageFormatJPEG.\n");
-    ok(IsEqualGUID(aguidFileTypes[3], Gdiplus::ImageFormatGIF), "Expected aguidFileTypes[3] to be Gdiplus::ImageFormatGIF.\n");
-    ok(IsEqualGUID(aguidFileTypes[4], Gdiplus::ImageFormatEMF), "Expected aguidFileTypes[4] to be Gdiplus::ImageFormatEMF.\n");
-    ok(IsEqualGUID(aguidFileTypes[5], Gdiplus::ImageFormatWMF), "Expected aguidFileTypes[5] to be Gdiplus::ImageFormatWMF.\n");
-    ok(IsEqualGUID(aguidFileTypes[6], Gdiplus::ImageFormatTIFF), "Expected aguidFileTypes[6] to be Gdiplus::ImageFormatTIFF.\n");
-    ok(IsEqualGUID(aguidFileTypes[7], Gdiplus::ImageFormatPNG), "Expected aguidFileTypes[7] to be Gdiplus::ImageFormatPNG.\n");
-    ok(IsEqualGUID(aguidFileTypes[8], Gdiplus::ImageFormatIcon), "Expected aguidFileTypes[8] to be Gdiplus::ImageFormatIcon.\n");
+    ok(aguidFileTypes.GetSize() >= 9, "Expected aguidFileTypes.GetSize() to be >= 9, was %d.", aguidFileTypes.GetSize());
+    ok_int(IsEqualGUID(aguidFileTypes[0], GUID_NULL), TRUE);
+    ok_int(IsEqualGUID(aguidFileTypes[1], Gdiplus::ImageFormatBMP), TRUE);
+    ok_int(IsEqualGUID(aguidFileTypes[2], Gdiplus::ImageFormatJPEG), TRUE);
+    ok_int(IsEqualGUID(aguidFileTypes[3], Gdiplus::ImageFormatGIF), TRUE);
+    ok_int(IsEqualGUID(aguidFileTypes[4], Gdiplus::ImageFormatEMF), TRUE);
+    ok_int(IsEqualGUID(aguidFileTypes[5], Gdiplus::ImageFormatWMF), TRUE);
+    ok_int(IsEqualGUID(aguidFileTypes[6], Gdiplus::ImageFormatTIFF), TRUE);
+    ok_int(IsEqualGUID(aguidFileTypes[7], Gdiplus::ImageFormatPNG), TRUE);
+    ok_int(IsEqualGUID(aguidFileTypes[8], Gdiplus::ImageFormatIcon), TRUE);
 
     psz = strImporters.GetString();
 #ifdef UNICODE
-    WideCharToMultiByte(CP_ACP, 0, psz, -1, szBuff, 512, NULL, NULL);
+    WideCharToMultiByte(CP_ACP, 0, psz, -1, szBuff, _countof(szBuff), NULL, NULL);
     ok(lstrcmpA(szBuff, "All Image Files|*.BMP;*.DIB;*.RLE;*.JPG;*.JPEG;*.JPE;*.JFIF;*.GIF;*.EMF;*.WMF;*.TIF;*.TIFF;*.PNG;*.ICO|BMP (*.BMP;*.DIB;*.RLE)|*.BMP;*.DIB;*.RLE|JPEG (*.JPG;*.JPEG;*.JPE;*.JFIF)|*.JPG;*.JPEG;*.JPE;*.JFIF|GIF (*.GIF)|*.GIF|EMF (*.EMF)|*.EMF|WMF (*.WMF)|*.WMF|TIFF (*.TIF;*.TIFF)|*.TIF;*.TIFF|PNG (*.PNG)|*.PNG|ICO (*.ICO)|*.ICO||") == 0,
        "The importer filter string is bad, was: %s\n", szBuff);
 #else
@@ -291,21 +290,45 @@ START_TEST(CImage)
                                          aguidFileTypes,
                                          TEXT("All Image Files"), 0);
     ok(hr == S_OK, "Expected hr to be S_OK, was: %ld\n", hr);
-    ok(aguidFileTypes.GetSize() == 6, "Expected aguidFileTypes.GetSize() to be 6, was %d.", aguidFileTypes.GetSize());
-    ok(IsEqualGUID(aguidFileTypes[0], GUID_NULL), "Expected aguidFileTypes[0] to be GUID_NULL.\n");
-    ok(IsEqualGUID(aguidFileTypes[1], Gdiplus::ImageFormatBMP), "Expected aguidFileTypes[1] to be Gdiplus::ImageFormatBMP.\n");
-    ok(IsEqualGUID(aguidFileTypes[2], Gdiplus::ImageFormatJPEG), "Expected aguidFileTypes[2] to be Gdiplus::ImageFormatJPEG.\n");
-    ok(IsEqualGUID(aguidFileTypes[3], Gdiplus::ImageFormatGIF), "Expected aguidFileTypes[3] to be Gdiplus::ImageFormatGIF.\n");
-    ok(IsEqualGUID(aguidFileTypes[4], Gdiplus::ImageFormatTIFF), "Expected aguidFileTypes[6] to be Gdiplus::ImageFormatTIFF.\n");
-    ok(IsEqualGUID(aguidFileTypes[5], Gdiplus::ImageFormatPNG), "Expected aguidFileTypes[7] to be Gdiplus::ImageFormatPNG.\n");
+    ok(aguidFileTypes.GetSize() >= 6, "Expected aguidFileTypes.GetSize() to be >= 6, was %d.", aguidFileTypes.GetSize());
+    ok_int(IsEqualGUID(aguidFileTypes[0], GUID_NULL), TRUE);
+    ok_int(IsEqualGUID(aguidFileTypes[1], Gdiplus::ImageFormatBMP), TRUE);
+    ok_int(IsEqualGUID(aguidFileTypes[2], Gdiplus::ImageFormatJPEG), TRUE);
+    ok_int(IsEqualGUID(aguidFileTypes[3], Gdiplus::ImageFormatGIF), TRUE);
+    BOOL bEmfSupported = IsEqualGUID(aguidFileTypes[4], Gdiplus::ImageFormatEMF);
+    if (bEmfSupported)
+    {
+        ok_int(IsEqualGUID(aguidFileTypes[4], Gdiplus::ImageFormatEMF), TRUE);
+        ok_int(IsEqualGUID(aguidFileTypes[5], Gdiplus::ImageFormatWMF), TRUE);
+    }
+    else
+    {
+        ok_int(IsEqualGUID(aguidFileTypes[4], Gdiplus::ImageFormatTIFF), TRUE);
+        ok_int(IsEqualGUID(aguidFileTypes[5], Gdiplus::ImageFormatPNG), TRUE);
+    }
+
+    static const char FilterWithEmf[] =
+        "All Image Files|*.BMP;*.DIB;*.RLE;*.JPG;*.JPEG;*.JPE;*.JFIF;*.GIF;*.EMF;*.WMF;*.TIF;*.TIFF;*.PNG;*.ICO|"
+        "BMP (*.BMP;*.DIB;*.RLE)|*.BMP;*.DIB;*.RLE|"
+        "JPEG (*.JPG;*.JPEG;*.JPE;*.JFIF)|*.JPG;*.JPEG;*.JPE;*.JFIF|"
+        "GIF (*.GIF)|*.GIF|"
+        "EMF (*.EMF)|*.EMF|WMF (*.WMF)|*.WMF|"
+        "TIFF (*.TIF;*.TIFF)|*.TIF;*.TIFF|"
+        "PNG (*.PNG)|*.PNG|"
+        "ICO (*.ICO)|*.ICO||";
+    static const char FilterNoEmf[] =
+        "All Image Files|*.BMP;*.DIB;*.RLE;*.JPG;*.JPEG;*.JPE;*.JFIF;*.GIF;*.TIF;*.TIFF;*.PNG|"
+        "BMP (*.BMP;*.DIB;*.RLE)|*.BMP;*.DIB;*.RLE|"
+        "JPEG (*.JPG;*.JPEG;*.JPE;*.JFIF)|*.JPG;*.JPEG;*.JPE;*.JFIF|"
+        "GIF (*.GIF)|*.GIF|"
+        "TIFF (*.TIF;*.TIFF)|*.TIF;*.TIFF|"
+        "PNG (*.PNG)|*.PNG||";
 
     psz = strExporters.GetString();
 #ifdef UNICODE
-    WideCharToMultiByte(CP_ACP, 0, psz, -1, szBuff, 512, NULL, NULL);
-    ok(lstrcmpA(szBuff, "All Image Files|*.BMP;*.DIB;*.RLE;*.JPG;*.JPEG;*.JPE;*.JFIF;*.GIF;*.TIF;*.TIFF;*.PNG|BMP (*.BMP;*.DIB;*.RLE)|*.BMP;*.DIB;*.RLE|JPEG (*.JPG;*.JPEG;*.JPE;*.JFIF)|*.JPG;*.JPEG;*.JPE;*.JFIF|GIF (*.GIF)|*.GIF|TIFF (*.TIF;*.TIFF)|*.TIF;*.TIFF|PNG (*.PNG)|*.PNG||") == 0,
-       "The exporter filter string is bad, was: %s\n", szBuff);
+    WideCharToMultiByte(CP_ACP, 0, psz, -1, szBuff, _countof(szBuff), NULL, NULL);
+    ok_str(szBuff, (bEmfSupported ? FilterWithEmf : FilterNoEmf));
 #else
-    ok(lstrcmpA(psz, "All Image Files|*.BMP;*.DIB;*.RLE;*.JPG;*.JPEG;*.JPE;*.JFIF;*.GIF;*.TIF;*.TIFF;*.PNG|BMP (*.BMP;*.DIB;*.RLE)|*.BMP;*.DIB;*.RLE|JPEG (*.JPG;*.JPEG;*.JPE;*.JFIF)|*.JPG;*.JPEG;*.JPE;*.JFIF|GIF (*.GIF)|*.GIF|TIFF (*.TIF;*.TIFF)|*.TIF;*.TIFF|PNG (*.PNG)|*.PNG||") == 0,
-       "The exporter filter string is bad, was: %s\n", psz);
+    ok_str(psz, (bEmfSupported ? FilterWithEmf : FilterNoEmf));
 #endif
 }

--- a/modules/rostests/apitests/atl/CImage.cpp
+++ b/modules/rostests/apitests/atl/CImage.cpp
@@ -250,10 +250,10 @@ static INT FindGUID(REFGUID rguid, const CSimpleArray<GUID>& guids)
     return -1;
 }
 
-static INT FindFilterItem(const WCHAR *filter, const WCHAR *item)
+static INT FindFilterItem(const TCHAR *filter, const TCHAR *item)
 {
     INT iFilter = 0;
-    size_t cbItem = wcslen(item) * sizeof(WCHAR);
+    DWORD cbItem = lstrlen(item) * sizeof(TCHAR);
     BOOL bFoundSep = TRUE;
     for (; *filter; ++filter)
     {
@@ -301,12 +301,12 @@ static void Test_Importer(void)
     ok(iEMF > 0, "iEMF was %d\n", iEMF);
     ok(iWMF > 0, "iWMF was %d\n", iWMF);
 
-    ok_int(memcmp(strImporters, L"All Image Files|", sizeof(L"All Image Files|") - sizeof(UNICODE_NULL)), 0);
-    ok_int(iBMP, FindFilterItem(strImporters, L"BMP (*.BMP;*.DIB;*.RLE)|*.BMP;*.DIB;*.RLE|"));
-    ok_int(iJPEG, FindFilterItem(strImporters, L"JPEG (*.JPG;*.JPEG;*.JPE;*.JFIF)|*.JPG;*.JPEG;*.JPE;*.JFIF|"));
-    ok_int(iGIF, FindFilterItem(strImporters, L"GIF (*.GIF)|*.GIF|"));
-    ok_int(iPNG, FindFilterItem(strImporters, L"PNG (*.PNG)|*.PNG|"));
-    ok_int(iTIFF, FindFilterItem(strImporters, L"TIFF (*.TIF;*.TIFF)|*.TIF;*.TIFF|"));
+    ok_int(memcmp(strImporters, TEXT("All Image Files|"), sizeof(TEXT("All Image Files|")) - sizeof(TCHAR)), 0);
+    ok_int(iBMP, FindFilterItem(strImporters, TEXT("BMP (*.BMP;*.DIB;*.RLE)|*.BMP;*.DIB;*.RLE|")));
+    ok_int(iJPEG, FindFilterItem(strImporters, TEXT("JPEG (*.JPG;*.JPEG;*.JPE;*.JFIF)|*.JPG;*.JPEG;*.JPE;*.JFIF|")));
+    ok_int(iGIF, FindFilterItem(strImporters, TEXT("GIF (*.GIF)|*.GIF|")));
+    ok_int(iPNG, FindFilterItem(strImporters, TEXT("PNG (*.PNG)|*.PNG|")));
+    ok_int(iTIFF, FindFilterItem(strImporters, TEXT("TIFF (*.TIF;*.TIFF)|*.TIF;*.TIFF|")));
 
     // Try importer without "All Image Files"
     aguidFileTypes.RemoveAll();
@@ -334,11 +334,11 @@ static void Test_Importer(void)
     ok(iEMF > 0, "iEMF was %d\n", iEMF);
     ok(iWMF > 0, "iWMF was %d\n", iWMF);
 
-    ok_int(iBMP, FindFilterItem(strImporters, L"BMP (*.BMP;*.DIB;*.RLE)|*.BMP;*.DIB;*.RLE|"));
-    ok_int(iJPEG, FindFilterItem(strImporters, L"JPEG (*.JPG;*.JPEG;*.JPE;*.JFIF)|*.JPG;*.JPEG;*.JPE;*.JFIF|"));
-    ok_int(iGIF, FindFilterItem(strImporters, L"GIF (*.GIF)|*.GIF|"));
-    ok_int(iPNG, FindFilterItem(strImporters, L"PNG (*.PNG)|*.PNG|"));
-    ok_int(iTIFF, FindFilterItem(strImporters, L"TIFF (*.TIF;*.TIFF)|*.TIF;*.TIFF|"));
+    ok_int(iBMP, FindFilterItem(strImporters, TEXT("BMP (*.BMP;*.DIB;*.RLE)|*.BMP;*.DIB;*.RLE|")));
+    ok_int(iJPEG, FindFilterItem(strImporters, TEXT("JPEG (*.JPG;*.JPEG;*.JPE;*.JFIF)|*.JPG;*.JPEG;*.JPE;*.JFIF|")));
+    ok_int(iGIF, FindFilterItem(strImporters, TEXT("GIF (*.GIF)|*.GIF|")));
+    ok_int(iPNG, FindFilterItem(strImporters, TEXT("PNG (*.PNG)|*.PNG|")));
+    ok_int(iTIFF, FindFilterItem(strImporters, TEXT("TIFF (*.TIF;*.TIFF)|*.TIF;*.TIFF|")));
 }
 
 static void Test_Exporter(void)
@@ -370,11 +370,11 @@ static void Test_Exporter(void)
     ok(iPNG > 0, "iPNG was %d\n", iPNG);
     ok(iTIFF > 0, "iTIFF was %d\n", iTIFF);
 
-    ok_int(iBMP, FindFilterItem(strExporters, L"BMP (*.BMP;*.DIB;*.RLE)|*.BMP;*.DIB;*.RLE|"));
-    ok_int(iJPEG, FindFilterItem(strExporters, L"JPEG (*.JPG;*.JPEG;*.JPE;*.JFIF)|*.JPG;*.JPEG;*.JPE;*.JFIF|"));
-    ok_int(iGIF, FindFilterItem(strExporters, L"GIF (*.GIF)|*.GIF|"));
-    ok_int(iPNG, FindFilterItem(strExporters, L"PNG (*.PNG)|*.PNG|"));
-    ok_int(iTIFF, FindFilterItem(strExporters, L"TIFF (*.TIF;*.TIFF)|*.TIF;*.TIFF|"));
+    ok_int(iBMP, FindFilterItem(strExporters, TEXT("BMP (*.BMP;*.DIB;*.RLE)|*.BMP;*.DIB;*.RLE|")));
+    ok_int(iJPEG, FindFilterItem(strExporters, TEXT("JPEG (*.JPG;*.JPEG;*.JPE;*.JFIF)|*.JPG;*.JPEG;*.JPE;*.JFIF|")));
+    ok_int(iGIF, FindFilterItem(strExporters, TEXT("GIF (*.GIF)|*.GIF|")));
+    ok_int(iPNG, FindFilterItem(strExporters, TEXT("PNG (*.PNG)|*.PNG|")));
+    ok_int(iTIFF, FindFilterItem(strExporters, TEXT("TIFF (*.TIF;*.TIFF)|*.TIF;*.TIFF|")));
 
     // Try exporter without "All Image Files"
     strExporters.Empty();
@@ -398,11 +398,11 @@ static void Test_Exporter(void)
     ok(iPNG > 0, "iPNG was %d\n", iPNG);
     ok(iTIFF > 0, "iTIFF was %d\n", iTIFF);
 
-    ok_int(iBMP, FindFilterItem(strExporters, L"BMP (*.BMP;*.DIB;*.RLE)|*.BMP;*.DIB;*.RLE|"));
-    ok_int(iJPEG, FindFilterItem(strExporters, L"JPEG (*.JPG;*.JPEG;*.JPE;*.JFIF)|*.JPG;*.JPEG;*.JPE;*.JFIF|"));
-    ok_int(iGIF, FindFilterItem(strExporters, L"GIF (*.GIF)|*.GIF|"));
-    ok_int(iPNG, FindFilterItem(strExporters, L"PNG (*.PNG)|*.PNG|"));
-    ok_int(iTIFF, FindFilterItem(strExporters, L"TIFF (*.TIF;*.TIFF)|*.TIF;*.TIFF|"));
+    ok_int(iBMP, FindFilterItem(strExporters, TEXT("BMP (*.BMP;*.DIB;*.RLE)|*.BMP;*.DIB;*.RLE|")));
+    ok_int(iJPEG, FindFilterItem(strExporters, TEXT("JPEG (*.JPG;*.JPEG;*.JPE;*.JFIF)|*.JPG;*.JPEG;*.JPE;*.JFIF|")));
+    ok_int(iGIF, FindFilterItem(strExporters, TEXT("GIF (*.GIF)|*.GIF|")));
+    ok_int(iPNG, FindFilterItem(strExporters, TEXT("PNG (*.PNG)|*.PNG|")));
+    ok_int(iTIFF, FindFilterItem(strExporters, TEXT("TIFF (*.TIF;*.TIFF)|*.TIF;*.TIFF|")));
 }
 
 START_TEST(CImage)

--- a/modules/rostests/apitests/atl/CImage.cpp
+++ b/modules/rostests/apitests/atl/CImage.cpp
@@ -134,7 +134,7 @@ static void determine_file_bpp(TCHAR* tfile, Gdiplus::PixelFormat expect_pf)
     Shutdown(gdiplusToken);
 }
 
-static void Test_SaveImage(void)
+static void Test_LoadSaveImage(void)
 {
     HRESULT hr;
     TCHAR* file;
@@ -144,12 +144,6 @@ static void Test_SaveImage(void)
     CImage image1, image2;
     COLORREF color;
     HDC hDC;
-
-#if 0
-    width = image1.GetWidth();
-    height = image1.GetHeight();
-    bpp = image1.GetBPP();
-#endif
 
     HINSTANCE hInst = GetModuleHandle(NULL);
     GetTempPath(MAX_PATH, szTempPath);
@@ -413,7 +407,7 @@ static void Test_Exporter(void)
 
 START_TEST(CImage)
 {
-    Test_SaveImage();
+    Test_LoadSaveImage();
     Test_Importer();
     Test_Exporter();
 }

--- a/modules/rostests/apitests/atl/CImage.cpp
+++ b/modules/rostests/apitests/atl/CImage.cpp
@@ -255,6 +255,7 @@ static INT FindFilterItem(const TCHAR *filter, const TCHAR *item)
     INT iFilter = 0;
     DWORD cbItem = lstrlen(item) * sizeof(TCHAR);
     BOOL bFoundSep = TRUE;
+
     for (; *filter; ++filter)
     {
         if (bFoundSep && memcmp(item, filter, cbItem) == 0)

--- a/modules/rostests/apitests/atl/devenv/.gitignore
+++ b/modules/rostests/apitests/atl/devenv/.gitignore
@@ -18,3 +18,5 @@ CSimpleArray/
 CSimpleMap/
 CString/
 SubclassWindow/
+Debug/
+Release/

--- a/modules/rostests/apitests/atl/devenv/CImage.vcxproj
+++ b/modules/rostests/apitests/atl/devenv/CImage.vcxproj
@@ -93,6 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_WINDOWS;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <ResourceCompile>
       <Culture>0x0409</Culture>

--- a/modules/rostests/apitests/atl/devenv/CImage.vcxproj
+++ b/modules/rostests/apitests/atl/devenv/CImage.vcxproj
@@ -130,6 +130,7 @@
       <Optimization>MaxSpeed</Optimization>
       <PreprocessorDefinitions>WIN32;_WINDOWS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <ResourceCompile>
       <Culture>0x0409</Culture>

--- a/modules/rostests/apitests/atl/devenv/CImage.vcxproj
+++ b/modules/rostests/apitests/atl/devenv/CImage.vcxproj
@@ -93,7 +93,6 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_WINDOWS;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <ResourceCompile>
       <Culture>0x0409</Culture>
@@ -130,7 +129,6 @@
       <Optimization>MaxSpeed</Optimization>
       <PreprocessorDefinitions>WIN32;_WINDOWS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <ResourceCompile>
       <Culture>0x0409</Culture>

--- a/sdk/lib/atl/atlimage.h
+++ b/sdk/lib/atl/atlimage.h
@@ -764,13 +764,8 @@ private:
                 CString ext(pCodecs[i].FilenameExtension);
                 extensions += ext;
             }
-            extensions.MakeLower();
 
-            strFilter += TEXT(" (");
-            strFilter += extensions;
-            strFilter += TEXT(")");
             strFilter += chSeparator;
-
             strFilter += extensions;
             strFilter += chSeparator;
 
@@ -783,7 +778,6 @@ private:
                 continue;
 
             CString extensions(pCodecs[i].FilenameExtension);
-            extensions.MakeLower();
 
             CString desc(pCodecs[i].FormatDescription);
             strFilter += desc;


### PR DESCRIPTION
## Purpose

Improve compatibility of `CImage`.
JIRA issue: [CORE-19008](https://jira.reactos.org/browse/CORE-19008)

## Proposed changes

- Improve `CImage` testcase of `atl_apitest.exe`.
- Improve `CImage::BuildCodecFilterString`.

## TODO

- [x] Do tests.

## Screenshot

Visual Studio 2015 in Win10:
![image](https://github.com/reactos/reactos/assets/2107452/de916ac5-af14-4d9a-9951-d1ae0de5094a)
Successful.

Win10 (AFTER):
![Win10](https://github.com/reactos/reactos/assets/2107452/282c1e14-0915-4efd-bf2a-aacd9a82bdae)
Successful.

WinXP (AFTER):
![WinXP](https://github.com/reactos/reactos/assets/2107452/fa099dcc-8380-421a-9c37-18e813d16b10)
Successful.

Win2k3 (AFTER):
![Win2k3](https://github.com/reactos/reactos/assets/2107452/724fce65-0254-42b2-8400-dcbe5d381f6b)
Successful.