### PR TITLE
[SHELL32] HCU_GetIconW: Fix the root key

### DIFF
--- a/dll/win32/shell32/wine/classes.c
+++ b/dll/win32/shell32/wine/classes.c
@@ -348,7 +348,7 @@ BOOL HCU_GetIconW(LPCWSTR szClass, LPWSTR szDest, LPCWSTR szName, DWORD len, int
 
     StringCchPrintfW(sTemp, _countof(sTemp), L"%s\\DefaultIcon", szClass);
 
-    if (!RegOpenKeyExW(HKEY_CURRENT_USER, sTemp, 0, KEY_READ, &hkey))
+    if (!RegOpenKeyExW(HKEY_CLASSES_ROOT, sTemp, 0, KEY_READ, &hkey))
     {
         ret = HCR_RegGetIconW(hkey, szDest, szName, len, picon_idx);
         RegCloseKey(hkey);


### PR DESCRIPTION
## Purpose

Load icon correctly. However this PR doesn't fix CORE-19202 yet.

JIRA issue: [CORE-19202](https://jira.reactos.org/browse/CORE-19202)

## Proposed changes

- In `HCU_GetIconW` function, change the root key from `HKEY_CURRENT_USER` to `HKEY_CLASSES_ROOT`.

