### PR TITLE
[COMDLG32] *.rc: Tweak spaces in IDS_INVALID_FILENAME

### DIFF
--- a/dll/win32/comdlg32/lang/cdlg_Bg.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Bg.rc
@@ -31,7 +31,7 @@ STRINGTABLE
 Искате ли да го замените?"
     IDS_INVALID_FILENAME_TITLE "Невалидни знаци в пътя"
     IDS_INVALID_FILENAME    "Името на файла не може да съдържа следните символи:\n\
-                          / : < > |"
+/ : < > |"
     IDS_PATHNOTEXISTING     "Пътят не съществува"
     IDS_FILENOTEXISTING     "Файлът не съществува"
     IDS_INVALID_FOLDERNAME  "The selection contains a non-folder object"

--- a/dll/win32/comdlg32/lang/cdlg_Ca.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Ca.rc
@@ -31,7 +31,7 @@ El voleu crear?"
 El voleu reemplaçar?"
     IDS_INVALID_FILENAME_TITLE "Hi ha caràcters invàlids en la ruta"
     IDS_INVALID_FILENAME    "Un nom de fitxer no pot contenir cualsevol dels caràcters següents:\n\
-                          / : < > |"
+/ : < > |"
     IDS_PATHNOTEXISTING     "La ruta no existeix"
     IDS_FILENOTEXISTING     "El fitxer no existeix"
     IDS_INVALID_FOLDERNAME  "The selection contains a non-folder object"

--- a/dll/win32/comdlg32/lang/cdlg_Cs.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Cs.rc
@@ -31,7 +31,7 @@ Chcete ho vytvořit?"
 Chcete ho přepsat novým?"
     IDS_INVALID_FILENAME_TITLE "Nedovolený(é) znak(y) v cestě k souboru"
     IDS_INVALID_FILENAME    "Název souboru nesmí obsahovat žádný z následujících znaků:\n\
-                          / : < > |"
+/ : < > |"
     IDS_PATHNOTEXISTING     "Adresář neexistuje"
     IDS_FILENOTEXISTING     "Soubor neexistuje"
     IDS_INVALID_FOLDERNAME  "The selection contains a non-folder object"

--- a/dll/win32/comdlg32/lang/cdlg_Da.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Da.rc
@@ -31,7 +31,7 @@ Vil du oprette filen?"
 Vil du erstatte den?"
     IDS_INVALID_FILENAME_TITLE "Der er et eller flere Ugyldige tegn i stien"
     IDS_INVALID_FILENAME    "Et filnavn må ikke indeholde følgende tegn:\n\
-                          / : < > |"
+/ : < > |"
     IDS_PATHNOTEXISTING     "Stien eksisterer ikke."
     IDS_FILENOTEXISTING     "Filen eksisterer ikke."
     IDS_INVALID_FOLDERNAME  "The selection contains a non-folder object"

--- a/dll/win32/comdlg32/lang/cdlg_De.rc
+++ b/dll/win32/comdlg32/lang/cdlg_De.rc
@@ -31,7 +31,7 @@ Wollen Sie sie neu anlegen?"
 Wollen Sie sie überschreiben?"
     IDS_INVALID_FILENAME_TITLE "Unzulässige Zeichen im Pfad"
     IDS_INVALID_FILENAME    "Ein Dateiname darf folgende Zeichen nicht enthalten:\n\
-                          / : < > |"
+/ : < > |"
     IDS_PATHNOTEXISTING     "Der Pfad existiert nicht"
     IDS_FILENOTEXISTING     "Die Datei existiert nicht"
     IDS_INVALID_FOLDERNAME  "The selection contains a non-folder object"

--- a/dll/win32/comdlg32/lang/cdlg_El.rc
+++ b/dll/win32/comdlg32/lang/cdlg_El.rc
@@ -31,7 +31,7 @@ STRINGTABLE
 Θέλετε να το αντικαταστήσετε;"
     IDS_INVALID_FILENAME_TITLE "Μη έγγυρος(οι) χαρακτήρας(ες) στο μονοπάτι"
     IDS_INVALID_FILENAME    "Ένα όνομα αρχείο δε μπορεί να περιέχει κάποιον από τους παρακάτω χαρακτήρες:\n\
-                          / : < > |"
+/ : < > |"
     IDS_PATHNOTEXISTING     "Το μονοπάτι δεν υπάρχει"
     IDS_FILENOTEXISTING     "Το αρχείο δεν υπάρχει"
     IDS_INVALID_FOLDERNAME  "The selection contains a non-folder object"

--- a/dll/win32/comdlg32/lang/cdlg_En.rc
+++ b/dll/win32/comdlg32/lang/cdlg_En.rc
@@ -31,7 +31,7 @@ Do you want to create file?"
 Do you want to replace it?"
     IDS_INVALID_FILENAME_TITLE "Invalid character(s) in path"
     IDS_INVALID_FILENAME    "A filename cannot contain any of the following characters:\n\
-                          / : < > |"
+/ : < > |"
     IDS_PATHNOTEXISTING     "Path does not exist"
     IDS_FILENOTEXISTING     "File does not exist"
     IDS_INVALID_FOLDERNAME  "The selection contains a non-folder object"

--- a/dll/win32/comdlg32/lang/cdlg_Eo.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Eo.rc
@@ -31,7 +31,7 @@ STRINGTABLE
 Ĉu vi volas superskribi ĝin?"
     IDS_INVALID_FILENAME_TITLE "Nekorekta(j) tipo(j) en vojo"
     IDS_INVALID_FILENAME    "La dosiernomo ne povas enhavi la jenajn tipojn:\n\
-                          / : < > |"
+/ : < > |"
     IDS_PATHNOTEXISTING     "Vojo estas neekzistanta"
     IDS_FILENOTEXISTING     "Dosiero estas neekzistanta"
     IDS_INVALID_FOLDERNAME  "The selection contains a non-folder object"

--- a/dll/win32/comdlg32/lang/cdlg_Es.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Es.rc
@@ -37,7 +37,7 @@ STRINGTABLE
 ¿Desea reemplazarlo?"
     IDS_INVALID_FILENAME_TITLE "Caracter(es) inválidos en la ruta"
     IDS_INVALID_FILENAME    "Un nombre de archivo no puede contener ninguno de los siguientes caracteres:\n\
-                          / : < > |"
+/ : < > |"
     IDS_PATHNOTEXISTING     "La ruta no existe"
     IDS_FILENOTEXISTING     "El archivo no existe"
     IDS_INVALID_FOLDERNAME  "La selección contiene algún elemento que no es una carpeta"

--- a/dll/win32/comdlg32/lang/cdlg_Et.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Et.rc
@@ -32,7 +32,7 @@ Kas soovite luua selle faili?"
 Kas soovite asendada selle?"
     IDS_INVALID_FILENAME_TITLE "Invalid character(s) in path"
     IDS_INVALID_FILENAME    "Failinimi ei tohi sisaldada järgmisi märke:\n\
-                          / : < > |"
+/ : < > |"
     IDS_PATHNOTEXISTING     "Koht ei eksisteeri"
     IDS_FILENOTEXISTING     "Fail ei eksisteeri"
     IDS_INVALID_FOLDERNAME  "Valik sisaldab muid objekte kui kausti."

--- a/dll/win32/comdlg32/lang/cdlg_Fi.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Fi.rc
@@ -31,7 +31,7 @@ Haluatko luoda sen?"
 Haluatko ylikirjoitaa sen?"
     IDS_INVALID_FILENAME_TITLE "Kansio sisältää epäkelpoja merkkejä"
     IDS_INVALID_FILENAME    "Tiedoston nimi ei voi sisältää näitä merkkejä:\n\
-                          / : < > |"
+/ : < > |"
     IDS_PATHNOTEXISTING     "Kansiota ei ole"
     IDS_FILENOTEXISTING     "Tiedostoa ei ole"
     IDS_INVALID_FOLDERNAME  "The selection contains a non-folder object"

--- a/dll/win32/comdlg32/lang/cdlg_Fr.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Fr.rc
@@ -31,7 +31,7 @@ Souhaitez-vous le créer ?"
 Voulez-vous le remplacer ?"
     IDS_INVALID_FILENAME_TITLE "Le chemin d'accès contient des caractères invalides"
     IDS_INVALID_FILENAME    "Un nom de fichier ne peut contenir aucun des caractères suivants :\n\
-                          / : < > |"
+/ : < > |"
     IDS_PATHNOTEXISTING     "Le chemin d'accès n'existe pas"
     IDS_FILENOTEXISTING     "Le fichier n'existe pas"
     IDS_INVALID_FOLDERNAME  "The selection contains a non-folder object"

--- a/dll/win32/comdlg32/lang/cdlg_He.rc
+++ b/dll/win32/comdlg32/lang/cdlg_He.rc
@@ -31,7 +31,7 @@ STRINGTABLE
 האם ברצונך להחליף אותו?"
     IDS_INVALID_FILENAME_TITLE "תווים שגויים בנתיב"
     IDS_INVALID_FILENAME    "שם קובץ לא יכול להכיל אף אחד מהתווים הבאים:\n\
-                          / : < > |"
+/ : < > |"
     IDS_PATHNOTEXISTING     "הנתיב אינו קיים"
     IDS_FILENOTEXISTING     "הקובץ אינו קיים"
     IDS_INVALID_FOLDERNAME  "The selection contains a non-folder object"

--- a/dll/win32/comdlg32/lang/cdlg_Hi.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Hi.rc
@@ -17,7 +17,7 @@ STRINGTABLE
 क्या आप इसे बदलना चाहते हैं?"
     IDS_INVALID_FILENAME_TITLE "पथ में अमान्य कैरेक्टर"
     IDS_INVALID_FILENAME    "फ़ाइलनेम में निम्न में से कोई भी कैरेक्टर नहीं हो सकता है:\n\
-                          / : < > |"
+/ : < > |"
     IDS_PATHNOTEXISTING     "पथ मौजूद नहीं है"
     IDS_FILENOTEXISTING     "फ़ाइल मौजूद नहीं है"
     IDS_INVALID_FOLDERNAME  "चयन में एक गैर-फ़ोल्डर ऑब्जेक्ट है"

--- a/dll/win32/comdlg32/lang/cdlg_Hu.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Hu.rc
@@ -31,7 +31,7 @@ Létrehozza a fájlt?"
 Cseréli a fájlt?"
     IDS_INVALID_FILENAME_TITLE "Érvénytelen karakter(ek) van(nak) az útvonalban"
     IDS_INVALID_FILENAME    "A fájlnév nem tartalmazhatja ezeket a karaktereket:\n\
-                          / : < > |"
+/ : < > |"
     IDS_PATHNOTEXISTING     "Útvonal nem létezik"
     IDS_FILENOTEXISTING     "Fájl nem létezik"
     IDS_INVALID_FOLDERNAME  "A kijelölés egy mappától eltérő objektumot tartalmaz"

--- a/dll/win32/comdlg32/lang/cdlg_Id.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Id.rc
@@ -32,7 +32,7 @@ Ingin buat berkas?"
 Ingin mengganti berkas?"
     IDS_INVALID_FILENAME_TITLE "Karakter pada jalur tidak valid"
     IDS_INVALID_FILENAME    "Nama file tidak boleh berisi salah satu karakter berikut:\n\
-                          / : < > |"
+/ : < > |"
     IDS_PATHNOTEXISTING     "Jalur tidak tersedia"
     IDS_FILENOTEXISTING     "Berkas tidak tersedia"
     IDS_INVALID_FOLDERNAME  "Pilihan ini berisi obyek non-folder"

--- a/dll/win32/comdlg32/lang/cdlg_It.rc
+++ b/dll/win32/comdlg32/lang/cdlg_It.rc
@@ -31,7 +31,7 @@ Creare il file"
 Sovrascriverlo?"
     IDS_INVALID_FILENAME_TITLE "Caratteri invalidi nel percorso"
     IDS_INVALID_FILENAME    "Il nome di un file non può contenere i seguenti caratteri:\n\
-                          / : < > |"
+/ : < > |"
     IDS_PATHNOTEXISTING     "Il percorso specificato non esiste"
     IDS_FILENOTEXISTING     "Il file non esiste"
     IDS_INVALID_FOLDERNAME  "The selection contains a non-folder object"

--- a/dll/win32/comdlg32/lang/cdlg_Ja.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Ja.rc
@@ -31,7 +31,7 @@ STRINGTABLE
 上書きしますか?"
     IDS_INVALID_FILENAME_TITLE "ファイル名に使えない文字"
     IDS_INVALID_FILENAME    "ファイル名には以下の文字は使えません:\n\
-                          / : < > |"
+/ : < > |"
     IDS_PATHNOTEXISTING     "パスが見つかりません"
     IDS_FILENOTEXISTING     "ファイルが見つかりません"
     IDS_INVALID_FOLDERNAME  "フォルダ以外のオブジェクトを選択しています"

--- a/dll/win32/comdlg32/lang/cdlg_Ko.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Ko.rc
@@ -31,7 +31,7 @@ STRINGTABLE
 덮어쓰겠습니까?"
     IDS_INVALID_FILENAME_TITLE "경로에 올바르지 않은 문자가 있습니다h"
     IDS_INVALID_FILENAME    "파일이름에는 다음 문자만 포함될 수 있습니다:\n\
-                          / : < > |"
+/ : < > |"
     IDS_PATHNOTEXISTING     "경로가 존재하지 않습니다."
     IDS_FILENOTEXISTING     "파일이 존재하지 않습니다"
     IDS_INVALID_FOLDERNAME  "The selection contains a non-folder object"

--- a/dll/win32/comdlg32/lang/cdlg_Lt.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Lt.rc
@@ -31,7 +31,7 @@ Ar norite sukurti failą?"
 Ar norite jį pakeisti?"
     IDS_INVALID_FILENAME_TITLE "Kelyje yra netinkamų simbolių"
     IDS_INVALID_FILENAME    "Failo vardas negali turėti šių simbolių:\n\
-                          / : < > |"
+/ : < > |"
     IDS_PATHNOTEXISTING     "Kelias neegzistuoja"
     IDS_FILENOTEXISTING     "Failas neegzistuoja"
     IDS_INVALID_FOLDERNAME  "The selection contains a non-folder object"

--- a/dll/win32/comdlg32/lang/cdlg_Nl.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Nl.rc
@@ -31,7 +31,7 @@ Wilt u het bestand aanmaken?"
 Wilt u het vervangen?"
     IDS_INVALID_FILENAME_TITLE "De naam van het pad bevat ongeldige tekens"
     IDS_INVALID_FILENAME    "De volgende tekens mogen niet in de bestandsnaam voorkomen:\n\
-                          / : < > |"
+/ : < > |"
     IDS_PATHNOTEXISTING     "Het pad bestaat niet"
     IDS_FILENOTEXISTING     "Kan het bestand niet vinden"
     IDS_INVALID_FOLDERNAME  "The selection contains a non-folder object"

--- a/dll/win32/comdlg32/lang/cdlg_No.rc
+++ b/dll/win32/comdlg32/lang/cdlg_No.rc
@@ -31,7 +31,7 @@ Skal den opprettes?"
 Skal den overskrives?"
     IDS_INVALID_FILENAME_TITLE "Ugyldige tegn i filnavnet"
     IDS_INVALID_FILENAME    "Et filnavn kan ikke inneholder følgende tegn:\n\
-                          / : < > |"
+/ : < > |"
     IDS_PATHNOTEXISTING     "Stien finnes ikke"
     IDS_FILENOTEXISTING     "Filen finnes ikke"
     IDS_INVALID_FOLDERNAME  "The selection contains a non-folder object"

--- a/dll/win32/comdlg32/lang/cdlg_Pl.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Pl.rc
@@ -32,7 +32,7 @@ Czy chcesz go utworzyć?"
 Czy chcesz go zastąpić?"
     IDS_INVALID_FILENAME_TITLE "Błędny(e) znak(i) w nazwie"
     IDS_INVALID_FILENAME    "Nazwa pliku nie może zawierać znaków:\n\
-                          / : < > |"
+/ : < > |"
     IDS_PATHNOTEXISTING     "Katalog nie istnieje"
     IDS_FILENOTEXISTING     "Plik nie istnieje"
     IDS_INVALID_FOLDERNAME  "Wybór nie zawiera folderu"

--- a/dll/win32/comdlg32/lang/cdlg_Pt.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Pt.rc
@@ -31,7 +31,8 @@ STRINGTABLE
     IDS_CREATEFILE          "O ficheiro não existe.\nGostaria de o criar?"
     IDS_OVERWRITEFILE       "O ficheiro já existe.\nGostaria de o substituir?"
     IDS_INVALID_FILENAME_TITLE "Caracter(es) inválidos na localização"
-    IDS_INVALID_FILENAME    "Um nome de ficheiro não pode conter quaisquer dos seguintes caracteres:\n / : < > |"
+    IDS_INVALID_FILENAME    "Um nome de ficheiro não pode conter quaisquer dos seguintes caracteres:\n\
+/ : < > |"
     IDS_PATHNOTEXISTING     "A localização não existe"
     IDS_FILENOTEXISTING     "O ficheiro não existe"
     IDS_INVALID_FOLDERNAME  "A sua selecção não contém nenhuma pasta"

--- a/dll/win32/comdlg32/lang/cdlg_Ro.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Ro.rc
@@ -34,7 +34,7 @@ Doriți crearea acest fișier?"
 Doriți să îl suprascrieți?"
     IDS_INVALID_FILENAME_TITLE "Caracter(e) nevalid(e) în cale"
     IDS_INVALID_FILENAME    "Numele de fișier nu poate conține caracterele următoare:\n\
-                          / : < > |"
+/ : < > |"
     IDS_PATHNOTEXISTING     "Calea nu există"
     IDS_FILENOTEXISTING     "Fișierul nu există"
     IDS_INVALID_FOLDERNAME  "Selecția nu conține un folder"

--- a/dll/win32/comdlg32/lang/cdlg_Ru.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Ru.rc
@@ -31,7 +31,7 @@ STRINGTABLE
 Заменить его?"
     IDS_INVALID_FILENAME_TITLE "Некорректный символ(ы) в записи пути"
     IDS_INVALID_FILENAME    "Имя файла не может содержать следующие символы:\n\
-                          / : < > |"
+/ : < > |"
     IDS_PATHNOTEXISTING     "Путь не существует"
     IDS_FILENOTEXISTING     "Файл не существует"
     IDS_INVALID_FOLDERNAME  "Выбор содержит объект не являющийся папкой"

--- a/dll/win32/comdlg32/lang/cdlg_Si.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Si.rc
@@ -31,7 +31,7 @@ Ali jo želite ustvariti?"
 Ali jo želite zamenjati?"
     IDS_INVALID_FILENAME_TITLE "Neveljavni znaki v poti"
     IDS_INVALID_FILENAME    "Ime datoteke ne sme vsebovati naslednjih znakov:\n\
-                          / : < > |"
+/ : < > |"
     IDS_PATHNOTEXISTING     "Pot ne obstaja"
     IDS_FILENOTEXISTING     "Datoteka ne obstaja"
     IDS_INVALID_FOLDERNAME  "The selection contains a non-folder object"

--- a/dll/win32/comdlg32/lang/cdlg_Sk.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Sk.rc
@@ -31,7 +31,7 @@ Do you want to create file?"
 Do you want to replace it?"
     IDS_INVALID_FILENAME_TITLE "Invalid character(s) in path"
     IDS_INVALID_FILENAME    "Názov súboru nemôže obsahovať žiadny z nasledovných znakov:\n\
-                          / : < > |"
+/ : < > |"
     IDS_PATHNOTEXISTING     "Cesta neexistuje"
     IDS_FILENOTEXISTING     "Súbor neexistuje"
     IDS_INVALID_FOLDERNAME  "The selection contains a non-folder object"

--- a/dll/win32/comdlg32/lang/cdlg_Sq.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Sq.rc
@@ -32,7 +32,7 @@ Doni ta krijoni dokumentin?"
 Doni ta zevendesoni?"
     IDS_INVALID_FILENAME_TITLE "Karatere te pavlere ne rruge"
     IDS_INVALID_FILENAME    "Nje emer dokumentin nuk mund te permbaje kararakteret e meposhtme:\n\
-                          / : < > |"
+/ : < > |"
     IDS_PATHNOTEXISTING     "Rruga nuk ekziston"
     IDS_FILENOTEXISTING     "Dokumenti nuk ekziston"
     IDS_INVALID_FOLDERNAME  "The selection contains a non-folder object"

--- a/dll/win32/comdlg32/lang/cdlg_Sr.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Sr.rc
@@ -31,7 +31,7 @@ STRINGTABLE
 Želite li da je zamenite?"
     IDS_INVALID_FILENAME_TITLE "Neispravan znak u putanji"
     IDS_INVALID_FILENAME    "Naziv datoteke ne sme sadržati sledeće znakove:\n\
-                          / : < > |"
+/ : < > |"
     IDS_PATHNOTEXISTING     "Putanja ne postoji"
     IDS_FILENOTEXISTING     "Datoteka ne postoji"
     IDS_INVALID_FOLDERNAME  "The selection contains a non-folder object"

--- a/dll/win32/comdlg32/lang/cdlg_Sv.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Sv.rc
@@ -31,7 +31,7 @@ Vill du skapa fil?"
 Vill du ersätta den?"
     IDS_INVALID_FILENAME_TITLE "Illegalt tecken i sökväg"
     IDS_INVALID_FILENAME    "Ett filnamn kan inte innehålla någon av följande tecken:\n\
-                                               / : < > |"
+                     / : < > |"
     IDS_PATHNOTEXISTING     "Sökvägen finns inte"
     IDS_FILENOTEXISTING     "Filen finns inte"
     IDS_INVALID_FOLDERNAME  "The selection contains a non-folder object"

--- a/dll/win32/comdlg32/lang/cdlg_Th.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Th.rc
@@ -31,7 +31,7 @@ Do you want to create file?"
 Do you want to replace it?"
     IDS_INVALID_FILENAME_TITLE "Invalid character(s) in path"
     IDS_INVALID_FILENAME    "ในชื่อแฟ้มใช้ไมได้ต้วนี้:\n\
-                          / : < > |"
+/ : < > |"
     IDS_PATHNOTEXISTING     "ไม่พบไดเรกทอรี"
     IDS_FILENOTEXISTING     "ไม่พบแฟ้ม"
     IDS_INVALID_FOLDERNAME  "The selection contains a non-folder object"

--- a/dll/win32/comdlg32/lang/cdlg_Tr.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Tr.rc
@@ -30,7 +30,7 @@ Dosya oluşturmak ister misiniz?"
 Onu değiştirmek ister misiniz?"
     IDS_INVALID_FILENAME_TITLE "Yolda geçersiz işaret ya da işaretler var."
     IDS_INVALID_FILENAME    "Bir dosya adı aşağıdaki işaretlerin rastgele birini içeremez:\n\
-                          / : < > |"
+/ : < > |"
     IDS_PATHNOTEXISTING     "Dosya yolu yok."
     IDS_FILENOTEXISTING     "Dosya yok."
     IDS_INVALID_FOLDERNAME  "Seçim dizin olmayan bir nesne içeriyor."

--- a/dll/win32/comdlg32/lang/cdlg_Uk.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Uk.rc
@@ -31,7 +31,7 @@ STRINGTABLE
 Замінити його?"
     IDS_INVALID_FILENAME_TITLE "Невірний символ в записі шляху"
     IDS_INVALID_FILENAME    "Ім'я файлу не може містити наступні символи:\n\
-                          / : < > |"
+/ : < > |"
     IDS_PATHNOTEXISTING     "Шлях не існує"
     IDS_FILENOTEXISTING     "Файл не існує"
     IDS_INVALID_FOLDERNAME  "The selection contains a non-folder object"

--- a/dll/win32/comdlg32/lang/cdlg_Zh.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Zh.rc
@@ -35,7 +35,7 @@ STRINGTABLE
 是否替换？"
     IDS_INVALID_FILENAME_TITLE "路径中包含无效字符"
     IDS_INVALID_FILENAME    "文件名中不能包含任何以下字符::\n\
-                          / : < > |"
+/ : < > |"
     IDS_PATHNOTEXISTING     "路径不存在"
     IDS_FILENOTEXISTING     "文件不存在"
     IDS_INVALID_FOLDERNAME  "所选内容包含一个非文件夹物体"
@@ -537,7 +537,7 @@ STRINGTABLE
 您要取代它嗎？"
     IDS_INVALID_FILENAME_TITLE "檔案名稱含有無效的字元"
     IDS_INVALID_FILENAME    "檔案名稱中不能包含以下任何一個字元：\n\
-                          / : < > |"
+/ : < > |"
     IDS_PATHNOTEXISTING     "路徑不存在"
     IDS_FILENOTEXISTING     "檔案不存在"
     IDS_INVALID_FOLDERNAME  "已選項目包含非資料夾物件"


### PR DESCRIPTION

This saves a few bytes in the binary, e.g.
comdlg32.dll master 0.4.15-dev-7887-g64a59a1 RosBEWin2.2.2 GCC8.4.0 dbg x86 shrinks from 1.011.712 bytes to 1.009.664 bytes.

Furthermore it syncs the translations at this line, because pt-PT.rc already applied such a tweak.

JIRA issue: none
