### PR TITLE
[COMDLG32] Color Picker: Limit value by maxval

### DIFF
--- a/dll/win32/comdlg32/colordlg.c
+++ b/dll/win32/comdlg32/colordlg.c
@@ -421,6 +421,9 @@ static int CC_CheckDigitsInEdit( HWND hwnd, int maxval )
  value = atoi(buffer);
  if (value > maxval)       /* build a new string */
  {
+#ifdef __REACTOS__
+  value = maxval;
+#endif
   sprintf(buffer, "%d", maxval);
   result = 2;
  }


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-19402](https://jira.reactos.org/browse/CORE-19402)

## Proposed changes

- Set maximum value to `value` if `value` was beyond maximum value.

## TODO

- [x] Do tests