### PR TITLE
[MSPAINT] Fix Copy-To-File feature

### DIFF
--- a/base/applications/mspaint/dialogs.cpp
+++ b/base/applications/mspaint/dialogs.cpp
@@ -361,10 +361,10 @@ void CFontsDialog::InitFontSizes()
     HWND hwndSizes = GetDlgItem(IDD_FONTSSIZES);
     ComboBox_ResetContent(hwndSizes);
 
-    TCHAR szText[16];
+    WCHAR szText[16];
     for (UINT i = 0; i < _countof(s_sizes); ++i)
     {
-        wsprintf(szText, TEXT("%d"), s_sizes[i]);
+        StringCchPrintfW(szText, _countof(szText), L"%d", s_sizes[i]);
         INT iItem = ComboBox_AddString(hwndSizes, szText);
         if (s_sizes[i] == (INT)registrySettings.PointSize)
             ComboBox_SetCurSel(hwndSizes, iItem);
@@ -372,7 +372,7 @@ void CFontsDialog::InitFontSizes()
 
     if (ComboBox_GetCurSel(hwndSizes) == CB_ERR)
     {
-        wsprintf(szText, TEXT("%d"), (INT)registrySettings.PointSize);
+        StringCchPrintfW(szText, _countof(szText), L"%d", (INT)registrySettings.PointSize);
         ::SetWindowText(hwndSizes, szText);
     }
 }

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -251,7 +251,7 @@ BOOL CMainWindow::GetSaveFileName(IN OUT LPTSTR pszFile, INT cchMaxFile)
         if (*pchDotExt == UNICODE_NULL)
         {
             // Choose PNG
-            wcscat(pszFile, L".png");
+            StringCchCatW(pszFile, cchMaxFile, L".png");
             for (INT i = 0; i < aguidFileTypesE.GetSize(); ++i)
             {
                 if (aguidFileTypesE[i] == Gdiplus::ImageFormatPNG)

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -7,6 +7,7 @@
 
 #include "precomp.h"
 
+#include <dlgs.h>
 #include <mapi.h>
 
 POINT g_ptStart, g_ptEnd;
@@ -66,6 +67,7 @@ OFNHookProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
     HWND hParent;
     OFNOTIFY *pon;
+    WCHAR Path[MAX_PATH];
     switch (uMsg)
     {
     case WM_NOTIFY:
@@ -73,10 +75,9 @@ OFNHookProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
         if (pon->hdr.code == CDN_TYPECHANGE)
         {
             hParent = GetParent(hwnd);
-            TCHAR Path[MAX_PATH];
-            SendMessage(hParent, CDM_GETFILEPATH, _countof(Path), (LPARAM)Path);
-            FileExtFromFilter(PathFindExtension(Path), pon->lpOFN);
-            SendMessage(hParent, CDM_SETCONTROLTEXT, 0x047c, (LPARAM)PathFindFileName(Path));
+            SendMessageW(hParent, CDM_GETFILEPATH, _countof(Path), (LPARAM)Path);
+            FileExtFromFilter(PathFindExtensionW(Path), pon->lpOFN);
+            SendMessageW(hParent, CDM_SETCONTROLTEXT, cmb13, (LPARAM)PathFindFileNameW(Path));
             StringCchCopyW(pon->lpOFN->lpstrFile, pon->lpOFN->nMaxFile, Path);
         }
         break;

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -55,7 +55,7 @@ FileExtFromFilter(LPTSTR pExt, OPENFILENAME *pOFN)
             CharLower(pExt);
             return TRUE;
         }
-        pch += lstrlen(pch) + 1;
+        pch += wcslen(pch) + 1;
     }
     return FALSE;
 }
@@ -77,7 +77,7 @@ OFNHookProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
             SendMessage(hParent, CDM_GETFILEPATH, _countof(Path), (LPARAM)Path);
             FileExtFromFilter(PathFindExtension(Path), pon->lpOFN);
             SendMessage(hParent, CDM_SETCONTROLTEXT, 0x047c, (LPARAM)PathFindFileName(Path));
-            lstrcpyn(pon->lpOFN->lpstrFile, Path, pon->lpOFN->nMaxFile);
+            StringCchCopyW(pon->lpOFN->lpstrFile, pon->lpOFN->nMaxFile, Path);
         }
         break;
     }

--- a/base/applications/mspaint/precomp.h
+++ b/base/applications/mspaint/precomp.h
@@ -25,6 +25,7 @@
 #include <math.h>
 #include <shellapi.h>
 #include <htmlhelp.h>
+#include <strsafe.h>
 #include "atlimagedx.h"
 
 #include <debug.h>

--- a/base/applications/mspaint/registry.cpp
+++ b/base/applications/mspaint/registry.cpp
@@ -123,7 +123,7 @@ void RegistrySettings::Load(INT nCmdShow)
         TCHAR szName[64];
         for (INT i = 0; i < MAX_RECENT_FILES; ++i)
         {
-            wsprintf(szName, _T("File%u"), i + 1);
+            StringCchPrintfW(szName, _countof(szName), L"File%u", i + 1);
             ReadString(files, szName, strFiles[i]);
         }
     }
@@ -204,10 +204,10 @@ void RegistrySettings::Store()
     CRegKey files;
     if (files.Create(paint, _T("Recent File List")) == ERROR_SUCCESS)
     {
-        TCHAR szName[64];
+        WCHAR szName[64];
         for (INT iFile = 0; iFile < MAX_RECENT_FILES; ++iFile)
         {
-            wsprintf(szName, _T("File%u"), iFile + 1);
+            StringCchPrintfW(szName, _countof(szName), L"File%u", iFile + 1);
             files.SetStringValue(szName, strFiles[iFile]);
         }
     }

--- a/base/applications/mspaint/selectionmodel.h
+++ b/base/applications/mspaint/selectionmodel.h
@@ -40,10 +40,7 @@ public:
     void HideSelection();
     void DeleteSelection();
 
-    HBITMAP CopyBitmap();
-    HBITMAP LockBitmap();
-    void UnlockBitmap(HBITMAP hbmLocked);
-    void GetSelectionContents(HDC hDCImage);
+    HBITMAP GetSelectionContents();
     void DrawFramePoly(HDC hDCImage);
     void DrawBackground(HDC hDCImage);
     void DrawBackgroundPoly(HDC hDCImage, COLORREF crBg);

--- a/base/applications/mspaint/textedit.cpp
+++ b/base/applications/mspaint/textedit.cpp
@@ -342,7 +342,7 @@ void CTextEditWindow::UpdateFont()
     lf.lfWeight = (registrySettings.Bold ? FW_BOLD : FW_NORMAL);
     lf.lfItalic = (BYTE)registrySettings.Italic;
     lf.lfUnderline = (BYTE)registrySettings.Underline;
-    lstrcpyn(lf.lfFaceName, registrySettings.strFontName, _countof(lf.lfFaceName));
+    StringCchCopyW(lf.lfFaceName, _countof(lf.lfFaceName), registrySettings.strFontName);
 
     HDC hdc = GetDC();
     if (hdc)

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -29,7 +29,7 @@ static HWND DoHtmlHelpW(HWND hwndCaller, LPCWSTR pszFile, UINT uCommand, DWORD_P
     {
         // The function loads the system library, not local
         GetSystemDirectoryW(szPath, _countof(szPath));
-        wcscat(szPath, L"\\hhctrl.ocx");
+        StringCchCatW(szPath, _countof(szPath), L"\\hhctrl.ocx");
         s_hHHCTRL_OCX = LoadLibraryW(szPath);
         if (s_hHHCTRL_OCX)
             s_pHtmlHelpW = (FN_HtmlHelpW)GetProcAddress(s_hHHCTRL_OCX, "HtmlHelpW");

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -841,9 +841,7 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
         case IDM_EDITCOPYTO:
         {
             WCHAR szFileName[MAX_LONG_PATH];
-            CStringW strUntitled(MAKEINTRESOURCEW(IDS_DEFAULTFILENAME));
-            StringCchCopyW(szFileName, _countof(szFileName), strUntitled);
-
+            LoadStringW(g_hinstExe, IDS_DEFAULTFILENAME, szFileName, _countof(szFileName));
             if (GetSaveFileName(szFileName, _countof(szFileName)))
             {
                 HBITMAP hbmSelection = selectionModel.GetSelectionContents();

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -382,8 +382,8 @@ void CMainWindow::ProcessFileMenu(HMENU hPopupMenu)
         assert(_tcslen((LPCTSTR)pathFile) <= MAX_RECENT_PATHNAME_DISPLAY);
 
         // Add an accelerator (by '&') to the item number for quick access
-        TCHAR szText[4 + MAX_RECENT_PATHNAME_DISPLAY + 1];
-        wsprintf(szText, _T("&%u %s"), iItem + 1, (LPCTSTR)pathFile);
+        WCHAR szText[4 + MAX_RECENT_PATHNAME_DISPLAY + 1];
+        StringCchPrintfW(szText, _countof(szText), L"&%u %s", iItem + 1, (LPCWSTR)pathFile);
 
         INT iMenuItem = (cMenuItems - 2) + iItem;
         InsertMenu(hPopupMenu, iMenuItem, MF_BYPOSITION | MF_STRING, IDM_FILE1 + iItem, szText);

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -840,9 +840,9 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
         }
         case IDM_EDITCOPYTO:
         {
-            WCHAR szFileName[MAX_LONG_PATH] = L"";
+            WCHAR szFileName[MAX_LONG_PATH];
             CStringW strUntitled(MAKEINTRESOURCEW(IDS_DEFAULTFILENAME));
-            lstrcpynW(szFileName, strUntitled, _countof(szFileName));
+            StringCchCopyW(szFileName, _countof(szFileName), strUntitled);
 
             if (GetSaveFileName(szFileName, _countof(szFileName)))
             {

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -847,15 +847,13 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
             if (GetSaveFileName(szFileName, _countof(szFileName)))
             {
                 HBITMAP hbmSelection = selectionModel.GetSelectionContents();
-                if (hbmSelection)
-                {
-                    SaveDIBToFile(hbmSelection, szFileName, FALSE);
-                    DeleteObject(hbmSelection);
-                }
-                else
+                if (!hbmSelection)
                 {
                     ShowOutOfMemory();
+                    break;
                 }
+                SaveDIBToFile(hbmSelection, szFileName, FALSE);
+                DeleteObject(hbmSelection);
             }
             break;
         }


### PR DESCRIPTION
## Purpose

The Copy-To-File feature had some bugs that the user couldn't save.
JIRA issue: [CORE-19186](https://jira.reactos.org/browse/CORE-19186)

## Proposed changes

- Modify `SelectionModel::GetSelectionContents`.
- Delete `SelectionModel::CopyBitmap`, `SelectionModel::LockBitmap`, and `SelectionModel::UnlockBitmap` functions.
- Fix Copy-To-File feature.

## TODO

- [x] Do tests.