### PR TITLE
[SHELL32_APITEST] Make SHChangeNotify testcase more stable

### DIFF
--- a/modules/rostests/apitests/shell32/SHChangeNotify.cpp
+++ b/modules/rostests/apitests/shell32/SHChangeNotify.cpp
@@ -154,7 +154,7 @@ static void DoBuildFilesAndDirs(void)
 }
 
 static void
-DoTestEntry(UINT uMsg, LONG lEvent, LPCITEMIDLIST pidl1, LPCITEMIDLIST pidl2)
+DoTestEntry(LONG lEvent, LPCITEMIDLIST pidl1, LPCITEMIDLIST pidl2)
 {
     WCHAR szPath1[MAX_PATH], szPath2[MAX_PATH];
 
@@ -426,7 +426,7 @@ static BOOL OnCopyData(HWND hwnd, HWND hwndSender, COPYDATASTRUCT *pCopyData)
     LPBYTE pbData = (LPBYTE)pCopyData->lpData;
 
     LONG cbTotal = pCopyData->cbData;
-    if (cbTotal < LONG(sizeof(UINT) + sizeof(DWORD) + sizeof(DWORD)))
+    if (cbTotal < LONG(sizeof(LONG) + sizeof(DWORD) + sizeof(DWORD)))
     {
         trace("\n");
         return FALSE;
@@ -434,14 +434,14 @@ static BOOL OnCopyData(HWND hwnd, HWND hwndSender, COPYDATASTRUCT *pCopyData)
 
     LPBYTE pb = pbData;
 
-    UINT uMsg = *(UINT*)pb;
-    pb += sizeof(uMsg);
-
     LONG lEvent = *(LONG*)pb;
     pb += sizeof(lEvent);
 
     DWORD cbPidl1 = *(DWORD*)pb;
     pb += sizeof(cbPidl1);
+
+    DWORD cbPidl2 = *(DWORD*)pb;
+    pb += sizeof(cbPidl2);
 
     LPITEMIDLIST pidl1 = NULL;
     if (cbPidl1)
@@ -450,9 +450,6 @@ static BOOL OnCopyData(HWND hwnd, HWND hwndSender, COPYDATASTRUCT *pCopyData)
         CopyMemory(pidl1, pb, cbPidl1);
         pb += cbPidl1;
     }
-
-    DWORD cbPidl2 = *(DWORD*)pb;
-    pb += sizeof(cbPidl2);
 
     LPITEMIDLIST pidl2 = NULL;
     if (cbPidl2)
@@ -468,7 +465,7 @@ static BOOL OnCopyData(HWND hwnd, HWND hwndSender, COPYDATASTRUCT *pCopyData)
         return FALSE;
     }
 
-    DoTestEntry(uMsg, lEvent, pidl1, pidl2);
+    DoTestEntry(lEvent, pidl1, pidl2);
 
     CoTaskMemFree(pidl1);
     CoTaskMemFree(pidl2);

--- a/modules/rostests/apitests/shell32/SHChangeNotify.cpp
+++ b/modules/rostests/apitests/shell32/SHChangeNotify.cpp
@@ -439,15 +439,10 @@ static BOOL OnCopyData(HWND hwnd, HWND hwndSender, COPYDATASTRUCT *pCopyData)
         return FALSE;
 
     LPBYTE pbData = (LPBYTE)pCopyData->lpData;
+    LPBYTE pb = pbData;
 
     LONG cbTotal = pCopyData->cbData;
-    if (cbTotal < LONG(sizeof(LONG) + sizeof(DWORD) + sizeof(DWORD)))
-    {
-        trace("\n");
-        return FALSE;
-    }
-
-    LPBYTE pb = pbData;
+    assert(cbTotal >= LONG(sizeof(LONG) + sizeof(DWORD) + sizeof(DWORD)));
 
     LONG lEvent = *(LONG*)pb;
     pb += sizeof(lEvent);
@@ -474,11 +469,7 @@ static BOOL OnCopyData(HWND hwnd, HWND hwndSender, COPYDATASTRUCT *pCopyData)
         pb += cbPidl2;
     }
 
-    if ((pb - pbData) != cbTotal)
-    {
-        trace("\n");
-        return FALSE;
-    }
+    assert((pb - pbData) == cbTotal);
 
     DoTestEntry(lEvent, pidl1, pidl2);
 

--- a/modules/rostests/apitests/shell32/SHChangeNotify.cpp
+++ b/modules/rostests/apitests/shell32/SHChangeNotify.cpp
@@ -2,673 +2,98 @@
  * PROJECT:     ReactOS api tests
  * LICENSE:     LGPL-2.0-or-later (https://spdx.org/licenses/LGPL-2.0-or-later)
  * PURPOSE:     Test for SHChangeNotify
- * COPYRIGHT:   Copyright 2020-2021 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
+ * COPYRIGHT:   Copyright 2020-2024 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
  */
 
-// NOTE: This test program closes the Explorer windows before tests.
+// NOTE: This testcase needs shell32_apitest_sub.exe .
+// NOTE: SHChangeNotify behavior is unstable even on Windows.
+//       The results of this testcase may vary depending on conditions.
 
 #include "shelltest.h"
 #include "shell32_apitest_sub.h"
-#include <time.h>
-#include <process.h>
-#include <versionhelpers.h>
+#include <assert.h>
 
-// --- The selection of tests ---
-#define DISABLE_THIS_TESTCASE
-#define NO_TRIVIAL
-//#define NO_INTERRUPT_LEVEL
-//#define NO_SHELL_LEVEL
-#define NEW_DELIVERY_ONLY
-//#define RANDOM_HALF
-#define RANDOM_QUARTER
+#define ID_TEST_START   777
+#define NUM_CHECKS      10
+#define NUM_STAGE       4
+#define NUM_STEP        7
+#define INTERVAL        800
+#define MAX_EVENT_TYPE  6
 
-// --- Show the elapsed time by GetTickCount() ---
-//#define ENTRY_TICK
-#define GROUP_TICK
-#define TOTAL_TICK
-
-static HWND s_hwnd = NULL;
+static HWND s_hMainWnd = NULL;
+static HWND s_hSubWnd = NULL;
 static WCHAR s_szSubProgram[MAX_PATH];
 static HANDLE s_hThread = NULL;
-static HANDLE s_hEvent = NULL;
+
+static INT s_iStage = -1;
+static INT s_iStep = -1;
+static BYTE s_abChecks[NUM_CHECKS] = { 0 };
+static BOOL s_bGotUpdateDir = FALSE;
 
 static BOOL DoCreateEmptyFile(LPCWSTR pszFileName)
 {
-    FILE *fp = _wfopen(pszFileName, L"wb");
-    if (fp)
-        fclose(fp);
-    return fp != NULL;
+    HANDLE hFile = ::CreateFileW(pszFileName, GENERIC_WRITE, FILE_SHARE_READ, NULL,
+                                 CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+    ::CloseHandle(hFile);
+    return hFile != INVALID_HANDLE_VALUE;
 }
 
-struct TEST_ENTRY;
-
-typedef BOOL (*ACTION)(const struct TEST_ENTRY *entry);
-
-typedef struct TEST_ENTRY
+static void DoDeleteDirectory(LPCWSTR pszDir)
 {
-    INT line;
-    DIRTYPE iWriteDir;
-    LPCSTR pattern;
-    LPCWSTR path1;
-    LPCWSTR path2;
-    ACTION action;
-} TEST_ENTRY;
-
-#define TEST_FILE      L"_TEST_.txt"
-#define TEST_FILE_KAI  L"_TEST_KAI_.txt"
-#define TEST_DIR       L"_TESTDIR_"
-#define TEST_DIR_KAI   L"_TESTDIR_KAI_"
-#define MOVE_FILE(from, to) MoveFileW((from), (to))
-
-static BOOL DoAction1(const TEST_ENTRY *entry)
-{
-    LPWSTR pszPath = DoGetDir(entry->iWriteDir);
-    PathAppendW(pszPath, TEST_FILE);
-    ok(DoCreateEmptyFile(pszPath), "Line %d: DoCreateEmptyFile failed\n", entry->line);
-    return TRUE;
+    WCHAR szPath[MAX_PATH];
+    ZeroMemory(szPath, sizeof(szPath));
+    StringCchCopyW(szPath, _countof(szPath), pszDir);
+    SHFILEOPSTRUCTW FileOp = { NULL, FO_DELETE, szPath, NULL, FOF_NOCONFIRMATION | FOF_SILENT };
+    SHFileOperation(&FileOp);
 }
 
-static BOOL DoAction2(const TEST_ENTRY *entry)
+static INT GetEventType(LONG lEvent)
 {
-    LPWSTR pszPath1 = DoGetDir(entry->iWriteDir), pszPath2 = DoGetDir(entry->iWriteDir);
-    PathAppendW(pszPath1, TEST_FILE);
-    PathAppendW(pszPath2, TEST_FILE_KAI);
-    ok(MOVE_FILE(pszPath1, pszPath2), "Line %d: MOVE_FILE(%ls, %ls) failed (%ld)\n",
-       entry->line, pszPath1, pszPath2, GetLastError());
-    return TRUE;
+    switch (lEvent)
+    {
+        case SHCNE_CREATE:          return 0;
+        case SHCNE_DELETE:          return 1;
+        case SHCNE_RENAMEITEM:      return 2;
+        case SHCNE_MKDIR:           return 3;
+        case SHCNE_RMDIR:           return 4;
+        case SHCNE_RENAMEFOLDER:    return 5;
+        C_ASSERT(5 + 1 == MAX_EVENT_TYPE);
+        default:                    return -1;
+    }
 }
 
-static BOOL DoAction3(const TEST_ENTRY *entry)
-{
-    LPWSTR pszPath1 = DoGetDir(entry->iWriteDir), pszPath2 = DoGetDir(entry->iWriteDir);
-    PathAppendW(pszPath1, TEST_FILE_KAI);
-    PathAppendW(pszPath2, TEST_FILE);
-    ok(MOVE_FILE(pszPath1, pszPath2), "Line %d: MOVE_FILE(%ls, %ls) failed (%ld)\n",
-       entry->line, pszPath1, pszPath2, GetLastError());
-    return TRUE;
-}
+#define FILE_1  L"_TESTFILE_1_.txt"
+#define FILE_2  L"_TESTFILE_2_.txt"
+#define DIR_1   L"_TESTDIR_1_"
 
-static BOOL DoAction4(const TEST_ENTRY *entry)
-{
-    LPWSTR pszPath = DoGetDir(entry->iWriteDir);
-    PathAppendW(pszPath, TEST_FILE);
-    ok(DeleteFileW(pszPath), "Line %d: DeleteFileW(%ls) failed (%ld)\n",
-       entry->line, pszPath, GetLastError());
-    return TRUE;
-}
-
-static BOOL DoAction5(const TEST_ENTRY *entry)
-{
-    LPWSTR pszPath = DoGetDir(entry->iWriteDir);
-    PathAppendW(pszPath, TEST_DIR);
-    ok(CreateDirectoryW(pszPath, NULL), "Line %d: CreateDirectoryW(%ls) failed (%ld)\n",
-       entry->line, pszPath, GetLastError());
-    return TRUE;
-}
-
-static BOOL DoAction6(const TEST_ENTRY *entry)
-{
-    LPWSTR pszPath1 = DoGetDir(entry->iWriteDir), pszPath2 = DoGetDir(entry->iWriteDir);
-    PathAppendW(pszPath1, TEST_DIR);
-    PathAppendW(pszPath2, TEST_DIR_KAI);
-    ok(MOVE_FILE(pszPath1, pszPath2), "Line %d: MOVE_FILE(%ls, %ls) failed (%ld)\n",
-       entry->line, pszPath1, pszPath2, GetLastError());
-    return TRUE;
-}
-
-static BOOL DoAction7(const TEST_ENTRY *entry)
-{
-    LPWSTR pszPath1 = DoGetDir(entry->iWriteDir), pszPath2 = DoGetDir(entry->iWriteDir);
-    PathAppendW(pszPath1, TEST_DIR_KAI);
-    PathAppendW(pszPath2, TEST_DIR);
-    ok(MOVE_FILE(pszPath1, pszPath2), "Line %d: MOVE_FILE(%ls, %ls) failed (%ld)\n",
-       entry->line, pszPath1, pszPath2, GetLastError());
-    return TRUE;
-}
-
-static BOOL DoAction8(const TEST_ENTRY *entry)
-{
-    LPWSTR pszPath = DoGetDir(entry->iWriteDir);
-    PathAppendW(pszPath, TEST_DIR);
-    ok(RemoveDirectoryW(pszPath), "Line %d: RemoveDirectoryW(%ls) failed (%ld)\n",
-       entry->line, pszPath, GetLastError());
-    return TRUE;
-}
-
-static BOOL DoAction9(const TEST_ENTRY *entry)
-{
-    LPWSTR pszPath = DoGetDir(entry->iWriteDir);
-    PathAppendW(pszPath, TEST_FILE);
-    SHChangeNotify(SHCNE_CREATE, SHCNF_PATHW | SHCNF_FLUSH, pszPath, NULL);
-    return FALSE;
-}
-
-static BOOL DoAction10(const TEST_ENTRY *entry)
-{
-    LPWSTR pszPath = DoGetDir(entry->iWriteDir);
-    PathAppendW(pszPath, TEST_FILE);
-    SHChangeNotify(SHCNE_DELETE, SHCNF_PATHW | SHCNF_FLUSH, pszPath, NULL);
-    return FALSE;
-}
-
-static BOOL DoAction11(const TEST_ENTRY *entry)
-{
-    LPWSTR pszPath = DoGetDir(entry->iWriteDir);
-    PathAppendW(pszPath, TEST_DIR);
-    SHChangeNotify(SHCNE_MKDIR, SHCNF_PATHW | SHCNF_FLUSH, pszPath, NULL);
-    return FALSE;
-}
-
-static BOOL DoAction12(const TEST_ENTRY *entry)
-{
-    LPWSTR pszPath = DoGetDir(entry->iWriteDir);
-    PathAppendW(pszPath, TEST_DIR);
-    SHChangeNotify(SHCNE_RMDIR, SHCNF_PATHW | SHCNF_FLUSH, pszPath, NULL);
-    return FALSE;
-}
-
-#define WRITEDIR_0 DIRTYPE_DESKTOP
-static WCHAR s_szDesktop[MAX_PATH];
-static WCHAR s_szTestFile0[MAX_PATH];
-static WCHAR s_szTestFile0Kai[MAX_PATH];
-static WCHAR s_szTestDir0[MAX_PATH];
-static WCHAR s_szTestDir0Kai[MAX_PATH];
-
-#define WRITEDIR_1 DIRTYPE_MYDOCUMENTS
-static WCHAR s_szDocuments[MAX_PATH];
-static WCHAR s_szTestFile1[MAX_PATH];
-static WCHAR s_szTestFile1Kai[MAX_PATH];
-static WCHAR s_szTestDir1[MAX_PATH];
-static WCHAR s_szTestDir1Kai[MAX_PATH];
+static WCHAR s_szDir1[MAX_PATH];
+static WCHAR s_szDir1InDir1[MAX_PATH];
+static WCHAR s_szFile1InDir1InDir1[MAX_PATH];
+static WCHAR s_szFile1InDir1[MAX_PATH];
+static WCHAR s_szFile2InDir1[MAX_PATH];
 
 static void DoDeleteFilesAndDirs(void)
 {
-    DeleteFileW(TEMP_FILE);
-    DeleteFileW(s_szTestFile0);
-    DeleteFileW(s_szTestFile0Kai);
-    DeleteFileW(s_szTestFile1);
-    DeleteFileW(s_szTestFile1Kai);
-    RemoveDirectoryW(s_szTestDir0);
-    RemoveDirectoryW(s_szTestDir0Kai);
-    RemoveDirectoryW(s_szTestDir1);
-    RemoveDirectoryW(s_szTestDir1Kai);
+    ::DeleteFileW(s_szFile1InDir1);
+    ::DeleteFileW(s_szFile2InDir1);
+    ::DeleteFileW(s_szFile1InDir1InDir1);
+    ::RemoveDirectoryW(s_szDir1InDir1);
+    DoDeleteDirectory(s_szDir1);
 }
 
-static const TEST_ENTRY s_group_00[] =
+static void TEST_Quit(void)
 {
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction1 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction2 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction3 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction4 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction5 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction6 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction7 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction8 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction9 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction10 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction11 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction12 },
+    CloseHandle(s_hThread);
+    s_hThread = NULL;
 
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction1 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction2 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction3 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction4 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction5 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction6 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction7 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction8 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction9 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction10 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction11 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction12 },
-};
-
-static const TEST_ENTRY s_group_01[] =
-{
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction1 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction2 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction3 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction4 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction5 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction6 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction7 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction8 },
-    { __LINE__, WRITEDIR_0, "0100000", s_szTestFile0, L"", DoAction9 },
-    { __LINE__, WRITEDIR_0, "0010000", s_szTestFile0, L"", DoAction10 },
-    { __LINE__, WRITEDIR_0, "0001000", s_szTestDir0, L"", DoAction11 },
-    { __LINE__, WRITEDIR_0, "0000100", s_szTestDir0, L"", DoAction12 },
-
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction1 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction2 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction3 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction4 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction5 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction6 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction7 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction8 },
-    { __LINE__, WRITEDIR_1, "0100000", s_szTestFile1, L"", DoAction9 },
-    { __LINE__, WRITEDIR_1, "0010000", s_szTestFile1, L"", DoAction10 },
-    { __LINE__, WRITEDIR_1, "0001000", s_szTestDir1, L"", DoAction11 },
-    { __LINE__, WRITEDIR_1, "0000100", s_szTestDir1, L"", DoAction12 },
-};
-
-static const TEST_ENTRY s_group_02[] =
-{
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction1 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction2 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction3 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction4 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction5 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction6 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction7 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction8 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction9 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction10 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction11 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction12 },
-
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction1 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction2 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction3 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction4 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction5 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction6 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction7 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction8 },
-    { __LINE__, WRITEDIR_1, "0100000", s_szTestFile1, L"", DoAction9 },
-    { __LINE__, WRITEDIR_1, "0010000", s_szTestFile1, L"", DoAction10 },
-    { __LINE__, WRITEDIR_1, "0001000", s_szTestDir1, L"", DoAction11 },
-    { __LINE__, WRITEDIR_1, "0000100", s_szTestDir1, L"", DoAction12 },
-};
-
-static const TEST_ENTRY s_group_03[] =
-{
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction1 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction2 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction3 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction4 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction5 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction6 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction7 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction8 },
-    { __LINE__, WRITEDIR_0, "0100000", s_szTestFile0, L"", DoAction9 },
-    { __LINE__, WRITEDIR_0, "0010000", s_szTestFile0, L"", DoAction10 },
-    { __LINE__, WRITEDIR_0, "0001000", s_szTestDir0, L"", DoAction11 },
-    { __LINE__, WRITEDIR_0, "0000100", s_szTestDir0, L"", DoAction12 },
-
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction1 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction2 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction3 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction4 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction5 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction6 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction7 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction8 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction9 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction10 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction11 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction12 },
-};
-
-static const TEST_ENTRY s_group_04[] =
-{
-    { __LINE__, WRITEDIR_0, "0100000", s_szTestFile0, L"", DoAction1 },
-    { __LINE__, WRITEDIR_0, "1000000", s_szTestFile0, s_szTestFile0Kai, DoAction2 },
-    { __LINE__, WRITEDIR_0, "1000000", s_szTestFile0Kai, s_szTestFile0, DoAction3 },
-    { __LINE__, WRITEDIR_0, "0010000", s_szTestFile0, L"", DoAction4 },
-    { __LINE__, WRITEDIR_0, "0001000", s_szTestDir0, L"", DoAction5 },
-    { __LINE__, WRITEDIR_0, "0000010", s_szTestDir0, s_szTestDir0Kai, DoAction6 },
-    { __LINE__, WRITEDIR_0, "0000010", s_szTestDir0Kai, s_szTestDir0, DoAction7 },
-    { __LINE__, WRITEDIR_0, "0000100", s_szTestDir0, L"", DoAction8 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction9 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction10 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction11 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction12 },
-
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction1 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction2 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction3 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction4 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction5 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction6 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction7 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction8 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction9 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction10 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction11 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction12 },
-};
-
-static const TEST_ENTRY s_group_05[] =
-{
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction1 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction2 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction3 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction4 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction5 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction6 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction7 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction8 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction9 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction10 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction11 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction12 },
-
-    { __LINE__, WRITEDIR_1, "0100000", s_szTestFile1, L"", DoAction1 },
-    { __LINE__, WRITEDIR_1, "1000000", s_szTestFile1, s_szTestFile1Kai, DoAction2 },
-    { __LINE__, WRITEDIR_1, "1000000", s_szTestFile1Kai, s_szTestFile1, DoAction3 },
-    { __LINE__, WRITEDIR_1, "0010000", s_szTestFile1, L"", DoAction4 },
-    { __LINE__, WRITEDIR_1, "0001000", s_szTestDir1, L"", DoAction5 },
-    { __LINE__, WRITEDIR_1, "0000010", s_szTestDir1, s_szTestDir1Kai, DoAction6 },
-    { __LINE__, WRITEDIR_1, "0000010", s_szTestDir1Kai, s_szTestDir1, DoAction7 },
-    { __LINE__, WRITEDIR_1, "0000100", s_szTestDir1, L"", DoAction8 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction9 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction10 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction11 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction12 },
-};
-
-static const TEST_ENTRY s_group_06[] =
-{
-    { __LINE__, WRITEDIR_0, "0100000", s_szTestFile0, L"", DoAction1 },
-    { __LINE__, WRITEDIR_0, "1000000", s_szTestFile0, s_szTestFile0Kai, DoAction2 },
-    { __LINE__, WRITEDIR_0, "1000000", s_szTestFile0Kai, s_szTestFile0, DoAction3 },
-    { __LINE__, WRITEDIR_0, "0010000", s_szTestFile0, L"", DoAction4 },
-    { __LINE__, WRITEDIR_0, "0001000", s_szTestDir0, L"", DoAction5 },
-    { __LINE__, WRITEDIR_0, "0000010", s_szTestDir0, s_szTestDir0Kai, DoAction6 },
-    { __LINE__, WRITEDIR_0, "0000010", s_szTestDir0Kai, s_szTestDir0, DoAction7 },
-    { __LINE__, WRITEDIR_0, "0000100", s_szTestDir0, L"", DoAction8 },
-    { __LINE__, WRITEDIR_0, "0100000", s_szTestFile0, L"", DoAction9 },
-    { __LINE__, WRITEDIR_0, "0010000", s_szTestFile0, L"", DoAction10 },
-    { __LINE__, WRITEDIR_0, "0001000", s_szTestDir0, L"", DoAction11 },
-    { __LINE__, WRITEDIR_0, "0000100", s_szTestDir0, L"", DoAction12 },
-
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction1 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction2 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction3 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction4 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction5 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction6 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction7 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction8 },
-    { __LINE__, WRITEDIR_1, "0100000", s_szTestFile1, L"", DoAction9 },
-    { __LINE__, WRITEDIR_1, "0010000", s_szTestFile1, L"", DoAction10 },
-    { __LINE__, WRITEDIR_1, "0001000", s_szTestDir1, L"", DoAction11 },
-    { __LINE__, WRITEDIR_1, "0000100", s_szTestDir1, L"", DoAction12 },
-};
-
-static const TEST_ENTRY s_group_07[] =
-{
-    { __LINE__, WRITEDIR_0, "0100000", s_szTestFile0, L"", DoAction1 },
-    { __LINE__, WRITEDIR_0, "1000000", s_szTestFile0, s_szTestFile0Kai, DoAction2 },
-    { __LINE__, WRITEDIR_0, "1000000", s_szTestFile0Kai, s_szTestFile0, DoAction3 },
-    { __LINE__, WRITEDIR_0, "0010000", s_szTestFile0, L"", DoAction4 },
-    { __LINE__, WRITEDIR_0, "0001000", s_szTestDir0, L"", DoAction5 },
-    { __LINE__, WRITEDIR_0, "0000010", s_szTestDir0, s_szTestDir0Kai, DoAction6 },
-    { __LINE__, WRITEDIR_0, "0000010", s_szTestDir0Kai, s_szTestDir0, DoAction7 },
-    { __LINE__, WRITEDIR_0, "0000100", s_szTestDir0, L"", DoAction8 },
-    { __LINE__, WRITEDIR_0, "0100000", s_szTestFile0, L"", DoAction9 },
-    { __LINE__, WRITEDIR_0, "0010000", s_szTestFile0, L"", DoAction10 },
-    { __LINE__, WRITEDIR_0, "0001000", s_szTestDir0, L"", DoAction11 },
-    { __LINE__, WRITEDIR_0, "0000100", s_szTestDir0, L"", DoAction12 },
-
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction1 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction2 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction3 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction4 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction5 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction6 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction7 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction8 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction9 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction10 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction11 },
-    { __LINE__, WRITEDIR_1, "0000000", L"", L"", DoAction12 },
-};
-
-static const TEST_ENTRY s_group_08[] =
-{
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction1 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction2 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction3 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction4 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction5 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction6 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction7 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction8 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction9 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction10 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction11 },
-    { __LINE__, WRITEDIR_0, "0000000", L"", L"", DoAction12 },
-
-    { __LINE__, WRITEDIR_1, "0100000", s_szTestFile1, L"", DoAction1 },
-    { __LINE__, WRITEDIR_1, "1000000", s_szTestFile1, s_szTestFile1Kai, DoAction2 },
-    { __LINE__, WRITEDIR_1, "1000000", s_szTestFile1Kai, s_szTestFile1, DoAction3 },
-    { __LINE__, WRITEDIR_1, "0010000", s_szTestFile1, L"", DoAction4 },
-    { __LINE__, WRITEDIR_1, "0001000", s_szTestDir1, L"", DoAction5 },
-    { __LINE__, WRITEDIR_1, "0000010", s_szTestDir1, s_szTestDir1Kai, DoAction6 },
-    { __LINE__, WRITEDIR_1, "0000010", s_szTestDir1Kai, s_szTestDir1, DoAction7 },
-    { __LINE__, WRITEDIR_1, "0000100", s_szTestDir1, L"", DoAction8 },
-    { __LINE__, WRITEDIR_1, "0100000", s_szTestFile1, L"", DoAction9 },
-    { __LINE__, WRITEDIR_1, "0010000", s_szTestFile1, L"", DoAction10 },
-    { __LINE__, WRITEDIR_1, "0001000", s_szTestDir1, L"", DoAction11 },
-    { __LINE__, WRITEDIR_1, "0000100", s_szTestDir1, L"", DoAction12 },
-};
-
-static LPCSTR PatternFromFlags(DWORD flags)
-{
-    static CHAR s_buf[(TYPE_MAX + 1) + 1];
-    for (INT i = 0; i < (TYPE_MAX + 1); ++i)
-        s_buf[i] = (char)('0' + !!(flags & (1 << i)));
-
-    s_buf[TYPE_MAX + 1] = 0;
-    return s_buf;
-}
-
-static BOOL DoGetPaths(LPWSTR pszPath1, LPWSTR pszPath2)
-{
-    pszPath1[0] = pszPath2[0] = 0;
-
-    WCHAR szText[MAX_PATH * 2];
-    szText[0] = 0;
-    FILE *fp = _wfopen(TEMP_FILE, L"rb");
-    if (fp)
-    {
-        fread(szText, 1, sizeof(szText), fp);
-        fclose(fp);
-    }
-
-    LPWSTR pch = wcschr(szText, L'|');
-    if (pch == NULL)
-        return FALSE;
-
-    *pch = 0;
-    StringCchCopyW(pszPath1, MAX_PATH, szText);
-    StringCchCopyW(pszPath2, MAX_PATH, pch + 1);
-    return TRUE;
-}
-
-static void DoTestEntry(INT iEntry, const TEST_ENTRY *entry, INT nSources)
-{
-#ifdef ENTRY_TICK
-    DWORD dwOldTick = GetTickCount();
-#endif
-
-    BOOL bInterrupting = FALSE;
-    if (entry->action)
-        bInterrupting = entry->action(entry);
-
-    DWORD flags;
-    LPCSTR pattern;
-    if ((nSources & SHCNRF_InterruptLevel) && bInterrupting)
-    {
-        // The event won't work at here. Manually waiting...
-        UINT cTry = ((iEntry == 0) ? 100 : 60);
-        for (UINT iTry = 0; iTry < cTry; ++iTry)
-        {
-            flags = SendMessageW(s_hwnd, WM_GET_NOTIFY_FLAGS, 0, 0);
-            pattern = PatternFromFlags(flags);
-            if (strcmp(pattern, "0000000") != 0)
-                break;
-
-            Sleep(1);
-        }
-    }
-    else
-    {
-        if (WaitForSingleObject(s_hEvent, 100) == WAIT_OBJECT_0)
-            Sleep(1);
-
-        flags = SendMessageW(s_hwnd, WM_GET_NOTIFY_FLAGS, 0, 0);
-        pattern = PatternFromFlags(flags);
-    }
-
-    SendMessageW(s_hwnd, WM_SET_PATHS, 0, 0);
-
-    WCHAR szPath1[MAX_PATH], szPath2[MAX_PATH];
-    szPath1[0] = szPath2[0] = 0;
-    BOOL bOK = DoGetPaths(szPath1, szPath2);
-
-    static UINT s_cCalmDown = 0;
-
-    if (pattern[TYPE_UPDATEDIR] == '1')
-    {
-        trace("Line %d: SHCNE_UPDATEDIR: Calm down (%u)...\n", entry->line, s_cCalmDown);
-
-        if (++s_cCalmDown < 3)
-            Sleep(3000);
-
-        if (entry->pattern)
-            ok(TRUE, "Line %d:\n", entry->line);
-        if (entry->path1)
-            ok(TRUE, "Line %d:\n", entry->line);
-        if (entry->path2)
-            ok(TRUE, "Line %d:\n", entry->line);
-    }
-    else
-    {
-        s_cCalmDown = 0;
-        if (entry->pattern)
-        {
-            ok(strcmp(pattern, entry->pattern) == 0,
-               "Line %d: pattern mismatch '%s', tick=0x%08lX\n",
-               entry->line, pattern, GetTickCount());
-        }
-        if (entry->path1)
-            ok(bOK && lstrcmpiW(entry->path1, szPath1) == 0,
-               "Line %d: path1 mismatch '%S' (%d)\n", entry->line, szPath1, bOK);
-        if (entry->path2)
-            ok(bOK && lstrcmpiW(entry->path2, szPath2) == 0,
-               "Line %d: path2 mismatch '%S' (%d)\n", entry->line, szPath2, bOK);
-    }
-
-    SendMessageW(s_hwnd, WM_CLEAR_FLAGS, 0, 0);
-    ResetEvent(s_hEvent);
-
-#ifdef ENTRY_TICK
-    DWORD dwNewTick = GetTickCount();
-    DWORD dwTick = dwNewTick - dwOldTick;
-    trace("DoTestEntry: Line %d: tick=%lu.%lu sec\n", entry->line,
-          (dwTick / 1000), (dwTick / 100 % 10));
-#endif
-}
-
-static void DoQuitTest(BOOL bForce)
-{
-    PostMessageW(s_hwnd, WM_COMMAND, IDOK, 0);
-
-    DoWaitForWindow(CLASSNAME, CLASSNAME, TRUE, bForce);
-    s_hwnd = NULL;
-
-    if (s_hEvent)
-    {
-        CloseHandle(s_hEvent);
-        s_hEvent = NULL;
-    }
+    PostMessageW(s_hSubWnd, WM_COMMAND, IDNO, 0);
+    DoWaitForWindow(SUB_CLASSNAME, SUB_CLASSNAME, TRUE, TRUE);
 
     DoDeleteFilesAndDirs();
-}
-
-static void DoAbortThread(void)
-{
-    skip("Aborting the thread...\n");
-    if (s_hThread)
-    {
-        TerminateThread(s_hThread, -1);
-        s_hThread = NULL;
-    }
-}
-
-static BOOL CALLBACK HandlerRoutine(DWORD dwCtrlType)
-{
-    switch (dwCtrlType)
-    {
-        case CTRL_C_EVENT:
-        case CTRL_BREAK_EVENT:
-            DoAbortThread();
-            DoQuitTest(TRUE);
-            return TRUE;
-    }
-    return FALSE;
-}
-
-static BOOL DoInitTest(void)
-{
-    // DIRTYPE_DESKTOP
-    LPWSTR psz = DoGetDir(DIRTYPE_DESKTOP);
-    StringCchCopyW(s_szDesktop, _countof(s_szDesktop), psz);
-
-    PathAppendW(psz, TEST_FILE);
-    StringCchCopyW(s_szTestFile0, _countof(s_szTestFile0), psz);
-
-    PathRemoveFileSpecW(psz);
-    PathAppendW(psz, TEST_FILE_KAI);
-    StringCchCopyW(s_szTestFile0Kai, _countof(s_szTestFile0Kai), psz);
-
-    PathRemoveFileSpecW(psz);
-    PathAppendW(psz, TEST_DIR);
-    StringCchCopyW(s_szTestDir0, _countof(s_szTestDir0), psz);
-
-    PathRemoveFileSpecW(psz);
-    PathAppendW(psz, TEST_DIR_KAI);
-    StringCchCopyW(s_szTestDir0Kai, _countof(s_szTestDir0Kai), psz);
-
-    // DIRTYPE_MYDOCUMENTS
-    psz = DoGetDir(DIRTYPE_MYDOCUMENTS);
-    StringCchCopyW(s_szDocuments, _countof(s_szDocuments), psz);
-
-    PathAppendW(psz, TEST_FILE);
-    StringCchCopyW(s_szTestFile1, _countof(s_szTestFile1), psz);
-
-    PathRemoveFileSpecW(psz);
-    PathAppendW(psz, TEST_FILE_KAI);
-    StringCchCopyW(s_szTestFile1Kai, _countof(s_szTestFile1Kai), psz);
-
-    PathRemoveFileSpecW(psz);
-    PathAppendW(psz, TEST_DIR);
-    StringCchCopyW(s_szTestDir1, _countof(s_szTestDir1), psz);
-
-    PathRemoveFileSpecW(psz);
-    PathAppendW(psz, TEST_DIR_KAI);
-    StringCchCopyW(s_szTestDir1Kai, _countof(s_szTestDir1Kai), psz);
-
-    // prepare for files and dirs
-    DoDeleteFilesAndDirs();
-    DoCreateEmptyFile(TEMP_FILE);
-
-    // Ctrl+C
-    SetConsoleCtrlHandler(HandlerRoutine, TRUE);
-
-    // close Explorer windows
-    trace("Closing Explorer windows...\n");
-    DoWaitForWindow(L"CabinetWClass", NULL, TRUE, TRUE);
-
-    // close the CLASSNAME windows
-    return DoWaitForWindow(CLASSNAME, CLASSNAME, TRUE, TRUE) == NULL;
 }
 
 static BOOL
-GetSubProgramPath(void)
+FindSubProgram(void)
 {
     GetModuleFileNameW(NULL, s_szSubProgram, _countof(s_szSubProgram));
     PathRemoveFileSpecW(s_szSubProgram);
@@ -686,258 +111,521 @@ GetSubProgramPath(void)
     return TRUE;
 }
 
-#define SRC_00 0
-#define SRC_01 SHCNRF_ShellLevel
-#define SRC_02 (SHCNRF_NewDelivery)
-#define SRC_03 (SHCNRF_NewDelivery | SHCNRF_ShellLevel)
-#define SRC_04 SHCNRF_InterruptLevel
-#define SRC_05 (SHCNRF_InterruptLevel | SHCNRF_ShellLevel)
-#define SRC_06 (SHCNRF_InterruptLevel | SHCNRF_NewDelivery)
-#define SRC_07 (SHCNRF_InterruptLevel | SHCNRF_NewDelivery | SHCNRF_ShellLevel)
-#define SRC_08 (SHCNRF_RecursiveInterrupt | SHCNRF_InterruptLevel)
-#define SRC_09 (SHCNRF_RecursiveInterrupt | SHCNRF_InterruptLevel | SHCNRF_ShellLevel)
-#define SRC_10 (SHCNRF_RecursiveInterrupt | SHCNRF_InterruptLevel | SHCNRF_NewDelivery)
-#define SRC_11 (SHCNRF_RecursiveInterrupt | SHCNRF_InterruptLevel | SHCNRF_NewDelivery | SHCNRF_ShellLevel)
-
-#define WATCHDIR_0 DIRTYPE_NULL
-#define WATCHDIR_1 DIRTYPE_DESKTOP
-#define WATCHDIR_2 DIRTYPE_MYCOMPUTER
-#define WATCHDIR_3 DIRTYPE_MYDOCUMENTS
-
-static void
-DoTestGroup(INT line, UINT cEntries, const TEST_ENTRY *pEntries, BOOL fRecursive,
-            INT nSources, DIRTYPE iWatchDir)
+static void DoBuildFilesAndDirs(void)
 {
-#ifdef NO_INTERRUPT_LEVEL
-    if (nSources & SHCNRF_InterruptLevel)
-        return;
-#endif
-#ifdef NO_SHELL_LEVEL
-    if (nSources & SHCNRF_ShellLevel)
-        return;
-#endif
-#ifdef NEW_DELIVERY_ONLY
-    if (!(nSources & SHCNRF_NewDelivery))
-        return;
-#endif
-#ifdef GROUP_TICK
-    DWORD dwOldTick = GetTickCount();
-#endif
-#ifdef RANDOM_QUARTER
-    if ((rand() & 3) == 0)
-        return;
-#elif defined(RANDOM_HALF)
-    if (rand() & 1)
-        return;
-#endif
+    WCHAR szPath1[MAX_PATH];
+    SHGetSpecialFolderPathW(NULL, szPath1, CSIDL_PERSONAL, FALSE); // My Documents
+    PathAppendW(szPath1, DIR_1);
+    StringCchCopyW(s_szDir1, _countof(s_szDir1), szPath1);
 
-    trace("DoTestGroup: Line %d: fRecursive:%u, iWatchDir:%u, nSources:0x%X\n",
-          line, fRecursive, iWatchDir, nSources);
+    PathAppendW(szPath1, DIR_1);
+    StringCchCopyW(s_szDir1InDir1, _countof(s_szDir1InDir1), szPath1);
+    PathRemoveFileSpecW(szPath1);
 
-    if (s_hEvent)
-    {
-        CloseHandle(s_hEvent);
-        s_hEvent = NULL;
-    }
-    s_hEvent = CreateEventW(NULL, TRUE, FALSE, EVENT_NAME);
+    PathAppendW(szPath1, DIR_1);
+    PathAppendW(szPath1, FILE_1);
+    StringCchCopyW(s_szFile1InDir1InDir1, _countof(s_szFile1InDir1InDir1), szPath1);
+    PathRemoveFileSpecW(szPath1);
+    PathRemoveFileSpecW(szPath1);
 
-    WCHAR szParams[64];
-    StringCchPrintfW(szParams, _countof(szParams), L"%u,%u,%u", fRecursive, iWatchDir, nSources);
+    PathAppendW(szPath1, FILE_1);
+    StringCchCopyW(s_szFile1InDir1, _countof(s_szFile1InDir1), szPath1);
+    PathRemoveFileSpecW(szPath1);
 
-    HINSTANCE hinst = ShellExecuteW(NULL, NULL, s_szSubProgram, szParams, NULL, SW_SHOWNORMAL);
-    if ((INT_PTR)hinst <= 32)
-    {
-        skip("Unable to run shell32_apitest_sub.exe.\n");
-        return;
-    }
+    PathAppendW(szPath1, FILE_2);
+    StringCchCopyW(s_szFile2InDir1, _countof(s_szFile2InDir1), szPath1);
+    PathRemoveFileSpecW(szPath1);
 
-    s_hwnd = DoWaitForWindow(CLASSNAME, CLASSNAME, FALSE, FALSE);
-    if (!s_hwnd)
-    {
-        skip("Unable to find window.\n");
-        return;
-    }
+#define TRACE_PATH(path) trace(#path ": %ls\n", path)
+    TRACE_PATH(s_szDir1);
+    TRACE_PATH(s_szDir1InDir1);
+    TRACE_PATH(s_szFile1InDir1);
+    TRACE_PATH(s_szFile1InDir1InDir1);
+    TRACE_PATH(s_szFile2InDir1);
+#undef TRACE_PATH
 
-    for (UINT i = 0; i < cEntries; ++i)
-    {
-        if (!IsWindow(s_hwnd))
-        {
-            DoAbortThread();
-            DoQuitTest(TRUE);
-            break;
-        }
+    DoDeleteFilesAndDirs();
 
-        DoTestEntry(i, &pEntries[i], nSources);
-    }
+    ::CreateDirectoryW(s_szDir1, NULL);
+    ok_int(!!PathIsDirectoryW(s_szDir1), TRUE);
 
-    DoQuitTest(FALSE);
-
-#ifdef GROUP_TICK
-    DWORD dwNewTick = GetTickCount();
-    DWORD dwTick = dwNewTick - dwOldTick;
-    trace("DoTestGroup: Line %d: %lu.%lu sec\n", line, (dwTick / 1000), (dwTick / 100 % 10));
-#endif
+    DoDeleteDirectory(s_szDir1InDir1);
+    ok_int(!PathIsDirectoryW(s_szDir1InDir1), TRUE);
 }
 
-static unsigned __stdcall TestThreadProc(void *)
+static void
+DoTestEntry(UINT uMsg, LONG lEvent, LPCITEMIDLIST pidl1, LPCITEMIDLIST pidl2)
 {
-    srand(time(NULL));
-#ifdef RANDOM_QUARTER
-    skip("RANDOM_QUARTER\n");
-#elif defined(RANDOM_HALF)
-    skip("RANDOM_HALF\n");
-#endif
+    WCHAR szPath1[MAX_PATH], szPath2[MAX_PATH];
 
-    // fRecursive == FALSE.
-    DoTestGroup(__LINE__, _countof(s_group_00), s_group_00, FALSE, SRC_00, WATCHDIR_0);
-    DoTestGroup(__LINE__, _countof(s_group_01), s_group_01, FALSE, SRC_01, WATCHDIR_0);
-    DoTestGroup(__LINE__, _countof(s_group_00), s_group_00, FALSE, SRC_02, WATCHDIR_0);
-    DoTestGroup(__LINE__, _countof(s_group_01), s_group_01, FALSE, SRC_03, WATCHDIR_0);
-    DoTestGroup(__LINE__, _countof(s_group_04), s_group_04, FALSE, SRC_04, WATCHDIR_0);
-    DoTestGroup(__LINE__, _countof(s_group_06), s_group_06, FALSE, SRC_05, WATCHDIR_0);
-    DoTestGroup(__LINE__, _countof(s_group_04), s_group_04, FALSE, SRC_06, WATCHDIR_0);
-    DoTestGroup(__LINE__, _countof(s_group_06), s_group_06, FALSE, SRC_07, WATCHDIR_0);
-    DoTestGroup(__LINE__, _countof(s_group_04), s_group_04, FALSE, SRC_08, WATCHDIR_0);
-    DoTestGroup(__LINE__, _countof(s_group_06), s_group_06, FALSE, SRC_09, WATCHDIR_0);
-    DoTestGroup(__LINE__, _countof(s_group_04), s_group_04, FALSE, SRC_10, WATCHDIR_0);
-    DoTestGroup(__LINE__, _countof(s_group_06), s_group_06, FALSE, SRC_11, WATCHDIR_0);
+    szPath1[0] = szPath2[0] = 0;
+    SHGetPathFromIDListW(pidl1, szPath1);
+    SHGetPathFromIDListW(pidl2, szPath2);
 
-    BOOL bTarget = IsWindowsXPOrGreater() && !IsWindowsVistaOrGreater();
+    trace("(0x%lX, '%ls', '%ls')\n", lEvent, szPath1, szPath2);
 
-#define SWITCH(x, y) (bTarget ? (x) : (y))
-    DoTestGroup(__LINE__, _countof(s_group_00), s_group_00, FALSE, SRC_00, WATCHDIR_1);
-    DoTestGroup(__LINE__, _countof(s_group_03), s_group_03, FALSE, SRC_01, WATCHDIR_1);
-    DoTestGroup(__LINE__, _countof(s_group_00), s_group_00, FALSE, SRC_02, WATCHDIR_1);
-    DoTestGroup(__LINE__, _countof(s_group_03), s_group_03, FALSE, SRC_03, WATCHDIR_1);
-    DoTestGroup(__LINE__, SWITCH(_countof(s_group_00), _countof(s_group_04)), SWITCH(s_group_00, s_group_04), FALSE, SRC_04, WATCHDIR_1);
-    DoTestGroup(__LINE__, _countof(s_group_07), s_group_07, FALSE, SRC_05, WATCHDIR_1);
-    DoTestGroup(__LINE__, SWITCH(_countof(s_group_00), _countof(s_group_04)), SWITCH(s_group_00, s_group_04), FALSE, SRC_06, WATCHDIR_1);
-    DoTestGroup(__LINE__, _countof(s_group_07), s_group_07, FALSE, SRC_07, WATCHDIR_1);
-    DoTestGroup(__LINE__, _countof(s_group_04), s_group_04, FALSE, SRC_08, WATCHDIR_1);
-    DoTestGroup(__LINE__, _countof(s_group_07), s_group_07, FALSE, SRC_09, WATCHDIR_1);
-    DoTestGroup(__LINE__, SWITCH(_countof(s_group_00), _countof(s_group_04)), SWITCH(s_group_00, s_group_04), FALSE, SRC_06, WATCHDIR_1);
-    DoTestGroup(__LINE__, _countof(s_group_07), s_group_07, FALSE, SRC_11, WATCHDIR_1);
-#undef SWITCH
+    if (lEvent == SHCNE_UPDATEDIR)
+    {
+        trace("Got SHCNE_UPDATEDIR\n");
+        s_bGotUpdateDir = TRUE;
+        return;
+    }
 
-#ifndef NO_TRIVIAL
-    DoTestGroup(__LINE__, _countof(s_group_00), s_group_00, FALSE, SRC_00, WATCHDIR_2);
-    DoTestGroup(__LINE__, _countof(s_group_00), s_group_00, FALSE, SRC_01, WATCHDIR_2);
-    DoTestGroup(__LINE__, _countof(s_group_00), s_group_00, FALSE, SRC_02, WATCHDIR_2);
-    DoTestGroup(__LINE__, _countof(s_group_00), s_group_00, FALSE, SRC_03, WATCHDIR_2);
-    DoTestGroup(__LINE__, _countof(s_group_00), s_group_00, FALSE, SRC_04, WATCHDIR_2);
-    DoTestGroup(__LINE__, _countof(s_group_00), s_group_00, FALSE, SRC_05, WATCHDIR_2);
-    DoTestGroup(__LINE__, _countof(s_group_00), s_group_00, FALSE, SRC_06, WATCHDIR_2);
-    DoTestGroup(__LINE__, _countof(s_group_00), s_group_00, FALSE, SRC_07, WATCHDIR_2);
-    DoTestGroup(__LINE__, _countof(s_group_00), s_group_00, FALSE, SRC_08, WATCHDIR_2);
-    DoTestGroup(__LINE__, _countof(s_group_00), s_group_00, FALSE, SRC_09, WATCHDIR_2);
-    DoTestGroup(__LINE__, _countof(s_group_00), s_group_00, FALSE, SRC_10, WATCHDIR_2);
-    DoTestGroup(__LINE__, _countof(s_group_00), s_group_00, FALSE, SRC_11, WATCHDIR_2);
-#endif
+    INT iEventType = GetEventType(lEvent);
+    if (iEventType < 0)
+        return;
 
-    DoTestGroup(__LINE__, _countof(s_group_00), s_group_00, FALSE, SRC_00, WATCHDIR_3);
-    DoTestGroup(__LINE__, _countof(s_group_02), s_group_02, FALSE, SRC_01, WATCHDIR_3);
-    DoTestGroup(__LINE__, _countof(s_group_00), s_group_00, FALSE, SRC_02, WATCHDIR_3);
-    DoTestGroup(__LINE__, _countof(s_group_02), s_group_02, FALSE, SRC_03, WATCHDIR_3);
-    DoTestGroup(__LINE__, _countof(s_group_05), s_group_05, FALSE, SRC_04, WATCHDIR_3);
-    DoTestGroup(__LINE__, _countof(s_group_08), s_group_08, FALSE, SRC_05, WATCHDIR_3);
-    DoTestGroup(__LINE__, _countof(s_group_05), s_group_05, FALSE, SRC_06, WATCHDIR_3);
-    DoTestGroup(__LINE__, _countof(s_group_08), s_group_08, FALSE, SRC_07, WATCHDIR_3);
-    DoTestGroup(__LINE__, _countof(s_group_05), s_group_05, FALSE, SRC_08, WATCHDIR_3);
-    DoTestGroup(__LINE__, _countof(s_group_08), s_group_08, FALSE, SRC_09, WATCHDIR_3);
-    DoTestGroup(__LINE__, _countof(s_group_05), s_group_05, FALSE, SRC_10, WATCHDIR_3);
-    DoTestGroup(__LINE__, _countof(s_group_08), s_group_08, FALSE, SRC_11, WATCHDIR_3);
+    assert(iEventType < MAX_EVENT_TYPE);
 
-    // fRecursive == TRUE.
-    DoTestGroup(__LINE__, _countof(s_group_00), s_group_00, TRUE, SRC_00, WATCHDIR_0);
-    DoTestGroup(__LINE__, _countof(s_group_01), s_group_01, TRUE, SRC_01, WATCHDIR_0);
-    DoTestGroup(__LINE__, _countof(s_group_00), s_group_00, TRUE, SRC_02, WATCHDIR_0);
-    DoTestGroup(__LINE__, _countof(s_group_01), s_group_01, TRUE, SRC_03, WATCHDIR_0);
-    DoTestGroup(__LINE__, _countof(s_group_04), s_group_04, TRUE, SRC_04, WATCHDIR_0);
-    DoTestGroup(__LINE__, _countof(s_group_06), s_group_06, TRUE, SRC_05, WATCHDIR_0);
-    DoTestGroup(__LINE__, _countof(s_group_04), s_group_04, TRUE, SRC_06, WATCHDIR_0);
-    DoTestGroup(__LINE__, _countof(s_group_06), s_group_06, TRUE, SRC_07, WATCHDIR_0);
-    DoTestGroup(__LINE__, _countof(s_group_04), s_group_04, TRUE, SRC_08, WATCHDIR_0);
-    DoTestGroup(__LINE__, _countof(s_group_06), s_group_06, TRUE, SRC_09, WATCHDIR_0);
-    DoTestGroup(__LINE__, _countof(s_group_04), s_group_04, TRUE, SRC_10, WATCHDIR_0);
-    DoTestGroup(__LINE__, _countof(s_group_06), s_group_06, TRUE, SRC_11, WATCHDIR_0);
+    INT i = 0;
+    s_abChecks[i++] |= (lstrcmpiW(szPath1, L"") == 0) << iEventType;
+    s_abChecks[i++] |= (lstrcmpiW(szPath1, s_szDir1) == 0) << iEventType;
+    s_abChecks[i++] |= (lstrcmpiW(szPath1, s_szFile1InDir1) == 0) << iEventType;
+    s_abChecks[i++] |= (lstrcmpiW(szPath1, s_szFile2InDir1) == 0) << iEventType;
+    s_abChecks[i++] |= (lstrcmpiW(szPath1, s_szFile1InDir1InDir1) == 0) << iEventType;
+    s_abChecks[i++] |= (lstrcmpiW(szPath2, L"") == 0) << iEventType;
+    s_abChecks[i++] |= (lstrcmpiW(szPath2, s_szDir1) == 0) << iEventType;
+    s_abChecks[i++] |= (lstrcmpiW(szPath2, s_szFile1InDir1) == 0) << iEventType;
+    s_abChecks[i++] |= (lstrcmpiW(szPath2, s_szFile2InDir1) == 0) << iEventType;
+    s_abChecks[i++] |= (lstrcmpiW(szPath2, s_szFile1InDir1InDir1) == 0) << iEventType;
+    assert(i == NUM_CHECKS);
+}
 
-    DoTestGroup(__LINE__, _countof(s_group_00), s_group_00, TRUE, SRC_00, WATCHDIR_1);
-    DoTestGroup(__LINE__, _countof(s_group_01), s_group_01, TRUE, SRC_01, WATCHDIR_1);
-    DoTestGroup(__LINE__, _countof(s_group_00), s_group_00, TRUE, SRC_02, WATCHDIR_1);
-    DoTestGroup(__LINE__, _countof(s_group_01), s_group_01, TRUE, SRC_03, WATCHDIR_1);
-    DoTestGroup(__LINE__, _countof(s_group_04), s_group_04, TRUE, SRC_04, WATCHDIR_1);
-    DoTestGroup(__LINE__, _countof(s_group_06), s_group_06, TRUE, SRC_05, WATCHDIR_1);
-    DoTestGroup(__LINE__, _countof(s_group_04), s_group_04, TRUE, SRC_06, WATCHDIR_1);
-    DoTestGroup(__LINE__, _countof(s_group_06), s_group_06, TRUE, SRC_07, WATCHDIR_1);
-    DoTestGroup(__LINE__, _countof(s_group_04), s_group_04, TRUE, SRC_08, WATCHDIR_1);
-    DoTestGroup(__LINE__, _countof(s_group_06), s_group_06, TRUE, SRC_09, WATCHDIR_1);
-    DoTestGroup(__LINE__, _countof(s_group_04), s_group_04, TRUE, SRC_10, WATCHDIR_1);
-    DoTestGroup(__LINE__, _countof(s_group_06), s_group_06, TRUE, SRC_11, WATCHDIR_1);
+LPSTR StringFromChecks(void)
+{
+    static char s_sz[2 * NUM_CHECKS + 1];
 
-    DoTestGroup(__LINE__, _countof(s_group_00), s_group_00, TRUE, SRC_00, WATCHDIR_2);
-    DoTestGroup(__LINE__, _countof(s_group_01), s_group_01, TRUE, SRC_01, WATCHDIR_2);
-    DoTestGroup(__LINE__, _countof(s_group_00), s_group_00, TRUE, SRC_02, WATCHDIR_2);
-    DoTestGroup(__LINE__, _countof(s_group_01), s_group_01, TRUE, SRC_03, WATCHDIR_2);
-    DoTestGroup(__LINE__, _countof(s_group_04), s_group_04, TRUE, SRC_04, WATCHDIR_2);
-    DoTestGroup(__LINE__, _countof(s_group_06), s_group_06, TRUE, SRC_05, WATCHDIR_2);
-    DoTestGroup(__LINE__, _countof(s_group_04), s_group_04, TRUE, SRC_06, WATCHDIR_2);
-    DoTestGroup(__LINE__, _countof(s_group_06), s_group_06, TRUE, SRC_07, WATCHDIR_2);
-    DoTestGroup(__LINE__, _countof(s_group_04), s_group_04, TRUE, SRC_08, WATCHDIR_2);
-    DoTestGroup(__LINE__, _countof(s_group_06), s_group_06, TRUE, SRC_09, WATCHDIR_2);
-    DoTestGroup(__LINE__, _countof(s_group_04), s_group_04, TRUE, SRC_10, WATCHDIR_2);
-    DoTestGroup(__LINE__, _countof(s_group_06), s_group_06, TRUE, SRC_11, WATCHDIR_2);
+    char *pch = s_sz;
+    for (INT i = 0; i < NUM_CHECKS; ++i)
+    {
+        WCHAR sz[3];
+        StringCchPrintfW(sz, _countof(sz), L"%02X", s_abChecks[i]);
+        *pch++ = sz[0];
+        *pch++ = sz[1];
+    }
 
-    DoTestGroup(__LINE__, _countof(s_group_00), s_group_00, TRUE, SRC_00, WATCHDIR_3);
-    DoTestGroup(__LINE__, _countof(s_group_02), s_group_02, TRUE, SRC_01, WATCHDIR_3);
-    DoTestGroup(__LINE__, _countof(s_group_00), s_group_00, TRUE, SRC_02, WATCHDIR_3);
-    DoTestGroup(__LINE__, _countof(s_group_02), s_group_02, TRUE, SRC_03, WATCHDIR_3);
-    DoTestGroup(__LINE__, _countof(s_group_05), s_group_05, TRUE, SRC_04, WATCHDIR_3);
-    DoTestGroup(__LINE__, _countof(s_group_08), s_group_08, TRUE, SRC_05, WATCHDIR_3);
-    DoTestGroup(__LINE__, _countof(s_group_05), s_group_05, TRUE, SRC_06, WATCHDIR_3);
-    DoTestGroup(__LINE__, _countof(s_group_08), s_group_08, TRUE, SRC_07, WATCHDIR_3);
-    DoTestGroup(__LINE__, _countof(s_group_05), s_group_05, TRUE, SRC_08, WATCHDIR_3);
-    DoTestGroup(__LINE__, _countof(s_group_08), s_group_08, TRUE, SRC_09, WATCHDIR_3);
-    DoTestGroup(__LINE__, _countof(s_group_05), s_group_05, TRUE, SRC_10, WATCHDIR_3);
-    DoTestGroup(__LINE__, _countof(s_group_08), s_group_08, TRUE, SRC_11, WATCHDIR_3);
+    assert((pch - s_sz) + 1 == sizeof(s_sz));
+
+    *pch = 0;
+    return s_sz;
+}
+
+struct TEST_DATA
+{
+    INT lineno;
+    LPCSTR vista_data;
+    LPCSTR xp_data;
+};
+
+struct TEST_ANSWER
+{
+    INT lineno;
+    LPCSTR answer;
+};
+
+static void DoStepCheck(INT iStage, INT iStep, LPCSTR checks)
+{
+    assert(0 <= iStep);
+    assert(iStep < NUM_STEP);
+
+    assert(0 <= iStage);
+    assert(iStage < NUM_STAGE);
+
+    if (s_bGotUpdateDir)
+    {
+        ok_int(TRUE, TRUE);
+        return;
+    }
+
+    LPCSTR answer = NULL;
+    INT lineno;
+    switch (iStage)
+    {
+        case 0:
+        {
+            static const TEST_ANSWER c_answers[] =
+            {
+                { __LINE__, "00000100000100000000" },
+                { __LINE__, "00000400000000000400" },
+                { __LINE__, "00000002000200000000" },
+                { __LINE__, "00000000000800000000" },
+                { __LINE__, "00000000010100000000" },
+                { __LINE__, "00000000020200000000" },
+                { __LINE__, "00000000001000000000" },
+            };
+            C_ASSERT(_countof(c_answers) == NUM_STEP);
+            lineno = c_answers[iStep].lineno;
+            answer = c_answers[iStep].answer;
+            break;
+        }
+        case 1:
+        {
+            static const TEST_ANSWER c_answers[] =
+            {
+                { __LINE__, "00000100000100000000" },
+                { __LINE__, "00000400000000000400" },
+                { __LINE__, "00000002000200000000" },
+                { __LINE__, "00000000000800000000" },
+                { __LINE__, "00000000010100000000" },
+                { __LINE__, "00000000020200000000" },
+                { __LINE__, "00000000001000000000" },
+            };
+            C_ASSERT(_countof(c_answers) == NUM_STEP);
+            lineno = c_answers[iStep].lineno;
+            answer = c_answers[iStep].answer;
+            break;
+        }
+        case 2:
+        {
+            static const TEST_ANSWER c_answers[] =
+            {
+                { __LINE__, "00000100000100000000" },
+                { __LINE__, "00000400000000000400" },
+                { __LINE__, "00000002000200000000" },
+                { __LINE__, "00000000000800000000" },
+                { __LINE__, "00000000010100000000" },
+                { __LINE__, "00000000020200000000" },
+                { __LINE__, "00000000001000000000" },
+            };
+            C_ASSERT(_countof(c_answers) == NUM_STEP);
+            lineno = c_answers[iStep].lineno;
+            answer = c_answers[iStep].answer;
+            break;
+        }
+        case 3:
+        {
+            static const TEST_ANSWER c_answers[] =
+            {
+                { __LINE__, "00000100000100000000" },
+                { __LINE__, "00000400000000000400" },
+                { __LINE__, "00000002000200000000" },
+                { __LINE__, "00000000000800000000" },
+                { __LINE__, "00000000010100000000" },
+                { __LINE__, "00000000020200000000" },
+                { __LINE__, "00000000001000000000" },
+            };
+            C_ASSERT(_countof(c_answers) == NUM_STEP);
+            lineno = c_answers[iStep].lineno;
+            answer = c_answers[iStep].answer;
+            break;
+        }
+        default:
+        {
+            assert(0);
+            break;
+        }
+    }
+
+    ok(lstrcmpA(checks, answer) == 0,
+       "Line %d: '%s' vs '%s' at Stage %d, Step %d\n", lineno, checks, answer, iStage, iStep);
+}
+
+static DWORD WINAPI StageThreadFunc(LPVOID arg)
+{
+    BOOL ret;
+
+    trace("Stage %d\n", s_iStage);
+
+    // 0: Create file1 in dir1
+    s_iStep = 0;
+    trace("Step %d\n", s_iStep);
+    ::Sleep(2000); // Extra wait
+    ZeroMemory(s_abChecks, sizeof(s_abChecks));
+    ret = DoCreateEmptyFile(s_szFile1InDir1);
+    ok_int(ret, TRUE);
+    SHChangeNotify(SHCNE_CREATE, SHCNF_PATHW | SHCNF_FLUSH | SHCNF_FLUSHNOWAIT, s_szFile1InDir1, 0);
+    ::Sleep(INTERVAL);
+    DoStepCheck(s_iStage, s_iStep, StringFromChecks());
+
+    // 1: Rename file1 as file2 in dir1
+    ++s_iStep;
+    trace("Step %d\n", s_iStep);
+    ZeroMemory(s_abChecks, sizeof(s_abChecks));
+    ret = MoveFileW(s_szFile1InDir1, s_szFile2InDir1);
+    ok_int(ret, TRUE);
+    SHChangeNotify(SHCNE_RENAMEITEM, SHCNF_PATHW | SHCNF_FLUSH | SHCNF_FLUSHNOWAIT, s_szFile1InDir1, s_szFile2InDir1);
+    ::Sleep(INTERVAL);
+    DoStepCheck(s_iStage, s_iStep, StringFromChecks());
+
+    // 2: Delete file2 in dir1
+    ++s_iStep;
+    trace("Step %d\n", s_iStep);
+    ZeroMemory(s_abChecks, sizeof(s_abChecks));
+    ret = DeleteFileW(s_szFile2InDir1);
+    ok_int(ret, TRUE);
+    SHChangeNotify(SHCNE_DELETE, SHCNF_PATHW | SHCNF_FLUSH | SHCNF_FLUSHNOWAIT, s_szFile2InDir1, NULL);
+    ::Sleep(INTERVAL);
+    DoStepCheck(s_iStage, s_iStep, StringFromChecks());
+
+    // 3: Create dir1 in dir1
+    ++s_iStep;
+    trace("Step %d\n", s_iStep);
+    ZeroMemory(s_abChecks, sizeof(s_abChecks));
+    ret = CreateDirectoryExW(s_szDir1, s_szDir1InDir1, NULL);
+    ok_int(ret, TRUE);
+    SHChangeNotify(SHCNE_MKDIR, SHCNF_PATHW | SHCNF_FLUSH | SHCNF_FLUSHNOWAIT, s_szDir1InDir1, NULL);
+    ::Sleep(INTERVAL);
+    DoStepCheck(s_iStage, s_iStep, StringFromChecks());
+
+    // 4: Create file1 in dir1 in dir1
+    ++s_iStep;
+    trace("Step %d\n", s_iStep);
+    ZeroMemory(s_abChecks, sizeof(s_abChecks));
+    ret = DoCreateEmptyFile(s_szFile1InDir1InDir1);
+    ok_int(ret, TRUE);
+    SHChangeNotify(SHCNE_CREATE, SHCNF_PATHW | SHCNF_FLUSH | SHCNF_FLUSHNOWAIT, s_szFile1InDir1InDir1, NULL);
+    ::Sleep(INTERVAL);
+    DoStepCheck(s_iStage, s_iStep, StringFromChecks());
+
+    // 5: Delete file1 in dir1 in dir1
+    ++s_iStep;
+    trace("Step %d\n", s_iStep);
+    ZeroMemory(s_abChecks, sizeof(s_abChecks));
+    ret = DeleteFileW(s_szFile1InDir1InDir1);
+    ok_int(ret, TRUE);
+    SHChangeNotify(SHCNE_DELETE, SHCNF_PATHW | SHCNF_FLUSH | SHCNF_FLUSHNOWAIT, s_szFile1InDir1InDir1, NULL);
+    ::Sleep(INTERVAL);
+    DoStepCheck(s_iStage, s_iStep, StringFromChecks());
+
+    // 6: Remove dir1 in dir1
+    ++s_iStep;
+    trace("Step %d\n", s_iStep);
+    ZeroMemory(s_abChecks, sizeof(s_abChecks));
+    ret = RemoveDirectoryW(s_szDir1InDir1);
+    ok_int(ret, TRUE);
+    SHChangeNotify(SHCNE_RMDIR, SHCNF_PATHW | SHCNF_FLUSH | SHCNF_FLUSHNOWAIT, s_szDir1InDir1, NULL);
+    ::Sleep(INTERVAL);
+    DoStepCheck(s_iStage, s_iStep, StringFromChecks());
+
+    // 7: Finish
+    ++s_iStep;
+    trace("Step %d\n", s_iStep);
+    assert(s_iStep == NUM_STEP);
+    C_ASSERT(NUM_STEP == 7);
+    ZeroMemory(s_abChecks, sizeof(s_abChecks));
+    if (s_iStage + 1 < NUM_STAGE)
+    {
+        ::PostMessage(s_hSubWnd, WM_COMMAND, IDRETRY, 0);
+    }
+    else
+    {
+        ::PostMessage(s_hSubWnd, WM_COMMAND, IDNO, 0);
+        ::PostMessage(s_hMainWnd, WM_COMMAND, IDNO, 0);
+    }
+
+    s_iStep = -1;
 
     return 0;
 }
 
-START_TEST(SHChangeNotify)
+static BOOL OnCopyData(HWND hwnd, HWND hwndSender, COPYDATASTRUCT *pCopyData)
 {
-#ifdef TOTAL_TICK
-    DWORD dwOldTick = GetTickCount();
-#endif
-#ifdef DISABLE_THIS_TESTCASE
-    skip("This testcase is disabled by DISABLE_THIS_TESTCASE macro.\n");
-    return;
-#endif
+    if (pCopyData->dwData != 0xBEEFCAFE)
+        return FALSE;
 
-    trace("Please don't operate your PC while testing...\n");
+    LPBYTE pbData = (LPBYTE)pCopyData->lpData;
 
-    if (!GetSubProgramPath())
+    LONG cbTotal = pCopyData->cbData;
+    if (cbTotal < LONG(sizeof(UINT) + sizeof(DWORD) + sizeof(DWORD)))
+    {
+        trace("\n");
+        return FALSE;
+    }
+
+    LPBYTE pb = pbData;
+
+    UINT uMsg = *(UINT*)pb;
+    pb += sizeof(uMsg);
+
+    LONG lEvent = *(LONG*)pb;
+    pb += sizeof(lEvent);
+
+    DWORD cbPidl1 = *(DWORD*)pb;
+    pb += sizeof(cbPidl1);
+
+    LPITEMIDLIST pidl1 = NULL;
+    if (cbPidl1)
+    {
+        pidl1 = (LPITEMIDLIST)CoTaskMemAlloc(cbPidl1);
+        CopyMemory(pidl1, pb, cbPidl1);
+        pb += cbPidl1;
+    }
+
+    DWORD cbPidl2 = *(DWORD*)pb;
+    pb += sizeof(cbPidl2);
+
+    LPITEMIDLIST pidl2 = NULL;
+    if (cbPidl2)
+    {
+        pidl2 = (LPITEMIDLIST)CoTaskMemAlloc(cbPidl2);
+        CopyMemory(pidl2, pb, cbPidl2);
+        pb += cbPidl2;
+    }
+
+    if ((pb - pbData) != cbTotal)
+    {
+        trace("\n");
+        return FALSE;
+    }
+
+    DoTestEntry(uMsg, lEvent, pidl1, pidl2);
+
+    CoTaskMemFree(pidl1);
+    CoTaskMemFree(pidl2);
+
+    return TRUE;
+}
+
+static LRESULT CALLBACK
+MainWndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
+{
+    switch (uMsg)
+    {
+        case WM_CREATE:
+            s_hMainWnd = hwnd;
+            return 0;
+
+        case WM_COMMAND:
+            switch (LOWORD(wParam))
+            {
+            case IDYES:
+                s_iStage = 0;
+                s_bGotUpdateDir = FALSE;
+                s_hThread = ::CreateThread(NULL, 0, StageThreadFunc, hwnd, 0, NULL);
+                if (!s_hThread)
+                {
+                    skip("!s_hThread\n");
+                    DestroyWindow(hwnd);
+                }
+                break;
+            case IDNO:
+                s_iStage = -1;
+                DestroyWindow(hwnd);
+                break;
+            case IDRETRY:
+                ::CloseHandle(s_hThread);
+                ++s_iStage;
+                s_bGotUpdateDir = FALSE;
+                s_hThread = ::CreateThread(NULL, 0, StageThreadFunc, hwnd, 0, NULL);
+                if (!s_hThread)
+                {
+                    skip("!s_hThread\n");
+                    DestroyWindow(hwnd);
+                }
+                break;
+            }
+            break;
+
+        case WM_COPYDATA:
+            if (s_iStage < 0 || s_iStep < 0)
+                break;
+            if (!OnCopyData(hwnd, (HWND)wParam, (COPYDATASTRUCT*)lParam))
+            {
+                trace("Calm down...\n");
+                ::Sleep(1000);
+            }
+            break;
+
+        case WM_DESTROY:
+            ::PostQuitMessage(0);
+            break;
+
+        default:
+            return ::DefWindowProcW(hwnd, uMsg, wParam, lParam);
+    }
+    return 0;
+}
+
+static BOOL TEST_Init(void)
+{
+    if (!FindSubProgram())
     {
         skip("shell32_apitest_sub.exe not found\n");
-        return;
+        return FALSE;
     }
 
-    if (!DoInitTest())
+    // close the SUB_CLASSNAME windows
+    DoWaitForWindow(SUB_CLASSNAME, SUB_CLASSNAME, TRUE, TRUE);
+
+    // Execute sub program
+    HINSTANCE hinst = ShellExecuteW(NULL, NULL, s_szSubProgram, L"---", NULL, SW_SHOWNORMAL);
+    if ((INT_PTR)hinst <= 32)
+    {
+        skip("Unable to run shell32_apitest_sub.exe.\n");
+        return FALSE;
+    }
+
+    // prepare for files and dirs
+    DoBuildFilesAndDirs();
+
+    // Create the window
+    WNDCLASSW wc = { 0, MainWndProc };
+    wc.hInstance = GetModuleHandleW(NULL);
+    wc.hIcon = LoadIconW(NULL, IDI_APPLICATION);
+    wc.hCursor = LoadCursorW(NULL, IDC_ARROW);
+    wc.hbrBackground = (HBRUSH)(COLOR_3DFACE + 1);
+    wc.lpszClassName = MAIN_CLASSNAME;
+    if (!RegisterClassW(&wc))
+    {
+        skip("RegisterClassW failed\n");
+        return FALSE;
+    }
+
+    HWND hwnd = CreateWindowW(MAIN_CLASSNAME, MAIN_CLASSNAME, WS_OVERLAPPEDWINDOW,
+                              CW_USEDEFAULT, CW_USEDEFAULT, 400, 100,
+                              NULL, NULL, GetModuleHandleW(NULL), NULL);
+    if (!hwnd)
+    {
+        skip("CreateWindowW failed\n");
+        return FALSE;
+    }
+
+    ::ShowWindow(hwnd, SW_SHOWNORMAL);
+    ::UpdateWindow(hwnd);
+
+    s_hSubWnd = DoWaitForWindow(SUB_CLASSNAME, SUB_CLASSNAME, FALSE, FALSE);
+    if (!s_hSubWnd)
+    {
+        skip("Unable to find sub-program window.\n");
+        return FALSE;
+    }
+
+    SendMessageW(s_hSubWnd, WM_COMMAND, IDYES, 0);
+
+    return TRUE;
+}
+
+static void TEST_Main(void)
+{
+    if (!TEST_Init())
     {
         skip("Unable to initialize.\n");
-        DoQuitTest(TRUE);
+        TEST_Quit();
         return;
     }
 
-    s_hThread = (HANDLE)_beginthreadex(NULL, 0, TestThreadProc, NULL, 0, NULL);
-    WaitForSingleObject(s_hThread, INFINITE);
-    CloseHandle(s_hThread);
+    MSG msg;
+    while (GetMessageW(&msg, NULL, 0, 0))
+    {
+        ::TranslateMessage(&msg);
+        ::DispatchMessage(&msg);
+    }
 
-#ifdef TOTAL_TICK
+    TEST_Quit();
+}
+
+START_TEST(SHChangeNotify)
+{
+    trace("Please close all Explorer windows before testing.\n");
+    trace("Please don't operate your PC while testing.\n");
+
+    trace("Calm down... 3 seconds\n");
+    ::Sleep(3000);
+
+    DWORD dwOldTick = GetTickCount();
+    TEST_Main();
     DWORD dwNewTick = GetTickCount();
+
     DWORD dwTick = dwNewTick - dwOldTick;
     trace("SHChangeNotify: Total %lu.%lu sec\n", (dwTick / 1000), (dwTick / 100 % 10));
-#endif
-
-    DoWaitForWindow(CLASSNAME, CLASSNAME, TRUE, TRUE);
-    Sleep(100);
 }

--- a/modules/rostests/apitests/shell32/SHChangeNotify.cpp
+++ b/modules/rostests/apitests/shell32/SHChangeNotify.cpp
@@ -28,7 +28,7 @@ static INT s_iStage = -1, s_iStep = -1;
 static BYTE s_abChecks[NUM_CHECKS] = { 0 };
 static BOOL s_bGotUpdateDir = FALSE;
 
-static BOOL DoCreateEmptyFile(LPCWSTR pszFileName)
+static BOOL DoCreateFile(LPCWSTR pszFileName)
 {
     HANDLE hFile = ::CreateFileW(pszFileName, GENERIC_WRITE, FILE_SHARE_READ, NULL,
                                  CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
@@ -348,7 +348,7 @@ static DWORD WINAPI StageThreadFunc(LPVOID arg)
     trace("Step %d\n", s_iStep);
     ::Sleep(2000); // Extra wait
     ZeroMemory(s_abChecks, sizeof(s_abChecks));
-    ret = DoCreateEmptyFile(s_szFile1InDir1);
+    ret = DoCreateFile(s_szFile1InDir1);
     ok_int(ret, TRUE);
     SHChangeNotify(SHCNE_CREATE, SHCNF_PATHW | SHCNF_FLUSH | SHCNF_FLUSHNOWAIT, s_szFile1InDir1, 0);
     ::Sleep(INTERVAL);
@@ -388,7 +388,7 @@ static DWORD WINAPI StageThreadFunc(LPVOID arg)
     ++s_iStep;
     trace("Step %d\n", s_iStep);
     ZeroMemory(s_abChecks, sizeof(s_abChecks));
-    ret = DoCreateEmptyFile(s_szFile1InDir1InDir1);
+    ret = DoCreateFile(s_szFile1InDir1InDir1);
     ok_int(ret, TRUE);
     SHChangeNotify(SHCNE_CREATE, SHCNF_PATHW | SHCNF_FLUSH | SHCNF_FLUSHNOWAIT, s_szFile1InDir1InDir1, NULL);
     ::Sleep(INTERVAL);

--- a/modules/rostests/apitests/shell32/SHChangeNotify.cpp
+++ b/modules/rostests/apitests/shell32/SHChangeNotify.cpp
@@ -414,10 +414,8 @@ static DWORD WINAPI StageThreadFunc(LPVOID arg)
 
     // 8: Finish
     ++s_iStep;
-    trace("Step %d\n", s_iStep);
     assert(s_iStep == NUM_STEP);
     C_ASSERT(NUM_STEP == 8);
-    ZeroMemory(s_abChecks, sizeof(s_abChecks));
     if (s_iStage + 1 < NUM_STAGE)
     {
         ::PostMessage(s_hSubWnd, WM_COMMAND, IDRETRY, 0); // Next stage

--- a/modules/rostests/apitests/shell32/SHChangeNotify.cpp
+++ b/modules/rostests/apitests/shell32/SHChangeNotify.cpp
@@ -14,7 +14,7 @@
 #include <assert.h>
 
 #define ID_TEST_START   777
-#define NUM_CHECKS      11
+#define NUM_CHECKS      12
 #define NUM_STAGE       4
 #define NUM_STEP        8
 #define INTERVAL        600
@@ -40,7 +40,7 @@ static void DoDeleteDirectory(LPCWSTR pszDir)
 {
     WCHAR szPath[MAX_PATH];
     ZeroMemory(szPath, sizeof(szPath));
-    StringCchCopyW(szPath, _countof(szPath), pszDir);
+    StringCchCopyW(szPath, _countof(szPath), pszDir); // Double-NULL terminated
     SHFILEOPSTRUCTW FileOp = { NULL, FO_DELETE, szPath, NULL, FOF_NOCONFIRMATION | FOF_SILENT };
     SHFileOperation(&FileOp);
 }
@@ -183,6 +183,7 @@ DoTestEntry(LONG lEvent, LPCITEMIDLIST pidl1, LPCITEMIDLIST pidl2)
     assert(iEventType < MAX_EVENT_TYPE);
 
     INT i = 0;
+    s_abChecks[i++] |= (lstrcmpiW(szPath1, L"") == 0) << iEventType;
     s_abChecks[i++] |= (lstrcmpiW(szPath1, s_szDir1) == 0) << iEventType;
     s_abChecks[i++] |= (lstrcmpiW(szPath1, s_szDir2InDir1) == 0) << iEventType;
     s_abChecks[i++] |= (lstrcmpiW(szPath1, s_szFile1InDir1) == 0) << iEventType;
@@ -251,14 +252,14 @@ static void DoStepCheck(INT iStage, INT iStep, LPCSTR checks)
         {
             static const TEST_ANSWER c_answers[] =
             {
-                { __LINE__, "0000010000010000000000" }, // 0
-                { __LINE__, "0000040000000000000400" }, // 1
-                { __LINE__, "0000000200020000000000" }, // 2
-                { __LINE__, "0000000000080000000000" }, // 3
-                { __LINE__, "0000000001010000000000" }, // 4
-                { __LINE__, "0000000002020000000000" }, // 5
-                { __LINE__, "0000000000000020000000" }, // 6
-                { __LINE__, "0010000000100000000000" }, // 7
+                { __LINE__, "000000010000010000000000" }, // 0
+                { __LINE__, "000000040000000000000400" }, // 1
+                { __LINE__, "000000000200020000000000" }, // 2
+                { __LINE__, "000000000000080000000000" }, // 3
+                { __LINE__, "000000000001010000000000" }, // 4
+                { __LINE__, "000000000002020000000000" }, // 5
+                { __LINE__, "000000000000000020000000" }, // 6
+                { __LINE__, "000010000000100000000000" }, // 7
             };
             C_ASSERT(_countof(c_answers) == NUM_STEP);
             lineno = c_answers[iStep].lineno;
@@ -269,14 +270,14 @@ static void DoStepCheck(INT iStage, INT iStep, LPCSTR checks)
         {
             static const TEST_ANSWER c_answers[] =
             {
-                { __LINE__, "0000010000010000000000" }, // 0
-                { __LINE__, "0000040000000000000400" }, // 1
-                { __LINE__, "0000000200020000000000" }, // 2
-                { __LINE__, "0000000000080000000000" }, // 3
-                { __LINE__, "0000000001010000000000" }, // 4
-                { __LINE__, "0000000002020000000000" }, // 5
-                { __LINE__, "0000000000000020000000" }, // 6
-                { __LINE__, "0010000000100000000000" }, // 7
+                { __LINE__, "000000010000010000000000" }, // 0
+                { __LINE__, "000000040000000000000400" }, // 1
+                { __LINE__, "000000000200020000000000" }, // 2
+                { __LINE__, "000000000000080000000000" }, // 3
+                { __LINE__, "000000000001010000000000" }, // 4
+                { __LINE__, "000000000002020000000000" }, // 5
+                { __LINE__, "000000000000000020000000" }, // 6
+                { __LINE__, "000010000000100000000000" }, // 7
             };
             C_ASSERT(_countof(c_answers) == NUM_STEP);
             lineno = c_answers[iStep].lineno;
@@ -287,22 +288,22 @@ static void DoStepCheck(INT iStage, INT iStep, LPCSTR checks)
         {
             static const TEST_ANSWER c_answers[] =
             {
-                { __LINE__, "0000010000010000000000" }, // 0
-                { __LINE__, "0000040000000000000400" }, // 1
-                { __LINE__, "0000000200020000000000" }, // 2
-                { __LINE__, "0000000000080000000000" }, // 3
-                { __LINE__, "0000000001010000000000" }, // 4 // Recursive
-                { __LINE__, "0000000002020000000000" }, // 5 // Recursive
-                { __LINE__, "0000000000000020000000" }, // 6
-                { __LINE__, "0010000000100000000000" }, // 7
+                { __LINE__, "000000010000010000000000" }, // 0
+                { __LINE__, "000000040000000000000400" }, // 1
+                { __LINE__, "000000000200020000000000" }, // 2
+                { __LINE__, "000000000000080000000000" }, // 3
+                { __LINE__, "000000000001010000000000" }, // 4 // Recursive
+                { __LINE__, "000000000002020000000000" }, // 5 // Recursive
+                { __LINE__, "000000000000000020000000" }, // 6
+                { __LINE__, "000010000000100000000000" }, // 7
             };
             C_ASSERT(_countof(c_answers) == NUM_STEP);
             lineno = c_answers[iStep].lineno;
             answer = c_answers[iStep].answer;
             if (iStep == 4 || iStep == 5) // Recursive cases
             {
-                if (lstrcmpA(checks, "0000000000000000000000") == 0)
-                    answer = "0000000000000000000000";
+                if (lstrcmpA(checks, "000000000000000000000000") == 0)
+                    answer = "000000000000000000000000";
                 else
                     trace("Warning\n");
             }
@@ -312,14 +313,14 @@ static void DoStepCheck(INT iStage, INT iStep, LPCSTR checks)
         {
             static const TEST_ANSWER c_answers[] =
             {
-                { __LINE__, "0000010000010000000000" }, // 0
-                { __LINE__, "0000040000000000000400" }, // 1
-                { __LINE__, "0000000200020000000000" }, // 2
-                { __LINE__, "0000000000080000000000" }, // 3
-                { __LINE__, "0000000001010000000000" }, // 4 // Recursive
-                { __LINE__, "0000000002020000000000" }, // 5 // Recursive
-                { __LINE__, "0000000000000020000000" }, // 6
-                { __LINE__, "0010000000100000000000" }, // 7
+                { __LINE__, "000000010000010000000000" }, // 0
+                { __LINE__, "000000040000000000000400" }, // 1
+                { __LINE__, "000000000200020000000000" }, // 2
+                { __LINE__, "000000000000080000000000" }, // 3
+                { __LINE__, "000000000001010000000000" }, // 4 // Recursive
+                { __LINE__, "000000000002020000000000" }, // 5 // Recursive
+                { __LINE__, "000000000000000020000000" }, // 6
+                { __LINE__, "000010000000100000000000" }, // 7
             };
             C_ASSERT(_countof(c_answers) == NUM_STEP);
             lineno = c_answers[iStep].lineno;
@@ -537,7 +538,7 @@ MainWndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
                     }
                     break;
                 }
-                case IDNO: // Finish
+                case IDNO: // Quit
                 {
                     s_iStage = -1;
                     DestroyWindow(hwnd);

--- a/modules/rostests/apitests/shell32/SHChangeNotify.cpp
+++ b/modules/rostests/apitests/shell32/SHChangeNotify.cpp
@@ -257,8 +257,8 @@ static void DoStepCheck(INT iStage, INT iStep, LPCSTR checks)
                 { __LINE__, "0000000000080000000000" }, // 3
                 { __LINE__, "0000000001010000000000" }, // 4
                 { __LINE__, "0000000002020000000000" }, // 5
-                { __LINE__, "0000000000100000000000" }, // 6
-                { __LINE__, "0000000000100000000000" }, // 7
+                { __LINE__, "0000000000000020000000" }, // 6
+                { __LINE__, "0010000000100000000000" }, // 7
             };
             C_ASSERT(_countof(c_answers) == NUM_STEP);
             lineno = c_answers[iStep].lineno;
@@ -275,8 +275,8 @@ static void DoStepCheck(INT iStage, INT iStep, LPCSTR checks)
                 { __LINE__, "0000000000080000000000" }, // 3
                 { __LINE__, "0000000001010000000000" }, // 4
                 { __LINE__, "0000000002020000000000" }, // 5
-                { __LINE__, "0000000000100000000000" }, // 6
-                { __LINE__, "0000000000100000000000" }, // 7
+                { __LINE__, "0000000000000020000000" }, // 6
+                { __LINE__, "0010000000100000000000" }, // 7
             };
             C_ASSERT(_countof(c_answers) == NUM_STEP);
             lineno = c_answers[iStep].lineno;
@@ -293,8 +293,8 @@ static void DoStepCheck(INT iStage, INT iStep, LPCSTR checks)
                 { __LINE__, "0000000000080000000000" }, // 3
                 { __LINE__, "0000000001010000000000" }, // 4 // Recursive
                 { __LINE__, "0000000002020000000000" }, // 5 // Recursive
-                { __LINE__, "0000000000100000000000" }, // 6
-                { __LINE__, "0000000000100000000000" }, // 7
+                { __LINE__, "0000000000000020000000" }, // 6
+                { __LINE__, "0010000000100000000000" }, // 7
             };
             C_ASSERT(_countof(c_answers) == NUM_STEP);
             lineno = c_answers[iStep].lineno;
@@ -318,8 +318,8 @@ static void DoStepCheck(INT iStage, INT iStep, LPCSTR checks)
                 { __LINE__, "0000000000080000000000" }, // 3
                 { __LINE__, "0000000001010000000000" }, // 4 // Recursive
                 { __LINE__, "0000000002020000000000" }, // 5 // Recursive
-                { __LINE__, "0000000000100000000000" }, // 6
-                { __LINE__, "0000000000100000000000" }, // 7
+                { __LINE__, "0000000000000020000000" }, // 6
+                { __LINE__, "0010000000100000000000" }, // 7
             };
             C_ASSERT(_countof(c_answers) == NUM_STEP);
             lineno = c_answers[iStep].lineno;
@@ -346,7 +346,7 @@ static DWORD WINAPI StageThreadFunc(LPVOID arg)
     // 0: Create file1 in dir1
     s_iStep = 0;
     trace("Step %d\n", s_iStep);
-    ::Sleep(2000); // Extra wait
+    ::Sleep(1000); // Extra wait
     ZeroMemory(s_abChecks, sizeof(s_abChecks));
     ret = DoCreateFile(s_szFile1InDir1);
     ok_int(ret, TRUE);
@@ -410,7 +410,7 @@ static DWORD WINAPI StageThreadFunc(LPVOID arg)
     ZeroMemory(s_abChecks, sizeof(s_abChecks));
     ret = ::MoveFileW(s_szDir1InDir1, s_szDir2InDir1);
     ok_int(ret, TRUE);
-    SHChangeNotify(SHCNE_RMDIR, SHCNF_PATHW | SHCNF_FLUSH | SHCNF_FLUSHNOWAIT, s_szDir1InDir1, NULL);
+    SHChangeNotify(SHCNE_RENAMEFOLDER, SHCNF_PATHW | SHCNF_FLUSH | SHCNF_FLUSHNOWAIT, s_szDir1InDir1, s_szDir2InDir1);
     ::Sleep(INTERVAL);
     DoStepCheck(s_iStage, s_iStep, StringFromChecks());
 
@@ -420,7 +420,7 @@ static DWORD WINAPI StageThreadFunc(LPVOID arg)
     ZeroMemory(s_abChecks, sizeof(s_abChecks));
     ret = RemoveDirectoryW(s_szDir2InDir1);
     ok_int(ret, TRUE);
-    SHChangeNotify(SHCNE_RMDIR, SHCNF_PATHW | SHCNF_FLUSH | SHCNF_FLUSHNOWAIT, s_szDir1InDir1, NULL);
+    SHChangeNotify(SHCNE_RMDIR, SHCNF_PATHW | SHCNF_FLUSH | SHCNF_FLUSHNOWAIT, s_szDir2InDir1, NULL);
     ::Sleep(INTERVAL);
     DoStepCheck(s_iStage, s_iStep, StringFromChecks());
 

--- a/modules/rostests/apitests/shell32/SHChangeNotify.cpp
+++ b/modules/rostests/apitests/shell32/SHChangeNotify.cpp
@@ -616,9 +616,6 @@ START_TEST(SHChangeNotify)
     trace("Please close all Explorer windows before testing.\n");
     trace("Please don't operate your PC while testing.\n");
 
-    trace("Calm down... 3 seconds\n");
-    ::Sleep(3000);
-
     DWORD dwOldTick = GetTickCount();
     TEST_Main();
     DWORD dwNewTick = GetTickCount();

--- a/modules/rostests/apitests/shell32/ShellExecCmdLine.cpp
+++ b/modules/rostests/apitests/shell32/ShellExecCmdLine.cpp
@@ -747,6 +747,6 @@ START_TEST(ShellExecCmdLine)
     ok(DeleteFileA("Test File 2.bat"), "failed to delete the test file\n");
     free(s_wi0.phwnd);
 
-    DoWaitForWindow(CLASSNAME, CLASSNAME, TRUE, TRUE);
+    DoWaitForWindow(SUB_CLASSNAME, SUB_CLASSNAME, TRUE, TRUE);
     Sleep(100);
 }

--- a/modules/rostests/apitests/shell32/shell32_apitest_sub.cpp
+++ b/modules/rostests/apitests/shell32/shell32_apitest_sub.cpp
@@ -83,30 +83,39 @@ static BOOL InitHook(HWND hwnd)
     LONG events;
     switch (s_iStage)
     {
-    case 0:
-        entry.fRecursive = TRUE;
-        entry.pidl = s_pidl[DIRTYPE_DESKTOP];
-        sources = SHCNRF_NewDelivery | SHCNRF_InterruptLevel | SHCNRF_ShellLevel | SHCNRF_RecursiveInterrupt;
-        events = EVENTS;
-        break;
-    case 1:
-        entry.fRecursive = TRUE;
-        entry.pidl = s_pidl[DIRTYPE_DRIVES];
-        sources = SHCNRF_NewDelivery | SHCNRF_InterruptLevel | SHCNRF_ShellLevel | SHCNRF_RecursiveInterrupt;
-        events = EVENTS;
-        break;
-    case 2:
-        entry.fRecursive = FALSE;
-        entry.pidl = s_pidl[DIRTYPE_DIR1];
-        sources = SHCNRF_NewDelivery | SHCNRF_InterruptLevel | SHCNRF_ShellLevel;
-        events = EVENTS;
-        break;
-    case 3:
-        entry.fRecursive = TRUE;
-        entry.pidl = s_pidl[DIRTYPE_DIR1];
-        sources = SHCNRF_NewDelivery | SHCNRF_InterruptLevel | SHCNRF_ShellLevel | SHCNRF_RecursiveInterrupt;
-        events = EVENTS;
-        break;
+        case 0:
+        {
+            entry.fRecursive = TRUE;
+            entry.pidl = s_pidl[DIRTYPE_DESKTOP];
+            sources = SHCNRF_NewDelivery | SHCNRF_ShellLevel;
+            events = EVENTS;
+            break;
+        }
+        case 1:
+        {
+            entry.fRecursive = TRUE;
+            entry.pidl = s_pidl[DIRTYPE_DRIVES];
+            sources = SHCNRF_NewDelivery | SHCNRF_ShellLevel;
+            events = EVENTS;
+            break;
+        }
+        case 2:
+        {
+            entry.fRecursive = FALSE;
+            entry.pidl = s_pidl[DIRTYPE_DIR1];
+            sources = SHCNRF_NewDelivery | SHCNRF_ShellLevel;
+            events = EVENTS;
+            break;
+        }
+        case 3:
+        {
+            entry.fRecursive = TRUE;
+            entry.pidl = s_pidl[DIRTYPE_DIR1];
+            sources = SHCNRF_NewDelivery | SHCNRF_ShellLevel | SHCNRF_InterruptLevel |
+                      SHCNRF_RecursiveInterrupt;
+            events = EVENTS;
+            break;
+        }
     }
 
     s_uRegID = SHChangeNotifyRegister(hwnd, sources, events, WM_SHELL_NOTIFY, 1, &entry);
@@ -133,12 +142,13 @@ OnCommand(HWND hwnd, UINT id)
         case IDOK:
         case IDCANCEL:
         case IDNO:
+            // Quit
             s_iStage = -1;
             UninitHook(hwnd);
             ::DestroyWindow(hwnd);
             break;
 
-        case IDYES:
+        case IDYES: // Start testing
             s_hMainWnd = ::FindWindow(MAIN_CLASSNAME, MAIN_CLASSNAME);
             if (!s_hMainWnd)
             {
@@ -150,7 +160,7 @@ OnCommand(HWND hwnd, UINT id)
             ::PostMessageW(s_hMainWnd, WM_COMMAND, IDYES, 0);
             break;
 
-        case IDRETRY:
+        case IDRETRY: // New stage
             UninitHook(hwnd);
             ++s_iStage;
             InitHook(hwnd);

--- a/modules/rostests/apitests/shell32/shell32_apitest_sub.cpp
+++ b/modules/rostests/apitests/shell32/shell32_apitest_sub.cpp
@@ -53,6 +53,7 @@ inline LPITEMIDLIST DoGetPidl(INT iDir)
         }
         default:
         {
+            assert(0);
             break;
         }
     }

--- a/modules/rostests/apitests/shell32/shell32_apitest_sub.cpp
+++ b/modules/rostests/apitests/shell32/shell32_apitest_sub.cpp
@@ -9,9 +9,6 @@
 #include "shell32_apitest_sub.h"
 #include <assert.h>
 
-static HWND s_hMainWnd = NULL;
-static HWND s_hSubWnd = NULL;
-
 typedef enum DIRTYPE
 {
     DIRTYPE_DESKTOP = 0,
@@ -20,6 +17,7 @@ typedef enum DIRTYPE
     DIRTYPE_MAX
 } DIRTYPE;
 
+static HWND s_hMainWnd = NULL, s_hSubWnd = NULL;
 static LPITEMIDLIST s_pidl[DIRTYPE_MAX];
 static UINT s_uRegID = 0;
 static INT s_iStage = -1;
@@ -139,16 +137,8 @@ OnCommand(HWND hwnd, UINT id)
 {
     switch (id)
     {
-        case IDOK:
-        case IDCANCEL:
-        case IDNO:
-            // Quit
-            s_iStage = -1;
-            UninitHook(hwnd);
-            ::DestroyWindow(hwnd);
-            break;
-
         case IDYES: // Start testing
+        {
             s_hMainWnd = ::FindWindow(MAIN_CLASSNAME, MAIN_CLASSNAME);
             if (!s_hMainWnd)
             {
@@ -159,13 +149,22 @@ OnCommand(HWND hwnd, UINT id)
             InitHook(hwnd);
             ::PostMessageW(s_hMainWnd, WM_COMMAND, IDYES, 0);
             break;
-
+        }
         case IDRETRY: // New stage
+        {
             UninitHook(hwnd);
             ++s_iStage;
             InitHook(hwnd);
             ::PostMessageW(s_hMainWnd, WM_COMMAND, IDRETRY, 0);
             break;
+        }
+        case IDNO: // Quit
+        {
+            s_iStage = -1;
+            UninitHook(hwnd);
+            ::DestroyWindow(hwnd);
+            break;
+        }
     }
 }
 
@@ -179,6 +178,8 @@ OnDestroy(HWND hwnd)
         CoTaskMemFree(pidl);
         pidl = NULL;
     }
+
+    ::PostMessageW(s_hMainWnd, WM_COMMAND, IDNO, 0);
 
     PostQuitMessage(0);
 }

--- a/modules/rostests/apitests/shell32/shell32_apitest_sub.h
+++ b/modules/rostests/apitests/shell32/shell32_apitest_sub.h
@@ -5,72 +5,10 @@
 #include <stdio.h>
 #include <strsafe.h>
 
-#define TEMP_FILE   L"shell-notify-temporary.txt"
-#define CLASSNAME   L"SHChangeNotify testcase window"
-#define EVENT_NAME  L"SHChangeNotify testcase event"
+#define MAIN_CLASSNAME   L"SHChangeNotify main window"
+#define SUB_CLASSNAME    L"SHChangeNotify sub-window"
 
 #define WM_SHELL_NOTIFY     (WM_USER + 100)
-#define WM_GET_NOTIFY_FLAGS (WM_USER + 101)
-#define WM_CLEAR_FLAGS      (WM_USER + 102)
-#define WM_SET_PATHS        (WM_USER + 103)
-
-typedef enum TYPE
-{
-    TYPE_RENAMEITEM,
-    TYPE_CREATE,
-    TYPE_DELETE,
-    TYPE_MKDIR,
-    TYPE_RMDIR,
-    TYPE_RENAMEFOLDER,
-    TYPE_UPDATEDIR,
-    TYPE_MAX = TYPE_UPDATEDIR
-} TYPE;
-
-typedef enum DIRTYPE
-{
-    DIRTYPE_NULL = 0,
-    DIRTYPE_DESKTOP,
-    DIRTYPE_MYCOMPUTER,
-    DIRTYPE_MYDOCUMENTS
-} DIRTYPE;
-
-inline LPITEMIDLIST DoGetPidl(DIRTYPE iDir)
-{
-    LPITEMIDLIST ret = NULL;
-
-    switch (iDir)
-    {
-        case DIRTYPE_NULL:
-            break;
-
-        case DIRTYPE_DESKTOP:
-            SHGetSpecialFolderLocation(NULL, CSIDL_DESKTOP, &ret);
-            break;
-
-        case DIRTYPE_MYCOMPUTER:
-            SHGetSpecialFolderLocation(NULL, CSIDL_DRIVES, &ret);
-            break;
-
-        case DIRTYPE_MYDOCUMENTS:
-            SHGetSpecialFolderLocation(NULL, CSIDL_PERSONAL, &ret);
-            break;
-    }
-
-    return ret;
-}
-
-static inline LPWSTR DoGetDir(DIRTYPE iDir)
-{
-    static size_t s_index = 0;
-    static WCHAR s_pathes[3][MAX_PATH];
-    LPWSTR psz = s_pathes[s_index];
-    LPITEMIDLIST pidl = DoGetPidl(iDir);
-    psz[0] = 0;
-    SHGetPathFromIDListW(pidl, psz);
-    CoTaskMemFree(pidl);
-    s_index = (s_index + 1) % _countof(s_pathes);
-    return psz;
-}
 
 static inline HWND DoWaitForWindow(LPCWSTR clsname, LPCWSTR text, BOOL bClosing, BOOL bForce)
 {


### PR DESCRIPTION
## Purpose

Make the testcase more stable and faster. Reduce code.
JIRA issue: [CORE-13950](https://jira.reactos.org/browse/CORE-13950)

## Proposed changes

- Use `WM_COPYDATA` message to communicate with `shell32_apitest_sub.exe`.
- Use concept of "stage" and "step".
- Do multiple checks in one step.
- Flush notification by using `(SHCNF_FLUSH | SHCNF_FLUSHNOWAIT)` flags.

## TODO

- [x] Do tests.

## Comparison

WinXP:
![WinXP](https://github.com/reactos/reactos/assets/2107452/1eea9210-91bb-45d9-b3d8-6956cf2056f8)
Successful. Double checked. About 25 seconds.

Win2k3:
![Win2k3](https://github.com/reactos/reactos/assets/2107452/5c079e54-e18c-40b2-9480-2bdceeb608eb)
Successful. Double checked. About 25 seconds.

Win10 x64:
![Win10](https://github.com/reactos/reactos/assets/2107452/972e70eb-567d-42a4-9767-a416a164a990)
Successful. Double checked. About 25 seconds.