### PR TITLE
[SHELL32][VFDLIB] Handle size check of CMINVOKECOMMANDINFOEX correctly

### DIFF
--- a/dll/win32/shell32/CShellLink.cpp
+++ b/dll/win32/shell32/CShellLink.cpp
@@ -2595,9 +2595,10 @@ HRESULT CShellLink::DoOpen(LPCMINVOKECOMMANDINFO lpici)
     HRESULT hr;
     LPWSTR args = NULL;
     LPWSTR path = strdupW(m_sPath);
+    BOOL unicode = lpici->cbSize >= FIELD_OFFSET(CMINVOKECOMMANDINFOEX, ptInvoke) &&
+                   (lpici->fMask & CMIC_MASK_UNICODE);
 
-    if ( lpici->cbSize == sizeof(CMINVOKECOMMANDINFOEX) &&
-        (lpici->fMask & CMIC_MASK_UNICODE) )
+    if (unicode)
     {
         LPCMINVOKECOMMANDINFOEX iciex = (LPCMINVOKECOMMANDINFOEX)lpici;
         SIZE_T len = 2;

--- a/modules/rosapps/lib/vfdlib/vfdshmenu.cpp
+++ b/modules/rosapps/lib/vfdlib/vfdshmenu.cpp
@@ -339,12 +339,16 @@ STDMETHODIMP CVfdShExt::InvokeCommand(
 	DWORD	ret;
 	CMINVOKECOMMANDINFOEX *excmi = (CMINVOKECOMMANDINFOEX *)lpcmi;
 
+#ifdef __REACTOS__
+	unicode = lpcmi->cbSize >= FIELD_OFFSET(CMINVOKECOMMANDINFOEX, ptInvoke) &&
+	          (lpcmi->fMask & CMIC_MASK_UNICODE);
+#else
 	if (lpcmi->cbSize >= sizeof(CMINVOKECOMMANDINFOEX) &&
 		(lpcmi->fMask & CMIC_MASK_UNICODE)) {
 
 		unicode = TRUE;
 	}
-
+#endif
 
 	if (!unicode && HIWORD(lpcmi->lpVerb)) {
 


### PR DESCRIPTION
Older NT versions had a smaller CMINVOKECOMMANDINFOEX struct. Places where 3rd-party code passes in the struct needs to accept the small size.