### PR TITLE
[BOOTDATA] Add TEMP folder to livecd image

### DIFF
--- a/boot/boot_images.cmake
+++ b/boot/boot_images.cmake
@@ -141,6 +141,9 @@ add_custom_target(bootcdregtest
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/livecd.cmake.lst "")
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/livecd.cmake.lst "${CMAKE_CURRENT_BINARY_DIR}/empty\n")
 
+# Create TEMP dir
+file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/livecd.cmake.lst "reactos/TEMP=${CMAKE_CURRENT_BINARY_DIR}/empty\n")
+
 # Create user profile directories
 add_allusers_profile_dirs(${CMAKE_CURRENT_BINARY_DIR}/livecd.cmake.lst "Profiles")
 add_user_profile_dirs(${CMAKE_CURRENT_BINARY_DIR}/livecd.cmake.lst "Profiles" "Default User")


### PR DESCRIPTION
## Purpose

Create the folder TEMP in X:\reactos so now we can match current livecd environment variables TMP and TEMP
May apply to [CORE-13041](https://jira.reactos.org/browse/CORE-13041)
