### PR TITLE
[TASKMGR] Simplify status-bar display when menus are shown

### DIFF
--- a/base/applications/taskmgr/perfpage.c
+++ b/base/applications/taskmgr/perfpage.c
@@ -8,8 +8,6 @@
 #include "precomp.h"
 #include <shlwapi.h>
 
-extern BOOL bInMenuLoop;        /* Tells us if we are in the menu loop - from taskmgr.c */
-
 TM_GRAPH_CONTROL PerformancePageCpuUsageHistoryGraph;
 TM_GRAPH_CONTROL PerformancePageMemUsageHistoryGraph;
 
@@ -328,6 +326,8 @@ DWORD WINAPI PerformancePageRefreshThread(PVOID Parameter)
 
     while (1)
     {
+        extern BOOL bTrackMenu; // From taskmgr.c
+
         int nBarsUsed1;
         int nBarsUsed2;
 
@@ -361,7 +361,7 @@ DWORD WINAPI PerformancePageRefreshThread(PVOID Parameter)
                                szChargeLimitFormat,
                                ARRAYSIZE(szChargeLimitFormat));
 
-            if (!bInMenuLoop)
+            if (!bTrackMenu)
             {
                 wsprintfW(Text, szMemUsage, szChargeTotalFormat, szChargeLimitFormat,
                     (CommitChargeLimit ? ((CommitChargeTotal * 100) / CommitChargeLimit) : 0));
@@ -406,7 +406,7 @@ DWORD WINAPI PerformancePageRefreshThread(PVOID Parameter)
             SetWindowTextW(hTotalsThreadCountEdit, Text);
             _ultow(TotalProcesses, Text, 10);
             SetWindowTextW(hTotalsProcessCountEdit, Text);
-            if (!bInMenuLoop)
+            if (!bTrackMenu)
             {
                 wsprintfW(Text, szProcesses, TotalProcesses);
                 SendMessageW(hStatusWnd, SB_SETTEXT, 0, (LPARAM)Text);
@@ -424,7 +424,7 @@ DWORD WINAPI PerformancePageRefreshThread(PVOID Parameter)
             CpuUsage = PerfDataGetProcessorUsage();
             CpuKernelUsage = PerfDataGetProcessorSystemUsage();
 
-            if (!bInMenuLoop)
+            if (!bTrackMenu)
             {
                 wsprintfW(Text, szCpuUsage, CpuUsage);
                 SendMessageW(hStatusWnd, SB_SETTEXT, 1, (LPARAM)Text);

--- a/base/applications/taskmgr/taskmgr.h
+++ b/base/applications/taskmgr/taskmgr.h
@@ -94,8 +94,6 @@ void FillSolidRect(HDC hDC, LPCRECT lpRect, COLORREF clr);
 void LoadSettings(void);
 void SaveSettings(void);
 void TaskManager_OnRestoreMainWindow(void);
-void TaskManager_DisableStatusBar(HWND hWnd);
-void TaskManager_EnableStatusBar(HWND hWnd);
 void TaskManager_OnMenuSelect(HWND hWnd, UINT nItemID, UINT nFlags, HMENU hSysMenu);
 void TaskManager_OnViewUpdateSpeed(DWORD);
 void TaskManager_OnTabWndSelChange(void);


### PR DESCRIPTION
## Purpose & Changes

Following PR #5571 (commit 2d53e95), it became apparent that the management of the status bar when showing the menu hints could be simplified further.
Use "simple-text" status-bar display mode when showing menu hints.
The original status-bar panes state is "remembered" and are automatically restored when the "simple-text" mode is disabled.

JIRA issue: [CORE-19061](https://jira.reactos.org/browse/CORE-19061)

(I would however recommend to merge this PR *after* PR #5573 that would exercise the previous code that works on Windows as well.)