### PR TITLE
[BOOTDATA][NTUSER] Prepare for CTF IME Part 1

### DIFF
--- a/boot/bootdata/hivesft.inf
+++ b/boot/bootdata/hivesft.inf
@@ -512,6 +512,7 @@ HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontMapper",,0x00000012
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\HotFix",,0x00000012
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\IME Compatibility",,0x00000012
 
+HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\IMM","IME File",2,"msctfime.ime"
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\IMM","LoadIMM",0x00010003,1
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\IMM","LoadCTFIME",0x00010003,0
 

--- a/win32ss/user/ntuser/metric.c
+++ b/win32ss/user/ntuser/metric.c
@@ -29,7 +29,14 @@ BOOL FASTCALL UserIsIMMEnabled(VOID)
 
 BOOL FASTCALL UserIsCiceroEnabled(VOID)
 {
+#if 1
     return FALSE; /* FIXME: Cicero is not supported yet */
+#else
+    if (RegGetSectionDWORD(L"IMM", L"DontLoadCTFIME", FALSE))
+        return FALSE;
+
+    return UserIsIMMEnabled();
+#endif
 }
 
 BOOL


### PR DESCRIPTION
## Purpose

Supporting TIPs...
JIRA issue: [CORE-19360](https://jira.reactos.org/browse/CORE-19360)

## Proposed changes

- Add `"IME File"` registry value as `"msctfime.ime"` at `HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\IMM`.
- Modify `UserIsCiceroEnabled` function for preparation of CTF IME.

## TODO

- [x] Do build.