### PR TITLE
[NOTEPAD] Do type cast to kill C4244 warnings

### DIFF
--- a/base/applications/notepad/dialog.c
+++ b/base/applications/notepad/dialog.c
@@ -865,6 +865,10 @@ VOID DIALOG_GoTo(VOID)
     else
         ich = (INT)SendMessage(Globals.hEdit, EM_LINEINDEX, GotoData.iLine, 0);
 
+    /* EM_LINEINDEX can return -1 on failure */
+    if (ich < 0)
+        ich = 0;
+
     /* Move the caret */
     SendMessage(Globals.hEdit, EM_SETSEL, ich, ich);
     SendMessage(Globals.hEdit, EM_SCROLLCARET, 0, 0);
@@ -872,13 +876,16 @@ VOID DIALOG_GoTo(VOID)
 
 VOID DIALOG_StatusBarUpdateCaretPos(VOID)
 {
-    int line, col;
+    int line, ich, col;
     TCHAR buff[MAX_PATH];
     DWORD dwStart, dwSize;
 
     SendMessage(Globals.hEdit, EM_GETSEL, (WPARAM)&dwStart, (LPARAM)&dwSize);
     line = SendMessage(Globals.hEdit, EM_LINEFROMCHAR, (WPARAM)dwStart, 0);
-    col = dwStart - SendMessage(Globals.hEdit, EM_LINEINDEX, (WPARAM)line, 0);
+    ich = (int)SendMessage(Globals.hEdit, EM_LINEINDEX, (WPARAM)line, 0);
+
+    /* EM_LINEINDEX can return -1 on failure */
+    col = ((ich < 0) ? 0 : (dwStart - ich));
 
     StringCchPrintf(buff, _countof(buff), Globals.szStatusBarLineCol, line + 1, col + 1);
     SendMessage(Globals.hStatusBar, SB_SETTEXT, SBPART_CURPOS, (LPARAM)buff);

--- a/base/applications/notepad/main.c
+++ b/base/applications/notepad/main.c
@@ -270,6 +270,7 @@ static VOID NOTEPAD_InitData(HINSTANCE hInstance)
  */
 static VOID NOTEPAD_InitMenuPopup(HMENU menu, LPARAM index)
 {
+    DWORD dwStart, dwEnd;
     int enable;
 
     UNREFERENCED_PARAMETER(index);
@@ -280,8 +281,8 @@ static VOID NOTEPAD_InitMenuPopup(HMENU menu, LPARAM index)
         SendMessage(Globals.hEdit, EM_CANUNDO, 0, 0) ? MF_ENABLED : MF_GRAYED);
     EnableMenuItem(menu, CMD_PASTE,
         IsClipboardFormatAvailable(CF_TEXT) ? MF_ENABLED : MF_GRAYED);
-    enable = (int) SendMessage(Globals.hEdit, EM_GETSEL, 0, 0);
-    enable = (HIWORD(enable) == LOWORD(enable)) ? MF_GRAYED : MF_ENABLED;
+    SendMessage(Globals.hEdit, EM_GETSEL, (WPARAM)&dwStart, (LPARAM)&dwEnd);
+    enable = ((dwStart == dwEnd) ? MF_GRAYED : MF_ENABLED);
     EnableMenuItem(menu, CMD_CUT, enable);
     EnableMenuItem(menu, CMD_COPY, enable);
     EnableMenuItem(menu, CMD_DELETE, enable);


### PR DESCRIPTION
## Purpose

![無題](https://github.com/reactos/reactos/assets/2107452/01bbc091-3efa-48d8-9377-952e70cdddfe)

JIRA issue: [CORE-18837](https://jira.reactos.org/browse/CORE-18837)

## Proposed changes

- Do type cast to `int` from `SendMessage` return value.
- Fix usage of `EM_GETSEL` and `EM_LINEINDEX` messages.

## TODO

- [x] Do build.
- [x] Do small tests.
