### PR TITLE
[NTDLL][MSVCRT] Initialize stuff in dll entrypoint

### DIFF
--- a/dll/ntdll/include/ntdllp.h
+++ b/dll/ntdll/include/ntdllp.h
@@ -226,4 +226,9 @@ RtlDoesFileExists_UStr(
     IN PUNICODE_STRING FileName
 );
 
+VOID
+NTAPI
+RtlpInitializeKeyedEvent(
+    VOID);
+
 /* EOF */

--- a/dll/ntdll/ldr/ldrinit.c
+++ b/dll/ntdll/ldr/ldrinit.c
@@ -2405,6 +2405,11 @@ LdrpInitializeProcess(IN PCONTEXT Context,
     /* Check whether all static imports were properly loaded and return here */
     if (!NT_SUCCESS(ImportStatus)) return ImportStatus;
 
+#if (DLL_EXPORT_VERSION >= _WIN32_WINNT_VISTA)
+    /* Initialize the keyed event for condition variables */
+    RtlpInitializeKeyedEvent();
+#endif
+
     /* Initialize TLS */
     Status = LdrpInitializeTls();
     if (!NT_SUCCESS(Status))

--- a/dll/ntdll/nt_0600/DllMain.c
+++ b/dll/ntdll/nt_0600/DllMain.c
@@ -14,9 +14,11 @@
 #include <debug.h>
 
 VOID
+NTAPI
 RtlpInitializeKeyedEvent(VOID);
 
 VOID
+NTAPI
 RtlpCloseKeyedEvent(VOID);
 
 BOOL

--- a/dll/win32/kernel32/kernel32.spec
+++ b/dll/win32/kernel32/kernel32.spec
@@ -711,7 +711,7 @@
 @ stdcall -version=0x600+ InitOnceBeginInitialize(ptr long ptr ptr)
 @ stdcall -version=0x600+ InitOnceComplete(ptr long ptr)
 @ stdcall -version=0x600+ InitOnceExecuteOnce(ptr ptr ptr ptr)
-@ stdcall -version=0x600+ InitOnceInitialize(ptr) NTDLL.RtlRunOnceInitialize
+@ stdcall -version=0x600+ InitOnceInitialize(ptr) ntdll.RtlRunOnceInitialize
 @ stdcall -version=0x600+ InitializeConditionVariable(ptr) ntdll.RtlInitializeConditionVariable
 @ stdcall InitializeCriticalSection(ptr)
 @ stdcall InitializeCriticalSectionAndSpinCount(ptr long)

--- a/dll/win32/msvcrt/dllmain.c
+++ b/dll/win32/msvcrt/dllmain.c
@@ -30,6 +30,7 @@ extern char** _environ;      /* pointer to environment block */
 extern char** __initenv;     /* pointer to initial environment block */
 extern wchar_t** _wenviron;  /* pointer to environment block */
 extern wchar_t** __winitenv; /* pointer to initial environment block */
+extern void msvcrt_init_exception(void*) DECLSPEC_HIDDEN;
 
 /* LIBRARY ENTRY POINT ********************************************************/
 
@@ -42,6 +43,8 @@ DllMain(PVOID hinstDll, ULONG dwReason, PVOID reserved)
     case DLL_PROCESS_ATTACH:
 
         TRACE("Process Attach\n");
+
+        msvcrt_init_exception(hinstDll);
 
         if (!crt_process_init())
         {

--- a/dll/win32/msvcrt/msvcrt.spec
+++ b/dll/win32/msvcrt/msvcrt.spec
@@ -934,7 +934,7 @@
 @ stub -version=0x600+ _scwprintf_p_l
 @ cdecl _searchenv(str str ptr)
 @ cdecl -version=0x600+ _searchenv_s(str str ptr long)
-@ stub -version=0x600+ -arch=i386 _seh_longjmp_unwind4
+@ stdcall -version=0x600+ -arch=i386 _seh_longjmp_unwind4(ptr)
 @ stdcall -arch=i386 _seh_longjmp_unwind(ptr)
 @ stub -arch=i386 _set_SSE2_enable
 @ stub -version=0x600+ _set_controlfp

--- a/sdk/lib/rtl/condvar.c
+++ b/sdk/lib/rtl/condvar.c
@@ -456,6 +456,7 @@ InternalSleep(IN OUT PRTL_CONDITION_VARIABLE ConditionVariable,
 }
 
 VOID
+NTAPI
 RtlpInitializeKeyedEvent(VOID)
 {
     ASSERT(CondVarKeyedEventHandle == NULL);
@@ -463,6 +464,7 @@ RtlpInitializeKeyedEvent(VOID)
 }
 
 VOID
+NTAPI
 RtlpCloseKeyedEvent(VOID)
 {
     ASSERT(CondVarKeyedEventHandle != NULL);


### PR DESCRIPTION
## Purpose

Initializes some stuff in ntdll and msvcrt entry point.

## Proposed changes

- [NTDLL] Initialize keyed event for condition variables
- [MSVCRT] Initialize exception support in DllMain

## Tests

- x86 KVM: https://reactos.org/testman/compare.php?ids=91930,91933,91949,91954
- x64 KvM: https://reactos.org/testman/compare.php?ids=91962,91967,91972,91976
