### PR TITLE
[WORDPAD] Use FILE_SHARE_READ and OPEN_ALWAYS for writing

### DIFF
--- a/base/applications/wordpad/wordpad.c
+++ b/base/applications/wordpad/wordpad.c
@@ -843,8 +843,15 @@ static BOOL DoSaveFile(LPCWSTR wszSaveFileName, WPARAM format)
     EDITSTREAM stream;
     LRESULT ret;
 
+#ifdef __REACTOS__
+    /* Use OPEN_ALWAYS instead of CREATE_ALWAYS in order to succeed
+     * even if the file has HIDDEN or SYSTEM attributes */
+    hFile = CreateFileW(wszSaveFileName, GENERIC_WRITE, FILE_SHARE_READ, NULL, OPEN_ALWAYS,
+        FILE_ATTRIBUTE_NORMAL, NULL);
+#else
     hFile = CreateFileW(wszSaveFileName, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS,
         FILE_ATTRIBUTE_NORMAL, NULL);
+#endif
 
     if(hFile == INVALID_HANDLE_VALUE)
     {
@@ -870,6 +877,10 @@ static BOOL DoSaveFile(LPCWSTR wszSaveFileName, WPARAM format)
 
     ret = SendMessageW(hEditorWnd, EM_STREAMOUT, format, (LPARAM)&stream);
 
+#ifdef __REACTOS__
+    /* Truncate the file and close it */
+    SetEndOfFile(hFile);
+#endif
     CloseHandle(hFile);
 
     SetFocus(hEditorWnd);


### PR DESCRIPTION
## Purpose

Follow-up to #6880. Fix access denial on writing file "C:\freeldr.ini".
JIRA issue: [CORE-19575](https://jira.reactos.org/browse/CORE-19575)

## Proposed changes

- Add `FILE_SHARE_READ` flag in `CreateFileW` call.
- Use `OPEN_ALWAYS` instead of `CREATE_ALWAYS`, and then explicitly use `SetEndOfFile` function.

## TODO

- [x] Do tests.

## Comparison

BEFORE:
![before](https://github.com/reactos/reactos/assets/2107452/2809c5fb-b2c6-4946-b210-c16378004dcf)
Access denial.

AFTER:
![after](https://github.com/reactos/reactos/assets/2107452/a82333bf-c357-4d51-bbf8-75c261a9528f)
Successful.