### PR TITLE
[CRT] intrin_x86.h: Use movsl instead of movsd to fix a GCC 13 warning

### DIFF
--- a/sdk/include/crt/mingw32/intrin_x86.h
+++ b/sdk/include/crt/mingw32/intrin_x86.h
@@ -833,7 +833,7 @@ __INTRIN_INLINE void __movsd(unsigned long * Destination, const unsigned long * 
 {
 	__asm__ __volatile__
 	(
-		"rep; movsd" :
+		"rep; movsl" :
 		[Destination] "=D" (Destination), [Source] "=S" (Source), [Count] "=c" (Count) :
 		"[Destination]" (Destination), "[Source]" (Source), "[Count]" (Count)
 	);


### PR DESCRIPTION
## Purpose

Fix a warning with GCC 13
