### PR TITLE
[SHELL32] SHFileOperation: Fail elegantly if source doesn't exist

### DIFF
--- a/dll/win32/shell32/shlfileop.cpp
+++ b/dll/win32/shell32/shlfileop.cpp
@@ -1737,11 +1737,11 @@ static void move_to_dir(FILE_OPERATION *op, const FILE_ENTRY *feFrom, const FILE
 {
     WCHAR szDestPath[MAX_PATH];
 
-    if (!PathFileExistsW(feTo->szFullPath))
-        SHNotifyCreateDirectoryW(feTo->szFullPath, NULL);
-
     if (feFrom->attributes == INVALID_FILE_ATTRIBUTES)
         return;
+
+    if (!PathFileExistsW(feTo->szFullPath))
+        SHNotifyCreateDirectoryW(feTo->szFullPath, NULL);
 
     PathCombineW(szDestPath, feTo->szFullPath, feFrom->szFilename);
 

--- a/dll/win32/shell32/shlfileop.cpp
+++ b/dll/win32/shell32/shlfileop.cpp
@@ -1742,6 +1742,9 @@ static void move_to_dir(FILE_OPERATION *op, const FILE_ENTRY *feFrom, const FILE
 
     PathCombineW(szDestPath, feTo->szFullPath, feFrom->szFilename);
 
+    if (feFrom->attributes == INVALID_FILE_ATTRIBUTES)
+        return;
+
     if (IsAttribFile(feFrom->attributes))
         move_file_to_file(op, feFrom->szFullPath, szDestPath);
     else if (!(op->req->fFlags & FOF_FILESONLY && feFrom->bFromWildcard))
@@ -1762,6 +1765,9 @@ static DWORD move_files(FILE_OPERATION *op, BOOL multiDest, const FILE_LIST *flF
 
     if (!flTo->dwNumFiles)
         return ERROR_FILE_NOT_FOUND;
+
+    if (flFrom->bAnyDontExist)
+        return ERROR_SHELL_INTERNAL_FILE_NOT_FOUND;
 
     if (!(multiDest) &&
         flTo->dwNumFiles > 1 && flFrom->dwNumFiles > 1)

--- a/dll/win32/shell32/shlfileop.cpp
+++ b/dll/win32/shell32/shlfileop.cpp
@@ -1735,14 +1735,13 @@ static BOOL move_file_to_file(FILE_OPERATION *op, const WCHAR *szFrom, const WCH
 /* moves a file or directory to another directory */
 static void move_to_dir(FILE_OPERATION *op, const FILE_ENTRY *feFrom, const FILE_ENTRY *feTo)
 {
-    WCHAR szDestPath[MAX_PATH];
-
     if (feFrom->attributes == INVALID_FILE_ATTRIBUTES)
         return;
 
     if (!PathFileExistsW(feTo->szFullPath))
         SHNotifyCreateDirectoryW(feTo->szFullPath, NULL);
 
+    WCHAR szDestPath[MAX_PATH];
     PathCombineW(szDestPath, feTo->szFullPath, feFrom->szFilename);
 
     if (IsAttribFile(feFrom->attributes))

--- a/dll/win32/shell32/shlfileop.cpp
+++ b/dll/win32/shell32/shlfileop.cpp
@@ -1740,10 +1740,10 @@ static void move_to_dir(FILE_OPERATION *op, const FILE_ENTRY *feFrom, const FILE
     if (!PathFileExistsW(feTo->szFullPath))
         SHNotifyCreateDirectoryW(feTo->szFullPath, NULL);
 
-    PathCombineW(szDestPath, feTo->szFullPath, feFrom->szFilename);
-
     if (feFrom->attributes == INVALID_FILE_ATTRIBUTES)
         return;
+
+    PathCombineW(szDestPath, feTo->szFullPath, feFrom->szFilename);
 
     if (IsAttribFile(feFrom->attributes))
         move_file_to_file(op, feFrom->szFullPath, szDestPath);


### PR DESCRIPTION
## Purpose

Based on KRosUser's `dragdropfixpart2.patch`.
JIRA issue: [CORE-19417](https://jira.reactos.org/browse/CORE-19417), [CORE-19211](https://jira.reactos.org/browse/CORE-19211)

## Proposed changes

- Check source file existence.
- `if (flFrom->bAnyDontExist) return ERROR_SHELL_INTERNAL_FILE_NOT_FOUND;`

## TODO

- [x] Do small tests.
- [x] Do big tests.