### PR TITLE
[BDASUP][KMIXER][MMIXER][STREAM] Replace meaningless YDEBUG

### DIFF
--- a/drivers/multimedia/bdasup/precomp.h
+++ b/drivers/multimedia/bdasup/precomp.h
@@ -10,7 +10,7 @@
 #include <bdamedia.h>
 #include <bdasup.h>
 
-#define YDEBUG
+// #define NDEBUG
 #include <debug.h>
 
 

--- a/drivers/wdm/audio/filters/kmixer/filter.c
+++ b/drivers/wdm/audio/filters/kmixer/filter.c
@@ -10,7 +10,7 @@
 
 #include <swenum.h>
 
-#define YDEBUG
+// #define NDEBUG
 #include <debug.h>
 
 NTSTATUS
@@ -199,4 +199,3 @@ KMixAllocateDeviceHeader(
                                     CreateItem);
     return Status;
 }
-

--- a/drivers/wdm/audio/filters/kmixer/kmixer.c
+++ b/drivers/wdm/audio/filters/kmixer/kmixer.c
@@ -8,7 +8,7 @@
 
 #include "kmixer.h"
 
-#define YDEBUG
+// #define NDEBUG
 #include <debug.h>
 
 NTSTATUS
@@ -72,7 +72,6 @@ KMix_AddDevice(
     /* initialize device extension */
     RtlZeroMemory(DeviceExtension, sizeof(KMIXER_DEVICE_EXT));
 
-
     Status = KMixAllocateDeviceHeader(DeviceExtension);
     if (!NT_SUCCESS(Status))
     {
@@ -97,7 +96,6 @@ cleanup:
     IoDeleteDevice(DeviceObject);
     return Status;
 }
-
 
 NTSTATUS
 NTAPI

--- a/drivers/wdm/audio/legacy/stream/stream.h
+++ b/drivers/wdm/audio/legacy/stream/stream.h
@@ -1,7 +1,8 @@
 #pragma once
 
 #include <strmini.h>
-#define YDEBUG
+
+// #define NDEBUG
 #include <debug.h>
 
 #define STREAMDEBUG_LEVEL DebugLevelMaximum

--- a/sdk/lib/drivers/sound/mmixer/controls.c
+++ b/sdk/lib/drivers/sound/mmixer/controls.c
@@ -8,7 +8,7 @@
 
 #include "precomp.h"
 
-#define YDEBUG
+// #define NDEBUG
 #include <debug.h>
 
 const GUID KSNODETYPE_DESKTOP_MICROPHONE = {0xDFF21BE2, 0xF70F, 0x11D0, {0xB9, 0x17, 0x00, 0xA0, 0xC9, 0x22, 0x31, 0x96}};
@@ -55,7 +55,6 @@ MMixerAddMixerControl(
         /* no memory */
         return MM_STATUS_NO_MEMORY;
     }
-
 
     /* initialize mixer control */
     MixerControl->hDevice = hMixer;
@@ -262,7 +261,6 @@ MMixerCreateDestinationLine(
     DestinationLine->Line.dwSource = MAXULONG;
     DestinationLine->Line.dwUser = 0;
     DestinationLine->Line.fdwLine = MIXERLINE_LINEF_ACTIVE;
-
 
     if (LineName)
     {
@@ -564,7 +562,6 @@ MMixerGetChannelCountEnhanced(
     Request.Property.Flags = KSPROPERTY_TYPE_BASICSUPPORT | KSPROPERTY_TYPE_TOPOLOGY;
     Request.Property.Id = KSPROPERTY_AUDIO_VOLUMELEVEL;
 
-
     /* get description */
     Status = MixerContext->Control(hMixer, IOCTL_KS_PROPERTY, (PVOID)&Request, sizeof(KSP_NODE), (PVOID)&Description, sizeof(KSPROPERTY_DESCRIPTION), &BytesReturned);
     if (Status == MM_STATUS_SUCCESS)
@@ -771,7 +768,6 @@ MMixerGetComponentAndTargetType(
     Request.Property.Flags = KSPROPERTY_TYPE_GET;
     Request.Property.Set = KSPROPSETID_Pin;
     Request.Property.Id = KSPROPERTY_PIN_CATEGORY;
-
 
     /* get pin category */
     Status = MixerContext->Control(hMixer, IOCTL_KS_PROPERTY, (PVOID)&Request, sizeof(KSP_PIN), &Guid, sizeof(GUID), &BytesReturned);
@@ -1162,7 +1158,6 @@ MMixerAddMixerSourceLines(
 
     return MM_STATUS_SUCCESS;
 }
-
 
 MIXER_STATUS
 MMixerAddMixerControlsToDestinationLine(
@@ -1623,7 +1618,6 @@ MMixerInitializeFilter(
         }
     }
 
-
     /* now get the bridge pin which is at the end of node path
      * For sink pins (wave out) search down stream
      * For source pins (wave in) search up stream
@@ -1828,7 +1822,6 @@ MMixerSetupFilter(
     /* done */
     return Status;
 }
-
 
 MIXER_STATUS
 MMixerAddEvent(

--- a/sdk/lib/drivers/sound/mmixer/filter.c
+++ b/sdk/lib/drivers/sound/mmixer/filter.c
@@ -8,7 +8,7 @@
 
 #include "precomp.h"
 
-#define YDEBUG
+// #define NDEBUG
 #include <debug.h>
 
 ULONG

--- a/sdk/lib/drivers/sound/mmixer/midi.c
+++ b/sdk/lib/drivers/sound/mmixer/midi.c
@@ -8,7 +8,7 @@
 
 #include "precomp.h"
 
-#define YDEBUG
+// #define NDEBUG
 #include <debug.h>
 
 MIXER_STATUS

--- a/sdk/lib/drivers/sound/mmixer/mixer.c
+++ b/sdk/lib/drivers/sound/mmixer/mixer.c
@@ -8,7 +8,7 @@
 
 #include "precomp.h"
 
-#define YDEBUG
+// #define NDEBUG
 #include <debug.h>
 
 ULONG
@@ -105,7 +105,6 @@ MMixerOpen(
 
     /* add the event */
     Status = MMixerAddEvent(MixerContext, MixerInfo, MixerEventContext, MixerEventRoutine);
-
 
     /* store result */
     *MixerHandle = (HANDLE)MixerInfo;
@@ -686,7 +685,6 @@ MMixerPrintMixers(
     DPRINT1("WaveInCount %lu\n", MixerList->WaveInListCount);
     DPRINT1("WaveOutCount %lu\n", MixerList->WaveOutListCount);
     DPRINT1("MixerCount %p\n", MixerList->MixerListCount);
-
 
     for(Index = 0; Index < MixerList->MixerListCount; Index++)
     {

--- a/sdk/lib/drivers/sound/mmixer/sup.c
+++ b/sdk/lib/drivers/sound/mmixer/sup.c
@@ -8,7 +8,7 @@
 
 #include "precomp.h"
 
-#define YDEBUG
+// #define NDEBUG
 #include <debug.h>
 
 const GUID KSNODETYPE_SUM = {0xDA441A60L, 0xC556, 0x11D0, {0x8A, 0x2B, 0x00, 0xA0, 0xC9, 0x25, 0x5A, 0xC1}};
@@ -35,7 +35,6 @@ const GUID KSEVENTSETID_AudioControlChange      = {0xE85E9698L, 0xFA2F, 0x11D1, 
 const GUID KSDATAFORMAT_TYPE_MUSIC = {0xE725D360L, 0x62CC, 0x11CF, {0xA5, 0xD6, 0x28, 0xDB, 0x04, 0xC1, 0x00, 0x00}};
 const GUID KSDATAFORMAT_SUBTYPE_MIDI = {0x1D262760L, 0xE957, 0x11CF, {0xA5, 0xD6, 0x28, 0xDB, 0x04, 0xC1, 0x00, 0x00}};
 const GUID KSDATAFORMAT_SPECIFIER_NONE = {0x0F6417D6L, 0xC318, 0x11D0, {0xA4, 0x3F, 0x00, 0xA0, 0xC9, 0x22, 0x31, 0x96}};
-
 
 MIXER_STATUS
 MMixerVerifyContext(
@@ -125,7 +124,6 @@ MMixerFreeMixerInfo(
     MixerContext->Free((PVOID)MixerInfo);
 }
 
-
 LPMIXER_DATA
 MMixerGetMixerDataByDeviceHandle(
     IN PMIXER_CONTEXT MixerContext,
@@ -155,7 +153,6 @@ MMixerGetMixerDataByDeviceHandle(
     }
     return NULL;
 }
-
 
 LPMIXER_INFO
 MMixerGetMixerInfoByIndex(

--- a/sdk/lib/drivers/sound/mmixer/topology.c
+++ b/sdk/lib/drivers/sound/mmixer/topology.c
@@ -8,7 +8,7 @@
 
 #include "precomp.h"
 
-#define YDEBUG
+// #define NDEBUG
 #include <debug.h>
 
 VOID
@@ -37,10 +37,7 @@ MMixerPrintTopology(
             Topology->TopologyNodes[Index].NodeConnectedFromCount, Topology->TopologyNodes[Index].NodeConnectedToCount, Topology->TopologyNodes[Index].Visited,
             Topology->TopologyNodes[Index].PinConnectedFromCount, Topology->TopologyNodes[Index].PinConnectedToCount);
     }
-
-
 }
-
 
 MIXER_STATUS
 MMixerAllocateTopology(
@@ -708,7 +705,6 @@ MMixerGetNodeIndexFromGuid(
     return MAXULONG;
 }
 
-
 VOID
 MMixerGetAllUpOrDownstreamPinsFromNodeIndex(
     IN PMIXER_CONTEXT MixerContext,
@@ -848,7 +844,6 @@ MMixerGetAllUpOrDownstreamPinsFromPinIndex(
         TopologyPinsCount = Pin->PinConnectedToCount;
     }
 
-
     /* reset visited status */
     MMixerResetTopologyVisitStatus(Topology);
 
@@ -906,7 +901,6 @@ MMixerGetAllUpOrDownstreamNodesFromPinIndex(
         TopologyNodesCount = Pin->NodesConnectedToCount;
     }
 
-
     /* reset visited status */
     MMixerResetTopologyVisitStatus(Topology);
 
@@ -923,7 +917,6 @@ MMixerGetAllUpOrDownstreamNodesFromPinIndex(
         MMixerGetAllUpOrDownstreamNodesFromNodeIndex(MixerContext, Topology, TopologyNodes[Index]->NodeIndex, bUpStream, OutNodesCount, OutNodes);
     }
 }
-
 
 VOID
 MMixerGetNextNodesFromPinIndex(
@@ -1247,7 +1240,6 @@ MMixerIsTopologyNodeReserved(
     /* get reserved status */
     *bReserved = Topology->TopologyNodes[NodeIndex].Reserved;
 }
-
 
 MIXER_STATUS
 MMixerCreateTopology(

--- a/sdk/lib/drivers/sound/mmixer/wave.c
+++ b/sdk/lib/drivers/sound/mmixer/wave.c
@@ -8,7 +8,7 @@
 
 #include "precomp.h"
 
-#define YDEBUG
+// #define NDEBUG
 #include <debug.h>
 
 const GUID KSPROPSETID_Connection               = {0x1D58C920L, 0xAC9B, 0x11CF, {0xA5, 0xD6, 0x28, 0xDB, 0x04, 0xC1, 0x00, 0x00}};
@@ -111,9 +111,6 @@ MMixerGetWaveInfoByIndexAndType(
     return MM_STATUS_INVALID_PARAMETER;
 }
 
-
-
-
 VOID
 MMixerInitializeDataFormat(
     IN PKSDATAFORMAT_WAVEFORMATEX DataFormat,
@@ -136,7 +133,6 @@ MMixerInitializeDataFormat(
     DataFormat->DataFormat.Specifier = KSDATAFORMAT_SPECIFIER_WAVEFORMATEX;
     DataFormat->DataFormat.SampleSize = 4;
 }
-
 
 MIXER_STATUS
 MMixerGetAudioPinDataRanges(
@@ -307,7 +303,6 @@ MMixerCheckFormat(
                 /* check if pin supports the sample rate in 16-Bit Mono */
                 Result |= TestRange[Index].Bit16Mono;
 
-
                 if (DataRangeAudio->MaximumChannels > 1)
                 {
                     /* check if pin supports the sample rate in 16-Bit Stereo */
@@ -316,7 +311,6 @@ MMixerCheckFormat(
             }
         }
     }
-
 
     if (bInput)
         WaveInfo->u.InCaps.dwFormats = Result;


### PR DESCRIPTION
## Purpose

Code cleanup.

bdasup: Addendum to 40c15ec (r46632).
kmixer: Addendum to 3e489bf (r42143).
mmixer: Addendum to c42d9f2 (r44872).
stream: Addendum to 4a0debf (r41662).

## Proposed changes

- Replace `YDEBUG` by commented out `NDEBUG`.