### PR TITLE
[ATL][ATL_APITEST] Add some missing CRect methods

### DIFF
--- a/modules/rostests/apitests/atl/atltest.h
+++ b/modules/rostests/apitests/atl/atltest.h
@@ -2,7 +2,7 @@
  * PROJECT:     ReactOS api tests
  * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
  * PURPOSE:     Testing
- * COPYRIGHT:   Copyright 2019 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
+ * COPYRIGHT:   Copyright 2019-2023 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
  */
 
 #ifndef ATLTEST_H_
@@ -134,5 +134,44 @@ char *wine_dbgstr_w(const wchar_t *wstr)
 #define ok_int(expression, result) ok_dec(expression, result)
 #define ok_ntstatus(status, expected) ok_hex(status, expected)
 #define ok_hdl ok_ptr
+
+static inline const char *wine_dbgstr_point(const POINT *ppt)
+{
+    static char s_asz[4][40];
+    static int s_i = 0;
+    char *buf;
+
+    if (!ppt)
+        return "(null)";
+    if (IS_INTRESOURCE(ppt))
+        return "(invalid ptr)";
+
+    buf = s_asz[s_i];
+    s_i = (s_i + 1) % _countof(s_asz);
+    sprintf_s(buf, _countof(s_asz[0]), "(%ld, %ld)", ppt->x, ppt->y);
+    return buf;
+}
+
+static inline const char *wine_dbgstr_size(const SIZE *psize)
+{
+    return wine_dbgstr_point((const POINT *)psize);
+}
+
+static inline const char *wine_dbgstr_rect(const RECT *prc)
+{
+    static char s_asz[4][80];
+    static int s_i = 0;
+    char *buf;
+
+    if (!prc)
+        return "(null)";
+    if (IS_INTRESOURCE(prc))
+        return "(invalid ptr)";
+
+    buf = s_asz[s_i];
+    s_i = (s_i + 1) % _countof(s_asz);
+    sprintf_s(buf, _countof(s_asz[0]), "(%ld, %ld) - (%ld, %ld)", prc->left, prc->top, prc->right, prc->bottom);
+    return buf;
+}
 
 #endif  /* ndef ATLTEST_H_ */

--- a/modules/rostests/apitests/atl/atltypes.cpp
+++ b/modules/rostests/apitests/atl/atltypes.cpp
@@ -7,7 +7,11 @@
  *                  Code based on MSDN samples regarding CPoint, CSize, CRect
  */
 
-#include <apitest.h>
+#ifdef HAVE_APITEST
+    #include <apitest.h>
+#else
+    #include "atltest.h"
+#endif
 #include <windows.h>
 #include <atltypes.h>
 
@@ -527,6 +531,46 @@ static void test_CRect()
     rect2 = rect1 - sz;
     rectResult = CRect(-100, -50, 200, 250);
     ok_rect(rectResult, rect2);
+
+    SetRect(&rect2, 10, 20, 300, 120);
+    rect2.MoveToX(30);
+    rectResult = CRect(30, 20, 320, 120);
+    ok_rect(rectResult, rect2);
+
+    SetRect(&rect2, 10, 20, 300, 120);
+    rect2.MoveToY(40);
+    rectResult = CRect(10, 40, 300, 140);
+    ok_rect(rectResult, rect2);
+
+    SetRect(&rect2, 10, 20, 300, 120);
+    rect2.MoveToXY(30, 40);
+    rectResult = CRect(30, 40, 320, 140);
+    ok_rect(rectResult, rect2);
+
+    SetRect(&rect2, 100, 80, -100, -50);
+    rectResult = CRect(-100, -50, 100, 80);
+    rect2.NormalizeRect();
+    ok_rect(rectResult, rect2);
+
+    rect2.SetRectEmpty();
+    rectResult = CRect(0, 0, 0, 0);
+    ok_rect(rectResult, rect2);
+
+    BOOL ret;
+
+    rect1 = CRect(5, 40, 40, 120);
+    rect2 = CRect(10, 30, 80, 100);
+    ret = rect.SubtractRect(rect1, rect2);
+    rectResult = CRect(10, 30, 80, 100);
+    ok_int(ret, TRUE);
+    ok_rect(rectResult, rect2);
+
+    rect1 = CRect(10, 40, 70, 110);
+    rect2 = CRect(8, 20, 40, 130);
+    ret = rect.SubtractRect(rect1, rect2);
+    rectResult = CRect(8, 20, 40, 130);
+    ok_int(ret, TRUE);
+    ok_rect(rect2, rectResult);
 }
 
 

--- a/modules/rostests/apitests/atl/devenv/ATLTest.sln
+++ b/modules/rostests/apitests/atl/devenv/ATLTest.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.34114.132
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CImage", "CImage.vcxproj", "{AE520E17-2DAE-40FF-B082-F32A7A935FB2}"
 EndProject
@@ -32,6 +32,8 @@ EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "AtlObjMap", "AtlObjMap.vcxproj", "{B628C42A-A38E-488E-8512-2B997B75E95C}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "atlconv", "atlconv.vcxproj", "{85194CA3-A828-4270-962A-333743E2BF83}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "atltypes", "atltypes.vcxproj", "{6F9D87BA-0FBD-4A0D-9B11-6363D12ADD1D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -161,6 +163,14 @@ Global
 		{85194CA3-A828-4270-962A-333743E2BF83}.Release|x64.Build.0 = Release|x64
 		{85194CA3-A828-4270-962A-333743E2BF83}.Release|x86.ActiveCfg = Release|Win32
 		{85194CA3-A828-4270-962A-333743E2BF83}.Release|x86.Build.0 = Release|Win32
+		{6F9D87BA-0FBD-4A0D-9B11-6363D12ADD1D}.Debug|x64.ActiveCfg = Debug|x64
+		{6F9D87BA-0FBD-4A0D-9B11-6363D12ADD1D}.Debug|x64.Build.0 = Debug|x64
+		{6F9D87BA-0FBD-4A0D-9B11-6363D12ADD1D}.Debug|x86.ActiveCfg = Debug|Win32
+		{6F9D87BA-0FBD-4A0D-9B11-6363D12ADD1D}.Debug|x86.Build.0 = Debug|Win32
+		{6F9D87BA-0FBD-4A0D-9B11-6363D12ADD1D}.Release|x64.ActiveCfg = Release|x64
+		{6F9D87BA-0FBD-4A0D-9B11-6363D12ADD1D}.Release|x64.Build.0 = Release|x64
+		{6F9D87BA-0FBD-4A0D-9B11-6363D12ADD1D}.Release|x86.ActiveCfg = Release|Win32
+		{6F9D87BA-0FBD-4A0D-9B11-6363D12ADD1D}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/modules/rostests/apitests/atl/devenv/atltypes.vcxproj
+++ b/modules/rostests/apitests/atl/devenv/atltypes.vcxproj
@@ -1,0 +1,154 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\atltypes.cpp" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{85194CA3-33FF-4270-962A-333743E2BF83}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>atltypes</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140_xp</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <UseOfMfc>false</UseOfMfc>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140_xp</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+    <UseOfMfc>false</UseOfMfc>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <IntDir>$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <IntDir>$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/sdk/lib/atl/atltypes.h
+++ b/sdk/lib/atl/atltypes.h
@@ -359,11 +359,46 @@ public:
             top == 0 && bottom == 0);
     }
 
-    //void MoveToX(int x) noexcept
-    //void MoveToXY(int x, int y) noexcept
-    //void MoveToXY(POINT point) noexcept
-    //void MoveToY(int y) noexcept
-    //void NormalizeRect() noexcept
+    void MoveToX(int x) noexcept
+    {
+        int dx = x - left;
+        left = x;
+        right += dx;
+    }
+
+    void MoveToY(int y) noexcept
+    {
+        int dy = y - top;
+        top = y;
+        bottom += dy;
+    }
+
+    void MoveToXY(int x, int y) noexcept
+    {
+        MoveToX(x);
+        MoveToY(y);
+    }
+
+    void MoveToXY(POINT point) noexcept
+    {
+        MoveToXY(point.x, point.y);
+    }
+
+    void NormalizeRect() noexcept
+    {
+        if (left > right)
+        {
+            LONG tmp = left;
+            left = right;
+            right = tmp;
+        }
+        if (top > bottom)
+        {
+            LONG tmp = top;
+            top = bottom;
+            bottom = tmp;
+        }
+    }
 
     void OffsetRect(int x, int y) noexcept
     {
@@ -384,10 +419,29 @@ public:
     {
         return ::PtInRect(this, point);
     }
-    //void SetRect(int x1, int y1, int x2, int y2) noexcept
-    //void SetRectEmpty() noexcept
-    //CSize Size() const noexcept
-    //BOOL SubtractRect(LPCRECT lpRectSrc1, LPCRECT lpRectSrc2) noexcept
+
+    void SetRect(int x1, int y1, int x2, int y2) noexcept
+    {
+        left = x1;
+        top = y1;
+        right = x2;
+        bottom = y2;
+    }
+
+    void SetRectEmpty() noexcept
+    {
+        ::SetRectEmpty(this);
+    }
+
+    CSize Size() const noexcept
+    {
+        return CSize(Width(), Height());
+    }
+
+    BOOL SubtractRect(LPCRECT lpRectSrc1, LPCRECT lpRectSrc2) noexcept
+    {
+        return ::SubtractRect(this, lpRectSrc1, lpRectSrc2);
+    }
 
     CPoint& TopLeft() noexcept
     {


### PR DESCRIPTION
## Purpose

Implementing missing features...
JIRA issue: N/A

## Proposed changes

- Strengthen `"atltest.h"`.
- Strengthen `atl_apitest:atltypes` testcase.
- Implement some missing `CRect` methods.

## TODO

- [x] Do tests.

## Comparison

Visual Studio 2015 (AFTER):
![VS2015-after](https://github.com/reactos/reactos/assets/2107452/b03279eb-214e-4963-a761-39e2ddc8e44e)

Win10 AFTER:
![after](https://github.com/reactos/reactos/assets/2107452/e7ebbb1e-d3e1-4513-8518-796bdd1b4525)