### PR TITLE
[SHELL32] ShellDispatch::ShellExecute must default to displaying the window

### DIFF
--- a/dll/win32/shell32/CShellDispatch.cpp
+++ b/dll/win32/shell32/CShellDispatch.cpp
@@ -245,7 +245,7 @@ HRESULT STDMETHODCALLTYPE CShellDispatch::ShellExecute(BSTR file, VARIANT v_args
 {
     CComVariant args_str, dir_str, op_str, show_int;
     WCHAR *args = NULL, *dir = NULL, *op = NULL;
-    INT show = 0;
+    INT show = SW_SHOW;
     HINSTANCE ret;
 
     TRACE("(%s, %s, %s, %s, %s)\n", debugstr_w(file), debugstr_variant(&v_args),


### PR DESCRIPTION
SW_HIDE is not the correct default show mode.

`WScript.CreateObject("Shell.Application").ShellExecute("calc.exe");`