### PR TITLE
[REGEDIT] Fix splitter move redraw issues.

### DIFF
--- a/base/applications/regedit/childwnd.c
+++ b/base/applications/regedit/childwnd.c
@@ -137,7 +137,7 @@ static void finish_splitbar(HWND hWnd, int x)
     GetClientRect(hWnd, &rt);
     g_pChildWnd->nSplitPos = x;
     ResizeWnd(rt.right, rt.bottom);
-    InvalidateRect(hWnd, &rt, FALSE); // HACK: See CORE-CORE-19576
+    InvalidateRect(hWnd, &rt, FALSE); // HACK: See CORE-19576
     ReleaseCapture();
 }
 

--- a/base/applications/regedit/childwnd.c
+++ b/base/applications/regedit/childwnd.c
@@ -137,6 +137,7 @@ static void finish_splitbar(HWND hWnd, int x)
     GetClientRect(hWnd, &rt);
     g_pChildWnd->nSplitPos = x;
     ResizeWnd(rt.right, rt.bottom);
+    InvalidateRect(hWnd, &rt, FALSE);
     ReleaseCapture();
 }
 

--- a/base/applications/regedit/childwnd.c
+++ b/base/applications/regedit/childwnd.c
@@ -137,7 +137,7 @@ static void finish_splitbar(HWND hWnd, int x)
     GetClientRect(hWnd, &rt);
     g_pChildWnd->nSplitPos = x;
     ResizeWnd(rt.right, rt.bottom);
-    InvalidateRect(hWnd, &rt, FALSE);
+    InvalidateRect(hWnd, &rt, FALSE); // HACK: See CORE-CORE-19576
     ReleaseCapture();
 }
 


### PR DESCRIPTION
CORE-19576

## Purpose

_Fix regedit's splitter redraw issues._

JIRA issue: [CORE-19576](https://jira.reactos.org/browse/CORE-19576)

## Proposed changes

_Add InvalidateRect to redraw right pane on splitter move._