### PR TITLE
[MSPAINT] Don't show error message twice

### DIFF
--- a/base/applications/mspaint/history.cpp
+++ b/base/applications/mspaint/history.cpp
@@ -261,26 +261,25 @@ void ImageModel::Clamp(POINT& pt) const
 
 HBITMAP ImageModel::CopyBitmap()
 {
-    // NOTE: An app cannot select a bitmap into more than one device context at a time.
-    ::SelectObject(m_hDrawingDC, m_hbmOld); // De-select
-    HBITMAP ret = CopyDIBImage(m_hBms[m_currInd]);
-    m_hbmOld = ::SelectObject(m_hDrawingDC, m_hBms[m_currInd]); // Re-select
+    HBITMAP hBitmap = LockBitmap();
+    HBITMAP ret = CopyDIBImage(hBitmap);
+    UnlockBitmap(hBitmap);
     return ret;
 }
 
 BOOL ImageModel::IsBlackAndWhite()
 {
-    ::SelectObject(m_hDrawingDC, m_hbmOld); // De-select
-    BOOL bBlackAndWhite = IsBitmapBlackAndWhite(m_hBms[m_currInd]);
-    m_hbmOld = ::SelectObject(m_hDrawingDC, m_hBms[m_currInd]); // Re-select
+    HBITMAP hBitmap = LockBitmap();
+    BOOL bBlackAndWhite = IsBitmapBlackAndWhite(hBitmap);
+    UnlockBitmap(hBitmap);
     return bBlackAndWhite;
 }
 
 void ImageModel::PushBlackAndWhite()
 {
-    ::SelectObject(m_hDrawingDC, m_hbmOld); // De-select
-    HBITMAP hNewBitmap = ConvertToBlackAndWhite(m_hBms[m_currInd]);
-    m_hbmOld = ::SelectObject(m_hDrawingDC, m_hBms[m_currInd]); // Re-select
+    HBITMAP hBitmap = LockBitmap();
+    HBITMAP hNewBitmap = ConvertToBlackAndWhite(hBitmap);
+    UnlockBitmap(hBitmap);
 
     if (hNewBitmap)
         PushImageForUndo(hNewBitmap);
@@ -288,8 +287,11 @@ void ImageModel::PushBlackAndWhite()
 
 HBITMAP ImageModel::LockBitmap()
 {
+    // NOTE: An app cannot select a bitmap into more than one device context at a time.
     ::SelectObject(m_hDrawingDC, m_hbmOld); // De-select
-    return m_hBms[m_currInd];
+    HBITMAP hbmLocked = m_hBms[m_currInd];
+    m_hBms[m_currInd] = NULL;
+    return hbmLocked;
 }
 
 void ImageModel::UnlockBitmap(HBITMAP hbmLocked)

--- a/base/applications/mspaint/history.cpp
+++ b/base/applications/mspaint/history.cpp
@@ -285,3 +285,15 @@ void ImageModel::PushBlackAndWhite()
     if (hNewBitmap)
         PushImageForUndo(hNewBitmap);
 }
+
+HBITMAP ImageModel::LockBitmap()
+{
+    ::SelectObject(m_hDrawingDC, m_hbmOld); // De-select
+    return m_hBms[m_currInd];
+}
+
+void ImageModel::UnlockBitmap(HBITMAP hbmLocked)
+{
+    m_hBms[m_currInd] = hbmLocked;
+    m_hbmOld = ::SelectObject(m_hDrawingDC, hbmLocked); // Re-select
+}

--- a/base/applications/mspaint/history.h
+++ b/base/applications/mspaint/history.h
@@ -31,6 +31,8 @@ public:
     int GetWidth() const;
     int GetHeight() const;
     HBITMAP CopyBitmap();
+    HBITMAP LockBitmap();
+    void UnlockBitmap(HBITMAP hbmLocked);
     void InvertColors();
     void FlipHorizontally();
     void FlipVertically();

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -117,9 +117,9 @@ BOOL OpenMailer(HWND hWnd, LPCWSTR pszPathName)
             strFileTitle += L".png";
 
             // Save it to the temporary file
-            HBITMAP hbm = imageModel.CopyBitmap();
-            BOOL ret = SaveDIBToFile(hbm, g_szMailTempFile, FALSE, Gdiplus::ImageFormatPNG);
-            ::DeleteObject(hbm);
+            HBITMAP hbmLocked = imageModel.LockBitmap();
+            BOOL ret = SaveDIBToFile(hbmLocked, g_szMailTempFile, FALSE, Gdiplus::ImageFormatPNG);
+            imageModel.UnlockBitmap(hbmLocked);
             if (!ret)
             {
                 g_szMailTempFile[0] = UNICODE_NULL;

--- a/base/applications/mspaint/selectionmodel.cpp
+++ b/base/applications/mspaint/selectionmodel.cpp
@@ -528,3 +528,15 @@ void SelectionModel::SwapWidthAndHeight()
     m_rc.right = m_rc.left + cy;
     m_rc.bottom = m_rc.top + cx;
 }
+
+HBITMAP SelectionModel::LockBitmap()
+{
+    HBITMAP hbm = m_hbmColor;
+    m_hbmColor = NULL;
+    return hbm;
+}
+
+void SelectionModel::UnlockBitmap(HBITMAP hbmLocked)
+{
+    m_hbmColor = hbmLocked;
+}

--- a/base/applications/mspaint/selectionmodel.h
+++ b/base/applications/mspaint/selectionmodel.h
@@ -40,6 +40,8 @@ public:
     void DeleteSelection();
 
     HBITMAP CopyBitmap();
+    HBITMAP LockBitmap();
+    void UnlockBitmap(HBITMAP hbmLocked);
     void GetSelectionContents(HDC hDCImage);
     void DrawFramePoly(HDC hDCImage);
     void DrawBackground(HDC hDCImage);

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -865,8 +865,7 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
             if (GetSaveFileName(szFileName, _countof(szFileName)))
             {
                 HBITMAP hbm = selectionModel.CopyBitmap();
-                if (!SaveDIBToFile(hbm, szFileName, FALSE))
-                    ShowError(IDS_SAVEERROR, szFileName);
+                SaveDIBToFile(hbm, szFileName, FALSE);
                 ::DeleteObject(hbm);
             }
             break;
@@ -879,8 +878,6 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
                 HBITMAP hbmNew = DoLoadImageFile(m_hWnd, szFileName, FALSE);
                 if (hbmNew)
                     InsertSelectionFromHBITMAP(hbmNew, m_hWnd);
-                else
-                    ShowError(IDS_LOADERRORTEXT, szFileName);
             }
             break;
         }

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -740,13 +740,13 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
             selectionModel.TakeOff();
 
             {
-                HBITMAP hbm = selectionModel.CopyBitmap();
-                if (hbm)
+                HBITMAP hbmLocked = selectionModel.LockBitmap();
+                if (hbmLocked)
                 {
-                    HGLOBAL hGlobal = BitmapToClipboardDIB(hbm);
+                    HGLOBAL hGlobal = BitmapToClipboardDIB(hbmLocked);
                     if (hGlobal)
                         ::SetClipboardData(CF_DIB, hGlobal);
-                    ::DeleteObject(hbm);
+                    selectionModel.UnlockBitmap(hbmLocked);
                 }
             }
 
@@ -864,9 +864,9 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
             WCHAR szFileName[MAX_LONG_PATH] = L"*.png";
             if (GetSaveFileName(szFileName, _countof(szFileName)))
             {
-                HBITMAP hbm = selectionModel.CopyBitmap();
-                SaveDIBToFile(hbm, szFileName, FALSE);
-                ::DeleteObject(hbm);
+                HBITMAP hbmLocked = selectionModel.LockBitmap();
+                SaveDIBToFile(hbmLocked, szFileName, FALSE);
+                selectionModel.UnlockBitmap(hbmLocked);
             }
             break;
         }
@@ -1004,7 +1004,6 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
             imageModel.PushImageForUndo(selectionModel.CopyBitmap());
             selectionModel.HideSelection();
             break;
-
         case IDM_VIEWTOOLBOX:
             registrySettings.ShowToolBox = !toolBoxContainer.IsWindowVisible();
             toolBoxContainer.ShowWindow(registrySettings.ShowToolBox ? SW_SHOWNOACTIVATE : SW_HIDE);


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-19181](https://jira.reactos.org/browse/CORE-19181), [CORE-19182](https://jira.reactos.org/browse/CORE-19182)

## Proposed changes

- Reduce display of error message on `IDM_EDITCOPYTO` and `IDM_EDITPASTEFROM` command actions.
- Introduce `LockBitmap`/`UnlockBitmap` mechanism for `ImageModel` and `SelectionModel`.