### PR TITLE
[RAPPS] Protect database update with a mutex

### DIFF
--- a/base/applications/rapps/gui.cpp
+++ b/base/applications/rapps/gui.cpp
@@ -304,6 +304,7 @@ CMainWindow::CheckAvailable()
 {
     if (m_Db->GetAvailableCount() == 0)
     {
+        CUpdateDatabaseMutex lock;
         m_Db->RemoveCached();
         m_Db->UpdateAvailable();
     }
@@ -591,9 +592,12 @@ CMainWindow::OnCommand(WPARAM wParam, LPARAM lParam)
                 break;
 
             case ID_RESETDB:
+            {
+                CUpdateDatabaseMutex lock;
                 m_Db->RemoveCached();
                 UpdateApplicationsList(SelectedEnumType, bReload);
                 break;
+            }
 
             case ID_HELP:
                 MessageBoxW(L"Help not implemented yet", NULL, MB_OK);

--- a/base/applications/rapps/include/rapps.h
+++ b/base/applications/rapps/include/rapps.h
@@ -17,4 +17,9 @@ extern LONG g_Busy;
 
 #define WM_NOTIFY_OPERATIONCOMPLETED (WM_APP + 0)
 
+struct CUpdateDatabaseMutex : public CScopedMutex
+{
+    CUpdateDatabaseMutex() : CScopedMutex(UPDATEDBMUTEX, 1000 * 60 * 10, FALSE) { };
+};
+
 #endif /* _RAPPS_H */

--- a/base/applications/rapps/include/rapps.h
+++ b/base/applications/rapps/include/rapps.h
@@ -17,6 +17,10 @@ extern LONG g_Busy;
 
 #define WM_NOTIFY_OPERATIONCOMPLETED (WM_APP + 0)
 
+#define MAINWINDOWCLASSNAME L"ROSAPPMGR2"
+#define MAINWINDOWMUTEX szWindowClass
+#define UPDATEDBMUTEX ( MAINWINDOWCLASSNAME L":UpDB" )
+
 struct CUpdateDatabaseMutex : public CScopedMutex
 {
     CUpdateDatabaseMutex() : CScopedMutex(UPDATEDBMUTEX, 1000 * 60 * 10, FALSE) { };

--- a/base/applications/rapps/include/winmain.h
+++ b/base/applications/rapps/include/winmain.h
@@ -2,10 +2,6 @@
 
 #include "settings.h"
 
-#define MAINWINDOWCLASSNAME L"ROSAPPMGR2"
-#define MAINWINDOWMUTEX szWindowClass
-#define UPDATEDBMUTEX ( MAINWINDOWCLASSNAME L":UpDB" )
-
 extern LPCWSTR szWindowClass;
 
 extern HWND hMainWnd;

--- a/base/applications/rapps/include/winmain.h
+++ b/base/applications/rapps/include/winmain.h
@@ -2,6 +2,10 @@
 
 #include "settings.h"
 
+#define MAINWINDOWCLASSNAME L"ROSAPPMGR2"
+#define MAINWINDOWMUTEX szWindowClass
+#define UPDATEDBMUTEX ( MAINWINDOWCLASSNAME L":UpDB" )
+
 extern LPCWSTR szWindowClass;
 
 extern HWND hMainWnd;

--- a/base/applications/rapps/unattended.cpp
+++ b/base/applications/rapps/unattended.cpp
@@ -351,7 +351,7 @@ ParseCmdAndExecute(LPWSTR lpCmdLine, BOOL bIsFirstLaunch, int nCmdShow)
     {
         // Check whether the RAPPS MainWindow is already launched in another process
         CStringW szWindowText(MAKEINTRESOURCEW(bAppwizMode ? IDS_APPWIZ_TITLE : IDS_APPTITLE));
-        LPCWSTR pszMutex = bAppwizMode ? L"RAPPWIZ" : szWindowClass;
+        LPCWSTR pszMutex = bAppwizMode ? L"RAPPWIZ" : MAINWINDOWMUTEX;
 
         HANDLE hMutex = CreateMutexW(NULL, FALSE, pszMutex);
         if ((!hMutex) || (GetLastError() == ERROR_ALREADY_EXISTS))

--- a/base/applications/rapps/unattended.cpp
+++ b/base/applications/rapps/unattended.cpp
@@ -338,6 +338,7 @@ ParseCmdAndExecute(LPWSTR lpCmdLine, BOOL bIsFirstLaunch, int nCmdShow)
     BOOL bAppwizMode = (argc > 1 && MatchCmdOption(argv[1], CMD_KEY_APPWIZ));
     if (!bAppwizMode)
     {
+        CUpdateDatabaseMutex lock;
         if (SettingsInfo.bUpdateAtStart || bIsFirstLaunch)
             db.RemoveCached();
 

--- a/base/applications/rapps/winmain.cpp
+++ b/base/applications/rapps/winmain.cpp
@@ -13,7 +13,7 @@
 #include <gdiplus.h>
 #include <conutils.h>
 
-LPCWSTR szWindowClass = L"ROSAPPMGR2";
+LPCWSTR szWindowClass = MAINWINDOWCLASSNAME;
 LONG g_Busy = 0;
 
 HWND hMainWnd;


### PR DESCRIPTION
While most of RApps will happily run with multiple instances, the database update code will delete the whole database directory and assumes nobody else is accessing the directory at the same time.

I made it time out and ignore the lock after 10 minutes just in case somebody is using this in a headless configuration and something somehow broke the update mechanism or is holding a lock on one of the files.