### PR TITLE
[CRT] Import wcrtomb and mbrtowc from wine

### DIFF
--- a/dll/win32/msvcrt/msvcrt.spec
+++ b/dll/win32/msvcrt/msvcrt.spec
@@ -1402,7 +1402,7 @@
 @ cdecl malloc(long)
 @ cdecl mblen(ptr long)
 @ cdecl -version=0x600+ mbrlen(str long ptr)
-@ stub -version=0x600+ mbrtowc
+@ cdecl -version=0x600+ mbrtowc(ptr str long ptr)
 @ stub -version=0x600+ mbsdup_dbg
 @ stub -version=0x600+ mbsrtowcs
 @ stub -version=0x600+ mbsrtowcs_s

--- a/dll/win32/msvcrt/msvcrt.spec
+++ b/dll/win32/msvcrt/msvcrt.spec
@@ -1518,7 +1518,7 @@
 @ stub -version=0x600+ vswprintf_s
 @ cdecl vwprintf(wstr ptr)
 @ stub -version=0x600+ vwprintf_s
-@ stub -version=0x600+ wcrtomb
+@ cdecl -version=0x600+ wcrtomb(ptr long ptr)
 @ stub -version=0x600+ wcrtomb_s
 @ cdecl wcscat(wstr wstr)
 @ cdecl -version=0x600+ wcscat_s(wstr long wstr)

--- a/sdk/lib/crt/msvcrtex.cmake
+++ b/sdk/lib/crt/msvcrtex.cmake
@@ -15,6 +15,7 @@ if(DLL_EXPORT_VERSION LESS 0x600)
         misc/dbgrpt.cpp
         stdlib/_invalid_parameter.c
         stdlib/rand_s.c
+        wstring/wcrtomb.c
     )
 endif()
 

--- a/sdk/lib/crt/msvcrtex.cmake
+++ b/sdk/lib/crt/msvcrtex.cmake
@@ -15,6 +15,7 @@ if(DLL_EXPORT_VERSION LESS 0x600)
         misc/dbgrpt.cpp
         stdlib/_invalid_parameter.c
         stdlib/rand_s.c
+        wstring/mbrtowc.c
         wstring/wcrtomb.c
     )
 endif()

--- a/sdk/lib/crt/wstring/mbrtowc.c
+++ b/sdk/lib/crt/wstring/mbrtowc.c
@@ -1,0 +1,69 @@
+/*
+ * msvcrt.dll mbcs functions
+ *
+ * Copyright 1999 Alexandre Julliard
+ * Copyright 2000 Jon Griffths
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#include <precomp.h>
+#include <locale.h>
+
+/*********************************************************************
+ *              mbrtowc(MSVCRT.@)
+ */
+size_t CDECL mbrtowc(wchar_t *dst, const char *str,
+        size_t n, mbstate_t *state)
+{
+    mbstate_t s = (state ? *state : 0);
+    char tmpstr[2];
+    int len = 0;
+
+    if(dst)
+        *dst = 0;
+
+    if(!n || !str || !*str)
+        return 0;
+
+    if(___mb_cur_max_func() == 1) {
+        tmpstr[len++] = *str;
+    }else if(!s && isleadbyte((unsigned char)*str)) {
+        if(n == 1) {
+            s = (unsigned char)*str;
+            len = -2;
+        }else {
+            tmpstr[0] = str[0];
+            tmpstr[1] = str[1];
+            len = 2;
+        }
+    }else if(!s) {
+        tmpstr[len++] = *str;
+    }else {
+        tmpstr[0] = s;
+        tmpstr[1] = *str;
+        len = 2;
+        s = 0;
+    }
+
+    if(len > 0) {
+        if(!MultiByteToWideChar(___lc_codepage_func(), 0, tmpstr, len, dst, dst ? 1 : 0))
+            len = -1;
+    }
+
+    if(state)
+        *state = s;
+    return len;
+}

--- a/sdk/lib/crt/wstring/wcrtomb.c
+++ b/sdk/lib/crt/wstring/wcrtomb.c
@@ -1,0 +1,32 @@
+/*
+ * msvcrt.dll mbcs functions
+ *
+ * Copyright 1999 Alexandre Julliard
+ * Copyright 2000 Jon Griffths
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#include <precomp.h>
+
+/*********************************************************************
+ *              wcrtomb (MSVCRT.@)
+ */
+size_t CDECL wcrtomb( char *dst, wchar_t ch, mbstate_t *s)
+{
+    if(s)
+        *s = 0;
+    return wctomb(dst, ch);
+}

--- a/sdk/lib/crt/wstring/wstring.cmake
+++ b/sdk/lib/crt/wstring/wstring.cmake
@@ -11,6 +11,7 @@ list(APPEND LIBCNTPR_WSTRING_SOURCE
 
 list(APPEND CRT_WSTRING_SOURCE
     ${LIBCNTPR_WSTRING_SOURCE}
+    wstring/mbrtowc.c
     wstring/wcrtomb.c
     wstring/wcscoll.c
     wstring/wcstok.c

--- a/sdk/lib/crt/wstring/wstring.cmake
+++ b/sdk/lib/crt/wstring/wstring.cmake
@@ -11,6 +11,7 @@ list(APPEND LIBCNTPR_WSTRING_SOURCE
 
 list(APPEND CRT_WSTRING_SOURCE
     ${LIBCNTPR_WSTRING_SOURCE}
+    wstring/wcrtomb.c
     wstring/wcscoll.c
     wstring/wcstok.c
     wstring/wcsxfrm.c


### PR DESCRIPTION
## Purpose

Import wcrtomb and mbrtowc from wine
These are needed when compiling with GCC 13.
