### PR TITLE
[SHELL32] Refresh UI on assoc change (SHOpenWithDialog)

### DIFF
--- a/dll/win32/shell32/COpenWithMenu.cpp
+++ b/dll/win32/shell32/COpenWithMenu.cpp
@@ -1052,6 +1052,7 @@ VOID COpenWithDialog::Accept()
         if (IsDlgButtonChecked(m_hDialog, 14003) == BST_CHECKED)
         {
             m_pAppList->SetDefaultHandler(pApp, m_pInfo->pcszFile);
+            // FIXME: Update DefaultIcon registry
             SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_FLUSHNOWAIT, NULL, NULL);
         }
 

--- a/dll/win32/shell32/COpenWithMenu.cpp
+++ b/dll/win32/shell32/COpenWithMenu.cpp
@@ -1049,8 +1049,11 @@ VOID COpenWithDialog::Accept()
     if (pApp)
     {
         /* Set programm as default handler */
-        if (SendDlgItemMessage(m_hDialog, 14003, BM_GETCHECK, 0, 0) == BST_CHECKED)
+        if (IsDlgButtonChecked(m_hDialog, 14003) == BST_CHECKED)
+        {
             m_pAppList->SetDefaultHandler(pApp, m_pInfo->pcszFile);
+            SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_FLUSHNOWAIT, NULL, NULL);
+        }
 
         /* Execute program */
         if (m_pInfo->oaifInFlags & OAIF_EXEC)

--- a/dll/win32/shell32/dialogs/filedefext.cpp
+++ b/dll/win32/shell32/dialogs/filedefext.cpp
@@ -742,8 +742,13 @@ CFileDefExt::GeneralPageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lPar
                 OPENASINFO oainfo;
                 oainfo.pcszFile = pFileDefExt->m_wszPath;
                 oainfo.pcszClass = NULL;
-                oainfo.oaifInFlags = OAIF_REGISTER_EXT|OAIF_FORCE_REGISTRATION;
-                return SUCCEEDED(SHOpenWithDialog(hwndDlg, &oainfo));
+                oainfo.oaifInFlags = OAIF_REGISTER_EXT | OAIF_FORCE_REGISTRATION;
+                if (SHOpenWithDialog(hwndDlg, &oainfo) == S_OK)
+                {
+                    pFileDefExt->InitGeneralPage(hwndDlg);
+                    PropSheet_Changed(GetParent(hwndDlg), hwndDlg);
+                }
+                break;
             }
             else if (LOWORD(wParam) == 14021 || LOWORD(wParam) == 14022 || LOWORD(wParam) == 14023) /* checkboxes */
                 PropSheet_Changed(GetParent(hwndDlg), hwndDlg);


### PR DESCRIPTION
## Purpose
Fix file association UX.
JIRA issue: [CORE-19670](https://jira.reactos.org/browse/CORE-19670)

## Proposed changes

- Check the return value of `shell32!SHOpenWithDialog` function.
- If changed, then update the UI display and internal data.
- Use `OAIF_FORCE_REGISTRATION` flag.

## TODO

- [x] Do check.
- [ ] Update file icon.

## Movie

https://github.com/reactos/reactos/assets/2107452/f00b9407-06f3-4808-af6d-a1f2c9290642