### PR TITLE
[IMM32] Disable some annoying logging

### DIFF
--- a/dll/win32/imm32/imm.c
+++ b/dll/win32/imm32/imm.c
@@ -834,7 +834,6 @@ Fail:
     return FALSE;
 }
 
-// Win: InternalImmLockIMC
 LPINPUTCONTEXT APIENTRY Imm32InternalLockIMC(HIMC hIMC, BOOL fSelect)
 {
     HANDLE hIC;
@@ -846,7 +845,7 @@ LPINPUTCONTEXT APIENTRY Imm32InternalLockIMC(HIMC hIMC, BOOL fSelect)
     PIMEDPI pImeDpi = NULL;
 
     pClientImc = ImmLockClientImc(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pClientImc))
+    if (!pClientImc)
         return NULL;
 
     RtlEnterCriticalSection(&pClientImc->cs);
@@ -946,7 +945,7 @@ PCLIENTIMC WINAPI ImmLockClientImc(HIMC hImc)
         return NULL;
 
     pIMC = ValidateHandle(hImc, TYPE_INPUTCONTEXT);
-    if (IS_NULL_UNEXPECTEDLY(pIMC) || !Imm32CheckImcProcess(pIMC))
+    if (!pIMC || !Imm32CheckImcProcess(pIMC))
         return NULL;
 
     pClientImc = (PCLIENTIMC)pIMC->dwClientImcData;


### PR DESCRIPTION
## Purpose

@HBelusca said in ReactOS Chat:
> hi, is it possible to disable those two dprints?
>
> > err:(../dll/win32/imm32/imm.c:949) pIMC was NULL
> > err:(../dll/win32/imm32/imm.c:849) pClientImc was NULL
>
> they come out every other second of usage of any app in ReactOS.

JIRA issue: [CORE-19268](https://jira.reactos.org/browse/CORE-19268)

## Proposed changes

- Disable logging on two points by not using `IS_NULL_UNEXPECTEDLY` macro.

## TODO

- [x] Do tests.