### PR TITLE
[REACTOS] Sync' __cxa_pure_virtual() definitions

### DIFF
--- a/dll/win32/shdocvw/mrulist.cpp
+++ b/dll/win32/shdocvw/mrulist.cpp
@@ -18,6 +18,7 @@
 #include <shlwapi.h>
 #include <shlwapi_undoc.h>
 #include <strsafe.h>
+
 #include "shdocvw.h"
 
 #include <wine/debug.h>
@@ -32,11 +33,13 @@ class CMruBase;
             class CMruPidlList;
 class CMruClassFactory;
 
-extern "C" void __cxa_pure_virtual(void)
+#ifdef __GNUC__ // GCC and Clang.
+extern "C" void __cxa_pure_virtual()
 {
     ERR("__cxa_pure_virtual\n");
     ::DebugBreak();
 }
+#endif
 
 BOOL IEILIsEqual(LPCITEMIDLIST pidl1, LPCITEMIDLIST pidl2, BOOL bUnknown)
 {

--- a/drivers/wdm/audio/backpln/portcls/CMakeLists.txt
+++ b/drivers/wdm/audio/backpln/portcls/CMakeLists.txt
@@ -39,13 +39,16 @@ list(APPEND SOURCE
     port_wavertstream.cpp
     power.cpp
     propertyhandler.cpp
-    purecall.cpp
     registry.cpp
     resource.cpp
     service_group.cpp
     undoc.cpp
     unregister.cpp
     version.cpp)
+
+if(CMAKE_C_COMPILER_ID STREQUAL "Clang" AND NOT MSVC)
+    list(APPEND SOURCE purecall.cpp)
+endif()
 
 list(APPEND PCH_SKIP_SOURCE
     guid.cpp)

--- a/drivers/wdm/audio/backpln/portcls/purecall.cpp
+++ b/drivers/wdm/audio/backpln/portcls/purecall.cpp
@@ -8,12 +8,11 @@
 
 #include "private.hpp"
 
-extern "C" {
-  void
-	  __cxa_pure_virtual()
-  {
+#if defined(__clang__) && defined(__GNUC__) // Clang only.
+extern "C" void __cxa_pure_virtual()
+{
     // put error handling here
 
     DbgBreakPoint();
-  }
 }
+#endif

--- a/sdk/lib/drivers/sound/stdunk/cunknown.cpp
+++ b/sdk/lib/drivers/sound/stdunk/cunknown.cpp
@@ -119,6 +119,7 @@ CUnknown::NonDelegatingQueryInterface(
     return STATUS_INVALID_PARAMETER;
 }
 
-#if __GNUC__
+#ifdef __GNUC__ // GCC and Clang.
+// Needed for 'CMIDriver' and 'ac97' drivers.
 extern "C" void __cxa_pure_virtual() { ASSERT(FALSE); }
 #endif

--- a/sdk/lib/drivers/wdf/reactos_special.cpp
+++ b/sdk/lib/drivers/wdf/reactos_special.cpp
@@ -66,10 +66,13 @@ RosInitWdf()
 	FxLibraryGlobals.OsVersionInfo.dwMinorVersion = 1;
 }
 
+#ifdef __GNUC__ // GCC and Clang.
+// Needed for 'cdrom' driver.
 void
 __cxa_pure_virtual()
 {
 	__debugbreak();
 }
+#endif
 
-}  // extern "C"
+} // extern "C"


### PR DESCRIPTION
## Purpose

Consistency, self-documentation, tiny compilation optimization

## Proposed changes

- Sync' __cxa_pure_virtual() definitions
- and compile them when needed only.