### PR TITLE
[NTOS:CM] Fix lock leak

### DIFF
--- a/ntoskrnl/config/cmalloc.c
+++ b/ntoskrnl/config/cmalloc.c
@@ -176,6 +176,9 @@ SearchKcbList:
             /* Now go back and search the list */
             goto SearchKcbList;
         }
+
+        /* Release the allocation lock */
+        KeReleaseGuardedMutex(&CmpAllocBucketLock);
     }
 
     /* Allocate a KCB only */


### PR DESCRIPTION
Triggered by low available pool memory during kmtest ExPools.
