### PR TITLE
[NTOS:CM] Fix unlocking on failure

### DIFF
--- a/ntoskrnl/config/ntapi.c
+++ b/ntoskrnl/config/ntapi.c
@@ -1953,6 +1953,7 @@ NtUnloadKey2(IN POBJECT_ATTRIBUTES TargetKey,
         _SEH2_END;
     }
 
+Quit:
     /* If CmUnloadKey() failed we need to unlock registry ourselves */
     if (!NT_SUCCESS(Status))
     {
@@ -1969,7 +1970,6 @@ NtUnloadKey2(IN POBJECT_ATTRIBUTES TargetKey,
         CmpUnlockRegistry();
     }
 
-Quit:
     /* Dereference the key */
     ObDereferenceObject(KeyBody);
 

--- a/ntoskrnl/include/internal/cm.h
+++ b/ntoskrnl/include/internal/cm.h
@@ -160,6 +160,9 @@ typedef struct _CM_KEY_HASH_TABLE_ENTRY
     EX_PUSH_LOCK Lock;
     PKTHREAD Owner;
     PCM_KEY_HASH Entry;
+#if DBG
+    PVOID LockBackTrace[5];
+#endif
 } CM_KEY_HASH_TABLE_ENTRY, *PCM_KEY_HASH_TABLE_ENTRY;
 
 //

--- a/ntoskrnl/include/internal/cm_x.h
+++ b/ntoskrnl/include/internal/cm_x.h
@@ -6,6 +6,19 @@
 * PROGRAMMERS:     Alex Ionescu (alex.ionescu@reactos.org)
 */
 
+#if DBG
+FORCEINLINE
+VOID
+CmpCaptureLockBackTraceByIndex(_In_ ULONG Index)
+{
+    /* Capture the backtrace */
+    RtlCaptureStackBackTrace(1,
+                             _countof(CmpCacheTable[Index].LockBackTrace),
+                             CmpCacheTable[Index].LockBackTrace,
+                             NULL);
+}
+#endif
+
 //
 // Returns the hashkey corresponding to a convkey
 //
@@ -104,8 +117,12 @@ FORCEINLINE
 VOID
 CmpAcquireKcbLockExclusiveByIndex(ULONG Index)
 {
+    ASSERT(CmpCacheTable[Index].Owner != KeGetCurrentThread());
     ExAcquirePushLockExclusive(&CmpCacheTable[Index].Lock);
     CmpCacheTable[Index].Owner = KeGetCurrentThread();
+#if DBG
+    CmpCaptureLockBackTraceByIndex(Index);
+#endif
 }
 
 //


### PR DESCRIPTION
## Purpose

Properly unlock registry on failure in NtUnloadKey2.
Fixes random hang when loading user profile.

Jira Issue: [CORE-19539](https://jira.reactos.org/browse/CORE-19539)

## Proposed changes
- Add lock debugging code
- Unlock on failure

## Tests
- KVM x86: https://reactos.org/testman/compare.php?ids=95136,95142,95154,95160,95167
- KVM x64: https://reactos.org/testman/compare.php?ids=95087,95088,95096,95115,95161
