### PR TITLE
[NTUSER] menu.c: Don't use RETURN() macro

### DIFF
--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -6536,7 +6536,7 @@ NtUserThunkedMenuItemInfo(
    PMENU Menu;
    NTSTATUS Status;
    UNICODE_STRING lstrCaption;
-   DECLARE_RETURN(BOOL);
+   BOOL Ret = FALSE;
 
    TRACE("Enter NtUserThunkedMenuItemInfo\n");
    UserEnterExclusive();
@@ -6548,7 +6548,7 @@ NtUserThunkedMenuItemInfo(
 
    if (!(Menu = UserGetMenuObject(hMenu)))
    {
-      RETURN(FALSE);
+      goto Cleanup;
    }
 
    /* Check if we got a Caption */
@@ -6562,23 +6562,27 @@ NtUserThunkedMenuItemInfo(
       {
          ERR("Failed to capture MenuItem Caption (status 0x%08x)\n",Status);
          SetLastNtError(Status);
-         RETURN(FALSE);
+         goto Cleanup;
       }
    }
 
-   if (bInsert) RETURN( UserInsertMenuItem(Menu, uItem, fByPosition, lpmii, &lstrCaption));
+   if (bInsert)
+   {
+      Ret = UserInsertMenuItem(Menu, uItem, fByPosition, lpmii, &lstrCaption);
+      goto Cleanup;
+   }
 
-   RETURN( UserMenuItemInfo(Menu, uItem, fByPosition, (PROSMENUITEMINFO)lpmii, TRUE, &lstrCaption));
+   Ret = UserMenuItemInfo(Menu, uItem, fByPosition, (PROSMENUITEMINFO)lpmii, TRUE, &lstrCaption);
 
-CLEANUP:
+Cleanup:
    if (lstrCaption.Buffer)
    {
       ReleaseCapturedUnicodeString(&lstrCaption, UserMode);
    }
 
-   TRACE("Leave NtUserThunkedMenuItemInfo, ret=%i\n",_ret_);
+   TRACE("Leave NtUserThunkedMenuItemInfo, ret=%i\n", Ret);
    UserLeave();
-   END_CLEANUP;
+   return Ret;
 }
 
 /*

--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -6362,23 +6362,20 @@ NtUserRemoveMenu(
    UINT uFlags)
 {
    PMENU Menu;
-   DECLARE_RETURN(BOOL);
+   BOOL Ret = FALSE;
 
    TRACE("Enter NtUserRemoveMenu\n");
    UserEnterExclusive();
 
-   if(!(Menu = UserGetMenuObject(hMenu)))
+   Menu = UserGetMenuObject(hMenu);
+   if (Menu)
    {
-      RETURN( FALSE);
+      Ret = IntRemoveMenuItem(Menu, uPosition, uFlags, FALSE);
    }
 
-   RETURN(IntRemoveMenuItem(Menu, uPosition, uFlags, FALSE));
-
-CLEANUP:
-   TRACE("Leave NtUserRemoveMenu, ret=%i\n",_ret_);
+   TRACE("Leave NtUserRemoveMenu, ret=%i\n", Ret);
    UserLeave();
-   END_CLEANUP;
-
+   return Ret;
 }
 
 /*

--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -6480,22 +6480,20 @@ NtUserSetMenuFlagRtoL(
    HMENU hMenu)
 {
    PMENU Menu;
-   DECLARE_RETURN(BOOL);
+   BOOL Ret = FALSE;
 
    TRACE("Enter NtUserSetMenuFlagRtoL\n");
    UserEnterExclusive();
 
-   if(!(Menu = UserGetMenuObject(hMenu)))
+   Menu = UserGetMenuObject(hMenu);
+   if (Menu)
    {
-      RETURN( FALSE);
+      Ret = IntSetMenuFlagRtoL(Menu);
    }
 
-   RETURN(IntSetMenuFlagRtoL(Menu));
-
-CLEANUP:
-   TRACE("Leave NtUserSetMenuFlagRtoL, ret=%i\n",_ret_);
+   TRACE("Leave NtUserSetMenuFlagRtoL, ret=%i\n", Ret);
    UserLeave();
-   END_CLEANUP;
+   return Ret;
 }
 
 /*

--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -6430,22 +6430,20 @@ NtUserSetMenuContextHelpId(
    DWORD dwContextHelpId)
 {
    PMENU Menu;
-   DECLARE_RETURN(BOOL);
+   BOOL Ret = FALSE;
 
    TRACE("Enter NtUserSetMenuContextHelpId\n");
    UserEnterExclusive();
 
-   if(!(Menu = UserGetMenuObject(hMenu)))
+   Menu = UserGetMenuObject(hMenu);
+   if (Menu)
    {
-      RETURN( FALSE);
+      Ret = IntSetMenuContextHelpId(Menu, dwContextHelpId);
    }
 
-   RETURN(IntSetMenuContextHelpId(Menu, dwContextHelpId));
-
-CLEANUP:
-   TRACE("Leave NtUserSetMenuContextHelpId, ret=%i\n",_ret_);
+   TRACE("Leave NtUserSetMenuContextHelpId, ret=%i\n", Ret);
    UserLeave();
-   END_CLEANUP;
+   return Ret;
 }
 
 /*

--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -5601,22 +5601,20 @@ NtUserDeleteMenu(
    UINT uFlags)
 {
    PMENU Menu;
-   DECLARE_RETURN(BOOL);
+   BOOL Ret = FALSE;
 
    TRACE("Enter NtUserDeleteMenu\n");
    UserEnterExclusive();
 
-   if(!(Menu = UserGetMenuObject(hMenu)))
+   Menu = UserGetMenuObject(hMenu);
+   if (Menu)
    {
-      RETURN( FALSE);
+      Ret = IntRemoveMenuItem(Menu, uPosition, uFlags, TRUE);
    }
 
-   RETURN( IntRemoveMenuItem(Menu, uPosition, uFlags, TRUE));
-
-CLEANUP:
-   TRACE("Leave NtUserDeleteMenu, ret=%i\n",_ret_);
+   TRACE("Leave NtUserDeleteMenu, ret=%i\n", Ret);
    UserLeave();
-   END_CLEANUP;
+   return Ret;
 }
 
 /*

--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -6272,19 +6272,19 @@ NtUserMenuItemFromPoint(
    PWND Window = NULL;
    PITEM mi;
    ULONG i;
-   DECLARE_RETURN(int);
+   int Ret = -1;
 
    TRACE("Enter NtUserMenuItemFromPoint\n");
    UserEnterExclusive();
 
    if (!(Menu = UserGetMenuObject(hMenu)))
    {
-      RETURN( -1);
+      goto Exit;
    }
 
    if (!(Window = UserGetWindowObject(Menu->hWnd)))
    {
-      RETURN( -1);
+      goto Exit;
    }
 
    X -= Window->rcWindow.left;
@@ -6308,12 +6308,12 @@ NtUserMenuItemFromPoint(
       }
    }
 
-   RETURN( (mi ? i : NO_SELECTED_ITEM));
+   Ret = (mi ? i : NO_SELECTED_ITEM);
 
-CLEANUP:
-   TRACE("Leave NtUserMenuItemFromPoint, ret=%i\n",_ret_);
+Exit:
+   TRACE("Leave NtUserMenuItemFromPoint, ret=%i\n", Ret);
    UserLeave();
-   END_CLEANUP;
+   return Ret;
 }
 
 

--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -5725,7 +5725,6 @@ NtUserGetTitleBarInfo(
 {
     PWND WindowObject;
     TITLEBARINFO bartitleinfo;
-    DECLARE_RETURN(BOOLEAN);
     BOOLEAN retValue = TRUE;
 
     TRACE("Enter NtUserGetTitleBarInfo\n");
@@ -5774,12 +5773,9 @@ NtUserGetTitleBarInfo(
         }
     }
 
-    RETURN( retValue );
-
-CLEANUP:
-    TRACE("Leave NtUserGetTitleBarInfo, ret=%u\n",_ret_);
+    TRACE("Leave NtUserGetTitleBarInfo, ret=%u\n", retValue);
     UserLeave();
-    END_CLEANUP;
+    return retValue;
 }
 
 /*

--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -5839,22 +5839,20 @@ NtUserEnableMenuItem(
    UINT uEnable)
 {
    PMENU Menu;
-   DECLARE_RETURN(UINT);
+   UINT Ret = (UINT)-1;
 
    TRACE("Enter NtUserEnableMenuItem\n");
    UserEnterExclusive();
 
-   if(!(Menu = UserGetMenuObject(hMenu)))
+   Menu = UserGetMenuObject(hMenu);
+   if (Menu)
    {
-      RETURN(-1);
+      Ret = IntEnableMenuItem(Menu, uIDEnableItem, uEnable);
    }
 
-   RETURN( IntEnableMenuItem(Menu, uIDEnableItem, uEnable));
-
-CLEANUP:
-   TRACE("Leave NtUserEnableMenuItem, ret=%u\n",_ret_);
+   TRACE("Leave NtUserEnableMenuItem, ret=%u\n", Ret);
    UserLeave();
-   END_CLEANUP;
+   return Ret;
 }
 
 /*

--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -6389,19 +6389,19 @@ NtUserSetMenu(
 {
    PWND Window;
    BOOL Changed;
-   DECLARE_RETURN(BOOL);
+   BOOL Ret = FALSE;
 
    TRACE("Enter NtUserSetMenu\n");
    UserEnterExclusive();
 
    if (!(Window = UserGetWindowObject(hWnd)))
    {
-      RETURN( FALSE);
+      goto Exit;
    }
 
    if (!IntSetMenu(Window, Menu, &Changed))
    {
-      RETURN( FALSE);
+      goto Exit;
    }
 
    // Not minimized and please repaint!!!
@@ -6413,12 +6413,12 @@ NtUserSetMenu(
       UserDerefObjectCo(Window);
    }
 
-   RETURN( TRUE);
+   Ret = TRUE;
 
-CLEANUP:
-   TRACE("Leave NtUserSetMenu, ret=%i\n",_ret_);
+Exit:
+   TRACE("Leave NtUserSetMenu, ret=%i\n", Ret);
    UserLeave();
-   END_CLEANUP;
+   return Ret;
 }
 
 /*

--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -6456,22 +6456,20 @@ NtUserSetMenuDefaultItem(
    UINT fByPos)
 {
    PMENU Menu;
-   DECLARE_RETURN(BOOL);
+   BOOL Ret = FALSE;
 
    TRACE("Enter NtUserSetMenuDefaultItem\n");
    UserEnterExclusive();
 
-   if(!(Menu = UserGetMenuObject(hMenu)))
+   Menu = UserGetMenuObject(hMenu);
+   if (Menu)
    {
-      RETURN( FALSE);
+      Ret = UserSetMenuDefaultItem(Menu, uItem, fByPos);
    }
 
-   RETURN( UserSetMenuDefaultItem(Menu, uItem, fByPos));
-
-CLEANUP:
-   TRACE("Leave NtUserSetMenuDefaultItem, ret=%i\n",_ret_);
+   TRACE("Leave NtUserSetMenuDefaultItem, ret=%i\n", Ret);
    UserLeave();
-   END_CLEANUP;
+   return Ret;
 }
 
 /*

--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -6095,14 +6095,14 @@ NtUserGetMenuItemRect(
    PMENU Menu;
    PITEM MenuItem;
    NTSTATUS Status = STATUS_SUCCESS;
-   DECLARE_RETURN(BOOL);
+   BOOL Ret = FALSE;
 
    TRACE("Enter NtUserGetMenuItemRect\n");
    UserEnterShared();
 
    if (!(Menu = UserGetMenuObject(hMenu)))
    {
-      RETURN(FALSE);
+      goto Exit;
    }
 
    if ((MenuItem = MENU_FindItem (&Menu, &uItem, MF_BYPOSITION)))
@@ -6113,16 +6113,16 @@ NtUserGetMenuItemRect(
       Rect.bottom = MenuItem->cyItem;
    }
    else
-      RETURN(FALSE);
+      goto Exit;
 
    if(!hWnd)
    {
        hWnd = Menu->hWnd;
    }
 
-   if (lprcItem == NULL) RETURN( FALSE);
+   if (lprcItem == NULL) goto Exit;
 
-   if (!(ReferenceWnd = UserGetWindowObject(hWnd))) RETURN( FALSE);
+   if (!(ReferenceWnd = UserGetWindowObject(hWnd))) goto Exit;
 
    if (Menu->fFlags & MNF_POPUP)
    {
@@ -6153,14 +6153,14 @@ NtUserGetMenuItemRect(
    if (!NT_SUCCESS(Status))
    {
       SetLastNtError(Status);
-      RETURN(FALSE);
+      goto Exit;
    }
-   RETURN(TRUE);
+   Ret = TRUE;
 
-CLEANUP:
-   TRACE("Leave NtUserGetMenuItemRect, ret=%i\n",_ret_);
+Exit:
+   TRACE("Leave NtUserGetMenuItemRect, ret=%i\n", Ret);
    UserLeave();
-   END_CLEANUP;
+   return Ret;
 }
 
 /*

--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -6175,7 +6175,7 @@ NtUserHiliteMenuItem(
 {
    PMENU Menu;
    PWND Window;
-   DECLARE_RETURN(BOOLEAN);
+   BOOL Ret = FALSE;
 
    TRACE("Enter NtUserHiliteMenuItem\n");
    UserEnterExclusive();
@@ -6183,21 +6183,21 @@ NtUserHiliteMenuItem(
    if(!(Window = UserGetWindowObject(hWnd)))
    {
       EngSetLastError(ERROR_INVALID_WINDOW_HANDLE);
-      RETURN(FALSE);
+      goto Exit;
    }
 
    if(!(Menu = UserGetMenuObject(hMenu)))
    {
       EngSetLastError(ERROR_INVALID_MENU_HANDLE);
-      RETURN(FALSE);
+      goto Exit;
    }
 
-   RETURN( IntHiliteMenuItem(Window, Menu, uItemHilite, uHilite));
+   Ret = IntHiliteMenuItem(Window, Menu, uItemHilite, uHilite);
 
-CLEANUP:
-   TRACE("Leave NtUserHiliteMenuItem, ret=%u\n",_ret_);
+Exit:
+   TRACE("Leave NtUserHiliteMenuItem, ret=%i\n", Ret);
    UserLeave();
-   END_CLEANUP;
+   return Ret;
 }
 
 /*

--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -5649,27 +5649,27 @@ NtUserGetSystemMenu(HWND hWnd, BOOL bRevert)
 {
    PWND Window;
    PMENU Menu;
-   DECLARE_RETURN(HMENU);
+   HMENU Ret = NULL;
 
    TRACE("Enter NtUserGetSystemMenu\n");
    UserEnterExclusive();
 
    if (!(Window = UserGetWindowObject(hWnd)))
    {
-      RETURN(NULL);
+      goto Exit;
    }
 
    if (!(Menu = IntGetSystemMenu(Window, bRevert)))
    {
-      RETURN(NULL);
+      goto Exit;
    }
 
-   RETURN(Menu->head.h);
+   Ret = UserHMGetHandle(Menu);
 
-CLEANUP:
-   TRACE("Leave NtUserGetSystemMenu, ret=%p\n", _ret_);
+Exit:
+   TRACE("Leave NtUserGetSystemMenu, ret=%p\n", Ret);
    UserLeave();
-   END_CLEANUP;
+   return Ret;
 }
 
 /*

--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -5685,14 +5685,13 @@ NtUserSetSystemMenu(HWND hWnd, HMENU hMenu)
    BOOL Result = FALSE;
    PWND Window;
    PMENU Menu;
-   DECLARE_RETURN(BOOL);
 
    TRACE("Enter NtUserSetSystemMenu\n");
    UserEnterExclusive();
 
    if (!(Window = UserGetWindowObject(hWnd)))
    {
-      RETURN( FALSE);
+      goto Exit;
    }
 
    if (hMenu)
@@ -5702,7 +5701,7 @@ NtUserSetSystemMenu(HWND hWnd, HMENU hMenu)
        */
       if (!(Menu = IntGetMenuObject(hMenu)))
       {
-         RETURN( FALSE);
+         goto Exit;
       }
 
       Result = IntSetSystemMenu(Window, Menu);
@@ -5710,12 +5709,10 @@ NtUserSetSystemMenu(HWND hWnd, HMENU hMenu)
    else
       EngSetLastError(ERROR_INVALID_MENU_HANDLE);
 
-   RETURN( Result);
-
-CLEANUP:
-   TRACE("Leave NtUserSetSystemMenu, ret=%i\n",_ret_);
+Exit:
+   TRACE("Leave NtUserSetSystemMenu, ret=%i\n", Result);
    UserLeave();
-   END_CLEANUP;
+   return Result;
 }
 
 /*

--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -6216,7 +6216,7 @@ NtUserDrawMenuBarTemp(
    PWND Window;
    RECT Rect;
    NTSTATUS Status = STATUS_SUCCESS;
-   DECLARE_RETURN(DWORD);
+   DWORD Ret = 0;
 
    ERR("Enter NtUserDrawMenuBarTemp\n");
    UserEnterExclusive();
@@ -6224,13 +6224,13 @@ NtUserDrawMenuBarTemp(
    if(!(Window = UserGetWindowObject(hWnd)))
    {
       EngSetLastError(ERROR_INVALID_WINDOW_HANDLE);
-      RETURN(0);
+      goto Exit;
    }
 
    if(!(Menu = UserGetMenuObject(hMenu)))
    {
       EngSetLastError(ERROR_INVALID_MENU_HANDLE);
-      RETURN(0);
+      goto Exit;
    }
 
    _SEH2_TRY
@@ -6247,15 +6247,15 @@ NtUserDrawMenuBarTemp(
    if (Status != STATUS_SUCCESS)
    {
       SetLastNtError(Status);
-      RETURN(0);
+      goto Exit;
    }
 
-   RETURN( IntDrawMenuBarTemp(Window, hDC, &Rect, Menu, hFont));
+   Ret = IntDrawMenuBarTemp(Window, hDC, &Rect, Menu, hFont);
 
-CLEANUP:
-   ERR("Leave NtUserDrawMenuBarTemp, ret=%u\n",_ret_);
+Exit:
+   ERR("Leave NtUserDrawMenuBarTemp, ret=%lu\n", Ret);
    UserLeave();
-   END_CLEANUP;
+   return Ret;
 }
 
 /*

--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -5075,7 +5075,7 @@ IntMenuItemInfo(
    if (!(MenuItem = MENU_FindItem( &Menu, &Item, (ByPosition ? MF_BYPOSITION : MF_BYCOMMAND) )))
    {
       EngSetLastError(ERROR_MENU_ITEM_NOT_FOUND);
-      return( FALSE);
+      return FALSE;
    }
    if (SetOrGet)
    {
@@ -5085,7 +5085,7 @@ IntMenuItemInfo(
    {
       Ret = IntGetMenuItemInfo(Menu, MenuItem, ItemInfo);
    }
-   return( Ret);
+   return Ret;
 }
 
 BOOL FASTCALL
@@ -5107,20 +5107,20 @@ UserMenuItemInfo(
    if (! NT_SUCCESS(Status))
    {
       SetLastNtError(Status);
-      return( FALSE);
+      return FALSE;
    }
    if ( Size != sizeof(MENUITEMINFOW) && 
         Size != FIELD_OFFSET(MENUITEMINFOW, hbmpItem) &&
         Size != sizeof(ROSMENUITEMINFO) )
    {
       EngSetLastError(ERROR_INVALID_PARAMETER);
-      return( FALSE);
+      return FALSE;
    }
    Status = MmCopyFromCaller(&ItemInfo, UnsafeItemInfo, Size);
    if (! NT_SUCCESS(Status))
    {
       SetLastNtError(Status);
-      return( FALSE);
+      return FALSE;
    }
    /* If this is a pre-0x0500 _WIN32_WINNT MENUITEMINFOW, you can't
       set/get hbmpItem */
@@ -5128,7 +5128,7 @@ UserMenuItemInfo(
          && 0 != (ItemInfo.fMask & MIIM_BITMAP))
    {
       EngSetLastError(ERROR_INVALID_PARAMETER);
-      return( FALSE);
+      return FALSE;
    }
 
    if (!(MenuItem = MENU_FindItem( &Menu, &Item, (ByPosition ? MF_BYPOSITION : MF_BYCOMMAND) )))
@@ -5138,7 +5138,7 @@ UserMenuItemInfo(
          return TRUE;
 
       EngSetLastError(ERROR_MENU_ITEM_NOT_FOUND);
-      return( FALSE);
+      return FALSE;
    }
 
    if (SetOrGet)
@@ -5154,12 +5154,12 @@ UserMenuItemInfo(
          if (! NT_SUCCESS(Status))
          {
             SetLastNtError(Status);
-            return( FALSE);
+            return FALSE;
          }
       }
    }
 
-   return( Ret);
+   return Ret;
 }
 
 BOOL FASTCALL
@@ -5177,18 +5177,18 @@ UserMenuInfo(
    if (! NT_SUCCESS(Status))
    {
       SetLastNtError(Status);
-      return( FALSE);
+      return FALSE;
    }
    if ( Size < sizeof(MENUINFO) || Size > sizeof(ROSMENUINFO) )
    {
       EngSetLastError(ERROR_INVALID_PARAMETER);
-      return( FALSE);
+      return FALSE;
    }
    Status = MmCopyFromCaller(&MenuInfo, UnsafeMenuInfo, Size);
    if (! NT_SUCCESS(Status))
    {
       SetLastNtError(Status);
-      return( FALSE);
+      return FALSE;
    }
 
    if(SetOrGet)
@@ -5206,12 +5206,12 @@ UserMenuInfo(
          if (! NT_SUCCESS(Status))
          {
             SetLastNtError(Status);
-            return( FALSE);
+            return FALSE;
          }
       }
    }
 
-   return( Res);
+   return Res;
 }
 
 BOOL FASTCALL

--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -5575,22 +5575,20 @@ NtUserCheckMenuItem(
    UINT uCheck)
 {
    PMENU Menu;
-   DECLARE_RETURN(DWORD);
+   DWORD Ret = (DWORD)-1;
 
    TRACE("Enter NtUserCheckMenuItem\n");
    UserEnterExclusive();
 
-   if(!(Menu = UserGetMenuObject(hMenu)))
+   Menu = UserGetMenuObject(hMenu);
+   if (Menu)
    {
-      RETURN( (DWORD)-1);
+      Ret = IntCheckMenuItem(Menu, uIDCheckItem, uCheck);
    }
 
-   RETURN( IntCheckMenuItem(Menu, uIDCheckItem, uCheck));
-
-CLEANUP:
-   TRACE("Leave NtUserCheckMenuItem, ret=%lu\n",_ret_);
+   TRACE("Leave NtUserCheckMenuItem, ret=%lu\n", Ret);
    UserLeave();
-   END_CLEANUP;
+   return Ret;
 }
 
 /*

--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -6505,22 +6505,20 @@ NtUserThunkedMenuInfo(
    LPCMENUINFO lpcmi)
 {
    PMENU Menu;
-   DECLARE_RETURN(BOOL);
+   BOOL Ret = FALSE;
 
    TRACE("Enter NtUserThunkedMenuInfo\n");
    UserEnterExclusive();
 
-   if (!(Menu = UserGetMenuObject(hMenu)))
+   Menu = UserGetMenuObject(hMenu);
+   if (Menu)
    {
-      RETURN(FALSE);
+      Ret = UserMenuInfo(Menu, (PROSMENUINFO)lpcmi, TRUE);
    }
 
-   RETURN(UserMenuInfo(Menu, (PROSMENUINFO)lpcmi, TRUE));
-
-CLEANUP:
-   TRACE("Leave NtUserThunkedMenuInfo, ret=%i\n",_ret_);
+   TRACE("Leave NtUserThunkedMenuInfo, ret=%i\n", Ret);
    UserLeave();
-   END_CLEANUP;
+   return Ret;
 }
 
 /*

--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -5807,26 +5807,26 @@ NtUserDestroyMenu(
    HMENU hMenu)
 {
    PMENU Menu;
-   DECLARE_RETURN(BOOL);
+   BOOL Ret = FALSE;
 
    TRACE("Enter NtUserDestroyMenu\n");
    UserEnterExclusive();
 
    if(!(Menu = UserGetMenuObject(hMenu)))
    {
-      RETURN( FALSE);
+      goto Exit;
    }
    if (Menu->head.rpdesk != gptiCurrent->rpdesk)
    {
       EngSetLastError(ERROR_ACCESS_DENIED);
-      RETURN( FALSE);
+      goto Exit;
    }
-   RETURN( IntDestroyMenuObject(Menu, TRUE));
+   Ret = IntDestroyMenuObject(Menu, TRUE);
 
-CLEANUP:
-   TRACE("Leave NtUserDestroyMenu, ret=%i\n",_ret_);
+Exit:
+   TRACE("Leave NtUserDestroyMenu, ret=%i\n", Ret);
    UserLeave();
-   END_CLEANUP;
+   return Ret;
 }
 
 /*

--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -6054,27 +6054,29 @@ NtUserGetMenuIndex(
    PMENU Menu, SubMenu;
    PITEM MenuItem;
    UINT i;
-   DECLARE_RETURN(UINT);
+   UINT Ret = 0xFFFFFFFF;
 
    TRACE("Enter NtUserGetMenuIndex\n");
    UserEnterShared();
 
    if ( !(Menu = UserGetMenuObject(hMenu)) ||
         !(SubMenu = UserGetMenuObject(hSubMenu)) )
-      RETURN(0xFFFFFFFF);
+      goto Exit;
 
    MenuItem = Menu->rgItems;
    for (i = 0; i < Menu->cItems; i++, MenuItem++)
    {
        if (MenuItem->spSubMenu == SubMenu)
-          RETURN(MenuItem->wID);
+       {
+          Ret = MenuItem->wID;
+          break;
+       }
    }
-   RETURN(0xFFFFFFFF);
 
-CLEANUP:
-   TRACE("Leave NtUserGetMenuIndex, ret=%u\n",_ret_);
+Exit:
+   TRACE("Leave NtUserGetMenuIndex, ret=%u\n", Ret);
    UserLeave();
-   END_CLEANUP;
+   return Ret;
 }
 
 /*


### PR DESCRIPTION
## Purposed changes
- Don't use RETURN() macro
- Remove parentheses around return value