### PR TITLE
[KERNEL32][KERNEL32_VISTA][SHELLBTRFS] Move SetFileInformationByHandle() to kernel32_vista

### DIFF
--- a/dll/win32/kernel32/kernel32.spec
+++ b/dll/win32/kernel32/kernel32.spec
@@ -1,5 +1,5 @@
-@ stdcall -version=0x600+ AcquireSRWLockExclusive(ptr) NTDLL.RtlAcquireSRWLockExclusive
-@ stdcall -version=0x600+ AcquireSRWLockShared(ptr) NTDLL.RtlAcquireSRWLockShared
+@ stdcall -version=0x600+ AcquireSRWLockExclusive(ptr) ntdll.RtlAcquireSRWLockExclusive
+@ stdcall -version=0x600+ AcquireSRWLockShared(ptr) ntdll.RtlAcquireSRWLockShared
 @ stdcall ActivateActCtx(ptr ptr)
 @ stdcall AddAtomA(str)
 @ stdcall AddAtomW(wstr)
@@ -565,6 +565,7 @@
 @ stdcall GetProcessId(long)
 @ stdcall GetProcessIdOfThread(ptr)
 @ stdcall GetProcessIoCounters(long ptr)
+# @ stdcall -version=0x601+ GetProcessPreferredUILanguages(long ptr wstr ptr)
 @ stdcall GetProcessPriorityBoost(long ptr)
 @ stdcall GetProcessShutdownParameters(ptr ptr)
 @ stdcall GetProcessTimes(long ptr ptr ptr ptr)
@@ -1057,6 +1058,7 @@
 @ stdcall SetProcessAffinityMask(long long)
 @ stub -version=0x600+ SetProcessAffinityUpdateMode
 @ stub -version=0x600+ SetProcessDEPPolicy
+# @ stdcall -version=0x601+ SetProcessPreferredUILanguages(long wstr ptr)
 @ stdcall SetProcessPriorityBoost(long long)
 @ stdcall SetProcessShutdownParameters(long long)
 @ stdcall SetProcessWorkingSetSize(long long long)

--- a/dll/win32/kernel32/kernel32.spec
+++ b/dll/win32/kernel32/kernel32.spec
@@ -1029,7 +1029,7 @@
 @ stdcall SetFileAttributesW(wstr long)
 @ stdcall -version=0x600+ SetFileBandwidthReservation(ptr long long long ptr ptr)
 @ stdcall SetFileCompletionNotificationModes(ptr long)
-@ stub -version=0x600+ SetFileInformationByHandle
+@ stdcall -version=0x600+ SetFileInformationByHandle(ptr long ptr long)
 @ stub -version=0x600+ SetFileIoOverlappedRange
 @ stdcall SetFilePointer(long long ptr long)
 @ stdcall SetFilePointerEx(long double ptr long)

--- a/dll/win32/kernel32/kernel32_vista/CMakeLists.txt
+++ b/dll/win32/kernel32/kernel32_vista/CMakeLists.txt
@@ -10,6 +10,7 @@ list(APPEND SOURCE
     GetFileInformationByHandleEx.c
     GetTickCount64.c
     InitOnce.c
+    SetFileInformationByHandle.c
     sync.c
     vista.c)
 

--- a/dll/win32/kernel32/kernel32_vista/SetFileInformationByHandle.c
+++ b/dll/win32/kernel32/kernel32_vista/SetFileInformationByHandle.c
@@ -11,37 +11,66 @@
 
 #include <k32_vista.h>
 
-/* Quick and dirty table for conversion */
-FILE_INFORMATION_CLASS ConvertToFileInfo[MaximumFileInfoByHandleClass] =
+/* Quick and dirty table for conversion
+   from FILE_INFO_BY_HANDLE_CLASS to FILE_INFORMATION_CLASS */
+static
+FILE_INFORMATION_CLASS ConvertInfoToInformation[] =
 {
-    FileBasicInformation, FileStandardInformation, FileNameInformation, FileRenameInformation,
-    FileDispositionInformation, FileAllocationInformation, FileEndOfFileInformation, FileStreamInformation,
-    FileCompressionInformation, FileAttributeTagInformation, FileIdBothDirectoryInformation, (FILE_INFORMATION_CLASS)-1,
-    FileIoPriorityHintInformation, FileRemoteProtocolInformation
+    FileBasicInformation,
+    FileStandardInformation,
+    FileNameInformation,
+    FileRenameInformation,
+    FileDispositionInformation,
+    FileAllocationInformation,
+    FileEndOfFileInformation,
+    FileStreamInformation,
+    FileCompressionInformation,
+    FileAttributeTagInformation,
+    FileIdBothDirectoryInformation,
+    0, // No match for FileIdBothDirectoryRestartInfo
+    FileIoPriorityHintInformation, // Vista || ReactOS
+    FileRemoteProtocolInformation, // Win7 || ReactOS
+    FileFullDirectoryInformation,
+    0, // No match for FileFullDirectoryRestartInfo
+#if (NTDDI_VERSION >= NTDDI_WIN8) || defined(__REACTOS__)
+    0, // No match for FileStorageInfo (Or is it FileStorageReserveIdInformation?)
+    FileAlignmentInformation,
+    FileIdInformation, // Win8 || ReactOS
+    FileIdExtdDirectoryInformation, // Win8 || ReactOS
+    0, // No match for FileIdExtdDirectoryRestartInfo
+#endif
+#if (NTDDI_VERSION >= NTDDI_WIN10_RS1) || defined(__REACTOS__)
+    FileDispositionInformationEx, // Win10rs1 || ReactOS
+    FileRenameInformationEx, // Win10rs1 || ReactOS
+#endif
+#if (NTDDI_VERSION >= NTDDI_WIN10_19H1) || defined(__REACTOS__)
+    FileCaseSensitiveInformation, // Win10rs4 || ReactOS
+    FileNormalizedNameInformation, // Vista || ReactOS
+#endif
 };
+C_ASSERT(_countof(ConvertInfoToInformation) == MaximumFileInfoByHandleClass);
 
 /* Quick implementation, still going farther than Wine implementation */
 BOOL
 WINAPI
-SetFileInformationByHandle(HANDLE hFile,
-                           FILE_INFO_BY_HANDLE_CLASS FileInformationClass,
-                           LPVOID lpFileInformation,
-                           DWORD dwBufferSize)
+SetFileInformationByHandle(
+    _In_ HANDLE hFile,
+    _In_range_(0, MaximumFileInfoByHandleClass - 1) FILE_INFO_BY_HANDLE_CLASS FileInfoClass,
+    _In_ LPVOID lpFileInformation,
+    _In_ DWORD dwBufferSize)
 {
-    NTSTATUS Status;
+    FILE_INFORMATION_CLASS FileInformationClass;
     IO_STATUS_BLOCK IoStatusBlock;
-    FILE_INFORMATION_CLASS FileInfoClass;
-
-    FileInfoClass = (FILE_INFORMATION_CLASS)-1;
+    NTSTATUS Status;
 
     /* Attempt to convert the class */
-    if (FileInformationClass < MaximumFileInfoByHandleClass)
-    {
-        FileInfoClass = ConvertToFileInfo[FileInformationClass];
-    }
+    if (FileInfoClass >= 0 && FileInfoClass < MaximumFileInfoByHandleClass)
+        FileInformationClass = ConvertInfoToInformation[FileInfoClass];
+    else
+        FileInformationClass = 0;
 
     /* If wrong, bail out */
-    if (FileInfoClass == -1)
+    if (FileInformationClass == 0)
     {
         SetLastError(ERROR_INVALID_PARAMETER);
         return FALSE;
@@ -49,8 +78,7 @@ SetFileInformationByHandle(HANDLE hFile,
 
     /* And set the information */
     Status = NtSetInformationFile(hFile, &IoStatusBlock, lpFileInformation,
-                                  dwBufferSize, FileInfoClass);
-
+                                  dwBufferSize, FileInformationClass);
     if (!NT_SUCCESS(Status))
     {
         BaseSetLastNTError(Status);

--- a/dll/win32/kernel32/kernel32_vista/SetFileInformationByHandle.c
+++ b/dll/win32/kernel32/kernel32_vista/SetFileInformationByHandle.c
@@ -1,0 +1,61 @@
+/*
+
+// TODO
+
+ * COPYRIGHT:       See COPYING in the top level directory
+ * PROJECT:         BtrFS FSD for ReactOS
+ * FILE:            dll/shellext/shellbtrfs/reactos.cpp
+ * PURPOSE:         ReactOS glue for Win8.1
+ * PROGRAMMERS:     Pierre Schweitzer <pierre@reactos.org>
+ */
+
+#include <k32_vista.h>
+
+/* Quick and dirty table for conversion */
+FILE_INFORMATION_CLASS ConvertToFileInfo[MaximumFileInfoByHandleClass] =
+{
+    FileBasicInformation, FileStandardInformation, FileNameInformation, FileRenameInformation,
+    FileDispositionInformation, FileAllocationInformation, FileEndOfFileInformation, FileStreamInformation,
+    FileCompressionInformation, FileAttributeTagInformation, FileIdBothDirectoryInformation, (FILE_INFORMATION_CLASS)-1,
+    FileIoPriorityHintInformation, FileRemoteProtocolInformation
+};
+
+/* Quick implementation, still going farther than Wine implementation */
+BOOL
+WINAPI
+SetFileInformationByHandle(HANDLE hFile,
+                           FILE_INFO_BY_HANDLE_CLASS FileInformationClass,
+                           LPVOID lpFileInformation,
+                           DWORD dwBufferSize)
+{
+    NTSTATUS Status;
+    IO_STATUS_BLOCK IoStatusBlock;
+    FILE_INFORMATION_CLASS FileInfoClass;
+
+    FileInfoClass = (FILE_INFORMATION_CLASS)-1;
+
+    /* Attempt to convert the class */
+    if (FileInformationClass < MaximumFileInfoByHandleClass)
+    {
+        FileInfoClass = ConvertToFileInfo[FileInformationClass];
+    }
+
+    /* If wrong, bail out */
+    if (FileInfoClass == -1)
+    {
+        SetLastError(ERROR_INVALID_PARAMETER);
+        return FALSE;
+    }
+
+    /* And set the information */
+    Status = NtSetInformationFile(hFile, &IoStatusBlock, lpFileInformation,
+                                  dwBufferSize, FileInfoClass);
+
+    if (!NT_SUCCESS(Status))
+    {
+        BaseSetLastNTError(Status);
+        return FALSE;
+    }
+
+    return TRUE;
+}

--- a/dll/win32/kernel32/kernel32_vista/kernel32_vista.spec
+++ b/dll/win32/kernel32/kernel32_vista/kernel32_vista.spec
@@ -8,6 +8,7 @@
 ; Individual files
 @ stdcall GetFileInformationByHandleEx(ptr long ptr long)
 @ stdcall -ret64 GetTickCount64()
+@ stdcall SetFileInformationByHandle(ptr long ptr long)
 
 ; sync.c SRWLock
 @ stdcall InitializeSRWLock(ptr)

--- a/dll/win32/kernel32/kernel32_vista/kernel32_vista.spec
+++ b/dll/win32/kernel32/kernel32_vista/kernel32_vista.spec
@@ -1,26 +1,30 @@
 
+; InitOnce.c
 @ stdcall InitOnceBeginInitialize(ptr long ptr ptr)
 @ stdcall InitOnceComplete(ptr long ptr)
 @ stdcall InitOnceExecuteOnce(ptr ptr ptr ptr)
-@ stdcall InitOnceInitialize(ptr) NTDLL.RtlRunOnceInitialize
+@ stdcall InitOnceInitialize(ptr) ntdll.RtlRunOnceInitialize
 
-@ stdcall GetFileInformationByHandleEx(long long ptr long)
+; Individual files
+@ stdcall GetFileInformationByHandleEx(ptr long ptr long)
 @ stdcall -ret64 GetTickCount64()
 
+; sync.c SRWLock
 @ stdcall InitializeSRWLock(ptr)
 @ stdcall AcquireSRWLockExclusive(ptr)
 @ stdcall AcquireSRWLockShared(ptr)
 @ stdcall ReleaseSRWLockExclusive(ptr)
 @ stdcall ReleaseSRWLockShared(ptr)
-
+; sync.c ConditionVariable
 @ stdcall InitializeConditionVariable(ptr)
 @ stdcall SleepConditionVariableCS(ptr ptr long)
 @ stdcall SleepConditionVariableSRW(ptr ptr long long)
 @ stdcall WakeAllConditionVariable(ptr)
 @ stdcall WakeConditionVariable(ptr)
-
+; sync.c CriticalSection
 @ stdcall InitializeCriticalSectionEx(ptr long long)
 
+; vista.c
 @ stdcall ApplicationRecoveryFinished(long)
 @ stdcall ApplicationRecoveryInProgress(ptr)
 @ stdcall CreateSymbolicLinkA(str str long)
@@ -32,6 +36,7 @@
 @ stdcall GetFileMUIPath(long wstr wstr ptr wstr ptr ptr)
 @ stdcall GetFinalPathNameByHandleA(ptr str long long)
 @ stdcall GetFinalPathNameByHandleW(ptr wstr long long)
+# @ stdcall -version=0x601+ GetProcessPreferredUILanguages(long ptr wstr ptr)
 @ stdcall GetSystemPreferredUILanguages(long ptr wstr ptr)
 @ stdcall GetThreadPreferredUILanguages(long ptr wstr ptr)
 @ stdcall GetThreadUILanguage()
@@ -43,4 +48,5 @@
 @ stdcall RegisterApplicationRecoveryCallback(ptr ptr long long)
 @ stdcall RegisterApplicationRestart(wstr long)
 @ stdcall SetFileBandwidthReservation(ptr long long long ptr ptr)
+# @ stdcall -version=0x601+ SetProcessPreferredUILanguages(long wstr ptr)
 @ stdcall SetThreadPreferredUILanguages(long wstr ptr)

--- a/dll/win32/kernel32/kernel32_vista/vista.c
+++ b/dll/win32/kernel32/kernel32_vista/vista.c
@@ -732,7 +732,7 @@ GetUserPreferredUILanguages(
 /*
  * @unimplemented
  */
-#if 0 // Tis is Windows 7+
+#if 0 // This is Windows 7+
 BOOL
 WINAPI
 SetProcessPreferredUILanguages(


### PR DESCRIPTION
## Purpose

Move this function to where it belongs.

Follow-up to 455f330 (0.4.15-dev-6969).

## Proposed changes

- *.spec: Minor sync'
- Move SetFileInformationByHandle() to kernel32_vista
- Improve SetFileInformationByHandle()

## TODO

- [ ] Maintainer, would you prefer to import (updated since then) Wine function?
https://source.winehq.org/git/wine.git/blob/7c45c7c5ebb59237d568a4e5b38626422e670b63:/dlls/kernelbase/file.c#l3671
- [ ] Update?/Run! related winetest...
