### PR TITLE
[FREELDR] Implement the FASTDETECT option and enable it by default

### DIFF
--- a/base/setup/lib/bootsup.c
+++ b/base/setup/lib/bootsup.c
@@ -73,7 +73,7 @@ CreateFreeLoaderReactOSEntries(
     /* ReactOS */
     // BootEntry->BootEntryKey = MAKESTRKEY(L"ReactOS");
     BootEntry->FriendlyName = L"\"ReactOS\"";
-    Options->OsLoadOptions  = NULL; // L"";
+    Options->OsLoadOptions  = L"/FASTDETECT";
     AddBootStoreEntry(BootStoreHandle, BootEntry, MAKESTRKEY(L"ReactOS"));
 
     /* ReactOS_Debug */

--- a/boot/bootdata/livecd.ini
+++ b/boot/bootdata/livecd.ini
@@ -18,34 +18,34 @@ LiveCD_LogFile="LiveCD (Log file)"
 [LiveCD]
 BootType=Windows2003
 SystemPath=\reactos
-Options=/MININT
+Options=/FASTDETECT /MININT
 
 [LiveCD_Debug]
 BootType=Windows2003
 SystemPath=\reactos
-Options=/DEBUG /DEBUGPORT=COM1 /BAUDRATE=115200 /SOS /MININT
+Options=/DEBUG /DEBUGPORT=COM1 /BAUDRATE=115200 /SOS /FASTDETECT /MININT
 
 [LiveCD_Macpi]
 BootType=Windows2003
 SystemPath=\reactos
-Options=/HAL=halmacpi.dll /KERNEL=ntkrnlmp.exe /DEBUG /DEBUGPORT=COM1 /BAUDRATE=115200 /SOS /MININT
+Options=/HAL=halmacpi.dll /KERNEL=ntkrnlmp.exe /DEBUG /DEBUGPORT=COM1 /BAUDRATE=115200 /SOS /FASTDETECT /MININT
 
 [LiveCD_Aacpi]
 BootType=Windows2003
 SystemPath=\reactos
-Options=/HAL=halaacpi.dll /DEBUG /DEBUGPORT=COM1 /BAUDRATE=115200 /SOS /MININT
+Options=/HAL=halaacpi.dll /DEBUG /DEBUGPORT=COM1 /BAUDRATE=115200 /SOS /FASTDETECT /MININT
 
 [LiveCD_VBoxDebug]
 BootType=Windows2003
 SystemPath=\reactos
-Options=/DEBUG /DEBUGPORT=VBOX /SOS /MININT
+Options=/DEBUG /DEBUGPORT=VBOX /SOS /FASTDETECT /MININT
 
 [LiveCD_Screen]
 BootType=Windows2003
 SystemPath=\reactos
-Options=/DEBUG /DEBUGPORT=SCREEN /SOS /MININT
+Options=/DEBUG /DEBUGPORT=SCREEN /SOS /FASTDETECT /MININT
 
 [LiveCD_LogFile]
 BootType=Windows2003
 SystemPath=\reactos
-Options=/DEBUG /DEBUGPORT=FILE:\Device\HarddiskX\PartitionY\debug.log /SOS /MININT
+Options=/DEBUG /DEBUGPORT=FILE:\Device\HarddiskX\PartitionY\debug.log /SOS /FASTDETECT /MININT

--- a/boot/bootdata/txtsetup.sif
+++ b/boot/bootdata/txtsetup.sif
@@ -216,7 +216,7 @@ Cabinet=reactos.cab
 DefaultPath = \ReactOS
 SetupDebugOptions = "/DEBUG /KDSERIAL /DEBUGPORT=COM1 /FIRSTCHANCE"
 ;SetupDebugOptions = "/DEBUG /SOS /DEBUGPORT=SCREEN"
-OsLoadOptions = "/NOGUIBOOT /NODEBUG"
+OsLoadOptions = "/FASTDETECT /NOGUIBOOT /NODEBUG"
 
 [NLS]
 AnsiCodepage     = c_1252.nls

--- a/boot/freeldr/freeldr/arch/i386/pc/machpc.c
+++ b/boot/freeldr/freeldr/arch/i386/pc/machpc.c
@@ -19,6 +19,8 @@
 #include <freeldr.h>
 #include <cportlib/cportlib.h>
 
+#include "../ntldr/ntldropts.h"
+
 #include <debug.h>
 DBG_DEFAULT_CHANNEL(HWDETECT);
 
@@ -710,6 +712,7 @@ DetectSerialPointerPeripheral(PCONFIGURATION_COMPONENT_DATA ControllerKey,
     }
 }
 
+static
 ULONG
 PcGetSerialPort(ULONG Index, PULONG Irq)
 {
@@ -727,8 +730,60 @@ PcGetSerialPort(ULONG Index, PULONG Irq)
     return (ULONG) *(BasePtr + Index);
 }
 
+/*
+ * Parse the serial mouse detection options.
+ * Format: /FASTDETECT
+ * or: /NOSERIALMICE=COM[0-9],[0-9],[0-9]...
+ * or: /NOSERIALMICE:COM[0-9]...
+ * If we have /FASTDETECT, then nothing can be detected.
+ */
+static
+ULONG
+GetSerialMouseDetectionBitmap(
+    _In_opt_ PCSTR Options)
+{
+    PCSTR Option, c;
+    ULONG OptionLength, PortBitmap, i;
+
+    if (NtLdrGetOption(Options, "FASTDETECT"))
+        return (1 << MAX_COM_PORTS) - 1;
+
+    Option = NtLdrGetOptionEx(Options, "NOSERIALMICE=", &OptionLength);
+    if (!Option)
+        Option = NtLdrGetOptionEx(Options, "NOSERIALMICE:", &OptionLength);
+
+    if (!Option)
+        return 0;
+
+    /* Invalid port list */
+    if (OptionLength < (sizeof("NOSERIALMICE=COM9") - 1))
+        return (1 << MAX_COM_PORTS) - 1;
+
+    /* Move to the port list */
+    Option += sizeof("NOSERIALMICE=COM") - 1;
+    OptionLength -= sizeof("NOSERIALMICE=COM") - 1;
+
+    PortBitmap = 0;
+    c = Option;
+    for (i = 0; i < OptionLength; i += 2)
+    {
+        UCHAR PortNumber = *c - '0';
+
+        if (PortNumber > 0 && PortNumber <= 9)
+            PortBitmap |= 1 << (PortNumber - 1);
+
+        c += 2;
+    }
+
+    return PortBitmap;
+}
+
 VOID
-DetectSerialPorts(PCONFIGURATION_COMPONENT_DATA BusKey, GET_SERIAL_PORT MachGetSerialPort, ULONG Count)
+DetectSerialPorts(
+    _In_opt_ PCSTR Options,
+    _Inout_ PCONFIGURATION_COMPONENT_DATA BusKey,
+    _In_ GET_SERIAL_PORT MachGetSerialPort,
+    _In_ ULONG Count)
 {
     PCM_PARTIAL_RESOURCE_LIST PartialResourceList;
     PCM_PARTIAL_RESOURCE_DESCRIPTOR PartialDescriptor;
@@ -740,8 +795,11 @@ DetectSerialPorts(PCONFIGURATION_COMPONENT_DATA BusKey, GET_SERIAL_PORT MachGetS
     PCONFIGURATION_COMPONENT_DATA ControllerKey;
     ULONG i;
     ULONG Size;
+    ULONG PortBitmap;
 
     TRACE("DetectSerialPorts()\n");
+
+    PortBitmap = GetSerialMouseDetectionBitmap(Options);
 
     for (i = 0; i < Count; i++)
     {
@@ -813,7 +871,7 @@ DetectSerialPorts(PCONFIGURATION_COMPONENT_DATA BusKey, GET_SERIAL_PORT MachGetS
                                Size,
                                &ControllerKey);
 
-        if (!Rs232PortInUse(UlongToPtr(Base)))
+        if (!(PortBitmap & (1 << i)) && !Rs232PortInUse(UlongToPtr(Base)))
         {
             /* Detect serial mouse */
             DetectSerialPointerPeripheral(ControllerKey, UlongToPtr(Base));
@@ -1561,7 +1619,10 @@ DetectDisplayController(PCONFIGURATION_COMPONENT_DATA BusKey)
 
 static
 VOID
-DetectIsaBios(PCONFIGURATION_COMPONENT_DATA SystemKey, ULONG *BusNumber)
+DetectIsaBios(
+    _In_opt_ PCSTR Options,
+    _Inout_ PCONFIGURATION_COMPONENT_DATA SystemKey,
+    _Out_ ULONG *BusNumber)
 {
     PCM_PARTIAL_RESOURCE_LIST PartialResourceList;
     PCONFIGURATION_COMPONENT_DATA BusKey;
@@ -1600,7 +1661,7 @@ DetectIsaBios(PCONFIGURATION_COMPONENT_DATA SystemKey, ULONG *BusNumber)
 
     /* Detect ISA/BIOS devices */
     DetectBiosDisks(SystemKey, BusKey);
-    DetectSerialPorts(BusKey, PcGetSerialPort, MAX_COM_PORTS);
+    DetectSerialPorts(Options, BusKey, PcGetSerialPort, MAX_COM_PORTS);
     DetectParallelPorts(BusKey);
     DetectKeyboardController(BusKey);
     DetectPS2Mouse(BusKey);
@@ -1647,7 +1708,7 @@ PcHwDetect(
     DetectPciBios(SystemKey, &BusNumber);
     DetectApmBios(SystemKey, &BusNumber);
     DetectPnpBios(SystemKey, &BusNumber);
-    DetectIsaBios(SystemKey, &BusNumber); // TODO: Detect first EISA or MCA, before ISA
+    DetectIsaBios(Options, SystemKey, &BusNumber); // TODO: Detect first EISA or MCA, before ISA
     DetectAcpiBios(SystemKey, &BusNumber);
 
     // TODO: Collect the ROM blocks from 0xC0000 to 0xF0000 and append their

--- a/boot/freeldr/freeldr/arch/i386/xbox/machxbox.c
+++ b/boot/freeldr/freeldr/arch/i386/xbox/machxbox.c
@@ -73,7 +73,11 @@ XboxGetSerialPort(ULONG Index, PULONG Irq)
 
 extern
 VOID
-DetectSerialPorts(PCONFIGURATION_COMPONENT_DATA BusKey, GET_SERIAL_PORT MachGetSerialPort, ULONG Count);
+DetectSerialPorts(
+    _In_opt_ PCSTR Options,
+    _Inout_ PCONFIGURATION_COMPONENT_DATA BusKey,
+    _In_ GET_SERIAL_PORT MachGetSerialPort,
+    _In_ ULONG Count);
 
 VOID
 XboxGetExtendedBIOSData(PULONG ExtendedBIOSDataArea, PULONG ExtendedBIOSDataSize)
@@ -201,7 +205,10 @@ DetectDisplayController(PCONFIGURATION_COMPONENT_DATA BusKey)
 
 static
 VOID
-DetectIsaBios(PCONFIGURATION_COMPONENT_DATA SystemKey, ULONG *BusNumber)
+DetectIsaBios(
+    _In_opt_ PCSTR Options,
+    _Inout_ PCONFIGURATION_COMPONENT_DATA SystemKey,
+    _Out_ ULONG *BusNumber)
 {
     PCM_PARTIAL_RESOURCE_LIST PartialResourceList;
     PCONFIGURATION_COMPONENT_DATA BusKey;
@@ -240,7 +247,7 @@ DetectIsaBios(PCONFIGURATION_COMPONENT_DATA SystemKey, ULONG *BusNumber)
 
     /* Detect ISA/BIOS devices */
     DetectBiosDisks(SystemKey, BusKey);
-    DetectSerialPorts(BusKey, XboxGetSerialPort, MAX_XBOX_COM_PORTS);
+    DetectSerialPorts(Options, BusKey, XboxGetSerialPort, MAX_XBOX_COM_PORTS);
     DetectDisplayController(BusKey);
 
     /* FIXME: Detect more ISA devices */
@@ -279,7 +286,7 @@ XboxHwDetect(
 
     /* TODO: Build actual xbox's hardware configuration tree */
     DetectPciBios(SystemKey, &BusNumber);
-    DetectIsaBios(SystemKey, &BusNumber);
+    DetectIsaBios(Options, SystemKey, &BusNumber);
 
     TRACE("DetectHardware() Done\n");
     return SystemKey;


### PR DESCRIPTION
## Purpose

The serial mouse is recognized by the serial stack since NT5.x.