### PR TITLE
[BROWSEUI] Clear pidlLastParsed on CAddressEditBox::Execute

### DIFF
--- a/dll/win32/browseui/addresseditbox.cpp
+++ b/dll/win32/browseui/addresseditbox.cpp
@@ -318,8 +318,16 @@ HRESULT STDMETHODCALLTYPE CAddressEditBox::Execute(long paramC)
     hr = psf->CompareIDs(0, pidl, pidlLastParsed);
 
     SHFree(pidl);
-    if (hr == 0)
+
+    if (hr == S_OK)
+    {
+        if (pidlLastParsed)
+        {
+            ILFree(pidlLastParsed);
+            pidlLastParsed = NULL;
+        }
         return S_OK;
+    }
 
     /*
      * Attempt to browse to the parsed pidl

--- a/dll/win32/browseui/addresseditbox.cpp
+++ b/dll/win32/browseui/addresseditbox.cpp
@@ -319,7 +319,7 @@ HRESULT STDMETHODCALLTYPE CAddressEditBox::Execute(long paramC)
 
     SHFree(pidl);
 
-    if (hr == S_OK)
+    if (hr == 0)
     {
         if (pidlLastParsed)
         {


### PR DESCRIPTION
## Purpose

Based on KRosUser's `gopidlparsed.patch`.
JIRA issue: [CORE-19019](https://jira.reactos.org/browse/CORE-19019)

## Proposed changes

- Clear `pidlLastParsed` if necessary.

## TODO

- [x] Do tests.