### PR TITLE
[NTUSER][USER32] Remove 1+3 remnant defines

### DIFF
--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -60,8 +60,6 @@ BOOL fInEndMenu = FALSE;
 #define IS_SYSTEM_MENU(MenuInfo)  \
 	(!((MenuInfo)->fFlags & MNF_POPUP) && ((MenuInfo)->fFlags & MNF_SYSMENU))
 
-#define IS_BITMAP_ITEM(flags) (MF_BITMAP == MENU_ITEM_TYPE(flags))
-
 #define IS_MAGIC_BITMAP(id) ((id) && ((INT_PTR)(id) < 12) && ((INT_PTR)(id) >= -1))
 #define IS_STRING_ITEM(flags) (MF_STRING == MENU_ITEM_TYPE(flags))
 

--- a/win32ss/user/user32/windows/menu.c
+++ b/win32ss/user/user32/windows/menu.c
@@ -42,14 +42,6 @@ WINE_DEFAULT_DEBUG_CHANNEL(menu);
 #define IS_STRING_ITEM(flags) (MF_STRING == MENU_ITEM_TYPE(flags))
 #define IS_MAGIC_BITMAP(id) ((id) && ((INT_PTR)(id) < 12) && ((INT_PTR)(id) >= -1))
 
-#define IS_SYSTEM_MENU(MenuInfo)  \
-	(0 == ((MenuInfo)->fFlags & MNF_POPUP) && 0 != ((MenuInfo)->fFlags & MNF_SYSMENU))
-
-#define IS_SYSTEM_POPUP(MenuInfo) \
-	(0 != ((MenuInfo)->fFlags & MNF_POPUP) && 0 != ((MenuInfo)->fFlags & MNF_SYSMENU))
-
-#define IS_BITMAP_ITEM(flags) (MF_BITMAP == MENU_ITEM_TYPE(flags))
-
 /*********************************************************************
  * PopupMenu class descriptor
  */


### PR DESCRIPTION
## Purpose

Trivial cleanup.

## Proposed changes

IS_SYSTEM_MENU():
"moved" to ntuser on 6dfa71c (r68904).

IS_SYSTEM_POPUP():
uselessly added on 6fc29cc (r8195).

IS_BITMAP_ITEM():
uses removed on 07b6ddc (r23221).
uselessly copied to ntuser on 6dfa71c (r68904).