### PR TITLE
[PSDK] enum FILE_INFO_BY_HANDLE_CLASS: Add NT version conditions

### DIFF
--- a/dll/shellext/shellbtrfs/reactos.cpp
+++ b/dll/shellext/shellbtrfs/reactos.cpp
@@ -153,7 +153,7 @@ NTSTATUS WINAPI RtlUTF8ToUnicodeN(PWSTR uni_dest, ULONG uni_bytes_max,
 }
 
 /* Quick and dirty table for conversion */
-FILE_INFORMATION_CLASS ConvertToFileInfo[MaximumFileInfoByHandlesClass] =
+FILE_INFORMATION_CLASS ConvertToFileInfo[MaximumFileInfoByHandleClass] =
 {
     FileBasicInformation, FileStandardInformation, FileNameInformation, FileRenameInformation,
     FileDispositionInformation, FileAllocationInformation, FileEndOfFileInformation, FileStreamInformation,
@@ -186,7 +186,7 @@ SetFileInformationByHandle(HANDLE hFile,
     FileInfoClass = (FILE_INFORMATION_CLASS)-1;
 
     /* Attempt to convert the class */
-    if (FileInformationClass < MaximumFileInfoByHandlesClass)
+    if (FileInformationClass < MaximumFileInfoByHandleClass)
     {
         FileInfoClass = ConvertToFileInfo[FileInformationClass];
     }

--- a/dll/shellext/shellbtrfs/reactos.cpp
+++ b/dll/shellext/shellbtrfs/reactos.cpp
@@ -153,12 +153,24 @@ NTSTATUS WINAPI RtlUTF8ToUnicodeN(PWSTR uni_dest, ULONG uni_bytes_max,
 }
 
 /* Quick and dirty table for conversion */
+#if 0 // < VISTA
+#ifndef FileIoPriorityHintInformation // FILE_INFORMATION_CLASS NT6.0+ feature.
+#define FileIoPriorityHintInformation ((FILE_INFORMATION_CLASS)43)
+#endif
+
+// FILE_INFO_BY_HANDLE_CLASS and its MaximumFileInfoByHandleClass are NT6.0+.
+// Some other files depend on NT6.0+ too, so to be continued later...
+#endif // 0 // < VISTA
+#ifndef FileRemoteProtocolInformation // FILE_INFORMATION_CLASS NT6.1+ feature.
+#define FileRemoteProtocolInformation ((FILE_INFORMATION_CLASS)55)
+#endif
 FILE_INFORMATION_CLASS ConvertToFileInfo[MaximumFileInfoByHandleClass] =
 {
     FileBasicInformation, FileStandardInformation, FileNameInformation, FileRenameInformation,
     FileDispositionInformation, FileAllocationInformation, FileEndOfFileInformation, FileStreamInformation,
     FileCompressionInformation, FileAttributeTagInformation, FileIdBothDirectoryInformation, (FILE_INFORMATION_CLASS)-1,
     FileIoPriorityHintInformation, FileRemoteProtocolInformation
+// FIXME: FILE_INFO_BY_HANDLE_CLASS has 2+ more values. What about them here? Should they be '-1' too?
 };
 
 /* Taken from kernel32 */

--- a/dll/win32/kernel32/kernel32_vista/GetFileInformationByHandleEx.c
+++ b/dll/win32/kernel32/kernel32_vista/GetFileInformationByHandleEx.c
@@ -23,11 +23,13 @@ BOOL WINAPI GetFileInformationByHandleEx( HANDLE handle, FILE_INFO_BY_HANDLE_CLA
     case FileRemoteProtocolInfo:
     case FileFullDirectoryInfo:
     case FileFullDirectoryRestartInfo:
+#if (_WIN32_WINNT >= _WIN32_WINNT_WIN8)
     case FileStorageInfo:
     case FileAlignmentInfo:
     case FileIdInfo:
     case FileIdExtdDirectoryInfo:
     case FileIdExtdDirectoryRestartInfo:
+#endif // _WIN32_WINNT_WIN8
         //FIXME( "%p, %u, %p, %u\n", handle, class, info, size );
         SetLastError( ERROR_CALL_NOT_IMPLEMENTED );
         return FALSE;

--- a/sdk/include/psdk/sdkddkver.h
+++ b/sdk/include/psdk/sdkddkver.h
@@ -30,6 +30,9 @@ Abstract:
 #define _WIN32_WINNT_WINBLUE                0x0603
 #define _WIN32_WINNT_WINTHRESHOLD           0x0A00
 #define _WIN32_WINNT_WIN10                  0x0A00
+#define _WIN32_WINNT_WIN10_RS1              _WIN32_WINNT_WIN10
+#define _WIN32_WINNT_WIN10_RS2              _WIN32_WINNT_WIN10
+#define _WIN32_WINNT_WIN10_RS3              _WIN32_WINNT_WIN10
 
 /* _WIN32_IE */
 #define _WIN32_IE_IE20                      0x0200

--- a/sdk/include/psdk/winbase.h
+++ b/sdk/include/psdk/winbase.h
@@ -1000,14 +1000,26 @@ typedef enum _FILE_INFO_BY_HANDLE_CLASS {
     FileIdBothDirectoryRestartInfo,
     FileIoPriorityHintInfo,
     FileRemoteProtocolInfo,
+// FIXME: Check NT version (> 6.0) for all following values.
+// #if (NTDDI_VERSION >= NTDDI_WIN8) // These 2 were not on PSDK2003R2 (yet?).
     FileFullDirectoryInfo,
     FileFullDirectoryRestartInfo,
+#if (_WIN32_WINNT >= _WIN32_WINNT_WIN8)
     FileStorageInfo,
     FileAlignmentInfo,
     FileIdInfo,
     FileIdExtdDirectoryInfo,
     FileIdExtdDirectoryRestartInfo,
-    MaximumFileInfoByHandlesClass
+#endif // _WIN32_WINNT_WIN8
+#if (_WIN32_WINNT >= _WIN32_WINNT_WIN10_RS1)
+    FileDispositionInfoEx,
+    FileRenameInfoEx,
+#endif // _WIN32_WINNT_WIN10_RS1
+#if 0 // NTDDI_WIN10_RS4
+    FileCaseSensitiveInfo,
+    FileNormalizedNameInfo,
+#endif // 0 // NTDDI_WIN10_RS4
+    MaximumFileInfoByHandleClass
 } FILE_INFO_BY_HANDLE_CLASS, *PFILE_INFO_BY_HANDLE_CLASS;
 
 typedef struct _FILE_ID_BOTH_DIR_INFO {
@@ -1110,7 +1122,7 @@ typedef struct _FILE_REMOTE_PROTOCOL_INFO {
     } ProtocolSpecificReserved;
 } FILE_REMOTE_PROTOCOL_INFO, *PFILE_REMOTE_PROTOCOL_INFO;
 
-#endif
+#endif // (_WIN32_WINNT >= 0x0600)
 
 typedef enum _FINDEX_INFO_LEVELS {
 	FindExInfoStandard,


### PR DESCRIPTION
## Purpose

Improve/Fix `enum FILE_INFO_BY_HANDLE_CLASS` definition.

## Proposed changes

-  Check/Update value list and related NT versions.

## TODO

- [ ] Helpwanted, to sort out `FILE_INFO_BY_HANDLE_CLASS` based on MS header(s). Thanks.
- [ ] Remove ShellBtrfs commit, which is there to give context only.
