### PR TITLE
[SDK][SPEC2DEF] Ignore -debug-only SPEC entries on Release

### DIFF
--- a/sdk/cmake/gcc.cmake
+++ b/sdk/cmake/gcc.cmake
@@ -421,7 +421,7 @@ function(spec2def _dllname _spec_file)
 
     if(DBG)
         set(__debug_build "--debug-build")
-    else
+    else()
         set(__debug_build "")
     endif()
 

--- a/sdk/cmake/gcc.cmake
+++ b/sdk/cmake/gcc.cmake
@@ -419,10 +419,8 @@ function(spec2def _dllname _spec_file)
         set(__version_arg "--version=${DLL_EXPORT_VERSION}")
     endif()
 
-    if(DBG)
+    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
         set(__debug_build "--debug-build")
-    else()
-        set(__debug_build "")
     endif()
 
     # Generate exports def and C stubs file for the DLL

--- a/sdk/cmake/gcc.cmake
+++ b/sdk/cmake/gcc.cmake
@@ -419,10 +419,16 @@ function(spec2def _dllname _spec_file)
         set(__version_arg "--version=${DLL_EXPORT_VERSION}")
     endif()
 
+    if(DBG)
+        set(__debug_version "--debug-version")
+    else
+        set(__debug_version "")
+    endif()
+
     # Generate exports def and C stubs file for the DLL
     add_custom_command(
         OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${_file}.def ${CMAKE_CURRENT_BINARY_DIR}/${_file}_stubs.c
-        COMMAND native-spec2def -n=${_dllname} -a=${ARCH2} -d=${CMAKE_CURRENT_BINARY_DIR}/${_file}.def -s=${CMAKE_CURRENT_BINARY_DIR}/${_file}_stubs.c ${__with_relay_arg} ${__version_arg} ${CMAKE_CURRENT_SOURCE_DIR}/${_spec_file}
+        COMMAND native-spec2def -n=${_dllname} -a=${ARCH2} -d=${CMAKE_CURRENT_BINARY_DIR}/${_file}.def -s=${CMAKE_CURRENT_BINARY_DIR}/${_file}_stubs.c ${__with_relay_arg} ${__version_arg} ${__debug_version} ${CMAKE_CURRENT_SOURCE_DIR}/${_spec_file}
         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${_spec_file} native-spec2def)
 
     if(__spec2def_ADD_IMPORTLIB)
@@ -431,7 +437,7 @@ function(spec2def _dllname _spec_file)
             set(_extraflags --no-private-warnings)
         endif()
 
-        generate_import_lib(lib${_file} ${_dllname} ${_spec_file} ${_extraflags} "${__version_arg}")
+        generate_import_lib(lib${_file} ${_dllname} ${_spec_file} ${_extraflags} "${__version_arg} ${__debug_version}")
     endif()
 endfunction()
 

--- a/sdk/cmake/gcc.cmake
+++ b/sdk/cmake/gcc.cmake
@@ -420,15 +420,15 @@ function(spec2def _dllname _spec_file)
     endif()
 
     if(DBG)
-        set(__debug_version "--debug-version")
+        set(__debug_build "--debug-build")
     else
-        set(__debug_version "")
+        set(__debug_build "")
     endif()
 
     # Generate exports def and C stubs file for the DLL
     add_custom_command(
         OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${_file}.def ${CMAKE_CURRENT_BINARY_DIR}/${_file}_stubs.c
-        COMMAND native-spec2def -n=${_dllname} -a=${ARCH2} -d=${CMAKE_CURRENT_BINARY_DIR}/${_file}.def -s=${CMAKE_CURRENT_BINARY_DIR}/${_file}_stubs.c ${__with_relay_arg} ${__version_arg} ${__debug_version} ${CMAKE_CURRENT_SOURCE_DIR}/${_spec_file}
+        COMMAND native-spec2def -n=${_dllname} -a=${ARCH2} -d=${CMAKE_CURRENT_BINARY_DIR}/${_file}.def -s=${CMAKE_CURRENT_BINARY_DIR}/${_file}_stubs.c ${__with_relay_arg} ${__version_arg} ${__debug_build} ${CMAKE_CURRENT_SOURCE_DIR}/${_spec_file}
         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${_spec_file} native-spec2def)
 
     if(__spec2def_ADD_IMPORTLIB)
@@ -437,7 +437,7 @@ function(spec2def _dllname _spec_file)
             set(_extraflags --no-private-warnings)
         endif()
 
-        generate_import_lib(lib${_file} ${_dllname} ${_spec_file} ${_extraflags} "${__version_arg} ${__debug_version}")
+        generate_import_lib(lib${_file} ${_dllname} ${_spec_file} ${_extraflags} "${__version_arg} ${__debug_build}")
     endif()
 endfunction()
 

--- a/sdk/cmake/msvc.cmake
+++ b/sdk/cmake/msvc.cmake
@@ -390,10 +390,8 @@ function(spec2def _dllname _spec_file)
         set(__version_arg "--version=${DLL_EXPORT_VERSION}")
     endif()
 
-    if(DBG)
+    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
         set(__debug_build "--debug-build")
-    else()
-        set(__debug_build "")
     endif()
 
     # Generate exports def and C stubs file for the DLL

--- a/sdk/cmake/msvc.cmake
+++ b/sdk/cmake/msvc.cmake
@@ -390,14 +390,20 @@ function(spec2def _dllname _spec_file)
         set(__version_arg "--version=${DLL_EXPORT_VERSION}")
     endif()
 
+    if(DBG)
+        set(__debug_version "--debug-version")
+    else
+        set(__debug_version "")
+    endif()
+
     # Generate exports def and C stubs file for the DLL
     add_custom_command(
         OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${_file}.def ${CMAKE_CURRENT_BINARY_DIR}/${_file}_stubs.c
-        COMMAND native-spec2def --ms -a=${SPEC2DEF_ARCH} -n=${_dllname} -d=${CMAKE_CURRENT_BINARY_DIR}/${_file}.def -s=${CMAKE_CURRENT_BINARY_DIR}/${_file}_stubs.c ${__with_relay_arg} ${__version_arg} ${CMAKE_CURRENT_SOURCE_DIR}/${_spec_file}
+        COMMAND native-spec2def --ms -a=${SPEC2DEF_ARCH} -n=${_dllname} -d=${CMAKE_CURRENT_BINARY_DIR}/${_file}.def -s=${CMAKE_CURRENT_BINARY_DIR}/${_file}_stubs.c ${__with_relay_arg} ${__version_arg} ${__debug_version} ${CMAKE_CURRENT_SOURCE_DIR}/${_spec_file}
         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${_spec_file} native-spec2def)
 
     if(__spec2def_ADD_IMPORTLIB)
-        generate_import_lib(lib${_file} ${_dllname} ${_spec_file} "${__version_arg}")
+        generate_import_lib(lib${_file} ${_dllname} ${_spec_file} "${__version_arg} ${__debug_version}")
         if(__spec2def_NO_PRIVATE_WARNINGS)
             set_property(TARGET lib${_file} APPEND PROPERTY STATIC_LIBRARY_OPTIONS /ignore:4104)
         endif()

--- a/sdk/cmake/msvc.cmake
+++ b/sdk/cmake/msvc.cmake
@@ -391,19 +391,19 @@ function(spec2def _dllname _spec_file)
     endif()
 
     if(DBG)
-        set(__debug_version "--debug-version")
+        set(__debug_build "--debug-build")
     else
-        set(__debug_version "")
+        set(__debug_build "")
     endif()
 
     # Generate exports def and C stubs file for the DLL
     add_custom_command(
         OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${_file}.def ${CMAKE_CURRENT_BINARY_DIR}/${_file}_stubs.c
-        COMMAND native-spec2def --ms -a=${SPEC2DEF_ARCH} -n=${_dllname} -d=${CMAKE_CURRENT_BINARY_DIR}/${_file}.def -s=${CMAKE_CURRENT_BINARY_DIR}/${_file}_stubs.c ${__with_relay_arg} ${__version_arg} ${__debug_version} ${CMAKE_CURRENT_SOURCE_DIR}/${_spec_file}
+        COMMAND native-spec2def --ms -a=${SPEC2DEF_ARCH} -n=${_dllname} -d=${CMAKE_CURRENT_BINARY_DIR}/${_file}.def -s=${CMAKE_CURRENT_BINARY_DIR}/${_file}_stubs.c ${__with_relay_arg} ${__version_arg} ${__debug_build} ${CMAKE_CURRENT_SOURCE_DIR}/${_spec_file}
         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${_spec_file} native-spec2def)
 
     if(__spec2def_ADD_IMPORTLIB)
-        generate_import_lib(lib${_file} ${_dllname} ${_spec_file} "${__version_arg} ${__debug_version}")
+        generate_import_lib(lib${_file} ${_dllname} ${_spec_file} "${__version_arg} ${__debug_build}")
         if(__spec2def_NO_PRIVATE_WARNINGS)
             set_property(TARGET lib${_file} APPEND PROPERTY STATIC_LIBRARY_OPTIONS /ignore:4104)
         endif()

--- a/sdk/cmake/msvc.cmake
+++ b/sdk/cmake/msvc.cmake
@@ -392,7 +392,7 @@ function(spec2def _dllname _spec_file)
 
     if(DBG)
         set(__debug_build "--debug-build")
-    else
+    else()
         set(__debug_build "")
     endif()
 

--- a/sdk/tools/spec2def/spec2def.c
+++ b/sdk/tools/spec2def/spec2def.c
@@ -72,7 +72,7 @@ char *pszArchString2;
 char *pszSourceFileName = NULL;
 char *pszDllName = NULL;
 char *gpszUnderscore = "";
-int gbDebugVersion = 0;
+int gbDebugBuild = 0;
 int gbDebug;
 unsigned guOsVersion = 0x502;
 #define DbgPrint(...) (!gbDebug || fprintf(stderr, __VA_ARGS__))
@@ -248,7 +248,7 @@ OutputLine_stub(FILE *file, EXPORT *pexp)
     int bInPrototype = 0;
 
     /* Ignore -dbgonly entries on Release */
-    if (!gbDebugVersion && (pexp->uFlags & FL_DBGONLY))
+    if (!gbDebugBuild && (pexp->uFlags & FL_DBGONLY))
     {
         return 0;
     }
@@ -756,7 +756,7 @@ int
 OutputLine_def(FILE *fileDest, EXPORT *pexp)
 {
     /* Ignore -dbgonly entries on Release */
-    if (!gbDebugVersion && (pexp->uFlags & FL_DBGONLY))
+    if (!gbDebugBuild && (pexp->uFlags & FL_DBGONLY))
     {
         return 0;
     }
@@ -1425,7 +1425,7 @@ void usage(void)
            "  --version=<version>     Sets the version to create exports for\n"
            "  --implib                generate a def file for an import library\n"
            "  --no-private-warnings   suppress warnings about symbols that should be -private\n"
-           "  --debug-version         enable -dbgonly entries\n"
+           "  --debug-build           enable -dbgonly entries\n"
            "  -a=<arch>               set architecture to <arch> (i386, x86_64, arm, arm64)\n"
            "  --with-tracing          generate wine-like \"+relay\" trace trampolines (needs -s)\n");
 }
@@ -1483,9 +1483,9 @@ int main(int argc, char *argv[])
         {
             gbMSComp = 1;
         }
-        else if (strcasecmp(argv[i], "--debug-version") == 0)
+        else if (strcasecmp(argv[i], "--debug-build") == 0)
         {
-            gbDebugVersion = 1;
+            gbDebugBuild = 1;
         }
         else if (strcasecmp(argv[i], "--no-private-warnings") == 0)
         {

--- a/sdk/tools/spec2def/spec2def.c
+++ b/sdk/tools/spec2def/spec2def.c
@@ -247,7 +247,7 @@ OutputLine_stub(FILE *file, EXPORT *pexp)
     int bRelay = 0;
     int bInPrototype = 0;
 
-    /* Ignore -dbgonly entries on Release */
+    /* Ignore -debug-only entries on Release */
     if (!gbDebugBuild && (pexp->uFlags & FL_DBGONLY))
     {
         return 0;
@@ -755,7 +755,7 @@ OutputLine_def_GCC(FILE *fileDest, EXPORT *pexp)
 int
 OutputLine_def(FILE *fileDest, EXPORT *pexp)
 {
-    /* Ignore -dbgonly entries on Release */
+    /* Ignore -debug-only entries on Release */
     if (!gbDebugBuild && (pexp->uFlags & FL_DBGONLY))
     {
         return 0;
@@ -1103,7 +1103,7 @@ ParseFile(char* pcStart, FILE *fileDest, unsigned *cExports)
 
                 } while (*pc == ',');
             }
-            else if (CompareToken(pc, "-dbgonly"))
+            else if (CompareToken(pc, "-debug-only"))
             {
                 exp.uFlags |= FL_DBGONLY;
             }
@@ -1425,7 +1425,7 @@ void usage(void)
            "  --version=<version>     Sets the version to create exports for\n"
            "  --implib                generate a def file for an import library\n"
            "  --no-private-warnings   suppress warnings about symbols that should be -private\n"
-           "  --debug-build           enable -dbgonly entries\n"
+           "  --debug-build           enable -debug-only entries\n"
            "  -a=<arch>               set architecture to <arch> (i386, x86_64, arm, arm64)\n"
            "  --with-tracing          generate wine-like \"+relay\" trace trampolines (needs -s)\n");
 }

--- a/sdk/tools/spec2def/spec2def.c
+++ b/sdk/tools/spec2def/spec2def.c
@@ -86,7 +86,7 @@ enum
     FL_NORELAY = 16,
     FL_RET64 = 32,
     FL_REGISTER = 64,
-    FL_DBGONLY = 128,
+    FL_DEBUG_ONLY = 128,
 };
 
 enum
@@ -248,7 +248,7 @@ OutputLine_stub(FILE *file, EXPORT *pexp)
     int bInPrototype = 0;
 
     /* Ignore -debug-only entries on Release */
-    if (!gbDebugBuild && (pexp->uFlags & FL_DBGONLY))
+    if (!gbDebugBuild && (pexp->uFlags & FL_DEBUG_ONLY))
     {
         return 0;
     }
@@ -756,7 +756,7 @@ int
 OutputLine_def(FILE *fileDest, EXPORT *pexp)
 {
     /* Ignore -debug-only entries on Release */
-    if (!gbDebugBuild && (pexp->uFlags & FL_DBGONLY))
+    if (!gbDebugBuild && (pexp->uFlags & FL_DEBUG_ONLY))
     {
         return 0;
     }
@@ -1105,7 +1105,7 @@ ParseFile(char* pcStart, FILE *fileDest, unsigned *cExports)
             }
             else if (CompareToken(pc, "-debug-only"))
             {
-                exp.uFlags |= FL_DBGONLY;
+                exp.uFlags |= FL_DEBUG_ONLY;
             }
             else if (CompareToken(pc, "-private"))
             {


### PR DESCRIPTION
## Purpose

I think #5662 needs this flag.
JIRA issue: [CORE-11835](https://jira.reactos.org/browse/CORE-11835)

## Proposed changes

- Add `--debug-build` command line option.
- Ignore `-debug-only` SPEC entries on Release.
- Modify some `cmake` files to append `--debug-build` option to `spec2def` command line.

## TODO

- [x] Pass `--debug-build` option on Debug.