### PR TITLE
[CMAKE] Remove "/Gy" option from ML

### DIFF
--- a/sdk/cmake/msvc.cmake
+++ b/sdk/cmake/msvc.cmake
@@ -22,8 +22,9 @@ endif()
 # helper macros. Note also that GCC builds use string pooling by default.
 add_compile_options(/GF)
 
-# Enable function level linking and comdat folding
-add_compile_options(/Gy)
+# Enable function level linking and comdat folding (only C/C++, not ASM!)
+add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/Gy>)
+add_compile_options($<$<COMPILE_LANGUAGE:C>:/Gy>)
 add_link_options(/OPT:REF /OPT:ICF)
 
 if(ARCH STREQUAL "i386")


### PR DESCRIPTION
## Purpose
Fix build with latest VS 2022

Reason: VS solution builds pass the compiler options to the assembler. These are usually ignored and result in a warning only, but ML of the latest VS supports /Gy (function level linking), but that requires all functions to be declared with "PROC" and otherwise results in an error.
