### PR TITLE
[XDK][NDK] Improve and sync KUSER_SHARED_DATA

### DIFF
--- a/sdk/include/ndk/ketypes.h
+++ b/sdk/include/ndk/ketypes.h
@@ -518,6 +518,47 @@ typedef struct _KSYSTEM_TIME
     LONG High2Time;
 } KSYSTEM_TIME, *PKSYSTEM_TIME;
 
+#define MAXIMUM_XSTATE_FEATURES             64
+
+typedef struct _XSTATE_FEATURE
+{
+    ULONG Offset;
+    ULONG Size;
+} XSTATE_FEATURE, *PXSTATE_FEATURE;
+
+typedef struct _XSTATE_CONFIGURATION
+{
+    ULONG64 EnabledFeatures;
+#if (NTDDI_VERSION >= NTDDI_WINBLUE)
+    ULONG64 EnabledVolatileFeatures;
+#endif
+    ULONG Size;
+    union
+    {
+        ULONG ControlFlags;
+        struct
+        {
+            ULONG OptimizedSave:1;
+            ULONG CompactionEnabled:1; // WIN10+
+        };
+    };
+    XSTATE_FEATURE Features[MAXIMUM_XSTATE_FEATURES];
+#if (NTDDI_VERSION >= NTDDI_WIN10)
+    ULONG64 EnabledSupervisorFeatures;
+    ULONG64 AlignedFeatures;
+    ULONG AllFeatureSize;
+    ULONG AllFeatures[MAXIMUM_XSTATE_FEATURES];
+#endif
+#if (NTDDI_VERSION >= NTDDI_WIN10_RS5)
+    ULONG64 EnabledUserVisibleSupervisorFeatures;
+#endif
+#if (NTDDI_VERSION >= NTDDI_WIN11)
+    ULONG64 ExtendedFeatureDisableFeatures;
+    ULONG AllNonLargeFeatureSize;
+    ULONG Spare;
+#endif
+} XSTATE_CONFIGURATION, *PXSTATE_CONFIGURATION;
+
 //
 // Shared Kernel User Data
 //

--- a/sdk/include/ndk/ketypes.h
+++ b/sdk/include/ndk/ketypes.h
@@ -561,76 +561,128 @@ typedef struct _XSTATE_CONFIGURATION
 
 //
 // Shared Kernel User Data
+// Keep in sync with sdk/include/xdk/ketypes.h
 //
 typedef struct _KUSER_SHARED_DATA
 {
-    ULONG TickCountLowDeprecated;
-    ULONG TickCountMultiplier;
-    volatile KSYSTEM_TIME InterruptTime;
-    volatile KSYSTEM_TIME SystemTime;
-    volatile KSYSTEM_TIME TimeZoneBias;
-    USHORT ImageNumberLow;
-    USHORT ImageNumberHigh;
-    WCHAR NtSystemRoot[260];
-    ULONG MaxStackTraceDepth;
-    ULONG CryptoExponent;
-    ULONG TimeZoneId;
-    ULONG LargePageMinimum;
-    ULONG Reserved2[7];
-    NT_PRODUCT_TYPE NtProductType;
-    BOOLEAN ProductTypeIsValid;
-    ULONG NtMajorVersion;
-    ULONG NtMinorVersion;
-    BOOLEAN ProcessorFeatures[PROCESSOR_FEATURE_MAX];
-    ULONG Reserved1;
-    ULONG Reserved3;
-    volatile ULONG TimeSlip;
-    ALTERNATIVE_ARCHITECTURE_TYPE AlternativeArchitecture;
-    LARGE_INTEGER SystemExpirationDate;
-    ULONG SuiteMask;
-    BOOLEAN KdDebuggerEnabled;
+    ULONG TickCountLowDeprecated;                           // 0x0
+    ULONG TickCountMultiplier;                              // 0x4
+    volatile KSYSTEM_TIME InterruptTime;                    // 0x8
+    volatile KSYSTEM_TIME SystemTime;                       // 0x14
+    volatile KSYSTEM_TIME TimeZoneBias;                     // 0x20
+    USHORT ImageNumberLow;                                  // 0x2c
+    USHORT ImageNumberHigh;                                 // 0x2e
+    WCHAR NtSystemRoot[260];                                // 0x30
+    ULONG MaxStackTraceDepth;                               // 0x238
+    ULONG CryptoExponent;                                   // 0x23c
+    ULONG TimeZoneId;                                       // 0x240
+    ULONG LargePageMinimum;                                 // 0x244
+    ULONG Reserved2[7];                                     // 0x248
+    NT_PRODUCT_TYPE NtProductType;                          // 0x264
+    BOOLEAN ProductTypeIsValid;                             // 0x268
+    ULONG NtMajorVersion;                                   // 0x26c
+    ULONG NtMinorVersion;                                   // 0x270
+    BOOLEAN ProcessorFeatures[PROCESSOR_FEATURE_MAX];       // 0x274
+    ULONG Reserved1;                                        // 0x2b4
+    ULONG Reserved3;                                        // 0x2b8
+    volatile ULONG TimeSlip;                                // 0x2bc
+    ALTERNATIVE_ARCHITECTURE_TYPE AlternativeArchitecture;  // 0x2c0
+    ULONG AltArchitecturePad[1];                            // 0x2c4
+    LARGE_INTEGER SystemExpirationDate;                     // 0x2c8
+    ULONG SuiteMask;                                        // 0x2d0
+    BOOLEAN KdDebuggerEnabled;                              // 0x2d4
 #if (NTDDI_VERSION >= NTDDI_WINXPSP2)
-    UCHAR NXSupportPolicy;
+    UCHAR NXSupportPolicy;                                  // 0x2d5
 #endif
-    volatile ULONG ActiveConsoleId;
-    volatile ULONG DismountCount;
-    ULONG ComPlusPackage;
-    ULONG LastSystemRITEventTickCount;
-    ULONG NumberOfPhysicalPages;
-    BOOLEAN SafeBootMode;
-    ULONG TraceLogging;
-    ULONG Fill0;
-    ULONGLONG TestRetInstruction;
-    ULONG SystemCall;
-    ULONG SystemCallReturn;
-    ULONGLONG SystemCallPad[3];
-    union {
-        volatile KSYSTEM_TIME TickCount;
-        volatile ULONG64 TickCountQuad;
-    };
-    ULONG Cookie;
-#if (NTDDI_VERSION >= NTDDI_WS03)
-    LONGLONG ConsoleSessionForegroundProcessId;
-    ULONG Wow64SharedInformation[MAX_WOW64_SHARED_ENTRIES];
-#endif
-#if (NTDDI_VERSION >= NTDDI_LONGHORN)
-    USHORT UserModeGlobalLogger[8];
-    ULONG HeapTracingPid[2];
-    ULONG CritSecTracingPid[2];
+    volatile ULONG ActiveConsoleId;                         // 0x2d8
+    volatile ULONG DismountCount;                           // 0x2dc
+    ULONG ComPlusPackage;                                   // 0x2e0
+    ULONG LastSystemRITEventTickCount;                      // 0x2e4
+    ULONG NumberOfPhysicalPages;                            // 0x2e8
+    BOOLEAN SafeBootMode;                                   // 0x2ec
+#if (NTDDI_VERSION >= NTDDI_WIN7)
     union
     {
-        ULONG SharedDataFlags;
+        UCHAR TscQpcData;                                   // 0x2ed
         struct
         {
-            ULONG DbgErrorPortPresent:1;
-            ULONG DbgElevationEnabled:1;
-            ULONG DbgVirtEnabled:1;
-            ULONG DbgInstallerDetectEnabled:1;
-            ULONG SpareBits:28;
-        };
-    };
-    ULONG ImageFileExecutionOptions;
-    KAFFINITY ActiveProcessorAffinity;
+            UCHAR TscQpcEnabled:1;                          // 0x2ed
+            UCHAR TscQpcSpareFlag:1;                        // 0x2ed
+            UCHAR TscQpcShift:6;                            // 0x2ed
+        } DUMMYSTRUCTNAME;
+    } DUMMYUNIONNAME;
+    UCHAR TscQpcPad[2];                                     // 0x2ee
+#endif
+#if (NTDDI_VERSION >= NTDDI_VISTA)
+    union
+    {
+        ULONG SharedDataFlags;                              // 0x2f0
+        struct
+        {
+            ULONG DbgErrorPortPresent:1;                    // 0x2f0
+            ULONG DbgElevationEnabled:1;                    // 0x2f0
+            ULONG DbgVirtEnabled:1;                         // 0x2f0
+            ULONG DbgInstallerDetectEnabled:1;              // 0x2f0
+            ULONG DbgSystemDllRelocated:1;                  // 0x2f0
+            ULONG DbgDynProcessorEnabled:1;                 // 0x2f0
+            ULONG DbgSEHValidationEnabled:1;                // 0x2f0
+            ULONG SpareBits:25;                             // 0x2f0
+        } DUMMYSTRUCTNAME2;
+    } DUMMYUNIONNAME2;
+#else
+    ULONG TraceLogging;
+#endif
+    ULONG DataFlagsPad[1];                                  // 0x2f4
+    ULONGLONG TestRetInstruction;                           // 0x2f8
+    ULONG SystemCall;                                       // 0x300
+    ULONG SystemCallReturn;                                 // 0x304
+    ULONGLONG SystemCallPad[3];                             // 0x308
+    union
+    {
+        volatile KSYSTEM_TIME TickCount;                    // 0x320
+        volatile ULONG64 TickCountQuad;                     // 0x320
+        struct
+        {
+            ULONG ReservedTickCountOverlay[3];              // 0x320
+            ULONG TickCountPad[1];                          // 0x32c
+        } DUMMYSTRUCTNAME;
+    } DUMMYUNIONNAME3;
+    ULONG Cookie;                                           // 0x330
+#if (NTDDI_VERSION >= NTDDI_VISTA)
+    ULONG CookiePad[1];                                     // 0x334
+    LONGLONG ConsoleSessionForegroundProcessId;             // 0x338
+#endif
+#if (NTDDI_VERSION >= NTDDI_WS03)
+    ULONG Wow64SharedInformation[MAX_WOW64_SHARED_ENTRIES]; // 2K3: 0x334 / Vista+: 0x340
+#endif
+#if (NTDDI_VERSION >= NTDDI_VISTA)
+#if (NTDDI_VERSION >= NTDDI_WIN7)
+    USHORT UserModeGlobalLogger[16];                        // 0x380
+#else
+    USHORT UserModeGlobalLogger[8];                         // 0x380
+    ULONG HeapTracingPid[2];                                // 0x390
+    ULONG CritSecTracingPid[2];                             // 0x398
+#endif
+    ULONG ImageFileExecutionOptions;                        // 0x3a0
+#if (NTDDI_VERSION >= NTDDI_VISTASP1)
+    ULONG LangGenerationCount;                              // 0x3a4
+#else
+  /* 4 bytes padding */
+#endif
+    ULONGLONG Reserved5;                                    // 0x3a8
+    volatile ULONG64 InterruptTimeBias;                     // 0x3b0
+#endif // NTDDI_VERSION >= NTDDI_VISTA
+#if (NTDDI_VERSION >= NTDDI_WIN7)
+    volatile ULONG64 TscQpcBias;                            // 0x3b8
+    volatile ULONG ActiveProcessorCount;                    // 0x3c0
+    volatile USHORT ActiveGroupCount;                       // 0x3c4
+    USHORT Reserved4;                                       // 0x3c6
+    volatile ULONG AitSamplingValue;                        // 0x3c8
+    volatile ULONG AppCompatFlag;                           // 0x3cc
+    ULONGLONG SystemDllNativeRelocation;                    // 0x3d0
+    ULONG SystemDllWowRelocation;                           // 0x3d8
+    ULONG XStatePad[1];                                     // 0x3dc
+    XSTATE_CONFIGURATION XState;                            // 0x3e0
 #endif
 } KUSER_SHARED_DATA, *PKUSER_SHARED_DATA;
 

--- a/sdk/include/xdk/ketypes.h
+++ b/sdk/include/xdk/ketypes.h
@@ -1265,122 +1265,124 @@ typedef struct _XSTATE_CONFIGURATION
 
 typedef struct _KUSER_SHARED_DATA
 {
-    ULONG TickCountLowDeprecated;
-    ULONG TickCountMultiplier;
-    volatile KSYSTEM_TIME InterruptTime;
-    volatile KSYSTEM_TIME SystemTime;
-    volatile KSYSTEM_TIME TimeZoneBias;
-    USHORT ImageNumberLow;
-    USHORT ImageNumberHigh;
-    WCHAR NtSystemRoot[260];
-    ULONG MaxStackTraceDepth;
-    ULONG CryptoExponent;
-    ULONG TimeZoneId;
-    ULONG LargePageMinimum;
-    ULONG Reserved2[7];
-    NT_PRODUCT_TYPE NtProductType;
-    BOOLEAN ProductTypeIsValid;
-    ULONG NtMajorVersion;
-    ULONG NtMinorVersion;
-    BOOLEAN ProcessorFeatures[PROCESSOR_FEATURE_MAX];
-    ULONG Reserved1;
-    ULONG Reserved3;
-    volatile ULONG TimeSlip;
-    ALTERNATIVE_ARCHITECTURE_TYPE AlternativeArchitecture;
-    ULONG AltArchitecturePad[1];
-    LARGE_INTEGER SystemExpirationDate;
-    ULONG SuiteMask;
-    BOOLEAN KdDebuggerEnabled;
+    ULONG TickCountLowDeprecated;                           // 0x0
+    ULONG TickCountMultiplier;                              // 0x4
+    volatile KSYSTEM_TIME InterruptTime;                    // 0x8
+    volatile KSYSTEM_TIME SystemTime;                       // 0x14
+    volatile KSYSTEM_TIME TimeZoneBias;                     // 0x20
+    USHORT ImageNumberLow;                                  // 0x2c
+    USHORT ImageNumberHigh;                                 // 0x2e
+    WCHAR NtSystemRoot[260];                                // 0x30
+    ULONG MaxStackTraceDepth;                               // 0x238
+    ULONG CryptoExponent;                                   // 0x23c
+    ULONG TimeZoneId;                                       // 0x240
+    ULONG LargePageMinimum;                                 // 0x244
+    ULONG Reserved2[7];                                     // 0x248
+    NT_PRODUCT_TYPE NtProductType;                          // 0x264
+    BOOLEAN ProductTypeIsValid;                             // 0x268
+    ULONG NtMajorVersion;                                   // 0x26c
+    ULONG NtMinorVersion;                                   // 0x270
+    BOOLEAN ProcessorFeatures[PROCESSOR_FEATURE_MAX];       // 0x274
+    ULONG Reserved1;                                        // 0x2b4
+    ULONG Reserved3;                                        // 0x2b8
+    volatile ULONG TimeSlip;                                // 0x2bc
+    ALTERNATIVE_ARCHITECTURE_TYPE AlternativeArchitecture;  // 0x2c0
+    ULONG AltArchitecturePad[1];                            // 0x2c4
+    LARGE_INTEGER SystemExpirationDate;                     // 0x2c8
+    ULONG SuiteMask;                                        // 0x2d0
+    BOOLEAN KdDebuggerEnabled;                              // 0x2d4
 #if (NTDDI_VERSION >= NTDDI_WINXPSP2)
-    UCHAR NXSupportPolicy;
+    UCHAR NXSupportPolicy;                                  // 0x2d5
 #endif
-    volatile ULONG ActiveConsoleId;
-    volatile ULONG DismountCount;
-    ULONG ComPlusPackage;
-    ULONG LastSystemRITEventTickCount;
-    ULONG NumberOfPhysicalPages;
-    BOOLEAN SafeBootMode;
+    volatile ULONG ActiveConsoleId;                         // 0x2d8
+    volatile ULONG DismountCount;                           // 0x2dc
+    ULONG ComPlusPackage;                                   // 0x2e0
+    ULONG LastSystemRITEventTickCount;                      // 0x2e4
+    ULONG NumberOfPhysicalPages;                            // 0x2e8
+    BOOLEAN SafeBootMode;                                   // 0x2ec
 #if (NTDDI_VERSION >= NTDDI_WIN7)
     union
     {
-        UCHAR TscQpcData;
+        UCHAR TscQpcData;                                   // 0x2ed
         struct
         {
-            UCHAR TscQpcEnabled:1;
-            UCHAR TscQpcSpareFlag:1;
-            UCHAR TscQpcShift:6;
+            UCHAR TscQpcEnabled:1;                          // 0x2ed
+            UCHAR TscQpcSpareFlag:1;                        // 0x2ed
+            UCHAR TscQpcShift:6;                            // 0x2ed
         } DUMMYSTRUCTNAME;
     } DUMMYUNIONNAME;
-    UCHAR TscQpcPad[2];
+    UCHAR TscQpcPad[2];                                     // 0x2ee
 #endif
 #if (NTDDI_VERSION >= NTDDI_VISTA)
     union
     {
-        ULONG SharedDataFlags;
+        ULONG SharedDataFlags;                              // 0x2f0
         struct
         {
-            ULONG DbgErrorPortPresent:1;
-            ULONG DbgElevationEnabled:1;
-            ULONG DbgVirtEnabled:1;
-            ULONG DbgInstallerDetectEnabled:1;
-            ULONG DbgSystemDllRelocated:1;
-            ULONG DbgDynProcessorEnabled:1;
-            ULONG DbgSEHValidationEnabled:1;
-            ULONG SpareBits:25;
+            ULONG DbgErrorPortPresent:1;                    // 0x2f0
+            ULONG DbgElevationEnabled:1;                    // 0x2f0
+            ULONG DbgVirtEnabled:1;                         // 0x2f0
+            ULONG DbgInstallerDetectEnabled:1;              // 0x2f0
+            ULONG DbgSystemDllRelocated:1;                  // 0x2f0
+            ULONG DbgDynProcessorEnabled:1;                 // 0x2f0
+            ULONG DbgSEHValidationEnabled:1;                // 0x2f0
+            ULONG SpareBits:25;                             // 0x2f0
         } DUMMYSTRUCTNAME2;
     } DUMMYUNIONNAME2;
 #else
     ULONG TraceLogging;
 #endif
-    ULONG DataFlagsPad[1];
-    ULONGLONG TestRetInstruction;
-    ULONG SystemCall;
-    ULONG SystemCallReturn;
-    ULONGLONG SystemCallPad[3];
+    ULONG DataFlagsPad[1];                                  // 0x2f4
+    ULONGLONG TestRetInstruction;                           // 0x2f8
+    ULONG SystemCall;                                       // 0x300
+    ULONG SystemCallReturn;                                 // 0x304
+    ULONGLONG SystemCallPad[3];                             // 0x308
     union
     {
-        volatile KSYSTEM_TIME TickCount;
-        volatile ULONG64 TickCountQuad;
+        volatile KSYSTEM_TIME TickCount;                    // 0x320
+        volatile ULONG64 TickCountQuad;                     // 0x320
         struct
         {
-            ULONG ReservedTickCountOverlay[3];
-            ULONG TickCountPad[1];
+            ULONG ReservedTickCountOverlay[3];              // 0x320
+            ULONG TickCountPad[1];                          // 0x32c
         } DUMMYSTRUCTNAME;
     } DUMMYUNIONNAME3;
-    ULONG Cookie;
-    ULONG CookiePad[1];
+    ULONG Cookie;                                           // 0x330
+#if (NTDDI_VERSION >= NTDDI_VISTA)
+    ULONG CookiePad[1];                                     // 0x334
+    LONGLONG ConsoleSessionForegroundProcessId;             // 0x338
+#endif
 #if (NTDDI_VERSION >= NTDDI_WS03)
-    LONGLONG ConsoleSessionForegroundProcessId;
-    ULONG Wow64SharedInformation[MAX_WOW64_SHARED_ENTRIES];
+    ULONG Wow64SharedInformation[MAX_WOW64_SHARED_ENTRIES]; // 2K3: 0x334 / Vista+: 0x340
 #endif
 #if (NTDDI_VERSION >= NTDDI_VISTA)
 #if (NTDDI_VERSION >= NTDDI_WIN7)
-    USHORT UserModeGlobalLogger[16];
+    USHORT UserModeGlobalLogger[16];                        // 0x380
 #else
-    USHORT UserModeGlobalLogger[8];
-    ULONG HeapTracingPid[2];
-    ULONG CritSecTracingPid[2];
+    USHORT UserModeGlobalLogger[8];                         // 0x380
+    ULONG HeapTracingPid[2];                                // 0x390
+    ULONG CritSecTracingPid[2];                             // 0x398
 #endif
-    ULONG ImageFileExecutionOptions;
+    ULONG ImageFileExecutionOptions;                        // 0x3a0
 #if (NTDDI_VERSION >= NTDDI_VISTASP1)
-    ULONG LangGenerationCount;
+    ULONG LangGenerationCount;                              // 0x3a4
 #else
   /* 4 bytes padding */
 #endif
-    ULONGLONG Reserved5;
-    volatile ULONG64 InterruptTimeBias;
+    ULONGLONG Reserved5;                                    // 0x3a8
+    volatile ULONG64 InterruptTimeBias;                     // 0x3b0
 #endif // NTDDI_VERSION >= NTDDI_VISTA
 #if (NTDDI_VERSION >= NTDDI_WIN7)
-    volatile ULONG64 TscQpcBias;
-    volatile ULONG ActiveProcessorCount;
-    volatile USHORT ActiveGroupCount;
-    USHORT Reserved4;
-    volatile ULONG AitSamplingValue;
-    volatile ULONG AppCompatFlag;
-    ULONGLONG SystemDllNativeRelocation;
-    ULONG SystemDllWowRelocation;
-    ULONG XStatePad[1];
-    XSTATE_CONFIGURATION XState;
+    volatile ULONG64 TscQpcBias;                            // 0x3b8
+    volatile ULONG ActiveProcessorCount;                    // 0x3c0
+    volatile USHORT ActiveGroupCount;                       // 0x3c4
+    USHORT Reserved4;                                       // 0x3c6
+    volatile ULONG AitSamplingValue;                        // 0x3c8
+    volatile ULONG AppCompatFlag;                           // 0x3cc
+    ULONGLONG SystemDllNativeRelocation;                    // 0x3d0
+    ULONG SystemDllWowRelocation;                           // 0x3d8
+    ULONG XStatePad[1];                                     // 0x3dc
+    XSTATE_CONFIGURATION XState;                            // 0x3e0
 #endif
 } KUSER_SHARED_DATA, *PKUSER_SHARED_DATA;
 

--- a/sdk/include/xdk/ketypes.h
+++ b/sdk/include/xdk/ketypes.h
@@ -1301,10 +1301,10 @@ typedef struct _KUSER_SHARED_DATA
     ULONG NumberOfPhysicalPages;
     BOOLEAN SafeBootMode;
 #if (NTDDI_VERSION >= NTDDI_WIN7)
-    _ANONYMOUS_UNION union
+    union
     {
         UCHAR TscQpcData;
-        _ANONYMOUS_STRUCT struct
+        struct
         {
             UCHAR TscQpcEnabled:1;
             UCHAR TscQpcSpareFlag:1;
@@ -1314,10 +1314,10 @@ typedef struct _KUSER_SHARED_DATA
     UCHAR TscQpcPad[2];
 #endif
 #if (NTDDI_VERSION >= NTDDI_VISTA)
-    _ANONYMOUS_UNION union
+    union
     {
         ULONG SharedDataFlags;
-        _ANONYMOUS_STRUCT struct
+        struct
         {
             ULONG DbgErrorPortPresent:1;
             ULONG DbgElevationEnabled:1;
@@ -1337,11 +1337,11 @@ typedef struct _KUSER_SHARED_DATA
     ULONG SystemCall;
     ULONG SystemCallReturn;
     ULONGLONG SystemCallPad[3];
-    _ANONYMOUS_UNION union
+    union
     {
         volatile KSYSTEM_TIME TickCount;
         volatile ULONG64 TickCountQuad;
-        _ANONYMOUS_STRUCT struct
+        struct
         {
             ULONG ReservedTickCountOverlay[3];
             ULONG TickCountPad[1];

--- a/sdk/include/xdk/ketypes.h
+++ b/sdk/include/xdk/ketypes.h
@@ -1263,117 +1263,124 @@ typedef struct _XSTATE_CONFIGURATION
 #define NX_SUPPORT_POLICY_OPTOUT    3
 #endif
 
-typedef struct _KUSER_SHARED_DATA {
-  ULONG TickCountLowDeprecated;
-  ULONG TickCountMultiplier;
-  volatile KSYSTEM_TIME InterruptTime;
-  volatile KSYSTEM_TIME SystemTime;
-  volatile KSYSTEM_TIME TimeZoneBias;
-  USHORT ImageNumberLow;
-  USHORT ImageNumberHigh;
-  WCHAR NtSystemRoot[260];
-  ULONG MaxStackTraceDepth;
-  ULONG CryptoExponent;
-  ULONG TimeZoneId;
-  ULONG LargePageMinimum;
-  ULONG Reserved2[7];
-  NT_PRODUCT_TYPE NtProductType;
-  BOOLEAN ProductTypeIsValid;
-  ULONG NtMajorVersion;
-  ULONG NtMinorVersion;
-  BOOLEAN ProcessorFeatures[PROCESSOR_FEATURE_MAX];
-  ULONG Reserved1;
-  ULONG Reserved3;
-  volatile ULONG TimeSlip;
-  ALTERNATIVE_ARCHITECTURE_TYPE AlternativeArchitecture;
-  ULONG AltArchitecturePad[1];
-  LARGE_INTEGER SystemExpirationDate;
-  ULONG SuiteMask;
-  BOOLEAN KdDebuggerEnabled;
+typedef struct _KUSER_SHARED_DATA
+{
+    ULONG TickCountLowDeprecated;
+    ULONG TickCountMultiplier;
+    volatile KSYSTEM_TIME InterruptTime;
+    volatile KSYSTEM_TIME SystemTime;
+    volatile KSYSTEM_TIME TimeZoneBias;
+    USHORT ImageNumberLow;
+    USHORT ImageNumberHigh;
+    WCHAR NtSystemRoot[260];
+    ULONG MaxStackTraceDepth;
+    ULONG CryptoExponent;
+    ULONG TimeZoneId;
+    ULONG LargePageMinimum;
+    ULONG Reserved2[7];
+    NT_PRODUCT_TYPE NtProductType;
+    BOOLEAN ProductTypeIsValid;
+    ULONG NtMajorVersion;
+    ULONG NtMinorVersion;
+    BOOLEAN ProcessorFeatures[PROCESSOR_FEATURE_MAX];
+    ULONG Reserved1;
+    ULONG Reserved3;
+    volatile ULONG TimeSlip;
+    ALTERNATIVE_ARCHITECTURE_TYPE AlternativeArchitecture;
+    ULONG AltArchitecturePad[1];
+    LARGE_INTEGER SystemExpirationDate;
+    ULONG SuiteMask;
+    BOOLEAN KdDebuggerEnabled;
 #if (NTDDI_VERSION >= NTDDI_WINXPSP2)
-  UCHAR NXSupportPolicy;
+    UCHAR NXSupportPolicy;
 #endif
-  volatile ULONG ActiveConsoleId;
-  volatile ULONG DismountCount;
-  ULONG ComPlusPackage;
-  ULONG LastSystemRITEventTickCount;
-  ULONG NumberOfPhysicalPages;
-  BOOLEAN SafeBootMode;
+    volatile ULONG ActiveConsoleId;
+    volatile ULONG DismountCount;
+    ULONG ComPlusPackage;
+    ULONG LastSystemRITEventTickCount;
+    ULONG NumberOfPhysicalPages;
+    BOOLEAN SafeBootMode;
 #if (NTDDI_VERSION >= NTDDI_WIN7)
-  _ANONYMOUS_UNION union {
-    UCHAR TscQpcData;
-    _ANONYMOUS_STRUCT struct {
-      UCHAR TscQpcEnabled:1;
-      UCHAR TscQpcSpareFlag:1;
-      UCHAR TscQpcShift:6;
-    } DUMMYSTRUCTNAME;
-  } DUMMYUNIONNAME;
-  UCHAR TscQpcPad[2];
+    _ANONYMOUS_UNION union
+    {
+        UCHAR TscQpcData;
+        _ANONYMOUS_STRUCT struct
+        {
+            UCHAR TscQpcEnabled:1;
+            UCHAR TscQpcSpareFlag:1;
+            UCHAR TscQpcShift:6;
+        } DUMMYSTRUCTNAME;
+    } DUMMYUNIONNAME;
+    UCHAR TscQpcPad[2];
 #endif
 #if (NTDDI_VERSION >= NTDDI_VISTA)
-  _ANONYMOUS_UNION union {
-    ULONG SharedDataFlags;
-    _ANONYMOUS_STRUCT struct {
-      ULONG DbgErrorPortPresent:1;
-      ULONG DbgElevationEnabled:1;
-      ULONG DbgVirtEnabled:1;
-      ULONG DbgInstallerDetectEnabled:1;
-      ULONG DbgSystemDllRelocated:1;
-      ULONG DbgDynProcessorEnabled:1;
-      ULONG DbgSEHValidationEnabled:1;
-      ULONG SpareBits:25;
-    } DUMMYSTRUCTNAME2;
-  } DUMMYUNIONNAME2;
+    _ANONYMOUS_UNION union
+    {
+        ULONG SharedDataFlags;
+        _ANONYMOUS_STRUCT struct
+        {
+            ULONG DbgErrorPortPresent:1;
+            ULONG DbgElevationEnabled:1;
+            ULONG DbgVirtEnabled:1;
+            ULONG DbgInstallerDetectEnabled:1;
+            ULONG DbgSystemDllRelocated:1;
+            ULONG DbgDynProcessorEnabled:1;
+            ULONG DbgSEHValidationEnabled:1;
+            ULONG SpareBits:25;
+        } DUMMYSTRUCTNAME2;
+    } DUMMYUNIONNAME2;
 #else
-  ULONG TraceLogging;
+    ULONG TraceLogging;
 #endif
-  ULONG DataFlagsPad[1];
-  ULONGLONG TestRetInstruction;
-  ULONG SystemCall;
-  ULONG SystemCallReturn;
-  ULONGLONG SystemCallPad[3];
-  _ANONYMOUS_UNION union {
-    volatile KSYSTEM_TIME TickCount;
-    volatile ULONG64 TickCountQuad;
-    _ANONYMOUS_STRUCT struct {
-      ULONG ReservedTickCountOverlay[3];
-      ULONG TickCountPad[1];
-    } DUMMYSTRUCTNAME;
-  } DUMMYUNIONNAME3;
-  ULONG Cookie;
-  ULONG CookiePad[1];
+    ULONG DataFlagsPad[1];
+    ULONGLONG TestRetInstruction;
+    ULONG SystemCall;
+    ULONG SystemCallReturn;
+    ULONGLONG SystemCallPad[3];
+    _ANONYMOUS_UNION union
+    {
+        volatile KSYSTEM_TIME TickCount;
+        volatile ULONG64 TickCountQuad;
+        _ANONYMOUS_STRUCT struct
+        {
+            ULONG ReservedTickCountOverlay[3];
+            ULONG TickCountPad[1];
+        } DUMMYSTRUCTNAME;
+    } DUMMYUNIONNAME3;
+    ULONG Cookie;
+    ULONG CookiePad[1];
 #if (NTDDI_VERSION >= NTDDI_WS03)
-  LONGLONG ConsoleSessionForegroundProcessId;
-  ULONG Wow64SharedInformation[MAX_WOW64_SHARED_ENTRIES];
+    LONGLONG ConsoleSessionForegroundProcessId;
+    ULONG Wow64SharedInformation[MAX_WOW64_SHARED_ENTRIES];
 #endif
 #if (NTDDI_VERSION >= NTDDI_VISTA)
 #if (NTDDI_VERSION >= NTDDI_WIN7)
-  USHORT UserModeGlobalLogger[16];
+    USHORT UserModeGlobalLogger[16];
 #else
-  USHORT UserModeGlobalLogger[8];
-  ULONG HeapTracingPid[2];
-  ULONG CritSecTracingPid[2];
+    USHORT UserModeGlobalLogger[8];
+    ULONG HeapTracingPid[2];
+    ULONG CritSecTracingPid[2];
 #endif
-  ULONG ImageFileExecutionOptions;
+    ULONG ImageFileExecutionOptions;
 #if (NTDDI_VERSION >= NTDDI_VISTASP1)
-  ULONG LangGenerationCount;
+    ULONG LangGenerationCount;
 #else
   /* 4 bytes padding */
 #endif
-  ULONGLONG Reserved5;
-  volatile ULONG64 InterruptTimeBias;
-#endif
+    ULONGLONG Reserved5;
+    volatile ULONG64 InterruptTimeBias;
+#endif // NTDDI_VERSION >= NTDDI_VISTA
 #if (NTDDI_VERSION >= NTDDI_WIN7)
-  volatile ULONG64 TscQpcBias;
-  volatile ULONG ActiveProcessorCount;
-  volatile USHORT ActiveGroupCount;
-  USHORT Reserved4;
-  volatile ULONG AitSamplingValue;
-  volatile ULONG AppCompatFlag;
-  ULONGLONG SystemDllNativeRelocation;
-  ULONG SystemDllWowRelocation;
-  ULONG XStatePad[1];
-  XSTATE_CONFIGURATION XState;
+    volatile ULONG64 TscQpcBias;
+    volatile ULONG ActiveProcessorCount;
+    volatile USHORT ActiveGroupCount;
+    USHORT Reserved4;
+    volatile ULONG AitSamplingValue;
+    volatile ULONG AppCompatFlag;
+    ULONGLONG SystemDllNativeRelocation;
+    ULONG SystemDllWowRelocation;
+    ULONG XStatePad[1];
+    XSTATE_CONFIGURATION XState;
 #endif
 } KUSER_SHARED_DATA, *PKUSER_SHARED_DATA;
 

--- a/sdk/include/xdk/ketypes.h
+++ b/sdk/include/xdk/ketypes.h
@@ -1263,6 +1263,10 @@ typedef struct _XSTATE_CONFIGURATION
 #define NX_SUPPORT_POLICY_OPTOUT    3
 #endif
 
+//
+// Shared Kernel User Data
+// Keep in sync with sdk/include/ndk/ketypes.h
+//
 typedef struct _KUSER_SHARED_DATA
 {
     ULONG TickCountLowDeprecated;                           // 0x0


### PR DESCRIPTION
## Purpose

Sync KUSER_SHARED_DATA between NDK and XDK.

## Proposed changes

- Add missing XSTATE definitions to NDK
- Update XSTATE stuff to latest SDK
- Apply our standard formatting
- Some versioning improvements
- Add field offsets
- Sync KUSER_SHARED_DATA between NDK and XDK

## TODO

Decide upon how to handle the (growing) number of `#if (NTDDI_VERSION ...)`. A lot of the layout is compatible between versions and adding more fields doesn't change anything. To enable support for modern features like XSTATE configuration, it will be needed to add `|| defined(__REACTOS__)`. Please provide feedback.

- [ ] Keep them all
- [ ] Remove them for newer fields that replace padding
- [ ] Remove them for newer fields that replace Reserved fields
- [ ] Remove them, unless required: use the more modern definition, unless we already use the old one in the kernel.
