### PR TITLE
[CMLIB] UNIMPLEMENTED_ONCE less hand-knitted

### DIFF
--- a/sdk/lib/cmlib/hivewrt.c
+++ b/sdk/lib/cmlib/hivewrt.c
@@ -24,6 +24,7 @@ HvpWriteLog(
     ULONG LastIndex;
     PVOID BlockPtr;
     BOOLEAN Success;
+
     ASSERT(RegistryHive->ReadOnly == FALSE);
     ASSERT(RegistryHive->BaseBlock->Length ==
            RegistryHive->Storage[Stable].Length * HBLOCK_SIZE);

--- a/sdk/lib/cmlib/hivewrt.c
+++ b/sdk/lib/cmlib/hivewrt.c
@@ -13,6 +13,8 @@ static BOOLEAN CMAPI
 HvpWriteLog(
     PHHIVE RegistryHive)
 {
+    UNIMPLEMENTED_ONCE;
+#if 0 // UNIMPLEMENTED
     ULONG FileOffset;
     UINT32 BufferSize;
     UINT32 BitmapSize;
@@ -22,14 +24,6 @@ HvpWriteLog(
     ULONG LastIndex;
     PVOID BlockPtr;
     BOOLEAN Success;
-    static ULONG PrintCount = 0;
-
-    if (PrintCount++ == 0)
-    {
-        UNIMPLEMENTED;
-    }
-    return TRUE;
-
     ASSERT(RegistryHive->ReadOnly == FALSE);
     ASSERT(RegistryHive->BaseBlock->Length ==
            RegistryHive->Storage[Stable].Length * HBLOCK_SIZE);
@@ -139,7 +133,7 @@ HvpWriteLog(
     {
         DPRINT("FileFlush failed\n");
     }
-
+#endif // UNIMPLEMENTED
     return TRUE;
 }
 


### PR DESCRIPTION

## Purpose

allows to get rid of static var PrintCount, at least visually in the code

JIRA issue: none
