### PR TITLE
[MSI] Fix heap assert in msi/dialog.c when installing Tortoise GIT

### DIFF
--- a/dll/win32/msi/dialog.c
+++ b/dll/win32/msi/dialog.c
@@ -2943,16 +2943,11 @@ static UINT msi_dialog_directorylist_up( msi_dialog *dialog )
 
     /* strip off the last directory */
     ptr = PathFindFileNameW( path );
-#ifdef __REACTOS__
     if (ptr != path)
     {
         *(ptr - 1) = '\0';
         PathAddBackslashW( path );
     }
-#else
-    if (ptr != path) *(ptr - 1) = '\0';
-    PathAddBackslashW( path );
-#endif
 
     msi_dialog_set_property( dialog->package, prop, path );
 

--- a/dll/win32/msi/dialog.c
+++ b/dll/win32/msi/dialog.c
@@ -2943,7 +2943,7 @@ static UINT msi_dialog_directorylist_up( msi_dialog *dialog )
 
     /* strip off the last directory */
     ptr = PathFindFileNameW( path );
-#if __REACTOS__
+#ifdef __REACTOS__
     if (ptr != path)
     {
         *(ptr - 1) = '\0';

--- a/dll/win32/msi/dialog.c
+++ b/dll/win32/msi/dialog.c
@@ -2943,8 +2943,16 @@ static UINT msi_dialog_directorylist_up( msi_dialog *dialog )
 
     /* strip off the last directory */
     ptr = PathFindFileNameW( path );
+#if __REACTOS__
+    if (ptr != path)
+    {
+        *(ptr - 1) = '\0';
+        PathAddBackslashW( path );
+    }
+#else
     if (ptr != path) *(ptr - 1) = '\0';
     PathAddBackslashW( path );
+#endif
 
     msi_dialog_set_property( dialog->package, prop, path );
 

--- a/media/doc/WINESYNC.txt
+++ b/media/doc/WINESYNC.txt
@@ -115,7 +115,7 @@ dll/win32/msg711.acm          # Synced to WineStaging-4.18
 dll/win32/msgsm32.acm         # Synced to WineStaging-4.0
 dll/win32/mshtml              # Synced to WineStaging-1.7.55
 dll/win32/mshtml.tlb          # Synced to WineStaging-1.7.55
-dll/win32/msi                 # Synced to WineStaging-7.3
+dll/win32/msi                 # Synced to WineStaging-7.3 (+ dialog.c synced to bbce5d014db7f023b133d6d09e6846e027586f7d)
 dll/win32/msimg32             # Synced to WineStaging-3.3
 dll/win32/msimtf              # Synced to WineStaging-4.18
 dll/win32/msisip              # Synced to WineStaging-4.18


### PR DESCRIPTION
## Purpose

_Fix heap assert in msi/dialog.c._

JIRA issue: [CORE-16693](https://jira.reactos.org/browse/CORE-16693)

## Proposed changes

_Implement Thomas Faber's suggestion to handle heap assert as noted below._
_Since there's not really something sensible to be done in the_
_"path contains no backslashes" case (adding a backslash seems pointless),_
_the PathAddBackslashW call was moved inside the if condition to avoid the crash._