### PR TITLE
[SDK:WINE] Improve wine/unicode.h (v)sprintfW defines, regarding the (v)swprintf functions.

### DIFF
--- a/sdk/include/reactos/wine/unicode.h
+++ b/sdk/include/reactos/wine/unicode.h
@@ -24,6 +24,12 @@
 #define WINE_UNICODE_INLINE static inline
 #endif
 
+#if (_WIN32_WINNT < _WIN32_WINNT_VISTA) || (DLL_EXPORT_VERSION < _WIN32_WINNT_VISTA)
+/* msvcrt versions incompatibilities */
+#define _swprintf(s,f,...) _snwprintf((s),MAXLONG,(f),##__VA_ARGS__)
+#define _vswprintf(s,f,v) _vsnwprintf((s),MAXLONG,(f),(v))
+#endif
+
 #define memicmpW(s1,s2,n) _wcsnicmp((s1),(s2),(n))
 #define strlenW(s) wcslen((s))
 #define strcpyW(d,s) wcscpy((d),(s))
@@ -55,8 +61,8 @@
 #define atolW(s) _wtol((s))
 #define strlwrW(s) _wcslwr((s))
 #define struprW(s) _wcsupr((s))
-#define sprintfW swprintf
-#define vsprintfW vswprintf
+#define sprintfW _swprintf
+#define vsprintfW _vswprintf
 #define snprintfW _snwprintf
 #define vsnprintfW _vsnwprintf
 #define isprintW iswprint


### PR DESCRIPTION
## Purpose & Proposed changes

These defines assumed that the (v)swprintf functions were the non-conformant ones (that don't take a 'count' 2nd parameter). Because of that, use instead the _(v)swprintf functions. However, those exist only in NT6+. Therefore, redefine these locally using the _(v)snprintf functions.

NOTE: wine/unicode.h has been removed in wine commit 348eebae872e90a735041a153635d00b01178cfa from July 13, 2022

Needed as part of [my work-in-progress setupapi winesync](https://github.com/reactos/reactos/tree/hbelusca/setupapi_partial_winesync/), this should also help with the winetests being done recently by @DarkFire01 @cbialorucki @maj113 and others.
