### PR TITLE
[SHELLBTRFS] Prevent redeclaration of __cpuidex with newer mingw-w64 headers

### DIFF
--- a/dll/shellext/shellbtrfs/recv.cpp
+++ b/dll/shellext/shellbtrfs/recv.cpp
@@ -27,6 +27,9 @@
 
 
 #ifndef _MSC_VER
+#ifdef __REACTOS__
+#define __cpuidex __cpuidex_ // prevent redeclaration
+#endif
 #include <cpuid.h>
 #else
 #include <intrin.h>


### PR DESCRIPTION
## Purpose

Make it build with newer mingw-w64 headers.

