### PR TITLE
[MSPAINT] Update scroll info on loading file

### DIFF
--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -180,7 +180,7 @@ VOID CCanvasWindow::DoDraw(HDC hDC, RECT& rcClient, RECT& rcPaint)
     ::DeleteDC(hdcMem0);
 }
 
-VOID CCanvasWindow::Update(HWND hwndFrom)
+VOID CCanvasWindow::updateScrollInfo()
 {
     CRect rcClient;
     GetClientRect(&rcClient);
@@ -214,7 +214,7 @@ VOID CCanvasWindow::Update(HWND hwndFrom)
 LRESULT CCanvasWindow::OnSize(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
     if (m_hWnd)
-        Update(m_hWnd);
+        updateScrollInfo();
 
     return 0;
 }
@@ -245,7 +245,7 @@ VOID CCanvasWindow::OnHVScroll(WPARAM wParam, INT fnBar)
             break;
     }
     SetScrollInfo(fnBar, &si);
-    Update(m_hWnd);
+    updateScrollInfo();
     Invalidate(FALSE); // FIXME: Flicker
 }
 
@@ -627,7 +627,7 @@ LRESULT CCanvasWindow::OnLRButtonUp(BOOL bLeftButton, UINT nMsg, WPARAM wParam, 
 
     m_hitCanvasSizeBox = HIT_NONE;
     toolsModel.resetTool(); // resets the point-buffer of the polygon and bezier functions
-    Update(NULL);
+    updateScrollInfo();
     Invalidate(TRUE);
     return 0;
 }

--- a/base/applications/mspaint/canvas.h
+++ b/base/applications/mspaint/canvas.h
@@ -42,7 +42,7 @@ public:
 
     VOID cancelDrawing();
     VOID finishDrawing();
-    VOID Update(HWND hwndFrom);
+    VOID updateScrollInfo();
 
     VOID ImageToCanvas(POINT& pt);
     VOID ImageToCanvas(RECT& rc);

--- a/base/applications/mspaint/dib.cpp
+++ b/base/applications/mspaint/dib.cpp
@@ -274,8 +274,14 @@ HBITMAP DoLoadImageFile(HWND hwnd, LPCWSTR name, BOOL fIsMainFile)
     CImageDx img;
     float xDpi = 0, yDpi = 0;
     HRESULT hr = img.LoadDx(name, &xDpi, &yDpi);
+    if (FAILED(hr) && fIsMainFile)
+    {
+        imageModel.ClearHistory();
+        hr = img.LoadDx(name, &xDpi, &yDpi);
+    }
     if (FAILED(hr))
     {
+        ATLTRACE("hr: 0x%08lX\n", hr);
         ShowError(IDS_LOADERRORTEXT, name);
         return NULL;
     }

--- a/base/applications/mspaint/history.cpp
+++ b/base/applications/mspaint/history.cpp
@@ -15,9 +15,13 @@ ImageModel imageModel;
 void ImageModel::NotifyImageChanged()
 {
     if (canvasWindow.IsWindow())
-        canvasWindow.Invalidate(FALSE);
+    {
+        canvasWindow.updateScrollInfo();
+        canvasWindow.Invalidate();
+    }
+
     if (miniature.IsWindow())
-        miniature.Invalidate(FALSE);
+        miniature.Invalidate();
 }
 
 ImageModel::ImageModel()
@@ -99,6 +103,15 @@ void ImageModel::ResetToPrevious()
 
 void ImageModel::ClearHistory()
 {
+    for (int i = 0; i < HISTORYSIZE; ++i)
+    {
+        if (m_hBms[i] && i != m_currInd)
+        {
+            ::DeleteObject(m_hBms[i]);
+            m_hBms[i] = NULL;
+        }
+    }
+
     m_undoSteps = 0;
     m_redoSteps = 0;
 }


### PR DESCRIPTION
## Purpose

The scroll info was not updated when the file is loading.
JIRA issue: [CORE-19094](https://jira.reactos.org/browse/CORE-19094)

## Proposed changes

- Rename `CCanvasWindow::Update` as `CCanvasWindow::updateScrollInfo`.
- Update scroll info on `ImageModel::NotifyImageChanged`.
- Improve `ImageModel::ClearHistory`.

## TODO

- [x] Do tests.