### PR TITLE
[EXT2FS] Fix a warning about ClearLongFlag()

### DIFF
--- a/drivers/filesystems/ext2/CMakeLists.txt
+++ b/drivers/filesystems/ext2/CMakeLists.txt
@@ -101,10 +101,10 @@ if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
 endif()
 
 if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
-    target_compile_options(ext2fs PRIVATE
-        -Wno-parentheses-equality
-        -Wno-incompatible-pointer-types-discards-qualifiers
-        "-Wno-#pragma-messages;-Wno-cast-calling-convention")
+    target_compile_options(ext2fs PRIVATE -Wno-parentheses-equality)
+    if(ARCH STREQUAL "i386")
+        target_compile_options(ext2fs PRIVATE -Wno-cast-calling-convention) # FIXME: CORE-17545
+    endif()
 endif()
 
 target_link_libraries(ext2fs memcmp ${PSEH_LIB})

--- a/drivers/filesystems/ext2/inc/ext2fs.h
+++ b/drivers/filesystems/ext2/inc/ext2fs.h
@@ -255,8 +255,13 @@ Ext2ClearFlag(PULONG Flags, ULONG FlagBit)
 
 #else
 
+#ifndef __REACTOS__
 #define SetLongFlag(_F,_SF)       InterlockedOr(&(_F), (ULONG)(_SF))
 #define ClearLongFlag(_F,_SF)     InterlockedAnd(&(_F), ~((ULONG)(_SF)))
+#else
+#define SetLongFlag(_F,_SF)       InterlockedOr((PULONG)&(_F), (ULONG)(_SF))
+#define ClearLongFlag(_F,_SF)     InterlockedAnd((PULONG)&(_F), ~((ULONG)(_SF)))
+#endif
 
 #endif  /* release */
 


### PR DESCRIPTION
## Purpose

build-linux (gcc, i386, Release, 0x502):
```c
2024-06-21T22:23:16.1871512Z [6438/12822] Building C object drivers/filesystems/ext2/CMakeFiles/ext2fs.dir/src/ext3/recover.c.obj
2024-06-21T22:23:16.1872914Z In file included from ../src/drivers/filesystems/ext2/src/ext3/recover.c:12:
2024-06-21T22:23:16.1874534Z ../src/drivers/filesystems/ext2/src/ext3/recover.c: In function 'Ext2RecoverJournal':
2024-06-21T22:23:16.1876978Z ../src/drivers/filesystems/ext2/inc/ext2fs.h:259:50: warning: passing argument 1 of '_InterlockedAnd' from incompatible pointer type [-Wincompatible-pointer-types]
2024-06-21T22:23:16.1880082Z  #define ClearLongFlag(_F,_SF)     InterlockedAnd(&(_F), ~((ULONG)(_SF)))
2024-06-21T22:23:16.1881028Z                                                   ^~~~~
2024-06-21T22:23:16.1882408Z ../src/drivers/filesystems/ext2/src/ext3/recover.c:154:9: note: in expansion of macro 'ClearLongFlag'
2024-06-21T22:23:16.1883780Z          ClearLongFlag(
2024-06-21T22:23:16.1884269Z          ^~~~~~~~~~~~~
2024-06-21T22:23:16.1884985Z In file included from ../src/sdk/include/crt/mingw32/intrin.h:89,
2024-06-21T22:23:16.1885917Z                  from ../src/sdk/include/crt/intrin.h:1017,
2024-06-21T22:23:16.1886640Z                  from sdk/include/ddk/wdm.h:70,
2024-06-21T22:23:16.1887320Z                  from sdk/include/ddk/ntddk.h:38,
2024-06-21T22:23:16.1888371Z                  from sdk/include/ddk/ntifs.h:35,
2024-06-21T22:23:16.1889206Z                  from ../src/drivers/filesystems/ext2/inc/linux/types.h:9,
2024-06-21T22:23:16.1890194Z                  from ../src/drivers/filesystems/ext2/inc/linux/module.h:16,
2024-06-21T22:23:16.1891183Z                  from ../src/drivers/filesystems/ext2/inc/ext2fs.h:15,
2024-06-21T22:23:16.1892211Z                  from ../src/drivers/filesystems/ext2/src/ext3/recover.c:12:
2024-06-21T22:23:16.1894339Z ../src/sdk/include/crt/mingw32/intrin_x86.h:243:54: note: expected 'volatile long int *' but argument is of type 'u32 *' {aka 'unsigned int *'}
2024-06-21T22:23:16.1896153Z  __INTRIN_INLINE long _InterlockedAnd(volatile long * value, long mask)
2024-06-21T22:23:16.1897074Z                                       ~~~~~~~~~~~~~~~~^~~~~
```

## Proposed changes

- [EXT2FS] CMakeLists.txt: Clean Clang warning exclusions up
- [EXT2FS] Fix a warning about ClearLongFlag()
Noticed on gcc-*-Release-0x502 builds, at least.
Addendum to 897634c (r69509).
