### PR TITLE
[SHELL32] AddStaticContextMenusToMenu(): Fix 3 MSVC 'warning C4805'

### DIFF
--- a/dll/win32/shell32/CDefaultContextMenu.cpp
+++ b/dll/win32/shell32/CDefaultContextMenu.cpp
@@ -540,7 +540,7 @@ CDefaultContextMenu::AddStaticContextMenusToMenu(
         }
 
         UINT cmdFlags = 0;
-        BOOL hide = FALSE;
+        bool hide = false;
         HKEY hkVerb;
         if (idResource > 0)
         {
@@ -585,12 +585,13 @@ CDefaultContextMenu::AddStaticContextMenusToMenu(
             // FIXME: GetAsyncKeyState should not be called here, clients
             // need to be updated to set the CMF_EXTENDEDVERBS flag.
             if (!(uFlags & CMF_EXTENDEDVERBS) && GetAsyncKeyState(VK_SHIFT) >= 0)
-                hide |= RegValueExists(hkVerb, L"Extended");
+                hide = RegValueExists(hkVerb, L"Extended");
 
-            hide |= RegValueExists(hkVerb, L"ProgrammaticAccessOnly");
+            if (!hide)
+                hide = RegValueExists(hkVerb, L"ProgrammaticAccessOnly");
 
-            if (!(uFlags & CMF_DISABLEDVERBS))
-                hide |= RegValueExists(hkVerb, L"LegacyDisable");
+            if (!hide && !(uFlags & CMF_DISABLEDVERBS))
+                hide = RegValueExists(hkVerb, L"LegacyDisable");
 
             if (RegValueExists(hkVerb, L"NeverDefault"))
                 fState &= ~MFS_DEFAULT;


### PR DESCRIPTION
Split off of #6170.

## Purpose

```
...\dll\win32\shell32\CDefaultContextMenu.cpp(588): warning C4805: '|=': unsafe mix of type 'BOOL' and type 'bool' in operation
...\dll\win32\shell32\CDefaultContextMenu.cpp(590): warning C4805: '|=': unsafe mix of type 'BOOL' and type 'bool' in operation
...\dll\win32\shell32\CDefaultContextMenu.cpp(593): warning C4805: '|=': unsafe mix of type 'BOOL' and type 'bool' in operation
```

Addendum to 7fb91d9 (0.4.15-dev-6915).

## Proposed changes

- Use 'bool' type.
- Do not abuse '|=' operator.