### PR TITLE
[NTOS][HAL] Add simple support for NUMPROC, BOOTPROC, MAXPROC and ONECPU boot switches

### DIFF
--- a/hal/halx86/generic/halinit.c
+++ b/hal/halx86/generic/halinit.c
@@ -14,6 +14,9 @@
 
 /* GLOBALS *******************************************************************/
 
+//#ifdef CONFIG_SMP // FIXME: Reenable conditional once HAL is consistently compiled for SMP mode
+BOOLEAN HalpOnlyBootProcessor;
+//#endif
 BOOLEAN HalpPciLockSettings;
 
 /* PRIVATE FUNCTIONS *********************************************************/
@@ -29,6 +32,12 @@ HalpGetParameters(
     {
         /* Read the command line */
         PCSTR CommandLine = LoaderBlock->LoadOptions;
+
+//#ifdef CONFIG_SMP // FIXME: Reenable conditional once HAL is consistently compiled for SMP mode
+        /* Check whether we should only start one CPU */
+        if (strstr(CommandLine, "ONECPU"))
+            HalpOnlyBootProcessor = TRUE;
+//#endif
 
         /* Check if PCI is locked */
         if (strstr(CommandLine, "PCILOCK"))

--- a/hal/halx86/smp/i386/spinup.c
+++ b/hal/halx86/smp/i386/spinup.c
@@ -16,6 +16,8 @@
 
 /* GLOBALS *******************************************************************/
 
+extern BOOLEAN HalpOnlyBootProcessor;
+
 extern PPROCESSOR_IDENTITY HalpProcessorIdentity;
 extern PHYSICAL_ADDRESS HalpLowStubPhysicalAddress;
 extern PVOID HalpLowStub;
@@ -88,6 +90,11 @@ HalStartNextProcessor(
     _In_ PLOADER_PARAMETER_BLOCK LoaderBlock,
     _In_ PKPROCESSOR_STATE ProcessorState)
 {
+    /* Bail out if we only use the boot CPU */
+    if (HalpOnlyBootProcessor)
+        return FALSE;
+
+    /* Bail out if we have started all available CPUs */
     if (HalpStartedProcessorCount == HalpApicInfoTable.ProcessorCount)
         return FALSE;
 

--- a/ntoskrnl/ex/init.c
+++ b/ntoskrnl/ex/init.c
@@ -1559,6 +1559,34 @@ Phase1InitializationDiscard(IN PVOID Context)
     }
 
 #ifdef CONFIG_SMP
+    /*
+     * IMPORTANT NOTE:
+     * Because ReactOS is a "nice" OS, we do not care _at all_
+     * about any number of registered/licensed processors:
+     * no usage of KeRegisteredProcessors nor KeLicensedProcessors.
+     */
+    if (CommandLine)
+    {
+        PSTR Option;
+
+        /* Check for NUMPROC: maximum number of logical processors
+         * that can be started (including dynamically) at run-time */
+        Option = strstr(CommandLine, "NUMPROC");
+        if (Option) Option = strstr(Option, "=");
+        if (Option) KeNumprocSpecified = atol(Option + 1);
+
+        /* Check for BOOTPROC (NT6+ and ReactOS): maximum number
+         * of logical processors that can be started at boot-time */
+        Option = strstr(CommandLine, "BOOTPROC");
+        if (Option) Option = strstr(Option, "=");
+        if (Option) KeBootprocSpecified = atol(Option + 1);
+
+        /* Check for MAXPROC (NT6+ and ReactOS): forces the kernel to report
+         * as existing the maximum number of processors that can be handled */
+        if (strstr(CommandLine, "MAXPROC"))
+            KeMaximumProcessors = MAXIMUM_PROCESSORS;
+    }
+
     /* Start Application Processors */
     KeStartAllProcessors();
 #endif

--- a/ntoskrnl/include/internal/ke.h
+++ b/ntoskrnl/include/internal/ke.h
@@ -90,7 +90,6 @@ typedef PCHAR
     IN ULONG Length
 );
 
-extern KAFFINITY KeActiveProcessors;
 extern PKNMI_HANDLER_CALLBACK KiNmiCallbackListHead;
 extern KSPIN_LOCK KiNmiCallbackListLock;
 extern PVOID KeUserApcDispatcher;
@@ -104,6 +103,13 @@ extern USHORT KeProcessorArchitecture;
 extern USHORT KeProcessorLevel;
 extern USHORT KeProcessorRevision;
 extern ULONG64 KeFeatureBits;
+extern KAFFINITY KeActiveProcessors;
+extern PKPRCB KiProcessorBlock[];
+#ifdef CONFIG_SMP
+extern ULONG KeMaximumProcessors;
+extern ULONG KeNumprocSpecified;
+extern ULONG KeBootprocSpecified;
+#endif
 extern KNODE KiNode0;
 extern PKNODE KeNodeBlock[1];
 extern UCHAR KeNumberNodes;
@@ -136,7 +142,6 @@ extern LIST_ENTRY KiProcessListHead;
 extern LIST_ENTRY KiProcessInSwapListHead, KiProcessOutSwapListHead;
 extern LIST_ENTRY KiStackInSwapListHead;
 extern KEVENT KiSwapEvent;
-extern PKPRCB KiProcessorBlock[];
 extern KAFFINITY KiIdleSummary;
 extern PVOID KeUserApcDispatcher;
 extern PVOID KeUserCallbackDispatcher;

--- a/ntoskrnl/ke/i386/mproc.c
+++ b/ntoskrnl/ke/i386/mproc.c
@@ -9,6 +9,7 @@
 /* INCLUDES *****************************************************************/
 
 #include <ntoskrnl.h>
+
 #define NDEBUG
 #include <debug.h>
 
@@ -38,12 +39,28 @@ NTAPI
 KeStartAllProcessors(VOID)
 {
     PVOID KernelStack, DPCStack;
-    ULONG ProcessorCount = 0;
     PAPINFO APInfo;
+    ULONG ProcessorCount;
+    ULONG MaximumProcessors;
 
-    while (TRUE)
+    /* NOTE: NT6+ HAL exports HalEnumerateProcessors() and
+     * HalQueryMaximumProcessorCount() that help determining
+     * the number of detected processors on the system. */
+    MaximumProcessors = KeMaximumProcessors;
+
+    /* Limit the number of processors we can start at run-time */
+    if (KeNumprocSpecified)
+        MaximumProcessors = min(MaximumProcessors, KeNumprocSpecified);
+
+    /* Limit also the number of processors we can start during boot-time */
+    if (KeBootprocSpecified)
+        MaximumProcessors = min(MaximumProcessors, KeBootprocSpecified);
+
+    // TODO: Support processor nodes
+
+    /* Start ProcessorCount at 1 because we already have the boot CPU */
+    for (ProcessorCount = 1; ProcessorCount < MaximumProcessors; ++ProcessorCount)
     {
-        ProcessorCount++;
         KernelStack = NULL;
         DPCStack = NULL;
 

--- a/ntoskrnl/ke/processor.c
+++ b/ntoskrnl/ke/processor.c
@@ -13,8 +13,26 @@
 
 /* GLOBALS *******************************************************************/
 
-CCHAR KeNumberProcessors = 0;
 KAFFINITY KeActiveProcessors = 0;
+
+/* Number of processors */
+CCHAR KeNumberProcessors = 0;
+
+#ifdef CONFIG_SMP
+
+/* Theoretical maximum number of processors that can be handled.
+ * Set once at run-time. Returned by KeQueryMaximumProcessorCount(). */
+ULONG KeMaximumProcessors = MAXIMUM_PROCESSORS;
+
+/* Maximum number of logical processors that can be started
+ * (including dynamically) at run-time. If 0: do not perform checks. */
+ULONG KeNumprocSpecified = 0;
+
+/* Maximum number of logical processors that can be started
+ * at boot-time. If 0: do not perform checks. */
+ULONG KeBootprocSpecified = 0;
+
+#endif // CONFIG_SMP
 
 /* FUNCTIONS *****************************************************************/
 


### PR DESCRIPTION
## Purpose

Add these switches mainly to test our new SMP support with different number
of CPUs configurations on multiprocessor systems.

- NUMPROC: maximum number of logical processors that can be started
  (including dynamically, not currently supported by ReactOS) at run-time.
- BOOTPROC: maximum number of logical processors that can be started at
  boot-time.
- MAXPROC: forces the OS to report the maximum possible number of CPUs
  as existing on the system.

HAL-only boot switch:
- ONECPU: It causes the HAL to only use one (the boot) CPU on a MP system.
Attempting to start other processors will fail.

For more information, see:
https://www.geoffchappell.com/notes/windows/boot/bcd/osloader/numproc.htm
https://www.geoffchappell.com/notes/windows/license/processors.htm
https://rmscrypt.wordpress.com/2011/02/
https://codeinsecurity.wordpress.com/2022/04/07/cpu-socket-and-core-count-limits-in-windows-10-and-how-to-remove-them/

Generic references about BOOT.INI switches:
https://learn.microsoft.com/en-us/windows-hardware/drivers/devtest/boot-options-in-a-boot-ini-file
https://www.itprotoday.com/cloud-computing/what-switches-can-be-used-bootini
http://franck.kiechel.free.fr/dbr_eng/BootIni.htm

References about BCD options:
https://learn.microsoft.com/en-us/windows-hardware/drivers/devtest/bcdedit--set
http://www.mistyprojects.co.uk/documents/BCDEdit/files/commands.6.1.7601.htm#TYPES%20OSLOADER

## How to test

0. Prerequisite: Verify that these switches change nothing in behaviour when using a single-processor ROS build.

1. With multiprocessor ROS build: setup a VM with more than 2 CPUs (three, or four): `N` CPUs;
 a) Check that without specifying any of these switches, ROS recognizes all the `N` CPUs;
 b) Verify that by using either `NUMPROC=m` or `BOOTPROC=m` switches, with `m` an integer _**less than or equal to `N`**_, ROS recognizes only `m` CPUs;
 c) If `m` is set to `0` then ROS should recognize all the `N` CPUs;
 d) Now, specify only the `MAXPROC` switch (it does not take any extra numerical argument!) and verify that only _**at most**_ 32 CPUs are recognized.

2. Now set your VM with more than 32 CPUs (I suppose using QEMU for that may be easier than e.g. VBox)
 a) Check that ROS currently only recognizes 32 CPUs and not more;
 b) Verify that `NUMPROC` and `BOOTPROC` switches still work; verify that if you specify a number greater than 32 for them, still only 32 CPUs are recognized.
 c) Now, specify only the `MAXPROC` switch (it does not take any extra numerical argument!) and verify that only 32 CPUs are recognized.

3. Testing `ONECPU`: Verify that when specifying this switch, no other CPUs can be started, regardless of the number of CPUs actually present on the system and regardless of the other boot switches (NUMPROC, BOOTPROC, MAXPROC...) being specified.