### PR TITLE
[REACTOS] Fix LoadCursorW() incorrect usage cases

### DIFF
--- a/base/applications/games/winmine/main.c
+++ b/base/applications/games/winmine/main.c
@@ -1092,7 +1092,11 @@ int WINAPI wWinMain( HINSTANCE hInst, HINSTANCE hPrevInst, LPWSTR cmdline, int c
     wc.cbWndExtra = 0;
     wc.hInstance = hInst;
     wc.hIcon = LoadIconW( hInst, MAKEINTRESOURCEW(IDI_WINEMINE) );
+#ifndef __REACTOS__
     wc.hCursor = LoadCursorW( 0, (LPWSTR)IDI_APPLICATION );
+#else
+    wc.hCursor = LoadCursorW(NULL, (LPWSTR)IDC_ARROW);
+#endif
     wc.hbrBackground = GetSysColorBrush(COLOR_BTNFACE); //MOD for ROS
     wc.lpszMenuName = MAKEINTRESOURCEW(IDM_WINEMINE);
     wc.lpszClassName = appname;

--- a/base/applications/mscutils/eventvwr/eventvwr.c
+++ b/base/applications/mscutils/eventvwr/eventvwr.c
@@ -2690,7 +2690,7 @@ MyRegisterClass(HINSTANCE hInstance)
     wcex.cbWndExtra = 0;
     wcex.hInstance = hInstance;
     wcex.hIcon = LoadIconW(hInstance, MAKEINTRESOURCEW(IDI_EVENTVWR));
-    wcex.hCursor = LoadCursorW(NULL, MAKEINTRESOURCEW(IDC_ARROW));
+    wcex.hCursor = LoadCursorW(NULL, IDC_ARROW);
     wcex.hbrBackground = (HBRUSH)(COLOR_3DFACE + 1); // COLOR_WINDOW + 1
     wcex.lpszMenuName = MAKEINTRESOURCEW(IDM_EVENTVWR);
     wcex.lpszClassName = EVENTVWR_WNDCLASS;

--- a/base/shell/progman/group.c
+++ b/base/shell/progman/group.c
@@ -376,7 +376,7 @@ ATOM GROUP_RegisterGroupWinClass(VOID)
     wndClass.cbWndExtra    = sizeof(LONG_PTR);
     wndClass.hInstance     = Globals.hInstance;
     wndClass.hIcon         = LoadIconW(Globals.hInstance, MAKEINTRESOURCEW(IDI_GROUP_ICON));
-    wndClass.hCursor       = LoadCursorW(NULL, MAKEINTRESOURCEW(IDC_ARROW));
+    wndClass.hCursor       = LoadCursorW(NULL, IDC_ARROW);
     wndClass.hbrBackground = (HBRUSH)(COLOR_WINDOW + 1);
     wndClass.lpszMenuName  = NULL;
     wndClass.lpszClassName = STRING_GROUP_WIN_CLASS_NAME;

--- a/base/shell/progman/main.c
+++ b/base/shell/progman/main.c
@@ -1061,7 +1061,7 @@ static ATOM MAIN_RegisterMainWinClass(VOID)
     wndClass.cbWndExtra    = 0;
     wndClass.hInstance     = Globals.hInstance;
     wndClass.hIcon         = Globals.hMainIcon;
-    wndClass.hCursor       = LoadCursorW(NULL, MAKEINTRESOURCEW(IDC_ARROW));
+    wndClass.hCursor       = LoadCursorW(NULL, IDC_ARROW);
     wndClass.hbrBackground = (HBRUSH)GetStockObject(NULL_BRUSH);
     wndClass.lpszMenuName  = NULL;
     wndClass.lpszClassName = STRING_MAIN_WIN_CLASS_NAME;

--- a/dll/cpl/console/layout.c
+++ b/dll/cpl/console/layout.c
@@ -39,7 +39,7 @@ RegisterWinPrevClass(
     WndClass.style = 0;
     WndClass.hInstance = hInstance;
     WndClass.hIcon = NULL;
-    WndClass.hCursor = LoadCursorW(NULL, MAKEINTRESOURCEW(IDC_ARROW));
+    WndClass.hCursor = LoadCursorW(NULL, IDC_ARROW);
     WndClass.hbrBackground =  (HBRUSH)(COLOR_BACKGROUND + 1);
     WndClass.lpszMenuName = NULL;
     WndClass.cbClsExtra = 0;

--- a/dll/win32/comctl32/draglist.c
+++ b/dll/win32/comctl32/draglist.c
@@ -155,7 +155,11 @@ DragList_SubclassWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam, 
                     SetCursor(data->cursor);
                     break;
                 case DL_COPYCURSOR:
+#ifndef __REACTOS__
                     data->cursor = LoadCursorW(COMCTL32_hModule, (LPCWSTR)IDC_COPY);
+#else
+                    data->cursor = LoadCursorW(COMCTL32_hModule, MAKEINTRESOURCEW(IDC_COPY));
+#endif
                     SetCursor(data->cursor);
                     break;
                 case DL_MOVECURSOR:

--- a/dll/win32/comctl32/toolbar.c
+++ b/dll/win32/comctl32/toolbar.c
@@ -5812,7 +5812,11 @@ TOOLBAR_LButtonDown (TOOLBAR_INFO *infoPtr, WPARAM wParam, LPARAM lParam)
             /* If drag cursor has not been loaded, load it.
              * Note: it doesn't need to be freed */
             if (!hCursorDrag)
+#ifndef __REACTOS__
                 hCursorDrag = LoadCursorW(COMCTL32_hModule, (LPCWSTR)IDC_MOVEBUTTON);
+#else
+                hCursorDrag = LoadCursorW(COMCTL32_hModule, MAKEINTRESOURCEW(IDC_MOVEBUTTON));
+#endif
             SetCursor(hCursorDrag);
         }
         else

--- a/dll/win32/msgina/shutdown.c
+++ b/dll/win32/msgina/shutdown.c
@@ -541,7 +541,7 @@ OwnerDrawButtonSubclass(
                 {
                     pContext->bIsButtonHot[HIBERNATE_BUTTON_HOT] = TRUE;
                 }
-                SetCursor(LoadCursorW(NULL, MAKEINTRESOURCEW(IDC_HAND)));
+                SetCursor(LoadCursorW(NULL, IDC_HAND));
             }
 
             ClientToScreen(hButton, &pt);

--- a/dll/win32/shell32/dialogs/dialogs.cpp
+++ b/dll/win32/shell32/dialogs/dialogs.cpp
@@ -1242,7 +1242,7 @@ INT_PTR CALLBACK OwnerDrawButtonSubclass(HWND hButton, UINT uMsg, WPARAM wParam,
                         break;
                     }
                 }
-                SetCursor(LoadCursorW(NULL, MAKEINTRESOURCEW(IDC_HAND)));
+                SetCursor(LoadCursorW(NULL, IDC_HAND));
             }
 
             ClientToScreen(hButton, &pt);

--- a/win32ss/user/winsrv/consrv/frontends/gui/conwnd.c
+++ b/win32ss/user/winsrv/consrv/frontends/gui/conwnd.c
@@ -150,7 +150,7 @@ RegisterConWndClass(IN HINSTANCE hInstance)
                                  GetSystemMetrics(SM_CXSMICON),
                                  GetSystemMetrics(SM_CYSMICON),
                                  LR_SHARED);
-    ghDefaultCursor = LoadCursorW(NULL, MAKEINTRESOURCEW(IDC_ARROW));
+    ghDefaultCursor = LoadCursorW(NULL, IDC_ARROW);
 
     WndClass.cbSize = sizeof(WNDCLASSEXW);
     WndClass.lpszClassName = GUI_CONWND_CLASS;


### PR DESCRIPTION
## Purpose

Fix wrong `MAKEINTRESOURCEW()` macro usage cases in `LoadCursorW()` system-wide. MSDN documentation for this function states we need to use `MAKEINTRESOURCEW()` macro only for internal application-defined cursors (loaded from the app instance specified by `hInstance` parameter), but not for system-defined cursors (those begin with `IDC_`* prefix), in case when `hInstance` is `NULL`. So get rid from `MAKEINTRESOURCEW()` macro usage for all cases when `hInstance` parameter is `NULL`. And on the contrary, when `hInstance` is valid and points to the application instance, then use it for the resource identifier.

JIRA issue: None.