### PR TITLE
[MSPAINT] Check out of image in updating status bar

### DIFF
--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -400,8 +400,12 @@ LRESULT CCanvasWindow::OnMouseMove(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL
 
         if (!m_drawing)
         {
+            RECT rcImage;
+            GetImageRect(rcImage);
+
             CString strCoord;
-            strCoord.Format(_T("%ld, %ld"), pt.x, pt.y);
+            if (::PtInRect(&rcImage, pt))
+                strCoord.Format(_T("%ld, %ld"), pt.x, pt.y);
             ::SendMessage(g_hStatusBar, SB_SETTEXT, 1, (LPARAM) (LPCTSTR) strCoord);
         }
     }


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-19219](https://jira.reactos.org/browse/CORE-19219)

## Proposed changes

- Get the image rectangle by using `CCanvasWindow::GetImageRect`.
- Check out of the image by using `::PtInRect`.
- If out, then don't show the status bar text.

## TODO

- [x] Do tests.