### PR TITLE
[GDI] eng/error.c: Minor code tweaks

### DIFF
--- a/win32ss/gdi/eng/error.c
+++ b/win32ss/gdi/eng/error.c
@@ -1,8 +1,5 @@
 #include <win32k.h>
 
-#define NDEBUG
-#include <debug.h>
-
 /*
  * @implemented
  * http://msdn.microsoft.com/en-us/library/ff564940%28VS.85%29.aspx
@@ -12,10 +9,7 @@ APIENTRY
 EngGetLastError(VOID)
 {
     PTEB pTeb = NtCurrentTeb();
-    if (pTeb)
-        return NtCurrentTeb()->LastErrorValue;
-    else
-        return ERROR_SUCCESS;
+    return (pTeb ? pTeb->LastErrorValue : ERROR_SUCCESS);
 }
 
 /*
@@ -34,7 +28,7 @@ EngSetLastError(_In_ ULONG iError)
 
 VOID
 FASTCALL
-SetLastNtError(NTSTATUS Status)
+SetLastNtError(_In_ NTSTATUS Status)
 {
     EngSetLastError(RtlNtStatusToDosError(Status));
 }

--- a/win32ss/gdi/ntgdi/misc.h
+++ b/win32ss/gdi/ntgdi/misc.h
@@ -60,9 +60,9 @@ DWORD
 NTAPI
 RegGetSectionDWORD(LPCWSTR pszSection, LPWSTR pszValue, DWORD dwDefault);
 
-VOID FASTCALL
-SetLastNtError(
-  NTSTATUS Status);
+VOID
+FASTCALL
+SetLastNtError(_In_ NTSTATUS Status);
 
 typedef struct _GDI_POOL *PGDI_POOL;
 


### PR DESCRIPTION
## Purpose

Optimization, consistency, simplification, documentation.

## Proposed changes

- Remove a useless `#include <debug.h>`.
- Use `pTeb` more.
- Remove a useless `else`.
- Add a SAL2 annotation.