### PR TITLE
[USER32] Skip STATIC controls on arrow keys

### DIFF
--- a/win32ss/user/user32/windows/dialog.c
+++ b/win32ss/user/user32/windows/dialog.c
@@ -2624,17 +2624,14 @@ IsDialogMessageW(
              if (!(dlgCode & DLGC_WANTARROWS))
              {
                  BOOL fPrevious = (lpMsg->wParam == VK_LEFT || lpMsg->wParam == VK_UP);
-                 HWND hwndFirst = NULL;
-                 HWND hwndNext = GetNextDlgGroupItem(hDlg, lpMsg->hwnd, fPrevious);
+                 HWND hwndFirst = lpMsg->hwnd;
+                 HWND hwndNext = GetNextDlgGroupItem(hDlg, hwndFirst, fPrevious);
 
-                 /* Skip static elements when arrow-moving through a list of controls */
-                 /* hwndFirst to prevent infinite looping */
-                 while (hwndNext && (SendMessageW(hwndNext, WM_GETDLGCODE, 0, 0) & DLGC_STATIC) &&
-                        (hwndFirst != hwndNext))
+                 /* Skip STATIC elements when arrow-moving through a list of controls */
+                 while (hwndNext && (hwndFirst != hwndNext) &&
+                        (SendMessageW(hwndNext, WM_GETDLGCODE, 0, 0) & DLGC_STATIC))
                  {
                      hwndNext = GetNextDlgGroupItem(hDlg, hwndNext, fPrevious);
-                     if (!hwndFirst)
-                         hwndFirst = hwndNext;
                  }
 
                  if (hwndNext && SendMessageW( hwndNext, WM_GETDLGCODE, lpMsg->wParam, (LPARAM)lpMsg ) == (DLGC_BUTTON | DLGC_RADIOBUTTON))

--- a/win32ss/user/user32/windows/dialog.c
+++ b/win32ss/user/user32/windows/dialog.c
@@ -2624,7 +2624,19 @@ IsDialogMessageW(
              if (!(dlgCode & DLGC_WANTARROWS))
              {
                  BOOL fPrevious = (lpMsg->wParam == VK_LEFT || lpMsg->wParam == VK_UP);
-                 HWND hwndNext = GetNextDlgGroupItem( hDlg, lpMsg->hwnd, fPrevious );
+                 HWND hwndFirst = NULL;
+                 HWND hwndNext = GetNextDlgGroupItem(hDlg, lpMsg->hwnd, fPrevious);
+
+                 /* Skip static elements when arrow-moving through a list of controls */
+                 /* hwndFirst to prevent infinite looping */
+                 while (hwndNext && (SendMessageW(hwndNext, WM_GETDLGCODE, 0, 0) & DLGC_STATIC) &&
+                        (hwndFirst != hwndNext))
+                 {
+                     hwndNext = GetNextDlgGroupItem(hDlg, hwndNext, fPrevious);
+                     if (!hwndFirst)
+                         hwndFirst = hwndNext;
+                 }
+
                  if (hwndNext && SendMessageW( hwndNext, WM_GETDLGCODE, lpMsg->wParam, (LPARAM)lpMsg ) == (DLGC_BUTTON | DLGC_RADIOBUTTON))
                  {
                      SetFocus( hwndNext );

--- a/win32ss/user/user32/windows/dialog.c
+++ b/win32ss/user/user32/windows/dialog.c
@@ -2628,9 +2628,10 @@ IsDialogMessageW(
                  HWND hwndNext = GetNextDlgGroupItem(hDlg, hwndFirst, fPrevious);
 
                  /* Skip STATIC elements when arrow-moving through a list of controls */
-                 while (hwndNext && (hwndFirst != hwndNext) &&
-                        (SendMessageW(hwndNext, WM_GETDLGCODE, 0, 0) & DLGC_STATIC))
+                 while (hwndNext && (SendMessageW(hwndNext, WM_GETDLGCODE, 0, 0) & DLGC_STATIC))
                  {
+                     if (hwndFirst == hwndNext)
+                         return TRUE;
                      hwndNext = GetNextDlgGroupItem(hDlg, hwndNext, fPrevious);
                  }
 

--- a/win32ss/user/user32/windows/dialog.c
+++ b/win32ss/user/user32/windows/dialog.c
@@ -2624,16 +2624,16 @@ IsDialogMessageW(
              if (!(dlgCode & DLGC_WANTARROWS))
              {
                  BOOL fPrevious = (lpMsg->wParam == VK_LEFT || lpMsg->wParam == VK_UP);
-                 HWND hwndFirst = lpMsg->hwnd;
-                 HWND hwndNext = GetNextDlgGroupItem(hDlg, hwndFirst, fPrevious);
 
                  /* Skip STATIC elements when arrow-moving through a list of controls */
-                 while (hwndNext && (SendMessageW(hwndNext, WM_GETDLGCODE, 0, 0) & DLGC_STATIC))
-                 {
-                     if (hwndFirst == hwndNext)
-                         return TRUE;
-                     hwndNext = GetNextDlgGroupItem(hDlg, hwndNext, fPrevious);
-                 }
+                 HWND hwndNext, hwndFirst = lpMsg->hwnd;
+                 for (hwndNext = GetNextDlgGroupItem(hDlg, hwndFirst, fPrevious);
+                      hwndNext && hwndFirst != hwndNext;
+                      hwndNext = GetNextDlgGroupItem(hDlg, hwndNext, fPrevious))
+                  {
+                      if (!(SendMessageW(hwndNext, WM_GETDLGCODE, 0, 0) & DLGC_STATIC))
+                          break;
+                  }
 
                  if (hwndNext && SendMessageW( hwndNext, WM_GETDLGCODE, lpMsg->wParam, (LPARAM)lpMsg ) == (DLGC_BUTTON | DLGC_RADIOBUTTON))
                  {


### PR DESCRIPTION
## Purpose

Based on KRosUser's `SkipStatic_v2.patch`.
JIRA issue: [CORE-6127](https://jira.reactos.org/browse/CORE-6127)

## Proposed changes

- Skip `DLGC_STATIC` controls on array keys.
- Avoid infinite loop by using `hwndFirst` variable.

## TODO

- [x] Do tests.