### PR TITLE
[SDK] ReleaseCComPtrExpectZero should print the relevant file:line

### DIFF
--- a/sdk/include/reactos/shellutils.h
+++ b/sdk/include/reactos/shellutils.h
@@ -242,10 +242,10 @@ ULONG ReleaseCComPtrExpectZeroHelper(CComPtr<T>& cptr, BOOL forceRelease = FALSE
     return r;
 }
 #define ReleaseCComPtrExpectZero(...) \
-    if (ULONG r = ReleaseCComPtrExpectZeroHelper(__VA_ARGS__)) \
-        DbgPrint("WARNING: Unexpected RefCount > 0 (%d)!\n", r); \
-    else \
-        (void)0
+    do { \
+        if (ULONG r = ReleaseCComPtrExpectZeroHelper(__VA_ARGS__)) \
+            DbgPrint("WARNING: Unexpected RefCount > 0 (%d)!\n", r); \
+    } while (0)
 
 template<class T, class R>
 HRESULT inline ShellDebugObjectCreator(REFIID riid, R ** ppv)


### PR DESCRIPTION
ReleaseCComPtrExpectZero currently always prints the same line from shellutils.h in the warning which is not very useful. A macro is required for __FILE__ to be correct.