### PR TITLE
[EXPLORER][COMCTL32] Toolbar: Fix text with BTNS_NOPREFIX

### DIFF
--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -287,7 +287,6 @@ public:
 
         // HACK & FIXME: CORE-18016
         HWND toolbar = CToolbar::Create(hWndParent, styles);
-        SetDrawTextFlags(DT_NOPREFIX, DT_NOPREFIX);
         m_hWnd = NULL;
         return SubclassWindow(toolbar);
     }

--- a/dll/win32/comctl32/toolbar.c
+++ b/dll/win32/comctl32/toolbar.c
@@ -286,6 +286,16 @@ static inline BOOL button_has_ddarrow(const TOOLBAR_INFO *infoPtr, const TBUTTON
         (btnPtr->fsStyle & BTNS_WHOLEDROPDOWN);
 }
 
+#ifdef __REACTOS__
+static inline DWORD TOOLBAR_GetButtonDTFlags(const TOOLBAR_INFO *infoPtr, const TBUTTON_INFO *btnPtr)
+{
+    DWORD dwDTFlags = infoPtr->dwDTFlags;
+    if (btnPtr->fsStyle & BTNS_NOPREFIX)
+        dwDTFlags |= DT_NOPREFIX;
+    return dwDTFlags;
+}
+#endif
+
 static LPWSTR
 TOOLBAR_GetText(const TOOLBAR_INFO *infoPtr, const TBUTTON_INFO *btnPtr)
 {
@@ -623,6 +633,9 @@ TOOLBAR_DrawArrow (HDC hdc, INT left, INT top, COLORREF clr)
  */
 static void
 TOOLBAR_DrawString (const TOOLBAR_INFO *infoPtr, RECT *rcText, LPCWSTR lpText,
+#ifdef __REACTOS__
+                    const TBUTTON_INFO *btnPtr,
+#endif
                     const NMTBCUSTOMDRAW *tbcd, DWORD dwItemCDFlag)
 {
     HDC hdc = tbcd->nmcd.hdc;
@@ -633,6 +646,7 @@ TOOLBAR_DrawString (const TOOLBAR_INFO *infoPtr, RECT *rcText, LPCWSTR lpText,
     UINT state = tbcd->nmcd.uItemState;
 #ifdef __REACTOS__
     HTHEME theme = GetWindowTheme (infoPtr->hwndSelf);
+    DWORD dwDTFlags = TOOLBAR_GetButtonDTFlags(infoPtr, btnPtr);
 #endif
 
     /* draw text */
@@ -660,7 +674,7 @@ TOOLBAR_DrawString (const TOOLBAR_INFO *infoPtr, RECT *rcText, LPCWSTR lpText,
         else if (state & CDIS_HOT)
             stateId = TS_HOT;
 
-        DrawThemeText(theme, hdc, partId, stateId, lpText, -1, infoPtr->dwDTFlags, dwDTFlags2, rcText);
+        DrawThemeText(theme, hdc, partId, stateId, lpText, -1, dwDTFlags, dwDTFlags2, rcText);
         SelectObject (hdc, hOldFont);
         return;
     }
@@ -672,7 +686,11 @@ TOOLBAR_DrawString (const TOOLBAR_INFO *infoPtr, RECT *rcText, LPCWSTR lpText,
 	else if (state & CDIS_DISABLED) {
 	    clrOld = SetTextColor (hdc, tbcd->clrBtnHighlight);
 	    OffsetRect (rcText, 1, 1);
+#ifdef __REACTOS__
+	    DrawTextW (hdc, lpText, -1, rcText, dwDTFlags);
+#else
 	    DrawTextW (hdc, lpText, -1, rcText, infoPtr->dwDTFlags);
+#endif
 	    SetTextColor (hdc, comctl32_color.clr3dShadow);
 	    OffsetRect (rcText, -1, -1);
 	}
@@ -688,7 +706,11 @@ TOOLBAR_DrawString (const TOOLBAR_INFO *infoPtr, RECT *rcText, LPCWSTR lpText,
 	    clrOld = SetTextColor (hdc, tbcd->clrText);
 	}
 
+#ifdef __REACTOS__
+	DrawTextW (hdc, lpText, -1, rcText, dwDTFlags);
+#else
 	DrawTextW (hdc, lpText, -1, rcText, infoPtr->dwDTFlags);
+#endif
 	SetTextColor (hdc, clrOld);
 	if ((state & CDIS_MARKED) && !(dwItemCDFlag & TBCDRF_NOMARK))
 	{
@@ -1197,7 +1219,11 @@ TOOLBAR_DrawButton (const TOOLBAR_INFO *infoPtr, TBUTTON_INFO *btnPtr, HDC hdc, 
 
     oldBkMode = SetBkMode (hdc, tbcd.nStringBkMode);
     if (!(infoPtr->dwExStyle & TBSTYLE_EX_MIXEDBUTTONS) || (btnPtr->fsStyle & BTNS_SHOWTEXT))
+#ifdef __REACTOS__
+        TOOLBAR_DrawString(infoPtr, &rcText, lpText, btnPtr, &tbcd, dwItemCDFlag);
+#else
         TOOLBAR_DrawString (infoPtr, &rcText, lpText, &tbcd, dwItemCDFlag);
+#endif
     SetBkMode (hdc, oldBkMode);
 
     TOOLBAR_DrawImage(infoPtr, btnPtr, rcBitmap.left, rcBitmap.top, &tbcd, dwItemCDFlag);


### PR DESCRIPTION
## Purpose

The ampersand (`&`) a.k.a. prefix of `DrawText` are specially treated for adding underscores.
We have to fix drawing on toolbar button with `BTNS_NOPREFIX` style.
JIRA issue: [CORE-11619](https://jira.reactos.org/browse/CORE-11619)

## Proposed changes

- Delete DT flags hack in `taskswnd.cpp`.
- Add `TOOLBAR_GetButtonDTFlags` helper function.
- Extend `TOOLBAR_DrawString` parameters for the button info.
- Fix `DrawText` flags for drawing when the button has `BTNS_NOPREFIX` style.

## Comparison

BEFORE (without hack):
![before](https://github.com/reactos/reactos/assets/2107452/a09b29c7-16ff-4d09-bcee-65da481ca771)
There is underscore on taskbar button.

AFTER:
![after](https://github.com/reactos/reactos/assets/2107452/e8e64f92-091b-4849-8d98-059f663cbfce)
Fixed.