### PR TITLE
[HALX86][NTOS:KE] Get to the point processors are active and spinning in idle for x86

### DIFF
--- a/hal/halx86/apic/halinit.c
+++ b/hal/halx86/apic/halinit.c
@@ -63,8 +63,11 @@ HalpInitPhase0(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
 VOID
 HalpInitPhase1(VOID)
 {
-    /* Initialize DMA. NT does this in Phase 0 */
-    HalpInitDma();
+    if (KeGetCurrentProcessorNumber() == 0)
+    {
+        /* Initialize DMA. NT does this in Phase 0 */
+        HalpInitDma();
+    }
 }
 
 /* EOF */

--- a/hal/halx86/generic/halinit.c
+++ b/hal/halx86/generic/halinit.c
@@ -155,8 +155,11 @@ HalInitSystem(IN ULONG BootPhase,
         /* Do some HAL-specific initialization */
         HalpInitPhase1();
 
-        /* Initialize Phase 1 of the x86 emulator */
-        HalInitializeBios(1, LoaderBlock);
+        if (KeGetCurrentProcessorNumber() == 0)
+        {
+            /* Initialize Phase 1 of the x86 emulator */
+            HalInitializeBios(1, LoaderBlock);
+        }
     }
 
     /* All done, return */


### PR DESCRIPTION
## Purpose

Just proposing some fixes so master can get cores spinning up to an idle loop state with execution being dispatched to them quite yet.

## Proposed changes
- Fix KiExecutionLock for x86, make it more like x64
- Don't verify CPUID features on other cores
- Load the initial IdleThread without accessing the constantly modified global parameter block
- Don't reinit InitializeBios over and over
- Lower to dispatch level before letting other cores continue onto the newly setup IdleThread to avoid an IRQL level bugcheck.
- Let loose the monsters



## TODO

- [x] More testing
