### PR TITLE
[COMCTL32] Fix combo box crash on WPS Office 2016 v10.1.0.5614 install

### DIFF
--- a/dll/win32/comctl32/combo.c
+++ b/dll/win32/comctl32/combo.c
@@ -1424,8 +1424,17 @@ static void CBResetPos(
        }
 
        if( bRedraw && !(lphc->wState & CBF_NOREDRAW) )
+#ifdef __REACTOS__
+       {
+           /* Possible HACK: Fix WPS Office 2016 Installer crash CORE-12033 */
+           if (SendMessageW(lphc->hWndLBox, LB_GETCOUNT, 0, 0))
+               RedrawWindow(lphc->self, NULL, 0,
+                               RDW_INVALIDATE | RDW_ERASE | RDW_UPDATENOW);
+       }
+#else
            RedrawWindow( lphc->self, NULL, 0,
                            RDW_INVALIDATE | RDW_ERASE | RDW_UPDATENOW );
+#endif
    }
 }
 


### PR DESCRIPTION
Patch by @I_Kill_Bugs

## Purpose

_Fix crash in comctl32 combobox on WPS Office install._

JIRA issue: [CORE-12033](https://jira.reactos.org/browse/CORE-12033)

## Proposed changes

_Only use 'RedrawWindow' from CBResetPos in combo.c when items in combobox != 0._

From @I_Kill_Bugs:
The combobox was sent a WM_PAINT message that it wasn't expecting
 which caused the ATL based installer control to try and access listbox strings
 that haven't been added yet causing the exception.