### PR TITLE
[HALX86] Implement the clock IPI handler

### DIFF
--- a/hal/halx86/apic.cmake
+++ b/hal/halx86/apic.cmake
@@ -6,7 +6,6 @@ list(APPEND HAL_APIC_ASM_SOURCE
 list(APPEND HAL_APIC_SOURCE
     apic/apic.c
     apic/apictimer.c
-    apic/apicsmp.c
     apic/halinit.c
     apic/processor.c
     apic/rtctimer.c

--- a/hal/halx86/apic/apic.c
+++ b/hal/halx86/apic/apic.c
@@ -528,10 +528,12 @@ HalpInitializePICs(IN BOOLEAN EnableInterrupts)
     HalpVectorToIndex[APC_VECTOR] = APIC_RESERVED_VECTOR;
     HalpVectorToIndex[DISPATCH_VECTOR] = APIC_RESERVED_VECTOR;
     HalpVectorToIndex[APIC_CLOCK_VECTOR] = 8;
+    HalpVectorToIndex[CLOCK_IPI_VECTOR] = APIC_RESERVED_VECTOR;
     HalpVectorToIndex[APIC_SPURIOUS_VECTOR] = APIC_RESERVED_VECTOR;
 
     /* Set interrupt handlers in the IDT */
     KeRegisterInterruptHandler(APIC_CLOCK_VECTOR, HalpClockInterrupt);
+    KeRegisterInterruptHandler(CLOCK_IPI_VECTOR, HalpClockIpi);
 #ifndef _M_AMD64
     KeRegisterInterruptHandler(APC_VECTOR, HalpApcInterrupt);
     KeRegisterInterruptHandler(DISPATCH_VECTOR, HalpDispatchInterrupt);

--- a/hal/halx86/apic/apicp.h
+++ b/hal/halx86/apic/apicp.h
@@ -43,6 +43,7 @@
     #define APIC_GENERIC_VECTOR  0xC1 // IRQL 27
     #define APIC_CLOCK_VECTOR    0xD1 // IRQL 28
     #define APIC_SYNCH_VECTOR    0xD1 // IRQL 28
+    #define CLOCK_IPI_VECTOR     0xD2 // IRQL 28
     #define APIC_IPI_VECTOR      0xE1 // IRQL 29
     #define APIC_ERROR_VECTOR    0xE3
     #define POWERFAIL_VECTOR     0xEF // IRQL 30

--- a/hal/halx86/apic/apictrap.S
+++ b/hal/halx86/apic/apictrap.S
@@ -16,6 +16,7 @@
 .code
 
 TRAP_ENTRY HalpClockInterrupt, (TF_VOLATILES OR TF_SEND_EOI)
+TRAP_ENTRY HalpClockIpi, (TF_VOLATILES OR TF_SEND_EOI)
 TRAP_ENTRY HalpProfileInterrupt, (TF_VOLATILES OR TF_SEND_EOI)
 
 PUBLIC ApicSpuriousService
@@ -28,6 +29,7 @@ ApicSpuriousService:
 .code
 
 TRAP_ENTRY HalpClockInterrupt, KI_PUSH_FAKE_ERROR_CODE
+TRAP_ENTRY HalpClockIpi, KI_PUSH_FAKE_ERROR_CODE
 TRAP_ENTRY HalpProfileInterrupt, KI_PUSH_FAKE_ERROR_CODE
 TRAP_ENTRY HalpTrap0D, 0
 TRAP_ENTRY HalpApcInterrupt, KI_PUSH_FAKE_ERROR_CODE

--- a/hal/halx86/generic/up.c
+++ b/hal/halx86/generic/up.c
@@ -40,6 +40,14 @@ HalpSetupProcessorsTable(
     NOTHING;
 }
 
+VOID
+FASTCALL
+HalpBroadcastClockIpi(
+    _In_ UCHAR Vector)
+{
+    NOTHING;
+}
+
 #ifdef _M_AMD64
 
 VOID

--- a/hal/halx86/include/halp.h
+++ b/hal/halx86/include/halp.h
@@ -235,6 +235,7 @@ extern BOOLEAN HalpProfilingStopped;
 /* timer.c */
 CODE_SEG("INIT") VOID NTAPI HalpInitializeClock(VOID);
 VOID __cdecl HalpClockInterrupt(VOID);
+VOID __cdecl HalpClockIpi(VOID);
 VOID __cdecl HalpProfileInterrupt(VOID);
 
 typedef struct _HALP_ROLLOVER
@@ -512,6 +513,12 @@ KeUpdateSystemTime(
     IN ULONG Increment,
     IN KIRQL OldIrql
 );
+
+VOID
+NTAPI
+KeUpdateRunTime(
+    _In_ PKTRAP_FRAME TrapFrame,
+    _In_ KIRQL Irql);
 
 CODE_SEG("INIT")
 VOID

--- a/hal/halx86/include/smp.h
+++ b/hal/halx86/include/smp.h
@@ -42,6 +42,11 @@ HalpSetupProcessorsTable(
 VOID
 HalpPrintApicTables(VOID);
 
+VOID
+FASTCALL
+HalpBroadcastClockIpi(
+    _In_ UCHAR Vector);
+
 /* APIC specific functions inside apic/apicsmp.c */
 
 VOID

--- a/hal/halx86/smp.cmake
+++ b/hal/halx86/smp.cmake
@@ -1,5 +1,6 @@
 
 list(APPEND HAL_SMP_SOURCE
+    apic/apicsmp.c
     generic/buildtype.c
     generic/spinlock.c
     smp/ipi.c

--- a/hal/halx86/smp/smp.c
+++ b/hal/halx86/smp/smp.c
@@ -33,3 +33,12 @@ HalpSetupProcessorsTable(
     CurrentPrcb = KeGetCurrentPrcb();
     HalpProcessorIdentity[NTProcessorNumber].ProcessorPrcb = CurrentPrcb;
 }
+
+VOID
+FASTCALL
+HalpBroadcastClockIpi(
+    _In_ UCHAR Vector)
+{
+    /* Send a clock IPI to all processors */
+    HalpBroadcastIpiSpecifyVector(Vector, FALSE);
+}


### PR DESCRIPTION
## Purpose

This implements the clock IPI handler, which will ensure that all CPUs get the same time updates.

## Proposed changes

- Move apicsmp.c from lib_hal_apic to lib_hal_smp
- Implement the Clock IPI handler and broadcast the IPI from the clock handler (this is a no-op on up)

## Tests
* GCC x86 KVM: https://reactos.org/testman/compare.php?ids=93637,93640,93644,93651
* MSVC x64 KVM: https://reactos.org/testman/compare.php?ids=93638,93642,93646,93652

## TODO

- [x] Run on testbots
- [x] Have @DarkFire01 double check it fully works with his x86 SMP work
