### PR TITLE
[SDK:CRT] Reenable malloc.h inclusion in xmmintrin.h

### DIFF
--- a/modules/rostests/winetests/msvcrt/msvcrt.h
+++ b/modules/rostests/winetests/msvcrt/msvcrt.h
@@ -64,9 +64,9 @@ typedef unsigned __int64 MSVCRT_size_t;
 typedef __int64 MSVCRT_intptr_t;
 typedef unsigned __int64 MSVCRT_uintptr_t;
 #else
-typedef unsigned long MSVCRT_size_t;
-typedef long MSVCRT_intptr_t;
-typedef unsigned long MSVCRT_uintptr_t;
+typedef unsigned int MSVCRT_size_t;
+typedef int MSVCRT_intptr_t;
+typedef unsigned int MSVCRT_uintptr_t;
 #endif
 typedef unsigned int   MSVCRT__dev_t;
 typedef int MSVCRT__off_t;

--- a/sdk/include/crt/xmmintrin.h
+++ b/sdk/include/crt/xmmintrin.h
@@ -29,7 +29,7 @@
 #endif
 
 #if !defined _VCRT_BUILD && !defined _INC_MALLOC
-//#include <malloc.h> // FIXME: This breaks build
+#include <malloc.h> // For _mm_malloc() and _mm_free()
 #endif
 
 #ifdef __cplusplus

--- a/sdk/lib/crt/wine/msvcrt.h
+++ b/sdk/lib/crt/wine/msvcrt.h
@@ -80,9 +80,9 @@ typedef unsigned __int64 MSVCRT_size_t;
 typedef __int64 MSVCRT_intptr_t;
 typedef unsigned __int64 MSVCRT_uintptr_t;
 #else
-typedef unsigned long MSVCRT_size_t;
-typedef long MSVCRT_intptr_t;
-typedef unsigned long MSVCRT_uintptr_t;
+typedef unsigned int MSVCRT_size_t;
+typedef int MSVCRT_intptr_t;
+typedef unsigned int MSVCRT_uintptr_t;
 #endif
 #ifdef _CRTDLL
 typedef short MSVCRT__dev_t;


### PR DESCRIPTION
## Purpose

Addendum to commit 318d696f0

It should now be possible to re-enable the MS-PSDK/CRT-compatible malloc.h inclusion in the xmmintrin.h header;
however Wine code is still incompatible in this regard.

The following build errors only happen in 32-bits, but not in 64-bits.

_**MSVC:**_
```
FAILED: sdk/lib/crt/CMakeFiles/crt.dir/wine/cpp.c.obj 
d:\a\reactos\reactos\src\sdk\lib\crt\wine\msvcrt.h(1066): error C4028: formal parameter 1 different from declaration
```

_**Clang:**_
```
FAILED: sdk/lib/crt/CMakeFiles/crt.dir/wine/cpp.c.obj 
In file included from D:\a\reactos\reactos\src\sdk\lib\crt\wine\cpp.c:31:
D:\a\reactos\reactos\src\sdk\lib\crt\wine/msvcrt.h(1066,18): error: conflicting types for 'malloc'
void* __cdecl    MSVCRT_malloc(MSVCRT_size_t);
                 ^
D:\a\reactos\reactos\src\sdk\lib\crt\wine/winternl.h(308,23): note: expanded from macro 'MSVCRT_malloc'
#define MSVCRT_malloc malloc
                      ^
D:\a\reactos\reactos\src\sdk\include\crt\malloc.h(88,3): note: previous declaration is here
  malloc(
  ^
D:\a\reactos\reactos\src\sdk\lib\crt\wine\cpp.c(605,28): warning: incompatible function pointer types passing 'void *(unsigned int)' to parameter of type 'malloc_func_t' (aka 'void *(*)(unsigned long)') [-Wincompatible-function-pointer-types]
                           MSVCRT_malloc, MSVCRT_free, UNDNAME_NO_ARGUMENTS | UNDNAME_32_BIT_DECODE);
                           ^~~~~~~~~~~~~
D:\a\reactos\reactos\src\sdk\lib\crt\wine/winternl.h(308,23): note: expanded from macro 'MSVCRT_malloc'
#define MSVCRT_malloc malloc
                      ^~~~~~
D:\a\reactos\reactos\src\sdk\lib\crt\wine/msvcrt.h(1248,68): note: passing argument to parameter here
extern char* __cdecl __unDName(char *,const char*,int,malloc_func_t,free_func_t,unsigned short int);
                                                                   ^
1 warning and 1 error generated.
```