### PR TITLE
[COMCTL32] Set TBBUTTON::fsState   before  RB_SETBANDINFOW message returns.

### DIFF
--- a/dll/win32/browseui/internettoolbar.cpp
+++ b/dll/win32/browseui/internettoolbar.cpp
@@ -1109,12 +1109,7 @@ HRESULT CInternetToolbar::ToggleBandVisibility(int BandID)
         {
             TBBUTTONINFO BtnInfo = {sizeof(TBBUTTONINFO), TBIF_BYINDEX | TBIF_STATE};
             ::SendMessage(fToolbarWindow, TB_GETBUTTONINFO, idx, (LPARAM)&BtnInfo);
-
-            if (bandInfo.fStyle & RBBS_HIDDEN)
-                BtnInfo.fsState |= TBSTATE_HIDDEN;
-            else
-                BtnInfo.fsState &= ~TBSTATE_HIDDEN;
-
+            BtnInfo.fsState = bandInfo.fStyle & RBBS_HIDDEN ? BtnInfo.fsState | TBSTATE_HIDDEN : BtnInfo.fsState & ~TBSTATE_HIDDEN;
             ::SendMessage(fToolbarWindow, TB_SETBUTTONINFO, idx, (LPARAM)&BtnInfo);
         }
     }

--- a/dll/win32/browseui/internettoolbar.cpp
+++ b/dll/win32/browseui/internettoolbar.cpp
@@ -1109,7 +1109,12 @@ HRESULT CInternetToolbar::ToggleBandVisibility(int BandID)
         {
             TBBUTTONINFO BtnInfo = {sizeof(TBBUTTONINFO), TBIF_BYINDEX | TBIF_STATE};
             ::SendMessage(fToolbarWindow, TB_GETBUTTONINFO, idx, (LPARAM)&BtnInfo);
-            BtnInfo.fsState = bandInfo.fStyle & RBBS_HIDDEN ? BtnInfo.fsState | TBSTATE_HIDDEN : BtnInfo.fsState & ~TBSTATE_HIDDEN;
+
+            if (bandInfo.fStyle & RBBS_HIDDEN)
+                BtnInfo.fsState |= TBSTATE_HIDDEN;
+            else
+                BtnInfo.fsState &= ~TBSTATE_HIDDEN;
+
             ::SendMessage(fToolbarWindow, TB_SETBUTTONINFO, idx, (LPARAM)&BtnInfo);
         }
     }

--- a/dll/win32/browseui/internettoolbar.cpp
+++ b/dll/win32/browseui/internettoolbar.cpp
@@ -1101,6 +1101,19 @@ HRESULT CInternetToolbar::ToggleBandVisibility(int BandID)
     else
         bandInfo.fStyle |= RBBS_HIDDEN;
 
+    if (BandID == ITBBID_TOOLSBAND)
+    {
+        int BtnCount = ::SendMessage(fToolbarWindow, TB_BUTTONCOUNT, 0, 0);
+
+        for (int idx = 0; idx < BtnCount; idx++)
+        {
+            TBBUTTONINFO BtnInfo = {sizeof(TBBUTTONINFO), TBIF_BYINDEX | TBIF_STATE};
+            ::SendMessage(fToolbarWindow, TB_GETBUTTONINFO, idx, (LPARAM)&BtnInfo);
+            BtnInfo.fsState = bandInfo.fStyle & RBBS_HIDDEN ? BtnInfo.fsState | TBSTATE_HIDDEN : BtnInfo.fsState & ~TBSTATE_HIDDEN;
+            ::SendMessage(fToolbarWindow, TB_SETBUTTONINFO, idx, (LPARAM)&BtnInfo);
+        }
+    }
+
     SendMessage(fMainReBar, RB_SETBANDINFOW, index, (LPARAM)&bandInfo);
 
     ReserveBorderSpace(0);

--- a/dll/win32/browseui/internettoolbar.cpp
+++ b/dll/win32/browseui/internettoolbar.cpp
@@ -1101,19 +1101,6 @@ HRESULT CInternetToolbar::ToggleBandVisibility(int BandID)
     else
         bandInfo.fStyle |= RBBS_HIDDEN;
 
-    if (BandID == ITBBID_TOOLSBAND)
-    {
-        int BtnCount = ::SendMessage(fToolbarWindow, TB_BUTTONCOUNT, 0, 0);
-
-        for (int idx = 0; idx < BtnCount; idx++)
-        {
-            TBBUTTONINFO BtnInfo = {sizeof(TBBUTTONINFO), TBIF_BYINDEX | TBIF_STATE};
-            ::SendMessage(fToolbarWindow, TB_GETBUTTONINFO, idx, (LPARAM)&BtnInfo);
-            BtnInfo.fsState = bandInfo.fStyle & RBBS_HIDDEN ? BtnInfo.fsState | TBSTATE_HIDDEN : BtnInfo.fsState & ~TBSTATE_HIDDEN;
-            ::SendMessage(fToolbarWindow, TB_SETBUTTONINFO, idx, (LPARAM)&BtnInfo);
-        }
-    }
-
     SendMessage(fMainReBar, RB_SETBANDINFOW, index, (LPARAM)&bandInfo);
 
     ReserveBorderSpace(0);

--- a/dll/win32/comctl32/rebar.c
+++ b/dll/win32/comctl32/rebar.c
@@ -2732,6 +2732,11 @@ REBAR_strdifW( LPCWSTR a, LPCWSTR b )
     return ( (a && !b) || (b && !a) || (a && b && lstrcmpW(a, b) ) );
 }
 
+#ifdef __REACTOS__
+static LRESULT
+REBAR_ShowBand (REBAR_INFO *infoPtr, INT iBand, BOOL show);
+#endif // __REACTOS__
+
 static LRESULT
 REBAR_SetBandInfoT(REBAR_INFO *infoPtr, INT iBand, const REBARBANDINFOW *lprbbi, BOOL bUnicode)
 {
@@ -2775,7 +2780,13 @@ REBAR_SetBandInfoT(REBAR_INFO *infoPtr, INT iBand, const REBARBANDINFOW *lprbbi,
 	  REBAR_Layout(infoPtr);
 	  InvalidateRect(infoPtr->hwndSelf, NULL, TRUE);
     }
-
+#ifdef __REACTOS__
+    if (uChanged & RBBIM_STYLE)
+    {
+        BOOL bVisible = (lprbbi->fStyle & RBBS_HIDDEN) != RBBS_HIDDEN;
+        REBAR_ShowBand(infoPtr, iBand, bVisible == TRUE);
+    }
+#endif
     return TRUE;
 }
 

--- a/dll/win32/comctl32/rebar.c
+++ b/dll/win32/comctl32/rebar.c
@@ -2734,7 +2734,7 @@ REBAR_strdifW( LPCWSTR a, LPCWSTR b )
 
 #ifdef __REACTOS__
 static LRESULT
-REBAR_ShowBand (REBAR_INFO *infoPtr, INT iBand, BOOL show);
+REBAR_ShowBand(REBAR_INFO *infoPtr, INT iBand, BOOL show);
 #endif
 
 static LRESULT

--- a/dll/win32/comctl32/rebar.c
+++ b/dll/win32/comctl32/rebar.c
@@ -2776,17 +2776,25 @@ REBAR_SetBandInfoT(REBAR_INFO *infoPtr, INT iBand, const REBARBANDINFOW *lprbbi,
 
     REBAR_DumpBand (infoPtr);
 
+#ifndef __REACTOS__
     if (uChanged & (RBBIM_CHILDSIZE | RBBIM_SIZE | RBBIM_STYLE | RBBIM_IMAGE)) {
 	  REBAR_Layout(infoPtr);
 	  InvalidateRect(infoPtr->hwndSelf, NULL, TRUE);
     }
-#ifdef __REACTOS__
-    if (uChanged & RBBIM_STYLE)
+#else
+    if (uChanged & (RBBIM_CHILDSIZE | RBBIM_SIZE | RBBIM_IMAGE))
+    {
+        REBAR_Layout(infoPtr);
+        InvalidateRect(infoPtr->hwndSelf, NULL, TRUE);
+    }
+    else if (uChanged &  RBBIM_STYLE)
     {
         BOOL bVisible = (lprbbi->fStyle & RBBS_HIDDEN) != RBBS_HIDDEN;
         REBAR_ShowBand(infoPtr, iBand, bVisible);
+        return TRUE;
     }
 #endif
+
     return TRUE;
 }
 

--- a/dll/win32/comctl32/rebar.c
+++ b/dll/win32/comctl32/rebar.c
@@ -2784,7 +2784,7 @@ REBAR_SetBandInfoT(REBAR_INFO *infoPtr, INT iBand, const REBARBANDINFOW *lprbbi,
     if (uChanged & RBBIM_STYLE)
     {
         BOOL bVisible = (lprbbi->fStyle & RBBS_HIDDEN) != RBBS_HIDDEN;
-        REBAR_ShowBand(infoPtr, iBand, bVisible == TRUE);
+        REBAR_ShowBand(infoPtr, iBand, bVisible);
     }
 #endif
     return TRUE;

--- a/dll/win32/comctl32/rebar.c
+++ b/dll/win32/comctl32/rebar.c
@@ -2735,7 +2735,7 @@ REBAR_strdifW( LPCWSTR a, LPCWSTR b )
 #ifdef __REACTOS__
 static LRESULT
 REBAR_ShowBand (REBAR_INFO *infoPtr, INT iBand, BOOL show);
-#endif // __REACTOS__
+#endif
 
 static LRESULT
 REBAR_SetBandInfoT(REBAR_INFO *infoPtr, INT iBand, const REBARBANDINFOW *lprbbi, BOOL bUnicode)


### PR DESCRIPTION
## Observed behavior:
In BrowserUI window, when deselecting the visibility of the standard buttons from  View menu , the toolbar is hidden, but if we move the mouse over the address bar, the buttons become visible.

## Proposed change:
The correct fix should be done  in commctl32/rebar.c.
As on Windows, the state of toolbar buttons must be set before the RB_SETBANDINFOW message returns. This solves the two previously listed problems in CORE-18742

JIRA issue: [CORE-18742](https://jira.reactos.org/browse/CORE-18742)