### PR TITLE
[NTUSER] Disable SC_MOVE if WS_MAXIMIZE or WS_MINIMIZE

### DIFF
--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -1366,7 +1366,7 @@ void FASTCALL MENU_InitSysMenuPopup(PMENU menu, DWORD style, DWORD clsStyle, LON
 
     gray = !(style & WS_THICKFRAME) || (style & (WS_MAXIMIZE | WS_MINIMIZE));
     IntEnableMenuItem( menu, SC_SIZE, (gray ? MF_GRAYED : MF_ENABLED) );
-    gray = ((style & WS_MAXIMIZE) != 0);
+    gray = ((style & (WS_MAXIMIZE | WS_MINIMIZE)) != 0);
     IntEnableMenuItem( menu, SC_MOVE, (gray ? MF_GRAYED : MF_ENABLED) );
     gray = !(style & WS_MINIMIZEBOX) || (style & WS_MINIMIZE);
     IntEnableMenuItem( menu, SC_MINIMIZE, (gray ? MF_GRAYED : MF_ENABLED) );


### PR DESCRIPTION
## Purpose
Based on KRosUser's `scmove.patch`.
JIRA issue: [CORE-19272](https://jira.reactos.org/browse/CORE-19272)

## Proposed changes

- Check also `WS_MINIMIZE` window style to determine to disable `SC_MOVE` system command.

## TODO

- [x] Do tests.