### PR TITLE
[SDK/arm] seh_prolog.s: Tweak ksarm.h inclusion

### DIFF
--- a/sdk/lib/pseh/arm/seh_prolog.s
+++ b/sdk/lib/pseh/arm/seh_prolog.s
@@ -8,7 +8,7 @@
 
 /* INCLUDES ******************************************************************/
 
-#include "ksarm.h"
+#include <ksarm.h>
 
     TEXTAREA
 


### PR DESCRIPTION
## Purpose

Be "explicit" that there is no local .h file. Same as everywhere else.

Addendum to d673279 (r64038).

## Proposed changes

- Tweak ksarm.h inclusion