### PR TITLE
[NTGDI][FREETYPE] Simplify code around bold/italic glyph caches

### DIFF
--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -4180,6 +4180,13 @@ IntGetRealGlyph(
     }
 
     glyph = Cache->Hashed.Face->glyph;
+
+    if (Cache->Hashed.Aspect.Emu.Bold)
+        FT_GlyphSlot_Embolden(glyph); /* Emulate Bold */
+
+    if (Cache->Hashed.Aspect.Emu.Italic)
+        FT_GlyphSlot_Oblique(glyph); /* Emulate Italic */
+
     realglyph = IntGetBitmapGlyphWithCache(Cache, glyph);
 
     if (!realglyph)

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -88,7 +88,7 @@ static BOOL             g_RenderingEnabled = TRUE;
 #define ASSERT_FREETYPE_LOCK_NOT_HELD() \
     ASSERT(g_FreeTypeLock->Owner != KeGetCurrentThread())
 
-#define MAX_FONT_CACHE 256
+#define MAX_FONT_CACHE 400
 
 static LIST_ENTRY g_FontCacheListHead;
 static UINT g_FontCacheNumEntries;

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -4210,42 +4210,21 @@ IntGetRealGlyph(
 
     ASSERT_FREETYPE_LOCK_HELD();
 
-    if (Cache->Hashed.Aspect.EmuBoldItalic)
+    Cache->dwHash = IntGetHash(&Cache->Hashed, sizeof(Cache->Hashed) / sizeof(DWORD));
+
+    realglyph = IntFindGlyphCache(Cache);
+    if (realglyph)
+        return realglyph;
+
+    error = FT_Load_Glyph(Cache->Hashed.Face, Cache->Hashed.GlyphIndex, FT_LOAD_DEFAULT);
+    if (error)
     {
-        error = FT_Load_Glyph(Cache->Hashed.Face, Cache->Hashed.GlyphIndex, FT_LOAD_NO_BITMAP);
-        if (error)
-        {
-            DPRINT1("WARNING: Failed to load and render glyph! [index: %d]\n",
-                    Cache->Hashed.GlyphIndex);
-            return NULL;
-        }
-
-        glyph = Cache->Hashed.Face->glyph;
-
-        if (Cache->Hashed.Aspect.Emu.Bold)
-            FT_GlyphSlot_Embolden(glyph);
-        if (Cache->Hashed.Aspect.Emu.Italic)
-            FT_GlyphSlot_Oblique(glyph);
-        realglyph = IntGetBitmapGlyphNoCache(Cache->Hashed.Face, glyph, Cache->Hashed.Aspect.RenderMode);
+        DPRINT1("WARNING: Failed to load and render glyph! [index: %d]\n", Cache->Hashed.GlyphIndex);
+        return NULL;
     }
-    else
-    {
-        Cache->dwHash = IntGetHash(&Cache->Hashed, sizeof(Cache->Hashed) / sizeof(DWORD));
 
-        realglyph = IntFindGlyphCache(Cache);
-        if (realglyph)
-            return realglyph;
-
-        error = FT_Load_Glyph(Cache->Hashed.Face, Cache->Hashed.GlyphIndex, FT_LOAD_DEFAULT);
-        if (error)
-        {
-            DPRINT1("WARNING: Failed to load and render glyph! [index: %d]\n", Cache->Hashed.GlyphIndex);
-            return NULL;
-        }
-
-        glyph = Cache->Hashed.Face->glyph;
-        realglyph = IntGetBitmapGlyphWithCache(Cache, glyph);
-    }
+    glyph = Cache->Hashed.Face->glyph;
+    realglyph = IntGetBitmapGlyphWithCache(Cache, glyph);
 
     if (!realglyph)
         DPRINT1("Failed to render glyph! [index: %d]\n", Cache->Hashed.GlyphIndex);
@@ -4332,12 +4311,6 @@ TextIntGetTextExtentPoint(PDC dc,
         if (NULL != Dx)
         {
             Dx[i] = (TotalWidth64 + 32) >> 6;
-        }
-
-        /* Bold and italic do not use the cache */
-        if (Cache.Hashed.Aspect.EmuBoldItalic)
-        {
-            FT_Done_Glyph((FT_Glyph)realglyph);
         }
 
         previous = glyph_index;
@@ -5927,9 +5900,6 @@ IntGetTextDisposition(
             Y64 -= vec.y;
         }
 
-        if (Cache->Hashed.Aspect.EmuBoldItalic)
-            FT_Done_Glyph((FT_Glyph)realglyph);
-
         previous = glyph_index;
     }
 
@@ -6330,8 +6300,6 @@ IntExtTextOutW(
             {
                 DPRINT1("WARNING: EngCreateBitmap() failed!\n");
                 bResult = FALSE;
-                if (Cache.Hashed.Aspect.EmuBoldItalic)
-                    FT_Done_Glyph((FT_Glyph)realglyph);
                 break;
             }
 
@@ -6341,8 +6309,6 @@ IntExtTextOutW(
                 EngDeleteSurface((HSURF)HSourceGlyph);
                 DPRINT1("WARNING: EngLockSurface() failed!\n");
                 bResult = FALSE;
-                if (Cache.Hashed.Aspect.EmuBoldItalic)
-                    FT_Done_Glyph((FT_Glyph)realglyph);
                 break;
             }
 
@@ -6385,11 +6351,7 @@ IntExtTextOutW(
         }
 
         if (DoBreak)
-        {
-            if (Cache.Hashed.Aspect.EmuBoldItalic)
-                FT_Done_Glyph((FT_Glyph)realglyph);
             break;
-        }
 
         if (NULL == Dx)
         {
@@ -6414,11 +6376,6 @@ IntExtTextOutW(
         DPRINT("New X64, New Y64: %I64d, %I64d\n", X64, Y64);
 
         previous = glyph_index;
-
-        if (Cache.Hashed.Aspect.EmuBoldItalic)
-        {
-            FT_Done_Glyph((FT_Glyph)realglyph);
-        }
     }
 
     if (pdcattr->flTextAlign & TA_UPDATECP)

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -3135,50 +3135,6 @@ IntFindGlyphCache(IN const FONT_CACHE_ENTRY *pCache)
     return FontEntry->BitmapGlyph;
 }
 
-/* no cache */
-static FT_BitmapGlyph
-IntGetBitmapGlyphNoCache(
-    FT_Face Face,
-    FT_GlyphSlot GlyphSlot,
-    FT_Render_Mode RenderMode)
-{
-    FT_Glyph Glyph;
-    INT error;
-    FT_Bitmap AlignedBitmap;
-    FT_BitmapGlyph BitmapGlyph;
-
-    ASSERT_FREETYPE_LOCK_HELD();
-
-    error = FT_Get_Glyph(GlyphSlot, &Glyph);
-    if (error)
-    {
-        DPRINT1("Failure getting glyph.\n");
-        return NULL;
-    }
-
-    error = FT_Glyph_To_Bitmap(&Glyph, RenderMode, 0, 1);
-    if (error)
-    {
-        FT_Done_Glyph(Glyph);
-        DPRINT1("Failure rendering glyph.\n");
-        return NULL;
-    }
-
-    BitmapGlyph = (FT_BitmapGlyph)Glyph;
-    FT_Bitmap_New(&AlignedBitmap);
-    if (FT_Bitmap_Convert(GlyphSlot->library, &BitmapGlyph->bitmap, &AlignedBitmap, 4))
-    {
-        DPRINT1("Conversion failed\n");
-        FT_Done_Glyph((FT_Glyph)BitmapGlyph);
-        return NULL;
-    }
-
-    FT_Bitmap_Done(GlyphSlot->library, &BitmapGlyph->bitmap);
-    BitmapGlyph->bitmap = AlignedBitmap;
-
-    return BitmapGlyph;
-}
-
 static FT_BitmapGlyph
 IntGetBitmapGlyphWithCache(
     IN OUT PFONT_CACHE_ENTRY Cache,

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -88,7 +88,7 @@ static BOOL             g_RenderingEnabled = TRUE;
 #define ASSERT_FREETYPE_LOCK_NOT_HELD() \
     ASSERT(g_FreeTypeLock->Owner != KeGetCurrentThread())
 
-#define MAX_FONT_CACHE 400
+#define MAX_FONT_CACHE 256
 
 static LIST_ENTRY g_FontCacheListHead;
 static UINT g_FontCacheNumEntries;


### PR DESCRIPTION
## Purpose
Simplify and reduce font code.
JIRA issue: [CORE-15554](https://jira.reactos.org/browse/CORE-15554)

## Proposed changes

- Don't treat bold/italic glyphs specially in font cache.
- Delete useless `IntGetBitmapGlyphNoCache` function.

## TODO

- [x] Do small tests.
- [x] Do big tests.
