### PR TITLE
[SHELL32_APITEST] Add SHRestricted testcase

### DIFF
--- a/modules/rostests/apitests/shell32/CMakeLists.txt
+++ b/modules/rostests/apitests/shell32/CMakeLists.txt
@@ -28,6 +28,7 @@ list(APPEND SOURCE
     SHCreateFileDataObject.cpp
     SHCreateFileExtractIconW.cpp
     SHParseDisplayName.cpp
+    SHRestricted.cpp
     She.cpp
     ShellExecCmdLine.cpp
     ShellExecuteEx.cpp

--- a/modules/rostests/apitests/shell32/SHRestricted.cpp
+++ b/modules/rostests/apitests/shell32/SHRestricted.cpp
@@ -1,0 +1,102 @@
+/*
+ * PROJECT:     ReactOS API tests
+ * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
+ * PURPOSE:     Test for SHRestricted
+ * COPYRIGHT:   Copyright 2024 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
+ */
+
+#include "shelltest.h"
+#include <versionhelpers.h>
+
+#define REGKEY_POLICIES L"Software\\Microsoft\\Windows\\CurrentVersion\\Policies"
+#define REGKEY_POLICIES_EXPLORER REGKEY_POLICIES L"\\Explorer"
+
+typedef DWORD (WINAPI *FN_SHRestricted)(RESTRICTIONS rest);
+typedef BOOL (WINAPI *FN_SHSettingsChanged)(LPCVOID unused, LPCVOID inpRegKey);
+
+#define DELETE_VALUE(hBaseKey) \
+    SHDeleteValueW((hBaseKey), REGKEY_POLICIES_EXPLORER, L"NoRun")
+
+#define SET_VALUE(hBaseKey, value) do { \
+    dwValue = (value); \
+    SHSetValueW((hBaseKey), REGKEY_POLICIES_EXPLORER, L"NoRun", \
+                REG_DWORD, &dwValue, sizeof(dwValue)); \
+} while (0)
+
+static VOID
+TEST_SHRestricted(FN_SHRestricted fn1, FN_SHSettingsChanged fn2)
+{
+    DWORD dwValue;
+
+    DELETE_VALUE(HKEY_CURRENT_USER);
+    DELETE_VALUE(HKEY_LOCAL_MACHINE);
+
+    fn2(NULL, NULL);
+    ok_long(fn1(REST_NORUN), 0);
+
+    SET_VALUE(HKEY_CURRENT_USER, 0);
+    DELETE_VALUE(HKEY_LOCAL_MACHINE);
+
+    fn2(NULL, NULL);
+    ok_long(fn1(REST_NORUN), 0);
+
+    SET_VALUE(HKEY_CURRENT_USER, 1);
+    DELETE_VALUE(HKEY_LOCAL_MACHINE);
+
+    fn2(NULL, NULL);
+    ok_long(fn1(REST_NORUN), 1);
+
+    DELETE_VALUE(HKEY_CURRENT_USER);
+    SET_VALUE(HKEY_LOCAL_MACHINE, 0);
+
+    fn2(NULL, NULL);
+    ok_long(fn1(REST_NORUN), 0);
+
+    DELETE_VALUE(HKEY_CURRENT_USER);
+    SET_VALUE(HKEY_LOCAL_MACHINE, 1);
+
+    fn2(NULL, NULL);
+    ok_long(fn1(REST_NORUN), 1);
+
+    SET_VALUE(HKEY_CURRENT_USER, 2);
+    SET_VALUE(HKEY_LOCAL_MACHINE, 1);
+
+    fn2(NULL, NULL);
+    ok_long(fn1(REST_NORUN), 1);
+
+    DELETE_VALUE(HKEY_CURRENT_USER);
+    DELETE_VALUE(HKEY_LOCAL_MACHINE);
+
+    fn2(NULL, NULL);
+    ok_long(fn1(REST_NORUN), 0);
+}
+
+START_TEST(SHRestricted)
+{
+    if (IsWindowsVistaOrGreater())
+    {
+        skip("Vista+");
+        return;
+    }
+
+    HMODULE hSHELL32 = LoadLibraryW(L"shell32.dll");
+    FN_SHRestricted fn1;
+    FN_SHSettingsChanged fn2;
+
+    fn1 = (FN_SHRestricted)GetProcAddress(hSHELL32, MAKEINTRESOURCEA(100));
+    fn2 = (FN_SHSettingsChanged)GetProcAddress(hSHELL32, MAKEINTRESOURCEA(244));
+
+    if (fn1 && fn2)
+    {
+        TEST_SHRestricted(fn1, fn2);
+    }
+    else
+    {
+        if (!fn1)
+            skip("SHRestricted not found\n");
+        if (!fn2)
+            skip("SHSettingsChanged not found\n");
+    }
+
+    FreeLibrary(hSHELL32);
+}

--- a/modules/rostests/apitests/shell32/testlist.c
+++ b/modules/rostests/apitests/shell32/testlist.c
@@ -38,6 +38,7 @@ extern void func_ShellState(void);
 extern void func_SHGetAttributesFromDataObject(void);
 extern void func_SHLimitInputEdit(void);
 extern void func_SHParseDisplayName(void);
+extern void func_SHRestricted(void);
 
 const struct test winetest_testlist[] =
 {
@@ -76,5 +77,7 @@ const struct test winetest_testlist[] =
     { "SHGetAttributesFromDataObject", func_SHGetAttributesFromDataObject },
     { "SHLimitInputEdit", func_SHLimitInputEdit },
     { "SHParseDisplayName", func_SHParseDisplayName },
+    { "SHRestricted", func_SHRestricted },
+
     { 0, 0 }
 };


### PR DESCRIPTION
## Purpose
I have a plan to implement `shell32!SHRestricted` correctly.
JIRA issue: [CORE-11515](https://jira.reactos.org/browse/CORE-11515)

## Proposed changes

- Get `SHRestricted` and `SHSettingsChanged` procedures from `shell32.dll`.
- Use them and check the results.

## TODO

- [x] Do tests.

## Screenshots

WinXP:
![winxp](https://github.com/reactos/reactos/assets/2107452/cbb2a523-799a-45a0-acfe-fafe86118a8f)
Successful.

Win2k3:
![win2k3](https://github.com/reactos/reactos/assets/2107452/4811a276-407d-46bb-9ea8-dffeb0648266)
Successful.

Win10 x64:
![win10](https://github.com/reactos/reactos/assets/2107452/d7405cff-dc1e-4f6d-bf4c-a0a92295196f)
Skipped.