### PR TITLE
[FMIFS][FORMAT][KERNEL32][NTOS:PNP] Get the format tool fully working

### DIFF
--- a/base/system/format/format.c
+++ b/base/system/format/format.c
@@ -364,7 +364,7 @@ int wmain(int argc, WCHAR *argv[])
     FMIFS_MEDIA_FLAG media = FMIFS_HARDDISK;
     DWORD driveType;
     WCHAR fileSystem[1024];
-    WCHAR volumeName[1024];
+    WCHAR volumeName[1024] = {0};
     WCHAR input[1024];
     DWORD serialNumber;
     DWORD flags, maxComponent;
@@ -475,9 +475,16 @@ int wmain(int argc, WCHAR *argv[])
                                &serialNumber, &maxComponent, &flags,
                                fileSystem, ARRAYSIZE(fileSystem)))
     {
-        K32LoadStringW(GetModuleHandle(NULL), STRING_NO_VOLUME, szMsg, ARRAYSIZE(szMsg));
-        PrintWin32Error(szMsg, GetLastError());
-        return -1;
+        if (GetLastError() == ERROR_UNRECOGNIZED_VOLUME)
+        {
+            wcscpy(fileSystem, L"RAW");
+        }
+        else
+        {
+            K32LoadStringW(GetModuleHandle(NULL), STRING_NO_VOLUME, szMsg, ARRAYSIZE(szMsg));
+            PrintWin32Error(szMsg, GetLastError());
+            return -1;
+        }
     }
 
     if (QueryDeviceInformation(RootDirectory,

--- a/dll/win32/fmifs/fmifs.spec
+++ b/dll/win32/fmifs/fmifs.spec
@@ -8,7 +8,7 @@
 @ stdcall FormatEx(wstr ptr wstr wstr long long ptr)
 @ stub FormatEx2
 @ stdcall QueryAvailableFileSystemFormat(long wstr str str ptr)
-@ stub QueryDeviceInformation
+@ stdcall QueryDeviceInformation(wstr ptr long)
 @ stub QueryDeviceInformationByHandle
 @ stub QueryFileSystemName
 @ stub QueryLatestFileSystemVersion

--- a/dll/win32/fmifs/format.c
+++ b/dll/win32/fmifs/format.c
@@ -9,6 +9,7 @@
  */
 
 #include "precomp.h"
+#include <ntstrsafe.h>
 
 #define NDEBUG
 #include <debug.h>
@@ -50,8 +51,8 @@ FormatEx(
     BOOLEAN Success = FALSE;
     BOOLEAN BackwardCompatible = FALSE; // Default to latest FS versions.
     MEDIA_TYPE MediaType;
+    WCHAR DriveName[MAX_PATH];
     WCHAR VolumeName[MAX_PATH];
-    //CURDIR CurDir;
 
 //
 // TODO: Convert filesystem Format into ULIB format string.
@@ -61,24 +62,31 @@ FormatEx(
     if (!Provider)
     {
         /* Unknown file system */
-        Callback(DONE, 0, &Success);
-        return;
+        goto Quit;
     }
 
-#if 1
-    DPRINT1("Warning: use GetVolumeNameForVolumeMountPointW() instead!\n");
-    swprintf(VolumeName, L"\\??\\%c:", towupper(DriveRoot[0]));
-    RtlCreateUnicodeString(&usDriveRoot, VolumeName);
-    /* Code disabled as long as our storage stack doesn't understand IOCTL_MOUNTDEV_QUERY_DEVICE_NAME */
-#else
-    if (!GetVolumeNameForVolumeMountPointW(DriveRoot, VolumeName, RTL_NUMBER_OF(VolumeName)) ||
-        !RtlDosPathNameToNtPathName_U(VolumeName, &usDriveRoot, NULL, &CurDir))
+    if (!NT_SUCCESS(RtlStringCchCopyW(DriveName, ARRAYSIZE(DriveName), DriveRoot)))
+        goto Quit;
+
+    if (DriveName[wcslen(DriveName) - 1] != L'\\')
     {
-        /* Report an error */
-        Callback(DONE, 0, &Success);
-        return;
+        /* Append the trailing backslash for GetVolumeNameForVolumeMountPointW */
+        if (!NT_SUCCESS(RtlStringCchCatW(DriveName, ARRAYSIZE(DriveName), L"\\")))
+            goto Quit;
     }
-#endif
+
+    if (!GetVolumeNameForVolumeMountPointW(DriveName, VolumeName, ARRAYSIZE(VolumeName)))
+    {
+        /* Couldn't get a volume GUID path, try formatting using a parameter provided path */
+        DPRINT1("Couldn't get a volume GUID path for drive %S\n", DriveName);
+        wcscpy(VolumeName, DriveName);
+    }
+
+    if (!RtlDosPathNameToNtPathName_U(VolumeName, &usDriveRoot, NULL, NULL))
+        goto Quit;
+
+    /* Trim the trailing backslash since we will work with a device object */
+    usDriveRoot.Length -= sizeof(WCHAR);
 
     RtlInitUnicodeString(&usLabel, Label);
 
@@ -119,10 +127,11 @@ FormatEx(
     if (!Success)
         DPRINT1("Format() failed\n");
 
-    /* Report success */
-    Callback(DONE, 0, &Success);
-
     RtlFreeUnicodeString(&usDriveRoot);
+
+Quit:
+    /* Report result */
+    Callback(DONE, 0, &Success);
 }
 
 /* EOF */

--- a/dll/win32/fmifs/query.c
+++ b/dll/win32/fmifs/query.c
@@ -8,6 +8,12 @@
  */
 
 #include "precomp.h"
+#include <ntddstor.h>
+#include <ntstrsafe.h>
+
+#define NTOS_MODE_USER
+#include <ndk/iofuncs.h>
+#include <ndk/obfuncs.h>
 
 BOOLEAN
 NTAPI
@@ -42,4 +48,156 @@ QueryAvailableFileSystemFormat(
     *LatestVersion = TRUE; /* FIXME */
 
     return TRUE;
+}
+
+/**
+ * @brief
+ * Retrieves disk device information.
+ *
+ * @param[in] DriveRoot
+ * String which contains a DOS device name,
+ *
+ * @param[in,out] DeviceInformation
+ * Pointer to buffer with DEVICE_INFORMATION structure which will receive data.
+ *
+ * @param[in] BufferSize
+ * Size of buffer in bytes.
+ *
+ * @return
+ * TRUE if the buffer was large enough and was filled with
+ * the requested information, FALSE otherwise.
+ *
+ * @remarks
+ * The returned information is mostly related to Sony Memory Stick devices.
+ * On Vista+ the returned information is disk sector size and volume length in sectors,
+ * regardless of the type of disk.
+ * ReactOS implementation returns DEVICE_HOTPLUG flag if inspected device is a hotplug device
+ * as well as sector size and volume length of disk device.
+ */
+BOOL
+NTAPI
+QueryDeviceInformation(
+    _In_ PWCHAR DriveRoot,
+    _Out_ PVOID DeviceInformation,
+    _In_ ULONG BufferSize)
+{
+    PDEVICE_INFORMATION DeviceInfo = DeviceInformation;
+    IO_STATUS_BLOCK Iosb;
+    DISK_GEOMETRY DiskGeometry;
+    STORAGE_HOTPLUG_INFO HotplugInfo;
+    GET_LENGTH_INFORMATION LengthInformation;
+    OBJECT_ATTRIBUTES ObjectAttributes;
+    UNICODE_STRING DeviceName;
+    HANDLE FileHandle;
+    NTSTATUS Status;
+    WCHAR DiskDevice[MAX_PATH];
+    WCHAR DriveName[MAX_PATH];
+
+    /* Buffer should be able to at least hold DeviceFlags */
+    if (BufferSize < sizeof(ULONG) ||
+        !NT_SUCCESS(RtlStringCchCopyW(DriveName, ARRAYSIZE(DriveName), DriveRoot)))
+    {
+        return FALSE;
+    }
+
+    if (DriveName[wcslen(DriveName) - 1] != L'\\')
+    {
+        /* Append the trailing backslash for GetVolumeNameForVolumeMountPointW */
+        if (!NT_SUCCESS(RtlStringCchCatW(DriveName, ARRAYSIZE(DriveName), L"\\")))
+            return FALSE;
+    }
+
+    if (!GetVolumeNameForVolumeMountPointW(DriveName, DiskDevice, ARRAYSIZE(DiskDevice)) ||
+        !RtlDosPathNameToNtPathName_U(DiskDevice, &DeviceName, NULL, NULL))
+    {
+        /* Disk has no volume GUID, fallback to QueryDosDevice */
+        DriveName[wcslen(DriveName) - 1] = UNICODE_NULL;
+        if (!QueryDosDeviceW(DriveName, DiskDevice, ARRAYSIZE(DiskDevice)))
+            return FALSE;
+        RtlInitUnicodeString(&DeviceName, DiskDevice);
+    }
+    else
+    {
+        /* Trim the trailing backslash since we will work with a device object */
+        DeviceName.Length -= sizeof(WCHAR);
+    }
+
+    InitializeObjectAttributes(&ObjectAttributes,
+                               &DeviceName,
+                               OBJ_CASE_INSENSITIVE,
+                               NULL,
+                               NULL);
+
+    Status = NtOpenFile(&FileHandle,
+                        FILE_READ_DATA | FILE_READ_ATTRIBUTES | SYNCHRONIZE,
+                        &ObjectAttributes,
+                        &Iosb,
+                        FILE_SHARE_READ | FILE_SHARE_WRITE,
+                        FILE_SYNCHRONOUS_IO_NONALERT);
+    if (!NT_SUCCESS(Status))
+        return FALSE;
+
+    Status = NtDeviceIoControlFile(FileHandle,
+                                   NULL,
+                                   NULL,
+                                   NULL,
+                                   &Iosb,
+                                   IOCTL_STORAGE_GET_HOTPLUG_INFO,
+                                   NULL,
+                                   0,
+                                   &HotplugInfo,
+                                   sizeof(HotplugInfo));
+    if (!NT_SUCCESS(Status))
+        goto Quit;
+
+    DeviceInfo->DeviceFlags = 0;
+    if (HotplugInfo.MediaHotplug || HotplugInfo.DeviceHotplug)
+    {
+        /* This is a hotplug device */
+        DeviceInfo->DeviceFlags |= DEVICE_HOTPLUG;
+    }
+
+    /* Other flags that would be set here are related to Sony "Memory Stick"
+     * type of devices which we do not have any special support for */
+
+    if (BufferSize >= sizeof(DEVICE_INFORMATION))
+    {
+        /* This is the Vista+ version of the structure.
+         * We need to also provide disk sector size and volume length in sectors. */
+        Status = NtDeviceIoControlFile(FileHandle,
+                                       NULL,
+                                       NULL,
+                                       NULL,
+                                       &Iosb,
+                                       IOCTL_DISK_GET_DRIVE_GEOMETRY,
+                                       NULL,
+                                       0,
+                                       &DiskGeometry,
+                                       sizeof(DiskGeometry));
+        if (!NT_SUCCESS(Status))
+            goto Quit;
+
+        Status = NtDeviceIoControlFile(FileHandle,
+                                       NULL,
+                                       NULL,
+                                       NULL,
+                                       &Iosb,
+                                       IOCTL_DISK_GET_LENGTH_INFO,
+                                       NULL,
+                                       0,
+                                       &LengthInformation,
+                                       sizeof(LengthInformation));
+        if (!NT_SUCCESS(Status))
+            goto Quit;
+
+        LengthInformation.Length.QuadPart /= DiskGeometry.BytesPerSector;
+        DeviceInfo->SectorSize = DiskGeometry.BytesPerSector;
+        DeviceInfo->SectorCount = LengthInformation.Length;
+    }
+
+    Status = STATUS_SUCCESS;
+
+Quit:
+    NtClose(FileHandle);
+    return NT_SUCCESS(Status);
 }

--- a/dll/win32/kernel32/client/file/disk.c
+++ b/dll/win32/kernel32/client/file/disk.c
@@ -608,6 +608,9 @@ GetDriveTypeW(IN LPCWSTR lpRootPathName)
         return DRIVE_NO_ROOT_DIR;
     }
 
+    /* We will work with a device object, so trim the trailing backslash now */
+    PathName.Length -= sizeof(WCHAR);
+
     /* Let's probe for it, by forcing open failure! */
     RetryOpen = TRUE;
     InitializeObjectAttributes(&ObjectAttributes, &PathName,

--- a/dll/win32/kernel32/client/file/mntpoint.c
+++ b/dll/win32/kernel32/client/file/mntpoint.c
@@ -61,7 +61,7 @@ GetVolumeNameForRoot(IN LPCWSTR lpszRootPath,
     {
         if (NtPathName.Buffer[(NtPathName.Length / sizeof(WCHAR)) - 1] == L':')
         {
-            NtPathName.Buffer[(NtPathName.Length / sizeof(WCHAR)) - 2] = _toupper(NtPathName.Buffer[(NtPathName.Length / sizeof(WCHAR)) - 2]);
+            NtPathName.Buffer[(NtPathName.Length / sizeof(WCHAR)) - 2] = towupper(NtPathName.Buffer[(NtPathName.Length / sizeof(WCHAR)) - 2]);
         }
     }
 

--- a/ntoskrnl/io/pnpmgr/pnpnotify.c
+++ b/ntoskrnl/io/pnpmgr/pnpnotify.c
@@ -315,7 +315,8 @@ PiNotifyTargetDeviceChange(
     }
 
     KeReleaseGuardedMutex(&PiNotifyTargetDeviceLock);
-    ExFreePoolWithTag(notificationStruct, TAG_PNP_NOTIFY);
+    if (notificationStruct != CustomNotification)
+        ExFreePoolWithTag(notificationStruct, TAG_PNP_NOTIFY);
     ObDereferenceObject(DeviceObject);
 }
 

--- a/ntoskrnl/io/pnpmgr/pnpreport.c
+++ b/ntoskrnl/io/pnpmgr/pnpreport.c
@@ -464,9 +464,9 @@ IoReportTargetDeviceChange(IN PDEVICE_OBJECT PhysicalDeviceObject,
     ASSERT(notifyStruct->FileObject == NULL);
 
     /* Do not handle system PnP events */
-    if ((RtlCompareMemory(&(notifyStruct->Event), &(GUID_TARGET_DEVICE_QUERY_REMOVE), sizeof(GUID)) != sizeof(GUID)) ||
-        (RtlCompareMemory(&(notifyStruct->Event), &(GUID_TARGET_DEVICE_REMOVE_CANCELLED), sizeof(GUID)) != sizeof(GUID)) ||
-        (RtlCompareMemory(&(notifyStruct->Event), &(GUID_TARGET_DEVICE_REMOVE_COMPLETE), sizeof(GUID)) != sizeof(GUID)))
+    if (IsEqualGUID(&(notifyStruct->Event), &GUID_TARGET_DEVICE_QUERY_REMOVE) ||
+        IsEqualGUID(&(notifyStruct->Event), &GUID_TARGET_DEVICE_REMOVE_CANCELLED) ||
+        IsEqualGUID(&(notifyStruct->Event), &GUID_TARGET_DEVICE_REMOVE_COMPLETE))
     {
         return STATUS_INVALID_DEVICE_REQUEST;
     }
@@ -515,9 +515,9 @@ IoReportTargetDeviceChangeAsynchronous(IN PDEVICE_OBJECT PhysicalDeviceObject,
     ASSERT(notifyStruct->FileObject == NULL);
 
     /* Do not handle system PnP events */
-    if ((RtlCompareMemory(&(notifyStruct->Event), &(GUID_TARGET_DEVICE_QUERY_REMOVE), sizeof(GUID)) != sizeof(GUID)) ||
-        (RtlCompareMemory(&(notifyStruct->Event), &(GUID_TARGET_DEVICE_REMOVE_CANCELLED), sizeof(GUID)) != sizeof(GUID)) ||
-        (RtlCompareMemory(&(notifyStruct->Event), &(GUID_TARGET_DEVICE_REMOVE_COMPLETE), sizeof(GUID)) != sizeof(GUID)))
+    if (IsEqualGUID(&(notifyStruct->Event), &GUID_TARGET_DEVICE_QUERY_REMOVE) ||
+        IsEqualGUID(&(notifyStruct->Event), &GUID_TARGET_DEVICE_REMOVE_CANCELLED) ||
+        IsEqualGUID(&(notifyStruct->Event), &GUID_TARGET_DEVICE_REMOVE_COMPLETE))
     {
         return STATUS_INVALID_DEVICE_REQUEST;
     }

--- a/sdk/include/reactos/libs/fmifs/fmifs.h
+++ b/sdk/include/reactos/libs/fmifs/fmifs.h
@@ -33,6 +33,20 @@ typedef struct
     PCHAR Output;
 } TEXTOUTPUT, *PTEXTOUTPUT;
 
+/* Device information */
+typedef struct _DEVICE_INFORMATION
+{
+    ULONG DeviceFlags;
+    ULONG SectorSize;
+    LARGE_INTEGER SectorCount;
+} DEVICE_INFORMATION, *PDEVICE_INFORMATION;
+
+/* Device information flags */
+#define MEMORYSTICK_FORMAT_CAPABLE 0x10
+#define MEMORYSTICK_SUPPORTS_PROGRESS_BAR 0x20
+#define DEVICE_HOTPLUG 0x40
+#define DEVICE_MEMORYSTICK 0x41
+
 /* media flags */
 typedef enum
 {
@@ -163,11 +177,12 @@ QueryAvailableFileSystemFormat(
     OUT UCHAR* Minor,
     OUT BOOLEAN* LatestVersion);
 
-BOOL NTAPI
+BOOL
+NTAPI
 QueryDeviceInformation(
-    IN PWCHAR DriveRoot,
-    OUT ULONG* Buffer, /* That is probably some 4-bytes structure */
-    IN ULONG BufferSize); /* 4 */
+    _In_ PWCHAR DriveRoot,
+    _Out_ PVOID DeviceInformation,
+    _In_ ULONG BufferSize);
 
 BOOL NTAPI
 QueryFileSystemName(


### PR DESCRIPTION
Fixes for getting the format tool (and rufus) to reliably format RAW volumes.

* Handle RAW volumes in format tool.
* Implement and use QueryDeviceInformation in format tool to reliably display volume size before formatting.
* PNP fixes for processing custom notifications. Without this, format (and everything else) was able to successfully set the new volume label, however PNP would still return error code which caused the format tool to exit before printing final statistics after formatting.
* Remove the hack for missing IOCTL_MOUNTDEV_QUERY_DEVICE_NAME in fmifs' FormatEx
* Minor kernel32 fixes

Before:
![Screenshot_20231031_182821](https://github.com/reactos/reactos/assets/32551254/482d17e2-fa71-4060-b19a-406bd545816c)

![Screenshot_ReactOS_2024-03-03_21:32:28](https://github.com/reactos/reactos/assets/32551254/9b9a43bb-08ce-4c9f-9ac8-84a09f6371b3)

After:
![Screenshot_ReactOS_2024-03-03_21:37:29](https://github.com/reactos/reactos/assets/32551254/44be8268-7044-4b0f-94c9-6a37ebad7c82)

![Screenshot_ReactOS_2024-03-03_21:39:24](https://github.com/reactos/reactos/assets/32551254/83305bc2-fcad-4d47-b21e-82b98b16cbba)
(Rufus still fails after formatting the volume due to unimplemented SetVolumeMountPoint)


