### PR TITLE
[HALX86:GENERIC] Define and use InterlockedBitTestAndSetPointer()

### DIFF
--- a/hal/halx86/generic/halinit.c
+++ b/hal/halx86/generic/halinit.c
@@ -12,6 +12,14 @@
 #define NDEBUG
 #include <debug.h>
 
+#ifdef _WIN64
+#define InterlockedBitTestAndSetPointer(ptr, val) \
+    InterlockedBitTestAndSet64((PLONGLONG)(ptr), (LONGLONG)(val))
+#else
+#define InterlockedBitTestAndSetPointer(ptr, val) \
+    InterlockedBitTestAndSet((PLONG)(ptr), (LONG)(val))
+#endif
+
 /* GLOBALS *******************************************************************/
 
 BOOLEAN HalpPciLockSettings;
@@ -54,9 +62,8 @@ HalInitializeProcessor(
     KeGetPcr()->StallScaleFactor = INITIAL_STALL_COUNT;
 
     /* Update the interrupt affinity and processor mask */
-    InterlockedBitTestAndSet((PLONG)&HalpActiveProcessors, ProcessorNumber);
-    InterlockedBitTestAndSet((PLONG)&HalpDefaultInterruptAffinity,
-                             ProcessorNumber);
+    InterlockedBitTestAndSetPointer(&HalpActiveProcessors, ProcessorNumber);
+    InterlockedBitTestAndSetPointer(&HalpDefaultInterruptAffinity, ProcessorNumber);
 
     /* Register routines for KDCOM */
     HalpRegisterKdSupportFunctions();


### PR DESCRIPTION
for KAFFINITY variables.

## Purpose

`KAFFINITY` is a `ULONG_PTR`.

Follow-up to #6046.

## Proposed changes

- Define and use InterlockedBitTestAndSetPointer()