### PR TITLE
[UMPNPMGR] PNP_RegisterNotification(): Fix a string format

### DIFF
--- a/base/services/umpnpmgr/rpcserver.c
+++ b/base/services/umpnpmgr/rpcserver.c
@@ -4702,7 +4702,7 @@ PNP_RegisterNotification(
     PDEV_BROADCAST_HANDLE pBroadcastDeviceHandle;
     PNOTIFY_ENTRY pNotifyData = NULL;
 
-    DPRINT1("PNP_RegisterNotification(%p %lx '%S' %p %lu 0x%lx %p %lx %p)\n",
+    DPRINT1("PNP_RegisterNotification(%p %p '%S' %p %lu 0x%lx %p %lx %p)\n",
            hBinding, hRecipient, pszName, pNotificationFilter,
            ulNotificationFilterSize, ulFlags, pNotifyHandle, ulProcessId, pulUnknown9);
 


### PR DESCRIPTION
## Purpose

Type was changed from `DWORD` to `DWORD_PTR` (as handle).

Addendum to 71df39b (0.4.15-dev-7294).

## Proposed changes

- Fix a string format