### PR TITLE
[NTUSER] Fix IntDefWindowProc()'s WM_MOUSEACTIVATE case

### DIFF
--- a/win32ss/user/ntuser/defwnd.c
+++ b/win32ss/user/ntuser/defwnd.c
@@ -566,7 +566,6 @@ IntDefWindowProc(
                     lResult = (LRESULT) (Wnd->strName.Length / sizeof(WCHAR));
                 }
             }
-            else lResult = 0L;
 
             break;
       }
@@ -1038,12 +1037,15 @@ IntDefWindowProc(
       case WM_MOUSEACTIVATE:
          if (Wnd->style & WS_CHILD)
          {
-             LONG Ret;
              HWND hwndParent;
              PWND pwndParent = IntGetParent(Wnd);
              hwndParent = pwndParent ? UserHMGetHandle(pwndParent) : NULL;
-             if (hwndParent) Ret = co_IntSendMessage(hwndParent, WM_MOUSEACTIVATE, wParam, lParam);
-             if (Ret) return (Ret);
+             if (hwndParent)
+             {
+                 lResult = co_IntSendMessage(hwndParent, WM_MOUSEACTIVATE, wParam, lParam);
+                 if (lResult)
+                     break;
+             }
          }
          return ( (HIWORD(lParam) == WM_LBUTTONDOWN && LOWORD(lParam) == HTCAPTION) ? MA_NOACTIVATE : MA_ACTIVATE );
 

--- a/win32ss/user/ntuser/defwnd.c
+++ b/win32ss/user/ntuser/defwnd.c
@@ -189,6 +189,7 @@ DefWndHandleSysCommand(PWND pWnd, WPARAM wParam, LPARAM lParam)
            }
         }
         break;
+
 //      case SC_DEFAULT:
       case SC_MOUSEMENU:
         {
@@ -197,15 +198,14 @@ DefWndHandleSysCommand(PWND pWnd, WPARAM wParam, LPARAM lParam)
           Pt.y = (short)HIWORD(lParam);
           MENU_TrackMouseMenuBar(pWnd, wParam & 0x000f, Pt);
         }
-	break;
+        break;
 
       case SC_KEYMENU:
         MENU_TrackKbdMenuBar(pWnd, wParam, (WCHAR)lParam);
-	break;
-
+        break;
 
       default:
-   // We do not support anything else here so we should return normal even when sending a hook.
+        // We do not support anything else here so we should return normal even when sending a hook.
         return 0;
    }
 
@@ -284,9 +284,9 @@ DefWndHandleSetCursor(PWND pWnd, WPARAM wParam, LPARAM lParam)
             }
          }
          ////
-	 if (Msg == WM_LBUTTONDOWN || Msg == WM_MBUTTONDOWN ||
-	     Msg == WM_RBUTTONDOWN || Msg == WM_XBUTTONDOWN)
-	 {
+         if (Msg == WM_LBUTTONDOWN || Msg == WM_MBUTTONDOWN ||
+             Msg == WM_RBUTTONDOWN || Msg == WM_XBUTTONDOWN)
+         {
              if (pwndPopUP)
              {
                  FLASHWINFO fwi =
@@ -299,9 +299,9 @@ DefWndHandleSetCursor(PWND pWnd, WPARAM wParam, LPARAM lParam)
                  // Now shake that window!
                  IntFlashWindowEx(pwndPopUP, &fwi);
              }
-	     UserPostMessage(hwndSAS, WM_LOGONNOTIFY, LN_MESSAGE_BEEP, 0);
-	 }
-	 break;
+             UserPostMessage(hwndSAS, WM_LOGONNOTIFY, LN_MESSAGE_BEEP, 0);
+         }
+         break;
       }
 
       case HTCLIENT:
@@ -309,8 +309,8 @@ DefWndHandleSetCursor(PWND pWnd, WPARAM wParam, LPARAM lParam)
          if (pWnd->pcls->spcur)
          {
             IntSystemSetCursor(pWnd->pcls->spcur);
-	 }
-	 return FALSE;
+         }
+         return FALSE;
       }
 
       case HTLEFT:
@@ -716,7 +716,7 @@ IntDefWindowProc(
            * "If it is appropriate to do so, the system sends the WM_SYSCOMMAND
            * message to the window". When is it appropriate?
            */
-           ERR("WM_NCRBUTTONUP\n");
+          ERR("WM_NCRBUTTONUP\n");
           break;
 
       case WM_XBUTTONUP:
@@ -773,7 +773,7 @@ IntDefWindowProc(
                 {
                    WARN("Scroll Menu Not Supported\n");
                 }
-	    }
+            }
             break;
       }
 
@@ -1286,12 +1286,12 @@ IntDefWindowProc(
                }
                if (!lResult)
                   lResult = co_HOOK_CallHooks(WH_CBT, HCBT_MOVESIZE, (WPARAM)UserHMGetHandle(Wnd), lParam ? (LPARAM)&rt : 0);
-           }
-            break;
+
+               break;
+            }
          }
          break;
       }
-      break;
    }
    return lResult;
 }


### PR DESCRIPTION
## Purpose

Clang:
```c
2024-06-19T19:18:45.4695390Z ../src/win32ss/user/ntuser/defwnd.c:1045:18: warning: variable 'Ret' is used uninitialized whenever 'if' condition is false [-Wsometimes-uninitialized]
2024-06-19T19:18:45.4697144Z              if (hwndParent) Ret = co_IntSendMessage(hwndParent, WM_MOUSEACTIVATE, wParam, lParam);
2024-06-19T19:18:45.4698021Z                  ^~~~~~~~~~
2024-06-19T19:18:45.4698806Z ../src/win32ss/user/ntuser/defwnd.c:1046:18: note: uninitialized use occurs here
2024-06-19T19:18:45.4699680Z              if (Ret) return (Ret);
2024-06-19T19:18:45.4700178Z                  ^~~
2024-06-19T19:18:45.4701187Z ../src/win32ss/user/ntuser/defwnd.c:1045:14: note: remove the 'if' if its condition is always true
2024-06-19T19:18:45.4702548Z              if (hwndParent) Ret = co_IntSendMessage(hwndParent, WM_MOUSEACTIVATE, wParam, lParam);
2024-06-19T19:18:45.4703432Z              ^~~~~~~~~~~~~~~~
2024-06-19T19:18:45.4704525Z ../src/win32ss/user/ntuser/defwnd.c:1041:22: note: initialize the variable 'Ret' to silence this warning
2024-06-19T19:18:45.4705548Z              LONG Ret;
2024-06-19T19:18:45.4705948Z                      ^
2024-06-19T19:18:45.4706344Z                       = 0
2024-06-19T19:18:45.4706774Z 1 warning generated.
```

JIRA issue: [CORE-17545](https://jira.reactos.org/browse/CORE-17545)

## Proposed changes

- [NTUSER] defwnd.c: Trivial formatting fixes
And (re)move 2 'break;'.
- [NTUSER] Fix IntDefWindowProc()'s WM_MOUSEACTIVATE case
Clang 13.0.1 was warning about broken 'Ret' handling.
Also remove an unrelated redundant 'else ...'.
Addendum to https://github.com/reactos/reactos/commit/6dfa71c487dbb193ed7fb1a249a8c964ec3aef0d (r68904).