### PR TITLE
[FREELDR][SDK] ARM64 FreeLoader bringup + fixes

### DIFF
--- a/boot/freeldr/freeldr/CMakeLists.txt
+++ b/boot/freeldr/freeldr/CMakeLists.txt
@@ -136,7 +136,10 @@ if(ARCH STREQUAL "i386")
         ${CMAKE_CURRENT_BINARY_DIR}/freeldr_pe.def)
 endif()
 
-include(pcat.cmake)
+if(ARCH STREQUAL "i386" OR ARCH STREQUAL "amd64")
+    include(pcat.cmake)
+endif()
+
 if(NOT ARCH STREQUAL "i386" OR NOT (SARCH STREQUAL "pc98" OR SARCH STREQUAL "xbox"))
     include(uefi.cmake)
 endif()

--- a/boot/freeldr/freeldr/arch/uefi/uefidisk.c
+++ b/boot/freeldr/freeldr/arch/uefi/uefidisk.c
@@ -415,7 +415,7 @@ UefiSetupBlockDevices(VOID)
         if (EFI_ERROR(Status) || 
             bio == NULL ||
             bio->Media->BlockSize == 0 ||
-            bio->Media->BlockSize > 2048)
+            bio->Media->BlockSize > 4096)
         {
             TRACE("UefiSetupBlockDevices: UEFI has found a block device that failed, skipping\n");
             continue;

--- a/boot/freeldr/freeldr/arch/uefi/uefildr.c
+++ b/boot/freeldr/freeldr/arch/uefi/uefildr.c
@@ -25,7 +25,7 @@ EfiEntry(
     GlobalImageHandle = ImageHandle;
     GlobalSystemTable = SystemTable;
 
-    BootMain(NULL);
+    BootMain("");
 
     UNREACHABLE;
     return 0;

--- a/boot/freeldr/freeldr/cmdline.c
+++ b/boot/freeldr/freeldr/cmdline.c
@@ -36,7 +36,6 @@ CmdLineParse(IN PCSTR CmdLine)
     CmdLineInfo.DefaultOs = NULL;
     CmdLineInfo.TimeOut = -1;
 
-    if (!CmdLine) return;
     /*
      * Get debug string, in the following format:
      * "debug=option1=XXX;option2=YYY;..."

--- a/boot/freeldr/freeldr/cmdline.c
+++ b/boot/freeldr/freeldr/cmdline.c
@@ -36,6 +36,7 @@ CmdLineParse(IN PCSTR CmdLine)
     CmdLineInfo.DefaultOs = NULL;
     CmdLineInfo.TimeOut = -1;
 
+    if (!CmdLine) return;
     /*
      * Get debug string, in the following format:
      * "debug=option1=XXX;option2=YYY;..."

--- a/boot/freeldr/freeldr/lib/fs/fat.c
+++ b/boot/freeldr/freeldr/lib/fs/fat.c
@@ -1369,7 +1369,7 @@ BOOLEAN FatReadVolumeSectors(PFAT_VOLUME_INFO Volume, ULONG SectorNumber, ULONG 
     //
     // Seek to right position
     //
-    Position.QuadPart = (ULONGLONG)SectorNumber * 512;
+    Position.QuadPart = (ULONGLONG)SectorNumber * Volume->BytesPerSector;
     Status = ArcSeek(Volume->DeviceId, &Position, SeekAbsolute);
     if (Status != ESUCCESS)
     {
@@ -1380,8 +1380,8 @@ BOOLEAN FatReadVolumeSectors(PFAT_VOLUME_INFO Volume, ULONG SectorNumber, ULONG 
     //
     // Read data
     //
-    Status = ArcRead(Volume->DeviceId, Buffer, SectorCount * 512, &Count);
-    if (Status != ESUCCESS || Count != SectorCount * 512)
+    Status = ArcRead(Volume->DeviceId, Buffer, SectorCount * Volume->BytesPerSector, &Count);
+    if (Status != ESUCCESS || Count != SectorCount * Volume->BytesPerSector)
     {
         TRACE("FatReadVolumeSectors() Failed to read\n");
         return FALSE;

--- a/sdk/include/crt/vadefs.h
+++ b/sdk/include/crt/vadefs.h
@@ -32,6 +32,10 @@ extern "C" {
 #define _VA_STRUCT_ALIGN 16
 #define _ALIGNOF(ap) ((((ap)+_VA_STRUCT_ALIGN - 1) & ~(_VA_STRUCT_ALIGN -1)) - (ap))
 #define _APALIGN(t,ap) (__alignof(t) > 8 ? _ALIGNOF((uintptr_t) ap) : 0)
+#elif defined(_M_ARM64)
+#define _VA_ALIGN 8
+#define _SLOTSIZEOF(t) ((sizeof(t) + _VA_ALIGN - 1) & ~(_VA_ALIGN - 1))
+#define _APALIGN(t,ap) (((va_list)0 - (ap)) & (__alignof(t) - 1))
 #else
 #define _SLOTSIZEOF(t) (sizeof(t))
 #define _APALIGN(t,ap) (__alignof(t))

--- a/sdk/include/ndk/arm64/ketypes.h
+++ b/sdk/include/ndk/arm64/ketypes.h
@@ -52,6 +52,11 @@ extern "C" {
 #define MM_HAL_VA_END           0xFFFFFFFFFFFFFFFFULL
 
 //
+// Static Kernel-Mode Address start (use MM_KSEG0_BASE for actual)
+//
+#define KSEG0_BASE 0xfffff80000000000ULL
+
+//
 // Structure for CPUID info
 //
 typedef union _CPU_INFO

--- a/sdk/lib/3rdparty/freetype/CMakeLists.txt
+++ b/sdk/lib/3rdparty/freetype/CMakeLists.txt
@@ -54,7 +54,7 @@ list(APPEND SOURCE
 
 add_library(freetype ${SOURCE})
 
-if(CMAKE_C_COMPILER_ID STREQUAL "MSVC" AND ARCH STREQUAL "amd64")
+if(CMAKE_C_COMPILER_ID STREQUAL "MSVC" AND (ARCH STREQUAL "amd64" OR ARCH STREQUAL "arm64"))
     # error C4312: 'type cast': conversion from 'unsigned long' to 'void *' of greater size
     remove_target_compile_option(freetype "/we4312")
 endif()


### PR DESCRIPTION
## Purpose

- Made FreeLoader compile and boot on ARM64
- Fixes crashes in functions with varargs caused by wrong va_defs ([MSVC ARM64 definitions have been sourced from here](https://github.com/microsoft/mu_basecore/blob/c3baf893e5380a48b3c4856bd169ad5fa98795b7/MdePkg/Include/Base.h#L657))
- Fixes 512 byte sector size assumption in FAT filesystem driver
- Added some fixes to SDK to get a bunch of other things to compile properly.