### PR TITLE
[GITHUB] Fix builds by dropping VS2017 and retargeting to VS2022

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,13 +85,13 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        toolset: ['14.2', '14.1'] # VS 2019, and 2017 (see below)
+        toolset: ['14.3','14.2'] # VS 2022, and 2019 (see below)
         arch: [i386, amd64]
         config: [Debug, Release]
         dllver: ['0x502', '0x600']
-        exclude: # VS 2019, 2017 only with windows-latest
+        exclude: # Build NT6 ISOs only with the latest toolset when compiled as a debug build
           - dllver: 0x600
-            toolset: '14.1'
+            toolset: 14.2
           - dllver: 0x600
             config: Release
       fail-fast: false
@@ -145,7 +145,7 @@ jobs:
   build-msvc-arm:
     strategy:
       matrix:
-        toolset: ['14.2', '14.1'] # VS 2019, 2017
+        toolset: ['14.3','14.2'] # VS 2022, 2019
         arch: [arm, arm64]
         config: [Debug, Release]
       fail-fast: false
@@ -222,6 +222,7 @@ jobs:
         name: reactos-syms-msvc${{matrix.toolset}}-${{matrix.arch}}-${{matrix.config}}-${{github.sha}}
         path: build/msvc_pdb
 
+  # FIXME: Does not boot on toolset 14.1, 14.3 is untested
   build-clang-cl:
     strategy:
       matrix:
@@ -248,13 +249,13 @@ jobs:
       uses: ilammy/msvc-dev-cmd@v1
       with:
         arch: amd64_x86
-        toolset: '14.1' # latest masm build known to make bootable builds
+        toolset: '14.3'
     - name: Activate VS cmd (amd64)
       if: ${{ matrix.arch == 'amd64' }}
       uses: ilammy/msvc-dev-cmd@v1
       with:
         arch: amd64
-        toolset: '14.1' # latest masm build known to make bootable builds
+        toolset: '14.3'
     - name: Add LLVM to PATH
       run: echo "${env:LLVM_PATH}" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     - name: Source checkout
@@ -283,7 +284,7 @@ jobs:
 
   build-msbuild-i386:
     name: MSBuild (i386)
-    runs-on: windows-2019
+    runs-on: windows-latest
     steps:
     - name: Install Flex and Bison
       run: |
@@ -303,6 +304,6 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake -G "Visual Studio 16 2019" -A Win32 -DCMAKE_TOOLCHAIN_FILE:FILEPATH=toolchain-msvc.cmake -DARCH:STRING=i386 -DENABLE_ROSTESTS=1 -DENABLE_ROSAPPS=1 ${{github.workspace}}\src
+        cmake -G "Visual Studio 17 2022" -A Win32 -DCMAKE_TOOLCHAIN_FILE:FILEPATH=toolchain-msvc.cmake -DARCH:STRING=i386 -DENABLE_ROSTESTS=1 -DENABLE_ROSAPPS=1 ${{github.workspace}}\src
     - name: Build
       run: cmake --build ${{github.workspace}}\build --target bootcd --target livecd

--- a/sdk/lib/crt/startup/crtexe.c
+++ b/sdk/lib/crt/startup/crtexe.c
@@ -116,7 +116,7 @@ pre_c_init (void)
     {
       __setusermatherr (_matherr);
     }
-#ifndef __clang__ /* FIXME: CORE-14042 */
+#if !defined(__clang__) && (!defined(_M_ARM64) || (_MSC_VER < 1930)) /* FIXME: CORE-14042 */
   if (__globallocalestatus == -1)
     {
     }


### PR DESCRIPTION
## Purpose

Github dropped VS2017 in the windows-latest ~~and seemingly also in windows-2019 (since clang-cl fails to find the 14.1 toolset and it uses windows-2019)~~ runners

https://github.com/actions/runner-images/commit/441122013e49b8a909c8007712da07504a2b4937 It also looks like 14.2 is getting removed

JIRA issue: N/A

## Proposed changes

- Drop VS2017 builder 
- Add VS2022 builder
- Add comment regarding Clang-CL, I tested a build from Github Actions that was compiled with 14.1, it did not boot, fails with 0x1E 

## TODO

- [ ] Either Fix arm64 debug VS2022/14.3 builder or only compile with VS2019/14.2
- [ ] Clang-CL now fails at 1st stage with 0x7F (0x00000008 | Double Fault), investigate