### PR TITLE
[TASKMGR] Get rid of cplusplus extern c

### DIFF
--- a/base/applications/taskmgr/perfdata.h
+++ b/base/applications/taskmgr/perfdata.h
@@ -93,4 +93,5 @@ ULONG	PerfDataGetPhysicalMemoryAvailableK(void);
 ULONG	PerfDataGetPhysicalMemorySystemCacheK(void);
 
 ULONG	PerfDataGetSystemHandleCount(void);
+
 ULONG	PerfDataGetTotalThreadCount(void);

--- a/base/applications/taskmgr/perfdata.h
+++ b/base/applications/taskmgr/perfdata.h
@@ -1,16 +1,12 @@
 /*
  * PROJECT:     ReactOS Task Manager
  * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
- * PURPOSE:     Performance Counters.
+ * PURPOSE:     Performance Counters
  * COPYRIGHT:   Copyright 1999-2001 Brian Palmer <brianp@reactos.org>
  *              Copyright 2014 Ismael Ferreras Morezuelas <swyterzone+ros@gmail.com>
  */
 
 #pragma once
-
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #define Li2Double(x) ((double)((x).HighPart) * 4.294967296E9 + (double)((x).LowPart))
 
@@ -43,9 +39,9 @@ typedef struct _PERFDATA
 
 typedef struct _CMD_LINE_CACHE
 {
-     DWORD idx;
+    DWORD  idx;
     LPWSTR str;
-     ULONG len;
+    ULONG  len;
     struct _CMD_LINE_CACHE* pnext;
 } CMD_LINE_CACHE, *PCMD_LINE_CACHE;
 
@@ -97,10 +93,4 @@ ULONG	PerfDataGetPhysicalMemoryAvailableK(void);
 ULONG	PerfDataGetPhysicalMemorySystemCacheK(void);
 
 ULONG	PerfDataGetSystemHandleCount(void);
-
 ULONG	PerfDataGetTotalThreadCount(void);
-
-
-#ifdef __cplusplus
-};
-#endif

--- a/base/applications/taskmgr/perfpage.h
+++ b/base/applications/taskmgr/perfpage.h
@@ -1,15 +1,11 @@
 /*
  * PROJECT:     ReactOS Task Manager
  * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
- * PURPOSE:     Performance Page.
+ * PURPOSE:     Performance Page
  * COPYRIGHT:   Copyright 1999-2001 Brian Palmer <brianp@reactos.org>
  */
 
 #pragma once
-
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 extern HWND hPerformancePage;   /* Performance Property Page */
 INT_PTR CALLBACK PerformancePageWndProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam);
@@ -18,7 +14,3 @@ void RefreshPerformancePage(void);
 void PerformancePage_OnViewShowKernelTimes(void);
 void PerformancePage_OnViewCPUHistoryOneGraphAll(void);
 void PerformancePage_OnViewCPUHistoryOneGraphPerCPU(void);
-
-#ifdef __cplusplus
-};
-#endif

--- a/base/applications/taskmgr/taskmgr.h
+++ b/base/applications/taskmgr/taskmgr.h
@@ -1,28 +1,11 @@
 /*
  * PROJECT:     ReactOS Task Manager
  * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
- * PURPOSE:     Main Header.
+ * PURPOSE:     Main Header
  * COPYRIGHT:   Copyright 1999-2001 Brian Palmer <brianp@reactos.org>
  */
 
 #pragma once
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#ifdef _MSC_VER
-/*MF
-typedef struct _IO_COUNTERS {
-	ULONGLONG  ReadOperationCount;
-	ULONGLONG  WriteOperationCount;
-	ULONGLONG  OtherOperationCount;
-	ULONGLONG ReadTransferCount;
-	ULONGLONG WriteTransferCount;
-	ULONGLONG OtherTransferCount;
-} IO_COUNTERS, *PIO_COUNTERS;
-*/
-#endif /* _MSC_VER */
 
 #include "resource.h"
 
@@ -100,7 +83,3 @@ void TaskManager_OnTabWndSelChange(void);
 VOID ShowWin32Error(DWORD dwError);
 LPTSTR GetLastErrorText( LPTSTR lpszBuf, DWORD dwSize );
 DWORD EndLocalThread(HANDLE *hThread, DWORD dwThread);
-
-#ifdef __cplusplus
-}
-#endif


### PR DESCRIPTION
Hermes took care of removing those in graphctrl.h and graph.h already within the yet uncommitted PR5343. Here are a few moreto get rid of, and a bit of other bloat.

I swear I checked, that we didn't collide here.

## Purpose

Just cleanup.

JIRA issue: none
