### PR TITLE
[SHELL32] SHOpenFolderAndSelectItems should handle children correctly

### DIFF
--- a/dll/win32/shell32/shlfolder.cpp
+++ b/dll/win32/shell32/shlfolder.cpp
@@ -373,17 +373,21 @@ SHOpenFolderAndSelectItems(PCIDLIST_ABSOLUTE pidlFolder,
                            DWORD dwFlags)
 {
     ERR("SHOpenFolderAndSelectItems() is hackplemented\n");
+    CComHeapPtr<ITEMIDLIST> freeItem;
     PCIDLIST_ABSOLUTE pidlItem;
     if (cidl)
     {
         /* Firefox sends a full pidl here dispite the fact it is a PCUITEMID_CHILD_ARRAY -_- */
-        if (ILGetNext(apidl[0]) != NULL)
+        if (!ILIsSingle(apidl[0]))
         {
             pidlItem = apidl[0];
         }
         else
         {
-            pidlItem = ILCombine(pidlFolder, apidl[0]);
+            HRESULT hr = SHILCombine(pidlFolder, apidl[0], &pidlItem);
+            if (FAILED_UNEXPECTEDLY(hr))
+                return hr;
+            freeItem.Attach(const_cast<PIDLIST_ABSOLUTE>(pidlItem));
         }
     }
     else

--- a/sdk/include/reactos/shellutils.h
+++ b/sdk/include/reactos/shellutils.h
@@ -572,6 +572,10 @@ struct CCoInit
 #define S_GREATERTHAN S_FALSE
 #define MAKE_COMPARE_HRESULT(x) ((x)>0 ? S_GREATERTHAN : ((x)<0 ? S_LESSTHAN : S_EQUAL))
 
+static inline BOOL ILIsSingle(LPCITEMIDLIST pidl)
+{
+    return pidl == ILFindLastID(pidl);
+}
 
 static inline PCUIDLIST_ABSOLUTE HIDA_GetPIDLFolder(CIDA const* pida)
 {


### PR DESCRIPTION
- Free pidl from `ILCombine`.
- `ILGetNext` will never return NULL on valid input, it is not the correct way to check.