### PR TITLE
[SHELL32] CDefView: Implement SFVM_GETCOMMANDIR callback

### DIFF
--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -1582,9 +1582,8 @@ HRESULT CDefView::InvokeContextMenuCommand(CComPtr<IContextMenu>& pCM, LPCSTR lp
         cmi.ptInvoke = *pt;
     }
 
-    WCHAR szDirW[MAX_PATH];
+    WCHAR szDirW[MAX_PATH] = L"";
     CHAR szDirA[MAX_PATH];
-    szDirW[0] = 0;
     if (SUCCEEDED(_DoFolderViewCB(SFVM_GETCOMMANDDIR, _countof(szDirW), (LPARAM)szDirW)) &&
         szDirW[0] != UNICODE_NULL)
     {

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -1585,7 +1585,7 @@ HRESULT CDefView::InvokeContextMenuCommand(CComPtr<IContextMenu>& pCM, LPCSTR lp
     WCHAR szDirW[MAX_PATH] = L"";
     CHAR szDirA[MAX_PATH];
     if (SUCCEEDED(_DoFolderViewCB(SFVM_GETCOMMANDDIR, _countof(szDirW), (LPARAM)szDirW)) &&
-        szDirW[0] != UNICODE_NULL)
+        *szDirW != UNICODE_NULL)
     {
         SHUnicodeToAnsi(szDirW, szDirA, _countof(szDirA));
         cmi.fMask |= CMIC_MASK_UNICODE;

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -1582,6 +1582,18 @@ HRESULT CDefView::InvokeContextMenuCommand(CComPtr<IContextMenu>& pCM, LPCSTR lp
         cmi.ptInvoke = *pt;
     }
 
+    WCHAR szDirW[MAX_PATH];
+    CHAR szDirA[MAX_PATH];
+    szDirW[0] = 0;
+    if (SUCCEEDED(_DoFolderViewCB(SFVM_GETCOMMANDDIR, _countof(szDirW), (LPARAM)szDirW)) &&
+        szDirW[0] != UNICODE_NULL)
+    {
+        SHUnicodeToAnsi(szDirW, szDirA, _countof(szDirA));
+        cmi.fMask |= CMIC_MASK_UNICODE;
+        cmi.lpDirectory = szDirA;
+        cmi.lpDirectoryW = szDirW;
+    }
+
     HRESULT hr = pCM->InvokeCommand((LPCMINVOKECOMMANDINFO)&cmi);
     // Most of our callers will do this, but if they would forget (File menu!)
     IUnknown_SetSite(pCM, NULL);


### PR DESCRIPTION
## Purpose
Implementing missing folder view callbacks...
JIRA issue: [CORE-19616](https://jira.reactos.org/browse/CORE-19616)

## Proposed changes

- In `CDefView::InvokeContextMenuCommand`, call `SFVM_GETCOMMANDDIR` callback and store the directory into `CMINVOKECOMMANDINFOEX` structure.

## TODO

- [x] Do build.