### PR TITLE
[PSDK][SHELLBTRFS] Get rid of MaximumFileInfoByHandlesClass

### DIFF
--- a/dll/shellext/shellbtrfs/reactos.cpp
+++ b/dll/shellext/shellbtrfs/reactos.cpp
@@ -153,7 +153,7 @@ NTSTATUS WINAPI RtlUTF8ToUnicodeN(PWSTR uni_dest, ULONG uni_bytes_max,
 }
 
 /* Quick and dirty table for conversion */
-FILE_INFORMATION_CLASS ConvertToFileInfo[MaximumFileInfoByHandlesClass] =
+FILE_INFORMATION_CLASS ConvertToFileInfo[MaximumFileInfoByHandleClass] =
 {
     FileBasicInformation, FileStandardInformation, FileNameInformation, FileRenameInformation,
     FileDispositionInformation, FileAllocationInformation, FileEndOfFileInformation, FileStreamInformation,
@@ -186,7 +186,7 @@ SetFileInformationByHandle(HANDLE hFile,
     FileInfoClass = (FILE_INFORMATION_CLASS)-1;
 
     /* Attempt to convert the class */
-    if (FileInformationClass < MaximumFileInfoByHandlesClass)
+    if (FileInformationClass < MaximumFileInfoByHandleClass)
     {
         FileInfoClass = ConvertToFileInfo[FileInformationClass];
     }

--- a/sdk/include/psdk/winbase.h
+++ b/sdk/include/psdk/winbase.h
@@ -1018,8 +1018,7 @@ typedef enum _FILE_INFO_BY_HANDLE_CLASS {
     FileCaseSensitiveInfo,
     FileNormalizedNameInfo,
 #endif
-    MaximumFileInfoByHandleClass,
-    MaximumFileInfoByHandlesClass = MaximumFileInfoByHandleClass // Old name
+    MaximumFileInfoByHandleClass
 } FILE_INFO_BY_HANDLE_CLASS, *PFILE_INFO_BY_HANDLE_CLASS;
 #endif
 


### PR DESCRIPTION
## Purpose

Code cleanup.

Follow-up to 455f330 (0.4.15-dev-6969).
See #5802.

## Proposed changes

- Get rid of FILE_INFO_BY_HANDLE_CLASS.MaximumFileInfoByHandlesClass