### PR TITLE
[W32TIME] Remember date/time sync settings

### DIFF
--- a/base/services/w32time/w32time.c
+++ b/base/services/w32time/w32time.c
@@ -284,7 +284,9 @@ W32TmServiceMain(DWORD argc, LPWSTR *argv)
     /* The service's worker loop */
     for (;;)
     {
-        bNoSync = FALSE;
+        /* The default is NoSync */
+        bNoSync = TRUE;
+
         /* TODO: Use RegNotifyChangeKeyValue() when implemented */
         if (RegOpenKeyExW(HKEY_LOCAL_MACHINE,
                           L"SYSTEM\\CurrentControlSet\\Services\\W32Time\\Parameters",

--- a/base/services/w32time/w32time.c
+++ b/base/services/w32time/w32time.c
@@ -281,7 +281,7 @@ W32TmServiceMain(DWORD argc, LPWSTR *argv)
     ServiceStatus.dwCurrentState = SERVICE_RUNNING;
     SetServiceStatus(hStatus, &ServiceStatus);
 
-    /* The worker loop of a service */
+    /* The service's worker loop */
     for (;;)
     {
         /* Is it Auto-Sync? */

--- a/base/services/w32time/w32time.c
+++ b/base/services/w32time/w32time.c
@@ -230,8 +230,6 @@ ControlHandler(DWORD request)
         default:
             break;
     }
-
-    return;
 }
 
 
@@ -239,7 +237,7 @@ VOID
 WINAPI
 W32TmServiceMain(DWORD argc, LPWSTR *argv)
 {
-    int   result;
+    LONG error;
     DWORD dwInterval;
     HKEY hKey;
     WCHAR szData[8];
@@ -296,7 +294,7 @@ W32TmServiceMain(DWORD argc, LPWSTR *argv)
         {
             cbData = sizeof(szData);
             RegQueryValueExW(hKey, L"Type", NULL, NULL, (LPBYTE)szData, &cbData);
-            szData[_countof(szData) - 1] = UNICODE_NULL; /* Avoid buffer overrun */
+            szData[ARRAYSIZE(szData) - 1] = UNICODE_NULL; /* Avoid buffer overrun */
             bAutoSync = (wcscmp(szData, L"NTP") == 0);
 
             RegCloseKey(hKey);
@@ -304,10 +302,10 @@ W32TmServiceMain(DWORD argc, LPWSTR *argv)
 
         if (bAutoSync)
         {
-            result = SetTime();
-            if (result)
+            error = SetTime();
+            if (error != ERROR_SUCCESS)
             {
-                DPRINT("W32Time Service failed to set clock: 0x%08lX\n", result);
+                DPRINT("W32Time Service failed to set clock: 0x%08lX\n", error);
 #if 0
                 /*
                  * In general, we do not want to stop this service for a single
@@ -315,7 +313,7 @@ W32TmServiceMain(DWORD argc, LPWSTR *argv)
                  * we really might want to stop it. Therefore this code is left here.
                  */
                 ServiceStatus.dwCurrentState  = SERVICE_STOPPED;
-                ServiceStatus.dwWin32ExitCode = result;
+                ServiceStatus.dwWin32ExitCode = error;
                 SetServiceStatus(hStatus, &ServiceStatus);
                 return;
 #endif
@@ -336,7 +334,6 @@ W32TmServiceMain(DWORD argc, LPWSTR *argv)
         }
     }
 }
-
 
 
 BOOL WINAPI

--- a/base/services/w32time/w32time.c
+++ b/base/services/w32time/w32time.c
@@ -242,7 +242,7 @@ W32TmServiceMain(DWORD argc, LPWSTR *argv)
     HKEY hKey;
     WCHAR szData[8];
     DWORD cbData;
-    BOOL bAutoSync;
+    BOOL bNoSync;
 
     UNREFERENCED_PARAMETER(argc);
     UNREFERENCED_PARAMETER(argv);
@@ -284,8 +284,8 @@ W32TmServiceMain(DWORD argc, LPWSTR *argv)
     /* The service's worker loop */
     for (;;)
     {
-        /* Is it Auto-Sync? */
-        bAutoSync = FALSE;
+        bNoSync = FALSE;
+        /* TODO: Use RegNotifyChangeKeyValue() when implemented */
         if (RegOpenKeyExW(HKEY_LOCAL_MACHINE,
                           L"SYSTEM\\CurrentControlSet\\Services\\W32Time\\Parameters",
                           0,
@@ -295,12 +295,11 @@ W32TmServiceMain(DWORD argc, LPWSTR *argv)
             cbData = sizeof(szData);
             RegQueryValueExW(hKey, L"Type", NULL, NULL, (LPBYTE)szData, &cbData);
             szData[ARRAYSIZE(szData) - 1] = UNICODE_NULL; /* Avoid buffer overrun */
-            bAutoSync = (wcscmp(szData, L"NTP") == 0);
-
+            bNoSync = (_wcsicmp(szData, L"NoSync") == 0);
             RegCloseKey(hKey);
         }
 
-        if (bAutoSync)
+        if (!bNoSync)
         {
             error = SetTime();
             if (error != ERROR_SUCCESS)


### PR DESCRIPTION
## Purpose

Based on KRosUser's patch.

JIRA issue: [CORE-19292](https://jira.reactos.org/browse/CORE-19292)

## Proposed changes

- In the `W32TmServiceMain` function, the time check loop does check the registry value.

## TODO

- [x] Do tests.