### PR TITLE
[HALX86:ACPI] Fix HalpPicVectorRedirect[]

### DIFF
--- a/hal/halx86/acpi/halacpi.c
+++ b/hal/halx86/acpi/halacpi.c
@@ -37,7 +37,7 @@ LIST_ENTRY HalpAcpiTableMatchList;
 
 ULONG HalpInvalidAcpiTable;
 
-ULONG HalpPicVectorRedirect[] = {0, 1, 2, 3, 4, 5, 6, 7, 9, 10, 11, 12, 13, 14, 15};
+ULONG HalpPicVectorRedirect[16] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
 
 /* This determines the HAL type */
 BOOLEAN HalDisableFirmwareMapper = TRUE;


### PR DESCRIPTION
## Purpose

Fix `HalpPicVectorRedirect[]`.

Addendum to cbc12bf (r46663).

## Proposed changes

- Add missing `8`.
- Add an explicit size: self-document, stricter, allows to use `_countof()` from other files...