### PR TITLE
[MSPAINT] Define SelectionBaseTool and use it

### DIFF
--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -520,7 +520,7 @@ LRESULT CCanvasWindow::OnButtonUp(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL&
     BOOL bLeftButton = (m_nMouseDownMsg == WM_LBUTTONDOWN);
     m_nMouseDownMsg = 0;
 
-    if (m_drawing || m_hitSelection != HIT_NONE)
+    if (m_drawing)
     {
         m_drawing = FALSE;
         toolsModel.OnButtonUp(bLeftButton, pt.x, pt.y);
@@ -702,7 +702,6 @@ VOID CCanvasWindow::cancelDrawing()
 {
     selectionModel.ClearColorImage();
     selectionModel.ClearMaskImage();
-    m_hitSelection = HIT_NONE;
     m_drawing = FALSE;
     toolsModel.OnEndDraw(TRUE);
     Invalidate(FALSE);

--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -319,7 +319,7 @@ LRESULT CCanvasWindow::OnButtonDown(UINT nMsg, WPARAM wParam, LPARAM lParam, BOO
         CanvasToImage(pt);
         SetCapture();
         toolsModel.OnButtonDown(bLeftButton, pt.x, pt.y, FALSE);
-        Invalidate(FALSE);
+        Invalidate();
         return 0;
     }
 
@@ -355,7 +355,7 @@ LRESULT CCanvasWindow::OnButtonDown(UINT nMsg, WPARAM wParam, LPARAM lParam, BOO
         m_drawing = TRUE;
         SetCapture();
         toolsModel.OnButtonDown(bLeftButton, pt.x, pt.y, FALSE);
-        Invalidate(FALSE);
+        Invalidate();
         return 0;
     }
 
@@ -380,7 +380,7 @@ LRESULT CCanvasWindow::OnButtonDblClk(UINT nMsg, WPARAM wParam, LPARAM lParam, B
 
     toolsModel.OnButtonDown(nMsg == WM_LBUTTONDBLCLK, pt.x, pt.y, TRUE);
     toolsModel.resetTool();
-    Invalidate(FALSE);
+    Invalidate();
     return 0;
 }
 

--- a/base/applications/mspaint/canvas.h
+++ b/base/applications/mspaint/canvas.h
@@ -67,10 +67,6 @@ protected:
     VOID DoDraw(HDC hDC, RECT& rcClient, RECT& rcPaint);
     VOID OnHVScroll(WPARAM wParam, INT fnBar);
 
-    VOID StartSelectionDrag(HITTEST hit, POINT ptImage);
-    VOID SelectionDragging(POINT ptImage);
-    VOID EndSelectionDrag(POINT ptImage);
-
     LRESULT OnSize(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
     LRESULT OnHScroll(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
     LRESULT OnVScroll(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);

--- a/base/applications/mspaint/canvas.h
+++ b/base/applications/mspaint/canvas.h
@@ -56,7 +56,6 @@ public:
     VOID zoomTo(INT newZoom, LONG left = 0, LONG top = 0);
 
 protected:
-    HITTEST m_hitSelection;
     HITTEST m_hitCanvasSizeBox;
     POINT m_ptOrig; // The origin of drag start
     HBITMAP m_ahbmCached[2]; // The cached buffer bitmaps

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -963,29 +963,7 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
                 textEditWindow.PostMessage(WM_UNDO, 0, 0);
                 break;
             }
-            if (selectionModel.m_bShow)
-            {
-                if (toolsModel.IsSelection())
-                {
-                    canvasWindow.cancelDrawing();
-                    if (toolsModel.GetActiveTool() == TOOL_FREESEL ||
-                        toolsModel.GetActiveTool() == TOOL_RECTSEL)
-                    {
-                        imageModel.Undo();
-                        if (selectionModel.m_nSelectionBrush == 2) // Selection Brush is drawn
-                        {
-                            imageModel.Undo();
-                            selectionModel.m_nSelectionBrush = 0;
-                        }
-                    }
-                    break;
-                }
-            }
-            if (ToolBase::s_pointSP != 0) // drawing something?
-            {
-                canvasWindow.cancelDrawing();
-                break;
-            }
+            canvasWindow.finishDrawing();
             imageModel.Undo();
             break;
         case IDM_EDITREDO:
@@ -994,11 +972,7 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
                 // There is no "WM_REDO" in EDIT control
                 break;
             }
-            if (ToolBase::s_pointSP != 0) // drawing something?
-            {
-                canvasWindow.finishDrawing();
-                break;
-            }
+            canvasWindow.finishDrawing();
             imageModel.Redo();
             break;
         case IDM_EDITCOPY:

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -373,7 +373,7 @@ struct SelectionBaseTool : SmoothDrawTool
         HITTEST hit = selectionModel.hitTest(ptCanvas);
         if (hit != HIT_NONE)
         {
-            if (m_bCtrlKey)
+            if (m_bCtrlKey || m_bShiftKey)
                 imageModel.SelectionClone();
 
             m_hitSelection = hit;
@@ -408,13 +408,13 @@ struct SelectionBaseTool : SmoothDrawTool
     {
         POINT pt = { x, y };
 
+        if (!m_bLeftButton)
+            return TRUE;
+
         if (m_hitSelection != HIT_NONE)
         {
-            if (m_bShiftKey || m_bCtrlKey)
-            {
+            if (m_bShiftKey)
                 imageModel.SelectionClone(m_bShiftKey);
-                m_bCtrlKey = FALSE;
-            }
 
             selectionModel.Dragging(m_hitSelection, pt);
             imageModel.NotifyImageChanged();
@@ -438,6 +438,9 @@ struct SelectionBaseTool : SmoothDrawTool
     {
         POINT pt = { x, y };
         m_bDrawing = FALSE;
+
+        if (!m_bLeftButton)
+            return TRUE;
 
         if (m_hitSelection != HIT_NONE)
         {

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -371,7 +371,7 @@ struct SelectionBaseTool : SmoothDrawTool
         POINT ptCanvas = pt;
         canvasWindow.ImageToCanvas(ptCanvas);
         HITTEST hit = selectionModel.hitTest(ptCanvas);
-        if (hit != HIT_NONE)
+        if (hit != HIT_NONE) // Dragging of selection started?
         {
             if (m_bCtrlKey || m_bShiftKey)
                 imageModel.SelectionClone();
@@ -408,7 +408,7 @@ struct SelectionBaseTool : SmoothDrawTool
         if (!m_bLeftButton)
             return TRUE;
 
-        if (m_hitSelection != HIT_NONE)
+        if (m_hitSelection != HIT_NONE) // Now dragging selection?
         {
             if (m_bShiftKey)
                 imageModel.SelectionClone(m_bShiftKey);
@@ -436,7 +436,7 @@ struct SelectionBaseTool : SmoothDrawTool
         if (!m_bLeftButton)
             return TRUE;
 
-        if (m_hitSelection != HIT_NONE)
+        if (m_hitSelection != HIT_NONE) // Dragging of selection ended?
         {
             selectionModel.Dragging(m_hitSelection, pt);
             m_hitSelection = HIT_NONE;

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -380,7 +380,6 @@ struct SelectionBaseTool : SmoothDrawTool
             selectionModel.m_ptHit = pt;
             selectionModel.TakeOff();
 
-            canvasWindow.SetCapture();
             imageModel.NotifyImageChanged();
             return;
         }

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -360,7 +360,7 @@ struct SelectionBaseTool : SmoothDrawTool
         m_hitSelection = HIT_NONE;
 
         POINT pt = { x, y };
-        if (!bLeftButton) // Show context menu on Right-click
+        if (!m_bLeftButton) // Show context menu on Right-click
         {
             canvasWindow.ImageToCanvas(pt);
             canvasWindow.ClientToScreen(&pt);
@@ -387,18 +387,15 @@ struct SelectionBaseTool : SmoothDrawTool
         selectionModel.Landing();
         m_bDrawing = TRUE;
 
-        if (m_bLeftButton)
+        imageModel.Clamp(pt);
+        if (isRectSelect())
         {
-            imageModel.Clamp(pt);
-            if (isRectSelect())
-            {
-                selectionModel.SetRectFromPoints(g_ptStart, pt);
-            }
-            else
-            {
-                selectionModel.ResetPtStack();
-                selectionModel.PushToPtStack(pt);
-            }
+            selectionModel.SetRectFromPoints(g_ptStart, pt);
+        }
+        else
+        {
+            selectionModel.ResetPtStack();
+            selectionModel.PushToPtStack(pt);
         }
 
         imageModel.NotifyImageChanged();
@@ -421,16 +418,13 @@ struct SelectionBaseTool : SmoothDrawTool
             return TRUE;
         }
 
-        if (m_bLeftButton)
-        {
-            imageModel.Clamp(pt);
-            if (isRectSelect())
-                selectionModel.SetRectFromPoints(g_ptStart, pt);
-            else
-                selectionModel.PushToPtStack(pt);
-            imageModel.NotifyImageChanged();
-        }
+        imageModel.Clamp(pt);
+        if (isRectSelect())
+            selectionModel.SetRectFromPoints(g_ptStart, pt);
+        else
+            selectionModel.PushToPtStack(pt);
 
+        imageModel.NotifyImageChanged();
         return TRUE;
     }
 
@@ -450,9 +444,9 @@ struct SelectionBaseTool : SmoothDrawTool
             return TRUE;
         }
 
+        imageModel.Clamp(pt);
         if (isRectSelect())
         {
-            imageModel.Clamp(pt);
             selectionModel.SetRectFromPoints(g_ptStart, pt);
             selectionModel.m_bShow = !selectionModel.m_rc.IsRectEmpty();
         }

--- a/base/applications/mspaint/selectionmodel.h
+++ b/base/applications/mspaint/selectionmodel.h
@@ -23,7 +23,6 @@ public:
     CRect m_rc;    // in image pixel coordinates
     POINT m_ptHit; // in image pixel coordinates
     CRect m_rcOld; // in image pixel coordinates
-    INT m_nSelectionBrush = 0;
 
     SelectionModel();
     ~SelectionModel();


### PR DESCRIPTION
## Purpose

Refactoring and arrangement for selection handling.
JIRA issue: [CORE-19094](https://jira.reactos.org/browse/CORE-19094)

## Proposed changes

- Move some selection-related codes in `canvas.cpp` to `mouse.cpp`.
- Add `SelectionBaseTool` structure for `FreeSelTool` and `RectSelTool`.
- Delete some useless codes.

## TODO

- [x] Do tests.
