### PR TITLE
[APPWIZ][SHELL32] Improve 'Create Shortcut' dialog

### DIFF
--- a/dll/cpl/appwiz/appwiz.h
+++ b/dll/cpl/appwiz/appwiz.h
@@ -27,8 +27,8 @@ WINE_DEFAULT_DEBUG_CHANNEL(appwiz);
 
 typedef struct
 {
+   LPITEMIDLIST pidlTarget;
    WCHAR szTarget[2 * MAX_PATH];
-   WCHAR szWorkingDirectory[MAX_PATH];
    WCHAR szDescription[MAX_PATH];
    WCHAR szArguments[2 * MAX_PATH];
    WCHAR szOrigin[MAX_PATH];

--- a/dll/win32/shell32/CShellLink.cpp
+++ b/dll/win32/shell32/CShellLink.cpp
@@ -2635,8 +2635,8 @@ HRESULT CShellLink::DoOpen(LPCMINVOKECOMMANDINFO lpici)
     else
     {
         sei.lpFile = path;
-        sei.lpParameters = args;
     }
+    sei.lpParameters = args;
     sei.lpClass = m_sLinkPath;
     sei.nShow = m_Header.nShowCommand;
     sei.lpDirectory = m_sWorkDir;


### PR DESCRIPTION
## Purpose

Now we can open special folder shortcut, thanks to #6546.
Let's allow users to create various shortcut files.
JIRA issue: [CORE-5866](https://jira.reactos.org/browse/CORE-5866)

## Proposed changes

- Remove `BIF_RETURNONLYFSDIRS` flag because the system can open special folder shortcuts now.
- Add `LPITEMIDLIST pidlTarget` to `CREATE_LINK_CONTEXT` structure.
- Use `pidlTarget` if the target is a special folder.
- Fix `CShellLink::DoOpen` for arguments.

## TODO

- [x] Do tests.

## Movie

https://github.com/reactos/reactos/assets/2107452/c02146d7-6c1a-4b7b-a4f6-ac5a4eb748f0

- We can create `"My Computer"` shortcut.
- We can create `"My Documents"` shortcut.
- We can create `"Network"` shortcut.
- We can create `"C:\"` shortcut.
- We can create `"C:\Documents and Settings"` shortcut.
- We can create `"cmd /k dir"` shortcut.