### PR TITLE
[EXPLORER][SHELL32] Smaller Start Menu

### DIFF
--- a/base/shell/explorer/precomp.h
+++ b/base/shell/explorer/precomp.h
@@ -205,6 +205,7 @@ typedef struct _TW_STUCKRECTS2
             DWORD AlwaysOnTop : 1;
             DWORD SmallIcons : 1;
             DWORD HideClock : 1;
+            DWORD SmallStartMenu : 1;
         };
     };
     DWORD Position;

--- a/base/shell/explorer/resource.h
+++ b/base/shell/explorer/resource.h
@@ -116,6 +116,7 @@
 #define IDS_ADVANCED_EXPAND_NET_CONNECTIONS         30473
 #define IDS_ADVANCED_DISPLAY_RUN                    30474
 #define IDS_ADVANCED_DISPLAY_ADMINTOOLS             30476
+#define IDS_ADVANCED_SMALL_START_MENU               30477
 
 /*******************************************************************************\
 |*                              Control Resources                              *|

--- a/base/shell/explorer/settings.cpp
+++ b/base/shell/explorer/settings.cpp
@@ -82,6 +82,7 @@ BOOL TaskbarSettings::Load()
         sr.AlwaysOnTop = TRUE;
         sr.SmallIcons = TRUE;
         sr.HideClock = FALSE;
+        sr.SmallStartMenu = FALSE;
         sr.Rect.left = sr.Rect.top = 0;
         sr.Rect.bottom = sr.Rect.right = 1;
         sr.Size.cx = sr.Size.cy = 0;

--- a/base/shell/explorer/startmnu.cpp
+++ b/base/shell/explorer/startmnu.cpp
@@ -97,9 +97,7 @@ CreateStartMenu(IN ITrayWindow *Tray,
     if (FAILED_UNEXPECTEDLY(hr))
         return NULL;
 
-    UpdateStartMenu(pMp,
-                    hbmBanner,
-                    bSmallIcons);
+    UpdateStartMenu(pMp, hbmBanner, bSmallIcons);
 
     *ppMenuBand = pMb.Detach();
 

--- a/base/shell/explorer/startmnucust.cpp
+++ b/base/shell/explorer/startmnucust.cpp
@@ -227,37 +227,30 @@ INT_PTR CALLBACK CustomizeClassicProc(HWND hwnd, UINT Message, WPARAM wParam, LP
         case WM_INITDIALOG:
             CustomizeClassic_OnInitDialog(hwnd);
             return TRUE;
-
         case WM_COMMAND:
             switch (LOWORD(wParam))
             {
                 case IDC_CLASSICSTART_ADD:
                     OnAddStartMenuItems(hwnd);
                     break;
-
                 case IDC_CLASSICSTART_REMOVE:
                     OnRemoveStartmenuItems(hwnd);
                     break;
-
                 case IDC_CLASSICSTART_ADVANCED:
                     OnAdvancedStartMenuItems();
                     break;
-
                 case IDC_CLASSICSTART_CLEAR:
                     OnClearRecentItems(hwnd);
                     break;
-
                 case IDOK:
                     if (CustomizeClassic_OnOK(hwnd))
                         EndDialog(hwnd, IDOK);
                     break;
-
                 case IDCANCEL:
                     EndDialog(hwnd, IDCANCEL);
                     break;
             }
             break;
-
         default:
             break;
     }

--- a/base/shell/explorer/startmnucust.cpp
+++ b/base/shell/explorer/startmnucust.cpp
@@ -9,7 +9,7 @@
 
 #include "precomp.h"
 
-// TreeView checkbox state index (Use with INDEXTOSTATEIMAGEMASK macro)
+// TreeView checkbox state indexes (Use with INDEXTOSTATEIMAGEMASK macro)
 #define I_UNCHECKED 1
 #define I_CHECKED   2
 

--- a/base/shell/explorer/startmnucust.cpp
+++ b/base/shell/explorer/startmnucust.cpp
@@ -76,8 +76,8 @@ static VOID OnClearRecentItems(HWND hwnd)
 }
 
 struct CUSTOMIZE_ENTRY;
-typedef DWORD (CALLBACK *FN_CUSTOMIZE_READ)(const CUSTOMIZE_ENTRY *entry);
-typedef BOOL (CALLBACK *FN_CUSTOMIZE_WRITE)(const CUSTOMIZE_ENTRY *entry, DWORD dwValue);
+typedef BOOL (CALLBACK *FN_CUSTOMIZE_READ)(const CUSTOMIZE_ENTRY *entry);
+typedef VOID (CALLBACK *FN_CUSTOMIZE_WRITE)(const CUSTOMIZE_ENTRY *entry, BOOL bValue);
 
 struct CUSTOMIZE_ENTRY
 {
@@ -89,25 +89,24 @@ struct CUSTOMIZE_ENTRY
     RESTRICTIONS policy1, policy2;
 };
 
-static DWORD CALLBACK CustomizeAdvancedRead(const CUSTOMIZE_ENTRY *entry)
+static BOOL CALLBACK CustomizeAdvancedRead(const CUSTOMIZE_ENTRY *entry)
 {
     return GetAdvancedBool(entry->name, entry->bDefaultValue);
 }
 
-static BOOL CALLBACK CustomizeAdvancedWrite(const CUSTOMIZE_ENTRY *entry, DWORD dwValue)
+static VOID CALLBACK CustomizeAdvancedWrite(const CUSTOMIZE_ENTRY *entry, BOOL bValue)
 {
-    return SetAdvancedDword(entry->name, dwValue);
+    SetAdvancedDword(entry->name, bValue);
 }
 
-static DWORD CALLBACK CustomizeSmallIconsRead(const CUSTOMIZE_ENTRY *entry)
+static BOOL CALLBACK CustomizeSmallIconsRead(const CUSTOMIZE_ENTRY *entry)
 {
     return g_TaskbarSettings.sr.SmallStartMenu;
 }
 
-static BOOL CALLBACK CustomizeSmallIconsWrite(const CUSTOMIZE_ENTRY *entry, DWORD dwValue)
+static VOID CALLBACK CustomizeSmallIconsWrite(const CUSTOMIZE_ENTRY *entry, BOOL bValue)
 {
-    g_TaskbarSettings.sr.SmallStartMenu = dwValue;
-    return TRUE;
+    g_TaskbarSettings.sr.SmallStartMenu = bValue;
 }
 
 static const CUSTOMIZE_ENTRY s_CustomizeEntries[] =

--- a/base/shell/explorer/startmnucust.cpp
+++ b/base/shell/explorer/startmnucust.cpp
@@ -118,27 +118,27 @@ static const CUSTOMIZE_ENTRY s_CustomizeEntries[] =
     {
         IDS_ADVANCED_DISPLAY_FAVORITES, L"StartMenuFavorites", FALSE,
         CustomizeAdvancedRead, CustomizeAdvancedWrite,
-        REST_NOFAVORITESMENU
+        REST_NOFAVORITESMENU,
     },
     {
         IDS_ADVANCED_DISPLAY_LOG_OFF, L"StartMenuLogoff", FALSE,
         CustomizeAdvancedRead, CustomizeAdvancedWrite,
-        REST_STARTMENULOGOFF
+        REST_STARTMENULOGOFF,
     },
     {
         IDS_ADVANCED_DISPLAY_RUN, L"StartMenuRun", TRUE,
         CustomizeAdvancedRead, CustomizeAdvancedWrite,
-        REST_NORUN
+        REST_NORUN,
     },
     {
         IDS_ADVANCED_EXPAND_MY_DOCUMENTS, L"CascadeMyDocuments", FALSE,
         CustomizeAdvancedRead, CustomizeAdvancedWrite,
-        REST_NOSMMYDOCS
+        REST_NOSMMYDOCS,
     },
     {
         IDS_ADVANCED_EXPAND_MY_PICTURES, L"CascadeMyPictures", FALSE,
         CustomizeAdvancedRead, CustomizeAdvancedWrite,
-        REST_NOSMMYPICS
+        REST_NOSMMYPICS,
     },
     {
         IDS_ADVANCED_EXPAND_CONTROL_PANEL, L"CascadeControlPanel", FALSE,
@@ -148,12 +148,12 @@ static const CUSTOMIZE_ENTRY s_CustomizeEntries[] =
     {
         IDS_ADVANCED_EXPAND_PRINTERS, L"CascadePrinters", FALSE,
         CustomizeAdvancedRead, CustomizeAdvancedWrite,
-        REST_NOSETFOLDERS
+        REST_NOSETFOLDERS,
     },
     {
         IDS_ADVANCED_EXPAND_NET_CONNECTIONS, L"CascadeNetworkConnections", FALSE,
         CustomizeAdvancedRead, CustomizeAdvancedWrite,
-        REST_NOSETFOLDERS, REST_NONETWORKCONNECTIONS
+        REST_NOSETFOLDERS, REST_NONETWORKCONNECTIONS,
     },
     {
         IDS_ADVANCED_SMALL_START_MENU, NULL, FALSE,

--- a/base/shell/explorer/startmnucust.cpp
+++ b/base/shell/explorer/startmnucust.cpp
@@ -75,94 +75,94 @@ static VOID OnClearRecentItems(HWND hwnd)
     EnableWindow(GetDlgItem(hwnd, IDC_CLASSICSTART_CLEAR), RecentHasShortcut(hwnd));
 }
 
-struct CUSTOMIZE_ENTRY;
+struct CUSTOM_ENTRY;
 
-typedef BOOL (CALLBACK *FN_GET_VALUE)(const CUSTOMIZE_ENTRY *entry);
-typedef VOID (CALLBACK *FN_SET_VALUE)(const CUSTOMIZE_ENTRY *entry, BOOL bValue);
+typedef BOOL (CALLBACK *FN_CUSTOM_GET)(const CUSTOM_ENTRY *entry);
+typedef VOID (CALLBACK *FN_CUSTOM_SET)(const CUSTOM_ENTRY *entry, BOOL bValue);
 
-struct CUSTOMIZE_ENTRY
+struct CUSTOM_ENTRY
 {
     LPARAM id;
     LPCWSTR name;
     BOOL bDefaultValue;
-    FN_GET_VALUE fnGetValue;
-    FN_SET_VALUE fnSetValue;
+    FN_CUSTOM_GET fnGetValue;
+    FN_CUSTOM_SET fnSetValue;
     RESTRICTIONS policy1, policy2;
 };
 
-static BOOL CALLBACK GetAdvanced(const CUSTOMIZE_ENTRY *entry)
+static BOOL CALLBACK CustomGetAdvanced(const CUSTOM_ENTRY *entry)
 {
     return GetAdvancedBool(entry->name, entry->bDefaultValue);
 }
 
-static VOID CALLBACK SetAdvanced(const CUSTOMIZE_ENTRY *entry, BOOL bValue)
+static VOID CALLBACK CustomSetAdvanced(const CUSTOM_ENTRY *entry, BOOL bValue)
 {
     SetAdvancedDword(entry->name, bValue);
 }
 
-static BOOL CALLBACK GetSmallStartMenu(const CUSTOMIZE_ENTRY *entry)
+static BOOL CALLBACK CustomGetSmallStartMenu(const CUSTOM_ENTRY *entry)
 {
     return g_TaskbarSettings.sr.SmallStartMenu;
 }
 
-static VOID CALLBACK SetSmallStartMenu(const CUSTOMIZE_ENTRY *entry, BOOL bValue)
+static VOID CALLBACK CustomSetSmallStartMenu(const CUSTOM_ENTRY *entry, BOOL bValue)
 {
     g_TaskbarSettings.sr.SmallStartMenu = bValue;
 }
 
-static const CUSTOMIZE_ENTRY s_CustomizeEntries[] =
+static const CUSTOM_ENTRY s_CustomEntries[] =
 {
     {
         IDS_ADVANCED_DISPLAY_ADMINTOOLS, L"StartMenuAdminTools", TRUE,
-        GetAdvanced, SetAdvanced,
+        CustomGetAdvanced, CustomSetAdvanced,
     },
     {
         IDS_ADVANCED_DISPLAY_FAVORITES, L"StartMenuFavorites", FALSE,
-        GetAdvanced, SetAdvanced,
+        CustomGetAdvanced, CustomSetAdvanced,
         REST_NOFAVORITESMENU,
     },
     {
         IDS_ADVANCED_DISPLAY_LOG_OFF, L"StartMenuLogoff", FALSE,
-        GetAdvanced, SetAdvanced,
+        CustomGetAdvanced, CustomSetAdvanced,
         REST_STARTMENULOGOFF,
     },
     {
         IDS_ADVANCED_DISPLAY_RUN, L"StartMenuRun", TRUE,
-        GetAdvanced, SetAdvanced,
+        CustomGetAdvanced, CustomSetAdvanced,
         REST_NORUN,
     },
     {
         IDS_ADVANCED_EXPAND_MY_DOCUMENTS, L"CascadeMyDocuments", FALSE,
-        GetAdvanced, SetAdvanced,
+        CustomGetAdvanced, CustomSetAdvanced,
         REST_NOSMMYDOCS,
     },
     {
         IDS_ADVANCED_EXPAND_MY_PICTURES, L"CascadeMyPictures", FALSE,
-        GetAdvanced, SetAdvanced,
+        CustomGetAdvanced, CustomSetAdvanced,
         REST_NOSMMYPICS,
     },
     {
         IDS_ADVANCED_EXPAND_CONTROL_PANEL, L"CascadeControlPanel", FALSE,
-        GetAdvanced, SetAdvanced,
+        CustomGetAdvanced, CustomSetAdvanced,
         REST_NOSETFOLDERS, REST_NOCONTROLPANEL,
     },
     {
         IDS_ADVANCED_EXPAND_PRINTERS, L"CascadePrinters", FALSE,
-        GetAdvanced, SetAdvanced,
+        CustomGetAdvanced, CustomSetAdvanced,
         REST_NOSETFOLDERS,
     },
     {
         IDS_ADVANCED_EXPAND_NET_CONNECTIONS, L"CascadeNetworkConnections", FALSE,
-        GetAdvanced, SetAdvanced,
+        CustomGetAdvanced, CustomSetAdvanced,
         REST_NOSETFOLDERS, REST_NONETWORKCONNECTIONS,
     },
     {
         IDS_ADVANCED_SMALL_START_MENU, NULL, FALSE,
-        GetSmallStartMenu, SetSmallStartMenu,
+        CustomGetSmallStartMenu, CustomSetSmallStartMenu,
     },
 };
 
-static VOID AddCustomizeItem(HWND hTreeView, const CUSTOMIZE_ENTRY *entry)
+static VOID AddCustomItem(HWND hTreeView, const CUSTOM_ENTRY *entry)
 {
     if (SHRestricted(entry->policy1) || SHRestricted(entry->policy2))
     {
@@ -193,9 +193,9 @@ static void CustomizeClassic_OnInitDialog(HWND hwnd)
     DWORD_PTR style = GetWindowLongPtrW(hTreeView, GWL_STYLE);
     SetWindowLongPtrW(hTreeView, GWL_STYLE, style | TVS_CHECKBOXES);
 
-    for (auto& entry : s_CustomizeEntries)
+    for (auto& entry : s_CustomEntries)
     {
-        AddCustomizeItem(hTreeView, &entry);
+        AddCustomItem(hTreeView, &entry);
     }
 }
 
@@ -213,7 +213,7 @@ static BOOL CustomizeClassic_OnOK(HWND hwnd)
         TreeView_GetItem(hTreeView, &item);
 
         BOOL bChecked = !!(item.state & INDEXTOSTATEIMAGEMASK(I_CHECKED));
-        for (auto& entry : s_CustomizeEntries)
+        for (auto& entry : s_CustomEntries)
         {
             if (SHRestricted(entry.policy1) || SHRestricted(entry.policy2))
                 continue;

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -2555,9 +2555,7 @@ ChangePos:
 
         /* Create and initialize the start menu */
         BOOL bSmallStartMenu = g_TaskbarSettings.sr.SmallStartMenu;
-        HBITMAP hbmBanner = NULL;
-        if (!bSmallStartMenu)
-            hbmBanner = LoadBitmapW(hExplorerInstance, MAKEINTRESOURCEW(IDB_STARTMENU));
+        HBITMAP hbmBanner = LoadBitmapW(hExplorerInstance, MAKEINTRESOURCEW(IDB_STARTMENU));
         m_StartMenuPopup = CreateStartMenu(this, &m_StartMenuBand, hbmBanner, bSmallStartMenu);
 
         /* Create the task band */
@@ -2668,9 +2666,7 @@ ChangePos:
             m_StartMenuBand.Release();
 
             BOOL bSmallStartMenu = g_TaskbarSettings.sr.SmallStartMenu;
-            HBITMAP hbmBanner = NULL;
-            if (!bSmallStartMenu)
-                hbmBanner = LoadBitmapW(hExplorerInstance, MAKEINTRESOURCEW(IDB_STARTMENU));
+            HBITMAP hbmBanner = LoadBitmapW(hExplorerInstance, MAKEINTRESOURCEW(IDB_STARTMENU));
             m_StartMenuPopup = CreateStartMenu(this, &m_StartMenuBand, hbmBanner, bSmallStartMenu);
         }
 

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -2554,8 +2554,11 @@ ChangePos:
         RegLoadSettings();
 
         /* Create and initialize the start menu */
-        HBITMAP hbmBanner = LoadBitmapW(hExplorerInstance, MAKEINTRESOURCEW(IDB_STARTMENU));
-        m_StartMenuPopup = CreateStartMenu(this, &m_StartMenuBand, hbmBanner, 0);
+        BOOL bSmallStartMenu = g_TaskbarSettings.sr.SmallStartMenu;
+        HBITMAP hbmBanner = NULL;
+        if (!bSmallStartMenu)
+            hbmBanner = LoadBitmapW(hExplorerInstance, MAKEINTRESOURCEW(IDB_STARTMENU));
+        m_StartMenuPopup = CreateStartMenu(this, &m_StartMenuBand, hbmBanner, bSmallStartMenu);
 
         /* Create the task band */
         hRet = CTaskBand_CreateInstance(this, m_StartButton.m_hWnd, IID_PPV_ARG(IDeskBand, &m_TaskBand));
@@ -2663,8 +2666,12 @@ ChangePos:
             /* Re-create the start menu */
             HideStartMenu();
             m_StartMenuBand.Release();
-            HBITMAP hbmBanner = LoadBitmapW(hExplorerInstance, MAKEINTRESOURCEW(IDB_STARTMENU));
-            m_StartMenuPopup = CreateStartMenu(this, &m_StartMenuBand, hbmBanner, FALSE);
+
+            BOOL bSmallStartMenu = g_TaskbarSettings.sr.SmallStartMenu;
+            HBITMAP hbmBanner = NULL;
+            if (!bSmallStartMenu)
+                hbmBanner = LoadBitmapW(hExplorerInstance, MAKEINTRESOURCEW(IDB_STARTMENU));
+            m_StartMenuPopup = CreateStartMenu(this, &m_StartMenuBand, hbmBanner, bSmallStartMenu);
         }
 
         return 0;

--- a/dll/win32/shell32/lang/bg-BG.rc
+++ b/dll/win32/shell32/lang/bg-BG.rc
@@ -1021,6 +1021,7 @@ BEGIN
     IDS_ADVANCED_EXPAND_NET_CONNECTIONS "Expand Network Connections"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
+    IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
     IDS_NEWEXT_ADVANCED_LEFT "<< Ad&vanced"
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"

--- a/dll/win32/shell32/lang/ca-ES.rc
+++ b/dll/win32/shell32/lang/ca-ES.rc
@@ -1021,6 +1021,7 @@ BEGIN
     IDS_ADVANCED_EXPAND_NET_CONNECTIONS "Expand Network Connections"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
+    IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
     IDS_NEWEXT_ADVANCED_LEFT "<< Ad&vanced"
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"

--- a/dll/win32/shell32/lang/cs-CZ.rc
+++ b/dll/win32/shell32/lang/cs-CZ.rc
@@ -1029,6 +1029,7 @@ BEGIN
     IDS_ADVANCED_EXPAND_NET_CONNECTIONS "Expand Network Connections"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
+    IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
     IDS_NEWEXT_ADVANCED_LEFT "<< Ad&vanced"
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"

--- a/dll/win32/shell32/lang/da-DK.rc
+++ b/dll/win32/shell32/lang/da-DK.rc
@@ -1028,6 +1028,7 @@ BEGIN
     IDS_ADVANCED_EXPAND_NET_CONNECTIONS "Expand Network Connections"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
+    IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
     IDS_NEWEXT_ADVANCED_LEFT "<< Ad&vanced"
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"

--- a/dll/win32/shell32/lang/de-DE.rc
+++ b/dll/win32/shell32/lang/de-DE.rc
@@ -1022,6 +1022,7 @@ BEGIN
     IDS_ADVANCED_EXPAND_NET_CONNECTIONS "Expand Network Connections"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
+    IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
     IDS_NEWEXT_ADVANCED_LEFT "<< Er&weitert"
     IDS_NEWEXT_ADVANCED_RIGHT "&Erweitert >>"

--- a/dll/win32/shell32/lang/de-DE.rc
+++ b/dll/win32/shell32/lang/de-DE.rc
@@ -1022,7 +1022,7 @@ BEGIN
     IDS_ADVANCED_EXPAND_NET_CONNECTIONS "Expand Network Connections"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
-    IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
+    IDS_ADVANCED_SMALL_START_MENU "Kleine Symbole im Startmenü anzeigen"
 
     IDS_NEWEXT_ADVANCED_LEFT "<< Er&weitert"
     IDS_NEWEXT_ADVANCED_RIGHT "&Erweitert >>"

--- a/dll/win32/shell32/lang/el-GR.rc
+++ b/dll/win32/shell32/lang/el-GR.rc
@@ -1021,6 +1021,7 @@ BEGIN
     IDS_ADVANCED_EXPAND_NET_CONNECTIONS "Expand Network Connections"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
+    IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
     IDS_NEWEXT_ADVANCED_LEFT "<< Ad&vanced"
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"

--- a/dll/win32/shell32/lang/en-GB.rc
+++ b/dll/win32/shell32/lang/en-GB.rc
@@ -1021,6 +1021,7 @@ BEGIN
     IDS_ADVANCED_EXPAND_NET_CONNECTIONS "Expand Network Connections"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
+    IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
     IDS_NEWEXT_ADVANCED_LEFT "<< Ad&vanced"
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"

--- a/dll/win32/shell32/lang/en-US.rc
+++ b/dll/win32/shell32/lang/en-US.rc
@@ -1021,6 +1021,7 @@ BEGIN
     IDS_ADVANCED_EXPAND_NET_CONNECTIONS "Expand Network Connections"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
+    IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
     IDS_NEWEXT_ADVANCED_LEFT "<< Ad&vanced"
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"

--- a/dll/win32/shell32/lang/es-ES.rc
+++ b/dll/win32/shell32/lang/es-ES.rc
@@ -1030,6 +1030,7 @@ BEGIN
     IDS_ADVANCED_EXPAND_NET_CONNECTIONS "Expand Network Connections"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
+    IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
     IDS_NEWEXT_ADVANCED_LEFT "<< A&vanzado"
     IDS_NEWEXT_ADVANCED_RIGHT "A&vanzado >>"

--- a/dll/win32/shell32/lang/et-EE.rc
+++ b/dll/win32/shell32/lang/et-EE.rc
@@ -1028,6 +1028,7 @@ BEGIN
     IDS_ADVANCED_EXPAND_NET_CONNECTIONS "Expand Network Connections"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
+    IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
     IDS_NEWEXT_ADVANCED_LEFT "<< T&äpsemalt"
     IDS_NEWEXT_ADVANCED_RIGHT "Tä&psemalt >>"

--- a/dll/win32/shell32/lang/eu-ES.rc
+++ b/dll/win32/shell32/lang/eu-ES.rc
@@ -1026,6 +1026,7 @@ BEGIN
     IDS_ADVANCED_EXPAND_NET_CONNECTIONS "Expand Network Connections"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
+    IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
     IDS_NEWEXT_ADVANCED_LEFT "<< &Aurreratua"
     IDS_NEWEXT_ADVANCED_RIGHT "&Aurreratua >>"

--- a/dll/win32/shell32/lang/fi-FI.rc
+++ b/dll/win32/shell32/lang/fi-FI.rc
@@ -1021,6 +1021,7 @@ BEGIN
     IDS_ADVANCED_EXPAND_NET_CONNECTIONS "Expand Network Connections"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
+    IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
     IDS_NEWEXT_ADVANCED_LEFT "<< Ad&vanced"
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"

--- a/dll/win32/shell32/lang/fr-FR.rc
+++ b/dll/win32/shell32/lang/fr-FR.rc
@@ -1021,6 +1021,7 @@ BEGIN
     IDS_ADVANCED_EXPAND_NET_CONNECTIONS "Expand Network Connections"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
+    IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
     IDS_NEWEXT_ADVANCED_LEFT "<< Avancé"
     IDS_NEWEXT_ADVANCED_RIGHT "Avancé >>"

--- a/dll/win32/shell32/lang/he-IL.rc
+++ b/dll/win32/shell32/lang/he-IL.rc
@@ -1028,6 +1028,7 @@ BEGIN
     IDS_ADVANCED_EXPAND_NET_CONNECTIONS "Expand Network Connections"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
+    IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
     IDS_NEWEXT_ADVANCED_LEFT "<< &מתקדם"
     IDS_NEWEXT_ADVANCED_RIGHT "&מתקדם >>"

--- a/dll/win32/shell32/lang/hi-IN.rc
+++ b/dll/win32/shell32/lang/hi-IN.rc
@@ -1023,6 +1023,7 @@ BEGIN
     IDS_ADVANCED_EXPAND_NET_CONNECTIONS "Expand Network Connections"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
+    IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
     IDS_NEWEXT_ADVANCED_LEFT "<< &उन्नत"
     IDS_NEWEXT_ADVANCED_RIGHT "&उन्नत >>"

--- a/dll/win32/shell32/lang/hu-HU.rc
+++ b/dll/win32/shell32/lang/hu-HU.rc
@@ -1020,6 +1020,7 @@ BEGIN
     IDS_ADVANCED_EXPAND_NET_CONNECTIONS "Expand Network Connections"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
+    IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
     IDS_NEWEXT_ADVANCED_LEFT "<< &Haladó"
     IDS_NEWEXT_ADVANCED_RIGHT "&Haladó >>"

--- a/dll/win32/shell32/lang/id-ID.rc
+++ b/dll/win32/shell32/lang/id-ID.rc
@@ -1018,6 +1018,7 @@ BEGIN
     IDS_ADVANCED_EXPAND_NET_CONNECTIONS "Expand Network Connections"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
+    IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
     IDS_NEWEXT_ADVANCED_LEFT "<< Tin&gkat lanjut"
     IDS_NEWEXT_ADVANCED_RIGHT "Tin&gkat lanjut >>"

--- a/dll/win32/shell32/lang/it-IT.rc
+++ b/dll/win32/shell32/lang/it-IT.rc
@@ -1021,6 +1021,7 @@ BEGIN
     IDS_ADVANCED_EXPAND_NET_CONNECTIONS "Expand Network Connections"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
+    IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
     IDS_NEWEXT_ADVANCED_LEFT "<< Ad&vanced"
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"

--- a/dll/win32/shell32/lang/ja-JP.rc
+++ b/dll/win32/shell32/lang/ja-JP.rc
@@ -1018,6 +1018,7 @@ BEGIN
     IDS_ADVANCED_EXPAND_NET_CONNECTIONS "「マイ ネットワーク」を展開"
     IDS_ADVANCED_DISPLAY_RUN "「ファイル名を指定して実行」を表示"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "「管理者ツール」を表示"
+    IDS_ADVANCED_SMALL_START_MENU "小さいアイコンでスタートメニューを表示"
 
     IDS_NEWEXT_ADVANCED_LEFT "<< 高度な設定(&V)"
     IDS_NEWEXT_ADVANCED_RIGHT "高度な設定(&V) >>"

--- a/dll/win32/shell32/lang/ko-KR.rc
+++ b/dll/win32/shell32/lang/ko-KR.rc
@@ -1028,6 +1028,7 @@ BEGIN
     IDS_ADVANCED_EXPAND_NET_CONNECTIONS "Expand Network Connections"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
+    IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
     IDS_NEWEXT_ADVANCED_LEFT "<< Ad&vanced"
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"

--- a/dll/win32/shell32/lang/nl-NL.rc
+++ b/dll/win32/shell32/lang/nl-NL.rc
@@ -1021,6 +1021,7 @@ BEGIN
     IDS_ADVANCED_EXPAND_NET_CONNECTIONS "Expand Network Connections"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
+    IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
     IDS_NEWEXT_ADVANCED_LEFT "<< Ad&vanced"
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"

--- a/dll/win32/shell32/lang/no-NO.rc
+++ b/dll/win32/shell32/lang/no-NO.rc
@@ -1021,6 +1021,7 @@ BEGIN
     IDS_ADVANCED_EXPAND_NET_CONNECTIONS "Expand Network Connections"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
+    IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
     IDS_NEWEXT_ADVANCED_LEFT "<< Ad&vanced"
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"

--- a/dll/win32/shell32/lang/pl-PL.rc
+++ b/dll/win32/shell32/lang/pl-PL.rc
@@ -1030,6 +1030,7 @@ BEGIN
     IDS_ADVANCED_EXPAND_NET_CONNECTIONS "Rozwiń polecenie Połączenia sieciowe"
     IDS_ADVANCED_DISPLAY_RUN "Wyświetl polecenie Uruchom"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Wyświetl polecenie Narzędzia administracyjne"
+    IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
     IDS_NEWEXT_ADVANCED_LEFT "<< &Zaawansowane"
     IDS_NEWEXT_ADVANCED_RIGHT "&Zaawansowane >>"

--- a/dll/win32/shell32/lang/pt-BR.rc
+++ b/dll/win32/shell32/lang/pt-BR.rc
@@ -1021,6 +1021,7 @@ BEGIN
     IDS_ADVANCED_EXPAND_NET_CONNECTIONS "Expand Network Connections"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
+    IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
     IDS_NEWEXT_ADVANCED_LEFT "<< Ad&vanced"
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"

--- a/dll/win32/shell32/lang/pt-PT.rc
+++ b/dll/win32/shell32/lang/pt-PT.rc
@@ -1020,6 +1020,7 @@ BEGIN
     IDS_ADVANCED_EXPAND_NET_CONNECTIONS "Expand Network Connections"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
+    IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
     IDS_NEWEXT_ADVANCED_LEFT "<< A&vançado"
     IDS_NEWEXT_ADVANCED_RIGHT "Avança&do >>"

--- a/dll/win32/shell32/lang/ro-RO.rc
+++ b/dll/win32/shell32/lang/ro-RO.rc
@@ -1029,6 +1029,7 @@ BEGIN
     IDS_ADVANCED_EXPAND_NET_CONNECTIONS "Expand Network Connections"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
+    IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
     IDS_NEWEXT_ADVANCED_LEFT "<< A&vansate"
     IDS_NEWEXT_ADVANCED_RIGHT "A&vansate >>"

--- a/dll/win32/shell32/lang/ru-RU.rc
+++ b/dll/win32/shell32/lang/ru-RU.rc
@@ -1030,6 +1030,7 @@ BEGIN
     IDS_ADVANCED_EXPAND_NET_CONNECTIONS "Раскрывать ""Сетевые подключения"""
     IDS_ADVANCED_DISPLAY_RUN "Отображать команду ""Выполнить"""
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Отображать меню ""Администрирование"""
+    IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
     IDS_NEWEXT_ADVANCED_LEFT "<< До&полнительно"
     IDS_NEWEXT_ADVANCED_RIGHT "До&полнительно >>"

--- a/dll/win32/shell32/lang/sk-SK.rc
+++ b/dll/win32/shell32/lang/sk-SK.rc
@@ -1021,6 +1021,7 @@ BEGIN
     IDS_ADVANCED_EXPAND_NET_CONNECTIONS "Expand Network Connections"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
+    IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
     IDS_NEWEXT_ADVANCED_LEFT "<< Ad&vanced"
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"

--- a/dll/win32/shell32/lang/sl-SI.rc
+++ b/dll/win32/shell32/lang/sl-SI.rc
@@ -1021,6 +1021,7 @@ BEGIN
     IDS_ADVANCED_EXPAND_NET_CONNECTIONS "Expand Network Connections"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
+    IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
     IDS_NEWEXT_ADVANCED_LEFT "<< Ad&vanced"
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"

--- a/dll/win32/shell32/lang/sq-AL.rc
+++ b/dll/win32/shell32/lang/sq-AL.rc
@@ -1028,6 +1028,7 @@ BEGIN
     IDS_ADVANCED_EXPAND_NET_CONNECTIONS "Expand Network Connections"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
+    IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
     IDS_NEWEXT_ADVANCED_LEFT "<< Ad&vanced"
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"

--- a/dll/win32/shell32/lang/sv-SE.rc
+++ b/dll/win32/shell32/lang/sv-SE.rc
@@ -1021,6 +1021,7 @@ BEGIN
     IDS_ADVANCED_EXPAND_NET_CONNECTIONS "Expand Network Connections"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
+    IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
     IDS_NEWEXT_ADVANCED_LEFT "<< Ad&vanced"
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"

--- a/dll/win32/shell32/lang/tr-TR.rc
+++ b/dll/win32/shell32/lang/tr-TR.rc
@@ -1030,6 +1030,7 @@ BEGIN
     IDS_ADVANCED_EXPAND_NET_CONNECTIONS "Expand Network Connections"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
+    IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
     IDS_NEWEXT_ADVANCED_LEFT "<< G&elişmiş"
     IDS_NEWEXT_ADVANCED_RIGHT "Ge&lişmiş >>"

--- a/dll/win32/shell32/lang/uk-UA.rc
+++ b/dll/win32/shell32/lang/uk-UA.rc
@@ -1021,6 +1021,7 @@ BEGIN
     IDS_ADVANCED_EXPAND_NET_CONNECTIONS "Expand Network Connections"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
+    IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
     IDS_NEWEXT_ADVANCED_LEFT "<< &Додатково"
     IDS_NEWEXT_ADVANCED_RIGHT "&Додатково >>"

--- a/dll/win32/shell32/lang/zh-CN.rc
+++ b/dll/win32/shell32/lang/zh-CN.rc
@@ -1031,6 +1031,7 @@ BEGIN
     IDS_ADVANCED_EXPAND_NET_CONNECTIONS "Expand Network Connections"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
+    IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
     IDS_NEWEXT_ADVANCED_LEFT "<< 高级(&V)"
     IDS_NEWEXT_ADVANCED_RIGHT "高级(&V) >>"

--- a/dll/win32/shell32/lang/zh-HK.rc
+++ b/dll/win32/shell32/lang/zh-HK.rc
@@ -1029,6 +1029,7 @@ BEGIN
     IDS_ADVANCED_EXPAND_NET_CONNECTIONS "Expand Network Connections"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
+    IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
     IDS_NEWEXT_ADVANCED_LEFT "<< 進階(&V)"
     IDS_NEWEXT_ADVANCED_RIGHT "進階(&V) >>"

--- a/dll/win32/shell32/lang/zh-TW.rc
+++ b/dll/win32/shell32/lang/zh-TW.rc
@@ -1030,6 +1030,7 @@ BEGIN
     IDS_ADVANCED_EXPAND_NET_CONNECTIONS "Expand Network Connections"
     IDS_ADVANCED_DISPLAY_RUN "Display Run"
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
+    IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
     IDS_NEWEXT_ADVANCED_LEFT "<< 進階(&V)"
     IDS_NEWEXT_ADVANCED_RIGHT "進階(&V) >>"

--- a/dll/win32/shell32/shellmenu/CMenuDeskBar.cpp
+++ b/dll/win32/shell32/shellmenu/CMenuDeskBar.cpp
@@ -551,7 +551,7 @@ HRESULT STDMETHODCALLTYPE CMenuDeskBar::GetIconSize(THIS_ DWORD* piIcon)
 
 HRESULT STDMETHODCALLTYPE CMenuDeskBar::SetBitmap(THIS_ HBITMAP hBitmap)
 {
-    if (m_Banner)
+    if (m_Banner && m_Banner != hBitmap)
         ::DeleteObject(m_Banner);
 
     m_Banner = hBitmap;

--- a/dll/win32/shell32/shellmenu/CMenuDeskBar.cpp
+++ b/dll/win32/shell32/shellmenu/CMenuDeskBar.cpp
@@ -551,6 +551,9 @@ HRESULT STDMETHODCALLTYPE CMenuDeskBar::GetIconSize(THIS_ DWORD* piIcon)
 
 HRESULT STDMETHODCALLTYPE CMenuDeskBar::SetBitmap(THIS_ HBITMAP hBitmap)
 {
+    if (m_Banner)
+        ::DeleteObject(m_Banner);
+
     m_Banner = hBitmap;
 
     BOOL bHandled;
@@ -682,7 +685,7 @@ LRESULT CMenuDeskBar::_OnSize(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHa
 
         GetClientRect(&rc);
 
-        if (m_Banner != NULL)
+        if (m_Banner && m_IconSize != BMICON_SMALL)
         {
             BITMAP bm;
             ::GetObject(m_Banner, sizeof(bm), &bm);

--- a/dll/win32/shell32/shresdef.h
+++ b/dll/win32/shell32/shresdef.h
@@ -316,6 +316,7 @@
 #define IDS_ADVANCED_EXPAND_NET_CONNECTIONS         30473
 #define IDS_ADVANCED_DISPLAY_RUN                    30474
 #define IDS_ADVANCED_DISPLAY_ADMINTOOLS             30476
+#define IDS_ADVANCED_SMALL_START_MENU               30477
 
 #define IDS_NEWEXT_ADVANCED_LEFT                    30515
 #define IDS_NEWEXT_ADVANCED_RIGHT                   30516


### PR DESCRIPTION
## Purpose
Improve customization of Start Menu.
JIRA issue: [CORE-19494](https://jira.reactos.org/browse/CORE-19494)

## Proposed changes

- Add `SmallStartMenu` flag to `TW_STRUCKRECTS2` structure.
- Add `IDS_ADVANCED_SMALL_START_MENU` resource string.
- Update `g_TaskbarSettings.sr.SmallStartMenu` via a callback function.
- Check `g_TaskbarSettings.sr.SmallStartMenu` when Start Menu is updated.

## TODO

- [x] Do tests.

## Screenshots

Settings:
![3](https://github.com/reactos/reactos/assets/2107452/7213962d-6e2e-4c58-96d7-0268b517e087)

When `SmallStartMenu` is `FALSE`:
![before](https://github.com/reactos/reactos/assets/2107452/b69079fd-3134-46a8-8bb8-e4d68d6a79c6)

When `SmallStartMenu` is `TRUE`:
![after](https://github.com/reactos/reactos/assets/2107452/bddb33a2-c7be-4bf7-b67d-6b8d6bac3e7b)

## Movie

https://github.com/reactos/reactos/assets/2107452/1f939ce4-246b-4b22-8629-df05a61d598f