### PR TITLE
[SHELL32] Fix FS folder assoc array class order

### DIFF
--- a/dll/win32/shell32/folders/CDesktopFolder.cpp
+++ b/dll/win32/shell32/folders/CDesktopFolder.cpp
@@ -624,7 +624,7 @@ HRESULT WINAPI CDesktopFolder::GetUIObjectOf(
             UINT cKeys = 0;
             if (cidl > 0)
             {
-                AddFSClassKeysToArray(apidl[0], hKeys, &cKeys);
+                AddFSClassKeysToArray(cidl, apidl, hKeys, &cKeys);
             }
 
             DEFCONTEXTMENU dcm;

--- a/dll/win32/shell32/folders/CFSFolder.cpp
+++ b/dll/win32/shell32/folders/CFSFolder.cpp
@@ -1204,7 +1204,7 @@ HRESULT WINAPI CFSFolder::GetUIObjectOf(HWND hwndOwner,
         {
             HKEY hKeys[16];
             UINT cKeys = 0;
-            AddFSClassKeysToArray(apidl[0], hKeys, &cKeys);
+            AddFSClassKeysToArray(cidl, apidl, hKeys, &cKeys);
 
             DEFCONTEXTMENU dcm;
             dcm.hwnd = hwndOwner;

--- a/dll/win32/shell32/shfldr.h
+++ b/dll/win32/shell32/shfldr.h
@@ -64,7 +64,7 @@ HRESULT SHELL32_BindToSF (LPCITEMIDLIST pidlRoot, PERSIST_FOLDER_TARGET_INFO* pp
 extern "C"
 BOOL HCR_RegOpenClassIDKey(REFIID riid, HKEY *hkey);
 
-void AddFSClassKeysToArray(PCUITEMID_CHILD pidl, HKEY* array, UINT* cKeys);
+void AddFSClassKeysToArray(UINT cidl, PCUITEMID_CHILD_ARRAY apidl, HKEY* array, UINT* cKeys);
 
 HRESULT CDefViewBckgrndMenu_CreateInstance(IShellFolder* psf, REFIID riid, void **ppv);
 
@@ -94,7 +94,7 @@ static __inline int SHELL32_GUIDToStringW (REFGUID guid, LPWSTR str)
 void SHELL_FS_ProcessDisplayFilename(LPWSTR szPath, DWORD dwFlags);
 BOOL SHELL_FS_HideExtension(LPCWSTR pwszPath);
 
-void AddClassKeyToArray(const WCHAR * szClass, HKEY* array, UINT* cKeys);
+LSTATUS AddClassKeyToArray(const WCHAR * szClass, HKEY* array, UINT* cKeys);
 
 #ifdef __cplusplus
 

--- a/dll/win32/shell32/shfldr.h
+++ b/dll/win32/shell32/shfldr.h
@@ -94,7 +94,7 @@ static __inline int SHELL32_GUIDToStringW (REFGUID guid, LPWSTR str)
 void SHELL_FS_ProcessDisplayFilename(LPWSTR szPath, DWORD dwFlags);
 BOOL SHELL_FS_HideExtension(LPCWSTR pwszPath);
 
-LSTATUS AddClassKeyToArray(const WCHAR * szClass, HKEY* array, UINT* cKeys);
+LSTATUS AddClassKeyToArray(const WCHAR* szClass, HKEY* array, UINT* cKeys);
 
 #ifdef __cplusplus
 

--- a/dll/win32/shell32/shlfolder.cpp
+++ b/dll/win32/shell32/shlfolder.cpp
@@ -283,7 +283,8 @@ LSTATUS AddClassKeyToArray(const WCHAR * szClass, HKEY* array, UINT* cKeys)
 
 void AddFSClassKeysToArray(UINT cidl, PCUITEMID_CHILD_ARRAY apidl, HKEY* array, UINT* cKeys)
 {
-    //learn.microsoft.com/en-us/windows/win32/shell/fa-associationarray#about-association-arrays
+    // This function opens the association array keys in canonical order for filesystem items.
+    // The order is documented: learn.microsoft.com/en-us/windows/win32/shell/fa-associationarray
 
     ASSERT(cidl >= 1 && apidl);
     PCUITEMID_CHILD pidl = apidl[0];
@@ -299,7 +300,7 @@ void AddFSClassKeysToArray(UINT cidl, PCUITEMID_CHILD_ARRAY apidl, HKEY* array, 
         {
             _ILSimpleGetTextW(pidl, name = buf, _countof(buf));
         }
-        LPWSTR extension = PathFindExtension(name);
+        LPCWSTR extension = PathFindExtension(name);
 
         if (extension)
         {

--- a/dll/win32/shell32/shlfolder.cpp
+++ b/dll/win32/shell32/shlfolder.cpp
@@ -266,7 +266,7 @@ HRESULT SHELL32_CompareDetails(IShellFolder2* isf, LPARAM lParam, LPCITEMIDLIST 
     return MAKE_COMPARE_HRESULT(ret);
 }
 
-LSTATUS AddClassKeyToArray(const WCHAR * szClass, HKEY* array, UINT* cKeys)
+LSTATUS AddClassKeyToArray(const WCHAR* szClass, HKEY* array, UINT* cKeys)
 {
     if (*cKeys >= 16)
         return ERROR_MORE_DATA;
@@ -290,7 +290,8 @@ void AddFSClassKeysToArray(UINT cidl, PCUITEMID_CHILD_ARRAY apidl, HKEY* array, 
     PCUITEMID_CHILD pidl = apidl[0];
     if (_ILIsValue(pidl))
     {
-        WCHAR buf[MAX_PATH], *name;
+        WCHAR buf[MAX_PATH];
+        PWSTR name;
         FileStructW* pFileData = _ILGetFileStructW(pidl);
         if (pFileData)
         {
@@ -298,7 +299,8 @@ void AddFSClassKeysToArray(UINT cidl, PCUITEMID_CHILD_ARRAY apidl, HKEY* array, 
         }
         else
         {
-            _ILSimpleGetTextW(pidl, name = buf, _countof(buf));
+            _ILSimpleGetTextW(pidl, buf, _countof(buf));
+            name = buf;
         }
         LPCWSTR extension = PathFindExtension(name);
 
@@ -312,7 +314,7 @@ void AddFSClassKeysToArray(UINT cidl, PCUITEMID_CHILD_ARRAY apidl, HKEY* array, 
                 // Only add the extension key if the ProgId is not valid
                 AddClassKeyToArray(extension, array, cKeys);
 
-                // Open With becomes the default when there are no verbs in the above keys
+                // "Open With" becomes the default when there are no verbs in the above keys
                 if (cidl == 1)
                     AddClassKeyToArray(L"Unknown", array, cKeys);
             }


### PR DESCRIPTION
Fixes the reg class key order for FS items. The existing code was close but for some reason used `//` as the path separator for SystemFileAssociations!

- Fixed SystemFileAssociations.
- Swapped the order of `*` and `AllFilesystemObjects`. This is [the documented order](https://learn.microsoft.com/en-us/windows/win32/shell/fa-associationarray#about-association-arrays) and can also be observed in Process Monitor.
- Removed `(..., L"%s//%s", extension, wszClass)`, this does not seem to be a valid thing (`.TestAAExtWeird` in my tests).
- Adds the `Unknown` class when appropriate. Not adding the `openas` verb to `Unknown` rgs registration now to mimic Windows because ROS `CDefaultContextMenu` lacks verb de-duplication and the menu would end up with two Open With entries. This just uses `(cidl == 1)` to simulate Windows while Windows on NT6 uses `MultiSelectModel=Single`, a NT6 feature not implemented on ROS.
- The class order for folders was wrong and is still "wrong" in this PR but I chose to use the Windows menu display order until the exact mechanics required in `CDefaultContextMenu` can be understood.
- Extracts the extension from ANSI PIDLs.

----

### Test environment

```
@echo off
setlocal
set CR=HKLM\Software\Classes

reg add "%CR%\.TestAAExtOnly\shell\TestAAExtOnly\command" /ve /d "calc.exe" /f

REM The ROS code implies this is a thing but Windows does not agree
reg add "%CR%\.TestAAExtWeird" /ve /d "TestAAExtWeird" /f
reg add "%CR%\.TestAAExtWeird\TestAAExtWeird\shell\open\command" /ve /d "calc.exe" /f

reg add "%CR%\.TestAA" /ve /d "TestAA" /f
reg add "%CR%\.TestAA" /v "PerceivedType" /d "image" /f
reg add "%CR%\.TestAA\shell\open\command" /ve /d "cmd.exe /k echo Ext.Open" /f
reg add "%CR%\.TestAA\shell\TestAA_Ext\command" /ve /d "calc.exe" /f
reg add "%CR%\TestAA\shell\TestAA_PId\command" /ve /d "calc.exe" /f
reg add "%CR%\*\shell\TestAA_Star\command" /ve /d "calc.exe" /f
reg add "%CR%\AllFilesystemObjects\shell\TestAA_AFO\command" /ve /d "calc.exe" /f
reg add "%CR%\SystemFileAssociations\.TestAA\shell\TestAA_SFAExt\command" /ve /d "calc.exe" /f
reg add "%CR%\SystemFileAssociations\image\shell\TestAA_SFAPT\command" /ve /d "calc.exe" /f

echo.> "%temp%\Test.TestAAExtOnly"
echo.> "%temp%\Test.TestAAExtWeird"
echo.> "%temp%\Test.TestAA"
echo.> "%temp%\Test.TestDoesNotExist"
```

### Unknown class

The class order on XP on a type without a ProgId showing the `Unknown` class being added.

![No PID array](https://github.com/reactos/reactos/assets/138629473/12825a72-a57c-4bc4-85a2-ce038ccf8f4c)

### Canonical Folder order

![Folder array](https://github.com/reactos/reactos/assets/138629473/34ba2795-b906-4136-8196-6a0fee9e0dc0)

