### PR TITLE
[NTUSER] Fix co_IntSetParent when calling on itself

### DIFF
--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -1218,28 +1218,25 @@ co_IntSetParent(PWND Wnd, PWND WndNewParent)
 
    if (WndOldParent) UserReferenceObject(WndOldParent); /* Caller must deref */
 
-   if (WndNewParent != WndOldParent)
+   /* Unlink the window from the siblings list */
+   IntUnlinkWindow(Wnd);
+   Wnd->ExStyle2 &= ~WS_EX2_LINKED;
+
+   /* Set the new parent */
+   WndSetParent(Wnd, WndNewParent);
+
+   if ( Wnd->style & WS_CHILD &&
+        Wnd->spwndOwner &&
+        Wnd->spwndOwner->ExStyle & WS_EX_TOPMOST )
    {
-      /* Unlink the window from the siblings list */
-      IntUnlinkWindow(Wnd);
-      Wnd->ExStyle2 &= ~WS_EX2_LINKED;
-
-      /* Set the new parent */
-      WndSetParent(Wnd, WndNewParent);
-
-      if ( Wnd->style & WS_CHILD &&
-           Wnd->spwndOwner &&
-           Wnd->spwndOwner->ExStyle & WS_EX_TOPMOST )
-      {
-         ERR("SetParent Top Most from Pop up!\n");
-         Wnd->ExStyle |= WS_EX_TOPMOST;
-      }
-
-      /* Link the window with its new siblings */
-      IntLinkHwnd( Wnd,
-                  ((0 == (Wnd->ExStyle & WS_EX_TOPMOST) &&
-                    UserIsDesktopWindow(WndNewParent) ) ? HWND_TOP : HWND_TOPMOST ) );
+      ERR("SetParent Top Most from Pop up!\n");
+      Wnd->ExStyle |= WS_EX_TOPMOST;
    }
+
+   /* Link the window with its new siblings */
+   IntLinkHwnd( Wnd,
+               ((0 == (Wnd->ExStyle & WS_EX_TOPMOST) &&
+                 UserIsDesktopWindow(WndNewParent) ) ? HWND_TOP : HWND_TOPMOST ) );
 
    if ( WndNewParent == co_GetDesktopWindow(Wnd) &&
        !(Wnd->style & WS_CLIPSIBLINGS) )

--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -1218,7 +1218,7 @@ co_IntSetParent(PWND Wnd, PWND WndNewParent)
 
    if (WndOldParent) UserReferenceObject(WndOldParent); /* Caller must deref */
 
-   /* Even if WndNewParent == WndOldParent contnue because the
+   /* Even if WndNewParent == WndOldParent continue because the
     * child window (Wnd) should be moved to the top of the z-order */
 
    /* Unlink the window from the siblings list */
@@ -1228,18 +1228,18 @@ co_IntSetParent(PWND Wnd, PWND WndNewParent)
    /* Set the new parent */
    WndSetParent(Wnd, WndNewParent);
 
-   if ( Wnd->style & WS_CHILD &&
-        Wnd->spwndOwner &&
-        Wnd->spwndOwner->ExStyle & WS_EX_TOPMOST )
+   if (Wnd->style & WS_CHILD &&
+       Wnd->spwndOwner &&
+       Wnd->spwndOwner->ExStyle & WS_EX_TOPMOST)
    {
-      ERR("SetParent Top Most from Pop up!\n");
+      ERR("SetParent Top Most from Pop up\n");
       Wnd->ExStyle |= WS_EX_TOPMOST;
    }
 
    /* Link the window with its new siblings */
-   IntLinkHwnd( Wnd,
+   IntLinkHwnd(Wnd,
                ((0 == (Wnd->ExStyle & WS_EX_TOPMOST) &&
-                 UserIsDesktopWindow(WndNewParent) ) ? HWND_TOP : HWND_TOPMOST ) );
+               UserIsDesktopWindow(WndNewParent)) ? HWND_TOP : HWND_TOPMOST));
 
    if ( WndNewParent == co_GetDesktopWindow(Wnd) &&
        !(Wnd->style & WS_CLIPSIBLINGS) )

--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -1218,6 +1218,9 @@ co_IntSetParent(PWND Wnd, PWND WndNewParent)
 
    if (WndOldParent) UserReferenceObject(WndOldParent); /* Caller must deref */
 
+   /* Even if WndNewParent == WndOldParent then contnue because the
+    * child window (Wnd) should be moved to the top of the z-order */
+
    /* Unlink the window from the siblings list */
    IntUnlinkWindow(Wnd);
    Wnd->ExStyle2 &= ~WS_EX2_LINKED;

--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -1218,7 +1218,7 @@ co_IntSetParent(PWND Wnd, PWND WndNewParent)
 
    if (WndOldParent) UserReferenceObject(WndOldParent); /* Caller must deref */
 
-   /* Even if WndNewParent == WndOldParent then contnue because the
+   /* Even if WndNewParent == WndOldParent contnue because the
     * child window (Wnd) should be moved to the top of the z-order */
 
    /* Unlink the window from the siblings list */


### PR DESCRIPTION
Patch by @I_Kill_Bugs.

## Purpose

_Fix SetParent which fixes rendering issues in PeaZip._

JIRA issue: [CORE-9386](https://jira.reactos.org/browse/CORE-9386)

## Proposed changes

_According to @I_Kill_Bugs we have the following:_

> _In Windows, using SetParent to set to the same parent causes the child window to move to the top of the z-order._
> _PeaZip was calling SetParent after each window creation trying to move the window to the top z-order,_
> _but ReactOS/SetParent was preventing that. Removing the test for equality of same parent hwnd solved the problem._