### PR TITLE
[SHLWAPI][EXPLORER] Implement OS_SERVERADMINUI

### DIFF
--- a/base/shell/explorer/explorer.cpp
+++ b/base/shell/explorer/explorer.cpp
@@ -54,7 +54,7 @@ InitializeServerAdminUI()
 {
     HKEY hKey = SHGetShellKey(SHKEY_Root_HKCU | SHKEY_Key_Explorer, L"Advanced", TRUE);
     if (!hKey)
-        return ;
+        return;
 
     DWORD value, size = sizeof(value), type;
     DWORD error = SHGetValueW(hKey, NULL, L"ServerAdminUI", &type, &value, &size);
@@ -62,12 +62,12 @@ InitializeServerAdminUI()
     {
         // The value doesn't exist or is invalid, calculate and apply a default value
         value = IsOS(OS_ANYSERVER) && IsUserAnAdmin();
+        SHSetValueW(hKey, NULL, L"ServerAdminUI", REG_DWORD, &value, sizeof(value));
         if (value)
         {
             // TODO: Apply registry tweaks with RegInstallW; RegServerAdmin in the REGINST resource in shell32.
             SystemParametersInfo(SPI_SETKEYBOARDCUES, 0, IntToPtr(TRUE), SPIF_SENDCHANGE | SPIF_UPDATEINIFILE);
         }
-        SHSetValueW(hKey, NULL, L"ServerAdminUI", REG_DWORD, &value, sizeof(value));
     }
     RegCloseKey(hKey);
 }

--- a/base/shell/explorer/explorer.cpp
+++ b/base/shell/explorer/explorer.cpp
@@ -49,6 +49,41 @@ static VOID InitializeAtlModule(HINSTANCE hInstance, BOOL bInitialize)
     }
 }
 
+static BOOL
+GetServerAdminUIDefault()
+{
+    BOOL server;
+    DWORD value = 0, size = sizeof(value);
+    LPCWSTR rosregpath = L"SYSTEM\\CurrentControlSet\\Control\\ReactOS\\Settings\\Version";
+    if (SHGetValueW(HKEY_LOCAL_MACHINE, rosregpath, L"ReportAsWorkstation", NULL, &value, &size) == NO_ERROR)
+        server = value == 0;
+    else
+        server = IsOS(OS_ANYSERVER);
+    return server && IsUserAnAdmin();
+}
+
+static void
+InitializeServerAdminUI()
+{
+    HKEY hKey = SHGetShellKey(SHKEY_Root_HKCU | SHKEY_Key_Explorer, L"Advanced", TRUE);
+    if (hKey)
+    {
+        DWORD value, size = sizeof(value), type;
+        DWORD error = SHGetValueW(hKey, NULL, L"ServerAdminUI", &type, &value, &size);
+        if (error || type != REG_DWORD || size != sizeof(value))
+        {
+            value = GetServerAdminUIDefault();
+            if (value)
+            {
+                // TODO: Apply registry tweaks with RegInstallW; RegServerAdmin in the REGINST resource in shell32.
+                SystemParametersInfo(SPI_SETKEYBOARDCUES, 0, IntToPtr(TRUE), SPIF_SENDCHANGE | SPIF_UPDATEINIFILE);
+            }
+            SHSetValueW(hKey, NULL, L"ServerAdminUI", REG_DWORD, &value, sizeof(value));
+        }
+        RegCloseKey(hKey);
+    }
+}
+
 #if !WIN7_DEBUG_MODE
 static BOOL
 SetShellReadyEvent(IN LPCWSTR lpEventName)
@@ -198,6 +233,8 @@ StartWithDesktop(IN HINSTANCE hInstance)
     /* WinXP: Notify msgina to hide the welcome screen */
     if (!SetShellReadyEvent(L"msgina: ShellReadyEvent"))
         SetShellReadyEvent(L"Global\\msgina: ShellReadyEvent");
+
+    InitializeServerAdminUI();
 
     if (DoStartStartupItems(Tray))
     {

--- a/base/shell/explorer/explorer.cpp
+++ b/base/shell/explorer/explorer.cpp
@@ -66,7 +66,9 @@ InitializeServerAdminUI()
         if (value)
         {
             // TODO: Apply registry tweaks with RegInstallW; RegServerAdmin in the REGINST resource in shell32.
+            #if !ROSPOLICY_SHELL_NODEFKEYBOARDCUES
             SystemParametersInfo(SPI_SETKEYBOARDCUES, 0, IntToPtr(TRUE), SPIF_SENDCHANGE | SPIF_UPDATEINIFILE);
+            #endif
         }
     }
     RegCloseKey(hKey);

--- a/base/shell/explorer/explorer.cpp
+++ b/base/shell/explorer/explorer.cpp
@@ -202,6 +202,8 @@ StartWithDesktop(IN HINSTANCE hInstance)
     /* Initialize CLSID_ShellWindows class */
     _WinList_Init();
 
+    InitializeServerAdminUI();
+
     CComPtr<ITrayWindow> Tray;
     CreateTrayWindow(&Tray);
 
@@ -221,8 +223,6 @@ StartWithDesktop(IN HINSTANCE hInstance)
     /* WinXP: Notify msgina to hide the welcome screen */
     if (!SetShellReadyEvent(L"msgina: ShellReadyEvent"))
         SetShellReadyEvent(L"Global\\msgina: ShellReadyEvent");
-
-    InitializeServerAdminUI();
 
     if (DoStartStartupItems(Tray))
     {

--- a/dll/cpl/sysdm/advanced.c
+++ b/dll/cpl/sysdm/advanced.c
@@ -9,8 +9,8 @@
  */
 
 #include "precomp.h"
-#define WIN32_NO_STATUS
-#include "pstypes.h" /* SharedUserData */
+#define NTOS_MODE_USER
+#include <ndk/pstypes.h> /* For SharedUserData */
 
 static TCHAR BugLink[] = _T("http://jira.reactos.org/");
 static TCHAR ReportAsWorkstationKey[] = _T("SYSTEM\\CurrentControlSet\\Control\\ReactOS\\Settings\\Version");
@@ -56,7 +56,7 @@ OnInitSysSettingsDialog(HWND hwndDlg)
     DWORD dwVal = 0;
     DWORD dwType = REG_DWORD;
     DWORD cbData = sizeof(DWORD);
-    BOOL ReportAsWorkstation = SharedUserData->NtProductType == VER_NT_WORKSTATION;
+    BOOL ReportAsWorkstation = SharedUserData->NtProductType == NtProductWinNt;
 
     if (RegOpenKeyEx(HKEY_LOCAL_MACHINE,
                      ReportAsWorkstationKey,
@@ -71,7 +71,7 @@ OnInitSysSettingsDialog(HWND hwndDlg)
                             (LPBYTE)&dwVal,
                             &cbData) == ERROR_SUCCESS)
         {
-            if (cbData == sizeof(DWORD))
+            if (dwType == REG_DWORD && cbData == sizeof(DWORD))
                 ReportAsWorkstation = dwVal != FALSE;
         }
 

--- a/dll/ntdll/rtl/version.c
+++ b/dll/ntdll/rtl/version.c
@@ -53,11 +53,11 @@ SetRosSpecificInfo(IN OUT PRTL_OSVERSIONINFOEXW VersionInformation)
             (kvpInfo->Type == REG_DWORD) &&
             (kvpInfo->DataLength == sizeof(ULONG)))
         {
-            ULONG IsWorkstation = SharedUserData->NtProductType == NtProductWinNt;
-            ULONG ReportAsWorkstation = (*(PULONG)kvpInfo->Data) != 0;
+            BOOLEAN IsWorkstation = SharedUserData->NtProductType == NtProductWinNt;
+            BOOLEAN ReportAsWorkstation = (*(PULONG)kvpInfo->Data) != 0;
             if (IsWorkstation != ReportAsWorkstation)
             {
-                g_ReportProductType = ReportAsWorkstation ? NtProductWinNt : NtProductServer;
+                g_ReportProductType = ReportAsWorkstation ? VER_NT_WORKSTATION : VER_NT_SERVER;
             }
         }
 
@@ -73,7 +73,7 @@ SetRosSpecificInfo(IN OUT PRTL_OSVERSIONINFOEXW VersionInformation)
     }
     else
     {
-        g_ReportProductType = -1;
+        g_ReportProductType = -1; /* No override, caller gets the real value */
     }
 }
 

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -3820,7 +3820,8 @@ HRESULT STDMETHODCALLTYPE CDefView::GetView(SHELLVIEWID *pVid, ULONG view_type)
     if ((int)view_type < 0)
         return E_UNEXPECTED;
 
-    if (!IsSupportedFolderViewMode(view_type += FVM_FIRST))
+    view_type += FVM_FIRST;
+    if (!IsSupportedFolderViewMode(view_type))
         return E_INVALIDARG;
     *pVid = *FolderViewModeToShellViewId(view_type);
     return S_OK;

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -218,6 +218,10 @@ static inline COLORREF GetViewColor(COLORREF Clr, UINT SysFallback)
     return Clr != CLR_INVALID ? Clr : GetSysColor(SysFallback);
 }
 
+#define VID_Default ( *(const SHELLVIEWID*)&IID_CDefView )
+extern HRESULT ShellViewIdToFolderViewMode(const SHELLVIEWID *pVid);
+extern const SHELLVIEWID* FolderViewModeToShellViewId(UINT FVM);
+
 class CDefView :
     public CWindowImpl<CDefView, CWindow, CControlWinTraits>,
     public CComObjectRootEx<CComMultiThreadModelNoCS>,
@@ -373,6 +377,11 @@ public:
         return 0;
     }
 
+    static inline bool IsSupportedFolderViewMode(int Mode)
+    {
+        return Mode >= FVM_FIRST && Mode <= FVM_DETAILS; // We don't support Tile nor Thumbstrip
+    }
+
     // *** IOleWindow methods ***
     STDMETHOD(GetWindow)(HWND *lphwnd) override;
     STDMETHOD(ContextSensitiveHelp)(BOOL fEnterMode) override;
@@ -391,7 +400,7 @@ public:
     STDMETHOD(GetItemObject)(UINT uItem, REFIID riid, void **ppv) override;
 
     // *** IShellView2 methods ***
-    STDMETHOD(GetView)(SHELLVIEWID *view_guid, ULONG view_type) override;
+    STDMETHOD(GetView)(SHELLVIEWID *pVid, ULONG view_type) override;
     STDMETHOD(CreateViewWindow2)(LPSV2CVW2_PARAMS view_params) override;
     STDMETHOD(HandleRename)(LPCITEMIDLIST pidl) override;
     STDMETHOD(SelectAndPositionItem)(LPCITEMIDLIST item, UINT flags, POINT *point) override;
@@ -842,10 +851,7 @@ LRESULT CDefView::OnUpdateStatusbar(UINT uMsg, WPARAM wParam, LPARAM lParam, BOO
 // creates the list view window
 BOOL CDefView::CreateList()
 {
-    HRESULT hr;
     DWORD dwStyle, dwExStyle, ListExStyle;
-    UINT ViewMode;
-
     TRACE("%p\n", this);
 
     dwStyle = WS_TABSTOP | WS_VISIBLE | WS_CHILDWINDOW | WS_CLIPSIBLINGS | WS_CLIPCHILDREN |
@@ -866,16 +872,6 @@ BOOL CDefView::CreateList()
 #if 0 // FIXME: Temporarily disabled until ListView is fixed (CORE-19624, CORE-19818)
         ListExStyle |= LVS_EX_DOUBLEBUFFER;
 #endif
-    }
-
-    ViewMode = m_FolderSettings.ViewMode;
-    hr = _DoFolderViewCB(SFVM_DEFVIEWMODE, 0, (LPARAM)&ViewMode);
-    if (SUCCEEDED(hr))
-    {
-        if (ViewMode >= FVM_FIRST && ViewMode <= FVM_LAST)
-            m_FolderSettings.ViewMode = ViewMode;
-        else
-            ERR("Ignoring invalid ViewMode from SFVM_DEFVIEWMODE: %u (was: %u)\n", ViewMode, m_FolderSettings.ViewMode);
     }
 
     switch (m_FolderSettings.ViewMode)
@@ -3605,7 +3601,7 @@ FOLDERVIEWMODE CDefView::GetDefaultViewMode()
 {
     FOLDERVIEWMODE mode = ((m_FolderSettings.fFlags & FWF_DESKTOP) || !IsOS(OS_SERVERADMINUI)) ? FVM_ICON : FVM_DETAILS;
     FOLDERVIEWMODE temp = mode;
-    if (SUCCEEDED(_DoFolderViewCB(SFVM_DEFVIEWMODE, 0, (LPARAM)&temp)) && temp >= FVM_FIRST && temp <= FVM_LAST)
+    if (SUCCEEDED(_DoFolderViewCB(SFVM_DEFVIEWMODE, 0, (LPARAM)&temp)) && IsSupportedFolderViewMode(temp))
         mode = temp;
     return mode;
 }
@@ -3812,10 +3808,22 @@ HRESULT STDMETHODCALLTYPE CDefView::SelectAndPositionItems(UINT cidl, PCUITEMID_
 
 // IShellView2 implementation
 
-HRESULT STDMETHODCALLTYPE CDefView::GetView(SHELLVIEWID *view_guid, ULONG view_type)
+HRESULT STDMETHODCALLTYPE CDefView::GetView(SHELLVIEWID *pVid, ULONG view_type)
 {
-    FIXME("(%p)->(%p, %lu) stub\n", this, view_guid, view_type);
-    return E_NOTIMPL;
+    if (view_type == SV2GV_DEFAULTVIEW)
+    {
+        *pVid = VID_Default;
+        return S_OK;
+    }
+    if (view_type == SV2GV_CURRENTVIEW)
+        view_type = m_FolderSettings.ViewMode;
+    if ((int)view_type < 0)
+        return E_UNEXPECTED;
+
+    if (!IsSupportedFolderViewMode(view_type += FVM_FIRST))
+        return E_INVALIDARG;
+    *pVid = *FolderViewModeToShellViewId(view_type);
+    return S_OK;
 }
 
 HRESULT STDMETHODCALLTYPE CDefView::CreateViewWindow2(LPSV2CVW2_PARAMS view_params)
@@ -3844,9 +3852,6 @@ HRESULT STDMETHODCALLTYPE CDefView::CreateViewWindow3(IShellBrowser *psb, IShell
     if (view_flags & ~SUPPORTED_SV3CVW3)
         FIXME("unsupported view flags 0x%08x\n", view_flags & ~SUPPORTED_SV3CVW3);
 
-    if (mode == FVM_AUTO)
-        mode = GetDefaultViewMode();
-
     /* Set up the member variables */
     m_pShellBrowser = psb;
     m_FolderSettings.ViewMode = mode;
@@ -3854,22 +3859,22 @@ HRESULT STDMETHODCALLTYPE CDefView::CreateViewWindow3(IShellBrowser *psb, IShell
 
     if (view_id)
     {
-        if (IsEqualIID(*view_id, VID_LargeIcons))
-            m_FolderSettings.ViewMode = FVM_ICON;
-        else if (IsEqualIID(*view_id, VID_SmallIcons))
-            m_FolderSettings.ViewMode = FVM_SMALLICON;
-        else if (IsEqualIID(*view_id, VID_List))
-            m_FolderSettings.ViewMode = FVM_LIST;
-        else if (IsEqualIID(*view_id, VID_Details))
-            m_FolderSettings.ViewMode = FVM_DETAILS;
-        else if (IsEqualIID(*view_id, VID_Thumbnails))
-            m_FolderSettings.ViewMode = FVM_THUMBNAIL;
-        else if (IsEqualIID(*view_id, VID_Tile))
-            m_FolderSettings.ViewMode = FVM_TILE;
-        else if (IsEqualIID(*view_id, VID_ThumbStrip))
-            m_FolderSettings.ViewMode = FVM_THUMBSTRIP;
+        FOLDERVIEWMODE temp = (FOLDERVIEWMODE)ShellViewIdToFolderViewMode(view_id);
+        if (IsSupportedFolderViewMode(temp))
+            mode = temp;
+        else if (*view_id == VID_Default)
+            mode = FVM_AUTO;
         else
             FIXME("Ignoring unrecognized VID %s\n", debugstr_guid(view_id));
+    }
+    if (mode == FVM_AUTO)
+        m_FolderSettings.ViewMode = GetDefaultViewMode();
+
+    if (!IsSupportedFolderViewMode(m_FolderSettings.ViewMode))
+    {
+        ERR("Ignoring %s FVM %u\n", FolderViewModeToShellViewId(m_FolderSettings.ViewMode)
+            ? "unsupported" : "invalid", m_FolderSettings.ViewMode);
+        m_FolderSettings.ViewMode = FVM_ICON;
     }
     const UINT requestedViewMode = m_FolderSettings.ViewMode;
 

--- a/dll/win32/shell32/CDefViewUtil.cpp
+++ b/dll/win32/shell32/CDefViewUtil.cpp
@@ -9,6 +9,38 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(shell);
 
+HRESULT
+ShellViewIdToFolderViewMode(const SHELLVIEWID *pVid)
+{
+    if (IsEqualIID(*pVid, VID_LargeIcons))
+        return FVM_ICON;
+    else if (IsEqualIID(*pVid, VID_SmallIcons))
+        return FVM_SMALLICON;
+    else if (IsEqualIID(*pVid, VID_List))
+        return FVM_LIST;
+    else if (IsEqualIID(*pVid, VID_Details))
+        return FVM_DETAILS;
+    else if (IsEqualIID(*pVid, VID_Thumbnails))
+        return FVM_THUMBNAIL;
+    else if (IsEqualIID(*pVid, VID_Tile))
+        return FVM_TILE;
+    else if (IsEqualIID(*pVid, VID_ThumbStrip))
+        return FVM_THUMBSTRIP;
+    return E_UNEXPECTED;
+}
+
+const SHELLVIEWID *
+FolderViewModeToShellViewId(UINT FVM)
+{
+    static const SHELLVIEWID *vids[] = {
+        &VID_LargeIcons, &VID_SmallIcons,
+        &VID_Details, &VID_Thumbnails,
+        &VID_Tile, &VID_ThumbStrip,
+    };
+    FVM -= FVM_FIRST;
+    return FVM < _countof(vids) ? vids[FVM] : NULL;
+}
+
 // This class adapts the legacy function callback to work as an IShellFolderViewCB
 class CShellFolderViewCBWrapper :
     public CComObjectRootEx<CComMultiThreadModelNoCS>,

--- a/dll/win32/shell32/folders/CControlPanelFolder.cpp
+++ b/dll/win32/shell32/folders/CControlPanelFolder.cpp
@@ -386,7 +386,7 @@ HRESULT WINAPI CControlPanelFolder::CreateViewObject(HWND hwndOwner, REFIID riid
             WARN("IContextMenu not implemented\n");
             hr = E_NOTIMPL;
         } else if (IsEqualIID(riid, IID_IShellView)) {
-            SFV_CREATE sfvparams = {sizeof(SFV_CREATE), this};
+            SFV_CREATE sfvparams = { sizeof(SFV_CREATE), this , NULL, this };
             hr = SHCreateShellFolderView(&sfvparams, (IShellView**)ppvOut);
         }
     }
@@ -671,6 +671,23 @@ HRESULT WINAPI CControlPanelFolder::GetCurFolder(PIDLIST_ABSOLUTE * pidl)
         return E_POINTER;
     *pidl = ILClone(pidlRoot);
     return S_OK;
+}
+
+HRESULT WINAPI CControlPanelFolder::MessageSFVCB(UINT uMsg, WPARAM wParam, LPARAM lParam)
+{
+    switch (uMsg)
+    {
+        case SFVM_DEFVIEWMODE:
+        {
+        #if ROSPOLICY_SHELLFOLDER_DEFLARGEICONS & ( 1 << (PT_CONTROLS_NEWREGITEM >> 4) )
+            *((FOLDERVIEWMODE*)lParam) = FVM_ICON;
+        #else
+            *((FOLDERVIEWMODE*)lParam) = IsOS(OS_SERVERADMINUI) ? FVM_LIST : FVM_ICON;
+        #endif
+            return S_OK;
+        }
+    }
+    return E_NOTIMPL;
 }
 
 CCPLItemMenu::CCPLItemMenu()

--- a/dll/win32/shell32/folders/CControlPanelFolder.cpp
+++ b/dll/win32/shell32/folders/CControlPanelFolder.cpp
@@ -679,7 +679,7 @@ HRESULT WINAPI CControlPanelFolder::MessageSFVCB(UINT uMsg, WPARAM wParam, LPARA
     {
         case SFVM_DEFVIEWMODE:
         {
-        #if ROSPOLICY_SHELLFOLDER_DEFLARGEICONS & ( 1 << (PT_CONTROLS_NEWREGITEM >> 4) )
+        #if ROSPOLICY_CONTROLSFOLDER_DEFLARGEICONS
             *((FOLDERVIEWMODE*)lParam) = FVM_ICON;
         #else
             *((FOLDERVIEWMODE*)lParam) = IsOS(OS_SERVERADMINUI) ? FVM_LIST : FVM_ICON;

--- a/dll/win32/shell32/folders/CControlPanelFolder.h
+++ b/dll/win32/shell32/folders/CControlPanelFolder.h
@@ -26,7 +26,8 @@ class CControlPanelFolder :
     public CComCoClass<CControlPanelFolder, &CLSID_ControlPanel>,
     public CComObjectRootEx<CComMultiThreadModelNoCS>,
     public IShellFolder2,
-    public IPersistFolder2
+    public IPersistFolder2,
+    public IShellFolderViewCB
 {
     private:
         /* both paths are parsible from the desktop */
@@ -70,6 +71,9 @@ class CControlPanelFolder :
         // IPersistFolder2
         STDMETHOD(GetCurFolder)(PIDLIST_ABSOLUTE * pidl) override;
 
+        // IShellFolderViewCB
+        STDMETHODIMP MessageSFVCB(UINT uMsg, WPARAM wParam, LPARAM lParam) override;
+
         DECLARE_REGISTRY_RESOURCEID(IDR_CONTROLPANEL)
         DECLARE_NOT_AGGREGATABLE(CControlPanelFolder)
 
@@ -81,6 +85,7 @@ class CControlPanelFolder :
         COM_INTERFACE_ENTRY_IID(IID_IPersistFolder, IPersistFolder)
         COM_INTERFACE_ENTRY_IID(IID_IPersistFolder2, IPersistFolder2)
         COM_INTERFACE_ENTRY_IID(IID_IPersist, IPersist)
+        COM_INTERFACE_ENTRY_IID(IID_IShellFolderViewCB, IShellFolderViewCB)
         END_COM_MAP()
 };
 

--- a/dll/win32/shell32/folders/CDesktopFolder.cpp
+++ b/dll/win32/shell32/folders/CDesktopFolder.cpp
@@ -1085,6 +1085,11 @@ HRESULT WINAPI CDesktopFolderViewCB::MessageSFVCB(UINT uMsg, WPARAM wParam, LPAR
 {
     switch (uMsg)
     {
+        #if ROSPOLICY_SHELLFOLDER_DEFLARGEICONS & ( 1 << (PT_DESKTOP_REGITEM >> 4) )
+        case SFVM_DEFVIEWMODE:                     // CDesktopBrowser always forces FVM_ICON.
+            *((FOLDERVIEWMODE*)lParam) = FVM_ICON; // This sets the default for generic browsers.
+            return S_OK;
+        #endif
         case SFVM_VIEWRELEASE:
             m_pShellView = NULL;
             return S_OK;

--- a/dll/win32/shell32/folders/CDesktopFolder.cpp
+++ b/dll/win32/shell32/folders/CDesktopFolder.cpp
@@ -1085,7 +1085,7 @@ HRESULT WINAPI CDesktopFolderViewCB::MessageSFVCB(UINT uMsg, WPARAM wParam, LPAR
 {
     switch (uMsg)
     {
-        #if ROSPOLICY_SHELLFOLDER_DEFLARGEICONS & ( 1 << (PT_DESKTOP_REGITEM >> 4) )
+        #if ROSPOLICY_DESKTOPFOLDER_DEFLARGEICONS
         case SFVM_DEFVIEWMODE:                     // CDesktopBrowser always forces FVM_ICON.
             *((FOLDERVIEWMODE*)lParam) = FVM_ICON; // This sets the default for generic browsers.
             return S_OK;

--- a/dll/win32/shell32/folders/CDrivesFolder.cpp
+++ b/dll/win32/shell32/folders/CDrivesFolder.cpp
@@ -936,8 +936,8 @@ HRESULT WINAPI CDrivesFolder::CreateViewObject(HWND hwndOwner, REFIID riid, LPVO
     }
     else if (IsEqualIID(riid, IID_IShellView))
     {
-            SFV_CREATE sfvparams = { sizeof(SFV_CREATE), this, NULL, static_cast<IShellFolderViewCB*>(this) };
-            hr = SHCreateShellFolderView(&sfvparams, (IShellView**)ppvOut);
+        SFV_CREATE sfvparams = { sizeof(SFV_CREATE), this, NULL, this };
+        hr = SHCreateShellFolderView(&sfvparams, (IShellView**)ppvOut);
     }
     TRACE("-- (%p)->(interface=%p)\n", this, ppvOut);
     return hr;
@@ -1383,6 +1383,7 @@ HRESULT WINAPI CDrivesFolder::ShouldShow(IShellFolder *psf, PCIDLIST_ABSOLUTE pi
     return S_OK;
 }
 
+<<<<<<< HEAD
 /**************************************************************************
  *    CDrivesFolder::MessageSFVCB (IShellFolderViewCB)
  */
@@ -1403,6 +1404,11 @@ STDMETHODIMP CDrivesFolder::MessageSFVCB(UINT uMsg, WPARAM wParam, LPARAM lParam
                 g_IsFloppyCache = 0;
             }
             break;
+        #if ROSPOLICY_SHELLFOLDER_DEFLARGEICONS & ( 1 << (PT_COMPUTER_REGITEM >> 4) )
+        case SFVM_DEFVIEWMODE:
+            *((FOLDERVIEWMODE*)lParam) = FVM_ICON;
+            return S_OK;
+        #endif
     }
     return E_NOTIMPL;
 }

--- a/dll/win32/shell32/folders/CDrivesFolder.cpp
+++ b/dll/win32/shell32/folders/CDrivesFolder.cpp
@@ -1404,7 +1404,7 @@ STDMETHODIMP CDrivesFolder::MessageSFVCB(UINT uMsg, WPARAM wParam, LPARAM lParam
                 g_IsFloppyCache = 0;
             }
             break;
-        #if ROSPOLICY_SHELLFOLDER_DEFLARGEICONS & ( 1 << (PT_COMPUTER_REGITEM >> 4) )
+        #if ROSPOLICY_DRIVESFOLDER_DEFLARGEICONS
         case SFVM_DEFVIEWMODE:
             *((FOLDERVIEWMODE*)lParam) = FVM_ICON;
             return S_OK;

--- a/dll/win32/shell32/folders/CDrivesFolder.cpp
+++ b/dll/win32/shell32/folders/CDrivesFolder.cpp
@@ -1383,7 +1383,6 @@ HRESULT WINAPI CDrivesFolder::ShouldShow(IShellFolder *psf, PCIDLIST_ABSOLUTE pi
     return S_OK;
 }
 
-<<<<<<< HEAD
 /**************************************************************************
  *    CDrivesFolder::MessageSFVCB (IShellFolderViewCB)
  */

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -4344,8 +4344,21 @@ BOOL WINAPI IsOS(DWORD feature)
         FIXME("(OS_TABLETPC) What should we return here?\n");
         return FALSE;
     case OS_SERVERADMINUI:
+#ifdef __REACTOS__
+        {
+            DWORD value = FALSE, size = sizeof(value);
+            HKEY hKey = SHGetShellKey(SHKEY_Root_HKCU | SHKEY_Key_Explorer, L"Advanced", FALSE);
+            if (hKey)
+            {
+                SHQueryValueExW(hKey, L"ServerAdminUI", NULL, NULL, &value, &size);
+                RegCloseKey(hKey);
+            }
+            ISOS_RETURN(value);
+        }
+#else
         FIXME("(OS_SERVERADMINUI) What should we return here?\n");
         return FALSE;
+#endif
     case OS_MEDIACENTER:
         FIXME("(OS_MEDIACENTER) What should we return here?\n");
         return FALSE;

--- a/modules/rostests/apitests/ntdll/RtlGetNtProductType.c
+++ b/modules/rostests/apitests/ntdll/RtlGetNtProductType.c
@@ -135,8 +135,8 @@ START_TEST(RtlGetNtProductType)
     if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, L"SYSTEM\\CurrentControlSet\\Control\\ReactOS\\Settings\\Version",
                       0, KEY_READ | KEY_WRITE, &hKey) == ERROR_SUCCESS)
     {
-        DWORD cb = sizeof(DWORD);
-        if (RegQueryValueExW(hKey, L"ReportAsWorkstation", NULL, NULL, (PBYTE)&ReportAsWorkstation, &cb))
+        DWORD cb = sizeof(ReportAsWorkstation);
+        if (RegQueryValueExW(hKey, L"ReportAsWorkstation", NULL, NULL, (PBYTE)&ReportAsWorkstation, &cb) != ERROR_SUCCESS)
             ReportAsWorkstation = 0xbaadf00d;
         RegDeleteValueW(hKey, L"ReportAsWorkstation");
         RegCloseKey(hKey);
@@ -178,13 +178,12 @@ START_TEST(RtlGetNtProductType)
 
     ok_char(ChangeNtProductType(ProductType), TRUE);
 
-
     /* Restore ReportAsWorkstation */
     if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, L"SYSTEM\\CurrentControlSet\\Control\\ReactOS\\Settings\\Version",
                       0, KEY_WRITE, &hKey) == ERROR_SUCCESS)
     {
         if (ReportAsWorkstation != 0xbaadf00d)
-            RegSetValueExW(hKey, L"ReportAsWorkstation", 0, REG_DWORD, (PBYTE)&ReportAsWorkstation, sizeof(DWORD));
+            RegSetValueExW(hKey, L"ReportAsWorkstation", 0, REG_DWORD, (PBYTE)&ReportAsWorkstation, sizeof(ReportAsWorkstation));
         RegCloseKey(hKey);
     }
 }

--- a/sdk/include/psdk/shobjidl.idl
+++ b/sdk/include/psdk/shobjidl.idl
@@ -793,6 +793,9 @@ interface IShellView : IOleWindow
 interface IShellView2 : IShellView
 {
     typedef GUID SHELLVIEWID;
+cpp_quote("#define SV2GV_CURRENTVIEW ((UINT)-1)")
+cpp_quote("#define SV2GV_DEFAULTVIEW ((UINT)-2)")
+
 cpp_quote("#include <pshpack8.h>")
     typedef struct _SV2CVW2_PARAMS
     {

--- a/sdk/include/reactos/undocshell.h
+++ b/sdk/include/reactos/undocshell.h
@@ -22,17 +22,19 @@
 #define SHSTDAPI SHSTDAPI_(HRESULT)
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* defined(__cplusplus) */
+
 // Because ReactOS installs as Server by default, we ignore OS_SERVERADMINUI
 // in certain places to present a Client/Server hybrid UI.
 
 // Windows defaults to FVM_DETAILS for Administrators on OS_ANYSERVER (instead of FVM_ICON).
-#define ROSPOLICY_SHELLFOLDER_DEFLARGEICONS ( ~0UL )
+#define ROSPOLICY_DESKTOPFOLDER_DEFLARGEICONS 1
+#define ROSPOLICY_DRIVESFOLDER_DEFLARGEICONS 1
+#define ROSPOLICY_CONTROLSFOLDER_DEFLARGEICONS 1
 
 #define ROSPOLICY_SHELL_NODEFKEYBOARDCUES 1
-
-#ifdef __cplusplus
-extern "C" {
-#endif /* defined(__cplusplus) */
 
 #if (NTDDI_VERSION < NTDDI_LONGHORN)
 #define DBIMF_NOGRIPPER         0x0800

--- a/sdk/include/reactos/undocshell.h
+++ b/sdk/include/reactos/undocshell.h
@@ -22,6 +22,11 @@
 #define SHSTDAPI SHSTDAPI_(HRESULT)
 #endif
 
+// Because ReactOS installs as Server by default, we ignore OS_SERVERADMINUI
+// in certain places to present a Client/Server hybrid UI.
+// Windows defaults to FVM_DETAILS for Administrators on OS_ANYSERVER (instead of FVM_ICON).
+#define ROSPOLICY_SHELLFOLDER_DEFLARGEICONS ( ~0UL )
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* defined(__cplusplus) */

--- a/sdk/include/reactos/undocshell.h
+++ b/sdk/include/reactos/undocshell.h
@@ -24,8 +24,11 @@
 
 // Because ReactOS installs as Server by default, we ignore OS_SERVERADMINUI
 // in certain places to present a Client/Server hybrid UI.
+
 // Windows defaults to FVM_DETAILS for Administrators on OS_ANYSERVER (instead of FVM_ICON).
 #define ROSPOLICY_SHELLFOLDER_DEFLARGEICONS ( ~0UL )
+
+#define ROSPOLICY_SHELL_NODEFKEYBOARDCUES 1
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
OS_SERVERADMINUI changes minor things in Explorer, the most visible is that the default folder view mode changes from large icons to details (although ROS has been incorrectly hardcoding details mode for a long time).

Notes:
- I took the liberty to check the ReportAsWorkstation value. Windows obviously does not do this.
- I'm not implementing the entire shell32 REGINST thing just for the 10 tweaks listed there for this setting.
- Yes, Windows only applies the registry tweaks when the value is true, it does not undo them on false.