### PR TITLE
[NTOS:MM] Clean up memory area stuff

### DIFF
--- a/ntoskrnl/cache/section/data.c
+++ b/ntoskrnl/cache/section/data.c
@@ -720,7 +720,7 @@ MmUnmapViewOfCacheSegment(PMMSUPPORT AddressSpace,
     PMM_SECTION_SEGMENT Segment;
 
     MemoryArea = MmLocateMemoryAreaByAddress(AddressSpace, BaseAddress);
-    if (MemoryArea == NULL || MemoryArea->DeleteInProgress)
+    if (MemoryArea == NULL || MemoryArea->Type == MEMORY_AREA_OWNED_BY_ARM3 || MemoryArea->DeleteInProgress)
     {
         ASSERT(MemoryArea);
         return STATUS_UNSUCCESSFUL;

--- a/ntoskrnl/include/internal/mm.h
+++ b/ntoskrnl/include/internal/mm.h
@@ -627,15 +627,6 @@ MmFindGap(
     BOOLEAN TopDown
 );
 
-VOID
-NTAPI
-MiRosCheckMemoryAreas(
-   PMMSUPPORT AddressSpace);
-
-VOID
-NTAPI
-MiCheckAllProcessMemoryAreas(VOID);
-
 /* npool.c *******************************************************************/
 
 CODE_SEG("INIT")
@@ -691,12 +682,6 @@ MmBuildMdlFromPages(
 );
 
 /* mminit.c ******************************************************************/
-
-VOID
-NTAPI
-MmInit1(
-    VOID
-);
 
 CODE_SEG("INIT")
 BOOLEAN
@@ -802,18 +787,6 @@ NTAPI
 MmSetMemoryPriorityProcess(
     IN PEPROCESS Process,
     IN UCHAR MemoryPriority
-);
-
-/* i386/pfault.c *************************************************************/
-
-NTSTATUS
-NTAPI
-MmPageFault(
-    ULONG Cs,
-    PULONG Eip,
-    PULONG Eax,
-    ULONG Cr2,
-    ULONG ErrorCode
 );
 
 /* special.c *****************************************************************/

--- a/ntoskrnl/include/internal/mm.h
+++ b/ntoskrnl/include/internal/mm.h
@@ -618,6 +618,13 @@ MmLocateMemoryAreaByRegion(
     SIZE_T Length
 );
 
+BOOLEAN
+NTAPI
+MmIsAddressRangeFree(
+    _In_ PMMSUPPORT AddressSpace,
+    _In_ PVOID Address,
+    _In_ ULONG_PTR Length);
+
 PVOID
 NTAPI
 MmFindGap(

--- a/ntoskrnl/include/internal/mm.h
+++ b/ntoskrnl/include/internal/mm.h
@@ -271,6 +271,8 @@ typedef struct _MEMORY_AREA
 
 #define MI_SET_MEMORY_AREA_VAD(Vad) do { (Vad)->u.VadFlags.Spare |= 1; } while (0)
 #define MI_IS_MEMORY_AREA_VAD(Vad) (((Vad)->u.VadFlags.Spare & 1) != 0)
+#define MI_SET_ROSMM_VAD(Vad) do { (Vad)->u.VadFlags.Spare |= 2; } while (0)
+#define MI_IS_ROSMM_VAD(Vad) (((Vad)->u.VadFlags.Spare & 2) != 0)
 
 typedef struct _MM_RMAP_ENTRY
 {

--- a/ntoskrnl/include/internal/mm.h
+++ b/ntoskrnl/include/internal/mm.h
@@ -259,7 +259,6 @@ typedef struct _MEMORY_AREA
     ULONG Flags;
     BOOLEAN DeleteInProgress;
     ULONG Magic;
-    PVOID Vad;
 
     struct
     {

--- a/ntoskrnl/include/internal/mm.h
+++ b/ntoskrnl/include/internal/mm.h
@@ -269,6 +269,9 @@ typedef struct _MEMORY_AREA
     } SectionData;
 } MEMORY_AREA, *PMEMORY_AREA;
 
+#define MI_SET_MEMORY_AREA_VAD(Vad) do { (Vad)->u.VadFlags.Spare |= 1; } while (0)
+#define MI_IS_MEMORY_AREA_VAD(Vad) (((Vad)->u.VadFlags.Spare & 1) != 0)
+
 typedef struct _MM_RMAP_ENTRY
 {
    struct _MM_RMAP_ENTRY* Next;

--- a/ntoskrnl/mm/ARM3/miarm.h
+++ b/ntoskrnl/mm/ARM3/miarm.h
@@ -2180,6 +2180,12 @@ MiIsPfnInUse(
 
 PMMVAD
 NTAPI
+MiLocateVad(
+    _In_ PMM_AVL_TABLE Table,
+    _In_ PVOID VirtualAddress);
+
+PMMVAD
+NTAPI
 MiLocateAddress(
     IN PVOID VirtualAddress
 );

--- a/ntoskrnl/mm/ARM3/miarm.h
+++ b/ntoskrnl/mm/ARM3/miarm.h
@@ -2330,9 +2330,9 @@ MiMakeProtectionMask(
 VOID
 NTAPI
 MiDeleteVirtualAddresses(
-    IN ULONG_PTR Va,
-    IN ULONG_PTR EndingAddress,
-    IN PMMVAD Vad
+    _In_ ULONG_PTR Va,
+    _In_ ULONG_PTR EndingAddress,
+    _In_opt_ PMMVAD Vad
 );
 
 VOID

--- a/ntoskrnl/mm/ARM3/miarm.h
+++ b/ntoskrnl/mm/ARM3/miarm.h
@@ -2264,10 +2264,10 @@ MiInsertBasedSection(
 NTSTATUS
 NTAPI
 MiRosUnmapViewOfSection(
-    IN PEPROCESS Process,
-    IN PVOID BaseAddress,
-    IN BOOLEAN SkipDebuggerNotify
-);
+    _In_ PEPROCESS Process,
+    _In_ PMEMORY_AREA MemoryArea,
+    _In_ PVOID BaseAddress,
+    _In_ BOOLEAN SkipDebuggerNotify);
 
 VOID
 NTAPI

--- a/ntoskrnl/mm/ARM3/procsup.c
+++ b/ntoskrnl/mm/ARM3/procsup.c
@@ -1327,14 +1327,6 @@ MmCleanProcessAddressSpace(IN PEPROCESS Process)
             MiUnlockProcessWorkingSetUnsafe(Process, Thread);
         }
 
-         /* Skip ARM3 fake VADs, they'll be freed by MmDeleteProcessAddresSpace */
-        if (Vad->u.VadFlags.Spare == 1)
-        {
-            /* Set a flag so MmDeleteMemoryArea knows to free, but not to remove */
-            Vad->u.VadFlags.Spare = 2;
-            continue;
-        }
-
         /* Free the VAD memory */
         ExFreePool(Vad);
 

--- a/ntoskrnl/mm/ARM3/procsup.c
+++ b/ntoskrnl/mm/ARM3/procsup.c
@@ -1293,7 +1293,7 @@ MmCleanProcessAddressSpace(IN PEPROCESS Process)
         Vad = (PMMVAD)VadTree->BalancedRoot.RightChild;
 
         /* Check for old-style memory areas */
-        if (Vad->u.VadFlags.Spare == 1)
+        if (MI_IS_MEMORY_AREA_VAD(Vad))
         {
             /* Let RosMm handle this */
             MiRosCleanupMemoryArea(Process, Vad);

--- a/ntoskrnl/mm/ARM3/procsup.c
+++ b/ntoskrnl/mm/ARM3/procsup.c
@@ -1295,6 +1295,9 @@ MmCleanProcessAddressSpace(IN PEPROCESS Process)
         /* Check for old-style memory areas */
         if (MI_IS_MEMORY_AREA_VAD(Vad))
         {
+            /* We do not expect ARM3 memory areas here, those are kernel only */
+            ASSERT(MI_IS_ROSMM_VAD(Vad));
+
             /* Let RosMm handle this */
             MiRosCleanupMemoryArea(Process, Vad);
             continue;

--- a/ntoskrnl/mm/ARM3/section.c
+++ b/ntoskrnl/mm/ARM3/section.c
@@ -778,6 +778,7 @@ MiRemoveMappedView(IN PEPROCESS CurrentProcess,
     ASSERT(Vad->u2.VadFlags2.ExtendableFile == FALSE);
     ASSERT(ControlArea);
     ASSERT(ControlArea->FilePointer == NULL);
+    ASSERT(!MI_IS_MEMORY_AREA_VAD(Vad));
 
     /* Delete the actual virtual memory pages */
     MiDeleteVirtualAddresses(Vad->StartingVpn << PAGE_SHIFT,
@@ -1564,7 +1565,7 @@ MiGetFileObjectForVad(
     PFILE_OBJECT FileObject;
 
     /* Check if this is a RosMm memory area */
-    if (Vad->u.VadFlags.Spare != 0)
+    if (MI_IS_MEMORY_AREA_VAD(Vad))
     {
         PMEMORY_AREA MemoryArea = (PMEMORY_AREA)Vad;
 

--- a/ntoskrnl/mm/ARM3/section.c
+++ b/ntoskrnl/mm/ARM3/section.c
@@ -1569,6 +1569,9 @@ MiGetFileObjectForVad(
     {
         PMEMORY_AREA MemoryArea = (PMEMORY_AREA)Vad;
 
+        /* We do not expect ARM3 memory areas here, those are kernel only */
+        ASSERT(MI_IS_ROSMM_VAD(Vad));
+
         /* Check if it's a section view (RosMm section) */
         if (MemoryArea->Type == MEMORY_AREA_SECTION_VIEW)
         {

--- a/ntoskrnl/mm/ARM3/section.c
+++ b/ntoskrnl/mm/ARM3/section.c
@@ -833,7 +833,7 @@ MiUnmapViewOfSection(IN PEPROCESS Process,
     {
         /* Call Mm API */
         ASSERT(MI_IS_ROSMM_VAD(Vad));
-        NTSTATUS Status = MiRosUnmapViewOfSection(Process, BaseAddress, Process->ProcessExiting);
+        Status = MiRosUnmapViewOfSection(Process, (PMEMORY_AREA)Vad, BaseAddress, Process->ProcessExiting);
         if (!Flags) MmUnlockAddressSpace(&Process->Vm);
         return Status;
     }

--- a/ntoskrnl/mm/ARM3/section.c
+++ b/ntoskrnl/mm/ARM3/section.c
@@ -805,7 +805,6 @@ MiUnmapViewOfSection(IN PEPROCESS Process,
                      IN PVOID BaseAddress,
                      IN ULONG Flags)
 {
-    PMEMORY_AREA MemoryArea;
     BOOLEAN Attached = FALSE;
     KAPC_STATE ApcState;
     PMMVAD Vad;
@@ -819,11 +818,21 @@ MiUnmapViewOfSection(IN PEPROCESS Process,
     /* Check if we need to lock the address space */
     if (!Flags) MmLockAddressSpace(&Process->Vm);
 
-    /* Check for Mm Region */
-    MemoryArea = MmLocateMemoryAreaByAddress(&Process->Vm, BaseAddress);
-    if ((MemoryArea) && (MemoryArea->Type != MEMORY_AREA_OWNED_BY_ARM3))
+    /* Find the VAD for the address and make sure it's a section VAD */
+    Vad = MiLocateVad(&Process->VadRoot, BaseAddress);
+    if (!(Vad) || (Vad->u.VadFlags.PrivateMemory))
+    {
+        /* Couldn't find it, or invalid VAD, fail */
+        DPRINT1("No VAD or invalid VAD\n");
+        if (!Flags) MmUnlockAddressSpace(&Process->Vm);
+        return STATUS_NOT_MAPPED_VIEW;
+    }
+
+    /* Check for RosMm memory area */
+    if (MI_IS_MEMORY_AREA_VAD(Vad))
     {
         /* Call Mm API */
+        ASSERT(MI_IS_ROSMM_VAD(Vad));
         NTSTATUS Status = MiRosUnmapViewOfSection(Process, BaseAddress, Process->ProcessExiting);
         if (!Flags) MmUnlockAddressSpace(&Process->Vm);
         return Status;
@@ -844,17 +853,6 @@ MiUnmapViewOfSection(IN PEPROCESS Process,
         DPRINT1("Process died!\n");
         if (!Flags) MmUnlockAddressSpace(&Process->Vm);
         Status = STATUS_PROCESS_IS_TERMINATING;
-        goto Quickie;
-    }
-
-    /* Find the VAD for the address and make sure it's a section VAD */
-    Vad = MiLocateAddress(BaseAddress);
-    if (!(Vad) || (Vad->u.VadFlags.PrivateMemory))
-    {
-        /* Couldn't find it, or invalid VAD, fail */
-        DPRINT1("No VAD or invalid VAD\n");
-        if (!Flags) MmUnlockAddressSpace(&Process->Vm);
-        Status = STATUS_NOT_MAPPED_VIEW;
         goto Quickie;
     }
 

--- a/ntoskrnl/mm/ARM3/vadnode.c
+++ b/ntoskrnl/mm/ARM3/vadnode.c
@@ -213,7 +213,7 @@ MiInsertNode(IN PMM_AVL_TABLE Table,
 
     /* Now insert an ARM3 MEMORY_AREA for this node, unless the insert was already from the MEMORY_AREA code */
     Vad = (PMMVAD_LONG)NewNode;
-    if (Vad->u.VadFlags.Spare == 0)
+    if (!MI_IS_MEMORY_AREA_VAD(Vad))
     {
         NTSTATUS Status;
         PMEMORY_AREA MemoryArea;
@@ -460,7 +460,7 @@ MiRemoveNode(IN PMMADDRESS_NODE Node,
 
     /* Free the node from ReactOS view as well */
     Vad = (PMMVAD_LONG)Node;
-    if ((Table != &MmSectionBasedRoot) && (Vad->u.VadFlags.Spare == 0))
+    if ((Table != &MmSectionBasedRoot) && !MI_IS_MEMORY_AREA_VAD(Vad))
     {
         PMEMORY_AREA MemoryArea;
         PEPROCESS Process;

--- a/ntoskrnl/mm/ARM3/vadnode.c
+++ b/ntoskrnl/mm/ARM3/vadnode.c
@@ -113,11 +113,10 @@ MiDbgAssertIsLockedForWrite(_In_ PMM_AVL_TABLE Table)
 
 PMMVAD
 NTAPI
-MiLocateAddress(IN PVOID VirtualAddress)
+MiLocateVad(_In_ PMM_AVL_TABLE Table, _In_ PVOID VirtualAddress)
 {
     PMMVAD FoundVad;
     ULONG_PTR Vpn;
-    PMM_AVL_TABLE Table = &PsGetCurrentProcess()->VadRoot;
     TABLE_SEARCH_RESULT SearchResult;
 
     ASSERT_LOCKED_FOR_READ(Table);
@@ -143,6 +142,14 @@ MiLocateAddress(IN PVOID VirtualAddress)
     /* We allow this (atomic) update without exclusive lock, because it's a hint only */
     Table->NodeHint = FoundVad;
     return FoundVad;
+}
+
+PMMVAD
+NTAPI
+MiLocateAddress(_In_ PVOID VirtualAddress)
+{
+    PMM_AVL_TABLE Table = &PsGetCurrentProcess()->VadRoot;
+    return MiLocateVad(Table, VirtualAddress);
 }
 
 TABLE_SEARCH_RESULT

--- a/ntoskrnl/mm/ARM3/virtual.c
+++ b/ntoskrnl/mm/ARM3/virtual.c
@@ -1902,10 +1902,9 @@ MiQueryMemoryBasicInformation(IN HANDLE ProcessHandle,
 
     /* Find the memory area the specified address belongs to */
     MemoryArea = MmLocateMemoryAreaByAddress(&TargetProcess->Vm, BaseAddress);
-    ASSERT(MemoryArea != NULL);
 
     /* Determine information dependent on the memory area type */
-    if (MemoryArea->Type == MEMORY_AREA_SECTION_VIEW)
+    if (MemoryArea && MemoryArea->Type == MEMORY_AREA_SECTION_VIEW)
     {
         Status = MmQuerySectionView(MemoryArea, BaseAddress, &MemoryInfo, &ResultLength);
         if (!NT_SUCCESS(Status))
@@ -4914,8 +4913,7 @@ NtAllocateVirtualMemory(IN HANDLE ProcessHandle,
     // Make sure this is an ARM3 section
     //
     MemoryArea = MmLocateMemoryAreaByAddress(AddressSpace, (PVOID)PAGE_ROUND_DOWN(PBaseAddress));
-    ASSERT(MemoryArea != NULL);
-    if (MemoryArea->Type != MEMORY_AREA_OWNED_BY_ARM3)
+    if (MemoryArea && MemoryArea->Type != MEMORY_AREA_OWNED_BY_ARM3)
     {
         DPRINT1("Illegal commit of non-ARM3 section!\n");
         Status = STATUS_ALREADY_COMMITTED;

--- a/ntoskrnl/mm/ARM3/virtual.c
+++ b/ntoskrnl/mm/ARM3/virtual.c
@@ -546,7 +546,7 @@ MiDeleteVirtualAddresses(IN ULONG_PTR Va,
     PSUBSECTION Subsection;
 
     /* Get out if this is a fake VAD, RosMm will free the marea pages */
-    if ((Vad) && (Vad->u.VadFlags.Spare == 1)) return;
+    if ((Vad) && MI_IS_MEMORY_AREA_VAD(Vad)) return;
 
     /* Get the current process */
     CurrentProcess = PsGetCurrentProcess();

--- a/ntoskrnl/mm/ARM3/virtual.c
+++ b/ntoskrnl/mm/ARM3/virtual.c
@@ -527,9 +527,10 @@ MiDeletePte(IN PMMPTE PointerPte,
 
 VOID
 NTAPI
-MiDeleteVirtualAddresses(IN ULONG_PTR Va,
-                         IN ULONG_PTR EndingAddress,
-                         IN PMMVAD Vad)
+MiDeleteVirtualAddresses(
+    _In_ ULONG_PTR Va,
+    _In_ ULONG_PTR EndingAddress,
+    _In_opt_ PMMVAD Vad)
 {
     PMMPTE PointerPte, PrototypePte, LastPrototypePte;
     PMMPDE PointerPde;
@@ -545,8 +546,8 @@ MiDeleteVirtualAddresses(IN ULONG_PTR Va,
     BOOLEAN AddressGap = FALSE;
     PSUBSECTION Subsection;
 
-    /* Get out if this is a fake VAD, RosMm will free the marea pages */
-    if ((Vad) && MI_IS_MEMORY_AREA_VAD(Vad)) return;
+    /* We should never get RosMm memory areas here */
+    ASSERT((Vad == NULL) || !MI_IS_MEMORY_AREA_VAD(Vad));
 
     /* Get the current process */
     CurrentProcess = PsGetCurrentProcess();

--- a/ntoskrnl/mm/ARM3/virtual.c
+++ b/ntoskrnl/mm/ARM3/virtual.c
@@ -2155,46 +2155,6 @@ MiIsEntireRangeCommitted(IN ULONG_PTR StartingAddress,
 
 NTSTATUS
 NTAPI
-MiRosProtectVirtualMemory(IN PEPROCESS Process,
-                          IN OUT PVOID *BaseAddress,
-                          IN OUT PSIZE_T NumberOfBytesToProtect,
-                          IN ULONG NewAccessProtection,
-                          OUT PULONG OldAccessProtection OPTIONAL)
-{
-    PMEMORY_AREA MemoryArea;
-    PMMSUPPORT AddressSpace;
-    ULONG OldAccessProtection_;
-    NTSTATUS Status;
-
-    *NumberOfBytesToProtect = PAGE_ROUND_UP((ULONG_PTR)(*BaseAddress) + (*NumberOfBytesToProtect)) - PAGE_ROUND_DOWN(*BaseAddress);
-    *BaseAddress = (PVOID)PAGE_ROUND_DOWN(*BaseAddress);
-
-    AddressSpace = &Process->Vm;
-    MmLockAddressSpace(AddressSpace);
-    MemoryArea = MmLocateMemoryAreaByAddress(AddressSpace, *BaseAddress);
-    if (MemoryArea == NULL || MemoryArea->DeleteInProgress)
-    {
-        MmUnlockAddressSpace(AddressSpace);
-        return STATUS_UNSUCCESSFUL;
-    }
-
-    if (OldAccessProtection == NULL) OldAccessProtection = &OldAccessProtection_;
-
-    ASSERT(MemoryArea->Type == MEMORY_AREA_SECTION_VIEW);
-    Status = MmProtectSectionView(AddressSpace,
-                                  MemoryArea,
-                                  *BaseAddress,
-                                  *NumberOfBytesToProtect,
-                                  NewAccessProtection,
-                                  OldAccessProtection);
-
-    MmUnlockAddressSpace(AddressSpace);
-
-    return Status;
-}
-
-NTSTATUS
-NTAPI
 MiProtectVirtualMemory(IN PEPROCESS Process,
                        IN OUT PVOID *BaseAddress,
                        IN OUT PSIZE_T NumberOfBytesToProtect,
@@ -2254,13 +2214,18 @@ MiProtectVirtualMemory(IN PEPROCESS Process,
     /* Check if this is a ROSMM VAD */
     if (MI_IS_ROSMM_VAD(Vad))
     {
-        /* Not very awesome hack */
+        /* Not too shabby hack */
+        ASSERT(((PMEMORY_AREA)Vad)->Type == MEMORY_AREA_SECTION_VIEW);
+        *NumberOfBytesToProtect = PAGE_ROUND_UP((ULONG_PTR)(*BaseAddress) + (*NumberOfBytesToProtect)) - PAGE_ROUND_DOWN(*BaseAddress);
+        *BaseAddress = (PVOID)PAGE_ROUND_DOWN(*BaseAddress);
+        Status = MmProtectSectionView(AddressSpace,
+                                      (PMEMORY_AREA)Vad,
+                                      *BaseAddress,
+                                      *NumberOfBytesToProtect,
+                                      NewAccessProtection,
+                                      OldAccessProtection);
         MmUnlockAddressSpace(AddressSpace);
-        return MiRosProtectVirtualMemory(Process,
-                                         BaseAddress,
-                                         NumberOfBytesToProtect,
-                                         NewAccessProtection,
-                                         OldAccessProtection);
+        return Status;
     }
 
     /* Make sure the address is within this VAD's boundaries */

--- a/ntoskrnl/mm/ARM3/virtual.c
+++ b/ntoskrnl/mm/ARM3/virtual.c
@@ -2201,7 +2201,6 @@ MiProtectVirtualMemory(IN PEPROCESS Process,
                        IN ULONG NewAccessProtection,
                        OUT PULONG OldAccessProtection OPTIONAL)
 {
-    PMEMORY_AREA MemoryArea;
     PMMVAD Vad;
     PMMSUPPORT AddressSpace;
     ULONG_PTR StartingAddress, EndingAddress;
@@ -2240,19 +2239,6 @@ MiProtectVirtualMemory(IN PEPROCESS Process,
         goto FailPath;
     }
 
-    /* Check for ROS specific memory area */
-    MemoryArea = MmLocateMemoryAreaByAddress(&Process->Vm, *BaseAddress);
-    if ((MemoryArea) && (MemoryArea->Type != MEMORY_AREA_OWNED_BY_ARM3))
-    {
-        /* Evil hack */
-        MmUnlockAddressSpace(AddressSpace);
-        return MiRosProtectVirtualMemory(Process,
-                                         BaseAddress,
-                                         NumberOfBytesToProtect,
-                                         NewAccessProtection,
-                                         OldAccessProtection);
-    }
-
     /* Get the VAD for this address range, and make sure it exists */
     Result = MiCheckForConflictingNode(StartingAddress >> PAGE_SHIFT,
                                        EndingAddress >> PAGE_SHIFT,
@@ -2263,6 +2249,18 @@ MiProtectVirtualMemory(IN PEPROCESS Process,
         DPRINT("Could not find a VAD for this allocation\n");
         Status = STATUS_CONFLICTING_ADDRESSES;
         goto FailPath;
+    }
+
+    /* Check if this is a ROSMM VAD */
+    if (MI_IS_ROSMM_VAD(Vad))
+    {
+        /* Not very awesome hack */
+        MmUnlockAddressSpace(AddressSpace);
+        return MiRosProtectVirtualMemory(Process,
+                                         BaseAddress,
+                                         NumberOfBytesToProtect,
+                                         NewAccessProtection,
+                                         OldAccessProtection);
     }
 
     /* Make sure the address is within this VAD's boundaries */

--- a/ntoskrnl/mm/ARM3/virtual.c
+++ b/ntoskrnl/mm/ARM3/virtual.c
@@ -4460,7 +4460,6 @@ NtAllocateVirtualMemory(IN HANDLE ProcessHandle,
                         IN ULONG Protect)
 {
     PEPROCESS Process;
-    PMEMORY_AREA MemoryArea;
     PMMVAD Vad = NULL, FoundVad;
     NTSTATUS Status;
     PMMSUPPORT AddressSpace;
@@ -4876,8 +4875,7 @@ NtAllocateVirtualMemory(IN HANDLE ProcessHandle,
     //
     // Make sure this is an ARM3 section
     //
-    MemoryArea = MmLocateMemoryAreaByAddress(AddressSpace, (PVOID)PAGE_ROUND_DOWN(PBaseAddress));
-    if (MemoryArea && MemoryArea->Type != MEMORY_AREA_OWNED_BY_ARM3)
+    if (MI_IS_ROSMM_VAD(FoundVad))
     {
         DPRINT1("Illegal commit of non-ARM3 section!\n");
         Status = STATUS_ALREADY_COMMITTED;

--- a/ntoskrnl/mm/marea.c
+++ b/ntoskrnl/mm/marea.c
@@ -511,7 +511,7 @@ MiRosCleanupMemoryArea(
 
     if (MemoryArea->Type == MEMORY_AREA_SECTION_VIEW)
     {
-        Status = MiRosUnmapViewOfSection(Process, BaseAddress, Process->ProcessExiting);
+        Status = MiRosUnmapViewOfSection(Process, MemoryArea, BaseAddress, Process->ProcessExiting);
     }
 #ifdef NEWCC
     else if (MemoryArea->Type == MEMORY_AREA_CACHE)

--- a/ntoskrnl/mm/marea.c
+++ b/ntoskrnl/mm/marea.c
@@ -56,49 +56,14 @@ BOOLEAN MiRosKernelVadRootInitialized;
 
 /* FUNCTIONS *****************************************************************/
 
-PMEMORY_AREA NTAPI
+PMEMORY_AREA
+NTAPI
 MmLocateMemoryAreaByAddress(
     PMMSUPPORT AddressSpace,
-    PVOID Address_)
+    PVOID Address)
 {
-    ULONG_PTR StartVpn = (ULONG_PTR)Address_ / PAGE_SIZE;
-    PEPROCESS Process;
-    PMM_AVL_TABLE Table;
-    PMMADDRESS_NODE Node;
-    PMEMORY_AREA MemoryArea;
-    TABLE_SEARCH_RESULT Result;
-    PMMVAD_LONG Vad;
-
-    Process = MmGetAddressSpaceOwner(AddressSpace);
-    Table = (Process != NULL) ? &Process->VadRoot : &MiRosKernelVadRoot;
-
-    Result = MiCheckForConflictingNode(StartVpn, StartVpn, Table, &Node);
-    if (Result != TableFoundNode)
-    {
-        return NULL;
-    }
-
-    Vad = (PMMVAD_LONG)Node;
-    if (Vad->u.VadFlags.Spare == 0)
-    {
-        /* Check if this is VM VAD */
-        if (Vad->ControlArea == NULL)
-        {
-            /* We store the reactos MEMORY_AREA here */
-            MemoryArea = (PMEMORY_AREA)Vad->FirstPrototypePte;
-        }
-        else
-        {
-            /* This is a section VAD. Store the MAREA here for now */
-            MemoryArea = (PMEMORY_AREA)Vad->u4.Banked;
-        }
-    }
-    else
-    {
-        MemoryArea = (PMEMORY_AREA)Node;
-    }
-
-    return MemoryArea;
+    /* Do it the simple way */
+    return MmLocateMemoryAreaByRegion(AddressSpace, Address, 1);
 }
 
 PMEMORY_AREA

--- a/ntoskrnl/mm/marea.c
+++ b/ntoskrnl/mm/marea.c
@@ -313,8 +313,7 @@ MmFreeMemoryArea(
             }
         }
 
-        //if (MemoryArea->VadNode.StartingVpn < (ULONG_PTR)MmSystemRangeStart >> PAGE_SHIFT
-        if (MemoryArea->Vad)
+        if (MemoryArea->VadNode.StartingVpn < (ULONG_PTR)MmSystemRangeStart >> PAGE_SHIFT)
         {
             ASSERT(MemoryArea->VadNode.EndingVpn + 1 < (ULONG_PTR)MmSystemRangeStart >> PAGE_SHIFT);
 #ifdef NEWCC

--- a/ntoskrnl/mm/marea.c
+++ b/ntoskrnl/mm/marea.c
@@ -440,6 +440,10 @@ MmCreateMemoryArea(PMMSUPPORT AddressSpace,
     MemoryArea->Magic = 'erAM';
     MemoryArea->DeleteInProgress = FALSE;
     MI_SET_MEMORY_AREA_VAD(&MemoryArea->VadNode);
+    if (MemoryArea->Type != MEMORY_AREA_OWNED_BY_ARM3)
+    {
+        MI_SET_ROSMM_VAD(&MemoryArea->VadNode);
+    }
 
     if (*BaseAddress == 0)
     {

--- a/ntoskrnl/mm/marea.c
+++ b/ntoskrnl/mm/marea.c
@@ -94,17 +94,8 @@ MmLocateMemoryAreaByRegion(
     Vad = (PMMVAD_LONG)Node;
     if (!MI_IS_MEMORY_AREA_VAD(Vad))
     {
-        /* Check if this is VM VAD */
-        if (Vad->ControlArea == NULL)
-        {
-            /* We store the reactos MEMORY_AREA here */
-            MemoryArea = (PMEMORY_AREA)Vad->FirstPrototypePte;
-        }
-        else
-        {
-            /* This is a section VAD. Store the MAREA here for now */
-            MemoryArea = (PMEMORY_AREA)Vad->u4.Banked;
-        }
+        /* This is an ARM3 VAD, we don't return it. */
+        return NULL;
     }
     else
     {
@@ -332,15 +323,13 @@ MmFreeMemoryArea(
             ASSERT(MemoryArea->Type == MEMORY_AREA_SECTION_VIEW);
 #endif
 
-            /* MmCleanProcessAddressSpace might have removed it (and this would be MmDeleteProcessAddressSpace) */
+            /* We do not have fake ARM3 memory areas anymore. */
             ASSERT(MI_IS_MEMORY_AREA_VAD(&MemoryArea->VadNode));
-            if (MI_IS_MEMORY_AREA_VAD((PMMVAD)MemoryArea->Vad))
-            {
-                ASSERT((PMMVAD)MemoryArea->Vad == &MemoryArea->VadNode);
-                MiLockProcessWorkingSet(PsGetCurrentProcess(), PsGetCurrentThread());
-                MiRemoveNode((PMMADDRESS_NODE)&MemoryArea->VadNode, &Process->VadRoot);
-                MiUnlockProcessWorkingSet(PsGetCurrentProcess(), PsGetCurrentThread());
-            }
+            ASSERT(MI_IS_MEMORY_AREA_VAD((PMMVAD)MemoryArea->Vad));
+            ASSERT((PMMVAD)MemoryArea->Vad == &MemoryArea->VadNode);
+            MiLockProcessWorkingSet(PsGetCurrentProcess(), PsGetCurrentThread());
+            MiRemoveNode((PMMADDRESS_NODE)&MemoryArea->VadNode, &Process->VadRoot);
+            MiUnlockProcessWorkingSet(PsGetCurrentProcess(), PsGetCurrentThread());
 
             MemoryArea->Vad = NULL;
         }

--- a/ntoskrnl/mm/marea.c
+++ b/ntoskrnl/mm/marea.c
@@ -115,6 +115,28 @@ MmLocateMemoryAreaByRegion(
     return MemoryArea;
 }
 
+BOOLEAN
+NTAPI
+MmIsAddressRangeFree(
+    _In_ PMMSUPPORT AddressSpace,
+    _In_ PVOID Address,
+    _In_ ULONG_PTR Length)
+{
+    ULONG_PTR StartVpn = (ULONG_PTR)Address / PAGE_SIZE;
+    ULONG_PTR EndVpn = ((ULONG_PTR)Address + Length - 1) / PAGE_SIZE;
+    PEPROCESS Process;
+    PMM_AVL_TABLE Table;
+    PMMADDRESS_NODE Node;
+    TABLE_SEARCH_RESULT Result;
+
+    Process = MmGetAddressSpaceOwner(AddressSpace);
+    Table = (Process != NULL) ? &Process->VadRoot : &MiRosKernelVadRoot;
+
+    Result = MiCheckForConflictingNode(StartVpn, EndVpn, Table, &Node);
+
+    return (Result != TableFoundNode);
+}
+
 VOID
 NTAPI
 MiInsertVad(IN PMMVAD Vad,
@@ -460,9 +482,7 @@ MmCreateMemoryArea(PMMSUPPORT AddressSpace,
         /* No need to check ARM3 owned memory areas, the range MUST be free */
         if (MemoryArea->Type != MEMORY_AREA_OWNED_BY_ARM3)
         {
-            if (MmLocateMemoryAreaByRegion(AddressSpace,
-                                           *BaseAddress,
-                                           tmpLength) != NULL)
+            if (!MmIsAddressRangeFree(AddressSpace, *BaseAddress, tmpLength))
             {
                 DPRINT("Memory area already occupied\n");
                 if (!(Type & MEMORY_AREA_STATIC)) ExFreePoolWithTag(MemoryArea, TAG_MAREA);

--- a/ntoskrnl/mm/marea.c
+++ b/ntoskrnl/mm/marea.c
@@ -166,7 +166,6 @@ MmInsertMemoryArea(
             MiLockProcessWorkingSetUnsafe(PsGetCurrentProcess(), PsGetCurrentThread());
             MiInsertVad(&marea->VadNode, &Process->VadRoot);
             MiUnlockProcessWorkingSetUnsafe(PsGetCurrentProcess(), PsGetCurrentThread());
-            marea->Vad = &marea->VadNode;
         }
     }
     else
@@ -184,7 +183,6 @@ MmInsertMemoryArea(
         MiLockWorkingSet(PsGetCurrentThread(), &MmSystemCacheWs);
         MiInsertVad(&marea->VadNode, &MiRosKernelVadRoot);
         MiUnlockWorkingSet(PsGetCurrentThread(), &MmSystemCacheWs);
-        marea->Vad = NULL;
     }
 }
 
@@ -324,13 +322,9 @@ MmFreeMemoryArea(
 
             /* We do not have fake ARM3 memory areas anymore. */
             ASSERT(MI_IS_MEMORY_AREA_VAD(&MemoryArea->VadNode));
-            ASSERT(MI_IS_MEMORY_AREA_VAD((PMMVAD)MemoryArea->Vad));
-            ASSERT((PMMVAD)MemoryArea->Vad == &MemoryArea->VadNode);
             MiLockProcessWorkingSet(PsGetCurrentProcess(), PsGetCurrentThread());
             MiRemoveNode((PMMADDRESS_NODE)&MemoryArea->VadNode, &Process->VadRoot);
             MiUnlockProcessWorkingSet(PsGetCurrentProcess(), PsGetCurrentThread());
-
-            MemoryArea->Vad = NULL;
         }
         else
         {

--- a/ntoskrnl/mm/section.c
+++ b/ntoskrnl/mm/section.c
@@ -4104,8 +4104,7 @@ MmMapViewOfSection(IN PVOID SectionObject,
         }
 
         /* Check there is enough space to map the section at that point. */
-        if (MmLocateMemoryAreaByRegion(AddressSpace, (PVOID)ImageBase,
-                                       PAGE_ROUND_UP(ImageSize)) != NULL)
+        if (!MmIsAddressRangeFree(AddressSpace, (PVOID)ImageBase, PAGE_ROUND_UP(ImageSize)))
         {
             /* Fail if the user requested a fixed base address. */
             if ((*BaseAddress) != NULL)

--- a/ntoskrnl/mm/section.c
+++ b/ntoskrnl/mm/section.c
@@ -3599,12 +3599,13 @@ MmUnmapViewOfSegment(PMMSUPPORT AddressSpace,
 /* This functions must be called with a locked address space */
 NTSTATUS
 NTAPI
-MiRosUnmapViewOfSection(IN PEPROCESS Process,
-                        IN PVOID BaseAddress,
-                        IN BOOLEAN SkipDebuggerNotify)
+MiRosUnmapViewOfSection(
+    _In_ PEPROCESS Process,
+    _In_ PMEMORY_AREA MemoryArea,
+    _In_ PVOID BaseAddress,
+    _In_ BOOLEAN SkipDebuggerNotify)
 {
     NTSTATUS Status;
-    PMEMORY_AREA MemoryArea;
     PMMSUPPORT AddressSpace;
     PVOID ImageBaseAddress = 0;
 
@@ -3612,11 +3613,10 @@ MiRosUnmapViewOfSection(IN PEPROCESS Process,
            Process, BaseAddress);
 
     ASSERT(Process);
+    ASSERT(MemoryArea);
 
     AddressSpace = &Process->Vm;
 
-    MemoryArea = MmLocateMemoryAreaByAddress(AddressSpace,
-                 BaseAddress);
     if (MemoryArea == NULL ||
 #ifdef NEWCC
             ((MemoryArea->Type != MEMORY_AREA_SECTION_VIEW) && (MemoryArea->Type != MEMORY_AREA_CACHE)) ||

--- a/ntoskrnl/mm/section.c
+++ b/ntoskrnl/mm/section.c
@@ -2076,6 +2076,13 @@ MmProtectSectionView(PMMSUPPORT AddressSpace,
     NTSTATUS Status;
     ULONG_PTR MaxLength;
 
+    ASSERT(MemoryArea->Type == MEMORY_AREA_SECTION_VIEW);
+
+    if (MemoryArea->DeleteInProgress)
+    {
+        return STATUS_UNSUCCESSFUL;
+    }
+
     MaxLength = MA_GetEndingAddress(MemoryArea) - (ULONG_PTR)BaseAddress;
     if (Length > MaxLength)
         Length = (ULONG)MaxLength;
@@ -2091,7 +2098,8 @@ MmProtectSectionView(PMMSUPPORT AddressSpace,
         return STATUS_INVALID_PAGE_PROTECTION;
     }
 
-    *OldProtect = Region->Protect;
+    if (OldProtect != NULL)
+        *OldProtect = Region->Protect;
     Status = MmAlterRegion(AddressSpace, (PVOID)MA_GetStartingAddress(MemoryArea),
                            &MemoryArea->SectionData.RegionListHead,
                            BaseAddress, Length, Region->Type, Protect,


### PR DESCRIPTION
## Purpose

Clean up the memory area code a bit to reduce it's hackyness.
This is some preparational work for implementing commitment accounting, i.e. making sure that we do not commit more memory than we have in terms of physical + page file. This requires some cleanup to reduce the amount of code that needs to deal with this.
Should be reviewed by commit.

## Tests
- ✅ KVM x86: https://reactos.org/testman/compare.php?ids=101510,101513,101515,101507
- ✅ KVM x64: https://reactos.org/testman/compare.php?ids=101512,101514,101516,101508