### PR TITLE
[CMD] Batch: Don't ClearBatch if bSameFn

### DIFF
--- a/base/shell/cmd/batch.c
+++ b/base/shell/cmd/batch.c
@@ -337,10 +337,11 @@ INT Batch(LPTSTR fullname, LPTSTR firstword, LPTSTR param, PARSED_COMMAND *Cmd)
      */
     bTopLevel = !bc;
 
-    if (bc != NULL && Cmd == bc->current)
+    if (bc && Cmd == bc->current)
     {
         /* Then we are transferring to another batch */
-        ClearBatch();
+        if (!bSameFn)
+            ClearBatch();
         AddBatchRedirection(&Cmd->Redirections);
     }
     else
@@ -408,17 +409,9 @@ INT Batch(LPTSTR fullname, LPTSTR firstword, LPTSTR param, PARSED_COMMAND *Cmd)
     /* Perform top-level batch initialization */
     if (bTopLevel)
     {
-        TCHAR *dot;
-
-        /* Default the top-level batch context type to .BAT */
-        BatType = BAT_TYPE;
-
-        /* If this is a .CMD file, adjust the type */
-        dot = _tcsrchr(bc->BatchFilePath, _T('.'));
-        if (dot && (!_tcsicmp(dot, _T(".cmd"))))
-        {
-            BatType = CMD_TYPE;
-        }
+        /* Is the top-level batch context type .CMD or .BAT? */
+        TCHAR *dotext = _tcsrchr(bc->BatchFilePath, _T('.'));
+        BatType = (dotext && (!_tcsicmp(dotext, _T(".cmd")))) ? CMD_TYPE : BAT_TYPE;
 
 #ifdef MSCMD_BATCH_ECHO
         bBcEcho = bEcho;

--- a/base/shell/cmd/batch.c
+++ b/base/shell/cmd/batch.c
@@ -409,8 +409,9 @@ INT Batch(LPTSTR fullname, LPTSTR firstword, LPTSTR param, PARSED_COMMAND *Cmd)
     /* Perform top-level batch initialization */
     if (bTopLevel)
     {
-        /* Is the top-level batch context type .CMD or .BAT? */
-        TCHAR *dotext = _tcsrchr(bc->BatchFilePath, _T('.'));
+        /* Default the top-level batch context type
+         * to .BAT, unless this is a .CMD file */
+        PTCHAR dotext = _tcsrchr(bc->BatchFilePath, _T('.'));
         BatType = (dotext && (!_tcsicmp(dotext, _T(".cmd")))) ? CMD_TYPE : BAT_TYPE;
 
 #ifdef MSCMD_BATCH_ECHO


### PR DESCRIPTION
## Purpose

Recursing batch was prevented by `ClearBatch` call.
JIRA issue: [CORE-18093](https://jira.reactos.org/browse/CORE-18093)

## Proposed changes

- Check `bSameFn` variable.
- If it was `TRUE`, don't call `ClearBatch` function.

## TODO

- [x] Do tests.

## Comparison

Win2k3:
![Win2k3](https://github.com/reactos/reactos/assets/2107452/49a0729c-52e1-45d1-951e-fd63fdbf1e1e)
Successful.

ReactOS (BEFORE):
![before](https://github.com/reactos/reactos/assets/2107452/d0e385dd-e1d1-4e75-9852-c4af8a647f40)
FAILED.

ReactOS (AFTER):
![after](https://github.com/reactos/reactos/assets/2107452/98b9984d-7c85-4f97-94fd-fb9fd8ce6824)
Successful.