### PR TITLE
[BROWSEUI] Fix CExplorerBand Right-Dragging menu

### DIFF
--- a/dll/win32/browseui/explorerband.cpp
+++ b/dll/win32/browseui/explorerband.cpp
@@ -389,7 +389,7 @@ void CExplorerBand::OnTreeItemDragging(LPNMTREEVIEW pnmtv, BOOL isRightClick)
     SFGAOF attrs = SFGAO_CANCOPY | SFGAO_CANMOVE | SFGAO_CANLINK;
     pSrcFolder->GetAttributesOf(1, &pLast, &attrs);
 
-    DWORD dwEffect = 0, dwEffect2;
+    DWORD dwEffect = 0;
     if (attrs & SFGAO_CANCOPY)
         dwEffect |= DROPEFFECT_COPY;
     if (attrs & SFGAO_CANMOVE)
@@ -402,7 +402,7 @@ void CExplorerBand::OnTreeItemDragging(LPNMTREEVIEW pnmtv, BOOL isRightClick)
     if (!SUCCEEDED(hr))
         return;
 
-    DoDragDrop(pObj, this, dwEffect, &dwEffect2);
+    DoDragDrop(pObj, this, dwEffect, &dwEffect);
 }
 
 // *** ATL event handlers ***

--- a/dll/win32/browseui/explorerband.cpp
+++ b/dll/win32/browseui/explorerband.cpp
@@ -378,8 +378,7 @@ void CExplorerBand::OnTreeItemDragging(LPNMTREEVIEW pnmtv, BOOL isRightClick)
     CComPtr<IDataObject>                pObj;
     LPCITEMIDLIST                       pLast;
     HRESULT                             hr;
-    DWORD                               dwEffect;
-    DWORD                               dwEffect2;
+    DWORD                               dwEffect, dwEffect2;
 
     if (!pnmtv->itemNew.lParam)
         return;
@@ -403,8 +402,8 @@ void CExplorerBand::OnTreeItemDragging(LPNMTREEVIEW pnmtv, BOOL isRightClick)
     hr = pSrcFolder->GetUIObjectOf(m_hWnd, 1, &pLast, IID_IDataObject, 0, reinterpret_cast<void**>(&pObj));
     if (!SUCCEEDED(hr))
         return;
+
     DoDragDrop(pObj, this, dwEffect, &dwEffect2);
-    return;
 }
 
 // *** ATL event handlers ***

--- a/dll/win32/browseui/explorerband.cpp
+++ b/dll/win32/browseui/explorerband.cpp
@@ -381,20 +381,31 @@ void CExplorerBand::OnTreeItemDragging(LPNMTREEVIEW pnmtv, BOOL isRightClick)
     DWORD                               dwEffect;
     DWORD                               dwEffect2;
 
-    dwEffect = DROPEFFECT_COPY | DROPEFFECT_MOVE;
     if (!pnmtv->itemNew.lParam)
         return;
+
     NodeInfo* pNodeInfo = GetNodeInfo(pnmtv->itemNew.hItem);
     hr = SHBindToParent(pNodeInfo->absolutePidl, IID_PPV_ARG(IShellFolder, &pSrcFolder), &pLast);
     if (!SUCCEEDED(hr))
         return;
+
+    SFGAOF attrs = SFGAO_CANCOPY | SFGAO_CANMOVE | SFGAO_CANLINK;
+    pSrcFolder->GetAttributesOf(1, &pLast, &attrs);
+
+    dwEffect = 0;
+    if (attrs & SFGAO_CANCOPY)
+        dwEffect |= DROPEFFECT_COPY;
+    if (attrs & SFGAO_CANMOVE)
+        dwEffect |= DROPEFFECT_MOVE;
+    if (attrs & SFGAO_CANLINK)
+        dwEffect |= DROPEFFECT_LINK;
+
     hr = pSrcFolder->GetUIObjectOf(m_hWnd, 1, &pLast, IID_IDataObject, 0, reinterpret_cast<void**>(&pObj));
     if (!SUCCEEDED(hr))
         return;
     DoDragDrop(pObj, this, dwEffect, &dwEffect2);
     return;
 }
-
 
 // *** ATL event handlers ***
 LRESULT CExplorerBand::OnContextMenu(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled)

--- a/dll/win32/browseui/explorerband.cpp
+++ b/dll/win32/browseui/explorerband.cpp
@@ -374,16 +374,14 @@ void CExplorerBand::OnSelectionChanged(LPNMTREEVIEW pnmtv)
 
 void CExplorerBand::OnTreeItemDragging(LPNMTREEVIEW pnmtv, BOOL isRightClick)
 {
-    CComPtr<IShellFolder>               pSrcFolder;
-    CComPtr<IDataObject>                pObj;
-    LPCITEMIDLIST                       pLast;
-    HRESULT                             hr;
-    DWORD                               dwEffect, dwEffect2;
-
     if (!pnmtv->itemNew.lParam)
         return;
 
     NodeInfo* pNodeInfo = GetNodeInfo(pnmtv->itemNew.hItem);
+
+    HRESULT hr;
+    CComPtr<IShellFolder> pSrcFolder;
+    LPCITEMIDLIST pLast;
     hr = SHBindToParent(pNodeInfo->absolutePidl, IID_PPV_ARG(IShellFolder, &pSrcFolder), &pLast);
     if (!SUCCEEDED(hr))
         return;
@@ -391,7 +389,7 @@ void CExplorerBand::OnTreeItemDragging(LPNMTREEVIEW pnmtv, BOOL isRightClick)
     SFGAOF attrs = SFGAO_CANCOPY | SFGAO_CANMOVE | SFGAO_CANLINK;
     pSrcFolder->GetAttributesOf(1, &pLast, &attrs);
 
-    dwEffect = 0;
+    DWORD dwEffect = 0, dwEffect2;
     if (attrs & SFGAO_CANCOPY)
         dwEffect |= DROPEFFECT_COPY;
     if (attrs & SFGAO_CANMOVE)
@@ -399,7 +397,8 @@ void CExplorerBand::OnTreeItemDragging(LPNMTREEVIEW pnmtv, BOOL isRightClick)
     if (attrs & SFGAO_CANLINK)
         dwEffect |= DROPEFFECT_LINK;
 
-    hr = pSrcFolder->GetUIObjectOf(m_hWnd, 1, &pLast, IID_IDataObject, 0, reinterpret_cast<void**>(&pObj));
+    CComPtr<IDataObject> pObj;
+    hr = pSrcFolder->GetUIObjectOf(m_hWnd, 1, &pLast, IID_IDataObject, 0, (LPVOID*)&pObj);
     if (!SUCCEEDED(hr))
         return;
 


### PR DESCRIPTION
## Purpose

Display correct menu on right-dragging an item in Folder explorer bar to Desktop.
JIRA issue: [CORE-19474](https://jira.reactos.org/browse/CORE-19474)

## Proposed changes

In `CExplorerBand::OnTreeItemDragging` method:

- Use `GetAttributesOf` to get the attributes of a folder item.
- Use correct `dwEffect` value for `DoDragDrop` call.

## TODO

- [x] Do tests.

## Screenshots

BEFORE:
![before](https://github.com/reactos/reactos/assets/2107452/31d60f2f-7215-42a3-a333-4ad7a9b5cbfc)

AFTER:
![after](https://github.com/reactos/reactos/assets/2107452/2b894931-ef14-4a5e-a6c3-785b7439a13f)