### PR TITLE
[BROWSEUI] Ensure menu dock site is visible when parent ShowDW is called

### DIFF
--- a/dll/win32/browseui/internettoolbar.cpp
+++ b/dll/win32/browseui/internettoolbar.cpp
@@ -1507,8 +1507,8 @@ HRESULT STDMETHODCALLTYPE CInternetToolbar::EnumBands(UINT uBand, DWORD *pdwBand
     if (uBand == ~0ul)
         return ::SendMessage(fMainReBar, RB_GETBANDCOUNT, 0, 0);
     int id;
-    IUnknown *pUnk;
-    HRESULT hr = EnumBands(uBand, &id, &pUnk);
+    IUnknown *pUnkUnused;
+    HRESULT hr = EnumBands(uBand, &id, &pUnkUnused);
     if (SUCCEEDED(hr))
         *pdwBandID = id;
     return hr;

--- a/dll/win32/browseui/internettoolbar.cpp
+++ b/dll/win32/browseui/internettoolbar.cpp
@@ -923,7 +923,7 @@ HRESULT STDMETHODCALLTYPE CInternetToolbar::ShowDW(BOOL fShow)
             return hResult;
     }
 
-    // TODO: Why should showing the IDockingWindow change all bands? Related to CORE-17236
+    // TODO: Why should showing the IDockingWindow change all bands? Related to CORE-17236 and CORE-19659.
     int id;
     IUnknown *pUnk;
     for (UINT i = 0; SUCCEEDED(EnumBands(i, &id, &pUnk)); ++i)

--- a/dll/win32/browseui/internettoolbar.h
+++ b/dll/win32/browseui/internettoolbar.h
@@ -102,6 +102,7 @@ public:
     CInternetToolbar();
     virtual ~CInternetToolbar();
     void AddDockItem(IUnknown *newItem, int bandID, int flags);
+    HRESULT EnumBands(UINT Index, int *pBandId, IUnknown **ppUnkBand);
     HRESULT ReserveBorderSpace(LONG maxHeight = -1);
     HRESULT CreateMenuBar(IShellMenu **menuBar);
     HRESULT CreateToolsBar(IUnknown **toolsBar);


### PR DESCRIPTION
Fix for JIRA issue [CORE-19659](https://jira.reactos.org/browse/CORE-19659)

Addendum to https://github.com/reactos/reactos/pull/7035

I'm still not sure why `ShowDW` on the InternetToolbar(rebar) should propagate to all its band children and on top of this, why the menu would care.

Also implemented `IBandSite::EnumBands` and the EnumBands helper function is designed to also ease the implementation of `GetBandObject` later.