### PR TITLE
[EXPLORER][SHELL32] Fix and improve Start Menu customization

### DIFF
--- a/base/shell/explorer/precomp.h
+++ b/base/shell/explorer/precomp.h
@@ -110,7 +110,6 @@ BOOL GetRegValue(IN LPCWSTR pszSubKey, IN LPCWSTR pszValueName, IN BOOL bDefault
 BOOL SetRegDword(IN LPCWSTR pszSubKey, IN LPCWSTR pszValueName, IN DWORD dwValue);
 BOOL GetAdvancedBool(IN LPCWSTR pszValueName, IN BOOL bDefaultValue);
 BOOL SetAdvancedDword(IN LPCWSTR pszValueName, IN DWORD dwValue);
-BOOL SetRestriction(IN LPCWSTR pszKey, IN LPCWSTR pszValueName, IN DWORD dwValue);
 
 /*
  *  rshell.c

--- a/base/shell/explorer/startmnucust.cpp
+++ b/base/shell/explorer/startmnucust.cpp
@@ -21,6 +21,7 @@
 
 #include "precomp.h"
 
+#define I_UNCHECKED 1
 #define I_CHECKED   2
 
 // TODO: Windows Explorer appears to be calling NewLinkHere / ConfigStartMenu directly for both items.
@@ -138,6 +139,8 @@ static VOID AddCustomizeItem(HWND hTreeView, const CUSTOMIZE_ENTRY *entry)
     Insert.item.stateMask = TVIS_STATEIMAGEMASK;
     if (GetAdvancedBool(entry->name, entry->dwDefaultValue))
         Insert.item.state = INDEXTOSTATEIMAGEMASK(I_CHECKED);
+    else
+        Insert.item.state = INDEXTOSTATEIMAGEMASK(I_UNCHECKED);
     TreeView_InsertItem(hTreeView, &Insert);
 }
 

--- a/base/shell/explorer/startmnucust.cpp
+++ b/base/shell/explorer/startmnucust.cpp
@@ -139,6 +139,7 @@ static VOID AddCustomizeItem(HWND hTreeView, const CUSTOMIZE_ENTRY *entry)
     Insert.item.stateMask = TVIS_STATEIMAGEMASK;
     BOOL bChecked = GetAdvancedBool(entry->name, entry->bDefaultValue);
     Insert.item.state = INDEXTOSTATEIMAGEMASK(bChecked ? I_CHECKED : I_UNCHECKED);
+    TRACE("%p: %d\n", entry->id, bChecked);
     TreeView_InsertItem(hTreeView, &Insert);
 }
 

--- a/base/shell/explorer/startmnucust.cpp
+++ b/base/shell/explorer/startmnucust.cpp
@@ -218,6 +218,7 @@ static BOOL CustomizeClassic_OnOK(HWND hwnd)
         {
             if (item.lParam == entry.id)
             {
+                TRACE("%p: %d\n", item.lParam, bChecked);
                 entry.fnWrite(&entry, bChecked);
                 break;
             }

--- a/base/shell/explorer/startmnucust.cpp
+++ b/base/shell/explorer/startmnucust.cpp
@@ -137,10 +137,8 @@ static VOID AddCustomizeItem(HWND hTreeView, const CUSTOMIZE_ENTRY *entry)
     Insert.item.pszText = szText;
     Insert.item.lParam = entry->id;
     Insert.item.stateMask = TVIS_STATEIMAGEMASK;
-    if (GetAdvancedBool(entry->name, entry->dwDefaultValue))
-        Insert.item.state = INDEXTOSTATEIMAGEMASK(I_CHECKED);
-    else
-        Insert.item.state = INDEXTOSTATEIMAGEMASK(I_UNCHECKED);
+    BOOL bChecked = GetAdvancedBool(entry->name, entry->dwDefaultValue);
+    Insert.item.state = INDEXTOSTATEIMAGEMASK(bChecked ? I_CHECKED : I_UNCHECKED);
     TreeView_InsertItem(hTreeView, &Insert);
 }
 

--- a/base/shell/explorer/startmnucust.cpp
+++ b/base/shell/explorer/startmnucust.cpp
@@ -127,7 +127,10 @@ static const CUSTOMIZE_ENTRY s_CustomizeEntries[] =
 static VOID AddCustomizeItem(HWND hTreeView, const CUSTOMIZE_ENTRY *entry)
 {
     if (SHRestricted(entry->policy1) || SHRestricted(entry->policy2))
+    {
+        TRACE("%p: Restricted\n", entry->id);
         return; // Restricted. Don't show
+    }
 
     TV_INSERTSTRUCT Insert = { TVI_ROOT, TVI_LAST };
     Insert.item.mask = TVIF_TEXT | TVIF_STATE | TVIF_PARAM;

--- a/base/shell/explorer/startmnucust.cpp
+++ b/base/shell/explorer/startmnucust.cpp
@@ -83,8 +83,8 @@ struct CUSTOMIZE_ENTRY
 {
     LPARAM id;
     LPCWSTR name;
-    DWORD dwDefaultValue;
-    RESTRICTIONS Policy1, Policy2;
+    BOOL bDefaultValue;
+    RESTRICTIONS policy1, policy2;
 };
 
 static const CUSTOMIZE_ENTRY s_CustomizeEntries[] =
@@ -126,7 +126,7 @@ static const CUSTOMIZE_ENTRY s_CustomizeEntries[] =
 
 static VOID AddCustomizeItem(HWND hTreeView, const CUSTOMIZE_ENTRY *entry)
 {
-    if (SHRestricted(entry->Policy1) || SHRestricted(entry->Policy2))
+    if (SHRestricted(entry->policy1) || SHRestricted(entry->policy2))
         return; // Restricted. Don't show
 
     TV_INSERTSTRUCT Insert = { TVI_ROOT, TVI_LAST };
@@ -137,7 +137,7 @@ static VOID AddCustomizeItem(HWND hTreeView, const CUSTOMIZE_ENTRY *entry)
     Insert.item.pszText = szText;
     Insert.item.lParam = entry->id;
     Insert.item.stateMask = TVIS_STATEIMAGEMASK;
-    BOOL bChecked = GetAdvancedBool(entry->name, entry->dwDefaultValue);
+    BOOL bChecked = GetAdvancedBool(entry->name, entry->bDefaultValue);
     Insert.item.state = INDEXTOSTATEIMAGEMASK(bChecked ? I_CHECKED : I_UNCHECKED);
     TreeView_InsertItem(hTreeView, &Insert);
 }
@@ -173,7 +173,7 @@ static BOOL CustomizeClassic_OnOK(HWND hwnd)
         BOOL bChecked = !!(item.state & INDEXTOSTATEIMAGEMASK(I_CHECKED));
         for (auto& entry : s_CustomizeEntries)
         {
-            if (SHRestricted(entry.Policy1) || SHRestricted(entry.Policy2))
+            if (SHRestricted(entry.policy1) || SHRestricted(entry.policy2))
                 continue;
 
             if (item.lParam == entry.id)

--- a/base/shell/explorer/startmnucust.cpp
+++ b/base/shell/explorer/startmnucust.cpp
@@ -169,7 +169,7 @@ static BOOL CustomizeClassic_OnOK(HWND hwnd)
         item.stateMask = TVIS_STATEIMAGEMASK;
         TreeView_GetItem(hTreeView, &item);
 
-        BOOL bChecked = (item.state & INDEXTOSTATEIMAGEMASK(I_CHECKED));
+        BOOL bChecked = !!(item.state & INDEXTOSTATEIMAGEMASK(I_CHECKED));
         for (auto& entry : s_CustomizeEntries)
         {
             if (SHRestricted(entry.Policy1) || SHRestricted(entry.Policy2))

--- a/base/shell/explorer/startmnusite.cpp
+++ b/base/shell/explorer/startmnusite.cpp
@@ -203,7 +203,7 @@ public:
 
         /* Run */
         if (SHRestricted(REST_NORUN) ||
-            !GetAdvancedBool(L"Start_ShowRun", TRUE))
+            !GetAdvancedBool(L"StartMenuRun", TRUE))
         {
             DeleteMenu(hMenu, IDM_RUN, MF_BYCOMMAND);
         }

--- a/base/shell/explorer/startmnusite.cpp
+++ b/base/shell/explorer/startmnusite.cpp
@@ -146,46 +146,45 @@ public:
 
         /* Settings */
         hSettingsMenu = FindSubMenu(hMenu, IDM_SETTINGS, FALSE);
-        if (hSettingsMenu)
+
+        /* Control Panel */
+        if (SHRestricted(REST_NOSETFOLDERS) ||
+            SHRestricted(REST_NOCONTROLPANEL) ||
+            !GetAdvancedBool(L"Start_ShowControlPanel", TRUE))
         {
-            /* Control Panel */
-            if (SHRestricted(REST_NOSETFOLDERS) ||
-                SHRestricted(REST_NOCONTROLPANEL) ||
-                !GetAdvancedBool(L"Start_ShowControlPanel", TRUE))
-            {
-                DeleteMenu(hSettingsMenu, IDM_CONTROLPANEL, MF_BYCOMMAND);
+            DeleteMenu(hSettingsMenu, IDM_CONTROLPANEL, MF_BYCOMMAND);
 
-                /* Delete the separator below it */
-                DeleteMenu(hSettingsMenu, 0, MF_BYPOSITION);
-            }
+            /* Delete the separator below it */
+            DeleteMenu(hSettingsMenu, 0, MF_BYPOSITION);
+        }
 
-            /* Network Connections */
-            if (SHRestricted(REST_NOSETFOLDERS) ||
-                SHRestricted(REST_NONETWORKCONNECTIONS) ||
-                !GetAdvancedBool(L"Start_ShowNetConn", TRUE))
-            {
-                DeleteMenu(hSettingsMenu, IDM_NETWORKCONNECTIONS, MF_BYCOMMAND);
-            }
+        /* Network Connections */
+        if (SHRestricted(REST_NOSETFOLDERS) ||
+            SHRestricted(REST_NONETWORKCONNECTIONS) ||
+            !GetAdvancedBool(L"Start_ShowNetConn", TRUE))
+        {
+            DeleteMenu(hSettingsMenu, IDM_NETWORKCONNECTIONS, MF_BYCOMMAND);
+        }
 
-            /* Printers and Faxes */
-            if (SHRestricted(REST_NOSETFOLDERS) ||
-                !GetAdvancedBool(L"Start_ShowPrinters", TRUE))
-            {
-                DeleteMenu(hSettingsMenu, IDM_PRINTERSANDFAXES, MF_BYCOMMAND);
-            }
+        /* Printers and Faxes */
+        if (SHRestricted(REST_NOSETFOLDERS) ||
+            !GetAdvancedBool(L"Start_ShowPrinters", TRUE))
+        {
+            DeleteMenu(hSettingsMenu, IDM_PRINTERSANDFAXES, MF_BYCOMMAND);
+        }
 
-            /* Security */
-            if (SHRestricted(REST_NOSETFOLDERS) ||
-                GetSystemMetrics(SM_REMOTECONTROL) == 0 ||
-                SHRestricted(REST_NOSECURITY))
-            {
-                DeleteMenu(hSettingsMenu, IDM_SECURITY, MF_BYCOMMAND);
-            }
+        /* Security */
+        if (SHRestricted(REST_NOSETFOLDERS) ||
+            GetSystemMetrics(SM_REMOTECONTROL) == 0 ||
+            SHRestricted(REST_NOSECURITY))
+        {
+            DeleteMenu(hSettingsMenu, IDM_SECURITY, MF_BYCOMMAND);
+        }
 
-            if (GetMenuItemCount(hSettingsMenu) == 0)
-            {
-                DeleteMenu(hMenu, IDM_SETTINGS, MF_BYCOMMAND);
-            }
+        /* Delete Settings menu if it was empty */
+        if (GetMenuItemCount(hSettingsMenu) == 0)
+        {
+            DeleteMenu(hMenu, IDM_SETTINGS, MF_BYCOMMAND);
         }
 
         /* Search */
@@ -199,7 +198,7 @@ public:
         if (SHRestricted(REST_NOSMHELP) ||
             !GetAdvancedBool(L"Start_ShowHelp", TRUE))
         {
-            /* FIXME */
+            DeleteMenu(hMenu, IDM_HELPANDSUPPORT, MF_BYCOMMAND);
         }
 
         /* Run */

--- a/base/shell/explorer/util.cpp
+++ b/base/shell/explorer/util.cpp
@@ -163,15 +163,6 @@ BOOL SetAdvancedDword(IN LPCWSTR pszValueName, IN DWORD dwValue)
     return SetRegDword(REGKEY_ADVANCED, pszValueName, dwValue);
 }
 
-BOOL SetRestriction(IN LPCWSTR pszKey, IN LPCWSTR pszValueName, IN DWORD dwValue)
-{
-    WCHAR szSubKey[MAX_PATH] = L"Software\\Microsoft\\Windows\\CurrentVersion\\Policies";
-    PathAppendW(szSubKey, pszKey);
-    SHSetValueW(HKEY_CURRENT_USER, szSubKey, pszValueName, REG_DWORD, &dwValue, sizeof(dwValue));
-    SHSettingsChanged(NULL, NULL);
-    return TRUE;
-}
-
 BOOL
 GetVersionInfoString(IN LPCWSTR szFileName,
                      IN LPCWSTR szVersionInfo,

--- a/dll/win32/shell32/shellmenu/CStartMenu.cpp
+++ b/dll/win32/shell32/shellmenu/CStartMenu.cpp
@@ -239,7 +239,7 @@ private:
 
     HRESULT AddStartMenuItems(IShellMenu *pShellMenu, INT csidl, DWORD dwFlags)
     {
-        LPITEMIDLIST pidlMenu;
+        CComHeapPtr<ITEMIDLIST> pidlMenu;
         CComPtr<IShellFolder> psfDesktop;
         CComPtr<IShellFolder> pShellFolder;
         HRESULT hr;

--- a/dll/win32/shell32/shellmenu/CStartMenu.cpp
+++ b/dll/win32/shell32/shellmenu/CStartMenu.cpp
@@ -196,12 +196,30 @@ private:
 
     HMENU CreateRecentMenu() const
     {
-        BOOL bExpandMyDocuments = GetAdvancedValue(L"CascadeMyDocuments", FALSE);
-        BOOL bExpandMyPictures = GetAdvancedValue(L"CascadeMyPictures", FALSE);
         HMENU hMenu = ::CreateMenu();
-        AddOrSetMenuItem(hMenu, IDM_MYDOCUMENTS, CSIDL_MYDOCUMENTS, bExpandMyDocuments);
-        AddOrSetMenuItem(hMenu, IDM_MYPICTURES, CSIDL_MYPICTURES, bExpandMyPictures);
-        AppendMenuW(hMenu, MF_SEPARATOR, 0, NULL);
+        BOOL bAdded = FALSE;
+
+        // My Documents
+        if (!SHRestricted(REST_NOSMMYDOCS) &&
+            GetAdvancedValue(L"Start_ShowMyDocs", TRUE))
+        {
+            BOOL bExpand = GetAdvancedValue(L"CascadeMyDocuments", FALSE);
+            AddOrSetMenuItem(hMenu, IDM_MYDOCUMENTS, CSIDL_MYDOCUMENTS, bExpand);
+            bAdded = TRUE;
+        }
+
+        // My Pictures
+        if (!SHRestricted(REST_NOSMMYPICS) &&
+            GetAdvancedValue(L"Start_ShowMyPics", TRUE))
+        {
+            BOOL bExpand = GetAdvancedValue(L"CascadeMyPictures", FALSE);
+            AddOrSetMenuItem(hMenu, IDM_MYPICTURES, CSIDL_MYPICTURES, bExpand);
+            bAdded = TRUE;
+        }
+
+        if (bAdded)
+            AppendMenuW(hMenu, MF_SEPARATOR, 0, NULL);
+
         return hMenu;
     }
 


### PR DESCRIPTION
## Purpose
Correct the details of Start Menu customization.
JIRA issue: [CORE-16956](https://jira.reactos.org/browse/CORE-16956)

## Proposed changes

- Hide the setting item if the item is restricted.
- Don't change restriction in Explorer.
- Fix Start Menu settings for restriction and registry.
- Fix and simplify code.

## TODO

- [x] Do tests.

## Screenshots

![after1](https://github.com/reactos/reactos/assets/2107452/89d7df63-7c5c-40b3-8ee4-f8333a7ea9ec)
![after2](https://github.com/reactos/reactos/assets/2107452/e274757e-18bd-48a8-bb84-45aaa702bdd8)
![after3](https://github.com/reactos/reactos/assets/2107452/e8d08ef0-fd42-4549-b2de-76289fbb4a47)
