### PR TITLE
[COMCTL32] Tab control: Use InvalidateRect in TAB_SetItemT update

### DIFF
--- a/dll/win32/comctl32/tab.c
+++ b/dll/win32/comctl32/tab.c
@@ -2800,7 +2800,11 @@ TAB_SetItemT (TAB_INFO *infoPtr, INT iItem, LPTCITEMW tabItem, BOOL bUnicode)
 
   /* Update and repaint tabs */
   TAB_SetItemBounds(infoPtr);
+#ifdef __REACTOS__
+  InvalidateRect(infoPtr->hwnd, NULL, TRUE);
+#else
   TAB_InvalidateTabArea(infoPtr);
+#endif
 
   return TRUE;
 }


### PR DESCRIPTION
## Purpose

Based on KRosUser's `tab.patch`.
JIRA issue: [CORE-11454](https://jira.reactos.org/browse/CORE-11454)

## Proposed changes

- In `TAB_SetItemT` function, use `InvalidateRect` instead of `TAB_InvalidateTabArea`.

## TODO

- [x] Do tests.