### PR TITLE
[REGEDIT] Fix condition of enabling load/unload hive menu item

### DIFF
--- a/base/applications/regedit/childwnd.c
+++ b/base/applications/regedit/childwnd.c
@@ -272,8 +272,8 @@ UpdateAddress(HTREEITEM hItem, HKEY hRootKey, LPCWSTR pszPath, BOOL bSelectNone)
             EnableMenuItem(hMenuFrame, ID_REGISTRY_LOADHIVE, MF_BYCOMMAND | MF_GRAYED);
             EnableMenuItem(hMenuFrame, ID_REGISTRY_UNLOADHIVE, MF_BYCOMMAND | MF_GRAYED);
             /* compare the strings to see if we should enable/disable the "Load Hive" menus accordingly */
-            if (_wcsicmp(rootName, L"HKEY_LOCAL_MACHINE") != 0 ||
-                _wcsicmp(rootName, L"HKEY_USERS") != 0)
+            if (_wcsicmp(rootName, L"HKEY_LOCAL_MACHINE") == 0 ||
+                _wcsicmp(rootName, L"HKEY_USERS") == 0)
             {
                 /*
                  * enable the unload menu item if at the root, otherwise


### PR DESCRIPTION
## Purpose

Based on KRosUser's `regedit_loadfix.patch`.
JIRA issue: [CORE-19298](https://jira.reactos.org/browse/CORE-19298)

## Proposed changes

- Fix the condition of enabling/disabling the "Load Hive" and `Unload Hive` menu items.

## TODO

- [x] Do tests.