### PR TITLE
[NTOS:CM] Simplify CmpDelayAllocBucketLock code a bit

### DIFF
--- a/ntoskrnl/config/cmalloc.c
+++ b/ntoskrnl/config/cmalloc.c
@@ -15,9 +15,9 @@
 /* GLOBALS *******************************************************************/
 
 BOOLEAN CmpAllocInited;
-KGUARDED_MUTEX CmpAllocBucketLock, CmpDelayAllocBucketLock;
-
+KGUARDED_MUTEX CmpAllocBucketLock;
 LIST_ENTRY CmpFreeKCBListHead;
+
 KGUARDED_MUTEX CmpDelayAllocBucketLock;
 LIST_ENTRY CmpFreeDelayItemsListHead;
 
@@ -252,16 +252,14 @@ SearchList:
             /* Clear the KCB pointer */
             Entry->Kcb = NULL;
         }
-    }
-    else
-    {
-        /* Release the lock */
-        KeReleaseGuardedMutex(&CmpDelayAllocBucketLock);
-        return NULL;
+
+        /* Do the search again */
+        goto SearchList;
     }
 
-    /* Do the search again */
-    goto SearchList;
+    /* Release the lock */
+    KeReleaseGuardedMutex(&CmpDelayAllocBucketLock);
+    return NULL;
 }
 
 VOID


### PR DESCRIPTION
## Purpose

Use similar code pattern as `CmpAllocateKeyControlBlock()`.

Note:
Code was added as is on r29954.

## Proposed changes

- Remove duplicate CmpDelayAllocBucketLock definition.
- Remove an else.