### PR TITLE
[INETCPL] Fix missing keyboard navigation

### DIFF
--- a/dll/cpl/inetcpl/lang/He.rc
+++ b/dll/cpl/inetcpl/lang/He.rc
@@ -71,8 +71,10 @@ FONT 8, "MS Shell Dlg"
 CAPTION "מחק היסטוריית גלישה"
 BEGIN
 
+    DEFPUSHBUTTON  "Cancel", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "Delete", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "Temporary internet files\nCached copies of web pages, images and certificates.",
-                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE
+                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "Cookies\nFiles saved on your computer by websites, which store things like user preferences and login information.",
                     IDC_DELETE_COOKIES, 10, 48, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "History\nList of websites you have accessed.",
@@ -81,8 +83,6 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "Passwords\nSaved passwords you have entered into forms.",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
-    DEFPUSHBUTTON  "Cancel", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "Delete", IDOK, 120, 230, 60, 15, WS_GROUP
 
 END
 

--- a/dll/cpl/inetcpl/lang/He.rc
+++ b/dll/cpl/inetcpl/lang/He.rc
@@ -71,8 +71,6 @@ FONT 8, "MS Shell Dlg"
 CAPTION "מחק היסטוריית גלישה"
 BEGIN
 
-    DEFPUSHBUTTON  "Cancel", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "Delete", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "Temporary internet files\nCached copies of web pages, images and certificates.",
                     IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "Cookies\nFiles saved on your computer by websites, which store things like user preferences and login information.",
@@ -83,6 +81,8 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "Passwords\nSaved passwords you have entered into forms.",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
+    DEFPUSHBUTTON  "Cancel", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "Delete", IDOK, 120, 230, 60, 15
 
 END
 

--- a/dll/cpl/inetcpl/lang/Sr.rc
+++ b/dll/cpl/inetcpl/lang/Sr.rc
@@ -68,8 +68,6 @@ FONT 8, "MS Shell Dlg"
 CAPTION "Delete browsing history"
 BEGIN
 
-    DEFPUSHBUTTON  "Cancel", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "Delete", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "Temporary internet files\nCached copies of web pages, images and certificates.",
                     IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "Cookies\nFiles saved on your computer by websites, which store things like user preferences and login information.",
@@ -80,6 +78,8 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "Passwords\nSaved passwords you have entered into forms.",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
+    DEFPUSHBUTTON  "Cancel", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "Delete", IDOK, 120, 230, 60, 15
 
 END
 
@@ -179,8 +179,6 @@ FONT 8, "MS Shell Dlg"
 CAPTION "Delete browsing history"
 BEGIN
 
-    DEFPUSHBUTTON  "Cancel", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "Delete", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "Temporary internet files\nCached copies of web pages, images and certificates.",
                     IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "Cookies\nFiles saved on your computer by websites, which store things like user preferences and login information.",
@@ -191,6 +189,8 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "Passwords\nSaved passwords you have entered into forms.",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
+    DEFPUSHBUTTON  "Cancel", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "Delete", IDOK, 120, 230, 60, 15
 
 END
 

--- a/dll/cpl/inetcpl/lang/Sr.rc
+++ b/dll/cpl/inetcpl/lang/Sr.rc
@@ -68,8 +68,10 @@ FONT 8, "MS Shell Dlg"
 CAPTION "Delete browsing history"
 BEGIN
 
+    DEFPUSHBUTTON  "Cancel", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "Delete", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "Temporary internet files\nCached copies of web pages, images and certificates.",
-                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE
+                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "Cookies\nFiles saved on your computer by websites, which store things like user preferences and login information.",
                     IDC_DELETE_COOKIES, 10, 48, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "History\nList of websites you have accessed.",
@@ -78,8 +80,6 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "Passwords\nSaved passwords you have entered into forms.",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
-    DEFPUSHBUTTON  "Cancel", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "Delete", IDOK, 120, 230, 60, 15, WS_GROUP
 
 END
 
@@ -179,8 +179,10 @@ FONT 8, "MS Shell Dlg"
 CAPTION "Delete browsing history"
 BEGIN
 
+    DEFPUSHBUTTON  "Cancel", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "Delete", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "Temporary internet files\nCached copies of web pages, images and certificates.",
-                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE
+                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "Cookies\nFiles saved on your computer by websites, which store things like user preferences and login information.",
                     IDC_DELETE_COOKIES, 10, 48, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "History\nList of websites you have accessed.",
@@ -189,8 +191,6 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "Passwords\nSaved passwords you have entered into forms.",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
-    DEFPUSHBUTTON  "Cancel", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "Delete", IDOK, 120, 230, 60, 15, WS_GROUP
 
 END
 

--- a/dll/cpl/inetcpl/lang/bg-BG.rc
+++ b/dll/cpl/inetcpl/lang/bg-BG.rc
@@ -65,8 +65,10 @@ FONT 8, "MS Shell Dlg"
 CAPTION "Изтриване на историята на браузъра"
 BEGIN
 
+    DEFPUSHBUTTON  "Изход", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "&Изтриване", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "&Временни интернет файлове\nКеширани копия на интернет страници, снимки и сертификати.",
-                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE
+                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "&Бисквитки\nФайлове запазени на вашия компютър, съхраняващи неща като потребителски предпочитания и информация за вход.",
                     IDC_DELETE_COOKIES, 10, 48, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "&Списък с историята на интернет странциите до които имате достъп.",
@@ -75,8 +77,6 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "&Пароли които се използват автоматично.",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
-    DEFPUSHBUTTON  "Изход", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "&Изтриване", IDOK, 120, 230, 60, 15, WS_GROUP
 
 END
 

--- a/dll/cpl/inetcpl/lang/bg-BG.rc
+++ b/dll/cpl/inetcpl/lang/bg-BG.rc
@@ -65,8 +65,6 @@ FONT 8, "MS Shell Dlg"
 CAPTION "Изтриване на историята на браузъра"
 BEGIN
 
-    DEFPUSHBUTTON  "Изход", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "&Изтриване", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "&Временни интернет файлове\nКеширани копия на интернет страници, снимки и сертификати.",
                     IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "&Бисквитки\nФайлове запазени на вашия компютър, съхраняващи неща като потребителски предпочитания и информация за вход.",
@@ -77,6 +75,8 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "&Пароли които се използват автоматично.",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
+    DEFPUSHBUTTON  "Изход", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "&Изтриване", IDOK, 120, 230, 60, 15
 
 END
 

--- a/dll/cpl/inetcpl/lang/cs-CZ.rc
+++ b/dll/cpl/inetcpl/lang/cs-CZ.rc
@@ -52,8 +52,6 @@ FONT 8, "MS Shell Dlg"
 CAPTION "Smazat historii prohlížení"
 BEGIN
 
-    DEFPUSHBUTTON  "Storno", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "Smazat", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "Dočasné internetové soubory\nUložené kopie webových stránek, obrázků a certifikátů.",
                     IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "Cookies\nSoubory uložené na počítači webovými stránkami, ve kterých jsou uložené například uživatelské předvolby nebo přihlašovací údaje.",
@@ -64,6 +62,8 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "Hesla\nUložená hesla, která byla zadána do formulářů.",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
+    DEFPUSHBUTTON  "Storno", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "Smazat", IDOK, 120, 230, 60, 15
 
 END
 

--- a/dll/cpl/inetcpl/lang/cs-CZ.rc
+++ b/dll/cpl/inetcpl/lang/cs-CZ.rc
@@ -52,8 +52,10 @@ FONT 8, "MS Shell Dlg"
 CAPTION "Smazat historii prohlížení"
 BEGIN
 
+    DEFPUSHBUTTON  "Storno", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "Smazat", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "Dočasné internetové soubory\nUložené kopie webových stránek, obrázků a certifikátů.",
-                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE
+                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "Cookies\nSoubory uložené na počítači webovými stránkami, ve kterých jsou uložené například uživatelské předvolby nebo přihlašovací údaje.",
                     IDC_DELETE_COOKIES, 10, 48, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "Historie\nSeznam navštívených webových stránek.",
@@ -62,8 +64,6 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "Hesla\nUložená hesla, která byla zadána do formulářů.",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
-    DEFPUSHBUTTON  "Storno", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "Smazat", IDOK, 120, 230, 60, 15, WS_GROUP
 
 END
 

--- a/dll/cpl/inetcpl/lang/de-DE.rc
+++ b/dll/cpl/inetcpl/lang/de-DE.rc
@@ -67,8 +67,6 @@ FONT 8, "MS Shell Dlg"
 CAPTION "Gespeicherte Browserdaten löschen"
 BEGIN
 
-    DEFPUSHBUTTON  "&Abbrechen", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "&Löschen", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "&Temporäre Internetdateien\nZwischengespeicherte Kopien von Webseiten, Bildern und Zertifikaten.",
                     IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "&Cookies\nVon Webseiten auf ihrem Computer gespeicherte Dateien, die Benutzereinstellungen oder Anmeldeinformationen enthalten.",
@@ -79,6 +77,8 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "&Kennwörter\nGespeicherte Kennwörter, die Sie in Formulare eingegeben haben.",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
+    DEFPUSHBUTTON  "&Abbrechen", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "&Löschen", IDOK, 120, 230, 60, 15
 
 END
 

--- a/dll/cpl/inetcpl/lang/de-DE.rc
+++ b/dll/cpl/inetcpl/lang/de-DE.rc
@@ -67,8 +67,10 @@ FONT 8, "MS Shell Dlg"
 CAPTION "Gespeicherte Browserdaten löschen"
 BEGIN
 
+    DEFPUSHBUTTON  "&Abbrechen", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "&Löschen", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "&Temporäre Internetdateien\nZwischengespeicherte Kopien von Webseiten, Bildern und Zertifikaten.",
-                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE
+                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "&Cookies\nVon Webseiten auf ihrem Computer gespeicherte Dateien, die Benutzereinstellungen oder Anmeldeinformationen enthalten.",
                     IDC_DELETE_COOKIES, 10, 48, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "&Verlauf\nListe von Webseiten, die Sie aufgerufen haben.",
@@ -77,8 +79,6 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "&Kennwörter\nGespeicherte Kennwörter, die Sie in Formulare eingegeben haben.",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
-    DEFPUSHBUTTON  "&Abbrechen", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "&Löschen", IDOK, 120, 230, 60, 15, WS_GROUP
 
 END
 

--- a/dll/cpl/inetcpl/lang/en-US.rc
+++ b/dll/cpl/inetcpl/lang/en-US.rc
@@ -65,8 +65,10 @@ FONT 8, "MS Shell Dlg"
 CAPTION "Delete browsing history"
 BEGIN
 
+    DEFPUSHBUTTON  "Cancel", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "&Delete", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "&Temporary internet files\nCached copies of web pages, images and certificates.",
-                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE
+                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "&Cookies\nFiles saved on your computer by websites, which store things like user preferences and login information.",
                     IDC_DELETE_COOKIES, 10, 48, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "&History\nList of websites you have accessed.",
@@ -75,8 +77,6 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "&Passwords\nSaved passwords you have entered into forms.",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
-    DEFPUSHBUTTON  "Cancel", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "&Delete", IDOK, 120, 230, 60, 15, WS_GROUP
 
 END
 

--- a/dll/cpl/inetcpl/lang/en-US.rc
+++ b/dll/cpl/inetcpl/lang/en-US.rc
@@ -65,8 +65,6 @@ FONT 8, "MS Shell Dlg"
 CAPTION "Delete browsing history"
 BEGIN
 
-    DEFPUSHBUTTON  "Cancel", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "&Delete", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "&Temporary internet files\nCached copies of web pages, images and certificates.",
                     IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "&Cookies\nFiles saved on your computer by websites, which store things like user preferences and login information.",
@@ -77,6 +75,8 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "&Passwords\nSaved passwords you have entered into forms.",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
+    DEFPUSHBUTTON  "Cancel", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "&Delete", IDOK, 120, 230, 60, 15
 
 END
 

--- a/dll/cpl/inetcpl/lang/es-ES.rc
+++ b/dll/cpl/inetcpl/lang/es-ES.rc
@@ -51,8 +51,6 @@ FONT 8, "MS Shell Dlg"
 CAPTION "Borrar historial de navegación"
 BEGIN
 
-    DEFPUSHBUTTON  "Cancelar", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "Borrar", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "Archivos temporales\nCopias en caché de páginas web, imágenes y certificados.",
                     IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "Cookies\nArchivos guardados en su equipo por los sitios Web, utilizados para almacenar preferencias e información de inicio de sesión.",
@@ -63,6 +61,8 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "Contraseñas\nContraseñas guardadas introducidas en formularios.",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
+    DEFPUSHBUTTON  "Cancelar", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "Borrar", IDOK, 120, 230, 60, 15
 
 END
 

--- a/dll/cpl/inetcpl/lang/es-ES.rc
+++ b/dll/cpl/inetcpl/lang/es-ES.rc
@@ -51,8 +51,10 @@ FONT 8, "MS Shell Dlg"
 CAPTION "Borrar historial de navegación"
 BEGIN
 
+    DEFPUSHBUTTON  "Cancelar", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "Borrar", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "Archivos temporales\nCopias en caché de páginas web, imágenes y certificados.",
-                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE
+                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "Cookies\nArchivos guardados en su equipo por los sitios Web, utilizados para almacenar preferencias e información de inicio de sesión.",
                     IDC_DELETE_COOKIES, 10, 48, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "Historial\nLista de sitios que se han visitado.",
@@ -61,8 +63,6 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "Contraseñas\nContraseñas guardadas introducidas en formularios.",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
-    DEFPUSHBUTTON  "Cancelar", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "Borrar", IDOK, 120, 230, 60, 15, WS_GROUP
 
 END
 

--- a/dll/cpl/inetcpl/lang/fr-FR.rc
+++ b/dll/cpl/inetcpl/lang/fr-FR.rc
@@ -69,8 +69,6 @@ FONT 8, "MS Shell Dlg"
 CAPTION "Effacer l'historique de navigation"
 BEGIN
 
-    DEFPUSHBUTTON  "Annuler", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "Effacer", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "Fichiers internet temporaires\nCopies en cache de pages web, d'images et de certificats.",
                     IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "Cookies\nDonnées enregistrées sur votre ordinateur par des sites web, telles que préférences utilisateur et informations de connexion.",
@@ -81,6 +79,8 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "Mots de passe\nMots de passe entrés dans des formulaires et sauvegardés.",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
+    DEFPUSHBUTTON  "Annuler", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "Effacer", IDOK, 120, 230, 60, 15
 
 END
 

--- a/dll/cpl/inetcpl/lang/fr-FR.rc
+++ b/dll/cpl/inetcpl/lang/fr-FR.rc
@@ -69,8 +69,10 @@ FONT 8, "MS Shell Dlg"
 CAPTION "Effacer l'historique de navigation"
 BEGIN
 
+    DEFPUSHBUTTON  "Annuler", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "Effacer", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "Fichiers internet temporaires\nCopies en cache de pages web, d'images et de certificats.",
-                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE
+                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "Cookies\nDonnées enregistrées sur votre ordinateur par des sites web, telles que préférences utilisateur et informations de connexion.",
                     IDC_DELETE_COOKIES, 10, 48, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "Historique\nListe des sites web accédés.",
@@ -79,8 +81,6 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "Mots de passe\nMots de passe entrés dans des formulaires et sauvegardés.",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
-    DEFPUSHBUTTON  "Annuler", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "Effacer", IDOK, 120, 230, 60, 15, WS_GROUP
 
 END
 

--- a/dll/cpl/inetcpl/lang/id-ID.rc
+++ b/dll/cpl/inetcpl/lang/id-ID.rc
@@ -44,8 +44,10 @@ FONT 8, "MS Shell Dlg"
 CAPTION "Hapus Riwayat Penjelajahan"
 BEGIN
 
+    DEFPUSHBUTTON  "Batal", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "&Hapus", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "&Berkas internet sementara\nSalinan halaman web, gambar, dan sertifikat dalam cache.",
-                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE
+                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "&Cookie\nBerkas disimpan di komputer anda oleh situs web, yakni beberapa hal-hal seperti preferensi pengguna dan informasi masuk.",
                     IDC_DELETE_COOKIES, 10, 48, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "&Riwayat\nDaftar situs web yang telah anda akses.",
@@ -54,8 +56,6 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "&Kata sandi\nKata sandi tersimpan yang telah Anda masukkan ke dalam formulir.",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
-    DEFPUSHBUTTON  "Batal", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "&Hapus", IDOK, 120, 230, 60, 15, WS_GROUP
 
 END
 

--- a/dll/cpl/inetcpl/lang/id-ID.rc
+++ b/dll/cpl/inetcpl/lang/id-ID.rc
@@ -44,8 +44,6 @@ FONT 8, "MS Shell Dlg"
 CAPTION "Hapus Riwayat Penjelajahan"
 BEGIN
 
-    DEFPUSHBUTTON  "Batal", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "&Hapus", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "&Berkas internet sementara\nSalinan halaman web, gambar, dan sertifikat dalam cache.",
                     IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "&Cookie\nBerkas disimpan di komputer anda oleh situs web, yakni beberapa hal-hal seperti preferensi pengguna dan informasi masuk.",
@@ -56,6 +54,8 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "&Kata sandi\nKata sandi tersimpan yang telah Anda masukkan ke dalam formulir.",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
+    DEFPUSHBUTTON  "Batal", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "&Hapus", IDOK, 120, 230, 60, 15
 
 END
 

--- a/dll/cpl/inetcpl/lang/it-IT.rc
+++ b/dll/cpl/inetcpl/lang/it-IT.rc
@@ -68,8 +68,10 @@ FONT 8, "MS Shell Dlg"
 CAPTION "Cancella Cronologia"
 BEGIN
 
+    DEFPUSHBUTTON  "Annulla", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "Cancella", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "File internet temporanei\nCopie di pagine web, immagini e certificati.",
-                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE
+                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "I Cookie\nFile salvate nel tuo computer dai siti web, che contengono dati come le preferenze dell'utente e altri informazioni.",
                     IDC_DELETE_COOKIES, 10, 48, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "Storia\nLista di siti web che hai visitato.",
@@ -78,8 +80,6 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "Password\nLe password salvate che hai inserito.",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
-    DEFPUSHBUTTON  "Annulla", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "Cancella", IDOK, 120, 230, 60, 15, WS_GROUP
 
 END
 

--- a/dll/cpl/inetcpl/lang/it-IT.rc
+++ b/dll/cpl/inetcpl/lang/it-IT.rc
@@ -68,8 +68,6 @@ FONT 8, "MS Shell Dlg"
 CAPTION "Cancella Cronologia"
 BEGIN
 
-    DEFPUSHBUTTON  "Annulla", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "Cancella", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "File internet temporanei\nCopie di pagine web, immagini e certificati.",
                     IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "I Cookie\nFile salvate nel tuo computer dai siti web, che contengono dati come le preferenze dell'utente e altri informazioni.",
@@ -80,6 +78,8 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "Password\nLe password salvate che hai inserito.",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
+    DEFPUSHBUTTON  "Annulla", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "Cancella", IDOK, 120, 230, 60, 15
 
 END
 

--- a/dll/cpl/inetcpl/lang/ja-JP.rc
+++ b/dll/cpl/inetcpl/lang/ja-JP.rc
@@ -69,8 +69,6 @@ FONT 9, "MS UI Gothic"
 CAPTION "検索履歴を消す"
 BEGIN
 
-    DEFPUSHBUTTON  "キャンセル", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "削除", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "一時インターネットファイル\nキャッシュされたウェブページと画像と証明書です。",
                     IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "クッキー\nウェブサイトにより保存されたファイルです。ユーザー設定やログイン情報を含みます。",
@@ -81,6 +79,8 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "パスワード\nフォームに入力した保存済みのパスワードです。",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
+    DEFPUSHBUTTON  "キャンセル", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "削除", IDOK, 120, 230, 60, 15
 
 END
 

--- a/dll/cpl/inetcpl/lang/ja-JP.rc
+++ b/dll/cpl/inetcpl/lang/ja-JP.rc
@@ -69,8 +69,10 @@ FONT 9, "MS UI Gothic"
 CAPTION "検索履歴を消す"
 BEGIN
 
+    DEFPUSHBUTTON  "キャンセル", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "削除", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "一時インターネットファイル\nキャッシュされたウェブページと画像と証明書です。",
-                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE
+                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "クッキー\nウェブサイトにより保存されたファイルです。ユーザー設定やログイン情報を含みます。",
                     IDC_DELETE_COOKIES, 10, 48, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "履歴\nアクセスしたウェブサイトのリストです。",
@@ -79,8 +81,6 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "パスワード\nフォームに入力した保存済みのパスワードです。",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
-    DEFPUSHBUTTON  "キャンセル", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "削除", IDOK, 120, 230, 60, 15, WS_GROUP
 
 END
 

--- a/dll/cpl/inetcpl/lang/ko-KR.rc
+++ b/dll/cpl/inetcpl/lang/ko-KR.rc
@@ -68,8 +68,6 @@ FONT 9, "굴림"
 CAPTION "방문 기록 지우기"
 BEGIN
 
-    DEFPUSHBUTTON  "취소", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "지우기", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "임시 인터넷 파일\n웹페이지의 캐시된 복사본,그림 그리고 인증서.",
                     IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "쿠키\n이 파일은 웹사이트에 위해 사용자 환경설정이나 로그인 정보같은 것을 당신의 컴퓨터에 저장하는데 사용됩니다. .",
@@ -80,6 +78,8 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "암호\n당신이 폼에 입력한 저장된 암호.",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
+    DEFPUSHBUTTON  "취소", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "지우기", IDOK, 120, 230, 60, 15
 
 END
 

--- a/dll/cpl/inetcpl/lang/ko-KR.rc
+++ b/dll/cpl/inetcpl/lang/ko-KR.rc
@@ -68,8 +68,10 @@ FONT 9, "굴림"
 CAPTION "방문 기록 지우기"
 BEGIN
 
+    DEFPUSHBUTTON  "취소", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "지우기", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "임시 인터넷 파일\n웹페이지의 캐시된 복사본,그림 그리고 인증서.",
-                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE
+                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "쿠키\n이 파일은 웹사이트에 위해 사용자 환경설정이나 로그인 정보같은 것을 당신의 컴퓨터에 저장하는데 사용됩니다. .",
                     IDC_DELETE_COOKIES, 10, 48, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "방문기록\n당신이 방문한 웹사이트의 목록.",
@@ -78,8 +80,6 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "암호\n당신이 폼에 입력한 저장된 암호.",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
-    DEFPUSHBUTTON  "취소", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "지우기", IDOK, 120, 230, 60, 15, WS_GROUP
 
 END
 

--- a/dll/cpl/inetcpl/lang/lt-LT.rc
+++ b/dll/cpl/inetcpl/lang/lt-LT.rc
@@ -68,8 +68,10 @@ FONT 8, "MS Shell Dlg"
 CAPTION "Šalinti naršymo istoriją"
 BEGIN
 
+    DEFPUSHBUTTON  "Atsisakyti", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "Šalinti", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "Laikini interneto failai\nTinklalapių kopijos podėlyje, paveikslai, liudijimai.",
-                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE
+                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "Slapukai\nTinklalapių kompiuteryje išsaugoti failai, kuriuose saugomi naudotojų nustatymai ir prisijungimo informacija.",
                     IDC_DELETE_COOKIES, 10, 48, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "Istorija\nTinklalapių, kuriuos naršėte, sąrašas.",
@@ -78,8 +80,6 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "Slaptažodžiai\nIšsaugoti slaptažodžiai, kuriuos įvedėte į formas.",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
-    DEFPUSHBUTTON  "Atsisakyti", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "Šalinti", IDOK, 120, 230, 60, 15, WS_GROUP
 
 END
 

--- a/dll/cpl/inetcpl/lang/lt-LT.rc
+++ b/dll/cpl/inetcpl/lang/lt-LT.rc
@@ -68,8 +68,6 @@ FONT 8, "MS Shell Dlg"
 CAPTION "Šalinti naršymo istoriją"
 BEGIN
 
-    DEFPUSHBUTTON  "Atsisakyti", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "Šalinti", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "Laikini interneto failai\nTinklalapių kopijos podėlyje, paveikslai, liudijimai.",
                     IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "Slapukai\nTinklalapių kompiuteryje išsaugoti failai, kuriuose saugomi naudotojų nustatymai ir prisijungimo informacija.",
@@ -80,7 +78,8 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "Slaptažodžiai\nIšsaugoti slaptažodžiai, kuriuos įvedėte į formas.",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
-
+    DEFPUSHBUTTON  "Atsisakyti", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "Šalinti", IDOK, 120, 230, 60, 15
 END
 
 /* "Security" propsheet */

--- a/dll/cpl/inetcpl/lang/nl-NL.rc
+++ b/dll/cpl/inetcpl/lang/nl-NL.rc
@@ -65,8 +65,10 @@ FONT 8, "MS Shell Dlg"
 CAPTION "Delete browsing history"
 BEGIN
 
+    DEFPUSHBUTTON  "Cancel", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "Delete", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "Temporary internet files\nCached copies of web pages, images and certificates.",
-                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE
+                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "Cookies\nFiles saved on your computer by websites, which store things like user preferences and login information.",
                     IDC_DELETE_COOKIES, 10, 48, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "History\nList of websites you have accessed.",
@@ -75,8 +77,6 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "Passwords\nSaved passwords you have entered into forms.",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
-    DEFPUSHBUTTON  "Cancel", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "Delete", IDOK, 120, 230, 60, 15, WS_GROUP
 
 END
 

--- a/dll/cpl/inetcpl/lang/nl-NL.rc
+++ b/dll/cpl/inetcpl/lang/nl-NL.rc
@@ -65,8 +65,6 @@ FONT 8, "MS Shell Dlg"
 CAPTION "Delete browsing history"
 BEGIN
 
-    DEFPUSHBUTTON  "Cancel", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "Delete", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "Temporary internet files\nCached copies of web pages, images and certificates.",
                     IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "Cookies\nFiles saved on your computer by websites, which store things like user preferences and login information.",
@@ -77,6 +75,8 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "Passwords\nSaved passwords you have entered into forms.",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
+    DEFPUSHBUTTON  "Cancel", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "Delete", IDOK, 120, 230, 60, 15
 
 END
 

--- a/dll/cpl/inetcpl/lang/pl-PL.rc
+++ b/dll/cpl/inetcpl/lang/pl-PL.rc
@@ -68,8 +68,6 @@ FONT 8, "MS Shell Dlg"
 CAPTION "Usuwanie historii przeglądania"
 BEGIN
 
-    DEFPUSHBUTTON  "Anuluj", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "Usuń", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "Tymczasowe pliki internetowe\nKopie stron sieci Web, obrazów i certyfikatów.",
                     IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "Pliki cookies\nPliki przechowywane na komputerze przez witryny sieci Web w celu zapisania preferencji takich jak informacje logowania.",
@@ -80,6 +78,8 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "Hasła\nHasła uzupełniane automatycznie po zalogowaniu się do wcześniej odwiedzonej witryny Web.",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
+    DEFPUSHBUTTON  "Anuluj", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "Usuń", IDOK, 120, 230, 60, 15
 
 END
 

--- a/dll/cpl/inetcpl/lang/pl-PL.rc
+++ b/dll/cpl/inetcpl/lang/pl-PL.rc
@@ -68,8 +68,10 @@ FONT 8, "MS Shell Dlg"
 CAPTION "Usuwanie historii przeglądania"
 BEGIN
 
+    DEFPUSHBUTTON  "Anuluj", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "Usuń", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "Tymczasowe pliki internetowe\nKopie stron sieci Web, obrazów i certyfikatów.",
-                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE
+                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "Pliki cookies\nPliki przechowywane na komputerze przez witryny sieci Web w celu zapisania preferencji takich jak informacje logowania.",
                     IDC_DELETE_COOKIES, 10, 48, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "Historia\nLista odwiedzonych witryn sieci Web.",
@@ -78,8 +80,6 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "Hasła\nHasła uzupełniane automatycznie po zalogowaniu się do wcześniej odwiedzonej witryny Web.",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
-    DEFPUSHBUTTON  "Anuluj", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "Usuń", IDOK, 120, 230, 60, 15, WS_GROUP
 
 END
 

--- a/dll/cpl/inetcpl/lang/pt-BR.rc
+++ b/dll/cpl/inetcpl/lang/pt-BR.rc
@@ -67,8 +67,6 @@ FONT 8, "MS Shell Dlg"
 CAPTION "Delete browsing history"
 BEGIN
 
-    DEFPUSHBUTTON  "Cancel", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "Delete", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "Temporary internet files\nCached copies of web pages, images and certificates.",
                     IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "Cookies\nFiles saved on your computer by websites, which store things like user preferences and login information.",
@@ -79,6 +77,8 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "Passwords\nSaved passwords you have entered into forms.",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
+    DEFPUSHBUTTON  "Cancel", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "Delete", IDOK, 120, 230, 60, 15
 
 END
 

--- a/dll/cpl/inetcpl/lang/pt-BR.rc
+++ b/dll/cpl/inetcpl/lang/pt-BR.rc
@@ -67,8 +67,10 @@ FONT 8, "MS Shell Dlg"
 CAPTION "Delete browsing history"
 BEGIN
 
+    DEFPUSHBUTTON  "Cancel", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "Delete", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "Temporary internet files\nCached copies of web pages, images and certificates.",
-                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE
+                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "Cookies\nFiles saved on your computer by websites, which store things like user preferences and login information.",
                     IDC_DELETE_COOKIES, 10, 48, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "History\nList of websites you have accessed.",
@@ -77,8 +79,6 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "Passwords\nSaved passwords you have entered into forms.",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
-    DEFPUSHBUTTON  "Cancel", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "Delete", IDOK, 120, 230, 60, 15, WS_GROUP
 
 END
 

--- a/dll/cpl/inetcpl/lang/pt-PT.rc
+++ b/dll/cpl/inetcpl/lang/pt-PT.rc
@@ -68,8 +68,6 @@ FONT 8, "MS Shell Dlg"
 CAPTION "Limpar histórico de navegação"
 BEGIN
 
-    DEFPUSHBUTTON  "Cancelar", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "Apagar", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "Ficheiros temporários da internet\nCópias de páginas web em cachê, imagens e certificados.",
                     IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "Cookies\nFicheiros guardados no computador, por websites que armazenam itens como preferências do utilizador e informações de início de sessão.",
@@ -80,6 +78,8 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "Passwords\n Passwords que inseriu em formulários",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
+    DEFPUSHBUTTON  "Cancelar", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "Apagar", IDOK, 120, 230, 60, 15
 
 END
 

--- a/dll/cpl/inetcpl/lang/pt-PT.rc
+++ b/dll/cpl/inetcpl/lang/pt-PT.rc
@@ -68,8 +68,10 @@ FONT 8, "MS Shell Dlg"
 CAPTION "Limpar histórico de navegação"
 BEGIN
 
+    DEFPUSHBUTTON  "Cancelar", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "Apagar", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "Ficheiros temporários da internet\nCópias de páginas web em cachê, imagens e certificados.",
-                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE
+                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "Cookies\nFicheiros guardados no computador, por websites que armazenam itens como preferências do utilizador e informações de início de sessão.",
                     IDC_DELETE_COOKIES, 10, 48, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "Histórico\nLista de websites que visitou recentemente.",
@@ -78,8 +80,6 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "Passwords\n Passwords que inseriu em formulários",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
-    DEFPUSHBUTTON  "Cancelar", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "Apagar", IDOK, 120, 230, 60, 15, WS_GROUP
 
 END
 

--- a/dll/cpl/inetcpl/lang/ro-RO.rc
+++ b/dll/cpl/inetcpl/lang/ro-RO.rc
@@ -67,8 +67,6 @@ FONT 8, "MS Shell Dlg"
 CAPTION "Eliminare istoric de navigare"
 BEGIN
 
-    DEFPUSHBUTTON  "A&nulează", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "&Elimină", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "Fișierele de internet t&emporare\nCopii ale paginilor temporar stocate, imagini și certificate.",
                     IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "Informațiile de &conexiune (Cookies)\nFișiere cu date precum informații de autentificare sau preferințe, stocate în calculatorul dumneavoastră din paginile vizitate.",
@@ -79,6 +77,8 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "&Parolele\nParolele salvate pe care le-ați introdus prin formulare.",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
+    DEFPUSHBUTTON  "A&nulează", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "&Elimină", IDOK, 120, 230, 60, 15
 
 END
 

--- a/dll/cpl/inetcpl/lang/ro-RO.rc
+++ b/dll/cpl/inetcpl/lang/ro-RO.rc
@@ -67,8 +67,10 @@ FONT 8, "MS Shell Dlg"
 CAPTION "Eliminare istoric de navigare"
 BEGIN
 
+    DEFPUSHBUTTON  "A&nulează", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "&Elimină", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "Fișierele de internet t&emporare\nCopii ale paginilor temporar stocate, imagini și certificate.",
-                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE
+                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "Informațiile de &conexiune (Cookies)\nFișiere cu date precum informații de autentificare sau preferințe, stocate în calculatorul dumneavoastră din paginile vizitate.",
                     IDC_DELETE_COOKIES, 10, 48, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "Ist&oricul\nLista paginilor pe care le-ați accesat în timp.",
@@ -77,8 +79,6 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "&Parolele\nParolele salvate pe care le-ați introdus prin formulare.",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
-    DEFPUSHBUTTON  "A&nulează", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "&Elimină", IDOK, 120, 230, 60, 15, WS_GROUP
 
 END
 

--- a/dll/cpl/inetcpl/lang/ru-RU.rc
+++ b/dll/cpl/inetcpl/lang/ru-RU.rc
@@ -68,8 +68,6 @@ FONT 8, "MS Shell Dlg"
 CAPTION "Очистка истории"
 BEGIN
 
-    DEFPUSHBUTTON  "Отмена", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "Удалить", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "Временные файлы\nКэшированные копии страниц, изображений и сертификатов.",
                     IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "Файлы cookies\nФайлы, сохранённые на вашем компьютере, могут содержать пользовательские настройки и информацию для авторизации.",
@@ -80,6 +78,8 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "Пароли\nСохранённые пароли, которые были указаны в веб-формах.",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
+    DEFPUSHBUTTON  "Отмена", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "Удалить", IDOK, 120, 230, 60, 15
 
 END
 

--- a/dll/cpl/inetcpl/lang/ru-RU.rc
+++ b/dll/cpl/inetcpl/lang/ru-RU.rc
@@ -68,8 +68,10 @@ FONT 8, "MS Shell Dlg"
 CAPTION "Очистка истории"
 BEGIN
 
+    DEFPUSHBUTTON  "Отмена", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "Удалить", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "Временные файлы\nКэшированные копии страниц, изображений и сертификатов.",
-                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE
+                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "Файлы cookies\nФайлы, сохранённые на вашем компьютере, могут содержать пользовательские настройки и информацию для авторизации.",
                     IDC_DELETE_COOKIES, 10, 48, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "История\nПеречень сайтов, к которым осуществлялся доступ.",
@@ -78,8 +80,6 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "Пароли\nСохранённые пароли, которые были указаны в веб-формах.",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
-    DEFPUSHBUTTON  "Отмена", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "Удалить", IDOK, 120, 230, 60, 15, WS_GROUP
 
 END
 

--- a/dll/cpl/inetcpl/lang/sq-AL.rc
+++ b/dll/cpl/inetcpl/lang/sq-AL.rc
@@ -67,8 +67,10 @@ FONT 8, "MS Shell Dlg"
 CAPTION "Fshi historine e Shfletimit"
 BEGIN
 
+    DEFPUSHBUTTON  "Anulo", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "Fshi", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "Dokumentat të përkohshëm të internetit\nKopje Kafazit te faqeveweb, imazhe dhe certifikata.",
-                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE
+                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "Rekorded\nDokumentat e ruajtur në kompjuterin tuaj nga faqet e internetit, e cila ruan gjëra si parapëlqimet e përdoruesit dhe informacionet e identifikimit.",
                     IDC_DELETE_COOKIES, 10, 48, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "Historia\nLista e faqet e internetit që keni përdorur.",
@@ -77,8 +79,6 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "Fjalëkalime\nFjalëkalime të ruajtura që kanë hyrë në forma.",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
-    DEFPUSHBUTTON  "Anulo", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "Fshi", IDOK, 120, 230, 60, 15, WS_GROUP
 
 END
 

--- a/dll/cpl/inetcpl/lang/sq-AL.rc
+++ b/dll/cpl/inetcpl/lang/sq-AL.rc
@@ -67,8 +67,6 @@ FONT 8, "MS Shell Dlg"
 CAPTION "Fshi historine e Shfletimit"
 BEGIN
 
-    DEFPUSHBUTTON  "Anulo", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "Fshi", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "Dokumentat të përkohshëm të internetit\nKopje Kafazit te faqeveweb, imazhe dhe certifikata.",
                     IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "Rekorded\nDokumentat e ruajtur në kompjuterin tuaj nga faqet e internetit, e cila ruan gjëra si parapëlqimet e përdoruesit dhe informacionet e identifikimit.",
@@ -79,6 +77,8 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "Fjalëkalime\nFjalëkalime të ruajtura që kanë hyrë në forma.",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
+    DEFPUSHBUTTON  "Anulo", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "Fshi", IDOK, 120, 230, 60, 15
 
 END
 

--- a/dll/cpl/inetcpl/lang/sv-SE.rc
+++ b/dll/cpl/inetcpl/lang/sv-SE.rc
@@ -67,8 +67,10 @@ FONT 8, "MS Shell Dlg"
 CAPTION "Delete browsing history"
 BEGIN
 
+    DEFPUSHBUTTON  "Avbryt", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "Ta bort", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "Temporary internet files\nCached copies of web pages, images and certificates.",
-                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE
+                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "Cookies\nFiles saved on your computer by websites, which store things like user preferences and login information.",
                     IDC_DELETE_COOKIES, 10, 48, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "History\nList of websites you have accessed.",
@@ -77,8 +79,6 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "Passwords\nSaved passwords you have entered into forms.",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
-    DEFPUSHBUTTON  "Avbryt", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "Ta bort", IDOK, 120, 230, 60, 15, WS_GROUP
 
 END
 

--- a/dll/cpl/inetcpl/lang/sv-SE.rc
+++ b/dll/cpl/inetcpl/lang/sv-SE.rc
@@ -67,8 +67,6 @@ FONT 8, "MS Shell Dlg"
 CAPTION "Delete browsing history"
 BEGIN
 
-    DEFPUSHBUTTON  "Avbryt", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "Ta bort", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "Temporary internet files\nCached copies of web pages, images and certificates.",
                     IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "Cookies\nFiles saved on your computer by websites, which store things like user preferences and login information.",
@@ -79,6 +77,8 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "Passwords\nSaved passwords you have entered into forms.",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
+    DEFPUSHBUTTON  "Avbryt", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "Ta bort", IDOK, 120, 230, 60, 15
 
 END
 

--- a/dll/cpl/inetcpl/lang/tr-TR.rc
+++ b/dll/cpl/inetcpl/lang/tr-TR.rc
@@ -68,8 +68,10 @@ FONT 8, "MS Shell Dlg"
 CAPTION "Tarama Geçmişini Sil"
 BEGIN
 
+    DEFPUSHBUTTON  "İptal", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "Sil", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "&Geçici İnternet Dosyaları:\nİnternet sayfalarının, resimlerin ve sertifikaların ön belleklenen kopyaları.",
-                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE
+                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "&Tanımlama Bilgileri:\nİnternet siteleri tarafından bilgisayarınıza kaydedilmiş, kullanıcı tercihleri ve oturum açma bilgileri gibi şeyleri saklayan dosyalar.",
                     IDC_DELETE_COOKIES, 10, 48, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "G&eçmiş:\nEriştiğiniz İnternet sitelerinin listesi.",
@@ -78,8 +80,6 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "&Parolalar:\nFormlarda girdiğiniz kaydedilmiş parolalar.",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
-    DEFPUSHBUTTON  "İptal", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "Sil", IDOK, 120, 230, 60, 15, WS_GROUP
 
 END
 

--- a/dll/cpl/inetcpl/lang/tr-TR.rc
+++ b/dll/cpl/inetcpl/lang/tr-TR.rc
@@ -68,8 +68,6 @@ FONT 8, "MS Shell Dlg"
 CAPTION "Tarama Geçmişini Sil"
 BEGIN
 
-    DEFPUSHBUTTON  "İptal", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "Sil", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "&Geçici İnternet Dosyaları:\nİnternet sayfalarının, resimlerin ve sertifikaların ön belleklenen kopyaları.",
                     IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "&Tanımlama Bilgileri:\nİnternet siteleri tarafından bilgisayarınıza kaydedilmiş, kullanıcı tercihleri ve oturum açma bilgileri gibi şeyleri saklayan dosyalar.",
@@ -80,6 +78,8 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "&Parolalar:\nFormlarda girdiğiniz kaydedilmiş parolalar.",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
+    DEFPUSHBUTTON  "İptal", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "Sil", IDOK, 120, 230, 60, 15
 
 END
 

--- a/dll/cpl/inetcpl/lang/uk-UA.rc
+++ b/dll/cpl/inetcpl/lang/uk-UA.rc
@@ -69,8 +69,10 @@ FONT 8, "MS Shell Dlg"
 CAPTION "Delete browsing history"
 BEGIN
 
+    DEFPUSHBUTTON  "Cancel", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "Delete", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "Temporary internet files\nCached copies of web pages, images and certificates.",
-                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE
+                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "Cookies\nFiles saved on your computer by websites, which store things like user preferences and login information.",
                     IDC_DELETE_COOKIES, 10, 48, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "History\nList of websites you have accessed.",
@@ -79,8 +81,6 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "Passwords\nSaved passwords you have entered into forms.",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
-    DEFPUSHBUTTON  "Cancel", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "Delete", IDOK, 120, 230, 60, 15, WS_GROUP
 
 END
 

--- a/dll/cpl/inetcpl/lang/uk-UA.rc
+++ b/dll/cpl/inetcpl/lang/uk-UA.rc
@@ -69,8 +69,6 @@ FONT 8, "MS Shell Dlg"
 CAPTION "Delete browsing history"
 BEGIN
 
-    DEFPUSHBUTTON  "Cancel", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "Delete", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "Temporary internet files\nCached copies of web pages, images and certificates.",
                     IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "Cookies\nFiles saved on your computer by websites, which store things like user preferences and login information.",
@@ -81,6 +79,8 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "Passwords\nSaved passwords you have entered into forms.",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
+    DEFPUSHBUTTON  "Cancel", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "Delete", IDOK, 120, 230, 60, 15
 
 END
 

--- a/dll/cpl/inetcpl/lang/zh-CN.rc
+++ b/dll/cpl/inetcpl/lang/zh-CN.rc
@@ -66,8 +66,6 @@ FONT 9, "宋体"
 CAPTION "删除浏览历史记录"
 BEGIN
 
-    DEFPUSHBUTTON  "取消", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "删除", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "Internet 临时文件\n缓存的网站页面、 图像和证书的副本。",
                     IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "Cookies\n通过网站在您的计算机上保存文件存储用户首选项和登录信息。",
@@ -78,6 +76,8 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "密码\n保存在窗口中输入的密码。",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
+    DEFPUSHBUTTON  "取消", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "删除", IDOK, 120, 230, 60, 15
 
 END
 

--- a/dll/cpl/inetcpl/lang/zh-CN.rc
+++ b/dll/cpl/inetcpl/lang/zh-CN.rc
@@ -66,8 +66,10 @@ FONT 9, "宋体"
 CAPTION "删除浏览历史记录"
 BEGIN
 
+    DEFPUSHBUTTON  "取消", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "删除", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "Internet 临时文件\n缓存的网站页面、 图像和证书的副本。",
-                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE
+                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "Cookies\n通过网站在您的计算机上保存文件存储用户首选项和登录信息。",
                     IDC_DELETE_COOKIES, 10, 48, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "历史记录\n您进入的网站的列表。",
@@ -76,8 +78,6 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "密码\n保存在窗口中输入的密码。",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
-    DEFPUSHBUTTON  "取消", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "删除", IDOK, 120, 230, 60, 15, WS_GROUP
 
 END
 

--- a/dll/cpl/inetcpl/lang/zh-TW.rc
+++ b/dll/cpl/inetcpl/lang/zh-TW.rc
@@ -65,8 +65,6 @@ FONT 9, "新細明體"
 CAPTION "刪除瀏覽歷史記錄"
 BEGIN
 
-    DEFPUSHBUTTON  "取消", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "刪除", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "暫時的網際網路檔案\n已快取的網頁、影像和憑證。",
                     IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "Cookie\n由網站儲存於您電腦的檔案，其存有諸如使用者偏好設定和登入資訊。",
@@ -77,6 +75,8 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "密碼\n您曾輸入表單的已儲存密碼。",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
+    DEFPUSHBUTTON  "取消", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "刪除", IDOK, 120, 230, 60, 15
 
 END
 

--- a/dll/cpl/inetcpl/lang/zh-TW.rc
+++ b/dll/cpl/inetcpl/lang/zh-TW.rc
@@ -65,8 +65,10 @@ FONT 9, "新細明體"
 CAPTION "刪除瀏覽歷史記錄"
 BEGIN
 
+    DEFPUSHBUTTON  "取消", IDCANCEL, 185, 230, 60, 15, WS_GROUP
+    PUSHBUTTON     "刪除", IDOK, 120, 230, 60, 15
     AUTOCHECKBOX   "暫時的網際網路檔案\n已快取的網頁、影像和憑證。",
-                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE
+                    IDC_DELETE_TEMP_FILES, 10, 8, 230, 40, BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP
     AUTOCHECKBOX   "Cookie\n由網站儲存於您電腦的檔案，其存有諸如使用者偏好設定和登入資訊。",
                     IDC_DELETE_COOKIES, 10, 48, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "歷程記錄\n您曾存取過的網站清單。",
@@ -75,8 +77,6 @@ BEGIN
                     IDC_DELETE_FORM_DATA, 10, 128, 230, 40, BS_TOP | BS_MULTILINE
     AUTOCHECKBOX   "密碼\n您曾輸入表單的已儲存密碼。",
                     IDC_DELETE_PASSWORDS, 10, 168, 230, 40, BS_TOP | BS_MULTILINE
-    DEFPUSHBUTTON  "取消", IDCANCEL, 185, 230, 60, 15, WS_GROUP
-    PUSHBUTTON     "刪除", IDOK, 120, 230, 60, 15, WS_GROUP
 
 END
 


### PR DESCRIPTION
## Purpose

Fix keyboard navigation in Inet delete browser history menu

JIRA issue: [CORE-19568](https://jira.reactos.org/browse/CORE-19568)

## Proposed changes

- Remove WS_GROUP from IDOK
- Add WS_GROUP to first AUTOCHECKBOX (IDC_DELETE_TEMP_FILES)
- Move buttons above IDC_DELETE_TEMP_FILES so that the cancel button is focused by default when opening the menu
