### PR TITLE
[SHELL32] Fix 2 compiler warnings for the rls-configuration 'unused variable'

### DIFF
--- a/dll/win32/shell32/dialogs/filetypes.cpp
+++ b/dll/win32/shell32/dialogs/filetypes.cpp
@@ -660,12 +660,11 @@ FileTypesDlg_InsertToLV(HWND hListView, LPCWSTR szName, INT iItem, LPCWSTR szFil
     }
 
     // add icon to imagelist
-    INT iLargeImage = -1, iSmallImage = -1;
+    INT iSmallImage = -1;
     if (Entry->hIconLarge && Entry->hIconSmall)
     {
-        iLargeImage = ImageList_AddIcon(himlLarge, Entry->hIconLarge);
+        ImageList_AddIcon(himlLarge, Entry->hIconLarge);
         iSmallImage = ImageList_AddIcon(himlSmall, Entry->hIconSmall);
-        ASSERT(iLargeImage == iSmallImage);
     }
 
     // Do not add excluded entries
@@ -1038,9 +1037,8 @@ EditTypeDlg_UpdateEntryIcon(HWND hwndDlg, PEDITTYPE_DIALOG pEditType,
     HIMAGELIST himlLarge = ListView_GetImageList(hListView, LVSIL_NORMAL);
     HIMAGELIST himlSmall = ListView_GetImageList(hListView, LVSIL_SMALL);
 
-    INT iLargeImage = ImageList_AddIcon(himlLarge, pEntry->hIconLarge);
+    ImageList_AddIcon(himlLarge, pEntry->hIconLarge);
     INT iSmallImage = ImageList_AddIcon(himlSmall, pEntry->hIconSmall);
-    ASSERT(iLargeImage == iSmallImage);
 
     INT iItem = ListView_GetNextItem(hListView, -1, LVNI_SELECTED);
     if (iItem != -1)

--- a/dll/win32/shell32/dialogs/filetypes.cpp
+++ b/dll/win32/shell32/dialogs/filetypes.cpp
@@ -660,11 +660,13 @@ FileTypesDlg_InsertToLV(HWND hListView, LPCWSTR szName, INT iItem, LPCWSTR szFil
     }
 
     // add icon to imagelist
-    INT iSmallImage = -1;
+    INT iLargeImage = -1, iSmallImage = -1;
     if (Entry->hIconLarge && Entry->hIconSmall)
     {
-        ImageList_AddIcon(himlLarge, Entry->hIconLarge);
+        iLargeImage = ImageList_AddIcon(himlLarge, Entry->hIconLarge);
         iSmallImage = ImageList_AddIcon(himlSmall, Entry->hIconSmall);
+        ASSERT(iLargeImage == iSmallImage);
+        DBG_UNREFERENCED_LOCAL_VARIABLE(iLargeImage);
     }
 
     // Do not add excluded entries
@@ -1037,8 +1039,10 @@ EditTypeDlg_UpdateEntryIcon(HWND hwndDlg, PEDITTYPE_DIALOG pEditType,
     HIMAGELIST himlLarge = ListView_GetImageList(hListView, LVSIL_NORMAL);
     HIMAGELIST himlSmall = ListView_GetImageList(hListView, LVSIL_SMALL);
 
-    ImageList_AddIcon(himlLarge, pEntry->hIconLarge);
+    INT iLargeImage = ImageList_AddIcon(himlLarge, pEntry->hIconLarge);
     INT iSmallImage = ImageList_AddIcon(himlSmall, pEntry->hIconSmall);
+    ASSERT(iLargeImage == iSmallImage);
+    DBG_UNREFERENCED_LOCAL_VARIABLE(iLargeImage);
 
     INT iItem = ListView_GetNextItem(hListView, -1, LVNI_SELECTED);
     if (iItem != -1)


### PR DESCRIPTION
I noticed it on releases/0.4.10 with the RosBEWin2.1.6 GCC4.7.2 **rls** configuration:
```
C:/0410rls/reactos/dll/win32/shell32/dialogs/filetypes.cpp: In function 'BOOL FileTypesDlg_InsertToLV(HWND, LPCWSTR, INT, LPCWSTR)':
C:/0410rls/reactos/dll/win32/shell32/dialogs/filetypes.cpp:663:9: warning: variable 'iLargeImage' set but not used [-Wunused-but-set-variable]
C:/0410rls/reactos/dll/win32/shell32/dialogs/filetypes.cpp: In function 'BOOL EditTypeDlg_UpdateEntryIcon(HWND, PEDITTYPE_DIALOG, LPCWSTR, INT)':
C:/0410rls/reactos/dll/win32/shell32/dialogs/filetypes.cpp:1040:9: warning: unused variable 'iLargeImage' [-Wunused-variable]
```
But I do assume, that MSVC compilers would also complain about that in **rls** cfg.

Please notice that before 0.4.10-dev-202-g 698cbc6184722f29389ccd75ca96d88d6cd4b010 which did splitup and restructure the code this function was placed within the file folder_options.cpp and was named
InsertFileType(HWND hDlgCtrl, WCHAR * szName, PINT iItem, WCHAR * szFile)
and not yet within file_types.cpp with the new name
FileTypesDlg_InsertToLV(HWND hListView, LPCWSTR szName, INT iItem, LPCWSTR szFile)

Back then it did not have the iLargeImage variable yet, and it also didn't warn upon rls-cfg-compilation. Therefore
0.4.10-dev-202-g 698cbc6184722f29389ccd75ca96d88d6cd4b010 from (#582) is indeed the guilty revision (2018-06-06). It was done in the very first commit of that PR https://github.com/reactos/reactos/pull/582/commits/2fe0eab7216425f6b963e55f55986110d2151c6b
FTR: It's bad practice to move and refactor/extend code in functionality within the very same commit, as it makes reviewing the changes much harder.

JIRA issue: none
