### PR TITLE
[SHELL32][SDK][SHELL32_APITEST] Implement PathIsTemporaryA/W

### DIFF
--- a/dll/win32/shell32/wine/shellord.c
+++ b/dll/win32/shell32/wine/shellord.c
@@ -47,6 +47,7 @@ WINE_DECLARE_DEBUG_CHANNEL(pidl);
 
 #ifdef __REACTOS__
 #include <comctl32_undoc.h>
+#include <shlwapi_undoc.h>
 #else
 /* FIXME: !!! move CREATEMRULIST and flags to header file !!! */
 /*        !!! it is in both here and comctl32undoc.c      !!! */
@@ -1918,19 +1919,63 @@ BOOL WINAPI GUIDFromStringW(LPCWSTR str, LPGUID guid)
 /*************************************************************************
  *      PathIsTemporaryA    [SHELL32.713]
  */
+#ifdef __REACTOS__
+/** @see https://undoc.airesoft.co.uk/shell32.dll/PathIsTemporaryA.php */
+BOOL WINAPI PathIsTemporaryA(_In_ LPCSTR Str)
+#else
 BOOL WINAPI PathIsTemporaryA(LPSTR Str)
+#endif
 {
+#ifdef __REACTOS__
+    WCHAR szWide[MAX_PATH];
+
+    TRACE("(%s)\n", debugstr_a(Str));
+
+    SHAnsiToUnicode(Str, szWide, _countof(szWide));
+    return PathIsTemporaryW(szWide);
+#else
     FIXME("(%s)stub\n", debugstr_a(Str));
     return FALSE;
+#endif
 }
 
 /*************************************************************************
  *      PathIsTemporaryW    [SHELL32.714]
  */
+#ifdef __REACTOS__
+/** @see https://undoc.airesoft.co.uk/shell32.dll/PathIsTemporaryW.php */
+BOOL WINAPI PathIsTemporaryW(_In_ LPCWSTR Str)
+#else
 BOOL WINAPI PathIsTemporaryW(LPWSTR Str)
+#endif
 {
+#ifdef __REACTOS__
+    WCHAR szLongPath[MAX_PATH], szTempPath[MAX_PATH];
+    DWORD attrs;
+    LPCWSTR pszTarget = Str;
+
+    TRACE("(%s)\n", debugstr_w(Str));
+
+    attrs = GetFileAttributesW(Str);
+    if (attrs != INVALID_FILE_ATTRIBUTES && (attrs & FILE_ATTRIBUTE_TEMPORARY))
+        return TRUE;
+
+    if (!GetTempPathW(_countof(szTempPath), szTempPath) ||
+        !GetLongPathNameW(szTempPath, szTempPath, _countof(szTempPath)))
+    {
+        return FALSE;
+    }
+
+    if (GetLongPathNameW(Str, szLongPath, _countof(szLongPath)))
+        pszTarget = szLongPath;
+
+    return (PathIsEqualOrSubFolder(szTempPath, pszTarget) ||
+            PathIsEqualOrSubFolder(UlongToPtr(CSIDL_INTERNET_CACHE), pszTarget) ||
+            PathIsEqualOrSubFolder(UlongToPtr(CSIDL_CDBURN_AREA), pszTarget));
+#else
     FIXME("(%s)stub\n", debugstr_w(Str));
     return FALSE;
+#endif
 }
 
 typedef struct _PSXA

--- a/modules/rostests/apitests/shell32/CMakeLists.txt
+++ b/modules/rostests/apitests/shell32/CMakeLists.txt
@@ -20,6 +20,7 @@ list(APPEND SOURCE
     IShellFolderViewCB.cpp
     OpenAs_RunDLL.cpp
     PathIsEqualOrSubFolder.cpp
+    PathIsTemporary.cpp
     PathResolve.cpp
     SHAppBarMessage.cpp
     SHChangeNotify.cpp

--- a/modules/rostests/apitests/shell32/PathIsTemporary.cpp
+++ b/modules/rostests/apitests/shell32/PathIsTemporary.cpp
@@ -1,0 +1,57 @@
+/*
+ * PROJECT:     ReactOS API Tests
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Tests for PathIsTemporaryA/W
+ * COPYRIGHT:   Copyright 2023 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ */
+
+#include "shelltest.h"
+#include <undocshell.h>
+
+static void Test_PathIsTemporaryA(void)
+{
+    CHAR szPath[MAX_PATH];
+    ok_int(PathIsTemporaryA("C:\\"), FALSE);
+    ok_int(PathIsTemporaryA("C:\\TestTestTest"), FALSE);
+
+    GetWindowsDirectoryA(szPath, _countof(szPath));
+    ok_int(PathIsTemporaryA(szPath), FALSE);
+
+    GetTempPathA(_countof(szPath), szPath);
+    ok_int(PathIsTemporaryA(szPath), TRUE);
+
+    PathAppendA(szPath, "TestTestTest");
+    ok_int(PathIsTemporaryA(szPath), FALSE);
+
+    CreateDirectoryA(szPath, NULL);
+    ok_int(PathIsTemporaryA(szPath), TRUE);
+
+    RemoveDirectoryA(szPath);
+}
+
+static void Test_PathIsTemporaryW(void)
+{
+    WCHAR szPath[MAX_PATH];
+    ok_int(PathIsTemporaryW(L"C:\\"), FALSE);
+    ok_int(PathIsTemporaryW(L"C:\\TestTestTest"), FALSE);
+
+    GetWindowsDirectoryW(szPath, _countof(szPath));
+    ok_int(PathIsTemporaryW(szPath), FALSE);
+
+    GetTempPathW(_countof(szPath), szPath);
+    ok_int(PathIsTemporaryW(szPath), TRUE);
+
+    PathAppendW(szPath, L"TestTestTest");
+    ok_int(PathIsTemporaryW(szPath), FALSE);
+
+    CreateDirectoryW(szPath, NULL);
+    ok_int(PathIsTemporaryW(szPath), TRUE);
+
+    RemoveDirectoryW(szPath);
+}
+
+START_TEST(PathIsTemporary)
+{
+    Test_PathIsTemporaryA();
+    Test_PathIsTemporaryW();
+}

--- a/modules/rostests/apitests/shell32/testlist.c
+++ b/modules/rostests/apitests/shell32/testlist.c
@@ -22,6 +22,7 @@ extern void func_IShellFolderViewCB(void);
 extern void func_menu(void);
 extern void func_OpenAs_RunDLL(void);
 extern void func_PathIsEqualOrSubFolder(void);
+extern void func_PathIsTemporary(void);
 extern void func_PathResolve(void);
 extern void func_SHAppBarMessage(void);
 extern void func_SHChangeNotify(void);
@@ -59,6 +60,7 @@ const struct test winetest_testlist[] =
     { "menu", func_menu },
     { "OpenAs_RunDLL", func_OpenAs_RunDLL },
     { "PathIsEqualOrSubFolder", func_PathIsEqualOrSubFolder },
+    { "PathIsTemporary", func_PathIsTemporary },
     { "PathResolve", func_PathResolve },
     { "SHAppBarMessage", func_SHAppBarMessage },
     { "SHChangeNotify", func_SHChangeNotify },

--- a/sdk/include/reactos/undocshell.h
+++ b/sdk/include/reactos/undocshell.h
@@ -500,6 +500,9 @@ BOOL WINAPI PathFindOnPathAW(LPVOID sFile, LPCVOID *sOtherDirs);
 
 BOOL WINAPI PathIsEqualOrSubFolder(_In_ LPCWSTR pszFile1OrCSIDL, _In_ LPCWSTR pszFile2);
 
+BOOL WINAPI PathIsTemporaryA(_In_ LPCSTR Str);
+BOOL WINAPI PathIsTemporaryW(_In_ LPCWSTR Str);
+
 /****************************************************************************
  * Shell File Operations error codes - SHFileOperationA/W
  */


### PR DESCRIPTION
## Purpose

Implementing missing features...
JIRA issue: [CORE-19278](https://jira.reactos.org/browse/CORE-19278)

## Proposed changes

- Implement `PathIsTemporaryA` and `PathIsTemporaryW` functions.
- Add them to `<undocshell.h>`.
- Add `PathIsTemporary` testcase.

## TODO

- [ ] Do small tests.