### PR TITLE
[ACLUI] Let image list be automatically deleted

### DIFF
--- a/dll/win32/aclui/aclui.c
+++ b/dll/win32/aclui/aclui.c
@@ -87,11 +87,6 @@ AceHeaderToSID(IN PACE_HEADER AceHeader)
 static VOID
 DestroySecurityPage(IN PSECURITY_PAGE sp)
 {
-    if(sp->hiPrincipals != NULL)
-    {
-        ImageList_Destroy(sp->hiPrincipals);
-    }
-
     DestroySidCacheMgr(sp->SidCacheMgr);
 
     if (sp->OwnerSid != NULL)


### PR DESCRIPTION
## Purpose

Based on KRosUser's `aclui.patch`. The list view will automatically delete the image list.
JIRA issue: [CORE-19187](https://jira.reactos.org/browse/CORE-19187)

## Proposed changes

- Don't delete the image list in `DestroySecurityPage` function.

## TODO

- [x] Do tests.