### PR TITLE
[SHELL32] SHBrowseForFolder: Fix pszDisplayName

### DIFF
--- a/dll/win32/shell32/wine/brsfolder.c
+++ b/dll/win32/shell32/wine/brsfolder.c
@@ -1052,7 +1052,19 @@ static BOOL BrsFolder_OnCommand( browse_info *info, UINT id )
             info->pidlRet = _ILCreateDesktop();
         pdump( info->pidlRet );
         if (lpBrowseInfo->pszDisplayName)
+#ifdef __REACTOS__
+        {
+            SHFILEINFOW fileInfo = { NULL };
+            lpBrowseInfo->pszDisplayName[0] = UNICODE_NULL;
+            if (SHGetFileInfoW((LPCWSTR)info->pidlRet, 0, &fileInfo, sizeof(fileInfo),
+                               SHGFI_PIDL | SHGFI_DISPLAYNAME))
+            {
+                lstrcpynW(lpBrowseInfo->pszDisplayName, fileInfo.szDisplayName, MAX_PATH);
+            }
+        }
+#else
             SHGetPathFromIDListW( info->pidlRet, lpBrowseInfo->pszDisplayName );
+#endif
         EndDialog( info->hWnd, 1 );
         return TRUE;
 


### PR DESCRIPTION
## Purpose

`pszDisplayName` is for display name, not for full path.
JIRA issue: [CORE-5866](https://jira.reactos.org/browse/CORE-5866)

## Proposed changes

- If `lpBrowseInfo->pszDisplayName` is valid, use `SHGetFileInfoW` to get display name.
- Don't use `SHGetPathFromIDListW` to get display name. It's wrong.

## TODO

- [x] Do tests.

## Comparison

BEFORE:
![before](https://github.com/reactos/reactos/assets/2107452/95a4c3cb-e589-457a-9e19-3bd099ac6c51)
AFTER:
![after](https://github.com/reactos/reactos/assets/2107452/57d7a41b-1c58-4463-b994-91930b801384)
Win2k3:
![2k3](https://github.com/reactos/reactos/assets/2107452/c4d94941-4e54-4e69-8c68-b1dc0de7fee7)