### PR TITLE
[NTOS:KE/x64] Fix bug in KiInitializeContextThread

### DIFF
--- a/ntoskrnl/ke/amd64/thrdini.c
+++ b/ntoskrnl/ke/amd64/thrdini.c
@@ -134,7 +134,7 @@ KiInitializeContextThread(IN PKTHREAD Thread,
 
     /* Set up the Context Switch Frame */
     CtxSwitchFrame->Return = (ULONG64)KiThreadStartup;
-    CtxSwitchFrame->ApcBypass = FALSE;
+    CtxSwitchFrame->ApcBypass = TRUE;
 
     StartFrame->P1Home = (ULONG64)StartRoutine;
     StartFrame->P2Home = (ULONG64)StartContext;


### PR DESCRIPTION
The function set CtxSwitchFrame->ApcBypass to FALSE, preventing APCs (like when user mode sets the context while the thread is suspended) from being delivered as soon as the thread lowers IRQL to PASSIVE_LEVEL. This resulted in the SetContext APC to be delivered only after the user mode APC was initialized, overwriting the user mode APC context in the trap frame. This caused kernel32_winetest process to break.
