### PR TITLE
[NTUSER] Fix popup menu positioning for Miranda IM

### DIFF
--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -2939,7 +2939,7 @@ static BOOL MENU_MoveRect(UINT flags, INT* x, INT* y, INT width, INT height, con
 static BOOL FASTCALL MENU_ShowPopup(PWND pwndOwner, PMENU menu, UINT id, UINT flags,
                               INT x, INT y, const RECT* pExclude)
 {
-    INT width, height;
+    INT width, height, AdjHgt;
     POINT ptx;
     PMONITOR monitor;
     PWND pWnd;
@@ -3023,7 +3023,14 @@ static BOOL FASTCALL MENU_ShowPopup(PWND pwndOwner, PMENU menu, UINT id, UINT fl
         if ((y - height) < monitor->rcMonitor.top || y >= monitor->rcMonitor.bottom)
             y = monitor->rcMonitor.bottom - height;
         else
-            y -= height;
+        {
+            AdjHgt = y + UserGetSystemMetrics(SM_CYMENUSIZE) +
+                     2 * UserGetSystemMetrics(SM_CYDLGFRAME);
+            if (AdjHgt >= monitor->rcMonitor.bottom)
+                y -= height;
+            else
+                y = AdjHgt - height;
+        }
     }
 
     if (pExclude)

--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -2939,7 +2939,7 @@ static BOOL MENU_MoveRect(UINT flags, INT* x, INT* y, INT width, INT height, con
 static BOOL FASTCALL MENU_ShowPopup(PWND pwndOwner, PMENU menu, UINT id, UINT flags,
                               INT x, INT y, const RECT* pExclude)
 {
-    INT width, height, AdjHgt;
+    INT width, height, adjHgt;
     POINT ptx;
     PMONITOR monitor;
     PWND pWnd;
@@ -3024,12 +3024,12 @@ static BOOL FASTCALL MENU_ShowPopup(PWND pwndOwner, PMENU menu, UINT id, UINT fl
             y = monitor->rcMonitor.bottom - height;
         else
         {
-            AdjHgt = y + UserGetSystemMetrics(SM_CYMENUSIZE) +
+            adjHgt = y + UserGetSystemMetrics(SM_CYMENUSIZE) +
                      2 * UserGetSystemMetrics(SM_CYDLGFRAME);
-            if (AdjHgt >= monitor->rcMonitor.bottom)
+            if (adjHgt >= monitor->rcMonitor.bottom)
                 y -= height;
             else
-                y = AdjHgt - height;
+                y = adjHgt - height;
         }
     }
 

--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -2939,7 +2939,7 @@ static BOOL MENU_MoveRect(UINT flags, INT* x, INT* y, INT width, INT height, con
 static BOOL FASTCALL MENU_ShowPopup(PWND pwndOwner, PMENU menu, UINT id, UINT flags,
                               INT x, INT y, const RECT* pExclude)
 {
-    INT width, height, adjHgt;
+    INT width, height;
     POINT ptx;
     PMONITOR monitor;
     PWND pWnd;
@@ -3024,8 +3024,8 @@ static BOOL FASTCALL MENU_ShowPopup(PWND pwndOwner, PMENU menu, UINT id, UINT fl
             y = monitor->rcMonitor.bottom - height;
         else
         {
-            adjHgt = y + UserGetSystemMetrics(SM_CYMENUSIZE) +
-                     2 * UserGetSystemMetrics(SM_CYDLGFRAME);
+            INT adjHgt = y + UserGetSystemMetrics(SM_CYMENUSIZE) +
+                         2 * UserGetSystemMetrics(SM_CYDLGFRAME);
             if (adjHgt >= monitor->rcMonitor.bottom)
                 y -= height;
             else


### PR DESCRIPTION
CORE-17838

## Purpose

_Fix secondary popup window position when clicking near the bottom right of the desktop._

JIRA issue: [CORE-17838](https://jira.reactos.org/browse/CORE-17838)

## Proposed changes

_Secondary popup window is one menu position too high when it is on the left side and has to extend upwards._
_Check if menu needs to move down one menu position and if it will fit on the screen, then move it down._