### PR TITLE
[SHLWAPI][SHLWAPI_APITEST][SDK] Implement SHGetPerScreenResName

### DIFF
--- a/dll/win32/shlwapi/propbag.cpp
+++ b/dll/win32/shlwapi/propbag.cpp
@@ -1814,7 +1814,7 @@ EXTERN_C VOID FreeViewStatePropertyBagCache(VOID)
  */
 INT WINAPI
 SHGetPerScreenResName(
-    _Out_writes_z_(cchBuffer) LPWSTR pszBuffer,
+    _Out_writes_(cchBuffer) LPWSTR pszBuffer,
     _In_ INT cchBuffer,
     _In_ DWORD dwReserved)
 {

--- a/dll/win32/shlwapi/propbag.cpp
+++ b/dll/win32/shlwapi/propbag.cpp
@@ -1806,3 +1806,30 @@ EXTERN_C VOID FreeViewStatePropertyBagCache(VOID)
     g_pCachedBag.Release();
     ::LeaveCriticalSection(&g_csBagCacheLock);
 }
+
+/**************************************************************************
+ *  SHGetPerScreenResName (SHLWAPI.533)
+ *
+ * @see https://www.geoffchappell.com/studies/windows/shell/shlwapi/api/propbag/getperscreenresname.htm
+ */
+INT WINAPI
+SHGetPerScreenResName(
+    _Out_writes_z_(cchBuffer) LPWSTR pszBuffer,
+    _In_ INT cchBuffer,
+    _In_ DWORD dwReserved)
+{
+    if (dwReserved)
+        return 0;
+
+    HDC hDC = ::GetDC(NULL);
+    INT cxWidth = ::GetDeviceCaps(hDC, HORZRES);
+    INT cyHeight = ::GetDeviceCaps(hDC, VERTRES);
+    ::ReleaseDC(NULL, hDC);
+
+    INT cMonitors = ::GetSystemMetrics(SM_CMONITORS);
+    INT ret = wnsprintfW(pszBuffer, cchBuffer, L"%dx%d(%d)", cxWidth, cyHeight, cMonitors);
+    if (ret < 0)
+        ret = 0;
+
+    return ret;
+}

--- a/dll/win32/shlwapi/propbag.cpp
+++ b/dll/win32/shlwapi/propbag.cpp
@@ -1821,11 +1821,8 @@ SHGetPerScreenResName(
     if (dwReserved)
         return 0;
 
-    HDC hDC = ::GetDC(NULL);
-    INT cxWidth = ::GetDeviceCaps(hDC, HORZRES);
-    INT cyHeight = ::GetDeviceCaps(hDC, VERTRES);
-    ::ReleaseDC(NULL, hDC);
-
+    INT cxWidth = ::GetSystemMetrics(SM_CXFULLSCREEN);
+    INT cyHeight = ::GetSystemMetrics(SM_CYFULLSCREEN);
     INT cMonitors = ::GetSystemMetrics(SM_CMONITORS);
     INT ret = wnsprintfW(pszBuffer, cchBuffer, L"%dx%d(%d)", cxWidth, cyHeight, cMonitors);
     if (ret < 0)

--- a/dll/win32/shlwapi/propbag.cpp
+++ b/dll/win32/shlwapi/propbag.cpp
@@ -13,6 +13,7 @@
 #include <atlsimpcoll.h>    // for CSimpleMap
 #include <atlcomcli.h>      // for CComVariant
 #include <atlconv.h>        // for CA2W and CW2A
+#include <strsafe.h>        // for StringC... functions
 
 WINE_DEFAULT_DEBUG_CHANNEL(shell);
 
@@ -1824,9 +1825,6 @@ SHGetPerScreenResName(
     INT cxWidth = ::GetSystemMetrics(SM_CXFULLSCREEN);
     INT cyHeight = ::GetSystemMetrics(SM_CYFULLSCREEN);
     INT cMonitors = ::GetSystemMetrics(SM_CMONITORS);
-    INT ret = wnsprintfW(pszBuffer, cchBuffer, L"%dx%d(%d)", cxWidth, cyHeight, cMonitors);
-    if (ret < 0)
-        ret = 0;
-
-    return ret;
+    StringCchPrintfW(pszBuffer, cchBuffer, L"%dx%d(%d)", cxWidth, cyHeight, cMonitors);
+    return lstrlenW(pszBuffer);
 }

--- a/dll/win32/shlwapi/shlwapi.spec
+++ b/dll/win32/shlwapi/shlwapi.spec
@@ -530,7 +530,7 @@
 530 stdcall -noname SHPropertyBag_WriteInt(ptr wstr long) SHPropertyBag_WriteLONG
 531 stdcall -noname SHPropertyBag_ReadStream(ptr wstr ptr)
 532 stdcall -noname SHPropertyBag_WriteStream(ptr wstr ptr)
-533 stub -noname SHGetPerScreenResName
+533 stdcall -noname SHGetPerScreenResName(ptr long long)
 534 stdcall -noname SHPropertyBag_ReadBOOL(ptr wstr ptr)
 535 stdcall -noname SHPropertyBag_Delete(ptr wstr)
 536 stdcall -stub -noname IUnknown_QueryServicePropertyBag(ptr long ptr ptr)

--- a/modules/rostests/apitests/shlwapi/SHPropertyBag.cpp
+++ b/modules/rostests/apitests/shlwapi/SHPropertyBag.cpp
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include <shlwapi_undoc.h>
 #include <versionhelpers.h>
+#include <strsafe.h>
 
 #include <pseh/pseh2.h>
 
@@ -826,9 +827,9 @@ static void SHPropertyBag_OnIniFile(void)
 static void SHPropertyBag_PerScreenRes(void)
 {
     WCHAR szBuff1[64], szBuff2[64];
-    wsprintfW(szBuff1, L"%dx%d(%d)",
-              GetSystemMetrics(SM_CXSCREEN), GetSystemMetrics(SM_CYSCREEN),
-              GetSystemMetrics(SM_CMONITORS));
+    StringCchPrintfW(szBuff1, _countof(szBuff1), L"%dx%d(%d)",
+                     GetSystemMetrics(SM_CXFULLSCREEN), GetSystemMetrics(SM_CYFULLSCREEN),
+                     GetSystemMetrics(SM_CMONITORS));
 
     szBuff2[0] = UNICODE_NULL;
     SHGetPerScreenResName(szBuff2, _countof(szBuff2), 0);

--- a/modules/rostests/apitests/shlwapi/SHPropertyBag.cpp
+++ b/modules/rostests/apitests/shlwapi/SHPropertyBag.cpp
@@ -688,7 +688,7 @@ static void SHPropertyBag_SHSetIniStringW(void)
     DeleteFileW(szIniFile);
 }
 
-void SHPropertyBag_OnIniFile(void)
+static void SHPropertyBag_OnIniFile(void)
 {
     WCHAR szIniFile[MAX_PATH], szValue[MAX_PATH];
     HRESULT hr;
@@ -823,6 +823,18 @@ void SHPropertyBag_OnIniFile(void)
     DeleteFileW(szIniFile);
 }
 
+static void SHPropertyBag_PerScreenRes(void)
+{
+    WCHAR szBuff1[64], szBuff2[64];
+    wsprintfW(szBuff1, L"%dx%d(%d)",
+              GetSystemMetrics(SM_CXSCREEN), GetSystemMetrics(SM_CYSCREEN),
+              GetSystemMetrics(SM_CMONITORS));
+
+    szBuff2[0] = UNICODE_NULL;
+    SHGetPerScreenResName(szBuff2, _countof(szBuff2), 0);
+    ok_wstr(szBuff1, szBuff2);
+}
+
 START_TEST(SHPropertyBag)
 {
     SHPropertyBag_ReadTest();
@@ -831,4 +843,5 @@ START_TEST(SHPropertyBag)
     SHPropertyBag_OnRegKey();
     SHPropertyBag_SHSetIniStringW();
     SHPropertyBag_OnIniFile();
+    SHPropertyBag_PerScreenRes();
 }

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -108,9 +108,11 @@ HRESULT WINAPI SHPropertyBag_ReadRECTL(IPropertyBag *ppb, LPCWSTR pszPropName, R
 HRESULT WINAPI SHPropertyBag_ReadGUID(IPropertyBag *ppb, LPCWSTR pszPropName, GUID *pguid);
 HRESULT WINAPI SHPropertyBag_ReadStream(IPropertyBag *ppb, LPCWSTR pszPropName, IStream **ppStream);
 
-HRESULT WINAPI SHGetPerScreenResName(OUT LPWSTR lpResName,
-                                     IN INT cchResName,
-                                     IN DWORD dwReserved);
+INT WINAPI
+SHGetPerScreenResName(
+    _Out_writes_z_(cchBuffer) LPWSTR pszBuffer,
+    _In_ INT cchBuffer,
+    _In_ DWORD dwReserved);
 
 HRESULT WINAPI SHPropertyBag_Delete(IPropertyBag *ppb, LPCWSTR pszPropName);
 HRESULT WINAPI SHPropertyBag_WriteBOOL(IPropertyBag *ppb, LPCWSTR pszPropName, BOOL bValue);

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -110,7 +110,7 @@ HRESULT WINAPI SHPropertyBag_ReadStream(IPropertyBag *ppb, LPCWSTR pszPropName, 
 
 INT WINAPI
 SHGetPerScreenResName(
-    _Out_writes_z_(cchBuffer) LPWSTR pszBuffer,
+    _Out_writes_(cchBuffer) LPWSTR pszBuffer,
     _In_ INT cchBuffer,
     _In_ DWORD dwReserved);
 


### PR DESCRIPTION
## Purpose

Implementing missing features...
JIRA issue: [CORE-9283](https://jira.reactos.org/browse/CORE-9283)

## Proposed changes

- Implement `SHGetPerScreenResName` function.
- Modify `shlwapi.spec` and `<shlwapi_undoc.h>`.
- Add some tests to `SHPropertyBag` testcase of `shlwapi_apitest.exe`.

## Comparison

WinXP:
![WinXP](https://github.com/reactos/reactos/assets/2107452/80f58e08-f66b-4511-ada5-37771fb3eb51)
Successful.

Win2k3:
![Win2k3](https://github.com/reactos/reactos/assets/2107452/50ec2a6a-c4fc-409a-84f5-24b06f6519b0)
Successful.

Win10:
![Win10](https://github.com/reactos/reactos/assets/2107452/52322d3a-f253-4bb2-8b13-afbdd8acbb72)
Successful.