### PR TITLE
[RAPPS] DelRegEmpty instruction should be best-effort, don't propagate errors

### DIFF
--- a/base/applications/rapps/geninst.cpp
+++ b/base/applications/rapps/geninst.cpp
@@ -752,7 +752,7 @@ UninstallThread(LPVOID Parameter)
                             if (op == UNOP_REGKEY)
                                 err = key.RecurseDeleteKey(tmp);
                             else if (RegKeyHasValues(hKey, str, wowsam) == S_FALSE)
-                                err = key.DeleteSubKey(tmp);
+                                key.DeleteSubKey(tmp); // DelRegEmpty ignores errors
                         }
                         switch(err)
                         {


### PR DESCRIPTION
DelRegEmpty exists to clean up "company" registry parent keys. If another application is writing to the key at the same time as we are gently trying to remove it, our uninstaller should ignore any errors.

