### PR TITLE
[WIN32K] Do not try to free a unicode string that is an int-resource

### DIFF
--- a/win32ss/user/ntuser/cursoricon.c
+++ b/win32ss/user/ntuser/cursoricon.c
@@ -1665,7 +1665,8 @@ Exit:
     /* Additional cleanup on failure */
     if (bResult == FALSE)
     {
-        if (ustrRsrc.Buffer != NULL)
+        if ((ustrRsrc.Buffer != NULL) &&
+            !IS_INTRESOURCE(ustrRsrc.Buffer))
         {
             ExFreePoolWithTag(ustrRsrc.Buffer, TAG_STRING);
         }


### PR DESCRIPTION
## Purpose

Use IS_INTRESOURCE to check whether a unicode string captured by ProbeAndCaptureUnicodeStringOrAtom and don't try to free it, if it is.
