### PR TITLE
[CRT] Some NT6 fixes

### DIFF
--- a/dll/win32/msvcrt/msvcrt.spec
+++ b/dll/win32/msvcrt/msvcrt.spec
@@ -549,7 +549,7 @@
 @ stub -version=0x600+ _fwscanf_l
 @ stub -version=0x600+ _fwscanf_s_l
 @ cdecl _gcvt(double long str)
-@ stub -version=0x600+ _gcvt_s
+@ cdecl -version=0x600+ _gcvt_s(ptr ptr double long)
 @ cdecl -version=0x600+ _get_doserrno(ptr)
 @ stub -version=0x600+ _get_environ
 @ cdecl -version=0x600+ _get_errno(ptr)

--- a/sdk/lib/crt/mbstring/mbscmp.c
+++ b/sdk/lib/crt/mbstring/mbscmp.c
@@ -1,10 +1,14 @@
 #include <mbstring.h>
 #include <string.h>
+#include <precomp.h>
 
 /*
  * @implemented
  */
 int _mbscmp(const unsigned char *str1, const unsigned char *str2)
 {
+    if (!MSVCRT_CHECK_PMT(str1 && str2))
+        return _NLSCMPERROR;
+
   return strcmp((const char*)str1, (char*)str2);
 }

--- a/sdk/lib/crt/mem/memicmp.c
+++ b/sdk/lib/crt/mem/memicmp.c
@@ -8,6 +8,19 @@ int
 CDECL
 _memicmp(const void *s1, const void *s2, size_t n)
 {
+    if (NtCurrentPeb()->OSMajorVersion >= 6)
+    {
+        if (!s1 || !s2)
+        {
+            if (n != 0)
+            {
+                MSVCRT_INVALID_PMT(NULL, EINVAL);
+                return _NLSCMPERROR;
+            }
+            return 0;
+        }
+    }
+
   if (n != 0)
   {
     const unsigned char *p1 = s1, *p2 = s2;

--- a/sdk/lib/crt/stdlib/gcvt.c
+++ b/sdk/lib/crt/stdlib/gcvt.c
@@ -1,32 +1,73 @@
-/* Copyright (C) 1998 DJ Delorie, see COPYING.DJ for details */
+/*
+ * msvcrt.dll math functions
+ *
+ * Copyright 2003 Alexandre Julliard <julliard@winehq.org>
+ * Copyright 2010 Piotr Caban <piotr@codeweavers.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ */
+
 #include <precomp.h>
 
-/*
- * @implemented
+/***********************************************************************
+ *		_gcvt  (MSVCRT.@)
  */
-char *
-_gcvt (double value, int ndigits, char *buf)
+char* CDECL _gcvt(double number, int ndigit, char* buff)
 {
-  char *p = buf;
-
-  sprintf (buf, "%-#.*g", ndigits, value);
-
-  /* It seems they expect us to return .XXXX instead of 0.XXXX  */
-  if (*p == '-')
-    p++;
-  if (*p == '0' && p[1] == '.')
-    memmove (p, p + 1, strlen (p + 1) + 1);
-
-  /* They want Xe-YY, not X.e-YY, and XXXX instead of XXXX.  */
-  p = strchr (buf, 'e');
-  if (!p)
-    {
-      p = buf + strlen (buf);
-      /* They don't want trailing zeroes.  */
-      while (p[-1] == '0' && p > buf + 2)
-	*--p = '\0';
+    if (!buff) {
+        *_errno() = EINVAL;
+        return NULL;
     }
-  if (p > buf && p[-1] == '.')
-    memmove (p - 1, p, strlen (p) + 1);
-  return buf;
+
+    if (ndigit < 0) {
+        *_errno() = ERANGE;
+        return NULL;
+    }
+
+    sprintf(buff, "%.*g", ndigit, number);
+    return buff;
+}
+
+/***********************************************************************
+ *              _gcvt_s  (MSVCRT.@)
+ */
+int CDECL _gcvt_s(char* buff, size_t size, double number, int digits)
+{
+    int len;
+
+    if (!buff) {
+        *_errno() = EINVAL;
+        return EINVAL;
+    }
+
+    if (digits < 0 || digits >= size) {
+        if (size)
+            buff[0] = '\0';
+
+        *_errno() = ERANGE;
+        return ERANGE;
+    }
+
+    len = _scprintf("%.*g", digits, number);
+    if (len > size) {
+        buff[0] = '\0';
+        *_errno() = ERANGE;
+        return ERANGE;
+    }
+
+    sprintf(buff, "%.*g", digits, number);
+    return 0;
 }


### PR DESCRIPTION
## Purpose

Some fixes for NT6

## Proposed changes
- Import _gcvt and _gcvt_s from wine and export _gcvt_s on Vista+
- Add parameter check to _mbscmp
- Fix parameter check for _memicmp on NT 6+
