### PR TITLE
[NOTEPAD] Use FILE_SHARE_READ and OPEN_ALWAYS for writing

### DIFF
--- a/base/applications/notepad/dialog.c
+++ b/base/applications/notepad/dialog.c
@@ -249,9 +249,13 @@ static BOOL DoSaveFile(VOID)
 
     WaitCursor(TRUE);
 
-    hFile = CreateFileW(Globals.szFileName, GENERIC_WRITE,
+    hFile = CreateFileW(Globals.szFileName,
+                        GENERIC_READ | GENERIC_WRITE,
                         FILE_SHARE_READ | FILE_SHARE_WRITE,
-                        NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+                        NULL,
+                        OPEN_ALWAYS,
+                        FILE_ATTRIBUTE_NORMAL,
+                        NULL);
     if (hFile == INVALID_HANDLE_VALUE)
     {
         ShowLastError();
@@ -282,6 +286,7 @@ static BOOL DoSaveFile(VOID)
         }
     }
 
+    SetEndOfFile(hFile);
     CloseHandle(hFile);
 
     if (bRet)

--- a/base/applications/notepad/dialog.c
+++ b/base/applications/notepad/dialog.c
@@ -253,7 +253,7 @@ static BOOL DoSaveFile(VOID)
      * even if the file has HIDDEN or SYSTEM attributes */
     hFile = CreateFileW(Globals.szFileName,
                         GENERIC_WRITE,
-                        FILE_SHARE_READ | FILE_SHARE_WRITE,
+                        FILE_SHARE_READ,
                         NULL,
                         OPEN_ALWAYS,
                         FILE_ATTRIBUTE_NORMAL,

--- a/base/applications/notepad/dialog.c
+++ b/base/applications/notepad/dialog.c
@@ -249,8 +249,10 @@ static BOOL DoSaveFile(VOID)
 
     WaitCursor(TRUE);
 
+    /* Use OPEN_ALWAYS instead of CREATE_ALWAYS in order to succeed
+     * even if the file has HIDDEN or SYSTEM attributes */
     hFile = CreateFileW(Globals.szFileName,
-                        GENERIC_READ | GENERIC_WRITE,
+                        GENERIC_WRITE,
                         FILE_SHARE_READ | FILE_SHARE_WRITE,
                         NULL,
                         OPEN_ALWAYS,
@@ -286,6 +288,7 @@ static BOOL DoSaveFile(VOID)
         }
     }
 
+    /* Truncate the file and close it */
     SetEndOfFile(hFile);
     CloseHandle(hFile);
 

--- a/base/applications/notepad/dialog.c
+++ b/base/applications/notepad/dialog.c
@@ -249,7 +249,8 @@ static BOOL DoSaveFile(VOID)
 
     WaitCursor(TRUE);
 
-    hFile = CreateFileW(Globals.szFileName, GENERIC_WRITE, FILE_SHARE_WRITE,
+    hFile = CreateFileW(Globals.szFileName, GENERIC_WRITE,
+                        FILE_SHARE_READ | FILE_SHARE_WRITE,
                         NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
     if (hFile == INVALID_HANDLE_VALUE)
     {

--- a/base/applications/notepad/dialog.c
+++ b/base/applications/notepad/dialog.c
@@ -251,13 +251,8 @@ static BOOL DoSaveFile(VOID)
 
     /* Use OPEN_ALWAYS instead of CREATE_ALWAYS in order to succeed
      * even if the file has HIDDEN or SYSTEM attributes */
-    hFile = CreateFileW(Globals.szFileName,
-                        GENERIC_WRITE,
-                        FILE_SHARE_READ,
-                        NULL,
-                        OPEN_ALWAYS,
-                        FILE_ATTRIBUTE_NORMAL,
-                        NULL);
+    hFile = CreateFileW(Globals.szFileName, GENERIC_WRITE, FILE_SHARE_READ,
+                        NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
     if (hFile == INVALID_HANDLE_VALUE)
     {
         ShowLastError();


### PR DESCRIPTION
## Purpose

Fix access denial on writing file `"C:\freeldr.ini"`.

JIRA issue: [CORE-19575](https://jira.reactos.org/browse/CORE-19575)

## Proposed changes
- Add `FILE_SHARE_READ` flag and delete `FILE_SHARE_WRITE` flag in `CreateFileW` call.
- Use `OPEN_ALWAYS` instead of `CREATE_ALWAYS`, and then explicitly use `SetEndOfFile` function.

## TODO

- [x] Do tests.

## Comparison

BEFORE:
![before](https://github.com/reactos/reactos/assets/2107452/b431b669-8555-4b33-8fe9-16f5ed79377a)
Access denial.

AFTER:
![after](https://github.com/reactos/reactos/assets/2107452/ffcf192d-a7a7-4965-a41e-778f98cdfa18)
Successfully saved.