### PR TITLE
[SHELL32] CGuidItemContextMenu: Fix pwszCLSID leak

### DIFF
--- a/dll/win32/shell32/folders/CRegFolder.cpp
+++ b/dll/win32/shell32/folders/CRegFolder.cpp
@@ -116,6 +116,7 @@ HRESULT CGuidItemContextMenu_CreateInstance(PCIDLIST_ABSOLUTE pidlFolder,
         {
             wcscpy(&key[6], pwszCLSID);
             AddClassKeyToArray(key, hKeys, &cKeys);
+            CoTaskMemFree(pwszCLSID);
         }
     }
     AddClassKeyToArray(L"Folder", hKeys, &cKeys);


### PR DESCRIPTION
## Purpose
Fix memory leak.
JIRA issue: [CORE-19478](https://jira.reactos.org/browse/CORE-19478)

## Proposed changes

- Use `CoTaskMemFree` for `pwszCLSID` to avoid memory leak in `CGuidItemContextMenu_CreateInstance` function.

## TODO

- [x] Do build.