### PR TITLE
[KS] KsRead/WriteFile: finish IRP initialization and properly setup I/O stack location for it

### DIFF
--- a/drivers/ksfilter/ks/irp.c
+++ b/drivers/ksfilter/ks/irp.c
@@ -150,6 +150,7 @@ KsReadFile(
     IN  KPROCESSOR_MODE RequestorMode)
 {
     PDEVICE_OBJECT DeviceObject;
+    PIO_STACK_LOCATION IoStack;
     PIRP Irp;
     NTSTATUS Status;
     BOOLEAN Result;
@@ -216,6 +217,16 @@ KsReadFile(
         return STATUS_INSUFFICIENT_RESOURCES;
     }
 
+    /* setup the rest of irp */
+    Irp->RequestorMode = RequestorMode;
+    Irp->Overlay.AsynchronousParameters.UserApcContext = PortContext;
+    Irp->Tail.Overlay.OriginalFileObject = FileObject;
+
+    /* setup irp stack */
+    IoStack = IoGetNextIrpStackLocation(Irp);
+    IoStack->FileObject = FileObject;
+    IoStack->Parameters.Read.Key = Key;
+
     /* send the packet */
     Status = IoCallDriver(DeviceObject, Irp);
 
@@ -250,6 +261,7 @@ KsWriteFile(
     IN  KPROCESSOR_MODE RequestorMode)
 {
     PDEVICE_OBJECT DeviceObject;
+    PIO_STACK_LOCATION IoStack;
     PIRP Irp;
     NTSTATUS Status;
     BOOLEAN Result;
@@ -315,6 +327,16 @@ KsWriteFile(
         /* not enough resources */
         return STATUS_INSUFFICIENT_RESOURCES;
     }
+
+    /* setup the rest of irp */
+    Irp->RequestorMode = RequestorMode;
+    Irp->Overlay.AsynchronousParameters.UserApcContext = PortContext;
+    Irp->Tail.Overlay.OriginalFileObject = FileObject;
+
+    /* setup irp stack */
+    IoStack = IoGetNextIrpStackLocation(Irp);
+    IoStack->FileObject = FileObject;
+    IoStack->Parameters.Write.Key = Key;
 
     /* send the packet */
     Status = IoCallDriver(DeviceObject, Irp);


### PR DESCRIPTION
## Purpose

Properly initialize several IRP data, which is not filled correctly by PnP and setup I/O stack location for this IRP, before it's passed to the target driver's read/write routine via `IoCallDriver`, similarly to the way as it's done in `KsStreamIo`.
This fixes several problems when calling these functions from outside, so now they are working correctly, as expected.
Discovered during my audio investigations.

JIRA issue: [CORE-19232](https://jira.reactos.org/browse/CORE-19232)

## Proposed changes

- Initialize the rest of IRP data which is not initialized by `IoBuildSynchronousFsdRequest`.
- Setup an `IO_STACK_LOCATION` structure for the IRP before calling the driver's read/write routine.
- Do this for both `KsReadFile` and `KsWriteFile` functions in our Kernel Streaming driver (ks.sys).