### PR TITLE
[SAMSRV] Fix SamrQuerySecurityObject on x64

### DIFF
--- a/dll/win32/lsasrv/lsarpc.c
+++ b/dll/win32/lsasrv/lsarpc.c
@@ -201,7 +201,7 @@ LsarQuerySecurityObject(
     PLSAPR_SR_SECURITY_DESCRIPTOR *SecurityDescriptor)
 {
     PLSA_DB_OBJECT DbObject = NULL;
-    PSECURITY_DESCRIPTOR RelativeSd = NULL;
+    PISECURITY_DESCRIPTOR_RELATIVE RelativeSd = NULL;
     PSECURITY_DESCRIPTOR ResultSd = NULL;
     PLSAPR_SR_SECURITY_DESCRIPTOR SdData = NULL;
     ACCESS_MASK DesiredAccess = 0;
@@ -256,16 +256,16 @@ LsarQuerySecurityObject(
 
     /* Invalidate the SD information that was not requested */
     if (!(SecurityInformation & OWNER_SECURITY_INFORMATION))
-        ((PISECURITY_DESCRIPTOR)RelativeSd)->Owner = NULL;
+        RelativeSd->Owner = 0;
 
     if (!(SecurityInformation & GROUP_SECURITY_INFORMATION))
-        ((PISECURITY_DESCRIPTOR)RelativeSd)->Group = NULL;
+        RelativeSd->Group = 0;
 
     if (!(SecurityInformation & DACL_SECURITY_INFORMATION))
-        ((PISECURITY_DESCRIPTOR)RelativeSd)->Control &= ~SE_DACL_PRESENT;
+        RelativeSd->Control &= ~SE_DACL_PRESENT;
 
     if (!(SecurityInformation & SACL_SECURITY_INFORMATION))
-        ((PISECURITY_DESCRIPTOR)RelativeSd)->Control &= ~SE_SACL_PRESENT;
+        RelativeSd->Control &= ~SE_SACL_PRESENT;
 
     /* Calculate the required SD size */
     Status = RtlMakeSelfRelativeSD(RelativeSd,
@@ -298,7 +298,7 @@ LsarQuerySecurityObject(
     }
 
     /* Fill the SD data buffer and return it to the caller */
-    SdData->Length = RelativeSdSize;
+    SdData->Length = ResultSdSize;
     SdData->SecurityDescriptor = (PBYTE)ResultSd;
 
     *SecurityDescriptor = SdData;

--- a/dll/win32/samsrv/samrpc.c
+++ b/dll/win32/samsrv/samrpc.c
@@ -332,7 +332,7 @@ SamrQuerySecurityObject(IN SAMPR_HANDLE ObjectHandle,
 {
     PSAM_DB_OBJECT SamObject;
     PSAMPR_SR_SECURITY_DESCRIPTOR SdData = NULL;
-    PSECURITY_DESCRIPTOR RelativeSd = NULL;
+    PISECURITY_DESCRIPTOR_RELATIVE RelativeSd = NULL;
     PSECURITY_DESCRIPTOR ResultSd = NULL;
     ACCESS_MASK DesiredAccess = 0;
     ULONG RelativeSdSize = 0;
@@ -397,16 +397,16 @@ SamrQuerySecurityObject(IN SAMPR_HANDLE ObjectHandle,
 
     /* Invalidate the SD information that was not requested */
     if (!(SecurityInformation & OWNER_SECURITY_INFORMATION))
-        ((PISECURITY_DESCRIPTOR)RelativeSd)->Owner = NULL;
+        RelativeSd->Owner = 0;
 
     if (!(SecurityInformation & GROUP_SECURITY_INFORMATION))
-        ((PISECURITY_DESCRIPTOR)RelativeSd)->Group = NULL;
+        RelativeSd->Group = 0;
 
     if (!(SecurityInformation & DACL_SECURITY_INFORMATION))
-        ((PISECURITY_DESCRIPTOR)RelativeSd)->Control &= ~SE_DACL_PRESENT;
+        RelativeSd->Control &= ~SE_DACL_PRESENT;
 
     if (!(SecurityInformation & SACL_SECURITY_INFORMATION))
-        ((PISECURITY_DESCRIPTOR)RelativeSd)->Control &= ~SE_SACL_PRESENT;
+        RelativeSd->Control &= ~SE_SACL_PRESENT;
 
     /* Calculate the required SD size */
     Status = RtlMakeSelfRelativeSD(RelativeSd,
@@ -439,7 +439,7 @@ SamrQuerySecurityObject(IN SAMPR_HANDLE ObjectHandle,
     }
 
     /* Fill the SD data buffer and return it to the caller */
-    SdData->Length = RelativeSdSize;
+    SdData->Length = ResultSdSize;
     SdData->SecurityDescriptor = (PBYTE)ResultSd;
 
     *SecurityDescriptor = SdData;

--- a/ntoskrnl/include/internal/se.h
+++ b/ntoskrnl/include/internal/se.h
@@ -87,7 +87,7 @@ typedef struct _TOKEN_AUDIT_POLICY_INFORMATION
 FORCEINLINE
 PSID
 SepGetGroupFromDescriptor(
-    _Inout_ PVOID _Descriptor)
+    _Inout_ PSECURITY_DESCRIPTOR _Descriptor)
 {
     PISECURITY_DESCRIPTOR Descriptor = (PISECURITY_DESCRIPTOR)_Descriptor;
     PISECURITY_DESCRIPTOR_RELATIVE SdRel;
@@ -107,7 +107,7 @@ SepGetGroupFromDescriptor(
 FORCEINLINE
 PSID
 SepGetOwnerFromDescriptor(
-    _Inout_ PVOID _Descriptor)
+    _Inout_ PSECURITY_DESCRIPTOR _Descriptor)
 {
     PISECURITY_DESCRIPTOR Descriptor = (PISECURITY_DESCRIPTOR)_Descriptor;
     PISECURITY_DESCRIPTOR_RELATIVE SdRel;
@@ -127,7 +127,7 @@ SepGetOwnerFromDescriptor(
 FORCEINLINE
 PACL
 SepGetDaclFromDescriptor(
-    _Inout_ PVOID _Descriptor)
+    _Inout_ PSECURITY_DESCRIPTOR _Descriptor)
 {
     PISECURITY_DESCRIPTOR Descriptor = (PISECURITY_DESCRIPTOR)_Descriptor;
     PISECURITY_DESCRIPTOR_RELATIVE SdRel;
@@ -149,7 +149,7 @@ SepGetDaclFromDescriptor(
 FORCEINLINE
 PACL
 SepGetSaclFromDescriptor(
-    _Inout_ PVOID _Descriptor)
+    _Inout_ PSECURITY_DESCRIPTOR _Descriptor)
 {
     PISECURITY_DESCRIPTOR Descriptor = (PISECURITY_DESCRIPTOR)_Descriptor;
     PISECURITY_DESCRIPTOR_RELATIVE SdRel;

--- a/sdk/lib/rtl/sd.c
+++ b/sdk/lib/rtl/sd.c
@@ -42,7 +42,7 @@ RtlpValidateSDOffsetAndSize(IN ULONG Offset,
 
 VOID
 NTAPI
-RtlpQuerySecurityDescriptor(IN PISECURITY_DESCRIPTOR SecurityDescriptor,
+RtlpQuerySecurityDescriptor(IN PSECURITY_DESCRIPTOR SecurityDescriptor,
                             OUT PSID *Owner,
                             OUT PULONG OwnerSize,
                             OUT PSID *PrimaryGroup,
@@ -644,7 +644,7 @@ RtlAbsoluteToSelfRelativeSD(IN PSECURITY_DESCRIPTOR AbsoluteSecurityDescriptor,
  */
 NTSTATUS
 NTAPI
-RtlMakeSelfRelativeSD(IN PSECURITY_DESCRIPTOR AbsoluteSD,
+RtlMakeSelfRelativeSD(IN PSECURITY_DESCRIPTOR SecurityDescriptor,
                       OUT PSECURITY_DESCRIPTOR SelfRelativeSD,
                       IN OUT PULONG BufferLength)
 {
@@ -652,12 +652,11 @@ RtlMakeSelfRelativeSD(IN PSECURITY_DESCRIPTOR AbsoluteSD,
     PACL Sacl, Dacl;
     ULONG OwnerLength, GroupLength, SaclLength, DaclLength, TotalLength;
     ULONG_PTR Current;
-    PISECURITY_DESCRIPTOR Sd = (PISECURITY_DESCRIPTOR)AbsoluteSD;
     PISECURITY_DESCRIPTOR_RELATIVE RelSd = (PISECURITY_DESCRIPTOR_RELATIVE)SelfRelativeSD;
     PAGED_CODE_RTL();
 
     /* Query all components */
-    RtlpQuerySecurityDescriptor(Sd,
+    RtlpQuerySecurityDescriptor(SecurityDescriptor,
                                 &Owner,
                                 &OwnerLength,
                                 &Group,
@@ -687,7 +686,7 @@ RtlMakeSelfRelativeSD(IN PSECURITY_DESCRIPTOR AbsoluteSD,
 
     /* Copy the header fields */
     RtlCopyMemory(RelSd,
-                  Sd,
+                  SecurityDescriptor,
                   FIELD_OFFSET(SECURITY_DESCRIPTOR_RELATIVE, Owner));
 
     /* Set the current copy pointer */


### PR DESCRIPTION
Fixes crash of netapi32_winetest access on x64

Testbot:
- x86 KVM: https://reactos.org/testman/compare.php?ids=89792,89797
- x64 KVM: https://reactos.org/testman/compare.php?ids=89786,89791 (netapi32:access crash fixed, the rest is random)

