### PR TITLE
[USERINIT] LiveCD: Set UI language

### DIFF
--- a/base/system/userinit/livecd.c
+++ b/base/system/userinit/livecd.c
@@ -715,6 +715,9 @@ LocaleDlgProc(
                         /* Store the locale settings in the registry */
                         InitializeDefaultUserLocale(&NewLcid);
 
+                        /* Set UI language for this thread */
+                        SetThreadLocale(NewLcid);
+
                         SetKeyboardLayout(GetDlgItem(hwndDlg, IDC_LAYOUTLIST));
 
                         pState->NextPage = STARTPAGE;


### PR DESCRIPTION
## Purpose

The LiveCD start dialog was not localized.
JIRA issue: N/A

## Proposed changes

- Just call `SetThreadLocale` after `InitializeDefaultUserLocale` call.

## Screenshots

Choose Russian for example...
![russian](https://github.com/reactos/reactos/assets/2107452/5822b6b8-5ca1-49b1-a230-3db3c2323c5a)

BEFORE:
![before](https://github.com/reactos/reactos/assets/2107452/63995023-b527-4a4e-97e3-f3de5d6f377c)
The LiveCD start dialog was not localized.

AFTER:
![after](https://github.com/reactos/reactos/assets/2107452/a373058b-3430-4417-949e-63026a1510eb)
The LiveCD start dialog has been localized.