### PR TITLE
[SHLWAPI][SHLWAPI_APITEST] Fix NULL behavior of StrDupA/W

### DIFF
--- a/dll/win32/shlwapi/string.c
+++ b/dll/win32/shlwapi/string.c
@@ -1068,7 +1068,13 @@ LPSTR WINAPI StrDupA(LPCSTR lpszStr)
 
   TRACE("(%s)\n",debugstr_a(lpszStr));
 
+#ifdef __REACTOS__
+  if (!lpszStr)
+    return NULL;
+  iLen = strlen(lpszStr) + 1;
+#else
   iLen = lpszStr ? strlen(lpszStr) + 1 : 1;
+#endif
   lpszRet = LocalAlloc(LMEM_FIXED, iLen);
 
   if (lpszRet)
@@ -1093,7 +1099,13 @@ LPWSTR WINAPI StrDupW(LPCWSTR lpszStr)
 
   TRACE("(%s)\n",debugstr_w(lpszStr));
 
+#ifdef __REACTOS__
+  if (!lpszStr)
+    return NULL;
+  iLen = (strlenW(lpszStr) + 1) * sizeof(WCHAR);
+#else
   iLen = (lpszStr ? strlenW(lpszStr) + 1 : 1) * sizeof(WCHAR);
+#endif
   lpszRet = LocalAlloc(LMEM_FIXED, iLen);
 
   if (lpszRet)

--- a/dll/win32/shlwapi/string.c
+++ b/dll/win32/shlwapi/string.c
@@ -1071,10 +1071,8 @@ LPSTR WINAPI StrDupA(LPCSTR lpszStr)
 #ifdef __REACTOS__
   if (!lpszStr)
     return NULL;
-  iLen = strlen(lpszStr) + 1;
-#else
-  iLen = lpszStr ? strlen(lpszStr) + 1 : 1;
 #endif
+  iLen = lpszStr ? strlen(lpszStr) + 1 : 1;
   lpszRet = LocalAlloc(LMEM_FIXED, iLen);
 
   if (lpszRet)
@@ -1102,10 +1100,8 @@ LPWSTR WINAPI StrDupW(LPCWSTR lpszStr)
 #ifdef __REACTOS__
   if (!lpszStr)
     return NULL;
-  iLen = (strlenW(lpszStr) + 1) * sizeof(WCHAR);
-#else
-  iLen = (lpszStr ? strlenW(lpszStr) + 1 : 1) * sizeof(WCHAR);
 #endif
+  iLen = (lpszStr ? strlenW(lpszStr) + 1 : 1) * sizeof(WCHAR);
   lpszRet = LocalAlloc(LMEM_FIXED, iLen);
 
   if (lpszRet)

--- a/modules/rostests/apitests/shlwapi/CMakeLists.txt
+++ b/modules/rostests/apitests/shlwapi/CMakeLists.txt
@@ -17,6 +17,7 @@ list(APPEND SOURCE
     SHLoadIndirectString.c
     SHLoadRegUIString.c
     SHPropertyBag.cpp
+    StrDup.c
     StrFormatByteSizeW.c
     testdata.rc
     testlist.c)

--- a/modules/rostests/apitests/shlwapi/StrDup.c
+++ b/modules/rostests/apitests/shlwapi/StrDup.c
@@ -1,0 +1,46 @@
+/*
+ * PROJECT:     ReactOS api tests
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Tests for StrDupA/W
+ * COPYRIGHT:   Copyright 2024 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ */
+
+#include <apitest.h>
+#include <shlwapi.h>
+#include <versionhelpers.h>
+
+static void TEST_StrDupA(void)
+{
+    LPSTR ptrA;
+
+    ptrA = StrDupA(NULL);
+
+    if (IsWindowsXPOrGreater())
+        ok_ptr(ptrA, NULL);
+    else
+        ok(ptrA && !*ptrA, "ptrA: '%s'\n", wine_dbgstr_a(ptrA));
+
+    if (ptrA)
+        LocalFree(ptrA);
+}
+
+static void TEST_StrDupW(void)
+{
+    LPWSTR ptrW;
+
+    ptrW = StrDupW(NULL);
+
+    if (IsWindowsXPOrGreater())
+        ok_ptr(ptrW, NULL);
+    else
+        ok(ptrW && !*ptrW, "ptrW: '%s'\n", wine_dbgstr_w(ptrW));
+
+    if (ptrW)
+        LocalFree(ptrW);
+}
+
+START_TEST(StrDup)
+{
+    TEST_StrDupA();
+    TEST_StrDupW();
+}

--- a/modules/rostests/apitests/shlwapi/testlist.c
+++ b/modules/rostests/apitests/shlwapi/testlist.c
@@ -13,6 +13,7 @@ extern void func_SHGetRestriction(void);
 extern void func_SHLoadIndirectString(void);
 extern void func_SHLoadRegUIString(void);
 extern void func_SHPropertyBag(void);
+extern void func_StrDup(void);
 extern void func_StrFormatByteSizeW(void);
 
 const struct test winetest_testlist[] =
@@ -29,6 +30,7 @@ const struct test winetest_testlist[] =
     { "SHLoadIndirectString", func_SHLoadIndirectString },
     { "SHLoadRegUIString", func_SHLoadRegUIString },
     { "SHPropertyBag", func_SHPropertyBag },
+    { "StrDup", func_StrDup },
     { "StrFormatByteSizeW", func_StrFormatByteSizeW },
     { 0, 0 }
 };


### PR DESCRIPTION
## Purpose

Fix wrong behavior of `shlwapi!StrDupA` and `shlwapi!StrDupW` functions.
JIRA issue: [CORE-19495](https://jira.reactos.org/browse/CORE-19495)

## Proposed changes

- Return `NULL` when `lpszStr == NULL`.

## TODO

- [x] Do big tests.