### PR TITLE
[UMANDLG] Update Romanian (ro-RO) translation

### DIFF
--- a/base/applications/utilman/umandlg/lang/ro-RO.rc
+++ b/base/applications/utilman/umandlg/lang/ro-RO.rc
@@ -2,9 +2,10 @@
  * PROJECT:     ReactOS Utility Manager Resources DLL (UManDlg.dll)
  * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
  * PURPOSE:     Romanian resource file
- * TRANSLATOR:  Copyright 2019 George Bișoc <george.bisoc@reactos.org>
+ * TRANSLATORS: Copyright 2019 George Bișoc <george.bisoc@reactos.org>
+ *              Copyright 2024 Andrei Miloiu <miloiuandrei@gmail.com>
  */
-
+ 
 LANGUAGE LANG_ROMANIAN, SUBLANG_NEUTRAL
 
 IDD_MAIN_DIALOG DIALOGEX 0, 0, 284, 183
@@ -17,12 +18,12 @@ BEGIN
     CONTROL "", IDC_GROUPBOX, "Button", BS_GROUPBOX | WS_CHILD | WS_VISIBLE, 3, 62, 275, 92
     CONTROL "Start", IDC_START, "Button", BS_PUSHBUTTON | WS_CHILD | WS_VISIBLE | WS_TABSTOP, 14, 76, 45, 16
     CONTROL "Oprire", IDC_STOP, "Button", BS_PUSHBUTTON | WS_CHILD | WS_VISIBLE | WS_TABSTOP, 69, 76, 45, 16
-    CONTROL "Pornire automată la Log in", IDC_START_LOG_IN, "Button", BS_CHECKBOX | WS_CHILD | WS_VISIBLE | WS_DISABLED | WS_TABSTOP, 12, 101, 206, 14
-    CONTROL "Pornire automată la blocarea spațiului de lucru", IDC_START_DESKTOP, "Button", BS_CHECKBOX | WS_CHILD | WS_VISIBLE | WS_DISABLED | WS_TABSTOP, 12, 118, 212, 14
-    CONTROL "Pornire automată la pornirea Managerului utilități", IDC_START_UTILMAN, "Button", BS_CHECKBOX | WS_CHILD | WS_VISIBLE | WS_DISABLED | WS_TABSTOP, 12, 134, 212, 13
-    CONTROL "&OK", IDC_OK, "Button", BS_DEFPUSHBUTTON | WS_CHILD | WS_VISIBLE | WS_TABSTOP, 160, 161, 50, 14
-    CONTROL "&Revocare", IDC_CANCEL, "Button", BS_PUSHBUTTON | WS_CHILD | WS_VISIBLE | WS_TABSTOP, 221, 161, 50, 14
-    CONTROL "&Ajutor", IDC_HELP_TOPICS, "Button", BS_PUSHBUTTON | WS_CHILD | WS_VISIBLE | WS_DISABLED | WS_TABSTOP, 98, 161, 50, 14
+    CONTROL "Pornire automată la &Log in", IDC_START_LOG_IN, "Button", BS_CHECKBOX | WS_CHILD | WS_VISIBLE | WS_DISABLED | WS_TABSTOP, 12, 101, 206, 14
+    CONTROL "Pornire automată la blocarea &desktopului", IDC_START_DESKTOP, "Button", BS_CHECKBOX | WS_CHILD | WS_VISIBLE | WS_DISABLED | WS_TABSTOP, 12, 118, 212, 14
+    CONTROL "Pornire automată la pornirea Managerului &utilităţi", IDC_START_UTILMAN, "Button", BS_CHECKBOX | WS_CHILD | WS_VISIBLE | WS_DISABLED | WS_TABSTOP, 12, 134, 212, 13
+    CONTROL "OK", IDC_OK, "Button", BS_DEFPUSHBUTTON | WS_CHILD | WS_VISIBLE | WS_TABSTOP, 160, 161, 50, 14
+    CONTROL "Revocare", IDC_CANCEL, "Button", BS_PUSHBUTTON | WS_CHILD | WS_VISIBLE | WS_TABSTOP, 221, 161, 50, 14
+    CONTROL "Ajutor", IDC_HELP_TOPICS, "Button", BS_PUSHBUTTON | WS_CHILD | WS_VISIBLE | WS_DISABLED | WS_TABSTOP, 98, 161, 50, 14
 END
 
 STRINGTABLE
@@ -40,7 +41,7 @@ END
 
 STRINGTABLE
 BEGIN
-    IDM_ABOUT "Despre Managerul utilitare..."
+    IDM_ABOUT "Despre Managerul utilitare"
     IDS_APP_NAME "Manager utilitare"
     IDS_AUTHORS "Drept de autor 2019 George Bișoc, Hermes Belusca-Maito"
 END


### PR DESCRIPTION
Attendum to https://github.com/reactos/reactos/pull/6517.

I added some accerators and changed the term "spațiu de lucru" that is used in XP/2k3 to the newer one which is "desktop" which is used in NT 6.0+. If you disagree with this change, please let me know.