### PR TITLE
[HALX86] Improve Ex*PoolWithTag() usages

### DIFF
--- a/hal/halx86/acpi/halpnpdd.c
+++ b/hal/halx86/acpi/halpnpdd.c
@@ -243,7 +243,7 @@ HalpQueryDeviceRelations(IN PDEVICE_OBJECT DeviceObject,
                 }
 
                 /* Free existing structure */
-                ExFreePool(*DeviceRelations);
+                ExFreePoolWithTag(*DeviceRelations, 0); // Tag is unknown.
             }
 
             /* Now check if we have a PDO list */
@@ -375,16 +375,15 @@ HalpQueryResources(IN PDEVICE_OBJECT DeviceObject,
 
         ASSERT(RequirementsList->AlternativeLists == 1);
 
-        /* Allocate the resourcel ist */
+        /* Allocate the resource list */
         ResourceList = ExAllocatePoolWithTag(PagedPool,
                                              sizeof(CM_RESOURCE_LIST),
                                              TAG_HAL);
         if (!ResourceList )
         {
             /* Fail, no memory */
-            Status = STATUS_INSUFFICIENT_RESOURCES;
             ExFreePoolWithTag(RequirementsList, TAG_HAL);
-            return Status;
+            return STATUS_INSUFFICIENT_RESOURCES;
         }
 
         /* Initialize it */

--- a/hal/halx86/generic/dma.c
+++ b/hal/halx86/generic/dma.c
@@ -1032,7 +1032,11 @@ HalpScatterGatherAdapterControl(IN PDEVICE_OBJECT DeviceObject,
 	ScatterGatherList = ExAllocatePoolWithTag(NonPagedPool,
 	                                          sizeof(SCATTER_GATHER_LIST) + sizeof(SCATTER_GATHER_ELEMENT) * ElementCount,
 											  TAG_DMA);
-	ASSERT(ScatterGatherList);
+	if (!ScatterGatherList)
+	{
+	    DPRINT1("ExAllocatePoolWithTag() failed\n");
+	    return DeallocateObject;
+	}
 
 	ScatterGatherList->NumberOfElements = ElementCount;
 	ScatterGatherList->Reserved = (ULONG_PTR)AdapterControlContext;

--- a/hal/halx86/generic/usage.c
+++ b/hal/halx86/generic/usage.c
@@ -541,8 +541,8 @@ HalpReportResourceUsage(IN PUNICODE_STRING HalName,
                              ListSize);
 
     /* Free our lists */
-    ExFreePool(RawList);
-    ExFreePool(TranslatedList);
+    ExFreePoolWithTag(RawList, TAG_HAL);
+    ExFreePoolWithTag(TranslatedList, TAG_HAL);
 
     /* Get the machine's serial number */
     HalpReportSerialNumber();

--- a/hal/halx86/include/hal.h
+++ b/hal/halx86/include/hal.h
@@ -6,8 +6,7 @@
  * PROGRAMMER:      Alex Ionescu (alex@relsoft.net)
  */
 
-#ifndef _HAL_PCH_
-#define _HAL_PCH_
+#pragma once
 
 /* INCLUDES ******************************************************************/
 
@@ -59,7 +58,7 @@
 #endif
 
 #define TAG_HAL    ' laH'
-#define TAG_BUS_HANDLER 'BusH'
+#define TAG_BUS_HANDLER 'HsuB'
 
 /* Internal HAL Headers */
 #include "bus.h"
@@ -78,5 +77,3 @@
 #include "halp.h"
 #include "mps.h"
 #include "halacpi.h"
-
-#endif /* _HAL_PCH_ */

--- a/hal/halx86/legacy/bus/pcibus.c
+++ b/hal/halx86/legacy/bus/pcibus.c
@@ -9,6 +9,7 @@
 /* INCLUDES ******************************************************************/
 
 #include <hal.h>
+
 #define NDEBUG
 #include <debug.h>
 
@@ -768,8 +769,10 @@ HalpAdjustPCIResourceList(IN PBUS_HANDLER BusHandler,
     SlotNumber.u.AsULONG = (*pResourceList)->SlotNumber;
 
     /* Get the IRQ supported range */
+    // FIXME: Isn't BusData->GetIrqRange NULL for _MINIHAL_?
     Status = BusData->GetIrqRange(BusHandler, RootHandler, SlotNumber, &Interrupt);
     if (!NT_SUCCESS(Status)) return Status;
+
 #ifndef _MINIHAL_
     /* Handle the /PCILOCK feature */
     if (HalpPciLockSettings)
@@ -778,6 +781,7 @@ HalpAdjustPCIResourceList(IN PBUS_HANDLER BusHandler,
         UNIMPLEMENTED_DBGBREAK("/PCILOCK boot switch is not yet supported.");
     }
 #endif
+
     /* Now create the correct resource list based on the supported bus ranges */
 #if 0
     Status = HaliAdjustResourceListRange(BusHandler->BusAddresses,
@@ -789,7 +793,7 @@ HalpAdjustPCIResourceList(IN PBUS_HANDLER BusHandler,
 #endif
 
     /* Return to caller */
-    ExFreePool(Interrupt);
+    ExFreePoolWithTag(Interrupt, TAG_HAL);
     return Status;
 }
 

--- a/hal/halx86/legacy/bus/pcibus.c
+++ b/hal/halx86/legacy/bus/pcibus.c
@@ -803,6 +803,7 @@ HalpAssignPCISlotResources(IN PBUS_HANDLER BusHandler,
                            IN PDEVICE_OBJECT DeviceObject OPTIONAL,
                            IN ULONG Slot,
                            IN OUT PCM_RESOURCE_LIST *AllocatedResources)
+// FIXME: AllocatedResources is OUT only. Check and fix callers too.
 {
     PCI_COMMON_CONFIG PciConfig;
     SIZE_T Address;
@@ -902,6 +903,8 @@ HalpAssignPCISlotResources(IN PBUS_HANDLER BusHandler,
             else
             {
                 ASSERT(FALSE);
+                ExFreePoolWithTag(*AllocatedResources, TAG_HAL);
+                *AllocatedResources = NULL;
                 return STATUS_UNSUCCESSFUL;
             }
             Descriptor++;

--- a/hal/halx86/legacy/halpnpdd.c
+++ b/hal/halx86/legacy/halpnpdd.c
@@ -9,6 +9,7 @@
 /* INCLUDES *******************************************************************/
 
 #include <hal.h>
+
 #define NDEBUG
 #include <debug.h>
 
@@ -220,7 +221,7 @@ HalpQueryDeviceRelations(IN PDEVICE_OBJECT DeviceObject,
                 }
 
                 /* Free existing structure */
-                ExFreePool(*DeviceRelations);
+                ExFreePoolWithTag(*DeviceRelations, 0); // Tag is unknown.
             }
 
             /* Now check if we have a PDO list */
@@ -335,12 +336,17 @@ HalpQueryResources(IN PDEVICE_OBJECT DeviceObject,
                    OUT PCM_RESOURCE_LIST *Resources)
 {
     PPDO_EXTENSION DeviceExtension = DeviceObject->DeviceExtension;
+#if 0
     NTSTATUS Status;
+#endif
     PCM_RESOURCE_LIST ResourceList;
-//    PIO_RESOURCE_REQUIREMENTS_LIST RequirementsList;
-//    PIO_RESOURCE_DESCRIPTOR Descriptor;
-//    PCM_PARTIAL_RESOURCE_DESCRIPTOR PartialDesc;
-//    ULONG i;
+#if 0
+    PIO_RESOURCE_REQUIREMENTS_LIST RequirementsList;
+    PIO_RESOURCE_DESCRIPTOR Descriptor;
+    PCM_PARTIAL_RESOURCE_DESCRIPTOR PartialDesc;
+    ULONG i;
+#endif
+
     PAGED_CODE();
 
     /* Only the ACPI PDO has requirements */
@@ -354,16 +360,17 @@ HalpQueryResources(IN PDEVICE_OBJECT DeviceObject,
         ASSERT(RequirementsList->AlternativeLists == 1);
 #endif
 
-        /* Allocate the resourcel ist */
+        /* Allocate the resource list */
         ResourceList = ExAllocatePoolWithTag(PagedPool,
                                              sizeof(CM_RESOURCE_LIST),
                                              TAG_HAL);
         if (!ResourceList )
         {
             /* Fail, no memory */
-            Status = STATUS_INSUFFICIENT_RESOURCES;
-//            ExFreePoolWithTag(RequirementsList, TAG_HAL);
-            return Status;
+#if 0
+            ExFreePoolWithTag(RequirementsList, TAG_HAL);
+#endif
+            return STATUS_INSUFFICIENT_RESOURCES;
         }
 
         /* Initialize it */
@@ -377,11 +384,11 @@ HalpQueryResources(IN PDEVICE_OBJECT DeviceObject,
         ResourceList->List[0].PartialResourceList.Revision = 1;
         ResourceList->List[0].PartialResourceList.Count = 0;
 
+#if 0
         /* Setup the first descriptor */
-        //PartialDesc = ResourceList->List[0].PartialResourceList.PartialDescriptors;
+        PartialDesc = ResourceList->List[0].PartialResourceList.PartialDescriptors;
 
         /* Find the requirement descriptor for the SCI */
-#if 0
         for (i = 0; i < RequirementsList->List[0].Count; i++)
         {
             /* Get this descriptor */
@@ -408,7 +415,9 @@ HalpQueryResources(IN PDEVICE_OBJECT DeviceObject,
         /* Return resources and success */
         *Resources = ResourceList;
 
-//        ExFreePoolWithTag(RequirementsList, TAG_HAL);
+#if 0
+        ExFreePoolWithTag(RequirementsList, TAG_HAL);
+#endif
 
         return STATUS_SUCCESS;
     }


### PR DESCRIPTION
## Purpose

More secure code.

Addendum to old commits.

## Proposed changes

- Reverse TAG_BUS_HANDLER value, so it displays correctly.
- Use ExFreePoolWithTag()
and add 1 missing call in an error case.