### PR TITLE
[NTOS:CC] Fix assertion failed in CcRosReleaseVacb

### DIFF
--- a/ntoskrnl/cc/view.c
+++ b/ntoskrnl/cc/view.c
@@ -1160,6 +1160,7 @@ CcFlushCache (
                 Status = CcRosFlushVacb(vacb, &VacbIosb);
                 if (!NT_SUCCESS(Status))
                 {
+                    CcRosReleaseVacb(SharedCacheMap, vacb, FALSE, FALSE);
                     goto quit;
                 }
                 DirtyVacb = TRUE;

--- a/ntoskrnl/cc/view.c
+++ b/ntoskrnl/cc/view.c
@@ -1142,6 +1142,8 @@ CcFlushCache (
         IoStatus->Information = 0;
     }
 
+    KeAcquireGuardedMutex(&SharedCacheMap->FlushCacheLock);
+
     /*
      * We flush the VACBs that we find here.
      * If there is no (dirty) VACB, it doesn't mean that there is no data to flush, so we call Mm to be sure.
@@ -1161,7 +1163,7 @@ CcFlushCache (
                 if (!NT_SUCCESS(Status))
                 {
                     CcRosReleaseVacb(SharedCacheMap, vacb, FALSE, FALSE);
-                    goto quit;
+                    break;
                 }
                 DirtyVacb = TRUE;
 
@@ -1191,7 +1193,7 @@ CcFlushCache (
             }
 
             if (!NT_SUCCESS(Status))
-                goto quit;
+                break;
 
             if (IoStatus)
                 IoStatus->Information += MmIosb.Information;
@@ -1210,6 +1212,8 @@ CcFlushCache (
         /* Round down to next VACB start now */
         FlushStart -= FlushStart % VACB_MAPPING_GRANULARITY;
     }
+
+    KeReleaseGuardedMutex(&SharedCacheMap->FlushCacheLock);
 
 quit:
     if (IoStatus)
@@ -1319,6 +1323,7 @@ CcRosInitializeFileCache (
         KeInitializeSpinLock(&SharedCacheMap->CacheMapLock);
         InitializeListHead(&SharedCacheMap->CacheMapVacbListHead);
         InitializeListHead(&SharedCacheMap->BcbList);
+        KeInitializeGuardedMutex(&SharedCacheMap->FlushCacheLock);
 
         SharedCacheMap->Flags = SHARED_CACHE_MAP_IN_CREATION;
 

--- a/ntoskrnl/include/internal/cc.h
+++ b/ntoskrnl/include/internal/cc.h
@@ -193,6 +193,7 @@ typedef struct _ROS_SHARED_CACHE_MAP
     LIST_ENTRY CacheMapVacbListHead;
     BOOLEAN PinAccess;
     KSPIN_LOCK CacheMapLock;
+    KGUARDED_MUTEX FlushCacheLock;
 #if DBG
     BOOLEAN Trace; /* enable extra trace output for this cache map and it's VACBs */
 #endif


### PR DESCRIPTION
## Purpose
JIRA issue: [CORE-19664](https://jira.reactos.org/browse/CORE-19664)

## Proposed changes
- ~`CcRosLookupVacb` : Add a VACB refcount check to ensure that the returned VACB is valid~ **UPDATE:** This is a hack and was removed.
- ~`CcRosReleaseVacb`: Do inc-dec refcount inside master lock~ **UPDATE:** Not working, still BSoD.
- `CcFlushCache` : Call `CcRosReleaseVacb` when `CcRosFlushVacb` fails (`CcRosLookupVacb` adds a refcount)
- Protect `CcFlushCache` call with a mutex