### PR TITLE
[EXPLORER][SHELL32] Show/hide 'Admin tools' menu

### DIFF
--- a/base/shell/explorer/startmnucust.cpp
+++ b/base/shell/explorer/startmnucust.cpp
@@ -89,7 +89,9 @@ struct CUSTOMIZE_ENTRY
 
 static const CUSTOMIZE_ENTRY s_CustomizeEntries[] =
 {
-    // FIXME: Make "StartMenuAdminTools" effective for IDS_ADVANCED_DISPLAY_ADMINTOOLS
+    {
+        IDS_ADVANCED_DISPLAY_ADMINTOOLS, L"StartMenuAdminTools", TRUE,
+    },
     {
         IDS_ADVANCED_DISPLAY_FAVORITES, L"StartMenuFavorites", FALSE,
         REST_NOFAVORITESMENU

--- a/dll/win32/shell32/shellmenu/CMenuToolbars.cpp
+++ b/dll/win32/shell32/shellmenu/CMenuToolbars.cpp
@@ -1323,6 +1323,18 @@ int CALLBACK PidlListSort(void* item1, void* item2, LPARAM lParam)
     return (int)(short)LOWORD(hr);
 }
 
+static BOOL IsPidlPrograms(LPCITEMIDLIST pidlTarget)
+{
+    WCHAR szTarget[MAX_PATH], szPath[MAX_PATH];
+    if (!SHGetPathFromIDListW(pidlTarget, szTarget))
+        return FALSE;
+    SHGetSpecialFolderPathW(NULL, szPath, CSIDL_COMMON_PROGRAMS, FALSE);
+    if (lstrcmpiW(szTarget, szPath) == 0)
+        return TRUE;
+    SHGetSpecialFolderPathW(NULL, szPath, CSIDL_PROGRAMS, FALSE);
+    return (lstrcmpiW(szTarget, szPath) == 0);
+}
+
 HRESULT CMenuSFToolbar::FillToolbar(BOOL clearFirst)
 {
     HRESULT hr;
@@ -1361,17 +1373,26 @@ HRESULT CMenuSFToolbar::FillToolbar(BOOL clearFirst)
 
     DPA_Sort(dpaSort, PidlListSort, (LPARAM) m_shellFolder.p);
 
+    BOOL StartMenuAdminTools = SHRegGetBoolUSValueW(
+        L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Advanced",
+        L"StartMenuAdminTools", FALSE, TRUE);
+
+    BOOL bMustHideAdminTools = IsPidlPrograms(m_idList) && StartMenuAdminTools;
+    TRACE("StartMenuAdminTools : %d\n", StartMenuAdminTools );
+    TRACE("bMustHideAdminTools: %d\n", bMustHideAdminTools);
+
+    WCHAR szAdminTools[MAX_PATH];
+    if (bMustHideAdminTools)
+    {
+        LoadStringW(GetModuleHandleW(L"shell32.dll"), IDS_ADMINISTRATIVETOOLS,
+                    szAdminTools, _countof(szAdminTools));
+    }
+
     for (int i = 0; i<DPA_GetPtrCount(dpaSort);)
     {
-        PWSTR MenuString;
-
-        INT index = 0;
-        INT indexOpen = 0;
-
-        STRRET sr = { STRRET_CSTR, { 0 } };
-
         item = (LPITEMIDLIST)DPA_GetPtr(dpaSort, i);
 
+        STRRET sr = { STRRET_CSTR };
         hr = m_shellFolder->GetDisplayNameOf(item, SIGDN_NORMALDISPLAY, &sr);
         if (FAILED_UNEXPECTEDLY(hr))
         {
@@ -1379,9 +1400,18 @@ HRESULT CMenuSFToolbar::FillToolbar(BOOL clearFirst)
             return hr;
         }
 
+        PWSTR MenuString;
         StrRetToStr(&sr, NULL, &MenuString);
 
-        index = SHMapPIDLToSystemImageListIndex(m_shellFolder, item, &indexOpen);
+        if (bMustHideAdminTools && lstrcmpiW(MenuString, szAdminTools) == 0)
+        {
+            ++i;
+            CoTaskMemFree(MenuString);
+            continue;
+        }
+
+        INT indexOpen = 0;
+        INT index = SHMapPIDLToSystemImageListIndex(m_shellFolder, item, &indexOpen);
 
         LPCITEMIDLIST itemc = item;
 

--- a/dll/win32/shell32/shellmenu/CMenuToolbars.cpp
+++ b/dll/win32/shell32/shellmenu/CMenuToolbars.cpp
@@ -1378,7 +1378,7 @@ HRESULT CMenuSFToolbar::FillToolbar(BOOL clearFirst)
         L"StartMenuAdminTools", FALSE, TRUE);
 
     BOOL bMustHideAdminTools = IsPidlPrograms(m_idList) && StartMenuAdminTools;
-    TRACE("StartMenuAdminTools : %d\n", StartMenuAdminTools );
+    TRACE("StartMenuAdminTools: %d\n", StartMenuAdminTools );
     TRACE("bMustHideAdminTools: %d\n", bMustHideAdminTools);
 
     WCHAR szAdminTools[MAX_PATH];

--- a/dll/win32/shell32/shellmenu/CMenuToolbars.cpp
+++ b/dll/win32/shell32/shellmenu/CMenuToolbars.cpp
@@ -1378,7 +1378,7 @@ HRESULT CMenuSFToolbar::FillToolbar(BOOL clearFirst)
         L"StartMenuAdminTools", FALSE, TRUE);
 
     BOOL bMustHideAdminTools = IsPidlPrograms(m_idList) && StartMenuAdminTools;
-    TRACE("StartMenuAdminTools: %d\n", StartMenuAdminTools );
+    TRACE("StartMenuAdminTools: %d\n", StartMenuAdminTools);
     TRACE("bMustHideAdminTools: %d\n", bMustHideAdminTools);
 
     WCHAR szAdminTools[MAX_PATH];


### PR DESCRIPTION
## Purpose

Improve Start Menu customization.
JIRA issue: [CORE-16956](https://jira.reactos.org/browse/CORE-16956)

## Proposed changes

- Add `IsPidlPrograms` helper function.
- Specify a PIDL for Programs menu.
- Check the `"StartMenuAdminTools"` registry value.
- Don't add "Admin Tools" menu item into `CMenuSFToolbar::FillToolbar` if necessary.

## TODO

- [x] Do tests.

## Screenshots

![after1](https://github.com/reactos/reactos/assets/2107452/0269e405-6278-4957-bca0-9377b633c2fd)
![after2](https://github.com/reactos/reactos/assets/2107452/325bbd4c-cfef-4a32-b256-0b6ffa304090)
![after3](https://github.com/reactos/reactos/assets/2107452/2430b51c-b317-459d-8d73-a0518c7f8a4d)