### PR TITLE
[MESA] Change reported version to 1.1.0

### DIFF
--- a/dll/opengl/mesa/misc.c
+++ b/dll/opengl/mesa/misc.c
@@ -313,7 +313,7 @@ const GLubyte *gl_GetString( GLcontext *ctx, GLenum name )
 {
    static char renderer[1000];
    static char *vendor = "Brian Paul & ReactOS Developers";
-   static char *version = "1.1";
+   static char *version = "1.1.0";
    static char *extensions = "GL_EXT_paletted_texture GL_EXT_bgra GL_WIN_swap_hint";
 
    if (INSIDE_BEGIN_END(ctx)) {


### PR DESCRIPTION
## Purpose

Trivial change to fix the [failing](https://reactos.org/testman/detail.php?id=66691804&prev=0) OpenGL `sw_extensions` test.
Test expects `1.1.0` and the version of Mesa ReactOS has was set to report `1.1`, windows also reports `1.1.0` per the [comment here](https://github.com/reactos/reactos/pull/3228#issuecomment-830666418).

![image](https://github.com/reactos/reactos/assets/17304943/b1878c18-d5ef-4be1-845f-b913ba4b9153)