### PR TITLE
[BROWSEUI] Fix incorrect text selection when double-clicking on text

### DIFF
--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -272,16 +272,27 @@ EditWordBreakProcW(LPWSTR lpch, INT index, INT count, INT code)
         {
             if (index)
                 --index;
-            while (index && !IsWordBreak(lpch[index]))
+            while (index)
+            {
+                if (!IsWordBreak(lpch[index]) && IsWordBreak(lpch[index-1]))
+                    break;
                 --index;
+            }    
             return index;
         }
         case WB_RIGHT:
         {
             if (!count)
                 break;
-            while (index < count && lpch[index] && !IsWordBreak(lpch[index]))
+            while (index < count && lpch[index])
+            {
+                if (IsWordBreak(lpch[index]) && !IsWordBreak(lpch[index+1]))
+                {
+                    ++index;
+                    break;
+                }
                 ++index;
+            }
             return index;
         }
     }


### PR DESCRIPTION
## Purpose

Fix improper text selection/highlighting when double-clicking on text 

JIRA issue: [CORE-19425](https://jira.reactos.org/browse/CORE-19425)

## Proposed changes

- Fix WB_LEFT and WB_RIGHT checks in EditWordBreakProcW
