### PR TITLE
[SHLWAPI][SDK] Add IShellFolder_... helper functions

### DIFF
--- a/dll/win32/shlwapi/shlwapi.spec
+++ b/dll/win32/shlwapi/shlwapi.spec
@@ -313,8 +313,8 @@
 313 stdcall -noname SHGetFileInfoWrapW(ptr long ptr long long)
 314 stdcall -noname RegisterClassExWrapW(ptr) user32.RegisterClassExW
 315 stdcall -noname GetClassInfoExWrapW(long wstr ptr) user32.GetClassInfoExW
-316 stub -noname IShellFolder_GetDisplayNameOf
-317 stub -noname IShellFolder_ParseDisplayName
+316 stdcall -noname IShellFolder_GetDisplayNameOf(ptr ptr long ptr long)
+317 stdcall -noname IShellFolder_ParseDisplayName(ptr ptr ptr wstr ptr ptr ptr)
 318 stdcall -noname DragQueryFileWrapW(long long wstr long)
 319 stdcall -noname FindWindowExWrapW(long long wstr wstr) user32.FindWindowExW
 320 stdcall -noname RegisterMIMETypeForExtensionA(str str)
@@ -548,7 +548,7 @@
 548 stdcall -noname SHAreIconsEqual(ptr ptr)
 549 stdcall -noname SHCoCreateInstanceAC(ptr ptr long ptr ptr)
 550 stub -noname GetTemplateInfoFromHandle
-551 stub -noname IShellFolder_CompareIDs
+551 stdcall -noname IShellFolder_CompareIDs(ptr ptr ptr ptr)
 552 stdcall -stub -noname -version=0x501-0x502 SHEvaluateSystemCommandTemplate(wstr ptr ptr ptr)
 553 stdcall IsInternetESCEnabled()
 554 stdcall -noname -stub SHGetAllAccessSA()

--- a/dll/win32/shlwapi/utils.cpp
+++ b/dll/win32/shlwapi/utils.cpp
@@ -183,19 +183,25 @@ IShellFolder_ParseDisplayName(
     _Out_opt_ PIDLIST_RELATIVE *ppidl,
     _Out_opt_ ULONG *pdwAttributes)
 {
-    ULONG dummy1, dummy2, *pAttrs, *pchAgent;
+    ULONG dummy1, dummy2;
 
     TRACE("(%p, %p, %s, %p, %p, %p)\n", hwndOwner, pbcReserved, lpszDisplayName,
                                         pchEaten, ppidl, pdwAttributes);
 
     /* Improve safety */
     dummy1 = dummy2 = 0;
-    pAttrs = (pdwAttributes ? pdwAttributes : &dummy1);
-    pchAgent = (pchEaten ? pchEaten : &dummy2);
+
+    if (!pdwAttributes)
+        pdwAttributes = &dummy1;
+
+    if (!pchEaten)
+        pchEaten = &dummy2;
+
     if (ppidl)
         *ppidl = NULL;
 
-    return psf->ParseDisplayName(hwndOwner, pbcReserved, lpszDisplayName, pchAgent, ppidl, pAttrs);
+    return psf->ParseDisplayName(hwndOwner, pbcReserved, lpszDisplayName, pchEaten,
+                                 ppidl, pdwAttributes);
 }
 
 /*************************************************************************

--- a/dll/win32/shlwapi/utils.cpp
+++ b/dll/win32/shlwapi/utils.cpp
@@ -6,15 +6,24 @@
  */
 
 #define _ATL_NO_EXCEPTIONS
+
+/*
+ * HACK!  These functions are conflicting with <shobjidl.h> inline functions...
+ */
 #define IShellFolder_GetDisplayNameOf _disabled_IShellFolder_GetDisplayNameOf_
 #define IShellFolder_ParseDisplayName _disabled_IShellFolder_ParseDisplayName_
 #define IShellFolder_CompareIDs _disabled_IShellFolder_CompareIDs_
+
 #include "precomp.h"
 #include <shellapi.h>
 #include <shlwapi.h>
 #include <shlobj_undoc.h>
 #include <shlguid_undoc.h>
 #include <atlstr.h>
+
+/*
+ * HACK!  These functions are conflicting with <shobjidl.h> inline functions...
+ */
 #undef IShellFolder_GetDisplayNameOf
 #undef IShellFolder_ParseDisplayName
 #undef IShellFolder_CompareIDs

--- a/dll/win32/shlwapi/utils.cpp
+++ b/dll/win32/shlwapi/utils.cpp
@@ -19,7 +19,7 @@
 #undef IShellFolder_ParseDisplayName
 #undef IShellFolder_CompareIDs
 
-#define WANT_ISHELLFOLDER_HELPERS
+#define SHLWAPI_ISHELLFOLDER_HELPERS
 #include <shlwapi_undoc.h>
 
 #include <strsafe.h>

--- a/dll/win32/shlwapi/utils.cpp
+++ b/dll/win32/shlwapi/utils.cpp
@@ -6,13 +6,19 @@
  */
 
 #define _ATL_NO_EXCEPTIONS
+#define IShellFolder_GetDisplayNameOf _disabled_IShellFolder_GetDisplayNameOf_
+#define IShellFolder_ParseDisplayName _disabled_IShellFolder_ParseDisplayName_
+#define IShellFolder_CompareIDs _disabled_IShellFolder_CompareIDs_
 #include "precomp.h"
 #include <shellapi.h>
 #include <shlwapi.h>
-#include <shlwapi_undoc.h>
 #include <shlobj_undoc.h>
 #include <shlguid_undoc.h>
 #include <atlstr.h>
+#undef IShellFolder_GetDisplayNameOf
+#undef IShellFolder_ParseDisplayName
+#undef IShellFolder_CompareIDs
+#include <shlwapi_undoc.h>
 #include <strsafe.h>
 
 WINE_DEFAULT_DEBUG_CHANNEL(shell);
@@ -125,6 +131,7 @@ SHLWAPI_IsBogusHRESULT(HRESULT hr)
 /*************************************************************************
  * IShellFolder_GetDisplayNameOf [SHLWAPI.316]
  */
+#undef IShellFolder_GetDisplayNameOf
 EXTERN_C HRESULT WINAPI
 IShellFolder_GetDisplayNameOf(
     _In_ IShellFolder *psf,
@@ -155,6 +162,7 @@ IShellFolder_GetDisplayNameOf(
 /*************************************************************************
  * IShellFolder_ParseDisplayName [SHLWAPI.317]
  */
+#undef IShellFolder_ParseDisplayName
 EXTERN_C HRESULT WINAPI
 IShellFolder_ParseDisplayName(
     _In_ IShellFolder *psf,
@@ -162,7 +170,7 @@ IShellFolder_ParseDisplayName(
     _In_opt_ LPBC pbcReserved,
     _In_ LPOLESTR lpszDisplayName,
     _Out_opt_ ULONG *pchEaten,
-    _Out_opt_ LPITEMIDLIST *ppidl,
+    _Out_opt_ PIDLIST_RELATIVE *ppidl,
     _Out_opt_ ULONG *pdwAttributes)
 {
     ULONG dummy1, dummy2, *pAttrs, *pchAgent;
@@ -183,12 +191,13 @@ IShellFolder_ParseDisplayName(
 /*************************************************************************
  * IShellFolder_CompareIDs [SHLWAPI.551]
  */
+#undef IShellFolder_CompareIDs
 EXTERN_C HRESULT WINAPI
 IShellFolder_CompareIDs(
     _In_ IShellFolder *psf,
     _In_ LPARAM lParam,
-    _In_ LPCITEMIDLIST pidl1,
-    _In_ LPCITEMIDLIST pidl2)
+    _In_ PCUIDLIST_RELATIVE pidl1,
+    _In_ PCUIDLIST_RELATIVE pidl2)
 {
     HRESULT hr;
     TRACE("(%p, %p, %p, %p)\n", psf, lParam, pidl1, pidl2);

--- a/dll/win32/shlwapi/utils.cpp
+++ b/dll/win32/shlwapi/utils.cpp
@@ -217,7 +217,7 @@ IShellFolder_CompareIDs(
     HRESULT hr;
     TRACE("(%p, %p, %p, %p)\n", psf, lParam, pidl1, pidl2);
 
-    if (lParam & ~SHCIDS_COLUMNMASK)
+    if (lParam & ~(SIZE_T)SHCIDS_COLUMNMASK)
     {
         /* Try as IShellFolder2 if possible */
         hr = psf->QueryInterface(IID_IShellFolder2, (void **)&psf);

--- a/dll/win32/shlwapi/utils.cpp
+++ b/dll/win32/shlwapi/utils.cpp
@@ -158,12 +158,12 @@ IShellFolder_GetDisplayNameOf(
 EXTERN_C HRESULT WINAPI
 IShellFolder_ParseDisplayName(
     _In_ IShellFolder *psf,
-    _In_ HWND hwndOwner,
-    _In_ LPBC pbcReserved,
+    _In_opt_ HWND hwndOwner,
+    _In_opt_ LPBC pbcReserved,
     _In_ LPOLESTR lpszDisplayName,
-    _Out_ ULONG *pchEaten,
-    _Out_ LPITEMIDLIST *ppidl,
-    _Out_ ULONG *pdwAttributes)
+    _Out_opt_ ULONG *pchEaten,
+    _Out_opt_ LPITEMIDLIST *ppidl,
+    _Out_opt_ ULONG *pdwAttributes)
 {
     ULONG dummy1, dummy2, *pAttrs, *pchAgent;
 
@@ -174,7 +174,8 @@ IShellFolder_ParseDisplayName(
     dummy1 = dummy2 = 0;
     pAttrs = (pdwAttributes ? pdwAttributes : &dummy1);
     pchAgent = (pchEaten ? pchEaten : &dummy2);
-    if (ppidl) *ppidl = NULL;
+    if (ppidl)
+        *ppidl = NULL;
 
     return psf->ParseDisplayName(hwndOwner, pbcReserved, lpszDisplayName, pchAgent, ppidl, pAttrs);
 }
@@ -194,7 +195,7 @@ IShellFolder_CompareIDs(
 
     if (!IS_INTRESOURCE(lParam))
     {
-        /* Try as IShellFolder2 */
+        /* Try as IShellFolder2 if possible */
         hr = psf->QueryInterface(IID_IShellFolder2, (void **)&psf);
         if (FAILED(hr))
             lParam = LOWORD(lParam);

--- a/dll/win32/shlwapi/utils.cpp
+++ b/dll/win32/shlwapi/utils.cpp
@@ -185,7 +185,7 @@ IShellFolder_ParseDisplayName(
 {
     ULONG dummy1, dummy2;
 
-    TRACE("(%p, %p, %s, %p, %p, %p)\n", hwndOwner, pbcReserved, lpszDisplayName,
+    TRACE("(%p, %p, %s, %p, %p, %p)\n", hwndOwner, pbcReserved, debugstr_w(lpszDisplayName),
                                         pchEaten, ppidl, pdwAttributes);
 
     if (!pdwAttributes)

--- a/dll/win32/shlwapi/utils.cpp
+++ b/dll/win32/shlwapi/utils.cpp
@@ -18,7 +18,10 @@
 #undef IShellFolder_GetDisplayNameOf
 #undef IShellFolder_ParseDisplayName
 #undef IShellFolder_CompareIDs
+
+#define WANT_ISHELLFOLDER_HELPERS
 #include <shlwapi_undoc.h>
+
 #include <strsafe.h>
 
 WINE_DEFAULT_DEBUG_CHANNEL(shell);
@@ -131,7 +134,6 @@ SHLWAPI_IsBogusHRESULT(HRESULT hr)
 /*************************************************************************
  * IShellFolder_GetDisplayNameOf [SHLWAPI.316]
  */
-#undef IShellFolder_GetDisplayNameOf
 EXTERN_C HRESULT WINAPI
 IShellFolder_GetDisplayNameOf(
     _In_ IShellFolder *psf,
@@ -162,7 +164,6 @@ IShellFolder_GetDisplayNameOf(
 /*************************************************************************
  * IShellFolder_ParseDisplayName [SHLWAPI.317]
  */
-#undef IShellFolder_ParseDisplayName
 EXTERN_C HRESULT WINAPI
 IShellFolder_ParseDisplayName(
     _In_ IShellFolder *psf,
@@ -191,7 +192,6 @@ IShellFolder_ParseDisplayName(
 /*************************************************************************
  * IShellFolder_CompareIDs [SHLWAPI.551]
  */
-#undef IShellFolder_CompareIDs
 EXTERN_C HRESULT WINAPI
 IShellFolder_CompareIDs(
     _In_ IShellFolder *psf,

--- a/dll/win32/shlwapi/utils.cpp
+++ b/dll/win32/shlwapi/utils.cpp
@@ -162,7 +162,7 @@ IShellFolder_GetDisplayNameOf(
     dwRetryFlags |= 0x80000000;
 
     if ((uFlags & SHGDN_FORPARSING) == 0)
-        dwRetryFlags |= 1;
+        dwRetryFlags |= SFGDNO_RETRYWITHFORPARSING;
 
     /* It seems the function is actually retrying here */
     FIXME("dwRetryFlags: 0x%X\n", dwRetryFlags);

--- a/dll/win32/shlwapi/utils.cpp
+++ b/dll/win32/shlwapi/utils.cpp
@@ -28,7 +28,7 @@
 #undef IShellFolder_ParseDisplayName
 #undef IShellFolder_CompareIDs
 
-#define SHLWAPI_ISHELLFOLDER_HELPERS
+#define SHLWAPI_ISHELLFOLDER_HELPERS /* HACK! */
 #include <shlwapi_undoc.h>
 
 #include <strsafe.h>

--- a/dll/win32/shlwapi/utils.cpp
+++ b/dll/win32/shlwapi/utils.cpp
@@ -8,7 +8,7 @@
 #define _ATL_NO_EXCEPTIONS
 
 /*
- * HACK!  These functions are conflicting with <shobjidl.h> inline functions...
+ * HACK! These functions are conflicting with <shobjidl.h> inline functions...
  */
 #define IShellFolder_GetDisplayNameOf _disabled_IShellFolder_GetDisplayNameOf_
 #define IShellFolder_ParseDisplayName _disabled_IShellFolder_ParseDisplayName_
@@ -22,7 +22,7 @@
 #include <atlstr.h>
 
 /*
- * HACK!  These functions are conflicting with <shobjidl.h> inline functions...
+ * HACK! These functions are conflicting with <shobjidl.h> inline functions...
  */
 #undef IShellFolder_GetDisplayNameOf
 #undef IShellFolder_ParseDisplayName
@@ -188,14 +188,17 @@ IShellFolder_ParseDisplayName(
     TRACE("(%p, %p, %s, %p, %p, %p)\n", hwndOwner, pbcReserved, lpszDisplayName,
                                         pchEaten, ppidl, pdwAttributes);
 
-    /* Improve safety */
-    dummy1 = dummy2 = 0;
-
     if (!pdwAttributes)
+    {
+        dummy1 = 0;
         pdwAttributes = &dummy1;
+    }
 
     if (!pchEaten)
+    {
+        dummy2 = 0;
         pchEaten = &dummy2;
+    }
 
     if (ppidl)
         *ppidl = NULL;
@@ -214,15 +217,14 @@ IShellFolder_CompareIDs(
     _In_ PCUIDLIST_RELATIVE pidl1,
     _In_ PCUIDLIST_RELATIVE pidl2)
 {
-    HRESULT hr;
     TRACE("(%p, %p, %p, %p)\n", psf, lParam, pidl1, pidl2);
 
     if (lParam & ~(SIZE_T)SHCIDS_COLUMNMASK)
     {
         /* Try as IShellFolder2 if possible */
-        hr = psf->QueryInterface(IID_IShellFolder2, (void **)&psf);
+        HRESULT hr = psf->QueryInterface(IID_IShellFolder2, (void **)&psf);
         if (FAILED(hr))
-            lParam = LOWORD(lParam);
+            lParam &= SHCIDS_COLUMNMASK;
         else
             psf->Release();
     }

--- a/dll/win32/shlwapi/utils.cpp
+++ b/dll/win32/shlwapi/utils.cpp
@@ -153,7 +153,7 @@ IShellFolder_GetDisplayNameOf(
 {
     HRESULT hr;
 
-    TRACE("(%p, %p, 0x%lX, %p, 0x%lX)\n", psf, pidl, uFlags, lpName, dwRetryFlags);
+    TRACE("(%p)->(%p, 0x%lX, %p, 0x%lX)\n", psf, pidl, uFlags, lpName, dwRetryFlags);
 
     hr = psf->GetDisplayNameOf(pidl, uFlags, lpName);
     if (!SHLWAPI_IsBogusHRESULT(hr))
@@ -185,8 +185,8 @@ IShellFolder_ParseDisplayName(
 {
     ULONG dummy1, dummy2;
 
-    TRACE("(%p, %p, %s, %p, %p, %p)\n", hwndOwner, pbcReserved, debugstr_w(lpszDisplayName),
-                                        pchEaten, ppidl, pdwAttributes);
+    TRACE("(%p)->(%p, %p, %s, %p, %p, %p)\n", psf, hwndOwner, pbcReserved,
+          debugstr_w(lpszDisplayName), pchEaten, ppidl, pdwAttributes);
 
     if (!pdwAttributes)
     {

--- a/dll/win32/shlwapi/utils.cpp
+++ b/dll/win32/shlwapi/utils.cpp
@@ -217,7 +217,7 @@ IShellFolder_CompareIDs(
     HRESULT hr;
     TRACE("(%p, %p, %p, %p)\n", psf, lParam, pidl1, pidl2);
 
-    if (!IS_INTRESOURCE(lParam))
+    if (lParam & ~SHCIDS_COLUMNMASK)
     {
         /* Try as IShellFolder2 if possible */
         hr = psf->QueryInterface(IID_IShellFolder2, (void **)&psf);

--- a/dll/win32/shlwapi/utils.cpp
+++ b/dll/win32/shlwapi/utils.cpp
@@ -22,7 +22,7 @@
 #include <atlstr.h>
 
 /*
- * HACK! These functions are conflicting with <shobjidl.h> inline functions...
+ * HACK!
  */
 #undef IShellFolder_GetDisplayNameOf
 #undef IShellFolder_ParseDisplayName

--- a/dll/win32/shlwapi/utils.cpp
+++ b/dll/win32/shlwapi/utils.cpp
@@ -2,7 +2,7 @@
  * PROJECT:     ReactOS Shell
  * LICENSE:     LGPL-2.0-or-later (https://spdx.org/licenses/LGPL-2.0-or-later)
  * PURPOSE:     Implement shell light-weight utility functions
- * COPYRIGHT:   Copyright 2023 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ * COPYRIGHT:   Copyright 2023-2024 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  */
 
 #define _ATL_NO_EXCEPTIONS

--- a/sdk/include/psdk/shobjidl.idl
+++ b/sdk/include/psdk/shobjidl.idl
@@ -225,6 +225,8 @@ interface IShellFolder : IUnknown
     cpp_quote("#define STR_PARSE_TRANSLATE_ALIASES L\"Parse Translate Aliases\"")
     cpp_quote("#define STR_DONT_PARSE_RELATIVE L\"Don't Parse Relative\"")
 
+    cpp_quote("#define SHCIDS_COLUMNMASK 0x0000FFFFL")
+
     typedef ULONG SFGAOF;
 
     HRESULT ParseDisplayName(

--- a/sdk/include/psdk/shobjidl.idl
+++ b/sdk/include/psdk/shobjidl.idl
@@ -226,6 +226,7 @@ interface IShellFolder : IUnknown
     cpp_quote("#define STR_DONT_PARSE_RELATIVE L\"Don't Parse Relative\"")
 
     cpp_quote("#define SHCIDS_COLUMNMASK 0x0000FFFFL")
+    cpp_quote("#define SHCIDS_BITMASK 0xFFFF0000L")
 
     typedef ULONG SFGAOF;
 

--- a/sdk/include/psdk/shobjidl.idl
+++ b/sdk/include/psdk/shobjidl.idl
@@ -218,17 +218,18 @@ interface IShellFolder : IUnknown
     cpp_quote("#define SFGAO_STORAGEANCESTOR   0x00800000L")
     cpp_quote("#define SFGAO_STORAGECAPMASK    0x70C50008L")
     cpp_quote("#define SFGAO_PKEYSFGAOMASK     0x81044000L")
+    typedef ULONG SFGAOF;
+
+    cpp_quote("#define SHCIDS_COLUMNMASK 0x0000FFFFL")
+    cpp_quote("#define SHCIDS_BITMASK 0xFFFF0000L")
+    cpp_quote("#define SHCIDS_CANONICALONLY 0x10000000L")
+    cpp_quote("#define SHCIDS_ALLFIELDS 0x80000000L")
 
     cpp_quote("#define STR_PARSE_SHELL_PROTOCOL_TO_FILE_OBJECTS L\"Parse Shell Protocol To File Objects\"")
     cpp_quote("#define STR_FILE_SYS_BIND_DATA L\"File System Bind Data\"")
     cpp_quote("#define STR_PARSE_PREFER_FOLDER_BROWSING L\"Parse Prefer Folder Browsing\"")
     cpp_quote("#define STR_PARSE_TRANSLATE_ALIASES L\"Parse Translate Aliases\"")
     cpp_quote("#define STR_DONT_PARSE_RELATIVE L\"Don't Parse Relative\"")
-
-    cpp_quote("#define SHCIDS_COLUMNMASK 0x0000FFFFL")
-    cpp_quote("#define SHCIDS_BITMASK 0xFFFF0000L")
-
-    typedef ULONG SFGAOF;
 
     HRESULT ParseDisplayName(
         [in] HWND hwndOwner,

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -332,6 +332,10 @@ IContextMenu_Invoke(
 
 DWORD WINAPI SHGetObjectCompatFlags(IUnknown *pUnk, const CLSID *clsid);
 
+/*
+ * HACK!  These functions are conflicting with <shobjidl.h> inline functions...
+ * We provide an macro option SHLWAPI_ISHELLFOLDER_HELPERS for using these functions.
+ */
 #ifdef SHLWAPI_ISHELLFOLDER_HELPERS
 HRESULT WINAPI
 IShellFolder_GetDisplayNameOf(

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -332,6 +332,31 @@ IContextMenu_Invoke(
 
 DWORD WINAPI SHGetObjectCompatFlags(IUnknown *pUnk, const CLSID *clsid);
 
+HRESULT WINAPI
+IShellFolder_GetDisplayNameOf(
+    _In_ IShellFolder *psf,
+    _In_ LPCITEMIDLIST pidl,
+    _In_ DWORD uFlags,
+    _Out_ LPSTRRET lpName,
+    _In_ DWORD dwRetryFlags);
+
+HRESULT WINAPI
+IShellFolder_ParseDisplayName(
+    _In_ IShellFolder *psf,
+    _In_ HWND hwndOwner,
+    _In_ LPBC pbcReserved,
+    _In_ LPOLESTR lpszDisplayName,
+    _Out_ ULONG *pchEaten,
+    _Out_ LPITEMIDLIST *ppidl,
+    _Out_ ULONG *pdwAttributes);
+
+EXTERN_C HRESULT WINAPI
+IShellFolder_CompareIDs(
+    _In_ IShellFolder *psf,
+    _In_ LPARAM lParam,
+    _In_ LPCITEMIDLIST pidl1,
+    _In_ LPCITEMIDLIST pidl2);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif /* defined(__cplusplus) */

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -332,7 +332,7 @@ IContextMenu_Invoke(
 
 DWORD WINAPI SHGetObjectCompatFlags(IUnknown *pUnk, const CLSID *clsid);
 
-#ifdef WANT_ISHELLFOLDER_HELPERS
+#ifdef SHLWAPI_ISHELLFOLDER_HELPERS
 HRESULT WINAPI
 IShellFolder_GetDisplayNameOf(
     _In_ IShellFolder *psf,
@@ -357,7 +357,7 @@ IShellFolder_CompareIDs(
     _In_ LPARAM lParam,
     _In_ PCUIDLIST_RELATIVE pidl1,
     _In_ PCUIDLIST_RELATIVE pidl2);
-#endif /* WANT_ISHELLFOLDER_HELPERS */
+#endif /* SHLWAPI_ISHELLFOLDER_HELPERS */
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -332,6 +332,7 @@ IContextMenu_Invoke(
 
 DWORD WINAPI SHGetObjectCompatFlags(IUnknown *pUnk, const CLSID *clsid);
 
+#ifdef WANT_ISHELLFOLDER_HELPERS
 HRESULT WINAPI
 IShellFolder_GetDisplayNameOf(
     _In_ IShellFolder *psf,
@@ -356,6 +357,7 @@ IShellFolder_CompareIDs(
     _In_ LPARAM lParam,
     _In_ PCUIDLIST_RELATIVE pidl1,
     _In_ PCUIDLIST_RELATIVE pidl2);
+#endif /* WANT_ISHELLFOLDER_HELPERS */
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -334,7 +334,7 @@ DWORD WINAPI SHGetObjectCompatFlags(IUnknown *pUnk, const CLSID *clsid);
 
 /*
  * HACK!  These functions are conflicting with <shobjidl.h> inline functions...
- * We provide an macro option SHLWAPI_ISHELLFOLDER_HELPERS for using these functions.
+ * We provide a macro option SHLWAPI_ISHELLFOLDER_HELPERS for using these functions.
  */
 #ifdef SHLWAPI_ISHELLFOLDER_HELPERS
 HRESULT WINAPI

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -345,6 +345,9 @@ IShellFolder_GetDisplayNameOf(
     _Out_ LPSTRRET lpName,
     _In_ DWORD dwRetryFlags);
 
+/* Flags for IShellFolder_GetDisplayNameOf */
+#define SFGDNO_RETRYWITHFORPARSING 1
+
 HRESULT WINAPI
 IShellFolder_ParseDisplayName(
     _In_ IShellFolder *psf,

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -333,7 +333,7 @@ IContextMenu_Invoke(
 DWORD WINAPI SHGetObjectCompatFlags(IUnknown *pUnk, const CLSID *clsid);
 
 /*
- * HACK!  These functions are conflicting with <shobjidl.h> inline functions...
+ * HACK! These functions are conflicting with <shobjidl.h> inline functions...
  * We provide a macro option SHLWAPI_ISHELLFOLDER_HELPERS for using these functions.
  */
 #ifdef SHLWAPI_ISHELLFOLDER_HELPERS

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -347,15 +347,15 @@ IShellFolder_ParseDisplayName(
     _In_ LPBC pbcReserved,
     _In_ LPOLESTR lpszDisplayName,
     _Out_ ULONG *pchEaten,
-    _Out_ LPITEMIDLIST *ppidl,
+    _Out_ PIDLIST_RELATIVE *ppidl,
     _Out_ ULONG *pdwAttributes);
 
 EXTERN_C HRESULT WINAPI
 IShellFolder_CompareIDs(
     _In_ IShellFolder *psf,
     _In_ LPARAM lParam,
-    _In_ LPCITEMIDLIST pidl1,
-    _In_ LPCITEMIDLIST pidl2);
+    _In_ PCUIDLIST_RELATIVE pidl1,
+    _In_ PCUIDLIST_RELATIVE pidl2);
 
 #ifdef __cplusplus
 } /* extern "C" */


### PR DESCRIPTION
## Purpose
Implementing missing features...
JIRA issue: [CORE-19278](https://jira.reactos.org/browse/CORE-19278)

## Proposed changes

- Implement `IShellFolder_GetDisplayNameOf`, `IShellFolder_ParseDisplayName`, and `IShellFolder_CompareIDs` functions.
- Add them to `<shlwapi_undoc.h>`.
- Modify `shlwapi.spec`.
- Add some `SHCIDS_...` macros into `shobjidl.idl`.
- Provide a macro option `SHLWAPI_ISHELLFOLDER_HELPERS` to avoid conflict with `<shobjidl.h>` `IShellFolder_...` inline functions. Ugly hack but effective!

## TODO

- [x] Do build.