### PR TITLE
[WIN32KNT_APITEST] Add NtUserSetTimer API tests

### DIFF
--- a/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
@@ -26,7 +26,7 @@
 typedef struct TIMER_MESSAGE_STATE1
 {
     UINT_PTR index;
-    int counter;
+    UINT counter;
 } TIMER_MESSAGE_STATE1;
 
 TIMER_MESSAGE_STATE1 timerId1[TEST1_COUNT];

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
@@ -62,7 +62,8 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
     return DefWindowProc(hwnd, uMsg, wParam, lParam);
 }
 
-BOOL test1(void)
+// TEST WITH MESSAGES WITHOUT WINDOW - test count of sent messages
+static BOOL test1(void)
 {
     UINT i, countErrors = 0;
 

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
@@ -14,14 +14,14 @@
 #define TEST1_COUNT 20
 #define TEST1_INTERVAL 10
 
-#define TEST2_COUNT 20
+#define TEST2_COUNT 40000
 #define TEST2_INTERVAL 10
 
-#define TEST3_COUNT 40000
-#define TEST3_INTERVAL 10
+#define TESTW1_COUNT 20
+#define TESTW1_INTERVAL 10
 
-#define TEST4_COUNT 40000
-#define TEST4_INTERVAL 10
+#define TESTW2_COUNT 40000
+#define TESTW2_INTERVAL 10
 
 typedef struct TIMER_MESSAGE_STATE1
 {
@@ -31,12 +31,12 @@ typedef struct TIMER_MESSAGE_STATE1
 
 TIMER_MESSAGE_STATE1 timerId1[TEST1_COUNT];
 
-typedef struct TIMER_MESSAGE_STATE2
+typedef struct TIMER_MESSAGE_STATEW1
 {
     UINT counter;
-} TIMER_MESSAGE_STATE2;
+} TIMER_MESSAGE_STATEW1;
 
-TIMER_MESSAGE_STATE2 timerId2[TEST2_COUNT];
+TIMER_MESSAGE_STATEW1 timerIdW1[TESTW1_COUNT];
 
 void CALLBACK TimerProc(HWND hWnd, UINT uMsg, UINT_PTR idEvent, DWORD dwTime)
 {
@@ -63,7 +63,7 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
     switch (uMsg)
     {
     case WM_TIMER:
-        timerId2[wParam].counter++;
+        timerIdW1[wParam].counter++;
         return 0;
     }
     return DefWindowProc(hwnd, uMsg, wParam, lParam);
@@ -125,21 +125,61 @@ BOOL test1(void)
     return FALSE;
 }
 
-BOOL test2(HWND hwnd)
+BOOL test2(void)
+{
+    int countErrors = 0;
+
+    for (long i = 0; i < TEST2_COUNT; i++)
+    {
+        UINT_PTR locIndex = SetTimer(NULL, 0, TEST2_INTERVAL, TimerProc);
+        if (locIndex == 0)
+        {
+            countErrors++;
+        }
+        if (KillTimer(NULL, locIndex) == 0)
+        {
+            countErrors++;
+        }
+    }
+
+    return (countErrors == 0);
+}
+
+BOOL test3(void)
+{
+    int countErrors = 0;
+
+    UINT_PTR locIndex1 = SetTimer(NULL, 0, TEST1_INTERVAL, TimerProc);
+    if (locIndex1 == 0)
+        countErrors++;
+    if (KillTimer(NULL, locIndex1) == 0)
+        countErrors++;
+    UINT_PTR locIndex2 = SetTimer(NULL, 0, TEST1_INTERVAL, TimerProc);
+    if (locIndex2 == 0)
+        countErrors++;
+    if (KillTimer(NULL, locIndex2) == 0)
+        countErrors++;
+    if(locIndex1 == locIndex2)
+        countErrors++;
+
+    return (countErrors == 0);
+}
+
+BOOL testW1(HWND hwnd)
 {
     UINT i, countErrors = 0;
 
-    int minMessages = (SLEEP_TIME / TEST2_INTERVAL) * (1 - TIME_TOLERANCE);
-    int maxMessages = (SLEEP_TIME / TEST2_INTERVAL) * (1 + TIME_TOLERANCE);
+    int minMessages = ((float)SLEEP_TIME / (float)TESTW1_INTERVAL) * (1 - TIME_TOLERANCE);
+    int maxMessages = ((float)SLEEP_TIME / (float)TESTW1_INTERVAL) * (1 + TIME_TOLERANCE);
     
-    for (i = 0; i < TEST2_COUNT; i++)
+    for (i = 0; i < TESTW1_COUNT; i++)
     {
-        timerId2[i].counter = 0;
+        timerIdW1[i].counter = 0;
     }
 
-    for (i = 0; i < TEST2_COUNT; i++)
+    for (i = 0; i < TESTW1_COUNT; i++)
     {
-        UINT_PTR locIndex = SetTimer(hwnd, i, TEST2_INTERVAL, NULL);
+        UINT_PTR locIndex = SetTimer(hwnd, i, TESTW1_INTERVAL, NULL);
         if (locIndex == 0)
         {
             countErrors++;
@@ -160,15 +200,15 @@ BOOL test2(HWND hwnd)
         }
     }
 
-    for (i = 0; i < TEST2_COUNT; i++)
+    for (i = 0; i < TESTW1_COUNT; i++)
     {
-        if ((timerId2[i].counter < minMessages) || (timerId2[i].counter > maxMessages))
+        if ((timerIdW1[i].counter < minMessages) || (timerIdW1[i].counter > maxMessages))
         {
             countErrors++;
         }
     }
 
-    for ( i = 0; i < TEST2_COUNT; i++)
+    for ( i = 0; i < TESTW1_COUNT; i++)
     {
         if (KillTimer(hwnd, i) == 0)
         {
@@ -181,27 +221,7 @@ BOOL test2(HWND hwnd)
     return FALSE;
 }
 
-BOOL test3(void)
-{
-    int countErrors = 0;
-
-    for (long i = 0; i < TEST3_COUNT; i++)
-    {
-        UINT_PTR locIndex = SetTimer(NULL, 0, TEST3_INTERVAL, TimerProc);
-        if (locIndex == 0)
-        {
-            countErrors++;
-        }
-        if (KillTimer(NULL, locIndex) == 0)
-        {
-            countErrors++;
-        }
-    }
-
-    return (countErrors == 0);
-}
-
-BOOL test4(HWND hwnd)
+BOOL testW2(HWND hwnd)
 {
     int countErrors = 0;
 
@@ -210,9 +230,9 @@ BOOL test4(HWND hwnd)
         return FALSE;
     }
 
-    for (int i = 0; i < TEST4_COUNT; i++)
+    for (int i = 0; i < TESTW2_COUNT; i++)
     {
-        UINT_PTR result = SetTimer(hwnd, 1, TEST4_INTERVAL, NULL);
+        UINT_PTR result = SetTimer(hwnd, 1, TESTW2_INTERVAL, NULL);
         if (result == 0)
             countErrors++;
         if (KillTimer(hwnd, 1) == 0)
@@ -222,28 +242,17 @@ BOOL test4(HWND hwnd)
     return (countErrors == 0);
 }
 
-BOOL test5(void)
-{
-    int countErrors = 0;
-
-    UINT_PTR locIndex1 = SetTimer(NULL, 0, TEST1_INTERVAL, TimerProc);
-    if (locIndex1 == 0)
-        countErrors++;
-    if (KillTimer(NULL, locIndex1) == 0)
-        countErrors++;
-    UINT_PTR locIndex2 = SetTimer(NULL, 0, TEST1_INTERVAL, TimerProc);
-    if (locIndex2 == 0)
-        countErrors++;
-    if (KillTimer(NULL, locIndex2) == 0)
-        countErrors++;
-    if(locIndex1 == locIndex2)
-        countErrors++;
-
-    return (countErrors == 0);
-}
-
 START_TEST(NtUserSetTimer)
 {
+    // TEST WITH MESSAGES WITHOUT WINDOW - test count of sent messages
+    TEST(test1());
+    
+    // TEST WITH MESSAGES WITHOUT WINDOW - create many timers
+    TEST(test2());
+    
+    // TEST WITH MESSAGES WITHOUT WINDOW - test different ids
+    TEST(test3());
+    
     WNDCLASS wc = {};
     wc.lpfnWndProc = WindowProc;
     wc.hInstance = GetModuleHandle(NULL);
@@ -258,27 +267,15 @@ START_TEST(NtUserSetTimer)
     {
         TEST(FALSE);
         TEST(FALSE);
-        TEST(FALSE);
-        TEST(FALSE);
-        TEST(FALSE);
         return;
     }
     
-    // TEST WITH MESSAGES WITHOUT WINDOW - test count of sent messages
-    TEST(test1());
-
     // TEST WITH MESSAGES WITH WINDOW - test count of sent messages
-    TEST(test2(hwnd));
-
-    // TEST WITH MESSAGES WITHOUT WINDOW - create many timers
-    TEST(test3());
+    TEST(testW1(hwnd));
 
     // TEST WITH MESSAGES WITH WINDOW - create many timers
-    TEST(test4(hwnd));
+    TEST(testW2(hwnd));
 
-    // TEST WITH MESSAGES WITHOUT WINDOW - test different ids
-    TEST(test5());
-    
     DestroyWindow(hwnd);
     UnregisterClass("TimerWindowClass", GetModuleHandle(NULL));
 }

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
@@ -45,6 +45,7 @@ void CALLBACK TimerProc(HWND hWnd, UINT uMsg, UINT_PTR idEvent, DWORD dwTime)
     {
         if (timerId1[i].index == idEvent)
             timerId1[i].counter++;
+    }
 }
 
 void MessageLoop(void)

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
@@ -190,7 +190,8 @@ static BOOL testW1(HWND hwnd)
     return (countErrors == 0);
 }
 
-BOOL testW2(HWND hwnd)
+// TEST WITH MESSAGES WITH WINDOW - create many timers
+static BOOL testW2(HWND hwnd)
 {
     UINT i, countErrors = 0;
 

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
@@ -7,10 +7,6 @@
 
 #include "../win32nt.h"
 
-//#include <iostream>
-
-#include "windows.h"
-
 #define SLEEP_TIME 500
 #define TIME_TOLERANCE 0.5
 
@@ -26,28 +22,33 @@
 #define TEST4_COUNT 40000
 #define TEST4_INTERVAL 10
 
-typedef struct TIMER_MESSAGE_STATE1 {
+typedef struct TIMER_MESSAGE_STATE1
+{
     UINT_PTR index;
     int counter;
 } TIMER_MESSAGE_STATE1;
 
 TIMER_MESSAGE_STATE1 timerId1[TEST1_COUNT];
 
-typedef struct TIMER_MESSAGE_STATE2 {
+typedef struct TIMER_MESSAGE_STATE2
+{
     int counter;
 } TIMER_MESSAGE_STATE2;
 
 TIMER_MESSAGE_STATE2 timerId2[TEST2_COUNT];
 
-void CALLBACK TimerProc(HWND hWnd, UINT uMsg, UINT_PTR idEvent, DWORD dwTime) {
+void CALLBACK TimerProc(HWND hWnd, UINT uMsg, UINT_PTR idEvent, DWORD dwTime)
+{
     for (int i = 0; i < TEST1_COUNT; i++)
         if (timerId1[i].index == idEvent)
             timerId1[i].counter++;
 }
 
-void MessageLoop() {
+void MessageLoop()
+{
     MSG msg;
-    while (GetMessage(&msg, NULL, 0, 0)) {
+    while (GetMessage(&msg, NULL, 0, 0))
+	{
         TranslateMessage(&msg);
         DispatchMessage(&msg);
     }
@@ -64,7 +65,8 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
     return DefWindowProc(hwnd, uMsg, wParam, lParam);
 }
 
-BOOL test1() {
+BOOL test1()
+{
     int countErrors = 0;
 
     int minMessages = (SLEEP_TIME / TEST1_INTERVAL) * (1 - TIME_TOLERANCE);
@@ -79,7 +81,8 @@ BOOL test1() {
     for (int i = 0; i < TEST1_COUNT; i++)
     {
         timerId1[i].index = SetTimer(NULL, 0, TEST1_INTERVAL, TimerProc);
-        if (timerId1[i].index == 0) {
+        if (timerId1[i].index == 0)
+		{
             countErrors++;
         }
     }
@@ -108,7 +111,8 @@ BOOL test1() {
 
     for (int i = 0; i < TEST1_COUNT; i++)
     {
-        if (KillTimer(NULL, timerId1[i].index) == 0) {
+        if (KillTimer(NULL, timerId1[i].index) == 0)
+		{
             countErrors++;
         }
     }
@@ -117,7 +121,8 @@ BOOL test1() {
     return FALSE;
 }
 
-BOOL test2() {
+BOOL test2()
+{
     int countErrors = 0;
 
     int minMessages = (SLEEP_TIME / TEST2_INTERVAL) * (1 - TIME_TOLERANCE);
@@ -146,7 +151,8 @@ BOOL test2() {
     for (int i = 0; i < TEST2_COUNT; i++)
     {
         UINT_PTR locIndex = SetTimer(hwnd, i, TEST2_INTERVAL, NULL);
-        if (locIndex == 0) {
+        if (locIndex == 0)
+		{
             countErrors++;
         }
     }
@@ -175,7 +181,8 @@ BOOL test2() {
 
     for (int i = 0; i < TEST2_COUNT; i++)
     {
-        if (KillTimer(hwnd, i) == 0) {
+        if (KillTimer(hwnd, i) == 0)
+		{
             countErrors++;
         }
     }
@@ -187,16 +194,19 @@ BOOL test2() {
     return FALSE;
 }
 
-BOOL test3() {
+BOOL test3()
+{
     int countErrors = 0;
 
     for (long i = 0; i < TEST3_COUNT; i++)
     {
         UINT_PTR locIndex = SetTimer(NULL, 0, TEST3_INTERVAL, TimerProc);
-        if (locIndex == 0) {
+        if (locIndex == 0)
+		{
             countErrors++;
         }
-        if (KillTimer(NULL, locIndex) == 0) {
+        if (KillTimer(NULL, locIndex) == 0)
+		{
             countErrors++;
         }
     }
@@ -206,7 +216,8 @@ BOOL test3() {
     return FALSE;
 }
 
-BOOL test4() {
+BOOL test4()
+{
     int countErrors = 0;
 
     WNDCLASS wc = {};
@@ -227,12 +238,10 @@ BOOL test4() {
     for (int i = 0; i < TEST4_COUNT; i++)
     {
         UINT_PTR result = SetTimer(hwnd, 1, TEST4_INTERVAL, NULL);
-        if (result == 0) {
+        if (result == 0)
             countErrors++;
-        }
-        if (KillTimer(hwnd, 1) == 0) {
+        if (KillTimer(hwnd, 1) == 0)
             countErrors++;
-        }
     }
 
     DestroyWindow(hwnd);
@@ -243,23 +252,20 @@ BOOL test4() {
     return FALSE;
 }
 
-BOOL test5() {
+BOOL test5()
+{
     int countErrors = 0;
 
     UINT_PTR locIndex1 = SetTimer(NULL, 0, TEST1_INTERVAL, TimerProc);
-    if (locIndex1 == 0) {
+    if (locIndex1 == 0)
         countErrors++;
-    }
-    if (KillTimer(NULL, locIndex1) == 0) {
+    if (KillTimer(NULL, locIndex1) == 0)
         countErrors++;
-    }
     UINT_PTR locIndex2 = SetTimer(NULL, 0, TEST1_INTERVAL, TimerProc);
-    if (locIndex2 == 0) {
+    if (locIndex2 == 0)
         countErrors++;
-    }
-    if (KillTimer(NULL, locIndex2) == 0) {
+    if (KillTimer(NULL, locIndex2) == 0)
         countErrors++;
-    }
     if(locIndex1 == locIndex2)
         countErrors++;
     if (countErrors == 0)

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
@@ -44,7 +44,7 @@ void CALLBACK TimerProc(HWND hWnd, UINT uMsg, UINT_PTR idEvent, DWORD dwTime)
             timerId1[i].counter++;
 }
 
-void MessageLoop()
+void MessageLoop(void)
 {
     MSG msg;
     while (GetMessage(&msg, NULL, 0, 0))
@@ -65,7 +65,7 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
     return DefWindowProc(hwnd, uMsg, wParam, lParam);
 }
 
-BOOL test1()
+BOOL test1(void)
 {
     int countErrors = 0;
 
@@ -121,7 +121,7 @@ BOOL test1()
     return FALSE;
 }
 
-BOOL test2()
+BOOL test2(void)
 {
     int countErrors = 0;
 
@@ -194,7 +194,7 @@ BOOL test2()
     return FALSE;
 }
 
-BOOL test3()
+BOOL test3(void)
 {
     int countErrors = 0;
 
@@ -216,7 +216,7 @@ BOOL test3()
     return FALSE;
 }
 
-BOOL test4()
+BOOL test4(void)
 {
     int countErrors = 0;
 
@@ -252,7 +252,7 @@ BOOL test4()
     return FALSE;
 }
 
-BOOL test5()
+BOOL test5(void)
 {
     int countErrors = 0;
 

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
@@ -49,7 +49,7 @@ void MessageLoop(void)
 {
     MSG msg;
     while (GetMessage(&msg, NULL, 0, 0))
-	{
+    {
         TranslateMessage(&msg);
         DispatchMessage(&msg);
     }
@@ -83,7 +83,7 @@ BOOL test1(void)
     {
         timerId1[i].index = SetTimer(NULL, 0, TEST1_INTERVAL, TimerProc);
         if (timerId1[i].index == 0)
-		{
+        {
             countErrors++;
         }
     }
@@ -113,7 +113,7 @@ BOOL test1(void)
     for (int i = 0; i < TEST1_COUNT; i++)
     {
         if (KillTimer(NULL, timerId1[i].index) == 0)
-		{
+        {
             countErrors++;
         }
     }
@@ -153,7 +153,7 @@ BOOL test2(void)
     {
         UINT_PTR locIndex = SetTimer(hwnd, i, TEST2_INTERVAL, NULL);
         if (locIndex == 0)
-		{
+        {
             countErrors++;
         }
     }
@@ -183,7 +183,7 @@ BOOL test2(void)
     for (int i = 0; i < TEST2_COUNT; i++)
     {
         if (KillTimer(hwnd, i) == 0)
-		{
+        {
             countErrors++;
         }
     }
@@ -203,11 +203,11 @@ BOOL test3(void)
     {
         UINT_PTR locIndex = SetTimer(NULL, 0, TEST3_INTERVAL, TimerProc);
         if (locIndex == 0)
-		{
+        {
             countErrors++;
         }
         if (KillTimer(NULL, locIndex) == 0)
-		{
+        {
             countErrors++;
         }
     }

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
@@ -115,9 +115,9 @@ BOOL test1(void)
 
 BOOL test2(void)
 {
-    UINT countErrors = 0;
+    UINT i, countErrors = 0;
 
-    for (long i = 0; i < TEST2_COUNT; i++)
+    for (i = 0; i < TEST2_COUNT; i++)
     {
         UINT_PTR locIndex = SetTimer(NULL, 0, TEST2_INTERVAL, TimerProc);
 
@@ -219,13 +219,13 @@ START_TEST(NtUserSetTimer)
 {
     // TEST WITH MESSAGES WITHOUT WINDOW - test count of sent messages
     TEST(test1());
-    
+
     // TEST WITH MESSAGES WITHOUT WINDOW - create many timers
     TEST(test2());
-    
+
     // TEST WITH MESSAGES WITHOUT WINDOW - test different ids
     TEST(test3());
-    
+
     WNDCLASS wc = { 0 };
     wc.lpfnWndProc = WindowProc;
     wc.hInstance = GetModuleHandle(NULL);

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
@@ -88,7 +88,7 @@ static BOOL test1(void)
     while (GetMessageW(&msg, NULL, 0, 0))
     {
         TranslateMessage(&msg);
-        DispatchMessage(&msg);
+        DispatchMessageW(&msg);
 
         if (GetTickCount() - startTime >= SLEEP_TIME)
             PostQuitMessage(0);

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
@@ -50,7 +50,9 @@ TimerProc(HWND hWnd, UINT uMsg, UINT_PTR idEvent, DWORD dwTime)
     }
 }
 
-LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
+/* TIMERPROC for the testW1,2() with messages with window */
+static LRESULT CALLBACK
+WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
     switch (uMsg)
     {

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
@@ -85,7 +85,7 @@ static BOOL test1(void)
 
     startTime = GetTickCount();
 
-    while (GetMessage(&msg, NULL, 0, 0))
+    while (GetMessageW(&msg, NULL, 0, 0))
     {
         TranslateMessage(&msg);
         DispatchMessage(&msg);

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
@@ -1,8 +1,9 @@
 /*
- * PROJECT:         ReactOS api tests
- * LICENSE:         GPL - See COPYING in the top level directory
- * PURPOSE:         Test for NtUserSetTimer
- * PROGRAMMERS:
+ * PROJECT:     ReactOS API tests
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Tests for NtUserSetTimer
+ * COPYRIGHT:   Copyright 2008 Timo Kreuzer <timo.kreuzer@reactos.org>
+ *              Copyright 2024 Tomas Vesely <turican0@gmail.com>
  */
 
 #include "../win32nt.h"

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
@@ -215,9 +215,7 @@ BOOL test3(void)
         }
     }
 
-    if (countErrors == 0)
-        return TRUE;
-    return FALSE;
+    return (countErrors == 0);
 }
 
 BOOL test4(void)

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
@@ -242,7 +242,7 @@ START_TEST(NtUserSetTimer)
 
     hwnd = CreateWindowExW(0, L"TimerWindowClass", L"Timer Window", 0,
         CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT,
-        HWND_MESSAGE, NULL, GetModuleHandle(NULL), NULL);
+        HWND_MESSAGE, NULL, GetModuleHandleW(NULL), NULL);
 
     // TEST WITH MESSAGES WITH WINDOW - test count of sent messages
     TEST(testW1(hwnd));

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
@@ -123,7 +123,8 @@ BOOL test2(void)
     return (countErrors == 0);
 }
 
-BOOL test3(void)
+// TEST WITH MESSAGES WITHOUT WINDOW - test different ids
+static BOOL test3(void)
 {
     UINT countErrors = 0;
 

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
@@ -231,7 +231,7 @@ START_TEST(NtUserSetTimer)
     wc.lpszClassName = "TimerWindowClass";
     RegisterClass(&wc);
 
-    HWND hwnd = CreateWindowEx(0, "TimerWindowClass", "Timer Window", 0,
+    HWND hwnd = CreateWindowExW(0, L"TimerWindowClass", L"Timer Window", 0,
         CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT,
         HWND_MESSAGE, NULL, GetModuleHandle(NULL), NULL);
 

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
@@ -249,9 +249,7 @@ BOOL test4(void)
     DestroyWindow(hwnd);
     UnregisterClass("TimerWindowClass", GetModuleHandle(NULL));
 
-    if (countErrors == 0)
-        return TRUE;
-    return FALSE;
+    return (countErrors == 0);
 }
 
 BOOL test5(void)

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
@@ -236,7 +236,7 @@ START_TEST(NtUserSetTimer)
     TEST(test3());
 
     wc.lpfnWndProc = WindowProc;
-    wc.hInstance = GetModuleHandle(NULL);
+    wc.hInstance = GetModuleHandleW(NULL);
     wc.lpszClassName = L"TimerWindowClass";
     RegisterClassW(&wc);
 

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
@@ -165,17 +165,13 @@ BOOL testW1(HWND hwnd)
     int maxMessages = ((float)SLEEP_TIME / (float)TESTW1_INTERVAL) * (1 + TIME_TOLERANCE);
     
     for (i = 0; i < TESTW1_COUNT; i++)
-    {
         timerIdW1[i].counter = 0;
-    }
 
     for (i = 0; i < TESTW1_COUNT; i++)
     {
         UINT_PTR locIndex = SetTimer(hwnd, i, TESTW1_INTERVAL, NULL);
         if (locIndex == 0)
-        {
             countErrors++;
-        }
     }
 
     ULONGLONG startTime = GetTickCount();
@@ -187,9 +183,7 @@ BOOL testW1(HWND hwnd)
         DispatchMessage(&msg);
 
         if (GetTickCount() - startTime >= SLEEP_TIME)
-        {
             PostQuitMessage(0);
-        }
     }
 
     for (i = 0; i < TESTW1_COUNT; i++)

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
@@ -61,7 +61,7 @@ WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
         return 0;
     }
 
-    return DefWindowProc(hwnd, uMsg, wParam, lParam);
+    return DefWindowProcW(hwnd, uMsg, wParam, lParam);
 }
 
 // TEST WITH MESSAGES WITHOUT WINDOW - test count of sent messages

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
@@ -176,7 +176,7 @@ static BOOL testW1(HWND hwnd)
 
     startTime = GetTickCount();
 
-    while (GetMessage(&msg, NULL, 0, 0))
+    while (GetMessageW(&msg, NULL, 0, 0))
     {
         TranslateMessage(&msg);
         DispatchMessage(&msg);

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
@@ -276,10 +276,10 @@ BOOL test5(void)
 
 START_TEST(NtUserSetTimer)
 {
-    // TEST WITH MESSAGES WITHOUT WINDOW - test count sended messages
+    // TEST WITH MESSAGES WITHOUT WINDOW - test count of sent messages
     TEST(test1());
 
-    // TEST WITH MESSAGES WITH WINDOW - test count sended messages
+    // TEST WITH MESSAGES WITH WINDOW - test count of sent messages
     TEST(test2());
 
     // TEST WITH MESSAGES WITHOUT WINDOW - create many timers

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
@@ -7,12 +7,280 @@
 
 #include "../win32nt.h"
 
+//#include <iostream>
+
+#include "windows.h"
+
+#define SLEEP_TIME 500
+#define TIME_TOLERANCE 0.5
+
+#define TEST1_COUNT 20
+#define TEST1_INTERVAL 10
+
+#define TEST2_COUNT 20
+#define TEST2_INTERVAL 10
+
+#define TEST3_COUNT 40000
+#define TEST3_INTERVAL 10
+
+#define TEST4_COUNT 40000
+#define TEST4_INTERVAL 10
+
+typedef struct TIMER_MESSAGE_STATE1 {
+    UINT_PTR index;
+    int counter;
+} TIMER_MESSAGE_STATE1;
+
+TIMER_MESSAGE_STATE1 timerId1[TEST1_COUNT];
+
+typedef struct TIMER_MESSAGE_STATE2 {
+    int counter;
+} TIMER_MESSAGE_STATE2;
+
+TIMER_MESSAGE_STATE2 timerId2[TEST2_COUNT];
+
+void CALLBACK TimerProc(HWND hWnd, UINT uMsg, UINT_PTR idEvent, DWORD dwTime) {
+    for (int i = 0; i < TEST1_COUNT; i++)
+        if (timerId1[i].index == idEvent)
+            timerId1[i].counter++;
+}
+
+void MessageLoop() {
+    MSG msg;
+    while (GetMessage(&msg, NULL, 0, 0)) {
+        TranslateMessage(&msg);
+        DispatchMessage(&msg);
+    }
+}
+
+LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
+{
+    switch (uMsg)
+    {
+    case WM_TIMER:
+        timerId2[wParam].counter++;
+        return 0;
+    }
+    return DefWindowProc(hwnd, uMsg, wParam, lParam);
+}
+
+BOOL test1() {
+    int countErrors = 0;
+
+    int minMessages = (SLEEP_TIME / TEST1_INTERVAL) * (1 - TIME_TOLERANCE);
+    int maxMessages = (SLEEP_TIME / TEST1_INTERVAL) * (1 + TIME_TOLERANCE);
+
+    for (int i = 0; i < TEST1_COUNT; i++)
+    {
+        timerId1[i].index = 0;
+        timerId1[i].counter = 0;
+    }
+
+    for (int i = 0; i < TEST1_COUNT; i++)
+    {
+        timerId1[i].index = SetTimer(NULL, 0, TEST1_INTERVAL, TimerProc);
+        if (timerId1[i].index == 0) {
+            countErrors++;
+        }
+    }
+
+    ULONGLONG startTime = GetTickCount();
+
+    MSG msg = {};
+    while (GetMessage(&msg, NULL, 0, 0))
+    {
+        TranslateMessage(&msg);
+        DispatchMessage(&msg);
+
+        if (GetTickCount() - startTime >= SLEEP_TIME)
+        {
+            PostQuitMessage(0);
+        }
+    }
+
+    for (int i = 0; i < TEST1_COUNT; i++)
+    {
+        if((timerId1[i].counter < minMessages) || (timerId1[i].counter > maxMessages))
+        {
+            countErrors++;
+        }
+    }
+
+    for (int i = 0; i < TEST1_COUNT; i++)
+    {
+        if (KillTimer(NULL, timerId1[i].index) == 0) {
+            countErrors++;
+        }
+    }
+    if (countErrors == 0)
+        return TRUE;
+    return FALSE;
+}
+
+BOOL test2() {
+    int countErrors = 0;
+
+    int minMessages = (SLEEP_TIME / TEST2_INTERVAL) * (1 - TIME_TOLERANCE);
+    int maxMessages = (SLEEP_TIME / TEST2_INTERVAL) * (1 + TIME_TOLERANCE);
+    
+    for (int i = 0; i < TEST2_COUNT; i++)
+    {
+        timerId2[i].counter = 0;
+    }
+
+    WNDCLASS wc = {};
+    wc.lpfnWndProc = WindowProc;
+    wc.hInstance = GetModuleHandle(NULL);
+    wc.lpszClassName = "TimerWindowClass";
+    RegisterClass(&wc);
+
+    HWND hwnd = CreateWindowEx(0, "TimerWindowClass", "Timer Window", 0,
+        CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT,
+        HWND_MESSAGE, NULL, GetModuleHandle(NULL), NULL);
+
+    if (hwnd == NULL)
+    {
+        return FALSE;
+    }
+
+    for (int i = 0; i < TEST2_COUNT; i++)
+    {
+        UINT_PTR locIndex = SetTimer(hwnd, i, TEST2_INTERVAL, NULL);
+        if (locIndex == 0) {
+            countErrors++;
+        }
+    }
+
+    ULONGLONG startTime = GetTickCount();
+
+    MSG msg = {};
+    while (GetMessage(&msg, NULL, 0, 0))
+    {
+        TranslateMessage(&msg);
+        DispatchMessage(&msg);
+
+        if (GetTickCount() - startTime >= SLEEP_TIME)
+        {
+            PostQuitMessage(0);
+        }
+    }
+
+    for (int i = 0; i < TEST2_COUNT; i++)
+    {
+        if ((timerId2[i].counter < minMessages) || (timerId2[i].counter > maxMessages))
+        {
+            countErrors++;
+        }
+    }
+
+    for (int i = 0; i < TEST2_COUNT; i++)
+    {
+        if (KillTimer(hwnd, i) == 0) {
+            countErrors++;
+        }
+    }
+    DestroyWindow(hwnd);
+    UnregisterClass("TimerWindowClass", GetModuleHandle(NULL));
+
+    if (countErrors == 0)
+        return TRUE;
+    return FALSE;
+}
+
+BOOL test3() {
+    int countErrors = 0;
+
+    for (long i = 0; i < TEST3_COUNT; i++)
+    {
+        UINT_PTR locIndex = SetTimer(NULL, 0, TEST3_INTERVAL, TimerProc);
+        if (locIndex == 0) {
+            countErrors++;
+        }
+        if (KillTimer(NULL, locIndex) == 0) {
+            countErrors++;
+        }
+    }
+
+    if (countErrors == 0)
+        return TRUE;
+    return FALSE;
+}
+
+BOOL test4() {
+    int countErrors = 0;
+
+    WNDCLASS wc = {};
+    wc.lpfnWndProc = WindowProc;
+    wc.hInstance = GetModuleHandle(NULL);
+    wc.lpszClassName = "TimerWindowClass";
+    RegisterClass(&wc);
+
+    HWND hwnd = CreateWindowEx(0, "TimerWindowClass", "Timer Window", 0,
+        CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT,
+        HWND_MESSAGE, NULL, GetModuleHandle(NULL), NULL);
+
+    if (hwnd == NULL)
+    {
+        return FALSE;
+    }
+
+    for (int i = 0; i < TEST4_COUNT; i++)
+    {
+        UINT_PTR result = SetTimer(hwnd, 1, TEST4_INTERVAL, NULL);
+        if (result == 0) {
+            countErrors++;
+        }
+        if (KillTimer(hwnd, 1) == 0) {
+            countErrors++;
+        }
+    }
+
+    DestroyWindow(hwnd);
+    UnregisterClass("TimerWindowClass", GetModuleHandle(NULL));
+
+    if (countErrors == 0)
+        return TRUE;
+    return FALSE;
+}
+
+BOOL test5() {
+    int countErrors = 0;
+
+    UINT_PTR locIndex1 = SetTimer(NULL, 0, TEST1_INTERVAL, TimerProc);
+    if (locIndex1 == 0) {
+        countErrors++;
+    }
+    if (KillTimer(NULL, locIndex1) == 0) {
+        countErrors++;
+    }
+    UINT_PTR locIndex2 = SetTimer(NULL, 0, TEST1_INTERVAL, TimerProc);
+    if (locIndex2 == 0) {
+        countErrors++;
+    }
+    if (KillTimer(NULL, locIndex2) == 0) {
+        countErrors++;
+    }
+    if(locIndex1 == locIndex2)
+        countErrors++;
+    if (countErrors == 0)
+        return TRUE;
+    return FALSE;
+}
+
 START_TEST(NtUserSetTimer)
 {
+    // TEST WITH MESSAGES WITHOUT WINDOW - test count sended messages
+    TEST(test1());
 
+    // TEST WITH MESSAGES WITH WINDOW - test count sended messages
+    TEST(test2());
 
-    // check valid argument
-    // check for replacement / new timers
-    // check when expiries are handled (msgs and calls)
+    // TEST WITH MESSAGES WITHOUT WINDOW - create many timers
+    TEST(test3());
 
+    // TEST WITH MESSAGES WITH WINDOW - create many timers
+    TEST(test4());
+
+    // TEST WITH MESSAGES WITHOUT WINDOW - test different ids
+    TEST(test5());
 }

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
@@ -106,7 +106,8 @@ static BOOL test1(void)
     return (countErrors == 0);
 }
 
-BOOL test2(void)
+// TEST WITH MESSAGES WITHOUT WINDOW - create many timers
+static BOOL test2(void)
 {
     UINT i, countErrors = 0;
 

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
@@ -107,7 +107,7 @@ BOOL test1(void)
 
     for (int i = 0; i < TEST1_COUNT; i++)
     {
-        if((timerId1[i].counter < minMessages) || (timerId1[i].counter > maxMessages))
+        if ((timerId1[i].counter < minMessages) || (timerId1[i].counter > maxMessages))
         {
             countErrors++;
         }

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
@@ -33,7 +33,7 @@ TIMER_MESSAGE_STATE1 timerId1[TEST1_COUNT];
 
 typedef struct TIMER_MESSAGE_STATE2
 {
-    int counter;
+    UINT counter;
 } TIMER_MESSAGE_STATE2;
 
 TIMER_MESSAGE_STATE2 timerId2[TEST2_COUNT];

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
@@ -38,7 +38,9 @@ typedef struct TIMER_MESSAGE_STATEW1
 
 TIMER_MESSAGE_STATEW1 timerIdW1[TESTW1_COUNT];
 
-void CALLBACK TimerProc(HWND hWnd, UINT uMsg, UINT_PTR idEvent, DWORD dwTime)
+/* TIMERPROC for the test1,2,3() with messages without window */
+static void CALLBACK
+TimerProc(HWND hWnd, UINT uMsg, UINT_PTR idEvent, DWORD dwTime)
 {
     UINT i;
     for (i = 0; i < TEST1_COUNT; i++)

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
@@ -268,9 +268,8 @@ BOOL test5(void)
         countErrors++;
     if(locIndex1 == locIndex2)
         countErrors++;
-    if (countErrors == 0)
-        return TRUE;
-    return FALSE;
+
+    return (countErrors == 0);
 }
 
 START_TEST(NtUserSetTimer)

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
@@ -228,8 +228,8 @@ START_TEST(NtUserSetTimer)
     WNDCLASSW wc = { 0 };
     wc.lpfnWndProc = WindowProc;
     wc.hInstance = GetModuleHandle(NULL);
-    wc.lpszClassName = "TimerWindowClass";
-    RegisterClass(&wc);
+    wc.lpszClassName = L"TimerWindowClass";
+    RegisterClassW(&wc);
 
     HWND hwnd = CreateWindowExW(0, L"TimerWindowClass", L"Timer Window", 0,
         CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT,

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
@@ -71,7 +71,7 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
 BOOL test1(void)
 {
-    int countErrors = 0;
+    UINT i, countErrors = 0;
 
     int minMessages = (SLEEP_TIME / TEST1_INTERVAL) * (1 - TIME_TOLERANCE);
     int maxMessages = (SLEEP_TIME / TEST1_INTERVAL) * (1 + TIME_TOLERANCE);

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
@@ -179,7 +179,7 @@ static BOOL testW1(HWND hwnd)
     while (GetMessageW(&msg, NULL, 0, 0))
     {
         TranslateMessage(&msg);
-        DispatchMessage(&msg);
+        DispatchMessageW(&msg);
 
         if (GetTickCount() - startTime >= SLEEP_TIME)
             PostQuitMessage(0);

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
@@ -3,7 +3,7 @@
  * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
  * PURPOSE:     Tests for NtUserSetTimer
  * COPYRIGHT:   Copyright 2008 Timo Kreuzer <timo.kreuzer@reactos.org>
- *              Copyright 2024 Tomaš Veselý <turican0@gmail.com>
+ *              Copyright 2024 Tomáš Veselý <turican0@gmail.com>
  */
 
 #include "../win32nt.h"

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
@@ -243,5 +243,5 @@ START_TEST(NtUserSetTimer)
 
     if (hwnd != NULL)
         DestroyWindow(hwnd);
-    UnregisterClass("TimerWindowClass", GetModuleHandle(NULL));
+    UnregisterClassW(L"TimerWindowClass", NULL);
 }

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
@@ -225,7 +225,7 @@ START_TEST(NtUserSetTimer)
     // TEST WITH MESSAGES WITHOUT WINDOW - test different ids
     TEST(test3());
 
-    WNDCLASS wc = { 0 };
+    WNDCLASSW wc = { 0 };
     wc.lpfnWndProc = WindowProc;
     wc.hInstance = GetModuleHandle(NULL);
     wc.lpszClassName = "TimerWindowClass";

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
@@ -40,7 +40,9 @@ TIMER_MESSAGE_STATE2 timerId2[TEST2_COUNT];
 
 void CALLBACK TimerProc(HWND hWnd, UINT uMsg, UINT_PTR idEvent, DWORD dwTime)
 {
-    for (int i = 0; i < TEST1_COUNT; i++)
+    UINT i;
+    for (i = 0; i < TEST1_COUNT; i++)
+    {
         if (timerId1[i].index == idEvent)
             timerId1[i].counter++;
 }

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
@@ -68,6 +68,8 @@ WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 static BOOL test1(void)
 {
     UINT i, countErrors = 0;
+    ULONGLONG startTime;
+    MSG msg = { NULL };
 
     int minMessages = ((float)SLEEP_TIME / (float)TEST1_INTERVAL) * (1 - TIME_TOLERANCE);
     int maxMessages = ((float)SLEEP_TIME / (float)TEST1_INTERVAL) * (1 + TIME_TOLERANCE);
@@ -81,9 +83,8 @@ static BOOL test1(void)
             countErrors++;
     }
 
-    ULONGLONG startTime = GetTickCount();
+    startTime = GetTickCount();
 
-    MSG msg = { NULL };
     while (GetMessage(&msg, NULL, 0, 0))
     {
         TranslateMessage(&msg);
@@ -112,10 +113,11 @@ static BOOL test1(void)
 static BOOL test2(void)
 {
     UINT i, countErrors = 0;
+    UINT_PTR locIndex;
 
     for (i = 0; i < TEST2_COUNT; i++)
     {
-        UINT_PTR locIndex = SetTimer(NULL, 0, TEST2_INTERVAL, TimerProc);
+        locIndex = SetTimer(NULL, 0, TEST2_INTERVAL, TimerProc);
 
         if (locIndex == 0)
             countErrors++;
@@ -130,13 +132,15 @@ static BOOL test2(void)
 static BOOL test3(void)
 {
     UINT countErrors = 0;
+    UINT_PTR locIndex1;
+    UINT_PTR locIndex2;
 
-    UINT_PTR locIndex1 = SetTimer(NULL, 0, TEST1_INTERVAL, TimerProc);
+    locIndex1 = SetTimer(NULL, 0, TEST1_INTERVAL, TimerProc);
     if (locIndex1 == 0)
         countErrors++;
     if (KillTimer(NULL, locIndex1) == 0)
         countErrors++;
-    UINT_PTR locIndex2 = SetTimer(NULL, 0, TEST1_INTERVAL, TimerProc);
+    locIndex2 = SetTimer(NULL, 0, TEST1_INTERVAL, TimerProc);
     if (locIndex2 == 0)
         countErrors++;
     if (KillTimer(NULL, locIndex2) == 0)
@@ -151,6 +155,9 @@ static BOOL test3(void)
 static BOOL testW1(HWND hwnd)
 {
     UINT i, countErrors = 0;
+    UINT_PTR locIndex;
+    ULONGLONG startTime;
+    MSG msg = { NULL };
 
     if (hwnd == NULL)
         return FALSE;
@@ -162,14 +169,13 @@ static BOOL testW1(HWND hwnd)
 
     for (i = 0; i < TESTW1_COUNT; i++)
     {
-        UINT_PTR locIndex = SetTimer(hwnd, i, TESTW1_INTERVAL, NULL);
+        locIndex = SetTimer(hwnd, i, TESTW1_INTERVAL, NULL);
         if (locIndex == 0)
             countErrors++;
     }
 
-    ULONGLONG startTime = GetTickCount();
+    startTime = GetTickCount();
 
-    MSG msg = { NULL };
     while (GetMessage(&msg, NULL, 0, 0))
     {
         TranslateMessage(&msg);
@@ -198,13 +204,14 @@ static BOOL testW1(HWND hwnd)
 static BOOL testW2(HWND hwnd)
 {
     UINT i, countErrors = 0;
+    UINT_PTR result;
 
     if (hwnd == NULL)
         return FALSE;
 
     for (i = 0; i < TESTW2_COUNT; i++)
     {
-        UINT_PTR result = SetTimer(hwnd, 1, TESTW2_INTERVAL, NULL);
+        result = SetTimer(hwnd, 1, TESTW2_INTERVAL, NULL);
         if (result == 0)
             countErrors++;
         if (KillTimer(hwnd, 1) == 0)
@@ -216,6 +223,9 @@ static BOOL testW2(HWND hwnd)
 
 START_TEST(NtUserSetTimer)
 {
+    WNDCLASSW wc = { 0 };
+    HWND hwnd;
+
     // TEST WITH MESSAGES WITHOUT WINDOW - test count of sent messages
     TEST(test1());
 
@@ -225,13 +235,12 @@ START_TEST(NtUserSetTimer)
     // TEST WITH MESSAGES WITHOUT WINDOW - test different ids
     TEST(test3());
 
-    WNDCLASSW wc = { 0 };
     wc.lpfnWndProc = WindowProc;
     wc.hInstance = GetModuleHandle(NULL);
     wc.lpszClassName = L"TimerWindowClass";
     RegisterClassW(&wc);
 
-    HWND hwnd = CreateWindowExW(0, L"TimerWindowClass", L"Timer Window", 0,
+    hwnd = CreateWindowExW(0, L"TimerWindowClass", L"Timer Window", 0,
         CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT,
         HWND_MESSAGE, NULL, GetModuleHandle(NULL), NULL);
 

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
@@ -48,16 +48,6 @@ void CALLBACK TimerProc(HWND hWnd, UINT uMsg, UINT_PTR idEvent, DWORD dwTime)
     }
 }
 
-void MessageLoop(void)
-{
-    MSG msg;
-    while (GetMessage(&msg, NULL, 0, 0))
-    {
-        TranslateMessage(&msg);
-        DispatchMessage(&msg);
-    }
-}
-
 LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
     switch (uMsg)

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
@@ -77,11 +77,7 @@ BOOL test1(void)
     int minMessages = ((float)SLEEP_TIME / (float)TEST1_INTERVAL) * (1 - TIME_TOLERANCE);
     int maxMessages = ((float)SLEEP_TIME / (float)TEST1_INTERVAL) * (1 + TIME_TOLERANCE);
 
-    for (i = 0; i < TEST1_COUNT; i++)
-    {
-        timerId1[i].index = 0;
-        timerId1[i].counter = 0;
-    }
+    ZeroMemory(timerId1, sizeof(timerId1));
 
     for (i = 0; i < TEST1_COUNT; i++)
     {
@@ -163,9 +159,8 @@ BOOL testW1(HWND hwnd)
 
     int minMessages = ((float)SLEEP_TIME / (float)TESTW1_INTERVAL) * (1 - TIME_TOLERANCE);
     int maxMessages = ((float)SLEEP_TIME / (float)TESTW1_INTERVAL) * (1 + TIME_TOLERANCE);
-    
-    for (i = 0; i < TESTW1_COUNT; i++)
-        timerIdW1[i].counter = 0;
+
+    ZeroMemory(timerIdW1, sizeof(timerIdW1));
 
     for (i = 0; i < TESTW1_COUNT; i++)
     {

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
@@ -143,7 +143,8 @@ BOOL test3(void)
     return (countErrors == 0);
 }
 
-BOOL testW1(HWND hwnd)
+// TEST WITH MESSAGES WITH WINDOW - test count of sent messages
+static BOOL testW1(HWND hwnd)
 {
     UINT i, countErrors = 0;
 

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserSetTimer.c
@@ -73,16 +73,16 @@ BOOL test1(void)
 {
     UINT i, countErrors = 0;
 
-    int minMessages = (SLEEP_TIME / TEST1_INTERVAL) * (1 - TIME_TOLERANCE);
-    int maxMessages = (SLEEP_TIME / TEST1_INTERVAL) * (1 + TIME_TOLERANCE);
+    int minMessages = ((float)SLEEP_TIME / (float)TEST1_INTERVAL) * (1 - TIME_TOLERANCE);
+    int maxMessages = ((float)SLEEP_TIME / (float)TEST1_INTERVAL) * (1 + TIME_TOLERANCE);
 
-    for (int i = 0; i < TEST1_COUNT; i++)
+    for (i = 0; i < TEST1_COUNT; i++)
     {
         timerId1[i].index = 0;
         timerId1[i].counter = 0;
     }
 
-    for (int i = 0; i < TEST1_COUNT; i++)
+    for (i = 0; i < TEST1_COUNT; i++)
     {
         timerId1[i].index = SetTimer(NULL, 0, TEST1_INTERVAL, TimerProc);
         if (timerId1[i].index == 0)
@@ -105,7 +105,7 @@ BOOL test1(void)
         }
     }
 
-    for (int i = 0; i < TEST1_COUNT; i++)
+    for (i = 0; i < TEST1_COUNT; i++)
     {
         if ((timerId1[i].counter < minMessages) || (timerId1[i].counter > maxMessages))
         {
@@ -113,7 +113,7 @@ BOOL test1(void)
         }
     }
 
-    for (int i = 0; i < TEST1_COUNT; i++)
+    for (i = 0; i < TEST1_COUNT; i++)
     {
         if (KillTimer(NULL, timerId1[i].index) == 0)
         {
@@ -125,34 +125,19 @@ BOOL test1(void)
     return FALSE;
 }
 
-BOOL test2(void)
+BOOL test2(HWND hwnd)
 {
-    int countErrors = 0;
+    UINT i, countErrors = 0;
 
     int minMessages = (SLEEP_TIME / TEST2_INTERVAL) * (1 - TIME_TOLERANCE);
     int maxMessages = (SLEEP_TIME / TEST2_INTERVAL) * (1 + TIME_TOLERANCE);
     
-    for (int i = 0; i < TEST2_COUNT; i++)
+    for (i = 0; i < TEST2_COUNT; i++)
     {
         timerId2[i].counter = 0;
     }
 
-    WNDCLASS wc = {};
-    wc.lpfnWndProc = WindowProc;
-    wc.hInstance = GetModuleHandle(NULL);
-    wc.lpszClassName = "TimerWindowClass";
-    RegisterClass(&wc);
-
-    HWND hwnd = CreateWindowEx(0, "TimerWindowClass", "Timer Window", 0,
-        CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT,
-        HWND_MESSAGE, NULL, GetModuleHandle(NULL), NULL);
-
-    if (hwnd == NULL)
-    {
-        return FALSE;
-    }
-
-    for (int i = 0; i < TEST2_COUNT; i++)
+    for (i = 0; i < TEST2_COUNT; i++)
     {
         UINT_PTR locIndex = SetTimer(hwnd, i, TEST2_INTERVAL, NULL);
         if (locIndex == 0)
@@ -175,7 +160,7 @@ BOOL test2(void)
         }
     }
 
-    for (int i = 0; i < TEST2_COUNT; i++)
+    for (i = 0; i < TEST2_COUNT; i++)
     {
         if ((timerId2[i].counter < minMessages) || (timerId2[i].counter > maxMessages))
         {
@@ -183,15 +168,13 @@ BOOL test2(void)
         }
     }
 
-    for (int i = 0; i < TEST2_COUNT; i++)
+    for ( i = 0; i < TEST2_COUNT; i++)
     {
         if (KillTimer(hwnd, i) == 0)
         {
             countErrors++;
         }
     }
-    DestroyWindow(hwnd);
-    UnregisterClass("TimerWindowClass", GetModuleHandle(NULL));
 
     if (countErrors == 0)
         return TRUE;
@@ -218,19 +201,9 @@ BOOL test3(void)
     return (countErrors == 0);
 }
 
-BOOL test4(void)
+BOOL test4(HWND hwnd)
 {
     int countErrors = 0;
-
-    WNDCLASS wc = {};
-    wc.lpfnWndProc = WindowProc;
-    wc.hInstance = GetModuleHandle(NULL);
-    wc.lpszClassName = "TimerWindowClass";
-    RegisterClass(&wc);
-
-    HWND hwnd = CreateWindowEx(0, "TimerWindowClass", "Timer Window", 0,
-        CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT,
-        HWND_MESSAGE, NULL, GetModuleHandle(NULL), NULL);
 
     if (hwnd == NULL)
     {
@@ -245,9 +218,6 @@ BOOL test4(void)
         if (KillTimer(hwnd, 1) == 0)
             countErrors++;
     }
-
-    DestroyWindow(hwnd);
-    UnregisterClass("TimerWindowClass", GetModuleHandle(NULL));
 
     return (countErrors == 0);
 }
@@ -274,18 +244,41 @@ BOOL test5(void)
 
 START_TEST(NtUserSetTimer)
 {
+    WNDCLASS wc = {};
+    wc.lpfnWndProc = WindowProc;
+    wc.hInstance = GetModuleHandle(NULL);
+    wc.lpszClassName = "TimerWindowClass";
+    RegisterClass(&wc);
+
+    HWND hwnd = CreateWindowEx(0, "TimerWindowClass", "Timer Window", 0,
+        CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT,
+        HWND_MESSAGE, NULL, GetModuleHandle(NULL), NULL);
+
+    if (hwnd == NULL)
+    {
+        TEST(FALSE);
+        TEST(FALSE);
+        TEST(FALSE);
+        TEST(FALSE);
+        TEST(FALSE);
+        return;
+    }
+    
     // TEST WITH MESSAGES WITHOUT WINDOW - test count of sent messages
     TEST(test1());
 
     // TEST WITH MESSAGES WITH WINDOW - test count of sent messages
-    TEST(test2());
+    TEST(test2(hwnd));
 
     // TEST WITH MESSAGES WITHOUT WINDOW - create many timers
     TEST(test3());
 
     // TEST WITH MESSAGES WITH WINDOW - create many timers
-    TEST(test4());
+    TEST(test4(hwnd));
 
     // TEST WITH MESSAGES WITHOUT WINDOW - test different ids
     TEST(test5());
+    
+    DestroyWindow(hwnd);
+    UnregisterClass("TimerWindowClass", GetModuleHandle(NULL));
 }


### PR DESCRIPTION
## Purpose

Addition of apitests for NtUserSetTimer


## Proposed changes

Test 1 - test of creating/canceling 20 timers and comparing the raw number of returned messages - without parent window
Test 2 - test of creating/cancelling 20 timers and comparing the raw number of returned messages - with parent window
Test 3 - test creation/cancellation of 40000 timers - without parent window
Test 4 - test of creation/cancellation of 40000 timers - with parent window
Test 5 - test creation/cancellation of 2 timers and compare their index to see if they differ - without parent window