### PR TITLE
[SHLWAPI] SHLWAPI_DEF_ASSOCF: Add ASSOCF_INIT_NOREMAPCLSID

### DIFF
--- a/dll/win32/shlwapi/assoc.c
+++ b/dll/win32/shlwapi/assoc.c
@@ -38,8 +38,13 @@
 WINE_DEFAULT_DEBUG_CHANNEL(shell);
 
 /* Default IQueryAssociations::Init() flags */
+#ifdef __REACTOS__
+#define SHLWAPI_DEF_ASSOCF (ASSOCF_INIT_BYEXENAME | ASSOCF_INIT_DEFAULTTOSTAR | \
+                            ASSOCF_INIT_DEFAULTTOFOLDER | ASSOCF_INIT_NOREMAPCLSID)
+#else
 #define SHLWAPI_DEF_ASSOCF (ASSOCF_INIT_BYEXENAME|ASSOCF_INIT_DEFAULTTOSTAR| \
                             ASSOCF_INIT_DEFAULTTOFOLDER)
+#endif
 
 /*************************************************************************
  * SHLWAPI_ParamAToW


### PR DESCRIPTION
## Purpose
Step up to correct `shell32!FindExecutable`.
JIRA issue: [CORE-19493](https://jira.reactos.org/browse/CORE-19493)

## Proposed changes

- Add `ASSOCF_INIT_NOREMAPCLSID` flag to `SHLWAPI_DEF_ASSOCF` flags.