### PR TITLE
[HAL] Fix SMP initialization

### DIFF
--- a/hal/halx86/apic/halinit.c
+++ b/hal/halx86/apic/halinit.c
@@ -25,16 +25,12 @@ HalpInitProcessor(
     IN ULONG ProcessorNumber,
     IN PLOADER_PARAMETER_BLOCK LoaderBlock)
 {
-#ifdef CONFIG_SMP
     if (ProcessorNumber == 0)
     {
-#endif
         HalpParseApicTables(LoaderBlock);
-#ifdef CONFIG_SMP
     }
 
     HalpSetupProcessorsTable(ProcessorNumber);
-#endif
 
     /* Initialize the local APIC for this cpu */
     ApicInitializeLocalApic(ProcessorNumber);

--- a/hal/halx86/generic/halinit.c
+++ b/hal/halx86/generic/halinit.c
@@ -57,8 +57,11 @@ HalInitializeProcessor(
     InterlockedBitTestAndSetAffinity(&HalpActiveProcessors, ProcessorNumber);
     InterlockedBitTestAndSetAffinity(&HalpDefaultInterruptAffinity, ProcessorNumber);
 
-    /* Register routines for KDCOM */
-    HalpRegisterKdSupportFunctions();
+    if (ProcessorNumber == 0)
+    {
+        /* Register routines for KDCOM */
+        HalpRegisterKdSupportFunctions();
+    }
 }
 
 /*

--- a/hal/halx86/generic/up.c
+++ b/hal/halx86/generic/up.c
@@ -33,6 +33,13 @@ HalStartNextProcessor(
     return FALSE;
 }
 
+VOID
+HalpSetupProcessorsTable(
+    _In_ UINT32 NTProcessorNumber)
+{
+    NOTHING;
+}
+
 #ifdef _M_AMD64
 
 VOID


### PR DESCRIPTION
## Purpose

Fixes SMP related bugs in hal.

## Proposed changes

- Don't use `CONFIG_SMP`, this isn't handled in (most of) hal
- Add a dummy HalpSetupProcessorsTable for UP
- Call HalpRegisterKdSupportFunctions only for processor 0
