### PR TITLE
[NETSHELL] Use STDMETHOD macro and keyword override

### DIFF
--- a/dll/shellext/netshell/connectmanager.h
+++ b/dll/shellext/netshell/connectmanager.h
@@ -18,13 +18,13 @@ class CNetConnectionManager:
         HRESULT EnumerateINetConnections();
 
         // INetConnectionManager
-        virtual HRESULT WINAPI EnumConnections(NETCONMGR_ENUM_FLAGS Flags, IEnumNetConnection **ppEnum);
+        STDMETHOD(EnumConnections)(NETCONMGR_ENUM_FLAGS Flags, IEnumNetConnection **ppEnum) override;
 
         // IEnumNetConnection
-        virtual HRESULT WINAPI Next(ULONG celt, INetConnection **rgelt, ULONG *pceltFetched);
-        virtual HRESULT WINAPI Skip(ULONG celt);
-        virtual HRESULT WINAPI Reset();
-        virtual HRESULT WINAPI Clone(IEnumNetConnection **ppenum);
+        STDMETHOD(Next)(ULONG celt, INetConnection **rgelt, ULONG *pceltFetched) override;
+        STDMETHOD(Skip)(ULONG celt) override;
+        STDMETHOD(Reset)() override;
+        STDMETHOD(Clone)(IEnumNetConnection **ppenum) override;
 
     private:
         PINetConnectionItem m_pHead;
@@ -54,13 +54,13 @@ class CNetConnection:
         HRESULT WINAPI Initialize(PINetConnectionItem pItem);
 
         // INetConnection
-        HRESULT WINAPI Connect();
-        HRESULT WINAPI Disconnect();
-        HRESULT WINAPI Delete();
-        HRESULT WINAPI Duplicate(LPCWSTR pszwDuplicateName, INetConnection **ppCon);
-        HRESULT WINAPI GetProperties(NETCON_PROPERTIES **ppProps);
-        HRESULT WINAPI GetUiObjectClassId(CLSID *pclsid);
-        HRESULT WINAPI Rename(LPCWSTR pszwDuplicateName);
+        STDMETHOD(Connect)() override;
+        STDMETHOD(Disconnect)() override;
+        STDMETHOD(Delete)() override;
+        STDMETHOD(Duplicate)(LPCWSTR pszwDuplicateName, INetConnection **ppCon) override;
+        STDMETHOD(GetProperties)(NETCON_PROPERTIES **ppProps) override;
+        STDMETHOD(GetUiObjectClassId)(CLSID *pclsid) override;
+        STDMETHOD(Rename)(LPCWSTR pszwDuplicateName) override;
 
         DECLARE_NOT_AGGREGATABLE(CNetConnection)
         DECLARE_PROTECT_FINAL_CONSTRUCT()

--- a/dll/shellext/netshell/enumlist.cpp
+++ b/dll/shellext/netshell/enumlist.cpp
@@ -137,10 +137,10 @@ class CEnumIDList:
         HRESULT Initialize();
 
         // IEnumIDList
-        virtual HRESULT STDMETHODCALLTYPE Next(ULONG celt, PITEMID_CHILD *rgelt, ULONG *pceltFetched);
-        virtual HRESULT STDMETHODCALLTYPE Skip(ULONG celt);
-        virtual HRESULT STDMETHODCALLTYPE Reset();
-        virtual HRESULT STDMETHODCALLTYPE Clone(IEnumIDList **ppenum);
+        STDMETHOD(Next)(ULONG celt, PITEMID_CHILD *rgelt, ULONG *pceltFetched) override;
+        STDMETHOD(Skip)(ULONG celt) override;
+        STDMETHOD(Reset)() override;
+        STDMETHOD(Clone)(IEnumIDList **ppenum) override;
 
     private:
         BOOL AddToEnumList(PITEMID_CHILD pidl);

--- a/dll/shellext/netshell/lanconnectui.h
+++ b/dll/shellext/netshell/lanconnectui.h
@@ -31,16 +31,16 @@ class CNetConnectionPropertyUi:
         ~CNetConnectionPropertyUi();
 
         // INetConnectionPropertyUi2
-        virtual HRESULT WINAPI AddPages(HWND hwndParent, LPFNADDPROPSHEETPAGE pfnAddPage, LPARAM lParam);
-        virtual HRESULT WINAPI GetIcon(DWORD dwSize, HICON *phIcon);
+        STDMETHOD(AddPages)(HWND hwndParent, LPFNADDPROPSHEETPAGE pfnAddPage, LPARAM lParam) override;
+        STDMETHOD(GetIcon)(DWORD dwSize, HICON *phIcon) override;
 
         // INetLanConnectionUiInfo
-        virtual HRESULT WINAPI GetDeviceGuid(GUID *pGuid);
+        STDMETHOD(GetDeviceGuid)(GUID *pGuid) override;
 
         // INetConnectionConnectUi
-        virtual HRESULT WINAPI SetConnection(INetConnection* pCon);
-        virtual HRESULT WINAPI Connect(HWND hwndParent, DWORD dwFlags);
-        virtual HRESULT WINAPI Disconnect(HWND hwndParent, DWORD dwFlags);
+        STDMETHOD(SetConnection)(INetConnection* pCon) override;
+        STDMETHOD(Connect)(HWND hwndParent, DWORD dwFlags) override;
+        STDMETHOD(Disconnect)(HWND hwndParent, DWORD dwFlags) override;
 
     private:
         BOOL GetINetCfgComponent(INetCfg *pNCfg, INetCfgComponent ** pOut);

--- a/dll/shellext/netshell/lanstatusui.h
+++ b/dll/shellext/netshell/lanstatusui.h
@@ -40,8 +40,8 @@ class CLanStatus:
         CLanStatus();
 
         // IOleCommandTarget
-        virtual HRESULT WINAPI QueryStatus(const GUID *pguidCmdGroup, ULONG cCmds, OLECMD *prgCmds, OLECMDTEXT *pCmdText);
-        virtual HRESULT WINAPI Exec(const GUID *pguidCmdGroup, DWORD nCmdID, DWORD nCmdexecopt, VARIANT *pvaIn, VARIANT *pvaOut);
+        STDMETHOD(QueryStatus)(const GUID *pguidCmdGroup, ULONG cCmds, OLECMD *prgCmds, OLECMDTEXT *pCmdText) override;
+        STDMETHOD(Exec)(const GUID *pguidCmdGroup, DWORD nCmdID, DWORD nCmdexecopt, VARIANT *pvaIn, VARIANT *pvaOut) override;
 
     private:
         HRESULT InitializeNetTaskbarNotifications();

--- a/dll/shellext/netshell/shfldr_netconnect.h
+++ b/dll/shellext/netshell/shfldr_netconnect.h
@@ -22,43 +22,43 @@ class CNetworkConnections:
         ~CNetworkConnections();
 
         // IPersistFolder2
-        virtual HRESULT WINAPI GetClassID(CLSID *lpClassId);
-        virtual HRESULT WINAPI Initialize(PCIDLIST_ABSOLUTE pidl);
-        virtual HRESULT WINAPI GetCurFolder(PIDLIST_ABSOLUTE *pidl);
+        STDMETHOD(GetClassID)(CLSID *lpClassId) override;
+        STDMETHOD(Initialize)(PCIDLIST_ABSOLUTE pidl) override;
+        STDMETHOD(GetCurFolder)(PIDLIST_ABSOLUTE *pidl) override;
 
         // IShellFolder
-        virtual HRESULT WINAPI ParseDisplayName(HWND hwndOwner, LPBC pbc, LPOLESTR lpszDisplayName, DWORD *pchEaten, PIDLIST_RELATIVE *ppidl, DWORD *pdwAttributes);
-        virtual HRESULT WINAPI EnumObjects(HWND hwndOwner, DWORD dwFlags, LPENUMIDLIST *ppEnumIDList);
-        virtual HRESULT WINAPI BindToObject(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut);
-        virtual HRESULT WINAPI BindToStorage(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut);
-        virtual HRESULT WINAPI CompareIDs(LPARAM lParam, PCUIDLIST_RELATIVE pidl1, PCUIDLIST_RELATIVE pidl2);
-        virtual HRESULT WINAPI CreateViewObject(HWND hwndOwner, REFIID riid, LPVOID *ppvOut);
-        virtual HRESULT WINAPI GetAttributesOf(UINT cidl, PCUITEMID_CHILD_ARRAY apidl, DWORD *rgfInOut);
-        virtual HRESULT WINAPI GetUIObjectOf(HWND hwndOwner, UINT cidl, PCUITEMID_CHILD_ARRAY apidl, REFIID riid, UINT * prgfInOut, LPVOID * ppvOut);
-        virtual HRESULT WINAPI GetDisplayNameOf(PCUITEMID_CHILD pidl, DWORD dwFlags, LPSTRRET strRet);
-        virtual HRESULT WINAPI SetNameOf(HWND hwndOwner, PCUITEMID_CHILD pidl, LPCOLESTR lpName, DWORD dwFlags, PITEMID_CHILD *pPidlOut);
+        STDMETHOD(ParseDisplayName)(HWND hwndOwner, LPBC pbc, LPOLESTR lpszDisplayName, DWORD *pchEaten, PIDLIST_RELATIVE *ppidl, DWORD *pdwAttributes) override;
+        STDMETHOD(EnumObjects)(HWND hwndOwner, DWORD dwFlags, LPENUMIDLIST *ppEnumIDList) override;
+        STDMETHOD(BindToObject)(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut) override;
+        STDMETHOD(BindToStorage)(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut) override;
+        STDMETHOD(CompareIDs)(LPARAM lParam, PCUIDLIST_RELATIVE pidl1, PCUIDLIST_RELATIVE pidl2) override;
+        STDMETHOD(CreateViewObject)(HWND hwndOwner, REFIID riid, LPVOID *ppvOut) override;
+        STDMETHOD(GetAttributesOf)(UINT cidl, PCUITEMID_CHILD_ARRAY apidl, DWORD *rgfInOut) override;
+        STDMETHOD(GetUIObjectOf)(HWND hwndOwner, UINT cidl, PCUITEMID_CHILD_ARRAY apidl, REFIID riid, UINT * prgfInOut, LPVOID * ppvOut) override;
+        STDMETHOD(GetDisplayNameOf)(PCUITEMID_CHILD pidl, DWORD dwFlags, LPSTRRET strRet) override;
+        STDMETHOD(SetNameOf)(HWND hwndOwner, PCUITEMID_CHILD pidl, LPCOLESTR lpName, DWORD dwFlags, PITEMID_CHILD *pPidlOut) override;
 
         // IShellFolder2
-        virtual HRESULT WINAPI GetDefaultSearchGUID(GUID *pguid);
-        virtual HRESULT WINAPI EnumSearches(IEnumExtraSearch **ppenum);
-        virtual HRESULT WINAPI GetDefaultColumn(DWORD dwRes, ULONG *pSort, ULONG *pDisplay);
-        virtual HRESULT WINAPI GetDefaultColumnState(UINT iColumn, DWORD *pcsFlags);
-        virtual HRESULT WINAPI GetDetailsEx(PCUITEMID_CHILD pidl, const SHCOLUMNID *pscid, VARIANT *pv);
-        virtual HRESULT WINAPI GetDetailsOf(PCUITEMID_CHILD pidl, UINT iColumn, SHELLDETAILS *psd);
-        virtual HRESULT WINAPI MapColumnToSCID(UINT column, SHCOLUMNID *pscid);
+        STDMETHOD(GetDefaultSearchGUID)(GUID *pguid) override;
+        STDMETHOD(EnumSearches)(IEnumExtraSearch **ppenum) override;
+        STDMETHOD(GetDefaultColumn)(DWORD dwRes, ULONG *pSort, ULONG *pDisplay) override;
+        STDMETHOD(GetDefaultColumnState)(UINT iColumn, DWORD *pcsFlags) override;
+        STDMETHOD(GetDetailsEx)(PCUITEMID_CHILD pidl, const SHCOLUMNID *pscid, VARIANT *pv) override;
+        STDMETHOD(GetDetailsOf)(PCUITEMID_CHILD pidl, UINT iColumn, SHELLDETAILS *psd) override;
+        STDMETHOD(MapColumnToSCID)(UINT column, SHCOLUMNID *pscid) override;
 
         // IShellExtInit
-        virtual HRESULT WINAPI Initialize(PCIDLIST_ABSOLUTE pidlFolder, IDataObject *pdtobj, HKEY hkeyProgID);
+        STDMETHOD(Initialize)(PCIDLIST_ABSOLUTE pidlFolder, IDataObject *pdtobj, HKEY hkeyProgID) override;
 
         // IOleCommandTarget
-        virtual HRESULT WINAPI Exec(const GUID *pguidCmdGroup, DWORD nCmdID, DWORD nCmdexecopt, VARIANT *pvaIn, VARIANT *pvaOut);
-        virtual HRESULT WINAPI QueryStatus(const GUID *pguidCmdGroup, ULONG cCmds, OLECMD prgCmds[], OLECMDTEXT *pCmdText);
+        STDMETHOD(Exec)(const GUID *pguidCmdGroup, DWORD nCmdID, DWORD nCmdexecopt, VARIANT *pvaIn, VARIANT *pvaOut) override;
+        STDMETHOD(QueryStatus)(const GUID *pguidCmdGroup, ULONG cCmds, OLECMD prgCmds[], OLECMDTEXT *pCmdText) override;
 
         // IShellFolderViewCB
-        virtual HRESULT WINAPI MessageSFVCB(UINT uMsg, WPARAM wParam, LPARAM lParam);
+        STDMETHOD(MessageSFVCB)(UINT uMsg, WPARAM wParam, LPARAM lParam) override;
 
         // IShellExecuteHookW
-        virtual HRESULT WINAPI Execute(LPSHELLEXECUTEINFOW pei);
+        STDMETHOD(Execute)(LPSHELLEXECUTEINFOW pei) override;
 
     private:
 

--- a/dll/shellext/netshell/shfldr_netconnect.h
+++ b/dll/shellext/netshell/shfldr_netconnect.h
@@ -103,23 +103,23 @@ class CNetConUiObject:
         HRESULT WINAPI Initialize(PCUITEMID_CHILD pidl, IOleCommandTarget *lpOleCmd);
 
         // IContextMenu3
-        virtual HRESULT WINAPI QueryContextMenu(HMENU hmenu, UINT indexMenu, UINT idCmdFirst, UINT idCmdLast, UINT uFlags);
-        virtual HRESULT WINAPI InvokeCommand(LPCMINVOKECOMMANDINFO lpici);
-        virtual HRESULT WINAPI GetCommandString(UINT_PTR idCmd, UINT uType, UINT *pwReserved, LPSTR pszName, UINT cchMax);
-        virtual HRESULT WINAPI HandleMenuMsg( UINT uMsg, WPARAM wParam, LPARAM lParam);
-        virtual HRESULT WINAPI HandleMenuMsg2(UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT *plResult);
+        STDMETHOD(QueryContextMenu)(HMENU hmenu, UINT indexMenu, UINT idCmdFirst, UINT idCmdLast, UINT uFlags) override;
+        STDMETHOD(InvokeCommand)(LPCMINVOKECOMMANDINFO lpici) override;
+        STDMETHOD(GetCommandString)(UINT_PTR idCmd, UINT uType, UINT *pwReserved, LPSTR pszName, UINT cchMax) override;
+        STDMETHOD(HandleMenuMsg)( UINT uMsg, WPARAM wParam, LPARAM lParam) override;
+        STDMETHOD(HandleMenuMsg2)(UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT *plResult) override;
 
         // IObjectWithSite
-        virtual HRESULT WINAPI SetSite(IUnknown *punk);
-        virtual HRESULT WINAPI GetSite(REFIID iid, void **ppvSite);
+        STDMETHOD(SetSite)(IUnknown *punk) override;
+        STDMETHOD(GetSite)(REFIID iid, void **ppvSite) override;
 
         // IQueryInfo
-        virtual HRESULT WINAPI GetInfoFlags(DWORD *pdwFlags);
-        virtual HRESULT WINAPI GetInfoTip(DWORD dwFlags, WCHAR **ppwszTip);
+        STDMETHOD(GetInfoFlags)(DWORD *pdwFlags) override;
+        STDMETHOD(GetInfoTip)(DWORD dwFlags, WCHAR **ppwszTip) override;
 
         // IExtractIconW
-        virtual HRESULT STDMETHODCALLTYPE GetIconLocation(UINT uFlags, LPWSTR szIconFile, UINT cchMax, int *piIndex, UINT *pwFlags);
-        virtual HRESULT STDMETHODCALLTYPE Extract(LPCWSTR pszFile, UINT nIconIndex, HICON *phiconLarge, HICON *phiconSmall, UINT nIconSize);
+        STDMETHOD(GetIconLocation)(UINT uFlags, LPWSTR szIconFile, UINT cchMax, int *piIndex, UINT *pwFlags) override;
+        STDMETHOD(Extract)(LPCWSTR pszFile, UINT nIconIndex, HICON *phiconLarge, HICON *phiconSmall, UINT nIconSize) override;
 
         BEGIN_COM_MAP(CNetConUiObject)
             COM_INTERFACE_ENTRY_IID(IID_IContextMenu, IContextMenu3)


### PR DESCRIPTION
## Purpose

For simplicity and short typing. Macro `STDMETHOD` is defined in `<basetyps.h>` as follows:

```c
# define STDMETHOD(m) virtual HRESULT STDMETHODCALLTYPE m
# define STDMETHOD_(t,m) virtual t STDMETHODCALLTYPE m
```
C++11 keyword `override` is used for checking whether the method is overrided.

JIRA issue: [CORE-19469](https://jira.reactos.org/browse/CORE-19469)

## Proposed changes

- Replace `virtual HRESULT STDMETHODCALLTYPE m` with `STDMETHOD(m)` (`m` is a method name).
- Replace `virtual t STDMETHODCALLTYPE m` with `STDMETHOD_(t, m)` (`t` is a type. `m` is a method name).
- Use `override` keyword as possible.

## TODO

- [x] Do build.