### PR TITLE
[KERNEL32_APITEST] Add LCMapString testcase

### DIFF
--- a/modules/rostests/apitests/kernel32/CMakeLists.txt
+++ b/modules/rostests/apitests/kernel32/CMakeLists.txt
@@ -22,6 +22,7 @@ list(APPEND SOURCE
     interlck.c
     IsDBCSLeadByteEx.c
     JapaneseCalendar.c
+    LCMapString.c
     LoadLibraryExW.c
     lstrcpynW.c
     lstrlen.c

--- a/modules/rostests/apitests/kernel32/LCMapString.c
+++ b/modules/rostests/apitests/kernel32/LCMapString.c
@@ -1,0 +1,58 @@
+/*
+ * PROJECT:     ReactOS api tests
+ * LICENSE:     LGPL-2.0-or-later (https://spdx.org/licenses/LGPL-2.0-or-later)
+ * PURPOSE:     Tests for LCMapString
+ * COPYRIGHT:   Copyright 2024 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
+ */
+
+#include "precomp.h"
+
+#undef ok_wstr_
+void ok_wstr_(const char *file, int line, LPCWSTR x, LPCWSTR y)
+{
+    char buf1[100], buf2[100];
+    lstrcpynA(buf1, wine_dbgstr_w(x), _countof(buf1));
+    lstrcpynA(buf2, wine_dbgstr_w(y), _countof(buf2));
+    ok_(file, line)(wcscmp(x, y) == 0, "Wrong string. Expected %s, got %s\n", buf2, buf1);
+}
+
+#undef ok_wstr
+#define ok_wstr(x, y)     ok_wstr_(__FILE__, __LINE__, x, y)
+
+// "ABab12ＡＢａｂ１２あアばバﾊﾟ万萬" in UTF-16
+static const WCHAR c_target[] =
+    L"ABab12\xff21\xff22\xff41\xff42\xff11\xff12\x3042\x30a2\x3070\x30d0\xff8a\xff9f\x4e07\x842c";
+
+static void TEST_LCMapStringW(void)
+{
+    WCHAR results[100];
+
+    LCMapStringW(0, LCMAP_FULLWIDTH, c_target, -1, results, _countof(results));
+    ok_wstr(results, L"\xff21\xff22\xff41\xff42\xff11\xff12\xff21\xff22\xff41\xff42\xff11\xff12\x3042\x30a2\x3070\x30d0\x30d1\x4e07\x842c");
+
+    LCMapStringW(0, LCMAP_HALFWIDTH, c_target, -1, results, _countof(results));
+    ok_wstr(results, L"ABab12ABab12\x3042\xff71\x3070\xff8a\xff9e\xff8a\xff9f\x4e07\x842c");
+
+    LCMapStringW(0, LCMAP_HIRAGANA, c_target, -1, results, _countof(results));
+    ok_wstr(results, L"ABab12\xff21\xff22\xff41\xff42\xff11\xff12\x3042\x3042\x3070\x3070\xff8a\xff9f\x4e07\x842c");
+
+    LCMapStringW(0, LCMAP_KATAKANA, c_target, -1, results, _countof(results));
+    ok_wstr(results, L"ABab12\xff21\xff22\xff41\xff42\xff11\xff12\x30a2\x30a2\x30d0\x30d0\xff8a\xff9f\x4e07\x842c");
+
+    LCMapStringW(0, LCMAP_LOWERCASE, c_target, -1, results, _countof(results));
+    ok_wstr(results, L"abab12\xff41\xff42\xff41\xff42\xff11\xff12\x3042\x30a2\x3070\x30d0\xff8a\xff9f\x4e07\x842c");
+
+    LCMapStringW(0, LCMAP_UPPERCASE, c_target, -1, results, _countof(results));
+    ok_wstr(results, L"ABAB12\xff21\xff22\xff21\xff22\xff11\xff12\x3042\x30a2\x3070\x30d0\xff8a\xff9f\x4e07\x842c");
+
+    LCMapStringW(0, LCMAP_SIMPLIFIED_CHINESE, c_target, -1, results, _countof(results));
+    ok_wstr(results, L"ABab12\xff21\xff22\xff41\xff42\xff11\xff12\x3042\x30a2\x3070\x30d0\xff8a\xff9f\x4e07\x4e07");
+
+    LCMapStringW(0, LCMAP_TRADITIONAL_CHINESE, c_target, -1, results, _countof(results));
+    ok_wstr(results, L"ABab12\xff21\xff22\xff41\xff42\xff11\xff12\x3042\x30a2\x3070\x30d0\xff8a\xff9f\x842c\x842c");
+}
+
+START_TEST(LCMapString)
+{
+    TEST_LCMapStringW();
+}

--- a/modules/rostests/apitests/kernel32/LCMapString.c
+++ b/modules/rostests/apitests/kernel32/LCMapString.c
@@ -8,7 +8,9 @@
 #include "precomp.h"
 
 #undef ok_wstr_
-void ok_wstr_(const char *file, int line, LPCWSTR x, LPCWSTR y)
+
+static void
+ok_wstr_(const char *file, int line, LPCWSTR x, LPCWSTR y)
 {
     char buf1[100], buf2[100];
     lstrcpynA(buf1, wine_dbgstr_w(x), _countof(buf1));

--- a/modules/rostests/apitests/kernel32/testlist.c
+++ b/modules/rostests/apitests/kernel32/testlist.c
@@ -22,6 +22,7 @@ extern void func_InitOnce(void);
 extern void func_interlck(void);
 extern void func_IsDBCSLeadByteEx(void);
 extern void func_JapaneseCalendar(void);
+extern void func_LCMapString(void);
 extern void func_LoadLibraryExW(void);
 extern void func_lstrcpynW(void);
 extern void func_lstrlen(void);
@@ -59,6 +60,7 @@ const struct test winetest_testlist[] =
     { "interlck",                    func_interlck },
     { "IsDBCSLeadByteEx",            func_IsDBCSLeadByteEx },
     { "JapaneseCalendar",            func_JapaneseCalendar },
+    { "LCMapString",                 func_LCMapString },
     { "LoadLibraryExW",              func_LoadLibraryExW },
     { "lstrcpynW",                   func_lstrcpynW },
     { "lstrlen",                     func_lstrlen },


### PR DESCRIPTION
## Purpose

@tkreuzer said he wants `LCMapString` testcase in chat.

JIRA issue: N/A

## Proposed changes

- Add `LCMapString` testcase.

## TODO

- [x] Do tests.

## Comparison

WinXP:
![WInXP](https://github.com/reactos/reactos/assets/2107452/8b109349-792c-4fa5-b53d-b044b6233bd7)
Successful.

Win2k3:
![Win2k3](https://github.com/reactos/reactos/assets/2107452/fe7f649b-15bc-427b-ab14-4b9239be0618)
Successful.

Win10 x64:
![Win10](https://github.com/reactos/reactos/assets/2107452/78f1cdbb-e733-4f75-87f8-569298404969)
Successful.