### PR TITLE
[SHELL32] Don't copy or move unless filesystem item

### DIFF
--- a/dll/win32/shell32/droptargets/CFSDropTarget.cpp
+++ b/dll/win32/shell32/droptargets/CFSDropTarget.cpp
@@ -48,7 +48,7 @@ HRESULT CFSDropTarget::_CopyItems(IShellFolder * pSFFrom, UINT cidl,
     for (UINT i = 0; i < cidl; i++)
     {
         SFGAOF rfg = SFGAO_FILESYSANCESTOR | SFGAO_FILESYSTEM;
-        ret = pSFFrom->GetAttributesOf(i, apidl, &rfg);
+        ret = pSFFrom->GetAttributesOf(1, apidl[i], &rfg);
         if (FAILED(ret))
             goto cleanup;
 

--- a/dll/win32/shell32/droptargets/CFSDropTarget.cpp
+++ b/dll/win32/shell32/droptargets/CFSDropTarget.cpp
@@ -47,14 +47,14 @@ HRESULT CFSDropTarget::_CopyItems(IShellFolder * pSFFrom, UINT cidl,
     /* Build a double null terminated list of C strings from source paths */
     for (UINT i = 0; i < cidl; i++)
     {
-        SFGAOF rfg = SFGAO_FILESYSANCESTOR | SFGAO_FILESYSTEM;
-        ret = pSFFrom->GetAttributesOf(1, apidl[i], &rfg);
+        SFGAOF rfg = SFGAO_FILESYSTEM;
+        ret = pSFFrom->GetAttributesOf(1, &apidl[i], &rfg);
         if (FAILED(ret))
             goto cleanup;
 
         if (!(rfg & (SFGAO_FILESYSANCESTOR | SFGAO_FILESYSTEM)))
         {
-            WARN("Skipping item without SFGAO_FILESYSANCESTOR or SFGAO_FILESYSTEM\n");
+            WARN("Skipping item without SFGAO_FILESYSTEM\n");
             continue;
         }
 

--- a/dll/win32/shell32/droptargets/CFSDropTarget.cpp
+++ b/dll/win32/shell32/droptargets/CFSDropTarget.cpp
@@ -54,7 +54,7 @@ HRESULT CFSDropTarget::_CopyItems(IShellFolder * pSFFrom, UINT cidl,
 
         if (!(rfg & (SFGAO_FILESYSANCESTOR | SFGAO_FILESYSTEM)))
         {
-            ERR("Skipping item unless (SFGAO_FILESYSANCESTOR | SFGAO_FILESYSTEM)\n");
+            WARN("Skipping item without SFGAO_FILESYSANCESTOR or SFGAO_FILESYSTEM\n");
             continue;
         }
 

--- a/dll/win32/shell32/droptargets/CFSDropTarget.cpp
+++ b/dll/win32/shell32/droptargets/CFSDropTarget.cpp
@@ -47,6 +47,17 @@ HRESULT CFSDropTarget::_CopyItems(IShellFolder * pSFFrom, UINT cidl,
     /* Build a double null terminated list of C strings from source paths */
     for (UINT i = 0; i < cidl; i++)
     {
+        SFGAOF rfg = SFGAO_FILESYSANCESTOR | SFGAO_FILESYSTEM;
+        ret = pSFFrom->GetAttributesOf(i, apidl, &rfg);
+        if (FAILED(ret))
+            goto cleanup;
+
+        if (!(rfg & (SFGAO_FILESYSANCESTOR | SFGAO_FILESYSTEM)))
+        {
+            ERR("Skipping item unless (SFGAO_FILESYSANCESTOR | SFGAO_FILESYSTEM)\n");
+            continue;
+        }
+
         ret = pSFFrom->GetDisplayNameOf(apidl[i], SHGDN_FORPARSING, &strretFrom);
         if (FAILED(ret))
             goto cleanup;


### PR DESCRIPTION
## Purpose
Based on KRosUser's `dragdrop_fix.patch`. Avoid wrong behaviour.
JIRA issue: [CORE-19211](https://jira.reactos.org/browse/CORE-19211)

## Proposed changes

- Skip item unless `SFGAO_FILESYSTEM`.

## TODO

- [x] Do tests.