### PR TITLE
[REGEDIT] Improve error handling

### DIFF
--- a/base/applications/regedit/main.h
+++ b/base/applications/regedit/main.h
@@ -134,6 +134,7 @@ BOOL IsDefaultValue(HWND hwndLV, int i);
 /* regedit.c */
 void WINAPIV output_message(unsigned int id, ...);
 void WINAPIV error_exit(unsigned int id, ...);
+void WINAPIV error_dont_exit(unsigned int id, ...);
 
 /* regproc.c */
 char *GetMultiByteString(const WCHAR *strW);

--- a/base/applications/regedit/main.h
+++ b/base/applications/regedit/main.h
@@ -134,7 +134,6 @@ BOOL IsDefaultValue(HWND hwndLV, int i);
 /* regedit.c */
 void WINAPIV output_message(unsigned int id, ...);
 void WINAPIV error_exit(unsigned int id, ...);
-void WINAPIV error_dont_exit(unsigned int id, ...);
 
 /* regproc.c */
 char *GetMultiByteString(const WCHAR *strW);

--- a/base/applications/regedit/regedit.c
+++ b/base/applications/regedit/regedit.c
@@ -119,6 +119,22 @@ void WINAPIV error_exit(unsigned int id, ...)
     exit(0); /* regedit.exe always terminates with error code zero */
 }
 
+#ifdef __REACTOS__
+void WINAPIV error_dont_exit(unsigned int id, ...)
+{
+    WCHAR fmt[256], text[512], title[64];
+    va_list va;
+
+    LoadStringW(hInst, IDS_APP_TITLE, title, _countof(title));
+    LoadStringW(hInst, id, fmt, _countof(fmt));
+
+    va_start(va, id);
+    FormatMessageW(FORMAT_MESSAGE_FROM_STRING, fmt, 0, 0, text, _countof(text), &va);
+    MessageBoxW(hFrameWnd, text, title, MB_ICONERROR);
+    va_end(va);
+}
+#endif
+
 typedef enum {
     ACTION_ADD, ACTION_EXPORT, ACTION_DELETE
 } REGEDIT_ACTION;
@@ -219,7 +235,11 @@ static void PerformRegAction(REGEDIT_ACTION action, WCHAR **argv, int *i)
             break;
         }
     default:
+#ifdef __REACTOS__
+        error_dont_exit(STRING_UNHANDLED_ACTION);
+#else
         error_exit(STRING_UNHANDLED_ACTION);
+#endif
         break;
     }
 }

--- a/base/applications/regedit/regedit.c
+++ b/base/applications/regedit/regedit.c
@@ -37,9 +37,7 @@ static void output_writeconsole(const WCHAR *str, DWORD wlen)
 #ifdef __REACTOS__
     /* This is win32gui application, don't ever try writing to console.
      * For the console version we have a separate reg.exe application. */
-    WCHAR AppStr[255];
-    LoadStringW(hInst, IDS_APP_TITLE, AppStr, ARRAY_SIZE(AppStr));
-    MessageBoxW(NULL, str, AppStr, MB_OK | MB_ICONINFORMATION);
+    MessageBoxW(NULL, str, NULL, MB_ICONERROR);
 #else
     DWORD count;
 
@@ -118,22 +116,6 @@ void WINAPIV error_exit(unsigned int id, ...)
 
     exit(0); /* regedit.exe always terminates with error code zero */
 }
-
-#ifdef __REACTOS__
-void WINAPIV error_dont_exit(unsigned int id, ...)
-{
-    WCHAR fmt[256], text[512], title[64];
-    va_list va;
-
-    LoadStringW(hInst, IDS_APP_TITLE, title, _countof(title));
-    LoadStringW(hInst, id, fmt, _countof(fmt));
-
-    va_start(va, id);
-    FormatMessageW(FORMAT_MESSAGE_FROM_STRING, fmt, 0, 0, text, _countof(text), &va);
-    MessageBoxW(hFrameWnd, text, title, MB_ICONERROR);
-    va_end(va);
-}
-#endif
 
 typedef enum {
     ACTION_ADD, ACTION_EXPORT, ACTION_DELETE
@@ -236,7 +218,7 @@ static void PerformRegAction(REGEDIT_ACTION action, WCHAR **argv, int *i)
         }
     default:
 #ifdef __REACTOS__
-        error_dont_exit(STRING_UNHANDLED_ACTION);
+        output_message(STRING_UNHANDLED_ACTION);
 #else
         error_exit(STRING_UNHANDLED_ACTION);
 #endif

--- a/base/applications/regedit/regproc.c
+++ b/base/applications/regedit/regproc.c
@@ -1106,7 +1106,7 @@ void delete_registry_key(WCHAR *reg_key_name)
     {
         if (key_name) *(key_name - 1) = 0;
 #ifdef __REACTOS__
-        error_dont_exit(STRING_INVALID_SYSTEM_KEY, reg_key_name);
+        output_message(STRING_INVALID_SYSTEM_KEY, reg_key_name);
         return;
 #else
         error_exit(STRING_INVALID_SYSTEM_KEY, reg_key_name);
@@ -1116,7 +1116,7 @@ void delete_registry_key(WCHAR *reg_key_name)
     if (!key_name || !*key_name)
 #ifdef __REACTOS__
     {
-        error_dont_exit(STRING_DELETE_FAILED, reg_key_name);
+        output_message(STRING_DELETE_FAILED, reg_key_name);
         return;
     }
 #else
@@ -1473,7 +1473,7 @@ static FILE *REGPROC_open_export_file(WCHAR *file_name, BOOL unicode)
         {
             _wperror(L"regedit");
 #ifdef __REACTOS__
-            error_dont_exit(STRING_CANNOT_OPEN_FILE, file_name);
+            output_message(STRING_CANNOT_OPEN_FILE, file_name);
             return NULL;
 #else
             error_exit(STRING_CANNOT_OPEN_FILE, file_name);

--- a/base/applications/regedit/regproc.c
+++ b/base/applications/regedit/regproc.c
@@ -1525,7 +1525,7 @@ static BOOL export_key(WCHAR *file_name, WCHAR *path, BOOL unicode)
     fp = REGPROC_open_export_file(file_name, unicode);
 #ifdef __REACTOS__
     if (!fp)
-        return TRUE;
+        return TRUE; /* Error message is already displayed */
 #endif
     export_registry_data(fp, key, path, unicode);
     export_newline(fp, unicode);
@@ -1545,7 +1545,7 @@ static BOOL export_all(WCHAR *file_name, WCHAR *path, BOOL unicode)
     fp = REGPROC_open_export_file(file_name, unicode);
 #ifdef __REACTOS__
     if (!fp)
-        return TRUE;
+        return TRUE; /* Error message is already displayed */
 #endif
 
     for (i = 0; i < ARRAY_SIZE(classes); i++)

--- a/base/applications/regedit/regproc.c
+++ b/base/applications/regedit/regproc.c
@@ -1105,11 +1105,23 @@ void delete_registry_key(WCHAR *reg_key_name)
     if (!(key_class = parse_key_name(reg_key_name, &key_name)))
     {
         if (key_name) *(key_name - 1) = 0;
+#ifdef __REACTOS__
+        error_dont_exit(STRING_INVALID_SYSTEM_KEY, reg_key_name);
+        return;
+#else
         error_exit(STRING_INVALID_SYSTEM_KEY, reg_key_name);
+#endif
     }
 
     if (!key_name || !*key_name)
+#ifdef __REACTOS__
+    {
+        error_dont_exit(STRING_DELETE_FAILED, reg_key_name);
+        return;
+    }
+#else
         error_exit(STRING_DELETE_FAILED, reg_key_name);
+#endif
 
 #ifdef __REACTOS__
     SHDeleteKey(key_class, key_name);
@@ -1460,7 +1472,12 @@ static FILE *REGPROC_open_export_file(WCHAR *file_name, BOOL unicode)
         if (!file)
         {
             _wperror(L"regedit");
+#ifdef __REACTOS__
+            error_dont_exit(STRING_CANNOT_OPEN_FILE, file_name);
+            return NULL;
+#else
             error_exit(STRING_CANNOT_OPEN_FILE, file_name);
+#endif
         }
     }
 
@@ -1506,6 +1523,10 @@ static BOOL export_key(WCHAR *file_name, WCHAR *path, BOOL unicode)
         return FALSE;
 
     fp = REGPROC_open_export_file(file_name, unicode);
+#ifdef __REACTOS__
+    if (!fp)
+        return TRUE;
+#endif
     export_registry_data(fp, key, path, unicode);
     export_newline(fp, unicode);
     fclose(fp);
@@ -1522,6 +1543,10 @@ static BOOL export_all(WCHAR *file_name, WCHAR *path, BOOL unicode)
     WCHAR *class_name;
 
     fp = REGPROC_open_export_file(file_name, unicode);
+#ifdef __REACTOS__
+    if (!fp)
+        return TRUE;
+#endif
 
     for (i = 0; i < ARRAY_SIZE(classes); i++)
     {


### PR DESCRIPTION
## Purpose

Don't exit the main program on error.
JIRA issue: [CORE-19188](https://jira.reactos.org/browse/CORE-19188)

## Proposed changes

- Improve `output_message` function.
- Use `output_message` instead of some `error_exit` function calls.

## TODO

- [x] Do tests.

## Screenshot

![error](https://github.com/reactos/reactos/assets/2107452/4efb6dc6-c1c8-41a0-94cd-100a12816bea)