### PR TITLE
[SETUPAPI] CMP_RegisterNotification(): Remove useless/broken check

### DIFF
--- a/dll/win32/setupapi/cfgmgr.c
+++ b/dll/win32/setupapi/cfgmgr.c
@@ -698,8 +698,7 @@ CMP_RegisterNotification(
     }
     else
     {
-        if (pNotifyData->hNotifyHandle == NULL)
-            HeapFree(GetProcessHeap(), 0, pNotifyData);
+        HeapFree(GetProcessHeap(), 0, pNotifyData);
 
         *phDevNotify = (HDEVNOTIFY)NULL;
     }


### PR DESCRIPTION
## Purpose

At best, the new check was useless too; at worst, it would leak.

Revert new b0a7374 (0.4.15-dev-3912) broken check,
and even remove initial a6eabc0 (r73394) useless check.

## Proposed changes

- Remove useless/broken check