### PR TITLE
[SHELL32] Enable Apply button when shortcut show mode is changed

### DIFF
--- a/dll/win32/shell32/CShellLink.cpp
+++ b/dll/win32/shell32/CShellLink.cpp
@@ -2886,7 +2886,7 @@ void CShellLink::OnCommand(HWND hwndDlg, int id, HWND hwndCtl, UINT codeNotify)
             return;
         }
     }
-    if (codeNotify == EN_CHANGE)
+    if (codeNotify == EN_CHANGE || codeNotify == CBN_SELCHANGE)
     {
         if (!m_bInInit)
             PropSheet_Changed(GetParent(hwndDlg), hwndDlg);


### PR DESCRIPTION
The apply button should be enabled when the show mode is changed