### PR TITLE
[MSPAINT] Improve Zoom tool

### DIFF
--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -29,18 +29,6 @@ CCanvasWindow::~CCanvasWindow()
         ::DeleteObject(m_ahbmCached[1]);
 }
 
-VOID CCanvasWindow::drawZoomFrame(INT mouseX, INT mouseY)
-{
-    // FIXME: Draw the border of the area that is to be zoomed in
-    CRect rc;
-    GetImageRect(rc);
-    ImageToCanvas(rc);
-
-    HDC hdc = GetDC();
-    DrawXorRect(hdc, &rc);
-    ReleaseDC(hdc);
-}
-
 RECT CCanvasWindow::GetBaseRect()
 {
     CRect rcBase;
@@ -376,6 +364,9 @@ LRESULT CCanvasWindow::OnMouseMove(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL
     POINT pt = { GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) };
     CanvasToImage(pt);
 
+    if (toolsModel.GetActiveTool() == TOOL_ZOOM)
+        Invalidate();
+
     if (m_hitSelection != HIT_NONE)
     {
         SelectionDragging(pt);
@@ -384,14 +375,6 @@ LRESULT CCanvasWindow::OnMouseMove(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL
 
     if (!m_drawing || toolsModel.GetActiveTool() <= TOOL_AIRBRUSH)
     {
-        if (toolsModel.GetActiveTool() == TOOL_ZOOM)
-        {
-            Invalidate(FALSE);
-            UpdateWindow();
-            CanvasToImage(pt);
-            drawZoomFrame(pt.x, pt.y);
-        }
-
         TRACKMOUSEEVENT tme = { sizeof(tme) };
         tme.dwFlags = TME_LEAVE;
         tme.hwndTrack = m_hWnd;

--- a/base/applications/mspaint/canvas.h
+++ b/base/applications/mspaint/canvas.h
@@ -62,7 +62,6 @@ protected:
     RECT GetBaseRect();
     VOID DoDraw(HDC hDC, RECT& rcClient, RECT& rcPaint);
     VOID OnHVScroll(WPARAM wParam, INT fnBar);
-    VOID drawZoomFrame(INT mouseX, INT mouseY);
 
     HITTEST SelectionHitTest(POINT ptImage);
     VOID StartSelectionDrag(HITTEST hit, POINT ptImage);

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -569,6 +569,21 @@ struct ZoomTool : ToolBase
     {
     }
 
+    void OnDrawOverlayOnCanvas(HDC hdc) override
+    {
+        CRect rc;
+        canvasWindow.GetImageRect(rc);
+        canvasWindow.ImageToCanvas(rc);
+
+        POINT pt;
+        ::GetCursorPos(&pt);
+        ::ScreenToClient(canvasWindow, &pt);
+
+        // FIXME: Draw the border of the area that is to be zoomed in
+        if (rc.PtInRect(pt))
+            DrawXorRect(hdc, &rc);
+    }
+
     void OnButtonDown(BOOL bLeftButton, LONG x, LONG y, BOOL bDoubleClick) override
     {
         if (bLeftButton)

--- a/base/applications/mspaint/toolsettings.cpp
+++ b/base/applications/mspaint/toolsettings.cpp
@@ -306,6 +306,17 @@ LRESULT CToolSettingsWindow::OnDestroy(UINT nMsg, WPARAM wParam, LPARAM lParam, 
     return 0;
 }
 
+LRESULT CToolSettingsWindow::OnNotify(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
+{
+    NMHDR *pnmhdr = (NMHDR*)lParam;
+    if (pnmhdr->code == NM_CUSTOMDRAW)
+    {
+        NMCUSTOMDRAW *pCustomDraw = (NMCUSTOMDRAW*)pnmhdr;
+        pCustomDraw->uItemState &= ~CDIS_FOCUS; // Do not draw the focus
+    }
+    return 0;
+}
+
 LRESULT CToolSettingsWindow::OnVScroll(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
     INT trackPos = (INT)(MAX_ZOOM_TRACK - trackbarZoom.SendMessage(TBM_GETPOS, 0, 0));

--- a/base/applications/mspaint/toolsettings.cpp
+++ b/base/applications/mspaint/toolsettings.cpp
@@ -285,7 +285,10 @@ LRESULT CToolSettingsWindow::OnCreate(UINT nMsg, WPARAM wParam, LPARAM lParam, W
     m_hTranspIcon = (HICON)LoadImage(g_hinstExe, MAKEINTRESOURCE(IDI_TRANSPARENT),
                                      IMAGE_ICON, CX_TRANS_ICON, CY_TRANS_ICON, LR_DEFAULTCOLOR);
 
-    RECT trackbarZoomPos = {1, 1, 1 + 40, 1 + 64};
+    RECT trackbarZoomPos, rect2;
+    calculateTwoBoxes(trackbarZoomPos, rect2);
+    ::InflateRect(&trackbarZoomPos, -1, -1);
+
     trackbarZoom.Create(TRACKBAR_CLASS, m_hWnd, trackbarZoomPos, NULL, WS_CHILD | TBS_VERT | TBS_AUTOTICKS);
     trackbarZoom.SendMessage(TBM_SETRANGE, (WPARAM) TRUE, MAKELPARAM(0, 6));
     trackbarZoom.SendMessage(TBM_SETPOS, (WPARAM) TRUE, (LPARAM) 3);

--- a/base/applications/mspaint/toolsettings.cpp
+++ b/base/applications/mspaint/toolsettings.cpp
@@ -308,8 +308,8 @@ LRESULT CToolSettingsWindow::OnDestroy(UINT nMsg, WPARAM wParam, LPARAM lParam, 
 
 LRESULT CToolSettingsWindow::OnVScroll(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
-    INT pos = (INT)(MAX_ZOOM_TRACK - trackbarZoom.SendMessage(TBM_GETPOS, 0, 0));
-    zoomTo(125 << pos, 0, 0); // 12.5% * (2 ** pos)
+    INT trackPos = (INT)(MAX_ZOOM_TRACK - trackbarZoom.SendMessage(TBM_GETPOS, 0, 0));
+    zoomTo(MIN_ZOOM << trackPos, 0, 0);
 
     INT zoomRate = toolsModel.GetZoom();
 

--- a/base/applications/mspaint/toolsettings.cpp
+++ b/base/applications/mspaint/toolsettings.cpp
@@ -358,9 +358,7 @@ LRESULT CToolSettingsWindow::OnPaint(UINT nMsg, WPARAM wParam, LPARAM lParam, BO
     PAINTSTRUCT ps;
     HDC hdc = BeginPaint(&ps);
 
-    if (toolsModel.GetActiveTool() == TOOL_ZOOM)
-        ::DrawEdge(hdc, &rect1, BDR_SUNKENOUTER, BF_RECT);
-    else
+    if (toolsModel.GetActiveTool() != TOOL_ZOOM)
         ::DrawEdge(hdc, &rect1, BDR_SUNKENOUTER, BF_RECT | BF_MIDDLE);
 
     if (toolsModel.GetActiveTool() >= TOOL_RECT)

--- a/base/applications/mspaint/toolsettings.cpp
+++ b/base/applications/mspaint/toolsettings.cpp
@@ -21,6 +21,10 @@
 #define MARGIN1 3
 #define MARGIN2 2
 
+#define MAX_ZOOM_TRACK 6
+#define MIN_ZOOM_TRACK 0
+#define DEFAULT_ZOOM_TRACK 3
+
 static const BYTE s_AirRadius[4] = { 5, 8, 3, 12 };
 
 CToolSettingsWindow toolSettingsWindow;
@@ -290,8 +294,8 @@ LRESULT CToolSettingsWindow::OnCreate(UINT nMsg, WPARAM wParam, LPARAM lParam, W
     ::InflateRect(&trackbarZoomPos, -1, -1);
 
     trackbarZoom.Create(TRACKBAR_CLASS, m_hWnd, trackbarZoomPos, NULL, WS_CHILD | TBS_VERT | TBS_AUTOTICKS);
-    trackbarZoom.SendMessage(TBM_SETRANGE, (WPARAM) TRUE, MAKELPARAM(0, 6));
-    trackbarZoom.SendMessage(TBM_SETPOS, (WPARAM) TRUE, (LPARAM) 3);
+    trackbarZoom.SendMessage(TBM_SETRANGE, (WPARAM) TRUE, MAKELPARAM(MIN_ZOOM_TRACK, MAX_ZOOM_TRACK));
+    trackbarZoom.SendMessage(TBM_SETPOS, (WPARAM) TRUE, (LPARAM) DEFAULT_ZOOM_TRACK);
     return 0;
 }
 
@@ -304,7 +308,7 @@ LRESULT CToolSettingsWindow::OnDestroy(UINT nMsg, WPARAM wParam, LPARAM lParam, 
 
 LRESULT CToolSettingsWindow::OnVScroll(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
-    INT pos = (INT)trackbarZoom.SendMessage(TBM_GETPOS, 0, 0);
+    INT pos = (INT)(MAX_ZOOM_TRACK - trackbarZoom.SendMessage(TBM_GETPOS, 0, 0));
     zoomTo(125 << pos, 0, 0);
 
     INT zoomRate = toolsModel.GetZoom();
@@ -472,7 +476,7 @@ LRESULT CToolSettingsWindow::OnToolsModelSettingsChanged(UINT nMsg, WPARAM wPara
 
 LRESULT CToolSettingsWindow::OnToolsModelZoomChanged(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
-    int tbPos = 0;
+    int tbPos = MIN_ZOOM_TRACK;
     int tempZoom = toolsModel.GetZoom();
 
     while (tempZoom > MIN_ZOOM)
@@ -480,6 +484,6 @@ LRESULT CToolSettingsWindow::OnToolsModelZoomChanged(UINT nMsg, WPARAM wParam, L
         tbPos++;
         tempZoom = tempZoom >> 1;
     }
-    trackbarZoom.SendMessage(TBM_SETPOS, (WPARAM) TRUE, (LPARAM) tbPos);
+    trackbarZoom.SendMessage(TBM_SETPOS, (WPARAM) TRUE, (LPARAM)(MAX_ZOOM_TRACK - tbPos));
     return 0;
 }

--- a/base/applications/mspaint/toolsettings.cpp
+++ b/base/applications/mspaint/toolsettings.cpp
@@ -306,17 +306,6 @@ LRESULT CToolSettingsWindow::OnDestroy(UINT nMsg, WPARAM wParam, LPARAM lParam, 
     return 0;
 }
 
-LRESULT CToolSettingsWindow::OnNotify(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
-{
-    NMHDR *pnmhdr = (NMHDR*)lParam;
-    if (pnmhdr->code == NM_CUSTOMDRAW)
-    {
-        NMCUSTOMDRAW *pCustomDraw = (NMCUSTOMDRAW*)pnmhdr;
-        pCustomDraw->uItemState &= ~CDIS_FOCUS; // Do not draw the focus
-    }
-    return 0;
-}
-
 LRESULT CToolSettingsWindow::OnVScroll(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
     INT trackPos = (INT)(MAX_ZOOM_TRACK - trackbarZoom.SendMessage(TBM_GETPOS, 0, 0));
@@ -334,6 +323,17 @@ LRESULT CToolSettingsWindow::OnVScroll(UINT nMsg, WPARAM wParam, LPARAM lParam, 
 
     OnToolsModelZoomChanged(nMsg, wParam, lParam, bHandled);
 
+    return 0;
+}
+
+LRESULT CToolSettingsWindow::OnNotify(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
+{
+    NMHDR *pnmhdr = (NMHDR*)lParam;
+    if (pnmhdr->code == NM_CUSTOMDRAW)
+    {
+        NMCUSTOMDRAW *pCustomDraw = (NMCUSTOMDRAW*)pnmhdr;
+        pCustomDraw->uItemState &= ~CDIS_FOCUS; // Do not draw the focus
+    }
     return 0;
 }
 

--- a/base/applications/mspaint/toolsettings.cpp
+++ b/base/applications/mspaint/toolsettings.cpp
@@ -308,7 +308,7 @@ LRESULT CToolSettingsWindow::OnDestroy(UINT nMsg, WPARAM wParam, LPARAM lParam, 
 
 LRESULT CToolSettingsWindow::OnVScroll(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
-    INT trackPos = (INT)(MAX_ZOOM_TRACK - trackbarZoom.SendMessage(TBM_GETPOS, 0, 0));
+    INT trackPos = MAX_ZOOM_TRACK - (INT)trackbarZoom.SendMessage(TBM_GETPOS, 0, 0);
     zoomTo(MIN_ZOOM << trackPos, 0, 0);
 
     INT zoomRate = toolsModel.GetZoom();
@@ -322,7 +322,6 @@ LRESULT CToolSettingsWindow::OnVScroll(UINT nMsg, WPARAM wParam, LPARAM lParam, 
     ::SendMessage(g_hStatusBar, SB_SETTEXT, 1, (LPARAM)(LPCTSTR)strZoom);
 
     OnToolsModelZoomChanged(nMsg, wParam, lParam, bHandled);
-
     return 0;
 }
 
@@ -496,6 +495,6 @@ LRESULT CToolSettingsWindow::OnToolsModelZoomChanged(UINT nMsg, WPARAM wParam, L
         tempZoom = tempZoom >> 1;
     }
 
-    trackbarZoom.SendMessage(TBM_SETPOS, (WPARAM) TRUE, (LPARAM)(MAX_ZOOM_TRACK - tbPos));
+    trackbarZoom.SendMessage(TBM_SETPOS, TRUE, MAX_ZOOM_TRACK - tbPos);
     return 0;
 }

--- a/base/applications/mspaint/toolsettings.cpp
+++ b/base/applications/mspaint/toolsettings.cpp
@@ -309,7 +309,7 @@ LRESULT CToolSettingsWindow::OnDestroy(UINT nMsg, WPARAM wParam, LPARAM lParam, 
 LRESULT CToolSettingsWindow::OnVScroll(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
     INT pos = (INT)(MAX_ZOOM_TRACK - trackbarZoom.SendMessage(TBM_GETPOS, 0, 0));
-    zoomTo(125 << pos, 0, 0);
+    zoomTo(125 << pos, 0, 0); // 12.5% * (2 ** pos)
 
     INT zoomRate = toolsModel.GetZoom();
 
@@ -484,6 +484,7 @@ LRESULT CToolSettingsWindow::OnToolsModelZoomChanged(UINT nMsg, WPARAM wParam, L
         tbPos++;
         tempZoom = tempZoom >> 1;
     }
+
     trackbarZoom.SendMessage(TBM_SETPOS, (WPARAM) TRUE, (LPARAM)(MAX_ZOOM_TRACK - tbPos));
     return 0;
 }

--- a/base/applications/mspaint/toolsettings.cpp
+++ b/base/applications/mspaint/toolsettings.cpp
@@ -304,10 +304,21 @@ LRESULT CToolSettingsWindow::OnDestroy(UINT nMsg, WPARAM wParam, LPARAM lParam, 
 
 LRESULT CToolSettingsWindow::OnVScroll(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
-    if (!zoomTo(125 << trackbarZoom.SendMessage(TBM_GETPOS, 0, 0), 0, 0))
-    {
-        OnToolsModelZoomChanged(nMsg, wParam, lParam, bHandled);
-    }
+    INT pos = (INT)trackbarZoom.SendMessage(TBM_GETPOS, 0, 0);
+    zoomTo(125 << pos, 0, 0);
+
+    INT zoomRate = toolsModel.GetZoom();
+
+    CString strZoom;
+    if (zoomRate % 10 == 0)
+        strZoom.Format(_T("%d%%"), zoomRate / 10);
+    else
+        strZoom.Format(_T("%d.%d%%"), zoomRate / 10, zoomRate % 10);
+
+    ::SendMessage(g_hStatusBar, SB_SETTEXT, 1, (LPARAM)(LPCTSTR)strZoom);
+
+    OnToolsModelZoomChanged(nMsg, wParam, lParam, bHandled);
+
     return 0;
 }
 

--- a/base/applications/mspaint/toolsettings.cpp
+++ b/base/applications/mspaint/toolsettings.cpp
@@ -294,8 +294,8 @@ LRESULT CToolSettingsWindow::OnCreate(UINT nMsg, WPARAM wParam, LPARAM lParam, W
     ::InflateRect(&trackbarZoomPos, -1, -1);
 
     trackbarZoom.Create(TRACKBAR_CLASS, m_hWnd, trackbarZoomPos, NULL, WS_CHILD | TBS_VERT | TBS_AUTOTICKS);
-    trackbarZoom.SendMessage(TBM_SETRANGE, (WPARAM) TRUE, MAKELPARAM(MIN_ZOOM_TRACK, MAX_ZOOM_TRACK));
-    trackbarZoom.SendMessage(TBM_SETPOS, (WPARAM) TRUE, (LPARAM) DEFAULT_ZOOM_TRACK);
+    trackbarZoom.SendMessage(TBM_SETRANGE, TRUE, MAKELPARAM(MIN_ZOOM_TRACK, MAX_ZOOM_TRACK));
+    trackbarZoom.SendMessage(TBM_SETPOS, TRUE, DEFAULT_ZOOM_TRACK);
     return 0;
 }
 

--- a/base/applications/mspaint/toolsettings.h
+++ b/base/applications/mspaint/toolsettings.h
@@ -17,6 +17,7 @@ public:
         MESSAGE_HANDLER(WM_VSCROLL, OnVScroll)
         MESSAGE_HANDLER(WM_PAINT, OnPaint)
         MESSAGE_HANDLER(WM_LBUTTONDOWN, OnLButtonDown)
+        MESSAGE_HANDLER(WM_NOTIFY, OnNotify)
         MESSAGE_HANDLER(WM_TOOLSMODELTOOLCHANGED, OnToolsModelToolChanged)
         MESSAGE_HANDLER(WM_TOOLSMODELSETTINGSCHANGED, OnToolsModelSettingsChanged)
         MESSAGE_HANDLER(WM_TOOLSMODELZOOMCHANGED, OnToolsModelZoomChanged)
@@ -43,6 +44,7 @@ private:
     LRESULT OnVScroll(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
     LRESULT OnPaint(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
     LRESULT OnLButtonDown(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
+    LRESULT OnNotify(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
     LRESULT OnToolsModelToolChanged(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
     LRESULT OnToolsModelSettingsChanged(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
     LRESULT OnToolsModelZoomChanged(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-19215](https://jira.reactos.org/browse/CORE-19215), [CORE-19216](https://jira.reactos.org/browse/CORE-19216)

## Proposed changes

- Delete `CCanvasWindow::drawZoomFrame`.
- Invalidate the canvas on mouse move when the active tool is Zoom tool.
- Add `ZoomTool::OnDrawOverlayOnCanvas` to draw the zoom rectangle without flickering.
- Improve the zoom trackbar position.
- Display the zoom rate on changing the value of the zoom trackbar.
- Reverse the direction of the zoom trackbar.
- Don't draw the focus rectangle.

## Screenshot

![after](https://github.com/reactos/reactos/assets/2107452/04c6a4f1-285a-413c-a56b-3546d67f7872)

## TODO

- [x] Do tests.