### PR TITLE
[SHELL32] shlexec.cpp: Automate buffer alloc/free

### DIFF
--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -2202,7 +2202,7 @@ static BOOL SHELL_execute(LPSHELLEXECUTEINFOW sei, SHELL_ExecuteW32 execfunc)
             wcmd = wcmdAlloc;
             wcmdLen = len;
         }
-        swprintf(wcmd, L"\"%s\"", wszApplicationName);
+        swprintf(wcmd, L"\"%s\"", (LPWSTR)wszApplicationName);
         if (sei_tmp.lpParameters[0])
         {
             strcatW(wcmd, L" ");

--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -1842,10 +1842,8 @@ static WCHAR *expand_environment( const WCHAR *str )
 
     len = ExpandEnvironmentStringsW(str, buf, len);
     if (!len)
-    {
-        HeapFree(GetProcessHeap(), 0, buf);
         return NULL;
-    }
+
     return buf.Detach();
 }
 

--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -2186,8 +2186,8 @@ static BOOL SHELL_execute(LPSHELLEXECUTEINFOW sei, SHELL_ExecuteW32 execfunc)
         lpFile = sei_tmp.lpFile;
 
     WCHAR wcmdBuffer[1024];
-    DWORD wcmdLen = ARRAY_SIZE(wcmdBuffer);
     LPWSTR wcmd = wcmdBuffer;
+    DWORD wcmdLen = _countof(wcmdBuffer);
     CHeapPtr<WCHAR, CHeapAllocator> wcmdAlloc;
 
     /* Only execute if it has an executable extension */

--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -1900,9 +1900,7 @@ static BOOL SHELL_execute(LPSHELLEXECUTEINFOW sei, SHELL_ExecuteW32 execfunc)
     else
     {
         DWORD l = strlenW(sei_tmp.lpFile) + 1;
-        if (l > dwApplicationNameLen)
-            dwApplicationNameLen = l + 1;
-
+        if(l > dwApplicationNameLen) dwApplicationNameLen = l + 1;
         wszApplicationName.Allocate(dwApplicationNameLen);
         memcpy(wszApplicationName, sei_tmp.lpFile, l * sizeof(WCHAR));
 
@@ -2049,8 +2047,7 @@ static BOOL SHELL_execute(LPSHELLEXECUTEINFOW sei, SHELL_ExecuteW32 execfunc)
     {
         CHeapPtr<WCHAR, CLocalAllocator> buf;
         DWORD size = MAX_PATH;
-        buf.Allocate(size);
-        if (!buf || FAILED(PathCreateFromUrlW(sei_tmp.lpFile, buf, &size, 0)))
+        if (!buf.Allocate(size) || FAILED(PathCreateFromUrlW(sei_tmp.lpFile, buf, &size, 0)))
             return SE_ERR_OOM;
 
         wszApplicationName.Attach(buf.Detach());
@@ -2200,8 +2197,7 @@ static BOOL SHELL_execute(LPSHELLEXECUTEINFOW sei, SHELL_ExecuteW32 execfunc)
     {
         WCHAR wExec[MAX_PATH];
         CHeapPtr<WCHAR, CLocalAllocator> lpQuotedFile;
-        lpQuotedFile.Allocate(strlenW(lpFile) + 3);
-        if (lpQuotedFile)
+        if (lpQuotedFile.Allocate(strlenW(lpFile) + 3))
         {
             retval = SHELL_FindExecutable(sei_tmp.lpDirectory, L"explorer",
                                           L"open", wExec, MAX_PATH,


### PR DESCRIPTION
## Purpose

Reduce code. Simplify code logic. Ensure leak zero.
JIRA issue: [CORE-17482](https://jira.reactos.org/browse/CORE-17482)

## Proposed changes

- Use `CHeapPtr<WCHAR, CLocalAllocator>` for allocation/freeing.