### PR TITLE
[RSYM/x64] Sync UNW_FLAG_* values

### DIFF
--- a/sdk/tools/rsym/rsym64.h
+++ b/sdk/tools/rsym/rsym64.h
@@ -105,9 +105,10 @@ typedef union _UNWIND_CODE
 
 enum
 {
+    UNW_FLAG_NHANDLER  = 0x00,
     UNW_FLAG_EHANDLER  = 0x01,
     UNW_FLAG_UHANDLER  = 0x02,
-    UNW_FLAG_CHAININFO = 0x03,
+    UNW_FLAG_CHAININFO = 0x04
 };
 
 typedef struct _UNWIND_INFO


### PR DESCRIPTION
## Purpose

Sync the `enum` (values) to the `DEFINE`s everywhere else.

Follow-up to  #6641.

## Proposed changes

- Sync UNW_FLAG_* values