### PR TITLE
[NTOS:IO] Fixes for Io*onnectInterrupt()

### DIFF
--- a/ntoskrnl/io/iomgr/irq.c
+++ b/ntoskrnl/io/iomgr/irq.c
@@ -70,8 +70,7 @@ IoConnectInterrupt(OUT PKINTERRUPT *InterruptObject,
         KeInitializeSpinLock(SpinLock);
     }
 
-    /* We first start with a built-in Interrupt inside the I/O Structure */
-    *InterruptObject = &IoInterrupt->FirstInterrupt;
+    /* We first start with a built-in interrupt inside the I/O structure */
     Interrupt = (PKINTERRUPT)(IoInterrupt + 1);
     FirstRun = TRUE;
 
@@ -115,7 +114,6 @@ IoConnectInterrupt(OUT PKINTERRUPT *InterruptObject,
             }
 
             /* And fail */
-            *InterruptObject = NULL;
             return STATUS_INVALID_PARAMETER;
         }
 
@@ -131,7 +129,8 @@ IoConnectInterrupt(OUT PKINTERRUPT *InterruptObject,
         }
     }
 
-    /* Return Success */
+    /* Return success */
+    *InterruptObject = &IoInterrupt->FirstInterrupt;
     return STATUS_SUCCESS;
 }
 

--- a/ntoskrnl/io/iomgr/irq.c
+++ b/ntoskrnl/io/iomgr/irq.c
@@ -57,11 +57,11 @@ IoConnectInterrupt(OUT PKINTERRUPT *InterruptObject,
     /* Make sure we have a valid CPU count */
     if (!Count) return STATUS_INVALID_PARAMETER;
 
-    /* Allocate the array of I/O Interrupts */
-    IoInterrupt = ExAllocatePoolWithTag(NonPagedPool,
-                                        (Count - 1) * sizeof(KINTERRUPT) +
-                                        sizeof(IO_INTERRUPT),
-                                        TAG_KINTERRUPT);
+    /* Allocate the array of I/O interrupts */
+    IoInterrupt = ExAllocatePoolZero(NonPagedPool,
+                                     (Count - 1) * sizeof(KINTERRUPT) +
+                                     sizeof(IO_INTERRUPT),
+                                     TAG_KINTERRUPT);
     if (!IoInterrupt) return STATUS_INSUFFICIENT_RESOURCES;
 
     /* Select which Spinlock to use */
@@ -71,9 +71,6 @@ IoConnectInterrupt(OUT PKINTERRUPT *InterruptObject,
     *InterruptObject = &IoInterrupt->FirstInterrupt;
     Interrupt = (PKINTERRUPT)(IoInterrupt + 1);
     FirstRun = TRUE;
-
-    /* Start with a fresh structure */
-    RtlZeroMemory(IoInterrupt, sizeof(IO_INTERRUPT));
 
     /* Now create all the interrupts */
     Affinity = ProcessorEnableMask & KeActiveProcessors;

--- a/ntoskrnl/io/iomgr/irq.c
+++ b/ntoskrnl/io/iomgr/irq.c
@@ -139,8 +139,8 @@ VOID
 NTAPI
 IoDisconnectInterrupt(PKINTERRUPT InterruptObject)
 {
-    LONG i;
     PIO_INTERRUPT IoInterrupt;
+    ULONG i;
 
     PAGED_CODE();
 
@@ -160,7 +160,7 @@ IoDisconnectInterrupt(PKINTERRUPT InterruptObject)
             continue;
 
         /* Disconnect it */
-        KeDisconnectInterrupt(&InterruptObject[i]);
+        KeDisconnectInterrupt(IoInterrupt->Interrupt[i]);
     }
 
     /* Free the I/O Interrupt */

--- a/ntoskrnl/io/iomgr/irq.c
+++ b/ntoskrnl/io/iomgr/irq.c
@@ -146,7 +146,7 @@ IoDisconnectInterrupt(PKINTERRUPT InterruptObject)
 
     PAGED_CODE();
 
-    /* Get the I/O Interrupt */
+    /* Get the I/O interrupt */
     IoInterrupt = CONTAINING_RECORD(InterruptObject,
                                     IO_INTERRUPT,
                                     FirstInterrupt);
@@ -165,8 +165,8 @@ IoDisconnectInterrupt(PKINTERRUPT InterruptObject)
         KeDisconnectInterrupt(IoInterrupt->Interrupt[i]);
     }
 
-    /* Free the I/O Interrupt */
-    ExFreePool(IoInterrupt); // ExFreePoolWithTag(IoInterrupt, TAG_KINTERRUPT);
+    /* Free the I/O interrupt */
+    ExFreePoolWithTag(IoInterrupt, TAG_KINTERRUPT);
 }
 
 NTSTATUS

--- a/ntoskrnl/ke/i386/irqobj.c
+++ b/ntoskrnl/ke/i386/irqobj.c
@@ -349,7 +349,7 @@ KeInitializeInterrupt(IN PKINTERRUPT Interrupt,
     }
     else
     {
-        /* This means we'll be usin the built-in one */
+        /* Use the built-in one */
         KeInitializeSpinLock(&Interrupt->SpinLock);
         Interrupt->ActualLock = &Interrupt->SpinLock;
     }


### PR DESCRIPTION
## Purpose

Fix and improve/optimize this code. Split from PR #6495 by @SergeGautherie 

## Proposed changes

- [FORMATTING] iomgr/irq.c
- IoConnectInterrupt(): Zero-out the allocated structure at the correct place
- IoDisconnectInterrupt(): Fix disconnecting other interrupts
- IoConnectInterrupt(): Fix default spinlock initialization
- IoConnectInterrupt(): Move InterruptObject assignment back to where it belongs
- IoDisconnectInterrupt(): Switch to ExFreePoolWithTag()
