### PR TITLE
[SHELL32][EXPLORER][SHLWAPI][SDK] Implement SHGetSetSettings

### DIFF
--- a/base/shell/explorer/trayprop.cpp
+++ b/base/shell/explorer/trayprop.cpp
@@ -204,10 +204,9 @@ public:
 
     LRESULT OnInitDialog(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled)
     {
-        // fix me: start menu style (classic/modern) should be read somewhere from the registry.
-        CheckDlgButton(IDC_TASKBARPROP_STARTMENUCLASSIC, BST_CHECKED); // HACK: This has to be read from registry!!!!!!!
+        BOOL modern = SHELL_GetSetting(SSF_STARTPANELON, fStartPanelOn);
+        CheckDlgButton(modern ? IDC_TASKBARPROP_STARTMENU : IDC_TASKBARPROP_STARTMENUCLASSIC, BST_CHECKED);
         _UpdateDialog();
-
         return TRUE;
     }
 
@@ -219,7 +218,9 @@ public:
 
     int OnApply()
     {
-        //TODO
+        SHELLSTATE ss;
+        ss.fStartPanelOn = !IsDlgButtonChecked(IDC_TASKBARPROP_STARTMENUCLASSIC);
+        SHGetSetSettings(&ss, SSF_STARTPANELON, TRUE);
         return PSNRET_NOERROR;
     }
 };

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -1397,14 +1397,14 @@ HRESULT CDefView::FillList(BOOL IsRefreshCommand)
 
     TRACE("%p\n", this);
 
-    SHELLSTATE ss;
-    SHGetSetSettings(&ss, SSF_SHOWALLOBJECTS | SSF_SHOWSUPERHIDDEN, FALSE);
-    if (ss.fShowAllObjects)
+    SHELLSTATE shellstate;
+    SHGetSetSettings(&shellstate, SSF_SHOWALLOBJECTS | SSF_SHOWSUPERHIDDEN, FALSE);
+    if (shellstate.fShowAllObjects)
     {
         dFlags |= SHCONTF_INCLUDEHIDDEN;
         m_ListView.SendMessageW(LVM_SETCALLBACKMASK, LVIS_CUT, 0);
     }
-    if (ss.fShowSuperHidden)
+    if (shellstate.fShowSuperHidden)
     {
         dFlags |= SHCONTF_INCLUDESUPERHIDDEN;
         m_ListView.SendMessageW(LVM_SETCALLBACKMASK, LVIS_CUT, 0);

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -1394,28 +1394,17 @@ HRESULT CDefView::FillList(BOOL IsRefreshCommand)
     HRESULT       hRes;
     HDPA          hdpa;
     DWORD         dFlags = SHCONTF_NONFOLDERS | SHCONTF_FOLDERS;
-    DWORD dwValue, cbValue;
 
     TRACE("%p\n", this);
 
-    // determine if there is a setting to show all the hidden files/folders
-    dwValue = 1;
-    cbValue = sizeof(dwValue);
-    SHGetValueW(HKEY_CURRENT_USER,
-                L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Advanced",
-                L"Hidden", NULL, &dwValue, &cbValue);
-    if (dwValue == 1)
+    SHELLSTATE ss;
+    SHGetSetSettings(&ss, SSF_SHOWALLOBJECTS | SSF_SHOWSUPERHIDDEN, FALSE);
+    if (ss.fShowAllObjects)
     {
         dFlags |= SHCONTF_INCLUDEHIDDEN;
         m_ListView.SendMessageW(LVM_SETCALLBACKMASK, LVIS_CUT, 0);
     }
-
-    dwValue = 0;
-    cbValue = sizeof(dwValue);
-    SHGetValueW(HKEY_CURRENT_USER,
-                L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Advanced",
-                L"ShowSuperHidden", NULL, &dwValue, &cbValue);
-    if (dwValue)
+    if (ss.fShowSuperHidden)
     {
         dFlags |= SHCONTF_INCLUDESUPERHIDDEN;
         m_ListView.SendMessageW(LVM_SETCALLBACKMASK, LVIS_CUT, 0);

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -802,7 +802,8 @@ BOOL CDefView::CreateList()
     if (m_FolderSettings.fFlags & FWF_FULLROWSELECT)
         ListExStyle |= LVS_EX_FULLROWSELECT;
 
-    if (m_FolderSettings.fFlags & FWF_SINGLECLICKACTIVATE)
+    if ((m_FolderSettings.fFlags & FWF_SINGLECLICKACTIVATE) ||
+        (!SHELL_GetSetting(SSF_DOUBLECLICKINWEBVIEW, fDoubleClickInWebView) && !SHELL_GetSetting(SSF_WIN95CLASSIC, fWin95Classic)))
         ListExStyle |= LVS_EX_TRACKSELECT | LVS_EX_ONECLICKACTIVATE;
 
     if (m_FolderSettings.fFlags & FWF_NOCOLUMNHEADER)

--- a/dll/win32/shell32/dialogs/general.cpp
+++ b/dll/win32/shell32/dialogs/general.cpp
@@ -31,6 +31,7 @@ typedef struct REGSHELLSTATE
 
 #define REGSHELLSTATE_SIZE 0x24
 #define REGSHELLSTATE_VERSION 0xD
+C_ASSERT(sizeof(REGSHELLSTATE) == REGSHELLSTATE_SIZE);
 
 static const LPCWSTR s_pszExplorerKey =
     L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer";
@@ -39,9 +40,9 @@ static const LPCWSTR s_pszExplorerKey =
 // Shell settings
 
 EXTERN_C void
-SHELL32_GetDefaultShellState(SHELLSTATE *pss)
+SHELL32_GetDefaultShellState(LPSHELLSTATE pss)
 {
-    ZeroMemory(pss, sizeof(SHELLSTATE));
+    ZeroMemory(pss, sizeof(*pss));
     pss->fShowAllObjects = TRUE;
     pss->fShowExtensions = TRUE;
     pss->fShowCompColor = TRUE;
@@ -60,7 +61,6 @@ EXTERN_C LSTATUS
 SHELL32_WriteRegShellState(void *pregshellstate)
 {
     REGSHELLSTATE *prss = (REGSHELLSTATE*)pregshellstate;
-    C_ASSERT(sizeof(REGSHELLSTATE) == REGSHELLSTATE_SIZE);
     prss->dwSize = REGSHELLSTATE_SIZE;
     prss->ss.version = REGSHELLSTATE_VERSION;
     return SHSetValueW(HKEY_CURRENT_USER, s_pszExplorerKey, L"ShellState",
@@ -79,8 +79,8 @@ static BOOL
 IntSetShellStateSettings(BOOL bDoubleClick, BOOL bUseCommonTasks)
 {
     SHELLSTATE ss;
-    ss.fDoubleClickInWebView = (bDoubleClick ? TRUE : FALSE);
-    ss.fWebView = (bUseCommonTasks ? TRUE : FALSE);
+    ss.fDoubleClickInWebView = !!bDoubleClick;
+    ss.fWebView = !!bUseCommonTasks;
     SHGetSetSettings(&ss, SSF_DOUBLECLICKINWEBVIEW | SSF_WEBVIEW, TRUE);
 
     SHSettingsChanged(0, L"ShellState");

--- a/dll/win32/shell32/dialogs/general.cpp
+++ b/dll/win32/shell32/dialogs/general.cpp
@@ -23,16 +23,6 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL (fprop);
 
-typedef struct REGSHELLSTATE
-{
-    DWORD dwSize;
-    SHELLSTATE ss;
-} REGSHELLSTATE, *PREGSHELLSTATE; // Note: SHGetSetSettings needs to stay in sync with this
-
-#define REGSHELLSTATE_SIZE 0x24
-#define REGSHELLSTATE_VERSION 0xD
-C_ASSERT(sizeof(REGSHELLSTATE) == REGSHELLSTATE_SIZE);
-
 static const LPCWSTR s_pszExplorerKey =
     L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer";
 
@@ -58,9 +48,8 @@ SHELL32_GetDefaultShellState(LPSHELLSTATE pss)
 }
 
 EXTERN_C LSTATUS
-SHELL32_WriteRegShellState(void *pregshellstate)
+SHELL32_WriteRegShellState(PREGSHELLSTATE prss)
 {
-    REGSHELLSTATE *prss = (REGSHELLSTATE*)pregshellstate;
     prss->dwSize = REGSHELLSTATE_SIZE;
     prss->ss.version = REGSHELLSTATE_VERSION;
     return SHSetValueW(HKEY_CURRENT_USER, s_pszExplorerKey, L"ShellState",
@@ -93,10 +82,9 @@ IntSetShellStateSettings(BOOL bDoubleClick, BOOL bUseCommonTasks)
 // SHLWAPI.dll	RegQueryValueExW ( 0x000005a8, "ShellState", NULL, 0x0007e474, 0x000c2050, 0x0007e4fc )	ERROR_SUCCESS		0.0000271
 // SHLWAPI.dll	RegCloseKey ( 0x000005a8 )	ERROR_SUCCESS		0.0000112
 EXTERN_C BOOL
-SHELL32_ReadRegShellState(void *pregshellstate)
+SHELL32_ReadRegShellState(PREGSHELLSTATE prss)
 {
     DWORD dwSize = sizeof(REGSHELLSTATE);
-    REGSHELLSTATE *prss = (REGSHELLSTATE*)pregshellstate;
     LSTATUS err = SHGetValueW(HKEY_CURRENT_USER, s_pszExplorerKey,
                               L"ShellState", NULL, prss, &dwSize);
     return err == ERROR_SUCCESS && prss->dwSize >= REGSHELLSTATE_SIZE;

--- a/dll/win32/shell32/dialogs/general.cpp
+++ b/dll/win32/shell32/dialogs/general.cpp
@@ -27,9 +27,10 @@ typedef struct REGSHELLSTATE
 {
     DWORD dwSize;
     SHELLSTATE ss;
-} REGSHELLSTATE, *PREGSHELLSTATE;
+} REGSHELLSTATE, *PREGSHELLSTATE; // Note: SHGetSetSettings needs to stay in sync with this
 
 #define REGSHELLSTATE_SIZE 0x24
+#define REGSHELLSTATE_VERSION 0xD
 
 static const LPCWSTR s_pszExplorerKey =
     L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer";
@@ -37,22 +38,33 @@ static const LPCWSTR s_pszExplorerKey =
 /////////////////////////////////////////////////////////////////////////////
 // Shell settings
 
-static void
-IntGetDefaultShellState(REGSHELLSTATE& rss)
+EXTERN_C void
+SHELL32_GetDefaultShellState(SHELLSTATE *pss)
 {
-    ZeroMemory(&rss, sizeof(rss));
-    rss.dwSize = REGSHELLSTATE_SIZE;
+    ZeroMemory(pss, sizeof(SHELLSTATE));
+    pss->fShowAllObjects = TRUE;
+    pss->fShowExtensions = TRUE;
+    pss->fShowCompColor = TRUE;
+    pss->fDoubleClickInWebView = TRUE;
+    pss->fShowAttribCol = TRUE; // ROS defaults to Details view with this column on
+    pss->fShowInfoTip = TRUE;
+    pss->fShowSuperHidden = FALSE;
+    pss->lParamSort = SHFSF_COL_NAME;
+    pss->iSortDirection = 1;
+    pss->version = REGSHELLSTATE_VERSION;
+    pss->fSepProcess = FALSE;
+    pss->fStartPanelOn = FALSE; // Note: This should be changed to TRUE when the modern start menu is implemented
+}
 
-    rss.ss.fShowAllObjects = TRUE;
-    rss.ss.fShowExtensions = TRUE;
-
-    rss.ss.fShowCompColor = TRUE;
-    rss.ss.fDoubleClickInWebView = TRUE;
-    rss.ss.fShowInfoTip = TRUE;
-
-    rss.ss.iSortDirection = 1;
-    rss.ss.version = 0xD;
-    rss.ss.fStartPanelOn = TRUE;
+EXTERN_C LSTATUS
+SHELL32_WriteRegShellState(void *pregshellstate)
+{
+    REGSHELLSTATE *prss = (REGSHELLSTATE*)pregshellstate;
+    C_ASSERT(sizeof(REGSHELLSTATE) == REGSHELLSTATE_SIZE);
+    prss->dwSize = REGSHELLSTATE_SIZE;
+    prss->ss.version = REGSHELLSTATE_VERSION;
+    return SHSetValueW(HKEY_CURRENT_USER, s_pszExplorerKey, L"ShellState",
+                       REG_BINARY, prss, prss->dwSize);
 }
 
 // bDoubleClick is TRUE if "Double-click to open an item (single-click to select)".
@@ -66,36 +78,10 @@ IntGetDefaultShellState(REGSHELLSTATE& rss)
 static BOOL
 IntSetShellStateSettings(BOOL bDoubleClick, BOOL bUseCommonTasks)
 {
-    REGSHELLSTATE rss;
-    DWORD dwSize = sizeof(rss);
-    LSTATUS nStatus;
-
-    // read ShellState
-    nStatus = SHGetValueW(HKEY_CURRENT_USER,
-                          s_pszExplorerKey,
-                          L"ShellState",
-                          NULL,
-                          &rss,
-                          &dwSize);
-    if (nStatus != ERROR_SUCCESS || rss.dwSize < REGSHELLSTATE_SIZE)
-    {
-        IntGetDefaultShellState(rss);
-    }
-
-    // update ShellState
-    rss.ss.fDoubleClickInWebView = (bDoubleClick ? TRUE : FALSE);
-    rss.ss.fWebView = (bUseCommonTasks ? TRUE : FALSE);
-
-    // write ShellState
-    rss.dwSize = dwSize = REGSHELLSTATE_SIZE;
-    nStatus = SHSetValueW(HKEY_CURRENT_USER,
-                          s_pszExplorerKey,
-                          L"ShellState",
-                          REG_BINARY,
-                          &rss,
-                          dwSize);
-    if (nStatus != ERROR_SUCCESS)
-        return FALSE;
+    SHELLSTATE ss;
+    ss.fDoubleClickInWebView = (bDoubleClick ? TRUE : FALSE);
+    ss.fWebView = (bUseCommonTasks ? TRUE : FALSE);
+    SHGetSetSettings(&ss, SSF_DOUBLECLICKINWEBVIEW | SSF_WEBVIEW, TRUE);
 
     SHSettingsChanged(0, L"ShellState");
     return TRUE;
@@ -106,24 +92,14 @@ IntSetShellStateSettings(BOOL bDoubleClick, BOOL bUseCommonTasks)
 // SHLWAPI.dll	RegOpenKeyExW ( 0x000000c8, NULL, 0, MAXIMUM_ALLOWED, 0x0007e484 )	ERROR_SUCCESS		0.0000388
 // SHLWAPI.dll	RegQueryValueExW ( 0x000005a8, "ShellState", NULL, 0x0007e474, 0x000c2050, 0x0007e4fc )	ERROR_SUCCESS		0.0000271
 // SHLWAPI.dll	RegCloseKey ( 0x000005a8 )	ERROR_SUCCESS		0.0000112
-static BOOL
-IntGetShellStateSettings(BOOL& bDoubleClick, BOOL& bUseCommonTasks)
+EXTERN_C BOOL
+SHELL32_ReadRegShellState(void *pregshellstate)
 {
-    REGSHELLSTATE rss;
-    DWORD dwSize = sizeof(rss);
-    LSTATUS nStatus;
-    bDoubleClick = TRUE;
-    bUseCommonTasks = FALSE;
-
-    // read ShellState
-    nStatus = SHGetValueW(HKEY_CURRENT_USER, s_pszExplorerKey,
-                          L"ShellState", NULL, &rss, &dwSize);
-    if (nStatus != ERROR_SUCCESS || rss.dwSize < REGSHELLSTATE_SIZE)
-        return FALSE;
-
-    bDoubleClick = !!rss.ss.fDoubleClickInWebView;
-    bUseCommonTasks = !!rss.ss.fWebView;
-    return TRUE;
+    DWORD dwSize = sizeof(REGSHELLSTATE);
+    REGSHELLSTATE *prss = (REGSHELLSTATE*)pregshellstate;
+    LSTATUS err = SHGetValueW(HKEY_CURRENT_USER, s_pszExplorerKey,
+                              L"ShellState", NULL, prss, &dwSize);
+    return err == ERROR_SUCCESS && prss->dwSize >= REGSHELLSTATE_SIZE;
 }
 
 // bIconUnderline is TRUE if "Underline icon titles only when I point at them".
@@ -318,12 +294,12 @@ GeneralDlg_StoreToUI(HWND hwndDlg, BOOL bDoubleClick, BOOL bUseCommonTasks,
 static BOOL
 GeneralDlg_OnInitDialog(HWND hwndDlg, PGENERAL_DIALOG pGeneral)
 {
-    BOOL bDoubleClick = TRUE;
-    BOOL bUseCommonTasks = FALSE;
+    SHELLSTATE ss;
+    SHGetSetSettings(&ss, SSF_DOUBLECLICKINWEBVIEW | SSF_WEBVIEW, FALSE);
+    BOOL bDoubleClick = !!ss.fDoubleClickInWebView;
+    BOOL bUseCommonTasks = !!ss.fWebView;
     BOOL bUnderline = IntGetUnderlineState();
     BOOL bNewWindowMode = IntGetNewWindowMode();
-
-    IntGetShellStateSettings(bDoubleClick, bUseCommonTasks);
 
     GeneralDlg_StoreToUI(hwndDlg, bDoubleClick, bUseCommonTasks, bUnderline, bNewWindowMode, pGeneral);
     GeneralDlg_UpdateIcons(hwndDlg, 0, pGeneral);

--- a/dll/win32/shell32/dialogs/general.cpp
+++ b/dll/win32/shell32/dialogs/general.cpp
@@ -67,10 +67,10 @@ SHELL32_WriteRegShellState(PREGSHELLSTATE prss)
 static BOOL
 IntSetShellStateSettings(BOOL bDoubleClick, BOOL bUseCommonTasks)
 {
-    SHELLSTATE ss;
-    ss.fDoubleClickInWebView = !!bDoubleClick;
-    ss.fWebView = !!bUseCommonTasks;
-    SHGetSetSettings(&ss, SSF_DOUBLECLICKINWEBVIEW | SSF_WEBVIEW, TRUE);
+    SHELLSTATE shellstate;
+    shellstate.fDoubleClickInWebView = !!bDoubleClick;
+    shellstate.fWebView = !!bUseCommonTasks;
+    SHGetSetSettings(&shellstate, SSF_DOUBLECLICKINWEBVIEW | SSF_WEBVIEW, TRUE);
 
     SHSettingsChanged(0, L"ShellState");
     return TRUE;

--- a/dll/win32/shell32/dialogs/view.cpp
+++ b/dll/win32/shell32/dialogs/view.cpp
@@ -824,7 +824,7 @@ ScanAdvancedSettings(SHELLSTATE *pSS, DWORD *pdwMask)
         }
         if (lstrcmpiW(pEntry->szKeyName, L"SHOWALL") == 0)
         {
-            pSS->fShowAllObjects = !bChecked ? 1 : 0;
+            pSS->fShowAllObjects = bChecked ? 1 : 0;
             *pdwMask |= SSF_SHOWALLOBJECTS;
             continue;
         }

--- a/dll/win32/shell32/folders/CFSFolder.cpp
+++ b/dll/win32/shell32/folders/CFSFolder.cpp
@@ -1355,20 +1355,10 @@ HRESULT WINAPI CFSFolder::GetUIObjectOf(HWND hwndOwner,
 BOOL SHELL_FS_HideExtension(LPCWSTR szPath)
 {
     HKEY hKey;
-    DWORD dwData, dwDataSize = sizeof(DWORD);
     BOOL doHide = FALSE; /* The default value is FALSE (win98 at least) */
     LONG lError;
 
-    lError = RegCreateKeyExW(HKEY_CURRENT_USER, L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Advanced",
-                             0, NULL, 0, KEY_ALL_ACCESS, NULL,
-                             &hKey, NULL);
-    if (lError == ERROR_SUCCESS)
-    {
-        lError = RegQueryValueExW(hKey, L"HideFileExt", NULL, NULL, (LPBYTE)&dwData, &dwDataSize);
-        if (lError == ERROR_SUCCESS)
-            doHide = dwData;
-        RegCloseKey(hKey);
-    }
+    doHide = !SHELL_GetSetting(SSF_SHOWEXTENSIONS, fShowExtensions);
 
     if (!doHide)
     {

--- a/dll/win32/shell32/wine/shellord.c
+++ b/dll/win32/shell32/wine/shellord.c
@@ -196,11 +196,192 @@ typedef BOOL (WINAPI *GetOpenFileNameProc)(OPENFILENAMEW *ofn);
     return ret;
 }
 
+#ifdef __REACTOS__
+BOOL SHELL_GlobalCounterChanged(LONG *pCounter, SHELL_GCOUNTER_DECLAREPARAMETERS(handle, id))
+{
+    LONG count = SHELL_GlobalCounterGet(SHELL_GCOUNTER_PARAMETERS(handle, id));
+    if (*pCounter == count)
+        return FALSE;
+    *pCounter = count;
+    return TRUE;
+}
+
+EXTERN_C void SHELL32_GetDefaultShellState(SHELLSTATE *pss);
+EXTERN_C BOOL SHELL32_ReadRegShellState(void *pregshellstate);
+EXTERN_C LSTATUS SHELL32_WriteRegShellState(void *pregshellstate);
+SHELL_GCOUNTER_DEFINE_GUID(SHGCGUID_ShellState, 0x7cb834f0, 0x527b, 0x11d2, 0x9d, 0x1f, 0x00, 0x00, 0xf8, 0x05, 0xca, 0x57);
+SHELL_GCOUNTER_DEFINE_HANDLE(g_hShellState);
+#define SHELL_GCOUNTER_SHELLSTATE SHELL_GCOUNTER_PARAMETERS(g_hShellState, GLOBALCOUNTER_SHELLSETTINGSCHANGED)
+static LONG g_ShellStateCounter = 0;
+static UINT g_CachedSSF = 0;
+static struct REGSHELLSTATE { DWORD dwSize; SHELLSTATE ss; } g_ShellState;
+enum { ssf_autocheckselect = 0x00800000, ssf_iconsonly = 0x01000000,
+       ssf_showtypeoverlay = 0x02000000, ssf_showstatusbar = 0x04000000 };
+#endif
+
 /*************************************************************************
  * SHGetSetSettings				[SHELL32.68]
  */
 VOID WINAPI SHGetSetSettings(LPSHELLSTATE lpss, DWORD dwMask, BOOL bSet)
 {
+#ifdef __REACTOS__
+    const DWORD inverted = SSF_SHOWEXTENSIONS;
+    SHELLSTATE *gpss = &g_ShellState.ss;
+    HKEY hKeyAdv;
+
+    if (!SHELL_GlobalCounterIsInitialized(g_hShellState))
+    {
+        SHELL_GlobalCounterCreate(&SHGCGUID_ShellState, g_hShellState);
+    }
+
+    if (!lpss)
+    {
+        SHELL_GlobalCounterIncrement(SHELL_GCOUNTER_SHELLSTATE);
+        return;
+    }
+
+    hKeyAdv = SHGetShellKey(SHKEY_Root_HKCU | SHKEY_Key_Explorer, L"Advanced", bSet);
+    if (!hKeyAdv && bSet)
+        return;
+
+#define SSF_STRUCTONLY (SSF_NOCONFIRMRECYCLE | SSF_DOUBLECLICKINWEBVIEW | SSF_DESKTOPHTML | \
+                        SSF_WIN95CLASSIC | SSF_SORTCOLUMNS | SSF_STARTPANELON)
+#define SHGSS_GetSetStruct(getsetmacro) \
+    do { \
+        getsetmacro(fNoConfirmRecycle, SSF_NOCONFIRMRECYCLE); \
+        getsetmacro(fDoubleClickInWebView, SSF_DOUBLECLICKINWEBVIEW); \
+        getsetmacro(fDesktopHTML, SSF_DESKTOPHTML); \
+        getsetmacro(fWin95Classic, SSF_WIN95CLASSIC); \
+        getsetmacro(lParamSort, SSF_SORTCOLUMNS); \
+        getsetmacro(iSortDirection, SSF_SORTCOLUMNS); \
+        getsetmacro(fStartPanelOn, SSF_STARTPANELON); \
+    } while (0)
+#define SHGSS_GetSetAdv(getsetmacro) \
+    do { \
+        getsetmacro(L"HideFileExt", fShowExtensions, SSF_SHOWEXTENSIONS); \
+        getsetmacro(L"ShowCompColor", fShowCompColor, SSF_SHOWCOMPCOLOR); \
+        getsetmacro(L"DontPrettyPath", fDontPrettyPath, SSF_DONTPRETTYPATH); \
+        getsetmacro(L"ShowAttribCol", fShowAttribCol, SSF_SHOWATTRIBCOL); \
+        getsetmacro(L"MapNetDrvBtn", fMapNetDrvBtn, SSF_MAPNETDRVBUTTON); \
+        getsetmacro(L"ShowInfoTip", fShowInfoTip, SSF_SHOWINFOTIP); \
+        getsetmacro(L"HideIcons", fHideIcons, SSF_HIDEICONS); \
+        getsetmacro(L"WebView", fWebView, SSF_WEBVIEW); \
+        getsetmacro(L"Filter", fFilter, SSF_FILTER); \
+        getsetmacro(L"ShowSuperHidden", fShowSuperHidden, SSF_SHOWSUPERHIDDEN); \
+        getsetmacro(L"NoNetCrawling", fNoNetCrawling, SSF_NONETCRAWLING); \
+        getsetmacro(L"SeparateProcess", fSepProcess, SSF_SEPPROCESS); \
+        getsetmacro(L"AutoCheckSelect", fAutoCheckSelect, ssf_autocheckselect); \
+        getsetmacro(L"IconsOnly", fIconsOnly, ssf_iconsonly); \
+        getsetmacro(L"ShowTypeOverlay", fShowTypeOverlay, ssf_showtypeoverlay); \
+        getsetmacro(L"ShowStatusBar", fShowStatusBar, ssf_showstatusbar); \
+    } while (0)
+
+    if (bSet)
+    {
+        DWORD changed = 0;
+
+#define SHGSS_WriteAdv(name, value, SSF) \
+    do { \
+        DWORD val = (value), cb = sizeof(DWORD); \
+        if (SHSetValueW(hKeyAdv, NULL, (name), REG_DWORD, &val, cb) == ERROR_SUCCESS) \
+        { \
+            ++changed; \
+        } \
+    } while (0)
+#define SHGSS_SetAdv(name, field, SSF) \
+    do { \
+        if ((dwMask & (SSF)) && gpss->field != lpss->field) \
+        { \
+            const DWORD bitval = (gpss->field = lpss->field); \
+            SHGSS_WriteAdv((name), ((SSF) & inverted) ? !bitval : !!bitval, (SSF)); \
+        } \
+    } while (0)
+#define SHGSS_SetStruct(field, SSF) \
+    do { \
+        if ((dwMask & (SSF)) && gpss->field != lpss->field) \
+        { \
+            gpss->field = lpss->field; \
+            ++changed; \
+        } \
+    } while (0)
+
+        if ((dwMask & SSF_SHOWALLOBJECTS) && gpss->fShowAllObjects != lpss->fShowAllObjects)
+        {
+            gpss->fShowAllObjects = lpss->fShowAllObjects;
+            SHGSS_WriteAdv(L"Hidden", lpss->fShowAllObjects ? 1 : 2, SSF_SHOWALLOBJECTS);
+        }
+        SHGSS_SetStruct(fShowSysFiles, SSF_SHOWSYSFILES);
+        SHGSS_GetSetAdv(SHGSS_SetAdv);
+        SHGSS_GetSetStruct(SHGSS_SetStruct);
+        if (changed)
+        {
+            extern DWORD WINAPI SHSendMessageBroadcastW(UINT uMsg, WPARAM wParam, LPARAM lParam);
+            if ((dwMask & SSF_SHOWSUPERHIDDEN) && DLL_EXPORT_VERSION < 0x600)
+            {
+                // This is probably a Windows bug but write this alternative name just in case someone reads it
+                DWORD val = gpss->fShowSuperHidden != FALSE;
+                SHSetValueW(hKeyAdv, NULL, L"SuperHidden", REG_DWORD, &val, sizeof(DWORD));
+            }
+            SHELL32_WriteRegShellState(&g_ShellState); // Write the new SHELLSTATE
+            SHGetSetSettings(NULL, 0, TRUE); // Invalidate counter
+            SHSendMessageBroadcastW(WM_SETTINGCHANGE, 0, (LPARAM)L"ShellState"); // Notify everyone
+        }
+    }
+    else
+    {
+        DWORD read = 0, data, cb, dummy = 0;
+        if (SHELL_GlobalCounterChanged(&g_ShellStateCounter, SHELL_GCOUNTER_SHELLSTATE))
+            g_CachedSSF = 0;
+
+#define SHGSS_ReadAdv(name, SSF) ( \
+    (g_CachedSSF & (SSF)) != (SSF) && (cb = sizeof(DWORD)) != 0 && \
+    SHQueryValueEx(hKeyAdv, (name), NULL, NULL, &data, &cb) == ERROR_SUCCESS && \
+    cb == sizeof(DWORD) && (read |= (SSF)) != 0 )
+#define SHGSS_GetFieldHelper(field, SSF, src, dst, cachevar) \
+    do { \
+        if (dwMask & (SSF)) \
+        { \
+            (dst)->field = (src)->field; \
+            cachevar |= (SSF); \
+        } \
+    } while (0)
+#define SHGSS_CacheField(field, SSF) SHGSS_GetFieldHelper(field, (SSF), &rss.ss, gpss, read)
+#define SHGSS_GetField(field, SSF) SHGSS_GetFieldHelper(field, (SSF), gpss, lpss, dummy)
+#define SHGSS_GetAdv(name, field, SSF) \
+    do { \
+        if (SHGSS_ReadAdv((name), (SSF))) \
+            gpss->field = ((SSF) & inverted) ? data == FALSE : data != FALSE; \
+        SHGSS_GetFieldHelper(field, (SSF), gpss, lpss, read); \
+    } while (0)
+
+        if (SHGSS_ReadAdv(L"Hidden", SSF_SHOWALLOBJECTS | SSF_SHOWSYSFILES))
+        {
+            gpss->fShowAllObjects = data == 1;
+            gpss->fShowSysFiles = data > 1;
+        }
+        SHGSS_GetField(fShowAllObjects, SSF_SHOWALLOBJECTS);
+        SHGSS_GetField(fShowSysFiles, SSF_SHOWSYSFILES);
+        SHGSS_GetSetAdv(SHGSS_GetAdv);
+        if (dwMask & ~(read | g_CachedSSF))
+        {
+            struct REGSHELLSTATE rss;
+            if (SHELL32_ReadRegShellState(&rss))
+            {
+                SHGSS_GetSetStruct(SHGSS_CacheField); // Copy the requested items to gpss
+            }
+            else
+            {
+                SHELL32_GetDefaultShellState(gpss);
+                read = 0; // The advanced items we read are no longer valid in gpss
+                g_CachedSSF = SSF_STRUCTONLY;
+            }
+        }
+        SHGSS_GetSetStruct(SHGSS_GetField); // Copy requested items from gpss to output
+        g_CachedSSF |= read;
+    }
+    if (hKeyAdv)
+        RegCloseKey(hKeyAdv);
+#else
   if(bSet)
   {
     FIXME("%p 0x%08x TRUE\n", lpss, dwMask);
@@ -209,6 +390,7 @@ VOID WINAPI SHGetSetSettings(LPSHELLSTATE lpss, DWORD dwMask, BOOL bSet)
   {
     SHGetSettings((LPSHELLFLAGSTATE)lpss,dwMask);
   }
+#endif
 }
 
 /*************************************************************************
@@ -221,6 +403,17 @@ VOID WINAPI SHGetSetSettings(LPSHELLSTATE lpss, DWORD dwMask, BOOL bSet)
  */
 VOID WINAPI SHGetSettings(LPSHELLFLAGSTATE lpsfs, DWORD dwMask)
 {
+#ifdef __REACTOS__
+    SHELLSTATE ss;
+    SHGetSetSettings(&ss, dwMask & ~(SSF_SORTCOLUMNS), FALSE);
+    *lpsfs = *(LPSHELLFLAGSTATE)&ss;
+    if (dwMask & SSF_HIDEICONS)
+        lpsfs->fHideIcons = ss.fHideIcons;
+    if (dwMask & ssf_autocheckselect)
+        lpsfs->fAutoCheckSelect = ss.fAutoCheckSelect;
+    if (dwMask & ssf_iconsonly)
+        lpsfs->fIconsOnly = ss.fIconsOnly;
+#else
 	HKEY	hKey;
 	DWORD	dwData;
 	DWORD	dwDataSize = sizeof (DWORD);
@@ -264,7 +457,7 @@ VOID WINAPI SHGetSettings(LPSHELLFLAGSTATE lpsfs, DWORD dwMask)
 	  }
 	}
 	RegCloseKey (hKey);
-
+#endif
 	TRACE("-- 0x%04x\n", *(WORD*)lpsfs);
 }
 

--- a/dll/win32/shell32/wine/shellord.c
+++ b/dll/win32/shell32/wine/shellord.c
@@ -207,14 +207,14 @@ BOOL SHELL_GlobalCounterChanged(LONG *pCounter, SHELL_GCOUNTER_DECLAREPARAMETERS
 }
 
 EXTERN_C void SHELL32_GetDefaultShellState(LPSHELLSTATE pss);
-EXTERN_C BOOL SHELL32_ReadRegShellState(void *pregshellstate);
-EXTERN_C LSTATUS SHELL32_WriteRegShellState(void *pregshellstate);
+EXTERN_C BOOL SHELL32_ReadRegShellState(PREGSHELLSTATE prss);
+EXTERN_C LSTATUS SHELL32_WriteRegShellState(PREGSHELLSTATE prss);
 SHELL_GCOUNTER_DEFINE_GUID(SHGCGUID_ShellState, 0x7cb834f0, 0x527b, 0x11d2, 0x9d, 0x1f, 0x00, 0x00, 0xf8, 0x05, 0xca, 0x57);
 SHELL_GCOUNTER_DEFINE_HANDLE(g_hShellState);
 #define SHELL_GCOUNTER_SHELLSTATE SHELL_GCOUNTER_PARAMETERS(g_hShellState, GLOBALCOUNTER_SHELLSETTINGSCHANGED)
 static LONG g_ShellStateCounter = 0;
 static UINT g_CachedSSF = 0;
-static struct REGSHELLSTATE { DWORD dwSize; SHELLSTATE ss; } g_ShellState;
+static REGSHELLSTATE g_ShellState;
 enum { ssf_autocheckselect = 0x00800000, ssf_iconsonly = 0x01000000,
        ssf_showtypeoverlay = 0x02000000, ssf_showstatusbar = 0x04000000 };
 #endif //__REACTOS__
@@ -363,7 +363,7 @@ VOID WINAPI SHGetSetSettings(LPSHELLSTATE lpss, DWORD dwMask, BOOL bSet)
         SHGSS_GetSetAdv(SHGSS_GetAdv);
         if (dwMask & ~(read | g_CachedSSF))
         {
-            struct REGSHELLSTATE rss;
+            REGSHELLSTATE rss;
             if (SHELL32_ReadRegShellState(&rss))
             {
                 SHGSS_GetSetStruct(SHGSS_CacheField); // Copy the requested items to gpss

--- a/dll/win32/shell32/wine/shpolicy.c
+++ b/dll/win32/shell32/wine/shpolicy.c
@@ -78,7 +78,11 @@ DWORD g_RestValues[_countof(s_PolicyTable)] = { 0 };
  * @return  The handle of the global counter.
  * @implemented
  */
+#ifdef __REACTOS__
+EXTERN_C HANDLE
+#else
 static HANDLE
+#endif
 SHELL_GetCachedGlobalCounter(_Inout_ HANDLE *phGlobalCounter, _In_ REFGUID rguid)
 {
     HANDLE hGlobalCounter;

--- a/sdk/include/psdk/shlobj.h
+++ b/sdk/include/psdk/shlobj.h
@@ -1566,7 +1566,11 @@ typedef struct
     BOOL  fSepProcess: 1;
     BOOL  fStartPanelOn: 1;
     BOOL  fShowStartPage: 1;
-    UINT  fSpareFlags : 13;
+    BOOL  fAutoCheckSelect:1; // Vista+
+    BOOL  fIconsOnly:1;
+    BOOL  fShowTypeOverlay:1;
+    BOOL  fShowStatusBar:1; // 8+
+    UINT  fSpareFlags : 9;
     UINT  :15; /* Required for proper binary layout with gcc */
 } SHELLSTATE, *LPSHELLSTATE;
 
@@ -1580,51 +1584,53 @@ typedef struct
 	BOOL fShowExtensions : 1;
 	BOOL fNoConfirmRecycle : 1;
 	BOOL fShowSysFiles : 1;
-
 	BOOL fShowCompColor : 1;
 	BOOL fDoubleClickInWebView : 1;
 	BOOL fDesktopHTML : 1;
 	BOOL fWin95Classic : 1;
-
 	BOOL fDontPrettyPath : 1;
 	BOOL fShowAttribCol : 1;
 	BOOL fMapNetDrvBtn : 1;
 	BOOL fShowInfoTip : 1;
-
 	BOOL fHideIcons : 1;
-	UINT fRestFlags : 3;
+	BOOL fAutoCheckSelect : 1;
+	BOOL fIconsOnly : 1;
+	UINT fRestFlags : 1;
 	UINT :15; /* Required for proper binary layout with gcc */
 } SHELLFLAGSTATE, * LPSHELLFLAGSTATE;
 
 VOID WINAPI SHGetSettings(_Out_ LPSHELLFLAGSTATE lpsfs, DWORD dwMask);
 
-#define SSF_SHOWALLOBJECTS		0x0001
-#define SSF_SHOWEXTENSIONS		0x0002
-#define SSF_SHOWCOMPCOLOR		0x0008
-#define SSF_SHOWSYSFILES		0x0020
-#define SSF_DOUBLECLICKINWEBVIEW	0x0080
-#define SSF_SHOWATTRIBCOL		0x0100
-#define SSF_DESKTOPHTML			0x0200
-#define SSF_WIN95CLASSIC		0x0400
-#define SSF_DONTPRETTYPATH		0x0800
-#define SSF_SHOWINFOTIP			0x2000
-#define SSF_MAPNETDRVBUTTON		0x1000
-#define SSF_NOCONFIRMRECYCLE		0x8000
-#define SSF_HIDEICONS			0x4000
-#define SSF_SHOWSUPERHIDDEN		0x00040000
-#define SSF_SEPPROCESS			0x00080000
+#define SSF_SHOWALLOBJECTS       0x00000001
+#define SSF_SHOWEXTENSIONS       0x00000002
+#define SSF_SHOWCOMPCOLOR        0x00000008
+#define SSF_SORTCOLUMNS          0x00000010
+#define SSF_SHOWSYSFILES         0x00000020
+#define SSF_DOUBLECLICKINWEBVIEW 0x00000080
+#define SSF_SHOWATTRIBCOL        0x00000100
+#define SSF_DESKTOPHTML          0x00000200
+#define SSF_WIN95CLASSIC         0x00000400
+#define SSF_DONTPRETTYPATH       0x00000800
+#define SSF_MAPNETDRVBUTTON      0x00001000
+#define SSF_SHOWINFOTIP          0x00002000
+#define SSF_HIDEICONS            0x00004000
+#define SSF_NOCONFIRMRECYCLE     0x00008000
+#define SSF_FILTER               0x00010000
+#define SSF_WEBVIEW              0x00020000
+#define SSF_SHOWSUPERHIDDEN      0x00040000
+#define SSF_SEPPROCESS           0x00080000
 #if (NTDDI_VERSION >= NTDDI_WINXP)
-#define SSF_NONETCRAWLING		0x00100000
-#define SSF_STARTPANELON		0x00200000
-#define SSF_SHOWSTARTPAGE		0x00400000
+#define SSF_NONETCRAWLING        0x00100000
+#define SSF_STARTPANELON         0x00200000
+#define SSF_SHOWSTARTPAGE        0x00400000
 #endif
 #if (NTDDI_VERSION >= NTDDI_VISTA)
-#define SSF_AUTOCHECKSELECT		0x00800000
-#define SSF_ICONSONLY			0x01000000
-#define SSF_SHOWTYPEOVERLAY		0x02000000
+#define SSF_AUTOCHECKSELECT      0x00800000
+#define SSF_ICONSONLY            0x01000000
+#define SSF_SHOWTYPEOVERLAY      0x02000000
 #endif
 #if (NTDDI_VERSION >= NTDDI_WIN8)
-#define SSF_SHOWSTATUSBAR		0x04000000
+#define SSF_SHOWSTATUSBAR        0x04000000
 #endif
 
 /****************************************************************************

--- a/sdk/include/psdk/shlobj.h
+++ b/sdk/include/psdk/shlobj.h
@@ -1563,13 +1563,13 @@ typedef struct
     int   iSortDirection;
     UINT  version;
     UINT  uNotUsed;
-    BOOL  fSepProcess: 1;
-    BOOL  fStartPanelOn: 1;
-    BOOL  fShowStartPage: 1;
-    BOOL  fAutoCheckSelect:1; // Vista+
-    BOOL  fIconsOnly:1;
-    BOOL  fShowTypeOverlay:1;
-    BOOL  fShowStatusBar:1; // 8+
+    BOOL  fSepProcess : 1;
+    BOOL  fStartPanelOn : 1;
+    BOOL  fShowStartPage : 1;
+    BOOL  fAutoCheckSelect : 1; // Vista+
+    BOOL  fIconsOnly : 1;
+    BOOL  fShowTypeOverlay : 1;
+    BOOL  fShowStatusBar : 1; // 8+
     UINT  fSpareFlags : 9;
     UINT  :15; /* Required for proper binary layout with gcc */
 } SHELLSTATE, *LPSHELLSTATE;
@@ -1601,36 +1601,36 @@ typedef struct
 
 VOID WINAPI SHGetSettings(_Out_ LPSHELLFLAGSTATE lpsfs, DWORD dwMask);
 
-#define SSF_SHOWALLOBJECTS       0x00000001
-#define SSF_SHOWEXTENSIONS       0x00000002
-#define SSF_SHOWCOMPCOLOR        0x00000008
-#define SSF_SORTCOLUMNS          0x00000010
-#define SSF_SHOWSYSFILES         0x00000020
-#define SSF_DOUBLECLICKINWEBVIEW 0x00000080
-#define SSF_SHOWATTRIBCOL        0x00000100
-#define SSF_DESKTOPHTML          0x00000200
-#define SSF_WIN95CLASSIC         0x00000400
-#define SSF_DONTPRETTYPATH       0x00000800
-#define SSF_MAPNETDRVBUTTON      0x00001000
-#define SSF_SHOWINFOTIP          0x00002000
-#define SSF_HIDEICONS            0x00004000
-#define SSF_NOCONFIRMRECYCLE     0x00008000
-#define SSF_FILTER               0x00010000
-#define SSF_WEBVIEW              0x00020000
-#define SSF_SHOWSUPERHIDDEN      0x00040000
-#define SSF_SEPPROCESS           0x00080000
+#define SSF_SHOWALLOBJECTS          0x00000001
+#define SSF_SHOWEXTENSIONS          0x00000002
+#define SSF_SHOWCOMPCOLOR           0x00000008
+#define SSF_SORTCOLUMNS             0x00000010
+#define SSF_SHOWSYSFILES            0x00000020
+#define SSF_DOUBLECLICKINWEBVIEW    0x00000080
+#define SSF_SHOWATTRIBCOL           0x00000100
+#define SSF_DESKTOPHTML             0x00000200
+#define SSF_WIN95CLASSIC            0x00000400
+#define SSF_DONTPRETTYPATH          0x00000800
+#define SSF_MAPNETDRVBUTTON         0x00001000
+#define SSF_SHOWINFOTIP             0x00002000
+#define SSF_HIDEICONS               0x00004000
+#define SSF_NOCONFIRMRECYCLE        0x00008000
+#define SSF_FILTER                  0x00010000
+#define SSF_WEBVIEW                 0x00020000
+#define SSF_SHOWSUPERHIDDEN         0x00040000
+#define SSF_SEPPROCESS              0x00080000
 #if (NTDDI_VERSION >= NTDDI_WINXP)
-#define SSF_NONETCRAWLING        0x00100000
-#define SSF_STARTPANELON         0x00200000
-#define SSF_SHOWSTARTPAGE        0x00400000
+#define SSF_NONETCRAWLING           0x00100000
+#define SSF_STARTPANELON            0x00200000
+#define SSF_SHOWSTARTPAGE           0x00400000
 #endif
 #if (NTDDI_VERSION >= NTDDI_VISTA)
-#define SSF_AUTOCHECKSELECT      0x00800000
-#define SSF_ICONSONLY            0x01000000
-#define SSF_SHOWTYPEOVERLAY      0x02000000
+#define SSF_AUTOCHECKSELECT         0x00800000
+#define SSF_ICONSONLY               0x01000000
+#define SSF_SHOWTYPEOVERLAY         0x02000000
 #endif
 #if (NTDDI_VERSION >= NTDDI_WIN8)
-#define SSF_SHOWSTATUSBAR        0x04000000
+#define SSF_SHOWSTATUSBAR           0x04000000
 #endif
 
 /****************************************************************************

--- a/sdk/include/reactos/shellutils.h
+++ b/sdk/include/reactos/shellutils.h
@@ -747,5 +747,17 @@ DataObject_SetOffset(IDataObject* pDataObject, POINT* point)
 
 #endif
 
+#ifdef __cplusplus
+struct SHELL_GetSettingImpl
+{
+    SHELLSTATE ss;
+    SHELL_GetSettingImpl(DWORD ssf) { SHGetSetSettings(&ss, ssf, FALSE); }
+    const SHELLSTATE* operator ->() { return &ss; }
+};
+#define SHELL_GetSetting(ssf, field) ( SHELL_GetSettingImpl(ssf)->field )
+#else
+#define SHELL_GetSetting(pss, ssf, field) ( SHGetSetSettings((pss), (ssf), FALSE), (pss)->field )
+#endif
+
 
 #endif /* __ROS_SHELL_UTILS_H */

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -39,6 +39,29 @@ PVOID WINAPI SHInterlockedCompareExchange(PVOID *dest, PVOID xchg, PVOID compare
 LONG WINAPI SHGlobalCounterGetValue(HANDLE hGlobalCounter);
 LONG WINAPI SHGlobalCounterIncrement(HANDLE hGlobalCounter);
 
+#if FALSE && DLL_EXPORT_VERSION >= _WIN32_WINNT_VISTA
+#define SHELL_GCOUNTER_DEFINE_GUID(name, a, b, c, d, e, f, g, h, i, j, k) enum { SHELLUNUSEDCOUNTERGUID_##name }
+#define SHELL_GCOUNTER_DEFINE_HANDLE(name) enum { SHELLUNUSEDCOUNTERHANDLE_##name }
+#define SHELL_GCOUNTER_PARAMETERS(handle, id) id
+#define SHELL_GlobalCounterCreate(refguid, handle) ( (refguid), (handle), (void)0 )
+#define SHELL_GlobalCounterIsInitialized(handle) ( (handle), TRUE )
+#define SHELL_GlobalCounterGet(id) SHGlobalCounterGetValue_Vista(id)
+#define SHELL_GlobalCounterIncrement(id) SHGlobalCounterIncrement_Vista(id)
+#else
+#define SHELL_GCOUNTER_DEFINE_GUID(name, a, b, c, d, e, f, g, h, i, j, k) const GUID name = { a, b, c, { d, e, f, g, h, i, j, k } }
+#define SHELL_GCOUNTER_DEFINE_HANDLE(name) HANDLE name = NULL
+#define SHELL_GCOUNTER_PARAMETERS(handle, id) handle
+#define SHELL_GlobalCounterCreate(refguid, handle) \
+  do { \
+    EXTERN_C HANDLE SHELL_GetCachedGlobalCounter(HANDLE *phGlobalCounter, REFGUID rguid); \
+    SHELL_GetCachedGlobalCounter(&(handle), (refguid)); \
+  } while (0)
+#define SHELL_GlobalCounterIsInitialized(handle) ( handle )
+#define SHELL_GlobalCounterGet(handle) SHGlobalCounterGetValue(handle)
+#define SHELL_GlobalCounterIncrement(handle) SHGlobalCounterIncrement(handle)
+#endif
+#define SHELL_GCOUNTER_DECLAREPARAMETERS(handle, id) SHELL_GCOUNTER_PARAMETERS(HANDLE handle, SHGLOBALCOUNTER id)
+
 DWORD WINAPI
 SHRestrictionLookup(
     _In_ DWORD policy,

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -39,7 +39,7 @@ PVOID WINAPI SHInterlockedCompareExchange(PVOID *dest, PVOID xchg, PVOID compare
 LONG WINAPI SHGlobalCounterGetValue(HANDLE hGlobalCounter);
 LONG WINAPI SHGlobalCounterIncrement(HANDLE hGlobalCounter);
 
-#if FALSE && DLL_EXPORT_VERSION >= _WIN32_WINNT_VISTA
+#if FALSE && ((DLL_EXPORT_VERSION) >= _WIN32_WINNT_VISTA)
 #define SHELL_GCOUNTER_DEFINE_GUID(name, a, b, c, d, e, f, g, h, i, j, k) enum { SHELLUNUSEDCOUNTERGUID_##name }
 #define SHELL_GCOUNTER_DEFINE_HANDLE(name) enum { SHELLUNUSEDCOUNTERHANDLE_##name }
 #define SHELL_GCOUNTER_PARAMETERS(handle, id) id
@@ -56,7 +56,7 @@ LONG WINAPI SHGlobalCounterIncrement(HANDLE hGlobalCounter);
     EXTERN_C HANDLE SHELL_GetCachedGlobalCounter(HANDLE *phGlobalCounter, REFGUID rguid); \
     SHELL_GetCachedGlobalCounter(&(handle), (refguid)); \
   } while (0)
-#define SHELL_GlobalCounterIsInitialized(handle) ( handle )
+#define SHELL_GlobalCounterIsInitialized(handle) ( (handle) != NULL )
 #define SHELL_GlobalCounterGet(handle) SHGlobalCounterGetValue(handle)
 #define SHELL_GlobalCounterIncrement(handle) SHGlobalCounterIncrement(handle)
 #endif
@@ -94,6 +94,7 @@ BOOL WINAPI SHSimulateDrop(IDropTarget *pDrop, IDataObject *pDataObj, DWORD grfK
 HMENU WINAPI SHGetMenuFromID(HMENU hMenu, UINT uID);
 DWORD WINAPI SHGetCurColorRes(void);
 DWORD WINAPI SHWaitForSendMessageThread(HANDLE hand, DWORD dwTimeout);
+DWORD WINAPI SHSendMessageBroadcastW(UINT uMsg, WPARAM wParam, LPARAM lParam);
 HRESULT WINAPI SHIsExpandableFolder(LPSHELLFOLDER lpFolder, LPCITEMIDLIST pidl);
 DWORD WINAPI SHFillRectClr(HDC hDC, LPCRECT pRect, COLORREF cRef);
 int WINAPI SHSearchMapInt(const int *lpKeys, const int *lpValues, int iLen, int iKey);

--- a/sdk/include/reactos/undocshell.h
+++ b/sdk/include/reactos/undocshell.h
@@ -539,7 +539,7 @@ BOOL WINAPI PathIsTemporaryW(_In_ LPCWSTR Str);
  * Shell settings
  */
 
-typedef struct REGSHELLSTATE
+typedef struct _REGSHELLSTATE
 {
     DWORD dwSize;
     SHELLSTATE ss;

--- a/sdk/include/reactos/undocshell.h
+++ b/sdk/include/reactos/undocshell.h
@@ -536,6 +536,19 @@ BOOL WINAPI PathIsTemporaryW(_In_ LPCWSTR Str);
 #define ERRORONDEST         0x10000
 
 /****************************************************************************
+ * Shell settings
+ */
+
+typedef struct REGSHELLSTATE
+{
+    DWORD dwSize;
+    SHELLSTATE ss;
+} REGSHELLSTATE, *PREGSHELLSTATE;
+#define REGSHELLSTATE_SIZE 0x24
+#define REGSHELLSTATE_VERSION 0xD
+C_ASSERT(sizeof(REGSHELLSTATE) == REGSHELLSTATE_SIZE);
+
+/****************************************************************************
  * Shell Namespace Routines
  */
 


### PR DESCRIPTION
These settings are cached per-process (and invalidated by the global counter). This should reduce the number of registry reads performed by DefView and CFSFolder.

Notes:
- `SSF_SHOWEXTENSIONS` is "inverted" because the registry value is the negative "HideFileExt".
- Pardon the macros, working with the bit fields and masks in `SHELLSTATE` is cumbersome.
- The macros in shlwapi are to help with the transition to the [documented](https://learn.microsoft.com/en-us/windows/win32/api/shlwapi/ne-shlwapi-shglobalcounter) NT6 version of the global counters.