### PR TITLE
[NTOSKRNL_VISTA] IoQueueWorkItemEx: Pass new context for the queue

### DIFF
--- a/sdk/lib/drivers/ntoskrnl_vista/io.c
+++ b/sdk/lib/drivers/ntoskrnl_vista/io.c
@@ -63,7 +63,7 @@ IoQueueWorkItemEx(
     newContext->WorkItemRoutineEx = WorkerRoutine;
     newContext->Context = Context;
 
-    IoQueueWorkItem(IoWorkItem, IopWorkItemExCallback, QueueType, Context);
+    IoQueueWorkItem(IoWorkItem, IopWorkItemExCallback, QueueType, newContext);
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)


### PR DESCRIPTION
Passing parameter-provided context results in missing WorkerRoutine and WorkItem when callback is executed.