### PR TITLE
[COMDLG32] Color Picker: Fix cursor clipping

### DIFF
--- a/dll/win32/comdlg32/colordlg.c
+++ b/dll/win32/comdlg32/colordlg.c
@@ -1251,18 +1251,16 @@ static INT_PTR CALLBACK ColorDlgProc( HWND hDlg, UINT message,
 			  return TRUE;
 			break;
 #ifdef __REACTOS__
-	  case WM_LBUTTONUP:
-#else
-	  case WM_LBUTTONUP:  /* FIXME: ClipCursor off (if in color graph)*/
+	  /* ReactOS: The following comment doesn't apply */
 #endif
+	  case WM_LBUTTONUP:  /* FIXME: ClipCursor off (if in color graph)*/
                         if (CC_WMLButtonUp(lpp))
                            return TRUE;
 			break;
 #ifdef __REACTOS__
-	  case WM_LBUTTONDOWN:
-#else
-	  case WM_LBUTTONDOWN:/* FIXME: ClipCursor on  (if in color graph)*/
+	  /* ReactOS: The following comment doesn't apply */
 #endif
+	  case WM_LBUTTONDOWN:/* FIXME: ClipCursor on  (if in color graph)*/
 	                if (CC_WMLButtonDown(lpp, lParam))
 	                   return TRUE;
 	                break;

--- a/dll/win32/comdlg32/colordlg.c
+++ b/dll/win32/comdlg32/colordlg.c
@@ -1227,7 +1227,8 @@ static INT_PTR CALLBACK ColorDlgProc( HWND hDlg, UINT message,
 	                return CC_WMInitDialog(hDlg, wParam, lParam);
 	  case WM_NCDESTROY:
 #ifdef __REACTOS__
-	                ClipCursor(NULL); // In case closed before WM_LBUTTONUP received.
+	                // Ensure clipping is released, in case the dialog is closed before WM_LBUTTONUP is received.
+	                ClipCursor(NULL);
 #endif
 	                DeleteDC(lpp->hdcMem);
 	                DeleteObject(lpp->hbmMem);

--- a/dll/win32/comdlg32/colordlg.c
+++ b/dll/win32/comdlg32/colordlg.c
@@ -1227,7 +1227,7 @@ static INT_PTR CALLBACK ColorDlgProc( HWND hDlg, UINT message,
 	                return CC_WMInitDialog(hDlg, wParam, lParam);
 	  case WM_NCDESTROY:
 #ifdef __REACTOS__
-	                ClipCursor(NULL); //in case closed before WM_LBUTTONUP received
+	                ClipCursor(NULL); // In case closed before WM_LBUTTONUP received.
 #endif
 	                DeleteDC(lpp->hdcMem);
 	                DeleteObject(lpp->hbmMem);

--- a/dll/win32/comdlg32/colordlg.c
+++ b/dll/win32/comdlg32/colordlg.c
@@ -1096,6 +1096,9 @@ static LRESULT CC_WMLButtonUp( CCPRIV *infoPtr )
 {
    if (infoPtr->capturedGraph)
    {
+#ifdef __REACTOS__
+       ClipCursor(NULL);
+#endif
        infoPtr->capturedGraph = 0;
        ReleaseCapture();
        CC_PaintCross(infoPtr);
@@ -1173,6 +1176,14 @@ static LRESULT CC_WMLButtonDown( CCPRIV *infoPtr, LPARAM lParam )
    }
    if (i)
    {
+#ifdef __REACTOS__
+      RECT rect;
+      if(infoPtr->capturedGraph)
+      {
+         GetWindowRect(GetDlgItem(infoPtr->hwndSelf, infoPtr->capturedGraph), &rect);
+         ClipCursor(&rect);
+      }
+#endif
       CC_EditSetRGB(infoPtr);
       CC_EditSetHSL(infoPtr);
       CC_PaintCross(infoPtr);
@@ -1215,6 +1226,9 @@ static INT_PTR CALLBACK ColorDlgProc( HWND hDlg, UINT message,
 	  case WM_INITDIALOG:
 	                return CC_WMInitDialog(hDlg, wParam, lParam);
 	  case WM_NCDESTROY:
+#ifdef __REACTOS__
+	                ClipCursor(NULL); //in case closed before WM_LBUTTONUP received
+#endif
 	                DeleteDC(lpp->hdcMem);
 	                DeleteObject(lpp->hbmMem);
                         heap_free(lpp);
@@ -1236,11 +1250,19 @@ static INT_PTR CALLBACK ColorDlgProc( HWND hDlg, UINT message,
 	                if (CC_WMMouseMove(lpp, lParam))
 			  return TRUE;
 			break;
+#ifdef __REACTOS__
+	  case WM_LBUTTONUP:
+#else
 	  case WM_LBUTTONUP:  /* FIXME: ClipCursor off (if in color graph)*/
+#endif
                         if (CC_WMLButtonUp(lpp))
                            return TRUE;
 			break;
+#ifdef __REACTOS__
+	  case WM_LBUTTONDOWN:
+#else
 	  case WM_LBUTTONDOWN:/* FIXME: ClipCursor on  (if in color graph)*/
+#endif
 	                if (CC_WMLButtonDown(lpp, lParam))
 	                   return TRUE;
 	                break;

--- a/dll/win32/comdlg32/colordlg.c
+++ b/dll/win32/comdlg32/colordlg.c
@@ -1177,9 +1177,9 @@ static LRESULT CC_WMLButtonDown( CCPRIV *infoPtr, LPARAM lParam )
    if (i)
    {
 #ifdef __REACTOS__
-      RECT rect;
-      if(infoPtr->capturedGraph)
+      if (infoPtr->capturedGraph)
       {
+         RECT rect;
          GetWindowRect(GetDlgItem(infoPtr->hwndSelf, infoPtr->capturedGraph), &rect);
          ClipCursor(&rect);
       }


### PR DESCRIPTION
## Purpose
Color spectrum had inconsistent behaviour in restricting cursor position of color picker.
JIRA issue: [CORE-17002](https://jira.reactos.org/browse/CORE-17002)

## Proposed changes

- `ClipCursor(NULL)` for `WM_LBUTTONUP` and `WM_NCDESTROY`.
- `ClipCursor(...)` for `WM_LBUTTONDOWN`.

## TODO

- [x] Do tests.