### PR TITLE
Revert "[SHELL32] SHChangeNotify: Use tree for CDirectoryList"

### DIFF
--- a/dll/win32/shell32/shelldesktop/CDirectoryWatcher.cpp
+++ b/dll/win32/shell32/shelldesktop/CDirectoryWatcher.cpp
@@ -71,7 +71,7 @@ static void NTAPI _RequestAllTerminationAPC(ULONG_PTR Parameter)
 CDirectoryWatcher::CDirectoryWatcher(LPCWSTR pszDirectoryPath, BOOL fSubTree)
     : m_fDead(FALSE)
     , m_fRecursive(fSubTree)
-    , m_dir_list(NULL, pszDirectoryPath, fSubTree)
+    , m_dir_list(pszDirectoryPath, fSubTree)
 {
     TRACE("CDirectoryWatcher::CDirectoryWatcher: %p, '%S'\n", this, pszDirectoryPath);
 


### PR DESCRIPTION
Reverts reactos/reactos#6784 that was a guilty commit of CORE-19531 that causing performance regression. 

JIRA issue: [CORE-19531](https://jira.reactos.org/browse/CORE-19531)