### PR TITLE
[SHELL32] Folder options: Enable visual styles for RunDLL

### DIFF
--- a/dll/win32/shell32/dialogs/folder_options.cpp
+++ b/dll/win32/shell32/dialogs/folder_options.cpp
@@ -238,7 +238,6 @@ ShowFolderOptionsDialogThreadProc(LPVOID param)
     HPROPSHEETPAGE hppages[3];
     HPROPSHEETPAGE hpage;
     UINT num_pages = 0;
-    WCHAR szOptions[100];
 
     hpage = SH_CreatePropertySheetPage(IDD_FOLDER_OPTIONS_GENERAL, FolderOptionsGeneralDlg, 0, NULL);
     if (hpage)
@@ -251,10 +250,6 @@ ShowFolderOptionsDialogThreadProc(LPVOID param)
     hpage = SH_CreatePropertySheetPage(IDD_FOLDER_OPTIONS_FILETYPES, FolderOptionsFileTypesDlg, 0, NULL);
     if (hpage)
         hppages[num_pages++] = hpage;
-
-    szOptions[0] = 0;
-    LoadStringW(shell32_hInstance, IDS_FOLDER_OPTIONS, szOptions, _countof(szOptions));
-    szOptions[_countof(szOptions) - 1] = 0;
 
     // the stub window to hide taskbar button
     DWORD style = WS_DISABLED | WS_CLIPSIBLINGS | WS_CAPTION;
@@ -272,8 +267,9 @@ ShowFolderOptionsDialogThreadProc(LPVOID param)
     pinfo.hwndParent = stub;
     pinfo.nPages = num_pages;
     pinfo.phpage = hppages;
+    pinfo.hInstance = shell32_hInstance;
     pinfo.pszIcon = MAKEINTRESOURCEW(IDI_SHELL_FOLDER_OPTIONS);
-    pinfo.pszCaption = szOptions;
+    pinfo.pszCaption = MAKEINTRESOURCEW(IDS_FOLDER_OPTIONS);
     pinfo.pfnCallback = PropSheetProc;
     pinfo.nStartPage = PtrToUlong(param);
 

--- a/dll/win32/shell32/shell32.rc
+++ b/dll/win32/shell32/shell32.rc
@@ -78,6 +78,7 @@ END
 #include "rgs_res.rc"
 
 #include <reactos/manifest_dll.rc>
+#include <reactos/manifest_hosted.rc>
 
 1 TYPELIB "shell32_shldisp.tlb"
 


### PR DESCRIPTION
## Proposed changes
- Enable visual styles for RunDLL using ~ReactOS default DLL manifest~ manifest resource ID 123.
- Dialog: Use `MAKEINTRESOURCE` instead of `LoadString`

Before:
![ReactOS_Before](https://github.com/reactos/reactos/assets/86486978/524d0dfa-4027-4301-a1e7-fe464e67bf9a)

After:
![ReactOS_After](https://github.com/reactos/reactos/assets/86486978/4ffc8227-f4b5-461a-b319-e4a3a92cc18c)