### PR TITLE
[NTOS:SE] Let SepGetSidFromAce figure out the ACE type

### DIFF
--- a/ntoskrnl/include/internal/se.h
+++ b/ntoskrnl/include/internal/se.h
@@ -634,7 +634,6 @@ SepSidInTokenEx(
 PSID
 NTAPI
 SepGetSidFromAce(
-    _In_ UCHAR AceType,
     _In_ PACE Ace);
 
 NTSTATUS

--- a/ntoskrnl/se/accesschk.c
+++ b/ntoskrnl/se/accesschk.c
@@ -517,7 +517,7 @@ SepAnalyzeAcesFromDacl(
                     if (CurrentAce->Header.AceType == ACCESS_DENIED_ACE_TYPE)
                     {
                         /* Get the SID from this ACE */
-                        Sid = SepGetSidFromAce(ACCESS_DENIED_ACE_TYPE, CurrentAce);
+                        Sid = SepGetSidFromAce(CurrentAce);
                         ASSERT(Sid);
 
                         if (SepSidInTokenEx(AccessToken, PrincipalSelfSid, Sid, TRUE, IsTokenRestricted))
@@ -539,7 +539,7 @@ SepAnalyzeAcesFromDacl(
                     else if (CurrentAce->Header.AceType == ACCESS_ALLOWED_ACE_TYPE)
                     {
                         /* Get the SID from this ACE */
-                        Sid = SepGetSidFromAce(ACCESS_ALLOWED_ACE_TYPE, CurrentAce);
+                        Sid = SepGetSidFromAce(CurrentAce);
                         ASSERT(Sid);
 
                         if (SepSidInTokenEx(AccessToken, PrincipalSelfSid, Sid, FALSE, IsTokenRestricted))
@@ -561,7 +561,7 @@ SepAnalyzeAcesFromDacl(
                     else if (CurrentAce->Header.AceType == ACCESS_DENIED_OBJECT_ACE_TYPE)
                     {
                         /* Get the SID and object type from this ACE */
-                        Sid = SepGetSidFromAce(ACCESS_DENIED_OBJECT_ACE_TYPE, CurrentAce);
+                        Sid = SepGetSidFromAce(CurrentAce);
                         ObjectTypeGuid = SepGetObjectTypeGuidFromAce(CurrentAce, TRUE);
                         ASSERT(Sid);
 
@@ -610,7 +610,7 @@ SepAnalyzeAcesFromDacl(
                     else if (CurrentAce->Header.AceType == ACCESS_ALLOWED_OBJECT_ACE_TYPE)
                     {
                         /* Get the SID and object type from this ACE */
-                        Sid = SepGetSidFromAce(ACCESS_ALLOWED_OBJECT_ACE_TYPE, CurrentAce);
+                        Sid = SepGetSidFromAce(CurrentAce);
                         ObjectTypeGuid = SepGetObjectTypeGuidFromAce(CurrentAce, FALSE);
                         ASSERT(Sid);
 
@@ -705,7 +705,7 @@ SepAnalyzeAcesFromDacl(
                     if (CurrentAce->Header.AceType == ACCESS_DENIED_ACE_TYPE)
                     {
                         /* Get the SID from this ACE */
-                        Sid = SepGetSidFromAce(ACCESS_DENIED_ACE_TYPE, CurrentAce);
+                        Sid = SepGetSidFromAce(CurrentAce);
                         ASSERT(Sid);
 
                         if (SepSidInTokenEx(AccessToken, PrincipalSelfSid, Sid, TRUE, IsTokenRestricted))
@@ -735,7 +735,7 @@ SepAnalyzeAcesFromDacl(
                     else if (CurrentAce->Header.AceType == ACCESS_ALLOWED_ACE_TYPE)
                     {
                         /* Get the SID from this ACE */
-                        Sid = SepGetSidFromAce(ACCESS_ALLOWED_ACE_TYPE, CurrentAce);
+                        Sid = SepGetSidFromAce(CurrentAce);
                         ASSERT(Sid);
 
                         if (SepSidInTokenEx(AccessToken, PrincipalSelfSid, Sid, FALSE, IsTokenRestricted))
@@ -761,7 +761,7 @@ SepAnalyzeAcesFromDacl(
                     else if (CurrentAce->Header.AceType == ACCESS_DENIED_OBJECT_ACE_TYPE)
                     {
                         /* Get the SID and object type from this ACE */
-                        Sid = SepGetSidFromAce(ACCESS_DENIED_OBJECT_ACE_TYPE, CurrentAce);
+                        Sid = SepGetSidFromAce(CurrentAce);
                         ObjectTypeGuid = SepGetObjectTypeGuidFromAce(CurrentAce, TRUE);
                         ASSERT(Sid);
 
@@ -811,7 +811,7 @@ SepAnalyzeAcesFromDacl(
                     else if (CurrentAce->Header.AceType == ACCESS_ALLOWED_OBJECT_ACE_TYPE)
                     {
                         /* Get the SID and object type from this ACE */
-                        Sid = SepGetSidFromAce(ACCESS_ALLOWED_OBJECT_ACE_TYPE, CurrentAce);
+                        Sid = SepGetSidFromAce(CurrentAce);
                         ObjectTypeGuid = SepGetObjectTypeGuidFromAce(CurrentAce, FALSE);
                         ASSERT(Sid);
 

--- a/ntoskrnl/se/debug.c
+++ b/ntoskrnl/se/debug.c
@@ -118,7 +118,7 @@ SepDumpAces(
         DbgPrint("Ace->Header.AceType -> %s\n", SepGetAceTypeString(Ace->Header.AceType));
         DbgPrint("Ace->AccessMask -> 0x%08lx\n", Ace->AccessMask);
 
-        Sid = SepGetSidFromAce(Ace->Header.AceType, Ace);
+        Sid = SepGetSidFromAce(Ace);
         ASSERT(Sid);
         RtlConvertSidToUnicodeString(&SidString, Sid, TRUE);
         DbgPrint("Ace SID -> %wZ\n", &SidString);

--- a/ntoskrnl/se/sid.c
+++ b/ntoskrnl/se/sid.c
@@ -558,13 +558,6 @@ SepSidInToken(
  * given access control entry. This identifier
  * is valid for the whole of its lifetime.
  *
- * @param[in] AceType
- * The type of an access control entry. This
- * type that is given by the calling thread
- * must coincide with the actual ACE that is
- * given in the second parameter otherwise this
- * can potentially lead to UNDEFINED behavior!
- *
  * @param[in] Ace
  * A pointer to an access control entry, which
  * can be obtained from a DACL.
@@ -577,7 +570,6 @@ SepSidInToken(
 PSID
 NTAPI
 SepGetSidFromAce(
-    _In_ UCHAR AceType,
     _In_ PACE Ace)
 {
     PULONG Flags;
@@ -589,7 +581,7 @@ SepGetSidFromAce(
     ASSERT(Ace);
 
     /* Obtain the SID based upon ACE type */
-    switch (AceType)
+    switch (Ace->Header.AceType)
     {
         case ACCESS_DENIED_ACE_TYPE:
         case ACCESS_ALLOWED_ACE_TYPE:
@@ -620,7 +612,7 @@ SepGetSidFromAce(
 
         default:
         {
-            DPRINT1("SepGetSidFromAce(): Unknown ACE type (Ace 0x%p, Type %u)\n", Ace, AceType);
+            DPRINT1("SepGetSidFromAce(): Unknown ACE type (Ace 0x%p, Type %u)\n", Ace, Ace->Header.AceType);
             break;
         }
     }


### PR DESCRIPTION
As the commit title says. Instead of having the caller figuring out what the ACE type should be of the ACE.