### PR TITLE
[SHELL32_APITEST] ShellExecuteEx: Fix command line checker

### DIFF
--- a/modules/rostests/apitests/shell32/ShellExecuteEx.cpp
+++ b/modules/rostests/apitests/shell32/ShellExecuteEx.cpp
@@ -388,14 +388,12 @@ static void TEST_End(void)
 
 static void test_properties()
 {
-    WCHAR Buffer[MAX_PATH * 4];
-
     HRESULT hrCoInit = CoInitialize(NULL);
 
+    WCHAR Buffer[MAX_PATH * 4];
     GetModuleFileNameW(NULL, Buffer, _countof(Buffer));
-    SHELLEXECUTEINFOW info = { sizeof(info) };
 
-    info.cbSize = sizeof(SHELLEXECUTEINFOW);
+    SHELLEXECUTEINFOW info = { sizeof(info) };
     info.fMask = SEE_MASK_INVOKEIDLIST | SEE_MASK_FLAG_NO_UI;
     info.lpVerb = L"properties";
     info.lpFile = Buffer;

--- a/modules/rostests/apitests/shell32/ShellExecuteEx.cpp
+++ b/modules/rostests/apitests/shell32/ShellExecuteEx.cpp
@@ -130,7 +130,7 @@ getCommandLineFromProcess(HANDLE hProcess)
     if (!cmdline)
         trace("!cmdline\n");
 
-    SIZE_T cchCmdLine = Params.CommandLine.Length / sizeof(WCHAR);
+    SIZE_T cchCmdLine = Params.CommandLine.Length;
     if (!cchCmdLine)
         trace("!cchCmdLine\n");
 

--- a/modules/rostests/apitests/shell32/ShellExecuteEx.cpp
+++ b/modules/rostests/apitests/shell32/ShellExecuteEx.cpp
@@ -130,19 +130,19 @@ getCommandLineFromProcess(HANDLE hProcess)
     if (!cmdline)
         trace("!cmdline\n");
 
-    SIZE_T cchCmdLine = Params.CommandLine.Length;
-    if (!cchCmdLine)
-        trace("!cchCmdLine\n");
+    SIZE_T cbCmdLine = Params.CommandLine.Length;
+    if (!cbCmdLine)
+        trace("!cbCmdLine\n");
 
-    LPWSTR pszBuffer = (LPWSTR)calloc(cchCmdLine + 1, sizeof(WCHAR));
+    LPWSTR pszBuffer = (LPWSTR)calloc(cbCmdLine + sizeof(WCHAR), sizeof(WCHAR));
     if (!pszBuffer)
         trace("!pszBuffer\n");
 
-    ret = ReadProcessMemory(hProcess, cmdline, pszBuffer, cchCmdLine, NULL);
+    ret = ReadProcessMemory(hProcess, cmdline, pszBuffer, cbCmdLine, NULL);
     if (!ret)
         trace("ReadProcessMemory failed (%ld)\n", GetLastError());
 
-    pszBuffer[cchCmdLine] = UNICODE_NULL;
+    pszBuffer[cbCmdLine / sizeof(WCHAR)] = UNICODE_NULL;
 
     return pszBuffer; // needs free()
 }

--- a/modules/rostests/apitests/shell32/ShellExecuteEx.cpp
+++ b/modules/rostests/apitests/shell32/ShellExecuteEx.cpp
@@ -111,12 +111,11 @@ getCommandLineFromProcess(HANDLE hProcess)
     PEB peb;
     PROCESS_BASIC_INFORMATION info;
     RTL_USER_PROCESS_PARAMETERS Params;
-    LONG status;
+    NTSTATUS Status;
     BOOL ret;
 
-    status = NtQueryInformationProcess(hProcess, ProcessBasicInformation, &info, sizeof(info), NULL);
-    if (status != 0)
-        trace("status: 0x%08lX\n", status);
+    Status = NtQueryInformationProcess(hProcess, ProcessBasicInformation, &info, sizeof(info), NULL);
+    ok_ntstatus(Status, STATUS_SUCCESS);
 
     ret = ReadProcessMemory(hProcess, info.PebBaseAddress, &peb, sizeof(peb), NULL);
     if (!ret)

--- a/modules/rostests/apitests/shell32/ShellExecuteEx.cpp
+++ b/modules/rostests/apitests/shell32/ShellExecuteEx.cpp
@@ -133,7 +133,7 @@ getCommandLineFromProcess(HANDLE hProcess)
     if (!cbCmdLine)
         trace("!cbCmdLine\n");
 
-    LPWSTR pszBuffer = (LPWSTR)calloc(cbCmdLine + sizeof(WCHAR), sizeof(WCHAR));
+    LPWSTR pszBuffer = (LPWSTR)calloc(cbCmdLine + sizeof(WCHAR), 1);
     if (!pszBuffer)
         trace("!pszBuffer\n");
 


### PR DESCRIPTION
## Purpose

Follow-up to #6617.

JIRA issue: [CORE-19482](https://jira.reactos.org/browse/CORE-19482)

## Proposed changes

- Add `trace`s for error checking.

## TODO

- [x] Do tests.

## Screenshots

Win2k3:
![test-success](https://github.com/reactos/reactos/assets/2107452/de063ab2-33e4-445c-be64-c910639d780b)
Successful.
