### PR TITLE
[RAPPS] Open parent folder if installing app is unable to open

### DIFF
--- a/base/applications/rapps/loaddlg.cpp
+++ b/base/applications/rapps/loaddlg.cpp
@@ -1003,12 +1003,10 @@ CDownloadManager::ThreadFunc(LPVOID param)
             if (bOpenParentFolder)
                 OpenPath.RemoveFileSpec(); // FIXME: Use "explore" verb if possible
 
-            SHELLEXECUTEINFOW shExInfo = {0};
-            shExInfo.cbSize = sizeof(shExInfo);
+            SHELLEXECUTEINFOW shExInfo = { sizeof(shExInfo) };
             shExInfo.fMask = SEE_MASK_NOCLOSEPROCESS;
             shExInfo.lpVerb = L"open";
             shExInfo.lpFile = OpenPath;
-            shExInfo.lpParameters = L"";
             shExInfo.nShow = SW_SHOW;
 
             /* FIXME: Do we want to log installer status? */

--- a/base/applications/rapps/loaddlg.cpp
+++ b/base/applications/rapps/loaddlg.cpp
@@ -983,7 +983,7 @@ CDownloadManager::ThreadFunc(LPVOID param)
         if (InfoArray[iAppId].DLType == DLTYPE_APPLICATION)
         {
             // FIXME: Unable to open ZIP/7Z/RAR files by ShellExecute.
-            //        Sorry but I use a workaround.
+            //        Sorry but I use a workaround by opening parent folder.
             static const LPCWSTR s_CanOpenDotExtsCurrently[] =
             {
                 L".exe", L".com", L".bat", L".reg", L".msi"

--- a/base/applications/rapps/loaddlg.cpp
+++ b/base/applications/rapps/loaddlg.cpp
@@ -982,9 +982,25 @@ CDownloadManager::ThreadFunc(LPVOID param)
         // run it
         if (InfoArray[iAppId].DLType == DLTYPE_APPLICATION)
         {
-            BOOL bZip = (lstrcmpiW(PathFindExtensionW(Path), L".zip") == 0);
+            // FIXME: Unable to open ZIP/7Z/RAR files by ShellExecute.
+            //        Sorry but I use a workaround.
+            static const LPCWSTR s_CanOpenDotExtsCurrently[] =
+            {
+                L".exe", L".com", L".bat", L".reg", L".msi"
+            };
+            LPCWSTR pszDotExt = PathFindExtensionW(Path);
+            BOOL bOpenParentFolder = FALSE;
+            for (auto dotext : s_CanOpenDotExtsCurrently)
+            {
+                if (lstrcmpiW(dotext, pszDotExt) == 0)
+                {
+                    bOpenParentFolder = TRUE;
+                    break;
+                }
+            }
+
             CPath OpenPath = Path;
-            if (bZip)
+            if (bOpenParentFolder)
                 OpenPath.RemoveFileSpec(); // FIXME: Use "explore" verb if possible
 
             SHELLEXECUTEINFOW shExInfo = {0};

--- a/base/applications/rapps/loaddlg.cpp
+++ b/base/applications/rapps/loaddlg.cpp
@@ -985,7 +985,7 @@ CDownloadManager::ThreadFunc(LPVOID param)
             BOOL bZip = (lstrcmpiW(PathFindExtensionW(Path), L".zip") == 0);
             CPath OpenPath = Path;
             if (bZip)
-                OpenPath.RemoveFileSpec();
+                OpenPath.RemoveFileSpec(); // FIXME: Use "explore" verb if possible
 
             SHELLEXECUTEINFOW shExInfo = {0};
             shExInfo.cbSize = sizeof(shExInfo);

--- a/base/applications/rapps/loaddlg.cpp
+++ b/base/applications/rapps/loaddlg.cpp
@@ -989,12 +989,12 @@ CDownloadManager::ThreadFunc(LPVOID param)
                 L".exe", L".com", L".bat", L".reg", L".msi"
             };
             LPCWSTR pszDotExt = PathFindExtensionW(Path);
-            BOOL bOpenParentFolder = FALSE;
+            BOOL bOpenParentFolder = TRUE;
             for (auto dotext : s_CanOpenDotExtsCurrently)
             {
                 if (lstrcmpiW(dotext, pszDotExt) == 0)
                 {
-                    bOpenParentFolder = TRUE;
+                    bOpenParentFolder = FALSE;
                     break;
                 }
             }

--- a/base/applications/rapps/loaddlg.cpp
+++ b/base/applications/rapps/loaddlg.cpp
@@ -982,11 +982,16 @@ CDownloadManager::ThreadFunc(LPVOID param)
         // run it
         if (InfoArray[iAppId].DLType == DLTYPE_APPLICATION)
         {
+            BOOL bZip = (lstrcmpiW(PathFindExtensionW(Path), L".zip") == 0);
+            CPath OpenPath = Path;
+            if (bZip)
+                OpenPath.RemoveFileSpec();
+
             SHELLEXECUTEINFOW shExInfo = {0};
             shExInfo.cbSize = sizeof(shExInfo);
             shExInfo.fMask = SEE_MASK_NOCLOSEPROCESS;
             shExInfo.lpVerb = L"open";
-            shExInfo.lpFile = Path;
+            shExInfo.lpFile = OpenPath;
             shExInfo.lpParameters = L"";
             shExInfo.nShow = SW_SHOW;
 


### PR DESCRIPTION
## Purpose

The ZIP shell extension won't work in opening the file item.
Add a workaround to installation of an application that is unable to open.

JIRA issue: [CORE-19490](https://jira.reactos.org/browse/CORE-19490)

## Proposed changes

- Open the parent folder if the installing app is a file unable to open, in the epilogue of installation process.

## TODO

- [x] Do tests.