### PR TITLE
[BROWSEUI][COMCTL32] Handle rename on other folders in Explorer bar tree

### DIFF
--- a/dll/win32/browseui/explorerband.cpp
+++ b/dll/win32/browseui/explorerband.cpp
@@ -297,12 +297,11 @@ HRESULT CExplorerBand::IsCurrentLocation(PCIDLIST_ABSOLUTE pidl)
     if (!pidl)
         return E_INVALIDARG;
     HRESULT hr = E_FAIL;
-    PIDLIST_ABSOLUTE location = m_pidlCurrent, free = NULL;
-    if (!location && SUCCEEDED(hr = GetCurrentLocation(location)))
-        free = location;
-    if (location)
+    PIDLIST_ABSOLUTE location = m_pidlCurrent;
+    if (location || SUCCEEDED(hr = GetCurrentLocation(location)))
         hr = SHELL_IsEqualAbsoluteID(location, pidl) ? S_OK : S_FALSE;
-    ILFree(free);
+    if (location != m_pidlCurrent)
+        ILFree(location);
     return hr;
 }
 
@@ -347,8 +346,7 @@ HRESULT CExplorerBand::UpdateBrowser(LPITEMIDLIST pidlGoto)
         return hr;
 
     ILFree(m_pidlCurrent);
-    hr = SHILClone(pidlGoto, &m_pidlCurrent);
-    return hr;
+    return SHILClone(pidlGoto, &m_pidlCurrent);
 }
 
 // *** notifications handling ***

--- a/dll/win32/browseui/explorerband.cpp
+++ b/dll/win32/browseui/explorerband.cpp
@@ -148,7 +148,7 @@ Cleanup:
 CExplorerBand::CExplorerBand()
     : m_pSite(NULL)
     , m_fVisible(FALSE)
-    , m_bNavigating(FALSE)
+    , m_bNavigating(0)
     , m_dwBandID(0)
     , m_isEditing(FALSE)
     , m_pidlCurrent(NULL)
@@ -574,9 +574,9 @@ LRESULT CExplorerBand::ContextMenuHack(UINT uMsg, WPARAM wParam, LPARAM lParam, 
 
         // Move to the item selected by the treeview (don't change right pane)
         TreeView_HitTest(m_hWnd, &info);
-        m_bNavigating = TRUE;
+        ++m_bNavigating;
         TreeView_SelectItem(m_hWnd, info.hItem);
-        m_bNavigating = FALSE;
+        --m_bNavigating;
     }
     return FALSE; /* let the wndproc process the message */
 }
@@ -910,10 +910,10 @@ BOOL CExplorerBand::NavigateToCurrentFolder()
         ERR("Unable to get browser PIDL !\n");
         return FALSE;
     }
-    m_bNavigating = TRUE;
+    ++m_bNavigating;
     /* find PIDL into our explorer */
     result = NavigateToPIDL(explorerPidl, &dummy, TRUE, FALSE, TRUE);
-    m_bNavigating = FALSE;
+    --m_bNavigating;
     ILFree(explorerPidl);
     return result;
 }
@@ -1574,9 +1574,9 @@ HRESULT STDMETHODCALLTYPE CExplorerBand::DragOver(DWORD glfKeyState, POINTL pt, 
 
     if (info.hItem)
     {
-        m_bNavigating = TRUE;
+        ++m_bNavigating;
         TreeView_SelectItem(m_hWnd, info.hItem);
-        m_bNavigating = FALSE;
+        --m_bNavigating;
         // Delegate to shell folder
         if (m_pDropTarget && info.hItem != m_childTargetNode)
         {
@@ -1635,9 +1635,9 @@ HRESULT STDMETHODCALLTYPE CExplorerBand::DragOver(DWORD glfKeyState, POINTL pt, 
 
 HRESULT STDMETHODCALLTYPE CExplorerBand::DragLeave()
 {
-    m_bNavigating = TRUE;
+    ++m_bNavigating;
     TreeView_SelectItem(m_hWnd, m_oldSelected);
-    m_bNavigating = FALSE;
+    --m_bNavigating;
     m_childTargetNode = NULL;
     if (m_pCurObject)
     {

--- a/dll/win32/browseui/explorerband.cpp
+++ b/dll/win32/browseui/explorerband.cpp
@@ -532,7 +532,7 @@ LRESULT CExplorerBand::OnContextMenu(UINT uMsg, WPARAM wParam, LPARAM lParam, BO
         {
             HTREEITEM oldSelected = m_oldSelected;
             SetFocus();
-            startedRename = (BOOL)TreeView_EditLabel(m_hWnd, item);
+            startedRename = TreeView_EditLabel(m_hWnd, item) != NULL;
             m_oldSelected = oldSelected; // Restore after TVN_BEGINLABELEDIT
             goto Cleanup;
         }

--- a/dll/win32/browseui/explorerband.h
+++ b/dll/win32/browseui/explorerband.h
@@ -64,7 +64,7 @@ private:
     HIMAGELIST m_hImageList;
     HTREEITEM  m_hRoot;
     HTREEITEM  m_oldSelected;
-    LPITEMIDLIST m_pidlCurrent;
+    LPITEMIDLIST m_pidlCurrent; // Note: This is NULL until the first user navigation!
 
     // *** notification cookies ***
     DWORD m_adviseCookie;
@@ -103,6 +103,8 @@ private:
     BOOL RenameItem(HTREEITEM toRename, LPITEMIDLIST newPidl);
     BOOL RefreshTreePidl(HTREEITEM tree, LPITEMIDLIST pidlParent);
     BOOL NavigateToCurrentFolder();
+    HRESULT GetCurrentLocation(PIDLIST_ABSOLUTE &pidl);
+    HRESULT IsCurrentLocation(PCIDLIST_ABSOLUTE pidl);
 
     // *** Tree item sorting callback ***
     static int CALLBACK CompareTreeItems(LPARAM p1, LPARAM p2, LPARAM p3);

--- a/dll/win32/browseui/explorerband.h
+++ b/dll/win32/browseui/explorerband.h
@@ -57,7 +57,7 @@ private:
 
     // *** tree explorer band stuff ***
     BOOL m_fVisible;
-    BYTE m_bNavigating;
+    BYTE m_mtxBlockNavigate; // A "lock" that prevents internal selection changes to initiate a navigation to the newly selected item.
     BOOL m_bFocused;
     DWORD m_dwBandID;
     BOOL m_isEditing;

--- a/dll/win32/browseui/explorerband.h
+++ b/dll/win32/browseui/explorerband.h
@@ -57,7 +57,7 @@ private:
 
     // *** tree explorer band stuff ***
     BOOL m_fVisible;
-    BOOL m_bNavigating;
+    BYTE m_bNavigating;
     BOOL m_bFocused;
     DWORD m_dwBandID;
     BOOL m_isEditing;

--- a/dll/win32/browseui/shellbrowser.cpp
+++ b/dll/win32/browseui/shellbrowser.cpp
@@ -2309,8 +2309,11 @@ HRESULT STDMETHODCALLTYPE CShellBrowser::QueryActiveShellView(IShellView **ppshv
         return E_POINTER;
     *ppshv = fCurrentShellView;
     if (fCurrentShellView.p != NULL)
+    {
         fCurrentShellView.p->AddRef();
-    return S_OK;
+        return S_OK;
+    }
+    return E_FAIL;
 }
 
 HRESULT STDMETHODCALLTYPE CShellBrowser::OnViewWindowActive(IShellView *ppshv)
@@ -2530,10 +2533,7 @@ HRESULT STDMETHODCALLTYPE CShellBrowser::CanNavigateNow()
 HRESULT STDMETHODCALLTYPE CShellBrowser::GetPidl(LPITEMIDLIST *ppidl)
 {
     // called by explorer bar to get current pidl
-    if (ppidl == NULL)
-        return E_POINTER;
-    *ppidl = ILClone(fCurrentDirectoryPIDL);
-    return S_OK;
+    return ppidl ? SHILClone(fCurrentDirectoryPIDL, ppidl) : E_POINTER;
 }
 
 HRESULT STDMETHODCALLTYPE CShellBrowser::SetReferrer(LPCITEMIDLIST pidl)

--- a/dll/win32/browseui/utility.cpp
+++ b/dll/win32/browseui/utility.cpp
@@ -1,4 +1,7 @@
 #include "precomp.h"
+#ifndef SHCIDS_CANONICALONLY
+#define SHCIDS_CANONICALONLY 0x10000000L
+#endif
 
 void *operator new(size_t size)
 {
@@ -13,4 +16,58 @@ void operator delete(void *p)
 void operator delete(void *p, UINT_PTR)
 {
     LocalFree(p);
+}
+
+HRESULT SHELL_GetIDListFromObject(IUnknown *punk, PIDLIST_ABSOLUTE *ppidl)
+{
+#if DLL_EXPORT_VERSION >= _WIN32_WINNT_VISTA && 0 // FIXME: SHELL32 not ready yet
+    return SHGetIDListFromObject(punk, ppidl);
+#else
+    HRESULT hr;
+    IPersistFolder2 *pf2;
+    if (SUCCEEDED(hr = punk->QueryInterface(IID_PPV_ARG(IPersistFolder2, &pf2))))
+    {
+        hr = pf2->GetCurFolder(ppidl);
+        pf2->Release();
+    }
+    IPersistIDList *pil;
+    if (FAILED(hr) && SUCCEEDED(hr = punk->QueryInterface(IID_PPV_ARG(IPersistIDList, &pil))))
+    {
+        hr = pil->GetIDList(ppidl);
+        pil->Release();
+    }
+    return hr;
+#endif
+}
+
+static HRESULT SHELL_CompareAbsoluteIDs(LPARAM lParam, PCIDLIST_ABSOLUTE a, PCIDLIST_ABSOLUTE b)
+{
+    IShellFolder *psf;
+    HRESULT hr = SHGetDesktopFolder(&psf);
+    if (FAILED(hr))
+        return hr;
+    hr = psf->CompareIDs(lParam, a, b);
+    psf->Release();
+    return hr;
+}
+
+BOOL SHELL_IsEqualAbsoluteID(PCIDLIST_ABSOLUTE a, PCIDLIST_ABSOLUTE b)
+{
+    return 0 == SHELL_CompareAbsoluteIDs(SHCIDS_CANONICALONLY, a, b);
+}
+
+BOOL SHELL_IsVerb(IContextMenu *pcm, UINT_PTR idCmd, LPCWSTR Verb)
+{
+    HRESULT hr;
+    WCHAR wide[MAX_PATH];
+    if (SUCCEEDED(hr = pcm->GetCommandString(idCmd, GCS_VERBW, NULL, (LPSTR)wide, _countof(wide))))
+        return !lstrcmpiW(wide, Verb);
+
+    char ansi[MAX_PATH], buf[_countof(wide)];
+    if (SHUnicodeToAnsi(Verb, buf, _countof(buf)))
+    {
+        if (SUCCEEDED(hr = pcm->GetCommandString(idCmd, GCS_VERBA, NULL, ansi, _countof(ansi))))
+            return !lstrcmpiA(ansi, buf);
+    }
+    return FALSE;
 }

--- a/dll/win32/browseui/utility.cpp
+++ b/dll/win32/browseui/utility.cpp
@@ -53,7 +53,7 @@ static HRESULT SHELL_CompareAbsoluteIDs(LPARAM lParam, PCIDLIST_ABSOLUTE a, PCID
 
 BOOL SHELL_IsEqualAbsoluteID(PCIDLIST_ABSOLUTE a, PCIDLIST_ABSOLUTE b)
 {
-    return 0 == SHELL_CompareAbsoluteIDs(SHCIDS_CANONICALONLY, a, b);
+    return !SHELL_CompareAbsoluteIDs(SHCIDS_CANONICALONLY, a, b);
 }
 
 BOOL SHELL_IsVerb(IContextMenu *pcm, UINT_PTR idCmd, LPCWSTR Verb)
@@ -63,7 +63,7 @@ BOOL SHELL_IsVerb(IContextMenu *pcm, UINT_PTR idCmd, LPCWSTR Verb)
     if (SUCCEEDED(hr = pcm->GetCommandString(idCmd, GCS_VERBW, NULL, (LPSTR)wide, _countof(wide))))
         return !lstrcmpiW(wide, Verb);
 
-    char ansi[MAX_PATH], buf[_countof(wide)];
+    CHAR ansi[_countof(wide)], buf[MAX_PATH];
     if (SHUnicodeToAnsi(Verb, buf, _countof(buf)))
     {
         if (SUCCEEDED(hr = pcm->GetCommandString(idCmd, GCS_VERBA, NULL, ansi, _countof(ansi))))

--- a/dll/win32/browseui/utility.h
+++ b/dll/win32/browseui/utility.h
@@ -2,3 +2,7 @@
 
 void *operator new(size_t size);
 void operator delete(void *p);
+
+HRESULT SHELL_GetIDListFromObject(IUnknown *punk, PIDLIST_ABSOLUTE *ppidl);
+BOOL SHELL_IsEqualAbsoluteID(PCIDLIST_ABSOLUTE a, PCIDLIST_ABSOLUTE b);
+BOOL SHELL_IsVerb(IContextMenu *pcm, UINT_PTR idCmd, LPCWSTR Verb);

--- a/dll/win32/comctl32/listview.c
+++ b/dll/win32/comctl32/listview.c
@@ -3254,7 +3254,18 @@ static RANGES ranges_clone(RANGES ranges)
 {
     RANGES clone;
     INT i;
-	   
+
+#ifdef __REACTOS__
+    if (!ranges || !ranges->hdpa)
+    {
+        /* 
+         * If a ExplorerBand tree rename operation is completed by left-clicking in
+         * DefView, the navigation to the newly named item causes the ListView in DefView
+         * to call LISTVIEW_DeselectAllSkipItems during ListView destruction.
+        */
+        return NULL;
+    }
+#endif
     if (!(clone = ranges_create(DPA_GetPtrCount(ranges->hdpa)))) goto fail;
 
     for (i = 0; i < DPA_GetPtrCount(ranges->hdpa); i++)
@@ -10575,6 +10586,9 @@ static LRESULT LISTVIEW_NCDestroy(LISTVIEW_INFO *infoPtr)
       Free(DPA_GetPtr(infoPtr->hdpaColumns, i));
   DPA_Destroy(infoPtr->hdpaColumns);
   ranges_destroy(infoPtr->selectionRanges);
+#ifdef __REACTOS__
+  infoPtr->selectionRanges = NULL; /* See note in ranges_clone */
+#endif
 
   /* destroy image lists */
   if (!(infoPtr->dwStyle & LVS_SHAREIMAGELISTS))


### PR DESCRIPTION
IContextMenu (CDefaultContextMenu) only knows how to rename when its site is an IShellView. The tree must detect the rename operation and perform it in the TreeView instead.

Fixed a bug in the ListView that is triggered by activating DefView (to complete the rename): Just after DefView has been activated, the tree performs a navigation to the newly renamed folder, this causes DefView to be destroyed and in turn the ListView. The ListView tries to handle a selection change during destruction of the ListView and ends up accessing an invalid pointer.

Also fixes a memory leak and some minor flaws in IShellBrowser return code handling.

JIRA issue: [CORE-19557](https://jira.reactos.org/browse/CORE-19557)
