### PR TITLE
[SHELL32][SDK] Implement SHGetShellStyleHInstance

### DIFF
--- a/dll/win32/shell32/stubs.cpp
+++ b/dll/win32/shell32/stubs.cpp
@@ -1234,14 +1234,3 @@ DWORD WINAPI SHGetComputerDisplayNameW(DWORD param1, DWORD param2, DWORD param3,
     FIXME("SHGetComputerDisplayNameW() stub\n");
     return E_FAIL;
 }
-
-/*
- * Unimplemented
- */
-EXTERN_C HINSTANCE
-WINAPI
-SHGetShellStyleHInstance(VOID)
-{
-    FIXME("SHGetShellStyleHInstance() stub\n");
-    return NULL;
-}

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -21,7 +21,7 @@ SHGetShellStyleHInstance(VOID)
     HRESULT hr;
     CStringW strShellStyle;
 
-    TRACE("\n");
+    TRACE("SHGetShellStyleHInstance called\n");
 
     /* First, attempt to load the shellstyle dll from the current active theme */
     hr = GetCurrentThemeName(szPath, _countof(szPath), szColorName, _countof(szColorName), NULL, 0);

--- a/sdk/include/psdk/shlobj.h
+++ b/sdk/include/psdk/shlobj.h
@@ -336,7 +336,7 @@ SHOpenFolderAndSelectItems(
 
 int WINAPI PathCleanupSpec(_In_opt_ LPCWSTR, _Inout_ LPWSTR);
 
-#if (_WIN32_WINNT_WINXP <= _WIN32_WINNT) && (_WIN32_WINNT <= _WIN32_WINNT_WS03)
+#if (_WIN32_WINNT >= _WIN32_WINNT_WINXP) && (_WIN32_WINNT <= _WIN32_WINNT_WS03)
 HINSTANCE WINAPI SHGetShellStyleHInstance(VOID);
 #endif
 

--- a/sdk/include/psdk/shlobj.h
+++ b/sdk/include/psdk/shlobj.h
@@ -336,6 +336,10 @@ SHOpenFolderAndSelectItems(
 
 int WINAPI PathCleanupSpec(_In_opt_ LPCWSTR, _Inout_ LPWSTR);
 
+#if (_WIN32_WINNT_WINXP <= _WIN32_WINNT) && (_WIN32_WINNT <= _WIN32_WINNT_WS03)
+HINSTANCE WINAPI SHGetShellStyleHInstance(VOID);
+#endif
+
 /*****************************************************************************
  * IContextMenu interface
  */


### PR DESCRIPTION
## Purpose
This PR supersedes PR #3851.
JIRA issue: [CORE-17707](https://jira.reactos.org/browse/CORE-17707)
Co-authored-by: Oleg Dubinskiy <oleg.dubinskij30@gmail.com>

## Proposed changes

- Implement `SHGetShellStyleHInstance` function.
- Add `SHGetShellStyleHInstance` prototype to `<shlobj.h>`.