### PR TITLE
[SHELL32] Improve FindExecutableW

### DIFF
--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -1287,7 +1287,7 @@ HINSTANCE WINAPI FindExecutableW(LPCWSTR lpFile, LPCWSTR lpDirectory, LPWSTR lpR
         if (PathIsExeW(res) ||
             SUCCEEDED(AssocQueryStringW(ASSOCF_NONE, ASSOCSTR_EXECUTABLE, res, NULL, res, &cch)))
         {
-            StrCpyNW(lpResult, res, MAX_PATH);
+            StringCchCopyW(lpResult, MAX_PATH, res);
             retval = 42;
         }
         else

--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -1257,7 +1257,7 @@ HINSTANCE WINAPI FindExecutableA(LPCSTR lpFile, LPCSTR lpDirectory, LPSTR lpResu
 HINSTANCE WINAPI FindExecutableW(LPCWSTR lpFile, LPCWSTR lpDirectory, LPWSTR lpResult)
 {
     UINT_PTR retval;
-    WCHAR old_dir[1024], res[MAX_PATH];
+    WCHAR old_dir[MAX_PATH], res[MAX_PATH];
     DWORD cch = _countof(res);
     LPCWSTR dirs[2];
 

--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -1265,15 +1265,17 @@ HINSTANCE WINAPI FindExecutableW(LPCWSTR lpFile, LPCWSTR lpDirectory, LPWSTR lpR
 
     *lpResult = UNICODE_NULL;
 
-    dirs[0] = lpDirectory;
-
     GetCurrentDirectoryW(_countof(old_dir), old_dir);
 
     if (lpDirectory && *lpDirectory)
+    {
         SetCurrentDirectoryW(lpDirectory);
+        dirs[0] = lpDirectory;
+    }
     else
+    {
         dirs[0] = old_dir;
-
+    }
     dirs[1] = NULL;
 
     if (!GetShortPathNameW(lpFile, res, _countof(res)))
@@ -1281,8 +1283,9 @@ HINSTANCE WINAPI FindExecutableW(LPCWSTR lpFile, LPCWSTR lpDirectory, LPWSTR lpR
 
     if (PathResolveW(res, dirs, PRF_TRYPROGRAMEXTENSIONS))
     {
+        // NOTE: The last parameter of this AssocQueryStringW call is "strange" in Windows.
         if (PathIsExeW(res) ||
-            SUCCEEDED(AssocQueryStringW(0, ASSOCSTR_EXECUTABLE, res, NULL, res, &cch)))
+            SUCCEEDED(AssocQueryStringW(ASSOCF_NONE, ASSOCSTR_EXECUTABLE, res, NULL, res, &cch)))
         {
             StrCpyNW(lpResult, res, MAX_PATH);
         }
@@ -2569,7 +2572,7 @@ HRESULT WINAPI ShellExecCmdLine(
     if (dwSeclFlags & SECL_RUNAS)
     {
         dwSize = 0;
-        hr = AssocQueryStringW(0, ASSOCSTR_COMMAND, lpCommand, L"RunAs", NULL, &dwSize);
+        hr = AssocQueryStringW(ASSOCF_NONE, ASSOCSTR_COMMAND, lpCommand, L"RunAs", NULL, &dwSize);
         if (SUCCEEDED(hr) && dwSize != 0)
         {
             pszVerb = L"runas";

--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -1256,7 +1256,7 @@ HINSTANCE WINAPI FindExecutableA(LPCSTR lpFile, LPCSTR lpDirectory, LPSTR lpResu
  */
 HINSTANCE WINAPI FindExecutableW(LPCWSTR lpFile, LPCWSTR lpDirectory, LPWSTR lpResult)
 {
-    UINT_PTR retval = 42;
+    UINT_PTR retval;
     WCHAR old_dir[1024], res[MAX_PATH];
     DWORD cch = _countof(res);
     LPCWSTR dirs[2];
@@ -1288,6 +1288,7 @@ HINSTANCE WINAPI FindExecutableW(LPCWSTR lpFile, LPCWSTR lpDirectory, LPWSTR lpR
             SUCCEEDED(AssocQueryStringW(ASSOCF_NONE, ASSOCSTR_EXECUTABLE, res, NULL, res, &cch)))
         {
             StrCpyNW(lpResult, res, MAX_PATH);
+            retval = 42;
         }
         else
         {

--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -1279,7 +1279,7 @@ HINSTANCE WINAPI FindExecutableW(LPCWSTR lpFile, LPCWSTR lpDirectory, LPWSTR lpR
     dirs[1] = NULL;
 
     if (!GetShortPathNameW(lpFile, res, _countof(res)))
-        lstrcpynW(res, lpFile, _countof(res));
+        StringCchCopyW(res, _countof(res), lpFile);
 
     if (PathResolveW(res, dirs, PRF_TRYPROGRAMEXTENSIONS))
     {


### PR DESCRIPTION
## Purpose
Follow-up to #6656. An approach to implement `ShellExecuteEx` correctly.
JIRA issue: [CORE-19493](https://jira.reactos.org/browse/CORE-19493)

## Proposed changes

- Rewrite code by using `AssocQueryStringW` and `PathResolveW` functions.

## TODO

- [x] Do small tests.
- [x] Do big tests.

## Comparison


Win2k3:
![Win2k3](https://github.com/reactos/reactos/assets/2107452/42df76e1-26cb-4454-8cbc-e1a66c9ed289)
Successful.

BEFORE:
![before](https://github.com/reactos/reactos/assets/2107452/b3627d1f-6f7d-4e76-b71b-8f21bb23c8d6)
81 failures.

AFTER:
![after](https://github.com/reactos/reactos/assets/2107452/70591cf2-afa0-477b-9a04-beaae00cf01e)
Reduced down to 4 failures. LGTM.