### PR TITLE
[VFATFS] FATGetNextDirEntry(): Fix 1 MSVC 'warning C4267'

### DIFF
--- a/drivers/filesystems/vfatfs/direntry.c
+++ b/drivers/filesystems/vfatfs/direntry.c
@@ -460,7 +460,7 @@ FATGetNextDirEntry(
     /* Make sure filename is NULL terminate and calculate length */
     DirContext->LongNameU.Buffer[DirContext->LongNameU.MaximumLength / sizeof(WCHAR) - 1]
         = UNICODE_NULL;
-    DirContext->LongNameU.Length = wcslen(DirContext->LongNameU.Buffer) * sizeof(WCHAR);
+    DirContext->LongNameU.Length = (USHORT)(wcslen(DirContext->LongNameU.Buffer) * sizeof(WCHAR));
 
     /* Init short name */
     vfat8Dot3ToString(&DirContext->DirEntry.Fat, &DirContext->ShortNameU);


### PR DESCRIPTION
## Purpose

`...\drivers\filesystems\vfatfs\direntry.c(463): warning C4267: '=': conversion from 'size_t' to 'USHORT', possible loss of data`

Addendum to 096a694 (r6279).

## Proposed changes

- Explicitly cast.
Ok as the line immediately before writes `UNICODE_NULL` within boundary.