### PR TITLE
[WINLOGON] Prevent LocalSystem from logging off

### DIFF
--- a/base/system/winlogon/CMakeLists.txt
+++ b/base/system/winlogon/CMakeLists.txt
@@ -1,3 +1,6 @@
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+    add_compile_options(-Wno-missing-braces)
+endif()
 
 include_directories(
     ${REACTOS_SOURCE_DIR}/sdk/include/reactos/idl

--- a/base/system/winlogon/CMakeLists.txt
+++ b/base/system/winlogon/CMakeLists.txt
@@ -1,6 +1,3 @@
-if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
-    add_compile_options(-Wno-missing-braces)
-endif()
 
 include_directories(
     ${REACTOS_SOURCE_DIR}/sdk/include/reactos/idl

--- a/base/system/winlogon/sas.c
+++ b/base/system/winlogon/sas.c
@@ -1015,18 +1015,19 @@ HandleShutdown(
     return STATUS_SUCCESS;
 }
 
+static
 BOOL
-IsLocalSystem(HANDLE UserToken)
+IsLocalSystem(_In_ HANDLE UserToken)
 {
     BOOL IsLocalSystem;
-    SID_IDENTIFIER_AUTHORITY NtAuthority = SECURITY_NT_AUTHORITY;
+    SID_IDENTIFIER_AUTHORITY NtAuthority = { SECURITY_NT_AUTHORITY };
     PSID pLocalSystemSID;
 
     IsLocalSystem = AllocateAndInitializeSid(&NtAuthority,
                                              1, SECURITY_LOCAL_SYSTEM_RID,
                                              0, 0, 0, 0, 0, 0, 0,
                                              &pLocalSystemSID);
-    if(IsLocalSystem)
+    if (IsLocalSystem)
     {
         if (!CheckTokenMembership(UserToken, pLocalSystemSID, &IsLocalSystem))
             IsLocalSystem = FALSE;


### PR DESCRIPTION
## Purpose

Prevents the LocalSystem account (SYSTEM) from logging off. This seems to match the behavior of Windows Server 2003 and prevents an issue where it is possible to log out of the live CD and be unable to log back in.

JIRA issue: [CORE-11397](https://jira.reactos.org/browse/CORE-11397)

## Proposed changes

- When attempting to log out, check if the current user token is `NULL`. If it is `NULL`, skip the logout process and attempt to shutdown if the user requested to shutdown. When logged in as the `SYSTEM` pseudo account, the user token is `NULL`.

## Testing and comparing against Windows Server 2003

- To test Windows' behavior in this scenario, you can use the famous `sethc.exe` exploit in Windows to launch explorer as `LocalSystem` on the log on screen. Trying to log off fails silently, whether it is done through `logoff.exe` or the start menu. Trying to shut down or restart does succeed however.

- After setting up the sethc.exe exploit, you can also use our GINA on Windows Server 2003 to test for GINA discrepancies. To do so create a new string registry value in `HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon` called `GinaDLL`. Set this value to the path of a copy of our GINA (I set mine to `C:\rosgina.dll`). You will not be able to log in to any account since our GINA is incomplete, but you can still access explorer if you set up the sethc.exe exploit earlier. To revert, you can rename or delete the registry value.

## TODO (in future PRs)

- Remove the log off entry in the start menu on the Live CD.