### PR TITLE
[ZIPFLDR] Don't handle DFM_INVOKECOMMANDEX if you need DFM_INVOKECOMMAND

### DIFF
--- a/dll/shellext/zipfldr/CZipFolder.hpp
+++ b/dll/shellext/zipfldr/CZipFolder.hpp
@@ -380,7 +380,6 @@ public:
             ici.lpVerb = MAKEINTRESOURCEA(wParam);
             return spContextMenu->InvokeCommand(&ici);
         }
-        case DFM_INVOKECOMMANDEX:
         case DFM_GETDEFSTATICID: // Required for Windows 7 to pick a default
             return S_FALSE;
         }


### PR DESCRIPTION
ZipFldr responds incorrectly to DFM_INVOKECOMMANDEX. This was not a problem until [now](https://github.com/reactos/reactos/pull/6765) because CDefaultContextMenu does not send it.

There are 4 possible ways to respond to DFM_INVOKECOMMANDEX:
- S_OK: I completed the command. CDefaultContextMenu does nothing because it has already been handled.
- S_FALSE: I cannot perform this command but I want CDefaultContextMenu to perform the action for me (cut/copy/delete/properties).
- E_NOTIMPL: I don't need nor know about DFM_INVOKECOMMANDEX. CDefaultContextMenu will send DFM_INVOKECOMMAND.
- E_*: I tried to complete the command but something failed. CDefaultContextMenu should pass this error back to the caller of IContextMenu::InvokeCommand.

If you only handle your commands in DFM_INVOKECOMMAND then E_NOTIMPL is the only correct return value for the EX message.

There are a couple of places in the source code where S_FALSE is returned and that is OK because it does not handle DFM_INVOKECOMMAND either. I suspect this code was just copied around without full understanding of what is going on.