### PR TITLE
[SDK:WINE] Some minor additions to wine/test.h

### DIFF
--- a/sdk/include/reactos/wine/test.h
+++ b/sdk/include/reactos/wine/test.h
@@ -25,6 +25,7 @@
 #include <stdlib.h>
 #include <windef.h>
 #include <winbase.h>
+#include <stdio.h> // In the future: replace by <wine/debug.h>
 
 #ifdef __WINE_CONFIG_H
 #error config.h should not be used in Wine tests
@@ -86,6 +87,8 @@ extern const char *wine_dbgstr_longlong( ULONGLONG ll );
 #endif
 static inline const char *debugstr_a( const char *s )  { return wine_dbgstr_an( s, -1 ); }
 static inline const char *debugstr_an( const CHAR *s, intptr_t n ) { return wine_dbgstr_an( s, n ); }
+static inline const char *debugstr_w( const WCHAR *s ) { return wine_dbgstr_wn( s, -1 ); }
+static inline const char *debugstr_wn( const WCHAR *s, int n ) { return wine_dbgstr_wn( s, n ); }
 static inline const char *wine_dbgstr_a( const char *s )  { return wine_dbgstr_an( s, -1 ); }
 static inline const char *wine_dbgstr_w( const WCHAR *s ) { return wine_dbgstr_wn( s, -1 ); }
 


### PR DESCRIPTION
## Purpose

Newer winetests use debugstr_w(n) helpers; however for whatever reason our wine/test.h glue header, only used for the tests, don't have these. This PR remedies this problem.
Needed as part of [my work-in-progress setupapi winesync](https://github.com/reactos/reactos/tree/hbelusca/setupapi_partial_winesync/), this should also help with the winetests being done recently by @DarkFire01 @cbialorucki @maj113 and others.

## Proposed changes

- Add two missing debugstr_w* helpers. These will be needed for future winetest syncs.

Note that such change would be unnecessary, would wine/test.h and wine/debug.h be also updated with latest Wine versions. Indeed, wine/debug.h is now allowed to be included in wine tests since wine commit:
```
include: Allow using debug.h in tests.

Signed-off-by: Alexandre Julliard <julliard@winehq.org>

wine commit id c8f338369695d360e021f2cbd82a18b2c0eb1514 by Alexandre Julliard <julliard@winehq.org>
```

- Since our wine/test.h doesn't include wine/debug.h for now, include instead stdio.h for the time being, in order to get support for s(w)printf() in tests that don't include stdio.h
