### PR TITLE
[NTGDI] Fix PatBlt with negative values

### DIFF
--- a/win32ss/gdi/ntgdi/bitblt.c
+++ b/win32ss/gdi/ntgdi/bitblt.c
@@ -858,26 +858,26 @@ IntPatBlt(
         return TRUE;
     }
 
-    if (Width > 0)
+    if (Width >= 0)
     {
         DestRect.left = XLeft;
         DestRect.right = XLeft + Width;
     }
     else
     {
-        DestRect.left = XLeft + Width + 1;
-        DestRect.right = XLeft + 1;
+        DestRect.left = XLeft + Width;
+        DestRect.right = XLeft;
     }
 
-    if (Height > 0)
+    if (Height >= 0)
     {
         DestRect.top = YLeft;
         DestRect.bottom = YLeft + Height;
     }
     else
     {
-        DestRect.top = YLeft + Height + 1;
-        DestRect.bottom = YLeft + 1;
+        DestRect.top = YLeft + Height;
+        DestRect.bottom = YLeft;
     }
 
     IntLPtoDP(pdc, (LPPOINT)&DestRect, 2);

--- a/win32ss/user/ntuser/nonclient.c
+++ b/win32ss/user/ntuser/nonclient.c
@@ -891,8 +891,8 @@ NC_DrawFrame( HDC hDC, RECT *CurrentRect, BOOL Active, DWORD Style, DWORD ExStyl
       /* Draw frame */
       NtGdiPatBlt(hDC, CurrentRect->left, CurrentRect->top, CurrentRect->right - CurrentRect->left, Height, PATCOPY);
       NtGdiPatBlt(hDC, CurrentRect->left, CurrentRect->top, Width, CurrentRect->bottom - CurrentRect->top, PATCOPY);
-      NtGdiPatBlt(hDC, CurrentRect->left, CurrentRect->bottom - 1, CurrentRect->right - CurrentRect->left, -Height, PATCOPY);
-      NtGdiPatBlt(hDC, CurrentRect->right - 1, CurrentRect->top, -Width, CurrentRect->bottom - CurrentRect->top, PATCOPY);
+      NtGdiPatBlt(hDC, CurrentRect->left, CurrentRect->bottom, CurrentRect->right - CurrentRect->left, -Height, PATCOPY);
+      NtGdiPatBlt(hDC, CurrentRect->right, CurrentRect->top, -Width, CurrentRect->bottom - CurrentRect->top, PATCOPY);
 
       RECTL_vInflateRect(CurrentRect, -Width, -Height);
    }

--- a/win32ss/user/ntuser/nonclient.c
+++ b/win32ss/user/ntuser/nonclient.c
@@ -47,8 +47,8 @@ UserDrawWindowFrame(HDC hdc,
    HBRUSH hbrush = NtGdiSelectBrush( hdc, gpsi->hbrGray );
    NtGdiPatBlt( hdc, rect->left, rect->top, rect->right - rect->left - width, height, PATINVERT );
    NtGdiPatBlt( hdc, rect->left, rect->top + height, width, rect->bottom - rect->top - height, PATINVERT );
-   NtGdiPatBlt( hdc, rect->left + width, rect->bottom - 1, rect->right - rect->left - width, -(LONG)height, PATINVERT );
-   NtGdiPatBlt( hdc, rect->right - 1, rect->top, -(LONG)width, rect->bottom - rect->top - height, PATINVERT );
+   NtGdiPatBlt( hdc, rect->left + width, rect->bottom, rect->right - rect->left - width, -(LONG)height, PATINVERT );
+   NtGdiPatBlt( hdc, rect->right, rect->top, -(LONG)width, rect->bottom - rect->top - height, PATINVERT );
    NtGdiSelectBrush( hdc, hbrush );
 }
 

--- a/win32ss/user/ntuser/nonclient.c
+++ b/win32ss/user/ntuser/nonclient.c
@@ -912,8 +912,8 @@ NC_DrawFrame( HDC hDC, RECT *CurrentRect, BOOL Active, DWORD Style, DWORD ExStyl
       /* Draw frame */
       NtGdiPatBlt(hDC, CurrentRect->left, CurrentRect->top, CurrentRect->right - CurrentRect->left, Height, PATCOPY);
       NtGdiPatBlt(hDC, CurrentRect->left, CurrentRect->top, Width, CurrentRect->bottom - CurrentRect->top, PATCOPY);
-      NtGdiPatBlt(hDC, CurrentRect->left, CurrentRect->bottom - 1, CurrentRect->right - CurrentRect->left, -Height, PATCOPY);
-      NtGdiPatBlt(hDC, CurrentRect->right - 1, CurrentRect->top, -Width, CurrentRect->bottom - CurrentRect->top, PATCOPY);
+      NtGdiPatBlt(hDC, CurrentRect->left, CurrentRect->bottom, CurrentRect->right - CurrentRect->left, -Height, PATCOPY);
+      NtGdiPatBlt(hDC, CurrentRect->right, CurrentRect->top, -Width, CurrentRect->bottom - CurrentRect->top, PATCOPY);
 
       RECTL_vInflateRect(CurrentRect, -Width, -Height);
    }


### PR DESCRIPTION
## Purpose

When I am implementing the IME soft keyboard (#6021 and #6036), I noticed an issue with `PatBlt` function.

JIRA issue: [CORE-19334](https://jira.reactos.org/browse/CORE-19334)

## Comparison
Using IME Software Keyboards...

Win2k3:
![image](https://github.com/reactos/reactos/assets/2107452/aed6f15d-fff9-43ba-969d-d4bee45503bd)
BEFORE:
![before-1](https://github.com/reactos/reactos/assets/2107452/2775fa78-74d5-444d-9d41-8845708a5762)
AFTER:
![after-1](https://github.com/reactos/reactos/assets/2107452/06dfc9d4-2d7c-4e17-813f-b6469897d2a4)
Successful.

Win2k3:
![image](https://github.com/reactos/reactos/assets/2107452/9eb1191c-d2b2-4e07-a59e-a54c4436bb29)
BEFORE:
![before-2](https://github.com/reactos/reactos/assets/2107452/46a01fa2-2663-4da7-84cc-77ca963322cf)
AFTER:
![after-2](https://github.com/reactos/reactos/assets/2107452/833f45b6-b10e-446b-bec8-fb1632f5d605)
Successful.

BEFORE:
![before-3](https://github.com/reactos/reactos/assets/2107452/c05f6534-d851-47bb-9ff7-0302ad7438e1)
AFTER:
![after-3](https://github.com/reactos/reactos/assets/2107452/5b63ea7c-743e-4a28-863f-a3246ae77461)
Successful.

## Proposed changes

- Fix the rectangle coordinates when the value was negative in `NtGdiPatBlt` function.
- Fix `NC_DrawFrame` function.
- Fix `UserDrawWindowFrame` function.

## TODO

- [x] Do small tests.
- [x] Do big tests.
- [x] Check and fix GUI parts.