### PR TITLE
[SCSIPORT] ScsiPortDeviceControl: Add IOCTL_ATA_* stub

### DIFF
--- a/drivers/storage/port/scsiport/ioctl.c
+++ b/drivers/storage/port/scsiport/ioctl.c
@@ -538,6 +538,16 @@ ScsiPortDeviceControl(
             status = STATUS_NOT_IMPLEMENTED;
             break;
 
+        case IOCTL_ATA_PASS_THROUGH:
+            DPRINT1("IOCTL_ATA_PASS_THROUGH unimplemented!\n");
+            status = STATUS_NOT_IMPLEMENTED;
+            break;
+
+        case IOCTL_ATA_PASS_THROUGH_DIRECT:
+            DPRINT1("IOCTL_ATA_PASS_THROUGH_DIRECT unimplemented!\n");
+            status = STATUS_NOT_IMPLEMENTED;
+            break;
+
         default:
             DPRINT1("unknown ioctl code: 0x%lX\n", Stack->Parameters.DeviceIoControl.IoControlCode);
             status = STATUS_NOT_SUPPORTED;


### PR DESCRIPTION
## Purpose
Fix system freeze when copying/extracting files on BTRFS.

I found that after the hang, ReactOS prints this error to the debug log:
`(drivers/storage/port/scsiport/ioctl.c:542) unknown ioctl code: 0x4d02c`

Note: `0x4d02c` is `IOCTL_ATA_PASS_THROUGH`

JIRA issue: Not sure but I think it's related to [CORE-18406](https://jira.reactos.org/browse/CORE-18406).