### PR TITLE
[HALX86][NTOS:KE] Remove useless '#include <debug.h>'

### DIFF
--- a/hal/halx86/generic/up.c
+++ b/hal/halx86/generic/up.c
@@ -9,9 +9,6 @@
 
 #include <hal.h>
 
-#define NDEBUG
-#include <debug.h>
-
 /* FUNCTIONS *****************************************************************/
 
 VOID

--- a/hal/halx86/smp/amd64/apentry.S
+++ b/hal/halx86/smp/amd64/apentry.S
@@ -17,8 +17,8 @@ HalpAPEntry16:
     cli
 
     xor ax, ax
-	mov ds, ax
-	mov ss, ax
+    mov ds, ax
+    mov ss, ax
     mov fs, ax
     mov gs, ax
 

--- a/hal/halx86/smp/amd64/spinup.c
+++ b/hal/halx86/smp/amd64/spinup.c
@@ -10,9 +10,6 @@
 #include <hal.h>
 #include <smp.h>
 
-#define NDEBUG
-#include <debug.h>
-
 BOOLEAN
 NTAPI
 HalStartNextProcessor(

--- a/hal/halx86/smp/i386/spinup.c
+++ b/hal/halx86/smp/i386/spinup.c
@@ -11,9 +11,6 @@
 #include <hal.h>
 #include <smp.h>
 
-#define NDEBUG
-#include <debug.h>
-
 /* GLOBALS *******************************************************************/
 
 extern PPROCESSOR_IDENTITY HalpProcessorIdentity;

--- a/hal/halx86/smp/ipi.c
+++ b/hal/halx86/smp/ipi.c
@@ -10,9 +10,6 @@
 #include <hal.h>
 #include <smp.h>
 
-#define NDEBUG
-#include <debug.h>
-
 /* GLOBALS *******************************************************************/
 
 VOID

--- a/ntoskrnl/ke/i386/kiinit.c
+++ b/ntoskrnl/ke/i386/kiinit.c
@@ -9,9 +9,11 @@
 /* INCLUDES *****************************************************************/
 
 #include <ntoskrnl.h>
-#define NDEBUG
-#include <debug.h>
+
 #include "internal/i386/trap_x.h"
+
+// #define NDEBUG
+#include <debug.h>
 
 /* GLOBALS *******************************************************************/
 
@@ -536,7 +538,7 @@ KiInitializeKernel(IN PKPROCESS InitProcess,
     else
     {
         /* FIXME */
-        DPRINT1("Starting CPU#%u - you are brave\n", Number);
+        DPRINT("Starting CPU %d\n", Number);
     }
 
     /* Setup the Idle Thread */


### PR DESCRIPTION
## Purpose

Code cleanup.

Addendum to 516ccad (0.4.15-dev-7016).

## Proposed changes

- Remove useless '#include <debug.h>'
- and demote 2 DPRINT1().