### PR TITLE
[MSPAINT] Fix assertion failure on text tool

### DIFF
--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -762,7 +762,8 @@ struct TextTool : ToolBase
 
     void OnFinishDraw() override
     {
-        if (textEditWindow.GetWindowTextLength() > 0)
+        if (::IsWindowVisible(textEditWindow) &&
+            textEditWindow.GetWindowTextLength() > 0)
         {
             imageModel.PushImageForUndo();
             draw(m_hdc);


### PR DESCRIPTION
## Purpose
Kill the assertion failure on choosing text tool.
JIRA issue: [CORE-19094](https://jira.reactos.org/browse/CORE-19094)

![無題](https://github.com/reactos/reactos/assets/2107452/532195fa-8944-4fb4-98bc-bf52de206dd5)

## Proposed changes

- Check whether `textEditWindow` is not null by using `IsWindowVisible`.

## TODO

- [x] Do tests.