### PR TITLE
[DBGHELP] Remove useless broken CMake defines

### DIFF
--- a/dll/win32/dbghelp/CMakeLists.txt
+++ b/dll/win32/dbghelp/CMakeLists.txt
@@ -31,10 +31,6 @@ else()
         -DHAVE_ALLOCA_H
         -D_IMAGEHLP_SOURCE_)
 
-    if(ARCH STREQUAL "amd64")
-        add_definitions(-DUNW_FLAG_NHANDLER=0 -DUNW_FLAG_EHANDLER=1 -DUNW_FLAG_UHANDLER=2 -DUNW_FLAG_CHAININFO=3)
-    endif()
-
     include_directories(
         BEFORE ${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 


### PR DESCRIPTION
## Purpose

Remove some defines that are not needed, because they are defined in winnt.h. One was also wrong. Fixes compiler warnings.