### PR TITLE
[MSVCRTEX] Only include _CrtDbgReport*, if we don't already export them

### DIFF
--- a/sdk/lib/crt/except/amd64/chkstk_ms.s
+++ b/sdk/lib/crt/except/amd64/chkstk_ms.s
@@ -16,9 +16,11 @@
 .code64
 
 PUBLIC __chkstk
+PUBLIC ___chkstk_ms
 PUBLIC __alloca_probe
 
 __alloca_probe:
+___chkstk_ms:
 .PROC __chkstk
 
     push rcx                    /* save temps */

--- a/sdk/lib/crt/msvcrtex.cmake
+++ b/sdk/lib/crt/msvcrtex.cmake
@@ -4,7 +4,6 @@ include_directories(include/internal/mingw-w64)
 list(APPEND MSVCRTEX_SOURCE
     ${CRT_STARTUP_SOURCE}
     math/sincos.c
-    misc/dbgrpt.cpp
     misc/fltused.c
     misc/isblank.c
     misc/iswblank.c
@@ -13,6 +12,7 @@ list(APPEND MSVCRTEX_SOURCE
 
 if(DLL_EXPORT_VERSION LESS 0x600)
     list(APPEND MSVCRTEX_SOURCE
+        misc/dbgrpt.cpp
         stdlib/_invalid_parameter.c
         stdlib/rand_s.c
     )


### PR DESCRIPTION
## Purpose

 Only include _CrtDbgReport*, if we don't already export them
Fixes duplcate symbol warning.
