### PR TITLE
[SETUPAPI] CM_Request_Device_Eject_ExW: Allow ulNameLength to be zero when pszVetoName is not NULL

### DIFF
--- a/dll/win32/setupapi/cfgmgr.c
+++ b/dll/win32/setupapi/cfgmgr.c
@@ -7548,15 +7548,12 @@ CM_Request_Device_Eject_ExW(
         return CR_INVALID_FLAG;
 
     if (pszVetoName == NULL && ulNameLength != 0)
-    {
         return CR_INVALID_POINTER;
-    }
-    else if (pszVetoName != NULL && ulNameLength == 0)
-    {
-        /* Windows 2003 SP2 ignores pszVetoName when ulNameLength is zero
-         * and behaves like when pszVetoName is NULL */
+
+    /* Windows 2003 SP2 ignores pszVetoName when ulNameLength is zero
+     * and behaves like when pszVetoName is NULL */
+    if (ulNameLength == 0)
         pszVetoName = NULL;
-    }
 
     if (hMachine != NULL)
     {

--- a/dll/win32/setupapi/cfgmgr.c
+++ b/dll/win32/setupapi/cfgmgr.c
@@ -7548,7 +7548,15 @@ CM_Request_Device_Eject_ExW(
         return CR_INVALID_FLAG;
 
     if (pszVetoName == NULL && ulNameLength != 0)
+    {
         return CR_INVALID_POINTER;
+    }
+    else if (pszVetoName != NULL && ulNameLength == 0)
+    {
+        /* Windows 2003 SP2 ignores pszVetoName when ulNameLength is zero
+         * and behaves like when pszVetoName is NULL */
+        pszVetoName = NULL;
+    }
 
     if (hMachine != NULL)
     {


### PR DESCRIPTION
## Purpose
Follow-up of PR [#5943](https://github.com/reactos/reactos/pull/5943)

Before:
![ReactOS_Before](https://github.com/reactos/reactos/assets/86486978/a9ffda7c-d8b1-412b-8f82-95ddd86b4c1d)

After:
![ReactOS_After](https://github.com/reactos/reactos/assets/86486978/6de65efc-a4f6-4faa-a9aa-f0543a3d779c)