### PR TITLE
[SETUPLIB] Improve the INI helpers; migrate old FreeLdr "Drive/Partition" types and "BootDrive/BootPartition" values

### DIFF
--- a/base/setup/lib/bootsup.c
+++ b/base/setup/lib/bootsup.c
@@ -189,15 +189,80 @@ CreateFreeLoaderIniForReactOSAndBootSector(
     IN PCWSTR ArcPath,
     IN PCWSTR Section,
     IN PCWSTR Description,
-    IN PCWSTR BootDrive,
-    IN PCWSTR BootPartition,
+    IN PCWSTR BootPath,
     IN PCWSTR BootSector)
 {
     NTSTATUS Status;
     PVOID BootStoreHandle;
-    UCHAR xxBootEntry[FIELD_OFFSET(BOOT_STORE_ENTRY, OsOptions) + sizeof(BOOT_SECTOR_OPTIONS)];
+    UCHAR xxBootEntry[FIELD_OFFSET(BOOT_STORE_ENTRY, OsOptions) + sizeof(BOOTSECTOR_OPTIONS)];
     PBOOT_STORE_ENTRY BootEntry = (PBOOT_STORE_ENTRY)&xxBootEntry;
-    PBOOT_SECTOR_OPTIONS Options = (PBOOT_SECTOR_OPTIONS)&BootEntry->OsOptions;
+    PBOOTSECTOR_OPTIONS Options = (PBOOTSECTOR_OPTIONS)&BootEntry->OsOptions;
+    WCHAR BootPathBuffer[MAX_PATH] = L"";
+
+    /* Since the BootPath given here is in NT format
+     * (not ARC), we need to hack-generate a mapping */
+    ULONG DiskNumber = 0, PartitionNumber = 0;
+    PCWSTR PathComponent = NULL;
+
+    /* From the NT path, compute the disk, partition and path components */
+    // NOTE: this function doesn't support stuff like \Device\FloppyX ...
+    if (NtPathToDiskPartComponents(BootPath, &DiskNumber, &PartitionNumber, &PathComponent))
+    {
+        DPRINT1("BootPath = '%S' points to disk #%d, partition #%d, path '%S'\n",
+               BootPath, DiskNumber, PartitionNumber, PathComponent);
+
+        /* HACK-build a possible ARC path:
+         * Hard disk path: multi(0)disk(0)rdisk(x)partition(y)[\path] */
+        RtlStringCchPrintfW(BootPathBuffer, _countof(BootPathBuffer),
+                            L"multi(0)disk(0)rdisk(%lu)partition(%lu)",
+                            DiskNumber, PartitionNumber);
+        if (PathComponent && *PathComponent &&
+            (PathComponent[0] != L'\\' || PathComponent[1]))
+        {
+            RtlStringCchCatW(BootPathBuffer, _countof(BootPathBuffer),
+                             PathComponent);
+        }
+    }
+    else
+    {
+        PCWSTR Path = BootPath;
+
+        if ((_wcsnicmp(Path, L"\\Device\\Floppy", 14) == 0) &&
+            (Path += 14) && iswdigit(*Path))
+        {
+            DiskNumber = wcstoul(Path, (PWSTR*)&PathComponent, 10);
+            if (PathComponent && *PathComponent && *PathComponent != L'\\')
+                PathComponent = NULL;
+
+            /* HACK-build a possible ARC path:
+             * Floppy disk path: multi(0)disk(0)fdisk(x)[\path] */
+            RtlStringCchPrintfW(BootPathBuffer, _countof(BootPathBuffer),
+                                L"multi(0)disk(0)fdisk(%lu)", DiskNumber);
+            if (PathComponent && *PathComponent &&
+                (PathComponent[0] != L'\\' || PathComponent[1]))
+            {
+                RtlStringCchCatW(BootPathBuffer, _countof(BootPathBuffer),
+                                 PathComponent);
+            }
+        }
+        else
+        {
+            /* HACK: Just keep the unresolved NT path and hope for the best... */
+
+            /* Remove any trailing backslash if needed */
+            UNICODE_STRING RootPartition;
+            RtlInitUnicodeString(&RootPartition, BootPath);
+            TrimTrailingPathSeparators_UStr(&RootPartition);
+
+            /* RootPartition is BootPath without counting any trailing
+             * path separator. Because of this, we need to copy the string
+             * in the buffer, instead of just using a pointer to it. */
+            RtlStringCchPrintfW(BootPathBuffer, _countof(BootPathBuffer),
+                                L"%wZ", &RootPartition);
+
+            DPRINT1("Unhandled NT path '%S'\n", BootPath);
+        }
+    }
 
     /* Initialize the INI file and create the common FreeLdr sections */
     Status = OpenBootStore(&BootStoreHandle, IniPath, FreeLdr,
@@ -211,14 +276,13 @@ CreateFreeLoaderIniForReactOSAndBootSector(
     BootEntry->Version = FreeLdr;
     BootEntry->BootFilePath = NULL;
 
-    BootEntry->OsOptionsLength = sizeof(BOOT_SECTOR_OPTIONS);
+    BootEntry->OsOptionsLength = sizeof(BOOTSECTOR_OPTIONS);
     RtlCopyMemory(Options->Signature,
-                  BOOT_SECTOR_OPTIONS_SIGNATURE,
-                  RTL_FIELD_SIZE(BOOT_SECTOR_OPTIONS, Signature));
+                  BOOTSECTOR_OPTIONS_SIGNATURE,
+                  RTL_FIELD_SIZE(BOOTSECTOR_OPTIONS, Signature));
 
-    Options->Drive = BootDrive;
-    Options->Partition = BootPartition;
-    Options->BootSectorFileName = BootSector;
+    Options->BootPath = BootPathBuffer;
+    Options->FileName = BootSector;
 
     // BootEntry->BootEntryKey = MAKESTRKEY(Section);
     BootEntry->FriendlyName = Description;
@@ -933,8 +997,6 @@ InstallFatBootcodeToPartition(
 
         PCWSTR Section;
         PCWSTR Description;
-        PCWSTR BootDrive;
-        PCWSTR BootPartition;
         PCWSTR BootSector;
 
         /* Search for COMPAQ MS-DOS 1.x (1.11, 1.12, based on MS-DOS 1.25) boot loader */
@@ -943,11 +1005,9 @@ InstallFatBootcodeToPartition(
         {
             DPRINT1("Found COMPAQ MS-DOS 1.x (1.11, 1.12) / MS-DOS 1.25 boot loader\n");
 
-            Section       = L"CPQDOS";
-            Description   = L"\"COMPAQ MS-DOS 1.x / MS-DOS 1.25\"";
-            BootDrive     = L"hd0";
-            BootPartition = L"1";
-            BootSector    = L"BOOTSECT.DOS";
+            Section     = L"CPQDOS";
+            Description = L"\"COMPAQ MS-DOS 1.x / MS-DOS 1.25\"";
+            BootSector  = L"BOOTSECT.DOS";
         }
         else
         /* Search for Microsoft DOS or Windows 9x boot loader */
@@ -957,11 +1017,9 @@ InstallFatBootcodeToPartition(
         {
             DPRINT1("Found Microsoft DOS or Windows 9x boot loader\n");
 
-            Section       = L"MSDOS";
-            Description   = L"\"MS-DOS/Windows\"";
-            BootDrive     = L"hd0";
-            BootPartition = L"1";
-            BootSector    = L"BOOTSECT.DOS";
+            Section     = L"MSDOS";
+            Description = L"\"MS-DOS/Windows\"";
+            BootSector  = L"BOOTSECT.DOS";
         }
         else
         /* Search for IBM PC-DOS or DR-DOS 5.x boot loader */
@@ -971,11 +1029,9 @@ InstallFatBootcodeToPartition(
         {
             DPRINT1("Found IBM PC-DOS or DR-DOS 5.x or IBM OS/2 1.0\n");
 
-            Section       = L"IBMDOS";
-            Description   = L"\"IBM PC-DOS or DR-DOS 5.x or IBM OS/2 1.0\"";
-            BootDrive     = L"hd0";
-            BootPartition = L"1";
-            BootSector    = L"BOOTSECT.DOS";
+            Section     = L"IBMDOS";
+            Description = L"\"IBM PC-DOS or DR-DOS 5.x or IBM OS/2 1.0\"";
+            BootSector  = L"BOOTSECT.DOS";
         }
         else
         /* Search for DR-DOS 3.x boot loader */
@@ -984,11 +1040,9 @@ InstallFatBootcodeToPartition(
         {
             DPRINT1("Found DR-DOS 3.x\n");
 
-            Section       = L"DRDOS";
-            Description   = L"\"DR-DOS 3.x\"";
-            BootDrive     = L"hd0";
-            BootPartition = L"1";
-            BootSector    = L"BOOTSECT.DOS";
+            Section     = L"DRDOS";
+            Description = L"\"DR-DOS 3.x\"";
+            BootSector  = L"BOOTSECT.DOS";
         }
         else
         /* Search for Dell Real-Mode Kernel (DRMK) OS */
@@ -997,11 +1051,9 @@ InstallFatBootcodeToPartition(
         {
             DPRINT1("Found Dell Real-Mode Kernel OS\n");
 
-            Section       = L"DRMK";
-            Description   = L"\"Dell Real-Mode Kernel OS\"";
-            BootDrive     = L"hd0";
-            BootPartition = L"1";
-            BootSector    = L"BOOTSECT.DOS";
+            Section     = L"DRMK";
+            Description = L"\"Dell Real-Mode Kernel OS\"";
+            BootSector  = L"BOOTSECT.DOS";
         }
         else
         /* Search for MS OS/2 1.x */
@@ -1011,11 +1063,9 @@ InstallFatBootcodeToPartition(
         {
             DPRINT1("Found MS OS/2 1.x\n");
 
-            Section       = L"MSOS2";
-            Description   = L"\"MS OS/2 1.x\"";
-            BootDrive     = L"hd0";
-            BootPartition = L"1";
-            BootSector    = L"BOOTSECT.OS2";
+            Section     = L"MSOS2";
+            Description = L"\"MS OS/2 1.x\"";
+            BootSector  = L"BOOTSECT.OS2";
         }
         else
         /* Search for MS or IBM OS/2 */
@@ -1025,11 +1075,9 @@ InstallFatBootcodeToPartition(
         {
             DPRINT1("Found MS/IBM OS/2\n");
 
-            Section       = L"IBMOS2";
-            Description   = L"\"MS/IBM OS/2\"";
-            BootDrive     = L"hd0";
-            BootPartition = L"1";
-            BootSector    = L"BOOTSECT.OS2";
+            Section     = L"IBMOS2";
+            Description = L"\"MS/IBM OS/2\"";
+            BootSector  = L"BOOTSECT.OS2";
         }
         else
         /* Search for FreeDOS boot loader */
@@ -1037,22 +1085,18 @@ InstallFatBootcodeToPartition(
         {
             DPRINT1("Found FreeDOS boot loader\n");
 
-            Section       = L"FDOS";
-            Description   = L"\"FreeDOS\"";
-            BootDrive     = L"hd0";
-            BootPartition = L"1";
-            BootSector    = L"BOOTSECT.DOS";
+            Section     = L"FDOS";
+            Description = L"\"FreeDOS\"";
+            BootSector  = L"BOOTSECT.DOS";
         }
         else
         {
             /* No or unknown boot loader */
             DPRINT1("No or unknown boot loader found\n");
 
-            Section       = L"Unknown";
-            Description   = L"\"Unknown Operating System\"";
-            BootDrive     = L"hd0";
-            BootPartition = L"1";
-            BootSector    = L"BOOTSECT.OLD";
+            Section     = L"Unknown";
+            Description = L"\"Unknown Operating System\"";
+            BootSector  = L"BOOTSECT.OLD";
         }
 
         /* Create or update 'freeldr.ini' */
@@ -1066,7 +1110,7 @@ InstallFatBootcodeToPartition(
                 Status = CreateFreeLoaderIniForReactOSAndBootSector(
                              SystemRootPath->Buffer, DestinationArcPath->Buffer,
                              Section, Description,
-                             BootDrive, BootPartition, BootSector);
+                             SystemRootPath->Buffer, BootSector);
                 if (!NT_SUCCESS(Status))
                 {
                     DPRINT1("CreateFreeLoaderIniForReactOSAndBootSector() failed (Status %lx)\n", Status);
@@ -1187,7 +1231,7 @@ InstallBtrfsBootcodeToPartition(
             Status = CreateFreeLoaderIniForReactOSAndBootSector(
                          SystemRootPath->Buffer, DestinationArcPath->Buffer,
                          L"Linux", L"\"Linux\"",
-                         L"hd0", L"1", BootSector);
+                         SystemRootPath->Buffer, BootSector);
             if (!NT_SUCCESS(Status))
             {
                 DPRINT1("CreateFreeLoaderIniForReactOSAndBootSector() failed (Status %lx)\n", Status);
@@ -1288,7 +1332,7 @@ InstallNtfsBootcodeToPartition(
         Status = CreateFreeLoaderIniForReactOSAndBootSector(
                      SystemRootPath->Buffer, DestinationArcPath->Buffer,
                      L"Linux", L"\"Linux\"",
-                     L"hd0", L"1", BootSector);
+                     SystemRootPath->Buffer, BootSector);
         if (!NT_SUCCESS(Status))
         {
             DPRINT1("CreateFreeLoaderIniForReactOSAndBootSector() failed (Status %lx)\n", Status);

--- a/base/setup/lib/utils/bldrsup.h
+++ b/base/setup/lib/utils/bldrsup.h
@@ -102,17 +102,16 @@ typedef struct _NTOS_OPTIONS
 #define NTOS_OPTIONS_SIGNATURE "NTOS_5\0\0"
 
 /* Options for boot-sector boot entries */
-typedef struct _BOOT_SECTOR_OPTIONS
+typedef struct _BOOTSECTOR_OPTIONS
 {
     UCHAR Signature[8];     // "BootSect"
     // ULONG Version;
     // ULONG Length;
-    PCWSTR Drive;
-    PCWSTR Partition;
-    PCWSTR BootSectorFileName;
-} BOOT_SECTOR_OPTIONS, *PBOOT_SECTOR_OPTIONS;
+    PCWSTR BootPath;
+    PCWSTR FileName;
+} BOOTSECTOR_OPTIONS, *PBOOTSECTOR_OPTIONS;
 
-#define BOOT_SECTOR_OPTIONS_SIGNATURE "BootSect"
+#define BOOTSECTOR_OPTIONS_SIGNATURE "BootSect"
 
 
 typedef NTSTATUS


### PR DESCRIPTION
## Purpose

The main purpose of this PR is to migrate the usage of the deprecated FreeLoader "Drive" and "Partition" boot types to the unified "BootSector" one (see to this effect, commit 5f3554a40 PR #6760) , as well as the "BootDrive" and "BootPartition" values to the "BootPath" one (this will be the subject of a future FreeLoader PR).

Because this requires the manipulation (addition/modification/removal) of key-values in FREELDR.INI, I took also the opportunity to:
- do a little revamping of the INI helpers (which is also something I had in my TODO list for years),
- add support for removing sections and key values.

## Proposed changes

### The INI helpers changes:

```
[SETUPLIB] Some INI support refactoring: function/struct names, duplicated code

And convert ANSI strings to UNICODE in a better way instead of
zero-extending them.
```

```
[SETUPLIB] Don't create new INI sections or key-values if they already exist

- If a section already exists, return the existing one. This allows
  avoiding different section entries with the same name in the cache.
  If an INI file has separate sections with the same name, their
  contents (key-values) get merged into a unique section.

- If a key-value already exists, update its data value and return the
  existing one. (Note that this may be subject to behaviour change in
  the future.)
```

```
[SETUPLIB] Add support for removing sections and key values, and remove some hacks.

- Use LIST_ENTRY instead of custom list pointers;
- Fix key/section unlinking before freeing.
```

### And the migration support of the old FreeLdr types/values:

```
[SETUPLIB] Use new BootPath value for BootSector boot entries

The BootDrive and BootPartition values are deprecated, and support
for them will soon be removed from FreeLoader.

Add an helper function to migrate these values during ReactOS
(re)installation / update.
```