### PR TITLE
[NOTEPAD] F3 should not display an error message when the find string is empty

### DIFF
--- a/base/applications/notepad/dialog.c
+++ b/base/applications/notepad/dialog.c
@@ -820,7 +820,7 @@ VOID DIALOG_SearchNext(BOOL bDown)
     else
         Globals.find.Flags &= ~FR_DOWN;
 
-    if (Globals.find.lpstrFindWhat != NULL)
+    if (Globals.find.lpstrFindWhat != NULL && *Globals.find.lpstrFindWhat)
         NOTEPAD_FindNext(&Globals.find, FALSE, TRUE);
     else
         DIALOG_Search();


### PR DESCRIPTION
Telling the user it can't find the `''` string is not very helpful, it's better to just display the find dialog again.

Steps to reproduce:

1. `reg DELETE "HKCU\SOFTWARE\Microsoft\Notepad" /v searchString /f`
2. `start Notepad.exe`
3. <kbd>F3</kbd>
4. <kbd>Esc</kbd>
5. <kbd>F3</kbd>

