### PR TITLE
[NTDLL][SHLWAPI][SYSDM] ReportAsWorkstation should always override the product type

### DIFF
--- a/dll/cpl/sysdm/advanced.c
+++ b/dll/cpl/sysdm/advanced.c
@@ -9,6 +9,8 @@
  */
 
 #include "precomp.h"
+#define WIN32_NO_STATUS
+#include "ntndk.h" // SharedUserData
 
 static TCHAR BugLink[] = _T("http://jira.reactos.org/");
 static TCHAR ReportAsWorkstationKey[] = _T("SYSTEM\\CurrentControlSet\\Control\\ReactOS\\Settings\\Version");
@@ -51,9 +53,10 @@ static VOID
 OnInitSysSettingsDialog(HWND hwndDlg)
 {
     HKEY hKey;
-    DWORD dwVal;
+    DWORD dwVal = 0;
     DWORD dwType = REG_DWORD;
     DWORD cbData = sizeof(DWORD);
+    BOOL ReportAsWorkstation = SharedUserData->NtProductType == VER_NT_WORKSTATION;
 
     if (RegOpenKeyEx(HKEY_LOCAL_MACHINE,
                      ReportAsWorkstationKey,
@@ -68,19 +71,14 @@ OnInitSysSettingsDialog(HWND hwndDlg)
                             (LPBYTE)&dwVal,
                             &cbData) == ERROR_SUCCESS)
         {
-            if (dwVal != FALSE)
-            {
-                // set the check box
-                SendDlgItemMessageW(hwndDlg,
-                                    IDC_REPORTASWORKSTATION,
-                                    BM_SETCHECK,
-                                    BST_CHECKED,
-                                    0);
-            }
+            if (cbData == sizeof(DWORD))
+                ReportAsWorkstation = dwVal != FALSE;
         }
 
         RegCloseKey(hKey);
     }
+    SendDlgItemMessageW(hwndDlg, IDC_REPORTASWORKSTATION, BM_SETCHECK,
+                        ReportAsWorkstation ? BST_CHECKED : BST_UNCHECKED, 0);
 }
 
 INT_PTR CALLBACK

--- a/dll/cpl/sysdm/advanced.c
+++ b/dll/cpl/sysdm/advanced.c
@@ -10,7 +10,7 @@
 
 #include "precomp.h"
 #define WIN32_NO_STATUS
-#include "ntndk.h" // SharedUserData
+#include "pstypes.h" /* SharedUserData */
 
 static TCHAR BugLink[] = _T("http://jira.reactos.org/");
 static TCHAR ReportAsWorkstationKey[] = _T("SYSTEM\\CurrentControlSet\\Control\\ReactOS\\Settings\\Version");

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -4090,6 +4090,23 @@ HRESULT WINAPI CLSIDFromStringWrap(LPCWSTR idstr, CLSID *id)
  */
 BOOL WINAPI IsOS(DWORD feature)
 {
+#ifdef __REACTOS__
+    OSVERSIONINFOEXA osvi;
+    DWORD platform, majorv, minorv;
+
+    osvi.dwOSVersionInfoSize = sizeof(osvi);
+    if (!GetVersionExA((OSVERSIONINFOA*)&osvi))
+    {
+        osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFOA);
+        if (!GetVersionExA((OSVERSIONINFOA*)&osvi))
+        {
+            ERR("GetVersionEx failed\n");
+            return FALSE;
+        }
+        osvi.wProductType = VER_NT_WORKSTATION;
+        osvi.wSuiteMask = 0;
+    }
+#else
     OSVERSIONINFOA osvi;
     DWORD platform, majorv, minorv;
 
@@ -4098,7 +4115,7 @@ BOOL WINAPI IsOS(DWORD feature)
         ERR("GetVersionEx failed\n");
         return FALSE;
     }
-
+#endif
     majorv = osvi.dwMajorVersion;
     minorv = osvi.dwMinorVersion;
     platform = osvi.dwPlatformId;
@@ -4173,7 +4190,11 @@ BOOL WINAPI IsOS(DWORD feature)
         FIXME("(OS_DOMAINMEMBER) What should we return here?\n");
         return TRUE;
     case OS_ANYSERVER:
+#ifdef __REACTOS__
+        ISOS_RETURN(osvi.wProductType > VER_NT_WORKSTATION)
+#else
         ISOS_RETURN(platform == VER_PLATFORM_WIN32_NT)
+#endif
     case OS_WOW6432:
         {
             BOOL is_wow64;


### PR DESCRIPTION
When choosing to install ROS as a server (the default), the ReportAsWorkstation checkbox in sysdm.cpl works correctly. If you instead choose to install ROS as a workstation, the product type is set to WinNT and the checkbox in sysdm.cpl does nothing.

This PR allows "ROS as a workstation" installs to report itself as a basic server to Win32 applications when the user toggles the sysdm.cpl checkbox (to unchecked in this case).

Notes:
- I'm now caching the ReportAsWorkstation value (per-process) instead of looking it up every time `[Rtl]GetVersion[Ex]` is called.
- ReportAsWorkstation now also overrides `RtlGetNtProductType` .
