### PR TITLE
[SHELL32] Don't free original PIDLs in CDefView::OnChangeNotify

### DIFF
--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -2347,17 +2347,18 @@ LRESULT CDefView::OnChangeNotify(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &
     // Translate PIDLs.
     // SHSimpleIDListFromPathW creates fake PIDLs (lacking some attributes)
     // FIXME: Use SHGetRealIDL
-    CComHeapPtr<ITEMIDLIST_ABSOLUTE> pidl0(ILClone(Pidls[0])), pidl1(ILClone(Pidls[1]));
+    PIDLIST_ABSOLUTE pidl0 = Pidls[0], pidl1 = Pidls[1];
+    CComHeapPtr<ITEMIDLIST_ABSOLUTE> pidl0Temp, pidl1Temp;
     WCHAR path[MAX_PATH];
     if (pidl0 && SHGetPathFromIDListW(pidl0, path) && PathFileExistsW(path))
     {
-        pidl0.Free();
-        pidl0.Attach(ILCreateFromPathW(path));
+        pidl0Temp.Attach(ILCreateFromPathW(path));
+        pidl0 = pidl0Temp;
     }
     if (pidl1 && SHGetPathFromIDListW(pidl1, path) && PathFileExistsW(path))
     {
-        pidl1.Free();
-        pidl1.Attach(ILCreateFromPathW(path));
+        pidl1Temp.Attach(ILCreateFromPathW(path));
+        pidl1 = pidl1Temp;
     }
 
     PITEMID_CHILD child0 = NULL, child1 = NULL;

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -2345,25 +2345,20 @@ LRESULT CDefView::OnChangeNotify(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &
     PIDLIST_ABSOLUTE pidl0 = Pidls[0], pidl1 = Pidls[1];
     CComHeapPtr<ITEMIDLIST_RELATIVE> pidl0Temp, pidl1Temp;
     PITEMID_CHILD child0 = NULL, child1 = NULL;
-    if (pidl0 && pidl0->mkid.cb)
+    if (pidl0 && ILIsParentOrSpecialParent(m_pidlParent, pidl0))
     {
         child0 = ILFindLastID(pidl0);
         hr = SHGetRealIDL(m_pSFParent, child0, &pidl0Temp);
         if (SUCCEEDED(hr))
             child0 = pidl0Temp;
     }
-    if (pidl1 && pidl1->mkid.cb)
+    if (pidl1 && ILIsParentOrSpecialParent(m_pidlParent, pidl1))
     {
         child1 = ILFindLastID(pidl1);
         hr = SHGetRealIDL(m_pSFParent, child1, &pidl1Temp);
         if (SUCCEEDED(hr))
             child1 = pidl1Temp;
     }
-
-    if (ILIsParentOrSpecialParent(m_pidlParent, pidl0))
-        child0 = ILFindLastID(pidl0);
-    if (ILIsParentOrSpecialParent(m_pidlParent, pidl1))
-        child1 = ILFindLastID(pidl1);
 
     lEvent &= ~SHCNE_INTERRUPT;
     switch (lEvent)

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -2345,14 +2345,14 @@ LRESULT CDefView::OnChangeNotify(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &
     PIDLIST_ABSOLUTE pidl0 = Pidls[0], pidl1 = Pidls[1];
     CComHeapPtr<ITEMIDLIST_RELATIVE> pidl0Temp, pidl1Temp;
     PITEMID_CHILD child0 = NULL, child1 = NULL;
-    if (pidl0 && ILIsParentOrSpecialParent(m_pidlParent, pidl0))
+    if (ILIsParentOrSpecialParent(m_pidlParent, pidl0))
     {
         child0 = ILFindLastID(pidl0);
         hr = SHGetRealIDL(m_pSFParent, child0, &pidl0Temp);
         if (SUCCEEDED(hr))
             child0 = pidl0Temp;
     }
-    if (pidl1 && ILIsParentOrSpecialParent(m_pidlParent, pidl1))
+    if (ILIsParentOrSpecialParent(m_pidlParent, pidl1))
     {
         child1 = ILFindLastID(pidl1);
         hr = SHGetRealIDL(m_pSFParent, child1, &pidl1Temp);

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -2347,7 +2347,7 @@ LRESULT CDefView::OnChangeNotify(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &
     // Translate PIDLs.
     // SHSimpleIDListFromPathW creates fake PIDLs (lacking some attributes)
     // FIXME: Use SHGetRealIDL
-    CComHeapPtr<ITEMIDLIST_ABSOLUTE> pidl0(Pidls[0]), pidl1(Pidls[1]);
+    CComHeapPtr<ITEMIDLIST_ABSOLUTE> pidl0(ILClone(Pidls[0])), pidl1(ILClone(Pidls[1]));
     WCHAR path[MAX_PATH];
     if (pidl0 && SHGetPathFromIDListW(pidl0, path) && PathFileExistsW(path))
     {

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -2342,19 +2342,18 @@ LRESULT CDefView::OnChangeNotify(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &
     // Translate child IDLs.
     // SHSimpleIDListFromPathW creates fake PIDLs (lacking some attributes)
     HRESULT hr;
-    PIDLIST_ABSOLUTE pidl0 = Pidls[0], pidl1 = Pidls[1];
-    CComHeapPtr<ITEMIDLIST_RELATIVE> pidl0Temp, pidl1Temp;
     PITEMID_CHILD child0 = NULL, child1 = NULL;
-    if (ILIsParentOrSpecialParent(m_pidlParent, pidl0))
+    CComHeapPtr<ITEMIDLIST_RELATIVE> pidl0Temp, pidl1Temp;
+    if (ILIsParentOrSpecialParent(m_pidlParent, Pidls[0]))
     {
-        child0 = ILFindLastID(pidl0);
+        child0 = ILFindLastID(Pidls[0]);
         hr = SHGetRealIDL(m_pSFParent, child0, &pidl0Temp);
         if (SUCCEEDED(hr))
             child0 = pidl0Temp;
     }
-    if (ILIsParentOrSpecialParent(m_pidlParent, pidl1))
+    if (ILIsParentOrSpecialParent(m_pidlParent, Pidls[1]))
     {
-        child1 = ILFindLastID(pidl1);
+        child1 = ILFindLastID(Pidls[1]);
         hr = SHGetRealIDL(m_pSFParent, child1, &pidl1Temp);
         if (SUCCEEDED(hr))
             child1 = pidl1Temp;

--- a/dll/win32/shell32/precomp.h
+++ b/dll/win32/shell32/precomp.h
@@ -40,6 +40,8 @@
 #include <comctl32_undoc.h>
 #include <shlguid_undoc.h>
 #include <shlobj_undoc.h>
+
+#define SHLWAPI_ISHELLFOLDER_HELPERS
 #include <shlwapi_undoc.h>
 
 #include <shellapi.h>

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -2,12 +2,23 @@
  * PROJECT:     shell32
  * LICENSE:     LGPL-2.1+ (https://spdx.org/licenses/LGPL-2.1+)
  * PURPOSE:     Utility functions
- * COPYRIGHT:   Copyright 2023 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ * COPYRIGHT:   Copyright 2023-2024 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  */
 
 #include "precomp.h"
 
 WINE_DEFAULT_DEBUG_CHANNEL(shell);
+
+HRESULT SHILClone(LPCITEMIDLIST pidl, LPITEMIDLIST *ppidl)
+{
+    if (!pidl)
+    {
+        *ppidl = NULL;
+        return S_OK;
+    }
+    *ppidl = ILClone(pidl);
+    return (*ppidl ? S_OK : E_OUTOFMEMORY);
+}
 
 BOOL PathIsDotOrDotDotW(_In_ LPCWSTR pszPath)
 {
@@ -1241,4 +1252,42 @@ PathIsEqualOrSubFolder(
         return FALSE;
 
     return strPath1.CompareNoCase(strCommon) == 0;
+}
+
+/*************************************************************************
+ *  SHGetRealIDL [SHELL32.98]
+ */
+EXTERN_C
+HRESULT WINAPI
+SHGetRealIDL(
+    _In_ IShellFolder *psf,
+    _In_ PCUITEMID_CHILD pidlSimple,
+    _Outptr_ PITEMID_CHILD * ppidlReal)
+{
+    HRESULT hr;
+    STRRET strret;
+    WCHAR szPath[MAX_PATH];
+    SFGAOF attrs;
+
+    *ppidlReal = NULL;
+
+    hr = IShellFolder_GetDisplayNameOf(psf, pidlSimple, SHGDN_INFOLDER | SHGDN_FORPARSING,
+                                       &strret, 0);
+    if (FAILED_UNEXPECTEDLY(hr))
+        return hr;
+
+    hr = StrRetToBufW(&strret, pidlSimple, szPath, _countof(szPath));
+    if (FAILED_UNEXPECTEDLY(hr))
+        return hr;
+
+    attrs = SFGAO_FILESYSTEM;
+    hr = psf->GetAttributesOf(1, &pidlSimple, &attrs);
+    if (SUCCEEDED(hr) && !(attrs & SFGAO_FILESYSTEM))
+        return SHILClone(pidlSimple, ppidlReal);
+
+    hr = IShellFolder_ParseDisplayName(psf, NULL, NULL, szPath, NULL, ppidlReal, NULL);
+    if (hr == E_INVALIDARG || hr == E_NOTIMPL)
+        return SHILClone(pidlSimple, ppidlReal);
+
+    return hr;
 }

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -1262,7 +1262,7 @@ HRESULT WINAPI
 SHGetRealIDL(
     _In_ IShellFolder *psf,
     _In_ PCUITEMID_CHILD pidlSimple,
-    _Outptr_ PITEMID_CHILD * ppidlReal)
+    _Outptr_ PITEMID_CHILD *ppidlReal)
 {
     HRESULT hr;
     STRRET strret;

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -9,7 +9,10 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(shell);
 
-HRESULT SHILClone(LPCITEMIDLIST pidl, LPITEMIDLIST *ppidl)
+HRESULT
+SHILClone(
+    _In_opt_ LPCITEMIDLIST pidl,
+    _Outptr_ LPITEMIDLIST *ppidl)
 {
     if (!pidl)
     {

--- a/dll/win32/shell32/wine/pidl.c
+++ b/dll/win32/shell32/wine/pidl.c
@@ -747,6 +747,7 @@ LPITEMIDLIST WINAPI ILCombine(LPCITEMIDLIST pidl1, LPCITEMIDLIST pidl2)
     return pidlNew;
 }
 
+#ifndef __REACTOS__ /* See ..\utils.cpp */
 /*************************************************************************
  *  SHGetRealIDL [SHELL32.98]
  *
@@ -794,6 +795,7 @@ HRESULT WINAPI SHGetRealIDL(LPSHELLFOLDER lpsf, LPCITEMIDLIST pidlSimple, LPITEM
 
     return hr;
 }
+#endif
 
 /*************************************************************************
  *  SHLogILFromFSIL [SHELL32.95]


### PR DESCRIPTION
## Purpose
Follow-up to #6898. These PIDLs shouldn't be freed because they are not allocated by `CoTaskMemAlloc`.
We should use PIDLs mainly in internal data instead of physical paths for change notifications.

JIRA issue: [CORE-13950](https://jira.reactos.org/browse/CORE-13950)
JIRA issue: [CORE-19612](https://jira.reactos.org/browse/CORE-19612)

## Proposed change

- Re-implement `SHGetRealIDL` function.
- Translate child IDLs by using `SHGetRealIDL`.
- Use newly-defined `pidl0Temp` and `pidl1Temp` for temporary creation.
- Improve `ILIsParentOrSpecialParent` function without using `SHGetPathFromIDListW` function.

## TODO

- [x] Do  tests.
