### PR TITLE
[SETUPAPI] cfgmgr.c: Do not debugstr_*(pszVetoName)

### DIFF
--- a/dll/win32/setupapi/cfgmgr.c
+++ b/dll/win32/setupapi/cfgmgr.c
@@ -6586,8 +6586,8 @@ CM_Query_And_Remove_SubTreeW(
     _In_ ULONG ulNameLength,
     _In_ ULONG ulFlags)
 {
-    TRACE("CM_Query_And_Remove_SubTreeW(%lx %p %s %lu %lx)\n",
-          dnAncestor, pVetoType, debugstr_w(pszVetoName), ulNameLength, ulFlags);
+    TRACE("CM_Query_And_Remove_SubTreeW(%lx %p %p %lu %lx)\n",
+          dnAncestor, pVetoType, pszVetoName, ulNameLength, ulFlags);
 
     return CM_Query_And_Remove_SubTree_ExW(dnAncestor, pVetoType, pszVetoName,
                                            ulNameLength, ulFlags, NULL);
@@ -6610,8 +6610,8 @@ CM_Query_And_Remove_SubTree_ExA(
     LPWSTR lpLocalVetoName;
     CONFIGRET ret;
 
-    TRACE("CM_Query_And_Remove_SubTree_ExA(%lx %p %s %lu %lx %p)\n",
-          dnAncestor, pVetoType, debugstr_a(pszVetoName), ulNameLength,
+    TRACE("CM_Query_And_Remove_SubTree_ExA(%lx %p %p %lu %lx %p)\n",
+          dnAncestor, pVetoType, pszVetoName, ulNameLength,
           ulFlags, hMachine);
 
     if (pszVetoName == NULL && ulNameLength == 0)
@@ -6660,8 +6660,8 @@ CM_Query_And_Remove_SubTree_ExW(
     LPWSTR lpDevInst;
     CONFIGRET ret;
 
-    TRACE("CM_Query_And_Remove_SubTree_ExW(%lx %p %s %lu %lx %p)\n",
-          dnAncestor, pVetoType, debugstr_w(pszVetoName), ulNameLength,
+    TRACE("CM_Query_And_Remove_SubTree_ExW(%lx %p %p %lu %lx %p)\n",
+          dnAncestor, pVetoType, pszVetoName, ulNameLength,
           ulFlags, hMachine);
 
     if (dnAncestor == 0)
@@ -7442,8 +7442,8 @@ CM_Request_Device_EjectA(
     _In_ ULONG ulNameLength,
     _In_ ULONG ulFlags)
 {
-    TRACE("CM_Request_Device_EjectA(%lx %p %s %lu %lx)\n",
-          dnDevInst, pVetoType, debugstr_a(pszVetoName), ulNameLength, ulFlags);
+    TRACE("CM_Request_Device_EjectA(%lx %p %p %lu %lx)\n",
+          dnDevInst, pVetoType, pszVetoName, ulNameLength, ulFlags);
 
     return CM_Request_Device_Eject_ExA(dnDevInst, pVetoType, pszVetoName,
                                        ulNameLength, ulFlags, NULL);
@@ -7462,8 +7462,8 @@ CM_Request_Device_EjectW(
     _In_ ULONG ulNameLength,
     _In_ ULONG ulFlags)
 {
-    TRACE("CM_Request_Device_EjectW(%lx %p %s %lu %lx)\n",
-          dnDevInst, pVetoType, debugstr_w(pszVetoName), ulNameLength, ulFlags);
+    TRACE("CM_Request_Device_EjectW(%lx %p %p %lu %lx)\n",
+          dnDevInst, pVetoType, pszVetoName, ulNameLength, ulFlags);
 
     return CM_Request_Device_Eject_ExW(dnDevInst, pVetoType, pszVetoName,
                                        ulNameLength, ulFlags, NULL);
@@ -7486,8 +7486,8 @@ CM_Request_Device_Eject_ExA(
     LPWSTR lpLocalVetoName = NULL;
     CONFIGRET ret;
 
-    TRACE("CM_Request_Device_Eject_ExA(%lx %p %s %lu %lx %p)\n",
-          dnDevInst, pVetoType, debugstr_a(pszVetoName), ulNameLength, ulFlags, hMachine);
+    TRACE("CM_Request_Device_Eject_ExA(%lx %p %p %lu %lx %p)\n",
+          dnDevInst, pVetoType, pszVetoName, ulNameLength, ulFlags, hMachine);
 
     if (ulNameLength != 0)
     {
@@ -7538,8 +7538,8 @@ CM_Request_Device_Eject_ExW(
     LPWSTR lpDevInst;
     CONFIGRET ret;
 
-    TRACE("CM_Request_Device_Eject_ExW(%lx %p %s %lu %lx %p)\n",
-          dnDevInst, pVetoType, debugstr_w(pszVetoName), ulNameLength, ulFlags, hMachine);
+    TRACE("CM_Request_Device_Eject_ExW(%lx %p %p %lu %lx %p)\n",
+          dnDevInst, pVetoType, pszVetoName, ulNameLength, ulFlags, hMachine);
 
     if (dnDevInst == 0)
         return CR_INVALID_DEVNODE;


### PR DESCRIPTION
which is an _Out_ parameter.

## Purpose

Fix "uninitialized" data read.

Follow-up to #5943.

## Proposed changes

- Do not debugstr_*(pszVetoName)