### PR TITLE
[BOOTDATA][HALX86] Compile the SMP hal on x86

### DIFF
--- a/boot/bootdata/livecd.ini
+++ b/boot/bootdata/livecd.ini
@@ -9,6 +9,7 @@ MinimalUI=Yes
 [Operating Systems]
 LiveCD="LiveCD"
 LiveCD_Debug="LiveCD (Debug)"
+LiveCD_Macpi="LiveCD ACPI SMP (Debug)"
 LiveCD_Aacpi="LiveCD ACPI APIC (Debug)"
 LiveCD_VBoxDebug="LiveCD (VBox Debug)"
 LiveCD_Screen="LiveCD (Screen)"
@@ -23,6 +24,11 @@ Options=/MININT
 BootType=Windows2003
 SystemPath=\reactos
 Options=/DEBUG /DEBUGPORT=COM1 /BAUDRATE=115200 /SOS /MININT
+
+[LiveCD_Macpi]
+BootType=Windows2003
+SystemPath=\reactos
+Options=/HAL=halmacpi.dll /KERNEL=ntkrnlmp.exe /DEBUG /DEBUGPORT=COM1 /BAUDRATE=115200 /SOS /MININT
 
 [LiveCD_Aacpi]
 BootType=Windows2003

--- a/boot/bootdata/txtsetup.sif
+++ b/boot/bootdata/txtsetup.sif
@@ -229,7 +229,7 @@ DefaultLanguage  = 00000409
 pci_up = "Standard PC Uniprocessor"
 ;pci_mp = "Standard PC Multiprocessor"
 acpi_up = "ACPI PC Uniprocessor"
-;acpi_mp = "ACPI PC Multiprocessor"
+acpi_mp = "ACPI PC Multiprocessor"
 apic_up = "Standard APIC PC Uniprocessor"
 aacpi_up = "ACPI APIC PC Uniprocessor"
 xbox = "Original Xbox (x86 based)"
@@ -244,7 +244,7 @@ x64_mp = "Standard x64 Multiprocessor"
 pci_up = "PC UP"
 ;pci_mp = "PC MP"
 acpi_up = "ACPI UP"
-;acpi_mp = "ACPI MP"
+acpi_mp = "ACPI MP"
 apic_up = "APIC UP"
 aacpi_up = "AAPIC UP"
 xbox = "Xbox"
@@ -266,9 +266,9 @@ hal.dll      = 1,,,,,,,2,,,,1,2
 ntoskrnl.exe = 1,,,,,,,2,,,,1,2
 halacpi.dll  = 1,,,,,,,2,,,hal.dll,1,2
 
-;[Files.acpi_mp]
-;ntkrnlmp.exe = 1,,,,,,,2,,,ntoskrnl.exe,1,2
-;halacpi.dll  = 1,,,,,,,2,,,hal.dll,1,2
+[Files.acpi_mp]
+ntkrnlmp.exe = 1,,,,,,,2,,,ntoskrnl.exe,1,2
+halmacpi.dll  = 1,,,,,,,2,,,hal.dll,1,2
 
 [Files.apic_up]
 ntoskrnl.exe = 1,,,,,,,2,,,,1,2

--- a/hal/halx86/CMakeLists.txt
+++ b/hal/halx86/CMakeLists.txt
@@ -66,7 +66,7 @@ if(ARCH STREQUAL "i386")
     add_hal(halxbox SOURCES xbox/halxbox.rc COMPONENTS xbox up)
     add_hal(halpc98 SOURCES pc98/halpc98.rc COMPONENTS pc98 up)
 
-    #add_hal(halmacpi SOURCES smp/halmacpi.rc COMPONENTS generic acpi smp apic)
+    add_hal(halmacpi SOURCES smp/halmacpi.rc COMPONENTS generic acpi smp apic)
     #add_hal(halmp SOURCES mp/halmp.rc COMPONENTS generic legacy smp apic)
 
 elseif(ARCH STREQUAL "amd64")


### PR DESCRIPTION
## Purpose

It appears the SMP kernel stopped booting on x86 again so let's just enable this so it stops regressing so fast.
