### PR TITLE
[SHLWAPI] Fix SHCreateMemStream corner case

### DIFF
--- a/dll/win32/shlwapi/regstream.c
+++ b/dll/win32/shlwapi/regstream.c
@@ -669,6 +669,10 @@ IStream * WINAPI SHCreateMemStream(const BYTE *lpbData, UINT dwDataLen)
     if (!strm)
       HeapFree(GetProcessHeap(), 0, lpbDup);
   }
+#ifdef __REACTOS__
+  if (!strm)
+    return NULL;
+#endif
   return &strm->IStream_iface;
 }
 


### PR DESCRIPTION
## Purpose

When the system run out of memory, check `NULL` and fail elegantly if necessary.
This doesn't fix CORE-19229 but I think it needs a fix.
JIRA issue: [CORE-19229](https://jira.reactos.org/browse/CORE-19229)

## Proposed changes

- Check if `strm` was `NULL`.

## TODO

- [x] Do build.