### PR TITLE
[NTOS:KE] Set IRQL to SYNCH_LEVEL when exiting from idle after the thread is ready for execution

### DIFF
--- a/ntoskrnl/ke/amd64/stubs.c
+++ b/ntoskrnl/ke/amd64/stubs.c
@@ -139,14 +139,18 @@ KiIdleLoop(VOID)
             /* The thread is now running */
             NewThread->State = Running;
 
+#ifdef CONFIG_SMP
             /* Do the swap at SYNCH_LEVEL */
             KfRaiseIrql(SYNCH_LEVEL);
+#endif
 
             /* Switch away from the idle thread */
             KiSwapContext(APC_LEVEL, OldThread);
 
+#ifdef CONFIG_SMP
             /* Go back to DISPATCH_LEVEL */
             KeLowerIrql(DISPATCH_LEVEL);
+#endif
         }
         else
         {

--- a/ntoskrnl/ke/arm/thrdini.c
+++ b/ntoskrnl/ke/arm/thrdini.c
@@ -193,8 +193,18 @@ KiIdleLoop(VOID)
             /* The thread is now running */
             NewThread->State = Running;
 
+#ifdef CONFIG_SMP
+            /* Do the swap at SYNCH_LEVEL */
+            KfRaiseIrql(SYNCH_LEVEL);
+#endif
+
             /* Switch away from the idle thread */
             KiSwapContext(APC_LEVEL, OldThread);
+
+#ifdef CONFIG_SMP
+            /* Go back to DISPATCH_LEVEL */
+            KeLowerIrql(DISPATCH_LEVEL);
+#endif
         }
         else
         {

--- a/ntoskrnl/ke/i386/thrdini.c
+++ b/ntoskrnl/ke/i386/thrdini.c
@@ -300,8 +300,18 @@ KiIdleLoop(VOID)
             /* The thread is now running */
             NewThread->State = Running;
 
+#ifdef CONFIG_SMP
+            /* Do the swap at SYNCH_LEVEL */
+            KfRaiseIrql(SYNCH_LEVEL);
+#endif
+
             /* Switch away from the idle thread */
             KiSwapContext(APC_LEVEL, OldThread);
+
+#ifdef CONFIG_SMP
+            /* Go back to DISPATCH_LEVEL */
+            KeLowerIrql(DISPATCH_LEVEL);
+#endif
         }
         else
         {


### PR DESCRIPTION
## Purpose

Raise IRQL to `SYNCH_LEVEL` when exiting from the idle thread in the idle loop, in case it is scheduled for the execution. Then restore it back, after that's done. This is a bit similarly to the way it's done on x64.
This prevents bugcheck DRIVER_IRQL_NOT_LESS_OR_EQUAL when booting SMP x86 ReactOS, in `KiTimerExpiration` when calling it 2nd time. It happens because of IRQL levels mismatch, since `SYNCH_LEVEL` is identical to `DISPATCH_LEVEL` on UP, so it has no any difference there, but on MP systems it is different `IPI_LEVEL - 2`.
Do this for both x86 and arm architectures.
Also place the same code for x64 into `CONFIG_SMP` ifdefs, because it is completely useless and unnecessary on UP.
#5874 is badly needed to be applied, to see effect from these changes.

JIRA issue: [CORE-1697](https://jira.reactos.org/browse/CORE-1697)

## TODO

- [x] Perhaps store my changes in `CONFIG_SMP` ifdef.