### PR TITLE
[WIN32K] Fix NULL pointer dereference in MENU_HideSubPopups

### DIFF
--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -3282,11 +3282,14 @@ static void FASTCALL MENU_HideSubPopups(PWND pWndOwner, PMENU Menu,
       {
           PWND pWnd;
           if (!VerifyMenu(Item->spSubMenu)) return;
-          pWnd = ValidateHwndNoErr(Item->spSubMenu->hWnd);
           MENU_HideSubPopups(pWndOwner, Item->spSubMenu, FALSE, wFlags);
           MENU_SelectItem(pWndOwner, Item->spSubMenu, NO_SELECTED_ITEM, SendMenuSelect, NULL);
           TRACE("M_HSP top p hm %p  pWndOwner IDMenu %p\n",top_popup_hmenu,pWndOwner->IDMenu);
-          co_UserDestroyWindow(pWnd);
+          pWnd = ValidateHwndNoErr(Item->spSubMenu->hWnd);
+          if (pWnd != NULL)
+          {
+              co_UserDestroyWindow(pWnd);
+          }
 
           /* Native returns handle to destroyed window */
           if (!(wFlags & TPM_NONOTIFY))


### PR DESCRIPTION
## Purpose

Fix NULL pointer dereference. Happens when the user heap gets depleted.

JIRA issue: [CORE-19367](https://jira.reactos.org/browse/CORE-19367)
