### PR TITLE
[SHIMGVW] Add filename extension on file save

### DIFF
--- a/dll/win32/shimgvw/shimgvw.c
+++ b/dll/win32/shimgvw/shimgvw.c
@@ -435,8 +435,9 @@ static void pSaveImageAs(HWND hwnd)
     sfn.hInstance   = hInstance;
     sfn.lpstrFile   = szSaveFileName;
     sfn.lpstrFilter = szFilterMask;
-    sfn.nMaxFile    = MAX_PATH;
+    sfn.nMaxFile    = _countof(szSaveFileName);
     sfn.Flags       = OFN_EXPLORER | OFN_OVERWRITEPROMPT | OFN_HIDEREADONLY;
+    sfn.lpstrDefExt = L"png";
 
     c = szFilterMask;
 


### PR DESCRIPTION
## Purpose

Add a filename extension if necessary.
JIRA issue: [CORE-19222](https://jira.reactos.org/browse/CORE-19222)

## Proposed changes

- Set `"png"` to `OPENFILENAME.lpstrDefExt`.

## TODO

- [x] Do tests.

## Comparison

BEFORE:
![before](https://github.com/reactos/reactos/assets/2107452/cad36f5b-c1a6-4479-8340-2ec5922a82b3)
The filename extension wasn't added.

AFTER:
![after](https://github.com/reactos/reactos/assets/2107452/3d0da098-d1ac-42e7-a197-7728bb05cfab)
The filename extension is added.