### PR TITLE
[RAPPS] Improve LicenseType handling

### DIFF
--- a/base/applications/rapps/appinfo.cpp
+++ b/base/applications/rapps/appinfo.cpp
@@ -159,13 +159,18 @@ CAvailableApplicationInfo::LicenseString()
     m_Parser->GetString(L"License", szLicenseString);
     LicenseType licenseType;
 
-    if (IsLicenseType(IntBuffer))
+    if (IsKnownLicenseType(IntBuffer))
     {
         licenseType = static_cast<LicenseType>(IntBuffer);
     }
     else
     {
         licenseType = LICENSE_NONE;
+        if (szLicenseString.CompareNoCase(L"Freeware") == 0)
+        {
+            licenseType = LICENSE_FREEWARE;
+            szLicenseString = L"";
+        }
     }
 
     CStringW szLicense;
@@ -184,7 +189,9 @@ CAvailableApplicationInfo::LicenseString()
             return szLicenseString;
     }
 
-    return szLicense + L" (" + szLicenseString + L")";
+    if (!szLicenseString.IsEmpty())
+        szLicense += L" (" + szLicenseString + L")";
+    return szLicense;
 }
 
 VOID

--- a/base/applications/rapps/include/appinfo.h
+++ b/base/applications/rapps/include/appinfo.h
@@ -8,17 +8,17 @@
 enum LicenseType
 {
     LICENSE_NONE,
-    LICENSE_OPENSOURCE,
-    LICENSE_FREEWARE,
-    LICENSE_TRIAL,
+    LICENSE_OPENSOURCE = 1,
+    LICENSE_FREEWARE = 2,
+    LICENSE_TRIAL = 3,
     LICENSE_MIN = LICENSE_NONE,
     LICENSE_MAX = LICENSE_TRIAL
 };
 
 inline BOOL
-IsLicenseType(INT x)
+IsKnownLicenseType(INT x)
 {
-    return (x >= LICENSE_MIN && x <= LICENSE_MAX);
+    return (x > 0 && x <= LICENSE_MAX);
 }
 
 enum AppsCategories

--- a/base/applications/rapps/include/appinfo.h
+++ b/base/applications/rapps/include/appinfo.h
@@ -18,7 +18,7 @@ enum LicenseType
 inline BOOL
 IsKnownLicenseType(INT x)
 {
-    return (x > 0 && x <= LICENSE_MAX);
+    return (x > LICENSE_NONE && x <= LICENSE_MAX);
 }
 
 enum AppsCategories


### PR DESCRIPTION
- If only the "License" field is set in the DB, nothing will change (this applies to 99% of the current entries in the DB)
- If both "LicenseType" and "License" are set, both will be used (no observable change in behavior): "Open Source (GPL v2)" etc.
- If only "LicenseType" is set, it will now display just the type "Freeware" instead of "Freeware ()".
----
- It now tries to map the "License" text set to "Freeware" to the `LICENSE_FREEWARE` "LicenseType" so it is translated correctly (`LoadString`).
- I added actual numbers in the enum to make it clearer that these values should not change.