### PR TITLE
[SHELL32] CDefView::InvokeContextMenuCommand must specify a showcmd

### DIFF
--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -1983,6 +1983,7 @@ HRESULT CDefView::InvokeContextMenuCommand(CComPtr<IContextMenu>& pCM, LPCSTR lp
     cmi.cbSize = sizeof(cmi);
     cmi.hwnd = m_hWnd;
     cmi.lpVerb = lpVerb;
+    cmi.nShow = SW_SHOW;
 
     if (GetKeyState(VK_SHIFT) < 0)
         cmi.fMask |= CMIC_MASK_SHIFT_DOWN;


### PR DESCRIPTION
`ZeroMemory` sets `CMINVOKECOMMANDINFOEX::nShow` to `SW_HIDE`. This causes shell extensions that propagates the `nShow` all the way to start child processes hidden.