### PR TITLE
[BROWSEUI][SHELL32] Implement BrowseObject flags

### DIFF
--- a/dll/win32/browseui/desktopipc.cpp
+++ b/dll/win32/browseui/desktopipc.cpp
@@ -366,9 +366,22 @@ static HRESULT ExplorerMessageLoop(IEThreadParamBlock * parameters)
     }
 
     CComPtr<IShellBrowser> psb;
+#if 0 // TODO
+    if (!(parameters->dwFlags & (SH_EXPLORER_CMDLINE_FLAG_E | SH_EXPLORER_CMDLINE_FLAG_NOREUSE)))
+    {
+        IShellWindows::FindWindowSW(...)
+    }
+#endif
     hResult = CShellBrowser_CreateInstance(IID_PPV_ARG(IShellBrowser, &psb));
     if (FAILED_UNEXPECTEDLY(hResult))
         return hResult;
+
+    if (parameters->dwFlags & SH_EXPLORER_CMDLINE_FLAG_EMBED)
+    {
+        CComPtr<IBrowserService> pbs;
+        if (SUCCEEDED(psb->QueryInterface(IID_PPV_ARG(IBrowserService, &pbs))))
+            pbs->SetFlags(BSF_UISETBYAUTOMATION, BSF_UISETBYAUTOMATION);
+    }
 
     hResult = psb->BrowseObject(parameters->directoryPIDL, wFlags);
     if (FAILED_UNEXPECTEDLY(hResult))

--- a/dll/win32/browseui/parsecmdline.cpp
+++ b/dll/win32/browseui/parsecmdline.cpp
@@ -259,7 +259,7 @@ SHExplorerParseCmdLine(_Out_ PEXPLORER_CMDLINE_PARSE_RESULTS pInfo)
         // Basic flags-only params first
         if (!StrCmpIW(strField, L"/N"))
         {
-            pInfo->dwFlags |= SH_EXPLORER_CMDLINE_FLAG_N | SH_EXPLORER_CMDLINE_FLAG_ONE;
+            pInfo->dwFlags |= SH_EXPLORER_CMDLINE_FLAG_NEWWND | SH_EXPLORER_CMDLINE_FLAG_NOREUSE;
             TRACE("CmdLine Parser: Parsed %S flag. dwFlags=%08lx\n", strField, pInfo->dwFlags);
         }
         else if (!StrCmpIW(strField, L"/S"))

--- a/dll/win32/shell32/dialogs/general.cpp
+++ b/dll/win32/shell32/dialogs/general.cpp
@@ -247,6 +247,8 @@ static void
 GeneralDlg_StoreToUI(HWND hwndDlg, BOOL bDoubleClick, BOOL bUseCommonTasks,
                      BOOL bUnderline, BOOL bNewWindowMode, PGENERAL_DIALOG pGeneral)
 {
+    EnableWindow(GetDlgItem(hwndDlg, IDC_FOLDER_OPTIONS_COMMONTASKS), bUseCommonTasks); // FIXME: ROS DefView does not support WebView nor the tasks pane
+
     if (bUseCommonTasks)
         CheckRadioButton(hwndDlg, IDC_FOLDER_OPTIONS_COMMONTASKS, IDC_FOLDER_OPTIONS_CLASSICFOLDERS, IDC_FOLDER_OPTIONS_COMMONTASKS);
     else
@@ -300,9 +302,9 @@ GeneralDlg_OnRestoreDefaults(HWND hwndDlg, PGENERAL_DIALOG pGeneral)
 {
     // default values
     BOOL bDoubleClick = TRUE;
-    BOOL bUseCommonTasks = FALSE;
+    BOOL bUseCommonTasks = TRUE;
     BOOL bUnderline = FALSE;
-    BOOL bNewWindowMode = FALSE;
+    BOOL bNewWindowMode = (_WIN32_WINNT < _WIN32_WINNT_WIN2K);
 
     GeneralDlg_StoreToUI(hwndDlg, bDoubleClick, bUseCommonTasks, bUnderline, bNewWindowMode, pGeneral);
     GeneralDlg_UpdateIcons(hwndDlg, 0, pGeneral);

--- a/dll/win32/shell32/shelldesktop/CDesktopBrowser.cpp
+++ b/dll/win32/shell32/shelldesktop/CDesktopBrowser.cpp
@@ -76,6 +76,9 @@ public:
     STDMETHOD(OnViewWindowActive)(struct IShellView *ppshv) override;
     STDMETHOD(SetToolbarItems)(LPTBBUTTON lpButtons, UINT nButtons, UINT uFlags) override;
 
+    // *** IBrowserService2 methods (fake for now) ***
+    inline void SetTopBrowser() const {}
+
     // *** IServiceProvider methods ***
     STDMETHOD(QueryService)(REFGUID guidService, REFIID riid, void **ppvObject) override;
 
@@ -120,6 +123,7 @@ CDesktopBrowser::CDesktopBrowser():
     m_hwndChangeNotifyServer(NULL),
     m_dwDrives(::GetLogicalDrives())
 {
+    SetTopBrowser();
 }
 
 CDesktopBrowser::~CDesktopBrowser()

--- a/sdk/include/reactos/browseui_undoc.h
+++ b/sdk/include/reactos/browseui_undoc.h
@@ -115,7 +115,7 @@ typedef struct ExplorerCommandLineParseResults
     // TODO: 'ULONG                   Padding[0x100];'?
 } EXPLORER_CMDLINE_PARSE_RESULTS, *PEXPLORER_CMDLINE_PARSE_RESULTS;
 
-#define SH_EXPLORER_CMDLINE_FLAG_ONE      0x00000001
+#define SH_EXPLORER_CMDLINE_FLAG_NEWWND   0x00000001
 #define SH_EXPLORER_CMDLINE_FLAG_S        0x00000002
 // unknown/unused                         0x00000004
 #define SH_EXPLORER_CMDLINE_FLAG_E        0x00000008
@@ -129,7 +129,7 @@ typedef struct ExplorerCommandLineParseResults
 // unknown/unused                         0x00000800
 #define SH_EXPLORER_CMDLINE_FLAG_NOUI     0x00001000
 // unknown/unused                         0x00002000
-#define SH_EXPLORER_CMDLINE_FLAG_N        0x00004000
+#define SH_EXPLORER_CMDLINE_FLAG_NOREUSE  0x00004000 // Don't use IShellWindows
 // unknown/unused                         0x00008000
 // unknown/unused                         0x00010000
 #define SH_EXPLORER_CMDLINE_FLAG_SEPARATE 0x00020000


### PR DESCRIPTION
- Support SBSP_NEWBROWSER, SBSP_PARENT and SBSP_RELATIVE.
- Partial support for SBSP_NAVIGATEBACK and SBSP_NAVIGATEFORWARD.
- Respect `CABINETSTATE::fNewWindowMode` if no other flags are relevant (allows Windows 95 style navigation).

Notes:
- The IDC_FOLDER_OPTIONS_COMMONTASKS radio button is disabled in the common/out-of-box configuration because it is unlikely that this option will ever be implemented in ROS (does not exist in NT6 and would require DirectUI in CDefView).