### PR TITLE
[USER32] Fix resource display of MSVC BI_BITFIELD 32-bit bitmaps.

### DIFF
--- a/win32ss/user/user32/windows/cursoricon.c
+++ b/win32ss/user/user32/windows/cursoricon.c
@@ -1085,7 +1085,7 @@ BITMAP_LoadImageW(
     HBITMAP hbmpOld, hbmpRet = NULL;
     LONG width, height;
     WORD bpp;
-    DWORD compr, HdrSize = 0, ResSize = 0;
+    DWORD compr, ResSize = 0;
 
     /* Map the bitmap info */
     if(fuLoad & LR_LOADFROMFILE)
@@ -1150,8 +1150,7 @@ BITMAP_LoadImageW(
     CopyMemory(pbmiCopy, pbmi, iBMISize);
 
     /* Test if MSVC Resource Compiler used and if so, adjust pvBits */
-    HdrSize = *(char*)pbmi;
-    if (pbmiCopy->bmiHeader.biSizeImage + HdrSize + 12 == ResSize
+    if (pbmiCopy->bmiHeader.biSizeImage + pbmiCopy->bmiHeader.biSize + 12 == ResSize
              && compr == BI_BITFIELDS && bpp == 32)
     {
         /* MSVC pointer to the image data has 12 more bytes than GCC */

--- a/win32ss/user/user32/windows/cursoricon.c
+++ b/win32ss/user/user32/windows/cursoricon.c
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * PROJECT:         ReactOS user32.dll
  * COPYRIGHT:       GPL - See COPYING in the top level directory
  * FILE:            win32ss/user/user32/windows/cursoricon.c

--- a/win32ss/user/user32/windows/cursoricon.c
+++ b/win32ss/user/user32/windows/cursoricon.c
@@ -1149,13 +1149,12 @@ BITMAP_LoadImageW(
         goto end;
     CopyMemory(pbmiCopy, pbmi, iBMISize);
 
-    /* Test if MSVC Resource Compiler used and if so, adjust pvBits */
+    /* Test compression BI_BITFIELDS & if its 12 bytes are in Resource Size */
     if (pbmiCopy->bmiHeader.biSizeImage + pbmiCopy->bmiHeader.biSize + 12 == ResSize
-             && compr == BI_BITFIELDS && bpp == 32)
+             && compr == BI_BITFIELDS && (bpp == 32 || bpp == 16))
     {
-        /* MSVC pointer to the image data has 12 more bytes than GCC */
         pvBits = (char*)pvBits + 12;
-        TRACE("MSVC Resource Compiled\n");
+        TRACE("12 bytes added to pvBits to adjust for BI_BITFIELDS\n");
     }
 
     /* Fix it up, if needed */

--- a/win32ss/user/user32/windows/cursoricon.c
+++ b/win32ss/user/user32/windows/cursoricon.c
@@ -177,7 +177,7 @@ static int bitmap_info_size( const BITMAPINFO * info, WORD coloruse )
          * at https://en.wikipedia.org/wiki/BMP_file_format. */
         if (info->bmiHeader.biCompression == BI_BITFIELDS &&
             (info->bmiHeader.biBitCount == 16 || info->bmiHeader.biBitCount == 32))
-                bitfields = 3 * sizeof(DWORD);  // BI_BITFIELDS
+            bitfields = 3 * sizeof(DWORD);  // BI_BITFIELDS
 
         colors = info->bmiHeader.biClrUsed;
         if (colors > 256) /* buffer overflow otherwise */
@@ -1177,7 +1177,7 @@ BITMAP_LoadImageW(
      * size of the bitfields previously included from bitmap_info_size.
      * If this is ever fixed, then this code needs to be removed. */
     if (pbmiCopy->bmiHeader.biSizeImage + pbmiCopy->bmiHeader.biSize == ResSize
-             && compr == BI_BITFIELDS && bpp == 32)
+        && compr == BI_BITFIELDS && bpp == 32)
     {
         /* GCC pointer to the image data has 12 less bytes than MSVC */
         pvBits = (char*)pvBits - 12;

--- a/win32ss/user/user32/windows/cursoricon.c
+++ b/win32ss/user/user32/windows/cursoricon.c
@@ -152,8 +152,7 @@ static BOOL is_dib_monochrome( const BITMAPINFO* info )
     }
 }
 
-/************************************************************************
- * Return the size of the bitmap info structure including color table and
+/* Return the size of the bitmap info structure including color table and
  * the bytes required for 3 DWORDS if this is a BI_BITFIELDS(3) bmp.
  */
 static int bitmap_info_size( const BITMAPINFO * info, WORD coloruse )

--- a/win32ss/user/user32/windows/cursoricon.c
+++ b/win32ss/user/user32/windows/cursoricon.c
@@ -1140,11 +1140,6 @@ BITMAP_LoadImageW(
         ResSize = SizeofResource(hinst, hrsrc);
     }
 
-    if (pbmi->bmiHeader.biCompression == BI_BITFIELDS &&
-        pbmi->bmiHeader.biBitCount == 32 &&
-        pbmi->bmiHeader.biSizeImage + pbmi->bmiHeader.biSize + 12 != ResSize)
-        WARN("Possibly bad resource size provided\n");
-
     /* Fix up values */
     if(DIB_GetBitmapInfo(&pbmi->bmiHeader, &width, &height, &bpp, &compr) == -1)
         goto end;
@@ -1174,14 +1169,13 @@ BITMAP_LoadImageW(
     /* Test if this is a GCC windres.exe compiled 32 bpp bitmap using
      * BI_BITFIELDS and if so, then a mistake causes it not to include
      * the bytes for the bitfields. So, we have to substract out the
-     * size of the bitfields previously included from bitmap_info_size.
-     * If this is ever fixed, then this code needs to be removed. */
+     * size of the bitfields previously included from bitmap_info_size.*/
     if (compr == BI_BITFIELDS && bpp == 32 &&
         pbmiCopy->bmiHeader.biSizeImage + pbmiCopy->bmiHeader.biSize == ResSize)
     {
         /* GCC pointer to the image data has 12 less bytes than MSVC */
         pvBits = (char*)pvBits - 12;
-        ERR("GCC Resource Compiled 32-bpp with error\n");
+        WARN("GCC Resource Compiled 32-bpp with error\n");
     }
 
     /* Fix it up, if needed */

--- a/win32ss/user/user32/windows/cursoricon.c
+++ b/win32ss/user/user32/windows/cursoricon.c
@@ -1166,7 +1166,7 @@ BITMAP_LoadImageW(
     TRACE("Size Image %d, Size Header %d, ResSize %d\n",
         pbmiCopy->bmiHeader.biSizeImage, pbmiCopy->bmiHeader.biSize, ResSize);
 
-    /* Test if this is a GCC windres.exe compiled 32 bpp bitmap using
+    /* Test if this is a GCC windres.exe compiled 16 or 32 bpp bitmap using
      * BI_BITFIELDS and if so, then a mistake causes it not to include
      * the bytes for the bitfields. So, we have to substract out the
      * size of the bitfields previously included from bitmap_info_size.*/

--- a/win32ss/user/user32/windows/cursoricon.c
+++ b/win32ss/user/user32/windows/cursoricon.c
@@ -1170,7 +1170,7 @@ BITMAP_LoadImageW(
      * BI_BITFIELDS and if so, then a mistake causes it not to include
      * the bytes for the bitfields. So, we have to substract out the
      * size of the bitfields previously included from bitmap_info_size.*/
-    if (compr == BI_BITFIELDS && bpp == 32 &&
+    if (compr == BI_BITFIELDS && (bpp == 16 || bpp == 32) &&
         pbmiCopy->bmiHeader.biSizeImage + pbmiCopy->bmiHeader.biSize == ResSize)
     {
         /* GCC pointer to the image data has 12 less bytes than MSVC */

--- a/win32ss/user/user32/windows/cursoricon.c
+++ b/win32ss/user/user32/windows/cursoricon.c
@@ -1175,7 +1175,7 @@ BITMAP_LoadImageW(
     {
         /* GCC pointer to the image data has 12 less bytes than MSVC */
         pvBits = (char*)pvBits - 12;
-        WARN("GCC Resource Compiled 32-bpp with error\n");
+        WARN("Found GCC Resource Compiled 16-bpp or 32-bpp error\n");
     }
 
     /* Fix it up, if needed */


### PR DESCRIPTION
## Purpose

_Fix Wordpad's Open and SaveAs dialog toolbar icon displays on MSVC builds._

JIRA issue: [CORE-17005](https://jira.reactos.org/browse/CORE-17005)

## Proposed changes

_Modify USER32 to account for differences in Resource Bitmaps between GCC and MSVC builds._

Before:
![MSVC_Wordpad_Toolbar_Icons_orig](https://github.com/reactos/reactos/assets/32620577/224a1c09-bb3d-40c0-a20e-2fae9d8b9c75)

After:
![MSVC_Wordpad_Toolbar_Icons_03](https://github.com/reactos/reactos/assets/32620577/74bba193-59da-458c-86c1-7e31c72954f8)
