### PR TITLE
[NTOS:MM] Fix ntoskrnl/mm/ARM3/virtual.c causing intermittent BSOD 0x1a

### DIFF
--- a/ntoskrnl/mm/ARM3/virtual.c
+++ b/ntoskrnl/mm/ARM3/virtual.c
@@ -19,6 +19,38 @@
 #define MI_POOL_COPY_BYTES    512
 #define MI_MAX_TRANSFER_SIZE  64 * 1024
 
+#if _MI_PAGING_LEVELS == 2
+FORCEINLINE
+USHORT
+MiQueryPageTableReferences(IN PVOID Address)
+{
+    PUSHORT RefCount;
+
+    RefCount = &MmWorkingSetList->UsedPageTableEntries[MiGetPdeOffset(Address)];
+
+    return *RefCount;
+}
+#else
+FORCEINLINE
+USHORT
+MiQueryPageTableReferences(IN PVOID Address)
+{
+    PMMPDE PointerPde;
+    PMMPFN Pfn;
+
+    /* Make sure we're locked */
+    ASSERT((PsGetCurrentThread()->OwnsProcessWorkingSetExclusive) ||
+           (PsGetCurrentThread()->OwnsProcessWorkingSetShared));
+
+    PointerPde = MiAddressToPde(Address);
+    ASSERT(PointerPde->u.Hard.Valid);
+
+    /* This lies on the PFN */
+    Pfn = MiGetPfnEntry(PFN_FROM_PDE(PointerPde));
+    return Pfn->OriginalPte.u.Soft.UsedPageTableEntries;
+}
+#endif
+
 NTSTATUS NTAPI
 MiProtectVirtualMemory(IN PEPROCESS Process,
                        IN OUT PVOID *BaseAddress,
@@ -666,6 +698,7 @@ MiDeleteVirtualAddresses(IN ULONG_PTR Va,
             TempPte = *PointerPte;
             if (TempPte.u.Long)
             {
+                MiDecrementPageTableReferences((PVOID)Va);
                 /* Check if the PTE is actually mapped in */
                 if (MI_IS_MAPPED_PTE(&TempPte))
                 {
@@ -710,7 +743,7 @@ MiDeleteVirtualAddresses(IN ULONG_PTR Va,
                     /* The PTE was never mapped, just nuke it here */
                     MI_ERASE_PTE(PointerPte);
                 }
-
+#if 0
                 if (MiDecrementPageTableReferences((PVOID)Va) == 0)
                 {
                     ASSERT(PointerPde->u.Long != 0);
@@ -725,13 +758,30 @@ MiDeleteVirtualAddresses(IN ULONG_PTR Va,
                     PointerPte++;
                     break;
                 }
+#endif
             }
 
             /* Update the address and PTE for it */
             Va += PAGE_SIZE;
             PointerPte++;
             PrototypePte++;
-        } while ((Va & (PDE_MAPPED_VA - 1)) && (Va <= EndingAddress));
+
+            /* Making sure the PDE is still valid */
+            ASSERT(PointerPde->u.Hard.Valid == 1);
+        }
+        while ((Va & (PDE_MAPPED_VA - 1)) && (Va <= EndingAddress));
+
+        /* The PDE should still be valid at this point */
+        ASSERT(PointerPde->u.Hard.Valid == 1);
+
+        /* Check remaining PTE count (go back 1 page due to above loop) */
+        if (MiQueryPageTableReferences((PVOID)(Va - PAGE_SIZE)) == 0)
+        {
+            ASSERT(PointerPde->u.Long != 0);
+
+            /* Delete the PDE proper */
+            MiDeletePde(PointerPde, CurrentProcess);
+        }
 
         /* Release the lock */
         MiReleasePfnLock(OldIrql);


### PR DESCRIPTION
This was introduced by commit https://github.com/reactos/reactos/commit/c7e09061ca
So, this is basically just a revert of this commit. I did move a block of the reverted code from miarm.h to virtual.c.

## Purpose

_Fix intermittent BSOD 0x0000001a in mm/ARM3/virtual.c._

JIRA issue: [CORE-18190](https://jira.reactos.org/browse/CORE-18190)
JIRA issue: [CORE-18818](https://jira.reactos.org/browse/CORE-18818)
JIRA issue: [CORE-19253](https://jira.reactos.org/browse/CORE-19253)
and probably others.

## Proposed changes

_Mostly revert all of the referenced commit in two out of three files._
_One file is left unreverted (page.c). Combine changes in other two files into new virtual.c changes._
_There was a code block regarding ```__MI_PAGING_LEVELS``` in 'ntoskrnl\mm\ARM3\miarm.h'._
_These lines are what I moved into virtual.c now to keep all this related code together._
_I left a ```#if 0``` block that contains the problematic code in place but disabled._
_This was to allow a future fix of the BSOD 0x1a caused by this code to be fixed more easily._

_Summary: Restore and use MiQueryPageTableReferences._

Testbot results:
PR#66633 refs/pull/6633/merge on top of 0.4.15-dev-7786-gc5e6456

VBox: https://reactos.org/testman/compare.php?ids=94065,94069 LGTM
KVM:  https://reactos.org/testman/compare.php?ids=94064,94070 LGTM
