### PR TITLE
[SHELL32] brfolder.cpp: Follow-up of af03438

### DIFF
--- a/dll/win32/shell32/brfolder.cpp
+++ b/dll/win32/shell32/brfolder.cpp
@@ -258,12 +258,10 @@ BrFolder_InsertItem(
         (pidlParent ? ILCombine(pidlParent, pidlChild) : ILClone(pidlChild));
     BrFolder_GetIconPair(pidlFull, &item);
 
-    pItemData->lpsfParent.Attach(lpsf);
-    lpsf->AddRef();
+    pItemData->lpsfParent = lpsf;
     pItemData->pidlChild.Attach(ILClone(pidlChild));
     pItemData->pidlFull.Attach(pidlFull);
-    pItemData->pEnumIL.Attach(pEnumIL);
-    pEnumIL->AddRef();
+    pItemData->pEnumIL = pEnumIL;
 
     TVINSERTSTRUCTW tvins = { hParent };
     tvins.item = item;
@@ -323,7 +321,7 @@ BrFolder_Expand(
                 {
                     if ((pEnumIL->Skip(1) != S_OK) || FAILED(pEnumIL->Reset()))
                     {
-                        pEnumIL.Release();
+                        pEnumIL = NULL;
                     }
                 }
             }
@@ -417,8 +415,7 @@ BrFolder_Treeview_Expand(BrFolder *info, NMTREEVIEWW *pnmtv)
     }
     else
     {
-        lpsf2.Attach(pItemData->lpsfParent);
-        pItemData->lpsfParent->AddRef();
+        lpsf2 = pItemData->lpsfParent;
     }
 
     HTREEITEM hItem = pnmtv->itemNew.hItem;
@@ -694,8 +691,7 @@ BrFolder_NewFolder(BrFolder *info)
     }
     else
     {
-        cur.Attach(desktop);
-        desktop->AddRef();
+        cur = desktop;
         hr = SHGetFolderPathW(NULL, CSIDL_DESKTOPDIRECTORY, NULL, SHGFP_TYPE_CURRENT, path);
     }
 
@@ -730,8 +726,7 @@ BrFolder_NewFolder(BrFolder *info)
     if (!item_data)
         return hr;
 
-    if (item_data->pEnumIL)
-        item_data->pEnumIL.Release();
+    item_data->pEnumIL = NULL;
     hr = cur->EnumObjects(info->hwndTreeView, flags, &item_data->pEnumIL);
     if (FAILED_UNEXPECTEDLY(hr))
         return hr;

--- a/dll/win32/shell32/brfolder.cpp
+++ b/dll/win32/shell32/brfolder.cpp
@@ -308,7 +308,8 @@ BrFolder_Expand(
         ULONG ulAttrs = SFGAO_HASSUBFOLDER | SFGAO_FOLDER;
         CComPtr<IEnumIDList> pEnumIL;
         CComPtr<IShellFolder> pSFChild;
-        lpsf->GetAttributesOf(1, (LPCITEMIDLIST *)&pidlTemp, &ulAttrs);
+        LPCITEMIDLIST pidlRef = pidlTemp;
+        lpsf->GetAttributesOf(1, &pidlRef, &ulAttrs);
         if (ulAttrs & SFGAO_FOLDER)
         {
             hr = lpsf->BindToObject(pidlTemp, NULL, IID_PPV_ARG(IShellFolder, &pSFChild));
@@ -362,15 +363,13 @@ BrFolder_CheckValidSelection(BrFolder *info, BrItemData *pItemData)
     if (lpBrowseInfo->ulFlags & BIF_RETURNFSANCESTORS)
     {
         dwAttributes = SFGAO_FILESYSANCESTOR | SFGAO_FILESYSTEM;
-        hr = pItemData->lpsfParent->GetAttributesOf(1, (LPCITEMIDLIST *)&pItemData->pidlChild,
-                                                    &dwAttributes);
+        hr = pItemData->lpsfParent->GetAttributesOf(1, &pidlChild, &dwAttributes);
         if (FAILED(hr) || !(dwAttributes & (SFGAO_FILESYSANCESTOR | SFGAO_FILESYSTEM)))
             bEnabled = FALSE;
     }
 
     dwAttributes = SFGAO_FOLDER | SFGAO_FILESYSTEM;
-    hr = pItemData->lpsfParent->GetAttributesOf(1, (LPCITEMIDLIST *)&pItemData->pidlChild,
-                                                &dwAttributes);
+    hr = pItemData->lpsfParent->GetAttributesOf(1, &pidlChild, &dwAttributes);
     if (FAILED_UNEXPECTEDLY(hr) ||
         ((dwAttributes & (SFGAO_FOLDER | SFGAO_FILESYSTEM)) != (SFGAO_FOLDER | SFGAO_FILESYSTEM)))
     {

--- a/dll/win32/shell32/brfolder.cpp
+++ b/dll/win32/shell32/brfolder.cpp
@@ -259,11 +259,11 @@ BrFolder_InsertItem(
     BrFolder_GetIconPair(pidlFull, &item);
 
     pItemData->lpsfParent.Attach(lpsf);
-    pItemData->lpsfParent.AddRef();
+    lpsf->AddRef();
     pItemData->pidlChild.Attach(ILClone(pidlChild));
     pItemData->pidlFull.Attach(pidlFull);
     pItemData->pEnumIL.Attach(pEnumIL);
-    pItemData->pEnumIL.AddRef();
+    pEnumIL->AddRef();
 
     TVINSERTSTRUCTW tvins = { hParent };
     tvins.item = item;
@@ -418,7 +418,7 @@ BrFolder_Treeview_Expand(BrFolder *info, NMTREEVIEWW *pnmtv)
     else
     {
         lpsf2.Attach(pItemData->lpsfParent);
-        lpsf2.AddRef();
+        pItemData->lpsfParent->AddRef();
     }
 
     HTREEITEM hItem = pnmtv->itemNew.hItem;
@@ -695,7 +695,7 @@ BrFolder_NewFolder(BrFolder *info)
     else
     {
         cur.Attach(desktop);
-        cur.AddRef(desktop);
+        desktop->AddRef();
         hr = SHGetFolderPathW(NULL, CSIDL_DESKTOPDIRECTORY, NULL, SHGFP_TYPE_CURRENT, path);
     }
 

--- a/dll/win32/shell32/brfolder.cpp
+++ b/dll/win32/shell32/brfolder.cpp
@@ -259,9 +259,11 @@ BrFolder_InsertItem(
     BrFolder_GetIconPair(pidlFull, &item);
 
     pItemData->lpsfParent.Attach(lpsf);
+    pItemData->lpsfParent.AddRef();
     pItemData->pidlChild.Attach(ILClone(pidlChild));
     pItemData->pidlFull.Attach(pidlFull);
     pItemData->pEnumIL.Attach(pEnumIL);
+    pItemData->pEnumIL.AddRef();
 
     TVINSERTSTRUCTW tvins = { hParent };
     tvins.item = item;
@@ -416,6 +418,7 @@ BrFolder_Treeview_Expand(BrFolder *info, NMTREEVIEWW *pnmtv)
     else
     {
         lpsf2.Attach(pItemData->lpsfParent);
+        lpsf2.AddRef();
     }
 
     HTREEITEM hItem = pnmtv->itemNew.hItem;
@@ -692,6 +695,7 @@ BrFolder_NewFolder(BrFolder *info)
     else
     {
         cur.Attach(desktop);
+        cur.AddRef(desktop);
         hr = SHGetFolderPathW(NULL, CSIDL_DESKTOPDIRECTORY, NULL, SHGFP_TYPE_CURRENT, path);
     }
 


### PR DESCRIPTION
## Purpose
Follow-up of #6909 (af03438). Fix assertions and exceptions of `CComPtr` and `CComHeapPtr`.
JIRA issue: [CORE-17340](https://jira.reactos.org/browse/CORE-17340)

## Proposed changes

- Don't use `AddRef`, `Release`, and `Attach` methods against `CComPtr` template class. Simply use assignment.
- Fix the 3rd parameter of three `IShellFolder::GetAttributesOf` method calls. It had referenced `CHeapPtr::operator&`.

## TODO

- [x] Do tests.

## Screenshot

ReactOS (AFTER):
![after](https://github.com/reactos/reactos/assets/2107452/99d007ad-a5a2-44be-b94a-5e090692b218)
Successful.