### PR TITLE
[RAPPS] Disable certificate pinning

### DIFF
--- a/base/applications/rapps/CMakeLists.txt
+++ b/base/applications/rapps/CMakeLists.txt
@@ -42,8 +42,10 @@ list(APPEND SOURCE
     ${ZLIB_SOURCE}
 )
 
-add_definitions(
-    -DUSE_CERT_PINNING)
+# USE_CERT_PINNING is disabled, not sustainable, because it breaks remotely every few years
+# and requires us to change our hard-codes in the binary recurrently.
+#add_definitions(
+#    -DUSE_CERT_PINNING)
 
 file(GLOB_RECURSE rapps_rc_deps res/*.*)
 add_rc_deps(rapps.rc ${rapps_rc_deps})


### PR DESCRIPTION
Fixes CORE-19666 '[RAPPS] Let's encrypt certificate (expired?), first seen 2024-06-30'
Yes, we could also groom the hardcodes within rapps to make the cert work again, but that wouldn't be a sustainable solution.

This stuff breaks recurrently every few years:
- When the cert is changed
- When the cert expires
- when the cert authority changes its name (it did that the last time in January 2021)
- and when the cert issuer's CEO's dog pisses on the street

Crypto-BS at its finest.

Yes, disabling it may have a slight negative impact on the DB's transmission security.
So take it or leave it.

JIRA issue: [CORE-19666](https://jira.reactos.org/browse/CORE-19666)
