### PR TITLE
[NTDLL_APITEST][KMTEST] Add tests for FileEndOfFileInformation

### DIFF
--- a/modules/rostests/apitests/ntdll/NtQueryInformationFile.c
+++ b/modules/rostests/apitests/ntdll/NtQueryInformationFile.c
@@ -20,4 +20,36 @@ START_TEST(NtQueryInformationFile)
     Status = NtQueryInformationFile(NULL, NULL, NULL, 0, 0x80000000);
     ok(Status == STATUS_INVALID_INFO_CLASS ||
        ntv6(Status == STATUS_NOT_IMPLEMENTED), "Status = %lx\n", Status);
+
+    /* Get the full path of the current executable */
+    CHAR Path[MAX_PATH];
+    DWORD Length = GetModuleFileNameA(NULL, Path, _countof(Path));
+    ok(Length != 0, "GetModuleFileNameA failed\n");
+    if (Length == 0)
+        return;
+
+    /* Open the file */
+    HANDLE hFile = CreateFileA(Path,
+                               GENERIC_READ,
+                               FILE_SHARE_READ,
+                               NULL,
+                               OPEN_EXISTING,
+                               FILE_ATTRIBUTE_NORMAL,
+                               NULL);
+    ok(hFile != INVALID_HANDLE_VALUE, "CreateFileA failed\n");
+    if (hFile == INVALID_HANDLE_VALUE)
+        return;
+
+    /* Query FileEndOfFileInformation */
+    FILE_END_OF_FILE_INFORMATION EndOfFileInformation;
+    EndOfFileInformation.EndOfFile.QuadPart = 0xdeaddead;
+    Status = NtQueryInformationFile(hFile,
+                                    NULL,
+                                    &EndOfFileInformation,
+                                    sizeof(EndOfFileInformation),
+                                    FileEndOfFileInformation);
+    ok_hex(Status, STATUS_INVALID_INFO_CLASS);
+    ok(EndOfFileInformation.EndOfFile.QuadPart == 0xdeaddead, "EndOfFile is modified\n");
+
+    CloseHandle(hFile);
 }

--- a/modules/rostests/kmtests/ntos_io/IoFilesystem.c
+++ b/modules/rostests/kmtests/ntos_io/IoFilesystem.c
@@ -221,6 +221,15 @@ TestAllInformation(VOID)
     if (FileAllInfo)
         KmtFreeGuarded(FileAllInfo);
 
+    PFILE_END_OF_FILE_INFORMATION FileEofInfo;
+    Length = sizeof(*FileEofInfo);
+    Status = QueryFileInfo(FileHandle, (PVOID*)&FileEofInfo, &Length, FileEndOfFileInformation);
+    // Checked build: STATUS_INVALID_INFO_CLASS, Free build: STATUS_INVALID_PARAMETER
+    ok(Status == STATUS_INVALID_PARAMETER || Status == STATUS_INVALID_INFO_CLASS, "Wrong Status = %lx\n", Status);
+    ok_eq_size(Length, (SIZE_T)0x5555555555555555ULL);
+    if (FileEofInfo)
+        KmtFreeGuarded(FileEofInfo);
+
 NoInfo:
     Status = ObCloseHandle(FileHandle, KernelMode);
     ok_eq_hex(Status, STATUS_SUCCESS);


### PR DESCRIPTION
## Purpose

Add tests for FileEndOfFileInformation

## Tests
✅ Test WHS: https://reactos.org/testman/compare.php?ids=94854,94862
✅ Test Windows 2003 x64: https://reactos.org/testman/compare.php?ids=94850,94863
✅ Test KVM x86: https://reactos.org/testman/compare.php?ids=95077,95079,95086,95093
✅ Test KVM x64: https://reactos.org/testman/compare.php?ids=95096,95104
