### PR TITLE
[NTUSER] Add UserHMSetHandle macro

### DIFF
--- a/win32ss/include/ntuser.h
+++ b/win32ss/include/ntuser.h
@@ -228,6 +228,7 @@ typedef struct _PROCMARKHEAD
 } PROCMARKHEAD, *PPROCMARKHEAD;
 
 #define UserHMGetHandle(obj) ((obj)->head.h)
+#define UserHMSetHandle(obj, handle) ((obj)->head.h = (handle))
 
 /* Window Client Information structure */
 struct _ETHREAD;

--- a/win32ss/user/ntuser/event.c
+++ b/win32ss/user/ntuser/event.c
@@ -371,7 +371,7 @@ NtUserSetWinEventHook(
       InsertTailList(&GlobalEvents->Events, &pEH->Chain);
       GlobalEvents->Counts++;
 
-      UserHMGetHandle(pEH) = Handle;
+      UserHMSetHandle(pEH, Handle);
       pEH->eventMin  = eventMin;
       pEH->eventMax  = eventMax;
       pEH->idProcess = idProcess; // These are cmp'ed

--- a/win32ss/user/ntuser/timer.c
+++ b/win32ss/user/ntuser/timer.c
@@ -57,7 +57,7 @@ CreateTimer(VOID)
   Ret = UserCreateObject(gHandleTable, NULL, NULL, &Handle, TYPE_TIMER, sizeof(TIMER));
   if (Ret)
   {
-     Ret->head.h = Handle;
+     UserHMSetHandle(Ret, Handle);
      InsertTailList(&TimersListHead, &Ret->ptmrList);
   }
 


### PR DESCRIPTION
## Proposed changes
- Add a new `UserHMSetHandle(obj, handle)` macro and use it instead of `UserHMGetHandle(obj) = handle` or `obj->head.h = handle`.