### PR TITLE
[SHELL32] Opening Special Folder shortcut

### DIFF
--- a/dll/win32/shell32/CShellLink.cpp
+++ b/dll/win32/shell32/CShellLink.cpp
@@ -2627,11 +2627,19 @@ HRESULT CShellLink::DoOpen(LPCMINVOKECOMMANDINFO lpici)
     sei.cbSize = sizeof(sei);
     sei.fMask = SEE_MASK_HASLINKNAME | SEE_MASK_UNICODE |
                (lpici->fMask & (SEE_MASK_NOASYNC | SEE_MASK_ASYNCOK | SEE_MASK_FLAG_NO_UI));
-    sei.lpFile = path;
+    if (m_pPidl)
+    {
+        sei.lpIDList = m_pPidl;
+        sei.fMask |= SEE_MASK_IDLIST;
+    }
+    else
+    {
+        sei.lpFile = path;
+        sei.lpParameters = args;
+    }
     sei.lpClass = m_sLinkPath;
     sei.nShow = m_Header.nShowCommand;
     sei.lpDirectory = m_sWorkDir;
-    sei.lpParameters = args;
     sei.lpVerb = L"open";
 
     // HACK for ShellExecuteExW


### PR DESCRIPTION
## Purpose
Fix opening special folder.
JIRA issue: [CORE-19464](https://jira.reactos.org/browse/CORE-19464)

## Proposed changes

- In `CShellLink::DoOpen`, if there is a PIDL, then use it and set `SEE_MASK_IDLIST` flag.

## TODO

- [x] Do tests.

## Movie

https://github.com/reactos/reactos/assets/2107452/857b7f38-1832-4a1e-91ec-65f229242c4b