### PR TITLE
[CRT] Sort-out secure functions

### DIFF
--- a/sdk/include/crt/sec_api/string_s.h
+++ b/sdk/include/crt/sec_api/string_s.h
@@ -81,6 +81,15 @@ extern "C" {
   _CRTIMP
   errno_t
   __cdecl
+  strcat_s(
+    _Inout_updates_z_(_Size) char *_Dst,
+    _In_ size_t _Size,
+    _In_z_ const char *_Src);
+
+  _Check_return_wat_
+  _CRTIMP
+  errno_t
+  __cdecl
   strncat_s(
     _Inout_updates_z_(_DstSizeInChars) char *_Dst,
     _In_ size_t _DstSizeInChars,
@@ -149,6 +158,30 @@ extern "C" {
 
 #ifndef _WSTRING_S_DEFINED
 #define _WSTRING_S_DEFINED
+
+  _CRTIMP
+  errno_t
+  __cdecl
+  wcscat_s(
+    wchar_t *Dest,
+    size_t SizeInWords,
+    const wchar_t *_Source);
+
+  _Check_return_wat_
+  _CRTIMP
+  errno_t
+  __cdecl
+  wcscpy_s(
+    _Out_writes_z_(SizeInWords) wchar_t *Dest,
+    _In_ size_t SizeInWords,
+    _In_z_ const wchar_t *_Source);
+
+  _CRTIMP
+  errno_t
+  __cdecl
+  wcsnlen_s(
+    wchar_t **_Src,
+    size_t _MaxCount);
 
   _Check_return_
   _CRTIMP

--- a/sdk/include/crt/sec_api/string_s.h
+++ b/sdk/include/crt/sec_api/string_s.h
@@ -19,15 +19,6 @@ extern "C" {
   _CRTIMP
   errno_t
   __cdecl
-  _strset_s(
-    _Inout_updates_z_(_DstSize) char *_Dst,
-    _In_ size_t _DstSize,
-    _In_ int _Value);
-
-  _Check_return_wat_
-  _CRTIMP
-  errno_t
-  __cdecl
   _strerror_s(
     _Out_writes_z_(_SizeInBytes) char *_Buf,
     _In_ size_t _SizeInBytes,
@@ -49,6 +40,15 @@ extern "C" {
     _Inout_updates_z_(_Size) char *_Str,
     _In_ size_t _Size,
     _In_opt_ _locale_t _Locale);
+
+  _Check_return_wat_
+  _CRTIMP
+  errno_t
+  __cdecl
+  _strset_s(
+    _Inout_updates_z_(_DstSize) char *_Dst,
+    _In_ size_t _DstSize,
+    _In_ int _Value);
 
   _Check_return_wat_
   _CRTIMP
@@ -277,22 +277,22 @@ extern "C" {
   _CRTIMP
   errno_t
   __cdecl
+  wcsncpy_s(
+    _Out_writes_z_(_DstSizeInChars) wchar_t *_Dst,
+    _In_ size_t _DstSizeInChars,
+    _In_z_ const wchar_t *_Src,
+    _In_ size_t _MaxCount);
+
+  _Check_return_wat_
+  _CRTIMP
+  errno_t
+  __cdecl
   _wcsncat_s_l(
     _Inout_updates_z_(_DstSizeInChars) wchar_t *_Dst,
     _In_ size_t _DstSizeInChars,
     _In_z_ const wchar_t *_Src,
     _In_ size_t _MaxCount,
     _In_opt_ _locale_t _Locale);
-
-  _Check_return_wat_
-  _CRTIMP
-  errno_t
-  __cdecl
-  wcsncpy_s(
-    _Out_writes_z_(_DstSizeInChars) wchar_t *_Dst,
-    _In_ size_t _DstSizeInChars,
-    _In_z_ const wchar_t *_Src,
-    _In_ size_t _MaxCount);
 
   _Check_return_wat_
   _CRTIMP

--- a/sdk/include/crt/sec_api/wchar_s.h
+++ b/sdk/include/crt/sec_api/wchar_s.h
@@ -334,6 +334,17 @@ extern "C" {
   _CRTIMP
   errno_t
   __cdecl
+  _wsopen_s(
+    _Out_ int *_FileHandle,
+    _In_z_ const wchar_t *_Filename,
+    _In_ int _OpenFlag,
+    _In_ int _ShareFlag,
+    _In_ int _PermissionFlag);
+
+  _Check_return_wat_
+  _CRTIMP
+  errno_t
+  __cdecl
   _wtmpnam_s(
     _Out_writes_z_(_SizeInWords) wchar_t *_DstBuf,
     _In_ size_t _SizeInWords);
@@ -643,7 +654,7 @@ extern "C" {
   __cdecl
   _wstrdate_s(
     _Out_writes_(_SizeInWords) _Post_readable_size_(9) wchar_t *_Buf,
-    _In_range_(>= , 9) size_t _SizeInWords);
+    _In_range_(>=, 9) size_t _SizeInWords);
 
   _CRTIMP
   errno_t
@@ -652,6 +663,8 @@ extern "C" {
     _Out_writes_(_SizeInWords) _Post_readable_size_(9) wchar_t *_Buf,
     _In_ size_t _SizeInWords);
 
+#if _INTEGRAL_MAX_BITS >= 64
+
   _CRTIMP
   errno_t
   __cdecl
@@ -659,6 +672,8 @@ extern "C" {
     _Out_writes_(_SizeInWords) _Post_readable_size_(26) wchar_t *_Buf,
     _In_ size_t _SizeInWords,
     _In_ const __time64_t *_Time);
+
+#endif /* _INTEGRAL_MAX_BITS >= 64 */
 
 #if !defined (RC_INVOKED) && !defined (_INC_WTIME_S_INL)
 #define _INC_WTIME_S_INL

--- a/sdk/include/crt/string.h
+++ b/sdk/include/crt/string.h
@@ -446,90 +446,6 @@ extern "C" {
     _In_ size_t _MaxCount,
     _In_opt_ _locale_t _Locale);
 
-#if __STDC_WANT_SECURE_LIB__
-
-  _Check_return_wat_
-  _CRTIMP
-  errno_t
-  __cdecl
-  _strset_s(
-    _Inout_updates_z_(_DstSize) char *_Dst,
-    _In_ size_t _DstSize,
-    _In_ int _Value);
-
-  _Check_return_wat_
-  _CRTIMP
-  errno_t
-  __cdecl
-  _strerror_s(
-    _Out_writes_z_(_SizeInBytes) char *_Buf,
-    _In_ size_t _SizeInBytes,
-    _In_opt_z_ const char *_ErrMsg);
-
-  _Check_return_wat_
-  _CRTIMP
-  errno_t
-  __cdecl
-  _strlwr_s(
-    _Inout_updates_z_(_Size) char *_Str,
-    _In_ size_t _Size);
-
-  _Check_return_wat_
-  _CRTIMP
-  errno_t
-  __cdecl
-  _strlwr_s_l(
-    _Inout_updates_z_(_Size) char *_Str,
-    _In_ size_t _Size,
-    _In_opt_ _locale_t _Locale);
-
-  _Check_return_wat_
-  _CRTIMP
-  errno_t
-  __cdecl
-  _strnset_s(
-    _Inout_updates_z_(_Size) char *_Str,
-    _In_ size_t _Size,
-    _In_ int _Val,
-    _In_ size_t _MaxCount);
-
-  _Check_return_wat_
-  _CRTIMP
-  errno_t
-  __cdecl
-  _strupr_s(
-    _Inout_updates_z_(_Size) char *_Str,
-    _In_ size_t _Size);
-
-  _Check_return_wat_
-  _CRTIMP
-  errno_t
-  __cdecl
-  _strupr_s_l(
-    _Inout_updates_z_(_Size) char *_Str,
-    _In_ size_t _Size,
-    _In_opt_ _locale_t _Locale);
-
-  _Check_return_wat_
-  _CRTIMP
-  errno_t
-  __cdecl
-  strcpy_s(
-    _Out_writes_z_(_Size) char *_Dst,
-    _In_ size_t _Size,
-    _In_z_ const char *_Src);
-
-  _Check_return_wat_
-  _CRTIMP
-  errno_t
-  __cdecl
-  strcat_s(
-    _Inout_updates_z_(_Size) char *_Dst,
-    _In_ size_t _Size,
-    _In_z_ const char *_Src);
-
-#endif /* __STDC_WANT_SECURE_LIB__ */
-
 #ifndef NO_OLDNAMES
 
   _Check_return_
@@ -943,115 +859,6 @@ extern "C" {
     _In_ size_t _MaxCount,
     _In_opt_ _locale_t _Locale);
 
-#if __STDC_WANT_SECURE_LIB__
-
-  _CRTIMP
-  errno_t
-  __cdecl
-  wcscat_s(
-    wchar_t *Dest,
-    size_t SizeInWords,
-    const wchar_t *_Source);
-
-  _Check_return_wat_
-  _CRTIMP
-  errno_t
-  __cdecl
-  wcscpy_s(
-    _Out_writes_z_(SizeInWords) wchar_t *Dest,
-    _In_ size_t SizeInWords,
-    _In_z_ const wchar_t *_Source);
-
-  _CRTIMP
-  errno_t
-  __cdecl
-  wcsnlen_s(
-    wchar_t **_Src,
-    size_t _MaxCount);
-
-  _Check_return_wat_
-  _CRTIMP
-  errno_t
-  __cdecl
-  wcsncpy_s(
-    _Out_writes_z_(_DstSizeInChars) wchar_t *_Dst,
-    _In_ size_t _DstSizeInChars,
-    _In_z_ const wchar_t *_Src,
-    _In_ size_t _MaxCount);
-
-  _Check_return_wat_
-  _CRTIMP
-  errno_t
-  __cdecl
-  _wcserror_s(
-    _Out_writes_opt_z_(_SizeInWords) wchar_t *_Buf,
-    _In_ size_t _SizeInWords,
-    _In_ int _ErrNum);
-
-  _Check_return_wat_
-  _CRTIMP
-  errno_t
-  __cdecl
-  __wcserror_s(
-    _Out_writes_opt_z_(_SizeInWords) wchar_t *_Buffer,
-    _In_ size_t _SizeInWords,
-    _In_z_ const wchar_t *_ErrMsg);
-
-  _Check_return_wat_
-  _CRTIMP
-  errno_t
-  __cdecl
-  _wcsnset_s(
-    _Inout_updates_z_(_DstSizeInWords) wchar_t *_Dst,
-    _In_ size_t _DstSizeInWords,
-    _In_ wchar_t _Val,
-    _In_ size_t _MaxCount);
-
-  _Check_return_wat_
-  _CRTIMP
-  errno_t
-  __cdecl
-  _wcsset_s(
-    _Inout_updates_z_(_SizeInWords) wchar_t *_Str,
-    _In_ size_t _SizeInWords,
-    _In_ wchar_t _Val);
-
-  _Check_return_wat_
-  _CRTIMP
-  errno_t
-  __cdecl
-  _wcslwr_s(
-    _Inout_updates_z_(_SizeInWords) wchar_t *_Str,
-    _In_ size_t _SizeInWords);
-
-  _Check_return_wat_
-  _CRTIMP
-  errno_t
-  __cdecl
-  _wcslwr_s_l(
-    _Inout_updates_z_(_SizeInWords) wchar_t *_Str,
-    _In_ size_t _SizeInWords,
-    _In_opt_ _locale_t _Locale);
-
-  _Check_return_wat_
-  _CRTIMP
-  errno_t
-  __cdecl
-  _wcsupr_s(
-    _Inout_updates_z_(_Size) wchar_t *_Str,
-    _In_ size_t _Size);
-
-  _Check_return_wat_
-  _CRTIMP
-  errno_t
-  __cdecl
-  _wcsupr_s_l(
-    _Inout_updates_z_(_Size) wchar_t *_Str,
-    _In_ size_t _Size,
-    _In_opt_ _locale_t _Locale);
-
-#endif /* __STDC_WANT_SECURE_LIB__ */
-
 #ifndef NO_OLDNAMES
 
   _Check_return_
@@ -1144,5 +951,8 @@ extern "C" {
 #define stricmp _stricmp
 #define wcsicmp _wcsicmp
 
+#if __STDC_WANT_SECURE_LIB__
 #include <sec_api/string_s.h>
+#endif /* __STDC_WANT_SECURE_LIB__ */
+
 #endif

--- a/sdk/include/crt/tchar.h
+++ b/sdk/include/crt/tchar.h
@@ -244,7 +244,6 @@ extern "C" {
 #define _tcscat wcscat
 #define _tcschr wcschr
 #define _tcscpy wcscpy
-#define _tcscpy_s wcscpy_s
 #define _tcscspn wcscspn
 #define _tcslen wcslen
 #define _tcsnlen wcsnlen
@@ -324,13 +323,6 @@ extern "C" {
 #define _tcsftime wcsftime
 #define _tcsftime_l _wcsftime_l
 
-#define _tasctime_s   _wasctime_s
-#define _tctime_s     _wctime_s
-#define _tctime32_s   _wctime32_s
-#define _tctime64_s   _wctime64_s
-#define _tstrdate_s   _wstrdate_s
-#define _tstrtime_s   _wstrtime_s
-
 #define _tchdir _wchdir
 #define _tgetcwd _wgetcwd
 #define _tgetdcwd _wgetdcwd
@@ -346,7 +338,6 @@ extern "C" {
 #define _tputenv _wputenv
 #define _tsearchenv _wsearchenv
 #define _tsplitpath _wsplitpath
-#define _tsplitpath_s _wsplitpath_s
 
 #define _tfdopen _wfdopen
 #define _tfsopen _wfsopen
@@ -621,7 +612,6 @@ extern "C" {
 
 #define _tcscat strcat
 #define _tcscpy strcpy
-#define _tcscpy_s strcpy_s
 #define _tcsdup _strdup
 #define _tcslen strlen
 #define _tcsnlen strnlen
@@ -662,13 +652,6 @@ extern "C" {
 #define _tcsftime strftime
 #define _tcsftime_l _strftime_l
 
-#define _tasctime_s   asctime_s
-#define _tctime_s     ctime_s
-#define _tctime32_s   _ctime32_s
-#define _tctime64_s   _ctime64_s
-#define _tstrdate_s   _strdate_s
-#define _tstrtime_s   _strtime_s
-
 #define _tchdir _chdir
 #define _tgetcwd _getcwd
 #define _tgetdcwd _getdcwd
@@ -684,7 +667,6 @@ extern "C" {
 #define _tputenv _putenv
 #define _tsearchenv _searchenv
 #define _tsplitpath _splitpath
-#define _tsplitpath_s _splitpath_s
 
 #ifdef _POSIX_
 #define _tfdopen fdopen
@@ -1538,5 +1520,8 @@ extern "C" {
 }
 #endif
 
+#if __STDC_WANT_SECURE_LIB__
 #include <sec_api/tchar_s.h>
+#endif /* __STDC_WANT_SECURE_LIB__ */
+
 #endif

--- a/sdk/include/crt/wchar.h
+++ b/sdk/include/crt/wchar.h
@@ -1902,6 +1902,7 @@ _CRTIMP int __cdecl iswblank(wint_t _C);
   _wcsdup(
     _In_z_ const wchar_t *_Str);
 
+  _CRTIMP
   wchar_t*
   __cdecl
   wcscat(
@@ -1916,12 +1917,14 @@ _CRTIMP int __cdecl iswblank(wint_t _C);
     wchar_t _Ch);
 
   _Check_return_
+  _CRTIMP
   int
   __cdecl
   wcscmp(
     _In_z_ const wchar_t *_Str1,
     _In_z_ const wchar_t *_Str2);
 
+  _CRTIMP
   wchar_t*
   __cdecl
   wcscpy(
@@ -1929,6 +1932,7 @@ _CRTIMP int __cdecl iswblank(wint_t _C);
     _In_z_ const wchar_t *_Source);
 
   _Check_return_
+  _CRTIMP
   size_t
   __cdecl
   wcscspn(

--- a/sdk/include/crt/wchar.h
+++ b/sdk/include/crt/wchar.h
@@ -387,17 +387,6 @@ _CRTIMP int __cdecl iswblank(wint_t _C);
 
 #endif /* _INTEGRAL_MAX_BITS >= 64 */
 
-  _Check_return_wat_
-  _CRTIMP
-  errno_t
-  __cdecl
-  _wsopen_s(
-    _Out_ int *_FileHandle,
-    _In_z_ const wchar_t *_Filename,
-    _In_ int _OpenFlag,
-    _In_ int _ShareFlag,
-    _In_ int _PermissionFlag);
-
 #if !defined(__cplusplus) || !(defined(_X86_) && !defined(__x86_64))
   _CRTIMP int __cdecl _wopen(const wchar_t *_Filename,int _OpenFlag,...);
   _CRTIMP int __cdecl _wsopen(const wchar_t *_Filename,int _OpenFlag,int _ShareFlag,...);
@@ -2340,50 +2329,12 @@ _CRTIMP int __cdecl iswblank(wint_t _C);
   _wstrtime(
     _Out_writes_z_(9) wchar_t *_Buffer);
 
-  _CRTIMP
-  errno_t
-  __cdecl
-  _wasctime_s(
-    _Out_writes_(_SizeInWords) _Post_readable_size_(26) wchar_t *_Buf,
-    _In_ size_t _SizeInWords,
-    _In_ const struct tm *_Tm);
-
-  _CRTIMP
-  errno_t
-  __cdecl
-  _wctime32_s(
-    _Out_writes_(_SizeInWords) _Post_readable_size_(26) wchar_t *_Buf,
-    _In_ size_t _SizeInWords,
-    _In_ const __time32_t *_Time);
-
-  _CRTIMP
-  errno_t
-  __cdecl
-  _wstrdate_s(
-    _Out_writes_(_SizeInWords) _Post_readable_size_(9) wchar_t *_Buf,
-    _In_range_(>=, 9) size_t _SizeInWords);
-
-  _CRTIMP
-  errno_t
-  __cdecl
-  _wstrtime_s(
-    _Out_writes_(_SizeInWords) _Post_readable_size_(9) wchar_t *_Buf,
-    _In_ size_t _SizeInWords);
-
 #if _INTEGRAL_MAX_BITS >= 64
 
   _CRTIMP
   wchar_t*
   __cdecl
   _wctime64(
-    _In_ const __time64_t *_Time);
-
-  _CRTIMP
-  errno_t
-  __cdecl
-  _wctime64_s(
-    _Out_writes_(_SizeInWords) _Post_readable_size_(26) wchar_t *_Buf,
-    _In_ size_t _SizeInWords,
     _In_ const __time64_t *_Time);
 
 #endif /* _INTEGRAL_MAX_BITS >= 64 */
@@ -2630,5 +2581,8 @@ __CRT_INLINE wchar_t *__cdecl _wctime(const time_t *_Time) { return _wctime64(_T
 
 #pragma pack(pop)
 
+#if __STDC_WANT_SECURE_LIB__
 #include <sec_api/wchar_s.h>
+#endif /* __STDC_WANT_SECURE_LIB__ */
+
 #endif


### PR DESCRIPTION
## Purpose

In our CRT headers, the *_s.h headers should contain all the *_s() CRT "secure" functions, while the non-_s contain the rest, and include the *_s.h files accordingly.