### PR TITLE
[MKISOFS] Fix Clang check for macOS platforms

### DIFF
--- a/sdk/tools/mkisofs/CMakeLists.txt
+++ b/sdk/tools/mkisofs/CMakeLists.txt
@@ -108,7 +108,7 @@ else()
     target_compile_options(libschily PRIVATE "-Wno-format")
 
     # MATCHES must be used here because on macOS, CMake uses the compiler ID "AppleClang".
-    if(CMAKE_C_COMPILER_ID MATCHES "Clang" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL "15")
+    if(CMAKE_C_COMPILER_ID MATCHES "Clang$" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL "15")
         # mkisofs uses K&R-style function definitions to support very old compilers.
         # This causes warnings with modern compilers.
         target_compile_options(libmdigest PRIVATE "-Wno-deprecated-non-prototype")

--- a/sdk/tools/mkisofs/CMakeLists.txt
+++ b/sdk/tools/mkisofs/CMakeLists.txt
@@ -107,7 +107,8 @@ else()
     # Silence compilers checking for invalid formatting sequences.
     target_compile_options(libschily PRIVATE "-Wno-format")
 
-    if(CMAKE_C_COMPILER_ID STREQUAL "Clang" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL "15")
+    # MATCHES must be used here because on macOS, CMake uses the compiler ID "AppleClang".
+    if(CMAKE_C_COMPILER_ID MATCHES "Clang" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL "15")
         # mkisofs uses K&R-style function definitions to support very old compilers.
         # This causes warnings with modern compilers.
         target_compile_options(libmdigest PRIVATE "-Wno-deprecated-non-prototype")


### PR DESCRIPTION
## Purpose

On macOS, CMAKE_C_COMPILER_ID is "AppleClang". While this certainly is Clang, it does not match the exact string "Clang" that is being checked for, and as a result the warning flags guarded thereby are not passed to the compiler.

JIRA issue: none

## Proposed changes

Get CMake to recognize both "Clang" and "AppleClang".