### PR TITLE
[BROWSEUI] More settings and window refresh

### DIFF
--- a/boot/bootdata/hivedef.inf
+++ b/boot/bootdata/hivedef.inf
@@ -1901,6 +1901,7 @@ HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced","Hidden",0x00
 HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced","ShowSuperHidden",0x00010003,0
 HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CabinetState",,0x00000012
 HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CabinetState","FullPath",0x00010003,0
+HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CabinetState","FullPathAddress",0x00010003,1
 HKCU,"SOFTWARE\Microsoft\Internet Explorer\Main","StatusBarOther",0x00010003,1
 HKCU,"SOFTWARE\Microsoft\Internet Explorer\Toolbar","Locked",0x00010003,1
 

--- a/dll/win32/browseui/CMakeLists.txt
+++ b/dll/win32/browseui/CMakeLists.txt
@@ -30,6 +30,7 @@ list(APPEND SOURCE
     internettoolbar.cpp
     parsecmdline.cpp
     regtreeoptions.cpp
+    settings_cabinet.cpp
     settings.cpp
     shellbrowser.cpp
     toolsband.cpp

--- a/dll/win32/browseui/addresseditbox.h
+++ b/dll/win32/browseui/addresseditbox.h
@@ -91,6 +91,7 @@ public:
     virtual HRESULT STDMETHODCALLTYPE GetSizeMax(ULARGE_INTEGER *pcbSize);
 
     // message handlers
+    LRESULT OnSettingChange(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
 
     DECLARE_REGISTRY_RESOURCEID(IDR_ADDRESSEDITBOX)
     DECLARE_NOT_AGGREGATABLE(CAddressEditBox)
@@ -98,6 +99,7 @@ public:
     DECLARE_PROTECT_FINAL_CONSTRUCT()
 
     BEGIN_MSG_MAP(CAddressEditBox)
+        MESSAGE_HANDLER(WM_SETTINGCHANGE, OnSettingChange)
     END_MSG_MAP()
 
     BEGIN_COM_MAP(CAddressEditBox)

--- a/dll/win32/browseui/precomp.h
+++ b/dll/win32/browseui/precomp.h
@@ -81,7 +81,6 @@ struct ShellSettings
 
 struct CabinetStateSettings : CABINETSTATE
 {
-    /* Additional CabinetState settings */
     BOOL fFullPathAddress = TRUE;
 
     BOOL Load();

--- a/dll/win32/browseui/precomp.h
+++ b/dll/win32/browseui/precomp.h
@@ -79,4 +79,14 @@ struct ShellSettings
     BOOL Load();
 };
 
+struct CabinetStateSettings : CABINETSTATE
+{
+    /* Additional CabinetState settings */
+    BOOL fFullPathAddress = TRUE;
+
+    BOOL Load();
+};
+
+extern CabinetStateSettings gCabinetState;
+
 #endif /* _BROWSEUI_PCH_ */

--- a/dll/win32/browseui/settings_cabinet.cpp
+++ b/dll/win32/browseui/settings_cabinet.cpp
@@ -1,0 +1,22 @@
+/*
+ * PROJECT:     ReactOS browseui
+ * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
+ * PURPOSE:     Stores the global cabinet state for the file explorer UI.
+ * COPYRIGHT:   Copyright 2023 Carl Bialorucki <cbialo2@outlook.com>
+ */
+
+#include "precomp.h"
+
+CabinetStateSettings gCabinetState;
+
+BOOL CabinetStateSettings::Load()
+{
+    /* Ideally we would use ReadCabinetState, but unfortunately Wine's implementation is incomplete. */
+    fFullPathTitle = SHRegGetBoolUSValueW(L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\CabinetState",
+                                          L"FullPath", FALSE, FALSE);
+
+    fFullPathAddress = SHRegGetBoolUSValueW(L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\CabinetState",
+                                            L"FullPathAddress", FALSE, TRUE);
+
+    return TRUE;
+}

--- a/dll/win32/browseui/shellbrowser.cpp
+++ b/dll/win32/browseui/shellbrowser.cpp
@@ -296,7 +296,6 @@ private:
     barInfo                                 fClientBars[3];
     CComPtr<ITravelLog>                     fTravelLog;
     HMENU                                   fCurrentMenuBar;
-    CABINETSTATE                            fCabinetState;
     GUID                                    fCurrentVertBar;             //The guid of the built in vertical bar that is being shown
     // The next three fields support persisted history for shell views.
     // They do not need to be reference counted.
@@ -350,7 +349,8 @@ public:
     HRESULT UpdateUpState();
     void UpdateGotoMenu(HMENU theMenu);
     void UpdateViewMenu(HMENU theMenu);
-    void LoadCabinetState();
+    void RefreshCabinetState();
+    void UpdateWindowTitle();
 
 /*    // *** IDockingWindowFrame methods ***
     virtual HRESULT STDMETHODCALLTYPE AddToolbar(IUnknown *punkSrc, LPCWSTR pwszItem, DWORD dwAddFlags);
@@ -719,6 +719,7 @@ CShellBrowser::CShellBrowser()
     fHistoryStream = NULL;
     fHistoryBindContext = NULL;
     m_settings.Load();
+    gCabinetState.Load();
 }
 
 CShellBrowser::~CShellBrowser()
@@ -738,11 +739,6 @@ HRESULT CShellBrowser::Initialize()
     menuDsa = DSA_Create(sizeof(MenuBandInfo), 5);
     if (!menuDsa)
         return E_OUTOFMEMORY;
-
-    fCabinetState.cLength = sizeof(fCabinetState);
-    if (ReadCabinetState(&fCabinetState, sizeof(fCabinetState)) == FALSE)
-    {
-    }
 
     // create window
     Create(HWND_DESKTOP);
@@ -787,8 +783,6 @@ HRESULT CShellBrowser::Initialize()
         return hResult;
 
     fToolbarProxy.Initialize(m_hWnd, clientBar);
-
-    LoadCabinetState();
 
     // create status bar
     DWORD dwStatusStyle = WS_CHILD | WS_CLIPSIBLINGS | SBARS_SIZEGRIP | SBARS_TOOLTIPS;
@@ -1049,42 +1043,33 @@ HRESULT CShellBrowser::BrowseToPath(IShellFolder *newShellFolder,
         FireNavigateComplete(L"ERROR");
     }
 
-    if (fCabinetState.fFullPathTitle)
-        nameFlags = SHGDN_FORADDRESSBAR | SHGDN_FORPARSING;
-    else
-        nameFlags = SHGDN_FORADDRESSBAR;
-    hResult = IEGetNameAndFlags(fCurrentDirectoryPIDL, nameFlags, newTitle,
-        sizeof(newTitle) / sizeof(wchar_t), NULL);
+    UpdateWindowTitle();
+
+    LPCITEMIDLIST pidlChild;
+    INT index, indexOpen;
+    HIMAGELIST himlSmall, himlLarge;
+
+    CComPtr<IShellFolder> sf;
+    hResult = SHBindToParent(absolutePIDL, IID_PPV_ARG(IShellFolder, &sf), &pidlChild);
     if (SUCCEEDED(hResult))
     {
-        SetWindowText(newTitle);
+        index = SHMapPIDLToSystemImageListIndex(sf, pidlChild, &indexOpen);
 
-        LPCITEMIDLIST pidlChild;
-        INT index, indexOpen;
-        HIMAGELIST himlSmall, himlLarge;
+        Shell_GetImageLists(&himlLarge, &himlSmall);
 
-        CComPtr<IShellFolder> sf;
-        hResult = SHBindToParent(absolutePIDL, IID_PPV_ARG(IShellFolder, &sf), &pidlChild);
-        if (SUCCEEDED(hResult))
-        {
-            index = SHMapPIDLToSystemImageListIndex(sf, pidlChild, &indexOpen);
+        HICON icSmall = ImageList_GetIcon(himlSmall, indexOpen, 0);
+        HICON icLarge = ImageList_GetIcon(himlLarge, indexOpen, 0);
 
-            Shell_GetImageLists(&himlLarge, &himlSmall);
+        /* Hack to make it possible to release the old icons */
+        /* Something seems to go wrong with WM_SETICON */
+        HICON oldSmall = (HICON)SendMessage(WM_GETICON, ICON_SMALL, 0);
+        HICON oldLarge = (HICON)SendMessage(WM_GETICON, ICON_BIG,   0);
 
-            HICON icSmall = ImageList_GetIcon(himlSmall, indexOpen, 0);
-            HICON icLarge = ImageList_GetIcon(himlLarge, indexOpen, 0);
+        SendMessage(WM_SETICON, ICON_SMALL, reinterpret_cast<LPARAM>(icSmall));
+        SendMessage(WM_SETICON, ICON_BIG,   reinterpret_cast<LPARAM>(icLarge));
 
-            /* Hack to make it possible to release the old icons */
-            /* Something seems to go wrong with WM_SETICON */
-            HICON oldSmall = (HICON)SendMessage(WM_GETICON, ICON_SMALL, 0);
-            HICON oldLarge = (HICON)SendMessage(WM_GETICON, ICON_BIG,   0);
-
-            SendMessage(WM_SETICON, ICON_SMALL, reinterpret_cast<LPARAM>(icSmall));
-            SendMessage(WM_SETICON, ICON_BIG,   reinterpret_cast<LPARAM>(icLarge));
-
-            DestroyIcon(oldSmall);
-            DestroyIcon(oldLarge);
-        }
+        DestroyIcon(oldSmall);
+        DestroyIcon(oldLarge);
     }
 
     FireCommandStateChangeAll();
@@ -1520,14 +1505,6 @@ void CShellBrowser::RepositionBars()
     ::SetWindowPos(fCurrentShellViewWindow, NULL, clientRect.left, clientRect.top,
                         clientRect.right - clientRect.left,
                         clientRect.bottom - clientRect.top, SWP_NOOWNERZORDER | SWP_NOZORDER);
-}
-
-void CShellBrowser::LoadCabinetState()
-{
-    fCabinetState.fFullPathTitle = SHRegGetBoolUSValueW(L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\CabinetState",
-                                                        L"FullPath",
-                                                        FALSE,
-                                                        FALSE);
 }
 
 HRESULT CShellBrowser::FireEvent(DISPID dispIdMember, int argCount, VARIANT *arguments)
@@ -3577,6 +3554,7 @@ LRESULT CShellBrowser::RelayMsgToShellView(UINT uMsg, WPARAM wParam, LPARAM lPar
 
 LRESULT CShellBrowser::OnSettingChange(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled)
 {
+    RefreshCabinetState();
     SHPropagateMessage(m_hWnd, uMsg, wParam, lParam, TRUE);
     return 0;
 }
@@ -3815,4 +3793,24 @@ LRESULT CShellBrowser::OnGetSettingsPtr(UINT uMsg, WPARAM wParam, LPARAM lParam,
 HRESULT CShellBrowser_CreateInstance(REFIID riid, void **ppv)
 {
     return ShellObjectCreatorInit<CShellBrowser>(riid, ppv);
+}
+
+void CShellBrowser::RefreshCabinetState()
+{
+    gCabinetState.Load();
+    UpdateWindowTitle();
+}
+
+void CShellBrowser::UpdateWindowTitle()
+{
+    WCHAR title[MAX_PATH];
+    SHGDNF flags;
+
+    if (gCabinetState.fFullPathTitle)
+        flags = SHGDN_FORADDRESSBAR | SHGDN_FORPARSING;
+    else
+        flags = SHGDN_FORADDRESSBAR;
+
+    if (SUCCEEDED(IEGetNameAndFlags(fCurrentDirectoryPIDL, flags, title, MAX_PATH, NULL)))
+        SetWindowText(title);
 }


### PR DESCRIPTION
## Purpose

![image](https://github.com/reactos/reactos/assets/16692240/64febaa5-9182-405e-9621-00b036911b92)

Adds the option to set the address edit box to use the display name or the full path. Also refreshes the window title and edit box in all open explorer windows when changing these settings using the folder options dialog.

JIRA issue: [CORE-9277](https://jira.reactos.org/browse/CORE-9277)

## Proposed changes
- Create a new `CabinetStateSettings` type that inherits from the `CABINETSTATE` type. This allows us to add additional cabinet state settings not exposed in the `CABINETSTATE` type as well as adding a `Load()` method to easily populate the cabinet state settings.
- Add a global cabinet state settings object. While most settings in browseui are stored independently in each shellbrowser window, cabinet state settings are global and apply to every shellbrowser window. This can be confirmed on Windows Server 2003 and Windows 7.
- When receiving the `WM_SETTINGCHANGE` window message from the folder options dialog, refresh the title of the window and the text in the address edit box. This is the same behavior as Windows Server 2003 and Windows 7.
- Add a DWORD registry value to `HKCU\...\Explorer\CabinetState\FullPathAddress` to allow users to toggle this setting on or off in our folder options.
