### PR TITLE
[USP10] ScriptTextOut: Fix glyph shifting bug

### DIFF
--- a/dll/win32/usp10/usp10.c
+++ b/dll/win32/usp10/usp10.c
@@ -3642,7 +3642,7 @@ HRESULT WINAPI ScriptTextOut(const HDC hdc, SCRIPT_CACHE *psc, int x, int y, UIN
             if (i == 0)
             {
                 x += pGoffset[orig_index].du * dir;
-                y += pGoffset[orig_index].dv;
+                y -= pGoffset[orig_index].dv;
             }
             else
             {


### PR DESCRIPTION
The bug is in `ScriptTextOut `if an offset is applied to the first glyph the entire text is randomly shifted 
this bug affects more scripts that use marks .. to reproduce the bug try  `Goffset[0].dv = 5` 

the initial text 
![initial-text](https://github.com/reactos/reactos/assets/40634105/5cff96ca-1017-436a-a7ef-56e86c320026)

text  with actual code  ..  

![err-offset](https://github.com/reactos/reactos/assets/40634105/31847313-8418-4ee9-a61b-fa2d563d7705)


after correction 

![offset](https://github.com/reactos/reactos/assets/40634105/3d5533f3-6a55-4708-a50b-df120a61d012)
