### PR TITLE
[NTOS:MM] Convert some annotations to SAL2 and fix them

### DIFF
--- a/ntoskrnl/mm/ARM3/section.c
+++ b/ntoskrnl/mm/ARM3/section.c
@@ -1150,17 +1150,18 @@ MiMapViewInSystemSpace(
 
 static
 NTSTATUS
-MiMapViewOfDataSection(IN PCONTROL_AREA ControlArea,
-                       IN PEPROCESS Process,
-                       IN PVOID *BaseAddress,
-                       IN PLARGE_INTEGER SectionOffset,
-                       IN PSIZE_T ViewSize,
-                       IN PSECTION Section,
-                       IN SECTION_INHERIT InheritDisposition,
-                       IN ULONG ProtectionMask,
-                       IN SIZE_T CommitSize,
-                       IN ULONG_PTR ZeroBits,
-                       IN ULONG AllocationType)
+MiMapViewOfDataSection(
+    _In_ PCONTROL_AREA ControlArea,
+    _In_ PEPROCESS Process,
+    _Outptr_result_bytebuffer_(*ViewSize) _Pre_opt_valid_ PVOID *BaseAddress,
+    _Inout_ PLARGE_INTEGER SectionOffset,
+    _Inout_ PSIZE_T ViewSize,
+    _In_ PSECTION Section,
+    _In_range_(ViewShare, ViewUnmap) SECTION_INHERIT InheritDisposition,
+    _In_ ULONG ProtectionMask,
+    _In_ SIZE_T CommitSize,
+    _In_ ULONG_PTR ZeroBits,
+    _In_ ULONG AllocationType)
 {
     PMMVAD_LONG Vad;
     ULONG_PTR StartAddress;
@@ -2530,16 +2531,20 @@ MmCreateArm3Section(OUT PVOID *SectionObject,
  */
 NTSTATUS
 NTAPI
-MmMapViewOfArm3Section(IN PVOID SectionObject,
-                       IN PEPROCESS Process,
-                       IN OUT PVOID *BaseAddress,
-                       IN ULONG_PTR ZeroBits,
-                       IN SIZE_T CommitSize,
-                       IN OUT PLARGE_INTEGER SectionOffset OPTIONAL,
-                       IN OUT PSIZE_T ViewSize,
-                       IN SECTION_INHERIT InheritDisposition,
-                       IN ULONG AllocationType,
-                       IN ULONG Protect)
+MmMapViewOfArm3Section(
+    _In_ PVOID SectionObject,
+    _In_ PEPROCESS Process,
+    _Outptr_result_bytebuffer_(*ViewSize)
+      _When_(*ViewSize != 0, _Pre_opt_valid_)
+      _When_(*ViewSize == 0, _Pre_valid_)
+        PVOID *BaseAddress,
+    _In_ ULONG_PTR ZeroBits,
+    _In_ SIZE_T CommitSize,
+    _Inout_ PLARGE_INTEGER SectionOffset,
+    _Inout_ PSIZE_T ViewSize,
+    _In_range_(ViewShare, ViewUnmap) SECTION_INHERIT InheritDisposition,
+    _In_ ULONG AllocationType,
+    _In_ ULONG Protect)
 {
     KAPC_STATE ApcState;
     BOOLEAN Attached = FALSE;
@@ -3256,16 +3261,17 @@ NtOpenSection(OUT PHANDLE SectionHandle,
 
 NTSTATUS
 NTAPI
-NtMapViewOfSection(IN HANDLE SectionHandle,
-                   IN HANDLE ProcessHandle,
-                   IN OUT PVOID* BaseAddress,
-                   IN ULONG_PTR ZeroBits,
-                   IN SIZE_T CommitSize,
-                   IN OUT PLARGE_INTEGER SectionOffset OPTIONAL,
-                   IN OUT PSIZE_T ViewSize,
-                   IN SECTION_INHERIT InheritDisposition,
-                   IN ULONG AllocationType,
-                   IN ULONG Protect)
+NtMapViewOfSection(
+    _In_ HANDLE SectionHandle,
+    _In_ HANDLE ProcessHandle,
+    _Outptr_result_bytebuffer_(*ViewSize) _Pre_valid_ PVOID *BaseAddress,
+    _In_ ULONG_PTR ZeroBits,
+    _In_ SIZE_T CommitSize,
+    _Inout_opt_ PLARGE_INTEGER SectionOffset,
+    _Inout_ PSIZE_T ViewSize,
+    _In_range_(ViewShare, ViewUnmap) SECTION_INHERIT InheritDisposition,
+    _In_ ULONG AllocationType,
+    _In_ ULONG Win32Protect)
 {
     PVOID SafeBaseAddress;
     LARGE_INTEGER SafeSectionOffset;
@@ -3299,7 +3305,7 @@ NtMapViewOfSection(IN HANDLE SectionHandle,
     }
 
     /* Convert the protection mask, and validate it */
-    ProtectionMask = MiMakeProtectionMask(Protect);
+    ProtectionMask = MiMakeProtectionMask(Win32Protect);
     if (ProtectionMask == MM_INVALID_PROTECTION)
     {
         DPRINT1("Invalid page protection\n");
@@ -3442,7 +3448,7 @@ NtMapViewOfSection(IN HANDLE SectionHandle,
                                 &SafeViewSize,
                                 InheritDisposition,
                                 AllocationType,
-                                Protect);
+                                Win32Protect);
 
     /* Return data only on success */
     if (NT_SUCCESS(Status))

--- a/ntoskrnl/mm/section.c
+++ b/ntoskrnl/mm/section.c
@@ -142,16 +142,20 @@ MmCreateArm3Section(OUT PVOID *SectionObject,
 
 NTSTATUS
 NTAPI
-MmMapViewOfArm3Section(IN PVOID SectionObject,
-                       IN PEPROCESS Process,
-                       IN OUT PVOID *BaseAddress,
-                       IN ULONG_PTR ZeroBits,
-                       IN SIZE_T CommitSize,
-                       IN OUT PLARGE_INTEGER SectionOffset OPTIONAL,
-                       IN OUT PSIZE_T ViewSize,
-                       IN SECTION_INHERIT InheritDisposition,
-                       IN ULONG AllocationType,
-                       IN ULONG Protect);
+MmMapViewOfArm3Section(
+    _In_ PVOID SectionObject,
+    _In_ PEPROCESS Process,
+    _Outptr_result_bytebuffer_(*ViewSize)
+      _When_(*ViewSize != 0, _Pre_opt_valid_)
+      _When_(*ViewSize == 0, _Pre_valid_)
+        PVOID *BaseAddress,
+    _In_ ULONG_PTR ZeroBits,
+    _In_ SIZE_T CommitSize,
+    _Inout_ PLARGE_INTEGER SectionOffset,
+    _Inout_ PSIZE_T ViewSize,
+    _In_range_(ViewShare, ViewUnmap) SECTION_INHERIT InheritDisposition,
+    _In_ ULONG AllocationType,
+    _In_ ULONG Protect);
 
 //
 // PeFmtCreateSection depends on the following:
@@ -4024,16 +4028,17 @@ NtQuerySection(
  * @implemented
  */
 NTSTATUS NTAPI
-MmMapViewOfSection(IN PVOID SectionObject,
-                   IN PEPROCESS Process,
-                   IN OUT PVOID *BaseAddress,
-                   IN ULONG_PTR ZeroBits,
-                   IN SIZE_T CommitSize,
-                   IN OUT PLARGE_INTEGER SectionOffset OPTIONAL,
-                   IN OUT PSIZE_T ViewSize,
-                   IN SECTION_INHERIT InheritDisposition,
-                   IN ULONG AllocationType,
-                   IN ULONG Protect)
+MmMapViewOfSection(
+    _In_ PVOID SectionObject,
+    _In_ PEPROCESS Process,
+    _Outptr_result_bytebuffer_(*ViewSize) _Pre_opt_valid_ PVOID *BaseAddress,
+    _In_ ULONG_PTR ZeroBits,
+    _In_ SIZE_T CommitSize,
+    _Inout_opt_ PLARGE_INTEGER SectionOffset,
+    _Inout_ PSIZE_T ViewSize,
+    _In_range_(ViewShare, ViewUnmap) SECTION_INHERIT InheritDisposition,
+    _In_ ULONG AllocationType,
+    _In_ ULONG Protect)
 {
     PSECTION Section;
     PMMSUPPORT AddressSpace;
@@ -4045,6 +4050,7 @@ MmMapViewOfSection(IN PVOID SectionObject,
     if (MiIsRosSectionObject(SectionObject) == FALSE)
     {
         DPRINT("Mapping ARM3 section into %s\n", Process->ImageFileName);
+        ASSERT(SectionOffset != NULL);
         return MmMapViewOfArm3Section(SectionObject,
                                       Process,
                                       BaseAddress,

--- a/sdk/include/ndk/mmfuncs.h
+++ b/sdk/include/ndk/mmfuncs.h
@@ -48,12 +48,12 @@ NTAPI
 MmMapViewOfSection(
     _In_ PVOID SectionObject,
     _In_ PEPROCESS Process,
-    _Inout_ PVOID *BaseAddress,
+    _Outptr_result_bytebuffer_(*ViewSize) _Pre_opt_valid_ PVOID *BaseAddress,
     _In_ ULONG_PTR ZeroBits,
     _In_ SIZE_T CommitSize,
     _Inout_opt_ PLARGE_INTEGER SectionOffset,
     _Inout_ PSIZE_T ViewSize,
-    _In_ SECTION_INHERIT InheritDisposition,
+    _In_range_(ViewShare, ViewUnmap) SECTION_INHERIT InheritDisposition,
     _In_ ULONG AllocationType,
     _In_ ULONG Protect
 );
@@ -217,14 +217,14 @@ NTAPI
 NtMapViewOfSection(
     _In_ HANDLE SectionHandle,
     _In_ HANDLE ProcessHandle,
-    _Inout_ PVOID *BaseAddress,
+    _Outptr_result_bytebuffer_(*ViewSize) _Pre_valid_ PVOID *BaseAddress,
     _In_ ULONG_PTR ZeroBits,
     _In_ SIZE_T CommitSize,
     _Inout_opt_ PLARGE_INTEGER SectionOffset,
     _Inout_ PSIZE_T ViewSize,
-    _In_ SECTION_INHERIT InheritDisposition,
+    _In_range_(ViewShare, ViewUnmap) SECTION_INHERIT InheritDisposition,
     _In_ ULONG AllocationType,
-    _In_ ULONG AccessProtection
+    _In_ ULONG Win32Protect
 );
 
 NTSYSCALLAPI
@@ -401,12 +401,12 @@ NTAPI
 ZwMapViewOfSection(
     _In_ HANDLE SectionHandle,
     _In_ HANDLE ProcessHandle,
-    _Outptr_result_bytebuffer_(*ViewSize) PVOID *BaseAddress,
+    _Outptr_result_bytebuffer_(*ViewSize) _Pre_valid_ PVOID *BaseAddress,
     _In_ ULONG_PTR ZeroBits,
     _In_ SIZE_T CommitSize,
     _Inout_opt_ PLARGE_INTEGER SectionOffset,
     _Inout_ PSIZE_T ViewSize,
-    _In_ SECTION_INHERIT InheritDisposition,
+    _In_range_(ViewShare, ViewUnmap) SECTION_INHERIT InheritDisposition,
     _In_ ULONG AllocationType,
     _In_ ULONG Win32Protect
 );

--- a/sdk/include/xdk/zwfuncs.h
+++ b/sdk/include/xdk/zwfuncs.h
@@ -211,14 +211,14 @@ NTAPI
 ZwMapViewOfSection(
   _In_ HANDLE SectionHandle,
   _In_ HANDLE ProcessHandle,
-  _Outptr_result_bytebuffer_(*ViewSize) PVOID *BaseAddress,
+  _Outptr_result_bytebuffer_(*ViewSize) _Pre_valid_ PVOID *BaseAddress,
   _In_ ULONG_PTR ZeroBits,
   _In_ SIZE_T CommitSize,
   _Inout_opt_ PLARGE_INTEGER SectionOffset,
   _Inout_ PSIZE_T ViewSize,
-  _In_ SECTION_INHERIT InheritDisposition,
+  _In_range_(ViewShare, ViewUnmap) SECTION_INHERIT InheritDisposition,
   _In_ ULONG AllocationType,
-  _In_ ULONG Protect);
+  _In_ ULONG Win32Protect);
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
 NTSYSAPI


### PR DESCRIPTION
## Purpose

Improve/Fix self documentation. Detect incorrect calls.
Follow-up of #5650.

## Proposed changes

- Convert some annotations to SAL2 and fix them
- And add a specific ASSERT(SectionOffset) in MmMapViewOfSection().