### PR TITLE
[ATL] Added CComPtr.CoCreateInstance helper methods

### DIFF
--- a/sdk/lib/atl/atlcomcli.h
+++ b/sdk/lib/atl/atlcomcli.h
@@ -98,6 +98,19 @@ public:
             p->Release();
     }
 
+    HRESULT CoCreateInstance(REFCLSID rclsid, REFIID riid, LPUNKNOWN pOuter = NULL, DWORD ClsCtx = CLSCTX_ALL)
+    {
+        ATLASSERT(!p);
+        return ::CoCreateInstance(rclsid, pOuter, ClsCtx, riid, (void**)&p);
+    }
+
+    HRESULT CoCreateInstance(LPCOLESTR ProgID, REFIID riid, LPUNKNOWN pOuter = NULL, DWORD ClsCtx = CLSCTX_ALL)
+    {
+        CLSID clsid;
+        HRESULT hr = CLSIDFromProgID(ProgID, &clsid);
+        return FAILED(hr) ? hr : CoCreateInstance(clsid, riid, pOuter, ClsCtx);
+    }
+
     T *operator = (T *lp)
     {
         T* pOld = p;
@@ -141,6 +154,16 @@ public:
             pOld->Release();
 
         return *this;
+    }
+
+    HRESULT CoCreateInstance(REFCLSID rclsid, LPUNKNOWN pOuter = NULL, DWORD ClsCtx = CLSCTX_ALL)
+    {
+        return CoCreateInstance(rclsid, __uuidof(T), pOuter, ClsCtx);
+    }
+
+    HRESULT CoCreateInstance(LPCOLESTR ProgID, LPUNKNOWN pOuter = NULL, DWORD ClsCtx = CLSCTX_ALL)
+    {
+        return CoCreateInstance(ProgID, __uuidof(T), pOuter, ClsCtx);
     }
 #endif
 


### PR DESCRIPTION
The equivalent of `CComPtrBase::CoCreateInstance` had to stay inside the `#if 0` because of `__uuidof` but the (non-standard) two parameter version should still be useful.

```
CComPtr<IFoo> foo;
HRESULT hr = foo.CoCreateInstance(CLSID_Foo, IID_IFoo);
```
