### PR TITLE
[SHELL32] CQueryAssociation: Add slash check

### DIFF
--- a/dll/win32/shell32/CQueryAssociations.cpp
+++ b/dll/win32/shell32/CQueryAssociations.cpp
@@ -98,9 +98,12 @@ HRESULT STDMETHODCALLTYPE CQueryAssociations::Init(
         HRESULT hr;
         LPCWSTR pchDotExt;
 
-        pchDotExt = PathFindExtensionW(pszAssoc);
-        if (pchDotExt && *pchDotExt)
-            pszAssoc = pchDotExt;
+        if (StrChrW(pszAssoc, L'\\'))
+        {
+            pchDotExt = PathFindExtensionW(pszAssoc);
+            if (pchDotExt && *pchDotExt)
+                pszAssoc = pchDotExt;
+        }
 
         LONG ret = RegOpenKeyExW(HKEY_CLASSES_ROOT,
                             pszAssoc,


### PR DESCRIPTION
## Purpose

Follow-up to #6656. I had forgotten to check the slash.
JIRA issue: [CORE-19493](https://jira.reactos.org/browse/CORE-19493)

## Proposed changes

- Add `StrChrW(pszAssoc, L'\\')` check before `PathFindExtensionW` call.

## TODO

- [x] Do big tests.