### PR TITLE
[CONSRV] Don't blink cursor if the console window is not active

### DIFF
--- a/win32ss/user/winsrv/consrv/frontends/gui/conwnd.c
+++ b/win32ss/user/winsrv/consrv/frontends/gui/conwnd.c
@@ -642,6 +642,7 @@ OnNcCreate(HWND hWnd, LPCREATESTRUCTW Create)
 
     GuiData->hWindow = hWnd;
     GuiData->hSysMenu = GetSystemMenu(hWnd, FALSE);
+    GuiData->IsWindowActive = FALSE;
 
     /* Initialize the fonts */
     if (!InitFonts(GuiData,
@@ -724,6 +725,8 @@ OnActivate(PGUI_CONSOLE_DATA GuiData, WPARAM wParam)
     WORD ActivationState = LOWORD(wParam);
 
     DPRINT("WM_ACTIVATE - ActivationState = %d\n", ActivationState);
+
+    GuiData->IsWindowActive = ActivationState != WA_INACTIVE;
 
     if ( ActivationState == WA_ACTIVE ||
          ActivationState == WA_CLICKACTIVE )
@@ -1324,8 +1327,11 @@ OnTimer(PGUI_CONSOLE_DATA GuiData)
     if (GetType(Buff) == TEXTMODE_BUFFER)
     {
         /* Repaint the caret */
-        InvalidateCell(GuiData, Buff->CursorPosition.X, Buff->CursorPosition.Y);
-        Buff->CursorBlinkOn = !Buff->CursorBlinkOn;
+        if (GuiData->IsWindowActive || Buff->CursorBlinkOn)
+        {
+            InvalidateCell(GuiData, Buff->CursorPosition.X, Buff->CursorPosition.Y);
+        }
+        Buff->CursorBlinkOn = GuiData->IsWindowActive ? !Buff->CursorBlinkOn : FALSE;
 
         if ((GuiData->OldCursor.x != Buff->CursorPosition.X) ||
             (GuiData->OldCursor.y != Buff->CursorPosition.Y))

--- a/win32ss/user/winsrv/consrv/frontends/gui/conwnd.c
+++ b/win32ss/user/winsrv/consrv/frontends/gui/conwnd.c
@@ -1330,8 +1330,8 @@ OnTimer(PGUI_CONSOLE_DATA GuiData)
         if (GuiData->IsWindowActive || Buff->CursorBlinkOn)
         {
             InvalidateCell(GuiData, Buff->CursorPosition.X, Buff->CursorPosition.Y);
+            Buff->CursorBlinkOn = !Buff->CursorBlinkOn;
         }
-        Buff->CursorBlinkOn = GuiData->IsWindowActive ? !Buff->CursorBlinkOn : FALSE;
 
         if ((GuiData->OldCursor.x != Buff->CursorPosition.X) ||
             (GuiData->OldCursor.y != Buff->CursorPosition.Y))

--- a/win32ss/user/winsrv/consrv/frontends/gui/conwnd.c
+++ b/win32ss/user/winsrv/consrv/frontends/gui/conwnd.c
@@ -726,7 +726,7 @@ OnActivate(PGUI_CONSOLE_DATA GuiData, WPARAM wParam)
 
     DPRINT("WM_ACTIVATE - ActivationState = %d\n", ActivationState);
 
-    GuiData->IsWindowActive = ActivationState != WA_INACTIVE;
+    GuiData->IsWindowActive = (ActivationState != WA_INACTIVE);
 
     if ( ActivationState == WA_ACTIVE ||
          ActivationState == WA_CLICKACTIVE )

--- a/win32ss/user/winsrv/consrv/frontends/gui/conwnd.h
+++ b/win32ss/user/winsrv/consrv/frontends/gui/conwnd.h
@@ -50,6 +50,7 @@ typedef struct _GUI_CONSOLE_DATA
     HDESK   Desktop;
 
     BOOLEAN IsWindowVisible;
+    BOOLEAN IsWindowActive;
 
     POINT OldCursor;
 


### PR DESCRIPTION
The cursor is not supposed to blink if the console window is not active.

Ideally the blink timer would be turned completely off when the window is inactive but that would require the hack in `GuiWriteStream` to change to a `PostMessage` with a private message?  The scrolling code that uses the same timer would also need changes if scrolling is possible when the window is not active.

A compromise would perhaps be to set the timer to a larger value when the window is not active? `4 * CURSOR_BLINK_TIME`?