### PR TITLE
[DXGTHK] Export DriverEntry

### DIFF
--- a/win32ss/reactx/dxgthk/dxgthk.spec
+++ b/win32ss/reactx/dxgthk/dxgthk.spec
@@ -1,3 +1,4 @@
+@ stdcall DriverEntry(ptr ptr)
 @ stdcall EngAcquireSemaphore(ptr) win32k.EngAcquireSemaphore
 @ stdcall EngAllocMem(long long long) win32k.EngAllocMem
 @ stdcall EngAllocUserMem(long long) win32k.EngAllocUserMem


### PR DESCRIPTION
## Purpose

Export driver entry point function `DriverEntry` from our dxgthk.sys. It does not improve anything so much, it just mimics Windows behaviour. Just do it the same in ReactOS as it's done in Windows. Confirmed that it is exported on Windows XP SP3 at least. See attached screenshot. :slightly_smiling_face: 
Small addendum to #5604 PR.

![dxgthk_xp](https://github.com/reactos/reactos/assets/26385117/589b6d28-5722-4f72-9965-5e5c65f2516c)

JIRA issue: None