### PR TITLE
[WIN32K] Prevent dereferencing NULL pointer

### DIFF
--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -596,7 +596,8 @@ LRESULT co_UserFreeWindow(PWND Window,
    /* remove the window already at this point from the thread window list so we
       don't get into trouble when destroying the thread windows while we're still
       in co_UserFreeWindow() */
-   RemoveEntryList(&Window->ThreadListEntry);
+   if (!IsListEmpty(&Window->ThreadListEntry))
+       RemoveEntryList(&Window->ThreadListEntry);
 
    BelongsToThreadData = IntWndBelongsToThread(Window, ThreadData);
 
@@ -1917,6 +1918,7 @@ PWND FASTCALL IntCreateWindow(CREATESTRUCTW* Cs,
        pWnd->HideAccel = pWnd->spwndParent->HideAccel;
    }
 
+   InitializeListHead(&pWnd->ThreadListEntry);
    pWnd->head.pti->cWindows++;
 
    if (Class->spicn && !Class->spicnSm)


### PR DESCRIPTION
Check whether Flink is NULL before removing a window from a linked list. This can happen on failure in IntCreateWindow, but I have seen it from a different path, so there are more issues here. It's a hackfix, but it makes win32k a tiny bit less crashy.
