### PR TITLE
[NTOS:KE] Fix boot on UP build - PrcbLocks are not used on UP

### DIFF
--- a/ntoskrnl/include/internal/ke_x.h
+++ b/ntoskrnl/include/internal/ke_x.h
@@ -1359,7 +1359,9 @@ KxQueueReadyThread(IN PKTHREAD Thread,
 
     /* Sanity checks */
     ASSERT(Prcb == KeGetCurrentPrcb());
+#ifdef CONFIG_SMP
     ASSERT(Prcb->PrcbLock != 0);
+#endif
     ASSERT(Thread->State == Running);
     ASSERT(Thread->NextProcessor == Prcb->Number);
 


### PR DESCRIPTION
On the uniprocessor kernel KiAcquirePrcbLock is a stub that doesn't modify the current Prcb's PrcbLock value. 
Quickly protect this assert around CONFIG_SMP
https://git.reactos.org/?p=reactos.git;a=blob;f=ntoskrnl/include/internal/ke_x.h;hb=ab528ac6ae105b19d457587dc680d8016720bc3d#l220

- Protect the new Prcb Check around a CONFIG_SMP preprocessor check
