### PR TITLE
[MSCTFIME][SDK] Add CInputContextOwner (stub)

### DIFF
--- a/dll/ime/msctfime/inputcontext.cpp
+++ b/dll/ime/msctfime/inputcontext.cpp
@@ -22,6 +22,7 @@ CInputContextOwner::CInputContextOwner(LPVOID fnCallback, LPVOID pCallbackPV)
     m_pCallbackPV = pCallbackPV;
 }
 
+/// @implemented
 CInputContextOwner::~CInputContextOwner()
 {
 }

--- a/dll/ime/msctfime/inputcontext.cpp
+++ b/dll/ime/msctfime/inputcontext.cpp
@@ -14,7 +14,7 @@ WINE_DEFAULT_DEBUG_CHANNEL(msctfime);
  */
 
 /// @unimplemented
-CInputContextOwner::CInputContextOwner(LPVOID fnCallback, LPVOID pCallbackPV)
+CInputContextOwner::CInputContextOwner(FN_IC_OWNER_CALLBACK fnCallback, LPVOID pCallbackPV)
 {
     m_dwCookie = -1;
     m_fnCallback = fnCallback;
@@ -117,7 +117,8 @@ STDMETHODIMP_(ULONG) CInputContextOwner::Release()
 }
 
 /// @unimplemented
-STDMETHODIMP CInputContextOwner::GetACPFromPoint(
+STDMETHODIMP
+CInputContextOwner::GetACPFromPoint(
     const POINT *ptScreen,
     DWORD       dwFlags,
     LONG        *pacp)
@@ -126,7 +127,8 @@ STDMETHODIMP CInputContextOwner::GetACPFromPoint(
 }
 
 /// @unimplemented
-STDMETHODIMP CInputContextOwner::GetTextExt(
+STDMETHODIMP
+CInputContextOwner::GetTextExt(
     LONG acpStart,
     LONG acpEnd,
     RECT *prc,
@@ -135,22 +137,22 @@ STDMETHODIMP CInputContextOwner::GetTextExt(
     return E_NOTIMPL;
 }
 
-/// @unimplemented
+/// @implemented
 STDMETHODIMP CInputContextOwner::GetScreenExt(RECT *prc)
 {
-    return E_NOTIMPL;
+    return m_fnCallback(2, &prc, m_pCallbackPV);
 }
 
-/// @unimplemented
+/// @implemented
 STDMETHODIMP CInputContextOwner::GetStatus(TF_STATUS *pdcs)
 {
-    return E_NOTIMPL;
+    return m_fnCallback(6, &pdcs, m_pCallbackPV);
 }
 
 /// @unimplemented
 STDMETHODIMP CInputContextOwner::GetWnd(HWND *phwnd)
 {
-    return E_NOTIMPL;
+    return m_fnCallback(7, &phwnd, m_pCallbackPV);
 }
 
 /// @unimplemented
@@ -159,19 +161,27 @@ STDMETHODIMP CInputContextOwner::GetAttribute(REFGUID rguidAttribute, VARIANT *p
     return E_NOTIMPL;
 }
 
-/// @unimplemented
+struct MOUSE_SINK_ARGS
+{
+    ITfRangeACP *range;
+    ITfMouseSink *pSink;
+    DWORD *pdwCookie;
+};
+
+/// @implemented
 STDMETHODIMP CInputContextOwner::AdviseMouseSink(
     ITfRangeACP *range,
     ITfMouseSink *pSink,
     DWORD *pdwCookie)
 {
-    return E_NOTIMPL;
+    MOUSE_SINK_ARGS args = { range, pSink, pdwCookie };
+    return m_fnCallback(9, &args, m_pCallbackPV);
 }
 
-/// @unimplemented
+/// @implemented
 STDMETHODIMP CInputContextOwner::UnadviseMouseSink(DWORD dwCookie)
 {
-    return E_NOTIMPL;
+    return m_fnCallback(10, &dwCookie, m_pCallbackPV);
 }
 
 /***********************************************************************

--- a/dll/ime/msctfime/inputcontext.cpp
+++ b/dll/ime/msctfime/inputcontext.cpp
@@ -326,7 +326,12 @@ CicInputContext::DestroyInputContext()
         m_pCompEventSink1 = NULL;
     }
 
-    //FIXME: m_pInputContextOwner
+    if (m_pInputContextOwner)
+    {
+        m_pInputContextOwner->_Unadvise();
+        m_pInputContextOwner->Release();
+        m_pInputContextOwner = NULL;
+    }
 
     if (m_pDocumentMgr)
         m_pDocumentMgr->Pop(1);

--- a/dll/ime/msctfime/inputcontext.cpp
+++ b/dll/ime/msctfime/inputcontext.cpp
@@ -9,6 +9,174 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(msctfime);
 
+/***********************************************************************
+ * CInputContextOwner
+ */
+
+/// @unimplemented
+CInputContextOwner::CInputContextOwner(LPVOID fnCallback, LPVOID pCallbackPV)
+{
+    m_dwCookie = -1;
+    m_fnCallback = fnCallback;
+    m_cRefs = 1;
+    m_pCallbackPV = pCallbackPV;
+}
+
+CInputContextOwner::~CInputContextOwner()
+{
+}
+
+/// @implemented
+HRESULT CInputContextOwner::_Advise(IUnknown *pContext)
+{
+    ITfSource *pSource = NULL;
+
+    m_pContext = NULL;
+
+    HRESULT hr = E_FAIL;
+    if (SUCCEEDED(m_pContext->QueryInterface(IID_ITfSource, (LPVOID*)&pSource)) &&
+        SUCCEEDED(pSource->AdviseSink(IID_ITfContextOwner,
+                                      static_cast<ITfContextOwner*>(this), &m_dwCookie)))
+    {
+        m_pContext = pContext;
+        m_pContext->AddRef();
+        hr = S_OK;
+    }
+
+    if (pSource)
+        pSource->Release();
+
+    return hr;
+}
+
+/// @implemented
+HRESULT CInputContextOwner::_Unadvise()
+{
+    ITfSource *pSource = NULL;
+
+    HRESULT hr = E_FAIL;
+    if (m_pContext)
+    {
+        if (SUCCEEDED(m_pContext->QueryInterface(IID_ITfSource, (LPVOID*)&pSource)) &&
+            SUCCEEDED(pSource->UnadviseSink(m_dwCookie)))
+        {
+            hr = S_OK;
+        }
+    }
+
+    if (m_pContext)
+    {
+        m_pContext->Release();
+        m_pContext = NULL;
+    }
+
+    if (pSource)
+        pSource->Release();
+
+    return hr;
+}
+
+/// @implemented
+STDMETHODIMP CInputContextOwner::QueryInterface(REFIID riid, LPVOID* ppvObj)
+{
+    *ppvObj = NULL;
+
+    if (IsEqualIID(riid, IID_IUnknown) || IsEqualIID(riid, IID_ITfContextOwner))
+    {
+        *ppvObj = this;
+        AddRef();
+        return S_OK;
+    }
+
+    if (IsEqualIID(riid, IID_ITfMouseTrackerACP))
+    {
+        *ppvObj = static_cast<ITfMouseTrackerACP*>(this);
+        AddRef();
+        return S_OK;
+    }
+
+    return E_NOINTERFACE;
+}
+
+/// @implemented
+STDMETHODIMP_(ULONG) CInputContextOwner::AddRef()
+{
+    return ++m_cRefs;
+}
+
+/// @implemented
+STDMETHODIMP_(ULONG) CInputContextOwner::Release()
+{
+    if (--m_cRefs == 0)
+    {
+        delete this;
+        return 0;
+    }
+    return m_cRefs;
+}
+
+/// @unimplemented
+STDMETHODIMP CInputContextOwner::GetACPFromPoint(
+    const POINT *ptScreen,
+    DWORD       dwFlags,
+    LONG        *pacp)
+{
+    return E_NOTIMPL;
+}
+
+/// @unimplemented
+STDMETHODIMP CInputContextOwner::GetTextExt(
+    LONG acpStart,
+    LONG acpEnd,
+    RECT *prc,
+    BOOL *pfClipped)
+{
+    return E_NOTIMPL;
+}
+
+/// @unimplemented
+STDMETHODIMP CInputContextOwner::GetScreenExt(RECT *prc)
+{
+    return E_NOTIMPL;
+}
+
+/// @unimplemented
+STDMETHODIMP CInputContextOwner::GetStatus(TF_STATUS *pdcs)
+{
+    return E_NOTIMPL;
+}
+
+/// @unimplemented
+STDMETHODIMP CInputContextOwner::GetWnd(HWND *phwnd)
+{
+    return E_NOTIMPL;
+}
+
+/// @unimplemented
+STDMETHODIMP CInputContextOwner::GetAttribute(REFGUID rguidAttribute, VARIANT *pvarValue)
+{
+    return E_NOTIMPL;
+}
+
+/// @unimplemented
+STDMETHODIMP CInputContextOwner::AdviseMouseSink(
+    ITfRangeACP *range,
+    ITfMouseSink *pSink,
+    DWORD *pdwCookie)
+{
+    return E_NOTIMPL;
+}
+
+/// @unimplemented
+STDMETHODIMP CInputContextOwner::UnadviseMouseSink(DWORD dwCookie)
+{
+    return E_NOTIMPL;
+}
+
+/***********************************************************************
+ * CicInputContext
+ */
+
 /// @unimplemented
 CicInputContext::CicInputContext(
     _In_ TfClientId cliendId,

--- a/dll/ime/msctfime/inputcontext.h
+++ b/dll/ime/msctfime/inputcontext.h
@@ -14,6 +14,55 @@ class CInputContextOwnerCallBack;
 class CInputContextOwner;
 
 /***********************************************************************
+ *      CInputContextOwner
+ */
+class CInputContextOwner
+    : public ITfContextOwner
+    , public ITfMouseTrackerACP
+{
+protected:
+    LONG m_cRefs;
+    IUnknown *m_pContext;
+    DWORD m_dwCookie;
+    LPVOID m_fnCallback;
+    LPVOID m_pCallbackPV;
+
+public:
+    CInputContextOwner(LPVOID fnCallback, LPVOID pCallbackPV);
+    virtual ~CInputContextOwner();
+
+    HRESULT _Advise(IUnknown *pContext);
+    HRESULT _Unadvise();
+
+    // IUnknown methods
+    STDMETHODIMP QueryInterface(REFIID riid, LPVOID* ppvObj) override;
+    STDMETHODIMP_(ULONG) AddRef() override;
+    STDMETHODIMP_(ULONG) Release() override;
+
+    // ITfContextOwner methods
+    STDMETHODIMP GetACPFromPoint(
+        const POINT *ptScreen,
+        DWORD       dwFlags,
+        LONG        *pacp) override;
+    STDMETHODIMP GetTextExt(
+        LONG acpStart,
+        LONG acpEnd,
+        RECT *prc,
+        BOOL *pfClipped) override;
+    STDMETHODIMP GetScreenExt(RECT *prc) override;
+    STDMETHODIMP GetStatus(TF_STATUS *pdcs) override;
+    STDMETHODIMP GetWnd(HWND *phwnd) override;
+    STDMETHODIMP GetAttribute(REFGUID rguidAttribute, VARIANT *pvarValue) override;
+
+    // ITfMouseTrackerACP methods
+    STDMETHODIMP AdviseMouseSink(
+        ITfRangeACP *range,
+        ITfMouseSink *pSink,
+        DWORD *pdwCookie) override;
+    STDMETHODIMP UnadviseMouseSink(DWORD dwCookie) override;
+};
+
+/***********************************************************************
  *      CicInputContext
  *
  * The msctfime.ime's input context.

--- a/dll/ime/msctfime/inputcontext.h
+++ b/dll/ime/msctfime/inputcontext.h
@@ -14,6 +14,9 @@ class CInputContextOwnerCallBack;
 class CInputContextOwner;
 class CicInputContext;
 
+
+typedef HRESULT (CALLBACK *FN_IC_OWNER_CALLBACK)(UINT uType, LPVOID args, LPVOID param);
+
 /***********************************************************************
  *      CInputContextOwner
  */
@@ -25,11 +28,11 @@ protected:
     LONG m_cRefs;
     IUnknown *m_pContext;
     DWORD m_dwCookie;
-    LPVOID m_fnCallback;
+    FN_IC_OWNER_CALLBACK m_fnCallback;
     LPVOID m_pCallbackPV;
 
 public:
-    CInputContextOwner(LPVOID fnCallback, LPVOID pCallbackPV);
+    CInputContextOwner(FN_IC_OWNER_CALLBACK fnCallback, LPVOID pCallbackPV);
     virtual ~CInputContextOwner();
 
     HRESULT _Advise(IUnknown *pContext);

--- a/dll/ime/msctfime/inputcontext.h
+++ b/dll/ime/msctfime/inputcontext.h
@@ -12,6 +12,7 @@
 
 class CInputContextOwnerCallBack;
 class CInputContextOwner;
+class CicInputContext;
 
 /***********************************************************************
  *      CInputContextOwner

--- a/sdk/include/psdk/msctf.idl
+++ b/sdk/include/psdk/msctf.idl
@@ -952,6 +952,38 @@ interface ITfTextEditSink : IUnknown
 
 [
     object,
+    uuid(AA80E80C-2021-11D2-93E0-0060B067B86E),
+    pointer_default(unique)
+]
+interface ITfContextOwner : IUnknown
+{
+    HRESULT GetACPFromPoint(
+        [in]  const POINT *ptScreen,
+        [in]  DWORD       dwFlags,
+        [out] LONG        *pacp);
+
+    HRESULT GetTextExt(
+        [in]  LONG acpStart,
+        [in]  LONG acpEnd,
+        [out] RECT *prc,
+        [out] BOOL *pfClipped);
+
+    HRESULT GetScreenExt(
+        [out] RECT *prc);
+
+    HRESULT GetStatus(
+        [out] TF_STATUS *pdcs);
+
+    HRESULT GetWnd(
+        [out] HWND *phwnd);
+
+    HRESULT GetAttribute(
+        [in]  REFGUID rguidAttribute,
+        [out] VARIANT *pvarValue);
+}
+
+[
+    object,
     uuid(5F20AA40-B57A-4F34-96AB-3576F377CC79),
     pointer_default(unique)
 ]


### PR DESCRIPTION
## Purpose

Supporting TIPs...

JIRA issue: [CORE-19360](https://jira.reactos.org/browse/CORE-19360)

## Proposed changes

- Add `ITfContextOwner` interface to `"msctf.idl"`.
- Stub-implement `CInputContextOwner` class.

## TODO

- [x] Do build.