### PR TITLE
[NTGDI][FREETYPE] Unload font engine on system shut-down

### DIFF
--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -714,7 +714,7 @@ InitFontSupport(VOID)
 }
 
 static VOID
-IntFreeFontCache(PLIST_ENTRY pHead)
+IntFreeFontCacheList(PLIST_ENTRY pHead)
 {
     PLIST_ENTRY pEntry, pNextEntry;
     PFONT_CACHE_ENTRY pFontCache;
@@ -750,7 +750,7 @@ IntFreeFontSubstList(PLIST_ENTRY pHead)
 }
 
 static VOID
-IntFreeFonts(PLIST_ENTRY pHead)
+IntFreeFontList(PLIST_ENTRY pHead)
 {
     PLIST_ENTRY pEntry, pNextEntry;
     PFONT_ENTRY pFontEntry;
@@ -771,9 +771,9 @@ VOID FASTCALL FreeFontSupport(VOID)
 {
     IntLockGlobalFonts();
 
-    IntFreeFontCache(&g_FontCacheListHead);
+    IntFreeFontCacheList(&g_FontCacheListHead);
     IntFreeFontSubstList(&g_FontSubstListHead);
-    IntFreeFonts(&g_FontListHead);
+    IntFreeFontList(&g_FontListHead);
 
     if (g_FreeTypeLibrary)
     {

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -711,7 +711,8 @@ InitFontSupport(VOID)
     return TRUE;
 }
 
-VOID FASTCALL FreeFontSupport(VOID)
+VOID FASTCALL
+FreeFontSupport(VOID)
 {
     PLIST_ENTRY pHead, pEntry;
     PFONT_CACHE_ENTRY pFontCache;

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -476,9 +476,7 @@ VOID DumpFontSubstList(VOID)
          pListEntry != pHead;
          pListEntry = pListEntry->Flink)
     {
-        pSubstEntry =
-            (PFONTSUBST_ENTRY)CONTAINING_RECORD(pListEntry, FONT_ENTRY, ListEntry);
-
+        pSubstEntry = CONTAINING_RECORD(pListEntry, FONTSUBST_ENTRY, ListEntry);
         DumpFontSubstEntry(pSubstEntry);
     }
 }
@@ -742,7 +740,7 @@ IntFreeFontSubstList(PLIST_ENTRY pHead)
     for (pEntry = pHead->Flink; pEntry != pHead; pEntry = pNextEntry)
     {
         pNextEntry = pEntry->Flink;
-        pSubstEntry = (PFONTSUBST_ENTRY)CONTAINING_RECORD(pEntry, FONT_ENTRY, ListEntry);
+        pSubstEntry = CONTAINING_RECORD(pEntry, FONTSUBST_ENTRY, ListEntry);
         ExFreePoolWithTag(pSubstEntry, TAG_FONT);
     }
 
@@ -858,8 +856,7 @@ SubstituteFontByList(PLIST_ENTRY        pHead,
          pListEntry != pHead;
          pListEntry = pListEntry->Flink)
     {
-        pSubstEntry =
-            (PFONTSUBST_ENTRY)CONTAINING_RECORD(pListEntry, FONT_ENTRY, ListEntry);
+        pSubstEntry = CONTAINING_RECORD(pListEntry, FONTSUBST_ENTRY, ListEntry);
 
         CharSets[FONTSUBST_FROM] = pSubstEntry->CharSets[FONTSUBST_FROM];
 

--- a/win32ss/gdi/ntgdi/text.h
+++ b/win32ss/gdi/ntgdi/text.h
@@ -110,6 +110,7 @@ NTSTATUS FASTCALL TextIntRealizeFont(HFONT,PTEXTOBJ);
 NTSTATUS FASTCALL TextIntCreateFontIndirect(CONST LPLOGFONTW lf, HFONT *NewFont);
 BYTE FASTCALL IntCharSetFromCodePage(UINT uCodePage);
 BOOL FASTCALL InitFontSupport(VOID);
+VOID FASTCALL FreeFontSupport(VOID);
 BOOL FASTCALL IntIsFontRenderingEnabled(VOID);
 BOOL FASTCALL IntIsFontRenderingEnabled(VOID);
 VOID FASTCALL IntEnableFontRendering(BOOL Enable);

--- a/win32ss/user/ntuser/main.c
+++ b/win32ss/user/ntuser/main.c
@@ -908,6 +908,7 @@ DriverUnload(IN PDRIVER_OBJECT DriverObject)
 {
     // TODO: Do more cleanup!
 
+    FreeFontSupport();
     ResetCsrApiPort();
     ResetCsrProcess();
 }


### PR DESCRIPTION
## Purpose

Check system integrity by explicitly releasing the font engine.
JIRA issue: [CORE-9616](https://jira.reactos.org/browse/CORE-9616)

## Proposed changes

- Use `RTL_STATIC_LIST_HEAD` against `g_FontListHead` and `g_FontCacheListHead` variables and omit initialization of them.
- Implement `FreeFontSupport` function.
- Call `FreeFontSupport` in `win32k!DriverUnload` function.
- Fix some usages of `CONTAINING_RECORD` macro.

## TODO

- [x] Do tests.