### PR TITLE
[SHLWAPI_APITEST] Add SHGetRestriction testcase

### DIFF
--- a/modules/rostests/apitests/shlwapi/CMakeLists.txt
+++ b/modules/rostests/apitests/shlwapi/CMakeLists.txt
@@ -12,6 +12,7 @@ list(APPEND SOURCE
     PathUnExpandEnvStrings.c
     PathUnExpandEnvStringsForUser.c
     SHAreIconsEqual.c
+    SHGetRestriction.c
     SHLoadIndirectString.c
     SHLoadRegUIString.c
     SHPropertyBag.cpp

--- a/modules/rostests/apitests/shlwapi/SHGetRestriction.c
+++ b/modules/rostests/apitests/shlwapi/SHGetRestriction.c
@@ -63,6 +63,15 @@ TEST_DoEntry(const TEST_ENTRY *entry, FN_SHGetRestriction fnSHGetRestriction)
     ok_long(value1, value2);
 }
 
+#define DELETE_VALUE(hBaseKey) \
+    SHDeleteValueW((hBaseKey), REGKEY_POLICIES_EXPLORER, L"NoRun")
+
+#define SET_VALUE(hBaseKey, value) do { \
+    dwValue = (value); \
+    SHSetValueW((hBaseKey), REGKEY_POLICIES_EXPLORER, L"NoRun", \
+                REG_DWORD, &dwValue, sizeof(dwValue)); \
+} while (0)
+
 static void
 TEST_SHGetRestriction_Stage(
     INT iStage,
@@ -76,48 +85,32 @@ TEST_SHGetRestriction_Stage(
     switch (iStage)
     {
         case 0:
-            SHDeleteValueW(HKEY_CURRENT_USER, REGKEY_POLICIES_EXPLORER, L"NoRun");
-            SHDeleteValueW(HKEY_LOCAL_MACHINE, REGKEY_POLICIES_EXPLORER, L"NoRun");
+            DELETE_VALUE(HKEY_CURRENT_USER);
+            DELETE_VALUE(HKEY_LOCAL_MACHINE);
             break;
         case 1:
-            dwValue = 0;
-            SHSetValueW(HKEY_CURRENT_USER, REGKEY_POLICIES_EXPLORER, L"NoRun",
-                        REG_DWORD, &dwValue, sizeof(dwValue));
-            SHDeleteValueW(HKEY_LOCAL_MACHINE, REGKEY_POLICIES_EXPLORER, L"NoRun");
+            SET_VALUE(HKEY_CURRENT_USER, 0);
+            DELETE_VALUE(HKEY_LOCAL_MACHINE);
             break;
         case 2:
-            dwValue = 1;
-            SHSetValueW(HKEY_CURRENT_USER, REGKEY_POLICIES_EXPLORER, L"NoRun",
-                        REG_DWORD, &dwValue, sizeof(dwValue));
-            SHDeleteValueW(HKEY_LOCAL_MACHINE, REGKEY_POLICIES_EXPLORER, L"NoRun");
+            SET_VALUE(HKEY_CURRENT_USER, 1);
+            DELETE_VALUE(HKEY_LOCAL_MACHINE);
             break;
         case 3:
-            dwValue = 0;
-            SHDeleteValueW(HKEY_CURRENT_USER, REGKEY_POLICIES_EXPLORER, L"NoRun");
-            SHSetValueW(HKEY_LOCAL_MACHINE, REGKEY_POLICIES_EXPLORER, L"NoRun",
-                        REG_DWORD, &dwValue, sizeof(dwValue));
+            DELETE_VALUE(HKEY_CURRENT_USER);
+            SET_VALUE(HKEY_LOCAL_MACHINE, 0);
             break;
         case 4:
-            dwValue = 1;
-            SHDeleteValueW(HKEY_CURRENT_USER, REGKEY_POLICIES_EXPLORER, L"NoRun");
-            SHSetValueW(HKEY_LOCAL_MACHINE, REGKEY_POLICIES_EXPLORER, L"NoRun",
-                        REG_DWORD, &dwValue, sizeof(dwValue));
+            DELETE_VALUE(HKEY_CURRENT_USER);
+            SET_VALUE(HKEY_LOCAL_MACHINE, 1);
             break;
         case 5:
-            dwValue = 0;
-            SHSetValueW(HKEY_LOCAL_MACHINE, REGKEY_POLICIES_EXPLORER, L"NoRun",
-                        REG_DWORD, &dwValue, sizeof(dwValue));
-            dwValue = 1;
-            SHSetValueW(HKEY_LOCAL_MACHINE, REGKEY_POLICIES_EXPLORER, L"NoRun",
-                        REG_DWORD, &dwValue, sizeof(dwValue));
+            SET_VALUE(HKEY_CURRENT_USER, 0);
+            SET_VALUE(HKEY_LOCAL_MACHINE, 1);
             break;
         case 6:
-            dwValue = 1;
-            SHSetValueW(HKEY_LOCAL_MACHINE, REGKEY_POLICIES_EXPLORER, L"NoRun",
-                        REG_DWORD, &dwValue, sizeof(dwValue));
-            dwValue = 0;
-            SHSetValueW(HKEY_LOCAL_MACHINE, REGKEY_POLICIES_EXPLORER, L"NoRun",
-                        REG_DWORD, &dwValue, sizeof(dwValue));
+            SET_VALUE(HKEY_CURRENT_USER, 1);
+            SET_VALUE(HKEY_LOCAL_MACHINE, 0);
             break;
     }
 

--- a/modules/rostests/apitests/shlwapi/SHGetRestriction.c
+++ b/modules/rostests/apitests/shlwapi/SHGetRestriction.c
@@ -1,0 +1,154 @@
+/*
+ * PROJECT:     ReactOS api tests
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Tests for SHGetRestriction
+ * COPYRIGHT:   Copyright 2024 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ */
+
+#include <apitest.h>
+#include <shlwapi.h>
+
+#define REGKEY_POLICIES L"Software\\Microsoft\\Windows\\CurrentVersion\\Policies"
+#define REGKEY_POLICIES_EXPLORER  REGKEY_POLICIES L"\\Explorer"
+
+typedef DWORD (WINAPI *FN_SHGetRestriction)(LPCWSTR lpSubKey, LPCWSTR lpSubName, LPCWSTR lpValue);
+typedef BOOL (WINAPI *FN_SHSettingsChanged)(LPCVOID unused, LPCVOID inpRegKey);
+
+static DWORD
+Candidate_SHGetRestriction(LPCWSTR lpSubKey, LPCWSTR lpSubName, LPCWSTR lpValue)
+{
+    WCHAR szPath[MAX_PATH];
+    DWORD cbValue, dwValue = 0;
+
+    if (!lpSubKey)
+        lpSubKey = REGKEY_POLICIES;
+
+    PathCombineW(szPath, lpSubKey, lpSubName);
+
+    cbValue = sizeof(dwValue);
+    if (SHGetValueW(HKEY_LOCAL_MACHINE, szPath, lpValue, NULL, &dwValue, &cbValue) == ERROR_SUCCESS)
+        return dwValue;
+
+    cbValue = sizeof(dwValue);
+    SHGetValueW(HKEY_CURRENT_USER, szPath, lpValue, NULL, &dwValue, &cbValue);
+    return dwValue;
+}
+
+typedef struct tagTEST_ENTRY
+{
+    LPCWSTR lpSubName;
+    LPCWSTR lpValue;
+} TEST_ENTRY, *PTEST_ENTRY;
+
+static const TEST_ENTRY s_Entries[] =
+{
+    { L"Explorer", L"RosTests1" },
+    { L"Explorer", L"RosTests2" },
+    { L"Explorer", L"ForceActiveDesktopOn" },
+    { L"Explorer", L"NoActiveDesktop" },
+    { L"Explorer", L"NoDisconnect" },
+    { L"Explorer", L"NoRecentDocsHistory" },
+    { L"Explorer", L"NoDriveTypeAutoRun" },
+    { L"System", L"DontDisplayLastUserName" },
+    { L"System", L"ShutdownWithoutLogOn" },
+};
+
+static void
+TEST_DoEntry(const TEST_ENTRY *entry, FN_SHGetRestriction fn2)
+{
+    ok_long(fn2(NULL, entry->lpSubName, entry->lpValue),
+            Candidate_SHGetRestriction(NULL, entry->lpSubName, entry->lpValue));
+}
+
+static void
+TEST_SHGetRestriction_Stage(
+    FN_SHSettingsChanged fn1, FN_SHGetRestriction fn2, INT iStage)
+{
+    size_t iItem;
+    DWORD dwValue;
+
+    trace("Stage #%d\n", iStage);
+
+    switch (iStage)
+    {
+        case 0:
+            SHDeleteValueW(HKEY_CURRENT_USER, REGKEY_POLICIES_EXPLORER, L"RosTests1");
+            SHDeleteValueW(HKEY_LOCAL_MACHINE, REGKEY_POLICIES_EXPLORER, L"RosTests1");
+            break;
+        case 1:
+            dwValue = 0;
+            SHSetValueW(HKEY_CURRENT_USER, REGKEY_POLICIES_EXPLORER, L"RosTests1",
+                        REG_DWORD, &dwValue, sizeof(dwValue));
+            SHDeleteValueW(HKEY_LOCAL_MACHINE, REGKEY_POLICIES_EXPLORER, L"RosTests1");
+            break;
+        case 2:
+            dwValue = 1;
+            SHSetValueW(HKEY_CURRENT_USER, REGKEY_POLICIES_EXPLORER, L"RosTests1",
+                        REG_DWORD, &dwValue, sizeof(dwValue));
+            SHDeleteValueW(HKEY_LOCAL_MACHINE, REGKEY_POLICIES_EXPLORER, L"RosTests1");
+            break;
+        case 3:
+            dwValue = 0;
+            SHDeleteValueW(HKEY_CURRENT_USER, REGKEY_POLICIES_EXPLORER, L"RosTests1");
+            SHSetValueW(HKEY_LOCAL_MACHINE, REGKEY_POLICIES_EXPLORER, L"RosTests1",
+                        REG_DWORD, &dwValue, sizeof(dwValue));
+            break;
+        case 4:
+            dwValue = 1;
+            SHDeleteValueW(HKEY_CURRENT_USER, REGKEY_POLICIES_EXPLORER, L"RosTests1");
+            SHSetValueW(HKEY_LOCAL_MACHINE, REGKEY_POLICIES_EXPLORER, L"RosTests1",
+                        REG_DWORD, &dwValue, sizeof(dwValue));
+            break;
+        case 5:
+            dwValue = 0;
+            SHSetValueW(HKEY_LOCAL_MACHINE, REGKEY_POLICIES_EXPLORER, L"RosTests1",
+                        REG_DWORD, &dwValue, sizeof(dwValue));
+            dwValue = 1;
+            SHSetValueW(HKEY_LOCAL_MACHINE, REGKEY_POLICIES_EXPLORER, L"RosTests1",
+                        REG_DWORD, &dwValue, sizeof(dwValue));
+            break;
+        case 6:
+            dwValue = 1;
+            SHSetValueW(HKEY_LOCAL_MACHINE, REGKEY_POLICIES_EXPLORER, L"RosTests1",
+                        REG_DWORD, &dwValue, sizeof(dwValue));
+            dwValue = 0;
+            SHSetValueW(HKEY_LOCAL_MACHINE, REGKEY_POLICIES_EXPLORER, L"RosTests1",
+                        REG_DWORD, &dwValue, sizeof(dwValue));
+            break;
+    }
+
+    fn1(NULL, NULL);
+
+    for (iItem = 0; iItem < _countof(s_Entries); ++iItem)
+    {
+        TEST_DoEntry(&s_Entries[iItem], fn2);
+    }
+}
+
+START_TEST(SHGetRestriction)
+{
+    HMODULE hSHELL32 = LoadLibraryW(L"shell32.dll");
+    HMODULE hSHLWAPI = LoadLibraryW(L"shlwapi.dll");
+    FN_SHSettingsChanged fn1 = (FN_SHSettingsChanged)GetProcAddress(hSHELL32, MAKEINTRESOURCEA(244));
+    FN_SHGetRestriction fn2 = (FN_SHGetRestriction)GetProcAddress(hSHLWAPI, MAKEINTRESOURCEA(271));
+
+    if (fn2 && fn1)
+    {
+        INT iStage;
+        for (iStage = 0; iStage < 7; ++iStage)
+            TEST_SHGetRestriction_Stage(fn1, fn2, iStage);
+
+        SHDeleteValueW(HKEY_CURRENT_USER, REGKEY_POLICIES_EXPLORER, L"RosTests1");
+        SHDeleteValueW(HKEY_LOCAL_MACHINE, REGKEY_POLICIES_EXPLORER, L"RosTests1");
+    }
+    else
+    {
+        if (!fn1)
+            skip("SHSetingsChanged not found\n");
+        if (!fn2)
+            skip("SHGetRestriction not found\n");
+    }
+
+    FreeLibrary(hSHELL32);
+    FreeLibrary(hSHLWAPI);
+}

--- a/modules/rostests/apitests/shlwapi/SHGetRestriction.c
+++ b/modules/rostests/apitests/shlwapi/SHGetRestriction.c
@@ -44,6 +44,7 @@ static const TEST_ENTRY s_Entries[] =
 {
     { L"Explorer", L"RosTests1" },
     { L"Explorer", L"RosTests2" },
+
     { L"Explorer", L"ForceActiveDesktopOn" },
     { L"Explorer", L"NoActiveDesktop" },
     { L"Explorer", L"NoDisconnect" },

--- a/modules/rostests/apitests/shlwapi/SHGetRestriction.c
+++ b/modules/rostests/apitests/shlwapi/SHGetRestriction.c
@@ -42,9 +42,7 @@ typedef struct tagTEST_ENTRY
 
 static const TEST_ENTRY s_Entries[] =
 {
-    { L"Explorer", L"RosTests1" },
-    { L"Explorer", L"RosTests2" },
-
+    { L"Explorer", L"NoRun" },
     { L"Explorer", L"ForceActiveDesktopOn" },
     { L"Explorer", L"NoActiveDesktop" },
     { L"Explorer", L"NoDisconnect" },
@@ -57,8 +55,10 @@ static const TEST_ENTRY s_Entries[] =
 static void
 TEST_DoEntry(const TEST_ENTRY *entry, FN_SHGetRestriction fn2)
 {
-    ok_long(fn2(NULL, entry->lpSubName, entry->lpValue),
-            Candidate_SHGetRestriction(NULL, entry->lpSubName, entry->lpValue));
+    DWORD value1 = fn2(NULL, entry->lpSubName, entry->lpValue);
+    DWORD value2 = Candidate_SHGetRestriction(NULL, entry->lpSubName, entry->lpValue);
+    trace("%ld vs %ld\n", value1, value2);
+    ok_long(value1, value2);
 }
 
 static void
@@ -75,47 +75,47 @@ TEST_SHGetRestriction_Stage(
     switch (iStage)
     {
         case 0:
-            SHDeleteValueW(HKEY_CURRENT_USER, REGKEY_POLICIES_EXPLORER, L"RosTests1");
-            SHDeleteValueW(HKEY_LOCAL_MACHINE, REGKEY_POLICIES_EXPLORER, L"RosTests1");
+            SHDeleteValueW(HKEY_CURRENT_USER, REGKEY_POLICIES_EXPLORER, L"NoRun");
+            SHDeleteValueW(HKEY_LOCAL_MACHINE, REGKEY_POLICIES_EXPLORER, L"NoRun");
             break;
         case 1:
             dwValue = 0;
-            SHSetValueW(HKEY_CURRENT_USER, REGKEY_POLICIES_EXPLORER, L"RosTests1",
+            SHSetValueW(HKEY_CURRENT_USER, REGKEY_POLICIES_EXPLORER, L"NoRun",
                         REG_DWORD, &dwValue, sizeof(dwValue));
-            SHDeleteValueW(HKEY_LOCAL_MACHINE, REGKEY_POLICIES_EXPLORER, L"RosTests1");
+            SHDeleteValueW(HKEY_LOCAL_MACHINE, REGKEY_POLICIES_EXPLORER, L"NoRun");
             break;
         case 2:
             dwValue = 1;
-            SHSetValueW(HKEY_CURRENT_USER, REGKEY_POLICIES_EXPLORER, L"RosTests1",
+            SHSetValueW(HKEY_CURRENT_USER, REGKEY_POLICIES_EXPLORER, L"NoRun",
                         REG_DWORD, &dwValue, sizeof(dwValue));
-            SHDeleteValueW(HKEY_LOCAL_MACHINE, REGKEY_POLICIES_EXPLORER, L"RosTests1");
+            SHDeleteValueW(HKEY_LOCAL_MACHINE, REGKEY_POLICIES_EXPLORER, L"NoRun");
             break;
         case 3:
             dwValue = 0;
-            SHDeleteValueW(HKEY_CURRENT_USER, REGKEY_POLICIES_EXPLORER, L"RosTests1");
-            SHSetValueW(HKEY_LOCAL_MACHINE, REGKEY_POLICIES_EXPLORER, L"RosTests1",
+            SHDeleteValueW(HKEY_CURRENT_USER, REGKEY_POLICIES_EXPLORER, L"NoRun");
+            SHSetValueW(HKEY_LOCAL_MACHINE, REGKEY_POLICIES_EXPLORER, L"NoRun",
                         REG_DWORD, &dwValue, sizeof(dwValue));
             break;
         case 4:
             dwValue = 1;
-            SHDeleteValueW(HKEY_CURRENT_USER, REGKEY_POLICIES_EXPLORER, L"RosTests1");
-            SHSetValueW(HKEY_LOCAL_MACHINE, REGKEY_POLICIES_EXPLORER, L"RosTests1",
+            SHDeleteValueW(HKEY_CURRENT_USER, REGKEY_POLICIES_EXPLORER, L"NoRun");
+            SHSetValueW(HKEY_LOCAL_MACHINE, REGKEY_POLICIES_EXPLORER, L"NoRun",
                         REG_DWORD, &dwValue, sizeof(dwValue));
             break;
         case 5:
             dwValue = 0;
-            SHSetValueW(HKEY_LOCAL_MACHINE, REGKEY_POLICIES_EXPLORER, L"RosTests1",
+            SHSetValueW(HKEY_LOCAL_MACHINE, REGKEY_POLICIES_EXPLORER, L"NoRun",
                         REG_DWORD, &dwValue, sizeof(dwValue));
             dwValue = 1;
-            SHSetValueW(HKEY_LOCAL_MACHINE, REGKEY_POLICIES_EXPLORER, L"RosTests1",
+            SHSetValueW(HKEY_LOCAL_MACHINE, REGKEY_POLICIES_EXPLORER, L"NoRun",
                         REG_DWORD, &dwValue, sizeof(dwValue));
             break;
         case 6:
             dwValue = 1;
-            SHSetValueW(HKEY_LOCAL_MACHINE, REGKEY_POLICIES_EXPLORER, L"RosTests1",
+            SHSetValueW(HKEY_LOCAL_MACHINE, REGKEY_POLICIES_EXPLORER, L"NoRun",
                         REG_DWORD, &dwValue, sizeof(dwValue));
             dwValue = 0;
-            SHSetValueW(HKEY_LOCAL_MACHINE, REGKEY_POLICIES_EXPLORER, L"RosTests1",
+            SHSetValueW(HKEY_LOCAL_MACHINE, REGKEY_POLICIES_EXPLORER, L"NoRun",
                         REG_DWORD, &dwValue, sizeof(dwValue));
             break;
     }
@@ -141,8 +141,8 @@ START_TEST(SHGetRestriction)
         for (iStage = 0; iStage < 7; ++iStage)
             TEST_SHGetRestriction_Stage(iStage, fn1, fn2);
 
-        SHDeleteValueW(HKEY_CURRENT_USER, REGKEY_POLICIES_EXPLORER, L"RosTests1");
-        SHDeleteValueW(HKEY_LOCAL_MACHINE, REGKEY_POLICIES_EXPLORER, L"RosTests1");
+        SHDeleteValueW(HKEY_CURRENT_USER, REGKEY_POLICIES_EXPLORER, L"NoRun");
+        SHDeleteValueW(HKEY_LOCAL_MACHINE, REGKEY_POLICIES_EXPLORER, L"NoRun");
     }
     else
     {

--- a/modules/rostests/apitests/shlwapi/SHGetRestriction.c
+++ b/modules/rostests/apitests/shlwapi/SHGetRestriction.c
@@ -59,7 +59,7 @@ TEST_DoEntry(const TEST_ENTRY *entry, FN_SHGetRestriction fnSHGetRestriction)
 {
     DWORD value1 = fnSHGetRestriction(NULL, entry->lpSubName, entry->lpValue);
     DWORD value2 = Candidate_SHGetRestriction(NULL, entry->lpSubName, entry->lpValue);
-    trace("%ld vs %ld\n", value1, value2);
+    //trace("%ld vs %ld\n", value1, value2);
     ok_long(value1, value2);
 }
 

--- a/modules/rostests/apitests/shlwapi/SHGetRestriction.c
+++ b/modules/rostests/apitests/shlwapi/SHGetRestriction.c
@@ -136,8 +136,7 @@ START_TEST(SHGetRestriction)
     }
     else
     {
-        if (!fn)
-            skip("SHGetRestriction not found\n");
+        skip("SHGetRestriction not found\n");
     }
 
     FreeLibrary(hSHLWAPI);

--- a/modules/rostests/apitests/shlwapi/SHGetRestriction.c
+++ b/modules/rostests/apitests/shlwapi/SHGetRestriction.c
@@ -48,8 +48,10 @@ static const TEST_ENTRY s_Entries[] =
     { L"Explorer", L"NoDisconnect" },
     { L"Explorer", L"NoRecentDocsHistory" },
     { L"Explorer", L"NoDriveTypeAutoRun" },
+    { L"Explorer", L"NoSimpleStartMenu" },
     { L"System", L"DontDisplayLastUserName" },
-    { L"System", L"ShutdownWithoutLogOn" },
+    { L"System", L"ShutdownWithoutLogon" },
+    { L"System", L"UndockWithoutLogon" },
 };
 
 static void

--- a/modules/rostests/apitests/shlwapi/SHGetRestriction.c
+++ b/modules/rostests/apitests/shlwapi/SHGetRestriction.c
@@ -62,7 +62,9 @@ TEST_DoEntry(const TEST_ENTRY *entry, FN_SHGetRestriction fn2)
 
 static void
 TEST_SHGetRestriction_Stage(
-    FN_SHSettingsChanged fn1, FN_SHGetRestriction fn2, INT iStage)
+    INT iStage,
+    FN_SHSettingsChanged fn1,
+    FN_SHGetRestriction fn2)
 {
     size_t iItem;
     DWORD dwValue;
@@ -132,11 +134,11 @@ START_TEST(SHGetRestriction)
     FN_SHSettingsChanged fn1 = (FN_SHSettingsChanged)GetProcAddress(hSHELL32, MAKEINTRESOURCEA(244));
     FN_SHGetRestriction fn2 = (FN_SHGetRestriction)GetProcAddress(hSHLWAPI, MAKEINTRESOURCEA(271));
 
-    if (fn2 && fn1)
+    if (fn1 && fn2)
     {
         INT iStage;
         for (iStage = 0; iStage < 7; ++iStage)
-            TEST_SHGetRestriction_Stage(fn1, fn2, iStage);
+            TEST_SHGetRestriction_Stage(iStage, fn1, fn2);
 
         SHDeleteValueW(HKEY_CURRENT_USER, REGKEY_POLICIES_EXPLORER, L"RosTests1");
         SHDeleteValueW(HKEY_LOCAL_MACHINE, REGKEY_POLICIES_EXPLORER, L"RosTests1");

--- a/modules/rostests/apitests/shlwapi/SHGetRestriction.c
+++ b/modules/rostests/apitests/shlwapi/SHGetRestriction.c
@@ -55,9 +55,9 @@ static const TEST_ENTRY s_Entries[] =
 };
 
 static void
-TEST_DoEntry(const TEST_ENTRY *entry, FN_SHGetRestriction fn2)
+TEST_DoEntry(const TEST_ENTRY *entry, FN_SHGetRestriction fnSHGetRestriction)
 {
-    DWORD value1 = fn2(NULL, entry->lpSubName, entry->lpValue);
+    DWORD value1 = fnSHGetRestriction(NULL, entry->lpSubName, entry->lpValue);
     DWORD value2 = Candidate_SHGetRestriction(NULL, entry->lpSubName, entry->lpValue);
     trace("%ld vs %ld\n", value1, value2);
     ok_long(value1, value2);
@@ -66,8 +66,8 @@ TEST_DoEntry(const TEST_ENTRY *entry, FN_SHGetRestriction fn2)
 static void
 TEST_SHGetRestriction_Stage(
     INT iStage,
-    FN_SHSettingsChanged fn1,
-    FN_SHGetRestriction fn2)
+    FN_SHSettingsChanged fnSHSettingsChanged,
+    FN_SHGetRestriction fnSHGetRestriction)
 {
     size_t iItem;
     DWORD dwValue;
@@ -122,11 +122,11 @@ TEST_SHGetRestriction_Stage(
             break;
     }
 
-    fn1(NULL, NULL);
+    fnSHSettingsChanged(NULL, NULL);
 
     for (iItem = 0; iItem < _countof(s_Entries); ++iItem)
     {
-        TEST_DoEntry(&s_Entries[iItem], fn2);
+        TEST_DoEntry(&s_Entries[iItem], fnSHGetRestriction);
     }
 }
 
@@ -134,8 +134,11 @@ START_TEST(SHGetRestriction)
 {
     HMODULE hSHELL32 = LoadLibraryW(L"shell32.dll");
     HMODULE hSHLWAPI = LoadLibraryW(L"shlwapi.dll");
-    FN_SHSettingsChanged fn1 = (FN_SHSettingsChanged)GetProcAddress(hSHELL32, MAKEINTRESOURCEA(244));
-    FN_SHGetRestriction fn2 = (FN_SHGetRestriction)GetProcAddress(hSHLWAPI, MAKEINTRESOURCEA(271));
+    FN_SHSettingsChanged fn1;
+    FN_SHGetRestriction fn2;
+
+    fn1 = (FN_SHSettingsChanged)GetProcAddress(hSHELL32, MAKEINTRESOURCEA(244));
+    fn2 = (FN_SHGetRestriction)GetProcAddress(hSHLWAPI, MAKEINTRESOURCEA(271));
 
     if (fn1 && fn2)
     {

--- a/modules/rostests/apitests/shlwapi/SHGetRestriction.c
+++ b/modules/rostests/apitests/shlwapi/SHGetRestriction.c
@@ -131,8 +131,8 @@ START_TEST(SHGetRestriction)
         for (iStage = 0; iStage < 7; ++iStage)
             TEST_SHGetRestriction_Stage(iStage, fn);
 
-        SHDeleteValueW(HKEY_CURRENT_USER, REGKEY_POLICIES_EXPLORER, L"NoRun");
-        SHDeleteValueW(HKEY_LOCAL_MACHINE, REGKEY_POLICIES_EXPLORER, L"NoRun");
+        DELETE_VALUE(HKEY_CURRENT_USER);
+        DELETE_VALUE(HKEY_LOCAL_MACHINE);
     }
     else
     {

--- a/modules/rostests/apitests/shlwapi/testlist.c
+++ b/modules/rostests/apitests/shlwapi/testlist.c
@@ -11,6 +11,7 @@ extern void func_SHAreIconsEqual(void);
 extern void func_SHLoadIndirectString(void);
 extern void func_SHLoadRegUIString(void);
 extern void func_SHPropertyBag(void);
+extern void func_SHGetRestriction(void);
 extern void func_StrFormatByteSizeW(void);
 
 const struct test winetest_testlist[] =
@@ -25,6 +26,7 @@ const struct test winetest_testlist[] =
     { "SHLoadIndirectString", func_SHLoadIndirectString },
     { "SHLoadRegUIString", func_SHLoadRegUIString },
     { "SHPropertyBag", func_SHPropertyBag },
+    { "SHGetRestriction", func_SHGetRestriction },
     { "StrFormatByteSizeW", func_StrFormatByteSizeW },
     { 0, 0 }
 };

--- a/modules/rostests/apitests/shlwapi/testlist.c
+++ b/modules/rostests/apitests/shlwapi/testlist.c
@@ -8,10 +8,10 @@ extern void func_isuncpathservershare(void);
 extern void func_PathUnExpandEnvStrings(void);
 extern void func_PathUnExpandEnvStringsForUser(void);
 extern void func_SHAreIconsEqual(void);
+extern void func_SHGetRestriction(void);
 extern void func_SHLoadIndirectString(void);
 extern void func_SHLoadRegUIString(void);
 extern void func_SHPropertyBag(void);
-extern void func_SHGetRestriction(void);
 extern void func_StrFormatByteSizeW(void);
 
 const struct test winetest_testlist[] =
@@ -23,10 +23,10 @@ const struct test winetest_testlist[] =
     { "PathUnExpandEnvStrings", func_PathUnExpandEnvStrings },
     { "PathUnExpandEnvStringsForUser", func_PathUnExpandEnvStringsForUser },
     { "SHAreIconsEqual", func_SHAreIconsEqual },
+    { "SHGetRestriction", func_SHGetRestriction },
     { "SHLoadIndirectString", func_SHLoadIndirectString },
     { "SHLoadRegUIString", func_SHLoadRegUIString },
     { "SHPropertyBag", func_SHPropertyBag },
-    { "SHGetRestriction", func_SHGetRestriction },
     { "StrFormatByteSizeW", func_StrFormatByteSizeW },
     { 0, 0 }
 };


### PR DESCRIPTION
## Purpose
I have a plan to implement `shell32!SHRestricted` correctly.
JIRA issue: [CORE-11515](https://jira.reactos.org/browse/CORE-11515)

## Proposed changes

In the testcase:
- Get procedure `SHGetRestriction` from `shlwapi.dll`.
- Call `SHGetRestriction` to test and check the results. 

## TODO

- [x] Do tests.

## Comparison

WinXP:
![winxp](https://github.com/reactos/reactos/assets/2107452/c2684fd1-9629-49ca-822d-d4f68869f92f)
Successful.

Win2k3:
![Win2k3](https://github.com/reactos/reactos/assets/2107452/2c0277eb-1aa2-4c52-9599-c4405c169319)
Successful.

Win10 x64:
![win10](https://github.com/reactos/reactos/assets/2107452/c4c4ea51-c7c0-4e8f-94a2-aed253850d6b)
Successful.