### PR TITLE
[EXPLORER] Fix assertion when running on Windows Server 2003

### DIFF
--- a/base/shell/explorer/tbsite.cpp
+++ b/base/shell/explorer/tbsite.cpp
@@ -459,7 +459,7 @@ public:
         /* Enumerate all bands */
         while (SUCCEEDED(m_BandSite->EnumBands(uBand, &dwBandID)))
         {
-            if (SUCCEEDED(m_BandSite->GetBandObject(dwBandID, IID_PPV_ARG(IPersist, &pBand))))
+            if (dwBandID && SUCCEEDED(m_BandSite->GetBandObject(dwBandID, IID_PPV_ARG(IPersist, &pBand))))
             {
                 if (SUCCEEDED(pBand->GetClassID(&BandCLSID)))
                 {


### PR DESCRIPTION
## Purpose

Allow the ReactOS explorer to run on Windows Server 2003 without failing an ATL debug assertion.

JIRA issue: [CORE-18807](https://jira.reactos.org/browse/CORE-18807)

## Proposed changes
- Ensure the band ID is not 0 before trying to get the band object in the `HasTaskBand()` function in the `CTrayBandSite` class.