### PR TITLE
[MSPAINT] Add border width to tool box

### DIFF
--- a/base/applications/mspaint/toolbox.cpp
+++ b/base/applications/mspaint/toolbox.cpp
@@ -34,7 +34,12 @@ CPaintToolBar::ToolBarWndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
 BOOL CPaintToolBar::DoCreate(HWND hwndParent)
 {
     // NOTE: The horizontal line above the toolbar is hidden by CCS_NODIVIDER style.
-    RECT toolbarPos = { 0, 0, CX_TOOLBAR, CY_TOOLBAR };
+    RECT toolbarPos =
+    {
+        0, 0,
+        CX_TOOLBAR + 2 * GetSystemMetrics(SM_CXBORDER),
+        CY_TOOLBAR + 2 * GetSystemMetrics(SM_CYBORDER)
+    };
     DWORD style = WS_CHILD | WS_VISIBLE | CCS_NOPARENTALIGN | CCS_VERT | CCS_NORESIZE |
                   TBSTYLE_TOOLTIPS | TBSTYLE_FLAT;
     if (!CWindow::Create(TOOLBARCLASSNAME, hwndParent, toolbarPos, NULL, style))


### PR DESCRIPTION
## Purpose
Make tool box pixel-perfect.

JIRA issue: [CORE-19217](https://jira.reactos.org/browse/CORE-19217)

## Proposed changes

- Add two border widths to the tool box.

## Screenshot

![after](https://github.com/reactos/reactos/assets/2107452/cd0b2714-d5bc-4149-a99d-3e3270656574)

## TODO

- [x] Do tests.
