### PR TITLE
[COMCTL32][USER32] Fix caret position on text box of 'Search' pane

### DIFF
--- a/dll/win32/comctl32/edit.c
+++ b/dll/win32/comctl32/edit.c
@@ -1752,6 +1752,11 @@ static void EDIT_SetCaretPos(EDITSTATE *es, INT pos,
 #ifdef __REACTOS__
     HKL hKL = GetKeyboardLayout(0);
     POINT pt = { (short)LOWORD(res), (short)HIWORD(res) };
+
+    /* Don't set caret if not focused */
+    if ((es->flags & EF_FOCUSED) == 0)
+        return;
+
     SetCaretPos(pt.x, pt.y);
 
     if (!ImmIsIME(hKL))

--- a/win32ss/user/user32/controls/edit.c
+++ b/win32ss/user/user32/controls/edit.c
@@ -1907,6 +1907,11 @@ static void EDIT_SetCaretPos(EDITSTATE *es, INT pos,
 #ifdef __REACTOS__
     HKL hKL = GetKeyboardLayout(0);
     POINT pt = { (short)LOWORD(res), (short)HIWORD(res) };
+
+    /* Don't set caret if not focused */
+    if ((es->flags & EF_FOCUSED) == 0)
+        return;
+
     SetCaretPos(pt.x, pt.y);
 
     if (!ImmIsIME(hKL))


### PR DESCRIPTION
## Purpose

_Original patch by @I_Kill_Bugs._
_Fix Cursor being in middle of '...file name:' edit box when using 'Search' from the Explorer toolbar._

JIRA issue: [CORE-19407](https://jira.reactos.org/browse/CORE-19407)

## Proposed changes

_Do not use SetCaretPos in EDIT_SetCaretPos when not focused._
