### PR TITLE
[NTOS:CC] Restore unlock/reacquire locks around MmPageOutPhysicalAddress

### DIFF
--- a/ntoskrnl/cc/view.c
+++ b/ntoskrnl/cc/view.c
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * COPYRIGHT:       See COPYING in the top level directory
  * PROJECT:         ReactOS kernel
  * FILE:            ntoskrnl/cc/view.c

--- a/ntoskrnl/cc/view.c
+++ b/ntoskrnl/cc/view.c
@@ -494,9 +494,7 @@ retry:
         /* Check if it's mapped and not dirty */
         if (InterlockedCompareExchange((PLONG)&current->MappedCount, 0, 0) > 0 && !current->Dirty)
         {
-            /* The code here presents a difficult to solve locking scenario.
-             * In testing, I (Doug Lyons) have never seen it exercised.
-             * For now we could bypass it with a message as shown below. */
+            /* This code is never executed. It is left for reference only. */
 #if 1
             DPRINT1("MmPageOutPhysicalAddress unexpectedly called\n");
             ASSERT(FALSE);

--- a/ntoskrnl/cc/view.c
+++ b/ntoskrnl/cc/view.c
@@ -485,7 +485,6 @@ retry:
         current = CONTAINING_RECORD(current_entry,
                                     ROS_VACB,
                                     VacbLruListEntry);
-        current_entry = current_entry->Flink;
 
         KeAcquireSpinLockAtDpcLevel(&current->SharedCacheMap->CacheMapLock);
 
@@ -522,6 +521,9 @@ retry:
             KeAcquireSpinLockAtDpcLevel(&current->SharedCacheMap->CacheMapLock);
 #endif
         }
+
+        /* Only keep iterating though the loop while the lock is held */
+        current_entry = current_entry->Flink;
 
         /* Dereference the VACB */
         Refs = CcRosVacbDecRefCount(current);


### PR DESCRIPTION
## Purpose

_Put back remove locks and reacquire locks around MmPageOutPhysicalAdress._

JIRA issue: maybe somewhat related to CORE17624, but reactosfanboy doesn't want the important commits of that to be spammed with it. Therefore only mentioned here in the text.

## Proposed changes

_The original code for CcRosTrimCache had this code._
_The committed PR mistakenly had a patch removing these unlock and reacquire locks_
_This was my mistake._
_This PR puts them back in place._

Revision Note: I added an ASSERT(FALSE) and a DPRINT1 into the main code path here and tested this.
During all of my testing on the items below, I was never able to trigger the ASSERT or get the DPRINT1 message.

1) I ran the large file copy test on 512 K memory as in https://jira.reactos.org/browse/CORE-17624.
2) I ran a full ReactOS regression test suite locally.
3) I did a full compile of ReactOS on ReactOS.

Based on the results of my testing and the apparent code issues here, I have proposed disabling this code.
I kept the original code in the 'else' path for the chance that someone can find a way to trigger this code path.
We will see what the developers familiar with the Memory Manager think about this option. Thanks.