### PR TITLE
[ATL][ATL_APITEST] Independent ReactOS ATL (RATL) support

### DIFF
--- a/modules/rostests/apitests/atl/CComObject.cpp
+++ b/modules/rostests/apitests/atl/CComObject.cpp
@@ -63,7 +63,7 @@ public:
     END_COM_MAP()
 };
 
-#ifndef __RATL__ // Avoid confliction of CAtlExeModuleT
+#ifndef __RATL__ // Avoid conflict (causing assertion at CAtlModule::CAtlModule)
 class CDumExe: public CAtlExeModuleT<CDumExe>
 {
 

--- a/modules/rostests/apitests/atl/CComObject.cpp
+++ b/modules/rostests/apitests/atl/CComObject.cpp
@@ -63,13 +63,13 @@ public:
     END_COM_MAP()
 };
 
-
+#ifndef __RATL__ // Avoid confliction of CAtlExeModuleT
 class CDumExe: public CAtlExeModuleT<CDumExe>
 {
 
 };
 CDumExe dum;
-
+#endif
 
 START_TEST(CComObject)
 {

--- a/modules/rostests/apitests/atl/CComQIPtr.cpp
+++ b/modules/rostests/apitests/atl/CComQIPtr.cpp
@@ -80,6 +80,8 @@ public:
 #define DECLARE_QIPTR(type)     CComQIIDPtr<I_ID(type)>
 #elif defined(__GNUC__)
 #define DECLARE_QIPTR(type)     CComQIIDPtr<I_ID(type)>
+#elif defined(__RATL__)
+#define DECLARE_QIPTR(type)     CComQIIDPtr<I_ID(type)>
 #else
 #define DECLARE_QIPTR(type)     CComQIPtr<type>
 #endif

--- a/sdk/lib/atl/atlsimpstr.h
+++ b/sdk/lib/atl/atlsimpstr.h
@@ -6,6 +6,12 @@
 #include <atlcore.h>
 #include <atlexcept.h>
 
+#ifdef __RATL__
+    #ifndef _In_count_
+        #define _In_count_(nLength)
+    #endif
+#endif
+
 namespace ATL
 {
 struct CStringData;

--- a/sdk/lib/atl/atlwin.h
+++ b/sdk/lib/atl/atlwin.h
@@ -49,6 +49,12 @@ inline LONG_PTR GetWindowLongPtr(HWND hWnd, int nIndex)
 #pragma push_macro("SubclassWindow")
 #undef SubclassWindow
 
+#ifdef __RATL__
+    #ifndef _Post_z_
+        #define _Post_z_
+    #endif
+#endif
+
 namespace ATL
 {
 


### PR DESCRIPTION
## Purpose

This is an attempt to make ReactOS ATL (RATL) independent.
If RATL got independent, then MSPAINT and RAPPS will be also able to be independent.
It will improve interoperability and compatibility, and gain user feedbacks ([like this](https://github.com/katahiromz/RNotepad/issues/1)).
See also: https://github.com/katahiromz/RATL

JIRA issue: [CORE-19153](https://jira.reactos.org/browse/CORE-19153)


## Proposed changes

- Avoid conflict of `CAtlExeModuleT` when `__RATL__` is defined.
- Add workaround of `DECLARE_QIPTR` when `__RATL__` is defined.
- Add workaround of `_In_count_` and `_Post_z_` when `__RATL__` is defined.
- No actual code change unless `__RATL__` is defined.

## TODO

- [x] ATL sample codes.
- [x] Independent ReactOS Paint.