### PR TITLE
[SDK] cicuif.h: Add CUIFColorTable

### DIFF
--- a/sdk/include/reactos/cicero/cicbase.h
+++ b/sdk/include/reactos/cicero/cicbase.h
@@ -62,20 +62,6 @@ inline void operator delete[](void* ptr, size_t size) noexcept
     cicMemFree(ptr);
 }
 
-template <typename T_FN>
-static inline BOOL
-cicGetFN(HINSTANCE& hinstDLL, T_FN& fn, LPCTSTR pszDllName, LPCSTR pszFuncName)
-{
-    if (fn)
-        return TRUE;
-    if (!hinstDLL)
-        hinstDLL = LoadLibrary(pszDllName);
-    if (!hinstDLL)
-        return FALSE;
-    fn = reinterpret_cast<T_FN>(GetProcAddress(hinstDLL, pszFuncName));
-    return !!fn;
-}
-
 typedef struct CIC_LIBTHREAD
 {
     IUnknown *m_pUnknown1;
@@ -174,6 +160,20 @@ cicLoadSystemLibrary(
     if (!ModPath.Init(pszFileName, bSysWinDir))
         return NULL;
     return ::LoadLibrary(ModPath.m_szPath);
+}
+
+template <typename T_FN>
+static inline BOOL
+cicGetFN(HINSTANCE& hinstDLL, T_FN& fn, LPCTSTR pszDllName, LPCSTR pszFuncName)
+{
+    if (fn)
+        return TRUE;
+    if (!hinstDLL)
+        hinstDLL = cicLoadSystemLibrary(pszDllName, FALSE);
+    if (!hinstDLL)
+        return FALSE;
+    fn = reinterpret_cast<T_FN>(GetProcAddress(hinstDLL, pszFuncName));
+    return !!fn;
 }
 
 #include <ndk/pstypes.h> /* for PROCESSINFOCLASS */


### PR DESCRIPTION
## Purpose

Supporting TIPs...
JIRA issue: [CORE-19360](https://jira.reactos.org/browse/CORE-19360)

## Proposed changes

- Improve `cicGetFN` function.
- Add `CUIFColorTable`, `CUIFColorTableSys`, and `CUIFColorTableOff10` classes.
- Implement `cicInitUIFScheme`, `cicUpdateUIFScheme`, and `cicDoneUIFScheme` functions.

## TODO

- [x] Do build.