### PR TITLE
[COMCTL32] IP Address control: Fix background drawing

### DIFF
--- a/dll/win32/comctl32/ipaddress.c
+++ b/dll/win32/comctl32/ipaddress.c
@@ -178,7 +178,11 @@ static LRESULT IPADDRESS_Draw (const IPADDRESS_INFO *infoPtr, HDC hdc)
             fgCol = comctl32_color.clrGrayText;
         }
 
+#ifdef __REACTOS__
+        FillRect(hdc, &rect, GetSysColorBrush(infoPtr->Enabled ? COLOR_WINDOW : COLOR_3DFACE));
+#else
         FillRect (hdc, &rect, (HBRUSH)(DWORD_PTR)(bgCol+1));
+#endif
         DrawEdge (hdc, &rect, EDGE_SUNKEN, BF_RECT | BF_ADJUST);
     }
     

--- a/dll/win32/comctl32/ipaddress.c
+++ b/dll/win32/comctl32/ipaddress.c
@@ -179,7 +179,11 @@ static LRESULT IPADDRESS_Draw (const IPADDRESS_INFO *infoPtr, HDC hdc)
         }
 
 #ifdef __REACTOS__
-        FillRect(hdc, &rect, GetSysColorBrush(infoPtr->Enabled ? COLOR_WINDOW : COLOR_3DFACE));
+        {
+            HBRUSH brush = CreateSolidBrush(bgCol);
+            FillRect(hdc, &rect, brush);
+            DeleteObject(brush);
+        }
 #else
         FillRect (hdc, &rect, (HBRUSH)(DWORD_PTR)(bgCol+1));
 #endif


### PR DESCRIPTION
## Purpose
Based on KRosUser's suggestion. `bgCol` is a `COLORREF` value, not a color index.
JIRA issue: [CORE-9853](https://jira.reactos.org/browse/CORE-9853)

## Proposed changes

- Create a brush from `bgCol`.
- Use it.

## TODO

- [x] Do tests.