### PR TITLE
[BOOTDATA] vfatfs.sys is packaged for xbox only

### DIFF
--- a/boot/bootdata/txtsetup.sif
+++ b/boot/bootdata/txtsetup.sif
@@ -124,7 +124,6 @@ pci.sys      = 1,,,,,,x,4,,,,1,4
 scsiport.sys = 1,,,,,,,4,,,,1,4
 storport.sys = 1,,,,,,,4,,,,1,4
 fastfat.sys  = 1,,,,,,x,4,,,,1,4
-vfatfs.sys   = 1,,,,,,,4,,,,1,4
 btrfs.sys    = 1,,,,,,x,4,,,,1,4
 ramdisk.sys  = 1,,,,,,x,4,,,,1,4
 pciide.sys   = 1,,,,,,,4,,,,1,4
@@ -282,6 +281,7 @@ halaacpi.dll  = 1,,,,,,,2,,,hal.dll,1,2
 [Files.xbox]
 ntoskrnl.exe = 1,,,,,,,2,,,,1,2
 halxbox.dll  = 1,,,,,,,2,,,hal.dll,1,2
+vfatfs.sys   = 1,,,,,,,4,,,,1,4
 
 [Files.pc98_up]
 ntoskrnl.exe = 1,,,,,,,2,,,,1,2


### PR DESCRIPTION
## Purpose

Avoid BootCD Stage 1
```
(base/setup/lib/utils/filesup.c:274) NtOpenFile failed: c0000034, \Device\CdRom0\reactos\system32\drivers\vfatfs.sys
(base/setup/usetup/usetup.c:3680) An error happened while trying to copy file '\Device\Harddisk0\Partition1\ReactOS\system32\drivers\vfatfs.sys' (error 0xc0000034), skipping it...
```

Addendum to 14c3936 (0.4.15-dev-5090).
JIRA issue: [CORE-16373](https://jira.reactos.org/browse/CORE-16373)

## Proposed changes

- Move this file to xbox section.
