### PR TITLE
[MOUNTMGR] Correct "NoAutoMount" mixup; Fix initial sending of device online notification

### DIFF
--- a/drivers/storage/mountmgr/database.c
+++ b/drivers/storage/mountmgr/database.c
@@ -1641,12 +1641,12 @@ ReconcileThisDatabaseWithMaster(IN PDEVICE_EXTENSION DeviceExtension,
     WorkItem->DeviceInformation = DeviceInformation;
     QueueWorkItem(DeviceExtension, WorkItem, &(WorkItem->DeviceExtension));
 
-    /* If there's no automount, and automatic letters
-     * all volumes to find those online and notify there presence
-     */
+    /* If the worker thread isn't started yet, automatic drive letter is
+     * enabled but automount disabled, manually set mounted volumes online.
+     * Otherwise, they will be set online during database reconciliation. */
     if (DeviceExtension->WorkerThreadStatus == 0 &&
-        DeviceExtension->AutomaticDriveLetter == 1 &&
-        DeviceExtension->NoAutoMount == FALSE)
+        DeviceExtension->AutomaticDriveLetter &&
+        DeviceExtension->NoAutoMount)
     {
         OnlineMountedVolumes(DeviceExtension, DeviceInformation);
     }

--- a/drivers/storage/mountmgr/mntmgr.h
+++ b/drivers/storage/mountmgr/mntmgr.h
@@ -225,15 +225,14 @@ MountMgrFreeDeadDeviceInfo(
 
 NTSTATUS
 QueryDeviceInformation(
-    IN PUNICODE_STRING SymbolicName,
-    OUT PUNICODE_STRING DeviceName OPTIONAL,
-    OUT PMOUNTDEV_UNIQUE_ID * UniqueId OPTIONAL,
-    OUT PBOOLEAN Removable OPTIONAL,
-    OUT PBOOLEAN GptDriveLetter OPTIONAL,
-    OUT PBOOLEAN HasGuid OPTIONAL,
-    IN OUT LPGUID StableGuid OPTIONAL,
-    OUT PBOOLEAN Valid OPTIONAL
-);
+    _In_ PUNICODE_STRING SymbolicName,
+    _Out_opt_ PUNICODE_STRING DeviceName,
+    _Out_opt_ PMOUNTDEV_UNIQUE_ID* UniqueId,
+    _Out_opt_ PBOOLEAN Removable,
+    _Out_opt_ PBOOLEAN GptDriveLetter,
+    _Out_opt_ PBOOLEAN HasGuid,
+    _Inout_opt_ LPGUID StableGuid,
+    _Out_opt_ PBOOLEAN IsFT);
 
 BOOLEAN
 HasDriveLetter(

--- a/drivers/storage/mountmgr/mntmgr.h
+++ b/drivers/storage/mountmgr/mntmgr.h
@@ -19,7 +19,7 @@ typedef struct _DEVICE_EXTENSION
     PVOID NotificationEntry;
     KSEMAPHORE DeviceLock;
     KSEMAPHORE RemoteDatabaseLock;
-    ULONG AutomaticDriveLetter;
+    BOOLEAN AutomaticDriveLetter;
     LIST_ENTRY IrpListHead;
     ULONG EpicNumber;
     LIST_ENTRY SavedLinksListHead;
@@ -238,12 +238,6 @@ QueryDeviceInformation(
 BOOLEAN
 HasDriveLetter(
     IN PDEVICE_INFORMATION DeviceInformation
-);
-
-CODE_SEG("INIT")
-BOOLEAN
-MountmgrReadNoAutoMount(
-    IN PUNICODE_STRING RegistryPath
 );
 
 /* database.c */

--- a/drivers/storage/mountmgr/mountmgr.c
+++ b/drivers/storage/mountmgr/mountmgr.c
@@ -271,14 +271,15 @@ CreateNewDriveLetterName(OUT PUNICODE_STRING DriveLetter,
  * @implemented
  */
 NTSTATUS
-QueryDeviceInformation(IN PUNICODE_STRING SymbolicName,
-                       OUT PUNICODE_STRING DeviceName OPTIONAL,
-                       OUT PMOUNTDEV_UNIQUE_ID * UniqueId OPTIONAL,
-                       OUT PBOOLEAN Removable OPTIONAL,
-                       OUT PBOOLEAN GptDriveLetter OPTIONAL,
-                       OUT PBOOLEAN HasGuid OPTIONAL,
-                       IN OUT LPGUID StableGuid OPTIONAL,
-                       OUT PBOOLEAN Valid OPTIONAL)
+QueryDeviceInformation(
+    _In_ PUNICODE_STRING SymbolicName,
+    _Out_opt_ PUNICODE_STRING DeviceName,
+    _Out_opt_ PMOUNTDEV_UNIQUE_ID* UniqueId,
+    _Out_opt_ PBOOLEAN Removable,
+    _Out_opt_ PBOOLEAN GptDriveLetter,
+    _Out_opt_ PBOOLEAN HasGuid,
+    _Inout_opt_ LPGUID StableGuid,
+    _Out_opt_ PBOOLEAN IsFT)
 {
     NTSTATUS Status;
     USHORT Size;
@@ -334,15 +335,7 @@ QueryDeviceInformation(IN PUNICODE_STRING SymbolicName,
                                                  &GptAttributes,
                                                  sizeof(GptAttributes),
                                                  NULL);
-#if 0
-            if (Status == STATUS_INSUFFICIENT_RESOURCES)
-            {
-                ObDereferenceObject(DeviceObject);
-                ObDereferenceObject(FileObject);
-                return Status;
-            }
-#endif
-            /* In case of failure, don't fail, that's no vital */
+            /* Failure isn't major */
             if (!NT_SUCCESS(Status))
             {
                 Status = STATUS_SUCCESS;
@@ -355,15 +348,16 @@ QueryDeviceInformation(IN PUNICODE_STRING SymbolicName,
         }
     }
 
-    /* If caller wants to know if there's valid contents */
-    if (Valid)
+    /* If caller wants to know if this is a FT volume */
+    if (IsFT)
     {
-        /* Suppose it's not OK */
-        *Valid = FALSE;
+        /* Suppose it's not */
+        *IsFT = FALSE;
 
+        /* FT volume can't be removable */
         if (!IsRemovable)
         {
-            /* Query partitions information */
+            /* Query partition information */
             Status = MountMgrSendSyncDeviceIoCtl(IOCTL_DISK_GET_PARTITION_INFO_EX,
                                                  DeviceObject,
                                                  NULL,
@@ -371,28 +365,22 @@ QueryDeviceInformation(IN PUNICODE_STRING SymbolicName,
                                                  &PartitionInfo,
                                                  sizeof(PartitionInfo),
                                                  NULL);
-#if 0
-            if (Status == STATUS_INSUFFICIENT_RESOURCES)
-            {
-                ObDereferenceObject(DeviceObject);
-                ObDereferenceObject(FileObject);
-                return Status;
-            }
-#endif
-            /* Once again here, failure isn't major */
+            /* Failure isn't major */
             if (!NT_SUCCESS(Status))
             {
                 Status = STATUS_SUCCESS;
             }
-            /* Verify we know something in */
-            else if (PartitionInfo.PartitionStyle == PARTITION_STYLE_MBR &&
-                     IsRecognizedPartition(PartitionInfo.Mbr.PartitionType))
+            /* Check if this is a FT volume */
+            else if ((PartitionInfo.PartitionStyle == PARTITION_STYLE_MBR) &&
+                     IsFTPartition(PartitionInfo.Mbr.PartitionType))
             {
-                *Valid = TRUE;
+                *IsFT = TRUE;
             }
 
-            /* It looks correct, ensure it is & query device number */
-            if (*Valid)
+            /* It looks like a FT volume. Verify it is really one by checking
+             * that it does NOT lie on a specific storage device (i.e. it is
+             * not a basic volume). */
+            if (*IsFT)
             {
                 Status = MountMgrSendSyncDeviceIoCtl(IOCTL_STORAGE_GET_DEVICE_NUMBER,
                                                      DeviceObject,
@@ -401,18 +389,10 @@ QueryDeviceInformation(IN PUNICODE_STRING SymbolicName,
                                                      &StorageDeviceNumber,
                                                      sizeof(StorageDeviceNumber),
                                                      NULL);
-#if 0
-                if (Status == STATUS_INSUFFICIENT_RESOURCES)
-                {
-                    ObDereferenceObject(DeviceObject);
-                    ObDereferenceObject(FileObject);
-                    return Status;
-                }
-#endif
                 if (!NT_SUCCESS(Status))
                     Status = STATUS_SUCCESS;
                 else
-                    *Valid = FALSE;
+                    *IsFT = FALSE; // Succeeded, so this cannot be a FT volume.
             }
         }
     }
@@ -890,7 +870,8 @@ MountMgrMountedDeviceArrival(IN PDEVICE_EXTENSION DeviceExtension,
     PDEVICE_INFORMATION DeviceInformation, CurrentDevice;
     WCHAR CSymLinkBuffer[RTL_NUMBER_OF(Cunc)], LinkTargetBuffer[MAX_PATH];
     UNICODE_STRING TargetDeviceName, SuggestedLinkName, DeviceName, VolumeName, DriveLetter, LinkTarget, CSymLink;
-    BOOLEAN HasGuid, HasGptDriveLetter, Valid, UseOnlyIfThereAreNoOtherLinks, IsDrvLetter, IsOff, IsVolumeName, LinkError;
+    BOOLEAN HasGuid, HasGptDriveLetter, IsFT, UseOnlyIfThereAreNoOtherLinks;
+    BOOLEAN IsDrvLetter, IsOff, IsVolumeName, SetOnline;
 
     /* New device = new structure to represent it */
     DeviceInformation = AllocatePool(sizeof(DEVICE_INFORMATION));
@@ -927,7 +908,7 @@ MountMgrMountedDeviceArrival(IN PDEVICE_EXTENSION DeviceExtension,
                                     &HasGptDriveLetter,
                                     &HasGuid,
                                     &StableGuid,
-                                    &Valid);
+                                    &IsFT);
     if (!NT_SUCCESS(Status))
     {
         KeWaitForSingleObject(&(DeviceExtension->DeviceLock), Executive, KernelMode, FALSE, NULL);
@@ -1151,7 +1132,7 @@ MountMgrMountedDeviceArrival(IN PDEVICE_EXTENSION DeviceExtension,
         Status = GlobalCreateSymbolicLink(&(SymLinks[i]), &TargetDeviceName);
         if (!NT_SUCCESS(Status))
         {
-            LinkError = TRUE;
+            BOOLEAN LinkError = TRUE;
 
             if ((SavedLinkInformation && !RedirectSavedLink(SavedLinkInformation, &(SymLinks[i]), &TargetDeviceName)) ||
                 !SavedLinkInformation)
@@ -1315,30 +1296,23 @@ MountMgrMountedDeviceArrival(IN PDEVICE_EXTENSION DeviceExtension,
         RtlCopyMemory(NewUniqueId->UniqueId, UniqueId->UniqueId, UniqueId->UniqueIdLength);
     }
 
-    /* If the device is offline or valid, skip its notifications */
-    if (IsOff || Valid)
-    {
+    /* Skip online notifications if the device is offline or a FT volume */
+    if (IsOff || IsFT)
         DeviceInformation->SkipNotifications = TRUE;
-    }
 
-    /* If automount is enabled or the device already mounted, set it offline */
+    /* If automount is enabled or the device was already mounted, send now
+     * the online notification if needed; otherwise, defer its posting */
     if (!DeviceExtension->NoAutoMount || IsDrvLetter)
-    {
-        IsOff = !DeviceInformation->SkipNotifications;
-    }
+        SetOnline = !DeviceInformation->SkipNotifications;
     else
-    {
-        IsOff = FALSE;
-    }
+        SetOnline = FALSE;
 
     /* Finally, release the exclusive lock */
     KeReleaseSemaphore(&(DeviceExtension->DeviceLock), IO_NO_INCREMENT, 1, FALSE);
 
-    /* If the device is not offline, notify its arrival */
-    if (!IsOff)
-    {
+    /* Set the device online now if necessary */
+    if (SetOnline)
         SendOnlineNotification(SymbolicName);
-    }
 
     /* If we had symlinks (from storage), free them */
     if (SymLinks)


### PR DESCRIPTION
## Purpose

1. Correct "NoAutoMount" mixup.
This "NoAutoMount" member wasn't consistently used. Sometimes it was
used correctly, some other times it was used as "not NoAutoMount" i.e.
"AutoMount" enabled. (Original code author may not have fully understood
the purpose).
Fix this consistently throughout the source, and fix also some comments.

2. Fix initial sending of device online notification.
- MountMgrMountedDeviceArrival():
  Fix the conditions under which the device's online notifications are
  skipped (SkipNotifications == TRUE) and fix the code comments.
- QueryDeviceInformation():
  Repurpose the the "Valid" parameter to something that actually makes sense:
  checking for fault-tolerant volume.
  See corresponding commit log for more details.

~~3. Revert commit 4359f488386c604c2e67a03c1fadadb27f40f1ea (see [CORE-17469](https://jira.reactos.org/browse/CORE-17469)) to see what happens now...~~


## TODO

- [x] Test arrival and removal of volumes on a live system (for example, USB drives).
- [x] ~~Retest BTRFS volume mounting, see commit 4359f488386c604c2e67a03c1fadadb27f40f1ea and [CORE-17469](https://jira.reactos.org/browse/CORE-17469).~~ RESULT: Still does not work... (tested by @SigmaTel71 )
