### PR TITLE
[EXPLORER][SHELL32] Expand/unexpand My Documents menu

### DIFF
--- a/base/shell/explorer/resource.h
+++ b/base/shell/explorer/resource.h
@@ -109,6 +109,8 @@
 /* These values must be synchronized with shell32 */
 #define IDS_ADVANCED_DISPLAY_FAVORITES              30466
 #define IDS_ADVANCED_DISPLAY_LOG_OFF                30467
+#define IDS_ADVANCED_EXPAND_MY_DOCUMENTS            30469
+#define IDS_ADVANCED_EXPAND_MY_PICTURES             30472
 #define IDS_ADVANCED_DISPLAY_RUN                    30474
 #define IDS_ADVANCED_DISPLAY_ADMINTOOLS             30476
 

--- a/base/shell/explorer/startmnucust.cpp
+++ b/base/shell/explorer/startmnucust.cpp
@@ -86,12 +86,12 @@ struct CUSTOMIZE_ENTRY
     FN_CUSTOMIZE_WRITE fnWrite;
 };
 
-static DWORD CALLBACK CustomizeRead0(const CUSTOMIZE_ENTRY *entry)
+static DWORD CALLBACK CustomizeReadAdvanced(const CUSTOMIZE_ENTRY *entry)
 {
     return GetAdvancedBool(entry->name, FALSE);
 }
 
-static BOOL CALLBACK CustomizeWrite0(const CUSTOMIZE_ENTRY *entry, DWORD dwValue)
+static BOOL CALLBACK CustomizeWriteAdvanced(const CUSTOMIZE_ENTRY *entry, DWORD dwValue)
 {
     return SetAdvancedDword(entry->name, dwValue);
 }
@@ -112,9 +112,11 @@ static const CUSTOMIZE_ENTRY s_CustomizeEntries[] =
     // FIXME: Make "StartMenuAdminTools" effective
     //{ IDS_ADVANCED_DISPLAY_ADMINTOOLS, L"StartMenuAdminTools", CustomizeRead1, CustomizeWrite1 }, // FIXME
 
-    { IDS_ADVANCED_DISPLAY_FAVORITES,  L"StartMenuFavorites",  CustomizeRead0, CustomizeWrite0 },
-    { IDS_ADVANCED_DISPLAY_LOG_OFF,    L"StartMenuLogoff",     CustomizeRead0, CustomizeWrite0 },
-    { IDS_ADVANCED_DISPLAY_RUN,        L"NoRun",               CustomizeReadRun, CustomizeWriteRest },
+    { IDS_ADVANCED_DISPLAY_FAVORITES,   L"StartMenuFavorites",  CustomizeReadAdvanced, CustomizeWriteAdvanced },
+    { IDS_ADVANCED_DISPLAY_LOG_OFF,     L"StartMenuLogoff",     CustomizeReadAdvanced, CustomizeWriteAdvanced },
+    { IDS_ADVANCED_DISPLAY_RUN,         L"NoRun",               CustomizeReadRun,      CustomizeWriteRest     },
+    { IDS_ADVANCED_EXPAND_MY_DOCUMENTS, L"CascadeMyDocuments",  CustomizeReadAdvanced, CustomizeWriteAdvanced },
+    { IDS_ADVANCED_EXPAND_MY_PICTURES,  L"CascadeMyPictures",   CustomizeReadAdvanced, CustomizeWriteAdvanced },
 };
 
 static VOID AddCustomizeItem(HWND hTreeView, const CUSTOMIZE_ENTRY *entry)

--- a/dll/win32/shell32/lang/bg-BG.rc
+++ b/dll/win32/shell32/lang/bg-BG.rc
@@ -1014,6 +1014,8 @@ BEGIN
     IDS_ADVANCED_SHOW_INFO_TIP "Show pop-up description for folder and desktop items"
     IDS_ADVANCED_DISPLAY_FAVORITES "Display Favorites"
     IDS_ADVANCED_DISPLAY_LOG_OFF "Display Log Off"
+    IDS_ADVANCED_EXPAND_MY_DOCUMENTS "Expand My Documents"
+    IDS_ADVANCED_EXPAND_MY_PICTURES "Expand My Pictures"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
 

--- a/dll/win32/shell32/lang/ca-ES.rc
+++ b/dll/win32/shell32/lang/ca-ES.rc
@@ -1014,6 +1014,8 @@ BEGIN
     IDS_ADVANCED_SHOW_INFO_TIP "Show pop-up description for folder and desktop items"
     IDS_ADVANCED_DISPLAY_FAVORITES "Display Favorites"
     IDS_ADVANCED_DISPLAY_LOG_OFF "Display Log Off"
+    IDS_ADVANCED_EXPAND_MY_DOCUMENTS "Expand My Documents"
+    IDS_ADVANCED_EXPAND_MY_PICTURES "Expand My Pictures"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
 

--- a/dll/win32/shell32/lang/cs-CZ.rc
+++ b/dll/win32/shell32/lang/cs-CZ.rc
@@ -1022,6 +1022,8 @@ BEGIN
     IDS_ADVANCED_SHOW_INFO_TIP "Show pop-up description for folder and desktop items"
     IDS_ADVANCED_DISPLAY_FAVORITES "Display Favorites"
     IDS_ADVANCED_DISPLAY_LOG_OFF "Display Log Off"
+    IDS_ADVANCED_EXPAND_MY_DOCUMENTS "Expand My Documents"
+    IDS_ADVANCED_EXPAND_MY_PICTURES "Expand My Pictures"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
 

--- a/dll/win32/shell32/lang/da-DK.rc
+++ b/dll/win32/shell32/lang/da-DK.rc
@@ -1021,6 +1021,8 @@ BEGIN
     IDS_ADVANCED_SHOW_INFO_TIP "Show pop-up description for folder and desktop items"
     IDS_ADVANCED_DISPLAY_FAVORITES "Display Favorites"
     IDS_ADVANCED_DISPLAY_LOG_OFF "Display Log Off"
+    IDS_ADVANCED_EXPAND_MY_DOCUMENTS "Expand My Documents"
+    IDS_ADVANCED_EXPAND_MY_PICTURES "Expand My Pictures"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
 

--- a/dll/win32/shell32/lang/de-DE.rc
+++ b/dll/win32/shell32/lang/de-DE.rc
@@ -1015,6 +1015,8 @@ BEGIN
     IDS_ADVANCED_SHOW_INFO_TIP "Popupinformationen für Ordner- und Desktop-Elemente anzeigen"
     IDS_ADVANCED_DISPLAY_FAVORITES "Display Favorites"
     IDS_ADVANCED_DISPLAY_LOG_OFF "Display Log Off"
+    IDS_ADVANCED_EXPAND_MY_DOCUMENTS "Expand My Documents"
+    IDS_ADVANCED_EXPAND_MY_PICTURES "Expand My Pictures"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
 

--- a/dll/win32/shell32/lang/el-GR.rc
+++ b/dll/win32/shell32/lang/el-GR.rc
@@ -1014,6 +1014,8 @@ BEGIN
     IDS_ADVANCED_SHOW_INFO_TIP "Show pop-up description for folder and desktop items"
     IDS_ADVANCED_DISPLAY_FAVORITES "Display Favorites"
     IDS_ADVANCED_DISPLAY_LOG_OFF "Display Log Off"
+    IDS_ADVANCED_EXPAND_MY_DOCUMENTS "Expand My Documents"
+    IDS_ADVANCED_EXPAND_MY_PICTURES "Expand My Pictures"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
 

--- a/dll/win32/shell32/lang/en-GB.rc
+++ b/dll/win32/shell32/lang/en-GB.rc
@@ -1014,6 +1014,8 @@ BEGIN
     IDS_ADVANCED_SHOW_INFO_TIP "Show pop-up description for folder and desktop items"
     IDS_ADVANCED_DISPLAY_FAVORITES "Display Favorites"
     IDS_ADVANCED_DISPLAY_LOG_OFF "Display Log Off"
+    IDS_ADVANCED_EXPAND_MY_DOCUMENTS "Expand My Documents"
+    IDS_ADVANCED_EXPAND_MY_PICTURES "Expand My Pictures"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
 

--- a/dll/win32/shell32/lang/en-US.rc
+++ b/dll/win32/shell32/lang/en-US.rc
@@ -1014,6 +1014,8 @@ BEGIN
     IDS_ADVANCED_SHOW_INFO_TIP "Show pop-up description for folder and desktop items"
     IDS_ADVANCED_DISPLAY_FAVORITES "Display Favorites"
     IDS_ADVANCED_DISPLAY_LOG_OFF "Display Log Off"
+    IDS_ADVANCED_EXPAND_MY_DOCUMENTS "Expand My Documents"
+    IDS_ADVANCED_EXPAND_MY_PICTURES "Expand My Pictures"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
 

--- a/dll/win32/shell32/lang/es-ES.rc
+++ b/dll/win32/shell32/lang/es-ES.rc
@@ -1023,6 +1023,8 @@ BEGIN
     IDS_ADVANCED_SHOW_INFO_TIP "Mostrar descripción de íconos y carpetas en el escritorio"
     IDS_ADVANCED_DISPLAY_FAVORITES "Display Favorites"
     IDS_ADVANCED_DISPLAY_LOG_OFF "Display Log Off"
+    IDS_ADVANCED_EXPAND_MY_DOCUMENTS "Expand My Documents"
+    IDS_ADVANCED_EXPAND_MY_PICTURES "Expand My Pictures"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
 

--- a/dll/win32/shell32/lang/et-EE.rc
+++ b/dll/win32/shell32/lang/et-EE.rc
@@ -1021,6 +1021,8 @@ BEGIN
     IDS_ADVANCED_SHOW_INFO_TIP "Näita kausta- ja töölauaüksuste hüpikkirjeldusi"
     IDS_ADVANCED_DISPLAY_FAVORITES "Display Favorites"
     IDS_ADVANCED_DISPLAY_LOG_OFF "Display Log Off"
+    IDS_ADVANCED_EXPAND_MY_DOCUMENTS "Expand My Documents"
+    IDS_ADVANCED_EXPAND_MY_PICTURES "Expand My Pictures"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
 

--- a/dll/win32/shell32/lang/eu-ES.rc
+++ b/dll/win32/shell32/lang/eu-ES.rc
@@ -1019,6 +1019,8 @@ BEGIN
     IDS_ADVANCED_SHOW_INFO_TIP "Erakutsi ikonoen eta karpeten deskribapena mahaigainean"
     IDS_ADVANCED_DISPLAY_FAVORITES "Display Favorites"
     IDS_ADVANCED_DISPLAY_LOG_OFF "Display Log Off"
+    IDS_ADVANCED_EXPAND_MY_DOCUMENTS "Expand My Documents"
+    IDS_ADVANCED_EXPAND_MY_PICTURES "Expand My Pictures"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
 

--- a/dll/win32/shell32/lang/fi-FI.rc
+++ b/dll/win32/shell32/lang/fi-FI.rc
@@ -1014,6 +1014,8 @@ BEGIN
     IDS_ADVANCED_SHOW_INFO_TIP "Show pop-up description for folder and desktop items"
     IDS_ADVANCED_DISPLAY_FAVORITES "Display Favorites"
     IDS_ADVANCED_DISPLAY_LOG_OFF "Display Log Off"
+    IDS_ADVANCED_EXPAND_MY_DOCUMENTS "Expand My Documents"
+    IDS_ADVANCED_EXPAND_MY_PICTURES "Expand My Pictures"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
 

--- a/dll/win32/shell32/lang/fr-FR.rc
+++ b/dll/win32/shell32/lang/fr-FR.rc
@@ -1014,6 +1014,8 @@ BEGIN
     IDS_ADVANCED_SHOW_INFO_TIP "Afficher les info-bulles pour les fichiers et les dossiers"
     IDS_ADVANCED_DISPLAY_FAVORITES "Display Favorites"
     IDS_ADVANCED_DISPLAY_LOG_OFF "Display Log Off"
+    IDS_ADVANCED_EXPAND_MY_DOCUMENTS "Expand My Documents"
+    IDS_ADVANCED_EXPAND_MY_PICTURES "Expand My Pictures"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
 

--- a/dll/win32/shell32/lang/he-IL.rc
+++ b/dll/win32/shell32/lang/he-IL.rc
@@ -1021,6 +1021,8 @@ BEGIN
     IDS_ADVANCED_SHOW_INFO_TIP "Show pop-up description for folder and desktop items"
     IDS_ADVANCED_DISPLAY_FAVORITES "Display Favorites"
     IDS_ADVANCED_DISPLAY_LOG_OFF "Display Log Off"
+    IDS_ADVANCED_EXPAND_MY_DOCUMENTS "Expand My Documents"
+    IDS_ADVANCED_EXPAND_MY_PICTURES "Expand My Pictures"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
 

--- a/dll/win32/shell32/lang/hi-IN.rc
+++ b/dll/win32/shell32/lang/hi-IN.rc
@@ -1016,6 +1016,8 @@ BEGIN
     IDS_ADVANCED_SHOW_INFO_TIP "फ़ोल्डर और डेस्कटॉप आइटम के लिए पॉप-अप विवरण दिखाएं"
     IDS_ADVANCED_DISPLAY_FAVORITES "Display Favorites"
     IDS_ADVANCED_DISPLAY_LOG_OFF "Display Log Off"
+    IDS_ADVANCED_EXPAND_MY_DOCUMENTS "Expand My Documents"
+    IDS_ADVANCED_EXPAND_MY_PICTURES "Expand My Pictures"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
 

--- a/dll/win32/shell32/lang/hu-HU.rc
+++ b/dll/win32/shell32/lang/hu-HU.rc
@@ -1013,6 +1013,8 @@ BEGIN
     IDS_ADVANCED_SHOW_INFO_TIP "Felugró leírások megjelenítése a mappákhoz és az asztalon lévő elemekhez"
     IDS_ADVANCED_DISPLAY_FAVORITES "Display Favorites"
     IDS_ADVANCED_DISPLAY_LOG_OFF "Display Log Off"
+    IDS_ADVANCED_EXPAND_MY_DOCUMENTS "Expand My Documents"
+    IDS_ADVANCED_EXPAND_MY_PICTURES "Expand My Pictures"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
 

--- a/dll/win32/shell32/lang/id-ID.rc
+++ b/dll/win32/shell32/lang/id-ID.rc
@@ -1011,6 +1011,8 @@ BEGIN
     IDS_ADVANCED_SHOW_INFO_TIP "Tampilkan deskrisi popup untuk butir folder dan desktop"
     IDS_ADVANCED_DISPLAY_FAVORITES "Display Favorites"
     IDS_ADVANCED_DISPLAY_LOG_OFF "Display Log Off"
+    IDS_ADVANCED_EXPAND_MY_DOCUMENTS "Expand My Documents"
+    IDS_ADVANCED_EXPAND_MY_PICTURES "Expand My Pictures"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
 

--- a/dll/win32/shell32/lang/it-IT.rc
+++ b/dll/win32/shell32/lang/it-IT.rc
@@ -1014,6 +1014,8 @@ BEGIN
     IDS_ADVANCED_SHOW_INFO_TIP "Show pop-up description for folder and desktop items"
     IDS_ADVANCED_DISPLAY_FAVORITES "Display Favorites"
     IDS_ADVANCED_DISPLAY_LOG_OFF "Display Log Off"
+    IDS_ADVANCED_EXPAND_MY_DOCUMENTS "Expand My Documents"
+    IDS_ADVANCED_EXPAND_MY_PICTURES "Expand My Pictures"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
 

--- a/dll/win32/shell32/lang/ja-JP.rc
+++ b/dll/win32/shell32/lang/ja-JP.rc
@@ -1011,8 +1011,8 @@ BEGIN
     IDS_ADVANCED_SHOW_INFO_TIP "フォルダとデスクトップの項目にポップアップ式の説明を表示する"
     IDS_ADVANCED_DISPLAY_FAVORITES "「お気に入り」を表示"
     IDS_ADVANCED_DISPLAY_LOG_OFF "「ログオフ」を表示"
-    IDS_ADVANCED_EXPAND_MY_DOCUMENTS "Expand My Documents"
-    IDS_ADVANCED_EXPAND_MY_PICTURES "Expand My Pictures"
+    IDS_ADVANCED_EXPAND_MY_DOCUMENTS "「マイ ドキュメント」を展開"
+    IDS_ADVANCED_EXPAND_MY_PICTURES "「マイ ピクチャ」を展開"
     IDS_ADVANCED_DISPLAY_RUN "「ファイル名を指定して実行」を表示"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "「管理者ツール」を表示"
 

--- a/dll/win32/shell32/lang/ja-JP.rc
+++ b/dll/win32/shell32/lang/ja-JP.rc
@@ -1011,6 +1011,8 @@ BEGIN
     IDS_ADVANCED_SHOW_INFO_TIP "フォルダとデスクトップの項目にポップアップ式の説明を表示する"
     IDS_ADVANCED_DISPLAY_FAVORITES "「お気に入り」を表示"
     IDS_ADVANCED_DISPLAY_LOG_OFF "「ログオフ」を表示"
+    IDS_ADVANCED_EXPAND_MY_DOCUMENTS "Expand My Documents"
+    IDS_ADVANCED_EXPAND_MY_PICTURES "Expand My Pictures"
     IDS_ADVANCED_DISPLAY_RUN "「ファイル名を指定して実行」を表示"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "「管理者ツール」を表示"
 

--- a/dll/win32/shell32/lang/ko-KR.rc
+++ b/dll/win32/shell32/lang/ko-KR.rc
@@ -1021,6 +1021,8 @@ BEGIN
     IDS_ADVANCED_SHOW_INFO_TIP "Show pop-up description for folder and desktop items"
     IDS_ADVANCED_DISPLAY_FAVORITES "Display Favorites"
     IDS_ADVANCED_DISPLAY_LOG_OFF "Display Log Off"
+    IDS_ADVANCED_EXPAND_MY_DOCUMENTS "Expand My Documents"
+    IDS_ADVANCED_EXPAND_MY_PICTURES "Expand My Pictures"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
 

--- a/dll/win32/shell32/lang/nl-NL.rc
+++ b/dll/win32/shell32/lang/nl-NL.rc
@@ -1014,6 +1014,8 @@ BEGIN
     IDS_ADVANCED_SHOW_INFO_TIP "Show pop-up description for folder and desktop items"
     IDS_ADVANCED_DISPLAY_FAVORITES "Display Favorites"
     IDS_ADVANCED_DISPLAY_LOG_OFF "Display Log Off"
+    IDS_ADVANCED_EXPAND_MY_DOCUMENTS "Expand My Documents"
+    IDS_ADVANCED_EXPAND_MY_PICTURES "Expand My Pictures"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
 

--- a/dll/win32/shell32/lang/no-NO.rc
+++ b/dll/win32/shell32/lang/no-NO.rc
@@ -1014,6 +1014,8 @@ BEGIN
     IDS_ADVANCED_SHOW_INFO_TIP "Show pop-up description for folder and desktop items"
     IDS_ADVANCED_DISPLAY_FAVORITES "Display Favorites"
     IDS_ADVANCED_DISPLAY_LOG_OFF "Display Log Off"
+    IDS_ADVANCED_EXPAND_MY_DOCUMENTS "Expand My Documents"
+    IDS_ADVANCED_EXPAND_MY_PICTURES "Expand My Pictures"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
 

--- a/dll/win32/shell32/lang/pl-PL.rc
+++ b/dll/win32/shell32/lang/pl-PL.rc
@@ -1023,6 +1023,8 @@ BEGIN
     IDS_ADVANCED_SHOW_INFO_TIP "Pokaż podręczny opis elementów folderów i pulpitu"
     IDS_ADVANCED_DISPLAY_FAVORITES "Wyświetl polecenie Ulubione"
     IDS_ADVANCED_DISPLAY_LOG_OFF "Wyświetl polecenie Wyloguj"
+    IDS_ADVANCED_EXPAND_MY_DOCUMENTS "Expand My Documents"
+    IDS_ADVANCED_EXPAND_MY_PICTURES "Expand My Pictures"
     IDS_ADVANCED_DISPLAY_RUN "Wyświetl polecenie Uruchom"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Wyświetl polecenie Narzędzia administracyjne"
 

--- a/dll/win32/shell32/lang/pt-BR.rc
+++ b/dll/win32/shell32/lang/pt-BR.rc
@@ -1014,6 +1014,8 @@ BEGIN
     IDS_ADVANCED_SHOW_INFO_TIP "Show pop-up description for folder and desktop items"
     IDS_ADVANCED_DISPLAY_FAVORITES "Display Favorites"
     IDS_ADVANCED_DISPLAY_LOG_OFF "Display Log Off"
+    IDS_ADVANCED_EXPAND_MY_DOCUMENTS "Expand My Documents"
+    IDS_ADVANCED_EXPAND_MY_PICTURES "Expand My Pictures"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
 

--- a/dll/win32/shell32/lang/pt-PT.rc
+++ b/dll/win32/shell32/lang/pt-PT.rc
@@ -1013,6 +1013,8 @@ BEGIN
     IDS_ADVANCED_SHOW_INFO_TIP "Mostrar descrição pop-up para itens de pastas e área de trabalho"
     IDS_ADVANCED_DISPLAY_FAVORITES "Display Favorites"
     IDS_ADVANCED_DISPLAY_LOG_OFF "Display Log Off"
+    IDS_ADVANCED_EXPAND_MY_DOCUMENTS "Expand My Documents"
+    IDS_ADVANCED_EXPAND_MY_PICTURES "Expand My Pictures"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
 

--- a/dll/win32/shell32/lang/ro-RO.rc
+++ b/dll/win32/shell32/lang/ro-RO.rc
@@ -1022,6 +1022,8 @@ BEGIN
     IDS_ADVANCED_SHOW_INFO_TIP "Permite descriere prin indicii pentru foldere și elemente de desktop"
     IDS_ADVANCED_DISPLAY_FAVORITES "Display Favorites"
     IDS_ADVANCED_DISPLAY_LOG_OFF "Display Log Off"
+    IDS_ADVANCED_EXPAND_MY_DOCUMENTS "Expand My Documents"
+    IDS_ADVANCED_EXPAND_MY_PICTURES "Expand My Pictures"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
 

--- a/dll/win32/shell32/lang/ru-RU.rc
+++ b/dll/win32/shell32/lang/ru-RU.rc
@@ -1023,6 +1023,8 @@ BEGIN
     IDS_ADVANCED_SHOW_INFO_TIP "Отображать описание для папок и элементов рабочего стола"
     IDS_ADVANCED_DISPLAY_FAVORITES "Отображать папку ""Избранное"""
     IDS_ADVANCED_DISPLAY_LOG_OFF "Отображать команду ""Завершение сеанса"""
+    IDS_ADVANCED_EXPAND_MY_DOCUMENTS "Expand My Documents"
+    IDS_ADVANCED_EXPAND_MY_PICTURES "Expand My Pictures"
     IDS_ADVANCED_DISPLAY_RUN "Отображать команду ""Выполнить"""
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Отображать меню ""Администрирование"""
 

--- a/dll/win32/shell32/lang/sk-SK.rc
+++ b/dll/win32/shell32/lang/sk-SK.rc
@@ -1014,6 +1014,8 @@ BEGIN
     IDS_ADVANCED_SHOW_INFO_TIP "Show pop-up description for folder and desktop items"
     IDS_ADVANCED_DISPLAY_FAVORITES "Display Favorites"
     IDS_ADVANCED_DISPLAY_LOG_OFF "Display Log Off"
+    IDS_ADVANCED_EXPAND_MY_DOCUMENTS "Expand My Documents"
+    IDS_ADVANCED_EXPAND_MY_PICTURES "Expand My Pictures"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
 

--- a/dll/win32/shell32/lang/sl-SI.rc
+++ b/dll/win32/shell32/lang/sl-SI.rc
@@ -1014,6 +1014,8 @@ BEGIN
     IDS_ADVANCED_SHOW_INFO_TIP "Show pop-up description for folder and desktop items"
     IDS_ADVANCED_DISPLAY_FAVORITES "Display Favorites"
     IDS_ADVANCED_DISPLAY_LOG_OFF "Display Log Off"
+    IDS_ADVANCED_EXPAND_MY_DOCUMENTS "Expand My Documents"
+    IDS_ADVANCED_EXPAND_MY_PICTURES "Expand My Pictures"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
 

--- a/dll/win32/shell32/lang/sq-AL.rc
+++ b/dll/win32/shell32/lang/sq-AL.rc
@@ -1021,6 +1021,8 @@ BEGIN
     IDS_ADVANCED_SHOW_INFO_TIP "Show pop-up description for folder and desktop items"
     IDS_ADVANCED_DISPLAY_FAVORITES "Display Favorites"
     IDS_ADVANCED_DISPLAY_LOG_OFF "Display Log Off"
+    IDS_ADVANCED_EXPAND_MY_DOCUMENTS "Expand My Documents"
+    IDS_ADVANCED_EXPAND_MY_PICTURES "Expand My Pictures"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
 

--- a/dll/win32/shell32/lang/sv-SE.rc
+++ b/dll/win32/shell32/lang/sv-SE.rc
@@ -1014,6 +1014,8 @@ BEGIN
     IDS_ADVANCED_SHOW_INFO_TIP "Show pop-up description for folder and desktop items"
     IDS_ADVANCED_DISPLAY_FAVORITES "Display Favorites"
     IDS_ADVANCED_DISPLAY_LOG_OFF "Display Log Off"
+    IDS_ADVANCED_EXPAND_MY_DOCUMENTS "Expand My Documents"
+    IDS_ADVANCED_EXPAND_MY_PICTURES "Expand My Pictures"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
 

--- a/dll/win32/shell32/lang/tr-TR.rc
+++ b/dll/win32/shell32/lang/tr-TR.rc
@@ -1023,6 +1023,8 @@ BEGIN
     IDS_ADVANCED_SHOW_INFO_TIP "Dizin ve masaüstü ögeleri için açılan tanım göster"
     IDS_ADVANCED_DISPLAY_FAVORITES "Display Favorites"
     IDS_ADVANCED_DISPLAY_LOG_OFF "Display Log Off"
+    IDS_ADVANCED_EXPAND_MY_DOCUMENTS "Expand My Documents"
+    IDS_ADVANCED_EXPAND_MY_PICTURES "Expand My Pictures"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
 

--- a/dll/win32/shell32/lang/uk-UA.rc
+++ b/dll/win32/shell32/lang/uk-UA.rc
@@ -1014,6 +1014,8 @@ BEGIN
     IDS_ADVANCED_SHOW_INFO_TIP "Показувати спливаючий опис для елементів папки та робочого столу"
     IDS_ADVANCED_DISPLAY_FAVORITES "Display Favorites"
     IDS_ADVANCED_DISPLAY_LOG_OFF "Display Log Off"
+    IDS_ADVANCED_EXPAND_MY_DOCUMENTS "Expand My Documents"
+    IDS_ADVANCED_EXPAND_MY_PICTURES "Expand My Pictures"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
 

--- a/dll/win32/shell32/lang/zh-CN.rc
+++ b/dll/win32/shell32/lang/zh-CN.rc
@@ -1024,6 +1024,8 @@ BEGIN
     IDS_ADVANCED_SHOW_INFO_TIP "显示文件夹和桌面项目的弹出描述"
     IDS_ADVANCED_DISPLAY_FAVORITES "Display Favorites"
     IDS_ADVANCED_DISPLAY_LOG_OFF "Display Log Off"
+    IDS_ADVANCED_EXPAND_MY_DOCUMENTS "Expand My Documents"
+    IDS_ADVANCED_EXPAND_MY_PICTURES "Expand My Pictures"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
 

--- a/dll/win32/shell32/lang/zh-HK.rc
+++ b/dll/win32/shell32/lang/zh-HK.rc
@@ -1022,6 +1022,8 @@ BEGIN
     IDS_ADVANCED_SHOW_INFO_TIP "顯示資料夾和桌面項目的快顯描述"
     IDS_ADVANCED_DISPLAY_FAVORITES "Display Favorites"
     IDS_ADVANCED_DISPLAY_LOG_OFF "Display Log Off"
+    IDS_ADVANCED_EXPAND_MY_DOCUMENTS "Expand My Documents"
+    IDS_ADVANCED_EXPAND_MY_PICTURES "Expand My Pictures"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
 

--- a/dll/win32/shell32/lang/zh-TW.rc
+++ b/dll/win32/shell32/lang/zh-TW.rc
@@ -1023,6 +1023,8 @@ BEGIN
     IDS_ADVANCED_SHOW_INFO_TIP "顯示資料夾和桌面項目的快顯描述"
     IDS_ADVANCED_DISPLAY_FAVORITES "Display Favorites"
     IDS_ADVANCED_DISPLAY_LOG_OFF "Display Log Off"
+    IDS_ADVANCED_EXPAND_MY_DOCUMENTS "Expand My Documents"
+    IDS_ADVANCED_EXPAND_MY_PICTURES "Expand My Pictures"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
 

--- a/dll/win32/shell32/shellmenu/CStartMenu.cpp
+++ b/dll/win32/shell32/shellmenu/CStartMenu.cpp
@@ -179,8 +179,17 @@ private:
         }
     }
 
-    HMENU CreateRecentMenu(BOOL bExpandMyDocuments, BOOL bExpandMyPictures) const
+    BOOL GetAdvancedValue(LPCWSTR pszName, BOOL bDefault) const
     {
+        return SHRegGetBoolUSValueW(
+            L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Advanced",
+            pszName, FALSE, bDefault);
+    }
+
+    HMENU CreateRecentMenu() const
+    {
+        BOOL bExpandMyDocuments = GetAdvancedValue(L"CascadeMyDocuments", FALSE);
+        BOOL bExpandMyPictures = GetAdvancedValue(L"CascadeMyPictures", FALSE);
         HMENU hMenu = ::CreateMenu();
         InsertRecentItem(hMenu, IDM_MYDOCUMENTS, CSIDL_MYDOCUMENTS, bExpandMyDocuments);
         InsertRecentItem(hMenu, IDM_MYPICTURES, CSIDL_MYPICTURES, bExpandMyPictures);
@@ -224,9 +233,7 @@ private:
             {
                 if (csidl == CSIDL_RECENT)
                 {
-                    BOOL bExpandMyDocuments = FALSE; /* FIXME: Get value from registry */
-                    BOOL bExpandMyPictures = FALSE;  /* FIXME: Get value from registry */
-                    HMENU hMenu = CreateRecentMenu(bExpandMyDocuments, bExpandMyPictures);
+                    HMENU hMenu = CreateRecentMenu();
                     if (hMenu == NULL)
                         ERR("CreateRecentMenu failed\n");
 

--- a/dll/win32/shell32/shresdef.h
+++ b/dll/win32/shell32/shresdef.h
@@ -309,6 +309,8 @@
 /* These values must be synchronized with explorer */
 #define IDS_ADVANCED_DISPLAY_FAVORITES              30466
 #define IDS_ADVANCED_DISPLAY_LOG_OFF                30467
+#define IDS_ADVANCED_EXPAND_MY_DOCUMENTS            30469
+#define IDS_ADVANCED_EXPAND_MY_PICTURES             30472
 #define IDS_ADVANCED_DISPLAY_RUN                    30474
 #define IDS_ADVANCED_DISPLAY_ADMINTOOLS             30476
 


### PR DESCRIPTION
## Purpose

Follow-up to #6592. Improve Start Menu customization.
JIRA issue: [CORE-16956](https://jira.reactos.org/browse/CORE-16956)

## Proposed changes

- Add `IDS_ADVANCED_EXPAND_MY_DOCUMENTS` and `IDS_ADVANCED_EXPAND_MY_PICTURES` resource strings.
- Check `L"CascadeMyDocuments"` and `L"CascadeMyPictures"` registry values.
- Add `GetAdvancedValue` helper function.
- Implement `CreateRecentMenu` function.

## TODO

- [x] Do tests.

## Screenshots

![after1](https://github.com/reactos/reactos/assets/2107452/189132f6-d2fe-43f4-9041-572123bc125b)
![after2](https://github.com/reactos/reactos/assets/2107452/03bf7ceb-07d5-4766-a95d-9857b4b31ede)
![after3](https://github.com/reactos/reactos/assets/2107452/0430ec04-2d5c-4265-ae25-887fcad10550)