### PR TITLE
[WINESYNC] Sync cabinet and its winetests to Wine-9.7

### DIFF
--- a/dll/win32/cabinet/cabinet.h
+++ b/dll/win32/cabinet/cabinet.h
@@ -29,27 +29,6 @@
 #include "fdi.h"
 #include "fci.h"
 
-/* from msvcrt/sys/stat.h */
-#define _S_IWRITE 0x0080
-#define _S_IREAD  0x0100
-
-/* from msvcrt/fcntl.h */
-#define _O_RDONLY      0
-#define _O_WRONLY      1
-#define _O_RDWR        2
-#define _O_ACCMODE     (_O_RDONLY|_O_WRONLY|_O_RDWR)
-#define _O_APPEND      0x0008
-#define _O_RANDOM      0x0010
-#define _O_SEQUENTIAL  0x0020
-#define _O_TEMPORARY   0x0040
-#define _O_NOINHERIT   0x0080
-#define _O_CREAT       0x0100
-#define _O_TRUNC       0x0200
-#define _O_EXCL        0x0400
-#define _O_SHORT_LIVED 0x1000
-#define _O_TEXT        0x4000
-#define _O_BINARY      0x8000
-
 #define CAB_SPLITMAX (10)
 
 #define CAB_SEARCH_SIZE (32*1024)

--- a/dll/win32/cabinet/cabinet_main.c
+++ b/dll/win32/cabinet/cabinet_main.c
@@ -18,11 +18,10 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-#include "config.h"
-
 #include <assert.h>
 #include <stdarg.h>
 #include <string.h>
+#include <fcntl.h>
 
 #include "windef.h"
 #include "winbase.h"

--- a/dll/win32/cabinet/fci.c
+++ b/dll/win32/cabinet/fci.c
@@ -32,15 +32,14 @@ There is still some work to be done:
 
 
 
-#include "config.h"
 
 #include <assert.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
-#ifdef HAVE_ZLIB
-# include <zlib.h>
-#endif
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <zlib.h>
 
 #include "windef.h"
 #include "winbase.h"
@@ -909,8 +908,6 @@ static cab_UWORD compress_NONE( FCI_Int *fci )
     return fci->cdata_in;
 }
 
-#ifdef HAVE_ZLIB
-
 static void *zalloc( void *opaque, unsigned int items, unsigned int size )
 {
     FCI_Int *fci = opaque;
@@ -946,8 +943,6 @@ static cab_UWORD compress_MSZIP( FCI_Int *fci )
     deflateEnd( &stream );
     return stream.total_out + 2;
 }
-
-#endif  /* HAVE_ZLIB */
 
 
 /***********************************************************************
@@ -1421,11 +1416,9 @@ BOOL __cdecl FCIAddFile(
       switch (typeCompress)
       {
       case tcompTYPE_MSZIP:
-#ifdef HAVE_ZLIB
           p_fci_internal->compression = tcompTYPE_MSZIP;
           p_fci_internal->compress    = compress_MSZIP;
           break;
-#endif
       default:
           FIXME( "compression %x not supported, defaulting to none\n", typeCompress );
           /* fall through */

--- a/dll/win32/cabinet/fdi.c
+++ b/dll/win32/cabinet/fdi.c
@@ -58,10 +58,10 @@
  *   -gmt
  */
 
-#include "config.h"
-
 #include <stdarg.h>
 #include <stdio.h>
+#include <sys/stat.h>
+#include <fcntl.h>
 
 #include "windef.h"
 #include "winbase.h"
@@ -482,7 +482,7 @@ static char *FDI_read_string(FDI_Int *fdi, INT_PTR hf, long cabsize)
   unsigned int i;
   cab_UBYTE *buf = NULL;
 
-  TRACE("(fdi == %p, hf == %ld, cabsize == %ld)\n", fdi, hf, cabsize);
+  TRACE("(fdi == %p, hf == %Id, cabsize == %ld)\n", fdi, hf, cabsize);
 
   do {
     if (len > maxlen) len = maxlen;
@@ -541,7 +541,7 @@ static BOOL FDI_read_entries(
   cab_UBYTE buf[64], block_resv;
   char *prevname = NULL, *previnfo = NULL, *nextname = NULL, *nextinfo = NULL;
 
-  TRACE("(fdi == ^%p, hf == %ld, pfdici == ^%p)\n", fdi, hf, pfdici);
+  TRACE("(fdi == ^%p, hf == %Id, pfdici == ^%p)\n", fdi, hf, pfdici);
 
   /* read in the CFHEADER */
   if (fdi->read(hf, buf, cfhead_SIZEOF) != cfhead_SIZEOF) {
@@ -698,7 +698,7 @@ BOOL __cdecl FDIIsCabinet(HFDI hfdi, INT_PTR hf, PFDICABINETINFO pfdici)
   BOOL rv;
   FDI_Int *fdi = get_fdi_ptr( hfdi );
 
-  TRACE("(hfdi == ^%p, hf == ^%ld, pfdici == ^%p)\n", hfdi, hf, pfdici);
+  TRACE("(hfdi == ^%p, hf == ^%Id, pfdici == ^%p)\n", hfdi, hf, pfdici);
 
   if (!fdi) return FALSE;
 
@@ -2050,24 +2050,13 @@ static int fdi_decomp(const struct fdi_file *fi, int savemode, fdi_decomp_state 
             fullpath[0] = '\0';
             if (pathlen) {
               strcpy(fullpath, userpath);
-#ifdef __REACTOS__
-              if (fullpath[pathlen - 1] == '\\')
-                fullpath[pathlen - 1] = '\0';
-#else
               if (fullpath[pathlen - 1] != '\\')
                 strcat(fullpath, "\\");
-#endif
             }
-#ifdef __REACTOS__
-            if (filenamelen) {
-              strcat(fullpath, "\\");
-#else
             if (filenamelen)
-#endif
               strcat(fullpath, cab->mii.nextname);
-#ifdef __REACTOS__
-            }
-#endif
+            else if (fullpath[0])
+                fullpath[strlen(fullpath)-1] = 0; /* remove trailing backslash */
 
             TRACE("full cab path/file name: %s\n", debugstr_a(fullpath));
 

--- a/media/doc/WINESYNC.txt
+++ b/media/doc/WINESYNC.txt
@@ -53,7 +53,7 @@ dll/win32/atl100              # Synced to WineStaging-3.3
 dll/win32/avifil32            # Synced to WineStaging-4.18
 dll/win32/bcrypt              # Synced to WineStaging-1.9.23 (+ winetest synced to 8d8936cbb6fea3cac862e059e814527f5361f48b, a.k.a 20161206-BJ)
 dll/win32/browseui            # Out of sync
-dll/win32/cabinet             # Synced to WineStaging-4.18
+dll/win32/cabinet             # Synced to Wine-9.7
 dll/win32/clusapi             # Synced to WineStaging-3.3
 dll/win32/comcat              # Synced to WineStaging-3.3
 dll/win32/comctl32            # Synced to WineStaging-3.3

--- a/modules/rostests/winetests/cabinet/CMakeLists.txt
+++ b/modules/rostests/winetests/cabinet/CMakeLists.txt
@@ -1,5 +1,6 @@
 
 add_definitions(-DUSE_WINE_TODOS)
+remove_definitions(-D__ROS_LONG64__)
 add_executable(cabinet_winetest extract.c fdi.c testlist.c)
 set_module_type(cabinet_winetest win32cui)
 add_importlibs(cabinet_winetest cabinet msvcrt kernel32)

--- a/modules/rostests/winetests/cabinet/extract.c
+++ b/modules/rostests/winetests/cabinet/extract.c
@@ -379,7 +379,7 @@ static void test_Extract(void)
     session.Operation = EXTRACT_FILLFILELIST | EXTRACT_EXTRACTFILES;
     res = pExtract(&session, "extract.cab");
     node = session.FileList;
-    ok(res == S_OK, "Expected S_OK, got %d\n", res);
+    ok(res == S_OK, "Expected S_OK, got %ld\n", res);
     ok(session.FileSize == 40, "Expected 40, got %d\n", session.FileSize);
     ok(session.Error.erfOper == FDIERROR_NONE,
        "Expected FDIERROR_NONE, got %d\n", session.Error.erfOper);
@@ -410,7 +410,7 @@ static void test_Extract(void)
     session.Operation = EXTRACT_FILLFILELIST;
     res = pExtract(&session, "extract.cab");
     node = session.FileList;
-    ok(res == S_OK, "Expected S_OK, got %d\n", res);
+    ok(res == S_OK, "Expected S_OK, got %ld\n", res);
     ok(session.FileSize == 40, "Expected 40, got %d\n", session.FileSize);
     ok(session.Error.erfOper == FDIERROR_NONE,
        "Expected FDIERROR_NONE, got %d\n", session.Error.erfOper);
@@ -435,7 +435,7 @@ static void test_Extract(void)
     session.Operation = EXTRACT_EXTRACTFILES;
     res = pExtract(&session, "extract.cab");
     node = session.FileList;
-    ok(res == S_OK, "Expected S_OK, got %d\n", res);
+    ok(res == S_OK, "Expected S_OK, got %ld\n", res);
     ok(session.FileSize == 40, "Expected 40, got %d\n", session.FileSize);
     ok(session.Error.erfOper == FDIERROR_NONE,
        "Expected FDIERROR_NONE, got %d\n", session.Error.erfOper);
@@ -463,7 +463,7 @@ static void test_Extract(void)
     /* Extract does not extract files if the dest dir does not exist */
     res = pExtract(&session, "extract.cab");
     node = session.FileList;
-    ok(res == S_OK, "Expected S_OK, got %d\n", res);
+    ok(res == S_OK, "Expected S_OK, got %ld\n", res);
     ok(session.FileSize == 40, "Expected 40, got %d\n", session.FileSize);
     ok(session.Error.erfOper == FDIERROR_NONE,
        "Expected FDIERROR_NONE, got %d\n", session.Error.erfOper);
@@ -496,7 +496,7 @@ static void test_Extract(void)
     CreateDirectoryA("dest", NULL);
     res = pExtract(&session, "extract.cab");
     node = session.FileList;
-    ok(res == S_OK, "Expected S_OK, got %d\n", res);
+    ok(res == S_OK, "Expected S_OK, got %ld\n", res);
     ok(session.FileSize == 40, "Expected 40, got %d\n", session.FileSize);
     ok(session.Error.erfOper == FDIERROR_NONE,
        "Expected FDIERROR_NONE, got %d\n", session.Error.erfOper);
@@ -524,7 +524,7 @@ static void test_Extract(void)
     session.FileList = NULL;
     res = pExtract(&session, "extract.cab");
     node = session.FileList;
-    ok(res == S_OK, "Expected S_OK, got %d\n", res);
+    ok(res == S_OK, "Expected S_OK, got %ld\n", res);
     ok(session.FileSize == 40, "Expected 40, got %d\n", session.FileSize);
     ok(session.Error.erfOper == FDIERROR_NONE,
        "Expected FDIERROR_NONE, got %d\n", session.Error.erfOper);
@@ -550,7 +550,7 @@ static void test_Extract(void)
     session.Operation = 0;
     res = pExtract(&session, "extract.cab");
     node = session.FileList;
-    ok(res == S_OK, "Expected S_OK, got %d\n", res);
+    ok(res == S_OK, "Expected S_OK, got %ld\n", res);
     ok(session.FileSize == 40, "Expected 40, got %d\n", session.FileSize);
     ok(session.Error.erfOper == FDIERROR_NONE,
        "Expected FDIERROR_NONE, got %d\n", session.Error.erfOper);
@@ -576,7 +576,7 @@ static void test_Extract(void)
     session.FilterList = session.FileList;
     res = pExtract(&session, "extract.cab");
     node = session.FileList;
-    ok(res == S_OK, "Expected S_OK, got %d\n", res);
+    ok(res == S_OK, "Expected S_OK, got %ld\n", res);
     ok(session.FileSize == 40, "Expected 40, got %d\n", session.FileSize);
     ok(session.Error.erfOper == FDIERROR_NONE,
        "Expected FDIERROR_NONE, got %d\n", session.Error.erfOper);
@@ -610,7 +610,7 @@ static void test_Extract(void)
     res = pExtract(&session, "nonexistent.cab");
     node = session.FileList;
     ok(res == HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND),
-       "Expected HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND), got %08x\n", res);
+       "Expected HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND), got %08lx\n", res);
     ok(session.Error.erfOper == FDIERROR_CABINET_NOT_FOUND,
        "Expected FDIERROR_CABINET_NOT_FOUND, got %d\n", session.Error.erfOper);
     ok(session.FileSize == 0, "Expected 0, got %d\n", session.FileSize);
@@ -643,7 +643,7 @@ static void test_Extract(void)
     res = pExtract(&session, "extract.cab");
     node = session.FileList;
     ok(res == HRESULT_FROM_WIN32(ERROR_ACCESS_DENIED) || res == E_FAIL,
-       "Expected HRESULT_FROM_WIN32(ERROR_ACCESS_DENIED) or E_FAIL, got %08x\n", res);
+       "Expected HRESULT_FROM_WIN32(ERROR_ACCESS_DENIED) or E_FAIL, got %08lx\n", res);
     ok(session.FileSize == 6, "Expected 6, got %d\n", session.FileSize);
     ok(session.Error.erfOper == FDIERROR_USER_ABORT,
        "Expected FDIERROR_USER_ABORT, got %d\n", session.Error.erfOper);
@@ -681,7 +681,7 @@ static void test_Extract(void)
     res = pExtract(&session, "extract.cab");
     node = session.FileList;
     ok(res == HRESULT_FROM_WIN32(ERROR_ACCESS_DENIED) || res == E_FAIL,
-       "Expected HRESULT_FROM_WIN32(ERROR_ACCESS_DENIED) or E_FAIL, got %08x\n", res);
+       "Expected HRESULT_FROM_WIN32(ERROR_ACCESS_DENIED) or E_FAIL, got %08lx\n", res);
     ok(session.FileSize == 26, "Expected 26, got %d\n", session.FileSize);
     ok(session.Error.erfOper == FDIERROR_USER_ABORT,
        "Expected FDIERROR_USER_ABORT, got %d\n", session.Error.erfOper);

--- a/modules/rostests/winetests/cabinet/fdi.c
+++ b/modules/rostests/winetests/cabinet/fdi.c
@@ -190,7 +190,7 @@ static INT_PTR CDECL fdi_open_static(char *pszFile, int oflag, int pmode)
 
 static UINT CDECL fdi_read_static(INT_PTR hf, void *pv, UINT cb)
 {
-    ok(hf == 0, "unexpected hf %lx\n", hf);
+    ok(hf == 0, "unexpected hf %Ix\n", hf);
     return fdi_read(static_fdi_handle, pv, cb);
 }
 
@@ -208,7 +208,7 @@ static int CDECL fdi_close_static(INT_PTR hf)
 
 static LONG CDECL fdi_seek_static(INT_PTR hf, LONG dist, int seektype)
 {
-    ok(hf == 0, "unexpected hf %lx\n", hf);
+    ok(hf == 0, "unexpected hf %Ix\n", hf);
     return fdi_seek(static_fdi_handle, dist, seektype);
 }
 
@@ -233,7 +233,7 @@ static void test_FDICreate(void)
                          cpuUNKNOWN, &erf);
         ok(hfdi != NULL, "Expected non-NULL context\n");
         ok(GetLastError() == 0xdeadbeef,
-           "Expected 0xdeadbeef, got %d\n", GetLastError());
+           "Expected 0xdeadbeef, got %ld\n", GetLastError());
         ok(erf.erfOper == 0x1abe11ed, "Expected 0x1abe11ed, got %d\n", erf.erfOper);
         ok(erf.erfType == 0x5eed1e55, "Expected 0x5eed1e55, got %d\n", erf.erfType);
         ok(erf.fError == 0x1ead1e55, "Expected 0x1ead1e55, got %d\n", erf.fError);
@@ -250,7 +250,7 @@ static void test_FDICreate(void)
                      cpuUNKNOWN, &erf);
     ok(hfdi != NULL, "Expected non-NULL context\n");
     ok(GetLastError() == 0xdeadbeef,
-       "Expected 0xdeadbeef, got %d\n", GetLastError());
+       "Expected 0xdeadbeef, got %ld\n", GetLastError());
     ok((erf.erfOper == 0x1abe11ed || erf.erfOper == 0 /* Vista */), "Expected 0x1abe11ed or 0, got %d\n", erf.erfOper);
     ok((erf.erfType == 0x5eed1e55 || erf.erfType == 0 /* Vista */), "Expected 0x5eed1e55 or 0, got %d\n", erf.erfType);
     ok((erf.fError == 0x1ead1e55 || erf.fError == 0 /* Vista */), "Expected 0x1ead1e55 or 0, got %d\n", erf.fError);
@@ -266,7 +266,7 @@ static void test_FDICreate(void)
                      cpuUNKNOWN, &erf);
     ok(hfdi != NULL, "Expected non-NULL context\n");
     ok(GetLastError() == 0xdeadbeef,
-       "Expected 0xdeadbeef, got %d\n", GetLastError());
+       "Expected 0xdeadbeef, got %ld\n", GetLastError());
     ok((erf.erfOper == 0x1abe11ed || erf.erfOper == 0 /* Vista */), "Expected 0x1abe11ed or 0, got %d\n", erf.erfOper);
     ok((erf.erfType == 0x5eed1e55 || erf.erfType == 0 /* Vista */), "Expected 0x5eed1e55 or 0, got %d\n", erf.erfType);
     ok((erf.fError == 0x1ead1e55 || erf.fError == 0 /* Vista */), "Expected 0x1ead1e55 or 0, got %d\n", erf.fError);
@@ -282,7 +282,7 @@ static void test_FDICreate(void)
                      cpuUNKNOWN, &erf);
     ok(hfdi != NULL, "Expected non-NULL context\n");
     ok(GetLastError() == 0xdeadbeef,
-       "Expected 0xdeadbeef, got %d\n", GetLastError());
+       "Expected 0xdeadbeef, got %ld\n", GetLastError());
     ok((erf.erfOper == 0x1abe11ed || erf.erfOper == 0 /* Vista */), "Expected 0x1abe11ed or 0, got %d\n", erf.erfOper);
     ok((erf.erfType == 0x5eed1e55 || erf.erfType == 0 /* Vista */), "Expected 0x5eed1e55 or 0, got %d\n", erf.erfType);
     ok((erf.fError == 0x1ead1e55 || erf.fError == 0 /* Vista */), "Expected 0x1ead1e55 or 0, got %d\n", erf.fError);
@@ -298,7 +298,7 @@ static void test_FDICreate(void)
                      cpuUNKNOWN, &erf);
     ok(hfdi != NULL, "Expected non-NULL context\n");
     ok(GetLastError() == 0xdeadbeef,
-       "Expected 0xdeadbeef, got %d\n", GetLastError());
+       "Expected 0xdeadbeef, got %ld\n", GetLastError());
     ok((erf.erfOper == 0x1abe11ed || erf.erfOper == 0 /* Vista */), "Expected 0x1abe11ed or 0, got %d\n", erf.erfOper);
     ok((erf.erfType == 0x5eed1e55 || erf.erfType == 0 /* Vista */), "Expected 0x5eed1e55 or 0, got %d\n", erf.erfType);
     ok((erf.fError == 0x1ead1e55 || erf.fError == 0 /* Vista */), "Expected 0x1ead1e55 or 0, got %d\n", erf.fError);
@@ -314,7 +314,7 @@ static void test_FDICreate(void)
                      cpuUNKNOWN, &erf);
     ok(hfdi != NULL, "Expected non-NULL context\n");
     ok(GetLastError() == 0xdeadbeef,
-       "Expected 0xdeadbeef, got %d\n", GetLastError());
+       "Expected 0xdeadbeef, got %ld\n", GetLastError());
     ok((erf.erfOper == 0x1abe11ed || erf.erfOper == 0 /* Vista */), "Expected 0x1abe11ed or 0, got %d\n", erf.erfOper);
     ok((erf.erfType == 0x5eed1e55 || erf.erfType == 0 /* Vista */), "Expected 0x5eed1e55 or 0, got %d\n", erf.erfType);
     ok((erf.fError == 0x1ead1e55 || erf.fError == 0 /* Vista */), "Expected 0x1ead1e55 or 0, got %d\n", erf.fError);
@@ -330,7 +330,7 @@ static void test_FDICreate(void)
                      cpuUNKNOWN, NULL);
     /* XP sets hfdi to a non-NULL value, but Vista sets it to NULL! */
     ok(GetLastError() == 0xdeadbeef,
-       "Expected 0xdeadbeef, got %d\n", GetLastError());
+       "Expected 0xdeadbeef, got %ld\n", GetLastError());
     /* NULL is passed to FDICreate instead of &erf, so don't retest the erf member values. */
 
     FDIDestroy(hfdi);
@@ -345,7 +345,7 @@ static void test_FDICreate(void)
                      0xcafebabe, &erf);
     ok(hfdi != NULL, "Expected non-NULL context\n");
     ok(GetLastError() == 0xdeadbeef,
-       "Expected 0xdeadbeef, got %d\n", GetLastError());
+       "Expected 0xdeadbeef, got %ld\n", GetLastError());
     ok((erf.erfOper == 0x1abe11ed || erf.erfOper == 0 /* Vista */), "Expected 0x1abe11ed or 0, got %d\n", erf.erfOper);
     ok((erf.erfType == 0x5eed1e55 || erf.erfType == 0 /* Vista */), "Expected 0x5eed1e55 or 0, got %d\n", erf.erfType);
     ok((erf.fError == 0x1ead1e55 || erf.fError == 0 /* Vista */), "Expected 0x1ead1e55 or 0, got %d\n", erf.fError);
@@ -365,7 +365,7 @@ static void test_FDICreate(void)
        "Expected FDIERROR_ALLOC_FAIL, got %d\n", erf.erfOper);
     ok(erf.fError == TRUE, "Expected TRUE, got %d\n", erf.fError);
     ok(GetLastError() == 0xdeadbeef,
-       "Expected 0xdeadbeef, got %d\n", GetLastError());
+       "Expected 0xdeadbeef, got %ld\n", GetLastError());
     ok(erf.erfType == 0, "Expected 0, got %d\n", erf.erfType);
 }
 
@@ -409,13 +409,6 @@ static void createTestFile(const CHAR *name)
 
 static void create_test_files(void)
 {
-    DWORD len;
-
-    len = GetCurrentDirectoryA(MAX_PATH, CURR_DIR);
-
-    if(len && (CURR_DIR[len-1] == '\\'))
-        CURR_DIR[len-1] = 0;
-
     createTestFile("a.txt");
     createTestFile("b.txt");
     CreateDirectoryA("testdir", NULL);
@@ -668,8 +661,8 @@ static void test_FDIIsCabinet(void)
     ret = FDIIsCabinet(hfdi, -1, &cabinfo);
     ok(ret == FALSE, "Expected FALSE, got %d\n", ret);
     ok(GetLastError() == ERROR_INVALID_HANDLE,
-       "Expected ERROR_INVALID_HANDLE, got %d\n", GetLastError());
-    ok(cabinfo.cbCabinet == 0, "Expected 0, got %d\n", cabinfo.cbCabinet);
+       "Expected ERROR_INVALID_HANDLE, got %ld\n", GetLastError());
+    ok(cabinfo.cbCabinet == 0, "Expected 0, got %ld\n", cabinfo.cbCabinet);
     ok(cabinfo.cFiles == 0, "Expected 0, got %d\n", cabinfo.cFiles);
     ok(cabinfo.cFolders == 0, "Expected 0, got %d\n", cabinfo.cFolders);
     ok(cabinfo.iCabinet == 0, "Expected 0, got %d\n", cabinfo.iCabinet);
@@ -683,8 +676,8 @@ static void test_FDIIsCabinet(void)
     SetLastError(0xdeadbeef);
     ret = FDIIsCabinet(hfdi, fd, &cabinfo);
     ok(ret == FALSE, "Expected FALSE, got %d\n", ret);
-    ok(GetLastError() == 0xdeadbeef, "Expected 0xdeadbeef, got %d\n", GetLastError());
-    ok(cabinfo.cbCabinet == 0, "Expected 0, got %d\n", cabinfo.cbCabinet);
+    ok(GetLastError() == 0xdeadbeef, "Expected 0xdeadbeef, got %ld\n", GetLastError());
+    ok(cabinfo.cbCabinet == 0, "Expected 0, got %ld\n", cabinfo.cbCabinet);
     ok(cabinfo.cFiles == 0, "Expected 0, got %d\n", cabinfo.cFiles);
     ok(cabinfo.cFolders == 0, "Expected 0, got %d\n", cabinfo.cFolders);
     ok(cabinfo.iCabinet == 0, "Expected 0, got %d\n", cabinfo.iCabinet);
@@ -699,11 +692,11 @@ static void test_FDIIsCabinet(void)
     SetLastError(0xdeadbeef);
     ret = FDIIsCabinet(hfdi, fd, &cabinfo);
     ok(ret == TRUE, "Expected TRUE, got %d\n", ret);
-    ok(GetLastError() == 0xdeadbeef, "Expected 0xdeadbeef, got %d\n", GetLastError());
+    ok(GetLastError() == 0xdeadbeef, "Expected 0xdeadbeef, got %ld\n", GetLastError());
     ok(cabinfo.cFiles == 4, "Expected 4, got %d\n", cabinfo.cFiles);
     ok(cabinfo.cFolders == 1, "Expected 1, got %d\n", cabinfo.cFolders);
     ok(cabinfo.setID == 0xbeef, "Expected 0xbeef, got %d\n", cabinfo.setID);
-    ok(cabinfo.cbCabinet == 182, "Expected 182, got %d\n", cabinfo.cbCabinet);
+    ok(cabinfo.cbCabinet == 182, "Expected 182, got %ld\n", cabinfo.cbCabinet);
     ok(cabinfo.iCabinet == 0, "Expected 0, got %d\n", cabinfo.iCabinet);
 
     fdi_close(fd);
@@ -720,11 +713,11 @@ static void test_FDIIsCabinet(void)
     SetLastError(0xdeadbeef);
     ret = FDIIsCabinet(hfdi, 0, &cabinfo);
     ok(ret == TRUE, "Expected TRUE, got %d\n", ret);
-    ok(GetLastError() == 0xdeadbeef, "Expected 0xdeadbeef, got %d\n", GetLastError());
+    ok(GetLastError() == 0xdeadbeef, "Expected 0xdeadbeef, got %ld\n", GetLastError());
     ok(cabinfo.cFiles == 4, "Expected 4, got %d\n", cabinfo.cFiles);
     ok(cabinfo.cFolders == 1, "Expected 1, got %d\n", cabinfo.cFolders);
     ok(cabinfo.setID == 0xbeef, "Expected 0xbeef, got %d\n", cabinfo.setID);
-    ok(cabinfo.cbCabinet == 182, "Expected 182, got %d\n", cabinfo.cbCabinet);
+    ok(cabinfo.cbCabinet == 182, "Expected 182, got %ld\n", cabinfo.cbCabinet);
     ok(cabinfo.iCabinet == 0, "Expected 0, got %d\n", cabinfo.iCabinet);
 
     fdi_close(static_fdi_handle);
@@ -778,9 +771,9 @@ static UINT CDECL fdi_mem_write(INT_PTR hf, void *pv, UINT cb)
 {
     static const char expected[] = "Hello World!";
 
-    trace("mem_write(%#lx,%p,%u)\n", hf, pv, cb);
+    trace("mem_write(%#Ix,%p,%u)\n", hf, pv, cb);
 
-    ok(hf == 0x12345678, "expected 0x12345678, got %#lx\n", hf);
+    ok(hf == 0x12345678, "expected 0x12345678, got %#Ix\n", hf);
     ok(cb == 12, "expected 12, got %u\n", cb);
     ok(!memcmp(pv, expected, 12), "expected %s, got %s\n", expected, (const char *)pv);
 
@@ -827,7 +820,7 @@ static INT_PTR CDECL fdi_mem_notify(FDINOTIFICATIONTYPE fdint, FDINOTIFICATION *
     switch (fdint)
     {
     case fdintCLOSE_FILE_INFO:
-        trace("mem_notify: CLOSE_FILE_INFO %s, handle %#lx\n", info->psz1, info->hf);
+        trace("mem_notify: CLOSE_FILE_INFO %s, handle %#Ix\n", info->psz1, info->hf);
 
         ok(!strcmp(info->psz1, expected), "expected %s, got %s\n", expected, info->psz1);
         ok(info->date == 0x1225, "expected 0x1225, got %#x\n", info->date);
@@ -838,9 +831,9 @@ static INT_PTR CDECL fdi_mem_notify(FDINOTIFICATIONTYPE fdint, FDINOTIFICATION *
 
     case fdintCOPY_FILE:
     {
-        trace("mem_notify: COPY_FILE %s, %d bytes\n", info->psz1, info->cb);
+        trace("mem_notify: COPY_FILE %s, %ld bytes\n", info->psz1, info->cb);
 
-        ok(info->cb == 12, "expected 12, got %u\n", info->cb);
+        ok(info->cb == 12, "expected 12, got %lu\n", info->cb);
         ok(!strcmp(info->psz1, expected), "expected %s, got %s\n", expected, info->psz1);
         ok(info->iFolder == 0x1234, "expected 0x1234, got %#x\n", info->iFolder);
         return 0x12345678; /* call write() callback */
@@ -893,7 +886,7 @@ static void test_FDICopy(void)
         ret = FDICopy(hfdi, name, path, 0, CopyProgress, NULL, 0);
         ok(ret == FALSE, "Expected FALSE, got %d\n", ret);
         ok(GetLastError() == ERROR_INVALID_HANDLE,
-           "Expected ERROR_INVALID_HANDLE, got %d\n", GetLastError());
+           "Expected ERROR_INVALID_HANDLE, got %ld\n", GetLastError());
 
         FDIDestroy(hfdi);
     }
@@ -910,7 +903,7 @@ static void test_FDICopy(void)
     SetLastError(0xdeadbeef);
     ret = FDICopy(hfdi, name, path, 0, CopyProgress, NULL, 0);
     ok(ret == TRUE, "Expected TRUE, got %d\n", ret);
-    ok(GetLastError() == 0, "Expected 0f, got %d\n", GetLastError());
+    ok(GetLastError() == 0, "Expected 0f, got %ld\n", GetLastError());
 
     FDIDestroy(hfdi);
 
@@ -927,7 +920,7 @@ static void test_FDICopy(void)
     memset(&info, 0, sizeof(info));
     ret = FDIIsCabinet(hfdi, fd, &info);
     ok(ret, "FDIIsCabinet error %d\n",  erf.erfOper);
-    ok(info.cbCabinet == 0x59, "expected 0x59, got %#x\n", info.cbCabinet);
+    ok(info.cbCabinet == 0x59, "expected 0x59, got %#lx\n", info.cbCabinet);
     ok(info.cFiles == 1, "expected 1, got %d\n", info.cFiles);
     ok(info.cFolders == 1, "expected 1, got %d\n", info.cFolders);
     ok(info.setID == 0x1225, "expected 0x1225, got %#x\n", info.setID);
@@ -944,6 +937,12 @@ static void test_FDICopy(void)
 
 START_TEST(fdi)
 {
+    int len;
+
+    len = GetCurrentDirectoryA(MAX_PATH, CURR_DIR);
+    if (len && (CURR_DIR[len - 1] == '\\'))
+        CURR_DIR[len - 1] = 0;
+
     test_FDICreate();
     test_FDIDestroy();
     test_FDIIsCabinet();

--- a/sdk/include/psdk/fdi.h
+++ b/sdk/include/psdk/fdi.h
@@ -199,8 +199,8 @@ typedef struct {
 
 /**********************************************************************/
 
-typedef void * (__cdecl *PFNALLOC)(ULONG cb);
-#define FNALLOC(fn) void * __cdecl fn(ULONG cb)
+typedef void * (__WINE_ALLOC_SIZE(1) __cdecl *PFNALLOC)(ULONG cb);
+#define FNALLOC(fn) void * __WINE_ALLOC_SIZE(1) __cdecl fn(ULONG cb)
 
 typedef void (__cdecl *PFNFREE)(void *pv);
 #define FNFREE(fn) void __cdecl fn(void *pv)

--- a/sdk/tools/winesync/cabinet.cfg
+++ b/sdk/tools/winesync/cabinet.cfg
@@ -1,0 +1,7 @@
+directories:
+  dlls/cabinet: dll/win32/cabinet
+files:
+  include/fci.h: /sdk/include/psdk/fci.h
+  include/fdi.h: /sdk/include/psdk/fdi.h
+tags:
+  wine: wine-9.7

--- a/sdk/tools/winesync/cabinet_tests.cfg
+++ b/sdk/tools/winesync/cabinet_tests.cfg
@@ -1,0 +1,5 @@
+directories:
+  dlls/cabinet/tests: modules/rostests/winetests/cabinet
+files: null
+tags:
+  wine: wine-9.7


### PR DESCRIPTION
## Purpose

Sync cabinet to reduce diff between ReactOS and wine

JIRA issue: [CORE-XXXX](https://jira.reactos.org/browse/CORE-XXXX)

## Proposed changes

- Sync cabinet and winetests to 9.7
- Remove ReactOS specific workarounds for handling trailing backslashes
- Compile with long types

## TODO

- [x] Check for winetest regressions (0 failures/no change)
- [ ] Check for regressions in [ROSTESTS-135](https://jira.reactos.org/browse/ROSTESTS-135)
- [ ] Remove/Update cabinet_ros.diff file
- [ ] Declare as forked (wine seems to update cabinet rarely)
