### PR TITLE
[NTOS:MM][NTOS:PS] Little fixes for NTDLL loading

### DIFF
--- a/ntoskrnl/include/internal/mm.h
+++ b/ntoskrnl/include/internal/mm.h
@@ -1645,9 +1645,7 @@ MmUnloadSystemImage(
 NTSTATUS
 NTAPI
 MmCheckSystemImage(
-    IN HANDLE ImageHandle,
-    IN BOOLEAN PurgeSection
-);
+    _In_ HANDLE ImageHandle);
 
 NTSTATUS
 NTAPI

--- a/ntoskrnl/ps/psmgr.c
+++ b/ntoskrnl/ps/psmgr.c
@@ -196,7 +196,7 @@ PsLocateSystemDll(VOID)
     /* Locate and open NTDLL to determine ImageBase and LdrStartup */
     InitializeObjectAttributes(&ObjectAttributes,
                                &PsNtDllPathName,
-                               0,
+                               OBJ_CASE_INSENSITIVE | OBJ_KERNEL_HANDLE,
                                NULL,
                                NULL);
     Status = ZwOpenFile(&FileHandle,
@@ -212,8 +212,8 @@ PsLocateSystemDll(VOID)
     }
 
     /* Check if the image is valid */
-    Status = MmCheckSystemImage(FileHandle, TRUE);
-    if (Status == STATUS_IMAGE_CHECKSUM_MISMATCH)
+    Status = MmCheckSystemImage(FileHandle);
+    if (Status == STATUS_IMAGE_CHECKSUM_MISMATCH || Status == STATUS_INVALID_IMAGE_PROTECT)
     {
         /* Raise a hard error */
         HardErrorParameters = (ULONG_PTR)&PsNtDllPathName;


### PR DESCRIPTION
## Purpose

- [NTOS:PS] `STATUS_INVALID_IMAGE_PROTECT` returned by `MmCheckSystemImage` should be a fatal error too.
- [NTOS:PS] Fix object attributes for opening Ntdll.
- [NTOS:MM] Remove `MmCheckSystemImage` unused parameter.
- [NTOS:MM] Inline `MmVerifyImageIsOkForMpUse` to `MmCheckSystemImage` and reduce a calling to `RtlImageNtHeader`.

JIRA issue: None