### PR TITLE
[REGEDIT] Limit registry type to 8 hex digits when importing

### DIFF
--- a/base/applications/regedit/regproc.c
+++ b/base/applications/regedit/regproc.c
@@ -337,10 +337,13 @@ static BOOL parse_data_type(struct parser *parser, WCHAR **line)
             if (!**line || towlower((*line)[1]) == 'x')
                 return FALSE;
 
-            /* "hex(xx):" is special */
+            /* "hex(xx):" is special. Up to 8 hex digits ("hex(000000002)" is invalid). */
             val = wcstoul(*line, &end, 16);
-            if (*end != ')' || *(end + 1) != ':' || (val == ~0u && errno == ERANGE))
+            if (*end != ')' || *(end + 1) != ':' || end - *line > 8 ||
+                (val == ~0u && errno == ERANGE))
+            {
                 return FALSE;
+            }
 
             parser->data_type = val;
             *line = end + 2;


### PR DESCRIPTION
Matches Windows and lets the Wine13i test in regedit_winetest pass.
