### PR TITLE
[CMAKE][WIN32U_APITEST] Remove 3 useless 'set_module_type(... IMAGEBA…

### DIFF
--- a/modules/rostests/apitests/win32u/win32u_2k3sp2/CMakeLists.txt
+++ b/modules/rostests/apitests/win32u/win32u_2k3sp2/CMakeLists.txt
@@ -7,5 +7,5 @@ add_library(win32u_2k3sp2 MODULE
     ${win32u_2k3sp2_asm}
     ${CMAKE_CURRENT_BINARY_DIR}/win32u_2k3sp2.def)
 
-set_module_type(win32u_2k3sp2 module IMAGEBASE default)
+set_module_type(win32u_2k3sp2 module)
 add_dependencies(win32u_2k3sp2 psdk)

--- a/modules/rostests/apitests/win32u/win32u_vista/CMakeLists.txt
+++ b/modules/rostests/apitests/win32u/win32u_vista/CMakeLists.txt
@@ -7,5 +7,5 @@ add_library(win32u_vista MODULE
     ${win32u_vista_asm}
     ${CMAKE_CURRENT_BINARY_DIR}/win32u_vista.def)
 
-set_module_type(win32u_vista module IMAGEBASE default)
+set_module_type(win32u_vista module)
 add_dependencies(win32u_vista psdk)

--- a/modules/rostests/apitests/win32u/win32u_xpsp2/CMakeLists.txt
+++ b/modules/rostests/apitests/win32u/win32u_xpsp2/CMakeLists.txt
@@ -7,5 +7,5 @@ add_library(win32u_xpsp2 MODULE
     ${win32u_xpsp2_asm}
     ${CMAKE_CURRENT_BINARY_DIR}/win32u_xpsp2.def)
 
-set_module_type(win32u_xpsp2 module IMAGEBASE default)
+set_module_type(win32u_xpsp2 module)
 add_dependencies(win32u_xpsp2 psdk)

--- a/sdk/cmake/CMakeMacros.cmake
+++ b/sdk/cmake/CMakeMacros.cmake
@@ -642,6 +642,7 @@ function(set_module_type MODULE TYPE)
     endif()
 
     # Set base address
+    # Use 'IMAGEBASE default' to skip these set_image_base(), especially for win32dll test files
     if(__module_IMAGEBASE)
         if(NOT ${__module_IMAGEBASE} STREQUAL "default")
             set_image_base(${MODULE} ${__module_IMAGEBASE})


### PR DESCRIPTION
…SE default)'

## Purpose

Code cleanup: be consistent (like the other (excluded) test `module`s), improve documentation.

Addendum to 2b7246f (0.4.15-dev-6898).

## Proposed changes

- Remove 3 useless 'set_module_type(... IMAGEBASE default)'
- And add an explicit documentation comment.