### PR TITLE
[UDFS] Remove packing around include of ntifs.h

### DIFF
--- a/drivers/filesystems/udfs/udffs.h
+++ b/drivers/filesystems/udfs/udffs.h
@@ -107,10 +107,8 @@
 // Common include files - should be in the include dir of the MS supplied IFS Kit
 #ifndef _CONSOLE
 extern "C" {
-#pragma pack(push, 8)
 #include "ntifs.h"
 #include "ntifs_ex.h"
-#pragma pack(pop)
 }
 #endif //_CONSOLE
 


### PR DESCRIPTION
This is not just wrong, it is criminal.

## Tests
- KVM x86: https://reactos.org/testman/compare.php?ids=94474,94480,94482,94486
- KVM x64: https://reactos.org/testman/compare.php?ids=94461,94469,94483,94488