### PR TITLE
Fall back to VGA driver if main display driver doesn't work

### DIFF
--- a/boot/bootdata/hiveinst.inf
+++ b/boot/bootdata/hiveinst.inf
@@ -7,6 +7,3 @@ Signature = "$Windows NT$"
 ;
 ; Display driver section
 ;
-
-; VGA miniport driver
-HKLM,"SYSTEM\CurrentControlSet\Services\VgaSave","Start",0x00010001,0x00000001

--- a/win32ss/drivers/miniport/vga/vga_reg.inf
+++ b/win32ss/drivers/miniport/vga/vga_reg.inf
@@ -3,7 +3,7 @@
 HKLM,"SYSTEM\CurrentControlSet\Services\VgaSave","ErrorControl",0x00010001,0x00000000
 HKLM,"SYSTEM\CurrentControlSet\Services\VgaSave","Group",0x00000000,"Video Save"
 HKLM,"SYSTEM\CurrentControlSet\Services\VgaSave","ImagePath",0x00020000,"system32\drivers\vga.sys"
-HKLM,"SYSTEM\CurrentControlSet\Services\VgaSave","Start",0x00010001,0x00000004
+HKLM,"SYSTEM\CurrentControlSet\Services\VgaSave","Start",0x00010001,0x00000001
 HKLM,"SYSTEM\CurrentControlSet\Services\VgaSave","Type",0x00010001,0x00000001
 HKLM,"SYSTEM\CurrentControlSet\Services\VgaSave","Tag",0x00010001,0x00000002
 HKLM,"SYSTEM\CurrentControlSet\Services\VgaSave\Video","Service",0x00000000,"VgaSave"

--- a/win32ss/drivers/videoprt/dispatch.c
+++ b/win32ss/drivers/videoprt/dispatch.c
@@ -805,7 +805,9 @@ IntVideoPortDispatchDeviceControl(
 
         case IOCTL_VIDEO_IS_VGA_DEVICE:
             WARN_(VIDEOPRT, "- IOCTL_VIDEO_IS_VGA_DEVICE is UNIMPLEMENTED!\n");
-            Status = STATUS_NOT_IMPLEMENTED;
+            *((PBOOLEAN)Irp->AssociatedIrp.SystemBuffer) = IntIsVgaSaveDriver(DeviceObject);
+            Irp->IoStatus.Information = sizeof(BOOLEAN);
+            Status = STATUS_SUCCESS;
             break;
 
         case IOCTL_VIDEO_USE_DEVICE_IN_SESSION:

--- a/win32ss/drivers/videoprt/resource.c
+++ b/win32ss/drivers/videoprt/resource.c
@@ -994,6 +994,12 @@ VideoPortVerifyAccessRanges(
 
     ExFreePoolWithTag(ResourceList, TAG_VIDEO_PORT);
 
+    if (ConflictDetected && IntIsVgaSaveDriver(DeviceExtension->FunctionalDeviceObject))
+    {
+        /* Ignore conflicts if it is the VgaSave driver */
+        return NO_ERROR;
+    }
+
     if (!NT_SUCCESS(Status) || ConflictDetected)
         return ERROR_INVALID_PARAMETER;
     else

--- a/win32ss/drivers/videoprt/videoprt.c
+++ b/win32ss/drivers/videoprt/videoprt.c
@@ -570,6 +570,40 @@ Failure:
     return Status;
 }
 
+/* We implement RtlSuffixUnicodeString, which doesn't exist... */
+static
+BOOLEAN
+VideoSuffixUnicodeString(
+    _In_ PCUNICODE_STRING String1,
+    _In_ PCUNICODE_STRING String2,
+    _In_ BOOLEAN CaseInsensitive)
+{
+    PWCHAR Str;
+
+    if (String1->Length > String2->Length)
+        return FALSE;
+
+    Str = String2->Buffer + (String2->Length - String1->Length) / sizeof(WCHAR);
+    if (CaseInsensitive)
+        return _wcsnicmp(String1->Buffer, Str, String1->Length / sizeof(WCHAR)) == 0;
+    else
+        return memcmp(String1->Buffer, Str, String1->Length) == 0;
+}
+
+BOOLEAN
+IntIsVgaSaveDriver(
+    PDEVICE_OBJECT DeviceObject)
+{
+    const UNICODE_STRING VgaSaveDriverName = RTL_CONSTANT_STRING(L"VgaSave");
+    PVIDEO_PORT_DRIVER_EXTENSION DriverExtension;
+    PVIDEO_PORT_DEVICE_EXTENSION DeviceExtension;
+
+    DeviceExtension = (PVIDEO_PORT_DEVICE_EXTENSION)DeviceObject->DeviceExtension;
+    DriverExtension = IoGetDriverObjectExtension(DeviceExtension->DriverObject, DeviceExtension->DriverObject);
+
+    return VideoSuffixUnicodeString(&VgaSaveDriverName, &DriverExtension->RegistryPath, TRUE);
+}
+
 VOID
 FASTCALL
 IntAttachToCSRSS(

--- a/win32ss/drivers/videoprt/videoprt.h
+++ b/win32ss/drivers/videoprt/videoprt.h
@@ -258,6 +258,9 @@ extern KMUTEX VideoPortInt10Mutex;
 extern KSPIN_LOCK HwResetAdaptersLock;
 extern LIST_ENTRY HwResetAdaptersList;
 
+BOOLEAN
+IntIsVgaSaveDriver(PDEVICE_OBJECT DeviceObject);
+
 VOID FASTCALL
 IntAttachToCSRSS(PKPROCESS *CallingProcess, PKAPC_STATE ApcState);
 

--- a/win32ss/gdi/eng/pdevobj.c
+++ b/win32ss/gdi/eng/pdevobj.c
@@ -543,7 +543,7 @@ PDEVOBJ_Create(
         {
             RtlCopyMemory(ppdev->pdmwDev, pdm, pdm->dmSize + pdm->dmDriverExtra);
             /* FIXME: this must be done in a better way */
-            pGraphicsDevice->StateFlags |= DISPLAY_DEVICE_PRIMARY_DEVICE | DISPLAY_DEVICE_ATTACHED_TO_DESKTOP;
+            pGraphicsDevice->StateFlags |= DISPLAY_DEVICE_ATTACHED_TO_DESKTOP;
         }
     }
 

--- a/win32ss/user/ntuser/display.c
+++ b/win32ss/user/ntuser/display.c
@@ -171,17 +171,8 @@ InitVideo(VOID)
     /* Check if we had any success */
     if (!gpPrimaryGraphicsDevice)
     {
-        /* Check if there is a VGA device we skipped */
-        if (gpVgaGraphicsDevice)
-        {
-            /* There is, use the VGA device */
-            gpPrimaryGraphicsDevice = gpVgaGraphicsDevice;
-        }
-        else
-        {
-            ERR("No usable display driver was found.\n");
-            return STATUS_UNSUCCESSFUL;
-        }
+        ERR("No usable display driver was found.\n");
+        return STATUS_UNSUCCESSFUL;
     }
 
     InitSysParams();


### PR DESCRIPTION
## Purpose

Fall back to VGA driver if main display driver doesn't work

JIRA issue: [CORE-7728](https://jira.reactos.org/browse/CORE-7728)

## Proposed changes

- always load the VgaSave driver
- change videoprt.sys to allow resource conflicts in VgaSave driver
- implement IOCTL_VIDEO_IS_VGA_DEVICE so win32k can detect the VgaSave driver
- rework EngpUpdateGraphicsDeviceList in win32k to handle gbBaseVideo = TRUE, even if no new graphics device is detected