### PR TITLE
[MSPAINT] Commonize OnFinishDraw and OnCancelDraw

### DIFF
--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -357,13 +357,13 @@ LRESULT CCanvasWindow::OnButtonDown(UINT nMsg, WPARAM wParam, LPARAM lParam, BOO
         {
             case TOOL_BEZIER:
             case TOOL_SHAPE:
-                toolsModel.OnCancelDraw();
+                toolsModel.OnEndDraw(TRUE);
                 Invalidate();
                 break;
 
             case TOOL_FREESEL:
             case TOOL_RECTSEL:
-                toolsModel.OnFinishDraw();
+                toolsModel.OnEndDraw(FALSE);
                 Invalidate();
                 break;
 
@@ -814,13 +814,13 @@ VOID CCanvasWindow::cancelDrawing()
     selectionModel.ClearMaskImage();
     m_hitSelection = HIT_NONE;
     m_drawing = FALSE;
-    toolsModel.OnCancelDraw();
+    toolsModel.OnEndDraw(TRUE);
     Invalidate(FALSE);
 }
 
 VOID CCanvasWindow::finishDrawing()
 {
-    toolsModel.OnFinishDraw();
+    toolsModel.OnEndDraw(FALSE);
     m_drawing = FALSE;
     Invalidate(FALSE);
 }

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -790,6 +790,7 @@ struct TextTool : ToolBase
                 draw(m_hdc);
             }
         }
+        quit();
         ToolBase::OnEndDraw(bCancel);
     }
 };

--- a/base/applications/mspaint/textedit.cpp
+++ b/base/applications/mspaint/textedit.cpp
@@ -104,7 +104,7 @@ LRESULT CTextEditWindow::OnKeyDown(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL
 {
     if (wParam == VK_ESCAPE)
     {
-        toolsModel.OnCancelDraw();
+        toolsModel.OnEndDraw(TRUE);
         return 0;
     }
 

--- a/base/applications/mspaint/toolsmodel.cpp
+++ b/base/applications/mspaint/toolsmodel.cpp
@@ -145,7 +145,7 @@ TOOLTYPE ToolsModel::GetOldActiveTool() const
 
 void ToolsModel::SetActiveTool(TOOLTYPE nActiveTool)
 {
-    OnFinishDraw();
+    OnEndDraw(FALSE);
 
     selectionModel.Landing();
 
@@ -288,19 +288,11 @@ void ToolsModel::OnButtonUp(BOOL bLeftButton, LONG x, LONG y)
     m_pToolObject->endEvent();
 }
 
-void ToolsModel::OnCancelDraw()
+void ToolsModel::OnEndDraw(BOOL bCancel)
 {
-    ATLTRACE("ToolsModel::OnCancelDraw()\n");
+    ATLTRACE("ToolsModel::OnEndDraw(%d)\n", bCancel);
     m_pToolObject->beginEvent();
-    m_pToolObject->OnCancelDraw();
-    m_pToolObject->endEvent();
-}
-
-void ToolsModel::OnFinishDraw()
-{
-    ATLTRACE("ToolsModel::OnFinishDraw()\n");
-    m_pToolObject->beginEvent();
-    m_pToolObject->OnFinishDraw();
+    m_pToolObject->OnEndDraw(bCancel);
     m_pToolObject->endEvent();
 }
 

--- a/base/applications/mspaint/toolsmodel.h
+++ b/base/applications/mspaint/toolsmodel.h
@@ -53,13 +53,12 @@ struct ToolBase
     virtual BOOL OnMouseMove(BOOL bLeftButton, LONG& x, LONG& y) { return TRUE; }
     virtual BOOL OnButtonUp(BOOL bLeftButton, LONG& x, LONG& y) { return TRUE; }
 
-    virtual void OnCancelDraw();
-    virtual void OnFinishDraw();
-
     virtual void OnDrawOverlayOnImage(HDC hdc) { }
     virtual void OnDrawOverlayOnCanvas(HDC hdc) { }
 
     virtual void OnSpecialTweak(BOOL bMinus) { }
+
+    virtual void OnEndDraw(BOOL bCancel);
 
     void beginEvent();
     void endEvent();
@@ -135,8 +134,7 @@ public:
     void OnButtonDown(BOOL bLeftButton, LONG x, LONG y, BOOL bDoubleClick);
     void OnMouseMove(BOOL bLeftButton, LONG x, LONG y);
     void OnButtonUp(BOOL bLeftButton, LONG x, LONG y);
-    void OnCancelDraw();
-    void OnFinishDraw();
+    void OnEndDraw(BOOL bCancel);
     void OnDrawOverlayOnImage(HDC hdc);
     void OnDrawOverlayOnCanvas(HDC hdc);
 


### PR DESCRIPTION
## Purpose

Reduce code and binary size a bit. This will reduce 1024 bytes in binary.
JIRA issue: [CORE-19094](https://jira.reactos.org/browse/CORE-19094)

## Proposed changes

- Unify `ToolBase::OnFinishDraw` and `ToolBase::OnCancelDraw` to `ToolBase::OnEndDraw`.

## TODO

- [x] Do tests.