### PR TITLE
[SHLWAPI][SHLWAPI_APITEST][SDK] PathFileExistsDefExtAndAttributesW

### DIFF
--- a/dll/win32/shlwapi/shlwapi.spec
+++ b/dll/win32/shlwapi/shlwapi.spec
@@ -508,7 +508,7 @@
 508 stdcall -noname SHPropertyBag_WriteDWORD(ptr wstr long)
 509 stdcall -noname IUnknown_OnFocusChangeIS(ptr ptr long)
 510 stdcall -noname SHLockSharedEx(ptr long long)
-511 stdcall -stub -noname PathFileExistsDefExtAndAttributesW(wstr long ptr)
+511 stdcall -noname PathFileExistsDefExtAndAttributesW(wstr long ptr)
 512 stub -ordinal IStream_ReadPidl
 513 stub -ordinal IStream_WritePidl
 514 stdcall -noname IUnknown_ProfferService(ptr ptr ptr ptr)

--- a/dll/win32/shlwapi/utils.cpp
+++ b/dll/win32/shlwapi/utils.cpp
@@ -79,87 +79,20 @@ IContextMenu_Invoke(
 }
 
 /*************************************************************************
- * PathAddDefExtW [Internal]
- *
- * @param pszPath The path string.
- * @param dwFlags The PADE_... flags.
- * @param pdwAttrs A pointer to the file attributes. Optional.
- * @return TRUE if successful.
- */
-static BOOL
-PathAddDefExtW(
-    _Inout_ LPWSTR pszPath,
-    _In_ DWORD dwFlags,
-    _Out_opt_ LPDWORD pdwAttrs)
-{
-    INT cchPath = lstrlenW(pszPath);
-    if (cchPath + 4 + 1 > MAX_PATH) // ".ext" is 4 letters, and then a NUL
-        return FALSE;
-
-    LPWSTR pch = &pszPath[cchPath];
-    INT_PTR cchFileTitle = pch - PathFindFileNameW(pszPath);
-
-    WIN32_FIND_DATAW FindData;
-    StringCchCatW(pszPath, MAX_PATH, L".*");
-    HANDLE hFind = FindFirstFileW(pszPath, &FindData);
-    if (hFind == INVALID_HANDLE_VALUE)
-    {
-        *pch = UNICODE_NULL;
-        return FALSE;
-    }
-
-    DWORD dwAttrs = INVALID_FILE_ATTRIBUTES;
-    static const LPCWSTR s_DotExts[] =
-    {
-        L".pif", L".com", L".exe", L".bat", L".lnk", L".cmd", L"", NULL
-    };
-
-    BOOL ret = FALSE;
-    do
-    {
-        for (SIZE_T iExt = 0, nBits = dwFlags; s_DotExts[iExt]; ++iExt)
-        {
-            if ((nBits & 1) || iExt == 6) // 6 --> L""
-            {
-                if (lstrcmpiW(&FindData.cFileName[cchFileTitle], s_DotExts[iExt]) == 0)
-                {
-                    dwAttrs = FindData.dwFileAttributes;
-                    *pch = UNICODE_NULL;
-                    StringCchCatW(pszPath, MAX_PATH, s_DotExts[iExt]);
-                    ret = TRUE;
-                    break;
-                }
-            }
-            nBits >>= 1;
-        }
-    } while (!ret && FindNextFileW(hFind, &FindData));
-
-    FindClose(hFind);
-
-    if (pdwAttrs)
-        *pdwAttrs = dwAttrs;
-
-    if (!ret)
-        *pch = UNICODE_NULL;
-
-    return ret;
-}
-
-/*************************************************************************
  * PathFileExistsDefExtAndAttributesW [SHLWAPI.511]
  *
  * @param pszPath The path string.
- * @param dwFlags The PADE_... flags.
+ * @param dwWhich The WHICH_... flags.
  * @param pdwFileAttributes A pointer to the file attributes. Optional.
  * @return TRUE if successful.
  */
 BOOL WINAPI
 PathFileExistsDefExtAndAttributesW(
     _Inout_ LPWSTR pszPath,
-    _In_ DWORD dwFlags,
+    _In_ DWORD dwWhich,
     _Out_opt_ LPDWORD pdwFileAttributes)
 {
-    TRACE("(%s, 0x%lX, %p)\n", debugstr_w(pszPath), dwFlags, pdwFileAttributes);
+    TRACE("(%s, 0x%lX, %p)\n", debugstr_w(pszPath), dwWhich, pdwFileAttributes);
 
     if (pdwFileAttributes)
         *pdwFileAttributes = INVALID_FILE_ATTRIBUTES;
@@ -167,8 +100,18 @@ PathFileExistsDefExtAndAttributesW(
     if (!pszPath)
         return FALSE;
 
-    if (!dwFlags || (*PathFindExtensionW(pszPath) && (dwFlags & PADE_OPTIONAL)))
+    if (!dwWhich || (*PathFindExtensionW(pszPath) && (dwWhich & WHICH_OPTIONAL)))
         return PathFileExistsAndAttributesW(pszPath, pdwFileAttributes);
 
-    return PathAddDefExtW(pszPath, dwFlags, pdwFileAttributes);
+    if (!PathFileExistsDefExtW(pszPath, dwWhich))
+    {
+        if (pdwFileAttributes)
+            *pdwFileAttributes = INVALID_FILE_ATTRIBUTES;
+        return FALSE;
+    }
+
+    if (pdwFileAttributes)
+        *pdwFileAttributes = GetFileAttributesW(pszPath);
+
+    return TRUE;
 }

--- a/dll/win32/shlwapi/utils.cpp
+++ b/dll/win32/shlwapi/utils.cpp
@@ -82,7 +82,7 @@ IContextMenu_Invoke(
  * PathAddDefExt [Internal]
  */
 static BOOL
-PathAddDefExt(
+PathAddDefExtW(
     _Inout_ LPWSTR pszPath,
     _In_ DWORD dwFlags,
     _Out_opt_ LPDWORD pdwAttrs)
@@ -128,7 +128,6 @@ PathAddDefExt(
 
         if (s_DotExts[iExt])
             break;
-
     } while (FindNextFileW(hFind, &FindData));
 
     FindClose(hFind);
@@ -146,16 +145,18 @@ BOOL WINAPI
 PathFileExistsDefExtAndAttributesW(
     _Inout_ LPWSTR pszPath,
     _In_ DWORD dwFlags,
-    _Out_opt_ LPDWORD pdwAttrs)
+    _Out_opt_ LPDWORD pdwFileAttributes)
 {
-    if (pdwAttrs)
-        *pdwAttrs = INVALID_FILE_ATTRIBUTES;
+    TRACE("(%s, 0x%lX, %p)\n", debugstr_w(pszPath), dwFlags, pdwFileAttributes);
+
+    if (pdwFileAttributes)
+        *pdwFileAttributes = INVALID_FILE_ATTRIBUTES;
 
     if (!pszPath)
         return FALSE;
 
     if (!dwFlags || (*PathFindExtensionW(pszPath) && (dwFlags & PADE_OPTIONAL)))
-        return PathFileExistsAndAttributes(pszPath, pdwAttrs);
+        return PathFileExistsAndAttributesW(pszPath, pdwFileAttributes);
 
-    return PathAddDefExt(pszPath, dwFlags, pdwAttrs);
+    return PathAddDefExtW(pszPath, dwFlags, pdwFileAttributes);
 }

--- a/modules/rostests/apitests/shlwapi/CMakeLists.txt
+++ b/modules/rostests/apitests/shlwapi/CMakeLists.txt
@@ -6,6 +6,7 @@ include_directories($<TARGET_FILE_DIR:shlwapi_resource_dll>)
 
 list(APPEND SOURCE
     AssocQueryString.c
+    PathFileExistsDefExtAndAttributesW.c
     PathFindOnPath.c
     PathIsUNC.c
     PathIsUNCServer.c

--- a/modules/rostests/apitests/shlwapi/PathFileExistsDefExtAndAttributesW.c
+++ b/modules/rostests/apitests/shlwapi/PathFileExistsDefExtAndAttributesW.c
@@ -19,6 +19,10 @@ START_TEST(PathFileExistsDefExtAndAttributesW)
     ret = PathFileExistsDefExtAndAttributesW(NULL, 0, NULL);
     ok_int(ret, FALSE);
 
+    lstrcpynW(szPath, L"This Is Not Existent File.txt");
+    ret = PathFileExistsDefExtAndAttributesW(szPath, 0, NULL);
+    ok_int(ret, FALSE);
+
     GetWindowsDirectoryW(szPath, _countof(szPath));
     ret = PathFileExistsDefExtAndAttributesW(szPath, 0, NULL);
     ok_int(ret, TRUE);

--- a/modules/rostests/apitests/shlwapi/PathFileExistsDefExtAndAttributesW.c
+++ b/modules/rostests/apitests/shlwapi/PathFileExistsDefExtAndAttributesW.c
@@ -19,7 +19,7 @@ START_TEST(PathFileExistsDefExtAndAttributesW)
     ret = PathFileExistsDefExtAndAttributesW(NULL, 0, NULL);
     ok_int(ret, FALSE);
 
-    lstrcpynW(szPath, L"This Is Not Existent File.txt");
+    lstrcpynW(szPath, L"This Is Not Existent File.txt", _countof(szPath));
     ret = PathFileExistsDefExtAndAttributesW(szPath, 0, NULL);
     ok_int(ret, FALSE);
 

--- a/modules/rostests/apitests/shlwapi/PathFileExistsDefExtAndAttributesW.c
+++ b/modules/rostests/apitests/shlwapi/PathFileExistsDefExtAndAttributesW.c
@@ -14,14 +14,17 @@ START_TEST(PathFileExistsDefExtAndAttributesW)
 {
     WCHAR szPath[MAX_PATH];
     DWORD attrs;
+    BOOL ret;
 
-    ok_int(PathFileExistsDefExtAndAttributesW(NULL, 0, NULL), FALSE);
+    ret = PathFileExistsDefExtAndAttributesW(NULL, 0, NULL);
+    ok_int(ret, FALSE);
 
     GetWindowsDirectoryW(szPath, _countof(szPath));
-
-    ok_int(PathFileExistsDefExtAndAttributesW(szPath, 0, NULL), TRUE);
+    ret = PathFileExistsDefExtAndAttributesW(szPath, 0, NULL);
+    ok_int(ret, TRUE);
 
     attrs = 0;
-    ok_int(PathFileExistsDefExtAndAttributesW(szPath, 0, &attrs), TRUE);
+    ret = PathFileExistsDefExtAndAttributesW(szPath, 0, &attrs);
+    ok_int(ret, TRUE);
     ok(attrs != 0 && attrs != INVALID_FILE_ATTRIBUTES, "attrs was 0x%lX\n", attrs);
 }

--- a/modules/rostests/apitests/shlwapi/PathFileExistsDefExtAndAttributesW.c
+++ b/modules/rostests/apitests/shlwapi/PathFileExistsDefExtAndAttributesW.c
@@ -16,19 +16,46 @@ START_TEST(PathFileExistsDefExtAndAttributesW)
     DWORD attrs;
     BOOL ret;
 
+    /* NULL check */
     ret = PathFileExistsDefExtAndAttributesW(NULL, 0, NULL);
     ok_int(ret, FALSE);
 
-    lstrcpynW(szPath, L"This Is Not Existent File.txt", _countof(szPath));
+    /* Not existent file */
+    lstrcpynW(szPath, L"Not Existent File.txt", _countof(szPath));
     ret = PathFileExistsDefExtAndAttributesW(szPath, 0, NULL);
     ok_int(ret, FALSE);
 
+    /* "Windows" directory */
     GetWindowsDirectoryW(szPath, _countof(szPath));
     ret = PathFileExistsDefExtAndAttributesW(szPath, 0, NULL);
     ok_int(ret, TRUE);
 
+    /* "Windows" directory with attributes check */
     attrs = 0;
     ret = PathFileExistsDefExtAndAttributesW(szPath, 0, &attrs);
     ok_int(ret, TRUE);
     ok(attrs != 0 && attrs != INVALID_FILE_ATTRIBUTES, "attrs was 0x%lX\n", attrs);
+
+    /* Find notepad.exe */
+    SearchPathW(NULL, L"notepad.exe", NULL, _countof(szPath), szPath, NULL);
+    ret = PathFileExistsW(szPath);
+    ok_int(ret, TRUE);
+
+    /* Remove .exe */
+    PathRemoveExtensionW(szPath);
+    ret = PathFileExistsW(szPath);
+    ok_int(ret, FALSE);
+
+    /* Add .exe */
+    ret = PathFileExistsDefExtAndAttributesW(szPath, PADE_EXE, NULL);
+    ok_int(ret, TRUE);
+    ret = PathFileExistsW(szPath);
+    ok_int(ret, TRUE);
+
+    /* notepad.cmd doesn't exist */
+    PathRemoveExtensionW(szPath);
+    ret = PathFileExistsDefExtAndAttributesW(szPath, PADE_CMD, NULL);
+    ok_int(ret, FALSE);
+    ret = PathFileExistsW(szPath);
+    ok_int(ret, FALSE);
 }

--- a/modules/rostests/apitests/shlwapi/PathFileExistsDefExtAndAttributesW.c
+++ b/modules/rostests/apitests/shlwapi/PathFileExistsDefExtAndAttributesW.c
@@ -1,0 +1,27 @@
+/*
+ * PROJECT:     ReactOS api tests
+ * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
+ * PURPOSE:     Tests for PathFileExistsDefExtAndAttributesW
+ * COPYRIGHT:   Copyright 2024 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ */
+
+#include <apitest.h>
+#include <shlobj.h>
+#include <shlwapi.h>
+#include <shlwapi_undoc.h>
+
+START_TEST(PathFileExistsDefExtAndAttributesW)
+{
+    WCHAR szPath[MAX_PATH];
+    DWORD attrs;
+
+    ok_int(PathFileExistsDefExtAndAttributesW(NULL, 0, NULL), FALSE);
+
+    GetWindowsDirectoryW(szPath, _countof(szPath));
+
+    ok_int(PathFileExistsDefExtAndAttributesW(szPath, 0, NULL), TRUE);
+
+    attrs = 0;
+    ok_int(PathFileExistsDefExtAndAttributesW(szPath, 0, &attrs), TRUE);
+    ok(attrs != 0 && attrs != INVALID_FILE_ATTRIBUTES, "attrs was 0x%lX\n", attrs);
+}

--- a/modules/rostests/apitests/shlwapi/PathFileExistsDefExtAndAttributesW.c
+++ b/modules/rostests/apitests/shlwapi/PathFileExistsDefExtAndAttributesW.c
@@ -47,14 +47,14 @@ START_TEST(PathFileExistsDefExtAndAttributesW)
     ok_int(ret, FALSE);
 
     /* Add .exe */
-    ret = PathFileExistsDefExtAndAttributesW(szPath, PADE_EXE, NULL);
+    ret = PathFileExistsDefExtAndAttributesW(szPath, WHICH_EXE, NULL);
     ok_int(ret, TRUE);
     ret = PathFileExistsW(szPath);
     ok_int(ret, TRUE);
 
     /* notepad.cmd doesn't exist */
     PathRemoveExtensionW(szPath);
-    ret = PathFileExistsDefExtAndAttributesW(szPath, PADE_CMD, NULL);
+    ret = PathFileExistsDefExtAndAttributesW(szPath, WHICH_CMD, NULL);
     ok_int(ret, FALSE);
     ret = PathFileExistsW(szPath);
     ok_int(ret, FALSE);

--- a/modules/rostests/apitests/shlwapi/testlist.c
+++ b/modules/rostests/apitests/shlwapi/testlist.c
@@ -2,6 +2,7 @@
 #include <apitest.h>
 
 extern void func_AssocQueryString(void);
+extern void func_PathFileExistsDefExtAndAttributesW(void);
 extern void func_PathFindOnPath(void);
 extern void func_isuncpath(void);
 extern void func_isuncpathserver(void);
@@ -19,6 +20,7 @@ extern void func_StrFormatByteSizeW(void);
 const struct test winetest_testlist[] =
 {
     { "AssocQueryString", func_AssocQueryString },
+    { "PathFileExistsDefExtAndAttributesW", func_PathFileExistsDefExtAndAttributesW },
     { "PathFindOnPath", func_PathFindOnPath },
     { "PathIsUNC", func_isuncpath },
     { "PathIsUNCServer", func_isuncpathserver },

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -324,6 +324,22 @@ IContextMenu_Invoke(
 
 DWORD WINAPI SHGetObjectCompatFlags(IUnknown *pUnk, const CLSID *clsid);
 
+/* Flags for PathFileExistsDefExtAndAttributesW */
+#define PADE_NONE     0x0000
+#define PADE_PIF      0x0001
+#define PADE_COM      0x0002
+#define PADE_EXE      0x0004
+#define PADE_BAT      0x0008
+#define PADE_LNK      0x0010
+#define PADE_CMD      0x0020
+#define PADE_OPTIONAL 0x0040
+
+BOOL WINAPI
+PathFileExistsDefExtAndAttributesW(
+    _Inout_ LPWSTR pszPath,
+    _In_ DWORD dwFlags,
+    _Out_opt_ LPDWORD pdwAttrs);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif /* defined(__cplusplus) */

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -338,7 +338,7 @@ BOOL WINAPI
 PathFileExistsDefExtAndAttributesW(
     _Inout_ LPWSTR pszPath,
     _In_ DWORD dwFlags,
-    _Out_opt_ LPDWORD pdwAttrs);
+    _Out_opt_ LPDWORD pdwFileAttributes);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -324,8 +324,7 @@ IContextMenu_Invoke(
 
 DWORD WINAPI SHGetObjectCompatFlags(IUnknown *pUnk, const CLSID *clsid);
 
-/* Flags for PathFileExistsDefExtAndAttributesW */
-#define PADE_NONE     0x0000
+/* Flags for appending an extension in PathFileExistsDefExtAndAttributesW */
 #define PADE_PIF      0x0001
 #define PADE_COM      0x0002
 #define PADE_EXE      0x0004

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -284,7 +284,7 @@ ShellMessageBoxWrapW(
   ...);
 
 /* dwWhich flags for PathFileExistsDefExtW, PathFindOnPathExW,
-   and PathFileExistsDefExtAndAttributesW. */
+ * and PathFileExistsDefExtAndAttributesW */
 #define WHICH_PIF       (1 << 0)
 #define WHICH_COM       (1 << 1)
 #define WHICH_EXE       (1 << 2)

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -283,7 +283,8 @@ ShellMessageBoxWrapW(
   _In_ UINT fuStyle,
   ...);
 
-/* dwWhich flags for PathFileExistsDefExtW and PathFindOnPathExW */
+/* dwWhich flags for PathFileExistsDefExtW, PathFindOnPathExW,
+   and PathFileExistsDefExtAndAttributesW. */
 #define WHICH_PIF       (1 << 0)
 #define WHICH_COM       (1 << 1)
 #define WHICH_EXE       (1 << 2)
@@ -324,20 +325,10 @@ IContextMenu_Invoke(
 
 DWORD WINAPI SHGetObjectCompatFlags(IUnknown *pUnk, const CLSID *clsid);
 
-/* Flags for appending an extension in PathFileExistsDefExtAndAttributesW */
-#define PADE_PIF      0x0001
-#define PADE_COM      0x0002
-#define PADE_EXE      0x0004
-#define PADE_BAT      0x0008
-#define PADE_LNK      0x0010
-#define PADE_CMD      0x0020
-#define PADE_OPTIONAL 0x0040
-#define PADE_ALL (PADE_PIF | PADE_COM | PADE_EXE | PADE_BAT | PADE_LNK | PADE_CMD | PADE_OPTIONAL)
-
 BOOL WINAPI
 PathFileExistsDefExtAndAttributesW(
     _Inout_ LPWSTR pszPath,
-    _In_ DWORD dwFlags,
+    _In_ DWORD dwWhich,
     _Out_opt_ LPDWORD pdwFileAttributes);
 
 #ifdef __cplusplus

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -332,6 +332,7 @@ DWORD WINAPI SHGetObjectCompatFlags(IUnknown *pUnk, const CLSID *clsid);
 #define PADE_LNK      0x0010
 #define PADE_CMD      0x0020
 #define PADE_OPTIONAL 0x0040
+#define PADE_ALL (PADE_PIF | PADE_COM | PADE_EXE | PADE_BAT | PADE_LNK | PADE_CMD | PADE_OPTIONAL)
 
 BOOL WINAPI
 PathFileExistsDefExtAndAttributesW(

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -310,6 +310,13 @@ ShellMessageBoxWrapW(
 #define PATH_CHAR_CLASS_ANY         0xffffffff
 
 BOOL WINAPI PathFileExistsDefExtW(LPWSTR lpszPath, DWORD dwWhich);
+
+BOOL WINAPI
+PathFileExistsDefExtAndAttributesW(
+    _Inout_ LPWSTR pszPath,
+    _In_ DWORD dwWhich,
+    _Out_opt_ LPDWORD pdwFileAttributes);
+
 BOOL WINAPI PathFindOnPathExW(LPWSTR lpszFile, LPCWSTR *lppszOtherDirs, DWORD dwWhich);
 VOID WINAPI FixSlashesAndColonW(LPWSTR);
 BOOL WINAPI PathIsValidCharA(char c, DWORD dwClass);
@@ -324,12 +331,6 @@ IContextMenu_Invoke(
     _In_ UINT uFlags);
 
 DWORD WINAPI SHGetObjectCompatFlags(IUnknown *pUnk, const CLSID *clsid);
-
-BOOL WINAPI
-PathFileExistsDefExtAndAttributesW(
-    _Inout_ LPWSTR pszPath,
-    _In_ DWORD dwWhich,
-    _Out_opt_ LPDWORD pdwFileAttributes);
 
 #ifdef __cplusplus
 } /* extern "C" */


### PR DESCRIPTION
## Purpose
Implementing missing features...
JIRA issue: [CORE-19278](https://jira.reactos.org/browse/CORE-19278)

## Proposed changes

- Implement `PathFileExistsDefExtAndAttributesW` function.
- Add its prototype to `<shlwapi_undoc.h>`.
- Modify `shlwapi.spec`.
- Add `PathFileExistsDefExtAndAttributesW`  testcase.

## TODO

- [x] Do build.
- [x] Do tests.

## Comparison

WinXP:
![WinXP](https://github.com/reactos/reactos/assets/2107452/510d85b3-d256-4b20-b23c-e95eb329a674)
Successful.

Win2k3:
![Win2k3](https://github.com/reactos/reactos/assets/2107452/2d6352e3-e4a3-40a9-ac30-db7ca2f1c2a4)
Successful.

Win10:
![Win10](https://github.com/reactos/reactos/assets/2107452/a06b6e75-f58d-4d64-8bd5-88be33cff83d)
Successful.

ReactOS (AFTER):
![after](https://github.com/reactos/reactos/assets/2107452/69df1991-5d64-4692-9681-b5ab7961a99f)
Successful.