### PR TITLE
[MSVCRT20][MSVCRT40] Fix heap initialization

### DIFF
--- a/dll/win32/msvcrt20/msvcrt20.c
+++ b/dll/win32/msvcrt20/msvcrt20.c
@@ -53,6 +53,8 @@ extern char** __initenv;     /* pointer to initial environment block */
 extern wchar_t** _wenviron;  /* pointer to environment block */
 extern wchar_t** __winitenv; /* pointer to initial environment block */
 
+
+extern BOOL msvcrt_init_heap(void);
 extern void CDECL __getmainargs(int *argc, char** *argv, char** *envp,
                                 int expand_wildcards, int *new_mode);
 extern void CDECL __wgetmainargs(int *argc, WCHAR** *wargv, WCHAR** *wenvp,
@@ -81,6 +83,9 @@ DllMain(PVOID hinstDll, ULONG dwReason, PVOID reserved)
         /* create tls stuff */
         if (!msvcrt_init_tls())
           return FALSE;
+
+        if (!msvcrt_init_heap())
+            return FALSE;
 
         if (BlockEnvToEnvironA() < 0)
             return FALSE;

--- a/dll/win32/msvcrt40/msvcrt40.c
+++ b/dll/win32/msvcrt40/msvcrt40.c
@@ -54,6 +54,8 @@ extern char** __initenv;     /* pointer to initial environment block */
 extern wchar_t** _wenviron;  /* pointer to environment block */
 extern wchar_t** __winitenv; /* pointer to initial environment block */
 
+extern BOOL msvcrt_init_heap(void);
+
 /* LIBRARY ENTRY POINT ********************************************************/
 
 BOOL
@@ -77,6 +79,9 @@ DllMain(PVOID hinstDll, ULONG dwReason, PVOID reserved)
         /* create tls stuff */
         if (!msvcrt_init_tls())
           return FALSE;
+
+        if (!msvcrt_init_heap())
+            return FALSE;
 
         if (BlockEnvToEnvironA() < 0)
             return FALSE;


### PR DESCRIPTION
## Purpose

Add missing heap initialization in `DllMain` entrypoints of msvcrt20.dll and msvcrt40.dll, similarly to as it is done in msvcrt.dll (CRT). The msvcrt.dll (CRT) initialization code was updated properly during the last winesync, accordingly to the new changes, but msvcrt20.dll/msvcrt40.dll one was not. So update it too.
This fixes the crash of HOVER 1.0 game from Rapps when it tries to allocate a dynamical memory from the uninitialized heap via `malloc()` function exported from our msvcrt20.dll.
Addendum to c47506a which was part of https://github.com/reactos/reactos/pull/4990

JIRA issue: [CORE-19505](https://jira.reactos.org/browse/CORE-19505)

## Result

The HOVER 1.0 game from Rapps reported as not running anymore in the ticket, now runs correctly again after applying my changes, as visible on the following screenshot:
![hover-fixed](https://github.com/reactos/reactos/assets/26385117/cd748b50-f4e4-4888-b4a6-1c11c365305e)