### PR TITLE
[SDK][SHELL32_APITEST] Fix some warnings

### DIFF
--- a/base/applications/network/telnet/src/tnconfig.cpp
+++ b/base/applications/network/telnet/src/tnconfig.cpp
@@ -547,7 +547,7 @@ void TConfig::keyfile_init() {
 		// if there is no environment variable
 		GetPrivateProfileString("Keyboard", "Keyfile", "", keyfile,
 			sizeof(keyfile), inifile);
-		if(keyfile == 0 || *keyfile == 0) {
+		if(keyfile == NULL || *keyfile == 0) {
 			// and there is no profile string
 			strcpy(keyfile, startdir);
 			if (sizeof(keyfile) >= strlen(keyfile)+strlen("telnet.cfg")) {

--- a/base/applications/network/telnet/src/tnconfig.cpp
+++ b/base/applications/network/telnet/src/tnconfig.cpp
@@ -547,7 +547,7 @@ void TConfig::keyfile_init() {
 		// if there is no environment variable
 		GetPrivateProfileString("Keyboard", "Keyfile", "", keyfile,
 			sizeof(keyfile), inifile);
-		if(keyfile == NULL || *keyfile == 0) {
+		if (!*keyfile) {
 			// and there is no profile string
 			strcpy(keyfile, startdir);
 			if (sizeof(keyfile) >= strlen(keyfile)+strlen("telnet.cfg")) {

--- a/base/applications/wordpad/wordpad.c
+++ b/base/applications/wordpad/wordpad.c
@@ -2048,7 +2048,7 @@ static LRESULT OnNotify( HWND hWnd, LPARAM lParam)
 
         sprintf( buf,"selection = %d..%d, line count=%ld",
                  pSC->chrg.cpMin, pSC->chrg.cpMax,
-                SendMessageW(hwndEditor, EM_GETLINECOUNT, 0, 0));
+                (LONG)SendMessageW(hwndEditor, EM_GETLINECOUNT, 0, 0));
         SetWindowTextA(GetDlgItem(hWnd, IDC_STATUSBAR), buf);
         SendMessageW(hWnd, WM_USER, 0, 0);
         return 1;

--- a/base/applications/wordpad/wordpad.c
+++ b/base/applications/wordpad/wordpad.c
@@ -2046,9 +2046,9 @@ static LRESULT OnNotify( HWND hWnd, LPARAM lParam)
 
         update_font_list();
 
-        sprintf( buf,"selection = %d..%d, line count=%ld",
+        sprintf( buf,"Selection: %d..%d | Lines: %u",
                  pSC->chrg.cpMin, pSC->chrg.cpMax,
-                (long int)SendMessageW(hwndEditor, EM_GETLINECOUNT, 0, 0));
+                (UINT)SendMessageW(hwndEditor, EM_GETLINECOUNT, 0, 0));
         SetWindowTextA(GetDlgItem(hWnd, IDC_STATUSBAR), buf);
         SendMessageW(hWnd, WM_USER, 0, 0);
         return 1;

--- a/base/applications/wordpad/wordpad.c
+++ b/base/applications/wordpad/wordpad.c
@@ -2048,7 +2048,7 @@ static LRESULT OnNotify( HWND hWnd, LPARAM lParam)
 
         sprintf( buf,"selection = %d..%d, line count=%ld",
                  pSC->chrg.cpMin, pSC->chrg.cpMax,
-                (LONG)SendMessageW(hwndEditor, EM_GETLINECOUNT, 0, 0));
+                (long int)SendMessageW(hwndEditor, EM_GETLINECOUNT, 0, 0));
         SetWindowTextA(GetDlgItem(hWnd, IDC_STATUSBAR), buf);
         SendMessageW(hWnd, WM_USER, 0, 0);
         return 1;

--- a/dll/win32/dbghelp/CMakeLists.txt
+++ b/dll/win32/dbghelp/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 if(NOT CMAKE_CROSSCOMPILING)
-    add_definitions(-DDBGHELP_STATIC_LIB)
+    add_definitions(-DDBGHELP_STATIC_LIB -DNONAMELESSUNION)
 
     include_directories(
         ${REACTOS_SOURCE_DIR}/tools)

--- a/dll/win32/dbghelp/CMakeLists.txt
+++ b/dll/win32/dbghelp/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 if(NOT CMAKE_CROSSCOMPILING)
-    add_definitions(-DDBGHELP_STATIC_LIB -DNONAMELESSUNION)
+    add_definitions(-DDBGHELP_STATIC_LIB)
 
     include_directories(
         ${REACTOS_SOURCE_DIR}/tools)

--- a/dll/win32/dbghelp/symbol.c
+++ b/dll/win32/dbghelp/symbol.c
@@ -19,9 +19,7 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-#ifndef NONAMELESSUNION
 #define NONAMELESSUNION
-#endif
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/dll/win32/dbghelp/symbol.c
+++ b/dll/win32/dbghelp/symbol.c
@@ -19,7 +19,9 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
+#ifndef NONAMELESSUNION
 #define NONAMELESSUNION
+#endif
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/dll/win32/dbghelp/symbol.c
+++ b/dll/win32/dbghelp/symbol.c
@@ -19,7 +19,9 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
+#ifndef NONAMELESSUNION /* Required to avoid a warning because ROS CMake sometimes defines it on the command line */
 #define NONAMELESSUNION
+#endif
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/dll/win32/dbghelp/symbol.c
+++ b/dll/win32/dbghelp/symbol.c
@@ -19,7 +19,7 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-#ifndef NONAMELESSUNION /* Required to avoid a warning because ROS CMake sometimes defines it on the command line */
+#ifndef NONAMELESSUNION /* Required to avoid a warning when NOT CMAKE_CROSSCOMPILING */
 #define NONAMELESSUNION
 #endif
 

--- a/modules/rostests/apitests/shell32/SHChangeNotify.cpp
+++ b/modules/rostests/apitests/shell32/SHChangeNotify.cpp
@@ -288,6 +288,7 @@ static void DoStepCheck(INT iStage, INT iStep, LPCSTR checks)
         default:
         {
             assert(0);
+            lineno = 0;
             break;
         }
     }

--- a/modules/rostests/apitests/shell32/SHChangeNotify.cpp
+++ b/modules/rostests/apitests/shell32/SHChangeNotify.cpp
@@ -213,7 +213,7 @@ static void DoStepCheck(INT iStage, INT iStep, LPCSTR checks)
     }
 
     LPCSTR answer = NULL;
-    INT lineno;
+    INT lineno = 0;
     switch (iStage)
     {
         case 0:
@@ -288,7 +288,7 @@ static void DoStepCheck(INT iStage, INT iStep, LPCSTR checks)
         default:
         {
             assert(0);
-            lineno = 0;
+            DEFAULT_UNREACHABLE;
             break;
         }
     }

--- a/modules/rostests/apitests/shell32/SHChangeNotify.cpp
+++ b/modules/rostests/apitests/shell32/SHChangeNotify.cpp
@@ -285,12 +285,7 @@ static void DoStepCheck(INT iStage, INT iStep, LPCSTR checks)
             }
             break;
         }
-        default:
-        {
-            assert(0);
-            DEFAULT_UNREACHABLE;
-            break;
-        }
+        DEFAULT_UNREACHABLE;
     }
 
     ok(lstrcmpA(checks, answer) == 0,

--- a/modules/rostests/apitests/shell32/ShellExecCmdLine.cpp
+++ b/modules/rostests/apitests/shell32/ShellExecCmdLine.cpp
@@ -28,7 +28,6 @@
 #define shell32_hInstance   GetModuleHandle(NULL)
 #define IDS_FILE_NOT_FOUND  (-1)
 
-static const WCHAR wszOpen[] = L"open";
 static const WCHAR wszExe[] = L".exe";
 static const WCHAR wszCom[] = L".com";
 

--- a/modules/rostests/apitests/shell32/shell32_apitest_sub.cpp
+++ b/modules/rostests/apitests/shell32/shell32_apitest_sub.cpp
@@ -179,6 +179,8 @@ static BOOL InitSHCN(HWND hwnd)
         default:
         {
             assert(0);
+            sources = 0;
+            events = EVENTS;
             break;
         }
     }

--- a/modules/rostests/apitests/shell32/shell32_apitest_sub.cpp
+++ b/modules/rostests/apitests/shell32/shell32_apitest_sub.cpp
@@ -176,12 +176,7 @@ static BOOL InitSHCN(HWND hwnd)
             events = EVENTS;
             break;
         }
-        default:
-        {
-            assert(0);
-            DEFAULT_UNREACHABLE;
-            break;
-        }
+        DEFAULT_UNREACHABLE;
     }
 
     s_uRegID = SHChangeNotifyRegister(hwnd, sources, events, WM_SHELL_NOTIFY, 1, &entry);

--- a/modules/rostests/apitests/shell32/shell32_apitest_sub.cpp
+++ b/modules/rostests/apitests/shell32/shell32_apitest_sub.cpp
@@ -91,8 +91,8 @@ static BOOL InitSHCN(HWND hwnd)
     assert(s_iStage < NUM_STAGE);
 
     SHChangeNotifyEntry entry;
-    INT sources;
-    LONG events;
+    INT sources = 0;
+    LONG events = EVENTS;
     switch (s_iStage)
     {
         case 0:
@@ -179,8 +179,7 @@ static BOOL InitSHCN(HWND hwnd)
         default:
         {
             assert(0);
-            sources = 0;
-            events = EVENTS;
+            DEFAULT_UNREACHABLE;
             break;
         }
     }

--- a/sdk/include/psdk/ddraw.h
+++ b/sdk/include/psdk/ddraw.h
@@ -3,15 +3,15 @@
 #define __DDRAW_INCLUDED__
 
 #if defined(_WIN32) && !defined(_NO_COM )
-#define COM_NO_WINDOWS_H
-#include <objbase.h>
+  #define COM_NO_WINDOWS_H
+  #include <objbase.h>
 #else
-#define IUnknown void
-#if !defined(NT_BUILD_ENVIRONMENT) && !defined(WINNT)
-  #ifndef CO_E_NOTINITIALIZED /* Avoid conflict warning with _HRESULT_TYPEDEF_(0x800401F0L) in winerror.h */
-  #define CO_E_NOTINITIALIZED 0x800401F0L
+  #define IUnknown void
+  #if !defined(NT_BUILD_ENVIRONMENT) && !defined(WINNT)
+    #ifndef CO_E_NOTINITIALIZED /* Avoid conflict warning with _HRESULT_TYPEDEF_(0x800401F0L) in winerror.h */
+      #define CO_E_NOTINITIALIZED 0x800401F0L
+    #endif
   #endif
-#endif
 #endif
 
 #define _FACDD        0x876

--- a/sdk/include/psdk/ddraw.h
+++ b/sdk/include/psdk/ddraw.h
@@ -2,7 +2,7 @@
 #ifndef __DDRAW_INCLUDED__
 #define __DDRAW_INCLUDED__
 
-#if defined(_WIN32) && !defined(_NO_COM )
+#if defined(_WIN32) && !defined(_NO_COM)
   #define COM_NO_WINDOWS_H
   #include <objbase.h>
 #else

--- a/sdk/include/reactos/wine/test.h
+++ b/sdk/include/reactos/wine/test.h
@@ -764,7 +764,7 @@ const char *wine_dbgstr_guid( const GUID *guid )
     if (!guid) return "(null)";
     res = get_temp_buffer( 39 ); /* CHARS_IN_GUID */
     sprintf( res, "{%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x}",
-             (unsigned int)(guid->Data1), guid->Data2, guid->Data3, guid->Data4[0],
+             (unsigned int)guid->Data1, guid->Data2, guid->Data3, guid->Data4[0],
              guid->Data4[1], guid->Data4[2], guid->Data4[3], guid->Data4[4],
              guid->Data4[5], guid->Data4[6], guid->Data4[7] );
     return res;

--- a/sdk/include/reactos/wine/test.h
+++ b/sdk/include/reactos/wine/test.h
@@ -764,7 +764,7 @@ const char *wine_dbgstr_guid( const GUID *guid )
     if (!guid) return "(null)";
     res = get_temp_buffer( 39 ); /* CHARS_IN_GUID */
     sprintf( res, "{%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x}",
-             guid->Data1, guid->Data2, guid->Data3, guid->Data4[0],
+             UINT(guid->Data1), guid->Data2, guid->Data3, guid->Data4[0],
              guid->Data4[1], guid->Data4[2], guid->Data4[3], guid->Data4[4],
              guid->Data4[5], guid->Data4[6], guid->Data4[7] );
     return res;

--- a/sdk/include/reactos/wine/test.h
+++ b/sdk/include/reactos/wine/test.h
@@ -764,7 +764,7 @@ const char *wine_dbgstr_guid( const GUID *guid )
     if (!guid) return "(null)";
     res = get_temp_buffer( 39 ); /* CHARS_IN_GUID */
     sprintf( res, "{%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x}",
-             UINT(guid->Data1), guid->Data2, guid->Data3, guid->Data4[0],
+             (unsigned int)(guid->Data1), guid->Data2, guid->Data3, guid->Data4[0],
              guid->Data4[1], guid->Data4[2], guid->Data4[3], guid->Data4[4],
              guid->Data4[5], guid->Data4[6], guid->Data4[7] );
     return res;

--- a/sdk/lib/crt/startup/gs_support.c
+++ b/sdk/lib/crt/startup/gs_support.c
@@ -29,7 +29,7 @@
 
 typedef LONG NTSTATUS;	/* same as in ntdef.h / winternl.h */
 
-#define UNW_FLAG_NHANDLER 0x00
+#define UNW_FLAG_NHANDLER 0x0
 
 typedef union
 {

--- a/subsystems/mvdm/ntvdm/dos/dos32krnl/country.c
+++ b/subsystems/mvdm/ntvdm/dos/dos32krnl/country.c
@@ -212,7 +212,7 @@ WORD DosIfCharYesNo(WORD Char)
     if (Char == YesNoTable[0])
         return 0x0001;
     /* Unknown type */
-        return 0x0002;
+    return 0x0002;
 }
 
 CHAR DosToUpper(CHAR Char)


### PR DESCRIPTION
These are pretty conservative, there are tons of other warnings left, some that look like actual bugs (-Wconstant-logical-operand, "implicit truncation from 'int' to bit-field changes value", "used uninitialized whenever", "overlapping comparisons always evaluate to true" etc.).

The "wine guid sprintf" warning appears many many times. `CO_E_NOTINITIALIZED` and `UNW_FLAG_NHANDLER` a couple of times. The rest are one-offs.