### PR TITLE
[CMAKE][REACTOS] Introduce a utf16le_convert() cmake helper

### DIFF
--- a/boot/bootdata/CMakeLists.txt
+++ b/boot/bootdata/CMakeLists.txt
@@ -6,9 +6,7 @@ add_subdirectory(packages)
 add_cd_file(FILE ${CMAKE_CURRENT_SOURCE_DIR}/txtsetup.sif DESTINATION reactos NO_CAB FOR bootcd regtest)
 
 add_custom_target(converted_caroots_inf DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/caroots.inf)
-add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/caroots.inf
-                   COMMAND native-utf16le "${CMAKE_CURRENT_SOURCE_DIR}/caroots.inf" "${CMAKE_CURRENT_BINARY_DIR}/caroots.inf"
-                   DEPENDS native-utf16le ${CMAKE_CURRENT_SOURCE_DIR}/caroots.inf)
+utf16le_convert(${CMAKE_CURRENT_SOURCE_DIR}/caroots.inf ${CMAKE_CURRENT_BINARY_DIR}/caroots.inf)
 add_cd_file(TARGET converted_caroots_inf FILE ${CMAKE_CURRENT_BINARY_DIR}/caroots.inf DESTINATION reactos NO_CAB FOR bootcd regtest)
 
 add_registry_inf(
@@ -45,9 +43,7 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/welcome_config/)
     foreach(_file ${I18N_FILES})
         set(_converted_file ${CMAKE_CURRENT_BINARY_DIR}/welcome_config/${_file})
         set(_source_file ${CMAKE_CURRENT_SOURCE_DIR}/welcome_config/${_file})
-        add_custom_command(OUTPUT "${_converted_file}"
-                           COMMAND native-utf16le "${_source_file}" "${_converted_file}"
-                           DEPENDS native-utf16le "${_source_file}")
+        utf16le_convert(${_source_file} ${_converted_file})
         add_cd_file(TARGET converted_welcome_i18n_files FILE ${_converted_file} DESTINATION bootcd/reactos/welcome NO_CAB NAME_ON_CD ${_file} FOR hybridcd)
         list(APPEND _converted_welcome_i18n_files ${_converted_file})
     endforeach(_file)

--- a/dll/win32/urlmon/CMakeLists.txt
+++ b/dll/win32/urlmon/CMakeLists.txt
@@ -12,12 +12,7 @@ add_rpcproxy_files(urlmon_urlmon.idl)
 
 set(_source_file ${CMAKE_CURRENT_SOURCE_DIR}/urlmon.inf)
 set(_converted_file ${CMAKE_CURRENT_BINARY_DIR}/urlmon_utf16.inf)
-add_custom_command(
-    OUTPUT "${_converted_file}"
-    COMMAND native-utf16le "${_source_file}" "${_converted_file}"
-    DEPENDS native-utf16le "${_source_file}")
-
-set_source_files_properties(${_converted_file} PROPERTIES GENERATED TRUE)
+utf16le_convert(${_source_file} ${_converted_file})
 set_source_files_properties(urlmon.rc PROPERTIES OBJECT_DEPENDS "${_converted_file}")
 
 list(APPEND SOURCE

--- a/media/themes/Blackshade/blackshade.msstyles/CMakeLists.txt
+++ b/media/themes/Blackshade/blackshade.msstyles/CMakeLists.txt
@@ -11,9 +11,7 @@ foreach(_file ${TEXTFILES})
     string(REPLACE ${_file_name} "${_file_name}_utf16" _converted_file ${_converted_file})
     set(_file ${CMAKE_CURRENT_SOURCE_DIR}/${_file})
     set(_converted_file ${CMAKE_CURRENT_BINARY_DIR}/${_converted_file})
-    add_custom_command(OUTPUT ${_converted_file}
-                       COMMAND native-utf16le ${_file} ${_converted_file}
-                       DEPENDS native-utf16le ${_file})
+    utf16le_convert(${_file} ${_converted_file})
     list(APPEND _converted_files ${_converted_file})
 endforeach()
 

--- a/media/themes/Lautus/lautus.msstyles/CMakeLists.txt
+++ b/media/themes/Lautus/lautus.msstyles/CMakeLists.txt
@@ -14,9 +14,7 @@ foreach(_file ${TEXTFILES})
     get_filename_component(_subdir ${_file} DIRECTORY)
     file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${_subdir})
     set(_converted_file ${CMAKE_CURRENT_BINARY_DIR}/${_subdir}/${_file_name}_utf16.INI)
-    add_custom_command(OUTPUT ${_converted_file}
-                       COMMAND native-utf16le ${CMAKE_CURRENT_SOURCE_DIR}/${_file} ${_converted_file}
-                       DEPENDS native-utf16le ${CMAKE_CURRENT_SOURCE_DIR}/${_file})
+    utf16le_convert(${CMAKE_CURRENT_SOURCE_DIR}/${_file} ${_converted_file})
     list(APPEND _converted_files ${_converted_file})
 endforeach()
 

--- a/media/themes/Lunar/lunar.msstyles/CMakeLists.txt
+++ b/media/themes/Lunar/lunar.msstyles/CMakeLists.txt
@@ -10,9 +10,7 @@ foreach(_file ${TEXTFILES})
     get_filename_component(_subdir ${_file} DIRECTORY)
     file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${_subdir})
     set(_converted_file ${CMAKE_CURRENT_BINARY_DIR}/${_subdir}/${_file_name}_utf16.INI)
-    add_custom_command(OUTPUT ${_converted_file}
-                       COMMAND native-utf16le ${CMAKE_CURRENT_SOURCE_DIR}/${_file} ${_converted_file}
-                       DEPENDS native-utf16le ${CMAKE_CURRENT_SOURCE_DIR}/${_file})
+    utf16le_convert(${CMAKE_CURRENT_SOURCE_DIR}/${_file} ${_converted_file})
     list(APPEND _converted_files ${_converted_file})
 endforeach()
 

--- a/media/themes/Mizu/mizu.msstyles/CMakeLists.txt
+++ b/media/themes/Mizu/mizu.msstyles/CMakeLists.txt
@@ -10,9 +10,7 @@ foreach(_file ${TEXTFILES})
     get_filename_component(_subdir ${_file} DIRECTORY)
     file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${_subdir})
     set(_converted_file ${CMAKE_CURRENT_BINARY_DIR}/${_subdir}/${_file_name}_utf16.INI)
-    add_custom_command(OUTPUT ${_converted_file}
-                       COMMAND native-utf16le ${CMAKE_CURRENT_SOURCE_DIR}/${_file} ${_converted_file}
-                       DEPENDS native-utf16le ${CMAKE_CURRENT_SOURCE_DIR}/${_file})
+    utf16le_convert(${CMAKE_CURRENT_SOURCE_DIR}/${_file} ${_converted_file})
     list(APPEND _converted_files ${_converted_file})
 endforeach()
 

--- a/media/themes/Modern/modern.msstyles/CMakeLists.txt
+++ b/media/themes/Modern/modern.msstyles/CMakeLists.txt
@@ -15,9 +15,7 @@ foreach(_file ${TEXTFILES})
     get_filename_component(_subdir ${_file} DIRECTORY)
     file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${_subdir})
     set(_converted_file ${CMAKE_CURRENT_BINARY_DIR}/${_subdir}/${_file_name}_utf16.INI)
-    add_custom_command(OUTPUT ${_converted_file}
-                       COMMAND native-utf16le ${CMAKE_CURRENT_SOURCE_DIR}/${_file} ${_converted_file}
-                       DEPENDS native-utf16le ${CMAKE_CURRENT_SOURCE_DIR}/${_file})
+    utf16le_convert(${CMAKE_CURRENT_SOURCE_DIR}/${_file} ${_converted_file})
     list(APPEND _converted_files ${_converted_file})
 endforeach()
 

--- a/modules/rosapps/CMakeLists.txt
+++ b/modules/rosapps/CMakeLists.txt
@@ -13,9 +13,7 @@ list(APPEND ROSAPPS_INF_FILES rosapps_shortcuts.inf)
 foreach(item ${ROSAPPS_INF_FILES})
     set(_rosapps_converted_item ${CMAKE_CURRENT_BINARY_DIR}/${item})
     set(_rosapps_source_item ${CMAKE_CURRENT_SOURCE_DIR}/${item})
-    add_custom_command(OUTPUT "${_rosapps_converted_item}"
-                       COMMAND native-utf16le "${_rosapps_source_item}" "${_rosapps_converted_item}"
-                       DEPENDS native-utf16le "${_rosapps_source_item}")
+    utf16le_convert(${_rosapps_source_item} ${_rosapps_converted_item})
     add_cd_file(TARGET converted_inf_files2 FILE ${_rosapps_converted_item} DESTINATION reactos/inf FOR all)
     list(APPEND rosapps_converted_item ${_rosapps_converted_item})
 endforeach(item)

--- a/sdk/cmake/CMakeMacros.cmake
+++ b/sdk/cmake/CMakeMacros.cmake
@@ -40,10 +40,7 @@ function(add_message_headers _type)
         get_filename_component(_file_name ${_file} NAME_WE)
         set(_converted_file ${CMAKE_CURRENT_BINARY_DIR}/${_file}) ## ${_file_name}.mc
         set(_source_file ${CMAKE_CURRENT_SOURCE_DIR}/${_file})    ## ${_file_name}.mc
-        add_custom_command(
-            OUTPUT "${_converted_file}"
-            COMMAND native-utf16le "${_source_file}" "${_converted_file}" nobom
-            DEPENDS native-utf16le "${_source_file}")
+        utf16le_convert(${_source_file} ${_converted_file} nobom)
         macro_mc(${_flag} ${_converted_file})
         add_custom_command(
             OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${_file_name}.h ${CMAKE_CURRENT_BINARY_DIR}/${_file_name}.rc
@@ -82,7 +79,8 @@ function(add_link)
         OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${_LINK_NAME}.lnk
         COMMAND native-mkshelllink -o ${CMAKE_CURRENT_BINARY_DIR}/${_LINK_NAME}.lnk ${_LINK_CMD_LINE_ARGS} ${_LINK_ICON} ${_LINK_GUID} ${_LINK_MINIMIZE} ${_LINK_PATH}
         DEPENDS native-mkshelllink)
-    set_source_files_properties(${CMAKE_CURRENT_BINARY_DIR}/${_LINK_NAME}.lnk PROPERTIES GENERATED TRUE)
+    set_source_files_properties(
+        ${CMAKE_CURRENT_BINARY_DIR}/${_LINK_NAME}.lnk PROPERTIES GENERATED TRUE)
 endfunction()
 
 #
@@ -698,6 +696,13 @@ function(end_module_group)
     set(CURRENT_MODULE_GROUP PARENT_SCOPE)
 endfunction()
 
+function(utf16le_convert _in _out)
+    add_custom_command(OUTPUT "${_out}"
+                       COMMAND native-utf16le "${_in}" "${_out}" ${ARGN}
+                       DEPENDS native-utf16le "${_in}")
+    set_source_files_properties("${_out}" PROPERTIES GENERATED TRUE)
+endfunction()
+
 function(preprocess_file __in __out)
     set(__arg ${__in})
     foreach(__def ${ARGN})
@@ -755,9 +760,7 @@ function(create_registry_hives)
         file(RELATIVE_PATH _subdir ${CMAKE_SOURCE_DIR} ${_file})
         get_filename_component(_subdir ${_subdir}  DIRECTORY)
         set(_converted_file ${CMAKE_BINARY_DIR}/${_subdir}/${_file_name}_utf16.inf)
-        add_custom_command(OUTPUT ${_converted_file}
-                           COMMAND native-utf16le ${_file} ${_converted_file}
-                           DEPENDS native-utf16le ${_file})
+        utf16le_convert(${_file} ${_converted_file})
         list(APPEND _converted_files ${_converted_file})
     endforeach()
 
@@ -853,9 +856,7 @@ function(add_driver_inf _module)
     foreach(_file ${ARGN})
         set(_converted_item ${CMAKE_CURRENT_BINARY_DIR}/${_file})
         set(_source_item ${CMAKE_CURRENT_SOURCE_DIR}/${_file})
-        add_custom_command(OUTPUT "${_converted_item}"
-                           COMMAND native-utf16le "${_source_item}" "${_converted_item}"
-                           DEPENDS native-utf16le "${_source_item}")
+        utf16le_convert(${_source_item} ${_converted_item})
         list(APPEND _converted_inf_files ${_converted_item})
     endforeach()
 


### PR DESCRIPTION
## Purpose

Used when we convert files to UTF16-LE during our build process. Removes duplicated code.
