### PR TITLE
[RTL/x64] Handle STATUS_UNWIND_CONSOLIDATE in RtlRestoreContext

### DIFF
--- a/sdk/lib/rtl/amd64/except_asm.S
+++ b/sdk/lib/rtl/amd64/except_asm.S
@@ -107,22 +107,19 @@ PUBLIC RtlCaptureContext
 .ENDP
 
 /*
- * VOID NTAPI
- * RtlRestoreContext(
- *     _In_ PCONTEXT ContextRecord@<rcx>,
- *     PEXCEPTION_RECORD *ExceptionRecord@<rdx>);
+ * VOID
+ * RtlpRestoreContextInternal(
+ *     _In_ PCONTEXT ContextRecord@<rcx>);
  */
-PUBLIC RtlRestoreContext
-.PROC RtlRestoreContext
+PUBLIC RtlpRestoreContextInternal
+.PROC RtlpRestoreContextInternal
 
     /* Allocate space */
     sub rsp, HEX(8)
     .ALLOCSTACK 8
     .ENDPROLOG
 
-    // TODO: Handle ExceptionRecord
-
-    /* Restore legacy floating point registers (It's slow, so do it first) */
+    /* Restore legacy floating point registers (It is slow, so do it first) */
     ldmxcsr [rcx + CxMxCsr]
     fxrstor [rcx + CxFltSave]
 

--- a/sdk/lib/rtl/amd64/unwind.c
+++ b/sdk/lib/rtl/amd64/unwind.c
@@ -1132,3 +1132,26 @@ RtlSetUnwindContext(
     *ContextPointers.Xmm14 = Context->Xmm14;
     *ContextPointers.Xmm15 = Context->Xmm15;
 }
+
+VOID
+RtlpRestoreContextInternal(
+    _In_ PCONTEXT ContextRecord);
+
+VOID
+RtlRestoreContext(
+    _In_ PCONTEXT ContextRecord,
+    _In_ PEXCEPTION_RECORD ExceptionRecord)
+{
+    if (ExceptionRecord != NULL)
+    {
+        if ((ExceptionRecord->ExceptionCode == STATUS_UNWIND_CONSOLIDATE) &&
+            (ExceptionRecord->NumberParameters >= 1))
+        {
+            PVOID (*Consolidate)(EXCEPTION_RECORD*) = (PVOID)ExceptionRecord->ExceptionInformation[0];
+            // FIXME: This should be called through an asm wrapper to allow handling recursive unwinding
+            ContextRecord->Rip = (ULONG64)Consolidate(ExceptionRecord);
+        }
+    }
+
+    RtlpRestoreContextInternal(ContextRecord);
+}


### PR DESCRIPTION
Code is inspired by wine code. It's not entirely correct yet and will probably fail on recursive c++ exceptions, but it fixes basic c++ exception handling.

## Tests
✅ MSVC_x64 on Test KVM_x64: https://reactos.org/testman/compare.php?ids=94601,94605,94609,94623,94628
