### PR TITLE
[SCRNSAVE] Avoid (DLGPROC) cast

### DIFF
--- a/sdk/lib/scrnsave/scrnsave.c
+++ b/sdk/lib/scrnsave/scrnsave.c
@@ -1,11 +1,10 @@
 /*
- * PROJECT:         ReactOS Screen Saver Library
- * LICENSE:         GPL v2 or any later version
- * FILE:            lib/sdk/scrnsave/scrnsave.c
- * PURPOSE:         Library for writing screen savers, compatible with
- *                  MS' scrnsave.lib without Win9x support.
- * PROGRAMMERS:     Anders Norlander <anorland@hem2.passagen.se>
- *                  Colin Finck <mail@colinfinck.de>
+ * PROJECT:     ReactOS Screen Saver Library
+ * LICENSE:     GPL v2 or any later version
+ * PURPOSE:     Library for writing screen savers, compatible with
+ *              MS' scrnsave.lib without Win9x support.
+ * COPYRIGHT:   Anders Norlander <anorland@hem2.passagen.se>
+ *              Colin Finck <mail@colinfinck.de>
  */
 
 #include <stdarg.h>
@@ -171,7 +170,7 @@ static int LaunchConfig(HWND hParent)
         return -1;
 
     return DialogBox(hMainInstance, MAKEINTRESOURCE(DLG_SCRNSAVECONFIGURE),
-                     hParent, (DLGPROC)ScreenSaverConfigureDialog);
+                     hParent, ScreenSaverConfigureDialog);
 }
 
 static int LaunchScreenSaver(HWND hParent)


### PR DESCRIPTION
## Purpose

(DLGPROC) casts are bad.
This one isn't as trivial as the others,
because our many screensavers are not entirely consistent in the signature of their individual
ScreenSaverConfigureDialog().
https://git.reactos.org/?p=reactos.git&a=search&h=HEAD&st=grep&s=ScreenSaverConfigureDialog

Interestingly MS does claim its signature to still be BOOL (not INT_PTR).
https://learn.microsoft.com/en-us/windows/win32/api/scrnsave/nf-scrnsave-screensaverconfiguredialog

In the future all our screensavers maybe should be harmonized to match that. Nevertheless GCC didn't spit errors or warnings on this commit locally. I do intend to let the buildbots confirm the same for all other supported compilers.

JIRA issue: none
