### PR TITLE
[NTOS:EX] Remove an ASSERT in ExpInsertPoolTracker

### DIFF
--- a/ntoskrnl/mm/ARM3/expool.c
+++ b/ntoskrnl/mm/ARM3/expool.c
@@ -877,7 +877,6 @@ ExpInsertPoolTracker(IN ULONG Key,
     // ASSERT on ReactOS features not yet supported
     //
     ASSERT(!(PoolType & SESSION_POOL_MASK));
-    ASSERT(KeGetCurrentProcessorNumber() == 0);
 
     //
     // Why the double indirection? Because normally this function is also used


### PR DESCRIPTION
## Purpose

Remove an ASSERT, which hits with SMP. While Windows seems to have multiple tracker tables, we shouldn't need this.