### PR TITLE
[NTGDI][FREETYPE] Initial support of Surrogate Pairs and emojis

### DIFF
--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -36,20 +36,18 @@
 #include <debug.h>
 
 /* The ranges of the surrogate pairs */
-#define HIGH_SURROGATE_MIN 0xD800
-#define HIGH_SURROGATE_MAX 0xDBFF
-#define LOW_SURROGATE_MIN  0xDC00
-#define LOW_SURROGATE_MAX  0xDFFF
+#define HIGH_SURROGATE_MIN 0xD800U
+#define HIGH_SURROGATE_MAX 0xDBFFU
+#define LOW_SURROGATE_MIN  0xDC00U
+#define LOW_SURROGATE_MAX  0xDFFFU
 
 #define IS_HIGH_SURROGATE(ch0) (HIGH_SURROGATE_MIN <= (ch0) && (ch0) <= HIGH_SURROGATE_MAX)
 #define IS_LOW_SURROGATE(ch1)  (LOW_SURROGATE_MIN  <= (ch1) && (ch1) <=  LOW_SURROGATE_MAX)
 
 static inline DWORD
-Utf32FromSurrogatePair(WCHAR ch0, WCHAR ch1)
+Utf32FromSurrogatePair(DWORD ch0, DWORD ch1)
 {
-    DWORD Code = ch0 - HIGH_SURROGATE_MIN;
-    Code <<= 10;
-    return Code + (ch1 - LOW_SURROGATE_MIN) + 0x10000;
+    return ((ch0 - HIGH_SURROGATE_MIN) << 10) + (ch1 - LOW_SURROGATE_MIN) + 0x10000;
 }
 
 /* TPMF_FIXED_PITCH is confusing; brain-dead api */

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -4230,8 +4230,7 @@ TextIntGetTextExtentPoint(PDC dc,
     BOOL use_kerning, bVerticalWriting;
     LONG ascender, descender;
     FONT_CACHE_ENTRY Cache;
-    WCHAR ch0, ch1;
-    DWORD Code;
+    DWORD ch0, ch1;
 
     FontGDI = ObjToGDI(TextObj->Font, FONT);
 
@@ -4267,7 +4266,7 @@ TextIntGetTextExtentPoint(PDC dc,
 
     for (i = 0; i < Count; i++)
     {
-        Code = ch0 = *String++;
+        ch0 = *String++;
         if (IS_HIGH_SURROGATE(ch0))
         {
             ++i;
@@ -4276,10 +4275,10 @@ TextIntGetTextExtentPoint(PDC dc,
 
             ch1 = *String++;
             if (IS_LOW_SURROGATE(ch1))
-                Code = Utf32FromSurrogatePair(ch0, ch1);
+                ch0 = Utf32FromSurrogatePair(ch0, ch1);
         }
 
-        glyph_index = get_glyph_index_flagged(Cache.Hashed.Face, Code, GTEF_INDICES, fl);
+        glyph_index = get_glyph_index_flagged(Cache.Hashed.Face, ch0, GTEF_INDICES, fl);
         Cache.Hashed.GlyphIndex = glyph_index;
 
         realglyph = IntGetRealGlyph(&Cache);
@@ -5852,14 +5851,13 @@ IntGetTextDisposition(
     BOOL use_kerning = FT_HAS_KERNING(face);
     ULONG previous = 0;
     FT_Vector delta, vec;
-    WCHAR ch0, ch1;
-    DWORD Code;
+    DWORD ch0, ch1;
 
     ASSERT_FREETYPE_LOCK_HELD();
 
     for (i = 0; i < Count; ++i)
     {
-        Code = ch0 = *String++;
+        ch0 = *String++;
         if (IS_HIGH_SURROGATE(ch0))
         {
             ++i;
@@ -5868,10 +5866,10 @@ IntGetTextDisposition(
 
             ch1 = *String++;
             if (IS_LOW_SURROGATE(ch1))
-                Code = Utf32FromSurrogatePair(ch0, ch1);
+                ch0 = Utf32FromSurrogatePair(ch0, ch1);
         }
 
-        glyph_index = get_glyph_index_flagged(face, Code, ETO_GLYPH_INDEX, fuOptions);
+        glyph_index = get_glyph_index_flagged(face, ch0, ETO_GLYPH_INDEX, fuOptions);
         Cache->Hashed.GlyphIndex = glyph_index;
 
         realglyph = IntGetRealGlyph(Cache);
@@ -6042,8 +6040,7 @@ IntExtTextOutW(
     FONT_CACHE_ENTRY Cache;
     FT_Matrix mat;
     BOOL bNoTransform;
-    WCHAR ch0, ch1;
-    DWORD Code;
+    DWORD ch0, ch1;
 
     /* Check if String is valid */
     if (Count > 0xFFFF || (Count > 0 && String == NULL))
@@ -6269,7 +6266,7 @@ IntExtTextOutW(
     bResult = TRUE; /* Assume success */
     for (i = 0; i < Count; ++i)
     {
-        Code = ch0 = *String++;
+        ch0 = *String++;
         if (IS_HIGH_SURROGATE(ch0))
         {
             ++i;
@@ -6278,10 +6275,10 @@ IntExtTextOutW(
 
             ch1 = *String++;
             if (IS_LOW_SURROGATE(ch1))
-                Code = Utf32FromSurrogatePair(ch0, ch1);
+                ch0 = Utf32FromSurrogatePair(ch0, ch1);
         }
 
-        glyph_index = get_glyph_index_flagged(face, Code, ETO_GLYPH_INDEX, fuOptions);
+        glyph_index = get_glyph_index_flagged(face, ch0, ETO_GLYPH_INDEX, fuOptions);
         Cache.Hashed.GlyphIndex = glyph_index;
 
         realglyph = IntGetRealGlyph(&Cache);


### PR DESCRIPTION
## Purpose

Support emoji characters and minor characters.
JIRA issue: [CORE-19030](https://jira.reactos.org/browse/CORE-19030)

NOTE: Not every emoji is supported yet (No ZWJ support). Surrogate pairs only.
NOTE: This feature only works if the appropriate font is selected.

## Proposed changes

- Add `IS_HIGH_SURROGATE` and `IS_LOW_SURROGATE` macros.
- Add `Utf32FromSurrogatePair` helper function to convert a surrogate pair to a UTF-32 code point.
- Convert the surrogate pairs in the text in `TextIntGetTextExtentPoint`, `IntGetTextDisposition`, and `IntExtTextOutW` functions.

## TODO

- [x] Do small tests.
- [x] Do big tests.

## Comparison

The test program: https://jira.reactos.org/secure/attachment/68032/win32_emoji_draw.zip
With borrowing `"Segoe UI Emoji"` font from Win10.

BEFORE:
![emoji-before](https://github.com/reactos/reactos/assets/2107452/3b1193c5-3aa0-4481-bc52-f1852403e18b)
Failed.

AFTER:
![emoji-after](https://github.com/reactos/reactos/assets/2107452/5fb29a24-4af6-46b3-94b5-a3839cd40a5a)
Successful.

The test program Part 2: https://jira.reactos.org/secure/attachment/68033/win32_emoji_draw2.zip

BEFORE:
![before-2](https://github.com/reactos/reactos/assets/2107452/9fa44950-109c-4773-8fe2-e3d672b3bc0f)
The surrogate pairs became tofu blocks.

AFTER:
![after2](https://github.com/reactos/reactos/assets/2107452/c17aae56-3e96-410a-b2b2-27afc8103428)
Successfully drawing emojis.