### PR TITLE
[NTGDI] FontLink: avoid invalid font name buffer freeing

### DIFF
--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -220,7 +220,8 @@ FontLink_Chain_Free(
     if (!FontLink_Chain_IsPopulated(pChain)) // The chain is not populated yet
         return;
 
-    ExFreePoolWithTag(pChain->pszzFontLink, TAG_FONT);
+    if (pChain->pszzFontLink)
+        ExFreePoolWithTag(pChain->pszzFontLink, TAG_FONT);
 
     while (!IsListEmpty(&pChain->FontLinkList))
     {


### PR DESCRIPTION
## Purpose

Don't free the linked font name if it's already NULL. Since it is allocated only once (when loading the font name from Registry), it should be freed only once too. All subsequent freeing attempts will result in invalid pool freeing. This fixes the 0xC2 BAD_POOL_CALLER bugcheck when trying to resize window (and draw more text) from soundcloud.com in K-Meleon 76.5.4 Goanna engine and when switching between channels (during redrawing the text) in DiscordMessenger v1.06 Beta. Addendum to 0f9e889736f01cef58fd50cd1f5558becbe882d5.

JIRA issue: [CORE-19681](https://jira.reactos.org/browse/CORE-19681)

## Result

K-Meleon 76.5.4 Goanna engine: the bug is not reproducible anymore:
![K-Meleon_fixed](https://github.com/reactos/reactos/assets/26385117/3d8cbbc1-cb36-4c1a-9c93-541063785bdc)
DiscordMessenger 1.06 Beta: the bug is not reproducible anymore:
![DiscordMessenger_fixed](https://github.com/reactos/reactos/assets/26385117/7b047f6a-da2b-4da2-b2a6-002564f4e9bc)