### PR TITLE
[SHELL32] ShellExecute: Re-work Part 1

### DIFF
--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -2445,10 +2445,10 @@ ShellExecuteExW(LPSHELLEXECUTEINFOW sei)
         {
             switch (sei->nShow)
             {
-                case SW_SHOWNORMAL:
                 case SW_SHOW:
-                case SW_RESTORE:
                 case SW_SHOWDEFAULT:
+                case SW_SHOWNORMAL:
+                case SW_RESTORE:
                     sei->nShow = SW_SHOWMAXIMIZED;
                     break;
                 default:


### PR DESCRIPTION
## Purpose

The goal is a correct implementation of `shell32!ShellExecute`.

JIRA issue: [CORE-17482](https://jira.reactos.org/browse/CORE-17482)

## Proposed changes

- Add `SHELL_InRunDllProcess` helper function.
- Add structure size check to `ShellExecuteExA` function.
- Add code to `ShellExecuteExW` function.
- Add `"MaximizeApps"` registry value check.

## TODO

- [x] Do big tests.