### PR TITLE
[WIN32K/x64] Increase size of desktop heap

### DIFF
--- a/win32ss/user/ntuser/desktop.c
+++ b/win32ss/user/ntuser/desktop.c
@@ -28,7 +28,11 @@ IntFreeDesktopHeap(IN PDESKTOP pdesk);
 /* GLOBALS *******************************************************************/
 
 /* These can be changed via CSRSS startup, these are defaults */
+#ifdef _WIN64 // FIXME: Workaround for CORE-19563 (there is probably a class leak)
+DWORD gdwDesktopSectionSize = 2048;
+#else
 DWORD gdwDesktopSectionSize = 512;
+#endif
 DWORD gdwNOIOSectionSize    = 128; // A guess, for one or more of the first three system desktops.
 
 /* Currently active desktop */


### PR DESCRIPTION
## Purpose

Increase size of desktop heap on x64.
This is a workaround for CORE-19563. During testing the desktop heap regularly gets exhausted and that leads to a lot of issues.

JIRA issue: [CORE-19563](https://jira.reactos.org/browse/CORE-19563)

## Tests
- KVM x64: https://reactos.org/testman/compare.php?ids=95087,95088,95096,95111
