### PR TITLE
[KERNEL32] Add CompareStringOrdinal from wine-3.21

### DIFF
--- a/dll/win32/kernel32/kernel32.spec
+++ b/dll/win32/kernel32/kernel32.spec
@@ -87,7 +87,7 @@
 @ stdcall CompareFileTime(ptr ptr)
 @ stdcall CompareStringA(long long str long str long)
 @ stdcall -version=0x600+ CompareStringEx(wstr long wstr long wstr long ptr ptr ptr)
-@ stdcall -stub -version=0x600+ CompareStringOrdinal(wstr long wstr long long)
+@ stdcall -version=0x600+ CompareStringOrdinal(wstr long wstr long long)
 @ stdcall CompareStringW(long long wstr long wstr long)
 @ stdcall ConnectNamedPipe(long ptr)
 ;@ stdcall -arch=x86_64 ConsoleIMERoutine()

--- a/dll/win32/kernel32/winnls/string/lang.c
+++ b/dll/win32/kernel32/winnls/string/lang.c
@@ -33,7 +33,7 @@ DEBUG_CHANNEL(nls);
 #endif
 
 #undef WINVER
-#define WINVER 0x600
+#define WINVER DLL_EXPORT_VERSION
 
 /* From winnls.h */
 #define LOCALE_NAME_USER_DEFAULT    NULL
@@ -2764,6 +2764,29 @@ INT WINAPI CompareStringA(LCID lcid, DWORD flags,
     if (str2W != buf2W) HeapFree(GetProcessHeap(), 0, str2W);
     return ret;
 }
+
+#if (WINVER >= 0x0600)
+/******************************************************************************
+ *           CompareStringOrdinal    (KERNEL32.@)
+ */
+INT WINAPI CompareStringOrdinal(const WCHAR *str1, INT len1, const WCHAR *str2, INT len2, BOOL ignore_case)
+{
+    int ret;
+
+    if (!str1 || !str2)
+    {
+        SetLastError(ERROR_INVALID_PARAMETER);
+        return 0;
+    }
+    if (len1 < 0) len1 = strlenW(str1);
+    if (len2 < 0) len2 = strlenW(str2);
+
+    ret = RtlCompareUnicodeStrings( str1, len1, str2, len2, ignore_case );
+    if (ret < 0) return CSTR_LESS_THAN;
+    if (ret > 0) return CSTR_GREATER_THAN;
+    return CSTR_EQUAL;
+}
+#endif
 
 #ifdef __REACTOS__
 HANDLE NLS_RegOpenKey(HANDLE hRootKey, LPCWSTR szKeyName)

--- a/sdk/include/ndk/rtlfuncs.h
+++ b/sdk/include/ndk/rtlfuncs.h
@@ -2123,6 +2123,18 @@ RtlCompareUnicodeString(
     BOOLEAN CaseInsensitive
 );
 
+_Must_inspect_result_
+NTSYSAPI
+LONG
+NTAPI
+RtlCompareUnicodeStrings(
+    _In_reads_(String1Length) PCWCH String1,
+    _In_ SIZE_T String1Length,
+    _In_reads_(String2Length) PCWCH String2,
+    _In_ SIZE_T String2Length,
+    _In_ BOOLEAN CaseInSensitive
+);
+
 NTSYSAPI
 VOID
 NTAPI


### PR DESCRIPTION
## Purpose

Add CompareStringOrdinal from wine-3.21

Why 3.21? Because that is the state that this file is at. Except for all the useless hackery.