### PR TITLE
[IMM32][KERNEL32][SDK] Half-implement BaseCheckAppcompatCache

### DIFF
--- a/dll/win32/imm32/ctf.c
+++ b/dll/win32/imm32/ctf.c
@@ -8,6 +8,7 @@
 #include "precomp.h"
 #include <msctf.h> /* for ITfLangBarMgr */
 #include <objidl.h> /* for IInitializeSpy */
+#include <compat_undoc.h> /* for BaseCheckAppcompatCache */
 
 WINE_DEFAULT_DEBUG_CHANNEL(imm);
 
@@ -240,13 +241,6 @@ HINSTANCE g_hCtfIme = NULL;
 
 /* The type of ApphelpCheckIME function in apphelp.dll */
 typedef BOOL (WINAPI *FN_ApphelpCheckIME)(_In_z_ LPCWSTR AppName);
-
-/* FIXME: This is kernel32 function. We have to declare this in some header. */
-BOOL WINAPI
-BaseCheckAppcompatCache(_In_z_ LPCWSTR ApplicationName,
-                        _In_ HANDLE FileHandle,
-                        _In_opt_z_ LPCWSTR Environment,
-                        _Out_ PULONG pdwReason);
 
 /***********************************************************************
  * This function checks whether the app's IME is disabled by application

--- a/dll/win32/kernel32/client/appcache.c
+++ b/dll/win32/kernel32/client/appcache.c
@@ -140,9 +140,9 @@ IsShimInfrastructureDisabled(VOID)
  */
 BOOL
 BasepShimCacheCheckBypass(
-    _In_ LPCWSTR ApplicationName,
+    _In_ PCWSTR ApplicationName,
     _In_ HANDLE FileHandle,
-    _In_opt_ LPCWSTR Environment,
+    _In_opt_ PCWSTR Environment,
     _In_ BOOL bUnknown,
     _Out_opt_ PULONG pdwReason)
 {
@@ -156,7 +156,7 @@ BasepShimCacheCheckBypass(
  */
 BOOL
 BasepShimCacheSearch(
-    _In_ LPCWSTR ApplicationName,
+    _In_ PCWSTR ApplicationName,
     _In_ HANDLE FileHandle)
 {
     APPHELP_CACHE_SERVICE_LOOKUP Lookup;
@@ -170,7 +170,7 @@ BasepShimCacheSearch(
  */
 BOOL
 BasepCheckCacheExcludeList(
-    _In_ LPCWSTR ApplicationName)
+    _In_ PCWSTR ApplicationName)
 {
     return FALSE;
 }
@@ -180,7 +180,7 @@ BasepCheckCacheExcludeList(
  */
 BOOL
 BasepCheckCacheExcludeCustom(
-    _In_ LPCWSTR ApplicationName)
+    _In_ PCWSTR ApplicationName)
 {
     return FALSE;
 }
@@ -190,7 +190,7 @@ BasepCheckCacheExcludeCustom(
  */
 VOID
 BasepShimCacheRemoveEntry(
-    _In_ LPCWSTR ApplicationName)
+    _In_ PCWSTR ApplicationName)
 {
     APPHELP_CACHE_SERVICE_LOOKUP Lookup;
     RtlInitUnicodeString(&Lookup.ImageName, ApplicationName);
@@ -203,7 +203,7 @@ BasepShimCacheRemoveEntry(
  */
 BOOL
 BasepShimCacheLookup(
-    _In_ LPCWSTR ApplicationName,
+    _In_ PCWSTR ApplicationName,
     _In_ HANDLE FileHandle)
 {
     DPRINT("fixme:(%S, %p)\n", ApplicationName, FileHandle);
@@ -227,9 +227,9 @@ BasepShimCacheLookup(
 BOOL
 WINAPI
 BaseCheckAppcompatCache(
-    _In_ LPCWSTR ApplicationName,
+    _In_ PCWSTR ApplicationName,
     _In_ HANDLE FileHandle,
-    _In_opt_ LPCWSTR Environment,
+    _In_opt_ PCWSTR Environment,
     _Out_opt_ PULONG pdwReason)
 {
     BOOL ret = FALSE;

--- a/dll/win32/kernel32/client/appcache.c
+++ b/dll/win32/kernel32/client/appcache.c
@@ -139,18 +139,62 @@ IsShimInfrastructureDisabled(VOID)
  * @unimplemented
  */
 BOOL
-WINAPI
-BaseCheckAppcompatCache(IN PWCHAR ApplicationName,
-                        IN HANDLE FileHandle,
-                        IN PWCHAR Environment,
-                        OUT PULONG Reason)
+BasepShimCacheCheckBypass(
+    _In_ LPCWSTR ApplicationName,
+    _In_ HANDLE FileHandle,
+    _In_opt_ LPCWSTR Environment,
+    _In_ BOOL bUnknown,
+    _Out_opt_ PULONG pdwReason)
 {
-    DPRINT("BaseCheckAppcompatCache is UNIMPLEMENTED\n");
-
-    if (Reason) *Reason = 0;
-
-    // We don't know this app.
+    DPRINT("fixme:(%S, %p, %S, %d, %p)\n", ApplicationName, FileHandle, Environment, bUnknown,
+           pdwReason);
     return FALSE;
+}
+
+/*
+ * @unimplemented
+ */
+BOOL
+BasepShimCacheLookup(
+    _In_ LPCWSTR ApplicationName,
+    _In_ HANDLE FileHandle)
+{
+    DPRINT("fixme:(%S, %p)\n", ApplicationName, FileHandle);
+    return FALSE;
+}
+
+/*
+ * @implemented
+ */
+BOOL
+WINAPI
+BaseCheckAppcompatCache(
+    _In_ LPCWSTR ApplicationName,
+    _In_ HANDLE FileHandle,
+    _In_opt_ LPCWSTR Environment,
+    _Out_opt_ PULONG pdwReason)
+{
+    BOOL ret = FALSE;
+    ULONG dwReason;
+
+    DPRINT("(%S, %p, %S, %p)\n", ApplicationName, FileHandle, Environment, pdwReason);
+
+    dwReason = 0;
+    if (BasepShimCacheCheckBypass(ApplicationName, FileHandle, Environment, TRUE, &dwReason))
+    {
+        dwReason |= 2;
+    }
+    else
+    {
+        ret = BasepShimCacheLookup(ApplicationName, FileHandle);
+        if (!ret)
+            dwReason |= 1;
+    }
+
+    if (pdwReason)
+        *pdwReason = dwReason;
+
+    return ret;
 }
 
 static

--- a/dll/win32/kernel32/kernel32.spec
+++ b/dll/win32/kernel32/kernel32.spec
@@ -24,7 +24,7 @@
 @ stdcall BackupRead(ptr ptr long ptr long long ptr)
 @ stdcall BackupSeek(ptr long long ptr ptr ptr)
 @ stdcall BackupWrite(ptr ptr long ptr long long ptr)
-@ stdcall BaseCheckAppcompatCache(long long long ptr)
+@ stdcall BaseCheckAppcompatCache(wstr ptr wstr ptr)
 @ stdcall BaseCheckRunApp(long ptr long long long long long long long long)
 @ stdcall BaseCleanupAppcompatCacheSupport(ptr)
 @ stdcall BaseDumpAppcompatCache()

--- a/sdk/include/reactos/compat_undoc.h
+++ b/sdk/include/reactos/compat_undoc.h
@@ -46,4 +46,12 @@ UINT RosGetProcessEffectiveVersion(VOID)
         return (peb->OSMajorVersion << 8) | (peb->OSMinorVersion);
 }
 
+BOOL
+WINAPI
+BaseCheckAppcompatCache(
+    _In_ LPCWSTR ApplicationName,
+    _In_ HANDLE FileHandle,
+    _In_opt_ LPCWSTR Environment,
+    _Out_opt_ PULONG pdwReason);
+
 #endif // COMPAT_UNDOC_H

--- a/sdk/include/reactos/compat_undoc.h
+++ b/sdk/include/reactos/compat_undoc.h
@@ -49,9 +49,9 @@ UINT RosGetProcessEffectiveVersion(VOID)
 BOOL
 WINAPI
 BaseCheckAppcompatCache(
-    _In_ LPCWSTR ApplicationName,
+    _In_ PCWSTR ApplicationName,
     _In_ HANDLE FileHandle,
-    _In_opt_ LPCWSTR Environment,
+    _In_opt_ PCWSTR Environment,
     _Out_opt_ PULONG pdwReason);
 
 #endif // COMPAT_UNDOC_H


### PR DESCRIPTION
## Purpose

Implementing missing features...
JIRA issue: [CORE-19268](https://jira.reactos.org/browse/CORE-19268)

## Proposed changes

- Half-implement `kernel32!BaseCheckAppcompatCache` function.
- Add it to `<compat_undoc.h>`.
- Use `<compat_undoc.h>` in IMM32.
- Modify `kernel32.spec`.

## TODO

- [x] Do build.