### PR TITLE
[SHELL32] Initialize MenuItemInfoW struct in AddStaticContextMenusToMenu

### DIFF
--- a/dll/win32/shell32/CDefaultContextMenu.cpp
+++ b/dll/win32/shell32/CDefaultContextMenu.cpp
@@ -499,6 +499,7 @@ CDefaultContextMenu::AddStaticContextMenusToMenu(
     UINT fState;
     UINT cIds = 0, indexFirst = *pIndexMenu;
 
+    mii = {0};
     mii.cbSize = sizeof(mii);
     mii.fMask = MIIM_ID | MIIM_TYPE | MIIM_STATE | MIIM_DATA;
     mii.fType = MFT_STRING;

--- a/dll/win32/shell32/CDefaultContextMenu.cpp
+++ b/dll/win32/shell32/CDefaultContextMenu.cpp
@@ -493,14 +493,12 @@ CDefaultContextMenu::AddStaticContextMenusToMenu(
     UINT uFlags)
 {
     UINT ntver = RosGetProcessEffectiveVersion();
-    MENUITEMINFOW mii;
+    MENUITEMINFOW mii = { sizeof(mii) };
     UINT idResource;
     WCHAR wszVerb[40];
     UINT fState;
     UINT cIds = 0, indexFirst = *pIndexMenu;
 
-    mii = {0};
-    mii.cbSize = sizeof(mii);
     mii.fMask = MIIM_ID | MIIM_TYPE | MIIM_STATE | MIIM_DATA;
     mii.fType = MFT_STRING;
     mii.dwTypeData = NULL;


### PR DESCRIPTION
## Purpose

This prevents an issue where clicking on most of the icons on the desktop that isn't the file explorer causes explorer to throw an exception, and also prevents another issue where most applications won't launch from the start menu; at least on MSVC builds running on VirtualBox 5.2.44.

## Proposed changes
- Initialize `MenuItemInfoW` struct in `CDefaultContextMenu::AddStaticContextMenusToMenu`