### PR TITLE
[SHELL32] brfolder.cpp: Fix exception in BrFolder_Treeview_Rename

### DIFF
--- a/dll/win32/shell32/brfolder.cpp
+++ b/dll/win32/shell32/brfolder.cpp
@@ -478,7 +478,7 @@ BrFolder_Treeview_Rename(BrFolder *info, NMTVDISPINFOW *pnmtv)
     item.pszText = pnmtv->item.pszText;
     TreeView_SetItem(info->hwndTreeView, &item);
 
-    nmtv.itemNew.lParam = item.lParam;
+    nmtv.itemNew.lParam = (LPARAM)item_data;
     BrFolder_Treeview_Changed(info, &nmtv);
     return 0;
 }


### PR DESCRIPTION
## Purpose

There were access violation in `shell32:brsfolder` testcase.
JIRA issue: [CORE-19622](https://jira.reactos.org/browse/CORE-19622)

## Proposed changes

- Set `nmtv.itemNew.lParam` to a correct value in `BrFolder_Treeview_Rename` function.

## TODO

- [x] Do tests.

## Comparison

BEFORE:
![before](https://github.com/reactos/reactos/assets/2107452/a417d61f-492c-4c29-ae85-66e8978c27cc)
It caused exception.

AFTER:
![after](https://github.com/reactos/reactos/assets/2107452/acc1aa85-e39e-499b-a81a-596b58842073)
Successful.