### PR TITLE
[TIMEDATE] Fix a typo in en-US locale

### DIFF
--- a/dll/cpl/timedate/lang/bg-BG.rc
+++ b/dll/cpl/timedate/lang/bg-BG.rc
@@ -54,6 +54,6 @@ BEGIN
     IDS_INETTIMENEXTSYNC "Следващо сверяване: %s at %s"
     IDS_INETTIMESYNCING "Почакайте, докато РеактОС сверява времето с %s"
     IDS_INETTIMEERROR "Възникна грешка при сверяване на времето %s"
-    IDS_INETTIMESUCFILL "Please type a NTP server name in order to synchronize the time"
-    IDS_INETTIMEWELCOME "Select a NTP server from the list or type a NTP server name to synchronize the computer's time"
+    IDS_INETTIMESUCFILL "Please type an NTP server name in order to synchronize the time"
+    IDS_INETTIMEWELCOME "Select an NTP server from the list or type an NTP server name to synchronize the computer's time"
 END

--- a/dll/cpl/timedate/lang/da-DK.rc
+++ b/dll/cpl/timedate/lang/da-DK.rc
@@ -54,6 +54,6 @@ BEGIN
     IDS_INETTIMENEXTSYNC "Next synchronization: %s at %s"
     IDS_INETTIMESYNCING "Please wait while ReactOS synchronizes the time with %s"
     IDS_INETTIMEERROR "An error occured while ReactOS was synchronizing with %s"
-    IDS_INETTIMESUCFILL "Please type a NTP server name in order to synchronize the time"
-    IDS_INETTIMEWELCOME "Select a NTP server from the list or type a NTP server name to synchronize the computer's time"
+    IDS_INETTIMESUCFILL "Please type an NTP server name in order to synchronize the time"
+    IDS_INETTIMEWELCOME "Select an NTP server from the list or type an NTP server name to synchronize the computer's time"
 END

--- a/dll/cpl/timedate/lang/de-DE.rc
+++ b/dll/cpl/timedate/lang/de-DE.rc
@@ -54,6 +54,6 @@ BEGIN
     IDS_INETTIMENEXTSYNC "Nächste Synchronisierung am %s um %s."
     IDS_INETTIMESYNCING "Bitte warten Sie, während ReactOS die Zeit mit %s synchronisiert."
     IDS_INETTIMEERROR "Ein Fehler trat beim Synchronisieren mit %s auf."
-    IDS_INETTIMESUCFILL "Please type a NTP server name in order to synchronize the time"
-    IDS_INETTIMEWELCOME "Select a NTP server from the list or type a NTP server name to synchronize the computer's time"
+    IDS_INETTIMESUCFILL "Please type an NTP server name in order to synchronize the time"
+    IDS_INETTIMEWELCOME "Select an NTP server from the list or type an NTP server name to synchronize the computer's time"
 END

--- a/dll/cpl/timedate/lang/el-GR.rc
+++ b/dll/cpl/timedate/lang/el-GR.rc
@@ -54,6 +54,6 @@ BEGIN
     IDS_INETTIMENEXTSYNC "Next synchronization: %s at %s"
     IDS_INETTIMESYNCING "Please wait while ReactOS synchronizes the time with %s"
     IDS_INETTIMEERROR "An error occured while ReactOS was synchronizing with %s"
-    IDS_INETTIMESUCFILL "Please type a NTP server name in order to synchronize the time"
-    IDS_INETTIMEWELCOME "Select a NTP server from the list or type a NTP server name to synchronize the computer's time"
+    IDS_INETTIMESUCFILL "Please type an NTP server name in order to synchronize the time"
+    IDS_INETTIMEWELCOME "Select an NTP server from the list or type an NTP server name to synchronize the computer's time"
 END

--- a/dll/cpl/timedate/lang/en-US.rc
+++ b/dll/cpl/timedate/lang/en-US.rc
@@ -54,6 +54,6 @@ BEGIN
     IDS_INETTIMENEXTSYNC "Next synchronization: %s at %s"
     IDS_INETTIMESYNCING "Please wait while ReactOS synchronizes the time with %s"
     IDS_INETTIMEERROR "An error occured while ReactOS was synchronizing with %s"
-    IDS_INETTIMESUCFILL "Please type a NTP server name in order to synchronize the time"
-    IDS_INETTIMEWELCOME "Select a NTP server from the list or type a NTP server name to synchronize the computer's time"
+    IDS_INETTIMESUCFILL "Please type an NTP server name in order to synchronize the time"
+    IDS_INETTIMEWELCOME "Select an NTP server from the list or type an NTP server name to synchronize the computer's time"
 END

--- a/dll/cpl/timedate/lang/es-ES.rc
+++ b/dll/cpl/timedate/lang/es-ES.rc
@@ -54,6 +54,6 @@ BEGIN
     IDS_INETTIMENEXTSYNC "Próxima sincronización: %s a las %s"
     IDS_INETTIMESYNCING "Por favor espere mientras ReactOS sincroniza la hora con %s"
     IDS_INETTIMEERROR "Ha ocurrido un error mientras ReactOS se sincronizaba con %s"
-    IDS_INETTIMESUCFILL "Please type a NTP server name in order to synchronize the time"
-    IDS_INETTIMEWELCOME "Select a NTP server from the list or type a NTP server name to synchronize the computer's time"
+    IDS_INETTIMESUCFILL "Please type an NTP server name in order to synchronize the time"
+    IDS_INETTIMEWELCOME "Select an NTP server from the list or type an NTP server name to synchronize the computer's time"
 END

--- a/dll/cpl/timedate/lang/et-EE.rc
+++ b/dll/cpl/timedate/lang/et-EE.rc
@@ -61,6 +61,6 @@ BEGIN
     IDS_INETTIMENEXTSYNC "Next synchronization: %s at %s"
     IDS_INETTIMESYNCING "Palun oodake, kuni ReactOS sünkroonib serveriga %s"
     IDS_INETTIMEERROR "ReactOSi sünkroonimisel serveriga %s ilmnes tõrge."
-    IDS_INETTIMESUCFILL "Please type a NTP server name in order to synchronize the time"
-    IDS_INETTIMEWELCOME "Select a NTP server from the list or type a NTP server name to synchronize the computer's time"
+    IDS_INETTIMESUCFILL "Please type an NTP server name in order to synchronize the time"
+    IDS_INETTIMEWELCOME "Select an NTP server from the list or type an NTP server name to synchronize the computer's time"
 END

--- a/dll/cpl/timedate/lang/eu-ES.rc
+++ b/dll/cpl/timedate/lang/eu-ES.rc
@@ -54,6 +54,6 @@ BEGIN
     IDS_INETTIMENEXTSYNC "Hurrengo sinkronizatzea: %s-n %s-etan"
     IDS_INETTIMESYNCING "Mesedez itxoin ReactOSek %s-rekin ordua sinkronizatu arte"
     IDS_INETTIMEERROR "Errore bat gertatu da ReactOS %s-kin sinkronizatzen zen bitartean"
-    IDS_INETTIMESUCFILL "Please type a NTP server name in order to synchronize the time"
-    IDS_INETTIMEWELCOME "Select a NTP server from the list or type a NTP server name to synchronize the computer's time"
+    IDS_INETTIMESUCFILL "Please type an NTP server name in order to synchronize the time"
+    IDS_INETTIMEWELCOME "Select an NTP server from the list or type an NTP server name to synchronize the computer's time"
 END

--- a/dll/cpl/timedate/lang/he-IL.rc
+++ b/dll/cpl/timedate/lang/he-IL.rc
@@ -54,6 +54,6 @@ BEGIN
     IDS_INETTIMENEXTSYNC "הסנכרון הבא: %s ב %s"
     IDS_INETTIMESYNCING "Please wait while ReactOS synchronizes the time with %s"
     IDS_INETTIMEERROR "An error occured while ReactOS was synchronizing with %s"
-    IDS_INETTIMESUCFILL "Please type a NTP server name in order to synchronize the time"
-    IDS_INETTIMEWELCOME "Select a NTP server from the list or type a NTP server name to synchronize the computer's time"
+    IDS_INETTIMESUCFILL "Please type an NTP server name in order to synchronize the time"
+    IDS_INETTIMEWELCOME "Select an NTP server from the list or type an NTP server name to synchronize the computer's time"
 END

--- a/dll/cpl/timedate/lang/nl-NL.rc
+++ b/dll/cpl/timedate/lang/nl-NL.rc
@@ -54,6 +54,6 @@ BEGIN
     IDS_INETTIMENEXTSYNC "Volgende synchronisatie: %s om %s"
     IDS_INETTIMESYNCING "ReactOS voert een synchronisatie met %s uit. Een ogenblik geduld."
     IDS_INETTIMEERROR "Er is een fout opgetreden bij een poging om een synchronisatie met %s uit te voeren."
-    IDS_INETTIMESUCFILL "Please type a NTP server name in order to synchronize the time"
-    IDS_INETTIMEWELCOME "Select a NTP server from the list or type a NTP server name to synchronize the computer's time"
+    IDS_INETTIMESUCFILL "Please type an NTP server name in order to synchronize the time"
+    IDS_INETTIMEWELCOME "Select an NTP server from the list or type an NTP server name to synchronize the computer's time"
 END

--- a/dll/cpl/timedate/lang/no-NO.rc
+++ b/dll/cpl/timedate/lang/no-NO.rc
@@ -54,6 +54,6 @@ BEGIN
     IDS_INETTIMENEXTSYNC "Neste synkonisering: %s med %s"
     IDS_INETTIMESYNCING "Vennligst vent mens ReactOS sykroniserer tiden med %s"
     IDS_INETTIMEERROR "En feil har oppstatt mens ReactOS ble sykronisert med %s"
-    IDS_INETTIMESUCFILL "Please type a NTP server name in order to synchronize the time"
-    IDS_INETTIMEWELCOME "Select a NTP server from the list or type a NTP server name to synchronize the computer's time"
+    IDS_INETTIMESUCFILL "Please type an NTP server name in order to synchronize the time"
+    IDS_INETTIMEWELCOME "Select an NTP server from the list or type an NTP server name to synchronize the computer's time"
 END

--- a/dll/cpl/timedate/lang/pt-BR.rc
+++ b/dll/cpl/timedate/lang/pt-BR.rc
@@ -54,6 +54,6 @@ BEGIN
     IDS_INETTIMENEXTSYNC "Próxima sincronização: %s às %s"
     IDS_INETTIMESYNCING "Aguarde enquanto o ReactOS é sincronizado com %s"
     IDS_INETTIMEERROR "Erro enquanto o ReactOS estava sincronizando com %s"
-    IDS_INETTIMESUCFILL "Please type a NTP server name in order to synchronize the time"
-    IDS_INETTIMEWELCOME "Select a NTP server from the list or type a NTP server name to synchronize the computer's time"
+    IDS_INETTIMESUCFILL "Please type an NTP server name in order to synchronize the time"
+    IDS_INETTIMEWELCOME "Select an NTP server from the list or type an NTP server name to synchronize the computer's time"
 END

--- a/dll/cpl/timedate/lang/sk-SK.rc
+++ b/dll/cpl/timedate/lang/sk-SK.rc
@@ -61,6 +61,6 @@ BEGIN
     IDS_INETTIMENEXTSYNC "Ďalšia synchronizácia: %s o %s"
     IDS_INETTIMESYNCING "Počkajte prosím, kým ReactOS zosynchronizuje čas s %s"
     IDS_INETTIMEERROR "Počas synchronizácie systému ReactOS s %s sa vyskytla chyba."
-    IDS_INETTIMESUCFILL "Please type a NTP server name in order to synchronize the time"
-    IDS_INETTIMEWELCOME "Select a NTP server from the list or type a NTP server name to synchronize the computer's time"
+    IDS_INETTIMESUCFILL "Please type an NTP server name in order to synchronize the time"
+    IDS_INETTIMEWELCOME "Select an NTP server from the list or type an NTP server name to synchronize the computer's time"
 END

--- a/dll/cpl/timedate/lang/sq-AL.rc
+++ b/dll/cpl/timedate/lang/sq-AL.rc
@@ -58,6 +58,6 @@ BEGIN
     IDS_INETTIMENEXTSYNC "Sinkronizimi tjetër: %s në %s"
     IDS_INETTIMESYNCING "Ju lutem prisni ndërkohë që ReactOS sinkronizon orën me %s"
     IDS_INETTIMEERROR "Një gabim ndodhi gjatë sinkronizimit të ReactOS me %s"
-    IDS_INETTIMESUCFILL "Please type a NTP server name in order to synchronize the time"
-    IDS_INETTIMEWELCOME "Select a NTP server from the list or type a NTP server name to synchronize the computer's time"
+    IDS_INETTIMESUCFILL "Please type an NTP server name in order to synchronize the time"
+    IDS_INETTIMEWELCOME "Select an NTP server from the list or type an NTP server name to synchronize the computer's time"
 END

--- a/dll/cpl/timedate/lang/sv-SE.rc
+++ b/dll/cpl/timedate/lang/sv-SE.rc
@@ -56,6 +56,6 @@ BEGIN
     IDS_INETTIMENEXTSYNC "Next synchronization: %s at %s"
     IDS_INETTIMESYNCING "Please wait while ReactOS synchronizes the time with %s"
     IDS_INETTIMEERROR "An error occured while ReactOS was synchronizing with %s"
-    IDS_INETTIMESUCFILL "Please type a NTP server name in order to synchronize the time"
-    IDS_INETTIMEWELCOME "Select a NTP server from the list or type a NTP server name to synchronize the computer's time"
+    IDS_INETTIMESUCFILL "Please type an NTP server name in order to synchronize the time"
+    IDS_INETTIMEWELCOME "Select an NTP server from the list or type an NTP server name to synchronize the computer's time"
 END

--- a/dll/cpl/timedate/lang/th-TH.rc
+++ b/dll/cpl/timedate/lang/th-TH.rc
@@ -54,6 +54,6 @@ BEGIN
     IDS_INETTIMENEXTSYNC "การปรับเทียบต่อไป: %s ใน %s"
     IDS_INETTIMESYNCING "โปรดรอ ReactOS กำลังปรับเทียบเวลาภายใน %s"
     IDS_INETTIMEERROR "เกิดการผิดพลาดในขณะที่ ReactOS กำลังปรับเทียบเวลาภายใน %s"
-    IDS_INETTIMESUCFILL "Please type a NTP server name in order to synchronize the time"
-    IDS_INETTIMEWELCOME "Select a NTP server from the list or type a NTP server name to synchronize the computer's time"
+    IDS_INETTIMESUCFILL "Please type an NTP server name in order to synchronize the time"
+    IDS_INETTIMEWELCOME "Select an NTP server from the list or type an NTP server name to synchronize the computer's time"
 END

--- a/dll/cpl/timedate/lang/uk-UA.rc
+++ b/dll/cpl/timedate/lang/uk-UA.rc
@@ -62,6 +62,6 @@ BEGIN
     IDS_INETTIMENEXTSYNC "Наступна синхронізація: %s в %s"
     IDS_INETTIMESYNCING "Будь ласка зачекайте, поки ReactOS синхронізує час з %s"
     IDS_INETTIMEERROR "Помилка під час синхронізації з %s"
-    IDS_INETTIMESUCFILL "Please type a NTP server name in order to synchronize the time"
-    IDS_INETTIMEWELCOME "Select a NTP server from the list or type a NTP server name to synchronize the computer's time"
+    IDS_INETTIMESUCFILL "Please type an NTP server name in order to synchronize the time"
+    IDS_INETTIMEWELCOME "Select an NTP server from the list or type an NTP server name to synchronize the computer's time"
 END


### PR DESCRIPTION
## Purpose

Fixes a typo in Timedate Control Panel's English strings IDS_INETTIMESUCFILL and IDS_INETTIMEWELCOME. The indefinite article is 'an' when it is before a vowel sound.

JIRA issue: none