### PR TITLE
[MSTSC] Update Romanian (ro-RO) translation

### DIFF
--- a/base/applications/mstsc/lang/ro-RO.rc
+++ b/base/applications/mstsc/lang/ro-RO.rc
@@ -16,12 +16,12 @@ BEGIN
     GROUPBOX "Gestiune conexiuni", IDC_STATIC, 7, 103, 228, 65
     ICON "", IDC_LOGONICON, 15, 19, 20, 20
     LTEXT "Introduceți adresa unui servitor.", IDC_STATIC, 47, 24, 121, 8
-    LTEXT "Servitor:", IDC_STATIC, 47, 41, 35, 8
+    LTEXT "Server:", IDC_STATIC, 47, 41, 35, 8
     LTEXT "Nume utilizator:", IDC_STATIC, 47, 58, 58, 8
     COMBOBOX IDC_SERVERCOMBO, 101, 39, 119, 13, CBS_DROPDOWN | WS_VSCROLL | WS_TABSTOP
     EDITTEXT IDC_NAMEEDIT, 101, 55, 119, 14, WS_TABSTOP | ES_AUTOHSCROLL
-    PUSHBUTTON "&Păstrează", IDC_SAVE, 57, 139, 50, 14
-    PUSHBUTTON "Păst&rare în…", IDC_SAVEAS, 112, 139, 60, 14
+    PUSHBUTTON "S&alvează", IDC_SAVE, 57, 139, 50, 14
+    PUSHBUTTON "Sal&vează ca…", IDC_SAVEAS, 112, 139, 60, 14
     PUSHBUTTON "&Deschidere…", IDC_OPEN, 177, 139, 50, 14
     ICON "", IDC_CONNICON, 16, 114, 20, 20
     LTEXT "Puteți păstra preferințele curente de conectare sau puteți deschide preferințe existente.", IDC_STATIC, 50, 115, 172, 20


### PR DESCRIPTION
Attendum to PR https://github.com/reactos/reactos/pull/5908
Also, revert the translation for the word "server". It won't be translated as "servitor" anymore.