### PR TITLE
[WINESYNC] Sync vbscript and winetests to Wine 18e7e07

### DIFF
--- a/dll/win32/vbscript/interp.c
+++ b/dll/win32/vbscript/interp.c
@@ -31,7 +31,6 @@ typedef struct {
     instr_t *instr;
     script_ctx_t *script;
     function_t *func;
-    IDispatch *this_obj;
     vbdisp_t *vbthis;
 
     VARIANT *args;
@@ -95,43 +94,73 @@ static BOOL lookup_dynamic_vars(dynamic_var_t *var, const WCHAR *name, ref_t *re
     return FALSE;
 }
 
+static BOOL lookup_global_vars(ScriptDisp *script, const WCHAR *name, ref_t *ref)
+{
+    dynamic_var_t **vars = script->global_vars;
+    size_t i, cnt = script->global_vars_cnt;
+
+    for(i = 0; i < cnt; i++) {
+        if(!wcsicmp(vars[i]->name, name)) {
+            ref->type = vars[i]->is_const ? REF_CONST : REF_VAR;
+            ref->u.v = &vars[i]->v;
+            return TRUE;
+        }
+    }
+
+    return FALSE;
+}
+
+static BOOL lookup_global_funcs(ScriptDisp *script, const WCHAR *name, ref_t *ref)
+{
+    function_t **funcs = script->global_funcs;
+    size_t i, cnt = script->global_funcs_cnt;
+
+    for(i = 0; i < cnt; i++) {
+        if(!wcsicmp(funcs[i]->name, name)) {
+            ref->type = REF_FUNC;
+            ref->u.f = funcs[i];
+            return TRUE;
+        }
+    }
+
+    return FALSE;
+}
+
 static HRESULT lookup_identifier(exec_ctx_t *ctx, BSTR name, vbdisp_invoke_type_t invoke_type, ref_t *ref)
 {
+    ScriptDisp *script_obj = ctx->script->script_obj;
     named_item_t *item;
-    function_t *func;
-    IDispatch *disp;
     unsigned i;
     DISPID id;
     HRESULT hres;
 
-    if(invoke_type == VBDISP_LET
-            && (ctx->func->type == FUNC_FUNCTION || ctx->func->type == FUNC_PROPGET || ctx->func->type == FUNC_DEFGET)
-            && !wcsicmp(name, ctx->func->name)) {
+    if((ctx->func->type == FUNC_FUNCTION || ctx->func->type == FUNC_PROPGET || ctx->func->type == FUNC_DEFGET)
+       && !wcsicmp(name, ctx->func->name)) {
         ref->type = REF_VAR;
         ref->u.v = &ctx->ret_val;
         return S_OK;
     }
 
-    for(i=0; i < ctx->func->var_cnt; i++) {
-        if(!wcsicmp(ctx->func->vars[i].name, name)) {
-            ref->type = REF_VAR;
-            ref->u.v = ctx->vars+i;
-            return TRUE;
-        }
-    }
-
-    for(i=0; i < ctx->func->arg_cnt; i++) {
-        if(!wcsicmp(ctx->func->args[i].name, name)) {
-            ref->type = REF_VAR;
-            ref->u.v = ctx->args+i;
-            return S_OK;
-        }
-    }
-
-    if(lookup_dynamic_vars(ctx->func->type == FUNC_GLOBAL ? ctx->script->global_vars : ctx->dynamic_vars, name, ref))
-        return S_OK;
-
     if(ctx->func->type != FUNC_GLOBAL) {
+        for(i=0; i < ctx->func->var_cnt; i++) {
+            if(!wcsicmp(ctx->func->vars[i].name, name)) {
+                ref->type = REF_VAR;
+                ref->u.v = ctx->vars+i;
+                return TRUE;
+            }
+        }
+
+        for(i=0; i < ctx->func->arg_cnt; i++) {
+            if(!wcsicmp(ctx->func->args[i].name, name)) {
+                ref->type = REF_VAR;
+                ref->u.v = ctx->args+i;
+                return S_OK;
+            }
+        }
+
+        if(lookup_dynamic_vars(ctx->dynamic_vars, name, ref))
+            return S_OK;
+
         if(ctx->vbthis) {
             /* FIXME: Bind such identifier while generating bytecode. */
             for(i=0; i < ctx->vbthis->desc->prop_cnt; i++) {
@@ -141,37 +170,40 @@ static HRESULT lookup_identifier(exec_ctx_t *ctx, BSTR name, vbdisp_invoke_type_
                     return S_OK;
                 }
             }
-        }
 
-        hres = disp_get_id(ctx->this_obj, name, invoke_type, TRUE, &id);
+            hres = vbdisp_get_id(ctx->vbthis, name, invoke_type, TRUE, &id);
+            if(SUCCEEDED(hres)) {
+                ref->type = REF_DISP;
+                ref->u.d.disp = (IDispatch*)&ctx->vbthis->IDispatchEx_iface;
+                ref->u.d.id = id;
+                return S_OK;
+            }
+        }
+    }
+
+    if(ctx->code->named_item) {
+        if(lookup_global_vars(ctx->code->named_item->script_obj, name, ref))
+            return S_OK;
+        if(lookup_global_funcs(ctx->code->named_item->script_obj, name, ref))
+            return S_OK;
+    }
+
+    if(ctx->func->code_ctx->named_item && ctx->func->code_ctx->named_item->disp &&
+       !(ctx->func->code_ctx->named_item->flags & SCRIPTITEM_CODEONLY))
+    {
+        hres = disp_get_id(ctx->func->code_ctx->named_item->disp, name, invoke_type, TRUE, &id);
         if(SUCCEEDED(hres)) {
             ref->type = REF_DISP;
-            ref->u.d.disp = ctx->this_obj;
+            ref->u.d.disp = ctx->func->code_ctx->named_item->disp;
             ref->u.d.id = id;
             return S_OK;
         }
     }
 
-    if(ctx->func->code_ctx->context) {
-        hres = disp_get_id(ctx->func->code_ctx->context, name, invoke_type, TRUE, &id);
-        if(SUCCEEDED(hres)) {
-            ref->type = REF_DISP;
-            ref->u.d.disp = ctx->func->code_ctx->context;
-            ref->u.d.id = id;
-            return S_OK;
-        }
-    }
-
-    if(ctx->func->type != FUNC_GLOBAL && lookup_dynamic_vars(ctx->script->global_vars, name, ref))
+    if(lookup_global_vars(script_obj, name, ref))
         return S_OK;
-
-    for(func = ctx->script->global_funcs; func; func = func->next) {
-        if(!wcsicmp(func->name, name)) {
-            ref->type = REF_FUNC;
-            ref->u.f = func;
-            return S_OK;
-        }
-    }
+    if(lookup_global_funcs(script_obj, name, ref))
+        return S_OK;
 
     hres = get_builtin_id(ctx->script->global_obj, name, &id);
     if(SUCCEEDED(hres)) {
@@ -181,10 +213,10 @@ static HRESULT lookup_identifier(exec_ctx_t *ctx, BSTR name, vbdisp_invoke_type_
         return S_OK;
     }
 
-    disp = lookup_named_item(ctx->script, name, SCRIPTITEM_ISVISIBLE);
-    if(disp) {
+    item = lookup_named_item(ctx->script, name, SCRIPTITEM_ISVISIBLE);
+    if(item && item->disp) {
         ref->type = REF_OBJ;
-        ref->u.obj = disp;
+        ref->u.obj = item->disp;
         return S_OK;
     }
 
@@ -207,12 +239,13 @@ static HRESULT lookup_identifier(exec_ctx_t *ctx, BSTR name, vbdisp_invoke_type_
 static HRESULT add_dynamic_var(exec_ctx_t *ctx, const WCHAR *name,
         BOOL is_const, VARIANT **out_var)
 {
+    ScriptDisp *script_obj = ctx->code->named_item ? ctx->code->named_item->script_obj : ctx->script->script_obj;
     dynamic_var_t *new_var;
     heap_pool_t *heap;
     WCHAR *str;
     unsigned size;
 
-    heap = ctx->func->type == FUNC_GLOBAL ? &ctx->script->heap : &ctx->heap;
+    heap = ctx->func->type == FUNC_GLOBAL ? &script_obj->heap : &ctx->heap;
 
     new_var = heap_pool_alloc(heap, sizeof(*new_var));
     if(!new_var)
@@ -225,11 +258,23 @@ static HRESULT add_dynamic_var(exec_ctx_t *ctx, const WCHAR *name,
     memcpy(str, name, size);
     new_var->name = str;
     new_var->is_const = is_const;
+    new_var->array = NULL;
     V_VT(&new_var->v) = VT_EMPTY;
 
     if(ctx->func->type == FUNC_GLOBAL) {
-        new_var->next = ctx->script->global_vars;
-        ctx->script->global_vars = new_var;
+        size_t cnt = script_obj->global_vars_cnt + 1;
+        if(cnt > script_obj->global_vars_size) {
+            dynamic_var_t **new_vars;
+            if(script_obj->global_vars)
+                new_vars = heap_realloc(script_obj->global_vars, cnt * 2 * sizeof(*new_vars));
+            else
+                new_vars = heap_alloc(cnt * 2 * sizeof(*new_vars));
+            if(!new_vars)
+                return E_OUTOFMEMORY;
+            script_obj->global_vars = new_vars;
+            script_obj->global_vars_size = cnt * 2;
+        }
+        script_obj->global_vars[script_obj->global_vars_cnt++] = new_var;
     }else {
         new_var->next = ctx->dynamic_vars;
         ctx->dynamic_vars = new_var;
@@ -245,6 +290,14 @@ void clear_ei(EXCEPINFO *ei)
     SysFreeString(ei->bstrDescription);
     SysFreeString(ei->bstrHelpFile);
     memset(ei, 0, sizeof(*ei));
+}
+
+static void clear_error_loc(script_ctx_t *ctx)
+{
+    if(ctx->error_loc_code) {
+        release_vbscode(ctx->error_loc_code);
+        ctx->error_loc_code = NULL;
+    }
 }
 
 static inline VARIANT *stack_pop(exec_ctx_t *ctx)
@@ -374,6 +427,7 @@ static int stack_pop_bool(exec_ctx_t *ctx, BOOL *b)
         *b = V_BOOL(val.v);
         break;
     case VT_NULL:
+    case VT_EMPTY:
         *b = FALSE;
         break;
     case VT_I2:
@@ -421,22 +475,22 @@ static HRESULT stack_assume_disp(exec_ctx_t *ctx, unsigned n, IDispatch **disp)
 {
     VARIANT *v = stack_top(ctx, n), *ref;
 
-    if(V_VT(v) != VT_DISPATCH) {
+    if(V_VT(v) != VT_DISPATCH && (disp || V_VT(v) != VT_UNKNOWN)) {
         if(V_VT(v) != (VT_VARIANT|VT_BYREF)) {
             FIXME("not supported type: %s\n", debugstr_variant(v));
             return E_FAIL;
         }
 
         ref = V_VARIANTREF(v);
-        if(V_VT(ref) != VT_DISPATCH) {
+        if(V_VT(ref) != VT_DISPATCH && (disp || V_VT(ref) != VT_UNKNOWN)) {
             FIXME("not disp %s\n", debugstr_variant(ref));
             return E_FAIL;
         }
 
-        V_VT(v) = VT_DISPATCH;
-        V_DISPATCH(v) = V_DISPATCH(ref);
-        if(V_DISPATCH(v))
-            IDispatch_AddRef(V_DISPATCH(v));
+        V_VT(v) = V_VT(ref);
+        V_UNKNOWN(v) = V_UNKNOWN(ref);
+        if(V_UNKNOWN(v))
+            IUnknown_AddRef(V_UNKNOWN(v));
     }
 
     if(disp)
@@ -515,6 +569,52 @@ static HRESULT array_access(exec_ctx_t *ctx, SAFEARRAY *array, DISPPARAMS *dp, V
     return hres;
 }
 
+static HRESULT variant_call(exec_ctx_t *ctx, VARIANT *v, unsigned arg_cnt, VARIANT *res)
+{
+    SAFEARRAY *array = NULL;
+    DISPPARAMS dp;
+    HRESULT hres;
+
+    TRACE("%s\n", debugstr_variant(v));
+
+    if(V_VT(v) == (VT_VARIANT|VT_BYREF))
+        v = V_VARIANTREF(v);
+
+    switch(V_VT(v)) {
+    case VT_ARRAY|VT_BYREF|VT_VARIANT:
+        array = *V_ARRAYREF(v);
+        break;
+    case VT_ARRAY|VT_VARIANT:
+        array = V_ARRAY(v);
+        break;
+    case VT_DISPATCH:
+        vbstack_to_dp(ctx, arg_cnt, FALSE, &dp);
+        hres = disp_call(ctx->script, V_DISPATCH(v), DISPID_VALUE, &dp, res);
+        break;
+    default:
+        FIXME("unsupported on %s\n", debugstr_variant(v));
+        return E_NOTIMPL;
+    }
+
+    if(array) {
+        if(!res) {
+            FIXME("no res\n");
+            return E_NOTIMPL;
+        }
+
+        vbstack_to_dp(ctx, arg_cnt, FALSE, &dp);
+        hres = array_access(ctx, array, &dp, &v);
+        if(FAILED(hres))
+            return hres;
+
+        V_VT(res) = VT_BYREF|VT_VARIANT;
+        V_BYREF(res) = v;
+    }
+
+    stack_popn(ctx, arg_cnt);
+    return S_OK;
+}
+
 static HRESULT do_icall(exec_ctx_t *ctx, VARIANT *res)
 {
     BSTR identifier = ctx->instr->arg1.bstr;
@@ -523,56 +623,26 @@ static HRESULT do_icall(exec_ctx_t *ctx, VARIANT *res)
     ref_t ref;
     HRESULT hres;
 
+    TRACE("%s %u\n", debugstr_w(identifier), arg_cnt);
+
     hres = lookup_identifier(ctx, identifier, VBDISP_CALLGET, &ref);
     if(FAILED(hres))
         return hres;
 
     switch(ref.type) {
     case REF_VAR:
-    case REF_CONST: {
-        VARIANT *v;
+    case REF_CONST:
+        if(arg_cnt)
+            return variant_call(ctx, ref.u.v, arg_cnt, res);
 
         if(!res) {
             FIXME("REF_VAR no res\n");
             return E_NOTIMPL;
         }
 
-        v = V_VT(ref.u.v) == (VT_VARIANT|VT_BYREF) ? V_VARIANTREF(ref.u.v) : ref.u.v;
-
-        if(arg_cnt) {
-            SAFEARRAY *array = NULL;
-
-            switch(V_VT(v)) {
-            case VT_ARRAY|VT_BYREF|VT_VARIANT:
-                array = *V_ARRAYREF(ref.u.v);
-                break;
-            case VT_ARRAY|VT_VARIANT:
-                array = V_ARRAY(ref.u.v);
-                break;
-            case VT_DISPATCH:
-                vbstack_to_dp(ctx, arg_cnt, FALSE, &dp);
-                hres = disp_call(ctx->script, V_DISPATCH(v), DISPID_VALUE, &dp, res);
-                if(FAILED(hres))
-                    return hres;
-                break;
-            default:
-                FIXME("arguments not implemented\n");
-                return E_NOTIMPL;
-            }
-
-            if(!array)
-                break;
-
-            vbstack_to_dp(ctx, arg_cnt, FALSE, &dp);
-            hres = array_access(ctx, array, &dp, &v);
-            if(FAILED(hres))
-                return hres;
-        }
-
         V_VT(res) = VT_BYREF|VT_VARIANT;
-        V_BYREF(res) = v;
+        V_BYREF(res) = V_VT(ref.u.v) == (VT_VARIANT|VT_BYREF) ? V_VARIANTREF(ref.u.v) : ref.u.v;
         break;
-    }
     case REF_DISP:
         vbstack_to_dp(ctx, arg_cnt, FALSE, &dp);
         hres = disp_call(ctx->script, ref.u.d.disp, ref.u.d.id, &dp, res);
@@ -633,6 +703,37 @@ static HRESULT interp_icallv(exec_ctx_t *ctx)
 {
     TRACE("\n");
     return do_icall(ctx, NULL);
+}
+
+static HRESULT interp_vcall(exec_ctx_t *ctx)
+{
+    const unsigned arg_cnt = ctx->instr->arg1.uint;
+    VARIANT res, *v;
+    HRESULT hres;
+
+    TRACE("\n");
+
+    v = stack_pop(ctx);
+    hres = variant_call(ctx, v, arg_cnt, &res);
+    VariantClear(v);
+    if(FAILED(hres))
+        return hres;
+
+    return stack_push(ctx, &res);
+}
+
+static HRESULT interp_vcallv(exec_ctx_t *ctx)
+{
+    const unsigned arg_cnt = ctx->instr->arg1.uint;
+    VARIANT *v;
+    HRESULT hres;
+
+    TRACE("\n");
+
+    v = stack_pop(ctx);
+    hres = variant_call(ctx, v, arg_cnt, NULL);
+    VariantClear(v);
+    return hres;
 }
 
 static HRESULT do_mcall(exec_ctx_t *ctx, VARIANT *res)
@@ -732,6 +833,11 @@ static HRESULT assign_ident(exec_ctx_t *ctx, BSTR name, WORD flags, DISPPARAMS *
         if(arg_cnt(dp)) {
             SAFEARRAY *array;
 
+            if(V_VT(v) == VT_DISPATCH) {
+                hres = disp_propput(ctx->script, V_DISPATCH(v), DISPID_VALUE, flags, dp);
+                break;
+            }
+
             if(!(V_VT(v) & VT_ARRAY)) {
                 FIXME("array assign on type %d\n", V_VT(v));
                 return E_FAIL;
@@ -824,23 +930,18 @@ static HRESULT interp_set_ident(exec_ctx_t *ctx)
     DISPPARAMS dp;
     HRESULT hres;
 
-    TRACE("%s\n", debugstr_w(arg));
+    TRACE("%s %u\n", debugstr_w(arg), arg_cnt);
 
-    if(arg_cnt) {
-        FIXME("arguments not supported\n");
-        return E_NOTIMPL;
-    }
-
-    hres = stack_assume_disp(ctx, 0, NULL);
+    hres = stack_assume_disp(ctx, arg_cnt, NULL);
     if(FAILED(hres))
         return hres;
 
-    vbstack_to_dp(ctx, 0, TRUE, &dp);
-    hres = assign_ident(ctx, ctx->instr->arg1.bstr, DISPATCH_PROPERTYPUTREF, &dp);
+    vbstack_to_dp(ctx, arg_cnt, TRUE, &dp);
+    hres = assign_ident(ctx, arg, DISPATCH_PROPERTYPUTREF, &dp);
     if(FAILED(hres))
         return hres;
 
-    stack_popn(ctx, 1);
+    stack_popn(ctx, arg_cnt + 1);
     return S_OK;
 }
 
@@ -981,10 +1082,47 @@ static HRESULT interp_pop(exec_ctx_t *ctx)
     return S_OK;
 }
 
+static HRESULT interp_stack(exec_ctx_t *ctx)
+{
+    const unsigned n = ctx->instr->arg1.uint;
+    VARIANT v;
+    HRESULT hres;
+
+    TRACE("%#x\n", n);
+
+    if(n == ~0)
+        return MAKE_VBSERROR(505);
+    assert(n < ctx->top);
+
+    V_VT(&v) = VT_EMPTY;
+    hres = VariantCopy(&v, ctx->stack + n);
+    if(FAILED(hres))
+        return hres;
+
+    return stack_push(ctx, &v);
+}
+
+static HRESULT interp_deref(exec_ctx_t *ctx)
+{
+    VARIANT copy, *v = stack_top(ctx, 0);
+    HRESULT hres;
+
+    TRACE("%s\n", debugstr_variant(v));
+
+    if(V_VT(v) != (VT_BYREF|VT_VARIANT))
+        return S_OK;
+
+    V_VT(&copy) = VT_EMPTY;
+    hres = VariantCopy(&copy, V_VARIANTREF(v));
+    if(SUCCEEDED(hres))
+        *v = copy;
+    return hres;
+}
+
 static HRESULT interp_new(exec_ctx_t *ctx)
 {
     const WCHAR *arg = ctx->instr->arg1.bstr;
-    class_desc_t *class_desc;
+    class_desc_t *class_desc = NULL;
     vbdisp_t *obj;
     VARIANT v;
     HRESULT hres;
@@ -1002,10 +1140,14 @@ static HRESULT interp_new(exec_ctx_t *ctx)
         return stack_push(ctx, &v);
     }
 
-    for(class_desc = ctx->script->classes; class_desc; class_desc = class_desc->next) {
-        if(!wcsicmp(class_desc->name, arg))
-            break;
-    }
+    if(ctx->code->named_item)
+        for(class_desc = ctx->code->named_item->script_obj->classes; class_desc; class_desc = class_desc->next)
+            if(!wcsicmp(class_desc->name, arg))
+                break;
+    if(!class_desc)
+        for(class_desc = ctx->script->script_obj->classes; class_desc; class_desc = class_desc->next)
+            if(!wcsicmp(class_desc->name, arg))
+                break;
     if(!class_desc) {
         FIXME("Class %s not found\n", debugstr_w(arg));
         return E_FAIL;
@@ -1022,24 +1164,108 @@ static HRESULT interp_new(exec_ctx_t *ctx)
 
 static HRESULT interp_dim(exec_ctx_t *ctx)
 {
+    ScriptDisp *script_obj = ctx->code->named_item ? ctx->code->named_item->script_obj : ctx->script->script_obj;
     const BSTR ident = ctx->instr->arg1.bstr;
     const unsigned array_id = ctx->instr->arg2.uint;
     const array_desc_t *array_desc;
-    ref_t ref;
+    SAFEARRAY **array_ref;
+    VARIANT *v;
     HRESULT hres;
 
     TRACE("%s\n", debugstr_w(ident));
 
     assert(array_id < ctx->func->array_cnt);
-    if(!ctx->arrays) {
-        ctx->arrays = heap_alloc_zero(ctx->func->array_cnt * sizeof(SAFEARRAY*));
-        if(!ctx->arrays)
+
+    if(ctx->func->type == FUNC_GLOBAL) {
+        unsigned i;
+        for(i = 0; i < script_obj->global_vars_cnt; i++) {
+            if(!wcsicmp(script_obj->global_vars[i]->name, ident))
+                break;
+        }
+        assert(i < script_obj->global_vars_cnt);
+        v = &script_obj->global_vars[i]->v;
+        array_ref = &script_obj->global_vars[i]->array;
+    }else {
+        ref_t ref;
+
+        if(!ctx->arrays) {
+            ctx->arrays = heap_alloc_zero(ctx->func->array_cnt * sizeof(SAFEARRAY*));
+            if(!ctx->arrays)
+                return E_OUTOFMEMORY;
+        }
+
+        hres = lookup_identifier(ctx, ident, VBDISP_LET, &ref);
+        if(FAILED(hres)) {
+            FIXME("lookup %s failed: %08x\n", debugstr_w(ident), hres);
+            return hres;
+        }
+
+        if(ref.type != REF_VAR) {
+            FIXME("got ref.type = %d\n", ref.type);
+            return E_FAIL;
+        }
+
+        v = ref.u.v;
+        array_ref = ctx->arrays + array_id;
+    }
+
+    if(*array_ref) {
+        FIXME("Array already initialized\n");
+        return E_FAIL;
+    }
+
+    array_desc = ctx->func->array_descs + array_id;
+    if(array_desc->dim_cnt) {
+        *array_ref = SafeArrayCreate(VT_VARIANT, array_desc->dim_cnt, array_desc->bounds);
+        if(!*array_ref)
             return E_OUTOFMEMORY;
     }
 
-    hres = lookup_identifier(ctx, ident, VBDISP_LET, &ref);
+    V_VT(v) = VT_ARRAY|VT_BYREF|VT_VARIANT;
+    V_ARRAYREF(v) = array_ref;
+    return S_OK;
+}
+
+static HRESULT array_bounds_from_stack(exec_ctx_t *ctx, unsigned dim_cnt, SAFEARRAYBOUND **ret)
+{
+    SAFEARRAYBOUND *bounds;
+    unsigned i;
+    int dim;
+    HRESULT hres;
+
+    if(!(bounds = heap_alloc(dim_cnt * sizeof(*bounds))))
+        return E_OUTOFMEMORY;
+
+    for(i = 0; i < dim_cnt; i++) {
+        hres = to_int(stack_top(ctx, dim_cnt - i - 1), &dim);
+        if(FAILED(hres)) {
+            heap_free(bounds);
+            return hres;
+        }
+
+        bounds[i].cElements = dim + 1;
+        bounds[i].lLbound = 0;
+    }
+
+    stack_popn(ctx, dim_cnt);
+    *ret = bounds;
+    return S_OK;
+}
+
+static HRESULT interp_redim(exec_ctx_t *ctx)
+{
+    BSTR identifier = ctx->instr->arg1.bstr;
+    const unsigned dim_cnt = ctx->instr->arg2.uint;
+    SAFEARRAYBOUND *bounds;
+    SAFEARRAY *array;
+    ref_t ref;
+    HRESULT hres;
+
+    TRACE("%s %u\n", debugstr_w(identifier), dim_cnt);
+
+    hres = lookup_identifier(ctx, identifier, VBDISP_LET, &ref);
     if(FAILED(hres)) {
-        FIXME("lookup %s failed: %08x\n", debugstr_w(ident), hres);
+        FIXME("lookup %s failed: %08x\n", debugstr_w(identifier), hres);
         return hres;
     }
 
@@ -1048,20 +1274,20 @@ static HRESULT interp_dim(exec_ctx_t *ctx)
         return E_FAIL;
     }
 
-    if(ctx->arrays[array_id]) {
-        FIXME("Array already initialized\n");
-        return E_FAIL;
-    }
+    hres = array_bounds_from_stack(ctx, dim_cnt, &bounds);
+    if(FAILED(hres))
+        return hres;
 
-    array_desc = ctx->func->array_descs + array_id;
-    if(array_desc->dim_cnt) {
-        ctx->arrays[array_id] = SafeArrayCreate(VT_VARIANT, array_desc->dim_cnt, array_desc->bounds);
-        if(!ctx->arrays[array_id])
-            return E_OUTOFMEMORY;
-    }
+    array = SafeArrayCreate(VT_VARIANT, dim_cnt, bounds);
+    heap_free(bounds);
+    if(!array)
+        return E_OUTOFMEMORY;
 
-    V_VT(ref.u.v) = VT_ARRAY|VT_BYREF|VT_VARIANT;
-    V_ARRAYREF(ref.u.v) = ctx->arrays+array_id;
+    /* FIXME: We should check if we're not modifying an existing static array here */
+
+    VariantClear(ref.u.v);
+    V_VT(ref.u.v) = VT_ARRAY|VT_VARIANT;
+    V_ARRAY(ref.u.v) = array;
     return S_OK;
 }
 
@@ -1270,9 +1496,7 @@ static HRESULT interp_retval(exec_ctx_t *ctx)
 
     TRACE("\n");
 
-    hres = stack_pop_val(ctx, &val);
-    if(FAILED(hres))
-        return hres;
+    stack_pop_deref(ctx, &val);
 
     if(val.owned) {
         VariantClear(&ctx->ret_val);
@@ -1297,13 +1521,32 @@ static HRESULT interp_stop(exec_ctx_t *ctx)
 
 static HRESULT interp_me(exec_ctx_t *ctx)
 {
+    IDispatch *disp;
     VARIANT v;
 
     TRACE("\n");
 
-    IDispatch_AddRef(ctx->this_obj);
+    if(ctx->vbthis) {
+        disp = (IDispatch*)&ctx->vbthis->IDispatchEx_iface;
+    }else if(ctx->code->named_item) {
+        disp = (ctx->code->named_item->flags & SCRIPTITEM_CODEONLY)
+               ? (IDispatch*)&ctx->code->named_item->script_obj->IDispatchEx_iface
+               : ctx->code->named_item->disp;
+    }else {
+        named_item_t *item;
+        disp = NULL;
+        LIST_FOR_EACH_ENTRY(item, &ctx->script->named_items, named_item_t, entry) {
+            if(!(item->flags & SCRIPTITEM_GLOBALMEMBERS)) continue;
+            disp = item->disp;
+            break;
+        }
+        if(!disp)
+            disp = (IDispatch*)&ctx->script->script_obj->IDispatchEx_iface;
+    }
+
+    IDispatch_AddRef(disp);
     V_VT(&v) = VT_DISPATCH;
-    V_DISPATCH(&v) = ctx->this_obj;
+    V_DISPATCH(&v) = disp;
     return stack_push(ctx, &v);
 }
 
@@ -1715,75 +1958,57 @@ static HRESULT interp_case(exec_ctx_t *ctx)
     return S_OK;
 }
 
-static HRESULT disp_cmp(IDispatch *disp1, IDispatch *disp2, VARIANT_BOOL *ret)
-{
-    IObjectIdentity *identity;
-    IUnknown *unk1, *unk2;
-    HRESULT hres;
-
-    if(disp1 == disp2) {
-        *ret = VARIANT_TRUE;
-        return S_OK;
-    }
-
-    if(!disp1 || !disp2) {
-        *ret = VARIANT_FALSE;
-        return S_OK;
-    }
-
-    hres = IDispatch_QueryInterface(disp1, &IID_IUnknown, (void**)&unk1);
-    if(FAILED(hres))
-        return hres;
-
-    hres = IDispatch_QueryInterface(disp2, &IID_IUnknown, (void**)&unk2);
-    if(FAILED(hres)) {
-        IUnknown_Release(unk1);
-        return hres;
-    }
-
-    if(unk1 == unk2) {
-        *ret = VARIANT_TRUE;
-    }else {
-        hres = IUnknown_QueryInterface(unk1, &IID_IObjectIdentity, (void**)&identity);
-        if(SUCCEEDED(hres)) {
-            hres = IObjectIdentity_IsEqualObject(identity, unk2);
-            IObjectIdentity_Release(identity);
-            *ret = hres == S_OK ? VARIANT_TRUE : VARIANT_FALSE;
-        }else {
-            *ret = VARIANT_FALSE;
-        }
-    }
-
-    IUnknown_Release(unk1);
-    IUnknown_Release(unk2);
-    return S_OK;
-}
-
 static HRESULT interp_is(exec_ctx_t *ctx)
 {
-    IDispatch *l, *r;
-    VARIANT v;
-    HRESULT hres;
+    IUnknown *l = NULL, *r = NULL;
+    variant_val_t v;
+    HRESULT hres = S_OK;
 
     TRACE("\n");
 
-    hres = stack_pop_disp(ctx, &r);
+    stack_pop_deref(ctx, &v);
+    if(V_VT(v.v) != VT_DISPATCH && V_VT(v.v) != VT_UNKNOWN) {
+        FIXME("Unhandled type %s\n", debugstr_variant(v.v));
+        hres = E_NOTIMPL;
+    }else if(V_UNKNOWN(v.v)) {
+        hres = IUnknown_QueryInterface(V_UNKNOWN(v.v), &IID_IUnknown, (void**)&r);
+    }
+    if(v.owned) VariantClear(v.v);
     if(FAILED(hres))
         return hres;
 
-    hres = stack_pop_disp(ctx, &l);
+    stack_pop_deref(ctx, &v);
+    if(V_VT(v.v) != VT_DISPATCH && V_VT(v.v) != VT_UNKNOWN) {
+        FIXME("Unhandled type %s\n", debugstr_variant(v.v));
+        hres = E_NOTIMPL;
+    }else if(V_UNKNOWN(v.v)) {
+        hres = IUnknown_QueryInterface(V_UNKNOWN(v.v), &IID_IUnknown, (void**)&l);
+    }
+    if(v.owned) VariantClear(v.v);
+
     if(SUCCEEDED(hres)) {
-        V_VT(&v) = VT_BOOL;
-        hres = disp_cmp(l, r, &V_BOOL(&v));
-        if(l)
-            IDispatch_Release(l);
+        VARIANT res;
+        V_VT(&res) = VT_BOOL;
+        if(r == l)
+            V_BOOL(&res) = VARIANT_TRUE;
+        else if(!r || !l)
+            V_BOOL(&res) = VARIANT_FALSE;
+        else {
+            IObjectIdentity *identity;
+            hres = IUnknown_QueryInterface(l, &IID_IObjectIdentity, (void**)&identity);
+            if(SUCCEEDED(hres)) {
+                hres = IObjectIdentity_IsEqualObject(identity, r);
+                IObjectIdentity_Release(identity);
+            }
+            V_BOOL(&res) = hres == S_OK ? VARIANT_TRUE : VARIANT_FALSE;
+        }
+        hres = stack_push(ctx, &res);
     }
     if(r)
-        IDispatch_Release(r);
-    if(FAILED(hres))
-        return hres;
-
-    return stack_push(ctx, &v);
+        IUnknown_Release(r);
+    if(l)
+        IUnknown_Release(l);
+    return hres;
 }
 
 static HRESULT interp_concat(exec_ctx_t *ctx)
@@ -2041,23 +2266,25 @@ OP_LIST
 #undef X
 };
 
-void release_dynamic_vars(dynamic_var_t *var)
+void release_dynamic_var(dynamic_var_t *var)
 {
-    while(var) {
-        VariantClear(&var->v);
-        var = var->next;
-    }
+    VariantClear(&var->v);
+    if(var->array)
+        SafeArrayDestroy(var->array);
 }
 
 static void release_exec(exec_ctx_t *ctx)
 {
+    dynamic_var_t *var;
     unsigned i;
 
     VariantClear(&ctx->ret_val);
-    release_dynamic_vars(ctx->dynamic_vars);
 
-    if(ctx->this_obj)
-        IDispatch_Release(ctx->this_obj);
+    for(var = ctx->dynamic_vars; var; var = var->next)
+        release_dynamic_var(var);
+
+    if(ctx->vbthis)
+        IDispatchEx_Release(&ctx->vbthis->IDispatchEx_iface);
 
     if(ctx->args) {
         for(i=0; i < ctx->func->arg_cnt; i++)
@@ -2070,7 +2297,7 @@ static void release_exec(exec_ctx_t *ctx)
     }
 
     if(ctx->arrays) {
-        for(i=0; i < ctx->func->var_cnt; i++) {
+        for(i=0; i < ctx->func->array_cnt; i++) {
             if(ctx->arrays[i])
                 SafeArrayDestroy(ctx->arrays[i]);
         }
@@ -2098,6 +2325,7 @@ HRESULT exec_script(script_ctx_t *ctx, BOOL extern_caller, function_t *func, vbd
 
     heap_pool_init(&exec.heap);
 
+    TRACE("%s(", debugstr_w(func->name));
     if(func->arg_cnt) {
         VARIANT *v;
         unsigned i;
@@ -2110,6 +2338,7 @@ HRESULT exec_script(script_ctx_t *ctx, BOOL extern_caller, function_t *func, vbd
 
         for(i=0; i < func->arg_cnt; i++) {
             v = get_arg(dp, i);
+            TRACE("%s%s", i ? ", " : "", debugstr_variant(v));
             if(V_VT(v) == (VT_VARIANT|VT_BYREF)) {
                 if(func->args[i].by_ref)
                     exec.args[i] = *v;
@@ -2126,6 +2355,7 @@ HRESULT exec_script(script_ctx_t *ctx, BOOL extern_caller, function_t *func, vbd
     }else {
         exec.args = NULL;
     }
+    TRACE(")\n");
 
     if(func->var_cnt) {
         exec.vars = heap_alloc_zero(func->var_cnt * sizeof(VARIANT));
@@ -2149,14 +2379,9 @@ HRESULT exec_script(script_ctx_t *ctx, BOOL extern_caller, function_t *func, vbd
         IActiveScriptSite_OnEnterScript(ctx->site);
 
     if(vbthis) {
-        exec.this_obj = (IDispatch*)&vbthis->IDispatchEx_iface;
+        IDispatchEx_AddRef(&vbthis->IDispatchEx_iface);
         exec.vbthis = vbthis;
-    }else if (ctx->host_global) {
-        exec.this_obj = ctx->host_global;
-    }else {
-        exec.this_obj = (IDispatch*)&ctx->script_obj->IDispatchEx_iface;
     }
-    IDispatch_AddRef(exec.this_obj);
 
     exec.instr = exec.code->instrs + func->code_off;
     exec.script = ctx;
@@ -2191,6 +2416,7 @@ HRESULT exec_script(script_ctx_t *ctx, BOOL extern_caller, function_t *func, vbd
 
                 TRACE("unwind jmp %d stack_off %d\n", exec.instr->arg1.uint, exec.instr->arg2.uint);
 
+                clear_error_loc(ctx);
                 stack_off = exec.instr->arg2.uint;
                 instr_jmp(&exec, exec.instr->arg1.uint);
 
@@ -2209,7 +2435,11 @@ HRESULT exec_script(script_ctx_t *ctx, BOOL extern_caller, function_t *func, vbd
 
                 continue;
             }else {
-                WARN("Failed %08x\n", hres);
+                if(!ctx->error_loc_code) {
+                    grab_vbscode(exec.code);
+                    ctx->error_loc_code = exec.code;
+                    ctx->error_loc_offset = exec.instr->loc;
+                }
                 stack_popn(&exec, exec.top);
                 break;
             }
@@ -2221,12 +2451,13 @@ HRESULT exec_script(script_ctx_t *ctx, BOOL extern_caller, function_t *func, vbd
     assert(!exec.top);
 
     if(extern_caller) {
-        IActiveScriptSite_OnLeaveScript(ctx->site);
         if(FAILED(hres)) {
             if(!ctx->ei.scode)
                 ctx->ei.scode = hres;
-            hres = report_script_error(ctx);
+            hres = report_script_error(ctx, ctx->error_loc_code, ctx->error_loc_offset);
+            clear_error_loc(ctx);
         }
+        IActiveScriptSite_OnLeaveScript(ctx->site);
     }
 
     if(SUCCEEDED(hres) && res) {

--- a/dll/win32/vbscript/lex.c
+++ b/dll/win32/vbscript/lex.c
@@ -32,125 +32,70 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(vbscript);
 
-static const WCHAR andW[] = {'a','n','d',0};
-static const WCHAR byrefW[] = {'b','y','r','e','f',0};
-static const WCHAR byvalW[] = {'b','y','v','a','l',0};
-static const WCHAR callW[] = {'c','a','l','l',0};
-static const WCHAR caseW[] = {'c','a','s','e',0};
-static const WCHAR classW[] = {'c','l','a','s','s',0};
-static const WCHAR constW[] = {'c','o','n','s','t',0};
-static const WCHAR defaultW[] = {'d','e','f','a','u','l','t',0};
-static const WCHAR dimW[] = {'d','i','m',0};
-static const WCHAR doW[] = {'d','o',0};
-static const WCHAR eachW[] = {'e','a','c','h',0};
-static const WCHAR elseW[] = {'e','l','s','e',0};
-static const WCHAR elseifW[] = {'e','l','s','e','i','f',0};
-static const WCHAR emptyW[] = {'e','m','p','t','y',0};
-static const WCHAR endW[] = {'e','n','d',0};
-static const WCHAR eqvW[] = {'e','q','v',0};
-static const WCHAR errorW[] = {'e','r','r','o','r',0};
-static const WCHAR exitW[] = {'e','x','i','t',0};
-static const WCHAR explicitW[] = {'e','x','p','l','i','c','i','t',0};
-static const WCHAR falseW[] = {'f','a','l','s','e',0};
-static const WCHAR forW[] = {'f','o','r',0};
-static const WCHAR functionW[] = {'f','u','n','c','t','i','o','n',0};
-static const WCHAR getW[] = {'g','e','t',0};
-static const WCHAR gotoW[] = {'g','o','t','o',0};
-static const WCHAR ifW[] = {'i','f',0};
-static const WCHAR impW[] = {'i','m','p',0};
-static const WCHAR inW[] = {'i','n',0};
-static const WCHAR isW[] = {'i','s',0};
-static const WCHAR letW[] = {'l','e','t',0};
-static const WCHAR loopW[] = {'l','o','o','p',0};
-static const WCHAR meW[] = {'m','e',0};
-static const WCHAR modW[] = {'m','o','d',0};
-static const WCHAR newW[] = {'n','e','w',0};
-static const WCHAR nextW[] = {'n','e','x','t',0};
-static const WCHAR notW[] = {'n','o','t',0};
-static const WCHAR nothingW[] = {'n','o','t','h','i','n','g',0};
-static const WCHAR nullW[] = {'n','u','l','l',0};
-static const WCHAR onW[] = {'o','n',0};
-static const WCHAR optionW[] = {'o','p','t','i','o','n',0};
-static const WCHAR orW[] = {'o','r',0};
-static const WCHAR privateW[] = {'p','r','i','v','a','t','e',0};
-static const WCHAR propertyW[] = {'p','r','o','p','e','r','t','y',0};
-static const WCHAR publicW[] = {'p','u','b','l','i','c',0};
-static const WCHAR remW[] = {'r','e','m',0};
-static const WCHAR resumeW[] = {'r','e','s','u','m','e',0};
-static const WCHAR selectW[] = {'s','e','l','e','c','t',0};
-static const WCHAR setW[] = {'s','e','t',0};
-static const WCHAR stepW[] = {'s','t','e','p',0};
-static const WCHAR stopW[] = {'s','t','o','p',0};
-static const WCHAR subW[] = {'s','u','b',0};
-static const WCHAR thenW[] = {'t','h','e','n',0};
-static const WCHAR toW[] = {'t','o',0};
-static const WCHAR trueW[] = {'t','r','u','e',0};
-static const WCHAR untilW[] = {'u','n','t','i','l',0};
-static const WCHAR wendW[] = {'w','e','n','d',0};
-static const WCHAR whileW[] = {'w','h','i','l','e',0};
-static const WCHAR xorW[] = {'x','o','r',0};
-
 static const struct {
     const WCHAR *word;
     int token;
 } keywords[] = {
-    {andW,       tAND},
-    {byrefW,     tBYREF},
-    {byvalW,     tBYVAL},
-    {callW,      tCALL},
-    {caseW,      tCASE},
-    {classW,     tCLASS},
-    {constW,     tCONST},
-    {defaultW,   tDEFAULT},
-    {dimW,       tDIM},
-    {doW,        tDO},
-    {eachW,      tEACH},
-    {elseW,      tELSE},
-    {elseifW,    tELSEIF},
-    {emptyW,     tEMPTY},
-    {endW,       tEND},
-    {eqvW,       tEQV},
-    {errorW,     tERROR},
-    {exitW,      tEXIT},
-    {explicitW,  tEXPLICIT},
-    {falseW,     tFALSE},
-    {forW,       tFOR},
-    {functionW,  tFUNCTION},
-    {getW,       tGET},
-    {gotoW,      tGOTO},
-    {ifW,        tIF},
-    {impW,       tIMP},
-    {inW,        tIN},
-    {isW,        tIS},
-    {letW,       tLET},
-    {loopW,      tLOOP},
-    {meW,        tME},
-    {modW,       tMOD},
-    {newW,       tNEW},
-    {nextW,      tNEXT},
-    {notW,       tNOT},
-    {nothingW,   tNOTHING},
-    {nullW,      tNULL},
-    {onW,        tON},
-    {optionW,    tOPTION},
-    {orW,        tOR},
-    {privateW,   tPRIVATE},
-    {propertyW,  tPROPERTY},
-    {publicW,    tPUBLIC},
-    {remW,       tREM},
-    {resumeW,    tRESUME},
-    {selectW,    tSELECT},
-    {setW,       tSET},
-    {stepW,      tSTEP},
-    {stopW,      tSTOP},
-    {subW,       tSUB},
-    {thenW,      tTHEN},
-    {toW,        tTO},
-    {trueW,      tTRUE},
-    {untilW,     tUNTIL},
-    {wendW,      tWEND},
-    {whileW,     tWHILE},
-    {xorW,       tXOR}
+    {L"and",       tAND},
+    {L"byref",     tBYREF},
+    {L"byval",     tBYVAL},
+    {L"call",      tCALL},
+    {L"case",      tCASE},
+    {L"class",     tCLASS},
+    {L"const",     tCONST},
+    {L"default",   tDEFAULT},
+    {L"dim",       tDIM},
+    {L"do",        tDO},
+    {L"each",      tEACH},
+    {L"else",      tELSE},
+    {L"elseif",    tELSEIF},
+    {L"empty",     tEMPTY},
+    {L"end",       tEND},
+    {L"eqv",       tEQV},
+    {L"error",     tERROR},
+    {L"exit",      tEXIT},
+    {L"explicit",  tEXPLICIT},
+    {L"false",     tFALSE},
+    {L"for",       tFOR},
+    {L"function",  tFUNCTION},
+    {L"get",       tGET},
+    {L"goto",      tGOTO},
+    {L"if",        tIF},
+    {L"imp",       tIMP},
+    {L"in",        tIN},
+    {L"is",        tIS},
+    {L"let",       tLET},
+    {L"loop",      tLOOP},
+    {L"me",        tME},
+    {L"mod",       tMOD},
+    {L"new",       tNEW},
+    {L"next",      tNEXT},
+    {L"not",       tNOT},
+    {L"nothing",   tNOTHING},
+    {L"null",      tNULL},
+    {L"on",        tON},
+    {L"option",    tOPTION},
+    {L"or",        tOR},
+    {L"preserve",  tPRESERVE},
+    {L"private",   tPRIVATE},
+    {L"property",  tPROPERTY},
+    {L"public",    tPUBLIC},
+    {L"redim",     tREDIM},
+    {L"rem",       tREM},
+    {L"resume",    tRESUME},
+    {L"select",    tSELECT},
+    {L"set",       tSET},
+    {L"step",      tSTEP},
+    {L"stop",      tSTOP},
+    {L"sub",       tSUB},
+    {L"then",      tTHEN},
+    {L"to",        tTO},
+    {L"true",      tTRUE},
+    {L"until",     tUNTIL},
+    {L"wend",      tWEND},
+    {L"while",     tWHILE},
+    {L"with",      tWITH},
+    {L"xor",       tXOR}
 };
 
 static inline BOOL is_identifier_char(WCHAR c)
@@ -273,7 +218,7 @@ static int parse_numeric_literal(parser_ctx_t *ctx, void **ret)
     if(*ctx->ptr == '0' && !('0' <= ctx->ptr[1] && ctx->ptr[1] <= '9') && ctx->ptr[1] != '.')
         return *ctx->ptr++;
 
-    while(ctx->ptr < ctx->end && iswdigit(*ctx->ptr)) {
+    while(ctx->ptr < ctx->end && is_digit(*ctx->ptr)) {
         hlp = d*10 + *(ctx->ptr++) - '0';
         if(d>MAXLONGLONG/10 || hlp<0) {
             exp++;
@@ -282,7 +227,7 @@ static int parse_numeric_literal(parser_ctx_t *ctx, void **ret)
         else
             d = hlp;
     }
-    while(ctx->ptr < ctx->end && iswdigit(*ctx->ptr)) {
+    while(ctx->ptr < ctx->end && is_digit(*ctx->ptr)) {
         exp++;
         ctx->ptr++;
     }
@@ -291,7 +236,7 @@ static int parse_numeric_literal(parser_ctx_t *ctx, void **ret)
         use_int = FALSE;
         ctx->ptr++;
 
-        while(ctx->ptr < ctx->end && iswdigit(*ctx->ptr)) {
+        while(ctx->ptr < ctx->end && is_digit(*ctx->ptr)) {
             hlp = d*10 + *(ctx->ptr++) - '0';
             if(d>MAXLONGLONG/10 || hlp<0)
                 break;
@@ -299,7 +244,7 @@ static int parse_numeric_literal(parser_ctx_t *ctx, void **ret)
             d = hlp;
             exp--;
         }
-        while(ctx->ptr < ctx->end && iswdigit(*ctx->ptr))
+        while(ctx->ptr < ctx->end && is_digit(*ctx->ptr))
             ctx->ptr++;
     }
 
@@ -314,7 +259,7 @@ static int parse_numeric_literal(parser_ctx_t *ctx, void **ret)
             ctx->ptr++;
         }
 
-        if(!iswdigit(*ctx->ptr)) {
+        if(!is_digit(*ctx->ptr)) {
             FIXME("Invalid numeric literal\n");
             return 0;
         }
@@ -325,7 +270,7 @@ static int parse_numeric_literal(parser_ctx_t *ctx, void **ret)
             e = e*10 + *(ctx->ptr++) - '0';
             if(sign == -1 && -e+exp < -(INT_MAX/100)) {
                 /* The literal will be rounded to 0 anyway. */
-                while(iswdigit(*ctx->ptr))
+                while(is_digit(*ctx->ptr))
                     ctx->ptr++;
                 *(double*)ret = 0;
                 return tDouble;
@@ -335,7 +280,7 @@ static int parse_numeric_literal(parser_ctx_t *ctx, void **ret)
                 FIXME("Invalid numeric literal\n");
                 return 0;
             }
-        } while(iswdigit(*ctx->ptr));
+        } while(is_digit(*ctx->ptr));
 
         exp += sign*e;
     }
@@ -369,7 +314,7 @@ static int hex_to_int(WCHAR c)
 static int parse_hex_literal(parser_ctx_t *ctx, LONG *ret)
 {
     const WCHAR *begin = ctx->ptr;
-    LONG l = 0, d;
+    unsigned l = 0, d;
 
     while((d = hex_to_int(*++ctx->ptr)) != -1)
         l = l*16 + d;
@@ -379,10 +324,12 @@ static int parse_hex_literal(parser_ctx_t *ctx, LONG *ret)
         return 0;
     }
 
-    if(*ctx->ptr == '&')
+    if(*ctx->ptr == '&') {
         ctx->ptr++;
-
-    *ret = l;
+        *ret = l;
+    }else {
+        *ret = l == (UINT16)l ? (INT16)l : l;
+    }
     return tInt;
 }
 
@@ -403,13 +350,14 @@ static int comment_line(parser_ctx_t *ctx)
     return tNL;
 }
 
-static int parse_next_token(void *lval, parser_ctx_t *ctx)
+static int parse_next_token(void *lval, unsigned *loc, parser_ctx_t *ctx)
 {
     WCHAR c;
 
     skip_spaces(ctx);
+    *loc = ctx->ptr - ctx->code;
     if(ctx->ptr == ctx->end)
-        return ctx->last_token == tNL ? tEOF : tNL;
+        return ctx->last_token == tNL ? 0 : tNL;
 
     c = *ctx->ptr;
 
@@ -417,7 +365,9 @@ static int parse_next_token(void *lval, parser_ctx_t *ctx)
         return parse_numeric_literal(ctx, lval);
 
     if(iswalpha(c)) {
-        int ret = check_keywords(ctx, lval);
+        int ret = 0;
+        if(ctx->last_token != '.' && ctx->last_token != tDOT)
+            ret = check_keywords(ctx, lval);
         if(!ret)
             return parse_identifier(ctx, lval);
         if(ret != tREM)
@@ -441,9 +391,17 @@ static int parse_next_token(void *lval, parser_ctx_t *ctx)
     case '/':
     case '^':
     case '\\':
-    case '.':
     case '_':
         return *ctx->ptr++;
+    case '.':
+        /*
+         * We need to distinguish between '.' used as part of a member expression and
+         * a beginning of a dot expression (a member expression accessing with statement
+         * expression).
+         */
+        c = ctx->ptr > ctx->code ? ctx->ptr[-1] : '\n';
+        ctx->ptr++;
+        return is_identifier_char(c) || c == ')' ? '.' : tDOT;
     case '-':
         if(ctx->is_html && ctx->ptr[1] == '-' && ctx->ptr[2] == '>')
             return comment_line(ctx);
@@ -460,7 +418,13 @@ static int parse_next_token(void *lval, parser_ctx_t *ctx)
             ctx->ptr++;
             return tEMPTYBRACKETS;
         }
-        return '(';
+        /*
+         * Parser can't predict if bracket is part of argument expression or an argument
+         * in call expression. We predict it here instead.
+         */
+        if(ctx->last_token == tIdentifier || ctx->last_token == ')')
+            return '(';
+        return tEXPRLBRACKET;
     case '"':
         return parse_string_literal(ctx, lval);
     case '&':
@@ -493,7 +457,7 @@ static int parse_next_token(void *lval, parser_ctx_t *ctx)
     return 0;
 }
 
-int parser_lex(void *lval, parser_ctx_t *ctx)
+int parser_lex(void *lval, unsigned *loc, parser_ctx_t *ctx)
 {
     int ret;
 
@@ -504,7 +468,7 @@ int parser_lex(void *lval, parser_ctx_t *ctx)
     }
 
     while(1) {
-        ret = parse_next_token(lval, ctx);
+        ret = parse_next_token(lval, loc, ctx);
         if(ret == '_') {
             skip_spaces(ctx);
             if(*ctx->ptr != '\n' && *ctx->ptr != '\r') {

--- a/dll/win32/vbscript/vbdisp.c
+++ b/dll/win32/vbscript/vbdisp.c
@@ -24,6 +24,9 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(vbscript);
 
+static const GUID GUID_VBScriptTypeInfo = {0xc59c6b12,0xf6c1,0x11cf,{0x88,0x35,0x00,0xa0,0xc9,0x11,0xe8,0xb2}};
+
+#define DISPID_FUNCTION_MASK 0x20000000
 #define FDEX_VERSION_MASK 0xf0000000
 
 static inline BOOL is_func_id(vbdisp_t *This, DISPID id)
@@ -526,48 +529,677 @@ HRESULT create_vbdisp(const class_desc_t *desc, vbdisp_t **ret)
     return S_OK;
 }
 
-struct _ident_map_t {
-    const WCHAR *name;
-    BOOL is_var;
-    union {
-        dynamic_var_t *var;
-        function_t *func;
-    } u;
+struct typeinfo_func {
+    function_t *func;
+    MEMBERID memid;
 };
 
-static inline DISPID ident_to_id(ScriptDisp *This, ident_map_t *ident)
+typedef struct {
+    ITypeInfo ITypeInfo_iface;
+    ITypeComp ITypeComp_iface;
+    LONG ref;
+
+    UINT num_vars;
+    UINT num_funcs;
+    struct typeinfo_func *funcs;
+
+    ScriptDisp *disp;
+} ScriptTypeInfo;
+
+static function_t *get_func_from_memid(const ScriptTypeInfo *typeinfo, MEMBERID memid)
 {
-    return (ident-This->ident_map)+1;
+    UINT a = 0, b = typeinfo->num_funcs;
+
+    if (!(memid & DISPID_FUNCTION_MASK)) return NULL;
+
+    while (a < b)
+    {
+        UINT i = (a + b - 1) / 2;
+
+        if (memid == typeinfo->funcs[i].memid)
+            return typeinfo->funcs[i].func;
+        else if (memid < typeinfo->funcs[i].memid)
+            b = i;
+        else
+            a = i + 1;
+    }
+    return NULL;
 }
 
-static inline ident_map_t *id_to_ident(ScriptDisp *This, DISPID id)
+static inline ScriptTypeInfo *ScriptTypeInfo_from_ITypeInfo(ITypeInfo *iface)
 {
-    return 0 < id && id <= This->ident_map_cnt ? This->ident_map+id-1 : NULL;
+    return CONTAINING_RECORD(iface, ScriptTypeInfo, ITypeInfo_iface);
 }
 
-static ident_map_t *add_ident(ScriptDisp *This, const WCHAR *name)
+static inline ScriptTypeInfo *ScriptTypeInfo_from_ITypeComp(ITypeComp *iface)
 {
-    ident_map_t *ret;
+    return CONTAINING_RECORD(iface, ScriptTypeInfo, ITypeComp_iface);
+}
 
-    if(!This->ident_map_size) {
-        This->ident_map = heap_alloc(4 * sizeof(*This->ident_map));
-        if(!This->ident_map)
-            return NULL;
-        This->ident_map_size = 4;
-    }else if(This->ident_map_cnt == This->ident_map_size) {
-        ident_map_t *new_map;
+static HRESULT WINAPI ScriptTypeInfo_QueryInterface(ITypeInfo *iface, REFIID riid, void **ppv)
+{
+    ScriptTypeInfo *This = ScriptTypeInfo_from_ITypeInfo(iface);
 
-        new_map = heap_realloc(This->ident_map, 2*This->ident_map_size*sizeof(*new_map));
-        if(!new_map)
-            return NULL;
-        This->ident_map = new_map;
-        This->ident_map_size *= 2;
+    if (IsEqualGUID(&IID_IUnknown, riid) || IsEqualGUID(&IID_ITypeInfo, riid))
+        *ppv = &This->ITypeInfo_iface;
+    else if (IsEqualGUID(&IID_ITypeComp, riid))
+        *ppv = &This->ITypeComp_iface;
+    else
+    {
+        WARN("(%p)->(%s %p)\n", This, debugstr_guid(riid), ppv);
+        *ppv = NULL;
+        return E_NOINTERFACE;
     }
 
-    ret = This->ident_map + This->ident_map_cnt++;
-    ret->name = name;
-    return ret;
+    TRACE("(%p)->(%s %p)\n", This, debugstr_guid(riid), ppv);
+    IUnknown_AddRef((IUnknown*)*ppv);
+    return S_OK;
 }
+
+static ULONG WINAPI ScriptTypeInfo_AddRef(ITypeInfo *iface)
+{
+    ScriptTypeInfo *This = ScriptTypeInfo_from_ITypeInfo(iface);
+    LONG ref = InterlockedIncrement(&This->ref);
+
+    TRACE("(%p) ref=%d\n", This, ref);
+
+    return ref;
+}
+
+static ULONG WINAPI ScriptTypeInfo_Release(ITypeInfo *iface)
+{
+    ScriptTypeInfo *This = ScriptTypeInfo_from_ITypeInfo(iface);
+    LONG ref = InterlockedDecrement(&This->ref);
+    UINT i;
+
+    TRACE("(%p) ref=%d\n", This, ref);
+
+    if (!ref)
+    {
+        for (i = 0; i < This->num_funcs; i++)
+            release_vbscode(This->funcs[i].func->code_ctx);
+
+        IDispatchEx_Release(&This->disp->IDispatchEx_iface);
+        heap_free(This->funcs);
+        heap_free(This);
+    }
+    return ref;
+}
+
+static HRESULT WINAPI ScriptTypeInfo_GetTypeAttr(ITypeInfo *iface, TYPEATTR **ppTypeAttr)
+{
+    ScriptTypeInfo *This = ScriptTypeInfo_from_ITypeInfo(iface);
+    TYPEATTR *attr;
+
+    TRACE("(%p)->(%p)\n", This, ppTypeAttr);
+
+    if (!ppTypeAttr) return E_INVALIDARG;
+
+    attr = heap_alloc_zero(sizeof(*attr));
+    if (!attr) return E_OUTOFMEMORY;
+
+    attr->guid = GUID_VBScriptTypeInfo;
+    attr->lcid = LOCALE_USER_DEFAULT;
+    attr->memidConstructor = MEMBERID_NIL;
+    attr->memidDestructor = MEMBERID_NIL;
+    attr->cbSizeInstance = 4;
+    attr->typekind = TKIND_DISPATCH;
+    attr->cFuncs = This->num_funcs;
+    attr->cVars = This->num_vars;
+    attr->cImplTypes = 1;
+    attr->cbSizeVft = sizeof(IDispatchVtbl);
+    attr->cbAlignment = 4;
+    attr->wTypeFlags = TYPEFLAG_FDISPATCHABLE;
+    attr->wMajorVerNum = VBSCRIPT_MAJOR_VERSION;
+    attr->wMinorVerNum = VBSCRIPT_MINOR_VERSION;
+
+    *ppTypeAttr = attr;
+    return S_OK;
+}
+
+static HRESULT WINAPI ScriptTypeInfo_GetTypeComp(ITypeInfo *iface, ITypeComp **ppTComp)
+{
+    ScriptTypeInfo *This = ScriptTypeInfo_from_ITypeInfo(iface);
+
+    TRACE("(%p)->(%p)\n", This, ppTComp);
+
+    if (!ppTComp) return E_INVALIDARG;
+
+    *ppTComp = &This->ITypeComp_iface;
+    ITypeInfo_AddRef(iface);
+    return S_OK;
+}
+
+static HRESULT WINAPI ScriptTypeInfo_GetFuncDesc(ITypeInfo *iface, UINT index, FUNCDESC **ppFuncDesc)
+{
+    ScriptTypeInfo *This = ScriptTypeInfo_from_ITypeInfo(iface);
+    function_t *func;
+    FUNCDESC *desc;
+    UINT i;
+
+    TRACE("(%p)->(%u %p)\n", This, index, ppFuncDesc);
+
+    if (!ppFuncDesc) return E_INVALIDARG;
+    if (index >= This->num_funcs) return TYPE_E_ELEMENTNOTFOUND;
+    func = This->funcs[index].func;
+
+    /* Store the parameter array after the FUNCDESC structure */
+    desc = heap_alloc_zero(sizeof(*desc) + sizeof(ELEMDESC) * func->arg_cnt);
+    if (!desc) return E_OUTOFMEMORY;
+
+    desc->memid = This->funcs[index].memid;
+    desc->funckind = FUNC_DISPATCH;
+    desc->invkind = INVOKE_FUNC;
+    desc->callconv = CC_STDCALL;
+    desc->cParams = func->arg_cnt;
+    desc->elemdescFunc.tdesc.vt = (func->type == FUNC_SUB) ? VT_VOID : VT_VARIANT;
+
+    if (func->arg_cnt) desc->lprgelemdescParam = (ELEMDESC*)(desc + 1);
+    for (i = 0; i < func->arg_cnt; i++)
+        desc->lprgelemdescParam[i].tdesc.vt = VT_VARIANT;
+
+    *ppFuncDesc = desc;
+    return S_OK;
+}
+
+static HRESULT WINAPI ScriptTypeInfo_GetVarDesc(ITypeInfo *iface, UINT index, VARDESC **ppVarDesc)
+{
+    ScriptTypeInfo *This = ScriptTypeInfo_from_ITypeInfo(iface);
+    VARDESC *desc;
+
+    TRACE("(%p)->(%u %p)\n", This, index, ppVarDesc);
+
+    if (!ppVarDesc) return E_INVALIDARG;
+    if (index >= This->num_vars) return TYPE_E_ELEMENTNOTFOUND;
+
+    desc = heap_alloc_zero(sizeof(*desc));
+    if (!desc) return E_OUTOFMEMORY;
+
+    desc->memid = index + 1;
+    desc->varkind = VAR_DISPATCH;
+    desc->elemdescVar.tdesc.vt = VT_VARIANT;
+
+    *ppVarDesc = desc;
+    return S_OK;
+}
+
+static HRESULT WINAPI ScriptTypeInfo_GetNames(ITypeInfo *iface, MEMBERID memid, BSTR *rgBstrNames,
+        UINT cMaxNames, UINT *pcNames)
+{
+    ScriptTypeInfo *This = ScriptTypeInfo_from_ITypeInfo(iface);
+    ITypeInfo *disp_typeinfo;
+    function_t *func;
+    HRESULT hr;
+    UINT i = 0;
+
+    TRACE("(%p)->(%d %p %u %p)\n", This, memid, rgBstrNames, cMaxNames, pcNames);
+
+    if (!rgBstrNames || !pcNames) return E_INVALIDARG;
+    if (memid <= 0) return TYPE_E_ELEMENTNOTFOUND;
+
+    func = get_func_from_memid(This, memid);
+    if (!func && memid > This->num_vars)
+    {
+        hr = get_dispatch_typeinfo(&disp_typeinfo);
+        if (FAILED(hr)) return hr;
+
+        return ITypeInfo_GetNames(disp_typeinfo, memid, rgBstrNames, cMaxNames, pcNames);
+    }
+
+    *pcNames = 0;
+    if (!cMaxNames) return S_OK;
+
+    if (func)
+    {
+        UINT num = min(cMaxNames, func->arg_cnt + 1);
+
+        rgBstrNames[0] = SysAllocString(func->name);
+        if (!rgBstrNames[0]) return E_OUTOFMEMORY;
+
+        for (i = 1; i < num; i++)
+        {
+            if (!(rgBstrNames[i] = SysAllocString(func->args[i - 1].name)))
+            {
+                do SysFreeString(rgBstrNames[--i]); while (i);
+                return E_OUTOFMEMORY;
+            }
+        }
+    }
+    else
+    {
+        rgBstrNames[0] = SysAllocString(This->disp->global_vars[memid - 1]->name);
+        if (!rgBstrNames[0]) return E_OUTOFMEMORY;
+        i++;
+    }
+
+    *pcNames = i;
+    return S_OK;
+}
+
+static HRESULT WINAPI ScriptTypeInfo_GetRefTypeOfImplType(ITypeInfo *iface, UINT index, HREFTYPE *pRefType)
+{
+    ScriptTypeInfo *This = ScriptTypeInfo_from_ITypeInfo(iface);
+
+    TRACE("(%p)->(%u %p)\n", This, index, pRefType);
+
+    /* We only inherit from IDispatch */
+    if (!pRefType) return E_INVALIDARG;
+    if (index != 0) return TYPE_E_ELEMENTNOTFOUND;
+
+    *pRefType = 1;
+    return S_OK;
+}
+
+static HRESULT WINAPI ScriptTypeInfo_GetImplTypeFlags(ITypeInfo *iface, UINT index, INT *pImplTypeFlags)
+{
+    ScriptTypeInfo *This = ScriptTypeInfo_from_ITypeInfo(iface);
+
+    TRACE("(%p)->(%u %p)\n", This, index, pImplTypeFlags);
+
+    if (!pImplTypeFlags) return E_INVALIDARG;
+    if (index != 0) return TYPE_E_ELEMENTNOTFOUND;
+
+    *pImplTypeFlags = 0;
+    return S_OK;
+}
+
+static HRESULT WINAPI ScriptTypeInfo_GetIDsOfNames(ITypeInfo *iface, LPOLESTR *rgszNames, UINT cNames,
+        MEMBERID *pMemId)
+{
+    ScriptTypeInfo *This = ScriptTypeInfo_from_ITypeInfo(iface);
+    ITypeInfo *disp_typeinfo;
+    const WCHAR *name;
+    HRESULT hr = S_OK;
+    int i, j, arg;
+
+    TRACE("(%p)->(%p %u %p)\n", This, rgszNames, cNames, pMemId);
+
+    if (!rgszNames || !cNames || !pMemId) return E_INVALIDARG;
+
+    for (i = 0; i < cNames; i++) pMemId[i] = MEMBERID_NIL;
+    name = rgszNames[0];
+
+    for (i = 0; i < This->num_funcs; i++)
+    {
+        function_t *func = This->funcs[i].func;
+
+        if (wcsicmp(name, func->name)) continue;
+        pMemId[0] = This->funcs[i].memid;
+
+        for (j = 1; j < cNames; j++)
+        {
+            name = rgszNames[j];
+            for (arg = func->arg_cnt; --arg >= 0;)
+                if (!wcsicmp(name, func->args[arg].name))
+                    break;
+            if (arg >= 0)
+                pMemId[j] = arg;
+            else
+                hr = DISP_E_UNKNOWNNAME;
+        }
+        return hr;
+    }
+
+    for (i = 0; i < This->num_vars; i++)
+    {
+        if (wcsicmp(name, This->disp->global_vars[i]->name)) continue;
+        pMemId[0] = i + 1;
+        return S_OK;
+    }
+
+    /* Look into the inherited IDispatch */
+    hr = get_dispatch_typeinfo(&disp_typeinfo);
+    if (FAILED(hr)) return hr;
+
+    return ITypeInfo_GetIDsOfNames(disp_typeinfo, rgszNames, cNames, pMemId);
+}
+
+static HRESULT WINAPI ScriptTypeInfo_Invoke(ITypeInfo *iface, PVOID pvInstance, MEMBERID memid, WORD wFlags,
+        DISPPARAMS *pDispParams, VARIANT *pVarResult, EXCEPINFO *pExcepInfo, UINT *puArgErr)
+{
+    ScriptTypeInfo *This = ScriptTypeInfo_from_ITypeInfo(iface);
+    ITypeInfo *disp_typeinfo;
+    IDispatch *disp;
+    HRESULT hr;
+
+    TRACE("(%p)->(%p %d %d %p %p %p %p)\n", This, pvInstance, memid, wFlags,
+          pDispParams, pVarResult, pExcepInfo, puArgErr);
+
+    if (!pvInstance) return E_INVALIDARG;
+    if (memid <= 0) return TYPE_E_ELEMENTNOTFOUND;
+
+    if (!get_func_from_memid(This, memid) && memid > This->num_vars)
+    {
+        hr = get_dispatch_typeinfo(&disp_typeinfo);
+        if (FAILED(hr)) return hr;
+
+        return ITypeInfo_Invoke(disp_typeinfo, pvInstance, memid, wFlags, pDispParams,
+                                pVarResult, pExcepInfo, puArgErr);
+    }
+
+    hr = IUnknown_QueryInterface((IUnknown*)pvInstance, &IID_IDispatch, (void**)&disp);
+    if (FAILED(hr)) return hr;
+
+    hr = IDispatch_Invoke(disp, memid, &IID_NULL, LOCALE_USER_DEFAULT, wFlags,
+                          pDispParams, pVarResult, pExcepInfo, puArgErr);
+    IDispatch_Release(disp);
+
+    return hr;
+}
+
+static HRESULT WINAPI ScriptTypeInfo_GetDocumentation(ITypeInfo *iface, MEMBERID memid, BSTR *pBstrName,
+        BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile)
+{
+    ScriptTypeInfo *This = ScriptTypeInfo_from_ITypeInfo(iface);
+    ITypeInfo *disp_typeinfo;
+    function_t *func;
+    HRESULT hr;
+
+    TRACE("(%p)->(%d %p %p %p %p)\n", This, memid, pBstrName, pBstrDocString, pdwHelpContext, pBstrHelpFile);
+
+    if (pBstrDocString) *pBstrDocString = NULL;
+    if (pdwHelpContext) *pdwHelpContext = 0;
+    if (pBstrHelpFile) *pBstrHelpFile = NULL;
+
+    if (memid == MEMBERID_NIL)
+    {
+        if (pBstrName && !(*pBstrName = SysAllocString(L"VBScriptTypeInfo")))
+            return E_OUTOFMEMORY;
+        if (pBstrDocString &&
+            !(*pBstrDocString = SysAllocString(L"Visual Basic Scripting Type Info")))
+        {
+            if (pBstrName) SysFreeString(*pBstrName);
+            return E_OUTOFMEMORY;
+        }
+        return S_OK;
+    }
+    if (memid <= 0) return TYPE_E_ELEMENTNOTFOUND;
+
+    func = get_func_from_memid(This, memid);
+    if (!func && memid > This->num_vars)
+    {
+        hr = get_dispatch_typeinfo(&disp_typeinfo);
+        if (FAILED(hr)) return hr;
+
+        return ITypeInfo_GetDocumentation(disp_typeinfo, memid, pBstrName, pBstrDocString,
+                                          pdwHelpContext, pBstrHelpFile);
+    }
+
+    if (pBstrName)
+    {
+        *pBstrName = SysAllocString(func ? func->name : This->disp->global_vars[memid - 1]->name);
+        if (!*pBstrName) return E_OUTOFMEMORY;
+    }
+    return S_OK;
+}
+
+static HRESULT WINAPI ScriptTypeInfo_GetDllEntry(ITypeInfo *iface, MEMBERID memid, INVOKEKIND invKind,
+        BSTR *pBstrDllName, BSTR *pBstrName, WORD *pwOrdinal)
+{
+    ScriptTypeInfo *This = ScriptTypeInfo_from_ITypeInfo(iface);
+    ITypeInfo *disp_typeinfo;
+    HRESULT hr;
+
+    TRACE("(%p)->(%d %d %p %p %p)\n", This, memid, invKind, pBstrDllName, pBstrName, pwOrdinal);
+
+    if (pBstrDllName) *pBstrDllName = NULL;
+    if (pBstrName) *pBstrName = NULL;
+    if (pwOrdinal) *pwOrdinal = 0;
+
+    if (!get_func_from_memid(This, memid) && memid > This->num_vars)
+    {
+        hr = get_dispatch_typeinfo(&disp_typeinfo);
+        if (FAILED(hr)) return hr;
+
+        return ITypeInfo_GetDllEntry(disp_typeinfo, memid, invKind, pBstrDllName, pBstrName, pwOrdinal);
+    }
+    return TYPE_E_BADMODULEKIND;
+}
+
+static HRESULT WINAPI ScriptTypeInfo_GetRefTypeInfo(ITypeInfo *iface, HREFTYPE hRefType, ITypeInfo **ppTInfo)
+{
+    ScriptTypeInfo *This = ScriptTypeInfo_from_ITypeInfo(iface);
+    HRESULT hr;
+
+    TRACE("(%p)->(%x %p)\n", This, hRefType, ppTInfo);
+
+    if (!ppTInfo || (INT)hRefType < 0) return E_INVALIDARG;
+
+    if (hRefType & ~3) return E_FAIL;
+    if (hRefType & 1)
+    {
+        hr = get_dispatch_typeinfo(ppTInfo);
+        if (FAILED(hr)) return hr;
+    }
+    else
+        *ppTInfo = iface;
+
+    ITypeInfo_AddRef(*ppTInfo);
+    return S_OK;
+}
+
+static HRESULT WINAPI ScriptTypeInfo_AddressOfMember(ITypeInfo *iface, MEMBERID memid, INVOKEKIND invKind, PVOID *ppv)
+{
+    ScriptTypeInfo *This = ScriptTypeInfo_from_ITypeInfo(iface);
+    ITypeInfo *disp_typeinfo;
+    HRESULT hr;
+
+    TRACE("(%p)->(%d %d %p)\n", This, memid, invKind, ppv);
+
+    if (!ppv) return E_INVALIDARG;
+    *ppv = NULL;
+
+    if (!get_func_from_memid(This, memid) && memid > This->num_vars)
+    {
+        hr = get_dispatch_typeinfo(&disp_typeinfo);
+        if (FAILED(hr)) return hr;
+
+        return ITypeInfo_AddressOfMember(disp_typeinfo, memid, invKind, ppv);
+    }
+    return TYPE_E_BADMODULEKIND;
+}
+
+static HRESULT WINAPI ScriptTypeInfo_CreateInstance(ITypeInfo *iface, IUnknown *pUnkOuter, REFIID riid, PVOID *ppvObj)
+{
+    ScriptTypeInfo *This = ScriptTypeInfo_from_ITypeInfo(iface);
+
+    TRACE("(%p)->(%p %s %p)\n", This, pUnkOuter, debugstr_guid(riid), ppvObj);
+
+    if (!ppvObj) return E_INVALIDARG;
+
+    *ppvObj = NULL;
+    return TYPE_E_BADMODULEKIND;
+}
+
+static HRESULT WINAPI ScriptTypeInfo_GetMops(ITypeInfo *iface, MEMBERID memid, BSTR *pBstrMops)
+{
+    ScriptTypeInfo *This = ScriptTypeInfo_from_ITypeInfo(iface);
+    ITypeInfo *disp_typeinfo;
+    HRESULT hr;
+
+    TRACE("(%p)->(%d %p)\n", This, memid, pBstrMops);
+
+    if (!pBstrMops) return E_INVALIDARG;
+
+    if (!get_func_from_memid(This, memid) && memid > This->num_vars)
+    {
+        hr = get_dispatch_typeinfo(&disp_typeinfo);
+        if (FAILED(hr)) return hr;
+
+        return ITypeInfo_GetMops(disp_typeinfo, memid, pBstrMops);
+    }
+
+    *pBstrMops = NULL;
+    return S_OK;
+}
+
+static HRESULT WINAPI ScriptTypeInfo_GetContainingTypeLib(ITypeInfo *iface, ITypeLib **ppTLib, UINT *pIndex)
+{
+    ScriptTypeInfo *This = ScriptTypeInfo_from_ITypeInfo(iface);
+
+    FIXME("(%p)->(%p %p)\n", This, ppTLib, pIndex);
+
+    return E_NOTIMPL;
+}
+
+static void WINAPI ScriptTypeInfo_ReleaseTypeAttr(ITypeInfo *iface, TYPEATTR *pTypeAttr)
+{
+    ScriptTypeInfo *This = ScriptTypeInfo_from_ITypeInfo(iface);
+
+    TRACE("(%p)->(%p)\n", This, pTypeAttr);
+
+    heap_free(pTypeAttr);
+}
+
+static void WINAPI ScriptTypeInfo_ReleaseFuncDesc(ITypeInfo *iface, FUNCDESC *pFuncDesc)
+{
+    ScriptTypeInfo *This = ScriptTypeInfo_from_ITypeInfo(iface);
+
+    TRACE("(%p)->(%p)\n", This, pFuncDesc);
+
+    heap_free(pFuncDesc);
+}
+
+static void WINAPI ScriptTypeInfo_ReleaseVarDesc(ITypeInfo *iface, VARDESC *pVarDesc)
+{
+    ScriptTypeInfo *This = ScriptTypeInfo_from_ITypeInfo(iface);
+
+    TRACE("(%p)->(%p)\n", This, pVarDesc);
+
+    heap_free(pVarDesc);
+}
+
+static const ITypeInfoVtbl ScriptTypeInfoVtbl = {
+    ScriptTypeInfo_QueryInterface,
+    ScriptTypeInfo_AddRef,
+    ScriptTypeInfo_Release,
+    ScriptTypeInfo_GetTypeAttr,
+    ScriptTypeInfo_GetTypeComp,
+    ScriptTypeInfo_GetFuncDesc,
+    ScriptTypeInfo_GetVarDesc,
+    ScriptTypeInfo_GetNames,
+    ScriptTypeInfo_GetRefTypeOfImplType,
+    ScriptTypeInfo_GetImplTypeFlags,
+    ScriptTypeInfo_GetIDsOfNames,
+    ScriptTypeInfo_Invoke,
+    ScriptTypeInfo_GetDocumentation,
+    ScriptTypeInfo_GetDllEntry,
+    ScriptTypeInfo_GetRefTypeInfo,
+    ScriptTypeInfo_AddressOfMember,
+    ScriptTypeInfo_CreateInstance,
+    ScriptTypeInfo_GetMops,
+    ScriptTypeInfo_GetContainingTypeLib,
+    ScriptTypeInfo_ReleaseTypeAttr,
+    ScriptTypeInfo_ReleaseFuncDesc,
+    ScriptTypeInfo_ReleaseVarDesc
+};
+
+static HRESULT WINAPI ScriptTypeComp_QueryInterface(ITypeComp *iface, REFIID riid, void **ppv)
+{
+    ScriptTypeInfo *This = ScriptTypeInfo_from_ITypeComp(iface);
+    return ITypeInfo_QueryInterface(&This->ITypeInfo_iface, riid, ppv);
+}
+
+static ULONG WINAPI ScriptTypeComp_AddRef(ITypeComp *iface)
+{
+    ScriptTypeInfo *This = ScriptTypeInfo_from_ITypeComp(iface);
+    return ITypeInfo_AddRef(&This->ITypeInfo_iface);
+}
+
+static ULONG WINAPI ScriptTypeComp_Release(ITypeComp *iface)
+{
+    ScriptTypeInfo *This = ScriptTypeInfo_from_ITypeComp(iface);
+    return ITypeInfo_Release(&This->ITypeInfo_iface);
+}
+
+static HRESULT WINAPI ScriptTypeComp_Bind(ITypeComp *iface, LPOLESTR szName, ULONG lHashVal, WORD wFlags,
+        ITypeInfo **ppTInfo, DESCKIND *pDescKind, BINDPTR *pBindPtr)
+{
+    ScriptTypeInfo *This = ScriptTypeInfo_from_ITypeComp(iface);
+    UINT flags = wFlags ? wFlags : ~0;
+    ITypeInfo *disp_typeinfo;
+    ITypeComp *disp_typecomp;
+    HRESULT hr;
+    UINT i;
+
+    TRACE("(%p)->(%s %08x %d %p %p %p)\n", This, debugstr_w(szName), lHashVal,
+          wFlags, ppTInfo, pDescKind, pBindPtr);
+
+    if (!szName || !ppTInfo || !pDescKind || !pBindPtr)
+        return E_INVALIDARG;
+
+    for (i = 0; i < This->num_funcs; i++)
+    {
+        if (wcsicmp(szName, This->funcs[i].func->name)) continue;
+        if (!(flags & INVOKE_FUNC)) return TYPE_E_TYPEMISMATCH;
+
+        hr = ITypeInfo_GetFuncDesc(&This->ITypeInfo_iface, i, &pBindPtr->lpfuncdesc);
+        if (FAILED(hr)) return hr;
+
+        *pDescKind = DESCKIND_FUNCDESC;
+        *ppTInfo = &This->ITypeInfo_iface;
+        ITypeInfo_AddRef(*ppTInfo);
+        return S_OK;
+    }
+
+    for (i = 0; i < This->num_vars; i++)
+    {
+        if (wcsicmp(szName, This->disp->global_vars[i]->name)) continue;
+        if (!(flags & INVOKE_PROPERTYGET)) return TYPE_E_TYPEMISMATCH;
+
+        hr = ITypeInfo_GetVarDesc(&This->ITypeInfo_iface, i, &pBindPtr->lpvardesc);
+        if (FAILED(hr)) return hr;
+
+        *pDescKind = DESCKIND_VARDESC;
+        *ppTInfo = &This->ITypeInfo_iface;
+        ITypeInfo_AddRef(*ppTInfo);
+        return S_OK;
+    }
+
+    /* Look into the inherited IDispatch */
+    hr = get_dispatch_typeinfo(&disp_typeinfo);
+    if (FAILED(hr)) return hr;
+
+    hr = ITypeInfo_GetTypeComp(disp_typeinfo, &disp_typecomp);
+    if (FAILED(hr)) return hr;
+
+    hr = ITypeComp_Bind(disp_typecomp, szName, lHashVal, wFlags, ppTInfo, pDescKind, pBindPtr);
+    ITypeComp_Release(disp_typecomp);
+    return hr;
+}
+
+static HRESULT WINAPI ScriptTypeComp_BindType(ITypeComp *iface, LPOLESTR szName, ULONG lHashVal,
+        ITypeInfo **ppTInfo, ITypeComp **ppTComp)
+{
+    ScriptTypeInfo *This = ScriptTypeInfo_from_ITypeComp(iface);
+    ITypeInfo *disp_typeinfo;
+    ITypeComp *disp_typecomp;
+    HRESULT hr;
+
+    TRACE("(%p)->(%s %08x %p %p)\n", This, debugstr_w(szName), lHashVal, ppTInfo, ppTComp);
+
+    if (!szName || !ppTInfo || !ppTComp)
+        return E_INVALIDARG;
+
+    /* Look into the inherited IDispatch */
+    hr = get_dispatch_typeinfo(&disp_typeinfo);
+    if (FAILED(hr)) return hr;
+
+    hr = ITypeInfo_GetTypeComp(disp_typeinfo, &disp_typecomp);
+    if (FAILED(hr)) return hr;
+
+    hr = ITypeComp_BindType(disp_typecomp, szName, lHashVal, ppTInfo, ppTComp);
+    ITypeComp_Release(disp_typecomp);
+    return hr;
+}
+
+static const ITypeCompVtbl ScriptTypeCompVtbl = {
+    ScriptTypeComp_QueryInterface,
+    ScriptTypeComp_AddRef,
+    ScriptTypeComp_Release,
+    ScriptTypeComp_Bind,
+    ScriptTypeComp_BindType
+};
 
 static inline ScriptDisp *ScriptDisp_from_IDispatchEx(IDispatchEx *iface)
 {
@@ -611,12 +1243,19 @@ static ULONG WINAPI ScriptDisp_Release(IDispatchEx *iface)
 {
     ScriptDisp *This = ScriptDisp_from_IDispatchEx(iface);
     LONG ref = InterlockedDecrement(&This->ref);
+    unsigned i;
 
     TRACE("(%p) ref=%d\n", This, ref);
 
     if(!ref) {
         assert(!This->ctx);
-        heap_free(This->ident_map);
+
+        for (i = 0; i < This->global_vars_cnt; i++)
+            release_dynamic_var(This->global_vars[i]);
+
+        heap_pool_free(&This->heap);
+        heap_free(This->global_vars);
+        heap_free(This->global_funcs);
         heap_free(This);
     }
 
@@ -633,12 +1272,53 @@ static HRESULT WINAPI ScriptDisp_GetTypeInfoCount(IDispatchEx *iface, UINT *pcti
     return S_OK;
 }
 
-static HRESULT WINAPI ScriptDisp_GetTypeInfo(IDispatchEx *iface, UINT iTInfo, LCID lcid,
-                                              ITypeInfo **ppTInfo)
+static HRESULT WINAPI ScriptDisp_GetTypeInfo(IDispatchEx *iface, UINT iTInfo, LCID lcid, ITypeInfo **ret)
 {
     ScriptDisp *This = ScriptDisp_from_IDispatchEx(iface);
-    FIXME("(%p)->(%u %u %p)\n", This, iTInfo, lcid, ppTInfo);
-    return E_NOTIMPL;
+    ScriptTypeInfo *type_info;
+    UINT num_funcs = 0;
+    unsigned i, j;
+
+    TRACE("(%p)->(%u %u %p)\n", This, iTInfo, lcid, ret);
+
+    if(iTInfo)
+        return DISP_E_BADINDEX;
+
+    if(!(type_info = heap_alloc(sizeof(*type_info))))
+        return E_OUTOFMEMORY;
+
+    for(i = 0; i < This->global_funcs_cnt; i++)
+        if(This->global_funcs[i]->is_public)
+            num_funcs++;
+
+    type_info->ITypeInfo_iface.lpVtbl = &ScriptTypeInfoVtbl;
+    type_info->ITypeComp_iface.lpVtbl = &ScriptTypeCompVtbl;
+    type_info->ref = 1;
+    type_info->num_funcs = num_funcs;
+    type_info->num_vars = This->global_vars_cnt;
+    type_info->disp = This;
+
+    type_info->funcs = heap_alloc(sizeof(*type_info->funcs) * num_funcs);
+    if(!type_info->funcs)
+    {
+        heap_free(type_info);
+        return E_OUTOFMEMORY;
+    }
+
+    for(j = 0, i = 0; i < This->global_funcs_cnt; i++)
+    {
+        if(!This->global_funcs[i]->is_public) continue;
+
+        type_info->funcs[j].memid = i + 1 + DISPID_FUNCTION_MASK;
+        type_info->funcs[j].func = This->global_funcs[i];
+        grab_vbscode(This->global_funcs[i]->code_ctx);
+        j++;
+    }
+
+    IDispatchEx_AddRef(&This->IDispatchEx_iface);
+
+    *ret = &type_info->ITypeInfo_iface;
+    return S_OK;
 }
 
 static HRESULT WINAPI ScriptDisp_GetIDsOfNames(IDispatchEx *iface, REFIID riid,
@@ -675,44 +1355,23 @@ static HRESULT WINAPI ScriptDisp_Invoke(IDispatchEx *iface, DISPID dispIdMember,
 static HRESULT WINAPI ScriptDisp_GetDispID(IDispatchEx *iface, BSTR bstrName, DWORD grfdex, DISPID *pid)
 {
     ScriptDisp *This = ScriptDisp_from_IDispatchEx(iface);
-    dynamic_var_t *var;
-    ident_map_t *ident;
-    function_t *func;
+    unsigned i;
 
     TRACE("(%p)->(%s %x %p)\n", This, debugstr_w(bstrName), grfdex, pid);
 
     if(!This->ctx)
         return E_UNEXPECTED;
 
-    for(ident = This->ident_map; ident < This->ident_map+This->ident_map_cnt; ident++) {
-        if(!wcsicmp(ident->name, bstrName)) {
-            *pid = ident_to_id(This, ident);
+    for(i = 0; i < This->global_vars_cnt; i++) {
+        if(!wcsicmp(This->global_vars[i]->name, bstrName)) {
+            *pid = i + 1;
             return S_OK;
         }
     }
 
-    for(var = This->ctx->global_vars; var; var = var->next) {
-        if(!wcsicmp(var->name, bstrName)) {
-            ident = add_ident(This, var->name);
-            if(!ident)
-                return E_OUTOFMEMORY;
-
-            ident->is_var = TRUE;
-            ident->u.var = var;
-            *pid = ident_to_id(This, ident);
-            return S_OK;
-        }
-    }
-
-    for(func = This->ctx->global_funcs; func; func = func->next) {
-        if(!wcsicmp(func->name, bstrName)) {
-            ident = add_ident(This, func->name);
-            if(!ident)
-                return E_OUTOFMEMORY;
-
-            ident->is_var = FALSE;
-            ident->u.func = func;
-            *pid =  ident_to_id(This, ident);
+    for(i = 0; i < This->global_funcs_cnt; i++) {
+        if(!wcsicmp(This->global_funcs[i]->name, bstrName)) {
+            *pid = i + 1 + DISPID_FUNCTION_MASK;
             return S_OK;
         }
     }
@@ -725,35 +1384,43 @@ static HRESULT WINAPI ScriptDisp_InvokeEx(IDispatchEx *iface, DISPID id, LCID lc
         VARIANT *pvarRes, EXCEPINFO *pei, IServiceProvider *pspCaller)
 {
     ScriptDisp *This = ScriptDisp_from_IDispatchEx(iface);
-    ident_map_t *ident;
     HRESULT hres;
 
     TRACE("(%p)->(%x %x %x %p %p %p %p)\n", This, id, lcid, wFlags, pdp, pvarRes, pei, pspCaller);
 
-    ident = id_to_ident(This, id);
-    if(!ident)
-        return DISP_E_MEMBERNOTFOUND;
+    if (!This->ctx)
+        return E_UNEXPECTED;
 
-    if(ident->is_var) {
-        if(ident->u.var->is_const) {
-            FIXME("const not supported\n");
-            return E_NOTIMPL;
+    if (id & DISPID_FUNCTION_MASK)
+    {
+        id &= ~DISPID_FUNCTION_MASK;
+        if (id > This->global_funcs_cnt)
+            return DISP_E_MEMBERNOTFOUND;
+
+        switch (wFlags)
+        {
+        case DISPATCH_METHOD:
+        case DISPATCH_METHOD | DISPATCH_PROPERTYGET:
+            hres = exec_script(This->ctx, TRUE, This->global_funcs[id - 1], NULL, pdp, pvarRes);
+            break;
+        default:
+            FIXME("Unsupported flags %x\n", wFlags);
+            hres = E_NOTIMPL;
         }
 
-        return invoke_variant_prop(This->ctx, &ident->u.var->v, wFlags, pdp, pvarRes);
+        return hres;
     }
 
-    switch(wFlags) {
-    case DISPATCH_METHOD:
-    case DISPATCH_METHOD|DISPATCH_PROPERTYGET:
-        hres = exec_script(This->ctx, TRUE, ident->u.func, NULL, pdp, pvarRes);
-        break;
-    default:
-        FIXME("Unsupported flags %x\n", wFlags);
-        hres = E_NOTIMPL;
+    if (id > This->global_vars_cnt)
+        return DISP_E_MEMBERNOTFOUND;
+
+    if (This->global_vars[id - 1]->is_const)
+    {
+        FIXME("const not supported\n");
+        return E_NOTIMPL;
     }
 
-    return hres;
+    return invoke_variant_prop(This->ctx, &This->global_vars[id - 1]->v, wFlags, pdp, pvarRes);
 }
 
 static HRESULT WINAPI ScriptDisp_DeleteMemberByName(IDispatchEx *iface, BSTR bstrName, DWORD grfdex)
@@ -827,6 +1494,7 @@ HRESULT create_script_disp(script_ctx_t *ctx, ScriptDisp **ret)
     script_disp->IDispatchEx_iface.lpVtbl = &ScriptDispVtbl;
     script_disp->ref = 1;
     script_disp->ctx = ctx;
+    heap_pool_init(&script_disp->heap);
 
     *ret = script_disp;
     return S_OK;
@@ -952,15 +1620,21 @@ HRESULT disp_call(script_ctx_t *ctx, IDispatch *disp, DISPID id, DISPPARAMS *dp,
         return invoke_vbdisp(vbdisp, id, flags, FALSE, dp, retv);
 
     hres = IDispatch_QueryInterface(disp, &IID_IDispatchEx, (void**)&dispex);
-    if(FAILED(hres)) {
+    if(SUCCEEDED(hres)) {
+        hres = IDispatchEx_InvokeEx(dispex, id, ctx->lcid, flags, dp, retv, &ei, NULL /* CALLER_FIXME */);
+        IDispatchEx_Release(dispex);
+    }else {
         UINT err = 0;
 
         TRACE("using IDispatch\n");
-        return IDispatch_Invoke(disp, id, &IID_NULL, ctx->lcid, flags, dp, retv, &ei, &err);
+        hres = IDispatch_Invoke(disp, id, &IID_NULL, ctx->lcid, flags, dp, retv, &ei, &err);
     }
 
-    hres = IDispatchEx_InvokeEx(dispex, id, ctx->lcid, flags, dp, retv, &ei, NULL /* CALLER_FIXME */);
-    IDispatchEx_Release(dispex);
+    if(hres == DISP_E_EXCEPTION) {
+        clear_ei(&ctx->ei);
+        ctx->ei = ei;
+        hres = SCRIPT_E_RECORDED;
+    }
     return hres;
 }
 
@@ -994,5 +1668,10 @@ HRESULT disp_propput(script_ctx_t *ctx, IDispatch *disp, DISPID id, WORD flags, 
         hres = IDispatch_Invoke(disp, id, &IID_NULL, ctx->lcid, flags, dp, NULL, &ei, &err);
     }
 
+    if(hres == DISP_E_EXCEPTION) {
+        clear_ei(&ctx->ei);
+        ctx->ei = ei;
+        hres = SCRIPT_E_RECORDED;
+    }
     return hres;
 }

--- a/dll/win32/vbscript/vbscript.c
+++ b/dll/win32/vbscript/vbscript.c
@@ -61,7 +61,18 @@ typedef struct {
     IActiveScriptError IActiveScriptError_iface;
     LONG ref;
     EXCEPINFO ei;
+    DWORD_PTR cookie;
+    unsigned line;
+    unsigned character;
 } VBScriptError;
+
+static inline WCHAR *heap_pool_strdup(heap_pool_t *heap, const WCHAR *str)
+{
+    size_t size = (lstrlenW(str) + 1) * sizeof(WCHAR);
+    WCHAR *ret = heap_pool_alloc(heap, size);
+    if (ret) memcpy(ret, str, size);
+    return ret;
+}
 
 static void change_state(VBScript *This, SCRIPTSTATE state)
 {
@@ -82,6 +93,97 @@ static inline BOOL is_started(VBScript *This)
 
 static HRESULT exec_global_code(script_ctx_t *ctx, vbscode_t *code, VARIANT *res)
 {
+    ScriptDisp *obj = ctx->script_obj;
+    function_t *func_iter, **new_funcs;
+    dynamic_var_t *var, **new_vars;
+    size_t cnt, i;
+    HRESULT hres;
+
+    if(code->named_item) {
+        if(!code->named_item->script_obj) {
+            hres = create_script_disp(ctx, &code->named_item->script_obj);
+            if(FAILED(hres)) return hres;
+        }
+        obj = code->named_item->script_obj;
+    }
+
+    cnt = obj->global_vars_cnt + code->main_code.var_cnt;
+    if (cnt > obj->global_vars_size)
+    {
+        if (obj->global_vars)
+            new_vars = heap_realloc(obj->global_vars, cnt * sizeof(*new_vars));
+        else
+            new_vars = heap_alloc(cnt * sizeof(*new_vars));
+        if (!new_vars)
+            return E_OUTOFMEMORY;
+        obj->global_vars = new_vars;
+        obj->global_vars_size = cnt;
+    }
+
+    cnt = obj->global_funcs_cnt;
+    for (func_iter = code->funcs; func_iter; func_iter = func_iter->next)
+        cnt++;
+    if (cnt > obj->global_funcs_size)
+    {
+        if (obj->global_funcs)
+            new_funcs = heap_realloc(obj->global_funcs, cnt * sizeof(*new_funcs));
+        else
+            new_funcs = heap_alloc(cnt * sizeof(*new_funcs));
+        if (!new_funcs)
+            return E_OUTOFMEMORY;
+        obj->global_funcs = new_funcs;
+        obj->global_funcs_size = cnt;
+    }
+
+    for (i = 0; i < code->main_code.var_cnt; i++)
+    {
+        if (!(var = heap_pool_alloc(&obj->heap, sizeof(*var))))
+            return E_OUTOFMEMORY;
+
+        var->name = heap_pool_strdup(&obj->heap, code->main_code.vars[i].name);
+        if (!var->name)
+            return E_OUTOFMEMORY;
+        V_VT(&var->v) = VT_EMPTY;
+        var->is_const = FALSE;
+        var->array = NULL;
+
+        obj->global_vars[obj->global_vars_cnt + i] = var;
+    }
+
+    obj->global_vars_cnt += code->main_code.var_cnt;
+
+    for (func_iter = code->funcs; func_iter; func_iter = func_iter->next)
+    {
+        for (i = 0; i < obj->global_funcs_cnt; i++)
+        {
+            if (!wcsicmp(obj->global_funcs[i]->name, func_iter->name))
+            {
+                /* global function already exists, replace it */
+                obj->global_funcs[i] = func_iter;
+                break;
+            }
+        }
+        if (i == obj->global_funcs_cnt)
+            obj->global_funcs[obj->global_funcs_cnt++] = func_iter;
+    }
+
+    if (code->classes)
+    {
+        class_desc_t *class = code->classes;
+
+        while (1)
+        {
+            class->ctx = ctx;
+            if (!class->next)
+                break;
+            class = class->next;
+        }
+
+        class->next = obj->classes;
+        obj->classes = code->classes;
+        code->last_class = class;
+    }
+
     code->pending_exec = FALSE;
     return exec_script(ctx, TRUE, &code->main_code, NULL, NULL, res);
 }
@@ -96,68 +198,104 @@ static void exec_queued_code(script_ctx_t *ctx)
     }
 }
 
-IDispatch *lookup_named_item(script_ctx_t *ctx, const WCHAR *name, unsigned flags)
+static HRESULT retrieve_named_item_disp(IActiveScriptSite *site, named_item_t *item)
+{
+    IUnknown *unk;
+    HRESULT hres;
+
+    hres = IActiveScriptSite_GetItemInfo(site, item->name, SCRIPTINFO_IUNKNOWN, &unk, NULL);
+    if(FAILED(hres)) {
+        WARN("GetItemInfo failed: %08x\n", hres);
+        return hres;
+    }
+
+    hres = IUnknown_QueryInterface(unk, &IID_IDispatch, (void**)&item->disp);
+    IUnknown_Release(unk);
+    if(FAILED(hres)) {
+        WARN("object does not implement IDispatch\n");
+        return hres;
+    }
+
+    return S_OK;
+}
+
+named_item_t *lookup_named_item(script_ctx_t *ctx, const WCHAR *name, unsigned flags)
 {
     named_item_t *item;
     HRESULT hres;
 
     LIST_FOR_EACH_ENTRY(item, &ctx->named_items, named_item_t, entry) {
         if((item->flags & flags) == flags && !wcsicmp(item->name, name)) {
-            if(!item->disp) {
-                IUnknown *unk;
-
-                hres = IActiveScriptSite_GetItemInfo(ctx->site, item->name,
-                                                     SCRIPTINFO_IUNKNOWN, &unk, NULL);
-                if(FAILED(hres)) {
-                    WARN("GetItemInfo failed: %08x\n", hres);
-                    continue;
-                }
-
-                hres = IUnknown_QueryInterface(unk, &IID_IDispatch, (void**)&item->disp);
-                IUnknown_Release(unk);
-                if(FAILED(hres)) {
-                    WARN("object does not implement IDispatch\n");
-                    continue;
-                }
+            if(!item->script_obj && !(item->flags & SCRIPTITEM_GLOBALMEMBERS)) {
+                hres = create_script_disp(ctx, &item->script_obj);
+                if(FAILED(hres)) return NULL;
             }
 
-            return item->disp;
+            if(!item->disp && (flags || !(item->flags & SCRIPTITEM_CODEONLY))) {
+                hres = retrieve_named_item_disp(ctx->site, item);
+                if(FAILED(hres)) continue;
+            }
+
+            return item;
         }
     }
 
     return NULL;
 }
 
+static void release_named_item_script_obj(named_item_t *item)
+{
+    if(!item->script_obj) return;
+
+    item->script_obj->ctx = NULL;
+    IDispatchEx_Release(&item->script_obj->IDispatchEx_iface);
+    item->script_obj = NULL;
+}
+
+void release_named_item(named_item_t *item)
+{
+    if(--item->ref) return;
+
+    heap_free(item->name);
+    heap_free(item);
+}
+
 static void release_script(script_ctx_t *ctx)
 {
-    class_desc_t *class_desc;
+    named_item_t *item, *item_next;
+    vbscode_t *code, *code_next;
 
     collect_objects(ctx);
     clear_ei(&ctx->ei);
 
-    release_dynamic_vars(ctx->global_vars);
-    ctx->global_vars = NULL;
-
-    while(!list_empty(&ctx->named_items)) {
-        named_item_t *iter = LIST_ENTRY(list_head(&ctx->named_items), named_item_t, entry);
-
-        list_remove(&iter->entry);
-        if(iter->disp)
-            IDispatch_Release(iter->disp);
-        heap_free(iter->name);
-        heap_free(iter);
+    LIST_FOR_EACH_ENTRY_SAFE(code, code_next, &ctx->code_list, vbscode_t, entry)
+    {
+        if(code->is_persistent)
+        {
+            code->pending_exec = TRUE;
+            if(code->last_class) code->last_class->next = NULL;
+            if(code->named_item) release_named_item_script_obj(code->named_item);
+        }
+        else
+        {
+            list_remove(&code->entry);
+            release_vbscode(code);
+        }
     }
 
-    while(ctx->procs) {
-        class_desc = ctx->procs;
-        ctx->procs = class_desc->next;
-
-        heap_free(class_desc);
-    }
-
-    if(ctx->host_global) {
-        IDispatch_Release(ctx->host_global);
-        ctx->host_global = NULL;
+    LIST_FOR_EACH_ENTRY_SAFE(item, item_next, &ctx->named_items, named_item_t, entry)
+    {
+        if(item->disp)
+        {
+            IDispatch_Release(item->disp);
+            item->disp = NULL;
+        }
+        release_named_item_script_obj(item);
+        if(!(item->flags & SCRIPTITEM_ISPERSISTENT))
+        {
+            list_remove(&item->entry);
+            release_named_item(item);
+        }
     }
 
     if(ctx->secmgr) {
@@ -177,19 +315,25 @@ static void release_script(script_ctx_t *ctx)
         script_obj->ctx = NULL;
         IDispatchEx_Release(&script_obj->IDispatchEx_iface);
     }
-
-    detach_global_objects(ctx);
-    heap_pool_free(&ctx->heap);
-    heap_pool_init(&ctx->heap);
 }
 
-static void destroy_script(script_ctx_t *ctx)
+static void release_code_list(script_ctx_t *ctx)
 {
-    while(!list_empty(&ctx->code_list))
-        release_vbscode(LIST_ENTRY(list_head(&ctx->code_list), vbscode_t, entry));
+    while(!list_empty(&ctx->code_list)) {
+        vbscode_t *iter = LIST_ENTRY(list_head(&ctx->code_list), vbscode_t, entry);
 
-    release_script(ctx);
-    heap_free(ctx);
+        list_remove(&iter->entry);
+        release_vbscode(iter);
+    }
+}
+
+static void release_named_item_list(script_ctx_t *ctx)
+{
+    while(!list_empty(&ctx->named_items)) {
+        named_item_t *iter = LIST_ENTRY(list_head(&ctx->named_items), named_item_t, entry);
+        list_remove(&iter->entry);
+        release_named_item(iter);
+    }
 }
 
 static void decrease_state(VBScript *This, SCRIPTSTATE state)
@@ -202,16 +346,19 @@ static void decrease_state(VBScript *This, SCRIPTSTATE state)
         /* FALLTHROUGH */
     case SCRIPTSTATE_STARTED:
     case SCRIPTSTATE_DISCONNECTED:
-        if(This->state == SCRIPTSTATE_DISCONNECTED)
-            change_state(This, SCRIPTSTATE_INITIALIZED);
-        if(state == SCRIPTSTATE_INITIALIZED)
-            break;
+        change_state(This, SCRIPTSTATE_INITIALIZED);
         /* FALLTHROUGH */
     case SCRIPTSTATE_INITIALIZED:
     case SCRIPTSTATE_UNINITIALIZED:
         change_state(This, state);
+        if(state == SCRIPTSTATE_INITIALIZED)
+            break;
         release_script(This->ctx);
         This->thread_id = 0;
+        if(state == SCRIPTSTATE_CLOSED) {
+            release_code_list(This->ctx);
+            release_named_item_list(This->ctx);
+        }
         break;
     case SCRIPTSTATE_CLOSED:
         break;
@@ -285,14 +432,14 @@ static HRESULT WINAPI VBScriptError_GetSourcePosition(IActiveScriptError *iface,
 {
     VBScriptError *This = impl_from_IActiveScriptError(iface);
 
-    FIXME("(%p)->(%p %p %p)\n", This, source_context, line, character);
+    TRACE("(%p)->(%p %p %p)\n", This, source_context, line, character);
 
     if(source_context)
-        *source_context = 0;
+        *source_context = This->cookie;
     if(line)
-        *line = 0;
+        *line = This->line;
     if(character)
-        *character = 0;
+        *character = This->character;
     return S_OK;
 }
 
@@ -312,9 +459,10 @@ static const IActiveScriptErrorVtbl VBScriptErrorVtbl = {
     VBScriptError_GetSourceLineText
 };
 
-HRESULT report_script_error(script_ctx_t *ctx)
+HRESULT report_script_error(script_ctx_t *ctx, const vbscode_t *code, unsigned loc)
 {
     VBScriptError *error;
+    const WCHAR *p, *nl;
     HRESULT hres, result;
 
     if(!(error = heap_alloc(sizeof(*error))))
@@ -325,6 +473,16 @@ HRESULT report_script_error(script_ctx_t *ctx)
     error->ei = ctx->ei;
     memset(&ctx->ei, 0, sizeof(ctx->ei));
     result = error->ei.scode;
+
+    p = code->source;
+    error->cookie = code->cookie;
+    error->line = code->start_line;
+    for(nl = p = code->source; p < code->source + loc; p++) {
+        if(*p != '\n') continue;
+        error->line++;
+        nl = p + 1;
+    }
+    error->character = code->source + loc - nl;
 
     hres = IActiveScriptSite_OnScriptError(ctx->site, &error->IActiveScriptError_iface);
     IActiveScriptError_Release(&error->IActiveScriptError_iface);
@@ -359,7 +517,7 @@ static HRESULT WINAPI VBScript_QueryInterface(IActiveScript *iface, REFIID riid,
         TRACE("(%p)->(IID_IObjectSafety %p)\n", This, ppv);
         *ppv = &This->IObjectSafety_iface;
     }else {
-        FIXME("(%p)->(%s %p)\n", This, debugstr_guid(riid), ppv);
+        WARN("(%p)->(%s %p)\n", This, debugstr_guid(riid), ppv);
         *ppv = NULL;
         return E_NOINTERFACE;
     }
@@ -387,7 +545,8 @@ static ULONG WINAPI VBScript_Release(IActiveScript *iface)
 
     if(!ref) {
         decrease_state(This, SCRIPTSTATE_CLOSED);
-        destroy_script(This->ctx);
+        detach_global_objects(This->ctx);
+        heap_free(This->ctx);
         heap_free(This);
     }
 
@@ -397,6 +556,7 @@ static ULONG WINAPI VBScript_Release(IActiveScript *iface)
 static HRESULT WINAPI VBScript_SetScriptSite(IActiveScript *iface, IActiveScriptSite *pass)
 {
     VBScript *This = impl_from_IActiveScript(iface);
+    named_item_t *item;
     LCID lcid;
     HRESULT hres;
 
@@ -410,6 +570,19 @@ static HRESULT WINAPI VBScript_SetScriptSite(IActiveScript *iface, IActiveScript
 
     if(InterlockedCompareExchange(&This->thread_id, GetCurrentThreadId(), 0))
         return E_UNEXPECTED;
+
+    /* Retrieve new dispatches for persistent named items */
+    LIST_FOR_EACH_ENTRY(item, &This->ctx->named_items, named_item_t, entry)
+    {
+        if(!item->disp)
+        {
+            hres = retrieve_named_item_disp(pass, item);
+            if(FAILED(hres)) return hres;
+        }
+
+        /* For some reason, CODEONLY flag is lost in re-initialized scripts */
+        item->flags &= ~SCRIPTITEM_CODEONLY;
+    }
 
     hres = create_script_disp(This->ctx, &This->ctx->script_obj);
     if(FAILED(hres))
@@ -452,7 +625,7 @@ static HRESULT WINAPI VBScript_SetScriptState(IActiveScript *iface, SCRIPTSTATE 
         return S_OK;
     }
 
-    if(!This->is_initialized)
+    if(!This->is_initialized || (!This->ctx->site && ss != SCRIPTSTATE_CLOSED))
         return E_UNEXPECTED;
 
     switch(ss) {
@@ -464,7 +637,10 @@ static HRESULT WINAPI VBScript_SetScriptState(IActiveScript *iface, SCRIPTSTATE 
         exec_queued_code(This->ctx);
         break;
     case SCRIPTSTATE_INITIALIZED:
-        FIXME("unimplemented SCRIPTSTATE_INITIALIZED\n");
+        decrease_state(This, SCRIPTSTATE_INITIALIZED);
+        return S_OK;
+    case SCRIPTSTATE_CLOSED:
+        decrease_state(This, SCRIPTSTATE_CLOSED);
         return S_OK;
     case SCRIPTSTATE_DISCONNECTED:
         FIXME("unimplemented SCRIPTSTATE_DISCONNECTED\n");
@@ -534,11 +710,6 @@ static HRESULT WINAPI VBScript_AddNamedItem(IActiveScript *iface, LPCOLESTR pstr
             WARN("object does not implement IDispatch\n");
             return hres;
         }
-
-        if(This->ctx->host_global)
-            IDispatch_Release(This->ctx->host_global);
-        IDispatch_AddRef(disp);
-        This->ctx->host_global = disp;
     }
 
     item = heap_alloc(sizeof(*item));
@@ -548,8 +719,10 @@ static HRESULT WINAPI VBScript_AddNamedItem(IActiveScript *iface, LPCOLESTR pstr
         return E_OUTOFMEMORY;
     }
 
+    item->ref = 1;
     item->disp = disp;
     item->flags = dwFlags;
+    item->script_obj = NULL;
     item->name = heap_strdupW(pstrName);
     if(!item->name) {
         if(disp)
@@ -573,8 +746,9 @@ static HRESULT WINAPI VBScript_AddTypeLib(IActiveScript *iface, REFGUID rguidTyp
 static HRESULT WINAPI VBScript_GetScriptDispatch(IActiveScript *iface, LPCOLESTR pstrItemName, IDispatch **ppdisp)
 {
     VBScript *This = impl_from_IActiveScript(iface);
+    ScriptDisp *script_obj;
 
-    TRACE("(%p)->(%p)\n", This, ppdisp);
+    TRACE("(%p)->(%s %p)\n", This, debugstr_w(pstrItemName), ppdisp);
 
     if(!ppdisp)
         return E_POINTER;
@@ -584,7 +758,14 @@ static HRESULT WINAPI VBScript_GetScriptDispatch(IActiveScript *iface, LPCOLESTR
         return E_UNEXPECTED;
     }
 
-    *ppdisp = (IDispatch*)&This->ctx->script_obj->IDispatchEx_iface;
+    script_obj = This->ctx->script_obj;
+    if(pstrItemName) {
+        named_item_t *item = lookup_named_item(This->ctx, pstrItemName, 0);
+        if(!item) return E_INVALIDARG;
+        if(item->script_obj) script_obj = item->script_obj;
+    }
+
+    *ppdisp = (IDispatch*)&script_obj->IDispatchEx_iface;
     IDispatch_AddRef(*ppdisp);
     return S_OK;
 }
@@ -763,7 +944,6 @@ static HRESULT WINAPI VBScriptParse_ParseScriptText(IActiveScriptParse *iface,
         DWORD dwFlags, VARIANT *pvarResult, EXCEPINFO *pexcepinfo)
 {
     VBScript *This = impl_from_IActiveScriptParse(iface);
-    IDispatch *context = NULL;
     vbscode_t *code;
     HRESULT hres;
 
@@ -774,20 +954,10 @@ static HRESULT WINAPI VBScriptParse_ParseScriptText(IActiveScriptParse *iface,
     if(This->thread_id != GetCurrentThreadId() || This->state == SCRIPTSTATE_CLOSED)
         return E_UNEXPECTED;
 
-    if(pstrItemName) {
-        context = lookup_named_item(This->ctx, pstrItemName, 0);
-        if(!context) {
-            WARN("Inknown context %s\n", debugstr_w(pstrItemName));
-            return E_INVALIDARG;
-        }
-    }
-
-    hres = compile_script(This->ctx, pstrCode, pstrDelimiter, dwFlags, &code);
+    hres = compile_script(This->ctx, pstrCode, pstrItemName, pstrDelimiter, dwSourceContextCookie,
+                          ulStartingLine, dwFlags, &code);
     if(FAILED(hres))
         return hres;
-
-    if(context)
-        IDispatch_AddRef(code->context = context);
 
     if(!(dwFlags & SCRIPTTEXT_ISEXPRESSION) && !is_started(This)) {
         code->pending_exec = TRUE;
@@ -846,7 +1016,8 @@ static HRESULT WINAPI VBScriptParseProcedure_ParseProcedureText(IActiveScriptPar
     if(This->thread_id != GetCurrentThreadId() || This->state == SCRIPTSTATE_CLOSED)
         return E_UNEXPECTED;
 
-    hres = compile_procedure(This->ctx, pstrCode, pstrDelimiter, dwFlags, &desc);
+    hres = compile_procedure(This->ctx, pstrCode, pstrItemName, pstrDelimiter, dwSourceContextCookie,
+                             ulStartingLineNumber, dwFlags, &desc);
     if(FAILED(hres))
         return hres;
 
@@ -955,7 +1126,6 @@ HRESULT WINAPI VBScriptFactory_CreateInstance(IClassFactory *iface, IUnknown *pU
     }
 
     ctx->safeopt = INTERFACE_USES_DISPEX;
-    heap_pool_init(&ctx->heap);
     list_init(&ctx->objects);
     list_init(&ctx->code_list);
     list_init(&ctx->named_items);

--- a/dll/win32/vbscript/vbscript.h
+++ b/dll/win32/vbscript/vbscript.h
@@ -60,14 +60,6 @@ typedef struct _vbscode_t vbscode_t;
 typedef struct _script_ctx_t script_ctx_t;
 typedef struct _vbdisp_t vbdisp_t;
 
-typedef struct named_item_t {
-    IDispatch *disp;
-    DWORD flags;
-    LPWSTR name;
-
-    struct list entry;
-} named_item_t;
-
 typedef enum {
     VBDISP_CALLGET,
     VBDISP_LET,
@@ -125,17 +117,30 @@ struct _vbdisp_t {
     VARIANT props[1];
 };
 
-typedef struct _ident_map_t ident_map_t;
+typedef struct _dynamic_var_t {
+    struct _dynamic_var_t *next;
+    VARIANT v;
+    const WCHAR *name;
+    BOOL is_const;
+    SAFEARRAY *array;
+} dynamic_var_t;
 
 typedef struct {
     IDispatchEx IDispatchEx_iface;
     LONG ref;
 
-    ident_map_t *ident_map;
-    unsigned ident_map_cnt;
-    unsigned ident_map_size;
+    dynamic_var_t **global_vars;
+    size_t global_vars_cnt;
+    size_t global_vars_size;
+
+    function_t **global_funcs;
+    size_t global_funcs_cnt;
+    size_t global_funcs_size;
+
+    class_desc_t *classes;
 
     script_ctx_t *ctx;
+    heap_pool_t heap;
 } ScriptDisp;
 
 typedef struct _builtin_prop_t builtin_prop_t;
@@ -147,6 +152,16 @@ typedef struct {
     const builtin_prop_t *members;
     script_ctx_t *ctx;
 } BuiltinDisp;
+
+typedef struct named_item_t {
+    ScriptDisp *script_obj;
+    IDispatch *disp;
+    unsigned ref;
+    DWORD flags;
+    LPWSTR name;
+
+    struct list entry;
+} named_item_t;
 
 HRESULT create_vbdisp(const class_desc_t*,vbdisp_t**) DECLSPEC_HIDDEN;
 HRESULT disp_get_id(IDispatch*,BSTR,vbdisp_invoke_type_t,BOOL,DISPID*) DECLSPEC_HIDDEN;
@@ -169,13 +184,6 @@ static inline VARIANT *get_arg(DISPPARAMS *dp, DWORD i)
     return dp->rgvarg + dp->cArgs-i-1;
 }
 
-typedef struct _dynamic_var_t {
-    struct _dynamic_var_t *next;
-    VARIANT v;
-    const WCHAR *name;
-    BOOL is_const;
-} dynamic_var_t;
-
 struct _script_ctx_t {
     IActiveScriptSite *site;
     LCID lcid;
@@ -183,21 +191,14 @@ struct _script_ctx_t {
     IInternetHostSecurityManager *secmgr;
     DWORD safeopt;
 
-    IDispatch *host_global;
-
     ScriptDisp *script_obj;
 
     BuiltinDisp *global_obj;
     BuiltinDisp *err_obj;
 
     EXCEPINFO ei;
-
-    dynamic_var_t *global_vars;
-    function_t *global_funcs;
-    class_desc_t *classes;
-    class_desc_t *procs;
-
-    heap_pool_t heap;
+    vbscode_t *error_loc_code;
+    unsigned error_loc_offset;
 
     struct list objects;
     struct list code_list;
@@ -225,10 +226,11 @@ typedef enum {
     X(assign_ident,   1, ARG_BSTR,    ARG_UINT)   \
     X(assign_member,  1, ARG_BSTR,    ARG_UINT)   \
     X(bool,           1, ARG_INT,     0)          \
-    X(catch,          1, ARG_ADDR,    ARG_UINT)    \
+    X(catch,          1, ARG_ADDR,    ARG_UINT)   \
     X(case,           0, ARG_ADDR,    0)          \
     X(concat,         1, 0,           0)          \
     X(const,          1, ARG_BSTR,    0)          \
+    X(deref,          1, 0,           0)          \
     X(dim,            1, ARG_BSTR,    ARG_UINT)   \
     X(div,            1, 0,           0)          \
     X(double,         1, ARG_DOUBLE,  0)          \
@@ -267,15 +269,19 @@ typedef enum {
     X(null,           1, 0,           0)          \
     X(or,             1, 0,           0)          \
     X(pop,            1, ARG_UINT,    0)          \
+    X(redim,          1, ARG_BSTR,    ARG_UINT)   \
     X(ret,            0, 0,           0)          \
     X(retval,         1, 0,           0)          \
     X(set_ident,      1, ARG_BSTR,    ARG_UINT)   \
     X(set_member,     1, ARG_BSTR,    ARG_UINT)   \
+    X(stack,          1, ARG_UINT,    0)          \
     X(step,           0, ARG_ADDR,    ARG_BSTR)   \
     X(stop,           1, 0,           0)          \
     X(string,         1, ARG_STR,     0)          \
     X(sub,            1, 0,           0)          \
     X(val,            1, 0,           0)          \
+    X(vcall,          1, ARG_UINT,    0)          \
+    X(vcallv,         1, ARG_UINT,    0)          \
     X(xor,            1, 0,           0)
 
 typedef enum {
@@ -295,6 +301,7 @@ typedef union {
 
 typedef struct {
     vbsop_t op;
+    unsigned loc;
     instr_arg_t arg1;
     instr_arg_t arg2;
 } instr_t;
@@ -335,41 +342,63 @@ struct _function_t {
 
 struct _vbscode_t {
     instr_t *instrs;
+    unsigned ref;
+
     WCHAR *source;
+    DWORD_PTR cookie;
+    unsigned start_line;
 
     BOOL option_explicit;
 
     BOOL pending_exec;
+    BOOL is_persistent;
     function_t main_code;
-    IDispatch *context;
+    named_item_t *named_item;
 
     BSTR *bstr_pool;
     unsigned bstr_pool_size;
     unsigned bstr_cnt;
     heap_pool_t heap;
 
+    function_t *funcs;
+    class_desc_t *classes;
+    class_desc_t *last_class;
+
     struct list entry;
 };
 
+static inline void grab_vbscode(vbscode_t *code)
+{
+    code->ref++;
+}
+
 void release_vbscode(vbscode_t*) DECLSPEC_HIDDEN;
-HRESULT compile_script(script_ctx_t*,const WCHAR*,const WCHAR*,DWORD,vbscode_t**) DECLSPEC_HIDDEN;
-HRESULT compile_procedure(script_ctx_t*,const WCHAR*,const WCHAR*,DWORD,class_desc_t**) DECLSPEC_HIDDEN;
+HRESULT compile_script(script_ctx_t*,const WCHAR*,const WCHAR*,const WCHAR*,DWORD_PTR,unsigned,DWORD,vbscode_t**) DECLSPEC_HIDDEN;
+HRESULT compile_procedure(script_ctx_t*,const WCHAR*,const WCHAR*,const WCHAR*,DWORD_PTR,unsigned,DWORD,class_desc_t**) DECLSPEC_HIDDEN;
 HRESULT exec_script(script_ctx_t*,BOOL,function_t*,vbdisp_t*,DISPPARAMS*,VARIANT*) DECLSPEC_HIDDEN;
-void release_dynamic_vars(dynamic_var_t*) DECLSPEC_HIDDEN;
-IDispatch *lookup_named_item(script_ctx_t*,const WCHAR*,unsigned) DECLSPEC_HIDDEN;
+void release_dynamic_var(dynamic_var_t*) DECLSPEC_HIDDEN;
+named_item_t *lookup_named_item(script_ctx_t*,const WCHAR*,unsigned) DECLSPEC_HIDDEN;
+void release_named_item(named_item_t*) DECLSPEC_HIDDEN;
 void clear_ei(EXCEPINFO*) DECLSPEC_HIDDEN;
-HRESULT report_script_error(script_ctx_t*) DECLSPEC_HIDDEN;
+HRESULT report_script_error(script_ctx_t*,const vbscode_t*,unsigned) DECLSPEC_HIDDEN;
 void detach_global_objects(script_ctx_t*) DECLSPEC_HIDDEN;
 HRESULT get_builtin_id(BuiltinDisp*,const WCHAR*,DISPID*) DECLSPEC_HIDDEN;
 
 void release_regexp_typelib(void) DECLSPEC_HIDDEN;
+HRESULT get_dispatch_typeinfo(ITypeInfo**) DECLSPEC_HIDDEN;
 
 static inline BOOL is_int32(double d)
 {
     return INT32_MIN <= d && d <= INT32_MAX && (double)(int)d == d;
 }
 
+static inline BOOL is_digit(WCHAR c)
+{
+    return '0' <= c && c <= '9';
+}
+
 HRESULT create_regexp(IDispatch**) DECLSPEC_HIDDEN;
+BSTR string_replace(BSTR,BSTR,BSTR,int,int) DECLSPEC_HIDDEN;
 
 HRESULT map_hres(HRESULT) DECLSPEC_HIDDEN;
 

--- a/dll/win32/vbscript/vbscript.rc
+++ b/dll/win32/vbscript/vbscript.rc
@@ -54,6 +54,7 @@ STRINGTABLE
     VBSE_INVALID_DLL_FUNCTION_NAME     "Specified DLL function not found"
     VBSE_INVALID_TYPELIB_VARIABLE      "Variable uses an Automation type not supported in VBScript"
     VBSE_SERVER_NOT_FOUND              "The remote server machine does not exist or is unavailable"
+    VBSE_UNQUALIFIED_REFERENCE         "Invalid or unqualified reference"
 
     VBS_COMPILE_ERROR                  "Microsoft VBScript compilation error"
     VBS_RUNTIME_ERROR                  "Microsoft VBScript runtime error"

--- a/dll/win32/vbscript/vbscript_defs.h
+++ b/dll/win32/vbscript/vbscript_defs.h
@@ -267,6 +267,7 @@
 #define VBSE_INVALID_DLL_FUNCTION_NAME    453
 #define VBSE_INVALID_TYPELIB_VARIABLE     458
 #define VBSE_SERVER_NOT_FOUND             462
+#define VBSE_UNQUALIFIED_REFERENCE        505
 
 #define VBS_COMPILE_ERROR                4096
 #define VBS_RUNTIME_ERROR                4097

--- a/media/doc/WINESYNC.txt
+++ b/media/doc/WINESYNC.txt
@@ -201,7 +201,7 @@ dll/win32/url                 # Synced to WineStaging-3.3
 dll/win32/urlmon              # Synced to WineStaging-4.18
 dll/win32/usp10               # Synced to WineStaging-4.18
 dll/win32/uxtheme             # Forked
-dll/win32/vbscript            # Synced to WineStaging-4.18
+dll/win32/vbscript            # Synced to Wine 18e7e07a77a754c4b48c6c9bde225ad5c7295944
 dll/win32/version             # Synced to WineStaging-4.18
 dll/win32/vssapi              # Synced to WineStaging-4.18
 dll/win32/wbemdisp            # Synced to WineStaging-4.18

--- a/modules/rostests/winetests/vbscript/api.vbs
+++ b/modules/rostests/winetests/vbscript/api.vbs
@@ -243,10 +243,18 @@ Call ok(UBound(x) = 2, "UBound(x) = " & UBound(x))
 Call ok(getVT(UBound(x, 1)) = "VT_I4", "getVT(UBound(x, 1)) = " & getVT(UBound(x, 1)))
 Call ok(UBound(x, 1) = 2, "UBound(x) = " & UBound(x, 1))
 
+x = Array(1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33)
+ok x(1) = 2, "x(1) = " & x(1)
+ok x(32) = 33, "x(32) = " & x(32)
+ok ubound(x) = 32, "ubound(x) = " & ubound(x)
+
 Dim arr2(2, 4)
 Call ok(UBound(arr2) = 2, "UBound(x) = " & UBound(x))
 Call ok(UBound(arr2, 1) = 2, "UBound(x) = " & UBound(x))
 Call ok(UBound(arr2, 2) = 4, "UBound(x) = " & UBound(x))
+Call ok(Lbound(arr2) = 0, "Lbound(x) = " & Lbound(x))
+Call ok(Lbound(arr2, 1) = 0, "Lbound(x) = " & Lbound(x))
+Call ok(Lbound(arr2, 2) = 0, "Lbound(x) = " & Lbound(x))
 
 sub testUBoundError()
     on error resume next
@@ -548,6 +556,34 @@ Call ok(Space(0.5) = "", "Space(0.5) = " & Space(0.5) & """")
 Call ok(Space(1.5) = "  ", "Space(1.5) = " & Space(1.5) & """")
 Call ok(Space("1") = " ", "Space(""1"") = " & Space("1") & """")
 
+sub test_string(cnt, char, exp)
+    call ok(String(cnt, char) = exp, "String(" & cnt & ", """ & char & """ = """ & _
+                                     String(cnt, char) & """ expected """ & exp & """")
+end sub
+
+test_string 3, "x", "xxx"
+test_string 3, "xy", "xxx"
+test_string 1, "z", "z"
+test_string 0, "z", ""
+test_string "3", "xy", "xxx"
+test_string 3, Chr(3), Chr(3)&Chr(3)&Chr(3)
+
+call ok(getVT(String(0, "z")) = "VT_BSTR", "getVT(String(0,z)) = " & getVT(String(0, "z")))
+
+sub test_string_error()
+    on error resume next
+    dim x
+    x = String(-2, "x")
+    call ok(err.number = 5, "err.number = " & err.number)
+    err.clear
+    x = String(3, "")
+    call ok(err.number = 5, "err.number = " & err.number)
+    err.clear
+    x = String(0, "")
+    call ok(err.number = 5, "err.number = " & err.number)
+end sub
+call test_string_error
+
 Sub TestStrReverse(str, ex)
     Call ok(StrReverse(str) = ex, "StrReverse(" & str & ") = " & StrReverse(str))
 End Sub
@@ -604,11 +640,6 @@ TestLTrim "", ""
 TestLTrim 123, "123"
 if isEnglishLang then TestLTrim true, "True"
 
-Sub TestRound(val, exval, vt)
-    Call ok(Round(val) = exval, "Round(" & val & ") = " & Round(val))
-    Call ok(getVT(Round(val)) = vt, "getVT(Round(" & val & ")) = " & getVT(Round(val)))
-End Sub
-
 Sub TestRTrim(str, exstr)
     Call ok(RTrim(str) = exstr, "RTrim(" & str & ") = " & RTrim(str))
 End Sub
@@ -620,6 +651,69 @@ TestRTrim "test", "test"
 TestRTrim "", ""
 TestRTrim 123, "123"
 if isEnglishLang then TestRTrim true, "True"
+
+sub test_replace(str, find, rep, exp)
+    dim r
+    r = Replace(str, find, rep)
+    ok r = exp, "Replace(""" & str & """, """ & find & """, """ & rep & """) = """ & _
+       r & """ expected """ & exp & """"
+end sub
+
+sub test_replace_from(str, find, rep, from, exp)
+    dim r
+    r = Replace(str, find, rep, from)
+    ok r = exp, "Replace(""" & str & """, """ & find & """, """ & rep & """, " & from & ") = """ & _
+       r & """ expected """ & exp & """"
+end sub
+
+sub test_replace_cnt(str, find, rep, from, cnt, exp)
+    dim r
+    r = Replace(str, find, rep, from, cnt)
+    ok r = exp, "Replace(""" & str & """, """ & find & """, """ & rep & """, " & from & ", " & cnt & ") = """ & _
+       r & """ expected """ & exp & """"
+end sub
+
+test_replace "xx testxx(xx)", "xx", "!", "! test!(!)"
+test_replace "xxx", "", "y", "xxx"
+test_replace "xxxxx", "xx", "y", "yyx"
+test_replace 123, 2, 6, "163"
+test_replace "xyz" & Chr(0) & "xyz", "y", "Y", "xYz" & Chr(0) & "xYz"
+test_replace "xyz" & Chr(0) & "xyz", Chr(0) & "x", "Y" & Chr(0) & Chr(0), "xyzY" & Chr(0) & Chr(0) & "yz"
+
+test_replace_from "xx testxx(xx)", "xx", "!", 1, "! test!(!)"
+test_replace_from "xx testxx(xx)", "xx", "!", 1, "! test!(!)"
+test_replace_from "xx testxx(xx)", "xx", "!", 2, "x test!(!)"
+test_replace_from "xx testxx(xx)", "xx", "!", 2000, ""
+test_replace_from "xxx", "", "y", 2, "xx"
+
+test_replace_cnt "xx testxx(xx)", "xx", "!", 1, 2, "! test!(xx)"
+test_replace_cnt "xx testxx(xx)", "xx", "!", 1, 1, "! testxx(xx)"
+test_replace_cnt "xx testxx(xx)", "xx", "!", 2, 1, "x test!(xx)"
+test_replace_cnt "xx testxx(xx)", "xx", "!", 1, -1, "! test!(!)"
+test_replace_cnt "xx testxx(xx)", "xx", "!", 1, 0, "xx testxx(xx)"
+
+on error resume next
+Replace "xx", "x", "y", -1
+x = err.number
+on error goto 0
+ok x = 5, "err = " & x
+
+on error resume next
+Replace "xx", "x", "y", 0
+x = err.number
+on error goto 0
+ok x = 5, "err = " & x
+
+on error resume next
+Replace "xx", "x", "y", 1, -2
+x = err.number
+on error goto 0
+ok x = 5, "err = " & x
+
+Sub TestRound(val, exval, vt)
+    Call ok(Round(val) = exval, "Round(" & val & ") = " & Round(val))
+    Call ok(getVT(Round(val)) = vt, "getVT(Round(" & val & ")) = " & getVT(Round(val)))
+End Sub
 
 TestRound 3, 3, "VT_I2"
 TestRound 3.3, 3, "VT_R8"

--- a/modules/rostests/winetests/vbscript/createobj.c
+++ b/modules/rostests/winetests/vbscript/createobj.c
@@ -131,13 +131,6 @@ static BSTR a2bstr(const char *str)
     return ret;
 }
 
-static int strcmp_wa(LPCWSTR strw, const char *stra)
-{
-    CHAR buf[512];
-    WideCharToMultiByte(CP_ACP, 0, strw, -1, buf, sizeof(buf), 0, 0);
-    return lstrcmpA(buf, stra);
-}
-
 static HRESULT WINAPI ObjectWithSite_QueryInterface(IObjectWithSite *iface, REFIID riid, void **ppv)
 {
     ok(0, "unexpected call\n");
@@ -229,7 +222,6 @@ static HRESULT WINAPI DispatchEx_GetTypeInfoCount(IDispatchEx *iface, UINT *pcti
 static HRESULT WINAPI DispatchEx_GetTypeInfo(IDispatchEx *iface, UINT iTInfo,
                                               LCID lcid, ITypeInfo **ppTInfo)
 {
-    ok(0, "unexpected call\n");
     return E_NOTIMPL;
 }
 
@@ -287,7 +279,7 @@ static HRESULT WINAPI DispatchEx_GetNameSpaceParent(IDispatchEx *iface, IUnknown
 
 static HRESULT WINAPI Test_GetDispID(IDispatchEx *iface, BSTR bstrName, DWORD grfdex, DISPID *pid)
 {
-    if(!strcmp_wa(bstrName, "reportSuccess")) {
+    if(!lstrcmpW(bstrName, L"reportSuccess")) {
         ok(grfdex == fdexNameCaseInsensitive, "grfdex = %x\n", grfdex);
         *pid = DISPID_TEST_REPORTSUCCESS;
         return S_OK;
@@ -343,7 +335,7 @@ static IDispatchEx testObj = { &testObjVtbl };
 
 static HRESULT WINAPI Global_GetDispID(IDispatchEx *iface, BSTR bstrName, DWORD grfdex, DISPID *pid)
 {
-    if(!strcmp_wa(bstrName, "ok")) {
+    if(!lstrcmpW(bstrName, L"ok")) {
         ok(grfdex == fdexNameCaseSensitive, "grfdex = %x\n", grfdex);
         *pid = DISPID_GLOBAL_OK;
         return S_OK;
@@ -621,7 +613,7 @@ static HRESULT WINAPI ActiveScriptSite_GetItemInfo(IActiveScriptSite *iface, LPC
 {
     ok(dwReturnMask == SCRIPTINFO_IUNKNOWN, "unexpected dwReturnMask %x\n", dwReturnMask);
     ok(!ppti, "ppti != NULL\n");
-    ok(!strcmp_wa(pstrName, "test"), "pstrName = %s\n", wine_dbgstr_w(pstrName));
+    ok(!lstrcmpW(pstrName, L"test"), "pstrName = %s\n", wine_dbgstr_w(pstrName));
 
     *ppiunkItem = (IUnknown*)&globalObj;
     return S_OK;

--- a/modules/rostests/winetests/vbscript/error.vbs
+++ b/modules/rostests/winetests/vbscript/error.vbs
@@ -77,6 +77,13 @@ const CO_E_SERVER_EXEC_FAILURE = &h80080005&
 call ok(Err.Number = 0, "Err.Number = " & Err.Number)
 call ok(getVT(Err.Number) = "VT_I4", "getVT(Err.Number) = " & getVT(Err.Number))
 
+class emptyclass
+end class
+
+class propclass
+    public prop
+end class
+
 dim calledFunc
 
 sub returnTrue
@@ -313,6 +320,70 @@ end sub
 
 call testForEachError()
 
+sub testWithError()
+    on error resume next
+    dim x
+
+    err.clear
+    x = false
+    with throwInt(E_TESTERROR)
+        ok Err.Number = E_TESTERROR, "Err.Number = " & Err.Number
+        x = true
+    end with
+    ok x, "with statement body not executed"
+
+    err.clear
+    x = false
+    with throwInt(E_TESTERROR)
+        x = true
+        .prop = 1
+        todo_wine_ok Err.Number = 424, "Err.Number = " & Err.Number
+    end with
+    ok x, "with statement body not executed"
+
+    err.clear
+    x = false
+    with empty
+        .prop = 1
+        todo_wine_ok Err.Number = 424, "Err.Number = " & Err.Number
+        x = true
+    end with
+    ok x, "with statement body not executed"
+end sub
+
+sub testWithError2()
+    on error resume next
+    dim x
+
+    err.clear
+    x = false
+    with new emptyclass
+        .prop = 1
+        ok Err.Number = 438, "Err.Number = " & Err.Number
+        x = true
+    end with
+    ok x, "with statement body not executed"
+
+    'dot expression can reference only inner-most with statement
+    err.clear
+    x = false
+    with new propclass
+        with new emptyclass
+            .prop = 1
+            ok Err.Number = 438, "Err.Number = " & Err.Number
+            x = true
+        end with
+    end with
+    ok x, "with statement body not executed"
+
+    err.clear
+    .prop
+    ok Err.Number = 505, "Err.Number = " & Err.Number & " description """ & err.description & """"
+end sub
+
+call testWithError()
+call testWithError2()
+
 sub testHresMap(hres, code)
     on error resume next
 
@@ -385,5 +456,21 @@ sub testVBErrorCodes()
 end sub
 
 call testVBErrorCodes
+
+on error resume next
+
+throwWithDesc
+ok err.number = &hdeadbeef&, "err.number = " & hex(err.number)
+ok err.description = "test", "err.description = " & err.description
+ok err.helpcontext = 10, "err.helpcontext = " & err.helpcontext
+ok err.helpfile = "test.chm", "err.helpfile = " & err.helpfile
+
+throwWithDesc = 1
+ok err.number = &hdeadbeef&, "err.number = " & hex(err.number)
+ok err.description = "test", "err.description = " & err.description
+ok err.helpcontext = 10, "err.helpcontext = " & err.helpcontext
+ok err.helpfile = "test.chm", "err.helpfile = " & err.helpfile
+
+on error goto 0
 
 call reportSuccess()

--- a/modules/rostests/winetests/vbscript/lang.vbs
+++ b/modules/rostests/winetests/vbscript/lang.vbs
@@ -18,7 +18,7 @@
 
 OPTION EXPLICIT  : : DIM W
 
-dim x, y, z
+dim x, y, z, e
 Dim obj
 
 call ok(true, "true is not true?")
@@ -53,6 +53,11 @@ Call ok(true = -1, "! true = -1")
 Call ok(false = 0, "false <> 0")
 Call ok(&hff = 255, "&hff <> 255")
 Call ok(&Hff = 255, "&Hff <> 255")
+Call ok(&hffff = -1, "&hffff <> -1")
+Call ok(&hfffe = -2, "&hfffe <> -2")
+Call ok(&hffff& = 65535, "&hffff& <> -1")
+Call ok(&hfffe& = 65534, "&hfffe& <> -2")
+Call ok(&hffffffff& = -1, "&hffffffff& <> -1")
 
 W = 5
 Call ok(W = 5, "W = " & W & " expected " & 5)
@@ -88,6 +93,9 @@ Call ok(getVT(&h10&) = "VT_I2", "getVT(&h10&) is not VT_I2")
 Call ok(getVT(&h10000&) = "VT_I4", "getVT(&h10000&) is not VT_I4")
 Call ok(getVT(&H10000&) = "VT_I4", "getVT(&H10000&) is not VT_I4")
 Call ok(getVT(&hffFFffFF&) = "VT_I2", "getVT(&hffFFffFF&) is not VT_I2")
+Call ok(getVT(&hffFFffFE&) = "VT_I2", "getVT(&hffFFffFE &) is not VT_I2")
+Call ok(getVT(&hffF&) = "VT_I2", "getVT(&hffFF&) is not VT_I2")
+Call ok(getVT(&hffFF&) = "VT_I4", "getVT(&hffFF&) is not VT_I4")
 Call ok(getVT(1e2) = "VT_R8", "getVT(1e2) is not VT_R8")
 Call ok(getVT(1e0) = "VT_R8", "getVT(1e0) is not VT_R8")
 Call ok(getVT(0.1e2) = "VT_R8", "getVT(0.1e2) is not VT_R8")
@@ -327,6 +335,14 @@ else
 end if
 
 while false
+wend
+
+if empty then
+   ok false, "if empty executed"
+end if
+
+while empty
+   ok false, "while empty executed"
 wend
 
 x = 0
@@ -665,6 +681,14 @@ select case 1  :
 end select
 Call ok(x, "wrong case")
 
+select case 0
+    case 1
+    case else
+       'empty else with comment test
+end select
+
+select case 0 : case 1 : case else : end select
+
 if false then
 Sub testsub
     x = true
@@ -878,6 +902,21 @@ Public Function TestSepFunc(ByVal a) : :
 End Function
 Call ok(TestSepFunc(1) = 1, "Function did not return 1")
 
+ok duplicatedfunc() = 2, "duplicatedfunc = " & duplicatedfunc()
+
+function duplicatedfunc
+    ok false, "duplicatedfunc called"
+end function
+
+sub duplicatedfunc
+    ok false, "duplicatedfunc called"
+end sub
+
+function duplicatedfunc
+    duplicatedfunc = 2
+end function
+
+ok duplicatedfunc() = 2, "duplicatedfunc = " & duplicatedfunc()
 
 ' Stop has an effect only in debugging mode
 Stop
@@ -1171,6 +1210,13 @@ Call ok(obj.Test1 = 6, "obj.Test1 is not 6")
 obj.AddToTest1(5)
 Call ok(obj.Test1 = 11, "obj.Test1 is not 11")
 
+set obj = unkObj
+set x = obj
+call ok(getVT(obj) = "VT_UNKNOWN*", "getVT(obj) = " & getVT(obj))
+call ok(getVT(x) = "VT_UNKNOWN*", "getVT(x) = " & getVT(x))
+call ok(getVT(unkObj) = "VT_UNKNOWN", "getVT(unkObj) = " & getVT(unkObj))
+call ok(obj is unkObj, "obj is not unkObj")
+
 ' Array tests
 
 Call ok(getVT(arr) = "VT_EMPTY*", "getVT(arr) = " & getVT(arr))
@@ -1246,6 +1292,100 @@ next
 x=1
 Call ok(forarr(x) = 2, "forarr(x) = " & forarr(x))
 
+sub accessArr()
+    ok arr(1) = 1, "arr(1) = " & arr(1)
+    arr(1) = 2
+end sub
+arr(1) = 1
+call accessArr
+ok arr(1) = 2, "arr(1) = " & arr(1)
+
+sub accessArr2(x,y)
+    ok arr2(x,y) = 1, "arr2(x,y) = " & arr2(x,y)
+    x = arr2(x,y)
+    arr2(x,y) = 2
+end sub
+arr2(1,2) = 1
+call accessArr2(1, 2)
+ok arr2(1,2) = 2, "arr2(1,2) = " & arr2(1,2)
+
+x = Array(Array(3))
+call ok(x(0)(0) = 3, "x(0)(0) = " & x(0)(0))
+
+function seta0(arr)
+    arr(0) = 2
+    seta0 = 1
+end function
+
+x = Array(1)
+seta0 x
+ok x(0) = 2, "x(0) = " & x(0)
+
+x = Array(1)
+seta0 (x)
+ok x(0) = 1, "x(0) = " & x(0)
+
+x = Array(1)
+call (((seta0))) ((x))
+ok x(0) = 1, "x(0) = " & x(0)
+
+x = Array(1)
+call (((seta0))) (x)
+ok x(0) = 2, "x(0) = " & x(0)
+
+x = Array(Array(3))
+seta0 x(0)
+call ok(x(0)(0) = 2, "x(0)(0) = " & x(0)(0))
+
+x = Array(Array(3))
+seta0 (x(0))
+call ok(x(0)(0) = 3, "x(0)(0) = " & x(0)(0))
+
+y = (seta0)(x)
+ok y = 1, "y = " & y
+
+y = ((x))(0)
+ok y = 2, "y = " & y
+
+sub changearg(x)
+    x = 2
+end sub
+
+x = Array(1)
+changearg x(0)
+ok x(0) = 2, "x(0) = " & x(0)
+ok getVT(x) = "VT_ARRAY|VT_VARIANT*", "getVT(x) after redim = " & getVT(x)
+
+x = Array(1)
+changearg (x(0))
+ok x(0) = 1, "x(0) = " & x(0)
+
+x = Array(1)
+redim x(4)
+ok ubound(x) = 4, "ubound(x) = " & ubound(x)
+ok x(0) = empty, "x(0) = " & x(0)
+
+x = 1
+redim x(3)
+ok ubound(x) = 3, "ubound(x) = " & ubound(x)
+
+x = Array(1, 2)
+redim x(-1)
+ok lbound(x) = 0, "lbound(x) = " & lbound(x)
+ok ubound(x) = -1, "ubound(x) = " & ubound(x)
+
+redim x(3, 2)
+ok ubound(x) = 3, "ubound(x) = " & ubound(x)
+ok ubound(x, 1) = 3, "ubound(x, 1) = " & ubound(x, 1)
+ok ubound(x, 2) = 2, "ubound(x, 2) = " & ubound(x, 2) & " expected 2"
+
+dim staticarray(4)
+on error resume next
+redim staticarray(3)
+e = err.number
+on error goto 0
+todo_wine_ok e = 10, "e = " & e
+
 Class ArrClass
     Dim classarr(3)
     Dim classnoarr()
@@ -1300,8 +1440,7 @@ Call testarrarg(false, "VT_BOOL*")
 Call testarrarg(Empty, "VT_EMPTY*")
 
 Sub modifyarr(arr)
-    'Following test crashes on wine
-    'Call ok(arr(0) = "not modified", "arr(0) = " & arr(0))
+    Call ok(arr(0) = "not modified", "arr(0) = " & arr(0))
     arr(0) = "modified"
 End Sub
 
@@ -1311,7 +1450,7 @@ Call ok(arr(0) = "modified", "arr(0) = " & arr(0))
 
 arr(0) = "not modified"
 modifyarr(arr)
-Call todo_wine_ok(arr(0) = "not modified", "arr(0) = " & arr(0))
+Call ok(arr(0) = "not modified", "arr(0) = " & arr(0))
 
 for x = 0 to UBound(arr)
     arr(x) = x
@@ -1398,7 +1537,7 @@ call test_identifiers()
 
 sub test_dotIdentifiers
     ' test keywords that can also be an identifier after a dot
-    ' Call ok(testObj.rem = 10, "testObj.rem = " & testObj.rem & " expected 10")
+    Call ok(testObj.rem = 10, "testObj.rem = " & testObj.rem & " expected 10")
     Call ok(testObj.true = 10, "testObj.true = " & testObj.true & " expected 10")
     Call ok(testObj.false = 10, "testObj.false = " & testObj.false & " expected 10")
     Call ok(testObj.not = 10, "testObj.not = " & testObj.not & " expected 10")
@@ -1448,10 +1587,16 @@ sub test_dotIdentifiers
     Call ok(testObj.on = 10, "testObj.on = " & testObj.on & " expected 10")
     Call ok(testObj.resume = 10, "testObj.resume = " & testObj.resume & " expected 10")
     Call ok(testObj.goto = 10, "testObj.goto = " & testObj.goto & " expected 10")
+    Call ok(testObj.with = 10, "testObj.with = " & testObj.with & " expected 10")
+    Call ok(testObj.redim = 10, "testObj.redim = " & testObj.redim & " expected 10")
+    Call ok(testObj.preserve = 10, "testObj.preserve = " & testObj.preserve & " expected 10")
+    Call ok(testObj.property = 10, "testObj.property = " & testObj.property & " expected 10")
+    Call ok(testObj.me = 10, "testObj.me = " & testObj.me & " expected 10")
+    Call ok(testObj.stop = 10, "testObj.stop = " & testObj.stop & " expected 10")
 end sub
 call test_dotIdentifiers
 
-' Test End statements not required to be preceeded by a newline or separator
+' Test End statements not required to be preceded by a newline or separator
 Sub EndTestSub
     x = 1 End Sub
 
@@ -1478,5 +1623,75 @@ Class EndTestClassWithProperty
     Public x
     Public default Property Get defprop
         defprop = x End Property End Class
+
+class TestPropSyntax
+    public prop
+
+    function getProp()
+        set getProp = prop
+    end function
+
+    public default property get def()
+        def = ""
+    end property
+end class
+
+set x = new TestPropSyntax
+set x.prop = new TestPropSyntax
+set x.prop.prop = new TestPropSyntax
+x.prop.prop.prop = 2
+call ok(x.getProp().getProp.prop = 2, "x.getProp().getProp.prop = " & x.getProp().getProp.prop)
+x.getprop.getprop().prop = 3
+call ok(x.getProp.prop.prop = 3, "x.getProp.prop.prop = " & x.getProp.prop.prop)
+set x.getprop.getprop().prop = new emptyclass
+set obj = new emptyclass
+set x.getprop.getprop().prop = obj
+call ok(x.getprop.getprop().prop is obj, "x.getprop.getprop().prop is not obj (emptyclass)")
+
+ok getVT(x) = "VT_DISPATCH*", "getVT(x) = " & getVT(x)
+todo_wine_ok getVT(x()) = "VT_BSTR", "getVT(x()) = " & getVT(x())
+
+with nothing
+end with
+
+set x = new TestPropSyntax
+with x
+     .prop = 1
+     ok .prop = 1, ".prop = "&.prop
+end with
+ok x.prop = 1, "x.prop = " & x.prop
+
+with new TestPropSyntax
+     .prop = 1
+     ok .prop = 1, ".prop = "&.prop
+end with
+
+function testsetresult(x, y)
+    set testsetresult = new TestPropSyntax
+    testsetresult.prop = x
+    y = testsetresult.prop + 1
+end function
+
+set x = testsetresult(1, 2)
+ok x.prop = 1, "x.prop = " & x.prop
+
+set arr(0) = new TestPropSyntax
+arr(0).prop = 1
+ok arr(0).prop = 1, "arr(0) = " & arr(0).prop
+
+function f2(x,y)
+end function
+
+f2 1 = 1, 2
+
+function f1(x)
+    ok x = true, "x = " & x
+end function
+
+f1 1 = 1
+f1 1 = (1)
+f1 not 1 = 0
+
+arr (0) = 2 xor -2
 
 reportSuccess()

--- a/modules/rostests/winetests/vbscript/regexp.vbs
+++ b/modules/rostests/winetests/vbscript/regexp.vbs
@@ -18,7 +18,7 @@
 
 Option Explicit
 
-Dim x, matches, match, submatch
+Dim x, matches, match, submatch, r
 
 Set x = CreateObject("vbscript.regexp")
 Call ok(getVT(x.Pattern) = "VT_BSTR", "getVT(RegExp.Pattern) = " & getVT(x.Pattern))
@@ -190,5 +190,38 @@ set match = matches.item(4)
 Call ok(match.Value = "", "match.Value = " & match.Value)
 matches = x.test("test")
 Call ok(matches = true, "matches = " & matches)
+
+dim test_global
+
+sub test_replace(pattern, string, rep, exp)
+    dim x, re
+    set re = new regexp
+    re.pattern = pattern
+    re.global = test_global
+    x = re.replace(string, rep)
+    call ok(x = exp, "replace returned " & x & " expected " & exp)
+end sub
+
+test_global = true
+test_replace "xxx", "xxxx", "y", "yx"
+test_replace "\[([^\[]+)\]", "- [test] -", "success", "- success -"
+test_replace "\[([^\[]+)\]", "[test] [test]", "aa", "aa aa"
+test_replace "(\&(\d))", "abc &1 123", "$'", "abc  123 123"
+test_replace "(\&(\d))", "abc &1 123", "$`", "abc abc  123"
+test_replace "(\&(\d))", "abc &1 123", "$3", "abc $3 123"
+test_replace "\[([^\[]+)\]", "- [test] -", true, "- -1 -"
+test_replace "\[([^\[]+)\]", "- [test] -", 6, "- 6 -"
+test_replace "(\$(\d))", "$1,$2", "$$1-$1$2", "$1-$11,$1-$22"
+test_replace "b", "abc", "x$&z", "axbzc"
+
+test_global = false
+test_replace "\[([^\[]+)\]", "[test] [test]", "aa", "aa [test]"
+
+set r = new regexp
+x = r.replace("xxx", "y")
+call ok(x = "yxxx", "x = " & x)
+r.global = true
+x = r.replace("xxx", "y")
+call ok(x = "yxyxyxy", "x = " & x)
 
 Call reportSuccess()

--- a/modules/rostests/winetests/vbscript/vbscript.c
+++ b/modules/rostests/winetests/vbscript/vbscript.c
@@ -1,5 +1,6 @@
 /*
  * Copyright 2011 Jacek Caban for CodeWeavers
+ * Copyright 2019 Dmitry Timoshkov
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -50,29 +51,39 @@
 #endif
 
 DEFINE_GUID(GUID_NULL,0,0,0,0,0,0,0,0,0,0,0);
+DEFINE_GUID(IID_IScriptTypeInfo, 0xc59c6b12, 0xf6c1, 0x11cf, 0x88,0x35, 0x00,0xa0,0xc9,0x11,0xe8,0xb2);
 
 #define DEFINE_EXPECT(func) \
-    static BOOL expect_ ## func = FALSE, called_ ## func = FALSE
+    static int expect_ ## func = 0, called_ ## func = 0
 
 #define SET_EXPECT(func) \
-    expect_ ## func = TRUE
+    expect_ ## func = 1
+
+#define SET_EXPECT_MULTI(func, num) \
+    expect_ ## func = num
 
 #define CHECK_EXPECT2(func) \
     do { \
         ok(expect_ ##func, "unexpected call " #func "\n"); \
-        called_ ## func = TRUE; \
+        called_ ## func++; \
     }while(0)
 
 #define CHECK_EXPECT(func) \
     do { \
         CHECK_EXPECT2(func); \
-        expect_ ## func = FALSE; \
+        expect_ ## func--; \
     }while(0)
 
 #define CHECK_CALLED(func) \
     do { \
         ok(called_ ## func, "expected " #func "\n"); \
-        expect_ ## func = called_ ## func = FALSE; \
+        expect_ ## func = called_ ## func = 0; \
+    }while(0)
+
+#define CHECK_CALLED_MULTI(func, num) \
+    do { \
+        ok(called_ ## func == num, "expected " #func " %d times (got %d)\n", num, called_ ## func); \
+        expect_ ## func = called_ ## func = 0; \
     }while(0)
 
 DEFINE_EXPECT(GetLCID);
@@ -84,8 +95,15 @@ DEFINE_EXPECT(OnStateChange_CLOSED);
 DEFINE_EXPECT(OnStateChange_INITIALIZED);
 DEFINE_EXPECT(OnEnterScript);
 DEFINE_EXPECT(OnLeaveScript);
+DEFINE_EXPECT(OnScriptError);
+DEFINE_EXPECT(GetIDsOfNames);
+DEFINE_EXPECT(GetIDsOfNames_visible);
+DEFINE_EXPECT(GetIDsOfNames_persistent);
 DEFINE_EXPECT(GetItemInfo_global);
+DEFINE_EXPECT(GetItemInfo_global_code);
 DEFINE_EXPECT(GetItemInfo_visible);
+DEFINE_EXPECT(GetItemInfo_visible_code);
+DEFINE_EXPECT(GetItemInfo_persistent);
 DEFINE_EXPECT(testCall);
 
 DEFINE_GUID(CLSID_VBScript, 0xb54f3741, 0x5b07, 0x11cf, 0xa4,0xb0, 0x00,0xaa,0x00,0x4a,0x55,0xe8);
@@ -126,7 +144,17 @@ static HRESULT WINAPI Dispatch_QueryInterface(IDispatch *iface, REFIID riid, voi
     return E_NOINTERFACE;
 }
 
-static ULONG global_named_item_ref, visible_named_item_ref;
+static ULONG WINAPI Dispatch_AddRef(IDispatch *iface)
+{
+    return 2;
+}
+
+static ULONG WINAPI Dispatch_Release(IDispatch *iface)
+{
+    return 1;
+}
+
+static ULONG global_named_item_ref, visible_named_item_ref, visible_code_named_item_ref, persistent_named_item_ref;
 
 static ULONG WINAPI global_AddRef(IDispatch *iface)
 {
@@ -148,6 +176,26 @@ static ULONG WINAPI visible_Release(IDispatch *iface)
     return --visible_named_item_ref;
 }
 
+static ULONG WINAPI visible_code_AddRef(IDispatch *iface)
+{
+    return ++visible_code_named_item_ref;
+}
+
+static ULONG WINAPI visible_code_Release(IDispatch *iface)
+{
+    return --visible_code_named_item_ref;
+}
+
+static ULONG WINAPI persistent_AddRef(IDispatch *iface)
+{
+    return ++persistent_named_item_ref;
+}
+
+static ULONG WINAPI persistent_Release(IDispatch *iface)
+{
+    return --persistent_named_item_ref;
+}
+
 static HRESULT WINAPI Dispatch_GetTypeInfoCount(IDispatch *iface, UINT *pctinfo)
 {
     ok(0, "unexpected call\n");
@@ -163,9 +211,35 @@ static HRESULT WINAPI Dispatch_GetIDsOfNames(IDispatch *iface, REFIID riid, LPOL
                                             LCID lcid, DISPID *ids)
 {
     ok(name_cnt == 1, "name_cnt = %u\n", name_cnt);
-    ok(!wcscmp(names[0], L"testCall"), "names[0] = %s\n", wine_dbgstr_w(names[0]));
-    *ids = 1;
-    return S_OK;
+    if(!wcscmp(names[0], L"testCall")) {
+        *ids = 1;
+        return S_OK;
+    }
+
+    CHECK_EXPECT2(GetIDsOfNames);
+    return DISP_E_UNKNOWNNAME;
+}
+
+static HRESULT WINAPI visible_GetIDsOfNames(IDispatch *iface, REFIID riid, LPOLESTR *names, UINT name_cnt,
+                                            LCID lcid, DISPID *ids)
+{
+    ok(name_cnt == 1, "name_cnt = %u\n", name_cnt);
+    if(!wcscmp(names[0], L"testCall")) {
+        *ids = 1;
+        return S_OK;
+    }
+
+    CHECK_EXPECT2(GetIDsOfNames_visible);
+    return DISP_E_UNKNOWNNAME;
+}
+
+static HRESULT WINAPI persistent_GetIDsOfNames(IDispatch *iface, REFIID riid, LPOLESTR *names, UINT name_cnt,
+                                               LCID lcid, DISPID *ids)
+{
+    ok(name_cnt == 1, "name_cnt = %u\n", name_cnt);
+
+    CHECK_EXPECT2(GetIDsOfNames_persistent);
+    return DISP_E_UNKNOWNNAME;
 }
 
 static HRESULT WINAPI Dispatch_Invoke(IDispatch *iface, DISPID id, REFIID riid, LCID lcid, WORD flags,
@@ -178,6 +252,18 @@ static HRESULT WINAPI Dispatch_Invoke(IDispatch *iface, DISPID id, REFIID riid, 
     ok(!res, "res = %p\n", res);
     return S_OK;
 }
+
+static const IDispatchVtbl dispatch_vtbl = {
+    Dispatch_QueryInterface,
+    Dispatch_AddRef,
+    Dispatch_Release,
+    Dispatch_GetTypeInfoCount,
+    Dispatch_GetTypeInfo,
+    Dispatch_GetIDsOfNames,
+    Dispatch_Invoke
+};
+
+static IDispatch dispatch_object = { &dispatch_vtbl };
 
 static const IDispatchVtbl global_named_item_vtbl = {
     Dispatch_QueryInterface,
@@ -197,11 +283,35 @@ static const IDispatchVtbl visible_named_item_vtbl = {
     visible_Release,
     Dispatch_GetTypeInfoCount,
     Dispatch_GetTypeInfo,
-    Dispatch_GetIDsOfNames,
+    visible_GetIDsOfNames,
     Dispatch_Invoke
 };
 
 static IDispatch visible_named_item = { &visible_named_item_vtbl };
+
+static const IDispatchVtbl visible_code_named_item_vtbl = {
+    Dispatch_QueryInterface,
+    visible_code_AddRef,
+    visible_code_Release,
+    Dispatch_GetTypeInfoCount,
+    Dispatch_GetTypeInfo,
+    Dispatch_GetIDsOfNames,
+    Dispatch_Invoke
+};
+
+static IDispatch visible_code_named_item = { &visible_code_named_item_vtbl };
+
+static const IDispatchVtbl persistent_named_item_vtbl = {
+    Dispatch_QueryInterface,
+    persistent_AddRef,
+    persistent_Release,
+    Dispatch_GetTypeInfoCount,
+    Dispatch_GetTypeInfo,
+    persistent_GetIDsOfNames,
+    Dispatch_Invoke
+};
+
+static IDispatch persistent_named_item = { &persistent_named_item_vtbl };
 
 static HRESULT WINAPI ActiveScriptSite_QueryInterface(IActiveScriptSite *iface, REFIID riid, void **ppv)
 {
@@ -244,10 +354,28 @@ static HRESULT WINAPI ActiveScriptSite_GetItemInfo(IActiveScriptSite *iface, LPC
         *item_unk = (IUnknown*)&global_named_item;
         return S_OK;
     }
+    if(!wcscmp(name, L"globalCodeItem")) {
+        CHECK_EXPECT(GetItemInfo_global_code);
+        IDispatch_AddRef(&dispatch_object);
+        *item_unk = (IUnknown*)&dispatch_object;
+        return S_OK;
+    }
     if(!wcscmp(name, L"visibleItem")) {
         CHECK_EXPECT(GetItemInfo_visible);
         IDispatch_AddRef(&visible_named_item);
         *item_unk = (IUnknown*)&visible_named_item;
+        return S_OK;
+    }
+    if(!wcscmp(name, L"visibleCodeItem")) {
+        CHECK_EXPECT(GetItemInfo_visible_code);
+        IDispatch_AddRef(&visible_code_named_item);
+        *item_unk = (IUnknown*)&visible_code_named_item;
+        return S_OK;
+    }
+    if(!wcscmp(name, L"persistent")) {
+        CHECK_EXPECT(GetItemInfo_persistent);
+        IDispatch_AddRef(&persistent_named_item);
+        *item_unk = (IUnknown*)&persistent_named_item;
         return S_OK;
     }
     ok(0, "unexpected call %s\n", wine_dbgstr_w(name));
@@ -297,7 +425,7 @@ static HRESULT WINAPI ActiveScriptSite_OnStateChange(IActiveScriptSite *iface, S
 
 static HRESULT WINAPI ActiveScriptSite_OnScriptError(IActiveScriptSite *iface, IActiveScriptError *pscripterror)
 {
-    ok(0, "unexpected call\n");
+    CHECK_EXPECT(OnScriptError);
     return E_NOTIMPL;
 }
 
@@ -420,14 +548,14 @@ static void test_safety(IActiveScript *script)
     IObjectSafety_Release(safety);
 }
 
-static IDispatchEx *get_script_dispatch(IActiveScript *script)
+static IDispatchEx *get_script_dispatch(IActiveScript *script, const WCHAR *item_name)
 {
     IDispatchEx *dispex;
     IDispatch *disp;
     HRESULT hres;
 
     disp = (void*)0xdeadbeef;
-    hres = IActiveScript_GetScriptDispatch(script, NULL, &disp);
+    hres = IActiveScript_GetScriptDispatch(script, item_name, &disp);
     ok(hres == S_OK, "GetScriptDispatch failed: %08x\n", hres);
     if(FAILED(hres))
         return NULL;
@@ -520,7 +648,7 @@ static void test_scriptdisp(void)
     ok(hres == S_OK, "SetScriptSite failed: %08x\n", hres);
     CHECK_CALLED(GetLCID);
 
-    script_disp2 = get_script_dispatch(vbscript);
+    script_disp2 = get_script_dispatch(vbscript, NULL);
 
     test_state(vbscript, SCRIPTSTATE_UNINITIALIZED);
 
@@ -538,7 +666,7 @@ static void test_scriptdisp(void)
 
     test_state(vbscript, SCRIPTSTATE_CONNECTED);
 
-    script_disp = get_script_dispatch(vbscript);
+    script_disp = get_script_dispatch(vbscript, NULL);
     ok(script_disp == script_disp2, "script_disp != script_disp2\n");
     IDispatchEx_Release(script_disp2);
 
@@ -621,6 +749,681 @@ static void test_scriptdisp(void)
 
     ref = IActiveScript_Release(vbscript);
     ok(!ref, "ref = %d\n", ref);
+}
+
+static void test_code_persistence(void)
+{
+    IActiveScriptParse *parser;
+    IDispatchEx *script_disp;
+    IActiveScript *vbscript;
+    VARIANT var;
+    HRESULT hr;
+    DISPID id;
+    ULONG ref;
+
+    vbscript = create_vbscript();
+
+    hr = IActiveScript_QueryInterface(vbscript, &IID_IActiveScriptParse, (void**)&parser);
+    ok(hr == S_OK, "Could not get IActiveScriptParse iface: %08x\n", hr);
+    test_state(vbscript, SCRIPTSTATE_UNINITIALIZED);
+    test_safety(vbscript);
+
+    SET_EXPECT(GetLCID);
+    hr = IActiveScript_SetScriptSite(vbscript, &ActiveScriptSite);
+    ok(hr == S_OK, "SetScriptSite failed: %08x\n", hr);
+    CHECK_CALLED(GetLCID);
+
+    SET_EXPECT(OnStateChange_INITIALIZED);
+    hr = IActiveScriptParse_InitNew(parser);
+    ok(hr == S_OK, "InitNew failed: %08x\n", hr);
+    CHECK_CALLED(OnStateChange_INITIALIZED);
+    test_state(vbscript, SCRIPTSTATE_INITIALIZED);
+
+    hr = IActiveScriptParse_ParseScriptText(parser, L""
+        "x = 1\n"
+        "dim y\ny = 2\n",
+        NULL, NULL, NULL, 0, 0, 0, NULL, NULL);
+    ok(hr == S_OK, "ParseScriptText failed: %08x\n", hr);
+
+    hr = IActiveScriptParse_ParseScriptText(parser, L""
+        "dim z\n"
+        "y = 42\n"
+        "var = 10\n",
+        NULL, NULL, NULL, 0, 0, SCRIPTTEXT_ISPERSISTENT, NULL, NULL);
+    ok(hr == S_OK, "ParseScriptText failed: %08x\n", hr);
+
+    /* Pending code does not add identifiers to the global scope */
+    script_disp = get_script_dispatch(vbscript, NULL);
+    id = 0;
+    get_disp_id(script_disp, "x", DISP_E_UNKNOWNNAME, &id);
+    ok(id == -1, "id = %d, expected -1\n", id);
+    id = 0;
+    get_disp_id(script_disp, "y", DISP_E_UNKNOWNNAME, &id);
+    ok(id == -1, "id = %d, expected -1\n", id);
+    id = 0;
+    get_disp_id(script_disp, "z", DISP_E_UNKNOWNNAME, &id);
+    ok(id == -1, "id = %d, expected -1\n", id);
+    IDispatchEx_Release(script_disp);
+
+    /* Uninitialized state removes code without SCRIPTTEXT_ISPERSISTENT */
+    SET_EXPECT(OnStateChange_UNINITIALIZED);
+    hr = IActiveScript_SetScriptState(vbscript, SCRIPTSTATE_UNINITIALIZED);
+    ok(hr == S_OK, "SetScriptState(SCRIPTSTATE_UNINITIALIZED) failed: %08x\n", hr);
+    CHECK_CALLED(OnStateChange_UNINITIALIZED);
+    test_no_script_dispatch(vbscript);
+
+    SET_EXPECT(GetLCID);
+    SET_EXPECT(OnStateChange_INITIALIZED);
+    hr = IActiveScript_SetScriptSite(vbscript, &ActiveScriptSite);
+    ok(hr == S_OK, "SetScriptSite failed: %08x\n", hr);
+    CHECK_CALLED(GetLCID);
+    CHECK_CALLED(OnStateChange_INITIALIZED);
+
+    hr = IActiveScriptParse_ParseScriptText(parser, L"var = 20\n", NULL, NULL, NULL, 0, 0, 0, NULL, NULL);
+    ok(hr == S_OK, "ParseScriptText failed: %08x\n", hr);
+
+    SET_EXPECT(OnStateChange_CONNECTED);
+    SET_EXPECT_MULTI(OnEnterScript, 2);
+    SET_EXPECT_MULTI(OnLeaveScript, 2);
+    hr = IActiveScript_SetScriptState(vbscript, SCRIPTSTATE_CONNECTED);
+    ok(hr == S_OK, "SetScriptState(SCRIPTSTATE_CONNECTED) failed: %08x\n", hr);
+    CHECK_CALLED(OnStateChange_CONNECTED);
+    CHECK_CALLED_MULTI(OnEnterScript, 2);
+    CHECK_CALLED_MULTI(OnLeaveScript, 2);
+    test_state(vbscript, SCRIPTSTATE_CONNECTED);
+
+    script_disp = get_script_dispatch(vbscript, NULL);
+    id = 0;
+    get_disp_id(script_disp, "x", DISP_E_UNKNOWNNAME, &id);
+    ok(id == -1, "id = %d, expected -1\n", id);
+    id = 0;
+    get_disp_id(script_disp, "y", S_OK, &id);
+    ok(id != -1, "id = -1\n");
+    id = 0;
+    get_disp_id(script_disp, "z", S_OK, &id);
+    ok(id != -1, "id = -1\n");
+    IDispatchEx_Release(script_disp);
+
+    SET_EXPECT(OnEnterScript);
+    SET_EXPECT(OnLeaveScript);
+    hr = IActiveScriptParse_ParseScriptText(parser, L"y", NULL, NULL, NULL, 0, 0, SCRIPTTEXT_ISEXPRESSION, &var, NULL);
+    ok(hr == S_OK, "ParseScriptText failed: %08x\n", hr);
+    ok(V_VT(&var) == VT_I2 && V_I2(&var) == 42, "V_VT(y) = %d, V_I2(y) = %d\n", V_VT(&var), V_I2(&var));
+    CHECK_CALLED(OnEnterScript);
+    CHECK_CALLED(OnLeaveScript);
+
+    SET_EXPECT(OnEnterScript);
+    SET_EXPECT(OnLeaveScript);
+    hr = IActiveScriptParse_ParseScriptText(parser, L"var", NULL, NULL, NULL, 0, 0, SCRIPTTEXT_ISEXPRESSION, &var, NULL);
+    ok(hr == S_OK, "ParseScriptText failed: %08x\n", hr);
+    ok(V_VT(&var) == VT_I2 && V_I2(&var) == 20, "V_VT(var) = %d, V_I2(var) = %d\n", V_VT(&var), V_I2(&var));
+    CHECK_CALLED(OnEnterScript);
+    CHECK_CALLED(OnLeaveScript);
+
+    /* Uninitialized state does not remove persistent code, even if it was executed */
+    SET_EXPECT(OnStateChange_DISCONNECTED);
+    SET_EXPECT(OnStateChange_INITIALIZED);
+    SET_EXPECT(OnStateChange_UNINITIALIZED);
+    hr = IActiveScript_SetScriptState(vbscript, SCRIPTSTATE_UNINITIALIZED);
+    ok(hr == S_OK, "SetScriptState(SCRIPTSTATE_UNINITIALIZED) failed: %08x\n", hr);
+    CHECK_CALLED(OnStateChange_DISCONNECTED);
+    CHECK_CALLED(OnStateChange_INITIALIZED);
+    CHECK_CALLED(OnStateChange_UNINITIALIZED);
+    test_no_script_dispatch(vbscript);
+
+    SET_EXPECT(GetLCID);
+    SET_EXPECT(OnStateChange_INITIALIZED);
+    hr = IActiveScript_SetScriptSite(vbscript, &ActiveScriptSite);
+    ok(hr == S_OK, "SetScriptSite failed: %08x\n", hr);
+    CHECK_CALLED(GetLCID);
+    CHECK_CALLED(OnStateChange_INITIALIZED);
+
+    script_disp = get_script_dispatch(vbscript, NULL);
+    id = 0;
+    get_disp_id(script_disp, "z", DISP_E_UNKNOWNNAME, &id);
+    ok(id == -1, "id = %d, expected -1\n", id);
+    IDispatchEx_Release(script_disp);
+
+    SET_EXPECT(OnStateChange_CONNECTED);
+    SET_EXPECT(OnEnterScript);
+    SET_EXPECT(OnLeaveScript);
+    hr = IActiveScript_SetScriptState(vbscript, SCRIPTSTATE_CONNECTED);
+    ok(hr == S_OK, "SetScriptState(SCRIPTSTATE_CONNECTED) failed: %08x\n", hr);
+    CHECK_CALLED(OnStateChange_CONNECTED);
+    CHECK_CALLED(OnEnterScript);
+    CHECK_CALLED(OnLeaveScript);
+    test_state(vbscript, SCRIPTSTATE_CONNECTED);
+
+    script_disp = get_script_dispatch(vbscript, NULL);
+    id = 0;
+    get_disp_id(script_disp, "z", S_OK, &id);
+    ok(id != -1, "id = -1\n");
+    IDispatchEx_Release(script_disp);
+
+    SET_EXPECT(OnEnterScript);
+    SET_EXPECT(OnLeaveScript);
+    hr = IActiveScriptParse_ParseScriptText(parser, L"y", NULL, NULL, NULL, 0, 0, SCRIPTTEXT_ISEXPRESSION, &var, NULL);
+    ok(hr == S_OK, "ParseScriptText failed: %08x\n", hr);
+    ok(V_VT(&var) == VT_I2 && V_I2(&var) == 42, "V_VT(y) = %d, V_I2(y) = %d\n", V_VT(&var), V_I2(&var));
+    CHECK_CALLED(OnEnterScript);
+    CHECK_CALLED(OnLeaveScript);
+
+    SET_EXPECT(OnEnterScript);
+    SET_EXPECT(OnLeaveScript);
+    hr = IActiveScriptParse_ParseScriptText(parser, L"var", NULL, NULL, NULL, 0, 0, SCRIPTTEXT_ISEXPRESSION, &var, NULL);
+    ok(hr == S_OK, "ParseScriptText failed: %08x\n", hr);
+    ok(V_VT(&var) == VT_I2 && V_I2(&var) == 10, "V_VT(var) = %d, V_I2(var) = %d\n", V_VT(&var), V_I2(&var));
+    CHECK_CALLED(OnEnterScript);
+    CHECK_CALLED(OnLeaveScript);
+
+    SET_EXPECT(OnStateChange_DISCONNECTED);
+    SET_EXPECT(OnStateChange_INITIALIZED);
+    SET_EXPECT(OnStateChange_UNINITIALIZED);
+    hr = IActiveScript_SetScriptState(vbscript, SCRIPTSTATE_UNINITIALIZED);
+    ok(hr == S_OK, "SetScriptState(SCRIPTSTATE_UNINITIALIZED) failed: %08x\n", hr);
+    CHECK_CALLED(OnStateChange_DISCONNECTED);
+    CHECK_CALLED(OnStateChange_INITIALIZED);
+    CHECK_CALLED(OnStateChange_UNINITIALIZED);
+
+    SET_EXPECT(GetLCID);
+    SET_EXPECT(OnStateChange_INITIALIZED);
+    hr = IActiveScript_SetScriptSite(vbscript, &ActiveScriptSite);
+    ok(hr == S_OK, "SetScriptSite failed: %08x\n", hr);
+    CHECK_CALLED(GetLCID);
+    CHECK_CALLED(OnStateChange_INITIALIZED);
+
+    hr = IActiveScriptParse_ParseScriptText(parser, L"dim y\ny = 2\n", NULL, NULL, NULL, 0, 0, SCRIPTTEXT_ISPERSISTENT, NULL, NULL);
+    ok(hr == S_OK, "ParseScriptText failed: %08x\n", hr);
+
+    /* Closing the script engine removes all code (even if it's pending and persistent) */
+    SET_EXPECT(OnStateChange_CLOSED);
+    hr = IActiveScript_Close(vbscript);
+    ok(hr == S_OK, "Close failed: %08x\n", hr);
+    CHECK_CALLED(OnStateChange_CLOSED);
+    test_state(vbscript, SCRIPTSTATE_CLOSED);
+    test_no_script_dispatch(vbscript);
+
+    SET_EXPECT(OnStateChange_INITIALIZED);
+    SET_EXPECT(GetLCID);
+    hr = IActiveScript_SetScriptSite(vbscript, &ActiveScriptSite);
+    ok(hr == S_OK, "SetScriptSite failed: %08x\n", hr);
+    CHECK_CALLED(OnStateChange_INITIALIZED);
+    CHECK_CALLED(GetLCID);
+    test_state(vbscript, SCRIPTSTATE_INITIALIZED);
+
+    SET_EXPECT(OnStateChange_CONNECTED);
+    hr = IActiveScript_SetScriptState(vbscript, SCRIPTSTATE_CONNECTED);
+    ok(hr == S_OK, "SetScriptState(SCRIPTSTATE_CONNECTED) failed: %08x\n", hr);
+    CHECK_CALLED(OnStateChange_CONNECTED);
+    test_state(vbscript, SCRIPTSTATE_CONNECTED);
+
+    script_disp = get_script_dispatch(vbscript, NULL);
+    id = 0;
+    get_disp_id(script_disp, "y", DISP_E_UNKNOWNNAME, &id);
+    ok(id == -1, "id = %d, expected -1\n", id);
+    id = 0;
+    get_disp_id(script_disp, "z", DISP_E_UNKNOWNNAME, &id);
+    ok(id == -1, "id = %d, expected -1\n", id);
+    IDispatchEx_Release(script_disp);
+
+    IActiveScriptParse_Release(parser);
+
+    SET_EXPECT(OnStateChange_DISCONNECTED);
+    SET_EXPECT(OnStateChange_INITIALIZED);
+    SET_EXPECT(OnStateChange_CLOSED);
+    ref = IActiveScript_Release(vbscript);
+    ok(!ref, "ref = %d\n", ref);
+    CHECK_CALLED(OnStateChange_DISCONNECTED);
+    CHECK_CALLED(OnStateChange_INITIALIZED);
+    CHECK_CALLED(OnStateChange_CLOSED);
+}
+
+static void test_script_typeinfo(void)
+{
+    static struct
+    {
+        const WCHAR *name;
+        VARTYPE ret_type;
+        UINT num_args;
+    } func[] =
+    {
+        { L"foobar",   VT_VARIANT, 0 },
+        { L"test",     VT_VOID,    0 },
+        { L"subtract", VT_VARIANT, 2 },
+        { L"emptyfn",  VT_VARIANT, 0 }
+    };
+    static struct
+    {
+        const WCHAR *name;
+    } var[] =
+    {
+        { L"global_var" },
+        { L"obj"        },
+        { L"const_var"  },
+        { L"implicit"   }
+    };
+    ITypeInfo *typeinfo, *typeinfo2;
+    ITypeComp *typecomp, *typecomp2;
+    IActiveScriptParse *parser;
+    IDispatchEx *script_disp;
+    IActiveScript *vbscript;
+    FUNCDESC *funcdesc;
+    VARDESC  *vardesc;
+    DESCKIND desckind;
+    INT implTypeFlags;
+    UINT count, index;
+    HREFTYPE reftype;
+    BINDPTR bindptr;
+    MEMBERID memid;
+    TYPEATTR *attr;
+    HRESULT hr;
+    WCHAR str[64], *names = str;
+    BSTR bstr, bstrs[5];
+    void *obj;
+    int i;
+
+    vbscript = create_vbscript();
+
+    hr = IActiveScript_QueryInterface(vbscript, &IID_IActiveScriptParse, (void**)&parser);
+    ok(hr == S_OK, "Could not get IActiveScriptParse iface: %08x\n", hr);
+
+    SET_EXPECT(GetLCID);
+    hr = IActiveScript_SetScriptSite(vbscript, &ActiveScriptSite);
+    ok(hr == S_OK, "SetScriptSite failed: %08x\n", hr);
+    CHECK_CALLED(GetLCID);
+
+    SET_EXPECT(OnStateChange_INITIALIZED);
+    hr = IActiveScriptParse_InitNew(parser);
+    ok(hr == S_OK, "InitNew failed: %08x\n", hr);
+    CHECK_CALLED(OnStateChange_INITIALIZED);
+
+    SET_EXPECT(OnStateChange_CONNECTED);
+    hr = IActiveScript_SetScriptState(vbscript, SCRIPTSTATE_CONNECTED);
+    ok(hr == S_OK, "SetScriptState(SCRIPTSTATE_CONNECTED) failed: %08x\n", hr);
+    CHECK_CALLED(OnStateChange_CONNECTED);
+
+    parse_script(parser,
+        "dim global_var\n"
+        "const const_var = 1337\n"
+
+        "function foobar\n"
+        "    foobar = \"foobar\"\n"
+        "end function\n"
+
+        "sub test\nend sub\n"
+        "private sub private_sub\nend sub\n"
+
+        "function subtract(byref x, byval y)\n"
+        "    subtract = x - y\n"
+        "end function\n"
+
+        "function emptyfn\nend function\n"
+
+        "class C\n"
+        "    dim x\n"
+        "    public sub method\nend sub\n"
+        "    private function strret\n"
+        "        strret = \"ret\"\n"
+        "    end function\n"
+        "end class\n"
+
+        "implicit = 10\n"
+        "dim obj\nset obj = new C\n");
+
+    script_disp = get_script_dispatch(vbscript, NULL);
+    hr = IDispatchEx_QueryInterface(script_disp, &IID_ITypeInfo, (void**)&typeinfo);
+    ok(hr == E_NOINTERFACE, "QueryInterface(IID_ITypeInfo) returned: %08x\n", hr);
+    hr = IDispatchEx_GetTypeInfo(script_disp, 1, LOCALE_USER_DEFAULT, &typeinfo);
+    ok(hr == DISP_E_BADINDEX, "GetTypeInfo returned: %08x\n", hr);
+    hr = IDispatchEx_GetTypeInfo(script_disp, 0, LOCALE_USER_DEFAULT, &typeinfo);
+    ok(hr == S_OK, "GetTypeInfo failed: %08x\n", hr);
+    hr = IDispatchEx_GetTypeInfo(script_disp, 0, LOCALE_USER_DEFAULT, &typeinfo2);
+    ok(hr == S_OK, "GetTypeInfo failed: %08x\n", hr);
+    ok(typeinfo != typeinfo2, "TypeInfo was not supposed to be shared.\n");
+    ITypeInfo_Release(typeinfo2);
+
+    obj = (void*)0xdeadbeef;
+    hr = ITypeInfo_CreateInstance(typeinfo, NULL, NULL, NULL);
+    ok(hr == E_INVALIDARG, "CreateInstance returned: %08x\n", hr);
+    hr = ITypeInfo_CreateInstance(typeinfo, NULL, NULL, &obj);
+    ok(hr == TYPE_E_BADMODULEKIND, "CreateInstance returned: %08x\n", hr);
+    hr = ITypeInfo_CreateInstance(typeinfo, NULL, &IID_IDispatch, &obj);
+    ok(hr == TYPE_E_BADMODULEKIND, "CreateInstance returned: %08x\n", hr);
+    ok(!obj, "Unexpected non-null obj %p.\n", obj);
+
+    hr = ITypeInfo_GetDocumentation(typeinfo, MEMBERID_NIL, &bstr, NULL, NULL, NULL);
+    ok(hr == S_OK, "GetDocumentation(MEMBERID_NIL) failed: %08x\n", hr);
+    ok(!lstrcmpW(bstr, L"VBScriptTypeInfo"), "Unexpected TypeInfo name %s\n", wine_dbgstr_w(bstr));
+    SysFreeString(bstr);
+
+    hr = ITypeInfo_GetTypeAttr(typeinfo, &attr);
+    ok(hr == S_OK, "GetTypeAttr failed: %08x\n", hr);
+    ok(IsEqualGUID(&attr->guid, &IID_IScriptTypeInfo), "Unexpected GUID %s\n", wine_dbgstr_guid(&attr->guid));
+    ok(attr->lcid == LOCALE_USER_DEFAULT, "Unexpected LCID %u\n", attr->lcid);
+    ok(attr->memidConstructor == MEMBERID_NIL, "Unexpected constructor memid %u\n", attr->memidConstructor);
+    ok(attr->memidDestructor == MEMBERID_NIL, "Unexpected destructor memid %u\n", attr->memidDestructor);
+    ok(attr->cbSizeInstance == 4, "Unexpected cbSizeInstance %u\n", attr->cbSizeInstance);
+    ok(attr->typekind == TKIND_DISPATCH, "Unexpected typekind %u\n", attr->typekind);
+    ok(attr->cFuncs == ARRAY_SIZE(func), "Unexpected cFuncs %u\n", attr->cFuncs);
+    ok(attr->cVars == ARRAY_SIZE(var), "Unexpected cVars %u\n", attr->cVars);
+    ok(attr->cImplTypes == 1, "Unexpected cImplTypes %u\n", attr->cImplTypes);
+    ok(attr->cbSizeVft == sizeof(IDispatchVtbl), "Unexpected cbSizeVft %u\n", attr->cbSizeVft);
+    ok(attr->cbAlignment == 4, "Unexpected cbAlignment %u\n", attr->cbAlignment);
+    ok(attr->wTypeFlags == TYPEFLAG_FDISPATCHABLE, "Unexpected wTypeFlags 0x%x\n", attr->wTypeFlags);
+    ok(attr->tdescAlias.vt == VT_EMPTY, "Unexpected tdescAlias.vt %d\n", attr->tdescAlias.vt);
+    ok(attr->idldescType.wIDLFlags == IDLFLAG_NONE, "Unexpected idldescType.wIDLFlags 0x%x\n", attr->idldescType.wIDLFlags);
+    ITypeInfo_ReleaseTypeAttr(typeinfo, attr);
+
+    /* The type inherits from IDispatch */
+    hr = ITypeInfo_GetImplTypeFlags(typeinfo, 0, NULL);
+    ok(hr == E_INVALIDARG, "GetImplTypeFlags returned: %08x\n", hr);
+    hr = ITypeInfo_GetImplTypeFlags(typeinfo, 1, &implTypeFlags);
+    ok(hr == TYPE_E_ELEMENTNOTFOUND, "GetImplTypeFlags returned: %08x\n", hr);
+    hr = ITypeInfo_GetImplTypeFlags(typeinfo, -1, &implTypeFlags);
+    ok(hr == TYPE_E_ELEMENTNOTFOUND, "GetImplTypeFlags returned: %08x\n", hr);
+    hr = ITypeInfo_GetImplTypeFlags(typeinfo, 0, &implTypeFlags);
+    ok(hr == S_OK, "GetImplTypeFlags failed: %08x\n", hr);
+    ok(implTypeFlags == 0, "Unexpected implTypeFlags 0x%x\n", implTypeFlags);
+
+    hr = ITypeInfo_GetRefTypeOfImplType(typeinfo, 0, NULL);
+    ok(hr == E_INVALIDARG, "GetRefTypeOfImplType returned: %08x\n", hr);
+    hr = ITypeInfo_GetRefTypeOfImplType(typeinfo, 1, &reftype);
+    ok(hr == TYPE_E_ELEMENTNOTFOUND, "GetRefTypeOfImplType returned: %08x\n", hr);
+    hr = ITypeInfo_GetRefTypeOfImplType(typeinfo, -1, &reftype);
+    ok(hr == TYPE_E_ELEMENTNOTFOUND, "GetRefTypeOfImplType failed: %08x\n", hr);
+    hr = ITypeInfo_GetRefTypeOfImplType(typeinfo, 0, &reftype);
+    ok(hr == S_OK, "GetRefTypeOfImplType failed: %08x\n", hr);
+    ok(reftype == 1, "Unexpected reftype %d\n", reftype);
+
+    hr = ITypeInfo_GetRefTypeInfo(typeinfo, reftype, NULL);
+    ok(hr == E_INVALIDARG, "GetRefTypeInfo returned: %08x\n", hr);
+    hr = ITypeInfo_GetRefTypeInfo(typeinfo, -1, &typeinfo2);
+    ok(hr == E_INVALIDARG, "GetRefTypeInfo returned: %08x\n", hr);
+    hr = ITypeInfo_GetRefTypeInfo(typeinfo, 4, &typeinfo2);
+    ok(hr == E_FAIL, "GetRefTypeInfo returned: %08x\n", hr);
+    hr = ITypeInfo_GetRefTypeInfo(typeinfo, 0, &typeinfo2);
+    ok(hr == S_OK, "GetRefTypeInfo failed: %08x\n", hr);
+    ok(typeinfo == typeinfo2, "Unexpected TypeInfo %p (expected %p)\n", typeinfo2, typeinfo);
+    ITypeInfo_Release(typeinfo2);
+    hr = ITypeInfo_GetRefTypeInfo(typeinfo, reftype, &typeinfo2);
+    ok(hr == S_OK, "GetRefTypeInfo failed: %08x\n", hr);
+    hr = ITypeInfo_GetDocumentation(typeinfo2, MEMBERID_NIL, &bstr, NULL, NULL, NULL);
+    ok(hr == S_OK, "GetDocumentation(MEMBERID_NIL) failed: %08x\n", hr);
+    ok(!lstrcmpW(bstr, L"IDispatch"), "Unexpected TypeInfo name %s\n", wine_dbgstr_w(bstr));
+    ITypeInfo_Release(typeinfo2);
+    SysFreeString(bstr);
+
+    /* GetIDsOfNames looks into the inherited types as well */
+    wcscpy(str, L"queryinterface");
+    hr = ITypeInfo_GetIDsOfNames(typeinfo, NULL, 1, &memid);
+    ok(hr == E_INVALIDARG, "GetIDsOfNames returned: %08x\n", hr);
+    hr = ITypeInfo_GetIDsOfNames(typeinfo, &names, 1, NULL);
+    ok(hr == E_INVALIDARG, "GetIDsOfNames returned: %08x\n", hr);
+    hr = ITypeInfo_GetIDsOfNames(typeinfo, &names, 0, &memid);
+    ok(hr == E_INVALIDARG, "GetIDsOfNames returned: %08x\n", hr);
+    hr = ITypeInfo_GetIDsOfNames(typeinfo, &names, 1, &memid);
+    ok(hr == S_OK, "GetIDsOfNames failed: %08x\n", hr);
+    ok(!lstrcmpW(str, L"queryinterface"), "Unexpected string %s\n", wine_dbgstr_w(str));
+    wcscpy(str, L"C");
+    hr = ITypeInfo_GetIDsOfNames(typeinfo, &names, 1, &memid);
+    ok(hr == DISP_E_UNKNOWNNAME, "GetIDsOfNames returned: %08x\n", hr);
+    wcscpy(str, L"SUBtract");
+    hr = ITypeInfo_GetIDsOfNames(typeinfo, &names, 1, &memid);
+    ok(hr == S_OK, "GetIDsOfNames failed: %08x\n", hr);
+    ok(!lstrcmpW(str, L"SUBtract"), "Unexpected string %s\n", wine_dbgstr_w(str));
+
+    hr = ITypeInfo_GetNames(typeinfo, memid, NULL, 1, &count);
+    ok(hr == E_INVALIDARG, "GetNames returned: %08x\n", hr);
+    hr = ITypeInfo_GetNames(typeinfo, memid, bstrs, 1, NULL);
+    ok(hr == E_INVALIDARG, "GetNames returned: %08x\n", hr);
+    hr = ITypeInfo_GetNames(typeinfo, memid, bstrs, 0, &count);
+    ok(hr == S_OK, "GetNames failed: %08x\n", hr);
+    ok(count == 0, "Unexpected count %u\n", count);
+    hr = ITypeInfo_GetNames(typeinfo, memid, bstrs, ARRAY_SIZE(bstrs), &count);
+    ok(hr == S_OK, "GetNames failed: %08x\n", hr);
+    ok(count == 3, "Unexpected count %u\n", count);
+    ok(!lstrcmpW(bstrs[0], L"subtract"), "Unexpected function name %s\n", wine_dbgstr_w(bstrs[0]));
+    ok(!lstrcmpW(bstrs[1], L"x"), "Unexpected function first param name %s\n", wine_dbgstr_w(bstrs[1]));
+    ok(!lstrcmpW(bstrs[2], L"y"), "Unexpected function second param name %s\n", wine_dbgstr_w(bstrs[2]));
+    for (i = 0; i < count; i++) SysFreeString(bstrs[i]);
+
+    hr = ITypeInfo_GetMops(typeinfo, memid, NULL);
+    ok(hr == E_INVALIDARG, "GetMops returned: %08x\n", hr);
+    hr = ITypeInfo_GetMops(typeinfo, memid, &bstr);
+    ok(hr == S_OK, "GetMops failed: %08x\n", hr);
+    ok(!bstr, "Unexpected non-null string %s\n", wine_dbgstr_w(bstr));
+    hr = ITypeInfo_GetMops(typeinfo, MEMBERID_NIL, &bstr);
+    ok(hr == S_OK, "GetMops failed: %08x\n", hr);
+    ok(!bstr, "Unexpected non-null string %s\n", wine_dbgstr_w(bstr));
+
+    /* These always fail */
+    obj = (void*)0xdeadbeef;
+    hr = ITypeInfo_AddressOfMember(typeinfo, memid, INVOKE_FUNC, NULL);
+    ok(hr == E_INVALIDARG, "AddressOfMember returned: %08x\n", hr);
+    hr = ITypeInfo_AddressOfMember(typeinfo, memid, INVOKE_FUNC, &obj);
+    ok(hr == TYPE_E_BADMODULEKIND, "AddressOfMember returned: %08x\n", hr);
+    ok(!obj, "Unexpected non-null obj %p.\n", obj);
+    bstr = (BSTR)0xdeadbeef;
+    hr = ITypeInfo_GetDllEntry(typeinfo, memid, INVOKE_FUNC, &bstr, NULL, NULL);
+    ok(hr == TYPE_E_BADMODULEKIND, "GetDllEntry returned: %08x\n", hr);
+    ok(!bstr, "Unexpected non-null str %p.\n", bstr);
+    wcscpy(str, L"Invoke");
+    hr = ITypeInfo_GetIDsOfNames(typeinfo, &names, 1, &memid);
+    ok(hr == S_OK, "GetIDsOfNames failed: %08x\n", hr);
+    obj = (void*)0xdeadbeef;
+    hr = ITypeInfo_AddressOfMember(typeinfo, memid, INVOKE_FUNC, &obj);
+    ok(hr == TYPE_E_BADMODULEKIND, "AddressOfMember returned: %08x\n", hr);
+    ok(!obj, "Unexpected non-null obj %p.\n", obj);
+    bstr = (BSTR)0xdeadbeef;
+    hr = ITypeInfo_GetDllEntry(typeinfo, memid, INVOKE_FUNC, &bstr, NULL, NULL);
+    ok(hr == TYPE_E_BADMODULEKIND, "GetDllEntry returned: %08x\n", hr);
+    ok(!bstr, "Unexpected non-null str %p.\n", bstr);
+
+    /* Check variable descriptions */
+    hr = ITypeInfo_GetVarDesc(typeinfo, 0, NULL);
+    ok(hr == E_INVALIDARG, "GetVarDesc returned: %08x\n", hr);
+    hr = ITypeInfo_GetVarDesc(typeinfo, 1337, &vardesc);
+    ok(hr == TYPE_E_ELEMENTNOTFOUND, "GetVarDesc returned: %08x\n", hr);
+    for (i = 0; i < ARRAY_SIZE(var); i++)
+    {
+        hr = ITypeInfo_GetVarDesc(typeinfo, i, &vardesc);
+        ok(hr == S_OK, "GetVarDesc(%u) failed: %08x\n", i, hr);
+        hr = ITypeInfo_GetDocumentation(typeinfo, vardesc->memid, &bstr, &bstrs[0], NULL, NULL);
+        ok(hr == S_OK, "[%u] GetDocumentation failed: %08x\n", i, hr);
+        ok(!lstrcmpW(bstr, var[i].name), "[%u] Unexpected variable name %s (expected %s)\n",
+            i, wine_dbgstr_w(bstr), wine_dbgstr_w(var[i].name));
+        ok(!bstrs[0], "[%u] Unexpected doc string %s\n", i, wine_dbgstr_w(bstrs[0]));
+        SysFreeString(bstr);
+        ok(vardesc->lpstrSchema == NULL, "[%u] Unexpected lpstrSchema %p\n", i, vardesc->lpstrSchema);
+        ok(vardesc->oInst == 0, "[%u] Unexpected oInst %u\n", i, vardesc->oInst);
+        ok(vardesc->varkind == VAR_DISPATCH, "[%u] Unexpected varkind %d\n", i, vardesc->varkind);
+        ok(vardesc->wVarFlags == 0, "[%u] Unexpected wVarFlags 0x%x\n", i, vardesc->wVarFlags);
+        ok(vardesc->elemdescVar.tdesc.vt == VT_VARIANT,
+            "[%u] Unexpected variable type vt %d (expected %d)\n", i, vardesc->elemdescVar.tdesc.vt, 0);
+        ok(vardesc->elemdescVar.paramdesc.pparamdescex == NULL,
+            "[%u] Unexpected variable type pparamdescex %p\n", i, vardesc->elemdescVar.paramdesc.pparamdescex);
+        ok(vardesc->elemdescVar.paramdesc.wParamFlags == PARAMFLAG_NONE,
+            "[%u] Unexpected variable type wParamFlags 0x%x\n", i, vardesc->elemdescVar.paramdesc.wParamFlags);
+        ITypeInfo_ReleaseVarDesc(typeinfo, vardesc);
+    }
+
+    /* Check function descriptions */
+    hr = ITypeInfo_GetFuncDesc(typeinfo, 0, NULL);
+    ok(hr == E_INVALIDARG, "GetFuncDesc returned: %08x\n", hr);
+    hr = ITypeInfo_GetFuncDesc(typeinfo, 1337, &funcdesc);
+    ok(hr == TYPE_E_ELEMENTNOTFOUND, "GetFuncDesc returned: %08x\n", hr);
+    for (i = 0; i < ARRAY_SIZE(func); i++)
+    {
+        hr = ITypeInfo_GetFuncDesc(typeinfo, i, &funcdesc);
+        ok(hr == S_OK, "GetFuncDesc(%u) failed: %08x\n", i, hr);
+        hr = ITypeInfo_GetDocumentation(typeinfo, funcdesc->memid, &bstr, &bstrs[0], NULL, NULL);
+        ok(hr == S_OK, "[%u] GetDocumentation failed: %08x\n", i, hr);
+        ok(!lstrcmpW(bstr, func[i].name), "[%u] Unexpected function name %s (expected %s)\n",
+            i, wine_dbgstr_w(bstr), wine_dbgstr_w(func[i].name));
+        ok(!bstrs[0], "[%u] Unexpected doc string %s\n", i, wine_dbgstr_w(bstrs[0]));
+        SysFreeString(bstr);
+        ok(funcdesc->lprgscode == NULL, "[%u] Unexpected lprgscode %p\n", i, funcdesc->lprgscode);
+        ok(func[i].num_args ? (funcdesc->lprgelemdescParam != NULL) : (funcdesc->lprgelemdescParam == NULL),
+            "[%u] Unexpected lprgelemdescParam %p\n", i, funcdesc->lprgelemdescParam);
+        ok(funcdesc->funckind == FUNC_DISPATCH, "[%u] Unexpected funckind %u\n", i, funcdesc->funckind);
+        ok(funcdesc->invkind == INVOKE_FUNC, "[%u] Unexpected invkind %u\n", i, funcdesc->invkind);
+        ok(funcdesc->callconv == CC_STDCALL, "[%u] Unexpected callconv %u\n", i, funcdesc->callconv);
+        ok(funcdesc->cParams == func[i].num_args, "[%u] Unexpected cParams %d (expected %d)\n",
+            i, funcdesc->cParams, func[i].num_args);
+        ok(funcdesc->cParamsOpt == 0, "[%u] Unexpected cParamsOpt %d\n", i, funcdesc->cParamsOpt);
+        ok(funcdesc->cScodes == 0, "[%u] Unexpected cScodes %d\n", i, funcdesc->cScodes);
+        ok(funcdesc->wFuncFlags == 0, "[%u] Unexpected wFuncFlags 0x%x\n", i, funcdesc->wFuncFlags);
+        ok(funcdesc->elemdescFunc.tdesc.vt == func[i].ret_type,
+            "[%u] Unexpected return type vt %d (expected %d)\n", i, funcdesc->elemdescFunc.tdesc.vt, func[i].ret_type);
+        ok(funcdesc->elemdescFunc.paramdesc.pparamdescex == NULL,
+            "[%u] Unexpected return type pparamdescex %p\n", i, funcdesc->elemdescFunc.paramdesc.pparamdescex);
+        ok(funcdesc->elemdescFunc.paramdesc.wParamFlags == PARAMFLAG_NONE,
+            "[%u] Unexpected return type wParamFlags 0x%x\n", i, funcdesc->elemdescFunc.paramdesc.wParamFlags);
+        if (funcdesc->lprgelemdescParam)
+            for (index = 0; index < funcdesc->cParams; index++)
+            {
+                ok(funcdesc->lprgelemdescParam[index].tdesc.vt == VT_VARIANT,
+                    "[%u] Unexpected parameter %u vt %d\n", i, index, funcdesc->lprgelemdescParam[index].tdesc.vt);
+                ok(funcdesc->lprgelemdescParam[index].paramdesc.pparamdescex == NULL,
+                    "[%u] Unexpected parameter %u pparamdescex %p\n", i, index, funcdesc->lprgelemdescParam[index].paramdesc.pparamdescex);
+                ok(funcdesc->lprgelemdescParam[index].paramdesc.wParamFlags == PARAMFLAG_NONE,
+                    "[%u] Unexpected parameter %u wParamFlags 0x%x\n", i, index, funcdesc->lprgelemdescParam[index].paramdesc.wParamFlags);
+            }
+        ITypeInfo_ReleaseFuncDesc(typeinfo, funcdesc);
+    }
+
+    /* Test TypeComp Binds */
+    hr = ITypeInfo_QueryInterface(typeinfo, &IID_ITypeComp, (void**)&typecomp);
+    ok(hr == S_OK, "QueryInterface(IID_ITypeComp) failed: %08x\n", hr);
+    hr = ITypeInfo_GetTypeComp(typeinfo, NULL);
+    ok(hr == E_INVALIDARG, "GetTypeComp returned: %08x\n", hr);
+    hr = ITypeInfo_GetTypeComp(typeinfo, &typecomp2);
+    ok(hr == S_OK, "GetTypeComp failed: %08x\n", hr);
+    ok(typecomp == typecomp2, "QueryInterface(IID_ITypeComp) and GetTypeComp returned different TypeComps\n");
+    ITypeComp_Release(typecomp2);
+    wcscpy(str, L"not_found");
+    hr = ITypeComp_Bind(typecomp, NULL, 0, 0, &typeinfo2, &desckind, &bindptr);
+    ok(hr == E_INVALIDARG, "Bind returned: %08x\n", hr);
+    hr = ITypeComp_Bind(typecomp, str, 0, 0, NULL, &desckind, &bindptr);
+    ok(hr == E_INVALIDARG, "Bind returned: %08x\n", hr);
+    hr = ITypeComp_Bind(typecomp, str, 0, 0, &typeinfo2, NULL, &bindptr);
+    ok(hr == E_INVALIDARG, "Bind returned: %08x\n", hr);
+    hr = ITypeComp_Bind(typecomp, str, 0, 0, &typeinfo2, &desckind, NULL);
+    ok(hr == E_INVALIDARG, "Bind returned: %08x\n", hr);
+
+    hr = ITypeComp_Bind(typecomp, str, 0, 0, &typeinfo2, &desckind, &bindptr);
+    ok(hr == S_OK, "Bind failed: %08x\n", hr);
+    ok(desckind == DESCKIND_NONE, "Unexpected desckind %u\n", desckind);
+    wcscpy(str, L"GLOBAL_VAR");
+    hr = ITypeComp_Bind(typecomp, str, 0, INVOKE_FUNC, &typeinfo2, &desckind, &bindptr);
+    ok(hr == TYPE_E_TYPEMISMATCH, "Bind returned: %08x\n", hr);
+    ok(!lstrcmpW(str, L"GLOBAL_VAR"), "Unexpected string %s\n", wine_dbgstr_w(str));
+    wcscpy(str, L"C");
+    hr = ITypeComp_Bind(typecomp, str, 0, 0, &typeinfo2, &desckind, &bindptr);
+    ok(hr == S_OK, "Bind failed: %08x\n", hr);
+    ok(desckind == DESCKIND_NONE, "Unexpected desckind %u\n", desckind);
+    wcscpy(str, L"addRef");
+    hr = ITypeComp_Bind(typecomp, str, 0, 0, &typeinfo2, &desckind, &bindptr);
+    ok(hr == S_OK, "Bind failed: %08x\n", hr);
+    ok(desckind == DESCKIND_FUNCDESC, "Unexpected desckind %u\n", desckind);
+    ok(!lstrcmpW(str, L"addRef"), "Unexpected string %s\n", wine_dbgstr_w(str));
+    ITypeInfo_ReleaseFuncDesc(typeinfo2, bindptr.lpfuncdesc);
+    ITypeInfo_Release(typeinfo2);
+    for (i = 0; i < ARRAY_SIZE(var); i++)
+    {
+        wcscpy(str, var[i].name);
+        hr = ITypeComp_Bind(typecomp, str, 0, INVOKE_PROPERTYGET, &typeinfo2, &desckind, &bindptr);
+        ok(hr == S_OK, "Bind failed: %08x\n", hr);
+        ok(desckind == DESCKIND_VARDESC, "Unexpected desckind %u\n", desckind);
+        ITypeInfo_ReleaseVarDesc(typeinfo2, bindptr.lpvardesc);
+        ITypeInfo_Release(typeinfo2);
+    }
+    for (i = 0; i < ARRAY_SIZE(func); i++)
+    {
+        wcscpy(str, func[i].name);
+        hr = ITypeComp_Bind(typecomp, str, 0, INVOKE_FUNC, &typeinfo2, &desckind, &bindptr);
+        ok(hr == S_OK, "Bind failed: %08x\n", hr);
+        ok(desckind == DESCKIND_FUNCDESC, "Unexpected desckind %u\n", desckind);
+        ITypeInfo_ReleaseFuncDesc(typeinfo2, bindptr.lpfuncdesc);
+        ITypeInfo_Release(typeinfo2);
+    }
+    wcscpy(str, L"VBScriptTypeInfo");
+    hr = ITypeComp_BindType(typecomp, NULL, 0, &typeinfo2, &typecomp2);
+    ok(hr == E_INVALIDARG, "BindType returned: %08x\n", hr);
+    hr = ITypeComp_BindType(typecomp, str, 0, NULL, &typecomp2);
+    ok(hr == E_INVALIDARG, "BindType returned: %08x\n", hr);
+    hr = ITypeComp_BindType(typecomp, str, 0, &typeinfo2, NULL);
+    ok(hr == E_INVALIDARG, "BindType returned: %08x\n", hr);
+    hr = ITypeComp_BindType(typecomp, str, 0, &typeinfo2, &typecomp2);
+    ok(hr == S_OK, "BindType failed: %08x\n", hr);
+    ok(!typeinfo2, "Unexpected TypeInfo %p (expected null)\n", typeinfo2);
+    ok(!typecomp2, "Unexpected TypeComp %p (expected null)\n", typecomp2);
+    wcscpy(str, L"C");
+    hr = ITypeComp_BindType(typecomp, str, 0, &typeinfo2, &typecomp2);
+    ok(hr == S_OK, "BindType failed: %08x\n", hr);
+    ok(!typeinfo2, "Unexpected TypeInfo %p (expected null)\n", typeinfo2);
+    ok(!typecomp2, "Unexpected TypeComp %p (expected null)\n", typecomp2);
+    wcscpy(str, L"IDispatch");
+    hr = ITypeComp_BindType(typecomp, str, 0, &typeinfo2, &typecomp2);
+    ok(hr == S_OK, "BindType failed: %08x\n", hr);
+    ok(!typeinfo2, "Unexpected TypeInfo %p (expected null)\n", typeinfo2);
+    ok(!typecomp2, "Unexpected TypeComp %p (expected null)\n", typecomp2);
+
+    ITypeComp_Release(typecomp);
+
+    /* Updating the script won't update the typeinfo obtained before,
+       but it will be reflected in any typeinfo obtained afterwards. */
+    parse_script(parser,
+        "dim new_var\nnew_var = 10\n"
+        "sub new_sub\nend sub\n"
+
+        /* Replace the function foobar with more args */
+        "function foobar(x, y, z)\nend function\n");
+
+    hr = IDispatchEx_GetTypeInfo(script_disp, 0, LOCALE_USER_DEFAULT, &typeinfo2);
+    ok(hr == S_OK, "GetTypeInfo failed: %08x\n", hr);
+    hr = ITypeInfo_GetTypeAttr(typeinfo, &attr);
+    ok(hr == S_OK, "GetTypeAttr failed: %08x\n", hr);
+    ok(attr->cFuncs == ARRAY_SIZE(func), "Unexpected cFuncs %u\n", attr->cFuncs);
+    ok(attr->cVars == ARRAY_SIZE(var), "Unexpected cVars %u\n", attr->cVars);
+    ITypeInfo_ReleaseTypeAttr(typeinfo, attr);
+    hr = ITypeInfo_GetTypeAttr(typeinfo2, &attr);
+    ok(hr == S_OK, "GetTypeAttr failed: %08x\n", hr);
+    ok(attr->cFuncs == ARRAY_SIZE(func) + 1, "Unexpected cFuncs %u\n", attr->cFuncs);
+    ok(attr->cVars == ARRAY_SIZE(var) + 1, "Unexpected cVars %u\n", attr->cVars);
+    ITypeInfo_ReleaseTypeAttr(typeinfo2, attr);
+    hr = ITypeInfo_GetVarDesc(typeinfo2, ARRAY_SIZE(var), &vardesc);
+    ok(hr == S_OK, "GetVarDesc failed: %08x\n", hr);
+    hr = ITypeInfo_GetDocumentation(typeinfo2, vardesc->memid, &bstr, &bstrs[0], NULL, NULL);
+    ok(hr == S_OK, "GetDocumentation failed: %08x\n", hr);
+    ok(!lstrcmpW(bstr, L"new_var"), "Unexpected variable name %s\n", wine_dbgstr_w(bstr));
+    ok(!bstrs[0], "Unexpected doc string %s\n", wine_dbgstr_w(bstrs[0]));
+    ITypeInfo_ReleaseVarDesc(typeinfo2, vardesc);
+    SysFreeString(bstr);
+    hr = ITypeInfo_GetFuncDesc(typeinfo, 0, &funcdesc);
+    ok(hr == S_OK, "GetFuncDesc failed: %08x\n", hr);
+    ok(funcdesc->cParams == 0, "Unexpected cParams %d\n", funcdesc->cParams);
+    ITypeInfo_ReleaseFuncDesc(typeinfo, funcdesc);
+    hr = ITypeInfo_GetFuncDesc(typeinfo2, 0, &funcdesc);
+    ok(hr == S_OK, "GetFuncDesc failed: %08x\n", hr);
+    ok(funcdesc->cParams == 3, "Unexpected cParams %d\n", funcdesc->cParams);
+    ITypeInfo_ReleaseFuncDesc(typeinfo2, funcdesc);
+    ITypeInfo_Release(typeinfo2);
+
+    ITypeInfo_Release(typeinfo);
+    IDispatchEx_Release(script_disp);
+    IActiveScriptParse_Release(parser);
+
+    SET_EXPECT(OnStateChange_DISCONNECTED);
+    SET_EXPECT(OnStateChange_INITIALIZED);
+    SET_EXPECT(OnStateChange_CLOSED);
+    hr = IActiveScript_Close(vbscript);
+    ok(hr == S_OK, "Close failed: %08x\n", hr);
+    CHECK_CALLED(OnStateChange_DISCONNECTED);
+    CHECK_CALLED(OnStateChange_INITIALIZED);
+    CHECK_CALLED(OnStateChange_CLOSED);
+
+    IActiveScript_Release(vbscript);
 }
 
 static void test_vbscript(void)
@@ -712,6 +1515,11 @@ static void test_vbscript_uninitializing(void)
 
     test_no_script_dispatch(script);
 
+    hres = IActiveScript_SetScriptState(script, SCRIPTSTATE_STARTED);
+    ok(hres == E_UNEXPECTED, "SetScriptState(SCRIPTSTATE_STARTED) failed: %08x\n", hres);
+    hres = IActiveScript_SetScriptState(script, SCRIPTSTATE_INITIALIZED);
+    ok(hres == E_UNEXPECTED, "SetScriptState(SCRIPTSTATE_INITIALIZED) failed: %08x\n", hres);
+
     SET_EXPECT(GetLCID);
     SET_EXPECT(OnStateChange_INITIALIZED);
     hres = IActiveScript_SetScriptSite(script, &ActiveScriptSite);
@@ -755,7 +1563,7 @@ static void test_vbscript_uninitializing(void)
 
     test_state(script, SCRIPTSTATE_CONNECTED);
 
-    dispex = get_script_dispatch(script);
+    dispex = get_script_dispatch(script, NULL);
     ok(dispex != NULL, "dispex == NULL\n");
     if(dispex)
         IDispatchEx_Release(dispex);
@@ -790,6 +1598,35 @@ static void test_vbscript_uninitializing(void)
 
     test_state(script, SCRIPTSTATE_INITIALIZED);
 
+    SET_EXPECT(OnStateChange_STARTED);
+    hres = IActiveScript_SetScriptState(script, SCRIPTSTATE_STARTED);
+    ok(hres == S_OK, "SetScriptState(SCRIPTSTATE_UNINITIALIZED) failed: %08x\n", hres);
+    CHECK_CALLED(OnStateChange_STARTED);
+
+    SET_EXPECT(OnStateChange_INITIALIZED);
+    hres = IActiveScript_SetScriptState(script, SCRIPTSTATE_INITIALIZED);
+    ok(hres == S_OK, "SetScriptState(SCRIPTSTATE_UNINITIALIZED) failed: %08x\n", hres);
+    CHECK_CALLED(OnStateChange_INITIALIZED);
+
+    hres = IActiveScript_SetScriptState(script, SCRIPTSTATE_INITIALIZED);
+    ok(hres == S_OK, "SetScriptState(SCRIPTSTATE_UNINITIALIZED) failed: %08x\n", hres);
+
+    SET_EXPECT(OnStateChange_CLOSED);
+    hres = IActiveScript_Close(script);
+    ok(hres == S_OK, "Close failed: %08x\n", hres);
+    CHECK_CALLED(OnStateChange_CLOSED);
+
+    test_state(script, SCRIPTSTATE_CLOSED);
+
+    SET_EXPECT(GetLCID);
+    SET_EXPECT(OnStateChange_INITIALIZED);
+    hres = IActiveScript_SetScriptSite(script, &ActiveScriptSite);
+    ok(hres == S_OK, "SetScriptSite failed: %08x\n", hres);
+    CHECK_CALLED(GetLCID);
+    CHECK_CALLED(OnStateChange_INITIALIZED);
+
+    test_state(script, SCRIPTSTATE_INITIALIZED);
+
     SET_EXPECT(OnStateChange_CLOSED);
     hres = IActiveScript_Close(script);
     ok(hres == S_OK, "Close failed: %08x\n", hres);
@@ -800,7 +1637,78 @@ static void test_vbscript_uninitializing(void)
     hres = IActiveScriptParse_InitNew(parse);
     ok(hres == E_UNEXPECTED, "InitNew failed: %08x\n", hres);
 
+    /* initialize again and use SetScriptState(SCRIPTSTATE_CLOSED) to uninitialize it */
+
+    SET_EXPECT(GetLCID);
+    SET_EXPECT(OnStateChange_INITIALIZED);
+    hres = IActiveScript_SetScriptSite(script, &ActiveScriptSite);
+    ok(hres == S_OK, "SetScriptSite failed: %08x\n", hres);
+    CHECK_CALLED(GetLCID);
+    CHECK_CALLED(OnStateChange_INITIALIZED);
+
+    SET_EXPECT(OnStateChange_CONNECTED);
+    hres = IActiveScript_SetScriptState(script, SCRIPTSTATE_CONNECTED);
+    ok(hres == S_OK, "SetScriptState(SCRIPTSTATE_CONNECTED) failed: %08x\n", hres);
+    CHECK_CALLED(OnStateChange_CONNECTED);
+
+    SET_EXPECT(OnStateChange_DISCONNECTED);
+    SET_EXPECT(OnStateChange_INITIALIZED);
+    SET_EXPECT(OnStateChange_CLOSED);
+    hres = IActiveScript_SetScriptState(script, SCRIPTSTATE_CLOSED);
+    ok(hres == S_OK, "SetScriptState(SCRIPTSTATE_CLOSED) failed: %08x\n", hres);
+    CHECK_CALLED(OnStateChange_DISCONNECTED);
+    CHECK_CALLED(OnStateChange_INITIALIZED);
+    CHECK_CALLED(OnStateChange_CLOSED);
+
+    test_state(script, SCRIPTSTATE_CLOSED);
+
+    hres = IActiveScript_SetScriptState(script, SCRIPTSTATE_CLOSED);
+    ok(hres == S_OK, "SetScriptState(SCRIPTSTATE_CLOSED) failed: %08x\n", hres);
+
+    hres = IActiveScript_SetScriptState(script, SCRIPTSTATE_INITIALIZED);
+    ok(hres == E_UNEXPECTED, "SetScriptState(SCRIPTSTATE_INITIALIZED) failed: %08x\n", hres);
+
+    hres = IActiveScript_Close(script);
+    ok(hres == S_OK, "Close failed: %08x\n", hres);
+
+    SET_EXPECT(GetLCID);
+    SET_EXPECT(OnStateChange_INITIALIZED);
+    hres = IActiveScript_SetScriptSite(script, &ActiveScriptSite);
+    ok(hres == S_OK, "SetScriptSite failed: %08x\n", hres);
+    CHECK_CALLED(GetLCID);
+    CHECK_CALLED(OnStateChange_INITIALIZED);
+
+    SET_EXPECT(OnStateChange_CONNECTED);
+    hres = IActiveScript_SetScriptState(script, SCRIPTSTATE_CONNECTED);
+    ok(hres == S_OK, "SetScriptState(SCRIPTSTATE_CONNECTED) failed: %08x\n", hres);
+    CHECK_CALLED(OnStateChange_CONNECTED);
+
+    SET_EXPECT(OnStateChange_DISCONNECTED);
+    SET_EXPECT(OnStateChange_INITIALIZED);
+    SET_EXPECT(OnStateChange_CLOSED);
+    hres = IActiveScript_Close(script);
+    ok(hres == S_OK, "Close failed: %08x\n", hres);
+    CHECK_CALLED(OnStateChange_DISCONNECTED);
+    CHECK_CALLED(OnStateChange_INITIALIZED);
+    CHECK_CALLED(OnStateChange_CLOSED);
+
+    test_state(script, SCRIPTSTATE_CLOSED);
+
+    hres = IActiveScript_SetScriptState(script, SCRIPTSTATE_CLOSED);
+    ok(hres == S_OK, "SetScriptState(SCRIPTSTATE_CLOSED) failed: %08x\n", hres);
+
+    hres = IActiveScript_SetScriptState(script, SCRIPTSTATE_INITIALIZED);
+    ok(hres == E_UNEXPECTED, "SetScriptState(SCRIPTSTATE_INITIALIZED) failed: %08x\n", hres);
+
     IActiveScriptParse_Release(parse);
+
+    ref = IActiveScript_Release(script);
+    ok(!ref, "ref = %d\n", ref);
+
+    script = create_vbscript();
+
+    hres = IActiveScript_SetScriptState(script, SCRIPTSTATE_CLOSED);
+    ok(hres == E_UNEXPECTED, "SetScriptState(SCRIPTSTATE_CLOSED) failed: %08x\n", hres);
 
     ref = IActiveScript_Release(script);
     ok(!ref, "ref = %d\n", ref);
@@ -911,9 +1819,43 @@ static void test_vbscript_initializing(void)
 
 static void test_named_items(void)
 {
+    static const WCHAR *global_idents[] =
+    {
+        L"global_me",
+        L"globalCode_me",
+        L"testSub_global",
+        L"testExplicitVar_global",
+        L"testVar_global"
+    };
+    static const WCHAR *global_code_test[] =
+    {
+        L"testSub_global\n",
+        L"if testExplicitVar_global <> 10 then err.raise 500\n",
+        L"if testVar_global <> 5 then err.raise 500\n",
+        L"set x = new testClass_global\n"
+    };
+    static const WCHAR *context_idents[] =
+    {
+        L"testSub",
+        L"testExplicitVar",
+        L"testVar"
+    };
+    static const WCHAR *context_code_test[] =
+    {
+        L"testSub\n",
+        L"if testExplicitVar <> 42 then err.raise 500\n",
+        L"if testVar <> 99 then err.raise 500\n",
+        L"set x = new testClass\n"
+    };
+    IDispatchEx *script_disp, *script_disp2;
     IActiveScriptParse *parse;
     IActiveScript *script;
+    IDispatch *disp;
+    VARIANT var;
+    unsigned i;
+    DISPID id;
     ULONG ref;
+    BSTR bstr;
     HRESULT hres;
 
     script = create_vbscript();
@@ -926,6 +1868,10 @@ static void test_named_items(void)
     hres = IActiveScript_AddNamedItem(script, L"visibleItem", SCRIPTITEM_ISVISIBLE);
     ok(hres == E_UNEXPECTED, "AddNamedItem returned: %08x\n", hres);
     hres = IActiveScript_AddNamedItem(script, L"globalItem", SCRIPTITEM_GLOBALMEMBERS);
+    ok(hres == E_UNEXPECTED, "AddNamedItem returned: %08x\n", hres);
+    hres = IActiveScript_AddNamedItem(script, L"codeOnlyItem", SCRIPTITEM_CODEONLY);
+    ok(hres == E_UNEXPECTED, "AddNamedItem returned: %08x\n", hres);
+    hres = IActiveScript_AddNamedItem(script, L"persistent", SCRIPTITEM_ISPERSISTENT | SCRIPTITEM_CODEONLY);
     ok(hres == E_UNEXPECTED, "AddNamedItem returned: %08x\n", hres);
 
     SET_EXPECT(GetLCID);
@@ -940,9 +1886,35 @@ static void test_named_items(void)
 
     hres = IActiveScript_AddNamedItem(script, L"visibleItem", SCRIPTITEM_ISVISIBLE);
     ok(hres == S_OK, "AddNamedItem failed: %08x\n", hres);
+    hres = IActiveScript_AddNamedItem(script, L"visibleCodeItem", SCRIPTITEM_ISVISIBLE | SCRIPTITEM_CODEONLY);
+    ok(hres == S_OK, "AddNamedItem failed: %08x\n", hres);
+    hres = IActiveScript_AddNamedItem(script, L"codeOnlyItem", SCRIPTITEM_CODEONLY);
+    ok(hres == S_OK, "AddNamedItem failed: %08x\n", hres);
+    hres = IActiveScript_AddNamedItem(script, L"persistent", SCRIPTITEM_ISPERSISTENT | SCRIPTITEM_CODEONLY);
+    ok(hres == S_OK, "AddNamedItem failed: %08x\n", hres);
 
     ok(global_named_item_ref > 0, "global_named_item_ref = %u\n", global_named_item_ref);
     ok(visible_named_item_ref == 0, "visible_named_item_ref = %u\n", visible_named_item_ref);
+    ok(visible_code_named_item_ref == 0, "visible_code_named_item_ref = %u\n", visible_code_named_item_ref);
+    ok(persistent_named_item_ref == 0, "persistent_named_item_ref = %u\n", persistent_named_item_ref);
+
+    hres = IActiveScript_GetScriptDispatch(script, L"noContext", &disp);
+    ok(hres == E_INVALIDARG, "GetScriptDispatch returned: %08x\n", hres);
+
+    SET_EXPECT(GetItemInfo_global_code);
+    hres = IActiveScript_AddNamedItem(script, L"globalCodeItem", SCRIPTITEM_GLOBALMEMBERS | SCRIPTITEM_CODEONLY);
+    ok(hres == S_OK, "AddNamedItem failed: %08x\n", hres);
+    CHECK_CALLED(GetItemInfo_global_code);
+
+    script_disp = get_script_dispatch(script, NULL);
+    script_disp2 = get_script_dispatch(script, L"globalItem");
+    ok(script_disp == script_disp2, "get_script_dispatch returned different dispatch objects.\n");
+    IDispatchEx_Release(script_disp2);
+    script_disp2 = get_script_dispatch(script, L"globalCodeItem");
+    ok(script_disp == script_disp2, "get_script_dispatch returned different dispatch objects.\n");
+    IDispatchEx_Release(script_disp2);
+    script_disp2 = get_script_dispatch(script, L"codeONLYitem");
+    ok(script_disp != script_disp2, "get_script_dispatch returned same dispatch objects.\n");
 
     SET_EXPECT(OnStateChange_INITIALIZED);
     hres = IActiveScriptParse_InitNew(parse);
@@ -964,12 +1936,470 @@ static void test_named_items(void)
     CHECK_CALLED(GetItemInfo_visible);
     CHECK_CALLED(testCall);
 
+    SET_EXPECT(OnEnterScript);
+    SET_EXPECT(OnLeaveScript);
+    SET_EXPECT(testCall);
+    hres = IActiveScriptParse_ParseScriptText(parse, L"testCall\n", L"visibleCodeItem", NULL, NULL, 0, 0, 0, NULL, NULL);
+    ok(hres == S_OK, "ParseScriptText failed: %08x\n", hres);
+    CHECK_CALLED(OnEnterScript);
+    CHECK_CALLED(OnLeaveScript);
+    CHECK_CALLED(testCall);
+
+    SET_EXPECT(OnEnterScript);
+    SET_EXPECT(GetIDsOfNames);
+    SET_EXPECT(OnScriptError);
+    SET_EXPECT(OnLeaveScript);
+    hres = IActiveScriptParse_ParseScriptText(parse, L"codeOnlyItem\n", L"codeOnlyItem", NULL, NULL, 0, 0, 0, NULL, NULL);
+    ok(FAILED(hres), "ParseScriptText returned: %08x\n", hres);
+    CHECK_CALLED(OnEnterScript);
+    CHECK_CALLED(GetIDsOfNames);
+    CHECK_CALLED(OnScriptError);
+    CHECK_CALLED(OnLeaveScript);
+
+    hres = IActiveScript_GetScriptDispatch(script, L"visibleCodeItem", &disp);
+    ok(hres == S_OK, "GetScriptDispatch returned: %08x\n", hres);
+    SET_EXPECT(OnEnterScript);
+    SET_EXPECT(OnLeaveScript);
+    hres = IActiveScriptParse_ParseScriptText(parse, L"me", L"visibleCodeItem", NULL, NULL, 0, 0, SCRIPTTEXT_ISEXPRESSION, &var, NULL);
+    ok(hres == S_OK, "ParseScriptText failed: %08x\n", hres);
+    ok(V_VT(&var) == VT_DISPATCH && V_DISPATCH(&var) == disp,
+        "Unexpected 'me': V_VT = %d, V_DISPATCH = %p\n", V_VT(&var), V_DISPATCH(&var));
+    VariantClear(&var);
+    CHECK_CALLED(OnEnterScript);
+    CHECK_CALLED(OnLeaveScript);
+    IDispatch_Release(disp);
+
+    SET_EXPECT(GetItemInfo_visible_code);
+    SET_EXPECT(testCall);
+    parse_script(parse, "visibleCodeItem.testCall\n");
+    CHECK_CALLED(GetItemInfo_visible_code);
+    CHECK_CALLED(testCall);
+
     ok(global_named_item_ref > 0, "global_named_item_ref = %u\n", global_named_item_ref);
     ok(visible_named_item_ref == 1, "visible_named_item_ref = %u\n", visible_named_item_ref);
+    ok(visible_code_named_item_ref == 1, "visible_code_named_item_ref = %u\n", visible_code_named_item_ref);
+    ok(persistent_named_item_ref == 0, "persistent_named_item_ref = %u\n", persistent_named_item_ref);
 
     SET_EXPECT(testCall);
     parse_script(parse, "visibleItem.testCall\n");
     CHECK_CALLED(testCall);
+
+    hres = IActiveScriptParse_ParseScriptText(parse, L"sub testSub\nend sub\n", L"noContext", NULL, NULL, 0, 0, 0, NULL, NULL);
+    ok(hres == E_INVALIDARG, "ParseScriptText returned: %08x\n", hres);
+    SET_EXPECT(OnEnterScript);
+    SET_EXPECT(GetIDsOfNames);
+    SET_EXPECT(OnLeaveScript);
+    hres = IActiveScriptParse_ParseScriptText(parse, L""
+        "dim global_me\nglobal_me = 0\n"
+        "dim globalCode_me\nglobalCode_me = 0\n"
+        "sub testSub_global\nend sub\n"
+        "dim testExplicitVar_global\ntestExplicitVar_global = 10\n"
+        "testVar_global = 10\n"
+        "class testClass_global\nend class\n",
+        NULL, NULL, NULL, 0, 0, SCRIPTTEXT_ISPERSISTENT, NULL, NULL);
+    ok(hres == S_OK, "ParseScriptText failed: %08x\n", hres);
+    CHECK_CALLED(OnEnterScript);
+    CHECK_CALLED(GetIDsOfNames);
+    CHECK_CALLED(OnLeaveScript);
+    SET_EXPECT(OnEnterScript);
+    SET_EXPECT(OnLeaveScript);
+    hres = IActiveScriptParse_ParseScriptText(parse, L""
+        "sub testSub\nend sub\n"
+        "dim testExplicitVar\ntestExplicitVar = 42\n"
+        "class testClass\nend class\n",
+        L"codeOnlyItem", NULL, NULL, 0, 0, 0, NULL, NULL);
+    ok(hres == S_OK, "ParseScriptText failed: %08x\n", hres);
+    CHECK_CALLED(OnEnterScript);
+    CHECK_CALLED(OnLeaveScript);
+    SET_EXPECT(OnEnterScript);
+    SET_EXPECT(GetIDsOfNames);
+    SET_EXPECT(OnLeaveScript);
+    hres = IActiveScriptParse_ParseScriptText(parse, L""
+        "testVar = 99\n"
+        "testVar_global = 5\n",
+        L"CodeOnlyITEM", NULL, NULL, 0, 0, SCRIPTTEXT_ISPERSISTENT, NULL, NULL);
+    ok(hres == S_OK, "ParseScriptText failed: %08x\n", hres);
+    CHECK_CALLED(OnEnterScript);
+    CHECK_CALLED(GetIDsOfNames);
+    CHECK_CALLED(OnLeaveScript);
+
+    SET_EXPECT(OnEnterScript);
+    SET_EXPECT(GetItemInfo_visible);
+    SET_EXPECT(GetIDsOfNames_visible);
+    SET_EXPECT(OnLeaveScript);
+    hres = IActiveScriptParse_ParseScriptText(parse, L"dim abc\n", L"visibleItem", NULL, NULL, 0, 0, 0, NULL, NULL);
+    ok(hres == S_OK, "ParseScriptText failed: %08x\n", hres);
+    CHECK_CALLED(OnEnterScript);
+    todo_wine CHECK_CALLED(GetItemInfo_visible);
+    todo_wine CHECK_CALLED(GetIDsOfNames_visible);
+    CHECK_CALLED(OnLeaveScript);
+    SET_EXPECT(OnEnterScript);
+    SET_EXPECT(OnLeaveScript);
+    hres = IActiveScriptParse_ParseScriptText(parse, L"abc = 5\n", L"visibleItem", NULL, NULL, 0, 0, 0, NULL, NULL);
+    ok(hres == S_OK, "ParseScriptText failed: %08x\n", hres);
+    CHECK_CALLED(OnEnterScript);
+    CHECK_CALLED(OnLeaveScript);
+    SET_EXPECT(OnEnterScript);
+    SET_EXPECT(GetIDsOfNames_visible);
+    SET_EXPECT(OnLeaveScript);
+    hres = IActiveScriptParse_ParseScriptText(parse, L"testVar_global = 5\n", L"visibleItem", NULL, NULL, 0, 0, 0, NULL, NULL);
+    ok(hres == S_OK, "ParseScriptText failed: %08x\n", hres);
+    CHECK_CALLED(OnEnterScript);
+    CHECK_CALLED(GetIDsOfNames_visible);
+    CHECK_CALLED(OnLeaveScript);
+
+    SET_EXPECT(OnEnterScript);
+    SET_EXPECT(OnLeaveScript);
+    hres = IActiveScriptParse_ParseScriptText(parse, L"dim abc\ntestVar_global = 5\n", L"visibleCodeItem", NULL, NULL, 0, 0, 0, NULL, NULL);
+    ok(hres == S_OK, "ParseScriptText failed: %08x\n", hres);
+    CHECK_CALLED(OnEnterScript);
+    CHECK_CALLED(OnLeaveScript);
+
+    SET_EXPECT(OnEnterScript);
+    SET_EXPECT(OnLeaveScript);
+    hres = IActiveScriptParse_ParseScriptText(parse, L"set global_me = me\n", L"globalItem", NULL, NULL, 0, 0, SCRIPTTEXT_ISPERSISTENT, NULL, NULL);
+    ok(hres == S_OK, "ParseScriptText failed: %08x\n", hres);
+    CHECK_CALLED(OnEnterScript);
+    CHECK_CALLED(OnLeaveScript);
+    SET_EXPECT(OnEnterScript);
+    SET_EXPECT(OnLeaveScript);
+    hres = IActiveScriptParse_ParseScriptText(parse, L"set globalCode_me = me\n", L"globalCodeItem", NULL, NULL, 0, 0, SCRIPTTEXT_ISPERSISTENT, NULL, NULL);
+    ok(hres == S_OK, "ParseScriptText failed: %08x\n", hres);
+    CHECK_CALLED(OnEnterScript);
+    CHECK_CALLED(OnLeaveScript);
+
+    for (i = 0; i < ARRAY_SIZE(global_idents); i++)
+    {
+        bstr = SysAllocString(global_idents[i]);
+        id = 0;
+        hres = IDispatchEx_GetDispID(script_disp, bstr, 0, &id);
+        ok(hres == S_OK, "GetDispID(%s) returned %08x\n", wine_dbgstr_w(global_idents[i]), hres);
+        ok(id != -1, "[%s] id = -1\n", wine_dbgstr_w(global_idents[i]));
+        id = 0;
+        hres = IDispatchEx_GetDispID(script_disp2, bstr, 0, &id);
+        ok(hres == DISP_E_UNKNOWNNAME, "GetDispID(%s) returned %08x\n", wine_dbgstr_w(global_idents[i]), hres);
+        ok(id == -1, "[%s] id = %d, expected -1\n", wine_dbgstr_w(global_idents[i]), id);
+        SysFreeString(bstr);
+    }
+    for (i = 0; i < ARRAY_SIZE(context_idents); i++)
+    {
+        bstr = SysAllocString(context_idents[i]);
+        id = 0;
+        hres = IDispatchEx_GetDispID(script_disp, bstr, 0, &id);
+        ok(hres == DISP_E_UNKNOWNNAME, "GetDispID(%s) returned %08x\n", wine_dbgstr_w(context_idents[i]), hres);
+        ok(id == -1, "[%s] id = %d, expected -1\n", wine_dbgstr_w(context_idents[i]), id);
+        id = 0;
+        hres = IDispatchEx_GetDispID(script_disp2, bstr, 0, &id);
+        ok(hres == S_OK, "GetDispID(%s) returned %08x\n", wine_dbgstr_w(context_idents[i]), hres);
+        ok(id != -1, "[%s] id = -1\n", wine_dbgstr_w(context_idents[i]));
+        SysFreeString(bstr);
+    }
+
+    for (i = 0; i < ARRAY_SIZE(global_code_test); i++)
+    {
+        SET_EXPECT(OnEnterScript);
+        SET_EXPECT(OnLeaveScript);
+        hres = IActiveScriptParse_ParseScriptText(parse, global_code_test[i], NULL, NULL, NULL, 0, 0, 0, NULL, NULL);
+        ok(hres == S_OK, "ParseScriptText(%s) failed: %08x\n", wine_dbgstr_w(global_code_test[i]), hres);
+        CHECK_CALLED(OnEnterScript);
+        CHECK_CALLED(OnLeaveScript);
+        SET_EXPECT(OnEnterScript);
+        SET_EXPECT(GetIDsOfNames);
+        SET_EXPECT(OnLeaveScript);
+        hres = IActiveScriptParse_ParseScriptText(parse, global_code_test[i], L"codeOnlyItem", NULL, NULL, 0, 0, 0, NULL, NULL);
+        ok(hres == S_OK, "ParseScriptText(%s) failed: %08x\n", wine_dbgstr_w(global_code_test[i]), hres);
+        CHECK_CALLED(OnEnterScript);
+        CHECK_CALLED(OnLeaveScript);
+    }
+    for (i = 0; i < ARRAY_SIZE(context_code_test); i++)
+    {
+        SET_EXPECT(OnEnterScript);
+        SET_EXPECT(GetIDsOfNames);
+        SET_EXPECT(OnScriptError);
+        SET_EXPECT(OnLeaveScript);
+        hres = IActiveScriptParse_ParseScriptText(parse, context_code_test[i], NULL, NULL, NULL, 0, 0, 0, NULL, NULL);
+        ok(FAILED(hres), "ParseScriptText(%s) returned: %08x\n", wine_dbgstr_w(context_code_test[i]), hres);
+        CHECK_CALLED(OnEnterScript);
+        CHECK_CALLED(OnScriptError);
+        CHECK_CALLED(OnLeaveScript);
+        SET_EXPECT(OnEnterScript);
+        SET_EXPECT(GetIDsOfNames);
+        SET_EXPECT(OnLeaveScript);
+        hres = IActiveScriptParse_ParseScriptText(parse, context_code_test[i], L"codeOnlyItem", NULL, NULL, 0, 0, 0, NULL, NULL);
+        ok(hres == S_OK, "ParseScriptText(%s) failed: %08x\n", wine_dbgstr_w(context_code_test[i]), hres);
+        CHECK_CALLED(OnEnterScript);
+        CHECK_CALLED(OnLeaveScript);
+    }
+    SET_EXPECT(OnScriptError);
+    SET_EXPECT(OnEnterScript);
+    SET_EXPECT(OnLeaveScript);
+    hres = IActiveScriptParse_ParseScriptText(parse, L"testSub_global = 10\n", L"codeOnlyItem", NULL, NULL, 0, 0, 0, NULL, NULL);
+    ok(FAILED(hres), "ParseScriptText returned: %08x\n", hres);
+    CHECK_CALLED(OnScriptError);
+    CHECK_CALLED(OnEnterScript);
+    CHECK_CALLED(OnLeaveScript);
+
+    SET_EXPECT(OnEnterScript);
+    SET_EXPECT(OnLeaveScript);
+    hres = IActiveScriptParse_ParseScriptText(parse, L"me", NULL, NULL, NULL, 0, 0, SCRIPTTEXT_ISEXPRESSION, &var, NULL);
+    ok(hres == S_OK, "ParseScriptText failed: %08x\n", hres);
+    ok(V_VT(&var) == VT_DISPATCH && V_DISPATCH(&var) == &global_named_item,
+        "Unexpected 'me': V_VT = %d, V_DISPATCH = %p\n", V_VT(&var), V_DISPATCH(&var));
+    VariantClear(&var);
+    CHECK_CALLED(OnEnterScript);
+    CHECK_CALLED(OnLeaveScript);
+    SET_EXPECT(OnEnterScript);
+    SET_EXPECT(OnLeaveScript);
+    hres = IActiveScriptParse_ParseScriptText(parse, L"me", L"globalItem", NULL, NULL, 0, 0, SCRIPTTEXT_ISEXPRESSION, &var, NULL);
+    ok(hres == S_OK, "ParseScriptText failed: %08x\n", hres);
+    ok(V_VT(&var) == VT_DISPATCH && V_DISPATCH(&var) == &global_named_item,
+        "Unexpected 'me': V_VT = %d, V_DISPATCH = %p\n", V_VT(&var), V_DISPATCH(&var));
+    VariantClear(&var);
+    CHECK_CALLED(OnEnterScript);
+    CHECK_CALLED(OnLeaveScript);
+    SET_EXPECT(OnEnterScript);
+    SET_EXPECT(OnLeaveScript);
+    hres = IActiveScriptParse_ParseScriptText(parse, L"me", L"codeOnlyItem", NULL, NULL, 0, 0, SCRIPTTEXT_ISEXPRESSION, &var, NULL);
+    ok(hres == S_OK, "ParseScriptText failed: %08x\n", hres);
+    ok(V_VT(&var) == VT_DISPATCH && V_DISPATCH(&var) == (IDispatch*)script_disp2,
+        "Unexpected 'me': V_VT = %d, V_DISPATCH = %p\n", V_VT(&var), V_DISPATCH(&var));
+    VariantClear(&var);
+    CHECK_CALLED(OnEnterScript);
+    CHECK_CALLED(OnLeaveScript);
+    SET_EXPECT(OnEnterScript);
+    SET_EXPECT(OnLeaveScript);
+    hres = IActiveScriptParse_ParseScriptText(parse, L"globalCode_me", NULL, NULL, NULL, 0, 0, SCRIPTTEXT_ISEXPRESSION, &var, NULL);
+    ok(hres == S_OK, "ParseScriptText failed: %08x\n", hres);
+    ok(V_VT(&var) == VT_DISPATCH && V_DISPATCH(&var) == &global_named_item,
+        "Unexpected 'me': V_VT = %d, V_DISPATCH = %p\n", V_VT(&var), V_DISPATCH(&var));
+    VariantClear(&var);
+    CHECK_CALLED(OnEnterScript);
+    CHECK_CALLED(OnLeaveScript);
+
+    IDispatchEx_Release(script_disp2);
+    IDispatchEx_Release(script_disp);
+
+    script_disp = get_script_dispatch(script, L"persistent");
+    SET_EXPECT(OnEnterScript);
+    SET_EXPECT(OnLeaveScript);
+    hres = IActiveScriptParse_ParseScriptText(parse, L"me", L"persistent", NULL, NULL, 0, 0, SCRIPTTEXT_ISEXPRESSION, &var, NULL);
+    ok(hres == S_OK, "ParseScriptText failed: %08x\n", hres);
+    ok(V_VT(&var) == VT_DISPATCH && V_DISPATCH(&var) == (IDispatch*)script_disp,
+        "Unexpected 'me': V_VT = %d, V_DISPATCH = %p\n", V_VT(&var), V_DISPATCH(&var));
+    VariantClear(&var);
+    CHECK_CALLED(OnEnterScript);
+    CHECK_CALLED(OnLeaveScript);
+    IDispatchEx_Release(script_disp);
+
+    SET_EXPECT(OnEnterScript);
+    SET_EXPECT(OnLeaveScript);
+    hres = IActiveScriptParse_ParseScriptText(parse, L"x = 13\n", L"persistent", NULL, NULL, 0, 0, SCRIPTTEXT_ISPERSISTENT, NULL, NULL);
+    ok(hres == S_OK, "ParseScriptText failed: %08x\n", hres);
+    CHECK_CALLED(OnEnterScript);
+    CHECK_CALLED(OnLeaveScript);
+    SET_EXPECT(OnEnterScript);
+    SET_EXPECT(OnLeaveScript);
+    hres = IActiveScriptParse_ParseScriptText(parse, L"x = 10\n", L"persistent", NULL, NULL, 0, 0, 0, NULL, NULL);
+    ok(hres == S_OK, "ParseScriptText failed: %08x\n", hres);
+    CHECK_CALLED(OnEnterScript);
+    CHECK_CALLED(OnLeaveScript);
+    SET_EXPECT(OnEnterScript);
+    SET_EXPECT(OnLeaveScript);
+    hres = IActiveScriptParse_ParseScriptText(parse, L"x", L"persistent", NULL, NULL, 0, 0, SCRIPTTEXT_ISEXPRESSION, &var, NULL);
+    ok(hres == S_OK, "ParseScriptText failed: %08x\n", hres);
+    ok(V_VT(&var) == VT_I2 && V_I2(&var) == 10, "Unexpected 'x': V_VT = %d, V_I2 = %d\n", V_VT(&var), V_I2(&var));
+    CHECK_CALLED(OnEnterScript);
+    CHECK_CALLED(OnLeaveScript);
+
+    script_disp = get_script_dispatch(script, L"persistent");
+
+    SET_EXPECT(OnStateChange_DISCONNECTED);
+    SET_EXPECT(OnStateChange_INITIALIZED);
+    SET_EXPECT(OnStateChange_UNINITIALIZED);
+    hres = IActiveScript_SetScriptState(script, SCRIPTSTATE_UNINITIALIZED);
+    ok(hres == S_OK, "SetScriptState(SCRIPTSTATE_UNINITIALIZED) failed: %08x\n", hres);
+    CHECK_CALLED(OnStateChange_DISCONNECTED);
+    CHECK_CALLED(OnStateChange_INITIALIZED);
+    CHECK_CALLED(OnStateChange_UNINITIALIZED);
+    test_no_script_dispatch(script);
+
+    ok(global_named_item_ref == 0, "global_named_item_ref = %u\n", global_named_item_ref);
+    ok(visible_named_item_ref == 0, "visible_named_item_ref = %u\n", visible_named_item_ref);
+    ok(visible_code_named_item_ref == 0, "visible_code_named_item_ref = %u\n", visible_code_named_item_ref);
+    ok(persistent_named_item_ref == 0, "persistent_named_item_ref = %u\n", persistent_named_item_ref);
+
+    hres = IActiveScript_GetScriptDispatch(script, L"codeOnlyItem", &disp);
+    ok(hres == E_UNEXPECTED, "hres = %08x, expected E_UNEXPECTED\n", hres);
+
+    SET_EXPECT(GetLCID);
+    SET_EXPECT(OnStateChange_INITIALIZED);
+    SET_EXPECT(GetItemInfo_persistent);
+    hres = IActiveScript_SetScriptSite(script, &ActiveScriptSite);
+    ok(hres == S_OK, "SetScriptSite failed: %08x\n", hres);
+    CHECK_CALLED(GetLCID);
+    CHECK_CALLED(OnStateChange_INITIALIZED);
+    CHECK_CALLED(GetItemInfo_persistent);
+    ok(persistent_named_item_ref > 0, "persistent_named_item_ref = %u\n", persistent_named_item_ref);
+
+    hres = IActiveScript_AddNamedItem(script, L"codeOnlyItem", SCRIPTITEM_CODEONLY);
+    ok(hres == S_OK, "AddNamedItem failed: %08x\n", hres);
+
+    SET_EXPECT(OnStateChange_CONNECTED);
+    SET_EXPECT_MULTI(OnEnterScript, 5);
+    SET_EXPECT_MULTI(OnLeaveScript, 5);
+    SET_EXPECT(GetIDsOfNames_persistent);
+    hres = IActiveScript_SetScriptState(script, SCRIPTSTATE_CONNECTED);
+    ok(hres == S_OK, "SetScriptState(SCRIPTSTATE_CONNECTED) failed: %08x\n", hres);
+    CHECK_CALLED(OnStateChange_CONNECTED);
+    CHECK_CALLED_MULTI(OnEnterScript, 5);
+    CHECK_CALLED_MULTI(OnLeaveScript, 5);
+    CHECK_CALLED(GetIDsOfNames_persistent);
+    test_state(script, SCRIPTSTATE_CONNECTED);
+
+    script_disp2 = get_script_dispatch(script, L"persistent");
+    ok(script_disp != script_disp2, "Same script dispatch returned for \"persistent\" named item\n");
+    IDispatchEx_Release(script_disp2);
+    IDispatchEx_Release(script_disp);
+    SET_EXPECT(OnEnterScript);
+    SET_EXPECT(OnLeaveScript);
+    hres = IActiveScriptParse_ParseScriptText(parse, L"x", L"persistent", NULL, NULL, 0, 0, SCRIPTTEXT_ISEXPRESSION, &var, NULL);
+    ok(hres == S_OK, "ParseScriptText failed: %08x\n", hres);
+    ok(V_VT(&var) == VT_I2 && V_I2(&var) == 13, "Unexpected 'x': V_VT = %d, V_I2 = %d\n", V_VT(&var), V_I2(&var));
+    CHECK_CALLED(OnEnterScript);
+    CHECK_CALLED(OnLeaveScript);
+
+    /* This object is set to named item when persistent items are re-initialized, even for CODEONLY items */
+    SET_EXPECT(OnEnterScript);
+    SET_EXPECT(OnLeaveScript);
+    hres = IActiveScriptParse_ParseScriptText(parse, L"me", L"persistent", NULL, NULL, 0, 0, SCRIPTTEXT_ISEXPRESSION, &var, NULL);
+    ok(hres == S_OK, "ParseScriptText failed: %08x\n", hres);
+    ok(V_VT(&var) == VT_DISPATCH && V_DISPATCH(&var) == &persistent_named_item,
+        "Unexpected 'me': V_VT = %d, V_DISPATCH = %p\n", V_VT(&var), V_DISPATCH(&var));
+    VariantClear(&var);
+    CHECK_CALLED(OnEnterScript);
+    CHECK_CALLED(OnLeaveScript);
+
+    /* Lookups also query named items */
+    SET_EXPECT(OnEnterScript);
+    SET_EXPECT(OnLeaveScript);
+    SET_EXPECT(GetIDsOfNames_persistent);
+    hres = IActiveScriptParse_ParseScriptText(parse, L"abc123 = 10\n", L"persistent", NULL, NULL, 0, 0, 0, NULL, NULL);
+    ok(hres == S_OK, "ParseScriptText failed: %08x\n", hres);
+    CHECK_CALLED(OnEnterScript);
+    CHECK_CALLED(OnLeaveScript);
+    CHECK_CALLED(GetIDsOfNames_persistent);
+
+    SET_EXPECT(OnEnterScript);
+    SET_EXPECT(OnLeaveScript);
+    SET_EXPECT(GetIDsOfNames_persistent);
+    SET_EXPECT(OnScriptError);
+    hres = IActiveScriptParse_ParseScriptText(parse, L"testCall\n", L"persistent", NULL, NULL, 0, 0, 0, NULL, NULL);
+    ok(FAILED(hres), "ParseScriptText returned: %08x\n", hres);
+    CHECK_CALLED(OnEnterScript);
+    CHECK_CALLED(OnLeaveScript);
+    CHECK_CALLED(GetIDsOfNames_persistent);
+    CHECK_CALLED(OnScriptError);
+
+    script_disp = get_script_dispatch(script, NULL);
+    for (i = 0; i < ARRAY_SIZE(global_idents); i++)
+    {
+        bstr = SysAllocString(global_idents[i]);
+        id = 0;
+        hres = IDispatchEx_GetDispID(script_disp, bstr, 0, &id);
+        ok(hres == S_OK, "GetDispID(%s) returned %08x\n", wine_dbgstr_w(global_idents[i]), hres);
+        ok(id != -1, "[%s] id = -1\n", wine_dbgstr_w(global_idents[i]));
+        SysFreeString(bstr);
+    }
+    for (i = 0; i < ARRAY_SIZE(context_idents); i++)
+    {
+        bstr = SysAllocString(context_idents[i]);
+        id = 0;
+        hres = IDispatchEx_GetDispID(script_disp, bstr, 0, &id);
+        ok(hres == DISP_E_UNKNOWNNAME, "GetDispID(%s) returned %08x\n", wine_dbgstr_w(context_idents[i]), hres);
+        ok(id == -1, "[%s] id = %d, expected -1\n", wine_dbgstr_w(context_idents[i]), id);
+        SysFreeString(bstr);
+    }
+    SET_EXPECT(OnEnterScript);
+    SET_EXPECT(OnLeaveScript);
+    hres = IActiveScriptParse_ParseScriptText(parse, L"global_me", NULL, NULL, NULL, 0, 0, SCRIPTTEXT_ISEXPRESSION, &var, NULL);
+    ok(hres == S_OK, "ParseScriptText failed: %08x\n", hres);
+    ok(V_VT(&var) == VT_DISPATCH && V_DISPATCH(&var) == (IDispatch*)script_disp,
+        "Unexpected 'me': V_VT = %d, V_DISPATCH = %p\n", V_VT(&var), V_DISPATCH(&var));
+    VariantClear(&var);
+    CHECK_CALLED(OnEnterScript);
+    CHECK_CALLED(OnLeaveScript);
+    SET_EXPECT(OnEnterScript);
+    SET_EXPECT(OnLeaveScript);
+    hres = IActiveScriptParse_ParseScriptText(parse, L"globalCode_me", NULL, NULL, NULL, 0, 0, SCRIPTTEXT_ISEXPRESSION, &var, NULL);
+    ok(hres == S_OK, "ParseScriptText failed: %08x\n", hres);
+    ok(V_VT(&var) == VT_DISPATCH && V_DISPATCH(&var) == (IDispatch*)script_disp,
+        "Unexpected 'me': V_VT = %d, V_DISPATCH = %p\n", V_VT(&var), V_DISPATCH(&var));
+    VariantClear(&var);
+    CHECK_CALLED(OnEnterScript);
+    CHECK_CALLED(OnLeaveScript);
+    SET_EXPECT(OnEnterScript);
+    SET_EXPECT(OnLeaveScript);
+    hres = IActiveScriptParse_ParseScriptText(parse, L"global_me = 0\nglobalCode_me = 0\n", NULL, NULL, NULL, 0, 0, 0, NULL, NULL);
+    ok(hres == S_OK, "ParseScriptText failed: %08x\n", hres);
+    CHECK_CALLED(OnEnterScript);
+    CHECK_CALLED(OnLeaveScript);
+    IDispatchEx_Release(script_disp);
+
+    script_disp = get_script_dispatch(script, L"codeOnlyItem");
+    for (i = 0; i < ARRAY_SIZE(global_idents); i++)
+    {
+        bstr = SysAllocString(global_idents[i]);
+        id = 0;
+        hres = IDispatchEx_GetDispID(script_disp, bstr, 0, &id);
+        ok(hres == DISP_E_UNKNOWNNAME, "GetDispID(%s) returned %08x\n", wine_dbgstr_w(global_idents[i]), hres);
+        ok(id == -1, "[%s] id = %d, expected -1\n", wine_dbgstr_w(global_idents[i]), id);
+        SysFreeString(bstr);
+    }
+    for (i = 0; i < ARRAY_SIZE(context_idents); i++)
+    {
+        bstr = SysAllocString(context_idents[i]);
+        id = 0;
+        hres = IDispatchEx_GetDispID(script_disp, bstr, 0, &id);
+        ok(hres == DISP_E_UNKNOWNNAME, "GetDispID(%s) returned %08x\n", wine_dbgstr_w(context_idents[i]), hres);
+        ok(id == -1, "[%s] id = %d, expected -1\n", wine_dbgstr_w(context_idents[i]), id);
+        SysFreeString(bstr);
+    }
+    IDispatchEx_Release(script_disp);
+
+    for (i = 0; i < ARRAY_SIZE(global_code_test); i++)
+    {
+        SET_EXPECT(OnEnterScript);
+        SET_EXPECT(OnLeaveScript);
+        hres = IActiveScriptParse_ParseScriptText(parse, global_code_test[i], NULL, NULL, NULL, 0, 0, 0, NULL, NULL);
+        ok(hres == S_OK, "ParseScriptText(%s) failed: %08x\n", wine_dbgstr_w(global_code_test[i]), hres);
+        CHECK_CALLED(OnEnterScript);
+        CHECK_CALLED(OnLeaveScript);
+        SET_EXPECT(OnEnterScript);
+        SET_EXPECT(OnLeaveScript);
+        hres = IActiveScriptParse_ParseScriptText(parse, global_code_test[i], L"codeOnlyItem", NULL, NULL, 0, 0, 0, NULL, NULL);
+        ok(hres == S_OK, "ParseScriptText(%s) failed: %08x\n", wine_dbgstr_w(global_code_test[i]), hres);
+        CHECK_CALLED(OnEnterScript);
+        CHECK_CALLED(OnLeaveScript);
+    }
+    for (i = 0; i < ARRAY_SIZE(context_code_test); i++)
+    {
+        SET_EXPECT(OnScriptError);
+        SET_EXPECT(OnEnterScript);
+        SET_EXPECT(OnLeaveScript);
+        hres = IActiveScriptParse_ParseScriptText(parse, context_code_test[i], NULL, NULL, NULL, 0, 0, 0, NULL, NULL);
+        ok(FAILED(hres), "ParseScriptText(%s) returned: %08x\n", wine_dbgstr_w(context_code_test[i]), hres);
+        CHECK_CALLED(OnScriptError);
+        CHECK_CALLED(OnEnterScript);
+        CHECK_CALLED(OnLeaveScript);
+        SET_EXPECT(OnScriptError);
+        SET_EXPECT(OnEnterScript);
+        SET_EXPECT(OnLeaveScript);
+        hres = IActiveScriptParse_ParseScriptText(parse, context_code_test[i], L"codeOnlyItem", NULL, NULL, 0, 0, 0, NULL, NULL);
+        ok(FAILED(hres), "ParseScriptText(%s) returned: %08x\n", wine_dbgstr_w(context_code_test[i]), hres);
+        CHECK_CALLED(OnScriptError);
+        CHECK_CALLED(OnEnterScript);
+        CHECK_CALLED(OnLeaveScript);
+    }
 
     SET_EXPECT(OnStateChange_DISCONNECTED);
     SET_EXPECT(OnStateChange_INITIALIZED);
@@ -982,6 +2412,8 @@ static void test_named_items(void)
 
     ok(global_named_item_ref == 0, "global_named_item_ref = %u\n", global_named_item_ref);
     ok(visible_named_item_ref == 0, "visible_named_item_ref = %u\n", visible_named_item_ref);
+    ok(visible_code_named_item_ref == 0, "visible_code_named_item_ref = %u\n", visible_code_named_item_ref);
+    ok(persistent_named_item_ref == 0, "persistent_named_item_ref = %u\n", persistent_named_item_ref);
 
     test_state(script, SCRIPTSTATE_CLOSED);
 
@@ -1131,6 +2563,64 @@ static void test_RegExp(void)
     IRegExp2_Release(regexp);
 }
 
+static void test_RegExp_Replace(void)
+{
+    static const struct
+    {
+        const char *pattern;
+        const char *replace;
+        const char *source;
+        const char *result;
+        BOOL global;
+    } test[] =
+    {
+        { "abc", "", "123abc456", "123456", FALSE },
+        { "abc", "dcba", "123abc456", "123dcba456", FALSE },
+        { "[\r\n\t\f]+", " ", "\nHello\rNew\fWorld\t!", " Hello\rNew\fWorld\t!", FALSE },
+        { "[\r\n\t\f]+", " ", "\nHello\rNew\fWorld\t!", " Hello New World !", TRUE },
+    };
+    HRESULT hr;
+    IRegExp2 *regexp;
+    VARIANT var;
+    BSTR str, ret, result;
+    int i;
+
+    hr = CoCreateInstance(&CLSID_VBScriptRegExp, NULL,
+                          CLSCTX_INPROC_SERVER | CLSCTX_INPROC_HANDLER,
+                          &IID_IRegExp2, (void **)&regexp);
+    if (hr == REGDB_E_CLASSNOTREG)
+    {
+        win_skip("VBScriptRegExp is not registered\n");
+        return;
+    }
+    ok(hr == S_OK, "got %#x\n", hr);
+
+    for (i = 0; i < ARRAY_SIZE(test); i++)
+    {
+        hr = IRegExp2_put_Global(regexp, test[i].global ? VARIANT_TRUE : VARIANT_FALSE);
+        ok(hr == S_OK, "got %#x\n", hr);
+
+        str = a2bstr(test[i].pattern);
+        hr = IRegExp2_put_Pattern(regexp, str);
+        ok(hr == S_OK, "got %#x\n", hr);
+        SysFreeString(str);
+
+        str = a2bstr(test[i].source);
+        V_VT(&var) = VT_BSTR;
+        V_BSTR(&var) = a2bstr(test[i].replace);
+        hr = IRegExp2_Replace(regexp, str, var, &ret);
+        ok(hr == S_OK, "got %#x\n", hr);
+        result = a2bstr(test[i].result);
+        ok(!wcscmp(ret, result), "got %s, expected %s\n", wine_dbgstr_w(ret), wine_dbgstr_w(result));
+        SysFreeString(result);
+        SysFreeString(ret);
+        SysFreeString(V_BSTR(&var));
+        SysFreeString(str);
+    }
+
+    IRegExp2_Release(regexp);
+}
+
 static BOOL check_vbscript(void)
 {
     IActiveScriptParseProcedure2 *vbscript;
@@ -1156,7 +2646,10 @@ START_TEST(vbscript)
         test_vbscript_initializing();
         test_named_items();
         test_scriptdisp();
+        test_code_persistence();
+        test_script_typeinfo();
         test_RegExp();
+        test_RegExp_Replace();
     }else {
         win_skip("VBScript engine not available or too old\n");
     }

--- a/sdk/tools/winesync/vbscript.cfg
+++ b/sdk/tools/winesync/vbscript.cfg
@@ -1,0 +1,5 @@
+directories:
+  dlls/vbscript: dll/win32/vbscript
+files: null
+tags:
+  wine: 18e7e07a77a754c4b48c6c9bde225ad5c7295944

--- a/sdk/tools/winesync/vbscript_tests.cfg
+++ b/sdk/tools/winesync/vbscript_tests.cfg
@@ -1,0 +1,5 @@
+directories:
+  dlls/vbscript/tests: modules/rostests/winetests/vbscript
+files: null
+tags:
+  wine: 18e7e07a77a754c4b48c6c9bde225ad5c7295944


### PR DESCRIPTION
## Purpose

Sync VBScript and its winetests to Wine commit 18e7e07 
Add vbscript and vbscript_tests winesync.py configs for future use

JIRA issue: [CORE-XXXX](https://jira.reactos.org/browse/CORE-XXXX)

## TODO

- [x]  Check if tests run / Check for regressions on ROS
  - vbscript_winetest createobj no change (556 tests 0 failures)
  - vbscript_winetest run 35363 tests 23 failures -> 37911 tests 15 failures
  - vbscript_winetest vbscript 468 tests 0 failures -> 1583 tests 2 failures
- [ ] Sync to 9.7 (requires FindStringOrdinal from wine's kernelbase/locale.c) (In a different PR)
