### PR TITLE
[NTUSER] IntSetTimer: Update HintIndex on each call

### DIFF
--- a/win32ss/user/ntuser/timer.c
+++ b/win32ss/user/ntuser/timer.c
@@ -223,10 +223,10 @@ IntSetTimer( PWND Window,
 
       IDEvent = RtlFindClearBitsAndSet(&WindowLessTimersBitMap, 1, HintIndex++);
       if (IDEvent == (UINT_PTR) -1)
-	  {
-		  HintIndex = HINTINDEX_BEGIN_VALUE;
-		  IDEvent = RtlFindClearBitsAndSet(&WindowLessTimersBitMap, 1, HintIndex++);
-	  }
+      {
+         HintIndex = HINTINDEX_BEGIN_VALUE;
+         IDEvent = RtlFindClearBitsAndSet(&WindowLessTimersBitMap, 1, HintIndex++);
+      }
       if (IDEvent == (UINT_PTR) -1)
       {
          IntUnlockWindowlessTimerBitmap();

--- a/win32ss/user/ntuser/timer.c
+++ b/win32ss/user/ntuser/timer.c
@@ -19,10 +19,12 @@ static LONG TimeLast = 0;
 /* Windows 2000 has room for 32768 window-less timers */
 #define NUM_WINDOW_LESS_TIMERS   32768
 
+#define HINTINDEX_BEGIN_VALUE   1
+
 static PFAST_MUTEX    Mutex;
 static RTL_BITMAP     WindowLessTimersBitMap;
 static PVOID          WindowLessTimersBitMapBuffer;
-static ULONG          HintIndex = 1;
+static ULONG          HintIndex = HINTINDEX_BEGIN_VALUE;
 
 ERESOURCE TimerLock;
 
@@ -219,8 +221,12 @@ IntSetTimer( PWND Window,
   {
       IntLockWindowlessTimerBitmap();
 
-      IDEvent = RtlFindClearBitsAndSet(&WindowLessTimersBitMap, 1, HintIndex);
-
+      IDEvent = RtlFindClearBitsAndSet(&WindowLessTimersBitMap, 1, HintIndex++);
+      if (IDEvent == (UINT_PTR) -1)
+	  {
+		  HintIndex = HINTINDEX_BEGIN_VALUE;
+		  IDEvent = RtlFindClearBitsAndSet(&WindowLessTimersBitMap, 1, HintIndex++);
+	  }
       if (IDEvent == (UINT_PTR) -1)
       {
          IntUnlockWindowlessTimerBitmap();

--- a/win32ss/user/ntuser/timer.c
+++ b/win32ss/user/ntuser/timer.c
@@ -222,7 +222,7 @@ IntSetTimer( PWND Window,
       IntLockWindowlessTimerBitmap();
 
       IDEvent = RtlFindClearBitsAndSet(&WindowLessTimersBitMap, 1, HintIndex++);
-      if (IDEvent == (UINT_PTR) -1)
+      if (IDEvent == (UINT_PTR)-1)
       {
          HintIndex = HINTINDEX_BEGIN_VALUE;
          IDEvent = RtlFindClearBitsAndSet(&WindowLessTimersBitMap, 1, HintIndex++);

--- a/win32ss/user/ntuser/timer.c
+++ b/win32ss/user/ntuser/timer.c
@@ -19,7 +19,7 @@ static LONG TimeLast = 0;
 /* Windows 2000 has room for 32768 window-less timers */
 #define NUM_WINDOW_LESS_TIMERS   32768
 
-#define HINTINDEX_BEGIN_VALUE   1
+#define HINTINDEX_BEGIN_VALUE   0
 
 static PFAST_MUTEX    Mutex;
 static RTL_BITMAP     WindowLessTimersBitMap;


### PR DESCRIPTION
## Purpose

Fixes [CORE-9141](https://jira.reactos.org/browse/CORE-9141) (and maybe some others)

The original code in SetTimer was returning the nearest free index.
But then what was happening was that if SetTimer was called, then KillTimer and then another SetTimer again, it got the same index(nearest free) as the previous SetTimer. This causes confusion in applications that have a single procedure to respond to DispatchMessageW/WM_TIMER for multiple timers and only the indexes(such as Abiword 2.6.8) differentiate them.

## Proposed changes

Add index increasing (decreasing) after each pass. If there is no free index anymore, the index value is reset to the beginning (HINTINDEX_BEGIN_VALUE).