### PR TITLE
[NTUSER] Relax condition for IntImmProcessKey

### DIFF
--- a/win32ss/user/ntuser/ime.c
+++ b/win32ss/user/ntuser/ime.c
@@ -565,15 +565,14 @@ DWORD FASTCALL UserBuildHimcList(PTHREADINFO pti, DWORD dwCount, HIMC *phList)
     return dwRealCount;
 }
 
-// Win: xxxImmProcessKey
 UINT FASTCALL
 IntImmProcessKey(PUSER_MESSAGE_QUEUE MessageQueue, PWND pWnd, UINT uMsg,
                  WPARAM wParam, LPARAM lParam)
 {
-    UINT uVirtualKey, ret = 0;
+    UINT uVirtualKey, ret;
     DWORD dwHotKeyId;
     PKL pKL;
-    PIMC pIMC = NULL;
+    PIMC pIMC;
     PIMEHOTKEY pImeHotKey;
     HKL hKL;
     HWND hWnd;
@@ -592,6 +591,7 @@ IntImmProcessKey(PUSER_MESSAGE_QUEUE MessageQueue, PWND pWnd, UINT uMsg,
             return 0;
     }
 
+    pIMC = NULL;
     hWnd = UserHMGetHandle(pWnd);
     pKL = pWnd->head.pti->KeyboardLayout;
     if (!pKL)

--- a/win32ss/user/ntuser/ime.c
+++ b/win32ss/user/ntuser/ime.c
@@ -638,7 +638,7 @@ IntImmProcessKey(PUSER_MESSAGE_QUEUE MessageQueue, PWND pWnd, UINT uMsg,
         if (!pIMC)
             return 0;
 
-        if ((lParam & 0x80000000) &&
+        if ((lParam & (KF_UP << 16)) &&
             (pKL->piiex->ImeInfo.fdwProperty & IME_PROP_IGNORE_UPKEYS))
         {
             return 0;

--- a/win32ss/user/ntuser/msgqueue.c
+++ b/win32ss/user/ntuser/msgqueue.c
@@ -1771,7 +1771,7 @@ BOOL co_IntProcessKeyboardMessage(MSG* Msg, BOOL* RemoveMessages)
     UINT ImmRet;
     BOOL Ret = TRUE, bKeyUpDown = FALSE;
     PTHREADINFO pti = PsGetCurrentThreadWin32Thread();
-    UINT uMsg = Msg->message;
+    const UINT uMsg = Msg->message;
 
     if (uMsg == VK_PACKET)
     {
@@ -1832,7 +1832,7 @@ BOOL co_IntProcessKeyboardMessage(MSG* Msg, BOOL* RemoveMessages)
     }
 
     //// Key Down!
-    if ( *RemoveMessages && uMsg == WM_SYSKEYDOWN )
+    if (*RemoveMessages && uMsg == WM_SYSKEYDOWN)
     {
         if ( HIWORD(Msg->lParam) & KF_ALTDOWN )
         {
@@ -1872,11 +1872,7 @@ BOOL co_IntProcessKeyboardMessage(MSG* Msg, BOOL* RemoveMessages)
 
     if (pWnd && Ret && *RemoveMessages && bKeyUpDown && !(pti->TIF_flags & TIF_DISABLEIME))
     {
-        LPARAM lParam = Msg->lParam;
-        if (uMsg == WM_KEYUP || uMsg == WM_SYSKEYUP)
-            lParam |= KF_UP << 16;
-
-        ImmRet = IntImmProcessKey(pti->MessageQueue, pWnd, uMsg, Msg->wParam, lParam);
+        ImmRet = IntImmProcessKey(pti->MessageQueue, pWnd, uMsg, Msg->wParam, Msg->lParam);
         if (ImmRet)
         {
             if ( ImmRet & (IPHK_HOTKEY|IPHK_SKIPTHISKEY) )

--- a/win32ss/user/ntuser/msgqueue.c
+++ b/win32ss/user/ntuser/msgqueue.c
@@ -1774,12 +1774,11 @@ BOOL co_IntProcessKeyboardMessage(MSG* Msg, BOOL* RemoveMessages)
     const UINT uMsg = Msg->message;
 
     if (uMsg == VK_PACKET)
-    {
         pti->wchInjected = HIWORD(Msg->wParam);
-    }
 
     if (uMsg == WM_KEYDOWN || uMsg == WM_SYSKEYDOWN || uMsg == WM_KEYUP || uMsg == WM_SYSKEYUP)
     {
+        bKeyUpDown = TRUE;
         switch (Msg->wParam)
         {
             case VK_LSHIFT: case VK_RSHIFT:
@@ -1792,7 +1791,6 @@ BOOL co_IntProcessKeyboardMessage(MSG* Msg, BOOL* RemoveMessages)
                 Msg->wParam = VK_MENU;
                 break;
         }
-        bKeyUpDown = TRUE;
     }
 
     pWnd = ValidateHwndNoErr(Msg->hwnd);

--- a/win32ss/user/ntuser/msgqueue.c
+++ b/win32ss/user/ntuser/msgqueue.c
@@ -1871,7 +1871,13 @@ BOOL co_IntProcessKeyboardMessage(MSG* Msg, BOOL* RemoveMessages)
 
     if (pWnd && Ret && *RemoveMessages && !(pti->TIF_flags & TIF_DISABLEIME))
     {
-        if ( (ImmRet = IntImmProcessKey(pti->MessageQueue, pWnd, Msg->message, Msg->wParam, Msg->lParam)) )
+        UINT uMsg = Msg->message;
+        LPARAM lParam = Msg->lParam;
+        if (uMsg == WM_KEYUP || uMsg == WM_SYSKEYUP)
+            lParam |= KF_UP << 16;
+
+        ImmRet = IntImmProcessKey(pti->MessageQueue, pWnd, uMsg, Msg->wParam, lParam);
+        if (ImmRet)
         {
             if ( ImmRet & (IPHK_HOTKEY|IPHK_SKIPTHISKEY) )
             {

--- a/win32ss/user/ntuser/msgqueue.c
+++ b/win32ss/user/ntuser/msgqueue.c
@@ -1869,7 +1869,7 @@ BOOL co_IntProcessKeyboardMessage(MSG* Msg, BOOL* RemoveMessages)
         Ret = FALSE;
     }
 
-    if ( pWnd && Ret && *RemoveMessages && Msg->message == WM_KEYDOWN && !(pti->TIF_flags & TIF_DISABLEIME))
+    if (pWnd && Ret && *RemoveMessages && !(pti->TIF_flags & TIF_DISABLEIME))
     {
         if ( (ImmRet = IntImmProcessKey(pti->MessageQueue, pWnd, Msg->message, Msg->wParam, Msg->lParam)) )
         {


### PR DESCRIPTION
## Purpose
First attempt to fix IME hotkey processing around `IMM32!ImmProcessKey` function.
JIRA issue: [CORE-19455](https://jira.reactos.org/browse/CORE-19455)

![無題](https://github.com/reactos/reactos/assets/2107452/f1562a4d-6878-4eda-bc4b-3db0e15d8767)

## Proposed changes

- Optimize `IntImmProcessKey` a little.
- Remove `(Msg->message == WM_KEYDOWN)` condition for `IntImmProcessKey` function call.

## TODO

- [x] Do build.
- [x] Do small test.
- [x] Do big test.
