### PR TITLE
[MSPAINT] Simplify tool creation

### DIFF
--- a/base/applications/mspaint/toolsmodel.cpp
+++ b/base/applications/mspaint/toolsmodel.cpp
@@ -22,22 +22,20 @@ ToolsModel::ToolsModel()
     m_rubberRadius = 4;
     m_transpBg = FALSE;
     m_zoom = 1000;
-    ZeroMemory(&m_tools, sizeof(m_tools));
     m_pToolObject = GetOrCreateTool(m_activeTool);
 }
 
 ToolsModel::~ToolsModel()
 {
-    for (size_t i = 0; i < _countof(m_tools); ++i)
-        delete m_tools[i];
+    delete m_pToolObject;
+    m_pToolObject = NULL;
 }
 
 ToolBase *ToolsModel::GetOrCreateTool(TOOLTYPE nTool)
 {
-    if (!m_tools[nTool])
-        m_tools[nTool] = ToolBase::createToolObject(nTool);
-
-    return m_tools[nTool];
+    delete m_pToolObject;
+    m_pToolObject = ToolBase::createToolObject(nTool);
+    return m_pToolObject;
 }
 
 BOOL ToolsModel::IsSelection() const

--- a/base/applications/mspaint/toolsmodel.h
+++ b/base/applications/mspaint/toolsmodel.h
@@ -84,7 +84,6 @@ private:
     int m_rubberRadius;
     BOOL m_transpBg;
     int m_zoom;
-    ToolBase* m_tools[TOOL_MAX + 1];
     ToolBase *m_pToolObject;
 
     ToolBase *GetOrCreateTool(TOOLTYPE nTool);


### PR DESCRIPTION
## Purpose

Reduce code and binary size. This will reduce 512 bytes in binary.

JIRA issue: [CORE-19094](https://jira.reactos.org/browse/CORE-19094)

## Proposed changes

- Don't use cache for tool creation.

## TODO

- [x] Do tests.