### PR TITLE
[NOTEPAD] Use wait cursor

### DIFF
--- a/base/applications/notepad/dialog.c
+++ b/base/applications/notepad/dialog.c
@@ -113,7 +113,7 @@ void UpdateWindowCaption(BOOL clearModifyAlert)
 
 VOID WaitCursor(BOOL bBegin)
 {
-    HCURSOR s_hOldCursor;
+    static HCURSOR s_hOldCursor = NULL;
     static INT s_nLock = 0;
 
     if (bBegin)

--- a/base/applications/notepad/dialog.c
+++ b/base/applications/notepad/dialog.c
@@ -125,6 +125,10 @@ VOID WaitCursor(BOOL bBegin)
                 s_hWaitCursor = LoadCursor(NULL, IDC_WAIT);
             s_hOldCursor = SetCursor(s_hWaitCursor);
         }
+        else
+        {
+            SetCursor(s_hWaitCursor);
+        }
     }
     else
     {

--- a/base/applications/notepad/dialog.c
+++ b/base/applications/notepad/dialog.c
@@ -113,13 +113,18 @@ void UpdateWindowCaption(BOOL clearModifyAlert)
 
 VOID WaitCursor(BOOL bBegin)
 {
+    static HCURSOR s_hWaitCursor = NULL;
     static HCURSOR s_hOldCursor = NULL;
     static INT s_nLock = 0;
 
     if (bBegin)
     {
         if (s_nLock++ == 0)
-            s_hOldCursor = SetCursor(LoadCursor(NULL, IDC_WAIT));
+        {
+            if (s_hWaitCursor == NULL)
+                s_hWaitCursor = LoadCursor(NULL, IDC_WAIT);
+            s_hOldCursor = SetCursor(s_hWaitCursor);
+        }
     }
     else
     {

--- a/base/applications/notepad/dialog.c
+++ b/base/applications/notepad/dialog.c
@@ -419,8 +419,6 @@ VOID DIALOG_FileOpen(VOID)
     OPENFILENAME openfilename;
     TCHAR szPath[MAX_PATH];
 
-    WaitCursor(TRUE);
-
     ZeroMemory(&openfilename, sizeof(openfilename));
 
     if (Globals.szFileName[0] == 0)
@@ -443,8 +441,6 @@ VOID DIALOG_FileOpen(VOID)
         else
             AlertFileNotFound(openfilename.lpstrFile);
     }
-
-    WaitCursor(FALSE);
 }
 
 BOOL DIALOG_FileSave(VOID)
@@ -662,8 +658,6 @@ VOID DoCreateEditWindow(VOID)
     LPTSTR pTemp = NULL;
     BOOL bModified = FALSE;
 
-    WaitCursor(TRUE);
-
     iSize = 0;
 
     /* If the edit control already exists, try to save its content */
@@ -678,7 +672,6 @@ VOID DoCreateEditWindow(VOID)
             if (!pTemp)
             {
                 ShowLastError();
-                WaitCursor(FALSE);
                 return;
             }
 
@@ -720,7 +713,6 @@ VOID DoCreateEditWindow(VOID)
         }
 
         ShowLastError();
-        WaitCursor(FALSE);
         return;
     }
 
@@ -748,8 +740,6 @@ VOID DoCreateEditWindow(VOID)
 
     /* Re-arrange controls */
     PostMessageW(Globals.hMainWnd, WM_SIZE, 0, 0);
-
-    WaitCursor(FALSE);
 }
 
 VOID DIALOG_EditWrap(VOID)

--- a/base/applications/notepad/dialog.h
+++ b/base/applications/notepad/dialog.h
@@ -57,3 +57,4 @@ VOID DoOpenFile(LPCTSTR szFileName);
 VOID DoShowHideStatusBar(VOID);
 VOID DoCreateEditWindow(VOID);
 void UpdateWindowCaption(BOOL clearModifyAlert);
+VOID WaitCursor(BOOL bBegin);

--- a/base/applications/notepad/main.c
+++ b/base/applications/notepad/main.c
@@ -591,7 +591,7 @@ int WINAPI _tWinMain(HINSTANCE hInstance, HINSTANCE prev, LPTSTR cmdline, int sh
     wndclass.lpfnWndProc = NOTEPAD_WndProc;
     wndclass.hInstance = Globals.hInstance;
     wndclass.hIcon = LoadIcon(hInstance, MAKEINTRESOURCE(IDI_NPICON));
-    wndclass.hCursor = LoadCursor(NULL, (GetSystemMetrics(SM_PENWINDOWS) ? IDC_ARROW : IDC_IBEAM));
+    wndclass.hCursor = LoadCursor(NULL, IDC_ARROW);
     wndclass.hbrBackground = (HBRUSH)(COLOR_WINDOW + 1);
     wndclass.lpszMenuName = MAKEINTRESOURCE(MAIN_MENU);
     wndclass.lpszClassName = className;

--- a/base/applications/notepad/main.c
+++ b/base/applications/notepad/main.c
@@ -349,11 +349,13 @@ NOTEPAD_WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
         break;
 
     case WM_COMMAND:
+        WaitCursor(TRUE);
         if (HIWORD(wParam) == EN_CHANGE || HIWORD(wParam) == EN_HSCROLL || HIWORD(wParam) == EN_VSCROLL)
             DIALOG_StatusBarUpdateCaretPos();
         if ((HIWORD(wParam) == EN_CHANGE))
             NOTEPAD_EnableSearchMenu();
         NOTEPAD_MenuCommand(LOWORD(wParam));
+        WaitCursor(FALSE);
         break;
 
     case WM_CLOSE:
@@ -417,9 +419,11 @@ NOTEPAD_WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
         TCHAR szFileName[MAX_PATH];
         HDROP hDrop = (HDROP) wParam;
 
+        WaitCursor(TRUE);
         DragQueryFile(hDrop, 0, szFileName, _countof(szFileName));
         DragFinish(hDrop);
         DoOpenFile(szFileName);
+        WaitCursor(FALSE);
         break;
     }
 
@@ -433,6 +437,8 @@ NOTEPAD_WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
             FINDREPLACE *pFindReplace = (FINDREPLACE *) lParam;
             Globals.find = *(FINDREPLACE *) lParam;
 
+            WaitCursor(TRUE);
+
             if (pFindReplace->Flags & FR_FINDNEXT)
                 NOTEPAD_FindNext(pFindReplace, FALSE, TRUE);
             else if (pFindReplace->Flags & FR_REPLACE)
@@ -441,6 +447,8 @@ NOTEPAD_WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
                 NOTEPAD_ReplaceAll(pFindReplace);
             else if (pFindReplace->Flags & FR_DIALOGTERM)
                 NOTEPAD_FindTerm();
+
+            WaitCursor(FALSE);
             break;
         }
 
@@ -587,7 +595,7 @@ int WINAPI _tWinMain(HINSTANCE hInstance, HINSTANCE prev, LPTSTR cmdline, int sh
     wndclass.lpfnWndProc = NOTEPAD_WndProc;
     wndclass.hInstance = Globals.hInstance;
     wndclass.hIcon = LoadIcon(hInstance, MAKEINTRESOURCE(IDI_NPICON));
-    wndclass.hCursor = LoadCursor(0, IDC_ARROW);
+    wndclass.hCursor = LoadCursor(NULL, (GetSystemMetrics(SM_PENWINDOWS) ? IDC_ARROW : IDC_IBEAM));
     wndclass.hbrBackground = (HBRUSH)(COLOR_WINDOW + 1);
     wndclass.lpszMenuName = MAKEINTRESOURCE(MAIN_MENU);
     wndclass.lpszClassName = className;

--- a/base/applications/notepad/main.c
+++ b/base/applications/notepad/main.c
@@ -349,13 +349,11 @@ NOTEPAD_WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
         break;
 
     case WM_COMMAND:
-        WaitCursor(TRUE);
         if (HIWORD(wParam) == EN_CHANGE || HIWORD(wParam) == EN_HSCROLL || HIWORD(wParam) == EN_VSCROLL)
             DIALOG_StatusBarUpdateCaretPos();
         if ((HIWORD(wParam) == EN_CHANGE))
             NOTEPAD_EnableSearchMenu();
         NOTEPAD_MenuCommand(LOWORD(wParam));
-        WaitCursor(FALSE);
         break;
 
     case WM_CLOSE:
@@ -419,11 +417,9 @@ NOTEPAD_WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
         TCHAR szFileName[MAX_PATH];
         HDROP hDrop = (HDROP) wParam;
 
-        WaitCursor(TRUE);
         DragQueryFile(hDrop, 0, szFileName, _countof(szFileName));
         DragFinish(hDrop);
         DoOpenFile(szFileName);
-        WaitCursor(FALSE);
         break;
     }
 

--- a/base/applications/notepad/printing.c
+++ b/base/applications/notepad/printing.c
@@ -538,6 +538,7 @@ DIALOG_Printing_DialogProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
                         EndDialog(hwnd, IDABORT);
                     else
                         EndDialog(hwnd, IDCANCEL);
+                    WaitCursor(FALSE);
                     break;
             }
             break;
@@ -573,6 +574,8 @@ VOID DIALOG_FilePrint(VOID)
         return;
     }
 
+    WaitCursor(TRUE);
+
     printer = &printData->printer;
     printer->lStructSize = sizeof(PRINTDLG);
     printer->hwndOwner = Globals.hMainWnd;
@@ -598,6 +601,7 @@ VOID DIALOG_FilePrint(VOID)
     if (!ret)
     {
         LocalFree(printData);
+        WaitCursor(FALSE);
         return; /* The user canceled printing */
     }
     assert(printer->hDC != NULL);
@@ -613,6 +617,8 @@ VOID DIALOG_FilePrint(VOID)
     {
         AlertPrintError();
     }
+
+    /* WaitCursor(FALSE) will be called in DIALOG_Printing_DialogProc */
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
@@ -671,6 +677,8 @@ VOID DIALOG_FilePageSetup(VOID)
 {
     PAGESETUPDLG page;
 
+    WaitCursor(TRUE);
+
     ZeroMemory(&page, sizeof(page));
     page.lStructSize = sizeof(page);
     page.hwndOwner = Globals.hMainWnd;
@@ -688,4 +696,6 @@ VOID DIALOG_FilePageSetup(VOID)
     Globals.hDevMode = page.hDevMode;
     Globals.hDevNames = page.hDevNames;
     Globals.lMargins = page.rtMargin;
+
+    WaitCursor(FALSE);
 }

--- a/base/applications/notepad/printing.c
+++ b/base/applications/notepad/printing.c
@@ -538,7 +538,6 @@ DIALOG_Printing_DialogProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
                         EndDialog(hwnd, IDABORT);
                     else
                         EndDialog(hwnd, IDCANCEL);
-                    WaitCursor(FALSE);
                     break;
             }
             break;
@@ -574,8 +573,6 @@ VOID DIALOG_FilePrint(VOID)
         return;
     }
 
-    WaitCursor(TRUE);
-
     printer = &printData->printer;
     printer->lStructSize = sizeof(PRINTDLG);
     printer->hwndOwner = Globals.hMainWnd;
@@ -601,7 +598,6 @@ VOID DIALOG_FilePrint(VOID)
     if (!ret)
     {
         LocalFree(printData);
-        WaitCursor(FALSE);
         return; /* The user canceled printing */
     }
     assert(printer->hDC != NULL);
@@ -617,8 +613,6 @@ VOID DIALOG_FilePrint(VOID)
     {
         AlertPrintError();
     }
-
-    /* WaitCursor(FALSE) will be called in DIALOG_Printing_DialogProc */
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
@@ -677,8 +671,6 @@ VOID DIALOG_FilePageSetup(VOID)
 {
     PAGESETUPDLG page;
 
-    WaitCursor(TRUE);
-
     ZeroMemory(&page, sizeof(page));
     page.lStructSize = sizeof(page);
     page.hwndOwner = Globals.hMainWnd;
@@ -696,6 +688,4 @@ VOID DIALOG_FilePageSetup(VOID)
     Globals.hDevMode = page.hDevMode;
     Globals.hDevNames = page.hDevNames;
     Globals.lMargins = page.rtMargin;
-
-    WaitCursor(FALSE);
 }


### PR DESCRIPTION
## Purpose
Using the proper cursors improves user experience.
JIRA issue: [CORE-18837](https://jira.reactos.org/browse/CORE-18837)
This PR is a reaction to "Independent ReactOS Notepad": https://github.com/katahiromz/RNotepad/issues/1

## Proposed changes

- Add `WaitCursor` helper function to display the wait cursor while heavy operation.
- Manage the wait cursor by using a lock count.

## TODO

- [x] Do tests.