### PR TITLE
[WINESYNC] Use --no-autoconf otherwise running time is too long.

### DIFF
--- a/sdk/tools/winesync/winesync.py
+++ b/sdk/tools/winesync/winesync.py
@@ -94,9 +94,9 @@ class wine_sync:
                 self.wine_staging_repo.reset(wine_staging_target_commit, pygit2.GIT_RESET_HARD)
 
                 # run the wine-staging script
-                if subprocess.call(['python', self.wine_staging_src + '/staging/patchinstall.py', 'DESTDIR=' + self.wine_src, '--all', '--backend=git-am']):
+                if subprocess.call(['python', self.wine_staging_src + '/staging/patchinstall.py', 'DESTDIR=' + self.wine_src, '--all', '--backend=git-am', '--no-autoconf']):
                     # the new script failed (it doesn't exist?), try the old one
-                    subprocess.call(['bash', '-c', self.wine_staging_src + '/patches/patchinstall.sh DESTDIR=' + self.wine_src + ' --all --backend=git-am'])
+                    subprocess.call(['bash', '-c', self.wine_staging_src + '/patches/patchinstall.sh DESTDIR=' + self.wine_src + ' --all --backend=git-am --no-autoconf'])
 
                 # delete the branch we created
                 self.wine_staging_repo.checkout(self.wine_staging_repo.lookup_branch('master'))


### PR DESCRIPTION
## Purpose

For whatever reason, when wine-syncing with wine-staging, everytime one needs to restart the sync-script the sub-script is called and tries to run the autoconf, which takes ages to run.
I disable the running of autoconf by adding this switch to the called sub-script command-line.

But this still needs to be investigated further, this is why this commit has been split from PR #5898 .