### PR TITLE
[SHELL32] Don't crash on Control Panel item D&D

### DIFF
--- a/dll/win32/shell32/shlfileop.cpp
+++ b/dll/win32/shell32/shlfileop.cpp
@@ -1336,7 +1336,11 @@ static void copy_dir_to_dir(FILE_OPERATION *op, const FILE_ENTRY *feFrom, LPCWST
     WCHAR szFrom[MAX_PATH], szTo[MAX_PATH];
     FILE_LIST flFromNew, flToNew;
 
+#ifdef __REACTOS__
+    if (feFrom->szFilename && IsDotDir(feFrom->szFilename))
+#else
     if (IsDotDir(feFrom->szFilename))
+#endif
         return;
 
     if (PathFileExistsW(szDestPath))
@@ -1719,7 +1723,11 @@ static void move_dir_to_dir(FILE_OPERATION *op, const FILE_ENTRY *feFrom, LPCWST
     WCHAR szFrom[MAX_PATH], szTo[MAX_PATH];
     FILE_LIST flFromNew, flToNew;
 
+#ifdef __REACTOS__
+    if (feFrom->szFilename && IsDotDir(feFrom->szFilename))
+#else
     if (IsDotDir(feFrom->szFilename))
+#endif
         return;
 
     SHNotifyCreateDirectoryW(szDestPath, NULL);


### PR DESCRIPTION
## Purpose

Based on @DougLyons 's `control-panel-copy-to-desktop-fix.patch`.
JIRA issue: [CORE-19210](https://jira.reactos.org/browse/CORE-19210)

## Proposed changes

- Delete needless `#ifdef __REACTOS__` guards because `shlfileop.cpp` is a forked file.
- Do `NULL` check against `feFrom->szFilename`.

## TODO

- [x] Do tests.