### PR TITLE
[SDK:NDK/XDK] Remove x86 KeGetPcr() definition from the DDK

### DIFF
--- a/sdk/include/ndk/i386/ketypes.h
+++ b/sdk/include/ndk/i386/ketypes.h
@@ -75,8 +75,10 @@ Author:
 #define K0IPCR                  ((ULONG_PTR)(KIP0PCRADDRESS))
 #define PCR                     ((KPCR *)K0IPCR)
 #if defined(CONFIG_SMP) || defined(NT_BUILD)
-#undef  KeGetPcr
+//#undef  KeGetPcr
 #define KeGetPcr()              ((KPCR *)__readfsdword(FIELD_OFFSET(KPCR, SelfPcr)))
+#else
+#define KeGetPcr()              PCR
 #endif
 
 //

--- a/sdk/include/xdk/x86/ke.h
+++ b/sdk/include/xdk/x86/ke.h
@@ -283,8 +283,6 @@ typedef struct _CONTEXT {
 } CONTEXT;
 #include "poppack.h"
 
-#define KeGetPcr()                      PCR
-
 #define PCR_MINOR_VERSION 1
 #define PCR_MAJOR_VERSION 1
 
@@ -324,6 +322,18 @@ typedef struct _KPCR {
   ULONG SecondLevelCacheSize;
   ULONG HalReserved[16];
 } KPCR, *PKPCR;
+
+/* NOTE: This macro is not exposed in the DDK/WDK for _M_IX86.
+ * If it were, this would be its definition. */
+#if 0
+// #define KeGetPcr()      ((PKPCR)__readfsdword(FIELD_OFFSET(KPCR, SelfPcr)))
+FORCEINLINE
+PKPCR
+KeGetPcr(VOID)
+{
+    return (PKPCR)__readfsdword(FIELD_OFFSET(KPCR, SelfPcr));
+}
+#endif
 
 #if (NTDDI_VERSION >= NTDDI_WIN7)
 _CRT_DEPRECATE_TEXT("KeGetCurrentProcessorNumber is deprecated. Use KeGetCurrentProcessorNumberEx or KeGetCurrentProcessorIndex instead.")


### PR DESCRIPTION
## Purpose

Fix some inconsistencies in definitions. May contribute fixing SMP support...

The official MS DDK/WDK does not expose KeGetPcr() for x86, so do
not expose it there as well. Use instead the private NDK definition.

If it were exposed in the DDK/WDK, it would have to be a
multiprocessor-compatible definition.

Note that the broken definition was working only in single-processor
mode, using the PCR static memory pointer value.
The official MS DDK/WDK exposes KeGetPcr() as an alias to such a
PCR value only for IA64, MIPS and PPC, which is of course not great.