### PR TITLE
[COMCTL32] Fix large combo box pull down closing too quickly

### DIFF
--- a/dll/win32/comctl32/combo.c
+++ b/dll/win32/comctl32/combo.c
@@ -1610,8 +1610,9 @@ static void COMBO_LButtonDown( LPHEADCOMBO lphc, LPARAM lParam )
        else
        {
 	   /* drop down the listbox and start tracking */
-
+#ifndef __REACTOS__
            lphc->wState |= CBF_CAPTURE;
+#endif
            SetCapture( hWnd );
            CBDropDown( lphc );
        }
@@ -1964,6 +1965,12 @@ static LRESULT CALLBACK COMBO_WindowProc( HWND hwnd, UINT message, WPARAM wParam
 
         if ( lphc->wState & CBF_CAPTURE )
             COMBO_MouseMove( lphc, wParam, lParam );
+
+#ifdef __REACTOS__
+        if (lphc->wState & CBF_DROPPED)
+            lphc->wState |= CBF_CAPTURE;
+#endif
+
         return  TRUE;
 
     case WM_MOUSEWHEEL:

--- a/dll/win32/comctl32/combo.c
+++ b/dll/win32/comctl32/combo.c
@@ -1610,10 +1610,11 @@ static void COMBO_LButtonDown( LPHEADCOMBO lphc, LPARAM lParam )
        else
        {
 	   /* drop down the listbox and start tracking */
+
 #ifndef __REACTOS__
            lphc->wState |= CBF_CAPTURE;
-#endif
            SetCapture( hWnd );
+#endif
            CBDropDown( lphc );
        }
        if( bButton ) CBRepaintButton( lphc );
@@ -1644,6 +1645,17 @@ static void COMBO_LButtonUp( LPHEADCOMBO lphc )
        ReleaseCapture();
        SetCapture(lphc->hWndLBox);
    }
+#ifdef __REACTOS__
+   else
+   {
+       /* if not CBF_CAPTURE */
+       if (lphc->wState & CBF_DROPPED)
+       {
+           lphc->wState |= CBF_CAPTURE;
+           SetCapture(lphc->self);
+       }
+   }
+#endif
 
    if( lphc->wState & CBF_BUTTONDOWN )
    {
@@ -1965,12 +1977,6 @@ static LRESULT CALLBACK COMBO_WindowProc( HWND hwnd, UINT message, WPARAM wParam
 
         if ( lphc->wState & CBF_CAPTURE )
             COMBO_MouseMove( lphc, wParam, lParam );
-
-#ifdef __REACTOS__
-        if (lphc->wState & CBF_DROPPED)
-            lphc->wState |= CBF_CAPTURE;
-#endif
-
         return  TRUE;
 
     case WM_MOUSEWHEEL:

--- a/dll/win32/comctl32/combo.c
+++ b/dll/win32/comctl32/combo.c
@@ -1611,10 +1611,8 @@ static void COMBO_LButtonDown( LPHEADCOMBO lphc, LPARAM lParam )
        {
 	   /* drop down the listbox and start tracking */
 
-#ifndef __REACTOS__
            lphc->wState |= CBF_CAPTURE;
            SetCapture( hWnd );
-#endif
            CBDropDown( lphc );
        }
        if( bButton ) CBRepaintButton( lphc );
@@ -1645,17 +1643,6 @@ static void COMBO_LButtonUp( LPHEADCOMBO lphc )
        ReleaseCapture();
        SetCapture(lphc->hWndLBox);
    }
-#ifdef __REACTOS__
-   else
-   {
-       /* if not CBF_CAPTURE */
-       if (lphc->wState & CBF_DROPPED)
-       {
-           lphc->wState |= CBF_CAPTURE;
-           SetCapture(lphc->self);
-       }
-   }
-#endif
 
    if( lphc->wState & CBF_BUTTONDOWN )
    {
@@ -1673,7 +1660,9 @@ static void COMBO_LButtonUp( LPHEADCOMBO lphc )
 static void COMBO_MouseMove( LPHEADCOMBO lphc, WPARAM wParam, LPARAM lParam )
 {
    POINT  pt;
+#ifndef __REACTOS__  // CORE-18769
    RECT   lbRect;
+#endif
 
    pt.x = (short)LOWORD(lParam);
    pt.y = (short)HIWORD(lParam);
@@ -1691,6 +1680,7 @@ static void COMBO_MouseMove( LPHEADCOMBO lphc, WPARAM wParam, LPARAM lParam )
      }
    }
 
+#ifndef __REACTOS__  // CORE-18769
    GetClientRect( lphc->hWndLBox, &lbRect );
    MapWindowPoints( lphc->self, lphc->hWndLBox, &pt, 1 );
    if( PtInRect(&lbRect, pt) )
@@ -1702,6 +1692,7 @@ static void COMBO_MouseMove( LPHEADCOMBO lphc, WPARAM wParam, LPARAM lParam )
        /* hand over pointer tracking */
        SendMessageW(lphc->hWndLBox, WM_LBUTTONDOWN, wParam, lParam);
    }
+#endif
 }
 
 static LRESULT COMBO_GetComboBoxInfo(const HEADCOMBO *lphc, COMBOBOXINFO *pcbi)

--- a/win32ss/user/user32/controls/combo.c
+++ b/win32ss/user/user32/controls/combo.c
@@ -1696,8 +1696,8 @@ static void COMBO_LButtonDown( LPHEADCOMBO lphc, LPARAM lParam )
 
 #ifndef __REACTOS__
            lphc->wState |= CBF_CAPTURE;
-#endif
            SetCapture( hWnd );
+#endif
            CBDropDown( lphc );
        }
        if( bButton ) CBRepaintButton( lphc );
@@ -1728,6 +1728,17 @@ static void COMBO_LButtonUp( LPHEADCOMBO lphc )
        ReleaseCapture();
        SetCapture(lphc->hWndLBox);
    }
+#ifdef __REACTOS__
+   else
+   {
+       /* if not CBF_CAPTURE */
+       if (lphc->wState & CBF_DROPPED)
+       {
+           lphc->wState |= CBF_CAPTURE;
+           SetCapture(lphc->self);
+       }
+   }
+#endif
 
    if( lphc->wState & CBF_BUTTONDOWN )
    {
@@ -2041,10 +2052,6 @@ LRESULT WINAPI ComboWndProc_common( HWND hwnd, UINT message, WPARAM wParam, LPAR
     case WM_MOUSEMOVE:
         if ( lphc->wState & CBF_CAPTURE )
             COMBO_MouseMove( lphc, wParam, lParam );
-#ifdef __REACTOS__
-        if ( lphc->wState & CBF_DROPPED )
-             lphc->wState |= CBF_CAPTURE;
-#endif
         return  TRUE;
 
     case WM_MOUSEWHEEL:

--- a/win32ss/user/user32/controls/combo.c
+++ b/win32ss/user/user32/controls/combo.c
@@ -1694,7 +1694,9 @@ static void COMBO_LButtonDown( LPHEADCOMBO lphc, LPARAM lParam )
        {
 	   /* drop down the listbox and start tracking */
 
+#ifndef __REACTOS__
            lphc->wState |= CBF_CAPTURE;
+#endif
            SetCapture( hWnd );
            CBDropDown( lphc );
        }
@@ -2039,6 +2041,10 @@ LRESULT WINAPI ComboWndProc_common( HWND hwnd, UINT message, WPARAM wParam, LPAR
     case WM_MOUSEMOVE:
         if ( lphc->wState & CBF_CAPTURE )
             COMBO_MouseMove( lphc, wParam, lParam );
+#ifdef __REACTOS__
+        if ( lphc->wState & CBF_DROPPED )
+             lphc->wState |= CBF_CAPTURE;
+#endif
         return  TRUE;
 
     case WM_MOUSEWHEEL:

--- a/win32ss/user/user32/controls/combo.c
+++ b/win32ss/user/user32/controls/combo.c
@@ -1694,10 +1694,8 @@ static void COMBO_LButtonDown( LPHEADCOMBO lphc, LPARAM lParam )
        {
 	   /* drop down the listbox and start tracking */
 
-#ifndef __REACTOS__
            lphc->wState |= CBF_CAPTURE;
            SetCapture( hWnd );
-#endif
            CBDropDown( lphc );
        }
        if( bButton ) CBRepaintButton( lphc );
@@ -1728,17 +1726,6 @@ static void COMBO_LButtonUp( LPHEADCOMBO lphc )
        ReleaseCapture();
        SetCapture(lphc->hWndLBox);
    }
-#ifdef __REACTOS__
-   else
-   {
-       /* if not CBF_CAPTURE */
-       if (lphc->wState & CBF_DROPPED)
-       {
-           lphc->wState |= CBF_CAPTURE;
-           SetCapture(lphc->self);
-       }
-   }
-#endif
 
    if( lphc->wState & CBF_BUTTONDOWN )
    {
@@ -1756,7 +1743,9 @@ static void COMBO_LButtonUp( LPHEADCOMBO lphc )
 static void COMBO_MouseMove( LPHEADCOMBO lphc, WPARAM wParam, LPARAM lParam )
 {
    POINT  pt;
+#ifndef __REACTOS__  // CORE-18769
    RECT   lbRect;
+#endif
 
    pt.x = (short)LOWORD(lParam);
    pt.y = (short)HIWORD(lParam);
@@ -1774,6 +1763,7 @@ static void COMBO_MouseMove( LPHEADCOMBO lphc, WPARAM wParam, LPARAM lParam )
      }
    }
 
+#ifndef __REACTOS__  // CORE-18769
    GetClientRect( lphc->hWndLBox, &lbRect );
    MapWindowPoints( lphc->self, lphc->hWndLBox, &pt, 1 );
    if( PtInRect(&lbRect, pt) )
@@ -1785,6 +1775,7 @@ static void COMBO_MouseMove( LPHEADCOMBO lphc, WPARAM wParam, LPARAM lParam )
        /* hand over pointer tracking */
        SendMessageW(lphc->hWndLBox, WM_LBUTTONDOWN, wParam, lParam);
    }
+#endif
 }
 
 static LRESULT COMBO_GetComboBoxInfo(const HEADCOMBO *lphc, COMBOBOXINFO *pcbi)


### PR DESCRIPTION
## Purpose

_Improve mouse combo box selection closing immediately._

JIRA issue: [CORE-18769](https://jira.reactos.org/browse/CORE-18769)

This is a retry of PR #4960.

## Proposed changes

_Do not handle CBF_CAPTURE/ReleaseCapture() in COMBO_MouseMove._
