### PR TITLE
[COMDLG32] cdlg_Sq.rc: Strip 2 includes

### DIFF
--- a/dll/win32/comdlg32/lang/cdlg_Sq.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Sq.rc
@@ -20,9 +20,6 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-#include "cdlg.h"
-#include "filedlgbrowser.h"
-
 LANGUAGE LANG_ALBANIAN, SUBLANG_NEUTRAL
 
 STRINGTABLE


### PR DESCRIPTION

They do look weird/wrong and no other rcs do have them.
Builds fine with GCC8.4.0dbg x86 here locally,
let's see what the bots and the reviewers think about that.
I do have no clue, why they were added here historically.

JIRA issue: none
