### PR TITLE
[INPUT] Fix exception on setting default language

### DIFF
--- a/dll/cpl/input/input_list.c
+++ b/dll/cpl/input/input_list.c
@@ -385,6 +385,7 @@ InputList_Process(VOID)
     DWORD dwNumber;
     BOOL bRet = FALSE;
     HKEY hPreloadKey, hSubstKey;
+    HKL hDefaultKL = NULL;
 
     if (!InputList_PrepareUserRegistry(&hPreloadKey, &hSubstKey))
     {
@@ -442,6 +443,9 @@ InputList_Process(VOID)
 
             /* Activate the DEFAULT entry */
             ActivateKeyboardLayout(pCurrent->hkl, KLF_RESET);
+
+            /* Save it */
+            hDefaultKL = pCurrent->hkl;
             break;
         }
     }
@@ -467,7 +471,7 @@ InputList_Process(VOID)
     }
 
     /* Change the default keyboard language */
-    if (SystemParametersInfoW(SPI_SETDEFAULTINPUTLANG, 0, &pCurrent->hkl, 0))
+    if (SystemParametersInfoW(SPI_SETDEFAULTINPUTLANG, 0, &hDefaultKL, 0))
     {
         DWORD dwRecipients = BSM_ALLDESKTOPS | BSM_APPLICATIONS;
 
@@ -475,7 +479,7 @@ InputList_Process(VOID)
                                 &dwRecipients,
                                 WM_INPUTLANGCHANGEREQUEST,
                                 INPUTLANGCHANGE_SYSCHARSET,
-                                (LPARAM)pCurrent->hkl);
+                                (LPARAM)hDefaultKL);
     }
 
     /* Retry to delete (in case of failure to delete the default keyboard) */


### PR DESCRIPTION
## Purpose

Follow-up to #4666. Fix an abnormal termination at setting the default language.
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700), [CORE-13244](https://jira.reactos.org/browse/CORE-13244), [CORE-18364](https://jira.reactos.org/browse/CORE-18364)

## Proposed changes

- `pCurrent` was an invalid pointer at the crime scene. Don't use it there for `SPI_SETDEFALTINPUTLANG`.
- Save the default keyboard layout.
- Use it.

## TODO

- [x] Do tests.

## Screenshots

BEFORE:
![before](https://github.com/reactos/reactos/assets/2107452/48b18c24-2829-4aa4-ba9f-eb01c020bcc9)
The crime scene: The user about to add Russian.

AFTER:
![after](https://github.com/reactos/reactos/assets/2107452/e11e8bf1-9eda-42e1-888c-d2bd1e8f4f46)
Fixed. Successful.
