### PR TITLE
[USER32] TileWindows: Adjust timeout of QuerySizeFix

### DIFF
--- a/win32ss/user/user32/windows/mdi.c
+++ b/win32ss/user/user32/windows/mdi.c
@@ -2053,7 +2053,7 @@ QuerySizeFix(HWND hwnd, LPINT pcx, LPINT pcy)
     mmi.ptMinTrackSize.x = mmi.ptMinTrackSize.y = 0;
     mmi.ptMaxTrackSize.x = mmi.ptMaxTrackSize.y = MAXLONG;
     if (SendMessageTimeoutW(hwnd, WM_GETMINMAXINFO, 0, (LPARAM)&mmi,
-                            SMTO_ABORTIFHUNG | SMTO_NORMAL, 120, &dwResult))
+                            SMTO_ABORTIFHUNG | SMTO_NORMAL, 700, &dwResult))
     {
         *pcx = min(max(*pcx, mmi.ptMinTrackSize.x), mmi.ptMaxTrackSize.x);
         *pcy = min(max(*pcy, mmi.ptMinTrackSize.y), mmi.ptMaxTrackSize.y);

--- a/win32ss/user/user32/windows/mdi.c
+++ b/win32ss/user/user32/windows/mdi.c
@@ -2053,7 +2053,7 @@ QuerySizeFix(HWND hwnd, LPINT pcx, LPINT pcy)
     mmi.ptMinTrackSize.x = mmi.ptMinTrackSize.y = 0;
     mmi.ptMaxTrackSize.x = mmi.ptMaxTrackSize.y = MAXLONG;
     if (SendMessageTimeoutW(hwnd, WM_GETMINMAXINFO, 0, (LPARAM)&mmi,
-                            SMTO_ABORTIFHUNG | SMTO_NORMAL, 700, &dwResult))
+                            SMTO_ABORTIFHUNG | SMTO_NORMAL, 1000, &dwResult))
     {
         *pcx = min(max(*pcx, mmi.ptMinTrackSize.x), mmi.ptMaxTrackSize.x);
         *pcy = min(max(*pcy, mmi.ptMinTrackSize.y), mmi.ptMaxTrackSize.y);


### PR DESCRIPTION
## Purpose
Since my machine performance became lower, we have to adjust timeout to get correct pattern of `user32!TileWindows` function.
JIRA issue: [CORE-19674](https://jira.reactos.org/browse/CORE-19674)

## Proposed changes

- Adjust timeout value in `QuerySizeFix` function.

## TODO

- [x] Do tests.

## Comparison

BEFORE:
![before](https://github.com/reactos/reactos/assets/2107452/d11be838-3a55-4e5f-b551-6275d9c6ccb8)

AFTER:
![after](https://github.com/reactos/reactos/assets/2107452/1ef46dfb-b0db-4a87-88f4-f8fef212082f)