### PR TITLE
[GETUNAME] Build only english on DBG builds

### DIFF
--- a/dll/win32/getuname/getuname.rc
+++ b/dll/win32/getuname/getuname.rc
@@ -43,4 +43,4 @@
 #ifdef LANGUAGE_ZH_TW
     #include "lang/zh-TW.rc"
 #endif
-#endif
+#endif /* DBG */

--- a/dll/win32/getuname/getuname.rc
+++ b/dll/win32/getuname/getuname.rc
@@ -9,6 +9,10 @@
 /* UTF-8 */
 #pragma code_page(65001)
 
+/* Only use english on debug builds to reduce compile time */
+#if DBG
+    #include "lang/en-US.rc"
+#else
 #ifdef LANGUAGE_DE_DE
     #include "lang/de-DE.rc"
 #endif
@@ -38,4 +42,5 @@
 #endif
 #ifdef LANGUAGE_ZH_TW
     #include "lang/zh-TW.rc"
+#endif
 #endif


### PR DESCRIPTION
This massively cuts down build time on MSVC builds.

Build times without this patch:
- [GCC x86](https://build.reactos.org/#/builders/9/builds/34610): 1:06
- [MSVC x86](https://build.reactos.org/#/builders/1/builds/22187): 14:51
- [MSVC x64](https://build.reactos.org/#/builders/8/builds/8508): 13:40

Build times with this patch:
- [GCC x86](https://build.reactos.org/#/builders/9/builds/34611): 58 s
- [MSVC x86](https://build.reactos.org/#/builders/1/builds/22188): 6:44
- [MSVC x64](https://build.reactos.org/#/builders/8/builds/8509): 5:30