### PR TITLE
[MSCTFIME] Delay-import msctf, oleaut32, and imm32

### DIFF
--- a/dll/ime/msctfime/CMakeLists.txt
+++ b/dll/ime/msctfime/CMakeLists.txt
@@ -17,5 +17,6 @@ add_library(msctfime MODULE
 set_module_type(msctfime win32dll UNICODE)
 set_target_properties(msctfime PROPERTIES SUFFIX ".ime")
 target_link_libraries(msctfime wine uuid)
-add_importlibs(msctfime msctf oleaut32 imm32 user32 gdi32 advapi32 comctl32 msvcrt kernel32 ntdll)
+add_importlibs(msctfime user32 gdi32 advapi32 msvcrt kernel32 ntdll)
+add_delay_importlibs(msctfime msctf oleaut32 imm32)
 add_cd_file(TARGET msctfime DESTINATION reactos/system32 FOR all)


### PR DESCRIPTION
## Purpose
Reduce DLL initialization cost.
JIRA issue: [CORE-19360](https://jira.reactos.org/browse/CORE-19360)

## Proposed changes

- Delay-import `msctf.dll`, `oleaut32.dll`, and `imm32.dll`.
- Unlink `comctl32.dll`.

## TODO

- [x] Do build.
