### PR TITLE
[SHELL32] Start Menu Customize: Fix bMustHideAdminTools

### DIFF
--- a/dll/win32/shell32/shellmenu/CMenuToolbars.cpp
+++ b/dll/win32/shell32/shellmenu/CMenuToolbars.cpp
@@ -1377,7 +1377,7 @@ HRESULT CMenuSFToolbar::FillToolbar(BOOL clearFirst)
         L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Advanced",
         L"StartMenuAdminTools", FALSE, TRUE);
 
-    BOOL bMustHideAdminTools = IsPidlPrograms(m_idList) && StartMenuAdminTools;
+    BOOL bMustHideAdminTools = IsPidlPrograms(m_idList) && !StartMenuAdminTools;
     TRACE("StartMenuAdminTools: %d\n", StartMenuAdminTools);
     TRACE("bMustHideAdminTools: %d\n", bMustHideAdminTools);
 


### PR DESCRIPTION
## Purpose
Follow-up to #6603. Fix a bug in Admin Tools display.
JIRA issue: [CORE-16956](https://jira.reactos.org/browse/CORE-16956)

## Proposed changes

- Fix the value of `bMustHideAdminTools` in `CMenuSFToolbar::FillToolbar`.

## TODO

- [x] Do tests.