### PR TITLE
[KERNEL32] Fix 64-bit bug in SetProcessAffinityMask

### DIFF
--- a/dll/win32/kernel32/client/proc.c
+++ b/dll/win32/kernel32/client/proc.c
@@ -900,7 +900,7 @@ SetProcessAffinityMask(IN HANDLE hProcess,
     Status = NtSetInformationProcess(hProcess,
                                      ProcessAffinityMask,
                                      (PVOID)&dwProcessAffinityMask,
-                                     sizeof(DWORD));
+                                     sizeof(dwProcessAffinityMask));
     if (!NT_SUCCESS(Status))
     {
         /* Handle failure */


### PR DESCRIPTION
## Purpose

Fix 64-bit bug in SetProcessAffinityMask
