### PR TITLE
[RSHELL] Use STDMETHOD macro and keyword override

### DIFF
--- a/base/shell/rshell/CQuickLaunchBand.h
+++ b/base/shell/rshell/CQuickLaunchBand.h
@@ -32,127 +32,96 @@ class CQuickLaunchBand :
     CQuickLaunchBand();
     virtual ~CQuickLaunchBand();
 
+    STDMETHOD(ContainsWindow)(IN HWND hWnd);
+
 // ATL construct
 
     HRESULT FinalConstruct();
 
 // IObjectWithSite
 
-    virtual STDMETHODIMP GetSite(
+    STDMETHOD(GetSite)(
         IN  REFIID riid,
-        OUT void   **ppvSite
-    );
+        OUT void   **ppvSite) override;
 
-    virtual STDMETHODIMP SetSite(
-        IN IUnknown *pUnkSite
-    );
+    STDMETHOD(SetSite)(IN IUnknown *pUnkSite) override;
 
 // IDeskBand
 
-    virtual STDMETHODIMP GetWindow(
-        OUT HWND *phwnd
-    );
+    STDMETHOD(GetWindow)(OUT HWND *phwnd) override;
 
-    virtual STDMETHODIMP ContextSensitiveHelp(
-        IN BOOL fEnterMode
-    );
+    STDMETHOD(ContextSensitiveHelp)(IN BOOL fEnterMode) override;
 
-    virtual STDMETHODIMP ShowDW(
-        IN BOOL bShow
-    );
+    STDMETHOD(ShowDW)(IN BOOL bShow) override;
 
-    virtual STDMETHODIMP CloseDW(
-        IN DWORD dwReserved
-    );
+    STDMETHOD(CloseDW)(IN DWORD dwReserved) override;
 
-    virtual STDMETHODIMP ResizeBorderDW(
+    STDMETHOD(ResizeBorderDW)(
         LPCRECT prcBorder,
         IUnknown *punkToolbarSite,
-        BOOL fReserved
-    );
+        BOOL fReserved) override;
 
-    virtual STDMETHODIMP GetBandInfo(
+    STDMETHOD(GetBandInfo)(
         IN DWORD dwBandID,
         IN DWORD dwViewMode,
-        IN OUT DESKBANDINFO *pdbi
-    );
+        IN OUT DESKBANDINFO *pdbi) override;
 
 // IPersistStream
 
-    virtual STDMETHODIMP GetClassID(
-        OUT CLSID *pClassID
-    );
+    STDMETHOD(GetClassID)(OUT CLSID *pClassID) override;
 
-    virtual STDMETHODIMP GetSizeMax(
-        OUT ULARGE_INTEGER *pcbSize
-    );
+    STDMETHOD(GetSizeMax)(OUT ULARGE_INTEGER *pcbSize) override;
 
-    virtual STDMETHODIMP IsDirty();
+    STDMETHOD(IsDirty)() override;
 
-    virtual STDMETHODIMP Load(
-        IN IStream *pStm
-    );
+    STDMETHOD(Load)(IN IStream *pStm) override;
 
-    virtual STDMETHODIMP Save(
+    STDMETHOD(Save)(
         IN IStream *pStm,
-        IN BOOL    fClearDirty
-    );
+        IN BOOL    fClearDirty) override;
 
 // IWinEventHandler
 
-    virtual STDMETHODIMP ContainsWindow(
-        IN HWND hWnd
-    );
-
-    virtual STDMETHODIMP OnWinEvent(
+    STDMETHOD(OnWinEvent)(
         HWND hWnd,
         UINT uMsg,
         WPARAM wParam,
         LPARAM lParam,
-        LRESULT *theResult
-    );
+        LRESULT *theResult) override;
 
-    virtual STDMETHODIMP IsWindowOwner(
-        HWND hWnd
-    );
+    STDMETHOD(IsWindowOwner)(HWND hWnd) override;
 
 // IOleCommandTarget
 
-    virtual STDMETHODIMP Exec(
+    STDMETHOD(Exec)(
         IN const GUID *pguidCmdGroup,
         IN DWORD nCmdID,
         IN DWORD nCmdexecopt,
         IN VARIANT *pvaIn,
-        IN OUT VARIANT *pvaOut
-    );
+        IN OUT VARIANT *pvaOut) override;
 
-    virtual STDMETHODIMP QueryStatus(
+    STDMETHOD(QueryStatus)(
         IN const GUID *pguidCmdGroup,
         IN ULONG cCmds,
         IN OUT OLECMD prgCmds[],
-        IN OUT OLECMDTEXT *pCmdText
-    );
+        IN OUT OLECMDTEXT *pCmdText) override;
 
 // IContextMenu
-    virtual STDMETHODIMP GetCommandString(
+    STDMETHOD(GetCommandString)(
         UINT_PTR idCmd,
         UINT uFlags,
         UINT *pwReserved,
         LPSTR pszName,
-        UINT cchMax
-    );
+        UINT cchMax) override;
 
-    virtual STDMETHODIMP InvokeCommand(
-        LPCMINVOKECOMMANDINFO pici
-    );
+    STDMETHOD(InvokeCommand)(LPCMINVOKECOMMANDINFO pici) override;
 
-    virtual STDMETHODIMP QueryContextMenu(
+    STDMETHOD(QueryContextMenu)(
         HMENU hmenu,
         UINT indexMenu,
         UINT idCmdFirst,
         UINT idCmdLast,
-        UINT uFlags
-    );
+        UINT uFlags) override;
 
 //*****************************************************************************************************
 


### PR DESCRIPTION
## Purpose

For simplicity and short typing. Macro `STDMETHOD` is defined in `<basetyps.h>` as follows:

```c
# define STDMETHOD(m) virtual HRESULT STDMETHODCALLTYPE m
# define STDMETHOD_(t,m) virtual t STDMETHODCALLTYPE m
```
C++11 keyword `override` is used for checking whether the method is overrided.

JIRA issue: [CORE-19469](https://jira.reactos.org/browse/CORE-19469)

## Proposed changes

- Replace `virtual HRESULT STDMETHODCALLTYPE m` with `STDMETHOD(m)` (`m` is a method name).
- Replace `virtual t STDMETHODCALLTYPE m` with `STDMETHOD_(t, m)` (`t` is a type. `m` is a method name).
- Use `override` keyword as possible.

## TODO

- [x] Do build.