### PR TITLE
Revert "[BOOT] Don't create empty CSIDL_ADMINTOOLS folder"

### DIFF
--- a/boot/boot_images.cmake
+++ b/boot/boot_images.cmake
@@ -100,7 +100,7 @@ function(add_user_profile_dirs _image_filelist _rootdir _username)
     file(APPEND ${_image_filelist} "${_rootdir}/${_username}/Recent=${CMAKE_CURRENT_BINARY_DIR}/empty\n")
     file(APPEND ${_image_filelist} "${_rootdir}/${_username}/SendTo=${CMAKE_CURRENT_BINARY_DIR}/empty\n")
     file(APPEND ${_image_filelist} "${_rootdir}/${_username}/Start Menu/Programs=${CMAKE_CURRENT_BINARY_DIR}/empty\n")
-    #file(APPEND ${_image_filelist} "${_rootdir}/${_username}/Start Menu/Programs/Administrative Tools=${CMAKE_CURRENT_BINARY_DIR}/empty\n") # CORE-12328
+    file(APPEND ${_image_filelist} "${_rootdir}/${_username}/Start Menu/Programs/Administrative Tools=${CMAKE_CURRENT_BINARY_DIR}/empty\n")
     file(APPEND ${_image_filelist} "${_rootdir}/${_username}/Start Menu/Programs/StartUp=${CMAKE_CURRENT_BINARY_DIR}/empty\n")
     file(APPEND ${_image_filelist} "${_rootdir}/${_username}/Templates=${CMAKE_CURRENT_BINARY_DIR}/empty\n")
 endfunction()


### PR DESCRIPTION
Reverts reactos/reactos#6551
This caused the non-English programs menu items to not be populated.
JIRA issue: [CORE-12328](https://jira.reactos.org/browse/CORE-12328) will have to be reopened afterwards and approached differently
JIRA issue: [CORE-19652](https://jira.reactos.org/browse/CORE-19652) will get resolved

BEFORE:
![Russian-LiveCD-StartMenu-Programs-not-populated](https://github.com/reactos/reactos/assets/2107452/7e7d2da5-948c-4799-b165-fdf415f01e44)

AFTER:
![after](https://github.com/reactos/reactos/assets/2107452/6b19b790-4f96-41ad-8dab-f66111713895)