### PR TITLE
[COMDLG32] Color Picker: Fix black cross

### DIFF
--- a/dll/win32/comdlg32/colordlg.c
+++ b/dll/win32/comdlg32/colordlg.c
@@ -523,8 +523,13 @@ static void CC_PaintCross(CCPRIV *infoPtr)
  if (IsWindowVisible(hwnd))   /* if full size */
  {
    HDC hDC;
+#ifdef __REACTOS__
+   int w = 10, wc = 5;
+   HRGN hRgn;
+#else
    int w = GetDialogBaseUnits() - 1;
    int wc = GetDialogBaseUnits() * 3 / 4;
+#endif
    RECT rect;
    POINT point, p;
    HPEN hPen;
@@ -535,7 +540,13 @@ static void CC_PaintCross(CCPRIV *infoPtr)
 
    GetClientRect(hwnd, &rect);
    hDC = GetDC(hwnd);
+#ifdef __REACTOS__
+   hRgn = CreateRectRgnIndirect(&rect);
+   SelectClipRgn(hDC, hRgn); /* SelectClipRgn uses a copy of HRGN */
+   DeleteObject(hRgn);
+#else
    SelectClipRgn( hDC, CreateRectRgnIndirect(&rect));
+#endif
 
    point.x = ((long)rect.right * (long)x) / (long)MAXHORI;
    point.y = rect.bottom - ((long)rect.bottom * (long)y) / (long)MAXVERT;
@@ -544,10 +555,17 @@ static void CC_PaintCross(CCPRIV *infoPtr)
               infoPtr->oldcross.right - infoPtr->oldcross.left,
               infoPtr->oldcross.bottom - infoPtr->oldcross.top,
               infoPtr->hdcMem, infoPtr->oldcross.left, infoPtr->oldcross.top, SRCCOPY);
+#ifdef __REACTOS__
+   infoPtr->oldcross.left   = point.x - w - 3;
+   infoPtr->oldcross.right  = point.x + w + 3;
+   infoPtr->oldcross.top    = point.y - w - 3;
+   infoPtr->oldcross.bottom = point.y + w + 3;
+#else
    infoPtr->oldcross.left   = point.x - w - 1;
    infoPtr->oldcross.right  = point.x + w + 1;
    infoPtr->oldcross.top    = point.y - w - 1;
    infoPtr->oldcross.bottom = point.y + w + 1;
+#endif
 
    hPen = CreatePen(PS_SOLID, 3, RGB(0, 0, 0)); /* -black- color */
    hPen = SelectObject(hDC, hPen);

--- a/dll/win32/comdlg32/colordlg.c
+++ b/dll/win32/comdlg32/colordlg.c
@@ -525,13 +525,13 @@ static void CC_PaintCross(CCPRIV *infoPtr)
    HDC hDC;
 #ifdef __REACTOS__
    int w = 8, wc = 6;
-   HRGN hRgn;
 #else
    int w = GetDialogBaseUnits() - 1;
    int wc = GetDialogBaseUnits() * 3 / 4;
 #endif
    RECT rect;
    POINT point, p;
+   HRGN region;
    HPEN hPen;
    int x, y;
 
@@ -540,13 +540,9 @@ static void CC_PaintCross(CCPRIV *infoPtr)
 
    GetClientRect(hwnd, &rect);
    hDC = GetDC(hwnd);
-#ifdef __REACTOS__
-   hRgn = CreateRectRgnIndirect(&rect);
-   SelectClipRgn(hDC, hRgn); /* SelectClipRgn uses a copy of HRGN */
-   DeleteObject(hRgn);
-#else
-   SelectClipRgn( hDC, CreateRectRgnIndirect(&rect));
-#endif
+   region = CreateRectRgnIndirect(&rect);
+   SelectClipRgn(hDC, region);
+   DeleteObject(region);
 
    point.x = ((long)rect.right * (long)x) / (long)MAXHORI;
    point.y = rect.bottom - ((long)rect.bottom * (long)y) / (long)MAXVERT;

--- a/dll/win32/comdlg32/colordlg.c
+++ b/dll/win32/comdlg32/colordlg.c
@@ -524,7 +524,7 @@ static void CC_PaintCross(CCPRIV *infoPtr)
  {
    HDC hDC;
 #ifdef __REACTOS__
-   int w = 10, wc = 5;
+   int w = 8, wc = 6;
    HRGN hRgn;
 #else
    int w = GetDialogBaseUnits() - 1;


### PR DESCRIPTION
## Purpose

Fix black cross drawing.
JIRA issue: [CORE-19403](https://jira.reactos.org/browse/CORE-19403), [CORE-19405](https://jira.reactos.org/browse/CORE-19405)

## Proposed changes

- Fix `HRGN` handle leak.
- Fix black cross coordinates.

## TODO

- [x] Do tests.

## Comparison

BEFORE:
![before](https://github.com/reactos/reactos/assets/2107452/c35e8019-5935-41e9-9071-77981e04adcf)
The black cross is not drawn.

AFTER:
![after](https://github.com/reactos/reactos/assets/2107452/2f320bc0-d5ff-4fc5-b4aa-aea56a2c750f)
The black cross is correctly drawn.

Win10:
![Win10](https://github.com/reactos/reactos/assets/2107452/b04bc9cf-464d-4c8f-b499-53e6bde1e411)
The black cross is correctly drawn.