### PR TITLE
[USER32] Support loading icons from data file module

### DIFF
--- a/modules/rostests/apitests/user32/LoadImage.c
+++ b/modules/rostests/apitests/user32/LoadImage.c
@@ -1,9 +1,8 @@
 
 #include "precomp.h"
 
-static void test_LoadImage_DataFile()
+static void test_LoadImage_DataFile(void)
 {
-    SIZE_T i;
     static const struct
     {
         int result;
@@ -21,6 +20,8 @@ static void test_LoadImage_DataFile()
         { 1, L"regedit.exe", 100,      0,         0, 0 },
         { 1, L"regedit.exe", 100,      LR_SHARED, 1, 1 }
     };
+
+    SIZE_T i;
     for (i = 0; i < ARRAY_SIZE(tests); ++i)
     {
         HANDLE handle1, handle2;

--- a/modules/rostests/apitests/user32/LoadImage.c
+++ b/modules/rostests/apitests/user32/LoadImage.c
@@ -31,15 +31,15 @@ static void test_LoadImage_DataFile()
             continue;
         }
 
-        handle1 = LoadImageW(hMod, (LPWSTR)(tests[i].res_id), IMAGE_ICON, 0, 0, tests[i].lr);
+        handle1 = LoadImage(hMod, MAKEINTRESOURCE(tests[i].res_id), IMAGE_ICON, 0, 0, tests[i].lr);
         ok(!!handle1 == !!tests[i].result, "Failed to load %ls,-%d from %p\n", tests[i].file, tests[i].res_id, hMod);
 
-        handle2 = LoadImageW(hMod, (LPWSTR)(tests[i].res_id), IMAGE_ICON, 0, 0, tests[i].lr);
+        handle2 = LoadImage(hMod, MAKEINTRESOURCE(tests[i].res_id), IMAGE_ICON, 0, 0, tests[i].lr);
         ok(!!(handle1 == handle2) == !!tests[i].same_handle, "Shared handles don't match\n");
 
         FreeLibrary(hMod);
 
-        handle1 = LoadImageW(hMod, (LPWSTR)(tests[i].res_id), IMAGE_ICON, 0, 0, tests[i].lr);
+        handle1 = LoadImage(hMod, MAKEINTRESOURCE(tests[i].res_id), IMAGE_ICON, 0, 0, tests[i].lr);
         ok(!!handle1 == !!tests[i].after_unload, "LR_%x handle should %sload after FreeLibrary\n", tests[i].lr, tests[i].after_unload ? "" : "not ");
     }
 }

--- a/modules/rostests/apitests/user32/LoadImage.c
+++ b/modules/rostests/apitests/user32/LoadImage.c
@@ -1,6 +1,49 @@
 
 #include "precomp.h"
 
+static void test_LoadImage_DataFile()
+{
+    SIZE_T i;
+    static const struct
+    {
+        int result;
+        LPCWSTR file;
+        int res_id;
+        UINT lr;
+        BOOL same_handle;
+        BOOL after_unload; /* LR_SHARED stays valid */
+    }
+    tests[] =
+    {
+        { 1, L"shell32.dll", 2,        0,         0, 0 },
+        { 1, L"shell32.dll", 2,        LR_SHARED, 1, 1 },
+        { 0, L"shell32.dll", 0xfff0,   0,         1, 0 }, /* Icon should not exist */
+        { 1, L"regedit.exe", 100,      0,         0, 0 },
+        { 1, L"regedit.exe", 100,      LR_SHARED, 1, 1 }
+    };
+    for (i = 0; i < ARRAY_SIZE(tests); ++i)
+    {
+        HANDLE handle1, handle2;
+        HMODULE hMod = LoadLibraryExW(tests[i].file, NULL, LOAD_LIBRARY_AS_DATAFILE);
+        if (!((SIZE_T)hMod & 3))
+        {
+            skip("Could not load library as datafile %ls\n", tests[i].file);
+            continue;
+        }
+
+        handle1 = LoadImageW(hMod, (LPWSTR)(tests[i].res_id), IMAGE_ICON, 0, 0, tests[i].lr);
+        ok(!!handle1 == !!tests[i].result, "Failed to load %ls,-%d from %p\n", tests[i].file, tests[i].res_id, hMod);
+
+        handle2 = LoadImageW(hMod, (LPWSTR)(tests[i].res_id), IMAGE_ICON, 0, 0, tests[i].lr);
+        ok(!!(handle1 == handle2) == !!tests[i].same_handle, "Shared handles don't match\n");
+
+        FreeLibrary(hMod);
+
+        handle1 = LoadImageW(hMod, (LPWSTR)(tests[i].res_id), IMAGE_ICON, 0, 0, tests[i].lr);
+        ok(!!handle1 == !!tests[i].after_unload, "LR_%x handle should %sload after FreeLibrary\n", tests[i].lr, tests[i].after_unload ? "" : "not ");
+    }
+}
+
 START_TEST(LoadImage)
 {
     char path[MAX_PATH];
@@ -76,6 +119,9 @@ START_TEST(LoadImage)
         ok(ii.hbmMask != NULL, "\n");
         DeleteObject(ii.hbmMask);
         if(ii.hbmColor) DeleteObject(ii.hbmColor);
+
+        /* LOAD_LIBRARY_AS_DATAFILE */
+        test_LoadImage_DataFile();
 
         return;
     }

--- a/win32ss/user/user32/windows/cursoricon.c
+++ b/win32ss/user/user32/windows/cursoricon.c
@@ -1456,8 +1456,10 @@ CURSORICON_LoadImageW(
 
     if(LDR_IS_RESOURCE(hinst))
     {
-        /* We don't have a real module, can't call GetModuleFileName */
-        LPCWSTR fakeNameFmt = sizeof(void*) > 4 ? L"*DF?%016IX" : L"*DF?%08IX";
+        /* We don't have a real module for GetModuleFileName, construct a fake name instead.
+        ** GetIconInfoEx reveals the name used by Windows.
+        */
+        LPCWSTR fakeNameFmt = sizeof(void*) > 4 ? L"\001%016IX" : L"\001%08IX";
         ustrModule.MaximumLength = 42 * sizeof(WCHAR);
         ustrModule.Buffer = HeapAlloc(GetProcessHeap(), 0, ustrModule.MaximumLength);
         if (!ustrModule.Buffer)

--- a/win32ss/user/user32/windows/cursoricon.c
+++ b/win32ss/user/user32/windows/cursoricon.c
@@ -1457,8 +1457,7 @@ CURSORICON_LoadImageW(
     if(LDR_IS_RESOURCE(hinst))
     {
         /* We don't have a real module for GetModuleFileName, construct a fake name instead.
-        ** GetIconInfoEx reveals the name used by Windows.
-        */
+         * GetIconInfoEx reveals the name used by Windows. */
         LPCWSTR fakeNameFmt = sizeof(void*) > 4 ? L"\x01%016IX" : L"\x01%08IX";
         ustrModule.MaximumLength = 18 * sizeof(WCHAR);
         ustrModule.Buffer = HeapAlloc(GetProcessHeap(), 0, ustrModule.MaximumLength);

--- a/win32ss/user/user32/windows/cursoricon.c
+++ b/win32ss/user/user32/windows/cursoricon.c
@@ -1459,8 +1459,8 @@ CURSORICON_LoadImageW(
         /* We don't have a real module for GetModuleFileName, construct a fake name instead.
         ** GetIconInfoEx reveals the name used by Windows.
         */
-        LPCWSTR fakeNameFmt = sizeof(void*) > 4 ? L"\001%016IX" : L"\001%08IX";
-        ustrModule.MaximumLength = 42 * sizeof(WCHAR);
+        LPCWSTR fakeNameFmt = sizeof(void*) > 4 ? L"\x01%016IX" : L"\x01%08IX";
+        ustrModule.MaximumLength = 18 * sizeof(WCHAR);
         ustrModule.Buffer = HeapAlloc(GetProcessHeap(), 0, ustrModule.MaximumLength);
         if (!ustrModule.Buffer)
         {

--- a/win32ss/user/user32/windows/cursoricon.c
+++ b/win32ss/user/user32/windows/cursoricon.c
@@ -1454,7 +1454,20 @@ CURSORICON_LoadImageW(
             RtlInitUnicodeString(&ustrRsrc, lpszName);
     }
 
-    if(hinst)
+    if(LDR_IS_RESOURCE(hinst))
+    {
+        /* We don't have a real module, can't call GetModuleFileName */
+        LPCWSTR fakeNameFmt = sizeof(void*) > 4 ? L"*DF?%016IX" : L"*DF?%08IX";
+        ustrModule.MaximumLength = 42 * sizeof(WCHAR);
+        ustrModule.Buffer = HeapAlloc(GetProcessHeap(), 0, ustrModule.MaximumLength);
+        if (!ustrModule.Buffer)
+        {
+            SetLastError(ERROR_NOT_ENOUGH_MEMORY);
+            return NULL;
+        }
+        ustrModule.Length = wsprintfW(ustrModule.Buffer, fakeNameFmt, hinst) * sizeof(WCHAR);
+    }
+    else if(hinst)
     {
         DWORD size = MAX_PATH;
         /* Get the module name string */


### PR DESCRIPTION
`GetModuleFileName` fails on `LOAD_LIBRARY_AS_DATAFILE` causing `LoadImage` to fail on icons.

I'm inventing a fake filename for `LR_SHARED`. I don't know if this is a good idea but it does match Windows shared icon handling. The fake name includes `*` and `?` so it should never be confused with a real path. I don't know how this name interacts with WOW64 so in the unlikely case that a WOW64 processes calls the 64-bit `LoadImage`, the worlds will not collide because the fake name is pointer size padded.

The alternative would be to turn off `LR_SHARED` but this means the caller gets a new icon each time and that might cause leaks because the caller does not expect having to call `DestroyIcon` on a shared icon. We would also then be left with no path to pass to `NtUserSetCursorIconData`.

### Test

```C++
{
    HMODULE hMod;
    WCHAR buf[MAX_PATH];

    #define Try(type, resid, lr) for (;;) { \
        HANDLE handle = LoadImageW(hMod, MAKEINTRESOURCE(resid), type, 0, 0, lr); \
        printf("%s %s %p.%p %d 0x%x\n", handle ? "PASS" : "FAIL", #type, hMod, handle, GetLastError(), lr); \
        break; }

    GetWindowsDirectory(buf, MAX_PATH), PathAppend(buf, TEXT("regedit.exe"));
    hMod = LoadLibraryEx(buf, NULL, LOAD_LIBRARY_AS_DATAFILE);
    Try(IMAGE_ICON, 101, 0);
    Try(IMAGE_ICON, 101, 0);
    Try(IMAGE_ICON, 101, LR_SHARED);
    Try(IMAGE_ICON, 101, LR_SHARED);

    FreeLibrary(hMod);

    // Try loading a normal icon after the module has been unloaded, this should fail.
    Try(IMAGE_ICON, 101, 0);

    // Try loading a shared icon after the module has been unloaded, this should actually work.
    Try(IMAGE_ICON, 101, LR_SHARED);
}
```

### NT6:
```TEXT
PASS IMAGE_ICON 00280001.2D77178B 126 0x0
PASS IMAGE_ICON 00280001.AE1118C3 126 0x0
PASS IMAGE_ICON 00280001.08C301F7 126 0x8000
PASS IMAGE_ICON 00280001.08C301F7 126 0x8000
FAIL IMAGE_ICON 00280001.00000000 1812 0x0
PASS IMAGE_ICON 00280001.08C301F7 126 0x8000
```

### ROS PR:
```TEXT
PASS IMAGE_ICON 00520001.000A02E2 0 0x0
PASS IMAGE_ICON 00520001.000902A8 0 0x0
PASS IMAGE_ICON 00520001.000A02EE 0 0x8000
PASS IMAGE_ICON 00520001.000A02EE 0 0x8000
FAIL IMAGE_ICON 00520001.00000000 1812 0x0
PASS IMAGE_ICON 00520001.000A02EE 1812 0x8000
```
