### PR TITLE
[BROWSEUI] Check focus before opening AutoComplete

### DIFF
--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -338,12 +338,14 @@ LRESULT CAutoComplete::EditWndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM l
                 return TRUE; // eat
             break;
         case WM_SETFOCUS:
+            m_bEditHasFocus = TRUE;
             break;
         case WM_KILLFOCUS:
             // hide the list if lost focus
             hwndGotFocus = (HWND)wParam;
             if (hwndGotFocus != m_hwndEdit && hwndGotFocus != m_hWnd)
                 HideDropDown();
+            m_bEditHasFocus = FALSE;
             break;
         case WM_IME_NOTIFY:
             if (wParam == IMN_OPENCANDIDATE)
@@ -656,7 +658,7 @@ LRESULT CACSizeBox::OnPaint(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHand
 // CAutoComplete public methods
 
 CAutoComplete::CAutoComplete()
-    : m_bInSetText(FALSE), m_bInSelectItem(FALSE)
+    : m_bInSetText(FALSE), m_bInSelectItem(FALSE), m_bEditHasFocus(FALSE)
     , m_bDowner(TRUE), m_dwOptions(ACO_AUTOAPPEND | ACO_AUTOSUGGEST)
     , m_bEnabled(TRUE), m_hwndCombo(NULL), m_hFont(NULL), m_bResized(FALSE)
     , m_hwndEdit(NULL), m_fnOldEditProc(NULL), m_fnOldWordBreakProc(NULL)
@@ -1121,6 +1123,7 @@ CAutoComplete::Init(HWND hwndEdit, IUnknown *punkACL,
     if (!::SetWindowSubclass(hwndEdit, EditSubclassProc, 0, reinterpret_cast<DWORD_PTR>(this)))
         return E_FAIL;
     m_hwndEdit = hwndEdit;
+    m_bEditHasFocus = (::GetFocus() == hwndEdit);
     // add reference to m_hwndEdit
     AddRef();
     // set word break procedure
@@ -1387,6 +1390,13 @@ CStringW CAutoComplete::GetQuickEdit(LPCWSTR pszText) const
 
 VOID CAutoComplete::RepositionDropDown()
 {
+    // If Edit has no focus, don't open auto-complete
+    if (!m_bEditHasFocus)
+    {
+        ERR("!m_bEditHasFocus\n");
+        return;
+    }
+
     // get nearest monitor from m_hwndEdit
     HMONITOR hMon = ::MonitorFromWindow(m_hwndEdit, MONITOR_DEFAULTTONEAREST);
     ATLASSERT(hMon != NULL);

--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -1393,7 +1393,7 @@ VOID CAutoComplete::RepositionDropDown()
     // If Edit has no focus, don't open auto-complete
     if (!m_bEditHasFocus)
     {
-        ERR("!m_bEditHasFocus\n");
+        TRACE("!m_bEditHasFocus\n");
         return;
     }
 

--- a/dll/win32/browseui/CAutoComplete.h
+++ b/dll/win32/browseui/CAutoComplete.h
@@ -153,6 +153,7 @@ public:
     static LPCWSTR GetWndClassName() { return WC_DROPDOWNW; }
     BOOL m_bInSetText; // this flag avoids subsequent action in WM_SETTEXT
     BOOL m_bInSelectItem; // this flag avoids subsequent action in LVN_ITEMCHANGED
+    BOOL m_bEditHasFocus;
 
     // public methods
     CAutoComplete();

--- a/dll/win32/browseui/CAutoComplete.h
+++ b/dll/win32/browseui/CAutoComplete.h
@@ -153,7 +153,7 @@ public:
     static LPCWSTR GetWndClassName() { return WC_DROPDOWNW; }
     BOOL m_bInSetText; // this flag avoids subsequent action in WM_SETTEXT
     BOOL m_bInSelectItem; // this flag avoids subsequent action in LVN_ITEMCHANGED
-    BOOL m_bEditHasFocus; // This flag watchs the focus status
+    BOOL m_bEditHasFocus;
 
     // public methods
     CAutoComplete();

--- a/dll/win32/browseui/CAutoComplete.h
+++ b/dll/win32/browseui/CAutoComplete.h
@@ -153,7 +153,7 @@ public:
     static LPCWSTR GetWndClassName() { return WC_DROPDOWNW; }
     BOOL m_bInSetText; // this flag avoids subsequent action in WM_SETTEXT
     BOOL m_bInSelectItem; // this flag avoids subsequent action in LVN_ITEMCHANGED
-    BOOL m_bEditHasFocus;
+    BOOL m_bEditHasFocus; // This flag watchs the focus status
 
     // public methods
     CAutoComplete();


### PR DESCRIPTION
## Purpose
Unexpectedly remaining AutoComplete list is annoying.
JIRA issue: [CORE-19685](https://jira.reactos.org/browse/CORE-19685)

## Proposed changes

- Add `CAutoComplete::m_bEditHasFocus` to watch focus.
- Update `m_bEditHasFocus` on `WM_SETFOCUS` and `WM_KILLFOCUS` messages on Edit window procedure.
- Don't open AutoComplete list when `m_bEditHasFocus` was `FALSE`.

## TODO

- [x] Do tests.

## Screenshots

BEFORE:
![before](https://github.com/reactos/reactos/assets/2107452/c6970e7d-ce98-41bf-93c0-e5710988a35c)

AFTER:
![after](https://github.com/reactos/reactos/assets/2107452/d57bcf72-edb4-4408-9b48-1bb2c731c55b)