### PR TITLE
[SHELL32][BROWSEUI] Implement ShellBrowser Apply/Reset default folder settings

### DIFF
--- a/dll/win32/browseui/globalfoldersettings.cpp
+++ b/dll/win32/browseui/globalfoldersettings.cpp
@@ -113,14 +113,14 @@ HRESULT CGlobalFolderSettings::Save(const DEFFOLDERSETTINGS *pFDS)
     return hr;
 }
 
-HRESULT STDMETHODCALLTYPE CGlobalFolderSettings::Get(DEFFOLDERSETTINGS *pFDS, UINT cb)
+HRESULT STDMETHODCALLTYPE CGlobalFolderSettings::Get(struct DEFFOLDERSETTINGS *pFDS, UINT cb)
 {
     if (cb != sizeof(DEFFOLDERSETTINGS) || !pFDS)
         return E_INVALIDARG;
     return Load(*pFDS);
 }
 
-HRESULT STDMETHODCALLTYPE CGlobalFolderSettings::Set(const DEFFOLDERSETTINGS *pFDS, UINT cb, UINT unknown)
+HRESULT STDMETHODCALLTYPE CGlobalFolderSettings::Set(const struct DEFFOLDERSETTINGS *pFDS, UINT cb, UINT unknown)
 {
     // NULL pFDS means reset
     if (cb != sizeof(DEFFOLDERSETTINGS) && pFDS)

--- a/dll/win32/browseui/globalfoldersettings.cpp
+++ b/dll/win32/browseui/globalfoldersettings.cpp
@@ -49,8 +49,8 @@ static void InitializeDefaults(DEFFOLDERSETTINGS &dfs)
     C_ASSERT(FIELD_OFFSET(DEFFOLDERSETTINGS, ViewPriority) == DEFFOLDERSETTINGS::SIZE_IE4);
     C_ASSERT(sizeof(DEFFOLDERSETTINGS) == DEFFOLDERSETTINGS::SIZE_XP);
 
-    *(UINT*)&dfs = 0; // Set all flags to 0
-    dfs.Statusbar = 1;
+    *(UINT*)&dfs = FALSE; // Set all unknown flags to FALSE
+    dfs.Statusbar = TRUE;
     dfs.FolderSettings.ViewMode = SBFOLDERSETTINGS::DEF_FVM;
     dfs.FolderSettings.fFlags = SBFOLDERSETTINGS::DEF_FWF;
     dfs.vid = DEFAULT_VID;

--- a/dll/win32/browseui/globalfoldersettings.cpp
+++ b/dll/win32/browseui/globalfoldersettings.cpp
@@ -20,6 +20,35 @@
 
 #include "precomp.h"
 
+#define ROSSIG ( ('R' << 0) | ('O' << 8) | ('S' << 16) | (('g' ^ 'f' ^ 's') << 24) )
+#define DEFBROWSERSTREAM L"Settings"
+
+template<class S, class D> static void CopyTo(const S &Src, D &Dst)
+{
+    Dst.FolderSettings = Src.FolderSettings;
+}
+
+static void EnsureValid(FOLDERSETTINGS &fs)
+{
+    if ((int)fs.ViewMode < FVM_AUTO || (int)fs.ViewMode > FVM_LAST)
+        fs.ViewMode = SBFOLDERSETTINGS::DEF_FVM;
+
+    fs.fFlags &= ~(FWF_OWNERDATA | FWF_DESKTOP | FWF_TRANSPARENT | FWF_NOCLIENTEDGE |
+                   FWF_NOSUBFOLDERS | FWF_NOSCROLL | FWF_NOENUMREFRESH | FWF_NOVISIBLE);
+}
+
+static void EnsureValid(DEFFOLDERSETTINGS &dfs)
+{
+    EnsureValid(dfs.FolderSettings);
+}
+
+void SBFOLDERSETTINGS::Load()
+{
+    DEFFOLDERSETTINGS dfs;
+    CGlobalFolderSettings::Load(dfs);
+    CopyTo(dfs, *this);
+}
+
 CGlobalFolderSettings::CGlobalFolderSettings()
 {
 }
@@ -28,13 +57,73 @@ CGlobalFolderSettings::~CGlobalFolderSettings()
 {
 }
 
-HRESULT STDMETHODCALLTYPE CGlobalFolderSettings::Get(DEFFOLDERSETTINGS *paramC, int param10)
+HRESULT CGlobalFolderSettings::ResetBrowserSettings()
 {
-    return E_NOTIMPL;
+    return Save(NULL);
 }
 
-HRESULT STDMETHODCALLTYPE CGlobalFolderSettings::Set(
-    const DEFFOLDERSETTINGS *paramC, int param10, unsigned int param14)
+HRESULT CGlobalFolderSettings::SaveBrowserSettings(const SBFOLDERSETTINGS &sbfs)
 {
-    return E_NOTIMPL;
+    DEFFOLDERSETTINGS dfs;
+    dfs.ReactOsSignature = ROSSIG;
+    CopyTo(sbfs, dfs);
+    return Save(&dfs);
+}
+
+HRESULT CGlobalFolderSettings::Load(DEFFOLDERSETTINGS &dfs)
+{
+    HKEY hStreamsKey = SHGetShellKey(SHKEY_Key_Explorer, L"Streams", FALSE);
+    if (hStreamsKey)
+    {
+        DWORD cb = sizeof(DEFFOLDERSETTINGS);
+        DWORD err = SHRegGetValueW(hStreamsKey, NULL, DEFBROWSERSTREAM,
+                                   SRRF_RT_REG_BINARY, NULL, &dfs, &cb);
+        RegCloseKey(hStreamsKey);
+        if (!err && cb == sizeof(DEFFOLDERSETTINGS) && dfs.ReactOsSignature == ROSSIG)
+        {
+            EnsureValid(dfs);
+            return S_OK;
+        }
+    }
+    SBFOLDERSETTINGS sbfs;
+    sbfs.InitializeDefaults();
+    CopyTo(sbfs, dfs);
+    return S_FALSE;
+}
+
+HRESULT CGlobalFolderSettings::Save(const DEFFOLDERSETTINGS *pFDS)
+{
+    HKEY hStreamsKey = SHGetShellKey(SHKEY_Key_Explorer, L"Streams", TRUE);
+    if (!hStreamsKey)
+        return E_FAIL;
+
+    HRESULT hr = E_INVALIDARG;
+    if (!pFDS)
+    {
+        DWORD err = SHDeleteValueW(hStreamsKey, NULL, DEFBROWSERSTREAM);
+        hr = (!err || err == ERROR_FILE_NOT_FOUND) ? S_OK : HResultFromWin32(err);
+    }
+    else if (pFDS->ReactOsSignature == ROSSIG)
+    {
+        // FIXME: Until we figure out the format Windows uses, just store our private version.
+        DWORD cb = sizeof(DEFFOLDERSETTINGS);
+        hr = HResultFromWin32(SHSetValueW(hStreamsKey, NULL, DEFBROWSERSTREAM, REG_BINARY, pFDS, cb));
+    }
+    RegCloseKey(hStreamsKey);
+    return hr;
+}
+
+HRESULT STDMETHODCALLTYPE CGlobalFolderSettings::Get(DEFFOLDERSETTINGS *pFDS, UINT cb)
+{
+    if (cb != sizeof(DEFFOLDERSETTINGS) || !pFDS)
+        return E_INVALIDARG;
+    return Load(*pFDS);
+}
+
+HRESULT STDMETHODCALLTYPE CGlobalFolderSettings::Set(const DEFFOLDERSETTINGS *pFDS, UINT cb, UINT unknown)
+{
+    // NULL pFDS means reset
+    if (cb != sizeof(DEFFOLDERSETTINGS) && pFDS)
+        return E_INVALIDARG;
+    return Save(pFDS);
 }

--- a/dll/win32/browseui/globalfoldersettings.h
+++ b/dll/win32/browseui/globalfoldersettings.h
@@ -49,8 +49,8 @@ public:
     static HRESULT Save(const DEFFOLDERSETTINGS *pFDS);
 
     // *** IGlobalFolderSettings methods ***
-    STDMETHOD(Get)(DEFFOLDERSETTINGS *pFDS, UINT cb) override;
-    STDMETHOD(Set)(const DEFFOLDERSETTINGS *pFDS, UINT cb, UINT unknown) override;
+    STDMETHOD(Get)(struct DEFFOLDERSETTINGS *pFDS, UINT cb) override;
+    STDMETHOD(Set)(const struct DEFFOLDERSETTINGS *pFDS, UINT cb, UINT unknown) override;
 
     DECLARE_REGISTRY_RESOURCEID(IDR_GLOBALFOLDERSETTINGS)
     DECLARE_NOT_AGGREGATABLE(CGlobalFolderSettings)

--- a/dll/win32/browseui/globalfoldersettings.h
+++ b/dll/win32/browseui/globalfoldersettings.h
@@ -25,10 +25,11 @@ struct SBFOLDERSETTINGS // Private version of DEFFOLDERSETTINGS used by CShellBr
     FOLDERSETTINGS FolderSettings;
 
     enum { DEF_FVM = FVM_DETAILS }; // Windows uses FVM_ICON?
+    enum { DEF_FWF = FWF_NOHEADERINALLVIEWS };
     void InitializeDefaults()
     {
         FolderSettings.ViewMode = DEF_FVM;
-        FolderSettings.fFlags = FWF_NOHEADERINALLVIEWS;
+        FolderSettings.fFlags = DEF_FWF;
     }
     void Load();
 };

--- a/dll/win32/browseui/globalfoldersettings.h
+++ b/dll/win32/browseui/globalfoldersettings.h
@@ -20,6 +20,19 @@
 
 #pragma once
 
+struct SBFOLDERSETTINGS // Private version of DEFFOLDERSETTINGS used by CShellBrowser
+{
+    FOLDERSETTINGS FolderSettings;
+
+    enum { DEF_FVM = FVM_DETAILS }; // Windows uses FVM_ICON?
+    void InitializeDefaults()
+    {
+        FolderSettings.ViewMode = DEF_FVM;
+        FolderSettings.fFlags = FWF_NOHEADERINALLVIEWS;
+    }
+    void Load();
+};
+
 class CGlobalFolderSettings :
     public CComCoClass<CGlobalFolderSettings, &CLSID_GlobalFolderSettings>,
     public CComObjectRootEx<CComMultiThreadModelNoCS>,
@@ -30,9 +43,14 @@ public:
     CGlobalFolderSettings();
     ~CGlobalFolderSettings();
 
+    static HRESULT ResetBrowserSettings();
+    static HRESULT SaveBrowserSettings(const SBFOLDERSETTINGS &sbfs);
+    static HRESULT Load(DEFFOLDERSETTINGS &dfs);
+    static HRESULT Save(const DEFFOLDERSETTINGS *pFDS);
+
     // *** IGlobalFolderSettings methods ***
-    STDMETHOD(Get)(DEFFOLDERSETTINGS *paramC, int param10) override;
-    STDMETHOD(Set)(const DEFFOLDERSETTINGS *paramC, int param10, unsigned int param14) override;
+    STDMETHOD(Get)(DEFFOLDERSETTINGS *pFDS, UINT cb) override;
+    STDMETHOD(Set)(const DEFFOLDERSETTINGS *pFDS, UINT cb, UINT unknown) override;
 
     DECLARE_REGISTRY_RESOURCEID(IDR_GLOBALFOLDERSETTINGS)
     DECLARE_NOT_AGGREGATABLE(CGlobalFolderSettings)

--- a/dll/win32/browseui/settings.cpp
+++ b/dll/win32/browseui/settings.cpp
@@ -24,7 +24,7 @@ void ShellSettings::Save()
 void ShellSettings::Load()
 {
     fStatusBarVisible = SHRegGetBoolUSValueW(L"Software\\Microsoft\\Internet Explorer\\Main",
-                                             L"StatusBarOther", FALSE, FALSE);
+                                             L"StatusBarOther", FALSE, TRUE);
 
     fShowGoButton = SHRegGetBoolUSValueW(L"Software\\Microsoft\\Internet Explorer\\Main",
                                          L"ShowGoButton", FALSE, TRUE);

--- a/dll/win32/browseui/settings.h
+++ b/dll/win32/browseui/settings.h
@@ -12,12 +12,13 @@
 
 struct ShellSettings
 {
-    BOOL fLocked = FALSE;
-    BOOL fShowGoButton = FALSE;
-    BOOL fStatusBarVisible = FALSE;
+    BOOL fLocked = TRUE;
+    BOOL fShowGoButton = TRUE;
+    BOOL fStatusBarVisible = TRUE;
 
     void Save();
     void Load();
+    void Reset() { ShellSettings().Save(); }
 };
 
 struct CabinetStateSettings : CABINETSTATE

--- a/dll/win32/browseui/shellbrowser.cpp
+++ b/dll/win32/browseui/shellbrowser.cpp
@@ -2153,7 +2153,6 @@ HRESULT STDMETHODCALLTYPE CShellBrowser::Exec(const GUID *pguidCmdGroup, DWORD n
         switch (nCmdID)
         {
             case DVCMDID_RESETDEFAULTFOLDERSETTINGS:
-                ApplyBrowserDefaultFolderSettings(NULL);
                 IUnknown_Exec(fCurrentShellView, CGID_DefView, nCmdID, OLECMDEXECOPT_DODEFAULT, NULL, NULL);
                 break;
         }

--- a/dll/win32/browseui/shellbrowser.cpp
+++ b/dll/win32/browseui/shellbrowser.cpp
@@ -812,9 +812,11 @@ HRESULT CShellBrowser::ApplyBrowserDefaultFolderSettings(IShellView *pvs)
     {
         m_settings.Save();
         SBFOLDERSETTINGS &sbfs = m_deffoldersettings, defsbfs;
-        defsbfs.InitializeDefaults();
         if (FAILED(pvs->GetCurrentInfo(&sbfs.FolderSettings)))
-            sbfs.FolderSettings = defsbfs.FolderSettings;
+        {
+            defsbfs.InitializeDefaults();
+            sbfs = defsbfs;
+        }
         hr = CGlobalFolderSettings::SaveBrowserSettings(sbfs);
     }
     else
@@ -2152,7 +2154,7 @@ HRESULT STDMETHODCALLTYPE CShellBrowser::Exec(const GUID *pguidCmdGroup, DWORD n
     {
         switch (nCmdID)
         {
-            case DVCMDID_RESETDEFAULTFOLDERSETTINGS:
+            case DVCMDID_RESET_DEFAULTFOLDER_SETTINGS:
                 IUnknown_Exec(fCurrentShellView, CGID_DefView, nCmdID, OLECMDEXECOPT_DODEFAULT, NULL, NULL);
                 break;
         }
@@ -2669,10 +2671,10 @@ LRESULT STDMETHODCALLTYPE CShellBrowser::WndProcBS(HWND hwnd, UINT uMsg, WPARAM 
 HRESULT STDMETHODCALLTYPE CShellBrowser::SetAsDefFolderSettings()
 {
     HRESULT hr = E_FAIL;
-    if (IShellView *psv = fCurrentShellView)
+    if (fCurrentShellView)
     {
-        hr = ApplyBrowserDefaultFolderSettings(psv);
-        IUnknown_Exec(psv, CGID_DefView, DVCMDID_SETDEFAULTFOLDERSETTINGS, OLECMDEXECOPT_DODEFAULT, NULL, NULL);
+        hr = ApplyBrowserDefaultFolderSettings(fCurrentShellView);
+        IUnknown_Exec(fCurrentShellView, CGID_DefView, DVCMDID_SET_DEFAULTFOLDER_SETTINGS, OLECMDEXECOPT_DODEFAULT, NULL, NULL);
     }
     return hr;
 }

--- a/dll/win32/browseui/shellbrowser.cpp
+++ b/dll/win32/browseui/shellbrowser.cpp
@@ -323,7 +323,6 @@ public:
     CShellBrowser();
     ~CShellBrowser();
     HRESULT Initialize();
-    HRESULT ApplyBrowserDefaultFolderSettings(IShellView *pvs);
 public:
     HRESULT BrowseToPIDL(LPCITEMIDLIST pidl, long flags);
     HRESULT BrowseToPath(IShellFolder *newShellFolder, LPCITEMIDLIST absolutePIDL,
@@ -334,6 +333,7 @@ public:
     HRESULT ShowBand(const CLSID &classID, bool vertical);
     HRESULT NavigateToParent();
     HRESULT DoFolderOptions();
+    HRESULT ApplyBrowserDefaultFolderSettings(IShellView *pvs);
     static LRESULT CALLBACK WindowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
     void RepositionBars();
     HRESULT BuildExplorerBandMenu();

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -1988,9 +1988,7 @@ SelectExtOnRename(void)
     LONG error;
     DWORD dwValue = FALSE, cbValue;
 
-    error = RegOpenKeyExW(HKEY_CURRENT_USER,
-                          L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer",
-                          0, KEY_READ, &hKey);
+    error = RegOpenKeyExW(HKEY_CURRENT_USER, REGSTR_PATH_EXPLORER, 0, KEY_READ, &hKey);
     if (error)
         return dwValue;
 
@@ -3325,6 +3323,23 @@ HRESULT WINAPI CDefView::Exec(const GUID *pguidCmdGroup, DWORD nCmdID, DWORD nCm
             (nCmdID == 9) &&
             (nCmdexecopt == 0))
         return 1;
+
+    if (IsEqualIID(*pguidCmdGroup, CGID_DefView))
+    {
+        WCHAR SubKey[MAX_PATH];
+        switch (nCmdID)
+        {
+            case DVCMDID_SETDEFAULTFOLDERSETTINGS:
+                SHDeleteKey(HKEY_CURRENT_USER, L"Software\\Microsoft\\Windows\\ShellNoRoam\\Bags");
+                FIXME("Save current as default\n");
+                break;
+            case DVCMDID_RESETDEFAULTFOLDERSETTINGS:
+                wsprintfW(SubKey, L"%s\\%s", REGSTR_PATH_EXPLORER, L"Streams\\Default");
+                SHDeleteKey(HKEY_CURRENT_USER, SubKey);
+                SHDeleteKey(HKEY_CURRENT_USER, L"Software\\Microsoft\\Windows\\ShellNoRoam\\Bags");
+                break;
+        }
+    }
 
     return OLECMDERR_E_UNKNOWNGROUP;
 }

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -3329,11 +3329,11 @@ HRESULT WINAPI CDefView::Exec(const GUID *pguidCmdGroup, DWORD nCmdID, DWORD nCm
         WCHAR SubKey[MAX_PATH];
         switch (nCmdID)
         {
-            case DVCMDID_SETDEFAULTFOLDERSETTINGS:
+            case DVCMDID_SET_DEFAULTFOLDER_SETTINGS:
                 SHDeleteKey(HKEY_CURRENT_USER, L"Software\\Microsoft\\Windows\\ShellNoRoam\\Bags");
                 FIXME("Save current as default\n");
                 break;
-            case DVCMDID_RESETDEFAULTFOLDERSETTINGS:
+            case DVCMDID_RESET_DEFAULTFOLDER_SETTINGS:
                 wsprintfW(SubKey, L"%s\\%s", REGSTR_PATH_EXPLORER, L"Streams\\Default");
                 SHDeleteKey(HKEY_CURRENT_USER, SubKey);
                 SHDeleteKey(HKEY_CURRENT_USER, L"Software\\Microsoft\\Windows\\ShellNoRoam\\Bags");

--- a/dll/win32/shell32/CFolderOptions.cpp
+++ b/dll/win32/shell32/CFolderOptions.cpp
@@ -122,7 +122,7 @@ HRESULT CFolderOptions::HandleDefFolderSettings(int Action)
         else if (Action == DFSA_RESET)
         {
             // There does not seem to be a method in IBrowserService2 for this
-            IUnknown_Exec(bs2, CGID_DefView, DVCMDID_RESETDEFAULTFOLDERSETTINGS, OLECMDEXECOPT_DODEFAULT, NULL, NULL);
+            IUnknown_Exec(bs2, CGID_DefView, DVCMDID_RESET_DEFAULTFOLDER_SETTINGS, OLECMDEXECOPT_DODEFAULT, NULL, NULL);
         }
         else
         {

--- a/dll/win32/shell32/CFolderOptions.cpp
+++ b/dll/win32/shell32/CFolderOptions.cpp
@@ -130,5 +130,18 @@ HRESULT CFolderOptions::HandleDefFolderSettings(int Action)
         }
         bs2->Release();
     }
+
+    if (Action == DFSA_RESET)
+    {
+        IGlobalFolderSettings *pgfs;
+        HRESULT hr = CoCreateInstance(CLSID_GlobalFolderSettings, NULL, CLSCTX_INPROC_SERVER,
+                                      IID_IGlobalFolderSettings, (void **)&pgfs);
+        if (SUCCEEDED(hr))
+        {
+            hr = pgfs->Set(NULL, 0, 0);
+            pgfs->Release();
+        }
+    }
+
     return hr;
 }

--- a/dll/win32/shell32/CFolderOptions.cpp
+++ b/dll/win32/shell32/CFolderOptions.cpp
@@ -19,6 +19,7 @@
  */
 
 #include <precomp.h>
+#include <shdeprecated.h>
 
 
 WINE_DEFAULT_DEBUG_CHANNEL(fprop);
@@ -42,8 +43,10 @@ INT_PTR CALLBACK FolderOptionsFileTypesDlg(HWND hwndDlg, UINT uMsg, WPARAM wPara
 
 HRESULT STDMETHODCALLTYPE CFolderOptions::AddPages(LPFNSVADDPROPSHEETPAGE pfnAddPage, LPARAM lParam)
 {
-    HPROPSHEETPAGE hPage = SH_CreatePropertySheetPage(IDD_FOLDER_OPTIONS_GENERAL, FolderOptionsGeneralDlg, 0, NULL);
+    HPROPSHEETPAGE hPage;
+    LPARAM sheetparam = (LPARAM)static_cast<CFolderOptions*>(this);
 
+    hPage = SH_CreatePropertySheetPage(IDD_FOLDER_OPTIONS_GENERAL, FolderOptionsGeneralDlg, sheetparam, NULL);
     if (hPage == NULL)
     {
         ERR("Failed to create property sheet page FolderOptionsGeneral\n");
@@ -52,7 +55,7 @@ HRESULT STDMETHODCALLTYPE CFolderOptions::AddPages(LPFNSVADDPROPSHEETPAGE pfnAdd
     if (!pfnAddPage(hPage, lParam))
         return E_FAIL;
 
-    hPage = SH_CreatePropertySheetPage(IDD_FOLDER_OPTIONS_VIEW, FolderOptionsViewDlg, 0, NULL);
+    hPage = SH_CreatePropertySheetPage(IDD_FOLDER_OPTIONS_VIEW, FolderOptionsViewDlg, sheetparam, NULL);
     if (hPage == NULL)
     {
         ERR("Failed to create property sheet page FolderOptionsView\n");
@@ -61,7 +64,7 @@ HRESULT STDMETHODCALLTYPE CFolderOptions::AddPages(LPFNSVADDPROPSHEETPAGE pfnAdd
     if (!pfnAddPage(hPage, lParam))
         return E_FAIL;
 
-    hPage = SH_CreatePropertySheetPage(IDD_FOLDER_OPTIONS_FILETYPES, FolderOptionsFileTypesDlg, 0, NULL);
+    hPage = SH_CreatePropertySheetPage(IDD_FOLDER_OPTIONS_FILETYPES, FolderOptionsFileTypesDlg, sheetparam, NULL);
     if (hPage == NULL)
     {
         ERR("Failed to create property sheet page FolderOptionsFileTypes\n");
@@ -90,7 +93,7 @@ HRESULT STDMETHODCALLTYPE CFolderOptions::Initialize(PCIDLIST_ABSOLUTE pidlFolde
 
 
 /*************************************************************************
- * FolderOptions IShellExtInit interface
+ * FolderOptions IObjectWithSite interface
  */
 HRESULT STDMETHODCALLTYPE CFolderOptions::SetSite(IUnknown *pUnkSite)
 {
@@ -100,6 +103,32 @@ HRESULT STDMETHODCALLTYPE CFolderOptions::SetSite(IUnknown *pUnkSite)
 
 HRESULT STDMETHODCALLTYPE CFolderOptions::GetSite(REFIID riid, void **ppvSite)
 {
-    return m_pSite->QueryInterface(riid, ppvSite);
+    return m_pSite ? m_pSite->QueryInterface(riid, ppvSite) : E_FAIL;
 }
 
+/*************************************************************************
+ * FolderOptions helper methods
+ */
+HRESULT CFolderOptions::HandleDefFolderSettings(int Action)
+{
+    IBrowserService2*bs2;
+    HRESULT hr = IUnknown_QueryService(m_pSite, SID_SShellBrowser, IID_PPV_ARG(IBrowserService2, &bs2));
+    if (SUCCEEDED(hr))
+    {
+        if (Action == DFSA_APPLY)
+        {
+            hr = bs2->SetAsDefFolderSettings();
+        }
+        else if (Action == DFSA_RESET)
+        {
+            // There does not seem to be a method in IBrowserService2 for this
+            IUnknown_Exec(bs2, CGID_DefView, DVCMDID_RESETDEFAULTFOLDERSETTINGS, OLECMDEXECOPT_DODEFAULT, NULL, NULL);
+        }
+        else
+        {
+            // FFSA_QUERY: hr is already correct
+        }
+        bs2->Release();
+    }
+    return hr;
+}

--- a/dll/win32/shell32/CFolderOptions.cpp
+++ b/dll/win32/shell32/CFolderOptions.cpp
@@ -111,7 +111,7 @@ HRESULT STDMETHODCALLTYPE CFolderOptions::GetSite(REFIID riid, void **ppvSite)
  */
 HRESULT CFolderOptions::HandleDefFolderSettings(int Action)
 {
-    IBrowserService2*bs2;
+    IBrowserService2 *bs2;
     HRESULT hr = IUnknown_QueryService(m_pSite, SID_SShellBrowser, IID_PPV_ARG(IBrowserService2, &bs2));
     if (SUCCEEDED(hr))
     {

--- a/dll/win32/shell32/CFolderOptions.h
+++ b/dll/win32/shell32/CFolderOptions.h
@@ -38,6 +38,10 @@ class CFolderOptions :
         //BOOL QueryDrop (DWORD dwKeyState, LPDWORD pdwEffect);
         //BOOL RecycleBinIsEmpty();
 
+    protected:
+        enum DEFFOLDERSETTINGACTION { DFSA_QUERY = -1, DFSA_RESET, DFSA_APPLY };
+        HRESULT HandleDefFolderSettings(int Action);
+
     public:
         CFolderOptions();
         ~CFolderOptions();
@@ -52,6 +56,15 @@ class CFolderOptions :
         // IObjectWithSite
         STDMETHOD(SetSite)(IUnknown *pUnkSite) override;
         STDMETHOD(GetSite)(REFIID riid, void **ppvSite) override;
+
+        bool CanSetDefFolderSettings()
+        {
+            return SUCCEEDED(HandleDefFolderSettings(DFSA_QUERY));
+        }
+        HRESULT ApplyDefFolderSettings(bool ResetToDefault)
+        {
+            return HandleDefFolderSettings(ResetToDefault ? DFSA_RESET : DFSA_APPLY);
+        }
 
         DECLARE_REGISTRY_RESOURCEID(IDR_FOLDEROPTIONS)
         DECLARE_NOT_AGGREGATABLE(CFolderOptions)

--- a/dll/win32/shell32/dialogs/view.cpp
+++ b/dll/win32/shell32/dialogs/view.cpp
@@ -618,7 +618,7 @@ ViewDlg_CreateTreeImageList(VOID)
 }
 
 static BOOL
-ViewDlg_OnInitDialog(HWND hwndDlg, PROPSHEETPAGE*psp)
+ViewDlg_OnInitDialog(HWND hwndDlg, LPPROPSHEETPAGE psp)
 {
     SetWindowLongPtr(hwndDlg, GWL_USERDATA, psp->lParam);
     CFolderOptions *pFO = (CFolderOptions*)psp->lParam;
@@ -951,7 +951,7 @@ FolderOptionsViewDlg(
     switch (uMsg)
     {
         case WM_INITDIALOG:
-            return ViewDlg_OnInitDialog(hwndDlg, (PROPSHEETPAGE*)lParam);
+            return ViewDlg_OnInitDialog(hwndDlg, (LPPROPSHEETPAGE)lParam);
 
         case WM_COMMAND:
             switch (LOWORD(wParam))

--- a/dll/win32/shell32/dialogs/view.cpp
+++ b/dll/win32/shell32/dialogs/view.cpp
@@ -962,15 +962,15 @@ FolderOptionsViewDlg(
 
                 case IDC_VIEW_APPLY_TO_ALL:
                 case IDC_VIEW_RESET_ALL:
-                    {
-                        HRESULT hr = HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
-                        CFolderOptions *pFO = (CFolderOptions*)GetWindowLongPtr(hwndDlg, GWL_USERDATA);
-                        if (pFO)
-                            hr = pFO->ApplyDefFolderSettings(LOWORD(wParam) == IDC_VIEW_RESET_ALL);
-                        if (FAILED(hr))
-                            SHELL_ErrorBox(hwndDlg, hr);
-                        break;
-                    }
+                {
+                    HRESULT hr = HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
+                    CFolderOptions *pFO = (CFolderOptions*)GetWindowLongPtr(hwndDlg, GWL_USERDATA);
+                    if (pFO)
+                        hr = pFO->ApplyDefFolderSettings(LOWORD(wParam) == IDC_VIEW_RESET_ALL);
+                    if (FAILED(hr))
+                        SHELL_ErrorBox(hwndDlg, hr);
+                    break;
+                }
             }
             break;
 

--- a/dll/win32/shell32/dialogs/view.cpp
+++ b/dll/win32/shell32/dialogs/view.cpp
@@ -618,8 +618,18 @@ ViewDlg_CreateTreeImageList(VOID)
 }
 
 static BOOL
-ViewDlg_OnInitDialog(HWND hwndDlg)
+ViewDlg_OnInitDialog(HWND hwndDlg, PROPSHEETPAGE*psp)
 {
+    SetWindowLongPtr(hwndDlg, GWL_USERDATA, psp->lParam);
+    CFolderOptions *pFO = (CFolderOptions*)psp->lParam;
+
+    if (!pFO || !pFO->CanSetDefFolderSettings())
+    {
+        // The global options (started from rundll32 or control panel) 
+        // has no browser to copy the current settings from.
+        EnableWindow(GetDlgItem(hwndDlg, IDC_VIEW_APPLY_TO_ALL), FALSE);
+    }
+
     HWND hwndTreeView = GetDlgItem(hwndDlg, IDC_VIEW_TREEVIEW);
 
     s_hTreeImageList = ViewDlg_CreateTreeImageList();
@@ -941,7 +951,7 @@ FolderOptionsViewDlg(
     switch (uMsg)
     {
         case WM_INITDIALOG:
-            return ViewDlg_OnInitDialog(hwndDlg);
+            return ViewDlg_OnInitDialog(hwndDlg, (PROPSHEETPAGE*)lParam);
 
         case WM_COMMAND:
             switch (LOWORD(wParam))
@@ -949,6 +959,18 @@ FolderOptionsViewDlg(
                 case IDC_VIEW_RESTORE_DEFAULTS: // Restore Defaults
                     ViewDlg_RestoreDefaults(hwndDlg);
                     break;
+
+                case IDC_VIEW_APPLY_TO_ALL:
+                case IDC_VIEW_RESET_ALL:
+                    {
+                        HRESULT hr = HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
+                        CFolderOptions *pFO = (CFolderOptions*)GetWindowLongPtr(hwndDlg, GWL_USERDATA);
+                        if (pFO)
+                            hr = pFO->ApplyDefFolderSettings(LOWORD(wParam) == IDC_VIEW_RESET_ALL);
+                        if (FAILED(hr))
+                            SHELL_ErrorBox(hwndDlg, hr);
+                        break;
+                    }
             }
             break;
 

--- a/dll/win32/shell32/precomp.h
+++ b/dll/win32/shell32/precomp.h
@@ -36,6 +36,7 @@
 #include <powrprof.h>
 #include <winnetwk.h>
 #include <objsafe.h>
+#include <regstr.h>
 
 #include <comctl32_undoc.h>
 #include <shlguid_undoc.h>

--- a/sdk/include/reactos/shellutils.h
+++ b/sdk/include/reactos/shellutils.h
@@ -98,7 +98,7 @@ static inline UINT
 SHELL_ErrorBoxHelper(HWND hwndOwner, UINT Error)
 {
     WCHAR buf[400];
-    UINT cch, user32_IDS_ERROR = 2;
+    UINT cch;
 
     if (!IsWindowVisible(hwndOwner))
         hwndOwner = NULL;
@@ -109,6 +109,7 @@ SHELL_ErrorBoxHelper(HWND hwndOwner, UINT Error)
                          NULL, Error, 0, buf, _countof(buf), NULL);
     if (!cch)
     {
+        enum { user32_IDS_ERROR = 2 }; // IDS_ERROR from user32 resource.h ("Error" string)
         cch = LoadStringW(LoadLibraryW(L"USER32"), user32_IDS_ERROR, buf, _countof(buf));
         wsprintfW(buf + cch, L"\n\n%#x (%d)", Error, Error);
     }

--- a/sdk/include/reactos/shellutils.h
+++ b/sdk/include/reactos/shellutils.h
@@ -94,6 +94,35 @@ inline BOOL _ROS_FAILED_HELPER(HRESULT hr, const char* expr, const char* filenam
 } /* extern "C" */
 #endif /* defined(__cplusplus) */
 
+static inline UINT
+SHELL_ErrorBoxHelper(HWND hwndOwner, UINT Error)
+{
+    WCHAR buf[400];
+    UINT cch, u32_errstr = 2;
+
+    if (!IsWindowVisible(hwndOwner))
+        hwndOwner = NULL;
+    if (Error == ERROR_SUCCESS)
+        Error = ERROR_INTERNAL_ERROR;
+
+    cch = FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+                         NULL, Error, 0, buf, _countof(buf), NULL);
+    if (!cch)
+    {
+        cch = LoadStringW(LoadLibraryW(L"USER32"), u32_errstr, buf, _countof(buf));
+        wsprintfW(buf + cch, L"\n\n%#x (%d)", Error, Error);
+    }
+    MessageBoxW(hwndOwner, buf, NULL, MB_OK | MB_ICONSTOP);
+    return Error;
+}
+#ifdef __cplusplus
+template<class H> static UINT
+SHELL_ErrorBox(H hwndOwner, UINT Error = GetLastError())
+{
+    return SHELL_ErrorBoxHelper(const_cast<HWND>(hwndOwner), Error);
+}
+#endif
+
 #ifdef __cplusplus
 template <typename T>
 class CComCreatorCentralInstance

--- a/sdk/include/reactos/shellutils.h
+++ b/sdk/include/reactos/shellutils.h
@@ -98,7 +98,7 @@ static inline UINT
 SHELL_ErrorBoxHelper(HWND hwndOwner, UINT Error)
 {
     WCHAR buf[400];
-    UINT cch, u32_errstr = 2;
+    UINT cch, user32_IDS_ERROR = 2;
 
     if (!IsWindowVisible(hwndOwner))
         hwndOwner = NULL;
@@ -109,7 +109,7 @@ SHELL_ErrorBoxHelper(HWND hwndOwner, UINT Error)
                          NULL, Error, 0, buf, _countof(buf), NULL);
     if (!cch)
     {
-        cch = LoadStringW(LoadLibraryW(L"USER32"), u32_errstr, buf, _countof(buf));
+        cch = LoadStringW(LoadLibraryW(L"USER32"), user32_IDS_ERROR, buf, _countof(buf));
         wsprintfW(buf + cch, L"\n\n%#x (%d)", Error, Error);
     }
     MessageBoxW(hwndOwner, buf, NULL, MB_OK | MB_ICONSTOP);

--- a/sdk/include/reactos/shlobj_undoc.h
+++ b/sdk/include/reactos/shlobj_undoc.h
@@ -150,7 +150,7 @@ DECLARE_INTERFACE_(IBanneredBar, IUnknown)//, "596A9A94-013E-11d1-8D34-00A0C90F2
  */
 struct DEFFOLDERSETTINGS
 {
-    enum { STRUCTSIZE_NT5 = 40 };
+    enum { STRUCTSIZE_XP = 40 };
     UINT ReactOsSignature;
     FOLDERSETTINGS FolderSettings;
 };
@@ -160,12 +160,12 @@ struct DEFFOLDERSETTINGS
 DECLARE_INTERFACE_(IGlobalFolderSettings, IUnknown)
 {
     /*** IUnknown ***/
-	STDMETHOD(QueryInterface)(THIS_ REFIID riid, void **ppv) PURE;
-	STDMETHOD_(ULONG,AddRef)(THIS) PURE;
-	STDMETHOD_(ULONG,Release)(THIS) PURE;
+    STDMETHOD(QueryInterface)(THIS_ REFIID riid, void **ppv) PURE;
+    STDMETHOD_(ULONG,AddRef)(THIS) PURE;
+    STDMETHOD_(ULONG,Release)(THIS) PURE;
     /*** IGlobalFolderSettings ***/
-    STDMETHOD(Get)(THIS_ DEFFOLDERSETTINGS *pFDS, UINT cb) PURE;
-    STDMETHOD(Set)(THIS_ const DEFFOLDERSETTINGS *pFDS, UINT cb, UINT unknown) PURE;
+    STDMETHOD(Get)(THIS_ struct DEFFOLDERSETTINGS *pFDS, UINT cb) PURE;
+    STDMETHOD(Set)(THIS_ const struct DEFFOLDERSETTINGS *pFDS, UINT cb, UINT unknown) PURE;
 };
 #undef INTERFACE
 

--- a/sdk/include/reactos/shlobj_undoc.h
+++ b/sdk/include/reactos/shlobj_undoc.h
@@ -150,9 +150,15 @@ DECLARE_INTERFACE_(IBanneredBar, IUnknown)//, "596A9A94-013E-11d1-8D34-00A0C90F2
  */
 struct DEFFOLDERSETTINGS
 {
-    enum { STRUCTSIZE_XP = 40 };
-    UINT ReactOsSignature;
+    enum { SIZE_NT4 = 8, SIZE_IE4 = 36, SIZE_XP = 40 };
+    enum { VER_98 = 0, VER_2000 = 3, VER_XP = 4 }; // Win98SE with IE5 writes 0, not 3 as the version
+    UINT Statusbar : 1; // "StatusBarOther" is the new location for this
+    UINT Toolbar : 1; // Not used when Explorer uses ReBar
     FOLDERSETTINGS FolderSettings;
+    SHELLVIEWID vid;
+    UINT Version;
+    UINT Counter; // Incremented every time default folder settings are applied. Invalidates a cache?
+    UINT ViewPriority; // VIEW_PRIORITY_*
 };
 
 #undef  INTERFACE

--- a/sdk/include/reactos/shlobj_undoc.h
+++ b/sdk/include/reactos/shlobj_undoc.h
@@ -84,6 +84,12 @@ struct persistState
 #endif
 
 /*****************************************************************************
+ * CGID_DefView OLECMD IDs
+ */
+#define DVCMDID_SETDEFAULTFOLDERSETTINGS 0
+#define DVCMDID_RESETDEFAULTFOLDERSETTINGS 1
+
+/*****************************************************************************
  * IInitializeObject interface
  */
 #undef  INTERFACE
@@ -144,7 +150,9 @@ DECLARE_INTERFACE_(IBanneredBar, IUnknown)//, "596A9A94-013E-11d1-8D34-00A0C90F2
  */
 struct DEFFOLDERSETTINGS
 {
-	long					offset0;
+    enum { STRUCTSIZE_NT5 = 40 };
+    UINT ReactOsSignature;
+    FOLDERSETTINGS FolderSettings;
 };
 
 #undef  INTERFACE
@@ -156,8 +164,8 @@ DECLARE_INTERFACE_(IGlobalFolderSettings, IUnknown)
 	STDMETHOD_(ULONG,AddRef)(THIS) PURE;
 	STDMETHOD_(ULONG,Release)(THIS) PURE;
     /*** IGlobalFolderSettings ***/
-	STDMETHOD(Get)(THIS_ struct DEFFOLDERSETTINGS *buffer, int theSize) PURE;
-	STDMETHOD(Set)(THIS_ const struct DEFFOLDERSETTINGS *buffer, int theSize, unsigned int param14) PURE;
+    STDMETHOD(Get)(THIS_ DEFFOLDERSETTINGS *pFDS, UINT cb) PURE;
+    STDMETHOD(Set)(THIS_ const DEFFOLDERSETTINGS *pFDS, UINT cb, UINT unknown) PURE;
 };
 #undef INTERFACE
 

--- a/sdk/include/reactos/shlobj_undoc.h
+++ b/sdk/include/reactos/shlobj_undoc.h
@@ -86,8 +86,8 @@ struct persistState
 /*****************************************************************************
  * CGID_DefView OLECMD IDs
  */
-#define DVCMDID_SETDEFAULTFOLDERSETTINGS 0
-#define DVCMDID_RESETDEFAULTFOLDERSETTINGS 1
+#define DVCMDID_SET_DEFAULTFOLDER_SETTINGS 0
+#define DVCMDID_RESET_DEFAULTFOLDER_SETTINGS 1
 
 /*****************************************************************************
  * IInitializeObject interface


### PR DESCRIPTION
Notes:
 - ~~I don't know the format of the Windows "Settings" stream. I made our version incompatible on purpose, it is much smaller and uses a special signature.~~
 - DefView only understands the Reset part, I'm not sure how/what to store as its settings yet.
 - SHELL_ErrorBox is a template to make it harder to pass in a NULL HWND on purpose.