### PR TITLE
[MSVIDC32] Don't confuse CRAM_MAGIC with MSVC_MAGIC

### DIFF
--- a/dll/win32/msvidc32/msvideo1.c
+++ b/dll/win32/msvidc32/msvideo1.c
@@ -583,11 +583,7 @@ LRESULT WINAPI CRAM_DriverProc( DWORD_PTR dwDriverId, HDRVR hdrvr, UINT msg,
         if( info )
         {
             memset( info, 0, sizeof *info );
-#ifdef __REACTOS__
-            info->dwMagic = MSVC_MAGIC;
-#else
             info->dwMagic = CRAM_MAGIC;
-#endif
         }
         r = (LRESULT) info;
         break;

--- a/dll/win32/msvidc32/msvideo1.c
+++ b/dll/win32/msvidc32/msvideo1.c
@@ -538,7 +538,11 @@ static LRESULT CRAM_GetInfo( const Msvideo1Context *info, ICINFO *icinfo, DWORD 
 
     icinfo->dwSize = sizeof(ICINFO);
     icinfo->fccType = ICTYPE_VIDEO;
+#ifdef __REACTOS__
+    icinfo->fccHandler = MSVC_MAGIC;
+#else
     icinfo->fccHandler = info ? info->dwMagic : CRAM_MAGIC;
+#endif
     icinfo->dwFlags = 0;
     icinfo->dwVersion = ICVERSION;
     icinfo->dwVersionICM = ICVERSION;


### PR DESCRIPTION
Partially reverts https://github.com/reactos/reactos/pull/6118. It had caused a regression.

JIRA issue: [CORE-19453](https://jira.reactos.org/browse/CORE-19453), [CORE-15382](https://jira.reactos.org/browse/CORE-15382)