### PR TITLE
[DEVMGR] Add DYNAMIC_FIELD_OFFSET macro

### DIFF
--- a/dll/win32/devmgr/precomp.h
+++ b/dll/win32/devmgr/precomp.h
@@ -76,6 +76,8 @@ OUT LPDWORD lpReboot);
 #include <devmgr/devmgr.h>
 #include <wine/debug.h>
 
+#define DYNAMIC_FIELD_OFFSET(Type, Field) ((LONG)(LONG_PTR)&(((Type*) 0)->Field))
+
 //WINE_DEFAULT_DEBUG_CHANNEL(devmgr);
 
 #endif

--- a/dll/win32/devmgr/properties/hwpage.cpp
+++ b/dll/win32/devmgr/properties/hwpage.cpp
@@ -1030,8 +1030,8 @@ DeviceCreateHardwarePageEx(IN HWND hWndParent,
        failure cases! */
     hpd = (PHARDWARE_PAGE_DATA)HeapAlloc(GetProcessHeap(),
                                          HEAP_ZERO_MEMORY,
-                                         FIELD_OFFSET(HARDWARE_PAGE_DATA,
-                                                      ClassDevInfo[uNumberOfGuids]));
+                                         DYNAMIC_FIELD_OFFSET(HARDWARE_PAGE_DATA,
+                                                              ClassDevInfo[uNumberOfGuids]));
     if (hpd != NULL)
     {
         HWND hWnd;


### PR DESCRIPTION
This replaces the usage of FIELD_OFFSET for dynamic indexing into array fields.
Sadly GCC has broken __builtin_offsetof and they don't seem to intend to fix it.
See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95942

I'm open for suggestions to put this into a global header, I just wasn't sure where to put it.