### PR TITLE
[TASKMGR] Fix text cutoff statusbar2 CPU%, improve statusbar3 Mem

### DIFF
--- a/base/applications/taskmgr/lang/bg-BG.rc
+++ b/base/applications/taskmgr/lang/bg-BG.rc
@@ -430,7 +430,7 @@ BEGIN
     IDS_MSG_WARNINGCHANGEPRIORITY "ВНИМАНИЕ: Промяната на първенството на това действие може да\nпричини нежелани последствия, включително неустойчивост на системата. Сигурен ли сте,\nче искате да смените старшинството?"
     IDS_MSG_TRAYICONCPUUSAGE "Заетост на ЦПУ: %d%%"
     IDS_STATUS_MEMUSAGE "Заета памет: %s / %s (%d%%)"
-    IDS_STATUS_CPUUSAGE "Заетост на ЦПУ: %3d%%"
+    IDS_STATUS_CPUUSAGE "ЦПУ: %3d%%"
     IDS_STATUS_PROCESSES "Действия: %d"
     IDS_NOT_RESPONDING "Не отговаря"
     IDS_RUNNING "Работи"

--- a/base/applications/taskmgr/lang/cs-CZ.rc
+++ b/base/applications/taskmgr/lang/cs-CZ.rc
@@ -430,7 +430,7 @@ BEGIN
     IDS_MSG_WARNINGCHANGEPRIORITY "Upozornění: Změna priority procesu může\nzpůsobit nestabilitu systému a jiné nepředvídatelné problémy. Jste si jisti\nse změnou priority procesu?"
     IDS_MSG_TRAYICONCPUUSAGE "Využití CPU: %d%%"
     IDS_STATUS_MEMUSAGE "Využití paměti: %s / %s (%d%%)"
-    IDS_STATUS_CPUUSAGE "Využití CPU: %3d%%"
+    IDS_STATUS_CPUUSAGE "CPU: %3d%%"
     IDS_STATUS_PROCESSES "Procesy: %d"
     IDS_NOT_RESPONDING "Neodpovídá"
     IDS_RUNNING "Běží"

--- a/base/applications/taskmgr/lang/da-DK.rc
+++ b/base/applications/taskmgr/lang/da-DK.rc
@@ -430,7 +430,7 @@ BEGIN
     IDS_MSG_WARNINGCHANGEPRIORITY "WARNING: Changing the priority class of this process may\ncause undesired results including system instability. Are you\nsure you want to change the priority class?"
     IDS_MSG_TRAYICONCPUUSAGE "CPU Usage: %d%%"
     IDS_STATUS_MEMUSAGE "Mem Usage: %s / %s (%d%%)"
-    IDS_STATUS_CPUUSAGE "CPU Usage: %3d%%"
+    IDS_STATUS_CPUUSAGE "CPU: %3d%%"
     IDS_STATUS_PROCESSES "Processes: %d"
     IDS_NOT_RESPONDING "Not Responding"
     IDS_RUNNING "Running"

--- a/base/applications/taskmgr/lang/de-DE.rc
+++ b/base/applications/taskmgr/lang/de-DE.rc
@@ -432,7 +432,7 @@ BEGIN
     IDS_MSG_WARNINGCHANGEPRIORITY "WARNUNG: Das Ändern der Prioritätsklasse dieses Prozesses\nkann zu unerwünschten Ergebnissen, einschl. Systeminstabilität, führen.\nSind Sie sicher, dass Sie diese ändern möchten?"
     IDS_MSG_TRAYICONCPUUSAGE "CPU-Last: %d%%"
     IDS_STATUS_MEMUSAGE "Speicher: %s / %s (%d%%)"
-    IDS_STATUS_CPUUSAGE "CPU-Last: %3d%%"
+    IDS_STATUS_CPUUSAGE "CPU: %3d%%"
     IDS_STATUS_PROCESSES "Prozesse: %d"
     IDS_NOT_RESPONDING "Keine Rückmeldung"
     IDS_RUNNING "Wird ausgeführt"

--- a/base/applications/taskmgr/lang/el-GR.rc
+++ b/base/applications/taskmgr/lang/el-GR.rc
@@ -432,7 +432,7 @@ BEGIN
     IDS_MSG_WARNINGCHANGEPRIORITY "WARNING: Changing the priority class of this process may\ncause undesired results including system instability. Are you\nsure you want to change the priority class?"
     IDS_MSG_TRAYICONCPUUSAGE "CPU Usage: %d%%"
     IDS_STATUS_MEMUSAGE "Commit Charge: %s / %s (%d%%)"
-    IDS_STATUS_CPUUSAGE "CPU Usage: %3d%%"
+    IDS_STATUS_CPUUSAGE "CPU: %3d%%"
     IDS_STATUS_PROCESSES "Processes: %d"
     IDS_NOT_RESPONDING "Not Responding"
     IDS_RUNNING "Running"

--- a/base/applications/taskmgr/lang/en-US.rc
+++ b/base/applications/taskmgr/lang/en-US.rc
@@ -430,7 +430,7 @@ BEGIN
     IDS_MSG_WARNINGCHANGEPRIORITY "WARNING: Changing the priority class of this process may\ncause undesired results including system instability. Are you\nsure you want to change the priority class?"
     IDS_MSG_TRAYICONCPUUSAGE "CPU Usage: %d%%"
     IDS_STATUS_MEMUSAGE "Commit Charge: %s / %s (%d%%)"
-    IDS_STATUS_CPUUSAGE "CPU Usage: %3d%%"
+    IDS_STATUS_CPUUSAGE "CPU: %3d%%"
     IDS_STATUS_PROCESSES "Processes: %d"
     IDS_NOT_RESPONDING "Not Responding"
     IDS_RUNNING "Running"

--- a/base/applications/taskmgr/lang/es-ES.rc
+++ b/base/applications/taskmgr/lang/es-ES.rc
@@ -432,7 +432,7 @@ BEGIN
     IDS_MSG_WARNINGCHANGEPRIORITY "Advertencia: El cambio de prioridad en ciertos procesos podría provocar la inestabilidad del sistema.\n¿Seguro que desea cambiar la prioridad?"
     IDS_MSG_TRAYICONCPUUSAGE "Promedio CPU: %d%%"
     IDS_STATUS_MEMUSAGE "Uso de memoria: %s / %s (%d%%)"
-    IDS_STATUS_CPUUSAGE "Uso de CPU: %3d%%"
+    IDS_STATUS_CPUUSAGE "CPU: %3d%%"
     IDS_STATUS_PROCESSES "Procesos: %d"
     IDS_NOT_RESPONDING "No responde"
     IDS_RUNNING "En ejecución"

--- a/base/applications/taskmgr/lang/et-EE.rc
+++ b/base/applications/taskmgr/lang/et-EE.rc
@@ -436,7 +436,7 @@ BEGIN
     IDS_MSG_WARNINGCHANGEPRIORITY "HOIATUS: Selle protsessi prioriteedi muutmine võib põhjustada soovimatuid\ntagajärgi sealhulgas süsteemi ebastabiilsust.\nKas olete kindel et tahate muuta prioriteeti?"
     IDS_MSG_TRAYICONCPUUSAGE "CPU hõivatus: %d%%"
     IDS_STATUS_MEMUSAGE "Hõivatud mälu: %s / %s (%d%%)"
-    IDS_STATUS_CPUUSAGE "CPU hõivatus: %3d%%"
+    IDS_STATUS_CPUUSAGE "CPU: %3d%%"
     IDS_STATUS_PROCESSES "Protsesse: %d"
     IDS_NOT_RESPONDING "Ei vasta"
     IDS_RUNNING "Töötab"

--- a/base/applications/taskmgr/lang/fr-FR.rc
+++ b/base/applications/taskmgr/lang/fr-FR.rc
@@ -1,4 +1,4 @@
-// COPYRIGHT: Benoit Plante (aka cmoibenlepro)
+// COPYRIGHT: Benoit Plante (cmoibenlepro)
 
 LANGUAGE LANG_FRENCH, SUBLANG_NEUTRAL
 
@@ -432,7 +432,7 @@ BEGIN
     IDS_MSG_WARNINGCHANGEPRIORITY "ATTENTION : Changer la priorité du processus peut causer des\neffets indésirables comme l'instabilité du système.\nÊtes-vous sûr de vouloir changer la priorité ?"
     IDS_MSG_TRAYICONCPUUSAGE "UC utilisée : %d%%"
     IDS_STATUS_MEMUSAGE "Fichier d'échange utilisé : %s / %s (%d%%)"
-    IDS_STATUS_CPUUSAGE "UC utilisée : %3d%%"
+    IDS_STATUS_CPUUSAGE "UC : %3d%%"
     IDS_STATUS_PROCESSES "Processus : %d"
     IDS_NOT_RESPONDING "Ne répond pas"
     IDS_RUNNING "En cours d'exécution"

--- a/base/applications/taskmgr/lang/fr-FR.rc
+++ b/base/applications/taskmgr/lang/fr-FR.rc
@@ -1,4 +1,4 @@
-// COPYRIGHT: Benoit Plante (cmoibenlepro)
+// COPYRIGHT: Benoit Plante (aka cmoibenlepro)
 
 LANGUAGE LANG_FRENCH, SUBLANG_NEUTRAL
 

--- a/base/applications/taskmgr/lang/he-IL.rc
+++ b/base/applications/taskmgr/lang/he-IL.rc
@@ -432,7 +432,7 @@ BEGIN
     IDS_MSG_WARNINGCHANGEPRIORITY "WARNING: Changing the priority class of this process may\ncause undesired results including system instability. Are you\nsure you want to change the priority class?"
     IDS_MSG_TRAYICONCPUUSAGE "%3d%% :שימוש במעבד"
     IDS_STATUS_MEMUSAGE "Commit Charge: %s / %s (%d%%)"
-    IDS_STATUS_CPUUSAGE "%3d%% :שימוש במעבד "
+    IDS_STATUS_CPUUSAGE "%3d%% :מעבד"
     IDS_STATUS_PROCESSES "%d :תהליכים"
     IDS_NOT_RESPONDING "לא מגיב"
     IDS_RUNNING "פועל"

--- a/base/applications/taskmgr/lang/hu-HU.rc
+++ b/base/applications/taskmgr/lang/hu-HU.rc
@@ -432,7 +432,7 @@ BEGIN
     IDS_MSG_WARNINGCHANGEPRIORITY "FIGYELEM: A prioritás megváltoztatása\nkellemetlenségeket, akár rendszer instabilitást is okozhat.\nBiztosan meg akarja változtatni a prioritást?"
     IDS_MSG_TRAYICONCPUUSAGE "CPU használat: %d%%"
     IDS_STATUS_MEMUSAGE "Mem használat: %s / %s (%d%%)"
-    IDS_STATUS_CPUUSAGE "CPU használat: %3d%%"
+    IDS_STATUS_CPUUSAGE "CPU: %3d%%"
     IDS_STATUS_PROCESSES "Folyamatok: %d"
     IDS_NOT_RESPONDING "Nem válaszol"
     IDS_RUNNING "Fut"

--- a/base/applications/taskmgr/lang/id-ID.rc
+++ b/base/applications/taskmgr/lang/id-ID.rc
@@ -432,7 +432,7 @@ BEGIN
     IDS_MSG_WARNINGCHANGEPRIORITY "PERINGATAN: Mengubah kelas prioritas dari proses ini\ndapat menyebabkan hasil yang tidak diinginkan termasuk ketidakstabilan sistem.\nAnda yakin ingin mengubah kelas prioritas?"
     IDS_MSG_TRAYICONCPUUSAGE "Pemakaian CPU: %d%%"
     IDS_STATUS_MEMUSAGE "Pemakaian Mem: %s / %s (%d%%)"
-    IDS_STATUS_CPUUSAGE "Pemakaian CPU: %3d%%"
+    IDS_STATUS_CPUUSAGE "CPU: %3d%%"
     IDS_STATUS_PROCESSES "Proses: %d"
     IDS_NOT_RESPONDING "Tidak Merespon"
     IDS_RUNNING "Berjalan"

--- a/base/applications/taskmgr/lang/it-IT.rc
+++ b/base/applications/taskmgr/lang/it-IT.rc
@@ -430,7 +430,7 @@ BEGIN
     IDS_MSG_WARNINGCHANGEPRIORITY "ATTENZIONE: La modifica della classe di priorità può provocare\n effetti indesiderati compresa la perdita di dati o l'instabilità del sistema.\nSei sicuro di voler procedere?"
     IDS_MSG_TRAYICONCPUUSAGE "Uso CPU: %d%%"
     IDS_STATUS_MEMUSAGE "Uso Mem: %s / %s (%d%%)"
-    IDS_STATUS_CPUUSAGE "Uso CPU: %3d%%"
+    IDS_STATUS_CPUUSAGE "CPU: %3d%%"
     IDS_STATUS_PROCESSES "Processi: %d"
     IDS_NOT_RESPONDING "Non risponde"
     IDS_RUNNING "In esecuzione"

--- a/base/applications/taskmgr/lang/ja-JP.rc
+++ b/base/applications/taskmgr/lang/ja-JP.rc
@@ -430,7 +430,7 @@ BEGIN
     IDS_MSG_WARNINGCHANGEPRIORITY "警告: このプロセスの優先度クラスを変更すると、システムが不安定に\nなるなど、予期しない結果になることがあります。\n優先度クラスを変更しますか?"
     IDS_MSG_TRAYICONCPUUSAGE "CPU 使用率: %d%%"
     IDS_STATUS_MEMUSAGE "メモリ使用量: %s / %s (%d%%)"
-    IDS_STATUS_CPUUSAGE "CPU 使用率: %3d%%"
+    IDS_STATUS_CPUUSAGE "CPU: %3d%%"
     IDS_STATUS_PROCESSES "プロセス: %d"
     IDS_NOT_RESPONDING "応答なし"
     IDS_RUNNING "実行中"

--- a/base/applications/taskmgr/lang/ko-KR.rc
+++ b/base/applications/taskmgr/lang/ko-KR.rc
@@ -432,7 +432,7 @@ BEGIN
     IDS_MSG_WARNINGCHANGEPRIORITY "경고: 이 프로세스의 우선 순위 클래스를 변경하면 시스템 불안정을 포함하여\n예기치 않은 결과를 초래할 수도 있습니다.\n우선 순위 클래스를 변경하시겠습니까?"
     IDS_MSG_TRAYICONCPUUSAGE "CPU 사용: %d%%"
     IDS_STATUS_MEMUSAGE "메모리 사용: %s / %s (%d%%)"
-    IDS_STATUS_CPUUSAGE "CPU 사용: %3d%%"
+    IDS_STATUS_CPUUSAGE "CPU: %3d%%"
     IDS_STATUS_PROCESSES "프로세스: %d"
     IDS_NOT_RESPONDING "응답 없음"
     IDS_RUNNING "실행 중"

--- a/base/applications/taskmgr/lang/nl-NL.rc
+++ b/base/applications/taskmgr/lang/nl-NL.rc
@@ -406,7 +406,7 @@ BEGIN
     IDS_TAB_IOOTHERBYTES "I/O: overige bytes"
     IDS_TAB_COMMANDLINE "Command Line"
     IDS_MENU_SELECTCOLUMNS "&Kolommen selecteren..."
-    IDS_MENU_16BITTASK "&16-bits taken weergeven"
+    IDS_MENU_16BITTASK "&16-bits taken weergeven" //FIXME: Please double-check this accelerator
     IDS_MENU_WINDOWS "&Vensters"
     IDS_MENU_LARGEICONS "&Grote pictogrammen"
     IDS_MENU_SMALLICONS "&Kleine pictogrammen"

--- a/base/applications/taskmgr/lang/nl-NL.rc
+++ b/base/applications/taskmgr/lang/nl-NL.rc
@@ -11,7 +11,7 @@ BEGIN
     POPUP "&Opties"
     BEGIN
         MENUITEM "&Altijd op voorgrond", ID_OPTIONS_ALWAYSONTOP, CHECKED
-        MENUITEM "Minimaliseren &bij gebruik", ID_OPTIONS_MINIMIZEONUSE, CHECKED //FIXME: accelerator collision &b with IDS_MENU_16BITTASK
+        MENUITEM "Minimaliseren &bij gebruik", ID_OPTIONS_MINIMIZEONUSE, CHECKED
         MENUITEM "&Verbergen indien geminimaliseerd", ID_OPTIONS_HIDEWHENMINIMIZED, CHECKED
         MENUITEM "", ID_OPTIONS_SHOW16BITTASKS, CHECKED
     END
@@ -406,7 +406,7 @@ BEGIN
     IDS_TAB_IOOTHERBYTES "I/O: overige bytes"
     IDS_TAB_COMMANDLINE "Command Line"
     IDS_MENU_SELECTCOLUMNS "&Kolommen selecteren..."
-    IDS_MENU_16BITTASK "16-&bits taken weergeven" //FIXME: accelerator collision &b with ID_OPTIONS_MINIMIZEONUSE
+    IDS_MENU_16BITTASK "&16-bits taken weergeven"
     IDS_MENU_WINDOWS "&Vensters"
     IDS_MENU_LARGEICONS "&Grote pictogrammen"
     IDS_MENU_SMALLICONS "&Kleine pictogrammen"
@@ -430,7 +430,7 @@ BEGIN
     IDS_MSG_WARNINGCHANGEPRIORITY "Waarschuwing: het wijzigen van de prioriteitsklasse van dit proces\nkan ongewenste resultaten hebben, zoals een instabiel systeem. Weet u\nzeker dat u de prioriteitsklasse wilt wijzigen?"
     IDS_MSG_TRAYICONCPUUSAGE "CPU-gebruik: %d%%"
     IDS_STATUS_MEMUSAGE "Geheugengebruik: %s / %s (%d%%)"
-    IDS_STATUS_CPUUSAGE "CPU-gebruik: %3d%%"
+    IDS_STATUS_CPUUSAGE "CPU: %3d%%"
     IDS_STATUS_PROCESSES "Processen: %d"
     IDS_NOT_RESPONDING "Reageert niet"
     IDS_RUNNING "Geactiveerd"

--- a/base/applications/taskmgr/lang/no-NO.rc
+++ b/base/applications/taskmgr/lang/no-NO.rc
@@ -430,7 +430,7 @@ BEGIN
     IDS_MSG_WARNINGCHANGEPRIORITY "ADVARSEL: Endring av prioritet klasse av denne prosess kan\nforutsake uønsket resultat inkluderer systemet kan bli ustabilt. Er du\nsikker på at du vil endre prioritet klassen?"
     IDS_MSG_TRAYICONCPUUSAGE "Prosessorbruk: %d%%"
     IDS_STATUS_MEMUSAGE "Tildelt minne: %s / %s (%d%%)"
-    IDS_STATUS_CPUUSAGE "Prosessorbruk: %3d%%"
+    IDS_STATUS_CPUUSAGE "CPU: %3d%%"
     IDS_STATUS_PROCESSES "Prosesser: %d"
     IDS_NOT_RESPONDING "Ingen reaksjon"
     IDS_RUNNING "Kjører"

--- a/base/applications/taskmgr/lang/pl-PL.rc
+++ b/base/applications/taskmgr/lang/pl-PL.rc
@@ -435,7 +435,7 @@ BEGIN
     IDS_MSG_WARNINGCHANGEPRIORITY "UWAGA: Zmiana priorytetu tego procesu może przynieść\nniepożądane skutki, w tym również niestabilność systemu.\nCzy na pewno chcesz zmieni priorytet?"
     IDS_MSG_TRAYICONCPUUSAGE "Użycie procesora: %d%%"
     IDS_STATUS_MEMUSAGE "Pam. zadeklar.: %s / %s (%d%%)"
-    IDS_STATUS_CPUUSAGE "Użycie procesora: %3d%%"
+    IDS_STATUS_CPUUSAGE "CPU: %3d%%"
     IDS_STATUS_PROCESSES "Procesy: %d"
     IDS_NOT_RESPONDING "Nie odpowiada"
     IDS_RUNNING "Uruchomiony"

--- a/base/applications/taskmgr/lang/pt-BR.rc
+++ b/base/applications/taskmgr/lang/pt-BR.rc
@@ -430,7 +430,7 @@ BEGIN
     IDS_MSG_WARNINGCHANGEPRIORITY "AVISO: a alteração da classe de prioridade do processo\npode causar efeitos indesejáveis, inclusive a instabilidade do sistema. Tem\ncerteza de que deseja alterar a classe de prioridade?"
     IDS_MSG_TRAYICONCPUUSAGE "Uso de CPU: %d%%"
     IDS_STATUS_MEMUSAGE "Uso de Memória: %s / %s (%d%%)"
-    IDS_STATUS_CPUUSAGE "Uso de CPU: %3d%%"
+    IDS_STATUS_CPUUSAGE "CPU: %3d%%"
     IDS_STATUS_PROCESSES "Processo: %d"
     IDS_NOT_RESPONDING "Não respondendo"
     IDS_RUNNING "Execuando"

--- a/base/applications/taskmgr/lang/pt-PT.rc
+++ b/base/applications/taskmgr/lang/pt-PT.rc
@@ -432,7 +432,7 @@ BEGIN
     IDS_MSG_WARNINGCHANGEPRIORITY "AVISO: a alteração da classe de prioridade do processo\npode causar efeitos indesejáveis, inclusive a instabilidade do sistema. Tem\ncerteza de que deseja alterar a classe de prioridade?"
     IDS_MSG_TRAYICONCPUUSAGE "Uso de CPU: %d%%"
     IDS_STATUS_MEMUSAGE "Uso de Memória: %s / %s (%d%%)"
-    IDS_STATUS_CPUUSAGE "Uso de CPU: %3d%%"
+    IDS_STATUS_CPUUSAGE "CPU: %3d%%"
     IDS_STATUS_PROCESSES "Processo: %d"
     IDS_NOT_RESPONDING "Não responde"
     IDS_RUNNING "Em execução"

--- a/base/applications/taskmgr/lang/ro-RO.rc
+++ b/base/applications/taskmgr/lang/ro-RO.rc
@@ -433,7 +433,7 @@ BEGIN
     IDS_MSG_WARNINGCHANGEPRIORITY "Schimbarea priorității poate duce la efecte colaterale\nprecum instabilitatea sistemului.\nSigur doriți schimbarea priorității procesului?"
     IDS_MSG_TRAYICONCPUUSAGE "Utilizare procesor: %d%%"
     IDS_STATUS_MEMUSAGE "Utilizare memorie: %s / %s (%d%%)"
-    IDS_STATUS_CPUUSAGE "Utilizare procesor: %3d%%"
+    IDS_STATUS_CPUUSAGE "CPU: %3d%%"
     IDS_STATUS_PROCESSES "Procese: %d"
     IDS_NOT_RESPONDING "EXECUȚIE ANORMALĂ"
     IDS_RUNNING "execuție normală"

--- a/base/applications/taskmgr/lang/ru-RU.rc
+++ b/base/applications/taskmgr/lang/ru-RU.rc
@@ -432,7 +432,7 @@ BEGIN
     IDS_MSG_WARNINGCHANGEPRIORITY "ВНИМАНИЕ! Изменение класса приоритета этого\nпроцесса может привести к нежелательным результатам,\nв том числе к нестабильной работе системы. Вы\nдействительно хотите изменить класс приоритета?"
     IDS_MSG_TRAYICONCPUUSAGE "Загрузка ЦП: %d%%"
     IDS_STATUS_MEMUSAGE "Выделение памяти: %s / %s (%d%%)"
-    IDS_STATUS_CPUUSAGE "Загрузка ЦП: %3d%%"
+    IDS_STATUS_CPUUSAGE "ЦП: %3d%%"
     IDS_STATUS_PROCESSES "Процессов: %d"
     IDS_NOT_RESPONDING "Не отвечает"
     IDS_RUNNING "Работает"

--- a/base/applications/taskmgr/lang/sk-SK.rc
+++ b/base/applications/taskmgr/lang/sk-SK.rc
@@ -432,7 +432,7 @@ BEGIN
     IDS_MSG_WARNINGCHANGEPRIORITY "UPOZORNENIE: Zmena triedy priority procesu môže mať\nnežiadúce dôsledky vrátane nestability systému.\nNaozaj chcete zmeniť triedu priority procesu?"
     IDS_MSG_TRAYICONCPUUSAGE "Využitie procesora: %d%%"
     IDS_STATUS_MEMUSAGE "Využitá pamäť: %s / %s (%d%%)"
-    IDS_STATUS_CPUUSAGE "Využitie procesora: %3d%%"
+    IDS_STATUS_CPUUSAGE "CPU: %3d%%"
     IDS_STATUS_PROCESSES "Procesy: %d"
     IDS_NOT_RESPONDING "Neodpovedá"
     IDS_RUNNING "Spustené"

--- a/base/applications/taskmgr/lang/sq-AL.rc
+++ b/base/applications/taskmgr/lang/sq-AL.rc
@@ -432,7 +432,7 @@ BEGIN
     IDS_MSG_WARNINGCHANGEPRIORITY "KUJDES: Ndryshimi i klases se prioritetit te ketij procesi mund te\nsjell rrezultate te padeshirushme ne stabilitetin e sistemit. Jeni i sigurt\nper ndryshimin e klases se prioriteteve?"
     IDS_MSG_TRAYICONCPUUSAGE "Perdorimi i CPU: %d%%"
     IDS_STATUS_MEMUSAGE "Perdorimi i Mem: %s / %s (%d%%)"
-    IDS_STATUS_CPUUSAGE "Perdorimi i CPU: %3d%%"
+    IDS_STATUS_CPUUSAGE "CPU: %3d%%"
     IDS_STATUS_PROCESSES "Proceset: %d"
     IDS_NOT_RESPONDING "Nuk pergjigjet"
     IDS_RUNNING "Ne pune"

--- a/base/applications/taskmgr/lang/sv-SE.rc
+++ b/base/applications/taskmgr/lang/sv-SE.rc
@@ -432,7 +432,7 @@ BEGIN
     IDS_MSG_WARNINGCHANGEPRIORITY "VARNING: Ändring av prioritetsklassen hos den här processen kan\norsaka oönskade effekter och påverka systemets stabilitet. Är du\nsäker på att du vill ändra prioritetsklassen?"
     IDS_MSG_TRAYICONCPUUSAGE "Processoranvändning: %d%%"
     IDS_STATUS_MEMUSAGE "Minnesanv: %s / %s (%d%%)"
-    IDS_STATUS_CPUUSAGE "Processoranv: %3d%%"
+    IDS_STATUS_CPUUSAGE "CPU: %3d%%"
     IDS_STATUS_PROCESSES "Processer: %d"
     IDS_NOT_RESPONDING "Svarar inte"
     IDS_RUNNING "Igång"

--- a/base/applications/taskmgr/lang/tr-TR.rc
+++ b/base/applications/taskmgr/lang/tr-TR.rc
@@ -432,7 +432,7 @@ BEGIN
     IDS_MSG_WARNINGCHANGEPRIORITY "UYARI: Bu işlemin öncelik sınıfının değiştirilmesi, sistem\nkararsızlığı dahil pek çok istenmeyen sonuca neden olabilir. Öncelik\nsınıfını değiştirmek istediğinizden emin misiniz?"
     IDS_MSG_TRAYICONCPUUSAGE "CPU Kullanımı: %%%d"
     IDS_STATUS_MEMUSAGE "Ayrılmış Bellek: %s / %s (%%%d)"
-    IDS_STATUS_CPUUSAGE "CPU Kullanımı: %%%3d"
+    IDS_STATUS_CPUUSAGE "CPU: %%%3d"
     IDS_STATUS_PROCESSES "İşlem: %d"
     IDS_NOT_RESPONDING "Yanıt Vermiyor"
     IDS_RUNNING "Çalışıyor"

--- a/base/applications/taskmgr/lang/uk-UA.rc
+++ b/base/applications/taskmgr/lang/uk-UA.rc
@@ -430,7 +430,7 @@ BEGIN
     IDS_MSG_WARNINGCHANGEPRIORITY "УВАГА! Зміна класу пріоритету цього процесу може призвести до\nнебажаних наслідків, включаючи нестабільну роботу\nсистеми.  Ви дійсно бажаєте змінити пріоритет класу?"
     IDS_MSG_TRAYICONCPUUSAGE "Використання ЦП: %d%%"
     IDS_STATUS_MEMUSAGE "Пам'ять: %s / %s (%d%%)"
-    IDS_STATUS_CPUUSAGE "Використання ЦП: %3d%%"
+    IDS_STATUS_CPUUSAGE "ЦП: %3d%%"
     IDS_STATUS_PROCESSES "Процесів: %d"
     IDS_NOT_RESPONDING "Не відповідає"
     IDS_RUNNING "Виконується"

--- a/base/applications/taskmgr/lang/zh-CN.rc
+++ b/base/applications/taskmgr/lang/zh-CN.rc
@@ -433,7 +433,7 @@ BEGIN
     IDS_MSG_WARNINGCHANGEPRIORITY "警告：改变这一进程的优先级可能会\n导致意外的结果，包括系统不稳定。 您确定\n要更改优先级类？"
     IDS_MSG_TRAYICONCPUUSAGE "CPU 使用情况：%d%%"
     IDS_STATUS_MEMUSAGE "内存使用情况：%s / %s（%d%%）"
-    IDS_STATUS_CPUUSAGE "CPU: %3d%%"
+    IDS_STATUS_CPUUSAGE "CPU： %3d%%"
     IDS_STATUS_PROCESSES "进程数：%d"
     IDS_NOT_RESPONDING "未响应"
     IDS_RUNNING "正在运行"

--- a/base/applications/taskmgr/lang/zh-CN.rc
+++ b/base/applications/taskmgr/lang/zh-CN.rc
@@ -433,7 +433,7 @@ BEGIN
     IDS_MSG_WARNINGCHANGEPRIORITY "警告：改变这一进程的优先级可能会\n导致意外的结果，包括系统不稳定。 您确定\n要更改优先级类？"
     IDS_MSG_TRAYICONCPUUSAGE "CPU 使用情况：%d%%"
     IDS_STATUS_MEMUSAGE "内存使用情况：%s / %s（%d%%）"
-    IDS_STATUS_CPUUSAGE "CPU 使用情况：%3d%%"
+    IDS_STATUS_CPUUSAGE "CPU: %3d%%"
     IDS_STATUS_PROCESSES "进程数：%d"
     IDS_NOT_RESPONDING "未响应"
     IDS_RUNNING "正在运行"

--- a/base/applications/taskmgr/lang/zh-HK.rc
+++ b/base/applications/taskmgr/lang/zh-HK.rc
@@ -438,7 +438,7 @@ BEGIN
     IDS_MSG_WARNINGCHANGEPRIORITY "警告：更改此處理程序的優先順序可能導致系統不穩定。\n你確定要更改優先順序嗎？"
     IDS_MSG_TRAYICONCPUUSAGE "CPU 使用情況： %d%%"
     IDS_STATUS_MEMUSAGE "記憶體使用情況： %s ／ %s (%d%%)"
-    IDS_STATUS_CPUUSAGE "CPU 使用情況： %3d%%"
+    IDS_STATUS_CPUUSAGE "CPU: %3d%%"
     IDS_STATUS_PROCESSES "處理程序： %d"
     IDS_NOT_RESPONDING "沒有回應"
     IDS_RUNNING "正在執行"

--- a/base/applications/taskmgr/lang/zh-HK.rc
+++ b/base/applications/taskmgr/lang/zh-HK.rc
@@ -438,7 +438,7 @@ BEGIN
     IDS_MSG_WARNINGCHANGEPRIORITY "警告：更改此處理程序的優先順序可能導致系統不穩定。\n你確定要更改優先順序嗎？"
     IDS_MSG_TRAYICONCPUUSAGE "CPU 使用情況： %d%%"
     IDS_STATUS_MEMUSAGE "記憶體使用情況： %s ／ %s (%d%%)"
-    IDS_STATUS_CPUUSAGE "CPU: %3d%%"
+    IDS_STATUS_CPUUSAGE "CPU： %3d%%"
     IDS_STATUS_PROCESSES "處理程序： %d"
     IDS_NOT_RESPONDING "沒有回應"
     IDS_RUNNING "正在執行"

--- a/base/applications/taskmgr/lang/zh-TW.rc
+++ b/base/applications/taskmgr/lang/zh-TW.rc
@@ -438,7 +438,7 @@ BEGIN
     IDS_MSG_WARNINGCHANGEPRIORITY "警告：更改此處理程序的優先順序可能導致系統不穩定。\n您確定要更改優先順序嗎？"
     IDS_MSG_TRAYICONCPUUSAGE "CPU 使用情況： %d%%"
     IDS_STATUS_MEMUSAGE "記憶體使用情況： %s ／ %s (%d%%)"
-    IDS_STATUS_CPUUSAGE "CPU 使用情況： %3d%%"
+    IDS_STATUS_CPUUSAGE "CPU: %3d%%"
     IDS_STATUS_PROCESSES "處理程序： %d"
     IDS_NOT_RESPONDING "沒有回應"
     IDS_RUNNING "正在執行"

--- a/base/applications/taskmgr/lang/zh-TW.rc
+++ b/base/applications/taskmgr/lang/zh-TW.rc
@@ -438,7 +438,7 @@ BEGIN
     IDS_MSG_WARNINGCHANGEPRIORITY "警告：更改此處理程序的優先順序可能導致系統不穩定。\n您確定要更改優先順序嗎？"
     IDS_MSG_TRAYICONCPUUSAGE "CPU 使用情況： %d%%"
     IDS_STATUS_MEMUSAGE "記憶體使用情況： %s ／ %s (%d%%)"
-    IDS_STATUS_CPUUSAGE "CPU: %3d%%"
+    IDS_STATUS_CPUUSAGE "CPU： %3d%%"
     IDS_STATUS_PROCESSES "處理程序： %d"
     IDS_NOT_RESPONDING "沒有回應"
     IDS_RUNNING "正在執行"

--- a/base/applications/taskmgr/taskmgr.h
+++ b/base/applications/taskmgr/taskmgr.h
@@ -36,7 +36,7 @@ typedef struct
 	BOOL	HideWhenMinimized;
 	BOOL	Show16BitTasks;
 
-	// 0 - Paused, 1 - High, 2 - Normal, 4 - Low
+	/* 0 - Paused, 1 - High, 2 - Normal, 4 - Low */
 	DWORD	UpdateSpeed;
 
 	/* Applications page settings */

--- a/base/applications/taskmgr/taskmgr.h
+++ b/base/applications/taskmgr/taskmgr.h
@@ -15,7 +15,7 @@
 
 #define STATUS_WINDOW	2001
 #define STATUS_SIZE1	85
-#define STATUS_SIZE2	157 // he-IL.rc determines 72 requirement
+#define STATUS_SIZE2	157 // he-IL.rc determines minimum width:  72 == 157 - 85
 #define STATUS_SIZE3	400
 
 typedef struct

--- a/base/applications/taskmgr/taskmgr.h
+++ b/base/applications/taskmgr/taskmgr.h
@@ -15,7 +15,7 @@
 
 #define STATUS_WINDOW	2001
 #define STATUS_SIZE1	85
-#define STATUS_SIZE2	157 // he-IL.rc determines minimum width:  72 == 157 - 85
+#define STATUS_SIZE2	157 // he-IL.rc determines minimum width: 72 == 157 - 85
 #define STATUS_SIZE3	400
 
 typedef struct

--- a/base/applications/taskmgr/taskmgr.h
+++ b/base/applications/taskmgr/taskmgr.h
@@ -15,7 +15,7 @@
 
 #define STATUS_WINDOW	2001
 #define STATUS_SIZE1	85
-#define STATUS_SIZE2	190
+#define STATUS_SIZE2	157 // he-IL.rc determines 72 requirement
 #define STATUS_SIZE3	400
 
 typedef struct
@@ -36,15 +36,14 @@ typedef struct
 	BOOL	HideWhenMinimized;
 	BOOL	Show16BitTasks;
 
-	/* Update speed settings */
-	/* How many half-seconds in between updates (i.e. 0 - Paused, 1 - High, 2 - Normal, 4 - Low) */
+	// 0 - Paused, 1 - High, 2 - Normal, 4 - Low
 	DWORD	UpdateSpeed;
 
 	/* Applications page settings */
 	DWORD	ViewMode;
 
 	/* Processes page settings */
-	BOOL	ShowProcessesFromAllUsers; /* Server-only? */
+	BOOL	ShowProcessesFromAllUsers;
 	BOOL	Columns[COLUMN_NMAX];
 	int		ColumnOrderArray[COLUMN_NMAX];
 	int		ColumnSizeArray[COLUMN_NMAX];
@@ -54,7 +53,6 @@ typedef struct
 	/* Performance page settings */
 	BOOL	CPUHistory_OneGraphPerCPU;
 	BOOL	ShowKernelTimes;
-
 } TASKMANAGER_SETTINGS, *LPTASKMANAGER_SETTINGS;
 
 /* Global Variables: */
@@ -82,5 +80,5 @@ void TaskManager_OnViewUpdateSpeed(DWORD);
 void TaskManager_OnTabWndSelChange(void);
 BOOL ConfirmMessageBox(HWND hWnd, LPCWSTR Text, LPCWSTR Title, UINT Type);
 VOID ShowWin32Error(DWORD dwError);
-LPTSTR GetLastErrorText( LPTSTR lpszBuf, DWORD dwSize );
+LPTSTR GetLastErrorText(LPTSTR lpszBuf, DWORD dwSize);
 DWORD EndLocalThread(HANDLE *hThread, DWORD dwThread);


### PR DESCRIPTION

## Purpose

see attached before-and-after-pics in the PR.
also fix an accelerator collision in nl-NL.rc

JIRA issue: none

for the before-pics with the text truncation please have a look into https://github.com/reactos/reactos/pull/5949 where I attached pictures of the state before this PR, where you can see the text-cutoff in very many languages for the CPU-column of statusbar, and also that for very many languages the third field in the statusbar with the Memory is not well visible for taskmgrs default size.

For the after state, where the text cutoff is fixed for **all** languages now, I decided to attach only after pics for those languages that now have the longest strings in the CPU-column. The Memory-column is improved for a lot of languages now, more text is visible there now (but for some languages still not all the text without increasing tasknmgrs size).

bg-BG-after.PNG
![bg-BG-after](https://github.com/reactos/reactos/assets/33393466/55889671-f443-4c03-91e3-edf9e7fec7da)

fr-FR-after.PNG
![fr-FR-after](https://github.com/reactos/reactos/assets/33393466/5f5e5d78-14d5-429f-bf8d-06f77a6c37ea)

he-IL-after.PNG
![he-IL-after](https://github.com/reactos/reactos/assets/33393466/b1ff1e5c-61ce-46a1-9fe1-128ad6757074)

tr-TR-after.PNG
![tr-TR-after](https://github.com/reactos/reactos/assets/33393466/87b5c85c-e73b-4c31-ab99-fc1d7c2cd1e4)
