### PR TITLE
[BROWSEUI] Use STDMETHOD macro and keyword override

### DIFF
--- a/dll/win32/browseui/CProgressDialog.h
+++ b/dll/win32/browseui/CProgressDialog.h
@@ -55,20 +55,20 @@ public:
     ~CProgressDialog();
 
     // IProgressDialog
-    virtual HRESULT WINAPI StartProgressDialog(HWND hwndParent, IUnknown *punkEnableModeless, DWORD dwFlags, LPCVOID reserved);
-    virtual HRESULT WINAPI StopProgressDialog();
-    virtual HRESULT WINAPI SetTitle(LPCWSTR pwzTitle);
-    virtual HRESULT WINAPI SetAnimation(HINSTANCE hInstance, UINT uiResourceId);
-    virtual BOOL    WINAPI HasUserCancelled();
-    virtual HRESULT WINAPI SetProgress64(ULONGLONG ullCompleted, ULONGLONG ullTotal);
-    virtual HRESULT WINAPI SetProgress(DWORD dwCompleted, DWORD dwTotal);
-    virtual HRESULT WINAPI SetLine(DWORD dwLineNum, LPCWSTR pwzLine, BOOL bPath, LPCVOID reserved);
-    virtual HRESULT WINAPI SetCancelMsg(LPCWSTR pwzMsg, LPCVOID reserved);
-    virtual HRESULT WINAPI Timer(DWORD dwTimerAction, LPCVOID reserved);
+    STDMETHOD(StartProgressDialog)(HWND hwndParent, IUnknown *punkEnableModeless, DWORD dwFlags, LPCVOID reserved) override;
+    STDMETHOD(StopProgressDialog)() override;
+    STDMETHOD(SetTitle)(LPCWSTR pwzTitle) override;
+    STDMETHOD(SetAnimation)(HINSTANCE hInstance, UINT uiResourceId) override;
+    STDMETHOD_(BOOL, HasUserCancelled)() override;
+    STDMETHOD(SetProgress64)(ULONGLONG ullCompleted, ULONGLONG ullTotal) override;
+    STDMETHOD(SetProgress)(DWORD dwCompleted, DWORD dwTotal) override;
+    STDMETHOD(SetLine)(DWORD dwLineNum, LPCWSTR pwzLine, BOOL bPath, LPCVOID reserved) override;
+    STDMETHOD(SetCancelMsg)(LPCWSTR pwzMsg, LPCVOID reserved) override;
+    STDMETHOD(Timer)(DWORD dwTimerAction, LPCVOID reserved) override;
 
-    //////// IOleWindow
-    virtual HRESULT WINAPI GetWindow(HWND* phwnd);
-    virtual HRESULT WINAPI ContextSensitiveHelp(BOOL fEnterMode);
+    // IOleWindow
+    STDMETHOD(GetWindow)(HWND* phwnd) override;
+    STDMETHOD(ContextSensitiveHelp)(BOOL fEnterMode) override;
 
 DECLARE_REGISTRY_RESOURCEID(IDR_PROGRESSDIALOG)
 DECLARE_NOT_AGGREGATABLE(CProgressDialog)

--- a/dll/win32/browseui/CTaskbarList.h
+++ b/dll/win32/browseui/CTaskbarList.h
@@ -24,15 +24,14 @@ public:
     virtual ~CTaskbarList();
 
     /*** ITaskbarList2 methods ***/
-    virtual HRESULT WINAPI MarkFullscreenWindow(HWND hwnd, BOOL fFullscreen);
+    STDMETHOD(MarkFullscreenWindow)(HWND hwnd, BOOL fFullscreen) override;
 
     /*** ITaskbarList methods ***/
-    virtual HRESULT STDMETHODCALLTYPE HrInit();
-    virtual HRESULT STDMETHODCALLTYPE AddTab(HWND hwnd);
-    virtual HRESULT STDMETHODCALLTYPE DeleteTab(HWND hwnd);
-    virtual HRESULT STDMETHODCALLTYPE ActivateTab(HWND hwnd);
-    virtual HRESULT STDMETHODCALLTYPE SetActiveAlt(HWND hwnd);
-
+    STDMETHOD(HrInit)() override;
+    STDMETHOD(AddTab)(HWND hwnd) override;
+    STDMETHOD(DeleteTab)(HWND hwnd) override;
+    STDMETHOD(ActivateTab)(HWND hwnd) override;
+    STDMETHOD(SetActiveAlt)(HWND hwnd) override;
 
     DECLARE_REGISTRY_RESOURCEID(IDR_TASKBARLIST)
     DECLARE_NOT_AGGREGATABLE(CTaskbarList)

--- a/dll/win32/browseui/aclistisf.h
+++ b/dll/win32/browseui/aclistisf.h
@@ -62,32 +62,30 @@ public:
                      CComHeapPtr<WCHAR>& pszExpanded);
 
     // *** IEnumString methods ***
-    STDMETHODIMP Next(ULONG celt, LPOLESTR *rgelt, ULONG *pceltFetched) override;
-    STDMETHODIMP Skip(ULONG celt) override;
-    STDMETHODIMP Reset() override;
-    STDMETHODIMP Clone(IEnumString **ppenum) override;
+    STDMETHOD(Next)(ULONG celt, LPOLESTR *rgelt, ULONG *pceltFetched) override;
+    STDMETHOD(Skip)(ULONG celt) override;
+    STDMETHOD(Reset)() override;
+    STDMETHOD(Clone)(IEnumString **ppenum) override;
 
     // *** IACList methods ***
-    STDMETHODIMP Expand(LPCOLESTR pszExpand) override;
+    STDMETHOD(Expand)(LPCOLESTR pszExpand) override;
 
     // *** IACList2 methods ***
-    STDMETHODIMP SetOptions(DWORD dwFlag) override;
-    STDMETHODIMP GetOptions(DWORD* pdwFlag) override;
-
-    // FIXME: These virtual keywords below should be removed.
+    STDMETHOD(SetOptions)(DWORD dwFlag) override;
+    STDMETHOD(GetOptions)(DWORD* pdwFlag) override;
 
     // *** IShellService methods ***
-    virtual STDMETHODIMP SetOwner(IUnknown *punkOwner) override;
+    STDMETHOD(SetOwner)(IUnknown *punkOwner) override;
 
     // *** IPersist methods ***
-    virtual STDMETHODIMP GetClassID(CLSID *pClassID) override;
+    STDMETHOD(GetClassID)(CLSID *pClassID) override;
 
     // *** IPersistFolder methods ***
-    virtual STDMETHODIMP Initialize(PCIDLIST_ABSOLUTE pidl) override;
+    STDMETHOD(Initialize)(PCIDLIST_ABSOLUTE pidl) override;
 
     // *** ICurrentWorkingDirectory methods ***
-    STDMETHODIMP GetDirectory(LPWSTR pwzPath, DWORD cchSize) override;
-    STDMETHODIMP SetDirectory(LPCWSTR pwzPath) override;
+    STDMETHOD(GetDirectory)(LPWSTR pwzPath, DWORD cchSize) override;
+    STDMETHOD(SetDirectory)(LPCWSTR pwzPath) override;
 
 public:
     DECLARE_REGISTRY_RESOURCEID(IDR_ACLISTISF)

--- a/dll/win32/browseui/aclmulti.h
+++ b/dll/win32/browseui/aclmulti.h
@@ -44,17 +44,17 @@ public:
     ~CACLMulti();
 
     // *** IEnumString methods ***
-    virtual HRESULT STDMETHODCALLTYPE Next(ULONG celt, LPOLESTR *rgelt, ULONG *pceltFetched);
-    virtual HRESULT STDMETHODCALLTYPE Skip(ULONG celt);
-    virtual HRESULT STDMETHODCALLTYPE Reset();
-    virtual HRESULT STDMETHODCALLTYPE Clone(IEnumString **ppenum);
+    STDMETHOD(Next)(ULONG celt, LPOLESTR *rgelt, ULONG *pceltFetched) override;
+    STDMETHOD(Skip)(ULONG celt) override;
+    STDMETHOD(Reset)() override;
+    STDMETHOD(Clone)(IEnumString **ppenum) override;
 
     // *** IACList methods ***
-    virtual HRESULT STDMETHODCALLTYPE Expand(LPCOLESTR pszExpand);
+    STDMETHOD(Expand)(LPCOLESTR pszExpand) override;
 
     // *** IObjMgr methods ***
-    virtual HRESULT STDMETHODCALLTYPE Append(IUnknown *punk);
-    virtual HRESULT STDMETHODCALLTYPE Remove(IUnknown *punk);
+    STDMETHOD(Append)(IUnknown *punk) override;
+    STDMETHOD(Remove)(IUnknown *punk) override;
 
 private:
     void release_obj(struct ACLMultiSublist *obj);

--- a/dll/win32/browseui/addressband.h
+++ b/dll/win32/browseui/addressband.h
@@ -52,52 +52,52 @@ private:
     void CreateGoButton();
 public:
     // *** IDeskBand methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetBandInfo(DWORD dwBandID, DWORD dwViewMode, DESKBANDINFO *pdbi);
+    STDMETHOD(GetBandInfo)(DWORD dwBandID, DWORD dwViewMode, DESKBANDINFO *pdbi) override;
 
     // *** IObjectWithSite methods ***
-    virtual HRESULT STDMETHODCALLTYPE SetSite(IUnknown *pUnkSite);
-    virtual HRESULT STDMETHODCALLTYPE GetSite(REFIID riid, void **ppvSite);
+    STDMETHOD(SetSite)(IUnknown *pUnkSite) override;
+    STDMETHOD(GetSite)(REFIID riid, void **ppvSite) override;
 
     // *** IOleWindow methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetWindow(HWND *lphwnd);
-    virtual HRESULT STDMETHODCALLTYPE ContextSensitiveHelp(BOOL fEnterMode);
+    STDMETHOD(GetWindow)(HWND *lphwnd) override;
+    STDMETHOD(ContextSensitiveHelp)(BOOL fEnterMode) override;
 
     // *** IDockingWindow methods ***
-    virtual HRESULT STDMETHODCALLTYPE CloseDW(DWORD dwReserved);
-    virtual HRESULT STDMETHODCALLTYPE ResizeBorderDW(const RECT *prcBorder, IUnknown *punkToolbarSite, BOOL fReserved);
-    virtual HRESULT STDMETHODCALLTYPE ShowDW(BOOL fShow);
+    STDMETHOD(CloseDW)(DWORD dwReserved) override;
+    STDMETHOD(ResizeBorderDW)(const RECT *prcBorder, IUnknown *punkToolbarSite, BOOL fReserved) override;
+    STDMETHOD(ShowDW)(BOOL fShow) override;
 
     // *** IOleCommandTarget methods ***
-    virtual HRESULT STDMETHODCALLTYPE QueryStatus(const GUID *pguidCmdGroup, ULONG cCmds, OLECMD prgCmds[  ], OLECMDTEXT *pCmdText);
-    virtual HRESULT STDMETHODCALLTYPE Exec(const GUID *pguidCmdGroup, DWORD nCmdID, DWORD nCmdexecopt, VARIANT *pvaIn, VARIANT *pvaOut);
+    STDMETHOD(QueryStatus)(const GUID *pguidCmdGroup, ULONG cCmds, OLECMD prgCmds[  ], OLECMDTEXT *pCmdText) override;
+    STDMETHOD(Exec)(const GUID *pguidCmdGroup, DWORD nCmdID, DWORD nCmdexecopt, VARIANT *pvaIn, VARIANT *pvaOut) override;
 
     // *** IInputObject methods ***
-    virtual HRESULT STDMETHODCALLTYPE UIActivateIO(BOOL fActivate, LPMSG lpMsg);
-    virtual HRESULT STDMETHODCALLTYPE HasFocusIO();
-    virtual HRESULT STDMETHODCALLTYPE TranslateAcceleratorIO(LPMSG lpMsg);
+    STDMETHOD(UIActivateIO)(BOOL fActivate, LPMSG lpMsg) override;
+    STDMETHOD(HasFocusIO)() override;
+    STDMETHOD(TranslateAcceleratorIO)(LPMSG lpMsg) override;
 
     // *** IWinEventHandler methods ***
-    virtual HRESULT STDMETHODCALLTYPE OnWinEvent(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT *theResult);
-    virtual HRESULT STDMETHODCALLTYPE IsWindowOwner(HWND hWnd);
+    STDMETHOD(OnWinEvent)(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT *theResult) override;
+    STDMETHOD(IsWindowOwner)(HWND hWnd) override;
 
     // *** IAddressBand methods ***
-    virtual HRESULT STDMETHODCALLTYPE FileSysChange(long param8, long paramC);
-    virtual HRESULT STDMETHODCALLTYPE Refresh(long param8);
+    STDMETHOD(FileSysChange)(long param8, long paramC) override;
+    STDMETHOD(Refresh)(long param8) override;
 
     // *** IServiceProvider methods ***
-    virtual HRESULT STDMETHODCALLTYPE QueryService(REFGUID guidService, REFIID riid, void **ppvObject);
+    STDMETHOD(QueryService)(REFGUID guidService, REFIID riid, void **ppvObject) override;
 
     // *** IInputObjectSite methods ***
-    virtual HRESULT STDMETHODCALLTYPE OnFocusChangeIS(IUnknown *punkObj, BOOL fSetFocus);
+    STDMETHOD(OnFocusChangeIS)(IUnknown *punkObj, BOOL fSetFocus) override;
 
     // *** IPersist methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetClassID(CLSID *pClassID);
+    STDMETHOD(GetClassID)(CLSID *pClassID) override;
 
     // *** IPersistStream methods ***
-    virtual HRESULT STDMETHODCALLTYPE IsDirty();
-    virtual HRESULT STDMETHODCALLTYPE Load(IStream *pStm);
-    virtual HRESULT STDMETHODCALLTYPE Save(IStream *pStm, BOOL fClearDirty);
-    virtual HRESULT STDMETHODCALLTYPE GetSizeMax(ULARGE_INTEGER *pcbSize);
+    STDMETHOD(IsDirty)() override;
+    STDMETHOD(Load)(IStream *pStm) override;
+    STDMETHOD(Save)(IStream *pStm, BOOL fClearDirty) override;
+    STDMETHOD(GetSizeMax)(ULARGE_INTEGER *pcbSize) override;
 
     // message handlers
     LRESULT OnNotifyClick(WPARAM wParam, NMHDR *notifyHeader, BOOL &bHandled);

--- a/dll/win32/browseui/addresseditbox.h
+++ b/dll/win32/browseui/addresseditbox.h
@@ -54,41 +54,41 @@ private:
     HRESULT RefreshAddress();
 public:
     // *** IShellService methods ***
-    virtual HRESULT STDMETHODCALLTYPE SetOwner(IUnknown *);
+    STDMETHOD(SetOwner)(IUnknown *) override;
 
     // *** IAddressBand methods ***
-    virtual HRESULT STDMETHODCALLTYPE FileSysChange(long param8, long paramC);
-    virtual HRESULT STDMETHODCALLTYPE Refresh(long param8);
+    STDMETHOD(FileSysChange)(long param8, long paramC) override;
+    STDMETHOD(Refresh)(long param8) override;
 
     // *** IAddressEditBox methods ***
-    virtual HRESULT STDMETHODCALLTYPE Init(HWND comboboxEx, HWND editControl, long param14, IUnknown *param18);
-    virtual HRESULT STDMETHODCALLTYPE SetCurrentDir(long paramC);
-    virtual HRESULT STDMETHODCALLTYPE ParseNow(long paramC);
-    virtual HRESULT STDMETHODCALLTYPE Execute(long paramC);
-    virtual HRESULT STDMETHODCALLTYPE Save(long paramC);
+    STDMETHOD(Init)(HWND comboboxEx, HWND editControl, long param14, IUnknown *param18) override;
+    STDMETHOD(SetCurrentDir)(long paramC) override;
+    STDMETHOD(ParseNow)(long paramC) override;
+    STDMETHOD(Execute)(long paramC) override;
+    STDMETHOD(Save)(long paramC) override;
 
     // *** IWinEventHandler methods ***
-    virtual HRESULT STDMETHODCALLTYPE OnWinEvent(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT *theResult);
-    virtual HRESULT STDMETHODCALLTYPE IsWindowOwner(HWND hWnd);
+    STDMETHOD(OnWinEvent)(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT *theResult) override;
+    STDMETHOD(IsWindowOwner)(HWND hWnd) override;
 
     // *** IOleCommandTarget methods ***
-    virtual HRESULT STDMETHODCALLTYPE QueryStatus(const GUID *pguidCmdGroup, ULONG cCmds, OLECMD prgCmds[  ], OLECMDTEXT *pCmdText);
-    virtual HRESULT STDMETHODCALLTYPE Exec(const GUID *pguidCmdGroup, DWORD nCmdID, DWORD nCmdexecopt, VARIANT *pvaIn, VARIANT *pvaOut);
+    STDMETHOD(QueryStatus)(const GUID *pguidCmdGroup, ULONG cCmds, OLECMD prgCmds[  ], OLECMDTEXT *pCmdText) override;
+    STDMETHOD(Exec)(const GUID *pguidCmdGroup, DWORD nCmdID, DWORD nCmdexecopt, VARIANT *pvaIn, VARIANT *pvaOut) override;
 
     // *** IDispatch methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetTypeInfoCount(UINT *pctinfo);
-    virtual HRESULT STDMETHODCALLTYPE GetTypeInfo(UINT iTInfo, LCID lcid, ITypeInfo **ppTInfo);
-    virtual HRESULT STDMETHODCALLTYPE GetIDsOfNames(REFIID riid, LPOLESTR *rgszNames, UINT cNames, LCID lcid, DISPID *rgDispId);
-    virtual HRESULT STDMETHODCALLTYPE Invoke(DISPID dispIdMember, REFIID riid, LCID lcid, WORD wFlags, DISPPARAMS *pDispParams, VARIANT *pVarResult, EXCEPINFO *pExcepInfo, UINT *puArgErr);
+    STDMETHOD(GetTypeInfoCount)(UINT *pctinfo) override;
+    STDMETHOD(GetTypeInfo)(UINT iTInfo, LCID lcid, ITypeInfo **ppTInfo) override;
+    STDMETHOD(GetIDsOfNames)(REFIID riid, LPOLESTR *rgszNames, UINT cNames, LCID lcid, DISPID *rgDispId) override;
+    STDMETHOD(Invoke)(DISPID dispIdMember, REFIID riid, LCID lcid, WORD wFlags, DISPPARAMS *pDispParams, VARIANT *pVarResult, EXCEPINFO *pExcepInfo, UINT *puArgErr) override;
 
     // *** IPersist methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetClassID(CLSID *pClassID);
+    STDMETHOD(GetClassID)(CLSID *pClassID) override;
 
     // *** IPersistStream methods ***
-    virtual HRESULT STDMETHODCALLTYPE IsDirty();
-    virtual HRESULT STDMETHODCALLTYPE Load(IStream *pStm);
-    virtual HRESULT STDMETHODCALLTYPE Save(IStream *pStm, BOOL fClearDirty);
-    virtual HRESULT STDMETHODCALLTYPE GetSizeMax(ULARGE_INTEGER *pcbSize);
+    STDMETHOD(IsDirty)() override;
+    STDMETHOD(Load)(IStream *pStm) override;
+    STDMETHOD(Save)(IStream *pStm, BOOL fClearDirty) override;
+    STDMETHOD(GetSizeMax)(ULARGE_INTEGER *pcbSize) override;
 
     // message handlers
     LRESULT OnSettingChange(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);

--- a/dll/win32/browseui/bandproxy.h
+++ b/dll/win32/browseui/bandproxy.h
@@ -33,12 +33,12 @@ public:
     HRESULT FindBrowserWindow(IUnknown **browser);
 
     // *** IBandProxy methods ***
-    virtual HRESULT STDMETHODCALLTYPE SetSite(IUnknown *paramC);
-    virtual HRESULT STDMETHODCALLTYPE CreateNewWindow(long paramC);
-    virtual HRESULT STDMETHODCALLTYPE GetBrowserWindow(IUnknown **paramC);
-    virtual HRESULT STDMETHODCALLTYPE IsConnected();
-    virtual HRESULT STDMETHODCALLTYPE NavigateToPIDL(LPCITEMIDLIST pidl);
-    virtual HRESULT STDMETHODCALLTYPE NavigateToURL(long paramC, long param10);
+    STDMETHOD(SetSite)(IUnknown *paramC) override;
+    STDMETHOD(CreateNewWindow)(long paramC) override;
+    STDMETHOD(GetBrowserWindow)(IUnknown **paramC) override;
+    STDMETHOD(IsConnected)() override;
+    STDMETHOD(NavigateToPIDL)(LPCITEMIDLIST pidl) override;
+    STDMETHOD(NavigateToURL)(long paramC, long param10) override;
 
     DECLARE_REGISTRY_RESOURCEID(IDR_BANDPROXY)
     DECLARE_NOT_AGGREGATABLE(CBandProxy)

--- a/dll/win32/browseui/basebarsite.cpp
+++ b/dll/win32/browseui/basebarsite.cpp
@@ -75,56 +75,56 @@ private:
     HRESULT InsertBar(IUnknown *newBar);
 
     // *** IOleWindow methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetWindow(HWND *lphwnd);
-    virtual HRESULT STDMETHODCALLTYPE ContextSensitiveHelp(BOOL fEnterMode);
+    STDMETHOD(GetWindow)(HWND *lphwnd) override;
+    STDMETHOD(ContextSensitiveHelp)(BOOL fEnterMode) override;
 
     // *** IInputObject methods ***
-    virtual HRESULT STDMETHODCALLTYPE UIActivateIO(BOOL fActivate, LPMSG lpMsg);
-    virtual HRESULT STDMETHODCALLTYPE HasFocusIO();
-    virtual HRESULT STDMETHODCALLTYPE TranslateAcceleratorIO(LPMSG lpMsg);
+    STDMETHOD(UIActivateIO)(BOOL fActivate, LPMSG lpMsg) override;
+    STDMETHOD(HasFocusIO)() override;
+    STDMETHOD(TranslateAcceleratorIO)(LPMSG lpMsg) override;
 
     // *** IServiceProvider methods ***
-    virtual HRESULT STDMETHODCALLTYPE QueryService(REFGUID guidService, REFIID riid, void **ppvObject);
+    STDMETHOD(QueryService)(REFGUID guidService, REFIID riid, void **ppvObject) override;
 
     // *** IWinEventHandler methods ***
-    virtual HRESULT STDMETHODCALLTYPE OnWinEvent(
-        HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT *theResult);
-    virtual HRESULT STDMETHODCALLTYPE IsWindowOwner(HWND hWnd);
+    STDMETHOD(OnWinEvent)(
+        HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT *theResult) override;
+    STDMETHOD(IsWindowOwner)(HWND hWnd) override;
 
     // *** IInputObjectSite specific methods ***
-    virtual HRESULT STDMETHODCALLTYPE OnFocusChangeIS(IUnknown *punkObj, BOOL fSetFocus);
+    STDMETHOD(OnFocusChangeIS)(IUnknown *punkObj, BOOL fSetFocus) override;
 
     // *** IDeskBarClient methods ***
-    virtual HRESULT STDMETHODCALLTYPE SetDeskBarSite(IUnknown *punkSite);
-    virtual HRESULT STDMETHODCALLTYPE SetModeDBC(DWORD dwMode);
-    virtual HRESULT STDMETHODCALLTYPE UIActivateDBC(DWORD dwState);
-    virtual HRESULT STDMETHODCALLTYPE GetSize(DWORD dwWhich, LPRECT prc);
+    STDMETHOD(SetDeskBarSite)(IUnknown *punkSite) override;
+    STDMETHOD(SetModeDBC)(DWORD dwMode) override;
+    STDMETHOD(UIActivateDBC)(DWORD dwState) override;
+    STDMETHOD(GetSize)(DWORD dwWhich, LPRECT prc) override;
 
     // *** IOleCommandTarget methods ***
-    virtual HRESULT STDMETHODCALLTYPE QueryStatus(const GUID *pguidCmdGroup, ULONG cCmds,
-        OLECMD prgCmds[  ], OLECMDTEXT *pCmdText);
-    virtual HRESULT STDMETHODCALLTYPE Exec(const GUID *pguidCmdGroup, DWORD nCmdID,
-        DWORD nCmdexecopt, VARIANT *pvaIn, VARIANT *pvaOut);
+    STDMETHOD(QueryStatus)(const GUID *pguidCmdGroup, ULONG cCmds,
+        OLECMD prgCmds[  ], OLECMDTEXT *pCmdText) override;
+    STDMETHOD(Exec)(const GUID *pguidCmdGroup, DWORD nCmdID,
+        DWORD nCmdexecopt, VARIANT *pvaIn, VARIANT *pvaOut) override;
 
     // *** IBandSite specific methods ***
-    virtual HRESULT STDMETHODCALLTYPE AddBand(IUnknown *punk);
-    virtual HRESULT STDMETHODCALLTYPE EnumBands(UINT uBand, DWORD *pdwBandID);
-    virtual HRESULT STDMETHODCALLTYPE QueryBand(DWORD dwBandID, IDeskBand **ppstb, DWORD *pdwState,
-        LPWSTR pszName, int cchName);
-    virtual HRESULT STDMETHODCALLTYPE SetBandState(DWORD dwBandID, DWORD dwMask, DWORD dwState);
-    virtual HRESULT STDMETHODCALLTYPE RemoveBand(DWORD dwBandID);
-    virtual HRESULT STDMETHODCALLTYPE GetBandObject(DWORD dwBandID, REFIID riid, void **ppv);
-    virtual HRESULT STDMETHODCALLTYPE SetBandSiteInfo(const BANDSITEINFO *pbsinfo);
-    virtual HRESULT STDMETHODCALLTYPE GetBandSiteInfo(BANDSITEINFO *pbsinfo);
+    STDMETHOD(AddBand)(IUnknown *punk) override;
+    STDMETHOD(EnumBands)(UINT uBand, DWORD *pdwBandID) override;
+    STDMETHOD(QueryBand)(DWORD dwBandID, IDeskBand **ppstb, DWORD *pdwState,
+        LPWSTR pszName, int cchName) override;
+    STDMETHOD(SetBandState)(DWORD dwBandID, DWORD dwMask, DWORD dwState) override;
+    STDMETHOD(RemoveBand)(DWORD dwBandID) override;
+    STDMETHOD(GetBandObject)(DWORD dwBandID, REFIID riid, void **ppv) override;
+    STDMETHOD(SetBandSiteInfo)(const BANDSITEINFO *pbsinfo) override;
+    STDMETHOD(GetBandSiteInfo)(BANDSITEINFO *pbsinfo) override;
 
     // *** IPersist methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetClassID(CLSID *pClassID);
+    STDMETHOD(GetClassID)(CLSID *pClassID) override;
 
     // *** IPersistStream methods ***
-    virtual HRESULT STDMETHODCALLTYPE IsDirty();
-    virtual HRESULT STDMETHODCALLTYPE Load(IStream *pStm);
-    virtual HRESULT STDMETHODCALLTYPE Save(IStream *pStm, BOOL fClearDirty);
-    virtual HRESULT STDMETHODCALLTYPE GetSizeMax(ULARGE_INTEGER *pcbSize);
+    STDMETHOD(IsDirty)() override;
+    STDMETHOD(Load)(IStream *pStm) override;
+    STDMETHOD(Save)(IStream *pStm, BOOL fClearDirty) override;
+    STDMETHOD(GetSizeMax)(ULARGE_INTEGER *pcbSize) override;
 
     // message handlers
     LRESULT OnNotify(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);

--- a/dll/win32/browseui/brandband.h
+++ b/dll/win32/browseui/brandband.h
@@ -49,51 +49,51 @@ public:
     void SelectImage();
 public:
     // *** IDeskBand methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetBandInfo(DWORD dwBandID, DWORD dwViewMode, DESKBANDINFO* pdbi);
+    STDMETHOD(GetBandInfo)(DWORD dwBandID, DWORD dwViewMode, DESKBANDINFO* pdbi) override;
 
     // *** IObjectWithSite methods ***
-    virtual HRESULT STDMETHODCALLTYPE SetSite(IUnknown* pUnkSite);
-    virtual HRESULT STDMETHODCALLTYPE GetSite(REFIID riid, void **ppvSite);
+    STDMETHOD(SetSite)(IUnknown* pUnkSite) override;
+    STDMETHOD(GetSite)(REFIID riid, void **ppvSite) override;
 
     // *** IOleWindow methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetWindow(HWND *lphwnd);
-    virtual HRESULT STDMETHODCALLTYPE ContextSensitiveHelp(BOOL fEnterMode);
+    STDMETHOD(GetWindow)(HWND *lphwnd) override;
+    STDMETHOD(ContextSensitiveHelp)(BOOL fEnterMode) override;
 
     // *** IDockingWindow methods ***
-    virtual HRESULT STDMETHODCALLTYPE CloseDW(DWORD dwReserved);
-    virtual HRESULT STDMETHODCALLTYPE ResizeBorderDW(const RECT* prcBorder, IUnknown* punkToolbarSite, BOOL fReserved);
-    virtual HRESULT STDMETHODCALLTYPE ShowDW(BOOL fShow);
+    STDMETHOD(CloseDW)(DWORD dwReserved) override;
+    STDMETHOD(ResizeBorderDW)(const RECT* prcBorder, IUnknown* punkToolbarSite, BOOL fReserved) override;
+    STDMETHOD(ShowDW)(BOOL fShow) override;
 
     // *** IInputObject methods ***
-    virtual HRESULT STDMETHODCALLTYPE HasFocusIO();
-    virtual HRESULT STDMETHODCALLTYPE TranslateAcceleratorIO(LPMSG lpMsg);
-    virtual HRESULT STDMETHODCALLTYPE UIActivateIO(BOOL fActivate, LPMSG lpMsg);
+    STDMETHOD(HasFocusIO)() override;
+    STDMETHOD(TranslateAcceleratorIO)(LPMSG lpMsg) override;
+    STDMETHOD(UIActivateIO)(BOOL fActivate, LPMSG lpMsg) override;
 
     // *** IPersist methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetClassID(CLSID *pClassID);
+    STDMETHOD(GetClassID)(CLSID *pClassID) override;
 
     // *** IPersistStream methods ***
-    virtual HRESULT STDMETHODCALLTYPE IsDirty();
-    virtual HRESULT STDMETHODCALLTYPE Load(IStream *pStm);
-    virtual HRESULT STDMETHODCALLTYPE Save(IStream *pStm, BOOL fClearDirty);
-    virtual HRESULT STDMETHODCALLTYPE GetSizeMax(ULARGE_INTEGER *pcbSize);
+    STDMETHOD(IsDirty)() override;
+    STDMETHOD(Load)(IStream *pStm) override;
+    STDMETHOD(Save)(IStream *pStm, BOOL fClearDirty) override;
+    STDMETHOD(GetSizeMax)(ULARGE_INTEGER *pcbSize) override;
 
     // *** IWinEventHandler methods ***
-    virtual HRESULT STDMETHODCALLTYPE OnWinEvent(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT *theResult);
-    virtual HRESULT STDMETHODCALLTYPE IsWindowOwner(HWND hWnd);
+    STDMETHOD(OnWinEvent)(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT *theResult) override;
+    STDMETHOD(IsWindowOwner)(HWND hWnd) override;
 
     // *** IOleCommandTarget methods ***
-    virtual HRESULT STDMETHODCALLTYPE QueryStatus(const GUID *pguidCmdGroup, ULONG cCmds, OLECMD prgCmds[  ], OLECMDTEXT *pCmdText);
-    virtual HRESULT STDMETHODCALLTYPE Exec(const GUID *pguidCmdGroup, DWORD nCmdID, DWORD nCmdexecopt, VARIANT *pvaIn, VARIANT *pvaOut);
+    STDMETHOD(QueryStatus)(const GUID *pguidCmdGroup, ULONG cCmds, OLECMD prgCmds[  ], OLECMDTEXT *pCmdText) override;
+    STDMETHOD(Exec)(const GUID *pguidCmdGroup, DWORD nCmdID, DWORD nCmdexecopt, VARIANT *pvaIn, VARIANT *pvaOut) override;
 
     // *** IServiceProvider methods ***
-    virtual HRESULT STDMETHODCALLTYPE QueryService(REFGUID guidService, REFIID riid, void **ppvObject);
+    STDMETHOD(QueryService)(REFGUID guidService, REFIID riid, void **ppvObject) override;
 
     // *** IDispatch methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetTypeInfoCount(UINT *pctinfo);
-    virtual HRESULT STDMETHODCALLTYPE GetTypeInfo(UINT iTInfo, LCID lcid, ITypeInfo **ppTInfo);
-    virtual HRESULT STDMETHODCALLTYPE GetIDsOfNames(REFIID riid, LPOLESTR *rgszNames, UINT cNames, LCID lcid, DISPID *rgDispId);
-    virtual HRESULT STDMETHODCALLTYPE Invoke(DISPID dispIdMember, REFIID riid, LCID lcid, WORD wFlags, DISPPARAMS *pDispParams, VARIANT *pVarResult, EXCEPINFO *pExcepInfo, UINT *puArgErr);
+    STDMETHOD(GetTypeInfoCount)(UINT *pctinfo) override;
+    STDMETHOD(GetTypeInfo)(UINT iTInfo, LCID lcid, ITypeInfo **ppTInfo) override;
+    STDMETHOD(GetIDsOfNames)(REFIID riid, LPOLESTR *rgszNames, UINT cNames, LCID lcid, DISPID *rgDispId) override;
+    STDMETHOD(Invoke)(DISPID dispIdMember, REFIID riid, LCID lcid, WORD wFlags, DISPPARAMS *pDispParams, VARIANT *pVarResult, EXCEPINFO *pExcepInfo, UINT *puArgErr) override;
 
     // message handlers
     LRESULT OnSize(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);

--- a/dll/win32/browseui/commonbrowser.h
+++ b/dll/win32/browseui/commonbrowser.h
@@ -39,152 +39,152 @@ public:
     ~CCommonBrowser();
 
     // *** IServiceProvider methods ***
-    virtual HRESULT STDMETHODCALLTYPE QueryService(REFGUID guidService, REFIID riid, void **ppvObject);
+    STDMETHOD(QueryService)(REFGUID guidService, REFIID riid, void **ppvObject) override;
 
     // *** IOleCommandTarget methods ***
-    virtual HRESULT STDMETHODCALLTYPE QueryStatus(const GUID *pguidCmdGroup, ULONG cCmds, OLECMD prgCmds[  ], OLECMDTEXT *pCmdText);
-    virtual HRESULT STDMETHODCALLTYPE Exec(const GUID *pguidCmdGroup, DWORD nCmdID, DWORD nCmdexecopt, VARIANT *pvaIn, VARIANT *pvaOut);
+    STDMETHOD(QueryStatus)(const GUID *pguidCmdGroup, ULONG cCmds, OLECMD prgCmds[  ], OLECMDTEXT *pCmdText) override;
+    STDMETHOD(Exec)(const GUID *pguidCmdGroup, DWORD nCmdID, DWORD nCmdexecopt, VARIANT *pvaIn, VARIANT *pvaOut) override;
 
     // *** IBrowserService methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetParentSite(IOleInPlaceSite **ppipsite);
-    virtual HRESULT STDMETHODCALLTYPE SetTitle(IShellView *psv, LPCWSTR pszName);
-    virtual HRESULT STDMETHODCALLTYPE GetTitle(IShellView *psv, LPWSTR pszName, DWORD cchName);
-    virtual HRESULT STDMETHODCALLTYPE GetOleObject(IOleObject **ppobjv);
-    virtual HRESULT STDMETHODCALLTYPE GetTravelLog(ITravelLog **pptl);
-    virtual HRESULT STDMETHODCALLTYPE ShowControlWindow(UINT id, BOOL fShow);
-    virtual HRESULT STDMETHODCALLTYPE IsControlWindowShown(UINT id, BOOL *pfShown);
-    virtual HRESULT STDMETHODCALLTYPE IEGetDisplayName(LPCITEMIDLIST pidl, LPWSTR pwszName, UINT uFlags);
-    virtual HRESULT STDMETHODCALLTYPE IEParseDisplayName(UINT uiCP, LPCWSTR pwszPath, LPITEMIDLIST *ppidlOut);
-    virtual HRESULT STDMETHODCALLTYPE DisplayParseError(HRESULT hres, LPCWSTR pwszPath);
-    virtual HRESULT STDMETHODCALLTYPE NavigateToPidl(LPCITEMIDLIST pidl, DWORD grfHLNF);
-    virtual HRESULT STDMETHODCALLTYPE SetNavigateState(BNSTATE bnstate);
-    virtual HRESULT STDMETHODCALLTYPE GetNavigateState(BNSTATE *pbnstate);
-    virtual HRESULT STDMETHODCALLTYPE NotifyRedirect(IShellView *psv, LPCITEMIDLIST pidl, BOOL *pfDidBrowse);
-    virtual HRESULT STDMETHODCALLTYPE UpdateWindowList();
-    virtual HRESULT STDMETHODCALLTYPE UpdateBackForwardState();
-    virtual HRESULT STDMETHODCALLTYPE SetFlags(DWORD dwFlags, DWORD dwFlagMask);
-    virtual HRESULT STDMETHODCALLTYPE GetFlags(DWORD *pdwFlags);
-    virtual HRESULT STDMETHODCALLTYPE CanNavigateNow();
-    virtual HRESULT STDMETHODCALLTYPE GetPidl(LPITEMIDLIST *ppidl);
-    virtual HRESULT STDMETHODCALLTYPE SetReferrer(LPCITEMIDLIST pidl);
-    virtual DWORD STDMETHODCALLTYPE GetBrowserIndex();
-    virtual HRESULT STDMETHODCALLTYPE GetBrowserByIndex(DWORD dwID, IUnknown **ppunk);
-    virtual HRESULT STDMETHODCALLTYPE GetHistoryObject(IOleObject **ppole, IStream **pstm, IBindCtx **ppbc);
-    virtual HRESULT STDMETHODCALLTYPE SetHistoryObject(IOleObject *pole, BOOL fIsLocalAnchor);
-    virtual HRESULT STDMETHODCALLTYPE CacheOLEServer(IOleObject *pole);
-    virtual HRESULT STDMETHODCALLTYPE GetSetCodePage(VARIANT *pvarIn, VARIANT *pvarOut);
-    virtual HRESULT STDMETHODCALLTYPE OnHttpEquiv(IShellView *psv, BOOL fDone, VARIANT *pvarargIn, VARIANT *pvarargOut);
-    virtual HRESULT STDMETHODCALLTYPE GetPalette(HPALETTE *hpal);
-    virtual HRESULT STDMETHODCALLTYPE RegisterWindow(BOOL fForceRegister, int swc);
+    STDMETHOD(GetParentSite)(IOleInPlaceSite **ppipsite) override;
+    STDMETHOD(SetTitle)(IShellView *psv, LPCWSTR pszName) override;
+    STDMETHOD(GetTitle)(IShellView *psv, LPWSTR pszName, DWORD cchName) override;
+    STDMETHOD(GetOleObject)(IOleObject **ppobjv) override;
+    STDMETHOD(GetTravelLog)(ITravelLog **pptl) override;
+    STDMETHOD(ShowControlWindow)(UINT id, BOOL fShow) override;
+    STDMETHOD(IsControlWindowShown)(UINT id, BOOL *pfShown) override;
+    STDMETHOD(IEGetDisplayName)(LPCITEMIDLIST pidl, LPWSTR pwszName, UINT uFlags) override;
+    STDMETHOD(IEParseDisplayName)(UINT uiCP, LPCWSTR pwszPath, LPITEMIDLIST *ppidlOut) override;
+    STDMETHOD(DisplayParseError)(HRESULT hres, LPCWSTR pwszPath) override;
+    STDMETHOD(NavigateToPidl)(LPCITEMIDLIST pidl, DWORD grfHLNF) override;
+    STDMETHOD(SetNavigateState)(BNSTATE bnstate) override;
+    STDMETHOD(GetNavigateState)(BNSTATE *pbnstate) override;
+    STDMETHOD(NotifyRedirect)(IShellView *psv, LPCITEMIDLIST pidl, BOOL *pfDidBrowse) override;
+    STDMETHOD(UpdateWindowList)() override;
+    STDMETHOD(UpdateBackForwardState)() override;
+    STDMETHOD(SetFlags)(DWORD dwFlags, DWORD dwFlagMask) override;
+    STDMETHOD(GetFlags)(DWORD *pdwFlags) override;
+    STDMETHOD(CanNavigateNow)() override;
+    STDMETHOD(GetPidl)(LPITEMIDLIST *ppidl) override;
+    STDMETHOD(SetReferrer)(LPCITEMIDLIST pidl) override;
+    STDMETHOD_(DWORD, GetBrowserIndex)() override;
+    STDMETHOD(GetBrowserByIndex)(DWORD dwID, IUnknown **ppunk) override;
+    STDMETHOD(GetHistoryObject)(IOleObject **ppole, IStream **pstm, IBindCtx **ppbc) override;
+    STDMETHOD(SetHistoryObject)(IOleObject *pole, BOOL fIsLocalAnchor) override;
+    STDMETHOD(CacheOLEServer)(IOleObject *pole) override;
+    STDMETHOD(GetSetCodePage)(VARIANT *pvarIn, VARIANT *pvarOut) override;
+    STDMETHOD(OnHttpEquiv)(IShellView *psv, BOOL fDone, VARIANT *pvarargIn, VARIANT *pvarargOut) override;
+    STDMETHOD(GetPalette)(HPALETTE *hpal) override;
+    STDMETHOD(RegisterWindow)(BOOL fForceRegister, int swc) override;
 
     // *** IBrowserService2 methods ***
-    virtual LRESULT STDMETHODCALLTYPE WndProcBS(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
-    virtual HRESULT STDMETHODCALLTYPE SetAsDefFolderSettings();
-    virtual HRESULT STDMETHODCALLTYPE GetViewRect(RECT *prc);
-    virtual HRESULT STDMETHODCALLTYPE OnSize(WPARAM wParam);
-    virtual HRESULT STDMETHODCALLTYPE OnCreate(struct tagCREATESTRUCTW *pcs);
-    virtual LRESULT STDMETHODCALLTYPE OnCommand(WPARAM wParam, LPARAM lParam);
-    virtual HRESULT STDMETHODCALLTYPE OnDestroy();
-    virtual LRESULT STDMETHODCALLTYPE OnNotify(struct tagNMHDR *pnm);
-    virtual HRESULT STDMETHODCALLTYPE OnSetFocus();
-    virtual HRESULT STDMETHODCALLTYPE OnFrameWindowActivateBS(BOOL fActive);
-    virtual HRESULT STDMETHODCALLTYPE ReleaseShellView();
-    virtual HRESULT STDMETHODCALLTYPE ActivatePendingView();
-    virtual HRESULT STDMETHODCALLTYPE CreateViewWindow(IShellView *psvNew, IShellView *psvOld, LPRECT prcView, HWND *phwnd);
-    virtual HRESULT STDMETHODCALLTYPE CreateBrowserPropSheetExt(REFIID riid, void **ppv);
-    virtual HRESULT STDMETHODCALLTYPE GetViewWindow(HWND *phwndView);
-    virtual HRESULT STDMETHODCALLTYPE GetBaseBrowserData(LPCBASEBROWSERDATA *pbbd);
-    virtual LPBASEBROWSERDATA STDMETHODCALLTYPE PutBaseBrowserData();
-    virtual HRESULT STDMETHODCALLTYPE InitializeTravelLog(ITravelLog *ptl, DWORD dw);
-    virtual HRESULT STDMETHODCALLTYPE SetTopBrowser();
-    virtual HRESULT STDMETHODCALLTYPE Offline(int iCmd);
-    virtual HRESULT STDMETHODCALLTYPE AllowViewResize(BOOL f);
-    virtual HRESULT STDMETHODCALLTYPE SetActivateState(UINT u);
-    virtual HRESULT STDMETHODCALLTYPE UpdateSecureLockIcon(int eSecureLock);
-    virtual HRESULT STDMETHODCALLTYPE InitializeDownloadManager();
-    virtual HRESULT STDMETHODCALLTYPE InitializeTransitionSite();
-    virtual HRESULT STDMETHODCALLTYPE _Initialize(HWND hwnd, IUnknown *pauto);
-    virtual HRESULT STDMETHODCALLTYPE _CancelPendingNavigationAsync();
-    virtual HRESULT STDMETHODCALLTYPE _CancelPendingView();
-    virtual HRESULT STDMETHODCALLTYPE _MaySaveChanges();
-    virtual HRESULT STDMETHODCALLTYPE _PauseOrResumeView(BOOL fPaused);
-    virtual HRESULT STDMETHODCALLTYPE _DisableModeless();
-    virtual HRESULT STDMETHODCALLTYPE _NavigateToPidl(LPCITEMIDLIST pidl, DWORD grfHLNF, DWORD dwFlags);
-    virtual HRESULT STDMETHODCALLTYPE _TryShell2Rename(IShellView *psv, LPCITEMIDLIST pidlNew);
-    virtual HRESULT STDMETHODCALLTYPE _SwitchActivationNow();
-    virtual HRESULT STDMETHODCALLTYPE _ExecChildren(IUnknown *punkBar, BOOL fBroadcast, const GUID *pguidCmdGroup, DWORD nCmdID, DWORD nCmdexecopt, VARIANTARG *pvarargIn, VARIANTARG *pvarargOut);
-    virtual HRESULT STDMETHODCALLTYPE _SendChildren(HWND hwndBar, BOOL fBroadcast, UINT uMsg, WPARAM wParam, LPARAM lParam);
-    virtual HRESULT STDMETHODCALLTYPE GetFolderSetData(struct tagFolderSetData *pfsd);
-    virtual HRESULT STDMETHODCALLTYPE _OnFocusChange(UINT itb);
-    virtual HRESULT STDMETHODCALLTYPE v_ShowHideChildWindows(BOOL fChildOnly);
-    virtual UINT STDMETHODCALLTYPE _get_itbLastFocus();
-    virtual HRESULT STDMETHODCALLTYPE _put_itbLastFocus(UINT itbLastFocus);
-    virtual HRESULT STDMETHODCALLTYPE _UIActivateView(UINT uState);
-    virtual HRESULT STDMETHODCALLTYPE _GetViewBorderRect(RECT *prc);
-    virtual HRESULT STDMETHODCALLTYPE _UpdateViewRectSize();
-    virtual HRESULT STDMETHODCALLTYPE _ResizeNextBorder(UINT itb);
-    virtual HRESULT STDMETHODCALLTYPE _ResizeView();
-    virtual HRESULT STDMETHODCALLTYPE _GetEffectiveClientArea(LPRECT lprectBorder, HMONITOR hmon);
-    virtual IStream *STDMETHODCALLTYPE v_GetViewStream(LPCITEMIDLIST pidl, DWORD grfMode, LPCWSTR pwszName);
-    virtual LRESULT STDMETHODCALLTYPE ForwardViewMsg(UINT uMsg, WPARAM wParam, LPARAM lParam);
-    virtual HRESULT STDMETHODCALLTYPE SetAcceleratorMenu(HACCEL hacc);
-    virtual int STDMETHODCALLTYPE _GetToolbarCount();
-    virtual LPTOOLBARITEM STDMETHODCALLTYPE _GetToolbarItem(int itb);
-    virtual HRESULT STDMETHODCALLTYPE _SaveToolbars(IStream *pstm);
-    virtual HRESULT STDMETHODCALLTYPE _LoadToolbars(IStream *pstm);
-    virtual HRESULT STDMETHODCALLTYPE _CloseAndReleaseToolbars(BOOL fClose);
-    virtual HRESULT STDMETHODCALLTYPE v_MayGetNextToolbarFocus(LPMSG lpMsg, UINT itbNext, int citb, LPTOOLBARITEM *pptbi, HWND *phwnd);
-    virtual HRESULT STDMETHODCALLTYPE _ResizeNextBorderHelper(UINT itb, BOOL bUseHmonitor);
-    virtual UINT STDMETHODCALLTYPE _FindTBar(IUnknown *punkSrc);
-    virtual HRESULT STDMETHODCALLTYPE _SetFocus(LPTOOLBARITEM ptbi, HWND hwnd, LPMSG lpMsg);
-    virtual HRESULT STDMETHODCALLTYPE v_MayTranslateAccelerator(MSG *pmsg);
-    virtual HRESULT STDMETHODCALLTYPE _GetBorderDWHelper(IUnknown *punkSrc, LPRECT lprectBorder, BOOL bUseHmonitor);
-    virtual HRESULT STDMETHODCALLTYPE v_CheckZoneCrossing(LPCITEMIDLIST pidl);
+    STDMETHOD_(LRESULT, WndProcBS)(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam) override;
+    STDMETHOD(SetAsDefFolderSettings)() override;
+    STDMETHOD(GetViewRect)(RECT *prc) override;
+    STDMETHOD(OnSize)(WPARAM wParam) override;
+    STDMETHOD(OnCreate)(struct tagCREATESTRUCTW *pcs) override;
+    STDMETHOD_(LRESULT, OnCommand)(WPARAM wParam, LPARAM lParam) override;
+    STDMETHOD(OnDestroy)() override;
+    STDMETHOD_(LRESULT, OnNotify)(struct tagNMHDR *pnm) override;
+    STDMETHOD(OnSetFocus)() override;
+    STDMETHOD(OnFrameWindowActivateBS)(BOOL fActive) override;
+    STDMETHOD(ReleaseShellView)() override;
+    STDMETHOD(ActivatePendingView)() override;
+    STDMETHOD(CreateViewWindow)(IShellView *psvNew, IShellView *psvOld, LPRECT prcView, HWND *phwnd) override;
+    STDMETHOD(CreateBrowserPropSheetExt)(REFIID riid, void **ppv) override;
+    STDMETHOD(GetViewWindow)(HWND *phwndView) override;
+    STDMETHOD(GetBaseBrowserData)(LPCBASEBROWSERDATA *pbbd) override;
+    STDMETHOD_(LPBASEBROWSERDATA, PutBaseBrowserData)() override;
+    STDMETHOD(InitializeTravelLog)(ITravelLog *ptl, DWORD dw) override;
+    STDMETHOD(SetTopBrowser)() override;
+    STDMETHOD(Offline)(int iCmd) override;
+    STDMETHOD(AllowViewResize)(BOOL f) override;
+    STDMETHOD(SetActivateState)(UINT u) override;
+    STDMETHOD(UpdateSecureLockIcon)(int eSecureLock) override;
+    STDMETHOD(InitializeDownloadManager)() override;
+    STDMETHOD(InitializeTransitionSite)() override;
+    STDMETHOD(_Initialize)(HWND hwnd, IUnknown *pauto) override;
+    STDMETHOD(_CancelPendingNavigationAsync)() override;
+    STDMETHOD(_CancelPendingView)() override;
+    STDMETHOD(_MaySaveChanges)() override;
+    STDMETHOD(_PauseOrResumeView)(BOOL fPaused) override;
+    STDMETHOD(_DisableModeless)() override;
+    STDMETHOD(_NavigateToPidl)(LPCITEMIDLIST pidl, DWORD grfHLNF, DWORD dwFlags) override;
+    STDMETHOD(_TryShell2Rename)(IShellView *psv, LPCITEMIDLIST pidlNew) override;
+    STDMETHOD(_SwitchActivationNow)() override;
+    STDMETHOD(_ExecChildren)(IUnknown *punkBar, BOOL fBroadcast, const GUID *pguidCmdGroup, DWORD nCmdID, DWORD nCmdexecopt, VARIANTARG *pvarargIn, VARIANTARG *pvarargOut) override;
+    STDMETHOD(_SendChildren)(HWND hwndBar, BOOL fBroadcast, UINT uMsg, WPARAM wParam, LPARAM lParam) override;
+    STDMETHOD(GetFolderSetData)(struct tagFolderSetData *pfsd) override;
+    STDMETHOD(_OnFocusChange)(UINT itb) override;
+    STDMETHOD(v_ShowHideChildWindows)(BOOL fChildOnly) override;
+    STDMETHOD_(UINT, _get_itbLastFocus)() override;
+    STDMETHOD(_put_itbLastFocus)(UINT itbLastFocus) override;
+    STDMETHOD(_UIActivateView)(UINT uState) override;
+    STDMETHOD(_GetViewBorderRect)(RECT *prc) override;
+    STDMETHOD(_UpdateViewRectSize)() override;
+    STDMETHOD(_ResizeNextBorder)(UINT itb) override;
+    STDMETHOD(_ResizeView)() override;
+    STDMETHOD(_GetEffectiveClientArea)(LPRECT lprectBorder, HMONITOR hmon) override;
+    STDMETHOD_(IStream *, v_GetViewStream)(LPCITEMIDLIST pidl, DWORD grfMode, LPCWSTR pwszName) override;
+    STDMETHOD_(LRESULT, ForwardViewMsg)(UINT uMsg, WPARAM wParam, LPARAM lParam) override;
+    STDMETHOD(SetAcceleratorMenu)(HACCEL hacc) override;
+    STDMETHOD_(INT, _GetToolbarCount)() override;
+    STDMETHOD_(LPTOOLBARITEM, _GetToolbarItem)(int itb) override;
+    STDMETHOD(_SaveToolbars)(IStream *pstm) override;
+    STDMETHOD(_LoadToolbars)(IStream *pstm) override;
+    STDMETHOD(_CloseAndReleaseToolbars)(BOOL fClose) override;
+    STDMETHOD(v_MayGetNextToolbarFocus)(LPMSG lpMsg, UINT itbNext, int citb, LPTOOLBARITEM *pptbi, HWND *phwnd) override;
+    STDMETHOD(_ResizeNextBorderHelper)(UINT itb, BOOL bUseHmonitor) override;
+    STDMETHOD_(UINT, _FindTBar)(IUnknown *punkSrc) override;
+    STDMETHOD(_SetFocus)(LPTOOLBARITEM ptbi, HWND hwnd, LPMSG lpMsg) override;
+    STDMETHOD(v_MayTranslateAccelerator)(MSG *pmsg) override;
+    STDMETHOD(_GetBorderDWHelper)(IUnknown *punkSrc, LPRECT lprectBorder, BOOL bUseHmonitor) override;
+    STDMETHOD(v_CheckZoneCrossing)(LPCITEMIDLIST pidl) override;
 
     // *** IBrowserService3 methods ***
-    virtual HRESULT STDMETHODCALLTYPE _PositionViewWindow(HWND, RECT *);
-    virtual HRESULT STDMETHODCALLTYPE IEParseDisplayNameEx(UINT, PCWSTR, DWORD, LPITEMIDLIST *);
+    STDMETHOD(_PositionViewWindow)(HWND, RECT *) override;
+    STDMETHOD(IEParseDisplayNameEx)(UINT, PCWSTR, DWORD, LPITEMIDLIST *) override;
 
     // *** IShellBrowser methods ***
-    virtual HRESULT STDMETHODCALLTYPE InsertMenusSB(HMENU hmenuShared, LPOLEMENUGROUPWIDTHS lpMenuWidths);
-    virtual HRESULT STDMETHODCALLTYPE SetMenuSB(HMENU hmenuShared, HOLEMENU holemenuRes, HWND hwndActiveObject);
-    virtual HRESULT STDMETHODCALLTYPE RemoveMenusSB(HMENU hmenuShared);
-    virtual HRESULT STDMETHODCALLTYPE SetStatusTextSB(LPCOLESTR pszStatusText);
-    virtual HRESULT STDMETHODCALLTYPE EnableModelessSB(BOOL fEnable);
-    virtual HRESULT STDMETHODCALLTYPE TranslateAcceleratorSB(MSG *pmsg, WORD wID);
-    virtual HRESULT STDMETHODCALLTYPE BrowseObject(LPCITEMIDLIST pidl, UINT wFlags);
-    virtual HRESULT STDMETHODCALLTYPE GetViewStateStream(DWORD grfMode, IStream **ppStrm);
-    virtual HRESULT STDMETHODCALLTYPE GetControlWindow(UINT id, HWND *lphwnd);
-    virtual HRESULT STDMETHODCALLTYPE SendControlMsg(UINT id, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT *pret);
-    virtual HRESULT STDMETHODCALLTYPE QueryActiveShellView(struct IShellView **ppshv);
-    virtual HRESULT STDMETHODCALLTYPE OnViewWindowActive(struct IShellView *ppshv);
-    virtual HRESULT STDMETHODCALLTYPE SetToolbarItems(LPTBBUTTON lpButtons, UINT nButtons, UINT uFlags);
+    STDMETHOD(InsertMenusSB)(HMENU hmenuShared, LPOLEMENUGROUPWIDTHS lpMenuWidths) override;
+    STDMETHOD(SetMenuSB)(HMENU hmenuShared, HOLEMENU holemenuRes, HWND hwndActiveObject) override;
+    STDMETHOD(RemoveMenusSB)(HMENU hmenuShared) override;
+    STDMETHOD(SetStatusTextSB)(LPCOLESTR pszStatusText) override;
+    STDMETHOD(EnableModelessSB)(BOOL fEnable) override;
+    STDMETHOD(TranslateAcceleratorSB)(MSG *pmsg, WORD wID) override;
+    STDMETHOD(BrowseObject)(LPCITEMIDLIST pidl, UINT wFlags) override;
+    STDMETHOD(GetViewStateStream)(DWORD grfMode, IStream **ppStrm) override;
+    STDMETHOD(GetControlWindow)(UINT id, HWND *lphwnd) override;
+    STDMETHOD(SendControlMsg)(UINT id, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT *pret) override;
+    STDMETHOD(QueryActiveShellView)(struct IShellView **ppshv) override;
+    STDMETHOD(OnViewWindowActive)(struct IShellView *ppshv) override;
+    STDMETHOD(SetToolbarItems)(LPTBBUTTON lpButtons, UINT nButtons, UINT uFlags) override;
 
     // *** IShellBowserService methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetPropertyBag(long flags, REFIID riid, void **ppvObject);
+    STDMETHOD(GetPropertyBag)(long flags, REFIID riid, void **ppvObject) override;
 
     // *** IOleWindow methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetWindow(HWND *lphwnd);
-    virtual HRESULT STDMETHODCALLTYPE ContextSensitiveHelp(BOOL fEnterMode);
+    STDMETHOD(GetWindow)(HWND *lphwnd) override;
+    STDMETHOD(ContextSensitiveHelp)(BOOL fEnterMode) override;
 
     // *** IDockingWindowSite methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetBorderDW(IUnknown* punkObj, LPRECT prcBorder);
-    virtual HRESULT STDMETHODCALLTYPE RequestBorderSpaceDW(IUnknown* punkObj, LPCBORDERWIDTHS pbw);
-    virtual HRESULT STDMETHODCALLTYPE SetBorderSpaceDW(IUnknown* punkObj, LPCBORDERWIDTHS pbw);
+    STDMETHOD(GetBorderDW)(IUnknown* punkObj, LPRECT prcBorder) override;
+    STDMETHOD(RequestBorderSpaceDW)(IUnknown* punkObj, LPCBORDERWIDTHS pbw) override;
+    STDMETHOD(SetBorderSpaceDW)(IUnknown* punkObj, LPCBORDERWIDTHS pbw) override;
 
     // *** IDockingWindowFrame methods ***
-    virtual HRESULT STDMETHODCALLTYPE AddToolbar(IUnknown *punkSrc, LPCWSTR pwszItem, DWORD dwAddFlags);
-    virtual HRESULT STDMETHODCALLTYPE RemoveToolbar(IUnknown *punkSrc, DWORD dwRemoveFlags);
-    virtual HRESULT STDMETHODCALLTYPE FindToolbar(LPCWSTR pwszItem, REFIID riid, void **ppv);
+    STDMETHOD(AddToolbar)(IUnknown *punkSrc, LPCWSTR pwszItem, DWORD dwAddFlags) override;
+    STDMETHOD(RemoveToolbar)(IUnknown *punkSrc, DWORD dwRemoveFlags) override;
+    STDMETHOD(FindToolbar)(LPCWSTR pwszItem, REFIID riid, void **ppv) override;
 
     // *** IInputObjectSite specific methods ***
-    virtual HRESULT STDMETHODCALLTYPE OnFocusChangeIS(IUnknown *punkObj, BOOL fSetFocus);
+    STDMETHOD(OnFocusChangeIS)(IUnknown *punkObj, BOOL fSetFocus) override;
 
     // *** IDropTarget methods ***
-    virtual HRESULT STDMETHODCALLTYPE DragEnter(IDataObject *pDataObj, DWORD grfKeyState, POINTL pt, DWORD *pdwEffect);
-    virtual HRESULT STDMETHODCALLTYPE DragOver(DWORD grfKeyState, POINTL pt, DWORD *pdwEffect);
-    virtual HRESULT STDMETHODCALLTYPE DragLeave();
-    virtual HRESULT STDMETHODCALLTYPE Drop(IDataObject *pDataObj, DWORD grfKeyState, POINTL pt, DWORD *pdwEffect);
+    STDMETHOD(DragEnter)(IDataObject *pDataObj, DWORD grfKeyState, POINTL pt, DWORD *pdwEffect) override;
+    STDMETHOD(DragOver)(DWORD grfKeyState, POINTL pt, DWORD *pdwEffect) override;
+    STDMETHOD(DragLeave)() override;
+    STDMETHOD(Drop)(IDataObject *pDataObj, DWORD grfKeyState, POINTL pt, DWORD *pdwEffect) override;
 
     DECLARE_REGISTRY_RESOURCEID(IDR_COMMONBROWSER)
     DECLARE_AGGREGATABLE(CCommonBrowser)

--- a/dll/win32/browseui/commonbrowser.h
+++ b/dll/win32/browseui/commonbrowser.h
@@ -128,7 +128,7 @@ public:
     STDMETHOD_(IStream *, v_GetViewStream)(LPCITEMIDLIST pidl, DWORD grfMode, LPCWSTR pwszName) override;
     STDMETHOD_(LRESULT, ForwardViewMsg)(UINT uMsg, WPARAM wParam, LPARAM lParam) override;
     STDMETHOD(SetAcceleratorMenu)(HACCEL hacc) override;
-    STDMETHOD_(INT, _GetToolbarCount)() override;
+    STDMETHOD_(int, _GetToolbarCount)() override;
     STDMETHOD_(LPTOOLBARITEM, _GetToolbarItem)(int itb) override;
     STDMETHOD(_SaveToolbars)(IStream *pstm) override;
     STDMETHOD(_LoadToolbars)(IStream *pstm) override;

--- a/dll/win32/browseui/explorerband.h
+++ b/dll/win32/browseui/explorerband.h
@@ -112,71 +112,71 @@ public:
     virtual ~CExplorerBand();
 
     // *** IOleWindow methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetWindow(HWND *lphwnd);
-    virtual HRESULT STDMETHODCALLTYPE ContextSensitiveHelp(BOOL fEnterMode);
+    STDMETHOD(GetWindow)(HWND *lphwnd) override;
+    STDMETHOD(ContextSensitiveHelp)(BOOL fEnterMode) override;
 
     // *** IDockingWindow methods ***
-    virtual HRESULT STDMETHODCALLTYPE CloseDW(DWORD dwReserved);
-    virtual HRESULT STDMETHODCALLTYPE ResizeBorderDW(const RECT *prcBorder, IUnknown *punkToolbarSite, BOOL fReserved);
-    virtual HRESULT STDMETHODCALLTYPE ShowDW(BOOL fShow);
+    STDMETHOD(CloseDW)(DWORD dwReserved) override;
+    STDMETHOD(ResizeBorderDW)(const RECT *prcBorder, IUnknown *punkToolbarSite, BOOL fReserved) override;
+    STDMETHOD(ShowDW)(BOOL fShow) override;
 
     // *** IDeskBand methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetBandInfo(DWORD dwBandID, DWORD dwViewMode, DESKBANDINFO *pdbi);
+    STDMETHOD(GetBandInfo)(DWORD dwBandID, DWORD dwViewMode, DESKBANDINFO *pdbi) override;
 
     // *** IObjectWithSite methods ***
-    virtual HRESULT STDMETHODCALLTYPE SetSite(IUnknown *pUnkSite);
-    virtual HRESULT STDMETHODCALLTYPE GetSite(REFIID riid, void **ppvSite);
+    STDMETHOD(SetSite)(IUnknown *pUnkSite) override;
+    STDMETHOD(GetSite)(REFIID riid, void **ppvSite) override;
 
     // *** IOleCommandTarget methods ***
-    virtual HRESULT STDMETHODCALLTYPE QueryStatus(const GUID *pguidCmdGroup, ULONG cCmds, OLECMD prgCmds [], OLECMDTEXT *pCmdText);
-    virtual HRESULT STDMETHODCALLTYPE Exec(const GUID *pguidCmdGroup, DWORD nCmdID, DWORD nCmdexecopt, VARIANT *pvaIn, VARIANT *pvaOut);
+    STDMETHOD(QueryStatus)(const GUID *pguidCmdGroup, ULONG cCmds, OLECMD prgCmds [], OLECMDTEXT *pCmdText) override;
+    STDMETHOD(Exec)(const GUID *pguidCmdGroup, DWORD nCmdID, DWORD nCmdexecopt, VARIANT *pvaIn, VARIANT *pvaOut) override;
 
     // *** IServiceProvider methods ***
-    virtual HRESULT STDMETHODCALLTYPE QueryService(REFGUID guidService, REFIID riid, void **ppvObject);
+    STDMETHOD(QueryService)(REFGUID guidService, REFIID riid, void **ppvObject) override;
 
     // *** IInputObject methods ***
-    virtual HRESULT STDMETHODCALLTYPE UIActivateIO(BOOL fActivate, LPMSG lpMsg);
-    virtual HRESULT STDMETHODCALLTYPE HasFocusIO();
-    virtual HRESULT STDMETHODCALLTYPE TranslateAcceleratorIO(LPMSG lpMsg);
+    STDMETHOD(UIActivateIO)(BOOL fActivate, LPMSG lpMsg) override;
+    STDMETHOD(HasFocusIO)() override;
+    STDMETHOD(TranslateAcceleratorIO)(LPMSG lpMsg) override;
 
     // *** IPersist methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetClassID(CLSID *pClassID);
+    STDMETHOD(GetClassID)(CLSID *pClassID) override;
 
     // *** IPersistStream methods ***
-    virtual HRESULT STDMETHODCALLTYPE IsDirty();
-    virtual HRESULT STDMETHODCALLTYPE Load(IStream *pStm);
-    virtual HRESULT STDMETHODCALLTYPE Save(IStream *pStm, BOOL fClearDirty);
-    virtual HRESULT STDMETHODCALLTYPE GetSizeMax(ULARGE_INTEGER *pcbSize);
+    STDMETHOD(IsDirty)() override;
+    STDMETHOD(Load)(IStream *pStm) override;
+    STDMETHOD(Save)(IStream *pStm, BOOL fClearDirty) override;
+    STDMETHOD(GetSizeMax)(ULARGE_INTEGER *pcbSize) override;
 
     // *** IWinEventHandler methods ***
-    virtual HRESULT STDMETHODCALLTYPE OnWinEvent(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT *theResult);
-    virtual HRESULT STDMETHODCALLTYPE IsWindowOwner(HWND hWnd);
+    STDMETHOD(OnWinEvent)(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT *theResult) override;
+    STDMETHOD(IsWindowOwner)(HWND hWnd) override;
 
     // *** IBandNavigate methods ***
-    virtual HRESULT STDMETHODCALLTYPE Select(long paramC);
+    STDMETHOD(Select)(long paramC) override;
 
     // *** INamespaceProxy ***
-    virtual HRESULT STDMETHODCALLTYPE GetNavigateTarget(long paramC, long param10, long param14);
-    virtual HRESULT STDMETHODCALLTYPE Invoke(long paramC);
-    virtual HRESULT STDMETHODCALLTYPE OnSelectionChanged(long paramC);
-    virtual HRESULT STDMETHODCALLTYPE RefreshFlags(long paramC, long param10, long param14);
-    virtual HRESULT STDMETHODCALLTYPE CacheItem(long paramC);
+    STDMETHOD(GetNavigateTarget)(long paramC, long param10, long param14) override;
+    STDMETHOD(Invoke)(long paramC) override;
+    STDMETHOD(OnSelectionChanged)(long paramC) override;
+    STDMETHOD(RefreshFlags)(long paramC, long param10, long param14) override;
+    STDMETHOD(CacheItem)(long paramC) override;
 
     // *** IDispatch methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetTypeInfoCount(UINT *pctinfo);
-    virtual HRESULT STDMETHODCALLTYPE GetTypeInfo(UINT iTInfo, LCID lcid, ITypeInfo **ppTInfo);
-    virtual HRESULT STDMETHODCALLTYPE GetIDsOfNames(REFIID riid, LPOLESTR *rgszNames, UINT cNames, LCID lcid, DISPID *rgDispId);
-    virtual HRESULT STDMETHODCALLTYPE Invoke(DISPID dispIdMember, REFIID riid, LCID lcid, WORD wFlags, DISPPARAMS *pDispParams, VARIANT *pVarResult, EXCEPINFO *pExcepInfo, UINT *puArgErr);
+    STDMETHOD(GetTypeInfoCount)(UINT *pctinfo) override;
+    STDMETHOD(GetTypeInfo)(UINT iTInfo, LCID lcid, ITypeInfo **ppTInfo) override;
+    STDMETHOD(GetIDsOfNames)(REFIID riid, LPOLESTR *rgszNames, UINT cNames, LCID lcid, DISPID *rgDispId) override;
+    STDMETHOD(Invoke)(DISPID dispIdMember, REFIID riid, LCID lcid, WORD wFlags, DISPPARAMS *pDispParams, VARIANT *pVarResult, EXCEPINFO *pExcepInfo, UINT *puArgErr) override;
 
     // *** IDropTarget methods ***
-    virtual HRESULT STDMETHODCALLTYPE DragEnter(IDataObject *pObj, DWORD glfKeyState, POINTL pt, DWORD *pdwEffect);
-    virtual HRESULT STDMETHODCALLTYPE DragOver(DWORD glfKeyState, POINTL pt, DWORD *pdwEffect);
-    virtual HRESULT STDMETHODCALLTYPE DragLeave();
-    virtual HRESULT STDMETHODCALLTYPE Drop(IDataObject *pObj, DWORD glfKeyState, POINTL pt, DWORD *pdwEffect);
+    STDMETHOD(DragEnter)(IDataObject *pObj, DWORD glfKeyState, POINTL pt, DWORD *pdwEffect) override;
+    STDMETHOD(DragOver)(DWORD glfKeyState, POINTL pt, DWORD *pdwEffect) override;
+    STDMETHOD(DragLeave)() override;
+    STDMETHOD(Drop)(IDataObject *pObj, DWORD glfKeyState, POINTL pt, DWORD *pdwEffect) override;
 
     // *** IDropSource methods ***
-    virtual HRESULT STDMETHODCALLTYPE QueryContinueDrag(BOOL fEscapePressed, DWORD grfKeyState);
-    virtual HRESULT STDMETHODCALLTYPE GiveFeedback(DWORD dwEffect);
+    STDMETHOD(QueryContinueDrag)(BOOL fEscapePressed, DWORD grfKeyState) override;
+    STDMETHOD(GiveFeedback)(DWORD dwEffect) override;
 
     DECLARE_REGISTRY_RESOURCEID(IDR_EXPLORERBAND)
     DECLARE_NOT_AGGREGATABLE(CExplorerBand)

--- a/dll/win32/browseui/globalfoldersettings.h
+++ b/dll/win32/browseui/globalfoldersettings.h
@@ -31,8 +31,8 @@ public:
     ~CGlobalFolderSettings();
 
     // *** IGlobalFolderSettings methods ***
-    virtual HRESULT STDMETHODCALLTYPE Get(DEFFOLDERSETTINGS *paramC, int param10);
-    virtual HRESULT STDMETHODCALLTYPE Set(const DEFFOLDERSETTINGS *paramC, int param10, unsigned int param14);
+    STDMETHOD(Get)(DEFFOLDERSETTINGS *paramC, int param10) override;
+    STDMETHOD(Set)(const DEFFOLDERSETTINGS *paramC, int param10, unsigned int param14) override;
 
     DECLARE_REGISTRY_RESOURCEID(IDR_GLOBALFOLDERSETTINGS)
     DECLARE_NOT_AGGREGATABLE(CGlobalFolderSettings)

--- a/dll/win32/browseui/internettoolbar.cpp
+++ b/dll/win32/browseui/internettoolbar.cpp
@@ -29,10 +29,10 @@ toolbar, and address band for an explorer window
 
 interface IAugmentedShellFolder : public IShellFolder
 {
-    virtual HRESULT STDMETHODCALLTYPE AddNameSpace(LPGUID, IShellFolder *, LPCITEMIDLIST, ULONG) = 0;
-    virtual HRESULT STDMETHODCALLTYPE GetNameSpaceID(LPCITEMIDLIST, LPGUID) = 0;
-    virtual HRESULT STDMETHODCALLTYPE QueryNameSpace(ULONG, LPGUID, IShellFolder **) = 0;
-    virtual HRESULT STDMETHODCALLTYPE EnumNameSpace(ULONG, PULONG) = 0;
+    STDMETHOD(AddNameSpace)(LPGUID, IShellFolder *, LPCITEMIDLIST, ULONG) = 0;
+    STDMETHOD(GetNameSpaceID)(LPCITEMIDLIST, LPGUID) = 0;
+    STDMETHOD(QueryNameSpace)(ULONG, LPGUID, IShellFolder **) = 0;
+    STDMETHOD(EnumNameSpace)(ULONG, PULONG) = 0;
 };
 
 #endif
@@ -150,25 +150,25 @@ public:
 private:
 
     // *** IOleWindow methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetWindow(HWND *lphwnd);
-    virtual HRESULT STDMETHODCALLTYPE ContextSensitiveHelp(BOOL fEnterMode);
+    STDMETHOD(GetWindow)(HWND *lphwnd) override;
+    STDMETHOD(ContextSensitiveHelp)(BOOL fEnterMode) override;
 
     // *** IDockingWindow methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetBorderDW(IUnknown* punkObj, LPRECT prcBorder);
-    virtual HRESULT STDMETHODCALLTYPE RequestBorderSpaceDW(IUnknown* punkObj, LPCBORDERWIDTHS pbw);
-    virtual HRESULT STDMETHODCALLTYPE SetBorderSpaceDW(IUnknown* punkObj, LPCBORDERWIDTHS pbw);
+    STDMETHOD(GetBorderDW)(IUnknown* punkObj, LPRECT prcBorder) override;
+    STDMETHOD(RequestBorderSpaceDW)(IUnknown* punkObj, LPCBORDERWIDTHS pbw) override;
+    STDMETHOD(SetBorderSpaceDW)(IUnknown* punkObj, LPCBORDERWIDTHS pbw) override;
 
     // *** IInputObjectSite specific methods ***
-    virtual HRESULT STDMETHODCALLTYPE OnFocusChangeIS(IUnknown *punkObj, BOOL fSetFocus);
+    STDMETHOD(OnFocusChangeIS)(IUnknown *punkObj, BOOL fSetFocus) override;
 
     // *** IOleCommandTarget specific methods ***
-    virtual HRESULT STDMETHODCALLTYPE QueryStatus(const GUID *pguidCmdGroup, ULONG cCmds,
-        OLECMD prgCmds[  ], OLECMDTEXT *pCmdText);
-    virtual HRESULT STDMETHODCALLTYPE Exec(const GUID *pguidCmdGroup, DWORD nCmdID,
-        DWORD nCmdexecopt, VARIANT *pvaIn, VARIANT *pvaOut);
+    STDMETHOD(QueryStatus)(const GUID *pguidCmdGroup, ULONG cCmds,
+        OLECMD prgCmds[  ], OLECMDTEXT *pCmdText) override;
+    STDMETHOD(Exec)(const GUID *pguidCmdGroup, DWORD nCmdID,
+        DWORD nCmdexecopt, VARIANT *pvaIn, VARIANT *pvaOut) override;
 
     // *** IServiceProvider methods ***
-    virtual HRESULT STDMETHODCALLTYPE QueryService(REFGUID guidService, REFIID riid, void **ppvObject);
+    STDMETHOD(QueryService)(REFGUID guidService, REFIID riid, void **ppvObject) override;
 
 BEGIN_COM_MAP(CDockSite)
     COM_INTERFACE_ENTRY_IID(IID_IOleWindow, IOleWindow)

--- a/dll/win32/browseui/internettoolbar.cpp
+++ b/dll/win32/browseui/internettoolbar.cpp
@@ -29,10 +29,10 @@ toolbar, and address band for an explorer window
 
 interface IAugmentedShellFolder : public IShellFolder
 {
-    STDMETHOD(AddNameSpace)(LPGUID, IShellFolder *, LPCITEMIDLIST, ULONG) = 0;
-    STDMETHOD(GetNameSpaceID)(LPCITEMIDLIST, LPGUID) = 0;
-    STDMETHOD(QueryNameSpace)(ULONG, LPGUID, IShellFolder **) = 0;
-    STDMETHOD(EnumNameSpace)(ULONG, PULONG) = 0;
+    STDMETHOD(AddNameSpace)(LPGUID, IShellFolder *, LPCITEMIDLIST, ULONG) PURE;
+    STDMETHOD(GetNameSpaceID)(LPCITEMIDLIST, LPGUID) PURE;
+    STDMETHOD(QueryNameSpace)(ULONG, LPGUID, IShellFolder **) PURE;
+    STDMETHOD(EnumNameSpace)(ULONG, PULONG) PURE;
 };
 
 #endif

--- a/dll/win32/browseui/internettoolbar.h
+++ b/dll/win32/browseui/internettoolbar.h
@@ -110,76 +110,76 @@ public:
 
 public:
     // *** IInputObject specific methods ***
-    virtual HRESULT STDMETHODCALLTYPE UIActivateIO(BOOL fActivate, LPMSG lpMsg);
-    virtual HRESULT STDMETHODCALLTYPE HasFocusIO();
-    virtual HRESULT STDMETHODCALLTYPE TranslateAcceleratorIO(LPMSG lpMsg);
+    STDMETHOD(UIActivateIO)(BOOL fActivate, LPMSG lpMsg) override;
+    STDMETHOD(HasFocusIO)() override;
+    STDMETHOD(TranslateAcceleratorIO)(LPMSG lpMsg) override;
 
     // *** IOleWindow methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetWindow(HWND *lphwnd);
-    virtual HRESULT STDMETHODCALLTYPE ContextSensitiveHelp(BOOL fEnterMode);
+    STDMETHOD(GetWindow)(HWND *lphwnd) override;
+    STDMETHOD(ContextSensitiveHelp)(BOOL fEnterMode) override;
 
     // *** IDockingWindow methods ***
-    virtual HRESULT STDMETHODCALLTYPE ShowDW(BOOL fShow);
-    virtual HRESULT STDMETHODCALLTYPE CloseDW(DWORD dwReserved);
-    virtual HRESULT STDMETHODCALLTYPE ResizeBorderDW(LPCRECT prcBorder, IUnknown *punkToolbarSite, BOOL fReserved);
+    STDMETHOD(ShowDW)(BOOL fShow) override;
+    STDMETHOD(CloseDW)(DWORD dwReserved) override;
+    STDMETHOD(ResizeBorderDW)(LPCRECT prcBorder, IUnknown *punkToolbarSite, BOOL fReserved) override;
 
     // *** IPersist methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetClassID(CLSID *pClassID);
+    STDMETHOD(GetClassID)(CLSID *pClassID) override;
 
     // *** IPersistStreamInit methods ***
-    virtual HRESULT STDMETHODCALLTYPE IsDirty();
-    virtual HRESULT STDMETHODCALLTYPE Load(IStream *pStm);
-    virtual HRESULT STDMETHODCALLTYPE Save(IStream *pStm, BOOL fClearDirty);
-    virtual HRESULT STDMETHODCALLTYPE GetSizeMax(ULARGE_INTEGER *pcbSize);
-    virtual HRESULT STDMETHODCALLTYPE InitNew();
+    STDMETHOD(IsDirty)() override;
+    STDMETHOD(Load)(IStream *pStm) override;
+    STDMETHOD(Save)(IStream *pStm, BOOL fClearDirty) override;
+    STDMETHOD(GetSizeMax)(ULARGE_INTEGER *pcbSize) override;
+    STDMETHOD(InitNew)() override;
 
     // *** IOleCommandTarget methods ***
-    virtual HRESULT STDMETHODCALLTYPE QueryStatus(const GUID *pguidCmdGroup, ULONG cCmds, OLECMD prgCmds[  ], OLECMDTEXT *pCmdText);
-    virtual HRESULT STDMETHODCALLTYPE Exec(const GUID *pguidCmdGroup, DWORD nCmdID, DWORD nCmdexecopt, VARIANT *pvaIn, VARIANT *pvaOut);
+    STDMETHOD(QueryStatus)(const GUID *pguidCmdGroup, ULONG cCmds, OLECMD prgCmds[  ], OLECMDTEXT *pCmdText) override;
+    STDMETHOD(Exec)(const GUID *pguidCmdGroup, DWORD nCmdID, DWORD nCmdexecopt, VARIANT *pvaIn, VARIANT *pvaOut) override;
 
     // *** IDispatch methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetTypeInfoCount(UINT *pctinfo);
-    virtual HRESULT STDMETHODCALLTYPE GetTypeInfo(UINT iTInfo, LCID lcid, ITypeInfo **ppTInfo);
-    virtual HRESULT STDMETHODCALLTYPE GetIDsOfNames(REFIID riid, LPOLESTR *rgszNames, UINT cNames, LCID lcid, DISPID *rgDispId);
-    virtual HRESULT STDMETHODCALLTYPE Invoke(DISPID dispIdMember, REFIID riid, LCID lcid, WORD wFlags, DISPPARAMS *pDispParams, VARIANT *pVarResult, EXCEPINFO *pExcepInfo, UINT *puArgErr);
+    STDMETHOD(GetTypeInfoCount)(UINT *pctinfo) override;
+    STDMETHOD(GetTypeInfo)(UINT iTInfo, LCID lcid, ITypeInfo **ppTInfo) override;
+    STDMETHOD(GetIDsOfNames)(REFIID riid, LPOLESTR *rgszNames, UINT cNames, LCID lcid, DISPID *rgDispId) override;
+    STDMETHOD(Invoke)(DISPID dispIdMember, REFIID riid, LCID lcid, WORD wFlags, DISPPARAMS *pDispParams, VARIANT *pVarResult, EXCEPINFO *pExcepInfo, UINT *puArgErr) override;
 
     // *** IExplorerToolbar methods ***
-    virtual HRESULT STDMETHODCALLTYPE SetCommandTarget(IUnknown *theTarget, GUID *category, long param14);
-    virtual HRESULT STDMETHODCALLTYPE Unknown1();
-    virtual HRESULT STDMETHODCALLTYPE AddButtons(const GUID *pguidCmdGroup, long buttonCount, TBBUTTON *buttons);
-    virtual HRESULT STDMETHODCALLTYPE AddString(const GUID *pguidCmdGroup, HINSTANCE param10, LPCTSTR param14, long *param18);
-    virtual HRESULT STDMETHODCALLTYPE GetButton(const GUID *pguidCmdGroup, long param10, long param14);
-    virtual HRESULT STDMETHODCALLTYPE GetState(const GUID *pguidCmdGroup, long commandID, long *theState);
-    virtual HRESULT STDMETHODCALLTYPE SetState(const GUID *pguidCmdGroup, long commandID, long theState);
-    virtual HRESULT STDMETHODCALLTYPE AddBitmap(const GUID *pguidCmdGroup, long param10, long buttonCount, TBADDBITMAP *lParam, long *newIndex, COLORREF param20);
-    virtual HRESULT STDMETHODCALLTYPE GetBitmapSize(long *paramC);
-    virtual HRESULT STDMETHODCALLTYPE SendToolbarMsg(const GUID *pguidCmdGroup, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT *result);
-    virtual HRESULT STDMETHODCALLTYPE SetImageList(const GUID *pguidCmdGroup, HIMAGELIST param10, HIMAGELIST param14, HIMAGELIST param18);
-    virtual HRESULT STDMETHODCALLTYPE ModifyButton(const GUID *pguidCmdGroup, long param10, long param14);
+    STDMETHOD(SetCommandTarget)(IUnknown *theTarget, GUID *category, long param14) override;
+    STDMETHOD(Unknown1)() override;
+    STDMETHOD(AddButtons)(const GUID *pguidCmdGroup, long buttonCount, TBBUTTON *buttons) override;
+    STDMETHOD(AddString)(const GUID *pguidCmdGroup, HINSTANCE param10, LPCTSTR param14, long *param18) override;
+    STDMETHOD(GetButton)(const GUID *pguidCmdGroup, long param10, long param14) override;
+    STDMETHOD(GetState)(const GUID *pguidCmdGroup, long commandID, long *theState) override;
+    STDMETHOD(SetState)(const GUID *pguidCmdGroup, long commandID, long theState) override;
+    STDMETHOD(AddBitmap)(const GUID *pguidCmdGroup, long param10, long buttonCount, TBADDBITMAP *lParam, long *newIndex, COLORREF param20) override;
+    STDMETHOD(GetBitmapSize)(long *paramC) override;
+    STDMETHOD(SendToolbarMsg)(const GUID *pguidCmdGroup, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT *result) override;
+    STDMETHOD(SetImageList)(const GUID *pguidCmdGroup, HIMAGELIST param10, HIMAGELIST param14, HIMAGELIST param18) override;
+    STDMETHOD(ModifyButton)(const GUID *pguidCmdGroup, long param10, long param14) override;
 
     // *** IShellChangeNotify methods ***
-    virtual HRESULT STDMETHODCALLTYPE OnChange(LONG lEvent, LPCITEMIDLIST pidl1, LPCITEMIDLIST pidl2);
+    STDMETHOD(OnChange)(LONG lEvent, LPCITEMIDLIST pidl1, LPCITEMIDLIST pidl2) override;
 
     // *** IObjectWithSite methods ***
-    virtual HRESULT STDMETHODCALLTYPE SetSite(IUnknown *pUnkSite);
-    virtual HRESULT STDMETHODCALLTYPE GetSite(REFIID riid, void **ppvSite);
+    STDMETHOD(SetSite)(IUnknown *pUnkSite) override;
+    STDMETHOD(GetSite)(REFIID riid, void **ppvSite) override;
 
     // *** IServiceProvider methods ***
-    virtual HRESULT STDMETHODCALLTYPE QueryService(REFGUID guidService, REFIID riid, void **ppvObject);
+    STDMETHOD(QueryService)(REFGUID guidService, REFIID riid, void **ppvObject) override;
 
     // *** IWinEventHandler methods ***
-    virtual HRESULT STDMETHODCALLTYPE OnWinEvent(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT *theResult);
-    virtual HRESULT STDMETHODCALLTYPE IsWindowOwner(HWND hWnd);
+    STDMETHOD(OnWinEvent)(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT *theResult) override;
+    STDMETHOD(IsWindowOwner)(HWND hWnd) override;
 
     // *** IBandSite specific methods ***
-    virtual HRESULT STDMETHODCALLTYPE AddBand(IUnknown *punk);
-    virtual HRESULT STDMETHODCALLTYPE EnumBands(UINT uBand, DWORD *pdwBandID);
-    virtual HRESULT STDMETHODCALLTYPE QueryBand(DWORD dwBandID, IDeskBand **ppstb, DWORD *pdwState, LPWSTR pszName, int cchName);
-    virtual HRESULT STDMETHODCALLTYPE SetBandState(DWORD dwBandID, DWORD dwMask, DWORD dwState);
-    virtual HRESULT STDMETHODCALLTYPE RemoveBand(DWORD dwBandID);
-    virtual HRESULT STDMETHODCALLTYPE GetBandObject(DWORD dwBandID, REFIID riid, void **ppv);
-    virtual HRESULT STDMETHODCALLTYPE SetBandSiteInfo(const BANDSITEINFO *pbsinfo);
-    virtual HRESULT STDMETHODCALLTYPE GetBandSiteInfo(BANDSITEINFO *pbsinfo);
+    STDMETHOD(AddBand)(IUnknown *punk) override;
+    STDMETHOD(EnumBands)(UINT uBand, DWORD *pdwBandID) override;
+    STDMETHOD(QueryBand)(DWORD dwBandID, IDeskBand **ppstb, DWORD *pdwState, LPWSTR pszName, int cchName) override;
+    STDMETHOD(SetBandState)(DWORD dwBandID, DWORD dwMask, DWORD dwState) override;
+    STDMETHOD(RemoveBand)(DWORD dwBandID) override;
+    STDMETHOD(GetBandObject)(DWORD dwBandID, REFIID riid, void **ppv) override;
+    STDMETHOD(SetBandSiteInfo)(const BANDSITEINFO *pbsinfo) override;
+    STDMETHOD(GetBandSiteInfo)(BANDSITEINFO *pbsinfo) override;
 
     // message handlers
     LRESULT OnTravelBack(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL &bHandled);

--- a/dll/win32/browseui/regtreeoptions.h
+++ b/dll/win32/browseui/regtreeoptions.h
@@ -32,14 +32,14 @@ public:
     ~CRegTreeOptions();
 
     // *** IRegTreeOptions methods ***
-    virtual HRESULT STDMETHODCALLTYPE InitTree(HWND paramC, HKEY param10, char const *param14, char const *param18);
-    virtual HRESULT STDMETHODCALLTYPE WalkTree(WALK_TREE_CMD paramC);
-    virtual HRESULT STDMETHODCALLTYPE ToggleItem(HTREEITEM paramC);
-    virtual HRESULT STDMETHODCALLTYPE ShowHelp(HTREEITEM paramC, unsigned long param10);
+    STDMETHOD(InitTree)(HWND paramC, HKEY param10, char const *param14, char const *param18) override;
+    STDMETHOD(WalkTree)(WALK_TREE_CMD paramC) override;
+    STDMETHOD(ToggleItem)(HTREEITEM paramC) override;
+    STDMETHOD(ShowHelp)(HTREEITEM paramC, unsigned long param10) override;
 
     // *** IObjectWithSite methods ***
-    virtual HRESULT STDMETHODCALLTYPE SetSite(IUnknown *pUnkSite);
-    virtual HRESULT STDMETHODCALLTYPE GetSite(REFIID riid, void **ppvSite);
+    STDMETHOD(SetSite)(IUnknown *pUnkSite) override;
+    STDMETHOD(GetSite)(REFIID riid, void **ppvSite) override;
 
     DECLARE_REGISTRY_RESOURCEID(IDR_REGTREEOPTIONS)
     DECLARE_NOT_AGGREGATABLE(CRegTreeOptions)

--- a/dll/win32/browseui/shellbars/CBandSite.h
+++ b/dll/win32/browseui/shellbars/CBandSite.h
@@ -61,62 +61,62 @@ public:
     ~CBandSiteBase();
 
     // *** IBandSite methods ***
-    virtual HRESULT STDMETHODCALLTYPE AddBand(IUnknown *punk);
-    virtual HRESULT STDMETHODCALLTYPE EnumBands(UINT uBand, DWORD *pdwBandID);
-    virtual HRESULT STDMETHODCALLTYPE QueryBand(DWORD dwBandID, IDeskBand **ppstb, DWORD *pdwState, LPWSTR pszName, int cchName);
-    virtual HRESULT STDMETHODCALLTYPE SetBandState(DWORD dwBandID, DWORD dwMask, DWORD dwState);
-    virtual HRESULT STDMETHODCALLTYPE RemoveBand(DWORD dwBandID);
-    virtual HRESULT STDMETHODCALLTYPE GetBandObject(DWORD dwBandID, REFIID riid, void **ppv);
-    virtual HRESULT STDMETHODCALLTYPE SetBandSiteInfo(const BANDSITEINFO *pbsinfo);
-    virtual HRESULT STDMETHODCALLTYPE GetBandSiteInfo(BANDSITEINFO *pbsinfo);
+    STDMETHOD(AddBand)(IUnknown *punk) override;
+    STDMETHOD(EnumBands)(UINT uBand, DWORD *pdwBandID) override;
+    STDMETHOD(QueryBand)(DWORD dwBandID, IDeskBand **ppstb, DWORD *pdwState, LPWSTR pszName, int cchName) override;
+    STDMETHOD(SetBandState)(DWORD dwBandID, DWORD dwMask, DWORD dwState) override;
+    STDMETHOD(RemoveBand)(DWORD dwBandID) override;
+    STDMETHOD(GetBandObject)(DWORD dwBandID, REFIID riid, void **ppv) override;
+    STDMETHOD(SetBandSiteInfo)(const BANDSITEINFO *pbsinfo) override;
+    STDMETHOD(GetBandSiteInfo)(BANDSITEINFO *pbsinfo) override;
 
     // *** IWinEventHandler methods ***
-    virtual HRESULT STDMETHODCALLTYPE OnWinEvent(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT *theResult);
-    virtual HRESULT STDMETHODCALLTYPE IsWindowOwner(HWND hWnd);
+    STDMETHOD(OnWinEvent)(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT *theResult) override;
+    STDMETHOD(IsWindowOwner)(HWND hWnd) override;
 
     // *** IOleWindow methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetWindow(HWND *lphwnd);
-    virtual HRESULT STDMETHODCALLTYPE ContextSensitiveHelp(BOOL fEnterMode);
+    STDMETHOD(GetWindow)(HWND *lphwnd) override;
+    STDMETHOD(ContextSensitiveHelp)(BOOL fEnterMode) override;
 
     // *** IDeskBarClient methods ***
-    virtual HRESULT STDMETHODCALLTYPE SetDeskBarSite(IUnknown *punkSite);
-    virtual HRESULT STDMETHODCALLTYPE SetModeDBC(DWORD dwMode);
-    virtual HRESULT STDMETHODCALLTYPE UIActivateDBC(DWORD dwState);
-    virtual HRESULT STDMETHODCALLTYPE GetSize(DWORD dwWhich, LPRECT prc);
+    STDMETHOD(SetDeskBarSite)(IUnknown *punkSite) override;
+    STDMETHOD(SetModeDBC)(DWORD dwMode) override;
+    STDMETHOD(UIActivateDBC)(DWORD dwState) override;
+    STDMETHOD(GetSize)(DWORD dwWhich, LPRECT prc) override;
 
     // *** IOleCommandTarget methods ***
-    virtual HRESULT STDMETHODCALLTYPE QueryStatus(const GUID *pguidCmdGroup, ULONG cCmds, OLECMD prgCmds[  ], OLECMDTEXT *pCmdText);
-    virtual HRESULT STDMETHODCALLTYPE Exec(const GUID *pguidCmdGroup, DWORD nCmdID, DWORD nCmdexecopt, VARIANT *pvaIn, VARIANT *pvaOut);
+    STDMETHOD(QueryStatus)(const GUID *pguidCmdGroup, ULONG cCmds, OLECMD prgCmds[  ], OLECMDTEXT *pCmdText) override;
+    STDMETHOD(Exec)(const GUID *pguidCmdGroup, DWORD nCmdID, DWORD nCmdexecopt, VARIANT *pvaIn, VARIANT *pvaOut) override;
 
     // *** IInputObject methods ***
-    virtual HRESULT STDMETHODCALLTYPE UIActivateIO(BOOL fActivate, LPMSG lpMsg);
-    virtual HRESULT STDMETHODCALLTYPE HasFocusIO();
-    virtual HRESULT STDMETHODCALLTYPE TranslateAcceleratorIO(LPMSG lpMsg);
+    STDMETHOD(UIActivateIO)(BOOL fActivate, LPMSG lpMsg) override;
+    STDMETHOD(HasFocusIO)() override;
+    STDMETHOD(TranslateAcceleratorIO)(LPMSG lpMsg) override;
 
     // *** IInputObjectSite methods ***
-    virtual HRESULT STDMETHODCALLTYPE OnFocusChangeIS(struct IUnknown *paramC, int param10);
+    STDMETHOD(OnFocusChangeIS)(struct IUnknown *paramC, int param10) override;
 
     // *** IServiceProvider methods ***
-    virtual HRESULT STDMETHODCALLTYPE QueryService(REFGUID guidService, REFIID riid, void **ppvObject);
+    STDMETHOD(QueryService)(REFGUID guidService, REFIID riid, void **ppvObject) override;
 
     // *** IPersist methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetClassID(CLSID *pClassID);
+    STDMETHOD(GetClassID)(CLSID *pClassID) override;
 
     // *** IPersistStream methods ***
-    virtual HRESULT STDMETHODCALLTYPE IsDirty();
-    virtual HRESULT STDMETHODCALLTYPE Load(IStream *pStm);
-    virtual HRESULT STDMETHODCALLTYPE Save(IStream *pStm, BOOL fClearDirty);
-    virtual HRESULT STDMETHODCALLTYPE GetSizeMax(ULARGE_INTEGER *pcbSize);
+    STDMETHOD(IsDirty)() override;
+    STDMETHOD(Load)(IStream *pStm) override;
+    STDMETHOD(Save)(IStream *pStm, BOOL fClearDirty) override;
+    STDMETHOD(GetSizeMax)(ULARGE_INTEGER *pcbSize) override;
 
     // *** IDropTarget methods ***
-    virtual HRESULT STDMETHODCALLTYPE DragEnter(IDataObject *pDataObj, DWORD grfKeyState, POINTL pt, DWORD *pdwEffect);
-    virtual HRESULT STDMETHODCALLTYPE DragOver(DWORD grfKeyState, POINTL pt, DWORD *pdwEffect);
-    virtual HRESULT STDMETHODCALLTYPE DragLeave();
-    virtual HRESULT STDMETHODCALLTYPE Drop(IDataObject *pDataObj, DWORD grfKeyState, POINTL pt, DWORD *pdwEffect);
+    STDMETHOD(DragEnter)(IDataObject *pDataObj, DWORD grfKeyState, POINTL pt, DWORD *pdwEffect) override;
+    STDMETHOD(DragOver)(DWORD grfKeyState, POINTL pt, DWORD *pdwEffect) override;
+    STDMETHOD(DragLeave)() override;
+    STDMETHOD(Drop)(IDataObject *pDataObj, DWORD grfKeyState, POINTL pt, DWORD *pdwEffect) override;
 
     // *** IBandSiteHelper methods ***
-    virtual HRESULT STDMETHODCALLTYPE LoadFromStreamBS(IStream *, const GUID &, void **);
-    virtual HRESULT STDMETHODCALLTYPE SaveToStreamBS(IUnknown *, IStream *);
+    STDMETHOD(LoadFromStreamBS)(IStream *, const GUID &, void **) override;
+    STDMETHOD(SaveToStreamBS)(IUnknown *, IStream *) override;
 
 private:
     UINT _GetBandID(struct BandObject *Band);

--- a/dll/win32/browseui/shellbars/CBandSiteMenu.h
+++ b/dll/win32/browseui/shellbars/CBandSiteMenu.h
@@ -51,18 +51,18 @@ public:
     HRESULT WINAPI FinalConstruct();
 
     // *** IShellService methods ***
-    virtual HRESULT STDMETHODCALLTYPE SetOwner(IUnknown *);
+    STDMETHOD(SetOwner)(IUnknown *) override;
 
     // *** IContextMenu methods ***
-    virtual HRESULT STDMETHODCALLTYPE QueryContextMenu(HMENU hmenu, UINT indexMenu, UINT idCmdFirst, UINT idCmdLast, UINT uFlags);
-    virtual HRESULT STDMETHODCALLTYPE InvokeCommand(LPCMINVOKECOMMANDINFO lpici);
-    virtual HRESULT STDMETHODCALLTYPE GetCommandString(UINT_PTR idCmd, UINT uType, UINT *pwReserved, LPSTR pszName, UINT cchMax);
+    STDMETHOD(QueryContextMenu)(HMENU hmenu, UINT indexMenu, UINT idCmdFirst, UINT idCmdLast, UINT uFlags) override;
+    STDMETHOD(InvokeCommand)(LPCMINVOKECOMMANDINFO lpici) override;
+    STDMETHOD(GetCommandString)(UINT_PTR idCmd, UINT uType, UINT *pwReserved, LPSTR pszName, UINT cchMax) override;
 
     // *** IContextMenu2 methods ***
-    virtual HRESULT STDMETHODCALLTYPE HandleMenuMsg(UINT uMsg, WPARAM wParam, LPARAM lParam);
+    STDMETHOD(HandleMenuMsg)(UINT uMsg, WPARAM wParam, LPARAM lParam) override;
 
     // *** IContextMenu3 methods ***
-    virtual HRESULT STDMETHODCALLTYPE HandleMenuMsg2(UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT *plResult);
+    STDMETHOD(HandleMenuMsg2)(UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT *plResult) override;
 
     DECLARE_REGISTRY_RESOURCEID(IDR_BANDSITEMENU)
     DECLARE_NOT_AGGREGATABLE(CBandSiteMenu)

--- a/dll/win32/browseui/shellbars/CBaseBar.cpp
+++ b/dll/win32/browseui/shellbars/CBaseBar.cpp
@@ -70,56 +70,56 @@ public:
     HRESULT ReserveBorderSpace();
 
     // *** IOleWindow methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetWindow(HWND *lphwnd);
-    virtual HRESULT STDMETHODCALLTYPE ContextSensitiveHelp(BOOL fEnterMode);
+    STDMETHOD(GetWindow)(HWND *lphwnd) override;
+    STDMETHOD(ContextSensitiveHelp)(BOOL fEnterMode) override;
 
     // *** IInputObjectSite specific methods ***
-    virtual HRESULT STDMETHODCALLTYPE OnFocusChangeIS(IUnknown *punkObj, BOOL fSetFocus);
+    STDMETHOD(OnFocusChangeIS)(IUnknown *punkObj, BOOL fSetFocus) override;
 
     // *** IOleCommandTarget specific methods ***
-    virtual HRESULT STDMETHODCALLTYPE QueryStatus(const GUID *pguidCmdGroup, ULONG cCmds,
-        OLECMD prgCmds[  ], OLECMDTEXT *pCmdText);
-    virtual HRESULT STDMETHODCALLTYPE Exec(const GUID *pguidCmdGroup, DWORD nCmdID,
-        DWORD nCmdexecopt, VARIANT *pvaIn, VARIANT *pvaOut);
+    STDMETHOD(QueryStatus)(const GUID *pguidCmdGroup, ULONG cCmds,
+        OLECMD prgCmds[  ], OLECMDTEXT *pCmdText) override;
+    STDMETHOD(Exec)(const GUID *pguidCmdGroup, DWORD nCmdID,
+        DWORD nCmdexecopt, VARIANT *pvaIn, VARIANT *pvaOut) override;
 
     // *** IServiceProvider methods ***
-    virtual HRESULT STDMETHODCALLTYPE QueryService(REFGUID guidService, REFIID riid, void **ppvObject);
+    STDMETHOD(QueryService)(REFGUID guidService, REFIID riid, void **ppvObject) override;
 
     // *** IInputObject methods ***
     // forward the methods to the contained active bar
-    virtual HRESULT STDMETHODCALLTYPE UIActivateIO(BOOL fActivate, LPMSG lpMsg);
-    virtual HRESULT STDMETHODCALLTYPE HasFocusIO();
-    virtual HRESULT STDMETHODCALLTYPE TranslateAcceleratorIO(LPMSG lpMsg);
+    STDMETHOD(UIActivateIO)(BOOL fActivate, LPMSG lpMsg) override;
+    STDMETHOD(HasFocusIO)() override;
+    STDMETHOD(TranslateAcceleratorIO)(LPMSG lpMsg) override;
 
     // *** IDeskBar methods ***
-    virtual HRESULT STDMETHODCALLTYPE SetClient(IUnknown *punkClient);
-    virtual HRESULT STDMETHODCALLTYPE GetClient(IUnknown **ppunkClient);
-    virtual HRESULT STDMETHODCALLTYPE OnPosRectChangeDB(LPRECT prc);
+    STDMETHOD(SetClient)(IUnknown *punkClient) override;
+    STDMETHOD(GetClient)(IUnknown **ppunkClient) override;
+    STDMETHOD(OnPosRectChangeDB)(LPRECT prc) override;
 
     // *** IDockingWindow methods ***
-    virtual HRESULT STDMETHODCALLTYPE ShowDW(BOOL fShow);
-    virtual HRESULT STDMETHODCALLTYPE CloseDW(DWORD dwReserved);
-    virtual HRESULT STDMETHODCALLTYPE ResizeBorderDW(LPCRECT prcBorder, IUnknown *punkToolbarSite, BOOL fReserved);
+    STDMETHOD(ShowDW)(BOOL fShow) override;
+    STDMETHOD(CloseDW)(DWORD dwReserved) override;
+    STDMETHOD(ResizeBorderDW)(LPCRECT prcBorder, IUnknown *punkToolbarSite, BOOL fReserved) override;
 
     // *** IObjectWithSite methods ***
-    virtual HRESULT STDMETHODCALLTYPE SetSite(IUnknown *pUnkSite);
-    virtual HRESULT STDMETHODCALLTYPE GetSite(REFIID riid, void **ppvSite);
+    STDMETHOD(SetSite)(IUnknown *pUnkSite) override;
+    STDMETHOD(GetSite)(REFIID riid, void **ppvSite) override;
 
     // *** IPersist methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetClassID(CLSID *pClassID);
+    STDMETHOD(GetClassID)(CLSID *pClassID) override;
 
     // *** IPersistStream methods ***
-    virtual HRESULT STDMETHODCALLTYPE IsDirty();
-    virtual HRESULT STDMETHODCALLTYPE Load(IStream *pStm);
-    virtual HRESULT STDMETHODCALLTYPE Save(IStream *pStm, BOOL fClearDirty);
-    virtual HRESULT STDMETHODCALLTYPE GetSizeMax(ULARGE_INTEGER *pcbSize);
+    STDMETHOD(IsDirty)() override;
+    STDMETHOD(Load)(IStream *pStm) override;
+    STDMETHOD(Save)(IStream *pStm, BOOL fClearDirty) override;
+    STDMETHOD(GetSizeMax)(ULARGE_INTEGER *pcbSize) override;
 
     // *** IPersistStreamInit methods ***
-    virtual HRESULT STDMETHODCALLTYPE InitNew();
+    STDMETHOD(InitNew)() override;
 
     // *** IPersistPropertyBag methods ***
-    virtual HRESULT STDMETHODCALLTYPE Load(IPropertyBag *pPropBag, IErrorLog *pErrorLog);
-    virtual HRESULT STDMETHODCALLTYPE Save(IPropertyBag *pPropBag, BOOL fClearDirty, BOOL fSaveAllProperties);
+    STDMETHOD(Load)(IPropertyBag *pPropBag, IErrorLog *pErrorLog) override;
+    STDMETHOD(Save)(IPropertyBag *pPropBag, BOOL fClearDirty, BOOL fSaveAllProperties) override;
 
     // message handlers
     LRESULT OnSize(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);

--- a/dll/win32/browseui/shellbars/CISFBand.h
+++ b/dll/win32/browseui/shellbars/CISFBand.h
@@ -41,137 +41,137 @@ public:
 // Personal Methods
     HRESULT CreateSimpleToolbar(HWND hWndParent);
 
-// IObjectWithSite
-
-    virtual STDMETHODIMP GetSite(
-        IN  REFIID riid,
-        OUT void   **ppvSite
-    );
-
-    virtual STDMETHODIMP SetSite(
-        IN IUnknown *pUnkSite
-    );
-
-// IDeskBand
-
-    virtual STDMETHODIMP GetWindow(
-        OUT HWND *phwnd
-    );
-
-    virtual STDMETHODIMP ContextSensitiveHelp(
-        IN BOOL fEnterMode
-    );
-
-    virtual STDMETHODIMP ShowDW(
-        IN BOOL bShow
-    );
-
-    virtual STDMETHODIMP CloseDW(
-        IN DWORD dwReserved
-    );
-
-    virtual STDMETHODIMP ResizeBorderDW(
-        LPCRECT prcBorder,
-        IUnknown *punkToolbarSite,
-        BOOL fReserved
-    );
-
-    virtual STDMETHODIMP GetBandInfo(
-        IN DWORD dwBandID,
-        IN DWORD dwViewMode,
-        IN OUT DESKBANDINFO *pdbi
-    );
-
-// IPersistStream
-
-    virtual STDMETHODIMP GetClassID(
-        OUT CLSID *pClassID
-    );
-
-    virtual STDMETHODIMP GetSizeMax(
-        OUT ULARGE_INTEGER *pcbSize
-    );
-
-    virtual STDMETHODIMP IsDirty();
-
-    virtual STDMETHODIMP Load(
-        IN IStream *pStm
-    );
-
-    virtual STDMETHODIMP Save(
-        IN IStream *pStm,
-        IN BOOL    fClearDirty
-    );
-
-// IWinEventHandler
-
-    virtual STDMETHODIMP ContainsWindow(
+    STDMETHOD(ContainsWindow)(
         IN HWND hWnd
     );
 
-    virtual STDMETHODIMP OnWinEvent(
+// IObjectWithSite
+
+    STDMETHOD(GetSite)(
+        IN  REFIID riid,
+        OUT void   **ppvSite
+    ) override;
+
+    STDMETHOD(SetSite)(
+        IN IUnknown *pUnkSite
+    ) override;
+
+// IDeskBand
+
+    STDMETHOD(GetWindow)(
+        OUT HWND *phwnd
+    ) override;
+
+    STDMETHOD(ContextSensitiveHelp)(
+        IN BOOL fEnterMode
+    ) override;
+
+    STDMETHOD(ShowDW)(
+        IN BOOL bShow
+    ) override;
+
+    STDMETHOD(CloseDW)(
+        IN DWORD dwReserved
+    ) override;
+
+    STDMETHOD(ResizeBorderDW)(
+        LPCRECT prcBorder,
+        IUnknown *punkToolbarSite,
+        BOOL fReserved
+    ) override;
+
+    STDMETHOD(GetBandInfo)(
+        IN DWORD dwBandID,
+        IN DWORD dwViewMode,
+        IN OUT DESKBANDINFO *pdbi
+    ) override;
+
+// IPersistStream
+
+    STDMETHOD(GetClassID)(
+        OUT CLSID *pClassID
+    ) override;
+
+    STDMETHOD(GetSizeMax)(
+        OUT ULARGE_INTEGER *pcbSize
+    ) override;
+
+    STDMETHOD(IsDirty)() override;
+
+    STDMETHOD(Load)(
+        IN IStream *pStm
+    ) override;
+
+    STDMETHOD(Save)(
+        IN IStream *pStm,
+        IN BOOL    fClearDirty
+    ) override;
+
+// IWinEventHandler
+
+    STDMETHOD(OnWinEvent)(
         HWND hWnd,
         UINT uMsg,
         WPARAM wParam,
         LPARAM lParam,
         LRESULT *theResult
-    );
+    ) override;
 
-    virtual STDMETHODIMP IsWindowOwner(
+    STDMETHOD(IsWindowOwner)(
         HWND hWnd
-    );
+    ) override;
 
 // IOleCommandTarget
 
-    virtual STDMETHODIMP Exec(
+    STDMETHOD(Exec)(
         IN const GUID *pguidCmdGroup,
         IN DWORD nCmdID,
         IN DWORD nCmdexecopt,
         IN VARIANT *pvaIn,
         IN OUT VARIANT *pvaOut
-    );
+    ) override;
 
-    virtual STDMETHODIMP QueryStatus(
+    STDMETHOD(QueryStatus)(
         IN const GUID *pguidCmdGroup,
         IN ULONG cCmds,
         IN OUT OLECMD prgCmds[],
         IN OUT OLECMDTEXT *pCmdText
-    );
+    ) override;
 
 // IShellFolderBand
-    virtual STDMETHODIMP GetBandInfoSFB(
+    STDMETHOD(GetBandInfoSFB)(
         PBANDINFOSFB pbi
-    );
+    ) override;
 
-    virtual STDMETHODIMP InitializeSFB(
+    STDMETHOD(InitializeSFB)(
         IShellFolder      *psf,
         PCIDLIST_ABSOLUTE pidl
-    );
+    ) override;
 
-    virtual STDMETHODIMP SetBandInfoSFB(
+    STDMETHOD(SetBandInfoSFB)(
         PBANDINFOSFB pbi
-    );
+    ) override;
 
 // IContextMenu
-    virtual STDMETHODIMP GetCommandString(
+    STDMETHOD(GetCommandString)(
         UINT_PTR idCmd,
         UINT uFlags,
         UINT *pwReserved,
         LPSTR pszName,
         UINT cchMax
-    );
+    ) override;
 
-    virtual STDMETHODIMP InvokeCommand(
+    STDMETHOD(InvokeCommand)(
         LPCMINVOKECOMMANDINFO pici
-    );
+    ) override;
 
-    virtual STDMETHODIMP QueryContextMenu(
+    STDMETHOD(QueryContextMenu)(
         HMENU hmenu,
         UINT indexMenu,
         UINT idCmdFirst,
         UINT idCmdLast,
         UINT uFlags
-    );
+    ) override;
 
 //*****************************************************************************************************
 

--- a/dll/win32/browseui/shellbars/CSHEnumClassesOfCategories.cpp
+++ b/dll/win32/browseui/shellbars/CSHEnumClassesOfCategories.cpp
@@ -222,12 +222,13 @@ class CSHEnumClassesOfCategories :
     public:
         CSHEnumClassesOfCategories();
         virtual ~CSHEnumClassesOfCategories();
-        virtual HRESULT STDMETHODCALLTYPE Initialize(ULONG cImplemented, CATID *pImplemented, ULONG cRequired, CATID *pRequired);
+        STDMETHOD(Initialize)(ULONG cImplemented, CATID *pImplemented, ULONG cRequired, CATID *pRequired);
+
         // *** IEnumGUID methods ***
-        virtual HRESULT STDMETHODCALLTYPE Clone(IEnumCLSID **ppvOut);
-        virtual HRESULT STDMETHODCALLTYPE Next(ULONG cElt, CLSID *pElts, ULONG *pFetched);
-        virtual HRESULT STDMETHODCALLTYPE Reset();
-        virtual HRESULT STDMETHODCALLTYPE Skip(ULONG nbElts);
+        STDMETHOD(Clone)(IEnumCLSID **ppvOut) override;
+        STDMETHOD(Next)(ULONG cElt, CLSID *pElts, ULONG *pFetched) override;
+        STDMETHOD(Reset)() override;
+        STDMETHOD(Skip)(ULONG nbElts) override;
 
         BEGIN_COM_MAP(CSHEnumClassesOfCategories)
             COM_INTERFACE_ENTRY_IID(IID_IEnumGUID, IEnumGUID)

--- a/dll/win32/browseui/shellbrowser.cpp
+++ b/dll/win32/browseui/shellbrowser.cpp
@@ -353,246 +353,246 @@ public:
     void UpdateWindowTitle();
 
 /*    // *** IDockingWindowFrame methods ***
-    virtual HRESULT STDMETHODCALLTYPE AddToolbar(IUnknown *punkSrc, LPCWSTR pwszItem, DWORD dwAddFlags);
-    virtual HRESULT STDMETHODCALLTYPE RemoveToolbar(IUnknown *punkSrc, DWORD dwRemoveFlags);
-    virtual HRESULT STDMETHODCALLTYPE FindToolbar(LPCWSTR pwszItem, REFIID riid, void **ppv);
+    STDMETHOD(AddToolbar)(IUnknown *punkSrc, LPCWSTR pwszItem, DWORD dwAddFlags) override;
+    STDMETHOD(RemoveToolbar)(IUnknown *punkSrc, DWORD dwRemoveFlags) override;
+    STDMETHOD(FindToolbar)(LPCWSTR pwszItem, REFIID riid, void **ppv) override;
     */
 
     // *** IDockingWindowSite methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetBorderDW(IUnknown* punkObj, LPRECT prcBorder);
-    virtual HRESULT STDMETHODCALLTYPE RequestBorderSpaceDW(IUnknown* punkObj, LPCBORDERWIDTHS pbw);
-    virtual HRESULT STDMETHODCALLTYPE SetBorderSpaceDW(IUnknown* punkObj, LPCBORDERWIDTHS pbw);
+    STDMETHOD(GetBorderDW)(IUnknown* punkObj, LPRECT prcBorder) override;
+    STDMETHOD(RequestBorderSpaceDW)(IUnknown* punkObj, LPCBORDERWIDTHS pbw) override;
+    STDMETHOD(SetBorderSpaceDW)(IUnknown* punkObj, LPCBORDERWIDTHS pbw) override;
 
     // *** IOleCommandTarget methods ***
-    virtual HRESULT STDMETHODCALLTYPE QueryStatus(const GUID *pguidCmdGroup, ULONG cCmds,
-        OLECMD prgCmds[  ], OLECMDTEXT *pCmdText);
-    virtual HRESULT STDMETHODCALLTYPE Exec(const GUID *pguidCmdGroup, DWORD nCmdID,
-        DWORD nCmdexecopt, VARIANT *pvaIn, VARIANT *pvaOut);
+    STDMETHOD(QueryStatus)(const GUID *pguidCmdGroup, ULONG cCmds,
+        OLECMD prgCmds[  ], OLECMDTEXT *pCmdText) override;
+    STDMETHOD(Exec)(const GUID *pguidCmdGroup, DWORD nCmdID,
+        DWORD nCmdexecopt, VARIANT *pvaIn, VARIANT *pvaOut) override;
 
     // *** IOleWindow methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetWindow(HWND *lphwnd);
-    virtual HRESULT STDMETHODCALLTYPE ContextSensitiveHelp(BOOL fEnterMode);
+    STDMETHOD(GetWindow)(HWND *lphwnd) override;
+    STDMETHOD(ContextSensitiveHelp)(BOOL fEnterMode) override;
 
     // *** IShellBrowser methods ***
-    virtual HRESULT STDMETHODCALLTYPE InsertMenusSB(HMENU hmenuShared, LPOLEMENUGROUPWIDTHS lpMenuWidths);
-    virtual HRESULT STDMETHODCALLTYPE SetMenuSB(HMENU hmenuShared, HOLEMENU holemenuRes, HWND hwndActiveObject);
-    virtual HRESULT STDMETHODCALLTYPE RemoveMenusSB(HMENU hmenuShared);
-    virtual HRESULT STDMETHODCALLTYPE SetStatusTextSB(LPCOLESTR pszStatusText);
-    virtual HRESULT STDMETHODCALLTYPE EnableModelessSB(BOOL fEnable);
-    virtual HRESULT STDMETHODCALLTYPE TranslateAcceleratorSB(MSG *pmsg, WORD wID);
-    virtual HRESULT STDMETHODCALLTYPE BrowseObject(LPCITEMIDLIST pidl, UINT wFlags);
-    virtual HRESULT STDMETHODCALLTYPE GetViewStateStream(DWORD grfMode, IStream **ppStrm);
-    virtual HRESULT STDMETHODCALLTYPE GetControlWindow(UINT id, HWND *lphwnd);
-    virtual HRESULT STDMETHODCALLTYPE SendControlMsg(UINT id, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT *pret);
-    virtual HRESULT STDMETHODCALLTYPE QueryActiveShellView(IShellView **ppshv);
-    virtual HRESULT STDMETHODCALLTYPE OnViewWindowActive(IShellView *ppshv);
-    virtual HRESULT STDMETHODCALLTYPE SetToolbarItems(LPTBBUTTON lpButtons, UINT nButtons, UINT uFlags);
+    STDMETHOD(InsertMenusSB)(HMENU hmenuShared, LPOLEMENUGROUPWIDTHS lpMenuWidths) override;
+    STDMETHOD(SetMenuSB)(HMENU hmenuShared, HOLEMENU holemenuRes, HWND hwndActiveObject) override;
+    STDMETHOD(RemoveMenusSB)(HMENU hmenuShared) override;
+    STDMETHOD(SetStatusTextSB)(LPCOLESTR pszStatusText) override;
+    STDMETHOD(EnableModelessSB)(BOOL fEnable) override;
+    STDMETHOD(TranslateAcceleratorSB)(MSG *pmsg, WORD wID) override;
+    STDMETHOD(BrowseObject)(LPCITEMIDLIST pidl, UINT wFlags) override;
+    STDMETHOD(GetViewStateStream)(DWORD grfMode, IStream **ppStrm) override;
+    STDMETHOD(GetControlWindow)(UINT id, HWND *lphwnd) override;
+    STDMETHOD(SendControlMsg)(UINT id, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT *pret) override;
+    STDMETHOD(QueryActiveShellView)(IShellView **ppshv) override;
+    STDMETHOD(OnViewWindowActive)(IShellView *ppshv) override;
+    STDMETHOD(SetToolbarItems)(LPTBBUTTON lpButtons, UINT nButtons, UINT uFlags) override;
 
     // *** IDropTarget methods ***
-    virtual HRESULT STDMETHODCALLTYPE DragEnter(IDataObject *pDataObj, DWORD grfKeyState, POINTL pt, DWORD *pdwEffect);
-    virtual HRESULT STDMETHODCALLTYPE DragOver(DWORD grfKeyState, POINTL pt, DWORD *pdwEffect);
-    virtual HRESULT STDMETHODCALLTYPE DragLeave();
-    virtual HRESULT STDMETHODCALLTYPE Drop(IDataObject *pDataObj, DWORD grfKeyState, POINTL pt, DWORD *pdwEffect);
+    STDMETHOD(DragEnter)(IDataObject *pDataObj, DWORD grfKeyState, POINTL pt, DWORD *pdwEffect) override;
+    STDMETHOD(DragOver)(DWORD grfKeyState, POINTL pt, DWORD *pdwEffect) override;
+    STDMETHOD(DragLeave)() override;
+    STDMETHOD(Drop)(IDataObject *pDataObj, DWORD grfKeyState, POINTL pt, DWORD *pdwEffect) override;
 
     // *** IServiceProvider methods ***
-    virtual HRESULT STDMETHODCALLTYPE QueryService(REFGUID guidService, REFIID riid, void **ppvObject);
+    STDMETHOD(QueryService)(REFGUID guidService, REFIID riid, void **ppvObject) override;
 
     // *** IShellBowserService methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetPropertyBag(long flags, REFIID riid, void **ppvObject);
+    STDMETHOD(GetPropertyBag)(long flags, REFIID riid, void **ppvObject) override;
 
     // *** IDispatch methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetTypeInfoCount(UINT *pctinfo);
-    virtual HRESULT STDMETHODCALLTYPE GetTypeInfo(UINT iTInfo, LCID lcid, ITypeInfo **ppTInfo);
-    virtual HRESULT STDMETHODCALLTYPE GetIDsOfNames(
-        REFIID riid, LPOLESTR *rgszNames, UINT cNames, LCID lcid, DISPID *rgDispId);
-    virtual HRESULT STDMETHODCALLTYPE Invoke(DISPID dispIdMember, REFIID riid, LCID lcid, WORD wFlags,
-        DISPPARAMS *pDispParams, VARIANT *pVarResult, EXCEPINFO *pExcepInfo, UINT *puArgErr);
+    STDMETHOD(GetTypeInfoCount)(UINT *pctinfo) override;
+    STDMETHOD(GetTypeInfo)(UINT iTInfo, LCID lcid, ITypeInfo **ppTInfo) override;
+    STDMETHOD(GetIDsOfNames)(
+        REFIID riid, LPOLESTR *rgszNames, UINT cNames, LCID lcid, DISPID *rgDispId) override;
+    STDMETHOD(Invoke)(DISPID dispIdMember, REFIID riid, LCID lcid, WORD wFlags,
+        DISPPARAMS *pDispParams, VARIANT *pVarResult, EXCEPINFO *pExcepInfo, UINT *puArgErr) override;
 
     // *** IBrowserService methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetParentSite(IOleInPlaceSite **ppipsite);
-    virtual HRESULT STDMETHODCALLTYPE SetTitle(IShellView *psv, LPCWSTR pszName);
-    virtual HRESULT STDMETHODCALLTYPE GetTitle(IShellView *psv, LPWSTR pszName, DWORD cchName);
-    virtual HRESULT STDMETHODCALLTYPE GetOleObject(IOleObject **ppobjv);
-    virtual HRESULT STDMETHODCALLTYPE GetTravelLog(ITravelLog **pptl);
-    virtual HRESULT STDMETHODCALLTYPE ShowControlWindow(UINT id, BOOL fShow);
-    virtual HRESULT STDMETHODCALLTYPE IsControlWindowShown(UINT id, BOOL *pfShown);
-    virtual HRESULT STDMETHODCALLTYPE IEGetDisplayName(LPCITEMIDLIST pidl, LPWSTR pwszName, UINT uFlags);
-    virtual HRESULT STDMETHODCALLTYPE IEParseDisplayName(UINT uiCP, LPCWSTR pwszPath, LPITEMIDLIST *ppidlOut);
-    virtual HRESULT STDMETHODCALLTYPE DisplayParseError(HRESULT hres, LPCWSTR pwszPath);
-    virtual HRESULT STDMETHODCALLTYPE NavigateToPidl(LPCITEMIDLIST pidl, DWORD grfHLNF);
-    virtual HRESULT STDMETHODCALLTYPE SetNavigateState(BNSTATE bnstate);
-    virtual HRESULT STDMETHODCALLTYPE GetNavigateState(BNSTATE *pbnstate);
-    virtual HRESULT STDMETHODCALLTYPE NotifyRedirect(IShellView *psv, LPCITEMIDLIST pidl, BOOL *pfDidBrowse);
-    virtual HRESULT STDMETHODCALLTYPE UpdateWindowList();
-    virtual HRESULT STDMETHODCALLTYPE UpdateBackForwardState();
-    virtual HRESULT STDMETHODCALLTYPE SetFlags(DWORD dwFlags, DWORD dwFlagMask);
-    virtual HRESULT STDMETHODCALLTYPE GetFlags(DWORD *pdwFlags);
-    virtual HRESULT STDMETHODCALLTYPE CanNavigateNow( void);
-    virtual HRESULT STDMETHODCALLTYPE GetPidl(LPITEMIDLIST *ppidl);
-    virtual HRESULT STDMETHODCALLTYPE SetReferrer(LPCITEMIDLIST pidl);
-    virtual DWORD STDMETHODCALLTYPE GetBrowserIndex();
-    virtual HRESULT STDMETHODCALLTYPE GetBrowserByIndex(DWORD dwID, IUnknown **ppunk);
-    virtual HRESULT STDMETHODCALLTYPE GetHistoryObject(IOleObject **ppole, IStream **pstm, IBindCtx **ppbc);
-    virtual HRESULT STDMETHODCALLTYPE SetHistoryObject(IOleObject *pole, BOOL fIsLocalAnchor);
-    virtual HRESULT STDMETHODCALLTYPE CacheOLEServer(IOleObject *pole);
-    virtual HRESULT STDMETHODCALLTYPE GetSetCodePage(VARIANT *pvarIn, VARIANT *pvarOut);
-    virtual HRESULT STDMETHODCALLTYPE OnHttpEquiv(IShellView *psv, BOOL fDone, VARIANT *pvarargIn, VARIANT *pvarargOut);
-    virtual HRESULT STDMETHODCALLTYPE GetPalette(HPALETTE *hpal);
-    virtual HRESULT STDMETHODCALLTYPE RegisterWindow(BOOL fForceRegister, int swc);
+    STDMETHOD(GetParentSite)(IOleInPlaceSite **ppipsite) override;
+    STDMETHOD(SetTitle)(IShellView *psv, LPCWSTR pszName) override;
+    STDMETHOD(GetTitle)(IShellView *psv, LPWSTR pszName, DWORD cchName) override;
+    STDMETHOD(GetOleObject)(IOleObject **ppobjv) override;
+    STDMETHOD(GetTravelLog)(ITravelLog **pptl) override;
+    STDMETHOD(ShowControlWindow)(UINT id, BOOL fShow) override;
+    STDMETHOD(IsControlWindowShown)(UINT id, BOOL *pfShown) override;
+    STDMETHOD(IEGetDisplayName)(LPCITEMIDLIST pidl, LPWSTR pwszName, UINT uFlags) override;
+    STDMETHOD(IEParseDisplayName)(UINT uiCP, LPCWSTR pwszPath, LPITEMIDLIST *ppidlOut) override;
+    STDMETHOD(DisplayParseError)(HRESULT hres, LPCWSTR pwszPath) override;
+    STDMETHOD(NavigateToPidl)(LPCITEMIDLIST pidl, DWORD grfHLNF) override;
+    STDMETHOD(SetNavigateState)(BNSTATE bnstate) override;
+    STDMETHOD(GetNavigateState)(BNSTATE *pbnstate) override;
+    STDMETHOD(NotifyRedirect)(IShellView *psv, LPCITEMIDLIST pidl, BOOL *pfDidBrowse) override;
+    STDMETHOD(UpdateWindowList)() override;
+    STDMETHOD(UpdateBackForwardState)() override;
+    STDMETHOD(SetFlags)(DWORD dwFlags, DWORD dwFlagMask) override;
+    STDMETHOD(GetFlags)(DWORD *pdwFlags) override;
+    STDMETHOD(CanNavigateNow)( void) override;
+    STDMETHOD(GetPidl)(LPITEMIDLIST *ppidl) override;
+    STDMETHOD(SetReferrer)(LPCITEMIDLIST pidl) override;
+    STDMETHOD_(DWORD, GetBrowserIndex)() override;
+    STDMETHOD(GetBrowserByIndex)(DWORD dwID, IUnknown **ppunk) override;
+    STDMETHOD(GetHistoryObject)(IOleObject **ppole, IStream **pstm, IBindCtx **ppbc) override;
+    STDMETHOD(SetHistoryObject)(IOleObject *pole, BOOL fIsLocalAnchor) override;
+    STDMETHOD(CacheOLEServer)(IOleObject *pole) override;
+    STDMETHOD(GetSetCodePage)(VARIANT *pvarIn, VARIANT *pvarOut) override;
+    STDMETHOD(OnHttpEquiv)(IShellView *psv, BOOL fDone, VARIANT *pvarargIn, VARIANT *pvarargOut) override;
+    STDMETHOD(GetPalette)(HPALETTE *hpal) override;
+    STDMETHOD(RegisterWindow)(BOOL fForceRegister, int swc) override;
 
     // *** IBrowserService2 methods ***
-    virtual LRESULT STDMETHODCALLTYPE WndProcBS(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
-    virtual HRESULT STDMETHODCALLTYPE SetAsDefFolderSettings();
-    virtual HRESULT STDMETHODCALLTYPE GetViewRect(RECT *prc);
-    virtual HRESULT STDMETHODCALLTYPE OnSize(WPARAM wParam);
-    virtual HRESULT STDMETHODCALLTYPE OnCreate(struct tagCREATESTRUCTW *pcs);
-    virtual LRESULT STDMETHODCALLTYPE OnCommand(WPARAM wParam, LPARAM lParam);
-    virtual HRESULT STDMETHODCALLTYPE OnDestroy();
-    virtual LRESULT STDMETHODCALLTYPE OnNotify(struct tagNMHDR *pnm);
-    virtual HRESULT STDMETHODCALLTYPE OnSetFocus();
-    virtual HRESULT STDMETHODCALLTYPE OnFrameWindowActivateBS(BOOL fActive);
-    virtual HRESULT STDMETHODCALLTYPE ReleaseShellView();
-    virtual HRESULT STDMETHODCALLTYPE ActivatePendingView();
-    virtual HRESULT STDMETHODCALLTYPE CreateViewWindow(IShellView *psvNew, IShellView *psvOld, LPRECT prcView, HWND *phwnd);
-    virtual HRESULT STDMETHODCALLTYPE CreateBrowserPropSheetExt(REFIID riid, void **ppv);
-    virtual HRESULT STDMETHODCALLTYPE GetViewWindow(HWND *phwndView);
-    virtual HRESULT STDMETHODCALLTYPE GetBaseBrowserData(LPCBASEBROWSERDATA *pbbd);
-    virtual LPBASEBROWSERDATA STDMETHODCALLTYPE PutBaseBrowserData( void);
-    virtual HRESULT STDMETHODCALLTYPE InitializeTravelLog(ITravelLog *ptl, DWORD dw);
-    virtual HRESULT STDMETHODCALLTYPE SetTopBrowser();
-    virtual HRESULT STDMETHODCALLTYPE Offline(int iCmd);
-    virtual HRESULT STDMETHODCALLTYPE AllowViewResize(BOOL f);
-    virtual HRESULT STDMETHODCALLTYPE SetActivateState(UINT u);
-    virtual HRESULT STDMETHODCALLTYPE UpdateSecureLockIcon(int eSecureLock);
-    virtual HRESULT STDMETHODCALLTYPE InitializeDownloadManager();
-    virtual HRESULT STDMETHODCALLTYPE InitializeTransitionSite();
-    virtual HRESULT STDMETHODCALLTYPE _Initialize(HWND hwnd, IUnknown *pauto);
-    virtual HRESULT STDMETHODCALLTYPE _CancelPendingNavigationAsync( void);
-    virtual HRESULT STDMETHODCALLTYPE _CancelPendingView();
-    virtual HRESULT STDMETHODCALLTYPE _MaySaveChanges();
-    virtual HRESULT STDMETHODCALLTYPE _PauseOrResumeView(BOOL fPaused);
-    virtual HRESULT STDMETHODCALLTYPE _DisableModeless();
-    virtual HRESULT STDMETHODCALLTYPE _NavigateToPidl(LPCITEMIDLIST pidl, DWORD grfHLNF, DWORD dwFlags);
-    virtual HRESULT STDMETHODCALLTYPE _TryShell2Rename(IShellView *psv, LPCITEMIDLIST pidlNew);
-    virtual HRESULT STDMETHODCALLTYPE _SwitchActivationNow();
-    virtual HRESULT STDMETHODCALLTYPE _ExecChildren(IUnknown *punkBar, BOOL fBroadcast, const GUID *pguidCmdGroup,
-        DWORD nCmdID, DWORD nCmdexecopt, VARIANTARG *pvarargIn, VARIANTARG *pvarargOut);
-    virtual HRESULT STDMETHODCALLTYPE _SendChildren(
-        HWND hwndBar, BOOL fBroadcast, UINT uMsg, WPARAM wParam, LPARAM lParam);
-    virtual HRESULT STDMETHODCALLTYPE GetFolderSetData(struct tagFolderSetData *pfsd);
-    virtual HRESULT STDMETHODCALLTYPE _OnFocusChange(UINT itb);
-    virtual HRESULT STDMETHODCALLTYPE v_ShowHideChildWindows(BOOL fChildOnly);
-    virtual UINT STDMETHODCALLTYPE _get_itbLastFocus();
-    virtual HRESULT STDMETHODCALLTYPE _put_itbLastFocus(UINT itbLastFocus);
-    virtual HRESULT STDMETHODCALLTYPE _UIActivateView(UINT uState);
-    virtual HRESULT STDMETHODCALLTYPE _GetViewBorderRect(RECT *prc);
-    virtual HRESULT STDMETHODCALLTYPE _UpdateViewRectSize();
-    virtual HRESULT STDMETHODCALLTYPE _ResizeNextBorder(UINT itb);
-    virtual HRESULT STDMETHODCALLTYPE _ResizeView();
-    virtual HRESULT STDMETHODCALLTYPE _GetEffectiveClientArea(LPRECT lprectBorder, HMONITOR hmon);
-    virtual IStream *STDMETHODCALLTYPE v_GetViewStream(LPCITEMIDLIST pidl, DWORD grfMode, LPCWSTR pwszName);
-    virtual LRESULT STDMETHODCALLTYPE ForwardViewMsg(UINT uMsg, WPARAM wParam, LPARAM lParam);
-    virtual HRESULT STDMETHODCALLTYPE SetAcceleratorMenu(HACCEL hacc);
-    virtual int STDMETHODCALLTYPE _GetToolbarCount();
-    virtual LPTOOLBARITEM STDMETHODCALLTYPE _GetToolbarItem(int itb);
-    virtual HRESULT STDMETHODCALLTYPE _SaveToolbars(IStream *pstm);
-    virtual HRESULT STDMETHODCALLTYPE _LoadToolbars(IStream *pstm);
-    virtual HRESULT STDMETHODCALLTYPE _CloseAndReleaseToolbars(BOOL fClose);
-    virtual HRESULT STDMETHODCALLTYPE v_MayGetNextToolbarFocus(LPMSG lpMsg, UINT itbNext,
-        int citb, LPTOOLBARITEM *pptbi, HWND *phwnd);
-    virtual HRESULT STDMETHODCALLTYPE _ResizeNextBorderHelper(UINT itb, BOOL bUseHmonitor);
-    virtual UINT STDMETHODCALLTYPE _FindTBar(IUnknown *punkSrc);
-    virtual HRESULT STDMETHODCALLTYPE _SetFocus(LPTOOLBARITEM ptbi, HWND hwnd, LPMSG lpMsg);
-    virtual HRESULT STDMETHODCALLTYPE v_MayTranslateAccelerator(MSG *pmsg);
-    virtual HRESULT STDMETHODCALLTYPE _GetBorderDWHelper(IUnknown *punkSrc, LPRECT lprectBorder, BOOL bUseHmonitor);
-    virtual HRESULT STDMETHODCALLTYPE v_CheckZoneCrossing(LPCITEMIDLIST pidl);
+    STDMETHOD_(LRESULT, WndProcBS)(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam) override;
+    STDMETHOD(SetAsDefFolderSettings)() override;
+    STDMETHOD(GetViewRect)(RECT *prc) override;
+    STDMETHOD(OnSize)(WPARAM wParam) override;
+    STDMETHOD(OnCreate)(struct tagCREATESTRUCTW *pcs) override;
+    STDMETHOD_(LRESULT, OnCommand)(WPARAM wParam, LPARAM lParam) override;
+    STDMETHOD(OnDestroy)() override;
+    STDMETHOD_(LRESULT, OnNotify)(struct tagNMHDR *pnm) override;
+    STDMETHOD(OnSetFocus)() override;
+    STDMETHOD(OnFrameWindowActivateBS)(BOOL fActive) override;
+    STDMETHOD(ReleaseShellView)() override;
+    STDMETHOD(ActivatePendingView)() override;
+    STDMETHOD(CreateViewWindow)(IShellView *psvNew, IShellView *psvOld, LPRECT prcView, HWND *phwnd) override;
+    STDMETHOD(CreateBrowserPropSheetExt)(REFIID riid, void **ppv) override;
+    STDMETHOD(GetViewWindow)(HWND *phwndView) override;
+    STDMETHOD(GetBaseBrowserData)(LPCBASEBROWSERDATA *pbbd) override;
+    STDMETHOD_(LPBASEBROWSERDATA, PutBaseBrowserData)(void) override;
+    STDMETHOD(InitializeTravelLog)(ITravelLog *ptl, DWORD dw) override;
+    STDMETHOD(SetTopBrowser)() override;
+    STDMETHOD(Offline)(int iCmd) override;
+    STDMETHOD(AllowViewResize)(BOOL f) override;
+    STDMETHOD(SetActivateState)(UINT u) override;
+    STDMETHOD(UpdateSecureLockIcon)(int eSecureLock) override;
+    STDMETHOD(InitializeDownloadManager)() override;
+    STDMETHOD(InitializeTransitionSite)() override;
+    STDMETHOD(_Initialize)(HWND hwnd, IUnknown *pauto) override;
+    STDMETHOD(_CancelPendingNavigationAsync)( void) override;
+    STDMETHOD(_CancelPendingView)() override;
+    STDMETHOD(_MaySaveChanges)() override;
+    STDMETHOD(_PauseOrResumeView)(BOOL fPaused) override;
+    STDMETHOD(_DisableModeless)() override;
+    STDMETHOD(_NavigateToPidl)(LPCITEMIDLIST pidl, DWORD grfHLNF, DWORD dwFlags) override;
+    STDMETHOD(_TryShell2Rename)(IShellView *psv, LPCITEMIDLIST pidlNew) override;
+    STDMETHOD(_SwitchActivationNow)() override;
+    STDMETHOD(_ExecChildren)(IUnknown *punkBar, BOOL fBroadcast, const GUID *pguidCmdGroup,
+        DWORD nCmdID, DWORD nCmdexecopt, VARIANTARG *pvarargIn, VARIANTARG *pvarargOut) override;
+    STDMETHOD(_SendChildren)(
+        HWND hwndBar, BOOL fBroadcast, UINT uMsg, WPARAM wParam, LPARAM lParam) override;
+    STDMETHOD(GetFolderSetData)(struct tagFolderSetData *pfsd) override;
+    STDMETHOD(_OnFocusChange)(UINT itb) override;
+    STDMETHOD(v_ShowHideChildWindows)(BOOL fChildOnly) override;
+    STDMETHOD_(UINT, _get_itbLastFocus)() override;
+    STDMETHOD(_put_itbLastFocus)(UINT itbLastFocus) override;
+    STDMETHOD(_UIActivateView)(UINT uState) override;
+    STDMETHOD(_GetViewBorderRect)(RECT *prc) override;
+    STDMETHOD(_UpdateViewRectSize)() override;
+    STDMETHOD(_ResizeNextBorder)(UINT itb) override;
+    STDMETHOD(_ResizeView)() override;
+    STDMETHOD(_GetEffectiveClientArea)(LPRECT lprectBorder, HMONITOR hmon) override;
+    STDMETHOD_(IStream *, v_GetViewStream)(LPCITEMIDLIST pidl, DWORD grfMode, LPCWSTR pwszName) override;
+    STDMETHOD_(LRESULT, ForwardViewMsg)(UINT uMsg, WPARAM wParam, LPARAM lParam) override;
+    STDMETHOD(SetAcceleratorMenu)(HACCEL hacc) override;
+    STDMETHOD_(int, _GetToolbarCount)() override;
+    STDMETHOD_(LPTOOLBARITEM, _GetToolbarItem)(int itb) override;
+    STDMETHOD(_SaveToolbars)(IStream *pstm) override;
+    STDMETHOD(_LoadToolbars)(IStream *pstm) override;
+    STDMETHOD(_CloseAndReleaseToolbars)(BOOL fClose) override;
+    STDMETHOD(v_MayGetNextToolbarFocus)(LPMSG lpMsg, UINT itbNext,
+        int citb, LPTOOLBARITEM *pptbi, HWND *phwnd) override;
+    STDMETHOD(_ResizeNextBorderHelper)(UINT itb, BOOL bUseHmonitor) override;
+    STDMETHOD_(UINT, _FindTBar)(IUnknown *punkSrc) override;
+    STDMETHOD(_SetFocus)(LPTOOLBARITEM ptbi, HWND hwnd, LPMSG lpMsg) override;
+    STDMETHOD(v_MayTranslateAccelerator)(MSG *pmsg) override;
+    STDMETHOD(_GetBorderDWHelper)(IUnknown *punkSrc, LPRECT lprectBorder, BOOL bUseHmonitor) override;
+    STDMETHOD(v_CheckZoneCrossing)(LPCITEMIDLIST pidl) override;
 
     // *** IWebBrowser methods ***
-    virtual HRESULT STDMETHODCALLTYPE GoBack();
-    virtual HRESULT STDMETHODCALLTYPE GoForward();
-    virtual HRESULT STDMETHODCALLTYPE GoHome();
-    virtual HRESULT STDMETHODCALLTYPE GoSearch();
-    virtual HRESULT STDMETHODCALLTYPE Navigate(BSTR URL, VARIANT *Flags, VARIANT *TargetFrameName,
-        VARIANT *PostData, VARIANT *Headers);
-    virtual HRESULT STDMETHODCALLTYPE Refresh();
-    virtual HRESULT STDMETHODCALLTYPE Refresh2(VARIANT *Level);
-    virtual HRESULT STDMETHODCALLTYPE Stop();
-    virtual HRESULT STDMETHODCALLTYPE get_Application(IDispatch **ppDisp);
-    virtual HRESULT STDMETHODCALLTYPE get_Parent(IDispatch **ppDisp);
-    virtual HRESULT STDMETHODCALLTYPE get_Container(IDispatch **ppDisp);
-    virtual HRESULT STDMETHODCALLTYPE get_Document(IDispatch **ppDisp);
-    virtual HRESULT STDMETHODCALLTYPE get_TopLevelContainer(VARIANT_BOOL *pBool);
-    virtual HRESULT STDMETHODCALLTYPE get_Type(BSTR *Type);
-    virtual HRESULT STDMETHODCALLTYPE get_Left(long *pl);
-    virtual HRESULT STDMETHODCALLTYPE put_Left(long Left);
-    virtual HRESULT STDMETHODCALLTYPE get_Top(long *pl);
-    virtual HRESULT STDMETHODCALLTYPE put_Top(long Top);
-    virtual HRESULT STDMETHODCALLTYPE get_Width(long *pl);
-    virtual HRESULT STDMETHODCALLTYPE put_Width(long Width);
-    virtual HRESULT STDMETHODCALLTYPE get_Height(long *pl);
-    virtual HRESULT STDMETHODCALLTYPE put_Height(long Height);
-    virtual HRESULT STDMETHODCALLTYPE get_LocationName(BSTR *LocationName);
-    virtual HRESULT STDMETHODCALLTYPE get_LocationURL(BSTR *LocationURL);
-    virtual HRESULT STDMETHODCALLTYPE get_Busy(VARIANT_BOOL *pBool);
+    STDMETHOD(GoBack)() override;
+    STDMETHOD(GoForward)() override;
+    STDMETHOD(GoHome)() override;
+    STDMETHOD(GoSearch)() override;
+    STDMETHOD(Navigate)(BSTR URL, VARIANT *Flags, VARIANT *TargetFrameName,
+        VARIANT *PostData, VARIANT *Headers) override;
+    STDMETHOD(Refresh)() override;
+    STDMETHOD(Refresh2)(VARIANT *Level) override;
+    STDMETHOD(Stop)() override;
+    STDMETHOD(get_Application)(IDispatch **ppDisp) override;
+    STDMETHOD(get_Parent)(IDispatch **ppDisp) override;
+    STDMETHOD(get_Container)(IDispatch **ppDisp) override;
+    STDMETHOD(get_Document)(IDispatch **ppDisp) override;
+    STDMETHOD(get_TopLevelContainer)(VARIANT_BOOL *pBool) override;
+    STDMETHOD(get_Type)(BSTR *Type) override;
+    STDMETHOD(get_Left)(long *pl) override;
+    STDMETHOD(put_Left)(long Left) override;
+    STDMETHOD(get_Top)(long *pl) override;
+    STDMETHOD(put_Top)(long Top) override;
+    STDMETHOD(get_Width)(long *pl) override;
+    STDMETHOD(put_Width)(long Width) override;
+    STDMETHOD(get_Height)(long *pl) override;
+    STDMETHOD(put_Height)(long Height) override;
+    STDMETHOD(get_LocationName)(BSTR *LocationName) override;
+    STDMETHOD(get_LocationURL)(BSTR *LocationURL) override;
+    STDMETHOD(get_Busy)(VARIANT_BOOL *pBool) override;
 
     // *** IWebBrowserApp methods ***
-    virtual HRESULT STDMETHODCALLTYPE Quit();
-    virtual HRESULT STDMETHODCALLTYPE ClientToWindow(int *pcx, int *pcy);
-    virtual HRESULT STDMETHODCALLTYPE PutProperty(BSTR Property, VARIANT vtValue);
-    virtual HRESULT STDMETHODCALLTYPE GetProperty(BSTR Property, VARIANT *pvtValue);
-    virtual HRESULT STDMETHODCALLTYPE get_Name(BSTR *Name);
-    virtual HRESULT STDMETHODCALLTYPE get_HWND(SHANDLE_PTR *pHWND);
-    virtual HRESULT STDMETHODCALLTYPE get_FullName(BSTR *FullName);
-    virtual HRESULT STDMETHODCALLTYPE get_Path(BSTR *Path);
-    virtual HRESULT STDMETHODCALLTYPE get_Visible(VARIANT_BOOL *pBool);
-    virtual HRESULT STDMETHODCALLTYPE put_Visible(VARIANT_BOOL Value);
-    virtual HRESULT STDMETHODCALLTYPE get_StatusBar(VARIANT_BOOL *pBool);
-    virtual HRESULT STDMETHODCALLTYPE put_StatusBar(VARIANT_BOOL Value);
-    virtual HRESULT STDMETHODCALLTYPE get_StatusText(BSTR *StatusText);
-    virtual HRESULT STDMETHODCALLTYPE put_StatusText(BSTR StatusText);
-    virtual HRESULT STDMETHODCALLTYPE get_ToolBar(int *Value);
-    virtual HRESULT STDMETHODCALLTYPE put_ToolBar(int Value);
-    virtual HRESULT STDMETHODCALLTYPE get_MenuBar(VARIANT_BOOL *Value);
-    virtual HRESULT STDMETHODCALLTYPE put_MenuBar(VARIANT_BOOL Value);
-    virtual HRESULT STDMETHODCALLTYPE get_FullScreen(VARIANT_BOOL *pbFullScreen);
-    virtual HRESULT STDMETHODCALLTYPE put_FullScreen(VARIANT_BOOL bFullScreen);
+    STDMETHOD(Quit)() override;
+    STDMETHOD(ClientToWindow)(int *pcx, int *pcy) override;
+    STDMETHOD(PutProperty)(BSTR Property, VARIANT vtValue) override;
+    STDMETHOD(GetProperty)(BSTR Property, VARIANT *pvtValue) override;
+    STDMETHOD(get_Name)(BSTR *Name) override;
+    STDMETHOD(get_HWND)(SHANDLE_PTR *pHWND) override;
+    STDMETHOD(get_FullName)(BSTR *FullName) override;
+    STDMETHOD(get_Path)(BSTR *Path) override;
+    STDMETHOD(get_Visible)(VARIANT_BOOL *pBool) override;
+    STDMETHOD(put_Visible)(VARIANT_BOOL Value) override;
+    STDMETHOD(get_StatusBar)(VARIANT_BOOL *pBool) override;
+    STDMETHOD(put_StatusBar)(VARIANT_BOOL Value) override;
+    STDMETHOD(get_StatusText)(BSTR *StatusText) override;
+    STDMETHOD(put_StatusText)(BSTR StatusText) override;
+    STDMETHOD(get_ToolBar)(int *Value) override;
+    STDMETHOD(put_ToolBar)(int Value) override;
+    STDMETHOD(get_MenuBar)(VARIANT_BOOL *Value) override;
+    STDMETHOD(put_MenuBar)(VARIANT_BOOL Value) override;
+    STDMETHOD(get_FullScreen)(VARIANT_BOOL *pbFullScreen) override;
+    STDMETHOD(put_FullScreen)(VARIANT_BOOL bFullScreen) override;
 
     // *** IWebBrowser2 methods ***
-    virtual HRESULT STDMETHODCALLTYPE Navigate2(VARIANT *URL, VARIANT *Flags, VARIANT *TargetFrameName,
-        VARIANT *PostData, VARIANT *Headers);
-    virtual HRESULT STDMETHODCALLTYPE QueryStatusWB(OLECMDID cmdID, OLECMDF *pcmdf);
-    virtual HRESULT STDMETHODCALLTYPE ExecWB(OLECMDID cmdID, OLECMDEXECOPT cmdexecopt,
-        VARIANT *pvaIn, VARIANT *pvaOut);
-    virtual HRESULT STDMETHODCALLTYPE ShowBrowserBar(VARIANT *pvaClsid, VARIANT *pvarShow, VARIANT *pvarSize);
-    virtual HRESULT STDMETHODCALLTYPE get_ReadyState(READYSTATE *plReadyState);
-    virtual HRESULT STDMETHODCALLTYPE get_Offline(VARIANT_BOOL *pbOffline);
-    virtual HRESULT STDMETHODCALLTYPE put_Offline(VARIANT_BOOL bOffline);
-    virtual HRESULT STDMETHODCALLTYPE get_Silent(VARIANT_BOOL *pbSilent);
-    virtual HRESULT STDMETHODCALLTYPE put_Silent(VARIANT_BOOL bSilent);
-    virtual HRESULT STDMETHODCALLTYPE get_RegisterAsBrowser(VARIANT_BOOL *pbRegister);
-    virtual HRESULT STDMETHODCALLTYPE put_RegisterAsBrowser(VARIANT_BOOL bRegister);
-    virtual HRESULT STDMETHODCALLTYPE get_RegisterAsDropTarget(VARIANT_BOOL *pbRegister);
-    virtual HRESULT STDMETHODCALLTYPE put_RegisterAsDropTarget(VARIANT_BOOL bRegister);
-    virtual HRESULT STDMETHODCALLTYPE get_TheaterMode(VARIANT_BOOL *pbRegister);
-    virtual HRESULT STDMETHODCALLTYPE put_TheaterMode(VARIANT_BOOL bRegister);
-    virtual HRESULT STDMETHODCALLTYPE get_AddressBar(VARIANT_BOOL *Value);
-    virtual HRESULT STDMETHODCALLTYPE put_AddressBar(VARIANT_BOOL Value);
-    virtual HRESULT STDMETHODCALLTYPE get_Resizable(VARIANT_BOOL *Value);
-    virtual HRESULT STDMETHODCALLTYPE put_Resizable(VARIANT_BOOL Value);
+    STDMETHOD(Navigate2)(VARIANT *URL, VARIANT *Flags, VARIANT *TargetFrameName,
+        VARIANT *PostData, VARIANT *Headers) override;
+    STDMETHOD(QueryStatusWB)(OLECMDID cmdID, OLECMDF *pcmdf) override;
+    STDMETHOD(ExecWB)(OLECMDID cmdID, OLECMDEXECOPT cmdexecopt,
+        VARIANT *pvaIn, VARIANT *pvaOut) override;
+    STDMETHOD(ShowBrowserBar)(VARIANT *pvaClsid, VARIANT *pvarShow, VARIANT *pvarSize) override;
+    STDMETHOD(get_ReadyState)(READYSTATE *plReadyState) override;
+    STDMETHOD(get_Offline)(VARIANT_BOOL *pbOffline) override;
+    STDMETHOD(put_Offline)(VARIANT_BOOL bOffline) override;
+    STDMETHOD(get_Silent)(VARIANT_BOOL *pbSilent) override;
+    STDMETHOD(put_Silent)(VARIANT_BOOL bSilent) override;
+    STDMETHOD(get_RegisterAsBrowser)(VARIANT_BOOL *pbRegister) override;
+    STDMETHOD(put_RegisterAsBrowser)(VARIANT_BOOL bRegister) override;
+    STDMETHOD(get_RegisterAsDropTarget)(VARIANT_BOOL *pbRegister) override;
+    STDMETHOD(put_RegisterAsDropTarget)(VARIANT_BOOL bRegister) override;
+    STDMETHOD(get_TheaterMode)(VARIANT_BOOL *pbRegister) override;
+    STDMETHOD(put_TheaterMode)(VARIANT_BOOL bRegister) override;
+    STDMETHOD(get_AddressBar)(VARIANT_BOOL *Value) override;
+    STDMETHOD(put_AddressBar)(VARIANT_BOOL Value) override;
+    STDMETHOD(get_Resizable)(VARIANT_BOOL *Value) override;
+    STDMETHOD(put_Resizable)(VARIANT_BOOL Value) override;
 
     // *** ITravelLogClient methods ***
-    virtual HRESULT STDMETHODCALLTYPE FindWindowByIndex(DWORD dwID, IUnknown **ppunk);
-    virtual HRESULT STDMETHODCALLTYPE GetWindowData(IStream *pStream, LPWINDOWDATA pWinData);
-    virtual HRESULT STDMETHODCALLTYPE LoadHistoryPosition(LPWSTR pszUrlLocation, DWORD dwPosition);
+    STDMETHOD(FindWindowByIndex)(DWORD dwID, IUnknown **ppunk) override;
+    STDMETHOD(GetWindowData)(IStream *pStream, LPWINDOWDATA pWinData) override;
+    STDMETHOD(LoadHistoryPosition)(LPWSTR pszUrlLocation, DWORD dwPosition) override;
 
     // *** IPersist methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetClassID(CLSID *pClassID);
+    STDMETHOD(GetClassID)(CLSID *pClassID) override;
 
     // *** IPersistHistory methods ***
-    virtual HRESULT STDMETHODCALLTYPE LoadHistory(IStream *pStream, IBindCtx *pbc);
-    virtual HRESULT STDMETHODCALLTYPE SaveHistory(IStream *pStream);
-    virtual HRESULT STDMETHODCALLTYPE SetPositionCookie(DWORD dwPositioncookie);
-    virtual HRESULT STDMETHODCALLTYPE GetPositionCookie(DWORD *pdwPositioncookie);
+    STDMETHOD(LoadHistory)(IStream *pStream, IBindCtx *pbc) override;
+    STDMETHOD(SaveHistory)(IStream *pStream) override;
+    STDMETHOD(SetPositionCookie)(DWORD dwPositioncookie) override;
+    STDMETHOD(GetPositionCookie)(DWORD *pdwPositioncookie) override;
 
     // message handlers
     LRESULT OnCreate(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);

--- a/dll/win32/browseui/shellfind/CSearchBar.h
+++ b/dll/win32/browseui/shellfind/CSearchBar.h
@@ -43,40 +43,40 @@ public:
     virtual ~CSearchBar();
 
     // *** IOleWindow methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetWindow(HWND *lphwnd);
-    virtual HRESULT STDMETHODCALLTYPE ContextSensitiveHelp(BOOL fEnterMode);
+    STDMETHOD(GetWindow)(HWND *lphwnd) override;
+    STDMETHOD(ContextSensitiveHelp)(BOOL fEnterMode) override;
 
     // *** IDockingWindow methods ***
-    virtual HRESULT STDMETHODCALLTYPE CloseDW(DWORD dwReserved);
-    virtual HRESULT STDMETHODCALLTYPE ResizeBorderDW(const RECT *prcBorder, IUnknown *punkToolbarSite, BOOL fReserved);
-    virtual HRESULT STDMETHODCALLTYPE ShowDW(BOOL fShow);
+    STDMETHOD(CloseDW)(DWORD dwReserved) override;
+    STDMETHOD(ResizeBorderDW)(const RECT *prcBorder, IUnknown *punkToolbarSite, BOOL fReserved) override;
+    STDMETHOD(ShowDW)(BOOL fShow) override;
 
     // *** IDeskBand methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetBandInfo(DWORD dwBandID, DWORD dwViewMode, DESKBANDINFO *pdbi);
+    STDMETHOD(GetBandInfo)(DWORD dwBandID, DWORD dwViewMode, DESKBANDINFO *pdbi) override;
 
     // *** IObjectWithSite methods ***
-    virtual HRESULT STDMETHODCALLTYPE SetSite(IUnknown *pUnkSite);
-    virtual HRESULT STDMETHODCALLTYPE GetSite(REFIID riid, void **ppvSite);
+    STDMETHOD(SetSite)(IUnknown *pUnkSite) override;
+    STDMETHOD(GetSite)(REFIID riid, void **ppvSite) override;
 
     // *** IInputObject methods ***
-    virtual HRESULT STDMETHODCALLTYPE UIActivateIO(BOOL fActivate, LPMSG lpMsg);
-    virtual HRESULT STDMETHODCALLTYPE HasFocusIO();
-    virtual HRESULT STDMETHODCALLTYPE TranslateAcceleratorIO(LPMSG lpMsg);
+    STDMETHOD(UIActivateIO)(BOOL fActivate, LPMSG lpMsg) override;
+    STDMETHOD(HasFocusIO)() override;
+    STDMETHOD(TranslateAcceleratorIO)(LPMSG lpMsg) override;
 
     // *** IPersist methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetClassID(CLSID *pClassID);
+    STDMETHOD(GetClassID)(CLSID *pClassID) override;
 
     // *** IPersistStream methods ***
-    virtual HRESULT STDMETHODCALLTYPE IsDirty();
-    virtual HRESULT STDMETHODCALLTYPE Load(IStream *pStm);
-    virtual HRESULT STDMETHODCALLTYPE Save(IStream *pStm, BOOL fClearDirty);
-    virtual HRESULT STDMETHODCALLTYPE GetSizeMax(ULARGE_INTEGER *pcbSize);
+    STDMETHOD(IsDirty)() override;
+    STDMETHOD(Load)(IStream *pStm) override;
+    STDMETHOD(Save)(IStream *pStm, BOOL fClearDirty) override;
+    STDMETHOD(GetSizeMax)(ULARGE_INTEGER *pcbSize) override;
 
     // *** IDispatch methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetTypeInfoCount(UINT *pctinfo);
-    virtual HRESULT STDMETHODCALLTYPE GetTypeInfo(UINT iTInfo, LCID lcid, ITypeInfo **ppTInfo);
-    virtual HRESULT STDMETHODCALLTYPE GetIDsOfNames(REFIID riid, LPOLESTR *rgszNames, UINT cNames, LCID lcid, DISPID *rgDispId);
-    virtual HRESULT STDMETHODCALLTYPE Invoke(DISPID dispIdMember, REFIID riid, LCID lcid, WORD wFlags, DISPPARAMS *pDispParams, VARIANT *pVarResult, EXCEPINFO *pExcepInfo, UINT *puArgErr);
+    STDMETHOD(GetTypeInfoCount)(UINT *pctinfo) override;
+    STDMETHOD(GetTypeInfo)(UINT iTInfo, LCID lcid, ITypeInfo **ppTInfo) override;
+    STDMETHOD(GetIDsOfNames)(REFIID riid, LPOLESTR *rgszNames, UINT cNames, LCID lcid, DISPID *rgDispId) override;
+    STDMETHOD(Invoke)(DISPID dispIdMember, REFIID riid, LCID lcid, WORD wFlags, DISPPARAMS *pDispParams, VARIANT *pVarResult, EXCEPINFO *pExcepInfo, UINT *puArgErr) override;
 
     enum { IDD = IDD_SEARCH_DLG };
 

--- a/dll/win32/browseui/toolsband.cpp
+++ b/dll/win32/browseui/toolsband.cpp
@@ -41,34 +41,34 @@ public:
     virtual ~CToolsBand();
 public:
     // *** IDeskBand methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetBandInfo(DWORD dwBandID, DWORD dwViewMode, DESKBANDINFO* pdbi);
+    STDMETHOD(GetBandInfo)(DWORD dwBandID, DWORD dwViewMode, DESKBANDINFO* pdbi) override;
 
     // *** IObjectWithSite methods ***
-    virtual HRESULT STDMETHODCALLTYPE SetSite(IUnknown* pUnkSite);
-    virtual HRESULT STDMETHODCALLTYPE GetSite(REFIID riid, void **ppvSite);
+    STDMETHOD(SetSite)(IUnknown* pUnkSite) override;
+    STDMETHOD(GetSite)(REFIID riid, void **ppvSite) override;
 
     // *** IOleWindow methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetWindow(HWND *lphwnd);
-    virtual HRESULT STDMETHODCALLTYPE ContextSensitiveHelp(BOOL fEnterMode);
+    STDMETHOD(GetWindow)(HWND *lphwnd) override;
+    STDMETHOD(ContextSensitiveHelp)(BOOL fEnterMode) override;
 
     // *** IDockingWindow methods ***
-    virtual HRESULT STDMETHODCALLTYPE CloseDW(DWORD dwReserved);
-    virtual HRESULT STDMETHODCALLTYPE ResizeBorderDW(const RECT* prcBorder, IUnknown* punkToolbarSite, BOOL fReserved);
-    virtual HRESULT STDMETHODCALLTYPE ShowDW(BOOL fShow);
+    STDMETHOD(CloseDW)(DWORD dwReserved) override;
+    STDMETHOD(ResizeBorderDW)(const RECT* prcBorder, IUnknown* punkToolbarSite, BOOL fReserved) override;
+    STDMETHOD(ShowDW)(BOOL fShow) override;
 
     // *** IInputObject methods ***
-    virtual HRESULT STDMETHODCALLTYPE HasFocusIO();
-    virtual HRESULT STDMETHODCALLTYPE TranslateAcceleratorIO(LPMSG lpMsg);
-    virtual HRESULT STDMETHODCALLTYPE UIActivateIO(BOOL fActivate, LPMSG lpMsg);
+    STDMETHOD(HasFocusIO)() override;
+    STDMETHOD(TranslateAcceleratorIO)(LPMSG lpMsg) override;
+    STDMETHOD(UIActivateIO)(BOOL fActivate, LPMSG lpMsg) override;
 
     // *** IPersist methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetClassID(CLSID *pClassID);
+    STDMETHOD(GetClassID)(CLSID *pClassID) override;
 
     // *** IPersistStream methods ***
-    virtual HRESULT STDMETHODCALLTYPE IsDirty();
-    virtual HRESULT STDMETHODCALLTYPE Load(IStream *pStm);
-    virtual HRESULT STDMETHODCALLTYPE Save(IStream *pStm, BOOL fClearDirty);
-    virtual HRESULT STDMETHODCALLTYPE GetSizeMax(ULARGE_INTEGER *pcbSize);
+    STDMETHOD(IsDirty)() override;
+    STDMETHOD(Load)(IStream *pStm) override;
+    STDMETHOD(Save)(IStream *pStm, BOOL fClearDirty) override;
+    STDMETHOD(GetSizeMax)(ULARGE_INTEGER *pcbSize) override;
 
     // message handlers
     LRESULT OnGetButtonInfo(UINT idControl, NMHDR *pNMHDR, BOOL &bHandled);

--- a/dll/win32/browseui/travellog.cpp
+++ b/dll/win32/browseui/travellog.cpp
@@ -60,9 +60,9 @@ public:
     long GetSize() const;
 
     // *** ITravelEntry methods ***
-    virtual HRESULT STDMETHODCALLTYPE Invoke(IUnknown *punk);
-    virtual HRESULT STDMETHODCALLTYPE Update(IUnknown *punk, BOOL fIsLocalAnchor);
-    virtual HRESULT STDMETHODCALLTYPE GetPidl(LPITEMIDLIST *ppidl);
+    STDMETHOD(Invoke)(IUnknown *punk) override;
+    STDMETHOD(Update)(IUnknown *punk, BOOL fIsLocalAnchor) override;
+    STDMETHOD(GetPidl)(LPITEMIDLIST *ppidl) override;
 
 BEGIN_COM_MAP(CTravelEntry)
     COM_INTERFACE_ENTRY_IID(IID_ITravelEntry, ITravelEntry)
@@ -90,17 +90,17 @@ public:
 public:
 
     // *** ITravelLog methods ***
-    virtual HRESULT STDMETHODCALLTYPE AddEntry(IUnknown *punk, BOOL fIsLocalAnchor);
-    virtual HRESULT STDMETHODCALLTYPE UpdateEntry(IUnknown *punk, BOOL fIsLocalAnchor);
-    virtual HRESULT STDMETHODCALLTYPE UpdateExternal(IUnknown *punk, IUnknown *punkHLBrowseContext);
-    virtual HRESULT STDMETHODCALLTYPE Travel(IUnknown *punk, int iOffset);
-    virtual HRESULT STDMETHODCALLTYPE GetTravelEntry(IUnknown *punk, int iOffset, ITravelEntry **ppte);
-    virtual HRESULT STDMETHODCALLTYPE FindTravelEntry(IUnknown *punk, LPCITEMIDLIST pidl, ITravelEntry **ppte);
-    virtual HRESULT STDMETHODCALLTYPE GetToolTipText(IUnknown *punk, int iOffset, int idsTemplate, LPWSTR pwzText, DWORD cchText);
-    virtual HRESULT STDMETHODCALLTYPE InsertMenuEntries(IUnknown *punk, HMENU hmenu, int nPos, int idFirst, int idLast, DWORD dwFlags);
-    virtual HRESULT STDMETHODCALLTYPE Clone(ITravelLog **pptl);
-    virtual DWORD STDMETHODCALLTYPE CountEntries(IUnknown *punk);
-    virtual HRESULT STDMETHODCALLTYPE Revert();
+    STDMETHOD(AddEntry)(IUnknown *punk, BOOL fIsLocalAnchor) override;
+    STDMETHOD(UpdateEntry)(IUnknown *punk, BOOL fIsLocalAnchor) override;
+    STDMETHOD(UpdateExternal)(IUnknown *punk, IUnknown *punkHLBrowseContext) override;
+    STDMETHOD(Travel)(IUnknown *punk, int iOffset) override;
+    STDMETHOD(GetTravelEntry)(IUnknown *punk, int iOffset, ITravelEntry **ppte) override;
+    STDMETHOD(FindTravelEntry)(IUnknown *punk, LPCITEMIDLIST pidl, ITravelEntry **ppte) override;
+    STDMETHOD(GetToolTipText)(IUnknown *punk, int iOffset, int idsTemplate, LPWSTR pwzText, DWORD cchText) override;
+    STDMETHOD(InsertMenuEntries)(IUnknown *punk, HMENU hmenu, int nPos, int idFirst, int idLast, DWORD dwFlags) override;
+    STDMETHOD(Clone)(ITravelLog **pptl) override;
+    STDMETHOD_(DWORD, CountEntries)(IUnknown *punk) override;
+    STDMETHOD(Revert)() override;
 
 BEGIN_COM_MAP(CTravelLog)
     COM_INTERFACE_ENTRY_IID(IID_ITravelLog, ITravelLog)


### PR DESCRIPTION
## Purpose

For simplicity and short typing. Macro `STDMETHOD` is defined in `<basetyps.h>` as follows:

```c
# define STDMETHOD(m) virtual HRESULT STDMETHODCALLTYPE m
# define STDMETHOD_(t,m) virtual t STDMETHODCALLTYPE m
```
C++11 keyword `override` is used for checking whether the method is overrided.

JIRA issue: [CORE-19469](https://jira.reactos.org/browse/CORE-19469)
## Proposed changes

- Replace `virtual HRESULT STDMETHODCALLTYPE m` with `STDMETHOD(m)` (`m` is a method name).
- Replace `virtual t STDMETHODCALLTYPE m` with `STDMETHOD_(t, m)` (`t` is a type. `m` is a method name).
- Use `override` keyword as possible.

## TODO

- [x] Do build.