### PR TITLE
[NTOS:EX] Fix a loop bug

### DIFF
--- a/ntoskrnl/inbv/inbv.c
+++ b/ntoskrnl/inbv/inbv.c
@@ -109,8 +109,9 @@ FindBitmapResource(
 
     /* Loop the driver list */
     ListHead = &LoaderBlock->LoadOrderListHead;
-    NextEntry = ListHead->Flink;
-    while (NextEntry != ListHead)
+    for (NextEntry = ListHead->Flink;
+         NextEntry != ListHead;
+         NextEntry = NextEntry->Flink)
     {
         /* Get the entry */
         LdrEntry = CONTAINING_RECORD(NextEntry,


### PR DESCRIPTION
## Purpose

Fix an infinite loop. This only works currently, because ntoskrnl is the first module.