### PR TITLE
[KERNEL32] Fix the pipe buffer overflow situation into Iosb.Status in the ReadFile

### DIFF
--- a/dll/win32/kernel32/client/file/rw.c
+++ b/dll/win32/kernel32/client/file/rw.c
@@ -95,16 +95,14 @@ WriteFile(IN HANDLE hFile,
             if (NT_SUCCESS(Status)) Status = Iosb.Status;
         }
 
-        if (NT_SUCCESS(Status))
-        {
-            /*
-             * lpNumberOfBytesWritten must not be NULL here, in fact Win doesn't
-             * check that case either and crashes (only after the operation
-             * completed).
-             */
-            *lpNumberOfBytesWritten = Iosb.Information;
-        }
-        else
+        /*
+         * lpNumberOfBytesWritten must not be NULL here, in fact Win doesn't
+         * check that case either and crashes (only after the operation
+         * completed).
+         */
+        *lpNumberOfBytesWritten = Iosb.Information;
+        
+        if (!NT_SUCCESS(Status))
         {
             BaseSetLastNTError(Status);
             return FALSE;
@@ -219,16 +217,14 @@ ReadFile(IN HANDLE hFile,
             return TRUE;
         }
 
-        if (NT_SUCCESS(Status))
-        {
-            /*
-             * lpNumberOfBytesRead must not be NULL here, in fact Win doesn't
-             * check that case either and crashes (only after the operation
-             * completed).
-             */
-            *lpNumberOfBytesRead = Iosb.Information;
-        }
-        else
+        /*
+         * lpNumberOfBytesRead must not be NULL here, in fact Win doesn't
+         * check that case either and crashes (only after the operation
+         * completed).
+         */
+        *lpNumberOfBytesRead = Iosb.Information;
+
+        if (!NT_SUCCESS(Status))
         {
             BaseSetLastNTError(Status);
             return FALSE;

--- a/modules/rostests/apitests/kernel32/CMakeLists.txt
+++ b/modules/rostests/apitests/kernel32/CMakeLists.txt
@@ -32,6 +32,7 @@ list(APPEND SOURCE
     lstrlen.c
     Mailslot.c
     MultiByteToWideChar.c
+    Pipes.c
     PrivMoveFileIdentityW.c
     QueueUserAPC.c
     SetComputerNameExW.c

--- a/modules/rostests/apitests/kernel32/Pipes.c
+++ b/modules/rostests/apitests/kernel32/Pipes.c
@@ -1,0 +1,131 @@
+/*
+ * PROJECT:         ReactOS api tests
+ * LICENSE:         GNU GPLv2 only as published by the Free Software Foundation
+ * PURPOSE:         Test for pipe (CORE-17376)
+ * PROGRAMMER:      Simone Mario Lombardo
+ */
+
+#include "precomp.h"
+
+#define LP TEXT("\\\\.\\pipe\\rostest_pipe")
+
+#define MINBUFFERSIZE 1
+#define MAXBUFFERSIZE 255
+
+static DWORD dReadBufferSize;
+
+DWORD
+WINAPI
+PipeWriter(
+        _In_ PVOID Param)
+{
+    DWORD cbWritten;
+    HANDLE hPipe;
+    DWORD dwLastError;
+    BOOL Success;
+    PCSTR pszInMsg = "Test";
+
+    hPipe = CreateFile(LP, GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE,
+            NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+    ok(hPipe != INVALID_HANDLE_VALUE, "CreateFile failed, results might not be accurate\n");
+    if (hPipe != INVALID_HANDLE_VALUE)
+    {
+        Sleep(0);
+        Success = WriteFile(hPipe, &pszInMsg, 4, &cbWritten, NULL);
+        dwLastError = GetLastError();
+
+        ok(Success, "Pipe's WriteFile returned FALSE, instead of expected TRUE\n");
+        if(dwLastError != 0)
+            trace("Last Error = 0x%lX\n",dwLastError);
+
+        ok(cbWritten > 0,"Pipe's Writefile has lpNumberOfBytesWritten <= 0\n");
+
+        CloseHandle(hPipe);
+    }
+    return 0;
+}
+
+DWORD
+WINAPI
+PipeReader(
+        _In_ PVOID Param)
+{
+    HANDLE hPipe;
+    DWORD cbRead;
+    HANDLE hThread;
+    DWORD dwLastError;
+    BOOL Success;
+    CHAR szOutMsg[MAXBUFFERSIZE];
+
+    hPipe = CreateNamedPipeA( 
+        LP,
+        PIPE_ACCESS_DUPLEX,
+        PIPE_TYPE_MESSAGE|PIPE_READMODE_MESSAGE,
+        1,
+        MAXBUFFERSIZE,
+        MAXBUFFERSIZE,
+        0,
+        NULL
+    );
+    ok(hPipe != INVALID_HANDLE_VALUE, "CreateNamedPipeA failed\n");
+    if (hPipe != INVALID_HANDLE_VALUE)
+    {
+        hThread = CreateThread(NULL,0, PipeWriter, NULL, 0, NULL);
+        ok(hThread != INVALID_HANDLE_VALUE, "CreateThread failed\n");
+        if (hThread != INVALID_HANDLE_VALUE)
+        {
+            Sleep(0);
+            Success = ReadFile(hPipe, &szOutMsg, dReadBufferSize, &cbRead, NULL);
+            dwLastError = GetLastError();
+
+            if(dReadBufferSize == MINBUFFERSIZE)
+            {
+                ok(!Success, "Pipe's ReadFile returned TRUE, instead of expected FALSE\n");
+            }
+            else
+            {
+                ok(Success, "Pipe's ReadFile returned FALSE, instead of expected TRUE\n");
+                if(dwLastError != 0)
+                    trace("Last Error = 0x%lX\n",dwLastError);
+            }
+
+            ok(cbRead > 0,"Pipe's Readfile has lpNumberOfBytesRead <= 0\n");
+
+            if(dReadBufferSize == MINBUFFERSIZE)
+                ok(dwLastError == ERROR_MORE_DATA, "Pipe's ReadFile last error is unexpected\n");
+
+            WaitForSingleObject(hThread, INFINITE);
+            CloseHandle(hThread);
+        }
+        CloseHandle(hPipe);
+    }
+    return 0;
+}
+
+VOID
+StartTestCORE17376(
+     _In_ DWORD adReadBufferSize)
+{
+    HANDLE hThread;
+
+    trace("adReadBufferSize = %ld - START\n", adReadBufferSize);
+
+    dReadBufferSize = adReadBufferSize;
+
+    hThread = CreateThread(NULL,0, PipeReader, NULL, 0, NULL);
+    ok(hThread != INVALID_HANDLE_VALUE, "CreateThread failed\n");
+    if (hThread != INVALID_HANDLE_VALUE)
+    {
+        WaitForSingleObject(hThread, INFINITE);
+        CloseHandle(hThread);
+    }
+
+    trace("adReadBufferSize = %ld - COMPLETED\n", adReadBufferSize);
+}
+
+START_TEST(Pipes)
+{
+    StartTestCORE17376(MINBUFFERSIZE);
+    StartTestCORE17376(MAXBUFFERSIZE);
+}
+

--- a/modules/rostests/apitests/kernel32/Pipes.c
+++ b/modules/rostests/apitests/kernel32/Pipes.c
@@ -2,7 +2,8 @@
  * PROJECT:         ReactOS api tests
  * LICENSE:         GNU GPLv2 only as published by the Free Software Foundation
  * PURPOSE:         Test for pipe (CORE-17376)
- * PROGRAMMER:      Simone Mario Lombardo
+ * PROGRAMMER:      Simone Mario Lombardo <me@simonelombardo.com>
+ *                  Julen Urizar Compains <julenuri@hotmail.com>
  */
 
 #include "precomp.h"
@@ -11,109 +12,99 @@ static const char* g_PipeName = "\\\\.\\pipe\\rostest_pipe";
 
 #define MINBUFFERSIZE 1
 #define MAXBUFFERSIZE 255
+#define TEST_MESSAGE "Test"
+#define TEST_MESSAGE_SIZE 4
 
 static DWORD g_dwReadBufferSize;
 
 DWORD WINAPI PipeWriter(_In_ PVOID Param)
 {
-    DWORD cbWritten;
-    HANDLE hPipe = (HANDLE) Param;
-    DWORD dwLastError;
-    BOOL Success;
-    PCSTR pszInMsg = "Test";
+    HANDLE hPipe = (HANDLE)Param;
+    DWORD cbWritten = 0;
+    BOOL Success = WriteFile(hPipe, TEST_MESSAGE, TEST_MESSAGE_SIZE, &cbWritten, NULL);
 
-    cbWritten = 0xdeadbeef;
-    Success = WriteFile(hPipe, &pszInMsg, 4, &cbWritten, NULL);
-    dwLastError = GetLastError();
-
-    ok(Success, "Pipe's WriteFile returned FALSE, instead of expected TRUE\n");
-    ok(dwLastError == 0, "dwLastError was 0x%lx\n", dwLastError);
-    trace("Last Error = 0x%lX\n",dwLastError);
-    ok(cbWritten == 4,"Invalid cbWritten: 0x%lx\n", cbWritten);
+    ok(Success, "WriteFile() failed, last error = 0x%lx\n", GetLastError());
+    ok_int(cbWritten, TEST_MESSAGE_SIZE);
 
     return 0;
 }
 
 DWORD WINAPI PipeReader(_In_ PVOID Param)
 {
-    DWORD cbRead;
-    DWORD dwLastError;
-    BOOL Success;
-    CHAR szOutMsg[MAXBUFFERSIZE];
-    HANDLE hPipe = (HANDLE) Param;
+    HANDLE hPipe = (HANDLE)Param;
+    CHAR outMsg[MAXBUFFERSIZE];
 
-    cbRead = 0xdeadbeef;
-    Success = ReadFile(hPipe, &szOutMsg, g_dwReadBufferSize, &cbRead, NULL);
-    dwLastError = GetLastError();
-
-    if(g_dwReadBufferSize == MINBUFFERSIZE)
-    {
-        ok(!Success, "Pipe's ReadFile returned TRUE, instead of expected FALSE\n");
-    }
+    DWORD cbRead = 0;
+    BOOL Success = ReadFile(hPipe, outMsg, g_dwReadBufferSize, &cbRead, NULL);
+    
+    if (g_dwReadBufferSize == MINBUFFERSIZE)
+        ok(!Success, "ReadFile() unexpectedly succeeded\n");
     else
-    {
-        ok(Success, "Pipe's ReadFile returned FALSE, instead of expected TRUE\n");
-        ok(dwLastError == 0, "dwLastError was 0x%lx\n", dwLastError);
-        trace("Last Error = 0x%lX\n",dwLastError);
-    }
+        ok(Success, "ReadFile() failed, last error = 0x%lx\n", GetLastError());
 
-    ok(cbRead > 0,"Invalid cbRead: 0x%lx\n", cbRead);
+    ok(cbRead != 0, "cbRead == 0\n");
 
-    if(g_dwReadBufferSize == MINBUFFERSIZE)
-        ok(dwLastError == ERROR_MORE_DATA, "Pipe's ReadFile last error is unexpected\n");
+    if (g_dwReadBufferSize == MINBUFFERSIZE)
+        ok_hex(GetLastError(), ERROR_MORE_DATA);
 
     return 0;
 }
 
 VOID StartTestCORE17376(_In_ DWORD adReadBufferSize)
 {
-    HANDLE hPipeReader;
-    HANDLE hPipeWriter;
-    HANDLE hThreadReader;
-    HANDLE hThreadWriter;
+    HANDLE hPipeReader, hPipeWriter, hThreadReader, hThreadWriter;
     trace("adReadBufferSize = %ld - START\n", adReadBufferSize);
 
     g_dwReadBufferSize = adReadBufferSize;
 
-    hPipeReader = CreateNamedPipeA( 
+    hPipeReader = CreateNamedPipeA(
         g_PipeName,
         PIPE_ACCESS_DUPLEX,
-        PIPE_TYPE_MESSAGE|PIPE_READMODE_MESSAGE,
+        PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE,
         1,
         MAXBUFFERSIZE,
         MAXBUFFERSIZE,
         0,
         NULL);
     ok(hPipeReader != INVALID_HANDLE_VALUE, "CreateNamedPipeA failed\n");
-    hThreadReader = CreateThread(NULL,0, PipeReader, hPipeReader, 0, NULL);
 
-    if (hPipeReader != INVALID_HANDLE_VALUE)
+    if (hPipeReader == INVALID_HANDLE_VALUE)
+        return;
+
+    hThreadReader = CreateThread(NULL, 0, PipeReader, hPipeReader, 0, NULL);
+    ok(hThreadReader != INVALID_HANDLE_VALUE, "CreateThread failed\n");
+
+    hPipeWriter = CreateFile(
+        g_PipeName,
+        GENERIC_READ | GENERIC_WRITE,
+        FILE_SHARE_READ | FILE_SHARE_WRITE,
+        NULL,
+        OPEN_EXISTING,
+        FILE_ATTRIBUTE_NORMAL,
+        NULL);
+    ok(hPipeWriter != INVALID_HANDLE_VALUE, "CreateFile failed\n");
+
+    if (hPipeWriter != INVALID_HANDLE_VALUE)
     {
-        ok(hThreadReader != INVALID_HANDLE_VALUE, "CreateThread failed\n");
+        hThreadWriter = CreateThread(NULL, 0, PipeWriter, hPipeWriter, 0, NULL);
+        ok(hThreadWriter != INVALID_HANDLE_VALUE, "CreateThread failed\n");
 
-        hPipeWriter = CreateFile(g_PipeName, GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE,
-        NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
-    ok(hPipeWriter != INVALID_HANDLE_VALUE, "CreateFile failed, results might not be accurate\n");
-
-        if (hPipeWriter != INVALID_HANDLE_VALUE)
+        if (hThreadWriter != INVALID_HANDLE_VALUE)
         {
-            hThreadWriter = CreateThread(NULL,0, PipeWriter, hPipeWriter, 0, NULL);
-            ok(hThreadWriter != INVALID_HANDLE_VALUE, "CreateThread failed\n");
-            if (hThreadWriter != INVALID_HANDLE_VALUE)
-            {
-                WaitForSingleObject(hThreadWriter, INFINITE);
-                CloseHandle(hThreadWriter);
-                if (hThreadReader != INVALID_HANDLE_VALUE)
-                {
-                    WaitForSingleObject(hThreadReader, INFINITE);
-                    CloseHandle(hThreadReader);
-                }
-            }
-            CloseHandle(hPipeWriter);
+            WaitForSingleObject(hThreadWriter, INFINITE);
+            CloseHandle(hThreadWriter);
         }
-        CloseHandle(hPipeReader);
+        CloseHandle(hPipeWriter);
     }
-        trace("adReadBufferSize = %ld - COMPLETED\n", adReadBufferSize);
+
+    if (hThreadReader != INVALID_HANDLE_VALUE)
+    {
+        WaitForSingleObject(hThreadReader, INFINITE);
+        CloseHandle(hThreadReader);
+    }
+    CloseHandle(hPipeReader);
+
+    trace("adReadBufferSize = %ld - COMPLETED\n", adReadBufferSize);
 }
 
 START_TEST(Pipes)
@@ -121,4 +112,3 @@ START_TEST(Pipes)
     StartTestCORE17376(MINBUFFERSIZE);
     StartTestCORE17376(MAXBUFFERSIZE);
 }
-

--- a/modules/rostests/apitests/kernel32/Pipes.c
+++ b/modules/rostests/apitests/kernel32/Pipes.c
@@ -7,120 +7,113 @@
 
 #include "precomp.h"
 
-#define LP TEXT("\\\\.\\pipe\\rostest_pipe")
+static const char* g_PipeName = "\\\\.\\pipe\\rostest_pipe";
 
 #define MINBUFFERSIZE 1
 #define MAXBUFFERSIZE 255
 
-static DWORD dReadBufferSize;
+static DWORD g_dwReadBufferSize;
 
-DWORD
-WINAPI
-PipeWriter(
-        _In_ PVOID Param)
+DWORD WINAPI PipeWriter(_In_ PVOID Param)
 {
     DWORD cbWritten;
-    HANDLE hPipe;
+    HANDLE hPipe = (HANDLE) Param;
     DWORD dwLastError;
     BOOL Success;
     PCSTR pszInMsg = "Test";
 
-    hPipe = CreateFile(LP, GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE,
-            NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
-    ok(hPipe != INVALID_HANDLE_VALUE, "CreateFile failed, results might not be accurate\n");
-    if (hPipe != INVALID_HANDLE_VALUE)
-    {
-        Sleep(0);
-        Success = WriteFile(hPipe, &pszInMsg, 4, &cbWritten, NULL);
-        dwLastError = GetLastError();
+    cbWritten = 0xdeadbeef;
+    Success = WriteFile(hPipe, &pszInMsg, 4, &cbWritten, NULL);
+    dwLastError = GetLastError();
 
-        ok(Success, "Pipe's WriteFile returned FALSE, instead of expected TRUE\n");
-        if(dwLastError != 0)
-            trace("Last Error = 0x%lX\n",dwLastError);
+    ok(Success, "Pipe's WriteFile returned FALSE, instead of expected TRUE\n");
+    ok(dwLastError == 0, "dwLastError was 0x%lx\n", dwLastError);
+    trace("Last Error = 0x%lX\n",dwLastError);
+    ok(cbWritten == 4,"Invalid cbWritten: 0x%lx\n", cbWritten);
 
-        ok(cbWritten > 0,"Pipe's Writefile has lpNumberOfBytesWritten <= 0\n");
-
-        CloseHandle(hPipe);
-    }
     return 0;
 }
 
-DWORD
-WINAPI
-PipeReader(
-        _In_ PVOID Param)
+DWORD WINAPI PipeReader(_In_ PVOID Param)
 {
-    HANDLE hPipe;
     DWORD cbRead;
-    HANDLE hThread;
     DWORD dwLastError;
     BOOL Success;
     CHAR szOutMsg[MAXBUFFERSIZE];
+    HANDLE hPipe = (HANDLE) Param;
 
-    hPipe = CreateNamedPipeA( 
-        LP,
+    cbRead = 0xdeadbeef;
+    Success = ReadFile(hPipe, &szOutMsg, g_dwReadBufferSize, &cbRead, NULL);
+    dwLastError = GetLastError();
+
+    if(g_dwReadBufferSize == MINBUFFERSIZE)
+    {
+        ok(!Success, "Pipe's ReadFile returned TRUE, instead of expected FALSE\n");
+    }
+    else
+    {
+        ok(Success, "Pipe's ReadFile returned FALSE, instead of expected TRUE\n");
+        ok(dwLastError == 0, "dwLastError was 0x%lx\n", dwLastError);
+        trace("Last Error = 0x%lX\n",dwLastError);
+    }
+
+    ok(cbRead > 0,"Invalid cbRead: 0x%lx\n", cbRead);
+
+    if(g_dwReadBufferSize == MINBUFFERSIZE)
+        ok(dwLastError == ERROR_MORE_DATA, "Pipe's ReadFile last error is unexpected\n");
+
+    return 0;
+}
+
+VOID StartTestCORE17376(_In_ DWORD adReadBufferSize)
+{
+    HANDLE hPipeReader;
+    HANDLE hPipeWriter;
+    HANDLE hThreadReader;
+    HANDLE hThreadWriter;
+    trace("adReadBufferSize = %ld - START\n", adReadBufferSize);
+
+    g_dwReadBufferSize = adReadBufferSize;
+
+    hPipeReader = CreateNamedPipeA( 
+        g_PipeName,
         PIPE_ACCESS_DUPLEX,
         PIPE_TYPE_MESSAGE|PIPE_READMODE_MESSAGE,
         1,
         MAXBUFFERSIZE,
         MAXBUFFERSIZE,
         0,
-        NULL
-    );
-    ok(hPipe != INVALID_HANDLE_VALUE, "CreateNamedPipeA failed\n");
-    if (hPipe != INVALID_HANDLE_VALUE)
+        NULL);
+    ok(hPipeReader != INVALID_HANDLE_VALUE, "CreateNamedPipeA failed\n");
+    hThreadReader = CreateThread(NULL,0, PipeReader, hPipeReader, 0, NULL);
+
+    if (hPipeReader != INVALID_HANDLE_VALUE)
     {
-        hThread = CreateThread(NULL,0, PipeWriter, NULL, 0, NULL);
-        ok(hThread != INVALID_HANDLE_VALUE, "CreateThread failed\n");
-        if (hThread != INVALID_HANDLE_VALUE)
+        ok(hThreadReader != INVALID_HANDLE_VALUE, "CreateThread failed\n");
+
+        hPipeWriter = CreateFile(g_PipeName, GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE,
+        NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+    ok(hPipeWriter != INVALID_HANDLE_VALUE, "CreateFile failed, results might not be accurate\n");
+
+        if (hPipeWriter != INVALID_HANDLE_VALUE)
         {
-            Sleep(0);
-            Success = ReadFile(hPipe, &szOutMsg, dReadBufferSize, &cbRead, NULL);
-            dwLastError = GetLastError();
-
-            if(dReadBufferSize == MINBUFFERSIZE)
+            hThreadWriter = CreateThread(NULL,0, PipeWriter, hPipeWriter, 0, NULL);
+            ok(hThreadWriter != INVALID_HANDLE_VALUE, "CreateThread failed\n");
+            if (hThreadWriter != INVALID_HANDLE_VALUE)
             {
-                ok(!Success, "Pipe's ReadFile returned TRUE, instead of expected FALSE\n");
+                WaitForSingleObject(hThreadWriter, INFINITE);
+                CloseHandle(hThreadWriter);
+                if (hThreadReader != INVALID_HANDLE_VALUE)
+                {
+                    WaitForSingleObject(hThreadReader, INFINITE);
+                    CloseHandle(hThreadReader);
+                }
             }
-            else
-            {
-                ok(Success, "Pipe's ReadFile returned FALSE, instead of expected TRUE\n");
-                if(dwLastError != 0)
-                    trace("Last Error = 0x%lX\n",dwLastError);
-            }
-
-            ok(cbRead > 0,"Pipe's Readfile has lpNumberOfBytesRead <= 0\n");
-
-            if(dReadBufferSize == MINBUFFERSIZE)
-                ok(dwLastError == ERROR_MORE_DATA, "Pipe's ReadFile last error is unexpected\n");
-
-            WaitForSingleObject(hThread, INFINITE);
-            CloseHandle(hThread);
+            CloseHandle(hPipeWriter);
         }
-        CloseHandle(hPipe);
+        CloseHandle(hPipeReader);
     }
-    return 0;
-}
-
-VOID
-StartTestCORE17376(
-     _In_ DWORD adReadBufferSize)
-{
-    HANDLE hThread;
-
-    trace("adReadBufferSize = %ld - START\n", adReadBufferSize);
-
-    dReadBufferSize = adReadBufferSize;
-
-    hThread = CreateThread(NULL,0, PipeReader, NULL, 0, NULL);
-    ok(hThread != INVALID_HANDLE_VALUE, "CreateThread failed\n");
-    if (hThread != INVALID_HANDLE_VALUE)
-    {
-        WaitForSingleObject(hThread, INFINITE);
-        CloseHandle(hThread);
-    }
-
-    trace("adReadBufferSize = %ld - COMPLETED\n", adReadBufferSize);
+        trace("adReadBufferSize = %ld - COMPLETED\n", adReadBufferSize);
 }
 
 START_TEST(Pipes)

--- a/modules/rostests/apitests/kernel32/Pipes.c
+++ b/modules/rostests/apitests/kernel32/Pipes.c
@@ -8,12 +8,12 @@
 
 #include "precomp.h"
 
-static const char* g_PipeName = "\\\\.\\pipe\\rostest_pipe";
+static PCWSTR g_PipeName = L"\\\\.\\pipe\\rostest_pipe";
 
 #define MINBUFFERSIZE 1
 #define MAXBUFFERSIZE 255
 #define TEST_MESSAGE "Test"
-#define TEST_MESSAGE_SIZE 4
+#define TEST_MESSAGE_SIZE (sizeof(TEST_MESSAGE) - sizeof(ANSI_NULL))
 
 static DWORD g_dwReadBufferSize;
 
@@ -38,7 +38,7 @@ DWORD WINAPI PipeReader(_In_ PVOID Param)
     BOOL Success = ReadFile(hPipe, outMsg, g_dwReadBufferSize, &cbRead, NULL);
     
     if (g_dwReadBufferSize == MINBUFFERSIZE)
-        ok(!Success, "ReadFile() unexpectedly succeeded\n");
+        ok(!Success, "ReadFile() succeeded unexpectedly\n");
     else
         ok(Success, "ReadFile() failed, last error = 0x%lx\n", GetLastError());
 
@@ -53,11 +53,11 @@ DWORD WINAPI PipeReader(_In_ PVOID Param)
 VOID StartTestCORE17376(_In_ DWORD adReadBufferSize)
 {
     HANDLE hPipeReader, hPipeWriter, hThreadReader, hThreadWriter;
-    trace("adReadBufferSize = %ld - START\n", adReadBufferSize);
+    trace("adReadBufferSize = %lu - START\n", adReadBufferSize);
 
     g_dwReadBufferSize = adReadBufferSize;
 
-    hPipeReader = CreateNamedPipeA(
+    hPipeReader = CreateNamedPipeW(
         g_PipeName,
         PIPE_ACCESS_DUPLEX,
         PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE,
@@ -66,7 +66,7 @@ VOID StartTestCORE17376(_In_ DWORD adReadBufferSize)
         MAXBUFFERSIZE,
         0,
         NULL);
-    ok(hPipeReader != INVALID_HANDLE_VALUE, "CreateNamedPipeA failed\n");
+    ok(hPipeReader != INVALID_HANDLE_VALUE, "CreateNamedPipeW failed\n");
 
     if (hPipeReader == INVALID_HANDLE_VALUE)
         return;
@@ -74,7 +74,7 @@ VOID StartTestCORE17376(_In_ DWORD adReadBufferSize)
     hThreadReader = CreateThread(NULL, 0, PipeReader, hPipeReader, 0, NULL);
     ok(hThreadReader != INVALID_HANDLE_VALUE, "CreateThread failed\n");
 
-    hPipeWriter = CreateFile(
+    hPipeWriter = CreateFileW(
         g_PipeName,
         GENERIC_READ | GENERIC_WRITE,
         FILE_SHARE_READ | FILE_SHARE_WRITE,
@@ -82,7 +82,7 @@ VOID StartTestCORE17376(_In_ DWORD adReadBufferSize)
         OPEN_EXISTING,
         FILE_ATTRIBUTE_NORMAL,
         NULL);
-    ok(hPipeWriter != INVALID_HANDLE_VALUE, "CreateFile failed\n");
+    ok(hPipeWriter != INVALID_HANDLE_VALUE, "CreateFileW failed\n");
 
     if (hPipeWriter != INVALID_HANDLE_VALUE)
     {
@@ -104,7 +104,7 @@ VOID StartTestCORE17376(_In_ DWORD adReadBufferSize)
     }
     CloseHandle(hPipeReader);
 
-    trace("adReadBufferSize = %ld - COMPLETED\n", adReadBufferSize);
+    trace("adReadBufferSize = %lu - COMPLETED\n", adReadBufferSize);
 }
 
 START_TEST(Pipes)

--- a/modules/rostests/apitests/kernel32/Pipes.c
+++ b/modules/rostests/apitests/kernel32/Pipes.c
@@ -1,6 +1,6 @@
 /*
  * PROJECT:         ReactOS api tests
- * LICENSE:         GNU GPLv2 only as published by the Free Software Foundation
+ * LICENSE:         GPLv2+ - See COPYING in the top level directory
  * PURPOSE:         Test for pipe (CORE-17376)
  * PROGRAMMER:      Simone Mario Lombardo <me@simonelombardo.com>
  *                  Julen Urizar Compains <julenuri@hotmail.com>

--- a/modules/rostests/apitests/kernel32/Pipes.c
+++ b/modules/rostests/apitests/kernel32/Pipes.c
@@ -1,9 +1,9 @@
 /*
- * PROJECT:         ReactOS api tests
- * LICENSE:         GPLv2+ - See COPYING in the top level directory
- * PURPOSE:         Test for pipe (CORE-17376)
- * PROGRAMMER:      Simone Mario Lombardo <me@simonelombardo.com>
- *                  Julen Urizar Compains <julenuri@hotmail.com>
+ * PROJECT:     ReactOS API tests
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Test for pipe (CORE-17376)
+ * COPYRIGHT:   Copyright 2024 Simone Mario Lombardo <me@simonelombardo.com>
+ *              Copyright 2024 Julen Urizar Compains <julenuri@hotmail.com>
  */
 
 #include "precomp.h"

--- a/modules/rostests/apitests/kernel32/testlist.c
+++ b/modules/rostests/apitests/kernel32/testlist.c
@@ -31,6 +31,7 @@ extern void func_lstrcpynW(void);
 extern void func_lstrlen(void);
 extern void func_Mailslot(void);
 extern void func_MultiByteToWideChar(void);
+extern void func_Pipes(void);
 extern void func_PrivMoveFileIdentityW(void);
 extern void func_QueueUserAPC(void);
 extern void func_SetComputerNameExW(void);
@@ -45,6 +46,7 @@ extern void func_WideCharToMultiByte(void);
 
 const struct test winetest_testlist[] =
 {
+    { "ActCtxWithXmlNamespaces",     func_ActCtxWithXmlNamespaces },
     { "ConsoleCP",                   func_ConsoleCP },
     { "CreateProcess",               func_CreateProcess },
     { "DefaultActCtx",               func_DefaultActCtx },
@@ -73,6 +75,7 @@ const struct test winetest_testlist[] =
     { "lstrlen",                     func_lstrlen },
     { "MailslotRead",                func_Mailslot },
     { "MultiByteToWideChar",         func_MultiByteToWideChar },
+    { "Pipes",                       func_Pipes },
     { "PrivMoveFileIdentityW",       func_PrivMoveFileIdentityW },
     { "QueueUserAPC",                func_QueueUserAPC },
     { "SetComputerNameExW",          func_SetComputerNameExW },
@@ -84,6 +87,5 @@ const struct test winetest_testlist[] =
     { "TunnelCache",                 func_TunnelCache },
     { "UEFIFirmware",                func_UEFIFirmware },
     { "WideCharToMultiByte",         func_WideCharToMultiByte },
-    { "ActCtxWithXmlNamespaces",     func_ActCtxWithXmlNamespaces },
     { 0, 0 }
 };


### PR DESCRIPTION
## Purpose

Fix the Calibre conversion failure under ReactOS. That fixes the pipes situations, and makes it to do it. Fixes the situation in both, x86 and x64 situations.

Not my patch, read the JIRA ticket with explanations by Simone.

JIRA issue: [CORE-17376](https://jira.reactos.org/browse/CORE-17376)

Before:
![Example Error](https://github.com/reactos/reactos/assets/27921286/0b70df4c-15af-4d1b-9247-97637348b85d)

After: 
![Example Fixed](https://github.com/reactos/reactos/assets/27921286/80e8629c-3dab-47b6-ab64-d3137b4b0883)


## Proposed changes

Change the way ReadFile and NTReadFile behaves under ReactOS, and fit more what Wine does.

## TODO

-  [x] Do tests and run testbots.
-  [x] Listen every single proposal about the code and about the fix. It might be or might not the best option, so...
