### PR TITLE
[MSPAINT] Larger/smaller Rubber/AirBrush on Ctrl+Plus/Minus

### DIFF
--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -505,6 +505,11 @@ struct RubberTool : SmoothDrawTool
         else
             Replace(m_hdc, g_ptEnd.x, g_ptEnd.y, x, y, m_fg, m_bg, toolsModel.GetRubberRadius());
     }
+
+    void OnSpecialTweak(BOOL bMinus) override
+    {
+        toolsModel.MakeRubberThickerOrThinner(bMinus);
+    }
 };
 
 // TOOL_FILL
@@ -630,6 +635,11 @@ struct AirBrushTool : SmoothDrawTool
     {
         COLORREF rgb = bLeftButton ? m_fg : m_bg;
         Airbrush(m_hdc, x, y, rgb, toolsModel.GetAirBrushWidth());
+    }
+
+    void OnSpecialTweak(BOOL bMinus) override
+    {
+        toolsModel.MakeAirBrushThickerOrThinner(bMinus);
     }
 };
 

--- a/base/applications/mspaint/toolsmodel.cpp
+++ b/base/applications/mspaint/toolsmodel.cpp
@@ -99,6 +99,18 @@ void ToolsModel::MakeBrushThickerOrThinner(BOOL bThinner)
     SetBrushWidth(bThinner ? max(1, thickness - 1) : (thickness + 1));
 }
 
+void ToolsModel::MakeAirBrushThickerOrThinner(BOOL bThinner)
+{
+    INT thickness = GetAirBrushWidth();
+    SetAirBrushWidth(bThinner ? max(1, thickness - 1) : (thickness + 1));
+}
+
+void ToolsModel::MakeRubberThickerOrThinner(BOOL bThinner)
+{
+    INT thickness = GetRubberRadius();
+    SetRubberRadius(bThinner ? max(1, thickness - 1) : (thickness + 1));
+}
+
 int ToolsModel::GetShapeStyle() const
 {
     return m_shapeStyle;

--- a/base/applications/mspaint/toolsmodel.h
+++ b/base/applications/mspaint/toolsmodel.h
@@ -120,9 +120,11 @@ public:
 
     int GetAirBrushWidth() const;
     void SetAirBrushWidth(int nAirBrushWidth);
+    void MakeAirBrushThickerOrThinner(BOOL bThinner);
 
     int GetRubberRadius() const;
     void SetRubberRadius(int nRubberRadius);
+    void MakeRubberThickerOrThinner(BOOL bThinner);
 
     BOOL IsBackgroundTransparent() const;
     void SetBackgroundTransparent(BOOL bTransparent);


### PR DESCRIPTION
## Purpose
Similarly.
JIRA issue: [CORE-19094](https://jira.reactos.org/browse/CORE-19094)

## Proposed changes

- Enable changing rubber/airbrush thickness by `Ctrl+Plus` / `Ctrl+Minus` key combination in `TOOL_AIRBRUSH` and `TOOL_RUBBER`.

## TODO

- [x] Do tests.