### PR TITLE
[SHELL32] Implement CSIDL_CONNECTIONS and fix CSIDL_PRINTERS

### DIFF
--- a/dll/win32/shell32/precomp.h
+++ b/dll/win32/shell32/precomp.h
@@ -181,7 +181,7 @@ Shell_DisplayNameOf(
     _Out_ LPWSTR pszBuf,
     _In_ UINT cchBuf);
 
-HRESULT SHBindToObject(
+EXTERN_C HRESULT SHBindToObject(
     _In_opt_ IShellFolder *psf,
     _In_ LPCITEMIDLIST pidl,
     _In_ REFIID riid,

--- a/dll/win32/shell32/precomp.h
+++ b/dll/win32/shell32/precomp.h
@@ -181,7 +181,8 @@ Shell_DisplayNameOf(
     _Out_ LPWSTR pszBuf,
     _In_ UINT cchBuf);
 
-EXTERN_C HRESULT SHBindToObject(
+EXTERN_C
+HRESULT SHBindToObject(
     _In_opt_ IShellFolder *psf,
     _In_ LPCITEMIDLIST pidl,
     _In_ REFIID riid,

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -202,7 +202,7 @@ SHBindToObjectEx(
     return hr;
 }
 
-HRESULT SHBindToObject(
+EXTERN_C HRESULT SHBindToObject(
     _In_opt_ IShellFolder *psf,
     _In_ LPCITEMIDLIST pidl,
     _In_ REFIID riid,

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -202,7 +202,8 @@ SHBindToObjectEx(
     return hr;
 }
 
-EXTERN_C HRESULT SHBindToObject(
+EXTERN_C
+HRESULT SHBindToObject(
     _In_opt_ IShellFolder *psf,
     _In_ LPCITEMIDLIST pidl,
     _In_ REFIID riid,

--- a/dll/win32/shell32/wine/pidl.c
+++ b/dll/win32/shell32/wine/pidl.c
@@ -1682,10 +1682,10 @@ LPITEMIDLIST _ILCreatePrinters(void)
 {
 #ifdef __REACTOS__
     // Note: Wine returns the PIDL as it was in Windows 95, NT5 moved it into CSIDL_CONTROLS
-    extern HRESULT WINAPI SHGetFolderLocationHelper(HWND hwnd, int nFolder, REFCLSID clsid, LPITEMIDLIST *ppidl);
+    extern HRESULT SHGetFolderLocationHelper(HWND hwnd, int nFolder, REFCLSID clsid, LPITEMIDLIST *ppidl);
     LPITEMIDLIST pidl;
-    HRESULT hr = SHGetFolderLocationHelper(NULL, CSIDL_CONTROLS, &CLSID_Printers, &pidl);
-    return SUCCEEDED(hr) ? pidl : NULL;
+    SHGetFolderLocationHelper(NULL, CSIDL_CONTROLS, &CLSID_Printers, &pidl);
+    return pidl;
 #else
     LPITEMIDLIST parent = _ILCreateGuid(PT_GUID, &CLSID_MyComputer), ret = NULL;
 

--- a/dll/win32/shell32/wine/pidl.c
+++ b/dll/win32/shell32/wine/pidl.c
@@ -1680,6 +1680,13 @@ LPITEMIDLIST _ILCreateControlPanel(void)
 
 LPITEMIDLIST _ILCreatePrinters(void)
 {
+#ifdef __REACTOS__
+    // Note: Wine returns the PIDL as it was in Windows 95, NT5 moved it into CSIDL_CONTROLS
+    extern HRESULT WINAPI SHGetFolderLocationHelper(HWND hwnd, int nFolder, REFCLSID clsid, LPITEMIDLIST *ppidl);
+    LPITEMIDLIST pidl;
+    HRESULT hr = SHGetFolderLocationHelper(NULL, CSIDL_CONTROLS, &CLSID_Printers, &pidl);
+    return SUCCEEDED(hr) ? pidl : NULL;
+#else
     LPITEMIDLIST parent = _ILCreateGuid(PT_GUID, &CLSID_MyComputer), ret = NULL;
 
     TRACE("()\n");
@@ -1695,6 +1702,7 @@ LPITEMIDLIST _ILCreatePrinters(void)
         SHFree(parent);
     }
     return ret;
+#endif
 }
 
 LPITEMIDLIST _ILCreateNetwork(void)

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -3100,7 +3100,7 @@ BOOL WINAPI SHGetSpecialFolderPathW (
 }
 
 #ifdef __REACTOS__
-HRESULT WINAPI SHGetFolderLocationHelper(HWND hwnd, int nFolder, REFCLSID clsid, LPITEMIDLIST *ppidl)
+HRESULT SHGetFolderLocationHelper(HWND hwnd, int nFolder, REFCLSID clsid, LPITEMIDLIST *ppidl)
 {
     HRESULT hr;
     IShellFolder *psf;

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -3099,6 +3099,32 @@ BOOL WINAPI SHGetSpecialFolderPathW (
                             szPath) == S_OK;
 }
 
+#ifdef __REACTOS__
+HRESULT WINAPI SHGetFolderLocationHelper(HWND hwnd, int nFolder, REFCLSID clsid, LPITEMIDLIST *ppidl)
+{
+    HRESULT hr;
+    IShellFolder *psf;
+    LPITEMIDLIST parent, child;
+    EXTERN_C HRESULT SHBindToObject(IShellFolder *psf, LPCITEMIDLIST pidl, REFIID riid, void **ppvObj);
+    *ppidl = NULL;
+    if (FAILED(hr = SHGetFolderLocation(hwnd, nFolder, NULL, 0, &parent)))
+        return hr;
+    if (SUCCEEDED(hr = SHBindToObject(NULL, parent, &IID_IShellFolder, (void**)&psf)))
+    {
+        WCHAR clsidstr[2 + 38 + 1];
+        clsidstr[0] = clsidstr[1] = L':';
+        StringFromGUID2(clsid, clsidstr + 2, 38 + 1);
+        hr = IShellFolder_ParseDisplayName(psf, hwnd, NULL, clsidstr, NULL, &child, NULL);
+        if (SUCCEEDED(hr))
+            *ppidl = ILCombine(parent, child);
+        IShellFolder_Release(psf);
+        ILFree(child);
+    }
+    ILFree(parent);
+    return hr;
+}
+#endif
+
 /*************************************************************************
  * SHGetFolderLocation [SHELL32.@]
  *
@@ -3185,6 +3211,15 @@ HRESULT WINAPI SHGetFolderLocation(
         case CSIDL_NETWORK:
             *ppidl = _ILCreateNetwork();
             break;
+
+#ifdef __REACTOS__
+        case CSIDL_CONNECTIONS:
+        {
+            EXTERN_C const CLSID CLSID_ConnectionFolder;
+            hr = SHGetFolderLocationHelper(hwndOwner, CSIDL_CONTROLS, &CLSID_ConnectionFolder, ppidl);
+            break;
+        }
+#endif
 
         default:
         {


### PR DESCRIPTION
CSIDL_CONNECTIONS is needed by external callers, mainly NetShell PR #6905