### PR TITLE
[AUDIO] Implement support for WAVE_FORMAT_EXTENSIBLE audio format

### DIFF
--- a/dll/win32/wdmaud.drv/legacy.c
+++ b/dll/win32/wdmaud.drv/legacy.c
@@ -506,7 +506,7 @@ WdmAudSetWaveDeviceFormatByLegacy(
     ZeroMemory(&DeviceInfo, sizeof(WDMAUD_DEVICE_INFO));
     DeviceInfo.DeviceType = DeviceType;
     DeviceInfo.DeviceIndex = DeviceId;
-    DeviceInfo.u.WaveFormatEx.cbSize = sizeof(WAVEFORMATEX); //WaveFormat->cbSize;
+    DeviceInfo.u.WaveFormatEx.cbSize = WaveFormat->cbSize;
     DeviceInfo.u.WaveFormatEx.wFormatTag = WaveFormat->wFormatTag;
 #ifdef USERMODE_MIXER
     DeviceInfo.u.WaveFormatEx.nChannels = 2;
@@ -546,7 +546,7 @@ WdmAudSetWaveDeviceFormatByLegacy(
     }
 
     /* store details */
-    Instance->WaveFormatEx.cbSize = sizeof(WAVEFORMATEX);
+    Instance->WaveFormatEx.cbSize = WaveFormat->cbSize;
     Instance->WaveFormatEx.wBitsPerSample = (DeviceInfo.u.WaveFormatEx.nAvgBytesPerSec * 8) / (DeviceInfo.u.WaveFormatEx.nSamplesPerSec * DeviceInfo.u.WaveFormatEx.nChannels);
 
     /* Store sound device handle instance handle */

--- a/drivers/ksfilter/ks/connectivity.c
+++ b/drivers/ksfilter/ks/connectivity.c
@@ -43,7 +43,7 @@ KsCreatePin(
 
     PKSDATAFORMAT_WAVEFORMATEX Format = (PKSDATAFORMAT_WAVEFORMATEX)(Connect + 1);
     if (Format->DataFormat.FormatSize == sizeof(KSDATAFORMAT) ||
-        Format->DataFormat.FormatSize == sizeof(KSDATAFORMAT) + sizeof(WAVEFORMATEX))
+        Format->DataFormat.FormatSize == sizeof(KSDATAFORMAT) + sizeof(WAVEFORMATEX) + Format->WaveFormatEx.cbSize)
     {
         ConnectSize += Format->DataFormat.FormatSize;
     }


### PR DESCRIPTION
## Purpose

Fix opening audio device error when trying to open it with `WAVE_FORMAT_EXTENSIBLE` format tag set in `wFormatTag` member of `WAVEFORMATEX` by the proper passing additional audio data size and removing a `WAVE_FORMAT_PCM` limitation check, both for Legacy and MMixer APIs.
This fixes audio playback in several apps those are using extensible audio data (e. g. AIMP 5.30 (**needs to manually set BPS to 16 in settings still!**), QMMP 0.12.17, all Chrome/Chromium based browsers, GameDevTycoon Demo game etc.).
Supersedes #3981.
Can be tested in pair with #6682 for better effect (**is merged now**).

JIRA issue: [CORE-10907](https://jira.reactos.org/browse/CORE-10907), [CORE-14783](https://jira.reactos.org/browse/CORE-14783), **other audio issues might also be fixed, they need to be retested too and added here in case they are fixed!**

## Proposed changes

[MMIXER]

- Pass additional data size from `WAVEFORMATEX.cbSize` to pin data format.
- Append it to the whole size of pin data format (`KSDATAFORMAT.FormatSize`).
- Set additional fields in `WAVEFORMATEXTENSIBLE` structure (data format, BPS and channel mask) when WAVE_FORMAT_EXTENSIBLE is used. They are used by our inbuilt Intel AC97 miniport driver at least. It simply fails when these members are not set.
- Fix pin connect allocation size by appending an additional data size from `WAVEFORMATEX.cbSize` to `KSPIN_CONNECT` + `KSDATAFORMAT` + `WAVEFORMATEX`. This allows to properly initialize additional extensible data and avoids kernel memory leakage when using extensible audio format.
- Remove format tag check which allowed WAVE_FORMAT_PCM to be opened correctly. So now all possible audio formats can be opened properly at least (although it does not mean they may work correctly).

[KS]

- Allow passing additional extensible audio data when extensible audio format is used, by appending additional data size from `WAVEFORMATEX.cbSize` to pin connect size passed to `KsCreatePin`. If the tag is `WAVE_FORMAT_PCM`, then this member should always be zero. So in that case, no any additional data is passed to creation request, and the passed data size is correct for PCM too (`KSDATAFORMAT` + `WAVEFORMATEX`).

[WDMAUD.DRV]

- Pass the correct additional data size to I/O control request, by storing a correct size of additional data in `WAVEFORMATEX.cbSize` when performing open of audio device, when `WAVE_FORMAT_EXTENSIBLE` audio format is used. It allows to properly open audio device with Legacy APIs enabled too.

## Result

As visible in the following video, all mentioned apps are now playing the sound correctly (can be played only in Chrome). :slightly_smiling_face: 

https://github.com/reactos/reactos/assets/26385117/2d5eeba6-1213-47fe-9c79-0daf6c23ff27

GameDevTycoon Demo was not tested in the video, but @julenuri confirmed this app is now playing the sound properly too, as it did not do before my changes.