### PR TITLE
[SHELL32] Fix ParseDisplayName Part 3

### DIFF
--- a/dll/win32/shell32/folders/CRegFolder.cpp
+++ b/dll/win32/shell32/folders/CRegFolder.cpp
@@ -313,6 +313,8 @@ class CRegFolder :
         CComHeapPtr<ITEMIDLIST> m_pidlRoot;
 
         HRESULT GetGuidItemAttributes (LPCITEMIDLIST pidl, LPDWORD pdwAttributes);
+        BOOL _IsInNameSpace(_In_ LPCITEMIDLIST pidl);
+
     public:
         CRegFolder();
         ~CRegFolder();
@@ -401,46 +403,69 @@ HRESULT CRegFolder::GetGuidItemAttributes (LPCITEMIDLIST pidl, LPDWORD pdwAttrib
     return S_OK;
 }
 
+BOOL CRegFolder::_IsInNameSpace(_In_ LPCITEMIDLIST pidl)
+{
+    CLSID clsid = *_ILGetGUIDPointer(pidl);
+    if (IsEqualGUID(clsid, CLSID_Printers))
+        return TRUE;
+    if (IsEqualGUID(clsid, CLSID_ConnectionFolder))
+        return TRUE;
+    FIXME("Check registry\n");
+    return TRUE;
+}
+
 HRESULT WINAPI CRegFolder::ParseDisplayName(HWND hwndOwner, LPBC pbc, LPOLESTR lpszDisplayName,
         ULONG *pchEaten, PIDLIST_RELATIVE *ppidl, ULONG *pdwAttributes)
 {
-    LPITEMIDLIST pidl;
-
-    if (!lpszDisplayName || !ppidl)
+    if (!ppidl)
         return E_INVALIDARG;
 
-    *ppidl = 0;
+    *ppidl = NULL;
 
-    if (pchEaten)
-        *pchEaten = 0;
+    if (!lpszDisplayName)
+        return E_INVALIDARG;
 
-    UINT cch = wcslen(lpszDisplayName);
-    if (cch < 39 || lpszDisplayName[0] != L':' || lpszDisplayName[1] != L':')
-        return E_FAIL;
-
-    pidl = _ILCreateGuidFromStrW(lpszDisplayName + 2);
-    if (pidl == NULL)
-        return E_FAIL;
-
-    if (cch < 41)
+    if (lpszDisplayName[0] != L':' || lpszDisplayName[1] != L':')
     {
-        *ppidl = pidl;
+        FIXME("What should we do here?\n");
+        return E_FAIL;
+    }
+
+    LPWSTR pch, pchNextOfComma = NULL;
+    for (pch = &lpszDisplayName[2]; *pch && *pch != L'\\'; ++pch)
+    {
+        if (*pch == L',' && !pchNextOfComma)
+            pchNextOfComma = pch + 1;
+    }
+
+    CLSID clsid;
+    if (!GUIDFromStringW(&lpszDisplayName[2], &clsid))
+        return CO_E_CLASSSTRING;
+
+    if (pchNextOfComma)
+    {
+        FIXME("Delegate folder\n");
+        return E_FAIL;
+    }
+
+    CComHeapPtr<ITEMIDLIST> pidl(_ILCreateGuid(PT_GUID, clsid));
+    if (!pidl)
+        return E_OUTOFMEMORY;
+
+    if (!*pch)
+    {
+        *ppidl = pidl.Detach();
         if (pdwAttributes && *pdwAttributes)
-        {
             GetGuidItemAttributes(*ppidl, pdwAttributes);
-        }
-    }
-    else
-    {
-        HRESULT hr = SHELL32_ParseNextElement(this, hwndOwner, pbc, &pidl, lpszDisplayName + 41, pchEaten, pdwAttributes);
-        if (SUCCEEDED(hr))
-        {
-            *ppidl = pidl;
-        }
-        return hr;
+
+        return S_OK;
     }
 
-    return S_OK;
+    if (!_IsInNameSpace(pidl) && !(BindCtx_GetMode(pbc, 0) & STGM_CREATE))
+        return E_INVALIDARG;
+
+    *ppidl = pidl.Detach();
+    return SHELL32_ParseNextElement(this, hwndOwner, pbc, ppidl, pch + 1, pchEaten, pdwAttributes);
 }
 
 HRESULT WINAPI CRegFolder::EnumObjects(HWND hwndOwner, DWORD dwFlags, LPENUMIDLIST *ppEnumIDList)

--- a/dll/win32/shell32/folders/CRegFolder.cpp
+++ b/dll/win32/shell32/folders/CRegFolder.cpp
@@ -448,23 +448,23 @@ HRESULT WINAPI CRegFolder::ParseDisplayName(HWND hwndOwner, LPBC pbc, LPOLESTR l
         return E_FAIL;
     }
 
-    CComHeapPtr<ITEMIDLIST> pidl(_ILCreateGuid(PT_GUID, clsid));
-    if (!pidl)
+    CComHeapPtr<ITEMIDLIST> pidlTemp(_ILCreateGuid(PT_GUID, clsid));
+    if (!pidlTemp)
         return E_OUTOFMEMORY;
 
     if (!*pch)
     {
-        *ppidl = pidl.Detach();
+        *ppidl = pidlTemp.Detach();
         if (pdwAttributes && *pdwAttributes)
             GetGuidItemAttributes(*ppidl, pdwAttributes);
 
         return S_OK;
     }
 
-    if (!_IsInNameSpace(pidl) && !(BindCtx_GetMode(pbc, 0) & STGM_CREATE))
+    if (!_IsInNameSpace(pidlTemp) && !(BindCtx_GetMode(pbc, 0) & STGM_CREATE))
         return E_INVALIDARG;
 
-    *ppidl = pidl.Detach();
+    *ppidl = pidlTemp.Detach();
     HRESULT hr = SHELL32_ParseNextElement(this, hwndOwner, pbc, ppidl, pch + 1, pchEaten,
                                           pdwAttributes);
     if (FAILED(hr))

--- a/dll/win32/shell32/folders/CRegFolder.cpp
+++ b/dll/win32/shell32/folders/CRegFolder.cpp
@@ -452,19 +452,19 @@ HRESULT WINAPI CRegFolder::ParseDisplayName(HWND hwndOwner, LPBC pbc, LPOLESTR l
     if (!pidlTemp)
         return E_OUTOFMEMORY;
 
+    if (!_IsInNameSpace(pidlTemp) && !(BindCtx_GetMode(pbc, 0) & STGM_CREATE))
+        return E_INVALIDARG;
+
+    *ppidl = pidlTemp.Detach();
+
     if (!*pch)
     {
-        *ppidl = pidlTemp.Detach();
         if (pdwAttributes && *pdwAttributes)
             GetGuidItemAttributes(*ppidl, pdwAttributes);
 
         return S_OK;
     }
 
-    if (!_IsInNameSpace(pidlTemp) && !(BindCtx_GetMode(pbc, 0) & STGM_CREATE))
-        return E_INVALIDARG;
-
-    *ppidl = pidlTemp.Detach();
     HRESULT hr = SHELL32_ParseNextElement(this, hwndOwner, pbc, ppidl, pch + 1, pchEaten,
                                           pdwAttributes);
     if (FAILED(hr))

--- a/dll/win32/shell32/folders/CRegFolder.cpp
+++ b/dll/win32/shell32/folders/CRegFolder.cpp
@@ -465,7 +465,14 @@ HRESULT WINAPI CRegFolder::ParseDisplayName(HWND hwndOwner, LPBC pbc, LPOLESTR l
         return E_INVALIDARG;
 
     *ppidl = pidl.Detach();
-    return SHELL32_ParseNextElement(this, hwndOwner, pbc, ppidl, pch + 1, pchEaten, pdwAttributes);
+    HRESULT hr = SHELL32_ParseNextElement(this, hwndOwner, pbc, ppidl, pch + 1, pchEaten,
+                                          pdwAttributes);
+    if (FAILED(hr))
+    {
+        ILFree(*ppidl);
+        *ppidl = NULL;
+    }
+    return hr;
 }
 
 HRESULT WINAPI CRegFolder::EnumObjects(HWND hwndOwner, DWORD dwFlags, LPENUMIDLIST *ppEnumIDList)


### PR DESCRIPTION
## Purpose

Follow-up to #6740. Reduce `SHParseDisplayName` failures.
JIRA issue: [CORE-19495](https://jira.reactos.org/browse/CORE-19495)

## Proposed changes

- Add `CRegFolder::_IsInNameSpace` helper method.
- Half-implement `CRegFolder::ParseDisplayName` method.
- Parse class string by using `GUIDFromStringW` function.
- Return `CO_E_CLASSSTRING` for invalid `CLSID` string.

## TODO

- [ ] Do big tests.

## Comparison

BEFORE:
![before](https://github.com/reactos/reactos/assets/2107452/593c2171-1d0c-4f14-bcfb-20a0a71e3b4d)
17 failures.

AFTER:
![after](https://github.com/reactos/reactos/assets/2107452/f13f046a-7c20-4a39-b66a-497d7c303c9a)
7 failures. This PR reduced 10 failures.