### PR TITLE
[MSPAINT][NOTEPAD][REGEDIT] Don't use CRTDBG for these apps

### DIFF
--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -299,11 +299,6 @@ HWND CMainWindow::DoCreate()
 INT WINAPI
 _tWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPTSTR lpCmdLine, INT nCmdShow)
 {
-#ifdef _DEBUG
-    // Report any memory leaks on exit
-    _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
-#endif
-
     g_hinstExe = hInstance;
 
     // Initialize common controls library

--- a/base/applications/mspaint/precomp.h
+++ b/base/applications/mspaint/precomp.h
@@ -26,10 +26,6 @@
 #include <shellapi.h>
 #include <htmlhelp.h>
 #include "atlimagedx.h"
-#ifdef _DEBUG
-    #define _CRTDBG_MAP_ALLOC
-    #include <crtdbg.h>
-#endif
 
 #include <debug.h>
 

--- a/base/applications/notepad/main.c
+++ b/base/applications/notepad/main.c
@@ -564,11 +564,6 @@ int WINAPI _tWinMain(HINSTANCE hInstance, HINSTANCE prev, LPTSTR cmdline, int sh
     static const TCHAR className[] = _T("Notepad");
     static const TCHAR winName[] = _T("Notepad");
 
-#ifdef _DEBUG
-    /* Report any memory leaks on exit */
-    _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
-#endif
-
     switch (GetUserDefaultUILanguage())
     {
     case MAKELANGID(LANG_HEBREW, SUBLANG_DEFAULT):

--- a/base/applications/notepad/notepad.h
+++ b/base/applications/notepad/notepad.h
@@ -25,10 +25,6 @@
 #include <tchar.h>
 #include <stdlib.h>
 #include <malloc.h>
-#ifdef _DEBUG
-    #define _CRTDBG_MAP_ALLOC
-    #include <crtdbg.h>
-#endif
 
 #include "dialog.h"
 #include "notepad_res.h"

--- a/base/applications/regedit/main.c
+++ b/base/applications/regedit/main.c
@@ -205,11 +205,6 @@ int WINAPI wWinMain(HINSTANCE hInstance,
 
     UNREFERENCED_PARAMETER(hPrevInstance);
 
-#ifdef _DEBUG
-    /* Report any memory leaks on exit */
-    _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
-#endif
-
     /* Initialize global strings */
     LoadStringW(hInstance, IDS_APP_TITLE, szTitle, ARRAY_SIZE(szTitle));
     LoadStringW(hInstance, IDC_REGEDIT_FRAME, szFrameClass, ARRAY_SIZE(szFrameClass));

--- a/base/applications/regedit/regedit.h
+++ b/base/applications/regedit/regedit.h
@@ -11,10 +11,6 @@
 #include <shellapi.h>
 #include <strsafe.h>
 #include <stdlib.h>
-#ifdef _DEBUG
-    #define _CRTDBG_MAP_ALLOC
-    #include <crtdbg.h>
-#endif
 
 #include "main.h"
 #include "hexedit.h"


### PR DESCRIPTION
## Purpose

Avoid using CRTDBG in these applications. This will reduce management cost.
JIRA issue: N/A

## Proposed changes

- Don't include `<crtdbg.h>`.
- Don't use `_CrtSetDbgFlag`.