### PR TITLE
[AUDIO] Implement volume control support

### DIFF
--- a/dll/win32/wdmaud.drv/legacy.c
+++ b/dll/win32/wdmaud.drv/legacy.c
@@ -850,6 +850,25 @@ WdmAudGetWavePositionByLegacy(
     return MMSYSERR_NOERROR;
 }
 
+MMRESULT
+WdmAudGetVolumeByLegacy(
+    _In_ PSOUND_DEVICE_INSTANCE SoundDeviceInstance,
+    _In_ DWORD DeviceId,
+    _Out_ PDWORD pdwVolume)
+{
+    /* FIXME */
+    return MMSYSERR_NOTSUPPORTED;
+}
+
+MMRESULT
+WdmAudSetVolumeByLegacy(
+    _In_ PSOUND_DEVICE_INSTANCE SoundDeviceInstance,
+    _In_ DWORD DeviceId,
+    _In_ DWORD dwVolume)
+{
+    /* FIXME */
+    return MMSYSERR_NOTSUPPORTED;
+}
 
 MMRESULT
 WdmAudResetStreamByLegacy(

--- a/dll/win32/wdmaud.drv/wdmaud.c
+++ b/dll/win32/wdmaud.drv/wdmaud.c
@@ -76,6 +76,12 @@ PopulateWdmDeviceList(
         FuncTable.Close = FUNC_NAME(WdmAudCloseSoundDevice);
         FuncTable.GetDeviceInterfaceString = FUNC_NAME(WdmAudGetDeviceInterfaceString);
 
+        if (DeviceType == AUX_DEVICE_TYPE || DeviceType == MIDI_OUT_DEVICE_TYPE || DeviceType == WAVE_OUT_DEVICE_TYPE)
+        {
+            FuncTable.GetVolume = FUNC_NAME(WdmAudGetVolume);
+            FuncTable.SetVolume = FUNC_NAME(WdmAudSetVolume);
+        }
+
         if (DeviceType == MIXER_DEVICE_TYPE)
         {
             FuncTable.SetWaveFormat = FUNC_NAME(WdmAudSetMixerDeviceFormat);

--- a/dll/win32/wdmaud.drv/wdmaud.h
+++ b/dll/win32/wdmaud.drv/wdmaud.h
@@ -145,6 +145,18 @@ WdmAudGetWavePositionByMMixer(
     IN  MMTIME* Time);
 
 MMRESULT
+WdmAudGetVolumeByMMixer(
+    _In_ PSOUND_DEVICE_INSTANCE SoundDeviceInstance,
+    _In_ DWORD DeviceId,
+    _Out_ PDWORD pdwVolume);
+
+MMRESULT
+WdmAudSetVolumeByMMixer(
+    _In_ PSOUND_DEVICE_INSTANCE SoundDeviceInstance,
+    _In_ DWORD DeviceId,
+    _In_ DWORD dwVolume);
+
+MMRESULT
 WdmAudCommitWaveBufferByMMixer(
     IN  PSOUND_DEVICE_INSTANCE SoundDeviceInstance,
     IN  PVOID OffsetPtr,
@@ -223,6 +235,18 @@ MMRESULT
 WdmAudGetWavePositionByLegacy(
     IN  struct _SOUND_DEVICE_INSTANCE* SoundDeviceInstance,
     IN  MMTIME* Time);
+
+MMRESULT
+WdmAudGetVolumeByLegacy(
+    _In_ PSOUND_DEVICE_INSTANCE SoundDeviceInstance,
+    _In_ DWORD DeviceId,
+    _Out_ PDWORD pdwVolume);
+
+MMRESULT
+WdmAudSetVolumeByLegacy(
+    _In_ PSOUND_DEVICE_INSTANCE SoundDeviceInstance,
+    _In_ DWORD DeviceId,
+    _In_ DWORD dwVolume);
 
 MMRESULT
 WriteFileEx_Committer2(

--- a/sdk/include/reactos/libs/sound/mmebuddy.h
+++ b/sdk/include/reactos/libs/sound/mmebuddy.h
@@ -190,6 +190,16 @@ typedef MMRESULT(*MMRESETSTREAM_FUNC)(
     IN  MMDEVICE_TYPE DeviceType,
     IN  BOOLEAN bStartReset);
 
+typedef MMRESULT(*MMGETVOLUME_FUNC)(
+    _In_ struct _SOUND_DEVICE_INSTANCE* SoundDeviceInstance,
+    _In_ DWORD DeviceId,
+    _Out_ PDWORD pdwVolume);
+
+typedef MMRESULT(*MMSETVOLUME_FUNC)(
+    _In_ struct _SOUND_DEVICE_INSTANCE* SoundDeviceInstance,
+    _In_ DWORD DeviceId,
+    _In_ DWORD dwVolume);
+
 typedef struct _MMFUNCTION_TABLE
 {
     union
@@ -215,6 +225,9 @@ typedef struct _MMFUNCTION_TABLE
     MMSETSTATE_FUNC                 SetState;
     MMQUERYDEVICEINTERFACESTRING_FUNC     GetDeviceInterfaceString;
     MMRESETSTREAM_FUNC               ResetStream;
+
+    MMGETVOLUME_FUNC                GetVolume;
+    MMSETVOLUME_FUNC                SetVolume;
 
     // Redundant
     //MMWAVEHEADER_FUNC               PrepareWaveHeader;
@@ -368,6 +381,20 @@ MmeGetPosition(
     IN  DWORD_PTR PrivateHandle,
     IN  MMTIME* Time,
     IN  DWORD Size);
+
+MMRESULT
+MmeGetVolume(
+    _In_ MMDEVICE_TYPE DeviceType,
+    _In_ DWORD DeviceId,
+    _In_ DWORD_PTR PrivateHandle,
+    _Out_ DWORD_PTR pdwVolume);
+
+MMRESULT
+MmeSetVolume(
+    _In_ MMDEVICE_TYPE DeviceType,
+    _In_ DWORD DeviceId,
+    _In_ DWORD_PTR PrivateHandle,
+    _In_ DWORD_PTR dwVolume);
 
 MMRESULT
 MmeGetDeviceInterfaceString(

--- a/sdk/lib/drivers/sound/mmebuddy/auxiliary/auxMessage.c
+++ b/sdk/lib/drivers/sound/mmebuddy/auxiliary/auxMessage.c
@@ -45,6 +45,24 @@ auxMessage(
                                                    Parameter2);
             break;
         }
+
+        case AUXDM_GETVOLUME:
+        {
+            Result = MmeGetVolume(AUX_DEVICE_TYPE,
+                                  DeviceId,
+                                  PrivateHandle,
+                                  Parameter1);
+            break;
+        }
+
+        case AUXDM_SETVOLUME:
+        {
+            Result = MmeSetVolume(AUX_DEVICE_TYPE,
+                                  DeviceId,
+                                  PrivateHandle,
+                                  Parameter1);
+            break;
+        }
     }
 
     SND_TRACE(L"auxMessage returning MMRESULT %d\n", Result);

--- a/sdk/lib/drivers/sound/mmebuddy/midi/modMessage.c
+++ b/sdk/lib/drivers/sound/mmebuddy/midi/modMessage.c
@@ -75,6 +75,23 @@ modMessage(
             break;
         }
 
+        case MODM_GETVOLUME:
+        {
+            Result = MmeGetVolume(MIDI_OUT_DEVICE_TYPE,
+                                  DeviceId,
+                                  PrivateHandle,
+                                  Parameter1);
+            break;
+        }
+
+        case MODM_SETVOLUME:
+        {
+            Result = MmeSetVolume(MIDI_OUT_DEVICE_TYPE,
+                                  DeviceId,
+                                  PrivateHandle,
+                                  Parameter1);
+            break;
+        }
     }
 
     SND_TRACE(L"modMessage returning MMRESULT %d\n", Result);

--- a/sdk/lib/drivers/sound/mmebuddy/mmewrap.c
+++ b/sdk/lib/drivers/sound/mmebuddy/mmewrap.c
@@ -365,3 +365,82 @@ MmeGetPosition(
     return Result;
 }
 
+MMRESULT
+MmeGetVolume(
+    _In_ MMDEVICE_TYPE DeviceType,
+    _In_ DWORD DeviceId,
+    _In_ DWORD_PTR PrivateHandle,
+    _Out_ DWORD_PTR pdwVolume)
+{
+    MMRESULT Result;
+    PSOUND_DEVICE_INSTANCE SoundDeviceInstance;
+    PSOUND_DEVICE SoundDevice;
+    PMMFUNCTION_TABLE FunctionTable;
+
+    /* Sanity check */
+    SND_ASSERT(DeviceType == AUX_DEVICE_TYPE ||
+               DeviceType == MIDI_OUT_DEVICE_TYPE ||
+               DeviceType == WAVE_OUT_DEVICE_TYPE);
+
+    VALIDATE_MMSYS_PARAMETER(PrivateHandle);
+    SoundDeviceInstance = (PSOUND_DEVICE_INSTANCE)PrivateHandle;
+
+    if (!IsValidSoundDeviceInstance(SoundDeviceInstance))
+        return MMSYSERR_INVALHANDLE;
+
+    Result = GetSoundDeviceFromInstance(SoundDeviceInstance, &SoundDevice);
+    if (!MMSUCCESS(Result))
+        return TranslateInternalMmResult(Result);
+
+    Result = GetSoundDeviceFunctionTable(SoundDevice, &FunctionTable);
+    if (!MMSUCCESS(Result))
+        return TranslateInternalMmResult(Result);
+
+    if (!FunctionTable->GetVolume)
+        return MMSYSERR_NOTSUPPORTED;
+
+    /* Call the driver */
+    Result = FunctionTable->GetVolume(SoundDeviceInstance, DeviceId, (PDWORD)pdwVolume);
+
+    return Result;
+}
+
+MMRESULT
+MmeSetVolume(
+    _In_ MMDEVICE_TYPE DeviceType,
+    _In_ DWORD DeviceId,
+    _In_ DWORD_PTR PrivateHandle,
+    _In_ DWORD_PTR dwVolume)
+{
+    MMRESULT Result;
+    PSOUND_DEVICE_INSTANCE SoundDeviceInstance;
+    PSOUND_DEVICE SoundDevice;
+    PMMFUNCTION_TABLE FunctionTable;
+
+    /* Sanity check */
+    SND_ASSERT(DeviceType == AUX_DEVICE_TYPE ||
+               DeviceType == MIDI_OUT_DEVICE_TYPE ||
+               DeviceType == WAVE_OUT_DEVICE_TYPE);
+
+    VALIDATE_MMSYS_PARAMETER(PrivateHandle);
+    SoundDeviceInstance = (PSOUND_DEVICE_INSTANCE)PrivateHandle;
+
+    if (!IsValidSoundDeviceInstance(SoundDeviceInstance))
+        return MMSYSERR_INVALHANDLE;
+
+    Result = GetSoundDeviceFromInstance(SoundDeviceInstance, &SoundDevice);
+    if (!MMSUCCESS(Result))
+        return TranslateInternalMmResult(Result);
+
+    Result = GetSoundDeviceFunctionTable(SoundDevice, &FunctionTable);
+    if (!MMSUCCESS(Result))
+        return TranslateInternalMmResult(Result);
+
+    if (!FunctionTable->SetVolume)
+        return MMSYSERR_NOTSUPPORTED;
+
+    /* Call the driver */
+    Result = FunctionTable->SetVolume(SoundDeviceInstance, DeviceId, (DWORD)dwVolume);
+
+    return Result;
+}

--- a/sdk/lib/drivers/sound/mmebuddy/wave/wodMessage.c
+++ b/sdk/lib/drivers/sound/mmebuddy/wave/wodMessage.c
@@ -118,6 +118,24 @@ wodMessage(
             break;
         }
 
+        case WODM_GETVOLUME:
+        {
+            Result = MmeGetVolume(WAVE_OUT_DEVICE_TYPE,
+                                  DeviceId,
+                                  PrivateHandle,
+                                  Parameter1);
+            break;
+        }
+
+        case WODM_SETVOLUME:
+        {
+            Result = MmeSetVolume(WAVE_OUT_DEVICE_TYPE,
+                                  DeviceId,
+                                  PrivateHandle,
+                                  Parameter1);
+            break;
+        }
+
         case DRV_QUERYDEVICEINTERFACESIZE :
         {
             Result = MmeGetDeviceInterfaceString(WAVE_OUT_DEVICE_TYPE, DeviceId, NULL, 0, (DWORD*)Parameter1); //FIXME DWORD_PTR


### PR DESCRIPTION
## Purpose

Implement volume level changing for Aux/MidiOut/WaveOut devices. The volume control is represented the following WINMM functions:
- `auxGetVolume`,
- `auxSetVolume`,
- `midiOutGetVolume`,
- `midiOutSetVolume`,
- `waveOutGetVolume`,
- `waveOutSetVolume`,

which are calling the following messages appropriately:
- `AUXDM_GETVOLUME`,
- `AUXDM_SETVOLUME`,
- `MODM_GETVOLUME`,
- `MODM_SETVOLUME`,
- `WODM_GETVOLUME`,
- `WODM_SETVOLUME`.  

This fixes volume control for several 3rd-party programs (like Fox Audio Player 0.10.2 from Rapps, Winamp 2.95 with WaveOut plugin). However it does not fix changing the volume in system volume mixers (SndVol32, MMSys), since they are using their own functionality instead. They technically do the same things, but apart from the functions mentioned above.

JIRA issue: [CORE-14780](https://jira.reactos.org/browse/CORE-14780)

## TODO

- [ ] **Implement volume control for Legacy mode too. Currently, it is implemented only for MMixer mode.**
- [x] For now, volume is changing only in range from 51% to 100%, but in range from 0% to 50% it is always at minimal 1% level. **Fix it to change in the whole range from 0% to 100%, as it's done in Windows.** **Done now in my new #6950 PR**. :slightly_smiling_face: 

## Result

See the following videos, which demonstrates how it works before after my changes. At least Fox Audio Player 0.10.2 from Rapps and Winamp 2.95 with WaveOut plugin are now changing the volume correctly. :smiley: 

Before:

[Part 1.webm](https://github.com/reactos/reactos/assets/26385117/53e002ce-4a1c-492a-bfd2-6e8f8d79173c)

After:

[Part 2.webm](https://github.com/reactos/reactos/assets/26385117/0add60ea-249c-4cd5-bf7a-dfa89ec2b225)

I also made a clip with these two videos together, comparing before and after behaviour. Will upload it on YouTube. Unfortunately it's too big to attach here. :slightly_frowning_face: 