### PR TITLE
[MSCTFIME] Implement ImeRegisterWord etc.

### DIFF
--- a/dll/ime/msctfime/msctfime.c
+++ b/dll/ime/msctfime/msctfime.c
@@ -21,6 +21,13 @@ ImeInquire(
     return FALSE;
 }
 
+/***********************************************************************
+ *      ImeConversionList (MSCTFIME.@)
+ *
+ * MSCTFIME has no conversion-list feature.
+ *
+ * @implemented
+ */
 DWORD WINAPI
 ImeConversionList(
     _In_ HIMC hIMC,
@@ -29,7 +36,7 @@ ImeConversionList(
     _In_ DWORD dwBufLen,
     _In_ UINT uFlag)
 {
-    FIXME("stub:(%p, %s, %p, 0x%lX, %u)\n", hIMC, debugstr_w(lpSrc), lpDst, dwBufLen, uFlag);
+    TRACE("(%p, %s, %p, 0x%lX, %u)\n", hIMC, debugstr_w(lpSrc), lpDst, dwBufLen, uFlag);
     return 0;
 }
 
@@ -122,13 +129,20 @@ ImeDestroy(
     return FALSE;
 }
 
+/***********************************************************************
+ *      ImeEscape (MSCTFIME.@)
+ *
+ * MSCTFIME has no Escape feature.
+ *
+ * @implemented
+ */
 LRESULT WINAPI
 ImeEscape(
     _In_ HIMC hIMC,
     _In_ UINT uEscape,
     _Inout_opt_ LPVOID lpData)
 {
-    FIXME("stub:(%p, %u, %p)\n", hIMC, uEscape, lpData);
+    TRACE("(%p, %u, %p)\n", hIMC, uEscape, lpData);
     return 0;
 }
 
@@ -143,21 +157,35 @@ ImeProcessKey(
     return FALSE;
 }
 
+/***********************************************************************
+ *      ImeSelect (MSCTFIME.@)
+ *
+ * MSCTFIME's ImeSelect does nothing.
+ *
+ * @implemented
+ */
 BOOL WINAPI
 ImeSelect(
     _In_ HIMC hIMC,
     _In_ BOOL fSelect)
 {
-    FIXME("stub:(%p, %u)\n", hIMC, fSelect);
+    TRACE("(%p, %u)\n", hIMC, fSelect);
     return FALSE;
 }
 
+/***********************************************************************
+ *      ImeSetActiveContext (MSCTFIME.@)
+ *
+ * MSCTFIME's ImeSetActiveContext does nothing.
+ *
+ * @implemented
+ */
 BOOL WINAPI
 ImeSetActiveContext(
     _In_ HIMC hIMC,
     _In_ BOOL fFlag)
 {
-    FIXME("stub:(%p, %u)\n", hIMC, fFlag);
+    TRACE("(%p, %u)\n", hIMC, fFlag);
     return FALSE;
 }
 

--- a/dll/ime/msctfime/msctfime.c
+++ b/dll/ime/msctfime/msctfime.c
@@ -24,7 +24,7 @@ ImeInquire(
 /***********************************************************************
  *      ImeConversionList (MSCTFIME.@)
  *
- * MSCTFIME has no IME conversion-list feature.
+ * MSCTFIME's ImeConversionList does nothing.
  *
  * @implemented
  * @see ImmGetConversionListW
@@ -137,7 +137,7 @@ ImeDestroy(
 /***********************************************************************
  *      ImeEscape (MSCTFIME.@)
  *
- * MSCTFIME has no IME Escape feature.
+ * MSCTFIME's ImeEscape does nothing.
  *
  * @implemented
  * @see CtfImeEscapeEx

--- a/dll/ime/msctfime/msctfime.c
+++ b/dll/ime/msctfime/msctfime.c
@@ -33,35 +33,63 @@ ImeConversionList(
     return 0;
 }
 
+/***********************************************************************
+ *      ImeRegisterWord (MSCTFIME.@)
+ *
+ * MSCTFIME has no feature of directly registering word.
+ *
+ * @implemented
+ */
 BOOL WINAPI
 ImeRegisterWord(
     _In_ LPCWSTR lpszReading,
     _In_ DWORD dwStyle,
     _In_ LPCWSTR lpszString)
 {
-    FIXME("stub:(%s, 0x%lX, %s)\n", debugstr_w(lpszReading), dwStyle, debugstr_w(lpszString));
+    TRACE("(%s, 0x%lX, %s)\n", debugstr_w(lpszReading), dwStyle, debugstr_w(lpszString));
     return FALSE;
 }
 
+/***********************************************************************
+ *      ImeUnregisterWord (MSCTFIME.@)
+ *
+ * MSCTFIME has no feature of directly registering word.
+ *
+ * @implemented
+ */
 BOOL WINAPI
 ImeUnregisterWord(
     _In_ LPCWSTR lpszReading,
     _In_ DWORD dwStyle,
     _In_ LPCWSTR lpszString)
 {
-    FIXME("stub:(%s, 0x%lX, %s)\n", debugstr_w(lpszReading), dwStyle, debugstr_w(lpszString));
+    TRACE("(%s, 0x%lX, %s)\n", debugstr_w(lpszReading), dwStyle, debugstr_w(lpszString));
     return FALSE;
 }
 
+/***********************************************************************
+ *      ImeGetRegisterWordStyle (MSCTFIME.@)
+ *
+ * MSCTFIME has no feature of directly registering word.
+ *
+ * @implemented
+ */
 UINT WINAPI
 ImeGetRegisterWordStyle(
     _In_ UINT nItem,
     _Out_ LPSTYLEBUFW lpStyleBuf)
 {
-    FIXME("stub:(%u, %p)\n", nItem, lpStyleBuf);
+    TRACE("(%u, %p)\n", nItem, lpStyleBuf);
     return 0;
 }
 
+/***********************************************************************
+ *      ImeEnumRegisterWord (MSCTFIME.@)
+ *
+ * MSCTFIME has no feature of directly registering word.
+ *
+ * @implemented
+ */
 UINT WINAPI
 ImeEnumRegisterWord(
     _In_ REGISTERWORDENUMPROCW lpfnEnumProc,
@@ -70,7 +98,7 @@ ImeEnumRegisterWord(
     _In_opt_ LPCWSTR lpszString,
     _In_opt_ LPVOID lpData)
 {
-    FIXME("stub:(%p, %s, %lu, %s, %p)\n", lpfnEnumProc, debugstr_w(lpszReading),
+    TRACE("(%p, %s, %lu, %s, %p)\n", lpfnEnumProc, debugstr_w(lpszReading),
           dwStyle, debugstr_w(lpszString), lpData);
     return 0;
 }

--- a/dll/ime/msctfime/msctfime.c
+++ b/dll/ime/msctfime/msctfime.c
@@ -27,6 +27,7 @@ ImeInquire(
  * MSCTFIME has no IME conversion-list feature.
  *
  * @implemented
+ * @see ImmGetConversionListW
  */
 DWORD WINAPI
 ImeConversionList(
@@ -46,6 +47,7 @@ ImeConversionList(
  * MSCTFIME has no feature of directly registering word.
  *
  * @implemented
+ * @see ImeUnregisterWord
  */
 BOOL WINAPI
 ImeRegisterWord(
@@ -63,6 +65,7 @@ ImeRegisterWord(
  * MSCTFIME has no feature of directly registering word.
  *
  * @implemented
+ * @see ImeRegisterWord
  */
 BOOL WINAPI
 ImeUnregisterWord(
@@ -80,6 +83,7 @@ ImeUnregisterWord(
  * MSCTFIME has no feature of directly registering word.
  *
  * @implemented
+ * @see ImeRegisterWord
  */
 UINT WINAPI
 ImeGetRegisterWordStyle(
@@ -96,6 +100,7 @@ ImeGetRegisterWordStyle(
  * MSCTFIME has no feature of directly registering word.
  *
  * @implemented
+ * @see ImeRegisterWord
  */
 UINT WINAPI
 ImeEnumRegisterWord(
@@ -135,6 +140,7 @@ ImeDestroy(
  * MSCTFIME has no IME Escape feature.
  *
  * @implemented
+ * @see CtfImeEscapeEx
  */
 LRESULT WINAPI
 ImeEscape(
@@ -163,6 +169,7 @@ ImeProcessKey(
  * MSCTFIME's ImeSelect does nothing.
  *
  * @implemented
+ * @see CtfImeSelectEx
  */
 BOOL WINAPI
 ImeSelect(
@@ -179,6 +186,7 @@ ImeSelect(
  * MSCTFIME's ImeSetActiveContext does nothing.
  *
  * @implemented
+ * @see CtfImeSetActiveContextAlways
  */
 BOOL WINAPI
 ImeSetActiveContext(

--- a/dll/ime/msctfime/msctfime.c
+++ b/dll/ime/msctfime/msctfime.c
@@ -132,7 +132,7 @@ ImeDestroy(
 /***********************************************************************
  *      ImeEscape (MSCTFIME.@)
  *
- * MSCTFIME has no Escape feature.
+ * MSCTFIME has no IME Escape feature.
  *
  * @implemented
  */

--- a/dll/ime/msctfime/msctfime.c
+++ b/dll/ime/msctfime/msctfime.c
@@ -44,7 +44,7 @@ ImeConversionList(
 /***********************************************************************
  *      ImeRegisterWord (MSCTFIME.@)
  *
- * MSCTFIME has no feature of directly registering word.
+ * MSCTFIME's ImeRegisterWord does nothing.
  *
  * @implemented
  * @see ImeUnregisterWord
@@ -62,7 +62,7 @@ ImeRegisterWord(
 /***********************************************************************
  *      ImeUnregisterWord (MSCTFIME.@)
  *
- * MSCTFIME has no feature of directly registering word.
+ * MSCTFIME's ImeUnregisterWord does nothing.
  *
  * @implemented
  * @see ImeRegisterWord
@@ -80,7 +80,7 @@ ImeUnregisterWord(
 /***********************************************************************
  *      ImeGetRegisterWordStyle (MSCTFIME.@)
  *
- * MSCTFIME has no feature of directly registering word.
+ * MSCTFIME's ImeGetRegisterWordStyle does nothing.
  *
  * @implemented
  * @see ImeRegisterWord
@@ -97,7 +97,7 @@ ImeGetRegisterWordStyle(
 /***********************************************************************
  *      ImeEnumRegisterWord (MSCTFIME.@)
  *
- * MSCTFIME has no feature of directly registering word.
+ * MSCTFIME's ImeEnumRegisterWord does nothing.
  *
  * @implemented
  * @see ImeRegisterWord

--- a/dll/ime/msctfime/msctfime.c
+++ b/dll/ime/msctfime/msctfime.c
@@ -24,7 +24,7 @@ ImeInquire(
 /***********************************************************************
  *      ImeConversionList (MSCTFIME.@)
  *
- * MSCTFIME has no conversion-list feature.
+ * MSCTFIME has no IME conversion-list feature.
  *
  * @implemented
  */


### PR DESCRIPTION
## Purpose
Implementing missing features...
JIRA issue: [CORE-19360](https://jira.reactos.org/browse/CORE-19360)

## Proposed changes

- Implement `ImeRegisterWord`, `ImeUnregisterWord`, `ImeGetRegisterWordStyle`, `ImeEnumRegisterWord`, `ImeConversionList`, `ImeEscape`, `ImeSelect`, and `ImeSetActiveContext` functions.
- These functions in `MSCTFIME` basically do nothing.

## TODO

- [x] Do build.