### PR TITLE
[MSCTFIME][SDK] Implement CtfImeGuidAtom

### DIFF
--- a/dll/ime/msctfime/msctfime.cpp
+++ b/dll/ime/msctfime/msctfime.cpp
@@ -82,6 +82,38 @@ IsInteractiveUserLogon(VOID)
     return bOK && IsMember;
 }
 
+class CicInputContext
+{
+public:
+    HRESULT
+    GetGuidAtom(
+        _Inout_ IMCLock& imcLock,
+        _In_ DWORD dwUnknown,
+        _Out_opt_ LPDWORD pdwGuidAtom);
+};
+
+/**
+ * @unimplemented
+ */
+HRESULT
+CicInputContext::GetGuidAtom(
+    _Inout_ IMCLock& imcLock,
+    _In_ DWORD dwUnknown,
+    _Out_opt_ LPDWORD pdwGuidAtom)
+{
+    InternalIMCCLock<CTFIMECONTEXT> imeContext(imcLock.m_pIC->hCompStr);
+
+    HRESULT hr = imeContext.m_hr;
+    if (!imeContext)
+        hr = E_FAIL;
+
+    if (FAILED(hr))
+        return hr;
+
+    // FIXME
+    return hr;
+}
+
 /**
  * @implemented
  */
@@ -756,14 +788,39 @@ CtfImeEscapeEx(
     return 0;
 }
 
+/***********************************************************************
+ *      CtfImeGetGuidAtom (MSCTFIME.@)
+ *
+ * @implemented
+ */
 EXTERN_C HRESULT WINAPI
 CtfImeGetGuidAtom(
     _In_ HIMC hIMC,
     _In_ DWORD dwUnknown,
     _Out_opt_ LPDWORD pdwGuidAtom)
 {
-    FIXME("stub:(%p, 0x%lX, %p)\n", hIMC, dwUnknown, pdwGuidAtom);
-    return E_FAIL;
+    TRACE("(%p, 0x%lX, %p)\n", hIMC, dwUnknown, pdwGuidAtom);
+
+    IMCLock imcLock(hIMC);
+
+    HRESULT hr = imcLock.m_hr;
+    if (!imcLock)
+        hr = E_FAIL;
+    if (FAILED(hr))
+        return hr;
+
+    InternalIMCCLock<CTFIMECONTEXT> imccLock(imcLock.m_pIC->hCtfImeContext);
+    hr = imccLock.m_hr;
+    if (!imccLock)
+        hr = E_FAIL;
+    if (FAILED(hr))
+        return hr;
+
+    if (!imccLock.m_pIMCC->m_pCicIC)
+        return E_OUTOFMEMORY;
+
+    hr = imccLock.m_pIMCC->m_pCicIC->GetGuidAtom(imcLock, dwUnknown, pdwGuidAtom);
+    return hr;
 }
 
 /***********************************************************************

--- a/dll/ime/msctfime/msctfime.h
+++ b/dll/ime/msctfime/msctfime.h
@@ -25,6 +25,14 @@
 #include <cicero/CModulePath.h>
 #include <cicero/imclock.h>
 
+class CicInputContext;
+
+typedef struct tagCTFIMECONTEXT
+{
+    CicInputContext *m_pCicIC;
+    DWORD m_dwCicFlags;
+} CTFIMECONTEXT, *PCTFIMECONTEXT;
+
 #include <wine/debug.h>
 
 #include "resource.h"

--- a/sdk/include/ddk/immdev.h
+++ b/sdk/include/ddk/immdev.h
@@ -149,7 +149,7 @@ typedef struct INPUTCONTEXTDX
     DWORD dwUnknown2;
     struct IME_STATE *pState;   // +0x154
     DWORD dwChange;             // +0x158
-    DWORD dwUnknown5;
+    HIMCC hCtfImeContext;
 } INPUTCONTEXTDX, *PINPUTCONTEXTDX, *LPINPUTCONTEXTDX;
 
 // bits of fdwInit of INPUTCONTEXT


### PR DESCRIPTION
## Purpose
Supporting TIPs...
JIRA issue: [CORE-19360](https://jira.reactos.org/browse/CORE-19360)

## Proposed changes

- Add `CTFIMECONTEXT` structure.
- Add `CicInputContext` class.
- Rename `INPUTCONTEXTDX.dwUnknown5` as `hCtfImeContext` and retype it as `HIMCC`.
- Implement `CtfImeGetGuidAtom` by using them.

## TODO

- [x] Do build.