### PR TITLE
[SHELL32] SHChangeNotify: Add drive, remove drive

### DIFF
--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -2287,6 +2287,7 @@ LRESULT CDefView::OnChangeNotify(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &
     {
         case SHCNE_MKDIR:
         case SHCNE_CREATE:
+        case SHCNE_DRIVEADD:
             if (bParent0)
             {
                 if (LV_FindItemByPidl(ILFindLastID(Pidls[0])) == -1)
@@ -2297,6 +2298,7 @@ LRESULT CDefView::OnChangeNotify(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &
             break;
         case SHCNE_RMDIR:
         case SHCNE_DELETE:
+        case SHCNE_DRIVEREMOVED:
             if (bParent0)
                 LV_DeleteItem(ILFindLastID(Pidls[0]));
             break;

--- a/dll/win32/shell32/shelldesktop/CDesktopBrowser.cpp
+++ b/dll/win32/shell32/shelldesktop/CDesktopBrowser.cpp
@@ -26,6 +26,8 @@
 #include <atlcoll.h>
 #endif
 
+#include <dbt.h>
+
 WINE_DEFAULT_DEBUG_CHANNEL(desktop);
 
 static const WCHAR szProgmanClassName[]  = L"Progman";
@@ -474,12 +476,12 @@ LRESULT CDesktopBrowser::OnDeviceChange(UINT uMsg, WPARAM wParam, LPARAM lParam,
         {
             WCHAR szPath[MAX_PATH];
             DWORD dwBit = (1 << iDrive);
-            if (!(m_dwDrives & dwBit) & (dwDrives & dwBit))
+            if (!(m_dwDrives & dwBit) && (dwDrives & dwBit)) // The drive is added
             {
                 PathBuildRootW(szPath, iDrive);
                 SHChangeNotify(SHCNE_DRIVEADD, SHCNF_PATHW, szPath, NULL);
             }
-            else if ((m_dwDrives & dwBit) & !(dwDrives & dwBit))
+            else if ((m_dwDrives & dwBit) && !(dwDrives & dwBit)) // The drive is removed
             {
                 PathBuildRootW(szPath, iDrive);
                 SHChangeNotify(SHCNE_DRIVEREMOVED, SHCNF_PATHW, szPath, NULL);
@@ -487,6 +489,7 @@ LRESULT CDesktopBrowser::OnDeviceChange(UINT uMsg, WPARAM wParam, LPARAM lParam,
         }
         m_dwDrives = dwDrives;
     }
+    return 0;
 }
 
 extern VOID WINAPI ShowFolderOptionsDialog(UINT Page, BOOL Async);

--- a/dll/win32/shell32/shelldesktop/CDesktopBrowser.cpp
+++ b/dll/win32/shell32/shelldesktop/CDesktopBrowser.cpp
@@ -42,12 +42,12 @@ class CDesktopBrowser :
 private:
     HACCEL m_hAccel;
     HWND m_hWndShellView;
-    DWORD m_dwDrives;
     CComPtr<IShellDesktopTray> m_Tray;
     CComPtr<IShellView>        m_ShellView;
 
     CComPtr<IOleWindow>        m_ChangeNotifyServer;
     HWND                       m_hwndChangeNotifyServer;
+    DWORD m_dwDrives;
 
     LRESULT _NotifyTray(UINT uMsg, WPARAM wParam, LPARAM lParam);
     HRESULT _Resize();
@@ -117,9 +117,9 @@ END_COM_MAP()
 CDesktopBrowser::CDesktopBrowser():
     m_hAccel(NULL),
     m_hWndShellView(NULL),
-    m_hwndChangeNotifyServer(NULL)
+    m_hwndChangeNotifyServer(NULL),
+    m_dwDrives(::GetLogicalDrives())
 {
-    m_dwDrives = ::GetLogicalDrives();
 }
 
 CDesktopBrowser::~CDesktopBrowser()
@@ -466,7 +466,7 @@ LRESULT CDesktopBrowser::OnGetChangeNotifyServer(UINT uMsg, WPARAM wParam, LPARA
     return (LRESULT)m_hwndChangeNotifyServer;
 }
 
-// Detect SHCNE_DRIVEADD and SHCNE_DRIVEREMOVED
+// Detect DBT_DEVICEARRIVAL and DBT_DEVICEREMOVECOMPLETE
 LRESULT CDesktopBrowser::OnDeviceChange(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled)
 {
     if (wParam == DBT_DEVICEARRIVAL || wParam == DBT_DEVICEREMOVECOMPLETE)


### PR DESCRIPTION
## Purpose

Implementing missing features...
JIRA issue: [CORE-13950](https://jira.reactos.org/browse/CORE-13950)

## Proposed changes

- Add `WM_DEVICECHANGE` message handler in the shell window to detect `DBT_DEVICEARRIVAL` and `DBT_DEVICEREMOVECOMPLETE`.
- Use `GetLogicalDrives` function to detect drives.
- Use `SHChangeNotify` to send `SHCNE_DRIVEADD` and `SHCNE_DRIVEREMOVED` notifications.
- Modify `CDefView::OnChangeNotify`.