### PR TITLE
[NETSHELL] Double click on component should open properties

### DIFF
--- a/dll/shellext/netshell/lanconnectui.cpp
+++ b/dll/shellext/netshell/lanconnectui.cpp
@@ -341,6 +341,13 @@ CNetConnectionPropertyUi::LANPropertiesUIDlg(
                 return PSNRET_NOERROR;
             }
 #endif
+            if (lppl->hdr.code == NM_DBLCLK)
+            {
+                This = (CNetConnectionPropertyUi*)GetWindowLongPtr(hwndDlg, DWLP_USER);
+                This->ShowNetworkComponentProperties(hwndDlg);
+                return FALSE;
+            }
+
             if (lppl->hdr.code == LVN_ITEMCHANGING)
             {
                 ZeroMemory(&li, sizeof(li));


### PR DESCRIPTION
## Purpose

Based on KRosUser's `lanprop.patch`.
JIRA issue: [CORE-19330](https://jira.reactos.org/browse/CORE-19330)

## Proposed changes

- Add `NM_DBLCLK` handling.

## TODO

- [x] Do tests.