### PR TITLE
[PARTMGR] Reimplement IOCTL_MOUNTDEV_QUERY_UNIQUE_ID for MBR and GPT partitions

### DIFF
--- a/drivers/storage/partmgr/partition.c
+++ b/drivers/storage/partmgr/partition.c
@@ -120,7 +120,7 @@ PartitionHandleStartDevice(
 
     PartExt->SymlinkCreated = TRUE;
 
-    TRACE("Symlink created %wZ -> %wZ\n", &PartExt->DeviceName, &partitionSymlink);
+    INFO("Symlink created %wZ -> %wZ\n", &partitionSymlink, &PartExt->DeviceName);
 
     // our partition device will have two interfaces:
     // GUID_DEVINTERFACE_PARTITION and GUID_DEVINTERFACE_VOLUME
@@ -203,7 +203,7 @@ PartitionHandleRemove(
         }
         PartExt->SymlinkCreated = FALSE;
 
-        INFO("Symlink removed %wZ -> %wZ\n", &PartExt->DeviceName, &partitionSymlink);
+        INFO("Symlink removed %wZ -> %wZ\n", &partitionSymlink, &PartExt->DeviceName);
     }
 
     // release device interfaces
@@ -258,7 +258,7 @@ PartitionHandleDeviceRelations(
 
     if (type == TargetDeviceRelation)
     {
-        // Device relations has one entry built in to it's size.
+        // Device relations have one entry built into their size.
         PDEVICE_RELATIONS deviceRelations =
             ExAllocatePoolZero(PagedPool, sizeof(DEVICE_RELATIONS), TAG_PARTMGR);
 

--- a/drivers/storage/partmgr/partmgr.c
+++ b/drivers/storage/partmgr/partmgr.c
@@ -367,7 +367,7 @@ FdoIoctlDiskGetDriveGeometryEx(
     // as disk.sys doesn't really know about the partition table on a disk
 
     PDISK_GEOMETRY_EX_INTERNAL geometryEx = Irp->AssociatedIrp.SystemBuffer;
-    size_t outBufferLength = ioStack->Parameters.DeviceIoControl.OutputBufferLength;
+    ULONG outBufferLength = ioStack->Parameters.DeviceIoControl.OutputBufferLength;
     NTSTATUS status;
 
     status = IssueSyncIoControlRequest(IOCTL_DISK_GET_DRIVE_GEOMETRY_EX,

--- a/drivers/storage/partmgr/partmgr.c
+++ b/drivers/storage/partmgr/partmgr.c
@@ -114,6 +114,84 @@ PartMgrConvertLayoutToExtended(
     return layoutEx;
 }
 
+/**
+ * @brief
+ * Detects whether a disk is a "super-floppy", i.e. an unpartitioned
+ * disk with only a valid VBR, as reported by IoReadPartitionTable()
+ * and IoWritePartitionTable():
+ * only one single partition starting at offset zero and spanning the
+ * whole disk, without hidden sectors, whose type is FAT16 non-bootable.
+ *
+ * Accessing \Device\HarddiskN\Partition0 or Partition1 on such disks
+ * returns the same data.
+ *
+ * @note
+ * - Requires partitioning lock held.
+ * - Uses the cached disk partition layout.
+ **/
+static
+CODE_SEG("PAGE")
+BOOLEAN
+PartMgrIsDiskSuperFloppy(
+    _In_ PFDO_EXTENSION FdoExtension)
+{
+    PPARTITION_INFORMATION_EX PartitionInfo;
+
+    PAGED_CODE();
+
+    ASSERT(FdoExtension->LayoutValid && FdoExtension->LayoutCache);
+
+    /* We must be MBR and have only one partition */
+    ASSERT(FdoExtension->DiskData.PartitionStyle == FdoExtension->LayoutCache->PartitionStyle);
+    if (FdoExtension->DiskData.PartitionStyle != PARTITION_STYLE_MBR)
+        return FALSE;
+    if (FdoExtension->LayoutCache->PartitionCount != 1)
+        return FALSE;
+
+    /* Get the single partition entry */
+    PartitionInfo = FdoExtension->LayoutCache->PartitionEntry;
+    ASSERT(FdoExtension->DiskData.PartitionStyle == PartitionInfo->PartitionStyle);
+
+    /* The single partition must start at the beginning of the disk */
+    if (!(PartitionInfo->StartingOffset.QuadPart == 0 &&
+          PartitionInfo->Mbr.HiddenSectors == 0))
+    {
+        return FALSE;
+    }
+
+    /* The disk signature is usually set to 1; warn in case it's not */
+    ASSERT(FdoExtension->DiskData.Mbr.Signature == FdoExtension->LayoutCache->Mbr.Signature);
+    if (FdoExtension->DiskData.Mbr.Signature != 1)
+    {
+        WARN("Super-Floppy disk %lu signature %08x != 1!\n",
+             FdoExtension->DiskData.DeviceNumber, FdoExtension->DiskData.Mbr.Signature);
+    }
+
+    /* The partition must be recognized and report as FAT16 non-bootable */
+    if ((PartitionInfo->Mbr.RecognizedPartition != TRUE) ||
+        (PartitionInfo->Mbr.PartitionType != PARTITION_FAT_16) ||
+        (PartitionInfo->Mbr.BootIndicator != FALSE))
+    {
+        WARN("Super-Floppy disk %lu does not return default settings!\n"
+             "    RecognizedPartition = %s, expected TRUE\n"
+             "    PartitionType = 0x%02x, expected 0x04 (PARTITION_FAT_16)\n"
+             "    BootIndicator = %s, expected FALSE\n",
+             FdoExtension->DiskData.DeviceNumber,
+             PartitionInfo->Mbr.RecognizedPartition ? "TRUE" : "FALSE",
+             PartitionInfo->Mbr.PartitionType,
+             PartitionInfo->Mbr.BootIndicator ? "TRUE" : "FALSE");
+    }
+
+    /* The partition and disk sizes should agree */
+    if (PartitionInfo->PartitionLength.QuadPart != FdoExtension->DiskData.DiskSize)
+    {
+        WARN("PartitionLength = %I64u is different from DiskSize = %I64u\n",
+             PartitionInfo->PartitionLength.QuadPart, FdoExtension->DiskData.DiskSize);
+    }
+
+    return TRUE;
+}
+
 static
 CODE_SEG("PAGE")
 VOID
@@ -304,7 +382,7 @@ PartMgrUpdatePartitionDevices(
         }
         else
         {
-            // insert in the beginning
+            // insert at the beginning
             partExt->ListEntry.Next = FdoExtension->PartitionList.Next;
             FdoExtension->PartitionList.Next = &partExt->ListEntry;
         }
@@ -315,7 +393,15 @@ PartMgrUpdatePartitionDevices(
     FdoExtension->EnumeratedPartitionsTotal = totalPartitions;
 }
 
-// requires partitioning lock held
+/**
+ * @brief
+ * Retrieves the disk partition layout from the given disk FDO.
+ *
+ * If the disk layout cache is valid, just return it; otherwise,
+ * read the partition table layout from disk and update the cache.
+ *
+ * @note    Requires partitioning lock held.
+ **/
 static
 CODE_SEG("PAGE")
 NTSTATUS
@@ -333,22 +419,29 @@ PartMgrGetDriveLayout(
 
     PDRIVE_LAYOUT_INFORMATION_EX layoutEx = NULL;
     NTSTATUS status = IoReadPartitionTableEx(FdoExtension->LowerDevice, &layoutEx);
-
     if (!NT_SUCCESS(status))
-    {
         return status;
-    }
 
     if (FdoExtension->LayoutCache)
-    {
         ExFreePool(FdoExtension->LayoutCache);
-    }
 
     FdoExtension->LayoutCache = layoutEx;
     FdoExtension->LayoutValid = TRUE;
 
-    *DriveLayout = layoutEx;
+    FdoExtension->DiskData.PartitionStyle = layoutEx->PartitionStyle;
+    if (FdoExtension->DiskData.PartitionStyle == PARTITION_STYLE_MBR)
+    {
+        FdoExtension->DiskData.Mbr.Signature = layoutEx->Mbr.Signature;
+        // FdoExtension->DiskData.Mbr.Checksum = geometryEx.Partition.Mbr.CheckSum;
+    }
+    else
+    {
+        FdoExtension->DiskData.Gpt.DiskId = layoutEx->Gpt.DiskId;
+    }
 
+    FdoExtension->IsSuperFloppy = PartMgrIsDiskSuperFloppy(FdoExtension);
+
+    *DriveLayout = layoutEx;
     return status;
 }
 
@@ -493,7 +586,6 @@ FdoIoctlDiskGetDriveLayout(
 
     PDRIVE_LAYOUT_INFORMATION_EX layoutEx;
     NTSTATUS status = PartMgrGetDriveLayout(FdoExtension, &layoutEx);
-
     if (!NT_SUCCESS(status))
     {
         PartMgrReleaseLayoutLock(FdoExtension);
@@ -603,6 +695,14 @@ FdoIoctlDiskSetDriveLayout(
 
     PartMgrAcquireLayoutLock(FdoExtension);
 
+    // If the current disk is super-floppy but the user changes
+    // the number of partitions to > 1, fail the call.
+    if (FdoExtension->IsSuperFloppy && (layoutEx->PartitionCount > 1))
+    {
+        PartMgrReleaseLayoutLock(FdoExtension);
+        return STATUS_INVALID_DEVICE_REQUEST;
+    }
+
     // this in fact updates the bus relations
     PartMgrUpdatePartitionDevices(FdoExtension, layoutEx);
 
@@ -625,6 +725,8 @@ FdoIoctlDiskSetDriveLayout(
 
             part->PartitionNumber = layoutEx->PartitionEntry[i].PartitionNumber;
         }
+
+        FdoExtension->IsSuperFloppy = PartMgrIsDiskSuperFloppy(FdoExtension);
     }
     else
     {
@@ -690,6 +792,16 @@ FdoIoctlDiskSetDriveLayoutEx(
 
     PartMgrAcquireLayoutLock(FdoExtension);
 
+    // If the current disk is super-floppy but the user changes either
+    // the disk type or the number of partitions to > 1, fail the call.
+    if (FdoExtension->IsSuperFloppy &&
+        ((layoutEx->PartitionStyle != PARTITION_STYLE_MBR) ||
+         (layoutEx->PartitionCount > 1)))
+    {
+        PartMgrReleaseLayoutLock(FdoExtension);
+        return STATUS_INVALID_DEVICE_REQUEST;
+    }
+
     // if partition count is 0, it's the same as IOCTL_DISK_CREATE_DISK
     if (layoutEx->PartitionCount == 0)
     {
@@ -734,6 +846,8 @@ FdoIoctlDiskSetDriveLayoutEx(
         }
         FdoExtension->LayoutCache = layoutEx;
         FdoExtension->LayoutValid = TRUE;
+
+        FdoExtension->IsSuperFloppy = PartMgrIsDiskSuperFloppy(FdoExtension);
     }
     else
     {
@@ -879,7 +993,13 @@ FdoHandleStartDevice(
     return status;
 }
 
-// requires partitioning lock held
+/**
+ * @brief
+ * Refreshes all the cached disk FDO data.
+ * The geometry of the disk and its partition layout cache is updated.
+ *
+ * @note    Requires partitioning lock held.
+ **/
 static
 CODE_SEG("PAGE")
 NTSTATUS
@@ -900,9 +1020,7 @@ PartMgrRefreshDiskData(
                                        sizeof(geometryEx),
                                        FALSE);
     if (!NT_SUCCESS(status))
-    {
         return status;
-    }
 
     FdoExtension->DiskData.DiskSize = geometryEx.DiskSize.QuadPart;
     FdoExtension->DiskData.BytesPerSector = geometryEx.Geometry.BytesPerSector;
@@ -911,20 +1029,7 @@ PartMgrRefreshDiskData(
     PDRIVE_LAYOUT_INFORMATION_EX layoutEx = NULL;
     status = PartMgrGetDriveLayout(FdoExtension, &layoutEx);
     if (!NT_SUCCESS(status))
-    {
         return status;
-    }
-
-    FdoExtension->DiskData.PartitionStyle = layoutEx->PartitionStyle;
-    if (FdoExtension->DiskData.PartitionStyle == PARTITION_STYLE_MBR)
-    {
-        FdoExtension->DiskData.Mbr.Signature = layoutEx->Mbr.Signature;
-        // FdoExtension->DiskData.Mbr.Checksum = geometryEx.Partition.Mbr.CheckSum;
-    }
-    else
-    {
-        FdoExtension->DiskData.Gpt.DiskId = layoutEx->Gpt.DiskId;
-    }
 
     return STATUS_SUCCESS;
 }
@@ -957,8 +1062,8 @@ FdoHandleDeviceRelations(
 
         INFO("Partition style %u\n", FdoExtension->DiskData.PartitionStyle);
 
-        // PartMgrAcquireLayoutLock calls PartMgrGetDriveLayout inside
-        // so we're sure here that it returns only cached layout
+        // PartMgrRefreshDiskData() calls PartMgrGetDriveLayout() inside
+        // so we're sure here that it returns only the cached layout.
         PDRIVE_LAYOUT_INFORMATION_EX layoutEx;
         PartMgrGetDriveLayout(FdoExtension, &layoutEx);
 

--- a/drivers/storage/partmgr/partmgr.h
+++ b/drivers/storage/partmgr/partmgr.h
@@ -44,7 +44,7 @@ typedef struct _FDO_EXTENSION
 
     SINGLE_LIST_ENTRY PartitionList;
     UINT32 EnumeratedPartitionsTotal;
-    UNICODE_STRING DiskInterfaceName;
+    BOOLEAN IsSuperFloppy;
 
     struct {
         UINT64 DiskSize;
@@ -60,6 +60,7 @@ typedef struct _FDO_EXTENSION
             } Gpt;
         };
     } DiskData;
+    UNICODE_STRING DiskInterfaceName;
 } FDO_EXTENSION, *PFDO_EXTENSION;
 
 typedef struct _PARTITION_EXTENSION

--- a/drivers/storage/partmgr/partmgr.h
+++ b/drivers/storage/partmgr/partmgr.h
@@ -31,6 +31,29 @@ typedef struct _DISK_GEOMETRY_EX_INTERNAL
     DISK_DETECTION_INFO Detection;
 } DISK_GEOMETRY_EX_INTERNAL, *PDISK_GEOMETRY_EX_INTERNAL;
 
+// Unique ID data for basic (disk partition-based) volumes.
+// It is stored in the MOUNTDEV_UNIQUE_ID::UniqueId member
+// as an array of bytes.
+#include <pshpack1.h>
+typedef union _BASIC_VOLUME_UNIQUE_ID
+{
+    struct
+    {
+        ULONG Signature;
+        ULONGLONG StartingOffset;
+    } Mbr;
+    struct
+    {
+        ULONGLONG Signature; // UCHAR[8] // "DMIO:ID:"
+        GUID PartitionGuid;
+    } Gpt;
+} BASIC_VOLUME_UNIQUE_ID, *PBASIC_VOLUME_UNIQUE_ID;
+#include <poppack.h>
+C_ASSERT(RTL_FIELD_SIZE(BASIC_VOLUME_UNIQUE_ID, Mbr) == 0x0C);
+C_ASSERT(RTL_FIELD_SIZE(BASIC_VOLUME_UNIQUE_ID, Gpt) == 0x18);
+
+#define DMIO_ID_SIGNATURE   (*(ULONGLONG*)"DMIO:ID:")
+
 typedef struct _FDO_EXTENSION
 {
     BOOLEAN IsFDO;


### PR DESCRIPTION
## Purpose

Reimplement IOCTL_MOUNTDEV_QUERY_UNIQUE_ID for MBR and GPT partitions, so that the MOUNTMGR (who sends this query to storage drivers) can retrieve something "nice" to store under `HKEY_LOCAL_MACHINE\SYSTEM\MountedDevices`.

JIRA issue: [CORE-15575](https://jira.reactos.org/browse/CORE-15575)

## Proposed changes

The returned standard UniqueId has the following format:

- Basic volume on MBR disk: disk Mbr.Signature + partition StartingOffset (length: 0x0C)
- Basic volume on GPT disk: "DMIO:ID:" + Gpt.PartitionGuid (length: 0x18)
- Volume on Basic disk (NT <= 4): 8-byte FTDisk identifier (length: 0x08)
- Volume on Dynamic disk (NT 5+): "DMIO:ID:" + dmio VolumeGuid (length: 0x18)
- Super-floppy (single-partition with StartingOffset == 0),
  or Removable media: DiskInterfaceName.
- As fallback, we use the VolumeInterfaceName.

References:
- https://winreg-kb.readthedocs.io/en/latest/sources/system-keys/Mounted-devices.html
- https://stackoverflow.com/a/72787681/21852502
- Manual testing on Windows.

Additional bug fixes to make the feature work reliably:

- Fix a `PartitionId` assignment copy-paste error in `PartitionCreateDevice()`.
- Fix the way the "symlink -> target" DPRINT is displayed.

- Detect whether the disk is of "super-floppy" format (i.e. it does
  not have an MBR, but has just one VBR starting at offset zero, thus
  describing a unique partition filling the whole disk).

- Make `PartMgrGetDriveLayout()` also update the FDO DiskData's
  PartitionStyle and Signature/GPT DiskId for consistency (code moved
  from `PartMgrRefreshDiskData()`).

- In `FdoIoctlDiskSetDriveLayout[Ex]()`, if the disk is "super-floppy",
  but the user wants to create more than one partition, fail the call.
  (In the Ex call, fail also if the partition style changes.)

## How to test

Run any build artifact from here, or replace partmgr.sys from an existing ReactOS installation with one from the artifacts, and monitor the contents of the values listed under `HKEY_LOCAL_MACHINE\SYSTEM\MountedDevices`.

## TODO

- [x] Fix the build errors caused by me forgetting that I need to give pointers to stuff when using RtlCopyMemory();
- [x] Add a comment in CORE-15575 about where the "mountmgr" problem really ws
- [x] Do tests with both MBR and GPT disks ~~(cc @DarkFire01 for GPT testing on UEFI :wink: )~~;
- [x] Revert the TRACE/INFO --> ERR changes I've made.
- [x] Split the large main commit into smaller ones.

## Test results matrix

| Test case | Win2003 | ReactOS |
| :-------: | :-----: | :-----: |
| _**1:**_ MBR partition | ![win2k3_MBR_part](https://github.com/reactos/reactos/assets/1969829/aad59097-f6b7-4998-802b-6b79d24449b6) | ![ros_MBR_part](https://github.com/reactos/reactos/assets/1969829/bcb8ce45-79a6-4463-be07-36dd30644725) |
| _**2:**_ GPT partition[^gpt_note] | ![win2k3_GPT_part](https://github.com/reactos/reactos/assets/1969829/9c8e4f8e-666a-4ce2-9cad-4f3cf48c62e0) | ![ros_GPT_part](https://github.com/reactos/reactos/assets/1969829/5ba6dfe2-cd33-4942-b162-6b09c5778200) |
| _**3:**_ Super-floppy[^floppa_note] | ![win2k3_superfloppy](https://github.com/reactos/reactos/assets/1969829/9c9818bb-4870-4b07-94ff-edc4a033e6ca) | ![ros_superfloppy](https://github.com/reactos/reactos/assets/1969829/ad46cb3f-6334-43ea-945b-89d8d34a4212) |

Win2003 volumes list:
![win2k3_diskvol_list](https://github.com/reactos/reactos/assets/1969829/4043085e-f6ab-4e03-8266-6a1a1551796f)

ReactOS volumes list[^ros_vol_note]:
![ros_diskvol_list](https://github.com/reactos/reactos/assets/1969829/f2ab3b04-77bd-4fd1-aedd-521767349d96)


[^gpt_note]:
    Normally, the `disk.sys` driver of Windows 2003 (and perhaps Windows XP, to a lesser extent) is able to directly display partitions on GPT disks. If not, restart in debug mode with WinDbg attached, and monitor for the appearance of the following warning message on the debugger:
    ```
    DISK: Disk <disk_pointer_here> recognized as a GPT disk on a system without GPT support.
          Disk will appear as RAW.
    ```
    If this message shows up, restart Windows and _break **very early** during boot_. Ensure that you have the debug symbols available. Then, enter `dd disk!DiskDisableGpt` and confirm that the first DWORD value is 1:
    ```
    kd> dd disk!DiskDisableGpt
    f9c5d0d0  00000001 ...
    ```
    Now, set it to 0 to forcefully enable GPT, and confirm that it has correctly been changed:
    ```
    kd> ed disk!DiskDisableGpt 0
    kd> dd disk!DiskDisableGpt
    f9c5d0d0  00000000 ...
    ```
    and you can continue execution (command `g`). You should be able to verify that the previous warning message does not appear now, and that the partitions on GPT disks are properly listed.

[^floppa_note]:
    ["Super-floppy": _**In partitioning context**_](https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/windows-and-gpt-faq?view=windows-11#superfloppy), this is a disk that does not have an MBR, but has just one VBR starting at offset zero,
thus describing a unique partition filling the whole disk.

[^ros_vol_note]:
    Manually assigning drive letters in the `HKLM\SYSTEM\MountedDevices` keys in ReactOS and forcing the `"NoAutoMount" = 1` REG_DWORD value in `HKLM\SYSTEM\CurrentControlSet\services\mountmgr`
so as to attempt to get the same drive assignments as on Windows 2003, does not appear to have any effect, and the drive letters are all re-assigned at the next reboot.
    The fact that ReactOS also appears to have more mounted drives than Windows 2003, is due to the fact that in this example, some partitions have type IDs known by ReactOS but unknown by Windows. (For example, the 3rd partition on the first disk has type 0x83 == Linux and is formatted in Btrfs.)
