### PR TITLE
[NTUSER] Fix popup menu position on menu item partly off the left screen

### DIFF
--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -3001,8 +3001,8 @@ static BOOL FASTCALL MENU_ShowPopup(PWND pwndOwner, PMENU menu, UINT id, UINT fl
     /* We are off the left side of the screen */
     if (x < monitor->rcMonitor.left)
     {
-        /* Re-orient the menu around the x-axis */
-        x += width;
+        /* Position menu at left edge of screen */
+        x = 0;
 
         if (x < monitor->rcMonitor.left || x >= monitor->rcMonitor.right || bIsPopup)
             x = monitor->rcMonitor.left;


### PR DESCRIPTION
## Purpose

_Fix popup menu position on menu item half off the left side of the screen._

JIRA issue: [CORE-16729](https://jira.reactos.org/browse/CORE-16729)

## Proposed changes

_Change menu popup calculated x position when menu item is part way off the left of the screen._
_Mark Jansen's revised positioning code made this fairly simple._