### PR TITLE
[MSCTFIME][MSCTF][SDK] Add compartment helper functions

### DIFF
--- a/dll/win32/msctf/msctf.spec
+++ b/dll/win32/msctf/msctf.spec
@@ -15,7 +15,7 @@
 @ stdcall TF_CreateLangBarItemMgr(ptr)
 @ stdcall TF_CreateLangBarMgr(ptr)
 @ stdcall TF_CreateThreadMgr(ptr)
-@ stub TF_DllDetachInOther
+@ stdcall -stub TF_DllDetachInOther()
 @ stdcall -stub TF_GetGlobalCompartment(ptr)
 @ stub TF_GetInputScope
 @ stub TF_GetLangIcon

--- a/sdk/include/psdk/msctf.idl
+++ b/sdk/include/psdk/msctf.idl
@@ -40,6 +40,7 @@ cpp_quote("EXTERN_C HRESULT WINAPI TF_CreateLangBarItemMgr(_Out_ ITfLangBarItemM
 cpp_quote("EXTERN_C HANDLE  WINAPI TF_CreateCicLoadMutex(_Out_ LPBOOL pfWinLogon);")
 cpp_quote("EXTERN_C HRESULT WINAPI TF_InvalidAssemblyListCache(VOID);")
 cpp_quote("EXTERN_C HRESULT WINAPI TF_InvalidAssemblyListCacheIfExist(VOID);")
+cpp_quote("EXTERN_C HRESULT WINAPI TF_DllDetachInOther(VOID);")
 
 cpp_quote("EXTERN_C const GUID GUID_PROP_TEXTOWNER;")
 cpp_quote("EXTERN_C const GUID GUID_PROP_ATTRIBUTE;")


### PR DESCRIPTION
## Purpose

Supporting TIPs...
JIRA issue: [CORE-19360](https://jira.reactos.org/browse/CORE-19360)

## Proposed changes

- Implement `GetCompartment`, `SetCompartmentDWORD`, `GetCompartmentDWORD`, `SetCompartmentUnknown`, and `ClearCompartment` helper functions.
- Add `TF_DllDetachInOther` prototype to `"msctf.idl"`.
- Implement `DllMain` function by using `TF_DllDetachInOther`.

## TODO

- [x] Do build.
