### PR TITLE
[SHELL32] Display Desktop folder name in IShellBrowser correctly

### DIFF
--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -254,6 +254,7 @@ private:
     void _HandleStatusBarResize(int width);
     void _ForceStatusBarResize();
     void _DoCopyToMoveToFolder(BOOL bCopy);
+    BOOL IsDesktop() const { return m_FolderSettings.fFlags & FWF_DESKTOP; }
 
 public:
     CDefView();
@@ -1675,7 +1676,7 @@ LRESULT CDefView::OnCreate(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandl
 
     // A folder is special if it is the Desktop folder,
     // a network folder, or a Control Panel folder
-    m_isParentFolderSpecial = _ILIsDesktop(m_pidlParent) || _ILIsNetHood(m_pidlParent)
+    m_isParentFolderSpecial = IsDesktop() || _ILIsNetHood(m_pidlParent)
         || _ILIsControlPanel(ILFindLastID(m_pidlParent));
 
     // Only force StatusBar part refresh if the state

--- a/dll/win32/shell32/folders/CDesktopFolder.cpp
+++ b/dll/win32/shell32/folders/CDesktopFolder.cpp
@@ -913,7 +913,7 @@ HRESULT WINAPI CDesktopFolder::GetDisplayNameOf(PCUITEMID_CHILD pidl, DWORD dwFl
     }
     else if (_ILIsDesktop(pidl))
     {
-        if ((GET_SHGDN_RELATION(dwFlags) == SHGDN_NORMAL) && (GET_SHGDN_FOR(dwFlags) & SHGDN_FORPARSING))
+        if (IS_SHGDN_DESKTOPABSOLUTEPARSING(dwFlags))
             return SHSetStrRet(strRet, sPathTarget);
         else
             return m_regFolder->GetDisplayNameOf(pidl, dwFlags, strRet);

--- a/dll/win32/shell32/folders/CRegFolder.cpp
+++ b/dll/win32/shell32/folders/CRegFolder.cpp
@@ -614,20 +614,21 @@ HRESULT WINAPI CRegFolder::GetDisplayNameOf(PCUITEMID_CHILD pidl, DWORD dwFlags,
 
     if (!pidl || !pidl->mkid.cb)
     {
-        if ((GET_SHGDN_RELATION(dwFlags) == SHGDN_NORMAL) && (GET_SHGDN_FOR(dwFlags) & SHGDN_FORPARSING))
+        if (IS_SHGDN_FOR_PARSING(dwFlags))
         {
-            LPWSTR pszPath = (LPWSTR)CoTaskMemAlloc((MAX_PATH + 1) * sizeof(WCHAR));
+            if (GET_SHGDN_RELATION(dwFlags) != SHGDN_INFOLDER)
+            {
+                TRACE("GDNO returning INFOLDER instead of %#x\n", GET_SHGDN_RELATION(dwFlags));
+            }
+            LPWSTR pszPath = (LPWSTR)CoTaskMemAlloc((2 + 38 + 1) * sizeof(WCHAR));
             if (!pszPath)
                 return E_OUTOFMEMORY;
-
             /* parsing name like ::{...} */
             pszPath[0] = ':';
             pszPath[1] = ':';
             SHELL32_GUIDToStringW(m_guid, &pszPath[2]);
-
             strRet->uType = STRRET_WSTR;
             strRet->pOleStr = pszPath;
-
             return S_OK;
         }
         else
@@ -639,7 +640,6 @@ HRESULT WINAPI CRegFolder::GetDisplayNameOf(PCUITEMID_CHILD pidl, DWORD dwFlags,
                 return E_FAIL;
 
             return SHSetStrRet(strRet, wstrName);
-
         }
     }
 

--- a/dll/win32/shell32/shfldr.h
+++ b/dll/win32/shell32/shfldr.h
@@ -49,6 +49,8 @@ https://learn.microsoft.com/en-us/windows/win32/api/shobjidl_core/nf-shobjidl_co
 
 #define GET_SHGDN_FOR(dwFlags)         ((DWORD)dwFlags & (DWORD)0x0000FF00)
 #define GET_SHGDN_RELATION(dwFlags)    ((DWORD)dwFlags & (DWORD)0x000000FF)
+#define IS_SHGDN_FOR_PARSING(flags) ( ((flags) & (SHGDN_FORADDRESSBAR | SHGDN_FORPARSING)) == SHGDN_FORPARSING)
+#define IS_SHGDN_DESKTOPABSOLUTEPARSING(flags) ( ((flags) & (SHGDN_FORADDRESSBAR | SHGDN_FORPARSING | 0xFF)) == SHGDN_FORPARSING)
 
 HRESULT
 Shell_NextElement(


### PR DESCRIPTION
- When the address-bar asks for FORADDRESSBAR, that should be prioritized over FORPARSING.

- DefView should not enter "special status-bar mode" when viewing the Desktop as a shell folder in the normal IShellBrowser (DefView in Progman/desktop continues to use the old mode).

![Change](https://github.com/reactos/reactos/assets/138629473/ea9f1461-7f7e-47a5-b2c6-5571670b057f)
