### PR TITLE
[BROWSEUI] GetControlWindow must support FCW_TREE for DefView usage

### DIFF
--- a/dll/win32/browseui/shellbrowser.cpp
+++ b/dll/win32/browseui/shellbrowser.cpp
@@ -2261,7 +2261,6 @@ HRESULT STDMETHODCALLTYPE CShellBrowser::GetControlWindow(UINT id, HWND *lphwnd)
     if (lphwnd == NULL)
         return E_POINTER;
     *lphwnd = NULL;
-    BOOL shown;
     switch (id)
     {
         case FCW_TOOLBAR:
@@ -2271,9 +2270,12 @@ HRESULT STDMETHODCALLTYPE CShellBrowser::GetControlWindow(UINT id, HWND *lphwnd)
             *lphwnd = fStatusBar;
             return S_OK;
         case FCW_TREE:
+        {
+            BOOL shown;
             if (SUCCEEDED(IsControlWindowShown(id, &shown)) && shown)
                 return IUnknown_GetWindow(fClientBars[BIVerticalBaseBar].clientBar.p, lphwnd);
             return S_FALSE;
+        }
         case FCW_PROGRESS:
             // is this a progress dialog?
             return S_OK;
@@ -2478,7 +2480,6 @@ HRESULT STDMETHODCALLTYPE CShellBrowser::ShowControlWindow(UINT id, BOOL fShow)
 
 HRESULT STDMETHODCALLTYPE CShellBrowser::IsControlWindowShown(UINT id, BOOL *pfShown)
 {
-    OLECMD cmd = {};
     HRESULT hr = S_OK;
     BOOL shown = FALSE;
     switch (id)
@@ -2487,10 +2488,12 @@ HRESULT STDMETHODCALLTYPE CShellBrowser::IsControlWindowShown(UINT id, BOOL *pfS
             shown = m_settings.fStatusBarVisible;
             break;
         case FCW_TREE:
-            cmd.cmdID = SBCMDID_EXPLORERBARFOLDERS;
+        {
+            OLECMD cmd = { SBCMDID_EXPLORERBARFOLDERS };
             hr = QueryStatus(&CGID_Explorer, 1, &cmd, NULL);
             shown = cmd.cmdf & OLECMDF_LATCHED;
             break;
+        }
         default:
             hr = E_NOTIMPL;
     }
@@ -2499,7 +2502,7 @@ HRESULT STDMETHODCALLTYPE CShellBrowser::IsControlWindowShown(UINT id, BOOL *pfS
         *pfShown = shown;
         return hr;
     }
-    return SUCCEEDED(hr) ? shown ? S_OK : S_FALSE : hr;
+    return SUCCEEDED(hr) ? (shown ? S_OK : S_FALSE) : hr;
 }
 
 HRESULT STDMETHODCALLTYPE CShellBrowser::IEGetDisplayName(LPCITEMIDLIST pidl, LPWSTR pwszName, UINT uFlags)

--- a/dll/win32/browseui/shellbrowser.cpp
+++ b/dll/win32/browseui/shellbrowser.cpp
@@ -1970,7 +1970,7 @@ HRESULT STDMETHODCALLTYPE CShellBrowser::QueryStatus(const GUID *pguidCmdGroup,
                     if (IsEqualCLSID(CLSID_SH_FavBand, fCurrentVertBar))
                         prgCmds->cmdf |= OLECMDF_LATCHED;
                     break;
-                case 0x23:  // folders
+                case SBCMDID_EXPLORERBARFOLDERS:  // folders
                     prgCmds->cmdf = OLECMDF_SUPPORTED | OLECMDF_ENABLED;
                     if (IsEqualCLSID(CLSID_ExplorerBand, fCurrentVertBar))
                         prgCmds->cmdf |= OLECMDF_LATCHED;
@@ -2019,7 +2019,7 @@ HRESULT STDMETHODCALLTYPE CShellBrowser::Exec(const GUID *pguidCmdGroup, DWORD n
             case 0x1c: //Toggle Search
             case 0x1d: //Toggle History
             case 0x1e: //Toggle Favorites
-            case 0x23: //Toggle Folders
+            case SBCMDID_EXPLORERBARFOLDERS: //Toggle Folders
                 const GUID* pclsid;
                 if (nCmdID == 0x1c) pclsid = &CLSID_FileSearchBand;
                 else if (nCmdID == 0x1d) pclsid = &CLSID_SH_HistBand;
@@ -2261,6 +2261,7 @@ HRESULT STDMETHODCALLTYPE CShellBrowser::GetControlWindow(UINT id, HWND *lphwnd)
     if (lphwnd == NULL)
         return E_POINTER;
     *lphwnd = NULL;
+    BOOL shown;
     switch (id)
     {
         case FCW_TOOLBAR:
@@ -2270,9 +2271,9 @@ HRESULT STDMETHODCALLTYPE CShellBrowser::GetControlWindow(UINT id, HWND *lphwnd)
             *lphwnd = fStatusBar;
             return S_OK;
         case FCW_TREE:
-            // find the directory browser and return it
-            // this should be used only to determine if a tree is present
-            return S_OK;
+            if (SUCCEEDED(IsControlWindowShown(id, &shown)) && shown)
+                return IUnknown_GetWindow(fClientBars[BIVerticalBaseBar].clientBar.p, lphwnd);
+            return S_FALSE;
         case FCW_PROGRESS:
             // is this a progress dialog?
             return S_OK;
@@ -2459,12 +2460,46 @@ HRESULT STDMETHODCALLTYPE CShellBrowser::GetTravelLog(ITravelLog **pptl)
 
 HRESULT STDMETHODCALLTYPE CShellBrowser::ShowControlWindow(UINT id, BOOL fShow)
 {
+    BOOL shown;
+    if (FAILED(IsControlWindowShown(id, &shown)))
+        return E_NOTIMPL;
+    else if (!shown == !fShow) // Negated for true boolean comparison
+        return S_OK;
+    else switch (id)
+    {
+        case FCW_STATUS:
+            OnToggleStatusBarVisible(0, 0, NULL, shown);
+            return S_OK;
+        case FCW_TREE:
+            return Exec(&CGID_Explorer, SBCMDID_EXPLORERBARFOLDERS, 0, NULL, NULL);
+    }
     return E_NOTIMPL;
 }
 
 HRESULT STDMETHODCALLTYPE CShellBrowser::IsControlWindowShown(UINT id, BOOL *pfShown)
 {
-    return E_NOTIMPL;
+    OLECMD cmd = {};
+    HRESULT hr = S_OK;
+    BOOL shown = FALSE;
+    switch (id)
+    {
+        case FCW_STATUS:
+            shown = m_settings.fStatusBarVisible;
+            break;
+        case FCW_TREE:
+            cmd.cmdID = SBCMDID_EXPLORERBARFOLDERS;
+            hr = QueryStatus(&CGID_Explorer, 1, &cmd, NULL);
+            shown = cmd.cmdf & OLECMDF_LATCHED;
+            break;
+        default:
+            hr = E_NOTIMPL;
+    }
+    if (pfShown)
+    {
+        *pfShown = shown;
+        return hr;
+    }
+    return SUCCEEDED(hr) ? shown ? S_OK : S_FALSE : hr;
 }
 
 HRESULT STDMETHODCALLTYPE CShellBrowser::IEGetDisplayName(LPCITEMIDLIST pidl, LPWSTR pwszName, UINT uFlags)

--- a/sdk/include/reactos/shlobj_undoc.h
+++ b/sdk/include/reactos/shlobj_undoc.h
@@ -59,6 +59,31 @@ struct persistState
 };
 
 /*****************************************************************************
+ * CGID_Explorer (IShellBrowser OLECMD IDs)
+ */
+#define SBCMDID_EXPLORERBARFOLDERS 35 // Query/Toggle
+#define SBCMDID_MIXEDZONE 39
+#define SBCMDID_ONVIEWMOVETOTOP 60
+//SBCMDID_ENABLESHOWTREE ?
+//SBCMDID_SHOWCONTROL ?
+//SBCMDID_CANCELNAVIGATION ?
+//SBCMDID_MAYSAVECHANGES ?
+//SBCMDID_SETHLINKFRAME ?
+//SBCMDID_ENABLESTOP ?
+//SBCMDID_SELECTHISTPIDL ?
+//SBCMDID_GETPANE ? // This is in the official SDK but only the panes are defined
+#define PANE_NONE       ((DWORD)-1)
+#define PANE_ZONE       1
+#define PANE_OFFLINE    2
+#define PANE_PRINTER    3
+#define PANE_SSL        4
+#define PANE_NAVIGATION 5
+#define PANE_PROGRESS   6
+#if (_WIN32_IE >= _WIN32_IE_IE60)
+#define PANE_PRIVACY    7
+#endif
+
+/*****************************************************************************
  * IInitializeObject interface
  */
 #undef  INTERFACE


### PR DESCRIPTION
Support GetControlWindow, ShowControlWindow and IsControlWindowShown for TREE and STATUS in the Shell Browser.

This combined with the [CMF_EXPLORE DefView PR](https://github.com/reactos/reactos/pull/6776) allows DFM to pick the correct default folder verb:

![Open and Explore](https://github.com/reactos/reactos/assets/138629473/96e6fb9a-fe49-4fb0-a0a7-6c41a4a00f3e)

Notes:
 - Yes, it seems like IsControlWindowShown should allow the output parameter to be NULL as some kind of shortcut.

----

I discovered that the commands related to CGID_Explorer are called SBCMDID_* (Shell Browser Cmd Id?). MSDN [leaks](https://learn.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/platform-apis/aa767714(v=vs.85)) the fact that one of the commands is called SBCMDID_SELECTHISTPIDL. This lead me to [this mailing list archive](https://wtl.yahoogroups.narkive.com/ejpCzFtj/ot-query-shell-sbcmdid-related-info) that discloses a few more but I had to invent a name for the one I needed here.

