### PR TITLE
[SHELL32] Remove 2 redundant initializations

### DIFF
--- a/dll/win32/shell32/CDefaultContextMenu.cpp
+++ b/dll/win32/shell32/CDefaultContextMenu.cpp
@@ -501,7 +501,6 @@ CDefaultContextMenu::AddStaticContextMenusToMenu(
 
     mii.fMask = MIIM_ID | MIIM_TYPE | MIIM_STATE | MIIM_DATA;
     mii.fType = MFT_STRING;
-    mii.dwTypeData = NULL;
 
     POSITION it = m_StaticEntries.GetHeadPosition();
     bool first = true;
@@ -511,7 +510,6 @@ CDefaultContextMenu::AddStaticContextMenusToMenu(
         BOOL forceFirstPos = FALSE;
 
         fState = MFS_ENABLED;
-        mii.dwTypeData = NULL;
 
         /* set first entry as default */
         if (first)


### PR DESCRIPTION
## Purpose

Code cleanup.
New init obsoletes old one(s).

Addendum to 6146fd0 (r54688) and 99b2e3d (r54979).

## Proposed changes

- Remove 2 redundant initializations
