### PR TITLE
[RTL] Sync actctx.c to wine-5.18

### DIFF
--- a/dll/ntdll/def/ntdll.spec
+++ b/dll/ntdll/def/ntdll.spec
@@ -1066,7 +1066,7 @@
 @ stub -version=0x600+ RtlProcessFlsData
 @ stdcall RtlProtectHeap(ptr long)
 @ stdcall RtlPushFrame(ptr)
-@ stub -version=0x600+ RtlQueryActivationContextApplicationSettings
+@ stdcall -version=0x600+ RtlQueryActivationContextApplicationSettings(long ptr wstr wstr ptr ptr ptr)
 @ stdcall RtlQueryAtomInAtomTable(ptr long ptr ptr ptr ptr)
 @ stub -version=0x600+ RtlQueryCriticalSectionOwner
 @ stdcall RtlQueryDepthSList(ptr)

--- a/dll/shellext/shellbtrfs/reactos.cpp
+++ b/dll/shellext/shellbtrfs/reactos.cpp
@@ -9,6 +9,7 @@
 #include "shellext.h"
 #include <initguid.h>
 #include <ntddstor.h>
+#define RtlUTF8ToUnicodeN RtlUTF8ToUnicodeN_
 #include <ndk/rtlfuncs.h>
 
 #ifdef __cplusplus

--- a/media/doc/WINESYNC.txt
+++ b/media/doc/WINESYNC.txt
@@ -263,9 +263,9 @@ check Wine current sources first as it may already be fixed.
 
 sdk/lib/3rdparty/strmbase           # Synced to WineStaging-3.3
 
-sdk/lib/rtl/actctx.c                # Partly synced with WineStaging-1.9.16
-sdk/lib/rtl/timerqueue.c            # Partly synced with WineStaging-1.7.55
-sdk/lib/rtl/wait.c                  # Partly synced with WineStaging-1.7.55
+sdk/lib/rtl/actctx.c                # Synced to wine-5.18
+sdk/lib/rtl/timerqueue.c            # Synced to wine-5.18
+sdk/lib/rtl/wait.c                  # Synced to wine-5.18
 
 advapi32 -
   dll/win32/advapi32/wine/cred.c         # Synced to WineStaging-3.3

--- a/sdk/include/ndk/rtlfuncs.h
+++ b/sdk/include/ndk/rtlfuncs.h
@@ -210,6 +210,18 @@ RtlConvertUlongToLuid(
     return TempLuid;
 }
 
+_Must_inspect_result_
+NTSYSAPI
+NTSTATUS
+NTAPI
+RtlUTF8ToUnicodeN(
+    _Out_writes_bytes_to_(UnicodeStringMaxByteCount, *UnicodeStringActualByteCount)
+        PWSTR UnicodeStringDestination,
+    _In_ ULONG UnicodeStringMaxByteCount,
+    _Out_ PULONG UnicodeStringActualByteCount,
+    _In_reads_bytes_(UTF8StringByteCount) PCCH UTF8StringSource,
+    _In_ ULONG UTF8StringByteCount);
+
 //
 // ASSERT Macros
 //

--- a/sdk/lib/rtl/actctx.c
+++ b/sdk/lib/rtl/actctx.c
@@ -5983,7 +5983,7 @@ NTSTATUS WINAPI RtlQueryActivationContextApplicationSettings( DWORD flags, HANDL
                                                               const WCHAR *settings, WCHAR *buffer,
                                                               SIZE_T size, SIZE_T *written )
 {
-    ACTIVATION_CONTEXT *actctx = check_actctx( handle );
+    ACTIVATION_CONTEXT *actctx;
     const WCHAR *res;
 
     if (flags)

--- a/sdk/lib/rtl/actctx.c
+++ b/sdk/lib/rtl/actctx.c
@@ -856,7 +856,7 @@ static WCHAR *xmlstrdupW(const xmlstr_t* str)
 
 static inline BOOL xmlstr_cmp(const xmlstr_t* xmlstr, const WCHAR *str)
 {
-    return !strncmpW(xmlstr->ptr, str, xmlstr->len) && !str[xmlstr->len];
+    return !wcsncmp(xmlstr->ptr, str, xmlstr->len) && !str[xmlstr->len];
 }
 
 static inline BOOL xmlstr_cmpi(const xmlstr_t* xmlstr, const WCHAR *str)
@@ -1701,7 +1701,7 @@ static OLEMISC get_olemisc_value(const WCHAR *str, int len)
 
         n = (min+max)/2;
 
-        c = strncmpW(olemisc_values[n].name, str, len);
+        c = wcsncmp(olemisc_values[n].name, str, len);
         if (!c && !olemisc_values[n].name[len])
             return olemisc_values[n].value;
 

--- a/sdk/lib/rtl/actctx.c
+++ b/sdk/lib/rtl/actctx.c
@@ -2327,7 +2327,11 @@ static void parse_dependent_assembly_elem( xmlbuf_t *xmlbuf, struct actctx_loade
         {
             parse_assembly_identity_elem(xmlbuf, acl->actctx, &ai, &elem);
             /* store the newly found identity for later loading */
-            if (ai.arch && !wcscmp(ai.arch, wildcardW)) ai.arch = strdupW( current_archW );
+            if (ai.arch && !wcscmp(ai.arch, wildcardW))
+            {
+                RtlFreeHeap( GetProcessHeap(), 0, ai.arch );
+                ai.arch = strdupW( current_archW );
+            }
             if (!add_dependent_assembly_id(acl, &ai)) set_error( xmlbuf );
         }
         else if (xml_elem_cmp(&elem, bindingRedirectW, asmv1W))

--- a/sdk/lib/rtl/actctx.c
+++ b/sdk/lib/rtl/actctx.c
@@ -1524,9 +1524,11 @@ static BOOL parse_xml_header(xmlbuf_t* xmlbuf)
 
 static BOOL parse_text_content(xmlbuf_t* xmlbuf, xmlstr_t* content)
 {
-    const WCHAR *ptr = memchrW(xmlbuf->ptr, '<', xmlbuf->end - xmlbuf->ptr);
+    const WCHAR *ptr;
 
-    if (!ptr) return FALSE;
+    if (xmlbuf->error) return FALSE;
+
+    if (!(ptr = memchrW(xmlbuf->ptr, '<', xmlbuf->end - xmlbuf->ptr))) return set_error( xmlbuf );
 
     content->ptr = xmlbuf->ptr;
     content->len = ptr - xmlbuf->ptr;

--- a/sdk/lib/rtl/actctx.c
+++ b/sdk/lib/rtl/actctx.c
@@ -3264,7 +3264,7 @@ static WCHAR *lookup_manifest_file( HANDLE dir, struct assembly_identity *ai )
             tmp = strchrW(tmp, '_') + 1;
             tmp = strchrW(tmp, '_') + 1;
             if (dir_info->FileNameLength - (tmp - dir_info->FileName) * sizeof(WCHAR) == sizeof(wine_trailerW) &&
-                !memicmpW( tmp, wine_trailerW, ARRAY_SIZE( wine_trailerW )))
+                !strncmpiW( tmp, wine_trailerW, ARRAY_SIZE( wine_trailerW )))
             {
                 /* prefer a non-Wine manifest if we already have one */
                 /* we'll still load the builtin dll if specified through DllOverrides */

--- a/sdk/lib/rtl/actctx.c
+++ b/sdk/lib/rtl/actctx.c
@@ -9,7 +9,7 @@
  *                  Jacek Caban for CodeWeavers
  *                  Alexandre Julliard
  *                  Stefan Ginsberg (stefan.ginsberg@reactos.org)
- *                  Samuel Serapión
+ *                  Samuel SerapiÃ³n
  */
 
 /* Based on Wine 3.2-37c98396 */
@@ -34,6 +34,7 @@
 #define FileEndOfFileInformation FileStandardInformation
 #define RELATIVE_PATH RtlPathTypeRelative
 #define user_shared_data SharedUserData
+#define ARRAY_SIZE(a) (sizeof(a)/sizeof((a)[0]))
 
 #undef RT_MANIFEST
 #undef CREATEPROCESS_MANIFEST_RESOURCE_ID
@@ -1666,7 +1667,7 @@ static OLEMISC get_olemisc_value(const WCHAR *str, int len)
     int min, max;
 
     min = 0;
-    max = sizeof(olemisc_values)/sizeof(struct olemisc_entry) - 1;
+    max = ARRAY_SIZE(olemisc_values) - 1;
 
     while (min <= max)
     {
@@ -3263,7 +3264,7 @@ static WCHAR *lookup_manifest_file( HANDLE dir, struct assembly_identity *ai )
             tmp = strchrW(tmp, '_') + 1;
             tmp = strchrW(tmp, '_') + 1;
             if (dir_info->FileNameLength - (tmp - dir_info->FileName) * sizeof(WCHAR) == sizeof(wine_trailerW) &&
-                !memicmpW( tmp, wine_trailerW, sizeof(wine_trailerW) / sizeof(WCHAR) ))
+                !memicmpW( tmp, wine_trailerW, ARRAY_SIZE( wine_trailerW )))
             {
                 /* prefer a non-Wine manifest if we already have one */
                 /* we'll still load the builtin dll if specified through DllOverrides */

--- a/sdk/lib/rtl/actctx.c
+++ b/sdk/lib/rtl/actctx.c
@@ -1060,6 +1060,7 @@ static void free_entity_array(struct entity_array *array)
         case ACTIVATION_CONTEXT_SECTION_APPLICATION_SETTINGS:
             RtlFreeHeap(GetProcessHeap(), 0, entity->u.settings.name);
             RtlFreeHeap(GetProcessHeap(), 0, entity->u.settings.value);
+            RtlFreeHeap(GetProcessHeap(), 0, entity->u.settings.ns);
             break;
         default:
             FIXME("Unknown entity kind %d\n", entity->kind);
@@ -5115,7 +5116,7 @@ static NTSTATUS find_guid(ACTIVATION_CONTEXT* actctx, ULONG section_kind,
     return STATUS_SUCCESS;
 }
 
-static const WCHAR *find_app_settings( ACTIVATION_CONTEXT *actctx, const WCHAR *settings )
+static const WCHAR *find_app_settings( ACTIVATION_CONTEXT *actctx, const WCHAR *settings, const WCHAR *ns )
 {
     unsigned int i, j;
 
@@ -5126,7 +5127,8 @@ static const WCHAR *find_app_settings( ACTIVATION_CONTEXT *actctx, const WCHAR *
         {
             struct entity *entity = &assembly->entities.base[j];
             if (entity->kind == ACTIVATION_CONTEXT_SECTION_APPLICATION_SETTINGS &&
-                !strcmpW( entity->u.settings.name, settings ))
+                !strcmpW( entity->u.settings.name, settings ) &&
+                !strcmpW( entity->u.settings.ns, ns ))
                 return entity->u.settings.value;
         }
     }
@@ -5979,7 +5981,6 @@ NTSTATUS WINAPI RtlQueryActivationContextApplicationSettings( DWORD flags, HANDL
                                                               const WCHAR *settings, WCHAR *buffer,
                                                               SIZE_T size, SIZE_T *written )
 {
-    static const WCHAR namespaceW[] = {'h','t','t','p',':','/','/','s','c','h','e','m','a','s','.','m','i','c','r','o','s','o','f','t','.','c','o','m','/','S','M','I','/','2','0',0};
     ACTIVATION_CONTEXT *actctx = check_actctx( handle );
     const WCHAR *res;
 
@@ -5989,16 +5990,20 @@ NTSTATUS WINAPI RtlQueryActivationContextApplicationSettings( DWORD flags, HANDL
         return STATUS_INVALID_PARAMETER;
     }
 
-    if (ns && strncmpW( ns, namespaceW, strlenW(namespaceW) ))
+    if (ns)
     {
-        WARN( "unknown namespace %S\n", ns );
-        return STATUS_INVALID_PARAMETER;
+        if (strcmpW( ns, windowsSettings2005NSW ) &&
+            strcmpW( ns, windowsSettings2011NSW ) &&
+            strcmpW( ns, windowsSettings2016NSW ) &&
+            strcmpW( ns, windowsSettings2017NSW ))
+            return STATUS_INVALID_PARAMETER;
     }
+    else ns = windowsSettings2005NSW;
 
     if (!handle) handle = process_actctx;
     if (!(actctx = check_actctx( handle ))) return STATUS_INVALID_PARAMETER;
 
-    if (!(res = find_app_settings( actctx, settings ))) return STATUS_SXS_KEY_NOT_FOUND;
+    if (!(res = find_app_settings( actctx, settings, ns ))) return STATUS_SXS_KEY_NOT_FOUND;
 
     if (written) *written = strlenW(res) + 1;
     if (size < strlenW(res)) return STATUS_BUFFER_TOO_SMALL;

--- a/sdk/lib/rtl/actctx.c
+++ b/sdk/lib/rtl/actctx.c
@@ -1057,6 +1057,10 @@ static void free_entity_array(struct entity_array *array)
             RtlFreeHeap(GetProcessHeap(), 0, entity->u.clrsurrogate.clsid);
             RtlFreeHeap(GetProcessHeap(), 0, entity->u.clrsurrogate.version);
             break;
+        case ACTIVATION_CONTEXT_SECTION_APPLICATION_SETTINGS:
+            RtlFreeHeap(GetProcessHeap(), 0, entity->u.settings.name);
+            RtlFreeHeap(GetProcessHeap(), 0, entity->u.settings.value);
+            break;
         default:
             FIXME("Unknown entity kind %d\n", entity->kind);
         }

--- a/sdk/lib/rtl/actctx.c
+++ b/sdk/lib/rtl/actctx.c
@@ -1554,7 +1554,8 @@ static BOOL parse_text_content(xmlbuf_t* xmlbuf, xmlstr_t* content)
 
     if (xmlbuf->error) return FALSE;
 
-    if (!(ptr = memchrW(xmlbuf->ptr, '<', xmlbuf->end - xmlbuf->ptr))) return set_error( xmlbuf );
+    for (ptr = xmlbuf->ptr; ptr < xmlbuf->end; ptr++) if (*ptr == '<') break;
+    if (ptr == xmlbuf->end) return set_error( xmlbuf );
 
     content->ptr = xmlbuf->ptr;
     content->len = ptr - xmlbuf->ptr;

--- a/sdk/lib/rtl/actctx.c
+++ b/sdk/lib/rtl/actctx.c
@@ -3427,7 +3427,8 @@ static NTSTATUS lookup_assembly(struct actctx_loader* acl,
                 status = get_manifest_in_pe_file( acl, ai, nameW.Buffer, directory, FALSE, file,
                                                   (LPCWSTR)CREATEPROCESS_MANIFEST_RESOURCE_ID, 0 );
                 NtClose( file );
-                break;
+                if (status == STATUS_SUCCESS)
+                    break;
             }
             RtlFreeUnicodeString( &nameW );
         }

--- a/sdk/lib/rtl/actctx.c
+++ b/sdk/lib/rtl/actctx.c
@@ -1946,6 +1946,9 @@ static void parse_cominterface_proxy_stub_elem( xmlbuf_t *xmlbuf, struct dll_red
         else if (xml_attr_cmp(&attr, threadingmodelW))
         {
         }
+        else if (!is_xmlns_attr( &attr ))
+        {
+        }
     }
 
     acl->actctx->sections |= IFACEREDIRECT_SECTION;

--- a/sdk/lib/rtl/actctx.c
+++ b/sdk/lib/rtl/actctx.c
@@ -3219,13 +3219,13 @@ static WCHAR *lookup_manifest_file( HANDLE dir, struct assembly_identity *ai )
     unsigned int data_pos = 0, data_len;
     char buffer[8192];
 
+    if (!lang || !strcmpiW( lang, neutralW )) lang = wildcardW;
+
     if (!(lookup = RtlAllocateHeap( GetProcessHeap(), 0,
                                     (strlenW(ai->arch) + strlenW(ai->name)
-                                     + strlenW(ai->public_key) + 20) * sizeof(WCHAR)
+                                     + strlenW(ai->public_key) + strlenW(lang) + 20) * sizeof(WCHAR)
                                     + sizeof(lookup_fmtW) )))
         return NULL;
-
-    if (!lang || !strcmpiW( lang, neutralW )) lang = wildcardW;
     sprintfW( lookup, lookup_fmtW, ai->arch, ai->name, ai->public_key,
               ai->version.major, ai->version.minor, lang );
     RtlInitUnicodeString( &lookup_us, lookup );

--- a/sdk/lib/rtl/actctx.c
+++ b/sdk/lib/rtl/actctx.c
@@ -1110,7 +1110,7 @@ static BOOL is_matching_identity( const struct assembly_identity *id1,
 
     if (id1->language && id2->language && !is_matching_string( id1->language, id2->language ))
     {
-        if (strcmpW( wildcardW, id1->language ) && strcmpW( wildcardW, id2->language ))
+        if (wcscmp( wildcardW, id1->language ) && wcscmp( wildcardW, id2->language ))
             return FALSE;
     }
     if (id1->version.major != id2->version.major) return FALSE;
@@ -5137,8 +5137,8 @@ static const WCHAR *find_app_settings( ACTIVATION_CONTEXT *actctx, const WCHAR *
         {
             struct entity *entity = &assembly->entities.base[j];
             if (entity->kind == ACTIVATION_CONTEXT_SECTION_APPLICATION_SETTINGS &&
-                !strcmpW( entity->u.settings.name, settings ) &&
-                !strcmpW( entity->u.settings.ns, ns ))
+                !wcscmp( entity->u.settings.name, settings ) &&
+                !wcscmp( entity->u.settings.ns, ns ))
                 return entity->u.settings.value;
         }
     }
@@ -6008,10 +6008,10 @@ NTSTATUS WINAPI RtlQueryActivationContextApplicationSettings( DWORD flags, HANDL
 
     if (ns)
     {
-        if (strcmpW( ns, windowsSettings2005NSW ) &&
-            strcmpW( ns, windowsSettings2011NSW ) &&
-            strcmpW( ns, windowsSettings2016NSW ) &&
-            strcmpW( ns, windowsSettings2017NSW ))
+        if (wcscmp( ns, windowsSettings2005NSW ) &&
+            wcscmp( ns, windowsSettings2011NSW ) &&
+            wcscmp( ns, windowsSettings2016NSW ) &&
+            wcscmp( ns, windowsSettings2017NSW ))
             return STATUS_INVALID_PARAMETER;
     }
     else ns = windowsSettings2005NSW;

--- a/sdk/lib/rtl/actctx.c
+++ b/sdk/lib/rtl/actctx.c
@@ -3357,7 +3357,7 @@ static NTSTATUS lookup_winsxs(struct actctx_loader* acl, struct assembly_identit
     path[path_us.Length/sizeof(WCHAR)] = '\\';
     wcscpy( path + path_us.Length/sizeof(WCHAR) + 1, file );
     RtlInitUnicodeString( &path_us, path );
-    *strrchrW(file, '.') = 0;  /* remove .manifest extension */
+    *wcsrchr(file, '.') = 0;  /* remove .manifest extension */
 
     if (!open_nt_file( &handle, &path_us ))
     {
@@ -5250,7 +5250,7 @@ RtlCreateActivationContext(IN ULONG Flags,
 
         status = get_module_filename( module, &dir, 0 );
         if (!NT_SUCCESS(status)) goto error;
-        if ((p = strrchrW( dir.Buffer, '\\' ))) p[1] = 0;
+        if ((p = wcsrchr( dir.Buffer, '\\' ))) p[1] = 0;
         actctx->appdir.info = dir.Buffer;
     }
 

--- a/sdk/lib/rtl/actctx.c
+++ b/sdk/lib/rtl/actctx.c
@@ -2867,22 +2867,19 @@ static NTSTATUS parse_manifest( struct actctx_loader* acl, struct assembly_ident
     }
     else
     {
-        /* TODO: this doesn't handle arbitrary encodings */
+        DWORD len;
         WCHAR *new_buff;
-        ULONG sizeU;
 
-        status = RtlMultiByteToUnicodeSize(&sizeU, buffer, size);
+        /* let's assume utf-8 for now */
+        status = RtlUTF8ToUnicodeN( NULL, 0, &len, buffer, size );
         if (!NT_SUCCESS(status))
         {
             DPRINT1("RtlMultiByteToUnicodeSize failed with %lx\n", status);
             return STATUS_SXS_CANT_GEN_ACTCTX;
         }
 
-        new_buff = RtlAllocateHeap(GetProcessHeap(), 0, sizeU);
-        if (!new_buff)
-            return STATUS_NO_MEMORY;
-
-        status = RtlMultiByteToUnicodeN(new_buff, sizeU, &sizeU, buffer, size);
+        if (!(new_buff = RtlAllocateHeap( GetProcessHeap(), 0, len ))) return STATUS_NO_MEMORY;
+        status = RtlUTF8ToUnicodeN( new_buff, len, &len, buffer, size );
         if (!NT_SUCCESS(status))
         {
             DPRINT1("RtlMultiByteToUnicodeN failed with %lx\n", status);
@@ -2890,7 +2887,7 @@ static NTSTATUS parse_manifest( struct actctx_loader* acl, struct assembly_ident
         }
 
         xmlbuf.ptr = new_buff;
-        xmlbuf.end = xmlbuf.ptr + sizeU / sizeof(WCHAR);
+        xmlbuf.end = xmlbuf.ptr + len / sizeof(WCHAR);
         status = parse_manifest_buffer( acl, assembly, ai, &xmlbuf );
         RtlFreeHeap( GetProcessHeap(), 0, new_buff );
     }

--- a/sdk/lib/rtl/actctx.c
+++ b/sdk/lib/rtl/actctx.c
@@ -3223,7 +3223,7 @@ static WCHAR *lookup_manifest_file( HANDLE dir, struct assembly_identity *ai )
     unsigned int data_pos = 0, data_len;
     char buffer[8192];
 
-    if (!lang || !strcmpiW( lang, neutralW )) lang = wildcardW;
+    if (!lang || !wcsicmp( lang, neutralW )) lang = wildcardW;
 
     if (!(lookup = RtlAllocateHeap( GetProcessHeap(), 0,
                                     (strlenW(ai->arch) + strlenW(ai->name)

--- a/sdk/lib/rtl/actctx.c
+++ b/sdk/lib/rtl/actctx.c
@@ -839,7 +839,7 @@ static WCHAR *strdupW(const WCHAR* str)
 
     if (!(ptr = RtlAllocateHeap(GetProcessHeap(), 0, (strlenW(str) + 1) * sizeof(WCHAR))))
         return NULL;
-    return strcpyW(ptr, str);
+    return wcscpy(ptr, str);
 }
 
 static WCHAR *xmlstrdupW(const xmlstr_t* str)
@@ -1194,7 +1194,7 @@ static WCHAR *build_assembly_dir(struct assembly_identity* ai)
 
     if (!(ret = RtlAllocateHeap( GetProcessHeap(), 0, size ))) return NULL;
 
-    strcpyW( ret, arch );
+    wcscpy( ret, arch );
     strcatW( ret, undW );
     strcatW( ret, name );
     strcatW( ret, undW );
@@ -1217,7 +1217,7 @@ static inline void append_string( WCHAR *buffer, const WCHAR *prefix, const WCHA
     strcatW( buffer, prefix );
     p += strlenW(p);
     *p++ = '"';
-    strcpyW( p, str );
+    wcscpy( p, str );
     p += strlenW(p);
     *p++ = '"';
     *p = 0;
@@ -1248,7 +1248,7 @@ static WCHAR *build_assembly_id( const struct assembly_identity *ai )
     if (!(ret = RtlAllocateHeap( GetProcessHeap(), 0, (size + 1) * sizeof(WCHAR) )))
         return NULL;
 
-    if (ai->name) strcpyW( ret, ai->name );
+    if (ai->name) wcscpy( ret, ai->name );
     else *ret = 0;
     append_string( ret, archW, ai->arch );
     append_string( ret, public_keyW, ai->public_key );
@@ -3196,7 +3196,7 @@ static NTSTATUS get_manifest_in_associated_manifest( struct actctx_loader* acl, 
         if (!(buffer = RtlAllocateHeap( GetProcessHeap(), 0,
                                         (strlenW(filename) + 10) * sizeof(WCHAR) + sizeof(dotManifestW) )))
             return STATUS_NO_MEMORY;
-        strcpyW( buffer, filename );
+        wcscpy( buffer, filename );
         if (resid != 1) NTDLL_swprintf( buffer + strlenW(buffer), fmtW, resid );
         strcatW( buffer, dotManifestW );
         RtlInitUnicodeString( &nameW, buffer );
@@ -3315,7 +3315,7 @@ static NTSTATUS lookup_winsxs(struct actctx_loader* acl, struct assembly_identit
                                   strlenW(user_shared_data->NtSystemRoot) * sizeof(WCHAR) )))
         return STATUS_NO_MEMORY;
 
-    strcpyW( path, user_shared_data->NtSystemRoot );
+    wcscpy( path, user_shared_data->NtSystemRoot );
     memcpy( path + strlenW(path), manifest_dirW, sizeof(manifest_dirW) );
 
     if (!RtlDosPathNameToNtPathName_U( path, &path_us, NULL, NULL ))
@@ -3355,7 +3355,7 @@ static NTSTATUS lookup_winsxs(struct actctx_loader* acl, struct assembly_identit
     }
 
     path[path_us.Length/sizeof(WCHAR)] = '\\';
-    strcpyW( path + path_us.Length/sizeof(WCHAR) + 1, file );
+    wcscpy( path + path_us.Length/sizeof(WCHAR) + 1, file );
     RtlInitUnicodeString( &path_us, path );
     *strrchrW(file, '.') = 0;  /* remove .manifest extension */
 
@@ -3411,7 +3411,7 @@ static NTSTATUS lookup_assembly(struct actctx_loader* acl,
      * First 'appdir' is used as <dir>, if that failed
      * it tries application manifest file path.
      */
-    strcpyW( buffer, acl->actctx->appdir.info );
+    wcscpy( buffer, acl->actctx->appdir.info );
     p = buffer + strlenW(buffer);
     for (i = 0; i < 4; i++)
     {
@@ -3422,10 +3422,10 @@ static NTSTATUS lookup_assembly(struct actctx_loader* acl,
         }
         else *p++ = '\\';
 
-        strcpyW( p, ai->name );
+        wcscpy( p, ai->name );
         p += strlenW(p);
 
-        strcpyW( p, dotDllW );
+        wcscpy( p, dotDllW );
         if (RtlDosPathNameToNtPathName_U( buffer, &nameW, NULL, NULL ))
         {
             status = open_nt_file( &file, &nameW );
@@ -3440,7 +3440,7 @@ static NTSTATUS lookup_assembly(struct actctx_loader* acl,
             RtlFreeUnicodeString( &nameW );
         }
 
-        strcpyW( p, dotManifestW );
+        wcscpy( p, dotManifestW );
         if (RtlDosPathNameToNtPathName_U( buffer, &nameW, NULL, NULL ))
         {
             status = open_nt_file( &file, &nameW );
@@ -6023,7 +6023,7 @@ NTSTATUS WINAPI RtlQueryActivationContextApplicationSettings( DWORD flags, HANDL
 
     if (written) *written = strlenW(res) + 1;
     if (size < strlenW(res)) return STATUS_BUFFER_TOO_SMALL;
-    strcpyW( buffer, res );
+    wcscpy( buffer, res );
     return STATUS_SUCCESS;
 }
 

--- a/sdk/lib/rtl/actctx.c
+++ b/sdk/lib/rtl/actctx.c
@@ -837,7 +837,7 @@ static WCHAR *strdupW(const WCHAR* str)
 {
     WCHAR*      ptr;
 
-    if (!(ptr = RtlAllocateHeap(GetProcessHeap(), 0, (strlenW(str) + 1) * sizeof(WCHAR))))
+    if (!(ptr = RtlAllocateHeap(GetProcessHeap(), 0, (wcslen(str) + 1) * sizeof(WCHAR))))
         return NULL;
     return wcscpy(ptr, str);
 }
@@ -1098,7 +1098,7 @@ static void free_entity_array(struct entity_array *array)
 static BOOL is_matching_string( const WCHAR *str1, const WCHAR *str2 )
 {
     if (!str1) return !str2;
-    return str2 && !RtlCompareUnicodeStrings( str1, strlenW(str1), str2, strlenW(str2), TRUE );
+    return str2 && !RtlCompareUnicodeStrings( str1, wcslen(str1), str2, wcslen(str2), TRUE );
 }
 
 static BOOL is_matching_identity( const struct assembly_identity *id1,
@@ -1188,8 +1188,8 @@ static WCHAR *build_assembly_dir(struct assembly_identity* ai)
     const WCHAR *key = ai->public_key ? ai->public_key : noneW;
     const WCHAR *lang = ai->language ? ai->language : noneW;
     const WCHAR *name = ai->name ? ai->name : noneW;
-    SIZE_T size = (strlenW(arch) + 1 + strlenW(name) + 1 + strlenW(key) + 24 + 1 +
-		    strlenW(lang) + 1) * sizeof(WCHAR) + sizeof(mskeyW);
+    SIZE_T size = (wcslen(arch) + 1 + wcslen(name) + 1 + wcslen(key) + 24 + 1 +
+		    wcslen(lang) + 1) * sizeof(WCHAR) + sizeof(mskeyW);
     WCHAR *ret;
 
     if (!(ret = RtlAllocateHeap( GetProcessHeap(), 0, size ))) return NULL;
@@ -1200,7 +1200,7 @@ static WCHAR *build_assembly_dir(struct assembly_identity* ai)
     wcscat( ret, undW );
     wcscat( ret, key );
     wcscat( ret, undW );
-    NTDLL_swprintf( ret + strlenW(ret), version_formatW,
+    NTDLL_swprintf( ret + wcslen(ret), version_formatW,
               ai->version.major, ai->version.minor, ai->version.build, ai->version.revision );
     wcscat( ret, undW );
     wcscat( ret, lang );
@@ -1215,10 +1215,10 @@ static inline void append_string( WCHAR *buffer, const WCHAR *prefix, const WCHA
 
     if (!str) return;
     wcscat( buffer, prefix );
-    p += strlenW(p);
+    p += wcslen(p);
     *p++ = '"';
     wcscpy( p, str );
-    p += strlenW(p);
+    p += wcslen(p);
     *p++ = '"';
     *p = 0;
 }
@@ -1239,11 +1239,11 @@ static WCHAR *build_assembly_id( const struct assembly_identity *ai )
 
     NTDLL_swprintf( version, version_formatW,
               ai->version.major, ai->version.minor, ai->version.build, ai->version.revision );
-    if (ai->name) size += strlenW(ai->name) * sizeof(WCHAR);
-    if (ai->arch) size += strlenW(archW) + strlenW(ai->arch) + 2;
-    if (ai->public_key) size += strlenW(public_keyW) + strlenW(ai->public_key) + 2;
-    if (ai->type) size += strlenW(typeW2) + strlenW(ai->type) + 2;
-    size += strlenW(versionW2) + strlenW(version) + 2;
+    if (ai->name) size += wcslen(ai->name) * sizeof(WCHAR);
+    if (ai->arch) size += wcslen(archW) + wcslen(ai->arch) + 2;
+    if (ai->public_key) size += wcslen(public_keyW) + wcslen(ai->public_key) + 2;
+    if (ai->type) size += wcslen(typeW2) + wcslen(ai->type) + 2;
+    size += wcslen(versionW2) + wcslen(version) + 2;
 
     if (!(ret = RtlAllocateHeap( GetProcessHeap(), 0, (size + 1) * sizeof(WCHAR) )))
         return NULL;
@@ -3183,7 +3183,7 @@ static NTSTATUS get_manifest_in_associated_manifest( struct actctx_loader* acl, 
 
         if (!(status = get_module_filename( module, &name, sizeof(dotManifestW) + 10*sizeof(WCHAR) )))
         {
-            if (resid != 1) NTDLL_swprintf( name.Buffer + strlenW(name.Buffer), fmtW, resid );
+            if (resid != 1) NTDLL_swprintf( name.Buffer + wcslen(name.Buffer), fmtW, resid );
             wcscat( name.Buffer, dotManifestW );
             if (!RtlDosPathNameToNtPathName_U( name.Buffer, &nameW, NULL, NULL ))
                 status = STATUS_RESOURCE_DATA_NOT_FOUND;
@@ -3194,10 +3194,10 @@ static NTSTATUS get_manifest_in_associated_manifest( struct actctx_loader* acl, 
     else
     {
         if (!(buffer = RtlAllocateHeap( GetProcessHeap(), 0,
-                                        (strlenW(filename) + 10) * sizeof(WCHAR) + sizeof(dotManifestW) )))
+                                        (wcslen(filename) + 10) * sizeof(WCHAR) + sizeof(dotManifestW) )))
             return STATUS_NO_MEMORY;
         wcscpy( buffer, filename );
-        if (resid != 1) NTDLL_swprintf( buffer + strlenW(buffer), fmtW, resid );
+        if (resid != 1) NTDLL_swprintf( buffer + wcslen(buffer), fmtW, resid );
         wcscat( buffer, dotManifestW );
         RtlInitUnicodeString( &nameW, buffer );
     }
@@ -3229,8 +3229,8 @@ static WCHAR *lookup_manifest_file( HANDLE dir, struct assembly_identity *ai )
     if (!lang || !wcsicmp( lang, neutralW )) lang = wildcardW;
 
     if (!(lookup = RtlAllocateHeap( GetProcessHeap(), 0,
-                                    (strlenW(ai->arch) + strlenW(ai->name)
-                                     + strlenW(ai->public_key) + strlenW(lang) + 20) * sizeof(WCHAR)
+                                    (wcslen(ai->arch) + wcslen(ai->name)
+                                     + wcslen(ai->public_key) + wcslen(lang) + 20) * sizeof(WCHAR)
                                     + sizeof(lookup_fmtW) )))
         return NULL;
     NTDLL_swprintf( lookup, lookup_fmtW, ai->arch, ai->name, ai->public_key,
@@ -3312,11 +3312,11 @@ static NTSTATUS lookup_winsxs(struct actctx_loader* acl, struct assembly_identit
     if (!ai->arch || !ai->name || !ai->public_key) return STATUS_NO_SUCH_FILE;
 
     if (!(path = RtlAllocateHeap( GetProcessHeap(), 0, sizeof(manifest_dirW) +
-                                  strlenW(user_shared_data->NtSystemRoot) * sizeof(WCHAR) )))
+                                  wcslen(user_shared_data->NtSystemRoot) * sizeof(WCHAR) )))
         return STATUS_NO_MEMORY;
 
     wcscpy( path, user_shared_data->NtSystemRoot );
-    memcpy( path + strlenW(path), manifest_dirW, sizeof(manifest_dirW) );
+    memcpy( path + wcslen(path), manifest_dirW, sizeof(manifest_dirW) );
 
     if (!RtlDosPathNameToNtPathName_U( path, &path_us, NULL, NULL ))
     {
@@ -3347,7 +3347,7 @@ static NTSTATUS lookup_winsxs(struct actctx_loader* acl, struct assembly_identit
 
     /* append file name to directory path */
     if (!(path = RtlReAllocateHeap( GetProcessHeap(), 0, path_us.Buffer,
-                                    path_us.Length + (strlenW(file) + 2) * sizeof(WCHAR) )))
+                                    path_us.Length + (wcslen(file) + 2) * sizeof(WCHAR) )))
     {
         RtlFreeHeap( GetProcessHeap(), 0, file );
         RtlFreeUnicodeString( &path_us );
@@ -3390,11 +3390,11 @@ static NTSTATUS lookup_assembly(struct actctx_loader* acl,
     /* FIXME: add support for language specific lookup */
 
     len = max(RtlGetFullPathName_U(acl->actctx->assemblies->manifest.info, 0, NULL, NULL) / sizeof(WCHAR),
-        strlenW(acl->actctx->appdir.info));
+        wcslen(acl->actctx->appdir.info));
 
     nameW.Buffer = NULL;
     if (!(buffer = RtlAllocateHeap( GetProcessHeap(), 0,
-                                    (len + 2 * strlenW(ai->name) + 2) * sizeof(WCHAR) + sizeof(dotManifestW) )))
+                                    (len + 2 * wcslen(ai->name) + 2) * sizeof(WCHAR) + sizeof(dotManifestW) )))
         return STATUS_NO_MEMORY;
 
     if (!(directory = build_assembly_dir( ai )))
@@ -3412,7 +3412,7 @@ static NTSTATUS lookup_assembly(struct actctx_loader* acl,
      * it tries application manifest file path.
      */
     wcscpy( buffer, acl->actctx->appdir.info );
-    p = buffer + strlenW(buffer);
+    p = buffer + wcslen(buffer);
     for (i = 0; i < 4; i++)
     {
         if (i == 2)
@@ -3423,7 +3423,7 @@ static NTSTATUS lookup_assembly(struct actctx_loader* acl,
         else *p++ = '\\';
 
         wcscpy( p, ai->name );
-        p += strlenW(p);
+        p += wcslen(p);
 
         wcscpy( p, dotDllW );
         if (RtlDosPathNameToNtPathName_U( buffer, &nameW, NULL, NULL ))
@@ -3541,7 +3541,7 @@ static NTSTATUS build_dllredirect_section(ACTIVATION_CONTEXT* actctx, struct str
             /* each entry needs index, data and string data */
             total_len += sizeof(*index);
             total_len += sizeof(*data);
-            total_len += aligned_string_len((strlenW(dll->name)+1)*sizeof(WCHAR));
+            total_len += aligned_string_len((wcslen(dll->name)+1)*sizeof(WCHAR));
 
             DPRINT("assembly %d (%p), dll %d: dll name %S\n", i, assembly, j, dll->name);
         }
@@ -3577,7 +3577,7 @@ static NTSTATUS build_dllredirect_section(ACTIVATION_CONTEXT* actctx, struct str
             DPRINT("%d: dll name %S\n", j, dll->name);
             /* setup new index entry */
             str.Buffer = dll->name;
-            str.Length = strlenW(dll->name)*sizeof(WCHAR);
+            str.Length = wcslen(dll->name)*sizeof(WCHAR);
             str.MaximumLength = str.Length + sizeof(WCHAR);
             /* hash original class name */
             RtlHashUnicodeString(&str, TRUE, HASH_STRING_ALGORITHM_X65599, &index->hash);
@@ -3742,7 +3742,7 @@ static NTSTATUS build_wndclass_section(ACTIVATION_CONTEXT* actctx, struct strsec
                 struct entity *entity = &dll->entities.base[k];
                 if (entity->kind == ACTIVATION_CONTEXT_SECTION_WINDOW_CLASS_REDIRECTION)
                 {
-                    int class_len = strlenW(entity->u.class.name) + 1;
+                    int class_len = wcslen(entity->u.class.name) + 1;
                     int len;
 
                     /* each class entry needs index, data and string data */
@@ -3755,7 +3755,7 @@ static NTSTATUS build_wndclass_section(ACTIVATION_CONTEXT* actctx, struct strsec
                         len = get_assembly_version(assembly, NULL) + class_len + 1 /* '!' separator */;
                     else
                         len = class_len;
-                    len += strlenW(dll->name) + 1;
+                    len += wcslen(dll->name) + 1;
                     total_len += aligned_string_len(len*sizeof(WCHAR));
 
                     class_count++;
@@ -3795,7 +3795,7 @@ static NTSTATUS build_wndclass_section(ACTIVATION_CONTEXT* actctx, struct strsec
 
                     /* setup new index entry */
                     str.Buffer = entity->u.class.name;
-                    str.Length = strlenW(entity->u.class.name)*sizeof(WCHAR);
+                    str.Length = wcslen(entity->u.class.name)*sizeof(WCHAR);
                     str.MaximumLength = str.Length + sizeof(WCHAR);
                     /* hash original class name */
                     RtlHashUnicodeString(&str, TRUE, HASH_STRING_ALGORITHM_X65599, &index->hash);
@@ -3805,7 +3805,7 @@ static NTSTATUS build_wndclass_section(ACTIVATION_CONTEXT* actctx, struct strsec
                         versioned_len = (get_assembly_version(assembly, NULL) + 1)*sizeof(WCHAR) + str.Length;
                     else
                         versioned_len = str.Length;
-                    module_len = strlenW(dll->name)*sizeof(WCHAR);
+                    module_len = wcslen(dll->name)*sizeof(WCHAR);
 
                     index->name_offset = name_offset;
                     index->name_len = str.Length;
@@ -3951,10 +3951,10 @@ static NTSTATUS build_tlib_section(ACTIVATION_CONTEXT* actctx, struct guidsectio
                     total_len += sizeof(*data);
                     /* help string is stored separately */
                     if (*entity->u.typelib.helpdir)
-                        total_len += aligned_string_len((strlenW(entity->u.typelib.helpdir)+1)*sizeof(WCHAR));
+                        total_len += aligned_string_len((wcslen(entity->u.typelib.helpdir)+1)*sizeof(WCHAR));
 
                     /* module names are packed one after another */
-                    names_len += (strlenW(dll->name)+1)*sizeof(WCHAR);
+                    names_len += (wcslen(dll->name)+1)*sizeof(WCHAR);
 
                     tlib_count++;
                 }
@@ -3994,11 +3994,11 @@ static NTSTATUS build_tlib_section(ACTIVATION_CONTEXT* actctx, struct guidsectio
                     NTSTATUS Status;
 
                     if (*entity->u.typelib.helpdir)
-                        help_len = strlenW(entity->u.typelib.helpdir)*sizeof(WCHAR);
+                        help_len = wcslen(entity->u.typelib.helpdir)*sizeof(WCHAR);
                     else
                         help_len = 0;
 
-                    module_len = strlenW(dll->name)*sizeof(WCHAR);
+                    module_len = wcslen(dll->name)*sizeof(WCHAR);
 
                     /* setup new index entry */
                     RtlInitUnicodeString(&str, entity->u.typelib.tlbid);
@@ -4137,11 +4137,11 @@ static void get_comserver_datalen(const struct entity_array *entities, const str
                 unsigned int str_len;
 
                 /* all string data is stored together in aligned block */
-                str_len = strlenW(entity->u.comclass.name)+1;
+                str_len = wcslen(entity->u.comclass.name)+1;
                 if (entity->u.comclass.progid)
-                    str_len += strlenW(entity->u.comclass.progid)+1;
+                    str_len += wcslen(entity->u.comclass.progid)+1;
                 if (entity->u.comclass.version)
-                    str_len += strlenW(entity->u.comclass.version)+1;
+                    str_len += wcslen(entity->u.comclass.version)+1;
 
                 *len += sizeof(struct clrclass_data);
                 *len += aligned_string_len(str_len*sizeof(WCHAR));
@@ -4153,9 +4153,9 @@ static void get_comserver_datalen(const struct entity_array *entities, const str
             {
                 /* progid string is stored separately */
                 if (entity->u.comclass.progid)
-                    *len += aligned_string_len((strlenW(entity->u.comclass.progid)+1)*sizeof(WCHAR));
+                    *len += aligned_string_len((wcslen(entity->u.comclass.progid)+1)*sizeof(WCHAR));
 
-                *module_len += (strlenW(dll->name)+1)*sizeof(WCHAR);
+                *module_len += (wcslen(dll->name)+1)*sizeof(WCHAR);
             }
 
             *count += 1;
@@ -4183,11 +4183,11 @@ static NTSTATUS add_comserver_record(const struct guidsection_header *section, c
             WCHAR *ptrW;
 
             if (entity->u.comclass.progid)
-                progid_len = strlenW(entity->u.comclass.progid)*sizeof(WCHAR);
+                progid_len = wcslen(entity->u.comclass.progid)*sizeof(WCHAR);
             else
                 progid_len = 0;
 
-            module_len = dll ? strlenW(dll->name)*sizeof(WCHAR) : strlenW(mscoreeW)*sizeof(WCHAR);
+            module_len = dll ? wcslen(dll->name)*sizeof(WCHAR) : wcslen(mscoreeW)*sizeof(WCHAR);
 
             /* setup new index entry */
             RtlInitUnicodeString(&str, entity->u.comclass.clsid);
@@ -4259,11 +4259,11 @@ static NTSTATUS add_comserver_record(const struct guidsection_header *section, c
                 clrdata->size = sizeof(*clrdata);
                 clrdata->res[0] = 0;
                 clrdata->res[1] = 2; /* FIXME: unknown field */
-                clrdata->module_len = strlenW(mscoreeW)*sizeof(WCHAR);
+                clrdata->module_len = wcslen(mscoreeW)*sizeof(WCHAR);
                 clrdata->module_offset = *module_offset + data->name_len + sizeof(WCHAR);
-                clrdata->name_len = strlenW(entity->u.comclass.name)*sizeof(WCHAR);
+                clrdata->name_len = wcslen(entity->u.comclass.name)*sizeof(WCHAR);
                 clrdata->name_offset = clrdata->size;
-                clrdata->version_len = entity->u.comclass.version ? strlenW(entity->u.comclass.version)*sizeof(WCHAR) : 0;
+                clrdata->version_len = entity->u.comclass.version ? wcslen(entity->u.comclass.version)*sizeof(WCHAR) : 0;
                 clrdata->version_offset = clrdata->version_len ? clrdata->name_offset + clrdata->name_len + sizeof(WCHAR) : 0;
                 clrdata->res2[0] = 0;
                 clrdata->res2[1] = 0;
@@ -4465,7 +4465,7 @@ static void get_ifaceps_datalen(const struct entity_array *entities, unsigned in
         {
             *len += sizeof(struct guid_index) + sizeof(struct ifacepsredirect_data);
             if (entity->u.ifaceps.name)
-                *len += aligned_string_len((strlenW(entity->u.ifaceps.name)+1)*sizeof(WCHAR));
+                *len += aligned_string_len((wcslen(entity->u.ifaceps.name)+1)*sizeof(WCHAR));
             *count += 1;
         }
     }
@@ -4487,7 +4487,7 @@ static NTSTATUS add_ifaceps_record(struct guidsection_header *section, struct en
             NTSTATUS Status;
 
             if (entity->u.ifaceps.name)
-                name_len = strlenW(entity->u.ifaceps.name)*sizeof(WCHAR);
+                name_len = wcslen(entity->u.ifaceps.name)*sizeof(WCHAR);
             else
                 name_len = 0;
 
@@ -4685,9 +4685,9 @@ static NTSTATUS build_clr_surrogate_section(ACTIVATION_CONTEXT* actctx, struct g
                 ULONG len;
 
                 total_len += sizeof(*index) + sizeof(*data);
-                len = strlenW(entity->u.clrsurrogate.name) + 1;
+                len = wcslen(entity->u.clrsurrogate.name) + 1;
                 if (entity->u.clrsurrogate.version)
-                   len += strlenW(entity->u.clrsurrogate.version) + 1;
+                   len += wcslen(entity->u.clrsurrogate.version) + 1;
                 total_len += aligned_string_len(len*sizeof(WCHAR));
 
                 count++;
@@ -4722,10 +4722,10 @@ static NTSTATUS build_clr_surrogate_section(ACTIVATION_CONTEXT* actctx, struct g
                 NTSTATUS Status;
 
                 if (entity->u.clrsurrogate.version)
-                    version_len = strlenW(entity->u.clrsurrogate.version)*sizeof(WCHAR);
+                    version_len = wcslen(entity->u.clrsurrogate.version)*sizeof(WCHAR);
                 else
                     version_len = 0;
-                name_len = strlenW(entity->u.clrsurrogate.name)*sizeof(WCHAR);
+                name_len = wcslen(entity->u.clrsurrogate.name)*sizeof(WCHAR);
 
                 /* setup new index entry */
                 RtlInitUnicodeString(&str, entity->u.clrsurrogate.clsid);
@@ -4835,12 +4835,12 @@ static void get_progid_datalen(struct entity_array *entities, unsigned int *coun
         {
             if (entity->u.comclass.progid)
             {
-                *total_len += single_len + aligned_string_len((strlenW(entity->u.comclass.progid)+1)*sizeof(WCHAR));
+                *total_len += single_len + aligned_string_len((wcslen(entity->u.comclass.progid)+1)*sizeof(WCHAR));
                 *count += 1;
             }
 
             for (j = 0; j < entity->u.comclass.progids.num; j++)
-                *total_len += aligned_string_len((strlenW(entity->u.comclass.progids.progids[j])+1)*sizeof(WCHAR));
+                *total_len += aligned_string_len((wcslen(entity->u.comclass.progids.progids[j])+1)*sizeof(WCHAR));
 
             *total_len += single_len*entity->u.comclass.progids.num;
             *count += entity->u.comclass.progids.num;
@@ -5268,8 +5268,8 @@ RtlCreateActivationContext(IN ULONG Flags,
         {
             DWORD dir_len, source_len;
 
-            dir_len = strlenW(pActCtx->lpAssemblyDirectory);
-            source_len = strlenW(pActCtx->lpSource);
+            dir_len = wcslen(pActCtx->lpAssemblyDirectory);
+            source_len = wcslen(pActCtx->lpSource);
             if (!(source = RtlAllocateHeap( GetProcessHeap(), 0, (dir_len+source_len+2)*sizeof(WCHAR))))
             {
                 status = STATUS_NO_MEMORY;
@@ -5640,9 +5640,9 @@ NTSTATUS WINAPI RtlQueryInformationActivationContext( ULONG flags, HANDLE handle
             if (actctx->num_assemblies) assembly = actctx->assemblies;
 
             if (assembly && assembly->manifest.info)
-                manifest_len = strlenW(assembly->manifest.info) + 1;
-            if (actctx->config.info) config_len = strlenW(actctx->config.info) + 1;
-            if (actctx->appdir.info) appdir_len = strlenW(actctx->appdir.info) + 1;
+                manifest_len = wcslen(assembly->manifest.info) + 1;
+            if (actctx->config.info) config_len = wcslen(actctx->config.info) + 1;
+            if (actctx->appdir.info) appdir_len = wcslen(actctx->appdir.info) + 1;
             len = sizeof(*acdi) + (manifest_len + config_len + appdir_len) * sizeof(WCHAR);
 
             if (retlen) *retlen = len;
@@ -5699,12 +5699,12 @@ NTSTATUS WINAPI RtlQueryInformationActivationContext( ULONG flags, HANDLE handle
             assembly = &actctx->assemblies[index - 1];
 
             if (!(assembly_id = build_assembly_id( &assembly->id ))) return STATUS_NO_MEMORY;
-            id_len = strlenW(assembly_id) + 1;
-            if (assembly->directory) ad_len = strlenW(assembly->directory) + 1;
+            id_len = wcslen(assembly_id) + 1;
+            if (assembly->directory) ad_len = wcslen(assembly->directory) + 1;
 
             if (assembly->manifest.info &&
                 (assembly->type == ASSEMBLY_MANIFEST || assembly->type == ASSEMBLY_SHARED_MANIFEST))
-                path_len  = strlenW(assembly->manifest.info) + 1;
+                path_len  = wcslen(assembly->manifest.info) + 1;
 
             len = sizeof(*afdi) + (id_len + ad_len + path_len) * sizeof(WCHAR);
 
@@ -5770,7 +5770,7 @@ NTSTATUS WINAPI RtlQueryInformationActivationContext( ULONG flags, HANDLE handle
                 return STATUS_INVALID_PARAMETER;
             dll = &assembly->dlls[acqi->ulFileIndexInAssembly];
 
-            if (dll->name) dll_len = strlenW(dll->name) + 1;
+            if (dll->name) dll_len = wcslen(dll->name) + 1;
             len = sizeof(*afdi) + dll_len * sizeof(WCHAR);
 
             if (!buffer || bufsize < len)
@@ -6021,8 +6021,8 @@ NTSTATUS WINAPI RtlQueryActivationContextApplicationSettings( DWORD flags, HANDL
 
     if (!(res = find_app_settings( actctx, settings, ns ))) return STATUS_SXS_KEY_NOT_FOUND;
 
-    if (written) *written = strlenW(res) + 1;
-    if (size < strlenW(res)) return STATUS_BUFFER_TOO_SMALL;
+    if (written) *written = wcslen(res) + 1;
+    if (size < wcslen(res)) return STATUS_BUFFER_TOO_SMALL;
     wcscpy( buffer, res );
     return STATUS_SUCCESS;
 }

--- a/sdk/lib/rtl/actctx.c
+++ b/sdk/lib/rtl/actctx.c
@@ -1195,17 +1195,17 @@ static WCHAR *build_assembly_dir(struct assembly_identity* ai)
     if (!(ret = RtlAllocateHeap( GetProcessHeap(), 0, size ))) return NULL;
 
     wcscpy( ret, arch );
-    strcatW( ret, undW );
-    strcatW( ret, name );
-    strcatW( ret, undW );
-    strcatW( ret, key );
-    strcatW( ret, undW );
+    wcscat( ret, undW );
+    wcscat( ret, name );
+    wcscat( ret, undW );
+    wcscat( ret, key );
+    wcscat( ret, undW );
     NTDLL_swprintf( ret + strlenW(ret), version_formatW,
               ai->version.major, ai->version.minor, ai->version.build, ai->version.revision );
-    strcatW( ret, undW );
-    strcatW( ret, lang );
-    strcatW( ret, undW );
-    strcatW( ret, mskeyW );
+    wcscat( ret, undW );
+    wcscat( ret, lang );
+    wcscat( ret, undW );
+    wcscat( ret, mskeyW );
     return ret;
 }
 
@@ -1214,7 +1214,7 @@ static inline void append_string( WCHAR *buffer, const WCHAR *prefix, const WCHA
     WCHAR *p = buffer;
 
     if (!str) return;
-    strcatW( buffer, prefix );
+    wcscat( buffer, prefix );
     p += strlenW(p);
     *p++ = '"';
     wcscpy( p, str );
@@ -3184,7 +3184,7 @@ static NTSTATUS get_manifest_in_associated_manifest( struct actctx_loader* acl, 
         if (!(status = get_module_filename( module, &name, sizeof(dotManifestW) + 10*sizeof(WCHAR) )))
         {
             if (resid != 1) NTDLL_swprintf( name.Buffer + strlenW(name.Buffer), fmtW, resid );
-            strcatW( name.Buffer, dotManifestW );
+            wcscat( name.Buffer, dotManifestW );
             if (!RtlDosPathNameToNtPathName_U( name.Buffer, &nameW, NULL, NULL ))
                 status = STATUS_RESOURCE_DATA_NOT_FOUND;
             RtlFreeUnicodeString( &name );
@@ -3198,7 +3198,7 @@ static NTSTATUS get_manifest_in_associated_manifest( struct actctx_loader* acl, 
             return STATUS_NO_MEMORY;
         wcscpy( buffer, filename );
         if (resid != 1) NTDLL_swprintf( buffer + strlenW(buffer), fmtW, resid );
-        strcatW( buffer, dotManifestW );
+        wcscat( buffer, dotManifestW );
         RtlInitUnicodeString( &nameW, buffer );
     }
 
@@ -3837,8 +3837,8 @@ static NTSTATUS build_wndclass_section(ACTIVATION_CONTEXT* actctx, struct strsec
                     if (entity->u.class.versioned)
                     {
                         get_assembly_version(assembly, ptrW);
-                        strcatW(ptrW, exclW);
-                        strcatW(ptrW, entity->u.class.name);
+                        wcscat(ptrW, exclW);
+                        wcscat(ptrW, entity->u.class.name);
                     }
                     else
                     {

--- a/sdk/lib/rtl/actctx.c
+++ b/sdk/lib/rtl/actctx.c
@@ -3262,14 +3262,14 @@ static WCHAR *lookup_manifest_file( HANDLE dir, struct assembly_identity *ai )
             if (dir_info->NextEntryOffset) data_pos += dir_info->NextEntryOffset;
             else data_pos = data_len;
 
-            tmp = (WCHAR *)dir_info->FileName + (strchrW(lookup, '*') - lookup);
+            tmp = (WCHAR *)dir_info->FileName + (wcschr(lookup, '*') - lookup);
             build = wcstoul( tmp, NULL, 10 );
             if (build < min_build) continue;
-            tmp = strchrW(tmp, '.') + 1;
+            tmp = wcschr(tmp, '.') + 1;
             revision = wcstoul( tmp, NULL, 10 );
             if (build == min_build && revision < min_revision) continue;
-            tmp = strchrW(tmp, '_') + 1;
-            tmp = strchrW(tmp, '_') + 1;
+            tmp = wcschr(tmp, '_') + 1;
+            tmp = wcschr(tmp, '_') + 1;
             if (dir_info->FileNameLength - (tmp - dir_info->FileName) * sizeof(WCHAR) == sizeof(wine_trailerW) &&
                 !wcsnicmp( tmp, wine_trailerW, ARRAY_SIZE( wine_trailerW )))
             {

--- a/sdk/lib/rtl/actctx.c
+++ b/sdk/lib/rtl/actctx.c
@@ -1097,7 +1097,7 @@ static void free_entity_array(struct entity_array *array)
 static BOOL is_matching_string( const WCHAR *str1, const WCHAR *str2 )
 {
     if (!str1) return !str2;
-    return str2 && !strcmpiW( str1, str2 );
+    return str2 && !RtlCompareUnicodeStrings( str1, strlenW(str1), str2, strlenW(str2), TRUE );
 }
 
 static BOOL is_matching_identity( const struct assembly_identity *id1,
@@ -1107,7 +1107,7 @@ static BOOL is_matching_identity( const struct assembly_identity *id1,
     if (!is_matching_string( id1->arch, id2->arch )) return FALSE;
     if (!is_matching_string( id1->public_key, id2->public_key )) return FALSE;
 
-    if (id1->language && id2->language && strcmpiW( id1->language, id2->language ))
+    if (id1->language && id2->language && !is_matching_string( id1->language, id2->language ))
     {
         if (strcmpW( wildcardW, id1->language ) && strcmpW( wildcardW, id2->language ))
             return FALSE;
@@ -3611,6 +3611,7 @@ static NTSTATUS build_dllredirect_section(ACTIVATION_CONTEXT* actctx, struct str
 static struct string_index *find_string_index(const struct strsection_header *section, const UNICODE_STRING *name)
 {
     struct string_index *iter, *index = NULL;
+    UNICODE_STRING str;
     ULONG hash = 0, i;
 
     DPRINT("section %p, name %wZ\n", section, name);
@@ -3623,16 +3624,15 @@ static struct string_index *find_string_index(const struct strsection_header *se
         DPRINT("iter->name %S\n", (WCHAR*)((BYTE*)section + iter->name_offset));
         if (iter->hash == hash)
         {
-            const WCHAR *nameW = (WCHAR*)((BYTE*)section + iter->name_offset);
-
-            if (!_wcsnicmp(nameW, name->Buffer, name->Length / sizeof(WCHAR)) &&
-                wcslen(nameW) == name->Length / sizeof(WCHAR))
+            str.Buffer = (WCHAR *)((BYTE *)section + iter->name_offset);
+            str.Length = iter->name_len;
+            if (RtlEqualUnicodeString( &str, name, TRUE ))
             {
                 index = iter;
                 break;
             }
             else
-                WARN("hash collision 0x%08x, %wZ, %S\n", hash, name, nameW);
+                WARN("hash collision 0x%08x, %wZ, %wZ\n", hash, name, &str);
         }
         iter++;
     }
@@ -3863,6 +3863,7 @@ static NTSTATUS find_window_class(ACTIVATION_CONTEXT* actctx, const UNICODE_STRI
 {
     struct string_index *iter, *index = NULL;
     struct wndclass_redirect_data *class;
+    UNICODE_STRING str;
     ULONG hash;
     int i;
 
@@ -3887,15 +3888,15 @@ static NTSTATUS find_window_class(ACTIVATION_CONTEXT* actctx, const UNICODE_STRI
     {
         if (iter->hash == hash)
         {
-            const WCHAR *nameW = (WCHAR*)((BYTE*)actctx->wndclass_section + iter->name_offset);
-
-            if (!strcmpiW(nameW, name->Buffer))
+            str.Buffer = (WCHAR *)((BYTE *)actctx->wndclass_section + iter->name_offset);
+            str.Length = iter->name_len;
+            if (RtlEqualUnicodeString( &str, name, TRUE ))
             {
                 index = iter;
                 break;
             }
             else
-                WARN("hash collision 0x%08x, %wZ, %S\n", hash, name, nameW);
+                WARN("hash collision 0x%08x, %wZ, %wZ\n", hash, name, &str);
         }
         iter++;
     }

--- a/sdk/lib/rtl/actctx.c
+++ b/sdk/lib/rtl/actctx.c
@@ -5181,6 +5181,12 @@ void actctx_init(PVOID* pOldShimData)
     {
         DPRINT1("Failed to create the implicit act ctx. Status: 0x%x!!!\n", Status);
     }
+
+#ifdef __REACTOS__
+    NtCurrentTeb()->ProcessEnvironmentBlock->ActivationContextData = process_actctx->ActivationContextData;
+#else
+    NtCurrentTeb()->Peb->ActivationContextData = process_actctx;
+#endif // __REACTOS__
 }
 
 

--- a/sdk/lib/rtl/actctx.c
+++ b/sdk/lib/rtl/actctx.c
@@ -33,7 +33,7 @@
 #define FILE_END_OF_FILE_INFORMATION FILE_STANDARD_INFORMATION
 #define FileEndOfFileInformation FileStandardInformation
 #define RELATIVE_PATH RtlPathTypeRelative
-#define user_shared_data SharedUserData
+#define windows_dir SharedUserData->NtSystemRoot
 #define ARRAY_SIZE(a) (sizeof(a)/sizeof((a)[0]))
 #define wcsnicmp _wcsnicmp
 #define NTDLL_swprintf swprintf
@@ -3312,11 +3312,11 @@ static NTSTATUS lookup_winsxs(struct actctx_loader* acl, struct assembly_identit
     if (!ai->arch || !ai->name || !ai->public_key) return STATUS_NO_SUCH_FILE;
 
     if (!(path = RtlAllocateHeap( GetProcessHeap(), 0, sizeof(manifest_dirW) +
-                                  wcslen(user_shared_data->NtSystemRoot) * sizeof(WCHAR) )))
+                                  wcslen(windows_dir) * sizeof(WCHAR) )))
         return STATUS_NO_MEMORY;
 
-    wcscpy( path, user_shared_data->NtSystemRoot );
-    memcpy( path + wcslen(path), manifest_dirW, sizeof(manifest_dirW) );
+    wcscpy( path, windows_dir );
+    wcscat( path, manifest_dirW );
 
     if (!RtlDosPathNameToNtPathName_U( path, &path_us, NULL, NULL ))
     {

--- a/sdk/lib/rtl/actctx.c
+++ b/sdk/lib/rtl/actctx.c
@@ -255,9 +255,7 @@ enum comclass_miscfields
 struct comclassredirect_data
 {
     ULONG size;
-    BYTE  res;
-    BYTE  miscmask;
-    BYTE  res1[2];
+    ULONG flags;
     DWORD model;
     GUID  clsid;
     GUID  alias;
@@ -4175,7 +4173,7 @@ static NTSTATUS add_comserver_record(const struct guidsection_header *section, c
         struct entity *entity = &entities->base[i];
         if (entity->kind == ACTIVATION_CONTEXT_SECTION_COM_SERVER_REDIRECTION)
         {
-            ULONG module_len, progid_len, str_len = 0;
+            ULONG module_len, progid_len, str_len = 0, miscmask;
             struct comclassredirect_data *data;
             struct guid_index *alias_index;
             struct clrclass_data *clrdata;
@@ -4211,9 +4209,6 @@ static NTSTATUS add_comserver_record(const struct guidsection_header *section, c
             /* setup data */
             data = (struct comclassredirect_data*)((BYTE*)section + (*index)->data_offset);
             data->size = sizeof(*data);
-            data->res = 0;
-            data->res1[0] = 0;
-            data->res1[1] = 0;
             data->model = entity->u.comclass.model;
             data->clsid = (*index)->guid;
             data->alias = alias_index->guid;
@@ -4240,17 +4235,18 @@ static NTSTATUS add_comserver_record(const struct guidsection_header *section, c
             data->miscstatusdocprint = entity->u.comclass.miscstatusdocprint;
 
             /* mask describes which misc* data is available */
-            data->miscmask = 0;
+            miscmask = 0;
             if (data->miscstatus)
-                data->miscmask |= MiscStatus;
+                miscmask |= MiscStatus;
             if (data->miscstatuscontent)
-                data->miscmask |= MiscStatusContent;
+                miscmask |= MiscStatusContent;
             if (data->miscstatusthumbnail)
-                data->miscmask |= MiscStatusThumbnail;
+                miscmask |= MiscStatusThumbnail;
             if (data->miscstatusicon)
-                data->miscmask |= MiscStatusIcon;
+                miscmask |= MiscStatusIcon;
             if (data->miscstatusdocprint)
-                data->miscmask |= MiscStatusDocPrint;
+                miscmask |= MiscStatusDocPrint;
+            data->flags = miscmask << 8;
 
             if (data->clrdata_offset)
             {

--- a/sdk/lib/rtl/actctx.c
+++ b/sdk/lib/rtl/actctx.c
@@ -36,6 +36,7 @@
 #define user_shared_data SharedUserData
 #define ARRAY_SIZE(a) (sizeof(a)/sizeof((a)[0]))
 #define wcsnicmp _wcsnicmp
+#define NTDLL_swprintf swprintf
 
 #undef RT_MANIFEST
 #undef CREATEPROCESS_MANIFEST_RESOURCE_ID
@@ -1199,7 +1200,7 @@ static WCHAR *build_assembly_dir(struct assembly_identity* ai)
     strcatW( ret, undW );
     strcatW( ret, key );
     strcatW( ret, undW );
-    sprintfW( ret + strlenW(ret), version_formatW,
+    NTDLL_swprintf( ret + strlenW(ret), version_formatW,
               ai->version.major, ai->version.minor, ai->version.build, ai->version.revision );
     strcatW( ret, undW );
     strcatW( ret, lang );
@@ -1236,7 +1237,7 @@ static WCHAR *build_assembly_id( const struct assembly_identity *ai )
     WCHAR version[64], *ret;
     SIZE_T size = 0;
 
-    sprintfW( version, version_formatW,
+    NTDLL_swprintf( version, version_formatW,
               ai->version.major, ai->version.minor, ai->version.build, ai->version.revision );
     if (ai->name) size += strlenW(ai->name) * sizeof(WCHAR);
     if (ai->arch) size += strlenW(archW) + strlenW(ai->arch) + 2;
@@ -2071,7 +2072,7 @@ static int get_assembly_version(struct assembly *assembly, WCHAR *ret)
     WCHAR buff[25];
 
     if (!ret) ret = buff;
-    return sprintfW(ret, fmtW, ver->major, ver->minor, ver->build, ver->revision);
+    return NTDLL_swprintf(ret, fmtW, ver->major, ver->minor, ver->build, ver->revision);
 }
 
 static void parse_window_class_elem( xmlbuf_t *xmlbuf, struct dll_redirect *dll,
@@ -3182,7 +3183,7 @@ static NTSTATUS get_manifest_in_associated_manifest( struct actctx_loader* acl, 
 
         if (!(status = get_module_filename( module, &name, sizeof(dotManifestW) + 10*sizeof(WCHAR) )))
         {
-            if (resid != 1) sprintfW( name.Buffer + strlenW(name.Buffer), fmtW, resid );
+            if (resid != 1) NTDLL_swprintf( name.Buffer + strlenW(name.Buffer), fmtW, resid );
             strcatW( name.Buffer, dotManifestW );
             if (!RtlDosPathNameToNtPathName_U( name.Buffer, &nameW, NULL, NULL ))
                 status = STATUS_RESOURCE_DATA_NOT_FOUND;
@@ -3196,7 +3197,7 @@ static NTSTATUS get_manifest_in_associated_manifest( struct actctx_loader* acl, 
                                         (strlenW(filename) + 10) * sizeof(WCHAR) + sizeof(dotManifestW) )))
             return STATUS_NO_MEMORY;
         strcpyW( buffer, filename );
-        if (resid != 1) sprintfW( buffer + strlenW(buffer), fmtW, resid );
+        if (resid != 1) NTDLL_swprintf( buffer + strlenW(buffer), fmtW, resid );
         strcatW( buffer, dotManifestW );
         RtlInitUnicodeString( &nameW, buffer );
     }
@@ -3232,7 +3233,7 @@ static WCHAR *lookup_manifest_file( HANDLE dir, struct assembly_identity *ai )
                                      + strlenW(ai->public_key) + strlenW(lang) + 20) * sizeof(WCHAR)
                                     + sizeof(lookup_fmtW) )))
         return NULL;
-    sprintfW( lookup, lookup_fmtW, ai->arch, ai->name, ai->public_key,
+    NTDLL_swprintf( lookup, lookup_fmtW, ai->arch, ai->name, ai->public_key,
               ai->version.major, ai->version.minor, lang );
     RtlInitUnicodeString( &lookup_us, lookup );
 

--- a/sdk/lib/rtl/actctx.c
+++ b/sdk/lib/rtl/actctx.c
@@ -3262,10 +3262,10 @@ static WCHAR *lookup_manifest_file( HANDLE dir, struct assembly_identity *ai )
             else data_pos = data_len;
 
             tmp = (WCHAR *)dir_info->FileName + (strchrW(lookup, '*') - lookup);
-            build = atoiW(tmp);
+            build = wcstoul( tmp, NULL, 10 );
             if (build < min_build) continue;
             tmp = strchrW(tmp, '.') + 1;
-            revision = atoiW(tmp);
+            revision = wcstoul( tmp, NULL, 10 );
             if (build == min_build && revision < min_revision) continue;
             tmp = strchrW(tmp, '_') + 1;
             tmp = strchrW(tmp, '_') + 1;

--- a/sdk/lib/rtl/actctx.c
+++ b/sdk/lib/rtl/actctx.c
@@ -35,6 +35,7 @@
 #define RELATIVE_PATH RtlPathTypeRelative
 #define user_shared_data SharedUserData
 #define ARRAY_SIZE(a) (sizeof(a)/sizeof((a)[0]))
+#define wcsnicmp _wcsnicmp
 
 #undef RT_MANIFEST
 #undef CREATEPROCESS_MANIFEST_RESOURCE_ID
@@ -859,7 +860,7 @@ static inline BOOL xmlstr_cmp(const xmlstr_t* xmlstr, const WCHAR *str)
 
 static inline BOOL xmlstr_cmpi(const xmlstr_t* xmlstr, const WCHAR *str)
 {
-    return !strncmpiW(xmlstr->ptr, str, xmlstr->len) && !str[xmlstr->len];
+    return !wcsnicmp(xmlstr->ptr, str, xmlstr->len) && !str[xmlstr->len];
 }
 
 static BOOL xml_attr_cmp( const struct xml_attr *attr, const WCHAR *str )
@@ -1969,13 +1970,13 @@ static BOOL parse_typelib_flags(const xmlstr_t *value, struct entity *entity)
         start = str;
         while (*str != ',' && (i++ < value->len)) str++;
 
-        if (!strncmpiW(start, restrictedW, str-start))
+        if (!wcsnicmp(start, restrictedW, str-start))
             *flags |= LIBFLAG_FRESTRICTED;
-        else if (!strncmpiW(start, controlW, str-start))
+        else if (!wcsnicmp(start, controlW, str-start))
             *flags |= LIBFLAG_FCONTROL;
-        else if (!strncmpiW(start, hiddenW, str-start))
+        else if (!wcsnicmp(start, hiddenW, str-start))
             *flags |= LIBFLAG_FHIDDEN;
-        else if (!strncmpiW(start, hasdiskimageW, str-start))
+        else if (!wcsnicmp(start, hasdiskimageW, str-start))
             *flags |= LIBFLAG_FHASDISKIMAGE;
         else
         {
@@ -3268,7 +3269,7 @@ static WCHAR *lookup_manifest_file( HANDLE dir, struct assembly_identity *ai )
             tmp = strchrW(tmp, '_') + 1;
             tmp = strchrW(tmp, '_') + 1;
             if (dir_info->FileNameLength - (tmp - dir_info->FileName) * sizeof(WCHAR) == sizeof(wine_trailerW) &&
-                !strncmpiW( tmp, wine_trailerW, ARRAY_SIZE( wine_trailerW )))
+                !wcsnicmp( tmp, wine_trailerW, ARRAY_SIZE( wine_trailerW )))
             {
                 /* prefer a non-Wine manifest if we already have one */
                 /* we'll still load the builtin dll if specified through DllOverrides */

--- a/sdk/tools/winesync/rtl.cfg
+++ b/sdk/tools/winesync/rtl.cfg
@@ -1,0 +1,7 @@
+directories: null
+files:
+  dlls/ntdll/actctx.c: sdk/lib/rtl/actctx.c
+  dlls/ntdll/timerqueue.c: sdk/lib/rtl/timerqueue.c
+  dlls/ntdll/wait.c: sdk/lib/rtl/wait.c
+tags:
+  wine: wine-5.18


### PR DESCRIPTION
## Purpose

Sync actctx.c to wine-5.18. Why this version? Because that is about the earliest version that guarantees consistent sync of the entire file, since code was in a weird state of being synced to multiple different versions.

## Tests
- [ ] KVM x86: https://reactos.org/testman/compare.php?ids=96317,96318,96319,96263
- [ ] KVM x86 (2nd run): https://reactos.org/testman/compare.php?ids=96349,96357,96360,96342
- [ ] KVM x64: https://reactos.org/testman/compare.php?ids=96323,96325,96326,96265

The regression in comctl32:animate and comctl32:button are due to user heap exhaustion.
