### PR TITLE
[RAPPS] Hide the main window during active download/install if the user closes it

### DIFF
--- a/base/applications/rapps/gui.cpp
+++ b/base/applications/rapps/gui.cpp
@@ -323,9 +323,8 @@ CMainWindow::ProcessWindowMessage(HWND hwnd, UINT Msg, WPARAM wParam, LPARAM lPa
 
         case WM_DESTROY:
         {
-            ShowWindow(SW_HIDE);
+            hMainWnd = NULL;
             SaveSettings(hwnd, &SettingsInfo);
-
             FreeLogs();
 
             delete m_ClientPanel;
@@ -335,14 +334,13 @@ CMainWindow::ProcessWindowMessage(HWND hwnd, UINT Msg, WPARAM wParam, LPARAM lPa
         }
 
         case WM_CLOSE:
-            if (g_Busy)
-            {
-                MessageBeep(MB_ICONEXCLAMATION);
-                HWND hActive = ::IsWindow(g_ActiveOperationWindow) ? g_ActiveOperationWindow : GetLastActivePopup();
-                ::SetForegroundWindow(hActive);
-                ::PostMessage(hActive, DM_REPOSITION, 0, 0);
-            }
+            ShowWindow(SW_HIDE);
             return g_Busy;
+
+        case WM_NOTIFY_OPERATIONCOMPLETED:
+            if (!g_Busy && !IsWindowVisible())
+                SendMessage(WM_CLOSE, 0, 0);
+            break;
 
         case DM_REPOSITION:
             EmulateDialogReposition(hwnd); // We are not a real dialog, we need help from a real one

--- a/base/applications/rapps/gui.cpp
+++ b/base/applications/rapps/gui.cpp
@@ -318,6 +318,7 @@ CMainWindow::ProcessWindowMessage(HWND hwnd, UINT Msg, WPARAM wParam, LPARAM lPa
         case WM_CREATE:
             if (!InitControls())
                 ::PostMessageW(hwnd, WM_CLOSE, 0, 0);
+            ::PostMessageW(hwnd, DM_REPOSITION, 0, 0);
             break;
 
         case WM_DESTROY:
@@ -332,6 +333,20 @@ CMainWindow::ProcessWindowMessage(HWND hwnd, UINT Msg, WPARAM wParam, LPARAM lPa
             PostQuitMessage(0);
             return 0;
         }
+
+        case WM_CLOSE:
+            if (g_Busy)
+            {
+                MessageBeep(MB_ICONEXCLAMATION);
+                HWND hActive = ::IsWindow(g_ActiveOperationWindow) ? g_ActiveOperationWindow : GetLastActivePopup();
+                ::SetForegroundWindow(hActive);
+                ::PostMessage(hActive, DM_REPOSITION, 0, 0);
+            }
+            return g_Busy;
+
+        case DM_REPOSITION:
+            EmulateDialogReposition(hwnd); // We are not a real dialog, we need help from a real one
+            break;
 
         case WM_COMMAND:
             OnCommand(wParam, lParam);

--- a/base/applications/rapps/include/misc.h
+++ b/base/applications/rapps/include/misc.h
@@ -30,6 +30,8 @@ VOID
 CopyTextToClipboard(LPCWSTR lpszText);
 VOID
 ShowPopupMenuEx(HWND hwnd, HWND hwndOwner, UINT MenuID, UINT DefaultItem, POINT *Point = NULL);
+VOID
+EmulateDialogReposition(HWND hwnd);
 BOOL
 StartProcess(const CStringW &Path, BOOL Wait);
 BOOL

--- a/base/applications/rapps/include/rapps.h
+++ b/base/applications/rapps/include/rapps.h
@@ -14,6 +14,7 @@
 #include "configparser.h"
 
 extern LONG g_Busy;
-extern HWND g_ActiveOperationWindow;
+
+#define WM_NOTIFY_OPERATIONCOMPLETED (WM_APP + 0)
 
 #endif /* _RAPPS_H */

--- a/base/applications/rapps/include/rapps.h
+++ b/base/applications/rapps/include/rapps.h
@@ -13,4 +13,7 @@
 #include "misc.h"
 #include "configparser.h"
 
+extern LONG g_Busy;
+extern HWND g_ActiveOperationWindow;
+
 #endif /* _RAPPS_H */

--- a/base/applications/rapps/loaddlg.cpp
+++ b/base/applications/rapps/loaddlg.cpp
@@ -470,6 +470,7 @@ CDownloadManager::DownloadDlgProc(HWND Dlg, UINT uMsg, WPARAM wParam, LPARAM lPa
     {
         case WM_INITDIALOG:
         {
+            g_Busy++;
             HICON hIconSm, hIconBg;
             CStringW szTempCaption;
 
@@ -533,6 +534,7 @@ CDownloadManager::DownloadDlgProc(HWND Dlg, UINT uMsg, WPARAM wParam, LPARAM lPa
 
             CloseHandle(Thread);
             AppsDownloadList.RemoveAll();
+            g_ActiveOperationWindow = Dlg;
             return TRUE;
         }
 
@@ -556,6 +558,11 @@ CDownloadManager::DownloadDlgProc(HWND Dlg, UINT uMsg, WPARAM wParam, LPARAM lPa
                 ::DestroyWindow(Dlg);
             }
             return TRUE;
+
+        case WM_DESTROY:
+            g_ActiveOperationWindow = NULL;
+            g_Busy--;
+            return FALSE;
 
         default:
             return FALSE;

--- a/base/applications/rapps/loaddlg.cpp
+++ b/base/applications/rapps/loaddlg.cpp
@@ -534,7 +534,6 @@ CDownloadManager::DownloadDlgProc(HWND Dlg, UINT uMsg, WPARAM wParam, LPARAM lPa
 
             CloseHandle(Thread);
             AppsDownloadList.RemoveAll();
-            g_ActiveOperationWindow = Dlg;
             return TRUE;
         }
 
@@ -560,8 +559,9 @@ CDownloadManager::DownloadDlgProc(HWND Dlg, UINT uMsg, WPARAM wParam, LPARAM lPa
             return TRUE;
 
         case WM_DESTROY:
-            g_ActiveOperationWindow = NULL;
             g_Busy--;
+            if (hMainWnd)
+                PostMessage(hMainWnd, WM_NOTIFY_OPERATIONCOMPLETED, 0, 0);
             return FALSE;
 
         default:

--- a/base/applications/rapps/misc.cpp
+++ b/base/applications/rapps/misc.cpp
@@ -39,6 +39,31 @@ CopyTextToClipboard(LPCWSTR lpszText)
     CloseClipboard();
 }
 
+static INT_PTR CALLBACK
+NothingDlgProc(HWND hDlg, UINT uMsg, WPARAM, LPARAM)
+{
+    return uMsg == WM_CLOSE ? DestroyWindow(hDlg) : FALSE;
+}
+
+VOID
+EmulateDialogReposition(HWND hwnd)
+{
+    static const DWORD DlgTmpl[] = { WS_POPUP | WS_CAPTION | WS_SYSMENU, 0, 0, 0, 0, 0 };
+    HWND hDlg = CreateDialogIndirectW(NULL, (LPDLGTEMPLATE)DlgTmpl, NULL, NothingDlgProc);
+    if (hDlg)
+    {
+        RECT r;
+        GetWindowRect(hwnd, &r);
+        if (SetWindowPos(hDlg, hDlg, r.left, r.top, r.right - r.left, r.bottom - r.top, SWP_NOZORDER | SWP_NOACTIVATE))
+        {
+            SendMessage(hDlg, DM_REPOSITION, 0, 0);
+            if (GetWindowRect(hDlg, &r))
+                SetWindowPos(hwnd, hwnd, r.left, r.top, r.right - r.left, r.bottom - r.top, SWP_NOZORDER | SWP_NOACTIVATE);
+        }
+        SendMessage(hDlg, WM_CLOSE, 0, 0);
+    }
+}
+
 VOID
 ShowPopupMenuEx(HWND hwnd, HWND hwndOwner, UINT MenuID, UINT DefaultItem, POINT *Point)
 {

--- a/base/applications/rapps/unattended.cpp
+++ b/base/applications/rapps/unattended.cpp
@@ -371,12 +371,9 @@ ParseCmdAndExecute(LPWSTR lpCmdLine, BOOL bIsFirstLaunch, int nCmdShow)
                 if (bAppwizMode)
                     PostMessage(hWindow, WM_COMMAND, ID_ACTIVATE_APPWIZ, 0);
 
-                if (IsWindowVisible(hWindow))
-                {
-                    if (hMutex)
-                        CloseHandle(hMutex);
-                    return FALSE;
-                }
+                if (hMutex)
+                    CloseHandle(hMutex);
+                return FALSE;
             }
         }
 

--- a/base/applications/rapps/unattended.cpp
+++ b/base/applications/rapps/unattended.cpp
@@ -366,14 +366,17 @@ ParseCmdAndExecute(LPWSTR lpCmdLine, BOOL bIsFirstLaunch, int nCmdShow)
             if (hWindow)
             {
                 /* Activate the window in the other instance */
+                ShowWindow(hWindow, SW_SHOW);
                 SwitchToThisWindow(hWindow, TRUE);
                 if (bAppwizMode)
                     PostMessage(hWindow, WM_COMMAND, ID_ACTIVATE_APPWIZ, 0);
 
-                if (hMutex)
-                    CloseHandle(hMutex);
-
-                return FALSE;
+                if (IsWindowVisible(hWindow))
+                {
+                    if (hMutex)
+                        CloseHandle(hMutex);
+                    return FALSE;
+                }
             }
         }
 

--- a/base/applications/rapps/unattended.cpp
+++ b/base/applications/rapps/unattended.cpp
@@ -373,6 +373,7 @@ ParseCmdAndExecute(LPWSTR lpCmdLine, BOOL bIsFirstLaunch, int nCmdShow)
 
                 if (hMutex)
                     CloseHandle(hMutex);
+
                 return FALSE;
             }
         }

--- a/base/applications/rapps/winmain.cpp
+++ b/base/applications/rapps/winmain.cpp
@@ -14,6 +14,8 @@
 #include <conutils.h>
 
 LPCWSTR szWindowClass = L"ROSAPPMGR2";
+LONG g_Busy = 0;
+HWND g_ActiveOperationWindow = NULL;
 
 HWND hMainWnd;
 HINSTANCE hInst;

--- a/base/applications/rapps/winmain.cpp
+++ b/base/applications/rapps/winmain.cpp
@@ -15,7 +15,6 @@
 
 LPCWSTR szWindowClass = L"ROSAPPMGR2";
 LONG g_Busy = 0;
-HWND g_ActiveOperationWindow = NULL;
 
 HWND hMainWnd;
 HINSTANCE hInst;


### PR DESCRIPTION

Reproducing the issue:

1. Start installing some app.
2. Close the main window that sits behind the download dialog.

Notes:
 - The `EmulateDialogReposition` related code is not strictly required but it is nice to make sure the main window is properly on screen as well. The download/install popup dialog supports `DM_REPOSITION` natively.
