### PR TITLE
[NTOS:KE/x64][SDK] Improve trap handling with some asm macros

### DIFF
--- a/ntoskrnl/ke/amd64/trap.S
+++ b/ntoskrnl/ke/amd64/trap.S
@@ -841,12 +841,9 @@ GLOBAL_LABEL KiSystemServiceExit
 
     ASSERT_TRAP_FRAME_INTS_ENABLED rsp + MAX_SYSCALL_PARAM_SIZE
 
-    /* Check for pending user APC */
-    mov rcx, gs:qword ptr [PcCurrentThread]
-    cmp byte ptr [rcx + ThApcState + AsUserApcPending], 0
-    jz no_user_apc_pending
-    call KiInitiateUserApc
-no_user_apc_pending:
+    /* Check for pending user APCs */
+    mov rcx, gs:[PcCurrentThread]
+    HANDLE_USER_APCS rcx, rsp + MAX_SYSCALL_PARAM_SIZE
 
     /* Disable interrupts for return */
     cli
@@ -1135,11 +1132,22 @@ PUBLIC KiSetTrapContext
  */
 EXTERN KiDeliverApc:PROC
 
+/*
+ * VOID
+ * KiInitiateUserApc(
+ *     _In_ PKTRAP_FRAME TrapFrame@<rcx>);
+ *
+ * This function is called to deliver user mode APCs.
+ * It clobbers all non-volatile registers, except rax.
+ */
 PUBLIC KiInitiateUserApc
 .PROC KiInitiateUserApc
 
     /* Generate a KEXCEPTION_FRAME on the stack */
     GENERATE_EXCEPTION_FRAME
+
+    /* Save rax to not clobber the return for the system call handler */
+    mov [rsp + ExP1Home], rax
 
     /* Raise IRQL to APC_LEVEL */
     mov rax, APC_LEVEL
@@ -1147,6 +1155,9 @@ PUBLIC KiInitiateUserApc
 
     /* Get the current thread */
     mov rbp, gs:[PcCurrentThread]
+
+    /* Save the trap frame in rsi */
+    mov rsi, rcx
 
 deliver_apcs:
 
@@ -1156,7 +1167,7 @@ deliver_apcs:
     /* Call the C function */
     mov ecx, 1
     mov rdx, rsp
-    mov r8, [rbp + ThTrapFrame]
+    mov r8, rsi
     call KiDeliverApc
 
     /* Disable interrupts again */
@@ -1171,6 +1182,7 @@ deliver_apcs:
     mov cr8, rax
 
     /* Restore the registers from the KEXCEPTION_FRAME */
+    mov rax, [rsp + ExP1Home]
     RESTORE_EXCEPTION_STATE
 
     /* Return */

--- a/ntoskrnl/ke/amd64/trap.S
+++ b/ntoskrnl/ke/amd64/trap.S
@@ -839,12 +839,7 @@ GLOBAL_LABEL KiSystemCall64Again
 
 GLOBAL_LABEL KiSystemServiceExit
 
-#if DBG
-    test dword ptr [rsp + MAX_SYSCALL_PARAM_SIZE + KTRAP_FRAME_EFlags], HEX(200)
-    jnz IntsEnabled
-    int 3
-IntsEnabled:
-#endif
+    ASSERT_TRAP_FRAME_INTS_ENABLED rsp + MAX_SYSCALL_PARAM_SIZE
 
     /* Check for pending user APC */
     mov rcx, gs:qword ptr [PcCurrentThread]

--- a/sdk/include/asm/trapamd64.inc
+++ b/sdk/include/asm/trapamd64.inc
@@ -1,3 +1,41 @@
+/*
+ * PROJECT:     ReactOS SDK
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     ASM macros for x64 trap handling
+ * COPYRIGHT:   Copyright 2011-2024 Timo Kreuzer (timo.kreuzer@reactos.org)
+ */
+
+MACRO(ASSERT_TRAP_FRAME_INTS_ENABLED, Register)
+#if DBG
+    LOCAL IntsAreEnabled
+    test dword ptr [Register + KTRAP_FRAME_EFlags], HEX(200)
+    jnz IntsAreEnabled
+    int HEX(2C)
+IntsAreEnabled:
+#endif
+ENDM
+
+MACRO(ASSERT_TRAP_FRAME_IRQL_VALID, Register)
+#if DBG
+    LOCAL IrqlIsValid
+    mov rax, cr8
+    cmp byte ptr [Register + KTRAP_FRAME_PreviousIrql], al
+    je IrqlIsValid
+    int HEX(2C)
+IrqlIsValid:
+#endif
+ENDM
+
+MACRO(ASSERT_IRQL_PASSIVE)
+#if DBG
+    LOCAL IrqlIsPassive
+    mov rax, cr8
+    test rax, rax
+    jz IrqlIsPassive
+    int HEX(2C)
+IrqlIsPassive:
+#endif
+ENDM
 
 APIC_EOI = HEX(0FFFFFFFFFFFE00B0)
 
@@ -122,13 +160,7 @@ MACRO(EnterTrap, Flags)
     /* Load kernel MXCSR */
     ldmxcsr gs:[PcMxCsr]
 
-#if DBG
-    /* Check IRQL */
-    mov rax, cr8
-    test rax, rax
-    jz kernel_mode_entry
-    int HEX(2c)
-#endif
+    ASSERT_IRQL_PASSIVE
 
 kernel_mode_entry:
 
@@ -163,19 +195,9 @@ ENDM
  */
 MACRO(ExitTrap, Flags)
     LOCAL kernel_mode_return
-    LOCAL IntsEnabled
     LOCAL NoUserApc
-    LOCAL IrqlPassive
-    LOCAL irql_ok
 
-#if DBG
-        /* Check previous irql */
-        mov rax, cr8
-        cmp [rbp + KTRAP_FRAME_PreviousIrql], al
-        je irql_ok
-        int HEX(2c)
-    irql_ok:
-#endif
+    ASSERT_TRAP_FRAME_IRQL_VALID rbp
 
     if (Flags AND TF_SEGMENTS)
         /* Restore segment selectors */
@@ -203,21 +225,8 @@ MACRO(ExitTrap, Flags)
     NoUserApc:
     endif
 
-#if DBG
-    /*Make sure interrupts are enabled */
-    test dword ptr [rbp + KTRAP_FRAME_EFlags], HEX(200)
-    jnz IntsEnabled
-    int HEX(2c)
-IntsEnabled:
-
-    /* Make sure we are at passive level */
-    mov rax, cr8
-    test rax, rax
-    jz IrqlPassive
-    int HEX(2C)
-
-IrqlPassive:
-#endif
+    ASSERT_TRAP_FRAME_INTS_ENABLED rbp
+    ASSERT_IRQL_PASSIVE
 
     cli
 

--- a/sdk/include/asm/trapamd64.inc
+++ b/sdk/include/asm/trapamd64.inc
@@ -37,6 +37,19 @@ IrqlIsPassive:
 #endif
 ENDM
 
+// Checks for user APCs and delivers them if necessary.
+// Clobbers all volatile registers except rax.
+MACRO(HANDLE_USER_APCS, ThreadReg, TrapFrame)
+    LOCAL NoUserApcPending
+
+    /* Check for pending user APC */
+    cmp byte ptr [ThreadReg + ThApcState + AsUserApcPending], 0
+    jz NoUserApcPending
+    lea rcx, [TrapFrame]
+    call KiInitiateUserApc
+NoUserApcPending:
+ENDM
+
 APIC_EOI = HEX(0FFFFFFFFFFFE00B0)
 
 TF_VOLATILES            = HEX(01)
@@ -195,7 +208,6 @@ ENDM
  */
 MACRO(ExitTrap, Flags)
     LOCAL kernel_mode_return
-    LOCAL NoUserApc
 
     ASSERT_TRAP_FRAME_IRQL_VALID rbp
 
@@ -217,12 +229,8 @@ MACRO(ExitTrap, Flags)
     jz kernel_mode_return
 
     if (Flags AND TF_CHECKUSERAPC)
-        /* Load current thread into r10 */
         mov r10, gs:[PcCurrentThread]
-        cmp byte ptr [r10 + KTHREAD_UserApcPending], 0
-        je NoUserApc
-        call KiInitiateUserApc
-    NoUserApc:
+        HANDLE_USER_APCS r10, rbp
     endif
 
     ASSERT_TRAP_FRAME_INTS_ENABLED rbp


### PR DESCRIPTION
## Purpose

This adds some asm macros for trap handling, uses them in the right places. It also fixes some problems, that existed before. The macros will be reused in other places.

## Proposed changes
- Add ASSERT_TRAP_FRAME_INTS_ENABLED, ASSERT_TRAP_FRAME_IRQL_VALID and ASSERT_IRQL_PASSIVE
- Add HANDLE_USER_APCS, make it versatile enough to be able to pass a register for the current thread and the trap frame

## Tests
- https://reactos.org/testman/compare.php?ids=94343,94347,94351,94366

