### PR TITLE
[TASKMGR] Restore a performance optimization

### DIFF
--- a/base/applications/taskmgr/perfpage.c
+++ b/base/applications/taskmgr/perfpage.c
@@ -422,13 +422,17 @@ DWORD WINAPI PerformancePageRefreshThread(PVOID Parameter)
              * Get the CPU usage
              */
             CpuUsage = PerfDataGetProcessorUsage();
-            CpuKernelUsage = PerfDataGetProcessorSystemUsage();
 
             if (!bTrackMenu)
             {
                 wsprintfW(Text, szCpuUsage, CpuUsage);
                 SendMessageW(hStatusWnd, SB_SETTEXT, 1, (LPARAM)Text);
             }
+
+            if (TaskManagerSettings.ShowKernelTimes)
+                CpuKernelUsage = PerfDataGetProcessorSystemUsage();
+            else
+                CpuKernelUsage = 0;
 
             /*
              * Get the memory usage


### PR DESCRIPTION

Restore a performance optimization
which got lost by 0.4.15-dev-3483-g 403222dd4f73836b38c11a42fa6c3fc1614681d7 (#4141)

aka.: Only query the kernel times and deal with the CriticalSection in there when kernel times are actually activated.
