### PR TITLE
[NTDLL_APITEST] Use `RtlConvertUlongToLuid`

### DIFF
--- a/modules/rostests/apitests/ntdll/NtAdjustPrivilegesToken.c
+++ b/modules/rostests/apitests/ntdll/NtAdjustPrivilegesToken.c
@@ -15,13 +15,10 @@ IsPrivilegeEnabled(
 {
     PRIVILEGE_SET PrivSet;
     BOOL Result, Success;
-    LUID Priv;
-
-    ConvertPrivLongToLuid(Privilege, &Priv);
 
     PrivSet.PrivilegeCount = 1;
     PrivSet.Control = PRIVILEGE_SET_ALL_NECESSARY;
-    PrivSet.Privilege[0].Luid = Priv;
+    PrivSet.Privilege[0].Luid = RtlConvertUlongToLuid(Privilege);
     PrivSet.Privilege[0].Attributes = 0;
 
     Success = PrivilegeCheck(TokenHandle, &PrivSet, &Result);

--- a/modules/rostests/apitests/ntdll/NtFilterToken.c
+++ b/modules/rostests/apitests/ntdll/NtFilterToken.c
@@ -31,7 +31,6 @@ START_TEST(NtFilterToken)
     NTSTATUS Status;
     HANDLE FilteredToken, Token;
     TOKEN_PRIVILEGES Priv;
-    LUID PrivLuid;
     ULONG Size;
     PTOKEN_STATISTICS TokenStats;
 
@@ -107,8 +106,7 @@ START_TEST(NtFilterToken)
     /* Fill in a privilege to delete */
     Priv.PrivilegeCount = 1;
 
-    ConvertPrivLongToLuid(SE_BACKUP_PRIVILEGE, &PrivLuid);
-    Priv.Privileges[0].Luid = PrivLuid;
+    Priv.Privileges[0].Luid = RtlConvertUlongToLuid(SE_BACKUP_PRIVILEGE);
     Priv.Privileges[0].Attributes = 0;
 
     /* Delete the privileges */

--- a/modules/rostests/apitests/ntdll/precomp.h
+++ b/modules/rostests/apitests/ntdll/precomp.h
@@ -41,12 +41,4 @@ SetupLocale(
     _In_ ULONG OemCode,
     _In_ ULONG Unicode);
 
-#define ConvertPrivLongToLuid(PrivilegeVal, ConvertedPrivLuid) \
-do {                                                           \
-    LUID Luid;                                                 \
-    Luid.LowPart = PrivilegeVal;                               \
-    Luid.HighPart = 0;                                         \
-    *ConvertedPrivLuid = Luid;                                 \
-} while (0)
-
 #endif /* _NTDLL_APITEST_PRECOMP_H_ */


### PR DESCRIPTION
## Purpose

Trivial code cleanup, use `RtlConvertUlongToLuid`.

JIRA issue: None
