### PR TITLE
[SHELL32][SDK] ExitWindowsDialog: Check shutdown privilege

### DIFF
--- a/sdk/include/reactos/undocshell.h
+++ b/sdk/include/reactos/undocshell.h
@@ -170,7 +170,7 @@ void WINAPI RunFileDlg(
     UINT uFlags);
 
 int WINAPI LogoffWindowsDialog(HWND hWndOwner);
-void WINAPI ExitWindowsDialog(HWND hWndOwner);
+int WINAPI ExitWindowsDialog(HWND hWndOwner);
 
 BOOL WINAPI SHFindComputer(
     LPCITEMIDLIST pidlRoot,


### PR DESCRIPTION
## Purpose

Implementing missing features...
JIRA issue: N/A

## Proposed changes

- Rename `ExitWindowsDialog` function as `ShutdownWindowsDialog`.
- Add `ExitWindowsDialog` as an extension of `ShutdownWindowsDialog`.
- Use helper function `IsShutdownAllowed`.
- Modify `ExitWindowsDialog` prototype.

## TODO

- [ ] Do build.