### PR TITLE
[WS2_32_WINETEST] Patch ws2_32:sock wine test to run on ReactOS

### DIFF
--- a/modules/rostests/winetests/ws2_32/sock.c
+++ b/modules/rostests/winetests/ws2_32/sock.c
@@ -7010,11 +7010,11 @@ static void test_write_watch(void)
     base = VirtualAlloc( 0, size, MEM_RESERVE | MEM_COMMIT | MEM_WRITE_WATCH, PAGE_READWRITE );
     ok( base != NULL, "VirtualAlloc failed %u\n", GetLastError() );
 
-#ifdef __REACTOS__  /* ROSTESTS-385 */
+#ifdef __REACTOS__
     if (!base)
     {
-        /* MEM_WRITE_WATCH is not supported yet in ReactOS */
-        win_skip( "VirtualAlloc not supported\n" );
+        skip("VirtualAlloc(MEM_WRITE_WATCH) is not supported yet on ReactOS\n");
+        skip("Skipping tests due to hang. See ROSTESTS-385\n");
         return;
     }
 #endif
@@ -8021,7 +8021,6 @@ static void test_getaddrinfo(void)
     }
 }
 
-#ifndef __REACTOS__    /* ROSTESTS-385 */
 static void test_ConnectEx(void)
 {
     SOCKET listener = INVALID_SOCKET;
@@ -8836,7 +8835,6 @@ static void test_DisconnectEx(void)
     closesocket(connector);
     closesocket(listener);
 }
-#endif // ifndef __REACTOS__   /* ROSTESTS-385 */
 
 #define compare_file(h,s,o) compare_file2(h,s,o,__FILE__,__LINE__)
 
@@ -11632,8 +11630,20 @@ START_TEST( sock )
     test_GetAddrInfoExW();
     test_getaddrinfo();
 
-#ifndef __REACTOS__    /* ROSTESTS-385 */
-    /* UNIMPLEMENTED in ReactOS See dll/win32/msafd/misc/stubs.c */
+#ifdef __REACTOS__
+    if (!winetest_interactive)
+    {
+        skip("WSPAcceptEx(), WSPConnectEx() and WSPDisconnectEx() are UNIMPLEMENTED on ReactOS\n");
+        skip("Skipping tests due to hang. See ROSTESTS-385\n");
+    }
+    else
+    {
+        /* UNIMPLEMENTED in ReactOS See dll/win32/msafd/misc/stubs.c */
+        test_AcceptEx();
+        test_ConnectEx();
+        test_DisconnectEx();
+    }
+#else
     test_AcceptEx();
     test_ConnectEx();
     test_DisconnectEx();

--- a/modules/rostests/winetests/ws2_32/sock.c
+++ b/modules/rostests/winetests/ws2_32/sock.c
@@ -7010,6 +7010,15 @@ static void test_write_watch(void)
     base = VirtualAlloc( 0, size, MEM_RESERVE | MEM_COMMIT | MEM_WRITE_WATCH, PAGE_READWRITE );
     ok( base != NULL, "VirtualAlloc failed %u\n", GetLastError() );
 
+#ifdef __REACTOS__  /* ROSTESTS-385 */
+    if (!base)
+    {
+        /* MEM_WRITE_WATCH is not supported yet in ReactOS */
+        win_skip( "VirtualAlloc not supported\n" );
+        return;
+    }
+#endif
+
     memset( base, 0, size );
     count = 64;
     ret = pGetWriteWatch( WRITE_WATCH_FLAG_RESET, base, size, results, &count, &pagesize );
@@ -8012,6 +8021,7 @@ static void test_getaddrinfo(void)
     }
 }
 
+#ifndef __REACTOS__    /* ROSTESTS-385 */
 static void test_ConnectEx(void)
 {
     SOCKET listener = INVALID_SOCKET;
@@ -8826,6 +8836,7 @@ static void test_DisconnectEx(void)
     closesocket(connector);
     closesocket(listener);
 }
+#endif // ifndef __REACTOS__   /* ROSTESTS-385 */
 
 #define compare_file(h,s,o) compare_file2(h,s,o,__FILE__,__LINE__)
 
@@ -11620,9 +11631,13 @@ START_TEST( sock )
     test_GetAddrInfoW();
     test_GetAddrInfoExW();
     test_getaddrinfo();
+
+#ifndef __REACTOS__    /* ROSTESTS-385 */
+    /* UNIMPLEMENTED in ReactOS See dll/win32/msafd/misc/stubs.c */
     test_AcceptEx();
     test_ConnectEx();
     test_DisconnectEx();
+#endif
 
     test_sioRoutingInterfaceQuery();
     test_sioAddressListChange();

--- a/modules/rostests/winetests/ws2_32/sock.c
+++ b/modules/rostests/winetests/ws2_32/sock.c
@@ -11638,15 +11638,12 @@ START_TEST( sock )
     }
     else
     {
-        /* UNIMPLEMENTED in ReactOS See dll/win32/msafd/misc/stubs.c */
-        test_AcceptEx();
-        test_ConnectEx();
-        test_DisconnectEx();
-    }
-#else
+#endif
     test_AcceptEx();
     test_ConnectEx();
     test_DisconnectEx();
+#ifdef __REACTOS__
+    }
 #endif
 
     test_sioRoutingInterfaceQuery();


### PR DESCRIPTION
## Purpose

_Disable ReactOS specific tests which are not implemented yet._

JIRA issue: [ROSTESTS-385](https://jira.reactos.org/browse/ROSTESTS-385)

## Proposed changes

_Bypass part of test that uses MEM_WRITE_WATCH._
_Bypass three tests that are unimplemented: 1) WSPAcceptEx, 2) WSPConnectEx, and 3) WSPDisconnectEx_

Testbot results:
winetest_ws2_32_fix_05.patch JID66261 on top of 0.4.15-dev-6526-g8d35887

VBox: https://reactos.org/testman/compare.php?ids=89111,89117 LGTM
KVM:  https://reactos.org/testman/compare.php?ids=89110,89118 LGTM