### PR TITLE
[CMICONTROL] Fix MSVC 14.2 dbg x64 warning C4267

### DIFF
--- a/drivers/wdm/audio/drivers/CMIDriver/cmicontrol/main.cpp
+++ b/drivers/wdm/audio/drivers/CMIDriver/cmicontrol/main.cpp
@@ -804,7 +804,7 @@ void printUsage()
 
 void deleteDriverFiles() {
 	TCHAR SysDir[MAX_PATH];
-	unsigned int len;
+	size_t len;
 	if (GetSystemDirectory(SysDir, sizeof(SysDir))==0) {
 		PrintLastError("GetSystemDirectory()");
 		return;


### PR DESCRIPTION
## Purpose

Can be observed on the buildbots:
2023-09-17T14:19:34.2051345Z [10663/14808] Building CXX object drivers\wdm\audio\drivers\CMIDriver\cmicontrol\CMakeFiles\cmicontrol.dir\main.cpp.obj 2023-09-17T14:19:34.2052611Z D:\a\reactos\reactos\src\drivers\wdm\audio\drivers\CMIDriver\cmicontrol\main.cpp(818): warning C4267: '=': conversion from 'size_t' to 'unsigned int', possible loss of data

JIRA issue: none
