### PR TITLE
[NTOS:CM] Avoid unnecessary ObDereferenceObject when handling an ObInsertObject failure

### DIFF
--- a/ntoskrnl/config/cmsysini.c
+++ b/ntoskrnl/config/cmsysini.c
@@ -1144,7 +1144,6 @@ CmpCreateRegistryRoot(VOID)
                             &CmpRegistryRootHandle);
     if (!NT_SUCCESS(Status))
     {
-        ObDereferenceObject(RootKey);
         return FALSE;
     }
 

--- a/ntoskrnl/config/cmsysini.c
+++ b/ntoskrnl/config/cmsysini.c
@@ -1109,7 +1109,11 @@ CmpCreateRegistryRoot(VOID)
     /* Sanity check, and get the key cell */
     ASSERT((&CmiVolatileHive->Hive)->ReleaseCellRoutine == NULL);
     KeyCell = (PCM_KEY_NODE)HvGetCell(&CmiVolatileHive->Hive, RootIndex);
-    if (!KeyCell) return FALSE;
+    if (!KeyCell)
+    {
+        ObDereferenceObject(RootKey);
+        return FALSE;
+    }
 
     /* Create the KCB */
     RtlInitUnicodeString(&KeyName, L"\\REGISTRY");


### PR DESCRIPTION
## Purpose

The problem is detailed in the JIRA ticket: https://jira.reactos.org/browse/CORE-17904. In case of failure, `ObInsertObject` itself dereferences the object, so calling `ObDereferenceObject` one more time in the failure handler is redundant.

JIRA issue: [CORE-17904](https://jira.reactos.org/browse/CORE-17904)

## Proposed changes

- Remove `ObDereferenceObject` call from `CmpCreateRegistryRoot` in case `ObInsertObject` fails.
- Add missing `RootKey` dereference if `CmpCreateRegistryRoot` failed to get the key cell (`KeyCell`).
