### PR TITLE
[COMDLG32] Fix comdlg32:printdlg crash

### DIFF
--- a/dll/win32/comdlg32/printdlg.c
+++ b/dll/win32/comdlg32/printdlg.c
@@ -2927,6 +2927,10 @@ static void pagesetup_set_devmode(pagesetup_data *data, DEVMODEW *dm)
     else
     {
         dmA = convert_to_devmodeA(dm);
+#ifdef __REACTOS__
+        if (!dmA)
+            return;
+#endif
         size = dmA->dmSize + dmA->dmDriverExtra;
         src = dmA;
     }

--- a/dll/win32/comdlg32/printdlg.c
+++ b/dll/win32/comdlg32/printdlg.c
@@ -2901,6 +2901,10 @@ static DEVMODEW *pagesetup_get_devmode(const pagesetup_data *data)
         ret = HeapAlloc(GetProcessHeap(), 0, dm->dmSize + dm->dmDriverExtra);
         memcpy(ret, dm, dm->dmSize + dm->dmDriverExtra);
     }
+#ifdef __REACTOS__
+    else if (!dm)
+        ret = NULL;
+#endif
     else
         ret = GdiConvertToDevmodeW((DEVMODEA *)dm);
 


### PR DESCRIPTION
## Purpose

Fix crash.
JIRA issue: [ROSTESTS-388](https://jira.reactos.org/browse/ROSTESTS-388)

## Proposed changes

- Do `NULL` check on `dmA` variable.

## TODO

- [ ] Do big tests.
