### PR TITLE
[NTOS:MM] Fix MiDeleteVirtualAddresses

### DIFF
--- a/ntoskrnl/mm/ARM3/virtual.c
+++ b/ntoskrnl/mm/ARM3/virtual.c
@@ -19,38 +19,6 @@
 #define MI_POOL_COPY_BYTES    512
 #define MI_MAX_TRANSFER_SIZE  64 * 1024
 
-#if _MI_PAGING_LEVELS == 2
-FORCEINLINE
-USHORT
-MiQueryPageTableReferences(IN PVOID Address)
-{
-    PUSHORT RefCount;
-
-    RefCount = &MmWorkingSetList->UsedPageTableEntries[MiGetPdeOffset(Address)];
-
-    return *RefCount;
-}
-#else
-FORCEINLINE
-USHORT
-MiQueryPageTableReferences(IN PVOID Address)
-{
-    PMMPDE PointerPde;
-    PMMPFN Pfn;
-
-    /* Make sure we're locked */
-    ASSERT((PsGetCurrentThread()->OwnsProcessWorkingSetExclusive) ||
-           (PsGetCurrentThread()->OwnsProcessWorkingSetShared));
-
-    PointerPde = MiAddressToPde(Address);
-    ASSERT(PointerPde->u.Hard.Valid);
-
-    /* This lies on the PFN */
-    Pfn = MiGetPfnEntry(PFN_FROM_PDE(PointerPde));
-    return Pfn->OriginalPte.u.Soft.UsedPageTableEntries;
-}
-#endif
-
 NTSTATUS NTAPI
 MiProtectVirtualMemory(IN PEPROCESS Process,
                        IN OUT PVOID *BaseAddress,
@@ -698,7 +666,6 @@ MiDeleteVirtualAddresses(IN ULONG_PTR Va,
             TempPte = *PointerPte;
             if (TempPte.u.Long)
             {
-                MiDecrementPageTableReferences((PVOID)Va);
                 /* Check if the PTE is actually mapped in */
                 if (MI_IS_MAPPED_PTE(&TempPte))
                 {
@@ -743,7 +710,7 @@ MiDeleteVirtualAddresses(IN ULONG_PTR Va,
                     /* The PTE was never mapped, just nuke it here */
                     MI_ERASE_PTE(PointerPte);
                 }
-#if 0
+
                 if (MiDecrementPageTableReferences((PVOID)Va) == 0)
                 {
                     ASSERT(PointerPde->u.Long != 0);
@@ -758,30 +725,13 @@ MiDeleteVirtualAddresses(IN ULONG_PTR Va,
                     PointerPte++;
                     break;
                 }
-#endif
             }
 
             /* Update the address and PTE for it */
             Va += PAGE_SIZE;
             PointerPte++;
             PrototypePte++;
-
-            /* Making sure the PDE is still valid */
-            ASSERT(PointerPde->u.Hard.Valid == 1);
-        }
-        while ((Va & (PDE_MAPPED_VA - 1)) && (Va <= EndingAddress));
-
-        /* The PDE should still be valid at this point */
-        ASSERT(PointerPde->u.Hard.Valid == 1);
-
-        /* Check remaining PTE count (go back 1 page due to above loop) */
-        if (MiQueryPageTableReferences((PVOID)(Va - PAGE_SIZE)) == 0)
-        {
-            ASSERT(PointerPde->u.Long != 0);
-
-            /* Delete the PDE proper */
-            MiDeletePde(PointerPde, CurrentProcess);
-        }
+        } while ((Va & (PDE_MAPPED_VA - 1)) && (Va <= EndingAddress));
 
         /* Release the lock */
         MiReleasePfnLock(OldIrql);

--- a/ntoskrnl/mm/ARM3/virtual.c
+++ b/ntoskrnl/mm/ARM3/virtual.c
@@ -723,6 +723,8 @@ MiDeleteVirtualAddresses(IN ULONG_PTR Va,
 
                     /* Use this to detect address gaps */
                     PointerPte++;
+
+                    PrototypePte++;
                     break;
                 }
             }


### PR DESCRIPTION
## Purpose
A fix for BSOD 0x1A caused by commit [c7e09061ca](https://github.com/reactos/reactos/commit/c7e09061ca) without re-introducing `MiQueryPageTableReferences`.

It seems that the code introduced by commit [c7e09061ca](https://github.com/reactos/reactos/commit/c7e09061ca) forgot to update `PrototypePte` before exiting loop when deleting PDE.

After applied this PR, I'm unable to reproduce API Monitor BSOD and SumatraPDF 3.1.2 zoom BSOD. Chromium-XP (49.0.2623.113-R2 VS2015 SSE2 from RAPPS) is usable.

This revert commit [0c612980a](https://github.com/reactos/reactos/commit/0c612980ac9699c329035fe25753a52650e28ff3) ([#6633](https://github.com/reactos/reactos/pull/6633)).

JIRA-issue: [CORE-18818](https://jira.reactos.org/browse/CORE-18818) and many duplicates of that like e.g.: [CORE-18190](https://jira.reactos.org/browse/CORE-18190) and [CORE-19253](https://jira.reactos.org/browse/CORE-19253) , ...