### PR TITLE
[NTDLL][NTDLL_APITEST] Add LdrLoadDll testcase

### DIFF
--- a/dll/ntdll/ldr/ldrutils.c
+++ b/dll/ntdll/ldr/ldrutils.c
@@ -2454,30 +2454,24 @@ LdrpLoadDll(IN BOOLEAN Redirected,
     RtlCopyUnicodeString(&RawDllName, DllName);
 
     /* Convert forward slashes to backslashes */
+    /* Find the extension, if present */
     endptr = &RawDllName.Buffer[RawDllName.Length / sizeof(WCHAR)];
+    GotExtension = FALSE;
     for (p = RawDllName.Buffer; p != endptr; ++p)
     {
-        if (*p == L'/')
-            *p = L'\\';
-    }
-
-    /* Find the extension, if present */
-    GotExtension = FALSE;
-    if (RawDllName.Length > 0)
-    {
-        p = RawDllName.Buffer + RawDllName.Length / sizeof(WCHAR) - 1;
-        while (RawDllName.Buffer <= p)
+        c = *p;
+        if (c == L'\\')
         {
-            c = *p--;
-            if (c == L'.')
-            {
-                GotExtension = TRUE;
-                break;
-            }
-            else if (c == L'\\')
-            {
-                break;
-            }
+            GotExtension = FALSE;
+        }
+        else if (c == L'.')
+        {
+            GotExtension = TRUE;
+        }
+        else if (c == L'/')
+        {
+            *p = L'\\';
+            GotExtension = FALSE;
         }
     }
 

--- a/dll/ntdll/ldr/ldrutils.c
+++ b/dll/ntdll/ldr/ldrutils.c
@@ -2442,9 +2442,9 @@ LdrpLoadDll(IN BOOLEAN Redirected,
     PPEB Peb = NtCurrentPeb();
     NTSTATUS Status = STATUS_SUCCESS;
     const WCHAR *p;
-    PWSTR pch, endptr;
     BOOLEAN GotExtension;
-    WCHAR c, NameBuffer[MAX_PATH + 6];
+    WCHAR c;
+    WCHAR NameBuffer[MAX_PATH + 6];
     UNICODE_STRING RawDllName;
     PLDR_DATA_TABLE_ENTRY LdrEntry;
     BOOLEAN InInit = LdrpInLdrInit;
@@ -2466,18 +2466,10 @@ LdrpLoadDll(IN BOOLEAN Redirected,
             GotExtension = TRUE;
             break;
         }
-        else if (c == L'\\' || c == L'/')
+        else if (c == L'\\')
         {
             break;
         }
-    }
-
-    /* Convert forward slashes to backslashes */
-    endptr = &RawDllName.Buffer[RawDllName.Length / sizeof(WCHAR)];
-    for (pch = RawDllName.Buffer; pch != endptr; ++pch)
-    {
-        if (*pch == L'/')
-            *pch == L'\\';
     }
 
     /* If no extension was found, add the default extension */

--- a/dll/ntdll/ldr/ldrutils.c
+++ b/dll/ntdll/ldr/ldrutils.c
@@ -2441,7 +2441,8 @@ LdrpLoadDll(IN BOOLEAN Redirected,
 {
     PPEB Peb = NtCurrentPeb();
     NTSTATUS Status = STATUS_SUCCESS;
-    PWSTR p, endptr;
+    const WCHAR *p;
+    PWSTR pch, endptr;
     BOOLEAN GotExtension;
     WCHAR c, NameBuffer[MAX_PATH + 6];
     UNICODE_STRING RawDllName;
@@ -2454,7 +2455,7 @@ LdrpLoadDll(IN BOOLEAN Redirected,
     RtlCopyUnicodeString(&RawDllName, DllName);
 
     /* Find the extension, if present */
-    /* NOTE: Access violation is expected here in some cases */
+    /* NOTE: Access violation is expected here in some cases (Buffer[-1]) */
     p = DllName->Buffer + DllName->Length / sizeof(WCHAR) - 1;
     GotExtension = FALSE;
     while (p >= DllName->Buffer)
@@ -2473,10 +2474,10 @@ LdrpLoadDll(IN BOOLEAN Redirected,
 
     /* Convert forward slashes to backslashes */
     endptr = &RawDllName.Buffer[RawDllName.Length / sizeof(WCHAR)];
-    for (p = RawDllName.Buffer; p != endptr; ++p)
+    for (pch = RawDllName.Buffer; pch != endptr; ++pch)
     {
-        if (*p == L'/')
-            *p == L'\\';
+        if (*pch == L'/')
+            *pch == L'\\';
     }
 
     /* If no extension was found, add the default extension */

--- a/dll/ntdll/ldr/ldrutils.c
+++ b/dll/ntdll/ldr/ldrutils.c
@@ -2441,11 +2441,9 @@ LdrpLoadDll(IN BOOLEAN Redirected,
 {
     PPEB Peb = NtCurrentPeb();
     NTSTATUS Status = STATUS_SUCCESS;
-    PCWSTR p;
     PWSTR pch, endptr;
     BOOLEAN GotExtension;
-    WCHAR c;
-    WCHAR NameBuffer[MAX_PATH + 6];
+    WCHAR ch, NameBuffer[MAX_PATH + 6];
     UNICODE_STRING RawDllName;
     PLDR_DATA_TABLE_ENTRY LdrEntry;
     BOOLEAN InInit = LdrpInLdrInit;
@@ -2465,18 +2463,18 @@ LdrpLoadDll(IN BOOLEAN Redirected,
 
     /* Find the extension, if present */
     GotExtension = FALSE;
-    if (DllName->Length > 0)
+    if (RawDllName.Length > 0)
     {
-        p = DllName->Buffer + DllName->Length / sizeof(WCHAR) - 1;
-        while (p >= DllName->Buffer)
+        pch = RawDllName.Buffer + RawDllName.Length / sizeof(WCHAR) - 1;
+        while (RawDllName.Buffer <= pch)
         {
-            c = *p--;
-            if (c == L'.')
+            ch = *pch--;
+            if (ch == L'.')
             {
                 GotExtension = TRUE;
                 break;
             }
-            else if (c == L'\\')
+            else if (ch == L'\\')
             {
                 break;
             }

--- a/dll/ntdll/ldr/ldrutils.c
+++ b/dll/ntdll/ldr/ldrutils.c
@@ -2456,7 +2456,7 @@ LdrpLoadDll(IN BOOLEAN Redirected,
     RtlCopyUnicodeString(&RawDllName, DllName);
 
     /* Convert forward slashes to backslashes */
-    endptr = &RawDllName.Buffer[RawDllName.Length / sizeof(WCHAR) - 1];
+    endptr = &RawDllName.Buffer[RawDllName.Length / sizeof(WCHAR)];
     for (pch = RawDllName.Buffer; pch != endptr; ++pch)
     {
         if (*pch == L'/')
@@ -2464,19 +2464,22 @@ LdrpLoadDll(IN BOOLEAN Redirected,
     }
 
     /* Find the extension, if present */
-    p = DllName->Buffer + DllName->Length / sizeof(WCHAR) - 1;
     GotExtension = FALSE;
-    while (p >= DllName->Buffer)
+    if (DllName->Length > 0)
     {
-        c = *p--;
-        if (c == L'.')
+        p = DllName->Buffer + DllName->Length / sizeof(WCHAR) - 1;
+        while (p >= DllName->Buffer)
         {
-            GotExtension = TRUE;
-            break;
-        }
-        else if (c == L'\\')
-        {
-            break;
+            c = *p--;
+            if (c == L'.')
+            {
+                GotExtension = TRUE;
+                break;
+            }
+            else if (c == L'\\')
+            {
+                break;
+            }
         }
     }
 

--- a/dll/ntdll/ldr/ldrutils.c
+++ b/dll/ntdll/ldr/ldrutils.c
@@ -2441,9 +2441,9 @@ LdrpLoadDll(IN BOOLEAN Redirected,
 {
     PPEB Peb = NtCurrentPeb();
     NTSTATUS Status = STATUS_SUCCESS;
-    PWSTR pch, endptr;
+    PWSTR p, endptr;
     BOOLEAN GotExtension;
-    WCHAR ch, NameBuffer[MAX_PATH + 6];
+    WCHAR c, NameBuffer[MAX_PATH + 6];
     UNICODE_STRING RawDllName;
     PLDR_DATA_TABLE_ENTRY LdrEntry;
     BOOLEAN InInit = LdrpInLdrInit;
@@ -2455,26 +2455,26 @@ LdrpLoadDll(IN BOOLEAN Redirected,
 
     /* Convert forward slashes to backslashes */
     endptr = &RawDllName.Buffer[RawDllName.Length / sizeof(WCHAR)];
-    for (pch = RawDllName.Buffer; pch != endptr; ++pch)
+    for (p = RawDllName.Buffer; p != endptr; ++p)
     {
-        if (*pch == L'/')
-            *pch = L'\\';
+        if (*p == L'/')
+            *p = L'\\';
     }
 
     /* Find the extension, if present */
     GotExtension = FALSE;
     if (RawDllName.Length > 0)
     {
-        pch = RawDllName.Buffer + RawDllName.Length / sizeof(WCHAR) - 1;
-        while (RawDllName.Buffer <= pch)
+        p = RawDllName.Buffer + RawDllName.Length / sizeof(WCHAR) - 1;
+        while (RawDllName.Buffer <= p)
         {
-            ch = *pch--;
-            if (ch == L'.')
+            c = *p--;
+            if (c == L'.')
             {
                 GotExtension = TRUE;
                 break;
             }
-            else if (ch == L'\\')
+            else if (c == L'\\')
             {
                 break;
             }

--- a/dll/ntdll/ldr/ldrutils.c
+++ b/dll/ntdll/ldr/ldrutils.c
@@ -2448,11 +2448,21 @@ LdrpLoadDll(IN BOOLEAN Redirected,
     UNICODE_STRING RawDllName;
     PLDR_DATA_TABLE_ENTRY LdrEntry;
     BOOLEAN InInit = LdrpInLdrInit;
+    SIZE_T ich, cch;
 
     /* Save the Raw DLL Name */
     if (DllName->Length >= sizeof(NameBuffer)) return STATUS_NAME_TOO_LONG;
     RtlInitEmptyUnicodeString(&RawDllName, NameBuffer, sizeof(NameBuffer));
     RtlCopyUnicodeString(&RawDllName, DllName);
+
+    /* Convert backslashes to forward slashes */
+    p = RawDllName.Buffer;
+    cch = RawDllName.Length / sizeof(WCHAR) - 1;
+    for (ich = 0; ich < cch; ++ich)
+    {
+        if (*p == L'/')
+            *p = L'\\';
+    }
 
     /* Find the extension, if present */
     p = DllName->Buffer + DllName->Length / sizeof(WCHAR) - 1;

--- a/dll/ntdll/ldr/ldrutils.c
+++ b/dll/ntdll/ldr/ldrutils.c
@@ -2441,27 +2441,26 @@ LdrpLoadDll(IN BOOLEAN Redirected,
 {
     PPEB Peb = NtCurrentPeb();
     NTSTATUS Status = STATUS_SUCCESS;
-    const WCHAR *p;
+    PCWSTR p;
+    PWSTR pch, endptr;
     BOOLEAN GotExtension;
     WCHAR c;
     WCHAR NameBuffer[MAX_PATH + 6];
     UNICODE_STRING RawDllName;
     PLDR_DATA_TABLE_ENTRY LdrEntry;
     BOOLEAN InInit = LdrpInLdrInit;
-    SIZE_T ich, cch;
 
     /* Save the Raw DLL Name */
     if (DllName->Length >= sizeof(NameBuffer)) return STATUS_NAME_TOO_LONG;
     RtlInitEmptyUnicodeString(&RawDllName, NameBuffer, sizeof(NameBuffer));
     RtlCopyUnicodeString(&RawDllName, DllName);
 
-    /* Convert backslashes to forward slashes */
-    p = RawDllName.Buffer;
-    cch = RawDllName.Length / sizeof(WCHAR) - 1;
-    for (ich = 0; ich < cch; ++ich)
+    /* Convert forward slashes to backslashes */
+    endptr = &RawDllName.Buffer[RawDllName.Length / sizeof(WCHAR) - 1];
+    for (pch = RawDllName.Buffer; pch != endptr; ++pch)
     {
-        if (*p == L'/')
-            *p = L'\\';
+        if (*pch == L'/')
+            *pch = L'\\';
     }
 
     /* Find the extension, if present */

--- a/modules/rostests/apitests/ntdll/CMakeLists.txt
+++ b/modules/rostests/apitests/ntdll/CMakeLists.txt
@@ -7,6 +7,7 @@ spec2def(ntdll_apitest.exe ntdll_apitest.spec)
 
 list(APPEND SOURCE
     LdrEnumResources.c
+    LdrLoadDll.c
     load_notifications.c
     locale.c
     NtAcceptConnectPort.c

--- a/modules/rostests/apitests/ntdll/LdrLoadDll.c
+++ b/modules/rostests/apitests/ntdll/LdrLoadDll.c
@@ -148,7 +148,6 @@ START_TEST(LdrLoadDll)
     EndSeh(STATUS_SUCCESS);
 
     StringCchPrintfW(szPath, _countof(szPath), L"%s\\advapi32.dll", szSysDir);
-
     for (pch = szPath; *pch != UNICODE_NULL; ++pch)
     {
         if (*pch == L'\\')

--- a/modules/rostests/apitests/ntdll/LdrLoadDll.c
+++ b/modules/rostests/apitests/ntdll/LdrLoadDll.c
@@ -179,6 +179,7 @@ START_TEST(LdrLoadDll)
     ok(BaseAddress != NULL, "BaseAddress was NULL\n");
 
     /* Test with only forward slashes in path; with file extension */
+    /* Test with only forward slashes in path; with file extension */
     StringCchPrintfW(szPath, _countof(szPath), L"%s\\advapi32.dll", szSysDir);
     for (pch = szPath; *pch != UNICODE_NULL; ++pch)
     {

--- a/modules/rostests/apitests/ntdll/LdrLoadDll.c
+++ b/modules/rostests/apitests/ntdll/LdrLoadDll.c
@@ -147,6 +147,7 @@ START_TEST(LdrLoadDll)
             LdrUnloadDll(BaseAddress);
     EndSeh(STATUS_SUCCESS);
 
+    /* Test with only forward slashes in path; with file extension */
     StringCchPrintfW(szPath, _countof(szPath), L"%s\\advapi32.dll", szSysDir);
     for (pch = szPath; *pch != UNICODE_NULL; ++pch)
     {

--- a/modules/rostests/apitests/ntdll/LdrLoadDll.c
+++ b/modules/rostests/apitests/ntdll/LdrLoadDll.c
@@ -100,6 +100,7 @@ START_TEST(LdrLoadDll)
             LdrUnloadDll(BaseAddress);
     EndSeh(STATUS_SUCCESS);
 
+    /* Test with only backslashes in path; with file extension */
     StringCchPrintfW(szPath, _countof(szPath), L"%s\\advapi32.dll", szSysDir);
     RtlInitUnicodeString(&DllName, szPath);
     StartSeh()

--- a/modules/rostests/apitests/ntdll/LdrLoadDll.c
+++ b/modules/rostests/apitests/ntdll/LdrLoadDll.c
@@ -130,6 +130,7 @@ START_TEST(LdrLoadDll)
     ok_ntstatus(Status, STATUS_SUCCESS);
     ok(BaseAddress != NULL, "BaseAddress was NULL\n");
 
+    /* Test with one forward slash in path; no file extension */
     StringCchPrintfW(szPath, _countof(szPath), L"%s/advapi32", szSysDir);
     RtlInitUnicodeString(&DllName, szPath);
     Status = 0xDEADFACE;

--- a/modules/rostests/apitests/ntdll/LdrLoadDll.c
+++ b/modules/rostests/apitests/ntdll/LdrLoadDll.c
@@ -146,7 +146,6 @@ START_TEST(LdrLoadDll)
 
     /* Test with one forward slash in path; with file extension */
     StringCchPrintfW(szPath, _countof(szPath), L"%s/advapi32.dll", szSysDir);
-
     RtlInitUnicodeString(&DllName, szPath);
     Status = 0xDEADFACE;
     BaseAddress = InvalidPointer;

--- a/modules/rostests/apitests/ntdll/LdrLoadDll.c
+++ b/modules/rostests/apitests/ntdll/LdrLoadDll.c
@@ -111,7 +111,6 @@ START_TEST(LdrLoadDll)
     EndSeh(STATUS_SUCCESS);
 
     StringCchPrintfW(szPath, _countof(szPath), L"%s/advapi32", szSysDir);
-
     RtlInitUnicodeString(&DllName, szPath);
     StartSeh()
         Status = LdrLoadDll(szWinDir, NULL, &DllName, &BaseAddress);

--- a/modules/rostests/apitests/ntdll/LdrLoadDll.c
+++ b/modules/rostests/apitests/ntdll/LdrLoadDll.c
@@ -7,7 +7,6 @@
  */
 
 #include "precomp.h"
-#include <ntstrsafe.h>
 
 /*
 
@@ -66,7 +65,7 @@ START_TEST(LdrLoadDll)
         Status = LdrLoadDll(L"\\SystemRoot\\System32", NULL, &DllName, NULL);
     EndSeh(STATUS_ACCESS_VIOLATION);
 
-    RtlStringCchPrintfW(szPath, _countof(szPath), L"%s\\advapi32", szSysDir);
+    StringCchPrintfW(szPath, _countof(szPath), L"%s\\advapi32", szSysDir);
 
     RtlInitUnicodeString(&DllName, szPath);
     StartSeh()
@@ -75,7 +74,7 @@ START_TEST(LdrLoadDll)
         if (NT_SUCCESS(Status)) LdrUnloadDll(BaseAddress);
     EndSeh(STATUS_SUCCESS);
 
-    RtlStringCchPrintfW(szPath, _countof(szPath), L"%s/advapi32", szSysDir);
+    StringCchPrintfW(szPath, _countof(szPath), L"%s/advapi32", szSysDir);
 
     RtlInitUnicodeString(&DllName, szPath);
     StartSeh()
@@ -84,7 +83,7 @@ START_TEST(LdrLoadDll)
         if (NT_SUCCESS(Status)) LdrUnloadDll(BaseAddress);
     EndSeh(STATUS_SUCCESS);
 
-    RtlStringCchPrintfW(szPath, _countof(szPath), L"%s\\advapi32", szSysDir);
+    StringCchPrintfW(szPath, _countof(szPath), L"%s\\advapi32", szSysDir);
 
     for (pch = szPath; *pch != UNICODE_NULL; ++pch)
     {

--- a/modules/rostests/apitests/ntdll/LdrLoadDll.c
+++ b/modules/rostests/apitests/ntdll/LdrLoadDll.c
@@ -132,7 +132,6 @@ START_TEST(LdrLoadDll)
     EndSeh(STATUS_SUCCESS);
 
     StringCchPrintfW(szPath, _countof(szPath), L"%s\\advapi32", szSysDir);
-
     for (pch = szPath; *pch != UNICODE_NULL; ++pch)
     {
         if (*pch == L'\\')

--- a/modules/rostests/apitests/ntdll/LdrLoadDll.c
+++ b/modules/rostests/apitests/ntdll/LdrLoadDll.c
@@ -90,6 +90,7 @@ START_TEST(LdrLoadDll)
         Status = LdrLoadDll(L"\\SystemRoot\\System32", NULL, &DllName, NULL);
     EndSeh(STATUS_ACCESS_VIOLATION);
 
+    /* Test with only backslashes in path; no file extension */
     StringCchPrintfW(szPath, _countof(szPath), L"%s\\advapi32", szSysDir);
     RtlInitUnicodeString(&DllName, szPath);
     StartSeh()

--- a/modules/rostests/apitests/ntdll/LdrLoadDll.c
+++ b/modules/rostests/apitests/ntdll/LdrLoadDll.c
@@ -37,98 +37,126 @@ START_TEST(LdrLoadDll)
     StartSeh()
         Status = LdrLoadDll(NULL, NULL, &DllName, NULL);
     EndSeh(STATUS_ACCESS_VIOLATION);
-    ok_long(Status, 0xDEADFACE);
+    ok_ntstatus(Status, 0xDEADFACE);
 
     Status = 0xDEADFACE;
     BaseAddress = InvalidPointer;
     StartSeh()
         Status = LdrLoadDll(NULL, NULL, &DllName, &BaseAddress);
     EndSeh(STATUS_ACCESS_VIOLATION);
-    ok_long(Status, 0xDEADFACE);
+    ok_ntstatus(Status, 0xDEADFACE);
     ok_ptr(BaseAddress, InvalidPointer);
 
     Status = 0xDEADFACE;
     StartSeh()
         Status = LdrLoadDll(L"", NULL, &DllName, NULL);
     EndSeh(STATUS_ACCESS_VIOLATION);
-    ok_long(Status, 0xDEADFACE);
+    ok_ntstatus(Status, 0xDEADFACE);
 
     Status = 0xDEADFACE;
     BaseAddress = InvalidPointer;
     StartSeh()
         Status = LdrLoadDll(L"", NULL, &DllName, &BaseAddress);
     EndSeh(STATUS_ACCESS_VIOLATION);
-    ok_long(Status, 0xDEADFACE);
+    ok_ntstatus(Status, 0xDEADFACE);
     ok_ptr(BaseAddress, InvalidPointer);
 
     RtlInitUnicodeString(&DllName, L"advapi32.dll");
 
+    Status = 0xDEADFACE;
+    BaseAddress = InvalidPointer;
     StartSeh()
         Status = LdrLoadDll(NULL, NULL, &DllName, NULL);
         if (NT_SUCCESS(Status))
             LdrUnloadDll(BaseAddress);
     EndSeh(STATUS_ACCESS_VIOLATION);
+    ok_ntstatus(Status, 0xDEADFACE);
+    ok_ptr(BaseAddress, InvalidPointer);
 
     RtlInitUnicodeString(&DllName, L"advapi32.dll");
+    Status = 0xDEADFACE;
+    BaseAddress = InvalidPointer;
     StartSeh()
         BaseAddress = InvalidPointer;
         Status = LdrLoadDll(NULL, NULL, &DllName, &BaseAddress);
-        ok(Status == STATUS_SUCCESS, "Status = %lx\n", Status);
+        ok_ntstatus(Status, STATUS_SUCCESS);
         ok(BaseAddress != NULL && BaseAddress != InvalidPointer, "BaseAddress = %p\n", BaseAddress);
         if (NT_SUCCESS(Status))
         {
             BaseAddress2 = InvalidPointer;
             Status = LdrLoadDll(NULL, NULL, &DllName, &BaseAddress2);
-            ok(Status == STATUS_SUCCESS, "Status = %lx\n", Status);
-            ok(BaseAddress2 == BaseAddress, "BaseAddress2 = %p, expected %p\n", BaseAddress2, BaseAddress);
+            ok_ntstatus(Status, STATUS_SUCCESS);
+            ok_ptr(BaseAddress2, BaseAddress);
             LdrUnloadDll(BaseAddress);
         }
     EndSeh(STATUS_SUCCESS);
+    ok_ntstatus(Status, STATUS_SUCCESS);
+    ok(BaseAddress != NULL, "BaseAddress was NULL\n");
 
     RtlInitUnicodeString(&DllName, L"advapi32.dll");
+    Status = 0xDEADFACE;
+    BaseAddress = InvalidPointer;
     StartSeh()
         Status = LdrLoadDll(L"\\SystemRoot\\System32", NULL, &DllName, NULL);
     EndSeh(STATUS_ACCESS_VIOLATION);
+    ok_ntstatus(Status, 0xDEADFACE);
+    ok_ptr(BaseAddress, InvalidPointer);
 
     /* Test with only backslashes in path; no file extension */
     StringCchPrintfW(szPath, _countof(szPath), L"%s\\advapi32", szSysDir);
     RtlInitUnicodeString(&DllName, szPath);
+    Status = 0xDEADFACE;
+    BaseAddress = InvalidPointer;
     StartSeh()
         Status = LdrLoadDll(szWinDir, NULL, &DllName, &BaseAddress);
-        ok(Status == STATUS_SUCCESS, "Status = %lx\n", Status);
+        ok_ntstatus(Status, STATUS_SUCCESS);
         if (NT_SUCCESS(Status))
             LdrUnloadDll(BaseAddress);
     EndSeh(STATUS_SUCCESS);
+    ok_ntstatus(Status, STATUS_SUCCESS);
+    ok(BaseAddress != NULL, "BaseAddress was NULL\n");
 
     /* Test with only backslashes in path; with file extension */
     StringCchPrintfW(szPath, _countof(szPath), L"%s\\advapi32.dll", szSysDir);
     RtlInitUnicodeString(&DllName, szPath);
+    Status = 0xDEADFACE;
+    BaseAddress = InvalidPointer;
     StartSeh()
         Status = LdrLoadDll(szWinDir, NULL, &DllName, &BaseAddress);
-        ok(Status == STATUS_SUCCESS, "Status = %lx\n", Status);
+        ok_ntstatus(Status, STATUS_SUCCESS);
         if (NT_SUCCESS(Status))
             LdrUnloadDll(BaseAddress);
     EndSeh(STATUS_SUCCESS);
+    ok_ntstatus(Status, STATUS_SUCCESS);
+    ok(BaseAddress != NULL, "BaseAddress was NULL\n");
 
     StringCchPrintfW(szPath, _countof(szPath), L"%s/advapi32", szSysDir);
     RtlInitUnicodeString(&DllName, szPath);
+    Status = 0xDEADFACE;
+    BaseAddress = InvalidPointer;
     StartSeh()
         Status = LdrLoadDll(szWinDir, NULL, &DllName, &BaseAddress);
-        ok(Status == STATUS_SUCCESS, "Status = %lx\n", Status);
+        ok_ntstatus(Status, STATUS_SUCCESS);
         if (NT_SUCCESS(Status))
             LdrUnloadDll(BaseAddress);
     EndSeh(STATUS_SUCCESS);
+    ok_ntstatus(Status, STATUS_SUCCESS);
+    ok(BaseAddress != NULL, "BaseAddress was NULL\n");
 
     /* Test with one forward slash in path; with file extension */
     StringCchPrintfW(szPath, _countof(szPath), L"%s/advapi32.dll", szSysDir);
 
     RtlInitUnicodeString(&DllName, szPath);
+    Status = 0xDEADFACE;
+    BaseAddress = InvalidPointer;
     StartSeh()
         Status = LdrLoadDll(szWinDir, NULL, &DllName, &BaseAddress);
-        ok(Status == STATUS_SUCCESS, "Status = %lx\n", Status);
+        ok_ntstatus(Status, STATUS_SUCCESS);
         if (NT_SUCCESS(Status))
             LdrUnloadDll(BaseAddress);
     EndSeh(STATUS_SUCCESS);
+    ok_ntstatus(Status, STATUS_SUCCESS);
+    ok(BaseAddress != NULL, "BaseAddress was NULL\n");
 
     /* Test with only forward slashes in path; no file extension */
     StringCchPrintfW(szPath, _countof(szPath), L"%s\\advapi32", szSysDir);
@@ -139,12 +167,16 @@ START_TEST(LdrLoadDll)
     }
 
     RtlInitUnicodeString(&DllName, szPath);
+    Status = 0xDEADFACE;
+    BaseAddress = InvalidPointer;
     StartSeh()
         Status = LdrLoadDll(szWinDir, NULL, &DllName, &BaseAddress);
-        ok(Status == STATUS_SUCCESS, "Status = %lx\n", Status);
+        ok_ntstatus(Status, STATUS_SUCCESS);
         if (NT_SUCCESS(Status))
             LdrUnloadDll(BaseAddress);
     EndSeh(STATUS_SUCCESS);
+    ok_ntstatus(Status, STATUS_SUCCESS);
+    ok(BaseAddress != NULL, "BaseAddress was NULL\n");
 
     /* Test with only forward slashes in path; with file extension */
     StringCchPrintfW(szPath, _countof(szPath), L"%s\\advapi32.dll", szSysDir);
@@ -155,10 +187,14 @@ START_TEST(LdrLoadDll)
     }
 
     RtlInitUnicodeString(&DllName, szPath);
+    Status = 0xDEADFACE;
+    BaseAddress = InvalidPointer;
     StartSeh()
         Status = LdrLoadDll(szWinDir, NULL, &DllName, &BaseAddress);
-        ok(Status == STATUS_SUCCESS, "Status = %lx\n", Status);
+        ok_ntstatus(Status, STATUS_SUCCESS);
         if (NT_SUCCESS(Status))
             LdrUnloadDll(BaseAddress);
     EndSeh(STATUS_SUCCESS);
+    ok_ntstatus(Status, STATUS_SUCCESS);
+    ok(BaseAddress != NULL, "BaseAddress was NULL\n");
 }

--- a/modules/rostests/apitests/ntdll/LdrLoadDll.c
+++ b/modules/rostests/apitests/ntdll/LdrLoadDll.c
@@ -131,6 +131,7 @@ START_TEST(LdrLoadDll)
             LdrUnloadDll(BaseAddress);
     EndSeh(STATUS_SUCCESS);
 
+    /* Test with only forward slashes in path; no file extension */
     StringCchPrintfW(szPath, _countof(szPath), L"%s\\advapi32", szSysDir);
     for (pch = szPath; *pch != UNICODE_NULL; ++pch)
     {

--- a/modules/rostests/apitests/ntdll/LdrLoadDll.c
+++ b/modules/rostests/apitests/ntdll/LdrLoadDll.c
@@ -91,7 +91,6 @@ START_TEST(LdrLoadDll)
     EndSeh(STATUS_ACCESS_VIOLATION);
 
     StringCchPrintfW(szPath, _countof(szPath), L"%s\\advapi32", szSysDir);
-
     RtlInitUnicodeString(&DllName, szPath);
     StartSeh()
         Status = LdrLoadDll(szWinDir, NULL, &DllName, &BaseAddress);

--- a/modules/rostests/apitests/ntdll/LdrLoadDll.c
+++ b/modules/rostests/apitests/ntdll/LdrLoadDll.c
@@ -120,6 +120,7 @@ START_TEST(LdrLoadDll)
             LdrUnloadDll(BaseAddress);
     EndSeh(STATUS_SUCCESS);
 
+    /* Test with one forward slash in path; with file extension */
     StringCchPrintfW(szPath, _countof(szPath), L"%s/advapi32.dll", szSysDir);
 
     RtlInitUnicodeString(&DllName, szPath);

--- a/modules/rostests/apitests/ntdll/LdrLoadDll.c
+++ b/modules/rostests/apitests/ntdll/LdrLoadDll.c
@@ -101,7 +101,6 @@ START_TEST(LdrLoadDll)
     EndSeh(STATUS_SUCCESS);
 
     StringCchPrintfW(szPath, _countof(szPath), L"%s\\advapi32.dll", szSysDir);
-
     RtlInitUnicodeString(&DllName, szPath);
     StartSeh()
         Status = LdrLoadDll(szWinDir, NULL, &DllName, &BaseAddress);

--- a/modules/rostests/apitests/ntdll/testlist.c
+++ b/modules/rostests/apitests/ntdll/testlist.c
@@ -4,6 +4,7 @@
 #include <apitest.h>
 
 extern void func_LdrEnumResources(void);
+extern void func_LdrLoadDll(void);
 extern void func_load_notifications(void);
 extern void func_NtAcceptConnectPort(void);
 extern void func_NtAccessCheck(void);
@@ -106,6 +107,7 @@ extern void func_UserModeException(void);
 const struct test winetest_testlist[] =
 {
     { "LdrEnumResources",               func_LdrEnumResources },
+    { "LdrLoadDll",                     func_LdrLoadDll },
     { "load_notifications",             func_load_notifications },
     { "NtAcceptConnectPort",            func_NtAcceptConnectPort },
     { "NtAccessCheck",                  func_NtAccessCheck },


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-6585](https://jira.reactos.org/browse/CORE-6585)

## Proposed changes

- Add one comment into `LdrpLoadDll` function.
- Add `LdrLoadDll` testcase.

## TODO

- [x] Add testcase.
- [x] Do small tests.

## Comparison

WinXP:
![winxp](https://github.com/reactos/reactos/assets/2107452/50fec488-a668-4ddd-a5ad-96cdb7bcd810)
Successful.

Win2k3:
![win2k3](https://github.com/reactos/reactos/assets/2107452/356255ff-b883-4589-84ee-b017ebbabc2d)
Successful.

Win10 x64:
![Win10](https://github.com/reactos/reactos/assets/2107452/dba70575-9ae1-469e-aafd-02687a4e964c)
Successful.