### PR TITLE
Revert "[BOOTDATA][INF] Add Tahoma entry to Asian FontLink"

### DIFF
--- a/boot/bootdata/hivesft.inf
+++ b/boot/bootdata/hivesft.inf
@@ -639,74 +639,61 @@ HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontLink\SystemLink","MingLiU
 	"micross.ttf,Microsoft Sans Serif",\
 	"simsun.ttc,SimSun",\
 	"msmincho.ttc,MS Mincho",\
-	"batang.ttc,BatangChe",\
-	"tahoma.ttf,Tahoma"
+	"batang.ttc,BatangChe"
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontLink\SystemLink","SimSun",0x00010000,\
 	"micross.ttf,Microsoft Sans Serif",\
 	"mingliu.ttc,PMingLiU",\
 	"msmincho.ttc,MS PMincho",\
-	"batang.ttc,Batang",\
-	"tahoma.ttf,Tahoma"
+	"batang.ttc,Batang"
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontLink\SystemLink","PMingLiU",0x00010000,\
 	"micross.ttf,Microsoft Sans Serif",\
 	"simsun.ttc,SimSun",\
 	"msmincho.ttc,MS PMincho",\
-	"BATANG.TTC,Batang",\
-	"tahoma.ttf,Tahoma"
+	"BATANG.TTC,Batang"
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontLink\SystemLink","NSimSun",0x00010000,\
 	"mingliu.ttc,PMingLiU",\
 	"msmincho.ttc,MS Mincho",\
-	"batang.ttc,BatangChe",\
-	"tahoma.ttf,Tahoma"
+	"batang.ttc,BatangChe"
 
 ; FontLink (Japanese to others)
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontLink\SystemLink","MS Gothic",0x00010000,\
 	"mingliu.ttc,MingLiU",\
 	"simsun.ttc,SimSun",\
 	"gulim.ttc,GulimChe"
-	"tahoma.ttf,Tahoma"
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontLink\SystemLink","MS Mincho",0x00010000,\
 	"mingliu.ttc,MingLiU",\
 	"simsun.ttc,SimSun",\
-	"batang.ttc,Batang",\
-	"tahoma.ttf,Tahoma"
+	"batang.ttc,Batang"
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontLink\SystemLink","MS PGothic",0x00010000,\
 	"mingliu.ttc,PMingLiU",\
 	"simsun.ttc,SimSun",\
-	"gulim.ttc,Gulim",\
-	"tahoma.ttf,Tahoma"
+	"gulim.ttc,Gulim"
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontLink\SystemLink","MS PMincho",0x00010000,\
 	"mingliu.ttc,PMingLiU",\
 	"simsun.ttc,SimSun",\
-	"batang.ttc,Batang",\
-	"tahoma.ttf,Tahoma"
+	"batang.ttc,Batang"
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontLink\SystemLink","MS UI Gothic",0x00010000,\
 	"simsun.ttc,SimSun",\
 	"gulim.ttc,Gulim",\
-	"mingliu.ttc,PMingLiU",\
-	"tahoma.ttf,Tahoma"
+	"mingliu.ttc,PMingLiU"
 
 ; FontLink (Korean to others)
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontLink\SystemLink","Batang",0x00010000,\
 	"msmincho.ttc,MS PMincho",\
 	"mingliu.ttc,PMingLiU",\
-	"simsun.ttc,SimSun",\
-	"tahoma.ttf,Tahoma"
+	"simsun.ttc,SimSun"
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontLink\SystemLink","BatangChe",0x00010000,\
 	"msmincho.ttc,MS Mincho",\
 	"mingliu.ttc,MingLiU",\
-	"simsun.ttc,SimSun",\
-	"tahoma.ttf,Tahoma"
+	"simsun.ttc,SimSun"
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontLink\SystemLink","Gulim",0x00010000,\
 	"micross.ttf,Microsoft Sans Serif",\
 	"msgothic.ttc,MS UI Gothic",\
-	"mingliu.ttc,PMingLiU",\
-	"tahoma.ttf,Tahoma"
+	"mingliu.ttc,PMingLiU"
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontLink\SystemLink","GulimChe",0x00010000,\
 	"msgothic.ttc,MS Gothic",\
 	"mingliu.ttc,MingLiU",\
-	"simsun.ttc,SimSun",\
-	"tahoma.ttf,Tahoma"
+	"simsun.ttc,SimSun"
 
 ; Win32k GRE initialization
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\GRE_Initialize",,0x00000012


### PR DESCRIPTION
Reverts reactos/reactos#6985
JIRA issue: [CORE-9616](https://jira.reactos.org/browse/CORE-9616)
Forgot a comma and a backslash.