### PR TITLE
[MSPAINT] Support JPEG/PNG/GIF/TIFF wallpapers

### DIFF
--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -642,20 +642,6 @@ LRESULT CMainWindow::OnClose(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHan
 
 void CMainWindow::ProcessFileMenu(HMENU hPopupMenu)
 {
-    LPCWSTR dotext = PathFindExtensionW(g_szFileName);
-    BOOL isBMP = FALSE;
-    if (_wcsicmp(dotext, L".bmp") == 0 ||
-        _wcsicmp(dotext, L".dib") == 0 ||
-        _wcsicmp(dotext, L".rle") == 0)
-    {
-        isBMP = TRUE;
-    }
-
-    UINT uWallpaperEnabled = ENABLED_IF(g_isAFile && isBMP && g_fileSize > 0);
-    ::EnableMenuItem(hPopupMenu, IDM_FILEASWALLPAPERPLANE,     uWallpaperEnabled);
-    ::EnableMenuItem(hPopupMenu, IDM_FILEASWALLPAPERCENTERED,  uWallpaperEnabled);
-    ::EnableMenuItem(hPopupMenu, IDM_FILEASWALLPAPERSTRETCHED, uWallpaperEnabled);
-
     for (INT iItem = 0; iItem < MAX_RECENT_FILES; ++iItem)
         RemoveMenu(hPopupMenu, IDM_FILE1 + iItem, MF_BYCOMMAND);
 

--- a/base/applications/mspaint/registry.cpp
+++ b/base/applications/mspaint/registry.cpp
@@ -38,14 +38,14 @@ static void ReadString(CRegKey &key, LPCWSTR lpName, CStringW &strValue, LPCWSTR
 
 void RegistrySettings::SetWallpaper(LPCWSTR szFileName, RegistrySettings::WallpaperStyle style)
 {
-    // Build the wallpaper path
+    // Build the BMP wallpaper path
     WCHAR szWallpaper[MAX_PATH];
     if (FAILED(SHGetFolderPathW(NULL, CSIDL_LOCAL_APPDATA | CSIDL_FLAG_CREATE, NULL, 0, szWallpaper)))
         return;
     if (FAILED(StringCchCatW(szWallpaper, _countof(szWallpaper), TEXT("\\Wallpaper1.bmp"))))
         return;
 
-    // Save to szWallpaper
+    // Save BMP to szWallpaper
     CImageDx img;
     HBITMAP hbmLocked = imageModel.LockBitmap();
     img.Attach(hbmLocked);

--- a/base/applications/mspaint/registry.cpp
+++ b/base/applications/mspaint/registry.cpp
@@ -55,7 +55,7 @@ void RegistrySettings::SetWallpaper(LPCWSTR szFileName, RegistrySettings::Wallpa
     if (FAILED(hr))
         return;
 
-    // Write to registry
+    // Write the wallpaper settings to the registry
     CRegKey desktop;
     if (desktop.Open(HKEY_CURRENT_USER, L"Control Panel\\Desktop") == ERROR_SUCCESS)
     {

--- a/base/applications/mspaint/registry.cpp
+++ b/base/applications/mspaint/registry.cpp
@@ -45,7 +45,7 @@ void RegistrySettings::SetWallpaper(LPCWSTR szFileName, RegistrySettings::Wallpa
     if (FAILED(StringCchCatW(szWallpaper, _countof(szWallpaper), TEXT("\\Wallpaper1.bmp"))))
         return;
 
-    // Save BMP to szWallpaper
+    // Save the converted wallpaper BMP
     CImageDx img;
     HBITMAP hbmLocked = imageModel.LockBitmap();
     img.Attach(hbmLocked);

--- a/base/applications/mspaint/registry.cpp
+++ b/base/applications/mspaint/registry.cpp
@@ -50,8 +50,8 @@ void RegistrySettings::SetWallpaper(LPCWSTR szFileName, RegistrySettings::Wallpa
     HBITMAP hbmLocked = imageModel.LockBitmap();
     img.Attach(hbmLocked);
     HRESULT hr = img.SaveDx(szWallpaper);
-    imageModel.UnlockBitmap(hbmLocked);
     img.Detach();
+    imageModel.UnlockBitmap(hbmLocked);
     if (FAILED(hr))
         return;
 

--- a/base/applications/mspaint/registry.cpp
+++ b/base/applications/mspaint/registry.cpp
@@ -52,7 +52,7 @@ void RegistrySettings::SetWallpaper(LPCWSTR szFileName, RegistrySettings::Wallpa
     CImageDx img;
     HBITMAP hbmLocked = imageModel.LockBitmap();
     img.Attach(hbmLocked);
-    HRESULT hr = img.SaveDx(szWallpaper);
+    hr = img.SaveDx(szWallpaper);
     img.Detach();
     imageModel.UnlockBitmap(hbmLocked);
     if (FAILED(hr))

--- a/base/applications/mspaint/registry.cpp
+++ b/base/applications/mspaint/registry.cpp
@@ -41,9 +41,11 @@ void RegistrySettings::SetWallpaper(LPCWSTR szFileName, RegistrySettings::Wallpa
     // Build the local path to the converted cached BMP wallpaper
     HRESULT hr;
     WCHAR szWallpaper[MAX_PATH];
-    if (FAILED(SHGetFolderPathW(NULL, CSIDL_LOCAL_APPDATA | CSIDL_FLAG_CREATE, NULL, 0, szWallpaper)))
+    hr = SHGetFolderPathW(NULL, CSIDL_LOCAL_APPDATA | CSIDL_FLAG_CREATE, NULL, 0, szWallpaper);
+    if (FAILED(hr))
         return;
-    if (FAILED(StringCchCatW(szWallpaper, _countof(szWallpaper), TEXT("\\Wallpaper1.bmp"))))
+    hr = StringCchCatW(szWallpaper, _countof(szWallpaper), TEXT("\\Wallpaper1.bmp"));
+    if (FAILED(hr))
         return;
 
     // Save the converted wallpaper BMP

--- a/base/applications/mspaint/registry.cpp
+++ b/base/applications/mspaint/registry.cpp
@@ -66,6 +66,7 @@ void RegistrySettings::SetWallpaper(LPCWSTR szFileName, RegistrySettings::Wallpa
         desktop.SetStringValue(L"OriginalWallpaper", szFileName);
     }
 
+    // Set desktop wallpaper
     SystemParametersInfoW(SPI_SETDESKWALLPAPER, 0, szWallpaper, SPIF_UPDATEINIFILE | SPIF_SENDCHANGE);
 }
 

--- a/base/applications/mspaint/registry.cpp
+++ b/base/applications/mspaint/registry.cpp
@@ -66,7 +66,7 @@ void RegistrySettings::SetWallpaper(LPCWSTR szFileName, RegistrySettings::Wallpa
         desktop.SetStringValue(L"OriginalWallpaper", szFileName);
     }
 
-    // Set desktop wallpaper
+    // Set the desktop wallpaper
     SystemParametersInfoW(SPI_SETDESKWALLPAPER, 0, szWallpaper, SPIF_UPDATEINIFILE | SPIF_SENDCHANGE);
 }
 

--- a/base/applications/mspaint/registry.cpp
+++ b/base/applications/mspaint/registry.cpp
@@ -39,6 +39,7 @@ static void ReadString(CRegKey &key, LPCWSTR lpName, CStringW &strValue, LPCWSTR
 void RegistrySettings::SetWallpaper(LPCWSTR szFileName, RegistrySettings::WallpaperStyle style)
 {
     // Build the local path to the converted cached BMP wallpaper
+    HRESULT hr;
     WCHAR szWallpaper[MAX_PATH];
     if (FAILED(SHGetFolderPathW(NULL, CSIDL_LOCAL_APPDATA | CSIDL_FLAG_CREATE, NULL, 0, szWallpaper)))
         return;

--- a/base/applications/mspaint/registry.cpp
+++ b/base/applications/mspaint/registry.cpp
@@ -38,7 +38,7 @@ static void ReadString(CRegKey &key, LPCWSTR lpName, CStringW &strValue, LPCWSTR
 
 void RegistrySettings::SetWallpaper(LPCWSTR szFileName, RegistrySettings::WallpaperStyle style)
 {
-    // Build the BMP wallpaper path
+    // Build the local path to the converted cached BMP wallpaper
     WCHAR szWallpaper[MAX_PATH];
     if (FAILED(SHGetFolderPathW(NULL, CSIDL_LOCAL_APPDATA | CSIDL_FLAG_CREATE, NULL, 0, szWallpaper)))
         return;


### PR DESCRIPTION
## Purpose
Improve usability.
JIRA issue: [CORE-19485](https://jira.reactos.org/browse/CORE-19485)

## Proposed changes

- Enable the menu items to set the wallpapars.
- Save the current bitmap as file `Wallpaper1.bmp` in `CSIDL_LOCAL_APPDATA` folder.
- Support JPEG/PNG/GIF/TIFF files in `RegistrySettings::SetWallpaper`.

## TODO

- [x] Do tests.

## Screenshots

Tested our AFTER `mspaint` on Win2k3:
![wallpaper](https://github.com/reactos/reactos/assets/2107452/ee88c11b-a95e-4621-8788-a493ad0d0aa8)