### PR TITLE
[DDK] wsk header: Added WSKAPI to exported functions.

### DIFF
--- a/sdk/include/ddk/wsk.h
+++ b/sdk/include/ddk/wsk.h
@@ -585,28 +585,33 @@ typedef struct _WSK_TRANSPORT
 
 _Must_inspect_result_
 NTSTATUS
+WSKAPI
 WskRegister(
     _In_ PWSK_CLIENT_NPI WskClientNpi,
     _Out_ PWSK_REGISTRATION WskRegistration);
 
 _Must_inspect_result_
 NTSTATUS
+WSKAPI
 WskCaptureProviderNPI(
     _In_ PWSK_REGISTRATION WskRegistration,
     _In_ ULONG WaitTimeout,
     _Out_ PWSK_PROVIDER_NPI WskProviderNpi);
 
 VOID
+WSKAPI
 WskReleaseProviderNPI(
     _In_ PWSK_REGISTRATION WskRegistration);
 
 _Must_inspect_result_
 NTSTATUS
+WSKAPI
 WskQueryProviderCharacteristics(
     _In_ PWSK_REGISTRATION WskRegistration,
     _Out_ PWSK_PROVIDER_CHARACTERISTICS WskProviderCharacteristics);
 
 VOID
+WSKAPI
 WskDeregister(
     _In_ PWSK_REGISTRATION WskRegistration);
 


### PR DESCRIPTION
Names need decoration (stdcall) in order to be linked.

## Purpose

When using the wsk.h header functions exported therein should
be WSKAPI (which enforces the stdcall calling convention). Linking
would later fail because stdcall functions are named differently in
the object code.

## Proposed changes

Just add WSKAPI (which expands to stdcall depending on compiler
used) to  the exported functions.
