### PR TITLE
[REGEDIT] Display REG_NONE as binary

### DIFF
--- a/base/applications/regedit/listview.c
+++ b/base/applications/regedit/listview.c
@@ -214,7 +214,6 @@ static void AddEntryToList(HWND hwndLV, LPWSTR Name, DWORD dwValType, void* ValB
         }
         break;
         case REG_DWORD:
-        case REG_NONE:
         {
             WCHAR buf[200];
             if(dwCount == sizeof(DWORD))
@@ -229,7 +228,7 @@ static void AddEntryToList(HWND hwndLV, LPWSTR Name, DWORD dwValType, void* ValB
         }
         /*            lpsRes = convertHexToDWORDStr(lpbData, dwLen); */
         break;
-        default:
+        default: /* REG_BINARY, REG_NONE etc. */
         {
             unsigned int i;
             LPBYTE pData = (LPBYTE)ValBuf;


### PR DESCRIPTION
REG_NONE is usually 0 bytes but can be any size. The binary display string for empty values is better than DWORD and also matches Windows.