### PR TITLE
[NETSHELL] Trivial tweaks

### DIFF
--- a/dll/shellext/netshell/lang/es-ES.rc
+++ b/dll/shellext/netshell/lang/es-ES.rc
@@ -21,7 +21,7 @@ BEGIN
     PUSHBUTTON "Inst&alar", IDC_INSTALL, 9, 105, 65, 14, WS_DISABLED | WS_TABSTOP
     PUSHBUTTON "&Desinstalar", IDC_UNINSTALL, 90, 105, 65, 14, WS_DISABLED | WS_TABSTOP
     PUSHBUTTON "&Propiedades", IDC_PROPERTIES, 174, 105, 65, 14
-    GROUPBOX "Descripción ", -1, 9, 128, 230, 46, BS_GROUPBOX
+    GROUPBOX "Descripción", -1, 9, 128, 230, 46, BS_GROUPBOX
     LTEXT "", IDC_DESCRIPTION, 15, 140, 217, 28, WS_GROUP
     AUTOCHECKBOX "Mostrar icono en el área de notificación al conectarse", IDC_SHOWTASKBAR, 9, 181, 230, 12, WS_TABSTOP
     AUTOCHECKBOX "Notificarme cuando esta conexión tenga conectividad limitada o nula", IDC_NOTIFYNOCONNECTION, 9, 195, 230, 20, BS_MULTILINE | BS_TOP | WS_TABSTOP
@@ -39,11 +39,11 @@ STYLE DS_SHELLFONT | WS_CHILD | WS_CAPTION
 CAPTION "General"
 FONT 8, "MS Shell Dlg"
 BEGIN
-    GROUPBOX "Conexión ", -1, 9, 8, 190, 58, BS_GROUPBOX
+    GROUPBOX "Conexión", -1, 9, 8, 190, 58, BS_GROUPBOX
     LTEXT "Estado:", -1, 22, 20, 65, 8
     LTEXT "Duración:", -1, 22, 34, 65, 8
     LTEXT "Velocidad:", -1, 22, 48, 65, 8
-    GROUPBOX "Actividad ", -1, 9, 74, 190, 70, BS_GROUPBOX
+    GROUPBOX "Actividad", -1, 9, 74, 190, 70, BS_GROUPBOX
     LTEXT "Enviados", -1, 60, 90, 60, 8
     ICON "", IDC_NETSTAT, 110, 85, 32, 32
     RTEXT "Recibidos", -1, 146, 90, 44, 8
@@ -62,7 +62,7 @@ STYLE DS_SHELLFONT | WS_CHILD | WS_DISABLED | WS_CAPTION
 CAPTION "Soporte"
 FONT 8, "MS Shell Dlg"
 BEGIN
-    GROUPBOX "Estado de la conexión ", -1, 9, 8, 190, 88, BS_GROUPBOX
+    GROUPBOX "Estado de la conexión", -1, 9, 8, 190, 88, BS_GROUPBOX
     LTEXT "Tipo de dirección:", -1, 22, 20, 80, 8
     LTEXT "Dirección IP:", -1, 22, 34, 80, 8
     LTEXT "Máscara de subred:", -1, 22, 48, 80, 8

--- a/dll/shellext/netshell/lang/pt-PT.rc
+++ b/dll/shellext/netshell/lang/pt-PT.rc
@@ -13,7 +13,7 @@ BEGIN
     PUSHBUTTON "Inst&alar", IDC_INSTALL, 9, 105, 65, 14, WS_DISABLED | WS_TABSTOP
     PUSHBUTTON "&Desinstalar", IDC_UNINSTALL, 90, 105, 65, 14, WS_DISABLED | WS_TABSTOP
     PUSHBUTTON "&Propriedades", IDC_PROPERTIES, 174, 105, 65, 14
-    GROUPBOX "Descrição ", -1, 9, 128, 230, 46, BS_GROUPBOX
+    GROUPBOX "Descrição", -1, 9, 128, 230, 46, BS_GROUPBOX
     LTEXT "", IDC_DESCRIPTION, 15, 140, 217, 28, WS_GROUP
     AUTOCHECKBOX "&Mostrar icon na área de notificação quando ligado", IDC_SHOWTASKBAR, 9, 181, 230, 12, WS_TABSTOP
     AUTOCHECKBOX "&Notificar-me quando a conectividade desta ligação for limitada ou nula", IDC_NOTIFYNOCONNECTION, 9, 195, 230, 20, BS_MULTILINE | BS_TOP | WS_TABSTOP
@@ -31,11 +31,11 @@ STYLE DS_SHELLFONT | WS_CHILD | WS_CAPTION
 CAPTION "Geral"
 FONT 8, "MS Shell Dlg"
 BEGIN
-    GROUPBOX "Ligação ", -1, 9, 8, 190, 58, BS_GROUPBOX
+    GROUPBOX "Ligação", -1, 9, 8, 190, 58, BS_GROUPBOX
     LTEXT "Estado:", -1, 22, 20, 65, 8
     LTEXT "Duração:", -1, 22, 34, 65, 8
     LTEXT "Velocidade:", -1, 22, 48, 65, 8
-    GROUPBOX "Actividade ", -1, 9, 74, 190, 70, BS_GROUPBOX
+    GROUPBOX "Actividade", -1, 9, 74, 190, 70, BS_GROUPBOX
     LTEXT "Enviados", -1, 60, 90, 60, 8
     ICON "", IDC_NETSTAT, 110, 85, 32, 32
     RTEXT "Recebidos", -1, 146, 90, 44, 8
@@ -54,7 +54,7 @@ STYLE DS_SHELLFONT | WS_CHILD | WS_DISABLED | WS_CAPTION
 CAPTION "Suporte"
 FONT 8, "MS Shell Dlg"
 BEGIN
-    GROUPBOX "Estado de ligação ", -1, 9, 8, 190, 88, BS_GROUPBOX
+    GROUPBOX "Estado de ligação", -1, 9, 8, 190, 88, BS_GROUPBOX
     LTEXT "Tipo de endereço:", -1, 22, 20, 80, 8
     LTEXT "Endereço IP:", -1, 22, 34, 80, 8
     LTEXT "Máscara de sub-rede:", -1, 22, 48, 80, 8

--- a/dll/shellext/netshell/lang/zh-TW.rc
+++ b/dll/shellext/netshell/lang/zh-TW.rc
@@ -93,7 +93,7 @@ BEGIN
     LTEXT "請問您想使用一般或自訂設定：", IDC_STATIC, 53, 7, 240, 20
     AUTORADIOBUTTON "一般設定", IDC_NETWORK_TYPICAL, 53, 27, 253, 18, WS_TABSTOP | WS_GROUP
     AUTORADIOBUTTON "自訂設定", IDC_NETWORK_CUSTOM, 53, 72, 253, 18, WS_TABSTOP
-	LTEXT "使用 ReactOS 網路用戶端、ReactOS 網絡檔案和列印共享及具有自動指派位址功能的 TCP/IP 傳輸協議來建立網路連接。", IDC_STATIC, 65, 45, 240, 30
+    LTEXT "使用 ReactOS 網路用戶端、ReactOS 網絡檔案和列印共享及具有自動指派位址功能的 TCP/IP 傳輸協議來建立網路連接。", IDC_STATIC, 65, 45, 240, 30
     LTEXT "可讓您手動更改網路元件。", IDC_STATIC, 65, 90, 243, 20
 END
 

--- a/dll/shellext/netshell/shfldr_netconnect.cpp
+++ b/dll/shellext/netshell/shfldr_netconnect.cpp
@@ -2,27 +2,7 @@
  * PROJECT:     ReactOS Shell
  * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
  * PURPOSE:     CNetworkConnections Shell Folder
- * COPYRIGHT:   Copyright 2008 Johannes Anderwald (johannes.anderwald@reactos.org)
- */
-
-/*
- * Network Connections Shell Folder
- *
- * Copyright 2008       Johannes Anderwald <johannes.anderwald@reactos.org>
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ * COPYRIGHT:   Copyright 2008 Johannes Anderwald <johannes.anderwald@reactos.org>
  */
 
 #include "precomp.h"
@@ -256,7 +236,7 @@ HRESULT WINAPI CNetworkConnections::GetDisplayNameOf(PCUITEMID_CHILD pidl, DWORD
     PWCHAR pwchName = ILGetConnName(pidl);
     if (!pwchName)
     {
-        ERR("Got invalid pidl!\n");
+        ERR("Got invalid pidl\n");
         return E_INVALIDARG;
     }
 
@@ -473,7 +453,7 @@ HRESULT WINAPI CNetConUiObject::QueryContextMenu(
     PNETCONIDSTRUCT pdata = ILGetConnData(m_pidl);
     if (!pdata)
     {
-        ERR("Got invalid pidl!\n");
+        ERR("Got invalid pidl\n");
         return E_FAIL;
     }
 
@@ -511,7 +491,7 @@ HRESULT WINAPI CNetConUiObject::QueryContextMenu(
     if (pdata->Status == NCS_CONNECTED)
         _InsertMenuItemW(hMenu, indexMenu++, TRUE, idCmdFirst + 7, MFT_STRING, MAKEINTRESOURCEW(IDS_NET_PROPERTIES), MFS_ENABLED);
     else
-        _InsertMenuItemW(hMenu, indexMenu++, TRUE, idCmdFirst + 7, MFT_STRING, MAKEINTRESOURCEW(IDS_NET_PROPERTIES),  MFS_DEFAULT);
+        _InsertMenuItemW(hMenu, indexMenu++, TRUE, idCmdFirst + 7, MFT_STRING, MAKEINTRESOURCEW(IDS_NET_PROPERTIES), MFS_DEFAULT);
 
     return MAKE_HRESULT(SEVERITY_SUCCESS, 0, 9);
 }
@@ -542,7 +522,7 @@ ShowNetConnectionStatus(
     PNETCONIDSTRUCT pdata = ILGetConnData(pidl);
     if (!pdata)
     {
-        ERR("Got invalid pidl!\n");
+        ERR("Got invalid pidl\n");
         return E_FAIL;
     }
 
@@ -758,7 +738,7 @@ HRESULT WINAPI CNetConUiObject::GetIconLocation(
     PNETCONIDSTRUCT pdata = ILGetConnData(m_pidl);
     if (!pdata)
     {
-        ERR("Got invalid pidl!\n");
+        ERR("Got invalid pidl\n");
         return E_FAIL;
     }
 
@@ -832,7 +812,7 @@ HRESULT WINAPI CNetworkConnections::Execute(LPSHELLEXECUTEINFOW pei)
     PNETCONIDSTRUCT pdata = ILGetConnData(pidl);
     if (!pdata)
     {
-        ERR("Got invalid pidl!\n");
+        ERR("Got invalid pidl\n");
         return E_FAIL;
     }
 


### PR DESCRIPTION
## Purpose

Some trivial tweaks that I saw while backporting other stuff:
- es-ES.rc/pt-PT.rc: undesired spaces at the end of groupboxes, which were used as a historic workaround ~ 10 years ago
- zh-TW.rc: wrong indentation (tabs instead of spaces)
- shfldr_netconnect.cpp: superfluous GPL duplication, unneeded exclamation-marks in dbg-prints, undesired double-space formatting

saves a few bytes

JIRA issue: none

Just opened a PR to quickly drag it through the different toolchains via the buildbots.