### PR TITLE
[MSTSC] Update Romanian (ro-RO) translation

### DIFF
--- a/base/applications/mstsc/lang/ro-RO.rc
+++ b/base/applications/mstsc/lang/ro-RO.rc
@@ -15,7 +15,7 @@ BEGIN
     GROUPBOX "Preferințe de conectare", IDC_STATIC, 7, 7, 228, 89
     GROUPBOX "Gestiune conexiuni", IDC_STATIC, 7, 103, 228, 65
     ICON "", IDC_LOGONICON, 15, 19, 20, 20
-    LTEXT "Introduceți adresa unui servitor.", IDC_STATIC, 47, 24, 121, 8
+    LTEXT "Introduceți adresa unui server.", IDC_STATIC, 47, 24, 121, 8
     LTEXT "Server:", IDC_STATIC, 47, 41, 35, 8
     LTEXT "Nume utilizator:", IDC_STATIC, 47, 58, 58, 8
     COMBOBOX IDC_SERVERCOMBO, 101, 39, 119, 13, CBS_DROPDOWN | WS_VSCROLL | WS_TABSTOP
@@ -24,7 +24,7 @@ BEGIN
     PUSHBUTTON "Sal&vează ca…", IDC_SAVEAS, 112, 139, 60, 14
     PUSHBUTTON "&Deschidere…", IDC_OPEN, 177, 139, 50, 14
     ICON "", IDC_CONNICON, 16, 114, 20, 20
-    LTEXT "Puteți păstra preferințele curente de conectare sau puteți deschide preferințe existente.", IDC_STATIC, 50, 115, 172, 20
+    LTEXT "Puteți salva setările curente de conectare sau puteți deschide o configurație existentă.", IDC_STATIC, 50, 115, 172, 20
 END
 
 IDD_DISPLAY DIALOGEX 0, 0, 242, 175
@@ -39,7 +39,7 @@ BEGIN
     CONTROL "", IDC_GEOSLIDER, "msctls_trackbar32", TBS_AUTOTICKS | WS_TABSTOP, 56, 42, 124, 17
     COMBOBOX IDC_BPPCOMBO, 56, 102, 128, 80, CBS_DROPDOWNLIST | CBS_AUTOHSCROLL | WS_VSCROLL | WS_TABSTOP
     CONTROL "", IDC_COLORIMAGE, "Static", SS_OWNERDRAW | SS_SUNKEN, 56, 121, 127, 10
-    LTEXT "Notă: Această preferință poate fi sau nu compatibilă cu configurația calculatorului gazdă. Preferințele incompatibile vor fi ignorate.", IDC_STATIC, 56, 138, 155, 27
+    LTEXT "Notă: Această preferință poate fi sau nu compatibilă cu setările calculatorului gazdă. Preferințele incompatibile vor fi ignorate.", IDC_STATIC, 56, 138, 155, 27
     LTEXT "Mică", IDC_STATIC, 35, 42, 15, 8
     LTEXT "Mare", IDC_STATIC, 189, 42, 17, 8
     LTEXT "", IDC_SETTINGS_RESOLUTION_TEXT, 56, 62, 120, 10, SS_CENTER


### PR DESCRIPTION
Attendum to PRs https://github.com/reactos/reactos/pull/5908 and https://github.com/reactos/reactos/pull/5914 .
Also, revert the translation for the word "server". It won't be translated as "servitor" anymore.