### PR TITLE
[SDK] Don't just infinitely spam the DbgPrint in the bootloader

### DIFF
--- a/sdk/lib/cmlib/cmlib.h
+++ b/sdk/lib/cmlib/cmlib.h
@@ -380,7 +380,8 @@ extern ULONG CmlibTraceLevel;
 // Hack since big keys are not yet supported
 //
 #ifdef _BLDR_ 
-#define ASSERT_VALUE_BIG(h, s) DbgPrint("Big keys aren't supported!\n");
+#define ASSERT_VALUE_BIG(h, s) \
+    do { if (CmpIsKeyValueBig(h,s)) DbgPrint("Big keys aren't supported!\n"); } while (0)
 #else 
 #define ASSERT_VALUE_BIG(h, s)  \
     ASSERTMSG("Big keys not supported!\n", !CmpIsKeyValueBig(h, s));


### PR DESCRIPTION
# Purpose 
I should have booted this before i merged the DbgPrint change oops.