### PR TITLE
[UXTHEME] Add Ukrainian (uk-UA) translation

### DIFF
--- a/dll/win32/uxtheme/lang/uk-UA.rc
+++ b/dll/win32/uxtheme/lang/uk-UA.rc
@@ -1,0 +1,19 @@
+/*
+ * PROJECT:     ReactOS uxtheme.dll
+ * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
+ * PURPOSE:     Ukrainian resource file
+ * TRANSLATOR:  Copyright 2024 Oleg Dubinskiy <oleg.dubinskij30@gmail.com>
+ */
+
+LANGUAGE LANG_UKRAINIAN, SUBLANG_DEFAULT
+
+/* Strings */
+
+STRINGTABLE
+BEGIN
+    IDS_MESSAGEBOX "Вікно повідомлення"
+    IDS_ACTIVEWIN "Активне вікно"
+    IDS_INACTIVEWIN "Неактивне вікно"
+    IDS_OK "ОК"
+    IDS_WINTEXT "Текст у вікні"
+END

--- a/dll/win32/uxtheme/uxtheme.rc
+++ b/dll/win32/uxtheme/uxtheme.rc
@@ -25,3 +25,6 @@
 #ifdef LANGUAGE_RU_RU
     #include "lang/ru-RU.rc"
 #endif
+#ifdef LANGUAGE_UK_UA
+    #include "lang/uk-UA.rc"
+#endif


### PR DESCRIPTION
## Purpose

Translate theme preview text in "Appearance" tab of "Desktop Properties" into Ukrainian.
Addendum to d11582f.

JIRA issue: [CORE-5991](https://jira.reactos.org/browse/CORE-5991)

## Proposed changes

- Add rc file with translated strings.
- Include it in main resource file.