### PR TITLE
[CMD] DATE: Simply use short date without weekday

### DIFF
--- a/base/shell/cmd/locale.c
+++ b/base/shell/cmd/locale.c
@@ -61,7 +61,7 @@ GetDateString(VOID)
     SYSTEMTIME t;
 
     GetLocalTime(&t);
-    GetDateFormat(LOCALE_USER_DEFAULT, 0, &t, NULL, szDate, ARRAYSIZE(szDate));
+    GetDateFormat(LOCALE_USER_DEFAULT, DATE_SHORTDATE, &t, NULL, szDate, ARRAYSIZE(szDate));
     return szDate;
 }
 

--- a/base/shell/cmd/locale.c
+++ b/base/shell/cmd/locale.c
@@ -53,18 +53,15 @@ VOID InitLocale(VOID)
 #endif
 }
 
-/* Return date string including weekday. Used for $D in prompt and %DATE% */
+/* Return date string without weekday. Used for $D in prompt and %DATE% */
 LPTSTR
 GetDateString(VOID)
 {
     static TCHAR szDate[32];
     SYSTEMTIME t;
-    INT len;
-    GetLocalTime(&t);
 
-    len = GetDateFormat(LOCALE_USER_DEFAULT, 0, &t, _T("ddd"), szDate, ARRAYSIZE(szDate));
-    szDate[len - 1] = _T(' ');
-    FormatDate(&szDate[len], &t, TRUE);
+    GetLocalTime(&t);
+    GetDateFormat(LOCALE_USER_DEFAULT, 0, &t, NULL, szDate, ARRAYSIZE(szDate));
     return szDate;
 }
 


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-13848](https://jira.reactos.org/browse/CORE-13848)

## Proposed changes

- Simply use the result of `GetDateFormat` function in `%DATE%` environment variable and the `DATE` command.

## TODO

- [x] Do tests.

## Comparison

Win2k3:
![intl-win2k3](https://github.com/reactos/reactos/assets/2107452/750e69ac-9379-47f1-be3a-28dbcb14570f)

ReactOS (BEFORE):
![intl-before](https://github.com/reactos/reactos/assets/2107452/8d29ebcb-8819-4cf7-a8a6-91229ba2d802)

ReactOS (AFTER):
![intl-after](https://github.com/reactos/reactos/assets/2107452/16e6e436-7d50-43b5-ac4f-8e5de7a45c5a)