### PR TITLE
[MSPAINT] Restrict drawing direction on Shift key

### DIFF
--- a/base/applications/mspaint/common.h
+++ b/base/applications/mspaint/common.h
@@ -48,3 +48,6 @@ BOOL nearlyEqualPoints(INT x0, INT y0, INT x1, INT y1);
 void updateStartAndLast(LONG x, LONG y);
 void updateLast(LONG x, LONG y);
 BOOL OpenMailer(HWND hWnd, LPCWSTR pszPathName);
+
+#define DEG2RAD(degree) (((degree) * M_PI) / 180)
+#define RAD2DEG(radian) ((LONG)(((radian) * 180) / M_PI))

--- a/base/applications/mspaint/common.h
+++ b/base/applications/mspaint/common.h
@@ -45,8 +45,6 @@ enum HITTEST // hit
 
 BOOL zoomTo(int newZoom, int mouseX, int mouseY);
 BOOL nearlyEqualPoints(INT x0, INT y0, INT x1, INT y1);
-void updateStartAndLast(LONG x, LONG y);
-void updateLast(LONG x, LONG y);
 BOOL OpenMailer(HWND hWnd, LPCWSTR pszPathName);
 
 #define DEG2RAD(degree) (((degree) * M_PI) / 180)

--- a/base/applications/mspaint/dib.cpp
+++ b/base/applications/mspaint/dib.cpp
@@ -338,10 +338,6 @@ HBITMAP Rotate90DegreeBlt(HDC hDC1, INT cx, INT cy, BOOL bRight, BOOL bMono)
     return hbm2;
 }
 
-#ifndef M_PI
-    #define M_PI 3.14159265
-#endif
-
 HBITMAP SkewDIB(HDC hDC1, HBITMAP hbm, INT nDegree, BOOL bVertical, BOOL bMono)
 {
     CWaitCursor waitCursor;

--- a/base/applications/mspaint/dib.cpp
+++ b/base/applications/mspaint/dib.cpp
@@ -6,7 +6,6 @@
  */
 
 #include "precomp.h"
-#include <math.h>
 
 INT g_fileSize = 0;
 float g_xDpi = 96;

--- a/base/applications/mspaint/drawing.cpp
+++ b/base/applications/mspaint/drawing.cpp
@@ -115,7 +115,7 @@ Fill(HDC hdc, LONG x, LONG y, COLORREF color)
 void
 Erase(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, COLORREF color, LONG radius)
 {
-    LONG b = max(1, max(abs(x2 - x1), abs(y2 - y1)));
+    LONG b = max(1, max(labs(x2 - x1), labs(y2 - y1)));
     HBRUSH hbr = ::CreateSolidBrush(color);
 
     for (LONG a = 0; a <= b; a++)
@@ -132,7 +132,7 @@ Erase(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, COLORREF color, LONG radius)
 void
 Replace(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, COLORREF fg, COLORREF bg, LONG radius)
 {
-    LONG b = max(1, max(abs(x2 - x1), abs(y2 - y1)));
+    LONG b = max(1, max(labs(x2 - x1), labs(y2 - y1)));
 
     for (LONG a = 0; a <= b; a++)
     {
@@ -169,7 +169,7 @@ Brush(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, COLORREF color, LONG style)
     HPEN oldPen = (HPEN) SelectObject(hdc, CreatePen(PS_SOLID, 1, color));
     HBRUSH oldBrush = (HBRUSH) SelectObject(hdc, CreateSolidBrush(color));
     LONG a, b;
-    b = max(1, max(abs(x2 - x1), abs(y2 - y1)));
+    b = max(1, max(labs(x2 - x1), labs(y2 - y1)));
     switch (style)
     {
         case 0:

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -323,8 +323,6 @@ struct TwoPointDrawTool : ToolBase
 
     void OnButtonUp(BOOL bLeftButton, LONG x, LONG y) override
     {
-        g_ptEnd.x = x;
-        g_ptEnd.y = y;
         imageModel.PushImageForUndo();
         OnDrawOverlayOnImage(m_hdc);
         m_bDrawing = FALSE;

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -369,8 +369,6 @@ GetDirection(LONG x0, LONG y0, LONG x1, LONG y1)
         return NO_DIRECTION;
 
     double radian = atan2((double)dy, (double)dx);
-#define DEG2RAD(degree) (((degree) * M_PI) / 180)
-#define RAD2DEG(radian) ((LONG)(((radian) * 180) / M_PI))
     if (radian < DEG2RAD(-180 + THRESHOULD_DEG))
     {
         ATLTRACE("DIRECTION_HORIZONTAL: %ld\n", RAD2DEG(radian));
@@ -413,8 +411,6 @@ GetDirection(LONG x0, LONG y0, LONG x1, LONG y1)
     }
     ATLTRACE("DIRECTION_HORIZONTAL: %ld\n", RAD2DEG(radian));
     return DIRECTION_HORIZONTAL;
-#undef DEG2RAD
-#undef RAD2DEG
 }
 
 static void

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -337,10 +337,6 @@ typedef enum DIRECTION
     DIRECTION_DIAGONAL_RIGHT_UP,
 } DIRECTION;
 
-#ifndef M_PI
-    #define M_PI 3.14156265
-#endif
-
 #define THRESHOULD_DEG 15
 
 static DIRECTION

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -772,7 +772,6 @@ struct TextTool : ToolBase
         textEditWindow.ValidateEditRect(&rc);
         textEditWindow.ShowWindow(SW_SHOWNOACTIVATE);
         textEditWindow.SetFocus();
-        updateLast(x, y);
     }
 
     void OnFinishDraw() override

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -414,6 +414,7 @@ GetDirection(LONG x0, LONG y0, LONG x1, LONG y1)
     ATLTRACE("DIRECTION_HORIZONTAL: %ld\n", RAD2DEG(radian));
     return DIRECTION_HORIZONTAL;
 #undef DEG2RAD
+#undef RAD2DEG
 }
 
 static void

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -50,18 +50,6 @@ BOOL nearlyEqualPoints(INT x0, INT y0, INT x1, INT y1)
     return (abs(x1 - x0) <= cxThreshold) && (abs(y1 - y0) <= cyThreshold);
 }
 
-void updateStartAndLast(LONG x, LONG y)
-{
-    g_ptStart.x = g_ptEnd.x = x;
-    g_ptStart.y = g_ptEnd.y = y;
-}
-
-void updateLast(LONG x, LONG y)
-{
-    g_ptEnd.x = x;
-    g_ptEnd.y = y;
-}
-
 void ToolBase::reset()
 {
     s_pointSP = 0;
@@ -471,7 +459,8 @@ struct SmoothDrawTool : ToolBase
             {
                 m_direction = NO_DIRECTION;
                 draw(bLeftButton, x, y);
-                updateStartAndLast(x, y);
+                g_ptStart.x = g_ptEnd.x = x;
+                g_ptStart.y = g_ptEnd.y = y;
                 return TRUE;
             }
         }

--- a/base/applications/mspaint/precomp.h
+++ b/base/applications/mspaint/precomp.h
@@ -21,6 +21,7 @@
 #include <commdlg.h>
 #include <commctrl.h>
 #include <stdlib.h>
+#include <math.h>
 #include <shellapi.h>
 #include <htmlhelp.h>
 #include "atlimagedx.h"

--- a/base/applications/mspaint/precomp.h
+++ b/base/applications/mspaint/precomp.h
@@ -21,6 +21,7 @@
 #include <commdlg.h>
 #include <commctrl.h>
 #include <stdlib.h>
+#define _USE_MATH_DEFINES /* for M_PI */
 #include <math.h>
 #include <shellapi.h>
 #include <htmlhelp.h>

--- a/base/applications/mspaint/toolsmodel.cpp
+++ b/base/applications/mspaint/toolsmodel.cpp
@@ -189,7 +189,6 @@ void ToolsModel::NotifyZoomChanged()
 void ToolsModel::OnButtonDown(BOOL bLeftButton, LONG x, LONG y, BOOL bDoubleClick)
 {
     m_pToolObject->beginEvent();
-    updateStartAndLast(x, y);
     m_pToolObject->OnButtonDown(bLeftButton, x, y, bDoubleClick);
     m_pToolObject->endEvent();
 }
@@ -198,7 +197,6 @@ void ToolsModel::OnMouseMove(BOOL bLeftButton, LONG x, LONG y)
 {
     m_pToolObject->beginEvent();
     m_pToolObject->OnMouseMove(bLeftButton, x, y);
-    updateLast(x, y);
     m_pToolObject->endEvent();
 }
 
@@ -206,7 +204,6 @@ void ToolsModel::OnButtonUp(BOOL bLeftButton, LONG x, LONG y)
 {
     m_pToolObject->beginEvent();
     m_pToolObject->OnButtonUp(bLeftButton, x, y);
-    updateLast(x, y);
     m_pToolObject->endEvent();
 }
 

--- a/base/applications/mspaint/toolsmodel.cpp
+++ b/base/applications/mspaint/toolsmodel.cpp
@@ -190,20 +190,23 @@ void ToolsModel::OnButtonDown(BOOL bLeftButton, LONG x, LONG y, BOOL bDoubleClic
 {
     m_pToolObject->beginEvent();
     m_pToolObject->OnButtonDown(bLeftButton, x, y, bDoubleClick);
+    updateStartAndLast(x, y);
     m_pToolObject->endEvent();
 }
 
 void ToolsModel::OnMouseMove(BOOL bLeftButton, LONG x, LONG y)
 {
     m_pToolObject->beginEvent();
-    m_pToolObject->OnMouseMove(bLeftButton, x, y);
+    if (m_pToolObject->OnMouseMove(bLeftButton, x, y))
+        updateLast(x, y);
     m_pToolObject->endEvent();
 }
 
 void ToolsModel::OnButtonUp(BOOL bLeftButton, LONG x, LONG y)
 {
     m_pToolObject->beginEvent();
-    m_pToolObject->OnButtonUp(bLeftButton, x, y);
+    if (m_pToolObject->OnButtonUp(bLeftButton, x, y))
+        updateLast(x, y);
     m_pToolObject->endEvent();
 }
 

--- a/base/applications/mspaint/toolsmodel.cpp
+++ b/base/applications/mspaint/toolsmodel.cpp
@@ -190,7 +190,8 @@ void ToolsModel::OnButtonDown(BOOL bLeftButton, LONG x, LONG y, BOOL bDoubleClic
 {
     m_pToolObject->beginEvent();
     m_pToolObject->OnButtonDown(bLeftButton, x, y, bDoubleClick);
-    updateStartAndLast(x, y);
+    g_ptStart.x = g_ptEnd.x = x;
+    g_ptStart.y = g_ptEnd.y = y;
     m_pToolObject->endEvent();
 }
 
@@ -198,7 +199,10 @@ void ToolsModel::OnMouseMove(BOOL bLeftButton, LONG x, LONG y)
 {
     m_pToolObject->beginEvent();
     if (m_pToolObject->OnMouseMove(bLeftButton, x, y))
-        updateLast(x, y);
+    {
+        g_ptEnd.x = x;
+        g_ptEnd.y = y;
+    }
     m_pToolObject->endEvent();
 }
 
@@ -206,7 +210,10 @@ void ToolsModel::OnButtonUp(BOOL bLeftButton, LONG x, LONG y)
 {
     m_pToolObject->beginEvent();
     if (m_pToolObject->OnButtonUp(bLeftButton, x, y))
-        updateLast(x, y);
+    {
+        g_ptEnd.x = x;
+        g_ptEnd.y = y;
+    }
     m_pToolObject->endEvent();
 }
 

--- a/base/applications/mspaint/toolsmodel.h
+++ b/base/applications/mspaint/toolsmodel.h
@@ -42,8 +42,8 @@ struct ToolBase
     virtual ~ToolBase() { }
 
     virtual void OnButtonDown(BOOL bLeftButton, LONG x, LONG y, BOOL bDoubleClick) { }
-    virtual void OnMouseMove(BOOL bLeftButton, LONG x, LONG y) { }
-    virtual void OnButtonUp(BOOL bLeftButton, LONG x, LONG y) { }
+    virtual BOOL OnMouseMove(BOOL bLeftButton, LONG& x, LONG& y) { return TRUE; }
+    virtual BOOL OnButtonUp(BOOL bLeftButton, LONG& x, LONG& y) { return TRUE; }
 
     virtual void OnCancelDraw();
     virtual void OnFinishDraw();


### PR DESCRIPTION
## Purpose

Implementing missing features...
JIRA issue: [CORE-19094](https://jira.reactos.org/browse/CORE-19094)

## Proposed changes

- While holding down the `Shift` key, drawing lines with the pen/brush is limited to either of 8 directions (horizontal/vertical/diagonal).
- `s/abs/labs/`

## TODO

- [x] Do tests.

## Screenshot

![Shot-2023-09-24-09-59-12](https://github.com/reactos/reactos/assets/2107452/e3299976-bf55-4333-9427-0bbd24d76d28)