### PR TITLE
[SDK] Add Wine <pathcch.h> header to psdk

### DIFF
--- a/sdk/include/psdk/pathcch.h
+++ b/sdk/include/psdk/pathcch.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 Michael Müller
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#define PATHCCH_NONE                            0x00
+#define PATHCCH_ALLOW_LONG_PATHS                0x01
+#define PATHCCH_FORCE_ENABLE_LONG_NAME_PROCESS  0x02
+#define PATHCCH_FORCE_DISABLE_LONG_NAME_PROCESS 0x04
+#define PATHCCH_DO_NOT_NORMALIZE_SEGMENTS       0x08
+#define PATHCCH_ENSURE_IS_EXTENDED_LENGTH_PATH  0x10
+#define PATHCCH_ENSURE_TRAILING_SLASH           0x20
+
+#define PATHCCH_MAX_CCH 0x8000
+
+HRESULT WINAPI PathAllocCanonicalize(const WCHAR *path_in, DWORD flags, WCHAR **path_out);
+HRESULT WINAPI PathAllocCombine(const WCHAR *path1, const WCHAR *path2, DWORD flags, WCHAR **out);
+HRESULT WINAPI PathCchAddBackslash(WCHAR *path, SIZE_T size);
+HRESULT WINAPI PathCchAddBackslashEx(WCHAR *path, SIZE_T size, WCHAR **end, SIZE_T *remaining);
+HRESULT WINAPI PathCchAddExtension(WCHAR *path, SIZE_T size, const WCHAR *extension);
+HRESULT WINAPI PathCchAppend(WCHAR *path1, SIZE_T size, const WCHAR *path2);
+HRESULT WINAPI PathCchAppendEx(WCHAR *path1, SIZE_T size, const WCHAR *path2, DWORD flags);
+HRESULT WINAPI PathCchCanonicalize(WCHAR *out, SIZE_T size, const WCHAR *in);
+HRESULT WINAPI PathCchCanonicalizeEx(WCHAR *out, SIZE_T size, const WCHAR *in, DWORD flags);
+HRESULT WINAPI PathCchCombine(WCHAR *out, SIZE_T size, const WCHAR *path1, const WCHAR *path2);
+HRESULT WINAPI PathCchCombineEx(WCHAR *out, SIZE_T size, const WCHAR *path1, const WCHAR *path2, DWORD flags);
+HRESULT WINAPI PathCchFindExtension(const WCHAR *path, SIZE_T size, const WCHAR **extension);
+BOOL    WINAPI PathCchIsRoot(const WCHAR *path);
+HRESULT WINAPI PathCchRemoveBackslash(WCHAR *path, SIZE_T path_size);
+HRESULT WINAPI PathCchRemoveBackslashEx(WCHAR *path, SIZE_T path_size, WCHAR **path_end, SIZE_T *free_size);
+HRESULT WINAPI PathCchRemoveExtension(WCHAR *path, SIZE_T size);
+HRESULT WINAPI PathCchRemoveFileSpec(WCHAR *path, SIZE_T size);
+HRESULT WINAPI PathCchRenameExtension(WCHAR *path, SIZE_T size, const WCHAR *extension);
+HRESULT WINAPI PathCchSkipRoot(const WCHAR *path, const WCHAR **root_end);
+HRESULT WINAPI PathCchStripPrefix(WCHAR *path, SIZE_T size);
+HRESULT WINAPI PathCchStripToRoot(WCHAR *path, SIZE_T size);
+BOOL    WINAPI PathIsUNCEx(const WCHAR *path, const WCHAR **server);

--- a/sdk/tools/winesync/pathcch.cfg
+++ b/sdk/tools/winesync/pathcch.cfg
@@ -1,3 +1,4 @@
+directories:
 files:
   include/pathcch.h: sdk/include/psdk/pathcch.h
 tags:

--- a/sdk/tools/winesync/pathcch.cfg
+++ b/sdk/tools/winesync/pathcch.cfg
@@ -1,0 +1,4 @@
+files:
+  include/pathcch.h: sdk/include/psdk/pathcch.h
+tags:
+  wine: wine-8.18

--- a/sdk/tools/winesync/wininet.cfg
+++ b/sdk/tools/winesync/wininet.cfg
@@ -2,6 +2,7 @@ directories:
   dlls/wininet: dll/win32/wininet
   dlls/wininet/tests: modules/rostests/winetests/wininet
 files:
+  include/pathcch.h: sdk/include/psdk/pathcch.h
   include/wininet.h: sdk/include/psdk/wininet.h
   include/winineti.h: sdk/include/psdk/winineti.h
 tags:

--- a/sdk/tools/winesync/wininet.cfg
+++ b/sdk/tools/winesync/wininet.cfg
@@ -2,7 +2,6 @@ directories:
   dlls/wininet: dll/win32/wininet
   dlls/wininet/tests: modules/rostests/winetests/wininet
 files:
-  include/pathcch.h: sdk/include/psdk/pathcch.h
   include/wininet.h: sdk/include/psdk/wininet.h
   include/winineti.h: sdk/include/psdk/winineti.h
 tags:


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-12686](https://jira.reactos.org/browse/CORE-12686)

## Proposed changes

- Borrow Wine `<pathcch.h>` header (`include\pathcch.h`).
- Add Wine sync (`sdk/tools/winesync/pathcch.cfg`).