### PR TITLE
[BROWSEUI][SDK] Half-implement CShellBrowser::GetPropertyBag

### DIFF
--- a/dll/win32/browseui/shellbrowser.cpp
+++ b/dll/win32/browseui/shellbrowser.cpp
@@ -351,7 +351,6 @@ public:
     void UpdateGotoMenu(HMENU theMenu);
     void UpdateViewMenu(HMENU theMenu);
     void LoadCabinetState();
-    static BOOL _DoesPidlRoam(LPCITEMIDLIST pidl);
 
 /*    // *** IDockingWindowFrame methods ***
     virtual HRESULT STDMETHODCALLTYPE AddToolbar(IUnknown *punkSrc, LPCWSTR pwszItem, DWORD dwAddFlags);
@@ -2388,7 +2387,7 @@ HRESULT STDMETHODCALLTYPE CShellBrowser::QueryService(REFGUID guidService, REFII
     return E_NOINTERFACE;
 }
 
-BOOL CShellBrowser::_DoesPidlRoam(LPCITEMIDLIST pidl)
+static BOOL _ILIsNetworkPlace(LPCITEMIDLIST pidl)
 {
     WCHAR szPath[MAX_PATH];
     return SHGetPathFromIDListWrapW(pidl, szPath) && PathIsUNCW(szPath);
@@ -2408,7 +2407,7 @@ HRESULT STDMETHODCALLTYPE CShellBrowser::GetPropertyBag(long flags, REFIID riid,
 
     // FIXME: pidl for Internet etc.
 
-    if (_DoesPidlRoam(pidl))
+    if (_ILIsNetworkPlace(pidl))
         flags |= SHGVSPB_ROAM;
 
     hr = SHGetViewStatePropertyBag(pidl, L"Shell", flags, riid, ppvObject);

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -263,6 +263,7 @@ BOOL WINAPI PathFileExistsDefExtW(LPWSTR lpszPath, DWORD dwWhich);
 BOOL WINAPI PathFindOnPathExW(LPWSTR lpszFile, LPCWSTR *lppszOtherDirs, DWORD dwWhich);
 VOID WINAPI FixSlashesAndColonW(LPWSTR);
 BOOL WINAPI PathIsValidCharW(WCHAR c, DWORD dwClass);
+BOOL WINAPI SHGetPathFromIDListWrapW(LPCITEMIDLIST pidl, LPWSTR pszPath);
 
 #ifdef __cplusplus
 } /* extern "C" */


### PR DESCRIPTION
## Purpose
Implementing missing features...
JIRA issue: [CORE-9283](https://jira.reactos.org/browse/CORE-9283)

## Proposed changes

- Add `_ILIsNetworkPlace` helper function.
- Implement `CShellBrowser::GetPropertyBag` function a little by using `SHGetViewStatePropertyBag`.
- Add `SHGetPathFromIDListWrapW` prototype to `<shlwapi_undoc.h>`.