### PR TITLE
[RAPPS] Improve existing window re-use

### DIFF
--- a/base/applications/rapps/unattended.cpp
+++ b/base/applications/rapps/unattended.cpp
@@ -269,6 +269,10 @@ ParseCmdAndExecute(LPWSTR lpCmdLine, BOOL bIsFirstLaunch, int nCmdShow)
                 SwitchToThisWindow(hWindow, TRUE);
                 if (bAppwizMode)
                     PostMessage(hWindow, WM_COMMAND, ID_ACTIVATE_APPWIZ, 0);
+
+                if (hMutex)
+                    CloseHandle(hMutex);
+
                 return FALSE;
             }
         }

--- a/base/applications/rapps/unattended.cpp
+++ b/base/applications/rapps/unattended.cpp
@@ -253,15 +253,20 @@ ParseCmdAndExecute(LPWSTR lpCmdLine, BOOL bIsFirstLaunch, int nCmdShow)
         hMutex = CreateMutexW(NULL, FALSE, szWindowClass);
         if ((!hMutex) || (GetLastError() == ERROR_ALREADY_EXISTS))
         {
-            /* If already started, find its window */
-            HWND hWindow = FindWindowW(szWindowClass, NULL);
+           /* If already started, find its window */
+            HWND hWindow;
+            for (int wait = 2500, inter = 250; wait > 0; wait -= inter)
+                if ((hWindow = FindWindowW(szWindowClass, NULL)) != 0)
+                    break;
+                else
+                    Sleep(inter);
 
-            /* Activate window */
-            ShowWindow(hWindow, SW_SHOWNORMAL);
-            SetForegroundWindow(hWindow);
+            /* Activate the window in the other instance */
+            SwitchToThisWindow(hWindow, TRUE);
             if (bAppwizMode)
                 PostMessage(hWindow, WM_COMMAND, ID_ACTIVATE_APPWIZ, 0);
-            return FALSE;
+            if (hWindow)
+                return FALSE;
         }
 
         CMainWindow wnd(&db, bAppwizMode);

--- a/base/applications/rapps/unattended.cpp
+++ b/base/applications/rapps/unattended.cpp
@@ -253,20 +253,24 @@ ParseCmdAndExecute(LPWSTR lpCmdLine, BOOL bIsFirstLaunch, int nCmdShow)
         hMutex = CreateMutexW(NULL, FALSE, szWindowClass);
         if ((!hMutex) || (GetLastError() == ERROR_ALREADY_EXISTS))
         {
-           /* If already started, find its window */
+            /* If already started, find its window */
             HWND hWindow;
             for (int wait = 2500, inter = 250; wait > 0; wait -= inter)
-                if ((hWindow = FindWindowW(szWindowClass, NULL)) != 0)
+            {
+                if ((hWindow = FindWindowW(szWindowClass, NULL)) != NULL)
                     break;
                 else
                     Sleep(inter);
+            }
 
-            /* Activate the window in the other instance */
-            SwitchToThisWindow(hWindow, TRUE);
-            if (bAppwizMode)
-                PostMessage(hWindow, WM_COMMAND, ID_ACTIVATE_APPWIZ, 0);
             if (hWindow)
+            {
+                /* Activate the window in the other instance */
+                SwitchToThisWindow(hWindow, TRUE);
+                if (bAppwizMode)
+                    PostMessage(hWindow, WM_COMMAND, ID_ACTIVATE_APPWIZ, 0);
                 return FALSE;
+            }
         }
 
         CMainWindow wnd(&db, bAppwizMode);

--- a/base/applications/rapps/unattended.cpp
+++ b/base/applications/rapps/unattended.cpp
@@ -259,8 +259,7 @@ ParseCmdAndExecute(LPWSTR lpCmdLine, BOOL bIsFirstLaunch, int nCmdShow)
             {
                 if ((hWindow = FindWindowW(szWindowClass, NULL)) != NULL)
                     break;
-                else
-                    Sleep(inter);
+                Sleep(inter);
             }
 
             if (hWindow)


### PR DESCRIPTION
 - There is a small race between `CreateMutex` and `CMainWindow` creating the window, another instance might get `NULL` in its `FindWindow`. This PR retries multiple times and if the window does not appear within a reasonable, it starts another instance.
- If the existing window is minimized, it should be restored. If the existing window is maximized, it should **not** be "normalized". `SwitchToThisWindow` does all this in addition to calling `SetForegroundWindow`.