### PR TITLE
[SHELL32] CDefaultContextMenu must respect the default verb list

### DIFF
--- a/dll/win32/shell32/COpenWithMenu.cpp
+++ b/dll/win32/shell32/COpenWithMenu.cpp
@@ -1222,7 +1222,6 @@ VOID COpenWithMenu::AddApp(PVOID pApp)
     mii.fState = MFS_ENABLED;
     mii.wID = m_idCmdLast;
     mii.dwTypeData = const_cast<LPWSTR>(pwszName);
-    mii.cch = wcslen(mii.dwTypeData);
     mii.dwItemData = (ULONG_PTR)pApp;
 
     HICON hIcon = m_pAppList->GetIcon((COpenWithList::SApp*)pApp);
@@ -1259,7 +1258,7 @@ HRESULT WINAPI COpenWithMenu::QueryContextMenu(
     m_idCmdFirst = m_idCmdLast = idCmdFirst;
     m_hSubMenu = NULL;
 
-    /* If we are going to be default item, we shouldn't be submenu */
+    /* We can only be a submenu if we are not the default */
     if (DefaultPos != -1)
     {
         /* Load applications list */
@@ -1298,13 +1297,14 @@ HRESULT WINAPI COpenWithMenu::QueryContextMenu(
 
     mii.fType = MFT_STRING;
     mii.dwTypeData = (LPWSTR)wszName;
-    mii.cch = wcslen(wszName);
-
     mii.fState = MFS_ENABLED;
     if (DefaultPos == -1)
+    {
         mii.fState |= MFS_DEFAULT;
+        indexMenu = 0;
+    }
 
-    if (!InsertMenuItemW(hMenu, DefaultPos + 1, TRUE, &mii))
+    if (!InsertMenuItemW(hMenu, indexMenu, TRUE, &mii))
         return E_FAIL;
 
     return MAKE_HRESULT(SEVERITY_SUCCESS, 0, m_idCmdLast - m_idCmdFirst + 1);


### PR DESCRIPTION
The default value in the shell key specifies the default verb(s) as specified on MSDN:

> Verbs can be ordered by specifying the default value of the Shell subkey for the association entry. This default value can include a single item, which will be displayed at the top position of the shortcut menu, or a list of items separated by spaces or commas. In the latter case, the first item in the list is the default item, and the other verbs are displayed immediately below it in the order specified.

Because our CDefaultContextMenu builds the menu in a different order than Windows, I cannot guarantee that the verbs will always be in the correct order but it's the best we can do for now.

While the order is not crucial, parsing the verb list is. Otherwise we will execute the wrong verb:

```BAT
@echo off&setlocal
set ext=TestDefVerb
set pid=.%ext%\PID
set CR=HKCU\Software\Classes
reg add "%CR%\.%ext%" /ve /d "%pid%" /f
reg add "%CR%\%pid%\shell\open\command" /ve /d "cmd.exe /K echo.FAIL" /f
reg add "%CR%\%pid%\shell\pass\command" /ve /d "cmd.exe /K echo.PASS" /f
reg add "%CR%\%pid%\shell" /ve /d "foo,bar  pass" /f

set desktop=%windir%\..
for /F "tokens=2,*" %%A in ('reg query "HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders" /v "Desktop"^|find "REG_"') do set desktop=%%B
echo.>>"%desktop%\TestFile.%ext%"
```

![XP vs ROS after PR](https://github.com/reactos/reactos/assets/138629473/532b88f3-7b8f-4876-88c6-75d9ceb13e2f)


Notes:
- COpenWithMenu is not allowed to force itself to the top unless it is the default item.