### PR TITLE
[SHELL32_APITEST] Improve FindExecutable testcase

### DIFF
--- a/modules/rostests/apitests/shell32/FindExecutable.cpp
+++ b/modules/rostests/apitests/shell32/FindExecutable.cpp
@@ -8,30 +8,6 @@
 #include "shelltest.h"
 #include <stdio.h>
 #include <shlwapi.h>
-#include "shell32_apitest_sub.h"
-
-static char s_sub_program[MAX_PATH];
-
-static BOOL
-GetSubProgramPath(void)
-{
-    GetModuleFileNameA(NULL, s_sub_program, _countof(s_sub_program));
-    PathRemoveFileSpecA(s_sub_program);
-    PathAppendA(s_sub_program, "shell32_apitest_sub.exe");
-
-    if (!PathFileExistsA(s_sub_program))
-    {
-        PathRemoveFileSpecA(s_sub_program);
-        PathAppendA(s_sub_program, "testdata\\shell32_apitest_sub.exe");
-
-        if (!PathFileExistsA(s_sub_program))
-        {
-            return FALSE;
-        }
-    }
-
-    return TRUE;
-}
 
 typedef struct TEST_ENTRY
 {
@@ -170,11 +146,6 @@ static const TEST_ENTRY s_entries[] =
     { __LINE__, TRUE, "\"test program.bat\"", DIR_2, s_sys_bat_file },
     { __LINE__, TRUE, "\"test program.bat\"", DIR_3, s_win_bat_file },
     { __LINE__, TRUE, "\"test program.bat\"", DIR_4, s_sys_bat_file },
-    { __LINE__, TRUE, "shell32_apitest_sub.exe", DIR_0, s_sub_program },
-    { __LINE__, TRUE, "shell32_apitest_sub.exe", DIR_1, "shell32_apitest_sub.exe" },
-    { __LINE__, FALSE, "shell32_apitest_sub.exe", DIR_2, "" },
-    { __LINE__, FALSE, "shell32_apitest_sub.exe", DIR_3, "" },
-    { __LINE__, FALSE, "shell32_apitest_sub.exe", DIR_4, "" },
     { __LINE__, TRUE, "test file.txt", DIR_0, s_sys_notepad },
     { __LINE__, TRUE, "test file.txt", DIR_1, s_sys_notepad },
     { __LINE__, TRUE, "test file.txt", DIR_2, s_sys_notepad },
@@ -203,12 +174,6 @@ static void DoTestEntry(const TEST_ENTRY *pEntry)
 
 START_TEST(FindExecutable)
 {
-    if (!GetSubProgramPath())
-    {
-        skip("shell32_apitest_sub.exe not found\n");
-        return;
-    }
-
     char cur_dir[MAX_PATH];
     GetCurrentDirectoryA(_countof(cur_dir), cur_dir);
     if (PathIsRootA(cur_dir))
@@ -227,7 +192,7 @@ START_TEST(FindExecutable)
 
     GetWindowsDirectoryA(s_win_test_exe, _countof(s_win_test_exe));
     PathAppendA(s_win_test_exe, "test program.exe");
-    BOOL ret = CopyFileA(s_sub_program, s_win_test_exe, FALSE);
+    BOOL ret = CopyFileA(s_win_notepad, s_win_test_exe, FALSE);
     if (!ret)
     {
         skip("Please retry with admin rights\n");
@@ -236,7 +201,12 @@ START_TEST(FindExecutable)
 
     GetSystemDirectoryA(s_sys_test_exe, _countof(s_sys_test_exe));
     PathAppendA(s_sys_test_exe, "test program.exe");
-    ok_int(CopyFileA(s_sub_program, s_sys_test_exe, FALSE), TRUE);
+    ret = CopyFileA(s_win_notepad, s_sys_test_exe, FALSE);
+    if (!ret)
+    {
+        skip("Please retry with admin rights\n");
+        return;
+    }
 
     GetWindowsDirectoryA(s_win_bat_file, _countof(s_win_bat_file));
     PathAppendA(s_win_bat_file, "test program.bat");
@@ -269,6 +239,4 @@ START_TEST(FindExecutable)
     DeleteFileA(s_sys_bat_file);
     DeleteFileA(s_win_txt_file);
     DeleteFileA(s_sys_txt_file);
-
-    DoWaitForWindow(CLASSNAME, CLASSNAME, TRUE, TRUE);
 }


### PR DESCRIPTION
## Purpose

Make `shell32:FindExecutable` testcase stable and trustworthy.
JIRA issue: [ROSTESTS-389](https://jira.reactos.org/browse/ROSTESTS-389)

## Proposed changes

- Reduce dependency with sub-program (instead use copy of `notepad.exe`).
- Simplify.

## TODO

- [x] Do tests.

## Screenshots

WinXP:
![winxp](https://github.com/reactos/reactos/assets/2107452/c5db8b34-0038-4283-a5ed-957d6fbdcaf5)
Successful.

Win2k3:
![win2k3](https://github.com/reactos/reactos/assets/2107452/8797301e-5491-42ce-b72f-fea1f4e97315)
Successful.

Win10 x64:
![win10](https://github.com/reactos/reactos/assets/2107452/64a2b5d8-d808-4659-b4d4-f8779ed6895d)
Successful.