### PR TITLE
[NTUSER] menu.c position fix to not hide 'Close'

### DIFF
--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -3394,7 +3394,7 @@ static PMENU FASTCALL MENU_ShowSubPopup(PWND WndOwner, PMENU Menu, BOOL SelectFi
   }
   Item->fState |= MF_MOUSESELECT;
 
-  if (IS_SYSTEM_MENU(Menu))
+  if (IS_SYSTEM_MENU(Menu) && !(Menu->fFlags & MNF_POPUP))
   {
       MENU_InitSysMenuPopup(Item->spSubMenu, pWnd->style, pWnd->pcls->style, HTSYSMENU);
 


### PR DESCRIPTION
CORE-19579

## Purpose

_Move CMD popup menu to not cover 'Close'._

JIRA issue: [CORE-19579](https://jira.reactos.org/browse/CORE-19579)

## Proposed changes

_When IS_SYSTEM_MENU was redefined, the old definition worked better in this location, so put its logic back._
_Fix an 'unintended consequence' of https://github.com/reactos/reactos/commit/3ae0ccdcc._

Before:

![cmd-taskbar-right-click-close-bad](https://github.com/reactos/reactos/assets/32620577/7ab7859f-6464-4fe2-81e8-4d945afc97a4)

After:

![cmd-menu-pos-fix1](https://github.com/reactos/reactos/assets/32620577/4469d1eb-b947-471b-aa93-3337f898e3e2)
