### PR TITLE
[SHELL32] Fix ParseDisplayName Part 4

### DIFF
--- a/dll/win32/shell32/folders/CDrivesFolder.cpp
+++ b/dll/win32/shell32/folders/CDrivesFolder.cpp
@@ -4,7 +4,7 @@
  *    Copyright 1997                Marcus Meissner
  *    Copyright 1998, 1999, 2002    Juergen Schmied
  *    Copyright 2009                Andrew Hill
- *    Copyright 2017-2019           Katayama Hirofumi MZ
+ *    Copyright 2017-2024           Katayama Hirofumi MZ
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -657,67 +657,66 @@ HRESULT WINAPI CDrivesFolder::FinalConstruct()
 HRESULT WINAPI CDrivesFolder::ParseDisplayName(HWND hwndOwner, LPBC pbc, LPOLESTR lpszDisplayName,
         DWORD * pchEaten, PIDLIST_RELATIVE * ppidl, DWORD * pdwAttributes)
 {
-    HRESULT hr = E_INVALIDARG;
-    LPCWSTR szNext = NULL;
-    LPITEMIDLIST pidlTemp = NULL;
-    INT nDriveNumber;
-
     TRACE("(%p)->(HWND=%p,%p,%p=%s,%p,pidl=%p,%p)\n", this,
           hwndOwner, pbc, lpszDisplayName, debugstr_w (lpszDisplayName),
           pchEaten, ppidl, pdwAttributes);
 
-    *ppidl = 0;
-    if (pchEaten)
-        *pchEaten = 0;        /* strange but like the original */
-
-    /* handle CLSID paths */
-    if (lpszDisplayName[0] == ':' && lpszDisplayName[1] == ':')
-        return m_regFolder->ParseDisplayName(hwndOwner, pbc, lpszDisplayName, pchEaten, ppidl, pdwAttributes);
-
-    nDriveNumber = PathGetDriveNumberW(lpszDisplayName);
-    if (nDriveNumber < 0)
+    if (!ppidl)
         return E_INVALIDARG;
 
-    /* check if this drive actually exists */
-    if ((::GetLogicalDrives() & (1 << nDriveNumber)) == 0)
-    {
-        return HRESULT_FROM_WIN32(ERROR_INVALID_DRIVE);
-    }
+    *ppidl = NULL;
 
-    pidlTemp = _ILCreateDrive(lpszDisplayName);
-    if (!pidlTemp)
-        return E_OUTOFMEMORY;
+    if (!lpszDisplayName)
+        return E_INVALIDARG;
 
-    if (lpszDisplayName[2] == L'\\')
-    {
-        szNext = &lpszDisplayName[3];
-    }
+    HRESULT hr = E_INVALIDARG;
 
-    if (szNext && *szNext)
+    if (lpszDisplayName[0] &&
+        ((L'A' <= lpszDisplayName[0] && lpszDisplayName[0] <= L'Z') ||
+         (L'a' <= lpszDisplayName[0] && lpszDisplayName[0] <= L'z')) &&
+        lpszDisplayName[1] == L':' && lpszDisplayName[2] == L'\\')
     {
-        hr = SHELL32_ParseNextElement (this, hwndOwner, pbc, &pidlTemp,
-                                       (LPOLESTR) szNext, pchEaten, pdwAttributes);
-    }
-    else
-    {
-        hr = S_OK;
-        if (pdwAttributes && *pdwAttributes)
+        // "C:\..."
+        INT iDrive = ((*lpszDisplayName - 1) & 0x1F);
+        if (iDrive == -1)
+            return E_INVALIDARG;
+
+        WCHAR szRoot[MAX_PATH];
+        PathBuildRootW(szRoot, iDrive);
+
+        if (SHIsFileSysBindCtx(pbc, NULL) != S_OK && !(BindCtx_GetMode(pbc, 0) & STGM_CREATE))
         {
-            if (_ILIsDrive(pidlTemp))
-            {
-                *pdwAttributes &= dwDriveAttributes;
+            if (::GetDriveType(szRoot) == DRIVE_NO_ROOT_DIR)
+                return HRESULT_FROM_WIN32(ERROR_PATH_NOT_FOUND);
+        }
 
-                if (_ILGetDriveType(pidlTemp) == DRIVE_CDROM)
-                    *pdwAttributes &= ~SFGAO_CANRENAME; // CD-ROM drive cannot rename
-            }
-            else if (_ILIsSpecialFolder(pidlTemp))
-                m_regFolder->GetAttributesOf(1, &pidlTemp, pdwAttributes);
-            else
-                ERR("Got unknown pidl\n");
+        CComHeapPtr<ITEMIDLIST> pidlTemp(_ILCreateDrive(szRoot));
+        if (!pidlTemp)
+            return E_OUTOFMEMORY;
+
+        if (lpszDisplayName[3])
+        {
+            CComPtr<IShellFolder> pChildFolder;
+            hr = BindToObject(pidlTemp, pbc, IID_PPV_ARG(IShellFolder, &pChildFolder));
+            if (FAILED(hr))
+                return hr;
+
+            ULONG chEaten;
+            CComHeapPtr<ITEMIDLIST> pidlChild;
+            hr = pChildFolder->ParseDisplayName(hwndOwner, pbc, &lpszDisplayName[3], &chEaten,
+                                                &pidlChild, pdwAttributes);
+            if (FAILED(hr))
+                return hr;
+
+            hr = SHILCombine(pidlTemp, pidlChild, ppidl);
+        }
+        else
+        {
+            hr = SHILClone(pidlTemp, ppidl);
+            if (pdwAttributes && *pdwAttributes)
+                GetAttributesOf(1, (PCUITEMID_CHILD_ARRAY)ppidl, pdwAttributes);
         }
     }
-
-    *ppidl = pidlTemp;
 
     TRACE("(%p)->(-- ret=0x%08x)\n", this, hr);
 

--- a/dll/win32/shell32/folders/CDrivesFolder.cpp
+++ b/dll/win32/shell32/folders/CDrivesFolder.cpp
@@ -705,14 +705,14 @@ HRESULT WINAPI CDrivesFolder::ParseDisplayName(HWND hwndOwner, LPBC pbc, LPOLEST
         {
             CComPtr<IShellFolder> pChildFolder;
             hr = BindToObject(pidlTemp, pbc, IID_PPV_ARG(IShellFolder, &pChildFolder));
-            if (FAILED(hr))
+            if (FAILED_UNEXPECTEDLY(hr))
                 return hr;
 
             ULONG chEaten;
             CComHeapPtr<ITEMIDLIST> pidlChild;
             hr = pChildFolder->ParseDisplayName(hwndOwner, pbc, &lpszDisplayName[3], &chEaten,
                                                 &pidlChild, pdwAttributes);
-            if (FAILED(hr))
+            if (FAILED_UNEXPECTEDLY(hr))
                 return hr;
 
             hr = SHILCombine(pidlTemp, pidlChild, ppidl);

--- a/dll/win32/shell32/folders/CDrivesFolder.cpp
+++ b/dll/win32/shell32/folders/CDrivesFolder.cpp
@@ -719,9 +719,10 @@ HRESULT WINAPI CDrivesFolder::ParseDisplayName(HWND hwndOwner, LPBC pbc, LPOLEST
         }
         else
         {
-            hr = SHILClone(pidlTemp, ppidl);
+            *ppidl = pidlTemp.Detach();
             if (pdwAttributes && *pdwAttributes)
                 GetAttributesOf(1, (PCUITEMID_CHILD_ARRAY)ppidl, pdwAttributes);
+            hr = S_OK;
         }
     }
 

--- a/dll/win32/shell32/folders/CDrivesFolder.cpp
+++ b/dll/win32/shell32/folders/CDrivesFolder.cpp
@@ -684,7 +684,7 @@ HRESULT WINAPI CDrivesFolder::ParseDisplayName(HWND hwndOwner, LPBC pbc, LPOLEST
         lpszDisplayName[1] == L':' && lpszDisplayName[2] == L'\\')
     {
         // "C:\..."
-        WCHAR szRoot[MAX_PATH];
+        WCHAR szRoot[8];
         PathBuildRootW(szRoot, ((*lpszDisplayName - 1) & 0x1F));
 
         if (SHIsFileSysBindCtx(pbc, NULL) != S_OK && !(BindCtx_GetMode(pbc, 0) & STGM_CREATE))

--- a/dll/win32/shell32/folders/CDrivesFolder.cpp
+++ b/dll/win32/shell32/folders/CDrivesFolder.cpp
@@ -684,12 +684,8 @@ HRESULT WINAPI CDrivesFolder::ParseDisplayName(HWND hwndOwner, LPBC pbc, LPOLEST
         lpszDisplayName[1] == L':' && lpszDisplayName[2] == L'\\')
     {
         // "C:\..."
-        INT iDrive = ((*lpszDisplayName - 1) & 0x1F);
-        if (iDrive == -1)
-            return E_INVALIDARG;
-
         WCHAR szRoot[MAX_PATH];
-        PathBuildRootW(szRoot, iDrive);
+        PathBuildRootW(szRoot, ((*lpszDisplayName - 1) & 0x1F));
 
         if (SHIsFileSysBindCtx(pbc, NULL) != S_OK && !(BindCtx_GetMode(pbc, 0) & STGM_CREATE))
         {

--- a/dll/win32/shell32/folders/CDrivesFolder.cpp
+++ b/dll/win32/shell32/folders/CDrivesFolder.cpp
@@ -657,19 +657,26 @@ HRESULT WINAPI CDrivesFolder::FinalConstruct()
 HRESULT WINAPI CDrivesFolder::ParseDisplayName(HWND hwndOwner, LPBC pbc, LPOLESTR lpszDisplayName,
         DWORD * pchEaten, PIDLIST_RELATIVE * ppidl, DWORD * pdwAttributes)
 {
+    HRESULT hr = E_INVALIDARG;
+
     TRACE("(%p)->(HWND=%p,%p,%p=%s,%p,pidl=%p,%p)\n", this,
           hwndOwner, pbc, lpszDisplayName, debugstr_w (lpszDisplayName),
           pchEaten, ppidl, pdwAttributes);
 
     if (!ppidl)
-        return E_INVALIDARG;
+        return hr;
 
     *ppidl = NULL;
 
     if (!lpszDisplayName)
-        return E_INVALIDARG;
+        return hr;
 
-    HRESULT hr = E_INVALIDARG;
+    /* handle CLSID paths */
+    if (lpszDisplayName[0] == L':' && lpszDisplayName[1] == L':')
+    {
+        return m_regFolder->ParseDisplayName(hwndOwner, pbc, lpszDisplayName, pchEaten, ppidl,
+                                             pdwAttributes);
+    }
 
     if (lpszDisplayName[0] &&
         ((L'A' <= lpszDisplayName[0] && lpszDisplayName[0] <= L'Z') ||


### PR DESCRIPTION
## Purpose

Follow-up to #6746. Reduce `SHParseDisplayName` failures.
JIRA issue: [CORE-19495](https://jira.reactos.org/browse/CORE-19495)

## Proposed changes

- Re-implement `CDrivesFolder::ParseDisplayName` method.

## TODO

- [ ] Do big tests.

## Comparison

BEFORE:
![before](https://github.com/reactos/reactos/assets/2107452/afe489c8-e5b3-42be-9515-485ceb796024)
17 failures.

AFTER:
![after](https://github.com/reactos/reactos/assets/2107452/237bc044-df9d-4f8c-b03b-77995d2e2637)
14 failures. This PR reduced 3 failures.