### PR TITLE
[NTOS:FSTUB] Pack the MASTER_BOOT_RECORD structure

### DIFF
--- a/ntoskrnl/fstub/fstubex.c
+++ b/ntoskrnl/fstub/fstubex.c
@@ -41,6 +41,7 @@ typedef struct _EFI_PARTITION_HEADER
     ULONG SizeOfPartitionEntry;  // 84
     ULONG PartitionEntryCRC32;   // 88
 } EFI_PARTITION_HEADER, *PEFI_PARTITION_HEADER;
+C_ASSERT(sizeof(EFI_PARTITION_HEADER) == 92);
 #include <poppack.h>
 
 typedef struct _EFI_PARTITION_ENTRY
@@ -52,6 +53,7 @@ typedef struct _EFI_PARTITION_ENTRY
     ULONGLONG Attributes;  // 48
     WCHAR Name[0x24];      // 56
 } EFI_PARTITION_ENTRY, *PEFI_PARTITION_ENTRY;
+C_ASSERT(sizeof(EFI_PARTITION_ENTRY) == 128);
 
 typedef struct _PARTITION_TABLE_ENTRY
 {
@@ -66,6 +68,7 @@ typedef struct _PARTITION_TABLE_ENTRY
     ULONG SectorCountBeforePartition;
     ULONG PartitionSectorCount;
 } PARTITION_TABLE_ENTRY, *PPARTITION_TABLE_ENTRY;
+C_ASSERT(sizeof(PARTITION_TABLE_ENTRY) == 16);
 
 #include <pshpack1.h>
 typedef struct _MASTER_BOOT_RECORD

--- a/ntoskrnl/fstub/fstubex.c
+++ b/ntoskrnl/fstub/fstubex.c
@@ -67,6 +67,7 @@ typedef struct _PARTITION_TABLE_ENTRY
     ULONG PartitionSectorCount;
 } PARTITION_TABLE_ENTRY, *PPARTITION_TABLE_ENTRY;
 
+#include <pshpack1.h>
 typedef struct _MASTER_BOOT_RECORD
 {
     UCHAR MasterBootRecordCodeAndData[0x1B8]; // 0
@@ -75,6 +76,8 @@ typedef struct _MASTER_BOOT_RECORD
     PARTITION_TABLE_ENTRY PartitionTable[4];  // 446
     USHORT MasterBootRecordMagic;             // 510
 } MASTER_BOOT_RECORD, *PMASTER_BOOT_RECORD;
+C_ASSERT(sizeof(MASTER_BOOT_RECORD) == 512);
+#include <poppack.h>
 
 /* Partition entry size (bytes) - FIXME: It's hardcoded as Microsoft does, but according to specs, it shouldn't be */
 #define PARTITION_ENTRY_SIZE 128


### PR DESCRIPTION
Otherwise the USHORT members are aligned to 4-byte boundary which overflows the disk sector buffer and ultimately results in crash. This can be reproduced by trying to format the USB drive with Rufus.

Before:
![Screenshot_20240127_174447](https://github.com/reactos/reactos/assets/32551254/20f372e1-6e5a-40de-9de0-999ec03657f1)

After:
![Screenshot_20240127_175218](https://github.com/reactos/reactos/assets/32551254/c8c21002-d0fc-4eaf-a1ef-37ded3cf509a)
Partition is successfully created, but it fails later on with formatting it.