### PR TITLE
[NTOS:IO] Fix and improve/optimize Io*onnectInterrupt()

### DIFF
--- a/ntoskrnl/include/internal/io.h
+++ b/ntoskrnl/include/internal/io.h
@@ -321,7 +321,7 @@ typedef struct _IO_WORKITEM
 typedef struct _IO_INTERRUPT
 {
     KINTERRUPT FirstInterrupt;
-    PKINTERRUPT Interrupt[MAXIMUM_PROCESSORS];
+    PKINTERRUPT Interrupt[MAXIMUM_PROCESSORS - 1];
     KSPIN_LOCK SpinLock;
 } IO_INTERRUPT, *PIO_INTERRUPT;
 

--- a/ntoskrnl/io/iomgr/irq.c
+++ b/ntoskrnl/io/iomgr/irq.c
@@ -163,7 +163,7 @@ IoDisconnectInterrupt(PKINTERRUPT InterruptObject)
             continue;
 
         /* Disconnect it */
-        KeDisconnectInterrupt(&InterruptObject[i]);
+        KeDisconnectInterrupt(IoInterrupt->Interrupt[i]);
     }
 
     /* Free the I/O Interrupt */

--- a/ntoskrnl/io/iomgr/irq.c
+++ b/ntoskrnl/io/iomgr/irq.c
@@ -74,7 +74,6 @@ IoConnectInterrupt(OUT PKINTERRUPT *InterruptObject,
     }
 
     /* We first start with a built-in Interrupt inside the I/O Structure */
-    *InterruptObject = &IoInterrupt->FirstInterrupt;
     Interrupt = (PKINTERRUPT)(IoInterrupt + 1);
     FirstRun = TRUE;
 
@@ -118,7 +117,6 @@ IoConnectInterrupt(OUT PKINTERRUPT *InterruptObject,
             }
 
             /* And fail */
-            *InterruptObject = NULL;
             return STATUS_INVALID_PARAMETER;
         }
 
@@ -135,6 +133,7 @@ IoConnectInterrupt(OUT PKINTERRUPT *InterruptObject,
     }
 
     /* Return Success */
+    *InterruptObject = &IoInterrupt->FirstInterrupt;
     return STATUS_SUCCESS;
 }
 

--- a/ntoskrnl/io/iomgr/irq.c
+++ b/ntoskrnl/io/iomgr/irq.c
@@ -64,9 +64,6 @@ IoConnectInterrupt(OUT PKINTERRUPT *InterruptObject,
                                         TAG_KINTERRUPT);
     if (!IoInterrupt) return STATUS_INSUFFICIENT_RESOURCES;
 
-    /* Zero the interrupt pointers */
-    RtlZeroMemory(&IoInterrupt->Interrupt, sizeof(IoInterrupt->Interrupt));
-
     /* Use structure's spinlock, if none was provided */
     if (!SpinLock)
     {
@@ -114,6 +111,7 @@ IoConnectInterrupt(OUT PKINTERRUPT *InterruptObject,
             else
             {
                 /* Far enough, so disconnect everything */
+                IoInterrupt->Interrupt[Count] = NULL;
                 IoDisconnectInterrupt(&IoInterrupt->FirstInterrupt);
             }
 
@@ -128,6 +126,10 @@ IoConnectInterrupt(OUT PKINTERRUPT *InterruptObject,
         /* Increase interrupt index */
         ++Count;
     }
+
+    /* Set actual end of the interrupt pointers */
+    if (Count < _countof(IoInterrupt->Interrupt))
+        IoInterrupt->Interrupt[Count] = NULL;
 
     /* Return Success */
     *InterruptObject = &IoInterrupt->FirstInterrupt;

--- a/ntoskrnl/io/iomgr/irq.c
+++ b/ntoskrnl/io/iomgr/irq.c
@@ -162,7 +162,7 @@ IoDisconnectInterrupt(PKINTERRUPT InterruptObject)
     }
 
     /* Free the I/O Interrupt */
-    ExFreePool(IoInterrupt); // ExFreePoolWithTag(IoInterrupt, TAG_KINTERRUPT);
+    ExFreePoolWithTag(IoInterrupt, TAG_KINTERRUPT);
 }
 
 NTSTATUS

--- a/ntoskrnl/ke/i386/irqobj.c
+++ b/ntoskrnl/ke/i386/irqobj.c
@@ -349,7 +349,7 @@ KeInitializeInterrupt(IN PKINTERRUPT Interrupt,
     }
     else
     {
-        /* This means we'll be usin the built-in one */
+        /* Use the built-in one */
         KeInitializeSpinLock(&Interrupt->SpinLock);
         Interrupt->ActualLock = &Interrupt->SpinLock;
     }


### PR DESCRIPTION
## Purpose

Fix and improve/optimize this code.

## Proposed changes

- [FORMATTING] iomgr/irq.c
- IoDisconnectInterrupt(): Fix disconnecting other interrupts
- IoConnectInterrupt(): Restore SpinLock initialization
- IoConnectInterrupt(): Move InterruptObject assignment
- IoConnectInterrupt(): Assign other interrupts contiguously
- IoDisconnectInterrupt(): Switch to ExFreePoolWithTag()