### PR TITLE
[MYEVENTPROVIDER_DLL][MC] Add Romanian (ro-RO) translation to message table

### DIFF
--- a/modules/rostests/win32/advapi32/eventlog/MyEventProvider.mc
+++ b/modules/rostests/win32/advapi32/eventlog/MyEventProvider.mc
@@ -34,7 +34,7 @@ Language=Polish
 Zdarzenia sieciowe
 .
 Language=Romanian
-Evenimante de rețea
+Evenimente de rețea
 .
 
 MessageId=0x2
@@ -109,7 +109,7 @@ od serwera i spróbuj ponownie później.
 .
 Language=Romanian
 Au fost %1 reîncercări cu %2 succes(e)! Deconectați-vă de la
-servitor și încercați din nou, mai târziu.
+server și încercați din nou, mai târziu.
 .
 
 MessageId=0x103


### PR DESCRIPTION
Revert the word "servitor" and fix a typo.