### PR TITLE
[SHELL32][SDK] Implement PathIsSlowA and SHSetFolderPathA

### DIFF
--- a/dll/win32/shell32/stubs.cpp
+++ b/dll/win32/shell32/stubs.cpp
@@ -225,13 +225,13 @@ SHGetSetFolderCustomSettingsA(LPSHFOLDERCUSTOMSETTINGSA pfcs,
  */
 BOOL WINAPI
 SHOpenPropSheetW(
-    _In_opt_z_ LPCWSTR pszCaption,
+    _In_opt_ LPCWSTR pszCaption,
     _In_opt_ HKEY *ahKeys,
     _In_ UINT cKeys,
     _In_ const CLSID *pclsidDefault,
     _In_ IDataObject *pDataObject,
     _In_opt_ IShellBrowser *pShellBrowser,
-    _In_opt_z_ LPCWSTR pszStartPage)
+    _In_opt_ LPCWSTR pszStartPage)
 {
     FIXME("SHOpenPropSheetW() stub\n");
     return FALSE;
@@ -1032,7 +1032,7 @@ SHSetFolderPathW(
     _In_ INT csidl,
     _In_ HANDLE hToken,
     _In_ DWORD dwFlags,
-    _In_z_ LPCWSTR pszPath)
+    _In_ LPCWSTR pszPath)
 {
     FIXME("SHSetFolderPathW() stub\n");
     return E_FAIL;
@@ -1077,7 +1077,7 @@ SHShouldShowWizards(LPVOID lpUnknown)
 EXTERN_C BOOL
 WINAPI
 PathIsSlowW(
-    _In_z_ LPCWSTR pszFile,
+    _In_ LPCWSTR pszFile,
     _In_ DWORD dwAttr)
 {
     FIXME("PathIsSlowW() stub\n");

--- a/dll/win32/shell32/stubs.cpp
+++ b/dll/win32/shell32/stubs.cpp
@@ -1028,24 +1028,11 @@ FirstUserLogon(LPWSTR lpUnknown1, LPWSTR lpUnknown2)
  */
 EXTERN_C HRESULT
 WINAPI
-SHSetFolderPathA(int csidl,
-                 HANDLE hToken,
-                 DWORD dwFlags,
-                 LPCSTR pszPath)
-{
-    FIXME("SHSetFolderPathA() stub\n");
-    return E_FAIL;
-}
-
-/*
- * Unimplemented
- */
-EXTERN_C HRESULT
-WINAPI
-SHSetFolderPathW(int csidl,
-                 HANDLE hToken,
-                 DWORD dwFlags,
-                 LPCWSTR pszPath)
+SHSetFolderPathW(
+    _In_ INT csidl,
+    _In_ HANDLE hToken,
+    _In_ DWORD dwFlags,
+    _In_z_ LPCWSTR pszPath)
 {
     FIXME("SHSetFolderPathW() stub\n");
     return E_FAIL;
@@ -1089,20 +1076,11 @@ SHShouldShowWizards(LPVOID lpUnknown)
  */
 EXTERN_C BOOL
 WINAPI
-PathIsSlowW(LPCWSTR pszFile, DWORD dwFileAttr)
+PathIsSlowW(
+    _In_z_ LPCWSTR pszFile,
+    _In_ DWORD dwAttr)
 {
     FIXME("PathIsSlowW() stub\n");
-    return FALSE;
-}
-
-/*
- * Unimplemented
- */
-EXTERN_C BOOL
-WINAPI
-PathIsSlowA(LPCSTR pszFile, DWORD dwFileAttr)
-{
-    FIXME("PathIsSlowA() stub\n");
     return FALSE;
 }
 

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -41,10 +41,9 @@ SHSetFolderPathA(
     _In_ DWORD dwFlags,
     _In_z_ LPCSTR pszPath)
 {
-    WCHAR szPathW[MAX_PATH];
     TRACE("(%d, %p, 0x%X, %s)\n", csidl, hToken, dwFlags, pszPath);
-    SHAnsiToUnicode(pszPath, szPathW, _countof(szPathW));
-    return SHSetFolderPathW(csidl, hToken, dwFlags, szPathW);
+    CStringW strPathW(pszPath);
+    return SHSetFolderPathW(csidl, hToken, dwFlags, strPathW);
 }
 
 /*************************************************************************
@@ -59,9 +58,8 @@ PathIsSlowA(
     _In_ DWORD dwAttr)
 {
     TRACE("(%s, 0x%X)\n", pszFile, dwAttr);
-    WCHAR szFileW[MAX_PATH];
-    SHAnsiToUnicode(pszFile, szFileW, _countof(szFileW));
-    return PathIsSlowW(szFileW, dwAttr);
+    CStringW strFileW(pszFile);
+    return PathIsSlowW(strFileW, dwAttr);
 }
 
 /*************************************************************************

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -41,7 +41,7 @@ SHSetFolderPathA(
     _In_ DWORD dwFlags,
     _In_z_ LPCSTR pszPath)
 {
-    TRACE("(%d, %p, 0x%X, %s)\n", csidl, hToken, dwFlags, pszPath);
+    TRACE("(%d, %p, 0x%X, %s)\n", csidl, hToken, dwFlags, debugstr_a(pszPath));
     CStringW strPathW(pszPath);
     return SHSetFolderPathW(csidl, hToken, dwFlags, strPathW);
 }
@@ -57,7 +57,7 @@ PathIsSlowA(
     _In_z_ LPCSTR pszFile,
     _In_ DWORD dwAttr)
 {
-    TRACE("(%s, 0x%X)\n", pszFile, dwAttr);
+    TRACE("(%s, 0x%X)\n", debugstr_a(pszFile), dwAttr);
     CStringW strFileW(pszFile);
     return PathIsSlowW(strFileW, dwAttr);
 }
@@ -520,8 +520,8 @@ SHOpenPropSheetA(
     WCHAR szStartPageW[MAX_PATH], szCaptionW[MAX_PATH];
     LPCWSTR pszCaptionW = NULL, pszStartPageW = NULL;
 
-    TRACE("(%s, %p, %u, %p, %p, %p, %s)", pszCaption, ahKeys, cKeys, pclsidDefault, pDataObject,
-          pShellBrowser, pszStartPage);
+    TRACE("(%s, %p, %u, %p, %p, %p, %s)", debugstr_a(pszCaption), ahKeys, cKeys, pclsidDefault,
+          pDataObject, pShellBrowser, debugstr_a(pszStartPage));
 
     if (pszCaption)
     {

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -29,6 +29,42 @@ static BOOL OpenEffectiveToken(DWORD DesiredAccess, HANDLE *phToken)
 }
 
 /*************************************************************************
+ *                SHSetFolderPathA (SHELL32.231)
+ *
+ * @see https://learn.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-shsetfolderpatha
+ */
+EXTERN_C
+HRESULT WINAPI
+SHSetFolderPathA(
+    _In_ INT csidl,
+    _In_ HANDLE hToken,
+    _In_ DWORD dwFlags,
+    _In_z_ LPCSTR pszPath)
+{
+    WCHAR szPathW[MAX_PATH];
+    TRACE("(%d, %p, 0x%X, %s)\n", csidl, hToken, dwFlags, pszPath);
+    SHAnsiToUnicode(pszPath, szPathW, _countof(szPathW));
+    return SHSetFolderPathW(csidl, hToken, dwFlags, szPathW);
+}
+
+/*************************************************************************
+ *                PathIsSlowA (SHELL32.240)
+ *
+ * @see https://learn.microsoft.com/en-us/windows/win32/api/shlobj/nf-shlobj-pathisslowa
+ */
+EXTERN_C
+BOOL WINAPI
+PathIsSlowA(
+    _In_z_ LPCSTR pszFile,
+    _In_ DWORD dwAttr)
+{
+    TRACE("(%s, 0x%X)\n", pszFile, dwAttr);
+    WCHAR szFileW[MAX_PATH];
+    SHAnsiToUnicode(pszFile, szFileW, _countof(szFileW));
+    return PathIsSlowW(szFileW, dwAttr);
+}
+
+/*************************************************************************
  *                SHOpenEffectiveToken (SHELL32.235)
  */
 EXTERN_C BOOL WINAPI SHOpenEffectiveToken(_Out_ LPHANDLE phToken)

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -517,7 +517,7 @@ SHOpenPropSheetA(
     _In_opt_ IShellBrowser *pShellBrowser,
     _In_opt_z_ LPCSTR pszStartPage)
 {
-    WCHAR szStartPageW[MAX_PATH], szCaptionW[MAX_PATH];
+    CStringW strStartPageW, strCaptionW;
     LPCWSTR pszCaptionW = NULL, pszStartPageW = NULL;
 
     TRACE("(%s, %p, %u, %p, %p, %p, %s)", debugstr_a(pszCaption), ahKeys, cKeys, pclsidDefault,
@@ -525,14 +525,14 @@ SHOpenPropSheetA(
 
     if (pszCaption)
     {
-        SHAnsiToUnicode(pszCaption, szCaptionW, _countof(szCaptionW));
-        pszCaptionW = szCaptionW;
+        strStartPageW = pszCaption;
+        pszCaptionW = strCaptionW;
     }
 
     if (pszStartPage)
     {
-        SHAnsiToUnicode(pszStartPage, szStartPageW, _countof(szStartPageW));
-        pszStartPageW = szStartPageW;
+        strStartPageW = pszStartPage;
+        pszStartPageW = strStartPageW;
     }
 
     return SHOpenPropSheetW(pszCaptionW, ahKeys, cKeys, pclsidDefault,

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -9,7 +9,10 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(shell);
 
-static BOOL OpenEffectiveToken(DWORD DesiredAccess, HANDLE *phToken)
+static BOOL
+OpenEffectiveToken(
+    _In_ DWORD DesiredAccess,
+    _Out_ HANDLE *phToken)
 {
     BOOL ret;
 
@@ -39,7 +42,7 @@ SHSetFolderPathA(
     _In_ INT csidl,
     _In_ HANDLE hToken,
     _In_ DWORD dwFlags,
-    _In_z_ LPCSTR pszPath)
+    _In_ LPCSTR pszPath)
 {
     TRACE("(%d, %p, 0x%X, %s)\n", csidl, hToken, dwFlags, debugstr_a(pszPath));
     CStringW strPathW(pszPath);
@@ -54,7 +57,7 @@ SHSetFolderPathA(
 EXTERN_C
 BOOL WINAPI
 PathIsSlowA(
-    _In_z_ LPCSTR pszFile,
+    _In_ LPCSTR pszFile,
     _In_ DWORD dwAttr)
 {
     TRACE("(%s, 0x%X)\n", debugstr_a(pszFile), dwAttr);
@@ -102,7 +105,7 @@ EXTERN_C DWORD WINAPI SHGetUserSessionId(_In_opt_ HANDLE hToken)
 EXTERN_C
 HRESULT WINAPI
 SHInvokePrivilegedFunctionW(
-    _In_z_ LPCWSTR pszName,
+    _In_ LPCWSTR pszName,
     _In_ PRIVILEGED_FUNCTION fn,
     _In_opt_ LPARAM lParam)
 {
@@ -144,7 +147,9 @@ SHInvokePrivilegedFunctionW(
  */
 EXTERN_C
 BOOL WINAPI
-SHTestTokenPrivilegeW(_In_opt_ HANDLE hToken, _In_z_ LPCWSTR lpName)
+SHTestTokenPrivilegeW(
+    _In_opt_ HANDLE hToken,
+    _In_ LPCWSTR lpName)
 {
     LUID Luid;
     DWORD dwLength;
@@ -348,7 +353,7 @@ SHFindComputer(LPCITEMIDLIST pidlRoot, LPCITEMIDLIST pidlSavedSearch)
 static HRESULT
 Int64ToStr(
     _In_ LONGLONG llValue,
-    _Out_writes_z_(cchValue) LPWSTR pszValue,
+    _Out_writes_(cchValue) LPWSTR pszValue,
     _In_ UINT cchValue)
 {
     WCHAR szBuff[40];
@@ -395,9 +400,9 @@ Int64GetNumFormat(
     _Out_ NUMBERFMTW *pDest,
     _In_opt_ const NUMBERFMTW *pSrc,
     _In_ DWORD dwNumberFlags,
-    _Out_writes_z_(cchDecimal) LPWSTR pszDecimal,
+    _Out_writes_(cchDecimal) LPWSTR pszDecimal,
     _In_ INT cchDecimal,
-    _Out_writes_z_(cchThousand) LPWSTR pszThousand,
+    _Out_writes_(cchThousand) LPWSTR pszThousand,
     _In_ INT cchThousand)
 {
     WCHAR szBuff[20];
@@ -453,7 +458,7 @@ EXTERN_C
 INT WINAPI
 Int64ToString(
     _In_ LONGLONG llValue,
-    _Out_writes_z_(cchOut) LPWSTR pszOut,
+    _Out_writes_(cchOut) LPWSTR pszOut,
     _In_ UINT cchOut,
     _In_ BOOL bUseFormat,
     _In_opt_ const NUMBERFMTW *pNumberFormat,
@@ -491,7 +496,7 @@ EXTERN_C
 INT WINAPI
 LargeIntegerToString(
     _In_ const LARGE_INTEGER *pLargeInt,
-    _Out_writes_z_(cchOut) LPWSTR pszOut,
+    _Out_writes_(cchOut) LPWSTR pszOut,
     _In_ UINT cchOut,
     _In_ BOOL bUseFormat,
     _In_opt_ const NUMBERFMTW *pNumberFormat,
@@ -509,13 +514,13 @@ LargeIntegerToString(
 EXTERN_C
 BOOL WINAPI
 SHOpenPropSheetA(
-    _In_opt_z_ LPCSTR pszCaption,
+    _In_opt_ LPCSTR pszCaption,
     _In_opt_ HKEY *ahKeys,
     _In_ UINT cKeys,
     _In_ const CLSID *pclsidDefault,
     _In_ IDataObject *pDataObject,
     _In_opt_ IShellBrowser *pShellBrowser,
-    _In_opt_z_ LPCSTR pszStartPage)
+    _In_opt_ LPCSTR pszStartPage)
 {
     CStringW strStartPageW, strCaptionW;
     LPCWSTR pszCaptionW = NULL, pszStartPageW = NULL;

--- a/sdk/include/psdk/shlobj.h
+++ b/sdk/include/psdk/shlobj.h
@@ -192,6 +192,32 @@ SHGetFolderPathAndSubDirW(
 
 #define SHGetFolderPathAndSubDir WINELIB_NAME_AW(SHGetFolderPathAndSubDir);
 
+HRESULT WINAPI
+SHSetFolderPathA(
+    _In_ INT csidl,
+    _In_ HANDLE hToken,
+    _In_ DWORD dwFlags,
+    _In_z_ LPCSTR pszPath);
+HRESULT WINAPI
+SHSetFolderPathW(
+    _In_ INT csidl,
+    _In_ HANDLE hToken,
+    _In_ DWORD dwFlags,
+    _In_z_ LPCWSTR pszPath);
+
+#define SHSetFolderPath WINELIB_NAME_AW(SHSetFolderPath);
+
+BOOL WINAPI
+PathIsSlowA(
+    _In_z_ LPCSTR pszFile,
+    _In_ DWORD dwAttr);
+BOOL WINAPI
+PathIsSlowW(
+    _In_z_ LPCWSTR pszFile,
+    _In_ DWORD dwAttr);
+
+#define PathIsSlow WINELIB_NAME_AW(PathIsSlow);
+
 _Success_(return != 0)
 BOOL
 WINAPI

--- a/sdk/include/psdk/shlobj.h
+++ b/sdk/include/psdk/shlobj.h
@@ -190,7 +190,7 @@ SHGetFolderPathAndSubDirW(
   _In_opt_ LPCWSTR,
   _Out_writes_(MAX_PATH) LPWSTR);
 
-#define SHGetFolderPathAndSubDir WINELIB_NAME_AW(SHGetFolderPathAndSubDir);
+#define SHGetFolderPathAndSubDir WINELIB_NAME_AW(SHGetFolderPathAndSubDir)
 
 HRESULT WINAPI
 SHSetFolderPathA(
@@ -206,7 +206,7 @@ SHSetFolderPathW(
     _In_ DWORD dwFlags,
     _In_z_ LPCWSTR pszPath);
 
-#define SHSetFolderPath WINELIB_NAME_AW(SHSetFolderPath);
+#define SHSetFolderPath WINELIB_NAME_AW(SHSetFolderPath)
 
 BOOL WINAPI
 PathIsSlowA(
@@ -218,7 +218,7 @@ PathIsSlowW(
     _In_z_ LPCWSTR pszFile,
     _In_ DWORD dwAttr);
 
-#define PathIsSlow WINELIB_NAME_AW(PathIsSlow);
+#define PathIsSlow WINELIB_NAME_AW(PathIsSlow)
 
 _Success_(return != 0)
 BOOL
@@ -270,7 +270,7 @@ SHPathPrepareForWriteW(
   _In_opt_ IUnknown*,
   _In_ LPCWSTR, DWORD);
 
-#define SHPathPrepareForWrite WINELIB_NAME_AW(SHPathPrepareForWrite);
+#define SHPathPrepareForWrite WINELIB_NAME_AW(SHPathPrepareForWrite)
 
 UINT
 WINAPI

--- a/sdk/include/psdk/shlobj.h
+++ b/sdk/include/psdk/shlobj.h
@@ -198,6 +198,7 @@ SHSetFolderPathA(
     _In_ HANDLE hToken,
     _In_ DWORD dwFlags,
     _In_z_ LPCSTR pszPath);
+
 HRESULT WINAPI
 SHSetFolderPathW(
     _In_ INT csidl,
@@ -211,6 +212,7 @@ BOOL WINAPI
 PathIsSlowA(
     _In_z_ LPCSTR pszFile,
     _In_ DWORD dwAttr);
+
 BOOL WINAPI
 PathIsSlowW(
     _In_z_ LPCWSTR pszFile,

--- a/sdk/include/psdk/shlobj.h
+++ b/sdk/include/psdk/shlobj.h
@@ -377,6 +377,7 @@ SHOpenPropSheetA(
     _In_ IDataObject *pDataObject,
     _In_opt_ IShellBrowser *pShellBrowser,
     _In_opt_z_ LPCSTR pszStartPage);
+
 BOOL WINAPI
 SHOpenPropSheetW(
     _In_opt_z_ LPCWSTR pszCaption,
@@ -386,6 +387,8 @@ SHOpenPropSheetW(
     _In_ IDataObject *pDataObject,
     _In_opt_ IShellBrowser *pShellBrowser,
     _In_opt_z_ LPCWSTR pszStartPage);
+
+#define SHOpenPropSheet WINELIB_NAME_AW(SHOpenPropSheet)
 
 /*****************************************************************************
  * IContextMenu interface

--- a/sdk/include/psdk/shlobj.h
+++ b/sdk/include/psdk/shlobj.h
@@ -197,25 +197,25 @@ SHSetFolderPathA(
     _In_ INT csidl,
     _In_ HANDLE hToken,
     _In_ DWORD dwFlags,
-    _In_z_ LPCSTR pszPath);
+    _In_ LPCSTR pszPath);
 
 HRESULT WINAPI
 SHSetFolderPathW(
     _In_ INT csidl,
     _In_ HANDLE hToken,
     _In_ DWORD dwFlags,
-    _In_z_ LPCWSTR pszPath);
+    _In_ LPCWSTR pszPath);
 
 #define SHSetFolderPath WINELIB_NAME_AW(SHSetFolderPath)
 
 BOOL WINAPI
 PathIsSlowA(
-    _In_z_ LPCSTR pszFile,
+    _In_ LPCSTR pszFile,
     _In_ DWORD dwAttr);
 
 BOOL WINAPI
 PathIsSlowW(
-    _In_z_ LPCWSTR pszFile,
+    _In_ LPCWSTR pszFile,
     _In_ DWORD dwAttr);
 
 #define PathIsSlow WINELIB_NAME_AW(PathIsSlow)
@@ -370,23 +370,23 @@ HINSTANCE WINAPI SHGetShellStyleHInstance(VOID);
 
 BOOL WINAPI
 SHOpenPropSheetA(
-    _In_opt_z_ LPCSTR pszCaption,
+    _In_opt_ LPCSTR pszCaption,
     _In_opt_ HKEY *ahKeys,
     _In_ UINT cKeys,
     _In_ const CLSID *pclsidDefault,
     _In_ IDataObject *pDataObject,
     _In_opt_ IShellBrowser *pShellBrowser,
-    _In_opt_z_ LPCSTR pszStartPage);
+    _In_opt_ LPCSTR pszStartPage);
 
 BOOL WINAPI
 SHOpenPropSheetW(
-    _In_opt_z_ LPCWSTR pszCaption,
+    _In_opt_ LPCWSTR pszCaption,
     _In_opt_ HKEY *ahKeys,
     _In_ UINT cKeys,
     _In_ const CLSID *pclsidDefault,
     _In_ IDataObject *pDataObject,
     _In_opt_ IShellBrowser *pShellBrowser,
-    _In_opt_z_ LPCWSTR pszStartPage);
+    _In_opt_ LPCWSTR pszStartPage);
 
 #define SHOpenPropSheet WINELIB_NAME_AW(SHOpenPropSheet)
 


### PR DESCRIPTION
## Purpose

Implementing missing features...
JIRA issue: N/A

## Proposed changes

- Implement `PathIsSlowA` and `SHSetFolderPathA` functions.
- Add `PathIsSlow` and `SHSetFolderPath` prototypes to `<shlobj.h>`.
- Fix some `<shlobj.h>`'s bugs.
- Improve `SHOpenPropSheetA` function.

## TODO

- [x] Do build.
