### PR TITLE
[MSPAINT] Adapt to Unicode and <strsafe.h>

### DIFF
--- a/base/applications/mspaint/atlimagedx.h
+++ b/base/applications/mspaint/atlimagedx.h
@@ -141,7 +141,7 @@ public:
         CLSID clsid;
         if (::IsEqualGUID(guidFileType, GUID_NULL))
         {
-            CStringW strExt(PathFindExtension(pszFileName));
+            CStringW strExt(PathFindExtensionW(pszFileName));
             clsid = FindCodecForExtension(strExt, pEncoders, cEncoders);
         }
         else

--- a/base/applications/mspaint/atlimagedx.h
+++ b/base/applications/mspaint/atlimagedx.h
@@ -69,7 +69,7 @@ public:
         return TRUE;
     }
 
-    HRESULT LoadDx(LPCTSTR pszFileName, float *pxDpi, float *pyDpi) throw()
+    HRESULT LoadDx(LPCWSTR pszFileName, float *pxDpi, float *pyDpi) throw()
     {
         using namespace Gdiplus;
 
@@ -111,7 +111,7 @@ public:
         return (status == Ok ? S_OK : E_FAIL);
     }
 
-    HRESULT SaveDx(LPCTSTR pszFileName, REFGUID guidFileType = GUID_NULL,
+    HRESULT SaveDx(LPCWSTR pszFileName, REFGUID guidFileType = GUID_NULL,
                    float xDpi = 0, float yDpi = 0) throw()
     {
         using namespace Gdiplus;
@@ -141,7 +141,7 @@ public:
         CLSID clsid;
         if (::IsEqualGUID(guidFileType, GUID_NULL))
         {
-            CString strExt(PathFindExtension(pszFileName));
+            CStringW strExt(PathFindExtension(pszFileName));
             clsid = FindCodecForExtension(strExt, pEncoders, cEncoders);
         }
         else
@@ -300,23 +300,23 @@ protected:
 
     // CImage::FindCodecForExtension is private. We have to duplicate it at here...
     static CLSID
-    FindCodecForExtension(LPCTSTR dotext, const Gdiplus::ImageCodecInfo *pCodecs, UINT nCodecs)
+    FindCodecForExtension(LPCWSTR dotext, const Gdiplus::ImageCodecInfo *pCodecs, UINT nCodecs)
     {
         for (UINT i = 0; i < nCodecs; ++i)
         {
-            CString strSpecs(pCodecs[i].FilenameExtension);
+            CStringW strSpecs(pCodecs[i].FilenameExtension);
             int ichOld = 0, ichSep;
             for (;;)
             {
-                ichSep = strSpecs.Find(TEXT(';'), ichOld);
+                ichSep = strSpecs.Find(L';', ichOld);
 
-                CString strSpec;
+                CStringW strSpec;
                 if (ichSep < 0)
                     strSpec = strSpecs.Mid(ichOld);
                 else
                     strSpec = strSpecs.Mid(ichOld, ichSep - ichOld);
 
-                int ichDot = strSpec.ReverseFind(TEXT('.'));
+                int ichDot = strSpec.ReverseFind(L'.');
                 if (ichDot >= 0)
                     strSpec = strSpec.Mid(ichDot);
 

--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -646,7 +646,7 @@ LRESULT CCanvasWindow::OnSetCursor(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL
     if (hitSelection != HIT_NONE)
     {
         if (!setCursorOnSizeBox(hitSelection))
-            ::SetCursor(::LoadCursorW(NULL, IDC_SIZEALL));
+            ::SetCursor(::LoadCursorW(NULL, (LPCWSTR)IDC_SIZEALL));
         return 0;
     }
 
@@ -674,7 +674,7 @@ LRESULT CCanvasWindow::OnSetCursor(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL
                 ::SetCursor(::LoadIconW(g_hinstExe, MAKEINTRESOURCEW(IDC_AIRBRUSH)));
                 break;
             default:
-                ::SetCursor(::LoadCursorW(NULL, MAKEINTRESOURCEW(IDC_CROSS)));
+                ::SetCursor(::LoadCursorW(NULL, (LPCWSTR)IDC_CROSS));
         }
         return 0;
     }

--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -321,7 +321,7 @@ LRESULT CCanvasWindow::OnButtonDown(UINT nMsg, WPARAM wParam, LPARAM lParam, BOO
     {
         m_ptOrig = pt;
         SetCapture();
-        ::SetCursor(::LoadCursor(g_hinstExe, MAKEINTRESOURCE(IDC_HANDDRAG)));
+        ::SetCursor(::LoadCursorW(g_hinstExe, MAKEINTRESOURCEW(IDC_HANDDRAG)));
         return 0;
     }
 
@@ -625,7 +625,7 @@ LRESULT CCanvasWindow::OnSetCursor(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL
 
     if (m_nMouseDownMsg == WM_MBUTTONDOWN)
     {
-        ::SetCursor(::LoadCursor(g_hinstExe, MAKEINTRESOURCE(IDC_HANDDRAG)));
+        ::SetCursor(::LoadCursorW(g_hinstExe, MAKEINTRESOURCEW(IDC_HANDDRAG)));
         return 0;
     }
 
@@ -646,7 +646,7 @@ LRESULT CCanvasWindow::OnSetCursor(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL
     if (hitSelection != HIT_NONE)
     {
         if (!setCursorOnSizeBox(hitSelection))
-            ::SetCursor(::LoadCursor(NULL, IDC_SIZEALL));
+            ::SetCursor(::LoadCursorW(NULL, IDC_SIZEALL));
         return 0;
     }
 
@@ -659,22 +659,22 @@ LRESULT CCanvasWindow::OnSetCursor(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL
         switch (toolsModel.GetActiveTool())
         {
             case TOOL_FILL:
-                ::SetCursor(::LoadIcon(g_hinstExe, MAKEINTRESOURCE(IDC_FILL)));
+                ::SetCursor(::LoadIconW(g_hinstExe, MAKEINTRESOURCEW(IDC_FILL)));
                 break;
             case TOOL_COLOR:
-                ::SetCursor(::LoadIcon(g_hinstExe, MAKEINTRESOURCE(IDC_COLOR)));
+                ::SetCursor(::LoadIconW(g_hinstExe, MAKEINTRESOURCEW(IDC_COLOR)));
                 break;
             case TOOL_ZOOM:
-                ::SetCursor(::LoadIcon(g_hinstExe, MAKEINTRESOURCE(IDC_ZOOM)));
+                ::SetCursor(::LoadIconW(g_hinstExe, MAKEINTRESOURCEW(IDC_ZOOM)));
                 break;
             case TOOL_PEN:
-                ::SetCursor(::LoadIcon(g_hinstExe, MAKEINTRESOURCE(IDC_PEN)));
+                ::SetCursor(::LoadIconW(g_hinstExe, MAKEINTRESOURCEW(IDC_PEN)));
                 break;
             case TOOL_AIRBRUSH:
-                ::SetCursor(::LoadIcon(g_hinstExe, MAKEINTRESOURCE(IDC_AIRBRUSH)));
+                ::SetCursor(::LoadIconW(g_hinstExe, MAKEINTRESOURCEW(IDC_AIRBRUSH)));
                 break;
             default:
-                ::SetCursor(::LoadCursor(NULL, IDC_CROSS));
+                ::SetCursor(::LoadCursorW(NULL, MAKEINTRESOURCEW(IDC_CROSS)));
         }
         return 0;
     }

--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -453,7 +453,7 @@ LRESULT CCanvasWindow::OnMouseMove(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL
             CStringW strCoord;
             if (::PtInRect(&rcImage, pt))
                 strCoord.Format(L"%ld, %ld", pt.x, pt.y);
-            ::SendMessageW(g_hStatusBar, SB_SETTEXT, 1, (LPARAM) (LPCWSTR) strCoord);
+            ::SendMessageW(g_hStatusBar, SB_SETTEXT, 1, (LPARAM)(LPCWSTR)strCoord);
         }
     }
 
@@ -513,7 +513,7 @@ LRESULT CCanvasWindow::OnMouseMove(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL
     // Display new size
     CStringW strSize;
     strSize.Format(L"%d x %d", cxImage, cyImage);
-    ::SendMessageW(g_hStatusBar, SB_SETTEXT, 2, (LPARAM) (LPCWSTR) strSize);
+    ::SendMessageW(g_hStatusBar, SB_SETTEXT, 2, (LPARAM)(LPCWSTR)strSize);
 
     // Dragging now... Fix the position...
     CRect rcResizing = { 0, 0, cxImage, cyImage };

--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -450,10 +450,10 @@ LRESULT CCanvasWindow::OnMouseMove(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL
             RECT rcImage;
             GetImageRect(rcImage);
 
-            CString strCoord;
+            CStringW strCoord;
             if (::PtInRect(&rcImage, pt))
-                strCoord.Format(_T("%ld, %ld"), pt.x, pt.y);
-            ::SendMessage(g_hStatusBar, SB_SETTEXT, 1, (LPARAM) (LPCTSTR) strCoord);
+                strCoord.Format(L"%ld, %ld", pt.x, pt.y);
+            ::SendMessageW(g_hStatusBar, SB_SETTEXT, 1, (LPARAM) (LPCWSTR) strCoord);
         }
     }
 
@@ -511,9 +511,9 @@ LRESULT CCanvasWindow::OnMouseMove(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL
     cyImage = min(MAXWORD, cyImage);
 
     // Display new size
-    CString strSize;
-    strSize.Format(_T("%d x %d"), cxImage, cyImage);
-    ::SendMessage(g_hStatusBar, SB_SETTEXT, 2, (LPARAM) (LPCTSTR) strSize);
+    CStringW strSize;
+    strSize.Format(L"%d x %d", cxImage, cyImage);
+    ::SendMessageW(g_hStatusBar, SB_SETTEXT, 2, (LPARAM) (LPCWSTR) strSize);
 
     // Dragging now... Fix the position...
     CRect rcResizing = { 0, 0, cxImage, cyImage };
@@ -559,7 +559,7 @@ LRESULT CCanvasWindow::OnButtonUp(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL&
         m_drawing = FALSE;
         toolsModel.OnButtonUp(bLeftButton, pt.x, pt.y);
         Invalidate(FALSE);
-        ::SendMessage(g_hStatusBar, SB_SETTEXT, 2, (LPARAM)_T(""));
+        ::SendMessageW(g_hStatusBar, SB_SETTEXT, 2, (LPARAM)L"");
         return 0;
     }
     else if (m_hitSelection != HIT_NONE && bLeftButton)
@@ -711,12 +711,12 @@ LRESULT CCanvasWindow::OnCancelMode(UINT nMsg, WPARAM wParam, LPARAM lParam, BOO
 
 LRESULT CCanvasWindow::OnMouseWheel(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
-    return ::SendMessage(GetParent(), nMsg, wParam, lParam);
+    return ::SendMessageW(GetParent(), nMsg, wParam, lParam);
 }
 
 LRESULT CCanvasWindow::OnCaptureChanged(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
-    ::SendMessage(g_hStatusBar, SB_SETTEXT, 2, (LPARAM)_T(""));
+    ::SendMessageW(g_hStatusBar, SB_SETTEXT, 2, (LPARAM)L"");
     return 0;
 }
 

--- a/base/applications/mspaint/canvas.h
+++ b/base/applications/mspaint/canvas.h
@@ -10,7 +10,7 @@
 class CCanvasWindow : public CWindowImpl<CCanvasWindow>
 {
 public:
-    DECLARE_WND_CLASS_EX(_T("ReactOSPaintCanvas"), CS_DBLCLKS | CS_HREDRAW | CS_VREDRAW,
+    DECLARE_WND_CLASS_EX(L"ReactOSPaintCanvas", CS_DBLCLKS | CS_HREDRAW | CS_VREDRAW,
                          COLOR_APPWORKSPACE)
 
     BEGIN_MSG_MAP(CCanvasWindow)

--- a/base/applications/mspaint/dialogs.cpp
+++ b/base/applications/mspaint/dialogs.cpp
@@ -272,9 +272,7 @@ LRESULT CStretchSkewDialog::OnClose(UINT nMsg, WPARAM wParam, LPARAM lParam, BOO
 
 LRESULT CStretchSkewDialog::OnOk(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL& bHandled)
 {
-    CStringW strrcIntNumbers;
-    CStringW strrcPercentage;
-    CStringW strrcAngle;
+    CStringW strrcIntNumbers, strrcPercentage, strrcAngle;
     BOOL tr1, tr2, tr3, tr4;
 
     strrcIntNumbers.LoadString(g_hinstExe, IDS_INTNUMBERS);
@@ -304,7 +302,7 @@ LRESULT CStretchSkewDialog::OnCancel(WORD wNotifyCode, WORD wID, HWND hWndCtl, B
 }
 
 static INT CALLBACK
-EnumFontFamProc(ENUMLOGFONT *lpelf, NEWTEXTMETRIC *lpntm, INT FontType, LPARAM lParam)
+EnumFontFamProc(ENUMLOGFONTW *lpelf, NEWTEXTMETRICW *lpntm, INT FontType, LPARAM lParam)
 {
     CSimpleArray<CStringW>& arrFontNames = *reinterpret_cast<CSimpleArray<CStringW>*>(lParam);
     LPWSTR name = lpelf->elfLogFont.lfFaceName;
@@ -547,7 +545,7 @@ LRESULT CFontsDialog::OnNotify(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
     NMHDR *pnmhdr = reinterpret_cast<NMHDR *>(lParam);
     if (pnmhdr->code == TTN_NEEDTEXT)
     {
-        LPTOOLTIPTEXT pToolTip = reinterpret_cast<LPTOOLTIPTEXT>(lParam);
+        LPTOOLTIPTEXTW pToolTip = reinterpret_cast<LPTOOLTIPTEXTW>(lParam);
         pToolTip->hinst = g_hinstExe;
         switch (pnmhdr->idFrom)
         {
@@ -603,19 +601,19 @@ LRESULT CFontsDialog::OnDrawItem(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& 
         if (pDrawItem->itemID == (UINT)-1)
             return TRUE;
 
-        SetBkMode(pDrawItem->hDC, TRANSPARENT);
+        ::SetBkMode(pDrawItem->hDC, TRANSPARENT);
 
         HWND hwndItem = pDrawItem->hwndItem;
         RECT rcItem = pDrawItem->rcItem;
         if (pDrawItem->itemState & ODS_SELECTED)
         {
-            FillRect(pDrawItem->hDC, &rcItem, GetSysColorBrush(COLOR_HIGHLIGHT));
-            SetTextColor(pDrawItem->hDC, GetSysColor(COLOR_HIGHLIGHTTEXT));
+            ::FillRect(pDrawItem->hDC, &rcItem, GetSysColorBrush(COLOR_HIGHLIGHT));
+            ::SetTextColor(pDrawItem->hDC, GetSysColor(COLOR_HIGHLIGHTTEXT));
         }
         else
         {
-            FillRect(pDrawItem->hDC, &rcItem, GetSysColorBrush(COLOR_WINDOW));
-            SetTextColor(pDrawItem->hDC, GetSysColor(COLOR_WINDOWTEXT));
+            ::FillRect(pDrawItem->hDC, &rcItem, GetSysColorBrush(COLOR_WINDOW));
+            ::SetTextColor(pDrawItem->hDC, GetSysColor(COLOR_WINDOWTEXT));
         }
 
         WCHAR szText[LF_FACESIZE];
@@ -625,7 +623,7 @@ LRESULT CFontsDialog::OnDrawItem(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& 
             ComboBox_GetLBText(hwndItem, pDrawItem->itemID, szText);
 
             rcItem.left += 24;
-            DrawText(pDrawItem->hDC, szText, -1, &rcItem, DT_LEFT | DT_VCENTER | DT_SINGLELINE);
+            ::DrawTextW(pDrawItem->hDC, szText, -1, &rcItem, DT_LEFT | DT_VCENTER | DT_SINGLELINE);
         }
 
         if (pDrawItem->itemState & ODS_FOCUS)

--- a/base/applications/mspaint/dialogs.cpp
+++ b/base/applications/mspaint/dialogs.cpp
@@ -388,7 +388,7 @@ void CFontsDialog::InitToolbar()
     AddBitmap.nID = IDB_FONTSTOOLBAR;
     ::SendMessageW(hwndToolbar, TB_ADDBITMAP, 4, (LPARAM)&AddBitmap);
 
-    HIMAGELIST himl = ImageList_LoadImage(g_hinstExe, MAKEINTRESOURCE(IDB_FONTSTOOLBAR),
+    HIMAGELIST himl = ImageList_LoadImage(g_hinstExe, MAKEINTRESOURCEW(IDB_FONTSTOOLBAR),
                                           16, 8, RGB(255, 0, 255), IMAGE_BITMAP,
                                           LR_CREATEDIBSECTION);
     ::SendMessageW(hwndToolbar, TB_SETIMAGELIST, 0, (LPARAM)himl);
@@ -551,10 +551,10 @@ LRESULT CFontsDialog::OnNotify(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
         pToolTip->hinst = g_hinstExe;
         switch (pnmhdr->idFrom)
         {
-            case IDM_BOLD:      pToolTip->lpszText = MAKEINTRESOURCE(IDS_BOLD); break;
-            case IDM_ITALIC:    pToolTip->lpszText = MAKEINTRESOURCE(IDS_ITALIC); break;
-            case IDM_UNDERLINE: pToolTip->lpszText = MAKEINTRESOURCE(IDS_UNDERLINE); break;
-            case IDM_VERTICAL:  pToolTip->lpszText = MAKEINTRESOURCE(IDS_VERTICAL); break;
+            case IDM_BOLD:      pToolTip->lpszText = MAKEINTRESOURCEW(IDS_BOLD); break;
+            case IDM_ITALIC:    pToolTip->lpszText = MAKEINTRESOURCEW(IDS_ITALIC); break;
+            case IDM_UNDERLINE: pToolTip->lpszText = MAKEINTRESOURCEW(IDS_UNDERLINE); break;
+            case IDM_VERTICAL:  pToolTip->lpszText = MAKEINTRESOURCEW(IDS_VERTICAL); break;
 
             default:
                 break;

--- a/base/applications/mspaint/dialogs.cpp
+++ b/base/applications/mspaint/dialogs.cpp
@@ -113,22 +113,21 @@ LRESULT CAttributesDialog::OnInitDialog(UINT nMsg, WPARAM wParam, LPARAM lParam,
 
     if (g_isAFile)
     {
-        TCHAR date[100];
-        TCHAR temp[100];
-        GetDateFormat(LOCALE_USER_DEFAULT, 0, &g_fileTime, NULL, date, _countof(date));
-        GetTimeFormat(LOCALE_USER_DEFAULT, 0, &g_fileTime, NULL, temp, _countof(temp));
-        _tcscat(date, _T(" "));
-        _tcscat(date, temp);
-        CString strSize;
+        WCHAR date[100], temp[100];
+        GetDateFormatW(LOCALE_USER_DEFAULT, 0, &g_fileTime, NULL, date, _countof(date));
+        GetTimeFormatW(LOCALE_USER_DEFAULT, 0, &g_fileTime, NULL, temp, _countof(temp));
+        StringCchCatW(date, _countof(date), L" ");
+        StringCchCatW(date, _countof(date), temp);
+        CStringW strSize;
         strSize.Format(IDS_FILESIZE, g_fileSize);
         SetDlgItemText(IDD_ATTRIBUTESTEXT6, date);
         SetDlgItemText(IDD_ATTRIBUTESTEXT7, strSize);
     }
 
-    CString strUnit;
+    CStringW strUnit;
     GetDlgItemText(IDD_ATTRIBUTESTEXT8, strUnit);
 
-    CString strRes;
+    CStringW strRes;
     if (strUnit == L"dpi")
         strRes.Format(IDS_PRINTRES, ROUND(g_xDpi), ROUND(g_yDpi));
     else
@@ -173,10 +172,10 @@ LRESULT CAttributesDialog::OnRadioButton1(WORD wNotifyCode, WORD wID, HWND hWndC
     if (IsDlgButtonChecked(IDD_ATTRIBUTESRB1) != BST_CHECKED)
         return 0;
 
-    CString strNum;
-    strNum.Format(_T("%.3lf"), newWidth / g_xDpi);
+    CStringW strNum;
+    strNum.Format(L"%.3lf", newWidth / g_xDpi);
     SetDlgItemText(IDD_ATTRIBUTESEDIT1, strNum);
-    strNum.Format(_T("%.3lf"), newHeight / g_yDpi);
+    strNum.Format(L"%.3lf", newHeight / g_yDpi);
     SetDlgItemText(IDD_ATTRIBUTESEDIT2, strNum);
     return 0;
 }
@@ -186,10 +185,10 @@ LRESULT CAttributesDialog::OnRadioButton2(WORD wNotifyCode, WORD wID, HWND hWndC
     if (IsDlgButtonChecked(IDD_ATTRIBUTESRB2) != BST_CHECKED)
         return 0;
 
-    CString strNum;
-    strNum.Format(_T("%.3lf"), newWidth / PpcmFromDpi(g_xDpi));
+    CStringW strNum;
+    strNum.Format(L"%.3lf", newWidth / PpcmFromDpi(g_xDpi));
     SetDlgItemText(IDD_ATTRIBUTESEDIT1, strNum);
-    strNum.Format(_T("%.3lf"), newHeight / PpcmFromDpi(g_yDpi));
+    strNum.Format(L"%.3lf", newHeight / PpcmFromDpi(g_yDpi));
     SetDlgItemText(IDD_ATTRIBUTESEDIT2, strNum);
     return 0;
 }
@@ -208,21 +207,21 @@ LRESULT CAttributesDialog::OnEdit1(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOO
 {
     if (Edit_GetModify(hWndCtl))
     {
-        TCHAR tempS[100];
+        WCHAR tempS[100];
         if (IsDlgButtonChecked(IDD_ATTRIBUTESRB1))
         {
-            GetDlgItemText(IDD_ATTRIBUTESEDIT1, tempS, _countof(tempS));
-            newWidth = max(1, (int) (_tcstod(tempS, NULL) * g_xDpi));
+            GetDlgItemTextW(IDD_ATTRIBUTESEDIT1, tempS, _countof(tempS));
+            newWidth = max(1, (int) (wcstod(tempS, NULL) * g_xDpi));
         }
         else if (IsDlgButtonChecked(IDD_ATTRIBUTESRB2))
         {
-            GetDlgItemText(IDD_ATTRIBUTESEDIT1, tempS, _countof(tempS));
-            newWidth = max(1, (int) (_tcstod(tempS, NULL) * PpcmFromDpi(g_xDpi)));
+            GetDlgItemTextW(IDD_ATTRIBUTESEDIT1, tempS, _countof(tempS));
+            newWidth = max(1, (int) (wcstod(tempS, NULL) * PpcmFromDpi(g_xDpi)));
         }
         else if (IsDlgButtonChecked(IDD_ATTRIBUTESRB3))
         {
-            GetDlgItemText(IDD_ATTRIBUTESEDIT1, tempS, _countof(tempS));
-            newWidth = max(1, _tstoi(tempS));
+            GetDlgItemTextW(IDD_ATTRIBUTESEDIT1, tempS, _countof(tempS));
+            newWidth = max(1, _wtoi(tempS));
         }
         Edit_SetModify(hWndCtl, FALSE);
     }
@@ -233,21 +232,21 @@ LRESULT CAttributesDialog::OnEdit2(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOO
 {
     if (Edit_GetModify(hWndCtl))
     {
-        TCHAR tempS[100];
+        WCHAR tempS[100];
         if (IsDlgButtonChecked(IDD_ATTRIBUTESRB1))
         {
-            GetDlgItemText(IDD_ATTRIBUTESEDIT2, tempS, _countof(tempS));
-            newHeight = max(1, (int) (_tcstod(tempS, NULL) * g_yDpi));
+            GetDlgItemTextW(IDD_ATTRIBUTESEDIT2, tempS, _countof(tempS));
+            newHeight = max(1, (int) (wcstod(tempS, NULL) * g_yDpi));
         }
         else if (IsDlgButtonChecked(IDD_ATTRIBUTESRB2))
         {
-            GetDlgItemText(IDD_ATTRIBUTESEDIT2, tempS, _countof(tempS));
-            newHeight = max(1, (int) (_tcstod(tempS, NULL) * PpcmFromDpi(g_yDpi)));
+            GetDlgItemTextW(IDD_ATTRIBUTESEDIT2, tempS, _countof(tempS));
+            newHeight = max(1, (int) (wcstod(tempS, NULL) * PpcmFromDpi(g_yDpi)));
         }
         else if (IsDlgButtonChecked(IDD_ATTRIBUTESRB3))
         {
-            GetDlgItemText(IDD_ATTRIBUTESEDIT2, tempS, _countof(tempS));
-            newHeight = max(1, _tstoi(tempS));
+            GetDlgItemTextW(IDD_ATTRIBUTESEDIT2, tempS, _countof(tempS));
+            newHeight = max(1, _wtoi(tempS));
         }
         Edit_SetModify(hWndCtl, FALSE);
     }
@@ -273,9 +272,9 @@ LRESULT CStretchSkewDialog::OnClose(UINT nMsg, WPARAM wParam, LPARAM lParam, BOO
 
 LRESULT CStretchSkewDialog::OnOk(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL& bHandled)
 {
-    CString strrcIntNumbers;
-    CString strrcPercentage;
-    CString strrcAngle;
+    CStringW strrcIntNumbers;
+    CStringW strrcPercentage;
+    CStringW strrcAngle;
     BOOL tr1, tr2, tr3, tr4;
 
     strrcIntNumbers.LoadString(g_hinstExe, IDS_INTNUMBERS);
@@ -307,9 +306,9 @@ LRESULT CStretchSkewDialog::OnCancel(WORD wNotifyCode, WORD wID, HWND hWndCtl, B
 static INT CALLBACK
 EnumFontFamProc(ENUMLOGFONT *lpelf, NEWTEXTMETRIC *lpntm, INT FontType, LPARAM lParam)
 {
-    CSimpleArray<CString>& arrFontNames = *reinterpret_cast<CSimpleArray<CString>*>(lParam);
-    LPTSTR name = lpelf->elfLogFont.lfFaceName;
-    if (name[0] == TEXT('@')) // Vertical fonts
+    CSimpleArray<CStringW>& arrFontNames = *reinterpret_cast<CSimpleArray<CStringW>*>(lParam);
+    LPWSTR name = lpelf->elfLogFont.lfFaceName;
+    if (name[0] == L'@') // Vertical fonts
         return TRUE;
 
     for (INT i = 0; i < arrFontNames.GetSize(); ++i)
@@ -331,7 +330,7 @@ CFontsDialog::CFontsDialog()
 void CFontsDialog::InitFontNames()
 {
     // List the fonts
-    CSimpleArray<CString> arrFontNames;
+    CSimpleArray<CStringW> arrFontNames;
     HDC hDC = CreateCompatibleDC(NULL);
     if (hDC)
     {
@@ -342,13 +341,13 @@ void CFontsDialog::InitFontNames()
 
     // Actually add them to the combobox
     HWND hwndNames = GetDlgItem(IDD_FONTSNAMES);
-    SendMessage(hwndNames, CB_RESETCONTENT, 0, 0);
+    ::SendMessageW(hwndNames, CB_RESETCONTENT, 0, 0);
     for (INT i = 0; i < arrFontNames.GetSize(); ++i)
     {
         ComboBox_AddString(hwndNames, arrFontNames[i]);
     }
 
-    ::SetWindowText(hwndNames, registrySettings.strFontName);
+    ::SetWindowTextW(hwndNames, registrySettings.strFontName);
 }
 
 void CFontsDialog::InitFontSizes()
@@ -373,26 +372,26 @@ void CFontsDialog::InitFontSizes()
     if (ComboBox_GetCurSel(hwndSizes) == CB_ERR)
     {
         StringCchPrintfW(szText, _countof(szText), L"%d", (INT)registrySettings.PointSize);
-        ::SetWindowText(hwndSizes, szText);
+        ::SetWindowTextW(hwndSizes, szText);
     }
 }
 
 void CFontsDialog::InitToolbar()
 {
     HWND hwndToolbar = GetDlgItem(IDD_FONTSTOOLBAR);
-    SendMessage(hwndToolbar, TB_BUTTONSTRUCTSIZE, sizeof(TBBUTTON), 0);
-    SendMessage(hwndToolbar, TB_SETBITMAPSIZE, 0, MAKELPARAM(16, 16));
-    SendMessage(hwndToolbar, TB_SETBUTTONWIDTH, 0, MAKELPARAM(20, 20));
+    ::SendMessageW(hwndToolbar, TB_BUTTONSTRUCTSIZE, sizeof(TBBUTTON), 0);
+    ::SendMessageW(hwndToolbar, TB_SETBITMAPSIZE, 0, MAKELPARAM(16, 16));
+    ::SendMessageW(hwndToolbar, TB_SETBUTTONWIDTH, 0, MAKELPARAM(20, 20));
     
     TBADDBITMAP AddBitmap;
     AddBitmap.hInst = g_hinstExe;
     AddBitmap.nID = IDB_FONTSTOOLBAR;
-    SendMessage(hwndToolbar, TB_ADDBITMAP, 4, (LPARAM)&AddBitmap);
+    ::SendMessageW(hwndToolbar, TB_ADDBITMAP, 4, (LPARAM)&AddBitmap);
 
     HIMAGELIST himl = ImageList_LoadImage(g_hinstExe, MAKEINTRESOURCE(IDB_FONTSTOOLBAR),
                                           16, 8, RGB(255, 0, 255), IMAGE_BITMAP,
                                           LR_CREATEDIBSECTION);
-    SendMessage(hwndToolbar, TB_SETIMAGELIST, 0, (LPARAM)himl);
+    ::SendMessageW(hwndToolbar, TB_SETIMAGELIST, 0, (LPARAM)himl);
 
     TBBUTTON buttons[] =
     {
@@ -401,11 +400,11 @@ void CFontsDialog::InitToolbar()
         { 2, IDM_UNDERLINE, TBSTATE_ENABLED, TBSTYLE_CHECK },
         { 3, IDM_VERTICAL, 0, TBSTYLE_CHECK }, // TODO:
     };
-    SendMessage(hwndToolbar, TB_ADDBUTTONS, _countof(buttons), (LPARAM)&buttons);
+    ::SendMessageW(hwndToolbar, TB_ADDBUTTONS, _countof(buttons), (LPARAM)&buttons);
 
-    SendMessage(hwndToolbar, TB_CHECKBUTTON, IDM_BOLD, registrySettings.Bold);
-    SendMessage(hwndToolbar, TB_CHECKBUTTON, IDM_ITALIC, registrySettings.Italic);
-    SendMessage(hwndToolbar, TB_CHECKBUTTON, IDM_UNDERLINE, registrySettings.Underline);
+    ::SendMessageW(hwndToolbar, TB_CHECKBUTTON, IDM_BOLD, registrySettings.Bold);
+    ::SendMessageW(hwndToolbar, TB_CHECKBUTTON, IDM_ITALIC, registrySettings.Italic);
+    ::SendMessageW(hwndToolbar, TB_CHECKBUTTON, IDM_UNDERLINE, registrySettings.Underline);
 }
 
 LRESULT CFontsDialog::OnInitDialog(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
@@ -441,7 +440,7 @@ void CFontsDialog::OnFontName(UINT codeNotify)
     HWND hwndNames = GetDlgItem(IDD_FONTSNAMES);
     INT iItem = CB_ERR;
     UINT cch;
-    TCHAR szText[LF_FACESIZE];
+    WCHAR szText[LF_FACESIZE];
 
     switch (codeNotify)
     {
@@ -487,7 +486,7 @@ void CFontsDialog::OnFontSize(UINT codeNotify)
             break;
 
         case CBN_EDITCHANGE:
-            ::GetWindowText(hwndSizes, szText, _countof(szText));
+            ::GetWindowTextW(hwndSizes, szText, _countof(szText));
             PointSize = _ttoi(szText);
             break;
     }
@@ -504,7 +503,7 @@ LRESULT CFontsDialog::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& b
     UINT id = LOWORD(wParam);
     UINT codeNotify = HIWORD(wParam);
     HWND hwndToolbar = GetDlgItem(IDD_FONTSTOOLBAR);
-    BOOL bChecked = (BOOL)::SendMessage(hwndToolbar, TB_ISBUTTONCHECKED, id, 0);
+    BOOL bChecked = (BOOL)::SendMessageW(hwndToolbar, TB_ISBUTTONCHECKED, id, 0);
 
     switch (id)
     {
@@ -619,7 +618,7 @@ LRESULT CFontsDialog::OnDrawItem(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& 
             SetTextColor(pDrawItem->hDC, GetSysColor(COLOR_WINDOWTEXT));
         }
 
-        TCHAR szText[LF_FACESIZE];
+        WCHAR szText[LF_FACESIZE];
         if ((UINT)ComboBox_GetLBTextLen(hwndItem, pDrawItem->itemID) < _countof(szText))
         {
             szText[0] = 0;

--- a/base/applications/mspaint/dialogs.cpp
+++ b/base/applications/mspaint/dialogs.cpp
@@ -210,17 +210,17 @@ LRESULT CAttributesDialog::OnEdit1(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOO
         WCHAR tempS[100];
         if (IsDlgButtonChecked(IDD_ATTRIBUTESRB1))
         {
-            GetDlgItemTextW(IDD_ATTRIBUTESEDIT1, tempS, _countof(tempS));
+            GetDlgItemText(IDD_ATTRIBUTESEDIT1, tempS, _countof(tempS));
             newWidth = max(1, (int) (wcstod(tempS, NULL) * g_xDpi));
         }
         else if (IsDlgButtonChecked(IDD_ATTRIBUTESRB2))
         {
-            GetDlgItemTextW(IDD_ATTRIBUTESEDIT1, tempS, _countof(tempS));
+            GetDlgItemText(IDD_ATTRIBUTESEDIT1, tempS, _countof(tempS));
             newWidth = max(1, (int) (wcstod(tempS, NULL) * PpcmFromDpi(g_xDpi)));
         }
         else if (IsDlgButtonChecked(IDD_ATTRIBUTESRB3))
         {
-            GetDlgItemTextW(IDD_ATTRIBUTESEDIT1, tempS, _countof(tempS));
+            GetDlgItemText(IDD_ATTRIBUTESEDIT1, tempS, _countof(tempS));
             newWidth = max(1, _wtoi(tempS));
         }
         Edit_SetModify(hWndCtl, FALSE);
@@ -235,17 +235,17 @@ LRESULT CAttributesDialog::OnEdit2(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOO
         WCHAR tempS[100];
         if (IsDlgButtonChecked(IDD_ATTRIBUTESRB1))
         {
-            GetDlgItemTextW(IDD_ATTRIBUTESEDIT2, tempS, _countof(tempS));
+            GetDlgItemText(IDD_ATTRIBUTESEDIT2, tempS, _countof(tempS));
             newHeight = max(1, (int) (wcstod(tempS, NULL) * g_yDpi));
         }
         else if (IsDlgButtonChecked(IDD_ATTRIBUTESRB2))
         {
-            GetDlgItemTextW(IDD_ATTRIBUTESEDIT2, tempS, _countof(tempS));
+            GetDlgItemText(IDD_ATTRIBUTESEDIT2, tempS, _countof(tempS));
             newHeight = max(1, (int) (wcstod(tempS, NULL) * PpcmFromDpi(g_yDpi)));
         }
         else if (IsDlgButtonChecked(IDD_ATTRIBUTESRB3))
         {
-            GetDlgItemTextW(IDD_ATTRIBUTESEDIT2, tempS, _countof(tempS));
+            GetDlgItemText(IDD_ATTRIBUTESEDIT2, tempS, _countof(tempS));
             newHeight = max(1, _wtoi(tempS));
         }
         Edit_SetModify(hWndCtl, FALSE);

--- a/base/applications/mspaint/dialogs.cpp
+++ b/base/applications/mspaint/dialogs.cpp
@@ -211,12 +211,12 @@ LRESULT CAttributesDialog::OnEdit1(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOO
         if (IsDlgButtonChecked(IDD_ATTRIBUTESRB1))
         {
             GetDlgItemText(IDD_ATTRIBUTESEDIT1, tempS, _countof(tempS));
-            newWidth = max(1, (int) (wcstod(tempS, NULL) * g_xDpi));
+            newWidth = max(1, (int)(wcstod(tempS, NULL) * g_xDpi));
         }
         else if (IsDlgButtonChecked(IDD_ATTRIBUTESRB2))
         {
             GetDlgItemText(IDD_ATTRIBUTESEDIT1, tempS, _countof(tempS));
-            newWidth = max(1, (int) (wcstod(tempS, NULL) * PpcmFromDpi(g_xDpi)));
+            newWidth = max(1, (int)(wcstod(tempS, NULL) * PpcmFromDpi(g_xDpi)));
         }
         else if (IsDlgButtonChecked(IDD_ATTRIBUTESRB3))
         {
@@ -236,12 +236,12 @@ LRESULT CAttributesDialog::OnEdit2(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOO
         if (IsDlgButtonChecked(IDD_ATTRIBUTESRB1))
         {
             GetDlgItemText(IDD_ATTRIBUTESEDIT2, tempS, _countof(tempS));
-            newHeight = max(1, (int) (wcstod(tempS, NULL) * g_yDpi));
+            newHeight = max(1, (int)(wcstod(tempS, NULL) * g_yDpi));
         }
         else if (IsDlgButtonChecked(IDD_ATTRIBUTESRB2))
         {
             GetDlgItemText(IDD_ATTRIBUTESEDIT2, tempS, _countof(tempS));
-            newHeight = max(1, (int) (wcstod(tempS, NULL) * PpcmFromDpi(g_yDpi)));
+            newHeight = max(1, (int)(wcstod(tempS, NULL) * PpcmFromDpi(g_yDpi)));
         }
         else if (IsDlgButtonChecked(IDD_ATTRIBUTESRB3))
         {
@@ -479,13 +479,13 @@ void CFontsDialog::OnFontSize(UINT codeNotify)
             if (iItem != CB_ERR && 0 < cch && cch < _countof(szText))
             {
                 ComboBox_GetLBText(hwndSizes, iItem, szText);
-                PointSize = _ttoi(szText);
+                PointSize = _wtoi(szText);
             }
             break;
 
         case CBN_EDITCHANGE:
             ::GetWindowTextW(hwndSizes, szText, _countof(szText));
-            PointSize = _ttoi(szText);
+            PointSize = _wtoi(szText);
             break;
     }
 

--- a/base/applications/mspaint/dialogs.cpp
+++ b/base/applications/mspaint/dialogs.cpp
@@ -332,9 +332,9 @@ void CFontsDialog::InitFontNames()
     HDC hDC = CreateCompatibleDC(NULL);
     if (hDC)
     {
-        EnumFontFamilies(hDC, NULL, (FONTENUMPROC)EnumFontFamProc,
-                         reinterpret_cast<LPARAM>(&arrFontNames));
-        DeleteDC(hDC);
+        EnumFontFamiliesW(hDC, NULL, (FONTENUMPROCW)EnumFontFamProc,
+                          reinterpret_cast<LPARAM>(&arrFontNames));
+        ::DeleteDC(hDC);
     }
 
     // Actually add them to the combobox
@@ -446,9 +446,7 @@ void CFontsDialog::OnFontName(UINT codeNotify)
             iItem = ComboBox_GetCurSel(hwndNames);
             cch = ComboBox_GetLBTextLen(hwndNames, iItem);
             if (iItem != CB_ERR && 0 < cch && cch < _countof(szText))
-            {
                 ComboBox_GetLBText(hwndNames, iItem, szText);
-            }
             break;
 
         case CBN_EDITCHANGE:

--- a/base/applications/mspaint/dib.cpp
+++ b/base/applications/mspaint/dib.cpp
@@ -212,7 +212,7 @@ void SetFileInfo(LPCWSTR name, LPWIN32_FIND_DATAW pFound, BOOL isAFile)
 
     // set title
     CStringW strTitle;
-    strTitle.Format(IDS_WINDOWTITLE, PathFindFileName(g_szFileName));
+    strTitle.Format(IDS_WINDOWTITLE, PathFindFileNameW(g_szFileName));
     mainWindow.SetWindowText(strTitle);
 
     // update file info and recent
@@ -258,7 +258,7 @@ HBITMAP DoLoadImageFile(HWND hwnd, LPCWSTR name, BOOL fIsMainFile)
     CWaitCursor waitCursor;
 
     // find the file
-    WIN32_FIND_DATA find;
+    WIN32_FIND_DATAW find;
     HANDLE hFind = ::FindFirstFileW(name, &find);
     if (hFind == INVALID_HANDLE_VALUE) // does not exist
     {

--- a/base/applications/mspaint/dib.cpp
+++ b/base/applications/mspaint/dib.cpp
@@ -211,7 +211,7 @@ void SetFileInfo(LPCWSTR name, LPWIN32_FIND_DATAW pFound, BOOL isAFile)
     }
 
     // set title
-    CString strTitle;
+    CStringW strTitle;
     strTitle.Format(IDS_WINDOWTITLE, PathFindFileName(g_szFileName));
     mainWindow.SetWindowText(strTitle);
 

--- a/base/applications/mspaint/dib.cpp
+++ b/base/applications/mspaint/dib.cpp
@@ -87,7 +87,7 @@ CreateColorDIB(int width, int height, COLORREF rgb)
 HBITMAP CopyMonoImage(HBITMAP hbm, INT cx, INT cy)
 {
     BITMAP bm;
-    if (!GetObject(hbm, sizeof(bm), &bm))
+    if (!::GetObjectW(hbm, sizeof(bm), &bm))
         return NULL;
 
     if (cx == 0 || cy == 0)
@@ -96,19 +96,19 @@ HBITMAP CopyMonoImage(HBITMAP hbm, INT cx, INT cy)
         cy = bm.bmHeight;
     }
 
-    HBITMAP hbmNew = CreateBitmap(cx, cy, 1, 1, NULL);
+    HBITMAP hbmNew = ::CreateBitmap(cx, cy, 1, 1, NULL);
     if (!hbmNew)
         return NULL;
 
-    HDC hdc1 = CreateCompatibleDC(NULL);
-    HDC hdc2 = CreateCompatibleDC(NULL);
-    HGDIOBJ hbm1Old = SelectObject(hdc1, hbm);
-    HGDIOBJ hbm2Old = SelectObject(hdc2, hbmNew);
-    StretchBlt(hdc2, 0, 0, cx, cy, hdc1, 0, 0, bm.bmWidth, bm.bmHeight, SRCCOPY);
-    SelectObject(hdc1, hbm1Old);
-    SelectObject(hdc2, hbm2Old);
-    DeleteDC(hdc1);
-    DeleteDC(hdc2);
+    HDC hdc1 = ::CreateCompatibleDC(NULL);
+    HDC hdc2 = ::CreateCompatibleDC(NULL);
+    HGDIOBJ hbm1Old = ::SelectObject(hdc1, hbm);
+    HGDIOBJ hbm2Old = ::SelectObject(hdc2, hbmNew);
+    ::StretchBlt(hdc2, 0, 0, cx, cy, hdc1, 0, 0, bm.bmWidth, bm.bmHeight, SRCCOPY);
+    ::SelectObject(hdc1, hbm1Old);
+    ::SelectObject(hdc2, hbm2Old);
+    ::DeleteDC(hdc1);
+    ::DeleteDC(hdc2);
     return hbmNew;
 }
 
@@ -120,7 +120,7 @@ HBITMAP CachedBufferDIB(HBITMAP hbm, int minimalWidth, int minimalHeight)
         minimalHeight = 1;
 
     BITMAP bm;
-    if (!GetObject(hbm, sizeof(bm), &bm))
+    if (!GetObjectW(hbm, sizeof(bm), &bm))
         hbm = NULL;
 
     if (hbm && minimalWidth <= bm.bmWidth && minimalHeight <= bm.bmHeight)
@@ -136,7 +136,7 @@ int
 GetDIBWidth(HBITMAP hBitmap)
 {
     BITMAP bm;
-    GetObject(hBitmap, sizeof(BITMAP), &bm);
+    ::GetObjectW(hBitmap, sizeof(BITMAP), &bm);
     return bm.bmWidth;
 }
 
@@ -144,7 +144,7 @@ int
 GetDIBHeight(HBITMAP hBitmap)
 {
     BITMAP bm;
-    GetObject(hBitmap, sizeof(BITMAP), &bm);
+    ::GetObjectW(hBitmap, sizeof(BITMAP), &bm);
     return bm.bmHeight;
 }
 
@@ -358,7 +358,7 @@ HBITMAP SkewDIB(HDC hDC1, HBITMAP hbm, INT nDegree, BOOL bVertical, BOOL bMono)
     const double eTan = tan(abs(nDegree) * M_PI / 180);
 
     BITMAP bm;
-    GetObjectW(hbm, sizeof(bm), &bm);
+    ::GetObjectW(hbm, sizeof(bm), &bm);
     INT cx = bm.bmWidth, cy = bm.bmHeight, dx = 0, dy = 0;
     if (bVertical)
         dy = INT(cx * eTan);
@@ -384,9 +384,9 @@ HBITMAP SkewDIB(HDC hDC1, HBITMAP hbm, INT nDegree, BOOL bVertical, BOOL bMono)
         {
             INT delta = INT(x * eTan);
             if (nDegree > 0)
-                BitBlt(hDC2, x, (dy - delta), 1, cy, hDC1, x, 0, SRCCOPY);
+                ::BitBlt(hDC2, x, (dy - delta), 1, cy, hDC1, x, 0, SRCCOPY);
             else
-                BitBlt(hDC2, x, delta, 1, cy, hDC1, x, 0, SRCCOPY);
+                ::BitBlt(hDC2, x, delta, 1, cy, hDC1, x, 0, SRCCOPY);
         }
     }
     else
@@ -395,9 +395,9 @@ HBITMAP SkewDIB(HDC hDC1, HBITMAP hbm, INT nDegree, BOOL bVertical, BOOL bMono)
         {
             INT delta = INT(y * eTan);
             if (nDegree > 0)
-                BitBlt(hDC2, (dx - delta), y, cx, 1, hDC1, 0, y, SRCCOPY);
+                ::BitBlt(hDC2, (dx - delta), y, cx, 1, hDC1, 0, y, SRCCOPY);
             else
-                BitBlt(hDC2, delta, y, cx, 1, hDC1, 0, y, SRCCOPY);
+                ::BitBlt(hDC2, delta, y, cx, 1, hDC1, 0, y, SRCCOPY);
         }
     }
 
@@ -416,7 +416,7 @@ HGLOBAL BitmapToClipboardDIB(HBITMAP hBitmap)
     CWaitCursor waitCursor;
 
     BITMAP bm;
-    if (!GetObject(hBitmap, sizeof(BITMAP), &bm))
+    if (!GetObjectW(hBitmap, sizeof(BITMAP), &bm))
         return NULL;
 
     BITMAPINFODX bmi;
@@ -600,7 +600,7 @@ HBITMAP ConvertToBlackAndWhite(HBITMAP hbm)
     CWaitCursor waitCursor;
 
     BITMAP bm;
-    if (!::GetObject(hbm, sizeof(bm), &bm))
+    if (!::GetObjectW(hbm, sizeof(bm), &bm))
         return NULL;
 
     BITMAPINFOEX bmi;

--- a/base/applications/mspaint/drawing.cpp
+++ b/base/applications/mspaint/drawing.cpp
@@ -253,7 +253,7 @@ RectSel(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2)
 }
 
 void
-Text(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, COLORREF fg, COLORREF bg, LPCTSTR lpchText, HFONT font, LONG style)
+Text(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, COLORREF fg, COLORREF bg, LPCWSTR lpchText, HFONT font, LONG style)
 {
     INT iSaveDC = SaveDC(hdc); // We will modify the clipping region. Save now.
 

--- a/base/applications/mspaint/drawing.cpp
+++ b/base/applications/mspaint/drawing.cpp
@@ -255,36 +255,35 @@ RectSel(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2)
 void
 Text(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, COLORREF fg, COLORREF bg, LPCWSTR lpchText, HFONT font, LONG style)
 {
-    INT iSaveDC = SaveDC(hdc); // We will modify the clipping region. Save now.
+    INT iSaveDC = ::SaveDC(hdc); // We will modify the clipping region. Save now.
 
     RECT rc;
-    SetRect(&rc, x1, y1, x2, y2);
+    ::SetRect(&rc, x1, y1, x2, y2);
 
     if (style == 0) // Transparent
     {
-        SetBkMode(hdc, TRANSPARENT);
-        GetBkColor(hdc);
+        ::SetBkMode(hdc, TRANSPARENT);
     }
     else // Opaque
     {
-        SetBkMode(hdc, OPAQUE);
-        SetBkColor(hdc, bg);
+        ::SetBkMode(hdc, OPAQUE);
+        ::SetBkColor(hdc, bg);
 
-        HBRUSH hbr = CreateSolidBrush(bg);
-        FillRect(hdc, &rc, hbr); // Fill the background
-        DeleteObject(hbr);
+        HBRUSH hbr = ::CreateSolidBrush(bg);
+        ::FillRect(hdc, &rc, hbr); // Fill the background
+        ::DeleteObject(hbr);
     }
 
     IntersectClipRect(hdc, rc.left, rc.top, rc.right, rc.bottom);
 
-    HGDIOBJ hFontOld = SelectObject(hdc, font);
-    SetTextColor(hdc, fg);
+    HGDIOBJ hFontOld = ::SelectObject(hdc, font);
+    ::SetTextColor(hdc, fg);
     const UINT uFormat = DT_LEFT | DT_TOP | DT_EDITCONTROL | DT_NOPREFIX | DT_NOCLIP |
                          DT_EXPANDTABS | DT_WORDBREAK;
-    DrawText(hdc, lpchText, -1, &rc, uFormat);
-    SelectObject(hdc, hFontOld);
+    ::DrawTextW(hdc, lpchText, -1, &rc, uFormat);
+    ::SelectObject(hdc, hFontOld);
 
-    RestoreDC(hdc, iSaveDC); // Restore
+    ::RestoreDC(hdc, iSaveDC); // Restore
 }
 
 BOOL

--- a/base/applications/mspaint/drawing.h
+++ b/base/applications/mspaint/drawing.h
@@ -31,7 +31,7 @@ void Brush(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, COLORREF color, LONG sty
 
 void RectSel(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2);
 
-void Text(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, COLORREF fg, COLORREF bg, LPCTSTR lpchText, HFONT font, LONG style);
+void Text(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, COLORREF fg, COLORREF bg, LPCWSTR lpchText, HFONT font, LONG style);
 
 BOOL
 ColorKeyedMaskBlt(HDC hdcDest, int nXDest, int nYDest, int nWidth, int nHeight,

--- a/base/applications/mspaint/fullscreen.cpp
+++ b/base/applications/mspaint/fullscreen.cpp
@@ -22,8 +22,8 @@ HWND CFullscreenWindow::DoCreate()
 
 LRESULT CFullscreenWindow::OnCreate(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
-    SendMessage(WM_SETICON, ICON_BIG, (LPARAM) LoadIcon(g_hinstExe, MAKEINTRESOURCE(IDI_APPICON)));
-    SendMessage(WM_SETICON, ICON_SMALL, (LPARAM) LoadIcon(g_hinstExe, MAKEINTRESOURCE(IDI_APPICON)));
+    SendMessage(WM_SETICON, ICON_BIG, (LPARAM)::LoadIconW(g_hinstExe, MAKEINTRESOURCEW(IDI_APPICON)));
+    SendMessage(WM_SETICON, ICON_SMALL, (LPARAM)::LoadIconW(g_hinstExe, MAKEINTRESOURCEW(IDI_APPICON)));
     return 0;
 }
 

--- a/base/applications/mspaint/fullscreen.h
+++ b/base/applications/mspaint/fullscreen.h
@@ -10,7 +10,7 @@
 class CFullscreenWindow : public CWindowImpl<CFullscreenWindow>
 {
 public:
-    DECLARE_WND_CLASS_EX(_T("FullscreenWindow"), CS_DBLCLKS | CS_HREDRAW | CS_VREDRAW,
+    DECLARE_WND_CLASS_EX(L"FullscreenWindow", CS_DBLCLKS | CS_HREDRAW | CS_VREDRAW,
                          COLOR_BACKGROUND)
 
     BEGIN_MSG_MAP(CFullscreenWindow)

--- a/base/applications/mspaint/globalvar.h
+++ b/base/applications/mspaint/globalvar.h
@@ -15,7 +15,7 @@ extern POINT g_ptStart, g_ptEnd;
 
 extern HINSTANCE g_hinstExe;
 
-extern TCHAR g_szFileName[MAX_LONG_PATH];
+extern WCHAR g_szFileName[MAX_LONG_PATH];
 extern BOOL g_isAFile;
 extern BOOL g_imageSaved;
 extern BOOL g_showGrid;

--- a/base/applications/mspaint/history.cpp
+++ b/base/applications/mspaint/history.cpp
@@ -266,8 +266,8 @@ void ImageModel::RotateNTimes90Degrees(int iN)
         case 2:
         {
             PushImageForUndo();
-            StretchBlt(m_hDrawingDC, GetWidth() - 1, GetHeight() - 1, -GetWidth(), -GetHeight(),
-                       m_hDrawingDC, 0, 0, GetWidth(), GetHeight(), SRCCOPY);
+            ::StretchBlt(m_hDrawingDC, GetWidth() - 1, GetHeight() - 1, -GetWidth(), -GetHeight(),
+                         m_hDrawingDC, 0, 0, GetWidth(), GetHeight(), SRCCOPY);
             break;
         }
     }

--- a/base/applications/mspaint/history.cpp
+++ b/base/applications/mspaint/history.cpp
@@ -179,7 +179,7 @@ void ImageModel::Crop(int nWidth, int nHeight, int nOffsetX, int nOffsetY)
     NotifyImageChanged();
 }
 
-void ImageModel::SaveImage(LPCTSTR lpFileName)
+void ImageModel::SaveImage(LPCWSTR lpFileName)
 {
     SaveDIBToFile(m_hBms[m_currInd], lpFileName, TRUE);
 }

--- a/base/applications/mspaint/history.h
+++ b/base/applications/mspaint/history.h
@@ -25,7 +25,7 @@ public:
     void Redo(void);
     void ClearHistory(void);
     void Crop(int nWidth, int nHeight, int nOffsetX = 0, int nOffsetY = 0);
-    void SaveImage(LPCTSTR lpFileName);
+    void SaveImage(LPCWSTR lpFileName);
     BOOL IsImageSaved() const;
     void StretchSkew(int nStretchPercentX, int nStretchPercentY, int nSkewDegX = 0, int nSkewDegY = 0);
     int GetWidth() const;

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -66,12 +66,12 @@ static UINT_PTR APIENTRY
 OFNHookProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
     HWND hParent;
-    OFNOTIFY *pon;
+    OFNOTIFYW *pon;
     WCHAR Path[MAX_PATH];
     switch (uMsg)
     {
     case WM_NOTIFY:
-        pon = (OFNOTIFY *)lParam;
+        pon = (OFNOTIFYW *)lParam;
         if (pon->hdr.code == CDN_TYPECHANGE)
         {
             hParent = GetParent(hwnd);
@@ -197,7 +197,7 @@ BOOL OpenMailer(HWND hWnd, LPCWSTR pszPathName)
 
 BOOL CMainWindow::GetOpenFileName(IN OUT LPWSTR pszFile, INT cchMaxFile)
 {
-    static OPENFILENAME ofn = { 0 };
+    static OPENFILENAMEW ofn = { 0 };
     static CStringW strFilter;
 
     if (ofn.lStructSize == 0)
@@ -223,12 +223,12 @@ BOOL CMainWindow::GetOpenFileName(IN OUT LPWSTR pszFile, INT cchMaxFile)
 
     ofn.lpstrFile = pszFile;
     ofn.nMaxFile  = cchMaxFile;
-    return ::GetOpenFileName(&ofn);
+    return ::GetOpenFileNameW(&ofn);
 }
 
 BOOL CMainWindow::GetSaveFileName(IN OUT LPWSTR pszFile, INT cchMaxFile)
 {
-    static OPENFILENAME sfn = { 0 };
+    static OPENFILENAMEW sfn = { 0 };
     static CStringW strFilter;
 
     if (sfn.lStructSize == 0)
@@ -266,7 +266,7 @@ BOOL CMainWindow::GetSaveFileName(IN OUT LPWSTR pszFile, INT cchMaxFile)
 
     sfn.lpstrFile = pszFile;
     sfn.nMaxFile  = cchMaxFile;
-    return ::GetSaveFileName(&sfn);
+    return ::GetSaveFileNameW(&sfn);
 }
 
 BOOL CMainWindow::ChooseColor(IN OUT COLORREF *prgbColor)
@@ -298,7 +298,7 @@ BOOL CMainWindow::ChooseColor(IN OUT COLORREF *prgbColor)
 
 HWND CMainWindow::DoCreate()
 {
-    ::LoadString(g_hinstExe, IDS_DEFAULTFILENAME, g_szFileName, _countof(g_szFileName));
+    ::LoadStringW(g_hinstExe, IDS_DEFAULTFILENAME, g_szFileName, _countof(g_szFileName));
 
     CStringW strTitle;
     strTitle.Format(IDS_WINDOWTITLE, PathFindFileName(g_szFileName));
@@ -309,7 +309,7 @@ HWND CMainWindow::DoCreate()
 
 // entry point
 INT WINAPI
-_tWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdLine, INT nCmdShow)
+wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdLine, INT nCmdShow)
 {
     g_hinstExe = hInstance;
 
@@ -346,7 +346,7 @@ _tWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdLine, INT nC
         if (fontsDialog.IsWindow() && fontsDialog.IsDialogMessage(&msg))
             continue;
 
-        if (::TranslateAccelerator(mainWindow, hAccel, &msg))
+        if (::TranslateAcceleratorW(mainWindow, hAccel, &msg))
             continue;
 
         ::TranslateMessage(&msg);

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -13,7 +13,7 @@
 POINT g_ptStart, g_ptEnd;
 BOOL g_askBeforeEnlarging = FALSE;  // TODO: initialize from registry
 HINSTANCE g_hinstExe = NULL;
-TCHAR g_szFileName[MAX_LONG_PATH] = { 0 };
+WCHAR g_szFileName[MAX_LONG_PATH] = { 0 };
 WCHAR g_szMailTempFile[MAX_LONG_PATH] = { 0 };
 BOOL g_isAFile = FALSE;
 BOOL g_imageSaved = FALSE;
@@ -37,18 +37,18 @@ void ShowOutOfMemory(void)
 
 // get file name extension from filter string
 static BOOL
-FileExtFromFilter(LPTSTR pExt, OPENFILENAME *pOFN)
+FileExtFromFilter(LPWSTR pExt, OPENFILENAME *pOFN)
 {
-    LPTSTR pchExt = pExt;
+    LPWSTR pchExt = pExt;
     *pchExt = 0;
 
     DWORD nIndex = 1;
-    for (LPCTSTR pch = pOFN->lpstrFilter; *pch; ++nIndex)
+    for (LPCWSTR pch = pOFN->lpstrFilter; *pch; ++nIndex)
     {
         pch += lstrlen(pch) + 1;
         if (pOFN->nFilterIndex == nIndex)
         {
-            for (++pch; *pch && *pch != _T(';'); ++pch)
+            for (++pch; *pch && *pch != L';'; ++pch)
             {
                 *pchExt++ = *pch;
             }
@@ -195,21 +195,21 @@ BOOL OpenMailer(HWND hWnd, LPCWSTR pszPathName)
     return FALSE; // Failure
 }
 
-BOOL CMainWindow::GetOpenFileName(IN OUT LPTSTR pszFile, INT cchMaxFile)
+BOOL CMainWindow::GetOpenFileName(IN OUT LPWSTR pszFile, INT cchMaxFile)
 {
     static OPENFILENAME ofn = { 0 };
-    static CString strFilter;
+    static CStringW strFilter;
 
     if (ofn.lStructSize == 0)
     {
         // The "All Files" item text
-        CString strAllPictureFiles;
+        CStringW strAllPictureFiles;
         strAllPictureFiles.LoadString(g_hinstExe, IDS_ALLPICTUREFILES);
 
         // Get the import filter
         CSimpleArray<GUID> aguidFileTypesI;
         CImage::GetImporterFilterString(strFilter, aguidFileTypesI, strAllPictureFiles,
-                                        CImage::excludeDefaultLoad, _T('\0'));
+                                        CImage::excludeDefaultLoad, UNICODE_NULL);
 
         // Initializing the OPENFILENAME structure for GetOpenFileName
         ZeroMemory(&ofn, sizeof(ofn));
@@ -226,17 +226,17 @@ BOOL CMainWindow::GetOpenFileName(IN OUT LPTSTR pszFile, INT cchMaxFile)
     return ::GetOpenFileName(&ofn);
 }
 
-BOOL CMainWindow::GetSaveFileName(IN OUT LPTSTR pszFile, INT cchMaxFile)
+BOOL CMainWindow::GetSaveFileName(IN OUT LPWSTR pszFile, INT cchMaxFile)
 {
     static OPENFILENAME sfn = { 0 };
-    static CString strFilter;
+    static CStringW strFilter;
 
     if (sfn.lStructSize == 0)
     {
         // Get the export filter
         CSimpleArray<GUID> aguidFileTypesE;
         CImage::GetExporterFilterString(strFilter, aguidFileTypesE, NULL,
-                                        CImage::excludeDefaultSave, _T('\0'));
+                                        CImage::excludeDefaultSave, UNICODE_NULL);
 
         // Initializing the OPENFILENAME structure for GetSaveFileName
         ZeroMemory(&sfn, sizeof(sfn));
@@ -300,7 +300,7 @@ HWND CMainWindow::DoCreate()
 {
     ::LoadString(g_hinstExe, IDS_DEFAULTFILENAME, g_szFileName, _countof(g_szFileName));
 
-    CString strTitle;
+    CStringW strTitle;
     strTitle.Format(IDS_WINDOWTITLE, PathFindFileName(g_szFileName));
 
     RECT& rc = registrySettings.WindowPlacement.rcNormalPosition;
@@ -309,7 +309,7 @@ HWND CMainWindow::DoCreate()
 
 // entry point
 INT WINAPI
-_tWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPTSTR lpCmdLine, INT nCmdShow)
+_tWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdLine, INT nCmdShow)
 {
     g_hinstExe = hInstance;
 
@@ -325,7 +325,7 @@ _tWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPTSTR lpCmdLine, INT nC
     // Create the main window
     if (!mainWindow.DoCreate())
     {
-        MessageBox(NULL, TEXT("Failed to create main window."), NULL, MB_ICONERROR);
+        MessageBox(NULL, L"Failed to create main window.", NULL, MB_ICONERROR);
         return 1;
     }
 

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -337,7 +337,7 @@ _tWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdLine, INT nC
     mainWindow.ShowWindow(registrySettings.WindowPlacement.showCmd);
 
     // Load the access keys
-    HACCEL hAccel = ::LoadAccelerators(hInstance, MAKEINTRESOURCE(800));
+    HACCEL hAccel = ::LoadAcceleratorsW(hInstance, MAKEINTRESOURCEW(800));
 
     // The message loop
     MSG msg;

--- a/base/applications/mspaint/miniature.cpp
+++ b/base/applications/mspaint/miniature.cpp
@@ -36,8 +36,8 @@ HWND CMiniatureWindow::DoCreate(HWND hwndParent)
         (LONG)(registrySettings.ThumbYPos + registrySettings.ThumbHeight)
     };
 
-    TCHAR strTitle[100];
-    ::LoadString(g_hinstExe, IDS_MINIATURETITLE, strTitle, _countof(strTitle));
+    WCHAR strTitle[100];
+    ::LoadStringW(g_hinstExe, IDS_MINIATURETITLE, strTitle, _countof(strTitle));
 
     DWORD style = WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_THICKFRAME;
     return Create(hwndParent, rc, strTitle, style, WS_EX_PALETTEWINDOW);

--- a/base/applications/mspaint/miniature.h
+++ b/base/applications/mspaint/miniature.h
@@ -11,7 +11,7 @@
 class CMiniatureWindow : public CWindowImpl<CMiniatureWindow>
 {
 public:
-    DECLARE_WND_CLASS_EX(_T("MiniatureWindow"), CS_DBLCLKS | CS_HREDRAW | CS_VREDRAW,
+    DECLARE_WND_CLASS_EX(L"MiniatureWindow", CS_DBLCLKS | CS_HREDRAW | CS_VREDRAW,
                          COLOR_BTNFACE)
 
     BEGIN_MSG_MAP(CMiniatureWindow)

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -703,7 +703,7 @@ struct TextTool : ToolBase
 
     void draw(HDC hdc)
     {
-        CString szText;
+        CStringW szText;
         textEditWindow.GetWindowText(szText);
 
         RECT rc;

--- a/base/applications/mspaint/palette.h
+++ b/base/applications/mspaint/palette.h
@@ -14,7 +14,7 @@
 class CPaletteWindow : public CWindowImpl<CPaletteWindow>
 {
 public:
-    DECLARE_WND_CLASS_EX(_T("Palette"), CS_DBLCLKS, COLOR_BTNFACE)
+    DECLARE_WND_CLASS_EX(L"Palette", CS_DBLCLKS, COLOR_BTNFACE)
 
     BEGIN_MSG_MAP(CPaletteWindow)
         MESSAGE_HANDLER(WM_ERASEBKGND, OnEraseBkgnd)

--- a/base/applications/mspaint/registry.cpp
+++ b/base/applications/mspaint/registry.cpp
@@ -77,8 +77,8 @@ void RegistrySettings::LoadPresets(INT nCmdShow)
     Bar1ID = BAR1ID_TOP;
     Bar2ID = BAR2ID_LEFT;
 
-    LOGFONT lf;
-    GetObject(GetStockObject(DEFAULT_GUI_FONT), sizeof(lf), &lf);
+    LOGFONTW lf;
+    ::GetObjectW(GetStockObject(DEFAULT_GUI_FONT), sizeof(lf), &lf);
     strFontName = lf.lfFaceName;
 
     ZeroMemory(&WindowPlacement, sizeof(WindowPlacement));

--- a/base/applications/mspaint/registry.cpp
+++ b/base/applications/mspaint/registry.cpp
@@ -15,18 +15,18 @@ RegistrySettings registrySettings;
 
 /* FUNCTIONS ********************************************************/
 
-static void ReadDWORD(CRegKey &key, LPCTSTR lpName, DWORD &dwValue)
+static void ReadDWORD(CRegKey &key, LPCWSTR lpName, DWORD &dwValue)
 {
     DWORD dwTemp;
     if (key.QueryDWORDValue(lpName, dwTemp) == ERROR_SUCCESS)
         dwValue = dwTemp;
 }
 
-static void ReadString(CRegKey &key, LPCTSTR lpName, CString &strValue, LPCTSTR lpDefault = TEXT(""))
+static void ReadString(CRegKey &key, LPCWSTR lpName, CStringW &strValue, LPCWSTR lpDefault = L"")
 {
-    CString strTemp;
+    CStringW strTemp;
     ULONG nChars = MAX_PATH;
-    LPTSTR psz = strTemp.GetBuffer(nChars);
+    LPWSTR psz = strTemp.GetBuffer(nChars);
     LONG error = key.QueryStringValue(lpName, psz, &nChars);
     strTemp.ReleaseBuffer();
 
@@ -36,15 +36,15 @@ static void ReadString(CRegKey &key, LPCTSTR lpName, CString &strValue, LPCTSTR 
         strValue = lpDefault;
 }
 
-void RegistrySettings::SetWallpaper(LPCTSTR szFileName, RegistrySettings::WallpaperStyle style)
+void RegistrySettings::SetWallpaper(LPCWSTR szFileName, RegistrySettings::WallpaperStyle style)
 {
     CRegKey desktop;
-    if (desktop.Open(HKEY_CURRENT_USER, _T("Control Panel\\Desktop")) == ERROR_SUCCESS)
+    if (desktop.Open(HKEY_CURRENT_USER, L"Control Panel\\Desktop") == ERROR_SUCCESS)
     {
-        desktop.SetStringValue(_T("Wallpaper"), szFileName);
+        desktop.SetStringValue(L"Wallpaper", szFileName);
 
-        desktop.SetStringValue(_T("WallpaperStyle"), (style == RegistrySettings::STRETCHED) ? _T("2") : _T("0"));
-        desktop.SetStringValue(_T("TileWallpaper"), (style == RegistrySettings::TILED) ? _T("1") : _T("0"));
+        desktop.SetStringValue(L"WallpaperStyle", (style == RegistrySettings::STRETCHED) ? L"2" : L"0");
+        desktop.SetStringValue(L"TileWallpaper", (style == RegistrySettings::TILED) ? L"1" : L"0");
     }
 
     SystemParametersInfo(SPI_SETDESKWALLPAPER, 0, (PVOID) szFileName, SPIF_UPDATEINIFILE | SPIF_SENDCHANGE);
@@ -94,33 +94,33 @@ void RegistrySettings::Load(INT nCmdShow)
     LoadPresets(nCmdShow);
 
     CRegKey paint;
-    if (paint.Open(HKEY_CURRENT_USER, _T("Software\\Microsoft\\Windows\\CurrentVersion\\Applets\\Paint"), KEY_READ) != ERROR_SUCCESS)
+    if (paint.Open(HKEY_CURRENT_USER, L"Software\\Microsoft\\Windows\\CurrentVersion\\Applets\\Paint", KEY_READ) != ERROR_SUCCESS)
         return;
 
     CRegKey view;
-    if (view.Open(paint, _T("View"), KEY_READ) == ERROR_SUCCESS)
+    if (view.Open(paint, L"View", KEY_READ) == ERROR_SUCCESS)
     {
-        ReadDWORD(view, _T("BMPHeight"),     BMPHeight);
-        ReadDWORD(view, _T("BMPWidth"),      BMPWidth);
-        ReadDWORD(view, _T("GridExtent"),    GridExtent);
-        ReadDWORD(view, _T("NoStretching"),  NoStretching);
-        ReadDWORD(view, _T("ShowThumbnail"), ShowThumbnail);
-        ReadDWORD(view, _T("SnapToGrid"),    SnapToGrid);
-        ReadDWORD(view, _T("ThumbHeight"),   ThumbHeight);
-        ReadDWORD(view, _T("ThumbWidth"),    ThumbWidth);
-        ReadDWORD(view, _T("ThumbXPos"),     ThumbXPos);
-        ReadDWORD(view, _T("ThumbYPos"),     ThumbYPos);
-        ReadDWORD(view, _T("UnitSetting"),   UnitSetting);
-        ReadDWORD(view, _T("ShowStatusBar"), ShowStatusBar);
+        ReadDWORD(view, L"BMPHeight",     BMPHeight);
+        ReadDWORD(view, L"BMPWidth",      BMPWidth);
+        ReadDWORD(view, L"GridExtent",    GridExtent);
+        ReadDWORD(view, L"NoStretching",  NoStretching);
+        ReadDWORD(view, L"ShowThumbnail", ShowThumbnail);
+        ReadDWORD(view, L"SnapToGrid",    SnapToGrid);
+        ReadDWORD(view, L"ThumbHeight",   ThumbHeight);
+        ReadDWORD(view, L"ThumbWidth",    ThumbWidth);
+        ReadDWORD(view, L"ThumbXPos",     ThumbXPos);
+        ReadDWORD(view, L"ThumbYPos",     ThumbYPos);
+        ReadDWORD(view, L"UnitSetting",   UnitSetting);
+        ReadDWORD(view, L"ShowStatusBar", ShowStatusBar);
 
         ULONG pnBytes = sizeof(WINDOWPLACEMENT);
-        view.QueryBinaryValue(_T("WindowPlacement"), &WindowPlacement, &pnBytes);
+        view.QueryBinaryValue(L"WindowPlacement", &WindowPlacement, &pnBytes);
     }
 
     CRegKey files;
-    if (files.Open(paint, _T("Recent File List"), KEY_READ) == ERROR_SUCCESS)
+    if (files.Open(paint, L"Recent File List", KEY_READ) == ERROR_SUCCESS)
     {
-        TCHAR szName[64];
+        WCHAR szName[64];
         for (INT i = 0; i < MAX_RECENT_FILES; ++i)
         {
             StringCchPrintfW(szName, _countof(szName), L"File%u", i + 1);
@@ -129,41 +129,41 @@ void RegistrySettings::Load(INT nCmdShow)
     }
 
     CRegKey text;
-    if (text.Open(paint, _T("Text"), KEY_READ) == ERROR_SUCCESS)
+    if (text.Open(paint, L"Text", KEY_READ) == ERROR_SUCCESS)
     {
-        ReadDWORD(text, _T("Bold"),         Bold);
-        ReadDWORD(text, _T("Italic"),       Italic);
-        ReadDWORD(text, _T("Underline"),    Underline);
-        ReadDWORD(text, _T("CharSet"),      CharSet);
-        ReadDWORD(text, _T("PointSize"),    PointSize);
-        ReadDWORD(text, _T("PositionX"),    FontsPositionX);
-        ReadDWORD(text, _T("PositionY"),    FontsPositionY);
-        ReadDWORD(text, _T("ShowTextTool"), ShowTextTool);
-        ReadString(text, _T("TypeFaceName"), strFontName, strFontName);
+        ReadDWORD(text, L"Bold",         Bold);
+        ReadDWORD(text, L"Italic",       Italic);
+        ReadDWORD(text, L"Underline",    Underline);
+        ReadDWORD(text, L"CharSet",      CharSet);
+        ReadDWORD(text, L"PointSize",    PointSize);
+        ReadDWORD(text, L"PositionX",    FontsPositionX);
+        ReadDWORD(text, L"PositionY",    FontsPositionY);
+        ReadDWORD(text, L"ShowTextTool", ShowTextTool);
+        ReadString(text, L"TypeFaceName", strFontName, strFontName);
     }
 
     CRegKey bar1;
-    if (bar1.Open(paint, _T("General-Bar1"), KEY_READ) == ERROR_SUCCESS)
+    if (bar1.Open(paint, L"General-Bar1", KEY_READ) == ERROR_SUCCESS)
     {
-        ReadDWORD(bar1, _T("BarID"), Bar1ID);
+        ReadDWORD(bar1, L"BarID", Bar1ID);
     }
 
     CRegKey bar2;
-    if (bar2.Open(paint, _T("General-Bar2"), KEY_READ) == ERROR_SUCCESS)
+    if (bar2.Open(paint, L"General-Bar2", KEY_READ) == ERROR_SUCCESS)
     {
-        ReadDWORD(bar2, _T("BarID"), Bar2ID);
+        ReadDWORD(bar2, L"BarID", Bar2ID);
     }
 
     CRegKey bar3;
-    if (bar3.Open(paint, _T("General-Bar3"), KEY_READ) == ERROR_SUCCESS)
+    if (bar3.Open(paint, L"General-Bar3", KEY_READ) == ERROR_SUCCESS)
     {
-        ReadDWORD(bar3, _T("Visible"), ShowToolBox);
+        ReadDWORD(bar3, L"Visible", ShowToolBox);
     }
 
     CRegKey bar4;
-    if (bar4.Open(paint, _T("General-Bar4"), KEY_READ) == ERROR_SUCCESS)
+    if (bar4.Open(paint, L"General-Bar4", KEY_READ) == ERROR_SUCCESS)
     {
-        ReadDWORD(bar4, _T("Visible"), ShowPalette);
+        ReadDWORD(bar4, L"Visible", ShowPalette);
     }
 
     // Fix the bitmap size if too large
@@ -179,30 +179,30 @@ void RegistrySettings::Store()
     BMPHeight = imageModel.GetHeight();
 
     CRegKey paint;
-    if (paint.Create(HKEY_CURRENT_USER, _T("Software\\Microsoft\\Windows\\CurrentVersion\\Applets\\Paint")) != ERROR_SUCCESS)
+    if (paint.Create(HKEY_CURRENT_USER, L"Software\\Microsoft\\Windows\\CurrentVersion\\Applets\\Paint") != ERROR_SUCCESS)
         return;
 
     CRegKey view;
-    if (view.Create(paint, _T("View")) == ERROR_SUCCESS)
+    if (view.Create(paint, L"View") == ERROR_SUCCESS)
     {
-        view.SetDWORDValue(_T("BMPHeight"),     BMPHeight);
-        view.SetDWORDValue(_T("BMPWidth"),      BMPWidth);
-        view.SetDWORDValue(_T("GridExtent"),    GridExtent);
-        view.SetDWORDValue(_T("NoStretching"),  NoStretching);
-        view.SetDWORDValue(_T("ShowThumbnail"), ShowThumbnail);
-        view.SetDWORDValue(_T("SnapToGrid"),    SnapToGrid);
-        view.SetDWORDValue(_T("ThumbHeight"),   ThumbHeight);
-        view.SetDWORDValue(_T("ThumbWidth"),    ThumbWidth);
-        view.SetDWORDValue(_T("ThumbXPos"),     ThumbXPos);
-        view.SetDWORDValue(_T("ThumbYPos"),     ThumbYPos);
-        view.SetDWORDValue(_T("UnitSetting"),   UnitSetting);
-        view.SetDWORDValue(_T("ShowStatusBar"), ShowStatusBar);
+        view.SetDWORDValue(L"BMPHeight",     BMPHeight);
+        view.SetDWORDValue(L"BMPWidth",      BMPWidth);
+        view.SetDWORDValue(L"GridExtent",    GridExtent);
+        view.SetDWORDValue(L"NoStretching",  NoStretching);
+        view.SetDWORDValue(L"ShowThumbnail", ShowThumbnail);
+        view.SetDWORDValue(L"SnapToGrid",    SnapToGrid);
+        view.SetDWORDValue(L"ThumbHeight",   ThumbHeight);
+        view.SetDWORDValue(L"ThumbWidth",    ThumbWidth);
+        view.SetDWORDValue(L"ThumbXPos",     ThumbXPos);
+        view.SetDWORDValue(L"ThumbYPos",     ThumbYPos);
+        view.SetDWORDValue(L"UnitSetting",   UnitSetting);
+        view.SetDWORDValue(L"ShowStatusBar", ShowStatusBar);
 
-        view.SetBinaryValue(_T("WindowPlacement"), &WindowPlacement, sizeof(WINDOWPLACEMENT));
+        view.SetBinaryValue(L"WindowPlacement", &WindowPlacement, sizeof(WINDOWPLACEMENT));
     }
 
     CRegKey files;
-    if (files.Create(paint, _T("Recent File List")) == ERROR_SUCCESS)
+    if (files.Create(paint, L"Recent File List") == ERROR_SUCCESS)
     {
         WCHAR szName[64];
         for (INT iFile = 0; iFile < MAX_RECENT_FILES; ++iFile)
@@ -213,45 +213,45 @@ void RegistrySettings::Store()
     }
 
     CRegKey text;
-    if (text.Create(paint, _T("Text")) == ERROR_SUCCESS)
+    if (text.Create(paint, L"Text") == ERROR_SUCCESS)
     {
-        text.SetDWORDValue(_T("Bold"),          Bold);
-        text.SetDWORDValue(_T("Italic"),        Italic);
-        text.SetDWORDValue(_T("Underline"),     Underline);
-        text.SetDWORDValue(_T("CharSet"),       CharSet);
-        text.SetDWORDValue(_T("PointSize"),     PointSize);
-        text.SetDWORDValue(_T("PositionX"),     FontsPositionX);
-        text.SetDWORDValue(_T("PositionY"),     FontsPositionY);
-        text.SetDWORDValue(_T("ShowTextTool"),  ShowTextTool);
-        text.SetStringValue(_T("TypeFaceName"), strFontName);
+        text.SetDWORDValue(L"Bold",          Bold);
+        text.SetDWORDValue(L"Italic",        Italic);
+        text.SetDWORDValue(L"Underline",     Underline);
+        text.SetDWORDValue(L"CharSet",       CharSet);
+        text.SetDWORDValue(L"PointSize",     PointSize);
+        text.SetDWORDValue(L"PositionX",     FontsPositionX);
+        text.SetDWORDValue(L"PositionY",     FontsPositionY);
+        text.SetDWORDValue(L"ShowTextTool",  ShowTextTool);
+        text.SetStringValue(L"TypeFaceName", strFontName);
     }
 
     CRegKey bar1;
-    if (bar1.Create(paint, _T("General-Bar1")) == ERROR_SUCCESS)
+    if (bar1.Create(paint, L"General-Bar1") == ERROR_SUCCESS)
     {
-        bar1.SetDWORDValue(_T("BarID"), Bar1ID);
+        bar1.SetDWORDValue(L"BarID", Bar1ID);
     }
 
     CRegKey bar2;
-    if (bar2.Create(paint, _T("General-Bar2")) == ERROR_SUCCESS)
+    if (bar2.Create(paint, L"General-Bar2") == ERROR_SUCCESS)
     {
-        bar2.SetDWORDValue(_T("BarID"), Bar2ID);
+        bar2.SetDWORDValue(L"BarID", Bar2ID);
     }
 
     CRegKey bar3;
-    if (bar3.Create(paint, _T("General-Bar3")) == ERROR_SUCCESS)
+    if (bar3.Create(paint, L"General-Bar3") == ERROR_SUCCESS)
     {
-        bar3.SetDWORDValue(_T("Visible"), ShowToolBox);
+        bar3.SetDWORDValue(L"Visible", ShowToolBox);
     }
 
     CRegKey bar4;
-    if (bar4.Create(paint, _T("General-Bar4")) == ERROR_SUCCESS)
+    if (bar4.Create(paint, L"General-Bar4") == ERROR_SUCCESS)
     {
-        bar4.SetDWORDValue(_T("Visible"), ShowPalette);
+        bar4.SetDWORDValue(L"Visible", ShowPalette);
     }
 }
 
-void RegistrySettings::SetMostRecentFile(LPCTSTR szPathName)
+void RegistrySettings::SetMostRecentFile(LPCWSTR szPathName)
 {
     // Register the file to the user's 'Recent' folder
     if (szPathName && szPathName[0])
@@ -265,7 +265,7 @@ void RegistrySettings::SetMostRecentFile(LPCTSTR szPathName)
 
         if (iFound >= 0)
         {
-            CString tmp = strFiles[i];
+            CStringW tmp = strFiles[i];
             strFiles[i] = strFiles[i - 1];
             strFiles[i - 1] = tmp;
         }

--- a/base/applications/mspaint/registry.h
+++ b/base/applications/mspaint/registry.h
@@ -28,9 +28,9 @@ public:
     DWORD UnitSetting;
     WINDOWPLACEMENT WindowPlacement;
 
-    CString strFiles[MAX_RECENT_FILES];
+    CStringW strFiles[MAX_RECENT_FILES];
 
-    CString strFontName;
+    CStringW strFontName;
     DWORD PointSize;
     DWORD Bold;
     DWORD Italic;
@@ -61,9 +61,9 @@ public:
         STRETCHED
     };
 
-    static void SetWallpaper(LPCTSTR szFileName, WallpaperStyle style);
+    static void SetWallpaper(LPCWSTR szFileName, WallpaperStyle style);
 
     void Load(INT nCmdShow);
     void Store();
-    void SetMostRecentFile(LPCTSTR szPathName);
+    void SetMostRecentFile(LPCWSTR szPathName);
 };

--- a/base/applications/mspaint/selectionmodel.cpp
+++ b/base/applications/mspaint/selectionmodel.cpp
@@ -139,7 +139,7 @@ void SelectionModel::DrawSelection(HDC hDCImage, COLORREF crBg, BOOL bBgTranspar
         return;
 
     BITMAP bm;
-    if (!GetObject(m_hbmColor, sizeof(BITMAP), &bm))
+    if (!GetObjectW(m_hbmColor, sizeof(BITMAP), &bm))
         return;
 
     COLORREF keyColor = (bBgTransparent ? crBg : CLR_INVALID);
@@ -516,7 +516,7 @@ void SelectionModel::InvertSelection()
     TakeOff();
 
     BITMAP bm;
-    ::GetObject(m_hbmColor, sizeof(bm), &bm);
+    ::GetObjectW(m_hbmColor, sizeof(bm), &bm);
 
     HDC hdc = ::CreateCompatibleDC(NULL);
     HGDIOBJ hbmOld = ::SelectObject(hdc, m_hbmColor);

--- a/base/applications/mspaint/sizebox.cpp
+++ b/base/applications/mspaint/sizebox.cpp
@@ -21,7 +21,7 @@ BOOL setCursorOnSizeBox(HITTEST hit)
 {
     if (HIT_UPPER_LEFT <= hit && hit <= HIT_LOWER_RIGHT)
     {
-        ::SetCursor(::LoadCursor(NULL, s_cursor_shapes[hit - HIT_UPPER_LEFT]));
+        ::SetCursor(::LoadCursorW(NULL, s_cursor_shapes[hit - HIT_UPPER_LEFT]));
         return TRUE;
     }
     return FALSE;

--- a/base/applications/mspaint/textedit.cpp
+++ b/base/applications/mspaint/textedit.cpp
@@ -65,7 +65,7 @@ void CTextEditWindow::FixEditPos(LPCWSTR pszOldText)
         szText += L"x"; // This is a trick to enable the g_ptEnd newlines
         const UINT uFormat = DT_LEFT | DT_TOP | DT_EDITCONTROL | DT_NOPREFIX | DT_NOCLIP |
                              DT_EXPANDTABS | DT_WORDBREAK;
-        DrawText(hDC, szText, -1, &rcText, uFormat | DT_CALCRECT);
+        DrawTextW(hDC, szText, -1, &rcText, uFormat | DT_CALCRECT);
         if (tm.tmDescent > 0)
             rcText.bottom += tm.tmDescent;
         ReleaseDC(hDC);
@@ -135,7 +135,7 @@ LRESULT CTextEditWindow::OnEraseBkGnd(UINT nMsg, WPARAM wParam, LPARAM lParam, B
         FillRect(hDC, &rc, hbr);
         DeleteObject(hbr);
     }
-    SetTextColor(hDC, paletteModel.GetFgColor());
+    ::SetTextColor(hDC, paletteModel.GetFgColor());
     return TRUE;
 }
 
@@ -336,7 +336,7 @@ void CTextEditWindow::UpdateFont()
         m_hFontZoomed = NULL;
     }
 
-    LOGFONT lf;
+    LOGFONTW lf;
     ZeroMemory(&lf, sizeof(lf));
     lf.lfCharSet = DEFAULT_CHARSET; // registrySettings.CharSet; // Ignore
     lf.lfWeight = (registrySettings.Bold ? FW_BOLD : FW_NORMAL);

--- a/base/applications/mspaint/textedit.cpp
+++ b/base/applications/mspaint/textedit.cpp
@@ -44,9 +44,9 @@ void CTextEditWindow::DrawGrip(HDC hDC, RECT& rc)
     drawSizeBoxes(hDC, &rc, TRUE, NULL);
 }
 
-void CTextEditWindow::FixEditPos(LPCTSTR pszOldText)
+void CTextEditWindow::FixEditPos(LPCWSTR pszOldText)
 {
-    CString szText;
+    CStringW szText;
     GetWindowText(szText);
 
     RECT rcParent;
@@ -62,7 +62,7 @@ void CTextEditWindow::FixEditPos(LPCTSTR pszOldText)
         SelectObject(hDC, m_hFontZoomed);
         TEXTMETRIC tm;
         GetTextMetrics(hDC, &tm);
-        szText += TEXT("x"); // This is a trick to enable the g_ptEnd newlines
+        szText += L"x"; // This is a trick to enable the g_ptEnd newlines
         const UINT uFormat = DT_LEFT | DT_TOP | DT_EDITCONTROL | DT_NOPREFIX | DT_NOCLIP |
                              DT_EXPANDTABS | DT_WORDBREAK;
         DrawText(hDC, szText, -1, &rcText, uFormat | DT_CALCRECT);
@@ -91,7 +91,7 @@ LRESULT CTextEditWindow::OnChar(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& b
     if (wParam == VK_TAB)
         return 0; // FIXME: Tabs
 
-    CString szText;
+    CStringW szText;
     GetWindowText(szText);
 
     LRESULT ret = DefWindowProc(nMsg, wParam, lParam);
@@ -108,7 +108,7 @@ LRESULT CTextEditWindow::OnKeyDown(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL
         return 0;
     }
 
-    CString szText;
+    CStringW szText;
     GetWindowText(szText);
 
     LRESULT ret = DefWindowProc(nMsg, wParam, lParam);
@@ -493,7 +493,7 @@ LRESULT CTextEditWindow::OnSizing(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL&
 
 LRESULT CTextEditWindow::OnMouseWheel(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
-    return ::SendMessage(GetParent(), nMsg, wParam, lParam);
+    return ::SendMessageW(GetParent(), nMsg, wParam, lParam);
 }
 
 LRESULT CTextEditWindow::OnCut(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)

--- a/base/applications/mspaint/textedit.cpp
+++ b/base/applications/mspaint/textedit.cpp
@@ -196,7 +196,7 @@ LRESULT CTextEditWindow::OnSetCursor(UINT nMsg, WPARAM wParam, LPARAM lParam, BO
     UINT nHitTest = LOWORD(lParam);
     if (nHitTest == HTCAPTION)
     {
-        ::SetCursor(::LoadCursor(NULL, IDC_SIZEALL)); // Enable drag move
+        ::SetCursor(::LoadCursorW(NULL, MAKEINTRESOURCEW(IDC_SIZEALL))); // Enable drag move
         return FALSE;
     }
     return DefWindowProc(nMsg, wParam, lParam);

--- a/base/applications/mspaint/textedit.cpp
+++ b/base/applications/mspaint/textedit.cpp
@@ -196,7 +196,7 @@ LRESULT CTextEditWindow::OnSetCursor(UINT nMsg, WPARAM wParam, LPARAM lParam, BO
     UINT nHitTest = LOWORD(lParam);
     if (nHitTest == HTCAPTION)
     {
-        ::SetCursor(::LoadCursorW(NULL, MAKEINTRESOURCEW(IDC_SIZEALL))); // Enable drag move
+        ::SetCursor(::LoadCursorW(NULL, (LPCWSTR)IDC_SIZEALL)); // Enable drag move
         return FALSE;
     }
     return DefWindowProc(nMsg, wParam, lParam);

--- a/base/applications/mspaint/textedit.h
+++ b/base/applications/mspaint/textedit.h
@@ -17,7 +17,7 @@ public:
 
     HWND Create(HWND hwndParent);
     void DoFillBack(HWND hwnd, HDC hDC);
-    void FixEditPos(LPCTSTR pszOldText);
+    void FixEditPos(LPCWSTR pszOldText);
     void InvalidateEditRect();
     void UpdateFont();
     BOOL GetEditRect(LPRECT prc) const;

--- a/base/applications/mspaint/toolbox.cpp
+++ b/base/applications/mspaint/toolbox.cpp
@@ -48,8 +48,8 @@ BOOL CPaintToolBar::DoCreate(HWND hwndParent)
     HIMAGELIST hImageList = ImageList_Create(16, 16, ILC_COLOR24 | ILC_MASK, 16, 0);
     SendMessage(TB_SETIMAGELIST, 0, (LPARAM)hImageList);
 
-    HBITMAP hbmIcons = (HBITMAP)::LoadImage(g_hinstExe, MAKEINTRESOURCE(IDB_TOOLBARICONS),
-                                            IMAGE_BITMAP, 256, 16, 0);
+    HBITMAP hbmIcons = (HBITMAP)::LoadImageW(g_hinstExe, MAKEINTRESOURCEW(IDB_TOOLBARICONS),
+                                             IMAGE_BITMAP, 256, 16, 0);
     ImageList_AddMasked(hImageList, hbmIcons, RGB(255, 0, 255));
     ::DeleteObject(hbmIcons);
 

--- a/base/applications/mspaint/toolbox.cpp
+++ b/base/applications/mspaint/toolbox.cpp
@@ -20,12 +20,12 @@ CPaintToolBar::ToolBarWndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
     {
         // We have to detect clicking on toolbar even if no change of pressed button
         POINT pt = { GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) };
-        INT index = (INT)::SendMessage(hwnd, TB_HITTEST, 0, (LPARAM)&pt);
+        INT index = (INT)::SendMessageW(hwnd, TB_HITTEST, 0, (LPARAM)&pt);
         if (index >= 0)
         {
             TBBUTTON button;
-            if (::SendMessage(hwnd, TB_GETBUTTON, index, (LPARAM)&button))
-                ::PostMessage(::GetParent(hwnd), WM_COMMAND, button.idCommand, 0);
+            if (::SendMessageW(hwnd, TB_GETBUTTON, index, (LPARAM)&button))
+                ::PostMessageW(::GetParent(hwnd), WM_COMMAND, button.idCommand, 0);
         }
     }
     return ::CallWindowProc(oldWndProc, hwnd, uMsg, wParam, lParam);
@@ -55,13 +55,13 @@ BOOL CPaintToolBar::DoCreate(HWND hwndParent)
 
     SendMessage(TB_BUTTONSTRUCTSIZE, sizeof(TBBUTTON), 0);
 
-    TCHAR szToolTip[30];
+    WCHAR szToolTip[30];
     TBBUTTON tbbutton;
     ZeroMemory(&tbbutton, sizeof(tbbutton));
     tbbutton.fsStyle = TBSTYLE_CHECKGROUP;
     for (INT i = 0; i < NUM_TOOLS; i++)
     {
-        ::LoadString(g_hinstExe, IDS_TOOLTIP1 + i, szToolTip, _countof(szToolTip));
+        ::LoadStringW(g_hinstExe, IDS_TOOLTIP1 + i, szToolTip, _countof(szToolTip));
         tbbutton.iString   = (INT_PTR)szToolTip;
         tbbutton.fsState   = TBSTATE_ENABLED | ((i % 2 == 1) ? TBSTATE_WRAP : 0);
         tbbutton.idCommand = ID_FREESEL + i;

--- a/base/applications/mspaint/toolbox.cpp
+++ b/base/applications/mspaint/toolbox.cpp
@@ -42,7 +42,7 @@ BOOL CPaintToolBar::DoCreate(HWND hwndParent)
     };
     DWORD style = WS_CHILD | WS_VISIBLE | CCS_NOPARENTALIGN | CCS_VERT | CCS_NORESIZE |
                   TBSTYLE_TOOLTIPS | TBSTYLE_FLAT;
-    if (!CWindow::Create(TOOLBARCLASSNAME, hwndParent, toolbarPos, NULL, style))
+    if (!CWindow::Create(TOOLBARCLASSNAMEW, hwndParent, toolbarPos, NULL, style))
         return FALSE;
 
     HIMAGELIST hImageList = ImageList_Create(16, 16, ILC_COLOR24 | ILC_MASK, 16, 0);

--- a/base/applications/mspaint/toolbox.h
+++ b/base/applications/mspaint/toolbox.h
@@ -24,7 +24,7 @@ public:
 class CToolBox : public CWindowImpl<CToolBox>
 {
 public:
-    DECLARE_WND_CLASS_EX(_T("ToolBox"), CS_DBLCLKS, COLOR_BTNFACE)
+    DECLARE_WND_CLASS_EX(L"ToolBox", CS_DBLCLKS, COLOR_BTNFACE)
 
     BEGIN_MSG_MAP(CToolBox)
         MESSAGE_HANDLER(WM_CREATE, OnCreate)

--- a/base/applications/mspaint/toolsettings.cpp
+++ b/base/applications/mspaint/toolsettings.cpp
@@ -284,10 +284,10 @@ VOID CToolSettingsWindow::drawBox(HDC hdc, LPCRECT prc)
 LRESULT CToolSettingsWindow::OnCreate(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
     /* preloading the draw transparent/nontransparent icons for later use */
-    m_hNontranspIcon = (HICON)LoadImage(g_hinstExe, MAKEINTRESOURCE(IDI_NONTRANSPARENT),
-                                        IMAGE_ICON, CX_TRANS_ICON, CY_TRANS_ICON, LR_DEFAULTCOLOR);
-    m_hTranspIcon = (HICON)LoadImage(g_hinstExe, MAKEINTRESOURCE(IDI_TRANSPARENT),
-                                     IMAGE_ICON, CX_TRANS_ICON, CY_TRANS_ICON, LR_DEFAULTCOLOR);
+    m_hNontranspIcon = (HICON)LoadImageW(g_hinstExe, MAKEINTRESOURCEW(IDI_NONTRANSPARENT),
+                                         IMAGE_ICON, CX_TRANS_ICON, CY_TRANS_ICON, LR_DEFAULTCOLOR);
+    m_hTranspIcon = (HICON)LoadImageW(g_hinstExe, MAKEINTRESOURCEW(IDI_TRANSPARENT),
+                                      IMAGE_ICON, CX_TRANS_ICON, CY_TRANS_ICON, LR_DEFAULTCOLOR);
 
     RECT trackbarZoomPos, rect2;
     calculateTwoBoxes(trackbarZoomPos, rect2);

--- a/base/applications/mspaint/toolsettings.cpp
+++ b/base/applications/mspaint/toolsettings.cpp
@@ -313,13 +313,13 @@ LRESULT CToolSettingsWindow::OnVScroll(UINT nMsg, WPARAM wParam, LPARAM lParam, 
 
     INT zoomRate = toolsModel.GetZoom();
 
-    CString strZoom;
+    CStringW strZoom;
     if (zoomRate % 10 == 0)
-        strZoom.Format(_T("%d%%"), zoomRate / 10);
+        strZoom.Format(L"%d%%", zoomRate / 10);
     else
-        strZoom.Format(_T("%d.%d%%"), zoomRate / 10, zoomRate % 10);
+        strZoom.Format(L"%d.%d%%", zoomRate / 10, zoomRate % 10);
 
-    ::SendMessage(g_hStatusBar, SB_SETTEXT, 1, (LPARAM)(LPCTSTR)strZoom);
+    ::SendMessageW(g_hStatusBar, SB_SETTEXT, 1, (LPARAM)(LPCWSTR)strZoom);
 
     OnToolsModelZoomChanged(nMsg, wParam, lParam, bHandled);
     return 0;

--- a/base/applications/mspaint/toolsettings.h
+++ b/base/applications/mspaint/toolsettings.h
@@ -10,7 +10,7 @@
 class CToolSettingsWindow : public CWindowImpl<CToolSettingsWindow>
 {
 public:
-    DECLARE_WND_CLASS_EX(_T("ToolSettings"), CS_DBLCLKS, COLOR_BTNFACE)
+    DECLARE_WND_CLASS_EX(L"ToolSettings", CS_DBLCLKS, COLOR_BTNFACE)
 
     BEGIN_MSG_MAP(CToolSettingsWindow)
         MESSAGE_HANDLER(WM_CREATE, OnCreate)

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -144,8 +144,8 @@ void CMainWindow::InsertSelectionFromHBITMAP(HBITMAP bitmap, HWND window)
 
         if (g_askBeforeEnlarging)
         {
-            TCHAR programname[20];
-            TCHAR shouldEnlargePromptText[100];
+            WCHAR programname[20];
+            WCHAR shouldEnlargePromptText[100];
 
             LoadString(g_hinstExe, IDS_PROGRAMNAME, programname, _countof(programname));
             LoadString(g_hinstExe, IDS_ENLARGEPROMPTTEXT, shouldEnlargePromptText, _countof(shouldEnlargePromptText));
@@ -233,7 +233,7 @@ LRESULT CMainWindow::OnMouseWheel(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL&
 
 LRESULT CMainWindow::OnDropFiles(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
-    TCHAR droppedfile[MAX_PATH];
+    WCHAR droppedfile[MAX_PATH];
 
     HDROP hDrop = (HDROP)wParam;
     DragQueryFile(hDrop, 0, droppedfile, _countof(droppedfile));
@@ -254,7 +254,7 @@ LRESULT CMainWindow::OnCreate(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHa
     DWORD style = SBARS_SIZEGRIP | WS_CHILD | (registrySettings.ShowStatusBar ? WS_VISIBLE : 0);
     g_hStatusBar = ::CreateWindowEx(0, STATUSCLASSNAME, NULL, style, 0, 0, 0, 0, m_hWnd,
                                   NULL, g_hinstExe, NULL);
-    ::SendMessage(g_hStatusBar, SB_SETMINHEIGHT, 21, 0);
+    ::SendMessageW(g_hStatusBar, SB_SETMINHEIGHT, 21, 0);
 
     // Create the tool box
     toolBoxContainer.DoCreate(m_hWnd);
@@ -314,10 +314,10 @@ BOOL CMainWindow::ConfirmSave()
     if (imageModel.IsImageSaved())
         return TRUE;
 
-    CString strProgramName;
+    CStringW strProgramName;
     strProgramName.LoadString(IDS_PROGRAMNAME);
 
-    CString strSavePromptText;
+    CStringW strSavePromptText;
     strSavePromptText.Format(IDS_SAVEPROMPTTEXT, PathFindFileName(g_szFileName));
 
     switch (MessageBox(strSavePromptText, strProgramName, MB_YESNOCANCEL | MB_ICONQUESTION))
@@ -345,11 +345,11 @@ LRESULT CMainWindow::OnClose(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHan
 
 void CMainWindow::ProcessFileMenu(HMENU hPopupMenu)
 {
-    LPCTSTR dotext = PathFindExtensionW(g_szFileName);
+    LPCWSTR dotext = PathFindExtensionW(g_szFileName);
     BOOL isBMP = FALSE;
-    if (_tcsicmp(dotext, _T(".bmp")) == 0 ||
-        _tcsicmp(dotext, _T(".dib")) == 0 ||
-        _tcsicmp(dotext, _T(".rle")) == 0)
+    if (_wcsicmp(dotext, L".bmp") == 0 ||
+        _wcsicmp(dotext, L".dib") == 0 ||
+        _wcsicmp(dotext, L".rle") == 0)
     {
         isBMP = TRUE;
     }
@@ -371,7 +371,7 @@ void CMainWindow::ProcessFileMenu(HMENU hPopupMenu)
 
     for (INT iItem = 0; iItem < MAX_RECENT_FILES; ++iItem)
     {
-        CString& strFile = registrySettings.strFiles[iItem];
+        CStringW& strFile = registrySettings.strFiles[iItem];
         if (strFile.IsEmpty())
             break;
 
@@ -379,7 +379,7 @@ void CMainWindow::ProcessFileMenu(HMENU hPopupMenu)
 #define MAX_RECENT_PATHNAME_DISPLAY 30
         CPath pathFile(strFile);
         pathFile.CompactPathEx(MAX_RECENT_PATHNAME_DISPLAY);
-        assert(_tcslen((LPCTSTR)pathFile) <= MAX_RECENT_PATHNAME_DISPLAY);
+        assert(wcslen((LPCWSTR)pathFile) <= MAX_RECENT_PATHNAME_DISPLAY);
 
         // Add an accelerator (by '&') to the item number for quick access
         WCHAR szText[4 + MAX_RECENT_PATHNAME_DISPLAY + 1];
@@ -489,8 +489,8 @@ LRESULT CMainWindow::OnSize(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHand
     int test[] = { LOWORD(lParam) - 260, LOWORD(lParam) - 140, LOWORD(lParam) - 20 };
     if (::IsWindow(g_hStatusBar))
     {
-        ::SendMessage(g_hStatusBar, WM_SIZE, 0, 0);
-        ::SendMessage(g_hStatusBar, SB_SETPARTS, 3, (LPARAM)&test);
+        ::SendMessageW(g_hStatusBar, WM_SIZE, 0, 0);
+        ::SendMessageW(g_hStatusBar, SB_SETPARTS, 3, (LPARAM)&test);
     }
     alignChildrenToMainWindow();
     return 0;
@@ -516,7 +516,7 @@ LRESULT CMainWindow::OnKeyDown(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
                 if (canvasWindow.m_hWnd == hwndCapture ||
                     fullscreenWindow.m_hWnd == hwndCapture)
                 {
-                    ::SendMessage(hwndCapture, nMsg, wParam, lParam);
+                    ::SendMessageW(hwndCapture, nMsg, wParam, lParam);
                 }
             }
             else if (selectionModel.m_bShow)
@@ -551,7 +551,7 @@ LRESULT CMainWindow::OnSysColorChange(UINT nMsg, WPARAM wParam, LPARAM lParam, B
 {
     /* Redirect message to common controls */
     HWND hToolbar = FindWindowEx(toolBoxContainer.m_hWnd, NULL, TOOLBARCLASSNAME, NULL);
-    SendMessage(hToolbar, WM_SYSCOLORCHANGE, 0, 0);
+    ::SendMessageW(hToolbar, WM_SYSCOLORCHANGE, 0, 0);
     return 0;
 }
 
@@ -569,8 +569,7 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
     {
         case IDM_HELPINFO:
         {
-            TCHAR infotitle[100];
-            TCHAR infotext[200];
+            WCHAR infotitle[100], infotext[200];
             LoadString(g_hinstExe, IDS_INFOTITLE, infotitle, _countof(infotitle));
             LoadString(g_hinstExe, IDS_INFOTEXT, infotext, _countof(infotext));
             ShellAbout(m_hWnd, infotitle, infotext,
@@ -591,7 +590,7 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
             break;
         case IDM_FILEOPEN:
             {
-                TCHAR szFileName[MAX_LONG_PATH] = _T("");
+                WCHAR szFileName[MAX_LONG_PATH] = L"";
                 if (ConfirmSave() && GetOpenFileName(szFileName, _countof(szFileName)))
                 {
                     DoLoadImageFile(m_hWnd, szFileName, TRUE);
@@ -795,7 +794,7 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
 
             // Failed to paste
             {
-                CString strText, strTitle;
+                CStringW strText, strTitle;
                 strText.LoadString(IDS_CANTPASTE);
                 strTitle.LoadString(IDS_PROGRAMNAME);
                 MessageBox(strText, strTitle, MB_ICONINFORMATION);
@@ -833,7 +832,7 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
                 break;
             }
             HWND hToolbar = FindWindowEx(toolBoxContainer.m_hWnd, NULL, TOOLBARCLASSNAME, NULL);
-            SendMessage(hToolbar, TB_CHECKBUTTON, ID_RECTSEL, MAKELPARAM(TRUE, 0));
+            ::SendMessageW(hToolbar, TB_CHECKBUTTON, ID_RECTSEL, MAKELPARAM(TRUE, 0));
             toolsModel.selectAll();
             canvasWindow.Invalidate(TRUE);
             break;
@@ -948,8 +947,8 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
                 CWaitCursor waitCursor;
                 if (attributesDialog.m_bBlackAndWhite && !imageModel.IsBlackAndWhite())
                 {
-                    CString strText(MAKEINTRESOURCE(IDS_LOSECOLOR));
-                    CString strTitle(MAKEINTRESOURCE(IDS_PROGRAMNAME));
+                    CStringW strText(MAKEINTRESOURCE(IDS_LOSECOLOR));
+                    CStringW strTitle(MAKEINTRESOURCE(IDS_PROGRAMNAME));
                     INT id = MessageBox(strText, strTitle, MB_ICONINFORMATION | MB_YESNOCANCEL);
                     if (id != IDYES)
                         break;

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -147,8 +147,8 @@ void CMainWindow::InsertSelectionFromHBITMAP(HBITMAP bitmap, HWND window)
             WCHAR programname[20];
             WCHAR shouldEnlargePromptText[100];
 
-            LoadString(g_hinstExe, IDS_PROGRAMNAME, programname, _countof(programname));
-            LoadString(g_hinstExe, IDS_ENLARGEPROMPTTEXT, shouldEnlargePromptText, _countof(shouldEnlargePromptText));
+            ::LoadStringW(g_hinstExe, IDS_PROGRAMNAME, programname, _countof(programname));
+            ::LoadStringW(g_hinstExe, IDS_ENLARGEPROMPTTEXT, shouldEnlargePromptText, _countof(shouldEnlargePromptText));
 
             switch (MessageBox(shouldEnlargePromptText, programname, MB_YESNOCANCEL | MB_ICONQUESTION))
             {
@@ -570,8 +570,8 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
         case IDM_HELPINFO:
         {
             WCHAR infotitle[100], infotext[200];
-            LoadString(g_hinstExe, IDS_INFOTITLE, infotitle, _countof(infotitle));
-            LoadString(g_hinstExe, IDS_INFOTEXT, infotext, _countof(infotext));
+            ::LoadStringW(g_hinstExe, IDS_INFOTITLE, infotitle, _countof(infotitle));
+            ::LoadStringW(g_hinstExe, IDS_INFOTEXT, infotext, _countof(infotext));
             ShellAbout(m_hWnd, infotitle, infotext,
                        LoadIcon(g_hinstExe, MAKEINTRESOURCE(IDI_APPICON)));
             break;
@@ -840,7 +840,7 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
         case IDM_EDITCOPYTO:
         {
             WCHAR szFileName[MAX_LONG_PATH];
-            LoadStringW(g_hinstExe, IDS_DEFAULTFILENAME, szFileName, _countof(szFileName));
+            ::LoadStringW(g_hinstExe, IDS_DEFAULTFILENAME, szFileName, _countof(szFileName));
             if (GetSaveFileName(szFileName, _countof(szFileName)))
             {
                 HBITMAP hbmSelection = selectionModel.GetSelectionContents();

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -247,13 +247,13 @@ LRESULT CMainWindow::OnDropFiles(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& 
 LRESULT CMainWindow::OnCreate(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
     // Loading and setting the window menu from resource
-    m_hMenu = ::LoadMenu(g_hinstExe, MAKEINTRESOURCE(ID_MENU));
+    m_hMenu = ::LoadMenuW(g_hinstExe, MAKEINTRESOURCEW(ID_MENU));
     SetMenu(m_hMenu);
 
     // Create the status bar
     DWORD style = SBARS_SIZEGRIP | WS_CHILD | (registrySettings.ShowStatusBar ? WS_VISIBLE : 0);
-    g_hStatusBar = ::CreateWindowEx(0, STATUSCLASSNAME, NULL, style, 0, 0, 0, 0, m_hWnd,
-                                  NULL, g_hinstExe, NULL);
+    g_hStatusBar = ::CreateWindowExW(0, STATUSCLASSNAME, NULL, style, 0, 0, 0, 0, m_hWnd,
+                                     NULL, g_hinstExe, NULL);
     ::SendMessageW(g_hStatusBar, SB_SETMINHEIGHT, 21, 0);
 
     // Create the tool box
@@ -276,8 +276,8 @@ LRESULT CMainWindow::OnCreate(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHa
     }
 
     // Set icon
-    SendMessage(WM_SETICON, ICON_BIG, (LPARAM) LoadIcon(g_hinstExe, MAKEINTRESOURCE(IDI_APPICON)));
-    SendMessage(WM_SETICON, ICON_SMALL, (LPARAM) LoadIcon(g_hinstExe, MAKEINTRESOURCE(IDI_APPICON)));
+    SendMessage(WM_SETICON, ICON_BIG, (LPARAM)::LoadIconW(g_hinstExe, MAKEINTRESOURCEW(IDI_APPICON)));
+    SendMessage(WM_SETICON, ICON_SMALL, (LPARAM)::LoadIconW(g_hinstExe, MAKEINTRESOURCEW(IDI_APPICON)));
 
     return 0;
 }
@@ -572,8 +572,8 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
             WCHAR infotitle[100], infotext[200];
             ::LoadStringW(g_hinstExe, IDS_INFOTITLE, infotitle, _countof(infotitle));
             ::LoadStringW(g_hinstExe, IDS_INFOTEXT, infotext, _countof(infotext));
-            ShellAbout(m_hWnd, infotitle, infotext,
-                       LoadIcon(g_hinstExe, MAKEINTRESOURCE(IDI_APPICON)));
+            ::ShellAboutW(m_hWnd, infotitle, infotext,
+                          LoadIconW(g_hinstExe, MAKEINTRESOURCEW(IDI_APPICON)));
             break;
         }
         case IDM_HELPHELPTOPICS:
@@ -947,8 +947,8 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
                 CWaitCursor waitCursor;
                 if (attributesDialog.m_bBlackAndWhite && !imageModel.IsBlackAndWhite())
                 {
-                    CStringW strText(MAKEINTRESOURCE(IDS_LOSECOLOR));
-                    CStringW strTitle(MAKEINTRESOURCE(IDS_PROGRAMNAME));
+                    CStringW strText(MAKEINTRESOURCEW(IDS_LOSECOLOR));
+                    CStringW strTitle(MAKEINTRESOURCEW(IDS_PROGRAMNAME));
                     INT id = MessageBox(strText, strTitle, MB_ICONINFORMATION | MB_YESNOCANCEL);
                     if (id != IDYES)
                         break;

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -627,7 +627,7 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
             pd.nMaxPage = 0xffff;
             if (PrintDlg(&pd) == TRUE)
             {
-                BitBlt(pd.hDC, 0, 0, imageModel.GetWidth(), imageModel.GetHeight(), imageModel.GetDC(), 0, 0, SRCCOPY);
+                ::BitBlt(pd.hDC, 0, 0, imageModel.GetWidth(), imageModel.GetHeight(), imageModel.GetDC(), 0, 0, SRCCOPY);
                 DeleteDC(pd.hDC);
             }
             if (pd.hDevMode)

--- a/base/applications/mspaint/winproc.h
+++ b/base/applications/mspaint/winproc.h
@@ -11,7 +11,7 @@
 class CMainWindow : public CWindowImpl<CMainWindow>
 {
 public:
-    DECLARE_WND_CLASS_EX(_T("MSPaintApp"), CS_DBLCLKS, COLOR_BTNFACE)
+    DECLARE_WND_CLASS_EX(L"MSPaintApp", CS_DBLCLKS, COLOR_BTNFACE)
 
     BEGIN_MSG_MAP(CMainWindow)
         MESSAGE_HANDLER(WM_DROPFILES, OnDropFiles)
@@ -30,8 +30,8 @@ public:
     CMainWindow() : m_hMenu(NULL) { }
 
     HWND DoCreate();
-    BOOL GetOpenFileName(IN OUT LPTSTR pszFile, INT cchMaxFile);
-    BOOL GetSaveFileName(IN OUT LPTSTR pszFile, INT cchMaxFile);
+    BOOL GetOpenFileName(IN OUT LPWSTR pszFile, INT cchMaxFile);
+    BOOL GetSaveFileName(IN OUT LPWSTR pszFile, INT cchMaxFile);
     BOOL ChooseColor(IN OUT COLORREF *prgbColor);
     VOID TrackPopupMenu(POINT ptScreen, INT iSubMenu);
     BOOL CanUndo() const;


### PR DESCRIPTION
## Purpose
Follow the standard way.
JIRA issue: [CORE-19094](https://jira.reactos.org/browse/CORE-19094)

## Proposed changes

- `TCHAR` --> `WCHAR`
- `LPTSTR` --> `LPWSTR`
- `LPCTSTR` --> `LPCWSTR`
- `CString` --> `CStringW`
- `TEXT("...")` --> `L"..."`
- `_T("...")` --> `L"..."`
- `::SendMessage(` --> `::SendMessageW(`.
- `::GetWindowText(` --> `::GetWindowTextW(`
- `::SetWindowText(` --> `::SetWindowTextW(`
- Replace `_tcscat` with `StringCchCatW`.
- Replace `_tcslen` with `wcslen`.
- etc. etc.

## TODO

- [x] Do check.