### PR TITLE
[REGEDIT] Fix inverted case matching when searching value data

### DIFF
--- a/base/applications/regedit/find.c
+++ b/base/applications/regedit/find.c
@@ -91,7 +91,7 @@ static BOOL CompareName(LPCWSTR pszName1, LPCWSTR pszName2)
 static BOOL MatchString(LPCWCH pch1, INT cch1, LPCWCH pch2, INT cch2)
 {
     INT i;
-    DWORD dwNorm = ((s_dwFlags & RSF_MATCHCASE) ? NORM_IGNORECASE : 0);
+    DWORD dwNorm = ((s_dwFlags & RSF_MATCHCASE) ? 0 : NORM_IGNORECASE);
 
     if (s_dwFlags & RSF_WHOLESTRING)
         return 2 == CompareStringW(LOCALE_SYSTEM_DEFAULT, dwNorm, pch1, cch1, pch2, cch2);


### PR DESCRIPTION
Reproduce:
- Search for "program files" and never get a match until you turn on the case matching checkbox and then find "Program Files"

Notes:
- This file is not synced with Wine AFAIK