### PR TITLE
[LIBWINE] Return empty path when given a UNIX path

### DIFF
--- a/dll/win32/dbghelp/path.c
+++ b/dll/win32/dbghelp/path.c
@@ -673,6 +673,7 @@ WCHAR *get_dos_file_name(const WCHAR *filename)
     WCHAR *dos_path;
     size_t len;
 
+#ifndef __REACTOS__
     if (*filename == '/')
     {
         char *unix_path;
@@ -683,6 +684,7 @@ WCHAR *get_dos_file_name(const WCHAR *filename)
         heap_free(unix_path);
     }
     else
+#endif
     {
         len = lstrlenW(filename);
         dos_path = heap_alloc((len + 1) * sizeof(WCHAR));

--- a/sdk/lib/3rdparty/libwine/path.c
+++ b/sdk/lib/3rdparty/libwine/path.c
@@ -61,6 +61,8 @@ WCHAR * CDECL wine_get_dos_file_name( LPCSTR str )
 #ifdef __REACTOS__
         ERR("Got absolute UNIX path name in function wine_get_dos_file_name. This is not UNIX. Please fix the caller!\n");
         ERR("File name: %s\n", str);
+        /* Return empty path */
+        return RtlAllocateHeap(GetProcessHeap(), HEAP_ZERO_MEMORY, 1 * sizeof(UNICODE_NULL));
 #else
         len += 8;  /* \??\unix prefix */
         if (!(buffer = HeapAlloc( GetProcessHeap(), 0, len * sizeof(WCHAR) ))) return NULL;


### PR DESCRIPTION
## Purpose

Wine code expects a non-null ret value. Seen with our GCC debug builds

JIRA issue: [CORE-19444](https://jira.reactos.org/browse/CORE-19444)
