### PR TITLE
[RAPPS] Don't download database at startup if appwiz mode

### DIFF
--- a/base/applications/rapps/gui.cpp
+++ b/base/applications/rapps/gui.cpp
@@ -293,6 +293,16 @@ CMainWindow::UninstallSelectedApp(BOOL bModify)
     return InstalledApp->UninstallApplication(bModify);
 }
 
+VOID
+CMainWindow::CheckAvailable()
+{
+    if (m_Db->GetAvailableCount() == 0)
+    {
+        m_Db->RemoveCached();
+        m_Db->UpdateAvailable();
+    }
+}
+
 BOOL
 CMainWindow::ProcessWindowMessage(HWND hwnd, UINT Msg, WPARAM wParam, LPARAM lParam, LRESULT &theResult, DWORD dwMapId)
 {
@@ -346,74 +356,92 @@ CMainWindow::ProcessWindowMessage(HWND hwnd, UINT Msg, WPARAM wParam, LPARAM lPa
                                 break;
 
                             case IDS_AVAILABLEFORINST:
+                                CheckAvailable();
                                 UpdateApplicationsList(ENUM_ALL_AVAILABLE);
                                 break;
 
                             case IDS_CAT_AUDIO:
+                                CheckAvailable();
                                 UpdateApplicationsList(ENUM_CAT_AUDIO);
                                 break;
 
                             case IDS_CAT_DEVEL:
+                                CheckAvailable();
                                 UpdateApplicationsList(ENUM_CAT_DEVEL);
                                 break;
 
                             case IDS_CAT_DRIVERS:
+                                CheckAvailable();
                                 UpdateApplicationsList(ENUM_CAT_DRIVERS);
                                 break;
 
                             case IDS_CAT_EDU:
+                                CheckAvailable();
                                 UpdateApplicationsList(ENUM_CAT_EDU);
                                 break;
 
                             case IDS_CAT_ENGINEER:
+                                CheckAvailable();
                                 UpdateApplicationsList(ENUM_CAT_ENGINEER);
                                 break;
 
                             case IDS_CAT_FINANCE:
+                                CheckAvailable();
                                 UpdateApplicationsList(ENUM_CAT_FINANCE);
                                 break;
 
                             case IDS_CAT_GAMES:
+                                CheckAvailable();
                                 UpdateApplicationsList(ENUM_CAT_GAMES);
                                 break;
 
                             case IDS_CAT_GRAPHICS:
+                                CheckAvailable();
                                 UpdateApplicationsList(ENUM_CAT_GRAPHICS);
                                 break;
 
                             case IDS_CAT_INTERNET:
+                                CheckAvailable();
                                 UpdateApplicationsList(ENUM_CAT_INTERNET);
                                 break;
 
                             case IDS_CAT_LIBS:
+                                CheckAvailable();
                                 UpdateApplicationsList(ENUM_CAT_LIBS);
                                 break;
 
                             case IDS_CAT_OFFICE:
+                                CheckAvailable();
                                 UpdateApplicationsList(ENUM_CAT_OFFICE);
                                 break;
 
                             case IDS_CAT_OTHER:
+                                CheckAvailable();
                                 UpdateApplicationsList(ENUM_CAT_OTHER);
                                 break;
 
                             case IDS_CAT_SCIENCE:
+                                CheckAvailable();
                                 UpdateApplicationsList(ENUM_CAT_SCIENCE);
                                 break;
 
                             case IDS_CAT_TOOLS:
+                                CheckAvailable();
                                 UpdateApplicationsList(ENUM_CAT_TOOLS);
                                 break;
 
                             case IDS_CAT_VIDEO:
+                                CheckAvailable();
                                 UpdateApplicationsList(ENUM_CAT_VIDEO);
                                 break;
 
                             case IDS_CAT_THEMES:
+                                CheckAvailable();
                                 UpdateApplicationsList(ENUM_CAT_THEMES);
                                 break;
 
                             case IDS_SELECTEDFORINST:
+                                CheckAvailable();
                                 UpdateApplicationsList(ENUM_CAT_SELECTED);
                                 break;
                         }

--- a/base/applications/rapps/gui.cpp
+++ b/base/applications/rapps/gui.cpp
@@ -356,92 +356,74 @@ CMainWindow::ProcessWindowMessage(HWND hwnd, UINT Msg, WPARAM wParam, LPARAM lPa
                                 break;
 
                             case IDS_AVAILABLEFORINST:
-                                CheckAvailable();
-                                UpdateApplicationsList(ENUM_ALL_AVAILABLE);
+                                UpdateApplicationsList(ENUM_ALL_AVAILABLE, FALSE, TRUE);
                                 break;
 
                             case IDS_CAT_AUDIO:
-                                CheckAvailable();
-                                UpdateApplicationsList(ENUM_CAT_AUDIO);
+                                UpdateApplicationsList(ENUM_CAT_AUDIO, FALSE, TRUE);
                                 break;
 
                             case IDS_CAT_DEVEL:
-                                CheckAvailable();
-                                UpdateApplicationsList(ENUM_CAT_DEVEL);
+                                UpdateApplicationsList(ENUM_CAT_DEVEL, FALSE, TRUE);
                                 break;
 
                             case IDS_CAT_DRIVERS:
-                                CheckAvailable();
-                                UpdateApplicationsList(ENUM_CAT_DRIVERS);
+                                UpdateApplicationsList(ENUM_CAT_DRIVERS, FALSE, TRUE);
                                 break;
 
                             case IDS_CAT_EDU:
-                                CheckAvailable();
-                                UpdateApplicationsList(ENUM_CAT_EDU);
+                                UpdateApplicationsList(ENUM_CAT_EDU, FALSE, TRUE);
                                 break;
 
                             case IDS_CAT_ENGINEER:
-                                CheckAvailable();
-                                UpdateApplicationsList(ENUM_CAT_ENGINEER);
+                                UpdateApplicationsList(ENUM_CAT_ENGINEER, FALSE, TRUE);
                                 break;
 
                             case IDS_CAT_FINANCE:
-                                CheckAvailable();
-                                UpdateApplicationsList(ENUM_CAT_FINANCE);
+                                UpdateApplicationsList(ENUM_CAT_FINANCE, FALSE, TRUE);
                                 break;
 
                             case IDS_CAT_GAMES:
-                                CheckAvailable();
-                                UpdateApplicationsList(ENUM_CAT_GAMES);
+                                UpdateApplicationsList(ENUM_CAT_GAMES, FALSE, TRUE);
                                 break;
 
                             case IDS_CAT_GRAPHICS:
-                                CheckAvailable();
-                                UpdateApplicationsList(ENUM_CAT_GRAPHICS);
+                                UpdateApplicationsList(ENUM_CAT_GRAPHICS, FALSE, TRUE);
                                 break;
 
                             case IDS_CAT_INTERNET:
-                                CheckAvailable();
-                                UpdateApplicationsList(ENUM_CAT_INTERNET);
+                                UpdateApplicationsList(ENUM_CAT_INTERNET, FALSE, TRUE);
                                 break;
 
                             case IDS_CAT_LIBS:
-                                CheckAvailable();
-                                UpdateApplicationsList(ENUM_CAT_LIBS);
+                                UpdateApplicationsList(ENUM_CAT_LIBS, FALSE, TRUE);
                                 break;
 
                             case IDS_CAT_OFFICE:
-                                CheckAvailable();
-                                UpdateApplicationsList(ENUM_CAT_OFFICE);
+                                UpdateApplicationsList(ENUM_CAT_OFFICE, FALSE, TRUE);
                                 break;
 
                             case IDS_CAT_OTHER:
-                                CheckAvailable();
-                                UpdateApplicationsList(ENUM_CAT_OTHER);
+                                UpdateApplicationsList(ENUM_CAT_OTHER, FALSE, TRUE);
                                 break;
 
                             case IDS_CAT_SCIENCE:
-                                CheckAvailable();
-                                UpdateApplicationsList(ENUM_CAT_SCIENCE);
+                                UpdateApplicationsList(ENUM_CAT_SCIENCE, FALSE, TRUE);
                                 break;
 
                             case IDS_CAT_TOOLS:
-                                CheckAvailable();
-                                UpdateApplicationsList(ENUM_CAT_TOOLS);
+                                UpdateApplicationsList(ENUM_CAT_TOOLS, FALSE, TRUE);
                                 break;
 
                             case IDS_CAT_VIDEO:
-                                CheckAvailable();
-                                UpdateApplicationsList(ENUM_CAT_VIDEO);
+                                UpdateApplicationsList(ENUM_CAT_VIDEO, FALSE, TRUE);
                                 break;
 
                             case IDS_CAT_THEMES:
-                                CheckAvailable();
-                                UpdateApplicationsList(ENUM_CAT_THEMES);
+                                UpdateApplicationsList(ENUM_CAT_THEMES, FALSE, TRUE);
                                 break;
 
                             case IDS_SELECTEDFORINST:
-                                CheckAvailable();
                                 UpdateApplicationsList(ENUM_CAT_SELECTED);
                                 break;
                         }
@@ -619,9 +601,12 @@ CMainWindow::AddApplicationsToView(CAtlList<CAppInfo *> &List)
 }
 
 VOID
-CMainWindow::UpdateApplicationsList(AppsCategories EnumType, BOOL bReload)
+CMainWindow::UpdateApplicationsList(AppsCategories EnumType, BOOL bReload, BOOL bCheckAvailable)
 {
     bUpdating = TRUE;
+
+    if (bCheckAvailable)
+        CheckAvailable();
 
     if (SelectedEnumType != EnumType)
         SelectedEnumType = EnumType;

--- a/base/applications/rapps/include/appdb.h
+++ b/base/applications/rapps/include/appdb.h
@@ -32,4 +32,9 @@ class CAppDB
 
     BOOL
     RemoveInstalledAppFromRegistry(const CAppInfo *Info);
+
+    size_t GetAvailableCount() const
+    {
+        return m_Available.GetCount();
+    }
 };

--- a/base/applications/rapps/include/gui.h
+++ b/base/applications/rapps/include/gui.h
@@ -108,7 +108,7 @@ class CMainWindow : public CWindowImpl<CMainWindow, CWindow, CFrameWinTraits>
     UpdateStatusBarText();
 
     VOID
-    UpdateApplicationsList(AppsCategories EnumType, BOOL bReload = FALSE);
+    UpdateApplicationsList(AppsCategories EnumType, BOOL bReload = FALSE, BOOL bCheckAvailable = FALSE);
     VOID
     AddApplicationsToView(CAtlList<CAppInfo *> &List);
 

--- a/base/applications/rapps/include/gui.h
+++ b/base/applications/rapps/include/gui.h
@@ -90,6 +90,9 @@ class CMainWindow : public CWindowImpl<CMainWindow, CWindow, CFrameWinTraits>
     VOID
     OnSize(HWND hwnd, WPARAM wParam, LPARAM lParam);
 
+    VOID
+    CheckAvailable();
+
     BOOL
     RemoveSelectedAppFromRegistry();
     BOOL

--- a/base/applications/rapps/unattended.cpp
+++ b/base/applications/rapps/unattended.cpp
@@ -222,11 +222,8 @@ ParseCmdAndExecute(LPWSTR lpCmdLine, BOOL bIsFirstLaunch, int nCmdShow)
 {
     INT argc;
     LPWSTR *argv = CommandLineToArgvW(lpCmdLine, &argc);
-
     if (!argv)
-    {
         return FALSE;
-    }
 
     CStringW Directory;
     GetStorageDirectory(Directory);

--- a/base/applications/rapps/unattended.cpp
+++ b/base/applications/rapps/unattended.cpp
@@ -222,7 +222,6 @@ ParseCmdAndExecute(LPWSTR lpCmdLine, BOOL bIsFirstLaunch, int nCmdShow)
 {
     INT argc;
     LPWSTR *argv = CommandLineToArgvW(lpCmdLine, &argc);
-    BOOL bAppwizMode = FALSE;
 
     if (!argv)
     {
@@ -233,18 +232,14 @@ ParseCmdAndExecute(LPWSTR lpCmdLine, BOOL bIsFirstLaunch, int nCmdShow)
     GetStorageDirectory(Directory);
     CAppDB db(Directory);
 
-    if (argc > 1 && MatchCmdOption(argv[1], CMD_KEY_APPWIZ))
-    {
-        bAppwizMode = TRUE;
-    }
-
-    if (SettingsInfo.bUpdateAtStart || bIsFirstLaunch)
-    {
-        db.RemoveCached();
-    }
-
+    BOOL bAppwizMode = (argc > 1 && MatchCmdOption(argv[1], CMD_KEY_APPWIZ));
     if (!bAppwizMode)
+    {
+        if (SettingsInfo.bUpdateAtStart || bIsFirstLaunch)
+            db.RemoveCached();
+
         db.UpdateAvailable();
+    }
 
     db.UpdateInstalled();
 

--- a/base/applications/rapps/unattended.cpp
+++ b/base/applications/rapps/unattended.cpp
@@ -242,7 +242,10 @@ ParseCmdAndExecute(LPWSTR lpCmdLine, BOOL bIsFirstLaunch, int nCmdShow)
     {
         db.RemoveCached();
     }
-    db.UpdateAvailable();
+
+    if (!bAppwizMode)
+        db.UpdateAvailable();
+
     db.UpdateInstalled();
 
     if (argc == 1 || bAppwizMode) // RAPPS is launched without options or APPWIZ mode is requested


### PR DESCRIPTION
## Purpose

Providing quick access of Control Panel `"Add/Remove Programs"`.
JIRA issue: [CORE-19419](https://jira.reactos.org/browse/CORE-19419)

## Proposed changes

- Don't download the `rapps-db` database if `bAppwizMode` in `ParseCmdAndExecute` function.
- Add `CAppDB::GetAvailableCount` method.
- Add `CMainWindow::CheckAvailable` method.
- Use `CMainWindow::CheckAvailable` in some cases of `TVN_SELCHANGED` handling.

## TODO

- [x] Do tests.