### PR TITLE
[MSPAINT] Set wallpaper from command line

### DIFF
--- a/base/applications/mspaint/dialogs.cpp
+++ b/base/applications/mspaint/dialogs.cpp
@@ -19,6 +19,9 @@ CFontsDialog fontsDialog;
 
 void ShowError(INT stringID, ...)
 {
+    if (g_bNoUI)
+        return;
+
     va_list va;
     va_start(va, stringID);
 

--- a/base/applications/mspaint/dib.cpp
+++ b/base/applications/mspaint/dib.cpp
@@ -262,7 +262,8 @@ HBITMAP DoLoadImageFile(HWND hwnd, LPCWSTR name, BOOL fIsMainFile)
     HANDLE hFind = ::FindFirstFileW(name, &find);
     if (hFind == INVALID_HANDLE_VALUE) // does not exist
     {
-        ShowError(IDS_LOADERRORTEXT, name);
+        if (!g_bNoUI)
+            ShowError(IDS_LOADERRORTEXT, name);
         return NULL;
     }
     ::FindClose(hFind);
@@ -286,7 +287,8 @@ HBITMAP DoLoadImageFile(HWND hwnd, LPCWSTR name, BOOL fIsMainFile)
     if (FAILED(hr))
     {
         ATLTRACE("hr: 0x%08lX\n", hr);
-        ShowError(IDS_LOADERRORTEXT, name);
+        if (!g_bNoUI)
+            ShowError(IDS_LOADERRORTEXT, name);
         return NULL;
     }
 

--- a/base/applications/mspaint/dib.cpp
+++ b/base/applications/mspaint/dib.cpp
@@ -262,8 +262,7 @@ HBITMAP DoLoadImageFile(HWND hwnd, LPCWSTR name, BOOL fIsMainFile)
     HANDLE hFind = ::FindFirstFileW(name, &find);
     if (hFind == INVALID_HANDLE_VALUE) // does not exist
     {
-        if (!g_bNoUI)
-            ShowError(IDS_LOADERRORTEXT, name);
+        ShowError(IDS_LOADERRORTEXT, name);
         return NULL;
     }
     ::FindClose(hFind);
@@ -287,8 +286,7 @@ HBITMAP DoLoadImageFile(HWND hwnd, LPCWSTR name, BOOL fIsMainFile)
     if (FAILED(hr))
     {
         ATLTRACE("hr: 0x%08lX\n", hr);
-        if (!g_bNoUI)
-            ShowError(IDS_LOADERRORTEXT, name);
+        ShowError(IDS_LOADERRORTEXT, name);
         return NULL;
     }
 

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -1422,13 +1422,15 @@ wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdLine, INT nCm
     // Set the desktop wallpaper
     if (fuOptions & OPTION_WALLPAPER) // ReactOS specific!
     {
-        INT nID = IDM_FILEASWALLPAPERSTRETCHED;
+        INT nID;
         if (!filename)
             nID = IDM_RESETWALLPAPER;
         else if (fuOptions & OPTION_WALLPAPER_TILE)
             nID = IDM_FILEASWALLPAPERPLANE;
         else if (fuOptions & OPTION_WALLPAPER_CENTERED)
             nID = IDM_FILEASWALLPAPERCENTERED;
+        else
+            nID = IDM_FILEASWALLPAPERSTRETCHED;
         mainWindow.PostMessage(WM_COMMAND, nID, 0);
     }
 

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -1377,12 +1377,12 @@ wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdLine, INT nCm
             mainWindow.PostMessage(WM_COMMAND, IDM_FILEASWALLPAPERSTRETCHED, 0);
         else
             RegistrySettings::ResetWallpaper();
+    }
 
-        if (g_bNoUI)
-        {
-            registrySettings.WindowPlacement.showCmd = nOldCmdShow; // Restore show settings
-            ::PostMessageW(mainWindow, WM_CLOSE, 0, 0); // Auto close
-        }
+    if (g_bNoUI)
+    {
+        registrySettings.WindowPlacement.showCmd = nOldCmdShow; // Restore show settings
+        ::PostMessageW(mainWindow, WM_CLOSE, 0, 0); // Auto close
     }
 
     // Load the access keys

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -1347,7 +1347,7 @@ LPCWSTR ParseCommandLine(INT argc, WCHAR **argv, UINT *pfuOptions)
         LPCWSTR arg = argv[iarg];
 
         // ReactOS specific!
-        if (lstrcmpiW(arg, L"/wallpaper") == 0 || lstrcmpiW(arg, L"/wallpaper:fit") == 0)
+        if (lstrcmpiW(arg, L"/wallpaper") == 0 || lstrcmpiW(arg, L"/wallpaper:stretch") == 0)
         {
             *pfuOptions |= OPTION_WALLPAPER;
             continue;

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -570,7 +570,7 @@ LRESULT CMainWindow::OnCreate(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHa
     canvasWindow.Create(m_hWnd, rcEmpty, NULL, style, WS_EX_CLIENTEDGE);
 
     // Create and show the miniature if necessary
-    if (registrySettings.ShowThumbnail)
+    if (registrySettings.ShowThumbnail && !g_bNoUI)
     {
         miniature.DoCreate(m_hWnd);
         miniature.ShowWindow(SW_SHOWNOACTIVATE);

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -1395,7 +1395,7 @@ wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdLine, INT nCm
     // Set the wallpaper
     if (bWallpaper)
     {
-        if (filename[0])
+        if (filename && filename[0])
             mainWindow.PostMessage(WM_COMMAND, IDM_FILEASWALLPAPERSTRETCHED, 0);
         else
             RegistrySettings::ResetWallpaper();

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -1382,7 +1382,7 @@ wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdLine, INT nCm
     // Set the wallpaper
     if (bWallpaper)
     {
-        if (__targv[1][0])
+        if (filename[0])
             mainWindow.PostMessage(WM_COMMAND, IDM_FILEASWALLPAPERSTRETCHED, 0);
         else
             RegistrySettings::ResetWallpaper();

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -1373,7 +1373,7 @@ wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdLine, INT nCm
 
     // Set wallpaper?
     BOOL bWallpaper = !!(fuOptions & OPTION_WALLPAPER);
-    g_bNoUI = bWallpaper;
+    g_bNoUI |= bWallpaper;
 
     if (g_bNoUI)
         registrySettings.WindowPlacement.showCmd = SW_HIDE; // Hide the main window

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -1353,6 +1353,13 @@ LPCWSTR ParseCommandLine(INT argc, WCHAR **argv, UINT *pfuOptions)
             continue;
         }
 
+        if (lstrcmpiW(arg, L"/wallpaper:no") == 0) // ReactOS specific!
+        {
+            *pfuOptions |= OPTION_WALLPAPER;
+            filename = L"";
+            continue;
+        }
+
         if (lstrcmpiW(arg, L"/wallpaper:tile") == 0) // ReactOS specific!
         {
             *pfuOptions |= OPTION_WALLPAPER | OPTION_WALLPAPER_TILE;
@@ -1362,12 +1369,6 @@ LPCWSTR ParseCommandLine(INT argc, WCHAR **argv, UINT *pfuOptions)
         if (lstrcmpiW(arg, L"/wallpaper:center") == 0) // ReactOS specific!
         {
             *pfuOptions |= OPTION_WALLPAPER | OPTION_WALLPAPER_CENTERED;
-            continue;
-        }
-
-        if (lstrcmpiW(arg, L"/wallpaper:no") == 0) // ReactOS specific!
-        {
-            filename = L"";
             continue;
         }
 

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -1347,14 +1347,23 @@ wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdLine, INT nCm
     // Load settings from registry
     registrySettings.Load(nCmdShow);
 
-    // Set wallpaper?
+    // Save show setting
     INT nOldCmdShow = registrySettings.WindowPlacement.showCmd;
-    BOOL bSetWallpaper = FALSE;
-    if (__argc >= 3 && lstrcmpiW(__targv[2], L"/Wallpaper") == 0)
+
+    // Set wallpaper?
+    BOOL bWallpaper = FALSE;
+    LPWSTR filename = (__argc >= 2 ? __targv[1] : NULL);
+    if (__argc >= 3)
     {
-        bSetWallpaper = g_bNoUI = TRUE;
-        registrySettings.WindowPlacement.showCmd = SW_HIDE; // Hide the main window
+        BOOL bWallpaper1 = (lstrcmpiW(__targv[1], L"/wallpaper") == 0);
+        BOOL bWallpaper2 = (lstrcmpiW(__targv[2], L"/wallpaper") == 0);
+        if (bWallpaper1)
+            filename = __targv[2];
+        g_bNoUI = bWallpaper = (bWallpaper1 || bWallpaper2);
     }
+
+    if (g_bNoUI)
+        registrySettings.WindowPlacement.showCmd = SW_HIDE; // Hide the main window
 
     // Create the main window
     if (!mainWindow.DoCreate())
@@ -1364,14 +1373,14 @@ wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdLine, INT nCm
     }
 
     // Initialize imageModel
-    if (__argc < 2 || !DoLoadImageFile(mainWindow, __targv[1], TRUE))
+    if (__argc < 2 || !DoLoadImageFile(mainWindow, filename, TRUE))
         InitializeImage(NULL, NULL, FALSE);
 
     // Make the window visible on the screen
     mainWindow.ShowWindow(registrySettings.WindowPlacement.showCmd);
 
     // Set the wallpaper
-    if (bSetWallpaper)
+    if (bWallpaper)
     {
         if (__targv[1][0])
             mainWindow.PostMessage(WM_COMMAND, IDM_FILEASWALLPAPERSTRETCHED, 0);

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -1332,7 +1332,9 @@ VOID CMainWindow::TrackPopupMenu(POINT ptScreen, INT iSubMenu)
     ::DestroyMenu(hMenu);
 }
 
-#define OPTION_WALLPAPER (1 << 0)
+#define OPTION_WALLPAPER           (1 << 0)
+#define OPTION_WALLPAPER_TILE      (1 << 1)
+#define OPTION_WALLPAPER_CENTERED  (1 << 2)
 
 LPCWSTR ParseCommandLine(INT argc, WCHAR **argv, UINT *pfuOptions)
 {
@@ -1342,6 +1344,16 @@ LPCWSTR ParseCommandLine(INT argc, WCHAR **argv, UINT *pfuOptions)
         if (lstrcmpiW(argv[iarg], L"/wallpaper") == 0)
         {
             *pfuOptions |= OPTION_WALLPAPER;
+            continue;
+        }
+        if (lstrcmpiW(argv[iarg], L"/tile") == 0)
+        {
+            *pfuOptions |= OPTION_WALLPAPER_TILE;
+            continue;
+        }
+        if (lstrcmpiW(argv[iarg], L"/center") == 0)
+        {
+            *pfuOptions |= OPTION_WALLPAPER_CENTERED;
             continue;
         }
         if (!filename)
@@ -1396,9 +1408,18 @@ wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdLine, INT nCm
     if (bWallpaper)
     {
         if (filename && filename[0])
-            mainWindow.PostMessage(WM_COMMAND, IDM_FILEASWALLPAPERSTRETCHED, 0);
+        {
+            if (fuOptions & OPTION_WALLPAPER_TILE)
+                mainWindow.PostMessage(WM_COMMAND, IDM_FILEASWALLPAPERPLANE, 0);
+            else if (fuOptions & OPTION_WALLPAPER_CENTERED)
+                mainWindow.PostMessage(WM_COMMAND, IDM_FILEASWALLPAPERCENTERED, 0);
+            else
+                mainWindow.PostMessage(WM_COMMAND, IDM_FILEASWALLPAPERSTRETCHED, 0);
+        }
         else
+        {
             RegistrySettings::ResetWallpaper();
+        }
     }
 
     if (g_bNoUI)

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -1399,7 +1399,10 @@ wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdLine, INT nCm
 
     // Initialize imageModel
     if (!filename || !filename[0] || !DoLoadImageFile(mainWindow, filename, TRUE))
+    {
         InitializeImage(NULL, NULL, FALSE);
+        filename = NULL;
+    }
 
     // Make the window visible on the screen
     mainWindow.ShowWindow(registrySettings.WindowPlacement.showCmd);
@@ -1407,19 +1410,14 @@ wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdLine, INT nCm
     // Set the wallpaper
     if (bWallpaper)
     {
-        if (filename && filename[0])
-        {
-            if (fuOptions & OPTION_WALLPAPER_TILE)
-                mainWindow.PostMessage(WM_COMMAND, IDM_FILEASWALLPAPERPLANE, 0);
-            else if (fuOptions & OPTION_WALLPAPER_CENTERED)
-                mainWindow.PostMessage(WM_COMMAND, IDM_FILEASWALLPAPERCENTERED, 0);
-            else
-                mainWindow.PostMessage(WM_COMMAND, IDM_FILEASWALLPAPERSTRETCHED, 0);
-        }
-        else
-        {
+        if (!filename)
             RegistrySettings::ResetWallpaper();
-        }
+        else if (fuOptions & OPTION_WALLPAPER_TILE)
+            mainWindow.PostMessage(WM_COMMAND, IDM_FILEASWALLPAPERPLANE, 0);
+        else if (fuOptions & OPTION_WALLPAPER_CENTERED)
+            mainWindow.PostMessage(WM_COMMAND, IDM_FILEASWALLPAPERCENTERED, 0);
+        else
+            mainWindow.PostMessage(WM_COMMAND, IDM_FILEASWALLPAPERSTRETCHED, 0);
     }
 
     if (g_bNoUI)

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -1334,14 +1334,14 @@ VOID CMainWindow::TrackPopupMenu(POINT ptScreen, INT iSubMenu)
 
 #define OPTION_WALLPAPER (1 << 0)
 
-LPCWSTR ParseCommandLine(INT argc, WCHAR **argv, UINT *puFlags)
+LPCWSTR ParseCommandLine(INT argc, WCHAR **argv, UINT *pfuOptions)
 {
     LPCWSTR filename = NULL;
     for (INT iarg = 1; iarg < argc; ++iarg)
     {
         if (lstrcmpiW(argv[iarg], L"/wallpaper") == 0)
         {
-            *puFlags |= OPTION_WALLPAPER;
+            *pfuOptions |= OPTION_WALLPAPER;
             continue;
         }
         if (!filename)
@@ -1368,11 +1368,11 @@ wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdLine, INT nCm
     // Save show setting
     INT nOldCmdShow = registrySettings.WindowPlacement.showCmd;
 
-    UINT uFlags = 0;
-    LPCWSTR filename = ParseCommandLine(__argc, __targv, &uFlags);
+    UINT fuOptions = 0;
+    LPCWSTR filename = ParseCommandLine(__argc, __targv, &fuOptions);
 
     // Set wallpaper?
-    BOOL bWallpaper = !!(uFlags & OPTION_WALLPAPER);
+    BOOL bWallpaper = !!(fuOptions & OPTION_WALLPAPER);
     g_bNoUI = bWallpaper;
 
     if (g_bNoUI)

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -1335,9 +1335,9 @@ VOID CMainWindow::TrackPopupMenu(POINT ptScreen, INT iSubMenu)
     ::DestroyMenu(hMenu);
 }
 
-#define OPTION_WALLPAPER           (1 << 0)
-#define OPTION_WALLPAPER_TILE      (1 << 1)
-#define OPTION_WALLPAPER_CENTERED  (1 << 2)
+#define OPTION_WALLPAPER           (1 << 0) // ReactOS specific!
+#define OPTION_WALLPAPER_TILE      (1 << 1) // ReactOS specific!
+#define OPTION_WALLPAPER_CENTERED  (1 << 2) // ReactOS specific!
 
 LPCWSTR ParseCommandLine(INT argc, WCHAR **argv, UINT *pfuOptions)
 {
@@ -1345,17 +1345,17 @@ LPCWSTR ParseCommandLine(INT argc, WCHAR **argv, UINT *pfuOptions)
     for (INT iarg = 1; iarg < argc; ++iarg)
     {
         LPCWSTR arg = argv[iarg];
-        if (lstrcmpiW(arg, L"/wallpaper") == 0)
+        if (lstrcmpiW(arg, L"/wallpaper") == 0) // ReactOS specific!
         {
             *pfuOptions |= OPTION_WALLPAPER;
             continue;
         }
-        if (lstrcmpiW(arg, L"/tile") == 0)
+        if (lstrcmpiW(arg, L"/tile") == 0) // ReactOS specific!
         {
             *pfuOptions |= OPTION_WALLPAPER | OPTION_WALLPAPER_TILE;
             continue;
         }
-        if (lstrcmpiW(arg, L"/center") == 0)
+        if (lstrcmpiW(arg, L"/center") == 0) // ReactOS specific!
         {
             *pfuOptions |= OPTION_WALLPAPER | OPTION_WALLPAPER_CENTERED;
             continue;
@@ -1408,7 +1408,7 @@ wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdLine, INT nCm
     mainWindow.ShowWindow(registrySettings.WindowPlacement.showCmd);
 
     // Set the desktop wallpaper
-    if (fuOptions & OPTION_WALLPAPER)
+    if (fuOptions & OPTION_WALLPAPER) // ReactOS specific!
     {
         INT nID = IDM_FILEASWALLPAPERSTRETCHED;
         if (!filename)

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -907,7 +907,7 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
                 ShowError(IDS_CANTSENDMAIL);
             }
             break;
-        case IDM_FILEASWALLPAPERRESET:
+        case IDM_RESETWALLPAPER:
             RegistrySettings::ResetWallpaper();
             break;
         case IDM_FILEASWALLPAPERPLANE:
@@ -1412,7 +1412,7 @@ wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdLine, INT nCm
     {
         INT nID = IDM_FILEASWALLPAPERSTRETCHED;
         if (!filename)
-            nID = IDM_FILEASWALLPAPERRESET;
+            nID = IDM_RESETWALLPAPER;
         else if (fuOptions & OPTION_WALLPAPER_TILE)
             nID = IDM_FILEASWALLPAPERPLANE;
         else if (fuOptions & OPTION_WALLPAPER_CENTERED)

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -22,7 +22,6 @@ BOOL g_imageSaved = FALSE;
 BOOL g_showGrid = FALSE;
 HWND g_hStatusBar = NULL;
 BOOL g_bNoUI = FALSE;
-BOOL g_bSetWallpaper = FALSE;
 
 CMainWindow mainWindow;
 
@@ -1350,10 +1349,11 @@ wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdLine, INT nCm
 
     // Set wallpaper?
     INT nOldCmdShow = registrySettings.WindowPlacement.showCmd;
+    BOOL bSetWallpaper = FALSE;
     if (__argc >= 3 && lstrcmpiW(__targv[2], L"/Wallpaper") == 0)
     {
-        g_bSetWallpaper = g_bNoUI = TRUE;
-        registrySettings.WindowPlacement.showCmd = SW_HIDE; // Hide main window
+        bSetWallpaper = g_bNoUI = TRUE;
+        registrySettings.WindowPlacement.showCmd = SW_HIDE; // Hide the main window
     }
 
     // Create the main window
@@ -1371,17 +1371,18 @@ wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdLine, INT nCm
     mainWindow.ShowWindow(registrySettings.WindowPlacement.showCmd);
 
     // Set the wallpaper
-    if (g_bSetWallpaper)
+    if (bSetWallpaper)
     {
-        registrySettings.WindowPlacement.showCmd = nOldCmdShow; // Restore show settings
-
         if (__targv[1][0])
             mainWindow.PostMessage(WM_COMMAND, IDM_FILEASWALLPAPERSTRETCHED, 0);
         else
             RegistrySettings::ResetWallpaper();
 
-        // Auto close
-        ::PostMessageW(mainWindow, WM_CLOSE, 0, 0);
+        if (g_bNoUI)
+        {
+            registrySettings.WindowPlacement.showCmd = nOldCmdShow; // Restore show settings
+            ::PostMessageW(mainWindow, WM_CLOSE, 0, 0); // Auto close
+        }
     }
 
     // Load the access keys

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -1344,23 +1344,24 @@ LPCWSTR ParseCommandLine(INT argc, WCHAR **argv, UINT *pfuOptions)
     LPCWSTR filename = NULL;
     for (INT iarg = 1; iarg < argc; ++iarg)
     {
-        if (lstrcmpiW(argv[iarg], L"/wallpaper") == 0)
+        LPCWSTR arg = argv[iarg];
+        if (lstrcmpiW(arg, L"/wallpaper") == 0)
         {
             *pfuOptions |= OPTION_WALLPAPER;
             continue;
         }
-        if (lstrcmpiW(argv[iarg], L"/tile") == 0)
+        if (lstrcmpiW(arg, L"/tile") == 0)
         {
             *pfuOptions |= OPTION_WALLPAPER | OPTION_WALLPAPER_TILE;
             continue;
         }
-        if (lstrcmpiW(argv[iarg], L"/center") == 0)
+        if (lstrcmpiW(arg, L"/center") == 0)
         {
             *pfuOptions |= OPTION_WALLPAPER | OPTION_WALLPAPER_CENTERED;
             continue;
         }
         if (!filename)
-            filename = argv[iarg];
+            filename = arg;
     }
     return filename;
 }

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -1348,12 +1348,12 @@ LPCWSTR ParseCommandLine(INT argc, WCHAR **argv, UINT *pfuOptions)
         }
         if (lstrcmpiW(argv[iarg], L"/tile") == 0)
         {
-            *pfuOptions |= OPTION_WALLPAPER_TILE;
+            *pfuOptions |= OPTION_WALLPAPER | OPTION_WALLPAPER_TILE;
             continue;
         }
         if (lstrcmpiW(argv[iarg], L"/center") == 0)
         {
-            *pfuOptions |= OPTION_WALLPAPER_CENTERED;
+            *pfuOptions |= OPTION_WALLPAPER | OPTION_WALLPAPER_CENTERED;
             continue;
         }
         if (!filename)

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -1345,21 +1345,32 @@ LPCWSTR ParseCommandLine(INT argc, WCHAR **argv, UINT *pfuOptions)
     for (INT iarg = 1; iarg < argc; ++iarg)
     {
         LPCWSTR arg = argv[iarg];
-        if (lstrcmpiW(arg, L"/wallpaper") == 0) // ReactOS specific!
+
+        // ReactOS specific!
+        if (lstrcmpiW(arg, L"/wallpaper") == 0 || lstrcmpiW(arg, L"/wallpaper:fit") == 0)
         {
             *pfuOptions |= OPTION_WALLPAPER;
             continue;
         }
-        if (lstrcmpiW(arg, L"/tile") == 0) // ReactOS specific!
+
+        if (lstrcmpiW(arg, L"/wallpaper:tile") == 0) // ReactOS specific!
         {
             *pfuOptions |= OPTION_WALLPAPER | OPTION_WALLPAPER_TILE;
             continue;
         }
-        if (lstrcmpiW(arg, L"/center") == 0) // ReactOS specific!
+
+        if (lstrcmpiW(arg, L"/wallpaper:center") == 0) // ReactOS specific!
         {
             *pfuOptions |= OPTION_WALLPAPER | OPTION_WALLPAPER_CENTERED;
             continue;
         }
+
+        if (lstrcmpiW(arg, L"/wallpaper:no") == 0) // ReactOS specific!
+        {
+            filename = L"";
+            continue;
+        }
+
         if (!filename)
             filename = arg;
     }

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -907,6 +907,9 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
                 ShowError(IDS_CANTSENDMAIL);
             }
             break;
+        case IDM_FILEASWALLPAPERRESET:
+            RegistrySettings::ResetWallpaper();
+            break;
         case IDM_FILEASWALLPAPERPLANE:
             RegistrySettings::SetWallpaper(g_szFileName, RegistrySettings::TILED);
             break;
@@ -1377,16 +1380,12 @@ wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdLine, INT nCm
     // Load settings from registry
     registrySettings.Load(nCmdShow);
 
-    // Save show setting
-    INT nOldCmdShow = registrySettings.WindowPlacement.showCmd;
-
+    // Parse the command line
     UINT fuOptions = 0;
     LPCWSTR filename = ParseCommandLine(__argc, __targv, &fuOptions);
+    g_bNoUI |= !!(fuOptions & OPTION_WALLPAPER);
 
-    // Set wallpaper?
-    BOOL bWallpaper = !!(fuOptions & OPTION_WALLPAPER);
-    g_bNoUI |= bWallpaper;
-
+    INT nOldCmdShow = registrySettings.WindowPlacement.showCmd; // Save old show setting
     if (g_bNoUI)
         registrySettings.WindowPlacement.showCmd = SW_HIDE; // Hide the main window
 
@@ -1407,17 +1406,17 @@ wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdLine, INT nCm
     // Make the window visible on the screen
     mainWindow.ShowWindow(registrySettings.WindowPlacement.showCmd);
 
-    // Set the wallpaper
-    if (bWallpaper)
+    // Set the desktop wallpaper
+    if (fuOptions & OPTION_WALLPAPER)
     {
+        INT nID = IDM_FILEASWALLPAPERSTRETCHED;
         if (!filename)
-            RegistrySettings::ResetWallpaper();
+            nID = IDM_FILEASWALLPAPERRESET;
         else if (fuOptions & OPTION_WALLPAPER_TILE)
-            mainWindow.PostMessage(WM_COMMAND, IDM_FILEASWALLPAPERPLANE, 0);
+            nID = IDM_FILEASWALLPAPERPLANE;
         else if (fuOptions & OPTION_WALLPAPER_CENTERED)
-            mainWindow.PostMessage(WM_COMMAND, IDM_FILEASWALLPAPERCENTERED, 0);
-        else
-            mainWindow.PostMessage(WM_COMMAND, IDM_FILEASWALLPAPERSTRETCHED, 0);
+            nID = IDM_FILEASWALLPAPERCENTERED;
+        mainWindow.PostMessage(WM_COMMAND, nID, 0);
     }
 
     if (g_bNoUI)

--- a/base/applications/mspaint/precomp.h
+++ b/base/applications/mspaint/precomp.h
@@ -152,4 +152,3 @@ extern CCanvasWindow canvasWindow;
 extern CTextEditWindow textEditWindow;
 
 extern BOOL g_bNoUI;
-extern BOOL g_bSetWallpaper;

--- a/base/applications/mspaint/precomp.h
+++ b/base/applications/mspaint/precomp.h
@@ -150,3 +150,6 @@ extern CToolSettingsWindow toolSettingsWindow;
 extern CPaletteWindow paletteWindow;
 extern CCanvasWindow canvasWindow;
 extern CTextEditWindow textEditWindow;
+
+extern BOOL g_bNoUI;
+extern BOOL g_bSetWallpaper;

--- a/base/applications/mspaint/registry.cpp
+++ b/base/applications/mspaint/registry.cpp
@@ -36,6 +36,24 @@ static void ReadString(CRegKey &key, LPCWSTR lpName, CStringW &strValue, LPCWSTR
         strValue = lpDefault;
 }
 
+void RegistrySettings::ResetWallpaper()
+{
+    // Write the wallpaper settings to the registry
+    CRegKey desktop;
+    if (desktop.Open(HKEY_CURRENT_USER, L"Control Panel\\Desktop") == ERROR_SUCCESS)
+    {
+        desktop.SetStringValue(L"Wallpaper", L"");
+        desktop.SetStringValue(L"WallpaperStyle", L"0");
+        desktop.SetStringValue(L"TileWallpaper", L"0");
+        desktop.SetStringValue(L"ConvertedWallpaper", L"");
+        desktop.SetStringValue(L"OriginalWallpaper", L"");
+    }
+
+    // Set the desktop wallpaper
+    WCHAR szEmpty[] = L"";
+    SystemParametersInfoW(SPI_SETDESKWALLPAPER, 0, szEmpty, SPIF_UPDATEINIFILE | SPIF_SENDCHANGE);
+}
+
 void RegistrySettings::SetWallpaper(LPCWSTR szFileName, RegistrySettings::WallpaperStyle style)
 {
     // Build the local path to the converted cached BMP wallpaper

--- a/base/applications/mspaint/registry.cpp
+++ b/base/applications/mspaint/registry.cpp
@@ -43,8 +43,6 @@ void RegistrySettings::ResetWallpaper()
     if (desktop.Open(HKEY_CURRENT_USER, L"Control Panel\\Desktop") == ERROR_SUCCESS)
     {
         desktop.SetStringValue(L"Wallpaper", L"");
-        desktop.SetStringValue(L"WallpaperStyle", L"0");
-        desktop.SetStringValue(L"TileWallpaper", L"0");
         desktop.SetStringValue(L"ConvertedWallpaper", L"");
         desktop.SetStringValue(L"OriginalWallpaper", L"");
     }

--- a/base/applications/mspaint/registry.h
+++ b/base/applications/mspaint/registry.h
@@ -62,6 +62,7 @@ public:
     };
 
     static void SetWallpaper(LPCWSTR szFileName, WallpaperStyle style);
+    static void ResetWallpaper();
 
     void Load(INT nCmdShow);
     void Store();

--- a/base/applications/mspaint/resource.h
+++ b/base/applications/mspaint/resource.h
@@ -107,7 +107,7 @@
 #define IDM_CTRL_MINUS  291
 
 #define IDM_CROPSELECTION 292
-#define IDM_FILEASWALLPAPERRESET 293
+#define IDM_RESETWALLPAPER 293
 
 /* the following 16 numbers need to be in order, increasing by 1 */
 #define ID_FREESEL  600

--- a/base/applications/mspaint/resource.h
+++ b/base/applications/mspaint/resource.h
@@ -107,6 +107,7 @@
 #define IDM_CTRL_MINUS  291
 
 #define IDM_CROPSELECTION 292
+#define IDM_FILEASWALLPAPERRESET 293
 
 /* the following 16 numbers need to be in order, increasing by 1 */
 #define ID_FREESEL  600


### PR DESCRIPTION
## Purpose

Enable us to set wallpaper from command line. It's a ReactOS extension.
NOTE: There is no compatible way to set wallpaper to a non-BMP image from the command line.
JIRA issue: [CORE-19618](https://jira.reactos.org/browse/CORE-19618)

## Proposed changes

- Add `g_bNoUI` variable.
- Add `ParseCommandLine` helper function.
- In the command line of `mspaint.exe`, if the filename and `/wallpaper` option are specified, then set the wallpaper and `g_bNoUI`.
- If `g_bNoUI` was `TRUE`, then hide the main window and quit silently.

```txt
Command Line # 1: mspaint.exe /wallpaper "wallpaper.png"
Command Line # 2: mspaint.exe /wallpaper:stretch "wallpaper.png"
Command Line # 3: mspaint.exe /wallpaper:tile "wallpaper.png"
Command Line # 4: mspaint.exe /wallpaper:center "wallpaper.png"
Command Line # 5: mspaint.exe /wallpaper:no
```
NOTE: `/wallpaper` is same as `/wallpaper:stretch`.
## TODO

- [x] Do tests.

## Screenshot

![VirtualBox_ReactOS_26_05_2024_18_15_16](https://github.com/reactos/reactos/assets/2107452/2898558f-ea55-47b5-82cd-910bfc6ca2b4)