### PR TITLE
[KERNEL32] CreateProcessInternalW(): Always use Peb variable

### DIFF
--- a/dll/win32/kernel32/client/proc.c
+++ b/dll/win32/kernel32/client/proc.c
@@ -3555,7 +3555,7 @@ StartScan:
 
     /* If the process is being debugged, only read IFEO if the PEB says so */
     if (!(dwCreationFlags & (DEBUG_PROCESS | DEBUG_ONLY_THIS_PROCESS)) ||
-        (NtCurrentPeb()->ReadImageFileExecOptions))
+        (Peb->ReadImageFileExecOptions))
     {
         /* Let's do this! Attempt to open IFEO */
         IFEOStatus = LdrOpenImageFileOptionsKey(&PathName, 0, &KeyHandle);


### PR DESCRIPTION
## Purpose

Trivial consistency/optimization.

Addendum to d81cd01 (r59637).

## Proposed changes

- Use Peb variable.
