### PR TITLE
[MKISOFS] Use prototypes in all function definitions

### DIFF
--- a/sdk/tools/mkisofs/schilytools/libmdigest/byte_order.h
+++ b/sdk/tools/mkisofs/schilytools/libmdigest/byte_order.h
@@ -140,8 +140,7 @@ static inline UInt32_t bswap_32(UInt32_t x) {
 #elif !defined(__STRICT_ANSI__)
 /* general bswap_32 definition */
 static inline UInt32_t bswap_32 __PR((UInt32_t x));
-static inline UInt32_t bswap_32(x)
-	UInt32_t	x;
+static inline UInt32_t bswap_32(UInt32_t x)
 {
 	x = ((x << 8) & 0xFF00FF00) | ((x >> 8) & 0x00FF00FF);
 	return ((x >> 16) | (x << 16));
@@ -157,8 +156,7 @@ static inline UInt32_t bswap_32(x)
 # define bswap_64(x) _byteswap_uint64((__int64)x)
 #elif !defined(__STRICT_ANSI__)
 static inline UInt64_t bswap_64 __PR((UInt64_t x));
-static inline UInt64_t bswap_64(x)
-	UInt64_t	x;
+static inline UInt64_t bswap_64(UInt64_t x)
 {
 	union {
 		UInt64_t ll;

--- a/sdk/tools/mkisofs/schilytools/libmdigest/sha3.c
+++ b/sdk/tools/mkisofs/schilytools/libmdigest/sha3.c
@@ -81,38 +81,31 @@ void SHA3_Update	__PR((SHA3_CTX *ctx,
 				size_t size));
 
 void
-SHA3_224_Init(ctx)
-	SHA3_CTX	*ctx;
+SHA3_224_Init(SHA3_CTX *ctx)
 {
 	rhash_sha3_224_init(ctx);
 }
 
 void
-SHA3_256_Init(ctx)
-	SHA3_CTX	*ctx;
+SHA3_256_Init(SHA3_CTX *ctx)
 {
 	rhash_sha3_256_init(ctx);
 }
 
 void
-SHA3_384_Init(ctx)
-	SHA3_CTX	*ctx;
+SHA3_384_Init(SHA3_CTX *ctx)
 {
 	rhash_sha3_384_init(ctx);
 }
 
 void
-SHA3_512_Init(ctx)
-	SHA3_CTX	*ctx;
+SHA3_512_Init(SHA3_CTX *ctx)
 {
 	rhash_sha3_512_init(ctx);
 }
 
 void
-SHA3_Update(ctx, msg, size)
-	SHA3_CTX	*ctx;
-	const unsigned char *msg;
-	size_t		size;
+SHA3_Update(SHA3_CTX *ctx, const unsigned char *msg, size_t size)
 {
 	rhash_sha3_update(ctx, msg, size);
 }
@@ -139,9 +132,7 @@ static UInt64_t keccak_round_constants[NumberOfRounds] = {
 
 /* Initializing a sha3 context for given number of output bits */
 static void
-rhash_keccak_init(ctx, bits)
-	sha3_ctx	*ctx;
-	unsigned	bits;
+rhash_keccak_init(sha3_ctx *ctx, unsigned bits)
 {
 	/* NB: The Keccak capacity parameter = bits * 2 */
 	unsigned rate = 1600 - bits * 2;
@@ -157,8 +148,7 @@ rhash_keccak_init(ctx, bits)
  * @param ctx context to initialize
  */
 void
-rhash_sha3_224_init(ctx)
-	sha3_ctx	*ctx;
+rhash_sha3_224_init(sha3_ctx *ctx)
 {
 	rhash_keccak_init(ctx, 224);
 }
@@ -169,8 +159,7 @@ rhash_sha3_224_init(ctx)
  * @param ctx context to initialize
  */
 void
-rhash_sha3_256_init(ctx)
-	sha3_ctx	*ctx;
+rhash_sha3_256_init(sha3_ctx *ctx)
 {
 	rhash_keccak_init(ctx, 256);
 }
@@ -181,8 +170,7 @@ rhash_sha3_256_init(ctx)
  * @param ctx context to initialize
  */
 void
-rhash_sha3_384_init(ctx)
-	sha3_ctx	*ctx;
+rhash_sha3_384_init(sha3_ctx *ctx)
 {
 	rhash_keccak_init(ctx, 384);
 }
@@ -193,16 +181,14 @@ rhash_sha3_384_init(ctx)
  * @param ctx context to initialize
  */
 void
-rhash_sha3_512_init(ctx)
-	sha3_ctx	*ctx;
+rhash_sha3_512_init(sha3_ctx *ctx)
 {
 	rhash_keccak_init(ctx, 512);
 }
 
 /* Keccak theta() transformation */
 static void
-keccak_theta(A)
-	UInt64_t	*A;
+keccak_theta(UInt64_t *A)
 {
 	unsigned int x;
 	UInt64_t C[5], D[5];
@@ -227,8 +213,7 @@ keccak_theta(A)
 
 /* Keccak pi() transformation */
 static void
-keccak_pi(A)
-	UInt64_t	*A;
+keccak_pi(UInt64_t *A)
 {
 	UInt64_t A1;
 	A1 = A[1];
@@ -261,8 +246,7 @@ keccak_pi(A)
 
 /* Keccak chi() transformation */
 static void
-keccak_chi(A)
-	UInt64_t	*A;
+keccak_chi(UInt64_t *A)
 {
 	int i;
 	for (i = 0; i < 25; i += 5) {
@@ -276,8 +260,7 @@ keccak_chi(A)
 }
 
 static void
-rhash_sha3_permutation(state)
-	UInt64_t	*state;
+rhash_sha3_permutation(UInt64_t *state)
 {
 	int round;
 	for (round = 0; round < NumberOfRounds; round++)
@@ -326,10 +309,7 @@ rhash_sha3_permutation(state)
  * @param block_size the size of the processed block in bytes
  */
 static void
-rhash_sha3_process_block(hash, block, block_size)
-	UInt64_t	hash[25];
-	const UInt64_t	*block;
-	size_t		block_size;
+rhash_sha3_process_block(UInt64_t hash[25], const UInt64_t *block, size_t block_size)
 {
 	/* expanded loop */
 	hash[ 0] ^= le2me_64(block[ 0]);
@@ -386,10 +366,7 @@ rhash_sha3_process_block(hash, block, block_size)
  * @param size length of the message chunk
  */
 void
-rhash_sha3_update(ctx, msg, size)
-	sha3_ctx		*ctx;
-	const unsigned char	*msg;
-	size_t			size;
+rhash_sha3_update(sha3_ctx *ctx, const unsigned char *msg, size_t size)
 {
 	size_t idx = (size_t)ctx->rest;
 	size_t block_size = (size_t)ctx->block_size;
@@ -441,9 +418,7 @@ rhash_sha3_update(ctx, msg, size)
  * @param result calculated hash in binary form
  */
 void
-rhash_sha3_final(ctx, result)
-	sha3_ctx	*ctx;
-	unsigned char	*result;
+rhash_sha3_final(sha3_ctx *ctx, unsigned char *result)
 {
 	size_t digest_length = 100 - ctx->block_size / 2;
 	const size_t block_size = ctx->block_size;
@@ -466,9 +441,7 @@ rhash_sha3_final(ctx, result)
 }
 
 void
-SHA3_Final(result, ctx)
-	UInt8_t		*result;
-	SHA3_CTX	*ctx;
+SHA3_Final(UInt8_t *result, SHA3_CTX *ctx)
 {
 	rhash_sha3_final(ctx, result);
 }

--- a/sdk/tools/mkisofs/schilytools/libschily/astoll.c
+++ b/sdk/tools/mkisofs/schilytools/libschily/astoll.c
@@ -53,18 +53,13 @@
 
 
 char *
-astoll(s, l)
-	register const char *s;
-	Llong *l;
+astoll(const char *s, Llong *l)
 {
 	return (astollb(s, l, 0));
 }
 
 char *
-astollb(s, l, base)
-	register const char *s;
-	Llong *l;
-	register int base;
+astollb(const char *s, Llong *l, int base)
 {
 	int neg = 0;
 	register ULlong ret = (ULlong)0;

--- a/sdk/tools/mkisofs/schilytools/libschily/checkerr.c
+++ b/sdk/tools/mkisofs/schilytools/libschily/checkerr.c
@@ -64,8 +64,7 @@ EXPORT	BOOL	errabort	__PR((int etype, const char *fname, BOOL doexit));
  * Read and parse error configuration file
  */
 EXPORT int
-errconfig(name)
-	char	*name;
+errconfig(char *name)
 {
 	char	line[8192];
 	FILE	*f;
@@ -90,8 +89,7 @@ errconfig(name)
 }
 
 LOCAL char *
-_endword(p)
-	char	*p;
+_endword(char *p)
 {
 	/*
 	 * Find end of word.
@@ -107,8 +105,7 @@ _endword(p)
 }
 
 LOCAL void
-parse_errctl(line)
-	char	*line;
+parse_errctl(char *line)
 {
 	int	plen;
 	char	*pattern;
@@ -189,9 +186,7 @@ LOCAL struct eflags {
  * Convert error condition string into flag word
  */
 LOCAL UInt32_t
-errflags(eflag, doexit)
-	char	*eflag;
-	BOOL	doexit;
+errflags(char *eflag, BOOL doexit)
 {
 	register char		*p = eflag;
 		char		*ef = _endword(eflag);
@@ -226,9 +221,7 @@ errflags(eflag, doexit)
 }
 
 LOCAL ec_t *
-_errptr(etype, fname)
-		int	etype;
-	const	char	*fname;
+_errptr(int etype, const char *fname)
 {
 	ec_t		*ep = ec_root;
 	char		*ret;
@@ -261,9 +254,7 @@ _errptr(etype, fname)
  * Check whether error condition should be ignored for file name.
  */
 EXPORT BOOL
-errhidden(etype, fname)
-		int	etype;
-	const	char	*fname;
+errhidden(int etype, const char *fname)
 {
 	ec_t		*ep;
 
@@ -279,9 +270,7 @@ errhidden(etype, fname)
  * Check whether error condition should not affect exit code for file name.
  */
 EXPORT BOOL
-errwarnonly(etype, fname)
-		int	etype;
-	const	char	*fname;
+errwarnonly(int etype, const char *fname)
 {
 	ec_t		*ep;
 
@@ -297,10 +286,7 @@ errwarnonly(etype, fname)
  * Check whether error condition should be fatal for file name.
  */
 EXPORT BOOL
-errabort(etype, fname, doexit)
-		int	etype;
-	const	char	*fname;
-		BOOL	doexit;
+errabort(int etype, const char *fname, BOOL doexit)
 {
 	ec_t	*ep;
 

--- a/sdk/tools/mkisofs/schilytools/libschily/comerr.c
+++ b/sdk/tools/mkisofs/schilytools/libschily/comerr.c
@@ -55,9 +55,7 @@ LOCAL	ex_t	*exfuncs;
  * in other words: call order is the reverse order of registration.
  */
 EXPORT	int
-on_comerr(func, arg)
-	void	(*func) __PR((int, void *));
-	void	*arg;
+on_comerr(void (*func)(int, void*), void *arg)
 {
 	ex_t	*fp;
 
@@ -76,23 +74,12 @@ on_comerr(func, arg)
  * Fetch current errno, print a related message and exit(errno).
  */
 /* VARARGS1 */
-#ifdef	PROTOTYPES
 EXPORT void
 comerr(const char *msg, ...)
-#else
-EXPORT void
-comerr(msg, va_alist)
-	char	*msg;
-	va_dcl
-#endif
 {
 	va_list	args;
 
-#ifdef	PROTOTYPES
 	va_start(args, msg);
-#else
-	va_start(args);
-#endif
 	(void) _comerr(stderr, COMERR_EXIT, 0, geterrno(), msg, args);
 	/* NOTREACHED */
 	va_end(args);
@@ -102,24 +89,12 @@ comerr(msg, va_alist)
  * Fetch current errno, print a related message and exit(exc).
  */
 /* VARARGS2 */
-#ifdef	PROTOTYPES
 EXPORT void
 xcomerr(int exc, const char *msg, ...)
-#else
-EXPORT void
-xcomerr(exc, msg, va_alist)
-	int	exc;
-	char	*msg;
-	va_dcl
-#endif
 {
 	va_list	args;
 
-#ifdef	PROTOTYPES
 	va_start(args, msg);
-#else
-	va_start(args);
-#endif
 	(void) _comerr(stderr, COMERR_EXCODE, exc, geterrno(), msg, args);
 	/* NOTREACHED */
 	va_end(args);
@@ -129,24 +104,12 @@ xcomerr(exc, msg, va_alist)
  * Print a message related to err and exit(err).
  */
 /* VARARGS2 */
-#ifdef	PROTOTYPES
 EXPORT void
 comerrno(int err, const char *msg, ...)
-#else
-EXPORT void
-comerrno(err, msg, va_alist)
-	int	err;
-	char	*msg;
-	va_dcl
-#endif
 {
 	va_list	args;
 
-#ifdef	PROTOTYPES
 	va_start(args, msg);
-#else
-	va_start(args);
-#endif
 	(void) _comerr(stderr, COMERR_EXIT, 0, err, msg, args);
 	/* NOTREACHED */
 	va_end(args);
@@ -156,25 +119,12 @@ comerrno(err, msg, va_alist)
  * Print a message related to err and exit(exc).
  */
 /* VARARGS3 */
-#ifdef	PROTOTYPES
 EXPORT void
 xcomerrno(int exc, int err, const char *msg, ...)
-#else
-EXPORT void
-xcomerrno(exc, err, msg, va_alist)
-	int	exc;
-	int	err;
-	char	*msg;
-	va_dcl
-#endif
 {
 	va_list	args;
 
-#ifdef	PROTOTYPES
 	va_start(args, msg);
-#else
-	va_start(args);
-#endif
 	(void) _comerr(stderr, COMERR_EXCODE, exc, err, msg, args);
 	/* NOTREACHED */
 	va_end(args);
@@ -184,24 +134,13 @@ xcomerrno(exc, err, msg, va_alist)
  * Fetch current errno, print a related message and return(errno).
  */
 /* VARARGS1 */
-#ifdef	PROTOTYPES
 EXPORT int
 errmsg(const char *msg, ...)
-#else
-EXPORT int
-errmsg(msg, va_alist)
-	char	*msg;
-	va_dcl
-#endif
 {
 	va_list	args;
 	int	ret;
 
-#ifdef	PROTOTYPES
 	va_start(args, msg);
-#else
-	va_start(args);
-#endif
 	ret = _comerr(stderr, COMERR_RETURN, 0, geterrno(), msg, args);
 	va_end(args);
 	return (ret);
@@ -211,25 +150,13 @@ errmsg(msg, va_alist)
  * Print a message related to err and return(err).
  */
 /* VARARGS2 */
-#ifdef	PROTOTYPES
 EXPORT int
 errmsgno(int err, const char *msg, ...)
-#else
-EXPORT int
-errmsgno(err, msg, va_alist)
-	int	err;
-	char	*msg;
-	va_dcl
-#endif
 {
 	va_list	args;
 	int	ret;
 
-#ifdef	PROTOTYPES
 	va_start(args, msg);
-#else
-	va_start(args);
-#endif
 	ret = _comerr(stderr, COMERR_RETURN, 0, err, msg, args);
 	va_end(args);
 	return (ret);
@@ -256,13 +183,7 @@ errmsgno(err, msg, va_alist)
 #define	silent_error(e)		((e) < 0)
 #endif
 EXPORT int
-_comerr(f, exflg, exc, err, msg, args)
-	FILE		*f;	/* FILE * to print to */
-	int		exflg;	/* COMERR_RETURN, COMERR_EXIT, COMERR_EXCODE */
-	int		exc;	/* Use for exit() if exflg & COMERR_EXCODE */
-	int		err;	/* Errno for text, exit(err) if !COMERR_EXIT*/
-	const char	*msg;	/* printf() format */
-	va_list		args;	/* printf() args for format */
+_comerr(FILE *f, int exflg, int exc, int err, const char *msg, va_list args)
 {
 	char	errbuf[20];
 	char	*errnam;
@@ -291,8 +212,7 @@ _comerr(f, exflg, exc, err, msg, args)
 }
 
 LOCAL int
-_ex_clash(exc)
-	int	exc;
+_ex_clash(int exc)
 {
 	int	exmod = exc % 256;
 
@@ -328,8 +248,7 @@ _ex_clash(exc)
  * on_comerr().
  */
 EXPORT void
-comexit(err)
-	int	err;
+comexit(int err)
 {
 	while (exfuncs) {
 		ex_t	*fp;
@@ -349,8 +268,7 @@ comexit(err)
  * return NULL.
  */
 EXPORT char *
-errmsgstr(err)
-	int	err;
+errmsgstr(int err)
 {
 #ifdef	HAVE_STRERROR
 	/*

--- a/sdk/tools/mkisofs/schilytools/libschily/dirent.c
+++ b/sdk/tools/mkisofs/schilytools/libschily/dirent.c
@@ -39,8 +39,7 @@ EXPORT	int		closedir __PR((DIR *));
 EXPORT	struct dirent	*readdir __PR((DIR *));
 
 EXPORT DIR *
-opendir(dname)
-	const char	*dname;
+opendir(const char *dname)
 {
 	char	path[PATH_MAX];
 	size_t	len;
@@ -100,8 +99,7 @@ opendir(dname)
 }
 
 EXPORT	int
-closedir(dp)
-	DIR	*dp;
+closedir(DIR *dp)
 {
 	int	ret = 0;
 
@@ -118,8 +116,7 @@ closedir(dp)
 }
 
 EXPORT struct dirent *
-readdir(dp)
-	DIR	*dp;
+readdir(DIR *dp)
 {
 	if (dp == NULL) {
 		seterrno(EFAULT);

--- a/sdk/tools/mkisofs/schilytools/libschily/eaccess.c
+++ b/sdk/tools/mkisofs/schilytools/libschily/eaccess.c
@@ -32,9 +32,7 @@ static	UConst char sccsid[] =
 EXPORT	int	eaccess		__PR((const char *name, int mode));
 
 EXPORT int
-eaccess(name, mode)
-	const	char	*name;
-		int	mode;
+eaccess(const char *name, int mode)
 {
 #ifdef	HAVE_EUIDACCESS
 	return (euidaccess(name, mode));

--- a/sdk/tools/mkisofs/schilytools/libschily/error.c
+++ b/sdk/tools/mkisofs/schilytools/libschily/error.c
@@ -38,24 +38,13 @@
 #pragma	weak error =	js_error
 #else
 /* VARARGS1 */
-#ifdef	PROTOTYPES
 EXPORT int
 error(const char *fmt, ...)
-#else
-EXPORT int
-error(fmt, va_alist)
-	char	*fmt;
-	va_dcl
-#endif
 {
 	va_list	args;
 	int	ret;
 
-#ifdef	PROTOTYPES
 	va_start(args, fmt);
-#else
-	va_start(args);
-#endif
 	ret = js_fprintf(stderr, "%r", fmt, args);
 	va_end(args);
 	return (ret);
@@ -64,24 +53,13 @@ error(fmt, va_alist)
 #endif	/* NO_WEAK_SYMBOLS */
 
 /* VARARGS1 */
-#ifdef	PROTOTYPES
 EXPORT int
 js_error(const char *fmt, ...)
-#else
-EXPORT int
-js_error(fmt, va_alist)
-	char	*fmt;
-	va_dcl
-#endif
 {
 	va_list	args;
 	int	ret;
 
-#ifdef	PROTOTYPES
 	va_start(args, fmt);
-#else
-	va_start(args);
-#endif
 	ret = js_fprintf(stderr, "%r", fmt, args);
 	va_end(args);
 	return (ret);

--- a/sdk/tools/mkisofs/schilytools/libschily/fconv.c
+++ b/sdk/tools/mkisofs/schilytools/libschily/fconv.c
@@ -206,11 +206,7 @@ static	int	_ferr __PR((char *, double));
 #define	abs(i)	((i) < 0 ? -(i) : (i))
 
 EXPORT int
-ftoes(s, val, fieldwidth, ndigits)
-	register	char 	*s;
-			MDOUBLE	val;
-	register	int	fieldwidth;
-	register	int	ndigits;
+ftoes(char *s, MDOUBLE val, int fieldwidth, int ndigits)
 {
 	register	char	*b;
 	register	char	*rs;
@@ -287,11 +283,7 @@ ftoes(s, val, fieldwidth, ndigits)
 #endif
 
 EXPORT int
-ftofs(s, val, fieldwidth, ndigits)
-	register	char 	*s;
-			MDOUBLE	val;
-	register	int	fieldwidth;
-	register	int	ndigits;
+ftofs(char *s, MDOUBLE val, int fieldwidth, int ndigits)
 {
 	register	char	*b;
 	register	char	*rs;
@@ -394,9 +386,7 @@ ftofs(s, val, fieldwidth, ndigits)
 #endif	/* HAVE_LONGDOUBLE */
 
 LOCAL int
-_ferr(s, val)
-	char	*s;
-	double	val;
+_ferr(char *s, double val)
 {
 	if (isnan(val)) {
 		strcpy(s, _js_nan);

--- a/sdk/tools/mkisofs/schilytools/libschily/fillbytes.c
+++ b/sdk/tools/mkisofs/schilytools/libschily/fillbytes.c
@@ -28,16 +28,8 @@
 /*
  * fillbytes(to, cnt, val) is the same as memset(to, val, cnt)
  */
-#ifdef	PROTOTYPES
 EXPORT char *
 fillbytes(void *tov, ssize_t cnt, char val)
-#else
-EXPORT char *
-fillbytes(tov, cnt, val)
-	void	*tov;
-	ssize_t	cnt;
-	char	val;
-#endif
 {
 	register char	*to = (char *)tov;
 	register ssize_t n;

--- a/sdk/tools/mkisofs/schilytools/libschily/fnmatch.c
+++ b/sdk/tools/mkisofs/schilytools/libschily/fnmatch.c
@@ -97,10 +97,7 @@ static int fnmatch1 __PR((const char *, const char *, const char *, int,
 #pragma	weak fnmatch =	js_fnmatch
 #else
 int
-fnmatch(pattern, string, flags)
-	const char	*pattern;
-	const char	*string;
-	int		flags;
+fnmatch(const char *pattern, const char *string, int flags)
 {
 	return (js_fnmatch(pattern, string, flags));
 }
@@ -108,10 +105,7 @@ fnmatch(pattern, string, flags)
 #endif
 
 int
-js_fnmatch(pattern, string, flags)
-	const char	*pattern;
-	const char	*string;
-	int		flags;
+js_fnmatch(const char *pattern, const char *string, int flags)
 {
 	/*
 	 * SunPro C gives a warning if we do not initialize an object:
@@ -127,13 +121,7 @@ js_fnmatch(pattern, string, flags)
 }
 
 static int
-fnmatch1(pattern, string, stringstart, flags, patmbs, strmbs)
-	const char	*pattern;
-	const char	*string;
-	const char	*stringstart;
-	int		flags;
-	mbstate_t	patmbs;
-	mbstate_t	strmbs;
+fnmatch1(const char *pattern, const char *string, const char *stringstart, int flags, mbstate_t patmbs, mbstate_t strmbs)
 {
 	const char *bt_pattern, *bt_string;
 	mbstate_t bt_patmbs, bt_strmbs;
@@ -280,19 +268,9 @@ fnmatch1(pattern, string, stringstart, flags, patmbs, strmbs)
 	/* NOTREACHED */
 }
 
-#ifdef	PROTOTYPES
 static int
 rangematch(const char *pattern, wchar_t test, int flags, char **newp,
 	    mbstate_t *patmbs)
-#else
-static int
-rangematch(pattern, test, flags, newp, patmbs)
-	const char *pattern;
-	wchar_t test;
-	int flags;
-	char **newp;
-	mbstate_t *patmbs;
-#endif
 {
 	int negate, ok;
 	wchar_t c, c2;

--- a/sdk/tools/mkisofs/schilytools/libschily/format.c
+++ b/sdk/tools/mkisofs/schilytools/libschily/format.c
@@ -185,7 +185,7 @@ LOCAL	int	prbuf  __PR((const char *, f_args *));
 LOCAL	int	prc    __PR((char, f_args *));
 LOCAL	int	prstring __PR((const char *, f_args *));
 #ifdef	DEBUG
-LOCAL	void	dbg_print __PR((char *fmt, int a, int b, int c, int d, int e, int f, int g, int h, int i));
+LOCAL	void	dbg_print __PR((char *fmt, ...));
 #endif
 
 #ifdef	USE_NL_ARGS
@@ -203,9 +203,7 @@ extern	void	_fmtgetarg  __PR((const char *fmt, int num, va_lists_t *));
 LOCAL char	xflsbuf	__PR((int c, f_args *ap));
 
 LOCAL char
-xflsbuf(c, ap)
-	int	c;
-	f_args	*ap;
+xflsbuf(int c, f_args *ap)
 {
 	*ap->ptr++ = c;
 	if (filewrite((FILE *)ap->fp, ap->iobuf, ap->ptr - ap->iobuf) < 0)
@@ -240,20 +238,11 @@ xflsbuf(c, ap)
 #define	FARG		farg
 #endif
 
-#ifdef	PROTOTYPES
 EXPORT int
 FORMAT_FUNC_NAME(FORMAT_FUNC_PROTO_DECL
 			void *farg,
 			const char *fmt,
 			va_list oargs)
-#else
-EXPORT int
-FORMAT_FUNC_NAME(FORMAT_FUNC_KR_ARGS farg, fmt, oargs)
-	FORMAT_FUNC_KR_DECL
-	register void	*farg;
-	register char	*fmt;
-	va_list		oargs;
-#endif
 {
 #ifdef	FORMAT_LOW_MEM
 	char buf[512];
@@ -1041,10 +1030,7 @@ LOCAL	unsigned char	dtab[]  = "0123456789abcdef";
 LOCAL	unsigned char	udtab[] = "0123456789ABCDEF";
 
 LOCAL void
-prnum(val, base, fa)
-	register Ulong val;
-	register unsigned base;
-	f_args *fa;
+prnum(Ulong val, unsigned base, f_args *fa)
 {
 	register char *p = fa->bufp;
 
@@ -1057,9 +1043,7 @@ prnum(val, base, fa)
 }
 
 LOCAL void
-prdnum(val, fa)
-	register Ulong val;
-	f_args *fa;
+prdnum(Ulong val, f_args *fa)
 {
 	register char *p = fa->bufp;
 
@@ -1075,9 +1059,7 @@ prdnum(val, fa)
  * We may need to use division here too (PDP-11, non two's complement ...)
  */
 LOCAL void
-pronum(val, fa)
-	register Ulong val;
-	f_args *fa;
+pronum(Ulong val, f_args *fa)
 {
 	register char *p = fa->bufp;
 
@@ -1090,9 +1072,7 @@ pronum(val, fa)
 }
 
 LOCAL void
-prxnum(val, fa)
-	register Ulong val;
-	f_args *fa;
+prxnum(Ulong val, f_args *fa)
 {
 	register char *p = fa->bufp;
 
@@ -1105,9 +1085,7 @@ prxnum(val, fa)
 }
 
 LOCAL void
-prXnum(val, fa)
-	register Ulong val;
-	f_args *fa;
+prXnum(Ulong val, f_args *fa)
 {
 	register char *p = fa->bufp;
 
@@ -1121,10 +1099,7 @@ prXnum(val, fa)
 
 #ifdef	USE_LONGLONG
 LOCAL void
-prlnum(val, base, fa)
-	register Ullong val;
-	register unsigned base;
-	f_args *fa;
+prlnum(Ullong val, unsigned base, f_args *fa)
 {
 	register char *p = fa->bufp;
 
@@ -1137,9 +1112,7 @@ prlnum(val, base, fa)
 }
 
 LOCAL void
-prldnum(val, fa)
-	register Ullong val;
-	f_args *fa;
+prldnum(Ullong val, f_args *fa)
 {
 	register char *p = fa->bufp;
 
@@ -1152,9 +1125,7 @@ prldnum(val, fa)
 }
 
 LOCAL void
-prlonum(val, fa)
-	register Ullong val;
-	f_args *fa;
+prlonum(Ullong val, f_args *fa)
 {
 	register char *p = fa->bufp;
 
@@ -1167,9 +1138,7 @@ prlonum(val, fa)
 }
 
 LOCAL void
-prlxnum(val, fa)
-	register Ullong val;
-	f_args *fa;
+prlxnum(Ullong val, f_args *fa)
 {
 	register char *p = fa->bufp;
 
@@ -1182,9 +1151,7 @@ prlxnum(val, fa)
 }
 
 LOCAL void
-prlXnum(val, fa)
-	register Ullong val;
-	f_args *fa;
+prlXnum(Ullong val, f_args *fa)
 {
 	register char *p = fa->bufp;
 
@@ -1202,9 +1169,7 @@ prlXnum(val, fa)
  * Final buffer print out routine.
  */
 LOCAL int
-prbuf(s, fa)
-	register const char *s;
-	f_args *fa;
+prbuf(const char *s, f_args *fa)
 {
 	register int diff;
 	register int rfillc;
@@ -1259,18 +1224,9 @@ prbuf(s, fa)
  * Print out one char, allowing prc('\0')
  * Similar to prbuf()
  */
-#ifdef	PROTOTYPES
 
 LOCAL int
 prc(char c, f_args *fa)
-
-#else
-
-LOCAL int
-prc(c, fa)
-	char	c;
-	f_args *fa;
-#endif
 {
 	register int diff;
 	register int rfillc;
@@ -1305,9 +1261,7 @@ prc(c, fa)
  * If fa->signific is 0, print no characters.
  */
 LOCAL int
-prstring(s, fa)
-	register const char	*s;
-	f_args *fa;
+prstring(const char *s, f_args *fa)
 {
 	register char	*bp;
 	register int	signific;
@@ -1330,12 +1284,15 @@ prstring(s, fa)
 
 #ifdef	DEBUG
 LOCAL void
-dbg_print(fmt, a, b, c, d, e, f, g, h, i)
-char *fmt;
+dbg_print(char *fmt, ...)
 {
 	char	ff[1024];
 
-	sprintf(ff, fmt, a, b, c, d, e, f, g, h, i);
+	va_list ap;
+	va_start(ap, fmt)
+	vsprintf(ff, fmt, ap);
+	va_end(ap);
+
 	write(STDERR_FILENO, ff, strlen(ff));
 }
 #endif
@@ -1387,10 +1344,7 @@ static	const char	*digits = &skips[8];
  *		store the related va_list state in arglist[]
  */
 EXPORT void
-_fmtarglist(fmt, fargs, arglist)
-	const char	*fmt;
-	va_lists_t	fargs;
-	va_lists_t	arglist[];
+_fmtarglist(const char *fmt, va_lists_t fargs, va_lists_t arglist[])
 {
 	int	i;
 	int	argindex;
@@ -1688,10 +1642,7 @@ error sizeof (ptrdiff_t) is unknown
  * the current FMT_ARGMAX definition of 30.
  */
 EXPORT void
-_fmtgetarg(fmt, num, fargs)
-	const char	*fmt;
-	int		num;
-	va_lists_t	*fargs;
+_fmtgetarg(const char *fmt, int num, va_lists_t *fargs)
 {
 	const char	*sfmt = fmt;
 	int		i;

--- a/sdk/tools/mkisofs/schilytools/libschily/getargs.c
+++ b/sdk/tools/mkisofs/schilytools/libschily/getargs.c
@@ -118,10 +118,7 @@ LOCAL	struct ga_props	props_default = { 0, 0, sizeof (struct ga_props) };
 LOCAL	struct ga_props	props_posix = { GAF_POSIX_DEFAULT, 0, sizeof (struct ga_props) };
 
 EXPORT int
-_getarginit(props, size, flags)
-	struct ga_props	*props;
-	size_t		size;
-	UInt32_t	flags;
+_getarginit(struct ga_props *props, size_t size, UInt32_t flags)
 {
 	if (size > sizeof (struct ga_props))
 		return (-1);
@@ -140,8 +137,7 @@ _getarginit(props, size, flags)
 }
 
 LOCAL struct ga_props *
-_getprops(props)
-	struct ga_props	*props;
+_getprops(struct ga_props *props)
 {
 	if (props == GA_NO_PROPS)
 		props = &props_default;
@@ -162,26 +158,13 @@ _getprops(props)
  *	get flags until a non flag type argument is reached (old version)
  */
 /* VARARGS3 */
-#ifdef	PROTOTYPES
 EXPORT int
 getargs(int *pac, char *const **pav, const char *fmt, ...)
-#else
-EXPORT int
-getargs(pac, pav, fmt, va_alist)
-	int	*pac;
-	char	**pav[];
-	char	*fmt;
-	va_dcl
-#endif
 {
 	va_list	args;
 	int	ret;
 
-#ifdef	PROTOTYPES
 	va_start(args, fmt);
-#else
-	va_start(args);
-#endif
 	ret = _getargs(pac, pav, (void *)fmt, SETARGS, GA_NO_PROPS, args);
 	va_end(args);
 	return (ret);
@@ -192,27 +175,13 @@ getargs(pac, pav, fmt, va_alist)
  *	get flags until a non flag type argument is reached (list version)
  */
 /* VARARGS4 */
-#ifdef	PROTOTYPES
 EXPORT int
 getlargs(int *pac, char *const **pav, struct ga_props *props, const char *fmt, ...)
-#else
-EXPORT int
-getlargs(pac, pav, props, fmt, va_alist)
-	int		*pac;
-	char		**pav[];
-	struct ga_props	*props;
-	char		*fmt;
-	va_dcl
-#endif
 {
 	va_list	args;
 	int	ret;
 
-#ifdef	PROTOTYPES
 	va_start(args, fmt);
-#else
-	va_start(args);
-#endif
 	ret = _getargs(pac, pav, (void *)fmt, SETARGS, props, args);
 	va_end(args);
 	return (ret);
@@ -223,11 +192,7 @@ getlargs(pac, pav, props, fmt, va_alist)
  *	get flags until a non flag type argument is reached (vector version)
  */
 EXPORT int
-getvargs(pac, pav, props, vfmt)
-	int	*pac;
-	char	* const *pav[];
-	struct ga_props	*props;
-	struct ga_flags *vfmt;
+getvargs(int *pac, char * const *pav[], struct ga_props *props, struct ga_flags *vfmt)
 {
 	return (_getargs(pac, pav, vfmt, SETARGS | ARGVECTOR, props, va_dummy));
 }
@@ -237,26 +202,13 @@ getvargs(pac, pav, props, vfmt)
  *	get all flags on the command line, do not stop on files (old version)
  */
 /* VARARGS3 */
-#ifdef	PROTOTYPES
 EXPORT int
 getallargs(int *pac, char *const **pav, const char *fmt, ...)
-#else
-EXPORT int
-getallargs(pac, pav, fmt, va_alist)
-	int	*pac;
-	char	**pav[];
-	char	*fmt;
-	va_dcl
-#endif
 {
 	va_list	args;
 	int	ret;
 
-#ifdef	PROTOTYPES
 	va_start(args, fmt);
-#else
-	va_start(args);
-#endif
 	for (; ; (*pac)--, (*pav)++) {
 		if ((ret = _getargs(pac, pav, (void *)fmt, SETARGS, GA_NO_PROPS, args)) < NOTAFLAG)
 			break;
@@ -270,27 +222,13 @@ getallargs(pac, pav, fmt, va_alist)
  *	get all flags on the command line, do not stop on files (list version)
  */
 /* VARARGS4 */
-#ifdef	PROTOTYPES
 EXPORT int
 getlallargs(int *pac, char *const **pav, struct ga_props *props, const char *fmt, ...)
-#else
-EXPORT int
-getlallargs(pac, pav, props, fmt, va_alist)
-	int		*pac;
-	char		**pav[];
-	struct ga_props	*props;
-	char		*fmt;
-	va_dcl
-#endif
 {
 	va_list	args;
 	int	ret;
 
-#ifdef	PROTOTYPES
 	va_start(args, fmt);
-#else
-	va_start(args);
-#endif
 	props = _getprops(props);
 	for (; ; (*pac)--, (*pav)++) {
 		if ((ret = _getargs(pac, pav, (void *)fmt, SETARGS, props, args)) < NOTAFLAG)
@@ -311,11 +249,7 @@ getlallargs(pac, pav, props, fmt, va_alist)
  *	get all flags on the command line, do not stop on files (vector version)
  */
 EXPORT int
-getvallargs(pac, pav, props, vfmt)
-	int	*pac;
-	char	* const *pav[];
-	struct ga_props	*props;
-	struct ga_flags *vfmt;
+getvallargs(int *pac, char * const *pav[], struct ga_props *props, struct ga_flags *vfmt)
 {
 	int	ret;
 
@@ -339,10 +273,7 @@ getvallargs(pac, pav, props, vfmt)
  *	getfiles() is a dry run getargs()
  */
 EXPORT int
-getfiles(pac, pav, fmt)
-	int		*pac;
-	char *const	*pav[];
-	const char	*fmt;
+getfiles(int *pac, char * const *pav[], const char *fmt)
 {
 	return (_getargs(pac, pav, (void *)fmt, SCANONLY, GA_NO_PROPS, va_dummy));
 }
@@ -353,11 +284,7 @@ getfiles(pac, pav, fmt)
  *	getlfiles() is a dry run getlargs()
  */
 EXPORT int
-getlfiles(pac, pav, props, fmt)
-	int		*pac;
-	char *const	*pav[];
-	struct ga_props	*props;
-	const char	*fmt;
+getlfiles(int *pac, char *const *pav[], struct ga_props *props, const char *fmt)
 {
 	return (_getargs(pac, pav, (void *)fmt, SCANONLY, props, va_dummy));
 }
@@ -368,11 +295,7 @@ getlfiles(pac, pav, props, fmt)
  *	getvfiles() is a dry run getvargs()
  */
 EXPORT int
-getvfiles(pac, pav, props, vfmt)
-	int		*pac;
-	char *const	*pav[];
-	struct ga_props	*props;
-	struct ga_flags	*vfmt;
+getvfiles(int *pac, char *const *pav[], struct ga_props *props, struct ga_flags *vfmt)
 {
 	return (_getargs(pac, pav, vfmt, SCANONLY | ARGVECTOR, props, va_dummy));
 }
@@ -392,13 +315,7 @@ getvfiles(pac, pav, props, vfmt)
  */
 /* LOCAL int */
 EXPORT int
-_getargs(pac, pav, vfmt, flags, props, args)
-	register int		*pac;
-	register char	*const	**pav;
-		void		*vfmt;
-		int		flags;
-		struct ga_props	*props;
-		va_list		args;
+_getargs(int *pac, char *const **pav, void *vfmt, int flags, struct ga_props *props, va_list args)
 {
 	const	char	*argp;
 		int	ret;
@@ -430,11 +347,7 @@ _getargs(pac, pav, vfmt, flags, props, args)
  * check if *pargp is a file type argument
  */
 LOCAL int
-dofile(pac, pav, pargp, props)
-	register int		*pac;
-	register char *const	**pav;
-		const char	**pargp;
-		struct ga_props	*props;
+dofile(int *pac, char * const **pav, const char **pargp, struct ga_props *props)
 {
 	register const char	*argp = *pargp;
 
@@ -499,13 +412,7 @@ dofile(pac, pav, pargp, props)
  *	va_list may be a dummy argument.
  */
 LOCAL int
-doflag(pac, pav, argp, vfmt, flags, oargs)
-		int		*pac;
-		char	*const	**pav;
-	register const char	*argp;
-		void		*vfmt;
-		int		flags;
-		va_list		oargs;
+doflag(int *pac, char * const **pav, const char *argp, void *vfmt, int flags, va_list oargs)
 {
 	register const char	*fmt = (const char *)vfmt;
 	struct ga_flags		*flagp = vfmt;
@@ -1032,13 +939,7 @@ typedef struct {
 } sflags;
 
 LOCAL int
-dosflags(argp, vfmt, pac, pav, flags, oargs)
-	register const char	*argp;
-		void		*vfmt;
-		int		*pac;
-		char	*const	**pav;
-		int		flags;
-		va_list		oargs;
+dosflags(const char *argp, void *vfmt, int *pac, char * const **pav, int flags, va_list oargs)
 {
 	register const char	*fmt = (const char *)vfmt;
 	struct ga_flags		*flagp = vfmt;
@@ -1294,8 +1195,7 @@ again:
  *	Otherwise raise the getarg_bad_format condition.
  */
 LOCAL int
-checkfmt(fmt)
-	const char	*fmt;
+checkfmt(const char *fmt)
 {
 	char	c;
 
@@ -1318,8 +1218,7 @@ checkfmt(fmt)
  *	contains a valid flag identifier.
  */
 LOCAL int
-checkeql(str)
-	register const char *str;
+checkeql(const char *str)
 {
 	register unsigned char c;
 
@@ -1332,8 +1231,7 @@ checkeql(str)
 }
 
 EXPORT char *
-getargerror(err)
-	int	err;
+getargerror(int err)
 {
 	if (err < RETMIN || err > RETMAX)
 		return ("Illegal arg error");

--- a/sdk/tools/mkisofs/schilytools/libschily/geterrno.c
+++ b/sdk/tools/mkisofs/schilytools/libschily/geterrno.c
@@ -31,7 +31,7 @@
 #endif
 
 EXPORT int
-geterrno()
+geterrno(void)
 
 {
 	return (errno);

--- a/sdk/tools/mkisofs/schilytools/libschily/getexecpath.c
+++ b/sdk/tools/mkisofs/schilytools/libschily/getexecpath.c
@@ -52,7 +52,7 @@
 
 
 EXPORT char *
-getexecpath()
+getexecpath(void)
 {
 #ifdef	PATH_IMPL
 #ifdef	METHOD_SYMLINK

--- a/sdk/tools/mkisofs/schilytools/libschily/gettimeofday.c
+++ b/sdk/tools/mkisofs/schilytools/libschily/gettimeofday.c
@@ -37,9 +37,7 @@ const	Int64_t MS_FTIME_SECS	= 10000000LL;
 #endif
 
 EXPORT int
-gettimeofday(tp, dummy)
-	struct timeval	*tp;
-	void		*dummy;		/* tzp is unspecified by POSIX */
+gettimeofday(struct timeval *tp, void *dummy) /* tzp is unspecified by POSIX */
 {
 	FILETIME	ft;
 	Int64_t		T;
@@ -68,9 +66,7 @@ gettimeofday(tp, dummy)
 #include <schily/standard.h>
 
 EXPORT int
-gettimeofday(tp, dummy)
-	struct timeval	*tp;
-	void		*dummy;		/* tzp is unspecified by POSIX */
+gettimeofday(struct timeval *tp, void *dummy) /* tzp is unspecified by POSIX */
 {
 	time_t	t;
 

--- a/sdk/tools/mkisofs/schilytools/libschily/gid.c
+++ b/sdk/tools/mkisofs/schilytools/libschily/gid.c
@@ -24,7 +24,7 @@
 #ifndef	HAVE_GETGID
 
 EXPORT gid_t
-getgid()
+getgid(void)
 {
 	return (0);
 }
@@ -34,7 +34,7 @@ getgid()
 #ifndef	HAVE_GETEGID
 
 EXPORT gid_t
-getegid()
+getegid(void)
 {
 	return (0);
 }
@@ -44,8 +44,7 @@ getegid()
 #ifndef	HAVE_SETGID
 
 EXPORT int
-setgid(gid)
-	gid_t	gid;
+setgid(gid_t gid)
 {
 	return (0);
 }
@@ -55,8 +54,7 @@ setgid(gid)
 #ifndef	HAVE_SETEGID
 
 EXPORT int
-setegid(gid)
-	gid_t	gid;
+setegid(gid_t gid)
 {
 	return (0);
 }

--- a/sdk/tools/mkisofs/schilytools/libschily/jsprintf.c
+++ b/sdk/tools/mkisofs/schilytools/libschily/jsprintf.c
@@ -39,49 +39,26 @@
  */
 
 /* VARARGS1 */
-#ifdef	PROTOTYPES
 EXPORT int
 js_printf(const char *form, ...)
-#else
-EXPORT int
-js_printf(form, va_alist)
-	char	*form;
-	va_dcl
-#endif
 {
 	va_list	args;
 	int	ret;
 
-#ifdef	PROTOTYPES
 	va_start(args, form);
-#else
-	va_start(args);
-#endif
 	ret = fprformat(stdout, form, args);
 	va_end(args);
 	return (ret);
 }
 
 /* VARARGS2 */
-#ifdef	PROTOTYPES
 EXPORT int
 js_fprintf(FILE *file, const char *form, ...)
-#else
-EXPORT int
-js_fprintf(file, form, va_alist)
-	FILE	*file;
-	char	*form;
-	va_dcl
-#endif
 {
 	va_list	args;
 	int	ret;
 
-#ifdef	PROTOTYPES
 	va_start(args, form);
-#else
-	va_start(args);
-#endif
 	ret = fprformat(file, form, args);
 	va_end(args);
 	return (ret);
@@ -108,8 +85,7 @@ EXPORT	int	js_fprintf	__PR((FILE *, const char *, ...));
 EXPORT	int	js_printf	__PR((const char *, ...));
 
 LOCAL void
-_bflush(bp)
-	register BUF	bp;
+_bflush(BUF bp)
 {
 	bp->count += bp->ptr - bp->buf;
 	if (filewrite(bp->f, bp->buf, bp->ptr - bp->buf) < 0)
@@ -118,15 +94,8 @@ _bflush(bp)
 	bp->cnt = BFSIZ;
 }
 
-#ifdef	PROTOTYPES
 LOCAL void
 _bput(char c, void *l)
-#else
-LOCAL void
-_bput(c, l)
-		char	c;
-		void	*l;
-#endif
 {
 	register BUF	bp = (BUF)l;
 
@@ -136,15 +105,8 @@ _bput(c, l)
 }
 
 /* VARARGS1 */
-#ifdef	PROTOTYPES
 EXPORT int
 js_printf(const char *form, ...)
-#else
-EXPORT int
-js_printf(form, va_alist)
-	char	*form;
-	va_dcl
-#endif
 {
 	va_list	args;
 	_BUF	bb;
@@ -153,11 +115,7 @@ js_printf(form, va_alist)
 	bb.cnt = BFSIZ;
 	bb.count = 0;
 	bb.f = stdout;
-#ifdef	PROTOTYPES
 	va_start(args, form);
-#else
-	va_start(args);
-#endif
 	format(_bput, &bb, form, args);
 	va_end(args);
 	if (bb.cnt < BFSIZ)
@@ -166,16 +124,8 @@ js_printf(form, va_alist)
 }
 
 /* VARARGS2 */
-#ifdef	PROTOTYPES
 EXPORT int
 js_fprintf(FILE *file, const char *form, ...)
-#else
-EXPORT int
-js_fprintf(file, form, va_alist)
-	FILE	*file;
-	char	*form;
-	va_dcl
-#endif
 {
 	va_list	args;
 	_BUF	bb;
@@ -184,11 +134,7 @@ js_fprintf(file, form, va_alist)
 	bb.cnt = BFSIZ;
 	bb.count = 0;
 	bb.f = file;
-#ifdef	PROTOTYPES
 	va_start(args, form);
-#else
-	va_start(args);
-#endif
 	format(_bput, &bb, form, args);
 	va_end(args);
 	if (bb.cnt < BFSIZ)

--- a/sdk/tools/mkisofs/schilytools/libschily/jssnprintf.c
+++ b/sdk/tools/mkisofs/schilytools/libschily/jssnprintf.c
@@ -31,15 +31,8 @@ typedef struct {
 	int	count;
 } *BUF, _BUF;
 
-#ifdef	PROTOTYPES
 static void
 _cput(char c, void *l)
-#else
-static void
-_cput(c, l)
-	char	c;
-	void	*l;
-#endif
 {
 	register BUF	bp = (BUF)l;
 
@@ -54,17 +47,8 @@ _cput(c, l)
 }
 
 /* VARARGS2 */
-#ifdef	PROTOTYPES
 EXPORT int
 js_snprintf(char *buf, size_t maxcnt, const char *form, ...)
-#else
-EXPORT int
-js_snprintf(buf, maxcnt, form, va_alist)
-	char	*buf;
-	unsigned maxcnt;
-	char	*form;
-	va_dcl
-#endif
 {
 	va_list	args;
 	int	cnt;
@@ -73,11 +57,7 @@ js_snprintf(buf, maxcnt, form, va_alist)
 	bb.ptr = buf;
 	bb.count = maxcnt;
 
-#ifdef	PROTOTYPES
 	va_start(args, form);
-#else
-	va_start(args);
-#endif
 	cnt = format(_cput, &bb, form,  args);
 	va_end(args);
 	if (maxcnt > 0)

--- a/sdk/tools/mkisofs/schilytools/libschily/match.c
+++ b/sdk/tools/mkisofs/schilytools/libschily/match.c
@@ -206,13 +206,7 @@ out:							\
  */
 #if !defined(__WIDE_CHAR) && !defined(__MB_CHAR)
 EXPORT CHAR
-*opatmatch(pat, aux, str, soff, slen, alt)
-	const PCHAR	*pat;
-	const int	*aux;
-	const CHAR	*str;
-	int		soff;
-	int		slen;
-	int		alt;
+*opatmatch(const PCHAR *pat, const int *aux, const CHAR *str, int soff, int slen, int alt)
 {
 	int		state[MAXPAT];
 
@@ -227,14 +221,7 @@ EXPORT CHAR
  *	against the compiled pattern.
  */
 EXPORT CHAR *
-patmatch(pat, aux, str, soff, slen, alt, state)
-	const PCHAR	*pat;
-	const int	*aux;
-	const CHAR	*str;
-	int		soff;
-	int		slen;
-	int		alt;
-	int		state[];
+patmatch(const PCHAR *pat, const int *aux, const CHAR *str, int soff, int slen, int alt, int state[])
 {
 	register int	*sp;
 	register int	*n;
@@ -425,8 +412,7 @@ LOCAL	int	join	 __PR((int *, int, int));
  *	get the next item from pattern
  */
 LOCAL void
-nextitem(ap)
-	arg_t	*ap;
+nextitem(arg_t *ap)
 {
 	if (ap->Ch == QUOTE)
 		rch(ap);
@@ -437,8 +423,7 @@ nextitem(ap)
  *	parse a primary
  */
 LOCAL int
-prim(ap)
-	arg_t	*ap;
+prim(arg_t *ap)
 {
 	int	a  = ap->patp;
 	int	op = ap->Ch;
@@ -509,9 +494,7 @@ prim(ap)
  *	parse an expression (a sequence of primaries)
  */
 LOCAL int
-expr(ap, altp)
-	arg_t	*ap;
-	int	*altp;
+expr(arg_t *ap, int *altp)
 {
 	int	exits = ENDSTATE;
 	int	a;
@@ -539,10 +522,7 @@ expr(ap, altp)
  *	set all exits in a list to a specified value
  */
 LOCAL void
-setexits(aux, list, val)
-	int	*aux;
-	int	list;
-	int	val;
+setexits(int *aux, int list, int val)
 {
 	int	a;
 
@@ -557,10 +537,7 @@ setexits(aux, list, val)
  *	concatenate two lists
  */
 LOCAL int
-join(aux, a, b)
-	int	*aux;
-	int	a;
-	int	b;
+join(int *aux, int a, int b)
 {
 	int	t;
 
@@ -581,10 +558,7 @@ join(aux, a, b)
  *	Error is indicated by return of 0.
  */
 EXPORT int
-patcompile(pat, len, aux)
-	const PCHAR	*pat;
-	int		len;
-	int		*aux;
+patcompile(const PCHAR *pat, int len, int *aux)
 {
 	arg_t	a;
 	int	alt = ENDSTATE;

--- a/sdk/tools/mkisofs/schilytools/libschily/mem.c
+++ b/sdk/tools/mkisofs/schilytools/libschily/mem.c
@@ -39,8 +39,7 @@ EXPORT	char	*___savestr	__PR((const char *s));
 LOCAL	int	mexval;
 
 EXPORT	int
-___mexval(exval)
-	int	exval;
+___mexval(int exval)
 {
 	int	ret = mexval;
 
@@ -50,9 +49,7 @@ ___mexval(exval)
 }
 
 EXPORT void *
-___malloc(size, msg)
-	size_t	size;
-	char	*msg;
+___malloc(size_t size, char *msg)
 {
 	void	*ret;
 
@@ -70,10 +67,7 @@ ___malloc(size, msg)
 }
 
 EXPORT void *
-___realloc(ptr, size, msg)
-	void	*ptr;
-	size_t	size;
-	char	*msg;
+___realloc(void *ptr, size_t size, char *msg)
 {
 	void	*ret;
 
@@ -94,8 +88,7 @@ ___realloc(ptr, size, msg)
 }
 
 EXPORT char *
-___savestr(s)
-	const char	*s;
+___savestr(const char *s)
 {
 	char	*ret = ___malloc(strlen(s)+1, "saved string");
 

--- a/sdk/tools/mkisofs/schilytools/libschily/movebytes.c
+++ b/sdk/tools/mkisofs/schilytools/libschily/movebytes.c
@@ -27,10 +27,7 @@
  * movebytes(from, to, cnt) is the same as memmove(to, from, cnt)
  */
 EXPORT char *
-movebytes(fromv, tov, cnt)
-	const void	*fromv;
-	void		*tov;
-	ssize_t		cnt;
+movebytes(const void *fromv, void *tov, ssize_t cnt)
 {
 	register const char	*from	= fromv;
 	register char		*to	= tov;

--- a/sdk/tools/mkisofs/schilytools/libschily/raisecond.c
+++ b/sdk/tools/mkisofs/schilytools/libschily/raisecond.c
@@ -97,9 +97,7 @@ LOCAL	BOOL framehandle __PR((SIGBLK *, const char *, const char *, long));
  *	containing different handlers.
  */
 EXPORT void
-raisecond(signame, arg2)
-	const char	*signame;
-	long		arg2;
+raisecond(const char *signame, long arg2)
 {
 	register void	*vp = NULL;
 
@@ -142,11 +140,7 @@ raisecond(signame, arg2)
  *	The return value in the latter case depends on the called function.
  */
 LOCAL BOOL
-framehandle(sp, handlename, signame, arg2)
-	register SIGBLK *sp;
-	const char	*handlename;
-	const char	*signame;
-	long		arg2;
+framehandle(SIGBLK *sp, const char *handlename, const char *signame, long arg2)
 {
 	for (; sp; sp = sp->sb_signext) {
 		if (sp->sb_signame != NULL &&
@@ -163,8 +157,7 @@ framehandle(sp, handlename, signame, arg2)
 }
 
 LOCAL void
-raiseabort(signame)
-	const	char	*signame;
+raiseabort(const char *signame)
 {
 	eprints("Condition not caught: "); eprintl(signame); eprints(".\n");
 	abort();

--- a/sdk/tools/mkisofs/schilytools/libschily/saveargs.c
+++ b/sdk/tools/mkisofs/schilytools/libschily/saveargs.c
@@ -55,9 +55,7 @@ LOCAL	void	init_progname	__PR((void));
 LOCAL	void	init_arginfo	__PR((void));
 
 EXPORT void
-save_args(ac, av)
-	int	ac;
-	char	*av[];
+save_args(int ac, char *av[])
 {
 	ac_saved = ac;
 	av_saved = av;
@@ -65,8 +63,7 @@ save_args(ac, av)
 }
 
 LOCAL void
-save_av0(av0)
-	char	*av0;
+save_av0(char *av0)
 {
 	int	slen;
 	char	*p;
@@ -93,7 +90,7 @@ save_av0(av0)
 }
 
 EXPORT int
-saved_ac()
+saved_ac(void)
 {
 	if (av_saved == NULL)
 		init_arginfo();
@@ -102,7 +99,7 @@ saved_ac()
 }
 
 EXPORT char **
-saved_av()
+saved_av(void)
 {
 	if (av_saved == NULL)
 		init_arginfo();
@@ -111,7 +108,7 @@ saved_av()
 }
 
 EXPORT char *
-saved_av0()
+saved_av0(void)
 {
 	if (av0_saved == NULL)
 		init_arginfo();
@@ -120,8 +117,7 @@ saved_av0()
 }
 
 EXPORT void
-set_progname(name)
-	const char	*name;
+set_progname(const char *name)
 {
 	int	slen;
 	char	*p;
@@ -148,7 +144,7 @@ set_progname(name)
 }
 
 EXPORT char *
-get_progname()
+get_progname(void)
 {
 	if (progname_saved)
 		return (progname_saved);
@@ -160,7 +156,7 @@ get_progname()
 }
 
 EXPORT char *
-get_progpath()
+get_progpath(void)
 {
 	if (progpath_saved)
 		return (progpath_saved);
@@ -172,7 +168,7 @@ get_progpath()
 }
 
 LOCAL void
-init_progname()
+init_progname(void)
 {
 #if defined(HAVE_SCANSTACK) || defined(HAVE_GETPROGNAME)
 	char	*progname;
@@ -205,7 +201,7 @@ init_progname()
 }
 
 LOCAL void
-init_arginfo()
+init_arginfo(void)
 {
 #if defined(HAVE_DLINFO) && defined(HAVE_DLOPEN_IN_LIBC) && defined(RTLD_DI_ARGSINFO)
 	Dl_argsinfo	args;

--- a/sdk/tools/mkisofs/schilytools/libschily/searchinpath.c
+++ b/sdk/tools/mkisofs/schilytools/libschily/searchinpath.c
@@ -65,11 +65,11 @@ LOCAL	char 	*strbs2s		__PR((char *s));
  * Assume that the file is ... bin/../name.
  */
 EXPORT char *
-searchfileinpath(name, mode, file_mode, path)
-	char	*name;			/* Find <execname>/../name in PATH	*/
-	int	mode;			/* Mode for access() e.g. X_OK		*/
-	int	file_mode;		/* How to check files			*/
-	char	*path;			/* PATH to use if not NULL		*/
+searchfileinpath(char *name, int mode, int file_mode, char *path)
+	/* name			Find <execname>/../name in PATH	*/
+	/* mode			Mode for access() e.g. X_OK		*/
+	/* file_mode	How to check files */
+	/* path			PATH to use if not NULL */
 {
 	char	pbuf[NAMEMAX];
 	char	*nbuf = pbuf;
@@ -183,14 +183,14 @@ searchfileinpath(name, mode, file_mode, path)
 }
 
 LOCAL char *
-searchonefile(name, mode, plain_file, xn, nbuf, np, ep)
-	register char	*name;		/* Find <execname>/../name in PATH	*/
-		int	mode;		/* Mode for access() e.g. X_OK		*/
-		BOOL	plain_file;	/* Whether to check only plain files	*/
-		char	*xn;		/* The basename of the executable	*/
-	register char	*nbuf;		/* Name buffer base			*/
-	register char	*np;		/* Where to append name to path		*/
-	register char	*ep;		/* Point to last valid char in nbuf	*/
+searchonefile(char *name, int mode, BOOL plain_file, char *xn, char *nbuf, char *np, char*ep)
+	/* name				Find <execname>/../name in PATH	*/
+	/* mode				Mode for access() e.g. X_OK */
+	/* plain_file		Whether to check only plain files */
+	/* xn				The basename of the executable */
+	/* nbuf				Name buffer base */
+	/* np				Where to append name to path */
+	/* ep				Point to last valid char in nbuf */
 {
 	struct stat	sb;
 
@@ -228,8 +228,7 @@ searchonefile(name, mode, plain_file, xn, nbuf, np, ep)
 
 #ifdef __DJGPP__
 LOCAL char *
-strbs2s(s)
-	char	*s;
+strbs2s(char *s)
 {
 	char	*tmp = s;
 

--- a/sdk/tools/mkisofs/schilytools/libschily/seterrno.c
+++ b/sdk/tools/mkisofs/schilytools/libschily/seterrno.c
@@ -31,8 +31,7 @@
 #endif
 
 EXPORT int
-seterrno(err)
-	int	err;
+seterrno(int err)
 {
 	int	old = errno;
 

--- a/sdk/tools/mkisofs/schilytools/libschily/streql.c
+++ b/sdk/tools/mkisofs/schilytools/libschily/streql.c
@@ -20,9 +20,7 @@
 #include <schily/schily.h>
 
 EXPORT int
-streql(a, b)
-	const char	*a;
-	const char	*b;
+streql(const char *a, const char *b)
 {
 	register const char	*s1 = a;
 	register const char	*s2 = b;

--- a/sdk/tools/mkisofs/schilytools/libschily/strlcat.c
+++ b/sdk/tools/mkisofs/schilytools/libschily/strlcat.c
@@ -29,10 +29,7 @@ static	UConst char sccsid[] =
 #ifndef	HAVE_STRLCAT
 
 EXPORT size_t
-strlcat(s1, s2, len)
-	register char		*s1;
-	register const char	*s2;
-	register size_t		len;
+strlcat(char *s1, const char *s2, size_t len)
 {
 	const char		*os1	= s1;
 		size_t		olen	= len;

--- a/sdk/tools/mkisofs/schilytools/libschily/strlcpy.c
+++ b/sdk/tools/mkisofs/schilytools/libschily/strlcpy.c
@@ -28,10 +28,7 @@ static	UConst char sccsid[] =
 #ifndef	HAVE_STRLCPY
 
 EXPORT size_t
-strlcpy(s1, s2, len)
-	register char		*s1;
-	register const char	*s2;
-	register size_t		len;
+strlcpy(char *s1, const char *s2, size_t len)
 {
 	const char		 *os2	= s2;
 

--- a/sdk/tools/mkisofs/schilytools/libschily/uid.c
+++ b/sdk/tools/mkisofs/schilytools/libschily/uid.c
@@ -24,7 +24,7 @@
 #ifndef	HAVE_GETUID
 
 EXPORT uid_t
-getuid()
+getuid(void)
 {
 	return (0);
 }
@@ -34,7 +34,7 @@ getuid()
 #ifndef	HAVE_GETEUID
 
 EXPORT uid_t
-geteuid()
+geteuid(void)
 {
 	return (0);
 }
@@ -44,8 +44,7 @@ geteuid()
 #ifndef	HAVE_SETUID
 
 EXPORT int
-setuid(uid)
-	uid_t	uid;
+setuid(uid_t uid)
 {
 	return (0);
 }
@@ -55,8 +54,7 @@ setuid(uid)
 #ifndef	HAVE_SETEUID
 
 EXPORT int
-seteuid(uid)
-	uid_t	uid;
+seteuid(uid_t uid)
 {
 	return (0);
 }

--- a/sdk/tools/mkisofs/schilytools/libschily/zerobytes.c
+++ b/sdk/tools/mkisofs/schilytools/libschily/zerobytes.c
@@ -27,9 +27,7 @@
  * zero(to, cnt)
  */
 EXPORT char *
-zerobytes(tov, cnt)
-	void	*tov;
-	ssize_t	cnt;
+zerobytes(void *tov, ssize_t cnt)
 {
 	register char	*to = (char *)tov;
 	register ssize_t n;

--- a/sdk/tools/mkisofs/schilytools/libsiconv/sic_nls.c
+++ b/sdk/tools/mkisofs/schilytools/libsiconv/sic_nls.c
@@ -95,8 +95,7 @@ LOCAL siconvt_t	*glist = (siconvt_t *) NULL;
  * Insert a table into the global list and allow to reuse it
  */
 LOCAL siconvt_t *
-insert_sic(sip)
-	siconvt_t	*sip;
+insert_sic(siconvt_t *sip)
 {
 	siconvt_t	**sp = &glist;
 
@@ -120,8 +119,7 @@ insert_sic(sip)
  * Remove a table from the global list
  */
 LOCAL int
-remove_sic(sip)
-	siconvt_t	*sip;
+remove_sic(siconvt_t *sip)
 {
 	siconvt_t	**sp = &glist;
 
@@ -157,8 +155,7 @@ remove_sic(sip)
  * Open a new translation
  */
 EXPORT siconvt_t *
-sic_open(charset)
-	char	*charset;
+sic_open(char *charset)
 {
 	siconvt_t	*sip = glist;
 
@@ -183,7 +180,7 @@ sic_open(charset)
  * Open a new translation
  */
 EXPORT const char *
-sic_base()
+sic_base(void)
 {
 	if (ins_base == NULL) {
 		ins_base = searchfileinpath("lib/siconv/iso8859-1", R_OK,
@@ -201,8 +198,7 @@ sic_base()
  * Close a translation
  */
 EXPORT int
-sic_close(sip)
-	siconvt_t	*sip;
+sic_close(siconvt_t *sip)
 {
 	if (remove_sic(sip) < 0)
 		return (-1);
@@ -230,8 +226,7 @@ sic_close(sip)
  * List all possible translation files in the install directory.
  */
 EXPORT int
-sic_list(f)
-	FILE	*f;
+sic_list(FILE *f)
 {
 	char		path[1024];
 	DIR		*d;
@@ -265,8 +260,7 @@ sic_list(f)
  * Free a reverse (uncode -> char) translation table
  */
 LOCAL void
-freetbl(uni2cs)
-	UInt8_t	**uni2cs;
+freetbl(UInt8_t **uni2cs)
 {
 	int	i;
 
@@ -283,8 +277,7 @@ freetbl(uni2cs)
  * in the install directory.
  */
 LOCAL FILE *
-pfopen(name)
-	char	*name;
+pfopen(char *name)
 {
 	char	path[1024];
 	char	*p;
@@ -309,8 +302,7 @@ pfopen(name)
  * Create a new translation either from a file or from iconv_open()
  */
 LOCAL siconvt_t *
-create_sic(name)
-	char	*name;
+create_sic(char *name)
 {
 	UInt16_t	*cs2uni  = NULL;
 	UInt8_t		**uni2cs = NULL;
@@ -466,8 +458,7 @@ do_reverse:
  * Create a new translation from iconv_open()
  */
 LOCAL siconvt_t *
-create_iconv_sic(name)
-	char	*name;
+create_iconv_sic(char *name)
 {
 	siconvt_t	*sip;
 	iconv_t		to;
@@ -512,8 +503,7 @@ create_iconv_sic(name)
  * if we like to get the same translation again.
  */
 LOCAL siconvt_t *
-dup_iconv_sic(sip)
-	siconvt_t	*sip;
+dup_iconv_sic(siconvt_t sip)
 {
 	siconvt_t	*sp;
 	iconv_t		to;

--- a/sdk/tools/mkisofs/schilytools/mkisofs/boot.c
+++ b/sdk/tools/mkisofs/schilytools/mkisofs/boot.c
@@ -60,7 +60,7 @@ LOCAL	int	genboot_write		__PR((FILE *outfile));
  * dkl_ncyl and dkl_pcyl later.
  */
 LOCAL void
-init_sparc_label()
+init_sparc_label(void)
 {
 	i_to_4_byte(cd_label.dkl_vtoc.v_version, V_VERSION);
 	i_to_2_byte(cd_label.dkl_vtoc.v_nparts, NDKMAP);
@@ -80,7 +80,7 @@ init_sparc_label()
 }
 
 LOCAL void
-init_sunx86_label()
+init_sunx86_label(void)
 {
 	li_to_4_byte(sx86_label.dkl_vtoc.v_sanity, VTOC_SANE);
 	li_to_4_byte(sx86_label.dkl_vtoc.v_version, V_VERSION);
@@ -109,8 +109,7 @@ init_sunx86_label()
  * For command line parser: set ASCII label.
  */
 EXPORT int
-sparc_boot_label(label)
-	char	*label;
+sparc_boot_label(char *label)
 {
 	strncpy(cd_label.dkl_ascilabel, label, 127);
 	cd_label.dkl_ascilabel[127] = '\0';
@@ -118,8 +117,7 @@ sparc_boot_label(label)
 }
 
 EXPORT int
-sunx86_boot_label(label)
-	char	*label;
+sunx86_boot_label(char *label)
 {
 	strncpy(sx86_label.dkl_vtoc.v_asciilabel, label, 127);
 	sx86_label.dkl_vtoc.v_asciilabel[127] = '\0';
@@ -130,8 +128,7 @@ sunx86_boot_label(label)
  * Parse the command line argument for boot images.
  */
 EXPORT int
-scan_sparc_boot(files)
-	char	*files;
+scan_sparc_boot(char *files)
 {
 	char		*p;
 	int		i = 1;
@@ -179,8 +176,7 @@ extern	int		use_sunx86boot;
 }
 
 EXPORT int
-scan_sunx86_boot(files)
-	char	*files;
+scan_sunx86_boot(char *files)
 {
 	char		*p;
 	int		i = 0;
@@ -240,7 +236,7 @@ extern	int		use_sunx86boot;
  * Finish the Sun disk label and compute the size of the additional data.
  */
 EXPORT int
-make_sun_label()
+make_sun_label(void)
 {
 	int	last;
 	int	cyl = 0;
@@ -284,7 +280,7 @@ make_sun_label()
  * ALL	Part 2 tag 0 flag  0 start    0 size 1318400
  */
 EXPORT int
-make_sunx86_label()
+make_sunx86_label(void)
 {
 	int	last;
 	int	cyl = 0;
@@ -344,8 +340,7 @@ make_sunx86_label()
  * Duplicate a partition of the Sun disk label until all partitions are filled up.
  */
 LOCAL void
-dup_sun_label(part)
-	int	part;
+dup_sun_label(int part)
 {
 	int	cyl;
 	int	nblk;
@@ -370,8 +365,7 @@ dup_sun_label(part)
  * Write out Sun boot partitions.
  */
 LOCAL int
-sunboot_write(outfile)
-	FILE	*outfile;
+sunboot_write(FILE *outfile)
 {
 	char	buffer[SECTOR_SIZE];
 	int	i;
@@ -435,8 +429,7 @@ sunboot_write(outfile)
  * sector of a disk.
  */
 LOCAL int
-sunlabel_size(starting_extent)
-	UInt32_t	starting_extent;
+sunlabel_size(UInt32_t starting_extent)
 {
 	if (last_extent != session_start)
 		comerrno(EX_BAD, _("Cannot create sparc boot on offset != 0.\n"));
@@ -451,8 +444,7 @@ sunlabel_size(starting_extent)
  * Sun disk label on the first 512 bytes of the generic boot code.
  */
 LOCAL int
-sunlabel_write(outfile)
-	FILE	*outfile;
+sunlabel_write(FILE *outfile)
 {
 		char	buffer[SECTOR_SIZE];
 	register char	*p;
@@ -512,8 +504,7 @@ sunlabel_write(outfile)
  * Do size management for the generic boot code on sectors 0..16.
  */
 LOCAL int
-genboot_size(starting_extent)
-	UInt32_t	starting_extent;
+genboot_size(UInt32_t starting_extent)
 {
 	if (last_extent > (session_start + 1))
 		comerrno(EX_BAD, _("Cannot create generic boot on offset != 0.\n"));
@@ -526,8 +517,7 @@ genboot_size(starting_extent)
  * If there is a Sun disk label, start writing at sector 1.
  */
 LOCAL int
-genboot_write(outfile)
-	FILE	*outfile;
+genboot_write(FILE *outfile)
 {
 	char	buffer[SECTOR_SIZE];
 	int	i;

--- a/sdk/tools/mkisofs/schilytools/mkisofs/eltorito.c
+++ b/sdk/tools/mkisofs/schilytools/mkisofs/eltorito.c
@@ -64,8 +64,7 @@ LOCAL	char				*bootcat_path; /* name of bootcatalog */
  * Make sure any existing boot catalog is excluded
  */
 EXPORT void
-init_boot_catalog(path)
-	const char	*path;
+init_boot_catalog(const char *path)
 {
 #ifdef	SORTING
 	struct eltorito_boot_entry_info	*cbe;
@@ -250,8 +249,7 @@ insert_boot_cat()
 }
 
 LOCAL void
-get_torito_desc(boot_desc)
-	struct eltorito_boot_descriptor	*boot_desc;
+get_torito_desc(struct eltorito_boot_descriptor *boot_desc)
 {
 	int			checksum;
 	unsigned char		*checksum_ptr;
@@ -387,9 +385,7 @@ get_torito_desc(boot_desc)
 } /* get_torito_desc(... */
 
 LOCAL void
-fill_boot_shdr(boot_shdr_entry, arch)
-	struct eltorito_sectionheader_entry	*boot_shdr_entry;
-	int					arch;
+fill_boot_shdr(struct eltorito_sectionheader_entry *boot_shdr_entry, int arch)
 {
 	memset(boot_shdr_entry, 0, sizeof (struct eltorito_sectionheader_entry));
 	boot_shdr_entry->header_id[0] = EL_TORITO_SHDR_ID_SHDR;
@@ -397,9 +393,7 @@ fill_boot_shdr(boot_shdr_entry, arch)
 }
 
 LOCAL void
-fill_boot_desc(boot_desc_entry, boot_entry)
-	struct eltorito_defaultboot_entry *boot_desc_entry;
-	struct eltorito_boot_entry_info *boot_entry;
+fill_boot_desc(struct eltorito_defaultboot_entry *boot_desc_entry, struct eltorito_boot_entry_info *boot_entry)
 {
 	struct directory_entry	*de;	/* Boot file */
 	int			bootmbr;
@@ -626,7 +620,7 @@ fill_boot_desc(boot_desc_entry, boot_entry)
 } /* fill_boot_desc(... */
 
 EXPORT void
-get_boot_entry()
+get_boot_entry(void)
 {
 	if (current_boot_entry)
 		return;
@@ -647,7 +641,7 @@ get_boot_entry()
 }
 
 EXPORT int
-new_boot_entry()
+new_boot_entry(void)
 {
 	current_boot_entry = NULL;
 	return (1);
@@ -657,9 +651,7 @@ new_boot_entry()
  * Exit with a boot no entry message.
  */
 EXPORT void
-ex_boot_enoent(msg, pname)
-	char	*msg;
-	char	*pname;
+ex_boot_enoent(char *msg, char *pname)
 {
 	comerrno(EX_BAD, _("Uh oh, I cant find the boot %s '%s' inside the target tree.\n"), msg, pname);
 	/* NOTREACHED */
@@ -669,8 +661,7 @@ ex_boot_enoent(msg, pname)
  * Function to write the EVD for the disc.
  */
 LOCAL int
-tvd_write(outfile)
-	FILE	*outfile;
+tvd_write(FILE *outfile)
 {
 	/* check the boot image is not NULL */
 	if (!boot_image) {

--- a/sdk/tools/mkisofs/schilytools/mkisofs/hash.c
+++ b/sdk/tools/mkisofs/schilytools/mkisofs/hash.c
@@ -103,7 +103,7 @@ LOCAL	unsigned char	*DIGEST_File	__PR((char *name, size_t size));
 
 #ifdef	HASH_DEBUG
 EXPORT void
-debug_hash()
+debug_hash(void)
 {
 	struct file_hash **p = hash_table;
 	int	i;
@@ -131,14 +131,13 @@ debug_hash()
 				minlen = k;
 		}
 	}
-	error("Unbenutzt: %d von %d Einträgen maxlen %d minlen %d total %d optmittel %d\n",
+	error("Unbenutzt: %d von %d Eintrï¿½gen maxlen %d minlen %d total %d optmittel %d\n",
 		j, NR_HASH, maxlen, minlen, tot, tot/NR_HASH);
 }
 #endif
 
 EXPORT void
-add_hash(spnt)
-	struct directory_entry	*spnt;
+add_hash(struct directory_entry *spnt)
 {
 	struct file_hash *s_hash;
 	unsigned int    hash_number = 0;
@@ -189,8 +188,7 @@ add_hash(spnt)
 }
 
 EXPORT struct file_hash *
-find_hash(spnt)
-	struct directory_entry	*spnt;
+find_hash(struct directory_entry *spnt)
 {
 	unsigned int    hash_number;
 	struct file_hash *s_hash;
@@ -237,7 +235,7 @@ find_hash(spnt)
  * file hash table.
  */
 EXPORT void
-flush_hash()
+flush_hash(void)
 {
 	struct file_hash	*fh;
 	struct file_hash	*fh1;
@@ -256,9 +254,7 @@ flush_hash()
 
 #ifdef	DUPLICATES_ONCE
 LOCAL struct directory_entry *
-compare_files(spnt1, spnt2)
-	struct directory_entry	*spnt1;
-	struct directory_entry	*spnt2;
+compare_files(struct directory_entry *spnt1, struct directory_entry *spnt2)
 {
 	if (spnt1->size != spnt2->size)
 		return (NULL);
@@ -303,9 +299,7 @@ compare_files(spnt1, spnt2)
 }
 
 LOCAL unsigned char *
-DIGEST_File(name, size)
-	char		*name;
-	size_t		size;
+DIGEST_File(char *name, size_t size)
 {
 	DIGEST_CTX	digest_ctx;
 	FILE		*infile;
@@ -338,15 +332,8 @@ DIGEST_File(name, size)
 
 static struct file_hash *directory_hash_table[NR_HASH];
 
-#ifdef	PROTOTYPES
 EXPORT void
 add_directory_hash(dev_t dev, ino_t inode)
-#else
-EXPORT void
-add_directory_hash(dev, inode)
-	dev_t	dev;
-	ino_t	inode;
-#endif
 {
 	struct file_hash *s_hash;
 	unsigned int    hash_number;
@@ -367,15 +354,8 @@ add_directory_hash(dev, inode)
 	directory_hash_table[hash_number] = s_hash;
 }
 
-#ifdef	PROTOTYPES
 EXPORT struct file_hash *
 find_directory_hash(dev_t dev, ino_t inode)
-#else
-EXPORT struct file_hash *
-find_directory_hash(dev, inode)
-	dev_t	dev;
-	ino_t	inode;
-#endif
 {
 	unsigned int    hash_number;
 	struct file_hash *spnt;
@@ -410,8 +390,7 @@ static struct name_hash *name_hash_table[NR_NAME_HASH] = {0, };
  * Find the hash bucket for this name.
  */
 LOCAL unsigned int
-name_hash(name)
-	const char	*name;
+name_hash(const char *name)
 {
 	unsigned int	hash = 0;
 	const char	*p;
@@ -433,8 +412,7 @@ name_hash(name)
 }
 
 EXPORT void
-add_file_hash(de)
-	struct directory_entry	*de;
+add_file_hash(struct directory_entry *de)
 {
 	struct name_hash	*new;
 	int			hash;
@@ -458,8 +436,7 @@ add_file_hash(de)
 }
 
 EXPORT struct directory_entry *
-find_file_hash(name)
-	register char			*name;
+find_file_hash(char *name)
 {
 	register char			*p1;
 	register char			*p2;
@@ -534,8 +511,7 @@ find_file_hash(name)
 		isoname_endsok(p))
 
 LOCAL BOOL
-isoname_endsok(name)
-	char	*name;
+isoname_endsok(char *name)
 {
 	int	i;
 	char	*p;
@@ -556,8 +532,7 @@ isoname_endsok(name)
 }
 
 EXPORT int
-delete_file_hash(de)
-	struct directory_entry	*de;
+delete_file_hash(struct directory_entry *de)
 {
 	struct name_hash	*nh;
 	struct name_hash	*prev;
@@ -581,7 +556,7 @@ delete_file_hash(de)
 }
 
 EXPORT void
-flush_file_hash()
+flush_file_hash(void)
 {
 	struct name_hash	*nh;
 	struct name_hash	*nh1;

--- a/sdk/tools/mkisofs/schilytools/mkisofs/inode.c
+++ b/sdk/tools/mkisofs/schilytools/mkisofs/inode.c
@@ -52,8 +52,7 @@ LOCAL	int	update_dir_nlink	__PR((struct directory *dpnt));
  * Inode/hard link related stuff for non-directory type files.
  */
 EXPORT void
-do_inode(dpnt)
-	struct directory	*dpnt;
+do_inode(struct directory *dpnt)
 {
 	null_ino_high = null_inodes;
 
@@ -82,8 +81,7 @@ do_inode(dpnt)
  * Set the link count for directories to 2 + number of sub-directories.
  */
 EXPORT void
-do_dir_nlink(dpnt)
-	struct directory	*dpnt;
+do_dir_nlink(struct directory *dpnt)
 {
 	int	rootlinks;
 
@@ -110,8 +108,7 @@ do_dir_nlink(dpnt)
  * Assign inode numbers to files of zero size and to symlinks.
  */
 LOCAL void
-assign_inodes(dpnt)
-	struct directory	*dpnt;
+assign_inodes(struct directory *dpnt)
 {
 	struct directory_entry	*s_entry;
 	struct file_hash	*s_hash;
@@ -195,8 +192,7 @@ assign_inodes(dpnt)
  * Compute the link count for non-directory type files.
  */
 LOCAL void
-compute_linkcount(dpnt)
-	struct directory	*dpnt;
+compute_linkcount(struct directory *dpnt)
 {
 	struct directory_entry	*s_entry;
 	struct file_hash	*s_hash;
@@ -281,8 +277,7 @@ compute_linkcount(dpnt)
  * computed with compute_linkcount().
  */
 LOCAL void
-assign_linkcount(dpnt)
-	struct directory	*dpnt;
+assign_linkcount(struct directory *dpnt)
 {
 	struct directory_entry	*s_entry;
 	struct file_hash	*s_hash;
@@ -326,9 +321,7 @@ assign_linkcount(dpnt)
  * Rewrite the content of the RR inode field in the PX record.
  */
 LOCAL void
-update_inode(s_entry, value)
-	struct directory_entry	*s_entry;
-	int			value;
+update_inode(struct directory_entry *s_entry, int value)
 {
 	unsigned char	*pnt;
 	int		len;
@@ -366,9 +359,7 @@ update_inode(s_entry, value)
  * Rewrite the content of the RR nlink field in the PX record.
  */
 LOCAL void
-update_nlink(s_entry, value)
-	struct directory_entry	*s_entry;
-	int			value;
+update_nlink(struct directory_entry *s_entry, int value)
 {
 	unsigned char	*pnt;
 	int		len;
@@ -402,8 +393,7 @@ update_nlink(s_entry, value)
  * This is done here for all diresctories except for "/..".
  */
 LOCAL int
-update_dir_nlink(dpnt)
-	struct directory *dpnt;
+update_dir_nlink(struct directory *dpnt)
 {
 	struct directory *xpnt;
 	struct directory_entry *s_entry;

--- a/sdk/tools/mkisofs/schilytools/mkisofs/isonum.c
+++ b/sdk/tools/mkisofs/schilytools/mkisofs/isonum.c
@@ -43,9 +43,7 @@ EXPORT	UInt32_t get_733	__PR((void *vp));
  * Set 16 bit unsigned int, store Least significant byte first
  */
 EXPORT void
-set_721(vp, i)
-	void		*vp;
-	UInt32_t	i;
+set_721(void *vp, UInt32_t i)
 {
 	Uchar	*p = vp;
 
@@ -58,9 +56,7 @@ set_721(vp, i)
  * Set 16 bit unsigned int, store Most significant byte first
  */
 EXPORT void
-set_722(vp, i)
-	void		*vp;
-	UInt32_t	i;
+set_722(void *vp, UInt32_t i)
 {
 	Uchar	*p = vp;
 
@@ -73,9 +69,7 @@ set_722(vp, i)
  * Set 16 bit unsigned int, store Both Byte orders
  */
 EXPORT void
-set_723(vp, i)
-	void		*vp;
-	UInt32_t	i;
+set_723(void *vp, UInt32_t i)
 {
 	Uchar	*p = vp;
 
@@ -88,9 +82,7 @@ set_723(vp, i)
  * Set 32 bit unsigned int, store Least significant byte first
  */
 EXPORT void
-set_731(vp, i)
-	void		*vp;
-	UInt32_t	i;
+set_731(void *vp, UInt32_t i)
 {
 	Uchar	*p = vp;
 
@@ -105,9 +97,7 @@ set_731(vp, i)
  * Set 32 bit unsigned int, store Most significant byte first
  */
 EXPORT void
-set_732(vp, i)
-	void		*vp;
-	UInt32_t	i;
+set_732(void *vp, UInt32_t i)
 {
 	Uchar	*p = vp;
 
@@ -122,9 +112,7 @@ set_732(vp, i)
  * Set 32 bit unsigned int, store Both Byte orders
  */
 EXPORT void
-set_733(vp, i)
-	void		*vp;
-	UInt32_t	i;
+set_733(void *vp, UInt32_t i)
 {
 	Uchar	*p = vp;
 
@@ -139,8 +127,7 @@ set_733(vp, i)
  * Get 8 bit unsigned int
  */
 EXPORT UInt32_t
-get_711(vp)
-	void	*vp;
+get_711(void *vp)
 {
 	Uchar	*p = vp;
 
@@ -152,8 +139,7 @@ get_711(vp)
  * Get 16 bit unsigned int, stored with Least significant byte first
  */
 EXPORT UInt32_t
-get_721(vp)
-	void	*vp;
+get_721(void *vp)
 {
 	Uchar	*p = vp;
 
@@ -166,8 +152,7 @@ get_721(vp)
  * Get 16 bit unsigned int, stored with Both Byte orders
  */
 EXPORT UInt32_t
-get_723(vp)
-	void	*vp;
+get_723(void *vp)
 {
 	Uchar	*p = vp;
 #if 0
@@ -184,8 +169,7 @@ get_723(vp)
  * Get 32 bit unsigned int, stored with Least significant byte first
  */
 EXPORT UInt32_t
-get_731(vp)
-	void	*vp;
+get_731(void *vp)
 {
 	Uchar	*p = vp;
 
@@ -200,8 +184,7 @@ get_731(vp)
  * Get 32 bit unsigned int, stored with Most significant byte first
  */
 EXPORT UInt32_t
-get_732(vp)
-	void	*vp;
+get_732(void *vp)
 {
 	Uchar	*p = vp;
 
@@ -216,8 +199,7 @@ get_732(vp)
  * Get 32 bit unsigned int, stored with Both Byte orders
  */
 EXPORT UInt32_t
-get_733(vp)
-	void	*vp;
+get_733(void *vp)
 {
 	Uchar	*p = vp;
 

--- a/sdk/tools/mkisofs/schilytools/mkisofs/joliet.c
+++ b/sdk/tools/mkisofs/schilytools/mkisofs/joliet.c
@@ -145,13 +145,7 @@ LOCAL	int	jpathtab_size		__PR((UInt32_t starting_extent));
  *
  */
 EXPORT void
-conv_charset(to, tosizep, from, fromsizep, inls, onls)
-	unsigned char	*to;
-	size_t		*tosizep;
-	unsigned char	*from;
-	size_t		*fromsizep;
-	siconvt_t	*inls;
-	siconvt_t	*onls;
+conv_charset(unsigned char *to, size_t *tosizep, unsigned char*from, size_t *fromsizep, siconvt_t *inls, siconvt_t *onls)
 {
 	UInt16_t	unichar;
 	size_t		fromsize = *fromsizep;
@@ -244,11 +238,7 @@ EXPORT void
 #else
 LOCAL void
 #endif
-convert_to_unicode(buffer, size, source, inls)
-	unsigned char	*buffer;
-	int		size;
-	char		*source;
-	siconvt_t	*inls;
+convert_to_unicode(unsigned char *buffer, int size, char *source, siconvt_t *inls)
 {
 	unsigned char	*tmpbuf;
 	int		i;
@@ -372,10 +362,7 @@ EXPORT int
 #else
 LOCAL int
 #endif
-joliet_strlen(string, maxlen, inls)
-	const char	*string;
-	size_t		maxlen;
-	siconvt_t	*inls;
+joliet_strlen(const char *string, size_t maxlen, siconvt_t *inls)
 {
 	int	rtn = 0;
 
@@ -433,8 +420,7 @@ joliet_strlen(string, maxlen, inls)
  *			appropriate fields.
  */
 LOCAL void
-get_joliet_vol_desc(jvol_desc)
-	struct iso_primary_descriptor	*jvol_desc;
+get_joliet_vol_desc(struct iso_primary_descriptor *jvol_desc)
 {
 	jvol_desc->type[0] = ISO_VD_SUPPLEMENTARY;
 	jvol_desc->version[0] = 1;
@@ -489,8 +475,7 @@ get_joliet_vol_desc(jvol_desc)
  * We ignore all files that are neither in the Joliet nor in the UDF tree
  */
 LOCAL void
-assign_joliet_directory_addresses(node)
-	struct directory	*node;
+assign_joliet_directory_addresses(struct directory *node)
 {
 	int		dir_size;
 	struct directory *dpnt;
@@ -522,8 +507,7 @@ assign_joliet_directory_addresses(node)
 }
 
 LOCAL void
-build_jpathlist(node)
-	struct directory	*node;
+build_jpathlist(struct directory *node)
 {
 	struct directory	*dpnt;
 
@@ -540,9 +524,7 @@ build_jpathlist(node)
 } /* build_jpathlist(... */
 
 LOCAL int
-joliet_compare_paths(r, l)
-	void const	*r;
-	void const	*l;
+joliet_compare_paths(void const *r, void const *l)
 {
 	struct directory const *ll = *(struct directory * const *) l;
 	struct directory const *rr = *(struct directory * const *) r;
@@ -626,7 +608,7 @@ joliet_compare_paths(r, l)
 } /* compare_paths(... */
 
 LOCAL int
-generate_joliet_path_tables()
+generate_joliet_path_tables(void)
 {
 	struct directory_entry *de;
 	struct directory *dpnt;
@@ -654,13 +636,8 @@ generate_joliet_path_tables()
 
 	do {
 		fix = 0;
-#ifdef	PROTOTYPES
 		qsort(&jpathlist[1], next_jpath_index - 1, sizeof (struct directory *),
 			(int (*) (const void *, const void *)) joliet_compare_paths);
-#else
-		qsort(&jpathlist[1], next_jpath_index - 1, sizeof (struct directory *),
-			joliet_compare_paths);
-#endif
 
 		for (j = 1; j < next_jpath_index; j++) {
 			if (jpathlist[j]->jpath_index != j) {
@@ -792,9 +769,7 @@ generate_joliet_path_tables()
 } /* generate_path_tables(... */
 
 LOCAL void
-generate_one_joliet_directory(dpnt, outfile)
-	struct directory	*dpnt;
-	FILE			*outfile;
+generate_one_joliet_directory(struct directory *dpnt, FILE *outfile)
 {
 	unsigned int		dir_index;
 	char			*directory_buffer;
@@ -954,8 +929,7 @@ generate_one_joliet_directory(dpnt, outfile)
 } /* generate_one_joliet_directory(... */
 
 LOCAL int
-joliet_sort_n_finish(this_dir)
-	struct directory	*this_dir;
+joliet_sort_n_finish(struct directory *this_dir)
 {
 	struct directory_entry	*s_entry;
 	int			status = 0;
@@ -1077,9 +1051,7 @@ joliet_sort_n_finish(this_dir)
  * regular name of the file, not the 8.3 version.
  */
 LOCAL int
-joliet_compare_dirs(rr, ll)
-	const void	*rr;
-	const void	*ll;
+joliet_compare_dirs(const void *rr, const void *ll)
 {
 	char		*rpnt,
 			*lpnt;
@@ -1241,8 +1213,7 @@ joliet_compare_dirs(rr, ll)
  * Notes:		Returns 0 if OK, returns > 0 if an error occurred.
  */
 LOCAL int
-joliet_sort_directory(sort_dir)
-	struct directory_entry	**sort_dir;
+joliet_sort_directory(struct directory_entry **sort_dir)
 {
 	int			dcount = 0;
 	int			i;
@@ -1314,8 +1285,7 @@ joliet_sort_directory(sort_dir)
 }
 
 EXPORT int
-joliet_sort_tree(node)
-	struct directory	*node;
+joliet_sort_tree(struct directory *node)
 {
 	struct directory	*dpnt;
 	int			ret = 0;
@@ -1338,9 +1308,7 @@ joliet_sort_tree(node)
 }
 
 LOCAL void
-generate_joliet_directories(node, outfile)
-	struct directory	*node;
-	FILE			*outfile;
+generate_joliet_directories(struct directory *node, FILE *outfile)
 {
 	struct directory *dpnt;
 
@@ -1371,8 +1339,7 @@ generate_joliet_directories(node, outfile)
  * Function to write the EVD for the disc.
  */
 LOCAL int
-jpathtab_write(outfile)
-	FILE	*outfile;
+jpathtab_write(FILE *outfile)
 {
 	/* Next we write the path tables */
 	xfwrite(jpath_table_l, jpath_blocks << 11, 1, outfile, 0, FALSE);
@@ -1386,15 +1353,14 @@ jpathtab_write(outfile)
 }
 
 LOCAL int
-jdirtree_size(starting_extent)
-	UInt32_t	starting_extent;
+jdirtree_size(UInt32_t starting_extent)
 {
 	assign_joliet_directory_addresses(root);
 	return (0);
 }
 
 LOCAL int
-jroot_gen()
+jroot_gen(void)
 {
 	jroot_record.length[0] =
 			1 + offsetof(struct iso_directory_record, name[0]);
@@ -1411,8 +1377,7 @@ jroot_gen()
 }
 
 LOCAL int
-jdirtree_write(outfile)
-	FILE	*outfile;
+jdirtree_write(FILE *outfile)
 {
 	generate_joliet_directories(root, outfile);
 	return (0);
@@ -1422,8 +1387,7 @@ jdirtree_write(outfile)
  * Function to write the EVD for the disc.
  */
 LOCAL int
-jvd_write(outfile)
-	FILE	*outfile;
+jvd_write(FILE *outfile)
 {
 	struct iso_primary_descriptor jvol_desc;
 
@@ -1439,8 +1403,7 @@ jvd_write(outfile)
  * Functions to describe padding block at the start of the disc.
  */
 LOCAL int
-jpathtab_size(starting_extent)
-	UInt32_t	starting_extent;
+jpathtab_size(UInt32_t starting_extent)
 {
 	jpath_table[0] = starting_extent;
 	jpath_table[1] = 0;

--- a/sdk/tools/mkisofs/schilytools/mkisofs/match.c
+++ b/sdk/tools/mkisofs/schilytools/mkisofs/match.c
@@ -59,9 +59,7 @@ typedef struct sort_match sort_match;
 static sort_match	*s_mats;
 
 EXPORT int
-add_sort_match(fn, val)
-	char	*fn;
-	int	val;
+add_sort_match(char *fn, int val)
 {
 	sort_match *s_mat;
 
@@ -89,12 +87,7 @@ add_sort_match(fn, val)
 }
 
 EXPORT int
-add_sort_list(file, valp, pac, pav, opt)
-	const char	*file;
-	void		*valp;
-	int		*pac;
-	char	*const	**pav;
-	const char	*opt;
+add_sort_list(const char *file, void *valp, int *pac, char * const **pav, const char *opt)
 {
 	FILE	*fp;
 	char	name[4096];
@@ -141,9 +134,7 @@ extern	int	do_sort;
 }
 
 EXPORT int
-sort_matches(fn, val)
-	char	*fn;
-	int	val;
+sort_matches(char *fn, int val)
 {
 	register sort_match	*s_mat;
 		int		flags = FNM_PATHNAME;
@@ -160,7 +151,7 @@ sort_matches(fn, val)
 }
 
 EXPORT void
-del_sort()
+del_sort(void)
 {
 	register sort_match * s_mat, *s_mat1;
 
@@ -181,9 +172,7 @@ del_sort()
 
 
 EXPORT int
-gen_add_match(fn, n)
-	char	*fn;
-	int	n;
+gen_add_match(char *fn, int n)
 {
 	match	*mat;
 
@@ -211,8 +200,7 @@ gen_add_match(fn, n)
 }
 
 EXPORT int
-add_match(fn)
-	char	*fn;
+add_match(char *fn)
 {
 	int	ret = gen_add_match(fn, EXCLUDE);
 
@@ -222,8 +210,7 @@ add_match(fn)
 }
 
 EXPORT int
-i_add_match(fn)
-	char	*fn;
+i_add_match(char *fn)
 {
 	int	ret = gen_add_match(fn, I_HIDE);
 
@@ -233,8 +220,7 @@ i_add_match(fn)
 }
 
 EXPORT int
-h_add_match(fn)
-	char	*fn;
+h_add_match(char *fn)
 {
 	int	ret = gen_add_match(fn, H_HIDE);
 
@@ -245,8 +231,7 @@ h_add_match(fn)
 
 #ifdef	APPLE_HYB
 EXPORT int
-hfs_add_match(fn)
-	char	*fn;
+hfs_add_match(char *fn)
 {
 	int	ret = gen_add_match(fn, HFS_HIDE);
 
@@ -257,8 +242,7 @@ hfs_add_match(fn)
 #endif	/* APPLE_HYB */
 
 EXPORT int
-j_add_match(fn)
-	char	*fn;
+j_add_match(char *fn)
 {
 	int	ret = gen_add_match(fn, J_HIDE);
 
@@ -268,8 +252,7 @@ j_add_match(fn)
 }
 
 EXPORT int
-u_add_match(fn)
-	char	*fn;
+u_add_match(char *fn)
 {
 	int	ret = gen_add_match(fn, U_HIDE);
 
@@ -279,9 +262,7 @@ u_add_match(fn)
 }
 
 EXPORT void
-gen_add_list(file, n)
-	char	*file;
-	int	n;
+gen_add_list(char *file, int n)
 {
 	FILE	*fp;
 	char	name[4096];
@@ -309,40 +290,35 @@ gen_add_list(file, n)
 }
 
 EXPORT int
-add_list(fn)
-	char	*fn;
+add_list(char *fn)
 {
 	gen_add_list(fn, EXCLUDE);
 	return (1);
 }
 
 EXPORT int
-i_add_list(fn)
-	char	*fn;
+i_add_list(char *fn)
 {
 	gen_add_list(fn, I_HIDE);
 	return (1);
 }
 
 EXPORT int
-h_add_list(fn)
-	char	*fn;
+h_add_list(char *fn)
 {
 	gen_add_list(fn, H_HIDE);
 	return (1);
 }
 
 EXPORT int
-j_add_list(fn)
-	char	*fn;
+j_add_list(char *fn)
 {
 	gen_add_list(fn, J_HIDE);
 	return (1);
 }
 
 EXPORT int
-u_add_list(fn)
-	char	*fn;
+u_add_list(char *fn)
 {
 	gen_add_list(fn, U_HIDE);
 	return (1);
@@ -350,8 +326,7 @@ u_add_list(fn)
 
 #ifdef	APPLE_HYB
 EXPORT int
-hfs_add_list(fn)
-	char	*fn;
+hfs_add_list(char *fn)
 {
 	gen_add_list(fn, HFS_HIDE);
 	return (1);
@@ -359,9 +334,7 @@ hfs_add_list(fn)
 #endif	/* APPLE_HYB */
 
 EXPORT int
-gen_matches(fn, n)
-	char	*fn;
-	int	n;
+gen_matches(char *fn, int n)
 {
 	register match * mat;
 		int		flags = FNM_PATHNAME;
@@ -382,8 +355,7 @@ gen_matches(fn, n)
 }
 
 EXPORT int
-gen_ishidden(n)
-	int	n;
+gen_ishidden(int n)
 {
 	if (n >= MAX_MAT)
 		return (0);
@@ -392,8 +364,7 @@ gen_ishidden(n)
 }
 
 EXPORT void
-gen_del_match(n)
-	int	n;
+gen_del_match(int n)
 {
 	register match	*mat;
 	register match 	*mat1;

--- a/sdk/tools/mkisofs/schilytools/mkisofs/mkisofs.c
+++ b/sdk/tools/mkisofs/schilytools/mkisofs/mkisofs.c
@@ -405,8 +405,7 @@ LOCAL	char	*parse_date	__PR((char *arg, struct tm *tp));
 LOCAL	int	get_ldate	__PR((char *opt_arg, void *valp));
 
 LOCAL int
-get_boot_image(opt_arg)
-	char	*opt_arg;
+get_boot_image(char *opt_arg)
 {
 	do_sort++;		/* We sort bootcat/botimage */
 	use_eltorito++;
@@ -422,8 +421,7 @@ get_boot_image(opt_arg)
 }
 
 LOCAL int
-get_hd_boot(opt_arg)
-	char	*opt_arg;
+get_hd_boot(char *opt_arg)
 {
 	use_eltorito++;
 	hard_disk_boot++;
@@ -433,8 +431,7 @@ get_hd_boot(opt_arg)
 }
 
 LOCAL int
-get_ne_boot(opt_arg)
-	char	*opt_arg;
+get_ne_boot(char *opt_arg)
 {
 	use_eltorito++;
 	no_emul_boot++;
@@ -444,8 +441,7 @@ get_ne_boot(opt_arg)
 }
 
 LOCAL int
-get_no_boot(opt_arg)
-	char	*opt_arg;
+get_no_boot(char *opt_arg)
 {
 	use_eltorito++;
 	not_bootable++;
@@ -455,8 +451,7 @@ get_no_boot(opt_arg)
 }
 
 LOCAL int
-get_boot_addr(opt_arg)
-	char	*opt_arg;
+get_boot_addr(char *opt_arg)
 {
 	long	val;
 	char	*ptr;
@@ -473,8 +468,7 @@ get_boot_addr(opt_arg)
 }
 
 LOCAL int
-get_boot_size(opt_arg)
-	char	*opt_arg;
+get_boot_size(char *opt_arg)
 {
 	long	val;
 	char	*ptr;
@@ -492,8 +486,7 @@ get_boot_size(opt_arg)
 }
 
 LOCAL int
-get_boot_platid(opt_arg)
-	char	*opt_arg;
+get_boot_platid(char *opt_arg)
 {
 	long	val;
 	char	*ptr;
@@ -531,8 +524,7 @@ get_boot_platid(opt_arg)
 }
 
 LOCAL int
-get_boot_table(opt_arg)
-	char	*opt_arg;
+get_boot_table(char *opt_arg)
 {
 	use_eltorito++;
 	boot_info_table++;
@@ -544,8 +536,7 @@ get_boot_table(opt_arg)
 #ifdef	APPLE_HYB
 #ifdef PREP_BOOT
 LOCAL int
-get_prep_boot(opt_arg)
-	char	*opt_arg;
+get_prep_boot(char *opt_arg)
 {
 	use_prep_boot++;
 	if (use_prep_boot > 4 - use_chrp_boot) {
@@ -562,8 +553,7 @@ get_prep_boot(opt_arg)
 }
 
 LOCAL int
-get_chrp_boot(opt_arg)
-	char	*opt_arg;
+get_chrp_boot(char *opt_arg)
 {
 	if (use_chrp_boot)
 		return (1);		/* silently allow duplicates */
@@ -578,8 +568,7 @@ get_chrp_boot(opt_arg)
 
 
 LOCAL int
-get_bsize(opt_arg)
-	char	*opt_arg;
+get_bsize(char *opt_arg)
 {
 	afe_size = atoi(opt_arg);
 	hfs_select |= DO_FEU;
@@ -588,35 +577,35 @@ get_bsize(opt_arg)
 }
 
 LOCAL int
-hfs_cap()
+hfs_cap(void)
 {
 	hfs_select |= DO_CAP;
 	return (1);
 }
 
 LOCAL int
-hfs_neta()
+hfs_neta(void)
 {
 	hfs_select |= DO_NETA;
 	return (1);
 }
 
 LOCAL int
-hfs_dbl()
+hfs_dbl(void)
 {
 	hfs_select |= DO_DBL;
 	return (1);
 }
 
 LOCAL int
-hfs_esh()
+hfs_esh(void)
 {
 	hfs_select |= DO_ESH;
 	return (1);
 }
 
 LOCAL int
-hfs_fe()
+hfs_fe(void)
 {
 	hfs_select |= DO_FEU;
 	hfs_select |= DO_FEL;
@@ -624,28 +613,28 @@ hfs_fe()
 }
 
 LOCAL int
-hfs_sgi()
+hfs_sgi(void)
 {
 	hfs_select |= DO_SGI;
 	return (1);
 }
 
 LOCAL int
-hfs_mbin()
+hfs_mbin(void)
 {
 	hfs_select |= DO_MBIN;
 	return (1);
 }
 
 LOCAL int
-hfs_sgl()
+hfs_sgl(void)
 {
 	hfs_select |= DO_SGL;
 	return (1);
 }
 
 LOCAL int
-hfs_dave()
+hfs_dave(void)
 {
 	hfs_select |= DO_DAVE;
 	return (1);
@@ -653,21 +642,21 @@ hfs_dave()
 
 
 LOCAL int
-hfs_sfm()
+hfs_sfm(void)
 {
 	hfs_select |= DO_SFM;
 	return (1);
 }
 
 LOCAL int
-hfs_xdbl()
+hfs_xdbl(void)
 {
 	hfs_select |= DO_XDBL;
 	return (1);
 }
 
 LOCAL int
-hfs_xhfs()
+hfs_xhfs(void)
 {
 #ifdef	IS_MACOS_X
 	hfs_select |= DO_XHFS;
@@ -679,7 +668,7 @@ hfs_xhfs()
 }
 
 LOCAL int
-hfs_nohfs()
+hfs_nohfs(void)
 {
 	no_apple_hyb = 1;
 	return (1);
@@ -688,17 +677,13 @@ hfs_nohfs()
 #endif	/* APPLE_HYB */
 
 LOCAL void
-ldate_error(arg)
-	char	*arg;
+ldate_error(char *arg)
 {
 	comerrno(EX_BAD, _("Ilegal date specification '%s'.\n"), arg);
 }
 
 LOCAL char *
-strntoi(p, n, ip)
-	char	*p;
-	int	n;
-	int	*ip;
+strntoi(char *p, int n, int *ip)
 {
 	int	i = 0;
 	int	digits = 0;
@@ -725,9 +710,7 @@ strntoi(p, n, ip)
 static int dmsize[12] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
 
 LOCAL int
-mosize(y, m)
-	int	y;
-	int	m;
+mosize(int y, int m)
 {
 
 	if (m == 1 && dysize(y) == 366)
@@ -736,9 +719,7 @@ mosize(y, m)
 }
 
 LOCAL char *
-parse_date(arg, tp)
-	char	*arg;
-	struct tm *tp;
+parse_date(char *arg, struct tm *tp)
 {
 	char	*oarg = arg;
 	char	*p;
@@ -829,9 +810,7 @@ parse_date(arg, tp)
  * YYYY[MM[DD[HH[MM[SS]]]]][.hh][+-GHGM]
  */
 LOCAL int
-get_ldate(opt_arg, valp)
-	char	*opt_arg;
-	void	*valp;
+get_ldate(char *opt_arg, void *valp)
 {
 	time_t	t;
 	int	usec = 0;
@@ -895,11 +874,7 @@ get_ldate(opt_arg, valp)
 #ifdef	USE_FIND
 /* ARGSUSED */
 LOCAL int
-getfind(arg, valp, pac, pav)
-	char	*arg;
-	long	*valp;	/* Not used until we introduce a ptr to opt struct */
-	int	*pac;
-	char	*const	**pav;
+getfind(char *arg, long *valp, int *pac, char * const **pav)
 {
 	dofind = TRUE;
 	find_ac = *pac;
@@ -911,12 +886,7 @@ getfind(arg, valp, pac, pav)
 
 /* ARGSUSED */
 LOCAL int
-getH(arg, valp, pac, pav, opt)	/* Follow symlinks encountered on cmdline */
-	const char	*arg;
-	void		*valp;
-	int		*pac;
-	char	*const	**pav;
-	const char	*opt;
+getH(const char *arg, void *valp, int *pac, char * const **pav, const char *opt)	/* Follow symlinks encountered on cmdline */
 {
 /*error("getH\n");*/
 	if (opt[0] == '-' && opt[1] == 'H' && opt[2] == '\0') {
@@ -941,12 +911,7 @@ getH(arg, valp, pac, pav, opt)	/* Follow symlinks encountered on cmdline */
 
 /* ARGSUSED */
 LOCAL int
-getL(arg, valp, pac, pav, opt)	/* Follow all symlinks */
-	const char	*arg;
-	void		*valp;
-	int		*pac;
-	char	*const	**pav;
-	const char	*opt;
+getL(const char *arg, void *valp, int *pac, char * const **pav, const char *opt)	/* Follow all symlinks */
 {
 /*error("getL\n");*/
 	if (opt[0] == '-' && opt[1] == 'L' && opt[2] == '\0') {
@@ -970,12 +935,7 @@ getL(arg, valp, pac, pav, opt)	/* Follow all symlinks */
 
 /* ARGSUSED */
 LOCAL int
-getP(arg, valp, pac, pav, opt)	/* Do not follow symlinks */
-	const char	*arg;
-	void		*valp;
-	int		*pac;
-	char	*const	**pav;
-	const char	*opt;
+getP(const char *arg, void *valp, int *pac, char * const **pav, const char *opt)	/* Do not follow symlinks */
 {
 /*error("getP\n");*/
 	if (opt[0] == '-' && opt[1] == 'P' && opt[2] == '\0') {
@@ -999,12 +959,7 @@ getP(arg, valp, pac, pav, opt)	/* Do not follow symlinks */
 LOCAL struct ga_flags *gl_flags;
 /* ARGSUSED */
 LOCAL int
-dolegacy(arg, valp, pac, pav, opt)	/* Follow symlinks encountered on cmdline */
-	const char	*arg;
-	void		*valp;
-	int		*pac;
-	char	*const	**pav;
-	const char	*opt;
+dolegacy(const char *arg, void *valp, int *pac, char * const **pav, const char *opt)	/* Follow symlinks encountered on cmdline */
 {
 	legacy = TRUE;
 #ifdef	APPLE_HYB
@@ -1486,8 +1441,7 @@ LOCAL	void	ovstrcpy	__PR((char *p2, char *p1));
 LOCAL	void	checkarch	__PR((char *name));
 
 LOCAL void
-read_rcfile(appname)
-	char		*appname;
+read_rcfile(char *appname)
 {
 	FILE		*rcfile = (FILE *)NULL;
 	struct rcopts	*rco;
@@ -1645,8 +1599,7 @@ int	goof = 0;
 #endif
 
 LOCAL void
-susage(excode)
-	int		excode;
+susage(int excode)
 {
 	const char	*program_name = "mkisofs";
 
@@ -1688,8 +1641,7 @@ susage(excode)
 
 const char *optend	__PR((const char *fmt));
 const char *
-optend(fmt)
-	const char	*fmt;
+optend(const char *fmt)
 {
 	int		c;
 	const char	*ofmt = fmt;
@@ -1713,11 +1665,7 @@ optend(fmt)
 
 int	printopts	__PR((FILE *f, const char *fmt, const char *arg, int twod));
 int
-printopts(f, fmt, arg, twod)
-	FILE		*f;
-	const char	*fmt;
-	const char	*arg;
-	int		twod;
+printopts(FILE *f, const char *fmt, const char *arg, int twod)
 {
 	const char	*p;
 	int		len = 0;
@@ -1760,9 +1708,7 @@ printopts(f, fmt, arg, twod)
 
 const char	*docstr	__PR((const char *str, int *no_help));
 const char *
-docstr(str, no_help)
-	const char	*str;
-	int		*no_help;
+docstr(const char *str, int *no_help)
 {
 	if (no_help)
 		*no_help = 0;
@@ -1791,8 +1737,7 @@ docstr(str, no_help)
 }
 
 LOCAL void
-usage(excode)
-	int		excode;
+usage(int excode)
 {
 	const char	*program_name = "mkisofs";
 
@@ -1865,9 +1810,7 @@ usage(excode)
  * of this wrong for ages (mkisofs had it wrong too until February 1997).
  */
 EXPORT int
-iso9660_date(result, crtime)
-	char	*result;
-	time_t	crtime;
+iso9660_date(char *result, time_t crtime)
 {
 	struct tm	local;
 	struct tm	gmt;
@@ -1904,11 +1847,7 @@ iso9660_date(result, crtime)
  * -modification-date command line option.
  */
 EXPORT int
-iso9660_ldate(result, crtime, nsec, gmtoff)
-	char	*result;
-	time_t	crtime;
-	int	nsec;
-	int	gmtoff;
+iso9660_ldate(char *result, time_t crtime, int nsec, int gmtoff)
 {
 	struct tm	local;
 	struct tm	gmt;
@@ -1944,7 +1883,7 @@ iso9660_ldate(result, crtime, nsec, gmtoff)
 
 /* hide "./rr_moved" if all its contents are hidden */
 LOCAL void
-hide_reloc_dir()
+hide_reloc_dir(void)
 {
 	struct directory_entry *s_entry;
 
@@ -1966,13 +1905,7 @@ hide_reloc_dir()
  * get pathnames from the command line, and then from given file
  */
 LOCAL char *
-get_pnames(argc, argv, opt, pname, pnsize, fp)
-	int	argc;
-	char	* const *argv;
-	int	opt;
-	char	*pname;
-	int	pnsize;
-	FILE	*fp;
+get_pnames(int argc, char * const *argv, int opt, char *pname, int pnsize, FILE *fp)
 {
 	int	len;
 
@@ -2007,9 +1940,7 @@ get_pnames(argc, argv, opt, pname, pnsize, fp)
 }
 
 EXPORT int
-main(argc, argv)
-	int		argc;
-	char		*argv[];
+main(int argc, char *argv[])
 {
 	int	cac = argc;
 	char	* const *cav = argv;
@@ -3609,7 +3540,7 @@ path_done:
 }
 
 LOCAL void
-list_locales()
+list_locales(void)
 {
 	int	n;
 
@@ -3639,8 +3570,7 @@ list_locales()
  * Find unescaped equal sign in graft pointer string.
  */
 EXPORT char *
-findgequal(s)
-	char	*s;
+findgequal(char *s)
 {
 	char	*p = s;
 
@@ -3656,10 +3586,7 @@ findgequal(s)
  * Find unescaped equal sign in string.
  */
 LOCAL char *
-escstrcpy(to, tolen, from)
-	char	*to;
-	size_t	tolen;
-	char	*from;
+escstrcpy(char *to, size_t tolen, char *from)
 {
 	char	*p = to;
 
@@ -3687,14 +3614,7 @@ escstrcpy(to, tolen, from)
 }
 
 struct directory *
-get_graft(arg, graft_point, glen, nodename, nlen, short_namep, do_insert)
-	char		*arg;
-	char		*graft_point;
-	size_t		glen;
-	char		*nodename;
-	size_t		nlen;
-	char		**short_namep;
-	BOOL		do_insert;
+get_graft(char *arg, char *graft_point, size_t glen, char *nodename, size_t nlen, char **short_namep, BOOL do_insert)
 {
 	char		*node = NULL;
 	struct directory_entry de;
@@ -3918,8 +3838,7 @@ get_graft(arg, graft_point, glen, nodename, nlen, short_namep, do_insert)
 }
 
 EXPORT void *
-e_malloc(size)
-	size_t		size;
+e_malloc(size_t size)
 {
 	void		*pt = 0;
 
@@ -3938,8 +3857,7 @@ e_malloc(size)
 }
 
 EXPORT char *
-e_strdup(s)
-	const	char	*s;
+e_strdup(const char *s)
 {
 	char	*ret = strdup(s);
 
@@ -3952,17 +3870,14 @@ e_strdup(s)
  * A strcpy() that works with overlapping buffers
  */
 LOCAL void
-ovstrcpy(p2, p1)
-	register char	*p2;
-	register char	*p1;
+ovstrcpy(char *p2, char *p1)
 {
 	while ((*p2++ = *p1++) != '\0')
 		;
 }
 
 LOCAL void
-checkarch(name)
-	char	*name;
+checkarch(char *name)
 {
 	struct stat	stbuf;
 

--- a/sdk/tools/mkisofs/schilytools/mkisofs/multi.c
+++ b/sdk/tools/mkisofs/schilytools/mkisofs/multi.c
@@ -110,16 +110,8 @@ char	er_id[256];
  * Anyways, this allows the use of a scsi-generics type of interface on
  * Solaris.
  */
-#ifdef	PROTOTYPES
 EXPORT int
 readsecs(UInt32_t startsecno, void *buffer, int sectorcount)
-#else
-EXPORT int
-readsecs(startsecno, buffer, sectorcount)
-	UInt32_t	startsecno;
-	void		*buffer;
-	int		sectorcount;
-#endif
 {
 	int		f = fileno(in_image);
 
@@ -136,10 +128,7 @@ readsecs(startsecno, buffer, sectorcount)
 #endif
 
 LOCAL void
-printasc(txt, p, len)
-	char		*txt;
-	unsigned char	*p;
-	int		len;
+printasc(char *txt, unsigned char *p, int len)
 {
 	int		i;
 
@@ -154,10 +143,7 @@ printasc(txt, p, len)
 }
 
 LOCAL void
-prbytes(txt, p, len)
-		char	*txt;
-	register Uchar	*p;
-	register int	len;
+prbytes(char *txt, Uchar *p, int len)
 {
 	error("%s", txt);
 	while (--len >= 0)
@@ -166,10 +152,7 @@ prbytes(txt, p, len)
 }
 
 unsigned char *
-parse_xa(pnt, lenp, dpnt)
-	unsigned char	*pnt;
-	int		*lenp;
-	struct directory_entry *dpnt;
+parse_xa(unsigned char *pnt, int *lenp, struct directory_entry *dpnt)
 {
 	struct iso_xa_dir_record *xadp;
 	int		len = *lenp;
@@ -222,10 +205,7 @@ static	int		did_xa = 0;
 }
 
 LOCAL BOOL
-find_rr(idr, pntp, lenp)
-	struct iso_directory_record *idr;
-	Uchar		**pntp;
-	int		*lenp;
+find_rr(struct iso_directory_record *idr, Uchar **pntp, int *lenp)
 {
 	struct iso_xa_dir_record *xadp;
 	int		len;
@@ -261,10 +241,7 @@ find_rr(idr, pntp, lenp)
 }
 
 LOCAL int
-parse_rrflags(pnt, len, cont_flag)
-	Uchar	*pnt;
-	int	len;
-	int	cont_flag;
+parse_rrflags(Uchar *pnt, int len, int cont_flag)
 {
 	int		ncount;
 	UInt32_t	cont_extent;
@@ -350,8 +327,7 @@ parse_rrflags(pnt, len, cont_flag)
 }
 
 int
-rr_flags(idr)
-	struct iso_directory_record *idr;
+rr_flags(struct iso_directory_record *idr)
 {
 	int		len;
 	unsigned char	*pnt;
@@ -367,10 +343,7 @@ rr_flags(idr)
  * Parse the RR attributes so we can find the file name.
  */
 LOCAL int
-parse_rr(pnt, len, dpnt)
-	unsigned char	*pnt;
-	int		len;
-	struct directory_entry *dpnt;
+parse_rr(unsigned char *pnt, int len, struct directory_entry *dpnt)
 {
 	UInt32_t	cont_extent;
 	UInt32_t	cont_offset;
@@ -450,11 +423,7 @@ parse_rr(pnt, len, dpnt)
  * Returns 0 if the two files differ
  */
 LOCAL int
-check_rr_dates(dpnt, current, statbuf, lstatbuf)
-	struct directory_entry *dpnt;
-	struct directory_entry *current;
-	struct stat	*statbuf;
-	struct stat	*lstatbuf;
+check_rr_dates(struct directory_entry *dpnt, struct directory_entry *current, struct stat *statbuf, struct stat *lstatbuf)
 {
 	UInt32_t	cont_extent;
 	UInt32_t	cont_offset;
@@ -564,10 +533,7 @@ check_rr_dates(dpnt, current, statbuf, lstatbuf)
 }
 
 LOCAL BOOL
-valid_iso_directory(idr, idr_off, space_left)
-	struct iso_directory_record	*idr;
-	int				idr_off;
-	size_t				space_left;
+valid_iso_directory(struct iso_directory_record *idr, int idr_off, size_t space_left)
 {
 	size_t	idr_length	= idr->length[0] & 0xFF;
 	size_t	idr_ext_length	= idr->ext_attr_length[0] & 0xFF;
@@ -661,9 +627,7 @@ valid_iso_directory(idr, idr_off, space_left)
 }
 
 LOCAL struct directory_entry **
-read_merging_directory(mrootp, nentp)
-	struct iso_directory_record *mrootp;
-	int		*nentp;
+read_merging_directory(struct iso_directory_record *mrootp, int *nentp)
 {
 	unsigned char	*cpnt;
 	unsigned char	*cpnt1;
@@ -1095,9 +1059,7 @@ read_merging_directory(mrootp, nentp)
  * Free any associated data related to the structures.
  */
 LOCAL int
-free_mdinfo(ptr, len)
-	struct directory_entry **ptr;
-	int		len;
+free_mdinfo(struct directory_entry **ptr, int len)
 {
 	int		i;
 	struct directory_entry **p;
@@ -1120,8 +1082,7 @@ free_mdinfo(ptr, len)
 }
 
 LOCAL void
-free_directory_entry(dirp)
-	struct directory_entry *dirp;
+free_directory_entry(struct directory_entry *dirp)
 {
 	if (dirp->name != NULL)
 		free(dirp->name);
@@ -1144,13 +1105,7 @@ free_directory_entry(dirp)
  * over so we don't bother to write it out to the new session.
  */
 int
-check_prev_session(ptr, len, curr_entry, statbuf, lstatbuf, odpnt)
-	struct directory_entry	**ptr;
-	int		len;
-	struct directory_entry *curr_entry;
-	struct stat	*statbuf;
-	struct stat	*lstatbuf;
-	struct directory_entry **odpnt;
+check_prev_session(struct directory_entry **ptr, int len, struct directory_entry *curr_entry, struct stat *statbuf, struct stat *lstatbuf, struct directory_entry **odpnt)
 {
 	int		i;
 	int		rr;
@@ -1263,8 +1218,7 @@ found_it:
  * but may be 3 or more in case of multi extent files.
  */
 LOCAL int
-iso_dir_ents(de)
-	struct directory_entry	*de;
+iso_dir_ents(struct directory_entry *de)
 {
 	struct directory_entry	*de2;
 	int	ret = 0;
@@ -1290,9 +1244,7 @@ iso_dir_ents(de)
  * we reuse the data extents from the file in the old session.
  */
 LOCAL void
-copy_mult_extent(se1, se2)
-	struct directory_entry	*se1;
-	struct directory_entry	*se2;
+copy_mult_extent(struct directory_entry *se1, struct directory_entry *se2)
 {
 	struct directory_entry	*curr_entry = se1;
 	int			len1;
@@ -1362,8 +1314,7 @@ copy_mult_extent(se1, se2)
  * open_merge_image:  Open an existing image.
  */
 int
-open_merge_image(path)
-	char	*path;
+open_merge_image(char *path)
 {
 #ifndef	USE_SCG
 	in_image = fopen(path, "rb");
@@ -1384,7 +1335,7 @@ open_merge_image(path)
  * close_merge_image:  Close an existing image.
  */
 int
-close_merge_image()
+close_merge_image(void)
 {
 #ifdef	USE_SCG
 	return (scsidev_close());
@@ -1398,8 +1349,7 @@ close_merge_image()
  * to the root directory for this image.
  */
 struct iso_directory_record *
-merge_isofs(path)
-	char	*path;
+merge_isofs(char *path)
 {
 	char		buffer[SECTOR_SIZE];
 	int		file_addr;
@@ -1487,10 +1437,7 @@ merge_isofs(path)
 }
 
 LOCAL void
-merge_remaining_entries(this_dir, pnt, n_orig)
-	struct directory *this_dir;
-	struct directory_entry **pnt;
-	int		n_orig;
+merge_remaining_entries(struct directory *this_dir, struct directory_entry **pnt, int n_orig)
 {
 	int		i;
 	struct directory_entry *s_entry;
@@ -1619,9 +1566,7 @@ merge_remaining_entries(this_dir, pnt, n_orig)
  * location.  FIXME(eric).
  */
 LOCAL int
-merge_old_directory_into_tree(dpnt, parent)
-	struct directory_entry	*dpnt;
-	struct directory *parent;
+merge_old_directory_into_tree(struct directory_entry *dpnt, struct directory *parent)
 {
 	struct directory_entry **contents = NULL;
 	int		i;
@@ -1748,8 +1693,7 @@ merge_old_directory_into_tree(dpnt, parent)
 char	*cdrecord_data = NULL;
 
 int
-get_session_start(file_addr)
-	int		*file_addr;
+get_session_start(int *file_addr)
 {
 	char		*pnt;
 
@@ -1808,11 +1752,7 @@ get_session_start(file_addr)
  * directory entries, so that we can determine how large each directory is.
  */
 int
-merge_previous_session(this_dir, mrootp, reloc_root, reloc_old_root)
-	struct directory *this_dir;
-	struct iso_directory_record *mrootp;
-	char *reloc_root;
-	char *reloc_old_root;
+merge_previous_session(struct directory *this_dir, struct iso_directory_record *mrootp, char *reloc_root, char *reloc_old_root)
 {
 	struct directory_entry **orig_contents = NULL;
 	struct directory_entry *odpnt = NULL;
@@ -2067,8 +2007,7 @@ static struct dir_extent_link	*cl_dirs = NULL;
 static struct dir_extent_link	*re_dirs = NULL;
 
 LOCAL void
-check_rr_relocation(de)
-	struct directory_entry *de;
+check_rr_relocation(struct directory_entry *de)
 {
 	unsigned char	sector[SECTOR_SIZE];
 	unsigned char	*pnt = de->rr_attributes;
@@ -2128,7 +2067,7 @@ check_rr_relocation(de)
 }
 
 void
-match_cl_re_entries()
+match_cl_re_entries(void)
 {
 	struct dir_extent_link *re = re_dirs;
 
@@ -2164,7 +2103,7 @@ match_cl_re_entries()
 }
 
 void
-finish_cl_pl_for_prev_session()
+finish_cl_pl_for_prev_session(void)
 {
 	struct dir_extent_link *re = re_dirs;
 

--- a/sdk/tools/mkisofs/schilytools/mkisofs/name.c
+++ b/sdk/tools/mkisofs/schilytools/mkisofs/name.c
@@ -42,9 +42,7 @@ int	iso9660_file_length	__PR((const char *name,
 					int dirflag));
 
 void
-iso9660_check(idr, ndr)
-	struct iso_directory_record *idr;
-	struct directory_entry *ndr;
+iso9660_check(struct iso_directory_record *idr, struct directory_entry *ndr)
 {
 	int	nlen;
 	char	schar;
@@ -102,10 +100,7 @@ iso9660_check(idr, ndr)
  *		fix without going through the whole source.
  */
 int
-iso9660_file_length(name, sresult, dirflag)
-	const char	*name;			/* Not really const !!! */
-	struct directory_entry *sresult;
-	int		dirflag;
+iso9660_file_length(const char *name, struct directory_entry *sresult, int dirflag)
 {
 	char		c;
 	char		*cp;

--- a/sdk/tools/mkisofs/schilytools/mkisofs/rock.c
+++ b/sdk/tools/mkisofs/schilytools/mkisofs/rock.c
@@ -101,12 +101,7 @@ LOCAL	int	reclimit;	/* Max. # of bytes usable in this area	*/
 
 /* if we are using converted filenames, we don't want the '/' character */
 LOCAL void
-rstrncpy(t, f, tlen, inls, onls)
-	char	*t;
-	char	*f;
-	size_t	tlen;		/* The to-length */
-	siconvt_t *inls;
-	siconvt_t *onls;
+rstrncpy(char *t, char *f, size_t tlen, siconvt_t *inls, siconvt_t *onls)
 {
 	size_t	flen = strlen(f);
 
@@ -124,9 +119,7 @@ rstrncpy(t, f, tlen, inls, onls)
 }
 
 LOCAL void
-add_CE_entry(field, line)
-	char	*field;
-	int	line;
+add_CE_entry(char *field, int line)
 {
 	if (MAYBE_ADD_CE_ENTRY(0)) {
 		errmsgno(EX_BAD,
@@ -158,14 +151,8 @@ add_CE_entry(field, line)
 	reclimit = SECTOR_SIZE - 8;	/* Limit to one sector */
 }
 
-#ifdef	PROTOTYPES
 LOCAL int
 gen_xa_attr(mode_t attr)
-#else
-LOCAL int
-gen_xa_attr(attr)
-	mode_t	attr;
-#endif
 {
 	int	ret = 0;
 
@@ -193,8 +180,7 @@ gen_xa_attr(attr)
 }
 
 LOCAL void
-gen_xa(lstatbuf)
-	struct stat	*lstatbuf;
+gen_xa(struct stat *lstatbuf)
 {
 		/*
 		 * Group ID
@@ -224,27 +210,12 @@ gen_xa(lstatbuf)
 
 }
 
-#ifdef PROTOTYPES
 EXPORT int
 generate_xa_rr_attributes(char *whole_name, char *name,
 			struct directory_entry *s_entry,
 			struct stat *statbuf,
 			struct stat *lstatbuf,
 			int deep_opt)
-#else
-EXPORT int
-generate_xa_rr_attributes(whole_name, name,
-			s_entry,
-			statbuf,
-			lstatbuf,
-			deep_opt)
-	char		*whole_name;
-	char		*name;
-	struct directory_entry *s_entry;
-	struct stat	*statbuf,
-			*lstatbuf;
-	int		deep_opt;
-#endif
 {
 	int		flagpos;
 	int		flagval;
@@ -900,11 +871,7 @@ xa_only:
  * Guaranteed to  return a single sector with the relevant info
  */
 EXPORT char *
-generate_rr_extension_record(id, descriptor, source, size)
-	char	*id;
-	char	*descriptor;
-	char	*source;
-	int	*size;
+generate_rr_extension_record(char *id, char *descriptor, char *source, int *size)
 {
 	int		lipnt = 0;
 	char		*pnt;

--- a/sdk/tools/mkisofs/schilytools/mkisofs/stream.c
+++ b/sdk/tools/mkisofs/schilytools/mkisofs/stream.c
@@ -56,8 +56,7 @@ LOCAL int		stream_finished = 0;
  * Compute the size of the file
  */
 LOCAL int
-size_str_file(starting_extent)
-	UInt32_t	starting_extent;
+size_str_file(UInt32_t starting_extent)
 {
 	int	n;
 extern	int	dopad;
@@ -91,8 +90,7 @@ extern	int	dopad;
  * The size of the directory record - one sector
  */
 LOCAL int
-size_str_dir(starting_extent)
-	UInt32_t	starting_extent;
+size_str_dir(UInt32_t starting_extent)
 {
 	root->extent = last_extent;
 	last_extent += 1;
@@ -103,8 +101,7 @@ size_str_dir(starting_extent)
  * The size of the path tables - two sectors
  */
 LOCAL int
-size_str_path(starting_extent)
-	UInt32_t	starting_extent;
+size_str_path(UInt32_t starting_extent)
 {
 	path_table[0] = starting_extent;
 	path_table[1] = 0;
@@ -142,8 +139,7 @@ gen_str_path()
  * Write the file content
  */
 LOCAL int
-write_str_file(outfile)
-	FILE	*outfile;
+write_str_file(FILE *outfile)
 {
 	unsigned int	idx = 0;
 	unsigned int	iso_blocks;
@@ -186,8 +182,7 @@ write_str_file(outfile)
  * Generate and write the directory record data
  */
 LOCAL int
-write_str_dir(outfile)
-	FILE	*outfile;
+write_str_dir(FILE *outfile)
 {
 	int	reclen;
 	char	*buf;
@@ -239,8 +234,7 @@ write_str_dir(outfile)
  * Generate the path table data
  */
 LOCAL int
-write_str_path(outfile)
-	FILE	*outfile;
+write_str_path(FILE *outfile)
 {
 	xfwrite(l_path, SECTOR_SIZE, 1, outfile, 0, FALSE);
 	xfwrite(m_path, SECTOR_SIZE, 1, outfile, 0, FALSE);

--- a/sdk/tools/mkisofs/schilytools/mkisofs/tree.c
+++ b/sdk/tools/mkisofs/schilytools/mkisofs/tree.c
@@ -111,8 +111,7 @@ struct stat	root_statbuf;		/* Stat buffer for root directory */
 struct directory *reloc_dir;
 
 LOCAL char *
-filetype(t)
-	int	t;
+filetype(int t)
 {
 	static	char	unkn[32];
 
@@ -162,9 +161,7 @@ filetype(t)
  * Check if s1 ends in strings s2
  */
 LOCAL char *
-rstr(s1, s2)
-	char	*s1;
-	char	*s2;
+rstr(char *s1, char *s2)
 {
 	int	l1;
 	int	l2;
@@ -180,8 +177,7 @@ rstr(s1, s2)
 }
 
 LOCAL void
-stat_fix(st)
-	struct stat	*st;
+stat_fix(struct stat *st)
 {
 	int adjust_modes = 0;
 
@@ -229,9 +225,7 @@ stat_fix(st)
 }
 
 EXPORT int
-stat_filter(path, st)
-	char		*path;
-	struct stat	*st;
+stat_filter(char *path, struct stat *st)
 {
 	int	result = stat(path, st);
 
@@ -241,9 +235,7 @@ stat_filter(path, st)
 }
 
 EXPORT int
-lstat_filter(path, st)
-	char		*path;
-	struct stat	*st;
+lstat_filter(char *path, struct stat *st)
 {
 	int	result = lstat(path, st);
 
@@ -253,8 +245,7 @@ lstat_filter(path, st)
 }
 
 LOCAL int
-sort_n_finish(this_dir)
-	struct directory	*this_dir;
+sort_n_finish(struct directory *this_dir)
 {
 	struct directory_entry *s_entry;
 	struct directory_entry *s_entry1;
@@ -902,10 +893,7 @@ generate_reloc_directory()
  *			we are creating.
  */
 EXPORT void
-attach_dot_entries(dirnode, this_stat, parent_stat)
-	struct directory	*dirnode;
-	struct stat		*this_stat;
-	struct stat		*parent_stat;
+attach_dot_entries(struct directory *dirnode, struct stat *this_stat, struct stat *parent_stat)
 {
 	struct directory_entry *s_entry;
 	struct directory_entry *orig_contents;
@@ -1004,10 +992,7 @@ attach_dot_entries(dirnode, this_stat, parent_stat)
 }
 
 EXPORT char *
-find_rr_attribute(pnt, len, attr_type)
-	unsigned char	*pnt;
-	int		len;
-	char		*attr_type;
+find_rr_attribute(unsigned char *pnt, int len, char *attr_type)
 {
 	pnt = parse_xa(pnt, &len, 0);
 	while (len >= 4) {
@@ -1033,7 +1018,7 @@ find_rr_attribute(pnt, len, attr_type)
 }
 
 EXPORT void
-finish_cl_pl_entries()
+finish_cl_pl_entries(void)
 {
 	struct directory_entry	*s_entry;
 	struct directory_entry	*s_entry1;
@@ -1115,10 +1100,7 @@ finish_cl_pl_entries()
 }
 
 LOCAL void
-dir_nesting_warn(this_dir, path, contflag)
-	struct directory	*this_dir;
-	char			*path;
-	int			contflag;
+dir_nesting_warn(struct directory *this_dir, char *path, int contflag)
 {
 	static	BOOL	did_hint = FALSE;
 
@@ -1144,10 +1126,7 @@ dir_nesting_warn(this_dir, path, contflag)
  * Notes:
  */
 EXPORT int
-scan_directory_tree(this_dir, path, de)
-	struct directory	*this_dir;
-	char			*path;
-	struct directory_entry	*de;
+scan_directory_tree(struct directory *this_dir, char *path, struct directory_entry *de)
 {
 	DIR		*current_dir;
 	char		whole_path[2*PATH_MAX];	/* Avoid stat buffer overflow */
@@ -1373,12 +1352,7 @@ extern	BOOL		nodesc;
 }
 
 LOCAL struct directory_entry *
-dup_relocated_dir(this_dir, s_entry, whole_path, short_name, statp)
-	struct directory	*this_dir;
-	struct directory_entry	*s_entry;
-	char			*whole_path;
-	char			*short_name;
-	struct stat		*statp;
+dup_relocated_dir(struct directory *this_dir, struct directory_entry *s_entry, char *whole_path, char *short_name, struct stat *statp)
 {
 	struct directory_entry *s_entry1;
 
@@ -1441,12 +1415,7 @@ dup_relocated_dir(this_dir, s_entry, whole_path, short_name, statp)
  * trees before we return.
  */
 EXPORT int
-insert_file_entry(this_dir, whole_path, short_name, statp, have_rsrc)
-	struct directory	*this_dir;
-	char			*whole_path;
-	char			*short_name;
-	struct stat		*statp;
-	int			have_rsrc;
+insert_file_entry(struct directory *this_dir, char *whole_path, char *short_name, struct stat *statp, int have_rsrc)
 {
 	struct stat	statbuf,
 			lstatbuf;
@@ -2426,8 +2395,7 @@ insert_file_entry(this_dir, whole_path, short_name, statp, have_rsrc)
 }
 
 EXPORT struct directory_entry *
-dup_directory_entry(s_entry)
-	struct directory_entry	*s_entry;
+dup_directory_entry(struct directory_entry *s_entry)
 {
 	struct directory_entry	*s_entry1;
 
@@ -2455,9 +2423,7 @@ dup_directory_entry(s_entry)
 }
 
 EXPORT void
-generate_iso9660_directories(node, outfile)
-	struct directory	*node;
-	FILE			*outfile;
+generate_iso9660_directories(struct directory *node, FILE *outfile)
 {
 	struct directory *dpnt;
 
@@ -2477,9 +2443,7 @@ generate_iso9660_directories(node, outfile)
  * XXX This may need some work for the MVS port.
  */
 LOCAL void
-set_de_path(parent, this)
-	struct directory	*parent;
-	struct directory	*this;
+set_de_path(struct directory *parent, struct directory *this)
 {
 	char	*p;
 	size_t	len;
@@ -2505,11 +2469,7 @@ set_de_path(parent, this)
  * Arguments:	parent & de are never NULL at the same time.
  */
 EXPORT struct directory *
-find_or_create_directory(parent, path, de, flag)
-	struct directory	*parent;
-	char			*path;
-	struct directory_entry	*de;
-	int			flag;
+find_or_create_directory(struct directory *parent, char *path, struct directory_entry *de, int flag)
 {
 	struct directory *child = 0;
 	struct directory *dpnt;
@@ -2798,9 +2758,7 @@ find_or_create_directory(parent, path, de, flag)
  * Arguments:
  */
 LOCAL void
-delete_directory(parent, child)
-	struct directory	*parent;
-	struct directory	*child;
+delete_directory(struct directory *parent, struct directory *child)
 {
 	struct directory *tdir;
 
@@ -2839,8 +2797,7 @@ delete_directory(parent, child)
 }
 
 EXPORT int
-sort_tree(node)
-	struct directory	*node;
+sort_tree(struct directory *node)
 {
 	struct directory *dpnt;
 	int		ret = 0;
@@ -2860,8 +2817,7 @@ sort_tree(node)
 }
 
 EXPORT void
-dump_tree(node)
-	struct directory *node;
+dump_tree(struct directory *node)
 {
 	struct directory *dpnt;
 
@@ -2882,9 +2838,7 @@ dump_tree(node)
  * directory entry for the desired file
  */
 EXPORT struct directory_entry *
-search_tree_file(node, filename)
-	struct directory *node;
-	char		*filename;
+search_tree_file(struct directory *node, char *filename)
 {
 	struct directory_entry *depnt;
 	struct directory *dpnt;
@@ -2971,7 +2925,7 @@ search_tree_file(node, filename)
 }
 
 EXPORT void
-init_fstatbuf()
+init_fstatbuf(void)
 {
 	struct timeval	current_time;
 

--- a/sdk/tools/mkisofs/schilytools/mkisofs/write.c
+++ b/sdk/tools/mkisofs/schilytools/mkisofs/write.c
@@ -165,13 +165,7 @@ LOCAL 	int	sort_file_addresses __PR((void));
 #define	FILL_SPACE(X)	memset(vol_desc.X, ' ', sizeof (vol_desc.X))
 
 EXPORT void
-xfwrite(buffer, size, count, file, submode, islast)
-	void	*buffer;
-	int	size;
-	int	count;
-	FILE	*file;
-	int	submode;
-	BOOL	islast;
+xfwrite(void *buffer, int size, int count, FILE *file, int submode, BOOL islast)
 {
 	/*
 	 * This is a hack that could be made better.
@@ -311,8 +305,7 @@ EXPORT	struct timeval tv_begun;
  * goes in front of them
  */
 LOCAL int
-assign_directory_addresses(node)
-	struct directory	*node;
+assign_directory_addresses(struct directory *node)
 {
 	int		dir_size;
 	struct directory *dpnt;
@@ -355,19 +348,10 @@ assign_directory_addresses(node)
 
 #if defined(APPLE_HYB) || defined(USE_LARGEFILES)
 LOCAL void
-write_one_file(filename, size, outfile, off, isrfile, rba)
-	char		*filename;
-	off_t		size;
-	FILE		*outfile;
-	off_t		off;
-	int		isrfile;
-	unsigned	rba;
+write_one_file(char *filename, off_t size, FILE *outfile, off_t off, int isrfile, unsigned rba)
 #else
 LOCAL void
-write_one_file(filename, size, outfile)
-	char		*filename;
-	off_t		size;
-	FILE		*outfile;
+write_one_file(char *filename, off_t size, FILE *outfile)
 #endif	/* APPLE_HYB || USE_LARGEFILES */
 {
 	/*
@@ -569,8 +553,7 @@ write_udf_symlink(filename, size, outfile)
 #endif
 
 LOCAL void
-write_files(outfile)
-	FILE	*outfile;
+write_files(FILE *outfile)
 {
 	struct deferred_write	*dwpnt,
 				*dwnext;
@@ -680,9 +663,7 @@ dump_filelist()
 #endif
 
 LOCAL int
-compare_dirs(rr, ll)
-	const void	*rr;
-	const void	*ll;
+compare_dirs(const void *rr, const void *ll)
 {
 	char		*rpnt,
 			*lpnt;
@@ -811,9 +792,7 @@ compare_dirs(rr, ll)
  * Notes:		Returns 0 if OK, returns > 0 if an error occurred.
  */
 EXPORT int
-sort_directory(sort_dir, rr)
-	struct directory_entry **sort_dir;
-	int		rr;
+sort_directory(struct directory_entry **sort_dir, int rr)
 {
 	int		dcount = 0;
 	int		xcount = 0;
@@ -892,7 +871,7 @@ sort_directory(sort_dir, rr)
 }
 
 LOCAL int
-root_gen()
+root_gen(void)
 {
 	init_fstatbuf();
 
@@ -915,9 +894,7 @@ root_gen()
  *	sorts deferred_write entries based on the sort weight
  */
 LOCAL int
-compare_sort(rr, ll)
-	const void	*rr;
-	const void	*ll;
+compare_sort(const void *rr, const void *ll)
 {
 	struct deferred_write	**r;
 	struct deferred_write	**l;
@@ -940,8 +917,7 @@ compare_sort(rr, ll)
  *	files that may have been sorted
  */
 LOCAL void
-reassign_link_addresses(dpnt)
-	struct directory	*dpnt;
+reassign_link_addresses(struct directory *dpnt)
 {
 	struct directory_entry	*s_entry;
 	struct file_hash	*s_hash;
@@ -972,7 +948,7 @@ reassign_link_addresses(dpnt)
  *	sort files in order of the given sort weight
  */
 LOCAL int
-sort_file_addresses()
+sort_file_addresses(void)
 {
 	struct deferred_write	*dwpnt;
 	struct deferred_write	**sortlist;
@@ -1079,9 +1055,7 @@ sort_file_addresses()
 
 
 LOCAL BOOL
-assign_file_addresses(dpnt, isnest)
-	struct directory	*dpnt;
-	BOOL			isnest;
+assign_file_addresses(struct directory *dpnt, BOOL isnest)
 {
 	struct directory *finddir;
 	struct directory_entry *s_entry;
@@ -1474,8 +1448,7 @@ assign_file_addresses(dpnt, isnest)
 } /* assign_file_addresses(... */
 
 LOCAL void
-free_one_directory(dpnt)
-	struct directory	*dpnt;
+free_one_directory(struct directory *dpnt)
 {
 	struct directory_entry *s_entry;
 	struct directory_entry *s_entry_d;
@@ -1536,9 +1509,7 @@ free_directories(dpnt)
 }
 
 EXPORT void
-generate_one_directory(dpnt, outfile)
-	struct directory	*dpnt;
-	FILE			*outfile;
+generate_one_directory(struct directory *dpnt, FILE *outfile)
 {
 	unsigned int	ce_address = 0;
 	char		*ce_buffer;
@@ -1711,8 +1682,7 @@ generate_one_directory(dpnt, outfile)
 } /* generate_one_directory(... */
 
 LOCAL void
-build_pathlist(node)
-	struct directory	*node;
+build_pathlist(struct directory *node)
 {
 	struct directory *dpnt;
 
@@ -1730,9 +1700,7 @@ build_pathlist(node)
 } /* build_pathlist(... */
 
 LOCAL int
-compare_paths(r, l)
-	void const	*r;
-	void const	*l;
+compare_paths(void const *r, void const *l)
 {
 	struct directory const *ll = *(struct directory * const *) l;
 	struct directory const *rr = *(struct directory * const *) r;
@@ -1748,7 +1716,7 @@ compare_paths(r, l)
 } /* compare_paths(... */
 
 LOCAL int
-generate_path_tables()
+generate_path_tables(void)
 {
 	struct directory_entry *de = NULL;
 	struct directory *dpnt;
@@ -1877,10 +1845,7 @@ generate_path_tables()
 } /* generate_path_tables(... */
 
 EXPORT void
-memcpy_max(to, from, max)
-	char	*to;
-	char	*from;
-	int	max;
+memcpy_max(char *to, char *from, int max)
 {
 	int	n = strlen(from);
 
@@ -1892,8 +1857,7 @@ memcpy_max(to, from, max)
 } /* memcpy_max(... */
 
 EXPORT void
-outputlist_insert(frag)
-	struct output_fragment *frag;
+outputlist_insert(struct output_fragment *frag)
 {
 	struct output_fragment *nfrag;
 
@@ -1910,8 +1874,7 @@ outputlist_insert(frag)
 }
 
 LOCAL int
-file_write(outfile)
-	FILE	*outfile;
+file_write(FILE *outfile)
 {
 	Uint	should_write;
 
@@ -2031,8 +1994,7 @@ file_write(outfile)
  * Function to write the PVD for the disc.
  */
 LOCAL int
-pvd_write(outfile)
-	FILE	*outfile;
+pvd_write(FILE *outfile)
 {
 	char		iso_time[17];
 	int		should_write;
@@ -2155,8 +2117,7 @@ extern	ldate		modification_date;
  * Function to write the Extended PVD for the disc.
  */
 LOCAL int
-xpvd_write(outfile)
-	FILE	*outfile;
+xpvd_write(FILE *outfile)
 {
 	vol_desc.type[0] = ISO_VD_SUPPLEMENTARY;
 	vol_desc.version[0] = 2;
@@ -2172,8 +2133,7 @@ xpvd_write(outfile)
  * Function to write the EVD for the disc.
  */
 LOCAL int
-evd_write(outfile)
-	FILE	*outfile;
+evd_write(FILE *outfile)
 {
 	struct iso_primary_descriptor evol_desc;
 
@@ -2197,8 +2157,7 @@ evd_write(outfile)
  * mkisofs version includes correct inode information.
  */
 LOCAL int
-vers_write(outfile)
-	FILE	*outfile;
+vers_write(FILE *outfile)
 {
 	char		vers[SECTOR_SIZE+1];
 	int		X_ac;
@@ -2265,10 +2224,7 @@ vers_write(outfile)
  * Avoid to write unwanted information into the version info string.
  */
 LOCAL int
-graftcp(to, from, ep)
-	char	*to;
-	char	*from;
-	char	*ep;
+graftcp(char *to, char *from, char *ep)
 {
 	int	len = strlen(from);
 	char	*node = NULL;
@@ -2291,10 +2247,7 @@ graftcp(to, from, ep)
 }
 
 LOCAL int
-pathcp(to, from, ep)
-	char	*to;
-	char	*from;
-	char	*ep;
+pathcp(char *to, char *from, char *ep)
 {
 	int	len = strlen(from);
 	char	*p;
@@ -2327,8 +2280,7 @@ pathcp(to, from, ep)
  * Function to write the path table for the disc.
  */
 LOCAL int
-pathtab_write(outfile)
-	FILE	*outfile;
+pathtab_write(FILE *outfile)
 {
 	/* Next we write the path tables */
 	xfwrite(path_table_l, path_blocks << 11, 1, outfile, 0, FALSE);
@@ -2342,8 +2294,7 @@ pathtab_write(outfile)
 }
 
 LOCAL int
-exten_write(outfile)
-	FILE	*outfile;
+exten_write(FILE *outfile)
 {
 	xfwrite(extension_record, SECTOR_SIZE, 1, outfile, 0, FALSE);
 	last_extent_written++;
@@ -2354,8 +2305,7 @@ exten_write(outfile)
  * Functions to describe padding block at the start of the disc.
  */
 EXPORT int
-oneblock_size(starting_extent)
-	UInt32_t	starting_extent;
+oneblock_size(UInt32_t starting_extent)
 {
 	last_extent++;
 	return (0);
@@ -2365,8 +2315,7 @@ oneblock_size(starting_extent)
  * Functions to describe path table size.
  */
 LOCAL int
-pathtab_size(starting_extent)
-	UInt32_t	starting_extent;
+pathtab_size(UInt32_t starting_extent)
 {
 	path_table[0] = starting_extent;
 
@@ -2381,8 +2330,7 @@ pathtab_size(starting_extent)
  * Functions to describe padding blocks before PVD.
  */
 LOCAL int
-startpad_size(starting_extent)
-	UInt32_t	starting_extent;
+startpad_size(UInt32_t starting_extent)
 {
 	last_extent = session_start + 16;
 	return (0);
@@ -2392,8 +2340,7 @@ startpad_size(starting_extent)
  * Functions to describe padding blocks between sections.
  */
 LOCAL int
-interpad_size(starting_extent)
-	UInt32_t	starting_extent;
+interpad_size(UInt32_t starting_extent)
 {
 	int	emod = 0;
 
@@ -2411,8 +2358,7 @@ interpad_size(starting_extent)
  * Functions to describe padding blocks at end of disk.
  */
 LOCAL int
-endpad_size(starting_extent)
-	UInt32_t	starting_extent;
+endpad_size(UInt32_t starting_extent)
 {
 	starting_extent += 150;			/* 150 pad blocks (post gap) */
 	last_extent = starting_extent;
@@ -2420,7 +2366,7 @@ endpad_size(starting_extent)
 }
 
 LOCAL int
-file_gen()
+file_gen(void)
 {
 #ifdef APPLE_HYB
 	UInt32_t	start_extent = last_extent;	/* orig ISO files start */
@@ -2468,7 +2414,7 @@ file_gen()
 }
 
 LOCAL int
-dirtree_dump()
+dirtree_dump(void)
 {
 	if (verbose > 2) {
 		dump_tree(root);
@@ -2477,8 +2423,7 @@ dirtree_dump()
 }
 
 LOCAL int
-dirtree_fixup(starting_extent)
-	UInt32_t	starting_extent;
+dirtree_fixup(UInt32_t starting_extent)
 {
 	if (use_RockRidge && reloc_dir)
 		finish_cl_pl_entries();
@@ -2492,16 +2437,14 @@ dirtree_fixup(starting_extent)
 }
 
 LOCAL int
-dirtree_size(starting_extent)
-	UInt32_t	starting_extent;
+dirtree_size(UInt32_t starting_extent)
 {
 	assign_directory_addresses(root);
 	return (0);
 }
 
 LOCAL int
-ext_size(starting_extent)
-	UInt32_t	starting_extent;
+ext_size(UInt32_t starting_extent)
 {
 	extern int		extension_record_size;
 	struct directory_entry *s_entry;
@@ -2517,24 +2460,21 @@ ext_size(starting_extent)
 }
 
 LOCAL int
-dirtree_write(outfile)
-	FILE	*outfile;
+dirtree_write(FILE *outfile)
 {
 	generate_iso9660_directories(root, outfile);
 	return (0);
 }
 
 LOCAL int
-dirtree_cleanup(outfile)
-	FILE	*outfile;
+dirtree_cleanup(FILE *outfile)
 {
 	free_directories(root);
 	return (0);
 }
 
 LOCAL int
-startpad_write(outfile)
-	FILE	*outfile;
+startpad_write(FILE *outfile)
 {
 	char	buffer[SECTOR_SIZE];
 	int	i;
@@ -2553,8 +2493,7 @@ startpad_write(outfile)
 }
 
 LOCAL int
-interpad_write(outfile)
-	FILE	*outfile;
+interpad_write(FILE *outfile)
 {
 	char	buffer[SECTOR_SIZE];
 	int	i;
@@ -2577,8 +2516,7 @@ interpad_write(outfile)
 }
 
 LOCAL int
-endpad_write(outfile)
-	FILE	*outfile;
+endpad_write(FILE *outfile)
 {
 	char	buffer[SECTOR_SIZE];
 	int	i;
@@ -2600,8 +2538,7 @@ endpad_write(outfile)
  */
 
 LOCAL int
-hfs_get_parms(key)
-	char	*key;
+hfs_get_parms(char *key)
 {
 	int	ret = 0;
 	char	*p;
@@ -2770,7 +2707,7 @@ hfs_file_gen(start_extent)
 
 #ifdef PREP_BOOT
 LOCAL void
-gen_prepboot()
+gen_prepboot(void)
 {
 	/*
 	 * we need to allocate the hce struct since hce->hfs_map is used to
@@ -2795,8 +2732,7 @@ gen_prepboot()
  *			allocation block size for each file
  */
 EXPORT Ulong
-get_adj_size(Csize)
-	int	Csize;
+get_adj_size(int Csize)
 {
 	struct deferred_write *dw;
 	Ulong		size = 0;
@@ -2825,10 +2761,7 @@ get_adj_size(Csize)
  *			based on the HFS allocation block size
  */
 EXPORT int
-adj_size(Csize, start_extent, extra)
-	int	Csize;
-	UInt32_t	start_extent;
-	int	extra;
+adj_size(int Csize, UInt32_t start_extent, int extra)
 {
 	struct deferred_write *dw;
 	struct directory_entry *s_entry;
@@ -2880,8 +2813,7 @@ adj_size(Csize, start_extent, extra)
  *			entry of it's own
  */
 EXPORT void
-adj_size_other(dpnt)
-	struct directory	*dpnt;
+adj_size_other(struct directory *dpnt)
 {
 	struct directory_entry *s_entry;
 	struct file_hash *s_hash;
@@ -2925,8 +2857,7 @@ adj_size_other(dpnt)
  *	hfs_hce_write:	write out the HFS header stuff
  */
 LOCAL int
-hfs_hce_write(outfile)
-	FILE	*outfile;
+hfs_hce_write(FILE *outfile)
 {
 	char	buffer[SECTOR_SIZE];
 	int	n = 0;
@@ -2967,8 +2898,7 @@ hfs_hce_write(outfile)
  *	XXX If we ever need to write more then 2 GB, make size off_t
  */
 EXPORT int
-insert_padding_file(size)
-	int	size;
+insert_padding_file(int size)
 {
 	struct deferred_write *dwpnt;
 


### PR DESCRIPTION
## Purpose

The C syntax in the mkisofs components is so ridiculously ancient it causes my compiler (a version of Clang, which is notoriously picky) to output warnings about every function definition in this part of the codebase.

JIRA issue: none

## Proposed changes

- Change all legacy non-prototype function definitions in the components of mkisofs to standard C syntax.