### PR TITLE
[KERNEL32] OpenFile(): Use InitializeObjectAttributes

### DIFF
--- a/dll/win32/kernel32/client/file/create.c
+++ b/dll/win32/kernel32/client/file/create.c
@@ -513,12 +513,11 @@ OpenFile(LPCSTR lpFileName,
 	// FILE_SHARE_READ
 	// FILE_NO_INTERMEDIATE_BUFFERING
 
-	ObjectAttributes.Length = sizeof(OBJECT_ATTRIBUTES);
-	ObjectAttributes.RootDirectory = NULL;
-	ObjectAttributes.ObjectName = &FileNameString;
-	ObjectAttributes.Attributes = OBJ_CASE_INSENSITIVE| OBJ_INHERIT;
-	ObjectAttributes.SecurityDescriptor = NULL;
-	ObjectAttributes.SecurityQualityOfService = NULL;
+    InitializeObjectAttributes(&ObjectAttributes,
+                               &FileNameString,
+                               OBJ_CASE_INSENSITIVE | OBJ_INHERIT,
+                               NULL,
+                               NULL);
 
 	errCode = NtOpenFile (&FileHandle,
 	                      GENERIC_READ | SYNCHRONIZE,


### PR DESCRIPTION
## Purpose

Improve readability and reduce code.
JIRA issue: None

## Proposed changes
- Use `InitializeObjectAttributes` macro instead of initialize the ObjectAttributes member manually. 