### PR TITLE
[NTGDI] AlphaBlend/TransparentBlt: check whether the source DC is an Info DC too

### DIFF
--- a/win32ss/gdi/ntgdi/bitblt.c
+++ b/win32ss/gdi/ntgdi/bitblt.c
@@ -61,7 +61,7 @@ NtGdiAlphaBlend(
     DCDest = apObj[0];
     DCSrc = apObj[1];
 
-    if (DCDest->dctype == DCTYPE_INFO || DCDest->dctype == DCTYPE_INFO)
+    if (DCSrc->dctype == DCTYPE_INFO || DCDest->dctype == DCTYPE_INFO)
     {
         GDIOBJ_vUnlockObject(&DCSrc->BaseObject);
         GDIOBJ_vUnlockObject(&DCDest->BaseObject);
@@ -239,7 +239,7 @@ NtGdiTransparentBlt(
     DCDest = apObj[0];
     DCSrc = apObj[1];
 
-    if (DCDest->dctype == DCTYPE_INFO || DCDest->dctype == DCTYPE_INFO)
+    if (DCSrc->dctype == DCTYPE_INFO || DCDest->dctype == DCTYPE_INFO)
     {
         GDIOBJ_vUnlockObject(&DCSrc->BaseObject);
         GDIOBJ_vUnlockObject(&DCDest->BaseObject);


### PR DESCRIPTION
## Purpose

Improve the checks in `AlphaBlend` and `TransparentBlt` functions: check whether `DCSrc` is of `DCTYPE_INFO` also, to fail in that case properly too. Spotted by PVS-Studio analysis.
Reference: https://pvs-studio.com/en/blog/posts/cpp/1122/.
JIRA issue: None.