### PR TITLE
[STOBJECT] Remove #if 0 and #endif in Volume_IsMute

### DIFF
--- a/dll/shellext/stobject/volume.cpp
+++ b/dll/shellext/stobject/volume.cpp
@@ -122,7 +122,7 @@ HRESULT Volume_IsMute()
         mixerControlDetails.cChannels = 1;
         mixerControlDetails.paDetails = &detailsResult;
         mixerControlDetails.cbDetails = sizeof(detailsResult);
-        if (mixerGetControlDetailsW((HMIXEROBJ) g_mixerId, &mixerControlDetails, 0))
+        if (mixerGetControlDetailsW((HMIXEROBJ)UlongToHandle(g_mixerId), &mixerControlDetails, 0))
             return E_FAIL;
 
         TRACE("Obtained mute status %d\n", detailsResult);

--- a/dll/shellext/stobject/volume.cpp
+++ b/dll/shellext/stobject/volume.cpp
@@ -111,7 +111,6 @@ static HRESULT __stdcall Volume_FindMixerControl(CSysTray * pSysTray)
 
 HRESULT Volume_IsMute()
 {
-#if 0
     MIXERCONTROLDETAILS mixerControlDetails;
 
     if (g_mixerId != (UINT)-1 && g_muteControlID != (DWORD)-1)
@@ -130,7 +129,7 @@ HRESULT Volume_IsMute()
 
         g_IsMute = detailsResult != 0;
     }
-#endif
+
     return S_OK;
 }
 


### PR DESCRIPTION
## Purpose

Based on KRosUser's `volume.patch`.
The pair of `#if 0` and `#endif` was added in https://github.com/reactos/reactos/commit/180b6fb0834038cd558b2791f6afdbf6063ed30c .
This PR will remove it.

JIRA issue: [CORE-18583](https://jira.reactos.org/browse/CORE-18583)

## TODO

- [x] Do tests.