### PR TITLE
[TASKMGR] Process page: Allow using "Open File Location" functionality without running Explorer shell

### DIFF
--- a/base/applications/taskmgr/procpage.c
+++ b/base/applications/taskmgr/procpage.c
@@ -1248,8 +1248,11 @@ void ProcessPage_OnOpenFileLocation(void)
 
     StringCchPrintfW(pszCmdLine, dwLength, szCmdFormat, pszExePath);
 
-    /* Call the shell to open the file location and select it */
-    ShellExecuteW(NULL, L"open", L"explorer.exe", pszCmdLine, NULL, SW_SHOWNORMAL);
+    /* Call the shell to open the file location and select it. If Explorer shell
+     * is not available, use ReactOS's alternative file browser instead. */
+    ShellExecuteW(NULL, L"open",
+                  GetShellWindow() ? L"explorer.exe" : L"filebrowser.exe",
+                  pszCmdLine, NULL, SW_SHOWNORMAL);
 
 Cleanup:
     HeapFree(GetProcessHeap(), 0, pszCmdLine);

--- a/base/applications/taskmgr/procpage.c
+++ b/base/applications/taskmgr/procpage.c
@@ -1222,6 +1222,7 @@ void ProcessPage_OnOpenFileLocation(void)
     DWORD dwProcessId;
     DWORD dwLength;
     LPWSTR pszExePath;
+    static const WCHAR szCmdFormat[] = L"/select,\"%s\"";
     LPWSTR pszCmdLine = NULL;
 
     dwProcessId = GetSelectedProcessId();
@@ -1240,11 +1241,12 @@ void ProcessPage_OnOpenFileLocation(void)
         goto Cleanup;
 
     /* Build the shell command line */
-    pszCmdLine = HeapAlloc(GetProcessHeap(), 0, (dwLength + CONST_STR_LEN(L"/select,\"\"")) * sizeof(WCHAR));
+    dwLength += CONST_STR_LEN(szCmdFormat) - CONST_STR_LEN(L"%s");
+    pszCmdLine = HeapAlloc(GetProcessHeap(), 0, dwLength * sizeof(WCHAR));
     if (!pszCmdLine)
         goto Cleanup;
 
-    StringCchPrintfW(pszCmdLine, dwLength + CONST_STR_LEN(L"/select,\"\""), L"/select,\"%s\"", pszExePath);
+    StringCchPrintfW(pszCmdLine, dwLength, szCmdFormat, pszExePath);
 
     /* Call the shell to open the file location and select it */
     ShellExecuteW(NULL, L"open", L"explorer.exe", pszCmdLine, NULL, SW_SHOWNORMAL);


### PR DESCRIPTION
If Explorer shell is not available, use ReactOS's alternative file browser instead.
Also improve readability of command line string formatting code.

ReactOS:
![VirtualBox_ReactOS_22_04_2024_21_26_41](https://github.com/reactos/reactos/assets/86486978/fc2c7a30-4a35-4e23-90db-3dc4b1a6b42d)

ReactOS TaskMgr+FileBrowser on Win2k3:
![VirtualBox_Win2003_SP2_22_04_2024_21_31_57](https://github.com/reactos/reactos/assets/86486978/3008b9ca-2588-4cea-a3ed-8037b9038a26)