### PR TITLE
[NETSHELL] Register Network connections folder attributes as SFGAO_FOLDER, not SFGAO_CANDELETE

### DIFF
--- a/dll/shellext/netshell/res/netshell.rgs
+++ b/dll/shellext/netshell/res/netshell.rgs
@@ -11,7 +11,7 @@ HKCR
             DefaultIcon = s '%MODULE%'
             ShellFolder
             {
-                val Attributes = d '0x00000020'
+                val Attributes = d '0x20000000'
             }
             val LocalizedString = s '@%MODULE%,-10000'
         }


### PR DESCRIPTION
Windows uses a binary value and someone forgot about little endian when converting it to a DWORD. This issue has not been very visible because of bugs in CRegFolderEnum.