### PR TITLE
[NTDLL:LDR] SAL improvements and fixes

### DIFF
--- a/dll/ntdll/include/ntdllp.h
+++ b/dll/ntdll/include/ntdllp.h
@@ -98,12 +98,14 @@ LdrpWalkImportDescriptor(IN LPWSTR DllPath OPTIONAL,
 
 
 /* ldrutils.c */
-NTSTATUS NTAPI
-LdrpGetProcedureAddress(IN PVOID BaseAddress,
-                        IN PANSI_STRING Name,
-                        IN ULONG Ordinal,
-                        OUT PVOID *ProcedureAddress,
-                        IN BOOLEAN ExecuteInit);
+NTSTATUS
+NTAPI
+LdrpGetProcedureAddress(
+    _In_ PVOID BaseAddress,
+    _In_opt_ _When_(Ordinal == 0, _Notnull_) PANSI_STRING Name,
+    _In_opt_ _When_(Name == NULL, _In_range_(>, 0)) ULONG Ordinal,
+    _Out_ PVOID *ProcedureAddress,
+    _In_ BOOLEAN ExecuteInit);
 
 PLDR_DATA_TABLE_ENTRY NTAPI
 LdrpAllocateDataTableEntry(IN PVOID BaseAddress);

--- a/dll/ntdll/ldr/ldrapi.c
+++ b/dll/ntdll/ldr/ldrapi.c
@@ -98,8 +98,9 @@ LdrpMakeCookie(VOID)
  */
 NTSTATUS
 NTAPI
-LdrUnlockLoaderLock(IN ULONG Flags,
-                    IN ULONG Cookie OPTIONAL)
+LdrUnlockLoaderLock(
+    _In_ ULONG Flags,
+    _In_opt_ ULONG Cookie)
 {
     NTSTATUS Status = STATUS_SUCCESS;
 
@@ -170,9 +171,10 @@ LdrUnlockLoaderLock(IN ULONG Flags,
  */
 NTSTATUS
 NTAPI
-LdrLockLoaderLock(IN ULONG Flags,
-                  OUT PULONG Disposition OPTIONAL,
-                  OUT PULONG_PTR Cookie OPTIONAL)
+LdrLockLoaderLock(
+    _In_ ULONG Flags,
+    _Out_opt_ PULONG Disposition,
+    _Out_opt_ PULONG_PTR Cookie)
 {
     NTSTATUS Status = STATUS_SUCCESS;
     BOOLEAN InInit = LdrpInLdrInit;
@@ -440,8 +442,9 @@ LdrLoadDll(IN PWSTR SearchPath OPTIONAL,
  */
 NTSTATUS
 NTAPI
-LdrFindEntryForAddress(PVOID Address,
-                       PLDR_DATA_TABLE_ENTRY *Module)
+LdrFindEntryForAddress(
+    _In_ PVOID Address,
+    _Out_ PLDR_DATA_TABLE_ENTRY *Module)
 {
     PLIST_ENTRY ListHead, NextEntry;
     PLDR_DATA_TABLE_ENTRY LdrEntry;
@@ -519,11 +522,12 @@ LdrFindEntryForAddress(PVOID Address,
  */
 NTSTATUS
 NTAPI
-LdrGetDllHandleEx(IN ULONG Flags,
-                  IN PWSTR DllPath OPTIONAL,
-                  IN PULONG DllCharacteristics OPTIONAL,
-                  IN PUNICODE_STRING DllName,
-                  OUT PVOID *DllHandle OPTIONAL)
+LdrGetDllHandleEx(
+    _In_ ULONG Flags,
+    _In_opt_ PWSTR DllPath,
+    _In_opt_ PULONG DllCharacteristics,
+    _In_ PUNICODE_STRING DllName,
+    _Out_opt_ PVOID *DllHandle)
 {
     NTSTATUS Status;
     PLDR_DATA_TABLE_ENTRY LdrEntry;
@@ -802,10 +806,11 @@ Quickie:
  */
 NTSTATUS
 NTAPI
-LdrGetDllHandle(IN PWSTR DllPath OPTIONAL,
-                IN PULONG DllCharacteristics OPTIONAL,
-                IN PUNICODE_STRING DllName,
-                OUT PVOID *DllHandle)
+LdrGetDllHandle(
+    _In_opt_ PWSTR DllPath,
+    _In_opt_ PULONG DllCharacteristics,
+    _In_ PUNICODE_STRING DllName,
+    _Out_ PVOID *DllHandle)
 {
     /* Call the newer API */
     return LdrGetDllHandleEx(LDR_GET_DLL_HANDLE_EX_UNCHANGED_REFCOUNT,
@@ -820,10 +825,11 @@ LdrGetDllHandle(IN PWSTR DllPath OPTIONAL,
  */
 NTSTATUS
 NTAPI
-LdrGetProcedureAddress(IN PVOID BaseAddress,
-                       IN PANSI_STRING Name,
-                       IN ULONG Ordinal,
-                       OUT PVOID *ProcedureAddress)
+LdrGetProcedureAddress(
+    _In_ PVOID BaseAddress,
+    _In_opt_ _When_(Ordinal == 0, _Notnull_) PANSI_STRING Name,
+    _In_opt_ _When_(Name == NULL, _In_range_(>, 0)) ULONG Ordinal,
+    _Out_ PVOID *ProcedureAddress)
 {
     /* Call the internal routine and tell it to execute DllInit */
     return LdrpGetProcedureAddress(BaseAddress, Name, Ordinal, ProcedureAddress, TRUE);

--- a/dll/ntdll/ldr/ldrutils.c
+++ b/dll/ntdll/ldr/ldrutils.c
@@ -2249,11 +2249,12 @@ lookinhash:
 
 NTSTATUS
 NTAPI
-LdrpGetProcedureAddress(IN PVOID BaseAddress,
-                        IN PANSI_STRING Name,
-                        IN ULONG Ordinal,
-                        OUT PVOID *ProcedureAddress,
-                        IN BOOLEAN ExecuteInit)
+LdrpGetProcedureAddress(
+    _In_ PVOID BaseAddress,
+    _In_opt_ _When_(Ordinal == 0, _Notnull_) PANSI_STRING Name,
+    _In_opt_ _When_(Name == NULL, _In_range_(>, 0)) ULONG Ordinal,
+    _Out_ PVOID *ProcedureAddress,
+    _In_ BOOLEAN ExecuteInit)
 {
     NTSTATUS Status = STATUS_SUCCESS;
     UCHAR ImportBuffer[64];

--- a/dll/win32/verifier/verifier.c
+++ b/dll/win32/verifier/verifier.c
@@ -22,7 +22,13 @@ VOID NTAPI AVrfpNtdllHeapFreeCallback(PVOID AllocationBase, SIZE_T AllocationSiz
 // DPFLTR_VERIFIER_ID
 
 
-NTSTATUS NTAPI AVrfpLdrGetProcedureAddress(IN PVOID BaseAddress, IN PANSI_STRING Name, IN ULONG Ordinal, OUT PVOID *ProcedureAddress);
+NTSTATUS
+NTAPI
+AVrfpLdrGetProcedureAddress(
+    _In_ PVOID BaseAddress,
+    _In_opt_ _When_(Ordinal == 0, _Notnull_) PANSI_STRING Name,
+    _In_opt_ _When_(Name == NULL, _In_range_(>, 0)) ULONG Ordinal,
+    _Out_ PVOID *ProcedureAddress);
 
 static RTL_VERIFIER_THUNK_DESCRIPTOR AVrfpNtdllThunks[] =
 {
@@ -116,9 +122,18 @@ PVOID AVrfpFindReplacementThunk(PVOID Proc)
 }
 
 
-NTSTATUS NTAPI AVrfpLdrGetProcedureAddress(IN PVOID BaseAddress, IN PANSI_STRING Name, IN ULONG Ordinal, OUT PVOID *ProcedureAddress)
+NTSTATUS NTAPI
+AVrfpLdrGetProcedureAddress(
+    _In_ PVOID BaseAddress,
+    _In_opt_ _When_(Ordinal == 0, _Notnull_) PANSI_STRING Name,
+    _In_opt_ _When_(Name == NULL, _In_range_(>, 0)) ULONG Ordinal,
+    _Out_ PVOID *ProcedureAddress)
 {
-    NTSTATUS (NTAPI *oLdrGetProcedureAddress)(IN PVOID BaseAddress, IN PANSI_STRING Name, IN ULONG Ordinal, OUT PVOID *ProcedureAddress);
+    NTSTATUS(NTAPI *oLdrGetProcedureAddress)(
+        _In_ PVOID BaseAddress,
+        _In_opt_ _When_(Ordinal == 0, _Notnull_) PANSI_STRING Name,
+        _In_opt_ _When_(Name == NULL, _In_range_(>, 0)) ULONG Ordinal,
+        _Out_ PVOID *ProcedureAddress);
     NTSTATUS Status;
     PVOID Replacement;
 

--- a/sdk/include/ndk/ldrfuncs.h
+++ b/sdk/include/ndk/ldrfuncs.h
@@ -89,8 +89,8 @@ NTSTATUS
 NTAPI
 LdrGetProcedureAddress(
     _In_ PVOID BaseAddress,
-    _In_ PANSI_STRING Name,
-    _In_ ULONG Ordinal,
+    _In_opt_ _When_(Ordinal == 0, _Notnull_) PANSI_STRING Name,
+    _In_opt_ _When_(Name == NULL, _In_range_(>, 0)) ULONG Ordinal,
     _Out_ PVOID *ProcedureAddress
 );
 

--- a/sdk/include/ndk/umfuncs.h
+++ b/sdk/include/ndk/umfuncs.h
@@ -115,7 +115,7 @@ NTSTATUS
 NTAPI
 LdrGetDllHandle(
     _In_opt_ PWSTR DllPath,
-    _In_ PULONG DllCharacteristics,
+    _In_opt_ PULONG DllCharacteristics,
     _In_ PUNICODE_STRING DllName,
     _Out_ PVOID *DllHandle
 );
@@ -140,8 +140,8 @@ NTSTATUS
 NTAPI
 LdrGetProcedureAddress(
     _In_ PVOID BaseAddress,
-    _In_ PANSI_STRING Name,
-    _In_ ULONG Ordinal,
+    _In_opt_ _When_(Ordinal == 0, _Notnull_) PANSI_STRING Name,
+    _In_opt_ _When_(Name == NULL, _In_range_(>, 0)) ULONG Ordinal,
     _Out_ PVOID *ProcedureAddress
 );
 


### PR DESCRIPTION
## Purpose
SAL improvements and fixes

JIRA issue: None

## Proposed changes
- Uniform some notations in .c and .h, and use SAL2.
- `Name` parameter in `LdrGetProcedureAddress`/`LdrpGetProcedureAddress` should be optional, if it's NULL, `Ordinal` indicates the ordinal of the function to get.
- `DllCharacteristics` parameter in `LdrGetDllHandle` should be optional, if it's NULL, no extra flag specified.