### PR TITLE
[FREELDR] Use ExAllocatePoolWithTag() and ExFreePoolWithTag()

### DIFF
--- a/boot/freeldr/freeldr/include/freeldr.h
+++ b/boot/freeldr/freeldr/include/freeldr.h
@@ -17,8 +17,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef __FREELDR_H
-#define __FREELDR_H
+#pragma once
 
 #define UINT64_C(val) val##ULL
 #define RVA(m, b) ((PVOID)((ULONG_PTR)(b) + (ULONG_PTR)(m)))
@@ -127,6 +126,14 @@
 #include <arch/mips/arcbios.h>
 #endif
 
+/* Tags for Ex*PoolWithTag() */
+#define TAG_FLDR_CMNBUF     'bcLF'
+#define TAG_FLDR_DISKCTX    'cdLF'
+#define TAG_FLDR_MBR        'bmLF'
+#define TAG_FLDR_PART       ' pLF'
+#define TAG_FLDR_SECTOR     ' sLF'
+#define TAG_FLDR_SRB        'rsLF'
+
 VOID __cdecl BootMain(IN PCCH CmdLine);
 VOID LoadOperatingSystem(IN OperatingSystemItem* OperatingSystem);
 #ifdef HAS_OPTION_MENU_EDIT_CMDLINE
@@ -134,5 +141,3 @@ VOID EditOperatingSystemEntry(IN OperatingSystemItem* OperatingSystem);
 #endif
 VOID RunLoader(VOID);
 VOID FrLdrCheckCpuCompatibility(VOID);
-
-#endif  /* __FREELDR_H */

--- a/boot/freeldr/freeldr/lib/mm/heap.c
+++ b/boot/freeldr/freeldr/lib/mm/heap.c
@@ -557,6 +557,8 @@ ExAllocatePoolWithTag(
     return FrLdrHeapAllocateEx(FrLdrDefaultHeap, NumberOfBytes, Tag);
 }
 
+// Deprecated.
+#if 0
 PVOID
 NTAPI
 ExAllocatePool(
@@ -565,7 +567,10 @@ ExAllocatePool(
 {
     return FrLdrHeapAllocateEx(FrLdrDefaultHeap, NumberOfBytes, 0);
 }
+#endif
 
+// 1 call remains.
+#if 1
 VOID
 NTAPI
 ExFreePool(
@@ -573,6 +578,7 @@ ExFreePool(
 {
     FrLdrHeapFreeEx(FrLdrDefaultHeap, P, 0);
 }
+#endif
 
 VOID
 NTAPI
@@ -611,4 +617,3 @@ RtlFreeHeap(
     FrLdrHeapFreeEx(FrLdrDefaultHeap, HeapBase, ' ltR');
     return TRUE;
 }
-


### PR DESCRIPTION
## Purpose

More secure code.

## Proposed changes

- Use ExAllocatePoolWithTag() and ExFreePoolWithTag()