### PR TITLE
[ACCESS] Improve IDC_RESET_COMBO selection

### DIFF
--- a/dll/cpl/access/general.c
+++ b/dll/cpl/access/general.c
@@ -196,7 +196,7 @@ GeneralPageProc(HWND hwndDlg,
                            IDC_RESET_BOX,
                            pGlobalData->accessTimeout.dwFlags & ATF_TIMEOUTON ? BST_CHECKED : BST_UNCHECKED);
             FillResetComboBox(GetDlgItem(hwndDlg, IDC_RESET_COMBO));
-            pGlobalData->accessTimeout.iTimeOutMSec = max(pGlobalData->accessTimeout.iTimeOutMSec, FIVE_MINS_IN_MS);
+            pGlobalData->accessTimeout.iTimeOutMSec = max(FIVE_MINS_IN_MS, pGlobalData->accessTimeout.iTimeOutMSec);
             iCurSel = (pGlobalData->accessTimeout.iTimeOutMSec / FIVE_MINS_IN_MS) - 1;
             SendDlgItemMessage(hwndDlg, IDC_RESET_COMBO, CB_SETCURSEL, iCurSel, 0);
             EnableWindow(GetDlgItem(hwndDlg, IDC_RESET_COMBO),

--- a/dll/cpl/access/general.c
+++ b/dll/cpl/access/general.c
@@ -236,7 +236,7 @@ GeneralPageProc(HWND hwndDlg,
                     {
                         INT nSel;
                         nSel = SendDlgItemMessage(hwndDlg, IDC_RESET_COMBO, CB_GETCURSEL, 0, 0);
-                        pGlobalData->accessTimeout.iTimeOutMSec = (ULONG)((nSel + 1) * FIVE_MINS_IN_MS);
+                        pGlobalData->accessTimeout.iTimeOutMSec = (DWORD)((nSel + 1) * FIVE_MINS_IN_MS);
                         PropSheet_Changed(GetParent(hwndDlg), hwndDlg);
                     }
                     break;

--- a/dll/cpl/access/general.c
+++ b/dll/cpl/access/general.c
@@ -12,6 +12,7 @@
 #define BAUDTICKS 6
 static UINT nBaudArray[BAUDTICKS] = {300, 1200, 2400, 4800, 9600, 19200};
 
+#define FIVE_MINS_IN_MS (5 * 60 * 1000)
 
 INT_PTR CALLBACK
 SerialKeysDlgProc(HWND hwndDlg,
@@ -195,8 +196,7 @@ GeneralPageProc(HWND hwndDlg,
                            IDC_RESET_BOX,
                            pGlobalData->accessTimeout.dwFlags & ATF_TIMEOUTON ? BST_CHECKED : BST_UNCHECKED);
             FillResetComboBox(GetDlgItem(hwndDlg, IDC_RESET_COMBO));
-#define FIVE_MINS_IN_MS (5 * 60 * 1000)
-            pGlobalData->accessTimeout.iTimeOutMSec = max(FIVE_MINS_IN_MS, pGlobalData->accessTimeout.iTimeOutMSec);
+            pGlobalData->accessTimeout.iTimeOutMSec = max(pGlobalData->accessTimeout.iTimeOutMSec, FIVE_MINS_IN_MS);
             iCurSel = (pGlobalData->accessTimeout.iTimeOutMSec / FIVE_MINS_IN_MS) - 1;
             SendDlgItemMessage(hwndDlg, IDC_RESET_COMBO, CB_SETCURSEL, iCurSel, 0);
             EnableWindow(GetDlgItem(hwndDlg, IDC_RESET_COMBO),
@@ -236,7 +236,7 @@ GeneralPageProc(HWND hwndDlg,
                     {
                         INT nSel;
                         nSel = SendDlgItemMessage(hwndDlg, IDC_RESET_COMBO, CB_GETCURSEL, 0, 0);
-                        pGlobalData->accessTimeout.iTimeOutMSec = (ULONG)((nSel + 1) * 300000);
+                        pGlobalData->accessTimeout.iTimeOutMSec = (ULONG)((nSel + 1) * FIVE_MINS_IN_MS);
                         PropSheet_Changed(GetParent(hwndDlg), hwndDlg);
                     }
                     break;

--- a/dll/cpl/access/general.c
+++ b/dll/cpl/access/general.c
@@ -198,8 +198,7 @@ GeneralPageProc(HWND hwndDlg,
             iCurSel = (pGlobalData->accessTimeout.iTimeOutMSec / 300000) - 1;
             if (iCurSel < 0)
                 iCurSel = 0;
-            SendDlgItemMessage(hwndDlg, IDC_RESET_COMBO, CB_SETCURSEL,
-                               iCurSel, 0);
+            SendDlgItemMessage(hwndDlg, IDC_RESET_COMBO, CB_SETCURSEL, iCurSel, 0);
             EnableWindow(GetDlgItem(hwndDlg, IDC_RESET_COMBO),
                          pGlobalData->accessTimeout.dwFlags & ATF_TIMEOUTON ? TRUE : FALSE);
 

--- a/dll/cpl/access/general.c
+++ b/dll/cpl/access/general.c
@@ -196,7 +196,7 @@ GeneralPageProc(HWND hwndDlg,
                            pGlobalData->accessTimeout.dwFlags & ATF_TIMEOUTON ? BST_CHECKED : BST_UNCHECKED);
             FillResetComboBox(GetDlgItem(hwndDlg, IDC_RESET_COMBO));
 #define FIVE_MINS_IN_MS (5 * 60 * 1000)
-            pGlobalData->accessTimeout.iTimeOutMSec = max(pGlobalData->accessTimeout.iTimeOutMSec, FIVE_MINS_IN_MS);
+            pGlobalData->accessTimeout.iTimeOutMSec = max(FIVE_MINS_IN_MS, pGlobalData->accessTimeout.iTimeOutMSec);
             iCurSel = (pGlobalData->accessTimeout.iTimeOutMSec / FIVE_MINS_IN_MS) - 1;
             SendDlgItemMessage(hwndDlg, IDC_RESET_COMBO, CB_SETCURSEL, iCurSel, 0);
             EnableWindow(GetDlgItem(hwndDlg, IDC_RESET_COMBO),

--- a/dll/cpl/access/general.c
+++ b/dll/cpl/access/general.c
@@ -177,7 +177,7 @@ GeneralPageProc(HWND hwndDlg,
 {
     PGLOBAL_DATA pGlobalData;
     LPPSHNOTIFY lppsn;
-    int iCurSel;
+    INT iCurSel;
 
     pGlobalData = (PGLOBAL_DATA)GetWindowLongPtr(hwndDlg, DWLP_USER);
 

--- a/dll/cpl/access/general.c
+++ b/dll/cpl/access/general.c
@@ -195,8 +195,9 @@ GeneralPageProc(HWND hwndDlg,
                            IDC_RESET_BOX,
                            pGlobalData->accessTimeout.dwFlags & ATF_TIMEOUTON ? BST_CHECKED : BST_UNCHECKED);
             FillResetComboBox(GetDlgItem(hwndDlg, IDC_RESET_COMBO));
-            pGlobalData->accessTimeout.iTimeOutMSec = max(pGlobalData->accessTimeout.iTimeOutMSec, 300000);
-            iCurSel = (pGlobalData->accessTimeout.iTimeOutMSec / 300000) - 1;
+#define FIVE_MINS_IN_MS (5 * 60 * 1000)
+            pGlobalData->accessTimeout.iTimeOutMSec = max(pGlobalData->accessTimeout.iTimeOutMSec, FIVE_MINS_IN_MS);
+            iCurSel = (pGlobalData->accessTimeout.iTimeOutMSec / FIVE_MINS_IN_MS) - 1;
             SendDlgItemMessage(hwndDlg, IDC_RESET_COMBO, CB_SETCURSEL, iCurSel, 0);
             EnableWindow(GetDlgItem(hwndDlg, IDC_RESET_COMBO),
                          pGlobalData->accessTimeout.dwFlags & ATF_TIMEOUTON ? TRUE : FALSE);

--- a/dll/cpl/access/general.c
+++ b/dll/cpl/access/general.c
@@ -177,6 +177,7 @@ GeneralPageProc(HWND hwndDlg,
 {
     PGLOBAL_DATA pGlobalData;
     LPPSHNOTIFY lppsn;
+    int iCurSel;
 
     pGlobalData = (PGLOBAL_DATA)GetWindowLongPtr(hwndDlg, DWLP_USER);
 
@@ -194,8 +195,11 @@ GeneralPageProc(HWND hwndDlg,
                            IDC_RESET_BOX,
                            pGlobalData->accessTimeout.dwFlags & ATF_TIMEOUTON ? BST_CHECKED : BST_UNCHECKED);
             FillResetComboBox(GetDlgItem(hwndDlg, IDC_RESET_COMBO));
+            iCurSel = (pGlobalData->accessTimeout.iTimeOutMSec / 300000) - 1;
+            if (iCurSel < 0)
+                iCurSel = 0;
             SendDlgItemMessage(hwndDlg, IDC_RESET_COMBO, CB_SETCURSEL,
-                               (pGlobalData->accessTimeout.iTimeOutMSec / 300000) - 1, 0);
+                               iCurSel, 0);
             EnableWindow(GetDlgItem(hwndDlg, IDC_RESET_COMBO),
                          pGlobalData->accessTimeout.dwFlags & ATF_TIMEOUTON ? TRUE : FALSE);
 

--- a/dll/cpl/access/general.c
+++ b/dll/cpl/access/general.c
@@ -195,9 +195,8 @@ GeneralPageProc(HWND hwndDlg,
                            IDC_RESET_BOX,
                            pGlobalData->accessTimeout.dwFlags & ATF_TIMEOUTON ? BST_CHECKED : BST_UNCHECKED);
             FillResetComboBox(GetDlgItem(hwndDlg, IDC_RESET_COMBO));
+            pGlobalData->accessTimeout.iTimeOutMSec = max(pGlobalData->accessTimeout.iTimeOutMSec, 300000);
             iCurSel = (pGlobalData->accessTimeout.iTimeOutMSec / 300000) - 1;
-            if (iCurSel < 0)
-                iCurSel = 0;
             SendDlgItemMessage(hwndDlg, IDC_RESET_COMBO, CB_SETCURSEL, iCurSel, 0);
             EnableWindow(GetDlgItem(hwndDlg, IDC_RESET_COMBO),
                          pGlobalData->accessTimeout.dwFlags & ATF_TIMEOUTON ? TRUE : FALSE);


### PR DESCRIPTION
## Purpose

Based on KRosUser's `access.patch`.
JIRA issue: [CORE-19303](https://jira.reactos.org/browse/CORE-19303)

## Proposed changes

- Anyway select something at `IDC_RESET_COMBO` combo box.

## TODO

- [x] Do tests.