### PR TITLE
[EXPLORER][SHELL32][SDK] Show/hide 'Run' menu item

### DIFF
--- a/base/shell/explorer/precomp.h
+++ b/base/shell/explorer/precomp.h
@@ -110,6 +110,7 @@ BOOL GetRegValue(IN LPCWSTR pszSubKey, IN LPCWSTR pszValueName, IN BOOL bDefault
 BOOL SetRegDword(IN LPCWSTR pszSubKey, IN LPCWSTR pszValueName, IN DWORD dwValue);
 BOOL GetAdvancedBool(IN LPCWSTR pszValueName, IN BOOL bDefaultValue);
 BOOL SetAdvancedDword(IN LPCWSTR pszValueName, IN DWORD dwValue);
+BOOL SetRestriction(IN LPCWSTR pszKey, IN LPCWSTR pszValueName, IN DWORD dwValue);
 
 /*
  *  rshell.c

--- a/base/shell/explorer/startmnucust.cpp
+++ b/base/shell/explorer/startmnucust.cpp
@@ -96,6 +96,17 @@ static BOOL CALLBACK CustomizeWrite0(const CUSTOMIZE_ENTRY *entry, DWORD dwValue
     return SetAdvancedDword(entry->name, dwValue);
 }
 
+static DWORD CALLBACK CustomizeReadRun(const CUSTOMIZE_ENTRY *entry)
+{
+    return !SHRestricted(REST_NORUN);
+}
+
+static BOOL CALLBACK CustomizeWriteRun(const CUSTOMIZE_ENTRY *entry, DWORD dwValue)
+{
+    SetRestriction(L"Explorer", L"NoRun", !dwValue);
+    return TRUE;
+}
+
 static const CUSTOMIZE_ENTRY s_CustomizeEntries[] =
 {
     // FIXME: Make "StartMenuAdminTools" effective
@@ -103,9 +114,7 @@ static const CUSTOMIZE_ENTRY s_CustomizeEntries[] =
 
     { IDS_ADVANCED_DISPLAY_FAVORITES,  L"StartMenuFavorites",  CustomizeRead0, CustomizeWrite0 },
     { IDS_ADVANCED_DISPLAY_LOG_OFF,    L"StartMenuLogoff",     CustomizeRead0, CustomizeWrite0 },
-
-    // FIXME: SHRestricted is buggy!
-    //{ IDS_ADVANCED_DISPLAY_RUN,        L"NoRun",               CustomizeRead2, CustomizeWrite2 },
+    { IDS_ADVANCED_DISPLAY_RUN,        L"NoRun",               CustomizeReadRun, CustomizeWriteRun },
 };
 
 static VOID AddCustomizeItem(HWND hTreeView, const CUSTOMIZE_ENTRY *entry)

--- a/base/shell/explorer/startmnucust.cpp
+++ b/base/shell/explorer/startmnucust.cpp
@@ -101,9 +101,9 @@ static DWORD CALLBACK CustomizeReadRun(const CUSTOMIZE_ENTRY *entry)
     return !SHRestricted(REST_NORUN);
 }
 
-static BOOL CALLBACK CustomizeWriteRun(const CUSTOMIZE_ENTRY *entry, DWORD dwValue)
+static BOOL CALLBACK CustomizeWriteRest(const CUSTOMIZE_ENTRY *entry, DWORD dwValue)
 {
-    SetRestriction(L"Explorer", L"NoRun", !dwValue);
+    SetRestriction(L"Explorer", entry->name, !dwValue);
     return TRUE;
 }
 
@@ -114,7 +114,7 @@ static const CUSTOMIZE_ENTRY s_CustomizeEntries[] =
 
     { IDS_ADVANCED_DISPLAY_FAVORITES,  L"StartMenuFavorites",  CustomizeRead0, CustomizeWrite0 },
     { IDS_ADVANCED_DISPLAY_LOG_OFF,    L"StartMenuLogoff",     CustomizeRead0, CustomizeWrite0 },
-    { IDS_ADVANCED_DISPLAY_RUN,        L"NoRun",               CustomizeReadRun, CustomizeWriteRun },
+    { IDS_ADVANCED_DISPLAY_RUN,        L"NoRun",               CustomizeReadRun, CustomizeWriteRest },
 };
 
 static VOID AddCustomizeItem(HWND hTreeView, const CUSTOMIZE_ENTRY *entry)

--- a/base/shell/explorer/startmnusite.cpp
+++ b/base/shell/explorer/startmnusite.cpp
@@ -216,9 +216,7 @@ public:
         /* Run */
         if (SHRestricted(REST_NORUN))
         {
-            DeleteMenu(hMenu,
-                       IDM_RUN,
-                       MF_BYCOMMAND);
+            DeleteMenu(hMenu, IDM_RUN, MF_BYCOMMAND);
         }
 
         /* Synchronize */

--- a/base/shell/explorer/util.cpp
+++ b/base/shell/explorer/util.cpp
@@ -163,6 +163,15 @@ BOOL SetAdvancedDword(IN LPCWSTR pszValueName, IN DWORD dwValue)
     return SetRegDword(REGKEY_ADVANCED, pszValueName, dwValue);
 }
 
+BOOL SetRestriction(IN LPCWSTR pszKey, IN LPCWSTR pszValueName, IN DWORD dwValue)
+{
+    WCHAR szSubKey[MAX_PATH] = L"Software\\Microsoft\\Windows\\CurrentVersion\\Policies";
+    PathAppendW(szSubKey, pszKey);
+    SHSetValueW(HKEY_CURRENT_USER, szSubKey, pszValueName, REG_DWORD, &dwValue, sizeof(dwValue));
+    SHSettingsChanged(NULL, NULL);
+    return TRUE;
+}
+
 BOOL
 GetVersionInfoString(IN LPCWSTR szFileName,
                      IN LPCWSTR szVersionInfo,

--- a/dll/win32/shell32/dialogs/general.cpp
+++ b/dll/win32/shell32/dialogs/general.cpp
@@ -34,9 +34,6 @@ typedef struct REGSHELLSTATE
 static const LPCWSTR s_pszExplorerKey =
     L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer";
 
-extern "C"
-BOOL WINAPI SHSettingsChanged(LPCVOID unused, LPCVOID inpRegKey);
-
 /////////////////////////////////////////////////////////////////////////////
 // Shell settings
 

--- a/sdk/include/reactos/undocshell.h
+++ b/sdk/include/reactos/undocshell.h
@@ -49,13 +49,11 @@ typedef struct _TRAYNOTIFYDATAW
 
 #endif /* defined (_SHELLAPI_H) || defined (_INC_SHELLAPI) */
 
-
 /****************************************************************************
  * Taskbar WM_COMMAND identifiers
  */
 #define TWM_DOEXITWINDOWS (WM_USER + 342)
 #define TWM_CYCLEFOCUS (WM_USER + 348)
-
 
 /****************************************************************************
  *  IDList Functions
@@ -95,7 +93,6 @@ HRESULT WINAPI SHILCreateFromPathW (
 */
 BOOL WINAPI StrRetToStrNA(LPSTR,DWORD,LPSTRRET,const ITEMIDLIST*);
 BOOL WINAPI StrRetToStrNW(LPWSTR,DWORD,LPSTRRET,const ITEMIDLIST*);
-
 
 /****************************************************************************
  * SHChangeNotifyRegister API
@@ -258,6 +255,7 @@ ExtractIconResInfoW(
 /****************************************************************************
  * File Menu Routines
  */
+
 /* FileMenu_Create nSelHeight constants */
 #define FM_DEFAULT_SELHEIGHT  -1
 #define FM_FULL_SELHEIGHT     0
@@ -731,6 +729,8 @@ Activate_RunDLL(
     _In_ HINSTANCE hinst,
     _In_ LPCWSTR cmdline,
     _In_ INT cmdshow);
+
+BOOL WINAPI SHSettingsChanged(LPCVOID unused, LPCWSTR pszKey);
 
 /*****************************************************************************
  * Shell32 resources


### PR DESCRIPTION
## Purpose
Improve Start Menu customization.
JIRA issue: [CORE-16956](https://jira.reactos.org/browse/CORE-16956)

## Proposed changes

- Add `SHSettingsChanged` prototype to `<undocshell.h>`.
- Add `SetRestriction` helper function.
- Implement showing/hiding `Run` menu item of Start Menu.

## TODO

- [x] Do tests.

## Screenshots

![after3](https://github.com/reactos/reactos/assets/2107452/03c354c9-3084-4107-9808-6141372dbbf8)
![after1](https://github.com/reactos/reactos/assets/2107452/5d3eff6d-317e-426e-b497-dc32b1c2df13)
![after2](https://github.com/reactos/reactos/assets/2107452/860ef43b-0d85-4195-a496-2b711f4ebe52)