### PR TITLE
[CTFMON][MSCTFIME][SDK] Define new(cicNoThrow) and use it

### DIFF
--- a/base/applications/ctfmon/ctfmon.cpp
+++ b/base/applications/ctfmon/ctfmon.cpp
@@ -224,7 +224,7 @@ InitApp(
         CRegWatcher::Init();
 
     // Create Tipbar loader window
-    g_pLoaderWnd = new CLoaderWnd();
+    g_pLoaderWnd = new(cicNoThrow) CLoaderWnd();
     if (!g_pLoaderWnd || !g_pLoaderWnd->Init())
         return FALSE;
 

--- a/dll/ime/msctfime/msctfime.cpp
+++ b/dll/ime/msctfime/msctfime.cpp
@@ -1598,7 +1598,7 @@ CFunctionProvider::GetFunction(
     if (IsEqualGUID(guid, GUID_NULL) &&
         IsEqualIID(riid, IID_IAImmFnDocFeed))
     {
-        *func = new CFnDocFeed();
+        *func = new(cicNoThrow) CFnDocFeed();
         if (*func)
             return S_OK;
     }
@@ -2147,7 +2147,7 @@ CicProfile::InitProfileInstance(_Inout_ TLS *pTLS)
     if (!m_pActiveLanguageProfileNotifySink)
     {
         CActiveLanguageProfileNotifySink *pSink =
-            new CActiveLanguageProfileNotifySink(
+            new(cicNoThrow) CActiveLanguageProfileNotifySink(
                 CicProfile::ActiveLanguageProfileNotifySinkCallback, this);
         if (!pSink)
         {
@@ -2326,7 +2326,7 @@ CicBridge::CreateInputContext(
     CicInputContext *pCicIC = imeContext.get().m_pCicIC;
     if (!pCicIC)
     {
-        pCicIC = new CicInputContext(m_cliendId, &m_LibThread, hIMC);
+        pCicIC = new(cicNoThrow) CicInputContext(m_cliendId, &m_LibThread, hIMC);
         if (!pCicIC)
         {
             imeContext.unlock();
@@ -2531,7 +2531,7 @@ CicBridge::ActivateIMMX(
         return hr;
     }
 
-    CFunctionProvider *pProvider = new CFunctionProvider(m_cliendId);
+    CFunctionProvider *pProvider = new(cicNoThrow) CFunctionProvider(m_cliendId);
     if (!pProvider)
     {
         hr = E_FAIL;
@@ -2645,7 +2645,7 @@ CicBridge::InitIMMX(_Inout_ TLS *pTLS)
     if (!m_pThreadMgrEventSink)
     {
         m_pThreadMgrEventSink =
-            new CThreadMgrEventSink(CThreadMgrEventSink::DIMCallback, NULL, NULL);
+            new(cicNoThrow) CThreadMgrEventSink(CThreadMgrEventSink::DIMCallback, NULL, NULL);
         if (!m_pThreadMgrEventSink)
         {
             UnInitIMMX(pTLS);
@@ -2658,7 +2658,7 @@ CicBridge::InitIMMX(_Inout_ TLS *pTLS)
 
     if (!pTLS->m_pProfile)
     {
-        pTLS->m_pProfile = new CicProfile();
+        pTLS->m_pProfile = new(cicNoThrow) CicProfile();
         if (!pTLS->m_pProfile)
             return E_OUTOFMEMORY;
 
@@ -3297,7 +3297,7 @@ CtfImeCreateThreadMgr(VOID)
 
     if (!pTLS->m_pBridge)
     {
-        pTLS->m_pBridge = new CicBridge();
+        pTLS->m_pBridge = new(cicNoThrow) CicBridge();
         if (!pTLS->m_pBridge)
             return E_OUTOFMEMORY;
     }
@@ -3337,7 +3337,7 @@ CtfImeDestroyThreadMgr(VOID)
 
     if (pTLS->m_pBridge)
     {
-        pTLS->m_pBridge = new CicBridge();
+        pTLS->m_pBridge = new(cicNoThrow) CicBridge();
         if (!pTLS->m_pBridge)
             return E_OUTOFMEMORY;
     }
@@ -3604,7 +3604,7 @@ UI::~UI()
  */
 HRESULT UI::_Create()
 {
-    m_pComp = new UIComposition();
+    m_pComp = new(cicNoThrow) UIComposition();
     if (!m_pComp)
         return E_OUTOFMEMORY;
 
@@ -3630,7 +3630,7 @@ void UI::OnCreate(HWND hWnd)
     UI *pUI = (UI*)GetWindowLongPtrW(hWnd, UIGWLP_UI);
     if (pUI)
         return;
-    pUI = new UI(hWnd);
+    pUI = new(cicNoThrow) UI(hWnd);
     if (pUI)
         pUI->_Create();
 }

--- a/sdk/include/reactos/cicero/cicbase.h
+++ b/sdk/include/reactos/cicero/cicbase.h
@@ -35,7 +35,7 @@ static inline void cicMemFree(LPVOID ptr)
 }
 
 struct CicNoThrow { };
-#define cicNoThrow CicNoThrow()
+#define cicNoThrow CicNoThrow{}
 
 inline void* operator new(size_t size, const CicNoThrow&) noexcept
 {

--- a/sdk/include/reactos/cicero/cicbase.h
+++ b/sdk/include/reactos/cicero/cicbase.h
@@ -34,17 +34,30 @@ static inline void cicMemFree(LPVOID ptr)
         LocalFree(ptr);
 }
 
-inline void* __cdecl operator new(size_t size) noexcept
+struct CicNoThrow { };
+#define cicNoThrow CicNoThrow()
+
+inline void* operator new(size_t size, const CicNoThrow&) noexcept
 {
     return cicMemAllocClear(size);
 }
-
-inline void __cdecl operator delete(void* ptr) noexcept
+inline void* operator new[](size_t size, const CicNoThrow&) noexcept
+{
+    return cicMemAllocClear(size);
+}
+inline void operator delete(void* ptr) noexcept
 {
     cicMemFree(ptr);
 }
-
-inline void __cdecl operator delete(void* ptr, size_t size) noexcept
+inline void operator delete[](void* ptr) noexcept
+{
+    cicMemFree(ptr);
+}
+inline void operator delete(void* ptr, size_t size) noexcept
+{
+    cicMemFree(ptr);
+}
+inline void operator delete[](void* ptr, size_t size) noexcept
 {
     cicMemFree(ptr);
 }


### PR DESCRIPTION
## Purpose

Use `new(cicNoThrow)` instead of plain operator `new`.
JIRA issue: [CORE-19360](https://jira.reactos.org/browse/CORE-19360)

## Proposed changes

- Define `CicNoThrow` structure and `cicNoThrow` macro in `<cicero/cicbase.h>`.
- Use `new(cicNoThrow)` instead of plain operator `new`.

## TODO

- [x] Do build.