### PR TITLE
[DC21X4] Fix uninitialized variable read

### DIFF
--- a/drivers/network/dd/dc21x4/media.c
+++ b/drivers/network/dd/dc21x4/media.c
@@ -326,7 +326,7 @@ MediaInitDefaultMedia(
     _In_ PDC21X4_ADAPTER Adapter,
     _In_ ULONG MediaNumber)
 {
-    ULONG Csr14, MiiAdvertising, MiiControl, i;
+    ULONG Csr14, MiiAdvertising, i;
     BOOLEAN UseMii;
 
     PAGED_CODE();
@@ -471,12 +471,14 @@ MediaInitDefaultMedia(
         }
         else
         {
+            ULONG MiiControl;
             Adapter->DefaultMedia = MEDIA_MII;
 
             switch (MediaNumber)
             {
                 case MEDIA_10T:
                     MiiAdvertising = MII_ADV_10T_HD;
+                    MiiControl = 0;
                     break;
                 case MEDIA_10T_FD:
                     MiiAdvertising = MII_ADV_10T_FD;
@@ -492,6 +494,7 @@ MediaInitDefaultMedia(
                     break;
                 case MEDIA_100T4:
                     MiiAdvertising = MII_ADV_100T4 | MII_CR_SPEED_SELECTION;
+                    MiiControl = 0;
                     break;
 
                 default:

--- a/drivers/network/dd/dc21x4/media.c
+++ b/drivers/network/dd/dc21x4/media.c
@@ -326,7 +326,7 @@ MediaInitDefaultMedia(
     _In_ PDC21X4_ADAPTER Adapter,
     _In_ ULONG MediaNumber)
 {
-    ULONG Csr14, MiiAdvertising, i;
+    ULONG Csr14, i;
     BOOLEAN UseMii;
 
     PAGED_CODE();
@@ -471,7 +471,7 @@ MediaInitDefaultMedia(
         }
         else
         {
-            ULONG MiiControl;
+            ULONG MiiAdvertising, MiiControl;
             Adapter->DefaultMedia = MEDIA_MII;
 
             switch (MediaNumber)
@@ -493,10 +493,9 @@ MediaInitDefaultMedia(
                     MiiControl = MII_CR_FULL_DUPLEX | MII_CR_SPEED_SELECTION;
                     break;
                 case MEDIA_100T4:
-                    MiiAdvertising = MII_ADV_100T4 | MII_CR_SPEED_SELECTION;
-                    MiiControl = 0;
+                    MiiAdvertising = MII_ADV_100T4;
+                    MiiControl = MII_CR_SPEED_SELECTION;
                     break;
-
                 default:
                     MiiAdvertising = 0;
                     MiiControl = 0;


### PR DESCRIPTION
This is the network driver which is used for MSVPC 2007 and according to his author Dmitry Borisov has never been tested on real HW yet.

First and foremost: A disclaimer: I am not a driver developer. The function is marked as CODE_SEG("PAGE"), but I do assume this doesn't play any role with variable initialization.

Long story short: This looks like 'uninitialized variable read' to me at (old) line 503:
    if (MiiControl & MII_CR_SPEED_SELECTION)

with the result as far as I can read the code, that the driver might chaotically decide whether it will connect with 10 or 100Mbps.

I will request a review of this PR from Dmitry Borisov.

GCC4.7.2 build warned me about that.
GCC8.4.0 build doesn't give a fuck, and does not warn. Either there is something that I don't understand yet, or the newer compiler is very poor at checking the code.


JIRA issue: none

Before-and-after-the-fix-picture (first `ninja dc21x4` was before the fix and failing to build, 2nd `ninja dc21x4` was after the fix):
![image](https://github.com/reactos/reactos/assets/33393466/ed6fae97-ed1c-4583-bce6-9f38476e7c4e)


