### PR TITLE
[SHELL32] Implement the desktop folder menu for Explorer tree

### DIFF
--- a/dll/win32/shell32/CDefaultContextMenu.cpp
+++ b/dll/win32/shell32/CDefaultContextMenu.cpp
@@ -263,7 +263,6 @@ HRESULT WINAPI CDefaultContextMenu::Initialize(const DEFCONTEXTMENU *pdcm, LPFND
         CComPtr<IPersistFolder2> pf = NULL;
         if (SUCCEEDED(m_psf->QueryInterface(IID_PPV_ARG(IPersistFolder2, &pf))))
         {
-            // FIXME: It is not supposed to do this? m_pidlFolder can be NULL
             if (FAILED(pf->GetCurFolder(&m_pidlFolder)))
                 ERR("GetCurFolder failed\n");
         }

--- a/dll/win32/shell32/brfolder.cpp
+++ b/dll/win32/shell32/brfolder.cpp
@@ -945,7 +945,7 @@ BrFolder_OnContextMenu(BrFolder &info, LPARAM lParam)
         return;
     info.pContextMenu = pcm;
     UINT cmf = ((GetKeyState(VK_SHIFT) < 0) ? CMF_EXTENDEDVERBS : 0) | CMF_CANRENAME;
-    hr = pcm->QueryContextMenu(hMenu, 0, ID_FIRSTCMD, ID_LASTCMD, CMF_NODEFAULT | cmf);
+    hr = pcm->QueryContextMenu(hMenu, 0, ID_FIRSTCMD, ID_LASTCMD, CMF_EXPLORE | cmf);
     if (hr > 0)
         _InsertMenuItemW(hMenu, 0, TRUE, 0, MFT_SEPARATOR, NULL, 0);
     _InsertMenuItemW(hMenu, 0, TRUE, IDC_TOGGLE, MFT_STRING,

--- a/dll/win32/shell32/brfolder.cpp
+++ b/dll/win32/shell32/brfolder.cpp
@@ -961,8 +961,7 @@ BrFolder_OnContextMenu(BrFolder &info, LPARAM lParam)
     }
     else if (cmd != 0 && GetDfmCmd(pcm, ici.lpVerb) == DFM_CMD_RENAME)
     {
-        TreeView_SelectItem(info.hwndTreeView, hSelected);
-        TreeView_EditLabel(info.hwndTreeView, hSelected);
+        BrFolder_Rename(&info, hSelected);
     }
     else if (cmd != 0)
     {

--- a/dll/win32/shell32/folders/CDesktopFolder.cpp
+++ b/dll/win32/shell32/folders/CDesktopFolder.cpp
@@ -849,7 +849,7 @@ HRESULT WINAPI CDesktopFolder::GetUIObjectOf(
 
             DEFCONTEXTMENU dcm;
             dcm.hwnd = hwndOwner;
-            dcm.pcmcb = self ? this : NULL; // Only our own Properties item needs callback handling
+            dcm.pcmcb = this;
             dcm.pidlFolder = pidlRoot;
             dcm.psf = this;
             dcm.cidl = cidl;

--- a/dll/win32/shell32/folders/CDesktopFolder.cpp
+++ b/dll/win32/shell32/folders/CDesktopFolder.cpp
@@ -843,9 +843,14 @@ HRESULT WINAPI CDesktopFolder::GetUIObjectOf(
             HKEY hKeys[16];
             UINT cKeys = 0;
             if (self)
+            {
+                AddClsidKeyToArray(CLSID_ShellDesktop, hKeys, &cKeys);
                 AddClassKeyToArray(L"Folder", hKeys, &cKeys);
+            }
             else if (cidl > 0)
+            {
                 AddFSClassKeysToArray(cidl, apidl, hKeys, &cKeys);
+            }
 
             DEFCONTEXTMENU dcm;
             dcm.hwnd = hwndOwner;

--- a/dll/win32/shell32/folders/CDesktopFolder.cpp
+++ b/dll/win32/shell32/folders/CDesktopFolder.cpp
@@ -25,6 +25,11 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(shell);
 
+static BOOL IsSelf(UINT cidl, PCUITEMID_CHILD_ARRAY apidl)
+{
+    return cidl == 0 || (cidl == 1 && apidl && _ILIsEmpty(apidl[0]));
+}
+
 STDMETHODIMP
 CDesktopFolder::ShellUrlParseDisplayName(
     HWND hwndOwner,
@@ -810,10 +815,10 @@ HRESULT WINAPI CDesktopFolder::GetUIObjectOf(
 
     if (!ppvOut)
         return hr;
-
     *ppvOut = NULL;
 
-    if (cidl == 1 && !_ILIsSpecialFolder(apidl[0]))
+    BOOL self = IsSelf(cidl, apidl);
+    if (cidl == 1 && !_ILIsSpecialFolder(apidl[0]) && !self)
     {
         CComPtr<IShellFolder2> psf;
         HRESULT hr = _GetSFFromPidl(apidl[0], &psf);
@@ -825,7 +830,8 @@ HRESULT WINAPI CDesktopFolder::GetUIObjectOf(
 
     if (IsEqualIID (riid, IID_IContextMenu))
     {
-        if (cidl > 0 && _ILIsSpecialFolder(apidl[0]))
+        // FIXME: m_regFolder vs AddFSClassKeysToArray is incorrect when the selection includes both regitems and FS items
+        if (!self && cidl > 0 && _ILIsSpecialFolder(apidl[0]))
         {
             hr = m_regFolder->GetUIObjectOf(hwndOwner, cidl, apidl, riid, prgfInOut, &pObj);
         }
@@ -836,14 +842,14 @@ HRESULT WINAPI CDesktopFolder::GetUIObjectOf(
             /* Otherwise operations like that involve items from both user and shared desktop will not work */
             HKEY hKeys[16];
             UINT cKeys = 0;
-            if (cidl > 0)
-            {
+            if (self)
+                AddClassKeyToArray(L"Folder", hKeys, &cKeys);
+            else if (cidl > 0)
                 AddFSClassKeysToArray(cidl, apidl, hKeys, &cKeys);
-            }
 
             DEFCONTEXTMENU dcm;
             dcm.hwnd = hwndOwner;
-            dcm.pcmcb = this;
+            dcm.pcmcb = self ? this : NULL; // Only our own Properties item needs callback handling
             dcm.pidlFolder = pidlRoot;
             dcm.psf = this;
             dcm.cidl = cidl;
@@ -1075,22 +1081,18 @@ HRESULT WINAPI CDesktopFolder::GetCurFolder(PIDLIST_ABSOLUTE * pidl)
 HRESULT WINAPI CDesktopFolder::CallBack(IShellFolder *psf, HWND hwndOwner, IDataObject *pdtobj, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
     enum { IDC_PROPERTIES };
-    /* no data object means no selection */
-    if (!pdtobj)
+    if (uMsg == DFM_INVOKECOMMAND && wParam == (pdtobj ? DFM_CMD_PROPERTIES : IDC_PROPERTIES))
     {
-        if (uMsg == DFM_INVOKECOMMAND && wParam == IDC_PROPERTIES)
-        {
-            return SHELL_ExecuteControlPanelCPL(hwndOwner, L"desk.cpl") ? S_OK : E_FAIL;
-        }
-        else if (uMsg == DFM_MERGECONTEXTMENU)
-        {
-            QCMINFO *pqcminfo = (QCMINFO *)lParam;
-            HMENU hpopup = CreatePopupMenu();
-            _InsertMenuItemW(hpopup, 0, TRUE, IDC_PROPERTIES, MFT_STRING, MAKEINTRESOURCEW(IDS_PROPERTIES), MFS_ENABLED);
-            pqcminfo->idCmdFirst = Shell_MergeMenus(pqcminfo->hmenu, hpopup, pqcminfo->indexMenu, pqcminfo->idCmdFirst, pqcminfo->idCmdLast, MM_ADDSEPARATOR);
-            DestroyMenu(hpopup);
-            return S_OK;
-        }
+        return SHELL_ExecuteControlPanelCPL(hwndOwner, L"desk.cpl") ? S_OK : E_FAIL;
+    }
+    else if (uMsg == DFM_MERGECONTEXTMENU && !pdtobj) // Add Properties item when called for directory background
+    {
+        QCMINFO *pqcminfo = (QCMINFO *)lParam;
+        HMENU hpopup = CreatePopupMenu();
+        _InsertMenuItemW(hpopup, 0, TRUE, IDC_PROPERTIES, MFT_STRING, MAKEINTRESOURCEW(IDS_PROPERTIES), MFS_ENABLED);
+        pqcminfo->idCmdFirst = Shell_MergeMenus(pqcminfo->hmenu, hpopup, pqcminfo->indexMenu, pqcminfo->idCmdFirst, pqcminfo->idCmdLast, MM_ADDSEPARATOR);
+        DestroyMenu(hpopup);
+        return S_OK;
     }
     return SHELL32_DefaultContextMenuCallBack(psf, pdtobj, uMsg);
 }

--- a/dll/win32/shell32/shfldr.h
+++ b/dll/win32/shell32/shfldr.h
@@ -113,6 +113,7 @@ void SHELL_FS_ProcessDisplayFilename(LPWSTR szPath, DWORD dwFlags);
 BOOL SHELL_FS_HideExtension(LPCWSTR pwszPath);
 
 LSTATUS AddClassKeyToArray(const WCHAR* szClass, HKEY* array, UINT* cKeys);
+LSTATUS AddClsidKeyToArray(REFCLSID clsid, HKEY* array, UINT* cKeys);
 
 #ifdef __cplusplus
 

--- a/dll/win32/shell32/shlfolder.cpp
+++ b/dll/win32/shell32/shlfolder.cpp
@@ -289,6 +289,13 @@ LSTATUS AddClassKeyToArray(const WCHAR* szClass, HKEY* array, UINT* cKeys)
     return result;
 }
 
+LSTATUS AddClsidKeyToArray(REFCLSID clsid, HKEY* array, UINT* cKeys)
+{
+    WCHAR path[6 + 38 + 1] = L"CLSID\\";
+    StringFromGUID2(clsid, path + 6, 38 + 1);
+    return AddClassKeyToArray(path, array, cKeys);
+}
+
 void AddFSClassKeysToArray(UINT cidl, PCUITEMID_CHILD_ARRAY apidl, HKEY* array, UINT* cKeys)
 {
     // This function opens the association array keys in canonical order for filesystem items.

--- a/dll/win32/shell32/wine/clipboard.c
+++ b/dll/win32/shell32/wine/clipboard.c
@@ -90,6 +90,11 @@ HGLOBAL RenderHDROP(LPITEMIDLIST pidlRoot, LPITEMIDLIST * apidl, UINT cidl)
 	for (i=0; i<cidl;i++)
 	{
 #ifdef __REACTOS__
+          /* The Windows default shell IDataObject::GetData fails with DV_E_CLIPFORMAT if the desktop is present. */
+          /* 7-Zip 23.01 relies on this to fail in its IShellExtInit when called on the desktop folder. */
+          if (ILIsEmpty(apidl[i]) && ILIsEmpty(pidlRoot))
+              goto cleanup;
+
           pidls[i] = ILCombine(pidlRoot, apidl[i]);
           SHGetPathFromIDListW(pidls[i], wszFileName);
           size += (wcslen(wszFileName) + 1) * sizeof(WCHAR);

--- a/dll/win32/shell32/wine/clipboard.c
+++ b/dll/win32/shell32/wine/clipboard.c
@@ -90,12 +90,6 @@ HGLOBAL RenderHDROP(LPITEMIDLIST pidlRoot, LPITEMIDLIST * apidl, UINT cidl)
 	for (i=0; i<cidl;i++)
 	{
 #ifdef __REACTOS__
-          /* The Windows default shell IDataObject::GetData fails with DV_E_CLIPFORMAT if the desktop is present.
-           * Windows does return HDROP in EnumFormatEtc and does not fail until GetData is called.
-           * Failing GetData causes 7-Zip 23.01 to not add its menu to the desktop folder. */
-          if (ILIsEmpty(apidl[i]) && ILIsEmpty(pidlRoot))
-              goto cleanup;
-
           pidls[i] = ILCombine(pidlRoot, apidl[i]);
           SHGetPathFromIDListW(pidls[i], wszFileName);
           size += (wcslen(wszFileName) + 1) * sizeof(WCHAR);

--- a/dll/win32/shell32/wine/clipboard.c
+++ b/dll/win32/shell32/wine/clipboard.c
@@ -90,8 +90,9 @@ HGLOBAL RenderHDROP(LPITEMIDLIST pidlRoot, LPITEMIDLIST * apidl, UINT cidl)
 	for (i=0; i<cidl;i++)
 	{
 #ifdef __REACTOS__
-          /* The Windows default shell IDataObject::GetData fails with DV_E_CLIPFORMAT if the desktop is present. */
-          /* 7-Zip 23.01 relies on this to fail in its IShellExtInit when called on the desktop folder. */
+          /* The Windows default shell IDataObject::GetData fails with DV_E_CLIPFORMAT if the desktop is present.
+           * Windows does return HDROP in EnumFormatEtc and does not fail until GetData is called.
+           * Failing GetData causes 7-Zip 23.01 to not add its menu to the desktop folder. */
           if (ILIsEmpty(apidl[i]) && ILIsEmpty(pidlRoot))
               goto cleanup;
 


### PR DESCRIPTION
Support IContextMenu for the desktop folder in Explorer tree and SHBrowseForFolder.

![screenshot](https://github.com/reactos/reactos/assets/138629473/ca161cf4-f4d2-45dc-b58d-055e9f576c0d)
