### PR TITLE
[SHELL32][SHELL32_APITEST][SDK] Implement GUIDFromStringA

### DIFF
--- a/dll/win32/shell32/wine/shellord.c
+++ b/dll/win32/shell32/wine/shellord.c
@@ -1892,6 +1892,8 @@ BOOL WINAPI GUIDFromStringA(LPCSTR str, LPGUID guid)
     ANSI_STRING ansi_str;
     WCHAR szWide[40];
     UNICODE_STRING guid_str = { 0, sizeof(szWide), szWide };
+    if (*str != '{')
+        return FALSE;
     RtlInitAnsiString(&ansi_str, str);
     return !RtlAnsiStringToUnicodeString(&guid_str, &ansi_str, FALSE) &&
            !RtlGUIDFromString(&guid_str, guid);
@@ -1903,6 +1905,8 @@ BOOL WINAPI GUIDFromStringA(LPCSTR str, LPGUID guid)
 BOOL WINAPI GUIDFromStringW(LPCWSTR str, LPGUID guid)
 {
     UNICODE_STRING guid_str;
+    if (!str || *str != L'{')
+        return FALSE;
     RtlInitUnicodeString(&guid_str, str);
     return !RtlGUIDFromString(&guid_str, guid);
 }

--- a/dll/win32/shell32/wine/shellord.c
+++ b/dll/win32/shell32/wine/shellord.c
@@ -1894,6 +1894,9 @@ BOOL WINAPI GUIDFromStringA(LPCSTR str, LPGUID guid)
     WCHAR szWide[38 + 1];
     UNICODE_STRING guid_str = { 0, sizeof(szWide), szWide };
 
+    if (*str != '{')
+        return FALSE;
+
     lstrcpynA(szAnsi, str, _countof(szAnsi)); /* Truncated copy */
     RtlInitAnsiString(&ansi_str, szAnsi);
     RtlAnsiStringToUnicodeString(&guid_str, &ansi_str, FALSE);
@@ -1908,6 +1911,9 @@ BOOL WINAPI GUIDFromStringW(LPCWSTR str, LPGUID guid)
 {
     UNICODE_STRING guid_str;
     WCHAR szBuff[38 + 1];
+
+    if (*str != L'{')
+        return FALSE;
 
     lstrcpynW(szBuff, str, _countof(szBuff)); /* Truncated copy */
     RtlInitUnicodeString(&guid_str, szBuff);

--- a/dll/win32/shell32/wine/shellord.c
+++ b/dll/win32/shell32/wine/shellord.c
@@ -1890,18 +1890,11 @@ DWORD WINAPI DoEnvironmentSubstAW(LPVOID x, UINT y)
 BOOL WINAPI GUIDFromStringA(LPCSTR str, LPGUID guid)
 {
     ANSI_STRING ansi_str;
-    CHAR szAnsi[38 + 1];
-    WCHAR szWide[38 + 1];
+    WCHAR szWide[40];
     UNICODE_STRING guid_str = { 0, sizeof(szWide), szWide };
-
-    if (*str != '{')
-        return FALSE;
-
-    lstrcpynA(szAnsi, str, _countof(szAnsi)); /* Truncated copy */
-    RtlInitAnsiString(&ansi_str, szAnsi);
-    RtlAnsiStringToUnicodeString(&guid_str, &ansi_str, FALSE);
-
-    return !RtlGUIDFromString(&guid_str, guid);
+    RtlInitAnsiString(&ansi_str, str);
+    return !RtlAnsiStringToUnicodeString(&guid_str, &ansi_str, FALSE) &&
+           !RtlGUIDFromString(&guid_str, guid);
 }
 
 /*************************************************************************
@@ -1910,14 +1903,7 @@ BOOL WINAPI GUIDFromStringA(LPCSTR str, LPGUID guid)
 BOOL WINAPI GUIDFromStringW(LPCWSTR str, LPGUID guid)
 {
     UNICODE_STRING guid_str;
-    WCHAR szBuff[38 + 1];
-
-    if (*str != L'{')
-        return FALSE;
-
-    lstrcpynW(szBuff, str, _countof(szBuff)); /* Truncated copy */
-    RtlInitUnicodeString(&guid_str, szBuff);
-
+    RtlInitUnicodeString(&guid_str, str);
     return !RtlGUIDFromString(&guid_str, guid);
 }
 

--- a/dll/win32/shell32/wine/shellord.c
+++ b/dll/win32/shell32/wine/shellord.c
@@ -1889,8 +1889,16 @@ DWORD WINAPI DoEnvironmentSubstAW(LPVOID x, UINT y)
  */
 BOOL WINAPI GUIDFromStringA(LPCSTR str, LPGUID guid)
 {
-    TRACE("GUIDFromStringA() stub\n");
-    return FALSE;
+    ANSI_STRING ansi_str;
+    CHAR szAnsi[38 + 1];
+    WCHAR szWide[38 + 1];
+    UNICODE_STRING guid_str = { 0, sizeof(szWide), szWide };
+
+    lstrcpynA(szAnsi, str, _countof(szAnsi)); /* Truncated copy */
+    RtlInitAnsiString(&ansi_str, szAnsi);
+    RtlAnsiStringToUnicodeString(&guid_str, &ansi_str, FALSE);
+
+    return !RtlGUIDFromString(&guid_str, guid);
 }
 
 /*************************************************************************
@@ -1899,8 +1907,11 @@ BOOL WINAPI GUIDFromStringA(LPCSTR str, LPGUID guid)
 BOOL WINAPI GUIDFromStringW(LPCWSTR str, LPGUID guid)
 {
     UNICODE_STRING guid_str;
+    WCHAR szBuff[38 + 1];
 
-    RtlInitUnicodeString(&guid_str, str);
+    lstrcpynW(szBuff, str, _countof(szBuff)); /* Truncated copy */
+    RtlInitUnicodeString(&guid_str, szBuff);
+
     return !RtlGUIDFromString(&guid_str, guid);
 }
 

--- a/modules/rostests/apitests/shell32/CMakeLists.txt
+++ b/modules/rostests/apitests/shell32/CMakeLists.txt
@@ -17,6 +17,7 @@ list(APPEND SOURCE
     ExtractIconEx.cpp
     FindExecutable.cpp
     GetDisplayNameOf.cpp
+    GUIDFromString.cpp
     Int64ToString.cpp
     IShellFolderViewCB.cpp
     OpenAs_RunDLL.cpp

--- a/modules/rostests/apitests/shell32/GUIDFromString.cpp
+++ b/modules/rostests/apitests/shell32/GUIDFromString.cpp
@@ -8,6 +8,7 @@
 #include <shelltest.h>
 #include <initguid.h>
 #include <undocshell.h>
+#include <versionhelpers.h>
 
 DEFINE_GUID(invalid_guid, 0xDEADDEAD, 0xDEAD, 0xDEAD, 0xED, 0xED, 0xED, 0xED,
             0xED, 0xED, 0xED, 0xED);
@@ -20,6 +21,24 @@ DEFINE_GUID(invalid_guid, 0xDEADDEAD, 0xDEAD, 0xDEAD, 0xED, 0xED, 0xED, 0xED,
 static void TEST_GUIDFromStringA(void)
 {
     GUID guid;
+    BOOL ret;
+
+    guid = invalid_guid;
+    _SEH2_TRY
+    {
+        ret = GUIDFromStringA(NULL, &guid);
+    }
+    _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+    {
+        ret = 0xDEADBEEF;
+    }
+    _SEH2_END;
+
+    if (IsWindowsVistaOrGreater())
+        ok_int(ret, FALSE);
+    else
+        ok_int(ret, 0xDEADBEEF);
+    ok_int(memcmp(&guid, &invalid_guid, sizeof(guid)) == 0, TRUE);
 
     guid = invalid_guid;
     ok_int(GUIDFromStringA("", &guid), FALSE);
@@ -49,6 +68,24 @@ static void TEST_GUIDFromStringA(void)
 static void TEST_GUIDFromStringW(void)
 {
     GUID guid;
+    BOOL ret;
+
+    guid = invalid_guid;
+    _SEH2_TRY
+    {
+        ret = GUIDFromStringW(NULL, &guid);
+    }
+    _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+    {
+        ret = 0xDEADBEEF;
+    }
+    _SEH2_END;
+
+    if (IsWindowsVistaOrGreater())
+        ok_int(ret, 0xDEADBEEF);
+    else
+        ok_int(ret, FALSE);
+    ok_int(memcmp(&guid, &invalid_guid, sizeof(guid)) == 0, TRUE);
 
     guid = invalid_guid;
     ok_int(GUIDFromStringW(L"", &guid), FALSE);

--- a/modules/rostests/apitests/shell32/GUIDFromString.cpp
+++ b/modules/rostests/apitests/shell32/GUIDFromString.cpp
@@ -1,0 +1,82 @@
+/*
+ * PROJECT:     ReactOS api tests
+ * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
+ * PURPOSE:     Tests for GUIDFromStringA/W
+ * COPYRIGHT:   Copyright 2024 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ */
+
+#include <shelltest.h>
+#include <initguid.h>
+#include <undocshell.h>
+
+DEFINE_GUID(invalid_guid, 0xDEADDEAD, 0xDEAD, 0xDEAD, 0xED, 0xED, 0xED, 0xED,
+            0xED, 0xED, 0xED, 0xED);
+
+//DEFINE_GUID(IID_IShellLinkW, 0x000214F9, 0x0000, 0x0000, 0xC0, 0x00, 0x00, 0x00,
+//            0x00, 0x00, 0x00, 0x46);
+//DEFINE_GUID(IID_IShellLinkW_Invalid, 0x000214F9, 0x0000, 0x0000, 0xC0, 0x00, 0x00, 0x00,
+//            0x00, 0x00, 0x00, 0xED);
+
+static void TEST_GUIDFromStringA(void)
+{
+    GUID guid;
+
+    guid = invalid_guid;
+    ok_int(GUIDFromStringA("", &guid), FALSE);
+    ok_int(memcmp(&guid, &invalid_guid, sizeof(guid)) == 0, TRUE);
+
+    guid = invalid_guid;
+    ok_int(GUIDFromStringA("{", &guid), FALSE);
+    ok_int(memcmp(&guid, &invalid_guid, sizeof(guid)) == 0, TRUE);
+
+    guid = invalid_guid;
+    ok_int(GUIDFromStringA("{000214F9-0000-0000-C000-000000000046", &guid), FALSE);
+    //ok_int(memcmp(&guid, &IID_IShellLinkW_Invalid, sizeof(guid)) == 0, TRUE); // Ignorable corner case
+
+    guid = invalid_guid;
+    ok_int(GUIDFromStringA("{000214F9-0000-0000-C000-000000000046}", &guid), TRUE);
+    ok_int(memcmp(&guid, &IID_IShellLinkW, sizeof(guid)) == 0, TRUE);
+
+    guid = invalid_guid;
+    ok_int(GUIDFromStringA("{000214F9-0000-0000-C000-000000000046}g", &guid), TRUE);
+    ok_int(memcmp(&guid, &IID_IShellLinkW, sizeof(guid)) == 0, TRUE);
+
+    guid = invalid_guid;
+    ok_int(GUIDFromStringA(" {000214F9-0000-0000-C000-000000000046}", &guid), FALSE);
+    ok_int(memcmp(&guid, &invalid_guid, sizeof(guid)) == 0, TRUE);
+}
+
+static void TEST_GUIDFromStringW(void)
+{
+    GUID guid;
+
+    guid = invalid_guid;
+    ok_int(GUIDFromStringW(L"", &guid), FALSE);
+    ok_int(memcmp(&guid, &invalid_guid, sizeof(guid)) == 0, TRUE);
+
+    guid = invalid_guid;
+    ok_int(GUIDFromStringW(L"{", &guid), FALSE);
+    ok_int(memcmp(&guid, &invalid_guid, sizeof(guid)) == 0, TRUE);
+
+    guid = invalid_guid;
+    ok_int(GUIDFromStringW(L"{000214F9-0000-0000-C000-000000000046", &guid), FALSE);
+    //ok_int(memcmp(&guid, &IID_IShellLinkW_Invalid, sizeof(guid)) == 0, TRUE); // Ignorable corner case
+
+    guid = invalid_guid;
+    ok_int(GUIDFromStringW(L"{000214F9-0000-0000-C000-000000000046}", &guid), TRUE);
+    ok_int(memcmp(&guid, &IID_IShellLinkW, sizeof(guid)) == 0, TRUE);
+
+    guid = invalid_guid;
+    ok_int(GUIDFromStringW(L"{000214F9-0000-0000-C000-000000000046}g", &guid), TRUE);
+    ok_int(memcmp(&guid, &IID_IShellLinkW, sizeof(guid)) == 0, TRUE);
+
+    guid = invalid_guid;
+    ok_int(GUIDFromStringW(L" {000214F9-0000-0000-C000-000000000046}", &guid), FALSE);
+    ok_int(memcmp(&guid, &invalid_guid, sizeof(guid)) == 0, TRUE);
+}
+
+START_TEST(GUIDFromString)
+{
+    TEST_GUIDFromStringA();
+    TEST_GUIDFromStringW();
+}

--- a/modules/rostests/apitests/shell32/testlist.c
+++ b/modules/rostests/apitests/shell32/testlist.c
@@ -17,6 +17,7 @@ extern void func_DragDrop(void);
 extern void func_ExtractIconEx(void);
 extern void func_FindExecutable(void);
 extern void func_GetDisplayNameOf(void);
+extern void func_GUIDFromString(void);
 extern void func_Int64ToString(void);
 extern void func_IShellFolderViewCB(void);
 extern void func_menu(void);
@@ -57,6 +58,7 @@ const struct test winetest_testlist[] =
     { "ExtractIconEx", func_ExtractIconEx },
     { "FindExecutable", func_FindExecutable },
     { "GetDisplayNameOf", func_GetDisplayNameOf },
+    { "GUIDFromString", func_GUIDFromString },
     { "Int64ToString", func_Int64ToString },
     { "IShellFolderViewCB", func_IShellFolderViewCB },
     { "menu", func_menu },

--- a/sdk/include/reactos/undocshell.h
+++ b/sdk/include/reactos/undocshell.h
@@ -727,10 +727,12 @@ HRESULT WINAPI SHCreatePropertyBag(_In_ REFIID riid, _Out_ void **ppvObj);
 HRESULT WINAPI SHLimitInputCombo(HWND hWnd, IShellFolder *psf);
 HRESULT WINAPI SHGetImageList(int iImageList, REFIID riid, void **ppv);
 
+BOOL WINAPI GUIDFromStringA(
+    _In_   PCSTR psz,
+    _Out_  LPGUID pguid);
 BOOL WINAPI GUIDFromStringW(
     _In_   PCWSTR psz,
-    _Out_  LPGUID pguid
-    );
+    _Out_  LPGUID pguid);
 
 LPSTR WINAPI SheRemoveQuotesA(LPSTR psz);
 LPWSTR WINAPI SheRemoveQuotesW(LPWSTR psz);


### PR DESCRIPTION
## Purpose
Implementing missing features...
JIRA issue: [CORE-19278](https://jira.reactos.org/browse/CORE-19278)

## Proposed changes

- Add `GUIDFromString` testcase.
- Implement `GUIDFromStringA` function.
- Add NULL check to `GUIDFromStringW`.
- Add `GUIDFromStringA` prototype.

## TODO

- [ ] Do big tests.

## Comparison

WinXP:
![WinXP](https://github.com/reactos/reactos/assets/2107452/0eb7d3da-0450-4d3e-8f99-20bc7c56c6eb)
Successful.

Win2k3:
![Win2k3](https://github.com/reactos/reactos/assets/2107452/3441ed45-21f5-45f4-a75d-ab13de743df2)
Successful.

Win10 x64:
![Win10](https://github.com/reactos/reactos/assets/2107452/577452a8-6b87-441c-823d-1e2a66e9b5ea)
Successful.

ReactOS (BEFORE):
![before](https://github.com/reactos/reactos/assets/2107452/cadfcdbf-8917-4392-a3be-35165ac90969)
Some failures.

ReactOS (AFTER):
![after](https://github.com/reactos/reactos/assets/2107452/74bf55c5-8230-4725-aa8a-f05bd3345f3d)
Successful.