### PR TITLE
[SHELL32] Fix status bar part sizes

### DIFF
--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -1784,7 +1784,7 @@ LRESULT CDefView::OnSize(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled
 
     _DoFolderViewCB(SFVM_SIZE, 0, 0);
 
-    _HandleStatusBarResize(wWidth);
+    _ForceStatusBarResize();
     UpdateStatusbar();
 
     return 0;


### PR DESCRIPTION
## Purpose

Based on KRosUser's `cdefview_fixstatus.patch`.
JIRA issue: [CORE-19406](https://jira.reactos.org/browse/CORE-19406)

## Proposed changes

- In `CDefView::OnSize`, call `_ForceStatusBarResize` function instead of `_HandleStatusBarResize` function.

## TODO

- [x] Do tests.