### PR TITLE
[COMCTL32] Fix Status Bar Updating

### DIFF
--- a/dll/win32/comctl32/status.c
+++ b/dll/win32/comctl32/status.c
@@ -1120,6 +1120,10 @@ STATUSBAR_WMSize (STATUS_INFO *infoPtr, WORD flags)
     y = parent_rect.bottom - infoPtr->height;
     MoveWindow (infoPtr->Self, x, y, width, infoPtr->height, TRUE);
     STATUSBAR_SetPartBounds (infoPtr);
+#ifdef __REACTOS__
+    parent_rect = infoPtr->parts[infoPtr->numParts - 1].bound;
+    InvalidateRect(infoPtr->Self, &parent_rect, TRUE);
+#endif
     return TRUE;
 }
 


### PR DESCRIPTION
Patch by @I_Kill_Bugs

## Purpose

_Fix bottom right drag triangle updates when window is resized._

JIRA issue: [CORE-19497](https://jira.reactos.org/browse/CORE-19497)

## Proposed changes

_Make STATUSBAR_WMSize Invalidate rectangle when window is resized._

Testbot Results:
PR#6696 refs/pull/6696/merge on top of 0.4.15-dev-7857-g24b4026

KVM:  https://reactos.org/testman/compare.php?ids=94433,94435
VBox: Builder Broken