### PR TITLE
[DESK] Handle ".SoftwareSettings" section to fix VBoxVGA 7.0.12 driver installation

### DIFF
--- a/dll/cpl/desk/classinst.c
+++ b/dll/cpl/desk/classinst.c
@@ -218,6 +218,33 @@ DisplayClassInstaller(
     /* Install SoftwareSettings section */
     /* Yes, we're installing this section for the second time.
      * We don't want to create a link to Settings subkey */
+    int i = 0;
+    TCHAR SectionNameMod[MAX_PATH];
+    TCHAR *pSectionName;
+
+    StringCbCat(SectionNameMod, sizeof(SectionNameMod), SectionName);
+    while (SectionNameMod[i] < 'A' || SectionNameMod[i] > 'Z')
+       i++;
+    pSectionName = &SectionNameMod[i];
+    while (i < _tcslen(SectionNameMod))
+    {
+        if (SectionNameMod[i] == '_')
+        {
+            SectionNameMod[i] = 0;
+            break;
+        }
+        i++;
+    }
+    StringCbCat(pSectionName, sizeof(SectionNameMod), _T(".SoftwareSettings"));
+    result = SetupInstallFromInfSection(
+        InstallParams.hwndParent, hInf, pSectionName, SPINST_REGISTRY, hDeviceSubKey, NULL, 0, NULL, NULL, NULL, NULL);
+    if (!result)
+    {
+        rc = GetLastError();
+        DPRINT("SetupInstallFromInfSection() failed with error 0x%lx\n", rc);
+        goto cleanup;
+    }
+
     result = SetupInstallFromInfSection(
         InstallParams.hwndParent, hInf, SectionName,
         SPINST_REGISTRY, hDeviceSubKey,

--- a/dll/cpl/desk/classinst.c
+++ b/dll/cpl/desk/classinst.c
@@ -4,7 +4,7 @@
  * FILE:            dll/cpl/desk/classinst.c
  * PURPOSE:         Class installers
  *
- * PROGRAMMERS:     Hervé Poussineau (hpoussin@reactos.org)
+ * PROGRAMMERS:     HervÃ© Poussineau (hpoussin@reactos.org)
  */
 
 #include "desk.h"
@@ -222,9 +222,7 @@ DisplayClassInstaller(
     TCHAR SectionNameMod[MAX_PATH];
     TCHAR *pSectionName;
 
-    StringCbCat(SectionNameMod, sizeof(SectionNameMod), SectionName);
-    while (SectionNameMod[i] < 'A' || SectionNameMod[i] > 'Z')
-       i++;
+    StringCbCopy(SectionNameMod, sizeof(SectionNameMod), SectionName);
     pSectionName = &SectionNameMod[i];
     while (i < _tcslen(SectionNameMod))
     {


### PR DESCRIPTION
Added code to read the SoftwareSettings section of the VBoxVGA video driver file from the Virtual Box Additions installation.   I was unable to run ReactOS with Virtual Box Additions (version 7.0.12).

This PR aimed to fix JIRA issue: [CORE-19224](https://jira.reactos.org/browse/CORE-19224) but has proven to be wrong. In fact we do see a VirtualBox issue here which does also affect e.g. Windows 2003 Server SP2.
We will wait for https://www.virtualbox.org/ticket/21982 to be fixed instead.
