### PR TITLE
[CALC] Adapt to <strsafe.h>

### DIFF
--- a/base/applications/calc/calc.h
+++ b/base/applications/calc/calc.h
@@ -15,6 +15,7 @@
 #include <htmlhelp.h>
 #endif
 #include <limits.h>
+#include <strsafe.h>
 
 /* RESOURCES */
 #include "resource.h"

--- a/base/applications/calc/utl_ieee.c
+++ b/base/applications/calc/utl_ieee.c
@@ -27,7 +27,7 @@ void prepare_rpn_result_2(calc_number_t *rpn, TCHAR *buffer, int size, int base)
 
     switch (base) {
     case IDC_RADIO_HEX:
-        _stprintf(buffer, _T("%I64X"), rpn->i);
+        StringCbPrintf(buffer, sizeof(buffer), _T("%I64X"), rpn->i);
         break;
     case IDC_RADIO_DEC:
 /*
@@ -40,11 +40,12 @@ void prepare_rpn_result_2(calc_number_t *rpn, TCHAR *buffer, int size, int base)
         /* calculate the width of integer number */
         width = (rpn->f==0) ? 1 : (int)log10(fabs(rpn->f))+1;
         if (calc.sci_out == TRUE || width > MAX_LD_WIDTH || width < -MAX_LD_WIDTH)
-            _stprintf(buffer, _T("%#.*e"), MAX_LD_WIDTH-1, rpn->f);
+            StringCbPrintf(buffer, sizeof(buffer), _T("%#.*e"), MAX_LD_WIDTH-1, rpn->f);
         else {
             TCHAR *ptr, *dst;
 
-            ptr = buffer + _stprintf(buffer, _T("%#*.*f"), width, ((MAX_LD_WIDTH-width-1)>=0) ? MAX_LD_WIDTH-width-1 : 0, rpn->f);
+            StringCbPrintf(buffer, sizeof(buffer), _T("%#*.*f"), width, ((MAX_LD_WIDTH-width-1)>=0) ? MAX_LD_WIDTH-width-1 : 0, rpn->f);
+            ptr = buffer + wcslen(buffer);
             /* format string ensures there is a '.': */
             dst = _tcschr(buffer, _T('.'));
             while (--ptr > dst)
@@ -61,7 +62,7 @@ void prepare_rpn_result_2(calc_number_t *rpn, TCHAR *buffer, int size, int base)
 #undef MAX_LD_WIDTH
         break;
     case IDC_RADIO_OCT:
-        _stprintf(buffer, _T("%I64o"), rpn->i);
+        StringCbPrintf(buffer, sizeof(buffer), _T("%I64o"), rpn->i);
         break;
     case IDC_RADIO_BIN:
         if (rpn->i == 0) {

--- a/base/applications/calc/utl_ieee.c
+++ b/base/applications/calc/utl_ieee.c
@@ -27,7 +27,7 @@ void prepare_rpn_result_2(calc_number_t *rpn, TCHAR *buffer, int size, int base)
 
     switch (base) {
     case IDC_RADIO_HEX:
-        StringCbPrintf(buffer, sizeof(buffer), _T("%I64X"), rpn->i);
+        StringCchPrintf(buffer, size, _T("%I64X"), rpn->i);
         break;
     case IDC_RADIO_DEC:
 /*
@@ -40,11 +40,11 @@ void prepare_rpn_result_2(calc_number_t *rpn, TCHAR *buffer, int size, int base)
         /* calculate the width of integer number */
         width = (rpn->f==0) ? 1 : (int)log10(fabs(rpn->f))+1;
         if (calc.sci_out == TRUE || width > MAX_LD_WIDTH || width < -MAX_LD_WIDTH)
-            StringCbPrintf(buffer, sizeof(buffer), _T("%#.*e"), MAX_LD_WIDTH-1, rpn->f);
+            StringCchPrintf(buffer, size, _T("%#.*e"), MAX_LD_WIDTH-1, rpn->f);
         else {
             TCHAR *ptr, *dst;
 
-            StringCbPrintf(buffer, sizeof(buffer), _T("%#*.*f"), width, ((MAX_LD_WIDTH-width-1)>=0) ? MAX_LD_WIDTH-width-1 : 0, rpn->f);
+            StringCchPrintf(buffer, size, _T("%#*.*f"), width, ((MAX_LD_WIDTH-width-1)>=0) ? MAX_LD_WIDTH-width-1 : 0, rpn->f);
             ptr = buffer + _tcslen(buffer);
             /* format string ensures there is a '.': */
             dst = _tcschr(buffer, _T('.'));
@@ -62,7 +62,7 @@ void prepare_rpn_result_2(calc_number_t *rpn, TCHAR *buffer, int size, int base)
 #undef MAX_LD_WIDTH
         break;
     case IDC_RADIO_OCT:
-        StringCbPrintf(buffer, sizeof(buffer), _T("%I64o"), rpn->i);
+        StringCchPrintf(buffer, size, _T("%I64o"), rpn->i);
         break;
     case IDC_RADIO_BIN:
         if (rpn->i == 0) {

--- a/base/applications/calc/utl_ieee.c
+++ b/base/applications/calc/utl_ieee.c
@@ -45,7 +45,7 @@ void prepare_rpn_result_2(calc_number_t *rpn, TCHAR *buffer, int size, int base)
             TCHAR *ptr, *dst;
 
             StringCbPrintf(buffer, sizeof(buffer), _T("%#*.*f"), width, ((MAX_LD_WIDTH-width-1)>=0) ? MAX_LD_WIDTH-width-1 : 0, rpn->f);
-            ptr = buffer + wcslen(buffer);
+            ptr = buffer + _tcslen(buffer);
             /* format string ensures there is a '.': */
             dst = _tcschr(buffer, _T('.'));
             while (--ptr > dst)

--- a/base/applications/calc/utl_ieee.c
+++ b/base/applications/calc/utl_ieee.c
@@ -44,8 +44,7 @@ void prepare_rpn_result_2(calc_number_t *rpn, TCHAR *buffer, int size, int base)
         else {
             TCHAR *ptr, *dst;
 
-            StringCchPrintf(buffer, size, _T("%#*.*f"), width, ((MAX_LD_WIDTH-width-1)>=0) ? MAX_LD_WIDTH-width-1 : 0, rpn->f);
-            ptr = buffer + _tcslen(buffer);
+            StringCchPrintfEx(buffer, size, &ptr, NULL, 0, _T("%#*.*f"), width, ((MAX_LD_WIDTH-width-1)>=0) ? MAX_LD_WIDTH-width-1 : 0, rpn->f);
             /* format string ensures there is a '.': */
             dst = _tcschr(buffer, _T('.'));
             while (--ptr > dst)

--- a/base/applications/calc/utl_mpfr.c
+++ b/base/applications/calc/utl_mpfr.c
@@ -107,7 +107,7 @@ void prepare_rpn_result_2(calc_number_t *rpn, TCHAR *buffer, int size, int base)
     }
     mpz_clear(zz);
     mpf_clear(ff);
-    _sntprintf(buffer, SIZEOF(calc.buffer), _T("%hs"), temp);
+    StringCbPrintf(buffer, sizeof(calc.buffer), _T("%hs"), temp);
 }
 
 void convert_text2number_2(calc_number_t *a)

--- a/base/applications/calc/utl_mpfr.c
+++ b/base/applications/calc/utl_mpfr.c
@@ -107,7 +107,7 @@ void prepare_rpn_result_2(calc_number_t *rpn, TCHAR *buffer, int size, int base)
     }
     mpz_clear(zz);
     mpf_clear(ff);
-    StringCbPrintf(buffer, sizeof(calc.buffer), _T("%hs"), temp);
+    StringCchPrintf(buffer, size, _T("%hs"), temp);
 }
 
 void convert_text2number_2(calc_number_t *a)

--- a/base/applications/calc/winmain.c
+++ b/base/applications/calc/winmain.c
@@ -505,7 +505,7 @@ static void update_lcd_display(HWND hwnd)
      */
     if (calc.base == IDC_RADIO_DEC && !calc.is_nan) {
         if (_tcschr(tmp, _T('.')) == NULL)
-            _tcscat(tmp, _T("."));
+            StringCbCat(tmp, sizeof(tmp), _T("."));
     }
     /* if separator mode is on, let's add an additional space */
     if (calc.usesep && !calc.sci_in && !calc.sci_out && !calc.is_nan) {

--- a/base/applications/calc/winmain.c
+++ b/base/applications/calc/winmain.c
@@ -645,7 +645,7 @@ static void build_operand(HWND hwnd, DWORD idc)
 
     StringCbPrintf(calc.ptr, cbPtr, _T("%C"), key2code[i].key);
 
-    calc.ptr += wcslen(calc.ptr);
+    calc.ptr += _tcslen(calc.ptr);
     update_lcd_display(hwnd);
 }
 

--- a/base/applications/calc/winmain.c
+++ b/base/applications/calc/winmain.c
@@ -642,9 +642,9 @@ static void build_operand(HWND hwnd, DWORD idc)
     }
 
     cbPtr = sizeof(calc.buffer) - ((BYTE*)calc.ptr - (BYTE*)calc.buffer);
-    StringCbPrintf(calc.ptr, cbPtr, _T("%C"), key2code[i].key);
+    StringCbPrintfEx(calc.ptr, cbPtr, &calc.ptr, NULL, STRSAFE_FILL_ON_FAILURE,
+                     _T("%C"), key2code[i].key);
 
-    calc.ptr += _tcslen(calc.ptr);
     update_lcd_display(hwnd);
 }
 
@@ -1065,8 +1065,8 @@ static char *handle_sequence_input(HWND hwnd, sequence_t *seq)
         }
     } else
     if (ch == '$') {
-        StringCbCopy(calc.buffer, sizeof(calc.buffer), calc.source);
-        calc.ptr = calc.buffer + _tcslen(calc.source);
+        StringCbCopyEx(calc.buffer, sizeof(calc.buffer), calc.source, &calc.ptr, NULL,
+                       STRSAFE_FILL_ON_FAILURE);
     } else {
         for (x=0; x<SIZEOF(key2code); x++) {
             if (!(key2code[x].mask & BITMASK_IS_ASCII) ||

--- a/base/applications/calc/winmain.c
+++ b/base/applications/calc/winmain.c
@@ -642,7 +642,6 @@ static void build_operand(HWND hwnd, DWORD idc)
     }
 
     cbPtr = sizeof(calc.buffer) - ((BYTE*)calc.ptr - (BYTE*)calc.buffer);
-
     StringCbPrintf(calc.ptr, cbPtr, _T("%C"), key2code[i].key);
 
     calc.ptr += _tcslen(calc.ptr);

--- a/base/applications/calc/winmain.c
+++ b/base/applications/calc/winmain.c
@@ -254,10 +254,10 @@ static void UpdateNumberIntl(void)
 {
     /* Get current user defaults */
     if (!GetLocaleInfo(LOCALE_USER_DEFAULT, LOCALE_SDECIMAL, calc.sDecimal, SIZEOF(calc.sDecimal)))
-        _tcscpy(calc.sDecimal, _T("."));
+        StringCbCopy(calc.sDecimal, sizeof(calc.sDecimal), _T("."));
 
     if (!GetLocaleInfo(LOCALE_USER_DEFAULT, LOCALE_STHOUSAND, calc.sThousand, SIZEOF(calc.sThousand)))
-        _tcscpy(calc.sThousand, _T(","));
+        StringCbCopy(calc.sThousand, sizeof(calc.sThousand), _T(","));
 
     /* get the string lengths */
     calc.sDecimal_len = _tcslen(calc.sDecimal);
@@ -342,7 +342,7 @@ static void save_config(void)
     switch (osvi.dwPlatformId) {
     case VER_PLATFORM_WIN32s:
     case VER_PLATFORM_WIN32_WINDOWS:
-        _stprintf(buf, _T("%lu"), calc.layout);
+        StringCbPrintf(buf, sizeof(buf), _T("%lu"), calc.layout);
         WriteProfileString(_T("SciCalc"), _T("layout"), buf);
         WriteProfileString(_T("SciCalc"), _T("UseSep"), (calc.usesep==TRUE) ? _T("1") : _T("0"));
         break;
@@ -496,9 +496,9 @@ static void update_lcd_display(HWND hwnd)
     TCHAR tmp[MAX_CALC_SIZE * 2 + 2];
 
     if (calc.buffer[0] == _T('\0'))
-        _tcscpy(tmp, _T("0"));
+        StringCbCopy(tmp, sizeof(tmp), _T("0"));
     else
-        _tcscpy(tmp, calc.buffer);
+        StringCbCopy(tmp, sizeof(tmp), calc.buffer);
 
     /* Add final '.' in decimal mode (if it's missing), but
      * only if it's a result: no append if it prints "ERROR".
@@ -573,13 +573,14 @@ static void update_parent_display(HWND hWnd)
     if (!n)
         str[0] = _T('\0');
     else
-        _stprintf(str,_T("(=%d"), n);
+        StringCbPrintf(str, sizeof(str), _T("(=%d"), n);
     SetDlgItemText(hWnd, IDC_TEXT_PARENT, str);
 }
 
 static void build_operand(HWND hwnd, DWORD idc)
 {
     unsigned int i = 0, n;
+    size_t cbPtr;
 
     if (idc == IDC_BUTTON_DOT) {
         /* if dot is the first char, it's added automatically */
@@ -617,12 +618,14 @@ static void build_operand(HWND hwnd, DWORD idc)
             if (idc != IDC_STATIC)
                 calc.esp = (calc.esp * 10 + (key2code[i].key-'0')) % LOCAL_EXP_SIZE;
             if (calc.ptr == calc.buffer)
-                _stprintf(calc.ptr, _T("0.e%+d"), calc.esp);
+                StringCbPrintf(calc.ptr, sizeof(calc.buffer), _T("0.e%+d"), calc.esp);
             else {
                 /* adds the dot at the end if the number has no decimal part */
                 if (!_tcschr(calc.buffer, _T('.')))
                     *calc.ptr++ = _T('.');
-                _stprintf(calc.ptr, _T("e%+d"), calc.esp);
+
+                cbPtr = sizeof(calc.buffer) - ((BYTE*)calc.ptr - (BYTE*)calc.buffer);
+                StringCbPrintf(calc.ptr, cbPtr, _T("e%+d"), calc.esp);
             }
             update_lcd_display(hwnd);
             return;
@@ -637,7 +640,12 @@ static void build_operand(HWND hwnd, DWORD idc)
             return;
         break;
     }
-    calc.ptr += _stprintf(calc.ptr, _T("%C"), key2code[i].key);
+
+    cbPtr = sizeof(calc.buffer) - ((BYTE*)calc.ptr - (BYTE*)calc.buffer);
+
+    StringCbPrintf(calc.ptr, cbPtr, _T("%C"), key2code[i].key);
+
+    calc.ptr += wcslen(calc.ptr);
     update_lcd_display(hwnd);
 }
 
@@ -850,11 +858,11 @@ static void update_memory_flag(HWND hWnd, BOOL mem_flag)
     SetDlgItemText(hWnd, IDC_TEXT_MEMORY, mem_flag ? _T("M") : _T(""));
 }
 
-static void update_n_stats_items(HWND hWnd, TCHAR *buffer)
+static void update_n_stats_items(HWND hWnd, TCHAR *buffer, size_t cbBuffer)
 {
     unsigned int n = SendDlgItemMessage(hWnd, IDC_LIST_STAT, LB_GETCOUNT, 0, 0);
 
-    _stprintf(buffer, _T("n=%u"), n);
+    StringCbPrintf(buffer, cbBuffer, _T("n=%u"), n);
     SetDlgItemText(hWnd, IDC_TEXT_NITEMS, buffer);
 }
 
@@ -905,7 +913,7 @@ static char *ReadConversion(const char *formula)
     str[len+1] = ')';
     str[len+2] = '\0';
 
-    _tcscpy(calc.source, (*calc.buffer == _T('\0')) ? _T("0") : calc.buffer);
+    StringCbCopy(calc.source, sizeof(calc.source), (*calc.buffer == _T('\0')) ? _T("0") : calc.buffer);
 
     /* clear display content before proceeding */
     calc.ptr = calc.buffer;
@@ -942,13 +950,13 @@ static INT_PTR CALLBACK DlgStatProc(HWND hWnd, UINT msg, WPARAM wp, LPARAM lp)
             if (n == LB_ERR)
                 return TRUE;
             SendDlgItemMessage(hWnd, IDC_LIST_STAT, LB_DELETESTRING, (WPARAM)n, 0);
-            update_n_stats_items(hWnd, buffer);
+            update_n_stats_items(hWnd, buffer, sizeof(buffer));
             delete_stat_item(n);
             return TRUE;
         case IDC_BUTTON_CAD:
             SendDlgItemMessage(hWnd, IDC_LIST_STAT, LB_RESETCONTENT, 0, 0);
             clean_stat_list();
-            update_n_stats_items(hWnd, buffer);
+            update_n_stats_items(hWnd, buffer, sizeof(buffer));
             return TRUE;
         }
         break;
@@ -964,7 +972,7 @@ static INT_PTR CALLBACK DlgStatProc(HWND hWnd, UINT msg, WPARAM wp, LPARAM lp)
                            buffer, SIZEOF(buffer),
                            ((statistic_t *)lp)->base);
         SendDlgItemMessage(hWnd, IDC_LIST_STAT, LB_ADDSTRING, 0, (LPARAM)buffer);
-        update_n_stats_items(hWnd, buffer);
+        update_n_stats_items(hWnd, buffer, sizeof(buffer));
         return TRUE;
     }
     return FALSE;
@@ -986,11 +994,13 @@ static void CopyMemToClipboard(void *ptr)
     if(OpenClipboard(NULL)) {
         HGLOBAL  clipbuffer;
         TCHAR   *buffer;
+        size_t cbBuffer;
 
         EmptyClipboard();
-        clipbuffer = GlobalAlloc(GMEM_DDESHARE, (_tcslen(ptr)+1)*sizeof(TCHAR));
+        cbBuffer = (_tcslen(ptr) + 1) * sizeof(TCHAR);
+        clipbuffer = GlobalAlloc(GMEM_DDESHARE, cbBuffer);
         buffer = (TCHAR *)GlobalLock(clipbuffer);
-        _tcscpy(buffer, ptr);
+        StringCbCopy(buffer, cbBuffer, ptr);
         GlobalUnlock(clipbuffer);
 #ifdef UNICODE
         SetClipboardData(CF_UNICODETEXT,clipbuffer);
@@ -1056,9 +1066,8 @@ static char *handle_sequence_input(HWND hwnd, sequence_t *seq)
         }
     } else
     if (ch == '$') {
-        calc.ptr =
-        _tcscpy(calc.buffer, calc.source) +
-        _tcslen(calc.source);
+        StringCbCopy(calc.buffer, sizeof(calc.buffer), calc.source);
+        calc.ptr = calc.buffer + _tcslen(calc.source);
     } else {
         for (x=0; x<SIZEOF(key2code); x++) {
             if (!(key2code[x].mask & BITMASK_IS_ASCII) ||


### PR DESCRIPTION
## Purpose

Use safer string functions.
JIRA issue: [CORE-19306](https://jira.reactos.org/browse/CORE-19306)

## Proposed changes

- `#include <strsafe.h>`
- Use `StringCbPrintf` instead of `_stprintf`.
- Use `StringCbCopy` insteaad of `_tcscpy`.
- Use `StringCbCat` instead of `_tcscat`.

## TODO

- [x] Do tests.