### PR TITLE
[NTGDI][FREETYPE] Increase STACK_TEXT_BUFFER_SIZE

### DIFF
--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -6492,7 +6492,8 @@ GreExtTextOutW(
     return bResult;
 }
 
-#define STACK_TEXT_BUFFER_SIZE 100
+#define STACK_TEXT_BUFFER_SIZE 512
+
 BOOL
 APIENTRY
 NtGdiExtTextOutW(
@@ -6534,7 +6535,7 @@ NtGdiExtTextOutW(
         }
 
         /* Check if our local buffer is large enough */
-        if (BufSize > STACK_TEXT_BUFFER_SIZE)
+        if (BufSize > sizeof(LocalBuffer))
         {
             /* It's not, allocate a temp buffer */
             Buffer = ExAllocatePoolWithTag(PagedPool, BufSize, GDITAG_TEXT);


### PR DESCRIPTION
## Purpose

Slight performance improvement.
`STACK_TEXT_BUFFER_SIZE = 100` was too small for long text.
This PR can reduce unnecessary buffer allocations in `NtGdiExtTextOutW` function.

JIRA issue: [CORE-15554](https://jira.reactos.org/browse/CORE-15554)

## Proposed changes

- Change `STACK_TEXT_BUFFER_SIZE` to `512`.

## TODO

- [x] Do small tests.
- [x] Do big tests.