### PR TITLE
[SHELL32] Don't display missing applications in Open with. CORE-19117

### DIFF
--- a/dll/win32/shell32/COpenWithMenu.cpp
+++ b/dll/win32/shell32/COpenWithMenu.cpp
@@ -240,12 +240,12 @@ HICON COpenWithList::GetIcon(SApp *pApp)
         if (!ExtractIconExW(wszPath, 0, NULL, &pApp->hIcon, 1))
         {
             SHFILEINFO fi;
-            /* FIXME: Ideally we should pass SHGFI_ICON|SHGFI_USEFILEATTRIBUTES because
+            /* FIXME: Ideally we should include SHGFI_USEFILEATTRIBUTES because
             ** we already know the file has no icons but SHGetFileInfo is broken in that case.
             ** Without SHGFI_USEFILEATTRIBUTES we needlessly hit the disk again but it will
             ** return the correct default .exe icon.
             */
-            SHGetFileInfoW(wszPath, 0, &fi, sizeof(fi), SHGFI_ICON);
+            SHGetFileInfoW(wszPath, 0, &fi, sizeof(fi), SHGFI_ICON|SHGFI_SMALLICON|SHGFI_SHELLICONSIZE);
             pApp->hIcon = fi.hIcon;
         }
     }

--- a/dll/win32/shell32/COpenWithMenu.cpp
+++ b/dll/win32/shell32/COpenWithMenu.cpp
@@ -240,8 +240,8 @@ HICON COpenWithList::GetIcon(SApp *pApp)
         if (!ExtractIconExW(wszPath, 0, NULL, &pApp->hIcon, 1))
         {
             SHFILEINFO fi;
-            /* FIXME: Ideally we should include SHGFI_USEFILEATTRIBUTES because
-            ** we already know the file has no icons but SHGetFileInfo is broken in that case.
+            /* FIXME: Ideally we should include SHGFI_USEFILEATTRIBUTES because we already
+            ** know the file has no icons but SHGetFileInfo is broken in that case (CORE-19122).
             ** Without SHGFI_USEFILEATTRIBUTES we needlessly hit the disk again but it will
             ** return the correct default .exe icon.
             */

--- a/dll/win32/shell32/COpenWithMenu.cpp
+++ b/dll/win32/shell32/COpenWithMenu.cpp
@@ -416,7 +416,7 @@ BOOL COpenWithList::GetPathFromCmd(LPWSTR pwszAppPath, LPCWSTR pwszCmd)
     ExpandEnvironmentStrings(wszBuf, pwszAppPath, MAX_PATH);
     if (!PathFileExists(pwszAppPath))
         return SearchPath(NULL, pwszAppPath, NULL, MAX_PATH, pwszAppPath, NULL);
-    return TRUE
+    return TRUE;
 }
 
 BOOL COpenWithList::LoadRecommended(LPCWSTR pwszFilePath)

--- a/dll/win32/shell32/COpenWithMenu.cpp
+++ b/dll/win32/shell32/COpenWithMenu.cpp
@@ -379,11 +379,9 @@ BOOL COpenWithList::LoadInfo(COpenWithList::SApp *pApp)
 
     /* Query name */
     swprintf(wszBuf, L"\\StringFileInfo\\%04x%04x\\FileDescription", wLang, wCode);
-    if (VerQueryValueW(pBuf, wszBuf, (LPVOID *)&pResult, &cchLen))
-    {
+    success = VerQueryValueW(pBuf, wszBuf, (LPVOID *)&pResult, &cchLen) && (cchLen > 1);
+    if (success)
         StringCchCopyNW(pApp->wszName, _countof(pApp->wszName), pResult, cchLen);
-        success = cchLen > 1;
-    }
     else
         ERR("Cannot get app name\n");
 
@@ -416,10 +414,9 @@ BOOL COpenWithList::GetPathFromCmd(LPWSTR pwszAppPath, LPCWSTR pwszCmd)
 
     /* Expand evn vers and optionally search for path */
     ExpandEnvironmentStrings(wszBuf, pwszAppPath, MAX_PATH);
-    if (PathFileExists(pwszAppPath))
-        return TRUE;
-    else
+    if (!PathFileExists(pwszAppPath))
         return SearchPath(NULL, pwszAppPath, NULL, MAX_PATH, pwszAppPath, NULL);
+    return TRUE
 }
 
 BOOL COpenWithList::LoadRecommended(LPCWSTR pwszFilePath)
@@ -884,7 +881,7 @@ BOOL COpenWithDialog::IsNoOpen(HWND hwnd)
 VOID COpenWithDialog::AddApp(COpenWithList::SApp *pApp, BOOL bSelected)
 {
     LPCWSTR pwszName = m_pAppList->GetName(pApp);
-    if (!pwszName) return ;
+    if (!pwszName) return;
     HICON hIcon = m_pAppList->GetIcon(pApp);
 
     TRACE("AddApp Cmd %ls Name %ls\n", pApp->wszCmd, pwszName);
@@ -1212,7 +1209,7 @@ VOID COpenWithMenu::AddApp(PVOID pApp)
 {
     MENUITEMINFOW mii;
     LPCWSTR pwszName = m_pAppList->GetName((COpenWithList::SApp*)pApp);
-    if (!pwszName) return ;
+    if (!pwszName) return;
 
     ZeroMemory(&mii, sizeof(mii));
     mii.cbSize = sizeof(mii);

--- a/dll/win32/shell32/COpenWithMenu.cpp
+++ b/dll/win32/shell32/COpenWithMenu.cpp
@@ -245,7 +245,7 @@ HICON COpenWithList::GetIcon(SApp *pApp)
             ** Without SHGFI_USEFILEATTRIBUTES we needlessly hit the disk again but it will
             ** return the correct default .exe icon.
             */
-            SHGetFileInfoW(wszPath, 0, &fi, sizeof(fi), SHGFI_ICON|SHGFI_USEFILEATTRIBUTES);
+            SHGetFileInfoW(wszPath, 0, &fi, sizeof(fi), SHGFI_ICON);
             pApp->hIcon = fi.hIcon;
         }
     }


### PR DESCRIPTION
## Purpose

Don't display applications that don't exist.

JIRA issue: [CORE-19117](https://jira.reactos.org/browse/CORE-19117)

I verified the behavior on XP. Exe files that no longer exist are hidden but their registry entry is not deleted.