### PR TITLE
[SHELL32_APITEST] Add RealShellExecuteEx testcase

### DIFF
--- a/modules/rostests/apitests/shell32/CMakeLists.txt
+++ b/modules/rostests/apitests/shell32/CMakeLists.txt
@@ -2,6 +2,7 @@
 spec2def(shell32_apitest.exe shell32_apitest.spec)
 
 list(APPEND SOURCE
+    closewnd.cpp
     AddCommas.cpp
     CFSFolder.cpp
     CheckEscapes.cpp
@@ -22,6 +23,7 @@ list(APPEND SOURCE
     PathIsEqualOrSubFolder.cpp
     PathIsTemporary.cpp
     PathResolve.cpp
+    RealShellExecuteEx.cpp
     SHAppBarMessage.cpp
     SHChangeNotify.cpp
     SHCreateDataObject.cpp

--- a/modules/rostests/apitests/shell32/RealShellExecuteEx.cpp
+++ b/modules/rostests/apitests/shell32/RealShellExecuteEx.cpp
@@ -1,0 +1,136 @@
+/*
+ * PROJECT:     ReactOS API tests
+ * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
+ * PURPOSE:     Test for RealShellExecuteExA/W
+ * COPYRIGHT:   Copyright 2024 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
+ */
+
+#include "shelltest.h"
+#include "closewnd.h"
+#include <versionhelpers.h>
+
+BOOL IsWindowsServer2003SP2OrGreater(void)
+{
+    return IsWindowsVersionOrGreater(5, 2, 2);
+}
+
+typedef HINSTANCE (WINAPI *FN_RealShellExecuteExA)(
+    _In_opt_ HWND hwnd,
+    _In_opt_ LPCSTR lpOperation,
+    _In_opt_ LPCSTR lpFile,
+    _In_opt_ LPCSTR lpParameters,
+    _In_opt_ LPCSTR lpDirectory,
+    _In_opt_ LPSTR lpReturn,
+    _In_opt_ LPCSTR lpTitle,
+    _In_opt_ LPVOID lpReserved,
+    _In_ INT nCmdShow,
+    _Out_opt_ PHANDLE lphProcess,
+    _In_ DWORD dwFlags);
+
+typedef HINSTANCE (WINAPI *FN_RealShellExecuteExW)(
+    _In_opt_ HWND hwnd,
+    _In_opt_ LPCWSTR lpOperation,
+    _In_opt_ LPCWSTR lpFile,
+    _In_opt_ LPCWSTR lpParameters,
+    _In_opt_ LPCWSTR lpDirectory,
+    _In_opt_ LPWSTR lpReturn,
+    _In_opt_ LPCWSTR lpTitle,
+    _In_opt_ LPVOID lpReserved,
+    _In_ INT nCmdShow,
+    _Out_opt_ PHANDLE lphProcess,
+    _In_ DWORD dwFlags);
+
+static HINSTANCE s_hSHELL32 = NULL;
+static FN_RealShellExecuteExA s_fnRealShellExecuteExA = NULL;
+static FN_RealShellExecuteExW s_fnRealShellExecuteExW = NULL;
+
+static WINDOW_LIST s_List1, s_List2;
+
+static void TEST_Start(void)
+{
+    GetWindowList(&s_List1);
+}
+
+static void TEST_End(void)
+{
+    Sleep(500);
+    GetWindowList(&s_List2);
+    CloseNewWindows(&s_List1, &s_List2);
+    FreeWindowList(&s_List1);
+    FreeWindowList(&s_List2);
+}
+
+static void TEST_RealShellExecuteExA(void)
+{
+    TEST_Start();
+
+    INT_PTR ret;
+
+    ret = (INT_PTR)s_fnRealShellExecuteExA(
+        NULL,
+        NULL,
+        "notepad.exe",
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        SW_SHOWDEFAULT,
+        NULL,
+        0);
+    if (IsWindowsServer2003SP2OrGreater())
+        ok_long((LONG)ret, 42);
+    else
+        ok_long((LONG)ret, 2);
+
+    TEST_End();
+}
+
+static void TEST_RealShellExecuteExW(void)
+{
+    TEST_Start();
+
+    INT_PTR ret;
+
+    ret = (INT_PTR)s_fnRealShellExecuteExW(
+        NULL,
+        NULL,
+        L"notepad.exe",
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        SW_SHOWDEFAULT,
+        NULL,
+        0);
+    ok_long((LONG)ret, 42);
+
+    TEST_End();
+}
+
+START_TEST(RealShellExecuteEx)
+{
+    if (IsWindowsVistaOrGreater())
+    {
+        skip("Vista+\n");
+        return;
+    }
+
+    s_hSHELL32 = LoadLibraryW(L"shell32.dll");
+
+    s_fnRealShellExecuteExA = (FN_RealShellExecuteExA)GetProcAddress(s_hSHELL32, MAKEINTRESOURCEA(266));
+    s_fnRealShellExecuteExW = (FN_RealShellExecuteExW)GetProcAddress(s_hSHELL32, MAKEINTRESOURCEA(267));
+
+    if (!s_fnRealShellExecuteExA || !s_fnRealShellExecuteExW)
+    {
+        skip("RealShellExecuteExA/W not found: %p, %p\n",
+             s_fnRealShellExecuteExA, s_fnRealShellExecuteExW);
+        return;
+    }
+
+    TEST_RealShellExecuteExA();
+    TEST_RealShellExecuteExW();
+
+    FreeLibrary(s_hSHELL32);
+}

--- a/modules/rostests/apitests/shell32/ShellExecuteEx.cpp
+++ b/modules/rostests/apitests/shell32/ShellExecuteEx.cpp
@@ -150,7 +150,8 @@ getCommandLineFromProcess(HANDLE hProcess)
 static void TEST_DoTestEntryStruct(const TEST_ENTRY *pEntry)
 {
     SHELLEXECUTEINFOW info = { sizeof(info) };
-    info.fMask = SEE_MASK_NOCLOSEPROCESS | SEE_MASK_WAITFORINPUTIDLE | SEE_MASK_FLAG_NO_UI;
+    info.fMask = SEE_MASK_NOCLOSEPROCESS | SEE_MASK_WAITFORINPUTIDLE |
+                 SEE_MASK_FLAG_NO_UI | SEE_MASK_NOASYNC;
     info.hwnd = NULL;
     info.lpVerb = NULL;
     info.lpFile = pEntry->lpFile;

--- a/modules/rostests/apitests/shell32/closewnd.cpp
+++ b/modules/rostests/apitests/shell32/closewnd.cpp
@@ -12,6 +12,7 @@ void FreeWindowList(PWINDOW_LIST pList)
 {
     free(pList->m_phWnds);
     pList->m_phWnds = NULL;
+    pList->m_chWnds = 0;
 }
 
 static BOOL CALLBACK EnumWindowsProc(HWND hwnd, LPARAM lParam)
@@ -31,6 +32,8 @@ static BOOL CALLBACK EnumWindowsProc(HWND hwnd, LPARAM lParam)
 
 void GetWindowList(PWINDOW_LIST pList)
 {
+    pList->m_chWnds = 0;
+    pList->m_phWnds = NULL;
     EnumWindows(EnumWindowsProc, (LPARAM)pList);
 }
 

--- a/modules/rostests/apitests/shell32/closewnd.cpp
+++ b/modules/rostests/apitests/shell32/closewnd.cpp
@@ -34,7 +34,7 @@ void GetWindowList(PWINDOW_LIST pList)
     EnumWindows(EnumWindowsProc, (LPARAM)pList);
 }
 
-void CloseNewWindows(PWINDOW_LIST List1, PWINDOW_LIST List2)
+HWND FindNewWindow(PWINDOW_LIST List1, PWINDOW_LIST List2)
 {
     for (SIZE_T i2 = 0; i2 < List2->m_chWnds; ++i2)
     {
@@ -49,22 +49,38 @@ void CloseNewWindows(PWINDOW_LIST List1, PWINDOW_LIST List2)
             }
         }
 Escape:
-        if (!bFoundInList1)
+        if (!bFoundInList1 && IsWindow(hWnd))
+            return hWnd;
+    }
+    return NULL;
+}
+
+void CloseNewWindows(PWINDOW_LIST List1, PWINDOW_LIST List2)
+{
+    INT cDiff = List2->m_chWnds - List1->m_chWnds;
+    if (cDiff <= 0)
+        cDiff = 32;
+
+    cDiff *= 2;
+    for (INT j = 0; j < cDiff; ++j)
+    {
+        HWND hWnd = FindNewWindow(List1, List2);
+        if (!hWnd)
+            break;
+
+        for (INT i = 0; i < 8; ++i)
         {
-            for (INT i = 0; i < 5; ++i)
-            {
-                if (!IsWindow(hWnd))
-                    break;
+            if (!IsWindow(hWnd))
+                break;
 
-                SwitchToThisWindow(hWnd, TRUE);
+            SwitchToThisWindow(hWnd, TRUE);
 
-                // Alt+F4
-                keybd_event(VK_MENU, 0x38, 0, 0);
-                keybd_event(VK_F4, 0x3E, 0, 0);
-                keybd_event(VK_F4, 0x3E, KEYEVENTF_KEYUP, 0);
-                keybd_event(VK_MENU, 0x38, KEYEVENTF_KEYUP, 0);
-                Sleep(100);
-            }
+            // Alt+F4
+            keybd_event(VK_MENU, 0x38, 0, 0);
+            keybd_event(VK_F4, 0x3E, 0, 0);
+            keybd_event(VK_F4, 0x3E, KEYEVENTF_KEYUP, 0);
+            keybd_event(VK_MENU, 0x38, KEYEVENTF_KEYUP, 0);
+            Sleep(100);
         }
     }
 }

--- a/modules/rostests/apitests/shell32/closewnd.cpp
+++ b/modules/rostests/apitests/shell32/closewnd.cpp
@@ -1,0 +1,70 @@
+/*
+ * PROJECT:     ReactOS API tests
+ * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
+ * PURPOSE:     Close windows after tests
+ * COPYRIGHT:   Copyright 2024 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
+ */
+
+#include "shelltest.h"
+#include "closewnd.h"
+
+void FreeWindowList(PWINDOW_LIST pList)
+{
+    free(pList->m_phWnds);
+    pList->m_phWnds = NULL;
+}
+
+static BOOL CALLBACK EnumWindowsProc(HWND hwnd, LPARAM lParam)
+{
+    if (!IsWindowVisible(hwnd))
+        return TRUE;
+
+    PWINDOW_LIST pList = (PWINDOW_LIST)lParam;
+    SIZE_T cb = (pList->m_chWnds + 1) * sizeof(HWND);
+    HWND *phWnds = (HWND *)realloc(pList->m_phWnds, cb);
+    if (!phWnds)
+        return FALSE;
+    phWnds[pList->m_chWnds++] = hwnd;
+    pList->m_phWnds = phWnds;
+    return TRUE;
+}
+
+void GetWindowList(PWINDOW_LIST pList)
+{
+    EnumWindows(EnumWindowsProc, (LPARAM)pList);
+}
+
+void CloseNewWindows(PWINDOW_LIST List1, PWINDOW_LIST List2)
+{
+    for (SIZE_T i2 = 0; i2 < List2->m_chWnds; ++i2)
+    {
+        BOOL bFoundInList1 = FALSE;
+        HWND hWnd = List2->m_phWnds[i2];
+        for (SIZE_T i1 = 0; i1 < List1->m_chWnds; ++i1)
+        {
+            if (hWnd == List1->m_phWnds[i1])
+            {
+                bFoundInList1 = TRUE;
+                goto Escape;
+            }
+        }
+Escape:
+        if (!bFoundInList1)
+        {
+            for (INT i = 0; i < 5; ++i)
+            {
+                if (!IsWindow(hWnd))
+                    break;
+
+                SwitchToThisWindow(hWnd, TRUE);
+
+                // Alt+F4
+                keybd_event(VK_MENU, 0x38, 0, 0);
+                keybd_event(VK_F4, 0x3E, 0, 0);
+                keybd_event(VK_F4, 0x3E, KEYEVENTF_KEYUP, 0);
+                keybd_event(VK_MENU, 0x38, KEYEVENTF_KEYUP, 0);
+                Sleep(100);
+            }
+        }
+    }
+}

--- a/modules/rostests/apitests/shell32/closewnd.cpp
+++ b/modules/rostests/apitests/shell32/closewnd.cpp
@@ -32,8 +32,8 @@ static BOOL CALLBACK EnumWindowsProc(HWND hwnd, LPARAM lParam)
 
 void GetWindowList(PWINDOW_LIST pList)
 {
-    pList->m_chWnds = 0;
     pList->m_phWnds = NULL;
+    pList->m_chWnds = 0;
     EnumWindows(EnumWindowsProc, (LPARAM)pList);
 }
 
@@ -48,10 +48,10 @@ HWND FindNewWindow(PWINDOW_LIST List1, PWINDOW_LIST List2)
             if (hWnd == List1->m_phWnds[i1])
             {
                 bFoundInList1 = TRUE;
-                goto Escape;
+                break;
             }
         }
-Escape:
+
         if (!bFoundInList1 && IsWindow(hWnd))
             return hWnd;
     }

--- a/modules/rostests/apitests/shell32/closewnd.cpp
+++ b/modules/rostests/apitests/shell32/closewnd.cpp
@@ -41,8 +41,11 @@ HWND FindNewWindow(PWINDOW_LIST List1, PWINDOW_LIST List2)
 {
     for (SIZE_T i2 = 0; i2 < List2->m_chWnds; ++i2)
     {
-        BOOL bFoundInList1 = FALSE;
         HWND hWnd = List2->m_phWnds[i2];
+        if (!IsWindowEnabled(hWnd) || !IsWindowVisible(hWnd))
+            continue;
+
+        BOOL bFoundInList1 = FALSE;
         for (SIZE_T i1 = 0; i1 < List1->m_chWnds; ++i1)
         {
             if (hWnd == List1->m_phWnds[i1])
@@ -52,26 +55,24 @@ HWND FindNewWindow(PWINDOW_LIST List1, PWINDOW_LIST List2)
             }
         }
 
-        if (!bFoundInList1 && IsWindow(hWnd))
+        if (!bFoundInList1)
             return hWnd;
     }
     return NULL;
 }
 
+#define TRIALS_COUNT 8
+
 void CloseNewWindows(PWINDOW_LIST List1, PWINDOW_LIST List2)
 {
     INT cDiff = List2->m_chWnds - List1->m_chWnds;
-    if (cDiff <= 0)
-        cDiff = 32;
-
-    cDiff *= 2;
     for (INT j = 0; j < cDiff; ++j)
     {
         HWND hWnd = FindNewWindow(List1, List2);
         if (!hWnd)
             break;
 
-        for (INT i = 0; i < 8; ++i)
+        for (INT i = 0; i < TRIALS_COUNT; ++i)
         {
             if (!IsWindow(hWnd))
                 break;

--- a/modules/rostests/apitests/shell32/closewnd.h
+++ b/modules/rostests/apitests/shell32/closewnd.h
@@ -14,5 +14,6 @@ typedef struct WINDOW_LIST
 } WINDOW_LIST, *PWINDOW_LIST;
 
 void GetWindowList(PWINDOW_LIST pList);
+HWND FindNewWindow(PWINDOW_LIST List1, PWINDOW_LIST List2);
 void CloseNewWindows(PWINDOW_LIST List1, PWINDOW_LIST List2);
 void FreeWindowList(PWINDOW_LIST pList);

--- a/modules/rostests/apitests/shell32/closewnd.h
+++ b/modules/rostests/apitests/shell32/closewnd.h
@@ -1,0 +1,18 @@
+/*
+ * PROJECT:     ReactOS API tests
+ * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
+ * PURPOSE:     Close windows after tests
+ * COPYRIGHT:   Copyright 2024 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
+ */
+
+#pragma once
+
+typedef struct WINDOW_LIST
+{
+    SIZE_T m_chWnds;
+    HWND *m_phWnds;
+} WINDOW_LIST, *PWINDOW_LIST;
+
+void GetWindowList(PWINDOW_LIST pList);
+void CloseNewWindows(PWINDOW_LIST List1, PWINDOW_LIST List2);
+void FreeWindowList(PWINDOW_LIST pList);

--- a/modules/rostests/apitests/shell32/testlist.c
+++ b/modules/rostests/apitests/shell32/testlist.c
@@ -24,6 +24,7 @@ extern void func_OpenAs_RunDLL(void);
 extern void func_PathIsEqualOrSubFolder(void);
 extern void func_PathIsTemporary(void);
 extern void func_PathResolve(void);
+extern void func_RealShellExecuteEx(void);
 extern void func_SHAppBarMessage(void);
 extern void func_SHChangeNotify(void);
 extern void func_SHCreateDataObject(void);
@@ -63,6 +64,7 @@ const struct test winetest_testlist[] =
     { "PathIsEqualOrSubFolder", func_PathIsEqualOrSubFolder },
     { "PathIsTemporary", func_PathIsTemporary },
     { "PathResolve", func_PathResolve },
+    { "RealShellExecuteEx", func_RealShellExecuteEx },
     { "SHAppBarMessage", func_SHAppBarMessage },
     { "SHChangeNotify", func_SHChangeNotify },
     { "SHCreateDataObject", func_SHCreateDataObject },


### PR DESCRIPTION
## Purpose
Follow-up to #5849.
JIRA issue: [CORE-19278](https://jira.reactos.org/browse/CORE-19278)

## Proposed changes

- Add `closewnd.cpp`, `closewnd.h`, and `RealShellExecuteEx.cpp` files.
- In `closewnd.cpp`, close newly-opened windows.
- Add `RealShellExecuteEx` testcase.

## TODO

- [x] Do tests.

## Comparison

WinXP:
![winXP](https://github.com/reactos/reactos/assets/2107452/5051b822-642f-4a5c-8ffd-be8560eb352e)
Successful.

Win2k3:
![Win2k3](https://github.com/reactos/reactos/assets/2107452/9b7c35ec-d1c7-442e-81da-00ad27aec0c5)
Successful.

Win10:
![Win10](https://github.com/reactos/reactos/assets/2107452/d456117d-df40-4e4a-9628-b7ce1f030e78)
Skipped.

ReactOS:
![after](https://github.com/reactos/reactos/assets/2107452/d4d51aba-9307-45bc-8b13-3888ab49d774)
FAILED.