### PR TITLE
[BOOTDATA] LiveCD: Enable Toggle key (Alt+Shift etc.) by registry

### DIFF
--- a/boot/bootdata/livecd.inf
+++ b/boot/bootdata/livecd.inf
@@ -10,6 +10,11 @@ HKLM,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders"
 ; Default locale for the keyboard layout
 HKU,".DEFAULT\Keyboard Layout\Preload","1",0x00000000,"00000409"
 
+; Toggle keys (Alt+Shift etc.)
+HKU,".DEFAULT\Keyboard Layout\Toggle","Hotkey",0x00000000,"1"
+HKU,".DEFAULT\Keyboard Layout\Toggle","Language Hotkey",0x00000000,"1"
+HKU,".DEFAULT\Keyboard Layout\Toggle","Layout Hotkey",0x00000000,"2"
+
 ; Cdrom class driver
 HKLM,"SYSTEM\CurrentControlSet\Services\Cdrom","Start",0x00010001,0x00000000
 


### PR DESCRIPTION
## Purpose
Write on the registry to enable toggle hot-keys.
JIRA issue: [CORE-13145](https://jira.reactos.org/browse/CORE-13145)

## Proposed changes

```reg
[HKEY_CURRENT_USER\Keyboard Layout\Toggle]
Hotkey=1
Language Hotkey=1
Layout Hotkey=2
```
## TODO

- [x] Do tests

## Comparison

BOOTCD:
![bootcd](https://github.com/reactos/reactos/assets/2107452/a9ba7bae-6a62-4323-aae9-470435ab5264)

LIVECD (AFTER):
![livecd-after](https://github.com/reactos/reactos/assets/2107452/4dd232e4-07e5-4ad5-a8a4-c39e4746438e)

Video:
[ReactOS-screen0.webm](https://github.com/reactos/reactos/assets/2107452/eb375c77-5726-4f68-8251-8bb6b31f1b96)
