### PR TITLE
Some fixes for "The Last Known Good" LKG configuration support

### DIFF
--- a/base/system/services/controlset.c
+++ b/base/system/services/controlset.c
@@ -392,9 +392,9 @@ ScmAcceptBoot(VOID)
 }
 
 DWORD
-ScmRunLastKnownGood(VOID)
+ScmRestoreLastKnownGood(VOID)
 {
-    DPRINT("ScmRunLastKnownGood()\n");
+    DPRINT("ScmRestoreLastKnownGood()\n");
 
     if (bBootAccepted)
     {
@@ -402,8 +402,7 @@ ScmRunLastKnownGood(VOID)
         return ERROR_BOOT_ALREADY_ACCEPTED;
     }
 
-    /* FIXME */
-
+    // FIXME: Restore the LKG and reboot.
     return ERROR_SUCCESS;
 }
 

--- a/base/system/services/controlset.c
+++ b/base/system/services/controlset.c
@@ -21,7 +21,6 @@ LSTATUS WINAPI RegDeleteTreeW(_In_ HKEY, _In_opt_ LPCWSTR);
 
 static BOOL bBootAccepted = FALSE;
 
-
 /* FUNCTIONS *****************************************************************/
 
 static
@@ -106,7 +105,6 @@ ScmGetControlSetValues(
     return dwError;
 }
 
-
 static
 DWORD
 ScmSetLastKnownGoodControlSet(
@@ -135,7 +133,6 @@ ScmSetLastKnownGoodControlSet(
 
     return dwError;
 }
-
 
 static
 DWORD
@@ -171,7 +168,6 @@ ScmGetSetupInProgress(VOID)
     DPRINT("SetupInProgress: %lu\n", dwSetupInProgress);
     return dwSetupInProgress;
 }
-
 
 static
 DWORD
@@ -226,15 +222,14 @@ ScmCopyControlSet(
     RegFlushKey(hDestinationControlSetKey);
 
 done:
-    if (hDestinationControlSetKey != NULL)
+    if (hDestinationControlSetKey)
         RegCloseKey(hDestinationControlSetKey);
 
-    if (hSourceControlSetKey != NULL)
+    if (hSourceControlSetKey)
         RegCloseKey(hSourceControlSetKey);
 
     return dwError;
 }
-
 
 static
 DWORD
@@ -261,15 +256,13 @@ ScmDeleteControlSet(
         return dwError;
 
     /* Delete the control set */
-    dwError = RegDeleteTreeW(hControlSetKey,
-                             NULL);
+    dwError = RegDeleteTreeW(hControlSetKey, NULL);
 
-    /* Open the system key */
+    /* Close the system key */
     RegCloseKey(hControlSetKey);
 
     return dwError;
 }
-
 
 DWORD
 ScmCreateLastKnownGoodControlSet(VOID)
@@ -300,10 +293,12 @@ ScmCreateLastKnownGoodControlSet(VOID)
                 (dwNewControlSet != dwDefaultControlSet) &&
                 (dwNewControlSet != dwFailedControlSet) &&
                 (dwNewControlSet != dwLastKnownGoodControlSet))
+            {
                 break;
+            }
         }
 
-        /* Fail if we did not find an unused control set!*/
+        /* Fail if we did not find an unused control set */
         if (dwNewControlSet >= 1000)
         {
             DPRINT1("Too many control sets\n");
@@ -311,8 +306,7 @@ ScmCreateLastKnownGoodControlSet(VOID)
         }
 
         /* Copy the current control set */
-        dwError = ScmCopyControlSet(dwCurrentControlSet,
-                                    dwNewControlSet);
+        dwError = ScmCopyControlSet(dwCurrentControlSet, dwNewControlSet);
         if (dwError != ERROR_SUCCESS)
             return dwError;
 
@@ -322,7 +316,7 @@ ScmCreateLastKnownGoodControlSet(VOID)
         {
             /*
              * Accept the boot here in order to prevent the creation of
-             * another control set when a user is going to get logged on
+             * another control set when a user is going to get logged on.
              */
             bBootAccepted = TRUE;
         }
@@ -330,7 +324,6 @@ ScmCreateLastKnownGoodControlSet(VOID)
 
     return dwError;
 }
-
 
 DWORD
 ScmAcceptBoot(VOID)
@@ -363,10 +356,12 @@ ScmAcceptBoot(VOID)
             (dwNewControlSet != dwDefaultControlSet) &&
             (dwNewControlSet != dwFailedControlSet) &&
             (dwNewControlSet != dwLastKnownGoodControlSet))
+        {
             break;
+        }
     }
 
-    /* Fail if we did not find an unused control set!*/
+    /* Fail if we did not find an unused control set */
     if (dwNewControlSet >= 1000)
     {
         DPRINT1("Too many control sets\n");
@@ -374,12 +369,11 @@ ScmAcceptBoot(VOID)
     }
 
     /* Copy the current control set */
-    dwError = ScmCopyControlSet(dwCurrentControlSet,
-                                dwNewControlSet);
+    dwError = ScmCopyControlSet(dwCurrentControlSet, dwNewControlSet);
     if (dwError != ERROR_SUCCESS)
         return dwError;
 
-    /* Delete the current last known good contol set, if it is not used anywhere else */
+    /* Delete the current last known good control set, if it is not used anywhere else */
     if ((dwLastKnownGoodControlSet != dwCurrentControlSet) &&
         (dwLastKnownGoodControlSet != dwDefaultControlSet) &&
         (dwLastKnownGoodControlSet != dwFailedControlSet))
@@ -396,7 +390,6 @@ ScmAcceptBoot(VOID)
 
     return ERROR_SUCCESS;
 }
-
 
 DWORD
 ScmRunLastKnownGood(VOID)

--- a/base/system/services/controlset.c
+++ b/base/system/services/controlset.c
@@ -253,11 +253,12 @@ ScmDeleteControlSet(
 
     DPRINT("ScmDeleteControSet(%lu)\n", dwControlSet);
 
+__debugbreak();
     /* Create the control set name */
     swprintf(szControlSetName, L"SYSTEM\\ControlSet%03lu", dwControlSet);
     DPRINT("Control set: %S\n", szControlSetName);
 
-    /* Open the system key */
+    /* Open the control set key */
     dwError = RegOpenKeyExW(HKEY_LOCAL_MACHINE,
                             szControlSetName,
                             0,
@@ -267,10 +268,22 @@ ScmDeleteControlSet(
         return dwError;
 
     /* Delete the control set */
-    dwError = RegDeleteTreeW(hControlSetKey, NULL);
+#if 0
+    dwError = RegDeleteTreeW(hControlSetKey, L"");
+#else
+    dwError = RegDeleteTreeW(hControlSetKey, NULL);   // Delete the values and subkeys.
+    if (dwError == ERROR_SUCCESS)
+        dwError = RegDeleteKeyW(hControlSetKey, L""); // And delete the key itself.
+#endif
 
-    /* Close the system key */
+    /* Close the control set key */
     RegCloseKey(hControlSetKey);
+
+#if 0
+    /* Finally delete the key */
+    if (dwError == ERROR_SUCCESS)
+        dwError = RegDeleteKeyW(HKEY_LOCAL_MACHINE, szControlSetName);
+#endif
 
     return dwError;
 }
@@ -286,6 +299,7 @@ ScmCreateLastKnownGoodControlSet(VOID)
 
     ASSERT(!bBootAccepted);
 
+__debugbreak();
     /* Get the control set values */
     dwError = ScmGetControlSetValues(&dwCurrentControlSet,
                                      &dwDefaultControlSet,
@@ -358,6 +372,8 @@ ScmAcceptBoot(VOID)
     NTSTATUS Status;
 
     DPRINT("ScmAcceptBoot()\n");
+
+__debugbreak();
 
     if (bBootAccepted)
     {

--- a/base/system/services/rpcserver.c
+++ b/base/system/services/rpcserver.c
@@ -1858,7 +1858,7 @@ RNotifyBootConfigStatus(
     if (BootAcceptable)
         return ScmAcceptBoot();
 
-    return ScmRunLastKnownGood();
+    return ScmRestoreLastKnownGood();
 }
 
 

--- a/base/system/services/rpcserver.c
+++ b/base/system/services/rpcserver.c
@@ -1852,8 +1852,26 @@ RNotifyBootConfigStatus(
     SVCCTL_HANDLEW lpMachineName,
     DWORD BootAcceptable)
 {
+    MANAGER_HANDLE hMgr; // Local handle for access checks only.
+    DWORD dwError;
+
     DPRINT("RNotifyBootConfigStatus(%p %lu)\n",
            lpMachineName, BootAcceptable);
+
+    /* Initialize the local handle */
+    hMgr.Handle.Tag = MANAGER_TAG;
+    hMgr.DatabaseName[0] = UNICODE_NULL;
+
+    /* Check the desired access */
+    dwError = ScmCheckAccess((SC_HANDLE)&hMgr, SC_MANAGER_MODIFY_BOOT_CONFIG);
+    if (dwError != ERROR_SUCCESS)
+    {
+        DPRINT("ScmCheckAccess() failed (Error %lu)\n", dwError);
+        return dwError;
+    }
+
+    // TODO: What if we are already on the LKG?
+    // return ERROR_ALREADY_RUNNING_LKG;
 
     if (BootAcceptable)
         return ScmAcceptBoot();

--- a/base/system/services/rpcserver.c
+++ b/base/system/services/rpcserver.c
@@ -252,6 +252,7 @@ ScmCheckAccess(SC_HANDLE Handle,
 
         hMgr->Handle.DesiredAccess = dwDesiredAccess;
 
+        // TODO: Perform the actual privileges check and object audit
         return ERROR_SUCCESS;
     }
     else if (hMgr->Handle.Tag == SERVICE_TAG)
@@ -261,6 +262,7 @@ ScmCheckAccess(SC_HANDLE Handle,
 
         hMgr->Handle.DesiredAccess = dwDesiredAccess;
 
+        // TODO: Perform the actual privileges check and object audit
         return ERROR_SUCCESS;
     }
 

--- a/base/system/services/services.c
+++ b/base/system/services/services.c
@@ -315,6 +315,8 @@ wWinMain(HINSTANCE hInstance,
         goto done;
     }
 
+    // TODO: Handle SafeBoot mode
+
     /* Create the services database */
     dwError = ScmCreateServiceDatabase();
     if (dwError != ERROR_SUCCESS)
@@ -364,10 +366,13 @@ wWinMain(HINSTANCE hInstance,
     /* Start auto-start services */
     ScmAutoStartServices();
 
+    /* FIXME: more to do ? */
+
+    // TODO: Run the optional user-specific boot verification program
+    // from HKLM\SYSTEM\CurrentControlSet\Control\BootVerificationProgram
+
     /* Signal auto-start complete event */
     SetEvent(hScmAutoStartCompleteEvent);
-
-    /* FIXME: more to do ? */
 
     /* Release the service start lock */
     ScmReleaseServiceStartLock(&Lock);

--- a/base/system/services/services.h
+++ b/base/system/services/services.h
@@ -172,7 +172,7 @@ DWORD
 ScmAcceptBoot(VOID);
 
 DWORD
-ScmRunLastKnownGood(VOID);
+ScmRestoreLastKnownGood(VOID);
 
 
 /* database.c */

--- a/base/system/winlogon/winlogon.c
+++ b/base/system/winlogon/winlogon.c
@@ -12,8 +12,6 @@
 
 #include "winlogon.h"
 
-#include <ndk/cmfuncs.h>
-
 /* GLOBALS ******************************************************************/
 
 HINSTANCE hAppInstance;
@@ -599,10 +597,6 @@ WinMain(
     }
 
     (void)LoadLibraryW(L"sfc_os.dll");
-
-    /* Tell kernel that CurrentControlSet is good (needed
-     * to support Last good known configuration boot) */
-    NtInitializeRegistry(CM_BOOT_FLAG_ACCEPTED | 1);
 
     /* Message loop for the SAS window */
     while (GetMessageW(&Msg, WLSession->SASWindow, 0, 0))

--- a/boot/bootdata/hivesft.inf
+++ b/boot/bootdata/hivesft.inf
@@ -1509,14 +1509,15 @@ HKLM,"SOFTWARE\ReactOS\ReactOS\CurrentVersion\IFS","EXT2",0x00000000,"uext2.dll"
 HKLM,"SOFTWARE\ReactOS\ReactOS\CurrentVersion\IFS","BtrFS",0x00000000,"ubtrfs.dll"
 
 ; Global Winlogon settings
-HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon","ConsoleShell",0x00020000,"%SystemRoot%\system32\cmd.exe"
-HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon","Shell",0x00020000,"%SystemRoot%\explorer.exe"
-HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon","Userinit",0x00020000,"%SystemRoot%\system32\userinit.exe"
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon","AutoAdminLogon",0x00000000,"1"
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon","LogonType",0x00010001,0
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon","DefaultDomainName",0x00000000,""
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon","DefaultUserName",0x00000000,""
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon","DefaultPassword",0x00000000,""
+HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon","ConsoleShell",0x00020000,"%SystemRoot%\system32\cmd.exe"
+HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon","Shell",0x00020000,"%SystemRoot%\explorer.exe"
+HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon","Userinit",0x00020000,"%SystemRoot%\system32\userinit.exe"
+HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon","ReportBootOk",0x00000002,"1"
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\Notify",,0x00000012
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\Notify\ScCertProp",,0x00000012
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\Notify\ScCertProp","DllName",0x00020000,"wlnotify.dll"

--- a/dll/win32/msgina/msgina.h
+++ b/dll/win32/msgina/msgina.h
@@ -18,6 +18,7 @@ extern "C" {
 #include <winreg.h>
 #include <winuser.h>
 #include <winwlx.h>
+#define NTOS_MODE_USER
 #include <ndk/rtlfuncs.h>
 #include <ntsecapi.h>
 

--- a/ntoskrnl/config/cmcontrl.c
+++ b/ntoskrnl/config/cmcontrl.c
@@ -264,8 +264,9 @@ CmGetSystemControlValues(IN PVOID SystemHiveData,
 
 NTSTATUS
 NTAPI
-CmpSaveBootControlSet(IN USHORT ControlSet)
+CmpSaveBootControlSet(
+    _In_ USHORT ControlSet)
 {
-    DPRINT1("CmpSaveBootControlSet(%lu)\n", ControlSet);
+    DPRINT1("CmpSaveBootControlSet(%lu) is UNIMPLEMENTED\n", ControlSet);
     return STATUS_SUCCESS;
 }

--- a/ntoskrnl/config/ntapi.c
+++ b/ntoskrnl/config/ntapi.c
@@ -1315,10 +1315,12 @@ NtNotifyChangeKey(IN HANDLE KeyHandle,
 
 NTSTATUS
 NTAPI
-NtInitializeRegistry(IN USHORT Flag)
+NtInitializeRegistry(
+    _In_ USHORT Flag)
 {
-    BOOLEAN SetupBoot;
     NTSTATUS Status = STATUS_SUCCESS;
+    BOOLEAN SetupBoot;
+
     PAGED_CODE();
 
     /* Always do this as kernel mode */
@@ -1329,13 +1331,15 @@ NtInitializeRegistry(IN USHORT Flag)
     Ki386PerfEnd();
 
     /* Validate flag */
-    if (Flag > CM_BOOT_FLAG_MAX) return STATUS_INVALID_PARAMETER;
+    if (Flag > CM_BOOT_FLAG_MAX)
+        return STATUS_INVALID_PARAMETER;
 
     /* Check if boot was accepted */
     if ((Flag >= CM_BOOT_FLAG_ACCEPTED) && (Flag <= CM_BOOT_FLAG_MAX))
     {
         /* Only allow once */
-        if (!CmBootAcceptFirstTime) return STATUS_ACCESS_DENIED;
+        if (!CmBootAcceptFirstTime)
+            return STATUS_ACCESS_DENIED;
         CmBootAcceptFirstTime = FALSE;
 
         /* Get the control set accepted */
@@ -1359,10 +1363,11 @@ NtInitializeRegistry(IN USHORT Flag)
     }
 
     /* Check if this was a setup boot */
-    SetupBoot = (Flag == CM_BOOT_FLAG_SETUP ? TRUE : FALSE);
+    SetupBoot = (Flag == CM_BOOT_FLAG_SETUP);
 
     /* Make sure we're only called once */
-    if (!CmFirstTime) return STATUS_ACCESS_DENIED;
+    if (!CmFirstTime)
+        return STATUS_ACCESS_DENIED;
     CmFirstTime = FALSE;
 
     /* Lock the registry exclusively */

--- a/ntoskrnl/include/internal/cm.h
+++ b/ntoskrnl/include/internal/cm.h
@@ -1147,7 +1147,7 @@ CmGetSystemControlValues(
 NTSTATUS
 NTAPI
 CmpSaveBootControlSet(
-    IN USHORT ControlSet
+    _In_ USHORT ControlSet
 );
 
 //


### PR DESCRIPTION
## Purpose

Enhance little aspects of Last-Known-Good configuration support.

In particular:
- Winlogon, via msgina.dll, [notifies with `NotifyBootConfigStatus()` the Services Control Manager (SCM)](https://learn.microsoft.com/en-us/windows/win32/api/winsvc/nf-winsvc-notifybootconfigstatus) that the current boot configuration should be good, when the first user logs in.
- The SCM notification function should check that the caller has the correct rights.
- Once the SCM successfully deals with the `HKLM\SYSTEM` Control Sets, it calls `NtInitializeRegistry()` with the (offset) index of the good control set. It is the SCM that does that call, not Winlogon.
- Note that currently, the control-set specific handler called by `NtInitializeRegistry()` is not yet implemented in ReactOS.
- The SCM should correctly delete the old control set keys, besides deleting their values and subkeys.