### PR TITLE
[BOOTDATA][INF] Add Tahoma entry to Asian FontLink

### DIFF
--- a/boot/bootdata/hivesft.inf
+++ b/boot/bootdata/hivesft.inf
@@ -639,61 +639,74 @@ HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontLink\SystemLink","MingLiU
 	"micross.ttf,Microsoft Sans Serif",\
 	"simsun.ttc,SimSun",\
 	"msmincho.ttc,MS Mincho",\
-	"batang.ttc,BatangChe"
+	"batang.ttc,BatangChe",\
+	"tahoma.ttf,Tahoma"
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontLink\SystemLink","SimSun",0x00010000,\
 	"micross.ttf,Microsoft Sans Serif",\
 	"mingliu.ttc,PMingLiU",\
 	"msmincho.ttc,MS PMincho",\
-	"batang.ttc,Batang"
+	"batang.ttc,Batang",\
+	"tahoma.ttf,Tahoma"
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontLink\SystemLink","PMingLiU",0x00010000,\
 	"micross.ttf,Microsoft Sans Serif",\
 	"simsun.ttc,SimSun",\
 	"msmincho.ttc,MS PMincho",\
-	"BATANG.TTC,Batang"
+	"BATANG.TTC,Batang",\
+	"tahoma.ttf,Tahoma"
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontLink\SystemLink","NSimSun",0x00010000,\
 	"mingliu.ttc,PMingLiU",\
 	"msmincho.ttc,MS Mincho",\
-	"batang.ttc,BatangChe"
+	"batang.ttc,BatangChe",\
+	"tahoma.ttf,Tahoma"
 
 ; FontLink (Japanese to others)
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontLink\SystemLink","MS Gothic",0x00010000,\
 	"mingliu.ttc,MingLiU",\
 	"simsun.ttc,SimSun",\
 	"gulim.ttc,GulimChe"
+	"tahoma.ttf,Tahoma"
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontLink\SystemLink","MS Mincho",0x00010000,\
 	"mingliu.ttc,MingLiU",\
 	"simsun.ttc,SimSun",\
-	"batang.ttc,Batang"
+	"batang.ttc,Batang",\
+	"tahoma.ttf,Tahoma"
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontLink\SystemLink","MS PGothic",0x00010000,\
 	"mingliu.ttc,PMingLiU",\
 	"simsun.ttc,SimSun",\
-	"gulim.ttc,Gulim"
+	"gulim.ttc,Gulim",\
+	"tahoma.ttf,Tahoma"
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontLink\SystemLink","MS PMincho",0x00010000,\
 	"mingliu.ttc,PMingLiU",\
 	"simsun.ttc,SimSun",\
-	"batang.ttc,Batang"
+	"batang.ttc,Batang",\
+	"tahoma.ttf,Tahoma"
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontLink\SystemLink","MS UI Gothic",0x00010000,\
 	"simsun.ttc,SimSun",\
 	"gulim.ttc,Gulim",\
-	"mingliu.ttc,PMingLiU"
+	"mingliu.ttc,PMingLiU",\
+	"tahoma.ttf,Tahoma"
 
 ; FontLink (Korean to others)
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontLink\SystemLink","Batang",0x00010000,\
 	"msmincho.ttc,MS PMincho",\
 	"mingliu.ttc,PMingLiU",\
-	"simsun.ttc,SimSun"
+	"simsun.ttc,SimSun",\
+	"tahoma.ttf,Tahoma"
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontLink\SystemLink","BatangChe",0x00010000,\
 	"msmincho.ttc,MS Mincho",\
 	"mingliu.ttc,MingLiU",\
-	"simsun.ttc,SimSun"
+	"simsun.ttc,SimSun",\
+	"tahoma.ttf,Tahoma"
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontLink\SystemLink","Gulim",0x00010000,\
 	"micross.ttf,Microsoft Sans Serif",\
 	"msgothic.ttc,MS UI Gothic",\
-	"mingliu.ttc,PMingLiU"
+	"mingliu.ttc,PMingLiU",\
+	"tahoma.ttf,Tahoma"
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontLink\SystemLink","GulimChe",0x00010000,\
 	"msgothic.ttc,MS Gothic",\
 	"mingliu.ttc,MingLiU",\
-	"simsun.ttc,SimSun"
+	"simsun.ttc,SimSun",\
+	"tahoma.ttf,Tahoma"
 
 ; Win32k GRE initialization
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\GRE_Initialize",,0x00000012


### PR DESCRIPTION
## Purpose
Follow-up to #6929.
Latin accented characters will be able to be mixed in East Asian text by FontLink framework in the future.
JIRA issue: [CORE-9616](https://jira.reactos.org/browse/CORE-9616)

## Proposed changes

- Modify `boot/bootdata/hivesft.inf`.
- Add `"tahoma.ttf,Tahoma"` entry to Asian FontLink registry values.
