### PR TITLE
[NTOS:KE] Acquire the PRCB lock before marking the thread ready for execution in dispatch interrupt routine for x86 and arm

### DIFF
--- a/ntoskrnl/include/internal/ke_x.h
+++ b/ntoskrnl/include/internal/ke_x.h
@@ -1359,6 +1359,7 @@ KxQueueReadyThread(IN PKTHREAD Thread,
 
     /* Sanity checks */
     ASSERT(Prcb == KeGetCurrentPrcb());
+    ASSERT(Prcb->PrcbLock != 0);
     ASSERT(Thread->State == Running);
     ASSERT(Thread->NextProcessor == Prcb->Number);
 

--- a/ntoskrnl/ke/arm/thrdini.c
+++ b/ntoskrnl/ke/arm/thrdini.c
@@ -324,6 +324,9 @@ KiDispatchInterrupt(VOID)
     }
     else if (Prcb->NextThread)
     {
+        /* Acquire the PRCB lock */
+        KiAcquirePrcbLock(Prcb);
+
         /* Capture current thread data */
         OldThread = Prcb->CurrentThread;
         NewThread = Prcb->NextThread;

--- a/ntoskrnl/ke/i386/thrdini.c
+++ b/ntoskrnl/ke/i386/thrdini.c
@@ -485,6 +485,9 @@ KiDispatchInterrupt(VOID)
     }
     else if (Prcb->NextThread)
     {
+        /* Acquire the PRCB lock */
+        KiAcquirePrcbLock(Prcb);
+
         /* Capture current thread data */
         OldThread = Prcb->CurrentThread;
         NewThread = Prcb->NextThread;


### PR DESCRIPTION
## Purpose

Acquire the PRCB lock before marking the thread ready for execution in dispatch interrupt routine for x86 and arm. This is needed because thread preparation routine (`KxQueueReadyThread`) releases `PRCB` lock, but does not acquire it, so that always must be done outside the function, same as in all its other usage cases.
This fixes an assert from release `PRCB` routine, when booting x86 ReactOS in SMP mode, because it attempts to release the lock when it is not actually acquired.
#5874 and #6386 PRs are badly needed to see an effect from these changes.

JIRA issue: [CORE-1697](https://jira.reactos.org/browse/CORE-1697)