### PR TITLE
[ROSTESTS/x64] Remove some tests from x64 testing, because they are too slow

### DIFF
--- a/modules/rostests/apitests/advapi32/testlist.c
+++ b/modules/rostests/apitests/advapi32/testlist.c
@@ -31,7 +31,9 @@ const struct test winetest_testlist[] =
     { "Hash", func_Hash },
     { "HKEY_CLASSES_ROOT", func_HKEY_CLASSES_ROOT },
     { "IsTextUnicode" , func_IsTextUnicode },
+#ifndef _M_AMD64 // FIXME: Too slow and doesn't provide much value, see ROSTESTS-392
     { "LockServiceDatabase" , func_LockServiceDatabase },
+#endif
     { "QueryServiceConfig2", func_QueryServiceConfig2 },
     { "RegCreateKeyEx", func_RegCreateKeyEx },
     { "RegEnumKey", func_RegEnumKey },

--- a/modules/rostests/apitests/ntdll/testlist.c
+++ b/modules/rostests/apitests/ntdll/testlist.c
@@ -145,7 +145,9 @@ const struct test winetest_testlist[] =
     { "NtQuerySystemInformation",       func_NtQuerySystemInformation },
     { "NtQueryValueKey",                func_NtQueryValueKey },
     { "NtQueryVolumeInformationFile",   func_NtQueryVolumeInformationFile },
+#ifndef _M_AMD64 // FIXME: Slow and can cause timeouts on x64, see ROSTESTS-392
     { "NtReadFile",                     func_NtReadFile },
+#endif
     { "NtSaveKey",                      func_NtSaveKey},
     { "NtSetDefaultLocale",             func_NtSetDefaultLocale },
     { "NtSetInformationFile",           func_NtSetInformationFile },
@@ -156,7 +158,9 @@ const struct test winetest_testlist[] =
     { "NtSetVolumeInformationFile",     func_NtSetVolumeInformationFile },
     { "NtSystemInformation",            func_NtSystemInformation },
     { "NtUnloadDriver",                 func_NtUnloadDriver },
+#ifndef _M_AMD64 // FIXME: Slow and can cause timeouts on x64, see ROSTESTS-392
     { "NtWriteFile",                    func_NtWriteFile },
+#endif
     { "RtlAllocateHeap",                func_RtlAllocateHeap },
     { "RtlBitmapApi",                   func_RtlBitmap },
     { "RtlComputePrivatizedDllName_U",  func_RtlComputePrivatizedDllName_U },

--- a/modules/rostests/apitests/ws2_32/testlist.c
+++ b/modules/rostests/apitests/ws2_32/testlist.c
@@ -25,7 +25,9 @@ const struct test winetest_testlist[] =
 {
     { "bind", func_bind },
     { "close", func_close },
+#ifndef _M_AMD64 // FIXME: Too slow and times out often, see ROSTESTS-392
     { "getaddrinfo", func_getaddrinfo },
+#endif
     { "gethostname", func_gethostname },
     { "getnameinfo", func_getnameinfo },
     { "getservbyname", func_getservbyname },

--- a/modules/rostests/winetests/msi/testlist.c
+++ b/modules/rostests/winetests/msi/testlist.c
@@ -17,7 +17,9 @@ extern void func_suminfo(void);
 
 const struct test winetest_testlist[] =
 {
+#ifndef _M_AMD64 // FIXME: Too slow and times out often, see ROSTESTS-392
     { "action", func_action },
+#endif
     { "automation", func_automation },
     { "db", func_db },
     { "format", func_format },

--- a/modules/rostests/winetests/shell32/testlist.c
+++ b/modules/rostests/winetests/shell32/testlist.c
@@ -31,7 +31,9 @@ const struct test winetest_testlist[] =
     { "brsfolder", func_brsfolder },
     { "ebrowser", func_ebrowser },
     { "generated", func_generated },
+#ifndef _M_AMD64 // FIXME: Slow and crashes, see ROSTESTS-392
     { "progman_dde", func_progman_dde },
+#endif
     { "recyclebin", func_recyclebin },
     { "shelldispatch", func_shelldispatch },
     { "shelllink", func_shelllink },


### PR DESCRIPTION
## Purpose

x64 tends to end up being canceled due to a global timeout and these tests are the main culprits together with crashes and hangs. Reduces test time by 30%. This is tracked in ROSTESTS-392.

JIRA issue: [ROSTESTS-392](https://jira.reactos.org/browse/ROSTESTS-392)

## Proposed changes
Comment out the following tests on x64:
- advapi32:LockServiceDatabase
- ntdll:NtReadFile
- ntdll:NtWriteFile
- shell32:progman_dde
- msi:action
- ws2_32:getaddrinfo

## Tests
✅ KVM x64: https://reactos.org/testman/compare.php?ids=95116,95121,95133,95134
