### PR TITLE
[NTOS:KE] Fix initialization of node block for application processors

### DIFF
--- a/ntoskrnl/ke/amd64/krnlinit.c
+++ b/ntoskrnl/ke/amd64/krnlinit.c
@@ -147,6 +147,10 @@ KiSystemStartupBootStack(VOID)
     PKPROCESS Process = Thread->ApcState.Process;
     PVOID KernelStack = (PVOID)KeLoaderBlock->KernelStack;
 
+    /* Set Node Data */
+    Prcb->ParentNode = KeNodeBlock[0];
+    Prcb->ParentNode->ProcessorMask |= Prcb->SetMember;
+
     /* Initialize the Power Management Support for this PRCB */
     PoInitializePrcb(Prcb);
 
@@ -227,11 +231,6 @@ KiInitializeKernel(IN PKPROCESS InitProcess,
     ULONG_PTR PageDirectory[2];
     PVOID DpcStack;
     ULONG i;
-
-    /* Set Node Data */
-    KeNodeBlock[0] = &KiNode0;
-    Prcb->ParentNode = KeNodeBlock[0];
-    KeNodeBlock[0]->ProcessorMask = Prcb->SetMember;
 
     /* Set boot-level flags */
     KeFeatureBits = Prcb->FeatureBits;

--- a/ntoskrnl/ke/i386/kiinit.c
+++ b/ntoskrnl/ke/i386/kiinit.c
@@ -413,7 +413,7 @@ KiVerifyCpuFeatures(PKPRCB Prcb)
     Cr0 &= ~(CR0_EM | CR0_MP);
     // Enable FPU exceptions.
     Cr0 |= CR0_NE;
-    
+
     __writecr0(Cr0);
 
     // Check for Pentium FPU bug.
@@ -492,14 +492,13 @@ KiInitializeKernel(IN PKPROCESS InitProcess,
     /* Initialize spinlocks and DPC data */
     KiInitSpinLocks(Prcb, Number);
 
+    /* Set Node Data */
+    Prcb->ParentNode = KeNodeBlock[0];
+    Prcb->ParentNode->ProcessorMask |= Prcb->SetMember;
+
     /* Check if this is the Boot CPU */
     if (!Number)
     {
-        /* Set Node Data */
-        KeNodeBlock[0] = &KiNode0;
-        Prcb->ParentNode = KeNodeBlock[0];
-        KeNodeBlock[0]->ProcessorMask = Prcb->SetMember;
-
         /* Set boot-level flags */
         KeI386CpuType = Prcb->CpuType;
         KeI386CpuStep = Prcb->CpuStep;

--- a/ntoskrnl/ke/krnlinit.c
+++ b/ntoskrnl/ke/krnlinit.c
@@ -36,7 +36,7 @@ CCHAR KeNumberProcessors = 0;
 
 /* NUMA Node Support */
 KNODE KiNode0;
-PKNODE KeNodeBlock[1];
+PKNODE KeNodeBlock[1] = { &KiNode0 };
 UCHAR KeNumberNodes = 1;
 UCHAR KeProcessNodeSeed;
 


### PR DESCRIPTION
## Purpose

Fix initialization of node block for application processors

## Proposed changes

- Initialize KeNodeBlock[0] statically
- Update KeNodeBlock[0]->ProcessorMask for all processors
