### PR TITLE
[BROWSEUI] Enable Address bar access key (Alt+D)

### DIFF
--- a/dll/win32/browseui/addressband.cpp
+++ b/dll/win32/browseui/addressband.cpp
@@ -259,17 +259,9 @@ HRESULT STDMETHODCALLTYPE CAddressBand::HasFocusIO()
     return S_FALSE;
 }
 
-WCHAR GetAddressBarAccessKey(WCHAR chAccess)
+WCHAR GetAccessKeyFromText(WCHAR chAccess, LPCWSTR pszText)
 {
-    static WCHAR s_chCache = 0;
-    if (s_chCache)
-        return s_chCache;
-
-    WCHAR szText[80], *pch;
-    LoadStringW(_AtlBaseModule.GetResourceInstance(), IDS_ADDRESSBANDLABEL,
-                szText, _countof(szText));
-
-    for (pch = szText; *pch; ++pch)
+    for (const WCHAR *pch = pszText; *pch; ++pch)
     {
         if (*pch == L'&' && pch[1] == L'&')
         {
@@ -285,8 +277,21 @@ WCHAR GetAddressBarAccessKey(WCHAR chAccess)
     }
 
     ::CharUpperBuffW(&chAccess, 1);
-    s_chCache = chAccess;
     return chAccess;
+}
+
+WCHAR GetAddressBarAccessKey(WCHAR chAccess)
+{
+    static WCHAR s_chCache = 0;
+    if (s_chCache)
+        return s_chCache;
+
+    WCHAR szText[80];
+    LoadStringW(_AtlBaseModule.GetResourceInstance(), IDS_ADDRESSBANDLABEL,
+                szText, _countof(szText));
+
+    s_chCache = GetAccessKeyFromText(chAccess, szText);
+    return s_chCache;
 }
 
 HRESULT STDMETHODCALLTYPE CAddressBand::TranslateAcceleratorIO(LPMSG lpMsg)

--- a/dll/win32/browseui/addressband.cpp
+++ b/dll/win32/browseui/addressband.cpp
@@ -284,7 +284,8 @@ static WCHAR GetAccessKeyFromText(WCHAR chAccess, LPCWSTR pszText)
 static WCHAR GetAddressBarAccessKey(WCHAR chAccess)
 {
     static WCHAR s_chCache = 0;
-    if (s_chCache)
+    static LANGID s_ThreadLocale = 0;
+    if (s_chCache && s_ThreadLocale == ::GetThreadLocale())
         return s_chCache;
 
     WCHAR szText[80];
@@ -295,6 +296,7 @@ static WCHAR GetAddressBarAccessKey(WCHAR chAccess)
     }
 
     s_chCache = GetAccessKeyFromText(chAccess, szText);
+    s_ThreadLocale = ::GetThreadLocale();
     return s_chCache;
 }
 

--- a/dll/win32/browseui/addressband.cpp
+++ b/dll/win32/browseui/addressband.cpp
@@ -265,6 +265,7 @@ static WCHAR GetAccessKeyFromText(WCHAR chAccess, LPCWSTR pszText)
     {
         if (*pch == L'&' && pch[1] == L'&')
         {
+            /* Skip the first '&', the second is skipped by the for-loop */
             ++pch;
             continue;
         }

--- a/dll/win32/browseui/addressband.cpp
+++ b/dll/win32/browseui/addressband.cpp
@@ -259,9 +259,9 @@ HRESULT STDMETHODCALLTYPE CAddressBand::HasFocusIO()
     return S_FALSE;
 }
 
-WCHAR GetAccessKeyFromText(WCHAR chAccess, LPCWSTR pszText)
+static WCHAR GetAccessKeyFromText(WCHAR chAccess, LPCWSTR pszText)
 {
-    for (const WCHAR *pch = pszText; *pch; ++pch)
+    for (const WCHAR *pch = pszText; *pch != UNICODE_NULL; ++pch)
     {
         if (*pch == L'&' && pch[1] == L'&')
         {
@@ -280,15 +280,18 @@ WCHAR GetAccessKeyFromText(WCHAR chAccess, LPCWSTR pszText)
     return chAccess;
 }
 
-WCHAR GetAddressBarAccessKey(WCHAR chAccess)
+static WCHAR GetAddressBarAccessKey(WCHAR chAccess)
 {
     static WCHAR s_chCache = 0;
     if (s_chCache)
         return s_chCache;
 
     WCHAR szText[80];
-    LoadStringW(_AtlBaseModule.GetResourceInstance(), IDS_ADDRESSBANDLABEL,
-                szText, _countof(szText));
+    if (!LoadStringW(_AtlBaseModule.GetResourceInstance(), IDS_ADDRESSBANDLABEL,
+                     szText, _countof(szText)))
+    {
+        return chAccess;
+    }
 
     s_chCache = GetAccessKeyFromText(chAccess, szText);
     return s_chCache;

--- a/dll/win32/browseui/addressband.cpp
+++ b/dll/win32/browseui/addressband.cpp
@@ -300,9 +300,9 @@ HRESULT STDMETHODCALLTYPE CAddressBand::TranslateAcceleratorIO(LPMSG lpMsg)
             WCHAR chAccess = GetAddressBarAccessKey(L'D');
             if (lpMsg->wParam == chAccess)
             {
-                ::SendMessage(fEditControl, EM_SETSEL, 0, -1);
+                ::PostMessageW(fEditControl, EM_SETSEL, 0, -1);
                 ::SetFocus(fEditControl);
-                return S_OK;
+                return S_FALSE;
             }
             break;
         }


### PR DESCRIPTION
## Purpose

Retrial of #5052. Improve keyboard interface usability.
JIRA issue: [CORE-18823](https://jira.reactos.org/browse/CORE-18823)

## Proposed changes

- Add `GetAddressBarAccessKey` helper function to get the accelerator of Address bar from resource string `IDS_ADDRESSBANDLABEL`.
- Implement `Alt+D` (or something) accelerator in `CAddressBand::TranslateAcceleratorIO` method by handling `WM_SYSKEYDOWN` and `WM_SYSCHAR` messages.

## TODO

- [x] Do tests.

## Movie

https://github.com/reactos/reactos/assets/2107452/832e8abc-4d76-4ee4-b4bf-e6790d0a1964