### PR TITLE
[CMAKE] writing_CmakeLists_for_ReactOS.txt: Fix typos

### DIFF
--- a/sdk/cmake/writing_CmakeLists_for_ReactOS.txt
+++ b/sdk/cmake/writing_CmakeLists_for_ReactOS.txt
@@ -8,14 +8,14 @@ Optional arguments are marked with [brackets], input is marked with <comparison 
 ---------------------------------------------------------------------------------------------------------------------------------------------
 set_module_type(<target> <type> [UNICODE] [BASEADDRESS <baseaddress>] [ENTRYPOINT <entrypoint> <stacksize>])
 
-This set the type of the module, and take cares of setting common linker options or definitions to the specified target, module file extension, etc. Please always use this when adding a module to reactos build.
+This sets the type of the module, and takes care of setting common linker options or definitions to the specified target, module file extension, etc. Please always use this when adding a module to ReactOS build.
 
 ARGUMENTS:
 <target>: name of the target. The module must have been added with add_executable or add_library before calling this function.
-<type>: one of win32gui, win32cui, win32dll, win32ocx, cpl, nativecui, nativedll, kernelmodedriver
-UNICODE: provide this if the module was written for unicode API
-<baseaddress>: provide this if you want your module to have a different base address than the defualt one (according to <type>). For win32dll modules, please use baseaddress.cmake instead.
-<entrypoint>: name of the function which will be the entr point of the module. If it's not provided, it's guessed from the module type.
+<type>: one of win32gui, win32cui, win32dll, win32ocx, cpl, nativecui, nativedll, kernelmodedriver.
+UNICODE: provide this if the module was written for unicode API.
+<baseaddress>: provide this if you want your module to have a different base address than the default one (according to <type>). For win32dll modules, please use baseaddress.cmake instead.
+<entrypoint>: name of the function which will be the entry point of the module. If it's not provided, it's guessed from the module type.
 <stacksize>: Size of stack required for the parameters of <entrypoint>.
 
 TYPICAL USE:


### PR DESCRIPTION
## Purpose

Improve documentation.

## Proposed changes

- Fix typos