### PR TITLE
[RICHED20] Fix assert in editpad due to excessive tab count

### DIFF
--- a/dll/win32/riched20/para.c
+++ b/dll/win32/riched20/para.c
@@ -494,8 +494,8 @@ static BOOL ME_SetParaFormat(ME_TextEditor *editor, ME_Paragraph *para, const PA
   COPY_FIELD(PFM_ALIGNMENT, wAlignment);
   if (dwMask & PFM_TABSTOPS)
   {
-    para->fmt.cTabCount = pFmt->cTabCount;
-    memcpy(para->fmt.rgxTabs, pFmt->rgxTabs, pFmt->cTabCount*sizeof(LONG));
+    para->fmt.cTabCount = max(0, min(pFmt->cTabCount, MAX_TAB_STOPS)); /* Clamp between 0 and MAX_TAB_STOPS */
+    memcpy(para->fmt.rgxTabs, pFmt->rgxTabs, para->fmt.cTabCount*sizeof(LONG));
   }
 
 #define EFFECTS_MASK (PFM_RTLPARA|PFM_KEEP|PFM_KEEPNEXT|PFM_PAGEBREAKBEFORE| \

--- a/modules/rostests/winetests/riched20/editor.c
+++ b/modules/rostests/winetests/riched20/editor.c
@@ -8642,6 +8642,35 @@ static void test_alignment_style(void)
         SendMessageW(richedit, EM_GETPARAFORMAT, 0, (LPARAM)&pf);
         ok(pf.wAlignment == align_mask[i], "got %d expect %d\n", pf.wAlignment, align_mask[i]);
 
+        /* Test out of bounds tab count */
+        pf.dwMask = PFM_TABSTOPS;
+        pf.cTabCount = -25000;
+        SendMessageW(richedit, EM_SETPARAFORMAT, 0, (LPARAM)&pf);
+        ok(pf.cTabCount == -25000, "Got %d\n", pf.cTabCount);
+        SendMessageW(richedit, EM_GETPARAFORMAT, 0, (LPARAM)&pf);
+        ok(pf.cTabCount == 0, "Got %d\n", pf.cTabCount);
+        pf.dwMask = PFM_TABSTOPS;
+        pf.cTabCount = 25000;
+        SendMessageW(richedit, EM_SETPARAFORMAT, 0, (LPARAM)&pf);
+        ok(pf.cTabCount == 25000, "Got %d\n", pf.cTabCount);
+        SendMessageW(richedit, EM_GETPARAFORMAT, 0, (LPARAM)&pf);
+        ok(pf.cTabCount == 32, "Got %d\n", pf.cTabCount);
+        pf.dwMask = PFM_TABSTOPS;
+        pf.cTabCount = 32;
+        SendMessageW(richedit, EM_SETPARAFORMAT, 0, (LPARAM)&pf);
+        SendMessageW(richedit, EM_GETPARAFORMAT, 0, (LPARAM)&pf);
+        ok(pf.cTabCount == 32, "Got %d\n", pf.cTabCount);
+        pf.dwMask = PFM_TABSTOPS;
+        pf.cTabCount = 33;
+        SendMessageW(richedit, EM_SETPARAFORMAT, 0, (LPARAM)&pf);
+        SendMessageW(richedit, EM_GETPARAFORMAT, 0, (LPARAM)&pf);
+        ok(pf.cTabCount == 32, "Got %d\n", pf.cTabCount);
+        pf.dwMask = PFM_TABSTOPS;
+        pf.cTabCount = 1;
+        SendMessageW(richedit, EM_SETPARAFORMAT, 0, (LPARAM)&pf);
+        SendMessageW(richedit, EM_GETPARAFORMAT, 0, (LPARAM)&pf);
+        ok(pf.cTabCount == 1, "Got %d\n", pf.cTabCount);
+
         DestroyWindow(richedit);
     }
 


### PR DESCRIPTION
CORE-8452

## Purpose

_Riched20 partial Wine sync to fix excessive tab count._

JIRA issue: [CORE-8452](https://jira.reactos.org/browse/CORE-8452)

## Proposed changes

_Partial Wine sync of riched20. No 'ifdef' used because this is already in Wine._