### PR TITLE
[CRT][MSVCRT][ATL] Implement _CrtDbgReport(W)V and redefine _CrtDbgReport(W) around those.

### DIFF
--- a/dll/win32/msvcrt/msvcrt.spec
+++ b/dll/win32/msvcrt/msvcrt.spec
@@ -200,9 +200,9 @@
 @ stub -version=0x600+ _CrtCheckMemory
 @ stub -version=0x600+ _CrtDbgBreak
 @ cdecl -version=0x600+ _CrtDbgReport(long str long str str)
-@ stub -version=0x600+ _CrtDbgReportV
+@ cdecl -version=0x600+ _CrtDbgReportV(long str long str str ptr)
 @ cdecl -version=0x600+ _CrtDbgReportW(long wstr long wstr wstr)
-@ stub -version=0x600+ _CrtDbgReportWV
+@ cdecl -version=0x600+ _CrtDbgReportWV(long wstr long wstr wstr ptr)
 @ stub -version=0x600+ _CrtDoForAllClientObjects
 @ stub -version=0x600+ _CrtDumpMemoryLeaks
 @ stub -version=0x600+ _CrtIsMemoryBlock

--- a/sdk/include/crt/crtdbg.h
+++ b/sdk/include/crt/crtdbg.h
@@ -81,12 +81,16 @@ extern "C" {
     size_t lTotalCount;
   } _CrtMemState;
 
+
 // Debug reporting functions
 
 #ifdef _DEBUG
 
     int __cdecl _CrtDbgReport(int reportType, const char *filename, int linenumber, const char *moduleName, const char *format, ...);
     int __cdecl _CrtDbgReportW(int reportType, const wchar_t *filename, int linenumber, const wchar_t *moduleName, const wchar_t *format, ...);
+
+    int __cdecl _CrtDbgReportV(int reportType, const char *filename, int linenumber, const char *moduleName, const char *format, va_list arglist);
+    int __cdecl _CrtDbgReportWV(int reportType, const wchar_t *filename, int linenumber, const wchar_t *moduleName, const wchar_t *format, va_list arglist);
 
 #endif
 

--- a/sdk/lib/atl/atltrace.h
+++ b/sdk/lib/atl/atltrace.h
@@ -9,17 +9,10 @@
 
 #include "atldef.h"
 
-#if DBG // FIXME: We should use _DEBUG instead of DBG. CORE-17505
+#ifdef _DEBUG
 
 #include <stdio.h>
 #include <crtdbg.h>
-
-extern "C"
-{
-// FIXME: Enabling _DEBUG at top level causes assertion failures... CORE-17505
-int __cdecl _CrtDbgReport(int reportType, const char *filename, int linenumber, const char *moduleName, const char *format, ...);
-int __cdecl _CrtDbgReportW(int reportType, const wchar_t *filename, int linenumber, const wchar_t *moduleName, const wchar_t *format, ...);
-}
 
 namespace ATL
 {
@@ -267,10 +260,10 @@ AtlTrace(_In_z_ _Printf_format_string_ const X_CHAR *format, ...)
 
 } // namespace ATL
 
-#endif // DBG
+#endif // _DEBUG
 
 #ifndef ATLTRACE
-    #if DBG  // FIXME: We should use _DEBUG instead of DBG. CORE-17505
+    #ifdef _DEBUG
         #define ATLTRACE(format, ...) ATL::AtlTraceEx(__FILE__, __LINE__, format, ##__VA_ARGS__)
     #else
         #define ATLTRACE(format, ...) ((void)0)
@@ -279,7 +272,7 @@ AtlTrace(_In_z_ _Printf_format_string_ const X_CHAR *format, ...)
 
 #define ATLTRACE2 ATLTRACE
 
-#if DBG // FIXME: We should use _DEBUG instead of DBG. CORE-17505
+#ifdef _DEBUG
     #define ATLTRACENOTIMPL(funcname) do { \
         ATLTRACE(atlTraceNotImpl, 0, #funcname " is not implemented.\n"); \
         return E_NOTIMPL; \

--- a/sdk/lib/crt/misc/dbgrpt.cpp
+++ b/sdk/lib/crt/misc/dbgrpt.cpp
@@ -309,7 +309,14 @@ static int _CrtHandleDbgReport(int reportType, const char_t* szCompleteMessage, 
 
 
 EXTERN_C
-int __cdecl _CrtDbgReport(int reportType, const char *filename, int linenumber, const char *moduleName, const char *format, ...)
+int __cdecl
+_VCrtDbgReportA(
+    int reportType,
+    const char *filename,
+    int linenumber,
+    const char *moduleName,
+    const char *format,
+    va_list arglist)
 {
     char szFormatted[DBGRPT_MAX_BUFFER_SIZE+1] = {0};           // The user provided message
     char szCompleteMessage[(DBGRPT_MAX_BUFFER_SIZE+1)*2] = {0}; // The output for debug / file
@@ -325,11 +332,7 @@ int __cdecl _CrtDbgReport(int reportType, const char *filename, int linenumber, 
 
     if (format)
     {
-        va_list arglist;
-        va_start(arglist, format);
         int len = _vsnprintf(szFormatted, DBGRPT_MAX_BUFFER_SIZE - 2 - sizeof(DBGRPT_ASSERT_PREFIX_MESSAGE), format, arglist);
-        va_end(arglist);
-
         if (len < 0)
         {
             strcpy(szFormatted, DBGRPT_STRING_TOO_LONG);
@@ -361,7 +364,14 @@ int __cdecl _CrtDbgReport(int reportType, const char *filename, int linenumber, 
 }
 
 EXTERN_C
-int __cdecl _CrtDbgReportW(int reportType, const wchar_t *filename, int linenumber, const wchar_t *moduleName, const wchar_t *format, ...)
+int __cdecl
+_VCrtDbgReportW(
+    int reportType,
+    const wchar_t *filename,
+    int linenumber,
+    const wchar_t *moduleName,
+    const wchar_t *format,
+    va_list arglist)
 {
     wchar_t szFormatted[DBGRPT_MAX_BUFFER_SIZE+1] = {0};           // The user provided message
     wchar_t szCompleteMessage[(DBGRPT_MAX_BUFFER_SIZE+1)*2] = {0}; // The output for debug / file
@@ -377,11 +387,7 @@ int __cdecl _CrtDbgReportW(int reportType, const wchar_t *filename, int linenumb
 
     if (format)
     {
-        va_list arglist;
-        va_start(arglist, format);
         int len = _vsnwprintf(szFormatted, DBGRPT_MAX_BUFFER_SIZE - 2 - sizeof(DBGRPT_ASSERT_PREFIX_MESSAGE), format, arglist);
-        va_end(arglist);
-
         if (len < 0)
         {
             wcscpy(szFormatted, _CRT_WIDE(DBGRPT_STRING_TOO_LONG));
@@ -412,5 +418,68 @@ int __cdecl _CrtDbgReportW(int reportType, const wchar_t *filename, int linenumb
     return nResult;
 }
 
+EXTERN_C
+int __cdecl
+_CrtDbgReportV(
+    int reportType,
+    const char *filename,
+    int linenumber,
+    const char *moduleName,
+    const char *format,
+    va_list arglist)
+{
+    return _VCrtDbgReportA(reportType, filename, linenumber, moduleName, format, arglist);
+}
+
+EXTERN_C
+int __cdecl
+_CrtDbgReportWV(
+    int reportType,
+    const wchar_t *filename,
+    int linenumber,
+    const wchar_t *moduleName,
+    const wchar_t *format,
+    va_list arglist)
+{
+    return _VCrtDbgReportW(reportType, filename, linenumber, moduleName, format, arglist);
+}
+
+EXTERN_C
+int __cdecl
+_CrtDbgReport(
+    int reportType,
+    const char *filename,
+    int linenumber,
+    const char *moduleName,
+    const char *format,
+    ...)
+{
+    va_list arglist;
+    int result;
+
+    va_start(arglist, format);
+    result = _VCrtDbgReportA(reportType, filename, linenumber, moduleName, format, arglist);
+    va_end(arglist);
+    return result;
+}
+
+EXTERN_C
+int __cdecl
+_CrtDbgReportW(
+    int reportType,
+    const wchar_t *filename,
+    int linenumber,
+    const wchar_t *moduleName,
+    const wchar_t *format,
+    ...)
+{
+    va_list arglist;
+    int result;
+
+    va_start(arglist, format);
+    result = _VCrtDbgReportW(reportType, filename, linenumber, moduleName, format, arglist);
+    va_end(arglist);
+    return result;
+}
 
 //#endif // _DEBUG

--- a/sdk/lib/crt/misc/dbgrpt.cpp
+++ b/sdk/lib/crt/misc/dbgrpt.cpp
@@ -133,7 +133,7 @@ HMODULE _CrtGetUser32()
         }
     }
 
-    return _CrtUser32Handle != INVALID_HANDLE_VALUE ? _CrtUser32Handle : NULL;
+    return (_CrtUser32Handle != INVALID_HANDLE_VALUE ? _CrtUser32Handle : NULL);
 }
 
 static tMessageBoxW _CrtGetMessageBox()
@@ -149,7 +149,7 @@ static tMessageBoxW _CrtGetMessageBox()
         _InterlockedCompareExchangePointer((PVOID*)&_CrtMessageBoxW, (PVOID)proc, NULL);
     }
 
-    return _CrtMessageBoxW != INVALID_HANDLE_VALUE ? _CrtMessageBoxW : NULL;
+    return (_CrtMessageBoxW != INVALID_HANDLE_VALUE ? _CrtMessageBoxW : NULL);
 }
 
 
@@ -158,7 +158,7 @@ static int _CrtDbgReportWindow(int reportType, const char_t *filename, int linen
 {
     typedef dbgrpt_char_traits<char_t> traits;
 
-    wchar_t szCompleteMessage[(DBGRPT_MAX_BUFFER_SIZE+1)*2] = {0};
+    wchar_t szCompleteMessage[DBGRPT_MAX_BUFFER_SIZE] = {0};
     wchar_t LineBuffer[20] = {0};
 
     if (filename && !filename[0])
@@ -170,7 +170,8 @@ static int _CrtDbgReportWindow(int reportType, const char_t *filename, int linen
     if (linenumber)
         _itow(linenumber, LineBuffer, 10);
 
-    _snwprintf(szCompleteMessage, DBGRPT_MAX_BUFFER_SIZE * 2,
+    _snwprintf(szCompleteMessage,
+               _countof(szCompleteMessage) - 1,
                traits::szAssertionMessage,
                _CrtModeMessages[reportType],
                moduleName ? L"\nModule: " : L"", moduleName ? moduleName : traits::szEmptyString,
@@ -185,7 +186,7 @@ static int _CrtDbgReportWindow(int reportType, const char_t *filename, int linen
 
     tMessageBoxW messageBox = _CrtGetMessageBox();
     if (!messageBox)
-        return IsDebuggerPresent() ? IDRETRY : IDABORT;
+        return (IsDebuggerPresent() ? IDRETRY : IDABORT);
 
     // TODO: If we are not interacive, add MB_SERVICE_NOTIFICATION
     return messageBox(NULL, szCompleteMessage, L"ReactOS C++ Runtime Library",
@@ -318,8 +319,8 @@ _VCrtDbgReportA(
     const char *format,
     va_list arglist)
 {
-    char szFormatted[DBGRPT_MAX_BUFFER_SIZE+1] = {0};           // The user provided message
-    char szCompleteMessage[(DBGRPT_MAX_BUFFER_SIZE+1)*2] = {0}; // The output for debug / file
+    char szFormatted[DBGRPT_MAX_BUFFER_SIZE] = {0};       // The user provided message
+    char szCompleteMessage[DBGRPT_MAX_BUFFER_SIZE] = {0}; // The output for debug / file
 
     // Check for recursive _CrtDbgReport calls, and validate reportType
     if (!_CrtEnterDbgReport(reportType, filename, linenumber))
@@ -327,12 +328,19 @@ _VCrtDbgReportA(
 
     if (filename)
     {
-        _snprintf(szCompleteMessage, DBGRPT_MAX_BUFFER_SIZE, "%s(%d) : ", filename, linenumber);
+        _snprintf(szCompleteMessage,
+                  _countof(szCompleteMessage) - 1,
+                  "%s(%d) : ",
+                  filename,
+                  linenumber);
     }
 
     if (format)
     {
-        int len = _vsnprintf(szFormatted, DBGRPT_MAX_BUFFER_SIZE - 2 - sizeof(DBGRPT_ASSERT_PREFIX_MESSAGE), format, arglist);
+        int len = _vsnprintf(szFormatted,
+                             _countof(szFormatted) - 2 - _countof(DBGRPT_ASSERT_PREFIX_MESSAGE),
+                             format,
+                             arglist);
         if (len < 0)
         {
             strcpy(szFormatted, DBGRPT_STRING_TOO_LONG);
@@ -373,8 +381,8 @@ _VCrtDbgReportW(
     const wchar_t *format,
     va_list arglist)
 {
-    wchar_t szFormatted[DBGRPT_MAX_BUFFER_SIZE+1] = {0};           // The user provided message
-    wchar_t szCompleteMessage[(DBGRPT_MAX_BUFFER_SIZE+1)*2] = {0}; // The output for debug / file
+    wchar_t szFormatted[DBGRPT_MAX_BUFFER_SIZE] = {0};       // The user provided message
+    wchar_t szCompleteMessage[DBGRPT_MAX_BUFFER_SIZE] = {0}; // The output for debug / file
 
     // Check for recursive _CrtDbgReportW calls, and validate reportType
     if (!_CrtEnterDbgReport(reportType, filename, linenumber))
@@ -382,12 +390,19 @@ _VCrtDbgReportW(
 
     if (filename)
     {
-        _snwprintf(szCompleteMessage, DBGRPT_MAX_BUFFER_SIZE, L"%s(%d) : ", filename, linenumber);
+        _snwprintf(szCompleteMessage,
+                   _countof(szCompleteMessage) - 1,
+                   L"%s(%d) : ",
+                   filename,
+                   linenumber);
     }
 
     if (format)
     {
-        int len = _vsnwprintf(szFormatted, DBGRPT_MAX_BUFFER_SIZE - 2 - sizeof(DBGRPT_ASSERT_PREFIX_MESSAGE), format, arglist);
+        int len = _vsnwprintf(szFormatted,
+                              _countof(szFormatted) - 2 - _countof(DBGRPT_ASSERT_PREFIX_MESSAGE),
+                              format,
+                              arglist);
         if (len < 0)
         {
             wcscpy(szFormatted, _CRT_WIDE(DBGRPT_STRING_TOO_LONG));


### PR DESCRIPTION
## Purpose

PR #5662 properly adds _CrtDbgReport(W) in msvcrt exports. This present PR also adds the variadic _CrtDbgReport(W)V functions.

JIRA issue: [CORE-11835](https://jira.reactos.org/browse/CORE-11835), [CORE-15517](https://jira.reactos.org/browse/CORE-15517)