### PR TITLE
[NTOS:KE] Apply a special boost if a signaling gate is used

### DIFF
--- a/ntoskrnl/ke/gate.c
+++ b/ntoskrnl/ke/gate.c
@@ -138,6 +138,9 @@ KeSignalGateBoostPriority(IN PKGATE Gate)
     PKTHREAD WaitThread;
     PKWAIT_BLOCK WaitBlock;
     KIRQL OldIrql;
+    SCHAR Priority;
+    PKTHREAD CurrentThread = KeGetCurrentThread();
+
     ASSERT_GATE(Gate);
     ASSERT_IRQL_LESS_OR_EQUAL(DISPATCH_LEVEL);
 
@@ -197,7 +200,10 @@ KeSignalGateBoostPriority(IN PKGATE Gate)
             /* Release the thread lock */
             KiReleaseThreadLock(WaitThread);
 
-            /* FIXME: Boosting */
+            /* Apply a priority boost */
+            Priority = KiComputeNewPriority(CurrentThread, 0);
+            WaitThread->AdjustIncrement = Priority;
+            WaitThread->AdjustReason = AdjustBoost;
 
             /* Check if we have a queue */
             if (WaitThread->Queue)


### PR DESCRIPTION
## Purpose

This PR is intended to address the FIXME in the gates code, namely the lack of priority boosting.
According to Windows Internals, 5th Edition:
"Signaling | Gates | A priority boost should be applied to the woken thread when the gate is signaled"
"A special boost is applied to threads that are awoken as a result of setting an event with the special functions NtSetEventBoostPriority (used in Ntdll.dll for critical sections) and KeSetEventBoostPriority (used for executive resources) or if a signaling gate is used (such as with pushlocks)."

## Proposed changes

In a similar manner to events, compute new thread priority and update adjustment parameters accordingly if a signaling gate is used.

## TODO

- [ ] Tests
