### PR TITLE
[NOTEPAD] Update Slovenian (sl-SI) translation

### DIFF
--- a/base/applications/notepad/lang/sl-SI.rc
+++ b/base/applications/notepad/lang/sl-SI.rc
@@ -47,7 +47,7 @@ BEGIN
         MENUITEM "P&oišči ...", CMD_SEARCH
         MENUITEM "Na&daljuj iskanje\tF3", CMD_SEARCH_NEXT
         MENUITEM "Zamenjaj ...\tCtrl+H", CMD_REPLACE
-        MENUITEM "Pojdi na...\tCtrl+G", CMD_GOTO
+        MENUITEM "Pojdi na ...\tCtrl+G", CMD_GOTO
         MENUITEM SEPARATOR
         MENUITEM "Izberi &vse", CMD_SELECT_ALL
         MENUITEM "Dat&um/čas\tF5", CMD_TIME_DATE
@@ -135,7 +135,7 @@ CAPTION "Trenutno se tiska"
 STYLE DS_SHELLFONT | DS_MODALFRAME | WS_CAPTION | WS_SYSMENU
 FONT 8, "MS Shell Dlg"
 BEGIN
-    CTEXT "Tiskanje se začenja...", IDC_PRINTING_STATUS, 5, 10, 150, 15
+    CTEXT "Tiskanje se začenja ...", IDC_PRINTING_STATUS, 5, 10, 150, 15
     CTEXT "(Filename)", IDC_PRINTING_FILENAME, 5, 35, 150, 15
     CTEXT "Stran %u", IDC_PRINTING_PAGE, 5, 55, 150, 15
     PUSHBUTTON "Prekliči", IDCANCEL, 50, 75, 60, 20
@@ -176,8 +176,8 @@ operacijo.\nČe ga želite sprostiti, končajte enega ali več programov in posk
     STRING_PRINTERROR "Tiskanje strani '%s' ni mogoče.\n\nPrepričajte se, da je tiskalnik prižgan in pravilno nastavljen."
     STRING_DEFAULTFONT "Lucida Console"
     STRING_LINE_NUMBER_OUT_OF_RANGE "Dana številka vrstice je izven obsega."
-    STRING_NOWPRINTING "Tiskanje strani..."
-    STRING_PRINTCANCELING "Tiskanje se prekinja..." /* Slovene doesn't have a proper way to say print job so just say printing is stopping */
+    STRING_NOWPRINTING "Tiskanje strani ..."
+    STRING_PRINTCANCELING "Tiskanje se prekinja ..." /* Slovene doesn't have a proper way to say print job so just say printing is stopping */
     STRING_PRINTCOMPLETE "Tiskanje uspešno."
     STRING_PRINTCANCELED "Tiskanje prekinjeno."
     STRING_PRINTFAILED "Napaka pri tiskanju."

--- a/base/applications/notepad/lang/sl-SI.rc
+++ b/base/applications/notepad/lang/sl-SI.rc
@@ -25,15 +25,15 @@ BEGIN
     POPUP "&Datoteka"
     BEGIN
         MENUITEM "&Nova\tCtrl+N", CMD_NEW
-        MENUITEM "Novo O&kno\tCtrl+Shift+N", CMD_NEW_WINDOW
+        MENUITEM "Novo &okno\tCtrl+Shift+N", CMD_NEW_WINDOW
         MENUITEM "&Odpri\tCtrl+O", CMD_OPEN
         MENUITEM "&Shrani\tCtrl+S", CMD_SAVE
-        MENUITEM "Sh&rani kot ...", CMD_SAVE_AS
+        MENUITEM "Shr&ani kot ...", CMD_SAVE_AS
         MENUITEM SEPARATOR
-        MENUITEM "Pr&iprava strani ...", CMD_PAGE_SETUP
-        MENUITEM "Na&tisni...\tCtrl+P", CMD_PRINT
+        MENUITEM "P&riprava strani ...", CMD_PAGE_SETUP
+        MENUITEM "Na&tisni ...\tCtrl+P", CMD_PRINT
         MENUITEM SEPARATOR
-        MENUITEM "Iz&hod", CMD_EXIT
+        MENUITEM "I&zhod", CMD_EXIT
     END
     POPUP "&Urejanje"
     BEGIN
@@ -46,16 +46,16 @@ BEGIN
         MENUITEM SEPARATOR
         MENUITEM "P&oišči ...", CMD_SEARCH
         MENUITEM "Na&daljuj iskanje\tF3", CMD_SEARCH_NEXT
-        MENUITEM "Zamenjaj...\tCtrl+H", CMD_REPLACE
+        MENUITEM "Zamenjaj ...\tCtrl+H", CMD_REPLACE
         MENUITEM "Pojdi na...\tCtrl+G", CMD_GOTO
         MENUITEM SEPARATOR
         MENUITEM "Izberi &vse", CMD_SELECT_ALL
-        MENUITEM "Čas/Dat&um\tF5", CMD_TIME_DATE
+        MENUITEM "Dat&um/čas\tF5", CMD_TIME_DATE
     END
     POPUP "F&ormat"
     BEGIN
         MENUITEM "Pr&elom vrstice", CMD_WRAP
-        MENUITEM "&Pisava...", CMD_FONT
+        MENUITEM "&Pisava ...", CMD_FONT
     END
     POPUP "&Pogled"
     BEGIN
@@ -75,16 +75,16 @@ STYLE DS_SHELLFONT | DS_MODALFRAME | WS_CAPTION | WS_SYSMENU | DS_CONTEXTHELP
 FONT 8, "MS Shell Dlg"
 CAPTION "Priprava strani"
 BEGIN
-    GROUPBOX "Pregled", 0, 240, 6, 120, 153, BS_GROUPBOX
+    GROUPBOX "Predogled", 0, 240, 6, 120, 153, BS_GROUPBOX
     CONTROL "", rct1, "Static", SS_WHITERECT, 260, 42, 80, 80
     CONTROL "", rct2, "Static", SS_GRAYRECT, 340, 46, 4, 80
     CONTROL "", rct3, "Static", SS_GRAYRECT, 264, 122, 80, 4
     GROUPBOX "Papir", grp2, 8, 6, 224, 56, BS_GROUPBOX
-    LTEXT "&Velikost:", stc2, 16, 22, 36, 8
+    LTEXT "Veli&kost:", stc2, 16, 22, 36, 8
     COMBOBOX cmb2, 64, 20, 160, 160, CBS_SIMPLE | CBS_DROPDOWN | CBS_SORT | WS_GROUP | WS_TABSTOP | WS_VSCROLL
-    LTEXT "&Pladenj:", stc3, 16, 42, 36, 8
+    LTEXT "&Vir:", stc3, 16, 42, 36, 8
     COMBOBOX cmb3, 64, 40, 160, 160, CBS_SIMPLE | CBS_DROPDOWN | CBS_SORT | WS_GROUP | WS_TABSTOP | WS_VSCROLL
-    GROUPBOX "Orientacija", grp1, 8, 66, 64, 56, BS_GROUPBOX
+    GROUPBOX "Usmerjenost", grp1, 8, 66, 64, 56, BS_GROUPBOX
     AUTORADIOBUTTON "&Portret", rad1, 16, 80, 52, 12, BS_AUTORADIOBUTTON
     AUTORADIOBUTTON "&Ležeče", rad2, 16, 100, 52, 12, BS_AUTORADIOBUTTON
     GROUPBOX "Robovi", grp4, 80, 66, 152, 56, BS_GROUPBOX
@@ -163,7 +163,7 @@ Ali želite shraniti spremembe?"
     STRING_NOTFOUND "Datoteke '%s' ni mogoče najti."
     STRING_OUT_OF_MEMORY "Na voljo ni dovolj pomnilnika, da bi bilo mogoče dokončati to \
 operacijo.\nČe ga želite sprostiti, končajte enega ali več programov in poskusite znova."
-    STRING_CANNOTFIND "Ni rezultatov za %s"
+    STRING_CANNOTFIND "Ni rezultatov za '%s'"
     STRING_ANSI "ANSI"
     STRING_UNICODE "Unicode"
     STRING_UNICODE_BE "Unicode (big endian)"

--- a/base/applications/notepad/lang/sl-SI.rc
+++ b/base/applications/notepad/lang/sl-SI.rc
@@ -173,7 +173,7 @@ operacijo.\nČe ga želite sprostiti, končajte enega ali več programov in posk
     STRING_LF "Unix (LF)"
     STRING_CR "Mac (CR)"
     STRING_LINE_COLUMN "Vrstica %d, stolpec %d"
-    STRING_PRINTERROR "Tiskanje strani '%s' ni mogoče.\n\nPrepričajte se da je tiskalnik prižgan in pravilno nastavljen."
+    STRING_PRINTERROR "Tiskanje strani '%s' ni mogoče.\n\nPrepričajte se, da je tiskalnik prižgan in pravilno nastavljen."
     STRING_DEFAULTFONT "Lucida Console"
     STRING_LINE_NUMBER_OUT_OF_RANGE "Dana številka vrstice je izven obsega."
     STRING_NOWPRINTING "Tiskanje strani..."

--- a/base/applications/notepad/lang/sl-SI.rc
+++ b/base/applications/notepad/lang/sl-SI.rc
@@ -25,12 +25,12 @@ BEGIN
     POPUP "&Datoteka"
     BEGIN
         MENUITEM "&Nova\tCtrl+N", CMD_NEW
-        MENUITEM "New &Window\tCtrl+Shift+N", CMD_NEW_WINDOW
+        MENUITEM "Novo O&kno\tCtrl+Shift+N", CMD_NEW_WINDOW
         MENUITEM "&Odpri\tCtrl+O", CMD_OPEN
         MENUITEM "&Shrani\tCtrl+S", CMD_SAVE
-        MENUITEM "Shrani &kot ...", CMD_SAVE_AS
+        MENUITEM "Sh&rani kot ...", CMD_SAVE_AS
         MENUITEM SEPARATOR
-        MENUITEM "P&riprava strani ...", CMD_PAGE_SETUP
+        MENUITEM "Pr&iprava strani ...", CMD_PAGE_SETUP
         MENUITEM "Na&tisni...\tCtrl+P", CMD_PRINT
         MENUITEM SEPARATOR
         MENUITEM "Iz&hod", CMD_EXIT
@@ -44,28 +44,28 @@ BEGIN
         MENUITEM "&Prilepi\tCtrl+V", CMD_PASTE
         MENUITEM "Izbri&ši\tDel", CMD_DELETE
         MENUITEM SEPARATOR
-        MENUITEM "&Najdi ...", CMD_SEARCH
+        MENUITEM "P&oišči ...", CMD_SEARCH
         MENUITEM "Na&daljuj iskanje\tF3", CMD_SEARCH_NEXT
-        MENUITEM "Replace...\tCtrl+H", CMD_REPLACE
-        MENUITEM "Go To...\tCtrl+G", CMD_GOTO
+        MENUITEM "Zamenjaj...\tCtrl+H", CMD_REPLACE
+        MENUITEM "Pojdi na...\tCtrl+G", CMD_GOTO
         MENUITEM SEPARATOR
         MENUITEM "Izberi &vse", CMD_SELECT_ALL
-        MENUITEM "Èas/&Datum\tF5", CMD_TIME_DATE
+        MENUITEM "Čas/Dat&um\tF5", CMD_TIME_DATE
     END
     POPUP "F&ormat"
     BEGIN
         MENUITEM "Pr&elom vrstice", CMD_WRAP
-        MENUITEM "&Font...", CMD_FONT
+        MENUITEM "&Pisava...", CMD_FONT
     END
-    POPUP "&View"
+    POPUP "&Pogled"
     BEGIN
-        MENUITEM "Status&bar", CMD_STATUSBAR
+        MENUITEM "Vrstica& stanja", CMD_STATUSBAR
     END
-    POPUP "&Pomoè"
+    POPUP "&Pomoč"
     BEGIN
-        MENUITEM "&Teme pomoèi", CMD_HELP_CONTENTS
+        MENUITEM "&Teme pomoči", CMD_HELP_CONTENTS
         MENUITEM SEPARATOR
-        MENUITEM "&About Notepad", CMD_HELP_ABOUT_NOTEPAD
+        MENUITEM "&O Beležnici", CMD_HELP_ABOUT_NOTEPAD
     END
 END
 
@@ -73,72 +73,72 @@ END
 DIALOG_PAGESETUP DIALOGEX 0, 0, 365, 193
 STYLE DS_SHELLFONT | DS_MODALFRAME | WS_CAPTION | WS_SYSMENU | DS_CONTEXTHELP
 FONT 8, "MS Shell Dlg"
-CAPTION "Page Setup"
+CAPTION "Priprava strani"
 BEGIN
-    GROUPBOX "Preview", 0, 240, 6, 120, 153, BS_GROUPBOX
+    GROUPBOX "Pregled", 0, 240, 6, 120, 153, BS_GROUPBOX
     CONTROL "", rct1, "Static", SS_WHITERECT, 260, 42, 80, 80
     CONTROL "", rct2, "Static", SS_GRAYRECT, 340, 46, 4, 80
     CONTROL "", rct3, "Static", SS_GRAYRECT, 264, 122, 80, 4
-    GROUPBOX "Paper", grp2, 8, 6, 224, 56, BS_GROUPBOX
-    LTEXT "&Size:", stc2, 16, 22, 36, 8
+    GROUPBOX "Papir", grp2, 8, 6, 224, 56, BS_GROUPBOX
+    LTEXT "&Velikost:", stc2, 16, 22, 36, 8
     COMBOBOX cmb2, 64, 20, 160, 160, CBS_SIMPLE | CBS_DROPDOWN | CBS_SORT | WS_GROUP | WS_TABSTOP | WS_VSCROLL
-    LTEXT "&Tray:", stc3, 16, 42, 36, 8
+    LTEXT "&Pladenj:", stc3, 16, 42, 36, 8
     COMBOBOX cmb3, 64, 40, 160, 160, CBS_SIMPLE | CBS_DROPDOWN | CBS_SORT | WS_GROUP | WS_TABSTOP | WS_VSCROLL
-    GROUPBOX "Orientation", grp1, 8, 66, 64, 56, BS_GROUPBOX
-    AUTORADIOBUTTON "&Portrait", rad1, 16, 80, 52, 12, BS_AUTORADIOBUTTON
-    AUTORADIOBUTTON "&Landscape", rad2, 16, 100, 52, 12, BS_AUTORADIOBUTTON
-    GROUPBOX "Borders", grp4, 80, 66, 152, 56, BS_GROUPBOX
-    LTEXT "L&eft:", stc15, 88, 82, 30, 8
+    GROUPBOX "Orientacija", grp1, 8, 66, 64, 56, BS_GROUPBOX
+    AUTORADIOBUTTON "&Portret", rad1, 16, 80, 52, 12, BS_AUTORADIOBUTTON
+    AUTORADIOBUTTON "&Ležeče", rad2, 16, 100, 52, 12, BS_AUTORADIOBUTTON
+    GROUPBOX "Robovi", grp4, 80, 66, 152, 56, BS_GROUPBOX
+    LTEXT "L&evo:", stc15, 88, 82, 30, 8
     EDITTEXT edt4, 119, 80, 36, 12, WS_TABSTOP | WS_GROUP | WS_BORDER
-    LTEXT "&Right:", stc16, 159, 82, 30, 8
+    LTEXT "&Desno:", stc16, 159, 82, 30, 8
     EDITTEXT edt6, 190, 80, 36, 12, WS_TABSTOP | WS_GROUP | WS_BORDER
-    LTEXT "T&op:", stc17, 88, 102, 30, 8
+    LTEXT "Z&goraj:", stc17, 88, 102, 30, 8
     EDITTEXT edt5, 119, 100, 36, 12, WS_TABSTOP | WS_GROUP | WS_BORDER
-    LTEXT "&Bottom:", stc18, 159, 102, 30, 8
+    LTEXT "&Spodaj:", stc18, 159, 102, 30, 8
     EDITTEXT edt7, 190, 100, 36, 12, WS_TABSTOP | WS_GROUP | WS_BORDER
-    LTEXT "&Header:", 0x140, 8, 132, 40, 15
+    LTEXT "&Glava:", 0x140, 8, 132, 40, 15
     EDITTEXT 0x141, 58, 130, 173, 12, WS_BORDER | WS_TABSTOP | ES_AUTOHSCROLL
-    LTEXT "&Footer:", 0x142, 8, 149, 40, 15
+    LTEXT "&Noga:", 0x142, 8, 149, 40, 15
     EDITTEXT 0x143, 58, 147, 173, 12, WS_BORDER | WS_TABSTOP | ES_AUTOHSCROLL
-    PUSHBUTTON "Help", IDHELP, 8, 170, 50, 14
-    DEFPUSHBUTTON "OK", IDOK, 198, 170, 50, 14, BS_PUSHBUTTON
-    PUSHBUTTON "Cancel", IDCANCEL, 254, 170, 50, 14
-    PUSHBUTTON "P&rinter...", psh3, 310, 170, 50, 14
+    PUSHBUTTON "Pomoč", IDHELP, 8, 170, 50, 14
+    DEFPUSHBUTTON "Vredu", IDOK, 198, 170, 50, 14, BS_PUSHBUTTON
+    PUSHBUTTON "Prekliči", IDCANCEL, 254, 170, 50, 14
+    PUSHBUTTON "&Tiskalnik...", psh3, 310, 170, 50, 14
 END
 
 /* Dialog 'Encoding' */
 DIALOG_ENCODING DIALOGEX 0, 0, 256, 44
 STYLE DS_SHELLFONT | DS_CONTROL | WS_CHILD | WS_CLIPSIBLINGS | WS_CAPTION | WS_SYSMENU
 FONT 8, "MS Shell Dlg"
-CAPTION "Encoding"
+CAPTION "Kodiranje" /* Kodiranje??? this technically means coding but windows notepad has that*/
 BEGIN
     COMBOBOX ID_ENCODING, 124, 0, 125, 80, CBS_DROPDOWNLIST | CBS_SORT | WS_VSCROLL | WS_TABSTOP
-    LTEXT "Encoding:", 0x155, 65, 2, 41, 12
+    LTEXT "Kodiranje:", 0x155, 65, 2, 41, 12
     COMBOBOX ID_EOLN, 124, 18, 125, 80, CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
-    LTEXT "Endlines:", 0x156, 65, 20, 41, 12
+    LTEXT "Konec vrstic:", 0x156, 65, 20, 41, 12
 END
 
 /* Dialog 'Go To' */
 DIALOG_GOTO DIALOGEX 0, 0, 165, 50
 STYLE DS_SHELLFONT | DS_MODALFRAME | WS_CAPTION | WS_SYSMENU
 FONT 8, "MS Shell Dlg"
-CAPTION "Goto line"
+CAPTION "Pojdi na vrstico:"
 BEGIN
-    LTEXT "Line number:", 0x155, 5, 12, 41, 12
+    LTEXT "Št. vrstice:", 0x155, 5, 12, 41, 12
     EDITTEXT ID_LINENUMBER, 54, 10, 106, 12, ES_NUMBER
-    DEFPUSHBUTTON "OK", IDOK, 75, 30, 40, 15
-    PUSHBUTTON "Cancel", IDCANCEL, 120, 30, 40, 15
+    DEFPUSHBUTTON "Vredu", IDOK, 75, 30, 40, 15
+    PUSHBUTTON "Prekliči", IDCANCEL, 120, 30, 40, 15
 END
 
 DIALOG_PRINTING DIALOG 0, 0, 160, 100
-CAPTION "Now printing"
+CAPTION "Trenutno se tiska"
 STYLE DS_SHELLFONT | DS_MODALFRAME | WS_CAPTION | WS_SYSMENU
 FONT 8, "MS Shell Dlg"
 BEGIN
-    CTEXT "Print job is starting...", IDC_PRINTING_STATUS, 5, 10, 150, 15
+    CTEXT "Tiskanje se začenja...", IDC_PRINTING_STATUS, 5, 10, 150, 15
     CTEXT "(Filename)", IDC_PRINTING_FILENAME, 5, 35, 150, 15
     CTEXT "Stran %u", IDC_PRINTING_PAGE, 5, 55, 150, 15
-    PUSHBUTTON "Cancel", IDCANCEL, 50, 75, 60, 20
+    PUSHBUTTON "Prekliči", IDCANCEL, 50, 75, 60, 20
 END
 
 STRINGTABLE
@@ -160,27 +160,27 @@ Vnesite besedilo in poskusite znova."
 Ali želite ustvariti novo datoteko?"
     STRING_NOTSAVED "Vsebina datoteke '%s'je bila spremenjena.\n\n\
 Ali želite shraniti spremembe?"
-    STRING_NOTFOUND "Ni mogoèe najti '%s'."
-    STRING_OUT_OF_MEMORY "Na voljo ni dovolj pomnilnika, da bi bilo mogoèe dokonèati to \
-operacijo.\nÈe ga želite sprostiti, konèajte enega ali veè programov in poskusite znova."
-    STRING_CANNOTFIND "Cannot find '%s'"
+    STRING_NOTFOUND "Datoteke '%s' ni mogoče najti."
+    STRING_OUT_OF_MEMORY "Na voljo ni dovolj pomnilnika, da bi bilo mogoče dokončati to \
+operacijo.\nČe ga želite sprostiti, končajte enega ali več programov in poskusite znova."
+    STRING_CANNOTFIND "Ni rezultatov za %s"
     STRING_ANSI "ANSI"
     STRING_UNICODE "Unicode"
     STRING_UNICODE_BE "Unicode (big endian)"
     STRING_UTF8 "UTF-8"
-    STRING_UTF8_BOM "UTF-8 with BOM"
+    STRING_UTF8_BOM "UTF-8 z BOM"
     STRING_CRLF "Windows (CR + LF)"
     STRING_LF "Unix (LF)"
     STRING_CR "Mac (CR)"
-    STRING_LINE_COLUMN "Line %d, column %d"
-    STRING_PRINTERROR "Cannot print the file '%s'.\n\nMake sure that the printer is turned on and is configured properly."
+    STRING_LINE_COLUMN "Vrstica %d, stolpec %d"
+    STRING_PRINTERROR "Tiskanje strani '%s' ni mogoče.\n\nPrepričajte se da je tiskalnik prižgan in pravilno nastavljen."
     STRING_DEFAULTFONT "Lucida Console"
-    STRING_LINE_NUMBER_OUT_OF_RANGE "The specified line number is out of range."
-    STRING_NOWPRINTING "Now printing page..."
-    STRING_PRINTCANCELING "The print job is being canceled..."
-    STRING_PRINTCOMPLETE "Printing is successfully done."
-    STRING_PRINTCANCELED "Printing has been canceled."
-    STRING_PRINTFAILED "Printing is failed."
+    STRING_LINE_NUMBER_OUT_OF_RANGE "Dana številka vrstice je izven obsega."
+    STRING_NOWPRINTING "Tiskanje strani..."
+    STRING_PRINTCANCELING "Tiskanje se prekinja..." /* Slovene doesn't have a proper way to say print job so just say printing is stopping */
+    STRING_PRINTCOMPLETE "Tiskanje uspešno."
+    STRING_PRINTCANCELED "Tiskanje prekinjeno."
+    STRING_PRINTFAILED "Napaka pri tiskanju."
 
     STRING_TEXT_DOCUMENT "Text Document"
     STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk\r\n"


### PR DESCRIPTION
## Purpose

Translate notepad and fix some characters being displayed wrong.

## TODOs:

  - Fix accelerators if needed??
  - Remove comments if needed

## Notes:

  - English translation of STRING_PRINTFAILED is wrong, should be either Printing failed or Printing has failed 

JIRA issue: None


