### PR TITLE
[SHELL32] CDefView: Implement SFVM_COLUMNCLICK callback

### DIFF
--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -2106,7 +2106,8 @@ LRESULT CDefView::OnNotify(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandl
                 m_sortInfo.bIsAscending = !m_sortInfo.bIsAscending;
             else
                 m_sortInfo.bIsAscending = TRUE;
-            _Sort();
+            if (_DoFolderViewCB(SFVM_COLUMNCLICK, lpnmlv->iSubItem, 0) != S_OK)
+                _Sort();
             break;
         case LVN_GETDISPINFOA:
         case LVN_GETDISPINFOW:


### PR DESCRIPTION
## Purpose
Implementing missing folder view callbacks...
JIRA issue: [CORE-19616](https://jira.reactos.org/browse/CORE-19616)

## Proposed changes

- Call `_DoFolderViewCB` on `LVN_COLUMNCLICK`.
- If it returned `S_OK`, then don't sort items.

## TODO

- [x] Do build.