### PR TITLE
[NTGDI] GetPixel's return top byte is zero if valid

### DIFF
--- a/win32ss/gdi/ntgdi/bitblt.c
+++ b/win32ss/gdi/ntgdi/bitblt.c
@@ -1598,6 +1598,10 @@ NtGdiGetPixel(
 
         /* Delete the surface */
         GDIOBJ_vDeleteObject(&psurfDest->BaseObject);
+
+        /* The top byte is zero if color was valid */
+        if (~ulRGBColor)
+            ulRGBColor &= 0xFFFFFF;
     }
 
 leave:

--- a/win32ss/gdi/ntgdi/bitblt.c
+++ b/win32ss/gdi/ntgdi/bitblt.c
@@ -1599,9 +1599,8 @@ NtGdiGetPixel(
         /* Delete the surface */
         GDIOBJ_vDeleteObject(&psurfDest->BaseObject);
 
-        /* The top byte is zero if color was valid */
-        if (~ulRGBColor)
-            ulRGBColor &= 0xFFFFFF;
+        /* The top byte is zero */
+        ulRGBColor &= 0x00FFFFFF;
     }
 
 leave:


### PR DESCRIPTION
## Purpose
According to the results of `CImage` testcase, the top byte of the `GetPixel()` return value is zero if the return is a valid color.
JIRA issue: [CORE-19008](https://jira.reactos.org/browse/CORE-19008)

## Proposed changes

- Do bitwise-AND operation if the color value is valid.

## TODO

- [x] Confirm the implementation.
- [x] Do big tests.