### PR TITLE
[NTUSER] On programmatic "move then resize", clear normal rectangle

### DIFF
--- a/win32ss/user/ntuser/nonclient.c
+++ b/win32ss/user/ntuser/nonclient.c
@@ -285,6 +285,7 @@ DefWndDoSizeMove(PWND pwnd, WORD wParam)
    }
    else  /* SC_SIZE */
    {
+      RECTL_vSetEmptyRect(&pwnd->InternalPos.NormalRect);
       if (!thickframe) return;
       if (hittest && (syscommand != SC_MOUSEMENU))
       {


### PR DESCRIPTION
## Purpose

_Fix Programmatic Move, then Resize followed by Move remembering old position._

JIRA issue: [CORE-19160](https://jira.reactos.org/browse/CORE-19160)

## Proposed changes

_Clear Normal Rectangle when Window opened with programmatic size followed by resize and move._
