### PR TITLE
[SHELL32] brfolder.cpp: Refresh items

### DIFF
--- a/dll/win32/shell32/brfolder.cpp
+++ b/dll/win32/shell32/brfolder.cpp
@@ -1030,26 +1030,6 @@ BrFolder_OnDestroy(BrFolder *info)
     SHChangeNotifyDeregister(info->hChangeNotify);
 }
 
-// Find a treeview node by recursively walking the treeview
-static HTREEITEM
-BrFolder_FindItemByPidl(BrFolder *info, PCIDLIST_ABSOLUTE pidlFull, HTREEITEM hItem)
-{
-    BrItemData *item_data = BrFolder_GetItemData(info, hItem);
-
-    if (ILIsEqual(item_data->pidlFull, pidlFull))
-        return hItem;
-
-    for (hItem = TreeView_GetChild(info->hwndTreeView, hItem); hItem;
-         hItem = TreeView_GetNextSibling(info->hwndTreeView, hItem))
-    {
-        HTREEITEM newItem = BrFolder_FindItemByPidl(info, pidlFull, hItem);
-        if (newItem)
-            return newItem;
-    }
-
-    return NULL;
-}
-
 static void
 BrFolder_RefreshRecurse(
     _Inout_ BrFolder *info,

--- a/dll/win32/shell32/brfolder.cpp
+++ b/dll/win32/shell32/brfolder.cpp
@@ -629,6 +629,12 @@ BrFolder_Treeview_Keydown(BrFolder *info, LPNMTVKEYDOWN keydown)
             }
             break;
         }
+        case VK_F5:
+        {
+            HTREEITEM hRoot = TreeView_GetRoot(info->hwndTreeView);
+            BrFolder_Refresh(info, hRoot);
+            break;
+        }
     }
     return 0;
 }

--- a/dll/win32/shell32/brfolder.cpp
+++ b/dll/win32/shell32/brfolder.cpp
@@ -313,11 +313,8 @@ BrFolder_UpdateItem(BrFolder *info, HTREEITEM hItem)
     if (BrFolder_GetChildrenEnum(info, pItemData, &pEnum) == S_OK)
     {
         CComHeapPtr<ITEMIDLIST_RELATIVE> pidlTemp;
-        while (S_OK == pEnum->Next(1, &pidlTemp, NULL))
-        {
+        if (pEnum->Next(1, &pidlTemp, NULL) == S_OK)
             ++item.cChildren;
-            pidlTemp.Free();
-        }
     }
 
     TreeView_SetItem(info->hwndTreeView, &item);

--- a/dll/win32/shell32/brfolder.cpp
+++ b/dll/win32/shell32/brfolder.cpp
@@ -536,8 +536,6 @@ BrFolder_Treeview_Rename(BrFolder *info, NMTVDISPINFOW *pnmtv)
     ASSERT(data);
     ASSERT(BrFolder_GetItemAttributes(info, hItem, SFGAO_CANRENAME) & SFGAO_CANRENAME);
 
-    CComHeapPtr<ITEMIDLIST_ABSOLUTE> pidlOldFull(ILClone(data->pidlFull));
-
     PITEMID_CHILD newChild;
     HRESULT hr = data->lpsfParent->SetNameOf(info->hWnd, data->pidlChild,
                                              pnmtv->item.pszText, SHGDN_NORMAL, &newChild);
@@ -550,8 +548,6 @@ BrFolder_Treeview_Rename(BrFolder *info, NMTVDISPINFOW *pnmtv)
         ILRemoveLastID(newFull);
         if (SUCCEEDED(hr = SHILAppend(newChild, &newFull)))
         {
-            SHChangeNotify(SHCNE_RENAMEFOLDER, SHCNF_IDLIST, pidlOldFull, newFull);
-
             data->pidlFull.Free();
             data->pidlFull.Attach(newFull);
             data->pidlChild = ILFindLastID(data->pidlFull);

--- a/dll/win32/shell32/brfolder.cpp
+++ b/dll/win32/shell32/brfolder.cpp
@@ -274,7 +274,7 @@ BrFolder_IsTreeItemInEnum(
             ret = TRUE;
             break;
         }
-        pidlTemp.Free(); // Finally, free the pidl that the shell gave us...
+        pidlTemp.Free();
     }
 
     return ret;

--- a/dll/win32/shell32/brfolder.cpp
+++ b/dll/win32/shell32/brfolder.cpp
@@ -281,7 +281,10 @@ BrFolder_IsTreeItemInEnum(
 }
 
 static BOOL
-BrFolder_TreeItemHasThisChild(BrFolder *info, HTREEITEM hItem, PITEMID_CHILD pidlChild)
+BrFolder_TreeItemHasThisChild(
+    _In_ BrFolder *info,
+    _In_ HTREEITEM hItem,
+    _Outptr_opt_ PITEMID_CHILD pidlChild)
 {
     HTREEITEM hNextItem;
     for (hItem = TreeView_GetChild(info->hwndTreeView, hItem); hItem; hItem = hNextItem)
@@ -297,7 +300,9 @@ BrFolder_TreeItemHasThisChild(BrFolder *info, HTREEITEM hItem, PITEMID_CHILD pid
 }
 
 static void
-BrFolder_UpdateItem(BrFolder *info, HTREEITEM hItem)
+BrFolder_UpdateItem(
+    _In_ BrFolder *info,
+    _In_ HTREEITEM hItem)
 {
     BrItemData *pItemData = BrFolder_GetItemData(info, hItem);
     if (!pItemData)

--- a/dll/win32/shell32/brfolder.cpp
+++ b/dll/win32/shell32/brfolder.cpp
@@ -599,7 +599,7 @@ BrFolder_Delete(BrFolder *info, HTREEITEM hItem)
 }
 
 static void
-BrFolder_Refresh(
+BrFolder_RefreshRecurse(
     _Inout_ BrFolder *info,
     _In_ HTREEITEM hTarget);
 
@@ -625,14 +625,14 @@ BrFolder_Treeview_Keydown(BrFolder *info, LPNMTVKEYDOWN keydown)
             if (GetKeyState(VK_CONTROL) < 0) // Ctrl+R
             {
                 HTREEITEM hRoot = TreeView_GetRoot(info->hwndTreeView);
-                BrFolder_Refresh(info, hRoot);
+                BrFolder_RefreshRecurse(info, hRoot);
             }
             break;
         }
         case VK_F5:
         {
             HTREEITEM hRoot = TreeView_GetRoot(info->hwndTreeView);
-            BrFolder_Refresh(info, hRoot);
+            BrFolder_RefreshRecurse(info, hRoot);
             break;
         }
     }
@@ -1057,7 +1057,7 @@ BrFolder_FindItemByPidl(BrFolder *info, PCIDLIST_ABSOLUTE pidlFull, HTREEITEM hI
 }
 
 static void
-BrFolder_Refresh(
+BrFolder_RefreshRecurse(
     _Inout_ BrFolder *info,
     _In_ HTREEITEM hTarget)
 {
@@ -1095,7 +1095,7 @@ BrFolder_Refresh(
         }
 
         BrFolder_UpdateItem(info, hItem);
-        BrFolder_Refresh(info, hItem);
+        BrFolder_RefreshRecurse(info, hItem);
     }
 
     if (SUCCEEDED(hrEnum))
@@ -1125,7 +1125,7 @@ BrFolder_OnChangeEx(
         case SHCNE_UPDATEITEM:
         {
             HTREEITEM hRoot = TreeView_GetRoot(info->hwndTreeView);
-            BrFolder_Refresh(info, hRoot);
+            BrFolder_RefreshRecurse(info, hRoot);
             break;
         }
     }

--- a/dll/win32/shell32/brfolder.cpp
+++ b/dll/win32/shell32/brfolder.cpp
@@ -1104,7 +1104,7 @@ BrFolder_OnChangeEx(
         case SHCNE_UPDATEDIR:
         case SHCNE_UPDATEITEM:
         {
-            // FIXME: Optimize for speed
+            // FIXME: Avoid full refresh and optimize for speed
             BrFolder_Refresh(info);
             break;
         }

--- a/dll/win32/shell32/brfolder.cpp
+++ b/dll/win32/shell32/brfolder.cpp
@@ -1104,7 +1104,7 @@ BrFolder_OnChangeEx(
         case SHCNE_UPDATEDIR:
         case SHCNE_UPDATEITEM:
         {
-            // FIXME: Avoid full refresh and optimize for speed
+            // FIXME: Avoid full refresh and optimize for speed. Use pidl0 and pidl1
             BrFolder_Refresh(info);
             break;
         }

--- a/dll/win32/shell32/brfolder.cpp
+++ b/dll/win32/shell32/brfolder.cpp
@@ -599,9 +599,7 @@ BrFolder_Delete(BrFolder *info, HTREEITEM hItem)
 }
 
 static void
-BrFolder_RefreshRecurse(
-    _Inout_ BrFolder *info,
-    _In_ HTREEITEM hTarget);
+BrFolder_Refresh(_Inout_ BrFolder *info);
 
 static LRESULT
 BrFolder_Treeview_Keydown(BrFolder *info, LPNMTVKEYDOWN keydown)
@@ -623,16 +621,12 @@ BrFolder_Treeview_Keydown(BrFolder *info, LPNMTVKEYDOWN keydown)
         case 'R':
         {
             if (GetKeyState(VK_CONTROL) < 0) // Ctrl+R
-            {
-                HTREEITEM hRoot = TreeView_GetRoot(info->hwndTreeView);
-                BrFolder_RefreshRecurse(info, hRoot);
-            }
+                BrFolder_Refresh(info);
             break;
         }
         case VK_F5:
         {
-            HTREEITEM hRoot = TreeView_GetRoot(info->hwndTreeView);
-            BrFolder_RefreshRecurse(info, hRoot);
+            BrFolder_Refresh(info);
             break;
         }
     }
@@ -1103,6 +1097,19 @@ BrFolder_RefreshRecurse(
 }
 
 static void
+BrFolder_Refresh(_Inout_ BrFolder *info)
+{
+    HTREEITEM hRoot = TreeView_GetRoot(info->hwndTreeView);
+
+    SendMessageW(info->hwndTreeView, WM_SETREDRAW, FALSE, 0);
+
+    BrFolder_RefreshRecurse(info, hRoot);
+
+    SendMessageW(info->hwndTreeView, WM_SETREDRAW, TRUE, 0);
+    InvalidateRect(info->hwndTreeView, NULL, TRUE);
+}
+
+static void
 BrFolder_OnChangeEx(
     _Inout_ BrFolder *info,
     _In_ PCIDLIST_ABSOLUTE pidl0,
@@ -1124,8 +1131,7 @@ BrFolder_OnChangeEx(
         case SHCNE_UPDATEDIR:
         case SHCNE_UPDATEITEM:
         {
-            HTREEITEM hRoot = TreeView_GetRoot(info->hwndTreeView);
-            BrFolder_RefreshRecurse(info, hRoot);
+            BrFolder_Refresh(info);
             break;
         }
     }

--- a/dll/win32/shell32/brfolder.cpp
+++ b/dll/win32/shell32/brfolder.cpp
@@ -265,19 +265,16 @@ BrFolder_IsTreeItemInEnum(
 
     pEnum->Reset();
 
-    BOOL ret = FALSE;
     CComHeapPtr<ITEMIDLIST_RELATIVE> pidlTemp;
-    while (S_OK == pEnum->Next(1, &pidlTemp, NULL))
+    while (pEnum->Next(1, &pidlTemp, NULL) == S_OK)
     {
         if (ILIsEqual(pidlTemp, pItemData->pidlChild))
-        {
-            ret = TRUE;
-            break;
-        }
+            return TRUE;
+
         pidlTemp.Free();
     }
 
-    return ret;
+    return FALSE;
 }
 
 static BOOL
@@ -286,11 +283,9 @@ BrFolder_TreeItemHasThisChild(
     _In_ HTREEITEM hItem,
     _Outptr_opt_ PITEMID_CHILD pidlChild)
 {
-    HTREEITEM hNextItem;
-    for (hItem = TreeView_GetChild(info->hwndTreeView, hItem); hItem; hItem = hNextItem)
+    for (hItem = TreeView_GetChild(info->hwndTreeView, hItem); hItem;
+         hItem = TreeView_GetNextSibling(info->hwndTreeView, hItem))
     {
-        hNextItem = TreeView_GetNextSibling(info->hwndTreeView, hItem);
-
         BrItemData *pItemData = BrFolder_GetItemData(info, hItem);
         if (ILIsEqual(pItemData->pidlChild, pidlChild))
             return TRUE;

--- a/dll/win32/shell32/brfolder.cpp
+++ b/dll/win32/shell32/brfolder.cpp
@@ -1104,6 +1104,7 @@ BrFolder_OnChangeEx(
         case SHCNE_UPDATEDIR:
         case SHCNE_UPDATEITEM:
         {
+            // FIXME: Optimize for speed
             BrFolder_Refresh(info);
             break;
         }

--- a/dll/win32/shell32/brfolder.cpp
+++ b/dll/win32/shell32/brfolder.cpp
@@ -281,7 +281,7 @@ BrFolder_IsTreeItemInEnum(
 }
 
 static BOOL
-BrFolder_TreeItemHasChild(BrFolder *info, HTREEITEM hItem, PITEMID_CHILD pidlChild)
+BrFolder_TreeItemHasThisChild(BrFolder *info, HTREEITEM hItem, PITEMID_CHILD pidlChild)
 {
     HTREEITEM hNextItem;
     for (hItem = TreeView_GetChild(info->hwndTreeView, hItem); hItem; hItem = hNextItem)
@@ -1046,7 +1046,7 @@ BrFolder_RefreshRecurse(
         CComHeapPtr<ITEMIDLIST_RELATIVE> pidlTemp;
         while (S_OK == pEnum->Next(1, &pidlTemp, NULL))
         {
-            if (!BrFolder_TreeItemHasChild(info, hTarget, pidlTemp))
+            if (!BrFolder_TreeItemHasThisChild(info, hTarget, pidlTemp))
             {
                 BrFolder_InsertItem(info, pItemData->lpsfParent, pidlTemp, pItemData->pidlFull,
                                     hTarget);


### PR DESCRIPTION
## Purpose

Refresh the items in the tree-view control of `SHBrowseForFolderA/W` functions against change notifications.
JIRA issue: [CORE-17340](https://jira.reactos.org/browse/CORE-17340)

## Proposed changes

- Add `BrFolder_IsTreeItemInEnum` and `BrFolder_TreeItemHasThisChild` helper functions.
- Add `BrFolder_Refresh`, `BrFolder_RefreshRecurse`, and `BrFolder_UpdateItem` functions to refresh items.
- Call `BrFolder_Refresh` in `BrFolder_OnChangeEx` function and on keyboard `F5` and `Ctrl+R` actions.

## TODO

- [x] Do tests.
- [x] Optimize for speed.

## Movie clip

https://github.com/reactos/reactos/assets/2107452/65159cfe-aecf-4247-86fd-4a980dc2da3e