### PR TITLE
[SDK][USER32_APITEST] Add GW_ENABLEDPOPUP testcase

### DIFF
--- a/modules/rostests/apitests/user32/CMakeLists.txt
+++ b/modules/rostests/apitests/user32/CMakeLists.txt
@@ -25,6 +25,7 @@ list(APPEND SOURCE
     GetSystemMetrics.c
     GetUserObjectInformation.c
     GetWindowPlacement.c
+    GW_ENABLEDPOPUP.c
     InitializeLpkHooks.c
     KbdLayout.c
     keybd_event.c

--- a/modules/rostests/apitests/user32/GW_ENABLEDPOPUP.c
+++ b/modules/rostests/apitests/user32/GW_ENABLEDPOPUP.c
@@ -1,0 +1,142 @@
+/*
+ * PROJECT:     ReactOS API tests
+ * LICENSE:     LGPL-2.1+ (https://spdx.org/licenses/LGPL-2.1+)
+ * PURPOSE:     Test for GW_ENABLEDPOPUP
+ * COPYRIGHT:   Copyright 2024 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ */
+
+#include "precomp.h"
+#include <windowsx.h>
+
+static HWND s_hwnd = NULL;
+static HWND s_hwndChild1 = NULL;
+static HWND s_hwndChild2 = NULL;
+static HWND s_hwndChild3 = NULL;
+
+static VOID DoTestBody(VOID)
+{
+    HWND hwndRet;
+#define CHECK(hwndTarget) do { \
+    hwndRet = GetWindow(s_hwnd, GW_ENABLEDPOPUP); \
+    trace("hwndRet: %p\n", hwndRet); \
+    ok_int(hwndRet == hwndTarget, TRUE); \
+} while (0)
+
+    trace("%p, %p, %p, %p\n", s_hwnd, s_hwndChild1, s_hwndChild2, s_hwndChild3);
+
+    CHECK(s_hwndChild3);
+
+    EnableWindow(s_hwndChild3, FALSE);
+
+    CHECK(s_hwndChild2);
+
+    EnableWindow(s_hwndChild2, FALSE);
+
+    CHECK(NULL);
+
+    EnableWindow(s_hwndChild2, TRUE);
+
+    CHECK(s_hwndChild2);
+
+    ShowWindow(s_hwndChild1, SW_HIDE);
+
+    CHECK(s_hwndChild2);
+
+    ShowWindow(s_hwndChild2, SW_HIDE);
+
+    CHECK(NULL);
+
+    ShowWindow(s_hwndChild2, SW_SHOWNOACTIVATE);
+
+    CHECK(s_hwndChild2);
+
+    EnableWindow(s_hwndChild1, TRUE);
+    ShowWindow(s_hwndChild2, SW_SHOWNOACTIVATE);
+
+    CHECK(s_hwndChild2);
+
+    ShowWindow(s_hwndChild1, SW_SHOWNOACTIVATE);
+
+    CHECK(s_hwndChild2);
+
+    ShowWindow(s_hwndChild2, SW_HIDE);
+
+    CHECK(s_hwndChild1);
+}
+
+static LRESULT CALLBACK
+WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
+{
+    switch (uMsg)
+    {
+        case WM_CREATE:
+            SetTimer(hwnd, 999, 500, NULL);
+            break;
+        case WM_DESTROY:
+            if (s_hwnd == hwnd)
+            {
+                DestroyWindow(s_hwndChild1);
+                DestroyWindow(s_hwndChild2);
+                DestroyWindow(s_hwndChild3);
+                PostQuitMessage(0);
+            }
+            break;
+        case WM_TIMER:
+            KillTimer(hwnd, wParam);
+            if (wParam == 999 && hwnd == s_hwnd)
+            {
+                DoTestBody();
+                DestroyWindow(hwnd);
+                break;
+            }
+            break;
+        default:
+            return DefWindowProcW(hwnd, uMsg, wParam, lParam);
+    }
+    return 0;
+}
+
+START_TEST(GW_ENABLEDPOPUP)
+{
+    WNDCLASSW wc = { 0 };
+    MSG msg;
+
+    wc.lpfnWndProc = WindowProc;
+    wc.hInstance = GetModuleHandleW(NULL);
+    wc.hIcon = LoadIcon(NULL, IDI_APPLICATION);
+    wc.hCursor = LoadCursor(NULL, IDC_ARROW);
+    wc.hbrBackground = (HBRUSH)(COLOR_3DFACE + 1);
+    wc.lpszClassName = L"GW_ENABLEDPOPUP";
+    if (!RegisterClassW(&wc))
+    {
+        skip("RegisterClass failed\n");
+        return;
+    }
+
+    s_hwnd = CreateWindowW(L"GW_ENABLEDPOPUP", L"GW_ENABLEDPOPUP",
+                           WS_OVERLAPPEDWINDOW | WS_VISIBLE,
+                           0, 0, 100, 100,
+                           NULL, NULL, wc.hInstance, NULL);
+    s_hwndChild1 = CreateWindowW(L"GW_ENABLEDPOPUP", L"Child #1",
+                                 WS_POPUPWINDOW | WS_CHILD | WS_VISIBLE | WS_DISABLED,
+                                 100, 100, 100, 100,
+                                 s_hwnd, NULL, wc.hInstance, NULL);
+    s_hwndChild2 = CreateWindowW(L"GW_ENABLEDPOPUP", L"Child #2",
+                                 WS_POPUPWINDOW | WS_CHILD | WS_VISIBLE,
+                                 200, 200, 100, 100,
+                                 s_hwnd, NULL, wc.hInstance, NULL);
+    s_hwndChild3 = CreateWindowW(L"GW_ENABLEDPOPUP", L"Child #3",
+                                 WS_POPUPWINDOW | WS_CHILD | WS_VISIBLE,
+                                 300, 100, 100, 100,
+                                 s_hwndChild2, NULL, wc.hInstance, NULL);
+    if (!s_hwnd || !s_hwndChild1 || !s_hwndChild2 || !s_hwndChild3)
+    {
+        skip("CreateWindow failed\n");
+    }
+
+    while (GetMessage(&msg, NULL, 0, 0))
+    {
+        TranslateMessage(&msg);
+        DispatchMessageW(&msg);
+    }
+}

--- a/modules/rostests/apitests/user32/testlist.c
+++ b/modules/rostests/apitests/user32/testlist.c
@@ -27,6 +27,7 @@ extern void func_GetSetWindowInt(void);
 extern void func_GetSystemMetrics(void);
 extern void func_GetUserObjectInformation(void);
 extern void func_GetWindowPlacement(void);
+extern void func_GW_ENABLEDPOPUP(void);
 extern void func_InitializeLpkHooks(void);
 extern void func_KbdLayout(void);
 extern void func_keybd_event(void);
@@ -85,6 +86,7 @@ const struct test winetest_testlist[] =
     { "GetSystemMetrics", func_GetSystemMetrics },
     { "GetUserObjectInformation", func_GetUserObjectInformation },
     { "GetWindowPlacement", func_GetWindowPlacement },
+    { "GW_ENABLEDPOPUP", func_GW_ENABLEDPOPUP },
     { "InitializeLpkHooks", func_InitializeLpkHooks },
     { "KbdLayout", func_KbdLayout },
     { "keybd_event", func_keybd_event },

--- a/sdk/include/psdk/winuser.h
+++ b/sdk/include/psdk/winuser.h
@@ -764,6 +764,7 @@ extern "C" {
 #define GW_HWNDFIRST 0
 #define GW_HWNDLAST 1
 #define GW_OWNER 4
+#define GW_ENABLEDPOPUP 6
 #define SW_HIDE 0
 #define SW_NORMAL 1
 #define SW_SHOWNORMAL 1


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-6920](https://jira.reactos.org/browse/CORE-6920)

## Proposed changes

- Add `GW_ENABLEDPOPUP` constant to `<winuser.h>`.
- Add `GW_ENABLEDPOPUP` testcase.

## TODO

- [x] Add tests on `GW_ENABLEDPOPUP`.
- [x] Do tests.

## Comparison

WinXP:
![winxp](https://github.com/reactos/reactos/assets/2107452/1bfde7b8-e0d2-4557-a74a-abd1217821cb)
Successful.

Win2k3:
![win2k3](https://github.com/reactos/reactos/assets/2107452/ea54a174-5ad3-4e5b-9960-aad99307ee7b)
Successful.

Win10 x64:
![image](https://github.com/reactos/reactos/assets/2107452/5fc34e9c-c03c-4636-a50d-3b9744078652)
Successful.
