### PR TITLE
[SHELL32] RegFolder must correctly handle GetDisplayNameOf parsing paths

### DIFF
--- a/dll/win32/shell32/folders/CRegFolder.cpp
+++ b/dll/win32/shell32/folders/CRegFolder.cpp
@@ -669,7 +669,7 @@ HRESULT WINAPI CRegFolder::GetDisplayNameOf(PCUITEMID_CHILD pidl, DWORD dwFlags,
             }
         }
 
-        if (SUCCEEDED(hr) && pathlen + 2 + 38 < cchPath)
+        if (SUCCEEDED(hr) && pathlen + 2 + 38 + 1 < cchPath)
         {
             /* parsing name like ::{...} */
             pItemName[0] = L':';

--- a/dll/win32/shell32/folders/CRegFolder.cpp
+++ b/dll/win32/shell32/folders/CRegFolder.cpp
@@ -654,9 +654,11 @@ HRESULT WINAPI CRegFolder::GetDisplayNameOf(PCUITEMID_CHILD pidl, DWORD dwFlags,
         PWCHAR pItemName = pszPath; // GET_SHGDN_RELATION(dwFlags) == SHGDN_INFOLDER
         if (GET_SHGDN_RELATION(dwFlags) != SHGDN_INFOLDER)
         {
-            if (SUCCEEDED(hr = StringCchCopyW(pszPath, cchPath, m_rootPath)))
+            hr = StringCchCopyW(pszPath, cchPath, m_rootPath);
+            if (SUCCEEDED(hr))
             {
-                pItemName = &pszPath[pathlen = wcslen(pszPath)];
+                pathlen = wcslen(pszPath);
+                pItemName = &pszPath[pathlen];
                 if (pathlen)
                 {
                     if (++pathlen < cchPath)
@@ -670,9 +672,9 @@ HRESULT WINAPI CRegFolder::GetDisplayNameOf(PCUITEMID_CHILD pidl, DWORD dwFlags,
         if (SUCCEEDED(hr) && pathlen + 2 + 38 < cchPath)
         {
             /* parsing name like ::{...} */
-            pItemName[0] = ':';
-            pItemName[1] = ':';
-            SHELL32_GUIDToStringW (*clsid, &pItemName[2]);
+            pItemName[0] = L':';
+            pItemName[1] = L':';
+            SHELL32_GUIDToStringW(*clsid, &pItemName[2]);
         }
         else
         {
@@ -682,7 +684,7 @@ HRESULT WINAPI CRegFolder::GetDisplayNameOf(PCUITEMID_CHILD pidl, DWORD dwFlags,
     else
     {
         /* user friendly name */
-        if (!HCR_GetClassNameW (*clsid, pszPath, cchPath))
+        if (!HCR_GetClassNameW(*clsid, pszPath, cchPath))
             hr = E_FAIL;
     }
 


### PR DESCRIPTION
Must add `\` path separator and handle INFOLDER.


## Test

```C++
static HRESULT MySHGetNameFromIDList(PCIDLIST_ABSOLUTE pidl, UINT sigdn, PWSTR*str)
{
	*str = NULL;
	IShellFolder *pSF;
	PCUITEMID_CHILD child;
	HRESULT hr = SHBindToParent(pidl, IID_PPV_ARG(IShellFolder, &pSF), &child);
	if (SUCCEEDED(hr))
	{
		STRRET sr;
		hr = pSF->GetDisplayNameOf(child, SHGDNF(LOWORD(sigdn)), &sr);
		pSF->Release();
		if (SUCCEEDED(hr)) hr = StrRetToStrW(&sr, child, str);
	}
	return hr;
}
...

PIDLIST_ABSOLUTE pidl;
SHGetSpecialFolderLocation(NULL, CSIDL_CONTROLS, &pidl);
PWSTR disp, rel, full;
MySHGetNameFromIDList(pidl, SIGDN_NORMALDISPLAY, &disp);
MySHGetNameFromIDList(pidl, SIGDN_PARENTRELATIVEPARSING, &rel);
MySHGetNameFromIDList(pidl, SIGDN_DESKTOPABSOLUTEPARSING, &full);
wprintf(L"%ls (%ls)\n%ls\n", disp, rel, full);
```

## Before
```
Control Panel (::{20D04FE0-3AEA-1069-A2D8-08002B30309D}::{21ec2020-3aea-1069-a2dd-08002b30309d})
::{20D04FE0-3AEA-1069-A2D8-08002B30309D}::{21ec2020-3aea-1069-a2dd-08002b30309d}
```

## After
```
Control Panel (::{21ec2020-3aea-1069-a2dd-08002b30309d})
::{20D04FE0-3AEA-1069-A2D8-08002B30309D}\::{21ec2020-3aea-1069-a2dd-08002b30309d}
```

This output matches NT5.