### PR TITLE
[SHELL32] Implement several ShellDispatch methods

### DIFF
--- a/dll/win32/shell32/CShellDispatch.cpp
+++ b/dll/win32/shell32/CShellDispatch.cpp
@@ -4,6 +4,7 @@
  * PURPOSE:     IShellDispatch implementation
  * COPYRIGHT:   Copyright 2015-2018 Mark Jansen (mark.jansen@reactos.org)
  *              Copyright 2018 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
+ *              Copyright 2023 Whindmar Saksit (whindsaks@proton.me)
  */
 
 #include "precomp.h"

--- a/sdk/include/reactos/shellutils.h
+++ b/sdk/include/reactos/shellutils.h
@@ -67,6 +67,12 @@ Win32DbgPrint(const char *filename, int line, const char *lpFormat, ...)
 #   define IID_NULL_PPV_ARG(Itype, ppType) IID_##Itype, NULL, (void**)(ppType)
 #endif
 
+inline HRESULT HResultFromWin32(DWORD hr)
+{
+     // HRESULT_FROM_WIN32 will evaluate its parameter twice, this function will not.
+    return HRESULT_FROM_WIN32(hr);
+}
+
 #if 1
 
 inline BOOL _ROS_FAILED_HELPER(HRESULT hr, const char* expr, const char* filename, int line)


### PR DESCRIPTION
Complete:
- AddToRecent
- Open, Explore
- MinimizeAll, UndoMinimizeALL, CascadeWindows, TileVertically, TileHorizontally, ToggleDesktop
- FindFiles, FindComputer
- FileRun
- ControlPanelItem
- SetTime
- ServiceStart, ServiceStop, CanStartStopService
- Help
- TrayProperties
- IsRestricted
- Windows
- WindowsSecurity

Partial:
- GetSystemInformation (Just the easy ones)
- GetSetting (The relevant ones)

Other:
- BrowseForFolder: RootFolder parameter

----

Most of these newly implemented features are hard to test because they just tell Explorer to open a window or execute a command.

The Service methods and GetSystemInformation/GetSetting are possible to test. I don't know if the WSH support is all there yet to do that or if it has to be done in C++.

