### PR TITLE
[SHELL32] Introduce 'HDELFILE' handle type

### DIFF
--- a/dll/win32/shell32/folders/CRecycleBin.cpp
+++ b/dll/win32/shell32/folders/CRecycleBin.cpp
@@ -62,14 +62,14 @@ static const columninfo RecycleBinColumns[] =
  * Recycle Bin folder
  */
 
-BOOL WINAPI CBSearchRecycleBin(IN PVOID Context, IN HANDLE hDeletedFile);
+BOOL WINAPI CBSearchRecycleBin(IN PVOID Context, IN HDELFILE hDeletedFile);
 
 static PIDLRecycleStruct * _ILGetRecycleStruct(LPCITEMIDLIST pidl);
 
 typedef struct _SEARCH_CONTEXT
 {
     PIDLRecycleStruct *pFileDetails;
-    HANDLE hDeletedFile;
+    HDELFILE hDeletedFile;
     BOOL bFound;
 } SEARCH_CONTEXT, *PSEARCH_CONTEXT;
 
@@ -122,8 +122,8 @@ class CRecycleBinEnum :
         CRecycleBinEnum();
         ~CRecycleBinEnum();
         HRESULT WINAPI Initialize(DWORD dwFlags);
-        static BOOL WINAPI CBEnumRecycleBin(IN PVOID Context, IN HANDLE hDeletedFile);
-        BOOL WINAPI CBEnumRecycleBin(IN HANDLE hDeletedFile);
+        static BOOL WINAPI CBEnumRecycleBin(IN PVOID Context, IN HDELFILE hDeletedFile);
+        BOOL WINAPI CBEnumRecycleBin(IN HDELFILE hDeletedFile);
 
         BEGIN_COM_MAP(CRecycleBinEnum)
         COM_INTERFACE_ENTRY_IID(IID_IEnumIDList, IEnumIDList)
@@ -155,7 +155,7 @@ class CRecycleBinItemContextMenu :
         END_COM_MAP()
 };
 
-BOOL WINAPI CBSearchRecycleBin(IN PVOID Context, IN HANDLE hDeletedFile)
+BOOL WINAPI CBSearchRecycleBin(IN PVOID Context, IN HDELFILE hDeletedFile)
 {
     PSEARCH_CONTEXT pContext = (PSEARCH_CONTEXT)Context;
 
@@ -273,12 +273,12 @@ static LPITEMIDLIST _ILCreateRecycleItem(PDELETED_FILE_DETAILS_W pFileDetails)
     return pidl;
 }
 
-BOOL WINAPI CRecycleBinEnum::CBEnumRecycleBin(IN PVOID Context, IN HANDLE hDeletedFile)
+BOOL WINAPI CRecycleBinEnum::CBEnumRecycleBin(IN PVOID Context, IN HDELFILE hDeletedFile)
 {
     return static_cast<CRecycleBinEnum *>(Context)->CBEnumRecycleBin(hDeletedFile);
 }
 
-BOOL WINAPI CRecycleBinEnum::CBEnumRecycleBin(IN HANDLE hDeletedFile)
+BOOL WINAPI CRecycleBinEnum::CBEnumRecycleBin(IN HDELFILE hDeletedFile)
 {
     PDELETED_FILE_DETAILS_W pFileDetails;
     DWORD dwSize;

--- a/dll/win32/shell32/shellrecyclebin/recyclebin.c
+++ b/dll/win32/shell32/shellrecyclebin/recyclebin.c
@@ -10,7 +10,7 @@
 
 BOOL WINAPI
 CloseRecycleBinHandle(
-    IN HANDLE hDeletedFile)
+    IN HDELFILE hDeletedFile)
 {
     IRecycleBinFile *rbf = (IRecycleBinFile *)hDeletedFile;
     HRESULT hr;
@@ -91,7 +91,7 @@ cleanup:
 
 BOOL WINAPI
 DeleteFileHandleToRecycleBin(
-    IN HANDLE hDeletedFile)
+    IN HDELFILE hDeletedFile)
 {
     IRecycleBinFile *rbf = (IRecycleBinFile *)hDeletedFile;
     HRESULT hr;
@@ -254,7 +254,7 @@ cleanup:
 
 BOOL WINAPI
 GetDeletedFileTypeNameW(
-    IN HANDLE hDeletedFile,
+    IN HDELFILE hDeletedFile,
     OUT LPWSTR pTypeName,
     IN DWORD BufferSize,
     OUT LPDWORD RequiredSize OPTIONAL)
@@ -280,7 +280,7 @@ GetDeletedFileTypeNameW(
 
 BOOL WINAPI
 GetDeletedFileDetailsA(
-    IN HANDLE hDeletedFile,
+    IN HDELFILE hDeletedFile,
     IN DWORD BufferSize,
     IN OUT PDELETED_FILE_DETAILS_A FileDetails OPTIONAL,
     OUT LPDWORD RequiredSize OPTIONAL)
@@ -325,7 +325,7 @@ cleanup:
 
 BOOL WINAPI
 GetDeletedFileDetailsW(
-    IN HANDLE hDeletedFile,
+    IN HDELFILE hDeletedFile,
     IN DWORD BufferSize,
     IN OUT PDELETED_FILE_DETAILS_W FileDetails OPTIONAL,
     OUT LPDWORD RequiredSize OPTIONAL)
@@ -378,7 +378,7 @@ cleanup:
 
 BOOL WINAPI
 RestoreFile(
-    IN HANDLE hDeletedFile)
+    IN HDELFILE hDeletedFile)
 {
     IRecycleBinFile *rbf = (IRecycleBinFile *)hDeletedFile;
     HRESULT hr;

--- a/dll/win32/shell32/shellrecyclebin/recyclebin.h
+++ b/dll/win32/shell32/shellrecyclebin/recyclebin.h
@@ -47,6 +47,9 @@ typedef struct _DELETED_FILE_DETAILS_W
 #define PDELETED_FILE_DETAILS PDELETED_FILE_DETAILS_A
 #endif
 
+/* Special handle type for deleted file/folder */
+DECLARE_HANDLE(HDELFILE);
+
 /* API Interface */
 
 /* Function called for each deleted file in the recycle bin
@@ -55,7 +58,7 @@ typedef struct _DELETED_FILE_DETAILS_W
  * Returning FALSE stops the enumeration.
  * Remarks: the handle must be closed with the CloseRecycleBinHandle function
  */
-typedef BOOL (WINAPI *PENUMERATE_RECYCLEBIN_CALLBACK)(IN PVOID Context, IN HANDLE hDeletedFile);
+typedef BOOL (WINAPI *PENUMERATE_RECYCLEBIN_CALLBACK)(IN PVOID Context, IN HDELFILE hDeletedFile);
 
 /* Closes a file deleted handle.
  * hDeletedFile: the handle to close
@@ -64,7 +67,7 @@ typedef BOOL (WINAPI *PENUMERATE_RECYCLEBIN_CALLBACK)(IN PVOID Context, IN HANDL
  */
 BOOL WINAPI
 CloseRecycleBinHandle(
-    IN HANDLE hDeletedFile);
+    IN HDELFILE hDeletedFile);
 
 /* Moves a file to the recycle bin.
  * FileName: the name of the file to move the recycle bin
@@ -89,7 +92,7 @@ DeleteFileToRecycleBinW(
  */
 BOOL WINAPI
 DeleteFileHandleToRecycleBin(
-    IN HANDLE hDeletedFile);
+    IN HDELFILE hDeletedFile);
 
 /* Removes all elements contained in a recycle bin
  * pszRoot: the name of the drive containing the recycle bin
@@ -133,7 +136,7 @@ EnumerateRecycleBinW(
 
 BOOL WINAPI
 GetDeletedFileTypeNameW(
-    IN HANDLE hDeletedFile,
+    IN HDELFILE hDeletedFile,
     OUT LPWSTR pTypeName,
     IN DWORD BufferSize,
     OUT LPDWORD RequiredSize OPTIONAL);
@@ -148,13 +151,13 @@ GetDeletedFileTypeNameW(
  */
 BOOL WINAPI
 GetDeletedFileDetailsA(
-    IN HANDLE hDeletedFile,
+    IN HDELFILE hDeletedFile,
     IN DWORD BufferSize,
     IN OUT PDELETED_FILE_DETAILS_A FileDetails OPTIONAL,
     OUT LPDWORD RequiredSize OPTIONAL);
 BOOL WINAPI
 GetDeletedFileDetailsW(
-    IN HANDLE hDeletedFile,
+    IN HDELFILE hDeletedFile,
     IN DWORD BufferSize,
     IN OUT PDELETED_FILE_DETAILS_W FileDetails OPTIONAL,
     OUT LPDWORD RequiredSize OPTIONAL);
@@ -171,7 +174,7 @@ GetDeletedFileDetailsW(
  */
 BOOL WINAPI
 RestoreFile(
-    IN HANDLE hDeletedFile);
+    IN HDELFILE hDeletedFile);
 
 /* COM interface */
 

--- a/dll/win32/shell32/shellrecyclebin/recyclebin.h
+++ b/dll/win32/shell32/shellrecyclebin/recyclebin.h
@@ -47,7 +47,7 @@ typedef struct _DELETED_FILE_DETAILS_W
 #define PDELETED_FILE_DETAILS PDELETED_FILE_DETAILS_A
 #endif
 
-/* Special handle type for deleted file/folder */
+/* Distinct handle type for deleted file/folder */
 DECLARE_HANDLE(HDELFILE);
 
 /* API Interface */


### PR DESCRIPTION
## Purpose
Generic `HANDLE` type is vague and unreadable.
Declare a special handle type for recycle bin items.
JIRA issue: [CORE-19595](https://jira.reactos.org/browse/CORE-19595)

## Proposed changes

- Declare the `HDELFILE` handle by `DECLARE_HANDLE(HDELFILE);`.
- Use `HDELFILE` instead of `HANDLE` for deleted items.

## TODO

- [x] Do tests.