### PR TITLE
[COMCTL32][USER32] ComboBox: Do default processing on WM_SYSKEYDOWN

### DIFF
--- a/dll/win32/comctl32/combo.c
+++ b/dll/win32/comctl32/combo.c
@@ -1890,8 +1890,15 @@ static LRESULT CALLBACK COMBO_WindowProc( HWND hwnd, UINT message, WPARAM wParam
     case WM_SYSKEYDOWN:
         if ( KEYDATA_ALT & HIWORD(lParam) )
             if( wParam == VK_UP || wParam == VK_DOWN )
+#ifdef __REACTOS__
+            {
+#endif
                 COMBO_FlipListbox( lphc, FALSE, FALSE );
         return  0;
+#ifdef __REACTOS__
+            }
+        break;
+#endif
 
     case WM_KEYDOWN:
         if ((wParam == VK_RETURN || wParam == VK_ESCAPE) &&

--- a/win32ss/user/user32/controls/combo.c
+++ b/win32ss/user/user32/controls/combo.c
@@ -1989,8 +1989,15 @@ LRESULT WINAPI ComboWndProc_common( HWND hwnd, UINT message, WPARAM wParam, LPAR
         if ( KEYDATA_ALT & HIWORD(lParam) )
 #endif
             if( wParam == VK_UP || wParam == VK_DOWN )
+#ifdef __REACTOS__
+            {
+#endif
                 COMBO_FlipListbox( lphc, FALSE, FALSE );
         return  0;
+#ifdef __REACTOS__
+            }
+        break;
+#endif
 
     case WM_KEYDOWN:
         if ((wParam == VK_RETURN || wParam == VK_ESCAPE) &&


### PR DESCRIPTION
## Purpose
Based on KRosUser's `combo.patch`. Enable `Alt+F4`.
JIRA issue: [CORE-18231](https://jira.reactos.org/browse/CORE-18231)

## Proposed changes

- ComboBox: Do default processing on `WM_SYSKEYDOWN` if necessary.

## TODO

- [x] Do tests.