### PR TITLE
[COMCTL32] Property Sheet: Use PROPSHEET_IsDialogMessage in message loop

### DIFF
--- a/dll/win32/comctl32/propsheet.c
+++ b/dll/win32/comctl32/propsheet.c
@@ -2787,6 +2787,10 @@ static void PROPSHEET_CleanUp(HWND hwndDlg)
   GlobalFree(psInfo);
 }
 
+#ifdef __REACTOS__
+static BOOL PROPSHEET_IsDialogMessage(HWND hwnd, LPMSG lpMsg);
+#endif
+
 static INT do_loop(const PropSheetInfo *psInfo)
 {
     MSG msg;
@@ -2799,7 +2803,11 @@ static INT do_loop(const PropSheetInfo *psInfo)
         if(ret == -1)
             break;
 
+#ifdef __REACTOS__
+        if (!PROPSHEET_IsDialogMessage(hwnd, &msg))
+#else
         if(!IsDialogMessageW(hwnd, &msg))
+#endif
         {
             TranslateMessage(&msg);
             DispatchMessageW(&msg);


### PR DESCRIPTION
## Purpose
Fix `Ctrl+Tab` and `Shift+Ctrl+Tab` key combination action in property sheet.
JIRA issue: [CORE-17941](https://jira.reactos.org/browse/CORE-17941)

## Proposed changes

- Use `PROPSHEET_IsDialogMessage` in the message loop of `PropertySheetA/W` function, instead of `IsDialogMessage`.

## TODO

- [x] Do tests.

## Movie

https://github.com/reactos/reactos/assets/2107452/df9c781f-9c81-4a0a-b0a6-2ee0aedefbf0