### PR TITLE
[COMCTL32] ToolTip: Expand tabs

### DIFF
--- a/dll/win32/comctl32/tooltips.c
+++ b/dll/win32/comctl32/tooltips.c
@@ -349,6 +349,9 @@ TOOLTIPS_Refresh (const TOOLTIPS_INFO *infoPtr, HDC hdc)
     }
 
     /* draw text */
+#ifdef __REACTOS__
+    uFlags |= DT_EXPANDTABS;
+#endif
     DrawTextW (hdc, infoPtr->szTipText, -1, &rc, uFlags);
 
     /* Custom draw - Call PostPaint after drawing */
@@ -562,6 +565,9 @@ TOOLTIPS_CalcTipSize (const TOOLTIPS_INFO *infoPtr, LPSIZE lpSize)
         title.cx += (rcTitle.right - rcTitle.left);
     }
     hOldFont = SelectObject (hdc, infoPtr->hFont);
+#ifdef __REACTOS__
+    uFlags |= DT_EXPANDTABS;
+#endif
     DrawTextW (hdc, infoPtr->szTipText, -1, &rc, uFlags);
     SelectObject (hdc, hOldFont);
     ReleaseDC (infoPtr->hwndSelf, hdc);


### PR DESCRIPTION
## Purpose
Based on KRosUser's `tooltip_tabfix.patch`.
ToolTip should expand tabs. Otherwise they will become squares.

![KingSel](https://github.com/reactos/reactos/assets/2107452/12eaafd1-ddcc-453e-8751-d29bd2d8ee22)

JIRA issue: [CORE-5635](https://jira.reactos.org/browse/CORE-5635), [CORE-13651](https://jira.reactos.org/browse/CORE-13651)

## Proposed changes

- Add `DT_EXPANDTABS` flag for `DrawText`.

## TODO

- [x] Do tests.
