### PR TITLE
[SHELL32] Start Menu: Enhance context menu

### DIFF
--- a/dll/win32/shell32/shellmenu/CStartMenu.cpp
+++ b/dll/win32/shell32/shellmenu/CStartMenu.cpp
@@ -371,7 +371,7 @@ private:
 
         TRACE("csidl: 0x%X\n", csidl);
 
-#if 1 // FIXME: These CSIDLs wrongly opens My Computer.
+#if 1 // FIXME: These CSIDLs wrongly opens My Computer. CORE-19477
         if (csidl == CSIDL_CONTROLS || csidl == CSIDL_NETWORK || csidl == CSIDL_PRINTERS)
             return FALSE;
 #endif

--- a/dll/win32/shell32/shellmenu/CStartMenu.cpp
+++ b/dll/win32/shell32/shellmenu/CStartMenu.cpp
@@ -371,7 +371,7 @@ private:
 
         TRACE("csidl: 0x%X\n", csidl);
 
-#if 1 // FIXME: These CSIDLs wrongly opens My Computer. CORE-19477
+#if 0 // FIXME: These CSIDLs wrongly opens My Computer. CORE-19477
         if (csidl == CSIDL_CONTROLS || csidl == CSIDL_NETWORK || csidl == CSIDL_PRINTERS)
             return FALSE;
 #endif

--- a/dll/win32/shell32/shellmenu/CStartMenu.cpp
+++ b/dll/win32/shell32/shellmenu/CStartMenu.cpp
@@ -292,8 +292,13 @@ private:
                 break;
             }
             case IDM_FAVORITES:
+            case IDM_MYDOCUMENTS:
+            case IDM_MYPICTURES:
+            case IDM_CONTROLPANEL:
+            case IDM_NETWORKCONNECTIONS:
+            case IDM_PRINTERSANDFAXES:
             {
-                hr = AddStartMenuItems(pShellMenu, CSIDL_FAVORITES, SMSET_TOP);
+                hr = AddStartMenuItems(pShellMenu, CSIDLFromID(psmd->uId), SMSET_TOP);
                 break;
             }
             case IDM_DOCUMENTS:
@@ -307,31 +312,6 @@ private:
                     return hr;
 
                 hr = AddStartMenuItems(pShellMenu, CSIDL_RECENT, SMSET_BOTTOM);
-                break;
-            }
-            case IDM_MYDOCUMENTS:
-            {
-                hr = AddStartMenuItems(pShellMenu, CSIDL_MYDOCUMENTS, SMSET_TOP);
-                break;
-            }
-            case IDM_MYPICTURES:
-            {
-                hr = AddStartMenuItems(pShellMenu, CSIDL_MYPICTURES, SMSET_TOP);
-                break;
-            }
-            case IDM_CONTROLPANEL:
-            {
-                hr = AddStartMenuItems(pShellMenu, CSIDL_CONTROLS, SMSET_TOP);
-                break;
-            }
-            case IDM_NETWORKCONNECTIONS:
-            {
-                hr = AddStartMenuItems(pShellMenu, CSIDL_NETWORK, SMSET_TOP);
-                break;
-            }
-            case IDM_PRINTERSANDFAXES:
-            {
-                hr = AddStartMenuItems(pShellMenu, CSIDL_PRINTERS, SMSET_TOP);
                 break;
             }
             case IDM_SETTINGS:
@@ -367,17 +347,45 @@ private:
         return hr;
     }
 
+    INT CSIDLFromID(UINT uId) const
+    {
+        switch (uId)
+        {
+            case IDM_PROGRAMS: return CSIDL_PROGRAMS;
+            case IDM_FAVORITES: return CSIDL_FAVORITES;
+            case IDM_DOCUMENTS: return CSIDL_RECENT;
+            case IDM_MYDOCUMENTS: return CSIDL_MYDOCUMENTS;
+            case IDM_MYPICTURES: return CSIDL_MYPICTURES;
+            case IDM_CONTROLPANEL: return CSIDL_CONTROLS;
+            case IDM_NETWORKCONNECTIONS: return CSIDL_NETWORK;
+            case IDM_PRINTERSANDFAXES: return CSIDL_PRINTERS;
+            default: return 0;
+        }
+    }
+
     HRESULT OnGetContextMenu(LPSMDATA psmd, REFIID iid, void ** pv)
     {
-        if (psmd->uId == IDM_PROGRAMS ||
-            psmd->uId == IDM_CONTROLPANEL ||
-            psmd->uId == IDM_NETWORKCONNECTIONS ||
-            psmd->uId == IDM_PRINTERSANDFAXES)
-        {
-            //UNIMPLEMENTED
-        }
+        INT csidl = CSIDLFromID(psmd->uId);
+        if (!csidl)
+            return S_FALSE;
 
-        return S_FALSE;
+        TRACE("csidl: 0x%X\n", csidl);
+
+#if 1 // FIXME: These CSIDLs wrongly opens My Computer.
+        if (csidl == CSIDL_CONTROLS || csidl == CSIDL_NETWORK || csidl == CSIDL_PRINTERS)
+            return FALSE;
+#endif
+
+        CComHeapPtr<ITEMIDLIST> pidl;
+        SHGetSpecialFolderLocation(NULL, csidl, &pidl);
+
+        CComPtr<IShellFolder> pSF;
+        LPCITEMIDLIST pidlChild = NULL;
+        HRESULT hr = SHBindToParent(pidl, IID_IShellFolder, (void**)&pSF, &pidlChild);
+        if (FAILED(hr))
+            return hr;
+
+        return pSF->GetUIObjectOf(NULL, 1, &pidlChild, IID_IContextMenu, NULL, pv);
     }
 
     HRESULT OnGetObject(LPSMDATA psmd, REFIID iid, void ** pv)

--- a/dll/win32/shell32/shellmenu/CStartMenu.cpp
+++ b/dll/win32/shell32/shellmenu/CStartMenu.cpp
@@ -371,10 +371,8 @@ private:
 
         TRACE("csidl: 0x%X\n", csidl);
 
-#if 0 // FIXME: These CSIDLs wrongly opens My Computer. CORE-19477
         if (csidl == CSIDL_CONTROLS || csidl == CSIDL_NETWORK || csidl == CSIDL_PRINTERS)
-            return FALSE;
-#endif
+            FIXME("This CSIDL %d wrongly opens My Computer. CORE-19477\n", csidl);
 
         CComHeapPtr<ITEMIDLIST> pidl;
         SHGetSpecialFolderLocation(NULL, csidl, &pidl);


### PR DESCRIPTION
## Purpose
Improve Start Menu usability.
JIRA issue: [CORE-19477](https://jira.reactos.org/browse/CORE-19477)

## Proposed changes

- Add `CSIDLFromID` helper function.
- Return a context menu interface at `CShellMenuCallback::OnGetContextMenu`.

## TODO

- [x] Do tests.
- [ ] `CSIDL_CONTROLS`, `CSIDL_NETWORK`, and `CSIDL_PRINTERS` wrongly open `My Computer`.

## Screenshots

![after1](https://github.com/reactos/reactos/assets/2107452/8bda957c-7dea-4041-af5b-28640acfc64f)
![after2](https://github.com/reactos/reactos/assets/2107452/2cf0c43e-fe1a-4c3d-a0f3-6cdcb92cbc2b)
![after3](https://github.com/reactos/reactos/assets/2107452/8db54faa-20da-4a40-865c-f53651cd84be)