### PR TITLE
[SHELL32] CDefView: Implement SFVM_CANSELECTALL callback

### DIFF
--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -1972,7 +1972,8 @@ LRESULT CDefView::OnCommand(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHand
                 AutoArrange();
             break;
         case FCIDM_SHVIEW_SELECTALL:
-            m_ListView.SetItemState(-1, LVIS_SELECTED, LVIS_SELECTED);
+            if (_DoFolderViewCB(SFVM_CANSELECTALL, 0, 0) != S_FALSE)
+                m_ListView.SetItemState(-1, LVIS_SELECTED, LVIS_SELECTED);
             break;
         case FCIDM_SHVIEW_INVERTSELECTION:
             nCount = m_ListView.GetItemCount();


### PR DESCRIPTION
## Purpose
Implementing missing folder view callbacks...
JIRA issue: [CORE-19616](https://jira.reactos.org/browse/CORE-19616)

## Proposed changes

- Call `SFVM_CANSELECTALL` callback on `FCIDM_SHVIEW_SELECTALL`.
- If it returned `S_FALSE`, then do not select all.

## TODO

- [x] Do build.