### PR TITLE
[DDRAW] Revert 67559215608eaf7338cbc7002ba3b74bf972a3a4. CORE-19167

### DIFF
--- a/dll/directx/wine/ddraw/ddraw_private.h
+++ b/dll/directx/wine/ddraw/ddraw_private.h
@@ -218,7 +218,7 @@ void ddraw_surface_init(struct ddraw_surface *surface, struct ddraw *ddraw,
         struct wined3d_texture *wined3d_texture, unsigned int sub_resource_idx,
         const struct wined3d_parent_ops **parent_ops) DECLSPEC_HIDDEN;
 HRESULT ddraw_surface_update_frontbuffer(struct ddraw_surface *surface,
-        const RECT *rect, BOOL read, unsigned int swap_interval) DECLSPEC_HIDDEN;
+        const RECT *rect, BOOL read) DECLSPEC_HIDDEN;
 
 static inline struct ddraw_surface *impl_from_IDirect3DTexture(IDirect3DTexture *iface)
 {

--- a/dll/directx/wine/ddraw/palette.c
+++ b/dll/directx/wine/ddraw/palette.c
@@ -176,7 +176,7 @@ static HRESULT WINAPI ddraw_palette_SetEntries(IDirectDrawPalette *iface,
     hr = wined3d_palette_set_entries(palette->wined3d_palette, flags, start, count, entries);
 
     if (SUCCEEDED(hr) && palette->flags & DDPCAPS_PRIMARYSURFACE)
-        ddraw_surface_update_frontbuffer(palette->ddraw->primary, NULL, FALSE, 0);
+        ddraw_surface_update_frontbuffer(palette->ddraw->primary, NULL, FALSE);
 
     wined3d_mutex_unlock();
 

--- a/media/doc/WINESYNC.txt
+++ b/media/doc/WINESYNC.txt
@@ -28,7 +28,7 @@ dll/directx/wine/d3dcompiler_43 # Synced to WineStaging-4.18
 dll/directx/wine/d3drm          # Synced to WineStaging-4.18
 dll/directx/wine/d3dx9_24 => 43 # Synced to WineStaging-6.0-rc5
 dll/directx/wine/d3dxof         # Synced to WineStaging-4.18
-dll/directx/wine/ddraw          # Synced to WineStaging-3.3 (+ partial sync of ddraw_private.h, palette.c, and surface.c to wine-7.19-557-g13cc08e32d6)
+dll/directx/wine/ddraw          # Synced to WineStaging-3.3
 dll/directx/wine/devenum        # Synced to WineStaging-4.18
 dll/directx/wine/dinput         # Synced to WineStaging-4.18
 dll/directx/wine/dinput8        # Synced to WineStaging-4.18


### PR DESCRIPTION
Proposal to temporarily revert 67559215608eaf7338cbc7002ba3b74bf972a3a4.

## Purpose

As stated in the the ticket me and a few discord community members have noticed for awhile now that ReactOS's DirectX has been acting a little weird. Only during my investigations into syncing modern WINE did I realize the extent of what was happening and what was going on. 
This PR is to fix one of the biggest problem we're running into; Many ddraw games currently don't seem to update the entire surface anymore. During a bisection we found out it ended up being since this commit was introduced. Attached below is a picture of how games looked (If they launched at all).

I propose we temporarily revert this and reassign [CORE-18547](https://jira.reactos.org/browse/CORE-18547) to me as I continue to sync and update wine using the associated script this will be reintroduced back into master sooner then later. This "un-forks" ddraw as well and allows the WINE script to be happy again.

Thanks winterhell for the help in bisection!
And I'll try to get ReactOS this patch back as soon as possible simone :)

![image](https://github.com/reactos/reactos/assets/23200630/09756a13-c9fb-490f-9125-fe124ee17942)

JIRA issue: [CORE-19167](https://jira.reactos.org/browse/CORE-19167)

## Proposed changes
just revert the partial sync for now.
