### PR TITLE
[SHELL32] CDefView: Implement SFVM_GETNAMELENGTH callback

### DIFF
--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -2228,7 +2228,7 @@ LRESULT CDefView::OnNotify(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandl
                     INT cchLimit = 0;
                     _DoFolderViewCB(SFVM_GETNAMELENGTH, (WPARAM)pidlFull, (LPARAM)&cchLimit);
                     if (cchLimit)
-                        ::PostMessageW(hEdit, EM_SETLIMITTEXT, cchLimit, 0);
+                        ::SendMessageW(hEdit, EM_SETLIMITTEXT, cchLimit, 0);
 
                     if (!SHELL_FS_HideExtension(szFullPath))
                     {

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -2225,6 +2225,11 @@ LRESULT CDefView::OnNotify(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandl
                     PIDLIST_ABSOLUTE pidlFull = ILCombine(m_pidlParent, pidl);
                     SHGetPathFromIDListW(pidlFull, szFullPath);
 
+                    INT cchLimit = 0;
+                    _DoFolderViewCB(SFVM_GETNAMELENGTH, (WPARAM)pidlFull, (LPARAM)&cchLimit);
+                    if (cchLimit)
+                        ::PostMessageW(hEdit, EM_SETLIMITTEXT, cchLimit, 0);
+
                     if (!SHELL_FS_HideExtension(szFullPath))
                     {
                         LPWSTR pszText = lpdi->item.pszText;


### PR DESCRIPTION
## Purpose

Implementing missing folder view callbacks...
JIRA issue: [CORE-19616](https://jira.reactos.org/browse/CORE-19616)

## Proposed changes

- Call `_DoFolderViewCB` on `LVN_BEGINLABELEDITW` message.
- Send `EM_SETLIMITTEXT` message if the limit was set.

## TODO

- [x] Do build.