### PR TITLE
[MSPAINT] Zoom tool shouldn't use undo buffer

### DIFF
--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -571,7 +571,6 @@ struct ZoomTool : ToolBase
 
     void OnButtonDown(BOOL bLeftButton, LONG x, LONG y, BOOL bDoubleClick) override
     {
-        imageModel.PushImageForUndo();
         if (bLeftButton)
         {
             if (toolsModel.GetZoom() < MAX_ZOOM)


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-19214](https://jira.reactos.org/browse/CORE-19214)

## Proposed changes

- Remove `PushImageForUndo` call in Zoom tool.

## TODO

- [x] Do tests.