### PR TITLE
[IMM32][NTUSER] Reduce a little IMM spams

### DIFF
--- a/dll/win32/imm32/ime.c
+++ b/dll/win32/imm32/ime.c
@@ -1585,7 +1585,7 @@ BOOL WINAPI ImmSetCompositionWindow(HIMC hIMC, LPCOMPOSITIONFORM lpCompForm)
     LPINPUTCONTEXTDX pIC;
     HWND hWnd;
 
-    if (IS_CROSS_THREAD_HIMC(hIMC))
+    if (Imm32IsCrossThreadAccess(hIMC))
         return FALSE;
 
     pIC = (LPINPUTCONTEXTDX)ImmLockIMC(hIMC);

--- a/win32ss/user/ntuser/ime.c
+++ b/win32ss/user/ntuser/ime.c
@@ -1797,10 +1797,7 @@ NtUserQueryInputContext(HIMC hIMC, DWORD dwType)
     UserEnterExclusive();
 
     if (!IS_IMM_MODE())
-    {
-        ERR("!IS_IMM_MODE()\n");
         goto Quit;
-    }
 
     pIMC = UserGetObject(gHandleTable, hIMC, TYPE_INPUTCONTEXT);
     if (!pIMC)


### PR DESCRIPTION
## Purpose

Reduce log spams that @julenuri reported.
JIRA issue: [CORE-19268](https://jira.reactos.org/browse/CORE-19268)

## Proposed changes

- Use `Imm32IsCrossThreadAccess` instead of `IS_CROSS_THREAD_HIMC` in `ImmSetCompositionWindow` function.
- Reduce `ERR` logging in `NtUserQueryInputContext` function.