### PR TITLE
[EXPLORER] Check IsHungAppWindow before minimizing

### DIFF
--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -1602,7 +1602,8 @@ public:
 
             if (!bIsMinimized && bIsActive)
             {
-                ::ShowWindowAsync(TaskItem->hWnd, SW_MINIMIZE);
+                if (!::IsHungAppWindow(TaskItem->hWnd))
+                    ::ShowWindowAsync(TaskItem->hWnd, SW_MINIMIZE);
                 TRACE("Valid button clicked. App window Minimized.\n");
             }
             else

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -101,7 +101,8 @@ VOID RestoreWindowPos()
 
 BOOL CanBeMinimized(HWND hwnd)
 {
-    if (::IsWindowVisible(hwnd) && !::IsIconic(hwnd) && ::IsWindowEnabled(hwnd))
+    if (::IsWindowVisible(hwnd) && !::IsIconic(hwnd) && ::IsWindowEnabled(hwnd) &&
+        !::IsHungAppWindow(hwnd))
     {
         if (::GetClassLongPtrW(hwnd, GCW_ATOM) == (ULONG_PTR)WC_DIALOG)
             return TRUE;


### PR DESCRIPTION
## Purpose

Reduce system freezing on `Win+D`.
Normal minimizing causes message transfer.
If the window was hanging, then it fell into endless message loop. (We have to support `SW_FORCEMINIMIZE`)

JIRA issue: [CORE-19673](https://jira.reactos.org/browse/CORE-19673)

## Proposed changes

- In `CanBeMinimize` function of `traywnd.cpp`, check the return value of `IsHungAppWindow` function.
- Before minimizing, check the value of `IsHungAppWindow(...)` in `taskswnd.cpp`.

## TODO

- [x] Do tests.

## Comparison

BEFORE:
![before](https://github.com/reactos/reactos/assets/2107452/ff1baee8-e151-435d-959b-f0eb8fb84013)
`Win+D` won't work expectedly if any hung apps.

![after](https://github.com/reactos/reactos/assets/2107452/59147e0c-48dc-4b8e-9001-92d398dacc6f)
`Win+D` has worked within 6 seconds even if any hung apps.