### PR TITLE
[NTOS:KE] Make the KiSystemStartup and KiInitializePcr functions slightly closer to the x86 one.

### DIFF
--- a/ntoskrnl/include/internal/amd64/ke.h
+++ b/ntoskrnl/include/internal/amd64/ke.h
@@ -476,12 +476,14 @@ KiSetTrapContext(
     _In_ PCONTEXT Context,
     _In_ KPROCESSOR_MODE RequestorMode);
 
+CODE_SEG("INIT")
 VOID
 NTAPI
-KiInitializePcr(IN PKIPCR Pcr,
-                IN ULONG ProcessorNumber,
-                IN PKTHREAD IdleThread,
-                IN PVOID DpcStack);
+KiInitializePcr(
+    _In_ ULONG ProcessorNumber,
+    _Inout_ PKIPCR Pcr,
+    _In_ PKTHREAD IdleThread,
+    _In_ PVOID DpcStack);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/ntoskrnl/include/internal/i386/ke.h
+++ b/ntoskrnl/include/internal/i386/ke.h
@@ -402,13 +402,14 @@ KiRundownThread(IN PKTHREAD Thread)
 CODE_SEG("INIT")
 VOID
 NTAPI
-KiInitializePcr(IN ULONG ProcessorNumber,
-                IN PKIPCR Pcr,
-                IN PKIDTENTRY Idt,
-                IN PKGDTENTRY Gdt,
-                IN PKTSS Tss,
-                IN PKTHREAD IdleThread,
-                IN PVOID DpcStack);
+KiInitializePcr(
+    _In_ ULONG ProcessorNumber,
+    _Inout_ PKIPCR Pcr,
+    _In_ PKIDTENTRY Idt,
+    _In_ PKGDTENTRY Gdt,
+    _In_ PKTSS Tss,
+    _In_ PKTHREAD IdleThread,
+    _In_ PVOID DpcStack);
 
 FORCEINLINE
 VOID

--- a/ntoskrnl/ke/arm/kiinit.c
+++ b/ntoskrnl/ke/arm/kiinit.c
@@ -173,13 +173,15 @@ KiInitializeKernel(IN PKPROCESS InitProcess,
 //C_ASSERT((FIELD_OFFSET(KIPCR, FirstLevelDcacheSize) & 4) == 0);
 //C_ASSERT(sizeof(KIPCR) <= PAGE_SIZE);
 
+CODE_SEG("INIT")
 VOID
 NTAPI
-KiInitializePcr(IN ULONG ProcessorNumber,
-                IN PKIPCR Pcr,
-                IN PKTHREAD IdleThread,
-                IN PVOID PanicStack,
-                IN PVOID InterruptStack)
+KiInitializePcr(
+    _In_ ULONG ProcessorNumber,
+    _Inout_ PKIPCR Pcr,
+    _In_ PKTHREAD IdleThread,
+    _In_ PVOID PanicStack,
+    _In_ PVOID InterruptStack)
 {
     ULONG i;
 
@@ -339,7 +341,7 @@ KiInitializeSystem(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
     /* Flush the TLB */
     KeFlushTb();
 
-    /* Save the loader block and get the current CPU */
+    /* Save the loader block and get the current CPU number */
     KeLoaderBlock = LoaderBlock;
     Cpu = KeNumberProcessors;
 

--- a/ntoskrnl/ke/i386/kiinit.c
+++ b/ntoskrnl/ke/i386/kiinit.c
@@ -281,13 +281,14 @@ KiInitMachineDependent(VOID)
 CODE_SEG("INIT")
 VOID
 NTAPI
-KiInitializePcr(IN ULONG ProcessorNumber,
-                IN PKIPCR Pcr,
-                IN PKIDTENTRY Idt,
-                IN PKGDTENTRY Gdt,
-                IN PKTSS Tss,
-                IN PKTHREAD IdleThread,
-                IN PVOID DpcStack)
+KiInitializePcr(
+    _In_ ULONG ProcessorNumber,
+    _Inout_ PKIPCR Pcr,
+    _In_ PKIDTENTRY Idt,
+    _In_ PKGDTENTRY Gdt,
+    _In_ PKTSS Tss,
+    _In_ PKTHREAD IdleThread,
+    _In_ PVOID DpcStack)
 {
     /* Setup the TIB */
     Pcr->NtTib.ExceptionList = EXCEPTION_CHAIN_END;
@@ -739,12 +740,12 @@ KiSystemStartup(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
     /* Boot cycles timestamp */
     BootCycles = __rdtsc();
 
-    /* Save the loader block and get the current CPU */
+    /* Save the loader block and get the current CPU number */
     KeLoaderBlock = LoaderBlock;
     Cpu = KeNumberProcessors;
     if (!Cpu)
     {
-        /* If this is the boot CPU, set FS and the CPU Number*/
+        /* If this is the boot CPU, set FS and the CPU number */
         Ke386SetFs(KGDT_R0_PCR);
         __writefsdword(KPCR_PROCESSOR_NUMBER, Cpu);
 


### PR DESCRIPTION
## Purpose

- Make the KiInitializePcr functions in each supported architecture, take its first two parameters in the same order as they are in its x86 version.
Ideally it may be of interest to have a unified one, whose internal implemention of course stays platform-specific.

- Make the x64 KiSystemStartup order of operations closer to what it is in the x86 and ARM versions, namely, delaying the initialization of the kernel debugger via CPU#0 after having updated the KeActiveProcessors and incremented KeNumberProcessors variables.