### PR TITLE
[NTUSER] Avoid sending superfluous WM_MOUSEMOVE messages

### DIFF
--- a/win32ss/user/ntuser/cursoricon.c
+++ b/win32ss/user/ntuser/cursoricon.c
@@ -264,13 +264,15 @@ BOOL UserSetCursorPos( INT x, INT y, DWORD flags, ULONG_PTR dwExtraInfo, BOOL Ho
     pt.x = x;
     pt.y = y;
 
-    /* 1. Generate a mouse move message, this sets the htEx and Track Window too. */
-    Msg.message = WM_MOUSEMOVE;
-    Msg.wParam = UserGetMouseButtonsState();
-    Msg.lParam = MAKELPARAM(x, y);
-    Msg.pt = pt;
-    co_MsqInsertMouseMessage(&Msg, flags, dwExtraInfo, Hook);
-
+    if ((gpsi->ptCursor.x != x) || (gpsi->ptCursor.y != y))
+    {
+        /* 1. Generate a mouse move message, this sets the htEx and Track Window too. */
+        Msg.message = WM_MOUSEMOVE;
+        Msg.wParam = UserGetMouseButtonsState();
+        Msg.lParam = MAKELPARAM(x, y);
+        Msg.pt = pt;
+        co_MsqInsertMouseMessage(&Msg, flags, dwExtraInfo, Hook);
+    }
     /* 2. Store the new cursor position */
     gpsi->ptCursor = pt;
 


### PR DESCRIPTION
## Purpose

_I_Kill_Bugs patch to fix extra mouse moves generated when clicking._

JIRA issues: [CORE-8394](https://jira.reactos.org/browse/CORE-8394)
and the following:
[CORE-19423](https://jira.reactos.org/browse/CORE-19423)
[CORE-19422](https://jira.reactos.org/browse/CORE-19422)
[CORE-18529](https://jira.reactos.org/browse/CORE-18529)

## Proposed changes

_Add check so that mouse moves are not generated unless there is a changed in the mouse x or y position._
