### PR TITLE
[HALX86] Fix some asserts on multiprocessor kernel

### DIFF
--- a/hal/halx86/generic/buildtype.c
+++ b/hal/halx86/generic/buildtype.c
@@ -1,7 +1,7 @@
 /*
 * PROJECT:     ReactOS Hardware Abstraction Layer
 * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
-* PURPOSE:     Defines HalpBuildType for either UP or SMP
+* PURPOSE:     Defines differences for either UP or SMP
 * COPYRIGHT:   Copyright 2021 Timo Kreuzer <timo.kreuzer@reactos.org>
 */
 
@@ -12,3 +12,9 @@
 /* GLOBALS ******************************************************************/
 
 const USHORT HalpBuildType = HAL_BUILD_TYPE;
+
+#ifdef CONFIG_SMP
+KIRQL HalpIrqlSynchLevel = IPI_LEVEL - 2;
+#else
+KIRQL HalpIrqlSynchLevel = DISPATCH_LEVEL;
+#endif

--- a/hal/halx86/include/halp.h
+++ b/hal/halx86/include/halp.h
@@ -10,6 +10,14 @@
 #define HAL_BUILD_TYPE ((DBG ? PRCB_BUILD_DEBUG : 0) | PRCB_BUILD_UNIPROCESSOR)
 #endif
 
+/* Don't include this in freeloader */
+#ifndef _BLDR_
+extern KIRQL HalpIrqlSynchLevel;
+
+#undef SYNCH_LEVEL
+#define SYNCH_LEVEL HalpIrqlSynchLevel
+#endif
+
 typedef struct _HAL_BIOS_FRAME
 {
     ULONG SegSs;


### PR DESCRIPTION
## Purpose

Try to get the multiprocessor kernel to boot on x86 again.

## Proposed changes

- Correct the SYNCH_LEVEL definition for MP vs UP HALs

