### PR TITLE
[SHELL32][CONTROL][NCPA] Add file browser fallback

### DIFF
--- a/base/applications/control/control.c
+++ b/base/applications/control/control.c
@@ -74,15 +74,16 @@ OpenShellFolder(LPWSTR lpFolderCLSID)
     WCHAR szParameters[MAX_PATH];
 
     /*
-     * Open a shell folder using "explorer.exe". The passed CLSIDs
-     * are all subfolders of the "Control Panel" shell folder.
+     * Open a shell folder using "explorer.exe". If Explorer shell is not
+     * available, use ReactOS's alternative file browser instead.
+     * The passed CLSIDs are all subfolders of the "Control Panel" shell folder.
      */
     StringCbCopyW(szParameters, sizeof(szParameters), L"/n,::{20D04FE0-3AEA-1069-A2D8-08002B30309D}\\::{21EC2020-3AEA-1069-A2DD-08002B30309D}");
     StringCbCatW(szParameters, sizeof(szParameters), lpFolderCLSID);
 
     return (INT_PTR)ShellExecuteW(NULL,
                                   L"open",
-                                  L"explorer.exe",
+                                  GetShellWindow() ? L"explorer.exe" : L"filebrowser.exe",
                                   szParameters,
                                   NULL,
                                   SW_SHOWDEFAULT) > 32;

--- a/dll/cpl/ncpa/CMakeLists.txt
+++ b/dll/cpl/ncpa/CMakeLists.txt
@@ -6,5 +6,5 @@ add_library(ncpa MODULE
     ${CMAKE_CURRENT_BINARY_DIR}/ncpa.def)
 
 set_module_type(ncpa cpl UNICODE)
-add_importlibs(ncpa advapi32 shell32 msvcrt kernel32)
+add_importlibs(ncpa user32 advapi32 shell32 msvcrt kernel32)
 add_cd_file(TARGET ncpa DESTINATION reactos/system32 FOR all)

--- a/dll/cpl/ncpa/ncpa.c
+++ b/dll/cpl/ncpa/ncpa.c
@@ -20,7 +20,10 @@ DisplayApplet(VOID)
 {
 	WCHAR szParameters[] = L"/n,::{20D04FE0-3AEA-1069-A2D8-08002B30309D}\\::{21EC2020-3AEA-1069-A2DD-08002B30309D}\\::{7007ACC7-3202-11D1-AAD2-00805FC1270E}";
 
-	return (INT_PTR) ShellExecuteW(NULL, L"open", L"explorer.exe", szParameters, NULL, SW_SHOWDEFAULT) > 32;
+	/* NOTE: If Explorer shell is not available, use ReactOS's alternative file browser instead */
+	return (INT_PTR) ShellExecuteW(NULL, L"open",
+	                               GetShellWindow() ? L"explorer.exe" : L"filebrowser.exe",
+								   szParameters, NULL, SW_SHOWDEFAULT) > 32;
 }
 
 /* Control Panel Callback */

--- a/dll/win32/shell32/wine/control.c
+++ b/dll/win32/shell32/wine/control.c
@@ -732,9 +732,10 @@ static	void	Control_DoWindow(CPanel* panel, HWND hWnd, HINSTANCE hInst)
 #else
 static	void	Control_DoWindow(CPanel* panel, HWND hWnd, HINSTANCE hInst)
 {
+    /* NOTE: If Explorer shell is not available, use ReactOS's alternative file browser instead */
     ShellExecuteW(NULL,
                   L"open",
-                  L"explorer.exe",
+                  GetShellWindow() ? L"explorer.exe" : L"filebrowser.exe",
                   L"::{20D04FE0-3AEA-1069-A2D8-08002B30309D}\\::{21EC2020-3AEA-1069-A2DD-08002B30309D}",
                   NULL,
                   SW_SHOWDEFAULT);


### PR DESCRIPTION
## Purpose
Fix some Control Panel functionalities not working when explorer.exe is not running.

JIRA issue: [CORE-19648](https://jira.reactos.org/browse/CORE-19648)

## Proposed changes
If Explorer shell is not available, use ReactOS's alternative file browser instead.