### PR TITLE
[SHELL32] Use STDMETHOD macro and keyword override

### DIFF
--- a/dll/win32/shell32/CActiveDesktop.h
+++ b/dll/win32/shell32/CActiveDesktop.h
@@ -23,30 +23,29 @@ public:
     virtual ~CActiveDesktop();
 
     /*** IActiveDesktop methods ***/
-    virtual HRESULT WINAPI ApplyChanges(DWORD dwFlags);
-    virtual HRESULT WINAPI GetWallpaper(PWSTR pwszWallpaper, UINT cchWallpaper, DWORD dwFlags);
-    virtual HRESULT WINAPI SetWallpaper(PCWSTR pwszWallpaper, DWORD dwReserved);
-    virtual HRESULT WINAPI GetWallpaperOptions(LPWALLPAPEROPT pwpo, DWORD dwReserved);
-    virtual HRESULT WINAPI SetWallpaperOptions(LPCWALLPAPEROPT pwpo, DWORD dwReserved);
-    virtual HRESULT WINAPI GetPattern(PWSTR pwszPattern, UINT cchPattern, DWORD dwReserved);
-    virtual HRESULT WINAPI SetPattern(PCWSTR pwszPattern, DWORD dwReserved);
-    virtual HRESULT WINAPI GetDesktopItemOptions(LPCOMPONENTSOPT pco, DWORD dwReserved);
-    virtual HRESULT WINAPI SetDesktopItemOptions(LPCCOMPONENTSOPT pco, DWORD dwReserved);
-    virtual HRESULT WINAPI AddDesktopItem(LPCCOMPONENT pcomp, DWORD dwReserved);
-    virtual HRESULT WINAPI AddDesktopItemWithUI(HWND hwnd, LPCOMPONENT pcomp, DWORD dwReserved);
-    virtual HRESULT WINAPI ModifyDesktopItem(LPCCOMPONENT pcomp, DWORD dwFlags);
-    virtual HRESULT WINAPI RemoveDesktopItem(LPCCOMPONENT pcomp, DWORD dwReserved);
-    virtual HRESULT WINAPI GetDesktopItemCount(int *pcItems, DWORD dwReserved);
-    virtual HRESULT WINAPI GetDesktopItem(int nComponent, LPCOMPONENT pcomp, DWORD dwReserved);
-    virtual HRESULT WINAPI GetDesktopItemByID(ULONG_PTR dwID, LPCOMPONENT pcomp, DWORD dwReserved);
-    virtual HRESULT WINAPI GenerateDesktopItemHtml(PCWSTR pwszFileName, LPCOMPONENT pcomp, DWORD dwReserved);
-    virtual HRESULT WINAPI AddUrl(HWND hwnd, PCWSTR pszSource, LPCOMPONENT pcomp, DWORD dwFlags);
-    virtual HRESULT WINAPI GetDesktopItemBySource(PCWSTR pwszSource, LPCOMPONENT pcomp, DWORD dwReserved);
+    STDMETHOD(ApplyChanges)(DWORD dwFlags) override;
+    STDMETHOD(GetWallpaper)(PWSTR pwszWallpaper, UINT cchWallpaper, DWORD dwFlags) override;
+    STDMETHOD(SetWallpaper)(PCWSTR pwszWallpaper, DWORD dwReserved) override;
+    STDMETHOD(GetWallpaperOptions)(LPWALLPAPEROPT pwpo, DWORD dwReserved) override;
+    STDMETHOD(SetWallpaperOptions)(LPCWALLPAPEROPT pwpo, DWORD dwReserved) override;
+    STDMETHOD(GetPattern)(PWSTR pwszPattern, UINT cchPattern, DWORD dwReserved) override;
+    STDMETHOD(SetPattern)(PCWSTR pwszPattern, DWORD dwReserved) override;
+    STDMETHOD(GetDesktopItemOptions)(LPCOMPONENTSOPT pco, DWORD dwReserved) override;
+    STDMETHOD(SetDesktopItemOptions)(LPCCOMPONENTSOPT pco, DWORD dwReserved) override;
+    STDMETHOD(AddDesktopItem)(LPCCOMPONENT pcomp, DWORD dwReserved) override;
+    STDMETHOD(AddDesktopItemWithUI)(HWND hwnd, LPCOMPONENT pcomp, DWORD dwReserved) override;
+    STDMETHOD(ModifyDesktopItem)(LPCCOMPONENT pcomp, DWORD dwFlags) override;
+    STDMETHOD(RemoveDesktopItem)(LPCCOMPONENT pcomp, DWORD dwReserved) override;
+    STDMETHOD(GetDesktopItemCount)(int *pcItems, DWORD dwReserved) override;
+    STDMETHOD(GetDesktopItem)(int nComponent, LPCOMPONENT pcomp, DWORD dwReserved) override;
+    STDMETHOD(GetDesktopItemByID)(ULONG_PTR dwID, LPCOMPONENT pcomp, DWORD dwReserved) override;
+    STDMETHOD(GenerateDesktopItemHtml)(PCWSTR pwszFileName, LPCOMPONENT pcomp, DWORD dwReserved) override;
+    STDMETHOD(AddUrl)(HWND hwnd, PCWSTR pszSource, LPCOMPONENT pcomp, DWORD dwFlags) override;
+    STDMETHOD(GetDesktopItemBySource)(PCWSTR pwszSource, LPCOMPONENT pcomp, DWORD dwReserved) override;
 
     /*** IPropertyBag methods ***/
-    virtual HRESULT STDMETHODCALLTYPE Read(LPCOLESTR pszPropName, VARIANT *pVar, IErrorLog *pErrorLog);
-    virtual HRESULT STDMETHODCALLTYPE Write(LPCOLESTR pszPropName, VARIANT *pVar);
-
+    STDMETHOD(Read)(LPCOLESTR pszPropName, VARIANT *pVar, IErrorLog *pErrorLog) override;
+    STDMETHOD(Write)(LPCOLESTR pszPropName, VARIANT *pVar) override;
 
 DECLARE_REGISTRY_RESOURCEID(IDR_ACTIVEDESKTOP)
 DECLARE_NOT_AGGREGATABLE(CActiveDesktop)

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -97,7 +97,7 @@ struct MenuCleanup
 class CDefView :
     public CWindowImpl<CDefView, CWindow, CControlWinTraits>,
     public CComObjectRootEx<CComMultiThreadModelNoCS>,
-    public IShellView2,
+    public IShellView3,
     public IFolderView,
     public IShellFolderView,
     public IOleCommandTarget,
@@ -200,103 +200,112 @@ public:
     LRESULT OnExplorerCommand(UINT uCommand, BOOL bUseSelection);
 
     // *** IOleWindow methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetWindow(HWND *lphwnd);
-    virtual HRESULT STDMETHODCALLTYPE ContextSensitiveHelp(BOOL fEnterMode);
+    STDMETHOD(GetWindow)(HWND *lphwnd) override;
+    STDMETHOD(ContextSensitiveHelp)(BOOL fEnterMode) override;
 
     // *** IShellView methods ***
-    virtual HRESULT STDMETHODCALLTYPE TranslateAccelerator(MSG *pmsg);
-    virtual HRESULT STDMETHODCALLTYPE EnableModeless(BOOL fEnable);
-    virtual HRESULT STDMETHODCALLTYPE UIActivate(UINT uState);
-    virtual HRESULT STDMETHODCALLTYPE Refresh();
-    virtual HRESULT STDMETHODCALLTYPE CreateViewWindow(IShellView *psvPrevious, LPCFOLDERSETTINGS pfs, IShellBrowser *psb, RECT *prcView, HWND *phWnd);
-    virtual HRESULT STDMETHODCALLTYPE DestroyViewWindow();
-    virtual HRESULT STDMETHODCALLTYPE GetCurrentInfo(LPFOLDERSETTINGS pfs);
-    virtual HRESULT STDMETHODCALLTYPE AddPropertySheetPages(DWORD dwReserved, LPFNSVADDPROPSHEETPAGE pfn, LPARAM lparam);
-    virtual HRESULT STDMETHODCALLTYPE SaveViewState();
-    virtual HRESULT STDMETHODCALLTYPE SelectItem(PCUITEMID_CHILD pidlItem, SVSIF uFlags);
-    virtual HRESULT STDMETHODCALLTYPE GetItemObject(UINT uItem, REFIID riid, void **ppv);
+    STDMETHOD(TranslateAccelerator)(MSG *pmsg) override;
+    STDMETHOD(EnableModeless)(BOOL fEnable) override;
+    STDMETHOD(UIActivate)(UINT uState) override;
+    STDMETHOD(Refresh)() override;
+    STDMETHOD(CreateViewWindow)(IShellView *psvPrevious, LPCFOLDERSETTINGS pfs, IShellBrowser *psb, RECT *prcView, HWND *phWnd) override;
+    STDMETHOD(DestroyViewWindow)() override;
+    STDMETHOD(GetCurrentInfo)(LPFOLDERSETTINGS pfs) override;
+    STDMETHOD(AddPropertySheetPages)(DWORD dwReserved, LPFNSVADDPROPSHEETPAGE pfn, LPARAM lparam) override;
+    STDMETHOD(SaveViewState)() override;
+    STDMETHOD(SelectItem)(PCUITEMID_CHILD pidlItem, SVSIF uFlags) override;
+    STDMETHOD(GetItemObject)(UINT uItem, REFIID riid, void **ppv) override;
 
     // *** IShellView2 methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetView(SHELLVIEWID *view_guid, ULONG view_type);
-    virtual HRESULT STDMETHODCALLTYPE CreateViewWindow2(LPSV2CVW2_PARAMS view_params);
-    virtual HRESULT STDMETHODCALLTYPE HandleRename(LPCITEMIDLIST new_pidl);
-    virtual HRESULT STDMETHODCALLTYPE SelectAndPositionItem(LPCITEMIDLIST item, UINT flags, POINT *point);
+    STDMETHOD(GetView)(SHELLVIEWID *view_guid, ULONG view_type) override;
+    STDMETHOD(CreateViewWindow2)(LPSV2CVW2_PARAMS view_params) override;
+    STDMETHOD(HandleRename)(LPCITEMIDLIST new_pidl) override;
+    STDMETHOD(SelectAndPositionItem)(LPCITEMIDLIST item, UINT flags, POINT *point) override;
 
     // *** IShellView3 methods ***
-    virtual HRESULT STDMETHODCALLTYPE CreateViewWindow3(IShellBrowser *psb, IShellView *psvPrevious, SV3CVW3_FLAGS view_flags, FOLDERFLAGS mask, FOLDERFLAGS flags, FOLDERVIEWMODE mode, const SHELLVIEWID *view_id, RECT *prcView, HWND *hwnd);
+    STDMETHOD(CreateViewWindow3)(
+        IShellBrowser *psb,
+        IShellView *psvPrevious,
+        SV3CVW3_FLAGS view_flags,
+        FOLDERFLAGS mask,
+        FOLDERFLAGS flags,
+        FOLDERVIEWMODE mode,
+        const SHELLVIEWID *view_id,
+        const RECT *prcView,
+        HWND *hwnd) override;
 
     // *** IFolderView methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetCurrentViewMode(UINT *pViewMode);
-    virtual HRESULT STDMETHODCALLTYPE SetCurrentViewMode(UINT ViewMode);
-    virtual HRESULT STDMETHODCALLTYPE GetFolder(REFIID riid, void **ppv);
-    virtual HRESULT STDMETHODCALLTYPE Item(int iItemIndex, PITEMID_CHILD *ppidl);
-    virtual HRESULT STDMETHODCALLTYPE ItemCount(UINT uFlags, int *pcItems);
-    virtual HRESULT STDMETHODCALLTYPE Items(UINT uFlags, REFIID riid, void **ppv);
-    virtual HRESULT STDMETHODCALLTYPE GetSelectionMarkedItem(int *piItem);
-    virtual HRESULT STDMETHODCALLTYPE GetFocusedItem(int *piItem);
-    virtual HRESULT STDMETHODCALLTYPE GetItemPosition(PCUITEMID_CHILD pidl, POINT *ppt);
-    virtual HRESULT STDMETHODCALLTYPE GetSpacing(POINT *ppt);
-    virtual HRESULT STDMETHODCALLTYPE GetDefaultSpacing(POINT *ppt);
-    virtual HRESULT STDMETHODCALLTYPE GetAutoArrange();
-    virtual HRESULT STDMETHODCALLTYPE SelectItem(int iItem, DWORD dwFlags);
-    virtual HRESULT STDMETHODCALLTYPE SelectAndPositionItems(UINT cidl, PCUITEMID_CHILD_ARRAY apidl, POINT *apt, DWORD dwFlags);
+    STDMETHOD(GetCurrentViewMode)(UINT *pViewMode) override;
+    STDMETHOD(SetCurrentViewMode)(UINT ViewMode) override;
+    STDMETHOD(GetFolder)(REFIID riid, void **ppv) override;
+    STDMETHOD(Item)(int iItemIndex, PITEMID_CHILD *ppidl) override;
+    STDMETHOD(ItemCount)(UINT uFlags, int *pcItems) override;
+    STDMETHOD(Items)(UINT uFlags, REFIID riid, void **ppv) override;
+    STDMETHOD(GetSelectionMarkedItem)(int *piItem) override;
+    STDMETHOD(GetFocusedItem)(int *piItem) override;
+    STDMETHOD(GetItemPosition)(PCUITEMID_CHILD pidl, POINT *ppt) override;
+    STDMETHOD(GetSpacing)(POINT *ppt) override;
+    STDMETHOD(GetDefaultSpacing)(POINT *ppt) override;
+    STDMETHOD(GetAutoArrange)() override;
+    STDMETHOD(SelectItem)(int iItem, DWORD dwFlags) override;
+    STDMETHOD(SelectAndPositionItems)(UINT cidl, PCUITEMID_CHILD_ARRAY apidl, POINT *apt, DWORD dwFlags) override;
 
     // *** IShellFolderView methods ***
-    virtual HRESULT STDMETHODCALLTYPE Rearrange(LPARAM sort);
-    virtual HRESULT STDMETHODCALLTYPE GetArrangeParam(LPARAM *sort);
-    virtual HRESULT STDMETHODCALLTYPE ArrangeGrid();
-    virtual HRESULT STDMETHODCALLTYPE AutoArrange();
-    virtual HRESULT STDMETHODCALLTYPE AddObject(PITEMID_CHILD pidl, UINT *item);
-    virtual HRESULT STDMETHODCALLTYPE GetObject(PITEMID_CHILD *pidl, UINT item);
-    virtual HRESULT STDMETHODCALLTYPE RemoveObject(PITEMID_CHILD pidl, UINT *item);
-    virtual HRESULT STDMETHODCALLTYPE GetObjectCount(UINT *count);
-    virtual HRESULT STDMETHODCALLTYPE SetObjectCount(UINT count, UINT flags);
-    virtual HRESULT STDMETHODCALLTYPE UpdateObject(PITEMID_CHILD pidl_old, PITEMID_CHILD pidl_new, UINT *item);
-    virtual HRESULT STDMETHODCALLTYPE RefreshObject(PITEMID_CHILD pidl, UINT *item);
-    virtual HRESULT STDMETHODCALLTYPE SetRedraw(BOOL redraw);
-    virtual HRESULT STDMETHODCALLTYPE GetSelectedCount(UINT *count);
-    virtual HRESULT STDMETHODCALLTYPE GetSelectedObjects(PCUITEMID_CHILD **pidl, UINT *items);
-    virtual HRESULT STDMETHODCALLTYPE IsDropOnSource(IDropTarget *drop_target);
-    virtual HRESULT STDMETHODCALLTYPE GetDragPoint(POINT *pt);
-    virtual HRESULT STDMETHODCALLTYPE GetDropPoint(POINT *pt);
-    virtual HRESULT STDMETHODCALLTYPE MoveIcons(IDataObject *obj);
-    virtual HRESULT STDMETHODCALLTYPE SetItemPos(PCUITEMID_CHILD pidl, POINT *pt);
-    virtual HRESULT STDMETHODCALLTYPE IsBkDropTarget(IDropTarget *drop_target);
-    virtual HRESULT STDMETHODCALLTYPE SetClipboard(BOOL move);
-    virtual HRESULT STDMETHODCALLTYPE SetPoints(IDataObject *obj);
-    virtual HRESULT STDMETHODCALLTYPE GetItemSpacing(ITEMSPACING *spacing);
-    virtual HRESULT STDMETHODCALLTYPE SetCallback(IShellFolderViewCB *new_cb, IShellFolderViewCB **old_cb);
-    virtual HRESULT STDMETHODCALLTYPE Select(UINT flags);
-    virtual HRESULT STDMETHODCALLTYPE QuerySupport(UINT *support);
-    virtual HRESULT STDMETHODCALLTYPE SetAutomationObject(IDispatch *disp);
+    STDMETHOD(Rearrange)(LPARAM sort) override;
+    STDMETHOD(GetArrangeParam)(LPARAM *sort) override;
+    STDMETHOD(ArrangeGrid)() override;
+    STDMETHOD(AutoArrange)() override;
+    STDMETHOD(AddObject)(PITEMID_CHILD pidl, UINT *item) override;
+    STDMETHOD(GetObject)(PITEMID_CHILD *pidl, UINT item) override;
+    STDMETHOD(RemoveObject)(PITEMID_CHILD pidl, UINT *item) override;
+    STDMETHOD(GetObjectCount)(UINT *count) override;
+    STDMETHOD(SetObjectCount)(UINT count, UINT flags) override;
+    STDMETHOD(UpdateObject)(PITEMID_CHILD pidl_old, PITEMID_CHILD pidl_new, UINT *item) override;
+    STDMETHOD(RefreshObject)(PITEMID_CHILD pidl, UINT *item) override;
+    STDMETHOD(SetRedraw)(BOOL redraw) override;
+    STDMETHOD(GetSelectedCount)(UINT *count) override;
+    STDMETHOD(GetSelectedObjects)(PCUITEMID_CHILD **pidl, UINT *items) override;
+    STDMETHOD(IsDropOnSource)(IDropTarget *drop_target) override;
+    STDMETHOD(GetDragPoint)(POINT *pt) override;
+    STDMETHOD(GetDropPoint)(POINT *pt) override;
+    STDMETHOD(MoveIcons)(IDataObject *obj) override;
+    STDMETHOD(SetItemPos)(PCUITEMID_CHILD pidl, POINT *pt) override;
+    STDMETHOD(IsBkDropTarget)(IDropTarget *drop_target) override;
+    STDMETHOD(SetClipboard)(BOOL move) override;
+    STDMETHOD(SetPoints)(IDataObject *obj) override;
+    STDMETHOD(GetItemSpacing)(ITEMSPACING *spacing) override;
+    STDMETHOD(SetCallback)(IShellFolderViewCB *new_cb, IShellFolderViewCB **old_cb) override;
+    STDMETHOD(Select)(UINT flags) override;
+    STDMETHOD(QuerySupport)(UINT *support) override;
+    STDMETHOD(SetAutomationObject)(IDispatch *disp) override;
 
     // *** IOleCommandTarget methods ***
-    virtual HRESULT STDMETHODCALLTYPE QueryStatus(const GUID *pguidCmdGroup, ULONG cCmds, OLECMD prgCmds[], OLECMDTEXT *pCmdText);
-    virtual HRESULT STDMETHODCALLTYPE Exec(const GUID *pguidCmdGroup, DWORD nCmdID, DWORD nCmdexecopt, VARIANT *pvaIn, VARIANT *pvaOut);
+    STDMETHOD(QueryStatus)(const GUID *pguidCmdGroup, ULONG cCmds, OLECMD prgCmds[], OLECMDTEXT *pCmdText) override;
+    STDMETHOD(Exec)(const GUID *pguidCmdGroup, DWORD nCmdID, DWORD nCmdexecopt, VARIANT *pvaIn, VARIANT *pvaOut) override;
 
     // *** IDropTarget methods ***
-    virtual HRESULT STDMETHODCALLTYPE DragEnter(IDataObject *pDataObj, DWORD grfKeyState, POINTL pt, DWORD *pdwEffect);
-    virtual HRESULT STDMETHODCALLTYPE DragOver(DWORD grfKeyState, POINTL pt, DWORD *pdwEffect);
-    virtual HRESULT STDMETHODCALLTYPE DragLeave();
-    virtual HRESULT STDMETHODCALLTYPE Drop(IDataObject *pDataObj, DWORD grfKeyState, POINTL pt, DWORD *pdwEffect);
+    STDMETHOD(DragEnter)(IDataObject *pDataObj, DWORD grfKeyState, POINTL pt, DWORD *pdwEffect) override;
+    STDMETHOD(DragOver)(DWORD grfKeyState, POINTL pt, DWORD *pdwEffect) override;
+    STDMETHOD(DragLeave)() override;
+    STDMETHOD(Drop)(IDataObject *pDataObj, DWORD grfKeyState, POINTL pt, DWORD *pdwEffect) override;
 
     // *** IDropSource methods ***
-    virtual HRESULT STDMETHODCALLTYPE QueryContinueDrag(BOOL fEscapePressed, DWORD grfKeyState);
-    virtual HRESULT STDMETHODCALLTYPE GiveFeedback(DWORD dwEffect);
+    STDMETHOD(QueryContinueDrag)(BOOL fEscapePressed, DWORD grfKeyState) override;
+    STDMETHOD(GiveFeedback)(DWORD dwEffect) override;
 
     // *** IViewObject methods ***
-    virtual HRESULT STDMETHODCALLTYPE Draw(DWORD dwDrawAspect, LONG lindex, void *pvAspect, DVTARGETDEVICE *ptd,
+    STDMETHOD(Draw)(DWORD dwDrawAspect, LONG lindex, void *pvAspect, DVTARGETDEVICE *ptd,
                                            HDC hdcTargetDev, HDC hdcDraw, LPCRECTL lprcBounds, LPCRECTL lprcWBounds,
-                                           BOOL (STDMETHODCALLTYPE *pfnContinue)(ULONG_PTR dwContinue), ULONG_PTR dwContinue);
-    virtual HRESULT STDMETHODCALLTYPE GetColorSet(DWORD dwDrawAspect, LONG lindex, void *pvAspect,
-            DVTARGETDEVICE *ptd, HDC hicTargetDev, LOGPALETTE **ppColorSet);
-    virtual HRESULT STDMETHODCALLTYPE Freeze(DWORD dwDrawAspect, LONG lindex, void *pvAspect, DWORD *pdwFreeze);
-    virtual HRESULT STDMETHODCALLTYPE Unfreeze(DWORD dwFreeze);
-    virtual HRESULT STDMETHODCALLTYPE SetAdvise(DWORD aspects, DWORD advf, IAdviseSink *pAdvSink);
-    virtual HRESULT STDMETHODCALLTYPE GetAdvise(DWORD *pAspects, DWORD *pAdvf, IAdviseSink **ppAdvSink);
+                                           BOOL (STDMETHODCALLTYPE *pfnContinue)(ULONG_PTR dwContinue), ULONG_PTR dwContinue) override;
+    STDMETHOD(GetColorSet)(DWORD dwDrawAspect, LONG lindex, void *pvAspect,
+            DVTARGETDEVICE *ptd, HDC hicTargetDev, LOGPALETTE **ppColorSet) override;
+    STDMETHOD(Freeze)(DWORD dwDrawAspect, LONG lindex, void *pvAspect, DWORD *pdwFreeze) override;
+    STDMETHOD(Unfreeze)(DWORD dwFreeze) override;
+    STDMETHOD(SetAdvise)(DWORD aspects, DWORD advf, IAdviseSink *pAdvSink) override;
+    STDMETHOD(GetAdvise)(DWORD *pAspects, DWORD *pAdvf, IAdviseSink **ppAdvSink) override;
 
     // *** IServiceProvider methods ***
-    virtual HRESULT STDMETHODCALLTYPE QueryService(REFGUID guidService, REFIID riid, void **ppvObject);
+    STDMETHOD(QueryService)(REFGUID guidService, REFIID riid, void **ppvObject) override;
 
     // Message handlers
     LRESULT OnShowWindow(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
@@ -383,6 +392,7 @@ public:
     COM_INTERFACE_ENTRY_IID(IID_IShellView, IShellView)
     COM_INTERFACE_ENTRY_IID(IID_CDefView, IShellView)
     COM_INTERFACE_ENTRY_IID(IID_IShellView2, IShellView2)
+    COM_INTERFACE_ENTRY_IID(IID_IShellView3, IShellView3)
     COM_INTERFACE_ENTRY_IID(IID_IFolderView, IFolderView)
     COM_INTERFACE_ENTRY_IID(IID_IShellFolderView, IShellFolderView)
     COM_INTERFACE_ENTRY_IID(IID_IOleCommandTarget, IOleCommandTarget)
@@ -2901,7 +2911,7 @@ HRESULT STDMETHODCALLTYPE CDefView::CreateViewWindow2(LPSV2CVW2_PARAMS view_para
         (FOLDERVIEWMODE)view_params->pfs->ViewMode, view_params->pvid, view_params->prcView, &view_params->hwndView);
 }
 
-HRESULT STDMETHODCALLTYPE CDefView::CreateViewWindow3(IShellBrowser *psb, IShellView *psvPrevious, SV3CVW3_FLAGS view_flags, FOLDERFLAGS mask, FOLDERFLAGS flags, FOLDERVIEWMODE mode, const SHELLVIEWID *view_id, RECT *prcView, HWND *hwnd)
+HRESULT STDMETHODCALLTYPE CDefView::CreateViewWindow3(IShellBrowser *psb, IShellView *psvPrevious, SV3CVW3_FLAGS view_flags, FOLDERFLAGS mask, FOLDERFLAGS flags, FOLDERVIEWMODE mode, const SHELLVIEWID *view_id, const RECT *prcView, HWND *hwnd)
 {
     OLEMENUGROUPWIDTHS omw = { { 0, 0, 0, 0, 0, 0 } };
 
@@ -2953,7 +2963,8 @@ HRESULT STDMETHODCALLTYPE CDefView::CreateViewWindow3(IShellBrowser *psb, IShell
         TRACE("-- CommDlgBrowser\n");
     }
 
-    Create(m_hWndParent, prcView, NULL, WS_CHILD | WS_CLIPSIBLINGS | WS_CLIPCHILDREN | WS_TABSTOP, 0, 0U);
+    RECT rcView = *prcView;
+    Create(m_hWndParent, rcView, NULL, WS_CHILD | WS_CLIPSIBLINGS | WS_CLIPCHILDREN | WS_TABSTOP, 0, 0U);
     if (m_hWnd == NULL)
         return E_FAIL;
 

--- a/dll/win32/shell32/CDefViewBckgrndMenu.cpp
+++ b/dll/win32/shell32/CDefViewBckgrndMenu.cpp
@@ -31,19 +31,19 @@ class CDefViewBckgrndMenu :
         HRESULT Initialize(IShellFolder* psf);
 
         // IContextMenu
-        virtual HRESULT WINAPI QueryContextMenu(HMENU hMenu, UINT indexMenu, UINT idCmdFirst, UINT idCmdLast, UINT uFlags);
-        virtual HRESULT WINAPI InvokeCommand(LPCMINVOKECOMMANDINFO lpcmi);
-        virtual HRESULT WINAPI GetCommandString(UINT_PTR idCommand, UINT uFlags, UINT *lpReserved, LPSTR lpszName, UINT uMaxNameLen);
+        STDMETHOD(QueryContextMenu)(HMENU hMenu, UINT indexMenu, UINT idCmdFirst, UINT idCmdLast, UINT uFlags) override;
+        STDMETHOD(InvokeCommand)(LPCMINVOKECOMMANDINFO lpcmi) override;
+        STDMETHOD(GetCommandString)(UINT_PTR idCommand, UINT uFlags, UINT *lpReserved, LPSTR lpszName, UINT uMaxNameLen) override;
 
         // IContextMenu2
-        virtual HRESULT WINAPI HandleMenuMsg(UINT uMsg, WPARAM wParam, LPARAM lParam);
+        STDMETHOD(HandleMenuMsg)(UINT uMsg, WPARAM wParam, LPARAM lParam) override;
 
         // IContextMenu3
-        virtual HRESULT WINAPI HandleMenuMsg2(UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT *plResult);
+        STDMETHOD(HandleMenuMsg2)(UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT *plResult) override;
 
         // IObjectWithSite
-        virtual HRESULT STDMETHODCALLTYPE SetSite(IUnknown *pUnkSite);
-        virtual HRESULT STDMETHODCALLTYPE GetSite(REFIID riid, void **ppvSite);
+        STDMETHOD(SetSite)(IUnknown *pUnkSite) override;
+        STDMETHOD(GetSite)(REFIID riid, void **ppvSite) override;
 
         BEGIN_COM_MAP(CDefViewBckgrndMenu)
         COM_INTERFACE_ENTRY_IID(IID_IContextMenu, IContextMenu)

--- a/dll/win32/shell32/CDefViewDual.cpp
+++ b/dll/win32/shell32/CDefViewDual.cpp
@@ -43,14 +43,14 @@ class CDefViewDual :
         }
 
         // *** IShellFolderViewDual methods ***
-        virtual HRESULT STDMETHODCALLTYPE get_Application(IDispatch **app) override
+        STDMETHOD(get_Application)(IDispatch **app) override
         {
             if (!app) return E_INVALIDARG;
 
             return CShellDispatch_Constructor(IID_IDispatch, (LPVOID*)app);
         }
 
-        virtual HRESULT STDMETHODCALLTYPE get_Parent(IDispatch **parent) override
+        STDMETHOD(get_Parent)(IDispatch **parent) override
         {
             if (!parent) return E_INVALIDARG;
             *parent = NULL;
@@ -58,7 +58,7 @@ class CDefViewDual :
             return E_NOTIMPL;
         }
 
-        virtual HRESULT STDMETHODCALLTYPE get_Folder(Folder **folder) override
+        STDMETHOD(get_Folder)(Folder **folder) override
         {
             if (!folder) return E_INVALIDARG;
             *folder = NULL;
@@ -66,7 +66,7 @@ class CDefViewDual :
             return E_NOTIMPL;
         }
 
-        virtual HRESULT STDMETHODCALLTYPE SelectedItems(FolderItems **items) override
+        STDMETHOD(SelectedItems)(FolderItems **items) override
         {
             if (!items) return E_INVALIDARG;
             *items = NULL;
@@ -74,7 +74,7 @@ class CDefViewDual :
             return E_NOTIMPL;
         }
 
-        virtual  HRESULT STDMETHODCALLTYPE get_FocusedItem(FolderItem **item) override
+        STDMETHOD(get_FocusedItem)(FolderItem **item) override
         {
             if (!item) return E_INVALIDARG;
             *item = NULL;
@@ -82,44 +82,44 @@ class CDefViewDual :
             return E_NOTIMPL;
         }
 
-        virtual HRESULT STDMETHODCALLTYPE SelectItem(VARIANT *item, int flags) override
+        STDMETHOD(SelectItem)(VARIANT *item, int flags) override
         {
             FIXME("CDefViewDual::SelectItem is UNIMPLEMENTED (%p, %p, %i)\n", this, item, flags);
             return E_NOTIMPL;
         }
 
-        virtual HRESULT STDMETHODCALLTYPE PopupItemMenu(FolderItem *item, VARIANT vx, VARIANT vy, BSTR *command) override
+        STDMETHOD(PopupItemMenu)(FolderItem *item, VARIANT vx, VARIANT vy, BSTR *command) override
         {
             FIXME("CDefViewDual::PopupItemMenu is UNIMPLEMENTED (%p, %p, %s, %s, %p)\n", this, item, wine_dbgstr_variant(&vx), wine_dbgstr_variant(&vy), command);
             return E_NOTIMPL;
         }
 
-        virtual HRESULT STDMETHODCALLTYPE get_Script(IDispatch **script) override
+        STDMETHOD(get_Script)(IDispatch **script) override
         {
             FIXME("CDefViewDual::get_Script is UNIMPLEMENTED (%p, %p)\n", this, script);
             return E_NOTIMPL;
         }
 
-        virtual HRESULT STDMETHODCALLTYPE get_ViewOptions(long *options) override
+        STDMETHOD(get_ViewOptions)(long *options) override
         {
             FIXME("CDefViewDual::get_ViewOptions is UNIMPLEMENTED (%p, %p)\n", this, options);
             return E_NOTIMPL;
         }
 
         // *** IShellFolderViewDual2 methods ***
-        virtual HRESULT STDMETHODCALLTYPE get_CurrentViewMode(UINT *mode) override
+        STDMETHOD(get_CurrentViewMode)(UINT *mode) override
         {
             FIXME("CDefViewDual::get_CurrentViewMode is UNIMPLEMENTED (%p, %p)\n", this, mode);
             return E_NOTIMPL;
         }
 
-        virtual HRESULT STDMETHODCALLTYPE put_CurrentViewMode(UINT mode) override
+        STDMETHOD(put_CurrentViewMode)(UINT mode) override
         {
             FIXME("CDefViewDual::put_CurrentViewMode is UNIMPLEMENTED (%p, %u)\n", this, mode);
             return E_NOTIMPL;
         }
 
-        virtual HRESULT STDMETHODCALLTYPE SelectItemRelative(int relative) override
+        STDMETHOD(SelectItemRelative)(int relative) override
         {
             FIXME("CDefViewDual::SelectItemRelative is UNIMPLEMENTED (%p, %i)\n", this, relative);
             return E_NOTIMPL;

--- a/dll/win32/shell32/CDefaultContextMenu.cpp
+++ b/dll/win32/shell32/CDefaultContextMenu.cpp
@@ -128,19 +128,19 @@ class CDefaultContextMenu :
         HRESULT WINAPI Initialize(const DEFCONTEXTMENU *pdcm, LPFNDFMCALLBACK lpfn);
 
         // IContextMenu
-        virtual HRESULT WINAPI QueryContextMenu(HMENU hMenu, UINT indexMenu, UINT idCmdFirst, UINT idCmdLast, UINT uFlags);
-        virtual HRESULT WINAPI InvokeCommand(LPCMINVOKECOMMANDINFO lpcmi);
-        virtual HRESULT WINAPI GetCommandString(UINT_PTR idCommand, UINT uFlags, UINT *lpReserved, LPSTR lpszName, UINT uMaxNameLen);
+        STDMETHOD(QueryContextMenu)(HMENU hMenu, UINT indexMenu, UINT idCmdFirst, UINT idCmdLast, UINT uFlags) override;
+        STDMETHOD(InvokeCommand)(LPCMINVOKECOMMANDINFO lpcmi) override;
+        STDMETHOD(GetCommandString)(UINT_PTR idCommand, UINT uFlags, UINT *lpReserved, LPSTR lpszName, UINT uMaxNameLen) override;
 
         // IContextMenu2
-        virtual HRESULT WINAPI HandleMenuMsg(UINT uMsg, WPARAM wParam, LPARAM lParam);
+        STDMETHOD(HandleMenuMsg)(UINT uMsg, WPARAM wParam, LPARAM lParam) override;
 
         // IContextMenu3
-        virtual HRESULT WINAPI HandleMenuMsg2(UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT *plResult);
+        STDMETHOD(HandleMenuMsg2)(UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT *plResult) override;
 
         // IObjectWithSite
-        virtual HRESULT STDMETHODCALLTYPE SetSite(IUnknown *pUnkSite);
-        virtual HRESULT STDMETHODCALLTYPE GetSite(REFIID riid, void **ppvSite);
+        STDMETHOD(SetSite)(IUnknown *pUnkSite) override;
+        STDMETHOD(GetSite)(REFIID riid, void **ppvSite) override;
 
         BEGIN_COM_MAP(CDefaultContextMenu)
         COM_INTERFACE_ENTRY_IID(IID_IContextMenu, IContextMenu)

--- a/dll/win32/shell32/CDropTargetHelper.h
+++ b/dll/win32/shell32/CDropTargetHelper.h
@@ -37,7 +37,7 @@ public:
 	virtual HRESULT WINAPI InitializeFromBitmap(LPSHDRAGIMAGE pshdi, IDataObject *pDataObject);
 	virtual HRESULT WINAPI InitializeFromWindow(HWND hwnd, POINT *ppt, IDataObject *pDataObject);
 
-	STDMETHOD(DragEnter )(HWND hwndTarget, IDataObject* pDataObject, POINT* ppt, DWORD dwEffect) override;
+	STDMETHOD(DragEnter)(HWND hwndTarget, IDataObject* pDataObject, POINT* ppt, DWORD dwEffect) override;
 	STDMETHOD(DragLeave)() override;
 	STDMETHOD(DragOver)(POINT *ppt, DWORD dwEffect) override;
 	STDMETHOD(Drop)(IDataObject* pDataObject, POINT* ppt, DWORD dwEffect) override;

--- a/dll/win32/shell32/CDropTargetHelper.h
+++ b/dll/win32/shell32/CDropTargetHelper.h
@@ -37,11 +37,11 @@ public:
 	virtual HRESULT WINAPI InitializeFromBitmap(LPSHDRAGIMAGE pshdi, IDataObject *pDataObject);
 	virtual HRESULT WINAPI InitializeFromWindow(HWND hwnd, POINT *ppt, IDataObject *pDataObject);
 
-	virtual HRESULT WINAPI DragEnter (HWND hwndTarget, IDataObject* pDataObject, POINT* ppt, DWORD dwEffect);
-	virtual HRESULT WINAPI DragLeave();
-	virtual HRESULT WINAPI DragOver(POINT *ppt, DWORD dwEffect);
-	virtual HRESULT WINAPI Drop(IDataObject* pDataObject, POINT* ppt, DWORD dwEffect);
-	virtual HRESULT WINAPI Show(BOOL fShow);
+	STDMETHOD(DragEnter )(HWND hwndTarget, IDataObject* pDataObject, POINT* ppt, DWORD dwEffect) override;
+	STDMETHOD(DragLeave)() override;
+	STDMETHOD(DragOver)(POINT *ppt, DWORD dwEffect) override;
+	STDMETHOD(Drop)(IDataObject* pDataObject, POINT* ppt, DWORD dwEffect) override;
+	STDMETHOD(Show)(BOOL fShow) override;
 
 DECLARE_REGISTRY_RESOURCEID(IDR_DRAGDROPHELPER)
 DECLARE_NOT_AGGREGATABLE(CDropTargetHelper)

--- a/dll/win32/shell32/CEnumIDListBase.h
+++ b/dll/win32/shell32/CEnumIDListBase.h
@@ -40,10 +40,10 @@ public:
     HRESULT AppendItemsFromEnumerator(IEnumIDList* pEnum);
 
 	// *** IEnumIDList methods ***
-	virtual HRESULT STDMETHODCALLTYPE Next(ULONG celt, LPITEMIDLIST *rgelt, ULONG *pceltFetched);
-	virtual HRESULT STDMETHODCALLTYPE Skip(ULONG celt);
-	virtual HRESULT STDMETHODCALLTYPE Reset();
-	virtual HRESULT STDMETHODCALLTYPE Clone(IEnumIDList **ppenum);
+	STDMETHOD(Next)(ULONG celt, LPITEMIDLIST *rgelt, ULONG *pceltFetched) override;
+	STDMETHOD(Skip)(ULONG celt) override;
+	STDMETHOD(Reset)() override;
+	STDMETHOD(Clone)(IEnumIDList **ppenum) override;
 
 BEGIN_COM_MAP(CEnumIDListBase)
 	COM_INTERFACE_ENTRY_IID(IID_IEnumIDList, IEnumIDList)

--- a/dll/win32/shell32/CExtractIcon.cpp
+++ b/dll/win32/shell32/CExtractIcon.cpp
@@ -35,30 +35,30 @@ public:
     ~CExtractIcon();
 
     // IDefaultExtractIconInit
-    virtual HRESULT STDMETHODCALLTYPE SetDefaultIcon(LPCWSTR pszFile, int iIcon);
-    virtual HRESULT STDMETHODCALLTYPE SetFlags(UINT uFlags);
-    virtual HRESULT STDMETHODCALLTYPE SetKey(HKEY hkey);
-    virtual HRESULT STDMETHODCALLTYPE SetNormalIcon(LPCWSTR pszFile, int iIcon);
-    virtual HRESULT STDMETHODCALLTYPE SetOpenIcon(LPCWSTR pszFile, int iIcon);
-    virtual HRESULT STDMETHODCALLTYPE SetShortcutIcon(LPCWSTR pszFile, int iIcon);
+    STDMETHOD(SetDefaultIcon)(LPCWSTR pszFile, int iIcon) override;
+    STDMETHOD(SetFlags)(UINT uFlags) override;
+    STDMETHOD(SetKey)(HKEY hkey) override;
+    STDMETHOD(SetNormalIcon)(LPCWSTR pszFile, int iIcon) override;
+    STDMETHOD(SetOpenIcon)(LPCWSTR pszFile, int iIcon) override;
+    STDMETHOD(SetShortcutIcon)(LPCWSTR pszFile, int iIcon) override;
 
     // IExtractIconW
-    virtual HRESULT STDMETHODCALLTYPE GetIconLocation(UINT uFlags, LPWSTR szIconFile, UINT cchMax, int *piIndex, UINT *pwFlags);
-    virtual HRESULT STDMETHODCALLTYPE Extract(LPCWSTR pszFile, UINT nIconIndex, HICON *phiconLarge, HICON *phiconSmall, UINT nIconSize);
+    STDMETHOD(GetIconLocation)(UINT uFlags, LPWSTR szIconFile, UINT cchMax, int *piIndex, UINT *pwFlags) override;
+    STDMETHOD(Extract)(LPCWSTR pszFile, UINT nIconIndex, HICON *phiconLarge, HICON *phiconSmall, UINT nIconSize) override;
 
     // IExtractIconA
-    virtual HRESULT STDMETHODCALLTYPE GetIconLocation(UINT uFlags, LPSTR szIconFile, UINT cchMax, int *piIndex, UINT *pwFlags);
-    virtual HRESULT STDMETHODCALLTYPE Extract(LPCSTR pszFile, UINT nIconIndex, HICON *phiconLarge, HICON *phiconSmall, UINT nIconSize);
+    STDMETHOD(GetIconLocation)(UINT uFlags, LPSTR szIconFile, UINT cchMax, int *piIndex, UINT *pwFlags) override;
+    STDMETHOD(Extract)(LPCSTR pszFile, UINT nIconIndex, HICON *phiconLarge, HICON *phiconSmall, UINT nIconSize) override;
 
     // IPersist
-    virtual HRESULT STDMETHODCALLTYPE GetClassID(CLSID *pClassID);
-    virtual HRESULT STDMETHODCALLTYPE IsDirty();
+    STDMETHOD(GetClassID)(CLSID *pClassID) override;
+    STDMETHOD(IsDirty)() override;
 
     // IPersistFile
-    virtual HRESULT STDMETHODCALLTYPE Load(LPCOLESTR pszFileName, DWORD dwMode);
-    virtual HRESULT STDMETHODCALLTYPE Save(LPCOLESTR pszFileName, BOOL fRemember);
-    virtual HRESULT STDMETHODCALLTYPE SaveCompleted(LPCOLESTR pszFileName);
-    virtual HRESULT STDMETHODCALLTYPE GetCurFile(LPOLESTR *ppszFileName);
+    STDMETHOD(Load)(LPCOLESTR pszFileName, DWORD dwMode) override;
+    STDMETHOD(Save)(LPCOLESTR pszFileName, BOOL fRemember) override;
+    STDMETHOD(SaveCompleted)(LPCOLESTR pszFileName) override;
+    STDMETHOD(GetCurFile)(LPOLESTR *ppszFileName) override;
 
 BEGIN_COM_MAP(CExtractIcon)
     COM_INTERFACE_ENTRY_IID(IID_IDefaultExtractIconInit, IDefaultExtractIconInit)

--- a/dll/win32/shell32/CFileSysBindData.cpp
+++ b/dll/win32/shell32/CFileSysBindData.cpp
@@ -38,8 +38,8 @@ public:
     ~CFileSysBindData();
 
     // *** IFileSystemBindData methods ***
-    virtual HRESULT STDMETHODCALLTYPE SetFindData(const WIN32_FIND_DATAW *pfd);
-    virtual HRESULT STDMETHODCALLTYPE GetFindData(WIN32_FIND_DATAW *pfd);
+    STDMETHOD(SetFindData)(const WIN32_FIND_DATAW *pfd) override;
+    STDMETHOD(GetFindData)(WIN32_FIND_DATAW *pfd) override;
 
 DECLARE_NOT_AGGREGATABLE(CFileSysBindData)
 DECLARE_PROTECT_FINAL_CONSTRUCT()

--- a/dll/win32/shell32/CFolder.h
+++ b/dll/win32/shell32/CFolder.h
@@ -27,23 +27,23 @@ public:
     HRESULT Initialize(LPITEMIDLIST idlist);
 
     // *** Folder methods ***
-    virtual HRESULT STDMETHODCALLTYPE get_Title(BSTR *pbs);
-    virtual HRESULT STDMETHODCALLTYPE get_Application(IDispatch **ppid);
-    virtual HRESULT STDMETHODCALLTYPE get_Parent(IDispatch **ppid);
-    virtual HRESULT STDMETHODCALLTYPE get_ParentFolder(Folder **ppsf);
-    virtual HRESULT STDMETHODCALLTYPE Items(FolderItems **ppid);
-    virtual HRESULT STDMETHODCALLTYPE ParseName(BSTR bName, FolderItem **ppid);
-    virtual HRESULT STDMETHODCALLTYPE NewFolder(BSTR bName, VARIANT vOptions);
-    virtual HRESULT STDMETHODCALLTYPE MoveHere(VARIANT vItem, VARIANT vOptions);
-    virtual HRESULT STDMETHODCALLTYPE CopyHere(VARIANT vItem, VARIANT vOptions);
-    virtual HRESULT STDMETHODCALLTYPE GetDetailsOf(VARIANT vItem, int iColumn, BSTR *pbs);
+    STDMETHOD(get_Title)(BSTR *pbs) override;
+    STDMETHOD(get_Application)(IDispatch **ppid) override;
+    STDMETHOD(get_Parent)(IDispatch **ppid) override;
+    STDMETHOD(get_ParentFolder)(Folder **ppsf) override;
+    STDMETHOD(Items)(FolderItems **ppid) override;
+    STDMETHOD(ParseName)(BSTR bName, FolderItem **ppid) override;
+    STDMETHOD(NewFolder)(BSTR bName, VARIANT vOptions) override;
+    STDMETHOD(MoveHere)(VARIANT vItem, VARIANT vOptions) override;
+    STDMETHOD(CopyHere)(VARIANT vItem, VARIANT vOptions) override;
+    STDMETHOD(GetDetailsOf)(VARIANT vItem, int iColumn, BSTR *pbs) override;
 
     // *** Folder2 methods ***
-    virtual HRESULT STDMETHODCALLTYPE get_Self(FolderItem **ppfi);
-    virtual HRESULT STDMETHODCALLTYPE get_OfflineStatus(LONG *pul);
-    virtual HRESULT STDMETHODCALLTYPE Synchronize();
-    virtual HRESULT STDMETHODCALLTYPE get_HaveToShowWebViewBarricade(VARIANT_BOOL *pbHaveToShowWebViewBarricade);
-    virtual HRESULT STDMETHODCALLTYPE DismissedWebViewBarricade();
+    STDMETHOD(get_Self)(FolderItem **ppfi) override;
+    STDMETHOD(get_OfflineStatus)(LONG *pul) override;
+    STDMETHOD(Synchronize)() override;
+    STDMETHOD(get_HaveToShowWebViewBarricade)(VARIANT_BOOL *pbHaveToShowWebViewBarricade) override;
+    STDMETHOD(DismissedWebViewBarricade)() override;
 
 DECLARE_NOT_AGGREGATABLE(CFolder)
 DECLARE_PROTECT_FINAL_CONSTRUCT()

--- a/dll/win32/shell32/CFolderItemVerbs.h
+++ b/dll/win32/shell32/CFolderItemVerbs.h
@@ -37,10 +37,10 @@ public:
     void Init(IContextMenu* menu, BSTR name);
 
     // *** FolderItemVerb methods ***
-    virtual HRESULT STDMETHODCALLTYPE get_Application(IDispatch **ppid);
-    virtual HRESULT STDMETHODCALLTYPE get_Parent(IDispatch **ppid);
-    virtual HRESULT STDMETHODCALLTYPE get_Name(BSTR *pbs);
-    virtual HRESULT STDMETHODCALLTYPE DoIt();
+    STDMETHOD(get_Application)(IDispatch **ppid) override;
+    STDMETHOD(get_Parent)(IDispatch **ppid) override;
+    STDMETHOD(get_Name)(BSTR *pbs) override;
+    STDMETHOD(DoIt)() override;
 
 
 DECLARE_NOT_AGGREGATABLE(CFolderItemVerb)
@@ -70,11 +70,11 @@ public:
     HRESULT Init(LPITEMIDLIST idlist);
 
     // *** FolderItemVerbs methods ***
-    virtual HRESULT STDMETHODCALLTYPE get_Count(LONG *plCount);
-    virtual HRESULT STDMETHODCALLTYPE get_Application(IDispatch **ppid);
-    virtual HRESULT STDMETHODCALLTYPE get_Parent(IDispatch **ppid);
-    virtual HRESULT STDMETHODCALLTYPE Item(VARIANT index, FolderItemVerb **ppid);
-    virtual HRESULT STDMETHODCALLTYPE _NewEnum(IUnknown **ppunk);
+    STDMETHOD(get_Count)(LONG *plCount) override;
+    STDMETHOD(get_Application)(IDispatch **ppid) override;
+    STDMETHOD(get_Parent)(IDispatch **ppid) override;
+    STDMETHOD(Item)(VARIANT index, FolderItemVerb **ppid) override;
+    STDMETHOD(_NewEnum)(IUnknown **ppunk) override;
 
 DECLARE_NOT_AGGREGATABLE(CFolderItemVerbs)
 DECLARE_PROTECT_FINAL_CONSTRUCT()

--- a/dll/win32/shell32/CFolderItems.h
+++ b/dll/win32/shell32/CFolderItems.h
@@ -24,25 +24,24 @@ public:
 
     HRESULT Initialize(Folder* folder, LPITEMIDLIST idlist);
 
-
     // *** FolderItem methods ***
-    virtual HRESULT STDMETHODCALLTYPE get_Application(IDispatch **ppid);
-    virtual HRESULT STDMETHODCALLTYPE get_Parent(IDispatch **ppid);
-    virtual HRESULT STDMETHODCALLTYPE get_Name(BSTR *pbs);
-    virtual HRESULT STDMETHODCALLTYPE put_Name(BSTR bs);
-    virtual HRESULT STDMETHODCALLTYPE get_Path(BSTR *pbs);
-    virtual HRESULT STDMETHODCALLTYPE get_GetLink(IDispatch **ppid);
-    virtual HRESULT STDMETHODCALLTYPE get_GetFolder(IDispatch **ppid);
-    virtual HRESULT STDMETHODCALLTYPE get_IsLink(VARIANT_BOOL *pb);
-    virtual HRESULT STDMETHODCALLTYPE get_IsFolder(VARIANT_BOOL *pb);
-    virtual HRESULT STDMETHODCALLTYPE get_IsFileSystem(VARIANT_BOOL *pb);
-    virtual HRESULT STDMETHODCALLTYPE get_IsBrowsable(VARIANT_BOOL *pb);
-    virtual HRESULT STDMETHODCALLTYPE get_ModifyDate(DATE *pdt);
-    virtual HRESULT STDMETHODCALLTYPE put_ModifyDate(DATE dt);
-    virtual HRESULT STDMETHODCALLTYPE get_Size(LONG *pul);
-    virtual HRESULT STDMETHODCALLTYPE get_Type(BSTR *pbs);
-    virtual HRESULT STDMETHODCALLTYPE Verbs(FolderItemVerbs **ppfic);
-    virtual HRESULT STDMETHODCALLTYPE InvokeVerb(VARIANT vVerb);
+    STDMETHOD(get_Application)(IDispatch **ppid) override;
+    STDMETHOD(get_Parent)(IDispatch **ppid) override;
+    STDMETHOD(get_Name)(BSTR *pbs) override;
+    STDMETHOD(put_Name)(BSTR bs) override;
+    STDMETHOD(get_Path)(BSTR *pbs) override;
+    STDMETHOD(get_GetLink)(IDispatch **ppid) override;
+    STDMETHOD(get_GetFolder)(IDispatch **ppid) override;
+    STDMETHOD(get_IsLink)(VARIANT_BOOL *pb) override;
+    STDMETHOD(get_IsFolder)(VARIANT_BOOL *pb) override;
+    STDMETHOD(get_IsFileSystem)(VARIANT_BOOL *pb) override;
+    STDMETHOD(get_IsBrowsable)(VARIANT_BOOL *pb) override;
+    STDMETHOD(get_ModifyDate)(DATE *pdt) override;
+    STDMETHOD(put_ModifyDate)(DATE dt) override;
+    STDMETHOD(get_Size)(LONG *pul) override;
+    STDMETHOD(get_Type)(BSTR *pbs) override;
+    STDMETHOD(Verbs)(FolderItemVerbs **ppfic) override;
+    STDMETHOD(InvokeVerb)(VARIANT vVerb) override;
 
 
 DECLARE_NOT_AGGREGATABLE(CFolderItem)
@@ -73,11 +72,11 @@ public:
     HRESULT Initialize(LPITEMIDLIST idlist, Folder* parent);
 
     // *** FolderItems methods ***
-    virtual HRESULT STDMETHODCALLTYPE get_Count(long *plCount);
-    virtual HRESULT STDMETHODCALLTYPE get_Application(IDispatch **ppid);
-    virtual HRESULT STDMETHODCALLTYPE get_Parent(IDispatch **ppid);
-    virtual HRESULT STDMETHODCALLTYPE Item(VARIANT index, FolderItem **ppid);
-    virtual HRESULT STDMETHODCALLTYPE _NewEnum(IUnknown **ppunk);
+    STDMETHOD(get_Count)(long *plCount) override;
+    STDMETHOD(get_Application)(IDispatch **ppid) override;
+    STDMETHOD(get_Parent)(IDispatch **ppid) override;
+    STDMETHOD(Item)(VARIANT index, FolderItem **ppid) override;
+    STDMETHOD(_NewEnum)(IUnknown **ppunk) override;
 
 DECLARE_NOT_AGGREGATABLE(CFolderItems)
 DECLARE_PROTECT_FINAL_CONSTRUCT()

--- a/dll/win32/shell32/CFolderOptions.h
+++ b/dll/win32/shell32/CFolderOptions.h
@@ -43,15 +43,15 @@ class CFolderOptions :
         ~CFolderOptions();
 
         // IShellPropSheetExt
-        virtual HRESULT STDMETHODCALLTYPE AddPages(LPFNSVADDPROPSHEETPAGE pfnAddPage, LPARAM lParam);
-        virtual HRESULT STDMETHODCALLTYPE ReplacePage(EXPPS uPageID, LPFNSVADDPROPSHEETPAGE pfnReplaceWith, LPARAM lParam);
+        STDMETHOD(AddPages)(LPFNSVADDPROPSHEETPAGE pfnAddPage, LPARAM lParam) override;
+        STDMETHOD(ReplacePage)(EXPPS uPageID, LPFNSVADDPROPSHEETPAGE pfnReplaceWith, LPARAM lParam) override;
 
         // IShellExtInit
-        virtual HRESULT STDMETHODCALLTYPE Initialize(PCIDLIST_ABSOLUTE pidlFolder, IDataObject *pdtobj, HKEY hkeyProgID);
+        STDMETHOD(Initialize)(PCIDLIST_ABSOLUTE pidlFolder, IDataObject *pdtobj, HKEY hkeyProgID) override;
 
         // IObjectWithSite
-        virtual HRESULT STDMETHODCALLTYPE SetSite(IUnknown *pUnkSite);
-        virtual HRESULT STDMETHODCALLTYPE GetSite(REFIID riid, void **ppvSite);
+        STDMETHOD(SetSite)(IUnknown *pUnkSite) override;
+        STDMETHOD(GetSite)(REFIID riid, void **ppvSite) override;
 
         DECLARE_REGISTRY_RESOURCEID(IDR_FOLDEROPTIONS)
         DECLARE_NOT_AGGREGATABLE(CFolderOptions)

--- a/dll/win32/shell32/CIDLDataObj.cpp
+++ b/dll/win32/shell32/CIDLDataObj.cpp
@@ -28,10 +28,10 @@ public:
     HRESULT WINAPI Initialize(UINT cfmt, const FORMATETC afmt[]);
 
     // *****************
-    virtual HRESULT WINAPI Next(ULONG celt, FORMATETC *rgelt, ULONG *pceltFethed);
-    virtual HRESULT WINAPI Skip(ULONG celt);
-    virtual HRESULT WINAPI Reset();
-    virtual HRESULT WINAPI Clone(LPENUMFORMATETC* ppenum);
+    STDMETHOD(Next)(ULONG celt, FORMATETC *rgelt, ULONG *pceltFethed) override;
+    STDMETHOD(Skip)(ULONG celt) override;
+    STDMETHOD(Reset)() override;
+    STDMETHOD(Clone)(LPENUMFORMATETC* ppenum) override;
 
 BEGIN_COM_MAP(IEnumFORMATETCImpl)
     COM_INTERFACE_ENTRY_IID(IID_IEnumFORMATETC, IEnumFORMATETC)
@@ -146,22 +146,22 @@ public:
     HRESULT WINAPI Initialize(HWND hwndOwner, PCIDLIST_ABSOLUTE pMyPidl, PCUIDLIST_RELATIVE_ARRAY apidlx, UINT cidlx, BOOL bAddAdditionalFormats);
 
     // *** IDataObject methods ***
-    virtual HRESULT WINAPI GetData(LPFORMATETC pformatetcIn, STGMEDIUM *pmedium);
-    virtual HRESULT WINAPI GetDataHere(LPFORMATETC pformatetc, STGMEDIUM *pmedium);
-    virtual HRESULT WINAPI QueryGetData(LPFORMATETC pformatetc);
-    virtual HRESULT WINAPI GetCanonicalFormatEtc(LPFORMATETC pformatectIn, LPFORMATETC pformatetcOut);
-    virtual HRESULT WINAPI SetData(LPFORMATETC pformatetc, STGMEDIUM *pmedium, BOOL fRelease);
-    virtual HRESULT WINAPI EnumFormatEtc(DWORD dwDirection, IEnumFORMATETC **ppenumFormatEtc);
-    virtual HRESULT WINAPI DAdvise(FORMATETC *pformatetc, DWORD advf, IAdviseSink *pAdvSink, DWORD *pdwConnection);
-    virtual HRESULT WINAPI DUnadvise(DWORD dwConnection);
-    virtual HRESULT WINAPI EnumDAdvise(IEnumSTATDATA **ppenumAdvise);
+    STDMETHOD(GetData)(LPFORMATETC pformatetcIn, STGMEDIUM *pmedium) override;
+    STDMETHOD(GetDataHere)(LPFORMATETC pformatetc, STGMEDIUM *pmedium) override;
+    STDMETHOD(QueryGetData)(LPFORMATETC pformatetc) override;
+    STDMETHOD(GetCanonicalFormatEtc)(LPFORMATETC pformatectIn, LPFORMATETC pformatetcOut) override;
+    STDMETHOD(SetData)(LPFORMATETC pformatetc, STGMEDIUM *pmedium, BOOL fRelease) override;
+    STDMETHOD(EnumFormatEtc)(DWORD dwDirection, IEnumFORMATETC **ppenumFormatEtc) override;
+    STDMETHOD(DAdvise)(FORMATETC *pformatetc, DWORD advf, IAdviseSink *pAdvSink, DWORD *pdwConnection) override;
+    STDMETHOD(DUnadvise)(DWORD dwConnection) override;
+    STDMETHOD(EnumDAdvise)(IEnumSTATDATA **ppenumAdvise) override;
 
     // *** IAsyncOperation methods ***
-    virtual HRESULT WINAPI SetAsyncMode(BOOL fDoOpAsync);
-    virtual HRESULT WINAPI GetAsyncMode(BOOL *pfIsOpAsync);
-    virtual HRESULT WINAPI StartOperation(IBindCtx *pbcReserved);
-    virtual HRESULT WINAPI InOperation(BOOL *pfInAsyncOp);
-    virtual HRESULT WINAPI EndOperation(HRESULT hResult, IBindCtx *pbcReserved, DWORD dwEffects);
+    STDMETHOD(SetAsyncMode)(BOOL fDoOpAsync) override;
+    STDMETHOD(GetAsyncMode)(BOOL *pfIsOpAsync) override;
+    STDMETHOD(StartOperation)(IBindCtx *pbcReserved) override;
+    STDMETHOD(InOperation)(BOOL *pfInAsyncOp) override;
+    STDMETHOD(EndOperation)(HRESULT hResult, IBindCtx *pbcReserved, DWORD dwEffects) override;
 
 BEGIN_COM_MAP(CIDLDataObj)
     COM_INTERFACE_ENTRY_IID(IID_IDataObject, IDataObject)

--- a/dll/win32/shell32/CNewMenu.h
+++ b/dll/win32/shell32/CNewMenu.h
@@ -81,22 +81,22 @@ public:
     ~CNewMenu();
 
     // IObjectWithSite
-    virtual HRESULT STDMETHODCALLTYPE SetSite(IUnknown *pUnkSite);
-    virtual HRESULT STDMETHODCALLTYPE GetSite(REFIID riid, void **ppvSite);
+    STDMETHOD(SetSite)(IUnknown *pUnkSite) override;
+    STDMETHOD(GetSite)(REFIID riid, void **ppvSite) override;
 
     // IContextMenu
-    virtual HRESULT WINAPI QueryContextMenu(HMENU hMenu, UINT indexMenu, UINT idCmdFirst, UINT idCmdLast, UINT uFlags);
-    virtual HRESULT WINAPI InvokeCommand(LPCMINVOKECOMMANDINFO lpcmi);
-    virtual HRESULT WINAPI GetCommandString(UINT_PTR idCommand, UINT uFlags, UINT *lpReserved, LPSTR lpszName, UINT uMaxNameLen);
+    STDMETHOD(QueryContextMenu)(HMENU hMenu, UINT indexMenu, UINT idCmdFirst, UINT idCmdLast, UINT uFlags) override;
+    STDMETHOD(InvokeCommand)(LPCMINVOKECOMMANDINFO lpcmi) override;
+    STDMETHOD(GetCommandString)(UINT_PTR idCommand, UINT uFlags, UINT *lpReserved, LPSTR lpszName, UINT uMaxNameLen) override;
 
     // IContextMenu3
-    virtual HRESULT WINAPI HandleMenuMsg2(UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT *plResult);
+    STDMETHOD(HandleMenuMsg2)(UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT *plResult) override;
 
     // IContextMenu2
-    virtual HRESULT WINAPI HandleMenuMsg(UINT uMsg, WPARAM wParam, LPARAM lParam);
+    STDMETHOD(HandleMenuMsg)(UINT uMsg, WPARAM wParam, LPARAM lParam) override;
 
     // IShellExtInit
-    virtual HRESULT STDMETHODCALLTYPE Initialize(PCIDLIST_ABSOLUTE pidlFolder, IDataObject *pdtobj, HKEY hkeyProgID);
+    STDMETHOD(Initialize)(PCIDLIST_ABSOLUTE pidlFolder, IDataObject *pdtobj, HKEY hkeyProgID) override;
 
 DECLARE_REGISTRY_RESOURCEID(IDR_NEWMENU)
 DECLARE_NOT_AGGREGATABLE(CNewMenu)

--- a/dll/win32/shell32/COpenWithMenu.h
+++ b/dll/win32/shell32/COpenWithMenu.h
@@ -46,15 +46,15 @@ class COpenWithMenu :
         ~COpenWithMenu();
 
         // IContextMenu
-        virtual HRESULT WINAPI QueryContextMenu(HMENU hMenu, UINT indexMenu, UINT idCmdFirst, UINT idCmdLast, UINT uFlags);
-        virtual HRESULT WINAPI InvokeCommand(LPCMINVOKECOMMANDINFO lpcmi);
-        virtual HRESULT WINAPI GetCommandString(UINT_PTR idCommand, UINT uFlags, UINT *lpReserved, LPSTR lpszName, UINT uMaxNameLen);
+        STDMETHOD(QueryContextMenu)(HMENU hMenu, UINT indexMenu, UINT idCmdFirst, UINT idCmdLast, UINT uFlags) override;
+        STDMETHOD(InvokeCommand)(LPCMINVOKECOMMANDINFO lpcmi) override;
+        STDMETHOD(GetCommandString)(UINT_PTR idCommand, UINT uFlags, UINT *lpReserved, LPSTR lpszName, UINT uMaxNameLen) override;
 
         // IContextMenu2
-        virtual HRESULT WINAPI HandleMenuMsg(UINT uMsg, WPARAM wParam, LPARAM lParam);
+        STDMETHOD(HandleMenuMsg)(UINT uMsg, WPARAM wParam, LPARAM lParam) override;
 
         // IShellExtInit
-        virtual HRESULT STDMETHODCALLTYPE Initialize(PCIDLIST_ABSOLUTE pidlFolder, IDataObject *pdtobj, HKEY hkeyProgID);
+        STDMETHOD(Initialize)(PCIDLIST_ABSOLUTE pidlFolder, IDataObject *pdtobj, HKEY hkeyProgID) override;
 
         DECLARE_REGISTRY_RESOURCEID(IDR_OPENWITHMENU)
         DECLARE_NOT_AGGREGATABLE(COpenWithMenu)

--- a/dll/win32/shell32/CQueryAssociations.h
+++ b/dll/win32/shell32/CQueryAssociations.h
@@ -20,11 +20,11 @@ public:
     ~CQueryAssociations();
 
     // *** IQueryAssociations methods ***
-    virtual HRESULT STDMETHODCALLTYPE Init(ASSOCF flags, LPCWSTR pwszAssoc, HKEY hkProgid, HWND hwnd);
-    virtual HRESULT STDMETHODCALLTYPE GetString(ASSOCF flags, ASSOCSTR str, LPCWSTR pwszExtra, LPWSTR pwszOut, DWORD *pcchOut);
-    virtual HRESULT STDMETHODCALLTYPE GetKey(ASSOCF flags, ASSOCKEY key, LPCWSTR pwszExtra, HKEY *phkeyOut);
-    virtual HRESULT STDMETHODCALLTYPE GetData(ASSOCF flags, ASSOCDATA data, LPCWSTR pwszExtra, void *pvOut, DWORD *pcbOut);
-    virtual HRESULT STDMETHODCALLTYPE GetEnum(ASSOCF cfFlags, ASSOCENUM assocenum, LPCWSTR pszExtra, REFIID riid, LPVOID *ppvOut);
+    STDMETHOD(Init)(ASSOCF flags, LPCWSTR pwszAssoc, HKEY hkProgid, HWND hwnd) override;
+    STDMETHOD(GetString)(ASSOCF flags, ASSOCSTR str, LPCWSTR pwszExtra, LPWSTR pwszOut, DWORD *pcchOut) override;
+    STDMETHOD(GetKey)(ASSOCF flags, ASSOCKEY key, LPCWSTR pwszExtra, HKEY *phkeyOut) override;
+    STDMETHOD(GetData)(ASSOCF flags, ASSOCDATA data, LPCWSTR pwszExtra, void *pvOut, DWORD *pcbOut) override;
+    STDMETHOD(GetEnum)(ASSOCF cfFlags, ASSOCENUM assocenum, LPCWSTR pszExtra, REFIID riid, LPVOID *ppvOut) override;
 
 DECLARE_REGISTRY_RESOURCEID(IDR_QUERYASSOCIATIONS)
 DECLARE_NOT_AGGREGATABLE(CQueryAssociations)

--- a/dll/win32/shell32/CShellDispatch.h
+++ b/dll/win32/shell32/CShellDispatch.h
@@ -26,58 +26,57 @@ public:
     HRESULT Initialize();
 
     // *** IShellDispatch methods ***
-    virtual HRESULT STDMETHODCALLTYPE get_Application(IDispatch **ppid);
-    virtual HRESULT STDMETHODCALLTYPE get_Parent(IDispatch **ppid);
-    virtual HRESULT STDMETHODCALLTYPE NameSpace(VARIANT vDir, Folder **ppsdf);
-    virtual HRESULT STDMETHODCALLTYPE BrowseForFolder(LONG Hwnd, BSTR Title, LONG Options, VARIANT RootFolder, Folder **ppsdf);
-    virtual HRESULT STDMETHODCALLTYPE Windows(IDispatch **ppid);
-    virtual HRESULT STDMETHODCALLTYPE Open(VARIANT vDir);
-    virtual HRESULT STDMETHODCALLTYPE Explore(VARIANT vDir);
-    virtual HRESULT STDMETHODCALLTYPE MinimizeAll();
-    virtual HRESULT STDMETHODCALLTYPE UndoMinimizeALL();
-    virtual HRESULT STDMETHODCALLTYPE FileRun();
-    virtual HRESULT STDMETHODCALLTYPE CascadeWindows();
-    virtual HRESULT STDMETHODCALLTYPE TileVertically();
-    virtual HRESULT STDMETHODCALLTYPE TileHorizontally();
-    virtual HRESULT STDMETHODCALLTYPE ShutdownWindows();
-    virtual HRESULT STDMETHODCALLTYPE Suspend();
-    virtual HRESULT STDMETHODCALLTYPE EjectPC();
-    virtual HRESULT STDMETHODCALLTYPE SetTime();
-    virtual HRESULT STDMETHODCALLTYPE TrayProperties();
-    virtual HRESULT STDMETHODCALLTYPE Help();
-    virtual HRESULT STDMETHODCALLTYPE FindFiles();
-    virtual HRESULT STDMETHODCALLTYPE FindComputer();
-    virtual HRESULT STDMETHODCALLTYPE RefreshMenu();
-    virtual HRESULT STDMETHODCALLTYPE ControlPanelItem(BSTR szDir);
+    STDMETHOD(get_Application)(IDispatch **ppid) override;
+    STDMETHOD(get_Parent)(IDispatch **ppid) override;
+    STDMETHOD(NameSpace)(VARIANT vDir, Folder **ppsdf) override;
+    STDMETHOD(BrowseForFolder)(LONG Hwnd, BSTR Title, LONG Options, VARIANT RootFolder, Folder **ppsdf) override;
+    STDMETHOD(Windows)(IDispatch **ppid) override;
+    STDMETHOD(Open)(VARIANT vDir) override;
+    STDMETHOD(Explore)(VARIANT vDir) override;
+    STDMETHOD(MinimizeAll)() override;
+    STDMETHOD(UndoMinimizeALL)() override;
+    STDMETHOD(FileRun)() override;
+    STDMETHOD(CascadeWindows)() override;
+    STDMETHOD(TileVertically)() override;
+    STDMETHOD(TileHorizontally)() override;
+    STDMETHOD(ShutdownWindows)() override;
+    STDMETHOD(Suspend)() override;
+    STDMETHOD(EjectPC)() override;
+    STDMETHOD(SetTime)() override;
+    STDMETHOD(TrayProperties)() override;
+    STDMETHOD(Help)() override;
+    STDMETHOD(FindFiles)() override;
+    STDMETHOD(FindComputer)() override;
+    STDMETHOD(RefreshMenu)() override;
+    STDMETHOD(ControlPanelItem)(BSTR szDir) override;
 
     // *** IShellDispatch2 methods ***
-    virtual HRESULT STDMETHODCALLTYPE IsRestricted(BSTR group, BSTR restriction, LONG *value);
-    virtual HRESULT STDMETHODCALLTYPE ShellExecute(BSTR file, VARIANT args, VARIANT dir, VARIANT op, VARIANT show);
-    virtual HRESULT STDMETHODCALLTYPE FindPrinter(BSTR name, BSTR location, BSTR model);
-    virtual HRESULT STDMETHODCALLTYPE GetSystemInformation(BSTR name, VARIANT *ret);
-    virtual HRESULT STDMETHODCALLTYPE ServiceStart(BSTR service, VARIANT persistent, VARIANT *ret);
-    virtual HRESULT STDMETHODCALLTYPE ServiceStop(BSTR service, VARIANT persistent, VARIANT *ret);
-    virtual HRESULT STDMETHODCALLTYPE IsServiceRunning(BSTR service, VARIANT *running);
-    virtual HRESULT STDMETHODCALLTYPE CanStartStopService(BSTR service, VARIANT *ret);
-    virtual HRESULT STDMETHODCALLTYPE ShowBrowserBar(BSTR clsid, VARIANT show, VARIANT *ret);
+    STDMETHOD(IsRestricted)(BSTR group, BSTR restriction, LONG *value) override;
+    STDMETHOD(ShellExecute)(BSTR file, VARIANT args, VARIANT dir, VARIANT op, VARIANT show) override;
+    STDMETHOD(FindPrinter)(BSTR name, BSTR location, BSTR model) override;
+    STDMETHOD(GetSystemInformation)(BSTR name, VARIANT *ret) override;
+    STDMETHOD(ServiceStart)(BSTR service, VARIANT persistent, VARIANT *ret) override;
+    STDMETHOD(ServiceStop)(BSTR service, VARIANT persistent, VARIANT *ret) override;
+    STDMETHOD(IsServiceRunning)(BSTR service, VARIANT *running) override;
+    STDMETHOD(CanStartStopService)(BSTR service, VARIANT *ret) override;
+    STDMETHOD(ShowBrowserBar)(BSTR clsid, VARIANT show, VARIANT *ret) override;
 
     // *** IShellDispatch3 methods ***
-    virtual HRESULT STDMETHODCALLTYPE AddToRecent(VARIANT file, BSTR category);
+    STDMETHOD(AddToRecent)(VARIANT file, BSTR category) override;
 
     // *** IShellDispatch4 methods ***
-    virtual HRESULT STDMETHODCALLTYPE WindowsSecurity();
-    virtual HRESULT STDMETHODCALLTYPE ToggleDesktop();
-    virtual HRESULT STDMETHODCALLTYPE ExplorerPolicy(BSTR policy, VARIANT *value);
-    virtual HRESULT STDMETHODCALLTYPE GetSetting(LONG setting, VARIANT_BOOL *result);
+    STDMETHOD(WindowsSecurity)() override;
+    STDMETHOD(ToggleDesktop)() override;
+    STDMETHOD(ExplorerPolicy)(BSTR policy, VARIANT *value) override;
+    STDMETHOD(GetSetting)(LONG setting, VARIANT_BOOL *result) override;
 
     // *** IObjectSafety methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetInterfaceSafetyOptions(REFIID riid, DWORD *pdwSupportedOptions, DWORD *pdwEnabledOptions);
-    virtual HRESULT STDMETHODCALLTYPE SetInterfaceSafetyOptions(REFIID riid, DWORD dwOptionSetMask, DWORD dwEnabledOptions);
+    STDMETHOD(GetInterfaceSafetyOptions)(REFIID riid, DWORD *pdwSupportedOptions, DWORD *pdwEnabledOptions) override;
+    STDMETHOD(SetInterfaceSafetyOptions)(REFIID riid, DWORD dwOptionSetMask, DWORD dwEnabledOptions) override;
 
     // *** IObjectWithSite methods ***
-    virtual HRESULT STDMETHODCALLTYPE SetSite(IUnknown *pUnkSite);
-    virtual HRESULT STDMETHODCALLTYPE GetSite(REFIID riid, PVOID *ppvSite);
-
+    STDMETHOD(SetSite)(IUnknown *pUnkSite) override;
+    STDMETHOD(GetSite)(REFIID riid, PVOID *ppvSite) override;
 
 DECLARE_REGISTRY_RESOURCEID(IDR_SHELL)
 DECLARE_NOT_AGGREGATABLE(CShellDispatch)

--- a/dll/win32/shell32/CShellItem.h
+++ b/dll/win32/shell32/CShellItem.h
@@ -39,16 +39,16 @@ public:
     HRESULT get_shellfolder(IBindCtx *pbc, REFIID riid, void **ppvOut);
 
     // IShellItem
-    virtual HRESULT WINAPI BindToHandler(IBindCtx *pbc, REFGUID rbhid, REFIID riid, void **ppvOut);
-    virtual HRESULT WINAPI GetParent(IShellItem **ppsi);
-    virtual HRESULT WINAPI GetDisplayName(SIGDN sigdnName, LPWSTR *ppszName);
-    virtual HRESULT WINAPI GetAttributes(SFGAOF sfgaoMask, SFGAOF *psfgaoAttribs);
-    virtual HRESULT WINAPI Compare(IShellItem *oth, SICHINTF hint, int *piOrder);
+    STDMETHOD(BindToHandler)(IBindCtx *pbc, REFGUID rbhid, REFIID riid, void **ppvOut) override;
+    STDMETHOD(GetParent)(IShellItem **ppsi) override;
+    STDMETHOD(GetDisplayName)(SIGDN sigdnName, LPWSTR *ppszName) override;
+    STDMETHOD(GetAttributes)(SFGAOF sfgaoMask, SFGAOF *psfgaoAttribs) override;
+    STDMETHOD(Compare)(IShellItem *oth, SICHINTF hint, int *piOrder) override;
 
     // IPersistIDList
-    virtual HRESULT WINAPI GetClassID(CLSID *pClassID);
-    virtual HRESULT WINAPI SetIDList(PCIDLIST_ABSOLUTE pidl);
-    virtual HRESULT WINAPI GetIDList(PIDLIST_ABSOLUTE *ppidl);
+    STDMETHOD(GetClassID)(CLSID *pClassID) override;
+    STDMETHOD(SetIDList)(PCIDLIST_ABSOLUTE pidl) override;
+    STDMETHOD(GetIDList)(PIDLIST_ABSOLUTE *ppidl) override;
 
 DECLARE_NO_REGISTRY()
 DECLARE_NOT_AGGREGATABLE(CShellItem)

--- a/dll/win32/shell32/CShellLink.h
+++ b/dll/win32/shell32/CShellLink.h
@@ -120,96 +120,96 @@ public:
     void OnDestroy(HWND hwndDlg);
 
     // IPersistFile
-    virtual HRESULT STDMETHODCALLTYPE GetClassID(CLSID *pclsid);
-    virtual HRESULT STDMETHODCALLTYPE IsDirty();
-    virtual HRESULT STDMETHODCALLTYPE Load(LPCOLESTR pszFileName, DWORD dwMode);
-    virtual HRESULT STDMETHODCALLTYPE Save(LPCOLESTR pszFileName, BOOL fRemember);
-    virtual HRESULT STDMETHODCALLTYPE SaveCompleted(LPCOLESTR pszFileName);
-    virtual HRESULT STDMETHODCALLTYPE GetCurFile(LPOLESTR *ppszFileName);
+    STDMETHOD(GetClassID)(CLSID *pclsid) override;
+    STDMETHOD(IsDirty)() override;
+    STDMETHOD(Load)(LPCOLESTR pszFileName, DWORD dwMode) override;
+    STDMETHOD(Save)(LPCOLESTR pszFileName, BOOL fRemember) override;
+    STDMETHOD(SaveCompleted)(LPCOLESTR pszFileName) override;
+    STDMETHOD(GetCurFile)(LPOLESTR *ppszFileName) override;
 
     // IPersistStream
-    // virtual HRESULT STDMETHODCALLTYPE GetClassID(CLSID *pclsid);
-    // virtual HRESULT STDMETHODCALLTYPE IsDirty();
-    virtual HRESULT STDMETHODCALLTYPE Load(IStream *stm);
-    virtual HRESULT STDMETHODCALLTYPE Save(IStream *stm, BOOL fClearDirty);
-    virtual HRESULT STDMETHODCALLTYPE GetSizeMax(ULARGE_INTEGER *pcbSize);
+    // STDMETHOD(GetClassID)(CLSID *pclsid) override;
+    // STDMETHOD(IsDirty)() override;
+    STDMETHOD(Load)(IStream *stm) override;
+    STDMETHOD(Save)(IStream *stm, BOOL fClearDirty) override;
+    STDMETHOD(GetSizeMax)(ULARGE_INTEGER *pcbSize) override;
 
     // IShellLinkA
-    virtual HRESULT STDMETHODCALLTYPE GetPath(LPSTR pszFile, INT cchMaxPath, WIN32_FIND_DATAA *pfd, DWORD fFlags);
-    virtual HRESULT STDMETHODCALLTYPE GetIDList(PIDLIST_ABSOLUTE *ppidl);
-    virtual HRESULT STDMETHODCALLTYPE SetIDList(PCIDLIST_ABSOLUTE pidl);
-    virtual HRESULT STDMETHODCALLTYPE GetDescription(LPSTR pszName, INT cchMaxName);
-    virtual HRESULT STDMETHODCALLTYPE SetDescription(LPCSTR pszName);
-    virtual HRESULT STDMETHODCALLTYPE GetWorkingDirectory(LPSTR pszDir, INT cchMaxPath);
-    virtual HRESULT STDMETHODCALLTYPE SetWorkingDirectory(LPCSTR pszDir);
-    virtual HRESULT STDMETHODCALLTYPE GetArguments(LPSTR pszArgs, INT cchMaxPath);
-    virtual HRESULT STDMETHODCALLTYPE SetArguments(LPCSTR pszArgs);
-    virtual HRESULT STDMETHODCALLTYPE GetHotkey(WORD *pwHotkey);
-    virtual HRESULT STDMETHODCALLTYPE SetHotkey(WORD wHotkey);
-    virtual HRESULT STDMETHODCALLTYPE GetShowCmd(INT *piShowCmd);
-    virtual HRESULT STDMETHODCALLTYPE SetShowCmd(INT iShowCmd);
-    virtual HRESULT STDMETHODCALLTYPE GetIconLocation(LPSTR pszIconPath, INT cchIconPath, INT *piIcon);
-    virtual HRESULT STDMETHODCALLTYPE SetIconLocation(LPCSTR pszIconPath, INT iIcon);
-    virtual HRESULT STDMETHODCALLTYPE SetRelativePath(LPCSTR pszPathRel, DWORD dwReserved);
-    virtual HRESULT STDMETHODCALLTYPE Resolve(HWND hwnd, DWORD fFlags);
-    virtual HRESULT STDMETHODCALLTYPE SetPath(LPCSTR pszFile);
+    STDMETHOD(GetPath)(LPSTR pszFile, INT cchMaxPath, WIN32_FIND_DATAA *pfd, DWORD fFlags) override;
+    STDMETHOD(GetIDList)(PIDLIST_ABSOLUTE *ppidl) override;
+    STDMETHOD(SetIDList)(PCIDLIST_ABSOLUTE pidl) override;
+    STDMETHOD(GetDescription)(LPSTR pszName, INT cchMaxName) override;
+    STDMETHOD(SetDescription)(LPCSTR pszName) override;
+    STDMETHOD(GetWorkingDirectory)(LPSTR pszDir, INT cchMaxPath) override;
+    STDMETHOD(SetWorkingDirectory)(LPCSTR pszDir) override;
+    STDMETHOD(GetArguments)(LPSTR pszArgs, INT cchMaxPath) override;
+    STDMETHOD(SetArguments)(LPCSTR pszArgs) override;
+    STDMETHOD(GetHotkey)(WORD *pwHotkey) override;
+    STDMETHOD(SetHotkey)(WORD wHotkey) override;
+    STDMETHOD(GetShowCmd)(INT *piShowCmd) override;
+    STDMETHOD(SetShowCmd)(INT iShowCmd) override;
+    STDMETHOD(GetIconLocation)(LPSTR pszIconPath, INT cchIconPath, INT *piIcon) override;
+    STDMETHOD(SetIconLocation)(LPCSTR pszIconPath, INT iIcon) override;
+    STDMETHOD(SetRelativePath)(LPCSTR pszPathRel, DWORD dwReserved) override;
+    STDMETHOD(Resolve)(HWND hwnd, DWORD fFlags) override;
+    STDMETHOD(SetPath)(LPCSTR pszFile) override;
 
     // IShellLinkW
-    virtual HRESULT STDMETHODCALLTYPE GetPath(LPWSTR pszFile, INT cchMaxPath, WIN32_FIND_DATAW *pfd, DWORD fFlags);
-    // virtual HRESULT STDMETHODCALLTYPE GetIDList(PIDLIST_ABSOLUTE *ppidl);
-    // virtual HRESULT STDMETHODCALLTYPE SetIDList(PCIDLIST_ABSOLUTE pidl);
-    virtual HRESULT STDMETHODCALLTYPE GetDescription(LPWSTR pszName, INT cchMaxName);
-    virtual HRESULT STDMETHODCALLTYPE SetDescription(LPCWSTR pszName);
-    virtual HRESULT STDMETHODCALLTYPE GetWorkingDirectory(LPWSTR pszDir, INT cchMaxPath);
-    virtual HRESULT STDMETHODCALLTYPE SetWorkingDirectory(LPCWSTR pszDir);
-    virtual HRESULT STDMETHODCALLTYPE GetArguments(LPWSTR pszArgs, INT cchMaxPath);
-    virtual HRESULT STDMETHODCALLTYPE SetArguments(LPCWSTR pszArgs);
-    // virtual HRESULT STDMETHODCALLTYPE GetHotkey(WORD *pwHotkey);
-    // virtual HRESULT STDMETHODCALLTYPE SetHotkey(WORD wHotkey);
-    // virtual HRESULT STDMETHODCALLTYPE GetShowCmd(INT *piShowCmd);
-    // virtual HRESULT STDMETHODCALLTYPE SetShowCmd(INT iShowCmd);
-    virtual HRESULT STDMETHODCALLTYPE GetIconLocation(LPWSTR pszIconPath, INT cchIconPath, INT *piIcon);
-    virtual HRESULT STDMETHODCALLTYPE SetIconLocation(LPCWSTR pszIconPath, INT iIcon);
-    virtual HRESULT STDMETHODCALLTYPE SetRelativePath(LPCWSTR pszPathRel, DWORD dwReserved);
-    // virtual HRESULT STDMETHODCALLTYPE Resolve(HWND hwnd, DWORD fFlags);
-    virtual HRESULT STDMETHODCALLTYPE SetPath(LPCWSTR pszFile);
+    STDMETHOD(GetPath)(LPWSTR pszFile, INT cchMaxPath, WIN32_FIND_DATAW *pfd, DWORD fFlags) override;
+    // STDMETHOD(GetIDList)(PIDLIST_ABSOLUTE *ppidl) override;
+    // STDMETHOD(SetIDList)(PCIDLIST_ABSOLUTE pidl) override;
+    STDMETHOD(GetDescription)(LPWSTR pszName, INT cchMaxName) override;
+    STDMETHOD(SetDescription)(LPCWSTR pszName) override;
+    STDMETHOD(GetWorkingDirectory)(LPWSTR pszDir, INT cchMaxPath) override;
+    STDMETHOD(SetWorkingDirectory)(LPCWSTR pszDir) override;
+    STDMETHOD(GetArguments)(LPWSTR pszArgs, INT cchMaxPath) override;
+    STDMETHOD(SetArguments)(LPCWSTR pszArgs) override;
+    // STDMETHOD(GetHotkey)(WORD *pwHotkey) override;
+    // STDMETHOD(SetHotkey)(WORD wHotkey) override;
+    // STDMETHOD(GetShowCmd)(INT *piShowCmd) override;
+    // STDMETHOD(SetShowCmd)(INT iShowCmd) override;
+    STDMETHOD(GetIconLocation)(LPWSTR pszIconPath, INT cchIconPath, INT *piIcon) override;
+    STDMETHOD(SetIconLocation)(LPCWSTR pszIconPath, INT iIcon) override;
+    STDMETHOD(SetRelativePath)(LPCWSTR pszPathRel, DWORD dwReserved) override;
+    // STDMETHOD(Resolve)(HWND hwnd, DWORD fFlags) override;
+    STDMETHOD(SetPath)(LPCWSTR pszFile) override;
 
     // IShellLinkDataList
-    virtual HRESULT STDMETHODCALLTYPE AddDataBlock(void *pDataBlock);
-    virtual HRESULT STDMETHODCALLTYPE CopyDataBlock(DWORD dwSig, void **ppDataBlock);
-    virtual HRESULT STDMETHODCALLTYPE RemoveDataBlock(DWORD dwSig);
-    virtual HRESULT STDMETHODCALLTYPE GetFlags(DWORD *pdwFlags);
-    virtual HRESULT STDMETHODCALLTYPE SetFlags(DWORD dwFlags);
+    STDMETHOD(AddDataBlock)(void *pDataBlock) override;
+    STDMETHOD(CopyDataBlock)(DWORD dwSig, void **ppDataBlock) override;
+    STDMETHOD(RemoveDataBlock)(DWORD dwSig) override;
+    STDMETHOD(GetFlags)(DWORD *pdwFlags) override;
+    STDMETHOD(SetFlags)(DWORD dwFlags) override;
 
     // IExtractIconA
-    virtual HRESULT STDMETHODCALLTYPE Extract(PCSTR pszFile, UINT nIconIndex, HICON *phiconLarge, HICON *phiconSmall, UINT nIconSize);
-    virtual HRESULT STDMETHODCALLTYPE GetIconLocation(UINT uFlags, PSTR pszIconFile, UINT cchMax, int *piIndex, UINT *pwFlags);
+    STDMETHOD(Extract)(PCSTR pszFile, UINT nIconIndex, HICON *phiconLarge, HICON *phiconSmall, UINT nIconSize) override;
+    STDMETHOD(GetIconLocation)(UINT uFlags, PSTR pszIconFile, UINT cchMax, int *piIndex, UINT *pwFlags) override;
 
     // IExtractIconW
-    virtual HRESULT STDMETHODCALLTYPE Extract(PCWSTR pszFile, UINT nIconIndex, HICON *phiconLarge, HICON *phiconSmall, UINT nIconSize);
-    virtual HRESULT STDMETHODCALLTYPE GetIconLocation(UINT uFlags, PWSTR pszIconFile, UINT cchMax, int *piIndex, UINT *pwFlags);
+    STDMETHOD(Extract)(PCWSTR pszFile, UINT nIconIndex, HICON *phiconLarge, HICON *phiconSmall, UINT nIconSize) override;
+    STDMETHOD(GetIconLocation)(UINT uFlags, PWSTR pszIconFile, UINT cchMax, int *piIndex, UINT *pwFlags) override;
 
     // IShellExtInit
-    virtual HRESULT STDMETHODCALLTYPE Initialize(PCIDLIST_ABSOLUTE pidlFolder, IDataObject *pdtobj, HKEY hkeyProgID);
+    STDMETHOD(Initialize)(PCIDLIST_ABSOLUTE pidlFolder, IDataObject *pdtobj, HKEY hkeyProgID) override;
 
     // IContextMenu
-    virtual HRESULT STDMETHODCALLTYPE QueryContextMenu(HMENU hmenu, UINT indexMenu, UINT idCmdFirst, UINT idCmdLast, UINT uFlags);
-    virtual HRESULT STDMETHODCALLTYPE InvokeCommand(LPCMINVOKECOMMANDINFO lpici);
-    virtual HRESULT STDMETHODCALLTYPE GetCommandString(UINT_PTR idCmd, UINT uType, UINT *pwReserved, LPSTR pszName, UINT cchMax);
+    STDMETHOD(QueryContextMenu)(HMENU hmenu, UINT indexMenu, UINT idCmdFirst, UINT idCmdLast, UINT uFlags) override;
+    STDMETHOD(InvokeCommand)(LPCMINVOKECOMMANDINFO lpici) override;
+    STDMETHOD(GetCommandString)(UINT_PTR idCmd, UINT uType, UINT *pwReserved, LPSTR pszName, UINT cchMax) override;
 
     // IShellPropSheetExt
-    virtual HRESULT STDMETHODCALLTYPE AddPages(LPFNADDPROPSHEETPAGE pfnAddPage, LPARAM lParam);
-    virtual HRESULT STDMETHODCALLTYPE ReplacePage(UINT uPageID, LPFNADDPROPSHEETPAGE pfnReplacePage, LPARAM lParam);
+    STDMETHOD(AddPages)(LPFNADDPROPSHEETPAGE pfnAddPage, LPARAM lParam) override;
+    STDMETHOD(ReplacePage)(UINT uPageID, LPFNADDPROPSHEETPAGE pfnReplacePage, LPARAM lParam) override;
 
     // IObjectWithSite
-    virtual HRESULT STDMETHODCALLTYPE SetSite(IUnknown *punk);
-    virtual HRESULT STDMETHODCALLTYPE GetSite(REFIID iid, void **ppvSite);
+    STDMETHOD(SetSite)(IUnknown *punk) override;
+    STDMETHOD(GetSite)(REFIID iid, void **ppvSite) override;
 
     // IDropTarget
-    virtual HRESULT STDMETHODCALLTYPE DragEnter(IDataObject *pDataObject, DWORD dwKeyState, POINTL pt, DWORD *pdwEffect);
-    virtual HRESULT STDMETHODCALLTYPE DragOver(DWORD dwKeyState, POINTL pt, DWORD *pdwEffect);
-    virtual HRESULT STDMETHODCALLTYPE DragLeave();
-    virtual HRESULT STDMETHODCALLTYPE Drop(IDataObject *pDataObject, DWORD dwKeyState, POINTL pt, DWORD *pdwEffect);
+    STDMETHOD(DragEnter)(IDataObject *pDataObject, DWORD dwKeyState, POINTL pt, DWORD *pdwEffect) override;
+    STDMETHOD(DragOver)(DWORD dwKeyState, POINTL pt, DWORD *pdwEffect) override;
+    STDMETHOD(DragLeave)() override;
+    STDMETHOD(Drop)(IDataObject *pDataObject, DWORD dwKeyState, POINTL pt, DWORD *pdwEffect) override;
 
 DECLARE_REGISTRY_RESOURCEID(IDR_SHELLLINK)
 DECLARE_NOT_AGGREGATABLE(CShellLink)

--- a/dll/win32/shell32/CUserNotification.h
+++ b/dll/win32/shell32/CUserNotification.h
@@ -66,35 +66,35 @@ public:
     ~CUserNotification();
 
     // IUserNotification
-    virtual HRESULT STDMETHODCALLTYPE SetBalloonInfo(
+    STDMETHOD(SetBalloonInfo)(
         IN LPCWSTR pszTitle,
         IN LPCWSTR pszText,
-        IN DWORD dwInfoFlags);
+        IN DWORD dwInfoFlags) override;
 
-    virtual HRESULT STDMETHODCALLTYPE SetBalloonRetry(
+    STDMETHOD(SetBalloonRetry)(
         IN DWORD dwShowTime,  // Time intervals in milliseconds
         IN DWORD dwInterval,
-        IN UINT cRetryCount);
+        IN UINT cRetryCount) override;
 
-    virtual HRESULT STDMETHODCALLTYPE SetIconInfo(
+    STDMETHOD(SetIconInfo)(
         IN HICON hIcon,
-        IN LPCWSTR pszToolTip);
+        IN LPCWSTR pszToolTip) override;
 
     // Blocks until the notification times out.
-    virtual HRESULT STDMETHODCALLTYPE Show(
+    STDMETHOD(Show)(
         IN IQueryContinue* pqc,
-        IN DWORD dwContinuePollInterval);
+        IN DWORD dwContinuePollInterval) override;
 
-    virtual HRESULT STDMETHODCALLTYPE PlaySound(
-        IN LPCWSTR pszSoundName);
+    STDMETHOD(PlaySound)(
+        IN LPCWSTR pszSoundName) override;
 
 #if 0
     // IUserNotification2
     // Blocks until the notification times out.
-    virtual HRESULT STDMETHODCALLTYPE Show(
+    STDMETHOD(Show)(
         IN IQueryContinue* pqc,
         IN DWORD dwContinuePollInterval,
-        IN IUserNotificationCallback* pSink);
+        IN IUserNotificationCallback* pSink) override;
 #endif
 
     DECLARE_REGISTRY_RESOURCEID(IDR_USERNOTIFICATION)

--- a/dll/win32/shell32/dialogs/drvdefext.h
+++ b/dll/win32/shell32/dialogs/drvdefext.h
@@ -44,20 +44,20 @@ public:
 	~CDrvDefExt();
 
 	// IShellExtInit
-	virtual HRESULT STDMETHODCALLTYPE Initialize(PCIDLIST_ABSOLUTE pidlFolder, IDataObject *pDataObj, HKEY hkeyProgID);
+	STDMETHOD(Initialize)(PCIDLIST_ABSOLUTE pidlFolder, IDataObject *pDataObj, HKEY hkeyProgID) override;
 
     // IContextMenu
-	virtual HRESULT WINAPI QueryContextMenu(HMENU hmenu, UINT indexMenu, UINT idCmdFirst, UINT idCmdLast, UINT uFlags);
-	virtual HRESULT WINAPI InvokeCommand(LPCMINVOKECOMMANDINFO lpici);
-	virtual HRESULT WINAPI GetCommandString(UINT_PTR idCmd, UINT uType, UINT *pwReserved, LPSTR pszName, UINT cchMax);
+	STDMETHOD(QueryContextMenu)(HMENU hmenu, UINT indexMenu, UINT idCmdFirst, UINT idCmdLast, UINT uFlags) override;
+	STDMETHOD(InvokeCommand)(LPCMINVOKECOMMANDINFO lpici) override;
+	STDMETHOD(GetCommandString)(UINT_PTR idCmd, UINT uType, UINT *pwReserved, LPSTR pszName, UINT cchMax) override;
 
 	// IShellPropSheetExt
-	virtual HRESULT WINAPI AddPages(LPFNADDPROPSHEETPAGE pfnAddPage, LPARAM lParam);
-	virtual HRESULT WINAPI ReplacePage(UINT uPageID, LPFNADDPROPSHEETPAGE pfnReplacePage, LPARAM lParam);
+	STDMETHOD(AddPages)(LPFNADDPROPSHEETPAGE pfnAddPage, LPARAM lParam) override;
+	STDMETHOD(ReplacePage)(UINT uPageID, LPFNADDPROPSHEETPAGE pfnReplacePage, LPARAM lParam) override;
 
     // IObjectWithSite
-	virtual HRESULT WINAPI SetSite(IUnknown *punk);
-	virtual HRESULT WINAPI GetSite(REFIID iid, void **ppvSite);
+	STDMETHOD(SetSite)(IUnknown *punk) override;
+	STDMETHOD(GetSite)(REFIID iid, void **ppvSite) override;
 
 DECLARE_REGISTRY_RESOURCEID(IDR_DRVDEFEXT)
 DECLARE_NOT_AGGREGATABLE(CDrvDefExt)

--- a/dll/win32/shell32/dialogs/filedefext.h
+++ b/dll/win32/shell32/dialogs/filedefext.h
@@ -105,20 +105,20 @@ public:
     void UpdateFolderIcon(HWND hwndDlg);
 
 	// IShellExtInit
-	virtual HRESULT STDMETHODCALLTYPE Initialize(PCIDLIST_ABSOLUTE pidlFolder, IDataObject *pdtobj, HKEY hkeyProgID);
+	STDMETHOD(Initialize)(PCIDLIST_ABSOLUTE pidlFolder, IDataObject *pdtobj, HKEY hkeyProgID) override;
 
     // IContextMenu
-	virtual HRESULT WINAPI QueryContextMenu(HMENU hmenu, UINT indexMenu, UINT idCmdFirst, UINT idCmdLast, UINT uFlags);
-	virtual HRESULT WINAPI InvokeCommand(LPCMINVOKECOMMANDINFO lpici);
-	virtual HRESULT WINAPI GetCommandString(UINT_PTR idCmd, UINT uType, UINT *pwReserved, LPSTR pszName, UINT cchMax);
+	STDMETHOD(QueryContextMenu)(HMENU hmenu, UINT indexMenu, UINT idCmdFirst, UINT idCmdLast, UINT uFlags) override;
+	STDMETHOD(InvokeCommand)(LPCMINVOKECOMMANDINFO lpici) override;
+	STDMETHOD(GetCommandString)(UINT_PTR idCmd, UINT uType, UINT *pwReserved, LPSTR pszName, UINT cchMax) override;
 
 	// IShellPropSheetExt
-	virtual HRESULT WINAPI AddPages(LPFNADDPROPSHEETPAGE pfnAddPage, LPARAM lParam);
-	virtual HRESULT WINAPI ReplacePage(UINT uPageID, LPFNADDPROPSHEETPAGE pfnReplacePage, LPARAM lParam);
+	STDMETHOD(AddPages)(LPFNADDPROPSHEETPAGE pfnAddPage, LPARAM lParam) override;
+	STDMETHOD(ReplacePage)(UINT uPageID, LPFNADDPROPSHEETPAGE pfnReplacePage, LPARAM lParam) override;
 
     // IObjectWithSite
-	virtual HRESULT WINAPI SetSite(IUnknown *punk);
-	virtual HRESULT WINAPI GetSite(REFIID iid, void **ppvSite);
+	STDMETHOD(SetSite)(IUnknown *punk) override;
+	STDMETHOD(GetSite)(REFIID iid, void **ppvSite) override;
 
 DECLARE_REGISTRY_RESOURCEID(IDR_FILEDEFEXT)
 DECLARE_NOT_AGGREGATABLE(CFileDefExt)

--- a/dll/win32/shell32/droptargets/CFSDropTarget.h
+++ b/dll/win32/shell32/droptargets/CFSDropTarget.h
@@ -51,14 +51,14 @@ class CFSDropTarget :
         HRESULT Initialize(LPWSTR PathTarget);
 
         // IDropTarget
-        virtual HRESULT WINAPI DragEnter(IDataObject *pDataObject, DWORD dwKeyState, POINTL pt, DWORD *pdwEffect);
-        virtual HRESULT WINAPI DragOver(DWORD dwKeyState, POINTL pt, DWORD *pdwEffect);
-        virtual HRESULT WINAPI DragLeave();
-        virtual HRESULT WINAPI Drop(IDataObject *pDataObject, DWORD dwKeyState, POINTL pt, DWORD *pdwEffect);
+        STDMETHOD(DragEnter)(IDataObject *pDataObject, DWORD dwKeyState, POINTL pt, DWORD *pdwEffect) override;
+        STDMETHOD(DragOver)(DWORD dwKeyState, POINTL pt, DWORD *pdwEffect) override;
+        STDMETHOD(DragLeave)() override;
+        STDMETHOD(Drop)(IDataObject *pDataObject, DWORD dwKeyState, POINTL pt, DWORD *pdwEffect) override;
 
         // IObjectWithSite
-        virtual HRESULT STDMETHODCALLTYPE SetSite(IUnknown *pUnkSite);
-        virtual HRESULT STDMETHODCALLTYPE GetSite(REFIID riid, void **ppvSite);
+        STDMETHOD(SetSite)(IUnknown *pUnkSite) override;
+        STDMETHOD(GetSite)(REFIID riid, void **ppvSite) override;
 
         DECLARE_NOT_AGGREGATABLE(CFSDropTarget)
 

--- a/dll/win32/shell32/droptargets/CRecyclerDropTarget.cpp
+++ b/dll/win32/shell32/droptargets/CRecyclerDropTarget.cpp
@@ -102,15 +102,14 @@ class CRecyclerDropTarget :
         }
 
     public:
-
         CRecyclerDropTarget()
         {
             fAcceptFmt = FALSE;
             cfShellIDList = RegisterClipboardFormatW(CFSTR_SHELLIDLIST);
         }
 
-        STDMETHOD(DragEnter)(IDataObject *pDataObject,
-                             DWORD dwKeyState, POINTL pt, DWORD *pdwEffect) override
+        STDMETHODIMP
+        DragEnter(IDataObject *pDataObject, DWORD dwKeyState, POINTL pt, DWORD *pdwEffect) override
         {
             TRACE("Recycle bin drag over (%p)\n", this);
             /* The recycle bin accepts pretty much everything, and sets a CSIDL flag. */
@@ -120,7 +119,8 @@ class CRecyclerDropTarget :
             return S_OK;
         }
 
-        STDMETHOD(DragOver)(DWORD dwKeyState, POINTL pt, DWORD *pdwEffect) override
+        STDMETHODIMP
+        DragOver(DWORD dwKeyState, POINTL pt, DWORD *pdwEffect) override
         {
             TRACE("(%p)\n", this);
 
@@ -132,7 +132,8 @@ class CRecyclerDropTarget :
             return S_OK;
         }
 
-        STDMETHOD(DragLeave)() override
+        STDMETHODIMP
+        DragLeave() override
         {
             TRACE("(%p)\n", this);
 
@@ -141,8 +142,8 @@ class CRecyclerDropTarget :
             return S_OK;
         }
 
-        STDMETHOD(Drop)(IDataObject *pDataObject,
-                        DWORD grfKeyState, POINTL pt, DWORD *pdwEffect) override
+        STDMETHODIMP
+        Drop(IDataObject *pDataObject, DWORD grfKeyState, POINTL pt, DWORD *pdwEffect) override
         {
             TRACE("(%p) object dropped on recycle bin, effect %u\n", this, *pdwEffect);
 

--- a/dll/win32/shell32/droptargets/CRecyclerDropTarget.cpp
+++ b/dll/win32/shell32/droptargets/CRecyclerDropTarget.cpp
@@ -109,8 +109,8 @@ class CRecyclerDropTarget :
             cfShellIDList = RegisterClipboardFormatW(CFSTR_SHELLIDLIST);
         }
 
-        HRESULT WINAPI DragEnter(IDataObject *pDataObject,
-                                            DWORD dwKeyState, POINTL pt, DWORD *pdwEffect)
+        STDMETHOD(DragEnter)(IDataObject *pDataObject,
+                             DWORD dwKeyState, POINTL pt, DWORD *pdwEffect) override
         {
             TRACE("Recycle bin drag over (%p)\n", this);
             /* The recycle bin accepts pretty much everything, and sets a CSIDL flag. */
@@ -120,7 +120,7 @@ class CRecyclerDropTarget :
             return S_OK;
         }
 
-        HRESULT WINAPI DragOver(DWORD dwKeyState, POINTL pt, DWORD *pdwEffect)
+        STDMETHOD(DragOver)(DWORD dwKeyState, POINTL pt, DWORD *pdwEffect) override
         {
             TRACE("(%p)\n", this);
 
@@ -132,7 +132,7 @@ class CRecyclerDropTarget :
             return S_OK;
         }
 
-        HRESULT WINAPI DragLeave()
+        STDMETHOD(DragLeave)() override
         {
             TRACE("(%p)\n", this);
 
@@ -141,8 +141,8 @@ class CRecyclerDropTarget :
             return S_OK;
         }
 
-        HRESULT WINAPI Drop(IDataObject *pDataObject,
-                            DWORD grfKeyState, POINTL pt, DWORD *pdwEffect)
+        STDMETHOD(Drop)(IDataObject *pDataObject,
+                        DWORD grfKeyState, POINTL pt, DWORD *pdwEffect) override
         {
             TRACE("(%p) object dropped on recycle bin, effect %u\n", this, *pdwEffect);
 

--- a/dll/win32/shell32/droptargets/CexeDropHandler.h
+++ b/dll/win32/shell32/droptargets/CexeDropHandler.h
@@ -35,21 +35,20 @@ public:
     ~CExeDropHandler();
 
     // IDropTarget
-    virtual HRESULT WINAPI DragEnter(IDataObject *pDataObject, DWORD dwKeyState, POINTL pt, DWORD *pdwEffect);
-    virtual HRESULT WINAPI DragOver(DWORD dwKeyState, POINTL pt, DWORD *pdwEffect);
-    virtual HRESULT WINAPI DragLeave();
-    virtual HRESULT WINAPI Drop(IDataObject *pDataObject, DWORD dwKeyState, POINTL pt, DWORD *pdwEffect);
+    STDMETHOD(DragEnter)(IDataObject *pDataObject, DWORD dwKeyState, POINTL pt, DWORD *pdwEffect) override;
+    STDMETHOD(DragOver)(DWORD dwKeyState, POINTL pt, DWORD *pdwEffect) override;
+    STDMETHOD(DragLeave)() override;
+    STDMETHOD(Drop)(IDataObject *pDataObject, DWORD dwKeyState, POINTL pt, DWORD *pdwEffect) override;
 
     // IPersist
-    virtual HRESULT WINAPI GetClassID(CLSID *lpClassId);
+    STDMETHOD(GetClassID)(CLSID *lpClassId) override;
 
     //////// IPersistFile
-    virtual HRESULT WINAPI GetCurFile(LPOLESTR *ppszFileName);
-    virtual HRESULT WINAPI IsDirty();
-    virtual HRESULT WINAPI Load(LPCOLESTR pszFileName, DWORD dwMode);
-    virtual HRESULT WINAPI Save(LPCOLESTR pszFileName, BOOL fRemember);
-    virtual HRESULT WINAPI SaveCompleted(LPCOLESTR pszFileName);
-
+    STDMETHOD(GetCurFile)(LPOLESTR *ppszFileName) override;
+    STDMETHOD(IsDirty)() override;
+    STDMETHOD(Load)(LPCOLESTR pszFileName, DWORD dwMode) override;
+    STDMETHOD(Save)(LPCOLESTR pszFileName, BOOL fRemember) override;
+    STDMETHOD(SaveCompleted)(LPCOLESTR pszFileName) override;
 
 DECLARE_REGISTRY_RESOURCEID(IDR_EXEDROPHANDLER)
 DECLARE_NOT_AGGREGATABLE(CExeDropHandler)

--- a/dll/win32/shell32/folders/CAdminToolsFolder.h
+++ b/dll/win32/shell32/folders/CAdminToolsFolder.h
@@ -36,34 +36,34 @@ class CAdminToolsFolder :
         ~CAdminToolsFolder();
 
         // IShellFolder
-        virtual HRESULT WINAPI ParseDisplayName(HWND hwndOwner, LPBC pbc, LPOLESTR lpszDisplayName, ULONG *pchEaten, PIDLIST_RELATIVE *ppidl, ULONG *pdwAttributes);
-        virtual HRESULT WINAPI EnumObjects(HWND hwndOwner, DWORD dwFlags, LPENUMIDLIST *ppEnumIDList);
-        virtual HRESULT WINAPI BindToObject(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut);
-        virtual HRESULT WINAPI BindToStorage(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut);
-        virtual HRESULT WINAPI CompareIDs(LPARAM lParam, PCUIDLIST_RELATIVE pidl1, PCUIDLIST_RELATIVE pidl2);
-        virtual HRESULT WINAPI CreateViewObject(HWND hwndOwner, REFIID riid, LPVOID *ppvOut);
-        virtual HRESULT WINAPI GetAttributesOf(UINT cidl, PCUITEMID_CHILD_ARRAY apidl, DWORD *rgfInOut);
-        virtual HRESULT WINAPI GetUIObjectOf(HWND hwndOwner, UINT cidl, PCUITEMID_CHILD_ARRAY apidl, REFIID riid, UINT * prgfInOut, LPVOID * ppvOut);
-        virtual HRESULT WINAPI GetDisplayNameOf(PCUITEMID_CHILD pidl, DWORD dwFlags, LPSTRRET strRet);
-        virtual HRESULT WINAPI SetNameOf(HWND hwndOwner, PCUITEMID_CHILD pidl, LPCOLESTR lpName, DWORD dwFlags, PITEMID_CHILD *pPidlOut);
+        STDMETHOD(ParseDisplayName)(HWND hwndOwner, LPBC pbc, LPOLESTR lpszDisplayName, ULONG *pchEaten, PIDLIST_RELATIVE *ppidl, ULONG *pdwAttributes) override;
+        STDMETHOD(EnumObjects)(HWND hwndOwner, DWORD dwFlags, LPENUMIDLIST *ppEnumIDList) override;
+        STDMETHOD(BindToObject)(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut) override;
+        STDMETHOD(BindToStorage)(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut) override;
+        STDMETHOD(CompareIDs)(LPARAM lParam, PCUIDLIST_RELATIVE pidl1, PCUIDLIST_RELATIVE pidl2) override;
+        STDMETHOD(CreateViewObject)(HWND hwndOwner, REFIID riid, LPVOID *ppvOut) override;
+        STDMETHOD(GetAttributesOf)(UINT cidl, PCUITEMID_CHILD_ARRAY apidl, DWORD *rgfInOut) override;
+        STDMETHOD(GetUIObjectOf)(HWND hwndOwner, UINT cidl, PCUITEMID_CHILD_ARRAY apidl, REFIID riid, UINT * prgfInOut, LPVOID * ppvOut) override;
+        STDMETHOD(GetDisplayNameOf)(PCUITEMID_CHILD pidl, DWORD dwFlags, LPSTRRET strRet) override;
+        STDMETHOD(SetNameOf)(HWND hwndOwner, PCUITEMID_CHILD pidl, LPCOLESTR lpName, DWORD dwFlags, PITEMID_CHILD *pPidlOut) override;
 
         /* ShellFolder2 */
-        virtual HRESULT WINAPI GetDefaultSearchGUID(GUID *pguid);
-        virtual HRESULT WINAPI EnumSearches(IEnumExtraSearch **ppenum);
-        virtual HRESULT WINAPI GetDefaultColumn(DWORD dwRes, ULONG *pSort, ULONG *pDisplay);
-        virtual HRESULT WINAPI GetDefaultColumnState(UINT iColumn, DWORD *pcsFlags);
-        virtual HRESULT WINAPI GetDetailsEx(PCUITEMID_CHILD pidl, const SHCOLUMNID *pscid, VARIANT *pv);
-        virtual HRESULT WINAPI GetDetailsOf(PCUITEMID_CHILD pidl, UINT iColumn, SHELLDETAILS *psd);
-        virtual HRESULT WINAPI MapColumnToSCID(UINT column, SHCOLUMNID *pscid);
+        STDMETHOD(GetDefaultSearchGUID)(GUID *pguid) override;
+        STDMETHOD(EnumSearches)(IEnumExtraSearch **ppenum) override;
+        STDMETHOD(GetDefaultColumn)(DWORD dwRes, ULONG *pSort, ULONG *pDisplay) override;
+        STDMETHOD(GetDefaultColumnState)(UINT iColumn, DWORD *pcsFlags) override;
+        STDMETHOD(GetDetailsEx)(PCUITEMID_CHILD pidl, const SHCOLUMNID *pscid, VARIANT *pv) override;
+        STDMETHOD(GetDetailsOf)(PCUITEMID_CHILD pidl, UINT iColumn, SHELLDETAILS *psd) override;
+        STDMETHOD(MapColumnToSCID)(UINT column, SHCOLUMNID *pscid) override;
 
         // IPersist
-        virtual HRESULT WINAPI GetClassID(CLSID *lpClassId);
+        STDMETHOD(GetClassID)(CLSID *lpClassId) override;
 
         // IPersistFolder
-        virtual HRESULT WINAPI Initialize(PCIDLIST_ABSOLUTE pidl);
+        STDMETHOD(Initialize)(PCIDLIST_ABSOLUTE pidl) override;
 
         // IPersistFolder2
-        virtual HRESULT WINAPI GetCurFolder(PIDLIST_ABSOLUTE * pidl);
+        STDMETHOD(GetCurFolder)(PIDLIST_ABSOLUTE * pidl) override;
 
         DECLARE_REGISTRY_RESOURCEID(IDR_ADMINFOLDERSHORTCUT)
         DECLARE_NOT_AGGREGATABLE(CAdminToolsFolder)

--- a/dll/win32/shell32/folders/CControlPanelFolder.h
+++ b/dll/win32/shell32/folders/CControlPanelFolder.h
@@ -41,34 +41,34 @@ class CControlPanelFolder :
         ~CControlPanelFolder();
 
         // IShellFolder
-        virtual HRESULT WINAPI ParseDisplayName(HWND hwndOwner, LPBC pbc, LPOLESTR lpszDisplayName, DWORD *pchEaten, PIDLIST_RELATIVE *ppidl, DWORD *pdwAttributes);
-        virtual HRESULT WINAPI EnumObjects(HWND hwndOwner, DWORD dwFlags, LPENUMIDLIST *ppEnumIDList);
-        virtual HRESULT WINAPI BindToObject(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut);
-        virtual HRESULT WINAPI BindToStorage(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut);
-        virtual HRESULT WINAPI CompareIDs(LPARAM lParam, PCUIDLIST_RELATIVE pidl1, PCUIDLIST_RELATIVE pidl2);
-        virtual HRESULT WINAPI CreateViewObject(HWND hwndOwner, REFIID riid, LPVOID *ppvOut);
-        virtual HRESULT WINAPI GetAttributesOf(UINT cidl, PCUITEMID_CHILD_ARRAY apidl, DWORD *rgfInOut);
-        virtual HRESULT WINAPI GetUIObjectOf(HWND hwndOwner, UINT cidl, PCUITEMID_CHILD_ARRAY apidl, REFIID riid, UINT * prgfInOut, LPVOID * ppvOut);
-        virtual HRESULT WINAPI GetDisplayNameOf(PCUITEMID_CHILD pidl, DWORD dwFlags, LPSTRRET strRet);
-        virtual HRESULT WINAPI SetNameOf(HWND hwndOwner, PCUITEMID_CHILD pidl, LPCOLESTR lpName, DWORD dwFlags, PITEMID_CHILD *pPidlOut);
+        STDMETHOD(ParseDisplayName)(HWND hwndOwner, LPBC pbc, LPOLESTR lpszDisplayName, DWORD *pchEaten, PIDLIST_RELATIVE *ppidl, DWORD *pdwAttributes) override;
+        STDMETHOD(EnumObjects)(HWND hwndOwner, DWORD dwFlags, LPENUMIDLIST *ppEnumIDList) override;
+        STDMETHOD(BindToObject)(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut) override;
+        STDMETHOD(BindToStorage)(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut) override;
+        STDMETHOD(CompareIDs)(LPARAM lParam, PCUIDLIST_RELATIVE pidl1, PCUIDLIST_RELATIVE pidl2) override;
+        STDMETHOD(CreateViewObject)(HWND hwndOwner, REFIID riid, LPVOID *ppvOut) override;
+        STDMETHOD(GetAttributesOf)(UINT cidl, PCUITEMID_CHILD_ARRAY apidl, DWORD *rgfInOut) override;
+        STDMETHOD(GetUIObjectOf)(HWND hwndOwner, UINT cidl, PCUITEMID_CHILD_ARRAY apidl, REFIID riid, UINT * prgfInOut, LPVOID * ppvOut) override;
+        STDMETHOD(GetDisplayNameOf)(PCUITEMID_CHILD pidl, DWORD dwFlags, LPSTRRET strRet) override;
+        STDMETHOD(SetNameOf)(HWND hwndOwner, PCUITEMID_CHILD pidl, LPCOLESTR lpName, DWORD dwFlags, PITEMID_CHILD *pPidlOut) override;
 
         /* ShellFolder2 */
-        virtual HRESULT WINAPI GetDefaultSearchGUID(GUID *pguid);
-        virtual HRESULT WINAPI EnumSearches(IEnumExtraSearch **ppenum);
-        virtual HRESULT WINAPI GetDefaultColumn(DWORD dwRes, ULONG *pSort, ULONG *pDisplay);
-        virtual HRESULT WINAPI GetDefaultColumnState(UINT iColumn, DWORD *pcsFlags);
-        virtual HRESULT WINAPI GetDetailsEx(PCUITEMID_CHILD pidl, const SHCOLUMNID *pscid, VARIANT *pv);
-        virtual HRESULT WINAPI GetDetailsOf(PCUITEMID_CHILD pidl, UINT iColumn, SHELLDETAILS *psd);
-        virtual HRESULT WINAPI MapColumnToSCID(UINT column, SHCOLUMNID *pscid);
+        STDMETHOD(GetDefaultSearchGUID)(GUID *pguid) override;
+        STDMETHOD(EnumSearches)(IEnumExtraSearch **ppenum) override;
+        STDMETHOD(GetDefaultColumn)(DWORD dwRes, ULONG *pSort, ULONG *pDisplay) override;
+        STDMETHOD(GetDefaultColumnState)(UINT iColumn, DWORD *pcsFlags) override;
+        STDMETHOD(GetDetailsEx)(PCUITEMID_CHILD pidl, const SHCOLUMNID *pscid, VARIANT *pv) override;
+        STDMETHOD(GetDetailsOf)(PCUITEMID_CHILD pidl, UINT iColumn, SHELLDETAILS *psd) override;
+        STDMETHOD(MapColumnToSCID)(UINT column, SHCOLUMNID *pscid) override;
 
         // IPersist
-        virtual HRESULT WINAPI GetClassID(CLSID *lpClassId);
+        STDMETHOD(GetClassID)(CLSID *lpClassId) override;
 
         // IPersistFolder
-        virtual HRESULT WINAPI Initialize(PCIDLIST_ABSOLUTE pidl);
+        STDMETHOD(Initialize)(PCIDLIST_ABSOLUTE pidl) override;
 
         // IPersistFolder2
-        virtual HRESULT WINAPI GetCurFolder(PIDLIST_ABSOLUTE * pidl);
+        STDMETHOD(GetCurFolder)(PIDLIST_ABSOLUTE * pidl) override;
 
         DECLARE_REGISTRY_RESOURCEID(IDR_CONTROLPANEL)
         DECLARE_NOT_AGGREGATABLE(CControlPanelFolder)
@@ -98,12 +98,12 @@ public:
     HRESULT WINAPI Initialize(UINT cidl, PCUITEMID_CHILD_ARRAY apidl);
 
     // IContextMenu
-    virtual HRESULT WINAPI QueryContextMenu(HMENU hMenu, UINT indexMenu, UINT idCmdFirst, UINT idCmdLast, UINT uFlags);
-    virtual HRESULT WINAPI InvokeCommand(LPCMINVOKECOMMANDINFO lpcmi);
-    virtual HRESULT WINAPI GetCommandString(UINT_PTR idCommand, UINT uFlags, UINT *lpReserved, LPSTR lpszName, UINT uMaxNameLen);
+    STDMETHOD(QueryContextMenu)(HMENU hMenu, UINT indexMenu, UINT idCmdFirst, UINT idCmdLast, UINT uFlags) override;
+    STDMETHOD(InvokeCommand)(LPCMINVOKECOMMANDINFO lpcmi) override;
+    STDMETHOD(GetCommandString)(UINT_PTR idCommand, UINT uFlags, UINT *lpReserved, LPSTR lpszName, UINT uMaxNameLen) override;
 
     // IContextMenu2
-    virtual HRESULT WINAPI HandleMenuMsg(UINT uMsg, WPARAM wParam, LPARAM lParam);
+    STDMETHOD(HandleMenuMsg)(UINT uMsg, WPARAM wParam, LPARAM lParam) override;
 
     BEGIN_COM_MAP(CCPLItemMenu)
     COM_INTERFACE_ENTRY_IID(IID_IContextMenu, IContextMenu)
@@ -118,9 +118,9 @@ class COpenControlPanel :
 {
     public:
         // IOpenControlPanel
-        virtual HRESULT WINAPI Open(LPCWSTR pszName, LPCWSTR pszPage, IUnknown *punkSite);
-        virtual HRESULT WINAPI GetPath(LPCWSTR pszName, LPWSTR pszPath, UINT cchPath);
-        virtual HRESULT WINAPI GetCurrentView(CPVIEW *pView);
+        STDMETHOD(Open)(LPCWSTR pszName, LPCWSTR pszPage, IUnknown *punkSite) override;
+        STDMETHOD(GetPath)(LPCWSTR pszName, LPWSTR pszPath, UINT cchPath) override;
+        STDMETHOD(GetCurrentView)(CPVIEW *pView) override;
 
         static HRESULT WINAPI UpdateRegistry(BOOL bRegister) { return S_OK; } // CControlPanelFolder does it for us
         DECLARE_NOT_AGGREGATABLE(COpenControlPanel)

--- a/dll/win32/shell32/folders/CDesktopFolder.h
+++ b/dll/win32/shell32/folders/CDesktopFolder.h
@@ -48,48 +48,46 @@ class CDesktopFolder :
         HRESULT WINAPI FinalConstruct();
 
         // *** IShellFolder methods ***
-        virtual HRESULT WINAPI ParseDisplayName(HWND hwndOwner, LPBC pbc, LPOLESTR lpszDisplayName, DWORD *pchEaten, PIDLIST_RELATIVE *ppidl, DWORD *pdwAttributes);
-        virtual HRESULT WINAPI EnumObjects(HWND hwndOwner, DWORD dwFlags, LPENUMIDLIST *ppEnumIDList);
-        virtual HRESULT WINAPI BindToObject(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut);
-        virtual HRESULT WINAPI BindToStorage(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut);
-        virtual HRESULT WINAPI CompareIDs(LPARAM lParam, PCUIDLIST_RELATIVE pidl1, PCUIDLIST_RELATIVE pidl2);
-        virtual HRESULT WINAPI CreateViewObject(HWND hwndOwner, REFIID riid, LPVOID *ppvOut);
-        virtual HRESULT WINAPI GetAttributesOf(UINT cidl, PCUITEMID_CHILD_ARRAY apidl, DWORD *rgfInOut);
-        virtual HRESULT WINAPI GetUIObjectOf(HWND hwndOwner, UINT cidl, PCUITEMID_CHILD_ARRAY apidl, REFIID riid, UINT * prgfInOut, LPVOID * ppvOut);
-        virtual HRESULT WINAPI GetDisplayNameOf(PCUITEMID_CHILD pidl, DWORD dwFlags, LPSTRRET strRet);
-        virtual HRESULT WINAPI SetNameOf(HWND hwndOwner, PCUITEMID_CHILD pidl, LPCOLESTR lpName, DWORD dwFlags, PITEMID_CHILD *pPidlOut);
+        STDMETHOD(ParseDisplayName)(HWND hwndOwner, LPBC pbc, LPOLESTR lpszDisplayName, DWORD *pchEaten, PIDLIST_RELATIVE *ppidl, DWORD *pdwAttributes) override;
+        STDMETHOD(EnumObjects)(HWND hwndOwner, DWORD dwFlags, LPENUMIDLIST *ppEnumIDList) override;
+        STDMETHOD(BindToObject)(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut) override;
+        STDMETHOD(BindToStorage)(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut) override;
+        STDMETHOD(CompareIDs)(LPARAM lParam, PCUIDLIST_RELATIVE pidl1, PCUIDLIST_RELATIVE pidl2) override;
+        STDMETHOD(CreateViewObject)(HWND hwndOwner, REFIID riid, LPVOID *ppvOut) override;
+        STDMETHOD(GetAttributesOf)(UINT cidl, PCUITEMID_CHILD_ARRAY apidl, DWORD *rgfInOut) override;
+        STDMETHOD(GetUIObjectOf)(HWND hwndOwner, UINT cidl, PCUITEMID_CHILD_ARRAY apidl, REFIID riid, UINT * prgfInOut, LPVOID * ppvOut) override;
+        STDMETHOD(GetDisplayNameOf)(PCUITEMID_CHILD pidl, DWORD dwFlags, LPSTRRET strRet) override;
+        STDMETHOD(SetNameOf)(HWND hwndOwner, PCUITEMID_CHILD pidl, LPCOLESTR lpName, DWORD dwFlags, PITEMID_CHILD *pPidlOut) override;
 
         // *** IShellFolder2 methods ***
-        virtual HRESULT WINAPI GetDefaultSearchGUID(GUID *pguid);
-        virtual HRESULT WINAPI EnumSearches(IEnumExtraSearch **ppenum);
-        virtual HRESULT WINAPI GetDefaultColumn(DWORD dwRes, ULONG *pSort, ULONG *pDisplay);
-        virtual HRESULT WINAPI GetDefaultColumnState(UINT iColumn, DWORD *pcsFlags);
-        virtual HRESULT WINAPI GetDetailsEx(PCUITEMID_CHILD pidl, const SHCOLUMNID *pscid, VARIANT *pv);
-        virtual HRESULT WINAPI GetDetailsOf(PCUITEMID_CHILD pidl, UINT iColumn, SHELLDETAILS *psd);
-        virtual HRESULT WINAPI MapColumnToSCID(UINT column, SHCOLUMNID *pscid);
+        STDMETHOD(GetDefaultSearchGUID)(GUID *pguid) override;
+        STDMETHOD(EnumSearches)(IEnumExtraSearch **ppenum) override;
+        STDMETHOD(GetDefaultColumn)(DWORD dwRes, ULONG *pSort, ULONG *pDisplay) override;
+        STDMETHOD(GetDefaultColumnState)(UINT iColumn, DWORD *pcsFlags) override;
+        STDMETHOD(GetDetailsEx)(PCUITEMID_CHILD pidl, const SHCOLUMNID *pscid, VARIANT *pv) override;
+        STDMETHOD(GetDetailsOf)(PCUITEMID_CHILD pidl, UINT iColumn, SHELLDETAILS *psd) override;
+        STDMETHOD(MapColumnToSCID)(UINT column, SHCOLUMNID *pscid) override;
 
         // *** IPersist methods ***
-        virtual HRESULT WINAPI GetClassID(CLSID *lpClassId);
+        STDMETHOD(GetClassID)(CLSID *lpClassId) override;
 
         // *** IPersistFolder methods ***
-        virtual HRESULT WINAPI Initialize(PCIDLIST_ABSOLUTE pidl);
+        STDMETHOD(Initialize)(PCIDLIST_ABSOLUTE pidl) override;
 
         // *** IPersistFolder2 methods ***
-        virtual HRESULT WINAPI GetCurFolder(PIDLIST_ABSOLUTE * pidl);
+        STDMETHOD(GetCurFolder)(PIDLIST_ABSOLUTE * pidl) override;
 
         // IContextMenuCB
-        virtual HRESULT WINAPI CallBack(IShellFolder *psf, HWND hwndOwner, IDataObject *pdtobj, UINT uMsg, WPARAM wParam, LPARAM lParam);
+        STDMETHOD(CallBack)(IShellFolder *psf, HWND hwndOwner, IDataObject *pdtobj, UINT uMsg, WPARAM wParam, LPARAM lParam) override;
 
         /*** IItemNameLimits methods ***/
 
-        STDMETHODIMP
-        GetMaxLength(LPCWSTR pszName, int *piMaxNameLen)
+        STDMETHOD(GetMaxLength)(LPCWSTR pszName, int *piMaxNameLen) override
         {
             return E_NOTIMPL;
         }
 
-        STDMETHODIMP
-        GetValidCharacters(LPWSTR *ppwszValidChars, LPWSTR *ppwszInvalidChars)
+        STDMETHOD(GetValidCharacters)(LPWSTR *ppwszValidChars, LPWSTR *ppwszInvalidChars) override
         {
             if (ppwszValidChars)
             {

--- a/dll/win32/shell32/folders/CDesktopFolder.h
+++ b/dll/win32/shell32/folders/CDesktopFolder.h
@@ -82,12 +82,14 @@ class CDesktopFolder :
 
         /*** IItemNameLimits methods ***/
 
-        STDMETHOD(GetMaxLength)(LPCWSTR pszName, int *piMaxNameLen) override
+        STDMETHODIMP
+        GetMaxLength(LPCWSTR pszName, int *piMaxNameLen) override
         {
             return E_NOTIMPL;
         }
 
-        STDMETHOD(GetValidCharacters)(LPWSTR *ppwszValidChars, LPWSTR *ppwszInvalidChars) override
+        STDMETHODIMP
+        GetValidCharacters(LPWSTR *ppwszValidChars, LPWSTR *ppwszInvalidChars) override
         {
             if (ppwszValidChars)
             {

--- a/dll/win32/shell32/folders/CDrivesFolder.h
+++ b/dll/win32/shell32/folders/CDrivesFolder.h
@@ -41,37 +41,37 @@ class CDrivesFolder :
         HRESULT WINAPI FinalConstruct();
 
         // IShellFolder
-        virtual HRESULT WINAPI ParseDisplayName(HWND hwndOwner, LPBC pbc, LPOLESTR lpszDisplayName, DWORD *pchEaten, PIDLIST_RELATIVE *ppidl, DWORD *pdwAttributes);
-        virtual HRESULT WINAPI EnumObjects(HWND hwndOwner, DWORD dwFlags, LPENUMIDLIST *ppEnumIDList);
-        virtual HRESULT WINAPI BindToObject(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut);
-        virtual HRESULT WINAPI BindToStorage(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut);
-        virtual HRESULT WINAPI CompareIDs(LPARAM lParam, PCUIDLIST_RELATIVE pidl1, PCUIDLIST_RELATIVE pidl2);
-        virtual HRESULT WINAPI CreateViewObject(HWND hwndOwner, REFIID riid, LPVOID *ppvOut);
-        virtual HRESULT WINAPI GetAttributesOf(UINT cidl, PCUITEMID_CHILD_ARRAY apidl, DWORD *rgfInOut);
-        virtual HRESULT WINAPI GetUIObjectOf(HWND hwndOwner, UINT cidl, PCUITEMID_CHILD_ARRAY apidl, REFIID riid, UINT * prgfInOut, LPVOID * ppvOut);
-        virtual HRESULT WINAPI GetDisplayNameOf(PCUITEMID_CHILD pidl, DWORD dwFlags, LPSTRRET strRet);
-        virtual HRESULT WINAPI SetNameOf(HWND hwndOwner, PCUITEMID_CHILD pidl, LPCOLESTR lpName, DWORD dwFlags, PITEMID_CHILD *pPidlOut);
+        STDMETHOD(ParseDisplayName)(HWND hwndOwner, LPBC pbc, LPOLESTR lpszDisplayName, DWORD *pchEaten, PIDLIST_RELATIVE *ppidl, DWORD *pdwAttributes) override;
+        STDMETHOD(EnumObjects)(HWND hwndOwner, DWORD dwFlags, LPENUMIDLIST *ppEnumIDList) override;
+        STDMETHOD(BindToObject)(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut) override;
+        STDMETHOD(BindToStorage)(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut) override;
+        STDMETHOD(CompareIDs)(LPARAM lParam, PCUIDLIST_RELATIVE pidl1, PCUIDLIST_RELATIVE pidl2) override;
+        STDMETHOD(CreateViewObject)(HWND hwndOwner, REFIID riid, LPVOID *ppvOut) override;
+        STDMETHOD(GetAttributesOf)(UINT cidl, PCUITEMID_CHILD_ARRAY apidl, DWORD *rgfInOut) override;
+        STDMETHOD(GetUIObjectOf)(HWND hwndOwner, UINT cidl, PCUITEMID_CHILD_ARRAY apidl, REFIID riid, UINT * prgfInOut, LPVOID * ppvOut) override;
+        STDMETHOD(GetDisplayNameOf)(PCUITEMID_CHILD pidl, DWORD dwFlags, LPSTRRET strRet) override;
+        STDMETHOD(SetNameOf)(HWND hwndOwner, PCUITEMID_CHILD pidl, LPCOLESTR lpName, DWORD dwFlags, PITEMID_CHILD *pPidlOut) override;
 
         /* ShellFolder2 */
-        virtual HRESULT WINAPI GetDefaultSearchGUID(GUID *pguid);
-        virtual HRESULT WINAPI EnumSearches(IEnumExtraSearch **ppenum);
-        virtual HRESULT WINAPI GetDefaultColumn(DWORD dwRes, ULONG *pSort, ULONG *pDisplay);
-        virtual HRESULT WINAPI GetDefaultColumnState(UINT iColumn, DWORD *pcsFlags);
-        virtual HRESULT WINAPI GetDetailsEx(PCUITEMID_CHILD pidl, const SHCOLUMNID *pscid, VARIANT *pv);
-        virtual HRESULT WINAPI GetDetailsOf(PCUITEMID_CHILD pidl, UINT iColumn, SHELLDETAILS *psd);
-        virtual HRESULT WINAPI MapColumnToSCID(UINT column, SHCOLUMNID *pscid);
+        STDMETHOD(GetDefaultSearchGUID)(GUID *pguid) override;
+        STDMETHOD(EnumSearches)(IEnumExtraSearch **ppenum) override;
+        STDMETHOD(GetDefaultColumn)(DWORD dwRes, ULONG *pSort, ULONG *pDisplay) override;
+        STDMETHOD(GetDefaultColumnState)(UINT iColumn, DWORD *pcsFlags) override;
+        STDMETHOD(GetDetailsEx)(PCUITEMID_CHILD pidl, const SHCOLUMNID *pscid, VARIANT *pv) override;
+        STDMETHOD(GetDetailsOf)(PCUITEMID_CHILD pidl, UINT iColumn, SHELLDETAILS *psd) override;
+        STDMETHOD(MapColumnToSCID)(UINT column, SHCOLUMNID *pscid) override;
 
         // IPersist
-        virtual HRESULT WINAPI GetClassID(CLSID *lpClassId);
+        STDMETHOD(GetClassID)(CLSID *lpClassId) override;
 
         // IPersistFolder
-        virtual HRESULT WINAPI Initialize(PCIDLIST_ABSOLUTE pidl);
+        STDMETHOD(Initialize)(PCIDLIST_ABSOLUTE pidl) override;
 
         // IPersistFolder2
-        virtual HRESULT WINAPI GetCurFolder(PIDLIST_ABSOLUTE * pidl);
+        STDMETHOD(GetCurFolder)(PIDLIST_ABSOLUTE * pidl) override;
 
         // IContextMenuCB
-        virtual HRESULT WINAPI CallBack(IShellFolder *psf, HWND hwndOwner, IDataObject *pdtobj, UINT uMsg, WPARAM wParam, LPARAM lParam);
+        STDMETHOD(CallBack)(IShellFolder *psf, HWND hwndOwner, IDataObject *pdtobj, UINT uMsg, WPARAM wParam, LPARAM lParam) override;
 
         DECLARE_REGISTRY_RESOURCEID(IDR_MYCOMPUTER)
         DECLARE_CENTRAL_INSTANCE_NOT_AGGREGATABLE(CDrivesFolder)

--- a/dll/win32/shell32/folders/CFSFolder.h
+++ b/dll/win32/shell32/folders/CFSFolder.h
@@ -79,12 +79,14 @@ class CFSFolder :
 
         /*** IItemNameLimits methods ***/
 
-        STDMETHOD(GetMaxLength)(LPCWSTR pszName, int *piMaxNameLen) override
+        STDMETHODIMP
+        GetMaxLength(LPCWSTR pszName, int *piMaxNameLen) override
         {
             return E_NOTIMPL;
         }
 
-        STDMETHOD(GetValidCharacters)(LPWSTR *ppwszValidChars, LPWSTR *ppwszInvalidChars) override
+        STDMETHODIMP
+        GetValidCharacters(LPWSTR *ppwszValidChars, LPWSTR *ppwszInvalidChars) override
         {
             if (ppwszValidChars)
             {

--- a/dll/win32/shell32/folders/CFSFolder.h
+++ b/dll/win32/shell32/folders/CFSFolder.h
@@ -38,55 +38,53 @@ class CFSFolder :
         ~CFSFolder();
 
         // IShellFolder
-        virtual HRESULT WINAPI ParseDisplayName(HWND hwndOwner, LPBC pbc, LPOLESTR lpszDisplayName, DWORD *pchEaten, PIDLIST_RELATIVE *ppidl, DWORD *pdwAttributes);
-        virtual HRESULT WINAPI EnumObjects(HWND hwndOwner, DWORD dwFlags, LPENUMIDLIST *ppEnumIDList);
-        virtual HRESULT WINAPI BindToObject(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut);
-        virtual HRESULT WINAPI BindToStorage(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut);
-        virtual HRESULT WINAPI CompareIDs(LPARAM lParam, PCUIDLIST_RELATIVE pidl1, PCUIDLIST_RELATIVE pidl2);
-        virtual HRESULT WINAPI CreateViewObject(HWND hwndOwner, REFIID riid, LPVOID *ppvOut);
-        virtual HRESULT WINAPI GetAttributesOf(UINT cidl, PCUITEMID_CHILD_ARRAY apidl, DWORD *rgfInOut);
-        virtual HRESULT WINAPI GetUIObjectOf(HWND hwndOwner, UINT cidl, PCUITEMID_CHILD_ARRAY apidl, REFIID riid, UINT * prgfInOut, LPVOID * ppvOut);
-        virtual HRESULT WINAPI GetDisplayNameOf(PCUITEMID_CHILD pidl, DWORD dwFlags, LPSTRRET strRet);
-        virtual HRESULT WINAPI SetNameOf(HWND hwndOwner, PCUITEMID_CHILD pidl, LPCOLESTR lpName, DWORD dwFlags, PITEMID_CHILD *pPidlOut);
+        STDMETHOD(ParseDisplayName)(HWND hwndOwner, LPBC pbc, LPOLESTR lpszDisplayName, DWORD *pchEaten, PIDLIST_RELATIVE *ppidl, DWORD *pdwAttributes) override;
+        STDMETHOD(EnumObjects)(HWND hwndOwner, DWORD dwFlags, LPENUMIDLIST *ppEnumIDList) override;
+        STDMETHOD(BindToObject)(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut) override;
+        STDMETHOD(BindToStorage)(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut) override;
+        STDMETHOD(CompareIDs)(LPARAM lParam, PCUIDLIST_RELATIVE pidl1, PCUIDLIST_RELATIVE pidl2) override;
+        STDMETHOD(CreateViewObject)(HWND hwndOwner, REFIID riid, LPVOID *ppvOut) override;
+        STDMETHOD(GetAttributesOf)(UINT cidl, PCUITEMID_CHILD_ARRAY apidl, DWORD *rgfInOut) override;
+        STDMETHOD(GetUIObjectOf)(HWND hwndOwner, UINT cidl, PCUITEMID_CHILD_ARRAY apidl, REFIID riid, UINT * prgfInOut, LPVOID * ppvOut) override;
+        STDMETHOD(GetDisplayNameOf)(PCUITEMID_CHILD pidl, DWORD dwFlags, LPSTRRET strRet) override;
+        STDMETHOD(SetNameOf)(HWND hwndOwner, PCUITEMID_CHILD pidl, LPCOLESTR lpName, DWORD dwFlags, PITEMID_CHILD *pPidlOut) override;
 
         /* ShellFolder2 */
-        virtual HRESULT WINAPI GetDefaultSearchGUID(GUID *pguid);
-        virtual HRESULT WINAPI EnumSearches(IEnumExtraSearch **ppenum);
-        virtual HRESULT WINAPI GetDefaultColumn(DWORD dwRes, ULONG *pSort, ULONG *pDisplay);
-        virtual HRESULT WINAPI GetDefaultColumnState(UINT iColumn, DWORD *pcsFlags);
-        virtual HRESULT WINAPI GetDetailsEx(PCUITEMID_CHILD pidl, const SHCOLUMNID *pscid, VARIANT *pv);
-        virtual HRESULT WINAPI GetDetailsOf(PCUITEMID_CHILD pidl, UINT iColumn, SHELLDETAILS *psd);
-        virtual HRESULT WINAPI MapColumnToSCID(UINT column, SHCOLUMNID *pscid);
+        STDMETHOD(GetDefaultSearchGUID)(GUID *pguid) override;
+        STDMETHOD(EnumSearches)(IEnumExtraSearch **ppenum) override;
+        STDMETHOD(GetDefaultColumn)(DWORD dwRes, ULONG *pSort, ULONG *pDisplay) override;
+        STDMETHOD(GetDefaultColumnState)(UINT iColumn, DWORD *pcsFlags) override;
+        STDMETHOD(GetDetailsEx)(PCUITEMID_CHILD pidl, const SHCOLUMNID *pscid, VARIANT *pv) override;
+        STDMETHOD(GetDetailsOf)(PCUITEMID_CHILD pidl, UINT iColumn, SHELLDETAILS *psd) override;
+        STDMETHOD(MapColumnToSCID)(UINT column, SHCOLUMNID *pscid) override;
 
         // IPersist
-        virtual HRESULT WINAPI GetClassID(CLSID *lpClassId);
+        STDMETHOD(GetClassID)(CLSID *lpClassId) override;
 
         // IPersistFolder
-        virtual HRESULT WINAPI Initialize(PCIDLIST_ABSOLUTE pidl);
+        STDMETHOD(Initialize)(PCIDLIST_ABSOLUTE pidl) override;
 
         // IPersistFolder2
-        virtual HRESULT WINAPI GetCurFolder(PIDLIST_ABSOLUTE * pidl);
+        STDMETHOD(GetCurFolder)(PIDLIST_ABSOLUTE * pidl) override;
 
         // IPersistFolder3
-        virtual HRESULT WINAPI InitializeEx(IBindCtx *pbc, LPCITEMIDLIST pidlRoot, const PERSIST_FOLDER_TARGET_INFO *ppfti);
-        virtual HRESULT WINAPI GetFolderTargetInfo(PERSIST_FOLDER_TARGET_INFO *ppfti);
+        STDMETHOD(InitializeEx)(IBindCtx *pbc, LPCITEMIDLIST pidlRoot, const PERSIST_FOLDER_TARGET_INFO *ppfti) override;
+        STDMETHOD(GetFolderTargetInfo)(PERSIST_FOLDER_TARGET_INFO *ppfti) override;
 
         // IContextMenuCB
-        virtual HRESULT WINAPI CallBack(IShellFolder *psf, HWND hwndOwner, IDataObject *pdtobj, UINT uMsg, WPARAM wParam, LPARAM lParam);
+        STDMETHOD(CallBack)(IShellFolder *psf, HWND hwndOwner, IDataObject *pdtobj, UINT uMsg, WPARAM wParam, LPARAM lParam) override;
 
         // IShellFolderViewCB
-        virtual HRESULT WINAPI MessageSFVCB(UINT uMsg, WPARAM wParam, LPARAM lParam);
+        STDMETHOD(MessageSFVCB)(UINT uMsg, WPARAM wParam, LPARAM lParam) override;
 
         /*** IItemNameLimits methods ***/
 
-        STDMETHODIMP
-        GetMaxLength(LPCWSTR pszName, int *piMaxNameLen)
+        STDMETHOD(GetMaxLength)(LPCWSTR pszName, int *piMaxNameLen) override
         {
             return E_NOTIMPL;
         }
 
-        STDMETHODIMP
-        GetValidCharacters(LPWSTR *ppwszValidChars, LPWSTR *ppwszInvalidChars)
+        STDMETHOD(GetValidCharacters)(LPWSTR *ppwszValidChars, LPWSTR *ppwszInvalidChars) override
         {
             if (ppwszValidChars)
             {

--- a/dll/win32/shell32/folders/CFontsFolder.h
+++ b/dll/win32/shell32/folders/CFontsFolder.h
@@ -36,34 +36,34 @@ class CFontsFolder :
         ~CFontsFolder();
 
         // IShellFolder
-        virtual HRESULT WINAPI ParseDisplayName(HWND hwndOwner, LPBC pbc, LPOLESTR lpszDisplayName, DWORD *pchEaten, PIDLIST_RELATIVE *ppidl, DWORD *pdwAttributes);
-        virtual HRESULT WINAPI EnumObjects(HWND hwndOwner, DWORD dwFlags, LPENUMIDLIST *ppEnumIDList);
-        virtual HRESULT WINAPI BindToObject(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut);
-        virtual HRESULT WINAPI BindToStorage(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut);
-        virtual HRESULT WINAPI CompareIDs(LPARAM lParam, PCUIDLIST_RELATIVE pidl1, PCUIDLIST_RELATIVE pidl2);
-        virtual HRESULT WINAPI CreateViewObject(HWND hwndOwner, REFIID riid, LPVOID *ppvOut);
-        virtual HRESULT WINAPI GetAttributesOf(UINT cidl, PCUITEMID_CHILD_ARRAY apidl, DWORD *rgfInOut);
-        virtual HRESULT WINAPI GetUIObjectOf(HWND hwndOwner, UINT cidl, PCUITEMID_CHILD_ARRAY apidl, REFIID riid, UINT * prgfInOut, LPVOID * ppvOut);
-        virtual HRESULT WINAPI GetDisplayNameOf(PCUITEMID_CHILD pidl, DWORD dwFlags, LPSTRRET strRet);
-        virtual HRESULT WINAPI SetNameOf(HWND hwndOwner, PCUITEMID_CHILD pidl, LPCOLESTR lpName, DWORD dwFlags, PITEMID_CHILD *pPidlOut);
+        STDMETHOD(ParseDisplayName)(HWND hwndOwner, LPBC pbc, LPOLESTR lpszDisplayName, DWORD *pchEaten, PIDLIST_RELATIVE *ppidl, DWORD *pdwAttributes) override;
+        STDMETHOD(EnumObjects)(HWND hwndOwner, DWORD dwFlags, LPENUMIDLIST *ppEnumIDList) override;
+        STDMETHOD(BindToObject)(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut) override;
+        STDMETHOD(BindToStorage)(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut) override;
+        STDMETHOD(CompareIDs)(LPARAM lParam, PCUIDLIST_RELATIVE pidl1, PCUIDLIST_RELATIVE pidl2) override;
+        STDMETHOD(CreateViewObject)(HWND hwndOwner, REFIID riid, LPVOID *ppvOut) override;
+        STDMETHOD(GetAttributesOf)(UINT cidl, PCUITEMID_CHILD_ARRAY apidl, DWORD *rgfInOut) override;
+        STDMETHOD(GetUIObjectOf)(HWND hwndOwner, UINT cidl, PCUITEMID_CHILD_ARRAY apidl, REFIID riid, UINT * prgfInOut, LPVOID * ppvOut) override;
+        STDMETHOD(GetDisplayNameOf)(PCUITEMID_CHILD pidl, DWORD dwFlags, LPSTRRET strRet) override;
+        STDMETHOD(SetNameOf)(HWND hwndOwner, PCUITEMID_CHILD pidl, LPCOLESTR lpName, DWORD dwFlags, PITEMID_CHILD *pPidlOut) override;
 
         /* ShellFolder2 */
-        virtual HRESULT WINAPI GetDefaultSearchGUID(GUID *pguid);
-        virtual HRESULT WINAPI EnumSearches(IEnumExtraSearch **ppenum);
-        virtual HRESULT WINAPI GetDefaultColumn(DWORD dwRes, ULONG *pSort, ULONG *pDisplay);
-        virtual HRESULT WINAPI GetDefaultColumnState(UINT iColumn, DWORD *pcsFlags);
-        virtual HRESULT WINAPI GetDetailsEx(PCUITEMID_CHILD pidl, const SHCOLUMNID *pscid, VARIANT *pv);
-        virtual HRESULT WINAPI GetDetailsOf(PCUITEMID_CHILD pidl, UINT iColumn, SHELLDETAILS *psd);
-        virtual HRESULT WINAPI MapColumnToSCID(UINT column, SHCOLUMNID *pscid);
+        STDMETHOD(GetDefaultSearchGUID)(GUID *pguid) override;
+        STDMETHOD(EnumSearches)(IEnumExtraSearch **ppenum) override;
+        STDMETHOD(GetDefaultColumn)(DWORD dwRes, ULONG *pSort, ULONG *pDisplay) override;
+        STDMETHOD(GetDefaultColumnState)(UINT iColumn, DWORD *pcsFlags) override;
+        STDMETHOD(GetDetailsEx)(PCUITEMID_CHILD pidl, const SHCOLUMNID *pscid, VARIANT *pv) override;
+        STDMETHOD(GetDetailsOf)(PCUITEMID_CHILD pidl, UINT iColumn, SHELLDETAILS *psd) override;
+        STDMETHOD(MapColumnToSCID)(UINT column, SHCOLUMNID *pscid) override;
 
         // IPersist
-        virtual HRESULT WINAPI GetClassID(CLSID *lpClassId);
+        STDMETHOD(GetClassID)(CLSID *lpClassId) override;
 
         // IPersistFolder
-        virtual HRESULT WINAPI Initialize(PCIDLIST_ABSOLUTE pidl);
+        STDMETHOD(Initialize)(PCIDLIST_ABSOLUTE pidl) override;
 
         // IPersistFolder2
-        virtual HRESULT WINAPI GetCurFolder(PIDLIST_ABSOLUTE *pidl);
+        STDMETHOD(GetCurFolder)(PIDLIST_ABSOLUTE *pidl) override;
 
         DECLARE_REGISTRY_RESOURCEID(IDR_FONTSFOLDERSHORTCUT)
         DECLARE_NOT_AGGREGATABLE(CFontsFolder)

--- a/dll/win32/shell32/folders/CMyDocsFolder.h
+++ b/dll/win32/shell32/folders/CMyDocsFolder.h
@@ -73,12 +73,14 @@ class CMyDocsFolder :
 
         /*** IItemNameLimits methods ***/
 
-        STDMETHOD(GetMaxLength)(LPCWSTR pszName, int *piMaxNameLen) override
+        STDMETHODIMP
+        GetMaxLength(LPCWSTR pszName, int *piMaxNameLen) override
         {
             return E_NOTIMPL;
         }
 
-        STDMETHOD(GetValidCharacters)(LPWSTR *ppwszValidChars, LPWSTR *ppwszInvalidChars) override
+        STDMETHODIMP
+        GetValidCharacters(LPWSTR *ppwszValidChars, LPWSTR *ppwszInvalidChars) override
         {
             if (ppwszValidChars)
             {

--- a/dll/win32/shell32/folders/CMyDocsFolder.h
+++ b/dll/win32/shell32/folders/CMyDocsFolder.h
@@ -42,45 +42,43 @@ class CMyDocsFolder :
         HRESULT WINAPI FinalConstruct();
 
         // IShellFolder
-        virtual HRESULT WINAPI ParseDisplayName(HWND hwndOwner, LPBC pbc, LPOLESTR lpszDisplayName, DWORD *pchEaten, PIDLIST_RELATIVE *ppidl, DWORD *pdwAttributes);
-        virtual HRESULT WINAPI EnumObjects(HWND hwndOwner, DWORD dwFlags, LPENUMIDLIST *ppEnumIDList);
-        virtual HRESULT WINAPI BindToObject(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut);
-        virtual HRESULT WINAPI BindToStorage(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut);
-        virtual HRESULT WINAPI CompareIDs(LPARAM lParam, PCUIDLIST_RELATIVE pidl1, PCUIDLIST_RELATIVE pidl2);
-        virtual HRESULT WINAPI CreateViewObject(HWND hwndOwner, REFIID riid, LPVOID *ppvOut);
-        virtual HRESULT WINAPI GetAttributesOf(UINT cidl, PCUITEMID_CHILD_ARRAY apidl, DWORD *rgfInOut);
-        virtual HRESULT WINAPI GetUIObjectOf(HWND hwndOwner, UINT cidl, PCUITEMID_CHILD_ARRAY apidl, REFIID riid, UINT * prgfInOut, LPVOID * ppvOut);
-        virtual HRESULT WINAPI GetDisplayNameOf(PCUITEMID_CHILD pidl, DWORD dwFlags, LPSTRRET strRet);
-        virtual HRESULT WINAPI SetNameOf(HWND hwndOwner, PCUITEMID_CHILD pidl, LPCOLESTR lpName, DWORD dwFlags, PITEMID_CHILD *pPidlOut);
+        STDMETHOD(ParseDisplayName)(HWND hwndOwner, LPBC pbc, LPOLESTR lpszDisplayName, DWORD *pchEaten, PIDLIST_RELATIVE *ppidl, DWORD *pdwAttributes) override;
+        STDMETHOD(EnumObjects)(HWND hwndOwner, DWORD dwFlags, LPENUMIDLIST *ppEnumIDList) override;
+        STDMETHOD(BindToObject)(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut) override;
+        STDMETHOD(BindToStorage)(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut) override;
+        STDMETHOD(CompareIDs)(LPARAM lParam, PCUIDLIST_RELATIVE pidl1, PCUIDLIST_RELATIVE pidl2) override;
+        STDMETHOD(CreateViewObject)(HWND hwndOwner, REFIID riid, LPVOID *ppvOut) override;
+        STDMETHOD(GetAttributesOf)(UINT cidl, PCUITEMID_CHILD_ARRAY apidl, DWORD *rgfInOut) override;
+        STDMETHOD(GetUIObjectOf)(HWND hwndOwner, UINT cidl, PCUITEMID_CHILD_ARRAY apidl, REFIID riid, UINT * prgfInOut, LPVOID * ppvOut) override;
+        STDMETHOD(GetDisplayNameOf)(PCUITEMID_CHILD pidl, DWORD dwFlags, LPSTRRET strRet) override;
+        STDMETHOD(SetNameOf)(HWND hwndOwner, PCUITEMID_CHILD pidl, LPCOLESTR lpName, DWORD dwFlags, PITEMID_CHILD *pPidlOut) override;
 
         /* ShellFolder2 */
-        virtual HRESULT WINAPI GetDefaultSearchGUID(GUID *pguid);
-        virtual HRESULT WINAPI EnumSearches(IEnumExtraSearch **ppenum);
-        virtual HRESULT WINAPI GetDefaultColumn(DWORD dwRes, ULONG *pSort, ULONG *pDisplay);
-        virtual HRESULT WINAPI GetDefaultColumnState(UINT iColumn, DWORD *pcsFlags);
-        virtual HRESULT WINAPI GetDetailsEx(PCUITEMID_CHILD pidl, const SHCOLUMNID *pscid, VARIANT *pv);
-        virtual HRESULT WINAPI GetDetailsOf(PCUITEMID_CHILD pidl, UINT iColumn, SHELLDETAILS *psd);
-        virtual HRESULT WINAPI MapColumnToSCID(UINT column, SHCOLUMNID *pscid);
+        STDMETHOD(GetDefaultSearchGUID)(GUID *pguid) override;
+        STDMETHOD(EnumSearches)(IEnumExtraSearch **ppenum) override;
+        STDMETHOD(GetDefaultColumn)(DWORD dwRes, ULONG *pSort, ULONG *pDisplay) override;
+        STDMETHOD(GetDefaultColumnState)(UINT iColumn, DWORD *pcsFlags) override;
+        STDMETHOD(GetDetailsEx)(PCUITEMID_CHILD pidl, const SHCOLUMNID *pscid, VARIANT *pv) override;
+        STDMETHOD(GetDetailsOf)(PCUITEMID_CHILD pidl, UINT iColumn, SHELLDETAILS *psd) override;
+        STDMETHOD(MapColumnToSCID)(UINT column, SHCOLUMNID *pscid) override;
 
         // IPersist
-        virtual HRESULT WINAPI GetClassID(CLSID *lpClassId);
+        STDMETHOD(GetClassID)(CLSID *lpClassId) override;
 
         // IPersistFolder
-        virtual HRESULT WINAPI Initialize(PCIDLIST_ABSOLUTE pidl);
+        STDMETHOD(Initialize)(PCIDLIST_ABSOLUTE pidl) override;
 
         // IPersistFolder2
-        virtual HRESULT WINAPI GetCurFolder(PIDLIST_ABSOLUTE * pidl);
+        STDMETHOD(GetCurFolder)(PIDLIST_ABSOLUTE * pidl) override;
 
         /*** IItemNameLimits methods ***/
 
-        STDMETHODIMP
-        GetMaxLength(LPCWSTR pszName, int *piMaxNameLen)
+        STDMETHOD(GetMaxLength)(LPCWSTR pszName, int *piMaxNameLen) override
         {
             return E_NOTIMPL;
         }
 
-        STDMETHODIMP
-        GetValidCharacters(LPWSTR *ppwszValidChars, LPWSTR *ppwszInvalidChars)
+        STDMETHOD(GetValidCharacters)(LPWSTR *ppwszValidChars, LPWSTR *ppwszInvalidChars) override
         {
             if (ppwszValidChars)
             {

--- a/dll/win32/shell32/folders/CNetFolder.h
+++ b/dll/win32/shell32/folders/CNetFolder.h
@@ -38,34 +38,34 @@ class CNetFolder :
         ~CNetFolder();
 
         // IShellFolder
-        virtual HRESULT WINAPI ParseDisplayName(HWND hwndOwner, LPBC pbc, LPOLESTR lpszDisplayName, DWORD *pchEaten, PIDLIST_RELATIVE *ppidl, DWORD *pdwAttributes);
-        virtual HRESULT WINAPI EnumObjects(HWND hwndOwner, DWORD dwFlags, LPENUMIDLIST *ppEnumIDList);
-        virtual HRESULT WINAPI BindToObject(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut);
-        virtual HRESULT WINAPI BindToStorage(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut);
-        virtual HRESULT WINAPI CompareIDs(LPARAM lParam, PCUIDLIST_RELATIVE pidl1, PCUIDLIST_RELATIVE pidl2);
-        virtual HRESULT WINAPI CreateViewObject(HWND hwndOwner, REFIID riid, LPVOID *ppvOut);
-        virtual HRESULT WINAPI GetAttributesOf(UINT cidl, PCUITEMID_CHILD_ARRAY apidl, DWORD *rgfInOut);
-        virtual HRESULT WINAPI GetUIObjectOf(HWND hwndOwner, UINT cidl, PCUITEMID_CHILD_ARRAY apidl, REFIID riid, UINT * prgfInOut, LPVOID * ppvOut);
-        virtual HRESULT WINAPI GetDisplayNameOf(PCUITEMID_CHILD pidl, DWORD dwFlags, LPSTRRET strRet);
-        virtual HRESULT WINAPI SetNameOf(HWND hwndOwner, PCUITEMID_CHILD pidl, LPCOLESTR lpName, DWORD dwFlags, PITEMID_CHILD *pPidlOut);
+        STDMETHOD(ParseDisplayName)(HWND hwndOwner, LPBC pbc, LPOLESTR lpszDisplayName, DWORD *pchEaten, PIDLIST_RELATIVE *ppidl, DWORD *pdwAttributes) override;
+        STDMETHOD(EnumObjects)(HWND hwndOwner, DWORD dwFlags, LPENUMIDLIST *ppEnumIDList) override;
+        STDMETHOD(BindToObject)(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut) override;
+        STDMETHOD(BindToStorage)(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut) override;
+        STDMETHOD(CompareIDs)(LPARAM lParam, PCUIDLIST_RELATIVE pidl1, PCUIDLIST_RELATIVE pidl2) override;
+        STDMETHOD(CreateViewObject)(HWND hwndOwner, REFIID riid, LPVOID *ppvOut) override;
+        STDMETHOD(GetAttributesOf)(UINT cidl, PCUITEMID_CHILD_ARRAY apidl, DWORD *rgfInOut) override;
+        STDMETHOD(GetUIObjectOf)(HWND hwndOwner, UINT cidl, PCUITEMID_CHILD_ARRAY apidl, REFIID riid, UINT * prgfInOut, LPVOID * ppvOut) override;
+        STDMETHOD(GetDisplayNameOf)(PCUITEMID_CHILD pidl, DWORD dwFlags, LPSTRRET strRet) override;
+        STDMETHOD(SetNameOf)(HWND hwndOwner, PCUITEMID_CHILD pidl, LPCOLESTR lpName, DWORD dwFlags, PITEMID_CHILD *pPidlOut) override;
 
         /* ShellFolder2 */
-        virtual HRESULT WINAPI GetDefaultSearchGUID(GUID *pguid);
-        virtual HRESULT WINAPI EnumSearches(IEnumExtraSearch **ppenum);
-        virtual HRESULT WINAPI GetDefaultColumn(DWORD dwRes, ULONG *pSort, ULONG *pDisplay);
-        virtual HRESULT WINAPI GetDefaultColumnState(UINT iColumn, DWORD *pcsFlags);
-        virtual HRESULT WINAPI GetDetailsEx(PCUITEMID_CHILD pidl, const SHCOLUMNID *pscid, VARIANT *pv);
-        virtual HRESULT WINAPI GetDetailsOf(PCUITEMID_CHILD pidl, UINT iColumn, SHELLDETAILS *psd);
-        virtual HRESULT WINAPI MapColumnToSCID(UINT column, SHCOLUMNID *pscid);
+        STDMETHOD(GetDefaultSearchGUID)(GUID *pguid) override;
+        STDMETHOD(EnumSearches)(IEnumExtraSearch **ppenum) override;
+        STDMETHOD(GetDefaultColumn)(DWORD dwRes, ULONG *pSort, ULONG *pDisplay) override;
+        STDMETHOD(GetDefaultColumnState)(UINT iColumn, DWORD *pcsFlags) override;
+        STDMETHOD(GetDetailsEx)(PCUITEMID_CHILD pidl, const SHCOLUMNID *pscid, VARIANT *pv) override;
+        STDMETHOD(GetDetailsOf)(PCUITEMID_CHILD pidl, UINT iColumn, SHELLDETAILS *psd) override;
+        STDMETHOD(MapColumnToSCID)(UINT column, SHCOLUMNID *pscid) override;
 
         // IPersist
-        virtual HRESULT WINAPI GetClassID(CLSID *lpClassId);
+        STDMETHOD(GetClassID)(CLSID *lpClassId) override;
 
         // IPersistFolder
-        virtual HRESULT WINAPI Initialize(PCIDLIST_ABSOLUTE pidl);
+        STDMETHOD(Initialize)(PCIDLIST_ABSOLUTE pidl) override;
 
         // IPersistFolder2
-        virtual HRESULT WINAPI GetCurFolder(PIDLIST_ABSOLUTE * pidl);
+        STDMETHOD(GetCurFolder)(PIDLIST_ABSOLUTE * pidl) override;
 
         DECLARE_REGISTRY_RESOURCEID(IDR_NETWORKPLACES)
         DECLARE_NOT_AGGREGATABLE(CNetFolder)

--- a/dll/win32/shell32/folders/CPrinterFolder.h
+++ b/dll/win32/shell32/folders/CPrinterFolder.h
@@ -41,34 +41,34 @@ class CPrinterFolder :
         ~CPrinterFolder();
 
         // IShellFolder
-        virtual HRESULT WINAPI ParseDisplayName(HWND hwndOwner, LPBC pbc, LPOLESTR lpszDisplayName, DWORD *pchEaten, PIDLIST_RELATIVE *ppidl, DWORD *pdwAttributes);
-        virtual HRESULT WINAPI EnumObjects(HWND hwndOwner, DWORD dwFlags, LPENUMIDLIST *ppEnumIDList);
-        virtual HRESULT WINAPI BindToObject(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut);
-        virtual HRESULT WINAPI BindToStorage(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut);
-        virtual HRESULT WINAPI CompareIDs(LPARAM lParam, PCUIDLIST_RELATIVE pidl1, PCUIDLIST_RELATIVE pidl2);
-        virtual HRESULT WINAPI CreateViewObject(HWND hwndOwner, REFIID riid, LPVOID *ppvOut);
-        virtual HRESULT WINAPI GetAttributesOf(UINT cidl, PCUITEMID_CHILD_ARRAY apidl, DWORD *rgfInOut);
-        virtual HRESULT WINAPI GetUIObjectOf(HWND hwndOwner, UINT cidl, PCUITEMID_CHILD_ARRAY apidl, REFIID riid, UINT * prgfInOut, LPVOID * ppvOut);
-        virtual HRESULT WINAPI GetDisplayNameOf(PCUITEMID_CHILD pidl, DWORD dwFlags, LPSTRRET strRet);
-        virtual HRESULT WINAPI SetNameOf(HWND hwndOwner, PCUITEMID_CHILD pidl, LPCOLESTR lpName, DWORD dwFlags, PITEMID_CHILD *pPidlOut);
+        STDMETHOD(ParseDisplayName)(HWND hwndOwner, LPBC pbc, LPOLESTR lpszDisplayName, DWORD *pchEaten, PIDLIST_RELATIVE *ppidl, DWORD *pdwAttributes) override;
+        STDMETHOD(EnumObjects)(HWND hwndOwner, DWORD dwFlags, LPENUMIDLIST *ppEnumIDList) override;
+        STDMETHOD(BindToObject)(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut) override;
+        STDMETHOD(BindToStorage)(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut) override;
+        STDMETHOD(CompareIDs)(LPARAM lParam, PCUIDLIST_RELATIVE pidl1, PCUIDLIST_RELATIVE pidl2) override;
+        STDMETHOD(CreateViewObject)(HWND hwndOwner, REFIID riid, LPVOID *ppvOut) override;
+        STDMETHOD(GetAttributesOf)(UINT cidl, PCUITEMID_CHILD_ARRAY apidl, DWORD *rgfInOut) override;
+        STDMETHOD(GetUIObjectOf)(HWND hwndOwner, UINT cidl, PCUITEMID_CHILD_ARRAY apidl, REFIID riid, UINT * prgfInOut, LPVOID * ppvOut) override;
+        STDMETHOD(GetDisplayNameOf)(PCUITEMID_CHILD pidl, DWORD dwFlags, LPSTRRET strRet) override;
+        STDMETHOD(SetNameOf)(HWND hwndOwner, PCUITEMID_CHILD pidl, LPCOLESTR lpName, DWORD dwFlags, PITEMID_CHILD *pPidlOut) override;
 
         /* ShellFolder2 */
-        virtual HRESULT WINAPI GetDefaultSearchGUID(GUID *pguid);
-        virtual HRESULT WINAPI EnumSearches(IEnumExtraSearch **ppenum);
-        virtual HRESULT WINAPI GetDefaultColumn(DWORD dwRes, ULONG *pSort, ULONG *pDisplay);
-        virtual HRESULT WINAPI GetDefaultColumnState(UINT iColumn, DWORD *pcsFlags);
-        virtual HRESULT WINAPI GetDetailsEx(PCUITEMID_CHILD pidl, const SHCOLUMNID *pscid, VARIANT *pv);
-        virtual HRESULT WINAPI GetDetailsOf(PCUITEMID_CHILD pidl, UINT iColumn, SHELLDETAILS *psd);
-        virtual HRESULT WINAPI MapColumnToSCID(UINT column, SHCOLUMNID *pscid);
+        STDMETHOD(GetDefaultSearchGUID)(GUID *pguid) override;
+        STDMETHOD(EnumSearches)(IEnumExtraSearch **ppenum) override;
+        STDMETHOD(GetDefaultColumn)(DWORD dwRes, ULONG *pSort, ULONG *pDisplay) override;
+        STDMETHOD(GetDefaultColumnState)(UINT iColumn, DWORD *pcsFlags) override;
+        STDMETHOD(GetDetailsEx)(PCUITEMID_CHILD pidl, const SHCOLUMNID *pscid, VARIANT *pv) override;
+        STDMETHOD(GetDetailsOf)(PCUITEMID_CHILD pidl, UINT iColumn, SHELLDETAILS *psd) override;
+        STDMETHOD(MapColumnToSCID)(UINT column, SHCOLUMNID *pscid) override;
 
         // IPersist
-        virtual HRESULT WINAPI GetClassID(CLSID *lpClassId);
+        STDMETHOD(GetClassID)(CLSID *lpClassId) override;
 
         // IPersistFolder
-        virtual HRESULT WINAPI Initialize(PCIDLIST_ABSOLUTE pidl);
+        STDMETHOD(Initialize)(PCIDLIST_ABSOLUTE pidl) override;
 
         // IPersistFolder2
-        virtual HRESULT WINAPI GetCurFolder(PIDLIST_ABSOLUTE * pidl);
+        STDMETHOD(GetCurFolder)(PIDLIST_ABSOLUTE * pidl) override;
 
         DECLARE_REGISTRY_RESOURCEID(IDR_PRINTERS)
         DECLARE_NOT_AGGREGATABLE(CPrinterFolder)

--- a/dll/win32/shell32/folders/CRecycleBin.cpp
+++ b/dll/win32/shell32/folders/CRecycleBin.cpp
@@ -142,12 +142,12 @@ class CRecycleBinItemContextMenu :
         HRESULT WINAPI Initialize(LPCITEMIDLIST pidl);
 
         // IContextMenu
-        virtual HRESULT WINAPI QueryContextMenu(HMENU hMenu, UINT indexMenu, UINT idCmdFirst, UINT idCmdLast, UINT uFlags);
-        virtual HRESULT WINAPI InvokeCommand(LPCMINVOKECOMMANDINFO lpcmi);
-        virtual HRESULT WINAPI GetCommandString(UINT_PTR idCommand, UINT uFlags, UINT *lpReserved, LPSTR lpszName, UINT uMaxNameLen);
+        STDMETHOD(QueryContextMenu)(HMENU hMenu, UINT indexMenu, UINT idCmdFirst, UINT idCmdLast, UINT uFlags) override;
+        STDMETHOD(InvokeCommand)(LPCMINVOKECOMMANDINFO lpcmi) override;
+        STDMETHOD(GetCommandString)(UINT_PTR idCommand, UINT uFlags, UINT *lpReserved, LPSTR lpszName, UINT uMaxNameLen) override;
 
         // IContextMenu2
-        virtual HRESULT WINAPI HandleMenuMsg(UINT uMsg, WPARAM wParam, LPARAM lParam);
+        STDMETHOD(HandleMenuMsg)(UINT uMsg, WPARAM wParam, LPARAM lParam) override;
 
         BEGIN_COM_MAP(CRecycleBinItemContextMenu)
         COM_INTERFACE_ENTRY_IID(IID_IContextMenu, IContextMenu)

--- a/dll/win32/shell32/folders/CRecycleBin.h
+++ b/dll/win32/shell32/folders/CRecycleBin.h
@@ -45,44 +45,44 @@ class CRecycleBin :
         ~CRecycleBin();
 
         // IPersistFolder
-        virtual HRESULT WINAPI GetClassID(CLSID *pClassID);
-        virtual HRESULT WINAPI Initialize(PCIDLIST_ABSOLUTE pidl);
+        STDMETHOD(GetClassID)(CLSID *pClassID) override;
+        STDMETHOD(Initialize)(PCIDLIST_ABSOLUTE pidl) override;
 
         // IPersistFolder2
-        virtual HRESULT WINAPI GetCurFolder(PIDLIST_ABSOLUTE * pidl);
+        STDMETHOD(GetCurFolder)(PIDLIST_ABSOLUTE * pidl) override;
 
         // IShellFolder
-        virtual HRESULT WINAPI ParseDisplayName(HWND hwndOwner, LPBC pbc, LPOLESTR lpszDisplayName, DWORD *pchEaten, PIDLIST_RELATIVE *ppidl, DWORD *pdwAttributes);
-        virtual HRESULT WINAPI EnumObjects(HWND hwndOwner, DWORD dwFlags, LPENUMIDLIST *ppEnumIDList);
-        virtual HRESULT WINAPI BindToObject(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut);
-        virtual HRESULT WINAPI BindToStorage(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut);
-        virtual HRESULT WINAPI CompareIDs(LPARAM lParam, PCUIDLIST_RELATIVE pidl1, PCUIDLIST_RELATIVE pidl2);
-        virtual HRESULT WINAPI CreateViewObject(HWND hwndOwner, REFIID riid, LPVOID *ppvOut);
-        virtual HRESULT WINAPI GetAttributesOf(UINT cidl, PCUITEMID_CHILD_ARRAY apidl, DWORD *rgfInOut);
-        virtual HRESULT WINAPI GetUIObjectOf(HWND hwndOwner, UINT cidl, PCUITEMID_CHILD_ARRAY apidl, REFIID riid, UINT * prgfInOut, LPVOID * ppvOut);
-        virtual HRESULT WINAPI GetDisplayNameOf(PCUITEMID_CHILD pidl, DWORD dwFlags, LPSTRRET strRet);
-        virtual HRESULT WINAPI SetNameOf(HWND hwndOwner, PCUITEMID_CHILD pidl, LPCOLESTR lpName, DWORD dwFlags, PITEMID_CHILD *pPidlOut);
+        STDMETHOD(ParseDisplayName)(HWND hwndOwner, LPBC pbc, LPOLESTR lpszDisplayName, DWORD *pchEaten, PIDLIST_RELATIVE *ppidl, DWORD *pdwAttributes) override;
+        STDMETHOD(EnumObjects)(HWND hwndOwner, DWORD dwFlags, LPENUMIDLIST *ppEnumIDList) override;
+        STDMETHOD(BindToObject)(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut) override;
+        STDMETHOD(BindToStorage)(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut) override;
+        STDMETHOD(CompareIDs)(LPARAM lParam, PCUIDLIST_RELATIVE pidl1, PCUIDLIST_RELATIVE pidl2) override;
+        STDMETHOD(CreateViewObject)(HWND hwndOwner, REFIID riid, LPVOID *ppvOut) override;
+        STDMETHOD(GetAttributesOf)(UINT cidl, PCUITEMID_CHILD_ARRAY apidl, DWORD *rgfInOut) override;
+        STDMETHOD(GetUIObjectOf)(HWND hwndOwner, UINT cidl, PCUITEMID_CHILD_ARRAY apidl, REFIID riid, UINT * prgfInOut, LPVOID * ppvOut) override;
+        STDMETHOD(GetDisplayNameOf)(PCUITEMID_CHILD pidl, DWORD dwFlags, LPSTRRET strRet) override;
+        STDMETHOD(SetNameOf)(HWND hwndOwner, PCUITEMID_CHILD pidl, LPCOLESTR lpName, DWORD dwFlags, PITEMID_CHILD *pPidlOut) override;
 
         // IShellFolder2
-        virtual HRESULT WINAPI GetDefaultSearchGUID(GUID *pguid);
-        virtual HRESULT WINAPI EnumSearches(IEnumExtraSearch **ppenum);
-        virtual HRESULT WINAPI GetDefaultColumn(DWORD dwRes, ULONG *pSort, ULONG *pDisplay);
-        virtual HRESULT WINAPI GetDefaultColumnState(UINT iColumn, DWORD *pcsFlags);
-        virtual HRESULT WINAPI GetDetailsEx(PCUITEMID_CHILD pidl, const SHCOLUMNID *pscid, VARIANT *pv);
-        virtual HRESULT WINAPI GetDetailsOf(PCUITEMID_CHILD pidl, UINT iColumn, SHELLDETAILS *psd);
-        virtual HRESULT WINAPI MapColumnToSCID(UINT column, SHCOLUMNID *pscid);
+        STDMETHOD(GetDefaultSearchGUID)(GUID *pguid) override;
+        STDMETHOD(EnumSearches)(IEnumExtraSearch **ppenum) override;
+        STDMETHOD(GetDefaultColumn)(DWORD dwRes, ULONG *pSort, ULONG *pDisplay) override;
+        STDMETHOD(GetDefaultColumnState)(UINT iColumn, DWORD *pcsFlags) override;
+        STDMETHOD(GetDetailsEx)(PCUITEMID_CHILD pidl, const SHCOLUMNID *pscid, VARIANT *pv) override;
+        STDMETHOD(GetDetailsOf)(PCUITEMID_CHILD pidl, UINT iColumn, SHELLDETAILS *psd) override;
+        STDMETHOD(MapColumnToSCID)(UINT column, SHCOLUMNID *pscid) override;
 
         // IContextMenu
-        virtual HRESULT WINAPI QueryContextMenu(HMENU hMenu, UINT indexMenu, UINT idCmdFirst, UINT idCmdLast, UINT uFlags);
-        virtual HRESULT WINAPI InvokeCommand(LPCMINVOKECOMMANDINFO lpcmi);
-        virtual HRESULT WINAPI GetCommandString(UINT_PTR idCommand, UINT uFlags, UINT *lpReserved, LPSTR lpszName, UINT uMaxNameLen);
+        STDMETHOD(QueryContextMenu)(HMENU hMenu, UINT indexMenu, UINT idCmdFirst, UINT idCmdLast, UINT uFlags) override;
+        STDMETHOD(InvokeCommand)(LPCMINVOKECOMMANDINFO lpcmi) override;
+        STDMETHOD(GetCommandString)(UINT_PTR idCommand, UINT uFlags, UINT *lpReserved, LPSTR lpszName, UINT uMaxNameLen) override;
 
         // IShellPropSheetExt
-        virtual HRESULT WINAPI AddPages(LPFNSVADDPROPSHEETPAGE pfnAddPage, LPARAM lParam);
-        virtual HRESULT WINAPI ReplacePage(EXPPS uPageID, LPFNSVADDPROPSHEETPAGE pfnReplaceWith, LPARAM lParam);
+        STDMETHOD(AddPages)(LPFNSVADDPROPSHEETPAGE pfnAddPage, LPARAM lParam) override;
+        STDMETHOD(ReplacePage)(EXPPS uPageID, LPFNSVADDPROPSHEETPAGE pfnReplaceWith, LPARAM lParam) override;
 
         // IShellExtInit
-        virtual HRESULT STDMETHODCALLTYPE Initialize(PCIDLIST_ABSOLUTE pidlFolder, IDataObject *pdtobj, HKEY hkeyProgID);
+        STDMETHOD(Initialize)(PCIDLIST_ABSOLUTE pidlFolder, IDataObject *pdtobj, HKEY hkeyProgID) override;
 
         DECLARE_REGISTRY_RESOURCEID(IDR_RECYCLEBIN)
         DECLARE_NOT_AGGREGATABLE(CRecycleBin)

--- a/dll/win32/shell32/folders/CRegFolder.cpp
+++ b/dll/win32/shell32/folders/CRegFolder.cpp
@@ -318,25 +318,25 @@ class CRegFolder :
         HRESULT WINAPI Initialize(const GUID *pGuid, LPCITEMIDLIST pidlRoot, LPCWSTR lpszPath, LPCWSTR lpszEnumKeyName);
 
         // IShellFolder
-        virtual HRESULT WINAPI ParseDisplayName(HWND hwndOwner, LPBC pbc, LPOLESTR lpszDisplayName, ULONG *pchEaten, PIDLIST_RELATIVE *ppidl, ULONG *pdwAttributes);
-        virtual HRESULT WINAPI EnumObjects(HWND hwndOwner, DWORD dwFlags, LPENUMIDLIST *ppEnumIDList);
-        virtual HRESULT WINAPI BindToObject(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut);
-        virtual HRESULT WINAPI BindToStorage(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut);
-        virtual HRESULT WINAPI CompareIDs(LPARAM lParam, PCUIDLIST_RELATIVE pidl1, PCUIDLIST_RELATIVE pidl2);
-        virtual HRESULT WINAPI CreateViewObject(HWND hwndOwner, REFIID riid, LPVOID *ppvOut);
-        virtual HRESULT WINAPI GetAttributesOf(UINT cidl, PCUITEMID_CHILD_ARRAY apidl, DWORD *rgfInOut);
-        virtual HRESULT WINAPI GetUIObjectOf(HWND hwndOwner, UINT cidl, PCUITEMID_CHILD_ARRAY apidl, REFIID riid, UINT * prgfInOut, LPVOID * ppvOut);
-        virtual HRESULT WINAPI GetDisplayNameOf(PCUITEMID_CHILD pidl, DWORD dwFlags, LPSTRRET strRet);
-        virtual HRESULT WINAPI SetNameOf(HWND hwndOwner, PCUITEMID_CHILD pidl, LPCOLESTR lpName, DWORD dwFlags, PITEMID_CHILD *pPidlOut);
+        STDMETHOD(ParseDisplayName)(HWND hwndOwner, LPBC pbc, LPOLESTR lpszDisplayName, ULONG *pchEaten, PIDLIST_RELATIVE *ppidl, ULONG *pdwAttributes) override;
+        STDMETHOD(EnumObjects)(HWND hwndOwner, DWORD dwFlags, LPENUMIDLIST *ppEnumIDList) override;
+        STDMETHOD(BindToObject)(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut) override;
+        STDMETHOD(BindToStorage)(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut) override;
+        STDMETHOD(CompareIDs)(LPARAM lParam, PCUIDLIST_RELATIVE pidl1, PCUIDLIST_RELATIVE pidl2) override;
+        STDMETHOD(CreateViewObject)(HWND hwndOwner, REFIID riid, LPVOID *ppvOut) override;
+        STDMETHOD(GetAttributesOf)(UINT cidl, PCUITEMID_CHILD_ARRAY apidl, DWORD *rgfInOut) override;
+        STDMETHOD(GetUIObjectOf)(HWND hwndOwner, UINT cidl, PCUITEMID_CHILD_ARRAY apidl, REFIID riid, UINT * prgfInOut, LPVOID * ppvOut) override;
+        STDMETHOD(GetDisplayNameOf)(PCUITEMID_CHILD pidl, DWORD dwFlags, LPSTRRET strRet) override;
+        STDMETHOD(SetNameOf)(HWND hwndOwner, PCUITEMID_CHILD pidl, LPCOLESTR lpName, DWORD dwFlags, PITEMID_CHILD *pPidlOut) override;
 
         /* ShellFolder2 */
-        virtual HRESULT WINAPI GetDefaultSearchGUID(GUID *pguid);
-        virtual HRESULT WINAPI EnumSearches(IEnumExtraSearch **ppenum);
-        virtual HRESULT WINAPI GetDefaultColumn(DWORD dwRes, ULONG *pSort, ULONG *pDisplay);
-        virtual HRESULT WINAPI GetDefaultColumnState(UINT iColumn, DWORD *pcsFlags);
-        virtual HRESULT WINAPI GetDetailsEx(PCUITEMID_CHILD pidl, const SHCOLUMNID *pscid, VARIANT *pv);
-        virtual HRESULT WINAPI GetDetailsOf(PCUITEMID_CHILD pidl, UINT iColumn, SHELLDETAILS *psd);
-        virtual HRESULT WINAPI MapColumnToSCID(UINT column, SHCOLUMNID *pscid);
+        STDMETHOD(GetDefaultSearchGUID)(GUID *pguid) override;
+        STDMETHOD(EnumSearches)(IEnumExtraSearch **ppenum) override;
+        STDMETHOD(GetDefaultColumn)(DWORD dwRes, ULONG *pSort, ULONG *pDisplay) override;
+        STDMETHOD(GetDefaultColumnState)(UINT iColumn, DWORD *pcsFlags) override;
+        STDMETHOD(GetDetailsEx)(PCUITEMID_CHILD pidl, const SHCOLUMNID *pscid, VARIANT *pv) override;
+        STDMETHOD(GetDetailsOf)(PCUITEMID_CHILD pidl, UINT iColumn, SHELLDETAILS *psd) override;
+        STDMETHOD(MapColumnToSCID)(UINT column, SHCOLUMNID *pscid) override;
 
         DECLARE_NOT_AGGREGATABLE(CRegFolder)
 

--- a/dll/win32/shell32/shell32.cpp
+++ b/dll/win32/shell32/shell32.cpp
@@ -137,8 +137,8 @@ public:
     HRESULT Initialize(LPFNCREATEINSTANCE lpfnCI, PLONG pcRefDll, const IID *riidInstx);
 
     // IClassFactory
-    virtual HRESULT WINAPI CreateInstance(IUnknown * pUnkOuter, REFIID riid, LPVOID *ppvObject);
-    virtual HRESULT WINAPI LockServer(BOOL fLock);
+    STDMETHOD(CreateInstance)(IUnknown * pUnkOuter, REFIID riid, LPVOID *ppvObject) override;
+    STDMETHOD(LockServer)(BOOL fLock) override;
 
 BEGIN_COM_MAP(IDefClFImpl)
     COM_INTERFACE_ENTRY_IID(IID_IClassFactory, IClassFactory)

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -42,8 +42,8 @@ public:
     HRESULT Initialize();
 
     // *** IOleWindow methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetWindow(HWND *lphwnd);
-    virtual HRESULT STDMETHODCALLTYPE ContextSensitiveHelp(BOOL fEnterMode);
+    STDMETHOD(GetWindow)(HWND *lphwnd) override;
+    STDMETHOD(ContextSensitiveHelp)(BOOL fEnterMode) override;
 
     // Message handlers
     LRESULT OnRegister(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);

--- a/dll/win32/shell32/shelldesktop/CDesktopBrowser.cpp
+++ b/dll/win32/shell32/shelldesktop/CDesktopBrowser.cpp
@@ -55,26 +55,26 @@ public:
     HRESULT Initialize(IShellDesktopTray *ShellDeskx);
 
     // *** IOleWindow methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetWindow(HWND *lphwnd);
-    virtual HRESULT STDMETHODCALLTYPE ContextSensitiveHelp(BOOL fEnterMode);
+    STDMETHOD(GetWindow)(HWND *lphwnd) override;
+    STDMETHOD(ContextSensitiveHelp)(BOOL fEnterMode) override;
 
     // *** IShellBrowser methods ***
-    virtual HRESULT STDMETHODCALLTYPE InsertMenusSB(HMENU hmenuShared, LPOLEMENUGROUPWIDTHS lpMenuWidths);
-    virtual HRESULT STDMETHODCALLTYPE SetMenuSB(HMENU hmenuShared, HOLEMENU holemenuRes, HWND hwndActiveObject);
-    virtual HRESULT STDMETHODCALLTYPE RemoveMenusSB(HMENU hmenuShared);
-    virtual HRESULT STDMETHODCALLTYPE SetStatusTextSB(LPCOLESTR pszStatusText);
-    virtual HRESULT STDMETHODCALLTYPE EnableModelessSB(BOOL fEnable);
-    virtual HRESULT STDMETHODCALLTYPE TranslateAcceleratorSB(MSG *pmsg, WORD wID);
-    virtual HRESULT STDMETHODCALLTYPE BrowseObject(LPCITEMIDLIST pidl, UINT wFlags);
-    virtual HRESULT STDMETHODCALLTYPE GetViewStateStream(DWORD grfMode, IStream **ppStrm);
-    virtual HRESULT STDMETHODCALLTYPE GetControlWindow(UINT id, HWND *lphwnd);
-    virtual HRESULT STDMETHODCALLTYPE SendControlMsg(UINT id, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT *pret);
-    virtual HRESULT STDMETHODCALLTYPE QueryActiveShellView(struct IShellView **ppshv);
-    virtual HRESULT STDMETHODCALLTYPE OnViewWindowActive(struct IShellView *ppshv);
-    virtual HRESULT STDMETHODCALLTYPE SetToolbarItems(LPTBBUTTON lpButtons, UINT nButtons, UINT uFlags);
+    STDMETHOD(InsertMenusSB)(HMENU hmenuShared, LPOLEMENUGROUPWIDTHS lpMenuWidths) override;
+    STDMETHOD(SetMenuSB)(HMENU hmenuShared, HOLEMENU holemenuRes, HWND hwndActiveObject) override;
+    STDMETHOD(RemoveMenusSB)(HMENU hmenuShared) override;
+    STDMETHOD(SetStatusTextSB)(LPCOLESTR pszStatusText) override;
+    STDMETHOD(EnableModelessSB)(BOOL fEnable) override;
+    STDMETHOD(TranslateAcceleratorSB)(MSG *pmsg, WORD wID) override;
+    STDMETHOD(BrowseObject)(LPCITEMIDLIST pidl, UINT wFlags) override;
+    STDMETHOD(GetViewStateStream)(DWORD grfMode, IStream **ppStrm) override;
+    STDMETHOD(GetControlWindow)(UINT id, HWND *lphwnd) override;
+    STDMETHOD(SendControlMsg)(UINT id, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT *pret) override;
+    STDMETHOD(QueryActiveShellView)(struct IShellView **ppshv) override;
+    STDMETHOD(OnViewWindowActive)(struct IShellView *ppshv) override;
+    STDMETHOD(SetToolbarItems)(LPTBBUTTON lpButtons, UINT nButtons, UINT uFlags) override;
 
     // *** IServiceProvider methods ***
-    virtual HRESULT STDMETHODCALLTYPE QueryService(REFGUID guidService, REFIID riid, void **ppvObject);
+    STDMETHOD(QueryService)(REFGUID guidService, REFIID riid, void **ppvObject) override;
 
     // message handlers
     LRESULT OnEraseBkgnd(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);

--- a/dll/win32/shell32/shellmenu/CMenuBand.h
+++ b/dll/win32/shell32/shellmenu/CMenuBand.h
@@ -100,86 +100,86 @@ public:
     END_COM_MAP()
 
     // *** IDeskBand methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetBandInfo(DWORD dwBandID, DWORD dwViewMode, DESKBANDINFO *pdbi);
+    STDMETHOD(GetBandInfo)(DWORD dwBandID, DWORD dwViewMode, DESKBANDINFO *pdbi) override;
 
     // *** IDockingWindow methods ***
-    virtual HRESULT STDMETHODCALLTYPE ShowDW(BOOL fShow);
-    virtual HRESULT STDMETHODCALLTYPE CloseDW(DWORD dwReserved);
-    virtual HRESULT STDMETHODCALLTYPE ResizeBorderDW(LPCRECT prcBorder, IUnknown *punkToolbarSite, BOOL fReserved);
+    STDMETHOD(ShowDW)(BOOL fShow) override;
+    STDMETHOD(CloseDW)(DWORD dwReserved) override;
+    STDMETHOD(ResizeBorderDW)(LPCRECT prcBorder, IUnknown *punkToolbarSite, BOOL fReserved) override;
 
     // *** IOleWindow methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetWindow(HWND *phwnd);
-    virtual HRESULT STDMETHODCALLTYPE ContextSensitiveHelp(BOOL fEnterMode);
+    STDMETHOD(GetWindow)(HWND *phwnd) override;
+    STDMETHOD(ContextSensitiveHelp)(BOOL fEnterMode) override;
 
     // *** IObjectWithSite methods ***
-    virtual HRESULT STDMETHODCALLTYPE SetSite(IUnknown *pUnkSite);
-    virtual HRESULT STDMETHODCALLTYPE GetSite(REFIID riid, PVOID *ppvSite);
+    STDMETHOD(SetSite)(IUnknown *pUnkSite) override;
+    STDMETHOD(GetSite)(REFIID riid, PVOID *ppvSite) override;
 
     // *** IInputObject methods ***
-    virtual HRESULT STDMETHODCALLTYPE UIActivateIO(BOOL fActivate, LPMSG lpMsg);
-    virtual HRESULT STDMETHODCALLTYPE HasFocusIO();
-    virtual HRESULT STDMETHODCALLTYPE TranslateAcceleratorIO(LPMSG lpMsg);
+    STDMETHOD(UIActivateIO)(BOOL fActivate, LPMSG lpMsg) override;
+    STDMETHOD(HasFocusIO)() override;
+    STDMETHOD(TranslateAcceleratorIO)(LPMSG lpMsg) override;
 
     // *** IPersistStream methods ***
-    virtual HRESULT STDMETHODCALLTYPE IsDirty();
-    virtual HRESULT STDMETHODCALLTYPE Load(IStream *pStm);
-    virtual HRESULT STDMETHODCALLTYPE Save(IStream *pStm, BOOL fClearDirty);
-    virtual HRESULT STDMETHODCALLTYPE GetSizeMax(ULARGE_INTEGER *pcbSize);
+    STDMETHOD(IsDirty)() override;
+    STDMETHOD(Load)(IStream *pStm) override;
+    STDMETHOD(Save)(IStream *pStm, BOOL fClearDirty) override;
+    STDMETHOD(GetSizeMax)(ULARGE_INTEGER *pcbSize) override;
 
     // *** IPersist methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetClassID(CLSID *pClassID);
+    STDMETHOD(GetClassID)(CLSID *pClassID) override;
 
     // *** IOleCommandTarget methods ***
-    virtual HRESULT STDMETHODCALLTYPE QueryStatus(const GUID *pguidCmdGroup, ULONG cCmds, OLECMD prgCmds [], OLECMDTEXT *pCmdText);
-    virtual HRESULT STDMETHODCALLTYPE Exec(const GUID *pguidCmdGroup, DWORD nCmdID, DWORD nCmdexecopt, VARIANT *pvaIn, VARIANT *pvaOut);
+    STDMETHOD(QueryStatus)(const GUID *pguidCmdGroup, ULONG cCmds, OLECMD prgCmds [], OLECMDTEXT *pCmdText) override;
+    STDMETHOD(Exec)(const GUID *pguidCmdGroup, DWORD nCmdID, DWORD nCmdexecopt, VARIANT *pvaIn, VARIANT *pvaOut) override;
 
     // *** IServiceProvider methods ***
-    virtual HRESULT STDMETHODCALLTYPE QueryService(REFGUID guidService, REFIID riid, void **ppvObject);
+    STDMETHOD(QueryService)(REFGUID guidService, REFIID riid, void **ppvObject) override;
 
     // *** IMenuPopup methods ***
-    virtual HRESULT STDMETHODCALLTYPE Popup(POINTL *ppt, RECTL *prcExclude, MP_POPUPFLAGS dwFlags);
-    virtual HRESULT STDMETHODCALLTYPE OnSelect(DWORD dwSelectType);
-    virtual HRESULT STDMETHODCALLTYPE SetSubMenu(IMenuPopup *pmp, BOOL fSet);
+    STDMETHOD(Popup)(POINTL *ppt, RECTL *prcExclude, MP_POPUPFLAGS dwFlags) override;
+    STDMETHOD(OnSelect)(DWORD dwSelectType) override;
+    STDMETHOD(SetSubMenu)(IMenuPopup *pmp, BOOL fSet) override;
 
     // *** IDeskBar methods ***
-    virtual HRESULT STDMETHODCALLTYPE SetClient(IUnknown *punkClient);
-    virtual HRESULT STDMETHODCALLTYPE GetClient(IUnknown **ppunkClient);
-    virtual HRESULT STDMETHODCALLTYPE OnPosRectChangeDB(RECT *prc);
+    STDMETHOD(SetClient)(IUnknown *punkClient) override;
+    STDMETHOD(GetClient)(IUnknown **ppunkClient) override;
+    STDMETHOD(OnPosRectChangeDB)(RECT *prc) override;
 
     // *** IMenuBand methods ***
-    virtual HRESULT STDMETHODCALLTYPE IsMenuMessage(MSG *pmsg);
-    virtual HRESULT STDMETHODCALLTYPE TranslateMenuMessage(MSG *pmsg, LRESULT *plRet);
+    STDMETHOD(IsMenuMessage)(MSG *pmsg) override;
+    STDMETHOD(TranslateMenuMessage)(MSG *pmsg, LRESULT *plRet) override;
 
     // *** IShellMenu methods ***
-    virtual HRESULT STDMETHODCALLTYPE Initialize(IShellMenuCallback *psmc, UINT uId, UINT uIdAncestor, DWORD dwFlags);
-    virtual HRESULT STDMETHODCALLTYPE GetMenuInfo(IShellMenuCallback **ppsmc, UINT *puId, UINT *puIdAncestor, DWORD *pdwFlags);
-    virtual HRESULT STDMETHODCALLTYPE SetShellFolder(IShellFolder *psf, LPCITEMIDLIST pidlFolder, HKEY hKey, DWORD dwFlags);
-    virtual HRESULT STDMETHODCALLTYPE GetShellFolder(DWORD *pdwFlags, LPITEMIDLIST *ppidl, REFIID riid, void **ppv);
-    virtual HRESULT STDMETHODCALLTYPE SetMenu(HMENU hmenu, HWND hwnd, DWORD dwFlags);
-    virtual HRESULT STDMETHODCALLTYPE GetMenu(HMENU *phmenu, HWND *phwnd, DWORD *pdwFlags);
-    virtual HRESULT STDMETHODCALLTYPE InvalidateItem(LPSMDATA psmd, DWORD dwFlags);
-    virtual HRESULT STDMETHODCALLTYPE GetState(LPSMDATA psmd);
-    virtual HRESULT STDMETHODCALLTYPE SetMenuToolbar(IUnknown *punk, DWORD dwFlags);
+    STDMETHOD(Initialize)(IShellMenuCallback *psmc, UINT uId, UINT uIdAncestor, DWORD dwFlags) override;
+    STDMETHOD(GetMenuInfo)(IShellMenuCallback **ppsmc, UINT *puId, UINT *puIdAncestor, DWORD *pdwFlags) override;
+    STDMETHOD(SetShellFolder)(IShellFolder *psf, LPCITEMIDLIST pidlFolder, HKEY hKey, DWORD dwFlags) override;
+    STDMETHOD(GetShellFolder)(DWORD *pdwFlags, LPITEMIDLIST *ppidl, REFIID riid, void **ppv) override;
+    STDMETHOD(SetMenu)(HMENU hmenu, HWND hwnd, DWORD dwFlags) override;
+    STDMETHOD(GetMenu)(HMENU *phmenu, HWND *phwnd, DWORD *pdwFlags) override;
+    STDMETHOD(InvalidateItem)(LPSMDATA psmd, DWORD dwFlags) override;
+    STDMETHOD(GetState)(LPSMDATA psmd) override;
+    STDMETHOD(SetMenuToolbar)(IUnknown *punk, DWORD dwFlags) override;
 
     // *** IWinEventHandler methods ***
-    virtual HRESULT STDMETHODCALLTYPE OnWinEvent(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT *theResult);
-    virtual HRESULT STDMETHODCALLTYPE IsWindowOwner(HWND hWnd);
+    STDMETHOD(OnWinEvent)(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT *theResult) override;
+    STDMETHOD(IsWindowOwner)(HWND hWnd) override;
 
     // *** IShellMenu2 methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetSubMenu(THIS);
-    virtual HRESULT STDMETHODCALLTYPE SetToolbar(THIS);
-    virtual HRESULT STDMETHODCALLTYPE SetMinWidth(THIS);
-    virtual HRESULT STDMETHODCALLTYPE SetNoBorder(THIS);
-    virtual HRESULT STDMETHODCALLTYPE SetTheme(THIS);
+    STDMETHOD(GetSubMenu)(THIS) override;
+    STDMETHOD(SetToolbar)(THIS) override;
+    STDMETHOD(SetMinWidth)(THIS) override;
+    STDMETHOD(SetNoBorder)(THIS) override;
+    STDMETHOD(SetTheme)(THIS) override;
 
     // *** IShellMenuAcc methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetTop(THIS);
-    virtual HRESULT STDMETHODCALLTYPE GetBottom(THIS);
-    virtual HRESULT STDMETHODCALLTYPE GetTracked(THIS);
-    virtual HRESULT STDMETHODCALLTYPE GetParentSite(THIS);
-    virtual HRESULT STDMETHODCALLTYPE GetState(THIS);
-    virtual HRESULT STDMETHODCALLTYPE DoDefaultAction(THIS);
-    virtual HRESULT STDMETHODCALLTYPE IsEmpty(THIS);
+    STDMETHOD(GetTop)(THIS) override;
+    STDMETHOD(GetBottom)(THIS) override;
+    STDMETHOD(GetTracked)(THIS) override;
+    STDMETHOD(GetParentSite)(THIS) override;
+    STDMETHOD(GetState)(THIS) override;
+    STDMETHOD(DoDefaultAction)(THIS) override;
+    STDMETHOD(IsEmpty)(THIS) override;
 
     HRESULT _CallCBWithItemId(UINT Id, UINT uMsg, WPARAM wParam, LPARAM lParam);
     HRESULT _CallCBWithItemPidl(LPITEMIDLIST pidl, UINT uMsg, WPARAM wParam, LPARAM lParam);

--- a/dll/win32/shell32/shellmenu/CMenuDeskBar.h
+++ b/dll/win32/shell32/shellmenu/CMenuDeskBar.h
@@ -91,46 +91,46 @@ public:
     END_COM_MAP()
 
     // *** IMenuPopup methods ***
-    virtual HRESULT STDMETHODCALLTYPE Popup(POINTL *ppt, RECTL *prcExclude, MP_POPUPFLAGS dwFlags);
-    virtual HRESULT STDMETHODCALLTYPE OnSelect(DWORD dwSelectType);
-    virtual HRESULT STDMETHODCALLTYPE SetSubMenu(IMenuPopup *pmp, BOOL fSet);
+    STDMETHOD(Popup)(POINTL *ppt, RECTL *prcExclude, MP_POPUPFLAGS dwFlags) override;
+    STDMETHOD(OnSelect)(DWORD dwSelectType) override;
+    STDMETHOD(SetSubMenu)(IMenuPopup *pmp, BOOL fSet) override;
 
     // *** IOleWindow methods ***
-    virtual HRESULT STDMETHODCALLTYPE GetWindow(HWND *phwnd);
-    virtual HRESULT STDMETHODCALLTYPE ContextSensitiveHelp(BOOL fEnterMode);
+    STDMETHOD(GetWindow)(HWND *phwnd) override;
+    STDMETHOD(ContextSensitiveHelp)(BOOL fEnterMode) override;
 
     // *** IObjectWithSite methods ***
-    virtual HRESULT STDMETHODCALLTYPE SetSite(IUnknown *pUnkSite);
-    virtual HRESULT STDMETHODCALLTYPE GetSite(REFIID riid, PVOID *ppvSite);
+    STDMETHOD(SetSite)(IUnknown *pUnkSite) override;
+    STDMETHOD(GetSite)(REFIID riid, PVOID *ppvSite) override;
 
     // *** IBanneredBar methods ***
-    virtual HRESULT STDMETHODCALLTYPE SetIconSize(DWORD iIcon);
-    virtual HRESULT STDMETHODCALLTYPE GetIconSize(DWORD* piIcon);
-    virtual HRESULT STDMETHODCALLTYPE SetBitmap(HBITMAP hBitmap);
-    virtual HRESULT STDMETHODCALLTYPE GetBitmap(HBITMAP* phBitmap);
+    STDMETHOD(SetIconSize)(DWORD iIcon) override;
+    STDMETHOD(GetIconSize)(DWORD* piIcon) override;
+    STDMETHOD(SetBitmap)(HBITMAP hBitmap) override;
+    STDMETHOD(GetBitmap)(HBITMAP* phBitmap) override;
 
     // *** IInitializeObject methods ***
-    virtual HRESULT STDMETHODCALLTYPE Initialize(THIS);
+    STDMETHOD(Initialize)(THIS) override;
 
     // *** IOleCommandTarget methods ***
-    virtual HRESULT STDMETHODCALLTYPE QueryStatus(const GUID *pguidCmdGroup, ULONG cCmds, OLECMD prgCmds [], OLECMDTEXT *pCmdText);
-    virtual HRESULT STDMETHODCALLTYPE Exec(const GUID *pguidCmdGroup, DWORD nCmdID, DWORD nCmdexecopt, VARIANT *pvaIn, VARIANT *pvaOut);
+    STDMETHOD(QueryStatus)(const GUID *pguidCmdGroup, ULONG cCmds, OLECMD prgCmds [], OLECMDTEXT *pCmdText) override;
+    STDMETHOD(Exec)(const GUID *pguidCmdGroup, DWORD nCmdID, DWORD nCmdexecopt, VARIANT *pvaIn, VARIANT *pvaOut) override;
 
     // *** IServiceProvider methods ***
-    virtual HRESULT STDMETHODCALLTYPE QueryService(REFGUID guidService, REFIID riid, void **ppvObject);
+    STDMETHOD(QueryService)(REFGUID guidService, REFIID riid, void **ppvObject) override;
 
     // *** IInputObjectSite methods ***
-    virtual HRESULT STDMETHODCALLTYPE OnFocusChangeIS(LPUNKNOWN lpUnknown, BOOL bFocus);
+    STDMETHOD(OnFocusChangeIS)(LPUNKNOWN lpUnknown, BOOL bFocus) override;
 
     // *** IInputObject methods ***
-    virtual HRESULT STDMETHODCALLTYPE UIActivateIO(BOOL bActivating, LPMSG lpMsg);
-    virtual HRESULT STDMETHODCALLTYPE HasFocusIO(THIS);
-    virtual HRESULT STDMETHODCALLTYPE TranslateAcceleratorIO(LPMSG lpMsg);
+    STDMETHOD(UIActivateIO)(BOOL bActivating, LPMSG lpMsg) override;
+    STDMETHOD(HasFocusIO)(THIS) override;
+    STDMETHOD(TranslateAcceleratorIO)(LPMSG lpMsg) override;
 
     // *** IDeskBar methods ***
-    virtual HRESULT STDMETHODCALLTYPE SetClient(IUnknown *punkClient);
-    virtual HRESULT STDMETHODCALLTYPE GetClient(IUnknown **ppunkClient);
-    virtual HRESULT STDMETHODCALLTYPE OnPosRectChangeDB(LPRECT prc);
+    STDMETHOD(SetClient)(IUnknown *punkClient) override;
+    STDMETHOD(GetClient)(IUnknown **ppunkClient) override;
+    STDMETHOD(OnPosRectChangeDB)(LPRECT prc) override;
 
 private:
     // message handlers

--- a/dll/win32/shell32/shellmenu/CMenuSite.h
+++ b/dll/win32/shell32/shellmenu/CMenuSite.h
@@ -91,11 +91,10 @@ public:
     // IServiceProvider
     STDMETHOD(QueryService)(REFGUID guidService, REFIID riid, void **ppvObject) override;
 
-
     // Using custom message map instead
     virtual BOOL ProcessWindowMessage(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT &lResult, DWORD mapId = 0);
 
-    // UNIMPLEMENTED
+    // IDeskBarClient
     STDMETHOD(ContextSensitiveHelp)(BOOL fEnterMode) override;
     STDMETHOD(GetBandSiteInfo)(BANDSITEINFO *pbsinfo) override;
     STDMETHOD(RemoveBand)(DWORD dwBandID) override;

--- a/dll/win32/shell32/shellmenu/CMenuSite.h
+++ b/dll/win32/shell32/shellmenu/CMenuSite.h
@@ -59,49 +59,49 @@ public:
     END_COM_MAP()
 
     // IBandSite
-    virtual HRESULT STDMETHODCALLTYPE AddBand(IUnknown * punk);
-    virtual HRESULT STDMETHODCALLTYPE EnumBands(UINT uBand, DWORD* pdwBandID);
-    virtual HRESULT STDMETHODCALLTYPE QueryBand(DWORD dwBandID, IDeskBand **ppstb, DWORD *pdwState, LPWSTR pszName, int cchName);
-    virtual HRESULT STDMETHODCALLTYPE GetBandObject(DWORD dwBandID, REFIID riid, VOID **ppv);
+    STDMETHOD(AddBand)(IUnknown * punk) override;
+    STDMETHOD(EnumBands)(UINT uBand, DWORD* pdwBandID) override;
+    STDMETHOD(QueryBand)(DWORD dwBandID, IDeskBand **ppstb, DWORD *pdwState, LPWSTR pszName, int cchName) override;
+    STDMETHOD(GetBandObject)(DWORD dwBandID, REFIID riid, VOID **ppv) override;
 
     // IDeskBarClient
-    virtual HRESULT STDMETHODCALLTYPE SetDeskBarSite(IUnknown *punkSite);
-    virtual HRESULT STDMETHODCALLTYPE GetSize(DWORD dwWhich, LPRECT prc);
-    virtual HRESULT STDMETHODCALLTYPE UIActivateDBC(DWORD dwState);
+    STDMETHOD(SetDeskBarSite)(IUnknown *punkSite) override;
+    STDMETHOD(GetSize)(DWORD dwWhich, LPRECT prc) override;
+    STDMETHOD(UIActivateDBC)(DWORD dwState) override;
 
     // IOleWindow
-    virtual HRESULT STDMETHODCALLTYPE GetWindow(HWND *phwnd);
+    STDMETHOD(GetWindow)(HWND *phwnd) override;
 
     // IOleCommandTarget
-    virtual HRESULT STDMETHODCALLTYPE QueryStatus(const GUID * pguidCmdGroup, ULONG cCmds, OLECMD prgCmds [], OLECMDTEXT *pCmdText);
-    virtual HRESULT STDMETHODCALLTYPE Exec(const GUID * pguidCmdGroup, DWORD nCmdID, DWORD nCmdexecopt, VARIANT *pvaIn, VARIANT *pvaOut);
+    STDMETHOD(QueryStatus)(const GUID * pguidCmdGroup, ULONG cCmds, OLECMD prgCmds [], OLECMDTEXT *pCmdText) override;
+    STDMETHOD(Exec)(const GUID * pguidCmdGroup, DWORD nCmdID, DWORD nCmdexecopt, VARIANT *pvaIn, VARIANT *pvaOut) override;
 
     // IInputObject
-    virtual HRESULT STDMETHODCALLTYPE UIActivateIO(BOOL fActivate, LPMSG lpMsg);
-    virtual HRESULT STDMETHODCALLTYPE HasFocusIO();
-    virtual HRESULT STDMETHODCALLTYPE TranslateAcceleratorIO(LPMSG lpMsg);
+    STDMETHOD(UIActivateIO)(BOOL fActivate, LPMSG lpMsg) override;
+    STDMETHOD(HasFocusIO)() override;
+    STDMETHOD(TranslateAcceleratorIO)(LPMSG lpMsg) override;
 
     // IInputObjectSite
-    virtual HRESULT STDMETHODCALLTYPE OnFocusChangeIS(IUnknown *punkObj, BOOL fSetFocus);
+    STDMETHOD(OnFocusChangeIS)(IUnknown *punkObj, BOOL fSetFocus) override;
 
     // IWinEventHandler
-    virtual HRESULT STDMETHODCALLTYPE IsWindowOwner(HWND hWnd);
-    virtual HRESULT STDMETHODCALLTYPE OnWinEvent(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT *theResult);
+    STDMETHOD(IsWindowOwner)(HWND hWnd) override;
+    STDMETHOD(OnWinEvent)(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT *theResult) override;
 
     // IServiceProvider
-    virtual HRESULT STDMETHODCALLTYPE QueryService(REFGUID guidService, REFIID riid, void **ppvObject);
+    STDMETHOD(QueryService)(REFGUID guidService, REFIID riid, void **ppvObject) override;
 
 
     // Using custom message map instead
     virtual BOOL ProcessWindowMessage(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT &lResult, DWORD mapId = 0);
 
     // UNIMPLEMENTED
-    virtual HRESULT STDMETHODCALLTYPE ContextSensitiveHelp(BOOL fEnterMode);
-    virtual HRESULT STDMETHODCALLTYPE GetBandSiteInfo(BANDSITEINFO *pbsinfo);
-    virtual HRESULT STDMETHODCALLTYPE RemoveBand(DWORD dwBandID);
-    virtual HRESULT STDMETHODCALLTYPE SetBandSiteInfo(const BANDSITEINFO *pbsinfo);
-    virtual HRESULT STDMETHODCALLTYPE SetBandState(DWORD dwBandID, DWORD dwMask, DWORD dwState);
-    virtual HRESULT STDMETHODCALLTYPE SetModeDBC(DWORD dwMode);
+    STDMETHOD(ContextSensitiveHelp)(BOOL fEnterMode) override;
+    STDMETHOD(GetBandSiteInfo)(BANDSITEINFO *pbsinfo) override;
+    STDMETHOD(RemoveBand)(DWORD dwBandID) override;
+    STDMETHOD(SetBandSiteInfo)(const BANDSITEINFO *pbsinfo) override;
+    STDMETHOD(SetBandState)(DWORD dwBandID, DWORD dwMask, DWORD dwState) override;
+    STDMETHOD(SetModeDBC)(DWORD dwMode) override;
 
 private:
     IUnknown * ToIUnknown() { return static_cast<IDeskBarClient*>(this); }

--- a/dll/win32/shell32/shellmenu/CMenuToolbars.h
+++ b/dll/win32/shell32/shellmenu/CMenuToolbars.h
@@ -102,13 +102,13 @@ public:
     HRESULT BeforeCancelPopup();
 
 protected:
-    STDMETHOD(OnDeletingButton)(const NMTOOLBAR * tb) = 0;
+    virtual HRESULT OnDeletingButton(const NMTOOLBAR * tb) PURE;
 
-    STDMETHOD(InternalGetTooltip)(INT iItem, INT index, DWORD_PTR dwData, LPWSTR pszText, INT cchTextMax) = 0;
-    STDMETHOD(InternalExecuteItem)(INT iItem, INT index, DWORD_PTR dwData) = 0;
-    STDMETHOD(InternalPopupItem)(INT iItem, INT index, DWORD_PTR dwData, BOOL keyInitiated) = 0;
-    STDMETHOD(InternalHasSubMenu)(INT iItem, INT index, DWORD_PTR dwData) = 0;
-    STDMETHOD(InternalContextMenu)(INT iItem, INT index, DWORD_PTR dwData, POINT pt) = 0;
+    virtual HRESULT InternalGetTooltip(INT iItem, INT index, DWORD_PTR dwData, LPWSTR pszText, INT cchTextMax) PURE;
+    virtual HRESULT InternalExecuteItem(INT iItem, INT index, DWORD_PTR dwData) PURE;
+    virtual HRESULT InternalPopupItem(INT iItem, INT index, DWORD_PTR dwData, BOOL keyInitiated) PURE;
+    virtual HRESULT InternalHasSubMenu(INT iItem, INT index, DWORD_PTR dwData) PURE;
+    virtual HRESULT InternalContextMenu(INT iItem, INT index, DWORD_PTR dwData, POINT pt) PURE;
 
     HRESULT AddButton(DWORD commandId, LPCWSTR caption, BOOL hasSubMenu, INT iconId, DWORD_PTR buttonData, BOOL last);
     HRESULT AddSeparator(BOOL last);
@@ -155,13 +155,13 @@ public:
     virtual HRESULT FillToolbar(BOOL clearFirst=FALSE) override;
 
 protected:
-    STDMETHOD(OnDeletingButton)(const NMTOOLBAR * tb) override;
+    virtual HRESULT OnDeletingButton(const NMTOOLBAR * tb) override;
 
-    STDMETHOD(InternalGetTooltip)(INT iItem, INT index, DWORD_PTR dwData, LPWSTR pszText, INT cchTextMax) override;
-    STDMETHOD(InternalExecuteItem)(INT iItem, INT index, DWORD_PTR dwData) override;
-    STDMETHOD(InternalPopupItem)(INT iItem, INT index, DWORD_PTR dwData, BOOL keyInitiated) override;
-    STDMETHOD(InternalHasSubMenu)(INT iItem, INT index, DWORD_PTR dwData) override;
-    STDMETHOD(InternalContextMenu)(INT iItem, INT index, DWORD_PTR dwData, POINT pt) override;
+    virtual HRESULT InternalGetTooltip(INT iItem, INT index, DWORD_PTR dwData, LPWSTR pszText, INT cchTextMax) override;
+    virtual HRESULT InternalExecuteItem(INT iItem, INT index, DWORD_PTR dwData) override;
+    virtual HRESULT InternalPopupItem(INT iItem, INT index, DWORD_PTR dwData, BOOL keyInitiated) override;
+    virtual HRESULT InternalHasSubMenu(INT iItem, INT index, DWORD_PTR dwData) override;
+    virtual HRESULT InternalContextMenu(INT iItem, INT index, DWORD_PTR dwData, POINT pt) override;
 };
 
 class CMenuSFToolbar :
@@ -182,11 +182,11 @@ public:
     virtual HRESULT FillToolbar(BOOL clearFirst=FALSE) override;
 
 protected:
-    STDMETHOD(OnDeletingButton)(const NMTOOLBAR * tb) override;
+    virtual HRESULT OnDeletingButton(const NMTOOLBAR * tb) override;
 
-    STDMETHOD(InternalGetTooltip)(INT iItem, INT index, DWORD_PTR dwData, LPWSTR pszText, INT cchTextMax) override;
-    STDMETHOD(InternalExecuteItem)(INT iItem, INT index, DWORD_PTR dwData) override;
-    STDMETHOD(InternalPopupItem)(INT iItem, INT index, DWORD_PTR dwData, BOOL keyInitiated) override;
-    STDMETHOD(InternalHasSubMenu)(INT iItem, INT index, DWORD_PTR dwData) override;
-    STDMETHOD(InternalContextMenu)(INT iItem, INT index, DWORD_PTR dwData, POINT pt) override;
+    virtual HRESULT InternalGetTooltip(INT iItem, INT index, DWORD_PTR dwData, LPWSTR pszText, INT cchTextMax) override;
+    virtual HRESULT InternalExecuteItem(INT iItem, INT index, DWORD_PTR dwData) override;
+    virtual HRESULT InternalPopupItem(INT iItem, INT index, DWORD_PTR dwData, BOOL keyInitiated) override;
+    virtual HRESULT InternalHasSubMenu(INT iItem, INT index, DWORD_PTR dwData) override;
+    virtual HRESULT InternalContextMenu(INT iItem, INT index, DWORD_PTR dwData, POINT pt) override;
 };

--- a/dll/win32/shell32/shellmenu/CMenuToolbars.h
+++ b/dll/win32/shell32/shellmenu/CMenuToolbars.h
@@ -102,13 +102,13 @@ public:
     HRESULT BeforeCancelPopup();
 
 protected:
-    virtual HRESULT OnDeletingButton(const NMTOOLBAR * tb) = 0;
+    STDMETHOD(OnDeletingButton)(const NMTOOLBAR * tb) = 0;
 
-    virtual HRESULT InternalGetTooltip(INT iItem, INT index, DWORD_PTR dwData, LPWSTR pszText, INT cchTextMax) = 0;
-    virtual HRESULT InternalExecuteItem(INT iItem, INT index, DWORD_PTR dwData) = 0;
-    virtual HRESULT InternalPopupItem(INT iItem, INT index, DWORD_PTR dwData, BOOL keyInitiated) = 0;
-    virtual HRESULT InternalHasSubMenu(INT iItem, INT index, DWORD_PTR dwData) = 0;
-    virtual HRESULT InternalContextMenu(INT iItem, INT index, DWORD_PTR dwData, POINT pt) = 0;
+    STDMETHOD(InternalGetTooltip)(INT iItem, INT index, DWORD_PTR dwData, LPWSTR pszText, INT cchTextMax) = 0;
+    STDMETHOD(InternalExecuteItem)(INT iItem, INT index, DWORD_PTR dwData) = 0;
+    STDMETHOD(InternalPopupItem)(INT iItem, INT index, DWORD_PTR dwData, BOOL keyInitiated) = 0;
+    STDMETHOD(InternalHasSubMenu)(INT iItem, INT index, DWORD_PTR dwData) = 0;
+    STDMETHOD(InternalContextMenu)(INT iItem, INT index, DWORD_PTR dwData, POINT pt) = 0;
 
     HRESULT AddButton(DWORD commandId, LPCWSTR caption, BOOL hasSubMenu, INT iconId, DWORD_PTR buttonData, BOOL last);
     HRESULT AddSeparator(BOOL last);
@@ -152,16 +152,16 @@ public:
     HRESULT SetMenu(HMENU hmenu, HWND hwnd, DWORD dwFlags);
     HRESULT GetMenu(HMENU *phmenu, HWND *phwnd, DWORD *pdwFlags);
 
-    virtual HRESULT FillToolbar(BOOL clearFirst=FALSE);
+    virtual HRESULT FillToolbar(BOOL clearFirst=FALSE) override;
 
 protected:
-    virtual HRESULT OnDeletingButton(const NMTOOLBAR * tb);
+    STDMETHOD(OnDeletingButton)(const NMTOOLBAR * tb) override;
 
-    virtual HRESULT InternalGetTooltip(INT iItem, INT index, DWORD_PTR dwData, LPWSTR pszText, INT cchTextMax);
-    virtual HRESULT InternalExecuteItem(INT iItem, INT index, DWORD_PTR dwData);
-    virtual HRESULT InternalPopupItem(INT iItem, INT index, DWORD_PTR dwData, BOOL keyInitiated);
-    virtual HRESULT InternalHasSubMenu(INT iItem, INT index, DWORD_PTR dwData);
-    virtual HRESULT InternalContextMenu(INT iItem, INT index, DWORD_PTR dwData, POINT pt);
+    STDMETHOD(InternalGetTooltip)(INT iItem, INT index, DWORD_PTR dwData, LPWSTR pszText, INT cchTextMax) override;
+    STDMETHOD(InternalExecuteItem)(INT iItem, INT index, DWORD_PTR dwData) override;
+    STDMETHOD(InternalPopupItem)(INT iItem, INT index, DWORD_PTR dwData, BOOL keyInitiated) override;
+    STDMETHOD(InternalHasSubMenu)(INT iItem, INT index, DWORD_PTR dwData) override;
+    STDMETHOD(InternalContextMenu)(INT iItem, INT index, DWORD_PTR dwData, POINT pt) override;
 };
 
 class CMenuSFToolbar :
@@ -179,14 +179,14 @@ public:
     HRESULT SetShellFolder(IShellFolder *psf, LPCITEMIDLIST pidlFolder, HKEY hKey, DWORD dwFlags);
     HRESULT GetShellFolder(DWORD *pdwFlags, LPITEMIDLIST *ppidl, REFIID riid, void **ppv);
 
-    virtual HRESULT FillToolbar(BOOL clearFirst=FALSE);
+    virtual HRESULT FillToolbar(BOOL clearFirst=FALSE) override;
 
 protected:
-    virtual HRESULT OnDeletingButton(const NMTOOLBAR * tb);
+    STDMETHOD(OnDeletingButton)(const NMTOOLBAR * tb) override;
 
-    virtual HRESULT InternalGetTooltip(INT iItem, INT index, DWORD_PTR dwData, LPWSTR pszText, INT cchTextMax);
-    virtual HRESULT InternalExecuteItem(INT iItem, INT index, DWORD_PTR dwData);
-    virtual HRESULT InternalPopupItem(INT iItem, INT index, DWORD_PTR dwData, BOOL keyInitiated);
-    virtual HRESULT InternalHasSubMenu(INT iItem, INT index, DWORD_PTR dwData);
-    virtual HRESULT InternalContextMenu(INT iItem, INT index, DWORD_PTR dwData, POINT pt);
+    STDMETHOD(InternalGetTooltip)(INT iItem, INT index, DWORD_PTR dwData, LPWSTR pszText, INT cchTextMax) override;
+    STDMETHOD(InternalExecuteItem)(INT iItem, INT index, DWORD_PTR dwData) override;
+    STDMETHOD(InternalPopupItem)(INT iItem, INT index, DWORD_PTR dwData, BOOL keyInitiated) override;
+    STDMETHOD(InternalHasSubMenu)(INT iItem, INT index, DWORD_PTR dwData) override;
+    STDMETHOD(InternalContextMenu)(INT iItem, INT index, DWORD_PTR dwData, POINT pt) override;
 };

--- a/dll/win32/shell32/shellmenu/CMergedFolder.cpp
+++ b/dll/win32/shell32/shellmenu/CMergedFolder.cpp
@@ -70,14 +70,14 @@ public:
     HRESULT FindPidlInList(HWND hwndOwner, LPCITEMIDLIST pcidl, LocalPidlInfo * pinfo);
     HRESULT FindByName(HWND hwndOwner, LPCWSTR strParsingName, LocalPidlInfo * pinfo);
 
-    virtual HRESULT STDMETHODCALLTYPE Next(
+    STDMETHOD(Next)(
         ULONG celt,
         LPITEMIDLIST *rgelt,
-        ULONG *pceltFetched);
+        ULONG *pceltFetched) override;
 
-    virtual HRESULT STDMETHODCALLTYPE Skip(ULONG celt);
-    virtual HRESULT STDMETHODCALLTYPE Reset();
-    virtual HRESULT STDMETHODCALLTYPE Clone(IEnumIDList **ppenum);
+    STDMETHOD(Skip)(ULONG celt) override;
+    STDMETHOD(Reset)() override;
+    STDMETHOD(Clone)(IEnumIDList **ppenum) override;
 };
 
 CEnumMergedFolder::CEnumMergedFolder() :

--- a/dll/win32/shell32/shellmenu/CMergedFolder.h
+++ b/dll/win32/shell32/shellmenu/CMergedFolder.h
@@ -200,12 +200,13 @@ public:
 
     /*** IItemNameLimits methods ***/
 
-    STDMETHOD(GetMaxLength)(LPCWSTR pszName, int *piMaxNameLen) override
+    STDMETHODIMP GetMaxLength(LPCWSTR pszName, int *piMaxNameLen) override
     {
         return E_NOTIMPL;
     }
 
-    STDMETHOD(GetValidCharacters)(LPWSTR *ppwszValidChars, LPWSTR *ppwszInvalidChars) override
+    STDMETHODIMP
+    GetValidCharacters(LPWSTR *ppwszValidChars, LPWSTR *ppwszInvalidChars) override
     {
         if (ppwszValidChars)
         {

--- a/dll/win32/shell32/shellmenu/CMergedFolder.h
+++ b/dll/win32/shell32/shellmenu/CMergedFolder.h
@@ -21,15 +21,15 @@
 
 interface IAugmentedShellFolder : public IShellFolder
 {
-    virtual HRESULT STDMETHODCALLTYPE AddNameSpace(LPGUID, IShellFolder *, LPCITEMIDLIST, ULONG) = 0;
-    virtual HRESULT STDMETHODCALLTYPE GetNameSpaceID(LPCITEMIDLIST, LPGUID) = 0;
-    virtual HRESULT STDMETHODCALLTYPE QueryNameSpace(ULONG, LPGUID, IShellFolder **) = 0;
-    virtual HRESULT STDMETHODCALLTYPE EnumNameSpace(ULONG, PULONG) = 0;
+    STDMETHOD(AddNameSpace)(LPGUID, IShellFolder *, LPCITEMIDLIST, ULONG) = 0;
+    STDMETHOD(GetNameSpaceID)(LPCITEMIDLIST, LPGUID) = 0;
+    STDMETHOD(QueryNameSpace)(ULONG, LPGUID, IShellFolder **) = 0;
+    STDMETHOD(EnumNameSpace)(ULONG, PULONG) = 0;
 };
 
 interface IAugmentedShellFolder2 : public IAugmentedShellFolder
 {
-    virtual HRESULT STDMETHODCALLTYPE UnWrapIDList(LPCITEMIDLIST, LONG, IShellFolder **, LPITEMIDLIST *, LPITEMIDLIST *, LONG *) = 0;
+    STDMETHOD(UnWrapIDList)(LPCITEMIDLIST, LONG, IShellFolder **, LPITEMIDLIST *, LPITEMIDLIST *, LONG *) = 0;
 };
 
 /* No idea what QUERYNAMESPACEINFO struct contains, yet */
@@ -40,7 +40,7 @@ struct QUERYNAMESPACEINFO
 
 interface IAugmentedShellFolder3 : public IAugmentedShellFolder2
 {
-    virtual HRESULT STDMETHODCALLTYPE QueryNameSpace2(ULONG, QUERYNAMESPACEINFO *) = 0;
+    STDMETHOD(QueryNameSpace2)(ULONG, QUERYNAMESPACEINFO *) = 0;
 };
 
 class CEnumMergedFolder;
@@ -99,115 +99,113 @@ public:
     END_COM_MAP()
 
     // IShellFolder
-    virtual HRESULT STDMETHODCALLTYPE ParseDisplayName(
+    STDMETHOD(ParseDisplayName)(
         HWND hwndOwner,
         LPBC pbcReserved,
         LPOLESTR lpszDisplayName,
         ULONG *pchEaten,
         LPITEMIDLIST *ppidl,
-        ULONG *pdwAttributes);
+        ULONG *pdwAttributes) override;
 
-    virtual HRESULT STDMETHODCALLTYPE EnumObjects(
+    STDMETHOD(EnumObjects)(
         HWND hwndOwner,
         SHCONTF grfFlags,
-        IEnumIDList **ppenumIDList);
+        IEnumIDList **ppenumIDList) override;
 
-    virtual HRESULT STDMETHODCALLTYPE BindToObject(
+    STDMETHOD(BindToObject)(
         LPCITEMIDLIST pidl,
         LPBC pbcReserved,
         REFIID riid,
-        void **ppvOut);
+        void **ppvOut) override;
 
-    virtual HRESULT STDMETHODCALLTYPE BindToStorage(
+    STDMETHOD(BindToStorage)(
         LPCITEMIDLIST pidl,
         LPBC pbcReserved,
         REFIID riid,
-        void **ppvObj);
+        void **ppvObj) override;
 
-    virtual HRESULT STDMETHODCALLTYPE CompareIDs(
+    STDMETHOD(CompareIDs)(
         LPARAM lParam,
         LPCITEMIDLIST pidl1,
-        LPCITEMIDLIST pidl2);
+        LPCITEMIDLIST pidl2) override;
 
-    virtual HRESULT STDMETHODCALLTYPE CreateViewObject(
+    STDMETHOD(CreateViewObject)(
         HWND hwndOwner,
         REFIID riid,
-        void **ppvOut);
+        void **ppvOut) override;
 
-    virtual HRESULT STDMETHODCALLTYPE GetAttributesOf(
+    STDMETHOD(GetAttributesOf)(
         UINT cidl,
         PCUITEMID_CHILD_ARRAY apidl,
-        SFGAOF *rgfInOut);
+        SFGAOF *rgfInOut) override;
 
-    virtual HRESULT STDMETHODCALLTYPE GetUIObjectOf(
+    STDMETHOD(GetUIObjectOf)(
         HWND hwndOwner,
         UINT cidl,
         PCUITEMID_CHILD_ARRAY apidl,
         REFIID riid,
         UINT *prgfInOut,
-        void **ppvOut);
+        void **ppvOut) override;
 
-    virtual HRESULT STDMETHODCALLTYPE GetDisplayNameOf(
+    STDMETHOD(GetDisplayNameOf)(
         LPCITEMIDLIST pidl,
         SHGDNF uFlags,
-        STRRET *lpName);
+        STRRET *lpName) override;
 
-    virtual HRESULT STDMETHODCALLTYPE SetNameOf(
+    STDMETHOD(SetNameOf)(
         HWND hwnd,
         LPCITEMIDLIST pidl,
         LPCOLESTR lpszName,
         SHGDNF uFlags,
-        LPITEMIDLIST *ppidlOut);
+        LPITEMIDLIST *ppidlOut) override;
 
     // IShellFolder2
-    virtual HRESULT STDMETHODCALLTYPE GetDefaultSearchGUID(
-        GUID *lpguid);
+    STDMETHOD(GetDefaultSearchGUID)(
+        GUID *lpguid) override;
 
-    virtual HRESULT STDMETHODCALLTYPE EnumSearches(
-        IEnumExtraSearch **ppenum);
+    STDMETHOD(EnumSearches)(
+        IEnumExtraSearch **ppenum) override;
 
-    virtual HRESULT STDMETHODCALLTYPE GetDefaultColumn(
+    STDMETHOD(GetDefaultColumn)(
         DWORD dwReserved,
         ULONG *pSort,
-        ULONG *pDisplay);
+        ULONG *pDisplay) override;
 
-    virtual HRESULT STDMETHODCALLTYPE GetDefaultColumnState(
+    STDMETHOD(GetDefaultColumnState)(
         UINT iColumn,
-        SHCOLSTATEF *pcsFlags);
+        SHCOLSTATEF *pcsFlags) override;
 
-    virtual HRESULT STDMETHODCALLTYPE GetDetailsEx(
+    STDMETHOD(GetDetailsEx)(
         LPCITEMIDLIST pidl,
         const SHCOLUMNID *pscid,
-        VARIANT *pv);
+        VARIANT *pv) override;
 
-    virtual HRESULT STDMETHODCALLTYPE GetDetailsOf(
+    STDMETHOD(GetDetailsOf)(
         LPCITEMIDLIST pidl,
         UINT iColumn,
-        SHELLDETAILS *psd);
+        SHELLDETAILS *psd) override;
 
-    virtual HRESULT STDMETHODCALLTYPE MapColumnToSCID(
+    STDMETHOD(MapColumnToSCID)(
         UINT iColumn,
-        SHCOLUMNID *pscid);
+        SHCOLUMNID *pscid) override;
 
     // IPersist
-    virtual HRESULT STDMETHODCALLTYPE GetClassID(CLSID *lpClassId);
+    STDMETHOD(GetClassID)(CLSID *lpClassId) override;
 
     // IPersistFolder
-    virtual HRESULT STDMETHODCALLTYPE Initialize(PCIDLIST_ABSOLUTE pidl);
+    STDMETHOD(Initialize)(PCIDLIST_ABSOLUTE pidl) override;
 
     // IPersistFolder2
-    virtual HRESULT STDMETHODCALLTYPE GetCurFolder(PIDLIST_ABSOLUTE * pidl);
+    STDMETHOD(GetCurFolder)(PIDLIST_ABSOLUTE * pidl) override;
 
     /*** IItemNameLimits methods ***/
 
-    STDMETHODIMP
-    GetMaxLength(LPCWSTR pszName, int *piMaxNameLen)
+    STDMETHOD(GetMaxLength)(LPCWSTR pszName, int *piMaxNameLen) override
     {
         return E_NOTIMPL;
     }
 
-    STDMETHODIMP
-    GetValidCharacters(LPWSTR *ppwszValidChars, LPWSTR *ppwszInvalidChars)
+    STDMETHOD(GetValidCharacters)(LPWSTR *ppwszValidChars, LPWSTR *ppwszInvalidChars) override
     {
         if (ppwszValidChars)
         {
@@ -221,12 +219,12 @@ public:
     }
 
     // IAugmentedShellFolder2
-    virtual HRESULT STDMETHODCALLTYPE AddNameSpace(LPGUID lpGuid, IShellFolder * psf, LPCITEMIDLIST pcidl, ULONG dwUnknown);
-    virtual HRESULT STDMETHODCALLTYPE GetNameSpaceID(LPCITEMIDLIST pcidl, LPGUID lpGuid);
-    virtual HRESULT STDMETHODCALLTYPE QueryNameSpace(ULONG dwUnknown, LPGUID lpGuid, IShellFolder ** ppsf);
-    virtual HRESULT STDMETHODCALLTYPE EnumNameSpace(ULONG dwUnknown, PULONG lpUnknown);
-    virtual HRESULT STDMETHODCALLTYPE UnWrapIDList(LPCITEMIDLIST pcidl, LONG lUnknown, IShellFolder ** ppsf, LPITEMIDLIST * ppidl1, LPITEMIDLIST *ppidl2, LONG * lpUnknown);
+    STDMETHOD(AddNameSpace)(LPGUID lpGuid, IShellFolder * psf, LPCITEMIDLIST pcidl, ULONG dwUnknown) override;
+    STDMETHOD(GetNameSpaceID)(LPCITEMIDLIST pcidl, LPGUID lpGuid) override;
+    STDMETHOD(QueryNameSpace)(ULONG dwUnknown, LPGUID lpGuid, IShellFolder ** ppsf) override;
+    STDMETHOD(EnumNameSpace)(ULONG dwUnknown, PULONG lpUnknown) override;
+    STDMETHOD(UnWrapIDList)(LPCITEMIDLIST pcidl, LONG lUnknown, IShellFolder ** ppsf, LPITEMIDLIST * ppidl1, LPITEMIDLIST *ppidl2, LONG * lpUnknown) override;
 
     // IAugmentedShellFolder3
-    virtual HRESULT STDMETHODCALLTYPE QueryNameSpace2(ULONG, QUERYNAMESPACEINFO *);
+    STDMETHOD(QueryNameSpace2)(ULONG, QUERYNAMESPACEINFO *) override;
 };

--- a/dll/win32/shell32/shellmenu/CMergedFolder.h
+++ b/dll/win32/shell32/shellmenu/CMergedFolder.h
@@ -21,15 +21,15 @@
 
 interface IAugmentedShellFolder : public IShellFolder
 {
-    STDMETHOD(AddNameSpace)(LPGUID, IShellFolder *, LPCITEMIDLIST, ULONG) = 0;
-    STDMETHOD(GetNameSpaceID)(LPCITEMIDLIST, LPGUID) = 0;
-    STDMETHOD(QueryNameSpace)(ULONG, LPGUID, IShellFolder **) = 0;
-    STDMETHOD(EnumNameSpace)(ULONG, PULONG) = 0;
+    STDMETHOD(AddNameSpace)(LPGUID, IShellFolder *, LPCITEMIDLIST, ULONG) PURE;
+    STDMETHOD(GetNameSpaceID)(LPCITEMIDLIST, LPGUID) PURE;
+    STDMETHOD(QueryNameSpace)(ULONG, LPGUID, IShellFolder **) PURE;
+    STDMETHOD(EnumNameSpace)(ULONG, PULONG) PURE;
 };
 
 interface IAugmentedShellFolder2 : public IAugmentedShellFolder
 {
-    STDMETHOD(UnWrapIDList)(LPCITEMIDLIST, LONG, IShellFolder **, LPITEMIDLIST *, LPITEMIDLIST *, LONG *) = 0;
+    STDMETHOD(UnWrapIDList)(LPCITEMIDLIST, LONG, IShellFolder **, LPITEMIDLIST *, LPITEMIDLIST *, LONG *) PURE;
 };
 
 /* No idea what QUERYNAMESPACEINFO struct contains, yet */
@@ -40,7 +40,7 @@ struct QUERYNAMESPACEINFO
 
 interface IAugmentedShellFolder3 : public IAugmentedShellFolder2
 {
-    STDMETHOD(QueryNameSpace2)(ULONG, QUERYNAMESPACEINFO *) = 0;
+    STDMETHOD(QueryNameSpace2)(ULONG, QUERYNAMESPACEINFO *) PURE;
 };
 
 class CEnumMergedFolder;


### PR DESCRIPTION
## Purpose

For simplicity and short typing. Macro `STDMETHOD` is defined in `<basetyps.h>` as follows:

```c
# define STDMETHOD(m) virtual HRESULT STDMETHODCALLTYPE m
# define STDMETHOD_(t,m) virtual t STDMETHODCALLTYPE m
```
C++11 keyword `override` is used for checking whether the method is overrided.

JIRA issue: [CORE-19469](https://jira.reactos.org/browse/CORE-19469)

## Proposed changes

- Replace `virtual HRESULT STDMETHODCALLTYPE m` with `STDMETHOD(m)` (`m` is a method name).
- Replace `virtual t STDMETHODCALLTYPE m` with `STDMETHOD_(t, m)` (`t` is a type. `m` is a method name).
- Use `override` keyword as possible.
- `CDefView` should inherit `IShellView3` due to override `CreateViewWindow3` method (really?).
- Fix `CDefView::CreateViewWindow3` (parameter `prcView` is `const RECT *`, not `LPRECT`).

## TODO

- [x] Do build.