### PR TITLE
[BOOT] Don't create empty CSIDL_ADMINTOOLS folder

### DIFF
--- a/boot/boot_images.cmake
+++ b/boot/boot_images.cmake
@@ -100,7 +100,7 @@ function(add_user_profile_dirs _image_filelist _rootdir _username)
     file(APPEND ${_image_filelist} "${_rootdir}/${_username}/Recent=${CMAKE_CURRENT_BINARY_DIR}/empty\n")
     file(APPEND ${_image_filelist} "${_rootdir}/${_username}/SendTo=${CMAKE_CURRENT_BINARY_DIR}/empty\n")
     file(APPEND ${_image_filelist} "${_rootdir}/${_username}/Start Menu/Programs=${CMAKE_CURRENT_BINARY_DIR}/empty\n")
-    file(APPEND ${_image_filelist} "${_rootdir}/${_username}/Start Menu/Programs/Administrative Tools=${CMAKE_CURRENT_BINARY_DIR}/empty\n")
+    #file(APPEND ${_image_filelist} "${_rootdir}/${_username}/Start Menu/Programs/Administrative Tools=${CMAKE_CURRENT_BINARY_DIR}/empty\n") # CORE-12328
     file(APPEND ${_image_filelist} "${_rootdir}/${_username}/Start Menu/Programs/StartUp=${CMAKE_CURRENT_BINARY_DIR}/empty\n")
     file(APPEND ${_image_filelist} "${_rootdir}/${_username}/Templates=${CMAKE_CURRENT_BINARY_DIR}/empty\n")
 endfunction()


### PR DESCRIPTION
## Purpose
We shouldn't create an empty `CSIDL_ADMINTOOLS` folder at initial status.
JIRA issue: [CORE-12328](https://jira.reactos.org/browse/CORE-12328)

## Proposed changes

- Modify `boot/boot_images.cmake`.

## TODO

- [x] Do tests.

## Screenshot

AFTER:
![after](https://github.com/reactos/reactos/assets/2107452/17c77e1d-be70-4828-940e-dd39b7c88139)