### PR TITLE
fix-CORE-15298

### DIFF
--- a/dll/win32/comctl32/static.c
+++ b/dll/win32/comctl32/static.c
@@ -627,6 +627,18 @@ static void STATIC_PaintTextfn( HWND hwnd, HDC hdc, DWORD style )
     else
     {
         DrawTextW( hdc, text, -1, &rc, format );
+        if(style & WS_DISABLED)
+        {
+            COLORREF oldTextColor=GetTextColor(hdc);
+            SetBkMode(hdc, TRANSPARENT);
+            SetTextColor(hdc, GetSysColor(COLOR_HIGHLIGHTTEXT));
+            rc.left++;rc.top++;
+            DrawTextW( hdc, text, -1, &rc, format );
+            SetTextColor(hdc, oldTextColor);
+            rc.left--;rc.top--;
+            DrawTextW( hdc, text, -1, &rc, format );
+            SetBkMode(hdc, OPAQUE);
+        }
     }
 
 no_TextOut:

--- a/win32ss/user/user32/controls/static.c
+++ b/win32ss/user/user32/controls/static.c
@@ -707,6 +707,18 @@ static void STATIC_PaintTextfn( HWND hwnd, HDC hdc, DWORD style )
     else
     {
         DrawTextW( hdc, text, -1, &rc, format );
+        if(style & WS_DISABLED)
+        {
+            COLORREF oldTextColor=GetTextColor(hdc);
+            SetBkMode(hdc, TRANSPARENT);
+            SetTextColor(hdc, GetSysColor(COLOR_HIGHLIGHTTEXT));
+            rc.left++;rc.top++;
+            DrawTextW( hdc, text, -1, &rc, format );
+            SetTextColor(hdc, oldTextColor);
+            rc.left--;rc.top--;
+            DrawTextW( hdc, text, -1, &rc, format );
+            SetBkMode(hdc, OPAQUE);
+        }
     }
 
 no_TextOut:


### PR DESCRIPTION
## Purpose

I added shadow rendering for emboss text in static.c.

JIRA issue: [CORE-15298](https://jira.reactos.org/browse/CORE-15298)

## Proposed changes

Adding text shadow rendering in the WS_DISABLED property.
\dll\win32\comctl32\static.c
\win32ss\user\user32\controls\static.c

- 
- 

## TODO

_Use a TODO when your pull request is Work in Progress._

- [ Maybe it could be improved, now the emboss text is rendered 3 times. The first time the original rendering is done with background, the second time the shadow is rendered(without background) and finally the text is rendered again(without background).
Instead of the first rendering, it would be enough to render a rectangle. But its size would have to be calculated according to the text to be rendered, so the question is whether this makes sense.] 
- [ ] 
