### PR TITLE
[REGEDIT] Use <strsafe.h> functions strictly

### DIFF
--- a/base/applications/regedit/childwnd.c
+++ b/base/applications/regedit/childwnd.c
@@ -177,7 +177,7 @@ static void SuggestKeys(HKEY hRootKey, LPCWSTR pszKeyPath, LPWSTR pszSuggestions
                         RegCloseKey(hOtherKey);
 
                         bFound = TRUE;
-                        wcscpy(szLastFound, szBuffer);
+                        StringCbCopyW(szLastFound, sizeof(szLastFound), szBuffer);
                         pszKeyPath = szLastFound;
                     }
                 }
@@ -258,10 +258,11 @@ UpdateAddress(HTREEITEM hItem, HKEY hRootKey, LPCWSTR pszPath, BOOL bSelectNone)
         if (fullPath)
         {
             /* set (correct) the address bar text */
-            if (keyPath[0] != L'\0')
-                swprintf(fullPath, L"%s%s%s", rootName, keyPath[0]==L'\\'?L"":L"\\", keyPath);
+            if (keyPath[0] != UNICODE_NULL)
+                StringCbPrintfW(fullPath, cbFullPath, L"%s%s%s", rootName,
+                                ((keyPath[0] == L'\\') ? L"" : L"\\"), keyPath);
             else
-                fullPath = wcscpy(fullPath, rootName);
+                StringCbCopyW(fullPath, cbFullPath, rootName);
 
             SendMessageW(hStatusBar, SB_SETTEXTW, 0, (LPARAM)fullPath);
             SendMessageW(g_pChildWnd->hAddressBarWnd, WM_SETTEXT, 0, (LPARAM)fullPath);

--- a/base/applications/regedit/edit.c
+++ b/base/applications/regedit/edit.c
@@ -50,10 +50,10 @@ void error(HWND hwnd, INT resId, ...)
     hInstance = GetModuleHandle(0);
 
     if (!LoadStringW(hInstance, IDS_ERROR, title, ARRAY_SIZE(title)))
-        wcscpy(title, L"Error");
+        StringCbCopyW(title, sizeof(title), L"Error");
 
     if (!LoadStringW(hInstance, resId, errfmt, ARRAY_SIZE(errfmt)))
-        wcscpy(errfmt, L"Unknown error string!");
+        StringCbCopyW(errfmt, sizeof(errfmt), L"Unknown error string!");
 
     va_start(ap, resId);
     _vsnwprintf(errstr, ARRAY_SIZE(errstr), errfmt, ap);
@@ -66,7 +66,7 @@ static void error_code_messagebox(HWND hwnd, DWORD error_code)
 {
     WCHAR title[256];
     if (!LoadStringW(hInst, IDS_ERROR, title, ARRAY_SIZE(title)))
-        wcscpy(title, L"Error");
+        StringCbCopyW(title, sizeof(title), L"Error");
     ErrorMessageBox(hwnd, title, error_code);
 }
 
@@ -81,13 +81,13 @@ void warning(HWND hwnd, INT resId, ...)
     hInstance = GetModuleHandle(0);
 
     if (!LoadStringW(hInstance, IDS_WARNING, title, ARRAY_SIZE(title)))
-        wcscpy(title, L"Warning");
+        StringCbCopyW(title, sizeof(title), L"Warning");
 
     if (!LoadStringW(hInstance, resId, errfmt, ARRAY_SIZE(errfmt)))
-        wcscpy(errfmt, L"Unknown error string!");
+        StringCbCopyW(errfmt, sizeof(errfmt), L"Unknown error string!");
 
     va_start(ap, resId);
-    _vsnwprintf(errstr, ARRAY_SIZE(errstr), errfmt, ap);
+    StringCbVPrintfW(errstr, sizeof(errstr), errfmt, ap);
     va_end(ap);
 
     MessageBoxW(hwnd, errstr, title, MB_OK | MB_ICONSTOP);
@@ -304,7 +304,7 @@ INT_PTR CALLBACK modify_dword_dlgproc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LP
             SetDlgItemTextW(hwndDlg, IDC_VALUE_NAME, buffer);
         }
         CheckRadioButton (hwndDlg, IDC_FORMAT_HEX, IDC_FORMAT_DEC, IDC_FORMAT_HEX);
-        swprintf(ValueString, L"%lx", dwordValueData);
+        StringCbPrintfW(ValueString, sizeof(ValueString), L"%lx", dwordValueData);
         SetDlgItemTextW(hwndDlg, IDC_VALUE_DATA, ValueString);
         SendMessage(GetDlgItem(hwndDlg, IDC_VALUE_DATA), EM_SETSEL, 0, -1);
         SetFocus(GetDlgItem(hwndDlg, IDC_VALUE_DATA));
@@ -327,7 +327,7 @@ INT_PTR CALLBACK modify_dword_dlgproc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LP
                         }
                     }
                 }
-                swprintf(ValueString, L"%lx", Value);
+                StringCbPrintfW(ValueString, sizeof(ValueString), L"%lx", Value);
                 SetDlgItemTextW(hwndDlg, IDC_VALUE_DATA, ValueString);
                 return TRUE;
             }
@@ -347,7 +347,7 @@ INT_PTR CALLBACK modify_dword_dlgproc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LP
                         }
                     }
                 }
-                swprintf(ValueString, L"%lu", Value);
+                StringCbPrintfW(ValueString, sizeof(ValueString), L"%lu", Value);
                 SetDlgItemTextW(hwndDlg, IDC_VALUE_DATA, ValueString);
                 return TRUE;
             }
@@ -1491,6 +1491,7 @@ LONG RenameKey(HKEY hKey, LPCWSTR lpSubKey, LPCWSTR lpNewName)
     LPCWSTR s;
     LPWSTR lpNewSubKey = NULL;
     LONG Ret = 0;
+    SIZE_T cbNewSubKey;
 
     if (!lpSubKey)
         return Ret;
@@ -1499,11 +1500,12 @@ LONG RenameKey(HKEY hKey, LPCWSTR lpSubKey, LPCWSTR lpNewName)
     if (s)
     {
         s++;
-        lpNewSubKey = (LPWSTR) HeapAlloc(GetProcessHeap(), 0, (s - lpSubKey + wcslen(lpNewName) + 1) * sizeof(WCHAR));
+        cbNewSubKey = (s - lpSubKey + wcslen(lpNewName) + 1) * sizeof(WCHAR);
+        lpNewSubKey = (LPWSTR) HeapAlloc(GetProcessHeap(), 0, cbNewSubKey);
         if (lpNewSubKey != NULL)
         {
-            memcpy(lpNewSubKey, lpSubKey, (s - lpSubKey) * sizeof(WCHAR));
-            wcscpy(lpNewSubKey + (s - lpSubKey), lpNewName);
+            StringCbCopyNW(lpNewSubKey, cbNewSubKey, lpSubKey, (s - lpSubKey) * sizeof(WCHAR));
+            StringCbCatW(lpNewSubKey, cbNewSubKey, lpNewName);
             lpNewName = lpNewSubKey;
         }
         else

--- a/base/applications/regedit/find.c
+++ b/base/applications/regedit/find.c
@@ -144,7 +144,7 @@ BOOL RegFindRecurse(
     if(wcslen(pszSubKey) >= _countof(szSubKey))
         return FALSE;
 
-    wcscpy(szSubKey, pszSubKey);
+    StringCbCopyW(szSubKey, sizeof(szSubKey), pszSubKey);
     hSubKey = NULL;
 
     lResult = RegOpenKeyExW(hKey, szSubKey, 0, KEY_ALL_ACCESS, &hSubKey);
@@ -304,14 +304,14 @@ BOOL RegFindRecurse(
                            ppszFoundValueName))
         {
             LPWSTR psz = *ppszFoundSubKey;
-            *ppszFoundSubKey = malloc(
-                                   (wcslen(szSubKey) + wcslen(psz) + 2) * sizeof(WCHAR));
+            SIZE_T cbFoundSubKey = (wcslen(szSubKey) + wcslen(psz) + 2) * sizeof(WCHAR);
+            *ppszFoundSubKey = malloc(cbFoundSubKey);
             if (*ppszFoundSubKey == NULL)
                 goto err;
             if (szSubKey[0])
             {
-                wcscpy(*ppszFoundSubKey, szSubKey);
-                wcscat(*ppszFoundSubKey, s_backslash);
+                StringCbCopyW(*ppszFoundSubKey, cbFoundSubKey, szSubKey);
+                StringCbCatW(*ppszFoundSubKey, cbFoundSubKey, s_backslash);
             }
             else
                 **ppszFoundSubKey = 0;
@@ -368,7 +368,7 @@ BOOL RegFindWalk(
                        ppszFoundValueName))
         return TRUE;
 
-    wcscpy(szSubKey, pszSubKey);
+    StringCbCopyW(szSubKey, sizeof(szSubKey), pszSubKey);
     while(szSubKey[0] != 0)
     {
         if (DoEvents())
@@ -460,15 +460,14 @@ BOOL RegFindWalk(
                                ppszFoundSubKey, ppszFoundValueName))
             {
                 LPWSTR psz = *ppszFoundSubKey;
-                *ppszFoundSubKey = malloc(
-                                       (wcslen(szSubKey) + wcslen(psz) + 2) *
-                                       sizeof(WCHAR));
+                SIZE_T cbFoundSubKey = (wcslen(szSubKey) + wcslen(psz) + 2) * sizeof(WCHAR);
+                *ppszFoundSubKey = malloc(cbFoundSubKey);
                 if (*ppszFoundSubKey == NULL)
                     goto err;
                 if (szSubKey[0])
                 {
-                    wcscpy(*ppszFoundSubKey, szSubKey);
-                    wcscat(*ppszFoundSubKey, s_backslash);
+                    StringCbCopyW(*ppszFoundSubKey, cbFoundSubKey, szSubKey);
+                    StringCbCatW(*ppszFoundSubKey, cbFoundSubKey, s_backslash);
                 }
                 else
                     **ppszFoundSubKey = 0;

--- a/base/applications/regedit/framewnd.c
+++ b/base/applications/regedit/framewnd.c
@@ -138,7 +138,7 @@ static void OnMenuSelect(HWND hWnd, UINT nItemID, UINT nFlags, HMENU hSysMenu)
 {
     WCHAR str[100];
 
-    wcscpy(str, L"");
+    str[0] = UNICODE_NULL;
     if (nFlags & MF_POPUP)
     {
         if (hSysMenu != GetMenu(hWnd))
@@ -814,6 +814,7 @@ BOOL CopyKeyName(HWND hWnd, HKEY hRootKey, LPCWSTR keyName)
     WCHAR szBuffer[512];
     HGLOBAL hGlobal;
     LPWSTR s;
+    SIZE_T cbGlobal;
 
     if (!OpenClipboard(hWnd))
         goto done;
@@ -825,12 +826,13 @@ BOOL CopyKeyName(HWND hWnd, HKEY hRootKey, LPCWSTR keyName)
     if (!GetKeyName(szBuffer, ARRAY_SIZE(szBuffer), hRootKey, keyName))
         goto done;
 
-    hGlobal = GlobalAlloc(GMEM_MOVEABLE, (wcslen(szBuffer) + 1) * sizeof(WCHAR));
+    cbGlobal = (wcslen(szBuffer) + 1) * sizeof(WCHAR);
+    hGlobal = GlobalAlloc(GMEM_MOVEABLE, cbGlobal);
     if (!hGlobal)
         goto done;
 
     s = GlobalLock(hGlobal);
-    wcscpy(s, szBuffer);
+    StringCbCopyW(s, cbGlobal, szBuffer);
     GlobalUnlock(hGlobal);
 
     SetClipboardData(CF_UNICODETEXT, hGlobal);

--- a/base/applications/regedit/security.c
+++ b/base/applications/regedit/security.c
@@ -782,8 +782,7 @@ CRegKeySecurity_fnConstructor(LPWSTR lpRegKey,
         obj->ObjectInfo = *ObjectInfo;
         obj->Btn = Btn;
         obj->hRootKey = hRootKey;
-        wcscpy(obj->szRegKey,
-                lpRegKey);
+        StringCbCopyW(obj->szRegKey, sizeof(obj->szRegKey), lpRegKey);
     }
     else
         SetLastError(ERROR_NOT_ENOUGH_MEMORY);

--- a/base/applications/regedit/txtproc.c
+++ b/base/applications/regedit/txtproc.c
@@ -194,8 +194,9 @@ static WCHAR *
 txt_build_subkey_path(LPCWSTR path, DWORD path_len, LPCWSTR subkey_name, DWORD subkey_len)
 {
     WCHAR *subkey_path;
-    subkey_path = malloc((path_len + subkey_len + 2) * sizeof(WCHAR));
-    swprintf(subkey_path, L"%s\\%s", path, subkey_name);
+    SIZE_T cb_subkey_path = (path_len + subkey_len + 2) * sizeof(WCHAR);
+    subkey_path = malloc(cb_subkey_path);
+    StringCbPrintfW(subkey_path, cb_subkey_path, L"%s\\%s", path, subkey_name);
     return subkey_path;
 }
 


### PR DESCRIPTION
## Purpose

Use safer functions for buffer manipulation to avoid buffer overflow/overrun.
JIRA issue: [CORE-18876](https://jira.reactos.org/browse/CORE-18876)

## Proposed changes

- Use `<strsafe.h>` functions instead of deprecated string functions.

## TODO

- [x] Do check.
