### PR TITLE
[CTFMON][MSCTFIME][MSCTF][MSUTB][SDK] Cicero is ANSI, not Unicode

### DIFF
--- a/base/applications/ctfmon/CLoaderWnd.cpp
+++ b/base/applications/ctfmon/CLoaderWnd.cpp
@@ -18,15 +18,15 @@ BOOL CLoaderWnd::Init()
         return TRUE; // Already registered
 
     // Register a window class
-    WNDCLASSEXW wc;
+    WNDCLASSEX wc;
     ZeroMemory(&wc, sizeof(wc));
     wc.cbSize           = sizeof(wc);
     wc.style            = CS_HREDRAW | CS_VREDRAW;
     wc.hInstance        = g_hInst;
-    wc.hCursor          = LoadCursorW(NULL, (LPCWSTR)IDC_ARROW);
+    wc.hCursor          = LoadCursor(NULL, IDC_ARROW);
     wc.lpfnWndProc      = WindowProc;
-    wc.lpszClassName    = L"CiCTipBarClass";
-    if (!::RegisterClassExW(&wc))
+    wc.lpszClassName    = TEXT("CiCTipBarClass");
+    if (!::RegisterClassEx(&wc))
         return FALSE;
 
     s_bWndClassRegistered = TRUE; // Remember
@@ -35,8 +35,8 @@ BOOL CLoaderWnd::Init()
 
 HWND CLoaderWnd::CreateWnd()
 {
-    m_hWnd = ::CreateWindowExW(0, L"CiCTipBarClass", NULL, WS_DISABLED,
-                               0, 0, 0, 0, NULL, NULL, g_hInst, NULL);
+    m_hWnd = ::CreateWindowEx(0, TEXT("CiCTipBarClass"), NULL, WS_DISABLED,
+                              0, 0, 0, 0, NULL, NULL, g_hInst, NULL);
     return m_hWnd;
 }
 
@@ -93,7 +93,7 @@ CLoaderWnd::WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
             break;
 
         default:
-            return DefWindowProcW(hwnd, uMsg, wParam, lParam);
+            return DefWindowProc(hwnd, uMsg, wParam, lParam);
     }
 
     return 0;

--- a/base/applications/ctfmon/CMakeLists.txt
+++ b/base/applications/ctfmon/CMakeLists.txt
@@ -6,7 +6,7 @@ list(APPEND SOURCE
 
 add_rc_deps(ctfmon.rc ${CMAKE_CURRENT_SOURCE_DIR}/res/ctfmon.ico)
 add_executable(ctfmon ${SOURCE} ctfmon.rc)
-set_module_type(ctfmon win32gui UNICODE)
+set_module_type(ctfmon win32gui)
 add_dependencies(ctfmon msctf msutb)
 target_link_libraries(ctfmon uuid)
 add_importlibs(ctfmon msctf msutb advapi32 shell32 user32 msvcrt kernel32)

--- a/base/applications/ctfmon/CRegWatcher.h
+++ b/base/applications/ctfmon/CRegWatcher.h
@@ -10,7 +10,7 @@
 struct WATCHENTRY
 {
     HKEY hRootKey;
-    LPCWSTR pszSubKey;
+    LPCTSTR pszSubKey;
     HKEY hKey;
 };
 

--- a/base/applications/ctfmon/precomp.h
+++ b/base/applications/ctfmon/precomp.h
@@ -12,6 +12,7 @@
 #include <shellapi.h>
 #include <shlwapi.h>
 #include <stdlib.h>
+#include <tchar.h>
 #include <strsafe.h>
 #include <msctf.h>
 #include <ctfutb.h>

--- a/dll/ime/msctfime/msctfime.cpp
+++ b/dll/ime/msctfime/msctfime.cpp
@@ -56,16 +56,17 @@ BOOL IsMsImeMessage(UINT uMsg)
  */
 BOOL RegisterMSIMEMessage(VOID)
 {
-    WM_MSIME_SERVICE = RegisterWindowMessageW(L"MSIMEService");
-    WM_MSIME_UIREADY = RegisterWindowMessageW(L"MSIMEUIReady");
-    WM_MSIME_RECONVERTREQUEST = RegisterWindowMessageW(L"MSIMEReconvertRequest");
-    WM_MSIME_RECONVERT = RegisterWindowMessageW(L"MSIMEReconvert");
-    WM_MSIME_DOCUMENTFEED = RegisterWindowMessageW(L"MSIMEDocumentFeed");
-    WM_MSIME_QUERYPOSITION = RegisterWindowMessageW(L"MSIMEQueryPosition");
-    WM_MSIME_MODEBIAS = RegisterWindowMessageW(L"MSIMEModeBias");
-    WM_MSIME_SHOWIMEPAD = RegisterWindowMessageW(L"MSIMEShowImePad");
-    WM_MSIME_MOUSE = RegisterWindowMessageW(L"MSIMEMouseOperation");
-    WM_MSIME_KEYMAP = RegisterWindowMessageW(L"MSIMEKeyMap");
+    // Using ANSI (A) version here can reduce binary size.
+    WM_MSIME_SERVICE = RegisterWindowMessageA("MSIMEService");
+    WM_MSIME_UIREADY = RegisterWindowMessageA("MSIMEUIReady");
+    WM_MSIME_RECONVERTREQUEST = RegisterWindowMessageA("MSIMEReconvertRequest");
+    WM_MSIME_RECONVERT = RegisterWindowMessageA("MSIMEReconvert");
+    WM_MSIME_DOCUMENTFEED = RegisterWindowMessageA("MSIMEDocumentFeed");
+    WM_MSIME_QUERYPOSITION = RegisterWindowMessageA("MSIMEQueryPosition");
+    WM_MSIME_MODEBIAS = RegisterWindowMessageA("MSIMEModeBias");
+    WM_MSIME_SHOWIMEPAD = RegisterWindowMessageA("MSIMEShowImePad");
+    WM_MSIME_MOUSE = RegisterWindowMessageA("MSIMEMouseOperation");
+    WM_MSIME_KEYMAP = RegisterWindowMessageA("MSIMEKeyMap");
     return (WM_MSIME_SERVICE &&
             WM_MSIME_UIREADY &&
             WM_MSIME_RECONVERTREQUEST &&

--- a/dll/ime/msctfime/msctfime.h
+++ b/dll/ime/msctfime/msctfime.h
@@ -17,6 +17,7 @@
 #include <imm.h>
 #include <ddk/immdev.h>
 #include <cguid.h>
+#include <tchar.h>
 #include <msctf.h>
 #include <ctffunc.h>
 #include <shlwapi.h>

--- a/dll/win32/msctf/utils.cpp
+++ b/dll/win32/msctf/utils.cpp
@@ -17,6 +17,7 @@
 #include <imm.h>
 #include <ddk/immdev.h>
 #include <cguid.h>
+#include <tchar.h>
 #include <msctf.h>
 #include <ctffunc.h>
 #include <shlwapi.h>
@@ -27,6 +28,23 @@
 #include <wine/debug.h>
 
 WINE_DEFAULT_DEBUG_CHANNEL(msctf);
+
+BOOL StringFromGUID2A(REFGUID rguid, LPSTR pszGUID, INT cchGUID)
+{
+    pszGUID[0] = ANSI_NULL;
+
+    WCHAR szWide[40];
+    szWide[0] = UNICODE_NULL;
+    BOOL ret = StringFromGUID2(rguid, szWide, _countof(szWide));
+    ::WideCharToMultiByte(CP_ACP, 0, szWide, -1, pszGUID, cchGUID, NULL, NULL);
+    return ret;
+}
+
+#ifdef UNICODE
+    #define StringFromGUID2T StringFromGUID2
+#else
+    #define StringFromGUID2T StringFromGUID2A
+#endif
 
 /***********************************************************************
  *      TF_RegisterLangBarAddIn (MSCTF.@)
@@ -47,19 +65,19 @@ TF_RegisterLangBarAddIn(
         return E_INVALIDARG;
     }
 
-    WCHAR szBuff[MAX_PATH], szGUID[40];
-    StringCchCopyW(szBuff, _countof(szBuff), L"SOFTWARE\\Microsoft\\CTF\\LangBarAddIn\\");
-    StringFromGUID2(rguid, szGUID, _countof(szGUID));
-    StringCchCatW(szBuff, _countof(szBuff), szGUID);
+    TCHAR szBuff[MAX_PATH], szGUID[40];
+    StringCchCopy(szBuff, _countof(szBuff), TEXT("SOFTWARE\\Microsoft\\CTF\\LangBarAddIn\\"));
+    StringFromGUID2T(rguid, szGUID, _countof(szGUID));
+    StringCchCat(szBuff, _countof(szBuff), szGUID);
 
     CicRegKey regKey;
     HKEY hBaseKey = ((dwFlags & 1) ? HKEY_LOCAL_MACHINE : HKEY_CURRENT_USER);
     LSTATUS error = regKey.Create(hBaseKey, szBuff);
     if (error == ERROR_SUCCESS)
     {
-        error = regKey.SetSz(L"FilePath", pszFilePath);
+        error = regKey.SetSzW(L"FilePath", pszFilePath);
         if (error == ERROR_SUCCESS)
-            error = regKey.SetDword(L"Enable", !!(dwFlags & 4));
+            error = regKey.SetDword(TEXT("Enable"), !!(dwFlags & 4));
     }
 
     return ((error == ERROR_SUCCESS) ? S_OK : E_FAIL);
@@ -83,8 +101,8 @@ TF_UnregisterLangBarAddIn(
         return E_INVALIDARG;
     }
 
-    WCHAR szSubKey[MAX_PATH];
-    StringCchCopyW(szSubKey, _countof(szSubKey), L"SOFTWARE\\Microsoft\\CTF\\LangBarAddIn\\");
+    TCHAR szSubKey[MAX_PATH];
+    StringCchCopy(szSubKey, _countof(szSubKey), TEXT("SOFTWARE\\Microsoft\\CTF\\LangBarAddIn\\"));
 
     CicRegKey regKey;
     HKEY hBaseKey = ((dwFlags & 1) ? HKEY_LOCAL_MACHINE : HKEY_CURRENT_USER);
@@ -92,8 +110,8 @@ TF_UnregisterLangBarAddIn(
     HRESULT hr = E_FAIL;
     if (error == ERROR_SUCCESS)
     {
-        WCHAR szGUID[40];
-        StringFromGUID2(rguid, szGUID, _countof(szGUID));
+        TCHAR szGUID[40];
+        StringFromGUID2T(rguid, szGUID, _countof(szGUID));
         regKey.RecurseDeleteKey(szGUID);
         hr = S_OK;
     }

--- a/dll/win32/msutb/CMakeLists.txt
+++ b/dll/win32/msutb/CMakeLists.txt
@@ -11,7 +11,7 @@ add_library(msutb MODULE
     ${SOURCE}
     msutb.rc
     ${CMAKE_CURRENT_BINARY_DIR}/msutb.def)
-set_module_type(msutb win32dll UNICODE)
+set_module_type(msutb win32dll)
 add_dependencies(msutb msctf psdk)
 target_link_libraries(msutb wine uuid atl_classes)
 add_importlibs(msutb user32 gdi32 advapi32 comctl32 msvcrt kernel32 ntdll)

--- a/sdk/include/reactos/cicero/cicevent.h
+++ b/sdk/include/reactos/cicero/cicevent.h
@@ -12,7 +12,7 @@
 class CicEvent
 {
     HANDLE m_hEvent;
-    LPCWSTR m_pszName;
+    LPCTSTR m_pszName;
 
 public:
     CicEvent() : m_hEvent(NULL), m_pszName(NULL)
@@ -23,20 +23,20 @@ public:
         Close();
     }
 
-    BOOL Create(LPSECURITY_ATTRIBUTES lpSA, LPCWSTR pszName)
+    BOOL Create(LPSECURITY_ATTRIBUTES lpSA, LPCTSTR pszName)
     {
         if (pszName)
             m_pszName = pszName;
         if (!m_pszName)
             return FALSE;
-        m_hEvent = ::CreateEventW(lpSA, FALSE, FALSE, m_pszName);
+        m_hEvent = ::CreateEvent(lpSA, FALSE, FALSE, m_pszName);
         return (m_hEvent != NULL);
     }
-    BOOL Open(LPCWSTR pszName)
+    BOOL Open(LPCTSTR pszName)
     {
         if (pszName)
             m_pszName = pszName;
-        m_hEvent = ::OpenEventW(EVENT_ALL_ACCESS, FALSE, m_pszName);
+        m_hEvent = ::OpenEvent(EVENT_ALL_ACCESS, FALSE, m_pszName);
         return (m_hEvent != NULL);
     }
     void Close()

--- a/sdk/include/reactos/cicero/cicfmap.h
+++ b/sdk/include/reactos/cicero/cicfmap.h
@@ -15,7 +15,7 @@
 class CicFileMappingStatic
 {
 protected:
-    LPCWSTR m_pszName;
+    LPCTSTR m_pszName;
     LPVOID m_pView;
     HANDLE m_hMapping;
     BOOL m_bCreated;
@@ -28,7 +28,7 @@ public:
     CicFileMappingStatic() { }
     ~CicFileMappingStatic() { }
 
-    void Init(LPCWSTR pszName, CicMutex *pMutex);
+    void Init(LPCTSTR pszName, CicMutex *pMutex);
 
     LPVOID Create(LPSECURITY_ATTRIBUTES pSA, DWORD dwMaximumSizeLow, LPBOOL pbAlreadyExists);
     LPVOID Open();
@@ -43,14 +43,14 @@ public:
 class CicFileMapping : public CCicFileMappingStatic
 {
 public:
-    CicFileMapping(LPCWSTR pszName, CicMutex *pMutex);
+    CicFileMapping(LPCTSTR pszName, CicMutex *pMutex);
     virtual ~CicFileMapping() { Finalize(); }
 };
 
 /******************************************************************************/
 
 inline
-CicFileMapping::CicFileMapping(LPCWSTR pszName, CicMutex *pMutex)
+CicFileMapping::CicFileMapping(LPCTSTR pszName, CicMutex *pMutex)
     : m_pszName(NULL)
     , m_pView(NULL)
     , m_hMapping(NULL)
@@ -78,7 +78,7 @@ inline void CicFileMappingStatic::Close()
     m_bCreated = FALSE;
 }
 
-inline void CicFileMappingStatic::Init(LPCWSTR pszName, CicMutex *pMutex)
+inline void CicFileMappingStatic::Init(LPCTSTR pszName, CicMutex *pMutex)
 {
     if (pMutex)
         m_pMutex = pMutex;
@@ -97,12 +97,12 @@ CicFileMappingStatic::Create(
     if (!m_pszName)
         return NULL;
 
-    m_hMapping = ::CreateFileMappingW(INVALID_HANDLE_VALUE,
-                                      pSA,
-                                      PAGE_READWRITE,
-                                      0,
-                                      dwMaximumSizeLow,
-                                      m_pszName);
+    m_hMapping = ::CreateFileMapping(INVALID_HANDLE_VALUE,
+                                     pSA,
+                                     PAGE_READWRITE,
+                                     0,
+                                     dwMaximumSizeLow,
+                                     m_pszName);
     if (pbAlreadyExists)
         *pbAlreadyExists = (::GetLastError() == ERROR_ALREADY_EXISTS);
     if (!m_hMapping)
@@ -116,7 +116,7 @@ inline LPVOID CicFileMappingStatic::Open()
 {
     if (!m_pszName)
         return NULL;
-    m_hMapping = ::OpenFileMappingW(FILE_MAP_ALL_ACCESS, FALSE, m_pszName);
+    m_hMapping = ::OpenFileMapping(FILE_MAP_ALL_ACCESS, FALSE, m_pszName);
     if (!m_hMapping)
         return NULL;
 

--- a/sdk/include/reactos/cicero/cicmutex.h
+++ b/sdk/include/reactos/cicero/cicmutex.h
@@ -23,9 +23,9 @@ public:
         Uninit();
     }
 
-    void Init(LPSECURITY_ATTRIBUTES lpSA, LPCWSTR pszMutexName)
+    void Init(LPSECURITY_ATTRIBUTES lpSA, LPCTSTR pszMutexName)
     {
-        m_hMutex = ::CreateMutexW(lpSA, FALSE, pszMutexName);
+        m_hMutex = ::CreateMutex(lpSA, FALSE, pszMutexName);
         m_bInit = TRUE;
     }
     void Uninit()

--- a/sdk/include/reactos/cicero/cicreg.h
+++ b/sdk/include/reactos/cicero/cicreg.h
@@ -23,43 +23,48 @@ public:
 
     LSTATUS Open(
         HKEY hKey,
-        LPCWSTR lpSubKey,
+        LPCTSTR lpSubKey,
         REGSAM samDesired = KEY_READ);
 
     LSTATUS Create(
         HKEY hKey,
-        LPCWSTR lpSubKey,
-        LPWSTR lpClass = NULL,
+        LPCTSTR lpSubKey,
+        LPTSTR lpClass = NULL,
         DWORD dwOptions = REG_OPTION_NON_VOLATILE,
         REGSAM samDesired = KEY_ALL_ACCESS,
         LPSECURITY_ATTRIBUTES lpSecurityAttributes = NULL,
         LPDWORD pdwDisposition = NULL);
 
-    LSTATUS QueryDword(LPCWSTR pszValueName, LPDWORD pdwValue)
+    LSTATUS QueryDword(LPCTSTR pszValueName, LPDWORD pdwValue)
     {
         DWORD cbData = sizeof(DWORD);
-        return ::RegQueryValueExW(m_hKey, pszValueName, 0, NULL, (LPBYTE)pdwValue, &cbData);
+        return ::RegQueryValueEx(m_hKey, pszValueName, 0, NULL, (LPBYTE)pdwValue, &cbData);
     }
 
-    LSTATUS SetDword(LPCWSTR pszValueName, DWORD dwValue)
+    LSTATUS SetDword(LPCTSTR pszValueName, DWORD dwValue)
     {
-        return ::RegSetValueExW(m_hKey, pszValueName, 0, REG_DWORD, (LPBYTE)&dwValue, sizeof(dwValue));
+        return ::RegSetValueEx(m_hKey, pszValueName, 0, REG_DWORD, (LPBYTE)&dwValue, sizeof(dwValue));
     }
 
-    LSTATUS QuerySz(LPCWSTR pszValueName, LPWSTR pszValue, DWORD cchValueMax);
+    LSTATUS QuerySz(LPCTSTR pszValueName, LPWSTR pszValue, DWORD cchValueMax);
 
-    LSTATUS SetSz(LPCWSTR pszValueName, LPCWSTR pszValue)
+    LSTATUS SetSz(LPCTSTR pszValueName, LPCTSTR pszValue)
+    {
+        DWORD cbValue = (lstrlen(pszValue) + 1) * sizeof(TCHAR);
+        return ::RegSetValueEx(m_hKey, pszValueName, 0, REG_SZ, (LPBYTE)pszValue, cbValue);
+    }
+    LSTATUS SetSzW(LPCWSTR pszValueName, LPCWSTR pszValue)
     {
         DWORD cbValue = (lstrlenW(pszValue) + 1) * sizeof(WCHAR);
         return ::RegSetValueExW(m_hKey, pszValueName, 0, REG_SZ, (LPBYTE)pszValue, cbValue);
     }
 
-    LSTATUS DeleteSubKey(LPCWSTR lpSubKey)
+    LSTATUS DeleteSubKey(LPCTSTR lpSubKey)
     {
-        return ::RegDeleteKeyW(m_hKey, lpSubKey);
+        return ::RegDeleteKey(m_hKey, lpSubKey);
     }
 
-    LSTATUS RecurseDeleteKey(LPCWSTR lpSubKey);
+    LSTATUS RecurseDeleteKey(LPCTSTR lpSubKey);
 };
 
 /******************************************************************************/
@@ -77,11 +82,11 @@ CicRegKey::Close()
 inline LSTATUS
 CicRegKey::Open(
     HKEY hKey,
-    LPCWSTR lpSubKey,
+    LPCTSTR lpSubKey,
     REGSAM samDesired)
 {
     HKEY hNewKey = NULL;
-    LSTATUS error = ::RegOpenKeyExW(hKey, lpSubKey, 0, samDesired, &hNewKey);
+    LSTATUS error = ::RegOpenKeyEx(hKey, lpSubKey, 0, samDesired, &hNewKey);
     if (error != ERROR_SUCCESS)
         return error;
 
@@ -93,23 +98,23 @@ CicRegKey::Open(
 inline LSTATUS
 CicRegKey::Create(
     HKEY hKey,
-    LPCWSTR lpSubKey,
-    LPWSTR lpClass,
+    LPCTSTR lpSubKey,
+    LPTSTR lpClass,
     DWORD dwOptions,
     REGSAM samDesired,
     LPSECURITY_ATTRIBUTES lpSecurityAttributes,
     LPDWORD pdwDisposition)
 {
     HKEY hNewKey = NULL;
-    LSTATUS error = ::RegCreateKeyExW(hKey,
-                                      lpSubKey,
-                                      0,
-                                      lpClass,
-                                      dwOptions,
-                                      samDesired,
-                                      lpSecurityAttributes,
-                                      &hNewKey,
-                                      pdwDisposition);
+    LSTATUS error = ::RegCreateKeyEx(hKey,
+                                     lpSubKey,
+                                     0,
+                                     lpClass,
+                                     dwOptions,
+                                     samDesired,
+                                     lpSecurityAttributes,
+                                     &hNewKey,
+                                     pdwDisposition);
     if (error != ERROR_SUCCESS)
         return error;
 
@@ -119,13 +124,13 @@ CicRegKey::Create(
 }
 
 inline LSTATUS
-CicRegKey::QuerySz(LPCWSTR pszValueName, LPWSTR pszValue, DWORD cchValueMax)
+CicRegKey::QuerySz(LPCTSTR pszValueName, LPWSTR pszValue, DWORD cchValueMax)
 {
     DWORD cchSaveMax = cchValueMax;
 
-    cchValueMax *= sizeof(WCHAR);
-    LSTATUS error = ::RegQueryValueExW(m_hKey, pszValueName, 0, NULL,
-                                       (LPBYTE)pszValue, &cchValueMax);
+    cchValueMax *= sizeof(TCHAR);
+    LSTATUS error = ::RegQueryValueEx(m_hKey, pszValueName, 0, NULL,
+                                      (LPBYTE)pszValue, &cchValueMax);
     if (cchSaveMax > 0)
         pszValue[(error == ERROR_SUCCESS) ? (cchSaveMax - 1) : 0] = UNICODE_NULL;
 
@@ -133,19 +138,19 @@ CicRegKey::QuerySz(LPCWSTR pszValueName, LPWSTR pszValue, DWORD cchValueMax)
 }
 
 inline LSTATUS
-CicRegKey::RecurseDeleteKey(LPCWSTR lpSubKey)
+CicRegKey::RecurseDeleteKey(LPCTSTR lpSubKey)
 {
     CicRegKey regKey;
     LSTATUS error = regKey.Open(m_hKey, lpSubKey, KEY_READ | KEY_WRITE);
     if (error != ERROR_SUCCESS)
         return error;
 
-    WCHAR szName[MAX_PATH];
+    TCHAR szName[MAX_PATH];
     DWORD cchName;
     do
     {
         cchName = _countof(szName);
-        error = ::RegEnumKeyExW(regKey, 0, szName, &cchName, NULL, NULL, NULL, NULL);
+        error = ::RegEnumKeyEx(regKey, 0, szName, &cchName, NULL, NULL, NULL, NULL);
         if (error != ERROR_SUCCESS)
             break;
 


### PR DESCRIPTION
## Purpose
Cicero interface is not Unicode (W) but ANSI (A).
JIRA issue: [CORE-19361](https://jira.reactos.org/browse/CORE-19361), [CORE-19362](https://jira.reactos.org/browse/CORE-19362), [CORE-19363](https://jira.reactos.org/browse/CORE-19363)

## Proposed changes

- `ctfmon.exe` is ANSI, not Unicode.
- `msutb.dll` is ANSI, not Unicode.
- Apply generic text mapping to the cicero library.
- Include `<tchar.h>` to use generic text mapping.

## TODO

- [x] Do build.