### PR TITLE
[CMD] Enable Ctrl+H (^H) as backspace

### DIFF
--- a/base/shell/cmd/cmdinput.c
+++ b/base/shell/cmd/cmdinput.c
@@ -232,7 +232,6 @@ BOOL ReadCommand(LPTSTR str, INT maxlen)
                         ConOutPrintf (_T("%s"), str);
                         GetCursorXY (&curx, &cury);
                         //bContinue=TRUE;
-                        break;
                     }
 #endif /*FEATURE_HISTORY*/
                     break;

--- a/base/shell/cmd/cmdinput.c
+++ b/base/shell/cmd/cmdinput.c
@@ -251,7 +251,6 @@ BOOL ReadCommand(LPTSTR str, INT maxlen)
                         str[charcount] = _T('\0');
                         ConOutChar (_T('\n'));
                         bReturn = TRUE;
-                        break;
                     }
                     break;
 

--- a/base/shell/cmd/cmdinput.c
+++ b/base/shell/cmd/cmdinput.c
@@ -220,6 +220,7 @@ BOOL ReadCommand(LPTSTR str, INT maxlen)
                         //bContinue=TRUE;
                         break;
                     }
+                    break;
 
                 case _T('D'):
                     /* delete current history entry */
@@ -235,6 +236,7 @@ BOOL ReadCommand(LPTSTR str, INT maxlen)
                         break;
                     }
 #endif /*FEATURE_HISTORY*/
+                    break;
 
                 case _T('M'):
                     /* ^M does the same as return */
@@ -253,6 +255,16 @@ BOOL ReadCommand(LPTSTR str, INT maxlen)
                         bReturn = TRUE;
                         break;
                     }
+                    break;
+
+                case _T('H'):
+                    /* ^H does the same as VK_BACK */
+                    if (dwControlKeyState & (LEFT_CTRL_PRESSED | RIGHT_CTRL_PRESSED))
+                    {
+                        bCharInput = FALSE;
+                        goto DoBackSpace;
+                    }
+                    break;
             }
         }
 
@@ -261,6 +273,7 @@ BOOL ReadCommand(LPTSTR str, INT maxlen)
         switch (ir.Event.KeyEvent.wVirtualKeyCode)
         {
             case VK_BACK:
+            DoBackSpace:
                 /* <BACKSPACE> - delete character to left of cursor */
                 if (current > 0 && charcount > 0)
                 {

--- a/base/shell/cmd/cmdinput.c
+++ b/base/shell/cmd/cmdinput.c
@@ -218,7 +218,6 @@ BOOL ReadCommand(LPTSTR str, INT maxlen)
                         curx = orgx;
                         cury = orgy;
                         //bContinue=TRUE;
-                        break;
                     }
                     break;
 

--- a/base/shell/cmd/cmdinput.c
+++ b/base/shell/cmd/cmdinput.c
@@ -257,8 +257,7 @@ BOOL ReadCommand(LPTSTR str, INT maxlen)
                     }
                     break;
 
-                case _T('H'):
-                    /* ^H does the same as VK_BACK */
+                case _T('H'): /* ^H does the same as VK_BACK */
                     if (dwControlKeyState & (LEFT_CTRL_PRESSED | RIGHT_CTRL_PRESSED))
                     {
                         bCharInput = FALSE;

--- a/base/shell/cmd/cmdinput.c
+++ b/base/shell/cmd/cmdinput.c
@@ -233,8 +233,8 @@ BOOL ReadCommand(LPTSTR str, INT maxlen)
                         GetCursorXY (&curx, &cury);
                         //bContinue=TRUE;
                     }
-#endif /*FEATURE_HISTORY*/
                     break;
+#endif /*FEATURE_HISTORY*/
 
                 case _T('M'):
                     /* ^M does the same as return */


### PR DESCRIPTION
## Purpose

`Ctrl+H` should pretend like `BackSpace` key on Command Prompt.
JIRA issue: [CORE-5702](https://jira.reactos.org/browse/CORE-5702)

## Proposed changes

- Add `Ctrl+H`  action in `ReadCommand` function.

## TODO

- [x] Do tests.

## Movie

AFTER:
https://github.com/reactos/reactos/assets/2107452/0e61cc84-af3d-47fe-9cea-94ba255f2814