### PR TITLE
[MSPAINT] Improve GetSelectionContents for free-shape selection

### DIFF
--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -1056,8 +1056,8 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
             HBITMAP hbmSelection = selectionModel.GetSelectionContents();
             if (hbmSelection)
             {
-                selectionModel.HideSelection();
                 imageModel.PushImageForUndo(hbmSelection);
+                selectionModel.HideSelection();
                 imageModel.NotifyImageChanged();
             }
             break;

--- a/base/applications/mspaint/selectionmodel.cpp
+++ b/base/applications/mspaint/selectionmodel.cpp
@@ -61,17 +61,30 @@ void SelectionModel::DrawBackground(HDC hDCImage, COLORREF crBg)
 void SelectionModel::DrawSelection(HDC hDCImage, COLORREF crBg, BOOL bBgTransparent)
 {
     CRect rc = m_rc;
+    DrawSelection(hDCImage, crBg, bBgTransparent, rc);
+}
+
+void
+SelectionModel::DrawSelection(HDC hDCImage, COLORREF crBg, BOOL bBgTransparent, const CRect& rc)
+{
+    DrawSelection(hDCImage, crBg, bBgTransparent, rc, m_hbmColor);
+}
+
+void
+SelectionModel::DrawSelection(HDC hDCImage, COLORREF crBg, BOOL bBgTransparent, const CRect& rc,
+                              HBITMAP hbm)
+{
     if (rc.IsRectEmpty())
         return;
 
     BITMAP bm;
-    if (!GetObjectW(m_hbmColor, sizeof(BITMAP), &bm))
+    if (!GetObjectW(hbm, sizeof(BITMAP), &bm))
         return;
 
     COLORREF keyColor = (bBgTransparent ? crBg : CLR_INVALID);
 
     HDC hMemDC = CreateCompatibleDC(hDCImage);
-    HGDIOBJ hbmOld = SelectObject(hMemDC, m_hbmColor);
+    HGDIOBJ hbmOld = SelectObject(hMemDC, hbm);
     ColorKeyedMaskBlt(hDCImage, rc.left, rc.top, rc.Width(), rc.Height(),
                       hMemDC, 0, 0, bm.bmWidth, bm.bmHeight, m_hbmMask, keyColor);
     SelectObject(hMemDC, hbmOld);
@@ -89,13 +102,22 @@ void SelectionModel::setMask(const CRect& rc, HBITMAP hbmMask)
 
 HBITMAP SelectionModel::GetSelectionContents()
 {
-    if (m_hbmColor)
-        return CopyDIBImage(m_hbmColor, m_rc.Width(), m_rc.Height());
-
     HBITMAP hbmWhole = imageModel.LockBitmap();
     HBITMAP hbmPart = getSubImage(hbmWhole, m_rc);
     imageModel.UnlockBitmap(hbmWhole);
-    return hbmPart;
+    if (!hbmPart)
+        return NULL;
+
+    HDC hdcMem = ::CreateCompatibleDC(NULL);
+    HBITMAP hbmNew = CreateColorDIB(m_rc.Width(), m_rc.Height(), paletteModel.GetBgColor());
+    HGDIOBJ hbmOld = ::SelectObject(hdcMem, hbmNew);
+    CRect rc = { 0, 0, m_rc.Width(), m_rc.Height() };
+    selectionModel.DrawSelection(hdcMem, paletteModel.GetBgColor(), TRUE, rc, hbmPart);
+    ::SelectObject(hdcMem, hbmOld);
+    ::DeleteDC(hdcMem);
+
+    ::DeleteObject(hbmPart);
+    return hbmNew;
 }
 
 BOOL SelectionModel::IsLanded() const

--- a/base/applications/mspaint/selectionmodel.cpp
+++ b/base/applications/mspaint/selectionmodel.cpp
@@ -91,13 +91,10 @@ void SelectionModel::setMask(const CRect& rc, HBITMAP hbmMask)
 HBITMAP SelectionModel::GetSelectionContents()
 {
     HBITMAP hbmWhole = imageModel.LockBitmap();
-    HBITMAP hbmPart = getSubImage(hbmWhole, m_rcOld);
+    HBITMAP hbmPart = getSubImage(hbmWhole, (IsLanded() ? m_rc : m_rcOld));
     imageModel.UnlockBitmap(hbmWhole);
     if (!hbmPart)
         return NULL;
-
-    if (toolsModel.GetActiveTool() == TOOL_RECTSEL)
-        return hbmPart;
 
     CRect rc = { 0, 0, m_rc.Width(), m_rc.Height() };
 

--- a/base/applications/mspaint/selectionmodel.cpp
+++ b/base/applications/mspaint/selectionmodel.cpp
@@ -103,7 +103,7 @@ void SelectionModel::setMask(const CRect& rc, HBITMAP hbmMask)
 HBITMAP SelectionModel::GetSelectionContents()
 {
     HBITMAP hbmWhole = imageModel.LockBitmap();
-    HBITMAP hbmPart = getSubImage(hbmWhole, m_rc);
+    HBITMAP hbmPart = getSubImage(hbmWhole, m_rcOld);
     imageModel.UnlockBitmap(hbmWhole);
     if (!hbmPart)
         return NULL;
@@ -111,10 +111,11 @@ HBITMAP SelectionModel::GetSelectionContents()
     if (toolsModel.GetActiveTool() == TOOL_RECTSEL)
         return hbmPart;
 
-    HDC hdcMem = ::CreateCompatibleDC(NULL);
-    HBITMAP hbmNew = CreateColorDIB(m_rc.Width(), m_rc.Height(), paletteModel.GetBgColor());
-    HGDIOBJ hbmOld = ::SelectObject(hdcMem, hbmNew);
     CRect rc = { 0, 0, m_rc.Width(), m_rc.Height() };
+
+    HDC hdcMem = ::CreateCompatibleDC(NULL);
+    HBITMAP hbmNew = CreateColorDIB(rc.Width(), rc.Height(), paletteModel.GetBgColor());
+    HGDIOBJ hbmOld = ::SelectObject(hdcMem, hbmNew);
     selectionModel.DrawSelection(hdcMem, paletteModel.GetBgColor(), TRUE, rc, hbmPart);
     ::SelectObject(hdcMem, hbmOld);
     ::DeleteDC(hdcMem);

--- a/base/applications/mspaint/selectionmodel.cpp
+++ b/base/applications/mspaint/selectionmodel.cpp
@@ -58,18 +58,6 @@ void SelectionModel::DrawBackground(HDC hDCImage, COLORREF crBg)
         DrawBackgroundRect(hDCImage, crBg);
 }
 
-void SelectionModel::DrawSelection(HDC hDCImage, COLORREF crBg, BOOL bBgTransparent)
-{
-    CRect rc = m_rc;
-    DrawSelection(hDCImage, crBg, bBgTransparent, rc);
-}
-
-void
-SelectionModel::DrawSelection(HDC hDCImage, COLORREF crBg, BOOL bBgTransparent, const CRect& rc)
-{
-    DrawSelection(hDCImage, crBg, bBgTransparent, rc, m_hbmColor);
-}
-
 void
 SelectionModel::DrawSelection(HDC hDCImage, COLORREF crBg, BOOL bBgTransparent, const CRect& rc,
                               HBITMAP hbm)

--- a/base/applications/mspaint/selectionmodel.cpp
+++ b/base/applications/mspaint/selectionmodel.cpp
@@ -108,6 +108,9 @@ HBITMAP SelectionModel::GetSelectionContents()
     if (!hbmPart)
         return NULL;
 
+    if (toolsModel.GetActiveTool() == TOOL_RECTSEL)
+        return hbmPart;
+
     HDC hdcMem = ::CreateCompatibleDC(NULL);
     HBITMAP hbmNew = CreateColorDIB(m_rc.Width(), m_rc.Height(), paletteModel.GetBgColor());
     HGDIOBJ hbmOld = ::SelectObject(hdcMem, hbmNew);

--- a/base/applications/mspaint/selectionmodel.h
+++ b/base/applications/mspaint/selectionmodel.h
@@ -42,6 +42,10 @@ public:
     void DrawBackgroundPoly(HDC hDCImage, COLORREF crBg);
     void DrawBackgroundRect(HDC hDCImage, COLORREF crBg);
     void DrawSelection(HDC hDCImage, COLORREF crBg = 0, BOOL bBgTransparent = FALSE);
+    void DrawSelection(HDC hDCImage, COLORREF crBg, BOOL bBgTransparent, const CRect& rc);
+    void DrawSelection(HDC hDCImage, COLORREF crBg, BOOL bBgTransparent, const CRect& rc,
+                       HBITMAP hbm);
+
     void InsertFromHBITMAP(HBITMAP hbmColor, INT x = 0, INT y = 0, HBITMAP hbmMask = NULL);
 
     // operation

--- a/base/applications/mspaint/selectionmodel.h
+++ b/base/applications/mspaint/selectionmodel.h
@@ -41,10 +41,18 @@ public:
     void DrawBackground(HDC hDCImage, COLORREF crBg);
     void DrawBackgroundPoly(HDC hDCImage, COLORREF crBg);
     void DrawBackgroundRect(HDC hDCImage, COLORREF crBg);
-    void DrawSelection(HDC hDCImage, COLORREF crBg = 0, BOOL bBgTransparent = FALSE);
-    void DrawSelection(HDC hDCImage, COLORREF crBg, BOOL bBgTransparent, const CRect& rc);
-    void DrawSelection(HDC hDCImage, COLORREF crBg, BOOL bBgTransparent, const CRect& rc,
-                       HBITMAP hbm);
+
+    void DrawSelection(HDC hDCImage, COLORREF crBg, BOOL bBgTransparent, const CRect& rc, HBITMAP hbm);
+
+    void DrawSelection(HDC hDCImage, COLORREF crBg, BOOL bBgTransparent)
+    {
+        return DrawSelection(hDCImage, crBg, bBgTransparent, m_rc);
+    }
+
+    void DrawSelection(HDC hDCImage, COLORREF crBg, BOOL bBgTransparent, const CRect& rc)
+    {
+        return DrawSelection(hDCImage, crBg, bBgTransparent, rc, m_hbmColor);
+    }
 
     void InsertFromHBITMAP(HBITMAP hbmColor, INT x = 0, INT y = 0, HBITMAP hbmMask = NULL);
 


### PR DESCRIPTION
## Purpose

Follow-up to #6552. There was a bug that the cropped selection image is not the shape of selection.

JIRA issue: [CORE-19466](https://jira.reactos.org/browse/CORE-19466)

## Proposed changes

- Extend `SelectionModel::DrawSelection` for drawing selection flexibly.
- Improve `SelectionModel::GetSelectionContents` method.

## TODO

- [x] Can crop.
- [x] Can Undo/Redo cropping.
- [x] Resizing selection and cropping.
- [x] Free-shape cropping.

## Screenshots

![1](https://github.com/reactos/reactos/assets/2107452/525622fc-765e-433d-b433-45d3838dce7f)

![2](https://github.com/reactos/reactos/assets/2107452/d67e515c-36be-43b3-8416-7e926a99fb8e)