### PR TITLE
[PARTMGR] Implement IOCTL_VOLUME_QUERY_VOLUME_NUMBER and IOCTL_VOLUME_IS_PARTITION

### DIFF
--- a/drivers/storage/partmgr/partmgr.h
+++ b/drivers/storage/partmgr/partmgr.h
@@ -73,6 +73,7 @@ typedef struct _PARTITION_EXTENSION
     UINT64 PartitionLength;
     SINGLE_LIST_ENTRY ListEntry;
 
+    UINT32 VolumeNumber; // Volume number in the "\Device\HarddiskVolumeN" device name
     UINT32 DetectedNumber;
     UINT32 OnDiskNumber; // partition number for issuing Io requests to the kernel
     BOOLEAN IsEnumerated; // reported via IRP_MN_QUERY_DEVICE_RELATIONS


### PR DESCRIPTION
## Purpose

Used by some 3rd-party software (see example link below). Also, `IOCTL_VOLUME_IS_PARTITION` is an easy way to know whether a `\Device\HarddiskVolumeN` (or whatever other volume) device corresponds to one single disk partition.

## Proposed changes

- Implement `IOCTL_VOLUME_QUERY_VOLUME_NUMBER`: See usage example in: https://github.com/dansdrivers/ndas4windows/blob/7241cebfa2a2076de546b8841c2ccda8ca599a8d/mayfield/branches/spr/src/umapps/ndassvc/service/drivematch.cpp#L627

- Stubplement `IOCTL_VOLUME_IS_PARTITION`: The only type of volume we support right now is disk partition so we just return success. A more robust algorithm would be to check whether the volume has only one single extent, that covers the whole partition on which it lies upon. If this is not the case, return STATUS_UNSUCCESSFUL instead.

