### PR TITLE
[SHELL32_APITEST] Add SHSimpleIDListFromPath testcase

### DIFF
--- a/modules/rostests/apitests/shell32/CMakeLists.txt
+++ b/modules/rostests/apitests/shell32/CMakeLists.txt
@@ -32,6 +32,7 @@ list(APPEND SOURCE
     SHCreateFileExtractIconW.cpp
     SHParseDisplayName.cpp
     SHRestricted.cpp
+    SHSimpleIDListFromPath.cpp
     She.cpp
     ShellExecCmdLine.cpp
     ShellExecuteEx.cpp

--- a/modules/rostests/apitests/shell32/SHSimpleIDListFromPath.cpp
+++ b/modules/rostests/apitests/shell32/SHSimpleIDListFromPath.cpp
@@ -37,11 +37,7 @@ START_TEST(SHSimpleIDListFromPath)
     hr = (psf2 ? psf2->GetAttributesOf(1, &pidl2Last, &attrs2) : E_UNEXPECTED);
     ok_long(hr, S_OK);
 
-    // This fact is the difference:
+    // There is the difference in attributes:
     ok_long((attrs1 & SFGAO_FOLDER), 0);
     ok_long((attrs2 & SFGAO_FOLDER), SFGAO_FOLDER);
-
-    // Clean up
-    ILFree(pidl1);
-    ILFree(pidl2);
 }

--- a/modules/rostests/apitests/shell32/SHSimpleIDListFromPath.cpp
+++ b/modules/rostests/apitests/shell32/SHSimpleIDListFromPath.cpp
@@ -1,0 +1,48 @@
+/*
+ * PROJECT:     ReactOS API tests
+ * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
+ * PURPOSE:     Test for SHSimpleIDListFromPath
+ * COPYRIGHT:   Copyright 2024 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
+ */
+
+#include "shelltest.h"
+#include <shellutils.h>
+
+START_TEST(SHSimpleIDListFromPath)
+{
+    HRESULT hr;
+    WCHAR szPath[MAX_PATH];
+    GetWindowsDirectoryW(szPath, _countof(szPath));
+
+    LPITEMIDLIST pidl1 = SHSimpleIDListFromPath(szPath);
+    LPITEMIDLIST pidl2 = ILCreateFromPathW(szPath);
+    LPITEMIDLIST pidl1Last = ILFindLastID(pidl1);
+    LPITEMIDLIST pidl2Last = ILFindLastID(pidl2);
+    ok_int(ILIsEqual(pidl1, pidl2), TRUE);
+    ok_int(ILIsEqual(pidl1Last, pidl2Last), TRUE);
+
+    IShellFolder *psf1 = NULL;
+    IShellFolder *psf2 = NULL;
+    hr = SHBindToParent(pidl1, IID_PPV_ARG(IShellFolder, &psf1), NULL);
+    ok_long(hr, S_OK);
+    hr = SHBindToParent(pidl2, IID_PPV_ARG(IShellFolder, &psf2), NULL);
+    ok_long(hr, S_OK);
+
+    DWORD attrs1 = SFGAO_FOLDER;
+    DWORD attrs2 = SFGAO_FOLDER;
+
+    hr = (psf1 ? psf1->GetAttributesOf(1, &pidl1Last, &attrs1) : E_UNEXPECTED);
+    ok_long(hr, S_OK);
+    hr = (psf2 ? psf2->GetAttributesOf(1, &pidl2Last, &attrs2) : E_UNEXPECTED);
+    ok_long(hr, S_OK);
+
+    ok_long((attrs1 & SFGAO_FOLDER), 0);
+    ok_long((attrs2 & SFGAO_FOLDER), SFGAO_FOLDER);
+
+    ILFree(pidl1);
+    ILFree(pidl2);
+    if (psf1)
+        psf1->Release();
+    if (psf2)
+        psf2->Release();
+}

--- a/modules/rostests/apitests/shell32/SHSimpleIDListFromPath.cpp
+++ b/modules/rostests/apitests/shell32/SHSimpleIDListFromPath.cpp
@@ -14,35 +14,31 @@ START_TEST(SHSimpleIDListFromPath)
     WCHAR szPath[MAX_PATH];
     GetWindowsDirectoryW(szPath, _countof(szPath));
 
-    LPITEMIDLIST pidl1 = SHSimpleIDListFromPath(szPath);
-    LPITEMIDLIST pidl2 = ILCreateFromPathW(szPath);
+    // We will compare pidl1 and pidl2
+    CComHeapPtr<ITEMIDLIST> pidl1(SHSimpleIDListFromPath(szPath));
+    CComHeapPtr<ITEMIDLIST> pidl2(ILCreateFromPathW(szPath));
+
     LPITEMIDLIST pidl1Last = ILFindLastID(pidl1);
     LPITEMIDLIST pidl2Last = ILFindLastID(pidl2);
     ok_int(ILIsEqual(pidl1, pidl2), TRUE);
     ok_int(ILIsEqual(pidl1Last, pidl2Last), TRUE);
 
-    IShellFolder *psf1 = NULL;
-    IShellFolder *psf2 = NULL;
+    CComPtr<IShellFolder> psf1, psf2;
     hr = SHBindToParent(pidl1, IID_PPV_ARG(IShellFolder, &psf1), NULL);
     ok_long(hr, S_OK);
     hr = SHBindToParent(pidl2, IID_PPV_ARG(IShellFolder, &psf2), NULL);
     ok_long(hr, S_OK);
 
-    DWORD attrs1 = SFGAO_FOLDER;
-    DWORD attrs2 = SFGAO_FOLDER;
-
+    DWORD attrs1 = SFGAO_FOLDER, attrs2 = SFGAO_FOLDER;
     hr = (psf1 ? psf1->GetAttributesOf(1, &pidl1Last, &attrs1) : E_UNEXPECTED);
     ok_long(hr, S_OK);
     hr = (psf2 ? psf2->GetAttributesOf(1, &pidl2Last, &attrs2) : E_UNEXPECTED);
     ok_long(hr, S_OK);
 
+    // This fact is important:
     ok_long((attrs1 & SFGAO_FOLDER), 0);
     ok_long((attrs2 & SFGAO_FOLDER), SFGAO_FOLDER);
 
     ILFree(pidl1);
     ILFree(pidl2);
-    if (psf1)
-        psf1->Release();
-    if (psf2)
-        psf2->Release();
 }

--- a/modules/rostests/apitests/shell32/SHSimpleIDListFromPath.cpp
+++ b/modules/rostests/apitests/shell32/SHSimpleIDListFromPath.cpp
@@ -14,31 +14,34 @@ START_TEST(SHSimpleIDListFromPath)
     WCHAR szPath[MAX_PATH];
     GetWindowsDirectoryW(szPath, _countof(szPath));
 
-    // We will compare pidl1 and pidl2
+    // We compare pidl1 and pidl2
     CComHeapPtr<ITEMIDLIST> pidl1(SHSimpleIDListFromPath(szPath));
     CComHeapPtr<ITEMIDLIST> pidl2(ILCreateFromPathW(szPath));
 
-    LPITEMIDLIST pidl1Last = ILFindLastID(pidl1);
-    LPITEMIDLIST pidl2Last = ILFindLastID(pidl2);
+    // Yes, they are equal logically
+    LPITEMIDLIST pidl1Last = ILFindLastID(pidl1), pidl2Last = ILFindLastID(pidl2);
     ok_int(ILIsEqual(pidl1, pidl2), TRUE);
     ok_int(ILIsEqual(pidl1Last, pidl2Last), TRUE);
 
+    // Bind to parent
     CComPtr<IShellFolder> psf1, psf2;
     hr = SHBindToParent(pidl1, IID_PPV_ARG(IShellFolder, &psf1), NULL);
     ok_long(hr, S_OK);
     hr = SHBindToParent(pidl2, IID_PPV_ARG(IShellFolder, &psf2), NULL);
     ok_long(hr, S_OK);
 
+    // Get attributes
     DWORD attrs1 = SFGAO_FOLDER, attrs2 = SFGAO_FOLDER;
     hr = (psf1 ? psf1->GetAttributesOf(1, &pidl1Last, &attrs1) : E_UNEXPECTED);
     ok_long(hr, S_OK);
     hr = (psf2 ? psf2->GetAttributesOf(1, &pidl2Last, &attrs2) : E_UNEXPECTED);
     ok_long(hr, S_OK);
 
-    // This fact is important:
+    // This fact is the difference:
     ok_long((attrs1 & SFGAO_FOLDER), 0);
     ok_long((attrs2 & SFGAO_FOLDER), SFGAO_FOLDER);
 
+    // Clean up
     ILFree(pidl1);
     ILFree(pidl2);
 }

--- a/modules/rostests/apitests/shell32/testlist.c
+++ b/modules/rostests/apitests/shell32/testlist.c
@@ -40,6 +40,7 @@ extern void func_ShellState(void);
 extern void func_SHGetAttributesFromDataObject(void);
 extern void func_SHLimitInputEdit(void);
 extern void func_SHParseDisplayName(void);
+extern void func_SHSimpleIDListFromPath(void);
 extern void func_SHRestricted(void);
 
 const struct test winetest_testlist[] =
@@ -81,6 +82,7 @@ const struct test winetest_testlist[] =
     { "SHGetAttributesFromDataObject", func_SHGetAttributesFromDataObject },
     { "SHLimitInputEdit", func_SHLimitInputEdit },
     { "SHParseDisplayName", func_SHParseDisplayName },
+    { "SHSimpleIDListFromPath", func_SHSimpleIDListFromPath },
     { "SHRestricted", func_SHRestricted },
 
     { 0, 0 }


### PR DESCRIPTION
## Purpose

Inspect the behavior of `shell32!SHSimpleIDListFromPath` function.
JIRA issue: [CORE-19591](https://jira.reactos.org/browse/CORE-19591)

## TODO

- [x] Do tests

## Comparison

WinXP:
![WinXP](https://github.com/reactos/reactos/assets/2107452/e900c732-1e49-45a5-8475-c65fc3318b2f)
Successful.

Win2k3:
![Win2k3](https://github.com/reactos/reactos/assets/2107452/9439a475-6b5e-4b60-a91b-62c7d68e5f7b)
Successful.

Win10 x64:
![Win10](https://github.com/reactos/reactos/assets/2107452/9c6abe73-dcfa-4fec-beaf-9752fe8ae7ff)
Successful.