### PR TITLE
[CRT] DEFINED_localeinfo_struct: Remove its value

### DIFF
--- a/sdk/include/crt/crtdefs.h
+++ b/sdk/include/crt/crtdefs.h
@@ -443,7 +443,7 @@ typedef struct localeinfo_struct {
     pthreadlocinfo locinfo;
     pthreadmbcinfo mbcinfo;
 }_locale_tstruct,*_locale_t;
-#define DEFINED_localeinfo_struct 1
+#define DEFINED_localeinfo_struct
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
## Purpose

Code cleanup.
Do not add superfluous/misleading value.

Addendum to 95bf896 (0.4.15-dev-7907).

## Proposed changes

- Remove its value
