### PR TITLE
[DESK] Fix filter format from OPENFILENAME structure 

### DIFF
--- a/dll/cpl/desk/background.c
+++ b/dll/cpl/desk/background.c
@@ -657,7 +657,7 @@ OnBrowseButton(HWND hwndDlg, PBACKGROUND_DATA pData)
     sizeRemain = buffersize;
     c = filter;
 
-    if (FAILED(StringCbPrintfEx(c, sizeRemain, &c, &sizeRemain, 0, L"%ls (%ls)", filterdesc, extensions)))
+    if (FAILED(StringCbPrintfEx(c, sizeRemain, &c, &sizeRemain, 0, L"%ls (%ls)\0", filterdesc, extensions)))
     {
         HeapFree(GetProcessHeap(), 0, extensions);
         HeapFree(GetProcessHeap(), 0, filter);
@@ -667,7 +667,7 @@ OnBrowseButton(HWND hwndDlg, PBACKGROUND_DATA pData)
     c++;
     sizeRemain -= sizeof(*c);
 
-    if (FAILED(StringCbPrintfEx(c, sizeRemain, &c, &sizeRemain, 0, L"%ls", extensions)))
+    if (FAILED(StringCbPrintfEx(c, sizeRemain, &c, &sizeRemain, 0, L"%ls\0", extensions)))
     {
         HeapFree(GetProcessHeap(), 0, extensions);
         HeapFree(GetProcessHeap(), 0, filter);

--- a/dll/cpl/desk/background.c
+++ b/dll/cpl/desk/background.c
@@ -1261,7 +1261,7 @@ BackgroundPageProc(HWND hwndDlg,
                             SetDesktopBackColor(hwndDlg, pData);
                         if (pData->desktopData.bSettingsChanged)
                             SetDesktopSettings(&pData->desktopData);
-                        SendMessage(HWND_BROADCAST, WM_SETTINGCHANGE, 0, (LPARAM)_T(""));
+                        SendMessageTimeout(HWND_BROADCAST, WM_SETTINGCHANGE, 0, (LPARAM)_T(""), SMTO_ABORTIFHUNG, 0, NULL);
                         return TRUE;
 
                     case LVN_ITEMCHANGED:


### PR DESCRIPTION
## Purpose
Fix filter format from OPENFILENAME structure 
when selecting a new wallpaper.

  It seems to me that the original idea would be to present only one pair of strings. So let's end both with a extra NULL character.


Use SendMessageTimeout instead of  SendMessage.

When sending the WM_SETTINGCHANGE message to all top-level windows, MS advises  to use SendMessageTimeout.
This also solves the system freeze when clicking the apply button when compiling livecd

JIRA issues: [CORE-18268](https://jira.reactos.org/browse/CORE-18268) [CORE-19050](https://jira.reactos.org/browse/CORE-19050)




