### PR TITLE
[WINHTTP_WINETEST] Skip using wine_dbgstr_wn when returned text length is zero

### DIFF
--- a/modules/rostests/winetests/winhttp/winhttp.c
+++ b/modules/rostests/winetests/winhttp/winhttp.c
@@ -4276,12 +4276,9 @@ static void test_IWinHttpRequest(int port)
 
     hr = IWinHttpRequest_get_ResponseText( req, &response );
     ok( hr == S_OK, "got %08x\n", hr );
-#if __REACTOS__
-    if (SysStringByteLen(response)) // Returned non-zero length response
-        ok( !memcmp(response, data_start, sizeof(data_start)), "got %s\n",
-            wine_dbgstr_wn(response, min(SysStringByteLen(response) / sizeof(WCHAR), 32)) );
-    else
-        ok(FALSE, "got zero (0) length response\n");
+#ifdef __REACTOS__
+    ok( !memcmp(response, data_start, sizeof(data_start)), "got %s\n",
+        wine_dbgstr_wn(response, min(SysStringLen(response), 32)) );
 #else
     ok( !memcmp(response, data_start, sizeof(data_start)), "got %s\n", wine_dbgstr_wn(response, 32) );
 #endif

--- a/modules/rostests/winetests/winhttp/winhttp.c
+++ b/modules/rostests/winetests/winhttp/winhttp.c
@@ -4282,7 +4282,6 @@ static void test_IWinHttpRequest(int port)
 #else
     ok( !memcmp(response, data_start, sizeof(data_start)), "got %s\n", wine_dbgstr_wn(response, 32) );
 #endif
-
     SysFreeString( response );
 
     IWinHttpRequest_Release( req );

--- a/modules/rostests/winetests/winhttp/winhttp.c
+++ b/modules/rostests/winetests/winhttp/winhttp.c
@@ -4278,7 +4278,8 @@ static void test_IWinHttpRequest(int port)
     ok( hr == S_OK, "got %08x\n", hr );
 #if __REACTOS__
     if (SysStringByteLen(response)) // Returned non-zero length response
-        ok( !memcmp(response, data_start, sizeof(data_start)), "got %s\n", wine_dbgstr_wn(response, 32) );
+        ok( !memcmp(response, data_start, sizeof(data_start)), "got %s\n",
+            wine_dbgstr_wn(response, min(SysStringByteLen(response) / sizeof(WCHAR), 32)) );
     else
         ok(FALSE, "got zero (0) length response\n");
 #else

--- a/modules/rostests/winetests/winhttp/winhttp.c
+++ b/modules/rostests/winetests/winhttp/winhttp.c
@@ -4276,7 +4276,15 @@ static void test_IWinHttpRequest(int port)
 
     hr = IWinHttpRequest_get_ResponseText( req, &response );
     ok( hr == S_OK, "got %08x\n", hr );
+#if __REACTOS__
+    if (SysStringByteLen(response)) // Returned non-zero length response
+        ok( !memcmp(response, data_start, sizeof(data_start)), "got %s\n", wine_dbgstr_wn(response, 32) );
+    else
+        ok(FALSE, "got zero (0) length response\n");
+#else
     ok( !memcmp(response, data_start, sizeof(data_start)), "got %s\n", wine_dbgstr_wn(response, 32) );
+#endif
+
     SysFreeString( response );
 
     IWinHttpRequest_Release( req );


### PR DESCRIPTION
## Purpose

_On receiving a zero length response, do not try to print returned text using wine_dbgstr_wn._

JIRA issue: [ROSTESTS-377](https://jira.reactos.org/browse/ROSTESTS-377)

## Proposed changes

_Check for zero length text returned and skip trying to print unmatched received text returned._
