### PR TITLE
[SHELL32] Compare the value of m_cidl attribute to zero.

### DIFF
--- a/dll/win32/shell32/CDefaultContextMenu.cpp
+++ b/dll/win32/shell32/CDefaultContextMenu.cpp
@@ -814,7 +814,7 @@ HRESULT CDefaultContextMenu::DoRename(LPCMINVOKECOMMANDINFOEX lpcmi)
     CComPtr<IShellBrowser> psb;
     HRESULT hr;
 
-    if (!m_site || !m_cidl)
+    if (!m_site || m_cidl == 0)
         return E_FAIL;
 
     /* Get a pointer to the shell browser */


### PR DESCRIPTION
## Purpose

EXPLORER "rename" does not work in Search Results

JIRA issue: [CORE-18326](https://jira.reactos.org/browse/CORE-18326)

## Proposed changes

Compare the value of m_cidl attribute to zero,
so that the DoRename method does not return E_FAIL when it is non-zero.

