### PR TITLE
[SETUPAPI] CM_Request_Device_Eject_ExA/W: Fix pszVetoName buffer size validation

### DIFF
--- a/dll/win32/setupapi/cfgmgr.c
+++ b/dll/win32/setupapi/cfgmgr.c
@@ -7489,7 +7489,7 @@ CM_Request_Device_Eject_ExA(
     TRACE("CM_Request_Device_Eject_ExA(%lx %p %s %lu %lx %p)\n",
           dnDevInst, pVetoType, debugstr_a(pszVetoName), ulNameLength, ulFlags, hMachine);
 
-    if (pszVetoName == NULL && ulNameLength == 0)
+    if (pszVetoName == NULL && ulNameLength != 0)
         return CR_INVALID_POINTER;
 
     lpLocalVetoName = HeapAlloc(GetProcessHeap(), 0, ulNameLength * sizeof(WCHAR));
@@ -7544,7 +7544,7 @@ CM_Request_Device_Eject_ExW(
     if (ulFlags != 0)
         return CR_INVALID_FLAG;
 
-    if (pszVetoName == NULL && ulNameLength == 0)
+    if (pszVetoName == NULL && ulNameLength != 0)
         return CR_INVALID_POINTER;
 
     if (hMachine != NULL)

--- a/dll/win32/setupapi/cfgmgr.c
+++ b/dll/win32/setupapi/cfgmgr.c
@@ -7483,22 +7483,25 @@ CM_Request_Device_Eject_ExA(
     _In_ ULONG ulFlags,
     _In_opt_ HMACHINE hMachine)
 {
-    LPWSTR lpLocalVetoName;
+    LPWSTR lpLocalVetoName = NULL;
     CONFIGRET ret;
 
     TRACE("CM_Request_Device_Eject_ExA(%lx %p %s %lu %lx %p)\n",
           dnDevInst, pVetoType, debugstr_a(pszVetoName), ulNameLength, ulFlags, hMachine);
 
-    if (pszVetoName == NULL && ulNameLength != 0)
-        return CR_INVALID_POINTER;
+    if (ulNameLength != 0)
+    {
+        if (pszVetoName == NULL)
+            return CR_INVALID_POINTER;
 
-    lpLocalVetoName = HeapAlloc(GetProcessHeap(), 0, ulNameLength * sizeof(WCHAR));
-    if (lpLocalVetoName == NULL)
-        return CR_OUT_OF_MEMORY;
+        lpLocalVetoName = HeapAlloc(GetProcessHeap(), 0, ulNameLength * sizeof(WCHAR));
+        if (lpLocalVetoName == NULL)
+            return CR_OUT_OF_MEMORY;
+    }
 
     ret = CM_Request_Device_Eject_ExW(dnDevInst, pVetoType, lpLocalVetoName,
                                       ulNameLength, ulFlags, hMachine);
-    if (ret == CR_REMOVE_VETOED)
+    if (ret == CR_REMOVE_VETOED && ulNameLength != 0)
     {
         if (WideCharToMultiByte(CP_ACP,
                                 0,


### PR DESCRIPTION
## Proposed changes
- Return CR_INVALID_POINTER if `pszVetoName` is NULL and `ulNameLength` is not zero.
- CM_Request_Device_Eject_ExA: Allow `ulNameLength` to be zero when `pszVetoName` is not NULL

Verified with Win2k3 SP2 using ROS hotplug.dll modified to call the function with different `pszVetoName` and `ulNameLength` values.