### PR TITLE
[NETSHELL] Property page needs to call ReleaseWriteLock

### DIFF
--- a/dll/shellext/netshell/lanconnectui.cpp
+++ b/dll/shellext/netshell/lanconnectui.cpp
@@ -17,6 +17,10 @@ CNetConnectionPropertyUi::~CNetConnectionPropertyUi()
     if (m_pNCfg)
         m_pNCfg->Uninitialize();
 
+    // Note: MSDN says we can only unlock after INetCfg::Uninitialize
+    if (m_NCfgLock)
+        m_NCfgLock->ReleaseWriteLock();
+
     if (m_pProperties)
         NcFreeNetconProperties(m_pProperties);
 }
@@ -181,7 +185,10 @@ CNetConnectionPropertyUi::InitializeLANPropertiesUIDlg(HWND hwndDlg)
 
     hr = pNCfg->Initialize(NULL);
     if (FAILED_UNEXPECTEDLY(hr))
+    {
+        pNCfgLock->ReleaseWriteLock();
         return;
+    }
 
     m_pNCfg = pNCfg;
     m_NCfgLock = pNCfgLock;


### PR DESCRIPTION
The property page does not release the lock it takes, this prevents other threads from taking the lock later.

JIRA issue: [CORE-18349](https://jira.reactos.org/browse/CORE-18349)

----

#### Related issues

- If you open the property page from the connections folder and the tray icon at the same time, only the first dialog gets the lock. To solve this, it would have to try to find the existing dialog and just set focus to it if found. Need to investigate how Windows handles this.
- `INetCfgImpl` leaks the mutex handle?