### PR TITLE
[NTOS:KE/KD64] Implement x64 freeze and processor switch code

### DIFF
--- a/ntoskrnl/include/internal/amd64/intrin_i.h
+++ b/ntoskrnl/include/internal/amd64/intrin_i.h
@@ -91,6 +91,10 @@ static __inline__ __attribute__((always_inline)) void __str(unsigned short *Dest
 	__asm__ __volatile__("str %0" : : "m"(*Destination) : "memory");
 }
 
+static __inline__ __attribute__((always_inline)) void __swapgs(void)
+{
+	__asm__ __volatile__("swapgs" : : : "memory");
+}
 
 #elif defined(_MSC_VER)
 
@@ -106,6 +110,7 @@ void __ltr(unsigned short Source);
 
 void __str(unsigned short *Destination);
 
+void __swapgs(void);
 
 #else
 #error Unknown compiler for inline assembler

--- a/ntoskrnl/include/internal/amd64/ke.h
+++ b/ntoskrnl/include/internal/amd64/ke.h
@@ -480,6 +480,11 @@ VOID
 KiUserCallbackExit(
     _In_ PKTRAP_FRAME TrapFrame);
 
+BOOLEAN
+KiProcessorFreezeHandler(
+    _In_ PKTRAP_FRAME TrapFrame,
+    _In_ PKEXCEPTION_FRAME ExceptionFrame);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/ntoskrnl/include/internal/kd64.h
+++ b/ntoskrnl/include/internal/kd64.h
@@ -72,14 +72,6 @@ BOOLEAN
     IN BOOLEAN SecondChance
 );
 
-typedef
-BOOLEAN
-(NTAPI *PKDEBUG_SWITCH_ROUTINE)(
-    IN PEXCEPTION_RECORD ExceptionRecord,
-    IN PCONTEXT Context,
-    IN BOOLEAN SecondChance
-);
-
 //
 // Initialization Routines
 //
@@ -110,13 +102,10 @@ KdIsThisAKdTrap(
 //
 // Multi-Processor Switch Support
 //
-BOOLEAN
+KCONTINUE_STATUS
 NTAPI
-KdpSwitchProcessor(
-    IN PEXCEPTION_RECORD ExceptionRecord,
-    IN OUT PCONTEXT ContextRecord,
-    IN BOOLEAN SecondChanceException
-);
+KdReportProcessorChange(
+    VOID);
 
 //
 // Time Slip Support
@@ -540,7 +529,6 @@ extern LARGE_INTEGER KdTimerStart;
 extern ULONG KdDisableCount;
 extern KD_CONTEXT KdpContext;
 extern PKDEBUG_ROUTINE KiDebugRoutine;
-extern PKDEBUG_SWITCH_ROUTINE KiDebugSwitchRoutine;
 extern BOOLEAN KdBreakAfterSymbolLoad;
 extern BOOLEAN KdPitchDebugger;
 extern BOOLEAN KdAutoEnableOnEvent;

--- a/ntoskrnl/include/internal/ke.h
+++ b/ntoskrnl/include/internal/ke.h
@@ -982,6 +982,16 @@ VOID
 NTAPI
 KiInitMachineDependent(VOID);
 
+VOID
+NTAPI
+KxFreezeExecution(
+    VOID);
+
+VOID
+NTAPI
+KxThawExecution(
+    VOID);
+
 BOOLEAN
 NTAPI
 KeFreezeExecution(IN PKTRAP_FRAME TrapFrame,

--- a/ntoskrnl/include/internal/ke.h
+++ b/ntoskrnl/include/internal/ke.h
@@ -1024,9 +1024,14 @@ KiSaveProcessorControlState(
 VOID
 NTAPI
 KiSaveProcessorState(
-    IN PKTRAP_FRAME TrapFrame,
-    IN PKEXCEPTION_FRAME ExceptionFrame
-);
+    _In_ PKTRAP_FRAME TrapFrame,
+    _In_ PKEXCEPTION_FRAME ExceptionFrame);
+
+VOID
+NTAPI
+KiRestoreProcessorState(
+    _Out_ PKTRAP_FRAME TrapFrame,
+    _Out_ PKEXCEPTION_FRAME ExceptionFrame);
 
 VOID
 FASTCALL

--- a/ntoskrnl/include/internal/ke.h
+++ b/ntoskrnl/include/internal/ke.h
@@ -1001,6 +1001,11 @@ VOID
 NTAPI
 KeThawExecution(IN BOOLEAN Enable);
 
+KCONTINUE_STATUS
+NTAPI
+KxSwitchKdProcessor(
+    _In_ ULONG ProcessorIndex);
+
 _IRQL_requires_min_(DISPATCH_LEVEL)
 _Acquires_nonreentrant_lock_(*LockHandle->Lock)
 _Acquires_exclusive_lock_(*LockHandle->Lock)

--- a/ntoskrnl/kd64/kdapi.c
+++ b/ntoskrnl/kd64/kdapi.c
@@ -1260,6 +1260,28 @@ KdpNotSupported(IN PDBGKD_MANIPULATE_STATE64 State)
                  &KdpContext);
 }
 
+static
+KCONTINUE_STATUS
+KdpSwitchProcessor(
+    _In_ USHORT ProcessorIndex)
+{
+    /* Make sure that the processor index is valid */
+    if (ProcessorIndex >= KeNumberProcessors)
+    {
+        KdpDprintf("%u is not a valid processor number\n", ProcessorIndex);
+        return ContinueProcessorReselected;
+    }
+
+    /* If the new processor is the current one, there is nothing to do */
+    if (ProcessorIndex == KeGetCurrentProcessorNumber())
+    {
+        return ContinueProcessorReselected;
+    }
+
+    /* Call the architecture specific Ke routine */
+    return KxSwitchKdProcessor(ProcessorIndex);
+}
+
 KCONTINUE_STATUS
 NTAPI
 KdpSendWaitContinue(IN ULONG PacketType,
@@ -1470,10 +1492,8 @@ SendPacket:
 
             case DbgKdSwitchProcessor:
 
-                /* TODO */
-                KdpDprintf("Processor Switch support is unimplemented!\n");
-                KdpNotSupported(&ManipulateState);
-                break;
+                /* Switch the processor and return */
+                return KdpSwitchProcessor(ManipulateState.Processor);
 
             case DbgKdPageInApi:
 
@@ -1785,6 +1805,33 @@ KdpReportExceptionStateChange(IN PEXCEPTION_RECORD ExceptionRecord,
     return Status;
 }
 
+KCONTINUE_STATUS
+NTAPI
+KdReportProcessorChange(
+    VOID)
+{
+    PKPRCB CurrentPrcb = KeGetCurrentPrcb();
+    PCONTEXT ContextRecord = &CurrentPrcb->ProcessorState.ContextFrame;
+    EXCEPTION_RECORD ExceptionRecord = {0};
+    KCONTINUE_STATUS Status;
+
+    /* Save the port data */
+    KdSave(FALSE);
+
+    ExceptionRecord.ExceptionAddress = (PVOID)KeGetContextPc(ContextRecord);
+    ExceptionRecord.ExceptionCode = STATUS_WAKE_SYSTEM_DEBUGGER;
+
+    /* Report the new state */
+    Status = KdpReportExceptionStateChange(&ExceptionRecord,
+                                           ContextRecord,
+                                           FALSE);
+
+    /* Restore the port data */
+    KdRestore(FALSE);
+
+    return Status;
+}
+
 VOID
 NTAPI
 KdpTimeSlipDpcRoutine(IN PKDPC Dpc,
@@ -1831,27 +1878,6 @@ KdpTimeSlipWork(IN PVOID Context)
     /* Delay the DPC until it runs next time */
     DueTime.QuadPart = -1800000000;
     KeSetTimer(&KdpTimeSlipTimer, DueTime, &KdpTimeSlipDpc);
-}
-
-BOOLEAN
-NTAPI
-KdpSwitchProcessor(IN PEXCEPTION_RECORD ExceptionRecord,
-                   IN OUT PCONTEXT ContextRecord,
-                   IN BOOLEAN SecondChanceException)
-{
-    BOOLEAN Status;
-
-    /* Save the port data */
-    KdSave(FALSE);
-
-    /* Report a state change */
-    Status = KdpReportExceptionStateChange(ExceptionRecord,
-                                           ContextRecord,
-                                           SecondChanceException);
-
-    /* Restore the port data and return */
-    KdRestore(FALSE);
-    return Status;
 }
 
 LARGE_INTEGER

--- a/ntoskrnl/kd64/kddata.c
+++ b/ntoskrnl/kd64/kddata.c
@@ -72,7 +72,6 @@ BOOLEAN KdpContextSent;
 // Debug Trap Handlers
 //
 PKDEBUG_ROUTINE KiDebugRoutine = KdpStub;
-PKDEBUG_SWITCH_ROUTINE KiDebugSwitchRoutine;
 
 //
 // Debugger Configuration Settings

--- a/ntoskrnl/kd64/kdinit.c
+++ b/ntoskrnl/kd64/kdinit.c
@@ -360,9 +360,8 @@ KdInitSystem(
         /* Check if we've already initialized our structures */
         if (!KdpDebuggerStructuresInitialized)
         {
-            /* Set the Debug Switch Routine and Retries */
+            /* Set Retries */
             KdpContext.KdpDefaultRetries = 20;
-            KiDebugSwitchRoutine = KdpSwitchProcessor;
 
             /* Initialize breakpoints owed flag and table */
             KdpOweBreakpoint = FALSE;

--- a/ntoskrnl/ke/amd64/cpu.c
+++ b/ntoskrnl/ke/amd64/cpu.c
@@ -614,6 +614,41 @@ KiSaveProcessorControlState(OUT PKPROCESSOR_STATE ProcessorState)
 
 VOID
 NTAPI
+KiSaveProcessorState(
+    _In_ PKTRAP_FRAME TrapFrame,
+    _In_ PKEXCEPTION_FRAME ExceptionFrame)
+{
+    PKPRCB Prcb = KeGetCurrentPrcb();
+
+    /* Save all context */
+    Prcb->ProcessorState.ContextFrame.ContextFlags = CONTEXT_ALL;
+    KeTrapFrameToContext(TrapFrame, ExceptionFrame, &Prcb->ProcessorState.ContextFrame);
+
+    /* Save control registers */
+    KiSaveProcessorControlState(&Prcb->ProcessorState);
+}
+
+VOID
+NTAPI
+KiRestoreProcessorState(
+    _Out_ PKTRAP_FRAME TrapFrame,
+    _Out_ PKEXCEPTION_FRAME ExceptionFrame)
+{
+    PKPRCB Prcb = KeGetCurrentPrcb();
+
+    /* Restore all context */
+    KeContextToTrapFrame(&Prcb->ProcessorState.ContextFrame,
+                         ExceptionFrame,
+                         TrapFrame,
+                         CONTEXT_ALL,
+                         TrapFrame->PreviousMode);
+
+    /* Restore control registers */
+    KiRestoreProcessorControlState(&Prcb->ProcessorState);
+}
+
+VOID
+NTAPI
 KeFlushEntireTb(IN BOOLEAN Invalid,
                 IN BOOLEAN AllProcessors)
 {

--- a/ntoskrnl/ke/amd64/freeze.c
+++ b/ntoskrnl/ke/amd64/freeze.c
@@ -1,0 +1,161 @@
+/*
+ * PROJECT:     ReactOS Kernel
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Processor freeze support for x64
+ * COPYRIGHT:   Copyright 2023 Timo Kreuzer <timo.kreuzer@reactos.org>
+ */
+
+/* INCLUDES *******************************************************************/
+
+#include <ntoskrnl.h>
+#define NDEBUG
+#include <debug.h>
+
+/* NOT INCLUDES ANYMORE ******************************************************/
+
+PKPRCB KiFreezeOwner;
+
+/* FUNCTIONS *****************************************************************/
+
+BOOLEAN
+KiProcessorFreezeHandler(
+    _In_ PKTRAP_FRAME TrapFrame,
+    _In_ PKEXCEPTION_FRAME ExceptionFrame)
+{
+    PKPRCB CurrentPrcb = KeGetCurrentPrcb();
+
+    /* Make sure this is a freeze request */
+    if (CurrentPrcb->IpiFrozen != IPI_FROZEN_STATE_TARGET_FREEZE)
+    {
+        /* Not a freeze request, return FALSE to signal it is unhandled */
+        return FALSE;
+    }
+
+    /* We are frozen now */
+    CurrentPrcb->IpiFrozen = IPI_FROZEN_STATE_FROZEN;
+
+    /* Save the processor state */
+    KiSaveProcessorState(TrapFrame, ExceptionFrame);
+
+    /* Wait for the freeze owner to release us */
+    while (CurrentPrcb->IpiFrozen != IPI_FROZEN_STATE_THAW)
+    {
+        YieldProcessor();
+        KeMemoryBarrier();
+    }
+
+    /* Restore the processor state */
+    KiRestoreProcessorState(TrapFrame, ExceptionFrame);
+
+    /* We are running again now */
+    CurrentPrcb->IpiFrozen = IPI_FROZEN_STATE_RUNNING;
+
+    /* Return TRUE to signal that we handled the freeze */
+    return TRUE;
+}
+
+VOID
+NTAPI
+KxFreezeExecution(
+    VOID)
+{
+    PKPRCB CurrentPrcb = KeGetCurrentPrcb();
+
+    /* Avoid blocking on recursive debug action */
+    if (KiFreezeOwner == CurrentPrcb)
+    {
+        return;
+    }
+
+    /* Try to acquire the freeze owner */
+    while (InterlockedCompareExchangePointer(&KiFreezeOwner, CurrentPrcb, NULL))
+    {
+        /* Someone else was faster. We expect an NMI to freeze any time.
+           Spin here until the freeze owner is available. */
+        while (KiFreezeOwner != NULL)
+        {
+            YieldProcessor();
+            KeMemoryBarrier();
+        }
+    }
+
+    /* We are the owner now */
+    CurrentPrcb->IpiFrozen = IPI_FROZEN_STATE_OWNER;
+
+    /* Loop all processors */
+    for (ULONG i = 0; i < KeNumberProcessors; i++)
+    {
+        PKPRCB TargetPrcb = KiProcessorBlock[i];
+        if (TargetPrcb != CurrentPrcb)
+        {
+            /* Nobody else is allowed to change IpiFrozen, except the freeze owner */
+            ASSERT(TargetPrcb->IpiFrozen == IPI_FROZEN_STATE_RUNNING);
+
+            /* Request target to freeze */
+            TargetPrcb->IpiFrozen = IPI_FROZEN_STATE_TARGET_FREEZE;
+        }
+    }
+
+    /* Send the freeze IPI */
+    KiIpiSend(KeActiveProcessors & ~CurrentPrcb->SetMember, IPI_FREEZE);
+
+    /* Wait for all targets to be frozen */
+    for (ULONG i = 0; i < KeNumberProcessors; i++)
+    {
+        PKPRCB TargetPrcb = KiProcessorBlock[i];
+        if (TargetPrcb != CurrentPrcb)
+        {
+            /* Wait for the target to be frozen */
+            while (TargetPrcb->IpiFrozen != IPI_FROZEN_STATE_FROZEN)
+            {
+                YieldProcessor();
+                KeMemoryBarrier();
+            }
+        }
+    }
+
+    /* All targets are frozen, we can continue */
+}
+
+VOID
+NTAPI
+KxThawExecution(
+    VOID)
+{
+    PKPRCB CurrentPrcb = KeGetCurrentPrcb();
+
+    /* Loop all processors */
+    for (ULONG i = 0; i < KeNumberProcessors; i++)
+    {
+        PKPRCB TargetPrcb = KiProcessorBlock[i];
+        if (TargetPrcb != CurrentPrcb)
+        {
+            /* Make sure they are still frozen */
+            ASSERT(TargetPrcb->IpiFrozen == IPI_FROZEN_STATE_FROZEN);
+
+            /* Request target to thaw */
+            TargetPrcb->IpiFrozen = IPI_FROZEN_STATE_THAW;
+        }
+    }
+
+    /* Wait for all targets to be running */
+    for (ULONG i = 0; i < KeNumberProcessors; i++)
+    {
+        PKPRCB TargetPrcb = KiProcessorBlock[i];
+        if (TargetPrcb != CurrentPrcb)
+        {
+            /* Wait for the target to be running again */
+            while (TargetPrcb->IpiFrozen != IPI_FROZEN_STATE_RUNNING)
+            {
+                YieldProcessor();
+                KeMemoryBarrier();
+            }
+        }
+    }
+
+    /* We are running again now */
+    CurrentPrcb->IpiFrozen = IPI_FROZEN_STATE_RUNNING;
+
+    /* Release the freeze owner */
+    InterlockedExchangePointer(&KiFreezeOwner, NULL);
+}

--- a/ntoskrnl/ke/amd64/trap.S
+++ b/ntoskrnl/ke/amd64/trap.S
@@ -192,14 +192,30 @@ KiDebugTrapOrFaultKMode:
     ExitTrap TF_SAVE_ALL
 ENDFUNC
 
+EXTERN KiNmiInterruptHandler:PROC
+
+FUNC KiNmiInterruptWithEf
+    /* Generate a KEXCEPTION_FRAME on the stack */
+    GENERATE_EXCEPTION_FRAME
+
+    /* Call the C handler */
+    lea rcx, [rsp + KEXCEPTION_FRAME_LENGTH]
+    lea rdx, [rsp]
+    call KiNmiInterruptHandler
+
+    /* Restore the registers from the KEXCEPTION_FRAME */
+    RESTORE_EXCEPTION_STATE
+
+    /* Return */
+    ret
+ENDFUNC
 
 PUBLIC KiNmiInterrupt
 FUNC KiNmiInterrupt
     /* Push pseudo error code */
     EnterTrap TF_SAVE_ALL
 
-    UNIMPLEMENTED KiNmiInterrupt
-    int 3
+    call KiNmiInterruptWithEf
 
     /* Return */
     ExitTrap TF_SAVE_ALL

--- a/ntoskrnl/ke/amd64/traphandler.c
+++ b/ntoskrnl/ke/amd64/traphandler.c
@@ -84,6 +84,14 @@ KiDpcInterruptHandler(VOID)
     KeLowerIrql(OldIrql);
 }
 
+VOID
+KiNmiInterruptHandler(
+    _In_ PKTRAP_FRAME TrapFrame,
+    _In_ PKEXCEPTION_FRAME ExceptionFrame)
+{
+    KiHandleNmi();
+}
+
 #define MAX_SYSCALL_PARAMS 16
 
 NTSTATUS

--- a/ntoskrnl/ke/amd64/traphandler.c
+++ b/ntoskrnl/ke/amd64/traphandler.c
@@ -89,15 +89,39 @@ KiNmiInterruptHandler(
     _In_ PKTRAP_FRAME TrapFrame,
     _In_ PKEXCEPTION_FRAME ExceptionFrame)
 {
+    BOOLEAN ManualSwapGs = FALSE;
+
+    /* Check if the NMI came from kernel mode */
+    if ((TrapFrame->SegCs & MODE_MASK) == 0)
+    {
+        /* Check if GS base is already kernel mode. This is needed, because
+           we might be interrupted during an interrupt/exception from user-mode
+           before the swapgs instruction. */
+        if ((LONG64)__readmsr(MSR_GS_BASE) >= 0)
+        {
+            /* Swap GS to kernel */
+            __swapgs();
+            ManualSwapGs = TRUE;
+        }
+    }
+
     /* Check if this is a freeze */
     if (KiProcessorFreezeHandler(TrapFrame, ExceptionFrame))
     {
         /* NMI was handled */
-        return;
+        goto Exit;
     }
 
     /* Handle the NMI */
     KiHandleNmi();
+
+Exit:
+    /* Check if we need to swap GS back */
+    if (ManualSwapGs)
+    {
+        /* Swap GS back to user */
+        __swapgs();
+    }
 }
 
 #define MAX_SYSCALL_PARAMS 16

--- a/ntoskrnl/ke/amd64/traphandler.c
+++ b/ntoskrnl/ke/amd64/traphandler.c
@@ -89,6 +89,14 @@ KiNmiInterruptHandler(
     _In_ PKTRAP_FRAME TrapFrame,
     _In_ PKEXCEPTION_FRAME ExceptionFrame)
 {
+    /* Check if this is a freeze */
+    if (KiProcessorFreezeHandler(TrapFrame, ExceptionFrame))
+    {
+        /* NMI was handled */
+        return;
+    }
+
+    /* Handle the NMI */
     KiHandleNmi();
 }
 

--- a/ntoskrnl/ke/freeze.c
+++ b/ntoskrnl/ke/freeze.c
@@ -49,7 +49,8 @@ KeFreezeExecution(IN PKTRAP_FRAME TrapFrame,
 #endif
 
 #ifdef CONFIG_SMP
-    // TODO: Add SMP support.
+    /* Architecture specific freeze code */
+    KxFreezeExecution();
 #endif
 
     /* Save the old IRQL to be restored on unfreeze */
@@ -64,7 +65,8 @@ NTAPI
 KeThawExecution(IN BOOLEAN Enable)
 {
 #ifdef CONFIG_SMP
-    // TODO: Add SMP support.
+    /* Architecture specific thaw code */
+    KxThawExecution();
 #endif
 
     /* Clear the freeze flag */

--- a/ntoskrnl/ke/i386/freeze.c
+++ b/ntoskrnl/ke/i386/freeze.c
@@ -26,3 +26,12 @@ KxThawExecution(
 {
     UNIMPLEMENTED;
 }
+
+KCONTINUE_STATUS
+NTAPI
+KxSwitchKdProcessor(
+    _In_ ULONG ProcessorIndex)
+{
+    UNIMPLEMENTED;
+    return ContinueError;
+}

--- a/ntoskrnl/ke/i386/freeze.c
+++ b/ntoskrnl/ke/i386/freeze.c
@@ -1,0 +1,28 @@
+/*
+ * PROJECT:     ReactOS Kernel
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Processor freeze support for i386
+ * COPYRIGHT:
+ */
+
+/* INCLUDES *******************************************************************/
+
+#include <ntoskrnl.h>
+#define NDEBUG
+#include <debug.h>
+
+VOID
+NTAPI
+KxFreezeExecution(
+    VOID)
+{
+    UNIMPLEMENTED;
+}
+
+VOID
+NTAPI
+KxThawExecution(
+    VOID)
+{
+    UNIMPLEMENTED;
+}

--- a/ntoskrnl/ntos.cmake
+++ b/ntoskrnl/ntos.cmake
@@ -316,6 +316,7 @@ if(ARCH STREQUAL "i386")
         ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/i386/cpu.c
         ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/i386/context.c
         ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/i386/exp.c
+        ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/i386/freeze.c
         ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/i386/irqobj.c
         ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/i386/kiinit.c
         ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/i386/ldt.c
@@ -350,6 +351,7 @@ elseif(ARCH STREQUAL "amd64")
         ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/amd64/context.c
         ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/amd64/cpu.c
         ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/amd64/except.c
+        ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/amd64/freeze.c
         ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/amd64/interrupt.c
         ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/amd64/ipi.c
         ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/amd64/irql.c

--- a/sdk/include/ndk/amd64/ketypes.h
+++ b/sdk/include/ndk/amd64/ketypes.h
@@ -301,6 +301,21 @@ typedef enum
 #define IPI_SYNCH_REQUEST       16
 
 //
+// Flags for KPRCB::IpiFrozen
+//
+// Values shown with !ipi extension in WinDbg:
+// 0 = [Running], 1 = [Unknown], 2 = [Frozen], 3 = [Thaw], 4 = [Freeze Owner]
+// 5 = [Target Freeze], 6-15 = [Unknown]
+// 0x20 = [Active] (flag)
+//
+#define IPI_FROZEN_STATE_RUNNING 0
+#define IPI_FROZEN_STATE_FROZEN 2
+#define IPI_FROZEN_STATE_THAW 3
+#define IPI_FROZEN_STATE_OWNER 4
+#define IPI_FROZEN_STATE_TARGET_FREEZE 5
+#define IPI_FROZEN_FLAG_ACTIVE 0x20
+
+//
 // PRCB Flags
 //
 #define PRCB_MINOR_VERSION      1


### PR DESCRIPTION
## Purpose

This PR implements the code to freeze processors and switch them in WinDbg. It is currently implemented as x64 specific code, but we might share it later with x86 (which on Windows works differently, using normal IPIs instead of NMIs, but there should be no reason to use the NMI based method on x86, too, which has some advantages).
Should be reviewed by commit.

JIRA issue: [CORE-XXXX](https://jira.reactos.org/browse/CORE-XXXX)

## Proposed changes

- [NTOS:KE/x64] Add KiNmiInterruptHandler
- [NTOS:KE] Improve freeze code in KeBugCheckWithTf
- [NTOS:KE/x64] Implement KiSaveProcessorState / KiRestoreProcessorState
- [NTOS:KE/x64] Implement processor freeze code
- [NTOS:KE/x64] Implement Kd processor switching

## Tests
✅ KVM x64: https://reactos.org/testman/compare.php?ids=94853,94869,94882,94889
