### PR TITLE
[BROWSEUI] Save/Restore ShellBrowser bar states

### DIFF
--- a/dll/win32/browseui/internettoolbar.cpp
+++ b/dll/win32/browseui/internettoolbar.cpp
@@ -78,11 +78,13 @@ extern HRESULT WINAPI SHBindToFolder(LPCITEMIDLIST path, IShellFolder **newFolde
 struct ITBARSTATE
 {
     static const UINT SIG = ('R' << 0) | ('O' << 8) | ('S' << 16) | (('i' ^ 't' ^ 'b') << 24);
-    UINT Signature;
-    UINT Menubar : 1; // ..\Explorer\Advanced\AlwaysShowMenus for NT6?
+    UINT cbSize;
+    UINT Signature; // Note: Windows has something else here (12 bytes)
     UINT StdToolbar : 1;
     UINT Addressbar : 1;
     UINT Linksbar : 1;
+    UINT Throbber : 1; // toastytech.com/files/throboff.html
+    UINT Menubar : 1; // ..\Explorer\Advanced\AlwaysShowMenus for NT6?
     // Note: Windows 8/10 stores the Ribbon state in ..\Explorer\Ribbon
 };
 
@@ -905,7 +907,7 @@ HRESULT STDMETHODCALLTYPE CInternetToolbar::ShowDW(BOOL fShow)
             return hResult;
     }
 
-#if 0 // Why should showing the IDockingWindow change all bands?
+#if 0 // Why should showing the IDockingWindow change all bands? Related to CORE-17236
     if (fMenuBar)
     {
         hResult = IUnknown_ShowDW(fMenuBar, fShow);
@@ -1043,6 +1045,7 @@ HRESULT STDMETHODCALLTYPE CInternetToolbar::Load(IStream *pStm)
             SetBandVisibility(ITBBID_TOOLSBAND, state.StdToolbar);
             SetBandVisibility(ITBBID_ADDRESSBAND, state.Addressbar);
             //SetBandVisibility(ITBBID_?, state.Linksbar);
+            //SetBandVisibility(ITBBID_?, state.Throbber);
             hr = S_OK;
         }
     }
@@ -1052,7 +1055,7 @@ HRESULT STDMETHODCALLTYPE CInternetToolbar::Load(IStream *pStm)
 
 HRESULT STDMETHODCALLTYPE CInternetToolbar::Save(IStream *pStm, BOOL fClearDirty)
 {
-    ITBARSTATE state = { state.SIG };
+    ITBARSTATE state = { sizeof(state), state.SIG };
     state.Menubar = IsBandVisible(ITBBID_MENUBAND) == S_OK;
     state.StdToolbar = IsBandVisible(ITBBID_TOOLSBAND) == S_OK;
     state.Addressbar = IsBandVisible(ITBBID_ADDRESSBAND) == S_OK;

--- a/dll/win32/browseui/internettoolbar.cpp
+++ b/dll/win32/browseui/internettoolbar.cpp
@@ -75,6 +75,17 @@ TODO:
 
 extern HRESULT WINAPI SHBindToFolder(LPCITEMIDLIST path, IShellFolder **newFolder);
 
+struct ITBARSTATE
+{
+    static const UINT SIG = ('R' << 0) | ('O' << 8) | ('S' << 16) | (('i' ^ 't' ^ 'b') << 24);
+    UINT Signature;
+    UINT Menubar : 1; // ..\Explorer\Advanced\AlwaysShowMenus for NT6?
+    UINT StdToolbar : 1;
+    UINT Addressbar : 1;
+    UINT Linksbar : 1;
+    // Note: Windows 8/10 stores the Ribbon state in ..\Explorer\Ribbon
+};
+
 HRESULT IUnknown_RelayWinEvent(IUnknown * punk, HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT *theResult)
 {
     CComPtr<IWinEventHandler> menuWinEventHandler;
@@ -614,6 +625,7 @@ CInternetToolbar::CInternetToolbar()
     fToolbarWindow = NULL;
     fAdviseCookie = 0;
     pSettings = NULL;
+    fIgnoreChanges = FALSE;
 }
 
 CInternetToolbar::~CInternetToolbar()
@@ -893,6 +905,7 @@ HRESULT STDMETHODCALLTYPE CInternetToolbar::ShowDW(BOOL fShow)
             return hResult;
     }
 
+#if 0 // Why should showing the IDockingWindow change all bands?
     if (fMenuBar)
     {
         hResult = IUnknown_ShowDW(fMenuBar, fShow);
@@ -918,6 +931,7 @@ HRESULT STDMETHODCALLTYPE CInternetToolbar::ShowDW(BOOL fShow)
         if (FAILED_UNEXPECTEDLY(hResult))
             return hResult;
     }
+#endif
     return S_OK;
 }
 
@@ -1001,6 +1015,14 @@ HRESULT STDMETHODCALLTYPE CInternetToolbar::GetClassID(CLSID *pClassID)
     return S_OK;
 }
 
+HRESULT CInternetToolbar::SetDirty()
+{
+    if (fIgnoreChanges)
+        return S_OK;
+    IUnknown_Exec(fSite, CGID_ShellBrowser, IDM_NOTIFYITBARDIRTY, 0, NULL, NULL);
+    return S_OK;
+}
+
 HRESULT STDMETHODCALLTYPE CInternetToolbar::IsDirty()
 {
     return E_NOTIMPL;
@@ -1008,12 +1030,34 @@ HRESULT STDMETHODCALLTYPE CInternetToolbar::IsDirty()
 
 HRESULT STDMETHODCALLTYPE CInternetToolbar::Load(IStream *pStm)
 {
-    return E_NOTIMPL;
+    fIgnoreChanges = TRUE;
+    HRESULT hr = InitNew();
+    ITBARSTATE state;
+    if (SUCCEEDED(hr))
+    {
+        hr = S_FALSE;
+        ULONG cb = sizeof(state);
+        if (pStm->Read(&state, cb, &cb) == S_OK && state.Signature == state.SIG)
+        {
+            SetBandVisibility(ITBBID_MENUBAND, state.Menubar);
+            SetBandVisibility(ITBBID_TOOLSBAND, state.StdToolbar);
+            SetBandVisibility(ITBBID_ADDRESSBAND, state.Addressbar);
+            //SetBandVisibility(ITBBID_?, state.Linksbar);
+            hr = S_OK;
+        }
+    }
+    fIgnoreChanges = FALSE;
+    return hr;
 }
 
 HRESULT STDMETHODCALLTYPE CInternetToolbar::Save(IStream *pStm, BOOL fClearDirty)
 {
-    return E_NOTIMPL;
+    ITBARSTATE state = { state.SIG };
+    state.Menubar = IsBandVisible(ITBBID_MENUBAND) == S_OK;
+    state.StdToolbar = IsBandVisible(ITBBID_TOOLSBAND) == S_OK;
+    state.Addressbar = IsBandVisible(ITBBID_ADDRESSBAND) == S_OK;
+    state.Linksbar = FALSE;
+    return pStm->Write(&state, sizeof(state), NULL);
 }
 
 HRESULT STDMETHODCALLTYPE CInternetToolbar::GetSizeMax(ULARGE_INTEGER *pcbSize)
@@ -1080,22 +1124,32 @@ HRESULT CInternetToolbar::IsBandVisible(int BandID)
     return (bandInfo.fStyle & RBBS_HIDDEN) ? S_FALSE : S_OK;
 }
 
-HRESULT CInternetToolbar::ToggleBandVisibility(int BandID)
+HRESULT CInternetToolbar::SetBandVisibility(int BandID, int Show)
 {
     int index = (int)SendMessage(fMainReBar, RB_IDTOINDEX, BandID, 0);
+    REBARBANDINFOW bandInfo = {sizeof(REBARBANDINFOW), RBBIM_STYLE | RBBIM_CHILD};
+    if (!SendMessage(fMainReBar, RB_GETBANDINFOW, index, (LPARAM)&bandInfo))
+        return E_FAIL;
 
-    REBARBANDINFOW bandInfo = {sizeof(REBARBANDINFOW), RBBIM_STYLE};
-    SendMessage(fMainReBar, RB_GETBANDINFOW, index, (LPARAM)&bandInfo);
-
-    if (bandInfo.fStyle & RBBS_HIDDEN)
+    if (Show < 0)
+        bandInfo.fStyle ^= RBBS_HIDDEN; // Toggle
+    else if (Show)
         bandInfo.fStyle &= ~RBBS_HIDDEN;
     else
         bandInfo.fStyle |= RBBS_HIDDEN;
 
+    bandInfo.fMask &= ~RBBIM_CHILD;
+    ::ShowWindow(bandInfo.hwndChild, (bandInfo.fStyle & RBBS_HIDDEN) ? SW_HIDE : SW_SHOW); // CORE-17236
     SendMessage(fMainReBar, RB_SETBANDINFOW, index, (LPARAM)&bandInfo);
 
     ReserveBorderSpace(0);
+    SetDirty();
     return S_OK;
+}
+
+HRESULT CInternetToolbar::ToggleBandVisibility(int BandID)
+{
+    return SetBandVisibility(BandID, -1);
 }
 
 HRESULT STDMETHODCALLTYPE CInternetToolbar::QueryStatus(const GUID *pguidCmdGroup,
@@ -1685,7 +1739,6 @@ LRESULT CInternetToolbar::OnContextMenu(UINT uMsg, WPARAM wParam, LPARAM lParam,
     if (hitTestInfo.iBand == -1)
         return 0;
 
-    pSettings->Load();
     rebarBandInfo.cbSize = sizeof(rebarBandInfo);
     rebarBandInfo.fMask = RBBIM_ID;
     SendMessage(fMainReBar, RB_GETBANDINFOW, hitTestInfo.iBand, (LPARAM)&rebarBandInfo);
@@ -1929,4 +1982,20 @@ LRESULT CInternetToolbar::OnSettingsChange(UINT uMsg, WPARAM wParam, LPARAM lPar
     RefreshLockedToolbarState();
 
     return 0;
+}
+
+HRESULT CInternetToolbar::GetStream(UINT StreamFor, DWORD Stgm, IStream **ppS)
+{
+    WCHAR path[MAX_PATH];
+    LPCWSTR subkey = NULL;
+    switch (StreamFor)
+    {
+    case ITBARSTREAM_SHELLBROWSER: subkey = L"ShellBrowser"; break;
+    case ITBARSTREAM_WEBBROWSER: subkey = L"WebBrowser"; break;
+    case ITBARSTREAM_EXPLORER: subkey = L"Explorer"; break;
+    default: return E_INVALIDARG;
+    }
+    wsprintfW(path, L"Software\\Microsoft\\Internet Explorer\\Toolbar\\%s", subkey);
+    *ppS = SHOpenRegStream2W(HKEY_CURRENT_USER, path, L"RosITBarLayout", Stgm); // ROS prefix until we figure out the correct format
+    return *ppS ? S_OK : E_FAIL;
 }

--- a/dll/win32/browseui/internettoolbar.h
+++ b/dll/win32/browseui/internettoolbar.h
@@ -20,6 +20,10 @@
 
 #pragma once
 
+#define ITBARSTREAM_SHELLBROWSER 0
+#define ITBARSTREAM_WEBBROWSER 1
+#define ITBARSTREAM_EXPLORER 2
+
 static const int gSearchCommandID = 1003;
 static const int gFoldersCommandID = 1004;
 static const int gMoveToCommandID = FCIDM_SHVIEW_MOVETO;
@@ -93,6 +97,7 @@ public:
     POINT                                   fStartPosition;
     LONG                                    fStartHeight;
     ShellSettings                           *pSettings;
+    BOOL                                    fIgnoreChanges;
 public:
     CInternetToolbar();
     virtual ~CInternetToolbar();
@@ -104,9 +109,13 @@ public:
     HRESULT CommandStateChanged(bool newValue, int commandID);
     HRESULT CreateAndInitBandProxy();
     HRESULT IsBandVisible(int BandID);
+    HRESULT SetBandVisibility(int BandID, int Show);
     HRESULT ToggleBandVisibility(int BandID);
     HRESULT SetState(const GUID *pguidCmdGroup, long commandID, OLECMD* pcmd);
     void RefreshLockedToolbarState();
+    HRESULT SetDirty();
+
+    static HRESULT GetStream(UINT StreamFor, DWORD Stgm, IStream **ppS);
 
 public:
     // *** IInputObject specific methods ***

--- a/dll/win32/browseui/resource.h
+++ b/dll/win32/browseui/resource.h
@@ -73,6 +73,7 @@
 
 /* Random id for band close button, feel free to change it */
 #define IDM_BASEBAR_CLOSE                0xA200
+#define IDM_NOTIFYITBARDIRTY             0xA239 /* Arbitrary id */
 
 /* User-installed explorer band IDs according to API Monitor traces */
 #define IDM_EXPLORERBAND_BEGINCUSTOM     0xA240

--- a/dll/win32/browseui/settings.cpp
+++ b/dll/win32/browseui/settings.cpp
@@ -35,6 +35,7 @@ void ShellSettings::Load()
 
 void CabinetStateSettings::Load()
 {
+    this->cLength = sizeof(CABINETSTATE);
     ReadCabinetState(this, this->cLength);
 
     /* Overrides */

--- a/dll/win32/browseui/shellbrowser.cpp
+++ b/dll/win32/browseui/shellbrowser.cpp
@@ -2113,8 +2113,8 @@ HRESULT STDMETHODCALLTYPE CShellBrowser::Exec(const GUID *pguidCmdGroup, DWORD n
             case 40994:
                 return NavigateToParent();
             case IDM_NOTIFYITBARDIRTY:
-                    SaveITBarLayout();
-                    break;
+                SaveITBarLayout();
+                break;
         }
     }
     else if (IsEqualIID(*pguidCmdGroup, CGID_IExplorerToolbar))
@@ -3978,21 +3978,21 @@ void CShellBrowser::UpdateWindowTitle()
 void CShellBrowser::SaveITBarLayout()
 {
     if (!gCabinetState.fSaveLocalView)
-        return ;
+        return;
 #if 0 // If CDesktopBrowser aggregates us, skip saving
     FOLDERSETTINGS fs;
     if (fCurrentShellView && SUCCEEDED(fCurrentShellView->GetCurrentInfo(&fs)) && (fs.fFlags & FWF_DESKTOP))
-        return ;
+        return;
 #endif
 
     CComPtr<IPersistStreamInit> pPSI;
     CComPtr<IStream> pITBarStream;
     if (!fClientBars[BIInternetToolbar].clientBar.p)
-        return ;
+        return;
     HRESULT hr = fClientBars[BIInternetToolbar].clientBar->QueryInterface(IID_PPV_ARG(IPersistStreamInit, &pPSI));
     if (FAILED(hr))
-        return ;
+        return;
     if (FAILED(hr = CInternetToolbar::GetStream(ITBARSTREAM_EXPLORER, STGM_WRITE, &pITBarStream)))
-        return ;
+        return;
     pPSI->Save(pITBarStream, TRUE);
 }

--- a/sdk/include/reactos/browseui_undoc.h
+++ b/sdk/include/reactos/browseui_undoc.h
@@ -21,6 +21,8 @@
 #ifndef __BROWSEUI_UNDOC_H
 #define __BROWSEUI_UNDOC_H
 
+#define FCW_ADDRESSBAR 9
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* defined(__cplusplus) */

--- a/sdk/include/reactos/browseui_undoc.h
+++ b/sdk/include/reactos/browseui_undoc.h
@@ -21,11 +21,11 @@
 #ifndef __BROWSEUI_UNDOC_H
 #define __BROWSEUI_UNDOC_H
 
-#define FCW_ADDRESSBAR 9
-
 #ifdef __cplusplus
 extern "C" {
 #endif /* defined(__cplusplus) */
+
+#define FCW_ADDRESSBAR 9 // GetControlWindow/IsControlWindowShown
 
 // Name is IETHREADPARAM according to symbols / mangled function names
 #ifdef _WIN64


### PR DESCRIPTION
Save/Restore the visibility state of the ShellBrowser toolbar/addressbar/statusbar. This is somewhat related to [CORE-9094](https://jira.reactos.org/browse/CORE-9094).

Windows shares the state of the Go button and the locked state between Explorer and Internet Explorer but the band/bar states are not shared.

Notes:
 - Seems to fix [CORE-17236](https://jira.reactos.org/browse/CORE-17236).
 - The stream layout does not match Windows so it uses a different name. The toolbar customize dialog needs to be fixed before it makes sense trying to save the toolbar state and the layout of other bands.