### PR TITLE
[FREELDR] Merge boot-drive and partition functionalities together

### DIFF
--- a/boot/freeldr/FREELDR.INI
+++ b/boot/freeldr/FREELDR.INI
@@ -64,36 +64,24 @@
 ; DarkGray, LightBlue, LightGreen, LightCyan, LightRed, LightMagenta,
 ; Yellow, White, Default.
 ;
-; Default color is the one that is being used by BIOS firmware by default.
+; Default color is the one that is being used by the firmware by default.
 ; On PC/AT-compatible machines it's Gray, and on NEC PC-98 series it's White.
 
 ; [OS-General] Section Commands:
 ;
-; BootType  - Specifies the boot type: Windows, WindowsNT40, Windows2003,
-;             ReactOSSetup, Linux, BootSector, Partition, Drive
+; BootType  - Specifies the boot type: BootSector, Linux,
+;             Windows, WindowsNT40, Windows2003, ReactOSSetup.
+;
 ; BootPath  - ARC path, e.g. multi(0)disk(0)rdisk(x)partition(y)
-; DriveMap  - Maps a BIOS drive number to another (i.e. DriveMap=hd1,hd0
-;             maps harddisk1 to harddisk0; or DriveMap=fd1,fd0).
-
-; ["Drive" OSType] Section Commands:
 ;
-; BootDrive - BIOS drive number to be used.
-;
-; REMARK: If a "BootPath" ARC path is specified, its value takes precedence
-; over the "BootDrive" value.
-
-; ["Partition" OSType] Section Commands:
-;
-; BootDrive     - BIOS drive number to be used.
-; BootPartition - Partition number to be used (default: 0).
-;
-; REMARK: If a "BootPath" ARC path is specified, its value takes precedence
-; over both the "BootDrive" and "BootPartition" values.
+; DriveMap  - For BIOS-based PCs, maps a BIOS drive number to another
+;             (i.e. DriveMap=hd1,hd0 maps hard-disk 1 to hard-disk 0;
+;             or DriveMap=fd1,fd0 for mapping floppy disks).
 
 ; ["BootSector" OSType] Section Commands:
 ;
 ; BootDrive      - BIOS drive number to be used.
-; BootPartition  - Partition number to be used (cannot be 0).
+; BootPartition  - Partition number to be used (optional).
 ;
 ; REMARK: If a "BootPath" ARC path is specified, its value takes precedence
 ; over both the "BootDrive" and "BootPartition" values.
@@ -102,7 +90,11 @@
 ; If none of them are given and a relative file path is specified by the
 ; "BootSectorFile" value, the default boot partition will be used instead.
 ;
-; BootSectorFile - File name of the bootsector to be loaded.
+; When a non-zero partition is specified (either via "BootPartition" or
+; via the "BootPath" ARC path), the drive is accessed in partitioned mode,
+; and the "BootSectorFile" option is checked for its presence.
+;
+; BootSectorFile - File name of the boot sector to be loaded.
 ;                  It can be either relative to "BootDrive" and "BootPartition"
 ;                  (or to "BootPath"), or be an absolute ARC path, in which case
 ;                  the "BootDrive" and "BootPartition" (or "BootPath") values
@@ -195,6 +187,7 @@ SpecialEffects=Yes
 
 [Operating Systems]
 ReactOSHD="ReactOS (HardDrive)"
+;ReactOS_Debug="ReactOS (Debug)"
 ReactOSFloppy="ReactOS (Floppy)"
 Linux="Debian Linux"
 Floppy="3 1/2 Floppy (A:)"
@@ -209,6 +202,13 @@ Options=/DEBUGPORT=SCREEN
 Kernel=\REACTOS\SYSTEM32\NTOSKRNL.EXE
 Hal=\REACTOS\SYSTEM32\HAL.DLL
 
+;[ReactOS_Debug]
+;BootType=Windows2003
+;SystemPath=multi(0)disk(0)rdisk(0)partition(1)\reactos
+;Options=/DEBUG /DEBUGPORT=COM1 /BAUDRATE=19200
+;Kernel=\NTOSKRNL.EXE
+;Hal=\HAL.DLL
+
 ; Load ReactOS from floppy (drive A:)
 [ReactOSFloppy]
 BootType=Windows2003
@@ -216,13 +216,6 @@ SystemPath=multi(0)disk(0)fdisk(0)
 Options=/DEBUGPORT=SCREEN
 Kernel=\reactos\NTOSKRNL.EXE
 Hal=\reactos\HAL.DLL
-
-;[ReactOS (Debug)]
-;BootType=Windows2003
-;SystemPath=multi(0)disk(0)rdisk(0)partition(1)\reactos
-;Options=/DEBUG /DEBUGPORT=COM1 /BAUDRATE=19200
-;Kernel=\NTOSKRNL.EXE
-;Hal=\HAL.DLL
 
 [Linux]
 BootType=Linux
@@ -232,16 +225,16 @@ Initrd=/initrd.img
 CommandLine="root=/dev/sdb1"
 
 [Floppy]
-BootType=Drive
+BootType=BootSector
 BootDrive=fd0
 
 [MSWinders]
-BootType=Partition
+BootType=BootSector
 BootPath=multi(0)disk(0)rdisk(0)partition(1)
 ;DriveMap=hd1,hd0
 ;DriveMap=hd2,hd0
 ;DriveMap=hd3,hd0
 
 [DriveD]
-BootType=Partition
+BootType=BootSector
 BootPath=multi(0)disk(0)rdisk(1)partition(1)

--- a/boot/freeldr/freeldr/include/custom.h
+++ b/boot/freeldr/freeldr/include/custom.h
@@ -30,16 +30,8 @@ VOID OptionMenuCustomBoot(VOID);
 #if defined(_M_IX86) || defined(_M_AMD64)
 
 VOID
-EditCustomBootDisk(
-    IN OUT OperatingSystemItem* OperatingSystem);
-
-VOID
-EditCustomBootPartition(
-    IN OUT OperatingSystemItem* OperatingSystem);
-
-VOID
-EditCustomBootSectorFile(
-    IN OUT OperatingSystemItem* OperatingSystem);
+EditCustomBootSector(
+    _Inout_ OperatingSystemItem* OperatingSystem);
 
 VOID
 EditCustomBootLinux(

--- a/boot/freeldr/freeldr/include/freeldr.h
+++ b/boot/freeldr/freeldr/include/freeldr.h
@@ -20,6 +20,10 @@
 #ifndef __FREELDR_H
 #define __FREELDR_H
 
+/* Enabled for supporting the deprecated boot options
+ * that will be removed in a future FreeLdr version */
+#define HAS_DEPRECATED_OPTIONS
+
 #define UINT64_C(val) val##ULL
 #define RVA(m, b) ((PVOID)((ULONG_PTR)(b) + (ULONG_PTR)(m)))
 
@@ -125,6 +129,13 @@
 #endif
 
 VOID __cdecl BootMain(IN PCCH CmdLine);
+
+#ifdef HAS_DEPRECATED_OPTIONS
+VOID
+WarnDeprecated(
+    _In_ PCSTR MsgFmt,
+    ...);
+#endif
 
 VOID
 LoadOperatingSystem(

--- a/boot/freeldr/freeldr/include/miscboot.h
+++ b/boot/freeldr/freeldr/include/miscboot.h
@@ -22,9 +22,9 @@
 #if defined(_M_IX86) || defined(_M_AMD64)
 
 ARC_STATUS
-LoadAndBootDevice(
-    IN ULONG Argc,
-    IN PCHAR Argv[],
-    IN PCHAR Envp[]);
+LoadAndBootSector(
+    _In_ ULONG Argc,
+    _In_ PCHAR Argv[],
+    _In_ PCHAR Envp[]);
 
 #endif /* _M_IX86 || _M_AMD64 */

--- a/boot/freeldr/freeldr/include/ver.h
+++ b/boot/freeldr/freeldr/include/ver.h
@@ -20,7 +20,7 @@
 #pragma once
 
 /* Just some stuff */
-#define VERSION         "FreeLoader v3.0"
+#define VERSION         "FreeLoader v3.2"
 #define COPYRIGHT       "Copyright (C) 1996-" COPYRIGHT_YEAR " ReactOS Project"
 #define AUTHOR_EMAIL    "<www.reactos.org>"
 #define BY_AUTHOR       "by ReactOS Project"
@@ -33,7 +33,7 @@
 // If you add major functionality then you increment the major version and zero the minor & patch versions
 //
 #define FREELOADER_MAJOR_VERSION    3
-#define FREELOADER_MINOR_VERSION    0
+#define FREELOADER_MINOR_VERSION    2
 #define FREELOADER_PATCH_VERSION    0
 
 extern const PCSTR FrLdrVersionString;


### PR DESCRIPTION
## Purpose

Merge boot-drive and partition functionalities together.
And deprecate corresponding boot types "Drive" and "Partition". These are replaced by the more general "BootSector" boot type.

Finish the unification of the code, started in commit ff85aa0c3, that loads and boots disk MBR, partition VBR or boot sector in file.

A "WarnDeprecated()" helper is added to warn the user about the deprecated features, and to inform them to adjust their FREELDR.INI file in accordance.

_**NOTE: Another functionality: the separate "BootDrive" and "BootPartition" values, will be deprecated as well in a subsequent PR. They will be replaced by the (already existing) "BootPath" value, which will be made aware of the syntax used in the old values, for example: `hd0,1`**_