### PR TITLE
[EXPLORER] Start Menu Customize: Use TreeView_GetRoot

### DIFF
--- a/base/shell/explorer/startmnucust.cpp
+++ b/base/shell/explorer/startmnucust.cpp
@@ -167,7 +167,7 @@ static BOOL CustomizeClassic_OnOK(HWND hwnd)
 {
     HWND hTreeView = GetDlgItem(hwnd, IDC_CLASSICSTART_SETTINGS);
 
-    for (HTREEITEM hItem = TreeView_GetFirstVisible(hTreeView);
+    for (HTREEITEM hItem = TreeView_GetRoot(hTreeView);
          hItem != NULL;
          hItem = TreeView_GetNextVisible(hTreeView, hItem))
     {


### PR DESCRIPTION
## Purpose
Follow-up to #6596. Enable the Favorite menu setting.
JIRA issue: [CORE-16956](https://jira.reactos.org/browse/CORE-16956)

## Proposed changes

- Use `TreeView_GetRoot` instead of `TreeView_GetFirstVisible` in `CustomizeClassic_OnOK` function.

## TODO

- [x] Do tests.