### PR TITLE
[RTL] Avoid some corner case ASSERTS in heap.c and fix heap allocations larger than MAXUSHORT.

### DIFF
--- a/sdk/lib/rtl/heap.c
+++ b/sdk/lib/rtl/heap.c
@@ -440,8 +440,7 @@ RtlpRemoveFreeBlock(PHEAP Heap,
     else
         HintIndex = FreeEntry->Size - 1;
 
-    if (FreeEntry->Size != Heap->FreeHintBitmap.SizeOfBitMap)
-        ASSERT(RtlTestBit(&Heap->FreeHintBitmap, HintIndex));
+    ASSERT(RtlTestBit(&Heap->FreeHintBitmap, HintIndex));
 
     /* Are we removing the hint entry for this size ? */
     if (Heap->FreeHints[HintIndex] == &FreeEntry->FreeList)

--- a/sdk/lib/rtl/heap.c
+++ b/sdk/lib/rtl/heap.c
@@ -361,6 +361,7 @@ RtlpInsertFreeBlock(PHEAP Heap,
     USHORT Size, PreviousSize;
     UCHAR SegmentOffset, Flags;
     PHEAP_SEGMENT Segment;
+    LONG FreeSize;
 
     DPRINT("RtlpInsertFreeBlock(%p %p %x)\n", Heap, FreeEntry, BlockSize);
 
@@ -368,6 +369,7 @@ RtlpInsertFreeBlock(PHEAP Heap,
     Heap->TotalFreeSize += BlockSize;
 
     /* Remember certain values */
+    FreeSize = FreeEntry->Size;
     Flags = FreeEntry->Flags;
     PreviousSize = FreeEntry->PreviousSize;
     SegmentOffset = FreeEntry->SegmentOffset;
@@ -406,12 +408,13 @@ RtlpInsertFreeBlock(PHEAP Heap,
         BlockSize -= Size;
 
         /* Go to the next entry */
+        FreeSize = FreeEntry->Size;
         FreeEntry = (PHEAP_FREE_ENTRY)((PHEAP_ENTRY)FreeEntry + Size);
 
         /* Check if that's all */
         if ((PHEAP_ENTRY)FreeEntry >= Segment->LastValidEntry)
         {
-            return FreeEntry->Size;
+            return FreeSize;
         }
     }
 
@@ -419,7 +422,7 @@ RtlpInsertFreeBlock(PHEAP Heap,
     if (!(Flags & HEAP_ENTRY_LAST_ENTRY))
         FreeEntry->PreviousSize = PreviousSize;
 
-    return FreeEntry->Size;
+    return FreeSize;
 }
 
 static


### PR DESCRIPTION
## Purpose

_Avoid some ASSERT corner cases._

JIRA issue: [CORE-18196](https://jira.reactos.org/browse/CORE-18196)

Edit: I just realized that @ThFabba has another PR for this here PR #4915.

## Proposed changes

_Place IF's around some heap.c ASSERT's to allow them to avoid corner cases._

