### PR TITLE
[SDK] Improve autogenerated stubs

### DIFF
--- a/dll/win32/msvcrt/stubs.c
+++ b/dll/win32/msvcrt/stubs.c
@@ -1,4 +1,5 @@
 
+#include <windef.h>
 #include <stubs.h>
 
 #undef UNIMPLEMENTED

--- a/dll/win32/msvcrt20/stubs.c
+++ b/dll/win32/msvcrt20/stubs.c
@@ -1,3 +1,4 @@
+#include <windef.h>
 #include <stubs.h>
 
 #undef UNIMPLEMENTED

--- a/dll/win32/msvcrt40/stubs.c
+++ b/dll/win32/msvcrt40/stubs.c
@@ -1,3 +1,4 @@
+#include <windef.h>
 #include <stubs.h>
 
 #undef UNIMPLEMENTED

--- a/sdk/cmake/gcc.cmake
+++ b/sdk/cmake/gcc.cmake
@@ -425,6 +425,9 @@ function(spec2def _dllname _spec_file)
         COMMAND native-spec2def -n=${_dllname} -a=${ARCH2} -d=${CMAKE_CURRENT_BINARY_DIR}/${_file}.def -s=${CMAKE_CURRENT_BINARY_DIR}/${_file}_stubs.c ${__with_relay_arg} ${__version_arg} ${CMAKE_CURRENT_SOURCE_DIR}/${_spec_file}
         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${_spec_file} native-spec2def)
 
+    # Do not use precompiled headers for the stub file
+    set_source_files_properties(${CMAKE_CURRENT_BINARY_DIR}/${_file}_stubs.c PROPERTIES SKIP_PRECOMPILE_HEADERS ON)
+
     if(__spec2def_ADD_IMPORTLIB)
         set(_extraflags)
         if(__spec2def_NO_PRIVATE_WARNINGS)

--- a/sdk/cmake/msvc.cmake
+++ b/sdk/cmake/msvc.cmake
@@ -396,6 +396,9 @@ function(spec2def _dllname _spec_file)
         COMMAND native-spec2def --ms -a=${SPEC2DEF_ARCH} -n=${_dllname} -d=${CMAKE_CURRENT_BINARY_DIR}/${_file}.def -s=${CMAKE_CURRENT_BINARY_DIR}/${_file}_stubs.c ${__with_relay_arg} ${__version_arg} ${CMAKE_CURRENT_SOURCE_DIR}/${_spec_file}
         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${_spec_file} native-spec2def)
 
+    # Do not use precompiled headers for the stub file
+    set_source_files_properties(${CMAKE_CURRENT_BINARY_DIR}/${_file}_stubs.c PROPERTIES SKIP_PRECOMPILE_HEADERS ON)
+
     if(__spec2def_ADD_IMPORTLIB)
         generate_import_lib(lib${_file} ${_dllname} ${_spec_file} "${__version_arg}")
         if(__spec2def_NO_PRIVATE_WARNINGS)

--- a/sdk/include/reactos/stubs.h
+++ b/sdk/include/reactos/stubs.h
@@ -1,6 +1,28 @@
-#define WIN32_NO_STATUS
-#define _NTSYSTEM_
-#include <windef.h>
+
+#ifndef _WINDEF_
+typedef unsigned short wchar_t;
+typedef unsigned long DWORD, ULONG;
+typedef void* PVOID;
+#define __int64 long long
+#ifdef _WIN64
+typedef unsigned long long ULONG_PTR;
+#else
+typedef unsigned long ULONG_PTR;
+#endif
+
+#define EXCEPTION_MAXIMUM_PARAMETERS 15
+typedef struct _EXCEPTION_RECORD {
+    DWORD ExceptionCode;
+    DWORD ExceptionFlags;
+    struct _EXCEPTION_RECORD* ExceptionRecord;
+    PVOID ExceptionAddress;
+    DWORD NumberParameters;
+    ULONG_PTR ExceptionInformation[EXCEPTION_MAXIMUM_PARAMETERS];
+} EXCEPTION_RECORD, * PEXCEPTION_RECORD;
+
+#define EXCEPTION_NONCONTINUABLE  0x01
+
+#endif
 
 #ifndef PRIx64
 #define PRIx64 "I64x"
@@ -9,24 +31,23 @@
 #define EXCEPTION_WINE_STUB     0x80000100
 #define EH_NONCONTINUABLE       0x01
 
-NTSYSAPI
-VOID
-NTAPI
+void
+__stdcall
 RtlRaiseException(
-    _In_ PEXCEPTION_RECORD ExceptionRecord
+    PEXCEPTION_RECORD ExceptionRecord
 );
 
 ULONG
 __cdecl
 DbgPrint(
-    _In_z_ _Printf_format_string_ PCSTR Format,
+    const char* Format,
     ...
 );
 
 #define __wine_spec_unimplemented_stub(module, function) \
 { \
     EXCEPTION_RECORD ExceptionRecord = {0}; \
-    ExceptionRecord.ExceptionRecord = NULL; \
+    ExceptionRecord.ExceptionRecord = 0; \
     ExceptionRecord.ExceptionCode = EXCEPTION_WINE_STUB; \
     ExceptionRecord.ExceptionFlags = EXCEPTION_NONCONTINUABLE; \
     ExceptionRecord.ExceptionInformation[0] = (ULONG_PTR)module; \

--- a/sdk/include/reactos/stubs.h
+++ b/sdk/include/reactos/stubs.h
@@ -31,6 +31,13 @@ typedef struct _EXCEPTION_RECORD {
 #define EXCEPTION_WINE_STUB     0x80000100
 #define EH_NONCONTINUABLE       0x01
 
+/* __int128 is not supported on x86, so use a custom type */
+typedef struct
+{
+    __int64 lower;
+    __int64 upper;
+} MyInt128;
+
 void
 __stdcall
 RtlRaiseException(

--- a/sdk/tools/spec2def/spec2def.c
+++ b/sdk/tools/spec2def/spec2def.c
@@ -228,13 +228,6 @@ OutputHeader_stub(FILE *file)
         fprintf(file, "WINE_DECLARE_DEBUG_CHANNEL(relay);\n");
     }
 
-    /* __int128 is not supported on x86, so use a custom type */
-    fprintf(file, "\n"
-                  "typedef struct {\n"
-                  "    __int64 lower;\n"
-                  "    __int64 upper;\n"
-                  "} MyInt128;\n");
-
     fprintf(file, "\n");
 }
 


### PR DESCRIPTION
## Purpose

- Exclude *_stubs file from precompiled headers
- Do not include windef.h in stubs.h

This prevents conflicts between incompatible functions declarations in headers and autogenerated stubs.