### PR TITLE
[KMTEST] Fix duplicated test names to stop testman from blowing up

### DIFF
--- a/modules/rostests/kmtests/kmtest/testlist.c
+++ b/modules/rostests/kmtests/kmtest/testlist.c
@@ -71,7 +71,7 @@ const KMT_TEST TestList[] =
     { "TcpIpTdi",                     Test_TcpIpTdi },
     { "TcpIpConnect",                 Test_TcpIpConnect },
 #ifdef _M_AMD64
-    { "RtlCaptureContext",            Test_RtlCaptureContext },
+    { "RtlCaptureContextUM",          Test_RtlCaptureContext },
 #endif
     { NULL,                           NULL },
 };

--- a/modules/rostests/kmtests/kmtest_drv/testlist.c
+++ b/modules/rostests/kmtests/kmtest_drv/testlist.c
@@ -169,7 +169,7 @@ const KMT_TEST TestList[] =
     { "ZwMapViewOfSection",                 Test_ZwMapViewOfSection },
     { "ZwWaitForMultipleObjects",           Test_ZwWaitForMultipleObjects},
 #ifdef _M_AMD64
-    { "RtlCaptureContext",                  Test_RtlCaptureContext },
+    { "RtlCaptureContextKM",                Test_RtlCaptureContext },
 #endif
     { NULL,                                 NULL }
 };


### PR DESCRIPTION
## Purpose

In the beginning two tests with the name "RtlCaptureContext" were added to kmtest. This had made testman very angry and has been widely regarded as a bad move.

## Test result
x64 kvm: https://reactos.org/testman/compare.php?ids=91072
