### PR TITLE
[WSHOM.OCX] WshShell::Run intWindowStyle parameter is optional

### DIFF
--- a/dll/win32/wshom.ocx/shell.c
+++ b/dll/win32/wshom.ocx/shell.c
@@ -1261,6 +1261,15 @@ static HRESULT WINAPI WshShell3_Run(IWshShell3 *iface, BSTR cmd, VARIANT *style,
         return E_POINTER;
 
     VariantInit(&s);
+#ifdef __REACTOS__
+    if (is_optional_argument(style))
+    {
+        V_VT(&s) = VT_I4;
+        V_I4(&s) = SW_SHOW;
+        hr = S_OK;
+    }
+    else
+#endif
     hr = VariantChangeType(&s, style, 0, VT_I4);
     if (FAILED(hr))
     {


### PR DESCRIPTION
The last two parameters are [optional](https://learn.microsoft.com/en-us/previous-versions/d5fk67ky(v=vs.85)).

```
' test.vbs
Set objShell = Wscript.CreateObject("Wscript.Shell")
objShell.Run "calc.exe" ' Should work because the arguments are optional
objShell.Run "winver.exe", invalidnumber ' Windows treats this as SW_HIDE because it can convert VT_EMPTY
objShell.Run "notepad.exe", "invalidnumber" ' Windows fails with error
```

Notes:
- The Wine part of the `else` is not indented correctly but I think this is better than duplicating Wine code inside the `#ifdef`?