### PR TITLE
[KBSWITCH][INPUT][SDK] Use <imm32_undoc.h>'s IS_IME_HKL

### DIFF
--- a/base/applications/kbswitch/kbswitch.c
+++ b/base/applications/kbswitch/kbswitch.c
@@ -11,6 +11,7 @@
 #include <shlobj.h>
 #include <shlwapi_undoc.h>
 #include <imm.h>
+#include <imm32_undoc.h>
 
 /*
  * This program kbswitch is a mimic of Win2k's internat.exe.
@@ -25,13 +26,6 @@
  * It might not work correctly on Vista+ because keyboard layout change notification
  * won't be generated in Vista+.
  */
-
-#define IME_MASK        (0xE0000000UL)
-#define SPECIAL_MASK    (0xF0000000UL)
-
-#define IS_IME_HKL(hKL)             ((((ULONG_PTR)(hKL)) & 0xF0000000) == IME_MASK)
-#define IS_SPECIAL_HKL(hKL)         ((((ULONG_PTR)(hKL)) & 0xF0000000) == SPECIAL_MASK)
-#define SPECIALIDFROMHKL(hKL)       ((WORD)(HIWORD(hKL) & 0x0FFF))
 
 #define WM_NOTIFYICONMSG (WM_USER + 248)
 

--- a/dll/cpl/input/input.h
+++ b/dll/cpl/input/input.h
@@ -16,6 +16,7 @@
 #include <setupapi.h>
 #include <strsafe.h>
 #include <cpl.h>
+#include <imm32_undoc.h>
 
 #include "resource.h"
 
@@ -82,17 +83,6 @@ DWORDfromString(const WCHAR *pszString)
 
     return wcstoul(pszString, &pszEnd, 16);
 }
-
-#define IME_MASK        (0xE0000000UL)
-#define SUBST_MASK      (0xD0000000UL)
-#define SPECIAL_MASK    (0xF0000000UL)
-
-#define IS_IME_HKL(hKL)             ((((ULONG_PTR)(hKL)) & 0xF0000000) == IME_MASK)
-#define IS_SPECIAL_HKL(hKL)         ((((ULONG_PTR)(hKL)) & 0xF0000000) == SPECIAL_MASK)
-#define SPECIALIDFROMHKL(hKL)       ((WORD)(HIWORD(hKL) & 0x0FFF))
-
-#define IS_IME_KLID(dwKLID)         ((((ULONG)(dwKLID)) & 0xF0000000) == IME_MASK)
-#define IS_SUBST_KLID(dwKLID)       ((((ULONG)(dwKLID)) & 0xF0000000) == SUBST_MASK)
 
 VOID GetSystemLibraryPath(LPWSTR pszPath, INT cchPath, LPCWSTR pszFileName);
 

--- a/sdk/include/reactos/imm32_undoc.h
+++ b/sdk/include/reactos/imm32_undoc.h
@@ -13,7 +13,16 @@ extern "C" {
 
 #include <immdev.h>
 
-#define IS_IME_HKL(hkl) ((((ULONG_PTR)(hkl)) & 0xF0000000) == 0xE0000000)
+#define IME_MASK        (0xE0000000UL)
+#define SUBST_MASK      (0xD0000000UL)
+#define SPECIAL_MASK    (0xF0000000UL)
+
+#define IS_IME_HKL(hKL)         ((((ULONG_PTR)(hKL)) & 0xF0000000) == IME_MASK)
+#define IS_SPECIAL_HKL(hKL)     ((((ULONG_PTR)(hKL)) & 0xF0000000) == SPECIAL_MASK)
+#define SPECIALIDFROMHKL(hKL)   ((WORD)(HIWORD(hKL) & 0x0FFF))
+
+#define IS_IME_KLID(dwKLID)     ((((ULONG)(dwKLID)) & 0xF0000000) == IME_MASK)
+#define IS_SUBST_KLID(dwKLID)   ((((ULONG)(dwKLID)) & 0xF0000000) == SUBST_MASK)
 
 typedef struct tagIMEINFOEX
 {


### PR DESCRIPTION
## Purpose
Unify the private IMM32 macro definitions. Refactoring...
JIRA issue: [CORE-19361](https://jira.reactos.org/browse/CORE-19361)

## Proposed changes

- Define `IS_SPECIAL_HKL` macro in `<imm32_undoc.h>`.
- Use `IS_IME_HKL` and `IS_SPECIAL_HKL` macros of `<imm32_undoc.h>`, in `kbswitch` and `input` modules.

## TODO

- [ ] Do build.