### PR TITLE
[USER32] Hackfix for CORE-17902 - The cursoricon (copyimage) that returns NULL to render - LR_COPYFROMRESOURCE

### DIFF
--- a/win32ss/user/user32/windows/cursoricon.c
+++ b/win32ss/user/user32/windows/cursoricon.c
@@ -2031,7 +2031,15 @@ HANDLE WINAPI CopyImage(
             return BITMAP_CopyImage(hImage, cxDesired, cyDesired, fuFlags);
         case IMAGE_CURSOR:
         case IMAGE_ICON:
-            return CURSORICON_CopyImage(hImage, uType == IMAGE_ICON, cxDesired, cyDesired, fuFlags);
+     /* HACK: Copying bitmaps with LR_COPYFROMRESOURCE flag fails. CORE-17902.
+     * This is a way to return original bit map it if we want
+     * the icons to show up. We need a simpler test. */
+        {
+            HANDLE handle = CURSORICON_CopyImage(hImage, uType == IMAGE_ICON, cxDesired, cyDesired, fuFlags);
+            if (!handle && (fuFlags & (LR_COPYFROMRESOURCE|LR_COPYRETURNORG)))
+                handle = CURSORICON_CopyImage(hImage, uType == IMAGE_ICON, cxDesired, cyDesired, (fuFlags & ~LR_COPYFROMRESOURCE));
+            return handle;
+        }
         default:
             SetLastError(ERROR_INVALID_PARAMETER);
             break;

--- a/win32ss/user/user32/windows/cursoricon.c
+++ b/win32ss/user/user32/windows/cursoricon.c
@@ -2031,9 +2031,9 @@ HANDLE WINAPI CopyImage(
             return BITMAP_CopyImage(hImage, cxDesired, cyDesired, fuFlags);
         case IMAGE_CURSOR:
         case IMAGE_ICON:
-     /* HACK: Copying bitmaps with LR_COPYFROMRESOURCE flag fails. CORE-17902.
-     * This is a way to return original bit map it if we want
-     * the icons to show up. We need a simpler test. */
+        /* HACK: Copying bitmaps with LR_COPYFROMRESOURCE flag fails. CORE-17902.
+         * This is a way to return the original bit map if we need
+         * the icons to show up. We need a simpler test. */
         {
             HANDLE handle = CURSORICON_CopyImage(hImage, uType == IMAGE_ICON, cxDesired, cyDesired, fuFlags);
             if (!handle && (fuFlags & (LR_COPYFROMRESOURCE|LR_COPYRETURNORG)))


### PR DESCRIPTION
Hackfix for CORE-17902 - The cursoricon (copyimage) that returns NULL to render - LR_COPYFROMRESOURCE

## Purpose

In this case, the aim is to render some VB5/6 software icons to show up. Those elements are icons rendered in a way that is common under Visual Basic icons loaded from a .ocx .

ThunderRT6FormDC->ThunderRT6UserControlDC->RebarWindows32->Toolbar20WndClass->msvb_lib_toolbar

Quoting Simone:

> Unable to render embedded object: File (ReactOS_workaround) not found.
> 
> it is making a CopyImage call with the LR_COPYFROMRESOURCE|LB_COPYRETURNORG flags. All of these are returning NULL.
> LB_COPYRETURNORG flag is only managed by bitmap copy function (BITMAP_CopyImage), not by the cursoricon copy function (CURSORICON_CopyImage) but it's not the critical one.
> The critical flag is the LR_COPYFROMRESOURCE. 

More info here: https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-copyimage

>By making it to return the original bitmap in the case of failure, makes the icon shown as expected.
>The issue so resides on application of api ("tries to" means "tries to" so the fallback to return the original image isneeded), or there is a failure on child NtUserGetIconInfo.

- Fix JIRA issue: [CORE-17902](https://jira.reactos.org/browse/CORE-17902)

## Proposed changes

Minor (fix? or hackfix?) that should make it to work. 
 
BEFORE:
![Before](https://github.com/reactos/reactos/assets/27921286/a385946c-425f-4eb8-9a05-9e490053b001)

AFTER: 
![After](https://github.com/reactos/reactos/assets/27921286/5147b6bf-2912-440a-991c-63de3b718816)

## TODO

- [ ] Investigate if the behavior is correct comparing to Windows.
- [ ] Investigate if there is any better way to implement it/or if there are similar failures under a more simple software to test.
