### PR TITLE
[CMD] Fix GetPathCase function

### DIFF
--- a/base/shell/cmd/cmd.h
+++ b/base/shell/cmd/cmd.h
@@ -325,7 +325,7 @@ VOID   StripQuotes(LPTSTR);
 BOOL IsValidPathName(IN LPCTSTR pszPath);
 BOOL IsExistingFile(IN LPCTSTR pszPath);
 BOOL IsExistingDirectory(IN LPCTSTR pszPath);
-VOID   GetPathCase(TCHAR *, TCHAR *);
+VOID GetPathCase(IN LPCTSTR Path, OUT LPTSTR OutPath);
 
 #define PROMPT_NO    0
 #define PROMPT_YES   1

--- a/base/shell/cmd/misc.c
+++ b/base/shell/cmd/misc.c
@@ -85,7 +85,8 @@ cgetchar (VOID)
  */
 VOID GetPathCase(IN LPCTSTR Path, OUT LPTSTR OutPath)
 {
-    UINT i, cchPath = lstrlen(Path);
+    UINT i;
+    UINT cchPath = _tcslen(Path);
     TCHAR TempPath[MAX_PATH];
     LPTSTR pchTemp = TempPath;
     LPTSTR pchTempEnd = TempPath + _countof(TempPath);

--- a/base/shell/cmd/misc.c
+++ b/base/shell/cmd/misc.c
@@ -99,6 +99,7 @@ VOID GetPathCase(IN LPCTSTR Path, OUT LPTSTR OutPath)
     {
         if (pchTemp + 1 >= pchTempEnd)
         {
+            // On failure, copy the original path for an error message
             StringCchCopy(OutPath, MAX_PATH, Path);
             return;
         }

--- a/base/shell/cmd/misc.c
+++ b/base/shell/cmd/misc.c
@@ -87,7 +87,8 @@ VOID GetPathCase(IN LPCTSTR Path, OUT LPTSTR OutPath)
 {
     UINT i, cchPath = lstrlen(Path);
     TCHAR TempPath[MAX_PATH];
-    LPTSTR pchTemp = TempPath, pchTempEnd = TempPath + _countof(TempPath);
+    LPTSTR pchTemp = TempPath;
+    LPTSTR pchTempEnd = TempPath + _countof(TempPath);
     WIN32_FIND_DATA FindFileData;
     HANDLE hFind;
 

--- a/base/shell/cmd/misc.c
+++ b/base/shell/cmd/misc.c
@@ -132,7 +132,7 @@ VOID GetPathCase(IN LPCTSTR Path, OUT LPTSTR OutPath)
             StringCchCat(OutPath, MAX_PATH, _T("\\"));
             StringCchCopy(TempPath, _countof(TempPath), OutPath);
         }
-        pchTemp = TempPath + lstrlen(TempPath);
+        pchTemp = TempPath + _tcslen(TempPath);
     }
 }
 

--- a/base/shell/cmd/misc.c
+++ b/base/shell/cmd/misc.c
@@ -85,7 +85,7 @@ cgetchar (VOID)
  */
 VOID GetPathCase(IN LPCTSTR Path, OUT LPTSTR OutPath)
 {
-    UINT i;
+    SIZE_T i;
     UINT cchPath = _tcslen(Path);
     TCHAR TempPath[MAX_PATH];
     LPTSTR pchTemp = TempPath;

--- a/base/shell/cmd/misc.c
+++ b/base/shell/cmd/misc.c
@@ -83,45 +83,56 @@ cgetchar (VOID)
 /*
  * Takes a path in and returns it with the correct case of the letters
  */
-VOID GetPathCase( TCHAR * Path, TCHAR * OutPath)
+VOID GetPathCase(IN LPCTSTR Path, OUT LPTSTR OutPath)
 {
-    UINT i = 0;
+    UINT i, cchPath = lstrlen(Path);
     TCHAR TempPath[MAX_PATH];
+    LPTSTR pchTemp = TempPath, pchTempEnd = TempPath + _countof(TempPath);
     WIN32_FIND_DATA FindFileData;
     HANDLE hFind;
-    _tcscpy(TempPath, _T(""));
-    _tcscpy(OutPath, _T(""));
 
-    for(i = 0; i < _tcslen(Path); i++)
+    *pchTemp = OutPath[0] = 0;
+
+    for (i = 0; i < cchPath; ++i)
     {
-        if (Path[i] != _T('\\'))
+        if (pchTemp + 1 >= pchTempEnd)
         {
-            _tcsncat(TempPath, &Path[i], 1);
-            if (i != _tcslen(Path) - 1)
+            StringCchCopy(OutPath, MAX_PATH, Path);
+            return;
+        }
+
+        if (Path[i] != _T('\\') && Path[i] != _T('/'))
+        {
+            *pchTemp++ = Path[i];
+            *pchTemp = 0;
+            if (i != cchPath - 1)
                 continue;
         }
+
         /* Handle the base part of the path different.
            Because if you put it into findfirstfile, it will
            return your current folder */
-        if (_tcslen(TempPath) == 2 && TempPath[1] == _T(':'))
+        if (!TempPath[2] && TempPath[0] && TempPath[1] == _T(':')) /* "C:", "X:" etc. */
         {
-            _tcscat(OutPath, TempPath);
-            _tcscat(OutPath, _T("\\"));
-            _tcscat(TempPath, _T("\\"));
+            StringCchCat(OutPath, MAX_PATH, TempPath);
+            StringCchCat(OutPath, MAX_PATH, _T("\\"));
+            StringCchCat(TempPath, _countof(TempPath), _T("\\"));
         }
         else
         {
-            hFind = FindFirstFile(TempPath,&FindFileData);
+            hFind = FindFirstFile(TempPath, &FindFileData);
             if (hFind == INVALID_HANDLE_VALUE)
             {
-                _tcscpy(OutPath, Path);
+                StringCchCopy(OutPath, MAX_PATH, Path);
                 return;
             }
-            _tcscat(TempPath, _T("\\"));
-            _tcscat(OutPath, FindFileData.cFileName);
-            _tcscat(OutPath, _T("\\"));
             FindClose(hFind);
+            StringCchCat(OutPath, MAX_PATH, _T("\\"));
+            StringCchCat(OutPath, MAX_PATH, FindFileData.cFileName);
+            StringCchCat(OutPath, MAX_PATH, _T("\\"));
+            StringCchCopy(TempPath, _countof(TempPath), OutPath);
         }
+        pchTemp = TempPath + lstrlen(TempPath);
     }
 }
 

--- a/base/shell/cmd/misc.c
+++ b/base/shell/cmd/misc.c
@@ -112,7 +112,7 @@ VOID GetPathCase(IN LPCTSTR Path, OUT LPTSTR OutPath)
         /* Handle the base part of the path different.
            Because if you put it into findfirstfile, it will
            return your current folder */
-        if (!TempPath[2] && TempPath[0] && TempPath[1] == _T(':')) /* "C:", "X:" etc. */
+        if (TempPath[0] && TempPath[1] == _T(':') && !TempPath[2]) /* "C:", "D:" etc. */
         {
             StringCchCat(OutPath, MAX_PATH, TempPath);
             StringCchCat(OutPath, MAX_PATH, _T("\\"));

--- a/base/shell/cmd/misc.c
+++ b/base/shell/cmd/misc.c
@@ -86,7 +86,7 @@ cgetchar (VOID)
 VOID GetPathCase(IN LPCTSTR Path, OUT LPTSTR OutPath)
 {
     SIZE_T i;
-    UINT cchPath = _tcslen(Path);
+    SIZE_T cchPath = _tcslen(Path);
     TCHAR TempPath[MAX_PATH];
     LPTSTR pchTemp = TempPath;
     LPTSTR pchTempEnd = TempPath + _countof(TempPath);


### PR DESCRIPTION
## Purpose

This `GetPathCase` function does resolve the path with wildcard pattern, and fix the alphabet cases, by using `kernel32!FindFirstFile` function.
Enable wildcard at the middle of the file path in `cmd.exe` by fixing this function.

JIRA issue: [CORE-6609](https://jira.reactos.org/browse/CORE-6609)
JIRA issue: [CORE-13906](https://jira.reactos.org/browse/CORE-13906)


## Proposed changes

- Fix `GetPathCase` function for supporting wildcard at the middle of the file path.
- Make `GetPathCase` string-safe.
- Optimize `GetPathCase`.

## TODO

- [x] Do tests.

## Comparison

BEFORE:
![before](https://github.com/reactos/reactos/assets/2107452/48210374-df50-44b1-82ac-a0e86b6bd1d8)
FAILED.

AFTER:
![after](https://github.com/reactos/reactos/assets/2107452/52d6e67b-da27-4969-b242-e8f3e28726c5)
Successful.