### PR TITLE
[SDK:NDK/XDK] Improve KeGetPcr() and NtCurrentTeb() definitions for some platforms

### DIFF
--- a/sdk/include/ndk/inline_ntcurrentteb.h
+++ b/sdk/include/ndk/inline_ntcurrentteb.h
@@ -1,29 +1,31 @@
 #ifndef _INLINE_NT_CURRENTTEB_H_
 #define _INLINE_NT_CURRENTTEB_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+FORCEINLINE struct _TEB * NtCurrentTeb(VOID)
+{
 #if defined(_M_IX86)
-FORCEINLINE struct _TEB * NtCurrentTeb(void)
-{
     return (struct _TEB *)__readfsdword(0x18);
-}
-#elif defined(_M_ARM)
-FORCEINLINE struct _TEB * NtCurrentTeb(void)
-{
-    __debugbreak();
-    return (struct _TEB *)0;
-}
 #elif defined(_M_AMD64)
-FORCEINLINE struct _TEB * NtCurrentTeb(void)
-{
     return (struct _TEB *)__readgsqword(FIELD_OFFSET(NT_TIB, Self));
-}
-#elif defined(_M_PPC)
-FORCEINLINE struct _TEB * NtCurrentTeb(void)
-{
-    return (struct _TEB *)__readfsdword_winnt(0x18);
-}
+#elif defined(_M_ARM)
+    // return (struct _TEB *)KeGetPcr()->Used_Self;
+    return (struct _TEB *)(ULONG_PTR)_MoveFromCoprocessor(CP15_TPIDRURW);
+#elif defined (_M_ARM64)
+    //UNIMPLEMENTED;
+    return 0;
+// #elif defined(_M_PPC)
+//     return (struct _TEB *)_read_teb_dword(0x18);
 #else
 #error Unsupported architecture
 #endif
+}
 
-#endif//_INLINE_NT_CURRENTTEB_H_
+#ifdef __cplusplus
+}
+#endif
+
+#endif // _INLINE_NT_CURRENTTEB_H_

--- a/sdk/include/ndk/psfuncs.h
+++ b/sdk/include/ndk/psfuncs.h
@@ -420,15 +420,23 @@ NtCreateThread(
 FORCEINLINE struct _TEB * NtCurrentTeb(VOID)
 {
 #if defined(_M_IX86)
-    return (PTEB)__readfsdword(0x18);
+    return (struct _TEB *)__readfsdword(0x18);
 #elif defined (_M_AMD64)
     return (struct _TEB *)__readgsqword(FIELD_OFFSET(NT_TIB, Self));
 #elif defined (_M_ARM)
-    return (struct _TEB *)KeGetPcr()->Used_Self;
+    // return (struct _TEB *)KeGetPcr()->Used_Self;
+    return (struct _TEB *)(ULONG_PTR)_MoveFromCoprocessor(CP15_TPIDRURW);
+#elif defined (_M_ARM64)
+    //UNIMPLEMENTED;
+    return 0;
+// #elif defined(_M_PPC)
+//     return (struct _TEB *)_read_teb_dword(0x18);
+#else
+#error Unsupported architecture
 #endif
 }
 #else
-struct _TEB * NtCurrentTeb(void);
+struct _TEB * NtCurrentTeb(VOID);
 #endif
 
 NTSYSCALLAPI

--- a/sdk/include/xdk/arm/ke.h
+++ b/sdk/include/xdk/arm/ke.h
@@ -334,14 +334,13 @@ typedef struct _KPCR
 } KPCR, *PKPCR;
 
 #define CP15_PCR_RESERVED_MASK 0xFFF
-//#define KIPCR() ((ULONG_PTR)(_MoveFromCoprocessor(CP15_TPIDRPRW)) & ~CP15_PCR_RESERVED_MASK)
+#define KIPCR() (((ULONG_PTR)_MoveFromCoprocessor(CP15_TPIDRPRW)) & ~CP15_PCR_RESERVED_MASK)
 
 FORCEINLINE
 PKPCR
-KeGetPcr(
-    VOID)
+KeGetPcr(VOID)
 {
-    return (PKPCR)(_MoveFromCoprocessor(CP15_TPIDRPRW) & ~CP15_PCR_RESERVED_MASK);
+    return (PKPCR)KIPCR();
 }
 
 #if (NTDDI_VERSION < NTDDI_WIN7) || !defined(NT_PROCESSOR_GROUPS)
@@ -349,8 +348,8 @@ FORCEINLINE
 ULONG
 KeGetCurrentProcessorNumber(VOID)
 {
-    return *((PUCHAR)KeGetPcr() + 0x580);
+    return (ULONG)*((PUCHAR)KIPCR() + 0x580);
 }
 #endif /* (NTDDI_VERSION < NTDDI_WIN7) || !defined(NT_PROCESSOR_GROUPS) */
 
-$endif
+$endif (_NTDDK_)

--- a/sdk/include/xdk/winnt_old.h
+++ b/sdk/include/xdk/winnt_old.h
@@ -4297,7 +4297,7 @@ RtlSecureZeroMemory(_Out_writes_bytes_all_(Length) PVOID Buffer,
 }
 
 #if defined(_M_IX86)
-FORCEINLINE struct _TEB * NtCurrentTeb(void)
+FORCEINLINE struct _TEB * NtCurrentTeb(VOID)
 {
     return (struct _TEB *)__readfsdword(0x18);
 }
@@ -4306,17 +4306,17 @@ FORCEINLINE PVOID GetCurrentFiber(VOID)
     return (PVOID)(ULONG_PTR)__readfsdword(0x10);
 }
 #elif defined (_M_AMD64)
-FORCEINLINE struct _TEB * NtCurrentTeb(void)
+FORCEINLINE struct _TEB * NtCurrentTeb(VOID)
 {
     return (struct _TEB *)__readgsqword(FIELD_OFFSET(NT_TIB, Self));
 }
 FORCEINLINE PVOID GetCurrentFiber(VOID)
 {
-  #ifdef NONAMELESSUNION
+#ifdef NONAMELESSUNION
     return (PVOID)__readgsqword(FIELD_OFFSET(NT_TIB, DUMMYUNIONNAME.FiberData));
-  #else
+#else
     return (PVOID)__readgsqword(FIELD_OFFSET(NT_TIB, FiberData));
-  #endif
+#endif
 }
 #elif defined (_M_ARM)
 #define CP15_PMSELR      15, 0,  9, 12, 5
@@ -4324,20 +4324,20 @@ FORCEINLINE PVOID GetCurrentFiber(VOID)
 #define CP15_TPIDRURW    15, 0, 13,  0, 2
 #define CP15_TPIDRURO    15, 0, 13,  0, 3
 #define CP15_TPIDRPRW    15, 0, 13,  0, 4
-FORCEINLINE struct _TEB * NtCurrentTeb(void)
+FORCEINLINE struct _TEB * NtCurrentTeb(VOID)
 {
     return (struct _TEB *)(ULONG_PTR)_MoveFromCoprocessor(CP15_TPIDRURW);
 }
 FORCEINLINE PVOID GetCurrentFiber(VOID)
 {
-  #ifdef NONAMELESSUNION
-    return ((PNT_TIB )(ULONG_PTR)_MoveFromCoprocessor(CP15_TPIDRURW))->DUMMYUNIONNAME.FiberData;
-  #else
-    return ((PNT_TIB )(ULONG_PTR)_MoveFromCoprocessor(CP15_TPIDRURW))->FiberData;
-  #endif
+#ifdef NONAMELESSUNION
+    return ((PNT_TIB)(ULONG_PTR)_MoveFromCoprocessor(CP15_TPIDRURW))->DUMMYUNIONNAME.FiberData;
+#else
+    return ((PNT_TIB)(ULONG_PTR)_MoveFromCoprocessor(CP15_TPIDRURW))->FiberData;
+#endif
 }
 #elif defined (_M_ARM64)
-FORCEINLINE struct _TEB * NtCurrentTeb(void)
+FORCEINLINE struct _TEB * NtCurrentTeb(VOID)
 {
     //UNIMPLEMENTED;
     return 0;
@@ -4358,11 +4358,11 @@ FORCEINLINE unsigned long _read_teb_dword(const unsigned long Offset)
             : "r7");
     return result;
 }
-FORCEINLINE struct _TEB * NtCurrentTeb(void)
+FORCEINLINE struct _TEB * NtCurrentTeb(VOID)
 {
     return (struct _TEB *)_read_teb_dword(0x18);
 }
-FORCEINLINE PVOID GetCurrentFiber(void)
+FORCEINLINE PVOID GetCurrentFiber(VOID)
 {
     return _read_teb_dword(0x10);
 }
@@ -4370,7 +4370,7 @@ FORCEINLINE PVOID GetCurrentFiber(void)
 #error Unknown architecture
 #endif
 
-FORCEINLINE PVOID GetFiberData(void)
+FORCEINLINE PVOID GetFiberData(VOID)
 {
     return *((PVOID *)GetCurrentFiber());
 }
@@ -4397,7 +4397,7 @@ FORCEINLINE PVOID GetFiberData(void)
 #if defined(_MSC_VER)
 FORCEINLINE
 VOID
-MemoryBarrier (VOID)
+MemoryBarrier(VOID)
 {
     LONG Barrier;
     __asm { xchg Barrier, eax }


### PR DESCRIPTION
## Purpose

Fix some inconsistencies in definitions and complete some others.
Affect ARM(64) platforms too.

## Proposed changes

```
[SDK:NDK/XDK] Adjust the KeGetPcr() ARM definition

Re-enable the KIPCR() macro and use it for KeGetPcr()
and KeGetCurrentProcessorNumber() definitions.
```
```
[SDK:NDK/XDK] Sync NtCurrentTeb() definitions between NDK and PSDK winnt.h

The definitions in the NDK inline_ntcurrentteb.h and psfuncs.h files are
synced togther with those of winnt.h (in the winnt_old.h generator file).

See commits c1929445d (r49627) and 925c587c8 (r56318).

IMPORTANT NOTE: The ARM64 definition is not yet existent in our headers!
```