### PR TITLE
[SHELL32] CDefaultContextMenu: Fix 3 MSVC 'warning C4805'

### DIFF
--- a/dll/win32/shell32/CDefaultContextMenu.cpp
+++ b/dll/win32/shell32/CDefaultContextMenu.cpp
@@ -540,7 +540,7 @@ CDefaultContextMenu::AddStaticContextMenusToMenu(
         }
 
         UINT cmdFlags = 0;
-        BOOL hide = FALSE;
+        bool hide = false;
         HKEY hkVerb;
         if (idResource > 0)
         {
@@ -585,12 +585,13 @@ CDefaultContextMenu::AddStaticContextMenusToMenu(
             // FIXME: GetAsyncKeyState should not be called here, clients
             // need to be updated to set the CMF_EXTENDEDVERBS flag.
             if (!(uFlags & CMF_EXTENDEDVERBS) && GetAsyncKeyState(VK_SHIFT) >= 0)
-                hide |= RegValueExists(hkVerb, L"Extended");
+                hide = RegValueExists(hkVerb, L"Extended");
 
-            hide |= RegValueExists(hkVerb, L"ProgrammaticAccessOnly");
+            if (!hide)
+                hide = RegValueExists(hkVerb, L"ProgrammaticAccessOnly");
 
-            if (!(uFlags & CMF_DISABLEDVERBS))
-                hide |= RegValueExists(hkVerb, L"LegacyDisable");
+            if (!hide && !(uFlags & CMF_DISABLEDVERBS))
+                hide = RegValueExists(hkVerb, L"LegacyDisable");
 
             if (RegValueExists(hkVerb, L"NeverDefault"))
                 fState &= ~MFS_DEFAULT;
@@ -1273,8 +1274,7 @@ CDefaultContextMenu::InvokeRegVerb(
                 /* In WinXP if we have browsed, we don't open any more folders.
                  * In Win7 we browse to the first folder we find and
                  * open new windows for each of the rest of the folders */
-                UINT ntver = RosGetProcessEffectiveVersion();
-                if (ntver >= _WIN32_WINNT_VISTA)
+                if (RosGetProcessEffectiveVersion() >= _WIN32_WINNT_VISTA)
                     wFlags = 0; // FIXME: = SBSP_NEWBROWSER | (wFlags & ~SBSP_SAMEBROWSER);
                 else
                     i = m_cidl;

--- a/sdk/include/reactos/compat_undoc.h
+++ b/sdk/include/reactos/compat_undoc.h
@@ -38,12 +38,14 @@ static
 inline
 UINT RosGetProcessEffectiveVersion(VOID)
 {
-    PPEB peb = NtCurrentPeb();
     UINT shimVer = RosGetProcessCompatVersion();
-    if (shimVer)
-        return shimVer;
-    else
-        return (peb->OSMajorVersion << 8) | (peb->OSMinorVersion);
+    if (!shimVer)
+    {
+        PPEB peb = NtCurrentPeb();
+        return (peb->OSMajorVersion << 8) | peb->OSMinorVersion;
+    }
+
+    return shimVer;
 }
 
 BOOL


### PR DESCRIPTION
## Purpose

```
...\dll\win32\shell32\CDefaultContextMenu.cpp(588): warning C4805: '|=': unsafe mix of type 'BOOL' and type 'bool' in operation
...\dll\win32\shell32\CDefaultContextMenu.cpp(590): warning C4805: '|=': unsafe mix of type 'BOOL' and type 'bool' in operation
...\dll\win32\shell32\CDefaultContextMenu.cpp(593): warning C4805: '|=': unsafe mix of type 'BOOL' and type 'bool' in operation
```

Addendum to 7fb91d9 (0.4.15-dev-6915).

## Proposed changes

- Use 'bool' type.
- Do not abuse '|=' operator.

And clarify RosGetProcessEffectiveVersion() a bit.