### PR TITLE
[DOC] 3rd Party Files.txt: Complete 'win-iconv'

### DIFF
--- a/media/doc/3rd Party Files.txt
+++ b/media/doc/3rd Party Files.txt
@@ -248,7 +248,7 @@ URL: http://www.mega-nerd.com/SRC/download.html
 Title: win-iconv
 Path: sdk/lib/3rdparty/libwin-iconv
 Used Version: git commit 8765259
-License:
+License: "Public Domain"
 URL: https://github.com/win-iconv/win-iconv
 
 Title: LibXML


### PR DESCRIPTION
## Purpose

Documentation.

Note:
Upstream (code) reads:
`win_iconv is placed in the public domain.`

## Proposed changes

- Add explicit license