### PR TITLE
[UXTHEME] Implement the rest of DrawNCPreview

### DIFF
--- a/dll/cpl/desk/theme.c
+++ b/dll/cpl/desk/theme.c
@@ -997,7 +997,8 @@ DrawThemePreview(IN HDC hdcMem, IN PCOLOR_SCHEME scheme, IN PTHEME_SELECTION pSe
     FillRect(hdcMem, prcWindow, hbrBack);
     DeleteObject(hbrBack);
 
-    InflateRect(prcWindow, -10, -10);
+    InflateRect(prcWindow, -8, -8);
+    prcWindow->bottom -= 12;
 
     hres = DrawNCPreview(hdcMem,
                          DNCP_DRAW_ALL,

--- a/dll/win32/uxtheme/uxthemep.h
+++ b/dll/win32/uxtheme/uxthemep.h
@@ -258,7 +258,9 @@ typedef enum {
 
 LRESULT CALLBACK ThemeWndProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam, WNDPROC DefWndProc);
 void ThemeCalculateCaptionButtonsPos(HWND hWnd, HTHEME htheme);
-void  ThemeDrawScrollBar(PDRAW_CONTEXT pcontext, INT Bar, POINT* pt);
+LONG SCROLL_getObjectId(INT nBar);
+void ThemeDrawScrollBarEx(PDRAW_CONTEXT pcontext, INT nBar, PSCROLLBARINFO psbi, POINT* pt);
+void ThemeDrawScrollBar(PDRAW_CONTEXT pcontext, INT Bar, POINT* pt);
 VOID NC_TrackScrollBar(HWND Wnd, WPARAM wParam, POINT Pt);
 void ThemeInitDrawContext(PDRAW_CONTEXT pcontext, HWND hWnd, HRGN hRgn);
 void ThemeCleanupDrawContext(PDRAW_CONTEXT pcontext);


### PR DESCRIPTION
## Purpose

![Draw the rest of the NCPreview](https://i.imgur.com/tnGwI1i.png)
- Metrics and colours from the theme specified in the `pszThemeFileName`/`pszColorName`/`pszSizeName` parameters are now used, instead of the existing system metrics/colours
- The existing active preview window now has a client area, featuring a preview scrollbar and some preview text
- An inactive preview window is now drawn behind the active preview window
- A preview dialog window is now drawn in front of the active preview window, featuring a preview button

## JIRA issue
- [CORE-5991](https://jira.reactos.org/browse/CORE-5991)

## TODO

- [x] Enable scrollbar in preview
- [x] Localization? (shelved for a future PR, apparently)
- [x] Window border widths (may be out of scope due to..._other_ problems regarding window border sizing...)
- [x] Address inexplicably-red window body text
- [x] Address visible flicker of "dummy" windows