### PR TITLE
[MKISOFS] Provide wctype.c implementation CORE-19660

### DIFF
--- a/sdk/tools/mkisofs/CMakeLists.txt
+++ b/sdk/tools/mkisofs/CMakeLists.txt
@@ -57,6 +57,7 @@ add_library(libschily
     schilytools/libschily/strlcat.c
     schilytools/libschily/strlcpy.c
     schilytools/libschily/uid.c
+    schilytools/libschily/wctype.c
     schilytools/libschily/zerobytes.c)
 
 add_library(libsiconv

--- a/sdk/tools/mkisofs/schilytools/include/schily/wctype.h
+++ b/sdk/tools/mkisofs/schilytools/include/schily/wctype.h
@@ -46,7 +46,7 @@
 
 #if	defined(HAVE_ISWPRINT) && defined(USE_WCHAR)
 #ifndef	USE_WCTYPE
-#undef	USE_WCTYPE
+#undef	USE_WCTYPE //FIXME: bug! This is #define USE_WCTYPE in newer versions, see https://github.com/roytam1/schilytools/tree/master/include/schily/wctype.h for surrounding changes also
 #endif
 #endif
 

--- a/sdk/tools/mkisofs/schilytools/libschily/wctype.c
+++ b/sdk/tools/mkisofs/schilytools/libschily/wctype.c
@@ -1,0 +1,98 @@
+#if defined __REACTOS__ && defined(_MSC_VER) && _MSC_VER == 1700
+#pragma message("Warning VS2012 extrawurst: wctype should come from MS CRT")
+// due to bugs in libschily the VS2012 does fail to link wctype-functions
+// used by match.c and fnmatch.c. But VS2010/VS2013 can properly link the MS CRT versions of it.
+// Therefore we provide libschily implementation of wctype.c for VS2012.
+
+
+/* @(#)wctype.c	1.3 17/08/13 Copyright 2017 J. Schilling */
+/*
+ *	Emulate the behavior of wctype() and iswctype()
+ *
+ *	Copyright (c) 2017 J. Schilling
+ */
+/*
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License, Version 1.0 only
+ * (the "License").  You may not use this file except in compliance
+ * with the License.
+ *
+ * See the file CDDL.Schily.txt in this distribution for details.
+ * A copy of the CDDL is also available via the Internet at
+ * http://www.opensource.org/licenses/cddl1.txt
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file CDDL.Schily.txt from this distribution.
+ */
+
+#include <schily/ctype.h>
+#include <schily/wctype.h>
+#include <schily/wchar.h>
+#include <schily/string.h>
+#include <schily/schily.h>
+
+#ifndef	HAVE_WCTYPE
+LOCAL struct wct {
+	char		*name;
+	wctype_t	val;
+} wct[] = {
+	{"alnum", 1},
+	{"alpha", 2},
+	{"blank", 3},
+	{"cntrl", 4},
+	{"digit", 5},
+	{"graph", 6},
+	{"lower", 7},
+	{"print", 8},
+	{"punct", 9},
+	{"space", 10},
+	{"upper", 11},
+	{"xdigit", 12},
+	{ NULL, 0}
+};
+
+wctype_t
+wctype(n)
+	const char	*n;
+{
+	register struct wct *wp = wct;
+
+	for (; wp->name; wp++) {
+		if (*n != *wp->name)
+			continue;
+		if (strcmp(n, wp->name) == 0)
+			return (wp->val);
+	}
+	return (0);
+}
+
+int
+iswctype(wc, t)
+	wint_t		wc;
+	wctype_t	t;
+{
+	switch (t) {
+
+	case 1: return (iswalnum(wc));
+	case 2: return (iswalpha(wc));
+#if defined(HAVE_ISWBLANK) || ((MB_LEN_MAX == 1) && defined(HAVE_ISBLANK))
+	case 3: return (iswblank(wc));
+#else
+	case 3: return (isspace(wc));
+#endif
+	case 4: return (iswcntrl(wc));
+	case 5: return (iswdigit(wc));
+	case 6: return (iswgraph(wc));
+	case 7: return (iswlower(wc));
+	case 8: return (iswprint(wc));
+	case 9: return (iswpunct(wc));
+	case 10: return (iswspace(wc));
+	case 11: return (iswupper(wc));
+	case 12: return (iswxdigit(wc));
+
+	default:
+		return (0);
+	}
+}
+#endif	/* HAVE_WCTYPE */
+#endif //__REACTOS__


### PR DESCRIPTION
This fixes a regression, introduced by
0.4.7-dev-219-g 6116aa816b9123271df91c1cdf111a79ab2c2cfe leading to the following linker errors LNK2019, LNK2001 when trying to link mkisofs with the VS2012 compiler 17.0.61030.0

```
FAILED: mkisofs.exe
cmd.exe /C "cd . && C:\Appz\RosBE2_1_6\Bin\cmake.exe -E vs_link_exe C:\Appz\MICROS~2.0\VC\bin\link.exe /nologo sdk\tools\mkisofs\CMakeFiles\mkisofs.dir\schilytools\mkisofs\boot.c.obj sdk\tools\mkisofs\CMakeFiles\mkisofs.dir\schilytools\mkisofs\eltorito.c.obj sdk\tools\mkisofs\CMakeFiles\mkisofs.dir\schilytools\mkisofs\hash.c.obj sdk\tools\mkisofs\CMakeFiles\mkisofs.dir\schilytools\mkisofs\inode.c.obj sdk\tools\mkisofs\CMakeFiles\mkisofs.dir\schilytools\mkisofs\isonum.c.obj sdk\tools\mkisofs\CMakeFiles\mkisofs.dir\schilytools\mkisofs\joliet.c.obj sdk\tools\mkisofs\CMakeFiles\mkisofs.dir\schilytools\mkisofs\match.c.obj sdk\tools\mkisofs\CMakeFiles\mkisofs.dir\schilytools\mkisofs\mkisofs.c.obj sdk\tools\mkisofs\CMakeFiles\mkisofs.dir\schilytools\mkisofs\multi.c.obj sdk\tools\mkisofs\CMakeFiles\mkisofs.dir\schilytools\mkisofs\name.c.obj sdk\tools\mkisofs\CMakeFiles\mkisofs.dir\schilytools\mkisofs\rock.c.obj sdk\tools\mkisofs\CMakeFiles\mkisofs.dir\schilytools\mkisofs\stream.c.obj sdk\tools\mkisofs\CMakeFiles\mkisofs.dir\schilytools\mkisofs\tree.c.obj sdk\tools\mkisofs\CMakeFiles\mkisofs.dir\schilytools\mkisofs\write.c.obj  /out:mkisofs.exe /pdb:mkisofs.pdb /version:0.0  /machine:X86 /MANIFEST:NO /debug /subsystem:console  sdk\tools\mkisofs\libmdigest.lib sdk\tools\mkisofs\libschily.lib sdk\tools\mkisofs\libsiconv.lib sdk\tools\mkisofs\libschily.lib && cd ."

libschily.lib(fnmatch.c.obj) : error LNK2019: unresolved external symbol _wctype referenced in function _rangematch

libschily.lib(match.c.obj) : error LNK2001: unresolved external symbol _wctype

mkisofs.exe : fatal error LNK1120: 1 unresolved externals
```

The interesting part about that is that the VS2010 and VS2013 toolchains do both *not* suffer from this issue: in their cases the MS CRT implementation of wctype is used. That is also present in MS VS2012 CRT, but for some not fully understood reasons it is not used when linking with VS2012.
I do suspect a bug in the defines and many #ifdef cases within the libschily implementation, and to underline that those indeed aren't entirely correct in our version, I also placed a FIXME within wctype.h. However acting on that FIXME would not solve the build-issue either yet, therefore I decided to only document the existing glitches instead of fixing that as well.

The wctype.c implementation was taken from the upstream repo https://github.com/roytam1/schilytools/blob/master/libschily/wctype.c

A more perfect solution would avoid the need for introducing that code, and would make the VS2012 MS CRT version being used, like we do for all other MSVC compilers. But the current patch, written with thin fingers, should be good enough for the releases/0.4.7 to releases/0.4.14 to fix the build without introducing any unintended side-effects for other toolchains.
I tested on the older branches:
* afterwards the VS2012 isos can be built properly for dbg-cfg and rls-cfg.
* afterwards the VS2012 dbg-cfg-bootcd-iso does make it to the desktop.

JIRA issue: [CORE-19660](https://jira.reactos.org/browse/CORE-19660)
