### PR TITLE
[UXTHEME] Implement various Vista+ functions, mostly from WINE

### DIFF
--- a/dll/win32/uxtheme/CMakeLists.txt
+++ b/dll/win32/uxtheme/CMakeLists.txt
@@ -1,7 +1,12 @@
 
 include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 add_definitions(-D__WINESRC__ -D__ROS_LONG64__)
-spec2def(uxtheme.dll uxtheme.spec ADD_IMPORTLIB)
+
+if(DLL_EXPORT_VERSION GREATER_EQUAL 0x600)
+    spec2def(uxtheme.dll uxtheme_vista.spec ADD_IMPORTLIB)
+else()
+    spec2def(uxtheme.dll uxtheme.spec ADD_IMPORTLIB)
+endif()
 
 list(APPEND SOURCE
     buffer.c

--- a/dll/win32/uxtheme/buffer.c
+++ b/dll/win32/uxtheme/buffer.c
@@ -19,6 +19,28 @@
  */
 
 #include "uxthemep.h"
+#include <wine/heap.h>
+
+struct paintbuffer
+{
+    HDC targetdc;
+    HDC memorydc;
+    HBITMAP bitmap;
+    RECT rect;
+    void *bits;
+};
+
+static void free_paintbuffer(struct paintbuffer *buffer)
+{
+    DeleteObject(buffer->bitmap);
+    DeleteDC(buffer->memorydc);
+    heap_free(buffer);
+}
+
+static struct paintbuffer *get_buffer_obj(HPAINTBUFFER handle)
+{
+    return handle;
+}
 
 /***********************************************************************
  *      BufferedPaintInit                                  (UXTHEME.@)
@@ -41,34 +63,103 @@ HRESULT WINAPI BufferedPaintUnInit(VOID)
 /***********************************************************************
  *      BeginBufferedPaint                                 (UXTHEME.@)
  */
-HPAINTBUFFER WINAPI BeginBufferedPaint(HDC hdcTarget,
-                                       const RECT * prcTarget,
-                                       BP_BUFFERFORMAT dwFormat,
-                                       BP_PAINTPARAMS *pPaintParams,
-                                       HDC *phdc)
+HPAINTBUFFER WINAPI BeginBufferedPaint(HDC targetdc, const RECT *rect,
+        BP_BUFFERFORMAT format, BP_PAINTPARAMS *params, HDC *retdc)
 {
-    static int i;
+#if (defined(_MSC_VER))
+    char bmibuf[FIELD_OFFSET(BITMAPINFO, bmiColors) + 256 * sizeof(RGBQUAD)];
+#else
+    char bmibuf[FIELD_OFFSET(BITMAPINFO, bmiColors[256])];
+#endif
+    BITMAPINFO *bmi = (BITMAPINFO *)bmibuf;
+    struct paintbuffer *buffer;
 
-    TRACE("Stub (%p %p %d %p %p)\n", hdcTarget, prcTarget, dwFormat,
-          pPaintParams, phdc);
+    TRACE("(%p %s %d %p %p)\n", targetdc, wine_dbgstr_rect(rect), format,
+          params, retdc);
 
-    if (!i++)
-        FIXME("Stub (%p %p %d %p %p)\n", hdcTarget, prcTarget, dwFormat,
-              pPaintParams, phdc);
-    return NULL;
+    if (retdc)
+        *retdc = NULL;
+
+    if (!targetdc || IsRectEmpty(rect))
+        return NULL;
+
+    if (params)
+        FIXME("painting parameters are ignored\n");
+
+    buffer = heap_alloc(sizeof(*buffer));
+    buffer->targetdc = targetdc;
+    buffer->rect = *rect;
+    buffer->memorydc = CreateCompatibleDC(targetdc);
+
+    switch (format)
+    {
+    case BPBF_COMPATIBLEBITMAP:
+        buffer->bitmap = CreateCompatibleBitmap(targetdc, rect->right - rect->left, rect->bottom - rect->top);
+        buffer->bits = NULL;
+        break;
+    case BPBF_DIB:
+    case BPBF_TOPDOWNDIB:
+    case BPBF_TOPDOWNMONODIB:
+        /* create DIB section */
+        memset(bmi, 0, sizeof(bmibuf));
+        bmi->bmiHeader.biSize = sizeof(bmi->bmiHeader);
+        bmi->bmiHeader.biHeight = format == BPBF_DIB ? rect->bottom - rect->top :
+                -(rect->bottom - rect->top);
+        bmi->bmiHeader.biWidth = rect->right - rect->left;
+        bmi->bmiHeader.biBitCount = format == BPBF_TOPDOWNMONODIB ? 1 : 32;
+        bmi->bmiHeader.biPlanes = 1;
+        bmi->bmiHeader.biCompression = BI_RGB;
+        buffer->bitmap = CreateDIBSection(buffer->memorydc, bmi, DIB_RGB_COLORS, &buffer->bits, NULL, 0);
+        break;
+    default:
+        WARN("Unknown buffer format %d\n", format);
+        buffer->bitmap = NULL;
+        free_paintbuffer(buffer);
+        return NULL;
+    }
+
+    if (!buffer->bitmap)
+    {
+        WARN("Failed to create buffer bitmap\n");
+        free_paintbuffer(buffer);
+        return NULL;
+    }
+
+    SetWindowOrgEx(buffer->memorydc, rect->left, rect->top, NULL);
+    IntersectClipRect(buffer->memorydc, rect->left, rect->top, rect->right, rect->bottom);
+    DeleteObject(SelectObject(buffer->memorydc, buffer->bitmap));
+
+    *retdc = buffer->memorydc;
+
+    return (HPAINTBUFFER)buffer;
 }
 
 
 /***********************************************************************
  *      EndBufferedPaint                                   (UXTHEME.@)
  */
-HRESULT WINAPI EndBufferedPaint(HPAINTBUFFER hPaintBuffer, BOOL fUpdateTarget)
+HRESULT WINAPI EndBufferedPaint(HPAINTBUFFER bufferhandle, BOOL update)
 {
-    FIXME("Stub (%p %d)\n", hPaintBuffer, fUpdateTarget);
+    struct paintbuffer *buffer = get_buffer_obj(bufferhandle);
+
+    TRACE("(%p %d)\n", bufferhandle, update);
+
+    if (!buffer)
+        return E_INVALIDARG;
+
+    if (update)
+    {
+        if (!BitBlt(buffer->targetdc, buffer->rect.left, buffer->rect.top,
+                buffer->rect.right - buffer->rect.left, buffer->rect.bottom - buffer->rect.top,
+                buffer->memorydc, buffer->rect.left, buffer->rect.top, SRCCOPY))
+        {
+            WARN("BitBlt() failed\n");
+        }
+    }
+
+    free_paintbuffer(buffer);
     return S_OK;
 }
-
-#ifndef __REACTOS__
 
 /***********************************************************************
  *      BufferedPaintClear                                 (UXTHEME.@)
@@ -91,38 +182,65 @@ HRESULT WINAPI BufferedPaintSetAlpha(HPAINTBUFFER hBufferedPaint, const RECT *pr
 /***********************************************************************
  *      GetBufferedPaintBits                               (UXTHEME.@)
  */
-HRESULT WINAPI GetBufferedPaintBits(HPAINTBUFFER hBufferedPaint, RGBQUAD **ppbBuffer,
-                                    int *pcxRow)
+HRESULT WINAPI GetBufferedPaintBits(HPAINTBUFFER bufferhandle, RGBQUAD **bits, int *width)
 {
-    FIXME("Stub (%p %p %p)\n", hBufferedPaint, ppbBuffer, pcxRow);
-    return E_NOTIMPL;
+    struct paintbuffer *buffer = get_buffer_obj(bufferhandle);
+
+    TRACE("(%p %p %p)\n", buffer, bits, width);
+
+    if (!bits || !width)
+        return E_POINTER;
+
+    if (!buffer || !buffer->bits)
+        return E_FAIL;
+
+    *bits = buffer->bits;
+    *width = buffer->rect.right - buffer->rect.left;
+
+    return S_OK;
 }
 
 /***********************************************************************
  *      GetBufferedPaintDC                                 (UXTHEME.@)
  */
-HDC WINAPI GetBufferedPaintDC(HPAINTBUFFER hBufferedPaint)
+HDC WINAPI GetBufferedPaintDC(HPAINTBUFFER bufferhandle)
 {
-    FIXME("Stub (%p)\n", hBufferedPaint);
-    return NULL;
+    struct paintbuffer *buffer = get_buffer_obj(bufferhandle);
+
+    TRACE("(%p)\n", buffer);
+
+    return buffer ? buffer->memorydc : NULL;
 }
 
 /***********************************************************************
  *      GetBufferedPaintTargetDC                           (UXTHEME.@)
  */
-HDC WINAPI GetBufferedPaintTargetDC(HPAINTBUFFER hBufferedPaint)
+HDC WINAPI GetBufferedPaintTargetDC(HPAINTBUFFER bufferhandle)
 {
-    FIXME("Stub (%p)\n", hBufferedPaint);
-    return NULL;
+    struct paintbuffer *buffer = get_buffer_obj(bufferhandle);
+
+    TRACE("(%p)\n", buffer);
+
+    return buffer ? buffer->targetdc : NULL;
 }
 
 /***********************************************************************
  *      GetBufferedPaintTargetRect                         (UXTHEME.@)
  */
-HRESULT WINAPI GetBufferedPaintTargetRect(HPAINTBUFFER hBufferedPaint, RECT *prc)
+HRESULT WINAPI GetBufferedPaintTargetRect(HPAINTBUFFER bufferhandle, RECT *rect)
 {
-    FIXME("Stub (%p %p)\n", hBufferedPaint, prc);
-    return E_NOTIMPL;
+    struct paintbuffer *buffer = get_buffer_obj(bufferhandle);
+
+    TRACE("(%p %p)\n", buffer, rect);
+
+    if (!rect)
+        return E_POINTER;
+
+    if (!buffer)
+        return E_FAIL;
+
+    *rect = buffer->rect;
+    return S_OK;
 }
 
 /***********************************************************************
@@ -168,5 +286,3 @@ HRESULT WINAPI EndBufferedAnimation(HANIMATIONBUFFER hbpAnimation, BOOL fUpdateT
 
     return E_NOTIMPL;
 }
-
-#endif /* __REACTOS__ */

--- a/dll/win32/uxtheme/metric.c
+++ b/dll/win32/uxtheme/metric.c
@@ -220,16 +220,38 @@ HRESULT WINAPI GetThemeSysString(HTHEME hTheme, int iStringID,
     return E_PROP_ID_UNSUPPORTED;
 }
 
-#ifndef __REACTOS__
 /***********************************************************************
  *      GetThemeTransitionDuration                          (UXTHEME.@)
  */
 HRESULT WINAPI GetThemeTransitionDuration(HTHEME hTheme, int iPartId, int iStateIdFrom,
                                           int iStateIdTo, int iPropId, DWORD *pdwDuration)
 {
-    FIXME("(%p, %u, %u, %u, %u, %p) stub\n", hTheme, iPartId, iStateIdFrom, iStateIdTo,
-          iPropId, pdwDuration);
+    INTLIST intlist;
+    HRESULT hr;
 
-    return E_NOTIMPL;
+    TRACE("(%p, %d, %d, %d, %d, %p)\n", hTheme, iPartId, iStateIdFrom, iStateIdTo, iPropId,
+          pdwDuration);
+
+    if (!pdwDuration || iStateIdFrom < 1 || iStateIdTo < 1)
+        return E_INVALIDARG;
+
+    hr = GetThemeIntList(hTheme, iPartId, 0, iPropId, &intlist);
+    if (FAILED(hr))
+    {
+        if (hr == E_PROP_ID_UNSUPPORTED)
+            *pdwDuration = 0;
+
+        return hr;
+    }
+
+    if (intlist.iValueCount < 1 || iStateIdFrom > intlist.iValues[0]
+        || iStateIdTo > intlist.iValues[0]
+        || intlist.iValueCount != 1 + intlist.iValues[0] * intlist.iValues[0])
+    {
+        *pdwDuration = 0;
+        return E_INVALIDARG;
+    }
+
+    *pdwDuration = intlist.iValues[1 + intlist.iValues[0] * (iStateIdFrom - 1) + (iStateIdTo - 1)];
+    return S_OK;
 }
-#endif

--- a/dll/win32/uxtheme/uxtheme_vista.spec
+++ b/dll/win32/uxtheme/uxtheme_vista.spec
@@ -1,0 +1,128 @@
+1 stdcall -noname QueryThemeServices()
+2 stdcall -noname OpenThemeFile(wstr wstr wstr ptr long)
+3 stdcall -noname CloseThemeFile(ptr)
+4 stdcall -noname ApplyTheme(ptr ptr ptr)
+5 stdcall BeginBufferedAnimation(ptr ptr ptr long ptr ptr ptr ptr)
+6 stdcall BeginBufferedPaint(ptr ptr long ptr ptr)
+7 stdcall -noname GetThemeDefaults(wstr wstr long wstr long)
+8 stdcall -noname EnumThemes(wstr ptr ptr)
+9 stdcall -noname EnumThemeColors(wstr wstr long ptr)
+10 stdcall -noname EnumThemeSizes(wstr wstr long ptr)
+11 stdcall -noname ParseThemeIniFile(wstr wstr ptr ptr)
+12 stdcall BufferedPaintClear(ptr ptr)
+13 stdcall -noname DrawNCPreview(ptr long ptr wstr wstr wstr ptr ptr)
+14 stub -noname RegisterDefaultTheme
+15 stub -noname DumpLoadedThemeToTextFile
+16 stdcall -noname OpenThemeDataFromFile(ptr ptr wstr long)
+17 stub -noname OpenThemeFileFromData
+18 stub -noname GetThemeSysSize96
+19 stub -noname GetThemeSysFont96
+20 stub -noname SessionAllocate
+21 stub -noname SessionFree
+22 stub -noname ThemeHooksOn
+23 stub -noname ThemeHooksOff
+24 stub -noname AreThemeHooksActive
+25 stub -noname GetCurrentChangeNumber
+26 stub -noname GetNewChangeNumber
+27 stub -noname SetGlobalTheme
+28 stub -noname GetGlobalTheme
+29 stdcall -noname CheckThemeSignature(wstr)
+30 stub -noname LoadTheme
+31 stub -noname InitUserTheme
+32 stub -noname InitUserRegistry
+33 stub -noname ReestablishServerConnection
+34 stdcall -noname ThemeHooksInstall()
+35 stdcall -noname ThemeHooksRemove()
+36 stub -noname RefreshThemeForTS
+37 stdcall BufferedPaintInit()
+38 stdcall BufferedPaintRenderAnimation(ptr ptr)
+39 stdcall BufferedPaintSetAlpha(ptr ptr long)
+40 stdcall BufferedPaintStopAllAnimations(ptr)
+41 stdcall BufferedPaintUnInit()
+42 stdcall CloseThemeData(ptr)
+43 stdcall -noname ClassicGetSystemMetrics(long)
+44 stdcall -noname ClassicSystemParametersInfoA(long long ptr long)
+45 stdcall -noname ClassicSystemParametersInfoW(long long ptr long)
+46 stdcall -noname ClassicAdjustWindowRectEx(ptr long long long)
+47 stdcall DrawThemeBackgroundEx(ptr ptr long long ptr ptr)
+48 stdcall -noname GetThemeParseErrorInfo(ptr)
+49 stdcall -stub OpenNcThemeData()
+50 stdcall -stub IsThemeClassDefined(ptr ptr long long ptr ptr)
+51 stdcall DrawThemeBackground(ptr ptr long long ptr ptr)
+52 stdcall DrawThemeEdge(ptr ptr long long ptr long long ptr)
+53 stdcall DrawThemeIcon(ptr ptr long long ptr ptr long)
+54 stdcall DrawThemeParentBackground(ptr ptr ptr)
+55 stub DrawThemeParentBackgroundEx
+56 stdcall DrawThemeText(ptr ptr long long wstr long long long ptr)
+57 stdcall DrawThemeTextEx(ptr ptr long long wstr long long ptr ptr)
+58 stdcall EnableThemeDialogTexture(ptr long)
+59 stdcall EnableTheming(long)
+60 stub -noname CreateThemeDataFromObjects
+61 stdcall -noname OpenThemeDataEx(ptr wstr long)
+62 stub -noname ServerClearStockObjects
+63 stub -noname MarkSelection
+64 stub ProcessLoadTheme_RunDLLW
+65 stub SetSystemVisualStyle
+66 stub ServiceClearStockObjects
+67 stdcall -stub AddThemeAppCompatFlag(ptr long long long ptr)
+68 stdcall -stub ResetThemeAppCompatFlags(ptr ptr long long long ptr ptr)
+69 stdcall -stub EnumThemeProperties(ptr ptr long long long ptr)
+70 stdcall EndBufferedAnimation(ptr long)
+71 stdcall EndBufferedPaint(ptr long)
+72 stdcall -stub DrawThemeIconEx(ptr long long long ptr)
+73 stub IsThemeActiveByPolicy
+74 stdcall -stub GetThemeClass(ptr long long long ptr)
+75 stdcall -stub ThemeForwardCapturedMouseMessage(ptr long long long wstr long)
+76 stdcall -stub EnableServiceConnection(ptr long)
+77 stdcall -stub Remote_LoadTheme(ptr long) ; This exits a thread
+78 stdcall GetBufferedPaintBits(ptr ptr ptr)
+79 stdcall GetBufferedPaintDC(ptr)
+80 stdcall GetBufferedPaintTargetDC(ptr)
+81 stdcall GetBufferedPaintTargetRect(ptr ptr)
+82 stdcall GetCurrentThemeName(wstr long wstr long wstr long)
+83 stdcall GetThemeAppProperties()
+84 stdcall GetThemeBackgroundContentRect(ptr ptr long long ptr ptr)
+85 stdcall GetThemeBackgroundExtent(ptr ptr long long ptr ptr)
+86 stdcall GetThemeBackgroundRegion(ptr ptr long long ptr ptr)
+87 stub GetThemeBitMap
+88 stdcall GetThemeBool(ptr long long long ptr)
+89 stdcall GetThemeColor(ptr long long long ptr)
+90 stdcall GetThemeDocumentationProperty(wstr wstr wstr long)
+91 stdcall GetThemeEnumValue(ptr long long long ptr)
+92 stdcall GetThemeFilename(ptr long long long wstr long)
+93 stdcall GetThemeFont(ptr ptr long long long ptr)
+94 stdcall GetThemeInt(ptr long long long ptr)
+95 stdcall GetThemeIntList(ptr long long long ptr)
+96 stdcall GetThemeMargins(ptr ptr long long long ptr ptr)
+97 stdcall GetThemeMetric(ptr ptr long long long ptr)
+98 stdcall GetThemePartSize(ptr ptr long long ptr long ptr)
+99 stdcall GetThemePosition(ptr long long long ptr)
+100 stdcall GetThemePropertyOrigin(ptr long long long ptr)
+101 stdcall GetThemeRect(ptr long long long ptr)
+102 stub GetThemeStream
+103 stdcall GetThemeString(ptr long long long wstr long)
+104 stdcall GetThemeSysBool(ptr long)
+105 stdcall GetThemeSysColor(ptr long)
+106 stdcall GetThemeSysColorBrush(ptr long)
+107 stdcall GetThemeSysFont(ptr long ptr)
+108 stdcall GetThemeSysInt(ptr long ptr)
+109 stdcall GetThemeSysSize(ptr long)
+110 stdcall GetThemeSysString(ptr long wstr long)
+111 stdcall GetThemeTextExtent(ptr ptr long long wstr long long ptr ptr)
+112 stdcall GetThemeTextMetrics(ptr ptr long long ptr)
+113 stdcall GetThemeTransitionDuration(ptr long long long long ptr)
+114 stdcall GetWindowTheme(ptr)
+115 stdcall HitTestThemeBackground(ptr long long long long ptr long double ptr)
+116 stdcall IsAppThemed()
+117 stdcall IsCompositionActive()
+118 stdcall IsThemeActive()
+119 stdcall IsThemeBackgroundPartiallyTransparent(ptr long long)
+120 stdcall IsThemeDialogTextureEnabled(ptr)
+121 stdcall IsThemePartDefined(ptr long long)
+122 stdcall OpenThemeData(ptr wstr)
+123 stdcall SetThemeAppProperties(long)
+124 stdcall SetWindowTheme(ptr wstr wstr)
+125 stdcall SetWindowThemeAttribute(ptr long ptr long)
+126 stdcall ThemeInitApiHook(long ptr)
+
+@ stdcall OpenThemeDataForDpi(ptr wstr long) ;win7

--- a/sdk/include/psdk/uxtheme.h
+++ b/sdk/include/psdk/uxtheme.h
@@ -15,8 +15,7 @@ extern "C" {
 #define DTBG_COMPUTINGREGION        0x00000010
 #define DTBG_MIRRORDC               0x00000020
 #define DTT_GRAYED                  0x00000001
-
-/* DTTOPTS.dwFlags bits */
+// Vista+
 #define DTT_TEXTCOLOR               0x00000001
 #define DTT_BORDERCOLOR             0x00000002
 #define DTT_SHADOWCOLOR             0x00000004
@@ -57,6 +56,8 @@ extern "C" {
 
 typedef HANDLE HPAINTBUFFER;
 typedef HANDLE HTHEME;
+// Vista+
+typedef HANDLE HANIMATIONBUFFER;
 typedef int (WINAPI *DTT_CALLBACK_PROC)(HDC,LPWSTR,int,RECT*,UINT,LPARAM);
 
 typedef enum _BP_BUFFERFORMAT
@@ -66,6 +67,7 @@ typedef enum _BP_BUFFERFORMAT
 	BPBF_TOPDOWNDIB,
 	BPBF_TOPDOWNMONODIB
 } BP_BUFFERFORMAT;
+
 
 typedef struct _BP_PAINTPARAMS
 {
@@ -89,6 +91,21 @@ typedef enum THEMESIZE {
     TS_DRAW
 } THEMESIZE;
 
+// Vista+
+
+typedef enum _BP_ANIMATIONSTYLE
+{
+    BPAS_NONE,
+    BPAS_LINEAR,
+    BPAS_CUBIC,
+    BPAS_SINE
+} BP_ANIMATIONSTYLE;
+enum WINDOWTHEMEATTRIBUTETYPE
+{
+    WTA_NONCLIENT = 1
+};
+
+
 typedef struct _DTBGOPTS {
     DWORD dwSize;
     DWORD dwFlags;
@@ -109,6 +126,7 @@ typedef struct _MARGINS {
     int cyBottomHeight;
 } MARGINS, *PMARGINS;
 
+// Vista+
 typedef struct _DTTOPTS {
     DWORD dwSize;
     DWORD dwFlags;
@@ -126,6 +144,14 @@ typedef struct _DTTOPTS {
     DTT_CALLBACK_PROC pfnDrawTextCallback;
     LPARAM lParam;
 } DTTOPTS, *PDTTOPTS;
+
+typedef struct _BP_ANIMATIONPARAMS
+{
+    DWORD cbSize;
+    DWORD dwFlags;
+    BP_ANIMATIONSTYLE style;
+    DWORD dwDuration;
+} BP_ANIMATIONPARAMS, *PBP_ANIMATIONPARAMS;
 
 HRESULT WINAPI CloseThemeData(HTHEME);
 HRESULT WINAPI DrawThemeBackground(HTHEME,HDC,int,int,const RECT*,const RECT*);
@@ -192,6 +218,25 @@ DrawThemeTextEx(
     _Inout_ LPRECT pRect,
     _In_ const DTTOPTS *options
 );
+
+// Vista+
+HRESULT WINAPI BufferedPaintInit(VOID);
+HRESULT WINAPI BufferedPaintUnInit(VOID);
+HPAINTBUFFER WINAPI BeginBufferedPaint(HDC, const RECT *, BP_BUFFERFORMAT,
+                                       BP_PAINTPARAMS *,HDC *);
+HRESULT WINAPI EndBufferedPaint(HPAINTBUFFER, BOOL);
+HRESULT WINAPI BufferedPaintClear(HPAINTBUFFER, const RECT *);
+HRESULT WINAPI BufferedPaintSetAlpha(HPAINTBUFFER, const RECT *, BYTE);
+HRESULT WINAPI GetBufferedPaintBits(HPAINTBUFFER, RGBQUAD **, int *);
+HDC WINAPI GetBufferedPaintDC(HPAINTBUFFER);
+HDC WINAPI GetBufferedPaintTargetDC(HPAINTBUFFER);
+HRESULT WINAPI GetBufferedPaintTargetRect(HPAINTBUFFER, RECT *prc);
+HANIMATIONBUFFER WINAPI BeginBufferedAnimation(HWND, HDC, const RECT *,
+                                               BP_BUFFERFORMAT, BP_PAINTPARAMS *,
+                                               BP_ANIMATIONPARAMS *, HDC *, HDC *);
+BOOL WINAPI BufferedPaintRenderAnimation(HWND, HDC);
+HRESULT WINAPI BufferedPaintStopAllAnimations(HWND);
+HRESULT WINAPI EndBufferedAnimation(HANIMATIONBUFFER, BOOL);
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
## Purpose

Implement various uxtheme functions added in Vista or later - most are from WINE.

JIRA issue: None...? (how)

## TODO

#### Minutiae
- [x] Rename `uxtheme_nt6plus.spec` to `uxtheme_vista.spec`
- [x] Determine if changes to `buffer.c` are meaningful, gate behind `DLL_EXPORT_VERSION` if so
- [x] Remove stray line (no.636) in `system.c`
- [x] Double-check for stray commented junk

#### Big important stuff
- [x] Fix NT 5.2 builds
- [x] Fix MSVC hack in `buffer.c`

#### DarkFire come pick me up im scared
- [x] Find out what (if anything) is needed by way of tests
- KVM [x] https://reactos.org/testman/compare.php?ids=102434,102441
-  KVM x64 [x] https://reactos.org/testman/compare.php?ids=102434,102441