### PR TITLE
[INF][BOOTDATA] Improve LiveCD hostname

### DIFF
--- a/boot/bootdata/hivesys.inf
+++ b/boot/bootdata/hivesys.inf
@@ -444,7 +444,7 @@ HKLM,"SYSTEM\CurrentControlSet\Control\CoDeviceInstallers","{4D36E97D-E325-11CE-
 
 ; Default computer name settings
 HKLM,"SYSTEM\CurrentControlSet\Control\ComputerName",,0x00000012
-HKLM,"SYSTEM\CurrentControlSet\Control\ComputerName\ComputerName","ComputerName",0x00000002,"COMPUTERNAME"
+HKLM,"SYSTEM\CurrentControlSet\Control\ComputerName\ComputerName","ComputerName",0x00000002,"ROSHOST"
 
 ; Crash Control
 HKLM,"SYSTEM\CurrentControlSet\Control\CrashControl","AutoReboot",0x00010003,0

--- a/boot/bootdata/livecd.inf
+++ b/boot/bootdata/livecd.inf
@@ -17,7 +17,7 @@ HKLM,"SYSTEM\CurrentControlSet\Services\Cdrom","Start",0x00010001,0x00000000
 HKLM,"SYSTEM\CurrentControlSet\Control\Session Manager","BootExecute",0x00010000,""
 
 ; ComputerName
-HKLM,"SYSTEM\CurrentControlSet\Control\ComputerName\ComputerName","ComputerName",0x00000002,"ROSLIVECD"
+HKLM,"SYSTEM\CurrentControlSet\Control\ComputerName\ComputerName","ComputerName",0x00000002,"ROSHOST"
 
 ; Shell
 HKLM,"SYSTEM\Setup","CmdLine",0x00020000,"setup -mini"

--- a/boot/bootdata/livecd.inf
+++ b/boot/bootdata/livecd.inf
@@ -16,6 +16,9 @@ HKLM,"SYSTEM\CurrentControlSet\Services\Cdrom","Start",0x00010001,0x00000000
 ; Reset BootExecute to an empty value: AutoChk should not start in MiniNT mode
 HKLM,"SYSTEM\CurrentControlSet\Control\Session Manager","BootExecute",0x00010000,""
 
+; ComputerName
+HKLM,"SYSTEM\CurrentControlSet\Control\ComputerName\ComputerName","ComputerName",0x00000002,"ROSLIVECD"
+
 ; Shell
 HKLM,"SYSTEM\Setup","CmdLine",0x00020000,"setup -mini"
 

--- a/boot/bootdata/livecd.inf
+++ b/boot/bootdata/livecd.inf
@@ -16,7 +16,7 @@ HKLM,"SYSTEM\CurrentControlSet\Services\Cdrom","Start",0x00010001,0x00000000
 ; Reset BootExecute to an empty value: AutoChk should not start in MiniNT mode
 HKLM,"SYSTEM\CurrentControlSet\Control\Session Manager","BootExecute",0x00010000,""
 
-; ComputerName
+; Host Name
 HKLM,"SYSTEM\CurrentControlSet\Control\ComputerName\ComputerName","ComputerName",0x00000002,"ROSHOST"
 
 ; Shell

--- a/media/inf/nettcpip.inf
+++ b/media/inf/nettcpip.inf
@@ -254,8 +254,8 @@ HKR,"Parameters\PersistentRoutes",,0x00000010
 [tcpip_AddReg]
 HKR,"Parameters","DataBasePath",0x00020000,"%SystemRoot%\System32\drivers\etc"
 HKR,"Parameters","Domain",0x00000000,""
-HKR,"Parameters","Hostname",0x00000000,"ROSLIVECD"
-HKR,"Parameters","NV Hostname",0x00000000,"ROSLIVECD"
+HKR,"Parameters","Hostname",0x00000000,"ROSHOST"
+HKR,"Parameters","NV Hostname",0x00000000,"ROSHOST"
 HKR,"Parameters","NameServer",0x00000000,""
 HKR,"Parameters","ForwardBroadcasts",0x00010001,0x00000000
 HKR,"Parameters","IPEnableRouter",0x00010001,0x00000000

--- a/media/inf/nettcpip.inf
+++ b/media/inf/nettcpip.inf
@@ -254,7 +254,8 @@ HKR,"Parameters\PersistentRoutes",,0x00000010
 [tcpip_AddReg]
 HKR,"Parameters","DataBasePath",0x00020000,"%SystemRoot%\System32\drivers\etc"
 HKR,"Parameters","Domain",0x00000000,""
-HKR,"Parameters","Hostname",0x00000000,"ROSHost"
+HKR,"Parameters","Hostname",0x00000000,"ROSLIVECD"
+HKR,"Parameters","NV Hostname",0x00000000,"ROSLIVECD"
 HKR,"Parameters","NameServer",0x00000000,""
 HKR,"Parameters","ForwardBroadcasts",0x00010001,0x00000000
 HKR,"Parameters","IPEnableRouter",0x00010001,0x00000000


### PR DESCRIPTION
## Purpose

Based on hpoussin's patch.

JIRA issue: [CORE-19205](https://jira.reactos.org/browse/CORE-19205)

## Proposed changes

- Modify `boot/bootdata/livecd.inf`.
- Modify the values of `"Hostname"` and `"NV Hostname"` in `media/inf/nettcpip.inf`.

## TODO

- [x] Do tests.