### PR TITLE
[NTUSER] Check class style for CS_NOCLOSE instead of window style

### DIFF
--- a/win32ss/user/ntuser/nonclient.c
+++ b/win32ss/user/ntuser/nonclient.c
@@ -1478,7 +1478,7 @@ NC_DoButton(PWND pWnd, WPARAM wParam, LPARAM lParam)
       case HTCLOSE:
          SysMenu = IntGetSystemMenu(pWnd, FALSE);
          MenuState = IntGetMenuState(SysMenu ? UserHMGetHandle(SysMenu) : NULL, SC_CLOSE, MF_BYCOMMAND); /* in case of error MenuState==0xFFFFFFFF */
-         if (!(Style & WS_SYSMENU) || (MenuState & (MF_GRAYED|MF_DISABLED)) || (pWnd->style & CS_NOCLOSE))
+         if (!(Style & WS_SYSMENU) || (MenuState & (MF_GRAYED|MF_DISABLED)) || (pWnd->pcls->style & CS_NOCLOSE))
             return;
          ButtonType = DFCS_CAPTIONCLOSE;
          SCMsg = SC_CLOSE;


### PR DESCRIPTION
CORE-11569
I_Kill_Bugs patch.

## Purpose

_Ad Muncher does not close when left-clicking with mouse button on the title bar "X"._

JIRA issue: [CORE-11569](https://jira.reactos.org/browse/CORE-11569)

## Proposed changes

_Change test from 'pWnd->style' to 'pWnd->pcls->style' to check for CS_NOCLOSE._
_Wrong parameter was selected for checking previously._