### PR TITLE
[SHELL32] CFSFolder parsing must only apply bind data to the last item

### DIFF
--- a/dll/win32/shell32/folders/CFSFolder.cpp
+++ b/dll/win32/shell32/folders/CFSFolder.cpp
@@ -667,7 +667,7 @@ HRESULT SHELL32_GetFSItemAttributes(IShellFolder * psf, LPCITEMIDLIST pidl, LPDW
 
 HRESULT CFSFolder::_ParseSimple(
     _In_ LPOLESTR lpszDisplayName,
-    _Out_ WIN32_FIND_DATAW *pFind,
+    _Inout_ WIN32_FIND_DATAW *pFind,
     _Out_ LPITEMIDLIST *ppidl)
 {
     HRESULT hr;
@@ -675,6 +675,8 @@ HRESULT CFSFolder::_ParseSimple(
 
     *ppidl = NULL;
 
+    const DWORD finalattr = pFind->dwFileAttributes;
+    const DWORD finalsizelo = pFind->nFileSizeLow;
     LPITEMIDLIST pidl;
     for (hr = S_OK; SUCCEEDED(hr); hr = SHILAppend(pidl, ppidl))
     {
@@ -682,9 +684,8 @@ HRESULT CFSFolder::_ParseSimple(
         if (hr != S_OK)
             break;
 
-        if (pchNext)
-            pFind->dwFileAttributes = FILE_ATTRIBUTE_DIRECTORY;
-
+        pFind->dwFileAttributes = pchNext ? FILE_ATTRIBUTE_DIRECTORY : finalattr;
+        pFind->nFileSizeLow = pchNext ? 0 : finalsizelo;
         pidl = _ILCreateFromFindDataW(pFind);
         if (!pidl)
         {

--- a/dll/win32/shell32/folders/CFSFolder.h
+++ b/dll/win32/shell32/folders/CFSFolder.h
@@ -36,7 +36,7 @@ class CFSFolder :
 
         HRESULT _ParseSimple(
             _In_ LPOLESTR lpszDisplayName,
-            _Out_ WIN32_FIND_DATAW *pFind,
+            _Inout_ WIN32_FIND_DATAW *pFind,
             _Out_ LPITEMIDLIST *ppidl);
         BOOL _GetFindDataFromName(_In_ LPCWSTR pszName, _Out_ WIN32_FIND_DATAW *pFind);
         HRESULT _CreateIDListFromName(LPCWSTR pszName, DWORD attrs, IBindCtx *pbc, LPITEMIDLIST *ppidl);


### PR DESCRIPTION
When IShellFolder::ParseDisplayName is asked to parse multiple path elements, the IFileSystemBindData (if any) only applies to the last item. The other elements are always folders.


```C
// Test
struct CStackScopeFileSysBindData : IFileSystemBindData {
	WIN32_FIND_DATAW m_wfd;
	IFACEMETHODIMP QueryInterface(REFIID riid, void **ppv)
	{
		if (riid == IID_IUnknown || riid == IID_IFileSystemBindData) return (*ppv = static_cast<IFileSystemBindData *>(this), AddRef(), S_OK);
		return (*ppv = NULL, E_NOINTERFACE);
	}
	IFACEMETHODIMP_(ULONG) AddRef() { return 2; } IFACEMETHODIMP_(ULONG) Release() { return 1; }
	IFACEMETHODIMP SetFindData(const WIN32_FIND_DATAW *pfd) { m_wfd = *pfd; return S_OK; }
	IFACEMETHODIMP GetFindData(WIN32_FIND_DATAW *pfd) { *pfd = m_wfd; return S_OK; }
};
OleInitialize(0);
PIDLIST_RELATIVE pidl;
IShellFolder *psf;
HRESULT hr = SHCoCreateInstance(L"{f3364ba0-65b9-11ce-a9ba-00aa004ae837}", 0, 0, IID_PPV_ARG(IShellFolder, &psf));
IBindCtx *pbc;
hr = CreateBindCtx(0, &pbc);
BIND_OPTS bo = { sizeof(bo), 0, STGM_CREATE, 0 };
hr = pbc->SetBindOptions(&bo);
CStackScopeFileSysBindData fsbd;
ZeroMemory(&fsbd.m_wfd, sizeof(fsbd.m_wfd));
fsbd.m_wfd.dwFileAttributes = FILE_ATTRIBUTE_HIDDEN;
hr = pbc->RegisterObjectParam(STR_FILE_SYS_BIND_DATA, &fsbd);
WCHAR path[MAX_PATH] = L"dir\\file.ext", i = 0;
hr = psf->ParseDisplayName(0, pbc, path, 0, &pidl, 0);
GetSystemDirectoryW(path, MAX_PATH), PathAppendW(path, L"kernel32_vista.dll");
printf("Testing on %s:\n", (GetFileAttributesW(path) & FILE_ATTRIBUTE_DIRECTORY) ? "Windows" : "ROS");
for (LPITEMIDLIST p = pidl; p->mkid.cb; p = ILGetNext(p))
{
	WORD att = MAKEWORD(p->mkid.abID[10], p->mkid.abID[11]), term = ILGetNext(p)->mkid.cb;
	ILGetNext(p)->mkid.cb = 0, SHGetPathFromIDListW(p, path), ILGetNext(p)->mkid.cb = term;
	printf("itemid#%d: type=%.2x attr=%.4x isdir=%d ishidden=%d name=%ls\n", ++i, p->mkid.abID[0], att, !!(att & FILE_ATTRIBUTE_DIRECTORY), !!(att & FILE_ATTRIBUTE_HIDDEN), PathFindFileNameW(path));
}
```

(Before)
Testing on ROS:
itemid#1: type=31 attr=0010 isdir=1 ishidden=0 name=dir
itemid#2: type=31 attr=0010 isdir=1 ishidden=0 name=file.ext

(After)
Testing on ROS:
itemid#1: type=31 attr=0010 isdir=1 ishidden=0 name=dir
itemid#2: type=32 attr=0002 isdir=0 ishidden=1 name=file.ext

Testing on Windows:
itemid#1: type=31 attr=0010 isdir=1 ishidden=0 name=dir
itemid#2: type=32 attr=0002 isdir=0 ishidden=1 name=file.ext


