### PR TITLE
[COMCTL32] Fix header redraw glitches when resizing

### DIFF
--- a/dll/win32/comctl32/header.c
+++ b/dll/win32/comctl32/header.c
@@ -1963,7 +1963,6 @@ HEADER_MouseMove (HEADER_INFO *infoPtr, LPARAM lParam)
                     ScrollWindowEx(infoPtr->hwndSelf, nWidth - nOldWidth, 0, &rcScroll, &rcClient, NULL, NULL, 0);
                     InvalidateRect(infoPtr->hwndSelf, &lpItem->rect, FALSE);
 #endif
-                        NULL, NULL, SW_INVALIDATE);
                     UpdateWindow(infoPtr->hwndSelf);
                     
                     HEADER_SendNotifyWithIntFieldT(infoPtr, HDN_ITEMCHANGEDW, infoPtr->iMoveItem, HDI_WIDTH, nWidth);

--- a/dll/win32/comctl32/header.c
+++ b/dll/win32/comctl32/header.c
@@ -1954,7 +1954,13 @@ HEADER_MouseMove (HEADER_INFO *infoPtr, LPARAM lParam)
                     GetClientRect(infoPtr->hwndSelf, &rcClient);
                     rcScroll = rcClient;
                     rcScroll.left = lpItem->rect.left + nOldWidth;
+#ifdef __REACTOS__
                     ScrollWindowEx(infoPtr->hwndSelf, nWidth - nOldWidth, 0, &rcScroll, &rcClient,
+                                   NULL, NULL, SW_INVALIDATE);
+#else
+                    ScrollWindowEx(infoPtr->hwndSelf, nWidth - nOldWidth, 0, &rcScroll, &rcClient, NULL, NULL, 0);
+                    InvalidateRect(infoPtr->hwndSelf, &lpItem->rect, FALSE);
+#endif
                         NULL, NULL, SW_INVALIDATE);
                     UpdateWindow(infoPtr->hwndSelf);
                     

--- a/dll/win32/comctl32/header.c
+++ b/dll/win32/comctl32/header.c
@@ -1948,7 +1948,9 @@ HEADER_MouseMove (HEADER_INFO *infoPtr, LPARAM lParam)
                     
                     if (nWidth < 0) nWidth = 0;
                     infoPtr->items[infoPtr->iMoveItem].cxy = nWidth;
+#ifdef __REACTOS__
                     InvalidateRect(infoPtr->hwndSelf, &lpItem->rect, FALSE);
+#endif
                     HEADER_SetItemBounds(infoPtr);
                     
                     GetClientRect(infoPtr->hwndSelf, &rcClient);

--- a/dll/win32/comctl32/header.c
+++ b/dll/win32/comctl32/header.c
@@ -1948,13 +1948,14 @@ HEADER_MouseMove (HEADER_INFO *infoPtr, LPARAM lParam)
                     
                     if (nWidth < 0) nWidth = 0;
                     infoPtr->items[infoPtr->iMoveItem].cxy = nWidth;
+                    InvalidateRect(infoPtr->hwndSelf, &lpItem->rect, FALSE);
                     HEADER_SetItemBounds(infoPtr);
                     
                     GetClientRect(infoPtr->hwndSelf, &rcClient);
                     rcScroll = rcClient;
                     rcScroll.left = lpItem->rect.left + nOldWidth;
-                    ScrollWindowEx(infoPtr->hwndSelf, nWidth - nOldWidth, 0, &rcScroll, &rcClient, NULL, NULL, 0);
-                    InvalidateRect(infoPtr->hwndSelf, &lpItem->rect, FALSE);
+                    ScrollWindowEx(infoPtr->hwndSelf, nWidth - nOldWidth, 0, &rcScroll, &rcClient,
+                        NULL, NULL, SW_INVALIDATE);
                     UpdateWindow(infoPtr->hwndSelf);
                     
                     HEADER_SendNotifyWithIntFieldT(infoPtr, HDN_ITEMCHANGEDW, infoPtr->iMoveItem, HDI_WIDTH, nWidth);


### PR DESCRIPTION
## Purpose

- Fix COMCTL32 headers from being garbage text when resizing while drawn off screen.

JIRA issue: [CORE-19404](https://jira.reactos.org/browse/CORE-19404)

## Proposed changes

- Invalidate header item rect before scrolling to prevent the divider from being redrawn over and over.
- Invalidate header item text through adding flag SW_INVALIDATE to ScrollWindowEx call to prevent the text from being redrawn over and over.

Before:
![before](https://github.com/reactos/reactos/assets/65135562/d0a1491e-2436-4949-ac91-c26b2fe500a9)

After:
![after](https://github.com/reactos/reactos/assets/65135562/85cd830c-9953-438f-b038-5ea0bec10376)