### PR TITLE
[LDR][NDK] Fix inconsistent Cookie type

### DIFF
--- a/dll/ntdll/def/ntdll.spec
+++ b/dll/ntdll/def/ntdll.spec
@@ -184,7 +184,7 @@
 @ stdcall LdrUnloadAlternateResourceModule(ptr)
 @ stub -version=0x600+ LdrUnloadAlternateResourceModuleEx
 @ stdcall LdrUnloadDll(ptr)
-@ stdcall LdrUnlockLoaderLock(long long)
+@ stdcall LdrUnlockLoaderLock(long ptr)
 @ stdcall -stub -version=0x600+ LdrUnregisterDllNotification(ptr)
 @ stdcall LdrVerifyImageMatchesChecksum(ptr long long long)
 @ stdcall -stub -version=0x600+ LdrVerifyImageMatchesChecksumEx(ptr ptr)

--- a/dll/ntdll/ldr/ldrapi.c
+++ b/dll/ntdll/ldr/ldrapi.c
@@ -100,7 +100,7 @@ NTSTATUS
 NTAPI
 LdrUnlockLoaderLock(
     _In_ ULONG Flags,
-    _In_opt_ ULONG Cookie)
+    _In_opt_ ULONG_PTR Cookie)
 {
     NTSTATUS Status = STATUS_SUCCESS;
 

--- a/dll/ntdll/ldr/ldrapi.c
+++ b/dll/ntdll/ldr/ldrapi.c
@@ -104,7 +104,7 @@ LdrUnlockLoaderLock(
 {
     NTSTATUS Status = STATUS_SUCCESS;
 
-    DPRINT("LdrUnlockLoaderLock(%x %x)\n", Flags, Cookie);
+    DPRINT("LdrUnlockLoaderLock(%x %Ix)\n", Flags, Cookie);
 
     /* Check for valid flags */
     if (Flags & ~LDR_UNLOCK_LOADER_LOCK_FLAG_RAISE_ON_ERRORS)

--- a/sdk/include/ndk/ldrfuncs.h
+++ b/sdk/include/ndk/ldrfuncs.h
@@ -119,7 +119,7 @@ NTSTATUS
 NTAPI
 LdrUnlockLoaderLock(
     _In_ ULONG Flags,
-    _In_opt_ ULONG Cookie
+    _In_opt_ ULONG_PTR Cookie
 );
 
 BOOLEAN


### PR DESCRIPTION
## Purpose

Make `LdrUnlockLoaderLock` `Cookie` type consistent with `LdrLockLoaderLock` and `LdrpMakeCookie` functions.

Truncating to a `ULONG` happens to work on ReactOS. However, testing on Windows 10 `LdrUnlockLoaderLock` fails to unlock loader lock unless you change the prototype such that `Cookie` is a `ULONG_PTR`. A `ULONG_PTR` is also what's used by Wine.