### PR TITLE
[SHELL32] Drive Property Sheet: Run in another thread

### DIFF
--- a/dll/win32/shell32/dialogs/drive.cpp
+++ b/dll/win32/shell32/dialogs/drive.cpp
@@ -250,7 +250,7 @@ SH_ShowDriveProperties(WCHAR *pwszDrive, IDataObject *pDataObj)
     if (FAILED_UNEXPECTEDLY(SHStrDupW(pwszDrive, &pwszDrive)))
         return FALSE;
 
-    SHOW_DRIVE_PROP_DATA *pData = (SHOW_DRIVE_PROP_DATA *)LocalAlloc(LPTR, sizeof(SHOW_DRIVE_PROP_DATA));
+    SHOW_DRIVE_PROP_DATA *pData = (SHOW_DRIVE_PROP_DATA *)LocalAlloc(LPTR, sizeof(*pData));
     if (!pData)
         return FALSE;
 

--- a/dll/win32/shell32/dialogs/drive.cpp
+++ b/dll/win32/shell32/dialogs/drive.cpp
@@ -250,10 +250,10 @@ SH_ShowDriveProperties(WCHAR *pwszDrive, IDataObject *pDataObj)
     if (FAILED_UNEXPECTEDLY(SHStrDupW(pwszDrive, &pwszDrive)))
         return FALSE;
 
+    // Prepare data for thread
     SHOW_DRIVE_PROP_DATA *pData = (SHOW_DRIVE_PROP_DATA *)LocalAlloc(LPTR, sizeof(*pData));
     if (!pData)
         return FALSE;
-
     *pData = { pwszDrive, pDataObj };
     pDataObj->AddRef();
 

--- a/dll/win32/shell32/dialogs/drive.cpp
+++ b/dll/win32/shell32/dialogs/drive.cpp
@@ -166,7 +166,7 @@ typedef struct _DRIVE_PROP_PAGE
     UINT DriveType;
 } DRIVE_PROP_PAGE;
 
-struct SHOW_DRIVE_PROP_DATA
+struct DRIVE_PROP_DATA
 {
     LPWSTR pwszDrive;
     IDataObject *pDataObj;
@@ -175,7 +175,7 @@ struct SHOW_DRIVE_PROP_DATA
 static DWORD WINAPI
 SH_ShowDrivePropThreadProc(LPVOID pParam)
 {
-    CHeapPtr<SHOW_DRIVE_PROP_DATA, CComAllocator> pPropData((SHOW_DRIVE_PROP_DATA *)pParam);
+    CHeapPtr<DRIVE_PROP_DATA, CComAllocator> pPropData((DRIVE_PROP_DATA *)pParam);
     CHeapPtr<WCHAR, CComAllocator> pwszDrive(pPropData->pwszDrive);
     CComPtr<IDataObject> pDataObj;
     pDataObj.Attach(pPropData->pDataObj); // We have already AddRef'ed. Use Attach
@@ -252,7 +252,7 @@ SH_ShowDriveProperties(WCHAR *pwszDrive, IDataObject *pDataObj)
         return FALSE;
 
     // Prepare data for thread
-    SHOW_DRIVE_PROP_DATA *pData = (SHOW_DRIVE_PROP_DATA *)SHAlloc(sizeof(*pData));
+    DRIVE_PROP_DATA *pData = (DRIVE_PROP_DATA *)SHAlloc(sizeof(*pData));
     if (!pData)
     {
         SHFree(pwszDrive);

--- a/dll/win32/shell32/dialogs/drive.cpp
+++ b/dll/win32/shell32/dialogs/drive.cpp
@@ -185,9 +185,7 @@ SH_ShowDrivePropThreadProc(LPVOID pParam)
 
     CDataObjectHIDA cida(pDataObj);
     if (FAILED_UNEXPECTEDLY(cida.hr()))
-    {
         return FAILED(cida.hr());
-    }
 
     RECT rcPosition = {CW_USEDEFAULT, CW_USEDEFAULT, 0, 0};
     POINT pt;


### PR DESCRIPTION
## Purpose

The drive property sheet was modal, so it used to lock the main thread. This PR will unlock by using another thread.

JIRA issue: [CORE-4217](https://jira.reactos.org/browse/CORE-4217)
JIRA issue: [CORE-11547](https://jira.reactos.org/browse/CORE-11547)

## Proposed changes

In `dll/win32/shell32/dialogs/drive.cpp`:

- Add `DRIVE_PROP_DATA` structure.
- Call `SHCreateThread` function in `SH_ShowDriveProperties` function.
- Clean up the data when they should be released.

## TODO

- [x] Do tests.

## Comparison

BEFORE:
![before](https://github.com/reactos/reactos/assets/2107452/7a1d512c-d28b-4152-ad74-1b07b53e882b)
FAILED. Not working well.

AFTER:
![after](https://github.com/reactos/reactos/assets/2107452/5032620d-4980-4f18-9728-498436309929)
It is working well.