### PR TITLE
[SHELL32] Map Alt+... menu keys

### DIFF
--- a/dll/win32/shell32/shellmenu/CMenuBand.cpp
+++ b/dll/win32/shell32/shellmenu/CMenuBand.cpp
@@ -930,7 +930,17 @@ HRESULT  CMenuBand::_KeyboardItemChange(DWORD change)
             else
                 tb = m_staticToolbar;
         }
+        else
+        {
+            if (m_staticToolbar)
+                tb = m_staticToolbar;
+            else
+                tb = m_SFToolbar;
+        }
     }
+
+    if (!tb)
+        return E_FAIL;
 
     // Ask the first toolbar to change
     hr = tb->KeyboardItemChange(change);
@@ -983,10 +993,21 @@ HRESULT CMenuBand::_MenuItemSelect(DWORD changeType)
             hr = _KeyboardItemChange(VK_UP);
             if (hr != S_FALSE)
                 return hr;
+            break;
         case VK_RIGHT:
             hr = _KeyboardItemChange(VK_DOWN);
             if (hr != S_FALSE)
                 return hr;
+            break;
+        default:
+            if (('A' <= changeType && changeType <= 'Z') ||
+                ('1' <= changeType && changeType <= '9'))
+            {
+                hr = _KeyboardItemChange(changeType);
+                if (hr != S_FALSE)
+                    return hr;
+            }
+            break;
         }
     }
 

--- a/dll/win32/shell32/shellmenu/CMenuBand.cpp
+++ b/dll/win32/shell32/shellmenu/CMenuBand.cpp
@@ -1001,7 +1001,7 @@ HRESULT CMenuBand::_MenuItemSelect(DWORD changeType)
             break;
         default:
             if (('A' <= changeType && changeType <= 'Z') ||
-                ('1' <= changeType && changeType <= '9'))
+                ('0' <= changeType && changeType <= '9'))
             {
                 hr = _KeyboardItemChange(changeType);
                 if (hr != S_FALSE)

--- a/dll/win32/shell32/shellmenu/CMenuFocusManager.cpp
+++ b/dll/win32/shell32/shellmenu/CMenuFocusManager.cpp
@@ -657,6 +657,17 @@ LRESULT CMenuFocusManager::GetMsgHook(INT nCode, WPARAM hookWParam, LPARAM hookL
                 msg->lParam = 0;
                 msg->wParam = 0;
             }
+            else
+            {
+                if (msg->message == WM_SYSKEYDOWN &&
+                    m_current->type == MenuBarEntry &&
+                    (('A' <= msg->wParam && msg->wParam <= 'Z') ||
+                     ('0' <= msg->wParam && msg->wParam <= '9'))
+                {
+                    if (m_current->mb->_MenuItemSelect(msg->wParam) == S_OK)
+                        msg->message = WM_NULL;
+                }
+            }
             break;
         }
 

--- a/dll/win32/shell32/shellmenu/CMenuFocusManager.cpp
+++ b/dll/win32/shell32/shellmenu/CMenuFocusManager.cpp
@@ -662,7 +662,7 @@ LRESULT CMenuFocusManager::GetMsgHook(INT nCode, WPARAM hookWParam, LPARAM hookL
                 if (msg->message == WM_SYSKEYDOWN &&
                     m_current->type == MenuBarEntry &&
                     (('A' <= msg->wParam && msg->wParam <= 'Z') ||
-                     ('0' <= msg->wParam && msg->wParam <= '9'))
+                     ('0' <= msg->wParam && msg->wParam <= '9')))
                 {
                     if (m_current->mb->_MenuItemSelect(msg->wParam) == S_OK)
                         msg->message = WM_NULL;

--- a/dll/win32/shell32/shellmenu/CMenuToolbars.cpp
+++ b/dll/win32/shell32/shellmenu/CMenuToolbars.cpp
@@ -913,7 +913,7 @@ HRESULT CMenuToolbarBase::KeyboardItemChange(DWORD dwSelectType)
             index = count - 1;
             dwSelectType = VK_UP;
         }
-        else
+        else if (dwSelectType == VK_UP || dwSelectType == VK_DOWN)
         {
             if (m_hotItem >= 0)
             {
@@ -945,6 +945,21 @@ HRESULT CMenuToolbarBase::KeyboardItemChange(DWORD dwSelectType)
                     index++;
                 }
             }
+        }
+        else
+        {
+            UINT_PTR id = 0;
+            if (::SendMessage(m_hWnd, TB_MAPACCELERATOR, dwSelectType, (LPARAM)&id))
+            {
+                INT nIndex = (INT)::SendMessage(m_hWnd, TB_COMMANDTOINDEX, id, 0);
+                if (nIndex != -1)
+                {
+                    m_menuBand->_ChangeHotItem(NULL, -1, 0);
+                    ProcessClick(id);
+                    return S_OK;
+                }
+            }
+            return S_FALSE;
         }
 
         TBBUTTON btn = { 0 };


### PR DESCRIPTION
## Purpose

On English Explorer, `Alt+F` will open the `"&File"` menu. `Alt+E` will open the `"&Edit"` menu. `Alt+V` will open the `"&View"` menu. etc.

JIRA issue: [CORE-12533](https://jira.reactos.org/browse/CORE-12533)

## Proposed changes

- Catch keys at `GetMsgHook`.
- Pass keys into `KeyboardItemChange`.
- Use `TB_MAPACCELERATOR` message in `CMenuToolbarBase::KeyboardItemChange`.

## TODO

- [x] Do tests.
- [ ] Correct submenu navigation.

## Movie

https://github.com/reactos/reactos/assets/2107452/884b35af-fabc-4326-9186-3313f5c6e101
Some bugs remain. Done is better than perfect.