### PR TITLE
[RTL/x64] Remove an ASSERT in RtlpTryToUnwindEpilog

### DIFF
--- a/sdk/lib/rtl/amd64/unwind.c
+++ b/sdk/lib/rtl/amd64/unwind.c
@@ -413,7 +413,6 @@ RtlpTryToUnwindEpilog(
     /* Make sure this is really a ret instruction */
     if (*InstrPtr != 0xc3)
     {
-        ASSERT(FALSE);
         return FALSE;
     }
 


### PR DESCRIPTION
This can fail on optimized builds, where functions can end after a noreturn function call without an epilog / ret, but with an int 3. We simply fail gracefully, which is the right thing to do.
