### PR TITLE
[SETUPAPI] Fix absolute dirid ProfileItems bug

### DIFF
--- a/dll/win32/setupapi/install.c
+++ b/dll/win32/setupapi/install.c
@@ -844,8 +844,10 @@ static BOOL Concatenate(int DirId, LPCWSTR SubDirPart, LPCWSTR NamePart, LPWSTR 
     *pFullName = NULL;
 
     Dir = DIRID_get_string(DirId);
-    if (Dir)
+    if (Dir && *Dir)
         dwRequired += wcslen(Dir) + 1;
+    else
+        Dir = NULL; /* DIRID_get_string returns L"" for DIRID_ABSOLUTE */
     if (SubDirPart)
         dwRequired += wcslen(SubDirPart) + 1;
     if (NamePart)


### PR DESCRIPTION
When a link section is something like `CmdLine=-1,"d:\","foo.exe"`, the root dirid should not write anything to the path. It currently accesses undefined memory when doing `FullName[wcslen(FullName) - 1] != '\\'` because `DIRID_get_string` returns an empty string for DIRID_ABSOLUTE instead of `NULL` like the code expects and this ends up prefixing the (absolute) path with a `\`.

Notes:
- This `Concatenate` function does not exist in Wine.