### PR TITLE
[TASKMGR] Hold Shift to bypass confirmation MessageBox

### DIFF
--- a/base/applications/taskmgr/debug.c
+++ b/base/applications/taskmgr/debug.c
@@ -30,7 +30,7 @@ void ProcessPage_OnDebug(void)
     LoadStringW(hInst, IDS_MSG_WARNINGDEBUG, szTemp, _countof(szTemp));
     LoadStringW(hInst, IDS_MSG_TASKMGRWARNING, szTempA, _countof(szTempA));
 
-    if (MessageBoxW(hMainWnd, szTemp, szTempA, MB_YESNO | MB_ICONWARNING) != IDYES)
+    if (!ConfirmMessageBox(hMainWnd, szTemp, szTempA, MB_YESNO | MB_ICONWARNING))
     {
         GetLastErrorText(strErrorText, _countof(strErrorText));
         LoadStringW(hInst, IDS_MSG_UNABLEDEBUGPROCESS, szTemp, _countof(szTemp));

--- a/base/applications/taskmgr/endproc.c
+++ b/base/applications/taskmgr/endproc.c
@@ -39,7 +39,7 @@ void ProcessPage_OnEndProcess(void)
     /* if this is a standard process just ask for confirmation before doing it */
     LoadStringW(hInst, IDS_MSG_WARNINGTERMINATING, strErrorText, 256);
     LoadStringW(hInst, IDS_MSG_TASKMGRWARNING, szTitle, 256);
-    if (MessageBoxW(hMainWnd, strErrorText, szTitle, MB_YESNO|MB_ICONWARNING|MB_TOPMOST) != IDYES)
+    if (!ConfirmMessageBox(hMainWnd, strErrorText, szTitle, MB_YESNO|MB_ICONWARNING|MB_TOPMOST))
     {
         if (hProcess) CloseHandle(hProcess);
         return;
@@ -169,7 +169,7 @@ void ProcessPage_OnEndProcessTree(void)
 
     LoadStringW(hInst, IDS_MSG_WARNINGTERMINATING, strErrorText, 256);
     LoadStringW(hInst, IDS_MSG_TASKMGRWARNING, szTitle, 256);
-    if (MessageBoxW(hMainWnd, strErrorText, szTitle, MB_YESNO|MB_ICONWARNING) != IDYES)
+    if (!ConfirmMessageBox(hMainWnd, strErrorText, szTitle, MB_YESNO|MB_ICONWARNING))
     {
         if (hProcess) CloseHandle(hProcess);
         return;

--- a/base/applications/taskmgr/priority.c
+++ b/base/applications/taskmgr/priority.c
@@ -22,7 +22,7 @@ void DoSetPriority(DWORD priority)
 
     LoadStringW(hInst, IDS_MSG_TASKMGRWARNING, szTitle, 256);
     LoadStringW(hInst, IDS_MSG_WARNINGCHANGEPRIORITY, szText, 260);
-    if (MessageBoxW(hMainWnd, szText, szTitle, MB_YESNO|MB_ICONWARNING) != IDYES)
+    if (!ConfirmMessageBox(hMainWnd, szText, szTitle, MB_YESNO|MB_ICONWARNING))
         return;
 
     hProcess = OpenProcess(PROCESS_SET_INFORMATION, FALSE, dwProcessId);

--- a/base/applications/taskmgr/taskmgr.c
+++ b/base/applications/taskmgr/taskmgr.c
@@ -1058,10 +1058,10 @@ void TaskManager_OnTabWndSelChange(void)
 
 BOOL ConfirmMessageBox(HWND hWnd, LPCWSTR Text, LPCWSTR Title, UINT Type)
 {
-    UINT positive = (Type & 0xF) <= MB_OKCANCEL ? IDOK : IDYES;
+    UINT positive = ((Type & 0xF) <= MB_OKCANCEL ? IDOK : IDYES);
     if (GetKeyState(VK_SHIFT) < 0)
         return TRUE;
-    return MessageBoxW(hWnd, Text, Title, Type) == positive;
+    return (MessageBoxW(hWnd, Text, Title, Type) == positive);
 }
 
 VOID ShowWin32Error(DWORD dwError)

--- a/base/applications/taskmgr/taskmgr.c
+++ b/base/applications/taskmgr/taskmgr.c
@@ -1056,6 +1056,14 @@ void TaskManager_OnTabWndSelChange(void)
     }
 }
 
+BOOL ConfirmMessageBox(HWND hWnd, LPCWSTR Text, LPCWSTR Title, UINT Type)
+{
+    UINT positive = (Type & 0xF) <= MB_OKCANCEL ? IDOK : IDYES;
+    if (GetKeyState(VK_SHIFT) < 0)
+        return TRUE;
+    return MessageBoxW(hWnd, Text, Title, Type) == positive;
+}
+
 VOID ShowWin32Error(DWORD dwError)
 {
     LPWSTR lpMessageBuffer;

--- a/base/applications/taskmgr/taskmgr.h
+++ b/base/applications/taskmgr/taskmgr.h
@@ -80,6 +80,7 @@ void TaskManager_OnRestoreMainWindow(void);
 void TaskManager_OnMenuSelect(HWND hWnd, UINT nItemID, UINT nFlags, HMENU hSysMenu);
 void TaskManager_OnViewUpdateSpeed(DWORD);
 void TaskManager_OnTabWndSelChange(void);
+BOOL ConfirmMessageBox(HWND hWnd, LPCWSTR Text, LPCWSTR Title, UINT Type);
 VOID ShowWin32Error(DWORD dwError);
 LPTSTR GetLastErrorText( LPTSTR lpszBuf, DWORD dwSize );
 DWORD EndLocalThread(HANDLE *hThread, DWORD dwThread);


### PR DESCRIPTION
Allow the user to hold shift to automatically answer `IDYES` when killing/debugging a process or changing the priority.