### PR TITLE
[SHELL32] Add two missing GlobalUnlock() calls

### DIFF
--- a/dll/win32/shell32/droptargets/CRecyclerDropTarget.cpp
+++ b/dll/win32/shell32/droptargets/CRecyclerDropTarget.cpp
@@ -46,6 +46,7 @@ class CRecyclerDropTarget :
             if (!lpdf)
             {
                 ERR("Error locking global\n");
+                ReleaseStgMedium(&medium);
                 return E_FAIL;
             }
 

--- a/dll/win32/shell32/droptargets/CRecyclerDropTarget.cpp
+++ b/dll/win32/shell32/droptargets/CRecyclerDropTarget.cpp
@@ -65,6 +65,7 @@ class CRecyclerDropTarget :
                 hr = E_FAIL;
             }
 
+            GlobalUnlock(medium.hGlobal);
             ReleaseStgMedium(&medium);
 
             return hr;

--- a/dll/win32/shell32/droptargets/CexeDropHandler.cpp
+++ b/dll/win32/shell32/droptargets/CexeDropHandler.cpp
@@ -84,6 +84,9 @@ HRESULT WINAPI CExeDropHandler::Drop(IDataObject *pDataObject, DWORD dwKeyState,
 
             pszSrcList += wcslen(pszSrcList) + 1;
         }
+
+        GlobalUnlock(medium.hGlobal);
+        ReleaseStgMedium(&medium);
     }
 
     ShellExecuteW(NULL, L"open", sPathTarget, wszBuf, NULL,SW_SHOWNORMAL);

--- a/dll/win32/shell32/droptargets/CexeDropHandler.cpp
+++ b/dll/win32/shell32/droptargets/CexeDropHandler.cpp
@@ -72,6 +72,7 @@ HRESULT WINAPI CExeDropHandler::Drop(IDataObject *pDataObject, DWORD dwKeyState,
         if (!lpdf)
         {
             ERR("Error locking global\n");
+            ReleaseStgMedium(&medium);
             return E_FAIL;
         }
         pszSrcList = (LPWSTR) (((byte*) lpdf) + lpdf->pFiles);


### PR DESCRIPTION
## Purpose

Plug an (apparent) memory leak.

## Proposed changes

Add missing `GlobalUnlock()` calls to balance `GlobalLock()`.