### PR TITLE
[MSPAINT] Calculate intersection to reduce bits transfer

### DIFF
--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -173,9 +173,7 @@ VOID CCanvasWindow::DoDraw(HDC hDC, RECT& rcClient, RECT& rcPaint)
         DrawXorRect(hdcMem0, &m_rcResizing);
 
     // Transfer the bits (hDC <-- hdcMem0)
-    ::BitBlt(hDC,
-             rcCanvasDraw.left, rcCanvasDraw.top,
-             rcCanvasDraw.Width(), rcCanvasDraw.Height(),
+    ::BitBlt(hDC, rcCanvasDraw.left, rcCanvasDraw.top, rcCanvasDraw.Width(), rcCanvasDraw.Height(),
              hdcMem0, rcCanvasDraw.left, rcCanvasDraw.top, SRCCOPY);
 
     // Clean up hdcMem0

--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -91,29 +91,39 @@ HITTEST CCanvasWindow::CanvasHitTest(POINT pt)
 
 VOID CCanvasWindow::DoDraw(HDC hDC, RECT& rcClient, RECT& rcPaint)
 {
+    // Calculate the intersect on canvas to reduce bits transfer
+    CRect rcIntersectCanvas;
+    rcIntersectCanvas.IntersectRect(&rcClient, &rcPaint);
+
     // We use a memory bitmap to reduce flickering
     HDC hdcMem0 = ::CreateCompatibleDC(hDC);
     m_ahbmCached[0] = CachedBufferDIB(m_ahbmCached[0], rcClient.right, rcClient.bottom);
     HGDIOBJ hbm0Old = ::SelectObject(hdcMem0, m_ahbmCached[0]);
 
     // Fill the background on hdcMem0
-    ::FillRect(hdcMem0, &rcPaint, (HBRUSH)(COLOR_APPWORKSPACE + 1));
+    ::FillRect(hdcMem0, &rcIntersectCanvas, (HBRUSH)(COLOR_APPWORKSPACE + 1));
 
     // Draw the sizeboxes if necessary
     RECT rcBase = GetBaseRect();
     if (!selectionModel.m_bShow && !::IsWindowVisible(textEditWindow))
-        drawSizeBoxes(hdcMem0, &rcBase, FALSE, &rcPaint);
+        drawSizeBoxes(hdcMem0, &rcBase, FALSE, &rcIntersectCanvas);
 
     // Calculate image size
     CRect rcImage;
     GetImageRect(rcImage);
     SIZE sizeImage = { imageModel.GetWidth(), imageModel.GetHeight() };
 
+    // Calculate the intersect on image to reduce bits transfer
+    CRect rcIntersectImage = rcIntersectCanvas;
+    CanvasToImage(rcIntersectImage);
+
     // hdcMem1 <-- imageModel
     HDC hdcMem1 = ::CreateCompatibleDC(hDC);
     m_ahbmCached[1] = CachedBufferDIB(m_ahbmCached[1], sizeImage.cx, sizeImage.cy);
     HGDIOBJ hbm1Old = ::SelectObject(hdcMem1, m_ahbmCached[1]);
-    BitBlt(hdcMem1, 0, 0, sizeImage.cx, sizeImage.cy, imageModel.GetDC(), 0, 0, SRCCOPY);
+    BitBlt(hdcMem1, rcIntersectImage.left, rcIntersectImage.top,
+                    rcIntersectImage.Width(), rcIntersectImage.Height(),
+           imageModel.GetDC(), rcIntersectImage.left, rcIntersectImage.top, SRCCOPY);
 
     // Draw overlay #1 on hdcMem1
     toolsModel.OnDrawOverlayOnImage(hdcMem1);
@@ -159,9 +169,9 @@ VOID CCanvasWindow::DoDraw(HDC hDC, RECT& rcClient, RECT& rcPaint)
 
     // Transfer the bits (hDC <-- hdcMem0)
     ::BitBlt(hDC,
-             rcPaint.left, rcPaint.top,
-             rcPaint.right - rcPaint.left, rcPaint.bottom - rcPaint.top,
-             hdcMem0, rcPaint.left, rcPaint.top, SRCCOPY);
+             rcIntersectCanvas.left, rcIntersectCanvas.top,
+             rcIntersectCanvas.Width(), rcIntersectCanvas.Height(),
+             hdcMem0, rcIntersectCanvas.left, rcIntersectCanvas.top, SRCCOPY);
 
     // Clean up hdcMem0
     ::SelectObject(hdcMem0, hbm0Old);

--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -91,7 +91,7 @@ HITTEST CCanvasWindow::CanvasHitTest(POINT pt)
 
 VOID CCanvasWindow::DoDraw(HDC hDC, RECT& rcClient, RECT& rcPaint)
 {
-    // Calculate the intersect on canvas to reduce bits transfer
+    // Calculate the intersection on the canvas to reduce bits transfer
     CRect rcIntersectCanvas;
     rcIntersectCanvas.IntersectRect(&rcClient, &rcPaint);
 
@@ -113,7 +113,7 @@ VOID CCanvasWindow::DoDraw(HDC hDC, RECT& rcClient, RECT& rcPaint)
     GetImageRect(rcImage);
     SIZE sizeImage = { imageModel.GetWidth(), imageModel.GetHeight() };
 
-    // Calculate the intersect on image to reduce bits transfer
+    // Calculate the intersection on the image to reduce bits transfer
     CRect rcIntersectImage = rcIntersectCanvas;
     CanvasToImage(rcIntersectImage);
 

--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -126,8 +126,7 @@ VOID CCanvasWindow::DoDraw(HDC hDC, RECT& rcClient, RECT& rcPaint)
     HDC hdcMem1 = ::CreateCompatibleDC(hDC);
     m_ahbmCached[1] = CachedBufferDIB(m_ahbmCached[1], sizeImage.cx, sizeImage.cy);
     HGDIOBJ hbm1Old = ::SelectObject(hdcMem1, m_ahbmCached[1]);
-    ::BitBlt(hdcMem1, rcImageDraw.left, rcImageDraw.top,
-                      rcImageDraw.Width(), rcImageDraw.Height(),
+    ::BitBlt(hdcMem1, rcImageDraw.left, rcImageDraw.top, rcImageDraw.Width(), rcImageDraw.Height(),
              imageModel.GetDC(), rcImageDraw.left, rcImageDraw.top, SRCCOPY);
 
     // Draw overlay #1 on hdcMem1

--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -116,6 +116,7 @@ VOID CCanvasWindow::DoDraw(HDC hDC, RECT& rcClient, RECT& rcPaint)
     // Calculate the target area on the image
     CRect rcImageDraw = rcCanvasDraw;
     CanvasToImage(rcImageDraw);
+    rcImageDraw &= rcImage;
 
     // hdcMem1 <-- imageModel
     HDC hdcMem1 = ::CreateCompatibleDC(hDC);

--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -118,6 +118,10 @@ VOID CCanvasWindow::DoDraw(HDC hDC, RECT& rcClient, RECT& rcPaint)
     CanvasToImage(rcImageDraw);
     rcImageDraw &= rcImage;
 
+    // Consider rounding down by zooming
+    rcImageDraw.right += 1;
+    rcImageDraw.bottom += 1;
+
     // hdcMem1 <-- imageModel
     HDC hdcMem1 = ::CreateCompatibleDC(hDC);
     m_ahbmCached[1] = CachedBufferDIB(m_ahbmCached[1], sizeImage.cx, sizeImage.cy);

--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -121,9 +121,9 @@ VOID CCanvasWindow::DoDraw(HDC hDC, RECT& rcClient, RECT& rcPaint)
     HDC hdcMem1 = ::CreateCompatibleDC(hDC);
     m_ahbmCached[1] = CachedBufferDIB(m_ahbmCached[1], sizeImage.cx, sizeImage.cy);
     HGDIOBJ hbm1Old = ::SelectObject(hdcMem1, m_ahbmCached[1]);
-    BitBlt(hdcMem1, rcIntersectImage.left, rcIntersectImage.top,
-                    rcIntersectImage.Width(), rcIntersectImage.Height(),
-           imageModel.GetDC(), rcIntersectImage.left, rcIntersectImage.top, SRCCOPY);
+    ::BitBlt(hdcMem1, rcIntersectImage.left, rcIntersectImage.top,
+                      rcIntersectImage.Width(), rcIntersectImage.Height(),
+             imageModel.GetDC(), rcIntersectImage.left, rcIntersectImage.top, SRCCOPY);
 
     // Draw overlay #1 on hdcMem1
     toolsModel.OnDrawOverlayOnImage(hdcMem1);

--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -116,7 +116,7 @@ VOID CCanvasWindow::DoDraw(HDC hDC, RECT& rcClient, RECT& rcPaint)
     // Calculate the target area on the image
     CRect rcImageDraw = rcCanvasDraw;
     CanvasToImage(rcImageDraw);
-    rcImageDraw &= rcImage;
+    rcImageDraw.IntersectRect(&rcImageDraw, &rcImage);
 
     // Consider rounding down by zooming
     rcImageDraw.right += 1;

--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -91,7 +91,8 @@ HITTEST CCanvasWindow::CanvasHitTest(POINT pt)
 
 VOID CCanvasWindow::DoDraw(HDC hDC, RECT& rcClient, RECT& rcPaint)
 {
-    // Calculate the intersection on the canvas to reduce bits transfer
+    // Calculate the intersection on the canvas to reduce bits transfer.
+    // This is the target area we have to draw on.
     CRect rcIntersectCanvas;
     rcIntersectCanvas.IntersectRect(&rcClient, &rcPaint);
 
@@ -113,7 +114,7 @@ VOID CCanvasWindow::DoDraw(HDC hDC, RECT& rcClient, RECT& rcPaint)
     GetImageRect(rcImage);
     SIZE sizeImage = { imageModel.GetWidth(), imageModel.GetHeight() };
 
-    // Calculate the intersection on the image to reduce bits transfer
+    // Calculate the target area on the image
     CRect rcIntersectImage = rcIntersectCanvas;
     CanvasToImage(rcIntersectImage);
 

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -421,6 +421,7 @@ RestrictDrawDirection(DIRECTION dir, LONG x0, LONG y0, LONG& x1, LONG& y1)
 struct SmoothDrawTool : ToolBase
 {
     DIRECTION m_direction = NO_DIRECTION;
+    BOOL m_bShiftDown = FALSE;
 
     SmoothDrawTool(TOOLTYPE type) : ToolBase(type)
     {
@@ -433,11 +434,12 @@ struct SmoothDrawTool : ToolBase
         m_direction = NO_DIRECTION;
         imageModel.PushImageForUndo();
         imageModel.NotifyImageChanged();
+        m_bShiftDown = (::GetKeyState(VK_SHIFT) < 0); // Is Shift key pressed?
     }
 
     BOOL OnMouseMove(BOOL bLeftButton, LONG& x, LONG& y) override
     {
-        if (::GetKeyState(VK_SHIFT) < 0) // Shift key is pressed
+        if (m_bShiftDown)
         {
             if (m_direction == NO_DIRECTION)
             {
@@ -450,14 +452,10 @@ struct SmoothDrawTool : ToolBase
         }
         else
         {
-            if (m_direction != NO_DIRECTION)
-            {
-                m_direction = NO_DIRECTION;
-                draw(bLeftButton, x, y);
-                g_ptStart.x = g_ptEnd.x = x;
-                g_ptStart.y = g_ptEnd.y = y;
-                return TRUE;
-            }
+            draw(bLeftButton, x, y);
+            g_ptStart.x = g_ptEnd.x = x;
+            g_ptStart.y = g_ptEnd.y = y;
+            return TRUE;
         }
 
         draw(bLeftButton, x, y);
@@ -467,7 +465,7 @@ struct SmoothDrawTool : ToolBase
 
     BOOL OnButtonUp(BOOL bLeftButton, LONG& x, LONG& y) override
     {
-        if (m_direction != NO_DIRECTION)
+        if (m_bShiftDown && m_direction != NO_DIRECTION)
         {
             RestrictDrawDirection(m_direction, g_ptStart.x, g_ptStart.y, x, y);
         }
@@ -480,6 +478,7 @@ struct SmoothDrawTool : ToolBase
     void OnFinishDraw() override
     {
         ToolBase::OnFinishDraw();
+        m_bShiftDown = FALSE;
     }
 
     void OnCancelDraw() override

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -434,7 +434,7 @@ struct SmoothDrawTool : ToolBase
         m_direction = NO_DIRECTION;
         imageModel.PushImageForUndo();
         imageModel.NotifyImageChanged();
-        m_bShiftDown = (::GetKeyState(VK_SHIFT) < 0); // Is Shift key pressed?
+        m_bShiftDown = (::GetKeyState(VK_SHIFT) & 0x8000); // Is Shift key pressed?
     }
 
     BOOL OnMouseMove(BOOL bLeftButton, LONG& x, LONG& y) override

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -478,7 +478,6 @@ struct SmoothDrawTool : ToolBase
     void OnFinishDraw() override
     {
         ToolBase::OnFinishDraw();
-        m_bShiftDown = FALSE;
     }
 
     void OnCancelDraw() override


### PR DESCRIPTION
## Purpose

Drawing lines smoothly on big image.
JIRA issue: [CORE-19094](https://jira.reactos.org/browse/CORE-19094), [CORE-19237](https://jira.reactos.org/browse/CORE-19237)

## Proposed changes

- In `CCanvasWindow::DoDraw`, calculate the intersection to reduce bits transfer.
- Improve `SmoothDrawTool` in handling `Shift` key.

## TODO

- [x] Do tests.
- [ ] Fix the lag when the stroke has began.

## Comparison

BEFORE:
https://github.com/reactos/reactos/assets/2107452/fbabc642-3c6e-421a-be08-cbd3ca873547

AFTER:
https://github.com/reactos/reactos/assets/2107452/2e4d8c0e-4282-4e72-af0d-4a9f1f00632e
Improved a little. The first stroke lag is not fixed yet.