### PR TITLE
[BOOTDATA] Fix URL protocol registration

### DIFF
--- a/boot/bootdata/hivesft.inf
+++ b/boot/bootdata/hivesft.inf
@@ -103,12 +103,12 @@ HKLM,"SOFTWARE\Classes\Applications\mplay32.exe\SupportedTypes",".avi",0x0000000
 
 HKLM,"SOFTWARE\Classes\ftp","",0x00000000,"URL:File Transfer Protocol"
 HKLM,"SOFTWARE\Classes\ftp\Source Filter","",0x00000000,"{E436EBB6-524F-11CE-9F53-0020AF0BA770}"
-HKLM,"SOFTWARE\Classes\ftp\URL Protocol","",0x00000000,""
+HKLM,"SOFTWARE\Classes\ftp","URL Protocol",,""
 HKLM,"SOFTWARE\Classes\ftp\shell\open\command","",0x00000000,"""%programfiles%\Internet Explorer\iexplore.exe"" ""%1"""
 
 HKLM,"SOFTWARE\Classes\gopher","",0x00000000,"URL:Gopher Protocol"
 HKLM,"SOFTWARE\Classes\gopher\Source Filter","",0x00000000,"{E436EBB6-524F-11CE-9F53-0020AF0BA770}"
-HKLM,"SOFTWARE\Classes\gopher\URL Protocol","",0x00000000,""
+HKLM,"SOFTWARE\Classes\gopher","URL Protocol",,""
 ;see http
 ;HKLM,"SOFTWARE\Classes\gopher\shell\open\command","",0x00000000,"""%programfiles%\Internet Explorer\iexplore.exe"" -nohome"
 HKLM,"SOFTWARE\Classes\gopher\shell\open\command","",0x00000000,"""%programfiles%\Internet Explorer\iexplore.exe"" ""%1"""
@@ -116,7 +116,7 @@ HKLM,"SOFTWARE\Classes\gopher\shell\open\command","",0x00000000,"""%programfiles
 HKLM,"SOFTWARE\Classes\http","",0x00000000,"URL:HyperText Transfer Protocol"
 HKLM,"SOFTWARE\Classes\http\DefaultIcon","",0x00000000,"%SystemRoot%\system32\url.dll,0"
 HKLM,"SOFTWARE\Classes\http\Source Filter","",0x00000000,"{E436EBB6-524F-11CE-9F53-0020AF0BA770}"
-HKLM,"SOFTWARE\Classes\http\URL Protocol","",0x00000000,""
+HKLM,"SOFTWARE\Classes\http","URL Protocol",,""
 HKLM,"SOFTWARE\Classes\http\shell\open\command","",0x00000000,"""%programfiles%\Internet Explorer\iexplore.exe"" ""%1"""
 ;TODO : iexplore should use DDE
 ;HKLM,"SOFTWARE\Classes\http\shell\open\ddeexec","",0x00000000,"""%1"",,-1,0,,,,"
@@ -127,7 +127,7 @@ HKLM,"SOFTWARE\Classes\http\shell\open\command","",0x00000000,"""%programfiles%\
 HKLM,"SOFTWARE\Classes\https","",0x00000000,"URL:HyperText Transfer Protocol with Privacy"
 HKLM,"SOFTWARE\Classes\https\DefaultIcon","",0x00000000,"%SystemRoot%\system32\url.dll,0"
 HKLM,"SOFTWARE\Classes\https\Source Filter","",0x00000000,"{E436EBB6-524F-11CE-9F53-0020AF0BA770}"
-HKLM,"SOFTWARE\Classes\https\URL Protocol","",0x00000000,""
+HKLM,"SOFTWARE\Classes\https","URL Protocol",,""
 ;see http
 ;HKLM,"SOFTWARE\Classes\https\shell\open\command","",0x00000000,"""%programfiles%\Internet Explorer\iexplore.exe"" -nohome"
 HKLM,"SOFTWARE\Classes\https\shell\open\command","",0x00000000,"""%programfiles%\Internet Explorer\iexplore.exe"" ""%1"""


### PR DESCRIPTION
URL protocol registration is a value, not a key!

IEFrame later comes along and adds the value covering up the issue for everyone except poor gopher.