### PR TITLE
[MSPAINT] Larger/smaller pen nib on Ctrl+Plus/Minus

### DIFF
--- a/base/applications/mspaint/drawing.cpp
+++ b/base/applications/mspaint/drawing.cpp
@@ -17,6 +17,7 @@ Line(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, COLORREF color, int thickness)
     HPEN oldPen = (HPEN) SelectObject(hdc, CreatePen(PS_SOLID, thickness, color));
     MoveToEx(hdc, x1, y1, NULL);
     LineTo(hdc, x2, y2);
+    SetPixelV(hdc, x2, y2, color);
     DeleteObject(SelectObject(hdc, oldPen));
 }
 

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -504,8 +504,6 @@ struct RubberTool : SmoothDrawTool
             Erase(m_hdc, g_ptEnd.x, g_ptEnd.y, x, y, m_bg, toolsModel.GetRubberRadius());
         else
             Replace(m_hdc, g_ptEnd.x, g_ptEnd.y, x, y, m_fg, m_bg, toolsModel.GetRubberRadius());
-        g_ptEnd.x = x;
-        g_ptEnd.y = y;
     }
 };
 
@@ -612,8 +610,6 @@ struct BrushTool : SmoothDrawTool
     {
         COLORREF rgb = bLeftButton ? m_fg : m_bg;
         Brush(m_hdc, g_ptEnd.x, g_ptEnd.y, x, y, rgb, toolsModel.GetBrushStyle());
-        g_ptEnd.x = x;
-        g_ptEnd.y = y;
     }
 
     void OnSpecialTweak(BOOL bMinus) override

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -320,6 +320,11 @@ struct TwoPointDrawTool : ToolBase
         m_bDrawing = FALSE;
         ToolBase::OnCancelDraw();
     }
+
+    void OnSpecialTweak(BOOL bMinus) override
+    {
+        toolsModel.MakeLineThickerOrThinner(bMinus);
+    }
 };
 
 typedef enum DIRECTION
@@ -587,10 +592,12 @@ struct PenTool : SmoothDrawTool
     void draw(BOOL bLeftButton, LONG x, LONG y) override
     {
         COLORREF rgb = bLeftButton ? m_fg : m_bg;
-        Line(m_hdc, g_ptEnd.x, g_ptEnd.y, x, y, rgb, 1);
-        ::SetPixelV(m_hdc, x, y, rgb);
-        g_ptEnd.x = x;
-        g_ptEnd.y = y;
+        Line(m_hdc, g_ptEnd.x, g_ptEnd.y, x, y, rgb, toolsModel.GetPenWidth());
+    }
+
+    void OnSpecialTweak(BOOL bMinus) override
+    {
+        toolsModel.MakePenThickerOrThinner(bMinus);
     }
 };
 
@@ -607,6 +614,11 @@ struct BrushTool : SmoothDrawTool
         Brush(m_hdc, g_ptEnd.x, g_ptEnd.y, x, y, rgb, toolsModel.GetBrushStyle());
         g_ptEnd.x = x;
         g_ptEnd.y = y;
+    }
+
+    void OnSpecialTweak(BOOL bMinus) override
+    {
+        // TODO:
     }
 };
 
@@ -863,6 +875,11 @@ struct BezierTool : ToolBase
         m_bDrawing = FALSE;
         ToolBase::OnFinishDraw();
     }
+
+    void OnSpecialTweak(BOOL bMinus) override
+    {
+        toolsModel.MakeLineThickerOrThinner(bMinus);
+    }
 };
 
 // TOOL_RECT
@@ -990,6 +1007,11 @@ struct ShapeTool : ToolBase
         s_pointSP = 0;
 
         ToolBase::OnFinishDraw();
+    }
+
+    void OnSpecialTweak(BOOL bMinus) override
+    {
+        toolsModel.MakeLineThickerOrThinner(bMinus);
     }
 };
 

--- a/base/applications/mspaint/toolbox.cpp
+++ b/base/applications/mspaint/toolbox.cpp
@@ -20,8 +20,13 @@ CPaintToolBar::ToolBarWndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
     {
         // We have to detect clicking on toolbar even if no change of pressed button
         POINT pt = { GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) };
-        INT id = (INT)SendMessage(hwnd, TB_HITTEST, 0, (LPARAM)&pt);
-        ::PostMessage(::GetParent(hwnd), WM_TOOLBARHIT, id, 0);
+        INT index = (INT)::SendMessage(hwnd, TB_HITTEST, 0, (LPARAM)&pt);
+        if (index >= 0)
+        {
+            TBBUTTON button;
+            if (::SendMessage(hwnd, TB_GETBUTTON, index, (LPARAM)&button))
+                ::PostMessage(::GetParent(hwnd), WM_COMMAND, button.idCommand, 0);
+        }
     }
     return ::CallWindowProc(oldWndProc, hwnd, uMsg, wParam, lParam);
 }
@@ -112,6 +117,7 @@ static const COMMAND_TO_TOOL CommandToToolMapping[] =
     { ID_ELLIPSE, TOOL_ELLIPSE },
     { ID_RRECT, TOOL_RRECT },
 };
+static_assert(_countof(CommandToToolMapping) == TOOL_MAX, "Logical error");
 
 LRESULT CToolBox::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
@@ -181,12 +187,5 @@ LRESULT CToolBox::OnLButtonUp(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHa
         return 0;
 
     ::ReleaseCapture();
-    return 0;
-}
-
-LRESULT CToolBox::OnToolBarHit(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
-{
-    // See also: CPaintToolBar::ToolBarWndProc
-    selectionModel.Landing();
     return 0;
 }

--- a/base/applications/mspaint/toolbox.h
+++ b/base/applications/mspaint/toolbox.h
@@ -14,8 +14,6 @@
 #define CX_TOOLBAR          (TOOLBAR_COLUMNS * CXY_TB_BUTTON)
 #define CY_TOOLBAR          (TOOLBAR_ROWS * CXY_TB_BUTTON)
 
-#define WM_TOOLBARHIT   (WM_APP + 1)
-
 class CPaintToolBar : public CWindow
 {
 public:
@@ -36,7 +34,6 @@ public:
         MESSAGE_HANDLER(WM_MOUSEMOVE, OnMouseMove)
         MESSAGE_HANDLER(WM_LBUTTONUP, OnLButtonUp)
         MESSAGE_HANDLER(WM_TOOLSMODELTOOLCHANGED, OnToolsModelToolChanged)
-        MESSAGE_HANDLER(WM_TOOLBARHIT, OnToolBarHit)
     END_MSG_MAP()
 
     BOOL DoCreate(HWND hwndParent);
@@ -51,5 +48,4 @@ private:
     LRESULT OnMouseMove(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
     LRESULT OnLButtonUp(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
     LRESULT OnToolsModelToolChanged(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
-    LRESULT OnToolBarHit(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
 };

--- a/base/applications/mspaint/toolsmodel.cpp
+++ b/base/applications/mspaint/toolsmodel.cpp
@@ -140,15 +140,9 @@ void ToolsModel::SetActiveTool(TOOLTYPE nActiveTool)
         case TOOL_RRECT:
         case TOOL_RUBBER:
         case TOOL_BRUSH:
-            // The active tool is an actually drawing tool. Save it for TOOL_COLOR to restore
-            m_oldActiveTool = nActiveTool;
-            break;
-
         case TOOL_PEN:
             // The active tool is an actually drawing tool. Save it for TOOL_COLOR to restore
             m_oldActiveTool = nActiveTool;
-
-            SetLineWidth(1);
             break;
     }
 

--- a/base/applications/mspaint/toolsmodel.cpp
+++ b/base/applications/mspaint/toolsmodel.cpp
@@ -229,9 +229,9 @@ void ToolsModel::NotifyZoomChanged()
 void ToolsModel::OnButtonDown(BOOL bLeftButton, LONG x, LONG y, BOOL bDoubleClick)
 {
     m_pToolObject->beginEvent();
-    m_pToolObject->OnButtonDown(bLeftButton, x, y, bDoubleClick);
     g_ptStart.x = g_ptEnd.x = x;
     g_ptStart.y = g_ptEnd.y = y;
+    m_pToolObject->OnButtonDown(bLeftButton, x, y, bDoubleClick);
     m_pToolObject->endEvent();
 }
 

--- a/base/applications/mspaint/toolsmodel.h
+++ b/base/applications/mspaint/toolsmodel.h
@@ -67,6 +67,7 @@ class ToolsModel
 {
 private:
     int m_lineWidth;
+    INT m_penWidth;
     int m_shapeStyle;
     int m_brushStyle;
     TOOLTYPE m_activeTool;
@@ -85,8 +86,15 @@ public:
     ~ToolsModel();
 
     BOOL IsSelection() const;
+
     int GetLineWidth() const;
     void SetLineWidth(int nLineWidth);
+    void MakeLineThickerOrThinner(BOOL bThinner);
+
+    INT GetPenWidth() const;
+    void SetPenWidth(INT nPenWidth);
+    void MakePenThickerOrThinner(BOOL bThinner);
+
     int GetShapeStyle() const;
     void SetShapeStyle(int nShapeStyle);
     int GetBrushStyle() const;


### PR DESCRIPTION
## Purpose

Make the pen nib bigger or smaller.
JIRA issue: [CORE-19094](https://jira.reactos.org/browse/CORE-19094)

![無題](https://github.com/reactos/reactos/assets/2107452/0cf74f8c-a2d8-4693-8673-0a9856d800ec)

## Proposed changes

- Introduce the concept of pen width (not line width) to the tools model.
- Enable changing pen/line width by `Ctrl+Plus/Minus` key combination in `TOOL_PEN`, `TOOL_LINE`, `TOOL_BEZIER`, `TOOL_RECT`, `TOOL_SHAPE`, `TOO_ELLIPSE`, and `TOOL_RRECT` tools.

## TODO

- [x] Do tests.
- [ ] `TOOL_BRUSH` (for later PR)