### PR TITLE
[NTOS:KE/x64] Fix/improve register handling on traps / syscalls

### DIFF
--- a/hal/halx86/apic/apictrap.S
+++ b/hal/halx86/apic/apictrap.S
@@ -15,9 +15,9 @@
 #include <trapamd64.inc>
 .code
 
-TRAP_ENTRY HalpClockInterrupt, (TF_VOLATILES OR TF_SEND_EOI)
-TRAP_ENTRY HalpClockIpi, (TF_VOLATILES OR TF_SEND_EOI)
-TRAP_ENTRY HalpProfileInterrupt, (TF_VOLATILES OR TF_SEND_EOI)
+TRAP_ENTRY HalpClockInterrupt, TF_SEND_EOI
+TRAP_ENTRY HalpClockIpi, TF_SEND_EOI
+TRAP_ENTRY HalpProfileInterrupt, TF_SEND_EOI
 
 PUBLIC ApicSpuriousService
 ApicSpuriousService:

--- a/ntoskrnl/ke/amd64/context.c
+++ b/ntoskrnl/ke/amd64/context.c
@@ -36,11 +36,8 @@ KeContextToTrapFrame(IN PCONTEXT Context,
     if (ContextFlags & CONTEXT_INTEGER)
     {
         TrapFrame->Rax = Context->Rax;
-        TrapFrame->Rbx = Context->Rbx;
         TrapFrame->Rcx = Context->Rcx;
         TrapFrame->Rdx = Context->Rdx;
-        TrapFrame->Rsi = Context->Rsi;
-        TrapFrame->Rdi = Context->Rdi;
         TrapFrame->Rbp = Context->Rbp;
         TrapFrame->R8 = Context->R8;
         TrapFrame->R9 = Context->R9;
@@ -48,6 +45,9 @@ KeContextToTrapFrame(IN PCONTEXT Context,
         TrapFrame->R11 = Context->R11;
         if (ExceptionFrame)
         {
+            ExceptionFrame->Rbx = Context->Rbx;
+            ExceptionFrame->Rsi = Context->Rsi;
+            ExceptionFrame->Rdi = Context->Rdi;
             ExceptionFrame->R12 = Context->R12;
             ExceptionFrame->R13 = Context->R13;
             ExceptionFrame->R14 = Context->R14;

--- a/ntoskrnl/ke/amd64/trap.S
+++ b/ntoskrnl/ke/amd64/trap.S
@@ -781,6 +781,7 @@ PUBLIC KiSystemCallEntry64
     /* The unwind info pretends we have a machine frame */
     .PUSHFRAME
     .ALLOCSTACK (KTRAP_FRAME_LENGTH + MAX_SYSCALL_PARAM_SIZE - MachineFrameLength)
+    .SAVEREG rbp, MAX_SYSCALL_PARAM_SIZE + KTRAP_FRAME_Rbp
     .ENDPROLOG
 
     /* Swap gs to kernel, so we can access the PCR */
@@ -795,7 +796,7 @@ PUBLIC KiSystemCallEntry64
     /* Allocate a TRAP_FRAME and space for parameters */
     sub rsp, (KTRAP_FRAME_LENGTH + MAX_SYSCALL_PARAM_SIZE)
 
-    /* Save volatile registers in the trap frame */
+    /* Save volatile registers and rbp in the trap frame */
     mov [rsp + MAX_SYSCALL_PARAM_SIZE + KTRAP_FRAME_Rax], rax
     mov [rsp + MAX_SYSCALL_PARAM_SIZE + KTRAP_FRAME_Rip], rcx
     mov [rsp + MAX_SYSCALL_PARAM_SIZE + KTRAP_FRAME_Rdx], rdx
@@ -803,6 +804,7 @@ PUBLIC KiSystemCallEntry64
     mov [rsp + MAX_SYSCALL_PARAM_SIZE + KTRAP_FRAME_R9], r9
     mov [rsp + MAX_SYSCALL_PARAM_SIZE + KTRAP_FRAME_Rcx], r10
     mov [rsp + MAX_SYSCALL_PARAM_SIZE + KTRAP_FRAME_EFlags], r11
+    mov [rsp + MAX_SYSCALL_PARAM_SIZE + KTRAP_FRAME_Rbp], rbp
 
     /* Store user stack pointer in the trap frame */
     mov rax, gs:[PcUserRsp]

--- a/sdk/include/asm/trapamd64.inc
+++ b/sdk/include/asm/trapamd64.inc
@@ -52,13 +52,10 @@ ENDM
 
 APIC_EOI = HEX(0FFFFFFFFFFFE00B0)
 
-TF_VOLATILES            = HEX(01)
-TF_NONVOLATILES         = HEX(02)
-TF_XMM                  = HEX(04)
 TF_SEGMENTS             = HEX(08)
 TF_DEBUG                = HEX(10)
 TF_IRQL                 = HEX(20)
-TF_SAVE_ALL             = (TF_VOLATILES OR TF_NONVOLATILES OR TF_XMM OR TF_SEGMENTS)
+TF_SAVE_ALL             = (TF_SEGMENTS)
 TF_HAS_ERROR_CODE       = HEX(40)
 TF_SEND_EOI             = HEX(80)
 //TF_SYSTEMSERVICE        = (TRAPFLAG_VOLATILES or TRAPFLAG_DEBUG)
@@ -98,11 +95,9 @@ MACRO(EnterTrap, Flags)
     sub rsp, (KTRAP_FRAME_LENGTH - SIZE_INITIAL_FRAME)
     .allocstack (KTRAP_FRAME_LENGTH - SIZE_INITIAL_FRAME)
 
-    /* Save rbp and rax */
+    /* Save rbp */
     mov [rsp + KTRAP_FRAME_Rbp], rbp
     .savereg rbp, KTRAP_FRAME_Rbp
-    mov [rsp + KTRAP_FRAME_Rax], rax
-    .savereg rax, KTRAP_FRAME_Rax
 
     /* Point rbp to the KTRAP_FRAME */
     lea rbp, [rsp]
@@ -110,25 +105,22 @@ MACRO(EnterTrap, Flags)
 
     .endprolog
 
-    if (Flags AND TF_VOLATILES)
-        /* Save volatile registers */
-        mov [rbp + KTRAP_FRAME_Rcx], rcx
-        mov [rbp + KTRAP_FRAME_Rdx], rdx
-        mov [rbp + KTRAP_FRAME_R8], r8
-        mov [rbp + KTRAP_FRAME_R9], r9
-        mov [rbp + KTRAP_FRAME_R10], r10
-        mov [rbp + KTRAP_FRAME_R11], r11
-    endif
+    /* Save volatile registers */
+    mov [rbp + KTRAP_FRAME_Rax], rax
+    mov [rbp + KTRAP_FRAME_Rcx], rcx
+    mov [rbp + KTRAP_FRAME_Rdx], rdx
+    mov [rbp + KTRAP_FRAME_R8], r8
+    mov [rbp + KTRAP_FRAME_R9], r9
+    mov [rbp + KTRAP_FRAME_R10], r10
+    mov [rbp + KTRAP_FRAME_R11], r11
 
-    if (Flags AND TF_XMM)
-        /* Save xmm registers */
-        movdqa [rbp + KTRAP_FRAME_Xmm0], xmm0
-        movdqa [rbp + KTRAP_FRAME_Xmm1], xmm1
-        movdqa [rbp + KTRAP_FRAME_Xmm2], xmm2
-        movdqa [rbp + KTRAP_FRAME_Xmm3], xmm3
-        movdqa [rbp + KTRAP_FRAME_Xmm4], xmm4
-        movdqa [rbp + KTRAP_FRAME_Xmm5], xmm5
-    endif
+    /* Save volatile xmm registers */
+    movdqa [rbp + KTRAP_FRAME_Xmm0], xmm0
+    movdqa [rbp + KTRAP_FRAME_Xmm1], xmm1
+    movdqa [rbp + KTRAP_FRAME_Xmm2], xmm2
+    movdqa [rbp + KTRAP_FRAME_Xmm3], xmm3
+    movdqa [rbp + KTRAP_FRAME_Xmm4], xmm4
+    movdqa [rbp + KTRAP_FRAME_Xmm5], xmm5
 
     if (Flags AND TF_SEGMENTS)
         /* Save segment selectors */
@@ -233,26 +225,22 @@ MACRO(ExitTrap, Flags)
 
 kernel_mode_return:
 
-    if (Flags AND TF_VOLATILES)
-        /* Restore volatile registers */
-        mov rax, [rbp + KTRAP_FRAME_Rax]
-        mov rcx, [rbp + KTRAP_FRAME_Rcx]
-        mov rdx, [rbp + KTRAP_FRAME_Rdx]
-        mov r8, [rbp + KTRAP_FRAME_R8]
-        mov r9, [rbp + KTRAP_FRAME_R9]
-        mov r10, [rbp + KTRAP_FRAME_R10]
-        mov r11, [rbp + KTRAP_FRAME_R11]
-    endif
+    /* Restore volatile registers */
+    mov rax, [rbp + KTRAP_FRAME_Rax]
+    mov rcx, [rbp + KTRAP_FRAME_Rcx]
+    mov rdx, [rbp + KTRAP_FRAME_Rdx]
+    mov r8, [rbp + KTRAP_FRAME_R8]
+    mov r9, [rbp + KTRAP_FRAME_R9]
+    mov r10, [rbp + KTRAP_FRAME_R10]
+    mov r11, [rbp + KTRAP_FRAME_R11]
 
-    if (Flags AND TF_XMM)
-        /* Restore xmm registers */
-        movdqa xmm0, [rbp + KTRAP_FRAME_Xmm0]
-        movdqa xmm1, [rbp + KTRAP_FRAME_Xmm1]
-        movdqa xmm2, [rbp + KTRAP_FRAME_Xmm2]
-        movdqa xmm3, [rbp + KTRAP_FRAME_Xmm3]
-        movdqa xmm4, [rbp + KTRAP_FRAME_Xmm4]
-        movdqa xmm5, [rbp + KTRAP_FRAME_Xmm5]
-    endif
+    /* Restore xmm registers */
+    movdqa xmm0, [rbp + KTRAP_FRAME_Xmm0]
+    movdqa xmm1, [rbp + KTRAP_FRAME_Xmm1]
+    movdqa xmm2, [rbp + KTRAP_FRAME_Xmm2]
+    movdqa xmm3, [rbp + KTRAP_FRAME_Xmm3]
+    movdqa xmm4, [rbp + KTRAP_FRAME_Xmm4]
+    movdqa xmm5, [rbp + KTRAP_FRAME_Xmm5]
 
     /* Restore MCXSR */
     ldmxcsr [rbp + KTRAP_FRAME_MxCsr]

--- a/sdk/include/asm/trapamd64.inc
+++ b/sdk/include/asm/trapamd64.inc
@@ -108,16 +108,6 @@ MACRO(EnterTrap, Flags)
     lea rbp, [rsp]
     .setframe rbp, 0
 
-    if (Flags AND TF_NONVOLATILES)
-        /* Save non-volatile registers */
-        mov [rbp + KTRAP_FRAME_Rbx], rbx
-        .savereg rbx, KTRAP_FRAME_Rbx
-        mov [rbp + KTRAP_FRAME_Rdi], rdi
-        .savereg rdi, KTRAP_FRAME_Rdi
-        mov [rbp + KTRAP_FRAME_Rsi], rsi
-        .savereg rsi, KTRAP_FRAME_Rsi
-    endif
-
     .endprolog
 
     if (Flags AND TF_VOLATILES)
@@ -242,13 +232,6 @@ MACRO(ExitTrap, Flags)
     swapgs
 
 kernel_mode_return:
-
-    if (Flags AND TF_NONVOLATILES)
-        /* Restore non-volatile registers */
-        mov rbx, [rbp + KTRAP_FRAME_Rbx]
-        mov rdi, [rbp + KTRAP_FRAME_Rdi]
-        mov rsi, [rbp + KTRAP_FRAME_Rsi]
-    endif
 
     if (Flags AND TF_VOLATILES)
         /* Restore volatile registers */

--- a/sdk/include/asm/trapamd64.inc
+++ b/sdk/include/asm/trapamd64.inc
@@ -115,12 +115,12 @@ MACRO(EnterTrap, Flags)
     mov [rbp + KTRAP_FRAME_R11], r11
 
     /* Save volatile xmm registers */
-    movdqa [rbp + KTRAP_FRAME_Xmm0], xmm0
-    movdqa [rbp + KTRAP_FRAME_Xmm1], xmm1
-    movdqa [rbp + KTRAP_FRAME_Xmm2], xmm2
-    movdqa [rbp + KTRAP_FRAME_Xmm3], xmm3
-    movdqa [rbp + KTRAP_FRAME_Xmm4], xmm4
-    movdqa [rbp + KTRAP_FRAME_Xmm5], xmm5
+    movaps [rbp + KTRAP_FRAME_Xmm0], xmm0
+    movaps [rbp + KTRAP_FRAME_Xmm1], xmm1
+    movaps [rbp + KTRAP_FRAME_Xmm2], xmm2
+    movaps [rbp + KTRAP_FRAME_Xmm3], xmm3
+    movaps [rbp + KTRAP_FRAME_Xmm4], xmm4
+    movaps [rbp + KTRAP_FRAME_Xmm5], xmm5
 
     if (Flags AND TF_SEGMENTS)
         /* Save segment selectors */
@@ -235,12 +235,12 @@ kernel_mode_return:
     mov r11, [rbp + KTRAP_FRAME_R11]
 
     /* Restore xmm registers */
-    movdqa xmm0, [rbp + KTRAP_FRAME_Xmm0]
-    movdqa xmm1, [rbp + KTRAP_FRAME_Xmm1]
-    movdqa xmm2, [rbp + KTRAP_FRAME_Xmm2]
-    movdqa xmm3, [rbp + KTRAP_FRAME_Xmm3]
-    movdqa xmm4, [rbp + KTRAP_FRAME_Xmm4]
-    movdqa xmm5, [rbp + KTRAP_FRAME_Xmm5]
+    movaps xmm0, [rbp + KTRAP_FRAME_Xmm0]
+    movaps xmm1, [rbp + KTRAP_FRAME_Xmm1]
+    movaps xmm2, [rbp + KTRAP_FRAME_Xmm2]
+    movaps xmm3, [rbp + KTRAP_FRAME_Xmm3]
+    movaps xmm4, [rbp + KTRAP_FRAME_Xmm4]
+    movaps xmm5, [rbp + KTRAP_FRAME_Xmm5]
 
     /* Restore MCXSR */
     ldmxcsr [rbp + KTRAP_FRAME_MxCsr]


### PR DESCRIPTION
## Purpose

Fix / improve register handling on traps / syscalls.

JIRA issue: [CORE-XXXX](https://jira.reactos.org/browse/CORE-XXXX)

## Proposed changes
- Fix handling of non-volatiles in trap vs exception frame
- Clean up EnterTrap/ExitTrap
- Use movaps instead of movdqa

## Tests
✅ KVM x64: https://reactos.org/testman/compare.php?ids=94655,94659,94663,94672
