### PR TITLE
[MSPAINT] Use <winuser.rh> instead of <winuser.h> in rsrc.rc

### DIFF
--- a/base/applications/mspaint/rsrc.rc
+++ b/base/applications/mspaint/rsrc.rc
@@ -8,7 +8,7 @@
 /* INCLUDES *********************************************************/
 
 #include <windef.h>
-#include <winuser.h>
+#include <winuser.rh>
 #include <commctrl.h>
 
 #include "resource.h"


### PR DESCRIPTION
## Purpose

Some environment failed in mspaint compilation.
JIRA issue: [CORE-19094](https://jira.reactos.org/browse/CORE-19094)

## TODO

- [x] Do build.