### PR TITLE
[REG] Fix importing *.reg file with Unicode encoding

### DIFF
--- a/base/applications/cmdutils/reg/import.c
+++ b/base/applications/cmdutils/reg/import.c
@@ -772,9 +772,16 @@ invalid:
 static WCHAR *hex_data_state(struct parser *parser, WCHAR *pos)
 {
     WCHAR *line = pos;
+#ifdef __REACTOS__
+    BOOL is_unicode_save = parser->is_unicode;
+#endif
 
     if (!*line)
         goto set_value;
+
+#ifdef __REACTOS__
+    parser->is_unicode = TRUE;
+#endif
 
     if (!convert_hex_csv_to_hex(parser, &line))
         goto invalid;
@@ -782,6 +789,9 @@ static WCHAR *hex_data_state(struct parser *parser, WCHAR *pos)
     if (parser->backslash)
     {
         set_state(parser, EOL_BACKSLASH);
+#ifdef __REACTOS__
+        parser->is_unicode = is_unicode_save;
+#endif
         return line;
     }
 
@@ -789,10 +799,16 @@ static WCHAR *hex_data_state(struct parser *parser, WCHAR *pos)
 
 set_value:
     set_state(parser, SET_VALUE);
+#ifdef __REACTOS__
+    parser->is_unicode = is_unicode_save;
+#endif
     return line;
 
 invalid:
     free_parser_data(parser);
+#ifdef __REACTOS__
+    parser->is_unicode = is_unicode_save;
+#endif
     set_state(parser, LINE_START);
     return line;
 }


### PR DESCRIPTION
## Purpose

_Fix 'reg import file.reg' importing when file is Unicode encoded._

JIRA issue: [CORE-15185](https://jira.reactos.org/browse/CORE-15185)

## Proposed changes

_Force 'parser->is_unicode' to TRUE when dealing with Unicode imports._