### PR TITLE
[COMCTL32] Fix Property Sheet initial position

### DIFF
--- a/dll/win32/comctl32/propsheet.c
+++ b/dll/win32/comctl32/propsheet.c
@@ -3633,7 +3633,7 @@ PROPSHEET_DialogProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
               HMONITOR hMonitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
               if (GetMonitorInfo(hMonitor, &mi))
               {
-                  /* Try to fit it into the desktop */
+                  /* Try to fit it onto the desktop */
                   if (mi.rcWork.right < rcInit.left + dx)
                       rcInit.left = mi.rcWork.right - dx;
                   if (mi.rcWork.bottom < rcInit.top + dy)

--- a/dll/win32/comctl32/propsheet.c
+++ b/dll/win32/comctl32/propsheet.c
@@ -3597,7 +3597,7 @@ PROPSHEET_DialogProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
               WINDOWPLACEMENT wndpl = { sizeof(wndpl) };
               bMove = TRUE;
 
-              /* hwndParent might be minimized (See Control_ShowAppletInTaskbar).
+              /* hwndParent can be minimized (See Control_ShowAppletInTaskbar).
                  Use normal position. */
               GetWindowPlacement(hwndParent, &wndpl);
               rcInit = wndpl.rcNormalPosition;

--- a/dll/win32/comctl32/propsheet.c
+++ b/dll/win32/comctl32/propsheet.c
@@ -3615,7 +3615,7 @@ PROPSHEET_DialogProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
           else
           {
               /* We cannot foresee CW_USEDEFAULT's posision without communicating with USER32.
-                 Use a top-level STATIC control creation to get the proper position. */
+                 Use a top-level STATIC control to get the proper position. */
               HWND hwndDummy = CreateWindowExW(0, L"STATIC", NULL, 0,
                                                CW_USEDEFAULT, CW_USEDEFAULT, dx, dy,
                                                NULL, NULL, GetModuleHandleW(NULL), NULL);

--- a/dll/win32/comctl32/propsheet.c
+++ b/dll/win32/comctl32/propsheet.c
@@ -3616,7 +3616,7 @@ PROPSHEET_DialogProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
           {
               /* We cannot foresee CW_USEDEFAULT's position without communicating with USER32.
                  Use a top-level STATIC control to get the proper position. */
-              HWND hwndDummy = CreateWindowExW(0, L"STATIC", NULL, 0,
+              HWND hwndDummy = CreateWindowExW(0, WC_STATICW, NULL, 0,
                                                CW_USEDEFAULT, CW_USEDEFAULT, dx, dy,
                                                NULL, NULL, GetModuleHandleW(NULL), NULL);
               if (hwndDummy)

--- a/dll/win32/comctl32/propsheet.c
+++ b/dll/win32/comctl32/propsheet.c
@@ -3587,7 +3587,6 @@ PROPSHEET_DialogProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
           RECT rcInit;
           HWND hwndParent = psInfo->ppshheader.hwndParent;
           BOOL bMove = FALSE;
-          WINDOWPLACEMENT wndpl = { sizeof(wndpl) };
 
           GetWindowRect(hwnd, &rcInit);
           dx = rcInit.right - rcInit.left;
@@ -3595,7 +3594,9 @@ PROPSHEET_DialogProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
           if (IsWindow(hwndParent))
           {
+              WINDOWPLACEMENT wndpl = { sizeof(wndpl) };
               bMove = TRUE;
+
               /* hwndParent might be minimized (See Control_ShowAppletInTaskbar).
                  Use normal position. */
               GetWindowPlacement(hwndParent, &wndpl);

--- a/dll/win32/comctl32/propsheet.c
+++ b/dll/win32/comctl32/propsheet.c
@@ -3614,7 +3614,7 @@ PROPSHEET_DialogProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
           }
           else
           {
-              /* We cannot foresee CW_USEDEFAULT's posision without communicating with USER32.
+              /* We cannot foresee CW_USEDEFAULT's position without communicating with USER32.
                  Use a top-level STATIC control to get the proper position. */
               HWND hwndDummy = CreateWindowExW(0, L"STATIC", NULL, 0,
                                                CW_USEDEFAULT, CW_USEDEFAULT, dx, dy,


### PR DESCRIPTION
## Purpose

Fix the initial position of the property sheet dialog.
JIRA issue: [CORE-19141](https://jira.reactos.org/browse/CORE-19141)
## Proposed changes

- On `WM_INITDIALOG` handling of the property sheet dialog procedure, move the dialog if necessary.

## TODO

- [x] Do small tests.

## Comparison

Win2k3:
https://github.com/reactos/reactos/assets/2107452/1fc973e8-4f17-47c1-b961-48efc66cbbfd

BEFORE:
https://github.com/reactos/reactos/assets/2107452/afd1ef52-56c0-4b6b-a714-fa1875fab399

AFTER:
https://github.com/reactos/reactos/assets/2107452/bc350650-1cd2-4c24-8fee-94db08e4584e
