### PR TITLE
[MSPAINT] Introduce partial image history, Part 2

### DIFF
--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -40,18 +40,14 @@ RECT CCanvasWindow::GetBaseRect()
 
 VOID CCanvasWindow::ImageToCanvas(POINT& pt)
 {
-    pt.x = Zoomed(pt.x);
-    pt.y = Zoomed(pt.y);
+    Zoomed(pt);
     pt.x += GRIP_SIZE - GetScrollPos(SB_HORZ);
     pt.y += GRIP_SIZE - GetScrollPos(SB_VERT);
 }
 
 VOID CCanvasWindow::ImageToCanvas(RECT& rc)
 {
-    rc.left = Zoomed(rc.left);
-    rc.top = Zoomed(rc.top);
-    rc.right = Zoomed(rc.right);
-    rc.bottom = Zoomed(rc.bottom);
+    Zoomed(rc);
     ::OffsetRect(&rc, GRIP_SIZE - GetScrollPos(SB_HORZ), GRIP_SIZE - GetScrollPos(SB_VERT));
 }
 
@@ -61,8 +57,7 @@ VOID CCanvasWindow::CanvasToImage(POINT& pt, BOOL bZoomed)
     pt.y -= GRIP_SIZE - GetScrollPos(SB_VERT);
     if (bZoomed)
         return;
-    pt.x = UnZoomed(pt.x);
-    pt.y = UnZoomed(pt.y);
+    UnZoomed(pt);
 }
 
 VOID CCanvasWindow::CanvasToImage(RECT& rc, BOOL bZoomed)
@@ -70,15 +65,12 @@ VOID CCanvasWindow::CanvasToImage(RECT& rc, BOOL bZoomed)
     ::OffsetRect(&rc, GetScrollPos(SB_HORZ) - GRIP_SIZE, GetScrollPos(SB_VERT) - GRIP_SIZE);
     if (bZoomed)
         return;
-    rc.left = UnZoomed(rc.left);
-    rc.top = UnZoomed(rc.top);
-    rc.right = UnZoomed(rc.right);
-    rc.bottom = UnZoomed(rc.bottom);
+    UnZoomed(rc);
 }
 
 VOID CCanvasWindow::GetImageRect(RECT& rc)
 {
-    ::SetRect(&rc, 0, 0, imageModel.GetWidth(), imageModel.GetHeight());
+    rc = { 0, 0, imageModel.GetWidth(), imageModel.GetHeight() };
 }
 
 HITTEST CCanvasWindow::CanvasHitTest(POINT pt)

--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -689,7 +689,7 @@ LRESULT CCanvasWindow::OnKeyDown(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& 
 {
     if (wParam == VK_ESCAPE && ::GetCapture() == m_hWnd)
     {
-        // Cancel dragging
+        cancelDrawing();
         ::ReleaseCapture();
         m_nMouseDownMsg = 0;
         m_hitCanvasSizeBox = HIT_NONE;

--- a/base/applications/mspaint/common.h
+++ b/base/applications/mspaint/common.h
@@ -46,7 +46,7 @@ enum HITTEST // hit
 void ShowOutOfMemory(void);
 BOOL nearlyEqualPoints(INT x0, INT y0, INT x1, INT y1);
 BOOL OpenMailer(HWND hWnd, LPCWSTR pszPathName);
-void getBoundaryOfPtStack(RECT& rcBoundary, INT cPoints, LPPOINT pPoints);
+void getBoundaryOfPtStack(RECT& rcBoundary, INT cPoints, const POINT *pPoints);
 
 #define DEG2RAD(degree) (((degree) * M_PI) / 180)
 #define RAD2DEG(radian) ((LONG)(((radian) * 180) / M_PI))

--- a/base/applications/mspaint/common.h
+++ b/base/applications/mspaint/common.h
@@ -46,6 +46,7 @@ enum HITTEST // hit
 void ShowOutOfMemory(void);
 BOOL nearlyEqualPoints(INT x0, INT y0, INT x1, INT y1);
 BOOL OpenMailer(HWND hWnd, LPCWSTR pszPathName);
+void getBoundaryOfPtStack(RECT& rcBoundary, INT cPoints, LPPOINT pPoints);
 
 #define DEG2RAD(degree) (((degree) * M_PI) / 180)
 #define RAD2DEG(radian) ((LONG)(((radian) * 180) / M_PI))

--- a/base/applications/mspaint/miniature.cpp
+++ b/base/applications/mspaint/miniature.cpp
@@ -122,7 +122,6 @@ LRESULT CMiniatureWindow::OnGetMinMaxInfo(UINT nMsg, WPARAM wParam, LPARAM lPara
 {
     // Avoid too small
     LPMINMAXINFO pInfo = (LPMINMAXINFO)lParam;
-    pInfo->ptMinTrackSize.x = 100;
-    pInfo->ptMinTrackSize.y = 75;
+    pInfo->ptMinTrackSize = { 100, 75 };
     return 0;
 }

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -59,10 +59,8 @@ void getBoundaryOfPtStack(RECT& rcBoundary, INT cPoints, const POINT *pPoints)
     while (cPoints-- > 0)
     {
         LONG x = pPoints->x, y = pPoints->y;
-        ptMin.x = min(x, ptMin.x);
-        ptMin.y = min(y, ptMin.y);
-        ptMax.x = max(x, ptMax.x);
-        ptMax.y = max(y, ptMax.y);
+        ptMin = { min(x, ptMin.x), min(y, ptMin.y) };
+        ptMax = { max(x, ptMax.x), max(y, ptMax.y) };
         ++pPoints;
     }
 

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -1063,6 +1063,10 @@ struct ShapeTool : ToolBase
             {
                 CRect rcPartial;
                 getBoundaryOfPtStack(rcPartial, s_pointSP, s_pointStack);
+
+                SIZE size = toolsModel.GetToolSize();
+                rcPartial.InflateRect((size.cx + 1) / 2, (size.cy + 1) / 2);
+
                 imageModel.PushImageForUndo(rcPartial);
 
                 m_bClosed = TRUE;

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -482,7 +482,7 @@ struct SmoothDrawTool : ToolBase
         m_bLeftButton = bLeftButton;
         s_pointSP = 0;
         pushToPtStack(x, y);
-        pushToPtStack(x, y);
+        pushToPtStack(x, y); // We have to draw the first point
         imageModel.NotifyImageChanged();
     }
 

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -481,6 +481,7 @@ struct SmoothDrawTool : ToolBase
         m_bLeftButton = bLeftButton;
         s_pointSP = 0;
         pushToPtStack(x, y);
+        pushToPtStack(x, y);
         imageModel.NotifyImageChanged();
     }
 

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -119,9 +119,13 @@ void ToolBase::pushToPtStack(LONG x, LONG y)
 {
     if (s_pointSP >= s_maxPointSP)
     {
-        SIZE_T newMax = s_maxPointSP + 256, cbNew = newMax * sizeof(POINT);
+        SIZE_T newMax = s_maxPointSP + 512;
+        SIZE_T cbNew = newMax * sizeof(POINT);
         if (!s_pointStack.ReallocateBytes(cbNew))
+        {
+            ATLTRACE("%d, %d, %d\n", (INT)s_pointSP, (INT)s_maxPointSP, (INT)cbNew);
             return;
+        }
 
         s_maxPointSP = newMax;
     }

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -56,13 +56,14 @@ BOOL nearlyEqualPoints(INT x0, INT y0, INT x1, INT y1)
 void getBoundaryOfPtStack(RECT& rcBoundary, INT cPoints, const POINT *pPoints)
 {
     POINT ptMin = { MAXLONG, MAXLONG }, ptMax = { (LONG)MINLONG, (LONG)MINLONG };
-    for (INT iPoint = 0; iPoint < cPoints; ++iPoint)
+    while (cPoints-- > 0)
     {
-        LONG x = pPoints[iPoint].x, y = pPoints[iPoint].y;
+        LONG x = pPoints->x, y = pPoints->y;
         ptMin.x = min(x, ptMin.x);
         ptMin.y = min(y, ptMin.y);
         ptMax.x = max(x, ptMax.x);
         ptMax.y = max(y, ptMax.y);
+        ++pPoints;
     }
 
     ptMax.x += 1;
@@ -75,8 +76,10 @@ void getBoundaryOfPtStack(RECT& rcBoundary, INT cPoints, const POINT *pPoints)
 void ToolBase::reset()
 {
     s_pointSP = 0;
-    g_ptStart.x = g_ptStart.y = g_ptEnd.x = g_ptEnd.y = -1;
+    g_ptEnd = g_ptStart = { -1, -1 };
+
     selectionModel.ResetPtStack();
+
     if (selectionModel.m_bShow)
     {
         selectionModel.Landing();

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -53,7 +53,7 @@ BOOL nearlyEqualPoints(INT x0, INT y0, INT x1, INT y1)
     return (abs(x1 - x0) <= cxThreshold) && (abs(y1 - y0) <= cyThreshold);
 }
 
-void getBoundaryOfPtStack(RECT& rcBoundary, INT cPoints, LPPOINT pPoints)
+void getBoundaryOfPtStack(RECT& rcBoundary, INT cPoints, const POINT *pPoints)
 {
     POINT ptMin = { MAXLONG, MAXLONG }, ptMax = { (LONG)MINLONG, (LONG)MINLONG };
     for (INT iPoint = 0; iPoint < cPoints; ++iPoint)

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -53,6 +53,25 @@ BOOL nearlyEqualPoints(INT x0, INT y0, INT x1, INT y1)
     return (abs(x1 - x0) <= cxThreshold) && (abs(y1 - y0) <= cyThreshold);
 }
 
+void getBoundaryOfPtStack(RECT& rcBoundary, INT cPoints, LPPOINT pPoints)
+{
+    POINT ptMin = { MAXLONG, MAXLONG }, ptMax = { (LONG)MINLONG, (LONG)MINLONG };
+    for (INT iPoint = 0; iPoint < cPoints; ++iPoint)
+    {
+        LONG x = pPoints[iPoint].x, y = pPoints[iPoint].y;
+        ptMin.x = min(x, ptMin.x);
+        ptMin.y = min(y, ptMin.y);
+        ptMax.x = max(x, ptMax.x);
+        ptMax.y = max(y, ptMax.y);
+    }
+
+    ptMax.x += 1;
+    ptMax.y += 1;
+
+    CRect rc(ptMin, ptMax);
+    rcBoundary = rc;
+}
+
 void ToolBase::reset()
 {
     s_pointSP = 0;
@@ -129,24 +148,6 @@ void ToolBase::pushToPtStack(LONG x, LONG y)
     }
 
     s_pointStack[s_pointSP++] = { x, y };
-}
-
-void ToolBase::getBoundaryOfPtStack(RECT& rcBoundary)
-{
-    POINT ptMin, ptMax;
-    ptMin = ptMax = s_pointStack[0];
-
-    for (INT i = 1; i < s_pointSP; ++i)
-    {
-        LONG x = s_pointStack[i].x, y = s_pointStack[i].y;
-        ptMin.x = min(x, ptMin.x);
-        ptMin.y = min(y, ptMin.y);
-        ptMax.x = max(x, ptMax.x);
-        ptMax.y = max(y, ptMax.y);
-    }
-
-    CRect rc(ptMin, ptMax);
-    rcBoundary = rc;
 }
 
 /* TOOLS ********************************************************/
@@ -515,7 +516,7 @@ struct SmoothDrawTool : ToolBase
         pushToPtStack(x, y);
 
         CRect rcPartial;
-        getBoundaryOfPtStack(rcPartial);
+        getBoundaryOfPtStack(rcPartial, s_pointSP, s_pointStack);
 
         SIZE size = toolsModel.GetToolSize();
         rcPartial.InflateRect((size.cx + 1) / 2, (size.cy + 1) / 2);

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -934,15 +934,13 @@ struct BezierTool : ToolBase
         if (!m_bDrawing)
         {
             m_bDrawing = TRUE;
-            s_pointStack[s_pointSP].x = s_pointStack[s_pointSP + 1].x = x;
-            s_pointStack[s_pointSP].y = s_pointStack[s_pointSP + 1].y = y;
+            s_pointStack[s_pointSP + 1] = s_pointStack[s_pointSP] = { x, y };
             ++s_pointSP;
         }
         else
         {
             ++s_pointSP;
-            s_pointStack[s_pointSP].x = x;
-            s_pointStack[s_pointSP].y = y;
+            s_pointStack[s_pointSP] = { x, y };
         }
 
         imageModel.NotifyImageChanged();
@@ -950,16 +948,14 @@ struct BezierTool : ToolBase
 
     BOOL OnMouseMove(BOOL bLeftButton, LONG& x, LONG& y) override
     {
-        s_pointStack[s_pointSP].x = x;
-        s_pointStack[s_pointSP].y = y;
+        s_pointStack[s_pointSP] = { x, y };
         imageModel.NotifyImageChanged();
         return TRUE;
     }
 
     BOOL OnButtonUp(BOOL bLeftButton, LONG& x, LONG& y) override
     {
-        s_pointStack[s_pointSP].x = x;
-        s_pointStack[s_pointSP].y = y;
+        s_pointStack[s_pointSP] = { x, y };
         if (s_pointSP >= 3)
         {
             OnEndDraw(FALSE);
@@ -1035,8 +1031,7 @@ struct ShapeTool : ToolBase
         if ((s_pointSP > 0) && (GetAsyncKeyState(VK_SHIFT) < 0))
             roundTo8Directions(s_pointStack[s_pointSP - 1].x, s_pointStack[s_pointSP - 1].y, x, y);
 
-        s_pointStack[s_pointSP].x = x;
-        s_pointStack[s_pointSP].y = y;
+        s_pointStack[s_pointSP] = { x, y };
 
         if (s_pointSP && bDoubleClick)
         {
@@ -1045,11 +1040,7 @@ struct ShapeTool : ToolBase
         }
 
         if (s_pointSP == 0)
-        {
-            s_pointSP++;
-            s_pointStack[s_pointSP].x = x;
-            s_pointStack[s_pointSP].y = y;
-        }
+            s_pointStack[++s_pointSP] = { x, y };
 
         imageModel.NotifyImageChanged();
     }
@@ -1059,8 +1050,7 @@ struct ShapeTool : ToolBase
         if ((s_pointSP > 0) && (GetAsyncKeyState(VK_SHIFT) < 0))
             roundTo8Directions(s_pointStack[s_pointSP - 1].x, s_pointStack[s_pointSP - 1].y, x, y);
 
-        s_pointStack[s_pointSP].x = x;
-        s_pointStack[s_pointSP].y = y;
+        s_pointStack[s_pointSP] = { x, y };
 
         imageModel.NotifyImageChanged();
         return TRUE;
@@ -1079,9 +1069,7 @@ struct ShapeTool : ToolBase
         }
         else
         {
-            s_pointSP++;
-            s_pointStack[s_pointSP].x = x;
-            s_pointStack[s_pointSP].y = y;
+            s_pointStack[++s_pointSP] = { x, y };
         }
 
         if (s_pointSP == s_maxPointSP)
@@ -1184,8 +1172,7 @@ ToolBase::createToolObject(TOOLTYPE type)
 void ToolsModel::OnButtonDown(BOOL bLeftButton, LONG x, LONG y, BOOL bDoubleClick)
 {
     m_pToolObject->beginEvent();
-    g_ptStart.x = g_ptEnd.x = x;
-    g_ptStart.y = g_ptEnd.y = y;
+    g_ptEnd = g_ptStart = { x, y };
     m_pToolObject->OnButtonDown(bLeftButton, x, y, bDoubleClick);
     m_pToolObject->endEvent();
 }
@@ -1194,10 +1181,8 @@ void ToolsModel::OnMouseMove(BOOL bLeftButton, LONG x, LONG y)
 {
     m_pToolObject->beginEvent();
     if (m_pToolObject->OnMouseMove(bLeftButton, x, y))
-    {
-        g_ptEnd.x = x;
-        g_ptEnd.y = y;
-    }
+        g_ptEnd = { x, y };
+
     m_pToolObject->endEvent();
 }
 
@@ -1205,10 +1190,8 @@ void ToolsModel::OnButtonUp(BOOL bLeftButton, LONG x, LONG y)
 {
     m_pToolObject->beginEvent();
     if (m_pToolObject->OnButtonUp(bLeftButton, x, y))
-    {
-        g_ptEnd.x = x;
-        g_ptEnd.y = y;
-    }
+        g_ptEnd = { x, y };
+
     m_pToolObject->endEvent();
 }
 

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -11,8 +11,8 @@
 #include "precomp.h"
 
 INT ToolBase::s_pointSP = 0;
-static INT s_maxPointSP = 256;
 static POINT s_staticPointStack[256];
+static INT s_maxPointSP = _countof(s_staticPointStack);
 static LPPOINT s_pointStack = s_staticPointStack;
 static POINT g_ptStart, g_ptEnd;
 

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -11,9 +11,9 @@
 #include "precomp.h"
 
 INT ToolBase::s_pointSP = 0;
-INT ToolBase::s_maxPointSP = 256;
+static INT s_maxPointSP = 256;
 static POINT s_staticPointStack[256];
-LPPOINT ToolBase::s_pointStack = s_staticPointStack;
+static LPPOINT s_pointStack = s_staticPointStack;
 static POINT g_ptStart, g_ptEnd;
 
 /* FUNCTIONS ********************************************************/

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -1057,24 +1057,20 @@ struct ShapeTool : ToolBase
 
     void OnEndDraw(BOOL bCancel) override
     {
-        if (!bCancel)
+        if (!bCancel && s_pointSP > 1)
         {
-            if (s_pointSP > 1)
-            {
-                CRect rcPartial;
-                getBoundaryOfPtStack(rcPartial, s_pointSP, s_pointStack);
+            CRect rcPartial;
+            getBoundaryOfPtStack(rcPartial, s_pointSP, s_pointStack);
 
-                SIZE size = toolsModel.GetToolSize();
-                rcPartial.InflateRect((size.cx + 1) / 2, (size.cy + 1) / 2);
+            SIZE size = toolsModel.GetToolSize();
+            rcPartial.InflateRect((size.cx + 1) / 2, (size.cy + 1) / 2);
 
-                imageModel.PushImageForUndo(rcPartial);
+            imageModel.PushImageForUndo(rcPartial);
 
-                m_bClosed = TRUE;
-                OnDrawOverlayOnImage(m_hdc);
-            }
-            m_bClosed = FALSE;
-            s_pointSP = 0;
+            m_bClosed = TRUE;
+            OnDrawOverlayOnImage(m_hdc);
         }
+        m_bClosed = FALSE;
         ToolBase::OnEndDraw(bCancel);
     }
 

--- a/base/applications/mspaint/selectionmodel.cpp
+++ b/base/applications/mspaint/selectionmodel.cpp
@@ -71,17 +71,8 @@ void SelectionModel::ShiftPtStack(INT dx, INT dy)
 
 void SelectionModel::BuildMaskFromPtStack()
 {
-    CRect rc = { MAXLONG, MAXLONG, 0, 0 };
-    for (INT i = 0; i < m_iPtSP; ++i)
-    {
-        POINT& pt = m_ptStack[i];
-        rc.left = min(pt.x, rc.left);
-        rc.top = min(pt.y, rc.top);
-        rc.right = max(pt.x, rc.right);
-        rc.bottom = max(pt.y, rc.bottom);
-    }
-    rc.right += 1;
-    rc.bottom += 1;
+    CRect rc;
+    getBoundaryOfPtStack(rc, m_iPtSP, m_ptStack);
 
     m_rc = m_rcOld = rc;
 

--- a/base/applications/mspaint/selectionmodel.cpp
+++ b/base/applications/mspaint/selectionmodel.cpp
@@ -23,7 +23,7 @@ SelectionModel::SelectionModel()
 {
     ::SetRectEmpty(&m_rc);
     ::SetRectEmpty(&m_rcOld);
-    m_ptHit.x = m_ptHit.y = -1;
+    m_ptHit = { -1, -1 };
 }
 
 SelectionModel::~SelectionModel()

--- a/base/applications/mspaint/toolsmodel.h
+++ b/base/applications/mspaint/toolsmodel.h
@@ -65,7 +65,6 @@ struct ToolBase
     void endEvent();
     void reset();
     void pushToPtStack(LONG x, LONG y);
-    void getBoundaryOfPtStack(RECT& rcBoundary);
 
     static ToolBase* createToolObject(TOOLTYPE type);
 

--- a/base/applications/mspaint/toolsmodel.h
+++ b/base/applications/mspaint/toolsmodel.h
@@ -44,8 +44,6 @@ struct ToolBase
     HDC m_hdc;
     COLORREF m_fg, m_bg;
     static INT s_pointSP;
-    static LPPOINT s_pointStack;
-    static INT s_maxPointSP;
 
     ToolBase(TOOLTYPE tool) : m_tool(tool), m_hdc(NULL) { }
     virtual ~ToolBase() { }

--- a/base/applications/mspaint/toolsmodel.h
+++ b/base/applications/mspaint/toolsmodel.h
@@ -44,7 +44,8 @@ struct ToolBase
     HDC m_hdc;
     COLORREF m_fg, m_bg;
     static INT s_pointSP;
-    static POINT s_pointStack[256];
+    static LPPOINT s_pointStack;
+    static INT s_maxPointSP;
 
     ToolBase(TOOLTYPE tool) : m_tool(tool), m_hdc(NULL) { }
     virtual ~ToolBase() { }
@@ -63,6 +64,8 @@ struct ToolBase
     void beginEvent();
     void endEvent();
     void reset();
+    void pushToPtStack(LONG x, LONG y);
+    void getBoundaryOfPtStack(RECT& rcBoundary);
 
     static ToolBase* createToolObject(TOOLTYPE type);
 

--- a/base/applications/mspaint/toolsmodel.h
+++ b/base/applications/mspaint/toolsmodel.h
@@ -43,7 +43,7 @@ struct ToolBase
     TOOLTYPE m_tool;
     HDC m_hdc;
     COLORREF m_fg, m_bg;
-    static INT s_pointSP;
+    static SIZE_T s_pointSP;
 
     ToolBase(TOOLTYPE tool) : m_tool(tool), m_hdc(NULL) { }
     virtual ~ToolBase() { }

--- a/base/applications/mspaint/toolsmodel.h
+++ b/base/applications/mspaint/toolsmodel.h
@@ -165,28 +165,20 @@ static inline int UnZoomed(int xy)
 
 static inline void Zoomed(POINT& pt)
 {
-    pt.x = Zoomed(pt.x);
-    pt.y = Zoomed(pt.y);
+    pt = { Zoomed(pt.x), Zoomed(pt.y) };
 }
 
 static inline void Zoomed(RECT& rc)
 {
-    rc.left = Zoomed(rc.left);
-    rc.top = Zoomed(rc.top);
-    rc.right = Zoomed(rc.right);
-    rc.bottom = Zoomed(rc.bottom);
+    rc = { Zoomed(rc.left), Zoomed(rc.top), Zoomed(rc.right), Zoomed(rc.bottom) };
 }
 
 static inline void UnZoomed(POINT& pt)
 {
-    pt.x = UnZoomed(pt.x);
-    pt.y = UnZoomed(pt.y);
+    pt = { UnZoomed(pt.x), UnZoomed(pt.y) };
 }
 
 static inline void UnZoomed(RECT& rc)
 {
-    rc.left = UnZoomed(rc.left);
-    rc.top = UnZoomed(rc.top);
-    rc.right = UnZoomed(rc.right);
-    rc.bottom = UnZoomed(rc.bottom);
+    rc = { UnZoomed(rc.left), UnZoomed(rc.top), UnZoomed(rc.right), UnZoomed(rc.bottom) };
 }

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -498,8 +498,8 @@ LRESULT CMainWindow::OnSize(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHand
 
 LRESULT CMainWindow::OnGetMinMaxInfo(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
-    MINMAXINFO *mm = (LPMINMAXINFO) lParam;
-    mm->ptMinTrackSize ={ 330, 360 };
+    MINMAXINFO *mm = (MINMAXINFO*)lParam;
+    mm->ptMinTrackSize = { 330, 360 };
     return 0;
 }
 

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -499,8 +499,7 @@ LRESULT CMainWindow::OnSize(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHand
 LRESULT CMainWindow::OnGetMinMaxInfo(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
     MINMAXINFO *mm = (LPMINMAXINFO) lParam;
-    mm->ptMinTrackSize.x = 330;
-    mm->ptMinTrackSize.y = 360;
+    mm->ptMinTrackSize ={ 330, 360 };
     return 0;
 }
 


### PR DESCRIPTION
## Purpose
Follow-up to #5994. Reduce the lag and the cost of drawing on large image.
JIRA issue: [CORE-19237](https://jira.reactos.org/browse/CORE-19237)

## Proposed changes

- Introduce partial image history on `SmoothDrawTool` and `ShapeTool`.

## TODO

- [x] Do tests.

## Screenshot

AFTER:
![image](https://github.com/reactos/reactos/assets/2107452/a56c6837-3cf3-46ea-8463-c3ed8e66bf42)
We can draw with pen smoothly even when the image is huge (10000x10000).