### PR TITLE
[COMCTL32][USER32] EDIT control: Check bCaptureState on WM_CHAR

### DIFF
--- a/dll/win32/comctl32/edit.c
+++ b/dll/win32/comctl32/edit.c
@@ -3051,6 +3051,11 @@ static LRESULT EDIT_WM_Char(EDITSTATE *es, WCHAR c)
 {
         BOOL control;
 
+	if (es->bCaptureState)
+	{
+		return 0;
+	}
+
 	control = GetKeyState(VK_CONTROL) & 0x8000;
 
 	switch (c) {

--- a/dll/win32/comctl32/edit.c
+++ b/dll/win32/comctl32/edit.c
@@ -3052,9 +3052,7 @@ static LRESULT EDIT_WM_Char(EDITSTATE *es, WCHAR c)
         BOOL control;
 
 	if (es->bCaptureState)
-	{
 		return 0;
-	}
 
 	control = GetKeyState(VK_CONTROL) & 0x8000;
 

--- a/dll/win32/comctl32/edit.c
+++ b/dll/win32/comctl32/edit.c
@@ -3051,8 +3051,10 @@ static LRESULT EDIT_WM_Char(EDITSTATE *es, WCHAR c)
 {
         BOOL control;
 
+#ifdef __REACTOS__
 	if (es->bCaptureState)
 		return 0;
+#endif
 
 	control = GetKeyState(VK_CONTROL) & 0x8000;
 

--- a/win32ss/user/user32/controls/edit.c
+++ b/win32ss/user/user32/controls/edit.c
@@ -3287,9 +3287,7 @@ static LRESULT EDIT_WM_Char(EDITSTATE *es, WCHAR c)
         BOOL control;
 
 	if (es->bCaptureState)
-	{
 		return 0;
-	}
 
 	control = GetKeyState(VK_CONTROL) & 0x8000;
 

--- a/win32ss/user/user32/controls/edit.c
+++ b/win32ss/user/user32/controls/edit.c
@@ -3286,6 +3286,11 @@ static LRESULT EDIT_WM_Char(EDITSTATE *es, WCHAR c)
 {
         BOOL control;
 
+	if (es->bCaptureState)
+	{
+		return 0;
+	}
+
 	control = GetKeyState(VK_CONTROL) & 0x8000;
 
 	switch (c) {

--- a/win32ss/user/user32/controls/edit.c
+++ b/win32ss/user/user32/controls/edit.c
@@ -3286,8 +3286,10 @@ static LRESULT EDIT_WM_Char(EDITSTATE *es, WCHAR c)
 {
         BOOL control;
 
+#ifdef __REACTOS__
 	if (es->bCaptureState)
 		return 0;
+#endif
 
 	control = GetKeyState(VK_CONTROL) & 0x8000;
 


### PR DESCRIPTION
## Purpose

Based on KRosUser's `edit_v2.patch`.
Edit control should stop processing characters when left mouse button is down.
JIRA issue: [CORE-10259](https://jira.reactos.org/browse/CORE-10259)

## Proposed changes

- If `es->bCaptureState` is set, then ignore `WM_CHAR` message.

## TODO

- [x] Do tests.