### PR TITLE
[FREELDR/x64] Set up CR0/CR4 for SSE instructions

### DIFF
--- a/boot/freeldr/freeldr/arch/amd64/entry.S
+++ b/boot/freeldr/freeldr/arch/amd64/entry.S
@@ -1,5 +1,6 @@
 
 #include <asm.inc>
+#include <ksamd64.inc>
 #include <arch/pc/x86common.h>
 #include <arch/pc/pcbios.h>
 
@@ -37,6 +38,18 @@ ContinueAddress:
     .quad FrldrStartup
 
 FrldrStartup:
+
+    /* Set up CR0 for SSE */
+    mov rax, cr0
+    and eax, not CR0_EM // Clear coprocessor emulation CR0.EM CR0.EM (bit 2)
+    or rax, CR0_MP // Set coprocessor monitoring CR0.MP (bit 1)
+    mov cr0, rax
+
+    /* Set up CR4 for SSE */
+    mov rax, cr4
+    or eax, CR4_FXSR // Enable fx save/restore CR4.OSFXSR (bit 9)
+    or eax, CR4_XMMEXCPT // Enable XMMI exceptions CR4.OSXMMEXCPT (bit 10)
+    mov cr4, rax
 
     /* Store BootDrive and BootPartition */
     mov al, byte ptr [BSS_BootDrive]

--- a/boot/freeldr/freeldr/arch/realmode/amd64.S
+++ b/boot/freeldr/freeldr/arch/realmode/amd64.S
@@ -322,9 +322,8 @@ ExitToLongMode:
     mov word ptr ds:[stack16], sp
 
     /* Set PAE and PGE: 10100000b */
-    // mov eax, cr4
-    // or eax, HEX(00A0)
-    mov eax, HEX(00A0)
+    mov eax, cr4
+    or eax, HEX(00A0)
     mov cr4, eax
 
     /* Point cr3 at the PML4 */


### PR DESCRIPTION
## Purpose

Enable support for SSE/SSE2 instructions in freeldr.
Newer GCC starts emitting SSE/SSE2 instructions, which would cause a triple fault, during early boot, if not enabled.
