### PR TITLE
[SHELL32] CDirectoryWatcher: Check if window is alive

### DIFF
--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -199,7 +199,8 @@ CreateDirectoryWatcherFromRegEntry(LPREGENTRY pRegEntry)
         return NULL;
 
     // create a CDirectoryWatcher
-    CDirectoryWatcher *pDirectoryWatcher = CDirectoryWatcher::Create(szPath, pRegEntry->fRecursive);
+    CDirectoryWatcher *pDirectoryWatcher =
+        CDirectoryWatcher::Create(pRegEntry->hwnd, szPath, pRegEntry->fRecursive);
     if (pDirectoryWatcher == NULL)
         return NULL;
 

--- a/dll/win32/shell32/shelldesktop/CDirectoryWatcher.cpp
+++ b/dll/win32/shell32/shelldesktop/CDirectoryWatcher.cpp
@@ -384,6 +384,7 @@ void CDirectoryWatcher::QuitWatching()
     assert(this != NULL);
 
     m_fDead = TRUE;
+    m_hNotifyWnd = NULL;
     CancelIo(m_hDirectory);
 }
 

--- a/dll/win32/shell32/shelldesktop/CDirectoryWatcher.cpp
+++ b/dll/win32/shell32/shelldesktop/CDirectoryWatcher.cpp
@@ -68,13 +68,13 @@ static void NTAPI _RequestAllTerminationAPC(ULONG_PTR Parameter)
     s_hThreadAPC = NULL;
 }
 
-CDirectoryWatcher::CDirectoryWatcher(HWND hNotifWnd, LPCWSTR pszDirectoryPath, BOOL fSubTree)
-    : m_hNotifWnd(hNotifWnd)
+CDirectoryWatcher::CDirectoryWatcher(HWND hNotifyWnd, LPCWSTR pszDirectoryPath, BOOL fSubTree)
+    : m_hNotifyWnd(hNotifyWnd)
     , m_fDead(FALSE)
     , m_fRecursive(fSubTree)
     , m_dir_list(pszDirectoryPath, fSubTree)
 {
-    TRACE("CDirectoryWatcher::CDirectoryWatcher: %p, '%S'\n", this, pszDirectoryPath);
+    TRACE("%p, '%S'\n", this, pszDirectoryPath);
 
     GetFullPathNameW(pszDirectoryPath, _countof(m_szDirectoryPath), m_szDirectoryPath, NULL);
 
@@ -87,10 +87,10 @@ CDirectoryWatcher::CDirectoryWatcher(HWND hNotifWnd, LPCWSTR pszDirectoryPath, B
 }
 
 /*static*/ CDirectoryWatcher *
-CDirectoryWatcher::Create(HWND hNotifWnd, LPCWSTR pszDirectoryPath, BOOL fSubTree)
+CDirectoryWatcher::Create(HWND hNotifyWnd, LPCWSTR pszDirectoryPath, BOOL fSubTree)
 {
     CDirectoryWatcher *pDirectoryWatcher =
-        new CDirectoryWatcher(hNotifWnd, pszDirectoryPath, fSubTree);
+        new CDirectoryWatcher(hNotifyWnd, pszDirectoryPath, fSubTree);
     if (pDirectoryWatcher->m_hDirectory == INVALID_HANDLE_VALUE)
     {
         ERR("CreateFileW failed\n");
@@ -102,7 +102,7 @@ CDirectoryWatcher::Create(HWND hNotifWnd, LPCWSTR pszDirectoryPath, BOOL fSubTre
 
 CDirectoryWatcher::~CDirectoryWatcher()
 {
-    TRACE("CDirectoryWatcher::~CDirectoryWatcher: %p, '%S'\n", this, m_szDirectoryPath);
+    TRACE("%p, '%S'\n", this, m_szDirectoryPath);
 
     if (m_hDirectory != INVALID_HANDLE_VALUE)
         CloseHandle(m_hDirectory);
@@ -389,10 +389,11 @@ void CDirectoryWatcher::QuitWatching()
 
 BOOL CDirectoryWatcher::IsDead()
 {
-    if (m_hNotifWnd && !::IsWindow(m_hNotifWnd))
+    if (m_hNotifyWnd && !::IsWindow(m_hNotifyWnd))
     {
-        m_hNotifWnd = NULL;
+        m_hNotifyWnd = NULL;
         m_fDead = TRUE;
+        CancelIo(m_hDirectory);
     }
     return m_fDead;
 }

--- a/dll/win32/shell32/shelldesktop/CDirectoryWatcher.h
+++ b/dll/win32/shell32/shelldesktop/CDirectoryWatcher.h
@@ -17,11 +17,11 @@ public:
     HANDLE m_hDirectory;
     WCHAR m_szDirectoryPath[MAX_PATH];
 
-    static CDirectoryWatcher *Create(LPCWSTR pszDirectoryPath, BOOL fSubTree);
+    static CDirectoryWatcher *Create(HWND hNotifWnd, LPCWSTR pszDirectoryPath, BOOL fSubTree);
     static void RequestAllWatchersTermination();
     ~CDirectoryWatcher();
 
-    BOOL IsDead() const;
+    BOOL IsDead();
     BOOL RestartWatching();
     void QuitWatching();
     BOOL RequestAddWatcher();
@@ -29,6 +29,7 @@ public:
     void ReadCompletion(DWORD dwErrorCode, DWORD dwNumberOfBytesTransfered);
 
 protected:
+    HWND m_hNotifWnd;
     BOOL m_fDead;
     BOOL m_fRecursive;
     CDirectoryList m_dir_list;
@@ -36,5 +37,5 @@ protected:
 
     BOOL CreateAPCThread();
     void ProcessNotification();
-    CDirectoryWatcher(LPCWSTR pszDirectoryPath, BOOL fSubTree);
+    CDirectoryWatcher(HWND hNotifWnd, LPCWSTR pszDirectoryPath, BOOL fSubTree);
 };

--- a/dll/win32/shell32/shelldesktop/CDirectoryWatcher.h
+++ b/dll/win32/shell32/shelldesktop/CDirectoryWatcher.h
@@ -17,7 +17,7 @@ public:
     HANDLE m_hDirectory;
     WCHAR m_szDirectoryPath[MAX_PATH];
 
-    static CDirectoryWatcher *Create(HWND hNotifWnd, LPCWSTR pszDirectoryPath, BOOL fSubTree);
+    static CDirectoryWatcher *Create(HWND hNotifyWnd, LPCWSTR pszDirectoryPath, BOOL fSubTree);
     static void RequestAllWatchersTermination();
     ~CDirectoryWatcher();
 
@@ -29,7 +29,7 @@ public:
     void ReadCompletion(DWORD dwErrorCode, DWORD dwNumberOfBytesTransfered);
 
 protected:
-    HWND m_hNotifWnd;
+    HWND m_hNotifyWnd;
     BOOL m_fDead;
     BOOL m_fRecursive;
     CDirectoryList m_dir_list;
@@ -37,5 +37,5 @@ protected:
 
     BOOL CreateAPCThread();
     void ProcessNotification();
-    CDirectoryWatcher(HWND hNotifWnd, LPCWSTR pszDirectoryPath, BOOL fSubTree);
+    CDirectoryWatcher(HWND hNotifyWnd, LPCWSTR pszDirectoryPath, BOOL fSubTree);
 };


### PR DESCRIPTION
## Purpose
Kill the zombie watchers for system performance.
JIRA issue: [CORE-13950](https://jira.reactos.org/browse/CORE-13950)

## Proposed changes

- Add `HWND` parameter to `CDirectoryWatcher::Create`.
- Check whether the `HWND` is alive at `CDirectoryWatcher::IsDead`.

## TODO

- [x] Do tests.