### PR TITLE
[COMCTL32][USER32] Button: Fix DLGC_... handling

### DIFF
--- a/dll/win32/comctl32/button.c
+++ b/dll/win32/comctl32/button.c
@@ -1667,7 +1667,7 @@ static void BUTTON_CheckAutoRadioButton( HWND hwnd )
     {
         if (!sibling) break;
 #ifdef __REACTOS__
-        if ((SendMessageW( sibling, WM_GETDLGCODE, 0, 0 ) & (DLGC_BUTTON | DLGC_RADIOBUTTON)) == (DLGC_BUTTON | DLGC_RADIOBUTTON))
+        if ((SendMessageW(sibling, WM_GETDLGCODE, 0, 0) & (DLGC_BUTTON | DLGC_RADIOBUTTON)) == (DLGC_BUTTON | DLGC_RADIOBUTTON))
             SendMessageW( sibling, BM_SETCHECK, sibling == hwnd ? BST_CHECKED : BST_UNCHECKED, 0 );
 #else
         if ((hwnd != sibling) &&

--- a/dll/win32/comctl32/button.c
+++ b/dll/win32/comctl32/button.c
@@ -1667,7 +1667,7 @@ static void BUTTON_CheckAutoRadioButton( HWND hwnd )
     {
         if (!sibling) break;
 #ifdef __REACTOS__
-        if (SendMessageW( sibling, WM_GETDLGCODE, 0, 0 ) == (DLGC_BUTTON | DLGC_RADIOBUTTON))
+        if ((SendMessageW( sibling, WM_GETDLGCODE, 0, 0 ) & (DLGC_BUTTON | DLGC_RADIOBUTTON)) == (DLGC_BUTTON | DLGC_RADIOBUTTON))
             SendMessageW( sibling, BM_SETCHECK, sibling == hwnd ? BST_CHECKED : BST_UNCHECKED, 0 );
 #else
         if ((hwnd != sibling) &&

--- a/win32ss/user/user32/controls/button.c
+++ b/win32ss/user/user32/controls/button.c
@@ -1197,7 +1197,7 @@ static void BUTTON_CheckAutoRadioButton( HWND hwnd )
     {
         if (!sibling) break;
 #ifdef __REACTOS__
-        if ((SendMessageW( sibling, WM_GETDLGCODE, 0, 0 ) & (DLGC_BUTTON | DLGC_RADIOBUTTON)) == (DLGC_BUTTON | DLGC_RADIOBUTTON))
+        if ((SendMessageW(sibling, WM_GETDLGCODE, 0, 0) & (DLGC_BUTTON | DLGC_RADIOBUTTON)) == (DLGC_BUTTON | DLGC_RADIOBUTTON))
 #else
         if (SendMessageW( sibling, WM_GETDLGCODE, 0, 0 ) == (DLGC_BUTTON | DLGC_RADIOBUTTON))
 #endif

--- a/win32ss/user/user32/controls/button.c
+++ b/win32ss/user/user32/controls/button.c
@@ -1196,7 +1196,11 @@ static void BUTTON_CheckAutoRadioButton( HWND hwnd )
     do
     {
         if (!sibling) break;
+#ifdef __REACTOS__
+        if ((SendMessageW( sibling, WM_GETDLGCODE, 0, 0 ) & (DLGC_BUTTON | DLGC_RADIOBUTTON)) == (DLGC_BUTTON | DLGC_RADIOBUTTON))
+#else
         if (SendMessageW( sibling, WM_GETDLGCODE, 0, 0 ) == (DLGC_BUTTON | DLGC_RADIOBUTTON))
+#endif
             SendMessageW( sibling, BM_SETCHECK, sibling == hwnd ? BST_CHECKED : BST_UNCHECKED, 0 );
         sibling = GetNextDlgGroupItem( parent, sibling, FALSE );
     } while (sibling != start);

--- a/win32ss/user/user32/windows/dialog.c
+++ b/win32ss/user/user32/windows/dialog.c
@@ -2642,7 +2642,7 @@ IsDialogMessageW(
                      SetFocus( hwndNext );
                      if ((GetWindowLongW( hwndNext, GWL_STYLE ) & BS_TYPEMASK) == BS_AUTORADIOBUTTON &&
                          SendMessageW( hwndNext, BM_GETCHECK, 0, 0 ) != BST_CHECKED)
-                         SendMessageW( hwndNext, BM_CLICK, 1, 0 );
+                         SendMessageW(hwndNext, BM_CLICK, 0, 0);
                  }
                  else
                      SendMessageW( hDlg, WM_NEXTDLGCTL, (WPARAM)hwndNext, 1 );

--- a/win32ss/user/user32/windows/dialog.c
+++ b/win32ss/user/user32/windows/dialog.c
@@ -2635,7 +2635,9 @@ IsDialogMessageW(
                           break;
                   }
 
-                 if (hwndNext && SendMessageW( hwndNext, WM_GETDLGCODE, lpMsg->wParam, (LPARAM)lpMsg ) == (DLGC_BUTTON | DLGC_RADIOBUTTON))
+                 if (hwndNext &&
+                     ((SendMessageW(hwndNext, WM_GETDLGCODE, lpMsg->wParam, (LPARAM)lpMsg) &
+                       (DLGC_BUTTON | DLGC_RADIOBUTTON)) == (DLGC_BUTTON | DLGC_RADIOBUTTON)))
                  {
                      SetFocus( hwndNext );
                      if ((GetWindowLongW( hwndNext, GWL_STYLE ) & BS_TYPEMASK) == BS_AUTORADIOBUTTON &&


### PR DESCRIPTION
## Purpose

Based on KRosUser's `button.patch`.
JIRA issue: [CORE-17210](https://jira.reactos.org/browse/CORE-17210)

## Proposed changes

- Fix `DLGC_...` handling by using `&` operator in `BUTTON_CheckAutoRadioButton` in `button.c`.
- Fix `DLGC_...` handling by using `&` operator in `IsDialogMessageW` in `dialog.c`.
- `BM_CLICK`'s `wParam` must be zero.

## TODO

- [x] Do tests.