### PR TITLE
[REGEDIT] Strip unneeded WM_TIMER, formatting

### DIFF
--- a/base/applications/regedit/framewnd.c
+++ b/base/applications/regedit/framewnd.c
@@ -1363,26 +1363,24 @@ static BOOL _CmdWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
         RegKeyEditPermissions(hWnd, hKeyRoot, NULL, keyPath);
         break;
     case ID_REGISTRY_PRINTERSETUP:
-        /*PRINTDLG pd;*/
-        /*PrintDlg(&pd);*/
-        /*PAGESETUPDLG psd;*/
-        /*PageSetupDlg(&psd);*/
+        //PRINTDLG pd;
+        //PrintDlg(&pd);
+        //PAGESETUPDLG psd;
+        //PageSetupDlg(&psd);
         break;
     case ID_REGISTRY_OPENLOCAL:
         break;
-
     case ID_VIEW_REFRESH:
         RefreshTreeView(g_pChildWnd->hTreeWnd);
         keyPath = GetItemPath(g_pChildWnd->hTreeWnd, 0, &hKeyRoot);
         RefreshListView(g_pChildWnd->hListWnd, hKeyRoot, keyPath, TRUE);
         break;
-        /*case ID_OPTIONS_TOOLBAR:*/
-        /* toggle_child(hWnd, LOWORD(wParam), hToolBar);*/
-        /*    break;*/
+        //case ID_OPTIONS_TOOLBAR:
+        //   toggle_child(hWnd, LOWORD(wParam), hToolBar);
+        //   break;
     case ID_EDIT_NEW_KEY:
         CreateNewKey(g_pChildWnd->hTreeWnd, TreeView_GetSelection(g_pChildWnd->hTreeWnd));
         break;
-
     case ID_TREE_EXPANDBRANCH:
         TreeView_Expand(g_pChildWnd->hTreeWnd, TreeView_GetSelection(g_pChildWnd->hTreeWnd), TVE_EXPAND);
         break;
@@ -1396,9 +1394,7 @@ static BOOL _CmdWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
     case ID_TREE_DELETE:
         keyPath = GetItemPath(g_pChildWnd->hTreeWnd, TreeView_GetSelection(g_pChildWnd->hTreeWnd), &hKeyRoot);
         if (keyPath == 0 || *keyPath == 0)
-        {
             MessageBeep(MB_ICONHAND);
-        }
         else if (DeleteKey(hWnd, hKeyRoot, keyPath))
             DeleteNode(g_pChildWnd->hTreeWnd, 0);
         break;
@@ -1418,12 +1414,10 @@ static BOOL _CmdWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
             SetFocus(hwndItem);
         }
         break;
-
     case ID_ADDRESS_FOCUS:
         SendMessageW(g_pChildWnd->hAddressBarWnd, EM_SETSEL, 0, -1);
         SetFocus(g_pChildWnd->hAddressBarWnd);
         break;
-
     default:
         if ((LOWORD(wParam) >= ID_FAVORITES_MIN) && (LOWORD(wParam) <= ID_FAVORITES_MAX))
         {

--- a/base/applications/regedit/framewnd.c
+++ b/base/applications/regedit/framewnd.c
@@ -1146,10 +1146,7 @@ FreeObjectPicker(IN IDsObjectPicker *pDsObjectPicker)
     pDsObjectPicker->lpVtbl->Release(pDsObjectPicker);
 }
 
-/*
- *  FUNCTION: _CmdWndProc(HWND, unsigned, WORD, LONG)
- *
- *  PURPOSE:  Processes WM_COMMAND messages for the main frame window.
+/* PURPOSE: Processes WM_COMMAND messages for the main frame window.
  */
 static BOOL _CmdWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
@@ -1472,13 +1469,10 @@ static BOOL _CmdWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
     return result;
 }
 
-/********************************************************************************
- *  FUNCTION: FrameWndProc(HWND, unsigned, WORD, LONG)
+/* PURPOSE: Processes messages for the main frame window
  *
- *  PURPOSE:  Processes messages for the main frame window.
- *
- *  WM_COMMAND  - process the application menu
- *  WM_DESTROY  - post a quit message and return
+ * WM_COMMAND - process the application menu
+ * WM_DESTROY - post a quit message and return
  */
 LRESULT CALLBACK FrameWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 {

--- a/base/applications/regedit/framewnd.c
+++ b/base/applications/regedit/framewnd.c
@@ -1146,7 +1146,7 @@ FreeObjectPicker(IN IDsObjectPicker *pDsObjectPicker)
     pDsObjectPicker->lpVtbl->Release(pDsObjectPicker);
 }
 
-/*
+/**
  * PURPOSE: Processes WM_COMMAND messages for the main frame window.
  */
 static BOOL _CmdWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)

--- a/base/applications/regedit/framewnd.c
+++ b/base/applications/regedit/framewnd.c
@@ -1146,7 +1146,7 @@ FreeObjectPicker(IN IDsObjectPicker *pDsObjectPicker)
     pDsObjectPicker->lpVtbl->Release(pDsObjectPicker);
 }
 
-/*******************************************************************************
+/*
  *  FUNCTION: _CmdWndProc(HWND, unsigned, WORD, LONG)
  *
  *  PURPOSE:  Processes WM_COMMAND messages for the main frame window.

--- a/base/applications/regedit/framewnd.c
+++ b/base/applications/regedit/framewnd.c
@@ -1480,7 +1480,6 @@ static BOOL _CmdWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
  *  WM_COMMAND  - process the application menu
  *  WM_DESTROY  - post a quit message and return
  */
-
 LRESULT CALLBACK FrameWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
     RECT rc;

--- a/base/applications/regedit/framewnd.c
+++ b/base/applications/regedit/framewnd.c
@@ -1464,7 +1464,7 @@ static BOOL _CmdWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
     return result;
 }
 
-/*
+/**
  * PURPOSE: Processes messages for the main frame window
  *
  * WM_COMMAND - process the application menu

--- a/base/applications/regedit/framewnd.c
+++ b/base/applications/regedit/framewnd.c
@@ -1147,11 +1147,9 @@ FreeObjectPicker(IN IDsObjectPicker *pDsObjectPicker)
 }
 
 /*******************************************************************************
- *
  *  FUNCTION: _CmdWndProc(HWND, unsigned, WORD, LONG)
  *
  *  PURPOSE:  Processes WM_COMMAND messages for the main frame window.
- *
  */
 static BOOL _CmdWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
@@ -1382,7 +1380,7 @@ static BOOL _CmdWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
         RefreshListView(g_pChildWnd->hListWnd, hKeyRoot, keyPath, TRUE);
         break;
         /*case ID_OPTIONS_TOOLBAR:*/
-        /*	toggle_child(hWnd, LOWORD(wParam), hToolBar);*/
+        /* toggle_child(hWnd, LOWORD(wParam), hToolBar);*/
         /*    break;*/
     case ID_EDIT_NEW_KEY:
         CreateNewKey(g_pChildWnd->hTreeWnd, TreeView_GetSelection(g_pChildWnd->hTreeWnd));
@@ -1475,14 +1473,12 @@ static BOOL _CmdWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 }
 
 /********************************************************************************
- *
  *  FUNCTION: FrameWndProc(HWND, unsigned, WORD, LONG)
  *
  *  PURPOSE:  Processes messages for the main frame window.
  *
  *  WM_COMMAND  - process the application menu
  *  WM_DESTROY  - post a quit message and return
- *
  */
 
 LRESULT CALLBACK FrameWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
@@ -1508,8 +1504,6 @@ LRESULT CALLBACK FrameWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lPa
         break;
     case WM_SIZE:
         resize_frame_client(hWnd);
-        break;
-    case WM_TIMER:
         break;
     case WM_INITMENU:
         OnInitMenu(hWnd);

--- a/base/applications/regedit/framewnd.c
+++ b/base/applications/regedit/framewnd.c
@@ -1464,7 +1464,8 @@ static BOOL _CmdWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
     return result;
 }
 
-/* PURPOSE: Processes messages for the main frame window
+/*
+ * PURPOSE: Processes messages for the main frame window
  *
  * WM_COMMAND - process the application menu
  * WM_DESTROY - post a quit message and return

--- a/base/applications/regedit/framewnd.c
+++ b/base/applications/regedit/framewnd.c
@@ -1146,7 +1146,8 @@ FreeObjectPicker(IN IDsObjectPicker *pDsObjectPicker)
     pDsObjectPicker->lpVtbl->Release(pDsObjectPicker);
 }
 
-/* PURPOSE: Processes WM_COMMAND messages for the main frame window.
+/*
+ * PURPOSE: Processes WM_COMMAND messages for the main frame window.
  */
 static BOOL _CmdWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 {

--- a/base/applications/regedit/framewnd.c
+++ b/base/applications/regedit/framewnd.c
@@ -1376,8 +1376,8 @@ static BOOL _CmdWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
         RefreshListView(g_pChildWnd->hListWnd, hKeyRoot, keyPath, TRUE);
         break;
         //case ID_OPTIONS_TOOLBAR:
-        //   toggle_child(hWnd, LOWORD(wParam), hToolBar);
-        //   break;
+        //    toggle_child(hWnd, LOWORD(wParam), hToolBar);
+        //    break;
     case ID_EDIT_NEW_KEY:
         CreateNewKey(g_pChildWnd->hTreeWnd, TreeView_GetSelection(g_pChildWnd->hTreeWnd));
         break;


### PR DESCRIPTION
This PR is just cleanup.
* Strip unneeded WM_TIMER
    (an addendum to 0.4.15-dev-7915-g d383b20b01e3528f829068165a2dd0965f869681
    where the WM_TIMER has also been stripped from childwnd.c)
    There is no SetTimer()-call within the whole app.

* Strip a tab-character before toggle_child

* Also strip some comments with outdated signatures, they are pure bloat, and misleading even.

JIRA issue: none
