### PR TITLE
[I8042PRT] Do not try to flush controller's input buffer

### DIFF
--- a/drivers/input/i8042prt/readwrite.c
+++ b/drivers/input/i8042prt/readwrite.c
@@ -28,12 +28,6 @@ i8042Flush(
 		KeStallExecutionProcessor(50);
 		TRACE_(I8042PRT, "Output data flushed\n");
 	}
-
-	/* Flush input buffer */
-	while (NT_SUCCESS(i8042ReadData(DeviceExtension, KBD_IBF, &Ignore))) {
-		KeStallExecutionProcessor(50);
-		TRACE_(I8042PRT, "Input data flushed\n");
-	}
 }
 
 BOOLEAN


### PR DESCRIPTION
Do not try to flush controller's input buffer - in fact, current code will try to flush very same controller's output port that above in code, but looking to wrong status flag

As I googled about i8042 - it seems that OS has no way flush controller's input buffer. And I found that linux happy with just flushing controller's output buffer: 
https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/input/serio/i8042.c?h=v6.4.13#n263


