### PR TITLE
[IPHLPAPI] Silence obsolete FIXME in GetAdaptersAddresses

### DIFF
--- a/dll/win32/iphlpapi/address.c
+++ b/dll/win32/iphlpapi/address.c
@@ -331,8 +331,8 @@ GetAdaptersAddresses(
     DWORD MIN_SIZE = 15 * 1024;
     PIP_ADAPTER_ADDRESSES PreviousAA = NULL;
 
-    FIXME("GetAdaptersAddresses - Semi Stub: Family %u, Flags 0x%08x, Reserved %p, pAdapterAddress %p, pOutBufLen %p.\n",
-        Family, Flags, Reserved, pAdapterAddresses, pOutBufLen);
+    TRACE("Family %u, Flags 0x%08x, Reserved %p, pAdapterAddress %p, pOutBufLen %p.\n",
+          Family, Flags, Reserved, pAdapterAddresses, pOutBufLen);
 
     if (!pOutBufLen)
         return ERROR_INVALID_PARAMETER;

--- a/dll/win32/iphlpapi/address.c
+++ b/dll/win32/iphlpapi/address.c
@@ -331,7 +331,7 @@ GetAdaptersAddresses(
     DWORD MIN_SIZE = 15 * 1024;
     PIP_ADAPTER_ADDRESSES PreviousAA = NULL;
 
-    TRACE("Family %u, Flags 0x%08x, Reserved %p, pAdapterAddress %p, pOutBufLen %p.\n",
+    TRACE("Family %u, Flags 0x%08x, Reserved %p, pAdapterAddress %p, pOutBufLen %p\n",
           Family, Flags, Reserved, pAdapterAddresses, pOutBufLen);
 
     if (!pOutBufLen)


### PR DESCRIPTION
## Purpose

_Quiet unneeded debug output for GetAdaptersAddresses._

JIRA issue: [CORE-14388](https://jira.reactos.org/browse/CORE-14388)

## Proposed changes

_Convert FIXME to TRACE in GetAdaptersAddresses._
