### PR TITLE
[RAPPS] Refreshing the Installed list should restore the selected item

### DIFF
--- a/base/applications/rapps/appview.cpp
+++ b/base/applications/rapps/appview.cpp
@@ -1996,20 +1996,21 @@ CApplicationView::GetRestoreListSelectionData(LVITEMW &Item, WCHAR *Name, UINT N
     }
 }
 
-int
+VOID
 CApplicationView::RestoreListSelection(const LVITEMW &Item)
 {
-    LVFINDINFOW fi;
-    fi.flags = LVFI_STRING;
-    fi.psz = Item.pszText;
-
-    HWND hList = m_ListView ? m_ListView->m_hWnd : NULL;
-    int index = hList ? ListView_FindItem(hList, -1, &fi) : -1;
-    if (index != -1)
+    int index = Item.iItem;
+    if (index != -1) // Was there a selected item?
     {
-        ListView_SetItemState(hList, index, Item.state, Item.stateMask);
+        LVFINDINFOW fi;
+        fi.flags = LVFI_STRING;
+        fi.psz = Item.pszText;
+        index = ListView_FindItem(m_ListView->m_hWnd, -1, &fi);
     }
-    return index;
+    if (index != -1) // Is it still in the list?
+    {
+        ListView_SetItemState(m_ListView->m_hWnd, index, Item.state, Item.stateMask);
+    }
 }
 
 // this function is called when a item of listview get focus.

--- a/base/applications/rapps/appview.cpp
+++ b/base/applications/rapps/appview.cpp
@@ -2004,8 +2004,8 @@ CApplicationView::RestoreListSelection(const LVITEMW &Item)
     fi.psz = Item.pszText;
 
     HWND hList = m_ListView ? m_ListView->m_hWnd : NULL;
-    int index = ListView_FindItem(hList, -1, &fi);
-    if (Item.iItem != -1)
+    int index = hList ? ListView_FindItem(hList, -1, &fi) : -1;
+    if (index != -1)
     {
         ListView_SetItemState(hList, index, Item.state, Item.stateMask);
     }

--- a/base/applications/rapps/appview.cpp
+++ b/base/applications/rapps/appview.cpp
@@ -1980,6 +1980,38 @@ CApplicationView::AppendTabOrderWindow(int Direction, ATL::CSimpleArray<HWND> &T
     m_AppsInfo->AppendTabOrderWindow(Direction, TabOrderList);
 }
 
+VOID
+CApplicationView::GetRestoreListSelectionData(LVITEMW &Item, WCHAR *Name, UINT NameLen)
+{
+    Item.mask = LVIF_TEXT|LVIF_STATE;
+    Item.iItem = -1, Item.iSubItem = 0;
+    Item.stateMask = LVIS_FOCUSED|LVIS_SELECTED;
+    Item.pszText = Name, Item.cchTextMax = NameLen;
+
+    HWND hList = m_ListView ? m_ListView->m_hWnd : NULL;
+    if (hList)
+    {
+        Item.iItem = ListView_GetNextItem(hList, -1, LVNI_FOCUSED);
+        ListView_GetItem(hList, &Item);
+    }
+}
+
+int
+CApplicationView::RestoreListSelection(const LVITEMW &Item)
+{
+    LVFINDINFOW fi;
+    fi.flags = LVFI_STRING;
+    fi.psz = Item.pszText;
+
+    HWND hList = m_ListView ? m_ListView->m_hWnd : NULL;
+    int index = ListView_FindItem(hList, -1, &fi);
+    if (Item.iItem != -1)
+    {
+        ListView_SetItemState(hList, index, Item.state, Item.stateMask);
+    }
+    return index;
+}
+
 // this function is called when a item of listview get focus.
 // CallbackParam is the param passed to listview when adding the item (the one getting focus now).
 VOID

--- a/base/applications/rapps/appview.cpp
+++ b/base/applications/rapps/appview.cpp
@@ -1981,12 +1981,13 @@ CApplicationView::AppendTabOrderWindow(int Direction, ATL::CSimpleArray<HWND> &T
 }
 
 VOID
-CApplicationView::GetRestoreListSelectionData(LVITEMW &Item, WCHAR *Name, UINT NameLen)
+CApplicationView::GetRestoreListSelectionData(RESTORELISTSELECTION &Restore)
 {
+    LVITEMW &Item = Restore.Item;
     Item.mask = LVIF_TEXT|LVIF_STATE;
     Item.iItem = -1, Item.iSubItem = 0;
     Item.stateMask = LVIS_FOCUSED|LVIS_SELECTED;
-    Item.pszText = Name, Item.cchTextMax = NameLen;
+    Item.pszText = Restore.Name, Item.cchTextMax = _countof(Restore.Name);
 
     HWND hList = m_ListView ? m_ListView->m_hWnd : NULL;
     if (hList)
@@ -1997,8 +1998,9 @@ CApplicationView::GetRestoreListSelectionData(LVITEMW &Item, WCHAR *Name, UINT N
 }
 
 VOID
-CApplicationView::RestoreListSelection(const LVITEMW &Item)
+CApplicationView::RestoreListSelection(const RESTORELISTSELECTION &Restore)
 {
+    const LVITEMW &Item = Restore.Item;
     int index = Item.iItem;
     if (index != -1) // Was there a selected item?
     {

--- a/base/applications/rapps/gui.cpp
+++ b/base/applications/rapps/gui.cpp
@@ -495,7 +495,7 @@ CMainWindow::ShowAboutDlg()
 VOID
 CMainWindow::OnCommand(WPARAM wParam, LPARAM lParam)
 {
-    const BOOL bReload = TRUE;
+    BOOL bReload = TRUE;
     WORD wCommand = LOWORD(wParam);
 
     if (!lParam)
@@ -552,6 +552,7 @@ CMainWindow::OnCommand(WPARAM wParam, LPARAM lParam)
                 break;
 
             case ID_REFRESH:
+                bReload = IsInstalledEnum(SelectedEnumType); // Force installed refresh from the registry
                 UpdateApplicationsList(SelectedEnumType, bReload);
                 break;
 
@@ -627,6 +628,10 @@ CMainWindow::UpdateApplicationsList(AppsCategories EnumType, BOOL bReload, BOOL 
     if (SelectedEnumType != EnumType)
         SelectedEnumType = EnumType;
 
+    LVITEMW selitem;
+    WCHAR selitembuf[MAX_PATH];
+    m_ApplicationView->GetRestoreListSelectionData(selitem, selitembuf, _countof(selitembuf));
+
     if (bReload)
         m_Selected.RemoveAll();
 
@@ -667,6 +672,8 @@ CMainWindow::UpdateApplicationsList(AppsCategories EnumType, BOOL bReload, BOOL 
     {
         ATLASSERT(0 && "This should be unreachable!");
     }
+
+    m_ApplicationView->RestoreListSelection(selitem);
     m_ApplicationView->SetRedraw(TRUE);
     m_ApplicationView->RedrawWindow(0, 0, RDW_INVALIDATE | RDW_ALLCHILDREN); // force the child window to repaint
     UpdateStatusBarText();

--- a/base/applications/rapps/gui.cpp
+++ b/base/applications/rapps/gui.cpp
@@ -495,7 +495,7 @@ CMainWindow::ShowAboutDlg()
 VOID
 CMainWindow::OnCommand(WPARAM wParam, LPARAM lParam)
 {
-    BOOL bReload = TRUE;
+    const BOOL bReload = TRUE;
     WORD wCommand = LOWORD(wParam);
 
     if (!lParam)
@@ -552,7 +552,6 @@ CMainWindow::OnCommand(WPARAM wParam, LPARAM lParam)
                 break;
 
             case ID_REFRESH:
-                bReload = IsInstalledEnum(SelectedEnumType); // Force installed refresh from the registry
                 UpdateApplicationsList(SelectedEnumType, bReload);
                 break;
 

--- a/base/applications/rapps/gui.cpp
+++ b/base/applications/rapps/gui.cpp
@@ -624,12 +624,13 @@ CMainWindow::UpdateApplicationsList(AppsCategories EnumType, BOOL bReload, BOOL 
     if (bCheckAvailable)
         CheckAvailable();
 
+    BOOL TryRestoreSelection = SelectedEnumType == EnumType;
     if (SelectedEnumType != EnumType)
         SelectedEnumType = EnumType;
 
-    LVITEMW selitem;
-    WCHAR selitembuf[MAX_PATH];
-    m_ApplicationView->GetRestoreListSelectionData(selitem, selitembuf, _countof(selitembuf));
+    CApplicationView::RESTORELISTSELECTION RestoreSelection;
+    if (TryRestoreSelection)
+        m_ApplicationView->GetRestoreListSelectionData(RestoreSelection);
 
     if (bReload)
         m_Selected.RemoveAll();
@@ -672,7 +673,8 @@ CMainWindow::UpdateApplicationsList(AppsCategories EnumType, BOOL bReload, BOOL 
         ATLASSERT(0 && "This should be unreachable!");
     }
 
-    m_ApplicationView->RestoreListSelection(selitem);
+    if (TryRestoreSelection)
+        m_ApplicationView->RestoreListSelection(RestoreSelection);
     m_ApplicationView->SetRedraw(TRUE);
     m_ApplicationView->RedrawWindow(0, 0, RDW_INVALIDATE | RDW_ALLCHILDREN); // force the child window to repaint
     UpdateStatusBarText();

--- a/base/applications/rapps/include/appview.h
+++ b/base/applications/rapps/include/appview.h
@@ -406,10 +406,14 @@ class CApplicationView : public CUiWindow<CWindowImpl<CApplicationView>>
     VOID
     AppendTabOrderWindow(int Direction, ATL::CSimpleArray<HWND> &TabOrderList);
 
+    struct RESTORELISTSELECTION {
+        LVITEMW Item;
+        WCHAR Name[MAX_PATH];
+    };
     VOID
-    GetRestoreListSelectionData(LVITEMW &Item, WCHAR *Name, UINT NameLen);
+    GetRestoreListSelectionData(RESTORELISTSELECTION &Restore);
     VOID
-    RestoreListSelection(const LVITEMW &Item);
+    RestoreListSelection(const RESTORELISTSELECTION &Restore);
 
     // this function is called when a item of listview get focus.
     // CallbackParam is the param passed to listview when adding the item (the one getting focus now).

--- a/base/applications/rapps/include/appview.h
+++ b/base/applications/rapps/include/appview.h
@@ -408,7 +408,7 @@ class CApplicationView : public CUiWindow<CWindowImpl<CApplicationView>>
 
     VOID
     GetRestoreListSelectionData(LVITEMW &Item, WCHAR *Name, UINT NameLen);
-    int
+    VOID
     RestoreListSelection(const LVITEMW &Item);
 
     // this function is called when a item of listview get focus.

--- a/base/applications/rapps/include/appview.h
+++ b/base/applications/rapps/include/appview.h
@@ -406,6 +406,11 @@ class CApplicationView : public CUiWindow<CWindowImpl<CApplicationView>>
     VOID
     AppendTabOrderWindow(int Direction, ATL::CSimpleArray<HWND> &TabOrderList);
 
+    VOID
+    GetRestoreListSelectionData(LVITEMW &Item, WCHAR *Name, UINT NameLen);
+    int
+    RestoreListSelection(const LVITEMW &Item);
+
     // this function is called when a item of listview get focus.
     // CallbackParam is the param passed to listview when adding the item (the one getting focus now).
     VOID


### PR DESCRIPTION
The Installed list must re-enumerate the registry when F5 is pressed because just adding the same items from the cached list is pointless.

Most of the code is related to restoring the selected item and as a bonus, works in the other modes as well.