### PR TITLE
[CRT] Add _Exit

### DIFF
--- a/sdk/include/crt/process.h
+++ b/sdk/include/crt/process.h
@@ -67,7 +67,6 @@ extern "C" {
   __declspec(noreturn) void __cdecl abort(void);
 #if __MINGW_GNUC_PREREQ(4,4)
 #pragma pop_macro("abort")
-#undef abort
 #endif
 #endif
 

--- a/sdk/include/crt/process.h
+++ b/sdk/include/crt/process.h
@@ -54,7 +54,12 @@ extern "C" {
 #define _CRT_TERMINATE_DEFINED
   __declspec(noreturn) void __cdecl exit(_In_ int _Code);
   _CRTIMP __declspec(noreturn) void __cdecl _exit(_In_ int _Code);
-
+#if !defined __NO_ISOCEXT /* extern stub in static libmingwex.a */
+  /* C99 function name */
+  __declspec(noreturn) void __cdecl _Exit(int); /* Declare to get noreturn attribute.  */
+  __CRT_INLINE void __cdecl _Exit(int status)
+  {  _exit(status); }
+#endif
 #if __MINGW_GNUC_PREREQ(4,4)
 #pragma push_macro("abort")
 #undef abort


### PR DESCRIPTION
## Purpose

Add _Exit to process.h

This is already done this way in our stdlib.h. It is needed by GCC 13 C++ headers. The problem happens like this:
- telnet/precomp.h includes fstream from GCC
- fstream includes pthread.h from GCC
- pthread.h includes process.h from ReactOS
- process.h defines _CRT_TERMINATE_DEFINED, but doesn't declare _Exit
- fstream includes cstdlib from GCC
- cstdlib includes stdlib.h from GCC (#include_next)
- stdlib.h doesn't declare _Exit, because _CRT_TERMINATE_DEFINED is defined
- cstdlib uses _Exit
