### PR TITLE
[MSPAINT] Reset scroll position in some situations

### DIFF
--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -199,6 +199,12 @@ VOID CCanvasWindow::updateScrollInfo()
     SetScrollInfo(SB_VERT, &si);
 }
 
+VOID CCanvasWindow::resetScrollPos()
+{
+    SetScrollPos(SB_HORZ, 0);
+    SetScrollPos(SB_VERT, 0);
+}
+
 LRESULT CCanvasWindow::OnSize(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
     if (m_hWnd)

--- a/base/applications/mspaint/canvas.h
+++ b/base/applications/mspaint/canvas.h
@@ -43,6 +43,7 @@ public:
     VOID cancelDrawing();
     VOID finishDrawing();
     VOID updateScrollInfo();
+    VOID resetScrollPos();
 
     VOID ImageToCanvas(POINT& pt);
     VOID ImageToCanvas(RECT& rc);

--- a/base/applications/mspaint/dib.cpp
+++ b/base/applications/mspaint/dib.cpp
@@ -241,6 +241,7 @@ HBITMAP InitializeImage(LPCWSTR name, LPWIN32_FIND_DATAW pFound, BOOL isFile)
 HBITMAP SetBitmapAndInfo(HBITMAP hBitmap, LPCWSTR name, LPWIN32_FIND_DATAW pFound, BOOL isFile)
 {
     // update image
+    canvasWindow.resetScrollPos();
     imageModel.PushImageForUndo(hBitmap);
     imageModel.ClearHistory();
 

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -921,6 +921,7 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
         case IDM_IMAGEROTATEMIRROR:
             {
                 CWaitCursor waitCursor;
+                canvasWindow.resetScrollPos();
                 switch (mirrorRotateDialog.DoModal(mainWindow.m_hWnd))
                 {
                     case 1: /* flip horizontally */


### PR DESCRIPTION
## Purpose

In some situations, the scroll position should be reset.
JIRA issue: [CORE-19094](https://jira.reactos.org/browse/CORE-19094)

## Proposed changes

- Add `CCanvasWindow::resetScrollPos` method.
- Reset the scroll position on loading a file.
- Reset the scroll position on mirroring/rotating the image.

## TODO

- [x] Do tests.

## Comparison

BEFORE:
https://github.com/reactos/reactos/assets/2107452/e3c26c2f-549b-4efe-aa00-7cf4e17940af

AFTER:
https://github.com/reactos/reactos/assets/2107452/4863b2e4-af6f-4a79-9cdb-00d734addc0b