### PR TITLE
[SHELL32] Allow using custom icons for folders, drives and Desktop places

### DIFF
--- a/dll/win32/shell32/folders/CDrivesFolder.cpp
+++ b/dll/win32/shell32/folders/CDrivesFolder.cpp
@@ -517,26 +517,26 @@ HRESULT CDrivesExtractIcon_CreateInstance(IShellFolder * psf, LPCITEMIDLIST pidl
     {
         case DRIVE_FIXED:
         case DRIVE_UNKNOWN:
-            reg_idx = 8;
+            reg_idx = IDI_SHELL_DRIVE - 1;
             break;
         case DRIVE_CDROM:
-            reg_idx = 11;
+            reg_idx = IDI_SHELL_CDROM - 1;
             break;
         case DRIVE_REMOTE:
-            reg_idx = 9;
+            reg_idx = IDI_SHELL_NETDRIVE - 1;
             break;
         case DRIVE_REMOVABLE:
             if (!IsDriveFloppyA(pszDrive))
-                reg_idx = 7;
+                reg_idx = IDI_SHELL_REMOVEABLE - 1;
             else
-                reg_idx = 6;
+                reg_idx = IDI_SHELL_3_14_FLOPPY - 1;
             break;
         case DRIVE_RAMDISK:
-            reg_idx = 12;
+            reg_idx = IDI_SHELL_RAMDISK - 1;
             break;
         case DRIVE_NO_ROOT_DIR:
         default:
-            reg_idx = 0;
+            reg_idx = IDI_SHELL_DOCUMENT - 1;
             break;
     }
     if (SUCCEEDED(getIconLocationForDrive(psf, pidl, 0, wTemp, _countof(wTemp),

--- a/dll/win32/shell32/folders/CDrivesFolder.cpp
+++ b/dll/win32/shell32/folders/CDrivesFolder.cpp
@@ -541,8 +541,9 @@ HRESULT CDrivesExtractIcon_CreateInstance(IShellFolder * psf, LPCITEMIDLIST pidl
             break;
     }
 
-    if (SUCCEEDED(getIconLocationForDrive(psf, pidl, 0, wTemp, _countof(wTemp),
-                                          &icon_idx, &flags)))
+    hr = getIconLocationForDrive(psf, pidl, 0, wTemp, _countof(wTemp),
+                                 &icon_idx, &flags);
+    if (SUCCEEDED(hr))
     {
         initIcon->SetNormalIcon(wTemp, icon_idx);
     }

--- a/dll/win32/shell32/folders/CDrivesFolder.cpp
+++ b/dll/win32/shell32/folders/CDrivesFolder.cpp
@@ -552,7 +552,7 @@ HRESULT CDrivesExtractIcon_CreateInstance(IShellFolder * psf, LPCITEMIDLIST pidl
         initIcon->SetNormalIcon(wTemp, icon_idx);
     }
     else if ((DriveType == DRIVE_FIXED || DriveType == DRIVE_UNKNOWN) &&
-        (HCR_GetIconW(L"Drive", wTemp, NULL, _countof(wTemp), &icon_idx)))
+             (HCR_GetIconW(L"Drive", wTemp, NULL, _countof(wTemp), &icon_idx)))
     {
         initIcon->SetNormalIcon(wTemp, icon_idx);
     }

--- a/dll/win32/shell32/folders/CDrivesFolder.cpp
+++ b/dll/win32/shell32/folders/CDrivesFolder.cpp
@@ -513,38 +513,40 @@ HRESULT CDrivesExtractIcon_CreateInstance(IShellFolder * psf, LPCITEMIDLIST pidl
     WCHAR wTemp[MAX_PATH];
     int icon_idx, reg_idx;
     UINT flags = 0;
+
     switch (DriveType)
     {
         case DRIVE_FIXED:
         case DRIVE_UNKNOWN:
-            reg_idx = IDI_SHELL_DRIVE - 1;
+            reg_idx = IDI_SHELL_DRIVE;
             break;
         case DRIVE_CDROM:
-            reg_idx = IDI_SHELL_CDROM - 1;
+            reg_idx = IDI_SHELL_CDROM;
             break;
         case DRIVE_REMOTE:
-            reg_idx = IDI_SHELL_NETDRIVE - 1;
+            reg_idx = IDI_SHELL_NETDRIVE;
             break;
         case DRIVE_REMOVABLE:
             if (!IsDriveFloppyA(pszDrive))
-                reg_idx = IDI_SHELL_REMOVEABLE - 1;
+                reg_idx = IDI_SHELL_REMOVEABLE;
             else
-                reg_idx = IDI_SHELL_3_14_FLOPPY - 1;
+                reg_idx = IDI_SHELL_3_14_FLOPPY;
             break;
         case DRIVE_RAMDISK:
-            reg_idx = IDI_SHELL_RAMDISK - 1;
+            reg_idx = IDI_SHELL_RAMDISK;
             break;
         case DRIVE_NO_ROOT_DIR:
         default:
-            reg_idx = IDI_SHELL_DOCUMENT - 1;
+            reg_idx = IDI_SHELL_DOCUMENT;
             break;
     }
+
     if (SUCCEEDED(getIconLocationForDrive(psf, pidl, 0, wTemp, _countof(wTemp),
                                                &icon_idx, &flags)))
     {
         initIcon->SetNormalIcon(wTemp, icon_idx);
     }
-    else if (HLM_GetIconW(reg_idx, wTemp, MAX_PATH, &icon_idx))
+    else if (HLM_GetIconW(reg_idx - 1, wTemp, MAX_PATH, &icon_idx))
     {
         initIcon->SetNormalIcon(wTemp, icon_idx);
     }

--- a/dll/win32/shell32/folders/CDrivesFolder.cpp
+++ b/dll/win32/shell32/folders/CDrivesFolder.cpp
@@ -542,16 +542,16 @@ HRESULT CDrivesExtractIcon_CreateInstance(IShellFolder * psf, LPCITEMIDLIST pidl
     }
 
     if (SUCCEEDED(getIconLocationForDrive(psf, pidl, 0, wTemp, _countof(wTemp),
-                                               &icon_idx, &flags)))
+                                          &icon_idx, &flags)))
     {
         initIcon->SetNormalIcon(wTemp, icon_idx);
     }
-    else if (HLM_GetIconW(reg_idx - 1, wTemp, MAX_PATH, &icon_idx))
+    else if (HLM_GetIconW(reg_idx - 1, wTemp, _countof(wTemp), &icon_idx))
     {
         initIcon->SetNormalIcon(wTemp, icon_idx);
     }
     else if ((DriveType == DRIVE_FIXED || DriveType == DRIVE_UNKNOWN) &&
-        (HCR_GetIconW(L"Drive", wTemp, NULL, MAX_PATH, &icon_idx)))
+        (HCR_GetIconW(L"Drive", wTemp, NULL, _countof(wTemp), &icon_idx)))
     {
         initIcon->SetNormalIcon(wTemp, icon_idx);
     }

--- a/dll/win32/shell32/folders/CFSFolder.cpp
+++ b/dll/win32/shell32/folders/CFSFolder.cpp
@@ -136,7 +136,7 @@ HRESULT GetCLSIDForFileType(PCUIDLIST_RELATIVE pidl, LPCWSTR KeyName, CLSID* pcl
 static HRESULT
 getDefaultIconLocation(LPWSTR szIconFile, UINT cchMax, int *piIndex, UINT uFlags)
 {
-    if (!HLM_GetIconW(3, szIconFile, cchMax, piIndex))
+    if (!HLM_GetIconW(IDI_SHELL_FOLDER - 1, szIconFile, cchMax, piIndex))
     {
         if (!HCR_GetIconW(L"Folder", szIconFile, NULL, cchMax, piIndex))
         {

--- a/dll/win32/shell32/folders/CFSFolder.cpp
+++ b/dll/win32/shell32/folders/CFSFolder.cpp
@@ -140,7 +140,7 @@ getDefaultIconLocation(LPWSTR szIconFile, UINT cchMax, int *piIndex, UINT uFlags
     {
         if (!HCR_GetIconW(L"Folder", szIconFile, NULL, cchMax, piIndex))
         {
-            lstrcpynW(szIconFile, swShell32Name, cchMax);
+            StringCchCopyW(szIconFile, cchMax, swShell32Name);
             *piIndex = -IDI_SHELL_FOLDER;
         }
     }

--- a/dll/win32/shell32/folders/CFSFolder.cpp
+++ b/dll/win32/shell32/folders/CFSFolder.cpp
@@ -136,10 +136,13 @@ HRESULT GetCLSIDForFileType(PCUIDLIST_RELATIVE pidl, LPCWSTR KeyName, CLSID* pcl
 static HRESULT
 getDefaultIconLocation(LPWSTR szIconFile, UINT cchMax, int *piIndex, UINT uFlags)
 {
-    if (!HCR_GetIconW(L"Folder", szIconFile, NULL, cchMax, piIndex))
+    if (!HLM_GetIconW(3, szIconFile, cchMax, piIndex))
     {
-        lstrcpynW(szIconFile, swShell32Name, cchMax);
-        *piIndex = -IDI_SHELL_FOLDER;
+        if (!HCR_GetIconW(L"Folder", szIconFile, NULL, cchMax, piIndex))
+        {
+            lstrcpynW(szIconFile, swShell32Name, cchMax);
+            *piIndex = -IDI_SHELL_FOLDER;
+        }
     }
 
     if (uFlags & GIL_OPENICON)

--- a/dll/win32/shell32/folders/CRegFolder.cpp
+++ b/dll/win32/shell32/folders/CRegFolder.cpp
@@ -192,7 +192,7 @@ HRESULT CGuidItemExtractIcon_CreateInstance(LPCITEMIDLIST pidl, REFIID iid, LPVO
         return hr;
 
     /* Load icon for the current user */
-    BOOL ret = HCU_GetIconW(KeyName, wTemp, iconname, MAX_PATH, &icon_idx);
+    BOOL ret = HCU_GetIconW(KeyName, wTemp, iconname, _countof(wTemp), &icon_idx);
     if (!ret)
     {
         /* Failed, load default system-wide icon */
@@ -200,7 +200,7 @@ HRESULT CGuidItemExtractIcon_CreateInstance(LPCITEMIDLIST pidl, REFIID iid, LPVO
         if (FAILED_UNEXPECTEDLY(hr))
             return hr;
 
-        ret = HCR_GetIconW(KeyName, wTemp, iconname, MAX_PATH, &icon_idx);
+        ret = HCR_GetIconW(KeyName, wTemp, iconname, _countof(wTemp), &icon_idx);
     }
 
     if (ret)

--- a/dll/win32/shell32/folders/CRegFolder.cpp
+++ b/dll/win32/shell32/folders/CRegFolder.cpp
@@ -145,14 +145,7 @@ HRESULT CGuidItemExtractIcon_CreateInstance(LPCITEMIDLIST pidl, REFIID iid, LPVO
     if (!riid)
         return E_FAIL;
 
-    /* my computer and other shell extensions */
-    WCHAR xriid[50];
-
-    swprintf(xriid, L"CLSID\\{%08lx-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x}",
-             riid->Data1, riid->Data2, riid->Data3,
-             riid->Data4[0], riid->Data4[1], riid->Data4[2], riid->Data4[3],
-             riid->Data4[4], riid->Data4[5], riid->Data4[6], riid->Data4[7]);
-
+    /* Choose a correct icon for Recycle Bin (full or empty) */
     const WCHAR* iconname = NULL;
     if (_ILIsBitBucket(pidl))
     {
@@ -179,23 +172,37 @@ HRESULT CGuidItemExtractIcon_CreateInstance(LPCITEMIDLIST pidl, REFIID iid, LPVO
         }
     }
 
-    if (HCR_GetIconW(xriid, wTemp, iconname, MAX_PATH, &icon_idx))
+    /* Prepare registry path for loading icons of My Computer and other shell extensions */
+    WCHAR xriid[MAX_PATH];
+
+    swprintf(xriid, L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\CLSID\\{%08lx-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x}",
+             riid->Data1, riid->Data2, riid->Data3,
+             riid->Data4[0], riid->Data4[1], riid->Data4[2], riid->Data4[3],
+             riid->Data4[4], riid->Data4[5], riid->Data4[6], riid->Data4[7]);
+
+    /* Load icon for the current user */
+    BOOL ret = HCU_GetIconW(xriid, wTemp, iconname, MAX_PATH, &icon_idx);
+    if (!ret)
     {
+        /* Failed, load default system-wide icon */
+        swprintf(xriid, L"CLSID\\{%08lx-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x}",
+                 riid->Data1, riid->Data2, riid->Data3,
+                 riid->Data4[0], riid->Data4[1], riid->Data4[2], riid->Data4[3],
+                 riid->Data4[4], riid->Data4[5], riid->Data4[6], riid->Data4[7]);
+
+        ret = HCR_GetIconW(xriid, wTemp, iconname, MAX_PATH, &icon_idx);
+    }
+
+    if (ret)
+    {
+        /* Success, set loaded icon */
         initIcon->SetNormalIcon(wTemp, icon_idx);
     }
     else
     {
-        // FIXME: Delete these hacks and make HCR_GetIconW and registry working
-        if (IsEqualGUID(*riid, CLSID_MyComputer))
-            initIcon->SetNormalIcon(swShell32Name, -IDI_SHELL_MY_COMPUTER);
-        else if (IsEqualGUID(*riid, CLSID_MyDocuments))
-            initIcon->SetNormalIcon(swShell32Name, -IDI_SHELL_MY_DOCUMENTS);
-        else if (IsEqualGUID(*riid, CLSID_NetworkPlaces))
-            initIcon->SetNormalIcon(swShell32Name, -IDI_SHELL_MY_NETWORK_PLACES);
-        else if (IsEqualGUID(*riid, CLSID_Internet))
-            initIcon->SetNormalIcon(swShell32Name, -IDI_SHELL_WEB_BROWSER);
-        else
-            initIcon->SetNormalIcon(swShell32Name, -IDI_SHELL_FOLDER);
+        /* Everything has failed, set blank paper icon */
+        WARN("Failed to load an icon for the item, setting blank icon\n");
+        initIcon->SetNormalIcon(swShell32Name, 0);
     }
 
     return initIcon->QueryInterface(iid, ppvOut);

--- a/dll/win32/shell32/folders/CRegFolder.cpp
+++ b/dll/win32/shell32/folders/CRegFolder.cpp
@@ -202,7 +202,7 @@ HRESULT CGuidItemExtractIcon_CreateInstance(LPCITEMIDLIST pidl, REFIID iid, LPVO
     {
         /* Everything has failed, set blank paper icon */
         WARN("Failed to load an icon for the item, setting blank icon\n");
-        initIcon->SetNormalIcon(swShell32Name, 0);
+        initIcon->SetNormalIcon(swShell32Name, IDI_SHELL_DOCUMENT - 1);
     }
 
     return initIcon->QueryInterface(iid, ppvOut);

--- a/dll/win32/shell32/iconcache.cpp
+++ b/dll/win32/shell32/iconcache.cpp
@@ -654,34 +654,15 @@ void SIC_Destroy(void)
  */
 static int SIC_LoadOverlayIcon(int icon_idx)
 {
-    WCHAR buffer[1024], wszIdx[8];
-    HKEY hKeyShellIcons;
-    LPCWSTR iconPath;
+    LPWSTR iconPath;
     int iconIdx;
 
     iconPath = swShell32Name;    /* default: load icon from shell32.dll */
     iconIdx = icon_idx;
 
-    if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Shell Icons",
-                      0, KEY_READ, &hKeyShellIcons) == ERROR_SUCCESS)
+    if (!HLM_GetIconW(icon_idx, iconPath, MAX_PATH, &iconIdx))
     {
-        DWORD count = sizeof(buffer);
-
-        swprintf(wszIdx, L"%d", icon_idx);
-
-        /* read icon path and index */
-        if (RegQueryValueExW(hKeyShellIcons, wszIdx, NULL, NULL, (LPBYTE)buffer, &count) == ERROR_SUCCESS)
-        {
-            LPWSTR p = wcschr(buffer, ',');
-
-            if (p)
-                *p++ = 0;
-
-            iconPath = buffer;
-            iconIdx = _wtoi(p);
-        }
-
-        RegCloseKey(hKeyShellIcons);
+        WARN("Failed to load icon with index %d, using default one\n", icon_idx);
     }
 
     if (!sic_hdpa)

--- a/dll/win32/shell32/iconcache.cpp
+++ b/dll/win32/shell32/iconcache.cpp
@@ -654,13 +654,18 @@ void SIC_Destroy(void)
  */
 static int SIC_LoadOverlayIcon(int icon_idx)
 {
+    WCHAR buffer[1024];
     LPWSTR iconPath;
     int iconIdx;
 
     iconPath = swShell32Name;    /* default: load icon from shell32.dll */
     iconIdx = icon_idx;
 
-    if (!HLM_GetIconW(icon_idx, iconPath, MAX_PATH, &iconIdx))
+    if (HLM_GetIconW(icon_idx, buffer, _countof(buffer), &iconIdx))
+    {
+        iconPath = buffer;
+    }
+    else
     {
         WARN("Failed to load icon with index %d, using default one\n", icon_idx);
     }

--- a/dll/win32/shell32/wine/classes.c
+++ b/dll/win32/shell32/wine/classes.c
@@ -34,6 +34,9 @@
 #include <shlwapi.h>
 #include <wine/debug.h>
 #include <wine/unicode.h>
+#ifdef __REACTOS__
+#include <strsafe.h>
+#endif
 
 #include "pidl.h"
 #include "shell32_main.h"

--- a/dll/win32/shell32/wine/classes.c
+++ b/dll/win32/shell32/wine/classes.c
@@ -334,6 +334,112 @@ BOOL HCR_GetIconA(LPCSTR szClass, LPSTR szDest, LPCSTR szName, DWORD len, int* p
 	return ret;
 }
 
+#ifdef __REACTOS__
+BOOL HCU_GetIconW(LPCWSTR szClass, LPWSTR szDest, LPCWSTR szName, DWORD len, int* picon_idx)
+{
+	HKEY	hkey;
+	WCHAR	sTemp[MAX_PATH];
+	BOOL	ret = FALSE;
+
+	TRACE("%s\n",debugstr_w(szClass) );
+
+	swprintf(sTemp, L"%s\\DefaultIcon", szClass);
+
+	if (!RegOpenKeyExW(HKEY_CURRENT_USER, sTemp, 0, KEY_READ, &hkey))
+	{
+	  ret = HCR_RegGetIconW(hkey, szDest, szName, len, picon_idx);
+	  RegCloseKey(hkey);
+	}
+
+        if(ret)
+            TRACE("-- %s %i\n", debugstr_w(szDest), *picon_idx);
+        else
+            TRACE("-- not found\n");
+
+	return ret;
+}
+
+BOOL HCU_GetIconA(LPCSTR szClass, LPSTR szDest, LPCSTR szName, DWORD len, int* picon_idx)
+{
+	HKEY	hkey;
+	char	sTemp[MAX_PATH];
+	BOOL	ret = FALSE;
+
+	TRACE("%s\n",szClass );
+
+	sprintf(sTemp, "%s\\DefaultIcon", szClass);
+
+	if (!RegOpenKeyExA(HKEY_CURRENT_USER, sTemp, 0, KEY_READ, &hkey))
+	{
+	  ret = HCR_RegGetIconA(hkey, szDest, szName, len, picon_idx);
+	  RegCloseKey(hkey);
+	}
+
+    if (ret)
+        TRACE("-- %s %i\n", szDest, *picon_idx);
+    else
+        TRACE("-- not found\n");
+
+	return ret;
+}
+
+BOOL HLM_GetIconW(int reg_idx, LPWSTR szDest, DWORD len, int* picon_idx)
+{
+	HKEY	hkey;
+	WCHAR	sTemp[5];
+	BOOL	ret = FALSE;
+
+	TRACE("%d\n",reg_idx );
+
+	swprintf(sTemp, L"%d", reg_idx);
+
+	if (!RegOpenKeyExW(HKEY_LOCAL_MACHINE,
+	                   L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Shell Icons",
+	                   0,
+	                   KEY_READ,
+	                   &hkey))
+	{
+	  ret = HCR_RegGetIconW(hkey, szDest, sTemp, len, picon_idx);
+	  RegCloseKey(hkey);
+	}
+
+        if(ret)
+            TRACE("-- %s %i\n", debugstr_w(szDest), *picon_idx);
+        else
+            TRACE("-- not found\n");
+
+	return ret;
+}
+
+BOOL HLM_GetIconA(int reg_idx, LPSTR szDest, DWORD len, int* picon_idx)
+{
+	HKEY	hkey;
+	char	sTemp[5];
+	BOOL	ret = FALSE;
+
+	TRACE("%d\n",reg_idx );
+
+	sprintf(sTemp, "%d", reg_idx);
+
+	if (!RegOpenKeyExA(HKEY_LOCAL_MACHINE,
+	                   "Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Shell Icons",
+	                   0,
+	                   KEY_READ,
+	                   &hkey))
+	{
+	  ret = HCR_RegGetIconA(hkey, szDest, sTemp, len, picon_idx);
+	  RegCloseKey(hkey);
+	}
+
+    if (ret)
+        TRACE("-- %s %i\n", szDest, *picon_idx);
+    else
+        TRACE("-- not found\n");
+
+	return ret;
+}
+#endif
+
 /***************************************************************************************
 *	HCR_GetClassName	[internal]
 *

--- a/dll/win32/shell32/wine/classes.c
+++ b/dll/win32/shell32/wine/classes.c
@@ -341,7 +341,7 @@ BOOL HCU_GetIconW(LPCWSTR szClass, LPWSTR szDest, LPCWSTR szName, DWORD len, int
 	WCHAR   sTemp[MAX_PATH];
 	BOOL    ret = FALSE;
 
-    TRACE("%s\n",debugstr_w(szClass) );
+    TRACE("%s\n", debugstr_w(szClass));
 
     swprintf(sTemp, L"%s\\DefaultIcon", szClass);
 

--- a/dll/win32/shell32/wine/classes.c
+++ b/dll/win32/shell32/wine/classes.c
@@ -338,8 +338,8 @@ BOOL HCR_GetIconA(LPCSTR szClass, LPSTR szDest, LPCSTR szName, DWORD len, int* p
 BOOL HCU_GetIconW(LPCWSTR szClass, LPWSTR szDest, LPCWSTR szName, DWORD len, int* picon_idx)
 {
     HKEY    hkey;
-	WCHAR   sTemp[MAX_PATH];
-	BOOL    ret = FALSE;
+    WCHAR   sTemp[MAX_PATH];
+    BOOL    ret = FALSE;
 
     TRACE("%s\n", debugstr_w(szClass));
 

--- a/dll/win32/shell32/wine/classes.c
+++ b/dll/win32/shell32/wine/classes.c
@@ -337,9 +337,9 @@ BOOL HCR_GetIconA(LPCSTR szClass, LPSTR szDest, LPCSTR szName, DWORD len, int* p
 #ifdef __REACTOS__
 BOOL HCU_GetIconW(LPCWSTR szClass, LPWSTR szDest, LPCWSTR szName, DWORD len, int* picon_idx)
 {
-    HKEY    hkey;
-    WCHAR   sTemp[MAX_PATH];
-    BOOL    ret = FALSE;
+    HKEY hkey;
+    WCHAR sTemp[MAX_PATH];
+    BOOL ret = FALSE;
 
     TRACE("%s\n", debugstr_w(szClass));
 
@@ -361,9 +361,9 @@ BOOL HCU_GetIconW(LPCWSTR szClass, LPWSTR szDest, LPCWSTR szName, DWORD len, int
 
 BOOL HCU_GetIconA(LPCSTR szClass, LPSTR szDest, LPCSTR szName, DWORD len, int* picon_idx)
 {
-    LPWSTR  wszClass, wszDest, wszName = NULL;
-    int     lenW;
-    BOOL    ret = FALSE;
+    LPWSTR wszClass, wszDest, wszName = NULL;
+    int lenW;
+    BOOL ret = FALSE;
 
     lenW = MultiByteToWideChar(CP_ACP, 0, szClass, -1, NULL, 0);
     wszClass = HeapAlloc(GetProcessHeap(), 0, lenW * sizeof(WCHAR));
@@ -393,9 +393,9 @@ BOOL HCU_GetIconA(LPCSTR szClass, LPSTR szDest, LPCSTR szName, DWORD len, int* p
 
 BOOL HLM_GetIconW(int reg_idx, LPWSTR szDest, DWORD len, int* picon_idx)
 {
-    HKEY    hkey;
-    WCHAR   sTemp[5];
-    BOOL    ret = FALSE;
+    HKEY hkey;
+    WCHAR sTemp[5];
+    BOOL ret = FALSE;
 
     TRACE("%d\n", reg_idx);
 
@@ -421,8 +421,8 @@ BOOL HLM_GetIconW(int reg_idx, LPWSTR szDest, DWORD len, int* picon_idx)
 
 BOOL HLM_GetIconA(int reg_idx, LPSTR szDest, DWORD len, int* picon_idx)
 {
-    LPWSTR  wszDest;
-    BOOL    ret = FALSE;
+    LPWSTR wszDest;
+    BOOL ret = FALSE;
 
     wszDest = HeapAlloc(GetProcessHeap(), 0, len * sizeof(WCHAR));
     if (wszDest)

--- a/dll/win32/shell32/wine/classes.c
+++ b/dll/win32/shell32/wine/classes.c
@@ -397,7 +397,7 @@ BOOL HLM_GetIconW(int reg_idx, LPWSTR szDest, DWORD len, int* picon_idx)
     WCHAR   sTemp[5];
     BOOL    ret = FALSE;
 
-    TRACE("%d\n",reg_idx );
+    TRACE("%d\n", reg_idx);
 
     swprintf(sTemp, L"%d", reg_idx);
 

--- a/dll/win32/shell32/wine/classes.c
+++ b/dll/win32/shell32/wine/classes.c
@@ -337,102 +337,102 @@ BOOL HCR_GetIconA(LPCSTR szClass, LPSTR szDest, LPCSTR szName, DWORD len, int* p
 #ifdef __REACTOS__
 BOOL HCU_GetIconW(LPCWSTR szClass, LPWSTR szDest, LPCWSTR szName, DWORD len, int* picon_idx)
 {
-	HKEY	hkey;
-	WCHAR	sTemp[MAX_PATH];
-	BOOL	ret = FALSE;
+    HKEY    hkey;
+	WCHAR   sTemp[MAX_PATH];
+	BOOL    ret = FALSE;
 
-	TRACE("%s\n",debugstr_w(szClass) );
+    TRACE("%s\n",debugstr_w(szClass) );
 
-	swprintf(sTemp, L"%s\\DefaultIcon", szClass);
+    swprintf(sTemp, L"%s\\DefaultIcon", szClass);
 
-	if (!RegOpenKeyExW(HKEY_CURRENT_USER, sTemp, 0, KEY_READ, &hkey))
-	{
-	  ret = HCR_RegGetIconW(hkey, szDest, szName, len, picon_idx);
-	  RegCloseKey(hkey);
+    if (!RegOpenKeyExW(HKEY_CURRENT_USER, sTemp, 0, KEY_READ, &hkey))
+    {
+        ret = HCR_RegGetIconW(hkey, szDest, szName, len, picon_idx);
+        RegCloseKey(hkey);
 	}
 
-        if(ret)
-            TRACE("-- %s %i\n", debugstr_w(szDest), *picon_idx);
-        else
-            TRACE("-- not found\n");
+    if (ret)
+        TRACE("-- %s %i\n", debugstr_w(szDest), *picon_idx);
+    else
+        TRACE("-- not found\n");
 
-	return ret;
+    return ret;
 }
 
 BOOL HCU_GetIconA(LPCSTR szClass, LPSTR szDest, LPCSTR szName, DWORD len, int* picon_idx)
 {
-	LPWSTR	wszClass, wszDest, wszName = NULL;
-	int		lenW;
-	BOOL	ret = FALSE;
+    LPWSTR  wszClass, wszDest, wszName = NULL;
+    int     lenW;
+    BOOL    ret = FALSE;
 
-	lenW = MultiByteToWideChar(CP_ACP, 0, szClass, -1, NULL, 0);
-	wszClass = HeapAlloc(GetProcessHeap(), 0, lenW * sizeof(WCHAR));
-	if (wszClass)
-	{
-		MultiByteToWideChar(CP_ACP, 0, szClass, -1, wszClass, lenW);
-		if (szName)
-		{
-			lenW = MultiByteToWideChar(CP_ACP, 0, szName, -1, NULL, 0);
-			wszName = HeapAlloc(GetProcessHeap(), 0, lenW * sizeof(WCHAR));
-			if (wszName)
-				MultiByteToWideChar(CP_ACP, 0, szName, -1, wszName, lenW);
-		}
-		wszDest = HeapAlloc(GetProcessHeap(), 0, len * sizeof(WCHAR));
-		if (wszDest)
-		{
-			ret = HCU_GetIconW(wszClass, wszDest, wszName, len, picon_idx);
-			WideCharToMultiByte(CP_ACP, 0, wszDest, -1, szDest, len, NULL, NULL);
-			HeapFree(GetProcessHeap(), 0, wszDest);
-		}
-		if (wszName)
-			HeapFree(GetProcessHeap(), 0, wszName);
-		HeapFree(GetProcessHeap(), 0, wszClass);
-	}
-	return ret;
+    lenW = MultiByteToWideChar(CP_ACP, 0, szClass, -1, NULL, 0);
+    wszClass = HeapAlloc(GetProcessHeap(), 0, lenW * sizeof(WCHAR));
+    if (wszClass)
+    {
+        MultiByteToWideChar(CP_ACP, 0, szClass, -1, wszClass, lenW);
+        if (szName)
+        {
+            lenW = MultiByteToWideChar(CP_ACP, 0, szName, -1, NULL, 0);
+            wszName = HeapAlloc(GetProcessHeap(), 0, lenW * sizeof(WCHAR));
+            if (wszName)
+                MultiByteToWideChar(CP_ACP, 0, szName, -1, wszName, lenW);
+        }
+        wszDest = HeapAlloc(GetProcessHeap(), 0, len * sizeof(WCHAR));
+        if (wszDest)
+        {
+            ret = HCU_GetIconW(wszClass, wszDest, wszName, len, picon_idx);
+            WideCharToMultiByte(CP_ACP, 0, wszDest, -1, szDest, len, NULL, NULL);
+            HeapFree(GetProcessHeap(), 0, wszDest);
+        }
+        if (wszName)
+            HeapFree(GetProcessHeap(), 0, wszName);
+        HeapFree(GetProcessHeap(), 0, wszClass);
+    }
+    return ret;
 }
 
 BOOL HLM_GetIconW(int reg_idx, LPWSTR szDest, DWORD len, int* picon_idx)
 {
-	HKEY	hkey;
-	WCHAR	sTemp[5];
-	BOOL	ret = FALSE;
+    HKEY    hkey;
+    WCHAR   sTemp[5];
+    BOOL    ret = FALSE;
 
-	TRACE("%d\n",reg_idx );
+    TRACE("%d\n",reg_idx );
 
-	swprintf(sTemp, L"%d", reg_idx);
+    swprintf(sTemp, L"%d", reg_idx);
 
-	if (!RegOpenKeyExW(HKEY_LOCAL_MACHINE,
-	                   L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Shell Icons",
-	                   0,
-	                   KEY_READ,
-	                   &hkey))
-	{
-	  ret = HCR_RegGetIconW(hkey, szDest, sTemp, len, picon_idx);
-	  RegCloseKey(hkey);
-	}
+    if (!RegOpenKeyExW(HKEY_LOCAL_MACHINE,
+                       L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Shell Icons",
+                       0,
+                       KEY_READ,
+                       &hkey))
+    {
+        ret = HCR_RegGetIconW(hkey, szDest, sTemp, len, picon_idx);
+        RegCloseKey(hkey);
+    }
 
-        if(ret)
-            TRACE("-- %s %i\n", debugstr_w(szDest), *picon_idx);
-        else
-            TRACE("-- not found\n");
+    if (ret)
+        TRACE("-- %s %i\n", debugstr_w(szDest), *picon_idx);
+    else
+        TRACE("-- not found\n");
 
-	return ret;
+    return ret;
 }
 
 BOOL HLM_GetIconA(int reg_idx, LPSTR szDest, DWORD len, int* picon_idx)
 {
-	LPWSTR	wszDest;
-	BOOL	ret = FALSE;
+    LPWSTR  wszDest;
+    BOOL    ret = FALSE;
 
-	wszDest = HeapAlloc(GetProcessHeap(), 0, len * sizeof(WCHAR));
-	if (wszDest)
-	{
-		ret = HLM_GetIconW(reg_idx, wszDest, len, picon_idx);
-		WideCharToMultiByte(CP_ACP, 0, wszDest, -1, szDest, len, NULL, NULL);
-		HeapFree(GetProcessHeap(), 0, wszDest);
-	}
+    wszDest = HeapAlloc(GetProcessHeap(), 0, len * sizeof(WCHAR));
+    if (wszDest)
+    {
+        ret = HLM_GetIconW(reg_idx, wszDest, len, picon_idx);
+        WideCharToMultiByte(CP_ACP, 0, wszDest, -1, szDest, len, NULL, NULL);
+        HeapFree(GetProcessHeap(), 0, wszDest);
+    }
 
-	return ret;
+    return ret;
 }
 #endif
 

--- a/dll/win32/shell32/wine/classes.c
+++ b/dll/win32/shell32/wine/classes.c
@@ -359,38 +359,6 @@ BOOL HCU_GetIconW(LPCWSTR szClass, LPWSTR szDest, LPCWSTR szName, DWORD len, int
     return ret;
 }
 
-BOOL HCU_GetIconA(LPCSTR szClass, LPSTR szDest, LPCSTR szName, DWORD len, int* picon_idx)
-{
-    LPWSTR wszClass, wszDest, wszName = NULL;
-    int lenW;
-    BOOL ret = FALSE;
-
-    lenW = MultiByteToWideChar(CP_ACP, 0, szClass, -1, NULL, 0);
-    wszClass = HeapAlloc(GetProcessHeap(), 0, lenW * sizeof(WCHAR));
-    if (wszClass)
-    {
-        MultiByteToWideChar(CP_ACP, 0, szClass, -1, wszClass, lenW);
-        if (szName)
-        {
-            lenW = MultiByteToWideChar(CP_ACP, 0, szName, -1, NULL, 0);
-            wszName = HeapAlloc(GetProcessHeap(), 0, lenW * sizeof(WCHAR));
-            if (wszName)
-                MultiByteToWideChar(CP_ACP, 0, szName, -1, wszName, lenW);
-        }
-        wszDest = HeapAlloc(GetProcessHeap(), 0, len * sizeof(WCHAR));
-        if (wszDest)
-        {
-            ret = HCU_GetIconW(wszClass, wszDest, wszName, len, picon_idx);
-            WideCharToMultiByte(CP_ACP, 0, wszDest, -1, szDest, len, NULL, NULL);
-            HeapFree(GetProcessHeap(), 0, wszDest);
-        }
-        if (wszName)
-            HeapFree(GetProcessHeap(), 0, wszName);
-        HeapFree(GetProcessHeap(), 0, wszClass);
-    }
-    return ret;
-}
-
 BOOL HLM_GetIconW(int reg_idx, LPWSTR szDest, DWORD len, int* picon_idx)
 {
     HKEY hkey;
@@ -415,22 +383,6 @@ BOOL HLM_GetIconW(int reg_idx, LPWSTR szDest, DWORD len, int* picon_idx)
         TRACE("-- %s %i\n", debugstr_w(szDest), *picon_idx);
     else
         TRACE("-- not found\n");
-
-    return ret;
-}
-
-BOOL HLM_GetIconA(int reg_idx, LPSTR szDest, DWORD len, int* picon_idx)
-{
-    LPWSTR wszDest;
-    BOOL ret = FALSE;
-
-    wszDest = HeapAlloc(GetProcessHeap(), 0, len * sizeof(WCHAR));
-    if (wszDest)
-    {
-        ret = HLM_GetIconW(reg_idx, wszDest, len, picon_idx);
-        WideCharToMultiByte(CP_ACP, 0, wszDest, -1, szDest, len, NULL, NULL);
-        HeapFree(GetProcessHeap(), 0, wszDest);
-    }
 
     return ret;
 }

--- a/dll/win32/shell32/wine/classes.c
+++ b/dll/win32/shell32/wine/classes.c
@@ -343,7 +343,7 @@ BOOL HCU_GetIconW(LPCWSTR szClass, LPWSTR szDest, LPCWSTR szName, DWORD len, int
 
     TRACE("%s\n", debugstr_w(szClass));
 
-    swprintf(sTemp, L"%s\\DefaultIcon", szClass);
+    StringCchPrintfW(sTemp, _countof(sTemp), L"%s\\DefaultIcon", szClass);
 
     if (!RegOpenKeyExW(HKEY_CURRENT_USER, sTemp, 0, KEY_READ, &hkey))
     {
@@ -399,7 +399,7 @@ BOOL HLM_GetIconW(int reg_idx, LPWSTR szDest, DWORD len, int* picon_idx)
 
     TRACE("%d\n", reg_idx);
 
-    swprintf(sTemp, L"%d", reg_idx);
+    StringCchPrintfW(sTemp, _countof(sTemp), L"%d", reg_idx);
 
     if (!RegOpenKeyExW(HKEY_LOCAL_MACHINE,
                        L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Shell Icons",

--- a/dll/win32/shell32/wine/shell32_main.h
+++ b/dll/win32/shell32/wine/shell32_main.h
@@ -51,7 +51,7 @@ BOOL HCR_GetIconW(LPCWSTR szClass, LPWSTR szDest, LPCWSTR szName, DWORD len, int
 BOOL HCR_GetClassNameW(REFIID riid, LPWSTR szDest, DWORD len) DECLSPEC_HIDDEN;
 
 #ifdef __REACTOS__
-/* Curren User */
+/* Current User */
 BOOL HCU_GetIconW(LPCWSTR szClass, LPWSTR szDest, LPCWSTR szName, DWORD len, int* picon_idx) DECLSPEC_HIDDEN;
 BOOL HCU_GetIconA(LPCSTR szClass, LPSTR szDest, LPCSTR szName, DWORD len, int* picon_idx) DECLSPEC_HIDDEN;
 

--- a/dll/win32/shell32/wine/shell32_main.h
+++ b/dll/win32/shell32/wine/shell32_main.h
@@ -50,6 +50,16 @@ BOOL HCR_GetExecuteCommandW( HKEY hkeyClass, LPCWSTR szClass, LPCWSTR szVerb, LP
 BOOL HCR_GetIconW(LPCWSTR szClass, LPWSTR szDest, LPCWSTR szName, DWORD len, int* picon_idx);
 BOOL HCR_GetClassNameW(REFIID riid, LPWSTR szDest, DWORD len) DECLSPEC_HIDDEN;
 
+#ifdef __REACTOS__
+/* Curren User */
+BOOL HCU_GetIconW(LPCWSTR szClass, LPWSTR szDest, LPCWSTR szName, DWORD len, int* picon_idx) DECLSPEC_HIDDEN;
+BOOL HCU_GetIconA(LPCSTR szClass, LPSTR szDest, LPCSTR szName, DWORD len, int* picon_idx) DECLSPEC_HIDDEN;
+
+/* Local Machine */
+BOOL HLM_GetIconW(int reg_idx, LPWSTR szDest, DWORD len, int* picon_idx) DECLSPEC_HIDDEN;
+BOOL HLM_GetIconA(int reg_idx, LPSTR szDest, DWORD len, int* picon_idx) DECLSPEC_HIDDEN;
+#endif
+
 /* ANSI versions of above functions, supposed to go away as soon as they are not used anymore */
 BOOL HCR_MapTypeToValueA(LPCSTR szExtension, LPSTR szFileType, LONG len, BOOL bPrependDot) DECLSPEC_HIDDEN;
 BOOL HCR_GetIconA(LPCSTR szClass, LPSTR szDest, LPCSTR sName, DWORD len, int* picon_idx);

--- a/dll/win32/shell32/wine/shell32_main.h
+++ b/dll/win32/shell32/wine/shell32_main.h
@@ -53,11 +53,9 @@ BOOL HCR_GetClassNameW(REFIID riid, LPWSTR szDest, DWORD len) DECLSPEC_HIDDEN;
 #ifdef __REACTOS__
 /* Current User */
 BOOL HCU_GetIconW(LPCWSTR szClass, LPWSTR szDest, LPCWSTR szName, DWORD len, int* picon_idx) DECLSPEC_HIDDEN;
-BOOL HCU_GetIconA(LPCSTR szClass, LPSTR szDest, LPCSTR szName, DWORD len, int* picon_idx) DECLSPEC_HIDDEN;
 
 /* Local Machine */
 BOOL HLM_GetIconW(int reg_idx, LPWSTR szDest, DWORD len, int* picon_idx) DECLSPEC_HIDDEN;
-BOOL HLM_GetIconA(int reg_idx, LPSTR szDest, DWORD len, int* picon_idx) DECLSPEC_HIDDEN;
 #endif
 
 /* ANSI versions of above functions, supposed to go away as soon as they are not used anymore */


### PR DESCRIPTION
## Purpose

Load the custom icons defined for the current user and for all users from registry, in case they are defined there, instead of always loading default system-defined icons.
**Depends on #6418 PR (is merged now).**

JIRA issue: [CORE-14758](https://jira.reactos.org/browse/CORE-14758)

## Proposed changes

- Add a code to load the icons specified by user in registry in the following keys:
    - `HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CLSID\{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}\DefaultIcon` (virtual namespace folders);
    - `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Shell Icons` (file system folders and drives).
- Implement two functions `HCU_GetIcon` and `HLM_GetIcon`, ANSI and Unicode versions, those are reading the icons from HKCU and HKLM appropriately. Note that `HCR_GetIcon` always loads only default icons, even when the custom ones are specified by user.
- Define them in the main shell32 header, for the later usage.
- Use previously added `HCU_RegGetIconW` and `HLM_RegGetIconW` functions for loading the icons.
- Do this for:
    - virtual namespace folders and other desktop items (like My Computer, My Documents, Network Places, Recycle Bin, Web Browser (aka Internet Explorer), Control Panel and some CPL items inside it);
    - normal filesystem folders (aka usual directories, inbuilt in the system and created by user);
    - all types of drives (like fixed disk drives (hard drive, inbuilt or external), removable drives (USB flash drives, SD cards), CD-ROMs (CD/DVD/BluRay optical storages), RamDisks and remote (network) drives). Handle invalid drives also, set the blank paper icon for them, since they cannot be recognized exactly or are not mounted correctly. Also, load the autorun icons first, to avoid overriding them by the icons defined in registry.
- Regarding Start Menu icons:
    - changing them should be corectly implemented in explorer instead of shell32, as explorer is responsible for the Start Menu and partially for Taskbar;
    - to actually use all of them, we need to implement modern Start Menu first.

I've rechecked twice: excepting Start Menu icons, Desktop Workspace icon and some FS folders icons (those have their own `desktop.ini` configuration files, we probably should write the custom icons we load to these configs, as Windows does it, perhaps via `WritePrivateProfileStringW`), all other icons can be changed now (only ones which can be changed on XP SP3/2003 SP2 of course), via inbuilt system tools (like Desktop icons in desk.cpl) or any 3rd-party tools, without any modification of system resources. Also all icons for the known file types can be changed, same as before my changes.
Useful reference: http://www.winfaq.de/faq_html/Content/tip0000/onlinefaq.php?h=tip0162.htm.

## Result

See demo video as well (works only in Chrome). :smiley: 

https://github.com/reactos/reactos/assets/26385117/49db6345-c0fe-4226-8fbd-f5dc2c68829b

