### PR TITLE
[SHELL32] shlexec.cpp: Parse 'shell:' and '::{CLSID}'

### DIFF
--- a/dll/win32/shell32/CDefaultContextMenu.cpp
+++ b/dll/win32/shell32/CDefaultContextMenu.cpp
@@ -11,10 +11,8 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(dmenu);
 
-
 // FIXME: 260 is correct, but should this be part of the SDK or just MAX_PATH?
 #define MAX_VERB 260
-#define VERBKEY_CCHMAX 64 // Note: 63+\0 seems to be the limit on XP
 
 static HRESULT
 SHELL_GetRegCLSID(HKEY hKey, LPCWSTR SubKey, LPCWSTR Value, CLSID &clsid)

--- a/dll/win32/shell32/precomp.h
+++ b/dll/win32/shell32/precomp.h
@@ -127,6 +127,8 @@ extern const GUID SHELL32_AdvtShortcutComponent;
 
 #define MAX_PROPERTY_SHEET_PAGE 32
 
+#define VERBKEY_CCHMAX 64 // Note: 63+\0 seems to be the limit on XP
+
 extern inline
 BOOL
 CALLBACK

--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -1738,51 +1738,56 @@ static BOOL SHELL_translate_idlist(LPSHELLEXECUTEINFOW sei, LPWSTR wszParameters
     return appKnownSingular;
 }
 
-BOOL SHELL_OpenPIDL(LPSHELLEXECUTEINFOW sei, LPCITEMIDLIST pidl)
+static BOOL
+SHELL_InvokePidl(
+    _In_ LPSHELLEXECUTEINFOW sei,
+    _In_ LPCITEMIDLIST pidl)
 {
+    // Bind pidl
     CComPtr<IShellFolder> psfFolder;
-    LPCITEMIDLIST ppidlLast;
-    HRESULT hr = SHBindToParent(pidl, IID_PPV_ARG(IShellFolder, &psfFolder), &ppidlLast);
+    LPCITEMIDLIST pidlLast;
+    HRESULT hr = SHBindToParent(pidl, IID_PPV_ARG(IShellFolder, &psfFolder), &pidlLast);
     if (FAILED_UNEXPECTEDLY(hr))
         return FALSE;
 
+    // Get the context menu to invoke a command
     CComPtr<IContextMenu> pCM;
-    hr = psfFolder->GetUIObjectOf(NULL, 1, &ppidlLast, IID_NULL_PPV_ARG(IContextMenu, &pCM));
+    hr = psfFolder->GetUIObjectOf(NULL, 1, &pidlLast, IID_NULL_PPV_ARG(IContextMenu, &pCM));
     if (FAILED_UNEXPECTEDLY(hr))
         return FALSE;
 
-    HMENU hMenu = CreatePopupMenu();
-    const INT idCmdFirst = 1, idCmdLast = 0x7FFF;
-    hr = pCM->QueryContextMenu(hMenu, 0, idCmdFirst, idCmdLast, CMF_NORMAL);
-    if (FAILED_UNEXPECTEDLY(hr))
-    {
-        DestroyMenu(hMenu);
-        return FALSE;
-    }
-
-    INT nDefaultID = GetMenuDefaultItem(hMenu, FALSE, 0);
-    if (nDefaultID == -1)
-        nDefaultID = idCmdFirst;
-
-    DestroyMenu(hMenu);
-
+    // Invoke a command
     CMINVOKECOMMANDINFO ici = { sizeof(ici) };
     ici.fMask = (sei->fMask & (SEE_MASK_NO_CONSOLE | SEE_MASK_ASYNCOK | SEE_MASK_FLAG_NO_UI));
     ici.nShow = sei->nShow;
     ici.hwnd = sei->hwnd;
-    char szVerb[64];
-    if (sei->lpVerb)
+    char szVerb[VERBKEY_CCHMAX];
+    if (sei->lpVerb && sei->lpVerb[0])
     {
         WideCharToMultiByte(CP_ACP, 0, sei->lpVerb, -1, szVerb, _countof(szVerb), NULL, NULL);
-        szVerb[_countof(szVerb) - 1] = ANSI_NULL;
+        szVerb[_countof(szVerb) - 1] = ANSI_NULL; // Avoid buffer overrun
         ici.lpVerb = szVerb;
     }
-    else
+    else // The default verb?
     {
+        HMENU hMenu = CreatePopupMenu();
+        const INT idCmdFirst = 1, idCmdLast = 0x7FFF;
+        hr = pCM->QueryContextMenu(hMenu, 0, idCmdFirst, idCmdLast, CMF_DEFAULTONLY);
+        if (FAILED_UNEXPECTEDLY(hr))
+        {
+            DestroyMenu(hMenu);
+            return FALSE;
+        }
+
+        INT nDefaultID = GetMenuDefaultItem(hMenu, FALSE, 0);
+        DestroyMenu(hMenu);
+        if (nDefaultID == -1)
+            nDefaultID = idCmdFirst;
+
         ici.lpVerb = MAKEINTRESOURCEA(nDefaultID - idCmdFirst);
     }
-
     hr = pCM->InvokeCommand(&ici);
+
     return !FAILED_UNEXPECTEDLY(hr);
 }
 
@@ -1893,6 +1898,12 @@ static WCHAR *expand_environment( const WCHAR *str )
         return NULL;
 
     return buf.Detach();
+}
+
+static inline BOOL
+PathIsShortcutFile(LPCWSTR pszFileName)
+{
+    return lstrcmpiW(PathFindExtensionW(pszFileName), L".lnk") == 0;
 }
 
 /*************************************************************************
@@ -2079,12 +2090,16 @@ static BOOL SHELL_execute(LPSHELLEXECUTEINFOW sei, SHELL_ExecuteW32 execfunc)
         return retval > 32;
     }
 
-    if (!(sei_tmp.fMask & SEE_MASK_IDLIST))
+    if (!(sei_tmp.fMask & SEE_MASK_IDLIST) && // Not an ID List
+        !PathIsShortcutFile(sei_tmp.lpFile)) // CShellLink::InvokeCommand depends on ShellExecute
     {
         CComHeapPtr<ITEMIDLIST> pidlParsed;
-        HRESULT hr = SHParseDisplayName(sei_tmp.lpFile, NULL, &pidlParsed, SFGAO_STORAGECAPMASK, NULL);
-        if (SUCCEEDED(hr))
-            return SHELL_OpenPIDL(&sei_tmp, pidlParsed);
+        HRESULT hr = SHParseDisplayName(sei_tmp.lpFile, NULL, &pidlParsed, 0, NULL);
+        if (SUCCEEDED(hr) && SHELL_InvokePidl(&sei_tmp, pidlParsed))
+        {
+            sei_tmp.hInstApp = (HINSTANCE)UlongToHandle(42);
+            return TRUE;
+        }
     }
 
     /* Has the IDList not yet been translated? */

--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -1900,12 +1900,6 @@ static WCHAR *expand_environment( const WCHAR *str )
     return buf.Detach();
 }
 
-static inline BOOL
-PathIsShortcutFile(LPCWSTR pszFileName)
-{
-    return lstrcmpiW(PathFindExtensionW(pszFileName), L".lnk") == 0;
-}
-
 /*************************************************************************
  *    SHELL_execute [Internal]
  */
@@ -2091,7 +2085,8 @@ static BOOL SHELL_execute(LPSHELLEXECUTEINFOW sei, SHELL_ExecuteW32 execfunc)
     }
 
     if (!(sei_tmp.fMask & SEE_MASK_IDLIST) && // Not an ID List
-        !PathIsShortcutFile(sei_tmp.lpFile)) // CShellLink::InvokeCommand depends on ShellExecute
+        (StrCmpNIW(sei_tmp.lpFile, L"shell:", 6) == 0 ||
+         StrCmpNW(sei_tmp.lpFile, L"::{", 3) == 0))
     {
         CComHeapPtr<ITEMIDLIST> pidlParsed;
         HRESULT hr = SHParseDisplayName(sei_tmp.lpFile, NULL, &pidlParsed, 0, NULL);


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-14177](https://jira.reactos.org/browse/CORE-14177)
JIRA issue: [CORE-17482](https://jira.reactos.org/browse/CORE-17482)

## Proposed changes

- Add `SHELL_InvokePidl` helper function.
- Call `SHParseDisplayName` and `SHELL_InvokePidl` in a specific condition.

## TODO

- [x] Do small tests.
- [x] Do big tests.

## Comparison

ReactOS (BEFORE):
![before](https://github.com/reactos/reactos/assets/2107452/97635e6a-f862-49ea-9263-360609c7895a)
`shell:sendto` and `::{CLSID}`  won't work.

ReactOS (AFTER):
![after](https://github.com/reactos/reactos/assets/2107452/24c9c3cf-bb45-4add-9fbb-1154caabad94)
`shell:sendto` and `::{CLSID}`  work well.