### PR TITLE
[NTUSER] Fix PeekMessageA for MsgFilterLow/High mouse clicks

### DIFF
--- a/win32ss/user/ntuser/msgqueue.c
+++ b/win32ss/user/ntuser/msgqueue.c
@@ -2002,7 +2002,7 @@ co_MsqPeekHardwareMessage(IN PTHREADINFO pti,
          
          if (MsgFilterLow != 0 || MsgFilterHigh != 0)
          {
-             /* Don't return message if not in range. */
+             /* Don't return message if not in range */
              if (msg.message < MsgFilterLow || msg.message > MsgFilterHigh)
                  AcceptMessage = FALSE;
          }


### PR DESCRIPTION
## Purpose

_Fix MSO and Word Viewer not closing when "X" on title bar is clicked._
_This is another @I_Kill_Bugs patch._

JIRA issue: [CORE-14436](https://jira.reactos.org/browse/CORE-14436)
JIRA issue: [CORE-16985](https://jira.reactos.org/browse/CORE-16985)

## Proposed changes

_Fix MsgFilterLow/MsgFilterHigh handling for nonclient areas for mouse events._