### PR TITLE
[SHOBJSHEX] Use STDMETHOD macro and keyword override

### DIFF
--- a/dll/shellext/ntobjshex/foldercommon.h
+++ b/dll/shellext/ntobjshex/foldercommon.h
@@ -20,7 +20,7 @@ public:
     CFolderViewCB() : m_View(NULL) {}
     virtual ~CFolderViewCB() {}
 
-    virtual HRESULT STDMETHODCALLTYPE MessageSFVCB(UINT uMsg, WPARAM wParam, LPARAM lParam)
+    STDMETHOD(MessageSFVCB)(UINT uMsg, WPARAM wParam, LPARAM lParam) override
     {
         switch (uMsg)
         {
@@ -42,7 +42,7 @@ public:
         return E_NOTIMPL;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE Initialize(IShellView* psv)
+    STDMETHOD(Initialize)(IShellView* psv)
     {
         m_View = psv;
         return S_OK;
@@ -81,13 +81,13 @@ public:
     }
 
     // IShellFolder
-    virtual HRESULT STDMETHODCALLTYPE ParseDisplayName(
+    STDMETHOD(ParseDisplayName)(
         HWND hwndOwner,
         LPBC pbcReserved,
         LPOLESTR lpszDisplayName,
         ULONG *pchEaten,
         LPITEMIDLIST *ppidl,
-        ULONG *pdwAttributes)
+        ULONG *pdwAttributes) override
     {
         if (!ppidl)
             return E_POINTER;
@@ -160,16 +160,16 @@ public:
         return S_OK;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE EnumObjects(
+    STDMETHOD(EnumObjects)(
         HWND hwndOwner,
         SHCONTF grfFlags,
         IEnumIDList **ppenumIDList) PURE;
 
-    virtual HRESULT STDMETHODCALLTYPE BindToObject(
+    STDMETHOD(BindToObject)(
         LPCITEMIDLIST pidl,
         LPBC pbcReserved,
         REFIID riid,
-        void **ppvOut)
+        void **ppvOut) override
     {
         const TItemId * info;
 
@@ -213,7 +213,7 @@ public:
     }
 
 protected:
-    virtual HRESULT STDMETHODCALLTYPE InternalBindToObject(
+    STDMETHOD(InternalBindToObject)(
         PWSTR path,
         const TItemId * info,
         LPITEMIDLIST first,
@@ -222,7 +222,7 @@ protected:
         LPBC pbcReserved,
         IShellFolder** ppsfChild) PURE;
 
-    virtual HRESULT STDMETHODCALLTYPE ResolveSymLink(
+    STDMETHOD(ResolveSymLink)(
         const TItemId * info,
         LPITEMIDLIST * fullPidl)
     {
@@ -231,20 +231,20 @@ protected:
 
 public:
 
-    virtual HRESULT STDMETHODCALLTYPE BindToStorage(
+    STDMETHOD(BindToStorage)(
         LPCITEMIDLIST pidl,
         LPBC pbcReserved,
         REFIID riid,
-        void **ppvObj)
+        void **ppvObj) override
     {
         UNIMPLEMENTED;
         return E_NOTIMPL;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE CompareIDs(
+    STDMETHOD(CompareIDs)(
         LPARAM lParam,
         LPCITEMIDLIST pidl1,
-        LPCITEMIDLIST pidl2)
+        LPCITEMIDLIST pidl2) override
     {
         HRESULT hr;
 
@@ -288,7 +288,7 @@ public:
     }
 
 protected:
-    virtual HRESULT STDMETHODCALLTYPE CompareName(
+    STDMETHOD(CompareName)(
         LPARAM lParam,
         const TItemId * first,
         const TItemId * second)
@@ -331,10 +331,10 @@ protected:
     }
 
 public:
-    virtual HRESULT STDMETHODCALLTYPE CreateViewObject(
+    STDMETHOD(CreateViewObject)(
         HWND hwndOwner,
         REFIID riid,
-        void **ppvOut)
+        void **ppvOut) override
     {
         if (!IsEqualIID(riid, IID_IShellView))
             return E_NOINTERFACE;
@@ -368,10 +368,10 @@ public:
         return S_OK;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE GetAttributesOf(
+    STDMETHOD(GetAttributesOf)(
         UINT cidl,
         PCUITEMID_CHILD_ARRAY apidl,
-        SFGAOF *rgfInOut)
+        SFGAOF *rgfInOut) override
     {
         const TItemId * info;
 
@@ -398,13 +398,13 @@ public:
         return S_OK;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE GetUIObjectOf(
+    STDMETHOD(GetUIObjectOf)(
         HWND hwndOwner,
         UINT cidl,
         PCUITEMID_CHILD_ARRAY apidl,
         REFIID riid,
         UINT *prgfInOut,
-        void **ppvOut)
+        void **ppvOut) override
     {
         DWORD res;
         TRACE("GetUIObjectOf\n");
@@ -499,10 +499,10 @@ public:
         return E_NOTIMPL;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE GetDisplayNameOf(
+    STDMETHOD(GetDisplayNameOf)(
         LPCITEMIDLIST pidl,
         SHGDNF uFlags,
-        STRRET *lpName)
+        STRRET *lpName) override
     {
         const TItemId * info;
 
@@ -566,36 +566,36 @@ public:
         return S_OK;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE SetNameOf(
+    STDMETHOD(SetNameOf)(
         HWND hwnd,
         LPCITEMIDLIST pidl,
         LPCOLESTR lpszName,
         SHGDNF uFlags,
-        LPITEMIDLIST *ppidlOut)
+        LPITEMIDLIST *ppidlOut) override
     {
         UNIMPLEMENTED;
         return E_NOTIMPL;
     }
 
     // IShellFolder2
-    virtual HRESULT STDMETHODCALLTYPE GetDefaultSearchGUID(
-        GUID *lpguid)
+    STDMETHOD(GetDefaultSearchGUID)(
+        GUID *lpguid) override
     {
         UNIMPLEMENTED;
         return E_NOTIMPL;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE EnumSearches(
-        IEnumExtraSearch **ppenum)
+    STDMETHOD(EnumSearches)(
+        IEnumExtraSearch **ppenum) override
     {
         UNIMPLEMENTED;
         return E_NOTIMPL;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE GetDefaultColumn(
+    STDMETHOD(GetDefaultColumn)(
         DWORD dwReserved,
         ULONG *pSort,
-        ULONG *pDisplay)
+        ULONG *pDisplay) override
     {
         if (pSort)
             *pSort = 0;
@@ -604,26 +604,26 @@ public:
         return S_OK;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE GetDefaultColumnState(
+    STDMETHOD(GetDefaultColumnState)(
         UINT iColumn,
         SHCOLSTATEF *pcsFlags) PURE;
 
-    virtual HRESULT STDMETHODCALLTYPE GetDetailsEx(
+    STDMETHOD(GetDetailsEx)(
         LPCITEMIDLIST pidl,
         const SHCOLUMNID *pscid,
         VARIANT *pv) PURE;
 
-    virtual HRESULT STDMETHODCALLTYPE GetDetailsOf(
+    STDMETHOD(GetDetailsOf)(
         LPCITEMIDLIST pidl,
         UINT iColumn,
         SHELLDETAILS *psd) PURE;
 
-    virtual HRESULT STDMETHODCALLTYPE MapColumnToSCID(
+    STDMETHOD(MapColumnToSCID)(
         UINT iColumn,
         SHCOLUMNID *pscid) PURE;
 
     // IPersist
-    virtual HRESULT STDMETHODCALLTYPE GetClassID(CLSID *lpClassId)
+    STDMETHOD(GetClassID)(CLSID *lpClassId) override
     {
         if (!lpClassId)
             return E_POINTER;
@@ -633,7 +633,7 @@ public:
     }
 
     // IPersistFolder
-    virtual HRESULT STDMETHODCALLTYPE Initialize(PCIDLIST_ABSOLUTE pidl)
+    STDMETHOD(Initialize)(PCIDLIST_ABSOLUTE pidl) override
     {
         m_shellPidl = ILClone(pidl);
 
@@ -643,7 +643,7 @@ public:
     }
 
     // IPersistFolder2
-    virtual HRESULT STDMETHODCALLTYPE GetCurFolder(PIDLIST_ABSOLUTE * pidl)
+    STDMETHOD(GetCurFolder)(PIDLIST_ABSOLUTE * pidl) override
     {
         if (pidl)
             *pidl = ILClone(m_shellPidl);
@@ -654,16 +654,16 @@ public:
 
     // Internal
 protected:
-    virtual HRESULT STDMETHODCALLTYPE CompareIDs(
+    STDMETHOD(CompareIDs)(
         LPARAM lParam,
         const TItemId * first,
         const TItemId * second) PURE;
 
-    virtual ULONG STDMETHODCALLTYPE ConvertAttributes(
+    STDMETHOD_(ULONG, ConvertAttributes)(
         const TItemId * entry,
         PULONG inMask) PURE;
 
-    virtual BOOL STDMETHODCALLTYPE IsFolder(LPCITEMIDLIST pcidl)
+    STDMETHOD_(BOOL, IsFolder)(LPCITEMIDLIST pcidl)
     {
         const TItemId * info;
 
@@ -674,9 +674,9 @@ protected:
         return IsFolder(info);
     }
 
-    virtual BOOL STDMETHODCALLTYPE IsFolder(const TItemId * info) PURE;
+    STDMETHOD_(BOOL, IsFolder)(const TItemId * info) PURE;
 
-    virtual BOOL STDMETHODCALLTYPE IsSymLink(LPCITEMIDLIST pcidl)
+    STDMETHOD_(BOOL, IsSymLink)(LPCITEMIDLIST pcidl)
     {
         const TItemId * info;
 
@@ -687,7 +687,7 @@ protected:
         return IsSymLink(info);
     }
 
-    virtual BOOL STDMETHODCALLTYPE IsSymLink(const TItemId * info)
+    STDMETHOD_(BOOL, IsSymLink)(const TItemId * info)
     {
         return FALSE;
     }

--- a/dll/shellext/ntobjshex/ntobjenum.cpp
+++ b/dll/shellext/ntobjshex/ntobjenum.cpp
@@ -243,7 +243,7 @@ public:
         return S_OK;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE Next(ULONG celt, LPITEMIDLIST *rgelt, ULONG *pceltFetched)
+    STDMETHOD(Next)(ULONG celt, LPITEMIDLIST *rgelt, ULONG *pceltFetched) override
     {
         if (pceltFetched)
             *pceltFetched = 0;
@@ -263,7 +263,7 @@ public:
         return S_OK;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE Skip(ULONG celt)
+    STDMETHOD(Skip)(ULONG celt) override
     {
         while (celt > 0)
         {
@@ -277,12 +277,12 @@ public:
         return S_OK;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE Reset()
+    STDMETHOD(Reset)() override
     {
         return E_NOTIMPL;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE Clone(IEnumIDList **ppenum)
+    STDMETHOD(Clone)(IEnumIDList **ppenum) override
     {
         return E_NOTIMPL;
     }
@@ -495,7 +495,7 @@ public:
         return NextValue(ppidl);
     }
 
-    virtual HRESULT STDMETHODCALLTYPE Next(ULONG celt, LPITEMIDLIST *rgelt, ULONG *pceltFetched)
+    STDMETHOD(Next)(ULONG celt, LPITEMIDLIST *rgelt, ULONG *pceltFetched) override
     {
         if (pceltFetched)
             *pceltFetched = 0;
@@ -515,7 +515,7 @@ public:
         return S_OK;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE Skip(ULONG celt)
+    STDMETHOD(Skip)(ULONG celt) override
     {
         while (celt > 0)
         {
@@ -529,12 +529,12 @@ public:
         return S_OK;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE Reset()
+    STDMETHOD(Reset)() override
     {
         return E_NOTIMPL;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE Clone(IEnumIDList **ppenum)
+    STDMETHOD(Clone)(IEnumIDList **ppenum) override
     {
         return E_NOTIMPL;
     }
@@ -672,7 +672,7 @@ public:
         return S_OK;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE Next(ULONG celt, LPITEMIDLIST *rgelt, ULONG *pceltFetched)
+    STDMETHOD(Next)(ULONG celt, LPITEMIDLIST *rgelt, ULONG *pceltFetched) override
     {
         if (pceltFetched)
             *pceltFetched = 0;
@@ -692,7 +692,7 @@ public:
         return S_OK;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE Skip(ULONG celt)
+    STDMETHOD(Skip)(ULONG celt) override
     {
         while (celt > 0)
         {
@@ -706,12 +706,12 @@ public:
         return S_OK;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE Reset()
+    STDMETHOD(Reset)() override
     {
         return E_NOTIMPL;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE Clone(IEnumIDList **ppenum)
+    STDMETHOD(Clone)(IEnumIDList **ppenum) override
     {
         return E_NOTIMPL;
     }

--- a/dll/shellext/ntobjshex/ntobjfolder.h
+++ b/dll/shellext/ntobjshex/ntobjfolder.h
@@ -23,19 +23,19 @@ public:
 
     HRESULT Initialize(LPCWSTR ntPath, PCIDLIST_ABSOLUTE parent, UINT cidl, PCUITEMID_CHILD_ARRAY apidl);
 
-    virtual HRESULT STDMETHODCALLTYPE GetIconLocation(
+    STDMETHOD(GetIconLocation)(
         UINT uFlags,
         LPWSTR szIconFile,
         UINT cchMax,
         INT *piIndex,
-        UINT *pwFlags);
+        UINT *pwFlags) override;
 
-    virtual HRESULT STDMETHODCALLTYPE Extract(
+    STDMETHOD(Extract)(
         LPCWSTR pszFile,
         UINT nIconIndex,
         HICON *phiconLarge,
         HICON *phiconSmall,
-        UINT nIconSize);
+        UINT nIconSize) override;
 
     DECLARE_NOT_AGGREGATABLE(CNtObjectFolderExtractIcon)
     DECLARE_PROTECT_FINAL_CONSTRUCT()
@@ -58,55 +58,55 @@ public:
 
     // IShellFolder
 
-    virtual HRESULT STDMETHODCALLTYPE EnumObjects(
+    STDMETHOD(EnumObjects)(
         HWND hwndOwner,
         SHCONTF grfFlags,
-        IEnumIDList **ppenumIDList);
+        IEnumIDList **ppenumIDList) override;
 
 protected:
-    virtual HRESULT STDMETHODCALLTYPE InternalBindToObject(
+    STDMETHOD(InternalBindToObject)(
         PWSTR path,
         const NtPidlEntry * info,
         LPITEMIDLIST first,
         LPCITEMIDLIST rest,
         LPITEMIDLIST fullPidl,
         LPBC pbcReserved,
-        IShellFolder** ppsfChild);
+        IShellFolder** ppsfChild) override;
 
-    virtual HRESULT STDMETHODCALLTYPE ResolveSymLink(
+    STDMETHOD(ResolveSymLink)(
         const NtPidlEntry * info,
-        LPITEMIDLIST * fullPidl);
+        LPITEMIDLIST * fullPidl) override;
 
 public:
-    virtual HRESULT STDMETHODCALLTYPE GetDefaultColumnState(
+    STDMETHOD(GetDefaultColumnState)(
         UINT iColumn,
-        SHCOLSTATEF *pcsFlags);
+        SHCOLSTATEF *pcsFlags) override;
 
-    virtual HRESULT STDMETHODCALLTYPE GetDetailsEx(
+    STDMETHOD(GetDetailsEx)(
         LPCITEMIDLIST pidl,
         const SHCOLUMNID *pscid,
-        VARIANT *pv);
+        VARIANT *pv) override;
 
-    virtual HRESULT STDMETHODCALLTYPE GetDetailsOf(
+    STDMETHOD(GetDetailsOf)(
         LPCITEMIDLIST pidl,
         UINT iColumn,
-        SHELLDETAILS *psd);
+        SHELLDETAILS *psd) override;
 
-    virtual HRESULT STDMETHODCALLTYPE MapColumnToSCID(
+    STDMETHOD(MapColumnToSCID)(
         UINT iColumn,
-        SHCOLUMNID *pscid);
+        SHCOLUMNID *pscid) override;
 
     // IPersistFolder
-    virtual HRESULT STDMETHODCALLTYPE Initialize(PCIDLIST_ABSOLUTE pidl);
+    STDMETHOD(Initialize)(PCIDLIST_ABSOLUTE pidl) override;
 
     // Internal
-    HRESULT STDMETHODCALLTYPE Initialize(PCIDLIST_ABSOLUTE pidl, PCWSTR ntPath);
+    STDMETHOD(Initialize)(PCIDLIST_ABSOLUTE pidl, PCWSTR ntPath);
 
 protected:
-    virtual HRESULT STDMETHODCALLTYPE CompareIDs(LPARAM lParam, const NtPidlEntry * first, const NtPidlEntry * second);
-    virtual ULONG STDMETHODCALLTYPE ConvertAttributes(const NtPidlEntry * entry, PULONG inMask);
-    virtual BOOL STDMETHODCALLTYPE IsFolder(const NtPidlEntry * info);
-    virtual BOOL STDMETHODCALLTYPE IsSymLink(const NtPidlEntry * info);
+    STDMETHOD(CompareIDs)(LPARAM lParam, const NtPidlEntry * first, const NtPidlEntry * second) override;
+    STDMETHOD_(ULONG, ConvertAttributes)(const NtPidlEntry * entry, PULONG inMask) override;
+    STDMETHOD_(BOOL, IsFolder)(const NtPidlEntry * info) override;
+    STDMETHOD_(BOOL, IsSymLink)(const NtPidlEntry * info) override;
 
     virtual HRESULT GetInfoFromPidl(LPCITEMIDLIST pcidl, const NtPidlEntry ** pentry);
 

--- a/dll/shellext/ntobjshex/regfolder.h
+++ b/dll/shellext/ntobjshex/regfolder.h
@@ -23,19 +23,19 @@ public:
 
     HRESULT Initialize(LPCWSTR ntPath, PCIDLIST_ABSOLUTE parent, UINT cidl, PCUITEMID_CHILD_ARRAY apidl);
 
-    virtual HRESULT STDMETHODCALLTYPE GetIconLocation(
+    STDMETHOD(GetIconLocation)(
         UINT uFlags,
         LPWSTR szIconFile,
         UINT cchMax,
         INT *piIndex,
-        UINT *pwFlags);
+        UINT *pwFlags) override;
 
-    virtual HRESULT STDMETHODCALLTYPE Extract(
+    STDMETHOD(Extract)(
         LPCWSTR pszFile,
         UINT nIconIndex,
         HICON *phiconLarge,
         HICON *phiconSmall,
-        UINT nIconSize);
+        UINT nIconSize) override;
 
     DECLARE_NOT_AGGREGATABLE(CRegistryFolderExtractIcon)
     DECLARE_PROTECT_FINAL_CONSTRUCT()
@@ -59,50 +59,50 @@ public:
     virtual ~CRegistryFolder();
 
     // IShellFolder
-    virtual HRESULT STDMETHODCALLTYPE EnumObjects(
+    STDMETHOD(EnumObjects)(
         HWND hwndOwner,
         SHCONTF grfFlags,
-        IEnumIDList **ppenumIDList);
+        IEnumIDList **ppenumIDList) override;
 
 protected:
-    virtual HRESULT STDMETHODCALLTYPE InternalBindToObject(
+    STDMETHOD(InternalBindToObject)(
         PWSTR path,
         const RegPidlEntry * info,
         LPITEMIDLIST first,
         LPCITEMIDLIST rest,
         LPITEMIDLIST fullPidl,
         LPBC pbcReserved,
-        IShellFolder** ppsfChild);
+        IShellFolder** ppsfChild) override;
 
 public:
-    virtual HRESULT STDMETHODCALLTYPE GetDefaultColumnState(
+    STDMETHOD(GetDefaultColumnState)(
         UINT iColumn,
-        SHCOLSTATEF *pcsFlags);
+        SHCOLSTATEF *pcsFlags) override;
 
-    virtual HRESULT STDMETHODCALLTYPE GetDetailsEx(
+    STDMETHOD(GetDetailsEx)(
         LPCITEMIDLIST pidl,
         const SHCOLUMNID *pscid,
-        VARIANT *pv);
+        VARIANT *pv) override;
 
-    virtual HRESULT STDMETHODCALLTYPE GetDetailsOf(
+    STDMETHOD(GetDetailsOf)(
         LPCITEMIDLIST pidl,
         UINT iColumn,
-        SHELLDETAILS *psd);
+        SHELLDETAILS *psd) override;
 
-    virtual HRESULT STDMETHODCALLTYPE MapColumnToSCID(
+    STDMETHOD(MapColumnToSCID)(
         UINT iColumn,
-        SHCOLUMNID *pscid);
+        SHCOLUMNID *pscid) override;
 
     // IPersistFolder
-    virtual HRESULT STDMETHODCALLTYPE Initialize(PCIDLIST_ABSOLUTE pidl);
+    STDMETHOD(Initialize)(PCIDLIST_ABSOLUTE pidl) override;
 
     // Internal
-    virtual HRESULT STDMETHODCALLTYPE Initialize(PCIDLIST_ABSOLUTE pidl, PCWSTR ntPath, HKEY hRoot);
+    STDMETHOD(Initialize)(PCIDLIST_ABSOLUTE pidl, PCWSTR ntPath, HKEY hRoot);
 
 protected:
-    virtual HRESULT STDMETHODCALLTYPE CompareIDs(LPARAM lParam, const RegPidlEntry * first, const RegPidlEntry * second);
-    virtual ULONG STDMETHODCALLTYPE ConvertAttributes(const RegPidlEntry * entry, PULONG inMask);
-    virtual BOOL STDMETHODCALLTYPE IsFolder(const RegPidlEntry * info);
+    STDMETHOD(CompareIDs)(LPARAM lParam, const RegPidlEntry * first, const RegPidlEntry * second);
+    STDMETHOD_(ULONG, ConvertAttributes)(const RegPidlEntry * entry, PULONG inMask);
+    STDMETHOD_(BOOL, IsFolder)(const RegPidlEntry * info);
 
     virtual HRESULT GetInfoFromPidl(LPCITEMIDLIST pcidl, const RegPidlEntry ** pentry);
 


### PR DESCRIPTION
## Purpose

For simplicity and short typing. Macro `STDMETHOD` is defined in `<basetyps.h>` as follows:

```c
# define STDMETHOD(m) virtual HRESULT STDMETHODCALLTYPE m
# define STDMETHOD_(t,m) virtual t STDMETHODCALLTYPE m
```

JIRA issue: [CORE-19469](https://jira.reactos.org/browse/CORE-19469)

## Proposed changes

- Replace `virtual HRESULT STDMETHODCALLTYPE m` with `STDMETHOD(m)`.
- Replace `virtual t STDMETHODCALLTYPE m` with `STDMETHOD_(t,m)`.
- Use `override` keyword as possible.

## TODO

- [ ] Do build.