### PR TITLE
[SHELL32][SDK] SHChangeNotify: Re-work Part 1

### DIFF
--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -2346,21 +2346,17 @@ LRESULT CDefView::OnChangeNotify(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &
 
     // Translate PIDLs.
     // SHSimpleIDListFromPathW creates fake PIDLs (lacking some attributes)
-    CComHeapPtr<ITEMIDLIST_ABSOLUTE> pidl0, pidl1;
-    WCHAR path0[MAX_PATH], path1[MAX_PATH];
-    if (Pidls[0])
+    CComHeapPtr<ITEMIDLIST_ABSOLUTE> pidl0(Pidls[0]), pidl1(Pidls[1]);
+    WCHAR path[MAX_PATH];
+    if (pidl0 && SHGetPathFromIDListW(pidl0, path) && PathFileExistsW(path))
     {
-        if (SHGetPathFromIDListW(Pidls[0], path0) && PathFileExistsW(path0))
-            pidl0.Attach(ILCreateFromPathW(path0));
-        else
-            pidl0.Attach(ILClone(Pidls[0]));
+        pidl0.Free();
+        pidl0.Attach(ILCreateFromPathW(path));
     }
-    if (Pidls[1])
+    if (pidl1 && SHGetPathFromIDListW(pidl1, path) && PathFileExistsW(path))
     {
-        if (SHGetPathFromIDListW(Pidls[1], path1) && PathFileExistsW(path1))
-            pidl1.Attach(ILCreateFromPathW(path1));
-        else
-            pidl1.Attach(ILClone(Pidls[1]));
+        pidl1.Free();
+        pidl1.Attach(ILCreateFromPathW(path));
     }
 
     PITEMID_CHILD child0 = NULL, child1 = NULL;
@@ -2417,8 +2413,6 @@ LRESULT CDefView::OnChangeNotify(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &
             break;
     }
 
-    ILFree(Pidls[0]);
-    ILFree(Pidls[1]);
     SHChangeNotification_Unlock(hLock);
     return TRUE;
 }

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -214,7 +214,8 @@ public:
     HRESULT drag_notify_subitem(DWORD grfKeyState, POINTL pt, DWORD *pdwEffect);
     HRESULT InvokeContextMenuCommand(CComPtr<IContextMenu>& pCM, LPCSTR lpVerb, POINT* pt = NULL);
     LRESULT OnExplorerCommand(UINT uCommand, BOOL bUseSelection);
-    void RefreshIcons();
+    void LV_RefreshIcon(INT iItem);
+    void LV_RefreshIcons();
 
     // *** IOleWindow methods ***
     STDMETHOD(GetWindow)(HWND *lphwnd) override;
@@ -2299,21 +2300,28 @@ static BOOL ILIsParentOrSpecialParent(PCIDLIST_ABSOLUTE pidl1, PCIDLIST_ABSOLUTE
     return FALSE;
 }
 
-void CDefView::RefreshIcons()
+void CDefView::LV_RefreshIcon(INT iItem)
 {
     ASSERT(m_ListView);
 
     LVITEMW lvItem = { LVIF_IMAGE };
+    lvItem.iItem = iItem;
+    lvItem.iImage = I_IMAGECALLBACK;
+    m_ListView.SetItem(&lvItem);
+    m_ListView.Update(iItem);
+}
+
+void CDefView::LV_RefreshIcons()
+{
+    ASSERT(m_ListView);
+
     for (INT iItem = -1;;)
     {
         iItem = ListView_GetNextItem(m_ListView, iItem, LVNI_ALL);
         if (iItem == -1)
             break;
 
-        lvItem.iItem = iItem;
-        lvItem.iImage = I_IMAGECALLBACK;
-        m_ListView.SetItem(&lvItem);
-        m_ListView.Update(iItem);
+        LV_RefreshIcon(iItem);
     }
 }
 
@@ -2394,7 +2402,7 @@ LRESULT CDefView::OnChangeNotify(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &
                 LV_UpdateItem(child0);
             break;
         case SHCNE_UPDATEIMAGE:
-            RefreshIcons();
+            LV_RefreshIcons();
             break;
         case SHCNE_UPDATEDIR:
         case SHCNE_ASSOCCHANGED:

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -2402,6 +2402,7 @@ LRESULT CDefView::OnChangeNotify(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &
                 LV_UpdateItem(child0);
             break;
         case SHCNE_UPDATEIMAGE:
+            /* HACK! */
             LV_RefreshIcons();
             break;
         case SHCNE_UPDATEDIR:

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -2402,13 +2402,12 @@ LRESULT CDefView::OnChangeNotify(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &
                 LV_UpdateItem(child0);
             break;
         case SHCNE_UPDATEIMAGE:
-            /* HACK! */
+        case SHCNE_MEDIAINSERTED:
+        case SHCNE_MEDIAREMOVED:
             LV_RefreshIcons();
             break;
         case SHCNE_UPDATEDIR:
         case SHCNE_ASSOCCHANGED:
-        case SHCNE_MEDIAINSERTED:
-        case SHCNE_MEDIAREMOVED:
             Refresh();
             break;
         case SHCNE_FREESPACE:

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -2404,10 +2404,10 @@ LRESULT CDefView::OnChangeNotify(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &
         case SHCNE_UPDATEIMAGE:
         case SHCNE_MEDIAINSERTED:
         case SHCNE_MEDIAREMOVED:
+        case SHCNE_ASSOCCHANGED:
             LV_RefreshIcons();
             break;
         case SHCNE_UPDATEDIR:
-        case SHCNE_ASSOCCHANGED:
             Refresh();
             break;
         case SHCNE_FREESPACE:

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -2346,6 +2346,7 @@ LRESULT CDefView::OnChangeNotify(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &
 
     // Translate PIDLs.
     // SHSimpleIDListFromPathW creates fake PIDLs (lacking some attributes)
+    // FIXME: Use SHGetRealIDL
     CComHeapPtr<ITEMIDLIST_ABSOLUTE> pidl0(Pidls[0]), pidl1(Pidls[1]);
     WCHAR path[MAX_PATH];
     if (pidl0 && SHGetPathFromIDListW(pidl0, path) && PathFileExistsW(path))

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -2408,7 +2408,9 @@ LRESULT CDefView::OnChangeNotify(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &
             LV_RefreshIcons();
             break;
         case SHCNE_UPDATEDIR:
+        case SHCNE_ATTRIBUTES:
             Refresh();
+            UpdateStatusbar();
             break;
         case SHCNE_FREESPACE:
             UpdateStatusbar();

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -200,6 +200,8 @@ public:
     BOOLEAN LV_DeleteItem(PCUITEMID_CHILD pidl);
     BOOLEAN LV_RenameItem(PCUITEMID_CHILD pidlOld, PCUITEMID_CHILD pidlNew);
     BOOLEAN LV_UpdateItem(PCUITEMID_CHILD pidl);
+    void LV_RefreshIcon(INT iItem);
+    void LV_RefreshIcons();
     static INT CALLBACK fill_list(LPVOID ptr, LPVOID arg);
     HRESULT FillList();
     HRESULT FillFileMenu();
@@ -214,8 +216,6 @@ public:
     HRESULT drag_notify_subitem(DWORD grfKeyState, POINTL pt, DWORD *pdwEffect);
     HRESULT InvokeContextMenuCommand(CComPtr<IContextMenu>& pCM, LPCSTR lpVerb, POINT* pt = NULL);
     LRESULT OnExplorerCommand(UINT uCommand, BOOL bUseSelection);
-    void LV_RefreshIcon(INT iItem);
-    void LV_RefreshIcons();
 
     // *** IOleWindow methods ***
     STDMETHOD(GetWindow)(HWND *lphwnd) override;
@@ -1044,6 +1044,31 @@ BOOLEAN CDefView::LV_UpdateItem(PCUITEMID_CHILD pidl)
     }
 
     return FALSE;
+}
+
+void CDefView::LV_RefreshIcon(INT iItem)
+{
+    ASSERT(m_ListView);
+
+    LVITEMW lvItem = { LVIF_IMAGE };
+    lvItem.iItem = iItem;
+    lvItem.iImage = I_IMAGECALLBACK;
+    m_ListView.SetItem(&lvItem);
+    m_ListView.Update(iItem);
+}
+
+void CDefView::LV_RefreshIcons()
+{
+    ASSERT(m_ListView);
+
+    for (INT iItem = -1;;)
+    {
+        iItem = ListView_GetNextItem(m_ListView, iItem, LVNI_ALL);
+        if (iItem == -1)
+            break;
+
+        LV_RefreshIcon(iItem);
+    }
 }
 
 INT CALLBACK CDefView::fill_list(LPVOID ptr, LPVOID arg)
@@ -2298,31 +2323,6 @@ static BOOL ILIsParentOrSpecialParent(PCIDLIST_ABSOLUTE pidl1, PCIDLIST_ABSOLUTE
     ILFree(pidl2Clone);
 
     return FALSE;
-}
-
-void CDefView::LV_RefreshIcon(INT iItem)
-{
-    ASSERT(m_ListView);
-
-    LVITEMW lvItem = { LVIF_IMAGE };
-    lvItem.iItem = iItem;
-    lvItem.iImage = I_IMAGECALLBACK;
-    m_ListView.SetItem(&lvItem);
-    m_ListView.Update(iItem);
-}
-
-void CDefView::LV_RefreshIcons()
-{
-    ASSERT(m_ListView);
-
-    for (INT iItem = -1;;)
-    {
-        iItem = ListView_GetNextItem(m_ListView, iItem, LVNI_ALL);
-        if (iItem == -1)
-            break;
-
-        LV_RefreshIcon(iItem);
-    }
 }
 
 LRESULT CDefView::OnChangeNotify(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled)

--- a/dll/win32/shell32/dialogs/filetypes.cpp
+++ b/dll/win32/shell32/dialogs/filetypes.cpp
@@ -66,7 +66,12 @@ DeleteExt(HWND hwndDlg, LPCWSTR pszExt)
         SHDeleteKeyW(HKEY_CLASSES_ROOT, szValue);
 
     // delete ".ext" key
-    return SHDeleteKeyW(HKEY_CLASSES_ROOT, pszExt) == ERROR_SUCCESS;
+    BOOL ret = (SHDeleteKeyW(HKEY_CLASSES_ROOT, pszExt) == ERROR_SUCCESS);
+
+    // notify
+    SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_FLUSHNOWAIT, NULL, NULL);
+
+    return ret;
 }
 
 static inline HICON

--- a/dll/win32/shell32/folders/CFSFolder.cpp
+++ b/dll/win32/shell32/folders/CFSFolder.cpp
@@ -683,6 +683,7 @@ HRESULT SHELL32_GetFSItemAttributes(IShellFolder * psf, LPCITEMIDLIST pidl, LPDW
     return S_OK;
 }
 
+// This method is typically invoked from SHSimpleIDListFromPathA/W.
 HRESULT CFSFolder::_ParseSimple(
     _In_ LPOLESTR lpszDisplayName,
     _Inout_ WIN32_FIND_DATAW *pFind,

--- a/dll/win32/shell32/folders/CRecycleBin.cpp
+++ b/dll/win32/shell32/folders/CRecycleBin.cpp
@@ -1078,10 +1078,8 @@ EXTERN_C HRESULT WINAPI SHUpdateRecycleBinIcon(void)
 {
     FIXME("stub\n");
 
-    /*
-     * HACK!
-     * This dwItem2 should be the icon index in the system image list that has changed
-     */
+    // HACK! This dwItem2 should be the icon index in the system image list that has changed.
+    // FIXME: Call SHMapPIDLToSystemImageListIndex
     DWORD dwItem2 = -1;
 
     SHChangeNotify(SHCNE_UPDATEIMAGE, SHCNF_DWORD, NULL, &dwItem2);

--- a/dll/win32/shell32/folders/CRecycleBin.cpp
+++ b/dll/win32/shell32/folders/CRecycleBin.cpp
@@ -1078,6 +1078,10 @@ EXTERN_C HRESULT WINAPI SHUpdateRecycleBinIcon(void)
 {
     FIXME("stub\n");
 
+    /* HACK! */
+    LPITEMIDLIST pidl = _ILCreateBitBucket();
+    SHChangeNotify(SHCNE_UPDATEIMAGE, SHCNF_IDLIST, pidl, NULL);
+    ILFree(pidl);
     return S_OK;
 }
 

--- a/dll/win32/shell32/folders/CRecycleBin.cpp
+++ b/dll/win32/shell32/folders/CRecycleBin.cpp
@@ -1078,7 +1078,12 @@ EXTERN_C HRESULT WINAPI SHUpdateRecycleBinIcon(void)
 {
     FIXME("stub\n");
 
-    DWORD dwItem2 = -1; /* HACK! */
+    /*
+     * HACK!
+     * This dwItem2 should be the icon index in the system image list that has changed
+     */
+    DWORD dwItem2 = -1;
+
     SHChangeNotify(SHCNE_UPDATEIMAGE, SHCNF_DWORD, NULL, &dwItem2);
     return S_OK;
 }

--- a/dll/win32/shell32/folders/CRecycleBin.cpp
+++ b/dll/win32/shell32/folders/CRecycleBin.cpp
@@ -1078,10 +1078,8 @@ EXTERN_C HRESULT WINAPI SHUpdateRecycleBinIcon(void)
 {
     FIXME("stub\n");
 
-    /* HACK! */
-    LPITEMIDLIST pidl = _ILCreateBitBucket();
-    SHChangeNotify(SHCNE_UPDATEIMAGE, SHCNF_IDLIST, pidl, NULL);
-    ILFree(pidl);
+    DWORD dwItem2 = -1; /* HACK! */
+    SHChangeNotify(SHCNE_UPDATEIMAGE, SHCNF_DWORD, NULL, &dwItem2);
     return S_OK;
 }
 

--- a/dll/win32/shell32/shlfileop.cpp
+++ b/dll/win32/shell32/shlfileop.cpp
@@ -2061,6 +2061,8 @@ cleanup:
 
     if (lpFileOp->wFunc != FO_DELETE)
         destroy_file_list(&flTo);
+    else if (lpFileOp->fFlags & FOF_ALLOWUNDO)
+        SHUpdateRecycleBinIcon();
 
     if (ret == ERROR_CANCELLED)
         lpFileOp->fAnyOperationsAborted = TRUE;

--- a/dll/win32/shell32/wine/pidl.c
+++ b/dll/win32/shell32/wine/pidl.c
@@ -1113,15 +1113,6 @@ LPITEMIDLIST WINAPI SHSimpleIDListFromPathA(LPCSTR lpszPath)
         wPath = HeapAlloc(GetProcessHeap(), 0, len * sizeof(WCHAR));
         MultiByteToWideChar(CP_ACP, 0, lpszPath, -1, wPath, len);
     }
-#ifdef __REACTOS__
-    // FIXME: Needs folder attribute
-    if (PathFileExistsW(wPath))
-    {
-        pidl = ILCreateFromPathW(wPath);
-        HeapFree(GetProcessHeap(), 0, wPath);
-        return pidl;
-    }
-#endif
 
     _ILParsePathW(wPath, NULL, TRUE, &pidl, NULL);
 
@@ -1135,13 +1126,9 @@ LPITEMIDLIST WINAPI SHSimpleIDListFromPathW(LPCWSTR lpszPath)
     LPITEMIDLIST pidl = NULL;
 
     TRACE("%s\n", debugstr_w(lpszPath));
-#ifdef __REACTOS__
-    // FIXME: Needs folder attribute
-    if (PathFileExistsW(lpszPath))
-        return ILCreateFromPathW(lpszPath);
-#endif
 
     _ILParsePathW(lpszPath, NULL, TRUE, &pidl, NULL);
+
     TRACE("%s %p\n", debugstr_w(lpszPath), pidl);
     return pidl;
 }

--- a/sdk/include/psdk/shlobj.h
+++ b/sdk/include/psdk/shlobj.h
@@ -1323,6 +1323,7 @@ SHCreateShellFolderViewEx(
 #define SFVM_SETISFV                  39
 #define SFVM_GETEXTVIEWS              40 /* undocumented */
 #define SFVM_THISIDLIST               41
+#define SFVM_UPDATINGOBJECT           43 /* undocumented */
 #define SFVM_ADDPROPERTYPAGES         47
 #define SFVM_BACKGROUNDENUMDONE       48
 #define SFVM_GETNOTIFY                49

--- a/sdk/include/reactos/undocshell.h
+++ b/sdk/include/reactos/undocshell.h
@@ -122,6 +122,7 @@ typedef struct _SHCNF_PRINTJOB_INFO
 #define SHCNF_PRINTJOBA 0x0004
 #define SHCNF_PRINTJOBW 0x0007
 
+HRESULT WINAPI SHUpdateRecycleBinIcon(void);
 
 /****************************************************************************
  * Shell Common Dialogs


### PR DESCRIPTION
## Purpose
Making shell change notification implementation better. Now recycle bin icon change is working.
JIRA issue: [CORE-13950](https://jira.reactos.org/browse/CORE-13950)
JIRA issue: [CORE-19591](https://jira.reactos.org/browse/CORE-19591)
JIRA issue: [CORE-11453](https://jira.reactos.org/browse/CORE-11453)

## Proposed changes

- Delete `SHSimpleIDListFromPathA/W` hacks.
- Translate simple PIDLs (coming from `SHSimpleIDListFromPathA/W`) in `CDefView::OnChangeNotify` method.
- Add `CDefView::LV_RefreshIcons` method for `SHCNE_UPDATEIMAGE` change event.
- Rename `CDefView::LV_ProdItem` method as `CDefView::LV_UpdateItem`.
- Call `SHUpdateRecycleBinIcon` in `SHFileOperationW` function.
- Half-implement `SHUpdateRecycleBinIcon`.
- Call `SHChangeNotify` in `DeleteExt` function.

## TODO

- [x] Do tests.