### PR TITLE
[ATL] Implement CSimpleStringT::Preallocate

### DIFF
--- a/sdk/lib/atl/atlsimpstr.h
+++ b/sdk/lib/atl/atlsimpstr.h
@@ -373,6 +373,11 @@ public:
         return m_pszData;
     }
 
+    void Preallocate(_In_ int nLength)
+    {
+        PrepareWrite( nLength );
+    }
+
     void ReleaseBufferSetLength(_In_ int nNewLength)
     {
         ATLASSERT(nNewLength >= 0);

--- a/sdk/lib/atl/atlsimpstr.h
+++ b/sdk/lib/atl/atlsimpstr.h
@@ -375,7 +375,7 @@ public:
 
     void Preallocate(_In_ int nLength)
     {
-        PrepareWrite( nLength );
+        PrepareWrite(nLength);
     }
 
     void ReleaseBufferSetLength(_In_ int nNewLength)


### PR DESCRIPTION
This public function is used to allocate memory for the string via private PrepareWrite, but it's missing somehow. Now it shouldn't be.

## Purpose

Implement CSimpleStringT::Preallocate function. Used in `ATL::CStringW` and `ATL::CStringA`, for example:
```c++
ATL::CStringW cswItemText = "";
cswItemText.Preallocate(64);

SendDlgItemMessageW(pdis->CtlID, LB_GETTEXT, pdis->itemID, reinterpret_cast<LPARAM>(cswItemText.GetBuffer()));
cswItemText.ReleaseBuffer();
```

JIRA issue: None

## Proposed changes

- Update [atlsimpstr.h](https://github.com/reactos/reactos/blob/master/sdk/lib/atl/atlsimpstr.h)
