### PR TITLE
[SHELL32] Select 1st item after deletion of file type

### DIFF
--- a/dll/win32/shell32/dialogs/filetypes.cpp
+++ b/dll/win32/shell32/dialogs/filetypes.cpp
@@ -1612,15 +1612,13 @@ FileTypesDlg_OnDelete(HWND hwndDlg)
     if (MessageBoxW(hwndDlg, strRemoveExt, strTitle, MB_ICONQUESTION | MB_YESNO) == IDYES)
     {
         FileTypesDlg_RemoveExt(hwndDlg);
-        // select first item
+
+        // Select first item
         HWND hListView = GetDlgItem(hwndDlg, IDC_FILETYPES_LISTVIEW);
-        LVITEMW lvItem;
-        ZeroMemory(&lvItem, sizeof(LVITEMW));
-        lvItem.mask = LVIF_STATE;
-        lvItem.stateMask = (UINT)-1;
-        lvItem.state = LVIS_FOCUSED | LVIS_SELECTED;
-        lvItem.iItem = 0;
-        ListView_SetItem(hListView, &lvItem);
+        LV_ITEMW item = { LVIF_STATE };
+        item.stateMask = item.state = LVIS_FOCUSED | LVIS_SELECTED;
+        item.iItem = 0;
+        ListView_SetItem(hListView, &item);
     }
 }
 

--- a/dll/win32/shell32/dialogs/filetypes.cpp
+++ b/dll/win32/shell32/dialogs/filetypes.cpp
@@ -1612,6 +1612,15 @@ FileTypesDlg_OnDelete(HWND hwndDlg)
     if (MessageBoxW(hwndDlg, strRemoveExt, strTitle, MB_ICONQUESTION | MB_YESNO) == IDYES)
     {
         FileTypesDlg_RemoveExt(hwndDlg);
+        // select first item
+        HWND hListView = GetDlgItem(hwndDlg, IDC_FILETYPES_LISTVIEW);
+        LVITEMW lvItem;
+        ZeroMemory(&lvItem, sizeof(LVITEMW));
+        lvItem.mask = LVIF_STATE;
+        lvItem.stateMask = (UINT)-1;
+        lvItem.state = LVIS_FOCUSED | LVIS_SELECTED;
+        lvItem.iItem = 0;
+        ListView_SetItem(hListView, &lvItem);
     }
 }
 

--- a/dll/win32/shell32/dialogs/filetypes.cpp
+++ b/dll/win32/shell32/dialogs/filetypes.cpp
@@ -1614,11 +1614,10 @@ FileTypesDlg_OnDelete(HWND hwndDlg)
         FileTypesDlg_RemoveExt(hwndDlg);
 
         // Select first item (Win2k3 does it)
-        HWND hListView = GetDlgItem(hwndDlg, IDC_FILETYPES_LISTVIEW);
         LV_ITEMW item = { LVIF_STATE };
         item.stateMask = item.state = LVIS_FOCUSED | LVIS_SELECTED;
         item.iItem = 0;
-        ListView_SetItem(hListView, &item);
+        ListView_SetItem(GetDlgItem(hwndDlg, IDC_FILETYPES_LISTVIEW), &item);
     }
 }
 

--- a/dll/win32/shell32/dialogs/filetypes.cpp
+++ b/dll/win32/shell32/dialogs/filetypes.cpp
@@ -1613,7 +1613,7 @@ FileTypesDlg_OnDelete(HWND hwndDlg)
     {
         FileTypesDlg_RemoveExt(hwndDlg);
 
-        // Select first item
+        // Select first item (Win2k3 does it)
         HWND hListView = GetDlgItem(hwndDlg, IDC_FILETYPES_LISTVIEW);
         LV_ITEMW item = { LVIF_STATE };
         item.stateMask = item.state = LVIS_FOCUSED | LVIS_SELECTED;


### PR DESCRIPTION
## Purpose

Based on KRosUser's `filestypedel.patch`.
JIRA issue: [CORE-19325](https://jira.reactos.org/browse/CORE-19325)

## Proposed changes

- Select the first item after the user deleted a file type.

## TODO

- [x] Do tests.