### PR TITLE
[EVTLIB] Fix size of event log record

### DIFF
--- a/sdk/lib/evtlib/evtlib.c
+++ b/sdk/lib/evtlib/evtlib.c
@@ -1205,7 +1205,7 @@ ElfReadRecord(
     NTSTATUS Status;
     LARGE_INTEGER FileOffset;
     ULONG RecOffset;
-    SIZE_T RecSize;
+    ULONG RecSize;
     SIZE_T ReadLength;
 
     ASSERT(LogFile);


### PR DESCRIPTION
The size is 32bit, don't read a SIZE_T. Fixes crashes of advapi32_winetest eventlog on x64.

## Tests

✅ KVM x86: https://reactos.org/testman/compare.php?ids=94840,94846,94851,94858
✅ KVM x64: https://reactos.org/testman/compare.php?ids=94842,94843,94853,94864

