### PR TITLE
[KERNEL32] Fix startup context of initial thread

### DIFF
--- a/dll/win32/kernel32/client/proc.c
+++ b/dll/win32/kernel32/client/proc.c
@@ -4181,7 +4181,7 @@ StartScan:
 
     /* Create the Thread's Context */
     BaseInitializeContext(&Context,
-                          Peb,
+                          RemotePeb,
                           ImageInformation.TransferAddress,
                           InitialTeb.StackBase,
                           0);

--- a/modules/rostests/winetests/kernel32/process.c
+++ b/modules/rostests/winetests/kernel32/process.c
@@ -3439,9 +3439,7 @@ static void test_SuspendProcessState(void)
 #endif
 
     ret = ReadProcessMemory( pi.hProcess, peb_ptr, &child_peb, sizeof(child_peb), NULL );
-    ros_skip_flaky
     ok( ret, "Failed to read PEB (%u)\n", GetLastError() );
-    ros_skip_flaky
     ok( child_peb.ImageBaseAddress == exe_base, "wrong base %p/%p\n",
         child_peb.ImageBaseAddress, exe_base );
     ok( entry_ptr == (char *)exe_base + nt_header.OptionalHeader.AddressOfEntryPoint,


### PR DESCRIPTION
When creating a new process the monster function CreateProcessInternalW calls BaseInitializeContext to set up the context for the initial thread. One of the parameters is the PEB pointer. Instead of passing the pointer to the newly created process' PEB, the function was passing its own PEB address, leading to test failures. How this is not an issue otherwise is a mystery to be resolved by someone else. Also remove ros_skip_flaky marks in kernel32_winetest:process (yes, flaky, because sometimes the PEB addresses actually match)

Test KVM: https://reactos.org/testman/compare.php?ids=88924,88926,88931,88934,88939