### PR TITLE
[SHELL32] IQueryAssociations: Fix path and length

### DIFF
--- a/dll/win32/shell32/CQueryAssociations.cpp
+++ b/dll/win32/shell32/CQueryAssociations.cpp
@@ -616,7 +616,6 @@ HRESULT CQueryAssociations::GetCommand(const WCHAR *extra, WCHAR **command)
             ret = RegQueryInfoKeyW(hkeyShell, NULL, NULL, NULL, NULL, &max_subkey_len, NULL, NULL, NULL, NULL, NULL, NULL);
             if (ret)
             {
-                ERR("0x%lX\n", ret);
                 RegCloseKey(hkeyShell);
                 return HRESULT_FROM_WIN32(ret);
             }

--- a/dll/win32/shell32/CQueryAssociations.cpp
+++ b/dll/win32/shell32/CQueryAssociations.cpp
@@ -652,7 +652,6 @@ HRESULT CQueryAssociations::GetCommand(const WCHAR *extra, WCHAR **command)
     RegCloseKey(hkeyVerb);
     if (ret)
     {
-        ERR("0x%lX\n", ret);
         return HRESULT_FROM_WIN32(ret);
     }
     hr = this->GetValue(hkeyCommand, NULL, (void**)command, NULL);

--- a/dll/win32/shell32/CQueryAssociations.cpp
+++ b/dll/win32/shell32/CQueryAssociations.cpp
@@ -221,7 +221,7 @@ HRESULT STDMETHODCALLTYPE CQueryAssociations::GetString(
         case ASSOCSTR_EXECUTABLE:
         {
             hr = this->GetExecutable(pszExtra, path, MAX_PATH, &len);
-            if (FAILED(hr))
+            if (FAILED_UNEXPECTEDLY(hr))
             {
                 return hr;
             }
@@ -666,7 +666,7 @@ HRESULT CQueryAssociations::GetExecutable(LPCWSTR pszExtra, LPWSTR path, DWORD p
     WCHAR *pszEnd;
 
     HRESULT hr = this->GetCommand(pszExtra, &pszCommand);
-    if (FAILED(hr))
+    if (FAILED_UNEXPECTEDLY(hr))
     {
         return hr;
     }

--- a/dll/win32/shell32/CQueryAssociations.cpp
+++ b/dll/win32/shell32/CQueryAssociations.cpp
@@ -666,7 +666,7 @@ HRESULT CQueryAssociations::GetExecutable(LPCWSTR pszExtra, LPWSTR path, DWORD p
     WCHAR *pszEnd;
 
     HRESULT hr = this->GetCommand(pszExtra, &pszCommand);
-    if (FAILED_UNEXPECTEDLY(hr))
+    if (FAILED(hr))
     {
         return hr;
     }

--- a/dll/win32/shell32/CQueryAssociations.cpp
+++ b/dll/win32/shell32/CQueryAssociations.cpp
@@ -599,7 +599,6 @@ HRESULT CQueryAssociations::GetCommand(const WCHAR *extra, WCHAR **command)
 
     if (ret)
     {
-        ERR("0x%lX\n", ret);
         return HRESULT_FROM_WIN32(ret);
     }
 

--- a/dll/win32/shell32/CQueryAssociations.cpp
+++ b/dll/win32/shell32/CQueryAssociations.cpp
@@ -649,7 +649,6 @@ HRESULT CQueryAssociations::GetCommand(const WCHAR *extra, WCHAR **command)
     RegCloseKey(hkeyShell);
     if (ret)
     {
-        ERR("0x%lX\n", ret);
         return HRESULT_FROM_WIN32(ret);
     }
     /* open command subkey */

--- a/dll/win32/shell32/CQueryAssociations.cpp
+++ b/dll/win32/shell32/CQueryAssociations.cpp
@@ -631,7 +631,6 @@ HRESULT CQueryAssociations::GetCommand(const WCHAR *extra, WCHAR **command)
             ret = RegEnumKeyExW(hkeyShell, 0, extra_from_reg, &max_subkey_len, NULL, NULL, NULL, NULL);
             if (ret)
             {
-                ERR("0x%lX\n", ret);
                 HeapFree(GetProcessHeap(), 0, extra_from_reg);
                 RegCloseKey(hkeyShell);
                 return HRESULT_FROM_WIN32(ret);

--- a/dll/win32/shell32/CQueryAssociations.cpp
+++ b/dll/win32/shell32/CQueryAssociations.cpp
@@ -624,7 +624,6 @@ HRESULT CQueryAssociations::GetCommand(const WCHAR *extra, WCHAR **command)
             extra_from_reg = static_cast<WCHAR*>(HeapAlloc(GetProcessHeap(), 0, max_subkey_len * sizeof(WCHAR)));
             if (!extra_from_reg)
             {
-                ERR("E_OUTOFMEMORY\n");
                 RegCloseKey(hkeyShell);
                 return E_OUTOFMEMORY;
             }

--- a/dll/win32/shell32/CQueryAssociations.cpp
+++ b/dll/win32/shell32/CQueryAssociations.cpp
@@ -221,7 +221,7 @@ HRESULT STDMETHODCALLTYPE CQueryAssociations::GetString(
         case ASSOCSTR_EXECUTABLE:
         {
             hr = this->GetExecutable(pszExtra, path, MAX_PATH, &len);
-            if (FAILED_UNEXPECTEDLY(hr))
+            if (FAILED(hr))
             {
                 return hr;
             }

--- a/dll/win32/shell32/CQueryAssociations.cpp
+++ b/dll/win32/shell32/CQueryAssociations.cpp
@@ -616,6 +616,8 @@ HRESULT CQueryAssociations::GetCommand(const WCHAR *extra, WCHAR **command)
         /* check for default verb */
         hr = this->GetValue(hkeyShell, NULL, (void**)&extra_from_reg, NULL);
         if (FAILED(hr))
+            hr = this->GetValue(hkeyShell, L"open", (void**)&extra_from_reg, NULL);
+        if (FAILED(hr))
         {
             /* no default verb, try first subkey */
             DWORD max_subkey_len;
@@ -653,8 +655,6 @@ HRESULT CQueryAssociations::GetCommand(const WCHAR *extra, WCHAR **command)
     ret = RegOpenKeyExW(hkeyShell, extra, 0, KEY_READ, &hkeyVerb);
     HeapFree(GetProcessHeap(), 0, extra_from_reg);
     RegCloseKey(hkeyShell);
-    if (ret)
-        ret = RegOpenKeyExW(hkeyShell, L"open", 0, KEY_READ, &hkeyVerb);
     if (ret)
     {
         ERR("0x%lX\n", ret);

--- a/dll/win32/shell32/CQueryAssociations.cpp
+++ b/dll/win32/shell32/CQueryAssociations.cpp
@@ -541,32 +541,25 @@ HRESULT CQueryAssociations::GetValue(HKEY hkey, const WCHAR *name, void **data, 
 
     ret = RegQueryValueExW(hkey, name, 0, NULL, NULL, &size);
     if (ret != ERROR_SUCCESS)
-    {
-        ERR("0x%lX\n", ret);
         return HRESULT_FROM_WIN32(ret);
-    }
+
     if (!size)
-    {
-        ERR("!size\n");
         return E_FAIL;
-    }
+
     *data = HeapAlloc(GetProcessHeap(), 0, size);
     if (!*data)
-    {
-        ERR("E_OUTOFMEMORY\n");
         return E_OUTOFMEMORY;
-    }
+
     ret = RegQueryValueExW(hkey, name, 0, NULL, (LPBYTE)*data, &size);
     if (ret != ERROR_SUCCESS)
     {
-        ERR("0x%lX\n", ret);
         HeapFree(GetProcessHeap(), 0, *data);
         return HRESULT_FROM_WIN32(ret);
     }
-    if(data_size)
-    {
+
+    if (data_size)
         *data_size = size;
-    }
+
     return S_OK;
 }
 

--- a/dll/win32/shell32/CQueryAssociations.cpp
+++ b/dll/win32/shell32/CQueryAssociations.cpp
@@ -2,7 +2,6 @@
  * IQueryAssociations object and helper functions
  *
  * Copyright 2002 Jon Griffiths
- * Copyright 2024 Katayama Hirofumi MZ
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public


### PR DESCRIPTION
## Purpose
Implementing correct `FindExecutable`...
JIRA issue: [CORE-19493](https://jira.reactos.org/browse/CORE-19493)

## Proposed changes

- If there were filename extension, then skip to the extension by using `PathFindExtensionW`.
- Use `"open"` verb if there is no default action if possible.
- Set `outlen` at `CQueryAssociations::ReturnString`.

## TODO

- [x] Do small tests.
- [x] Do big tests.

## Comparison

BEFORE:
![before](https://github.com/reactos/reactos/assets/2107452/bab3a0ec-dfa1-4a9c-a2fc-70fa6ffa7e8c)
12 failures.

AFTER:
![after](https://github.com/reactos/reactos/assets/2107452/fa10e976-2240-4b1e-a2c8-6fa7dae2c061)
9 failures. `AssocQueryStringW` failures are reduced. LGTM.