### PR TITLE
[MSAFD] Fix non-blocking sockets support for recv()

### DIFF
--- a/dll/win32/msafd/misc/dllmain.c
+++ b/dll/win32/msafd/misc/dllmain.c
@@ -1785,8 +1785,6 @@ WSPAccept(
 
     AcceptSocketInfo->SharedData->State = SocketConnected;
     AcceptSocketInfo->SharedData->ConnectTime = GetCurrentTimeInSeconds();
-
-    /* Inherit non-blocking state to new socket */
     AcceptSocketInfo->SharedData->NonBlocking = Socket->SharedData->NonBlocking;
 
     /* Return Address in SOCKADDR FORMAT */

--- a/dll/win32/msafd/misc/dllmain.c
+++ b/dll/win32/msafd/misc/dllmain.c
@@ -1783,6 +1783,12 @@ WSPAccept(
     AcceptSocketInfo->SharedData->State = SocketConnected;
     AcceptSocketInfo->SharedData->ConnectTime = GetCurrentTimeInSeconds();
 
+    /* Inherit non-blocking state to new socket */
+    if (Socket->SharedData->NonBlocking)
+    {
+        AcceptSocketInfo->SharedData->NonBlocking = Socket->SharedData->NonBlocking;
+    }
+
     /* Return Address in SOCKADDR FORMAT */
     if( SocketAddress )
     {

--- a/dll/win32/msafd/misc/dllmain.c
+++ b/dll/win32/msafd/misc/dllmain.c
@@ -1787,10 +1787,7 @@ WSPAccept(
     AcceptSocketInfo->SharedData->ConnectTime = GetCurrentTimeInSeconds();
 
     /* Inherit non-blocking state to new socket */
-    if (Socket->SharedData->NonBlocking)
-    {
-        AcceptSocketInfo->SharedData->NonBlocking = Socket->SharedData->NonBlocking;
-    }
+    AcceptSocketInfo->SharedData->NonBlocking = Socket->SharedData->NonBlocking;
 
     /* Return Address in SOCKADDR FORMAT */
     if( SocketAddress )

--- a/dll/win32/msafd/misc/dllmain.c
+++ b/dll/win32/msafd/misc/dllmain.c
@@ -1495,22 +1495,25 @@ WSPAccept(
     ListenReceiveData = (PAFD_RECEIVED_ACCEPT_DATA)ReceiveBuffer;
 
     /* If this is non-blocking, make sure there's something for us to accept */
-    FD_ZERO(&ReadSet);
-    FD_SET(Socket->Handle, &ReadSet);
-    Timeout.tv_sec=0;
-    Timeout.tv_usec=0;
-
-    if (WSPSelect(0, &ReadSet, NULL, NULL, &Timeout, lpErrno) == SOCKET_ERROR)
+    if (Socket->SharedData->NonBlocking)
     {
-        NtClose(SockEvent);
-        return SOCKET_ERROR;
-    }
+        FD_ZERO(&ReadSet);
+        FD_SET(Socket->Handle, &ReadSet);
+        Timeout.tv_sec=0;
+        Timeout.tv_usec=0;
 
-    if (ReadSet.fd_array[0] != Socket->Handle)
-    {
-        NtClose(SockEvent);
-        if (lpErrno) *lpErrno = WSAEWOULDBLOCK;
-        return SOCKET_ERROR;
+        if (WSPSelect(0, &ReadSet, NULL, NULL, &Timeout, lpErrno) == SOCKET_ERROR)
+        {
+            NtClose(SockEvent);
+            return SOCKET_ERROR;
+        }
+
+        if (ReadSet.fd_array[0] != Socket->Handle)
+        {
+            NtClose(SockEvent);
+            if (lpErrno) *lpErrno = WSAEWOULDBLOCK;
+            return SOCKET_ERROR;
+        }
     }
 
     /* Send IOCTL */

--- a/dll/win32/msafd/misc/sndrcv.c
+++ b/dll/win32/msafd/misc/sndrcv.c
@@ -294,8 +294,7 @@ WSPRecv(SOCKET Handle,
     /* Non-blocking sockets must wait until data is available*/
     if (Status == STATUS_PENDING && Socket->SharedData->NonBlocking)
     {
-        if (lpErrno)
-            *lpErrno = WSAEWOULDBLOCK;
+        if (lpErrno) *lpErrno = WSAEWOULDBLOCK;
         return SOCKET_ERROR;
     }
 

--- a/dll/win32/msafd/misc/sndrcv.c
+++ b/dll/win32/msafd/misc/sndrcv.c
@@ -291,6 +291,14 @@ WSPRecv(SOCKET Handle,
                                    NULL,
                                    0);
 
+    /* Non-blocking sockets must wait until data is available*/
+    if (Status == STATUS_PENDING && Socket->SharedData->NonBlocking)
+    {
+        if (lpErrno)
+            *lpErrno = WSAEWOULDBLOCK;
+        return SOCKET_ERROR;
+    }
+
     /* Wait for completion of not overlapped */
     if (Status == STATUS_PENDING && lpOverlapped == NULL)
     {

--- a/dll/win32/msafd/misc/sndrcv.c
+++ b/dll/win32/msafd/misc/sndrcv.c
@@ -291,7 +291,7 @@ WSPRecv(SOCKET Handle,
                                    NULL,
                                    0);
 
-    /* Non-blocking sockets must wait until data is available*/
+    /* Non-blocking sockets must wait until data is available */
     if (Status == STATUS_PENDING && Socket->SharedData->NonBlocking)
     {
         if (lpErrno) *lpErrno = WSAEWOULDBLOCK;


### PR DESCRIPTION
## Purpose

Currently ReactOS' winsock2 implementation lacks of non-blocking sockets support for recv() apicall, this causes that applications that make use of this feature can lead to unexpected behaviors, one of them is Nginx web server, which uses non-blocking sockets when serving pages through Https protocol.

JIRA issue: [CORE-14486](https://jira.reactos.org/browse/CORE-14486)

## Proposed changes

According to MSDN:

1) new sockets created by accept() should inherit listening socket properties, but we're ignoring if it is a non-blocking socket.

2) recv() apicall must return SOCKET_ERROR and set last error to WSAEWOULDBLOCK when the socket is non-blocking and there is still no data to read.
