### PR TITLE
[SHELL32] Handle the Progman Folder options message and tab switching support

### DIFF
--- a/base/shell/rshell/misc.cpp
+++ b/base/shell/rshell/misc.cpp
@@ -274,3 +274,11 @@ LPVOID *ppv)
 
     return ShellObjectCreatorInit<CRShellClassFactory>(rclsid, riid, ppv);
 }
+
+VOID WINAPI ShowFolderOptionsDialog(UINT Page, BOOL Async)
+{
+    char buf[MAX_PATH];
+    wsprintfA(buf, "rundll32.exe shell32.dll,Options_RunDLL %u", Page);
+    WinExec(buf, SW_SHOW);
+}
+

--- a/dll/win32/shell32/dialogs/folder_options.cpp
+++ b/dll/win32/shell32/dialogs/folder_options.cpp
@@ -192,10 +192,13 @@ HBITMAP CreateRadioMask(HDC hDC)
 
 // CMSGlobalFolderOptionsStub --- The owner window of Folder Options.
 // This window hides taskbar button of Folder Options.
+
+#define GlobalFolderOptionsClassName _T("MSGlobalFolderOptionsStub")
+
 class CMSGlobalFolderOptionsStub : public CWindowImpl<CMSGlobalFolderOptionsStub>
 {
 public:
-    DECLARE_WND_CLASS_EX(_T("MSGlobalFolderOptionsStub"), 0, COLOR_WINDOWTEXT)
+    DECLARE_WND_CLASS_EX(GlobalFolderOptionsClassName, 0, COLOR_WINDOWTEXT)
 
     BEGIN_MSG_MAP(CMSGlobalFolderOptionsStub)
     END_MSG_MAP()
@@ -222,8 +225,10 @@ PropSheetProc(HWND hwndDlg, UINT uMsg, LPARAM lParam)
     return 0;
 }
 
-static VOID
-ShowFolderOptionsDialog(HWND hWnd, HINSTANCE hInst)
+enum { PAGE_GENERAL, PAGE_VIEW, PAGE_FILETYPES };
+
+static DWORD CALLBACK
+ShowFolderOptionsDialogThreadProc(LPVOID param)
 {
     PROPSHEETHEADERW pinfo;
     HPROPSHEETPAGE hppages[3];
@@ -254,7 +259,7 @@ ShowFolderOptionsDialog(HWND hWnd, HINSTANCE hInst)
     if (!stub.Create(NULL, NULL, NULL, style, exstyle))
     {
         ERR("stub.Create failed\n");
-        return;
+        return 0;
     }
 
     memset(&pinfo, 0x0, sizeof(PROPSHEETHEADERW));
@@ -266,10 +271,34 @@ ShowFolderOptionsDialog(HWND hWnd, HINSTANCE hInst)
     pinfo.pszIcon = MAKEINTRESOURCEW(IDI_SHELL_FOLDER_OPTIONS);
     pinfo.pszCaption = szOptions;
     pinfo.pfnCallback = PropSheetProc;
+    pinfo.nStartPage = (UINT) param;
 
     PropertySheetW(&pinfo);
 
     stub.DestroyWindow();
+    return 0;
+}
+
+VOID WINAPI 
+ShowFolderOptionsDialog(UINT Page, BOOL Async = false)
+{
+    HWND hWnd = FindWindow(GlobalFolderOptionsClassName, NULL);
+    if (hWnd)
+    {
+        HWND hPop = GetLastActivePopup(hWnd);
+        if (hWnd == GetParent(hPop))
+        {
+            PostMessage(hPop, PSM_SETCURSEL, Page, 0);
+        }
+        SetForegroundWindow(hPop);
+        return ;
+    }
+    
+    LPVOID param = (LPVOID) Page;
+    if (Async)
+        SHCreateThread(ShowFolderOptionsDialogThreadProc, param, 0, 0);
+    else
+        ShowFolderOptionsDialogThreadProc(param); // Rundll32 caller cannot be async!
 }
 
 static VOID
@@ -278,13 +307,15 @@ Options_RunDLLCommon(HWND hWnd, HINSTANCE hInst, int fOptions, DWORD nCmdShow)
     switch(fOptions)
     {
         case 0:
-            ShowFolderOptionsDialog(hWnd, hInst);
+            ShowFolderOptionsDialog(PAGE_GENERAL);
             break;
 
-        case 1:
-            // show taskbar options dialog
-            FIXME("notify explorer to show taskbar options dlg\n");
-            //PostMessage(GetShellWindow(), WM_USER+22, fOptions, 0);
+        case 1: // Show taskbar options dialog
+            PostMessage(GetShellWindow(), WM_USER+22, fOptions, 0);
+            break;
+
+        case 7: // Windows 8, 10
+            ShowFolderOptionsDialog(PAGE_VIEW);
             break;
 
         default:

--- a/dll/win32/shell32/dialogs/folder_options.cpp
+++ b/dll/win32/shell32/dialogs/folder_options.cpp
@@ -284,7 +284,7 @@ ShowFolderOptionsDialogThreadProc(LPVOID param)
 }
 
 VOID WINAPI 
-ShowFolderOptionsDialog(UINT Page, BOOL Async = false)
+ShowFolderOptionsDialog(UINT Page, BOOL Async = FALSE)
 {
     HWND hWnd = FindWindow(GlobalFolderOptionsClassName, NULL);
     if (hWnd)

--- a/dll/win32/shell32/dialogs/folder_options.cpp
+++ b/dll/win32/shell32/dialogs/folder_options.cpp
@@ -225,7 +225,11 @@ PropSheetProc(HWND hwndDlg, UINT uMsg, LPARAM lParam)
     return 0;
 }
 
-enum { PAGE_GENERAL, PAGE_VIEW, PAGE_FILETYPES };
+enum {
+    PAGE_GENERAL,
+    PAGE_VIEW,
+    PAGE_FILETYPES
+};
 
 static DWORD CALLBACK
 ShowFolderOptionsDialogThreadProc(LPVOID param)
@@ -271,7 +275,7 @@ ShowFolderOptionsDialogThreadProc(LPVOID param)
     pinfo.pszIcon = MAKEINTRESOURCEW(IDI_SHELL_FOLDER_OPTIONS);
     pinfo.pszCaption = szOptions;
     pinfo.pfnCallback = PropSheetProc;
-    pinfo.nStartPage = (UINT) param;
+    pinfo.nStartPage = (UINT)param;
 
     PropertySheetW(&pinfo);
 
@@ -291,10 +295,10 @@ ShowFolderOptionsDialog(UINT Page, BOOL Async = false)
             PostMessage(hPop, PSM_SETCURSEL, Page, 0);
         }
         SetForegroundWindow(hPop);
-        return ;
+        return;
     }
     
-    LPVOID param = (LPVOID) Page;
+    LPVOID param = (LPVOID)Page;
     if (Async)
         SHCreateThread(ShowFolderOptionsDialogThreadProc, param, 0, 0);
     else

--- a/dll/win32/shell32/dialogs/folder_options.cpp
+++ b/dll/win32/shell32/dialogs/folder_options.cpp
@@ -298,7 +298,7 @@ ShowFolderOptionsDialog(UINT Page, BOOL Async = FALSE)
         return;
     }
     
-    LPVOID param = (LPVOID)Page;
+    LPVOID param = (LPVOID)(UINT_PTR)Page;
     if (Async)
         SHCreateThread(ShowFolderOptionsDialogThreadProc, param, 0, 0);
     else

--- a/dll/win32/shell32/dialogs/folder_options.cpp
+++ b/dll/win32/shell32/dialogs/folder_options.cpp
@@ -275,7 +275,7 @@ ShowFolderOptionsDialogThreadProc(LPVOID param)
     pinfo.pszIcon = MAKEINTRESOURCEW(IDI_SHELL_FOLDER_OPTIONS);
     pinfo.pszCaption = szOptions;
     pinfo.pfnCallback = PropSheetProc;
-    pinfo.nStartPage = (UINT)param;
+    pinfo.nStartPage = (UINT)(UINT_PTR)param;
 
     PropertySheetW(&pinfo);
 

--- a/dll/win32/shell32/dialogs/folder_options.cpp
+++ b/dll/win32/shell32/dialogs/folder_options.cpp
@@ -275,7 +275,7 @@ ShowFolderOptionsDialogThreadProc(LPVOID param)
     pinfo.pszIcon = MAKEINTRESOURCEW(IDI_SHELL_FOLDER_OPTIONS);
     pinfo.pszCaption = szOptions;
     pinfo.pfnCallback = PropSheetProc;
-    pinfo.nStartPage = (UINT)(UINT_PTR)param;
+    pinfo.nStartPage = PtrToUlong(param);
 
     PropertySheetW(&pinfo);
 
@@ -298,7 +298,7 @@ ShowFolderOptionsDialog(UINT Page, BOOL Async = FALSE)
         return;
     }
     
-    LPVOID param = (LPVOID)(UINT_PTR)Page;
+    LPVOID param = UlongToPtr(Page);
     if (Async)
         SHCreateThread(ShowFolderOptionsDialogThreadProc, param, 0, 0);
     else
@@ -314,8 +314,13 @@ Options_RunDLLCommon(HWND hWnd, HINSTANCE hInst, int fOptions, DWORD nCmdShow)
             ShowFolderOptionsDialog(PAGE_GENERAL);
             break;
 
-        case 1: // Show taskbar options dialog
-            PostMessage(GetShellWindow(), WM_USER+22, fOptions, 0);
+        case 1: // Taskbar settings
+#if (NTDDI_VERSION >= NTDDI_VISTA)
+        case 3: // Start menu settings
+        case 4: // Tray icon settings
+        case 6: // Taskbar toolbars
+#endif
+            PostMessage(GetShellWindow(), WM_PROGMAN_OPENSHELLSETTINGS, fOptions, 0);
             break;
 
         case 7: // Windows 8, 10

--- a/dll/win32/shell32/shelldesktop/CDesktopBrowser.cpp
+++ b/dll/win32/shell32/shelldesktop/CDesktopBrowser.cpp
@@ -467,7 +467,7 @@ LRESULT CDesktopBrowser::OnShowOptionsDlg(UINT uMsg, WPARAM wParam, LPARAM lPara
     switch (wParam)
     {
         case 0:
-            ShowFolderOptionsDialog(0, true);
+            ShowFolderOptionsDialog(0, TRUE);
             break;
         case 1:
             _NotifyTray(WM_COMMAND, TRAYCMD_TASKBAR_PROPERTIES, 0);

--- a/dll/win32/shell32/shelldesktop/CDesktopBrowser.cpp
+++ b/dll/win32/shell32/shelldesktop/CDesktopBrowser.cpp
@@ -85,6 +85,7 @@ public:
     LRESULT OnCommand(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
     LRESULT OnSetFocus(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
     LRESULT OnGetChangeNotifyServer(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
+    LRESULT OnShowOptionsDlg(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
 
 DECLARE_WND_CLASS_EX(szProgmanClassName, CS_DBLCLKS, COLOR_DESKTOP)
 
@@ -98,6 +99,7 @@ BEGIN_MSG_MAP(CBaseBar)
     MESSAGE_HANDLER(WM_COMMAND, OnCommand)
     MESSAGE_HANDLER(WM_SETFOCUS, OnSetFocus)
     MESSAGE_HANDLER(WM_DESKTOP_GET_CNOTIFY_SERVER, OnGetChangeNotifyServer)
+    MESSAGE_HANDLER(WM_USER+22, OnShowOptionsDlg)
 END_MSG_MAP()
 
 BEGIN_COM_MAP(CDesktopBrowser)
@@ -456,6 +458,22 @@ LRESULT CDesktopBrowser::OnGetChangeNotifyServer(UINT uMsg, WPARAM wParam, LPARA
             return NULL;
     }
     return (LRESULT)m_hwndChangeNotifyServer;
+}
+
+extern VOID WINAPI ShowFolderOptionsDialog(UINT Page, BOOL Async);
+
+LRESULT CDesktopBrowser::OnShowOptionsDlg(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled)
+{
+    switch(wParam)
+    {
+    case 0:
+        ShowFolderOptionsDialog(0, true);
+        break;
+    case 1:
+        _NotifyTray(WM_COMMAND, TRAYCMD_TASKBAR_PROPERTIES, 0);
+        break;
+    }
+    return 0;
 }
 
 HRESULT CDesktopBrowser_CreateInstance(IShellDesktopTray *Tray, REFIID riid, void **ppv)

--- a/dll/win32/shell32/shelldesktop/CDesktopBrowser.cpp
+++ b/dll/win32/shell32/shelldesktop/CDesktopBrowser.cpp
@@ -464,14 +464,14 @@ extern VOID WINAPI ShowFolderOptionsDialog(UINT Page, BOOL Async);
 
 LRESULT CDesktopBrowser::OnShowOptionsDlg(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled)
 {
-    switch(wParam)
+    switch (wParam)
     {
-    case 0:
-        ShowFolderOptionsDialog(0, true);
-        break;
-    case 1:
-        _NotifyTray(WM_COMMAND, TRAYCMD_TASKBAR_PROPERTIES, 0);
-        break;
+        case 0:
+            ShowFolderOptionsDialog(0, true);
+            break;
+        case 1:
+            _NotifyTray(WM_COMMAND, TRAYCMD_TASKBAR_PROPERTIES, 0);
+            break;
     }
     return 0;
 }

--- a/dll/win32/shell32/shelldesktop/CDesktopBrowser.cpp
+++ b/dll/win32/shell32/shelldesktop/CDesktopBrowser.cpp
@@ -471,7 +471,7 @@ LRESULT CDesktopBrowser::OnShowOptionsDlg(UINT uMsg, WPARAM wParam, LPARAM lPara
         case 2:
         case 7:
 #endif
-            ShowFolderOptionsDialog(PtrToUlong(wParam), TRUE);
+            ShowFolderOptionsDialog((UINT)(UINT_PTR)wParam, TRUE);
             break;
         case 1:
             _NotifyTray(WM_COMMAND, TRAYCMD_TASKBAR_PROPERTIES, 0);

--- a/dll/win32/shell32/shelldesktop/CDesktopBrowser.cpp
+++ b/dll/win32/shell32/shelldesktop/CDesktopBrowser.cpp
@@ -99,7 +99,7 @@ BEGIN_MSG_MAP(CBaseBar)
     MESSAGE_HANDLER(WM_COMMAND, OnCommand)
     MESSAGE_HANDLER(WM_SETFOCUS, OnSetFocus)
     MESSAGE_HANDLER(WM_DESKTOP_GET_CNOTIFY_SERVER, OnGetChangeNotifyServer)
-    MESSAGE_HANDLER(WM_USER+22, OnShowOptionsDlg)
+    MESSAGE_HANDLER(WM_PROGMAN_OPENSHELLSETTINGS, OnShowOptionsDlg)
 END_MSG_MAP()
 
 BEGIN_COM_MAP(CDesktopBrowser)
@@ -467,7 +467,11 @@ LRESULT CDesktopBrowser::OnShowOptionsDlg(UINT uMsg, WPARAM wParam, LPARAM lPara
     switch (wParam)
     {
         case 0:
-            ShowFolderOptionsDialog(0, TRUE);
+#if (NTDDI_VERSION >= NTDDI_VISTA)
+        case 2:
+        case 7:
+#endif
+            ShowFolderOptionsDialog(PtrToUlong(wParam), TRUE);
             break;
         case 1:
             _NotifyTray(WM_COMMAND, TRAYCMD_TASKBAR_PROPERTIES, 0);

--- a/sdk/include/reactos/undocshell.h
+++ b/sdk/include/reactos/undocshell.h
@@ -55,6 +55,11 @@ typedef struct _TRAYNOTIFYDATAW
 #define TWM_CYCLEFOCUS (WM_USER + 348)
 
 /****************************************************************************
+ * ProgMan messages
+ */
+#define WM_PROGMAN_OPENSHELLSETTINGS (WM_USER + 22) /* wParam specifies the dialog (and tab page) */
+
+/****************************************************************************
  *  IDList Functions
  */
 BOOL WINAPI ILGetDisplayName(


### PR DESCRIPTION
Options_RunDLL is supposed to reuse the same window.

On newer Windows versions, tab switching is also supported:

````bat
rundll32 shell32.dll,Options_RunDLL 0& REM General tab
ping localhost
rundll32 shell32.dll,Options_RunDLL 7& REM View tab
REM Should be on the View tab now

rundll32 shell32.dll,Options_RunDLL 1& REM Open the taskbar options
````