### PR TITLE
[REGEDIT] Fix unhandled exception when trying to create a key in root

### DIFF
--- a/base/applications/regedit/treeview.c
+++ b/base/applications/regedit/treeview.c
@@ -594,6 +594,8 @@ BOOL CreateNewKey(HWND hwndTV, HTREEITEM hItem)
     HTREEITEM hNewItem;
 
     pszKeyPath = GetItemPath(hwndTV, hItem, &hRootKey);
+    if (pszKeyPath==NULL)
+        return bSuccess;
     if (pszKeyPath[0] == L'\0')
         hKey = hRootKey;
     else if (RegOpenKeyW(hRootKey, pszKeyPath, &hKey) != ERROR_SUCCESS)

--- a/base/applications/regedit/treeview.c
+++ b/base/applications/regedit/treeview.c
@@ -594,7 +594,7 @@ BOOL CreateNewKey(HWND hwndTV, HTREEITEM hItem)
     HTREEITEM hNewItem;
 
     pszKeyPath = GetItemPath(hwndTV, hItem, &hRootKey);
-    if (pszKeyPath==NULL)
+    if (!pszKeyPath)
         return bSuccess;
     if (pszKeyPath[0] == L'\0')
         hKey = hRootKey;


### PR DESCRIPTION
## Purpose

Fix an unhandled exception in regedit treeview.c when attempting to create a key in root/"My computer"

JIRA issue: [CORE-19567](https://jira.reactos.org/browse/CORE-19567)

## Proposed changes

- Check if pszKeyPath is NULL and return bSuccess if so
