### PR TITLE
[RAPPS] Don't ask for 'remote from registry' when no selection

### DIFF
--- a/base/applications/rapps/gui.cpp
+++ b/base/applications/rapps/gui.cpp
@@ -270,14 +270,12 @@ CMainWindow::RemoveSelectedAppFromRegistry()
     if (!szMsgText.LoadStringW(IDS_APP_REG_REMOVE) || !szMsgTitle.LoadStringW(IDS_INFORMATION))
         return FALSE;
 
-    if (MessageBoxW(szMsgText, szMsgTitle, MB_YESNO | MB_ICONQUESTION) == IDYES)
-    {
-        CAppInfo *InstalledApp = (CAppInfo *)m_ApplicationView->GetFocusedItemData();
-        if (!InstalledApp)
-            return FALSE;
+    CAppInfo *InstalledApp = (CAppInfo *)m_ApplicationView->GetFocusedItemData();
+    if (!InstalledApp)
+        return FALSE;
 
+    if (MessageBoxW(szMsgText, szMsgTitle, MB_YESNO | MB_ICONQUESTION) == IDYES)
         return m_Db->RemoveInstalledAppFromRegistry(InstalledApp);
-    }
 
     return FALSE;
 }


### PR DESCRIPTION
## Purpose

Based on KRosUser's `RAPPS.patch`.
JIRA issue: [CORE-19409](https://jira.reactos.org/browse/CORE-19409)

## Proposed changes

- If `m_ApplicationView->GetFocusedItemData` was `NULL`, then do not ask for removal.

## TODO

- [x] Do tests.