### PR TITLE
[CMAKE] Improve configure script to properly work with newer CMake ve…

### DIFF
--- a/configure.cmd
+++ b/configure.cmd
@@ -75,66 +75,59 @@ if not defined ARCH (
 
 set USE_CLANG_CL=0
 
-REM Some magic code to parse the parameters and extract those for CMake
+REM Parse command line parameters
 set CMAKE_PARAMS=
 set REMAINING=%*
-:loop
-for /f "tokens=1*" %%a in ("%REMAINING%") do (
-    set "PARAM=%%a"
-    if "!PARAM:~0,1!" == "-" (
-        if "!PARAM!" NEQ "-VS_VER" (
-            set "CMAKE_PARAMS=%CMAKE_PARAMS% !PARAM!"
-        )
-    )
-    set REMAINING=%%b
-)
-if defined REMAINING goto :loop
-
-REM Parse command line parameters
 :repeat
+
+    REM Extract a parameter without removing '='
+    for /f "tokens=1*" %%a in ("%REMAINING%") do (
+        set "PARAM=%%a"
+        set REMAINING=%%b
+    )
+
     if "%BUILD_ENVIRONMENT%" == "MinGW" (
-        if /I "%1" == "Codeblocks" (
+        if /I "!PARAM!" == "Codeblocks" (
             set CMAKE_GENERATOR="CodeBlocks - MinGW Makefiles"
-        ) else if /I "%1" == "Eclipse" (
+        ) else if /I "!PARAM!" == "Eclipse" (
             set CMAKE_GENERATOR="Eclipse CDT4 - MinGW Makefiles"
-        ) else if /I "%1" == "Makefiles" (
+        ) else if /I "!PARAM!" == "Makefiles" (
             set CMAKE_GENERATOR="MinGW Makefiles"
-        ) else if /I "%1" == "Ninja" (
+        ) else if /I "!PARAM!" == "Ninja" (
             set CMAKE_GENERATOR="Ninja"
-        ) else if /I "%1" == "VSSolution" (
+        ) else if /I "!PARAM!" == "VSSolution" (
             echo. && echo Error: Creation of VS Solution files is not supported in a MinGW environment.
             echo Please run this command in a [Developer] Command Prompt for Visual Studio.
             goto quit
-        ) else if /I "%1" NEQ "" (
-            echo.%1| find /I "-D" >nul 2>&1
-            if not errorlevel 1 (
-                REM User is passing a switch to CMake
-                REM Ignore it, and ignore the next parameter that follows
-                Shift
-            ) else (
-                echo. && echo   Warning: Unrecognized switch "%1" && echo.
-            )
+        ) else if /I "!PARAM:~0,2!" == "-D" (
+            REM User is passing a switch to CMake
+            set "CMAKE_PARAMS=%CMAKE_PARAMS% !PARAM!"
         ) else (
-            goto continue
+            echo. && echo   Warning: Unrecognized switch "!PARAM!" && echo.
         )
     ) else (
-        if /I "%1" == "CodeBlocks" (
+        if /I "!PARAM!" == "CodeBlocks" (
             set CMAKE_GENERATOR="CodeBlocks - NMake Makefiles"
-        ) else if /I "%1" == "Eclipse" (
+        ) else if /I "!PARAM!" == "Eclipse" (
             set CMAKE_GENERATOR="Eclipse CDT4 - NMake Makefiles"
-        ) else if /I "%1" == "Makefiles" (
+        ) else if /I "!PARAM!" == "Makefiles" (
             set CMAKE_GENERATOR="NMake Makefiles"
-        ) else if /I "%1" == "Ninja" (
+        ) else if /I "!PARAM!" == "Ninja" (
             set CMAKE_GENERATOR="Ninja"
-        ) else if /I "%1" == "clang" (
+        ) else if /I "!PARAM!" == "clang" (
             set USE_CLANG_CL=1
-        ) else if /I "%1" == "VSSolution" (
+        ) else if /I "!PARAM!" == "VSSolution" (
             set VS_SOLUTION=1
             REM explicitly set VS version for project generator
-            if /I "%2" == "-VS_VER" (
-                set VS_VERSION=%3
-                SHIFT
-                SHIFT
+            for /f "tokens=1*" %%a in ("%REMAINING%") do (
+                set PARAM=%%a
+                set REMAINING2=%%b
+            )
+            if /I "!PARAM!" == "-VS_VER" (
+                for /f "tokens=1*" %%a in ("!REMAINING2!") do (
+                    set VS_VERSION=%%a
+                    set REMAINING=%%b
+                )
                 echo Visual Studio Environment set to !BUILD_ENVIRONMENT!!VS_VERSION!-!ARCH!
             )
             set CMAKE_GENERATOR="Visual Studio !VS_VERSION!"
@@ -147,24 +140,16 @@ REM Parse command line parameters
             ) else if "!ARCH!" == "arm64" (
                 set CMAKE_ARCH=-A ARM64
             )
-        ) else if /I "%1" NEQ "" (
-            echo.%1| find /I "-D" >nul 2>&1
-            if not errorlevel 1 (
-                REM User is passing a switch to CMake
-                REM Ignore it, and ignore the next parameter that follows
-                Shift
-            ) else (
-                echo. && echo   Warning: Unrecognized switch "%1" && echo.
-            )
+        ) else if /I "!PARAM:~0,2!" == "-D" (
+            REM User is passing a switch to CMake
+            set "CMAKE_PARAMS=%CMAKE_PARAMS% !PARAM!"
         ) else (
-            goto continue
+            echo. && echo   Warning: Unrecognized switch "!PARAM!" && echo.
         )
     )
 
     REM Go to next parameter
-    SHIFT
-    goto repeat
-:continue
+    if defined REMAINING goto repeat
 
 REM Inform the user about the default build
 if "!CMAKE_GENERATOR!" == "Ninja" (
@@ -211,9 +196,9 @@ if EXIST CMakeCache.txt (
 
 
 if "%BUILD_ENVIRONMENT%" == "MinGW" (
-    cmake -G %CMAKE_GENERATOR% -DENABLE_CCACHE:BOOL=0 -DCMAKE_TOOLCHAIN_FILE:FILEPATH=%MINGW_TOOCHAIN_FILE% -DARCH:STRING=%ARCH% %BUILD_TOOLS_FLAG% %* "%REACTOS_SOURCE_DIR%"
+    cmake -G %CMAKE_GENERATOR% -DENABLE_CCACHE:BOOL=0 -DCMAKE_TOOLCHAIN_FILE:FILEPATH=%MINGW_TOOCHAIN_FILE% -DARCH:STRING=%ARCH% %BUILD_TOOLS_FLAG% %CMAKE_PARAMS% "%REACTOS_SOURCE_DIR%"
 ) else if %USE_CLANG_CL% == 1 (
-    cmake -G %CMAKE_GENERATOR% -DCMAKE_TOOLCHAIN_FILE:FILEPATH=toolchain-msvc.cmake -DARCH:STRING=%ARCH% %BUILD_TOOLS_FLAG% -DUSE_CLANG_CL:BOOL=1 %* "%REACTOS_SOURCE_DIR%"
+    cmake -G %CMAKE_GENERATOR% -DCMAKE_TOOLCHAIN_FILE:FILEPATH=toolchain-msvc.cmake -DARCH:STRING=%ARCH% %BUILD_TOOLS_FLAG% -DUSE_CLANG_CL:BOOL=1 %CMAKE_PARAMS% "%REACTOS_SOURCE_DIR%"
 ) else (
     cmake -G %CMAKE_GENERATOR% %CMAKE_ARCH% -DCMAKE_TOOLCHAIN_FILE:FILEPATH=toolchain-msvc.cmake -DARCH:STRING=%ARCH% %BUILD_TOOLS_FLAG% %CMAKE_PARAMS% "%REACTOS_SOURCE_DIR%"
 )


### PR DESCRIPTION
…rsions

## Purpose

This change allows to properly pass parameters to newer CMake versions. Currently the script passes "VSSolution" and similar on to CMake, which are ignored, but newer CMake will complain. Works for me to configure a VSSolution with CMake 3.27.4. More testing appreciated.