### PR TITLE
Improve Romanian translation

### DIFF
--- a/base/applications/clipbrd/lang/ro-RO.rc
+++ b/base/applications/clipbrd/lang/ro-RO.rc
@@ -1,4 +1,11 @@
-/* Translator: Ștefan Fulea (stefan dot fulea at mail dot com) */
+/*
+ * PROJECT:     ReactOS Clipboard
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Romanian resource file
+ * TRANSLATORS: Copyright 2011-2019 Ștefan Fulea <stefan.fulea@mail.com>
+ *              Copyright 2023 Andrei Miloiu <miloiuandrei@gmail.com>
+ */
+
 LANGUAGE LANG_ROMANIAN, SUBLANG_NEUTRAL
 
 ID_ACCEL ACCELERATORS
@@ -11,7 +18,7 @@ BEGIN
     POPUP "&Fișier"
     BEGIN
         MENUITEM "&Deschidere…", CMD_OPEN
-        MENUITEM "Păst&rare ca…", CMD_SAVE_AS
+        MENUITEM "S&alvează ca…", CMD_SAVE_AS
         MENUITEM SEPARATOR
         MENUITEM "I&eșire", CMD_EXIT
     END

--- a/base/applications/dxdiag/lang/ro-RO.rc
+++ b/base/applications/dxdiag/lang/ro-RO.rc
@@ -1,7 +1,9 @@
 /*
- * FILE:        base/applications/dxdiag/lang/ro-RO.rc
- *              ReactOS Project (https://reactos.org)
- * TRANSLATOR:  Ștefan Fulea (stefan dot fulea at mail dot com)
+ * PROJECT:     ReactOS DX Diagnostic
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Romanian resource file
+ * TRANSLATORS: Copyright 2011-2019 Ștefan Fulea <stefan.fulea@mail.com>
+ *              Copyright 2023 Andrei Miloiu <miloiuandrei@gmail.com>
  */
 
 LANGUAGE LANG_ROMANIAN, SUBLANG_NEUTRAL
@@ -15,7 +17,7 @@ BEGIN
     CONTROL "Tab1", IDC_TAB_CONTROL, "SysTabControl32", WS_TABSTOP, 2, 2, 474, 250
     PUSHBUTTON "&Manual…", IDC_BUTTON_HELP, 2, 260, 50, 14, WS_CHILD | WS_VISIBLE | WS_TABSTOP | WS_DISABLED
     DEFPUSHBUTTON "&Următorul compartiment", IDC_BUTTON_NEXT, 187, 260, 120, 14, WS_CHILD | WS_VISIBLE | WS_TABSTOP
-    PUSHBUTTON "&Păstrare informații…", IDC_BUTTON_SAVE_INFO, 311, 260, 110, 14, WS_CHILD | WS_VISIBLE | WS_TABSTOP | WS_DISABLED
+    PUSHBUTTON "S&alvare informații…", IDC_BUTTON_SAVE_INFO, 311, 260, 110, 14, WS_CHILD | WS_VISIBLE | WS_TABSTOP | WS_DISABLED
     PUSHBUTTON "Î&nchide", IDC_BUTTON_EXIT, 425, 260, 50, 14, WS_CHILD | WS_VISIBLE | WS_TABSTOP
 END
 

--- a/base/applications/games/solitaire/lang/ro-RO.rc
+++ b/base/applications/games/solitaire/lang/ro-RO.rc
@@ -4,7 +4,7 @@
  * PURPOSE:     Romanian resource file
  * TRANSLATORS: Copyright 2009 Petru Dimitriu <petrimetri@gmail.com>
  *              Copyright 2011-2018 Ștefan Fulea <stefan.fulea@mail.com>
- *              Copyright 2022 Andrei Miloiu <miloiuandrei@gmail.com>
+ *              Copyright 2022-2023 Andrei Miloiu <miloiuandrei@gmail.com>
  */
 
 LANGUAGE LANG_ROMANIAN, SUBLANG_NEUTRAL
@@ -25,7 +25,7 @@ BEGIN
     AUTORADIOBUTTON "Fă&ră", IDC_OPT_NOSCORE, 107, 45, 60, 10
     AUTOCHECKBOX "&Afișează timp", IDC_OPT_SHOWTIME, 7 ,51 ,65 ,10, WS_TABSTOP
     AUTOCHECKBOX "&Bară de stare", IDC_OPT_STATUSBAR, 7, 66, 64, 10, WS_TABSTOP
-    AUTOCHECKBOX "&Păstrează scorul", IDC_OPT_KEEPSCORE, 100, 66, 65, 10, WS_TABSTOP
+    AUTOCHECKBOX "Salvea&ză scorul", IDC_OPT_KEEPSCORE, 100, 66, 65, 10, WS_TABSTOP
     DEFPUSHBUTTON "Con&firmă", IDOK, 35, 97, 50, 14
     PUSHBUTTON "A&nulează", IDCANCEL, 101, 97, 50, 14
 END

--- a/base/applications/mmc/lang/ro-RO.rc
+++ b/base/applications/mmc/lang/ro-RO.rc
@@ -28,8 +28,8 @@ BEGIN
     BEGIN
         MENUITEM "&Nou\tCtrl+N", IDM_FILE_NEW
         MENUITEM "&Deschide\tCtrl+O", IDM_FILE_OPEN
-        MENUITEM "&Păstrează", IDM_FILE_SAVE
-        MENUITEM "Păst&rare în…", IDM_FILE_SAVEAS
+        MENUITEM "S&alvează", IDM_FILE_SAVE
+        MENUITEM "Sal&vează ca…", IDM_FILE_SAVEAS
         MENUITEM SEPARATOR
         MENUITEM "I&eșire\tAlt+F4", IDM_FILE_EXIT
     END

--- a/base/applications/mspaint/lang/ro-RO.rc
+++ b/base/applications/mspaint/lang/ro-RO.rc
@@ -17,8 +17,8 @@ BEGIN
     BEGIN
         MENUITEM "&Nou\tCtrl+N", IDM_FILENEW
         MENUITEM "&Deschidere...\tCtrl+O", IDM_FILEOPEN
-        MENUITEM "&Păstrează\tCtrl+S", IDM_FILESAVE
-        MENUITEM "Păst&rare în...", IDM_FILESAVEAS
+        MENUITEM "S&alvează\tCtrl+S", IDM_FILESAVE
+        MENUITEM "Sal&vează ca...", IDM_FILESAVEAS
         MENUITEM SEPARATOR
         MENUITEM "Din aparat media...", IDM_FILEFROMSCANNERORCAMERA
         MENUITEM SEPARATOR
@@ -234,7 +234,7 @@ BEGIN
     IDS_WINDOWTITLE "%s - Pictare"
     IDS_INFOTITLE "Pictare pentru ReactOS"
     IDS_INFOTEXT "Disponibilă sub licența GNU Lesser General Public (vedeți www.gnu.org)"
-    IDS_SAVEPROMPTTEXT "Doriți păstrarea modificărilor din %s?"
+    IDS_SAVEPROMPTTEXT "Doriți salvarea modificărilor din %s?"
     IDS_DEFAULTFILENAME "Fără nume"
     IDS_MINIATURETITLE "Miniatură"
     IDS_TOOLTIP1 "Golire selecție"
@@ -267,7 +267,7 @@ BEGIN
     IDS_VERTICAL "Vertical"
     IDS_PRINTRES "%d x %d pixeli/cm"
     IDS_CANTPASTE "Nu a putut fi lipit din clipboard. Formatul de date este fie incorect, fie nesuportat."
-    IDS_SAVEERROR "Eșec în păstrarea imaginii bitmap („hartă de biți”) în fișierul:\n\n%s"
+    IDS_SAVEERROR "Eșec în salvarea imaginii bitmap („hartă de biți”) în fișierul:\n\n%s"
     IDS_CANTSENDMAIL "Eșec în trimiterea unei scrisori."
     IDS_LOSECOLOR "În această operațiune informațiile legate de culoare vor fi pierdute. Sigur veți continua?"
 END

--- a/base/applications/mstsc/lang/ro-RO.rc
+++ b/base/applications/mstsc/lang/ro-RO.rc
@@ -20,8 +20,8 @@ BEGIN
     LTEXT "Nume utilizator:", IDC_STATIC, 47, 58, 58, 8
     COMBOBOX IDC_SERVERCOMBO, 101, 39, 119, 13, CBS_DROPDOWN | WS_VSCROLL | WS_TABSTOP
     EDITTEXT IDC_NAMEEDIT, 101, 55, 119, 14, WS_TABSTOP | ES_AUTOHSCROLL
-    PUSHBUTTON "&Păstrează", IDC_SAVE, 57, 139, 50, 14
-    PUSHBUTTON "Păst&rare în…", IDC_SAVEAS, 112, 139, 60, 14
+    PUSHBUTTON "S&alvează", IDC_SAVE, 57, 139, 50, 14
+    PUSHBUTTON "Sal&vează ca…", IDC_SAVEAS, 112, 139, 60, 14
     PUSHBUTTON "&Deschidere…", IDC_OPEN, 177, 139, 50, 14
     ICON "", IDC_CONNICON, 16, 114, 20, 20
     LTEXT "Puteți păstra preferințele curente de conectare sau puteți deschide preferințe existente.", IDC_STATIC, 50, 115, 172, 20

--- a/base/applications/notepad/lang/ro-RO.rc
+++ b/base/applications/notepad/lang/ro-RO.rc
@@ -36,8 +36,8 @@ BEGIN
         MENUITEM "&Nou\tCtrl+N", CMD_NEW
         MENUITEM "Fereastră &nouă\tCtrl+Shift+N", CMD_NEW_WINDOW
         MENUITEM "&Deschidere…\tCtrl+O", CMD_OPEN
-        MENUITEM "&Păstrează\tCtrl+S", CMD_SAVE
-        MENUITEM "Păst&rare în…", CMD_SAVE_AS
+        MENUITEM "S&alvează\tCtrl+S", CMD_SAVE
+        MENUITEM "Sal&vare în…", CMD_SAVE_AS
         MENUITEM SEPARATOR
         MENUITEM "&Configurare pagină…", CMD_PAGE_SETUP
         MENUITEM "I&mprimare…\tCtrl+P", CMD_PRINT

--- a/base/applications/sndrec32/lang/ro-RO.rc
+++ b/base/applications/sndrec32/lang/ro-RO.rc
@@ -1,4 +1,10 @@
-/* Translator: Ștefan Fulea (stefan dot fulea at mail dot com) */
+/*
+ * PROJECT:     ReactOS SNDREC32
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Romanian resource file
+ * TRANSLATORS: Copyright 2011-2019 Ștefan Fulea <stefan.fulea@mail.com>
+ *              Copyright 2023 Andrei Miloiu <miloiuandrei@gmail.com>
+ */
 
 LANGUAGE LANG_ROMANIAN, SUBLANG_NEUTRAL
 
@@ -14,8 +20,8 @@ BEGIN
     BEGIN
         MENUITEM "&Nou", ID_FILE_NEW
         MENUITEM "&Deschidere…", ID_FILE_OPEN
-        MENUITEM "&Păstrează", ID_FILE_SAVE, GRAYED
-        MENUITEM "Păst&rare în…", ID_FILE_SAVEAS, GRAYED
+        MENUITEM "S&alvează", ID_FILE_SAVE, GRAYED
+        MENUITEM "Sal&vează ca…", ID_FILE_SAVEAS, GRAYED
         MENUITEM "Re&constituire…", ID_FILE_RESTORE, GRAYED
         MENUITEM "Pr&oprietăți…", ID_FILE_PROPERTIES
         MENUITEM SEPARATOR

--- a/base/applications/wordpad/lang/ro-RO.rc
+++ b/base/applications/wordpad/lang/ro-RO.rc
@@ -1,8 +1,16 @@
 /*
- * Copyright 2004 Krzysztof Foltman
- * Copyright 2010 Claudia Cotună
- *                Michael Stefaniuc
- *           2011 Ștefan Fulea
+
+
+
+ * PROJECT:     ReactOS Wordpad
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Romanian resource file
+ * TRANSLATORS: Copyright 2004 Krzysztof Foltman
+ *              Copyright 2010 Claudia Cotună
+ *              Copyright 2010 Michael Stefaniuc
+ *              Copyright 2011 Ștefan Fulea <stefan.fulea@mail.com>
+ *              Copyright 2023 Andrei Miloiu <miloiuandrei@gmail.com>
+ 
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -27,8 +35,8 @@ BEGIN
     BEGIN
         MENUITEM "&Nou…\tCtrl+N",            ID_FILE_NEW
         MENUITEM "&Deschidere…\tCtrl+O",     ID_FILE_OPEN
-        MENUITEM "&Pătrează\tCtrl+S",        ID_FILE_SAVE
-        MENUITEM "Păst&rare în…",            ID_FILE_SAVEAS
+        MENUITEM "S&alvează\tCtrl+S",        ID_FILE_SAVE
+        MENUITEM "Sal&vează ca…",            ID_FILE_SAVEAS
         MENUITEM SEPARATOR
         MENUITEM "I&mprimare…\tCtrl+P",      ID_PRINT
         MENUITEM "Pre&vizionare imprimare…", ID_PREVIEW
@@ -178,13 +186,13 @@ END
 STRINGTABLE
 BEGIN
     STRING_DEFAULT_FILENAME,     "Document"
-    STRING_PROMPT_SAVE_CHANGES,  "Păstrați modificările la „%s”?"
+    STRING_PROMPT_SAVE_CHANGES,  "Salvați modificările la „%s”?"
     STRING_SEARCH_FINISHED,      "Căutarea în document a fost finalizată."
     STRING_LOAD_RICHED_FAILED,   "Biblioteca RichEdit nu a putut fi încărcată."
     STRING_SAVE_LOSEFORMATTING,  "Ați ales să salvați în formatul de text simplu, care va pierde formatarea. Sigur doriți să continuați?"
     STRING_INVALID_NUMBER,       "Formatul de număr nu este valid."
     STRING_OLE_STORAGE_NOT_SUPPORTED, "Documentele de depozitare OLE nu sunt suportate."
-    STRING_WRITE_FAILED,              "Fișierul nu a putut fi păstrat."
+    STRING_WRITE_FAILED,              "Fișierul nu a putut fi salvat."
     STRING_WRITE_ACCESS_DENIED,       "Nu aveți permisiunea să salvați fișierul."
     STRING_OPEN_FAILED,               "Fișierul nu a putut fi deschis."
     STRING_OPEN_ACCESS_DENIED,        "Nu aveți permisiunea de a deschide fișierul."

--- a/base/applications/wordpad/lang/ro-RO.rc
+++ b/base/applications/wordpad/lang/ro-RO.rc
@@ -1,7 +1,4 @@
 /*
-
-
-
  * PROJECT:     ReactOS Wordpad
  * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
  * PURPOSE:     Romanian resource file
@@ -10,7 +7,6 @@
  *              Copyright 2010 Michael Stefaniuc
  *              Copyright 2011 Ștefan Fulea <stefan.fulea@mail.com>
  *              Copyright 2023 Andrei Miloiu <miloiuandrei@gmail.com>
- 
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/base/shell/cmd/lang/ro-RO.rc
+++ b/base/shell/cmd/lang/ro-RO.rc
@@ -1,4 +1,10 @@
-/* Translator: Ștefan Fulea (stefan dot fulea at mail dot com) */
+/*
+ * PROJECT:     ReactOS Command Prompt
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Romanian resource file
+ * TRANSLATORS: Copyright 2011-2019 Ștefan Fulea <stefan.fulea@mail.com>
+ *              Copyright 2023 Andrei Miloiu <miloiuandrei@gmail.com>
+ */
 
 LANGUAGE LANG_ROMANIAN, SUBLANG_NEUTRAL
 
@@ -120,7 +126,7 @@ dispozitivul auxiliar."
 DATE [/T][dată]\n\n\
   /T    doar afișează\n\n\
 Tastați DATE fără argumente pentru a afișa data curentă urmată de\n\
-cerea modificării ei.  Confirmați aceiași dată apăsând ENTER.\n"
+cerea modificării ei.  Confirmați aceeași dată apăsând ENTER.\n"
     STRING_DEL_HELP1 "Șterge unul sau mai multe fișiere.\n\n\
 DEL [/N /P /T /Q /S /W /Y /Z /A[[:]atribute]] fișier ...\n\
 DELETE [/N /P /T /Q /S /W /Y /Z /A[[:]atribute]] fișier ...\n\
@@ -428,7 +434,7 @@ TITLE [șir]\n\n\
 TIME [/T][oră]\n\n\
   /T    Omite modificarea orei curente\n\n\
 Tastați TIME fără perametri pentru a afișa ora curentă urmată de posibilitatea\n\
-de a introduce o nouă oră. Tastați ENTER pentru a păstra aceiași oră.\n"
+de a introduce o nouă oră. Tastați ENTER pentru a păstra aceeași oră.\n"
     STRING_TIME_HELP2 "Introduceți noua oră: "
     STRING_TIMER_HELP1 "Timp cronometrat: %d msec\n"
     STRING_TIMER_HELP2 "Timp cronometrat: %02d%c%02d%c%02d%c%02d\n"

--- a/dll/cpl/console/lang/ro-RO.rc
+++ b/dll/cpl/console/lang/ro-RO.rc
@@ -1,9 +1,10 @@
 /*
- * PROJECT:    ReactOS Console Configuration DLL
- * LICENSE:    GPL - See COPYING in the top level directory
- * PURPOSE:    Romanian resource file
- * TRANSLATOR: Petru Dimitriu <petrimetri@gmail.com>
- *             Ștefan Fulea <stefan.fulea@mail.com>
+ * PROJECT:     ReactOS DX Diagnostic
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Romanian resource file
+ * TRANSLATORS: Copyright 2011 Petru Dimitriu <petrimetri@gmail.com>
+ *              Copyright 2011-2019 Ștefan Fulea <stefan.fulea@mail.com>
+ *              Copyright 2023 Andrei Miloiu <miloiuandrei@gmail.com>
  */
 
 LANGUAGE LANG_ROMANIAN, SUBLANG_NEUTRAL
@@ -31,8 +32,8 @@ BEGIN
             UDS_AUTOBUDDY | UDS_ARROWKEYS | WS_GROUP, 119, 120, 12, 15
     AUTOCHECKBOX "Înlătură duplicatele &vechi", IDC_CHECK_DISCARD_DUPLICATES, 12, 140, 110, 15
     GROUPBOX "Opțiuni de editare", IDC_STATIC, 133, 85, 112, 77, BS_GROUPBOX | WS_CHILD | WS_VISIBLE | WS_GROUP
-    AUTOCHECKBOX "Mod de &editare rapidă”", IDC_CHECK_QUICK_EDIT, 140, 97, 102, 15, WS_CHILD | WS_VISIBLE | WS_TABSTOP
-    AUTOCHECKBOX "Mod de inse&rție”", IDC_CHECK_INSERT_MODE, 140, 113, 76, 15, WS_CHILD | WS_VISIBLE | WS_TABSTOP
+    AUTOCHECKBOX "Mod de &editare rapidă", IDC_CHECK_QUICK_EDIT, 140, 97, 102, 15, WS_CHILD | WS_VISIBLE | WS_TABSTOP
+    AUTOCHECKBOX "Mod de inse&rție", IDC_CHECK_INSERT_MODE, 140, 113, 76, 15, WS_CHILD | WS_VISIBLE | WS_TABSTOP
     GROUPBOX "Cod de pagină", IDC_STATIC, 7, 170, 238, 31
     COMBOBOX IDL_CODEPAGE, 13, 181, 224, 58, CBS_DROPDOWNLIST | CBS_SORT | WS_VSCROLL | WS_TABSTOP
 END
@@ -47,7 +48,7 @@ BEGIN
     LTEXT "Mărime:", IDC_STATIC, 130, 7, 45, 10
     LISTBOX IDC_LBOX_FONTSIZE, 130, 20, 50, 86, LBS_SORT | LBS_HASSTRINGS | WS_VSCROLL | WS_TABSTOP
     COMBOBOX IDC_CBOX_FONTSIZE, 130, 20, 30, 86, CBS_SIMPLE | CBS_SORT | WS_VSCROLL | WS_TABSTOP
-    AUTORADIOBUTTON "pi&xels", IDC_RADIO_PIXEL_UNIT, 165, 17, 60, 10, WS_CHILD | WS_VISIBLE | WS_TABSTOP
+    AUTORADIOBUTTON "pi&xeli", IDC_RADIO_PIXEL_UNIT, 165, 17, 60, 10, WS_CHILD | WS_VISIBLE | WS_TABSTOP
     AUTORADIOBUTTON "p&uncte", IDC_RADIO_POINT_UNIT, 165, 28, 60, 10, WS_CHILD | WS_VISIBLE | WS_TABSTOP
     LTEXT "F&ont:", IDC_STATIC, 10, 105, 33, 10
     AUTOCHECKBOX "&Aldin", IDC_CHECK_BOLD_FONTS, 56, 105, 60, 10

--- a/dll/cpl/console/lang/ro-RO.rc
+++ b/dll/cpl/console/lang/ro-RO.rc
@@ -1,5 +1,5 @@
 /*
- * PROJECT:     ReactOS DX Diagnostic
+ * PROJECT:     ReactOS Console
  * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
  * PURPOSE:     Romanian resource file
  * TRANSLATORS: Copyright 2011 Petru Dimitriu <petrimetri@gmail.com>

--- a/dll/cpl/desk/lang/ro-RO.rc
+++ b/dll/cpl/desk/lang/ro-RO.rc
@@ -4,7 +4,7 @@
  * PURPOSE:     Romanian resource file
  * TRANSLATORS: Copyright 2009 Petru Dimitriu <petrimetri@gmail.com>
  *              Copyright 2011-2019 Ștefan Fulea <stefan.fulea@mail.com>
- *              Copyright 2022 Andrei Miloiu <miloiuandrei@gmail.com>
+ *              Copyright 2022-2023 Andrei Miloiu <miloiuandrei@gmail.com>
  */
 
 LANGUAGE LANG_ROMANIAN, SUBLANG_NEUTRAL
@@ -17,7 +17,7 @@ BEGIN
     LTEXT "O temă este un fundal plus un set de sunete, pictograme și alte elemente care vă ajută să vă personalizați calculatorul cu un singur clic.", IDC_STATIC, 5, 5, 235, 30
     LTEXT "Temă:", IDC_STATIC, 5, 42, 55, 10
     COMBOBOX IDC_THEMES_COMBOBOX, 5, 52, 160, 300, CBS_HASSTRINGS | CBS_AUTOHSCROLL | CBS_DROPDOWN | WS_VSCROLL | WS_TABSTOP
-    PUSHBUTTON "Păstrare &ca…", IDC_THEMES_SAVE_AS, 170, 52, 70, 14
+    PUSHBUTTON "Salvare &ca…", IDC_THEMES_SAVE_AS, 170, 52, 70, 14
     PUSHBUTTON "Șt&erge", IDC_THEMES_DELETE, 170, 70, 70, 14
     CONTROL "", IDC_THEMES_PREVIEW, "STATIC", SS_BITMAP, 5, 90, 235, 115, WS_EX_CLIENTEDGE
 END

--- a/dll/cpl/hdwwiz/lang/ro-RO.rc
+++ b/dll/cpl/hdwwiz/lang/ro-RO.rc
@@ -127,7 +127,7 @@ BEGIN
     LTEXT "Starea curentă a dispozitivului selectat:", -1, 114, 40, 193, 19
     EDITTEXT IDC_HWSTATUSEDIT, 114, 60, 193, 70, ES_MULTILINE | ES_AUTOVSCROLL | ES_READONLY | WS_VSCROLL | NOT WS_TABSTOP
     LTEXT "Pentru a porni un program de depanare pentru rezolvarea posibilelor probleme de instalare, apăsați „Sfârșit”.", -1, 114, 136, 193, 16
-    LTEXT "Pentru a ieși, apăsți „Anulează”.", IDC_STATUSTEXT, 114, 166, 132, 8
+    LTEXT "Pentru a ieși, apăsați „Anulează”.", IDC_STATUSTEXT, 114, 166, 132, 8
 END
 
 IDD_NOTCONNECTEDPAGE DIALOGEX 0, 0, 317, 186

--- a/dll/cpl/inetcpl/lang/ro-RO.rc
+++ b/dll/cpl/inetcpl/lang/ro-RO.rc
@@ -17,7 +17,8 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  *
- * TRANSLATOR: Ștefan Fulea (stefan dot fulea at mail dot com)
+ * TRANSLATORS: Copyright 2011-2019 Ștefan Fulea <stefan.fulea@mail.com>
+ *             Copyright 2022 Andrei Miloiu <miloiuandrei@gmail.com>
  */
 
 LANGUAGE LANG_ROMANIAN, SUBLANG_NEUTRAL
@@ -74,7 +75,7 @@ BEGIN
                     IDC_DELETE_HISTORY, 10, 88, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "&Datele formularelor\nNume de utilizatori și alte informații pe care le-ați introdus prin formulare.",
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
-    AUTOCHECKBOX   "&Parolele\nParolele păstrate pe care le-ați introdus prin formulare.",
+    AUTOCHECKBOX   "&Parolele\nParolele salvate pe care le-ați introdus prin formulare.",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
     DEFPUSHBUTTON  "A&nulează", IDCANCEL, 185, 230, 60, 15, WS_GROUP
     PUSHBUTTON     "&Elimină", IDOK, 120, 230, 60, 15, WS_GROUP

--- a/dll/cpl/inetcpl/lang/ro-RO.rc
+++ b/dll/cpl/inetcpl/lang/ro-RO.rc
@@ -18,7 +18,7 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  *
  * TRANSLATORS: Copyright 2011-2019 Ștefan Fulea <stefan.fulea@mail.com>
- *             Copyright 2022 Andrei Miloiu <miloiuandrei@gmail.com>
+ *              Copyright 2022 Andrei Miloiu <miloiuandrei@gmail.com>
  */
 
 LANGUAGE LANG_ROMANIAN, SUBLANG_NEUTRAL

--- a/dll/win32/ieframe/lang/ro-RO.rc
+++ b/dll/win32/ieframe/lang/ro-RO.rc
@@ -17,7 +17,7 @@ IDR_BROWSE_MAIN_MENU MENU
             MENUITEM "&Fereastră",              ID_BROWSE_NEW_WINDOW
         }
         MENUITEM "&Deschidere…",                ID_BROWSE_OPEN
-        MENUITEM "S&alvează",                  ID_BROWSE_SAVE
+        MENUITEM "S&alvează",                   ID_BROWSE_SAVE
         MENUITEM "Sal&vează ca…",               ID_BROWSE_SAVE_AS
         MENUITEM SEPARATOR
         MENUITEM "Formatare imprima&bil…",      ID_BROWSE_PRINT_FORMAT

--- a/dll/win32/ieframe/lang/ro-RO.rc
+++ b/dll/win32/ieframe/lang/ro-RO.rc
@@ -17,8 +17,8 @@ IDR_BROWSE_MAIN_MENU MENU
             MENUITEM "&Fereastră",              ID_BROWSE_NEW_WINDOW
         }
         MENUITEM "&Deschidere…",                ID_BROWSE_OPEN
-        MENUITEM "&Păstrează",                  ID_BROWSE_SAVE
-        MENUITEM "Păst&rare în…",               ID_BROWSE_SAVE_AS
+        MENUITEM "S&alvează",                  ID_BROWSE_SAVE
+        MENUITEM "Sal&vează ca…",               ID_BROWSE_SAVE_AS
         MENUITEM SEPARATOR
         MENUITEM "Formatare imprima&bil…",      ID_BROWSE_PRINT_FORMAT
         MENUITEM "I&mprimare…",                 ID_BROWSE_PRINT

--- a/dll/win32/rasdlg/lang/ro-RO.rc
+++ b/dll/win32/rasdlg/lang/ro-RO.rc
@@ -1,7 +1,9 @@
 /*
- * FILE:       dll/win32/rasdlg/lang/ro-RO.rc
- *             ReactOS Project (https://reactos.org)
- * TRANSLATOR: Ștefan Fulea (stefan dot fulea at mail dot com)
+ * PROJECT:     ReactOS RASDLG
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Romanian resource file
+ * TRANSLATORS: Copyright 2011-2019 Ștefan Fulea <stefan.fulea@mail.com>
+ *              Copyright 2023 Andrei Miloiu <miloiuandrei@gmail.com>
  */
 
 LANGUAGE LANG_ROMANIAN, SUBLANG_NEUTRAL
@@ -533,7 +535,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "Tastați numele pe care îl dați acestei conexiuni:", -1, 8, 4, 190, 8
     EDITTEXT 1114, 8, 17, 190, 12, ES_AUTOHSCROLL
-    LTEXT "Apăsați „Sfârșit” pentru a o păstra în „Conexiuni de rețea”.", -1, 8, 38, 193, 8
+    LTEXT "Apăsați „Sfârșit” pentru a o salva în „Conexiuni de rețea”.", -1, 8, 38, 193, 8
     LTEXT "Puteți edita această conexiune mai târziu, alegând „Proprietăți” din meniul „Fișier”.", -1, 8, 58, 193, 16
 END
 
@@ -1614,7 +1616,7 @@ STYLE DS_SHELLFONT | WS_CHILD | WS_DISABLED | WS_CAPTION
 CAPTION "Creare conexiune nouă"
 FONT 8, "MS Shell Dlg"
 BEGIN
-    LTEXT "Introduceți numele și parola contului unui furnizor de Internet, apoi scrieți aceste informații și păstrați-le.\n(Dacă ați uitat o parolă sau un nume de cont, contactați furnizorul de servicii de Internet)", 1689, 10, 4, 308, 25
+    LTEXT "Introduceți numele și parola contului unui furnizor de Internet, apoi scrieți aceste informații și salvați-le.\n(Dacă ați uitat o parolă sau un nume de cont, contactați furnizorul de servicii de Internet)", 1689, 10, 4, 308, 25
     LTEXT "N&umele de utilizator:", 1636, 23, 35, 89, 15
     EDITTEXT 1614, 115, 34, 190, 15, ES_AUTOHSCROLL
     LTEXT "&Parola:", 1637, 23, 55, 90, 13
@@ -1908,7 +1910,7 @@ BEGIN
     260 "%1 CP este conectată.\n\0"
     261 "Puteți alege care dintre protocoalele de linie comutată îl folosiți.\0"
     262 "Alegeți protocolul de linie comutată\0"
-    263 "Apăsați „Sfârșit” pentru a păstra '%1'.\0"
+    263 "Apăsați „Sfârșit” pentru a salva '%1'.\0"
     264 "netcfg.hlp\0"
     265 "&Mutați numărul testat cu succes în capul listei de conectare\0"
     266 "N&oul număr de telefon:\0"
@@ -1960,7 +1962,7 @@ BEGIN
     312 "În listă deja există „%1”.\0"
     313 "Securizează parola și datele\0"
     314 "Protocolul %1 nu poate fi selectat, deoarece fie nu este instalat, fie este dezactivat pentru accesul la distanță.  Pentru a activa, mergeți în Panoul de control, deschideți Rețea, apoi în pagina Servicii, alegeți Proprietăți pentru accesul în rețea și apăsați butonul Rețea.\0"
-    315 "Parola nu poate fi păstrată.\0"
+    315 "Parola nu poate fi salvată.\0"
     316 "Datele nu pot fi afișate.\0"
     317 "Informațiile de autoapelare nu au putut fi preluate.\0"
     318 "Fereastra de dialog nu a putut fi încărcată.\0"
@@ -1983,12 +1985,12 @@ BEGIN
     335 "Recepția de la dispozitiv nu este posibilă.\0"
     336 "Transmisia către dispozitiv nu este posibilă.\0"
     337 "Date nu pot fi obținute.\0"
-    338 "Informația TAPI nu poate fi păstrată.\0"
-    339 "Date nu pot fi păstrate.\0"
+    338 "Informația TAPI nu poate fi salvată.\0"
+    339 "Date nu pot fi salvate.\0"
     340 "Scriptul a fost oprit.\0"
     341 "Scriptul a fost oprit din cauza unei erori. Doriți să vedeți raportul de eroare?\0"
     342 "Informația de autoapelare nu poate fi accesată.\0"
-    343 "Parolele păstrate nu au putut fi eliminate.\0"
+    343 "Parolele salvate nu au putut fi eliminate.\0"
     344 "Agenda telefonică nu a putut fi scrisă.\0"
     345 "Scriere preferințe în registru\0"
     346 "Fișierul scurtătură nu a putut fi scris.\0"
@@ -2015,7 +2017,7 @@ BEGIN
     367 "A eșuat conectarea unuia sau mai multor protocoale de rețea cerute.\n\n\0"
     368 "Apăsați „Accept” pentru a utiliza conexiunea așa cum este sau „Închide” pentru a o deconecta.\0"
     369 "Opțiunile utilizate ale protocolului Punct-la-Punct când %1 inițiază un apel pentru conexiune către interfața %2:\0"
-    370 "[Pentru a modifica parola păstrată, apăsați aici]\0"
+    370 "[Pentru a modifica parola salvată, apăsați aici]\0"
     405 "Protocolul NetBEUI este necesar pentru a apela vechile servere RAS.\0"
     406 "Înainte de a apela un server RAS, este necesară instalarea protocolului NetBEUI.  NetBEUI poate fi instalat în Panoul de control, la Rețea.\0"
     407 "&Reapelează\0"
@@ -2215,7 +2217,7 @@ BEGIN
     1571 "Opțiunea curentă de criptare cere EAP sau o careva versiune de autentificare securizată MS-CHAP.\0"
     1572 "Protocoale și securitate\0"
     1573 "Alegeți transporturi și opțiuni de securitate pentru conexiune.\0"
-    1574 "Protocolul ales include PAP, SPAP, și/sau CHAP.  Dacă unul dintre acestea este negociat, criptarea datelor nu va avea loc.  Doriți păstrarea acestei configurații?\0"
+    1574 "Protocolul ales include PAP, SPAP, și/sau CHAP.  Dacă unul dintre acestea este negociat, criptarea datelor nu va avea loc. Doriți păstrarea acestei configurații?\0"
     1575 "Pentru conectarea la „%1”, este necesară mai întâi conectarea la „%2”.  Doriți conectarea la „%2”?\0"
     1576 "Conectarea prin cablu paralel…\0"
     1577 "Conectarea prin infraroșu…\0"
@@ -2224,7 +2226,7 @@ BEGIN
     1580 "Această conexiune a fost configurată cu un nivel de securitate nesusținut de infrastructura programelor instalate.  Opțiunile de securitate ale acestei conexiuni au fost ajustate la nivelul de securitate disponibil.\0"
     1581 "Tip&ul de VPN:\0"
     1582 "Introduceți un nume de utilizator.\0"
-    1583 "Aceste date de autentificare sunt păstrate pentru propria dumneavoastră utilizare.  Totuși deja există un nume de utilizator disponibil pentru toți utilizatorii acestei conexiuni.  Doriți înlăturarea datelor de autentificare disponibile pentru toți ceilalți utilizatori?\0"
+    1583 "Aceste date de autentificare sunt salvate pentru propria dumneavoastră utilizare.  Totuși deja există un nume de utilizator disponibil pentru toți utilizatorii acestei conexiuni.  Doriți înlăturarea datelor de autentificare disponibile pentru toți ceilalți utilizatori?\0"
     1584 "De exemplu, veți putea introduce numele serverului la care vă conectați.\0"
     1585 "Informații de cont\0"
     1586 "Controalele acestui formular sunt dezactivate deoarece sistemul trebuie mai întâi repornit înainte de a putea efectua alte modificări.\0"

--- a/media/doc/Romanian translation notes.txt
+++ b/media/doc/Romanian translation notes.txt
@@ -1,5 +1,7 @@
 The following material is addressed (in Romanian) to Romanian translators.
-Last modified: 2023 Miloiu Andrei
+
+Copyright 2017 ColinFinck
+Copyright 2023 Miloiu Andrei
 
 ------------------------------------------------------------------------------
 
@@ -36,7 +38,6 @@ La acestea se adaugă și câteva norme (deduse) din „greșeli frecvente” ra
   - „logică computațională” vs. „software”
   - „configurare”/„particularizare” vs. „Setare”
   - „modul pilot” (sau doar „pilot”) vs. „driver”
-  - „Confirmă”/„Anulează” vs. „OK”/„Renunță”
  16. Acceleratorii (combinațiile de taste de gen „«Ctrl» + «tastă»”) rămân aceiași ca în limba engleză.
  17. Tastele de acces (combinațiile de taste de gen „«Alt» + «tastă»”) nu rămân neapărat la fel ca în limba engleză. În mulțimea de taste cu această utilizare:
   - Este recomandată evitarea utilizării literelor „s” și „t” pe post de taste de acces pentru a preveni confuzia între acestea și diacriticele „ș” și „ț”.

--- a/media/doc/Romanian translation notes.txt
+++ b/media/doc/Romanian translation notes.txt
@@ -1,4 +1,5 @@
 The following material is addressed (in Romanian) to Romanian translators.
+Last modified: 2023 Miloiu Andrei
 
 ------------------------------------------------------------------------------
 
@@ -35,7 +36,6 @@ La acestea se adaugă și câteva norme (deduse) din „greșeli frecvente” ra
   - „logică computațională” vs. „software”
   - „configurare”/„particularizare” vs. „Setare”
   - „modul pilot” (sau doar „pilot”) vs. „driver”
-  - „păstrează” vs. „salvează”
   - „Confirmă”/„Anulează” vs. „OK”/„Renunță”
  16. Acceleratorii (combinațiile de taste de gen „«Ctrl» + «tastă»”) rămân aceiași ca în limba engleză.
  17. Tastele de acces (combinațiile de taste de gen „«Alt» + «tastă»”) nu rămân neapărat la fel ca în limba engleză. În mulțimea de taste cu această utilizare:

--- a/win32ss/printing/monitors/localmon/ui/lang/ui_Ro.rc
+++ b/win32ss/printing/monitors/localmon/ui/lang/ui_Ro.rc
@@ -1,7 +1,11 @@
 /*
- * Copyright 2007 Detlef Riekenberg
- * Copyright 2008 Michael Stefaniuc
- *           2011 Fulea Ștefan
+ * PROJECT:     ReactOS Local Monitor
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Romanian resource file
+ * TRANSLATORS: Copyright 2007 Detlef Riekenberg
+ *              Copyright 2008 Michael Stefaniuc
+ *              Copyright 2011 Ștefan Fulea <stefan.fulea@mail.com>
+ *              Copyright 2023 Andrei Miloiu <miloiuandrei@gmail.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -27,7 +31,7 @@ STRINGTABLE
 {
     IDS_LOCALPORT "Port local"
     IDS_INVALIDNAME "„%s” nu este un nume valid de port"
-    IDS_PORTEXISTS "Portul %s existsă deja"
+    IDS_PORTEXISTS "Portul %s există deja"
     IDS_NOTHINGTOCONFIG "Acest port nu are opțiuni de configurat"
 }
 


### PR DESCRIPTION
I propose more flexible rules. In every software they translate the terms "Save" and "Save as" as "Salvează" and "Salvează ca", not as "Păstrează", "Păstrează în", "Păstrează ca", "Păstrare în" and "Păstrare ca", respectively.

Another proposal is to keep both options:   „Confirmă”/„Anulează”, „OK”/„Renunță” and also a combination of them, as I saw in some places they use the word „Anulează” and in others the word „Renunță”.

Also, I want to fix some typos.

I hope that every file is modified.