### PR TITLE
[NTGDI][FREETYPE] Reduce MAX_FONTLINK_CACHE

### DIFF
--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -68,7 +68,7 @@ static BOOL s_fFontLinkUseAnsi = FALSE;
 static BOOL s_fFontLinkUseOem = FALSE;
 static BOOL s_fFontLinkUseSymbol = FALSE;
 
-#define MAX_FONTLINK_CACHE 128
+#define MAX_FONTLINK_CACHE 32
 static RTL_STATIC_LIST_HEAD(g_FontLinkCache); // The list of FONTLINK_CACHE
 static LONG g_nFontLinkCacheCount = 0;
 


### PR DESCRIPTION
## Purpose
According to @Doug-Lyons report, it seems like #7009 introduced wrongly rebooting on `Test KVM`. Reduce memory usage in bot tests.
JIRA issue: [CORE-XXXX](https://jira.reactos.org/browse/CORE-XXXX)

## TODO

- [ ] Do big tests.