### PR TITLE
[SNDVOL32] Add CTRL-S hotkey to switch between Small and Normal modes

### DIFF
--- a/base/applications/sndvol32/sndvol32.c
+++ b/base/applications/sndvol32/sndvol32.c
@@ -1249,6 +1249,8 @@ MainWindowProc(HWND hwnd,
                     Result = -1;
                 }
             }
+
+            RegisterHotKey(hwnd, HOTKEY_CTRL_S, MOD_CONTROL, 'S');
             break;
         }
 
@@ -1387,11 +1389,6 @@ CreateApplicationWindow(
         HeapFree(hAppHeap,
                  0,
                  MixerWindow);
-    }
-
-    if (!RegisterHotKey(hWnd, HOTKEY_CTRL_S, MOD_CONTROL, 'S'))
-    {
-        return NULL;
     }
 
     return hWnd;

--- a/base/applications/sndvol32/sndvol32.c
+++ b/base/applications/sndvol32/sndvol32.c
@@ -971,6 +971,7 @@ MainWindowProc(HWND hwnd,
                 case IDM_EXIT:
                 {
                     PostQuitMessage(0);
+                    UnregisterHotKey(hwnd, 1);
                     break;
                 }
 
@@ -1275,6 +1276,21 @@ MainWindowProc(HWND hwnd,
             break;
         }
 
+        case WM_HOTKEY:
+        {
+            if (wParam == 1) 
+            {
+                if (Preferences.MixerWindow->Mode == NORMAL_MODE) {
+                    Preferences.MixerWindow->Mode = SMALL_MODE;
+                } else {
+                    Preferences.MixerWindow->Mode = NORMAL_MODE;
+                }
+
+                RebuildMixerWindowControls(&Preferences);
+            }
+            break;
+        }
+
         default:
         {
             Result = DefWindowProc(hwnd,
@@ -1376,6 +1392,11 @@ CreateApplicationWindow(
         HeapFree(hAppHeap,
                  0,
                  MixerWindow);
+    }
+
+    if (!RegisterHotKey(hWnd, 1, MOD_CONTROL, 'S'))
+    {
+        return NULL;
     }
 
     return hWnd;

--- a/base/applications/sndvol32/sndvol32.c
+++ b/base/applications/sndvol32/sndvol32.c
@@ -971,7 +971,7 @@ MainWindowProc(HWND hwnd,
                 case IDM_EXIT:
                 {
                     PostQuitMessage(0);
-                    UnregisterHotKey(hwnd, 1);
+                    UnregisterHotKey(hwnd, HOTKEY_CTRL_S);
                     break;
                 }
 
@@ -1278,14 +1278,9 @@ MainWindowProc(HWND hwnd,
 
         case WM_HOTKEY:
         {
-            if (wParam == 1) 
+            if (wParam == HOTKEY_CTRL_S) 
             {
-                if (Preferences.MixerWindow->Mode == NORMAL_MODE) {
-                    Preferences.MixerWindow->Mode = SMALL_MODE;
-                } else {
-                    Preferences.MixerWindow->Mode = NORMAL_MODE;
-                }
-
+                Preferences.MixerWindow->Mode = (Preferences.MixerWindow->Mode == NORMAL_MODE ? SMALL_MODE : NORMAL_MODE);
                 RebuildMixerWindowControls(&Preferences);
             }
             break;
@@ -1394,7 +1389,7 @@ CreateApplicationWindow(
                  MixerWindow);
     }
 
-    if (!RegisterHotKey(hWnd, 1, MOD_CONTROL, 'S'))
+    if (!RegisterHotKey(hWnd, HOTKEY_CTRL_S, MOD_CONTROL, 'S'))
     {
         return NULL;
     }

--- a/base/applications/sndvol32/sndvol32.h
+++ b/base/applications/sndvol32/sndvol32.h
@@ -31,6 +31,8 @@
 
 #define ADVANCED_BUTTON_HEIGHT 16
 
+#define HOTKEY_CTRL_S 1
+
 typedef enum _WINDOW_MODE
 {
     NORMAL_MODE,


### PR DESCRIPTION
## Purpose

Adds a Hotkey (CTRL-S) which switches between the Normal and Small Modes of the Volume Control Window (also seen in WINXP)

JIRA issue: [CORE-17043](https://jira.reactos.org/browse/CORE-17043)