### PR TITLE
[MSVCRT] Officially implement _localtime32{,_s}

### DIFF
--- a/dll/apisets/api-ms-win-crt-time-l1-1-0.spec
+++ b/dll/apisets/api-ms-win-crt-time-l1-1-0.spec
@@ -37,7 +37,7 @@
 @ cdecl _localtime32 msvcrt._localtime32
 @ cdecl _localtime32_s msvcrt._localtime32_s
 @ cdecl _localtime64() msvcrt._localtime64
-@ stub _localtime64_s
+@ cdecl _localtime64_s() msvcrt._localtime64_s
 @ stub _mkgmtime32
 @ stdcall _mkgmtime64() msvcrt._mkgmtime64
 @ stub _mktime32

--- a/dll/apisets/api-ms-win-crt-time-l1-1-0.spec
+++ b/dll/apisets/api-ms-win-crt-time-l1-1-0.spec
@@ -36,7 +36,7 @@
 @ stub _gmtime64_s
 @ cdecl _localtime32 msvcrt._localtime32
 @ cdecl _localtime32_s msvcrt._localtime32_s
-@ stdcall _localtime64() msvcrt._localtime64
+@ cdecl _localtime64() msvcrt._localtime64
 @ stub _localtime64_s
 @ stub _mkgmtime32
 @ stdcall _mkgmtime64() msvcrt._mkgmtime64

--- a/dll/apisets/api-ms-win-crt-time-l1-1-0.spec
+++ b/dll/apisets/api-ms-win-crt-time-l1-1-0.spec
@@ -34,8 +34,8 @@
 @ stub _gmtime32_s
 @ stdcall _gmtime64() msvcrt._gmtime64
 @ stub _gmtime64_s
-@ stub _localtime32
-@ stub _localtime32_s
+@ cdecl _localtime32 msvcrt._localtime32
+@ cdecl _localtime32_s msvcrt._localtime32_s
 @ stdcall _localtime64() msvcrt._localtime64
 @ stub _localtime64_s
 @ stub _mkgmtime32

--- a/dll/apisets/api-ms-win-crt-time-l1-1-0.spec
+++ b/dll/apisets/api-ms-win-crt-time-l1-1-0.spec
@@ -34,8 +34,8 @@
 @ stub _gmtime32_s
 @ stdcall _gmtime64() msvcrt._gmtime64
 @ stub _gmtime64_s
-@ cdecl _localtime32 msvcrt._localtime32
-@ cdecl _localtime32_s msvcrt._localtime32_s
+@ cdecl _localtime32() msvcrt._localtime32
+@ cdecl _localtime32_s() msvcrt._localtime32_s
 @ cdecl _localtime64() msvcrt._localtime64
 @ cdecl _localtime64_s() msvcrt._localtime64_s
 @ stub _mkgmtime32

--- a/dll/apisets/api-ms-win-crt-time-l1-1-0.spec
+++ b/dll/apisets/api-ms-win-crt-time-l1-1-0.spec
@@ -34,10 +34,10 @@
 @ stub _gmtime32_s
 @ stdcall _gmtime64() msvcrt._gmtime64
 @ stub _gmtime64_s
-@ cdecl _localtime32() msvcrt._localtime32
-@ cdecl _localtime32_s() msvcrt._localtime32_s
+@ cdecl -version=0x600+ _localtime32() msvcrt._localtime32
+@ cdecl -version=0x600+ _localtime32_s() msvcrt._localtime32_s
 @ cdecl _localtime64() msvcrt._localtime64
-@ cdecl _localtime64_s() msvcrt._localtime64_s
+@ cdecl -version=0x600+ _localtime64_s() msvcrt._localtime64_s
 @ stub _mkgmtime32
 @ stdcall _mkgmtime64() msvcrt._mkgmtime64
 @ stub _mktime32

--- a/dll/win32/msvcrt/msvcrt.spec
+++ b/dll/win32/msvcrt/msvcrt.spec
@@ -710,8 +710,8 @@
 @ cdecl -arch=x86_64 _local_unwind(ptr ptr)
 @ cdecl -arch=i386 _local_unwind2(ptr long)
 @ cdecl -arch=i386 -version=0x600+ _local_unwind4(ptr ptr long)
-@ stub -version=0x600+ _localtime32
-@ stub -version=0x600+ _localtime32_s
+@ cdecl -version=0x600+ _localtime32(ptr)
+@ cdecl -version=0x600+ _localtime32_s(ptr ptr)
 @ cdecl _localtime64(ptr)
 @ cdecl -version=0x600+ _localtime64_s(ptr ptr)
 @ cdecl _lock(long)


### PR DESCRIPTION
## Purpose

These two functions are implemented in our CRT, but still listed as stubs in the spec file. This function came up when I was unsuccessfully trying to get my VM’s guest tools running on ReactOS. (I am a Mac user, so I cannot use VirtualBox. I use an app called [UTM](https://getutm.app/), which is a variant on QEMU.)

## Proposed changes

- Remove stub notation for `localtime32` and `localtime32_s` symbols in msvcrt.spec.