### PR TITLE
[AC97] Use individual Decibel range for Master Volume control

### DIFF
--- a/drivers/wdm/audio/drivers/ac97/prophnd.cpp
+++ b/drivers/wdm/audio/drivers/ac97/prophnd.cpp
@@ -170,7 +170,9 @@ NTSTATUS CAC97MiniportTopology::GetDBValues
     {
         // These nodes could have 5bit or 6bit controls, so we first
         // have to check this.
+#ifndef __REACTOS__
         case NODE_MASTEROUT_VOLUME:
+#endif
         case NODE_FRONT_VOLUME:
         case NODE_HPOUT_VOLUME:
         case NODE_SURROUND_VOLUME:
@@ -230,6 +232,11 @@ NTSTATUS CAC97MiniportTopology::GetDBValues
         case NODE_VIDEO_VOLUME:
         case NODE_AUX_VOLUME:
         case NODE_WAVEOUT_VOLUME:
+#ifdef __REACTOS__
+        // ReactOS change: use the same Decibel range as for WaveOut,
+        // to fix incorrect volume level change scaling. CORE-14780
+        case NODE_MASTEROUT_VOLUME:
+#endif
             *plMaximum = 0x000C0000;   // 12 dB
             *plMinimum = 0xFFDD8000;   // -34.5 dB
             *puStep    = 0x00018000;   // 1.5 dB


### PR DESCRIPTION
## Purpose

Add ReactOS change to use the same Decibel (dB) sound loudness range for Master Volume control as for WaveOut Volume Control. This fixes incompatible volume level change scaling when changing the volume in Fox Audio Player 0.10.2 from Rapps and Winamp 2.95 with WaveOut output plugin. Now it is identical to the one when using original AC97 driver from Windows XP/Server 2003. :slightly_smiling_face: 
Depends on my previous #6922 PR.

Results of my testing:
- ROS with our AC97 driver in VirtualBox (before my changes): :x: the volume is changing only from 51% to 100%, from 0% to 50% it is always at 1% actually.
- ROS with our AC97 driver in VirtualBox (after my changes): :white_check_mark: the volume is changing from 0% to 100%, as it ideally should.
- ROS with original AC97 driver from Windows XP/2003 (ac97intc.sys renamed to ac97.sys): :white_check_mark: exactly the same outcome result.
- ROS with VMAudio (SB16) driver in VMWare Player 16.2.5: :white_check_mark: the volume control works exactly the same, changing works fine in the whole trackbar range: from 0% to 100%.
- XP/2003 with inbuilt AC97 driver: :white_check_mark: volume is changing from 0% to 100%, as it should.
- XP/2003 with our AC97 driver before my changes: :x: the volume control is buggy too, however the volume is mostly changing in another range: from 0% to 50%. From 51% to 100% it nearly does not change.
- XP/2003 with our AC97 driver after my changes: :white_check_mark: the volume is changing correctly again, in range from 0% to 100%, as it should. Same outcome result as in ROS.

Conclusion: since our one is behaving similarly both in ROS and XP/2003, this is definitely a bug in our AC97 driver.

JIRA issue: [CORE-14780](https://jira.reactos.org/browse/CORE-14780)