### PR TITLE
[SHELL32] Implement ExtractIconResInfoA

### DIFF
--- a/dll/win32/shell32/stubs.cpp
+++ b/dll/win32/shell32/stubs.cpp
@@ -939,26 +939,12 @@ Printers_AddPrinterPropPages(LPVOID lpUnknown1, LPVOID lpUnknown2)
  */
 EXTERN_C WORD
 WINAPI
-ExtractIconResInfoA(HANDLE hHandle,
-                    LPSTR lpFile,
-                    WORD wIndex,
-                    LPWORD lpSize,
-                    LPHANDLE lpIcon)
-{
-    FIXME("ExtractIconResInfoA() stub\n");
-    return 0;
-}
-
-/*
- * Unimplemented
- */
-EXTERN_C WORD
-WINAPI
-ExtractIconResInfoW(HANDLE hHandle,
-                    LPWSTR lpFile,
-                    WORD wIndex,
-                    LPWORD lpSize,
-                    LPHANDLE lpIcon)
+ExtractIconResInfoW(
+    _In_ HANDLE hHandle,
+    _In_ LPCWSTR lpFileName,
+    _In_ WORD wIndex,
+    _Out_ LPWORD lpSize,
+    _Out_ LPHANDLE lpIcon)
 {
     FIXME("ExtractIconResInfoW() stub\n");
     return 0;

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -66,6 +66,27 @@ PathIsSlowA(
 }
 
 /*************************************************************************
+ *                ExtractIconResInfoA (SHELL32.221)
+ */
+EXTERN_C
+WORD WINAPI
+ExtractIconResInfoA(
+    _In_ HANDLE hHandle,
+    _In_ LPCSTR lpFileName,
+    _In_ WORD wIndex,
+    _Out_ LPWORD lpSize,
+    _Out_ LPHANDLE lpIcon)
+{
+    TRACE("(%p, %s, %u, %p, %p)\n", hHandle, debugstr_a(lpFileName), wIndex, lpSize, lpIcon);
+
+    if (!lpFileName)
+        return 0;
+
+    CStringW strFileNameW(lpFileName);
+    return ExtractIconResInfoW(hHandle, strFileNameW, wIndex, lpSize, lpIcon);
+}
+
+/*************************************************************************
  *                SHOpenEffectiveToken (SHELL32.235)
  */
 EXTERN_C BOOL WINAPI SHOpenEffectiveToken(_Out_ LPHANDLE phToken)

--- a/sdk/include/reactos/undocshell.h
+++ b/sdk/include/reactos/undocshell.h
@@ -239,6 +239,22 @@ HICON WINAPI SHGetFileIcon(
 
 BOOL WINAPI FileIconInit(BOOL bFullInit);
 
+WORD WINAPI
+ExtractIconResInfoA(
+    _In_ HANDLE hHandle,
+    _In_ LPCSTR lpFileName,
+    _In_ WORD wIndex,
+    _Out_ LPWORD lpSize,
+    _Out_ LPHANDLE lpIcon);
+
+WORD WINAPI
+ExtractIconResInfoW(
+    _In_ HANDLE hHandle,
+    _In_ LPCWSTR lpFileName,
+    _In_ WORD wIndex,
+    _Out_ LPWORD lpSize,
+    _Out_ LPHANDLE lpIcon);
+
 /****************************************************************************
  * File Menu Routines
  */


### PR DESCRIPTION
## Purpose
Implementing missing features...
JIRA issue: N/A

## Proposed changes

- Add `ExtractIconResInfoA` function implementation.
- Add `ExtractIconResInfo` prototype to `<undocshell.h>`.

## TODO

- [x] Do build.