### PR TITLE
[WIN32SS] Fix const-ness of registry helper functions

### DIFF
--- a/win32ss/gdi/ntgdi/misc.h
+++ b/win32ss/gdi/ntgdi/misc.h
@@ -46,19 +46,19 @@ RegQueryValue(
 
 VOID
 NTAPI
-RegWriteSZ(HKEY hkey, PWSTR pwszValue, PWSTR pwszData);
+RegWriteSZ(HKEY hkey, PCWSTR pwszValue, PWSTR pwszData);
 
 VOID
 NTAPI
-RegWriteDWORD(HKEY hkey, PWSTR pwszValue, DWORD dwData);
+RegWriteDWORD(HKEY hkey, PCWSTR pwszValue, DWORD dwData);
 
 BOOL
 NTAPI
-RegReadDWORD(HKEY hkey, PWSTR pwszValue, PDWORD pdwData);
+RegReadDWORD(HKEY hkey, PCWSTR pwszValue, PDWORD pdwData);
 
 DWORD
 NTAPI
-RegGetSectionDWORD(LPCWSTR pszSection, LPWSTR pszValue, DWORD dwDefault);
+RegGetSectionDWORD(LPCWSTR pszSection, PCWSTR pszValue, DWORD dwDefault);
 
 VOID
 FASTCALL

--- a/win32ss/user/ntuser/metric.c
+++ b/win32ss/user/ntuser/metric.c
@@ -21,12 +21,10 @@ BOOL FASTCALL UserIsDBCSEnabled(VOID)
 
 BOOL FASTCALL UserIsIMMEnabled(VOID)
 {
-    static WCHAR s_szLoadIMM[] = L"LoadIMM";
-
     if (NLS_MB_CODE_PAGE_TAG)
         return TRUE;
 
-    return !!RegGetSectionDWORD(L"IMM", s_szLoadIMM, TRUE);
+    return !!RegGetSectionDWORD(L"IMM", L"LoadIMM", FALSE);
 }
 
 BOOL FASTCALL UserIsCiceroEnabled(VOID)

--- a/win32ss/user/ntuser/misc/registry.c
+++ b/win32ss/user/ntuser/misc/registry.c
@@ -120,12 +120,11 @@ RegQueryValue(
         ExFreePoolWithTag(pInfo, TAG_TEMP);
 
     return Status;
-
 }
 
 VOID
 NTAPI
-RegWriteSZ(HKEY hkey, PWSTR pwszValue, PWSTR pwszData)
+RegWriteSZ(HKEY hkey, PCWSTR pwszValue, PWSTR pwszData)
 {
     UNICODE_STRING ustrValue;
     UNICODE_STRING ustrData;
@@ -137,7 +136,7 @@ RegWriteSZ(HKEY hkey, PWSTR pwszValue, PWSTR pwszData)
 
 VOID
 NTAPI
-RegWriteDWORD(HKEY hkey, PWSTR pwszValue, DWORD dwData)
+RegWriteDWORD(HKEY hkey, PCWSTR pwszValue, DWORD dwData)
 {
     UNICODE_STRING ustrValue;
 
@@ -147,7 +146,7 @@ RegWriteDWORD(HKEY hkey, PWSTR pwszValue, DWORD dwData)
 
 BOOL
 NTAPI
-RegReadDWORD(HKEY hkey, PWSTR pwszValue, PDWORD pdwData)
+RegReadDWORD(HKEY hkey, PCWSTR pwszValue, PDWORD pdwData)
 {
     NTSTATUS Status;
     ULONG cbSize = sizeof(DWORD);
@@ -170,7 +169,7 @@ RegOpenSectionKey(
 
 DWORD
 NTAPI
-RegGetSectionDWORD(LPCWSTR pszSection, LPWSTR pszValue, DWORD dwDefault)
+RegGetSectionDWORD(LPCWSTR pszSection, PCWSTR pszValue, DWORD dwDefault)
 {
     HKEY hKey;
     DWORD dwValue;


### PR DESCRIPTION
## Purpose

Improve code quality.
JIRA issue: [CORE-19360](https://jira.reactos.org/browse/CORE-19360)

## Proposed changes

- Fix `const`-ness of the arguments of `win32k` registry helper functions.
- Compact `UserIsIMMEnabled` function.

## TODO

- [x] Do build.