### PR TITLE
[SHELL32] SHChangeNotify: Use ReplyMessage for quick response

### DIFF
--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -390,7 +390,7 @@ BOOL CChangeNotifyServer::DeliverNotification(HANDLE hTicket, DWORD dwOwnerPID)
             // do notify
             TRACE("Notifying: %p, 0x%x, %p, %lu\n",
                   pRegEntry->hwnd, pRegEntry->uMsg, hTicket, dwOwnerPID);
-            ::PostMessageW(pRegEntry->hwnd, pRegEntry->uMsg, (WPARAM)hTicket, dwOwnerPID);
+            ::SendMessageW(pRegEntry->hwnd, pRegEntry->uMsg, (WPARAM)hTicket, dwOwnerPID);
             TRACE("GetLastError(): %ld\n", ::GetLastError());
         }
     }

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -394,7 +394,7 @@ BOOL CChangeNotifyServer::DeliverNotification(HANDLE hTicket, DWORD dwOwnerPID)
             // do notify
             TRACE("Notifying: %p, 0x%x, %p, %lu\n",
                   pRegEntry->hwnd, pRegEntry->uMsg, hTicket, dwOwnerPID);
-            SendMessageW(pRegEntry->hwnd, pRegEntry->uMsg, (WPARAM)hTicket, dwOwnerPID);
+            PostMessageW(pRegEntry->hwnd, pRegEntry->uMsg, (WPARAM)hTicket, dwOwnerPID);
             TRACE("GetLastError(): %ld\n", ::GetLastError());
         }
     }

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -370,6 +370,10 @@ BOOL CChangeNotifyServer::DeliverNotification(HANDLE hTicket, DWORD dwOwnerPID)
             ::ReplyMessage(TRUE);
     }
 
+    // Protect CChangeNotifyServer by using mutex
+    HANDLE hMutex = ::CreateMutex(NULL, FALSE, L"CChangeNotifyServer::DeliverNotification");
+    ::WaitForSingleObject(hMutex, INFINITE);
+
     // for all items
     for (INT i = 0; i < m_items.GetSize(); ++i)
     {
@@ -394,6 +398,10 @@ BOOL CChangeNotifyServer::DeliverNotification(HANDLE hTicket, DWORD dwOwnerPID)
             TRACE("GetLastError(): %ld\n", ::GetLastError());
         }
     }
+
+    // Release mutex
+    ::ReleaseMutex(hMutex);
+    ::CloseHandle(hMutex);
 
     // unlock the ticket
     SHUnlockShared(pTicket);

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -394,7 +394,7 @@ BOOL CChangeNotifyServer::DeliverNotification(HANDLE hTicket, DWORD dwOwnerPID)
             // do notify
             TRACE("Notifying: %p, 0x%x, %p, %lu\n",
                   pRegEntry->hwnd, pRegEntry->uMsg, hTicket, dwOwnerPID);
-            PostMessageW(pRegEntry->hwnd, pRegEntry->uMsg, (WPARAM)hTicket, dwOwnerPID);
+            ::PostMessageW(pRegEntry->hwnd, pRegEntry->uMsg, (WPARAM)hTicket, dwOwnerPID);
             TRACE("GetLastError(): %ld\n", ::GetLastError());
         }
     }

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -371,7 +371,7 @@ BOOL CChangeNotifyServer::DeliverNotification(HANDLE hTicket, DWORD dwOwnerPID)
     }
 
     // Protect CChangeNotifyServer by using mutex
-    HANDLE hMutex = ::CreateMutex(NULL, FALSE, L"CChangeNotifyServer::DeliverNotification");
+    HANDLE hMutex = ::CreateMutexW(NULL, FALSE, L"CChangeNotifyServer::DeliverNotification");
     ::WaitForSingleObject(hMutex, INFINITE);
 
     // for all items

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -363,6 +363,13 @@ BOOL CChangeNotifyServer::DeliverNotification(HANDLE hTicket, DWORD dwOwnerPID)
         return FALSE;
     }
 
+    // Use ReplyMessage for quick response
+    if ((pTicket->uFlags & (SHCNF_FLUSH | SHCNF_FLUSHNOWAIT)) != SHCNF_FLUSH)
+    {
+        if (::InSendMessage())
+            ::ReplyMessage(TRUE);
+    }
+
     // for all items
     for (INT i = 0; i < m_items.GetSize(); ++i)
     {

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -370,10 +370,6 @@ BOOL CChangeNotifyServer::DeliverNotification(HANDLE hTicket, DWORD dwOwnerPID)
             ::ReplyMessage(TRUE);
     }
 
-    // Protect CChangeNotifyServer by using mutex
-    HANDLE hMutex = ::CreateMutexW(NULL, FALSE, L"CChangeNotifyServer::DeliverNotification");
-    ::WaitForSingleObject(hMutex, INFINITE);
-
     // for all items
     for (INT i = 0; i < m_items.GetSize(); ++i)
     {
@@ -398,10 +394,6 @@ BOOL CChangeNotifyServer::DeliverNotification(HANDLE hTicket, DWORD dwOwnerPID)
             TRACE("GetLastError(): %ld\n", ::GetLastError());
         }
     }
-
-    // Release mutex
-    ::ReleaseMutex(hMutex);
-    ::CloseHandle(hMutex);
 
     // unlock the ticket
     SHUnlockShared(pTicket);

--- a/dll/win32/shell32/shelldesktop/CDirectoryWatcher.cpp
+++ b/dll/win32/shell32/shelldesktop/CDirectoryWatcher.cpp
@@ -15,7 +15,7 @@ WINE_DEFAULT_DEBUG_CHANNEL(shcn);
 static inline void
 NotifyFileSystemChange(LONG wEventId, LPCWSTR path1, LPCWSTR path2)
 {
-    SHChangeNotify(wEventId | SHCNE_INTERRUPT, SHCNF_PATHW | SHCNF_FLUSH, path1, path2);
+    SHChangeNotify(wEventId, SHCNF_PATHW, path1, path2);
 }
 
 // The handle of the APC thread


### PR DESCRIPTION
## Purpose
Make shell change notificatioin quicker.
JIRA issue: [CORE-13950](https://jira.reactos.org/browse/CORE-13950)

## Proposed changes

- Use `InSendMessage` and `ReplyMessage` for quick response if not `SHCNF_FLUSH` in `CChangeNotifyServer::DeliverNotification`.
- Modify `NotifyFileSystemChange` function.

## TODO

- [x] Do manual tests.

## Comparison

BEFORE:
![before](https://github.com/reactos/reactos/assets/2107452/80e399b4-e460-455e-a971-5611e3f17e19)
292 seconds, 160 failures.

AFTER:
![after](https://github.com/reactos/reactos/assets/2107452/d202fd02-029d-40e2-bc0d-380caaddfcd5)
306 seconds, 238 failures.