### PR TITLE
[BROWSEUI] SHExplorerParseCmdLine: Fix parsing of /root

### DIFF
--- a/dll/win32/browseui/parsecmdline.cpp
+++ b/dll/win32/browseui/parsecmdline.cpp
@@ -252,9 +252,8 @@ SHExplorerParseCmdLine(_Out_ PEXPLORER_CMDLINE_PARSE_RESULTS pInfo)
 
     PCWSTR strNextArg = _FindFirstField(strFieldArray);
 
-    BOOL hasNext = TRUE;
+    BOOL hasNext = _ReadNextArg(&strNextArg, strField, _countof(strField));
 
-    hasNext = _ReadNextArg(&strNextArg, strField, _countof(strField));
     while (TRUE)
     {
         // Basic flags-only params first
@@ -318,9 +317,6 @@ SHExplorerParseCmdLine(_Out_ PEXPLORER_CMDLINE_PARSE_RESULTS pInfo)
             // The window should be rooted
 
             TRACE("CmdLine Parser: Found %S flag\n", strField);
-
-            if (!pInfo->pidlPath)
-                return FALSE;
 
             if (!hasNext)
                 return FALSE;
@@ -414,7 +410,6 @@ SHExplorerParseCmdLine(_Out_ PEXPLORER_CMDLINE_PARSE_RESULTS pInfo)
                         TRACE("CmdLine Parser: Parsed target path. dwFlags=%08lx, strPath=%S\n", pInfo->dwFlags, field);
                     }
                 }
-
             }
         }
 


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-16939](https://jira.reactos.org/browse/CORE-16939)

## Proposed changes

- Remove excessive `(!pInfo->pidlPath)` check in `SHExplorerParseCmdLine` function.

## Comparison

BEFORE:
![before-1](https://github.com/reactos/reactos/assets/2107452/9bc84a89-d728-43ce-bcf1-c6d6c93604f4)
Cannot open the special folder.

AFTER:
![after-1](https://github.com/reactos/reactos/assets/2107452/0dcc38b0-c574-487d-b15b-af5a5b884482)
Able to open the special folder.

BEFORE:
![before-2](https://github.com/reactos/reactos/assets/2107452/74a0c105-7339-4d27-99c5-3a217efb25f4)
63 failures.

AFTER:
![after-2](https://github.com/reactos/reactos/assets/2107452/a8c11c65-f02b-48a4-9dba-891695e803dc)
61 failures. This PR reduced 2 failures.