### PR TITLE
[NTOS:KE/x64] Implement initial IPI code

### DIFF
--- a/ntoskrnl/ke/amd64/ipi.c
+++ b/ntoskrnl/ke/amd64/ipi.c
@@ -1,0 +1,50 @@
+/*
+ * PROJECT:     ReactOS Kernel
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     IPI code for x64
+ * COPYRIGHT:   Copyright 2023 Timo Kreuzer <timo.kreuzer@reactos.org>
+ */
+
+/* INCLUDES *******************************************************************/
+
+#include <ntoskrnl.h>
+#define NDEBUG
+#include <debug.h>
+
+/* FUNCTIONS *****************************************************************/
+
+VOID
+FASTCALL
+KiIpiSend(
+    _In_ KAFFINITY TargetSet,
+    _In_ ULONG IpiRequest)
+{
+    /* Check if we can send the IPI directly */
+    if (IpiRequest == IPI_APC)
+    {
+        HalSendSoftwareInterrupt(TargetSet, APC_LEVEL);
+    }
+    else if (IpiRequest == IPI_DPC)
+    {
+        HalSendSoftwareInterrupt(TargetSet, DISPATCH_LEVEL);
+    }
+    else if (IpiRequest == IPI_FREEZE)
+    {
+        /* On x64 the freeze IPI is an NMI */
+        HalSendNMI(TargetSet);
+    }
+    else
+    {
+        ASSERT(FALSE);
+    }
+}
+
+ULONG_PTR
+NTAPI
+KeIpiGenericCall(
+    _In_ PKIPI_BROADCAST_WORKER Function,
+    _In_ ULONG_PTR Argument)
+{
+    __debugbreak();
+    return 0;
+}

--- a/ntoskrnl/ke/ipi.c
+++ b/ntoskrnl/ke/ipi.c
@@ -18,6 +18,8 @@ extern KSPIN_LOCK KiReverseStallIpiLock;
 
 /* PRIVATE FUNCTIONS *********************************************************/
 
+#ifndef _M_AMD64
+
 VOID
 NTAPI
 KiIpiGenericCallTarget(IN PKIPI_CONTEXT PacketContext,
@@ -270,3 +272,5 @@ KeIpiGenericCall(IN PKIPI_BROADCAST_WORKER Function,
     KeLowerIrql(OldIrql);
     return Status;
 }
+
+#endif // !_M_AMD64

--- a/ntoskrnl/ntos.cmake
+++ b/ntoskrnl/ntos.cmake
@@ -351,6 +351,7 @@ elseif(ARCH STREQUAL "amd64")
         ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/amd64/cpu.c
         ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/amd64/except.c
         ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/amd64/interrupt.c
+        ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/amd64/ipi.c
         ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/amd64/irql.c
         ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/amd64/kiinit.c
         ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/amd64/krnlinit.c


### PR DESCRIPTION
## Purpose

This PR implements the basic x64 kernel IPI code. For now it only supports APC, DPC and freeze IPIs, which will be made use of soon. DPC for SMP scheduling and freeze for SMP debugging. It doesn't yet support generic function IPIs, which are a bit more complex and will come later.
