### PR TITLE
[SHELL32] Sync HCR_RegGetIconW to Wine 9.1

### DIFF
--- a/dll/win32/shell32/wine/classes.c
+++ b/dll/win32/shell32/wine/classes.c
@@ -239,11 +239,11 @@ BOOL HCR_RegOpenClassIDKey(REFIID riid, HKEY *hkey)
 
 static BOOL HCR_RegGetIconW(HKEY hkey, LPWSTR szDest, LPCWSTR szName, DWORD len, int* picon_idx)
 {
-    DWORD dwType;
+    DWORD dwType, size = len * sizeof(WCHAR);
     WCHAR sTemp[MAX_PATH];
-    WCHAR sNum[7];
+    WCHAR sNum[5];
 
-    if (!RegQueryValueExW(hkey, szName, 0, &dwType, (LPBYTE)szDest, &len))
+    if (!RegQueryValueExW(hkey, szName, 0, &dwType, (LPBYTE)szDest, &size))
     {
       if (dwType == REG_EXPAND_SZ)
       {


### PR DESCRIPTION
## Purpose

Update the internal `HCR_RegGetIconW` function to the Wine 9.1 state.
https://source.winehq.org/git/wine.git/blob/HEAD:/dlls/shell32/classes.c#l213 These changes fix the problems when loading custom (user-defined) items icons from registry, like icons defined for the current user or for all users, instead of just default icons from root classes.

JIRA issue: [CORE-14758](https://jira.reactos.org/browse/CORE-14758)

## Proposed changes

Import the following fixes:
- Use the number of bytes instead of the number of characters in the length passed to `RegQueryValueExW`. Calculate this as multiplying the number of characters on size in bytes of one wide character, since the only length of characters is passed to the function. This fixes `ERROR_MORE_DATA` returned from `RegQueryValueExW`, because the passed number of bytes was less than the actual length of the output buffer, since it was calculated incorrectly, so the function fails even when it received the correct number of wide characters.
- Limit the number of characters in registry icon index buffer from 7 to 5, as it done in ANSI version of this function, since registry index number can contain 4 digits maximally + add a space for a null-terminating character.