### PR TITLE
[SHLWAPI][SHLWAPI_APITEST] Fix SHGetPerScreenResName

### DIFF
--- a/dll/win32/shlwapi/propbag.cpp
+++ b/dll/win32/shlwapi/propbag.cpp
@@ -1947,9 +1947,12 @@ SHGetPerScreenResName(
     if (dwReserved)
         return 0;
 
-    INT cxWidth = ::GetSystemMetrics(SM_CXFULLSCREEN);
-    INT cyHeight = ::GetSystemMetrics(SM_CYFULLSCREEN);
+    HDC hDC = ::GetDC(NULL);
+    INT cxWidth = ::GetDeviceCaps(hDC, HORZRES);
+    INT cyHeight = ::GetDeviceCaps(hDC, VERTRES);
     INT cMonitors = ::GetSystemMetrics(SM_CMONITORS);
+    ::ReleaseDC(NULL, hDC);
+
     StringCchPrintfW(pszBuffer, cchBuffer, L"%dx%d(%d)", cxWidth, cyHeight, cMonitors);
     return lstrlenW(pszBuffer);
 }

--- a/modules/rostests/apitests/shlwapi/CMakeLists.txt
+++ b/modules/rostests/apitests/shlwapi/CMakeLists.txt
@@ -25,6 +25,6 @@ add_rc_deps(testdata.rc ${CMAKE_CURRENT_BINARY_DIR}/shlwapi_resource_dll/shlwapi
 add_executable(shlwapi_apitest ${SOURCE})
 set_module_type(shlwapi_apitest win32cui)
 target_link_libraries(shlwapi_apitest ${PSEH_LIB} uuid)
-add_importlibs(shlwapi_apitest shlwapi oleaut32 ole32 user32 advapi32 msvcrt kernel32)
+add_importlibs(shlwapi_apitest shlwapi oleaut32 ole32 user32 gdi32 advapi32 msvcrt kernel32)
 add_dependencies(shlwapi_apitest shlwapi_resource_dll)
 add_rostests_file(TARGET shlwapi_apitest)

--- a/modules/rostests/apitests/shlwapi/SHPropertyBag.cpp
+++ b/modules/rostests/apitests/shlwapi/SHPropertyBag.cpp
@@ -826,10 +826,14 @@ static void SHPropertyBag_OnIniFile(void)
 
 static void SHPropertyBag_PerScreenRes(void)
 {
+    HDC hDC = GetDC(NULL);
+    INT cxWidth = GetDeviceCaps(hDC, HORZRES);
+    INT cyHeight = GetDeviceCaps(hDC, VERTRES);
+    INT cMonitors = GetSystemMetrics(SM_CMONITORS);
+    ReleaseDC(NULL, hDC);
+
     WCHAR szBuff1[64], szBuff2[64];
-    StringCchPrintfW(szBuff1, _countof(szBuff1), L"%dx%d(%d)",
-                     GetSystemMetrics(SM_CXFULLSCREEN), GetSystemMetrics(SM_CYFULLSCREEN),
-                     GetSystemMetrics(SM_CMONITORS));
+    StringCchPrintfW(szBuff1, _countof(szBuff1), L"%dx%d(%d)", cxWidth, cyHeight, cMonitors);
 
     szBuff2[0] = UNICODE_NULL;
     SHGetPerScreenResName(szBuff2, _countof(szBuff2), 0);


### PR DESCRIPTION
## Purpose

https://reactos.org/testman/detail.php?id=66922401&prev=0
```txt
SHPropertyBag.cpp:836: Test failed: Wrong string. Expected '1024x768(1)', got '1024x719(1)'
```

JIRA issue: [CORE-9283](https://jira.reactos.org/browse/CORE-9283)

## Proposed changes

- Use `HORZRES` and `VERTRES` instead of `SM_CXFULLSCREEN` and `SM_CYFULLSCREEN`.

## TODO

- [x] Do small tests.

## Comparison

WinXP:
![WinXP](https://github.com/reactos/reactos/assets/2107452/96ce8815-e16f-4cbc-aafb-c22a42f8e92b)
Successful.

Win2k3:
![Win2k3](https://github.com/reactos/reactos/assets/2107452/75ebeb2a-aeb4-44ec-85ba-dc149bd9169a)
Successful.

Win10:
![Win10](https://github.com/reactos/reactos/assets/2107452/c2b01d41-7629-44f8-a959-abbc34c3df0c)
Successful.