### PR TITLE
[WIN32K] Fix/improve User callout referencing

### DIFF
--- a/win32ss/user/ntuser/main.c
+++ b/win32ss/user/ntuser/main.c
@@ -813,6 +813,9 @@ ExitThreadCallback(PETHREAD Thread)
             UserDereferenceObject(ref->obj);
 
             psle = PopEntryList(&ptiCurrent->ReferencesList);
+#if DBG
+            ptiCurrent->cRefObjectCo--;
+#endif
         }
     }
 
@@ -871,6 +874,8 @@ ExitThreadCallback(PETHREAD Thread)
        ObDereferenceObject(ptiCurrent->pEventQueueServer);
     }
     ptiCurrent->hEventQueueClient = NULL;
+
+    ASSERT(ptiCurrent->cRefObjectCo == 0);
 
     /* The thread is dying */
     PsSetThreadWin32Thread(Thread /*ptiCurrent->pEThread*/, NULL, ptiCurrent);

--- a/win32ss/user/ntuser/object.h
+++ b/win32ss/user/ntuser/object.h
@@ -34,6 +34,9 @@ UserRefObjectCo(PVOID obj, PUSER_REFERENCE_ENTRY UserReferenceEntry)
     UserReferenceEntry->obj = obj;
     UserReferenceObject(obj);
     PushEntryList(&W32Thread->ReferencesList, &UserReferenceEntry->Entry);
+#if DBG
+    W32Thread->cRefObjectCo++;
+#endif
 }
 
 static __inline VOID
@@ -53,6 +56,9 @@ UserDerefObjectCo(PVOID obj)
 
     ASSERT(obj == UserReferenceEntry->obj);
     UserDereferenceObject(obj);
+#if DBG
+    W32Thread->cRefObjectCo--;
+#endif
 }
 
 void FreeProcMarkObject(_In_ PVOID Object);

--- a/win32ss/user/ntuser/painting.c
+++ b/win32ss/user/ntuser/painting.c
@@ -519,6 +519,7 @@ VOID FASTCALL
 co_IntUpdateWindows(PWND Wnd, ULONG Flags, BOOL Recurse)
 {
    HWND hWnd = UserHMGetHandle(Wnd);
+   USER_REFERENCE_ENTRY Ref;
 
    if ( Wnd->hrgnUpdate != NULL || Wnd->state & WNDS_INTERNALPAINT )
    {
@@ -542,15 +543,15 @@ co_IntUpdateWindows(PWND Wnd, ULONG Flags, BOOL Recurse)
       Wnd->state &= ~WNDS_UPDATEDIRTY;
 
       Wnd->state2 |= WNDS2_WMPAINTSENT;
+
+      UserRefObjectCo(Wnd, &Ref);
       co_IntSendMessage(hWnd, WM_PAINT, 0, 0);
 
       if (Wnd->state & WNDS_PAINTNOTPROCESSED)
       {
-         USER_REFERENCE_ENTRY Ref;
-         UserRefObjectCo(Wnd, &Ref);
          co_IntPaintWindows(Wnd, RDW_NOCHILDREN, FALSE);
-         UserDerefObjectCo(Wnd);
       }
+      UserDerefObjectCo(Wnd);
    }
 
    // Force flags as a toggle. Fixes msg:test_paint_messages:WmChildPaintNc.

--- a/win32ss/user/ntuser/win32.h
+++ b/win32ss/user/ntuser/win32.h
@@ -158,6 +158,7 @@ typedef struct _THREADINFO
     ULONG cExclusiveLocks;
 #if DBG
     USHORT acExclusiveLockCount[GDIObjTypeTotal + 1];
+    UINT cRefObjectCo;
 #endif
 #endif // __cplusplus
 } THREADINFO;

--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -583,6 +583,7 @@ LRESULT co_UserFreeWindow(PWND Window,
    PWND Child;
    PMENU Menu;
    BOOLEAN BelongsToThreadData;
+   USER_REFERENCE_ENTRY Ref;
 
    ASSERT(Window);
 
@@ -740,7 +741,7 @@ LRESULT co_UserFreeWindow(PWND Window,
    WndSetChild(Window, NULL);
    WndSetLastActive(Window, NULL);
 
-   UserReferenceObject(Window);
+   UserRefObjectCo(Window, &Ref);
    UserMarkObjectDestroy(Window);
 
    IntDestroyScrollBars(Window);
@@ -769,7 +770,7 @@ LRESULT co_UserFreeWindow(PWND Window,
 //   ASSERT(Window != NULL);
    UserFreeWindowInfo(Window->head.pti, Window);
 
-   UserDereferenceObject(Window);
+   UserDerefObjectCo(Window);
    UserDeleteObject(UserHMGetHandle(Window), TYPE_WINDOW);
 
    return 0;


### PR DESCRIPTION
## Purpose
Fixes some referencing issues.

## Proposed changes
- Add debug assertions that all callout references are cleaned up, when the thread exits
- Fix 2 instances of callout referencing

## Testing
- GCCLin_x86 on Test KVM: https://reactos.org/testman/compare.php?ids=90169,90176,90181,90184
- MSVC_x64 on Test KVM_x64: https://reactos.org/testman/compare.php?ids=90170,90178,90182,90189

