### PR TITLE
[GDI32] Avoid invalid input in SetBkMode CORE-19656

### DIFF
--- a/win32ss/gdi/gdi32/objects/dc.c
+++ b/win32ss/gdi/gdi32/objects/dc.c
@@ -1058,7 +1058,7 @@ SetBkMode(
     _In_ int iBkMode)
 {
     /* Avoid bad mode setting */
-    if(iBkMode != TRANSPARENT)
+    if (iBkMode != TRANSPARENT)
         iBkMode = OPAQUE;
 	
     PDC_ATTR pdcattr;

--- a/win32ss/gdi/gdi32/objects/dc.c
+++ b/win32ss/gdi/gdi32/objects/dc.c
@@ -1063,7 +1063,7 @@ SetBkMode(
     /* Avoid bad mode setting */
     if ((iBkMode != TRANSPARENT) && (iBkMode != OPAQUE))
     {
-        DPRINT1("SetBkMode - incorrect value");
+        DPRINT1("SetBkMode: Incorrect value\n");
         return 0;
     }
 

--- a/win32ss/gdi/gdi32/objects/dc.c
+++ b/win32ss/gdi/gdi32/objects/dc.c
@@ -1061,8 +1061,11 @@ SetBkMode(
     INT iOldMode;
 
     /* Avoid bad mode setting */
-    if (iBkMode != TRANSPARENT)
-        iBkMode = OPAQUE;
+    if((iBkMode != TRANSPARENT) & (iBkMode != TRANSPARENT))
+    {
+        DPRINT1("SetBkMode - incorrect value");
+        return 0;
+    }
 
     HANDLE_METADC(INT, SetBkMode, 0, hdc, iBkMode);
 

--- a/win32ss/gdi/gdi32/objects/dc.c
+++ b/win32ss/gdi/gdi32/objects/dc.c
@@ -1057,12 +1057,12 @@ SetBkMode(
     _In_ HDC hdc,
     _In_ int iBkMode)
 {
+    PDC_ATTR pdcattr;
+    INT iOldMode;
+
     /* Avoid bad mode setting */
     if (iBkMode != TRANSPARENT)
         iBkMode = OPAQUE;
-	
-    PDC_ATTR pdcattr;
-    INT iOldMode;
 
     HANDLE_METADC(INT, SetBkMode, 0, hdc, iBkMode);
 

--- a/win32ss/gdi/gdi32/objects/dc.c
+++ b/win32ss/gdi/gdi32/objects/dc.c
@@ -1061,7 +1061,7 @@ SetBkMode(
     INT iOldMode;
 
     /* Avoid bad mode setting */
-    if((iBkMode != TRANSPARENT) & (iBkMode != TRANSPARENT))
+    if ((iBkMode != TRANSPARENT) && (iBkMode != OPAQUE))
     {
         DPRINT1("SetBkMode - incorrect value");
         return 0;

--- a/win32ss/gdi/gdi32/objects/dc.c
+++ b/win32ss/gdi/gdi32/objects/dc.c
@@ -1058,8 +1058,8 @@ SetBkMode(
     _In_ int iBkMode)
 {
     /* Avoid bad mode setting */
-    if(iBkMode!=TRANSPARENT)
-        iBkMode=OPAQUE;
+    if(iBkMode != TRANSPARENT)
+        iBkMode = OPAQUE;
 	
     PDC_ATTR pdcattr;
     INT iOldMode;

--- a/win32ss/gdi/gdi32/objects/dc.c
+++ b/win32ss/gdi/gdi32/objects/dc.c
@@ -1057,7 +1057,9 @@ SetBkMode(
     _In_ HDC hdc,
     _In_ int iBkMode)
 {
-    if(iBkMode!=TRANSPARENT)iBkMode=OPAQUE;//fix for bad mode setting
+    /* Avoid bad mode setting */
+    if(iBkMode!=TRANSPARENT)
+        iBkMode=OPAQUE;
 	
     PDC_ATTR pdcattr;
     INT iOldMode;

--- a/win32ss/gdi/gdi32/objects/dc.c
+++ b/win32ss/gdi/gdi32/objects/dc.c
@@ -1057,6 +1057,8 @@ SetBkMode(
     _In_ HDC hdc,
     _In_ int iBkMode)
 {
+    if(iBkMode!=TRANSPARENT)iBkMode=OPAQUE;//fix for bad mode setting
+	
     PDC_ATTR pdcattr;
     INT iOldMode;
 


### PR DESCRIPTION
## Purpose

There is a bug in Midori installer 0.5.11 that probably causes overflow and bad rendering.
In Windows it is visible as FillRect( 0x89011a1f, 0x0019f87c, 0xabababab ), in ReactOS again as SetBkMode( 0xb5010fce, -1546139919 ).
Unfortunately this bug makes the text in ReactOS hard to read (no background).

Jira issue: [CORE-19656](https://jira.reactos.org/browse/CORE-19656)

## Proposed changes

After a number of attempts to get the same behavior, I haven't found a way to fix it without a hack so that the installer looks identical to Windows. So I added at least a fix for the incorrect value in SetBkMode. This shouldn't matter anywhere. It may not look the same as on Windows, but the text will at least be readable.