### PR TITLE
[NTOS:KE/x86/arm] Fix boot process affinity

### DIFF
--- a/ntoskrnl/ke/arm/kiinit.c
+++ b/ntoskrnl/ke/arm/kiinit.c
@@ -101,7 +101,7 @@ KiInitializeKernel(IN PKPROCESS InitProcess,
         PageDirectory[1] = 0;
         KeInitializeProcess(InitProcess,
                             0,
-                            0xFFFFFFFF,
+                            MAXULONG_PTR,
                             PageDirectory,
                             FALSE);
         InitProcess->QuantumReset = MAXCHAR;

--- a/ntoskrnl/ke/i386/kiinit.c
+++ b/ntoskrnl/ke/i386/kiinit.c
@@ -527,7 +527,7 @@ KiInitializeKernel(IN PKPROCESS InitProcess,
         PageDirectory[1] = 0;
         KeInitializeProcess(InitProcess,
                             0,
-                            0xFFFFFFFF,
+                            MAXULONG_PTR,
                             PageDirectory,
                             FALSE);
         InitProcess->QuantumReset = MAXCHAR;


### PR DESCRIPTION
Addendum to 96d5b62.

JIRA issue: [CORE-1697](https://jira.reactos.org/browse/CORE-1697)

## TODO

- [x] Are the different values required for x86 and arm? :thinking: **UPD: No, they aren't. This value is correct, as it's compatible with all platforms.**