### PR TITLE
[KMTEST:TcpIp] Use 10 second timeout value instead of INFINITE

### DIFF
--- a/modules/rostests/kmtests/tcpip/TcpIp_user.c
+++ b/modules/rostests/kmtests/tcpip/TcpIp_user.c
@@ -113,7 +113,7 @@ START_TEST(TcpIpConnect)
     Error = KmtSendToDriver(IOCTL_TEST_CONNECT);
     ok_eq_ulong(Error, ERROR_SUCCESS);
 
-    WaitForSingleObject(AcceptThread, INFINITE);
+    WaitForSingleObject(AcceptThread, 10 * 1000);
 
     UnloadTcpIpTestDriver();
 

--- a/modules/rostests/kmtests/tcpip/TcpIp_user.c
+++ b/modules/rostests/kmtests/tcpip/TcpIp_user.c
@@ -113,7 +113,8 @@ START_TEST(TcpIpConnect)
     Error = KmtSendToDriver(IOCTL_TEST_CONNECT);
     ok_eq_ulong(Error, ERROR_SUCCESS);
 
-    WaitForSingleObject(AcceptThread, 10 * 1000);
+    Error = WaitForSingleObject(AcceptThread, 10 * 1000);
+    ok(Error == WAIT_OBJECT_0, "AcceptThread timed out\n");
 
     UnloadTcpIpTestDriver();
 


### PR DESCRIPTION
On x64 the test sometimes fails to connect and then times out on the testbot, causing the system to be rebooted.
