### PR TITLE
[COMCTL32] Ignore next mouse move after single/double-click in edit box

### DIFF
--- a/dll/win32/comctl32/edit.c
+++ b/dll/win32/comctl32/edit.c
@@ -3501,7 +3501,7 @@ static LRESULT EDIT_WM_LButtonDblClk(EDITSTATE *es)
 	es->region_posx = es->region_posy = 0;
 	SetTimer(es->hwndSelf, 0, 100, NULL);
 #ifdef __REACTOS__
-    /* set flags indicating WM_MOUSEMOVE to be ignored due to CORE-8394 */
+    /* HACK: set flags indicating WM_MOUSEMOVE to be ignored due to CORE-8394 */
     es->flags |= EF_IGNORENEXTWMMOUSEMOVE;
 #endif
 	return 0;
@@ -3527,7 +3527,7 @@ static LRESULT EDIT_WM_LButtonDown(EDITSTATE *es, DWORD keys, INT x, INT y)
 	es->region_posx = es->region_posy = 0;
 	SetTimer(es->hwndSelf, 0, 100, NULL);
 #ifdef __REACTOS__
-    /* set flags indicating WM_MOUSEMOVE to be ignored due to CORE-8394 */
+    /* HACK: set flags indicating WM_MOUSEMOVE to be ignored due to CORE-8394 */
     es->flags |= EF_IGNORENEXTWMMOUSEMOVE;
 #endif
 
@@ -3586,7 +3586,7 @@ static LRESULT EDIT_WM_MouseMove(EDITSTATE *es, INT x, INT y)
 #ifdef __REACTOS__
         if (es->flags & EF_IGNORENEXTWMMOUSEMOVE)
         {
-            /* clear flags indicating WM_MOUSEMOVE to be ignored due to CORE-8394 */
+            /* HACK: clear flags indicating WM_MOUSEMOVE to be ignored due to CORE-8394 */
              es->flags &= ~EF_IGNORENEXTWMMOUSEMOVE;
             return 0;
         }


### PR DESCRIPTION
## Purpose
_Patch from @KRosUser based on a patch by me._
_In comctl32 edit box fix word selection when mouse double-click is used ._

JIRA issues: [CORE-19422](https://jira.reactos.org/browse/CORE-19422) [CORE-19423](https://jira.reactos.org/browse/CORE-19423)

## Proposed changes

_When using the edit control in comctl32 when mouse single-click or double-click is used,_
_ignore the next mouse move event to fix word selection._

The root cause of this problem is [CORE-8394](https://jira.reactos.org/browse/CORE-8394) and the fix is based on an existing
workaround as implemented in several modules such as consrv ( See PR #5441).