### PR TITLE
[FREETYPE] Multiple indirect Font Substitutes fix for Factusol

### DIFF
--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -934,6 +934,7 @@ SubstituteFontRecurse(LOGFONTW* pLogFont)
             break;
 
         IntUnicodeStringToBuffer(pLogFont->lfFaceName, sizeof(pLogFont->lfFaceName), &OutputNameW);
+        RtlInitUnicodeString(&InputNameW, pLogFont->lfFaceName);
 
         if (CharSetMap[FONTSUBST_FROM] == DEFAULT_CHARSET ||
             CharSetMap[FONTSUBST_FROM] == pLogFont->lfCharSet)


### PR DESCRIPTION
## Purpose

_Fix SubstituteFontRecurse to work when multiple indirect Font Substitutes are needed._

JIRA issue: [CORE-19651](https://jira.reactos.org/browse/CORE-19651)

## Proposed changes

_In SubstituteFontRecurse, after an output is found, then the next input should be the previous output._

Before/After:
![15-8188-Factusol_Install_Bad-01](https://github.com/reactos/reactos/assets/32620577/0c4bc460-d030-4f75-9064-a846588013fc)