### PR TITLE
[COMDLG32][WINSPOOL] Fix crashes in winetests for comdlg32:printdlg

### DIFF
--- a/dll/win32/comdlg32/CMakeLists.txt
+++ b/dll/win32/comdlg32/CMakeLists.txt
@@ -26,7 +26,7 @@ add_library(comdlg32 MODULE
     ${CMAKE_CURRENT_BINARY_DIR}/comdlg32.def)
 
 set_module_type(comdlg32 win32dll)
-target_link_libraries(comdlg32 uuid wine)
+target_link_libraries(comdlg32 uuid wine ${PSEH_LIB})
 add_delay_importlibs(comdlg32 ole32)
 add_importlibs(comdlg32 shell32 shlwapi comctl32 winspool user32 gdi32 advapi32 msvcrt kernel32 ntdll)
 add_pch(comdlg32 precomp.h SOURCE)

--- a/dll/win32/comdlg32/printdlg.c
+++ b/dll/win32/comdlg32/printdlg.c
@@ -3129,8 +3129,9 @@ static BOOL pagesetup_change_printer(LPWSTR name, pagesetup_data *data)
     pagesetup_set_devmode(data, dm);
 #ifdef __REACTOS__
     if(!data->u.dlgw->hDevMode)
-    {    ERR("pagesetup_set_devmode failed\n");
-         goto end;
+    {
+        ERR("pagesetup_set_devmode failed\n");
+        goto end;
     }
 #endif
     pagesetup_set_devnames(data, drv_info->pDriverPath, prn_info->pPrinterName,

--- a/dll/win32/comdlg32/printdlg.c
+++ b/dll/win32/comdlg32/printdlg.c
@@ -3452,7 +3452,7 @@ static BOOL pagesetup_wm_command(HWND hDlg, WPARAM wParam, LPARAM lParam, pagese
 #ifdef __REACTOS__
             if (pagesetup_change_printer(name, data))
             {
-                ERR("pagesetup_change_printer failed.\n");
+                ERR("pagesetup_change_printer failed\n");
                 return FALSE;
             }
 #else
@@ -3935,7 +3935,7 @@ static BOOL pagesetup_common(pagesetup_data *data)
 #ifdef __REACTOS__
         if (!pagesetup_change_printer(def, data))
         {
-            ERR("pagesetup_change_printer failed.\n");
+            ERR("pagesetup_change_printer failed\n");
             return FALSE;
         }
 #else

--- a/win32ss/printing/base/winspool/printers.c
+++ b/win32ss/printing/base/winspool/printers.c
@@ -599,6 +599,11 @@ DeviceCapabilitiesW(LPCWSTR pDevice, LPCWSTR pPort, WORD fwCapability, LPWSTR pO
             {
                 iDevCap = fpDeviceCapabilities( hPrinter, (PWSTR)pDevice, fwCapability, pOutput, (PDEVMODE)pDevMode );
             }
+            else
+            {
+                FIXME("Handle ReactOS Not Able to Print Wine Tests\n");
+                if (fwCapability == DC_COPIES) iDevCap = 0;
+            }
 
             FreeLibrary(hLibrary);
         }

--- a/win32ss/printing/base/winspool/printers.c
+++ b/win32ss/printing/base/winspool/printers.c
@@ -601,7 +601,7 @@ DeviceCapabilitiesW(LPCWSTR pDevice, LPCWSTR pPort, WORD fwCapability, LPWSTR pO
             }
             else
             {
-                FIXME("Handle ReactOS Not Able to Print Wine Tests\n");
+                FIXME("Handle ReactOS not able to print Wine tests\n");
                 if (fwCapability == DC_COPIES) iDevCap = 0;
             }
 


### PR DESCRIPTION
## Purpose

_Fix crashes in winetest comdlg32:printdlg._
JIRA issue: [CORE-19173](https://jira.reactos.org/browse/CORE-19173)

## Proposed changes

_Use PSEH to check for bad memory parameters and test for NULL parameters in print functions._

Testbot results for comdlg32:printdlg:
printing_crash_fix.patch JID66371 on top of 0.4.15-dev-6611-ge4512e6

VBox: https://reactos.org/testman/compare.php?ids=89526,89546 LGTM
KVM: https://reactos.org/testman/compare.php?ids=89525,89547 LGTM