### PR TITLE
[TCPIP] Update link status each time link goes up

### DIFF
--- a/drivers/network/tcpip/datalink/lan.c
+++ b/drivers/network/tcpip/datalink/lan.c
@@ -718,7 +718,7 @@ BOOLEAN ReconfigureAdapter(PRECONFIGURE_CONTEXT Context)
 {
     PLAN_ADAPTER Adapter = Context->Adapter;
     PIP_INTERFACE Interface = Adapter->Context;
-    //NDIS_STATUS NdisStatus;
+    NDIS_STATUS NdisStatus;
     IP_ADDRESS DefaultMask;
 
     /* Initialize the default unspecified address (0.0.0.0) */
@@ -754,47 +754,40 @@ BOOLEAN ReconfigureAdapter(PRECONFIGURE_CONTEXT Context)
     TCPUpdateInterfaceIPInformation(Interface);
     TCPUpdateInterfaceLinkStatus(Interface);
 
-    /* We're done here if the adapter isn't connected */
-    if (Context->State != LAN_STATE_STARTED)
+    if (Context->State == LAN_STATE_STARTED)
     {
-        Adapter->State = Context->State;
-        return TRUE;
+        /* Get maximum link speed */
+        NdisStatus = NDISCall(Adapter,
+                              NdisRequestQueryInformation,
+                              OID_GEN_LINK_SPEED,
+                              &Interface->Speed,
+                              sizeof(Interface->Speed));
+
+        if (!NT_SUCCESS(NdisStatus))
+            Interface->Speed = IP_DEFAULT_LINK_SPEED;
+
+        Adapter->Speed = Interface->Speed * 100L;
+
+        /* Get maximum frame size */
+        NdisStatus = NDISCall(Adapter,
+                              NdisRequestQueryInformation,
+                              OID_GEN_MAXIMUM_FRAME_SIZE,
+                              &Adapter->MTU,
+                              sizeof(Adapter->MTU));
+        if (NdisStatus != NDIS_STATUS_SUCCESS)
+            return FALSE;
+
+        Interface->MTU = Adapter->MTU;
+
+        /* Get maximum packet size */
+        NdisStatus = NDISCall(Adapter,
+                              NdisRequestQueryInformation,
+                              OID_GEN_MAXIMUM_TOTAL_SIZE,
+                              &Adapter->MaxPacketSize,
+                              sizeof(Adapter->MaxPacketSize));
+        if (NdisStatus != NDIS_STATUS_SUCCESS)
+            return FALSE;
     }
-
-    /* NDIS Bug! */
-#if 0
-    /* Get maximum link speed */
-    NdisStatus = NDISCall(Adapter,
-                          NdisRequestQueryInformation,
-                          OID_GEN_LINK_SPEED,
-                          &Interface->Speed,
-                          sizeof(UINT));
-
-    if (!NT_SUCCESS(NdisStatus))
-        Interface->Speed = IP_DEFAULT_LINK_SPEED;
-
-    Adapter->Speed = Interface->Speed * 100L;
-
-    /* Get maximum frame size */
-    NdisStatus = NDISCall(Adapter,
-                          NdisRequestQueryInformation,
-                          OID_GEN_MAXIMUM_FRAME_SIZE,
-                          &Adapter->MTU,
-                          sizeof(UINT));
-    if (NdisStatus != NDIS_STATUS_SUCCESS)
-        return FALSE;
-
-    Interface->MTU = Adapter->MTU;
-
-    /* Get maximum packet size */
-    NdisStatus = NDISCall(Adapter,
-                          NdisRequestQueryInformation,
-                          OID_GEN_MAXIMUM_TOTAL_SIZE,
-                          &Adapter->MaxPacketSize,
-                          sizeof(UINT));
-    if (NdisStatus != NDIS_STATUS_SUCCESS)
-        return FALSE;
-#endif
 
     Adapter->State = Context->State;
 

--- a/drivers/network/tcpip/datalink/lan.c
+++ b/drivers/network/tcpip/datalink/lan.c
@@ -1371,38 +1371,6 @@ BOOLEAN BindAdapter(
     TI_DbgPrint(DEBUG_DATALINK,("Adapter Description: %wZ\n",
                 &IF->Description));
 
-    /* Get maximum link speed */
-    NdisStatus = NDISCall(Adapter,
-                          NdisRequestQueryInformation,
-                          OID_GEN_LINK_SPEED,
-                          &IF->Speed,
-                          sizeof(UINT));
-
-    if (!NT_SUCCESS(NdisStatus))
-        IF->Speed = IP_DEFAULT_LINK_SPEED;
-
-    Adapter->Speed = IF->Speed * 100L;
-
-    /* Get maximum frame size */
-    NdisStatus = NDISCall(Adapter,
-                          NdisRequestQueryInformation,
-                          OID_GEN_MAXIMUM_FRAME_SIZE,
-                          &Adapter->MTU,
-                          sizeof(UINT));
-    if (NdisStatus != NDIS_STATUS_SUCCESS)
-        return FALSE;
-
-    IF->MTU = Adapter->MTU;
-
-    /* Get maximum packet size */
-    NdisStatus = NDISCall(Adapter,
-                          NdisRequestQueryInformation,
-                          OID_GEN_MAXIMUM_TOTAL_SIZE,
-                          &Adapter->MaxPacketSize,
-                          sizeof(UINT));
-    if (NdisStatus != NDIS_STATUS_SUCCESS)
-        return FALSE;
-
     /* Register interface with IP layer */
     IPRegisterInterface(IF);
 

--- a/drivers/network/tcpip/datalink/lan.c
+++ b/drivers/network/tcpip/datalink/lan.c
@@ -750,10 +750,6 @@ BOOLEAN ReconfigureAdapter(PRECONFIGURE_CONTEXT Context)
 
     Context->Adapter->CompletingReset = FALSE;
 
-    /* Update the IP and link status information cached in TCP */
-    TCPUpdateInterfaceIPInformation(Interface);
-    TCPUpdateInterfaceLinkStatus(Interface);
-
     if (Context->State == LAN_STATE_STARTED)
     {
         /* Get maximum link speed */
@@ -790,6 +786,10 @@ BOOLEAN ReconfigureAdapter(PRECONFIGURE_CONTEXT Context)
     }
 
     Adapter->State = Context->State;
+
+    /* Update the IP and link status information cached in TCP */
+    TCPUpdateInterfaceIPInformation(Interface);
+    TCPUpdateInterfaceLinkStatus(Interface);
 
     return TRUE;
 }

--- a/drivers/network/tcpip/include/lan.h
+++ b/drivers/network/tcpip/include/lan.h
@@ -52,7 +52,7 @@ typedef struct LAN_ADAPTER {
     UCHAR BCastCheck;                       /* Value to check against */
     UCHAR BCastOffset;                      /* Offset in frame to check against */
     UCHAR HeaderSize;                       /* Size of link-level header */
-    USHORT MTU;                             /* Maximum Transfer Unit */
+    UINT MTU;                               /* Maximum Transfer Unit */
     UINT MinFrameSize;                      /* Minimum frame size in bytes */
     UINT MaxPacketSize;                     /* Maximum packet size when sending */
     UINT MaxSendPackets;                    /* Maximum number of packets per send */

--- a/drivers/network/tcpip/ip/transport/tcp/if.c
+++ b/drivers/network/tcpip/ip/transport/tcp/if.c
@@ -6,6 +6,7 @@
 #include "lwip/ip.h"
 #include "lwip/api.h"
 #include "lwip/tcpip.h"
+#include <ipifcons.h>
 
 err_t
 TCPSendDataCallback(struct netif *netif, struct pbuf *p, struct ip_addr *dest)
@@ -80,7 +81,6 @@ TCPSendDataCallback(struct netif *netif, struct pbuf *p, struct ip_addr *dest)
 VOID
 TCPUpdateInterfaceLinkStatus(PIP_INTERFACE IF)
 {
-#if 0
     ULONG OperationalStatus;
 
     GetInterfaceConnectionStatus(IF, &OperationalStatus);
@@ -89,7 +89,6 @@ TCPUpdateInterfaceLinkStatus(PIP_INTERFACE IF)
         netif_set_link_up(IF->TCPContext);
     else
         netif_set_link_down(IF->TCPContext);
-#endif
 }
 
 err_t


### PR DESCRIPTION
## Purpose

Fix some problems found in lwIP glue related to link status:
- NETIF_FLAG_LINK_UP was not updated properly
- Link speed, MTU and MaxPacketSize were only queried once (at init)

This will also ease update to lwIP 2.x, which requires NETIF_FLAG_LINK_UP to be set correctly.

## Proposed changes

- Update NETIF_FLAG_LINK_UP flag by calling netif_set_link_up/netif_set_link_down
- Update link speed, MTU and MaxPacketSize only when adapter goes to connected state