### PR TITLE
[WS2_32] Implement inet_pton and inet_ntop

### DIFF
--- a/dll/3rdparty/libtirpc/src/rpc_generic.c
+++ b/dll/3rdparty/libtirpc/src/rpc_generic.c
@@ -641,7 +641,7 @@ void freenetbuf(struct netbuf *nbuf)
 #ifdef __REACTOS__
 PCSTR
 WSAAPI
-inet_ntop(INT af, PVOID src, PSTR dst, size_t cnt)
+inet_ntop(INT af, const VOID *src, PSTR dst, size_t cnt)
 {
 	struct in_addr in;
 	char *text_addr;

--- a/dll/win32/winhttp/inet_ntop.c
+++ b/dll/win32/winhttp/inet_ntop.c
@@ -54,7 +54,7 @@ static const char *inet_ntop6(const u_char *src, char *dst, size_t size);
 
 PCSTR
 WSAAPI
-inet_ntop(INT Family, PVOID pAddr, PSTR pStringBuf, size_t StringBufSize)
+inet_ntop(INT Family, const VOID *pAddr, PSTR pStringBuf, size_t StringBufSize)
 {
 
 	switch (Family) {

--- a/dll/win32/wininet/inet_ntop.c
+++ b/dll/win32/wininet/inet_ntop.c
@@ -53,7 +53,7 @@ PCSTR
 WSAAPI
 inet_ntop(
   _In_ INT af,
-  _In_ PVOID src,
+  _In_ const VOID *src,
   _Out_writes_(StringBufSize) PSTR dst,
   _In_ size_t size)
 {

--- a/dll/win32/ws2_32/src/addrconv.c
+++ b/dll/win32/ws2_32/src/addrconv.c
@@ -492,3 +492,143 @@ WSANtohs(IN SOCKET s,
     return SOCKET_ERROR;
 }
 
+PCSTR
+WSAAPI
+inet_ntop(
+    _In_ INT Family,
+    _In_ const VOID *pAddr,
+    _Out_writes_(StringBufSize) PSTR pStringBuf,
+    _In_ size_t StringBufSize)
+{
+    NTSTATUS Status;
+    ULONG BufSize = StringBufSize;
+
+    switch (Family)
+    {
+        case AF_INET:
+            Status = RtlIpv4AddressToStringExA(pAddr, 0, pStringBuf, &BufSize);
+            break;
+        case AF_INET6:
+            Status = RtlIpv6AddressToStringExA(pAddr, 0, 0, pStringBuf, &BufSize);
+            break;
+        default:
+            SetLastError(WSAEAFNOSUPPORT);
+            return NULL;
+    }
+
+    if (!NT_SUCCESS(Status)) 
+    {
+        SetLastError(WSAEINVAL);
+        return NULL;
+    }
+
+    return pStringBuf;
+}
+
+PCWSTR
+WSAAPI
+InetNtopW(
+    _In_ INT Family,
+    _In_ const VOID *pAddr,
+    _Out_writes_(StringBufSize) PWSTR pStringBuf,
+    _In_ size_t StringBufSize)
+{
+    NTSTATUS Status;
+    ULONG BufSize = StringBufSize;
+
+    switch (Family)
+    {
+        case AF_INET:
+            Status = RtlIpv4AddressToStringExW(pAddr, 0, pStringBuf, &BufSize);
+            break;
+        case AF_INET6:
+            Status = RtlIpv6AddressToStringExW(pAddr, 0, 0, pStringBuf, &BufSize);
+            break;
+        default:
+            SetLastError(WSAEAFNOSUPPORT);
+            return NULL;
+    }
+
+    if (!NT_SUCCESS(Status)) 
+    {
+        SetLastError(WSAEINVAL);
+        return NULL;
+    }
+
+    return pStringBuf;
+}
+
+INT
+WSAAPI
+inet_pton(
+    _In_ INT Family,
+    _In_ PCSTR pszAddrString,
+    _Out_writes_bytes_(sizeof(IN_ADDR6)) PVOID pAddrBuf)
+{
+    NTSTATUS Status;
+    PCSTR ch;
+
+    if (!pszAddrString || !pAddrBuf)
+    {
+        SetLastError(WSAEFAULT);
+        return -1;
+    }
+
+    switch (Family)
+    {
+        case AF_INET:
+            Status = RtlIpv4StringToAddressA(pszAddrString, TRUE, &ch, pAddrBuf);
+            break;
+        case AF_INET6:
+            Status = RtlIpv6StringToAddressA(pszAddrString, &ch, pAddrBuf);
+            break;
+        default:
+            SetLastError(WSAEAFNOSUPPORT);
+            return -1;
+    }
+
+    if (!NT_SUCCESS(Status) || (*ch != 0)) 
+    {
+        return 0;
+    }
+
+    return 1;
+}
+
+INT
+WSAAPI
+InetPtonW(
+    _In_ INT Family,
+    _In_ PCWSTR pszAddrString,
+    _Out_writes_bytes_(sizeof(IN_ADDR6)) PVOID pAddrBuf)
+{
+    NTSTATUS Status;
+    PCWSTR ch;
+
+    if (!pszAddrString || !pAddrBuf)
+    {
+        SetLastError(WSAEFAULT);
+        return -1;
+    }
+
+    switch (Family)
+    {
+        case AF_INET:
+            Status = RtlIpv4StringToAddressW(pszAddrString, TRUE, &ch, pAddrBuf);
+            break;
+        case AF_INET6:
+            Status = RtlIpv6StringToAddressW(pszAddrString, &ch, pAddrBuf);
+            break;
+        default:
+            SetLastError(WSAEAFNOSUPPORT);
+            return -1;
+    }
+
+    if (!NT_SUCCESS(Status) || (*ch != 0)) 
+    {
+        SetLastError(WSAEINVAL); /* Only unicode version sets this error */
+        return 0;
+    }
+
+    return 1;
+}

--- a/dll/win32/ws2_32/ws2_32.spec
+++ b/dll/win32/ws2_32/ws2_32.spec
@@ -115,3 +115,7 @@
 23  stdcall  socket(long long long)
 @ stdcall GetAddrInfoW(wstr wstr ptr ptr)
 @ stdcall GetNameInfoW(ptr long wstr long wstr long long)
+@ stdcall -version=0x600+ inet_ntop(long ptr ptr long)
+@ stdcall -version=0x600+ InetNtopW(long ptr ptr long)
+@ stdcall -version=0x600+ inet_pton(long str ptr)
+@ stdcall -version=0x600+ InetPtonW(long wstr ptr)

--- a/sdk/include/psdk/ws2tcpip.h
+++ b/sdk/include/psdk/ws2tcpip.h
@@ -451,7 +451,7 @@ PCSTR
 WSAAPI
 inet_ntop(
   _In_ INT Family,
-  _In_ PVOID pAddr,
+  _In_ const VOID *pAddr,
   _Out_writes_(StringBufSize) PSTR pStringBuf,
   _In_ size_t StringBufSize);
 
@@ -459,7 +459,7 @@ PCWSTR
 WSAAPI
 InetNtopW(
   _In_ INT Family,
-  _In_ PVOID pAddr,
+  _In_ const VOID *pAddr,
   _Out_writes_(StringBufSize) PWSTR pStringBuf,
   _In_ size_t StringBufSize);
 


### PR DESCRIPTION
## Purpose

Add implementations of the functions inet_pton and inet_ntop

## Proposed changes

Add implementations for the functions and their Unicode counterparts
Sync the wine tests for these functions.
Import WINE's implementation for RtlIpv6StringToAddress* (used by inet_pton) as the current implementation fails in tests

These are common functions and should be used instead of attempting to reimplement IP<->String conversions.
