### PR TITLE
[BROWSEUI] Don't call SHOpenFolderAndSelectItems with full pidls and don't leak them

### DIFF
--- a/dll/win32/browseui/shellfind/CFindFolder.cpp
+++ b/dll/win32/browseui/shellfind/CFindFolder.cpp
@@ -809,11 +809,10 @@ class CFindFolderContextMenu :
                 CComHeapPtr<ITEMIDLIST> folderPidl(ILCreateFromPathW(_ILGetPath(apidl[i])));
                 if (!folderPidl)
                     return E_OUTOFMEMORY;
-                CComHeapPtr<ITEMIDLIST> filePidl(ILCombine(folderPidl, _ILGetFSPidl(apidl[i])));
-                if (!filePidl)
-                    return E_OUTOFMEMORY;
-                SHOpenFolderAndSelectItems(folderPidl, 1, &filePidl, 0);
+                LPCITEMIDLIST child = _ILGetFSPidl(apidl[i]);
+                SHOpenFolderAndSelectItems(folderPidl, 1, &child, 0);
             }
+            LocalFree(apidl); // Yes, LocalFree
             return S_OK;
         }
 


### PR DESCRIPTION
- The children passed to `SHOpenFolderAndSelectItems` are not supposed to be full pilds.
- Don't leak the array from `IShellFolderView::GetSelectedObjects`.