### PR TITLE
[NTOS:CM] Remove orphaned KCBs of keys during normal hive unload

### DIFF
--- a/ntoskrnl/config/cmapi.c
+++ b/ntoskrnl/config/cmapi.c
@@ -2242,7 +2242,7 @@ CmUnloadKey(IN PCM_KEY_CONTROL_BLOCK Kcb,
     {
         if (Flags != REG_FORCE_UNLOAD)
         {
-            if (CmpEnumerateOpenSubKeys(Kcb, FALSE, FALSE, FALSE) != 0)
+            if (CmpEnumerateOpenSubKeys(Kcb, FALSE, TRUE, FALSE) != 0)
             {
                 /* There are open subkeys but we don't force hive unloading, fail */
                 Hive->HiveFlags &= ~HIVE_IS_UNLOADING;
@@ -2251,7 +2251,6 @@ CmUnloadKey(IN PCM_KEY_CONTROL_BLOCK Kcb,
         }
         else
         {
-            DPRINT1("CmUnloadKey: Force unloading is HALF-IMPLEMENTED, expect dangling KCBs problems!\n");
             if (CmpEnumerateOpenSubKeys(Kcb, TRUE, TRUE, TRUE) != 0)
             {
                 /* There are open subkeys that we cannot force to unload, fail */

--- a/ntoskrnl/config/cmapi.c
+++ b/ntoskrnl/config/cmapi.c
@@ -2242,7 +2242,7 @@ CmUnloadKey(IN PCM_KEY_CONTROL_BLOCK Kcb,
     {
         if (Flags != REG_FORCE_UNLOAD)
         {
-            if (CmpEnumerateOpenSubKeys(Kcb, FALSE, FALSE) != 0)
+            if (CmpEnumerateOpenSubKeys(Kcb, FALSE, FALSE, FALSE) != 0)
             {
                 /* There are open subkeys but we don't force hive unloading, fail */
                 Hive->HiveFlags &= ~HIVE_IS_UNLOADING;
@@ -2252,7 +2252,7 @@ CmUnloadKey(IN PCM_KEY_CONTROL_BLOCK Kcb,
         else
         {
             DPRINT1("CmUnloadKey: Force unloading is HALF-IMPLEMENTED, expect dangling KCBs problems!\n");
-            if (CmpEnumerateOpenSubKeys(Kcb, TRUE, TRUE) != 0)
+            if (CmpEnumerateOpenSubKeys(Kcb, TRUE, TRUE, TRUE) != 0)
             {
                 /* There are open subkeys that we cannot force to unload, fail */
                 Hive->HiveFlags &= ~HIVE_IS_UNLOADING;
@@ -2340,9 +2340,10 @@ CmUnloadKey(IN PCM_KEY_CONTROL_BLOCK Kcb,
 ULONG
 NTAPI
 CmpEnumerateOpenSubKeys(
-    IN PCM_KEY_CONTROL_BLOCK RootKcb,
-    IN BOOLEAN RemoveEmptyCacheEntries,
-    IN BOOLEAN DereferenceOpenedEntries)
+    _In_ PCM_KEY_CONTROL_BLOCK RootKcb,
+    _In_ BOOLEAN LockHeldExclusively,
+    _In_ BOOLEAN RemoveEmptyCacheEntries,
+    _In_ BOOLEAN DereferenceOpenedEntries)
 {
     PCM_KEY_HASH Entry;
     PCM_KEY_CONTROL_BLOCK CachedKcb;
@@ -2430,11 +2431,20 @@ CmpEnumerateOpenSubKeys(
                     }
                     else if ((CachedKcb->RefCount == 0) && RemoveEmptyCacheEntries)
                     {
+                        /* Lock the cached KCB of subkey before removing it from cache entries */
+                        if (!LockHeldExclusively)
+                            CmpAcquireKcbLockExclusive(CachedKcb);
+
                         /* Remove the current key from the delayed close list */
                         CmpRemoveFromDelayedClose(CachedKcb);
 
                         /* Remove the current cache entry */
-                        CmpCleanUpKcbCacheWithLock(CachedKcb, TRUE);
+                        // Lock is either held by ourselves or registry is locked exclusively
+                        CmpCleanUpKcbCacheWithLock(CachedKcb, LockHeldExclusively);
+
+                        /* Unlock the cached KCB if it was done by ourselves */
+                        if (!LockHeldExclusively)
+                            CmpReleaseKcbLock(CachedKcb);
 
                         /* Restart, because the hash list has changed */
                         Entry = CmpCacheTable[i].Entry;

--- a/ntoskrnl/config/ntapi.c
+++ b/ntoskrnl/config/ntapi.c
@@ -1565,7 +1565,7 @@ NtQueryOpenSubKeys(IN POBJECT_ATTRIBUTES TargetKey,
 
     /* Call the internal API */
     SubKeys = CmpEnumerateOpenSubKeys(KeyBody->KeyControlBlock,
-                                      FALSE, FALSE);
+                                      TRUE, FALSE, FALSE);
 
     /* Unlock the registry */
     CmpUnlockRegistry();

--- a/ntoskrnl/include/internal/cm.h
+++ b/ntoskrnl/include/internal/cm.h
@@ -1333,9 +1333,10 @@ CmUnloadKey(
 ULONG
 NTAPI
 CmpEnumerateOpenSubKeys(
-    IN PCM_KEY_CONTROL_BLOCK RootKcb,
-    IN BOOLEAN RemoveEmptyCacheEntries,
-    IN BOOLEAN DereferenceOpenedEntries
+    _In_ PCM_KEY_CONTROL_BLOCK RootKcb,
+    _In_ BOOLEAN LockHeldExclusively,
+    _In_ BOOLEAN RemoveEmptyCacheEntries,
+    _In_ BOOLEAN DereferenceOpenedEntries
 );
 
 HCELL_INDEX


### PR DESCRIPTION
A hive whose KCBs have a reference count of 0, meaning nobody is using these keys anymore, will not get removed from the cache table. As a result during normal hive unloading you will get orphaned KCBs which results in an unload failure.

This is wrong, because this is what a normal hive unloading is supposed to do. What it cannot do of course is that it cannot scramble the references of opened keys by the users who use the Registry, as it is the job of force unloading mechanism to do that.

Also remove a misleading debug print. Force unloading works as intended by scrambling the references of keys and marking the KCB for deletion, which is what how a force unload works. Namely Windows does exactly that.

## Notes
Whilst this patch does not fix the issue mentioned in the ticket below, it is a small step closer to the main goal of fixing it. What is left to address is to implement _rinse-and-repeat force unload approach_ in `NtUnloadKey2` function and solve the biggest elephant in the room -- aka the Win32 subsystem shutdown code is not fully implemented and broken.

**JIRA Issue:** [CORE-10705](https://jira.reactos.org/browse/CORE-10705)