### PR TITLE
[NTOS:IO] Initialize InterruptObject to NULL on failure

### DIFF
--- a/modules/rostests/kmtests/ntos_io/IoInterrupt.c
+++ b/modules/rostests/kmtests/ntos_io/IoInterrupt.c
@@ -91,7 +91,34 @@ TestSynchronizeExecution(VOID)
     }
 }
 
+static
+VOID
+TestConnectInterrupt(VOID)
+{
+    PKINTERRUPT InterruptObject;
+    NTSTATUS Status;
+
+    /* If the IoConnectInterrupt() fails, the interrupt object should be set to NULL */
+    InterruptObject = KmtInvalidPointer;
+
+    /* Test for invalid interrupt */
+    Status = IoConnectInterrupt(&InterruptObject,
+                                (PKSERVICE_ROUTINE)TestConnectInterrupt,
+                                NULL,
+                                NULL,
+                                0,
+                                0,
+                                0,
+                                LevelSensitive,
+                                TRUE,
+                                (KAFFINITY)-1,
+                                FALSE);
+    ok_eq_hex(Status, STATUS_INVALID_PARAMETER);
+    ok_eq_pointer(InterruptObject, NULL);
+}
+
 START_TEST(IoInterrupt)
 {
     TestSynchronizeExecution();
+    TestConnectInterrupt();
 }

--- a/ntoskrnl/io/iomgr/irq.c
+++ b/ntoskrnl/io/iomgr/irq.c
@@ -112,6 +112,7 @@ IoConnectInterrupt(OUT PKINTERRUPT *InterruptObject,
                 }
 
                 /* And fail */
+                *InterruptObject = NULL;
                 return STATUS_INVALID_PARAMETER;
             }
 


### PR DESCRIPTION
## Purpose

Fixes a pool corruption when trying to handle IRP_MN_REMOVE_DEVICE in the driver. The typical use of the `IoDisconnectInterrupt`:

```
if (DevExt->InterruptObject)
{
    IoDisconnectInterrupt(DevExt->InterruptObject);
    DevExt->InterruptObject= NULL;
}
```

JIRA issue: [CORE-17256](https://jira.reactos.org/browse/CORE-17256)

## Proposed changes

- Initialize InterruptObject to NULL on failure
