### PR TITLE
[SDK] Fixed "Move to... & Copy to..." dialog broken button navigation

### DIFF
--- a/sdk/include/reactos/ui/layout.h
+++ b/sdk/include/reactos/ui/layout.h
@@ -85,7 +85,7 @@ LayoutShowGrip(LAYOUT_DATA *pData, BOOL bShow)
 
     if (pData->m_hwndGrip == NULL)
     {
-        DWORD style = WS_CHILD | WS_CLIPSIBLINGS | SBS_SIZEGRIP;
+        DWORD style = WS_GROUP | WS_CHILD | WS_CLIPSIBLINGS | SBS_SIZEGRIP;
         pData->m_hwndGrip = CreateWindowExW(0, L"SCROLLBAR", NULL, style,
                                             0, 0, 0, 0, pData->m_hwndParent,
                                             NULL, GetModuleHandleW(NULL), NULL);

--- a/sdk/include/reactos/ui/layout.h
+++ b/sdk/include/reactos/ui/layout.h
@@ -85,6 +85,7 @@ LayoutShowGrip(LAYOUT_DATA *pData, BOOL bShow)
 
     if (pData->m_hwndGrip == NULL)
     {
+        /* CORE-19585: WS_GROUP set to avoid navigation over the grip control */
         DWORD style = WS_GROUP | WS_CHILD | WS_CLIPSIBLINGS | SBS_SIZEGRIP;
         pData->m_hwndGrip = CreateWindowExW(0, L"SCROLLBAR", NULL, style,
                                             0, 0, 0, 0, pData->m_hwndParent,

--- a/win32ss/user/user32/windows/dialog.c
+++ b/win32ss/user/user32/windows/dialog.c
@@ -2104,7 +2104,7 @@ EndDialog(
        owner = GetAncestor( hwnd, GA_PARENT);
     }
     else
-       owner = GetWindow( hwnd, GW_OWNER );    
+       owner = GetWindow( hwnd, GW_OWNER );
 
     if (owner)
         EnableWindow( owner, TRUE );
@@ -2186,7 +2186,7 @@ GetDlgItem(
     HWND *list;
     HWND ret = 0;
 
-    if (!hDlg) return 0; 
+    if (!hDlg) return 0;
 
     list = WIN_ListChildren(hDlg);
     if (!list) return 0;
@@ -2394,7 +2394,7 @@ GetNextDlgTabItem(
   BOOL bPrevious)
 {
     PWND pWindow;
-      
+
     pWindow = ValidateHwnd( hDlg );
     if (!pWindow) return NULL;
     if (hCtl)
@@ -2563,7 +2563,7 @@ IsDialogMessageW(
                 {
                     fIsDialog = (GETDLGINFO(hDlg) != NULL);
                 }
-  
+
                 SendMessageW(hDlg, WM_CHANGEUISTATE, MAKEWPARAM(UIS_CLEAR, UISF_HIDEFOCUS), 0);
 
                 /* I am not sure under which circumstances the TAB is handled
@@ -2618,13 +2618,13 @@ IsDialogMessageW(
              {
                  BOOL fPrevious = (lpMsg->wParam == VK_LEFT || lpMsg->wParam == VK_UP);
 
-                 /* Skip STATIC elements when arrow-moving through a list of controls */
+                 /* Skip STATIC, SBS_SIZEBOX and SBS_SIZEGRIP elements when arrow-moving through a list of controls */
                  HWND hwndNext, hwndFirst = lpMsg->hwnd;
                  for (hwndNext = GetNextDlgGroupItem(hDlg, hwndFirst, fPrevious);
                       hwndNext && hwndFirst != hwndNext;
                       hwndNext = GetNextDlgGroupItem(hDlg, hwndNext, fPrevious))
                   {
-                      if (!(SendMessageW(hwndNext, WM_GETDLGCODE, 0, 0) & DLGC_STATIC))
+                      if ( (!(SendMessageW(hwndNext, WM_GETDLGCODE, 0, 0) & DLGC_STATIC)) && !(GetWindowLongPtrW(hwndNext, GWL_STYLE) & (SBS_SIZEBOX | SBS_SIZEGRIP)) )
                           break;
                   }
 

--- a/win32ss/user/user32/windows/dialog.c
+++ b/win32ss/user/user32/windows/dialog.c
@@ -2618,13 +2618,13 @@ IsDialogMessageW(
              {
                  BOOL fPrevious = (lpMsg->wParam == VK_LEFT || lpMsg->wParam == VK_UP);
 
-                 /* Skip STATIC, SBS_SIZEBOX and SBS_SIZEGRIP elements when arrow-moving through a list of controls */
+                 /* Skip STATIC elements when arrow-moving through a list of controls */
                  HWND hwndNext, hwndFirst = lpMsg->hwnd;
                  for (hwndNext = GetNextDlgGroupItem(hDlg, hwndFirst, fPrevious);
                       hwndNext && hwndFirst != hwndNext;
                       hwndNext = GetNextDlgGroupItem(hDlg, hwndNext, fPrevious))
                   {
-                      if ( !(SendMessageW(hwndNext, WM_GETDLGCODE, 0, 0) & DLGC_STATIC) && !(GetWindowLongPtrW(hwndNext, GWL_STYLE) & (SBS_SIZEBOX | SBS_SIZEGRIP)) )
+                      if (!(SendMessageW(hwndNext, WM_GETDLGCODE, 0, 0) & DLGC_STATIC))
                           break;
                   }
 

--- a/win32ss/user/user32/windows/dialog.c
+++ b/win32ss/user/user32/windows/dialog.c
@@ -2624,7 +2624,7 @@ IsDialogMessageW(
                       hwndNext && hwndFirst != hwndNext;
                       hwndNext = GetNextDlgGroupItem(hDlg, hwndNext, fPrevious))
                   {
-                      if ( (!(SendMessageW(hwndNext, WM_GETDLGCODE, 0, 0) & DLGC_STATIC)) && !(GetWindowLongPtrW(hwndNext, GWL_STYLE) & (SBS_SIZEBOX | SBS_SIZEGRIP)) )
+                      if ( !(SendMessageW(hwndNext, WM_GETDLGCODE, 0, 0) & DLGC_STATIC) && !(GetWindowLongPtrW(hwndNext, GWL_STYLE) & (SBS_SIZEBOX | SBS_SIZEGRIP)) )
                           break;
                   }
 

--- a/win32ss/user/user32/windows/dialog.c
+++ b/win32ss/user/user32/windows/dialog.c
@@ -2104,7 +2104,7 @@ EndDialog(
        owner = GetAncestor( hwnd, GA_PARENT);
     }
     else
-       owner = GetWindow( hwnd, GW_OWNER );
+       owner = GetWindow( hwnd, GW_OWNER );    
 
     if (owner)
         EnableWindow( owner, TRUE );
@@ -2186,7 +2186,7 @@ GetDlgItem(
     HWND *list;
     HWND ret = 0;
 
-    if (!hDlg) return 0;
+    if (!hDlg) return 0; 
 
     list = WIN_ListChildren(hDlg);
     if (!list) return 0;
@@ -2394,7 +2394,7 @@ GetNextDlgTabItem(
   BOOL bPrevious)
 {
     PWND pWindow;
-
+      
     pWindow = ValidateHwnd( hDlg );
     if (!pWindow) return NULL;
     if (hCtl)
@@ -2563,7 +2563,7 @@ IsDialogMessageW(
                 {
                     fIsDialog = (GETDLGINFO(hDlg) != NULL);
                 }
-
+  
                 SendMessageW(hDlg, WM_CHANGEUISTATE, MAKEWPARAM(UIS_CLEAR, UISF_HIDEFOCUS), 0);
 
                 /* I am not sure under which circumstances the TAB is handled


### PR DESCRIPTION
Fixes CORE-19585

## Purpose

I've added the corresponding patch that fixes the keyboard navigation bug that makes the cursor get stuck, according to [CORE-19585](https://jira.reactos.org/browse/CORE-19585). ~The patch just now checks for SBS_SIZEBOX and SBS_SIZEGRIP.~ After some research, this patch just adds WS_GROUP to layout.h to avoid getting the cursor stuck. 

With this path, the bug is fixed:
### "Move to..." menu
![2024-05-20 22-33-52](https://github.com/reactos/reactos/assets/117179675/1e39741d-8756-4473-8aed-7456e5f62a79)

### "Copy to..." menu
![imagen](https://github.com/reactos/reactos/assets/117179675/32fd83e8-6bad-4601-b95a-a4555a2728db)
