### PR TITLE
[ACCESS] GeneralPageProc().WM_INITDIALOG: Do not change iTimeOutMSec

### DIFF
--- a/dll/cpl/access/general.c
+++ b/dll/cpl/access/general.c
@@ -196,8 +196,8 @@ GeneralPageProc(HWND hwndDlg,
                            IDC_RESET_BOX,
                            pGlobalData->accessTimeout.dwFlags & ATF_TIMEOUTON ? BST_CHECKED : BST_UNCHECKED);
             FillResetComboBox(GetDlgItem(hwndDlg, IDC_RESET_COMBO));
-            pGlobalData->accessTimeout.iTimeOutMSec = max(FIVE_MINS_IN_MS, pGlobalData->accessTimeout.iTimeOutMSec);
-            iCurSel = (pGlobalData->accessTimeout.iTimeOutMSec / FIVE_MINS_IN_MS) - 1;
+            iCurSel = pGlobalData->accessTimeout.iTimeOutMSec >= FIVE_MINS_IN_MS
+                      ? (pGlobalData->accessTimeout.iTimeOutMSec / FIVE_MINS_IN_MS) - 1 : 0;
             SendDlgItemMessage(hwndDlg, IDC_RESET_COMBO, CB_SETCURSEL, iCurSel, 0);
             EnableWindow(GetDlgItem(hwndDlg, IDC_RESET_COMBO),
                          pGlobalData->accessTimeout.dwFlags & ATF_TIMEOUTON ? TRUE : FALSE);


### PR DESCRIPTION
## Purpose

Remove unwanted change.

Partly revert 416d630 (0.4.15-dev-6974).
See #5893.
JIRA issue: [CORE-19303](https://jira.reactos.org/browse/CORE-19303)

## Proposed changes

- Do not change iTimeOutMSec