### PR TITLE
Winesync.py Script: Diverse improvements

### DIFF
--- a/sdk/tools/winesync/winesync.py
+++ b/sdk/tools/winesync/winesync.py
@@ -64,10 +64,14 @@ class wine_sync:
             wine_target_commit = self.wine_repo.revparse_single(wine_tag)
             if isinstance(wine_target_commit, pygit2.Tag):
                 wine_target_commit = wine_target_commit.target
+            if isinstance(wine_target_commit, pygit2.Commit):
+                wine_target_commit = wine_target_commit.id
 
             wine_staging_target_commit = self.wine_staging_repo.revparse_single(wine_staging_tag)
             if isinstance(wine_staging_target_commit, pygit2.Tag):
                 wine_staging_target_commit = wine_staging_target_commit.target
+            if isinstance(wine_staging_target_commit, pygit2.Commit):
+                wine_staging_target_commit = wine_staging_target_commit.id
 
             self.wine_repo.branches.local.create(wine_branch_name, self.wine_repo.revparse_single('HEAD'))
             self.wine_repo.checkout(self.wine_repo.lookup_branch(wine_branch_name))
@@ -306,16 +310,18 @@ class wine_sync:
         wine_target_commit = self.wine_repo.revparse_single(wine_tag)
         if isinstance(wine_target_commit, pygit2.Tag):
             wine_target_commit = wine_target_commit.target
+        if isinstance(wine_target_commit, pygit2.Commit):
+            wine_target_commit = wine_target_commit.id
         # print(f'wine target commit is {wine_target_commit}')
 
         # get the wine commit id where we left
         in_staging = False
         wine_last_sync = self.wine_repo.revparse_single(self.module_cfg['tags']['wine'])
-        if (isinstance(wine_last_sync, pygit2.Tag)):
+        if isinstance(wine_last_sync, pygit2.Tag):
             if not self.revert_staged_patchset():
                 return
             wine_last_sync = wine_last_sync.target
-        if (isinstance(wine_last_sync, pygit2.Commit)):
+        if isinstance(wine_last_sync, pygit2.Commit):
             wine_last_sync = wine_last_sync.id
 
         # create a branch to keep things clean

--- a/sdk/tools/winesync/winesync.py
+++ b/sdk/tools/winesync/winesync.py
@@ -137,7 +137,8 @@ class wine_sync:
         if in_staging:
             # see if we already applied this patch
             patch_file_name = f'{staging_patch_index:04}-{string_to_valid_file_name(wine_commit.message.splitlines()[0])}.diff'
-            patch_path = os.path.join(self.reactos_src, self.staged_patch_dir, patch_file_name)
+            patch_dir = os.path.join(self.reactos_src, self.staged_patch_dir)
+            patch_path = os.path.join(patch_dir, patch_file_name)
             if os.path.isfile(patch_path):
                 print(f'Skipping patch as {patch_path} already exists')
                 return True, ''
@@ -234,8 +235,8 @@ class wine_sync:
         else:
             # Add the staging patch
             # do not save the wine commit ID in <module>.cfg, as it's a local one for staging patches
-            if not os.path.isdir(os.path.join(self.reactos_src, self.staged_patch_dir)):
-                os.mkdir(os.path.join(self.reactos_src, self.staged_patch_dir))
+            if not os.path.isdir(patch_dir):
+                os.mkdir(patch_dir)
             with open(patch_path, 'w') as file_output:
                 file_output.write(complete_patch)
             self.reactos_index.add(posixpath.join(self.staged_patch_dir, patch_file_name))
@@ -264,11 +265,12 @@ class wine_sync:
                     f'You can see the details of the wine commit here:\n' \
                     f'    https://source.winehq.org/git/wine.git/commit/{str(wine_commit.id)}\n'
             else:
+                patch_file_path = posixpath.join(self.staged_patch_dir, patch_file_name)
                 warning_message += f'\n' \
                     f'Do not forget to run\n' \
-                    f'    git diff HEAD^ \':(exclude)sdk/tools/winesync/{patch_file_name}\' > sdk/tools/winesync/{patch_file_name}\n' \
+                    f'    git diff HEAD^ \':(exclude){patch_file_path}\' > {patch_file_path}\n' \
                     f'after your correction and then\n' \
-                    f'    git add sdk/tools/winesync/{patch_file_name}\n' \
+                    f'    git add {patch_file_path}\n' \
                     f'before running "git commit --amend"'
 
         return True, warning_message

--- a/sdk/tools/winesync/winesync.py
+++ b/sdk/tools/winesync/winesync.py
@@ -290,7 +290,7 @@ class wine_sync:
 
             with open(patch_path, 'rb') as patch_file:
                 try:
-                    subprocess.run(['git', '-C', self.reactos_src, 'apply', '-R', '--reject'], stdin=patch_file, check=True)
+                    subprocess.run(['git', '-C', self.reactos_src, 'apply', '-R', '--ignore-whitespace', '--reject'], stdin=patch_file, check=True)
                 except subprocess.CalledProcessError as err:
                     print(f'Error while reverting patch {patch_file_name}')
                     print('Please check, remove the offending patch with git rm, and relaunch this script')

--- a/sdk/tools/winesync/winesync.py
+++ b/sdk/tools/winesync/winesync.py
@@ -46,6 +46,9 @@ class wine_sync:
         self.wine_staging_repo = pygit2.Repository(self.wine_staging_src)
         self.reactos_repo = pygit2.Repository(self.reactos_src)
 
+        # the standard author signature we will use
+        self.winesync_author_signature = pygit2.Signature('winesync', 'ros-dev@reactos.org')
+
         # read the index from the reactos tree
         self.reactos_index = self.reactos_repo.index
         self.reactos_index.read()
@@ -245,8 +248,9 @@ class wine_sync:
         else:
             commit_msg += f'wine commit id {str(wine_commit.id)} by {wine_commit.author.name} <{wine_commit.author.email}>'
 
-        self.reactos_repo.create_commit('HEAD',
-            pygit2.Signature('winesync', 'ros-dev@reactos.org'),
+        self.reactos_repo.create_commit(
+            'HEAD',
+            self.winesync_author_signature,
             self.reactos_repo.default_signature,
             commit_msg,
             self.reactos_index.write_tree(),
@@ -310,7 +314,7 @@ class wine_sync:
 
         self.reactos_repo.create_commit(
             'HEAD',
-            self.reactos_repo.default_signature,
+            self.winesync_author_signature,
             self.reactos_repo.default_signature,
             f'[WINESYNC]: revert wine-staging patchset for {self.module}',
             self.reactos_index.write_tree(),
@@ -376,7 +380,7 @@ class wine_sync:
             self.reactos_index.write()
             self.reactos_repo.create_commit(
                 'HEAD',
-                self.reactos_repo.default_signature,
+                self.winesync_author_signature,
                 self.reactos_repo.default_signature,
                 f'[WINESYNC]: {self.module} is now in sync with wine-staging {wine_tag}',
                 self.reactos_index.write_tree(),

--- a/sdk/tools/winesync/winesync.py
+++ b/sdk/tools/winesync/winesync.py
@@ -2,6 +2,7 @@
 
 import sys
 import os
+import posixpath
 import string
 import argparse
 import subprocess
@@ -54,7 +55,7 @@ class wine_sync:
         with open(module + '.cfg', 'r') as file_input:
             self.module_cfg = yaml.safe_load(file_input)
 
-        self.staged_patch_dir = os.path.join('sdk', 'tools', 'winesync', self.module + '_staging')
+        self.staged_patch_dir = posixpath.join('sdk', 'tools', 'winesync', self.module + '_staging')
 
     def create_or_checkout_wine_branch(self, wine_tag, wine_staging_tag):
         wine_branch_name = 'winesync-' + wine_tag + '-' + wine_staging_tag
@@ -110,7 +111,7 @@ class wine_sync:
         wine_dir, wine_file = os.path.split(wine_path)
         if wine_dir in self.module_cfg['directories']:
             # we have a mapping for the directory
-            return os.path.join(self.module_cfg['directories'][wine_dir], wine_file)
+            return posixpath.join(self.module_cfg['directories'][wine_dir], wine_file)
 
         # no match
         return None
@@ -228,7 +229,7 @@ class wine_sync:
                 os.mkdir(os.path.join(self.reactos_src, self.staged_patch_dir))
             with open(patch_path, 'w') as file_output:
                 file_output.write(complete_patch)
-            self.reactos_index.add(os.path.join(self.staged_patch_dir, patch_file_name))
+            self.reactos_index.add(posixpath.join(self.staged_patch_dir, patch_file_name))
 
         self.reactos_index.write()
 
@@ -264,7 +265,7 @@ class wine_sync:
 
     def revert_staged_patchset(self):
         # revert all of this in one commit
-        staged_patch_dir_path = os.path.join(self.reactos_src, self.staged_patch_dir)
+        staged_patch_dir_path = posixpath.join(self.reactos_src, self.staged_patch_dir)
         if not os.path.isdir(staged_patch_dir_path):
             return True
 
@@ -285,7 +286,7 @@ class wine_sync:
                     print('Please check, remove the offending patch with git rm, and relaunch this script')
                     return False
 
-            self.reactos_index.remove(os.path.join(self.staged_patch_dir, patch_file_name))
+            self.reactos_index.remove(posixpath.join(self.staged_patch_dir, patch_file_name))
             self.reactos_index.write()
             os.remove(patch_path)
 

--- a/sdk/tools/winesync/winesync.py
+++ b/sdk/tools/winesync/winesync.py
@@ -35,7 +35,7 @@ class wine_sync:
             self.reactos_src = input('Please enter the path to the reactos git tree: ')
             self.wine_src = input('Please enter the path to the wine git tree: ')
             self.wine_staging_src = input('Please enter the path to the wine-staging git tree: ')
-            config['repos'] = { 'reactos' : self.reactos_src,
+            config['repos'] = { 'reactos': self.reactos_src,
                                 'wine': self.wine_src,
                                 'wine-staging': self.wine_staging_src }
             with open('winesync.cfg', 'w') as file_output:
@@ -89,8 +89,8 @@ class wine_sync:
 
         return wine_branch_name
 
-    # helper function for resolving wine tree path to reactos one
-    # Note : it doesn't care about the fact that the file actually exists or not
+    # Helper function for resolving wine tree path to reactos one
+    # Note: it doesn't care about the fact that the file actually exists or not
     def wine_to_reactos_path(self, wine_path):
         if wine_path in self.module_cfg['files']:
             # we have a direct mapping
@@ -133,7 +133,7 @@ class wine_sync:
                 # check if we should care
                 new_reactos_path = self.wine_to_reactos_path(delta.new_file.path)
                 if not new_reactos_path is None:
-                    warning_message += 'file ' + delta.new_file.path + ' is added to the wine tree !\n'
+                    warning_message += 'file ' + delta.new_file.path + ' is added to the wine tree!\n'
                     old_reactos_path = '/dev/null'
                 else:
                     old_reactos_path = None
@@ -141,12 +141,12 @@ class wine_sync:
                 # check if we should care
                 old_reactos_path = self.wine_to_reactos_path(delta.old_file.path)
                 if not old_reactos_path is None:
-                    warning_message += 'file ' + delta.old_file.path + ' is removed from the wine tree !\n'
+                    warning_message += 'file ' + delta.old_file.path + ' is removed from the wine tree!\n'
                     new_reactos_path = '/dev/null'
                 else:
                     new_reactos_path = None
             elif delta.new_file.path.endswith('Makefile.in'):
-                warning_message += 'file ' + delta.new_file.path + ' was modified !\n'
+                warning_message += 'file ' + delta.new_file.path + ' was modified!\n'
                 # no need to warn that those are ignored, we just did.
                 continue
             else:
@@ -210,7 +210,7 @@ class wine_sync:
         print('Applied patches from wine commit ' + str(wine_commit.id))
 
         if ignored_files:
-            warning_message += 'WARNING : some files were ignored: ' + ' '.join(ignored_files) + '\n'
+            warning_message += 'WARNING: some files were ignored: ' + ' '.join(ignored_files) + '\n'
 
         if not in_staging:
             self.module_cfg['tags']['wine'] = str(wine_commit.id)

--- a/sdk/tools/winesync/winesync.py
+++ b/sdk/tools/winesync/winesync.py
@@ -84,7 +84,9 @@ class wine_sync:
             self.wine_staging_repo.reset(wine_staging_target_commit, pygit2.GIT_RESET_HARD)
 
             # run the wine-staging script
-            subprocess.call(['bash', '-c', self.wine_staging_src + '/patches/patchinstall.sh DESTDIR=' + self.wine_src + ' --all --backend=git-am'])
+            if subprocess.call(['python', self.wine_staging_src + '/staging/patchinstall.py', 'DESTDIR=' + self.wine_src, '--all', '--backend=git-am']):
+                # the new script failed (it doesn't exist?), try the old one
+                subprocess.call(['bash', '-c', self.wine_staging_src + '/patches/patchinstall.sh DESTDIR=' + self.wine_src + ' --all --backend=git-am'])
 
             # delete the branch we created
             self.wine_staging_repo.checkout(self.wine_staging_repo.lookup_branch('master'))


### PR DESCRIPTION
## Purpose

This PR introduces diverse improvements and fixes for the `winesync.py` script.
The most important ones are:

- Fixing some apparent problems with commits manipulation with pygit2;
- Explicitly using posix paths for git file manipulations;
- Allowing using the "new" Wine-Staging patchinstall.py script, that has been introduced in Wine-Staging in Feb.16, 2023;
- Elegantly handle empty 'files' and 'directories' lists (expanding on @tkreuzer commit 4b5a55516)
- Make the Wine-Staging tag optional, when one doesn't want to sync with Wine-Staging, but just with Wine.

## Testing

These modifications have been used to successfully [sync setupapi](https://github.com/reactos/reactos/commits/hbelusca/setupapi_partial_winesync) [with Wine-Staging 8.15](https://github.com/reactos/reactos/commits/hbelusca/setupapi_winetest_winesync).