### PR TITLE
[NOTEPAD] Use StringCchPrintf instead of _stprintf etc.

### DIFF
--- a/base/applications/notepad/dialog.c
+++ b/base/applications/notepad/dialog.c
@@ -164,7 +164,7 @@ int DIALOG_StringMsgBox(HWND hParent, int formatId, LPCTSTR szString, DWORD dwFl
 
     /* Load and format szMessage */
     LoadString(Globals.hInstance, formatId, szResource, _countof(szResource));
-    _sntprintf(szMessage, _countof(szMessage), szResource, szString);
+    StringCchPrintf(szMessage, _countof(szMessage), szResource, szString);
 
     /* Load szCaption */
     if ((dwFlags & MB_ICONMASK) == MB_ICONEXCLAMATION)
@@ -880,7 +880,7 @@ VOID DIALOG_StatusBarUpdateCaretPos(VOID)
     line = SendMessage(Globals.hEdit, EM_LINEFROMCHAR, (WPARAM)dwStart, 0);
     col = dwStart - SendMessage(Globals.hEdit, EM_LINEINDEX, (WPARAM)line, 0);
 
-    _stprintf(buff, Globals.szStatusBarLineCol, line + 1, col + 1);
+    StringCchPrintf(buff, _countof(buff), Globals.szStatusBarLineCol, line + 1, col + 1);
     SendMessage(Globals.hStatusBar, SB_SETTEXT, SBPART_CURPOS, (LPARAM)buff);
 }
 

--- a/base/applications/notepad/main.c
+++ b/base/applications/notepad/main.c
@@ -202,7 +202,7 @@ BOOL NOTEPAD_FindNext(FINDREPLACE *pFindReplace, BOOL bReplace, BOOL bShowAlert)
         if (bShowAlert)
         {
             LoadString(Globals.hInstance, STRING_CANNOTFIND, szResource, _countof(szResource));
-            _sntprintf(szText, _countof(szText), szResource, pFindReplace->lpstrFindWhat);
+            StringCchPrintf(szText, _countof(szText), szResource, pFindReplace->lpstrFindWhat);
             LoadString(Globals.hInstance, STRING_NOTEPAD, szResource, _countof(szResource));
             MessageBox(Globals.hFindReplaceDlg, szText, szResource, MB_OK);
         }


### PR DESCRIPTION
## Purpose

Use preferred string functions.
JIRA issue: [CORE-18837](https://jira.reactos.org/browse/CORE-18837)

## Proposed changes

- Use `<strsafe.h>`'s `StringCchPrintf` function instead of `_sntprintf` and `_stprintf`.

## TODO

- [x] Do build.
- [x] Do small test.