### PR TITLE
[CRT] Fix crash on fclose(NULL)

### DIFF
--- a/modules/rostests/apitests/advpack/DelNode.c
+++ b/modules/rostests/apitests/advpack/DelNode.c
@@ -425,9 +425,7 @@ static void Test_DelNodeA(void)
                 }
                 else
                 {
-                    FILE *fout = fopen(path, "w");
-                    if (fout)
-                        fclose(fout);
+                    fclose(fopen(path, "w"));
 
                     attr = GetFileAttributesA(path);
                     ok(attr != INVALID_FILE_ATTRIBUTES, "Line %d: attr was 0x%08lX\n", lineno, attr);

--- a/modules/rostests/apitests/advpack/DelNode.c
+++ b/modules/rostests/apitests/advpack/DelNode.c
@@ -425,7 +425,9 @@ static void Test_DelNodeA(void)
                 }
                 else
                 {
-                    fclose(fopen(path, "w"));
+                    FILE *fout = fopen(path, "w");
+                    if (fout)
+                        fclose(fout);
 
                     attr = GetFileAttributesA(path);
                     ok(attr != INVALID_FILE_ATTRIBUTES, "Line %d: attr was 0x%08lX\n", lineno, attr);

--- a/sdk/lib/crt/stdio/file.c
+++ b/sdk/lib/crt/stdio/file.c
@@ -1195,7 +1195,7 @@ void CDECL _lock_file(FILE *file)
     if(file>=_iob && file<_iob+_IOB_ENTRIES)
         _lock(_STREAM_LOCKS+(file-_iob));
     /* ReactOS: string streams dont need to be locked */
-    else if(file && !(file->_flag & _IOSTRG))
+    else if(!(file->_flag & _IOSTRG))
         EnterCriticalSection(&((file_crit*)file)->crit);
 }
 
@@ -1207,7 +1207,7 @@ void CDECL _unlock_file(FILE *file)
     if(file>=_iob && file<_iob+_IOB_ENTRIES)
         _unlock(_STREAM_LOCKS+(file-_iob));
     /* ReactOS: string streams dont need to be locked */
-    else if (file && !(file->_flag & _IOSTRG))
+    else if(!(file->_flag & _IOSTRG))
         LeaveCriticalSection(&((file_crit*)file)->crit);
 }
 

--- a/sdk/lib/crt/stdio/file.c
+++ b/sdk/lib/crt/stdio/file.c
@@ -1207,9 +1207,8 @@ void CDECL _unlock_file(FILE *file)
     if(file>=_iob && file<_iob+_IOB_ENTRIES)
         _unlock(_STREAM_LOCKS+(file-_iob));
     /* ReactOS: string streams dont need to be locked */
-    else if(!(file->_flag & _IOSTRG))
+    else if (file && !(file->_flag & _IOSTRG))
         LeaveCriticalSection(&((file_crit*)file)->crit);
-
 }
 
 /*********************************************************************

--- a/sdk/lib/crt/stdio/file.c
+++ b/sdk/lib/crt/stdio/file.c
@@ -1195,7 +1195,7 @@ void CDECL _lock_file(FILE *file)
     if(file>=_iob && file<_iob+_IOB_ENTRIES)
         _lock(_STREAM_LOCKS+(file-_iob));
     /* ReactOS: string streams dont need to be locked */
-    else if(!(file->_flag & _IOSTRG))
+    else if(file && !(file->_flag & _IOSTRG))
         EnterCriticalSection(&((file_crit*)file)->crit);
 }
 

--- a/sdk/lib/crt/stdio/file.c
+++ b/sdk/lib/crt/stdio/file.c
@@ -1209,6 +1209,7 @@ void CDECL _unlock_file(FILE *file)
     /* ReactOS: string streams dont need to be locked */
     else if(!(file->_flag & _IOSTRG))
         LeaveCriticalSection(&((file_crit*)file)->crit);
+
 }
 
 /*********************************************************************

--- a/sdk/lib/crt/stdio/file.c
+++ b/sdk/lib/crt/stdio/file.c
@@ -2783,6 +2783,8 @@ int CDECL fclose(FILE* file)
 {
   int r, flag;
 
+  if(!file)
+    return EOF;
   _lock_file(file);
   flag = file->_flag;
   free(file->_tmpfname);


### PR DESCRIPTION
## Purpose

Fix the crash at `advpack:DelNode` testcase.
```txt
Entered debugger on first-chance exception (Exception Code: 0xc0000005) (Page Fault)
Memory at 0x0000000C could not be accessed

kdb:> bt
Eip:
<msvcrt.dll:12a75 (sdk/lib/crt/stdio/file.c:1198 (_lock_file))>
Frames:
<msvcrt.dll:15442 (sdk/lib/crt/stdio/file.c:2785 (fclose))>
<advpack_apitest.exe:12a3 (modules/rostests/apitests/advpack/DelNode.c:428 (func_DelNode))>
<advpack_apitest.exe:1b79 (sdk/include/reactos/wine/test.h:873 (run_test))>
<advpack_apitest.exe:283e (sdk/include/reactos/wine/test.h:930 (main))>
<advpack_apitest.exe:2d9d (sdk/lib/crt/startup/crtexe.c:311 (__tmainCRTStartup))>
<advpack_apitest.exe:2e14 (sdk/lib/crt/startup/crtexe.c:192 (mainCRTStartup))>
<kernel32.dll:11b41 (dll/win32/kernel32/client/proc.c:465 (BaseProcessStartup))>
```

JIRA issue: [ROSTESTS-388](https://jira.reactos.org/browse/ROSTESTS-388)

## Proposed changes

- Add `NULL` check at the prologue of `fclose` function.
- Return `EOF` if `NULL`.

## TODO

- [ ] Do big tests.