### PR TITLE
[MSPAINT] Improve Zoom tool

### DIFF
--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -95,9 +95,8 @@ VOID CCanvasWindow::getNewZoomRect(CRect& rcView, INT newZoom, CPoint ptTarget)
     GetImageRect(rcImage);
     ImageToCanvas(rcImage);
 
-    GetClientRect(rcView);
-
     INT oldZoom = toolsModel.GetZoom();
+    GetClientRect(rcView);
     LONG cxView = rcView.Width() * oldZoom / newZoom;
     LONG cyView = rcView.Height() * oldZoom / newZoom;
     ::SetRect(&rcView, ptTarget.x - cxView / 2, ptTarget.y - cyView / 2,

--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -117,7 +117,7 @@ VOID CCanvasWindow::getNewZoomRect(CRect& rcView, INT newZoom, CPoint ptTarget)
     rcView.IntersectRect(&rcView, &rcImage);
 }
 
-VOID CCanvasWindow::zoomTo(INT newZoom, INT left, INT top)
+VOID CCanvasWindow::zoomTo(INT newZoom, LONG left, LONG top)
 {
     POINT pt = { left, top };
     CanvasToImage(pt);

--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -95,18 +95,14 @@ VOID CCanvasWindow::getNewZoomRect(CRect& rcView, INT newZoom, CPoint ptTarget)
     GetImageRect(rcImage);
     ImageToCanvas(rcImage);
 
+    // Calculate the zoom rectangle
     INT oldZoom = toolsModel.GetZoom();
     GetClientRect(rcView);
-    LONG cxView = rcView.Width() * oldZoom / newZoom;
-    LONG cyView = rcView.Height() * oldZoom / newZoom;
+    LONG cxView = rcView.right * oldZoom / newZoom, cyView = rcView.bottom * oldZoom / newZoom;
     ::SetRect(&rcView, ptTarget.x - cxView / 2, ptTarget.y - cyView / 2,
                        ptTarget.x + cxView / 2, ptTarget.y + cyView / 2);
-    if (rcView.IsRectEmpty())
-    {
-        rcView = rcImage;
-        return;
-    }
 
+    // Shift the rectangle if necessary
     INT dx = 0, dy = 0;
     if (rcView.left < rcImage.left)
         dx = rcImage.left - rcView.left;

--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -100,8 +100,8 @@ VOID CCanvasWindow::getNewZoomRect(CRect& rcView, INT newZoom, CPoint ptTarget)
     INT oldZoom = toolsModel.GetZoom();
     LONG cxView = rcView.Width() * oldZoom / newZoom;
     LONG cyView = rcView.Height() * oldZoom / newZoom;
-    SetRect(&rcView, ptTarget.x - cxView / 2, ptTarget.y - cyView / 2,
-                     ptTarget.x + cxView / 2, ptTarget.y + cyView / 2);
+    ::SetRect(&rcView, ptTarget.x - cxView / 2, ptTarget.y - cyView / 2,
+                       ptTarget.x + cxView / 2, ptTarget.y + cyView / 2);
 
     if (rcView.IsRectEmpty())
     {

--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -107,15 +107,16 @@ VOID CCanvasWindow::getNewZoomRect(CRect& rcView, INT newZoom, CPoint ptTarget)
         return;
     }
 
+    INT dx = 0, dy = 0;
     if (rcView.left < rcImage.left)
-        rcView.OffsetRect(rcImage.left - rcView.left, 0);
+        dx = rcImage.left - rcView.left;
     else if (rcImage.right < rcView.right)
-        rcView.OffsetRect(rcImage.right - rcView.right, 0);
-
+        dx = rcImage.right - rcView.right;
     if (rcView.top < rcImage.top)
-        rcView.OffsetRect(0, rcImage.top - rcView.top);
+        dy = rcImage.top - rcView.top;
     else if (rcImage.bottom < rcView.bottom)
-        rcView.OffsetRect(0, rcImage.bottom - rcView.bottom);
+        dy = rcImage.bottom - rcView.bottom;
+    rcView.OffsetRect(dx, dy);
 
     rcView.IntersectRect(&rcView, &rcImage);
 }

--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -101,7 +101,6 @@ VOID CCanvasWindow::getNewZoomRect(CRect& rcView, INT newZoom, CPoint ptTarget)
     LONG cyView = rcView.Height() * oldZoom / newZoom;
     ::SetRect(&rcView, ptTarget.x - cxView / 2, ptTarget.y - cyView / 2,
                        ptTarget.x + cxView / 2, ptTarget.y + cyView / 2);
-
     if (rcView.IsRectEmpty())
     {
         rcView = rcImage;

--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -143,7 +143,7 @@ VOID CCanvasWindow::zoomTo(INT newZoom, INT left, INT top)
     pt.y += GetScrollPos(SB_VERT);
 
     updateScrollRange();
-    setScrollPos(pt.x, pt.y);
+    updateScrollPos(pt.x, pt.y);
     Invalidate(TRUE);
 }
 
@@ -269,7 +269,7 @@ VOID CCanvasWindow::updateScrollRange()
     SetScrollInfo(SB_VERT, &si);
 }
 
-VOID CCanvasWindow::setScrollPos(INT x, INT y)
+VOID CCanvasWindow::updateScrollPos(INT x, INT y)
 {
     SetScrollPos(SB_HORZ, x);
     SetScrollPos(SB_VERT, y);

--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -122,17 +122,7 @@ VOID CCanvasWindow::getNewZoomRect(CRect& rcView, INT newZoom, CPoint ptTarget)
 
 VOID CCanvasWindow::zoomTo(INT newZoom, INT left, INT top)
 {
-    POINT pt;
-    if (left == -1 && top == -1)
-    {
-        CRect rc;
-        GetClientRect(&rc);
-        pt = { rc.left, rc.top };
-    }
-    else
-    {
-        pt = { left, top };
-    }
+    POINT pt = { left, top };
     CanvasToImage(pt);
 
     toolsModel.SetZoom(newZoom);

--- a/base/applications/mspaint/canvas.h
+++ b/base/applications/mspaint/canvas.h
@@ -52,7 +52,7 @@ public:
     VOID GetImageRect(RECT& rc);
     VOID MoveSelection(INT xDelta, INT yDelta);
     VOID getNewZoomRect(CRect& rcView, INT newZoom, CPoint ptTarget);
-    VOID zoomTo(INT newZoom, INT left = 0, INT top = 0);
+    VOID zoomTo(INT newZoom, LONG left = 0, LONG top = 0);
 
 protected:
     HITTEST m_hitSelection;

--- a/base/applications/mspaint/canvas.h
+++ b/base/applications/mspaint/canvas.h
@@ -42,8 +42,8 @@ public:
 
     VOID cancelDrawing();
     VOID finishDrawing();
-    VOID updateScrollInfo();
-    VOID resetScrollPos();
+    VOID updateScrollRange();
+    VOID setScrollPos(INT x = 0, INT y = 0);
 
     VOID ImageToCanvas(POINT& pt);
     VOID ImageToCanvas(RECT& rc);
@@ -51,6 +51,8 @@ public:
     VOID CanvasToImage(RECT& rc, BOOL bZoomed = FALSE);
     VOID GetImageRect(RECT& rc);
     VOID MoveSelection(INT xDelta, INT yDelta);
+    VOID getNewZoomRect(CRect& rcView, INT newZoom, CPoint ptTarget);
+    VOID zoomTo(INT newZoom, INT left = -1, INT top = -1);
 
 protected:
     HITTEST m_hitSelection;

--- a/base/applications/mspaint/canvas.h
+++ b/base/applications/mspaint/canvas.h
@@ -52,7 +52,7 @@ public:
     VOID GetImageRect(RECT& rc);
     VOID MoveSelection(INT xDelta, INT yDelta);
     VOID getNewZoomRect(CRect& rcView, INT newZoom, CPoint ptTarget);
-    VOID zoomTo(INT newZoom, INT left = -1, INT top = -1);
+    VOID zoomTo(INT newZoom, INT left = 0, INT top = 0);
 
 protected:
     HITTEST m_hitSelection;

--- a/base/applications/mspaint/canvas.h
+++ b/base/applications/mspaint/canvas.h
@@ -43,7 +43,7 @@ public:
     VOID cancelDrawing();
     VOID finishDrawing();
     VOID updateScrollRange();
-    VOID setScrollPos(INT x = 0, INT y = 0);
+    VOID updateScrollPos(INT x = 0, INT y = 0);
 
     VOID ImageToCanvas(POINT& pt);
     VOID ImageToCanvas(RECT& rc);

--- a/base/applications/mspaint/common.h
+++ b/base/applications/mspaint/common.h
@@ -43,7 +43,6 @@ enum HITTEST // hit
 
 /* FUNCTIONS ********************************************************/
 
-BOOL zoomTo(int newZoom, int mouseX, int mouseY);
 BOOL nearlyEqualPoints(INT x0, INT y0, INT x1, INT y1);
 BOOL OpenMailer(HWND hWnd, LPCWSTR pszPathName);
 

--- a/base/applications/mspaint/dib.cpp
+++ b/base/applications/mspaint/dib.cpp
@@ -241,7 +241,7 @@ HBITMAP InitializeImage(LPCWSTR name, LPWIN32_FIND_DATAW pFound, BOOL isFile)
 HBITMAP SetBitmapAndInfo(HBITMAP hBitmap, LPCWSTR name, LPWIN32_FIND_DATAW pFound, BOOL isFile)
 {
     // update image
-    canvasWindow.resetScrollPos();
+    canvasWindow.setScrollPos();
     imageModel.PushImageForUndo(hBitmap);
     imageModel.ClearHistory();
 

--- a/base/applications/mspaint/dib.cpp
+++ b/base/applications/mspaint/dib.cpp
@@ -241,7 +241,7 @@ HBITMAP InitializeImage(LPCWSTR name, LPWIN32_FIND_DATAW pFound, BOOL isFile)
 HBITMAP SetBitmapAndInfo(HBITMAP hBitmap, LPCWSTR name, LPWIN32_FIND_DATAW pFound, BOOL isFile)
 {
     // update image
-    canvasWindow.setScrollPos();
+    canvasWindow.updateScrollPos();
     imageModel.PushImageForUndo(hBitmap);
     imageModel.ClearHistory();
 

--- a/base/applications/mspaint/history.cpp
+++ b/base/applications/mspaint/history.cpp
@@ -16,7 +16,7 @@ void ImageModel::NotifyImageChanged()
 {
     if (canvasWindow.IsWindow())
     {
-        canvasWindow.updateScrollInfo();
+        canvasWindow.updateScrollRange();
         canvasWindow.Invalidate();
     }
 

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -581,8 +581,7 @@ struct ZoomTool : ToolBase
 
     void OnButtonDown(BOOL bLeftButton, LONG x, LONG y, BOOL bDoubleClick) override
     {
-        INT oldZoom = toolsModel.GetZoom();
-        INT newZoom;
+        INT newZoom, oldZoom = toolsModel.GetZoom();
         if (bLeftButton)
             newZoom = (oldZoom < MAX_ZOOM) ? (oldZoom * 2) : MIN_ZOOM;
         else

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -581,14 +581,14 @@ struct ZoomTool : ToolBase
 
     void OnButtonDown(BOOL bLeftButton, LONG x, LONG y, BOOL bDoubleClick) override
     {
-        m_bZoomed = FALSE;
-
         INT oldZoom = toolsModel.GetZoom();
         INT newZoom;
         if (bLeftButton)
             newZoom = (oldZoom < MAX_ZOOM) ? (oldZoom * 2) : MIN_ZOOM;
         else
             newZoom = (oldZoom > MIN_ZOOM) ? (oldZoom / 2) : MAX_ZOOM;
+
+        m_bZoomed = FALSE;
 
         if (oldZoom != newZoom)
         {

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -569,25 +569,13 @@ struct ZoomTool : ToolBase
     {
     }
 
-    BOOL getNewZoomRect(CRect& rcView, INT newZoom)
-    {
-        CPoint pt;
-        ::GetCursorPos(&pt);
-        canvasWindow.ScreenToClient(&pt);
-
-        canvasWindow.getNewZoomRect(rcView, newZoom, pt);
-
-        CRect rc;
-        canvasWindow.GetImageRect(rc);
-        canvasWindow.ImageToCanvas(rc);
-
-        return rc.PtInRect(pt);
-    }
+    BOOL getNewZoomRect(CRect& rcView, INT newZoom);
 
     void OnDrawOverlayOnCanvas(HDC hdc) override
     {
         CRect rcView;
-        if (getNewZoomRect(rcView, toolsModel.GetZoom() * 2))
+        INT oldZoom = toolsModel.GetZoom();
+        if (oldZoom < MAX_ZOOM && getNewZoomRect(rcView, oldZoom * 2))
             DrawXorRect(hdc, &rcView);
     }
 
@@ -595,17 +583,12 @@ struct ZoomTool : ToolBase
     {
         m_bZoomed = FALSE;
 
-        INT oldZoom = toolsModel.GetZoom(), newZoom = oldZoom;
+        INT oldZoom = toolsModel.GetZoom();
+        INT newZoom;
         if (bLeftButton)
-        {
-            if (oldZoom < MAX_ZOOM)
-                newZoom = oldZoom * 2;
-        }
+            newZoom = (oldZoom < MAX_ZOOM) ? (oldZoom * 2) : MIN_ZOOM;
         else
-        {
-            if (oldZoom > MIN_ZOOM)
-                newZoom = oldZoom / 2;
-        }
+            newZoom = (oldZoom > MIN_ZOOM) ? (oldZoom / 2) : MAX_ZOOM;
 
         if (oldZoom != newZoom)
         {
@@ -626,6 +609,21 @@ struct ZoomTool : ToolBase
         return TRUE;
     }
 };
+
+BOOL ZoomTool::getNewZoomRect(CRect& rcView, INT newZoom)
+{
+    CPoint pt;
+    ::GetCursorPos(&pt);
+    canvasWindow.ScreenToClient(&pt);
+
+    canvasWindow.getNewZoomRect(rcView, newZoom, pt);
+
+    CRect rc;
+    canvasWindow.GetImageRect(rc);
+    canvasWindow.ImageToCanvas(rc);
+
+    return rc.PtInRect(pt);
+}
 
 // TOOL_PEN
 struct PenTool : SmoothDrawTool

--- a/base/applications/mspaint/toolsettings.cpp
+++ b/base/applications/mspaint/toolsettings.cpp
@@ -309,7 +309,7 @@ LRESULT CToolSettingsWindow::OnDestroy(UINT nMsg, WPARAM wParam, LPARAM lParam, 
 LRESULT CToolSettingsWindow::OnVScroll(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
     INT trackPos = MAX_ZOOM_TRACK - (INT)trackbarZoom.SendMessage(TBM_GETPOS, 0, 0);
-    zoomTo(MIN_ZOOM << trackPos, 0, 0);
+    canvasWindow.zoomTo(MIN_ZOOM << trackPos);
 
     INT zoomRate = toolsModel.GetZoom();
 

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -41,37 +41,6 @@ static HWND DoHtmlHelpW(HWND hwndCaller, LPCWSTR pszFile, UINT uCommand, DWORD_P
     return s_pHtmlHelpW(hwndCaller, pszFile, uCommand, dwData);
 }
 
-BOOL
-zoomTo(int newZoom, int mouseX, int mouseY)
-{
-    int x, y, w, h;
-    RECT clientRectScrollbox;
-    canvasWindow.GetClientRect(&clientRectScrollbox);
-
-    RECT clientRectImageArea;
-    ::SetRect(&clientRectImageArea, 0, 0, imageModel.GetWidth(), imageModel.GetHeight());
-    Zoomed(clientRectImageArea);
-
-    w = clientRectImageArea.right * newZoom / toolsModel.GetZoom();
-    h = clientRectImageArea.bottom * newZoom / toolsModel.GetZoom();
-    if (!w || !h)
-    {
-        return FALSE;
-    }
-    w = clientRectImageArea.right * clientRectScrollbox.right / w;
-    h = clientRectImageArea.bottom * clientRectScrollbox.bottom / h;
-    x = max(0, min(clientRectImageArea.right - w, mouseX - w / 2)) * newZoom / toolsModel.GetZoom();
-    y = max(0, min(clientRectImageArea.bottom - h, mouseY - h / 2)) * newZoom / toolsModel.GetZoom();
-
-    toolsModel.SetZoom(newZoom);
-
-    canvasWindow.Invalidate(TRUE);
-
-    canvasWindow.SendMessage(WM_HSCROLL, MAKEWPARAM(SB_THUMBPOSITION, x), 0);
-    canvasWindow.SendMessage(WM_VSCROLL, MAKEWPARAM(SB_THUMBPOSITION, y), 0);
-    return TRUE;
-}
-
 void CMainWindow::alignChildrenToMainWindow()
 {
     RECT clientRect, rc;
@@ -216,20 +185,20 @@ LRESULT CMainWindow::OnMouseWheel(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL&
 {
     INT zDelta = (SHORT)HIWORD(wParam);
 
-    if (::GetAsyncKeyState(VK_CONTROL) < 0)
+    if (::GetKeyState(VK_CONTROL) < 0) // Ctrl+Wheel
     {
         if (zDelta < 0)
         {
             if (toolsModel.GetZoom() > MIN_ZOOM)
-                zoomTo(toolsModel.GetZoom() / 2, 0, 0);
+                canvasWindow.zoomTo(toolsModel.GetZoom() / 2);
         }
         else if (zDelta > 0)
         {
             if (toolsModel.GetZoom() < MAX_ZOOM)
-                zoomTo(toolsModel.GetZoom() * 2, 0, 0);
+                canvasWindow.zoomTo(toolsModel.GetZoom() * 2);
         }
     }
-    else
+    else // Wheel only
     {
         UINT nCount = 3;
         if (::GetAsyncKeyState(VK_SHIFT) < 0)
@@ -921,7 +890,7 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
         case IDM_IMAGEROTATEMIRROR:
             {
                 CWaitCursor waitCursor;
-                canvasWindow.resetScrollPos();
+                canvasWindow.setScrollPos();
                 switch (mirrorRotateDialog.DoModal(mainWindow.m_hWnd))
                 {
                     case 1: /* flip horizontally */
@@ -1054,25 +1023,25 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
             break;
 
         case IDM_VIEWZOOM125:
-            zoomTo(125, 0, 0);
+            canvasWindow.zoomTo(125);
             break;
         case IDM_VIEWZOOM25:
-            zoomTo(250, 0, 0);
+            canvasWindow.zoomTo(250);
             break;
         case IDM_VIEWZOOM50:
-            zoomTo(500, 0, 0);
+            canvasWindow.zoomTo(500);
             break;
         case IDM_VIEWZOOM100:
-            zoomTo(1000, 0, 0);
+            canvasWindow.zoomTo(1000);
             break;
         case IDM_VIEWZOOM200:
-            zoomTo(2000, 0, 0);
+            canvasWindow.zoomTo(2000);
             break;
         case IDM_VIEWZOOM400:
-            zoomTo(4000, 0, 0);
+            canvasWindow.zoomTo(4000);
             break;
         case IDM_VIEWZOOM800:
-            zoomTo(8000, 0, 0);
+            canvasWindow.zoomTo(8000);
             break;
 
         case IDM_VIEWFULLSCREEN:

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -890,7 +890,7 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
         case IDM_IMAGEROTATEMIRROR:
             {
                 CWaitCursor waitCursor;
-                canvasWindow.setScrollPos();
+                canvasWindow.updateScrollPos();
                 switch (mirrorRotateDialog.DoModal(mainWindow.m_hWnd))
                 {
                     case 1: /* flip horizontally */


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-19094](https://jira.reactos.org/browse/CORE-19094)

## Proposed changes

- Delete global `zoomTo` function.
- Add `CCanvasWindow::zoomTo` and `CCanvasWindow::getNewZoomRect` functions.
- Rename `CCanvasWindow::updateScrollInfo` as `CCanvasWindow::updateScrollRange`.
- Rename `CCanvasWindow::resetScrollPos` as `CCanvasWindow::updateScrollPos`.
- Draw the proper zoom rectangle on mouse move.
- Revert the active tool on click when the tool was Zoom.

## TODO

- [x] Do tests.