### PR TITLE
[CMD] Implement /F[:ON|:OFF] switch for file/path completion

### DIFF
--- a/base/shell/cmd/cmd.c
+++ b/base/shell/cmd/cmd.c
@@ -2254,6 +2254,22 @@ Initialize(VOID)
             {
                 OutputStreamMode = UTF16Text;
             }
+            else if (option == _T('F'))
+            {
+                if (!_tcsnicmp(&ptr[2], _T(":OFF"), 4))
+                {
+                    /* Disable file and path completion */
+                    AutoCompletionChar = 0x20;
+                    PathCompletionChar = 0x20;
+                }
+                else /* Enable completion by default */
+                {
+                    /* Enable (and replace) file and path completion
+                     * characters with Ctrl-F and Ctrl-D respectively */
+                    AutoCompletionChar = 0x06; // Ctrl-F
+                    PathCompletionChar = 0x04; // Ctrl-D
+                }
+            }
             else if (option == _T('V'))
             {
                 // FIXME: Check validity of the parameter given to V !


### PR DESCRIPTION
## Purpose

The switch enables or disables file/path completion in a unique
CMD instance. The defaulted values for the completion characters
are those mentioned in CMD's help (see also MSDN[^1]):
  File: Ctrl-F (0x06); Directory: Ctrl-D (0x04)

Manual tests show that only /F:OFF explicitly disables completion.
Otherwise, using /F(anything else following) always enables completion
with the specific values described above.

JIRA issue: [CORE-8002](https://jira.reactos.org/browse/CORE-8002)

[^1]: For additional details, see also
https://technet.microsoft.com/en-us/library/cc978715.aspx
https://technet.microsoft.com/en-us/library/cc940805.aspx
