### PR TITLE
[VFDLIB] Disable PDB generation for VFD.dll

### DIFF
--- a/modules/rosapps/lib/vfdlib/CMakeLists.txt
+++ b/modules/rosapps/lib/vfdlib/CMakeLists.txt
@@ -32,6 +32,12 @@ include_directories(${REACTOS_SOURCE_DIR}/modules/rosapps/include/vfd
 set_module_type(vfd win32dll ENTRYPOINT DllMain 12)
 target_link_libraries(vfd zlib_solo uuid cppstl)
 set_target_cpp_properties(vfd WITH_EXCEPTIONS)
+
+# Okay - After a long investigation this modules PDBs are just absolutely fighting github actions
+if(MSVC)
+    target_link_options(vfd PRIVATE "/DEBUG:NONE")
+endif()
+
 add_importlibs(vfd advapi32 user32 gdi32 shell32 comdlg32 comctl32 ole32 version psapi msvcrt kernel32 ntdll)
 add_dependencies(vfd vfdmsg_lib)
 add_cd_file(TARGET vfd DESTINATION reactos/system32 FOR all)


### PR DESCRIPTION
# Purpose

To workaround github actions.

After a back and fourth investigation I've just decided to disable pdb generation for this ROSAPP for now.
We tried taking the code apart a bit and only building parts but alas it didnt yield any sucess.

disabling the AV also didn't help.

For documentation purposes:
https://chat.reactos.org/reactos/pl/akm3mj9yhbdtdgiie3onpn9uzh