### PR TITLE
[MSPAINT] Selection Clone and Selection Brush

### DIFF
--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -268,7 +268,7 @@ LRESULT CCanvasWindow::OnLRButtonDown(BOOL bLeftButton, UINT nMsg, WPARAM wParam
     HITTEST hitSelection = SelectionHitTest(pt);
     if (hitSelection != HIT_NONE)
     {
-        m_bSelectionBrush = FALSE;
+        selectionModel.m_nSelectionBrush = 0; // Selection Brush is OFF
         if (bLeftButton)
         {
             CanvasToImage(pt);
@@ -278,7 +278,7 @@ LRESULT CCanvasWindow::OnLRButtonDown(BOOL bLeftButton, UINT nMsg, WPARAM wParam
             }
             else if (::GetKeyState(VK_SHIFT) < 0) // Selection Brush
             {
-                m_bSelectionBrush = TRUE;
+                selectionModel.m_nSelectionBrush = 1; // Selection Brush is ON
             }
             StartSelectionDrag(hitSelection, pt);
         }
@@ -799,8 +799,11 @@ VOID CCanvasWindow::StartSelectionDrag(HITTEST hit, POINT ptImage)
 
 VOID CCanvasWindow::SelectionDragging(POINT ptImage)
 {
-    if (m_bSelectionBrush)
-        imageModel.SelectionStamp();
+    if (selectionModel.m_nSelectionBrush)
+    {
+        imageModel.SelectionStamp(selectionModel.m_nSelectionBrush == 1);
+        selectionModel.m_nSelectionBrush = 2; // Selection Brush is ON and drawn
+    }
 
     selectionModel.Dragging(m_hitSelection, ptImage);
     Invalidate(FALSE);
@@ -810,7 +813,6 @@ VOID CCanvasWindow::EndSelectionDrag(POINT ptImage)
 {
     selectionModel.Dragging(m_hitSelection, ptImage);
     m_hitSelection = HIT_NONE;
-    m_bSelectionBrush = FALSE;
     Invalidate(FALSE);
 }
 

--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -268,9 +268,18 @@ LRESULT CCanvasWindow::OnLRButtonDown(BOOL bLeftButton, UINT nMsg, WPARAM wParam
     HITTEST hitSelection = SelectionHitTest(pt);
     if (hitSelection != HIT_NONE)
     {
+        m_bSelectionBrush = FALSE;
         if (bLeftButton)
         {
             CanvasToImage(pt);
+            if (::GetKeyState(VK_CONTROL) < 0) // Selection Stamp
+            {
+                imageModel.SelectionStamp();
+            }
+            else if (::GetKeyState(VK_SHIFT) < 0) // Selection Brush
+            {
+                m_bSelectionBrush = TRUE;
+            }
             StartSelectionDrag(hitSelection, pt);
         }
         else
@@ -790,6 +799,9 @@ VOID CCanvasWindow::StartSelectionDrag(HITTEST hit, POINT ptImage)
 
 VOID CCanvasWindow::SelectionDragging(POINT ptImage)
 {
+    if (m_bSelectionBrush)
+        imageModel.SelectionStamp();
+
     selectionModel.Dragging(m_hitSelection, ptImage);
     Invalidate(FALSE);
 }
@@ -798,6 +810,7 @@ VOID CCanvasWindow::EndSelectionDrag(POINT ptImage)
 {
     selectionModel.Dragging(m_hitSelection, ptImage);
     m_hitSelection = HIT_NONE;
+    m_bSelectionBrush = FALSE;
     Invalidate(FALSE);
 }
 

--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -272,11 +272,11 @@ LRESULT CCanvasWindow::OnLRButtonDown(BOOL bLeftButton, UINT nMsg, WPARAM wParam
         if (bLeftButton)
         {
             CanvasToImage(pt);
-            if (::GetKeyState(VK_CONTROL) < 0) // Selection Stamp
+            if (::GetKeyState(VK_CONTROL) < 0) // Ctrl+Click is Selection Clone
             {
-                imageModel.SelectionStamp();
+                imageModel.SelectionClone();
             }
-            else if (::GetKeyState(VK_SHIFT) < 0) // Selection Brush
+            else if (::GetKeyState(VK_SHIFT) < 0) // Shift+Dragging is Selection Brush
             {
                 selectionModel.m_nSelectionBrush = 1; // Selection Brush is ON
             }
@@ -801,7 +801,7 @@ VOID CCanvasWindow::SelectionDragging(POINT ptImage)
 {
     if (selectionModel.m_nSelectionBrush)
     {
-        imageModel.SelectionStamp(selectionModel.m_nSelectionBrush == 1);
+        imageModel.SelectionClone(selectionModel.m_nSelectionBrush == 1);
         selectionModel.m_nSelectionBrush = 2; // Selection Brush is ON and drawn
     }
 

--- a/base/applications/mspaint/canvas.h
+++ b/base/applications/mspaint/canvas.h
@@ -57,6 +57,7 @@ protected:
     POINT m_ptOrig; // The origin of drag start
     HBITMAP m_ahbmCached[2]; // The cached buffer bitmaps
     CRect m_rcResizing; // Resizing rectagle
+    BOOL m_bSelectionBrush = FALSE; // Using the selection as a brush
 
     HITTEST CanvasHitTest(POINT pt);
     RECT GetBaseRect();

--- a/base/applications/mspaint/canvas.h
+++ b/base/applications/mspaint/canvas.h
@@ -57,7 +57,6 @@ protected:
     POINT m_ptOrig; // The origin of drag start
     HBITMAP m_ahbmCached[2]; // The cached buffer bitmaps
     CRect m_rcResizing; // Resizing rectagle
-    BOOL m_bSelectionBrush = FALSE; // Using the selection as a brush
 
     HITTEST CanvasHitTest(POINT pt);
     RECT GetBaseRect();

--- a/base/applications/mspaint/history.cpp
+++ b/base/applications/mspaint/history.cpp
@@ -299,3 +299,15 @@ void ImageModel::UnlockBitmap(HBITMAP hbmLocked)
     m_hBms[m_currInd] = hbmLocked;
     m_hbmOld = ::SelectObject(m_hDrawingDC, hbmLocked); // Re-select
 }
+
+void ImageModel::SelectionStamp()
+{
+    if (!selectionModel.m_bShow || ::IsRectEmpty(&selectionModel.m_rc))
+        return;
+
+    PushImageForUndo(CopyBitmap());
+
+    selectionModel.DrawSelection(m_hDrawingDC, paletteModel.GetBgColor(),
+                                 toolsModel.IsBackgroundTransparent());
+    NotifyImageChanged();
+}

--- a/base/applications/mspaint/history.cpp
+++ b/base/applications/mspaint/history.cpp
@@ -300,12 +300,13 @@ void ImageModel::UnlockBitmap(HBITMAP hbmLocked)
     m_hbmOld = ::SelectObject(m_hDrawingDC, hbmLocked); // Re-select
 }
 
-void ImageModel::SelectionStamp()
+void ImageModel::SelectionStamp(BOOL bUndoable)
 {
     if (!selectionModel.m_bShow || ::IsRectEmpty(&selectionModel.m_rc))
         return;
 
-    PushImageForUndo(CopyBitmap());
+    if (bUndoable)
+        PushImageForUndo(CopyBitmap());
 
     selectionModel.DrawSelection(m_hDrawingDC, paletteModel.GetBgColor(),
                                  toolsModel.IsBackgroundTransparent());

--- a/base/applications/mspaint/history.cpp
+++ b/base/applications/mspaint/history.cpp
@@ -300,7 +300,7 @@ void ImageModel::UnlockBitmap(HBITMAP hbmLocked)
     m_hbmOld = ::SelectObject(m_hDrawingDC, hbmLocked); // Re-select
 }
 
-void ImageModel::SelectionStamp(BOOL bUndoable)
+void ImageModel::SelectionClone(BOOL bUndoable)
 {
     if (!selectionModel.m_bShow || ::IsRectEmpty(&selectionModel.m_rc))
         return;

--- a/base/applications/mspaint/history.h
+++ b/base/applications/mspaint/history.h
@@ -41,6 +41,7 @@ public:
     void NotifyImageChanged();
     BOOL IsBlackAndWhite();
     void PushBlackAndWhite();
+    void SelectionStamp();
 
 protected:
     HDC m_hDrawingDC; // The device context for this class

--- a/base/applications/mspaint/history.h
+++ b/base/applications/mspaint/history.h
@@ -41,7 +41,7 @@ public:
     void NotifyImageChanged();
     BOOL IsBlackAndWhite();
     void PushBlackAndWhite();
-    void SelectionStamp();
+    void SelectionStamp(BOOL bUndoable = TRUE);
 
 protected:
     HDC m_hDrawingDC; // The device context for this class

--- a/base/applications/mspaint/history.h
+++ b/base/applications/mspaint/history.h
@@ -41,7 +41,7 @@ public:
     void NotifyImageChanged();
     BOOL IsBlackAndWhite();
     void PushBlackAndWhite();
-    void SelectionStamp(BOOL bUndoable = TRUE);
+    void SelectionClone(BOOL bUndoable = TRUE);
 
 protected:
     HDC m_hDrawingDC; // The device context for this class

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -112,10 +112,7 @@ struct FreeSelTool : ToolBase
     void OnDrawOverlayOnImage(HDC hdc) override
     {
         if (!selectionModel.IsLanded())
-        {
-            selectionModel.DrawBackgroundPoly(hdc, selectionModel.m_rgbBack);
             selectionModel.DrawSelection(hdc, paletteModel.GetBgColor(), toolsModel.IsBackgroundTransparent());
-        }
 
         if (canvasWindow.m_drawing)
         {
@@ -208,10 +205,7 @@ struct RectSelTool : ToolBase
     void OnDrawOverlayOnImage(HDC hdc) override
     {
         if (!selectionModel.IsLanded())
-        {
-            selectionModel.DrawBackgroundRect(hdc, selectionModel.m_rgbBack);
             selectionModel.DrawSelection(hdc, paletteModel.GetBgColor(), toolsModel.IsBackgroundTransparent());
-        }
 
         if (canvasWindow.m_drawing)
         {

--- a/base/applications/mspaint/selectionmodel.cpp
+++ b/base/applications/mspaint/selectionmodel.cpp
@@ -187,6 +187,17 @@ BOOL SelectionModel::TakeOff()
     // Save the selection area
     m_rcOld = m_rc;
 
+    if (toolsModel.GetActiveTool() == TOOL_RECTSEL)
+    {
+        imageModel.PushImageForUndo();
+        selectionModel.DrawBackgroundRect(imageModel.GetDC(), selectionModel.m_rgbBack);
+    }
+    else if (toolsModel.GetActiveTool() == TOOL_FREESEL)
+    {
+        imageModel.PushImageForUndo();
+        selectionModel.DrawBackgroundPoly(imageModel.GetDC(), selectionModel.m_rgbBack);
+    }
+
     imageModel.NotifyImageChanged();
     return TRUE;
 }

--- a/base/applications/mspaint/selectionmodel.h
+++ b/base/applications/mspaint/selectionmodel.h
@@ -23,6 +23,7 @@ public:
     CRect m_rc;    // in image pixel coordinates
     POINT m_ptHit; // in image pixel coordinates
     CRect m_rcOld; // in image pixel coordinates
+    INT m_nSelectionBrush = 0;
 
     SelectionModel();
     ~SelectionModel();

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -704,6 +704,16 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
                 if (toolsModel.IsSelection())
                 {
                     canvasWindow.cancelDrawing();
+                    if (toolsModel.GetActiveTool() == TOOL_FREESEL ||
+                        toolsModel.GetActiveTool() == TOOL_RECTSEL)
+                    {
+                        imageModel.Undo();
+                        if (selectionModel.m_nSelectionBrush == 2) // Selection Brush is drawn
+                        {
+                            imageModel.Undo();
+                            selectionModel.m_nSelectionBrush = 0;
+                        }
+                    }
                     break;
                 }
             }


### PR DESCRIPTION
## Purpose

Implement missing "Selection Clone" and "Selection Brush" features.

![image](https://github.com/reactos/reactos/assets/2107452/0f28c994-8fab-4013-8265-aebb6145b925)

JIRA issue: [CORE-19094](https://jira.reactos.org/browse/CORE-19094)

## Proposed changes

- Stamp the image of the selection when the user clicks on the selection while holding down the `Ctrl` key.
- Draw the image of the selection continuously when the user starts dragging the selection while holding down the `Shift` key.

## TODO

- [x] Do tests.