### PR TITLE
[ACPPAGE] Use STDMETHOD macro and keyword override

### DIFF
--- a/dll/shellext/acppage/CLayerStringList.hpp
+++ b/dll/shellext/acppage/CLayerStringList.hpp
@@ -28,7 +28,7 @@ public:
         SdbCloseDatabase(m_db);
     }
 
-    virtual HRESULT STDMETHODCALLTYPE Next(ULONG celt, LPOLESTR *rgelt, ULONG *pceltFetched)
+    STDMETHOD(Next)(ULONG celt, LPOLESTR *rgelt, ULONG *pceltFetched) override
     {
         if (pceltFetched)
             *pceltFetched = 0;
@@ -58,7 +58,7 @@ public:
         return celt ? S_FALSE : S_OK;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE Skip(ULONG celt)
+    STDMETHOD(Skip)(ULONG celt) override
     {
         while (m_layer && celt)
         {
@@ -68,7 +68,7 @@ public:
         return celt ? S_FALSE : S_OK;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE Reset()
+    STDMETHOD(Reset)() override
     {
         m_root = m_layer = TAGID_NULL;
         if (m_db)
@@ -83,7 +83,7 @@ public:
         return E_FAIL;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE Clone(IEnumString **ppenum)
+    STDMETHOD(Clone)(IEnumString **ppenum) override
     {
         return E_NOTIMPL;
     }


### PR DESCRIPTION
## Purpose

For simplicity and short typing. Macro `STDMETHOD` is defined in `<basetyps.h>` as follows:

```c
# define STDMETHOD(m) virtual HRESULT STDMETHODCALLTYPE m
# define STDMETHOD_(t,m) virtual t STDMETHODCALLTYPE m
```
C++11 keyword override is used for checking whether the method is overrided.

JIRA issue: [CORE-19469](https://jira.reactos.org/browse/CORE-19469)

## Proposed changes

- Replace `virtual HRESULT STDMETHODCALLTYPE m` with `STDMETHOD(m)` (`m` is a method name).
- Replace `virtual t STDMETHODCALLTYPE m` with `STDMETHOD_(t, m)` (`t` is a type. `m` is a method name).
- Use `override` keyword as possible.

## TODO

- [x] Do build.
