### PR TITLE
[NTOS:KE/x64] Move setting the thread's trap frame to KiSystemCallEntry64

### DIFF
--- a/ntoskrnl/ke/amd64/trap.S
+++ b/ntoskrnl/ke/amd64/trap.S
@@ -817,6 +817,15 @@ PUBLIC KiSystemCallEntry64
     stmxcsr [rsp + MAX_SYSCALL_PARAM_SIZE + KTRAP_FRAME_MxCsr]
     ldmxcsr gs:[PcMxCsr]
 
+    /* Get the current thread and the trap frame */
+    mov rax, gs:[PcCurrentThread]
+    mov rcx, [rax + ThTrapFrame]
+
+    /* Save the old trap frame */
+    lea rdx, [rsp + MAX_SYSCALL_PARAM_SIZE]
+    mov [rsp + MAX_SYSCALL_PARAM_SIZE + KTRAP_FRAME_TrapFrame], rcx
+    mov [rax + ThTrapFrame], rdx
+
 #if DBG
     /* Check IRQL */
     mov rax, cr8
@@ -1077,12 +1086,6 @@ AlreadyLargeStack:
 
     /* Disable interrupts for return */
     cli
-
-    // FIXME: should just do the trap frame switch in KiSystemCallHandler64
-    /* Restore old trap frame */
-    mov rcx, gs:[PcCurrentThread]
-    mov rdx, [rsp + 48 + MAX_SYSCALL_PARAM_SIZE + KTRAP_FRAME_TrapFrame]
-    mov [rcx + KTHREAD_TrapFrame], rdx
 
     // Restore register parameters
     mov rcx, [rsp + 48 + MAX_SYSCALL_PARAM_SIZE + KTRAP_FRAME_Rip]

--- a/ntoskrnl/ke/amd64/traphandler.c
+++ b/ntoskrnl/ke/amd64/traphandler.c
@@ -116,10 +116,6 @@ KiSystemCallHandler(
     /* Set previous mode */
     Thread->PreviousMode = TrapFrame->PreviousMode = UserMode;
 
-    /* Save the old trap frame and set the new */
-    TrapFrame->TrapFrame = (ULONG64)Thread->TrapFrame;
-    Thread->TrapFrame = TrapFrame;
-
     /* We don't have an exception frame yet */
     TrapFrame->ExceptionFrame = 0;
 


### PR DESCRIPTION
## Purpose

This is needed, because KiSystemCallHandler can be called multiple times for the same syscall entry, which would mess up the linkage.

## Tests
- https://reactos.org/testman/compare.php?ids=94343,94347,94351,94359
