### PR TITLE
[SHELL32][BROWSEUI] CDefView: Implement SFVM_ADDPROPERTYPAGES callback

### DIFF
--- a/dll/win32/browseui/shellbrowser.cpp
+++ b/dll/win32/browseui/shellbrowser.cpp
@@ -1355,17 +1355,13 @@ HRESULT CShellBrowser::DoFolderOptions()
     if (FAILED_UNEXPECTEDLY(hResult))
         return E_FAIL;
 
-// CORE-11140 : Disabled this bit, because it prevents the folder options from showing.
-//              It returns 'E_NOTIMPL'
-#if 0
-    if (fCurrentShellView != NULL)
+    if (fCurrentShellView)
     {
         hResult = fCurrentShellView->AddPropertySheetPages(
             0, AddFolderOptionsPage, reinterpret_cast<LPARAM>(&m_PropSheet));
         if (FAILED_UNEXPECTEDLY(hResult))
             return E_FAIL;
     }
-#endif
 
     // show sheet
     CStringW strFolderOptions(MAKEINTRESOURCEW(IDS_FOLDER_OPTIONS));

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -2647,9 +2647,19 @@ HRESULT WINAPI CDefView::GetCurrentInfo(LPFOLDERSETTINGS lpfs)
     return S_OK;
 }
 
+//typedef struct _SFVM_PROPPAGE_DATA
+//{
+//    DWORD                dwReserved;
+//    LPFNADDPROPSHEETPAGE pfn;
+//    LPARAM               lParam;
+//} SFVM_PROPPAGE_DATA;
+
 HRESULT WINAPI CDefView::AddPropertySheetPages(DWORD dwReserved, LPFNADDPROPSHEETPAGE lpfn, LPARAM lparam)
 {
-    FIXME("(%p) stub\n", this);
+    TRACE("(%p)->(0x%lX, %p, %p)\n", this, dwReserved, lpfn, lparam);
+
+    SFVM_PROPPAGE_DATA Data = { dwReserved, lpfn, lparam };
+    _DoFolderViewCB(SFVM_ADDPROPERTYPAGES , 0, (LPARAM)&Data);
 
     return E_NOTIMPL;
 }

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -2647,21 +2647,13 @@ HRESULT WINAPI CDefView::GetCurrentInfo(LPFOLDERSETTINGS lpfs)
     return S_OK;
 }
 
-//typedef struct _SFVM_PROPPAGE_DATA
-//{
-//    DWORD                dwReserved;
-//    LPFNADDPROPSHEETPAGE pfn;
-//    LPARAM               lParam;
-//} SFVM_PROPPAGE_DATA;
-
 HRESULT WINAPI CDefView::AddPropertySheetPages(DWORD dwReserved, LPFNADDPROPSHEETPAGE lpfn, LPARAM lparam)
 {
     TRACE("(%p)->(0x%lX, %p, %p)\n", this, dwReserved, lpfn, lparam);
 
     SFVM_PROPPAGE_DATA Data = { dwReserved, lpfn, lparam };
-    _DoFolderViewCB(SFVM_ADDPROPERTYPAGES , 0, (LPARAM)&Data);
-
-    return E_NOTIMPL;
+    _DoFolderViewCB(SFVM_ADDPROPERTYPAGES, 0, (LPARAM)&Data);
+    return S_OK;
 }
 
 HRESULT WINAPI CDefView::SaveViewState()

--- a/sdk/include/psdk/shlobj.h
+++ b/sdk/include/psdk/shlobj.h
@@ -110,6 +110,13 @@ typedef enum
 
 typedef int GPFIDL_FLAGS;
 
+typedef struct _SFVM_PROPPAGE_DATA
+{
+    DWORD                dwReserved;
+    LPFNADDPROPSHEETPAGE pfn;
+    LPARAM               lParam;
+} SFVM_PROPPAGE_DATA, *LPSFVM_PROPPAGE_DATA;
+
 UINT
 WINAPI
 SHAddFromPropSheetExtArray(

--- a/sdk/include/psdk/shlobj.h
+++ b/sdk/include/psdk/shlobj.h
@@ -112,9 +112,9 @@ typedef int GPFIDL_FLAGS;
 
 typedef struct _SFVM_PROPPAGE_DATA
 {
-    DWORD                dwReserved;
+    DWORD dwReserved;
     LPFNADDPROPSHEETPAGE pfn;
-    LPARAM               lParam;
+    LPARAM lParam;
 } SFVM_PROPPAGE_DATA, *LPSFVM_PROPPAGE_DATA;
 
 UINT

--- a/sdk/include/psdk/shobjidl.idl
+++ b/sdk/include/psdk/shobjidl.idl
@@ -120,6 +120,12 @@ cpp_quote("#include <prsht.h>")
 cpp_quote("typedef LPFNADDPROPSHEETPAGE LPFNSVADDPROPSHEETPAGE;")
 cpp_quote("#endif")
 
+cpp_quote("typedef struct _SFVM_PROPPAGE_DATA {")
+cpp_quote("    DWORD                dwReserved;")
+cpp_quote("    LPFNADDPROPSHEETPAGE pfn;")
+cpp_quote("    LPARAM               lParam;")
+cpp_quote("} SFVM_PROPPAGE_DATA;")
+
 [
     object,
     uuid(000214E9-0000-0000-C000-000000000046),

--- a/sdk/include/psdk/shobjidl.idl
+++ b/sdk/include/psdk/shobjidl.idl
@@ -120,12 +120,6 @@ cpp_quote("#include <prsht.h>")
 cpp_quote("typedef LPFNADDPROPSHEETPAGE LPFNSVADDPROPSHEETPAGE;")
 cpp_quote("#endif")
 
-cpp_quote("typedef struct _SFVM_PROPPAGE_DATA {")
-cpp_quote("    DWORD                dwReserved;")
-cpp_quote("    LPFNADDPROPSHEETPAGE pfn;")
-cpp_quote("    LPARAM               lParam;")
-cpp_quote("} SFVM_PROPPAGE_DATA;")
-
 [
     object,
     uuid(000214E9-0000-0000-C000-000000000046),


### PR DESCRIPTION
## Purpose
Implementing missing folder view callbacks...
JIRA issue: [CORE-19616](https://jira.reactos.org/browse/CORE-19616)

## Proposed changes

- Add `SFVM_PROPPAGE_DATA` structure to `"shobjidl.idl"`.
- Implement `CDefView::AddPropertySheetPages` by calling `SFVM_ADDPROPERTYPAGES` callback.
- Modify `CShellBrowser::DoFolderOptions` that uses `AddPropertySheetPages`.

## TODO

- [x] Do build.