### PR TITLE
[DXGTHK] Fix EngCreateBitmap exported parameters

### DIFF
--- a/win32ss/reactx/dxgthk/dxgthk.spec
+++ b/win32ss/reactx/dxgthk/dxgthk.spec
@@ -2,7 +2,7 @@
 @ stdcall EngAllocMem(long long long) win32k.EngAllocMem
 @ stdcall EngAllocUserMem(long long) win32k.EngAllocUserMem
 @ stdcall EngCopyBits(ptr ptr ptr ptr ptr ptr) win32k.EngCopyBits
-@ stdcall EngCreateBitmap(long long long long ptr) win32k.EngCreateBitmap
+@ stdcall EngCreateBitmap(long long long long long ptr) win32k.EngCreateBitmap
 @ stdcall EngCreatePalette(long long long long long long) win32k.EngCreatePalette
 @ stdcall EngCreateSemaphore() win32k.EngCreateSemaphore
 @ stdcall EngDeletePalette(ptr) win32k.EngDeletePalette


### PR DESCRIPTION
## Purpose

Use two longs instead of one for the first parameter of `EngCreateBitmap` export. Make it same as win32k export. MSDN documentation says that 1st parameter is `SIZEL` (`SIZE`) structure, which actually contains 2 longs inside. Sice it is passed by value, it needs to take enough memory when export in dxgthk and redirect to win32k (since it's actually a win32k function).
Fixes the compilation of our dxg.sys when calling dxgthk!`EngCreateBitmap` from it. Found during my DirectX investigations.
Small addendum to #5604 PR.

JIRA issue: None