### PR TITLE
[MOUNTMGR][NTOS:IO] Several fixes for IOCTL_MOUNTMGR_QUERY_DOS_VOLUME_PATH and IoVolumeDeviceToDosName() + tests

### DIFF
--- a/drivers/storage/mountmgr/device.c
+++ b/drivers/storage/mountmgr/device.c
@@ -887,20 +887,16 @@ MountMgrQueryDosVolumePath(IN PDEVICE_EXTENSION DeviceExtension,
             }
         }
 
-        /* We didn't find, break */
-        if (SymlinksEntry == &(DeviceInformation->SymbolicLinksListHead))
-        {
-            return STATUS_NOT_FOUND;
-        }
+        /* If we've found a device via drive letter, do default processing */
+        if (SymlinksEntry != &(DeviceInformation->SymbolicLinksListHead))
+            break;
 
-        /* It doesn't have associated device, go to fallback method */
+        /* If it doesn't have an associated device, go to fallback method */
         if (IsListEmpty(&DeviceInformation->AssociatedDevicesHead))
-        {
             goto TryWithVolumeName;
-        }
 
         /* Create a string with the information about the device */
-        AssociatedDevice = CONTAINING_RECORD(&(DeviceInformation->SymbolicLinksListHead), ASSOCIATED_DEVICE_ENTRY, AssociatedDevicesEntry);
+        AssociatedDevice = CONTAINING_RECORD(&(DeviceInformation->AssociatedDevicesHead), ASSOCIATED_DEVICE_ENTRY, AssociatedDevicesEntry);
         OldLength = DeviceLength;
         OldBuffer = DeviceString;
         DeviceLength += AssociatedDevice->String.Length;
@@ -967,6 +963,7 @@ TryWithVolumeName:
         if (DeviceString)
         {
             FreePool(DeviceString);
+            DeviceString = NULL;
             DeviceLength = 0;
         }
 

--- a/drivers/storage/mountmgr/device.c
+++ b/drivers/storage/mountmgr/device.c
@@ -1004,8 +1004,8 @@ TryWithVolumeName:
     Output = (PMOUNTMGR_VOLUME_PATHS)Irp->AssociatedIrp.SystemBuffer;
 
     /* At least, we will return our length */
-    Output->MultiSzLength = DeviceLength;
-    Irp->IoStatus.Information = FIELD_OFFSET(MOUNTMGR_VOLUME_PATHS, MultiSz) + DeviceLength;
+    Output->MultiSzLength = DeviceLength + 2 * sizeof(UNICODE_NULL);
+    Irp->IoStatus.Information = FIELD_OFFSET(MOUNTMGR_VOLUME_PATHS, MultiSz) + Output->MultiSzLength;
 
     /* If we have enough room for copying the string */
     if (Irp->IoStatus.Information <= Stack->Parameters.DeviceIoControl.OutputBufferLength)

--- a/drivers/storage/mountmgr/device.c
+++ b/drivers/storage/mountmgr/device.c
@@ -856,7 +856,7 @@ MountMgrQueryDosVolumePath(IN PDEVICE_EXTENSION DeviceExtension,
     }
 
     /* Construct string for query */
-    SymbolicName.Length = Target->DeviceNameLength;
+    SymbolicName.Length =
     SymbolicName.MaximumLength = Target->DeviceNameLength;
     SymbolicName.Buffer = Target->DeviceName;
 
@@ -1482,8 +1482,8 @@ MountMgrQueryDosVolumePaths(IN PDEVICE_EXTENSION DeviceExtension,
     }
 
     /* Construct string for query */
-    SymbolicName.Length = Target->DeviceNameLength;
-    SymbolicName.MaximumLength = Target->DeviceNameLength + sizeof(UNICODE_NULL);
+    SymbolicName.Length =
+    SymbolicName.MaximumLength = Target->DeviceNameLength;
     SymbolicName.Buffer = Target->DeviceName;
 
     /* Find device with our info */

--- a/modules/rostests/apitests/mountmgr/CMakeLists.txt
+++ b/modules/rostests/apitests/mountmgr/CMakeLists.txt
@@ -1,6 +1,7 @@
 
 list(APPEND SOURCE
-    QueryPoints.c)
+    QueryPoints.c
+    utils.c)
 
 list(APPEND PCH_SKIP_SOURCE
     testlist.c)
@@ -9,9 +10,8 @@ add_executable(mountmgr_apitest
     ${SOURCE}
     ${PCH_SKIP_SOURCE})
 
+add_pch(mountmgr_apitest precomp.h "${PCH_SKIP_SOURCE}")
 target_link_libraries(mountmgr_apitest wine ${PSEH_LIB})
 set_module_type(mountmgr_apitest win32cui)
 add_importlibs(mountmgr_apitest msvcrt kernel32 ntdll)
-# TODO: Enable this when we get more than one source file to justify its use
-#add_pch(mountmgr_apitest precomp.h "${PCH_SKIP_SOURCE}")
 add_rostests_file(TARGET mountmgr_apitest)

--- a/modules/rostests/apitests/mountmgr/CMakeLists.txt
+++ b/modules/rostests/apitests/mountmgr/CMakeLists.txt
@@ -1,5 +1,6 @@
 
 list(APPEND SOURCE
+    QueryDosVolumePaths.c
     QueryPoints.c
     utils.c)
 

--- a/modules/rostests/apitests/mountmgr/QueryDosVolumePaths.c
+++ b/modules/rostests/apitests/mountmgr/QueryDosVolumePaths.c
@@ -1,0 +1,635 @@
+/*
+ * PROJECT:     ReactOS API Tests
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Test for IOCTL_MOUNTMGR_QUERY_DOS_VOLUME_PATH(S)
+ * COPYRIGHT:   Copyright 2025 Hermès Bélusca-Maïto <hermes.belusca-maito@reactos.org>
+ */
+
+#include "precomp.h"
+
+
+/**
+ * @brief
+ * Invokes either IOCTL_MOUNTMGR_QUERY_DOS_VOLUME_PATH or
+ * IOCTL_MOUNTMGR_QUERY_DOS_VOLUME_PATHS for testing, given
+ * the volume device name, and returns an allocated volume
+ * paths buffer. This buffer must be freed by the caller via
+ * RtlFreeHeap(RtlGetProcessHeap(), ...) .
+ *
+ * These IOCTLs return both the drive letter (if any) and the
+ * volume GUID symlink path, as well as any other file-system
+ * mount reparse points linking to the volume.
+ **/
+static VOID
+Call_QueryDosVolume_Path_Paths(
+    _In_ HANDLE MountMgrHandle,
+    _In_ PCWSTR NtVolumeName,
+    _In_ ULONG IoctlPathOrPaths,
+    _Out_ PMOUNTMGR_VOLUME_PATHS* pVolumePathPtr)
+{
+    NTSTATUS Status;
+    ULONG Length;
+    IO_STATUS_BLOCK IoStatusBlock;
+    UNICODE_STRING VolumeName;
+    MOUNTMGR_VOLUME_PATHS VolumePath;
+    PMOUNTMGR_VOLUME_PATHS VolumePathPtr;
+    ULONG DeviceNameLength;
+    /*
+     * This variable is used to query the device name.
+     * It's based on MOUNTMGR_TARGET_NAME (mountmgr.h).
+     * Doing it this way prevents memory allocation.
+     * The device name won't be longer.
+     */
+    struct
+    {
+        USHORT NameLength;
+        WCHAR DeviceName[256];
+    } DeviceName;
+
+
+    *pVolumePathPtr = NULL;
+
+    /* First, build the corresponding device name */
+    RtlInitUnicodeString(&VolumeName, NtVolumeName);
+    DeviceName.NameLength = VolumeName.Length;
+    RtlCopyMemory(&DeviceName.DeviceName, VolumeName.Buffer, VolumeName.Length);
+    DeviceNameLength = FIELD_OFFSET(MOUNTMGR_TARGET_NAME, DeviceName) + DeviceName.NameLength;
+
+    /* Now, query the MountMgr for the DOS path(s) */
+    Status = NtDeviceIoControlFile(MountMgrHandle,
+                                   NULL, NULL, NULL,
+                                   &IoStatusBlock,
+                                   IoctlPathOrPaths,
+                                   &DeviceName, DeviceNameLength,
+                                   &VolumePath, sizeof(VolumePath));
+
+    /* Check for unsupported device */
+    if (Status == STATUS_NO_MEDIA_IN_DEVICE || Status == STATUS_INVALID_DEVICE_REQUEST)
+    {
+        skip("Device '%S': Doesn't support MountMgr queries, Status 0x%08lx\n",
+             NtVolumeName, Status);
+        return;
+    }
+
+    /* The only tolerated failure here is buffer too small, which is expected */
+    ok(NT_SUCCESS(Status) || (Status == STATUS_BUFFER_OVERFLOW),
+       "Device '%S': IOCTL 0x%lx failed unexpectedly, Status 0x%08lx\n",
+       NtVolumeName, IoctlPathOrPaths, Status);
+    if (!NT_SUCCESS(Status) && (Status != STATUS_BUFFER_OVERFLOW))
+    {
+        skip("Device '%S': Wrong Status\n", NtVolumeName);
+        return;
+    }
+
+    /* Compute the needed size to store the DOS path(s).
+     * Even if MOUNTMGR_VOLUME_PATHS allows bigger name lengths
+     * than MAXUSHORT, we can't use them, because we have to return
+     * this in an UNICODE_STRING that stores length in a USHORT. */
+    Length = sizeof(VolumePath) + VolumePath.MultiSzLength;
+    ok(Length <= MAXUSHORT,
+       "Device '%S': DOS volume path too large: %lu\n",
+       NtVolumeName, Length);
+    if (Length > MAXUSHORT)
+    {
+        skip("Device '%S': Wrong Length\n", NtVolumeName);
+        return;
+    }
+
+    /* Allocate the buffer and fill it with test pattern */
+    VolumePathPtr = RtlAllocateHeap(RtlGetProcessHeap(), 0, Length);
+    if (!VolumePathPtr)
+    {
+        skip("Device '%S': Failed to allocate buffer with size %lu)\n",
+             NtVolumeName, Length);
+        return;
+    }
+    RtlFillMemory(VolumePathPtr, Length, 0xCC);
+
+    /* Re-query the DOS path(s) with the proper size */
+    Status = NtDeviceIoControlFile(MountMgrHandle,
+                                   NULL, NULL, NULL,
+                                   &IoStatusBlock,
+                                   IoctlPathOrPaths,
+                                   &DeviceName, DeviceNameLength,
+                                   VolumePathPtr, Length);
+    ok(NT_SUCCESS(Status),
+       "Device '%S': IOCTL 0x%lx failed unexpectedly, Status 0x%08lx\n",
+       NtVolumeName, IoctlPathOrPaths, Status);
+
+    if (winetest_debug > 1)
+    {
+        trace("Buffer:\n");
+        DumpBuffer(VolumePathPtr, Length);
+        printf("\n");
+    }
+
+    /* Return the buffer */
+    *pVolumePathPtr = VolumePathPtr;
+}
+
+/**
+ * @brief
+ * Invokes IOCTL_MOUNTMGR_QUERY_POINTS for testing, given
+ * the volume device name, and returns an allocated mount
+ * points buffer. This buffer must be freed by the caller
+ * via RtlFreeHeap(RtlGetProcessHeap(), ...) .
+ *
+ * This IOCTL only returns both the drive letter (if any)
+ * and the volume GUID symlink path, but does NOT return
+ * file-system mount reparse points.
+ **/
+static VOID
+Call_QueryPoints(
+    _In_ HANDLE MountMgrHandle,
+    _In_ PCWSTR NtVolumeName,
+    _Out_ PMOUNTMGR_MOUNT_POINTS* pMountPointsPtr)
+{
+    NTSTATUS Status;
+    ULONG Length;
+    IO_STATUS_BLOCK IoStatusBlock;
+    UNICODE_STRING VolumeName;
+    MOUNTMGR_MOUNT_POINTS MountPoints;
+    PMOUNTMGR_MOUNT_POINTS MountPointsPtr;
+    /*
+     * This variable is used to query the device name.
+     * It's based on MOUNTMGR_MOUNT_POINT (mountmgr.h).
+     * Doing it this way prevents memory allocation.
+     * The device name won't be longer.
+     */
+    struct
+    {
+        MOUNTMGR_MOUNT_POINT;
+        WCHAR DeviceName[256];
+    } DeviceName;
+
+
+    *pMountPointsPtr = NULL;
+
+    /* First, build the corresponding device name */
+    RtlInitUnicodeString(&VolumeName, NtVolumeName);
+    DeviceName.SymbolicLinkNameOffset = DeviceName.UniqueIdOffset = 0;
+    DeviceName.SymbolicLinkNameLength = DeviceName.UniqueIdLength = 0;
+    DeviceName.DeviceNameOffset = ((ULONG_PTR)&DeviceName.DeviceName - (ULONG_PTR)&DeviceName);
+    DeviceName.DeviceNameLength = VolumeName.Length;
+    RtlCopyMemory(&DeviceName.DeviceName, VolumeName.Buffer, VolumeName.Length);
+
+    /* Now, query the MountMgr for the mount points */
+    Status = NtDeviceIoControlFile(MountMgrHandle,
+                                   NULL, NULL, NULL,
+                                   &IoStatusBlock,
+                                   IOCTL_MOUNTMGR_QUERY_POINTS,
+                                   &DeviceName, sizeof(DeviceName),
+                                   &MountPoints, sizeof(MountPoints));
+
+    /* Check for unsupported device */
+    if (Status == STATUS_NO_MEDIA_IN_DEVICE || Status == STATUS_INVALID_DEVICE_REQUEST)
+    {
+        skip("Device '%S': Doesn't support MountMgr queries, Status 0x%08lx\n",
+             NtVolumeName, Status);
+        return;
+    }
+
+    /* The only tolerated failure here is buffer too small, which is expected */
+    ok(NT_SUCCESS(Status) || (Status == STATUS_BUFFER_OVERFLOW),
+       "Device '%S': IOCTL 0x%lx failed unexpectedly, Status 0x%08lx\n",
+       NtVolumeName, IOCTL_MOUNTMGR_QUERY_POINTS, Status);
+    if (!NT_SUCCESS(Status) && (Status != STATUS_BUFFER_OVERFLOW))
+    {
+        skip("Device '%S': Wrong Status\n", NtVolumeName);
+        return;
+    }
+
+    /* Compute the needed size to retrieve the mount points */
+    Length = MountPoints.Size;
+
+    /* Allocate the buffer and fill it with test pattern */
+    MountPointsPtr = RtlAllocateHeap(RtlGetProcessHeap(), 0, Length);
+    if (!MountPointsPtr)
+    {
+        skip("Device '%S': Failed to allocate buffer with size %lu)\n",
+             NtVolumeName, Length);
+        return;
+    }
+    RtlFillMemory(MountPointsPtr, Length, 0xCC);
+
+    /* Re-query the mount points with the proper size */
+    Status = NtDeviceIoControlFile(MountMgrHandle,
+                                   NULL, NULL, NULL,
+                                   &IoStatusBlock,
+                                   IOCTL_MOUNTMGR_QUERY_POINTS,
+                                   &DeviceName, sizeof(DeviceName),
+                                   MountPointsPtr, Length);
+    ok(NT_SUCCESS(Status),
+       "Device '%S': IOCTL 0x%lx failed unexpectedly, Status 0x%08lx\n",
+       NtVolumeName, IOCTL_MOUNTMGR_QUERY_POINTS, Status);
+
+    if (winetest_debug > 1)
+    {
+        trace("IOCTL_MOUNTMGR_QUERY_POINTS returned:\n"
+              "  Size: %lu\n"
+              "  NumberOfMountPoints: %lu\n",
+              MountPointsPtr->Size,
+              MountPointsPtr->NumberOfMountPoints);
+
+        trace("Buffer:\n");
+        DumpBuffer(MountPointsPtr, Length);
+        printf("\n");
+    }
+
+    /* Return the buffer */
+    *pMountPointsPtr = MountPointsPtr;
+}
+
+
+#define IS_DRIVE_LETTER_PFX(s) \
+  ((s)->Length >= 2*sizeof(WCHAR) && (s)->Buffer[0] >= 'A' && \
+   (s)->Buffer[0] <= 'Z' && (s)->Buffer[1] == ':')
+
+/* Differs from MOUNTMGR_IS_DRIVE_LETTER(): no '\DosDevices\' accounted for */
+#define IS_DRIVE_LETTER(s) \
+  (IS_DRIVE_LETTER_PFX(s) && (s)->Length == 2*sizeof(WCHAR))
+
+
+/**
+ * @brief   Tests the output of IOCTL_MOUNTMGR_QUERY_DOS_VOLUME_PATH.
+ **/
+static VOID
+Test_QueryDosVolumePath(
+    _In_ PCWSTR NtVolumeName,
+    _In_ PMOUNTMGR_VOLUME_PATHS VolumePath)
+{
+    UNICODE_STRING DosPath;
+
+    UNREFERENCED_PARAMETER(NtVolumeName);
+
+    /* The VolumePath should contain one NUL-terminated string (always there?),
+     * plus one final NUL-terminator */
+    ok(VolumePath->MultiSzLength >= 2 * sizeof(UNICODE_NULL),
+       "DOS volume path string too short (length: %lu)\n",
+       VolumePath->MultiSzLength / sizeof(WCHAR));
+    ok(VolumePath->MultiSz[VolumePath->MultiSzLength / sizeof(WCHAR) - 2] == UNICODE_NULL,
+       "Missing NUL-terminator (2)\n");
+    ok(VolumePath->MultiSz[VolumePath->MultiSzLength / sizeof(WCHAR) - 1] == UNICODE_NULL,
+       "Missing NUL-terminator (1)\n");
+
+    /* Build the result string */
+    // RtlInitUnicodeString(&DosPath, VolumePath->MultiSz);
+    DosPath.Length = (USHORT)VolumePath->MultiSzLength - 2 * sizeof(UNICODE_NULL);
+    DosPath.MaximumLength = DosPath.Length + sizeof(UNICODE_NULL);
+    DosPath.Buffer = VolumePath->MultiSz;
+
+    /* The returned DOS path is either a drive letter (*WITHOUT* any
+     * '\DosDevices\' prefix present) or a Win32 file-system reparse point
+     * path, or a volume GUID name in Win32 format, i.e. prefixed by '\\?\' */
+    ok(IS_DRIVE_LETTER_PFX(&DosPath) || MOUNTMGR_IS_DOS_VOLUME_NAME(&DosPath),
+       "Invalid DOS volume path returned '%s'\n", wine_dbgstr_us(&DosPath));
+}
+
+/**
+ * @brief   Tests the output of IOCTL_MOUNTMGR_QUERY_DOS_VOLUME_PATHS.
+ **/
+static VOID
+Test_QueryDosVolumePaths(
+    _In_ PCWSTR NtVolumeName,
+    _In_ PMOUNTMGR_VOLUME_PATHS VolumePaths,
+    _In_opt_ PMOUNTMGR_VOLUME_PATHS VolumePath)
+{
+    UNICODE_STRING DosPath;
+    PCWSTR pMountPoint;
+
+    /* The VolumePaths should contain zero or more NUL-terminated strings,
+     * plus one final NUL-terminator */
+
+    ok(VolumePaths->MultiSzLength >= sizeof(UNICODE_NULL),
+       "DOS volume path string too short (length: %lu)\n",
+       VolumePaths->MultiSzLength / sizeof(WCHAR));
+
+    /* Check for correct double-NUL-termination, if there is at least one string */
+    if (VolumePaths->MultiSzLength >= 2 * sizeof(UNICODE_NULL),
+        VolumePaths->MultiSz[0] != UNICODE_NULL)
+    {
+        ok(VolumePaths->MultiSz[VolumePaths->MultiSzLength / sizeof(WCHAR) - 2] == UNICODE_NULL,
+           "Missing NUL-terminator (2)\n");
+    }
+    /* Check for the final NUL-terminator */
+    ok(VolumePaths->MultiSz[VolumePaths->MultiSzLength / sizeof(WCHAR) - 1] == UNICODE_NULL,
+       "Missing NUL-terminator (1)\n");
+
+    if (winetest_debug > 1)
+    {
+        trace("\n%S =>\n", NtVolumeName);
+        for (pMountPoint = VolumePaths->MultiSz; *pMountPoint;
+             pMountPoint += wcslen(pMountPoint) + 1)
+        {
+            printf("  '%S'\n", pMountPoint);
+        }
+        printf("\n");
+    }
+
+    for (pMountPoint = VolumePaths->MultiSz; *pMountPoint;
+         pMountPoint += wcslen(pMountPoint) + 1)
+    {
+        /* The returned DOS path is either a drive letter (*WITHOUT* any
+         * '\DosDevices\' prefix present) or a Win32 file-system reparse point
+         * path, or a volume GUID name in Win32 format, i.e. prefixed by '\\?\' */
+        RtlInitUnicodeString(&DosPath, pMountPoint);
+        ok(IS_DRIVE_LETTER_PFX(&DosPath) || MOUNTMGR_IS_DOS_VOLUME_NAME(&DosPath),
+           "Invalid DOS volume path returned '%s'\n", wine_dbgstr_us(&DosPath));
+    }
+
+    /*
+     * If provided, verify that the single VolumePath is found at the
+     * first position in the volume paths list, *IF* this is a DOS path;
+     * otherwise if it's a Volume{GUID} path, this means there is no
+     * DOS path associated, and none is listed in the volume paths list.
+     */
+    if (VolumePath)
+    {
+        RtlInitUnicodeString(&DosPath, VolumePath->MultiSz);
+        if (IS_DRIVE_LETTER_PFX(&DosPath))
+        {
+            /*
+             * The single path is a DOS path (single drive letter or Win32
+             * file-system reparse point path). It has to be listed first
+             * in the volume paths list.
+             */
+            UNICODE_STRING FirstPath;
+            BOOLEAN AreEqual;
+
+            ok(VolumePaths->MultiSzLength >= 2 * sizeof(UNICODE_NULL),
+               "DOS VolumePaths list isn't long enough\n");
+            ok(*VolumePaths->MultiSz != UNICODE_NULL,
+               "Empty DOS VolumePaths list\n");
+
+            RtlInitUnicodeString(&FirstPath, VolumePaths->MultiSz);
+            AreEqual = RtlEqualUnicodeString(&DosPath, &FirstPath, FALSE);
+            ok(AreEqual, "DOS paths '%s' and '%s' are not the same!\n",
+               wine_dbgstr_us(&DosPath), wine_dbgstr_us(&FirstPath));
+        }
+        else if (MOUNTMGR_IS_DOS_VOLUME_NAME(&DosPath))
+        {
+            /*
+             * The single "DOS" path is actually a volume name. This means
+             * that it wasn't really mounted, and the volume paths list must
+             * be empty. It contains only the last NUL-terminator.
+             */
+            ok(VolumePaths->MultiSzLength == sizeof(UNICODE_NULL),
+               "DOS VolumePaths list isn't 1 WCHAR long\n");
+            ok(*VolumePaths->MultiSz == UNICODE_NULL,
+               "Non-empty DOS VolumePaths list\n");
+        }
+        else
+        {
+            /* The volume path is invalid (shouldn't happen) */
+            ok(FALSE, "Invalid DOS volume path returned '%s'\n", wine_dbgstr_us(&DosPath));
+        }
+    }
+}
+
+static BOOLEAN
+doesPathExistInMountPoints(
+    _In_ PMOUNTMGR_MOUNT_POINTS MountPoints,
+    _In_ PUNICODE_STRING DosPath)
+{
+    UNICODE_STRING DosDevicesPrefix = RTL_CONSTANT_STRING(L"\\DosDevices\\");
+    ULONG i;
+    BOOLEAN IsDosVolName;
+    BOOLEAN Found = FALSE;
+
+    IsDosVolName = MOUNTMGR_IS_DOS_VOLUME_NAME(DosPath);
+    /* Temporarily patch \\?\ to \??\ in DosPath for comparison */
+    if (IsDosVolName)
+        DosPath->Buffer[1] = L'?';
+
+    for (i = 0; i < MountPoints->NumberOfMountPoints; ++i)
+    {
+        UNICODE_STRING SymLink;
+
+        SymLink.Length = SymLink.MaximumLength = MountPoints->MountPoints[i].SymbolicLinkNameLength;
+        SymLink.Buffer = (PWCHAR)((ULONG_PTR)MountPoints + MountPoints->MountPoints[i].SymbolicLinkNameOffset);
+
+        if (IS_DRIVE_LETTER(DosPath))
+        {
+            if (RtlPrefixUnicodeString(&DosDevicesPrefix, &SymLink, FALSE))
+            {
+                /* Advance past the prefix */
+                SymLink.Length -= DosDevicesPrefix.Length;
+                SymLink.MaximumLength -= DosDevicesPrefix.Length;
+                SymLink.Buffer += DosDevicesPrefix.Length / sizeof(WCHAR);
+
+                Found = RtlEqualUnicodeString(DosPath, &SymLink, FALSE);
+            }
+        }
+        else if (/*MOUNTMGR_IS_DOS_VOLUME_NAME(DosPath) ||*/ // See above
+                 MOUNTMGR_IS_NT_VOLUME_NAME(DosPath))
+        {
+            Found = RtlEqualUnicodeString(DosPath, &SymLink, FALSE);
+        }
+        else
+        {
+            /* Just test for simple string comparison, the path should not be found */
+            Found = RtlEqualUnicodeString(DosPath, &SymLink, FALSE);
+        }
+
+        /* Stop searching if we've found something */
+        if (Found)
+            break;
+    }
+
+    /* Revert \??\ back to \\?\ */
+    if (IsDosVolName)
+        DosPath->Buffer[1] = L'\\';
+
+    return Found;
+}
+
+/**
+ * @brief   Tests the output of IOCTL_MOUNTMGR_QUERY_POINTS.
+ **/
+static VOID
+Test_QueryPoints(
+    _In_ PCWSTR NtVolumeName,
+    _In_ PMOUNTMGR_MOUNT_POINTS MountPoints,
+    _In_opt_ PMOUNTMGR_VOLUME_PATHS VolumePath,
+    _In_opt_ PMOUNTMGR_VOLUME_PATHS VolumePaths)
+{
+    UNICODE_STRING DosPath;
+    PCWSTR pMountPoint;
+    BOOLEAN ExpectedFound, Found;
+
+    if (winetest_debug > 1)
+    {
+        ULONG i;
+        trace("\n%S =>\n", NtVolumeName);
+        for (i = 0; i < MountPoints->NumberOfMountPoints; ++i)
+        {
+            UNICODE_STRING DevName, SymLink;
+
+            DevName.Length = DevName.MaximumLength = MountPoints->MountPoints[i].DeviceNameLength;
+            DevName.Buffer = (PWCHAR)((ULONG_PTR)MountPoints + MountPoints->MountPoints[i].DeviceNameOffset);
+
+            SymLink.Length = SymLink.MaximumLength = MountPoints->MountPoints[i].SymbolicLinkNameLength;
+            SymLink.Buffer = (PWCHAR)((ULONG_PTR)MountPoints + MountPoints->MountPoints[i].SymbolicLinkNameOffset);
+
+            printf("  '%s' -- '%s'\n", wine_dbgstr_us(&DevName), wine_dbgstr_us(&SymLink));
+        }
+        printf("\n");
+    }
+
+    /*
+     * The Win32 file-system reparse point paths are NOT listed amongst
+     * the mount points. Only the drive letter and the volume GUID name
+     * are, but in an NT format (using '\DosDevices\' or '\??\' prefixes).
+     */
+
+    if (VolumePath)
+    {
+        /* VolumePath can either be a drive letter (usual case), a Win32
+         * reparse point path (if the volume is mounted only with these),
+         * or a volume GUID name (if the volume is NOT mounted). */
+        RtlInitUnicodeString(&DosPath, VolumePath->MultiSz);
+        ExpectedFound = (IS_DRIVE_LETTER(&DosPath) || MOUNTMGR_IS_DOS_VOLUME_NAME(&DosPath));
+        Found = doesPathExistInMountPoints(MountPoints, &DosPath);
+        ok(Found == ExpectedFound,
+           "DOS path '%s' %sfound in the mount points list, expected %sto be found\n",
+           wine_dbgstr_us(&DosPath), Found ? "" : "NOT ", ExpectedFound ? "" : "NOT ");
+    }
+
+    if (VolumePaths)
+    {
+        /* VolumePaths only contains a drive letter (usual case) or a Win32
+         * reparse point path (if the volume is mounted only with these).
+         * If the volume is NOT mounted, VolumePaths does not list the
+         * volume GUID name, contrary to VolumePath. */
+        for (pMountPoint = VolumePaths->MultiSz; *pMountPoint;
+             pMountPoint += wcslen(pMountPoint) + 1)
+        {
+            /* Only the drive letter (but NOT the volume GUID name!) can be found in the list */
+            RtlInitUnicodeString(&DosPath, pMountPoint);
+            ExpectedFound = IS_DRIVE_LETTER(&DosPath);
+            Found = doesPathExistInMountPoints(MountPoints, &DosPath);
+            ok(Found == ExpectedFound,
+               "DOS path '%s' %sfound in the mount points list, expected %sto be found\n",
+               wine_dbgstr_us(&DosPath), Found ? "" : "NOT ", ExpectedFound ? "" : "NOT ");
+        }
+    }
+}
+
+/**
+ * @brief
+ * Tests the consistency of IOCTL_MOUNTMGR_QUERY_DOS_VOLUME_PATH,
+ * IOCTL_MOUNTMGR_QUERY_DOS_VOLUME_PATHS and IOCTL_MOUNTMGR_QUERY_POINTS.
+ **/
+static VOID
+Test_QueryDosVolumePathAndPaths(
+    _In_ HANDLE MountMgrHandle,
+    _In_ PCWSTR NtVolumeName)
+{
+    PMOUNTMGR_VOLUME_PATHS VolumePath = NULL;
+    PMOUNTMGR_VOLUME_PATHS VolumePaths = NULL;
+    PMOUNTMGR_MOUNT_POINTS MountPoints = NULL;
+
+    if (winetest_debug > 1)
+        trace("%S\n", NtVolumeName);
+
+    Call_QueryDosVolume_Path_Paths(MountMgrHandle,
+                                   NtVolumeName,
+                                   IOCTL_MOUNTMGR_QUERY_DOS_VOLUME_PATH,
+                                   &VolumePath);
+    if (VolumePath)
+        Test_QueryDosVolumePath(NtVolumeName, VolumePath);
+    else
+        skip("Device '%S': IOCTL_MOUNTMGR_QUERY_DOS_VOLUME_PATH failed\n", NtVolumeName);
+
+    Call_QueryDosVolume_Path_Paths(MountMgrHandle,
+                                   NtVolumeName,
+                                   IOCTL_MOUNTMGR_QUERY_DOS_VOLUME_PATHS,
+                                   &VolumePaths);
+    if (VolumePaths)
+        Test_QueryDosVolumePaths(NtVolumeName, VolumePaths, VolumePath);
+    else
+        skip("Device '%S': IOCTL_MOUNTMGR_QUERY_DOS_VOLUME_PATHS failed\n", NtVolumeName);
+
+    Call_QueryPoints(MountMgrHandle, NtVolumeName, &MountPoints);
+    if (MountPoints)
+        Test_QueryPoints(NtVolumeName, MountPoints, VolumePath, VolumePaths);
+    else
+        skip("Device '%S': IOCTL_MOUNTMGR_QUERY_POINTS failed\n", NtVolumeName);
+
+    if (MountPoints)
+        RtlFreeHeap(RtlGetProcessHeap(), 0, MountPoints);
+    if (VolumePaths)
+        RtlFreeHeap(RtlGetProcessHeap(), 0, VolumePaths);
+    if (VolumePath)
+        RtlFreeHeap(RtlGetProcessHeap(), 0, VolumePath);
+}
+
+
+START_TEST(QueryDosVolumePaths)
+{
+    HANDLE MountMgrHandle;
+    HANDLE hFindVolume;
+    WCHAR szVolumeName[MAX_PATH];
+
+    MountMgrHandle = GetMountMgrHandle();
+    if (!MountMgrHandle)
+    {
+        win_skip("MountMgr unavailable: %lu\n", GetLastError());
+        return;
+    }
+
+    hFindVolume = FindFirstVolumeW(szVolumeName, _countof(szVolumeName));
+    if (hFindVolume == INVALID_HANDLE_VALUE)
+        goto otherTests;
+    do
+    {
+        UNICODE_STRING VolumeName;
+        USHORT Length;
+
+        /*
+         * The Win32 FindFirst/NextVolumeW() functions convert the '\??\'
+         * prefix in '\??\Volume{...}' to '\\?\' and append a trailing
+         * backslash. Test this behaviour.
+         *
+         * NOTE: these functions actively filter out anything that is NOT
+         * '\??\Volume{...}' returned from IOCTL_MOUNTMGR_QUERY_POINTS.
+         * Thus, it also excludes mount-points specified as drive letters,
+         * like '\DosDevices\C:' .
+         */
+
+        RtlInitUnicodeString(&VolumeName, szVolumeName);
+        Length = VolumeName.Length / sizeof(WCHAR);
+        ok(Length >= 1 && VolumeName.Buffer[Length - 1] == L'\\',
+           "No trailing backslash found\n");
+
+        /* Remove the trailing backslash */
+        if (Length >= 1)
+        {
+            VolumeName.Length -= sizeof(WCHAR);
+            if (szVolumeName[Length - 1] == L'\\')
+                szVolumeName[Length - 1] = UNICODE_NULL;
+        }
+
+        ok(MOUNTMGR_IS_DOS_VOLUME_NAME(&VolumeName),
+           "Invalid DOS volume path returned '%s'\n", wine_dbgstr_us(&VolumeName));
+
+        /* Patch '\\?\' back to '\??\' to convert to an NT path */
+        if (szVolumeName[0] == L'\\' && szVolumeName[1] == L'\\' &&
+            szVolumeName[2] == L'?'  && szVolumeName[3] == L'\\')
+        {
+            szVolumeName[1] = L'?';
+        }
+
+        Test_QueryDosVolumePathAndPaths(MountMgrHandle, szVolumeName);
+    } while (FindNextVolumeW(hFindVolume, szVolumeName, _countof(szVolumeName)));
+    FindVolumeClose(hFindVolume);
+
+otherTests:
+    /* Test the drive containing SystemRoot */
+    wcscpy(szVolumeName, L"\\DosDevices\\?:");
+    szVolumeName[sizeof("\\DosDevices\\")-1] = SharedUserData->NtSystemRoot[0];
+    Test_QueryDosVolumePathAndPaths(MountMgrHandle, szVolumeName);
+
+    /* We are done */
+    CloseHandle(MountMgrHandle);
+}

--- a/modules/rostests/apitests/mountmgr/QueryPoints.c
+++ b/modules/rostests/apitests/mountmgr/QueryPoints.c
@@ -1,68 +1,75 @@
 /*
- * PROJECT:         ReactOS api tests
- * LICENSE:         GPLv2+ - See COPYING in the top level directory
- * PURPOSE:         Test for QueryPoints IOCTL
- * PROGRAMMER:      Pierre Schweitzer
+ * PROJECT:     ReactOS API Tests
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Test for IOCTL_MOUNTMGR_QUERY_POINTS
+ * COPYRIGHT:   Copyright 2019 Pierre Schweitzer <pierre@reactos.org>
  */
 
 #include "precomp.h"
 
 VOID
-TraceMountPoint(PMOUNTMGR_MOUNT_POINTS MountPoints,
-                PMOUNTMGR_MOUNT_POINT MountPoint)
+TraceMountPoint(
+    _In_ const MOUNTMGR_MOUNT_POINTS* MountPoints,
+    _In_ const MOUNTMGR_MOUNT_POINT* MountPoint)
 {
     trace("MountPoint: %p\n", MountPoint);
     trace("\tSymbolicOffset: %ld\n", MountPoint->SymbolicLinkNameOffset);
-    trace("\tSymbolicLinkName: %.*S\n", MountPoint->SymbolicLinkNameLength / sizeof(WCHAR), (PWSTR)((ULONG_PTR)MountPoints + MountPoint->SymbolicLinkNameOffset));
+    trace("\tSymbolicLinkName: %.*S\n",
+          MountPoint->SymbolicLinkNameLength / sizeof(WCHAR),
+          (PWCHAR)((ULONG_PTR)MountPoints + MountPoint->SymbolicLinkNameOffset));
     trace("\tDeviceOffset: %ld\n", MountPoint->DeviceNameOffset);
-    trace("\tDeviceName: %.*S\n", MountPoint->DeviceNameLength / sizeof(WCHAR), (PWSTR)((ULONG_PTR)MountPoints + MountPoint->DeviceNameOffset));
+    trace("\tDeviceName: %.*S\n",
+          MountPoint->DeviceNameLength / sizeof(WCHAR),
+          (PWCHAR)((ULONG_PTR)MountPoints + MountPoint->DeviceNameOffset));
 }
 
 START_TEST(QueryPoints)
 {
     BOOL Ret;
     HANDLE MountMgrHandle;
-    DWORD BytesReturned, Drives, i;
-    struct {
+    DWORD LastError, BytesReturned, Drives, i;
+    struct
+    {
         MOUNTMGR_MOUNT_POINT;
-        WCHAR Buffer[sizeof(L"\\DosDevice\\A:")];
+        WCHAR Buffer[sizeof("\\DosDevice\\A:")];
     } SinglePoint;
     MOUNTMGR_MOUNT_POINTS MountPoints;
     PMOUNTMGR_MOUNT_POINTS AllocatedPoints;
 
-    MountMgrHandle = CreateFileW(MOUNTMGR_DOS_DEVICE_NAME, 0,
-                                 FILE_SHARE_READ | FILE_SHARE_WRITE, NULL,
-                                 OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL,
-                                 INVALID_HANDLE_VALUE);
-    if (MountMgrHandle == INVALID_HANDLE_VALUE)
+    MountMgrHandle = GetMountMgrHandle();
+    if (!MountMgrHandle)
     {
-        win_skip("MountMgr unavailable: %lx\n", GetLastError());
+        win_skip("MountMgr unavailable: %lu\n", GetLastError());
         return;
     }
 
     ZeroMemory(&SinglePoint, sizeof(SinglePoint));
 
+    /* Retrieve the size needed to enumerate all the existing mount points */
     Ret = DeviceIoControl(MountMgrHandle, IOCTL_MOUNTMGR_QUERY_POINTS,
-                          &SinglePoint, sizeof(MOUNTMGR_MOUNT_POINT),
-                          &MountPoints, sizeof(MOUNTMGR_MOUNT_POINTS),
+                          &SinglePoint, sizeof(MOUNTMGR_MOUNT_POINT), // Size without the string.
+                          &MountPoints, sizeof(MountPoints),
                           &BytesReturned, NULL);
-    ok(Ret == FALSE, "IOCTL unexpectedly succeed\n");
-    ok(GetLastError() == ERROR_MORE_DATA, "Unexcepted failure: %lx\n", GetLastError());
+    LastError = GetLastError();
+    ok(Ret == FALSE, "IOCTL unexpectedly succeeded\n");
+    ok(LastError == ERROR_MORE_DATA, "Unexpected failure: %lu\n", LastError);
 
+    /* Allocate a suitably-sized buffer for the mount points */
     AllocatedPoints = RtlAllocateHeap(RtlGetProcessHeap(), 0, MountPoints.Size);
     if (AllocatedPoints == NULL)
     {
-        win_skip("Insufficiant memory\n");
+        skip("Insufficient memory\n");
     }
     else
     {
         AllocatedPoints->NumberOfMountPoints = 0;
 
+        /* Retrieve the list of all the existing mount points */
         Ret = DeviceIoControl(MountMgrHandle, IOCTL_MOUNTMGR_QUERY_POINTS,
-                              &SinglePoint, sizeof(MOUNTMGR_MOUNT_POINT),
+                              &SinglePoint, sizeof(MOUNTMGR_MOUNT_POINT), // Size without the string.
                               AllocatedPoints, MountPoints.Size,
                               &BytesReturned, NULL);
-        ok(Ret == TRUE, "IOCTL unexpectedly failed %lx\n", GetLastError());
+        ok(Ret == TRUE, "IOCTL unexpectedly failed: %lu\n", GetLastError());
 
         for (i = 0; i < AllocatedPoints->NumberOfMountPoints; ++i)
         {
@@ -72,40 +79,37 @@ START_TEST(QueryPoints)
         RtlFreeHeap(RtlGetProcessHeap(), 0, AllocatedPoints);
     }
 
+    /* Now, find the first unused drive letter */
     Drives = GetLogicalDrives();
     if (Drives == 0)
     {
-        win_skip("Drives map unavailable: %lx\n", GetLastError());
+        skip("Drives map unavailable: %lu\n", GetLastError());
         goto Done;
     }
-
-    for (i = 0; i < 26; i++)
+    for (i = 0; i <= 'Z'-'A'; ++i)
     {
         if (!(Drives & (1 << i)))
-        {
             break;
-        }
     }
-
-    if (i == 26)
+    if (i > 'Z'-'A')
     {
-        win_skip("All the drive letters are in use, skipping\n");
+        skip("All the drive letters are in use, skipping\n");
         goto Done;
     }
 
-    SinglePoint.SymbolicLinkNameOffset = sizeof(MOUNTMGR_MOUNT_POINT);
-    SinglePoint.SymbolicLinkNameLength = sizeof(L"\\DosDevice\\A:") - sizeof(UNICODE_NULL);
-    StringCbPrintfW((PWSTR)((ULONG_PTR)&SinglePoint + sizeof(MOUNTMGR_MOUNT_POINT)),
-                    sizeof(L"\\DosDevice\\A:"),
-                    L"\\DosDevice\\%C:",
-                    i + L'A');
+    /* Check that this drive letter is not an existing mount point */
+    SinglePoint.SymbolicLinkNameOffset = ((ULONG_PTR)&SinglePoint.Buffer - (ULONG_PTR)&SinglePoint);
+    SinglePoint.SymbolicLinkNameLength = sizeof(SinglePoint.Buffer) - sizeof(UNICODE_NULL);
+    StringCbPrintfW(SinglePoint.Buffer, sizeof(SinglePoint.Buffer),
+                    L"\\DosDevice\\%C:", L'A' + i);
 
     Ret = DeviceIoControl(MountMgrHandle, IOCTL_MOUNTMGR_QUERY_POINTS,
                           &SinglePoint, sizeof(SinglePoint),
-                          &MountPoints, sizeof(MOUNTMGR_MOUNT_POINTS),
+                          &MountPoints, sizeof(MountPoints),
                           &BytesReturned, NULL);
-    ok(Ret == FALSE, "IOCTL unexpectedly succeed\n");
-    ok(GetLastError() == ERROR_FILE_NOT_FOUND, "Unexcepted failure: %lx\n", GetLastError());
+    LastError = GetLastError();
+    ok(Ret == FALSE, "IOCTL unexpectedly succeeded\n");
+    ok(LastError == ERROR_FILE_NOT_FOUND, "Unexpected failure: %lu\n", LastError);
 
 Done:
     CloseHandle(MountMgrHandle);

--- a/modules/rostests/apitests/mountmgr/precomp.h
+++ b/modules/rostests/apitests/mountmgr/precomp.h
@@ -25,4 +25,9 @@ LPCSTR wine_dbgstr_us(const UNICODE_STRING *us);
 HANDLE
 GetMountMgrHandle(VOID);
 
+VOID
+DumpBuffer(
+    _In_ PVOID Buffer,
+    _In_ ULONG Length);
+
 /* EOF */

--- a/modules/rostests/apitests/mountmgr/precomp.h
+++ b/modules/rostests/apitests/mountmgr/precomp.h
@@ -1,12 +1,28 @@
-#ifndef _MOUNTMGR_APITEST_PRECOMP_H_
-#define _MOUNTMGR_APITEST_PRECOMP_H_
+/*
+ * PROJECT:     ReactOS API Tests
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Precompiled header
+ * COPYRIGHT:   Copyright 2019 Pierre Schweitzer <pierre@reactos.org>
+ *              Copyright 2025 Hermès Bélusca-Maïto <hermes.belusca-maito@reactos.org>
+ */
+
+#pragma once
 
 #define WIN32_NO_STATUS
-
 #include <apitest.h>
-#include <strsafe.h>
-#include <ntstatus.h>
-#include <mountmgr.h>
+
+#define NTOS_MODE_USER
+#include <ndk/iofuncs.h>
 #include <ndk/rtlfuncs.h>
 
-#endif /* _MOUNTMGR_APITEST_PRECOMP_H_ */
+#include <mountmgr.h>
+#include <strsafe.h>
+
+/* utils.c */
+
+LPCSTR wine_dbgstr_us(const UNICODE_STRING *us);
+
+HANDLE
+GetMountMgrHandle(VOID);
+
+/* EOF */

--- a/modules/rostests/apitests/mountmgr/testlist.c
+++ b/modules/rostests/apitests/mountmgr/testlist.c
@@ -1,10 +1,12 @@
 #define STANDALONE
 #include <apitest.h>
 
+extern void func_QueryDosVolumePaths(void);
 extern void func_QueryPoints(void);
 
 const struct test winetest_testlist[] =
 {
+    { "QueryDosVolumePaths", func_QueryDosVolumePaths },
     { "QueryPoints", func_QueryPoints },
     { 0, 0 }
 };

--- a/modules/rostests/apitests/mountmgr/utils.c
+++ b/modules/rostests/apitests/mountmgr/utils.c
@@ -1,0 +1,49 @@
+/*
+ * PROJECT:     ReactOS API Tests
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Utility functions
+ * COPYRIGHT:   Copyright 2025 Hermès Bélusca-Maïto <hermes.belusca-maito@reactos.org>
+ */
+
+#include "precomp.h"
+
+LPCSTR wine_dbgstr_us(const UNICODE_STRING *us)
+{
+    if (!us) return "(null)";
+    return wine_dbgstr_wn(us->Buffer, us->Length / sizeof(WCHAR));
+}
+
+/**
+ * @brief
+ * Retrieves a handle to the MountMgr controlling device.
+ * The handle should be closed with NtClose() once it is no longer in use.
+ **/
+HANDLE
+GetMountMgrHandle(VOID)
+{
+    NTSTATUS Status;
+    UNICODE_STRING MountMgrDevice;
+    OBJECT_ATTRIBUTES ObjectAttributes;
+    IO_STATUS_BLOCK IoStatusBlock;
+    HANDLE MountMgrHandle = NULL;
+
+    RtlInitUnicodeString(&MountMgrDevice, MOUNTMGR_DEVICE_NAME);
+    InitializeObjectAttributes(&ObjectAttributes,
+                               &MountMgrDevice,
+                               OBJ_CASE_INSENSITIVE,
+                               NULL,
+                               NULL);
+    Status = NtOpenFile(&MountMgrHandle,
+                        FILE_READ_ATTRIBUTES | SYNCHRONIZE,
+                        &ObjectAttributes,
+                        &IoStatusBlock,
+                        FILE_SHARE_READ | FILE_SHARE_WRITE,
+                        FILE_SYNCHRONOUS_IO_NONALERT);
+    if (!NT_SUCCESS(Status))
+    {
+        winetest_print("NtOpenFile(%s) failed, Status 0x%08lx\n",
+                       wine_dbgstr_us(&MountMgrDevice), Status);
+    }
+
+    return MountMgrHandle;
+}

--- a/modules/rostests/apitests/mountmgr/utils.c
+++ b/modules/rostests/apitests/mountmgr/utils.c
@@ -47,3 +47,56 @@ GetMountMgrHandle(VOID)
 
     return MountMgrHandle;
 }
+
+VOID
+DumpBuffer(
+    _In_ PVOID Buffer,
+    _In_ ULONG Length)
+{
+#define LINE_SIZE   (75 + 2)
+    ULONG i;
+    PBYTE Ptr1, Ptr2;
+    CHAR  LineBuffer[LINE_SIZE];
+    PCHAR Line;
+    ULONG LineSize;
+
+    Ptr1 = Ptr2 = Buffer;
+    while ((ULONG_PTR)Buffer + Length - (ULONG_PTR)Ptr1 > 0)
+    {
+        Ptr1 = Ptr2;
+        Line = LineBuffer;
+
+        /* Print the address */
+        Line += _snprintf(Line, LINE_SIZE + LineBuffer - Line, "%08Ix ", (ULONG_PTR)Ptr1);
+
+        /* Print up to 16 bytes... */
+
+        /* ... in hexadecimal form first... */
+        i = 0;
+        while (i++ <= 0x0F && ((ULONG_PTR)Buffer + Length - (ULONG_PTR)Ptr1 > 0))
+        {
+            Line += _snprintf(Line, LINE_SIZE + LineBuffer - Line, " %02x", *Ptr1);
+            ++Ptr1;
+        }
+
+        /* ... align with spaces if needed... */
+        RtlFillMemory(Line, (0x0F + 2 - i) * 3 + 2, ' ');
+        Line += (0x0F + 2 - i) * 3 + 2;
+
+        /* ... then in character form. */
+        i = 0;
+        while (i++ <= 0x0F && ((ULONG_PTR)Buffer + Length - (ULONG_PTR)Ptr2 > 0))
+        {
+            *Line++ = ((*Ptr2 >= 0x20 && *Ptr2 <= 0x7E) || (*Ptr2 >= 0x80 && *Ptr2 < 0xFF) ? *Ptr2 : '.');
+            ++Ptr2;
+        }
+
+        /* Newline */
+        *Line++ = '\r';
+        *Line++ = '\n';
+
+        /* Finally display the line */
+        LineSize = Line - LineBuffer;
+        printf("%.*s", (int)LineSize, LineBuffer);
+    }
+}

--- a/ntoskrnl/io/iomgr/volume.c
+++ b/ntoskrnl/io/iomgr/volume.c
@@ -1328,7 +1328,7 @@ IoVolumeDeviceToDosName(
         return Status;
     }
 
-    /* Now, query the MountMgr for the DOS path */
+    /* Retrieve the MountMgr controlling device */
     RtlInitUnicodeString(&MountMgrDevice, MOUNTMGR_DEVICE_NAME);
     Status = IoGetDeviceObjectPointer(&MountMgrDevice, FILE_READ_ATTRIBUTES,
                                       &FileObject, &DeviceObject);
@@ -1337,6 +1337,7 @@ IoVolumeDeviceToDosName(
         return Status;
     }
 
+    /* Now, query the MountMgr for the DOS path */
     KeInitializeEvent(&Event, NotificationEvent, FALSE);
     Irp = IoBuildDeviceIoControlRequest(IOCTL_MOUNTMGR_QUERY_DOS_VOLUME_PATH,
                                         DeviceObject,
@@ -1362,7 +1363,7 @@ IoVolumeDeviceToDosName(
         goto Quit;
     }
 
-    /* Compute the needed size to store the DOS name.
+    /* Compute the needed size to store the DOS path.
      * Even if MOUNTMGR_VOLUME_PATHS allows bigger name lengths
      * than MAXUSHORT, we can't use them, because we have to return
      * this in an UNICODE_STRING that stores length in a USHORT. */
@@ -1373,8 +1374,8 @@ IoVolumeDeviceToDosName(
         goto Quit;
     }
 
-    /* Reallocate the memory, even in case of success, because
-     * that's the buffer that will be returned to the caller */
+    /* Allocate the buffer, even in case of success,
+     * because it is returned to the caller */
     VolumePathPtr = ExAllocatePoolWithTag(PagedPool, Length, TAG_DEV2DOS);
     if (!VolumePathPtr)
     {


### PR DESCRIPTION
## Purpose & Proposed changes

The VolumePath buffer returned by `IOCTL_MOUNTMGR_QUERY_DOS_VOLUME_PATH` contains one string stored as a multi-NUL-terminated string, whose total length is given by its `MultiSzLength` member.

The DosName UNICODE_STRING just returns the (single) string as a normal NUL-terminated string. So, we need to remove the two NUL-terminators from the `MultiSzLength` count to retrieve the correct length.

See commit 69e98d56715ade9d5f0ee350730cab9f9f8c3d93.

- Add tests for mountmgr handling of `IOCTL_MOUNTMGR_QUERY_DOS_VOLUME_PATH` and `IOCTL_MOUNTMGR_QUERY_DOS_VOLUME_PATHS`.
- Add tests for `IoVolumeDeviceToDosName()` (which uses `IOCTL_MOUNTMGR_QUERY_DOS_VOLUME_PATH`).
- Various fixes for these modules.

## Test results

### _NOTE: The number of executed tests depend on the number of volumes present on the system and whether they are mounted with a drive letter, or with a filesystem reparse point, or just with the volume GUID._

- Test VBox: https://reactos.org/testman/compare.php?ids=99948,99960,99962,99964
- Test KVM: https://reactos.org/testman/compare.php?ids=99949,99959,99963,99965
- Test KVM_x64: https://reactos.org/testman/compare.php?ids=99951,99961,99966,99969

![image](https://github.com/user-attachments/assets/9c781f29-ed4a-4415-807a-a60767554f2a)
(Results are from Test VBox, the other bots show the same.)

### Observations

1. While the new `IoVolumeDeviceToDosName` tests appear at first to succeed, the new tests for mountmgr `IOCTL_MOUNTMGR_QUERY_DOS_VOLUME_PATH(S)` fail:
  **kmtest:IoVolume**: 8 tests, 0 failures.
  **mountmgr:QueryDosVolumePaths**: 61 tests, 12 failures.

2. Fixing mountmgr fixes its corresponding tests (and runs 6 new ones), but make some of the `IoVolumeDeviceToDosName` tests now to fail:
  **kmtest:IoVolume**: 8 tests, 2 failures.
  **mountmgr:QueryDosVolumePaths**: 67 tests, 0 failures.

3. `IoVolumeDeviceToDosName()` needed its own fixes and this makes its tests to now pass as well:
  **kmtest:IoVolume**: 7 tests, 0 failures.
  **mountmgr:QueryDosVolumePaths**: 67 tests, 0 failures.

4. Observe that between the points 1 (or 2) and 3, the number of kmtest:IoVolume tests decreased: this is because the returned DOS name for the mounted single volume (on our testbots), is now correct: the `C:` drive letter, instead of a volume GUID. Because the kmtest:IoVolume tests perform a different number of validation tests depending on whether the returned DOS name is a drive letter, or a volume GUID (which happens only in the case the drive is NOT mounted), this explains the observation:
https://reactos.org/testman/diff.php?id1=79176551&id2=79182177&type=1&strip=0
```diff
-IoVolume.c:57: DOS name for \Device\HarddiskVolume1 is \\?\Volume{b3bc3fc0-d771-11ef-887c-806e6f6e6963}
+IoVolume.c:57: DOS name for \Device\HarddiskVolume1 is C:
 ...
-IoVolume: 8 tests executed (0 marked as todo, 0 failures), 0 skipped.
+IoVolume: 7 tests executed (0 marked as todo, 0 failures), 0 skipped.
```

### On Windows:

Drives used in the Windows 2003 test:
![win2k3_drives_list](https://github.com/user-attachments/assets/23b0466a-5a17-47d2-b73c-297bdee84a35)

Windows 2003:
![win2k3_mountmgr_iovolume_success](https://github.com/user-attachments/assets/26862613-619b-4d9c-9206-aead2312e44d)

Windows 7 showing only the mountmgr results (and with a different number of mounted volumes):
![win7_mountmgr_success](https://github.com/user-attachments/assets/5e33a009-0932-4e8b-a080-48ee54032c50)
