### PR TITLE
[WIN32SS:ENG] Fix parameter to MmMapViewOfSection

### DIFF
--- a/ntoskrnl/mm/ARM3/procsup.c
+++ b/ntoskrnl/mm/ARM3/procsup.c
@@ -1110,7 +1110,7 @@ MmInitializeProcessAddressSpace(IN PEPROCESS Process,
                                     0,
                                     NULL,
                                     &ViewSize,
-                                    0,
+                                    ViewUnmap,
                                     MEM_COMMIT,
                                     PAGE_READWRITE);
 

--- a/win32ss/gdi/eng/mapping.c
+++ b/win32ss/gdi/eng/mapping.c
@@ -207,7 +207,7 @@ EngMapSection(
                                     pSection->cjViewSize,
                                     NULL,
                                     &pSection->cjViewSize,
-                                    0,
+                                    ViewUnmap,
                                     0,
                                     PAGE_READWRITE);
         if (!NT_SUCCESS(Status))


### PR DESCRIPTION
## Purpose

Fix a call to MmMapViewOfSection. It was passing 0 instead of SECTION_INHERIT ::ViewUnmap (2). 0 isn't even a proper constant to be used here. It worked, because MmMapViewOfSection only compares against ViewShare (1) and treats everything else as ViewUnmap.
