### PR TITLE
[NTOS:KE] Fix kernel32_apitest QueueUserAPC

### DIFF
--- a/modules/rostests/apitests/kernel32/QueueUserAPC.c
+++ b/modules/rostests/apitests/kernel32/QueueUserAPC.c
@@ -8,7 +8,7 @@
 
 #define MAX_RECORD 30
 
-static DWORD s_record_count = 0;
+static LONG s_record_count = 0;
 static DWORD s_record[MAX_RECORD + 1] = { 0 };
 static BOOL s_terminate_all = FALSE;
 
@@ -24,9 +24,9 @@ static const SIZE_T s_expected_count = _countof(s_expected);
 
 static void AddValueToRecord(DWORD dwValue)
 {
-    s_record[s_record_count] = dwValue;
-    if (s_record_count < MAX_RECORD)
-        s_record_count++;
+    LONG next = InterlockedIncrement(&s_record_count) - 1;
+    if (next < MAX_RECORD)
+        s_record[next] = dwValue;
 }
 
 static VOID CheckRecord(void)

--- a/ntoskrnl/ke/amd64/trap.S
+++ b/ntoskrnl/ke/amd64/trap.S
@@ -1184,8 +1184,6 @@ PUBLIC KiInitiateUserApc
     /* Save the trap frame in rsi */
     mov rsi, rcx
 
-deliver_apcs:
-
     /* Enable interrupts */
     sti
 
@@ -1197,10 +1195,6 @@ deliver_apcs:
 
     /* Disable interrupts again */
     cli
-
-    /* Check if there are more APCs to deliver */
-    cmp byte ptr [rbp + ThApcState + AsUserApcPending], 0
-    jne deliver_apcs
 
     /* Go back to PASSIVE_LEVEL */
     mov rax, PASSIVE_LEVEL

--- a/ntoskrnl/ke/amd64/trap.S
+++ b/ntoskrnl/ke/amd64/trap.S
@@ -852,8 +852,34 @@ GLOBAL_LABEL KiSystemServiceExit
 
     /* Check for pending user APCs */
     mov rcx, gs:[PcCurrentThread]
-    HANDLE_USER_APCS rcx, rsp + MAX_SYSCALL_PARAM_SIZE
+    cmp byte ptr [rcx + ThApcState + AsUserApcPending], 0
+    jz NoUserApcPending
 
+    /* Save missing regs in the trap frame */
+    mov [rsp + MAX_SYSCALL_PARAM_SIZE + KTRAP_FRAME_Rax], rax
+    mov [rsp + MAX_SYSCALL_PARAM_SIZE + KTRAP_FRAME_Rbp], rbp
+    mov [rsp + MAX_SYSCALL_PARAM_SIZE + KTRAP_FRAME_R9], rbp
+    mov rax, [rsp + MAX_SYSCALL_PARAM_SIZE + KTRAP_FRAME_Rsp]
+    mov [rsp + MAX_SYSCALL_PARAM_SIZE + KTRAP_FRAME_R8], rax
+    mov rax, [rsp + MAX_SYSCALL_PARAM_SIZE + KTRAP_FRAME_Rip]
+    mov [rsp + MAX_SYSCALL_PARAM_SIZE + KTRAP_FRAME_Rcx], rax
+    mov rax, [rsp + MAX_SYSCALL_PARAM_SIZE + KTRAP_FRAME_EFlags]
+    mov [rsp + MAX_SYSCALL_PARAM_SIZE + KTRAP_FRAME_R11], rax
+    xor rax, rax
+    mov [rsp + MAX_SYSCALL_PARAM_SIZE + KTRAP_FRAME_Rdx], rax
+    mov [rsp + MAX_SYSCALL_PARAM_SIZE + KTRAP_FRAME_R10], rax
+    pxor xmm0, xmm0
+    movdqa [rsp + MAX_SYSCALL_PARAM_SIZE + KTRAP_FRAME_Xmm0], xmm0
+    movdqa [rsp + MAX_SYSCALL_PARAM_SIZE + KTRAP_FRAME_Xmm1], xmm0
+    movdqa [rsp + MAX_SYSCALL_PARAM_SIZE + KTRAP_FRAME_Xmm2], xmm0
+    movdqa [rsp + MAX_SYSCALL_PARAM_SIZE + KTRAP_FRAME_Xmm3], xmm0
+    movdqa [rsp + MAX_SYSCALL_PARAM_SIZE + KTRAP_FRAME_Xmm4], xmm0
+    movdqa [rsp + MAX_SYSCALL_PARAM_SIZE + KTRAP_FRAME_Xmm5], xmm0
+
+    lea rcx, [rsp + MAX_SYSCALL_PARAM_SIZE]
+    call KiInitiateUserApc
+
+NoUserApcPending:
     /* Disable interrupts for return */
     cli
 
@@ -1148,9 +1174,6 @@ PUBLIC KiInitiateUserApc
     /* Generate a KEXCEPTION_FRAME on the stack */
     GENERATE_EXCEPTION_FRAME
 
-    /* Save rax to not clobber the return for the system call handler */
-    mov [rsp + ExP1Home], rax
-
     /* Raise IRQL to APC_LEVEL */
     mov rax, APC_LEVEL
     mov cr8, rax
@@ -1184,7 +1207,6 @@ deliver_apcs:
     mov cr8, rax
 
     /* Restore the registers from the KEXCEPTION_FRAME */
-    mov rax, [rsp + ExP1Home]
     RESTORE_EXCEPTION_STATE
 
     /* Return */

--- a/ntoskrnl/ke/timerobj.c
+++ b/ntoskrnl/ke/timerobj.c
@@ -63,8 +63,8 @@ FASTCALL
 KiInsertTimerTable(IN PKTIMER Timer,
                    IN ULONG Hand)
 {
-    LARGE_INTEGER InterruptTime;
-    LONGLONG DueTime = Timer->DueTime.QuadPart;
+    ULONGLONG InterruptTime;
+    ULONGLONG DueTime = Timer->DueTime.QuadPart;
     BOOLEAN Expired = FALSE;
     PLIST_ENTRY ListHead, NextEntry;
     PKTIMER CurrentTimer;
@@ -101,8 +101,8 @@ KiInsertTimerTable(IN PKTIMER Timer,
         KiTimerTableListHead[Hand].Time.QuadPart = DueTime;
 
         /* Make sure it hasn't expired already */
-        InterruptTime.QuadPart = KeQueryInterruptTime();
-        if (DueTime <= InterruptTime.QuadPart) Expired = TRUE;
+        InterruptTime = KeQueryInterruptTime();
+        if (DueTime <= InterruptTime) Expired = TRUE;
     }
 
     /* Return expired state */


### PR DESCRIPTION
## Purpose

Multiple fixes for kernel32_apitest QueueUserAPC
Please read carefully!

## Proposed changes
- Fix calculation of timer expiration (this fixes all test failures on x86 / most on x64)
- Use InterlockedIncrement for proper synchronization in the test
- Add test for multiple queued user APCs
- Fix user APC delivery on syscall exit (this fixes remeaining tests on x64)
- Remove pointless loop in KiInitiateUserApc

## Tests
✅ Windows 2003 x64: https://reactos.org/testman/compare.php?ids=94438
✅ WHS: https://reactos.org/testman/compare.php?ids=94442
✅ KVM x86: https://reactos.org/testman/compare.php?ids=94429,94434,94440
✅ KVM x64: https://reactos.org/testman/compare.php?ids=94431,94432,94437,94451

## TODO
- [x] Run on testbots
