### PR TITLE
Fix build with GCC x64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -345,7 +345,11 @@ Enable this if the module uses typeid or dynamic_cast. You will probably need to
             include(sdk/cmake/baseaddress_msvc.cmake)
         endif()
     else()
-        include(sdk/cmake/baseaddress.cmake)
+        if (ARCH STREQUAL "amd64")
+            include(sdk/cmake/baseaddress_gcc_x64.cmake)
+        else()
+            include(sdk/cmake/baseaddress.cmake)
+        endif()
     endif()
 
     # For MSVC builds, this puts all debug symbols file in the same directory.

--- a/sdk/tools/gen_baseaddress.py
+++ b/sdk/tools/gen_baseaddress.py
@@ -20,6 +20,7 @@ Multiple directories can be specified:
 import os
 import struct
 import sys
+import subprocess
 
 try:
     import pefile
@@ -343,6 +344,13 @@ class MemoryLayout(object):
         for obj in self.addresses:
             obj.gen_baseaddress(output_file)
 
+def is_gcc():
+    try:
+        result = subprocess.run(['gcc', '--version'], capture_output=True, text=True)
+        return result.stdout
+    except FileNotFoundError:
+        return None
+
 def get_target_file(ntdll_path):
     if 'pefile' in globals():
         ntdll_pe = pefile.PE(ntdll_path, fast_load=True)
@@ -356,6 +364,8 @@ def get_target_file(ntdll_path):
             return 'baseaddress_msvc.cmake'
         elif count > 3:
             return 'baseaddress_dwarf.cmake'
+        elif is_gcc() and is_x64():
+            return 'baseaddress_gcc_x64.cmake'
         else:
             assert False, "Unknown"
     return None


### PR DESCRIPTION
## Purpose

Generate a baseaddress for GCC compiler.

JIRA issue: [CORE-19248](https://jira.reactos.org/browse/CORE-19248)

## Proposed changes

- GCC baseaddress is not in the source tree.

## TODO

- [ ] Ensure it creates the correct file.
- [ ] Ensure it passes.
