### PR TITLE
[KDVM] Fix definition of RtlEqualMemory()

### DIFF
--- a/drivers/base/kdvm/kdvm.c
+++ b/drivers/base/kdvm/kdvm.c
@@ -121,7 +121,7 @@ KdVmSendReceive(
         return NULL;
     }
 
-    if (RtlEqualMemory(ReceiveHeader->Magic, KdVmReplyMagic, 9))
+    if (!RtlEqualMemory(ReceiveHeader->Magic, KdVmReplyMagic, 9))
     {
         KDDBGPRINT("KdVmSendReceive: got invalid Magic: '%*s'\n",
                    sizeof(KdVmReplyMagic), ReceiveHeader->Magic);

--- a/drivers/base/kdvm/kdvm.h
+++ b/drivers/base/kdvm/kdvm.h
@@ -15,7 +15,7 @@
 #include <arc/arc.h>
 
 #undef RtlEqualMemory
-#define RtlEqualMemory(a, b, c) (RtlCompareMemory(a, b, c) != c)
+#define RtlEqualMemory(dst, src, len) (RtlCompareMemory((dst), (src), (len)) == (len))
 
 //#define KDDEBUG /* uncomment to enable debugging this dll */
 


### PR DESCRIPTION
## Purpose

Comply with the standard documented behaviour:

https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-rtlequalmemory#return-value
> RtlEqualMemory returns TRUE if Source1 and Source2 are equivalent; otherwise, it returns FALSE.

and
https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-rtlcomparememory#return-value
> [...] If all bytes match up to the specified Length value, the Length value is returned.
