### PR TITLE
[SHELL32] Don't add folder verbs to non-folder RegItems

### DIFF
--- a/dll/win32/shell32/folders/CRegFolder.cpp
+++ b/dll/win32/shell32/folders/CRegFolder.cpp
@@ -109,7 +109,13 @@ HRESULT CGuidItemContextMenu_CreateInstance(PCIDLIST_ABSOLUTE pidlFolder,
             CoTaskMemFree(pwszCLSID);
         }
     }
-    AddClassKeyToArray(L"Folder", hKeys, &cKeys);
+    UINT folderKey = TRUE;
+    SFGAOF att = SFGAO_FOLDER;
+    if (psf && SUCCEEDED(psf->GetAttributesOf(1, apidl, &att)))
+        folderKey = (att & SFGAO_FOLDER);
+
+    if (folderKey)
+        AddClassKeyToArray(L"Folder", hKeys, &cKeys);
 
     return CDefFolderMenu_Create2(pidlFolder, hwnd, cidl, apidl, psf, RegFolderContextMenuCallback, cKeys, hKeys, ppcm);
 }
@@ -390,10 +396,7 @@ HRESULT CRegFolder::GetGuidItemAttributes (LPCITEMIDLIST pidl, LPDWORD pdwAttrib
     }
 
     /* In any case, links can be created */
-    if (*pdwAttributes == NULL)
-    {
-        *pdwAttributes |= (dwAttributes & SFGAO_CANLINK);
-    }
+    *pdwAttributes |= (dwAttributes & SFGAO_CANLINK);
     return S_OK;
 }
 

--- a/dll/win32/shell32/folders/CRegFolder.cpp
+++ b/dll/win32/shell32/folders/CRegFolder.cpp
@@ -97,24 +97,14 @@ HRESULT CGuidItemContextMenu_CreateInstance(PCIDLIST_ABSOLUTE pidlFolder,
     GUID *pGuid = _ILGetGUIDPointer(apidl[0]);
     if (pGuid)
     {
-        LPOLESTR pwszCLSID;
         WCHAR key[60];
-
         wcscpy(key, L"CLSID\\");
-        HRESULT hr = StringFromCLSID(*pGuid, &pwszCLSID);
-        if (hr == S_OK)
-        {
-            wcscpy(&key[6], pwszCLSID);
-            AddClassKeyToArray(key, hKeys, &cKeys);
-            CoTaskMemFree(pwszCLSID);
-        }
+        StringFromGUID2(*pGuid, &key[6], 39);
+        AddClassKeyToArray(key, hKeys, &cKeys);
     }
-    UINT folderKey = TRUE;
-    SFGAOF att = SFGAO_FOLDER;
-    if (psf && SUCCEEDED(psf->GetAttributesOf(1, apidl, &att)))
-        folderKey = (att & SFGAO_FOLDER);
 
-    if (folderKey)
+    SFGAOF att = (psf && cidl) ? SHGetAttributes(psf, apidl[0], SFGAO_FOLDER) : 0;
+    if (att & SFGAO_FOLDER)
         AddClassKeyToArray(L"Folder", hKeys, &cKeys);
 
     return CDefFolderMenu_Create2(pidlFolder, hwnd, cidl, apidl, psf, RegFolderContextMenuCallback, cKeys, hKeys, ppcm);

--- a/dll/win32/shell32/folders/CRegFolder.cpp
+++ b/dll/win32/shell32/folders/CRegFolder.cpp
@@ -103,7 +103,14 @@ HRESULT CGuidItemContextMenu_CreateInstance(PCIDLIST_ABSOLUTE pidlFolder,
         AddClassKeyToArray(key, hKeys, &cKeys);
     }
 
-    SFGAOF att = (psf && cidl) ? SHGetAttributes(psf, apidl[0], SFGAO_FOLDER) : 0;
+    // FIXME: CRegFolder should be aggregated by its outer folder and should
+    // provide the attributes for all required non-registry folders.
+    // It currently does not so we have to ask the outer folder ourself so
+    // that we get the correct attributes for My Computer etc.
+    CComPtr<IShellFolder> pOuterSF;
+    SHBindToObject(NULL, pidlFolder, IID_PPV_ARG(IShellFolder, &pOuterSF));
+
+    SFGAOF att = (psf && cidl) ? SHGetAttributes(pOuterSF ? pOuterSF.p : psf, apidl[0], SFGAO_FOLDER) : 0;
     if (att & SFGAO_FOLDER)
         AddClassKeyToArray(L"Folder", hKeys, &cKeys);
 

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -245,20 +245,16 @@ Shell_DisplayNameOf(
 DWORD
 SHGetAttributes(_In_ IShellFolder *psf, _In_ LPCITEMIDLIST pidl, _In_ DWORD dwAttributes)
 {
-    LPCITEMIDLIST pidlLast;
-
-    if (psf)
-    {
-        psf->AddRef();
-        pidlLast = pidl;
-    }
-    else
-    {
-        SHBindToParent(pidl, IID_PPV_ARG(IShellFolder, &psf), &pidlLast);
-    }
+    LPCITEMIDLIST pidlLast = pidl;
+    IShellFolder *release = NULL;
 
     if (!psf)
-        return 0;
+    {
+        SHBindToParent(pidl, IID_PPV_ARG(IShellFolder, &psf), &pidlLast);
+        if (!psf)
+            return 0;
+        release = psf;
+    }
 
     DWORD oldAttrs = dwAttributes;
     if (FAILED(psf->GetAttributesOf(1, &pidlLast, &dwAttributes)))
@@ -276,9 +272,8 @@ SHGetAttributes(_In_ IShellFolder *psf, _In_ LPCITEMIDLIST pidl, _In_ DWORD dwAt
         dwAttributes |= SFGAO_STORAGEANCESTOR;
     }
 
-    if (psf)
-        psf->Release();
-
+    if (release)
+        release->Release();
     return dwAttributes;
 }
 


### PR DESCRIPTION
RegItems that pretend to be files should not have Folder verbs

![Before/After](https://github.com/reactos/reactos/assets/138629473/246501ba-c232-4393-a560-fb4004f3c9a7)
