### PR TITLE
[NTOS:MM] Add locking around MmLocateMemoryAreaByAddress

### DIFF
--- a/ntoskrnl/mm/ARM3/virtual.c
+++ b/ntoskrnl/mm/ARM3/virtual.c
@@ -2226,16 +2226,19 @@ MiProtectVirtualMemory(IN PEPROCESS Process,
     }
 
     /* Check for ROS specific memory area */
+    MmLockAddressSpace(&Process->Vm);
     MemoryArea = MmLocateMemoryAreaByAddress(&Process->Vm, *BaseAddress);
     if ((MemoryArea) && (MemoryArea->Type != MEMORY_AREA_OWNED_BY_ARM3))
     {
         /* Evil hack */
+        MmUnlockAddressSpace(&Process->Vm);
         return MiRosProtectVirtualMemory(Process,
                                          BaseAddress,
                                          NumberOfBytesToProtect,
                                          NewAccessProtection,
                                          OldAccessProtection);
     }
+    MmUnlockAddressSpace(&Process->Vm);
 
     /* Lock the address space and make sure the process isn't already dead */
     AddressSpace = MmGetCurrentAddressSpace();

--- a/ntoskrnl/mm/ARM3/virtual.c
+++ b/ntoskrnl/mm/ARM3/virtual.c
@@ -2226,19 +2226,19 @@ MiProtectVirtualMemory(IN PEPROCESS Process,
     }
 
     /* Check for ROS specific memory area */
-//    MmLockAddressSpace(&Process->Vm);
+    MmLockAddressSpace(&Process->Vm);
     MemoryArea = MmLocateMemoryAreaByAddress(&Process->Vm, *BaseAddress);
     if ((MemoryArea) && (MemoryArea->Type != MEMORY_AREA_OWNED_BY_ARM3))
     {
         /* Evil hack */
-//        MmUnlockAddressSpace(&Process->Vm);
+        MmUnlockAddressSpace(&Process->Vm);
         return MiRosProtectVirtualMemory(Process,
                                          BaseAddress,
                                          NumberOfBytesToProtect,
                                          NewAccessProtection,
                                          OldAccessProtection);
     }
-//    MmUnlockAddressSpace(&Process->Vm);
+    MmUnlockAddressSpace(&Process->Vm);
 
     /* Lock the address space and make sure the process isn't already dead */
     AddressSpace = MmGetCurrentAddressSpace();

--- a/ntoskrnl/mm/ARM3/virtual.c
+++ b/ntoskrnl/mm/ARM3/virtual.c
@@ -2226,19 +2226,19 @@ MiProtectVirtualMemory(IN PEPROCESS Process,
     }
 
     /* Check for ROS specific memory area */
-    MmLockAddressSpace(&Process->Vm);
+//    MmLockAddressSpace(&Process->Vm);
     MemoryArea = MmLocateMemoryAreaByAddress(&Process->Vm, *BaseAddress);
     if ((MemoryArea) && (MemoryArea->Type != MEMORY_AREA_OWNED_BY_ARM3))
     {
         /* Evil hack */
-        MmUnlockAddressSpace(&Process->Vm);
+//        MmUnlockAddressSpace(&Process->Vm);
         return MiRosProtectVirtualMemory(Process,
                                          BaseAddress,
                                          NumberOfBytesToProtect,
                                          NewAccessProtection,
                                          OldAccessProtection);
     }
-    MmUnlockAddressSpace(&Process->Vm);
+//    MmUnlockAddressSpace(&Process->Vm);
 
     /* Lock the address space and make sure the process isn't already dead */
     AddressSpace = MmGetCurrentAddressSpace();

--- a/ntoskrnl/mm/marea.c
+++ b/ntoskrnl/mm/marea.c
@@ -72,6 +72,9 @@ MmLocateMemoryAreaByAddress(
     Process = MmGetAddressSpaceOwner(AddressSpace);
     Table = (Process != NULL) ? &Process->VadRoot : &MiRosKernelVadRoot;
 
+    if (Process == NULL)
+        ASSERT(PsIdleProcess->AddressCreationLock.Owner == KeGetCurrentThread());
+
     Result = MiCheckForConflictingNode(StartVpn, StartVpn, Table, &Node);
     if (Result != TableFoundNode)
     {

--- a/ntoskrnl/mm/marea.c
+++ b/ntoskrnl/mm/marea.c
@@ -72,8 +72,8 @@ MmLocateMemoryAreaByAddress(
     Process = MmGetAddressSpaceOwner(AddressSpace);
     Table = (Process != NULL) ? &Process->VadRoot : &MiRosKernelVadRoot;
 
-    if (Process == NULL)
-        ASSERT(PsIdleProcess->AddressCreationLock.Owner == KeGetCurrentThread());
+//    if (Process == NULL)
+//        ASSERT(PsIdleProcess->AddressCreationLock.Owner == KeGetCurrentThread());
 
     Result = MiCheckForConflictingNode(StartVpn, StartVpn, Table, &Node);
     if (Result != TableFoundNode)

--- a/ntoskrnl/mm/marea.c
+++ b/ntoskrnl/mm/marea.c
@@ -72,8 +72,8 @@ MmLocateMemoryAreaByAddress(
     Process = MmGetAddressSpaceOwner(AddressSpace);
     Table = (Process != NULL) ? &Process->VadRoot : &MiRosKernelVadRoot;
 
-//    if (Process == NULL)
-//        ASSERT(PsIdleProcess->AddressCreationLock.Owner == KeGetCurrentThread());
+    if (Process == NULL)
+        ASSERT(PsIdleProcess->AddressCreationLock.Owner == KeGetCurrentThread());
 
     Result = MiCheckForConflictingNode(StartVpn, StartVpn, Table, &Node);
     if (Result != TableFoundNode)

--- a/ntoskrnl/mm/marea.c
+++ b/ntoskrnl/mm/marea.c
@@ -74,6 +74,8 @@ MmLocateMemoryAreaByAddress(
 
     if (Process == NULL)
         ASSERT(PsIdleProcess->AddressCreationLock.Owner == KeGetCurrentThread());
+    else
+        ASSERT(Process->AddressCreationLock.Owner == KeGetCurrentThread());
 
     Result = MiCheckForConflictingNode(StartVpn, StartVpn, Table, &Node);
     if (Result != TableFoundNode)

--- a/ntoskrnl/mm/mmfault.c
+++ b/ntoskrnl/mm/mmfault.c
@@ -246,9 +246,9 @@ MmAccessFault(IN ULONG FaultCode,
         if (!(MemoryArea) && (Address <= MM_HIGHEST_USER_ADDRESS))
         {
             /* Could this be a VAD fault from user-mode? */
-            MmLockAddressSpace(MmGetCurrentAddressSpace());
+//            MmLockAddressSpace(MmGetCurrentAddressSpace());
             MemoryArea = MmLocateMemoryAreaByAddress(MmGetCurrentAddressSpace(), Address);
-            MmUnlockAddressSpace(MmGetCurrentAddressSpace());
+//            MmUnlockAddressSpace(MmGetCurrentAddressSpace());
         }
     }
 

--- a/ntoskrnl/mm/mmfault.c
+++ b/ntoskrnl/mm/mmfault.c
@@ -246,7 +246,9 @@ MmAccessFault(IN ULONG FaultCode,
         if (!(MemoryArea) && (Address <= MM_HIGHEST_USER_ADDRESS))
         {
             /* Could this be a VAD fault from user-mode? */
+            MmLockAddressSpace(MmGetCurrentAddressSpace());
             MemoryArea = MmLocateMemoryAreaByAddress(MmGetCurrentAddressSpace(), Address);
+            MmUnlockAddressSpace(MmGetCurrentAddressSpace());
         }
     }
 

--- a/ntoskrnl/mm/mmfault.c
+++ b/ntoskrnl/mm/mmfault.c
@@ -239,7 +239,10 @@ MmAccessFault(IN ULONG FaultCode,
     if (MmGetKernelAddressSpace())
     {
         /* Check if this is an ARM3 memory area */
+        ASSERT(KeGetCurrentIrql() < DISPATCH_LEVEL);
+        MmLockAddressSpace(MmGetKernelAddressSpace());
         MemoryArea = MmLocateMemoryAreaByAddress(MmGetKernelAddressSpace(), Address);
+        MmUnlockAddressSpace(MmGetKernelAddressSpace());
         if (!(MemoryArea) && (Address <= MM_HIGHEST_USER_ADDRESS))
         {
             /* Could this be a VAD fault from user-mode? */

--- a/ntoskrnl/mm/mmfault.c
+++ b/ntoskrnl/mm/mmfault.c
@@ -246,9 +246,9 @@ MmAccessFault(IN ULONG FaultCode,
         if (!(MemoryArea) && (Address <= MM_HIGHEST_USER_ADDRESS))
         {
             /* Could this be a VAD fault from user-mode? */
-//            MmLockAddressSpace(MmGetCurrentAddressSpace());
+            MmLockAddressSpace(MmGetCurrentAddressSpace());
             MemoryArea = MmLocateMemoryAreaByAddress(MmGetCurrentAddressSpace(), Address);
-//            MmUnlockAddressSpace(MmGetCurrentAddressSpace());
+            MmUnlockAddressSpace(MmGetCurrentAddressSpace());
         }
     }
 


### PR DESCRIPTION
## Purpose

_Improve locking for MmLocateMemoryAreaByAddress._

JIRA issue: [CORE-18519](https://jira.reactos.org/browse/CORE-18519) (fixed already after the 1st commit in here)

## Proposed changes
```
Try to improve compiling ReactOS on ReactOS after receiving the below on MSVC build:
nt!MiCheckForConflictingNode+0x8b:
804f1ccb 3b5110          cmp     edx,dword ptr [ecx+10h]
kd> g
Access violation - code c0000005 (!!! second chance !!!)
nt!MiCheckForConflictingNode+0x8b:
804f1ccb 3b5110          cmp     edx,dword ptr [ecx+10h]
kd> k
 # ChildEBP RetAddr  
00 f6b60ca8 80502a36 nt!MiCheckForConflictingNode+0x8b [d:\reacto\reactos\ntoskrnl\mm\arm3\vadnode.c @ 96]
01 f6b60cec 80502c8a nt!MmLocateMemoryAreaByAddress+0x66 [d:\reacto\reactos\ntoskrnl\mm\marea.c @ 75]
02 f6b60d10 80565c8a nt!MmAccessFault+0x8a [d:\reacto\reactos\ntoskrnl\mm\mmfault.c @ 242]
03 f6b60d5c 804036fe nt!KiTrap0EHandler+0x13a [d:\reacto\reactos\ntoskrnl\ke\i386\traphdlr.c @ 1369]
04 f6b60d5c 7c93e90f nt!KiTrap0E+0x99
05 0245f554 7c93dfa4 ntdll!RtlpFindAndCommitPages+0x5bf [d:\reacto\reactos\sdk\lib\rtl\heap.c @ 814]
06 0245f5c0 7c93cc8b ntdll!RtlpExtendHeap+0x84 [d:\reacto\reactos\sdk\lib\rtl\heap.c @ 1279]
07 0245f650 7c9399eb ntdll!RtlpAllocateNonDedicated+0x8b [d:\reacto\reactos\sdk\lib\rtl\heap.c @ 1971]
08 0245f744 7c5c2364 ntdll!RtlAllocateHeap+0x2eb [d:\reacto\reactos\sdk\lib\rtl\heap.c @ 2132]
09 0245f764 7c5c22a8 msvcrt!msvcrt_heap_alloc+0x84 [d:\reacto\reactos\sdk\lib\crt\wine\heap.c @ 93]
*** WARNING: Unable to verify timestamp for cc1.exe
*** ERROR: Module load completed but symbols could not be loaded for cc1.exe
```
Note: The associated Jira ticket has been updated.