### PR TITLE
[INPUT] Implement advanced settings

### DIFF
--- a/dll/cpl/input/advanced_settings_page.c
+++ b/dll/cpl/input/advanced_settings_page.c
@@ -14,8 +14,8 @@ BOOL LoadAdvancedSettings(HWND hwndDlg)
 {
     HKEY hKey;
     LRESULT error;
-    DWORD dwValue;
     DWORD dwType;
+    DWORD dwValue;
     DWORD cbValue = sizeof(dwValue);
 
     error = RegOpenKeyExW(HKEY_CURRENT_USER, L"Software\\Microsoft\\CTF", 0, KEY_READ, &hKey);

--- a/dll/cpl/input/advanced_settings_page.c
+++ b/dll/cpl/input/advanced_settings_page.c
@@ -14,7 +14,8 @@ BOOL LoadAdvancedSettings(HWND hwndDlg)
 {
     HKEY hKey;
     LONG error;
-    DWORD dwValue = FALSE, cbValue = sizeof(dwValue);
+    DWORD dwValue = FALSE;
+    DWORD cbValue = sizeof(dwValue);
 
     error = RegOpenKeyExW(HKEY_CURRENT_USER, L"Software\\Microsoft\\CTF", 0, KEY_READ, &hKey);
     if (error != ERROR_SUCCESS)

--- a/dll/cpl/input/advanced_settings_page.c
+++ b/dll/cpl/input/advanced_settings_page.c
@@ -14,15 +14,23 @@ BOOL LoadAdvancedSettings(HWND hwndDlg)
 {
     HKEY hKey;
     LRESULT error;
-    DWORD dwValue = FALSE;
+    DWORD dwValue;
+    DWORD dwType;
     DWORD cbValue = sizeof(dwValue);
 
     error = RegOpenKeyExW(HKEY_CURRENT_USER, L"Software\\Microsoft\\CTF", 0, KEY_READ, &hKey);
     if (error != ERROR_SUCCESS)
         return FALSE;
 
-    RegQueryValueExW(hKey, L"Disable Thread Input Manager", NULL, NULL,
-                     (LPBYTE)&dwValue, &cbValue);
+    error = RegQueryValueExW(hKey,
+                             L"Disable Thread Input Manager",
+                             NULL,
+                             &dwType,
+                             (LPBYTE)&dwValue,
+                             &cbValue);
+    if ((error != ERROR_SUCCESS) || (dwType != REG_DWORD) || (cbValue != sizeof(dwValue)))
+        dwValue = FALSE;
+
     RegCloseKey(hKey);
 
     CheckDlgButton(hwndDlg, IDC_TURNOFFTEXTSVCS_CB, (dwValue ? BST_CHECKED : BST_UNCHECKED));

--- a/dll/cpl/input/advanced_settings_page.c
+++ b/dll/cpl/input/advanced_settings_page.c
@@ -74,16 +74,6 @@ static INT_PTR OnNotifyAdvancedSettingsPage(HWND hwndDlg, LPARAM lParam)
     return 0;
 }
 
-VOID OnCommandAdvancedSettingsPage(HWND hwndDlg, WPARAM wParam)
-{
-    switch (LOWORD(wParam))
-    {
-        case IDC_TURNOFFTEXTSVCS_CB:
-            PropSheet_Changed(GetParent(hwndDlg), hwndDlg);
-            break;
-    }
-}
-
 INT_PTR CALLBACK
 AdvancedSettingsPageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
@@ -97,8 +87,15 @@ AdvancedSettingsPageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
             return OnNotifyAdvancedSettingsPage(hwndDlg, lParam);
 
         case WM_COMMAND:
-            OnCommandAdvancedSettingsPage(hwndDlg, wParam);
+        {
+            switch (LOWORD(wParam))
+            {
+                case IDC_TURNOFFTEXTSVCS_CB:
+                    PropSheet_Changed(GetParent(hwndDlg), hwndDlg);
+                    break;
+            }
             break;
+        }
     }
 
     return 0;

--- a/dll/cpl/input/advanced_settings_page.c
+++ b/dll/cpl/input/advanced_settings_page.c
@@ -34,8 +34,7 @@ static BOOL SaveAdvancedSettings(HWND hwndDlg, BOOL bOff)
 {
     HKEY hKey;
     LONG error;
-    const DWORD dwValue = bOff;
-    const DWORD cbValue = sizeof(dwValue);
+    const DWORD dwValue = bOff, cbValue = sizeof(dwValue);
 
     error = RegOpenKeyExW(HKEY_CURRENT_USER, L"Software\\Microsoft\\CTF", 0, KEY_WRITE, &hKey);
     if (error != ERROR_SUCCESS)

--- a/dll/cpl/input/advanced_settings_page.c
+++ b/dll/cpl/input/advanced_settings_page.c
@@ -67,6 +67,9 @@ static INT_PTR OnNotifyAdvancedSettingsPage(HWND hwndDlg, LPARAM lParam)
             BOOL bOff = (IsDlgButtonChecked(hwndDlg, IDC_TURNOFFTEXTSVCS_CB) == BST_CHECKED);
             g_bRebootNeeded |= (g_bTextServiceIsOff && !bOff);
             g_bTextServiceIsOff = bOff;
+
+            /* Write advanced settings */
+            SaveAdvancedSettings(hwndDlg);
             break;
         }
     }

--- a/dll/cpl/input/advanced_settings_page.c
+++ b/dll/cpl/input/advanced_settings_page.c
@@ -29,7 +29,7 @@ BOOL LoadAdvancedSettings(HWND hwndDlg)
                              (LPBYTE)&dwValue,
                              &cbValue);
     if ((error != ERROR_SUCCESS) || (dwType != REG_DWORD) || (cbValue != sizeof(dwValue)))
-        dwValue = FALSE;
+        dwValue = FALSE; /* Default */
 
     RegCloseKey(hKey);
 

--- a/dll/cpl/input/advanced_settings_page.c
+++ b/dll/cpl/input/advanced_settings_page.c
@@ -3,13 +3,80 @@
 * FILE:            dll/cpl/input/advanced_settings_page.c
 * PURPOSE:         input.dll
 * PROGRAMMER:      Dmitry Chapyshev (dmitry@reactos.org)
+*                  Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
 */
 
 #include "input.h"
 
+static BOOL LoadAdvancedSettings(HWND hwndDlg)
+{
+    HKEY hKey;
+    LONG error;
+    DWORD dwValue = FALSE, cbValue = sizeof(dwValue);
+
+    error = RegOpenKeyExW(HKEY_CURRENT_USER, L"Software\\Microsoft\\CTF", 0, KEY_READ, &hKey);
+    if (error != ERROR_SUCCESS)
+        return FALSE;
+
+    RegQueryValueExW(hKey, L"Disable Thread Input Manager", NULL, NULL,
+                     (LPBYTE)&dwValue, &cbValue);
+    RegCloseKey(hKey);
+
+    CheckDlgButton(hwndDlg, IDC_TURNOFFTEXTSVCS_CB, (dwValue ? BST_CHECKED : BST_UNCHECKED));
+    return TRUE;
+}
+
+static BOOL SaveAdvancedSettings(HWND hwndDlg)
+{
+    HKEY hKey;
+    LONG error;
+    const DWORD dwValue = (IsDlgButtonChecked(hwndDlg, IDC_TURNOFFTEXTSVCS_CB) == BST_CHECKED);
+    const DWORD cbValue = sizeof(dwValue);
+
+    error = RegOpenKeyExW(HKEY_CURRENT_USER, L"Software\\Microsoft\\CTF", 0, KEY_WRITE, &hKey);
+    if (error != ERROR_SUCCESS)
+        return FALSE;
+
+    error = RegSetValueExW(hKey, L"Disable Thread Input Manager", 0, REG_DWORD,
+                           (const BYTE *)&dwValue, cbValue);
+
+    RegCloseKey(hKey);
+    return error == ERROR_SUCCESS;
+}
+
+static VOID OnInitAdvancedSettingsPage(HWND hwndDlg)
+{
+    LoadAdvancedSettings(hwndDlg);
+}
+
+static INT_PTR OnNotifyAdvancedSettingsPage(HWND hwndDlg, LPARAM lParam)
+{
+    LPNMHDR header = (LPNMHDR)lParam;
+
+    switch (header->code)
+    {
+        case PSN_APPLY:
+        {
+            SaveAdvancedSettings(hwndDlg);
+            break;
+        }
+    }
+
+    return 0;
+}
 
 INT_PTR CALLBACK
 AdvancedSettingsPageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-    return FALSE;
+    switch (uMsg)
+    {
+        case WM_INITDIALOG:
+            OnInitAdvancedSettingsPage(hwndDlg);
+            return TRUE;
+
+        case WM_NOTIFY:
+            return OnNotifyAdvancedSettingsPage(hwndDlg, lParam);
+    }
+
+    return 0;
 }

--- a/dll/cpl/input/advanced_settings_page.c
+++ b/dll/cpl/input/advanced_settings_page.c
@@ -26,11 +26,11 @@ static BOOL LoadAdvancedSettings(HWND hwndDlg)
     return TRUE;
 }
 
-static BOOL SaveAdvancedSettings(HWND hwndDlg)
+static BOOL SaveAdvancedSettings(HWND hwndDlg, BOOL bOff)
 {
     HKEY hKey;
     LONG error;
-    const DWORD dwValue = (IsDlgButtonChecked(hwndDlg, IDC_TURNOFFTEXTSVCS_CB) == BST_CHECKED);
+    const DWORD dwValue = bOff;
     const DWORD cbValue = sizeof(dwValue);
 
     error = RegOpenKeyExW(HKEY_CURRENT_USER, L"Software\\Microsoft\\CTF", 0, KEY_WRITE, &hKey);
@@ -57,7 +57,15 @@ static INT_PTR OnNotifyAdvancedSettingsPage(HWND hwndDlg, LPARAM lParam)
     {
         case PSN_APPLY:
         {
-            SaveAdvancedSettings(hwndDlg);
+            BOOL bOff = (IsDlgButtonChecked(hwndDlg, IDC_TURNOFFTEXTSVCS_CB) == BST_CHECKED);
+            SaveAdvancedSettings(hwndDlg, bOff);
+            if (!bOff)
+            {
+                WCHAR szText[128], szCaption[64];
+                LoadStringW(hApplet, IDS_REQUIRE_REBOOT, szText, _countof(szText));
+                LoadStringW(hApplet, IDS_ADVANCED_SETTINGS, szCaption, _countof(szCaption));
+                MessageBoxW(hwndDlg, szText, szCaption, MB_ICONINFORMATION);
+            }
             break;
         }
     }

--- a/dll/cpl/input/advanced_settings_page.c
+++ b/dll/cpl/input/advanced_settings_page.c
@@ -8,6 +8,9 @@
 
 #include "input.h"
 
+static BOOL s_bTextServiceWasOff = FALSE;
+BOOL g_bRebootNeeded = FALSE;
+
 static BOOL LoadAdvancedSettings(HWND hwndDlg)
 {
     HKEY hKey;
@@ -23,6 +26,7 @@ static BOOL LoadAdvancedSettings(HWND hwndDlg)
     RegCloseKey(hKey);
 
     CheckDlgButton(hwndDlg, IDC_TURNOFFTEXTSVCS_CB, (dwValue ? BST_CHECKED : BST_UNCHECKED));
+    s_bTextServiceWasOff = !!dwValue;
     return TRUE;
 }
 
@@ -59,13 +63,7 @@ static INT_PTR OnNotifyAdvancedSettingsPage(HWND hwndDlg, LPARAM lParam)
         {
             BOOL bOff = (IsDlgButtonChecked(hwndDlg, IDC_TURNOFFTEXTSVCS_CB) == BST_CHECKED);
             SaveAdvancedSettings(hwndDlg, bOff);
-            if (!bOff)
-            {
-                WCHAR szText[128], szCaption[64];
-                LoadStringW(hApplet, IDS_REQUIRE_REBOOT, szText, _countof(szText));
-                LoadStringW(hApplet, IDS_ADVANCED_SETTINGS, szCaption, _countof(szCaption));
-                MessageBoxW(hwndDlg, szText, szCaption, MB_ICONINFORMATION);
-            }
+            g_bRebootNeeded |= (s_bTextServiceWasOff && !bOff);
             break;
         }
     }

--- a/dll/cpl/input/advanced_settings_page.c
+++ b/dll/cpl/input/advanced_settings_page.c
@@ -44,7 +44,7 @@ BOOL SaveAdvancedSettings(HWND hwndDlg)
                            (const BYTE *)&dwValue, cbValue);
 
     RegCloseKey(hKey);
-    return error == ERROR_SUCCESS;
+    return (error == ERROR_SUCCESS);
 }
 
 static INT_PTR OnNotifyAdvancedSettingsPage(HWND hwndDlg, LPARAM lParam)

--- a/dll/cpl/input/advanced_settings_page.c
+++ b/dll/cpl/input/advanced_settings_page.c
@@ -13,7 +13,7 @@ BOOL g_bTextServiceIsOff = FALSE;
 BOOL LoadAdvancedSettings(HWND hwndDlg)
 {
     HKEY hKey;
-    LONG error;
+    LRESULT error;
     DWORD dwValue = FALSE;
     DWORD cbValue = sizeof(dwValue);
 
@@ -33,8 +33,9 @@ BOOL LoadAdvancedSettings(HWND hwndDlg)
 BOOL SaveAdvancedSettings(HWND hwndDlg)
 {
     HKEY hKey;
-    LONG error;
-    const DWORD dwValue = g_bTextServiceIsOff, cbValue = sizeof(dwValue);
+    LRESULT error;
+    const DWORD dwValue = g_bTextServiceIsOff;
+    const DWORD cbValue = sizeof(dwValue);
 
     error = RegOpenKeyExW(HKEY_CURRENT_USER, L"Software\\Microsoft\\CTF", 0, KEY_WRITE, &hKey);
     if (error != ERROR_SUCCESS)

--- a/dll/cpl/input/input.c
+++ b/dll/cpl/input/input.c
@@ -37,6 +37,14 @@ InitPropSheetPage(PROPSHEETPAGEW *page, WORD idDlg, DLGPROC DlgProc)
     page->pfnDlgProc  = DlgProc;
 }
 
+static BOOL AskForReboot(VOID)
+{
+    WCHAR szText[128], szCaption[64];
+    LoadStringW(hApplet, IDS_REBOOT_NOW, szText, _countof(szText));
+    LoadStringW(hApplet, IDS_LANGUAGE, szCaption, _countof(szCaption));
+    return (MessageBoxW(hwndDlg, szText, szCaption, MB_ICONINFORMATION | MB_YESNO) == IDYES)
+}
+
 static int CALLBACK
 PropSheetProc(HWND hwndDlg, UINT uMsg, LPARAM lParam)
 {
@@ -63,17 +71,10 @@ PropSheetProc(HWND hwndDlg, UINT uMsg, LPARAM lParam)
                 /* Write advanced settings */
                 SaveAdvancedSettings(hwndDlg);
 
-                if (g_bRebootNeeded)
+                if (g_bRebootNeeded && AskForReboot())
                 {
-                    WCHAR szText[128], szCaption[64];
-                    LoadStringW(hApplet, IDS_REBOOT_NOW, szText, _countof(szText));
-                    LoadStringW(hApplet, IDS_LANGUAGE, szCaption, _countof(szCaption));
-
-                    if (MessageBoxW(hwndDlg, szText, szCaption, MB_ICONINFORMATION | MB_YESNO) == IDYES)
-                    {
-                        EnableProcessPrivileges(SE_SHUTDOWN_NAME, TRUE);
-                        ExitWindowsEx(EWX_REBOOT | EWX_FORCE, 0);
-                    }
+                    EnableProcessPrivileges(SE_SHUTDOWN_NAME, TRUE);
+                    ExitWindowsEx(EWX_REBOOT | EWX_FORCE, 0);
                 }
                 break;
             }

--- a/dll/cpl/input/input.c
+++ b/dll/cpl/input/input.c
@@ -37,12 +37,12 @@ InitPropSheetPage(PROPSHEETPAGEW *page, WORD idDlg, DLGPROC DlgProc)
     page->pfnDlgProc  = DlgProc;
 }
 
-static BOOL AskForReboot(VOID)
+static BOOL AskForReboot(HWND hwndDlg)
 {
     WCHAR szText[128], szCaption[64];
     LoadStringW(hApplet, IDS_REBOOT_NOW, szText, _countof(szText));
     LoadStringW(hApplet, IDS_LANGUAGE, szCaption, _countof(szCaption));
-    return (MessageBoxW(hwndDlg, szText, szCaption, MB_ICONINFORMATION | MB_YESNO) == IDYES)
+    return (MessageBoxW(hwndDlg, szText, szCaption, MB_ICONINFORMATION | MB_YESNO) == IDYES);
 }
 
 static int CALLBACK
@@ -71,7 +71,7 @@ PropSheetProc(HWND hwndDlg, UINT uMsg, LPARAM lParam)
                     /* Write advanced settings */
                     SaveAdvancedSettings(hwndDlg);
 
-                    if (g_bRebootNeeded && AskForReboot())
+                    if (g_bRebootNeeded && AskForReboot(hwndDlg))
                     {
                         EnableProcessPrivileges(SE_SHUTDOWN_NAME, TRUE);
                         ExitWindowsEx(EWX_REBOOT | EWX_FORCE, 0);

--- a/dll/cpl/input/input.c
+++ b/dll/cpl/input/input.c
@@ -48,13 +48,12 @@ static BOOL AskForReboot(VOID)
 static int CALLBACK
 PropSheetProc(HWND hwndDlg, UINT uMsg, LPARAM lParam)
 {
-    HICON hIcon;
     switch (uMsg)
     {
         case PSCB_INITIALIZED:
         {
             /* Set large icon correctly */
-            hIcon = LoadIconW(hApplet, MAKEINTRESOURCEW(IDI_CPLSYSTEM));
+            HICON hIcon = LoadIconW(hApplet, MAKEINTRESOURCEW(IDI_CPLSYSTEM));
             SendMessageW(hwndDlg, WM_SETICON, ICON_BIG, (LPARAM)hIcon);
             break;
         }

--- a/dll/cpl/input/input.c
+++ b/dll/cpl/input/input.c
@@ -9,7 +9,6 @@
  */
 
 #include "input.h"
-#include "input_list.h"
 
 #define NUM_APPLETS    (1)
 
@@ -65,12 +64,6 @@ PropSheetProc(HWND hwndDlg, UINT uMsg, LPARAM lParam)
                 case PSBTN_OK:
                 case PSBTN_APPLYNOW:
                 {
-                    /* Write Input Methods list to registry */
-                    InputList_Process();
-
-                    /* Write advanced settings */
-                    SaveAdvancedSettings(hwndDlg);
-
                     if (g_bRebootNeeded && AskForReboot(hwndDlg))
                     {
                         EnableProcessPrivileges(SE_SHUTDOWN_NAME, TRUE);

--- a/dll/cpl/input/input.c
+++ b/dll/cpl/input/input.c
@@ -48,12 +48,12 @@ static BOOL AskForReboot(VOID)
 static int CALLBACK
 PropSheetProc(HWND hwndDlg, UINT uMsg, LPARAM lParam)
 {
-    // NOTE: This callback is needed to set large icon correctly.
     HICON hIcon;
     switch (uMsg)
     {
         case PSCB_INITIALIZED:
         {
+            /* Set large icon correctly */
             hIcon = LoadIconW(hApplet, MAKEINTRESOURCEW(IDI_CPLSYSTEM));
             SendMessageW(hwndDlg, WM_SETICON, ICON_BIG, (LPARAM)hIcon);
             break;
@@ -63,20 +63,22 @@ PropSheetProc(HWND hwndDlg, UINT uMsg, LPARAM lParam)
         {
             switch (lParam)
             {
-            case PSBTN_OK:
-            case PSBTN_APPLYNOW:
-                /* Write Input Methods list to registry */
-                InputList_Process();
-
-                /* Write advanced settings */
-                SaveAdvancedSettings(hwndDlg);
-
-                if (g_bRebootNeeded && AskForReboot())
+                case PSBTN_OK:
+                case PSBTN_APPLYNOW:
                 {
-                    EnableProcessPrivileges(SE_SHUTDOWN_NAME, TRUE);
-                    ExitWindowsEx(EWX_REBOOT | EWX_FORCE, 0);
+                    /* Write Input Methods list to registry */
+                    InputList_Process();
+
+                    /* Write advanced settings */
+                    SaveAdvancedSettings(hwndDlg);
+
+                    if (g_bRebootNeeded && AskForReboot())
+                    {
+                        EnableProcessPrivileges(SE_SHUTDOWN_NAME, TRUE);
+                        ExitWindowsEx(EWX_REBOOT | EWX_FORCE, 0);
+                    }
+                    break;
                 }
-                break;
             }
             break;
         }

--- a/dll/cpl/input/input.c
+++ b/dll/cpl/input/input.c
@@ -58,6 +58,7 @@ SystemApplet(HWND hwnd, UINT uMsg, LPARAM lParam1, LPARAM lParam2)
 {
     PROPSHEETPAGEW page[2];
     PROPSHEETHEADERW header;
+    LONG ret;
 
     ZeroMemory(&header, sizeof(header));
 
@@ -78,7 +79,23 @@ SystemApplet(HWND hwnd, UINT uMsg, LPARAM lParam1, LPARAM lParam2)
     /* Advanced Settings */
     InitPropSheetPage(&page[1], IDD_PROPPAGEADVANCEDSETTINGS, AdvancedSettingsPageProc);
 
-    return (LONG)(PropertySheetW(&header) != -1);
+    ret = (LONG)(PropertySheetW(&header) != -1);
+
+    /* Reboot now? */
+    if (g_bRebootNeeded)
+    {
+        WCHAR szText[128], szCaption[64];
+        LoadStringW(hApplet, IDS_REBOOT_NOW, szText, _countof(szText));
+        LoadStringW(hApplet, IDS_LANGUAGE, szCaption, _countof(szCaption));
+
+        if (MessageBoxW(hwnd, szText, szCaption, MB_ICONINFORMATION | MB_YESNO) == IDYES)
+        {
+            EnableProcessPrivileges(SE_SHUTDOWN_NAME, TRUE);
+            ExitWindowsEx(EWX_REBOOT | EWX_FORCE, 0);
+        }
+    }
+
+    return ret;
 }
 
 

--- a/dll/cpl/input/input.h
+++ b/dll/cpl/input/input.h
@@ -28,6 +28,7 @@ typedef struct
 } APPLET, *PAPPLET;
 
 extern HINSTANCE hApplet;
+extern BOOL g_bRebootNeeded;
 
 // Character Count of a layout ID like "00000409"
 #define CCH_LAYOUT_ID    8
@@ -40,6 +41,7 @@ extern HINSTANCE hApplet;
 /* settings_page.c */
 INT_PTR CALLBACK
 SettingsPageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
+BOOL EnableProcessPrivileges(LPCWSTR lpPrivilegeName, BOOL bEnable);
 
 /* advanced_settings_page.c */
 INT_PTR CALLBACK

--- a/dll/cpl/input/input.h
+++ b/dll/cpl/input/input.h
@@ -44,10 +44,8 @@ SettingsPageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
 BOOL EnableProcessPrivileges(LPCWSTR lpPrivilegeName, BOOL bEnable);
 
 /* advanced_settings_page.c */
-extern BOOL g_bTextServiceIsOff;
 INT_PTR CALLBACK
 AdvancedSettingsPageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
-BOOL SaveAdvancedSettings(HWND hwndDlg);
 
 /* add_dialog.c */
 INT_PTR CALLBACK

--- a/dll/cpl/input/input.h
+++ b/dll/cpl/input/input.h
@@ -44,8 +44,10 @@ SettingsPageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
 BOOL EnableProcessPrivileges(LPCWSTR lpPrivilegeName, BOOL bEnable);
 
 /* advanced_settings_page.c */
+extern BOOL g_bTextServiceIsOff;
 INT_PTR CALLBACK
 AdvancedSettingsPageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
+BOOL SaveAdvancedSettings(HWND hwndDlg);
 
 /* add_dialog.c */
 INT_PTR CALLBACK
@@ -95,5 +97,7 @@ DWORDfromString(const WCHAR *pszString)
 #define IS_SUBST_KLID(dwKLID)       ((((ULONG)(dwKLID)) & 0xF0000000) == SUBST_MASK)
 
 VOID GetSystemLibraryPath(LPWSTR pszPath, INT cchPath, LPCWSTR pszFileName);
+
+extern BOOL g_bRebootNeeded;
 
 #endif /* _INPUT_H */

--- a/dll/cpl/input/input.h
+++ b/dll/cpl/input/input.h
@@ -98,6 +98,4 @@ DWORDfromString(const WCHAR *pszString)
 
 VOID GetSystemLibraryPath(LPWSTR pszPath, INT cchPath, LPCWSTR pszFileName);
 
-extern BOOL g_bRebootNeeded;
-
 #endif /* _INPUT_H */

--- a/dll/cpl/input/input_list.c
+++ b/dll/cpl/input/input_list.c
@@ -395,12 +395,28 @@ InputList_Process(VOID)
         return FALSE;
     }
 
+    /* Find change in the IME HKLs */
+    for (pCurrent = _InputList; pCurrent != NULL; pCurrent = pCurrent->pNext)
+    {
+        if (!IS_IME_HKL(pCurrent->hkl))
+            continue;
+
+        if ((pCurrent->wFlags & INPUT_LIST_NODE_FLAG_ADDED) ||
+            (pCurrent->wFlags & INPUT_LIST_NODE_FLAG_EDITED) ||
+            (pCurrent->wFlags & INPUT_LIST_NODE_FLAG_DELETED))
+        {
+            bRet = TRUE; /* Reboot is needed */
+            break;
+        }
+    }
+
     /* Process DELETED and EDITED entries */
     for (pCurrent = _InputList; pCurrent != NULL; pCurrent = pCurrent->pNext)
     {
         if ((pCurrent->wFlags & INPUT_LIST_NODE_FLAG_DELETED) ||
             (pCurrent->wFlags & INPUT_LIST_NODE_FLAG_EDITED))
         {
+
             /* Only unload the DELETED and EDITED entries */
             if (UnloadKeyboardLayout(pCurrent->hkl))
             {

--- a/dll/cpl/input/lang/bg-BG.rc
+++ b/dll/cpl/input/lang/bg-BG.rc
@@ -111,8 +111,6 @@ BEGIN
     IDS_LEFT_ALT_SHIFT       "Ляв Alt+Shift"
     IDS_SWITCH_BET_INLANG    "Превключване на езиците за въвеждане"
     IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
-    IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
-    IDS_ADVANCED_SETTINGS "Advanced Settings"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/bg-BG.rc
+++ b/dll/cpl/input/lang/bg-BG.rc
@@ -110,7 +110,9 @@ BEGIN
     IDS_CTRL_SHIFT "Ctrl+Shift"
     IDS_LEFT_ALT_SHIFT       "Ляв Alt+Shift"
     IDS_SWITCH_BET_INLANG    "Превключване на езиците за въвеждане"
-    IDS_REBOOT_NOW, "Рестартирай сега?"
+    IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
+    IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
+    IDS_ADVANCED_SETTINGS "Advanced Settings"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/cs-CZ.rc
+++ b/dll/cpl/input/lang/cs-CZ.rc
@@ -116,8 +116,6 @@ BEGIN
     IDS_LEFT_ALT_SHIFT "Levý Alt+Shift"
     IDS_SWITCH_BET_INLANG "Přepnout mezi vstupními jazyky"
     IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
-    IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
-    IDS_ADVANCED_SETTINGS "Rozšířená nastavení"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/cs-CZ.rc
+++ b/dll/cpl/input/lang/cs-CZ.rc
@@ -117,7 +117,7 @@ BEGIN
     IDS_SWITCH_BET_INLANG "Přepnout mezi vstupními jazyky"
     IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
     IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
-    IDS_ADVANCED_SETTINGS "Advanced Settings"
+    IDS_ADVANCED_SETTINGS "Rozšířená nastavení"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/cs-CZ.rc
+++ b/dll/cpl/input/lang/cs-CZ.rc
@@ -115,7 +115,9 @@ BEGIN
     IDS_CTRL_SHIFT "Ctrl+Shift"
     IDS_LEFT_ALT_SHIFT "Levý Alt+Shift"
     IDS_SWITCH_BET_INLANG "Přepnout mezi vstupními jazyky"
-    IDS_REBOOT_NOW, "Reboot now?"
+    IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
+    IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
+    IDS_ADVANCED_SETTINGS "Advanced Settings"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/de-DE.rc
+++ b/dll/cpl/input/lang/de-DE.rc
@@ -110,7 +110,9 @@ BEGIN
     IDS_CTRL_SHIFT "Strg+Umschalt"
     IDS_LEFT_ALT_SHIFT "Alt links+Umschalt"
     IDS_SWITCH_BET_INLANG "Zwischen Eingabesprachen umschalten"
-    IDS_REBOOT_NOW, "Reboot now?"
+    IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
+    IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
+    IDS_ADVANCED_SETTINGS "Advanced Settings"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/de-DE.rc
+++ b/dll/cpl/input/lang/de-DE.rc
@@ -112,7 +112,7 @@ BEGIN
     IDS_SWITCH_BET_INLANG "Zwischen Eingabesprachen umschalten"
     IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
     IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
-    IDS_ADVANCED_SETTINGS "Advanced Settings"
+    IDS_ADVANCED_SETTINGS "Erweiterte Einstellungen"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/de-DE.rc
+++ b/dll/cpl/input/lang/de-DE.rc
@@ -111,8 +111,6 @@ BEGIN
     IDS_LEFT_ALT_SHIFT "Alt links+Umschalt"
     IDS_SWITCH_BET_INLANG "Zwischen Eingabesprachen umschalten"
     IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
-    IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
-    IDS_ADVANCED_SETTINGS "Erweiterte Einstellungen"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/el-GR.rc
+++ b/dll/cpl/input/lang/el-GR.rc
@@ -110,7 +110,9 @@ BEGIN
     IDS_CTRL_SHIFT "Ctrl+Shift"
     IDS_LEFT_ALT_SHIFT "Left Alt+Shift"
     IDS_SWITCH_BET_INLANG "Switch between input languages"
-    IDS_REBOOT_NOW, "Reboot now?"
+    IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
+    IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
+    IDS_ADVANCED_SETTINGS "Advanced Settings"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/el-GR.rc
+++ b/dll/cpl/input/lang/el-GR.rc
@@ -111,8 +111,6 @@ BEGIN
     IDS_LEFT_ALT_SHIFT "Left Alt+Shift"
     IDS_SWITCH_BET_INLANG "Switch between input languages"
     IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
-    IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
-    IDS_ADVANCED_SETTINGS "Advanced Settings"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/en-US.rc
+++ b/dll/cpl/input/lang/en-US.rc
@@ -110,7 +110,9 @@ BEGIN
     IDS_CTRL_SHIFT "Ctrl+Shift"
     IDS_LEFT_ALT_SHIFT "Left Alt+Shift"
     IDS_SWITCH_BET_INLANG "Switch between input languages"
-    IDS_REBOOT_NOW, "Reboot now?"
+    IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
+    IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
+    IDS_ADVANCED_SETTINGS "Advanced Settings"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/en-US.rc
+++ b/dll/cpl/input/lang/en-US.rc
@@ -111,8 +111,6 @@ BEGIN
     IDS_LEFT_ALT_SHIFT "Left Alt+Shift"
     IDS_SWITCH_BET_INLANG "Switch between input languages"
     IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
-    IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
-    IDS_ADVANCED_SETTINGS "Advanced Settings"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/es-ES.rc
+++ b/dll/cpl/input/lang/es-ES.rc
@@ -119,7 +119,9 @@ BEGIN
     IDS_CTRL_SHIFT "Ctrl+Mayús"
     IDS_LEFT_ALT_SHIFT "Alt Izq+Mayús"
     IDS_SWITCH_BET_INLANG "Cambiar entre los idiomas de entrada"
-    IDS_REBOOT_NOW, "¿Reiniciar ahora?"
+    IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
+    IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
+    IDS_ADVANCED_SETTINGS "Advanced Settings"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/es-ES.rc
+++ b/dll/cpl/input/lang/es-ES.rc
@@ -120,8 +120,6 @@ BEGIN
     IDS_LEFT_ALT_SHIFT "Alt Izq+Mayús"
     IDS_SWITCH_BET_INLANG "Cambiar entre los idiomas de entrada"
     IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
-    IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
-    IDS_ADVANCED_SETTINGS "Ajustes avanzados"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/es-ES.rc
+++ b/dll/cpl/input/lang/es-ES.rc
@@ -121,7 +121,7 @@ BEGIN
     IDS_SWITCH_BET_INLANG "Cambiar entre los idiomas de entrada"
     IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
     IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
-    IDS_ADVANCED_SETTINGS "Advanced Settings"
+    IDS_ADVANCED_SETTINGS "Ajustes avanzados"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/fr-FR.rc
+++ b/dll/cpl/input/lang/fr-FR.rc
@@ -110,7 +110,9 @@ BEGIN
     IDS_CTRL_SHIFT "Ctrl+Maj"
     IDS_LEFT_ALT_SHIFT "Alt Gauche+Maj"
     IDS_SWITCH_BET_INLANG "Changer les langues de saisie"
-    IDS_REBOOT_NOW, "Redémarrer maintenant ?"
+    IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
+    IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
+    IDS_ADVANCED_SETTINGS "Advanced Settings"
 END
 
 /* FIXME : À améliorer/compléter */

--- a/dll/cpl/input/lang/fr-FR.rc
+++ b/dll/cpl/input/lang/fr-FR.rc
@@ -112,7 +112,7 @@ BEGIN
     IDS_SWITCH_BET_INLANG "Changer les langues de saisie"
     IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
     IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
-    IDS_ADVANCED_SETTINGS "Advanced Settings"
+    IDS_ADVANCED_SETTINGS "Paramètres avancés"
 END
 
 /* FIXME : À améliorer/compléter */

--- a/dll/cpl/input/lang/fr-FR.rc
+++ b/dll/cpl/input/lang/fr-FR.rc
@@ -111,8 +111,6 @@ BEGIN
     IDS_LEFT_ALT_SHIFT "Alt Gauche+Maj"
     IDS_SWITCH_BET_INLANG "Changer les langues de saisie"
     IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
-    IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
-    IDS_ADVANCED_SETTINGS "Paramètres avancés"
 END
 
 /* FIXME : À améliorer/compléter */

--- a/dll/cpl/input/lang/fr-FR.rc
+++ b/dll/cpl/input/lang/fr-FR.rc
@@ -110,7 +110,7 @@ BEGIN
     IDS_CTRL_SHIFT "Ctrl+Maj"
     IDS_LEFT_ALT_SHIFT "Alt Gauche+Maj"
     IDS_SWITCH_BET_INLANG "Changer les langues de saisie"
-    IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
+    IDS_REBOOT_NOW "Il est nécessaire de redémarrer le système afin que les changements prennent effet. Redémarrer maintenant ?"
 END
 
 /* FIXME : À améliorer/compléter */

--- a/dll/cpl/input/lang/he-IL.rc
+++ b/dll/cpl/input/lang/he-IL.rc
@@ -114,7 +114,7 @@ BEGIN
     IDS_SWITCH_BET_INLANG "החלף בין שפות כתיבה"
     IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
     IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
-    IDS_ADVANCED_SETTINGS "Advanced Settings"
+    IDS_ADVANCED_SETTINGS "הגדרות מתקדמות"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/he-IL.rc
+++ b/dll/cpl/input/lang/he-IL.rc
@@ -112,7 +112,9 @@ BEGIN
     IDS_CTRL_SHIFT "Ctrl+Shift"
     IDS_LEFT_ALT_SHIFT "מקש Alt שמאלי+Shift"
     IDS_SWITCH_BET_INLANG "החלף בין שפות כתיבה"
-    IDS_REBOOT_NOW, "להפעיל מחדש כעת?"
+    IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
+    IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
+    IDS_ADVANCED_SETTINGS "Advanced Settings"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/he-IL.rc
+++ b/dll/cpl/input/lang/he-IL.rc
@@ -113,8 +113,6 @@ BEGIN
     IDS_LEFT_ALT_SHIFT "מקש Alt שמאלי+Shift"
     IDS_SWITCH_BET_INLANG "החלף בין שפות כתיבה"
     IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
-    IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
-    IDS_ADVANCED_SETTINGS "הגדרות מתקדמות"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/id-ID.rc
+++ b/dll/cpl/input/lang/id-ID.rc
@@ -110,7 +110,9 @@ BEGIN
     IDS_CTRL_SHIFT "Ctrl+Shift"
     IDS_LEFT_ALT_SHIFT "Alt kiri+Shift"
     IDS_SWITCH_BET_INLANG "Mengganti salah satu bahasa masukan"
-    IDS_REBOOT_NOW, "Mulai ulang sekarang?"
+    IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
+    IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
+    IDS_ADVANCED_SETTINGS "Advanced Settings"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/id-ID.rc
+++ b/dll/cpl/input/lang/id-ID.rc
@@ -112,7 +112,7 @@ BEGIN
     IDS_SWITCH_BET_INLANG "Mengganti salah satu bahasa masukan"
     IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
     IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
-    IDS_ADVANCED_SETTINGS "Advanced Settings"
+    IDS_ADVANCED_SETTINGS "Setelan Lanjutan"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/id-ID.rc
+++ b/dll/cpl/input/lang/id-ID.rc
@@ -111,8 +111,6 @@ BEGIN
     IDS_LEFT_ALT_SHIFT "Alt kiri+Shift"
     IDS_SWITCH_BET_INLANG "Mengganti salah satu bahasa masukan"
     IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
-    IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
-    IDS_ADVANCED_SETTINGS "Setelan Lanjutan"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/it-IT.rc
+++ b/dll/cpl/input/lang/it-IT.rc
@@ -112,7 +112,7 @@ BEGIN
     IDS_SWITCH_BET_INLANG "Cambia lingua di digitazione"
     IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
     IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
-    IDS_ADVANCED_SETTINGS "Advanced Settings"
+    IDS_ADVANCED_SETTINGS "Impostazioni avanzate"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/it-IT.rc
+++ b/dll/cpl/input/lang/it-IT.rc
@@ -110,7 +110,9 @@ BEGIN
     IDS_CTRL_SHIFT "Ctrl+Shift"
     IDS_LEFT_ALT_SHIFT "Alt sinistro+Shift"
     IDS_SWITCH_BET_INLANG "Cambia lingua di digitazione"
-    IDS_REBOOT_NOW, "Reboot now?"
+    IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
+    IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
+    IDS_ADVANCED_SETTINGS "Advanced Settings"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/it-IT.rc
+++ b/dll/cpl/input/lang/it-IT.rc
@@ -111,8 +111,6 @@ BEGIN
     IDS_LEFT_ALT_SHIFT "Alt sinistro+Shift"
     IDS_SWITCH_BET_INLANG "Cambia lingua di digitazione"
     IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
-    IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
-    IDS_ADVANCED_SETTINGS "Impostazioni avanzate"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/ja-JP.rc
+++ b/dll/cpl/input/lang/ja-JP.rc
@@ -110,7 +110,9 @@ BEGIN
     IDS_CTRL_SHIFT "Ctrl+Shift"
     IDS_LEFT_ALT_SHIFT "左Alt+Shift"
     IDS_SWITCH_BET_INLANG "入力言語の切り替え"
-    IDS_REBOOT_NOW, "再起動しますか?"
+    IDS_REBOOT_NOW "設定を有効にするにはシステムを再起動する必要があります。今すぐ再起動しますか？"
+    IDS_REQUIRE_REBOOT "設定を有効にするにはシステムを再起動する必要があります。"
+    IDS_ADVANCED_SETTINGS "上級者向け設定"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/ja-JP.rc
+++ b/dll/cpl/input/lang/ja-JP.rc
@@ -111,8 +111,6 @@ BEGIN
     IDS_LEFT_ALT_SHIFT "左Alt+Shift"
     IDS_SWITCH_BET_INLANG "入力言語の切り替え"
     IDS_REBOOT_NOW "設定を有効にするにはシステムを再起動する必要があります。今すぐ再起動しますか？"
-    IDS_REQUIRE_REBOOT "設定を有効にするにはシステムを再起動する必要があります。"
-    IDS_ADVANCED_SETTINGS "上級者向け設定"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/no-NO.rc
+++ b/dll/cpl/input/lang/no-NO.rc
@@ -110,7 +110,9 @@ BEGIN
     IDS_CTRL_SHIFT "Ctrl+Shift"
     IDS_LEFT_ALT_SHIFT "Venstre Alt+Shift"
     IDS_SWITCH_BET_INLANG "Bytt mellom inndataspråk"
-    IDS_REBOOT_NOW, "Reboot now?"
+    IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
+    IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
+    IDS_ADVANCED_SETTINGS "Advanced Settings"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/no-NO.rc
+++ b/dll/cpl/input/lang/no-NO.rc
@@ -111,8 +111,6 @@ BEGIN
     IDS_LEFT_ALT_SHIFT "Venstre Alt+Shift"
     IDS_SWITCH_BET_INLANG "Bytt mellom inndataspråk"
     IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
-    IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
-    IDS_ADVANCED_SETTINGS "Advanced Settings"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/pl-PL.rc
+++ b/dll/cpl/input/lang/pl-PL.rc
@@ -120,8 +120,6 @@ BEGIN
     IDS_LEFT_ALT_SHIFT "Lewy Alt+Shift"
     IDS_SWITCH_BET_INLANG "Przełącza pomiędzy układami klawiatury"
     IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
-    IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
-    IDS_ADVANCED_SETTINGS "Zaawansowane"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/pl-PL.rc
+++ b/dll/cpl/input/lang/pl-PL.rc
@@ -121,7 +121,7 @@ BEGIN
     IDS_SWITCH_BET_INLANG "Przełącza pomiędzy układami klawiatury"
     IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
     IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
-    IDS_ADVANCED_SETTINGS "Advanced Settings"
+    IDS_ADVANCED_SETTINGS "Zaawansowane"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/pl-PL.rc
+++ b/dll/cpl/input/lang/pl-PL.rc
@@ -119,7 +119,9 @@ BEGIN
     IDS_CTRL_SHIFT "Ctrl+Shift"
     IDS_LEFT_ALT_SHIFT "Lewy Alt+Shift"
     IDS_SWITCH_BET_INLANG "Przełącza pomiędzy układami klawiatury"
-    IDS_REBOOT_NOW, "Uruchomić ponownie system?"
+    IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
+    IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
+    IDS_ADVANCED_SETTINGS "Advanced Settings"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/pt-BR.rc
+++ b/dll/cpl/input/lang/pt-BR.rc
@@ -110,7 +110,9 @@ BEGIN
     IDS_CTRL_SHIFT "CTRL+SHIFT"
     IDS_LEFT_ALT_SHIFT "ALT esquerdo+SHIFT"
     IDS_SWITCH_BET_INLANG "Alternar entre idiomas de entrada"
-    IDS_REBOOT_NOW, "Reboot now?"
+    IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
+    IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
+    IDS_ADVANCED_SETTINGS "Advanced Settings"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/pt-BR.rc
+++ b/dll/cpl/input/lang/pt-BR.rc
@@ -111,8 +111,6 @@ BEGIN
     IDS_LEFT_ALT_SHIFT "ALT esquerdo+SHIFT"
     IDS_SWITCH_BET_INLANG "Alternar entre idiomas de entrada"
     IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
-    IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
-    IDS_ADVANCED_SETTINGS "Configurações avançadas"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/pt-BR.rc
+++ b/dll/cpl/input/lang/pt-BR.rc
@@ -112,7 +112,7 @@ BEGIN
     IDS_SWITCH_BET_INLANG "Alternar entre idiomas de entrada"
     IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
     IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
-    IDS_ADVANCED_SETTINGS "Advanced Settings"
+    IDS_ADVANCED_SETTINGS "Configurações avançadas"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/pt-PT.rc
+++ b/dll/cpl/input/lang/pt-PT.rc
@@ -111,8 +111,6 @@ BEGIN
     IDS_LEFT_ALT_SHIFT "ALT esquerdo+SHIFT"
     IDS_SWITCH_BET_INLANG "Alternar entre idiomas de entrada"
     IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
-    IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
-    IDS_ADVANCED_SETTINGS "Definições avançadas"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/pt-PT.rc
+++ b/dll/cpl/input/lang/pt-PT.rc
@@ -110,7 +110,9 @@ BEGIN
     IDS_CTRL_SHIFT "CTRL+SHIFT"
     IDS_LEFT_ALT_SHIFT "ALT esquerdo+SHIFT"
     IDS_SWITCH_BET_INLANG "Alternar entre idiomas de entrada"
-    IDS_REBOOT_NOW, "Reiniciar agora?"
+    IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
+    IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
+    IDS_ADVANCED_SETTINGS "Advanced Settings"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/pt-PT.rc
+++ b/dll/cpl/input/lang/pt-PT.rc
@@ -112,7 +112,7 @@ BEGIN
     IDS_SWITCH_BET_INLANG "Alternar entre idiomas de entrada"
     IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
     IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
-    IDS_ADVANCED_SETTINGS "Advanced Settings"
+    IDS_ADVANCED_SETTINGS "Definições avançadas"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/ro-RO.rc
+++ b/dll/cpl/input/lang/ro-RO.rc
@@ -120,7 +120,7 @@ BEGIN
     IDS_SWITCH_BET_INLANG "Comutarea între limbile de intrare"
     IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
     IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
-    IDS_ADVANCED_SETTINGS "Advanced Settings"
+    IDS_ADVANCED_SETTINGS "Configurație avansată"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/ro-RO.rc
+++ b/dll/cpl/input/lang/ro-RO.rc
@@ -119,8 +119,6 @@ BEGIN
     IDS_LEFT_ALT_SHIFT "«Alt» (stâng) + «Shift»"
     IDS_SWITCH_BET_INLANG "Comutarea între limbile de intrare"
     IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
-    IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
-    IDS_ADVANCED_SETTINGS "Configurație avansată"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/ro-RO.rc
+++ b/dll/cpl/input/lang/ro-RO.rc
@@ -118,7 +118,9 @@ BEGIN
     IDS_CTRL_SHIFT "«Ctrl» + «Shift»"
     IDS_LEFT_ALT_SHIFT "«Alt» (stâng) + «Shift»"
     IDS_SWITCH_BET_INLANG "Comutarea între limbile de intrare"
-    IDS_REBOOT_NOW, "Reporniți acum?"
+    IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
+    IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
+    IDS_ADVANCED_SETTINGS "Advanced Settings"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/ru-RU.rc
+++ b/dll/cpl/input/lang/ru-RU.rc
@@ -111,8 +111,6 @@ BEGIN
     IDS_LEFT_ALT_SHIFT "Alt слева+Shift"
     IDS_SWITCH_BET_INLANG "Переключение между языками ввода"
     IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
-    IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
-    IDS_ADVANCED_SETTINGS "Дополнительные параметры"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/ru-RU.rc
+++ b/dll/cpl/input/lang/ru-RU.rc
@@ -110,7 +110,9 @@ BEGIN
     IDS_CTRL_SHIFT "Ctrl+Shift"
     IDS_LEFT_ALT_SHIFT "Alt слева+Shift"
     IDS_SWITCH_BET_INLANG "Переключение между языками ввода"
-    IDS_REBOOT_NOW, "Перезагрузить сейчас?"
+    IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
+    IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
+    IDS_ADVANCED_SETTINGS "Advanced Settings"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/ru-RU.rc
+++ b/dll/cpl/input/lang/ru-RU.rc
@@ -112,7 +112,7 @@ BEGIN
     IDS_SWITCH_BET_INLANG "Переключение между языками ввода"
     IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
     IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
-    IDS_ADVANCED_SETTINGS "Advanced Settings"
+    IDS_ADVANCED_SETTINGS "Дополнительные параметры"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/sk-SK.rc
+++ b/dll/cpl/input/lang/sk-SK.rc
@@ -115,7 +115,9 @@ BEGIN
     IDS_CTRL_SHIFT "Ctrl+Shift"
     IDS_LEFT_ALT_SHIFT "Ľavý Alt+Shift"
     IDS_SWITCH_BET_INLANG "Switch between input languages"
-    IDS_REBOOT_NOW, "Reboot now?"
+    IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
+    IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
+    IDS_ADVANCED_SETTINGS "Advanced Settings"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/sk-SK.rc
+++ b/dll/cpl/input/lang/sk-SK.rc
@@ -116,8 +116,6 @@ BEGIN
     IDS_LEFT_ALT_SHIFT "Ľavý Alt+Shift"
     IDS_SWITCH_BET_INLANG "Switch between input languages"
     IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
-    IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
-    IDS_ADVANCED_SETTINGS "Advanced Settings"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/sq-AL.rc
+++ b/dll/cpl/input/lang/sq-AL.rc
@@ -115,8 +115,6 @@ BEGIN
     IDS_LEFT_ALT_SHIFT "Left Alt+Shift"
     IDS_SWITCH_BET_INLANG "Ndërro ndër gjuhët hyrese"
     IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
-    IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
-    IDS_ADVANCED_SETTINGS "Cilësimet Avancume"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/sq-AL.rc
+++ b/dll/cpl/input/lang/sq-AL.rc
@@ -116,7 +116,7 @@ BEGIN
     IDS_SWITCH_BET_INLANG "Ndërro ndër gjuhët hyrese"
     IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
     IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
-    IDS_ADVANCED_SETTINGS "Advanced Settings"
+    IDS_ADVANCED_SETTINGS "Cilësimet Avancume"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/sq-AL.rc
+++ b/dll/cpl/input/lang/sq-AL.rc
@@ -114,7 +114,9 @@ BEGIN
     IDS_CTRL_SHIFT "Ctrl+Shift"
     IDS_LEFT_ALT_SHIFT "Left Alt+Shift"
     IDS_SWITCH_BET_INLANG "Ndërro ndër gjuhët hyrese"
-    IDS_REBOOT_NOW, "Reboot now?"
+    IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
+    IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
+    IDS_ADVANCED_SETTINGS "Advanced Settings"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/tr-TR.rc
+++ b/dll/cpl/input/lang/tr-TR.rc
@@ -113,8 +113,6 @@ BEGIN
     IDS_LEFT_ALT_SHIFT "Sol Alt + Shift"
     IDS_SWITCH_BET_INLANG "Giriş dilleri arasında geçiş yap."
     IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
-    IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
-    IDS_ADVANCED_SETTINGS "Gelişmiş Ayarlar"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/tr-TR.rc
+++ b/dll/cpl/input/lang/tr-TR.rc
@@ -114,7 +114,7 @@ BEGIN
     IDS_SWITCH_BET_INLANG "Giriş dilleri arasında geçiş yap."
     IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
     IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
-    IDS_ADVANCED_SETTINGS "Advanced Settings"
+    IDS_ADVANCED_SETTINGS "Gelişmiş Ayarlar"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/tr-TR.rc
+++ b/dll/cpl/input/lang/tr-TR.rc
@@ -112,7 +112,9 @@ BEGIN
     IDS_CTRL_SHIFT "Ctrl + Shift"
     IDS_LEFT_ALT_SHIFT "Sol Alt + Shift"
     IDS_SWITCH_BET_INLANG "Giriş dilleri arasında geçiş yap."
-    IDS_REBOOT_NOW, "Şimdi yeniden başlatılsın mı?"
+    IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
+    IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
+    IDS_ADVANCED_SETTINGS "Advanced Settings"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/uk-UA.rc
+++ b/dll/cpl/input/lang/uk-UA.rc
@@ -120,7 +120,7 @@ BEGIN
     IDS_SWITCH_BET_INLANG "Перемикання мов вводу"
     IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
     IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
-    IDS_ADVANCED_SETTINGS "Advanced Settings"
+    IDS_ADVANCED_SETTINGS "Додаткові параметри"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/uk-UA.rc
+++ b/dll/cpl/input/lang/uk-UA.rc
@@ -118,7 +118,9 @@ BEGIN
     IDS_CTRL_SHIFT "Ctrl+Shift"
     IDS_LEFT_ALT_SHIFT "Alt зліва+Shift"
     IDS_SWITCH_BET_INLANG "Перемикання мов вводу"
-    IDS_REBOOT_NOW, "Перезавантажити зараз?"
+    IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
+    IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
+    IDS_ADVANCED_SETTINGS "Advanced Settings"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/uk-UA.rc
+++ b/dll/cpl/input/lang/uk-UA.rc
@@ -119,8 +119,6 @@ BEGIN
     IDS_LEFT_ALT_SHIFT "Alt зліва+Shift"
     IDS_SWITCH_BET_INLANG "Перемикання мов вводу"
     IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
-    IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
-    IDS_ADVANCED_SETTINGS "Додаткові параметри"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/zh-CN.rc
+++ b/dll/cpl/input/lang/zh-CN.rc
@@ -113,8 +113,6 @@ BEGIN
     IDS_LEFT_ALT_SHIFT "左 Alt+Shift"
     IDS_SWITCH_BET_INLANG "在输入语言间切换"
     IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
-    IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
-    IDS_ADVANCED_SETTINGS "高级设置"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/zh-CN.rc
+++ b/dll/cpl/input/lang/zh-CN.rc
@@ -112,7 +112,9 @@ BEGIN
     IDS_CTRL_SHIFT "Ctrl+Shift"
     IDS_LEFT_ALT_SHIFT "左 Alt+Shift"
     IDS_SWITCH_BET_INLANG "在输入语言间切换"
-    IDS_REBOOT_NOW, "要现在重新启动计算机吗？"
+    IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
+    IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
+    IDS_ADVANCED_SETTINGS "Advanced Settings"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/zh-CN.rc
+++ b/dll/cpl/input/lang/zh-CN.rc
@@ -114,7 +114,7 @@ BEGIN
     IDS_SWITCH_BET_INLANG "在输入语言间切换"
     IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
     IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
-    IDS_ADVANCED_SETTINGS "Advanced Settings"
+    IDS_ADVANCED_SETTINGS "高级设置"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/zh-HK.rc
+++ b/dll/cpl/input/lang/zh-HK.rc
@@ -119,8 +119,6 @@ BEGIN
     IDS_LEFT_ALT_SHIFT "左 Alt+Shift"
     IDS_SWITCH_BET_INLANG "在輸入語言間切換"
     IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
-    IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
-    IDS_ADVANCED_SETTINGS "進階設定"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/zh-HK.rc
+++ b/dll/cpl/input/lang/zh-HK.rc
@@ -120,7 +120,7 @@ BEGIN
     IDS_SWITCH_BET_INLANG "在輸入語言間切換"
     IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
     IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
-    IDS_ADVANCED_SETTINGS "Advanced Settings"
+    IDS_ADVANCED_SETTINGS "進階設定"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/zh-HK.rc
+++ b/dll/cpl/input/lang/zh-HK.rc
@@ -118,7 +118,9 @@ BEGIN
     IDS_CTRL_SHIFT "Ctrl+Shift"
     IDS_LEFT_ALT_SHIFT "左 Alt+Shift"
     IDS_SWITCH_BET_INLANG "在輸入語言間切換"
-    IDS_REBOOT_NOW, "要立即重新啟動嗎？"
+    IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
+    IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
+    IDS_ADVANCED_SETTINGS "Advanced Settings"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/zh-TW.rc
+++ b/dll/cpl/input/lang/zh-TW.rc
@@ -119,8 +119,6 @@ BEGIN
     IDS_LEFT_ALT_SHIFT "左 Alt+Shift"
     IDS_SWITCH_BET_INLANG "在輸入語言間切換"
     IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
-    IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
-    IDS_ADVANCED_SETTINGS "進階設定"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/zh-TW.rc
+++ b/dll/cpl/input/lang/zh-TW.rc
@@ -120,7 +120,7 @@ BEGIN
     IDS_SWITCH_BET_INLANG "在輸入語言間切換"
     IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
     IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
-    IDS_ADVANCED_SETTINGS "Advanced Settings"
+    IDS_ADVANCED_SETTINGS "進階設定"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/zh-TW.rc
+++ b/dll/cpl/input/lang/zh-TW.rc
@@ -118,7 +118,9 @@ BEGIN
     IDS_CTRL_SHIFT "Ctrl+Shift"
     IDS_LEFT_ALT_SHIFT "左 Alt+Shift"
     IDS_SWITCH_BET_INLANG "在輸入語言間切換"
-    IDS_REBOOT_NOW, "要立即重新啟動嗎？"
+    IDS_REBOOT_NOW "You have to restart the system for the settings to take effect. Reboot now?"
+    IDS_REQUIRE_REBOOT "You have to restart the system for the settings to take effect."
+    IDS_ADVANCED_SETTINGS "Advanced Settings"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/resource.h
+++ b/dll/cpl/input/resource.h
@@ -60,8 +60,6 @@
 #define IDS_SWITCH_BET_INLANG    16
 #define IDC_TURNOFFTEXTSVCS_CB   17
 #define IDS_REBOOT_NOW           18
-#define IDS_REQUIRE_REBOOT       19
-#define IDS_ADVANCED_SETTINGS    20
 
 /* Layouts */
 #define IDS_US_LAYOUT                                  5000

--- a/dll/cpl/input/resource.h
+++ b/dll/cpl/input/resource.h
@@ -60,6 +60,8 @@
 #define IDS_SWITCH_BET_INLANG    16
 #define IDC_TURNOFFTEXTSVCS_CB   17
 #define IDS_REBOOT_NOW           18
+#define IDS_REQUIRE_REBOOT       19
+#define IDS_ADVANCED_SETTINGS    20
 
 /* Layouts */
 #define IDS_US_LAYOUT                                  5000

--- a/dll/cpl/input/settings_page.c
+++ b/dll/cpl/input/settings_page.c
@@ -619,23 +619,10 @@ OnNotifySettingsPage(HWND hwndDlg, LPARAM lParam)
 
         case PSN_APPLY:
         {
-            BOOL bRebootNeeded = IsRebootNeeded();
+            g_bRebootNeeded |= IsRebootNeeded();
 
             /* Write Input Methods list to registry */
-            if (InputList_Process() && bRebootNeeded)
-            {
-                /* Needs reboot */
-                WCHAR szNeedsReboot[128], szLanguage[64];
-                LoadStringW(hApplet, IDS_REBOOT_NOW, szNeedsReboot, _countof(szNeedsReboot));
-                LoadStringW(hApplet, IDS_LANGUAGE, szLanguage, _countof(szLanguage));
-
-                if (MessageBoxW(hwndDlg, szNeedsReboot, szLanguage,
-                                MB_ICONINFORMATION | MB_YESNOCANCEL) == IDYES)
-                {
-                    EnableProcessPrivileges(SE_SHUTDOWN_NAME, TRUE);
-                    ExitWindowsEx(EWX_REBOOT | EWX_FORCE, 0);
-                }
-            }
+            InputList_Process();
             break;
         }
     }

--- a/dll/cpl/input/settings_page.c
+++ b/dll/cpl/input/settings_page.c
@@ -610,6 +610,9 @@ OnNotifySettingsPage(HWND hwndDlg, LPARAM lParam)
                     break;
                 }
             }
+
+            /* Write Input Methods list to registry */
+            InputList_Process();
             break;
         }
     }

--- a/dll/cpl/input/settings_page.c
+++ b/dll/cpl/input/settings_page.c
@@ -600,19 +600,8 @@ OnNotifySettingsPage(HWND hwndDlg, LPARAM lParam)
 
         case PSN_APPLY:
         {
-            /* If an HKL is IME, then reboot is needed */
-            INPUT_LIST_NODE *pNode;
-            for (pNode = InputList_GetFirst(); pNode != NULL; pNode = pNode->pNext)
-            {
-                if (IS_IME_HKL(pNode->hkl)) /* IME? */
-                {
-                    g_bRebootNeeded = TRUE;
-                    break;
-                }
-            }
-
             /* Write Input Methods list to registry */
-            InputList_Process();
+            g_bRebootNeeded |= InputList_Process();
             break;
         }
     }


### PR DESCRIPTION
## Purpose

Allow the user to turn off `"Advanced Text Service"`.
JIRA issue: [CORE-19268](https://jira.reactos.org/browse/CORE-19268)

```reg
[HKEY_CURRENT_USER\Software\Microsoft\CTF]
"Disable Thread Input Manager"=dword:00000001
```
## Proposed changes

- Add `LoadAdvancedSettings` and `SaveAdvancedSettings` helper functions.
- Implement `AdvancedSettingsPageProc` procedure.
- Modify `IDS_REBOOT_NOW` resource string.

## TODO

- [x] Do build.
- [x] Do small test.