### PR TITLE
[CRYPTEXT] Add Czech (cs-CZ) and Slovak (sk-SK) translations

### DIFF
--- a/dll/shellext/cryptext/cryptext.rc
+++ b/dll/shellext/cryptext/cryptext.rc
@@ -50,6 +50,9 @@
 #ifdef LANGUAGE_RU_RU
     #include "lang/ru-RU.rc"
 #endif
+#ifdef LANGUAGE_SK_SK
+    #include "lang/sk-SK.rc"
+#endif
 #ifdef LANGUAGE_TR_TR
     #include "lang/tr-TR.rc"
 #endif

--- a/dll/shellext/cryptext/cryptext.rc
+++ b/dll/shellext/cryptext/cryptext.rc
@@ -14,6 +14,9 @@
 /* UTF-8 */
 #pragma code_page(65001)
 
+#ifdef LANGUAGE_CS_CZ
+    #include "lang/cs-CZ.rc"
+#endif
 #ifdef LANGUAGE_DE_DE
     #include "lang/de-DE.rc"
 #endif

--- a/dll/shellext/cryptext/lang/cs-CZ.rc
+++ b/dll/shellext/cryptext/lang/cs-CZ.rc
@@ -2,7 +2,7 @@
  * PROJECT:     ReactOS CryptExt Shell Extension
  * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
  * PURPOSE:     Czech resource file
- * COPYRIGHT:   Copyright 2024 Václav Zouzalík (Venca24) <vaclav.zouzalik@seznam.cz>
+ * TRANSLATOR:  Copyright 2024 Václav Zouzalík (Venca24) <vaclav.zouzalik@seznam.cz>
  */
 
 LANGUAGE LANG_CZECH, SUBLANG_DEFAULT

--- a/dll/shellext/cryptext/lang/cs-CZ.rc
+++ b/dll/shellext/cryptext/lang/cs-CZ.rc
@@ -1,0 +1,14 @@
+/*
+ * PROJECT:     ReactOS CryptExt Shell Extension
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Czech resource file
+ * COPYRIGHT:   Copyright 2024 Václav Zouzalík (Venca24) <vaclav.zouzalik@seznam.cz>
+ */
+
+LANGUAGE LANG_CZECH, SUBLANG_DEFAULT
+
+STRINGTABLE
+BEGIN
+    IDS_INVALIDFILE "Toto není platný soubor certifikátu."
+    IDS_CER_FILE "Soubor certifikátu"
+END

--- a/dll/shellext/cryptext/lang/sk-SK.rc
+++ b/dll/shellext/cryptext/lang/sk-SK.rc
@@ -1,0 +1,14 @@
+/*
+ * PROJECT:     ReactOS CryptExt Shell Extension
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Slovak resource file
+ * COPYRIGHT:   Copyright 2024 Václav Zouzalík (Venca24) <vaclav.zouzalik@seznam.cz>
+ */
+
+LANGUAGE LANG_SLOVAK, SUBLANG_DEFAULT
+
+STRINGTABLE
+BEGIN
+    IDS_INVALIDFILE "Toto nie je platný súbor certifikátu."
+    IDS_CER_FILE "Súbor certifikátu"
+END

--- a/dll/shellext/cryptext/lang/sk-SK.rc
+++ b/dll/shellext/cryptext/lang/sk-SK.rc
@@ -2,7 +2,7 @@
  * PROJECT:     ReactOS CryptExt Shell Extension
  * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
  * PURPOSE:     Slovak resource file
- * COPYRIGHT:   Copyright 2024 Václav Zouzalík (Venca24) <vaclav.zouzalik@seznam.cz>
+ * TRANSLATOR:  Copyright 2024 Václav Zouzalík (Venca24) <vaclav.zouzalik@seznam.cz>
  */
 
 LANGUAGE LANG_SLOVAK, SUBLANG_DEFAULT


### PR DESCRIPTION
## Purpose

Adds the Czech and Slovak translations of CryptExt Shell Extension.

JIRA issue: none