### PR TITLE
[DBGHELP][NDK][RTL] RtlComputeCrc32(): Add 'const' to 2nd parameter

### DIFF
--- a/dll/win32/dbghelp/compat.c
+++ b/dll/win32/dbghelp/compat.c
@@ -498,7 +498,7 @@ static const ULONG CrcTable[256] =
  * @implemented
  */
 ULONG
-__RtlComputeCrc32(ULONG Initial, PUCHAR Data, ULONG Length)
+__RtlComputeCrc32(ULONG Initial, const UCHAR *Data, ULONG Length)
 {
   ULONG CrcValue = ~Initial;
 

--- a/dll/win32/dbghelp/compat.h
+++ b/dll/win32/dbghelp/compat.h
@@ -818,7 +818,7 @@ typedef LONG KPRIORITY;
 PIMAGE_NT_HEADERS __RtlImageNtHeader(void *data);
 PVOID __RtlImageRvaToVa (const IMAGE_NT_HEADERS* NtHeader, PVOID BaseAddress, ULONG Rva, PIMAGE_SECTION_HEADER *SectionHeader);
 PVOID __RtlImageDirectoryEntryToData(PVOID BaseAddress, BOOLEAN MappedAsImage, USHORT Directory, PULONG Size);
-ULONG __RtlComputeCrc32(ULONG Initial, PUCHAR Data, ULONG Length);
+ULONG __RtlComputeCrc32(ULONG Initial, const UCHAR *Data, ULONG Length);
 
 typedef struct _CLIENT_ID
 {

--- a/sdk/include/ndk/rtlfuncs.h
+++ b/sdk/include/ndk/rtlfuncs.h
@@ -4436,7 +4436,7 @@ ULONG
 NTAPI
 RtlComputeCrc32(
     _In_ ULONG InitialCrc,
-    _In_ PUCHAR Buffer,
+    _In_ const UCHAR *Buffer,
     _In_ ULONG Length
 );
 

--- a/sdk/lib/rtl/crc32.c
+++ b/sdk/lib/rtl/crc32.c
@@ -86,9 +86,9 @@ static const ULONG CrcTable[256] =
  * @implemented
  */
 ULONG NTAPI
-RtlComputeCrc32(IN ULONG Initial,
-                IN PUCHAR Data,
-                IN ULONG Length)
+RtlComputeCrc32(_In_ ULONG Initial,
+                _In_ const UCHAR *Data,
+                _In_ ULONG Length)
 {
   ULONG CrcValue = ~Initial;
 


### PR DESCRIPTION
and sync SAL2 annotations.

## Purpose

Be consistent with other/Wine declarations.
Fix warnings:
gcc:
```
/home/runner/work/reactos/reactos/src/dll/win32/dbghelp/inflate.c:1402:60: warning: passing argument 2 of ‘__RtlComputeCrc32’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
/home/runner/work/reactos/reactos/src/dll/win32/dbghelp/inflate.c:1423:56: warning: passing argument 2 of ‘__RtlComputeCrc32’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
/home/runner/work/reactos/reactos/src/dll/win32/dbghelp/inflate.c:1444:56: warning: passing argument 2 of ‘__RtlComputeCrc32’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
```
msvc:
```
[49/295] Building C object dll\win32\dbghelp\CMakeFiles\dbghelphost.dir\inflate.c.obj
D:\a\reactos\reactos\src\dll\win32\dbghelp\inflate.c(1402): warning C4090: 'function': different 'const' qualifiers
D:\a\reactos\reactos\src\dll\win32\dbghelp\inflate.c(1423): warning C4090: 'function': different 'const' qualifiers
D:\a\reactos\reactos\src\dll\win32\dbghelp\inflate.c(1444): warning C4090: 'function': different 'const' qualifiers
```

## Proposed changes

- Add 'const' to 2nd parameter
- sync SAL2 annotations