### PR TITLE
[COMCTL32][USER32] RadioButton: Notify BN_CLICKED on WM_SETFOCUS

### DIFF
--- a/dll/win32/comctl32/button.c
+++ b/dll/win32/comctl32/button.c
@@ -1043,6 +1043,10 @@ static LRESULT CALLBACK BUTTON_WindowProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
         paint_button( infoPtr, btn_type, ODA_FOCUS );
         if (style & BS_NOTIFY)
             BUTTON_NOTIFY_PARENT(hWnd, BN_SETFOCUS);
+#ifdef __REACTOS__
+        if ((btn_type == BS_RADIOBUTTON) || (btn_type == BS_AUTORADIOBUTTON))
+            BUTTON_NOTIFY_PARENT(hWnd, BN_CLICKED);
+#endif
         break;
 
     case WM_KILLFOCUS:

--- a/dll/win32/comctl32/button.c
+++ b/dll/win32/comctl32/button.c
@@ -1044,8 +1044,11 @@ static LRESULT CALLBACK BUTTON_WindowProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
         if (style & BS_NOTIFY)
             BUTTON_NOTIFY_PARENT(hWnd, BN_SETFOCUS);
 #ifdef __REACTOS__
-        if ((btn_type == BS_RADIOBUTTON) || (btn_type == BS_AUTORADIOBUTTON))
+        if (((btn_type == BS_RADIOBUTTON) || (btn_type == BS_AUTORADIOBUTTON)) &&
+            !(get_button_state(hWnd) & BST_CHECKED))
+        {
             BUTTON_NOTIFY_PARENT(hWnd, BN_CLICKED);
+        }
 #endif
         break;
 

--- a/dll/win32/comctl32/button.c
+++ b/dll/win32/comctl32/button.c
@@ -1045,7 +1045,7 @@ static LRESULT CALLBACK BUTTON_WindowProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
             BUTTON_NOTIFY_PARENT(hWnd, BN_SETFOCUS);
 #ifdef __REACTOS__
         if (((btn_type == BS_RADIOBUTTON) || (btn_type == BS_AUTORADIOBUTTON)) &&
-            !(get_button_state(hWnd) & BST_CHECKED))
+            !(infoPtr->state & BST_CHECKED))
         {
             BUTTON_NOTIFY_PARENT(hWnd, BN_CLICKED);
         }

--- a/win32ss/user/user32/controls/button.c
+++ b/win32ss/user/user32/controls/button.c
@@ -533,8 +533,11 @@ LRESULT WINAPI ButtonWndProc_common(HWND hWnd, UINT uMsg,
         if (style & BS_NOTIFY)
             BUTTON_NOTIFY_PARENT(hWnd, BN_SETFOCUS);
 #ifdef __REACTOS__
-        if ((btn_type == BS_RADIOBUTTON) || (btn_type == BS_AUTORADIOBUTTON))
+        if (((btn_type == BS_RADIOBUTTON) || (btn_type == BS_AUTORADIOBUTTON)) &&
+            !(get_button_state(hWnd) & BST_CHECKED))
+        {
             BUTTON_NOTIFY_PARENT(hWnd, BN_CLICKED);
+        }
 #endif
         break;
 

--- a/win32ss/user/user32/controls/button.c
+++ b/win32ss/user/user32/controls/button.c
@@ -532,6 +532,10 @@ LRESULT WINAPI ButtonWndProc_common(HWND hWnd, UINT uMsg,
         paint_button( hWnd, btn_type, ODA_FOCUS );
         if (style & BS_NOTIFY)
             BUTTON_NOTIFY_PARENT(hWnd, BN_SETFOCUS);
+#ifdef __REACTOS__
+        if ((btn_type == BS_RADIOBUTTON) || (btn_type == BS_AUTORADIOBUTTON))
+            BUTTON_NOTIFY_PARENT(hWnd, BN_CLICKED);
+#endif
         break;
 
     case WM_KILLFOCUS:


### PR DESCRIPTION
## Purpose

Based on KRosUser's `button_fixnotif.patch`.
JIRA issue: [CORE-6542](https://jira.reactos.org/browse/CORE-6542), [CORE-19384](https://jira.reactos.org/browse/CORE-19384)

## Proposed changes

- Notify `BN_CLICKED` to the parent on `WM_SETFOCUS` message handling if the button type was either `BS_RADIOBUTTON` or `BS_AUTORADIOBUTTON`, and if the button was unchecked.

## TODO

- [x] Do small tests.
- [x] Do big tests.