### PR TITLE
[NTUSER] Rewrite Window Snap handling

### DIFF
--- a/win32ss/user/ntuser/defwnd.c
+++ b/win32ss/user/ntuser/defwnd.c
@@ -790,9 +790,6 @@ IntDefWindowProc(
          }
          if (g_bWindowSnapEnabled && (IS_KEY_DOWN(gafAsyncKeyState, VK_LWIN) || IS_KEY_DOWN(gafAsyncKeyState, VK_RWIN)))
          {
-            BOOL IsTaskBar;
-            DWORD StyleTB;
-            DWORD ExStyleTB;
             HWND hwndTop = UserGetForegroundWindow();
             PWND topWnd = UserGetWindowObject(hwndTop);
 
@@ -800,102 +797,56 @@ IntDefWindowProc(
             if (!topWnd)
                return 0;
 
-            // We want to forbid snapping operations on the TaskBar
-            // We use a heuristic for detecting the TaskBar Wnd by its typical Style & ExStyle Values
-            ExStyleTB = (topWnd->ExStyle & WS_EX_TOOLWINDOW);
-            StyleTB = (topWnd->style & (WS_POPUP | WS_VISIBLE | WS_CLIPSIBLINGS | WS_CLIPCHILDREN));
-            IsTaskBar = (StyleTB == (WS_POPUP | WS_VISIBLE | WS_CLIPSIBLINGS | WS_CLIPCHILDREN))
-                        && (ExStyleTB == WS_EX_TOOLWINDOW);
-            TRACE("ExStyle=%x Style=%x IsTaskBar=%d\n", ExStyleTB, StyleTB, IsTaskBar);
-
-            if (!IsTaskBar)
+            if (IntIsSnapAllowedForWindow(topWnd))
             {
+               UINT snapped = IntGetWindowSnapEdge(topWnd);
+
                if ((topWnd->style & WS_THICKFRAME) == 0)
                   return 0;
 
                if (wParam == VK_DOWN)
                {
                    if (topWnd->style & WS_MAXIMIZE)
-                   {
-                       co_IntSendMessage(hwndTop, WM_SYSCOMMAND, SC_RESTORE, lParam);
-
-                       /* "Normal size" must be erased after restoring, otherwise it will block next side snap actions */
-                       RECTL_vSetEmptyRect(&topWnd->InternalPos.NormalRect);
-                   }
+                       co_IntSendMessage(hwndTop, WM_SYSCOMMAND, SC_RESTORE, MAKELONG(0, 1));
+                   else if (snapped)
+                       co_IntUnsnapWindow(topWnd);
                    else
-                   {
-                       co_IntSendMessage(hwndTop, WM_SYSCOMMAND, SC_MINIMIZE, lParam);
-                   }
+                       co_IntSendMessage(hwndTop, WM_SYSCOMMAND, SC_MINIMIZE, MAKELONG(0, 1));
                }
                else if (wParam == VK_UP)
                {
-                  RECT currentRect;
-                  if ((topWnd->InternalPos.NormalRect.right == topWnd->InternalPos.NormalRect.left) ||
-                      (topWnd->InternalPos.NormalRect.top == topWnd->InternalPos.NormalRect.bottom))
-                  {
-                      currentRect = topWnd->rcWindow;
-                  }
-                  else
-                  {
-                      currentRect = topWnd->InternalPos.NormalRect;
-                  }
-                  co_IntSendMessage(hwndTop, WM_SYSCOMMAND, SC_MAXIMIZE, 0);
-
-                  // save normal rect if maximazing snapped window
-                  topWnd->InternalPos.NormalRect = currentRect;
+                   if (topWnd->style & WS_MINIMIZE)
+                       co_IntSendMessage(hwndTop, WM_SYSCOMMAND, SC_RESTORE, MAKELONG(0, 1));
+                   else
+                       co_IntSendMessage(hwndTop, WM_SYSCOMMAND, SC_MAXIMIZE, MAKELONG(0, 1));
                }
                else if (wParam == VK_LEFT || wParam == VK_RIGHT)
                {
-                  RECT snapRect, normalRect, windowRect;
-                  BOOL snapped;
-                  normalRect = topWnd->InternalPos.NormalRect;
-                  snapped = (normalRect.left != 0 && normalRect.right != 0 &&
-                             normalRect.top != 0 && normalRect.bottom != 0);
+                  UINT edge = wParam == VK_LEFT ? HTLEFT : HTRIGHT;
+                  UINT otherEdge = edge == HTLEFT ? HTRIGHT : HTLEFT;
 
                   if (topWnd->style & WS_MAXIMIZE)
                   {
-                     co_IntSendMessage(hwndTop, WM_SYSCOMMAND, SC_RESTORE, lParam);
-                     snapped = FALSE;
+                     /* SC_RESTORE + Snap causes the window to visually move twice, place it manually in the snap position */
+                     RECT normalRect = topWnd->InternalPos.NormalRect;
+                     co_IntCalculateSnapPosition(topWnd, edge, &topWnd->InternalPos.NormalRect); /* Place us here please */
+                     IntSetSnapEdge(topWnd, edge); /* Tell everyone the edge we are snapped to */
+                     co_IntSendMessage(hwndTop, WM_SYSCOMMAND, SC_RESTORE, MAKELONG(0, 1));
+                     IntSetSnapInfo(topWnd, edge, &normalRect); /* Reset the real place to unsnap to */
+                     snapped = FALSE; /* Force snap */
                   }
-                  windowRect = topWnd->rcWindow;
+                  #if 0 /* Windows 8 does this but is it a good feature? */
+                  else if (snapped == edge)
+                  {
+                       /* Already snapped to this edge, snap to the opposite side */
+                     edge = otherEdge;
+                  }
+                  #endif
 
-                  UserSystemParametersInfo(SPI_GETWORKAREA, 0, &snapRect, 0);
-                  if (wParam == VK_LEFT)
-                  {
-                     snapRect.right = (snapRect.left + snapRect.right) / 2;
-                  }
-                  else // VK_RIGHT
-                  {
-                     snapRect.left = (snapRect.left + snapRect.right) / 2;
-                  }
-
-                  if (snapped)
-                  {
-                     // if window was snapped but moved to other location - restore normal size
-                     if (!IntEqualRect(&snapRect, &windowRect))
-                     {
-                        RECT empty = {0, 0, 0, 0};
-                        co_WinPosSetWindowPos(topWnd,
-                                              0,
-                                              normalRect.left,
-                                              normalRect.top,
-                                              normalRect.right - normalRect.left,
-                                              normalRect.bottom - normalRect.top,
-                                              0);
-                        topWnd->InternalPos.NormalRect = empty;
-                     }
-                  }
+                  if (snapped == otherEdge)
+                     co_IntUnsnapWindow(topWnd);
                   else
-                  {
-                     co_WinPosSetWindowPos(topWnd,
-                                           0,
-                                           snapRect.left,
-                                           snapRect.top,
-                                           snapRect.right - snapRect.left,
-                                           snapRect.bottom - snapRect.top,
-                                           0);
-                     topWnd->InternalPos.NormalRect = windowRect;
-                  }
+                     co_IntSnapWindow(topWnd, edge);
                }
             }
          }

--- a/win32ss/user/ntuser/defwnd.c
+++ b/win32ss/user/ntuser/defwnd.c
@@ -792,17 +792,19 @@ IntDefWindowProc(
          {
             HWND hwndTop = UserGetForegroundWindow();
             PWND topWnd = UserGetWindowObject(hwndTop);
+            BOOL allowSnap = FALSE;
 
             // MS Doc: foreground window can be NULL, e.g. when window is losing activation
             if (!topWnd)
                return 0;
 
-            if (IntIsSnapAllowedForWindow(topWnd))
+            allowSnap = IntIsSnapAllowedForWindow(topWnd);
+            if (!allowSnap && (topWnd->style & (WS_MINIMIZEBOX|WS_THICKFRAME)) == WS_MINIMIZEBOX)
+                allowSnap = wParam == VK_DOWN; // Allow minimize Calc.exe
+
+            if (allowSnap)
             {
                UINT snapped = IntGetWindowSnapEdge(topWnd);
-
-               if ((topWnd->style & WS_THICKFRAME) == 0)
-                  return 0;
 
                if (wParam == VK_DOWN)
                {

--- a/win32ss/user/ntuser/defwnd.c
+++ b/win32ss/user/ntuser/defwnd.c
@@ -835,13 +835,13 @@ IntDefWindowProc(
                      IntSetSnapInfo(topWnd, edge, &normalRect); /* Reset the real place to unsnap to */
                      snapped = FALSE; /* Force snap */
                   }
-                  #if 0 /* Windows 8 does this but is it a good feature? */
+#if 0 /* Windows 8 does this but is it a good feature? */
                   else if (snapped == edge)
                   {
                        /* Already snapped to this edge, snap to the opposite side */
                      edge = otherEdge;
                   }
-                  #endif
+#endif
 
                   if (snapped == otherEdge)
                      co_IntUnsnapWindow(topWnd);

--- a/win32ss/user/ntuser/defwnd.c
+++ b/win32ss/user/ntuser/defwnd.c
@@ -799,8 +799,9 @@ IntDefWindowProc(
                return 0;
 
             allowSnap = IntIsSnapAllowedForWindow(topWnd);
+            /* Allow the minimize action if it has a minimize button, even if the window cannot be snapped (eg. Calc.exe) */
             if (!allowSnap && (topWnd->style & (WS_MINIMIZEBOX|WS_THICKFRAME)) == WS_MINIMIZEBOX)
-                allowSnap = wParam == VK_DOWN; // Allow minimize Calc.exe
+                allowSnap = wParam == VK_DOWN;
 
             if (allowSnap)
             {
@@ -835,12 +836,12 @@ IntDefWindowProc(
                      IntSetSnapEdge(topWnd, edge); /* Tell everyone the edge we are snapped to */
                      co_IntSendMessage(hwndTop, WM_SYSCOMMAND, SC_RESTORE, MAKELONG(0, 1));
                      IntSetSnapInfo(topWnd, edge, &normalRect); /* Reset the real place to unsnap to */
-                     snapped = FALSE; /* Force snap */
+                     snapped = HTNOWHERE; /* Force snap */
                   }
 #if 0 /* Windows 8 does this but is it a good feature? */
                   else if (snapped == edge)
                   {
-                       /* Already snapped to this edge, snap to the opposite side */
+                     /* Already snapped to this edge, snap to the opposite side */
                      edge = otherEdge;
                   }
 #endif

--- a/win32ss/user/ntuser/defwnd.c
+++ b/win32ss/user/ntuser/defwnd.c
@@ -792,14 +792,14 @@ IntDefWindowProc(
          {
             HWND hwndTop = UserGetForegroundWindow();
             PWND topWnd = UserGetWindowObject(hwndTop);
-            BOOL allowSnap = FALSE;
+            BOOL allowSnap;
 
             // MS Doc: foreground window can be NULL, e.g. when window is losing activation
             if (!topWnd)
                return 0;
 
             allowSnap = IntIsSnapAllowedForWindow(topWnd);
-            /* Allow the minimize action if it has a minimize button, even if the window cannot be snapped (eg. Calc.exe) */
+            /* Allow the minimize action if it has a minimize button, even if the window cannot be snapped (e.g. Calc.exe) */
             if (!allowSnap && (topWnd->style & (WS_MINIMIZEBOX|WS_THICKFRAME)) == WS_MINIMIZEBOX)
                 allowSnap = wParam == VK_DOWN;
 
@@ -832,7 +832,7 @@ IntDefWindowProc(
                   {
                      /* SC_RESTORE + Snap causes the window to visually move twice, place it manually in the snap position */
                      RECT normalRect = topWnd->InternalPos.NormalRect;
-                     co_IntCalculateSnapPosition(topWnd, edge, &topWnd->InternalPos.NormalRect); /* Place us here please */
+                     co_IntCalculateSnapPosition(topWnd, edge, &topWnd->InternalPos.NormalRect); /* Calculate edge position */
                      IntSetSnapEdge(topWnd, edge); /* Tell everyone the edge we are snapped to */
                      co_IntSendMessage(hwndTop, WM_SYSCOMMAND, SC_RESTORE, MAKELONG(0, 1));
                      IntSetSnapInfo(topWnd, edge, &normalRect); /* Reset the real place to unsnap to */

--- a/win32ss/user/ntuser/nonclient.c
+++ b/win32ss/user/ntuser/nonclient.c
@@ -309,7 +309,7 @@ DefWndDoSizeMove(PWND pwnd, WORD wParam)
       {
           co_UserSetCapture(UserHMGetHandle(pwnd));
           hittest = DefWndStartSizeMove(pwnd, wParam, &capturePoint);
-	  if (!hittest)
+          if (!hittest)
           {
               IntReleaseCapture();
               return;
@@ -444,10 +444,10 @@ DefWndDoSizeMove(PWND pwnd, WORD wParam)
 
       if (msg.message == WM_KEYDOWN) switch(msg.wParam)
       {
-	case VK_UP:    pt.y -= 8; break;
-	case VK_DOWN:  pt.y += 8; break;
-	case VK_LEFT:  pt.x -= 8; break;
-	case VK_RIGHT: pt.x += 8; break;
+      case VK_UP:    pt.y -= 8; break;
+      case VK_DOWN:  pt.y += 8; break;
+      case VK_LEFT:  pt.x -= 8; break;
+      case VK_RIGHT: pt.x += 8; break;
       }
 
       pt.x = max( pt.x, mouseRect.left );
@@ -460,9 +460,9 @@ DefWndDoSizeMove(PWND pwnd, WORD wParam)
 
       if (dx || dy)
       {
-	  if ( !moved )
-	  {
-	      moved = TRUE;
+      if ( !moved )
+      {
+          moved = TRUE;
           if ( iconic ) /* ok, no system popup tracking */
           {
               OldCursor = UserSetCursor(DragCursor, FALSE);
@@ -470,7 +470,7 @@ DefWndDoSizeMove(PWND pwnd, WORD wParam)
           }
           else if(!DragFullWindows)
              UserDrawMovingFrame( hdc, &sizingRect, thickframe );
-	  }
+      }
 
       if (msg.message == WM_KEYDOWN)
       {
@@ -537,12 +537,12 @@ DefWndDoSizeMove(PWND pwnd, WORD wParam)
               /* regular window moving */
               RECTL_vOffsetRect(&newRect, dx, dy);
           }
-	      if (ON_LEFT_BORDER(hittest)) newRect.left += dx;
-	      else if (ON_RIGHT_BORDER(hittest)) newRect.right += dx;
-	      if (ON_TOP_BORDER(hittest)) newRect.top += dy;
-	      else if (ON_BOTTOM_BORDER(hittest)) newRect.bottom += dy;
+          if (ON_LEFT_BORDER(hittest)) newRect.left += dx;
+          else if (ON_RIGHT_BORDER(hittest)) newRect.right += dx;
+          if (ON_TOP_BORDER(hittest)) newRect.top += dy;
+          else if (ON_BOTTOM_BORDER(hittest)) newRect.bottom += dy;
 
-	      capturePoint = pt;
+          capturePoint = pt;
 
               //
               //  Save the new position to the unmodified rectangle. This allows explorer task bar
@@ -551,7 +551,7 @@ DefWndDoSizeMove(PWND pwnd, WORD wParam)
               //
               unmodRect = newRect;
 
-	      /* determine the hit location */
+          /* determine the hit location */
               if (syscommand == SC_SIZE)
               {
                   WPARAM wpSizingHit = 0;
@@ -563,7 +563,7 @@ DefWndDoSizeMove(PWND pwnd, WORD wParam)
               else
                   co_IntSendMessage( UserHMGetHandle(pwnd), WM_MOVING, 0, (LPARAM)&newRect );
 
-	      if (!iconic)
+              if (!iconic)
               {
                  if (!DragFullWindows)
                      UserDrawMovingFrame( hdc, &newRect, thickframe );
@@ -611,7 +611,7 @@ DefWndDoSizeMove(PWND pwnd, WORD wParam)
                  }
               }
               sizingRect = newRect;
-	  }
+        }
       }
    }
 
@@ -704,15 +704,14 @@ DefWndDoSizeMove(PWND pwnd, WORD wParam)
 
    if ( IntIsWindow(UserHMGetHandle(pwnd)) )
    {
-     if ( iconic )
-     {
-	/* Single click brings up the system menu when iconized */
-	if ( !moved )
-        {
-	    if( Style & WS_SYSMENU )
-	      co_IntSendMessage( UserHMGetHandle(pwnd), WM_SYSCOMMAND, SC_MOUSEMENU + HTSYSMENU, MAKELONG(pt.x,pt.y));
-        }
-     }
+      if ( iconic )
+      {
+         /* Single click brings up the system menu when iconized */
+         if ( !moved && ( Style & WS_SYSMENU ) )
+         {
+            co_IntSendMessage( UserHMGetHandle(pwnd), WM_SYSCOMMAND, SC_MOUSEMENU + HTSYSMENU, MAKELONG(pt.x,pt.y));
+         }
+      }
    }
 }
 

--- a/win32ss/user/ntuser/nonclient.c
+++ b/win32ss/user/ntuser/nonclient.c
@@ -300,7 +300,6 @@ DefWndDoSizeMove(PWND pwnd, WORD wParam)
    }
    else  /* SC_SIZE */
    {
-      RECTL_vSetEmptyRect(&pwnd->InternalPos.NormalRect); /* CORE-19160 */
       if (!thickframe) return;
       if (hittest && (syscommand != SC_MOUSEMENU))
       {
@@ -495,7 +494,7 @@ DefWndDoSizeMove(PWND pwnd, WORD wParam)
                   !RECTL_bIsEmptyRect(&pwnd->InternalPos.NormalRect))
               {
                   *r = pwnd->InternalPos.NormalRect;
-                  origRect = *r; /* Save normal size - it required when window unsnapped from one side and snapped to another holding mouse down */
+                  origRect = *r; /* Save normal size - is required when window unsnapped from one side and snapped to another holding mouse down */
 
                   /* Try to position the center of the caption where the mouse is horizontally */
                   capcy = UserGetSystemMetrics((ExStyle & WS_EX_TOPMOST) ? SM_CYSMCAPTION : SM_CYCAPTION); /* No border, close enough */

--- a/win32ss/user/ntuser/nonclient.c
+++ b/win32ss/user/ntuser/nonclient.c
@@ -563,7 +563,7 @@ DefWndDoSizeMove(PWND pwnd, WORD wParam)
               //
               unmodRect = newRect;
 
-              /* determine the hit location */
+              /* Determine the hit location */
               if (syscommand == SC_SIZE)
               {
                   WPARAM wpSizingHit = 0;

--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -550,7 +550,8 @@ WinPosInitInternalPos(PWND Wnd, RECTL *RestoreRect)
    }
    else
    {
-      /* Lie about the snap */
+      /* Lie about the snap; Windows does this so applications don't save their
+       * position as a snap but rather the unsnapped "real" position. */
       if (!IntIsWindowSnapped(Wnd) ||
           RECTL_bIsEmptyRect(&Wnd->InternalPos.NormalRect))
       {

--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -3904,7 +3904,7 @@ IntGetWindowSnapEdge(PWND Wnd)
 {
     if (Wnd->ExStyle2 & WS_EX2_VERTICALLYMAXIMIZEDLEFT) return HTLEFT;
     if (Wnd->ExStyle2 & WS_EX2_VERTICALLYMAXIMIZEDRIGHT) return HTRIGHT;
-    return 0;
+    return HTNOWHERE;
 }
 
 VOID FASTCALL
@@ -3920,7 +3920,7 @@ co_IntCalculateSnapPosition(PWND Wnd, UINT Edge, OUT RECT *Pos)
     height = Pos->bottom - Pos->top;
     height = min(max(height, mint.y), maxt.y);
 
-    switch(Edge)
+    switch (Edge)
     {
     case HTTOP: /* Maximized (Calculate RECT snap preview for SC_MOVE) */
         height = min(Pos->bottom - Pos->top, maxs.y);
@@ -3974,7 +3974,7 @@ co_IntSnapWindow(PWND Wnd, UINT Edge)
     }
 
     TRACE("WindowSnap: %d->%d\n", IntGetWindowSnapEdge(Wnd), Edge);
-    co_WinPosSetWindowPos(Wnd, NULL,
+    co_WinPosSetWindowPos(Wnd, HWND_TOP,
                           newPos.left,
                           newPos.top,
                           newPos.right - newPos.left,
@@ -3989,7 +3989,7 @@ IntSetSnapEdge(PWND Wnd, UINT Edge)
 {
     UINT styleMask = WS_EX2_VERTICALLYMAXIMIZEDLEFT | WS_EX2_VERTICALLYMAXIMIZEDRIGHT;
     UINT style = 0;
-    switch(Edge)
+    switch (Edge)
     {
     case HTNOWHERE:
         style = 0;
@@ -4010,11 +4010,11 @@ IntSetSnapEdge(PWND Wnd, UINT Edge)
 }
 
 VOID FASTCALL
-IntSetSnapInfo(PWND Wnd, UINT Edge, IN const RECT *Pos)
+IntSetSnapInfo(PWND Wnd, UINT Edge, IN const RECT *Pos OPTIONAL)
 {
     RECT r;
     IntSetSnapEdge(Wnd, Edge);
-    if (!Edge)
+    if (Edge != HTNOWHERE)
     {
         RECTL_vSetEmptyRect(&r);
         Pos = (Wnd->style & WS_MINIMIZE) ? NULL : &r;

--- a/win32ss/user/ntuser/winpos.h
+++ b/win32ss/user/ntuser/winpos.h
@@ -84,10 +84,10 @@ co_IntUnsnapWindow(PWND w)
     co_IntSnapWindow(w, 0);
 }
 
-FORCEINLINE UINT
+FORCEINLINE BOOLEAN
 IntIsWindowSnapped(PWND w)
 {
-    return w->ExStyle2 & (WS_EX2_VERTICALLYMAXIMIZEDLEFT|WS_EX2_VERTICALLYMAXIMIZEDRIGHT);
+    return (w->ExStyle2 & (WS_EX2_VERTICALLYMAXIMIZEDLEFT | WS_EX2_VERTICALLYMAXIMIZEDRIGHT)) != 0;
 }
 
 FORCEINLINE BOOLEAN
@@ -95,10 +95,10 @@ IntIsSnapAllowedForWindow(PWND w)
 {
     /* We want to forbid snapping operations on the TaskBar and on child windows */
     /* We use a heuristic for detecting the TaskBar by its typical Style & ExStyle */
-    UINT style = w->style;
-    UINT tbws = WS_POPUP | WS_VISIBLE | WS_CLIPSIBLINGS | WS_CLIPCHILDREN;
-    UINT tbes = WS_EX_TOOLWINDOW;
-    BOOL istb = (style & tbws) == tbws && (w->ExStyle & (tbes|WS_EX_APPWINDOW)) == tbes;
-    BOOL thickframe = (style & WS_THICKFRAME) && (style & (WS_DLGFRAME|WS_BORDER)) != WS_DLGFRAME;
+    const UINT style = w->style;
+    const UINT tbws = WS_POPUP | WS_VISIBLE | WS_CLIPSIBLINGS | WS_CLIPCHILDREN;
+    const UINT tbes = WS_EX_TOOLWINDOW;
+    BOOLEAN istb = (style & tbws) == tbws && (w->ExStyle & (tbes|WS_EX_APPWINDOW)) == tbes;
+    BOOLEAN thickframe = (style & WS_THICKFRAME) && (style & (WS_DLGFRAME|WS_BORDER)) != WS_DLGFRAME;
     return thickframe && !(style & WS_CHILD) && !istb;
 }

--- a/win32ss/user/ntuser/winpos.h
+++ b/win32ss/user/ntuser/winpos.h
@@ -95,8 +95,10 @@ IntIsSnapAllowedForWindow(PWND w)
 {
     /* We want to forbid snapping operations on the TaskBar and on child windows */
     /* We use a heuristic for detecting the TaskBar by its typical Style & ExStyle */
+    UINT style = w->style;
     UINT tbws = WS_POPUP | WS_VISIBLE | WS_CLIPSIBLINGS | WS_CLIPCHILDREN;
     UINT tbes = WS_EX_TOOLWINDOW;
-    BOOL istb = (w->style & tbws) == tbws && (w->ExStyle & (tbes|WS_EX_APPWINDOW)) == tbes;
-    return !(w->style & WS_CHILD) && !istb;
+    BOOL istb = (style & tbws) == tbws && (w->ExStyle & (tbes|WS_EX_APPWINDOW)) == tbes;
+    BOOL thickframe = (style & WS_THICKFRAME) && (style & (WS_DLGFRAME|WS_BORDER)) != WS_DLGFRAME;
+    return thickframe && !(style & WS_CHILD) && !istb;
 }

--- a/win32ss/user/ntuser/winpos.h
+++ b/win32ss/user/ntuser/winpos.h
@@ -71,3 +71,32 @@ BOOL FASTCALL IntClientToScreen(PWND,LPPOINT);
 BOOL FASTCALL IntGetWindowRect(PWND,RECTL*);
 BOOL UserHasWindowEdge(DWORD,DWORD);
 VOID UserGetWindowBorders(DWORD,DWORD,SIZE*,BOOL);
+
+UINT FASTCALL IntGetWindowSnapEdge(PWND Wnd);
+VOID FASTCALL co_IntCalculateSnapPosition(PWND Wnd, UINT Edge, OUT RECT *Pos);
+VOID FASTCALL co_IntSnapWindow(PWND Wnd, UINT Edge);
+VOID FASTCALL IntSetSnapEdge(PWND Wnd, UINT Edge);
+VOID FASTCALL IntSetSnapInfo(PWND Wnd, UINT Edge, IN const RECT *Pos);
+
+FORCEINLINE VOID
+co_IntUnsnapWindow(PWND w)
+{
+    co_IntSnapWindow(w, 0);
+}
+
+FORCEINLINE UINT
+IntIsWindowSnapped(PWND w)
+{
+    return w->ExStyle2 & (WS_EX2_VERTICALLYMAXIMIZEDLEFT|WS_EX2_VERTICALLYMAXIMIZEDRIGHT);
+}
+
+FORCEINLINE BOOLEAN
+IntIsSnapAllowedForWindow(PWND w)
+{
+    /* We want to forbid snapping operations on the TaskBar and on child windows */
+    /* We use a heuristic for detecting the TaskBar by its typical Style & ExStyle */
+    UINT tbws = WS_POPUP | WS_VISIBLE | WS_CLIPSIBLINGS | WS_CLIPCHILDREN;
+    UINT tbes = WS_EX_TOOLWINDOW;
+    BOOL istb = (w->style & tbws) == tbws && (w->ExStyle & (tbes|WS_EX_APPWINDOW)) == tbes;
+    return !(w->style & WS_CHILD) && !istb;
+}

--- a/win32ss/user/ntuser/winpos.h
+++ b/win32ss/user/ntuser/winpos.h
@@ -76,29 +76,29 @@ UINT FASTCALL IntGetWindowSnapEdge(PWND Wnd);
 VOID FASTCALL co_IntCalculateSnapPosition(PWND Wnd, UINT Edge, OUT RECT *Pos);
 VOID FASTCALL co_IntSnapWindow(PWND Wnd, UINT Edge);
 VOID FASTCALL IntSetSnapEdge(PWND Wnd, UINT Edge);
-VOID FASTCALL IntSetSnapInfo(PWND Wnd, UINT Edge, IN const RECT *Pos);
+VOID FASTCALL IntSetSnapInfo(PWND Wnd, UINT Edge, IN const RECT *Pos OPTIONAL);
 
 FORCEINLINE VOID
-co_IntUnsnapWindow(PWND w)
+co_IntUnsnapWindow(PWND Wnd)
 {
-    co_IntSnapWindow(w, 0);
+    co_IntSnapWindow(Wnd, 0);
 }
 
 FORCEINLINE BOOLEAN
-IntIsWindowSnapped(PWND w)
+IntIsWindowSnapped(PWND Wnd)
 {
-    return (w->ExStyle2 & (WS_EX2_VERTICALLYMAXIMIZEDLEFT | WS_EX2_VERTICALLYMAXIMIZEDRIGHT)) != 0;
+    return (Wnd->ExStyle2 & (WS_EX2_VERTICALLYMAXIMIZEDLEFT | WS_EX2_VERTICALLYMAXIMIZEDRIGHT)) != 0;
 }
 
 FORCEINLINE BOOLEAN
-IntIsSnapAllowedForWindow(PWND w)
+IntIsSnapAllowedForWindow(PWND Wnd)
 {
     /* We want to forbid snapping operations on the TaskBar and on child windows */
     /* We use a heuristic for detecting the TaskBar by its typical Style & ExStyle */
-    const UINT style = w->style;
+    const UINT style = Wnd->style;
     const UINT tbws = WS_POPUP | WS_VISIBLE | WS_CLIPSIBLINGS | WS_CLIPCHILDREN;
     const UINT tbes = WS_EX_TOOLWINDOW;
-    BOOLEAN istb = (style & tbws) == tbws && (w->ExStyle & (tbes|WS_EX_APPWINDOW)) == tbes;
+    BOOLEAN istb = (style & tbws) == tbws && (Wnd->ExStyle & (tbes|WS_EX_APPWINDOW)) == tbes;
     BOOLEAN thickframe = (style & WS_THICKFRAME) && (style & (WS_DLGFRAME|WS_BORDER)) != WS_DLGFRAME;
     return thickframe && !(style & WS_CHILD) && !istb;
 }

--- a/win32ss/user/ntuser/winpos.h
+++ b/win32ss/user/ntuser/winpos.h
@@ -93,12 +93,12 @@ IntIsWindowSnapped(PWND Wnd)
 FORCEINLINE BOOLEAN
 IntIsSnapAllowedForWindow(PWND Wnd)
 {
-    /* We want to forbid snapping operations on the TaskBar and on child windows */
-    /* We use a heuristic for detecting the TaskBar by its typical Style & ExStyle */
+    /* We want to forbid snapping operations on the TaskBar and on child windows.
+     * We use a heuristic for detecting the TaskBar by its typical Style & ExStyle. */
     const UINT style = Wnd->style;
     const UINT tbws = WS_POPUP | WS_VISIBLE | WS_CLIPSIBLINGS | WS_CLIPCHILDREN;
     const UINT tbes = WS_EX_TOOLWINDOW;
-    BOOLEAN istb = (style & tbws) == tbws && (Wnd->ExStyle & (tbes|WS_EX_APPWINDOW)) == tbes;
-    BOOLEAN thickframe = (style & WS_THICKFRAME) && (style & (WS_DLGFRAME|WS_BORDER)) != WS_DLGFRAME;
+    BOOLEAN istb = (style & tbws) == tbws && (Wnd->ExStyle & (tbes | WS_EX_APPWINDOW)) == tbes;
+    BOOLEAN thickframe = (style & WS_THICKFRAME) && (style & (WS_DLGFRAME | WS_BORDER)) != WS_DLGFRAME;
     return thickframe && !(style & WS_CHILD) && !istb;
 }


### PR DESCRIPTION
This fixes many Window Snap related bugs and uses the `WS_EX2_VERTICALLYMAXIMIZED*` styles to remember which edge it is snapped to.

The most significant change is that `GetWindowPlacement` lies about the normal position when it is snapped, just like Windows.

Fixes:
* JIRA issue: [CORE-19165](https://jira.reactos.org/browse/CORE-19165)
* JIRA issue: [CORE-19166](https://jira.reactos.org/browse/CORE-19166)
* JIRA issue: [CORE-19160](https://jira.reactos.org/browse/CORE-19160)

Partially fixes:
* JIRA issue: [CORE-16331](https://jira.reactos.org/browse/CORE-16331) (Fixed only for `!DragFullWindows`)
* JIRA issue: [CORE-18039](https://jira.reactos.org/browse/CORE-18039) (Now follows Windows 8 exactly, if this means fixed is up for debate I suppose, it does not meet the reporters definition of fixed but that could be handled by using `SW_SHOWMINIMIZED` but Windows does not)

