### PR TITLE
[SHIMGVW] Refactor Part 3

### DIFF
--- a/dll/win32/shimgvw/shimgvw.c
+++ b/dll/win32/shimgvw/shimgvw.c
@@ -747,7 +747,9 @@ ZoomWndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
             break;
         }
         default:
+        {
             return CallWindowProcW(pData->m_fnPrevProc, hwnd, uMsg, wParam, lParam);
+        }
     }
     return 0;
 }

--- a/dll/win32/shimgvw/shimgvw.c
+++ b/dll/win32/shimgvw/shimgvw.c
@@ -1036,6 +1036,10 @@ Preview_OnDestroy(HWND hwnd)
     SetWindowLongPtr(pData->m_hwndZoom, GWLP_USERDATA, 0);
     DestroyWindow(pData->m_hwndZoom);
     pData->m_hwndZoom = NULL;
+
+    DestroyWindow(pData->m_hwndToolBar);
+    pData->m_hwndToolBar = NULL;
+
     QuickFree(pData);
 
     PostQuitMessage(0);

--- a/dll/win32/shimgvw/shimgvw.c
+++ b/dll/win32/shimgvw/shimgvw.c
@@ -271,7 +271,7 @@ Preview_pLoadImage(PPREVIEW_DATA pData, LPCWSTR szOpenFileName)
 static VOID
 Preview_pLoadImageFromNode(PPREVIEW_DATA pData, SHIMGVW_FILENODE *pNode)
 {
-    return Preview_pLoadImage(pData, (pNode ? pNode->FileName : NULL));
+    Preview_pLoadImage(pData, (pNode ? pNode->FileName : NULL));
 }
 
 static VOID

--- a/dll/win32/shimgvw/shimgvw.h
+++ b/dll/win32/shimgvw/shimgvw.h
@@ -29,11 +29,7 @@
 
 #include "resource.h"
 
-#define TB_IMAGE_WIDTH  16
-#define TB_IMAGE_HEIGHT 16
-
 extern HINSTANCE g_hInstance;
-extern HWND g_hDispWnd;
 extern GpImage *g_pImage;
 
 typedef struct


### PR DESCRIPTION
## Purpose
Improve code flexibility.
JIRA issue: [CORE-19358](https://jira.reactos.org/browse/CORE-19358)

## Proposed changes

- Remove `g_fnPrevProc`, `g_hDispWnd`, `g_hToolBar`, and `g_Anime` global variables.
- Declare `PREVIEW_DATA` structure and use it.
- Encapsulate preview window by using user data.

## TODO

- [x] Do tests.