### PR TITLE
[SHELL32][SHELLEXT] IEnumIDList::Next must handle pceltFetched and memory errors correctly

### DIFF
--- a/dll/shellext/netshell/enumlist.cpp
+++ b/dll/shellext/netshell/enumlist.cpp
@@ -277,9 +277,17 @@ CEnumIDList::Next(
     for (i = 0; i < celt; i++)
     {
         if (!m_pCurrent)
+        {
+            hr = S_FALSE;
             break;
+        }
 
         temp = ILClone(m_pCurrent->pidl);
+        if (!temp)
+        {
+            hr = i ? S_FALSE : E_OUTOFMEMORY;
+            break;
+        }
         rgelt[i] = temp;
         m_pCurrent = m_pCurrent->pNext;
     }

--- a/dll/win32/shell32/CEnumIDListBase.cpp
+++ b/dll/win32/shell32/CEnumIDListBase.cpp
@@ -172,9 +172,15 @@ HRESULT WINAPI CEnumIDListBase::Next(
 
     for(i = 0; i < celt; i++)
     { if(!mpCurrent)
+      { hr = S_FALSE;
         break;
+      }
 
       temp = ILClone(mpCurrent->pidl);
+      if (!temp)
+      { hr = i ? S_FALSE : E_OUTOFMEMORY;
+        break;
+      }
       rgelt[i] = temp;
       mpCurrent = mpCurrent->pNext;
     }


### PR DESCRIPTION
- pceltFetched can be NULL if the caller is not requesting multiple items.
- All entries returned in rgelt must be valid, they cannot be NULL.
- Pardon the `{ hr = S_FALSE;`... code, that is the actual style used there.