### PR TITLE
[ADVAPI32] RegEnumKeyExW on HKCR keys must work with just KEY_ENUMERATE_SUB_KEYS access

### DIFF
--- a/dll/win32/advapi32/reg/hkcr.c
+++ b/dll/win32/advapi32/reg/hkcr.c
@@ -218,8 +218,8 @@ static
 LONG
 GetSubkeyInfoHelper(
     _In_ HKEY hKey,
-    _Out_ LPDWORD lpSubKeys,
-    _Out_ LPDWORD lpMaxSubKeyLen)
+    _Out_opt_ LPDWORD lpSubKeys,
+    _Out_opt_ LPDWORD lpMaxSubKeyLen)
 {
     LONG err = RegQueryInfoKeyW(hKey, NULL, NULL, NULL, lpSubKeys, lpMaxSubKeyLen,
                                 NULL, NULL, NULL, NULL, NULL, NULL);
@@ -229,7 +229,7 @@ GetSubkeyInfoHelper(
     /* Windows RegEdit only uses KEY_ENUMERATE_SUB_KEYS when enumerating but
      * KEY_QUERY_VALUE is required to get the info in EnumHKCRKey.
      */
-    if (!RegOpenKeyExW(hKey, NULL, 0, KEY_QUERY_VALUE, &hKey))
+    if (RegOpenKeyExW(hKey, NULL, 0, KEY_QUERY_VALUE, &hKey) == ERROR_SUCCESS)
     {
         err = RegQueryInfoKeyW(hKey, NULL, NULL, NULL, lpSubKeys, lpMaxSubKeyLen,
                                NULL, NULL, NULL, NULL, NULL, NULL);

--- a/dll/win32/advapi32/reg/hkcr.c
+++ b/dll/win32/advapi32/reg/hkcr.c
@@ -214,6 +214,30 @@ GetPreferredHKCRKey(
     return ErrorCode;
 }
 
+static
+LONG
+GetSubkeyInfoHelper(
+    _In_ HKEY hKey,
+    _Out_ LPDWORD lpSubKeys,
+    _Out_ LPDWORD lpMaxSubKeyLen)
+{
+    LONG err = RegQueryInfoKeyW(hKey, NULL, NULL, NULL, lpSubKeys, lpMaxSubKeyLen,
+                                NULL, NULL, NULL, NULL, NULL, NULL);
+    if (err != ERROR_ACCESS_DENIED)
+        return err;
+
+    /* Windows RegEdit only uses KEY_ENUMERATE_SUB_KEYS when enumerating but
+     * KEY_QUERY_VALUE is required to get the info in EnumHKCRKey.
+     */
+    if (!RegOpenKeyExW(hKey, NULL, 0, KEY_QUERY_VALUE, &hKey))
+    {
+        err = RegQueryInfoKeyW(hKey, NULL, NULL, NULL, lpSubKeys, lpMaxSubKeyLen,
+                               NULL, NULL, NULL, NULL, NULL, NULL);
+        RegCloseKey(hKey);
+    }
+    return err;
+}
+
 /* HKCR version of RegCreateKeyExW. */
 LONG
 WINAPI
@@ -654,19 +678,7 @@ EnumHKCRKey(
     }
 
     /* Get some info on the HKCU side */
-    ErrorCode = RegQueryInfoKeyW(
-        PreferredKey,
-        NULL,
-        NULL,
-        NULL,
-        &NumPreferredSubKeys,
-        NULL,
-        NULL,
-        NULL,
-        NULL,
-        NULL,
-        NULL,
-        NULL);
+    ErrorCode = GetSubkeyInfoHelper(PreferredKey, &NumPreferredSubKeys, NULL);
     if (ErrorCode != ERROR_SUCCESS)
         goto Exit;
 
@@ -692,19 +704,7 @@ EnumHKCRKey(
     dwIndex -= NumPreferredSubKeys;
 
     /* Get some info */
-    ErrorCode = RegQueryInfoKeyW(
-        FallbackKey,
-        NULL,
-        NULL,
-        NULL,
-        NULL,
-        &MaxFallbackSubKeyLen,
-        NULL,
-        NULL,
-        NULL,
-        NULL,
-        NULL,
-        NULL);
+    ErrorCode = GetSubkeyInfoHelper(FallbackKey, NULL, &MaxFallbackSubKeyLen);
     if (ErrorCode != ERROR_SUCCESS)
     {
         ERR("Could not query info of key %p (Err: %d)\n", FallbackKey, ErrorCode);


### PR DESCRIPTION
This fixes Windows RegEdit when the same HKCR key exists in HKCU and HKLM.