### PR TITLE
[FREELDR][NTOS:MM] Add security cookie generation to FreeLoader

### DIFF
--- a/boot/freeldr/freeldr/include/peloader.h
+++ b/boot/freeldr/freeldr/include/peloader.h
@@ -56,3 +56,7 @@ PeLdrCheckForLoadedDll(
     IN OUT PLIST_ENTRY ModuleListHead,
     IN PCH DllName,
     OUT PLDR_DATA_TABLE_ENTRY *LoadedEntry);
+
+PVOID
+PeLdrInitSecurityCookie(
+    _In_ PLDR_DATA_TABLE_ENTRY LdrEntry);

--- a/boot/freeldr/freeldr/ntldr/winldr.c
+++ b/boot/freeldr/freeldr/ntldr/winldr.c
@@ -342,6 +342,9 @@ WinLdrLoadDeviceDriver(PLIST_ENTRY LoadOrderListHead,
         return FALSE;
     }
 
+    /* Init security cookie */
+    PeLdrInitSecurityCookie(*DriverDTE);
+
     // Modify any flags, if needed
     (*DriverDTE)->Flags |= Flags;
 
@@ -537,8 +540,11 @@ LoadModule(
         /* Cleanup and bail out */
         ERR("PeLdrAllocateDataTableEntry('%s') failed\n", FullFileName);
         MmFreeMemory(BaseAddress);
-        BaseAddress = NULL;
+        return NULL;
     }
+
+    /* Init security cookie */
+    PeLdrInitSecurityCookie(*Dte);
 
     return BaseAddress;
 }


### PR DESCRIPTION
Add support for security cookie generation in Freeloader (based on the code from [kernel](https://github.com/reactos/reactos/blob/88107adc9249bcc7eb691a8b3f97a797bb58d5ab/ntoskrnl/mm/ARM3/sysldr.c#L2898)). This allows core modules (kernel/HAL/KD dlls) or boot-start drivers from Windows 8+ loaded with FreeLDR to work (on master+this PR, this can be already tested with null.sys from Windows 8 RTM loaded as a boot-start driver). 

JIRA issue: [CORE-17808](https://jira.reactos.org/browse/CORE-17808)