### PR TITLE
[SHELL32] idCmdFirst shouldn't be zero

### DIFF
--- a/dll/win32/shell32/shellmenu/CMenuBand.cpp
+++ b/dll/win32/shell32/shellmenu/CMenuBand.cpp
@@ -832,7 +832,8 @@ HRESULT CMenuBand::_TrackContextMenu(IContextMenu * contextMenu, INT x, INT y)
         return E_FAIL;
 
     TRACE("Before Query\n");
-    hr = contextMenu->QueryContextMenu(popup, 0, 0, UINT_MAX, CMF_NORMAL);
+    const INT idCmdFirst = 100;
+    hr = contextMenu->QueryContextMenu(popup, 0, idCmdFirst, UINT_MAX, CMF_NORMAL);
     if (FAILED_UNEXPECTEDLY(hr))
     {
         TRACE("Query failed\n");
@@ -854,10 +855,8 @@ HRESULT CMenuBand::_TrackContextMenu(IContextMenu * contextMenu, INT x, INT y)
         _MenuItemSelect(MPOS_FULLCANCEL);
 
         TRACE("Before InvokeCommand\n");
-        CMINVOKECOMMANDINFO cmi = { 0 };
-        cmi.cbSize = sizeof(cmi);
-        cmi.lpVerb = MAKEINTRESOURCEA(uCommand);
-        cmi.hwnd = hwnd;
+        CMINVOKECOMMANDINFO cmi = { sizeof(cmi), 0, hwnd };
+        cmi.lpVerb = MAKEINTRESOURCEA(uCommand - idCmdFirst);
         hr = contextMenu->InvokeCommand(&cmi);
         TRACE("InvokeCommand returned hr=%08x\n", hr);
     }


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-17453](https://jira.reactos.org/browse/CORE-17453), [CORE-12328](https://jira.reactos.org/browse/CORE-12328)

## Proposed changes

In `CMenuBand::_TrackContextMenu` method:

- Use `100` for `idCmdFirst`, instead of zero.
- Use `uCommand - idCmdFirst` for `cmi.lpVerb`.

Zero is an invalid command ID.

## TODO

- [x] Do tests.

## Screenshot

![can-open-notepad](https://github.com/reactos/reactos/assets/2107452/5acb38c4-764f-48c1-9db4-a0e9bbcd9725)
I can open notepad from context menu.