### PR TITLE
[SETUPAPI] Fix crash by checking if InfName is non-NULL 

### DIFF
--- a/dll/win32/setupapi/parser.c
+++ b/dll/win32/setupapi/parser.c
@@ -2326,11 +2326,10 @@ SetupDiGetINFClassW(
     TRACE("%s %p %p %ld %p\n", debugstr_w(InfName), ClassGuid,
         ClassName, ClassNameSize, RequiredSize);
 
-    /* Open .inf file */
-#ifdef __REACTOS__
     if (!InfName)
         return ret;
-#endif
+
+    /* Open .inf file */
     hInf = SetupOpenInfFileW(InfName, NULL, INF_STYLE_WIN4, NULL);
     if (hInf == INVALID_HANDLE_VALUE)
         goto cleanup;

--- a/dll/win32/setupapi/parser.c
+++ b/dll/win32/setupapi/parser.c
@@ -2327,6 +2327,10 @@ SetupDiGetINFClassW(
         ClassName, ClassNameSize, RequiredSize);
 
     /* Open .inf file */
+#ifdef __REACTOS__
+    if (!InfName)
+        return ret;
+#endif
     hInf = SetupOpenInfFileW(InfName, NULL, INF_STYLE_WIN4, NULL);
     if (hInf == INVALID_HANDLE_VALUE)
         goto cleanup;


### PR DESCRIPTION
## Purpose

Fix crash in `setupapi:devinst` testcase.
JIRA issue: [ROSTESTS-388](https://jira.reactos.org/browse/ROSTESTS-388)

## Proposed changes

- Check if variable `InfName` is non-`NULL`.

## TODO

- [x] Do big tests.
