### PR TITLE
[SYSSETUP] syssetup.rc improve URLs

### DIFF
--- a/dll/win32/syssetup/syssetup.rc
+++ b/dll/win32/syssetup/syssetup.rc
@@ -34,16 +34,16 @@ IDI_ICON5 ICON "resources/5.ico"
 STRINGTABLE
 BEGIN
     IDS_ACKPROJECTS "\
-Wine - http://www.winehq.org\
-\nFreeType - http://www.freetype.org\
+Wine - http://winehq.org\
+\nFreeType - http://freetype.org\
 \nSYSLINUX - http://syslinux.zytor.com\
-\nMinGW - http://www.mingw.org\
+\nMinGW - http://mingw.org\
 \nBochs - http://bochs.sourceforge.net\
-\nMesa3D - http://www.mesa3d.org\
-\nadns - http://www.gnu.org/software/adns\
+\nMesa3D - http://mesa3d.org\
+\nadns - http://gnu.org/software/adns\
 \nICU - http://icu.unicode.org\
 \nGraphApp - http://enchantia.com/software/graphapp\
-\nExt2 - http://www.ext2fsd.com\
+\nExt2 - http://ext2fsd.com\
 \nGNU FreeFont - http://savannah.gnu.org/projects/freefont\
 \nDejaVu Fonts - http://dejavu.sourceforge.net\
 \nLiberation(tm) Fonts - http://pagure.io/liberation-fonts\

--- a/dll/win32/syssetup/syssetup.rc
+++ b/dll/win32/syssetup/syssetup.rc
@@ -41,12 +41,12 @@ Wine - http://www.winehq.org\
 \nBochs - http://bochs.sourceforge.net\
 \nMesa3D - http://www.mesa3d.org\
 \nadns - http://www.gnu.org/software/adns\
-\nICU - http://www.icu-project.org\
+\nICU - http://icu.unicode.org\
 \nGraphApp - http://enchantia.com/software/graphapp\
 \nExt2 - http://www.ext2fsd.com\
 \nGNU FreeFont - http://savannah.gnu.org/projects/freefont\
 \nDejaVu Fonts - http://dejavu.sourceforge.net\
-\nLiberation(tm) Fonts - https://fedorahosted.org/liberation-fonts\
+\nLiberation(tm) Fonts - http://pagure.io/liberation-fonts\
 \nBtrfs - https://github.com/maharmstone/btrfs\
 \nTango Desktop Project - http://tango.freedesktop.org/Tango_Desktop_Project\
 "

--- a/dll/win32/syssetup/syssetup.rc
+++ b/dll/win32/syssetup/syssetup.rc
@@ -33,8 +33,7 @@ IDI_ICON5 ICON "resources/5.ico"
 
 STRINGTABLE
 BEGIN
-    IDS_ACKPROJECTS "\
-Wine - http://winehq.org\
+    IDS_ACKPROJECTS "Wine - http://winehq.org\
 \nFreeType - http://freetype.org\
 \nSYSLINUX - http://syslinux.zytor.com\
 \nMinGW - http://mingw.org\
@@ -43,7 +42,7 @@ Wine - http://winehq.org\
 \nadns - http://gnu.org/software/adns\
 \nICU - http://icu.unicode.org\
 \nGraphApp - http://enchantia.com/software/graphapp\
-\nExt2 - http://ext2fsd.com\
+\nExt2 - http://sourceforge.net/projects/ext2fsd\
 \nGNU FreeFont - http://savannah.gnu.org/projects/freefont\
 \nDejaVu Fonts - http://dejavu.sourceforge.net\
 \nLiberation(tm) Fonts - http://pagure.io/liberation-fonts\

--- a/dll/win32/syssetup/syssetup.rc
+++ b/dll/win32/syssetup/syssetup.rc
@@ -33,7 +33,23 @@ IDI_ICON5 ICON "resources/5.ico"
 
 STRINGTABLE
 BEGIN
-    IDS_ACKPROJECTS "Wine - http://www.winehq.org\nFreeType - http://www.freetype.org\nSYSLINUX - http://syslinux.zytor.com\nMinGW - http://www.mingw.org\nBochs - http://bochs.sourceforge.net\nMesa3D - http://www.mesa3d.org\nadns - http://www.gnu.org/software/adns\nICU - http://www.icu-project.org/\nGraphApp - http://enchantia.com/software/graphapp/\nExt2 - http://www.ext2fsd.com/\nGNU FreeFont - http://savannah.gnu.org/projects/freefont/\nDejaVu Fonts - http://dejavu.sourceforge.net\nLiberation(tm) Fonts - https://fedorahosted.org/liberation-fonts/\nBtrfs - https://github.com/maharmstone/btrfs\nTango Desktop Project - http://tango.freedesktop.org/Tango_Desktop_Project"
+    IDS_ACKPROJECTS "\
+Wine - http://www.winehq.org\
+\nFreeType - http://www.freetype.org\
+\nSYSLINUX - http://syslinux.zytor.com\
+\nMinGW - http://www.mingw.org\
+\nBochs - http://bochs.sourceforge.net\
+\nMesa3D - http://www.mesa3d.org\
+\nadns - http://www.gnu.org/software/adns\
+\nICU - http://www.icu-project.org\
+\nGraphApp - http://enchantia.com/software/graphapp\
+\nExt2 - http://www.ext2fsd.com\
+\nGNU FreeFont - http://savannah.gnu.org/projects/freefont\
+\nDejaVu Fonts - http://dejavu.sourceforge.net\
+\nLiberation(tm) Fonts - https://fedorahosted.org/liberation-fonts\
+\nBtrfs - https://github.com/maharmstone/btrfs\
+\nTango Desktop Project - http://tango.freedesktop.org/Tango_Desktop_Project\
+"
 END
 
 IDR_GPL RT_TEXT "COPYING"

--- a/media/doc/3rd Party Files.txt
+++ b/media/doc/3rd Party Files.txt
@@ -93,8 +93,8 @@ Path: drivers/filesystems/ext2
 Path: sdk/lib/fslib/ext2lib
 Used Version: 0.69
 License: GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later.html)
-URL: http://web.archive.org/web/20210516213924/http://www.ext2fsd.com
-URL: http://sourceforge.net/projects/ext2fsd
+URL: https://web.archive.org/web/20210516213924/http://www.ext2fsd.com
+URL: https://sourceforge.net/projects/ext2fsd
 
 Title: NFSv4.1 Client for Windows
 Path: base/services/nfsd

--- a/media/doc/3rd Party Files.txt
+++ b/media/doc/3rd Party Files.txt
@@ -93,7 +93,8 @@ Path: drivers/filesystems/ext2
 Path: sdk/lib/fslib/ext2lib
 Used Version: 0.69
 License: GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later.html)
-URL: http://www.ext2fsd.com
+URL: http://web.archive.org/web/20210516213924/http://www.ext2fsd.com
+URL: http://sourceforge.net/projects/ext2fsd
 
 Title: NFSv4.1 Client for Windows
 Path: base/services/nfsd


### PR DESCRIPTION
## Purpose

Improves URLs in 3 distinct steps for easy review:


* [SYSSETUP] syssetup.rc part1: Kill 'git blame s worst enemy in the project'

Reformat those URLs in a way that allows new lines to be added, or
existing lines to be removed or changed,
without the need to touch any neighbor line.
This will also allow git blame to work much better in the future.

No changes to the used URLs yet.


* [SYSSETUP] syssetup.rc part2: Fix 2 outdated URLs

http://www.icu-project.org -> http://icu.unicode.org
https://fedorahosted.org/liberation-fonts -> http://pagure.io/liberation-fonts


* [SYSSETUP] syssetup.rc part3: and finally tweak for size and consistency

I checked: all of the URLs do still work as good as before.

And for the record, both:
http://www.ext2fsd.com
and
http://ext2fsd.com
do behave the same and show something, that only with
a lot of fantasy can be called a website.
That did not change.


JIRA issue: none

Here is a video of the after-state:
[video-2023-10-20T02-06-36-890625000Z.webm](https://github.com/reactos/reactos/assets/33393466/c025928c-e6a5-41a9-971b-a64feb4822c9)
