### PR TITLE
[WIN32SS] Introduce the NATIVE_REACTX define and disable some Dx calls

### DIFF
--- a/win32ss/CMakeLists.txt
+++ b/win32ss/CMakeLists.txt
@@ -4,6 +4,10 @@ set(USE_DIBLIB FALSE)
 # Give WIN32 subsystem its own project.
 PROJECT(WIN32SS)
 
+if (NATIVE_REACTX)
+    add_definitions(-DNATIVE_REACTX)
+endif()
+
 add_subdirectory(drivers)
 
 if(USE_DIBLIB)


### PR DESCRIPTION
## Purpose
Introduce NATIVE_REACTX and hide some native directx calls behind it 
The code itself isn't wrong but we're entirely missing the logic needed to make it work. This leads to spontaneous crashes with video drivers and various unity games.

JIRA issue: [CORE-19142](https://jira.reactos.org/browse/CORE-19142)

[TESTS_KVM](https://reactos.org/testman/compare.php?ids=94755)