### PR TITLE
[COMCTL32][USER32] ComboBox: Don't close listbox on letter type

### DIFF
--- a/dll/win32/comctl32/combo.c
+++ b/dll/win32/comctl32/combo.c
@@ -1918,6 +1918,10 @@ static LRESULT CALLBACK COMBO_WindowProc( HWND hwnd, UINT message, WPARAM wParam
         {
             HWND hwndTarget;
 
+#ifdef __REACTOS__
+            if (lphc->wState & CBF_DROPPED)
+                lphc->wState |= CBF_NOROLLUP;
+#endif
             if ( lphc->wState & CBF_EDIT )
                 hwndTarget = lphc->hWndEdit;
             else

--- a/win32ss/user/user32/controls/combo.c
+++ b/win32ss/user/user32/controls/combo.c
@@ -2017,6 +2017,10 @@ LRESULT WINAPI ComboWndProc_common( HWND hwnd, UINT message, WPARAM wParam, LPAR
         {
             HWND hwndTarget;
 
+#ifdef __REACTOS__
+            if (lphc->wState & CBF_DROPPED)
+                lphc->wState |= CBF_NOROLLUP;
+#endif
             if ( lphc->wState & CBF_EDIT )
                 hwndTarget = lphc->hWndEdit;
             else


### PR DESCRIPTION
## Purpose

Based on KRosUser's `combo_v3.patch`.
JIRA issue: [CORE-16376](https://jira.reactos.org/browse/CORE-16376)

## Proposed changes

- Set `CBF_NOROLLUP` flag on (`WM_CHAR` or `WM_IME_CHAR`) and `CBF_DROPPED` state.

## TODO

- [x] Do small tests.
- [x] Do big tests.