### PR TITLE
[BROWSEUI] AutoComplete: Close before opening IME candidates

### DIFF
--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -21,7 +21,7 @@
  */
 
 #include "precomp.h"
-#include <imm.h>
+#include <imm.h> // For IMN_OPENCANDIDATE
 #include <process.h> // _beginthreadex
 
 /*

--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -344,6 +344,10 @@ LRESULT CAutoComplete::EditWndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM l
             if (hwndGotFocus != m_hwndEdit && hwndGotFocus != m_hWnd)
                 HideDropDown();
             break;
+        case WM_IME_NOTIFY:
+            if (wParam == IMN_OPENCANDIDATE)
+                HideDropDown();
+            break;
         case WM_SETTEXT:
             if (!m_bInSetText)
                 HideDropDown(); // it's mechanical WM_SETTEXT

--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "precomp.h"
+#include <imm.h>
 #include <process.h> // _beginthreadex
 
 /*


### PR DESCRIPTION
## Purpose

The auto-complete window and the IME candidate window were conflicting each other.
JIRA issue: [CORE-19268](https://jira.reactos.org/browse/CORE-19268)

## Proposed changes

- Call `HideDropDown` method when processing `IMN_OPENCANDIDATE` message.

## NOTE

IMM/IME is currently unstable.

## TODO

- [x] Do tests.

## Comparison

WinXP Japanese:
![WinXP](https://github.com/reactos/reactos/assets/2107452/9a341913-0b9b-4031-b3be-9d02f552e2ac)
Works as expected.

ReactOS (BEFORE):
![before](https://github.com/reactos/reactos/assets/2107452/75b73c51-e1dd-4f3e-a9e2-54de8e3b0c79)
FAILED. Conflicting.

ReactOS (AFTER):
![after](https://github.com/reactos/reactos/assets/2107452/500fcddd-12ac-4559-9e81-941dd072e704)
Works as expected.