### PR TITLE
[VFD] Properly mark ReactOS's diffs

### DIFF
--- a/media/doc/3rd Party Files.txt
+++ b/media/doc/3rd Party Files.txt
@@ -287,3 +287,11 @@ Path: sdk/lib/crt/math/libm_sse2
 Used Version: git commit 6121d02
 License: MIT (https://spdx.org/licenses/MIT.html)
 URL: https://github.com/amd/win-libm
+
+Title: Virtual Floppy Drive
+Path: modules/rosapps/applications/cmdutils/vfdcmd
+Path: modules/rosapps/drivers/vfd
+Path: modules/rosapps/lib/vfdlib
+Used Version: 2.1.2008.206
+License: GPL-2.0 (https://spdx.org/licenses/GPL-2.0.html)
+URL: https://vfd.sourceforge.net/

--- a/modules/rosapps/CMakeLists.txt
+++ b/modules/rosapps/CMakeLists.txt
@@ -1,7 +1,6 @@
 add_subdirectory(applications)
 add_subdirectory(demos)
 add_subdirectory(drivers)
-add_subdirectory(include)
 add_subdirectory(lib)
 
 if(ENABLE_ROSAPPS_TEMPLATES)

--- a/modules/rosapps/applications/cmdutils/vfdcmd/vfdmsg.mc
+++ b/modules/rosapps/applications/cmdutils/vfdcmd/vfdmsg.mc
@@ -11,6 +11,11 @@
 ;#ifndef _VFDMSG_H_
 ;#define _VFDMSG_H_
 ;
+;/*
+; __REACTOS__:
+; - Removed Japanese language.
+; + Added a second blank line between some entries.
+;*/
 
 MessageIdTypedef=DWORD
 LanguageNames=(English=0x409:MSG0409)
@@ -1161,6 +1166,7 @@ of the shell extension.
 .
 
 
+;// __REACTOS__: s/read only/read-only/.
 MessageId=
 SymbolicName=MSG_HELP_OPEN
 Language=English
@@ -1360,6 +1366,7 @@ The SAVE command always fails if the target is a ZIP compressed file.
 .
 
 
+;// __REACTOS__: s/read only/read-only/.
 MessageId=
 SymbolicName=MSG_HELP_PROTECT
 Language=English

--- a/modules/rosapps/drivers/vfd/imports.h
+++ b/modules/rosapps/drivers/vfd/imports.h
@@ -27,17 +27,15 @@
 extern "C" {
 #endif	// __cplusplus
 
-#ifdef _MSC_VER
+#if !defined(__REACTOS__) || defined(_MSC_VER)
 #pragma warning(push,3)
 #endif
 #include <ntddk.h>
 #include <ntdddisk.h>
 #include <ntverp.h>
-#ifdef _MSC_VER
+#if !defined(__REACTOS__) || defined(_MSC_VER)
 #pragma warning(pop)
-#endif
 
-#ifdef _MSC_VER
 // disable unwanted (and trivial) warnings :
 //	4054 - type cast from a function pointer to a data pointer
 //	4201 - anonymous structure
@@ -178,6 +176,8 @@ typedef struct _MOUNTMGR_MOUNT_POINTS {
 } MOUNTMGR_MOUNT_POINTS, *PMOUNTMGR_MOUNT_POINTS;
 
 #endif	// (VER_PRODUCTBUILD < 2195)
+
+// __REACTOS__: NTAPI added on some functions in this file, vfddrv.h and some *.c.
 
 #if (VER_PRODUCTBUILD < 2600)
 //

--- a/modules/rosapps/drivers/vfd/vfddbg.c
+++ b/modules/rosapps/drivers/vfd/vfddbg.c
@@ -9,9 +9,11 @@
 
 #if !DBG
 
+#if !defined(__REACTOS__) || defined(_MSC_VER)
 //	suppress empty compile unit warning
 #pragma warning (disable: 4206)
 #pragma message ("Debug feature is disabled.")
+#endif
 
 #else	// DBG
 
@@ -514,7 +516,7 @@ GetIoControlName(
 	CASE_RETURN_STR(IOCTL_DISK_GROW_PARTITION);
 	CASE_RETURN_STR(IOCTL_DISK_GET_CACHE_INFORMATION);
 	CASE_RETURN_STR(IOCTL_DISK_SET_CACHE_INFORMATION);
-#if (NTDDI_VERSION < NTDDI_WS03)
+#if !defined(__REACTOS__) || (NTDDI_VERSION < NTDDI_WS03)
 	CASE_RETURN_STR(IOCTL_DISK_GET_WRITE_CACHE_STATE);
 #else
     CASE_RETURN_STR(OBSOLETE_DISK_GET_WRITE_CACHE_STATE);

--- a/modules/rosapps/drivers/vfd/vfdimg.c
+++ b/modules/rosapps/drivers/vfd/vfdimg.c
@@ -284,7 +284,7 @@ VfdOpenImage (
 #ifndef __REACTOS__
 			&file_object,
 #else
-            (PVOID *)&file_object,
+			(PVOID *)&file_object,
 #endif
 			NULL);
 

--- a/modules/rosapps/drivers/vfd/vfdmnt.c
+++ b/modules/rosapps/drivers/vfd/vfdmnt.c
@@ -13,7 +13,7 @@
 	so DO NOT define VFD_MOUNT_MANAGER macro
 	unless you know exactly what you are doing...
 */
-#ifdef _MSC_VER
+#if !defined(__REACTOS__) || defined(_MSC_VER)
 //	suppress empty compile unit warning
 #pragma warning (disable: 4206)
 #pragma message ("Mount Manager support feature is disabled.")

--- a/modules/rosapps/drivers/vfd/vfdpnp.c
+++ b/modules/rosapps/drivers/vfd/vfdpnp.c
@@ -13,8 +13,8 @@
 	so DO NOT define VFD_PNP macro
 	unless you know exactly what you are doing...
 */
+#if !defined(__REACTOS__) || defined(_MSC_VER)
 //	suppress empty compile unit warning
-#ifdef _MSC_VER
 #pragma warning (disable: 4206)
 #pragma message ("Plug and play support feature is disabled.")
 #endif

--- a/modules/rosapps/include/CMakeLists.txt
+++ b/modules/rosapps/include/CMakeLists.txt
@@ -1,1 +1,0 @@
-add_subdirectory(vfd)

--- a/modules/rosapps/include/vfd/vfdio.h
+++ b/modules/rosapps/include/vfd/vfdio.h
@@ -55,7 +55,7 @@
 //	Used for IOCTL_VFD_OPEN_IMAGE and IOCTL_VFD_QUERY_IMAGE
 //
 #pragma pack	(push,2)
-#ifdef _MSC_VER
+#if !defined(__REACTOS__) || defined(_MSC_VER)
 #pragma warning (push)
 #pragma warning (disable: 4200)		//	Zero sized struct member warning
 #endif
@@ -70,7 +70,7 @@ typedef struct _VFD_IMAGE_INFO {
 	CHAR			FileName[0];	//	variable length file name string
 } VFD_IMAGE_INFO, *PVFD_IMAGE_INFO;
 
-#ifdef _MSC_VER
+#if !defined(__REACTOS__) || defined(_MSC_VER)
 #pragma warning (pop)
 #endif
 #pragma pack	(pop)

--- a/modules/rosapps/lib/vfdlib/vfdctl.c
+++ b/modules/rosapps/lib/vfdlib/vfdctl.c
@@ -15,12 +15,12 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <dbt.h>
-#ifdef _MSC_VER
+#if !defined(__REACTOS__) || defined(_MSC_VER)
 #pragma warning (push, 3)
 #endif
 #include <shlobj.h>
 #include <winioctl.h>
-#ifdef _MSC_VER
+#if !defined(__REACTOS__) || defined(_MSC_VER)
 #pragma warning (pop)
 #endif
 #include <stdio.h>

--- a/modules/rosapps/lib/vfdlib/vfdguiopen.c
+++ b/modules/rosapps/lib/vfdlib/vfdguiopen.c
@@ -14,11 +14,11 @@
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#ifdef _MSC_VER
+#if !defined(__REACTOS__) || defined(_MSC_VER)
 #pragma warning(push,3)
 #endif
 #include <commdlg.h>
-#ifdef _MSC_VER
+#if !defined(__REACTOS__) || defined(_MSC_VER)
 #pragma warning(pop)
 #endif
 
@@ -404,7 +404,11 @@ void OnBrowse(
 	ofn.nMaxFile	= sizeof(file);
 	ofn.lpstrInitialDir = dir;
 	ofn.lpstrTitle	= title ? title : FALLBACK_IMAGE_TITLE;
+#ifndef __REACTOS__
+	ofn.Flags		= OFN_ENABLESIZING | OFN_HIDEREADONLY | OFN_PATHMUSTEXIST;
+#else
 	ofn.Flags		= OFN_EXPLORER | OFN_ENABLESIZING | OFN_HIDEREADONLY | OFN_PATHMUSTEXIST;
+#endif
 
 	//	show the open file dialog box
 

--- a/modules/rosapps/lib/vfdlib/vfdguisave.c
+++ b/modules/rosapps/lib/vfdlib/vfdguisave.c
@@ -14,11 +14,11 @@
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#ifdef _MSC_VER
+#if !defined(__REACTOS__) || defined(_MSC_VER)
 #pragma warning(push,3)
 #endif
 #include <commdlg.h>
-#ifdef _MSC_VER
+#if !defined(__REACTOS__) || defined(_MSC_VER)
 #pragma warning(pop)
 #endif
 
@@ -195,7 +195,11 @@ void OnInit(
 {
 	//	Store parameters
 
+#ifndef __REACTOS__
+	SetWindowLong(hDlg, GWL_USERDATA, (ULONG)pParam);
+#else
 	SetWindowLongPtr(hDlg, GWLP_USERDATA, (ULONG_PTR)pParam);
+#endif
 
 	//	clear the target existence flag
 
@@ -293,7 +297,11 @@ void OnTarget(
 	//
 	//	get the current image info
 	//
+#ifndef __REACTOS__
+	param = (PCSAVE_PARAM)GetWindowLong(hDlg, GWL_USERDATA);
+#else
 	param = (PCSAVE_PARAM)GetWindowLongPtr(hDlg, GWLP_USERDATA);
+#endif
 
 	if (_stricmp(param->ImageName, buf) == 0) {
 
@@ -422,7 +430,11 @@ void OnBrowse(
 	ofn.lpstrInitialDir = dir;
 	ofn.lpstrTitle	= title ? title : "Save Image";
 	ofn.lpstrFilter	= "*.*\0*.*\0";
+#ifndef __REACTOS__
+	ofn.Flags		= OFN_ENABLESIZING | OFN_HIDEREADONLY | OFN_PATHMUSTEXIST;
+#else
 	ofn.Flags		= OFN_EXPLORER | OFN_ENABLESIZING | OFN_HIDEREADONLY | OFN_PATHMUSTEXIST;
+#endif
 
 	if (GetSaveFileName(&ofn)) {
 		SetDlgItemText(hDlg, IDC_TARGETFILE, file);
@@ -469,7 +481,11 @@ DWORD OnOK(
 	BOOL			truncate;
 	DWORD			ret;
 
+#ifndef __REACTOS__
+	param = (PCSAVE_PARAM)GetWindowLong(hDlg, GWL_USERDATA);
+#else
 	param = (PCSAVE_PARAM)GetWindowLongPtr(hDlg, GWLP_USERDATA);
+#endif
 
 	if (!param) {
 		return ERROR_INVALID_FUNCTION;

--- a/modules/rosapps/lib/vfdlib/vfdguitip.c
+++ b/modules/rosapps/lib/vfdlib/vfdguitip.c
@@ -41,8 +41,13 @@ static LRESULT CALLBACK ToolTipProc(
 	switch (uMsg) {
 	case WM_CREATE:
 		//	Store Font handle
+#ifndef __REACTOS__
+		SetWindowLong(hWnd, GWL_USERDATA,
+			(LONG)((LPCREATESTRUCT)lParam)->lpCreateParams);
+#else
 		SetWindowLongPtr(hWnd, GWLP_USERDATA,
 			(LONG_PTR)((LPCREATESTRUCT)lParam)->lpCreateParams);
+#endif
 		return 0;
 
 	case WM_PAINT:
@@ -56,7 +61,11 @@ static LRESULT CALLBACK ToolTipProc(
 				RECT rc;
 
 
+#ifndef __REACTOS__
+				SelectObject(hDC, (HFONT)GetWindowLong(hWnd, GWL_USERDATA));
+#else
 				SelectObject(hDC, (HFONT)GetWindowLongPtr(hWnd, GWLP_USERDATA));
+#endif
 
 				SetTextColor(hDC, GetSysColor(COLOR_INFOTEXT));
 				SetBkMode(hDC, TRANSPARENT);
@@ -121,7 +130,11 @@ static LRESULT CALLBACK ToolTipProc(
 
 	case WM_DESTROY:
 		//	delete font
+#ifndef __REACTOS__
+		DeleteObject((HFONT)GetWindowLong(hWnd, GWL_USERDATA));
+#else
 		DeleteObject((HFONT)GetWindowLongPtr(hWnd, GWLP_USERDATA));
+#endif
 		return 0;
 	}
 

--- a/modules/rosapps/lib/vfdlib/vfdmsg_lib.mc
+++ b/modules/rosapps/lib/vfdlib/vfdmsg_lib.mc
@@ -11,6 +11,12 @@
 ;#ifndef _VFDMSG_H_
 ;#define _VFDMSG_H_
 ;
+;/*
+; __REACTOS__:
+; * Renamed file from vfdmsg.mc.
+; - Removed Japanese language.
+; + Added a second blank line between some entries.
+;*/
 
 MessageIdTypedef=DWORD
 LanguageNames=(English=0x409:msg0409)

--- a/modules/rosapps/lib/vfdlib/vfdshext.h
+++ b/modules/rosapps/lib/vfdlib/vfdshext.h
@@ -70,7 +70,7 @@ public:
 #ifndef __REACTOS__
 		UINT			idCmd,
 #else
-        UINT_PTR		idCmd,
+		UINT_PTR		idCmd,
 #endif
 		UINT			uFlags,
 		UINT			*reserved,

--- a/modules/rosapps/lib/vfdlib/vfdshmenu.cpp
+++ b/modules/rosapps/lib/vfdlib/vfdshmenu.cpp
@@ -270,7 +270,7 @@ STDMETHODIMP CVfdShExt::GetCommandString(
 #ifndef __REACTOS__
 	UINT			idCmd,
 #else
-    UINT_PTR		idCmd,
+	UINT_PTR		idCmd,
 #endif
 	UINT			uFlags,
 	UINT			*reserved,
@@ -349,6 +349,7 @@ STDMETHODIMP CVfdShExt::InvokeCommand(
 		unicode = TRUE;
 	}
 #endif
+
 
 	if (!unicode && HIWORD(lpcmi->lpVerb)) {
 

--- a/modules/rosapps/lib/vfdlib/vfdshutil.cpp
+++ b/modules/rosapps/lib/vfdlib/vfdshutil.cpp
@@ -22,14 +22,14 @@
 // Initialize the GUID instance
 //=====================================
 
-#ifdef _MSC_VER
+#if !defined(__REACTOS__) || defined(_MSC_VER)
 #pragma data_seg(".text")
 #endif
 #define INITGUID
 #include <initguid.h>
 #include <shlguid.h>
 #include "vfdshguid.h"
-#ifdef _MSC_VER
+#if !defined(__REACTOS__) || defined(_MSC_VER)
 #pragma data_seg()
 #endif
 


### PR DESCRIPTION
## Purpose

build-linux (gcc, i386, Release, 0x502):
```c
2024-06-20T14:31:18.4098509Z [7100/12822] Building C object modules/rosapps/drivers/vfd/CMakeFiles/vfddrv.dir/vfddbg.c.obj
2024-06-20T14:31:18.4100686Z ../src/modules/rosapps/drivers/vfd/vfddbg.c:13: warning: ignoring #pragma warning  [-Wunknown-pragmas]
2024-06-20T14:31:18.4102219Z  #pragma warning (disable: 4206)
2024-06-20T14:31:18.4102853Z  
2024-06-20T14:31:18.4103740Z ../src/modules/rosapps/drivers/vfd/vfddbg.c:14:9: note: #pragma message: Debug feature is disabled.
2024-06-20T14:31:18.4104893Z  #pragma message ("Debug feature is disabled.")
2024-06-20T14:31:18.4105488Z          ^~~~~~~
```

Addendum to https://github.com/reactos/reactos/commit/25c7e1a8d049932380fb101bf413142dd058d723 (0.4.7-dev-1106) and follow-ups.

## Proposed changes

- [DOC] 3rd Party Files.txt: Add 'Virtual Floppy Drive
- [VFD] Remove 2 useless CMakeLists.txt
- [VFD] Properly mark ReactOS's diffs