### PR TITLE
[NETSHELL] LanStatusUI: Fix the Network Connection Systray icon opening several dialog windows when cable isn't connected

### DIFF
--- a/dll/shellext/netshell/lanstatusui.cpp
+++ b/dll/shellext/netshell/lanstatusui.cpp
@@ -832,7 +832,21 @@ ShowStatusPropertyDialog(
             }
             else
             {
-                ShellExecuteW(NULL, L"open", L"explorer.exe", L"::{20D04FE0-3AEA-1069-A2D8-08002B30309D}\\::{21EC2020-3AEA-1069-A2DD-08002B30309D}\\::{7007ACC7-3202-11D1-AAD2-00805FC1270E}", NULL, SW_SHOWNORMAL);
+                LPITEMIDLIST pidl = NULL;
+                if (SUCCEEDED(SHGetSpecialFolderLocation(NULL, CSIDL_CONNECTIONS, &pidl)))
+                {
+                    SHELLEXECUTEINFOW shExInfo = { 0 };
+                    shExInfo.cbSize = sizeof(shExInfo);
+                    shExInfo.fMask = SEE_MASK_INVOKEIDLIST;
+                    shExInfo.hwnd = NULL;
+                    shExInfo.lpVerb = L"open";
+                    shExInfo.lpIDList = pidl;
+                    shExInfo.nShow = SW_SHOWNORMAL;
+
+                    ShellExecuteExW(&shExInfo);
+
+                    ILFree(pidl);
+                }
             }
         }
 

--- a/dll/shellext/netshell/lanstatusui.cpp
+++ b/dll/shellext/netshell/lanstatusui.cpp
@@ -822,13 +822,13 @@ ShowStatusPropertyDialog(
             WCHAR buffer[100];
             
             LoadStringW(netshell_hInstance, IDS_NETWORKCONNECTION, buffer, _countof(buffer));
-            HWND prophwnd = FindWindow(NULL, buffer);
+            HWND hWndProp = FindWindow(NULL, buffer);
 
-            /* if the window is already open, prevent it from opening again */
-            if (prophwnd != NULL)
+            /* If the window is already opened, prevent it from opening again */
+            if (hWndProp != NULL)
             {
-                ShowWindow(prophwnd, SW_SHOWNORMAL);
-                SetForegroundWindow(prophwnd);
+                ShowWindow(hWndProp, SW_SHOWNORMAL);
+                SetForegroundWindow(hWndProp);
             }
             else
             {

--- a/dll/shellext/netshell/lanstatusui.cpp
+++ b/dll/shellext/netshell/lanstatusui.cpp
@@ -821,10 +821,9 @@ ShowStatusPropertyDialog(
         {
             WCHAR buffer[100];
             
+            /* If the window is already opened, prevent it from opening again */
             LoadStringW(netshell_hInstance, IDS_NETWORKCONNECTION, buffer, _countof(buffer));
             HWND hWndProp = FindWindow(NULL, buffer);
-
-            /* If the window is already opened, prevent it from opening again */
             if (hWndProp != NULL)
             {
                 ShowWindow(hWndProp, SW_SHOWNORMAL);

--- a/dll/shellext/netshell/lanstatusui.cpp
+++ b/dll/shellext/netshell/lanstatusui.cpp
@@ -819,7 +819,21 @@ ShowStatusPropertyDialog(
         else if (pProperties->Status == NCS_MEDIA_DISCONNECTED || pProperties->Status == NCS_DISCONNECTED ||
                  pProperties->Status == NCS_HARDWARE_DISABLED)
         {
-            ShowNetConnectionProperties(pContext->pNet, pContext->hwndDlg);
+            WCHAR buffer[100];
+            
+            LoadStringW(netshell_hInstance, IDS_NETWORKCONNECTION, buffer, _countof(buffer));
+            HWND prophwnd = FindWindow(NULL, buffer);
+
+            /* if the window is already open, prevent it from opening again */
+            if (prophwnd != NULL)
+            {
+                ShowWindow(prophwnd, SW_SHOWNORMAL);
+                SetForegroundWindow(prophwnd);
+            }
+            else
+            {
+                ShellExecuteW(NULL, L"open", L"explorer.exe", L"::{20D04FE0-3AEA-1069-A2D8-08002B30309D}\\::{21EC2020-3AEA-1069-A2DD-08002B30309D}\\::{7007ACC7-3202-11D1-AAD2-00805FC1270E}", NULL, SW_SHOWNORMAL);
+            }
         }
 
         NcFreeNetconProperties(pProperties);


### PR DESCRIPTION
## Purpose

Prevents the Icon from opening up more than one window + Changes the window that's opened from the Connection Properties dialog to the Network Connections Folder (like in Server '03, which is the expected result as per the JIRA issue).

JIRA issue: [CORE-19562](https://jira.reactos.org/browse/CORE-19562)

## Proposed changes

- Changes the window being opened by the Disconnected Systray icon from the Connection Properties Dialog for the respective Adapter to the Network Connections Folder.
- Prevents the icon from opening the window more than once (if it's already open, find it and bring it to the top instead).
