### PR TITLE
[COMCTL32] TreeView: Fix selection display on checking checkbox

### DIFF
--- a/dll/win32/comctl32/treeview.c
+++ b/dll/win32/comctl32/treeview.c
@@ -2334,8 +2334,18 @@ TREEVIEW_GetCount(const TREEVIEW_INFO *infoPtr)
     return (LRESULT)infoPtr->uNumItems;
 }
 
+#ifdef __REACTOS__
+static LRESULT
+TREEVIEW_SelectItem(TREEVIEW_INFO *infoPtr, INT wParam, HTREEITEM item);
+#endif
+
+#ifdef __REACTOS__
+static VOID
+TREEVIEW_ToggleItemState(TREEVIEW_INFO *infoPtr, TREEVIEW_ITEM *item)
+#else
 static VOID
 TREEVIEW_ToggleItemState(const TREEVIEW_INFO *infoPtr, TREEVIEW_ITEM *item)
+#endif
 {
     if (infoPtr->dwStyle & TVS_CHECKBOXES)
     {
@@ -2353,6 +2363,9 @@ TREEVIEW_ToggleItemState(const TREEVIEW_INFO *infoPtr, TREEVIEW_ITEM *item)
 	item->state |= INDEXTOSTATEIMAGEMASK(state);
 
 	TRACE("state: 0x%x\n", state);
+#ifdef __REACTOS__
+	TREEVIEW_SelectItem(infoPtr, TVGN_CARET, item);
+#endif
 	TREEVIEW_Invalidate(infoPtr, item);
     }
 }


### PR DESCRIPTION
## Purpose

Fix checkboxed treeview selection display.
JIRA issue: [CORE-19480](https://jira.reactos.org/browse/CORE-19480)

## Proposed changes

- Make the first argument of `TREEVIEW_ToggleItemState` non-`const`.
- Select the item by calling `TREEVIEW_SelectItem` in `TREEVIEW_ToggleItemState`.

## TODO

- [x] Do tests.

## Comparison

BEFORE:
![before](https://github.com/reactos/reactos/assets/2107452/18b6360e-c0ae-4904-8afd-147c70ec6e3c)
AFTER:
![after](https://github.com/reactos/reactos/assets/2107452/0c09e8ea-ef42-492a-a083-b06ff62779e9)