### PR TITLE
[BDASUP][PORTCLS][SYSAUDIO][USB] Use ExAllocatePoolZero() and ExFreePoolWithTag()

### DIFF
--- a/drivers/multimedia/bdasup/bdasup.c
+++ b/drivers/multimedia/bdasup/bdasup.c
@@ -1,6 +1,8 @@
 
 #include "precomp.h"
 
+#define TAG_BDASUP 'SadB'
+
 const GUID KSPROPSETID_BdaPinControl = {0xded49d5, 0xa8b7, 0x4d5d, {0x97, 0xa1, 0x12, 0xb0, 0xc1, 0x95, 0x87, 0x4d}};
 const GUID KSMETHODSETID_BdaDeviceConfiguration = {0x71985f45, 0x1ca1, 0x11d3, {0x9c, 0xc8, 0x0, 0xc0, 0x4f, 0x79, 0x71, 0xe0}};
 const GUID KSPROPSETID_BdaTopology = {0xa14ee835, 0x0a23, 0x11d3, {0x9c, 0xc7, 0x0, 0xc0, 0x4f, 0x79, 0x71, 0xe0}};
@@ -23,7 +25,6 @@ KSPROPERTY_ITEM FilterPropertyItem[] =
     DEFINE_KSPROPERTY_ITEM_BDA_CONTROLLING_PIN_ID(BdaPropertyGetControllingPinId, NULL),
     DEFINE_KSPROPERTY_ITEM_BDA_NODE_DESCRIPTORS(BdaPropertyNodeDescriptors, NULL)
 };
-
 
 KSPROPERTY_SET FilterPropertySet =
 {
@@ -90,27 +91,20 @@ KSAUTOMATION_TABLE PinAutomationTable =
     NULL
 };
 
-
 PVOID
 AllocateItem(
     IN POOL_TYPE PoolType,
     IN SIZE_T NumberOfBytes)
 {
-    PVOID Item = ExAllocatePool(PoolType, NumberOfBytes);
-    if (!Item)
-        return Item;
-
-    RtlZeroMemory(Item, NumberOfBytes);
-    return Item;
+    return ExAllocatePoolZero(PoolType, NumberOfBytes, TAG_BDASUP);
 }
 
 VOID
 FreeItem(
     IN PVOID Item)
 {
-    ExFreePool(Item);
+    ExFreePoolWithTag(Item, TAG_BDASUP);
 }
-
 
 PBDA_FILTER_INSTANCE_ENTRY
 GetFilterInstanceEntry(
@@ -140,7 +134,6 @@ GetFilterInstanceEntry(
         /* set to null as it has not been found */
         InstanceEntry = NULL;
     }
-
 
     /* release spin lock */
     KeReleaseSpinLock(&g_Settings.FilterFactoryInstanceListLock, OldLevel);
@@ -245,7 +238,6 @@ FreeFilterInstance(
     KeReleaseSpinLock(&g_Settings.FilterFactoryInstanceListLock, OldLevel);
 }
 
-
 /*
     @implemented
 */
@@ -338,7 +330,6 @@ BdaCreateFilterFactoryEx(
 
         /* release spin lock */
         KeReleaseSpinLock(&g_Settings.FilterFactoryInstanceListLock, OldLevel);
-
 
         if (ppKSFilterFactory)
         {
@@ -450,7 +441,6 @@ BdaCreatePin(
         }
     }
 
-
     DPRINT("BdaCreatePin Result %x PinId %u\n", Status, PinId);
     return Status;
 }
@@ -542,8 +532,6 @@ BdaInitFilter(
     /* done */
     return Status;
 }
-
-
 
 /*
     @implemented

--- a/drivers/usb/usbccgp/misc.c
+++ b/drivers/usb/usbccgp/misc.c
@@ -95,17 +95,8 @@ AllocateItem(
     IN POOL_TYPE PoolType,
     IN ULONG ItemSize)
 {
-    /* Allocate item */
-    PVOID Item = ExAllocatePoolWithTag(PoolType, ItemSize, USBCCPG_TAG);
-
-    if (Item)
-    {
-        /* Zero item */
-        RtlZeroMemory(Item, ItemSize);
-    }
-
-    /* Return element */
-    return Item;
+    /* Allocate, zero and return item */
+    return ExAllocatePoolZero(PoolType, ItemSize, USBCCPG_TAG);
 }
 
 VOID
@@ -122,7 +113,6 @@ DumpFunctionDescriptor(
     IN ULONG FunctionDescriptorCount)
 {
     ULONG Index, SubIndex;
-
 
     DPRINT("FunctionCount %lu\n", FunctionDescriptorCount);
     for (Index = 0; Index < FunctionDescriptorCount; Index++)

--- a/drivers/usb/usbstor/misc.c
+++ b/drivers/usb/usbstor/misc.c
@@ -12,7 +12,6 @@
 #define NDEBUG
 #include <debug.h>
 
-
 IO_COMPLETION_ROUTINE SyncForwardIrpCompletionRoutine;
 
 NTSTATUS
@@ -126,14 +125,7 @@ AllocateItem(
     IN POOL_TYPE PoolType,
     IN ULONG ItemSize)
 {
-    PVOID Item = ExAllocatePoolWithTag(PoolType, ItemSize, USB_STOR_TAG);
-
-    if (Item)
-    {
-        RtlZeroMemory(Item, ItemSize);
-    }
-
-    return Item;
+    return ExAllocatePoolZero(PoolType, ItemSize, USB_STOR_TAG);
 }
 
 VOID

--- a/drivers/usb/usbstor_new/misc.c
+++ b/drivers/usb/usbstor_new/misc.c
@@ -55,7 +55,6 @@ USBSTOR_SyncForwardIrp(PDEVICE_OBJECT DeviceObject, PIRP Irp)
     //
     IoSetCompletionRoutine(Irp, USBSTOR_SyncForwardIrpCompletionRoutine, &Event, TRUE, TRUE, TRUE);
 
-
     //
     // call driver
     //
@@ -101,12 +100,10 @@ USBSTOR_GetBusInterface(
     ASSERT(DeviceObject);
     ASSERT(BusInterface);
 
-
     //
     // initialize event
     //
     KeInitializeEvent(&Event, NotificationEvent, FALSE);
-
 
     //
     // create irp
@@ -194,7 +191,6 @@ USBSTOR_SyncUrbRequest(
     //
     KeInitializeEvent(&Event, NotificationEvent, FALSE);
 
-
     //
     // get next stack location
     //
@@ -252,22 +248,9 @@ AllocateItem(
     IN ULONG ItemSize)
 {
     //
-    // allocate item
+    // allocate, zero and return item
     //
-    PVOID Item = ExAllocatePoolWithTag(PoolType, ItemSize, USB_STOR_TAG);
-
-    if (Item)
-    {
-        //
-        // zero item
-        //
-        RtlZeroMemory(Item, ItemSize);
-    }
-
-    //
-    // return element
-    //
-    return Item;
+    return ExAllocatePoolZero(PoolType, ItemSize, USB_STOR_TAG);
 }
 
 VOID
@@ -332,7 +315,6 @@ USBSTOR_ClassRequest(
     //
     return Status;
 }
-
 
 NTSTATUS
 USBSTOR_GetMaxLUN(

--- a/drivers/wdm/audio/backpln/portcls/pool.cpp
+++ b/drivers/wdm/audio/backpln/portcls/pool.cpp
@@ -11,7 +11,6 @@
 #ifndef YDEBUG
 #define NDEBUG
 #endif
-
 #include <debug.h>
 
 PVOID
@@ -20,12 +19,7 @@ AllocateItem(
     IN SIZE_T NumberOfBytes,
     IN ULONG Tag)
 {
-    PVOID Item = ExAllocatePoolWithTag(PoolType, NumberOfBytes, Tag);
-    if (!Item)
-        return Item;
-
-    RtlZeroMemory(Item, NumberOfBytes);
-    return Item;
+    return ExAllocatePoolZero(PoolType, NumberOfBytes, Tag);
 }
 
 VOID
@@ -33,6 +27,5 @@ FreeItem(
     IN PVOID Item,
     IN ULONG Tag)
 {
-
     ExFreePoolWithTag(Item, Tag);
 }

--- a/drivers/wdm/audio/sysaudio/main.c
+++ b/drivers/wdm/audio/sysaudio/main.c
@@ -14,6 +14,8 @@
 #define NDEBUG
 #include <debug.h>
 
+#define TAG_SYSAUDIO 'AsyS'
+
 const GUID KSCATEGORY_SYSAUDIO                 = {0xA7C7A5B1L, 0x5AF3, 0x11D1, {0x9C, 0xED, 0x00, 0xA0, 0x24, 0xBF, 0x04, 0x07}};
 const GUID KSCATEGORY_AUDIO_DEVICE             = {0xFBF6F530L, 0x07B9, 0x11D2, {0xA7, 0x1E, 0x00, 0x00, 0xF8, 0x00, 0x47, 0x88}};
 const GUID KSCATEGORY_PREFERRED_WAVEOUT_DEVICE = {0xD6C5066EL, 0x72C1, 0x11D2, {0x97, 0x55, 0x00, 0x00, 0xF8, 0x00, 0x47, 0x88}};
@@ -25,21 +27,15 @@ AllocateItem(
     IN POOL_TYPE PoolType,
     IN SIZE_T NumberOfBytes)
 {
-    PVOID Item = ExAllocatePool(PoolType, NumberOfBytes);
-    if (!Item)
-        return Item;
-
-    RtlZeroMemory(Item, NumberOfBytes);
-    return Item;
+    return ExAllocatePoolZero(PoolType, NumberOfBytes, TAG_SYSAUDIO);
 }
 
 VOID
 FreeItem(
     IN PVOID Item)
 {
-    ExFreePool(Item);
+    ExFreePoolWithTag(Item, TAG_SYSAUDIO);
 }
-
 
 VOID
 NTAPI
@@ -87,7 +83,6 @@ SysAudio_Shutdown(
     IoCompleteRequest(Irp, IO_NO_INCREMENT);
     return STATUS_SUCCESS;
 }
-
 
 NTSTATUS
 NTAPI
@@ -221,7 +216,6 @@ SysAudio_AddDevice(
 
      /* register shutdown notification */
      IoRegisterShutdownNotification(DeviceObject);
-
 
     /* Done */
     return STATUS_SUCCESS;


### PR DESCRIPTION
## Purpose

Simpler and more secure code.

Follow-up of #5792.

## Proposed changes

- Use ExAllocatePoolZero() and ExFreePoolWithTag()