### PR TITLE
[UXTHEME][NTUSER] Check class style for CS_NOCLOSE instead of window style

### DIFF
--- a/dll/win32/uxtheme/nonclient.c
+++ b/dll/win32/uxtheme/nonclient.c
@@ -297,7 +297,7 @@ ThemeDrawCaptionButton(PDRAW_CONTEXT pcontext,
     case CLOSEBUTTON:
         SysMenu = GetSystemMenu(pcontext->hWnd, FALSE);
         MenuState = GetMenuState(SysMenu, SC_CLOSE, MF_BYCOMMAND);
-        if (!(pcontext->wi.dwStyle & WS_SYSMENU) || (MenuState & (MF_GRAYED | MF_DISABLED)) || pcontext->wi.dwStyle & CS_NOCLOSE)
+        if (!(pcontext->wi.dwStyle & WS_SYSMENU) || (MenuState & (MF_GRAYED | MF_DISABLED)) || (GetClassLongPtrW(pcontext->hWnd, GCL_STYLE) & CS_NOCLOSE))
         {
             iStateId = (pcontext->Active ? BUTTON_DISABLED : BUTTON_INACTIVE_DISABLED);
         }

--- a/win32ss/user/ntuser/defwnd.c
+++ b/win32ss/user/ntuser/defwnd.c
@@ -920,7 +920,7 @@ IntDefWindowProc(
                 if (wParam == VK_F4) /* Try to close the window */
                 {
                    PWND top = UserGetAncestor(Wnd, GA_ROOT);
-                   if (!(top->style & CS_NOCLOSE))
+                   if (!(top->pcls->style & CS_NOCLOSE))
                       UserPostMessage(UserHMGetHandle(top), WM_SYSCOMMAND, SC_CLOSE, 0);
                 }
                 else if (wParam == VK_SNAPSHOT) // Alt-VK_SNAPSHOT?


### PR DESCRIPTION
## Purpose

Addendum to commit 71bed0f5f8 (PR #7123).

The problem in uxtheme was introduced in commit 685084b63c (as part
of a fix for CORE-17203), because it was a copy-paste and adaptation
of the corresponding code in `ntuser/nonclient.c!NC_DoButton()`.

The bugs in `win32ss/user/ntuser/defwnd.c` (and `nonclient.c` as fixed by
the previous commit) were in turn introduced from the migration of menu
and related code from user32 to win32k, see commit 6dfa71c487 (r68904).

JIRA issues: [CORE-11569](https://jira.reactos.org/browse/CORE-11569), [CORE-19684](https://jira.reactos.org/browse/CORE-19684)
