### PR TITLE
[NTUSER][USER32] Populate dwExpWinVer

### DIFF
--- a/sdk/include/ndk/rtlfuncs.h
+++ b/sdk/include/ndk/rtlfuncs.h
@@ -3986,6 +3986,10 @@ LdrRelocateImageWithBias(
     _In_ ULONG Invalid
 );
 
+ULONG
+NTAPI
+RtlGetExpWinVer(_In_ PVOID BaseAddress);
+
 //
 // Activation Context Functions
 //

--- a/sdk/include/ndk/rtlfuncs.h
+++ b/sdk/include/ndk/rtlfuncs.h
@@ -3986,10 +3986,6 @@ LdrRelocateImageWithBias(
     _In_ ULONG Invalid
 );
 
-ULONG
-NTAPI
-RtlGetExpWinVer(_In_ PVOID BaseAddress);
-
 //
 // Activation Context Functions
 //

--- a/win32ss/CMakeLists.txt
+++ b/win32ss/CMakeLists.txt
@@ -164,8 +164,8 @@ list(APPEND SOURCE
     user/ntuser/winpos.c
     user/ntuser/winsta.c
     user/ntuser/object.c
-    user/rtl/text.c
     user/rtl/image.c
+    user/rtl/text.c
     gdi/ntgdi/arc.c
     gdi/ntgdi/bezier.c
     gdi/ntgdi/bitblt.c

--- a/win32ss/CMakeLists.txt
+++ b/win32ss/CMakeLists.txt
@@ -165,6 +165,7 @@ list(APPEND SOURCE
     user/ntuser/winsta.c
     user/ntuser/object.c
     user/rtl/text.c
+    user/rtl/image.c
     gdi/ntgdi/arc.c
     gdi/ntgdi/bezier.c
     gdi/ntgdi/bitblt.c

--- a/win32ss/include/ntuser.h
+++ b/win32ss/include/ntuser.h
@@ -3628,6 +3628,9 @@ NtUserSetScrollBarInfo(
     LONG idObject,
     SETSCROLLBARINFO *info);
 
+ULONG
+RtlGetExpWinVer(_In_ PVOID BaseAddress);
+
 #endif /* __WIN32K_NTUSER_H */
 
 /* EOF */

--- a/win32ss/user/ntuser/main.c
+++ b/win32ss/user/ntuser/main.c
@@ -456,15 +456,15 @@ DWORD WINAPI RtlGetExpWinVer(HMODULE hModule)
 {
     DWORD dwMajorVersion = 3, dwMinorVersion = 10; /* Set default to Windows 3.10 */
     PIMAGE_NT_HEADERS pNT;
-    PVOID BaseAddress = (PVOID)hModule;
+    ULONG_PTR BaseAddress = (ULONG_PTR)hModule;
 
     /* Fix alignment */
-    if (((ULONG_PTR)BaseAddress) & 1)
-        BaseAddress = (PVOID)(((ULONG_PTR)BaseAddress) & ~1);
+    if (BaseAddress & 1)
+        BaseAddress = (BaseAddress & ~1);
 
     if (BaseAddress && !LOWORD(BaseAddress))
     {
-        pNT = RtlImageNtHeader(BaseAddress);
+        pNT = RtlImageNtHeader((PVOID)BaseAddress);
         if (pNT)
         {
             dwMajorVersion = pNT->OptionalHeader.MajorSubsystemVersion;

--- a/win32ss/user/ntuser/main.c
+++ b/win32ss/user/ntuser/main.c
@@ -451,33 +451,6 @@ UserThreadDestroy(PETHREAD Thread)
     return STATUS_SUCCESS;
 }
 
-/* Get the expected OS version from the application module */
-DWORD WINAPI RtlGetExpWinVer(HMODULE hModule)
-{
-    DWORD dwMajorVersion = 3, dwMinorVersion = 10; /* Set default to Windows 3.10 */
-    PIMAGE_NT_HEADERS pNT;
-    ULONG_PTR BaseAddress = (ULONG_PTR)hModule;
-
-    /* Fix alignment */
-    if (BaseAddress & 1)
-        BaseAddress = (BaseAddress & ~1);
-
-    if (BaseAddress && !LOWORD(BaseAddress))
-    {
-        pNT = RtlImageNtHeader((PVOID)BaseAddress);
-        if (pNT)
-        {
-            dwMajorVersion = pNT->OptionalHeader.MajorSubsystemVersion;
-            if (dwMajorVersion == 1)
-                dwMajorVersion = 3;
-            else
-                dwMinorVersion = pNT->OptionalHeader.MinorSubsystemVersion;
-        }
-    }
-
-    return MAKEWORD(dwMinorVersion, dwMajorVersion);
-}
-
 NTSTATUS NTAPI
 InitThreadCallback(PETHREAD Thread)
 {
@@ -584,7 +557,7 @@ InitThreadCallback(PETHREAD Thread)
 
     /* Populate dwExpWinVer */
     if (Process->Peb)
-        ptiCurrent->dwExpWinVer = RtlGetExpWinVer((HMODULE)Process->SectionBaseAddress);
+        ptiCurrent->dwExpWinVer = RtlGetExpWinVer(Process->SectionBaseAddress);
     else
         ptiCurrent->dwExpWinVer = WINVER_WINNT4;
     pci->dwExpWinVer = ptiCurrent->dwExpWinVer;

--- a/win32ss/user/ntuser/main.c
+++ b/win32ss/user/ntuser/main.c
@@ -451,12 +451,14 @@ UserThreadDestroy(PETHREAD Thread)
     return STATUS_SUCCESS;
 }
 
+/* Get the expected OS version from the application module */
 DWORD WINAPI RtlGetExpWinVer(HMODULE hModule)
 {
     DWORD dwMajorVersion = 3, dwMinorVersion = 10; /* Set default to Windows 3.10 */
     PIMAGE_NT_HEADERS pNT;
     PVOID BaseAddress = (PVOID)hModule;
 
+    /* Fix alignment */
     if (((ULONG_PTR)BaseAddress) & 1)
         BaseAddress = (PVOID)(((ULONG_PTR)BaseAddress) & ~1);
 

--- a/win32ss/user/ntuser/main.c
+++ b/win32ss/user/ntuser/main.c
@@ -458,7 +458,7 @@ DWORD WINAPI RtlGetExpWinVer(HMODULE hModule)
     PVOID BaseAddress = (PVOID)hModule;
 
     if (((ULONG_PTR)BaseAddress) & 1)
-        BaseAddress = (PVOID)((ULONG_PTR)BaseAddress & ~1);
+        BaseAddress = (PVOID)(((ULONG_PTR)BaseAddress) & ~1);
 
     if (BaseAddress && !LOWORD(BaseAddress))
     {

--- a/win32ss/user/rtl/image.c
+++ b/win32ss/user/rtl/image.c
@@ -2,7 +2,8 @@
  * PROJECT:     ReactOS Win32ss RTL
  * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
  * PURPOSE:     RtlGetExpWinVer function
- * COPYRIGHT:   Copyright 2024 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ * COPYRIGHT:   Copyright 2019 James Tabor <james.tabor@reactos.org>
+ *              Copyright 2024 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  */
 
 #ifdef _WIN32K_

--- a/win32ss/user/rtl/image.c
+++ b/win32ss/user/rtl/image.c
@@ -6,15 +6,12 @@
  */
 
 #ifdef _WIN32K_
-    #include <win32k.h>
-
-    #define NDEBUG
-    #include <debug.h>
+#include <win32k.h>
+DBG_DEFAULT_CHANNEL(UserMisc);
 #else
-    #include <user32.h>
-    #include <wine/debug.h>
-
-    WINE_DEFAULT_DEBUG_CHANNEL(user32);
+#include <user32.h>
+#include <wine/debug.h>
+WINE_DEFAULT_DEBUG_CHANNEL(user32);
 #endif
 
 /* Get the expected OS version from the application module */

--- a/win32ss/user/rtl/image.c
+++ b/win32ss/user/rtl/image.c
@@ -1,6 +1,6 @@
 /*
- * PROJECT:     ReactOS Win32ss RTL
- * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
+ * PROJECT:     ReactOS user32.dll
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
  * PURPOSE:     RtlGetExpWinVer function
  * COPYRIGHT:   Copyright 2019 James Tabor <james.tabor@reactos.org>
  *              Copyright 2024 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>

--- a/win32ss/user/rtl/image.c
+++ b/win32ss/user/rtl/image.c
@@ -18,7 +18,7 @@ WINE_DEFAULT_DEBUG_CHANNEL(user32);
 ULONG
 RtlGetExpWinVer(_In_ PVOID BaseAddress)
 {
-    ULONG dwMajorVersion = 3, dwMinorVersion = 10; /* Set default to Windows 3.10 */
+    ULONG dwMajorVersion = 3, dwMinorVersion = 10; /* Set default to Windows 3.10 (WINVER_WIN31) */
     PIMAGE_NT_HEADERS pNTHeader;
     ULONG_PTR AlignedAddress = (ULONG_PTR)BaseAddress;
 

--- a/win32ss/user/rtl/image.c
+++ b/win32ss/user/rtl/image.c
@@ -1,0 +1,52 @@
+/*
+ * PROJECT:   ReactOS RTL
+ * LICENSE:   LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
+ * PURPOSE:   RtlGetExpWinVer function
+ * COPYRIGHT: Copyright 2024 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ */
+
+#ifdef _WIN32K_
+    #include <win32k.h>
+
+    #define NDEBUG
+    #include <debug.h>
+#else
+    #include <user32.h>
+    #include <wine/debug.h>
+
+    WINE_DEFAULT_DEBUG_CHANNEL(user32);
+#endif
+
+/* Get the expected OS version from the application module */
+ULONG
+NTAPI
+RtlGetExpWinVer(_In_ PVOID BaseAddress)
+{
+    ULONG dwMajorVersion = 3, dwMinorVersion = 10; /* Set default to Windows 3.10 */
+    PIMAGE_NT_HEADERS pNT;
+    ULONG_PTR AlignedAddress = (ULONG_PTR)BaseAddress;
+
+#ifdef _WIN32K_
+    DPRINT("(%p)\n", BaseAddress);
+#else
+    TRACE("(%p)\n", BaseAddress);
+#endif
+
+    if (AlignedAddress & 1)
+        AlignedAddress = (AlignedAddress & ~1);
+
+    if (AlignedAddress && !LOWORD(AlignedAddress))
+    {
+        pNT = RtlImageNtHeader((PVOID)AlignedAddress);
+        if (pNT)
+        {
+            dwMajorVersion = pNT->OptionalHeader.MajorSubsystemVersion;
+            if (dwMajorVersion == 1)
+                dwMajorVersion = 3;
+            else
+                dwMinorVersion = pNT->OptionalHeader.MinorSubsystemVersion;
+        }
+    }
+
+    return MAKEWORD(dwMinorVersion, dwMajorVersion);
+}

--- a/win32ss/user/rtl/image.c
+++ b/win32ss/user/rtl/image.c
@@ -24,6 +24,7 @@ RtlGetExpWinVer(_In_ PVOID BaseAddress)
 
     TRACE("(%p)\n", BaseAddress);
 
+    /* Remove the magic flag for non-mapped images */
     if (AlignedAddress & 1)
         AlignedAddress = (AlignedAddress & ~1);
 

--- a/win32ss/user/rtl/image.c
+++ b/win32ss/user/rtl/image.c
@@ -19,7 +19,7 @@ ULONG
 RtlGetExpWinVer(_In_ PVOID BaseAddress)
 {
     ULONG dwMajorVersion = 3, dwMinorVersion = 10; /* Set default to Windows 3.10 */
-    PIMAGE_NT_HEADERS pNT;
+    PIMAGE_NT_HEADERS pNTHeader;
     ULONG_PTR AlignedAddress = (ULONG_PTR)BaseAddress;
 
     TRACE("(%p)\n", BaseAddress);
@@ -29,14 +29,14 @@ RtlGetExpWinVer(_In_ PVOID BaseAddress)
 
     if (AlignedAddress && !LOWORD(AlignedAddress))
     {
-        pNT = RtlImageNtHeader((PVOID)AlignedAddress);
-        if (pNT)
+        pNTHeader = RtlImageNtHeader((PVOID)AlignedAddress);
+        if (pNTHeader)
         {
-            dwMajorVersion = pNT->OptionalHeader.MajorSubsystemVersion;
+            dwMajorVersion = pNTHeader->OptionalHeader.MajorSubsystemVersion;
             if (dwMajorVersion == 1)
                 dwMajorVersion = 3;
             else
-                dwMinorVersion = pNT->OptionalHeader.MinorSubsystemVersion;
+                dwMinorVersion = pNTHeader->OptionalHeader.MinorSubsystemVersion;
         }
     }
 

--- a/win32ss/user/rtl/image.c
+++ b/win32ss/user/rtl/image.c
@@ -26,11 +26,7 @@ RtlGetExpWinVer(_In_ PVOID BaseAddress)
     PIMAGE_NT_HEADERS pNT;
     ULONG_PTR AlignedAddress = (ULONG_PTR)BaseAddress;
 
-#ifdef _WIN32K_
-    DPRINT("(%p)\n", BaseAddress);
-#else
     TRACE("(%p)\n", BaseAddress);
-#endif
 
     if (AlignedAddress & 1)
         AlignedAddress = (AlignedAddress & ~1);

--- a/win32ss/user/rtl/image.c
+++ b/win32ss/user/rtl/image.c
@@ -19,7 +19,6 @@
 
 /* Get the expected OS version from the application module */
 ULONG
-NTAPI
 RtlGetExpWinVer(_In_ PVOID BaseAddress)
 {
     ULONG dwMajorVersion = 3, dwMinorVersion = 10; /* Set default to Windows 3.10 */

--- a/win32ss/user/rtl/image.c
+++ b/win32ss/user/rtl/image.c
@@ -1,5 +1,5 @@
 /*
- * PROJECT:     ReactOS user32.dll
+ * PROJECT:     ReactOS user32.dll and win32k.sys
  * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
  * PURPOSE:     RtlGetExpWinVer function
  * COPYRIGHT:   Copyright 2019 James Tabor <james.tabor@reactos.org>

--- a/win32ss/user/rtl/image.c
+++ b/win32ss/user/rtl/image.c
@@ -1,8 +1,8 @@
 /*
- * PROJECT:   ReactOS RTL
- * LICENSE:   LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
- * PURPOSE:   RtlGetExpWinVer function
- * COPYRIGHT: Copyright 2024 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ * PROJECT:     ReactOS Win32ss RTL
+ * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
+ * PURPOSE:     RtlGetExpWinVer function
+ * COPYRIGHT:   Copyright 2024 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  */
 
 #ifdef _WIN32K_

--- a/win32ss/user/user32/CMakeLists.txt
+++ b/win32ss/user/user32/CMakeLists.txt
@@ -62,6 +62,7 @@ list(APPEND SOURCE
     windows/text.c
     windows/window.c
     windows/winpos.c
+    ${REACTOS_SOURCE_DIR}/win32ss/user/rtl/image.c
     ${REACTOS_SOURCE_DIR}/win32ss/user/rtl/text.c
     ${CMAKE_CURRENT_BINARY_DIR}/user32_stubs.c
     include/user32.h)

--- a/win32ss/user/user32/windows/window.c
+++ b/win32ss/user/user32/windows/window.c
@@ -148,34 +148,6 @@ RtlFreeLargeString(
     }
 }
 
-DWORD
-FASTCALL
-RtlGetExpWinVer(HMODULE hModule)
-{
-    DWORD dwMajorVersion = 3;  // Set default to Windows 3.10.
-    DWORD dwMinorVersion = 10;
-    PIMAGE_NT_HEADERS pinth;
-
-    if (hModule && !LOWORD((ULONG_PTR)hModule))
-    {
-        pinth = RtlImageNtHeader(hModule);
-        if (pinth)
-        {
-            dwMajorVersion = pinth->OptionalHeader.MajorSubsystemVersion;
-
-            if (dwMajorVersion == 1)
-            {
-                dwMajorVersion = 3;
-            }
-            else
-            {
-                dwMinorVersion = pinth->OptionalHeader.MinorSubsystemVersion;
-            }
-        }
-    }
-    return MAKELONG(MAKEWORD(dwMinorVersion, dwMajorVersion), 0);
-}
-
 HWND WINAPI
 User32CreateWindowEx(DWORD dwExStyle,
                      LPCSTR lpClassName,


### PR DESCRIPTION
## Purpose
This value is needed for `SetWindowPlacement` and IMM.
JIRA issue: [CORE-19675](https://jira.reactos.org/browse/CORE-19675)
JIRA issue: [CORE-19268](https://jira.reactos.org/browse/CORE-19268)

## Proposed changes

- Add `RtlGetExpWinVer` function into `win32ss/user/rtl/image.c`.
- Add `RtlGetExpWinVer` prototype into `win32ss/include/ntuser.h`.
- Delete `RtlGetExpWinVer` definition in `win32ss/user/user32/windows/window.c`.
- Populate `THREADINFO.dwExpWinVer` and `CLIENTINFO.dwExpWinVer` by using `RtlGetExpWinVer` in `InitThreadCallback` function.

## TODO

- [x] Do tests.