### PR TITLE
[CMD][BOOTDATA] Populate 'Command Processor' registry data

### DIFF
--- a/base/shell/cmd/cmdinput.c
+++ b/base/shell/cmd/cmdinput.c
@@ -106,7 +106,7 @@
  * See https://technet.microsoft.com/en-us/library/cc978715.aspx
  * and https://technet.microsoft.com/en-us/library/cc940805.aspx
  * to know the differences between those two settings.
- * Values 0x00, 0x0D (carriage return) and 0x20 (space) disable completion.
+ * Values 0x00, 0x0D (carriage return) and >= 0x20 (space) disable completion.
  */
 TCHAR AutoCompletionChar = 0x20; // Disabled by default
 TCHAR PathCompletionChar = 0x20; // Disabled by default

--- a/base/shell/cmd/cmdinput.c
+++ b/base/shell/cmd/cmdinput.c
@@ -108,8 +108,8 @@
  * to know the differences between those two settings.
  * Values 0x00, 0x0D (carriage return) and 0x20 (space) disable completion.
  */
-TCHAR AutoCompletionChar = _T('\t'); // Default is 0x20
-TCHAR PathCompletionChar = _T('\t'); // Default is 0x20
+TCHAR AutoCompletionChar = 0x20; // Disabled by default
+TCHAR PathCompletionChar = 0x20; // Disabled by default
 
 
 SHORT maxx;

--- a/boot/bootdata/hivedef.inf
+++ b/boot/bootdata/hivedef.inf
@@ -160,6 +160,11 @@ HKCU,"Control Panel\International\Geo",,0x00000012
 HKCU,"Control Panel\Cursors",,,"ReactOS Default"
 HKCU,"Control Panel\Cursors","Scheme Source",0x00010001,0x00000002
 
+; CMD Settings
+HKCU,"SOFTWARE\Microsoft\Command Processor","CompletionChar",0x00010001,9
+HKCU,"SOFTWARE\Microsoft\Command Processor","DefaultColor",0x00010001,0
+HKCU,"SOFTWARE\Microsoft\Command Processor","EnableExtensions",0x00010001,1
+
 ; PowerCfg
 HKCU,"Control Panel\PowerCfg","CurrentPowerPolicy",2,"0"
 HKCU,"Control Panel\PowerCfg\GlobalPowerPolicy","Policies",0x00030003,01,00,00,00,00,\

--- a/boot/bootdata/hivedef.inf
+++ b/boot/bootdata/hivedef.inf
@@ -161,7 +161,7 @@ HKCU,"Control Panel\Cursors",,,"ReactOS Default"
 HKCU,"Control Panel\Cursors","Scheme Source",0x00010001,0x00000002
 
 ; CMD Settings
-HKCU,"SOFTWARE\Microsoft\Command Processor","CompletionChar",0x00010001,9
+HKCU,"SOFTWARE\Microsoft\Command Processor","CompletionChar",0x00010001,0x09
 HKCU,"SOFTWARE\Microsoft\Command Processor","DefaultColor",0x00010001,0
 HKCU,"SOFTWARE\Microsoft\Command Processor","EnableExtensions",0x00010001,1
 

--- a/boot/bootdata/hivesft.inf
+++ b/boot/bootdata/hivesft.inf
@@ -469,10 +469,10 @@ HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\BitBucket\Volume",,0x00
 
 ; CMD Settings
 HKLM,"SOFTWARE\Microsoft\Command Processor","AutoRun",0x00020000,""
-HKLM,"SOFTWARE\Microsoft\Command Processor","CompletionChar",0x00010001,0x00000040
-HKLM,"SOFTWARE\Microsoft\Command Processor","DefaultColor",0x00010001,0x00000000
-HKLM,"SOFTWARE\Microsoft\Command Processor","EnableExtensions",0x00010001,0x00000001
-HKLM,"SOFTWARE\Microsoft\Command Processor","PathCompletionChar",0x00010001,0x00000040
+HKLM,"SOFTWARE\Microsoft\Command Processor","CompletionChar",0x00010001,64
+HKLM,"SOFTWARE\Microsoft\Command Processor","DefaultColor",0x00010001,0
+HKLM,"SOFTWARE\Microsoft\Command Processor","EnableExtensions",0x00010001,1
+HKLM,"SOFTWARE\Microsoft\Command Processor","PathCompletionChar",0x00010001,64
 
 ; Uninstall Application list
 HKLM,"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall",,0x00000012

--- a/boot/bootdata/hivesft.inf
+++ b/boot/bootdata/hivesft.inf
@@ -469,10 +469,10 @@ HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\BitBucket\Volume",,0x00
 
 ; CMD Settings
 HKLM,"SOFTWARE\Microsoft\Command Processor","AutoRun",0x00020000,""
-HKLM,"SOFTWARE\Microsoft\Command Processor","CompletionChar",0x00010001,64
+HKLM,"SOFTWARE\Microsoft\Command Processor","CompletionChar",0x00010001,0x40
 HKLM,"SOFTWARE\Microsoft\Command Processor","DefaultColor",0x00010001,0
 HKLM,"SOFTWARE\Microsoft\Command Processor","EnableExtensions",0x00010001,1
-HKLM,"SOFTWARE\Microsoft\Command Processor","PathCompletionChar",0x00010001,64
+HKLM,"SOFTWARE\Microsoft\Command Processor","PathCompletionChar",0x00010001,0x40
 
 ; Uninstall Application list
 HKLM,"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall",,0x00000012

--- a/boot/bootdata/hivesft.inf
+++ b/boot/bootdata/hivesft.inf
@@ -469,6 +469,10 @@ HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\BitBucket\Volume",,0x00
 
 ; CMD Settings
 HKLM,"SOFTWARE\Microsoft\Command Processor","AutoRun",0x00020000,""
+HKLM,"SOFTWARE\Microsoft\Command Processor","CompletionChar",0x00010001,0x00000040
+HKLM,"SOFTWARE\Microsoft\Command Processor","DefaultColor",0x00010001,0x00000000
+HKLM,"SOFTWARE\Microsoft\Command Processor","EnableExtensions",0x00010001,0x00000001
+HKLM,"SOFTWARE\Microsoft\Command Processor","PathCompletionChar",0x00010001,0x00000040
 
 ; Uninstall Application list
 HKLM,"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall",,0x00000012


### PR DESCRIPTION
## Purpose

Improve compatibility.
JIRA issue: [CORE-8002](https://jira.reactos.org/browse/CORE-8002)

## Proposed changes

- Fix the default values of `AutoCompletionChar` and `PathCompletionChar` in `cmd.exe`.
- Populate `"SOFTWARE\Microsoft\Command Processor"` registry key like Win2k3 does.

## TODO

- [x] Do tests.

## Comparison

WinXP Japanese (`HKLM`):
![WinXP](https://github.com/reactos/reactos/assets/2107452/6765e8fe-4f02-429a-aed2-1bb7cd189b46)
Populated.

WinXP Japanese (`HKCU`):
![winxp-hkcu](https://github.com/reactos/reactos/assets/2107452/23d142ee-85fb-4474-8b30-301866b78410)
Populated.

Win2k3 (`HKLM`):
![Win2k3](https://github.com/reactos/reactos/assets/2107452/ee298a97-21c8-40d7-83fb-17ba4bd00848)
Populated.

Win2k3 (`HKCU`):
![win2k3-hkcu](https://github.com/reactos/reactos/assets/2107452/1a09938a-6cdf-4924-8efe-6cd70997fe27)
Populated.

ReactOS (AFTER, `HKLM`):
![after2](https://github.com/reactos/reactos/assets/2107452/491ffec8-24ec-4340-a0e1-1d2c2af6f056)
Populated.

ReactOS (AFTER, `HKCU`):
![after-hkcu](https://github.com/reactos/reactos/assets/2107452/3c754fd6-4d3b-4878-b0c9-e69c4ec85069)
Populated.