### PR TITLE
[EXPLORER] Notification area icon improvements

### DIFF
--- a/base/shell/explorer/precomp.h
+++ b/base/shell/explorer/precomp.h
@@ -212,12 +212,13 @@ struct TaskbarSettings
     BOOL bPreferDate;
     BOOL bHideInactiveIcons;
     BOOL bSmallIcons;
-    BOOL bCompactTrayIcons;
+    DWORD dwCompactTrayIcons;
     BOOL bShowDesktopButton;
     TW_STRUCKRECTS2 sr;
 
     BOOL Load();
     BOOL Save();
+    BOOL UseCompactTrayIcons();
 };
 
 extern TaskbarSettings g_TaskbarSettings;

--- a/base/shell/explorer/precomp.h
+++ b/base/shell/explorer/precomp.h
@@ -184,6 +184,14 @@ TrayMessageLoop(IN OUT ITrayWindow *Tray);
  * settings.c
  */
 
+enum TrayIconsMode
+{
+    TIM_Default,
+    TIM_NeverCompact,
+    TIM_AlwaysCompact,
+    TIM_Max = TIM_AlwaysCompact
+};
+
 typedef struct _TW_STUCKRECTS2
 {
     DWORD cbSize;
@@ -204,8 +212,6 @@ typedef struct _TW_STUCKRECTS2
     RECT Rect;
 } TW_STRUCKRECTS2, *PTW_STUCKRECTS2;
 
-#define NeverCompact 1
-#define AlwaysCompact 2
 struct TaskbarSettings
 {
     BOOL bLock;
@@ -214,7 +220,7 @@ struct TaskbarSettings
     BOOL bPreferDate;
     BOOL bHideInactiveIcons;
     BOOL bSmallIcons;
-    DWORD dwCompactTrayIcons;
+    TrayIconsMode eCompactTrayIcons;
     BOOL bShowDesktopButton;
     TW_STRUCKRECTS2 sr;
 
@@ -222,11 +228,11 @@ struct TaskbarSettings
     BOOL Save();
     inline BOOL UseCompactTrayIcons()
     {
-        switch (dwCompactTrayIcons)
+        switch (eCompactTrayIcons)
         {
-            case NeverCompact:
+            case TIM_NeverCompact:
                 return FALSE;
-            case AlwaysCompact:
+            case TIM_AlwaysCompact:
                 return TRUE;
             default:
                 return bSmallIcons;
@@ -235,8 +241,6 @@ struct TaskbarSettings
 };
 
 extern TaskbarSettings g_TaskbarSettings;
-#undef NeverCompact
-#undef AlwaysCompact
 
 /*
  * shellservice.cpp

--- a/base/shell/explorer/precomp.h
+++ b/base/shell/explorer/precomp.h
@@ -204,6 +204,8 @@ typedef struct _TW_STUCKRECTS2
     RECT Rect;
 } TW_STRUCKRECTS2, *PTW_STUCKRECTS2;
 
+#define NeverCompact 1
+#define AlwaysCompact 2
 struct TaskbarSettings
 {
     BOOL bLock;
@@ -218,10 +220,23 @@ struct TaskbarSettings
 
     BOOL Load();
     BOOL Save();
-    BOOL UseCompactTrayIcons();
+    inline BOOL UseCompactTrayIcons()
+    {
+        switch (dwCompactTrayIcons)
+        {
+            case NeverCompact:
+                return FALSE;
+            case AlwaysCompact:
+                return TRUE;
+            default:
+                return bSmallIcons;
+        }
+    }
 };
 
 extern TaskbarSettings g_TaskbarSettings;
+#undef NeverCompact
+#undef AlwaysCompact
 
 /*
  * shellservice.cpp

--- a/base/shell/explorer/settings.cpp
+++ b/base/shell/explorer/settings.cpp
@@ -63,7 +63,10 @@ BOOL TaskbarSettings::Load()
     bSmallIcons = (dwRet == ERROR_SUCCESS) ? (dwValue != 0) : TRUE;
 
     dwRet = SHGetValueW(hkExplorer, L"Advanced", L"CompactTrayIcons", NULL, &dwValue, &cbSize);
-    dwCompactTrayIcons = (dwRet == ERROR_SUCCESS) ? dwValue : 0;
+    if (dwRet == ERROR_SUCCESS && dwValue <= TIM_Max)
+        eCompactTrayIcons = static_cast<TrayIconsMode>(dwValue);
+    else
+        eCompactTrayIcons = TIM_Default;
 
     dwRet = SHGetValueW(hkExplorer, L"Advanced", L"TaskbarSd", NULL, &dwValue, &cbSize);
     bShowDesktopButton = (dwRet == ERROR_SUCCESS) ? (dwValue != 0) : TRUE;

--- a/base/shell/explorer/settings.cpp
+++ b/base/shell/explorer/settings.cpp
@@ -32,7 +32,6 @@ BOOL TaskbarSettings::Save()
     SHSetValueW(hkExplorer, L"Advanced", L"TaskbarSizeMove", REG_DWORD, &bAllowSizeMove, sizeof(bAllowSizeMove));
     sr.cbSize = sizeof(sr);
     SHSetValueW(hkExplorer, L"Advanced", L"TaskbarSmallIcons", REG_DWORD, &bSmallIcons, sizeof(bSmallIcons));
-    SHSetValueW(hkExplorer, L"Advanced", L"CompactTrayIcons", REG_DWORD, &dwCompactTrayIcons, sizeof(dwCompactTrayIcons));
     SHSetValueW(hkExplorer, L"Advanced", L"TaskbarSd", REG_DWORD, &bShowDesktopButton, sizeof(bShowDesktopButton));
     SHSetValueW(hkExplorer, L"StuckRects2", L"Settings", REG_BINARY, &sr, sizeof(sr));
 

--- a/base/shell/explorer/settings.cpp
+++ b/base/shell/explorer/settings.cpp
@@ -92,17 +92,4 @@ BOOL TaskbarSettings::Load()
     return TRUE;
 }
 
-BOOL TaskbarSettings::UseCompactTrayIcons()
-{
-    switch (dwCompactTrayIcons)
-    {
-        case 1:
-            return FALSE;
-        case 2:
-            return TRUE;
-        default:
-            return bSmallIcons;
-    }
-}
-
 /* EOF */

--- a/base/shell/explorer/settings.cpp
+++ b/base/shell/explorer/settings.cpp
@@ -32,7 +32,7 @@ BOOL TaskbarSettings::Save()
     SHSetValueW(hkExplorer, L"Advanced", L"TaskbarSizeMove", REG_DWORD, &bAllowSizeMove, sizeof(bAllowSizeMove));
     sr.cbSize = sizeof(sr);
     SHSetValueW(hkExplorer, L"Advanced", L"TaskbarSmallIcons", REG_DWORD, &bSmallIcons, sizeof(bSmallIcons));
-    SHSetValueW(hkExplorer, L"Advanced", L"CompactTrayIcons", REG_DWORD, &bCompactTrayIcons, sizeof(bCompactTrayIcons));
+    SHSetValueW(hkExplorer, L"Advanced", L"CompactTrayIcons", REG_DWORD, &dwCompactTrayIcons, sizeof(dwCompactTrayIcons));
     SHSetValueW(hkExplorer, L"Advanced", L"TaskbarSd", REG_DWORD, &bShowDesktopButton, sizeof(bShowDesktopButton));
     SHSetValueW(hkExplorer, L"StuckRects2", L"Settings", REG_BINARY, &sr, sizeof(sr));
 
@@ -64,7 +64,7 @@ BOOL TaskbarSettings::Load()
     bSmallIcons = (dwRet == ERROR_SUCCESS) ? (dwValue != 0) : TRUE;
 
     dwRet = SHGetValueW(hkExplorer, L"Advanced", L"CompactTrayIcons", NULL, &dwValue, &cbSize);
-    bCompactTrayIcons = (dwRet == ERROR_SUCCESS) ? (dwValue != 0) : bSmallIcons;
+    dwCompactTrayIcons = (dwRet == ERROR_SUCCESS) ? (dwValue) : 0;
 
     dwRet = SHGetValueW(hkExplorer, L"Advanced", L"TaskbarSd", NULL, &dwValue, &cbSize);
     bShowDesktopButton = (dwRet == ERROR_SUCCESS) ? (dwValue != 0) : TRUE;
@@ -91,6 +91,19 @@ BOOL TaskbarSettings::Load()
     }
 
     return TRUE;
+}
+
+BOOL TaskbarSettings::UseCompactTrayIcons()
+{
+    switch(dwCompactTrayIcons)
+    {
+        case 1:
+            return FALSE;
+        case 2:
+            return TRUE;
+        default:
+            return bSmallIcons;
+    }
 }
 
 /* EOF */

--- a/base/shell/explorer/settings.cpp
+++ b/base/shell/explorer/settings.cpp
@@ -64,7 +64,7 @@ BOOL TaskbarSettings::Load()
     bSmallIcons = (dwRet == ERROR_SUCCESS) ? (dwValue != 0) : TRUE;
 
     dwRet = SHGetValueW(hkExplorer, L"Advanced", L"CompactTrayIcons", NULL, &dwValue, &cbSize);
-    dwCompactTrayIcons = (dwRet == ERROR_SUCCESS) ? (dwValue) : 0;
+    dwCompactTrayIcons = (dwRet == ERROR_SUCCESS) ? dwValue : 0;
 
     dwRet = SHGetValueW(hkExplorer, L"Advanced", L"TaskbarSd", NULL, &dwValue, &cbSize);
     bShowDesktopButton = (dwRet == ERROR_SUCCESS) ? (dwValue != 0) : TRUE;
@@ -95,7 +95,7 @@ BOOL TaskbarSettings::Load()
 
 BOOL TaskbarSettings::UseCompactTrayIcons()
 {
-    switch(dwCompactTrayIcons)
+    switch (dwCompactTrayIcons)
     {
         case 1:
             return FALSE;

--- a/base/shell/explorer/syspager.cpp
+++ b/base/shell/explorer/syspager.cpp
@@ -1259,8 +1259,8 @@ void CNotifyToolbar::Initialize(HWND hWndParent, CBalloonQueue * queue)
 void CNotifyToolbar::RefreshToolbarMetrics(BOOL bForceRefresh = FALSE)
 {
     // Toolbar metrics only needs to be refreshed for the automatic setting and first launch
-    if((g_TaskbarSettings.dwCompactTrayIcons != 1 &&
-        g_TaskbarSettings.dwCompactTrayIcons != 2) ||
+    if ((g_TaskbarSettings.dwCompactTrayIcons != 1 &&
+         g_TaskbarSettings.dwCompactTrayIcons != 2) ||
         bForceRefresh)
     {
         TBMETRICS tbm = {sizeof(tbm)};

--- a/base/shell/explorer/syspager.cpp
+++ b/base/shell/explorer/syspager.cpp
@@ -1259,8 +1259,7 @@ void CNotifyToolbar::Initialize(HWND hWndParent, CBalloonQueue * queue)
 void CNotifyToolbar::RefreshToolbarMetrics(BOOL bForceRefresh = FALSE)
 {
     // Toolbar metrics only needs to be refreshed for the automatic setting and first launch
-    if ((g_TaskbarSettings.dwCompactTrayIcons != 1 &&
-         g_TaskbarSettings.dwCompactTrayIcons != 2) ||
+    if (g_TaskbarSettings.eCompactTrayIcons == TrayIconsMode::TIM_Default ||
         bForceRefresh)
     {
         TBMETRICS tbm = {sizeof(tbm)};

--- a/base/shell/explorer/trayclock.cpp
+++ b/base/shell/explorer/trayclock.cpp
@@ -572,7 +572,7 @@ VOID CTrayClockWnd::PaintLine(IN HDC hDC, IN OUT RECT *rcClient, IN UINT LineNum
         return;
 
     INT HShift = ((IsHorizontal && (VisibleLines <= 1 ||
-                   g_TaskbarSettings.bCompactTrayIcons)) ? 0 : TRAY_CLOCK_WND_SPACING_X);
+                   g_TaskbarSettings.UseCompactTrayIcons())) ? 0 : TRAY_CLOCK_WND_SPACING_X);
 
     TextOut(hDC,
             ((rcClient->right - LineSizes[szLinesIndex].cx) / 2) + HShift,
@@ -684,7 +684,7 @@ LRESULT CTrayClockWnd::OnSize(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHa
     VisibleLines = GetMinimumSize(IsHorizontal, &szClient);
     CurrentSize = szClient;
 
-    InvalidateRect(NULL, TRUE);
+    UpdateWnd();
     return TRUE;
 }
 


### PR DESCRIPTION
## Purpose

Automatically adjusts the spacing of the tray icons according to the small or large taskbar icons setting. Also, a minor bug fix to the clock spacing when switching between taskbar icon sizes.

Jira Issue: [CORE-19380](https://jira.reactos.org/browse/CORE-19380)

## Proposed changes

- Update the ROS-specific `CompactTrayIcons` registry value from a binary yes/no to have three states. The three states are as follows:

> 0 (default) - Automatic. When small taskbar icons are used, the notification area will use compact tray icon spacing. When large taskbar icons are used, the notification area will use larger tray icon spacing. While no version of Windows behaves this way, I believe this is a smart default choice for ReactOS since users wanting large taskbar icons will generally expect larger tray icon spacing, while users with small taskbar icons may want more compact spacing.

> 1 - Never Compact. Regardless of the taskbar icon size setting, the notification area will always use the larger spacing. This follows the behavior of Windows 7 and newer versions.

> 2 - Always Compact. Regardless of the taskbar icon size setting, the notification area will always use the compact spacing. This follows the behavior of Windows Vista and older versions.

- Fix a clock spacing bug that occurs when changing the taskbar size before advancing to the next minute. The taskbar clock now adjusts its spacing when the size of the taskbar changes.

## TODO

- Add a wiki article explaining the `CompactTrayIcons` registry value if this PR is merged.
