### PR TITLE
[WIDL] CMakeLists.txt: Replace 'add_definitions(-DINT16=SHORT)'

### DIFF
--- a/sdk/tools/widl/CMakeLists.txt
+++ b/sdk/tools/widl/CMakeLists.txt
@@ -35,7 +35,9 @@ list(APPEND SOURCE
     ../port/getopt1.c
     ../port/mkstemps.c)
 
-add_definitions(-DINT16=SHORT)
+# typelib_struct.h uses INT16.
+set_source_files_properties(typelib.c write_msft.c write_sltg.c PROPERTIES COMPILE_DEFINITIONS "INT16=SHORT")
+
 add_host_tool(widl ${SOURCE})
 target_link_libraries(widl PRIVATE host_includes wpphost)
 


### PR DESCRIPTION
by 'set_source_files_properties(...)'.

## Purpose

Be stricter / more explicit.

Follow-up to #6016.

## Proposed changes

- Replace 'add_definitions(-DINT16=SHORT)' by 'set_source_files_properties(...)'.