### PR TITLE
[NTOS:MM] ExFreePoolWithTag: validate the pool tag only in case the pool is "protected"

### DIFF
--- a/ntoskrnl/mm/ARM3/expool.c
+++ b/ntoskrnl/mm/ARM3/expool.c
@@ -2597,19 +2597,20 @@ ExFreePoolWithTag(IN PVOID P,
         else if (Tag & PROTECTED_POOL)
         {
             Tag &= ~PROTECTED_POOL;
-        }
+            TagToFree &= ~PROTECTED_POOL;
 
-        //
-        // Check block tag
-        //
-        if (TagToFree && TagToFree != Tag)
-        {
-            DPRINT1("Freeing pool - invalid tag specified: %.4s != %.4s\n", (char*)&TagToFree, (char*)&Tag);
+            //
+            // Check block tag
+            //
+            if (TagToFree && TagToFree != Tag)
+            {
+                DPRINT1("Freeing pool - invalid tag specified: %.4s != %.4s\n", (char*)&TagToFree, (char*)&Tag);
 #if DBG
-            /* Do not bugcheck in case this is a big allocation for which we didn't manage to insert the tag */
-            if (Tag != ' GIB')
-                KeBugCheckEx(BAD_POOL_CALLER, 0x0A, (ULONG_PTR)P, Tag, TagToFree);
+                /* Do not bugcheck in case this is a big allocation for which we didn't manage to insert the tag */
+                if (Tag != ' GIB')
+                    KeBugCheckEx(BAD_POOL_CALLER, 0x0A, (ULONG_PTR)P, Tag, TagToFree);
 #endif
+            }
         }
 
         //
@@ -2683,17 +2684,21 @@ ExFreePoolWithTag(IN PVOID P,
     // Get the pool tag and get rid of the PROTECTED_POOL flag
     //
     Tag = Entry->PoolTag;
-    if (Tag & PROTECTED_POOL) Tag &= ~PROTECTED_POOL;
-
-    //
-    // Check block tag
-    //
-    if (TagToFree && TagToFree != Tag)
+    if (Tag & PROTECTED_POOL)
     {
-        DPRINT1("Freeing pool - invalid tag specified: %.4s != %.4s\n", (char*)&TagToFree, (char*)&Tag);
+        Tag &= ~PROTECTED_POOL;
+        TagToFree &= ~PROTECTED_POOL;
+
+        //
+        // Check block tag
+        //
+        if (TagToFree && TagToFree != Tag)
+        {
+            DPRINT1("Freeing pool - invalid tag specified: %.4s != %.4s\n", (char*)&TagToFree, (char*)&Tag);
 #if DBG
-        KeBugCheckEx(BAD_POOL_CALLER, 0x0A, (ULONG_PTR)P, Tag, TagToFree);
+            KeBugCheckEx(BAD_POOL_CALLER, 0x0A, (ULONG_PTR)P, Tag, TagToFree);
 #endif
+	    }
     }
 
     //


### PR DESCRIPTION
## Purpose

Perform the pool tag validation in `ExFreePoolWithTag` only when `PROTECTED_POOL` flag is specified by the caller.
Reference: https://community.osr.com/discussion/236393/exfreepoolwithtag-etc.

> In general the tags are associated with the memory but not checked. So
allocating with a tag, then using a different tag or no tag to free
memory is fine. You can change this behavior by or'ing `PROTECTED_POOL`
to the tag, then the tag is checked at memory freeing to ensure they are
the same. Using `PROTECTED_POOL` can be a good diagnostic.

Although MSDN does not tell anything about this, but nevertheless some others Web References are proving this too, so it's more correct compared to Windows behaviour.
Also I've found an info that this is the most actual for XP and Server 2003. Starting from Vista, this flag seems to have no any effect.
The main statement remains valid: different pool tags those are causing mismatch, are still an issue on the caller's side, but the checking for it should actually be done only in case the caller really wants it (adds `PROTECTED_POOL` flag to the actual tag via bitwise "OR" operator).
This should fix several corner cases when bugcheck 0xC2 (BAD_POOL_CALLER) occurs due to the mismatching tag for allocating and freeing dynamic memory, like in CORE-18160. I also saw this problem when tested many other software and can confirm that it fixes the issue for me. :slightly_smiling_face: 

JIRA issue: [CORE-18160](https://jira.reactos.org/browse/CORE-18160)

## Proposed changes

- Perform the pool tag validation in ExFreePoolWithTag only when PROTECTED_POOL flag is specified by the caller.
- Add test for allocating/freeing dynamical memory with `PROTECTED_POOL` flag appended to the pool tag.

## TODO

- [ ] Make the kmtest actually working. I'm not sure how to do it correctly (should I append `PROTECTED_POOL` flag in `ExAllocatePoolWithTag` call also? :thinking:) In the current state it does not trigger the checks on Windows Server 2003, same as on ReactOS after my changes. So this is an issue in kmtest still.

## Result

The kmtest in its current state completely succeeds on Windows Server 2003 (but does not trigger the bugcheck yet, seems due to release configuration):
![VirtualBox_Windows Server 2003_13_10_2023_15_25_07](https://github.com/reactos/reactos/assets/26385117/a930c306-572a-43e1-95dc-cc24257f0309)

Same as on ReactOS after my changes:
![VirtualBox_ReactOS_13_10_2023_15_32_25](https://github.com/reactos/reactos/assets/26385117/7cd112ec-3328-42cf-8989-fed1017db553)
However, without my patch it always triggers the bugcheck.