### PR TITLE
[ATL] s/throw()/noexcept/

### DIFF
--- a/sdk/lib/atl/atlbase.h
+++ b/sdk/lib/atl/atlbase.h
@@ -1120,40 +1120,40 @@ public:
 
 public:
 
-    CRegKey() throw()
+    CRegKey() noexcept
         : m_hKey(NULL)
     {
     }
 
-    CRegKey(CRegKey& key) throw()
+    CRegKey(CRegKey& key) noexcept
         : m_hKey(key.Detach())
     {
     }
 
-    explicit CRegKey(HKEY hKey) throw()
+    explicit CRegKey(HKEY hKey) noexcept
         : m_hKey(hKey)
     {
     }
 
 #if 0
     // FIXME & TODO:
-    CRegKey(CAtlTransactionManager* pTM) throw()
+    CRegKey(CAtlTransactionManager* pTM) noexcept
     {
         ...
     }
 #endif
 
-    ~CRegKey() throw()
+    ~CRegKey() noexcept
     {
         Close();
     }
 
-    void Attach(HKEY hKey) throw()
+    void Attach(HKEY hKey) noexcept
     {
         m_hKey = hKey;
     }
 
-    LONG Close() throw()
+    LONG Close() noexcept
     {
         if (m_hKey)
         {
@@ -1163,7 +1163,7 @@ public:
         return ERROR_SUCCESS;
     }
 
-    HKEY Detach() throw()
+    HKEY Detach() noexcept
     {
         HKEY hKey = m_hKey;
         m_hKey = NULL;
@@ -1171,7 +1171,7 @@ public:
     }
 
     LONG Open(HKEY hKeyParent, LPCTSTR lpszKeyName,
-              REGSAM samDesired = KEY_READ | KEY_WRITE) throw()
+              REGSAM samDesired = KEY_READ | KEY_WRITE) noexcept
     {
         ATLASSERT(hKeyParent);
         ATLASSERT(lpszKeyName);
@@ -1191,7 +1191,7 @@ public:
                 DWORD dwOptions = REG_OPTION_NON_VOLATILE,
                 REGSAM samDesired = KEY_READ | KEY_WRITE,
                 LPSECURITY_ATTRIBUTES lpSecAttr = NULL,
-                LPDWORD lpdwDisposition = NULL) throw()
+                LPDWORD lpdwDisposition = NULL) noexcept
     {
         ATLASSERT(hKeyParent);
         ATLASSERT(lpszKeyName);
@@ -1208,13 +1208,13 @@ public:
         return lRes;
     }
 
-    LONG QueryValue(LPCTSTR pszValueName, DWORD* pdwType, void* pData, ULONG* pnBytes) throw()
+    LONG QueryValue(LPCTSTR pszValueName, DWORD* pdwType, void* pData, ULONG* pnBytes) noexcept
     {
         ATLASSERT(m_hKey);
         return ::RegQueryValueEx(m_hKey, pszValueName, NULL, pdwType, (LPBYTE)pData, pnBytes);
     }
 
-    LONG QueryDWORDValue(LPCTSTR pszValueName, DWORD& dwValue) throw()
+    LONG QueryDWORDValue(LPCTSTR pszValueName, DWORD& dwValue) noexcept
     {
         ULONG size = sizeof(DWORD);
         DWORD type = 0;
@@ -1226,7 +1226,7 @@ public:
         return lRet;
     }
 
-    LONG QueryBinaryValue(LPCTSTR pszValueName, void* pValue, ULONG* pnBytes) throw()
+    LONG QueryBinaryValue(LPCTSTR pszValueName, void* pValue, ULONG* pnBytes) noexcept
     {
         DWORD type = 0;
         LONG lRet = QueryValue(pszValueName, &type, pValue, pnBytes);
@@ -1237,7 +1237,7 @@ public:
         return lRet;
     }
 
-    LONG QueryStringValue(LPCTSTR pszValueName, LPTSTR pszValue, ULONG* pnChars) throw()
+    LONG QueryStringValue(LPCTSTR pszValueName, LPTSTR pszValue, ULONG* pnChars) noexcept
     {
         ULONG size = (*pnChars) * sizeof(TCHAR);
         DWORD type = 0;
@@ -1250,7 +1250,7 @@ public:
         return lRet;
     }
 
-    LONG QueryGUIDValue(LPCTSTR pszValueName, GUID& guidValue) throw()
+    LONG QueryGUIDValue(LPCTSTR pszValueName, GUID& guidValue) noexcept
     {
         OLECHAR buf[40] = {0};
         ULONG nChars = 39;
@@ -1275,7 +1275,7 @@ public:
         return lRet;
     }
 
-    LONG QueryQWORDValue(LPCTSTR pszValueName, ULONGLONG& qwValue) throw()
+    LONG QueryQWORDValue(LPCTSTR pszValueName, ULONGLONG& qwValue) noexcept
     {
         ULONG size = sizeof(ULONGLONG);
         DWORD type = 0;
@@ -1288,7 +1288,7 @@ public:
     }
 
     LONG QueryMultiStringValue(LPCTSTR pszValueName, LPTSTR pszValue,
-                               ULONG* pnChars) throw()
+                               ULONG* pnChars) noexcept
     {
         ULONG size = (*pnChars) * sizeof(TCHAR);
         DWORD type;
@@ -1301,18 +1301,18 @@ public:
         return lRet;
     }
 
-    LONG SetValue(LPCTSTR pszValueName, DWORD dwType, const void* pValue, ULONG nBytes) throw()
+    LONG SetValue(LPCTSTR pszValueName, DWORD dwType, const void* pValue, ULONG nBytes) noexcept
     {
         ATLASSERT(m_hKey);
         return ::RegSetValueEx(m_hKey, pszValueName, 0, dwType, (const BYTE*)pValue, nBytes);
     }
 
-    LONG SetDWORDValue(LPCTSTR pszValueName, DWORD dwValue) throw()
+    LONG SetDWORDValue(LPCTSTR pszValueName, DWORD dwValue) noexcept
     {
         return SetValue(pszValueName, REG_DWORD, &dwValue, sizeof(DWORD));
     }
 
-    LONG SetStringValue(LPCTSTR pszValueName, LPCTSTR pszValue, DWORD dwType = REG_SZ) throw()
+    LONG SetStringValue(LPCTSTR pszValueName, LPCTSTR pszValue, DWORD dwType = REG_SZ) noexcept
     {
         SIZE_T length;
         switch (dwType)
@@ -1328,7 +1328,7 @@ public:
         }
     }
 
-    LONG SetGUIDValue(LPCTSTR pszValueName, REFGUID guidValue) throw()
+    LONG SetGUIDValue(LPCTSTR pszValueName, REFGUID guidValue) noexcept
     {
         OLECHAR buf[40] = {0};
         ::StringFromGUID2(guidValue, buf, 39);
@@ -1341,25 +1341,25 @@ public:
 #endif
     }
 
-    LONG SetBinaryValue(LPCTSTR pszValueName, const void* pValue, ULONG nBytes) throw()
+    LONG SetBinaryValue(LPCTSTR pszValueName, const void* pValue, ULONG nBytes) noexcept
     {
         return SetValue(pszValueName, REG_BINARY, pValue, nBytes);
     }
 
-    LONG SetMultiStringValue(LPCTSTR pszValueName, LPCTSTR pszValue) throw()
+    LONG SetMultiStringValue(LPCTSTR pszValueName, LPCTSTR pszValue) noexcept
     {
         ULONG dwSize = CRegKey::_GetMultiStringSize(pszValue);
         return SetValue(pszValueName, REG_MULTI_SZ, pszValue, dwSize);
     }
 
-    LONG SetQWORDValue(LPCTSTR pszValueName, ULONGLONG qwValue) throw()
+    LONG SetQWORDValue(LPCTSTR pszValueName, ULONGLONG qwValue) noexcept
     {
         ULONG dwSize = sizeof(ULONGLONG);
         return SetValue(pszValueName, REG_QWORD, &qwValue, dwSize);
     }
 
     LONG NotifyChangeKeyValue(BOOL bWatchSubtree, DWORD dwNotifyFilter,
-                              HANDLE hEvent, BOOL bAsync = TRUE) throw()
+                              HANDLE hEvent, BOOL bAsync = TRUE) noexcept
     {
         ATLASSERT(m_hKey);
         LONG ret = ::RegNotifyChangeKeyValue(m_hKey, bWatchSubtree,
@@ -1367,7 +1367,7 @@ public:
         return ret;
     }
 
-    LONG Flush() throw()
+    LONG Flush() noexcept
     {
         ATLASSERT(m_hKey);
         LONG ret = ::RegFlushKey(m_hKey);
@@ -1387,7 +1387,7 @@ public:
     }
 
     LONG SetKeyValue(LPCTSTR lpszKeyName, LPCTSTR lpszValue,
-                     LPCTSTR lpszValueName = NULL) throw()
+                     LPCTSTR lpszValueName = NULL) noexcept
     {
         CRegKey key;
         LONG lRet = key.Create(m_hKey, lpszKeyName);
@@ -1398,20 +1398,20 @@ public:
         return lRet;
     }
 
-    LONG DeleteValue(LPCTSTR lpszValue) throw()
+    LONG DeleteValue(LPCTSTR lpszValue) noexcept
     {
         ATLASSERT(m_hKey);
         return ::RegDeleteValue(m_hKey, lpszValue);
     }
 
-    LONG DeleteSubKey(LPCTSTR lpszSubKey) throw()
+    LONG DeleteSubKey(LPCTSTR lpszSubKey) noexcept
     {
         ATLASSERT(m_hKey);
         ATLASSERT(lpszSubKey);
         return ::RegDeleteKey(m_hKey, lpszSubKey);
     }
 
-    LONG RecurseDeleteKey(LPCTSTR lpszKey) throw()
+    LONG RecurseDeleteKey(LPCTSTR lpszKey) noexcept
     {
         ATLASSERT(m_hKey);
         ATLASSERT(lpszKey);
@@ -1419,7 +1419,7 @@ public:
     }
 
     LONG EnumKey(DWORD iIndex, LPTSTR pszName, LPDWORD pnNameLength,
-                 FILETIME* pftLastWriteTime = NULL) throw()
+                 FILETIME* pftLastWriteTime = NULL) noexcept
     {
         ATLASSERT(m_hKey);
         LONG ret = ::RegEnumKeyEx(m_hKey, iIndex, pszName, pnNameLength, NULL,
@@ -1428,7 +1428,7 @@ public:
     }
 
     LONG GetKeySecurity(SECURITY_INFORMATION si, PSECURITY_DESCRIPTOR psd,
-                        LPDWORD pnBytes) throw()
+                        LPDWORD pnBytes) noexcept
     {
         ATLASSERT(m_hKey);
         LONG ret = ::RegGetKeySecurity(m_hKey, si, psd, pnBytes);
@@ -1436,19 +1436,19 @@ public:
     }
 
     LONG SetKeySecurity(SECURITY_INFORMATION si,
-                        PSECURITY_DESCRIPTOR psd) throw()
+                        PSECURITY_DESCRIPTOR psd) noexcept
     {
         ATLASSERT(m_hKey);
         LONG ret = ::RegSetKeySecurity(m_hKey, si, psd);
         return ret;
     }
 
-    operator HKEY() const throw()
+    operator HKEY() const noexcept
     {
         return m_hKey;
     }
 
-    CRegKey& operator=(CRegKey& key) throw()
+    CRegKey& operator=(CRegKey& key) noexcept
     {
         if (m_hKey != key.m_hKey)
         {

--- a/sdk/lib/atl/atlcoll.h
+++ b/sdk/lib/atl/atlcoll.h
@@ -9,8 +9,8 @@
 // would also need to set the option 'WITH_STL'..
 // For now we just copy the definition here, under a guard..
 #ifndef _NEW
-inline void* operator new (size_t size, void* ptr) throw() { return ptr; }
-inline void operator delete (void* ptr, void* voidptr2) throw() { }
+inline void* operator new (size_t size, void* ptr) noexcept { return ptr; }
+inline void operator delete (void* ptr, void* voidptr2) noexcept { }
 #endif
 
 

--- a/sdk/lib/atl/atlcomcli.h
+++ b/sdk/lib/atl/atlcomcli.h
@@ -53,7 +53,7 @@
 namespace ATL
 {
 
-inline HRESULT AtlHresultFromLastError() throw()
+inline HRESULT AtlHresultFromLastError() noexcept
 {
     DWORD dwError = ::GetLastError();
     return HRESULT_FROM_WIN32(dwError);

--- a/sdk/lib/atl/atlconv.h
+++ b/sdk/lib/atl/atlconv.h
@@ -29,14 +29,14 @@ public:
         UNREFERENCED_PARAMETER(nCodePage);
     }
 
-    ~CA2CAEX() throw() { } // There is nothing to free here
+    ~CA2CAEX() noexcept { } // There is nothing to free here
 
-    _Ret_z_ operator LPCSTR() const throw() { return m_psz; }
+    _Ret_z_ operator LPCSTR() const noexcept { return m_psz; }
 
 private:
     // CA2CAEX is not copyable
-    CA2CAEX(_In_ const CA2CAEX&) throw() = delete;
-    CA2CAEX& operator=(_In_ const CA2CAEX&) throw() = delete;
+    CA2CAEX(_In_ const CA2CAEX&) noexcept = delete;
+    CA2CAEX& operator=(_In_ const CA2CAEX&) noexcept = delete;
 };
 
 // This class does not own the string
@@ -53,14 +53,14 @@ public:
         UNREFERENCED_PARAMETER(nCodePage);
     }
 
-    ~CW2CWEX() throw() { } // There is nothing to free here
+    ~CW2CWEX() noexcept { } // There is nothing to free here
 
-    _Ret_z_ operator LPCWSTR() const throw() { return m_psz; }
+    _Ret_z_ operator LPCWSTR() const noexcept { return m_psz; }
 
 private:
     // CW2CWEX is not copyable
-    CW2CWEX(_In_ const CW2CWEX&) throw() = delete;
-    CW2CWEX& operator=(_In_ const CW2CWEX&) throw() = delete;
+    CW2CWEX(_In_ const CW2CWEX&) noexcept = delete;
+    CW2CWEX& operator=(_In_ const CW2CWEX&) noexcept = delete;
 };
 
 template <int t_nBufferLength = 128>
@@ -81,21 +81,21 @@ public:
         Init(psz);
     }
 
-    ~CA2AEX() throw()
+    ~CA2AEX() noexcept
     {
         if (m_psz != m_szBuffer)
             free(m_psz);
     }
 
-    _Ret_z_ operator LPSTR() const throw()
+    _Ret_z_ operator LPSTR() const noexcept
     {
         return m_psz;
     }
 
 private:
     // CA2AEX is not copyable
-    CA2AEX(_In_ const CA2AEX &) throw() = delete;
-    CA2AEX& operator=(_In_ const CA2AEX &) throw() = delete;
+    CA2AEX(_In_ const CA2AEX &) noexcept = delete;
+    CA2AEX& operator=(_In_ const CA2AEX &) noexcept = delete;
 
     void Init(_In_z_ LPCSTR psz)
     {
@@ -142,21 +142,21 @@ public:
         Init(psz);
     }
 
-    ~CW2WEX() throw()
+    ~CW2WEX() noexcept
     {
         if (m_psz != m_szBuffer)
             free(m_psz);
     }
 
-    _Ret_z_ operator LPWSTR() const throw()
+    _Ret_z_ operator LPWSTR() const noexcept
     {
         return m_psz;
     }
 
 private:
     // CW2WEX is not copyable
-    CW2WEX(_In_ const CW2WEX&) throw() = delete;
-    CW2WEX& operator=(_In_ const CW2WEX&) throw() = delete;
+    CW2WEX(_In_ const CW2WEX&) noexcept = delete;
+    CW2WEX& operator=(_In_ const CW2WEX&) noexcept = delete;
 
     void Init(_In_z_ LPCWSTR psz)
     {
@@ -202,21 +202,21 @@ public:
         Init(psz, nCodePage);
     }
 
-    ~CA2WEX() throw()
+    ~CA2WEX() noexcept
     {
         if (m_psz != m_szBuffer)
             free(m_psz);
     }
 
-    _Ret_z_ operator LPWSTR() const throw()
+    _Ret_z_ operator LPWSTR() const noexcept
     {
         return m_psz;
     }
 
 private:
     // CA2WEX is not copyable
-    CA2WEX(_In_ const CA2WEX&) throw() = delete;
-    CA2WEX& operator=(_In_ const CA2WEX&) throw() = delete;
+    CA2WEX(_In_ const CA2WEX&) noexcept = delete;
+    CA2WEX& operator=(_In_ const CA2WEX&) noexcept = delete;
 
     void Init(_In_z_ LPCSTR psz, _In_ UINT nCodePage)
     {
@@ -269,21 +269,21 @@ public:
         Init(psz, nCodePage);
     }
 
-    ~CW2AEX() throw()
+    ~CW2AEX() noexcept
     {
         if (m_psz != m_szBuffer)
             free(m_psz);
     }
 
-    _Ret_z_ operator LPSTR() const throw()
+    _Ret_z_ operator LPSTR() const noexcept
     {
         return m_psz;
     }
 
 private:
     // CW2AEX is not copyable
-    CW2AEX(_In_ const CW2AEX&) throw() = delete;
-    CW2AEX& operator=(_In_ const CW2AEX&) throw() = delete;
+    CW2AEX(_In_ const CW2AEX&) noexcept = delete;
+    CW2AEX& operator=(_In_ const CW2AEX&) noexcept = delete;
 
     void Init(_In_z_ LPCWSTR psz, _In_ UINT nConvertCodePage)
     {

--- a/sdk/lib/atl/atlcore.h
+++ b/sdk/lib/atl/atlcore.h
@@ -272,7 +272,7 @@ inline const ATLSTRINGRESOURCEIMAGE* _AtlGetStringResourceImage(
 
 inline const ATLSTRINGRESOURCEIMAGE* AtlGetStringResourceImage(
     _In_ HINSTANCE hInstance,
-    _In_ UINT id) throw()
+    _In_ UINT id) noexcept
 {
     HRSRC hResource;
     hResource = ::FindResourceW(hInstance, MAKEINTRESOURCEW((((id >> 4) + 1) & static_cast<WORD>(~0))), (LPWSTR)RT_STRING);

--- a/sdk/lib/atl/atlfile.h
+++ b/sdk/lib/atl/atlfile.h
@@ -34,7 +34,7 @@ private:
     DWORD m_dwViewDesiredAccess;
 
 public:
-    CAtlFileMappingBase() throw()
+    CAtlFileMappingBase() noexcept
         :m_pData(NULL)
         ,m_nMappingSize(0)
         ,m_hMapping(NULL)
@@ -43,7 +43,7 @@ public:
         m_nOffset.QuadPart = 0;
     }
 
-    ~CAtlFileMappingBase() throw()
+    ~CAtlFileMappingBase() noexcept
     {
         Unmap();
     }
@@ -74,7 +74,7 @@ public:
         return *this;
     }
 
-    HRESULT CopyFrom(CAtlFileMappingBase& orig) throw()
+    HRESULT CopyFrom(CAtlFileMappingBase& orig) noexcept
     {
         HRESULT hr = S_OK;
 
@@ -112,7 +112,7 @@ public:
         SIZE_T nMappingSize = 0,
         ULONGLONG nOffset = 0,
         DWORD dwMappingProtection = PAGE_READONLY,
-        DWORD dwViewDesiredAccess = FILE_MAP_READ) throw()
+        DWORD dwViewDesiredAccess = FILE_MAP_READ) noexcept
     {
         HRESULT hr = S_OK;
         ULARGE_INTEGER FileSize;
@@ -153,7 +153,7 @@ public:
         BOOL* pbAlreadyExisted = NULL,
         LPSECURITY_ATTRIBUTES lpsa = NULL,
         DWORD dwMappingProtection = PAGE_READWRITE,
-        DWORD dwViewDesiredAccess = FILE_MAP_ALL_ACCESS) throw()
+        DWORD dwViewDesiredAccess = FILE_MAP_ALL_ACCESS) noexcept
     {
         HRESULT hr = S_OK;
         ULARGE_INTEGER Size;
@@ -194,7 +194,7 @@ public:
         LPCTSTR szName,
         SIZE_T nMappingSize,
         ULONGLONG nOffset = 0,
-        DWORD dwViewDesiredAccess = FILE_MAP_ALL_ACCESS) throw()
+        DWORD dwViewDesiredAccess = FILE_MAP_ALL_ACCESS) noexcept
     {
         HRESULT hr = S_OK;
 
@@ -225,7 +225,7 @@ public:
         return hr;
     }
 
-    HRESULT Unmap() throw()
+    HRESULT Unmap() noexcept
     {
         HRESULT hr = S_OK;
 
@@ -248,7 +248,7 @@ public:
         return hr;
     }
 
-    void* GetData() const throw()
+    void* GetData() const noexcept
     {
         return m_pData;
     }
@@ -258,7 +258,7 @@ public:
         return m_hMapping;
     }
 
-    SIZE_T GetMappingSize() throw()
+    SIZE_T GetMappingSize() noexcept
     {
         return m_nMappingSize;
     }
@@ -271,7 +271,7 @@ class CAtlFileMapping:
     public CAtlFileMappingBase
 {
 public:
-    operator T*() const throw()
+    operator T*() const noexcept
     {
         return reinterpret_cast<T*>(GetData());
     }

--- a/sdk/lib/atl/atlpath.h
+++ b/sdk/lib/atl/atlpath.h
@@ -111,7 +111,7 @@ public:
         m_strPath = path.m_strPath;
     }
 
-    CPathT() throw()
+    CPathT() noexcept
     {
         // do nothing, m_strPath initializes itself
     }
@@ -367,17 +367,17 @@ public:
         m_strPath.ReleaseBuffer();
     }
 
-    operator const StringType&() const throw()
+    operator const StringType&() const noexcept
     {
         return m_strPath;
     }
 
-    operator PCXSTR() const throw()
+    operator PCXSTR() const noexcept
     {
         return m_strPath;
     }
 
-    operator StringType&() throw()
+    operator StringType&() noexcept
     {
         return m_strPath;
     }

--- a/sdk/lib/atl/atlsimpstr.h
+++ b/sdk/lib/atl/atlsimpstr.h
@@ -52,18 +52,18 @@ struct CStringData
     int nDataLength;
     long nRefs;
 
-    void* data() throw()
+    void* data() noexcept
     {
         return (this + 1);
     }
 
-    void AddRef() throw()
+    void AddRef() noexcept
     {
         ATLASSERT(nRefs > 0);
         _InterlockedIncrement(&nRefs);
     }
 
-    void Release() throw()
+    void Release() noexcept
     {
         ATLASSERT(nRefs != 0);
 
@@ -73,12 +73,12 @@ struct CStringData
         }
     }
 
-    bool IsLocked() const throw()
+    bool IsLocked() const noexcept
     {
         return (nRefs < 0);
     }
 
-    bool IsShared() const throw()
+    bool IsShared() const noexcept
     {
         return (nRefs > 1);
     }
@@ -88,7 +88,7 @@ class CNilStringData :
     public CStringData
 {
 public:
-    CNilStringData() throw()
+    CNilStringData() noexcept
     {
         pStringMgr = NULL;
         nRefs = 2;
@@ -98,7 +98,7 @@ public:
         achNil[1] = 0;
     }
 
-    void SetManager(_In_ IAtlStringMgr* pMgr) throw()
+    void SetManager(_In_ IAtlStringMgr* pMgr) noexcept
     {
         ATLASSERT(pStringMgr == NULL);
         pStringMgr = pMgr;
@@ -193,7 +193,7 @@ public:
         CopyChars(m_pszData, nLength, pchSrc, nLength);
     }
 
-    ~CSimpleStringT() throw()
+    ~CSimpleStringT() noexcept
     {
         CStringData* pData = GetData();
         pData->Release();
@@ -245,12 +245,12 @@ public:
         return *this;
     }
 
-    operator PCXSTR() const throw()
+    operator PCXSTR() const noexcept
     {
         return m_pszData;
     }
 
-    void Empty() throw()
+    void Empty() noexcept
     {
         CStringData* pOldData = GetData();
         IAtlStringMgr* pStringMgr = pOldData->pStringMgr;
@@ -354,21 +354,21 @@ public:
         return PrepareWrite(nMinBufferLength);
     }
 
-    int GetAllocLength() const throw()
+    int GetAllocLength() const noexcept
     {
         return GetData()->nAllocLength;
     }
 
-    int GetLength() const throw()
+    int GetLength() const noexcept
     {
         return GetData()->nDataLength;
     }
 
-    PXSTR GetString() throw()
+    PXSTR GetString() noexcept
     {
         return m_pszData;
     }
-    PCXSTR GetString() const throw()
+    PCXSTR GetString() const noexcept
     {
         return m_pszData;
     }
@@ -386,17 +386,17 @@ public:
         ReleaseBufferSetLength(nNewLength);
     }
 
-    bool IsEmpty() const throw()
+    bool IsEmpty() const noexcept
     {
         return (GetLength() == 0);
     }
 
-    CStringData* GetData() const throw()
+    CStringData* GetData() const noexcept
     {
         return (reinterpret_cast<CStringData*>(m_pszData) - 1);
     }
 
-    IAtlStringMgr* GetManager() const throw()
+    IAtlStringMgr* GetManager() const noexcept
     {
         IAtlStringMgr* pStringMgr = GetData()->pStringMgr;
         return (pStringMgr ? pStringMgr->Clone() : NULL);
@@ -434,7 +434,7 @@ public:
         _Out_writes_to_(nDestLen, nChars) XCHAR* pchDest,
         _In_ size_t nDestLen,
         _In_reads_opt_(nChars) const XCHAR* pchSrc,
-        _In_ int nChars) throw()
+        _In_ int nChars) noexcept
     {
         memcpy(pchDest, pchSrc, nChars * sizeof(XCHAR));
     }
@@ -443,18 +443,18 @@ public:
         _Out_writes_to_(nDestLen, nDestLen) XCHAR* pchDest,
         _In_ size_t nDestLen,
         _In_reads_(nChars) const XCHAR* pchSrc,
-        _In_ int nChars) throw()
+        _In_ int nChars) noexcept
     {
         memmove(pchDest, pchSrc, nChars * sizeof(XCHAR));
     }
 
-    static int __cdecl StringLength(_In_opt_z_ const char* psz) throw()
+    static int __cdecl StringLength(_In_opt_z_ const char* psz) noexcept
     {
         if (psz == NULL) return 0;
         return (int)strlen(psz);
     }
 
-    static int __cdecl StringLength(_In_opt_z_ const wchar_t* psz) throw()
+    static int __cdecl StringLength(_In_opt_z_ const wchar_t* psz) noexcept
     {
         if (psz == NULL) return 0;
         return (int)wcslen(psz);
@@ -464,7 +464,7 @@ public:
       // strnlen / wcsnlen are available in MSVCRT starting Vista+.
     static int __cdecl StringLengthN(
         _In_opt_z_count_(sizeInXChar) const char* psz,
-        _In_ size_t sizeInXChar) throw()
+        _In_ size_t sizeInXChar) noexcept
     {
         if (psz == NULL) return 0;
         return (int)strnlen(psz, sizeInXChar);
@@ -472,7 +472,7 @@ public:
 
     static int __cdecl StringLengthN(
         _In_opt_z_count_(sizeInXChar) const wchar_t* psz,
-        _In_ size_t sizeInXChar) throw()
+        _In_ size_t sizeInXChar) noexcept
     {
         if (psz == NULL) return 0;
         return (int)wcsnlen(psz, sizeInXChar);
@@ -495,7 +495,7 @@ protected:
     }
 
 private:
-    void Attach(_Inout_ CStringData* pData) throw()
+    void Attach(_Inout_ CStringData* pData) noexcept
     {
         m_pszData = static_cast<PXSTR>(pData->data());
     }

--- a/sdk/lib/atl/atlstr.h
+++ b/sdk/lib/atl/atlstr.h
@@ -61,7 +61,7 @@ public:
     virtual _Ret_maybenull_ _Post_writable_byte_size_(sizeof(CStringData) + nChars*nCharSize) CStringData* Reallocate(
         _Inout_ _Post_readable_byte_size_(sizeof(CStringData)) CStringData* StrData,
         _In_ int nChars,
-        _In_ int nCharSize) throw()
+        _In_ int nCharSize) noexcept
     {
         ATLASSERT(StrData->pStringMgr == this);
 
@@ -79,12 +79,12 @@ public:
         pNewData->nAllocLength = nChars - 1;
         return pNewData;
     }
-    virtual CStringData* GetNilString() throw()
+    virtual CStringData* GetNilString() noexcept
     {
         m_NilStrData.AddRef();
         return &m_NilStrData;
     }
-    virtual IAtlStringMgr* Clone() throw()
+    virtual IAtlStringMgr* Clone() noexcept
     {
         return this;
     }
@@ -111,12 +111,12 @@ class StrTraitATL :
     public StringIterator
 {
 public:
-    static HINSTANCE FindStringResourceInstance(_In_ UINT nID) throw()
+    static HINSTANCE FindStringResourceInstance(_In_ UINT nID) noexcept
     {
         return AtlFindStringResourceInstance(nID);
     }
 
-    static IAtlStringMgr* GetDefaultManager() throw()
+    static IAtlStringMgr* GetDefaultManager() noexcept
     {
         return CAtlStringMgr::GetInstance();
     }

--- a/sdk/lib/atl/atltime.h
+++ b/sdk/lib/atl/atltime.h
@@ -23,17 +23,17 @@ class CTimeSpan
 {
     __time64_t m_nSpan;
 public:
-    CTimeSpan() throw()
+    CTimeSpan() noexcept
     {
         // leave uninitialized
     }
 
-    CTimeSpan(__time64_t time) throw()
+    CTimeSpan(__time64_t time) noexcept
     {
         m_nSpan = time;
     }
 
-    CTimeSpan(LONG lDays, int nHours, int nMins, int nSecs) throw()
+    CTimeSpan(LONG lDays, int nHours, int nMins, int nSecs) noexcept
     {
         ATLASSERT(lDays >= 0 && nHours >= 0 && nHours <= 23 && nMins >= 0 && nMins <= 59 && nSecs >= 0 && nSecs <= 59);
         m_nSpan = ((((LONGLONG)lDays) * 24 + nHours) * 60 + nMins) * 60 + nSecs;
@@ -79,42 +79,42 @@ public:
         return strTime;
     }
 
-    LONGLONG GetTotalHours() const throw()
+    LONGLONG GetTotalHours() const noexcept
     {
         return m_nSpan / 60 / 60;
     }
 
-    LONGLONG GetTotalMinutes() const throw()
+    LONGLONG GetTotalMinutes() const noexcept
     {
         return m_nSpan / 60;
     }
 
-    LONGLONG GetTotalSeconds() const throw()
+    LONGLONG GetTotalSeconds() const noexcept
     {
         return m_nSpan;
     }
 
-    LONGLONG GetDays() const throw()
+    LONGLONG GetDays() const noexcept
     {
         return m_nSpan / 60 / 60 / 24;
     }
 
-    LONG GetHours() const throw()
+    LONG GetHours() const noexcept
     {
         return GetTotalHours() - GetDays() * 24;
     }
 
-    LONG GetMinutes() const throw()
+    LONG GetMinutes() const noexcept
     {
         return GetTotalMinutes() - GetTotalHours() * 60;
     }
 
-    LONG GetSeconds() const throw()
+    LONG GetSeconds() const noexcept
     {
         return GetTotalSeconds() - GetTotalMinutes() * 60;
     }
 
-    __time64_t GetTimeSpan() const throw()
+    __time64_t GetTimeSpan() const noexcept
     {
         return m_nSpan;
     }
@@ -130,12 +130,12 @@ class CTime
 {
     __time64_t m_nTime;
 public:
-    CTime() throw()
+    CTime() noexcept
     {
         // leave uninitialized
     }
 
-    CTime(__time64_t time) throw()
+    CTime(__time64_t time) noexcept
     {
         m_nTime = time;
     }
@@ -170,7 +170,7 @@ public:
         m_nTime = _mktime64(&time);
     }
 
-    CTime(const SYSTEMTIME& st, int nDST = -1) throw()
+    CTime(const SYSTEMTIME& st, int nDST = -1) noexcept
     {
         struct tm time;
         time.tm_year = st.wYear;
@@ -198,7 +198,7 @@ public:
         m_nTime = _mktime64(&time);
     }
 
-    CTime(const DBTIMESTAMP& dbts, int nDST = -1) throw()
+    CTime(const DBTIMESTAMP& dbts, int nDST = -1) noexcept
     {
         struct tm time;
         time.tm_year = dbts.year;
@@ -270,7 +270,7 @@ public:
         return strTime;
     }
 
-    bool GetAsDBTIMESTAMP(DBTIMESTAMP& dbts) const throw()
+    bool GetAsDBTIMESTAMP(DBTIMESTAMP& dbts) const noexcept
     {
         struct tm time;
         _gmtime64_s(&time, &m_nTime);
@@ -284,7 +284,7 @@ public:
         return true;  // TODO: error handling?
     }
 
-    bool GetAsSystemTime(SYSTEMTIME& st) const throw()
+    bool GetAsSystemTime(SYSTEMTIME& st) const noexcept
     {
         struct tm time;
         _gmtime64_s(&time, &m_nTime);
@@ -299,21 +299,21 @@ public:
         return true;  // TODO: error handling?
     }
 
-    static CTime WINAPI GetCurrentTime() throw()
+    static CTime WINAPI GetCurrentTime() noexcept
     {
         __time64_t time;
         _time64(&time);
         return CTime(time);
     }
 
-    int GetDay() const throw()
+    int GetDay() const noexcept
     {
         struct tm time;
         _localtime64_s(&time, &m_nTime);
         return time.tm_mday;
     }
 
-    int GetDayOfWeek() const throw()
+    int GetDayOfWeek() const noexcept
     {
         struct tm time;
         _localtime64_s(&time, &m_nTime);
@@ -326,7 +326,7 @@ public:
         return ptm;
     }
 
-    int GetHour() const throw()
+    int GetHour() const noexcept
     {
         struct tm time;
         _localtime64_s(&time, &m_nTime);
@@ -339,28 +339,28 @@ public:
         return ptm;
     }
 
-    int GetMinute() const throw()
+    int GetMinute() const noexcept
     {
         struct tm time;
         _localtime64_s(&time, &m_nTime);
         return time.tm_min;
     }
 
-    int GetMonth() const throw()
+    int GetMonth() const noexcept
     {
         struct tm time;
         _localtime64_s(&time, &m_nTime);
         return time.tm_mon;
     }
 
-    int GetSecond() const throw()
+    int GetSecond() const noexcept
     {
         struct tm time;
         _localtime64_s(&time, &m_nTime);
         return time.tm_sec;
     }
 
-    __time64_t GetTime() const throw()
+    __time64_t GetTime() const noexcept
     {
         return m_nTime;
     }
@@ -377,65 +377,65 @@ public:
 //         // TODO
 //     }
 
-    CTime operator+(CTimeSpan timeSpan) const throw()
+    CTime operator+(CTimeSpan timeSpan) const noexcept
     {
         return CTime(m_nTime + timeSpan.GetTimeSpan());
     }
 
-    CTime operator-(CTimeSpan timeSpan) const throw()
+    CTime operator-(CTimeSpan timeSpan) const noexcept
     {
         return CTime(m_nTime - timeSpan.GetTimeSpan());
     }
 
-    CTimeSpan operator-(CTime time) const throw()
+    CTimeSpan operator-(CTime time) const noexcept
     {
         return CTimeSpan(m_nTime - time.GetTime());
     }
 
-    CTime& operator+=(CTimeSpan span) throw()
+    CTime& operator+=(CTimeSpan span) noexcept
     {
         m_nTime += span.GetTimeSpan();
         return *this;
     }
 
-    CTime& operator-=(CTimeSpan span) throw()
+    CTime& operator-=(CTimeSpan span) noexcept
     {
         m_nTime -= span.GetTimeSpan();
         return *this;
     }
 
-    CTime& operator=(__time64_t time) throw()
+    CTime& operator=(__time64_t time) noexcept
     {
         m_nTime = time;
         return *this;
     }
 
-    bool operator==(CTime time) const throw()
+    bool operator==(CTime time) const noexcept
     {
         return m_nTime == time.GetTime();
     }
 
-    bool operator!=(CTime time) const throw()
+    bool operator!=(CTime time) const noexcept
     {
         return m_nTime != time.GetTime();
     }
 
-    bool operator<(CTime time) const throw()
+    bool operator<(CTime time) const noexcept
     {
         return m_nTime < time.GetTime();
     }
 
-    bool operator>(CTime time) const throw()
+    bool operator>(CTime time) const noexcept
     {
         return m_nTime > time.GetTime();
     }
 
-    bool operator<=(CTime time) const throw()
+    bool operator<=(CTime time) const noexcept
     {
         return m_nTime <= time.GetTime();
     }
 
-    bool operator>=(CTime time) const throw()
+    bool operator>=(CTime time) const noexcept
     {
         return m_nTime >= time.GetTime();
     }
@@ -446,85 +446,85 @@ class CFileTimeSpan
 {
     LONGLONG m_nSpan;
 public:
-    CFileTimeSpan() throw()
+    CFileTimeSpan() noexcept
     {
         m_nSpan = 0;
     }
 
-    CFileTimeSpan(const CFileTimeSpan& span) throw()
+    CFileTimeSpan(const CFileTimeSpan& span) noexcept
     {
         m_nSpan = span.GetTimeSpan();
     }
 
-    CFileTimeSpan(LONGLONG nSpan) throw()
+    CFileTimeSpan(LONGLONG nSpan) noexcept
     {
         m_nSpan = nSpan;
     }
 
-    LONGLONG GetTimeSpan() const throw()
+    LONGLONG GetTimeSpan() const noexcept
     {
         return m_nSpan;
     }
 
-    void SetTimeSpan(LONGLONG nSpan) throw()
+    void SetTimeSpan(LONGLONG nSpan) noexcept
     {
         m_nSpan = nSpan;
     }
 
-    CFileTimeSpan operator-(CFileTimeSpan span) const throw()
+    CFileTimeSpan operator-(CFileTimeSpan span) const noexcept
     {
         return CFileTimeSpan(m_nSpan - span.GetTimeSpan());
     }
 
-    bool operator!=(CFileTimeSpan span) const throw()
+    bool operator!=(CFileTimeSpan span) const noexcept
     {
         return m_nSpan != span.GetTimeSpan();
     }
 
-    CFileTimeSpan operator+(CFileTimeSpan span) const throw()
+    CFileTimeSpan operator+(CFileTimeSpan span) const noexcept
     {
         return CFileTimeSpan(m_nSpan + span.GetTimeSpan());
     }
 
-    CFileTimeSpan& operator+=(CFileTimeSpan span) throw()
+    CFileTimeSpan& operator+=(CFileTimeSpan span) noexcept
     {
         m_nSpan += span.GetTimeSpan();
         return *this;
     }
 
-    bool operator<(CFileTimeSpan span) const throw()
+    bool operator<(CFileTimeSpan span) const noexcept
     {
         return m_nSpan < span.GetTimeSpan();
     }
 
-    bool operator<=(CFileTimeSpan span) const throw()
+    bool operator<=(CFileTimeSpan span) const noexcept
     {
         return m_nSpan <= span.GetTimeSpan();
     }
 
-    CFileTimeSpan& operator=(const CFileTimeSpan& span) throw()
+    CFileTimeSpan& operator=(const CFileTimeSpan& span) noexcept
     {
         m_nSpan = span.GetTimeSpan();
         return *this;
     }
 
-    CFileTimeSpan& operator-=(CFileTimeSpan span) throw()
+    CFileTimeSpan& operator-=(CFileTimeSpan span) noexcept
     {
         m_nSpan -= span.GetTimeSpan();
         return *this;
     }
 
-    bool operator==(CFileTimeSpan span) const throw()
+    bool operator==(CFileTimeSpan span) const noexcept
     {
         return m_nSpan == span.GetTimeSpan();
     }
 
-    bool operator>(CFileTimeSpan span) const throw()
+    bool operator>(CFileTimeSpan span) const noexcept
     {
         return m_nSpan > span.GetTimeSpan();
     }
 
-    bool operator>=(CFileTimeSpan span) const throw()
+    bool operator>=(CFileTimeSpan span) const noexcept
     {
         return m_nSpan >= span.GetTimeSpan();
     }
@@ -541,116 +541,116 @@ public:
     static const ULONGLONG Day = Hour * 24;
     static const ULONGLONG Week = Day * 7;
 
-    CFileTime() throw()
+    CFileTime() noexcept
     {
         this->dwLowDateTime = 0;
         this->dwHighDateTime = 0;
     }
 
-    CFileTime(const FILETIME& ft) throw()
+    CFileTime(const FILETIME& ft) noexcept
     {
         this->dwLowDateTime = ft.dwLowDateTime;
         this->dwHighDateTime = ft.dwHighDateTime;
     }
 
-    CFileTime(ULONGLONG nTime) throw()
+    CFileTime(ULONGLONG nTime) noexcept
     {
         this->dwLowDateTime = (DWORD) nTime;
         this->dwHighDateTime = nTime >> 32;
     }
 
-    static CFileTime GetCurrentTime() throw()
+    static CFileTime GetCurrentTime() noexcept
     {
         FILETIME ft;
         GetSystemTimeAsFileTime(&ft);
         return CFileTime(ft);
     }
 
-    ULONGLONG GetTime() const throw()
+    ULONGLONG GetTime() const noexcept
     {
         return ((ULONGLONG)this->dwLowDateTime) | (((ULONGLONG)this->dwHighDateTime) << 32);
     }
 
-    CFileTime LocalToUTC() const throw()
+    CFileTime LocalToUTC() const noexcept
     {
         FILETIME ft;
         LocalFileTimeToFileTime(this, &ft);
         return CFileTime(ft);
     }
 
-    void SetTime(ULONGLONG nTime) throw()
+    void SetTime(ULONGLONG nTime) noexcept
     {
         this->dwLowDateTime = (DWORD) nTime;
         this->dwHighDateTime = nTime >> 32;
     }
 
-    CFileTime UTCToLocal() const throw()
+    CFileTime UTCToLocal() const noexcept
     {
         FILETIME ft;
         FileTimeToLocalFileTime(this, &ft);
         return CFileTime(ft);
     }
 
-    CFileTime operator-(CFileTimeSpan span) const throw()
+    CFileTime operator-(CFileTimeSpan span) const noexcept
     {
         return CFileTime(this->GetTime() - span.GetTimeSpan());
     }
 
-    CFileTimeSpan operator-(CFileTime ft) const throw()
+    CFileTimeSpan operator-(CFileTime ft) const noexcept
     {
         return CFileTimeSpan(this->GetTime() - ft.GetTime());
     }
 
-    bool operator!=(CFileTime ft) const throw()
+    bool operator!=(CFileTime ft) const noexcept
     {
         return this->GetTime() != ft.GetTime();
     }
 
-    CFileTime operator+(CFileTimeSpan span) const throw()
+    CFileTime operator+(CFileTimeSpan span) const noexcept
     {
         return CFileTime(this->GetTime() + span.GetTimeSpan());
     }
 
-    CFileTime& operator+=(CFileTimeSpan span) throw()
+    CFileTime& operator+=(CFileTimeSpan span) noexcept
     {
         this->SetTime(this->GetTime() + span.GetTimeSpan());
         return *this;
     }
 
-    bool operator<(CFileTime ft) const throw()
+    bool operator<(CFileTime ft) const noexcept
     {
         return this->GetTime() < ft.GetTime();
     }
 
-    bool operator<=(CFileTime ft) const throw()
+    bool operator<=(CFileTime ft) const noexcept
     {
         return this->GetTime() <= ft.GetTime();
     }
 
-    CFileTime& operator=(const FILETIME& ft) throw()
+    CFileTime& operator=(const FILETIME& ft) noexcept
     {
         this->dwLowDateTime = ft.dwLowDateTime;
         this->dwHighDateTime = ft.dwHighDateTime;
         return *this;
     }
 
-    CFileTime& operator-=(CFileTimeSpan span) throw()
+    CFileTime& operator-=(CFileTimeSpan span) noexcept
     {
         this->SetTime(this->GetTime() - span.GetTimeSpan());
         return *this;
     }
 
-    bool operator==(CFileTime ft) const throw()
+    bool operator==(CFileTime ft) const noexcept
     {
         return this->GetTime() == ft.GetTime();
     }
 
-    bool operator>(CFileTime ft) const throw()
+    bool operator>(CFileTime ft) const noexcept
     {
         return this->GetTime() > ft.GetTime();
     }
 
-    bool operator>=(CFileTime ft) const throw()
+    bool operator>=(CFileTime ft) const noexcept
     {
         return this->GetTime() >= ft.GetTime();
     }

--- a/sdk/lib/atl/atltypes.h
+++ b/sdk/lib/atl/atltypes.h
@@ -29,101 +29,101 @@ class CPoint : public tagPOINT
 {
 public:
 
-    CPoint() throw()
+    CPoint() noexcept
     {
         x = y = 0;
     }
 
-    CPoint(int initX, int initY) throw()
+    CPoint(int initX, int initY) noexcept
     {
         x = initX;
         y = initY;
     }
 
-    CPoint(POINT initPt) throw()
+    CPoint(POINT initPt) noexcept
     {
         *((POINT*)this) = initPt;
     }
 
-    CPoint(SIZE initSize) throw()
+    CPoint(SIZE initSize) noexcept
     {
         *((SIZE*)this) = initSize;
     }
 
-    CPoint(LPARAM dwPoint) throw()
+    CPoint(LPARAM dwPoint) noexcept
     {
         x = LOWORD(dwPoint);
         y = HIWORD(dwPoint);
     }
 
-    void Offset(int xOffset, int yOffset) throw()
+    void Offset(int xOffset, int yOffset) noexcept
     {
         x += xOffset;
         y += yOffset;
     }
 
-    void Offset(POINT point) throw()
+    void Offset(POINT point) noexcept
     {
         Offset(point.x, point.y);
     }
 
-    void Offset(SIZE size) throw()
+    void Offset(SIZE size) noexcept
     {
         Offset(size.cx, size.cy);
     }
 
-    BOOL operator==(POINT point) const throw()
+    BOOL operator==(POINT point) const noexcept
     {
         return (x == point.x && y == point.y);
     }
 
-    BOOL operator!=(POINT point) const throw()
+    BOOL operator!=(POINT point) const noexcept
     {
         return !(*this == point);
     }
 
-    void operator+=(SIZE size) throw()
+    void operator+=(SIZE size) noexcept
     {
         Offset(size);
     }
 
-    void operator+=(POINT point) throw()
+    void operator+=(POINT point) noexcept
     {
         Offset(point);
     }
 
-    void operator-=(SIZE size) throw()
+    void operator-=(SIZE size) noexcept
     {
         Offset(-size.cx, -size.cy);
     }
 
-    void operator-=(POINT point) throw()
+    void operator-=(POINT point) noexcept
     {
         Offset(-point.x, -point.y);
     }
 
-    CPoint operator+(SIZE size) const throw()
+    CPoint operator+(SIZE size) const noexcept
     {
         return CPoint(x + size.cx, y + size.cy);
     }
 
-    CPoint operator+(POINT point) const throw()
+    CPoint operator+(POINT point) const noexcept
     {
         return CPoint(x + point.x, y + point.y);
     }
 
-    CRect operator+(const RECT* lpRect) const throw();
+    CRect operator+(const RECT* lpRect) const noexcept;
 
-    CSize operator-(POINT point) const throw();
+    CSize operator-(POINT point) const noexcept;
 
-    CPoint operator-(SIZE size) const throw()
+    CPoint operator-(SIZE size) const noexcept
     {
         return CPoint(x - size.cx, y - size.cy);
     }
 
-    CRect operator-(const RECT* lpRect) const throw();
+    CRect operator-(const RECT* lpRect) const noexcept;
 
-    CPoint operator-() const throw()
+    CPoint operator-() const noexcept
     {
         return CPoint(-x, -y);
     }
@@ -132,87 +132,87 @@ public:
 class CSize : public tagSIZE
 {
 public:
-    CSize() throw()
+    CSize() noexcept
     {
         cx = cy = 0;
     }
 
-    CSize(int initCX, int initCY) throw()
+    CSize(int initCX, int initCY) noexcept
     {
         cx = initCX;
         cy = initCY;
     }
 
-    CSize(SIZE initSize) throw()
+    CSize(SIZE initSize) noexcept
     {
         *((SIZE*)this) = initSize;
     }
 
-    CSize(POINT initPt) throw()
+    CSize(POINT initPt) noexcept
     {
         *((POINT*)this) = initPt;
     }
 
-    CSize(DWORD dwSize) throw()
+    CSize(DWORD dwSize) noexcept
     {
         cx = LOWORD(dwSize);
         cy = HIWORD(dwSize);
     }
 
-    BOOL operator==(SIZE size) const throw()
+    BOOL operator==(SIZE size) const noexcept
     {
         return (size.cx == cx && size.cy == cy);
     }
 
-    BOOL operator!=(SIZE size) const throw()
+    BOOL operator!=(SIZE size) const noexcept
     {
         return !(*this == size);
     }
 
-    void operator+=(SIZE size) throw()
+    void operator+=(SIZE size) noexcept
     {
         cx += size.cx;
         cy += size.cy;
     }
 
-    void operator-=(SIZE size) throw()
+    void operator-=(SIZE size) noexcept
     {
         cx -= size.cx;
         cy -= size.cy;
     }
 
-    CSize operator+(SIZE size) const throw()
+    CSize operator+(SIZE size) const noexcept
     {
         return CSize(cx + size.cx, cy + size.cy);
     }
 
-    CPoint operator+(POINT point) const throw()
+    CPoint operator+(POINT point) const noexcept
     {
         return CPoint(cx + point.x, cy + point.y);
     }
 
-    CRect operator+(const RECT* lpRect) const throw();
+    CRect operator+(const RECT* lpRect) const noexcept;
 
-    CSize operator-(SIZE size) const throw()
+    CSize operator-(SIZE size) const noexcept
     {
         return CSize(cx - size.cx, cy - size.cy);
     }
 
-    CPoint operator-(POINT point) const throw()
+    CPoint operator-(POINT point) const noexcept
     {
         return CPoint(cx - point.x, cy - point.y);
     }
 
-    CRect operator-(const RECT* lpRect) const throw();
+    CRect operator-(const RECT* lpRect) const noexcept;
 
-    CSize operator-() const throw()
+    CSize operator-() const noexcept
     {
         return CSize(-cx, -cy);
     }
 };
 
 
-inline CSize CPoint::operator-(POINT point) const throw()
+inline CSize CPoint::operator-(POINT point) const noexcept
 {
     return CSize(x - point.x, y - point.y);
 }
@@ -221,12 +221,12 @@ inline CSize CPoint::operator-(POINT point) const throw()
 class CRect : public tagRECT
 {
 public:
-    CRect() throw()
+    CRect() noexcept
     {
         left = top = right = bottom = 0;
     }
 
-    CRect(int l, int t, int r, int b) throw()
+    CRect(int l, int t, int r, int b) noexcept
     {
         left = l;
         top = t;
@@ -234,7 +234,7 @@ public:
         bottom = b;
     }
 
-    CRect(const RECT& srcRect) throw()
+    CRect(const RECT& srcRect) noexcept
     {
         left = srcRect.left;
         top = srcRect.top;
@@ -242,7 +242,7 @@ public:
         bottom = srcRect.bottom;
     }
 
-    CRect(LPCRECT lpSrcRect) throw()
+    CRect(LPCRECT lpSrcRect) noexcept
     {
         left = lpSrcRect->left;
         top = lpSrcRect->top;
@@ -250,7 +250,7 @@ public:
         bottom = lpSrcRect->bottom;
     }
 
-    CRect(POINT point, SIZE size) throw()
+    CRect(POINT point, SIZE size) noexcept
     {
         left = point.x;
         top = point.y;
@@ -258,7 +258,7 @@ public:
         bottom = point.y + size.cy;
     }
 
-    CRect(POINT topLeft, POINT bottomRight) throw()
+    CRect(POINT topLeft, POINT bottomRight) noexcept
     {
         left = topLeft.x;
         top = topLeft.y;
@@ -266,42 +266,42 @@ public:
         bottom = bottomRight.y;
     }
 
-    CPoint& BottomRight() throw()
+    CPoint& BottomRight() noexcept
     {
         return ((CPoint*)this)[1];
     }
 
-    const CPoint& BottomRight() const throw()
+    const CPoint& BottomRight() const noexcept
     {
         return ((const CPoint*)this)[1];
     }
 
-    CPoint CenterPoint() const throw()
+    CPoint CenterPoint() const noexcept
     {
         return CPoint(left + (Width() >> 1), top + (Height() >> 1));
     }
 
-    void CopyRect(LPCRECT lpSrcRect) throw()
+    void CopyRect(LPCRECT lpSrcRect) noexcept
     {
         ::CopyRect(this, lpSrcRect);
     }
 
-    void DeflateRect(int x, int y) throw()
+    void DeflateRect(int x, int y) noexcept
     {
         ::InflateRect(this, -x, -y);
     }
 
-    void DeflateRect(SIZE size) throw()
+    void DeflateRect(SIZE size) noexcept
     {
         ::InflateRect(this, -size.cx, -size.cy);
     }
 
-    void DeflateRect(LPCRECT lpRect) throw()
+    void DeflateRect(LPCRECT lpRect) noexcept
     {
         DeflateRect(lpRect->left, lpRect->top, lpRect->right, lpRect->bottom);
     }
 
-    void DeflateRect(int l, int t, int r, int b) throw()
+    void DeflateRect(int l, int t, int r, int b) noexcept
     {
         left += l;
         top += t;
@@ -309,33 +309,33 @@ public:
         bottom -= b;
     }
 
-    BOOL EqualRect(LPCRECT lpRect) const throw()
+    BOOL EqualRect(LPCRECT lpRect) const noexcept
     {
         return ::EqualRect(this, lpRect);
     }
 
 
-    int Height() const throw()
+    int Height() const noexcept
     {
         return bottom - top;
     }
 
-    void InflateRect(int x, int y) throw()
+    void InflateRect(int x, int y) noexcept
     {
         ::InflateRect(this, x, y);
     }
 
-    void InflateRect(SIZE size) throw()
+    void InflateRect(SIZE size) noexcept
     {
         ::InflateRect(this, size.cx, size.cy);
     }
 
-    void InflateRect(LPCRECT lpRect) throw()
+    void InflateRect(LPCRECT lpRect) noexcept
     {
         InflateRect(lpRect->left, lpRect->top, lpRect->right, lpRect->bottom);
     }
 
-    void InflateRect(int l, int t, int r, int b) throw()
+    void InflateRect(int l, int t, int r, int b) noexcept
     {
         left -= l;
         top -= t;
@@ -343,74 +343,74 @@ public:
         bottom += b;
     }
 
-    BOOL IntersectRect(LPCRECT lpRect1, LPCRECT lpRect2) throw()
+    BOOL IntersectRect(LPCRECT lpRect1, LPCRECT lpRect2) noexcept
     {
         return ::IntersectRect(this, lpRect1, lpRect2);
     }
 
-    BOOL IsRectEmpty() const throw()
+    BOOL IsRectEmpty() const noexcept
     {
         return ::IsRectEmpty(this);
     }
 
-    BOOL IsRectNull() const throw()
+    BOOL IsRectNull() const noexcept
     {
         return (left == 0 && right == 0 &&
             top == 0 && bottom == 0);
     }
 
-    //void MoveToX(int x) throw()
-    //void MoveToXY(int x, int y) throw()
-    //void MoveToXY(POINT point) throw()
-    //void MoveToY(int y) throw()
-    //void NormalizeRect() throw()
+    //void MoveToX(int x) noexcept
+    //void MoveToXY(int x, int y) noexcept
+    //void MoveToXY(POINT point) noexcept
+    //void MoveToY(int y) noexcept
+    //void NormalizeRect() noexcept
 
-    void OffsetRect(int x, int y) throw()
+    void OffsetRect(int x, int y) noexcept
     {
         ::OffsetRect(this, x, y);
     }
 
-    void OffsetRect(POINT point) throw()
+    void OffsetRect(POINT point) noexcept
     {
         ::OffsetRect(this, point.x, point.y);
     }
 
-    void OffsetRect(SIZE size) throw()
+    void OffsetRect(SIZE size) noexcept
     {
         ::OffsetRect(this, size.cx, size.cy);
     }
 
-    BOOL PtInRect(POINT point) const throw()
+    BOOL PtInRect(POINT point) const noexcept
     {
         return ::PtInRect(this, point);
     }
-    //void SetRect(int x1, int y1, int x2, int y2) throw()
-    //void SetRectEmpty() throw()
-    //CSize Size() const throw()
-    //BOOL SubtractRect(LPCRECT lpRectSrc1, LPCRECT lpRectSrc2) throw()
+    //void SetRect(int x1, int y1, int x2, int y2) noexcept
+    //void SetRectEmpty() noexcept
+    //CSize Size() const noexcept
+    //BOOL SubtractRect(LPCRECT lpRectSrc1, LPCRECT lpRectSrc2) noexcept
 
-    CPoint& TopLeft() throw()
+    CPoint& TopLeft() noexcept
     {
         return ((CPoint*)this)[0];
     }
 
-    const CPoint& TopLeft() const throw()
+    const CPoint& TopLeft() const noexcept
     {
         return ((const CPoint*)this)[0];
     }
 
-    BOOL UnionRect(LPCRECT lpRect1, LPCRECT lpRect2) throw()
+    BOOL UnionRect(LPCRECT lpRect1, LPCRECT lpRect2) noexcept
     {
         return ::UnionRect(this, lpRect1, lpRect2);
     }
 
-    int Width() const throw()
+    int Width() const noexcept
     {
         return right - left;
     }
 
 
-    BOOL operator==(const RECT& rect) const throw()
+    BOOL operator==(const RECT& rect) const noexcept
     {
         return (left == rect.left &&
             top == rect.top &&
@@ -418,12 +418,12 @@ public:
             bottom == rect.bottom);
     }
 
-    BOOL operator!=(const RECT& rect) const throw()
+    BOOL operator!=(const RECT& rect) const noexcept
     {
         return !(*this == rect);
     }
 
-    void operator=(const RECT& srcRect) throw()
+    void operator=(const RECT& srcRect) noexcept
     {
         left = srcRect.left;
         top = srcRect.top;
@@ -431,136 +431,136 @@ public:
         bottom = srcRect.bottom;
     }
 
-    void operator+=(POINT point) throw()
+    void operator+=(POINT point) noexcept
     {
         OffsetRect(point);
     }
 
-    void operator+=(SIZE size) throw()
+    void operator+=(SIZE size) noexcept
     {
         OffsetRect(size);
     }
 
-    void operator+=(LPCRECT lpRect) throw()
+    void operator+=(LPCRECT lpRect) noexcept
     {
         InflateRect(lpRect);
     }
 
-    void operator-=(POINT point) throw()
+    void operator-=(POINT point) noexcept
     {
         OffsetRect(-point.x, -point.y);
     }
 
-    void operator-=(SIZE size) throw()
+    void operator-=(SIZE size) noexcept
     {
         OffsetRect(-size.cx, -size.cy);
     }
 
-    void operator-=(LPCRECT lpRect) throw()
+    void operator-=(LPCRECT lpRect) noexcept
     {
         DeflateRect(lpRect);
     }
 
 
-    CRect operator+(POINT point) const throw()
+    CRect operator+(POINT point) const noexcept
     {
         CRect r(this);
         r.OffsetRect(point);
         return r;
     }
 
-    CRect operator+(LPCRECT lpRect) const throw()
+    CRect operator+(LPCRECT lpRect) const noexcept
     {
         CRect r(this);
         r.InflateRect(lpRect);
         return r;
     }
 
-    CRect operator+(SIZE size) const throw()
+    CRect operator+(SIZE size) const noexcept
     {
         CRect r(this);
         r.OffsetRect(size);
         return r;
     }
 
-    CRect operator-(POINT point) const throw()
+    CRect operator-(POINT point) const noexcept
     {
         CRect r(this);
         r.OffsetRect(-point.x, -point.y);
         return r;
     }
 
-    CRect operator-(SIZE size) const throw()
+    CRect operator-(SIZE size) const noexcept
     {
         CRect r(this);
         r.OffsetRect(-size.cx, -size.cy);
         return r;
     }
 
-    CRect operator-(LPCRECT lpRect) const throw()
+    CRect operator-(LPCRECT lpRect) const noexcept
     {
         CRect r(this);
         r.DeflateRect(lpRect);
         return r;
     }
 
-    void operator&=(const RECT& rect) throw()
+    void operator&=(const RECT& rect) noexcept
     {
         IntersectRect(this, &rect);
     }
 
-    CRect operator&(const RECT& rect2) const throw()
+    CRect operator&(const RECT& rect2) const noexcept
     {
         CRect r;
         r.IntersectRect(this, &rect2);
         return r;
     }
 
-    void operator|=(const RECT& rect) throw()
+    void operator|=(const RECT& rect) noexcept
     {
         UnionRect(this, &rect);
     }
 
-    CRect operator|(const RECT& rect2) const throw()
+    CRect operator|(const RECT& rect2) const noexcept
     {
         CRect r;
         r.UnionRect(this, &rect2);
         return r;
     }
 
-    operator LPRECT() throw()
+    operator LPRECT() noexcept
     {
         return this;
     }
 
-    operator LPCRECT() const throw()
+    operator LPCRECT() const noexcept
     {
         return this;
     }
 };
 
-inline CRect CPoint::operator+(const RECT* lpRect) const throw()
+inline CRect CPoint::operator+(const RECT* lpRect) const noexcept
 {
     CRect r(lpRect);
     r += *this;
     return r;
 }
 
-inline CRect CPoint::operator-(const RECT* lpRect) const throw()
+inline CRect CPoint::operator-(const RECT* lpRect) const noexcept
 {
     CRect r(lpRect);
     r -= *this;
     return r;
 }
 
-inline CRect CSize::operator+(const RECT* lpRect) const throw()
+inline CRect CSize::operator+(const RECT* lpRect) const noexcept
 {
     CRect r(lpRect);
     r += *this;
     return r;
 }
 
-inline CRect CSize::operator-(const RECT* lpRect) const throw()
+inline CRect CSize::operator-(const RECT* lpRect) const noexcept
 {
     CRect r(lpRect);
     r -= *this;

--- a/sdk/lib/atl/cstringt.h
+++ b/sdk/lib/atl/cstringt.h
@@ -11,7 +11,7 @@
 namespace ATL
 {
 
-inline UINT WINAPI _AtlGetConversionACP() throw()
+inline UINT WINAPI _AtlGetConversionACP() noexcept
 {
 #ifdef _CONVERSION_DONT_USE_THREAD_LOCALE
     return CP_ACP;
@@ -26,13 +26,13 @@ class ChTraitsCRT : public ChTraitsBase<_CharType>
 {
 public:
 
-    static int __cdecl GetBaseTypeLength(_In_z_ LPCWSTR pszSource) throw()
+    static int __cdecl GetBaseTypeLength(_In_z_ LPCWSTR pszSource) noexcept
     {
         if (pszSource == NULL) return -1;
         return static_cast<int>(wcslen(pszSource));
     }
 
-    static int __cdecl GetBaseTypeLength(_In_z_ LPCSTR pszSource) throw()
+    static int __cdecl GetBaseTypeLength(_In_z_ LPCSTR pszSource) noexcept
     {
         if (pszSource == NULL) return 0;
         return ::MultiByteToWideChar(_AtlGetConversionACP(), 0, pszSource, -1, NULL, 0) - 1;
@@ -40,14 +40,14 @@ public:
 
     static int __cdecl GetBaseTypeLength(
         _In_reads_(nLength) LPCWSTR pszSource,
-        _In_ int nLength) throw()
+        _In_ int nLength) noexcept
     {
         return nLength;
     }
 
     static int __cdecl GetBaseTypeLength(
         _In_reads_(nLength) LPCSTR pszSource,
-        _In_ int nLength) throw()
+        _In_ int nLength) noexcept
     {
         return ::MultiByteToWideChar(_AtlGetConversionACP(), 0, pszSource, nLength, NULL, 0);
     }
@@ -214,12 +214,12 @@ class ChTraitsCRT<char> : public ChTraitsBase<char>
 {
 public:
 
-    static int __cdecl GetBaseTypeLength(_In_z_ LPCWSTR pszSource) throw()
+    static int __cdecl GetBaseTypeLength(_In_z_ LPCWSTR pszSource) noexcept
     {
         return ::WideCharToMultiByte(_AtlGetConversionACP(), 0, pszSource, -1, NULL, 0, NULL, NULL) - 1;
     }
 
-    static int __cdecl GetBaseTypeLength(_In_z_ LPCSTR pszSource) throw()
+    static int __cdecl GetBaseTypeLength(_In_z_ LPCSTR pszSource) noexcept
     {
         if (pszSource == NULL) return 0;
         return static_cast<int>(strlen(pszSource));
@@ -227,14 +227,14 @@ public:
 
     static int __cdecl GetBaseTypeLength(
         _In_reads_(nLength) LPCWSTR pszSource,
-        _In_ int nLength) throw()
+        _In_ int nLength) noexcept
     {
         return ::WideCharToMultiByte(_AtlGetConversionACP(), 0, pszSource, nLength, NULL, 0, NULL, NULL);
     }
 
     static int __cdecl GetBaseTypeLength(
         _In_reads_(nLength) LPCSTR pszSource,
-        _In_ int nLength) throw()
+        _In_ int nLength) noexcept
     {
         return nLength;
     }
@@ -428,12 +428,12 @@ public:
     typedef typename CThisSimpleString::PCYSTR PCYSTR;
 
 public:
-    CStringT() throw() :
+    CStringT() noexcept :
         CThisSimpleString(StringTraits::GetDefaultManager())
     {
     }
 
-    explicit CStringT( _In_ IAtlStringMgr* pStringMgr) throw() :
+    explicit CStringT( _In_ IAtlStringMgr* pStringMgr) noexcept :
         CThisSimpleString(pStringMgr)
     {
     }
@@ -544,76 +544,76 @@ public:
         return *this;
     }
 
-    friend bool operator==(const CStringT& str1, const CStringT& str2) throw()
+    friend bool operator==(const CStringT& str1, const CStringT& str2) noexcept
     {
         return str1.Compare(str2) == 0;
     }
 
-    friend bool operator==(const CStringT& str1, PCXSTR psz2) throw()
+    friend bool operator==(const CStringT& str1, PCXSTR psz2) noexcept
     {
         return str1.Compare(psz2) == 0;
     }
 
-    friend bool operator==(const CStringT& str1, PCYSTR psz2) throw()
+    friend bool operator==(const CStringT& str1, PCYSTR psz2) noexcept
     {
         CStringT tmp(psz2, str1.GetManager());
         return tmp.Compare(str1) == 0;
     }
 
-    friend bool operator==(const CStringT& str1, XCHAR ch2) throw()
+    friend bool operator==(const CStringT& str1, XCHAR ch2) noexcept
     {
         return str1.GetLength() == 1 && str1[0] == ch2;
     }
 
-    friend bool operator==(PCXSTR psz1, const CStringT& str2) throw()
+    friend bool operator==(PCXSTR psz1, const CStringT& str2) noexcept
     {
         return str2.Compare(psz1) == 0;
     }
 
-    friend bool operator==(PCYSTR psz1, const CStringT& str2) throw()
+    friend bool operator==(PCYSTR psz1, const CStringT& str2) noexcept
     {
         CStringT tmp(psz1, str2.GetManager());
         return tmp.Compare(str2) == 0;
     }
 
-    friend bool operator==(XCHAR ch1, const CStringT& str2) throw()
+    friend bool operator==(XCHAR ch1, const CStringT& str2) noexcept
     {
         return str2.GetLength() == 1 && str2[0] == ch1;
     }
 
-    friend bool operator!=(const CStringT& str1, const CStringT& str2) throw()
+    friend bool operator!=(const CStringT& str1, const CStringT& str2) noexcept
     {
         return str1.Compare(str2) != 0;
     }
 
-    friend bool operator!=(const CStringT& str1, PCXSTR psz2) throw()
+    friend bool operator!=(const CStringT& str1, PCXSTR psz2) noexcept
     {
         return str1.Compare(psz2) != 0;
     }
 
-    friend bool operator!=(const CStringT& str1, PCYSTR psz2) throw()
+    friend bool operator!=(const CStringT& str1, PCYSTR psz2) noexcept
     {
         CStringT tmp(psz2, str1.GetManager());
         return tmp.Compare(str1) != 0;
     }
 
-    friend bool operator!=(const CStringT& str1, XCHAR ch2) throw()
+    friend bool operator!=(const CStringT& str1, XCHAR ch2) noexcept
     {
         return str1.GetLength() != 1 || str1[0] != ch2;
     }
 
-    friend bool operator!=(PCXSTR psz1, const CStringT& str2) throw()
+    friend bool operator!=(PCXSTR psz1, const CStringT& str2) noexcept
     {
         return str2.Compare(psz1) != 0;
     }
 
-    friend bool operator!=(PCYSTR psz1, const CStringT& str2) throw()
+    friend bool operator!=(PCYSTR psz1, const CStringT& str2) noexcept
     {
         CStringT tmp(psz1, str2.GetManager());
         return tmp.Compare(str2) != 0;
     }
 
-    friend bool operator!=(XCHAR ch1, const CStringT& str2) throw()
+    friend bool operator!=(XCHAR ch1, const CStringT& str2) noexcept
     {
         return str2.GetLength() != 1 || str2[0] != ch1;
     }
@@ -693,7 +693,7 @@ public:
         return *this;
     }
 
-    int Find(_In_ PCXSTR pszSub, _In_opt_ int iStart = 0) const throw()
+    int Find(_In_ PCXSTR pszSub, _In_opt_ int iStart = 0) const noexcept
     {
         int nLength = CThisSimpleString::GetLength();
 
@@ -706,7 +706,7 @@ public:
         return pszResult ? ((int)(pszResult - pszString)) : -1;
     }
 
-    int Find(_In_ XCHAR ch, _In_opt_ int iStart = 0) const throw()
+    int Find(_In_ XCHAR ch, _In_opt_ int iStart = 0) const noexcept
     {
         int nLength = CThisSimpleString::GetLength();
 
@@ -719,7 +719,7 @@ public:
         return pszResult ? ((int)(pszResult - pszString)) : -1;
     }
 
-    int FindOneOf(_In_ PCXSTR pszCharSet) const throw()
+    int FindOneOf(_In_ PCXSTR pszCharSet) const noexcept
     {
         PCXSTR pszString = CThisSimpleString::GetString();
         PCXSTR pszResult = StringTraits::FindOneOf(pszString, pszCharSet);
@@ -727,7 +727,7 @@ public:
         return pszResult ? ((int)(pszResult - pszString)) : -1;
     }
 
-    int ReverseFind(_In_ XCHAR ch) const throw()
+    int ReverseFind(_In_ XCHAR ch) const noexcept
     {
         PCXSTR pszString = CThisSimpleString::GetString();
         PCXSTR pszResult = StringTraits::FindCharReverse(pszString, ch);


### PR DESCRIPTION
## Purpose

Avoid use of deprecated `throw()`.
JIRA issue: N/A

## Proposed changes

- Mechanically replace `throw()` with `noexcept` of C++11.

## TODO

- [x] Do build.