### PR TITLE
[FONTEXT] Fix CFontExt::GetDisplayNameOf for SHGDN_FORPARSING

### DIFF
--- a/dll/shellext/fontext/CFontExt.cpp
+++ b/dll/shellext/fontext/CFontExt.cpp
@@ -426,7 +426,7 @@ STDMETHODIMP CFontExt::GetDisplayNameOf(PCUITEMID_CHILD pidl, DWORD dwFlags, LPS
     if (!fontEntry)
         return E_FAIL;
 
-    if (dwFlags == SHGDN_FORPARSING)
+    if (dwFlags & SHGDN_FORPARSING)
     {
         CStringW File = g_FontCache->Filename(g_FontCache->Find(fontEntry), true);
         if (!File.IsEmpty())


### PR DESCRIPTION
## Purpose

Fix font enumeration and AutoComplete on `%WINDIR%\Fonts`.

JIRA issue: [CORE-9281](https://jira.reactos.org/browse/CORE-9281)

## Proposed changes

- Replace `if (dwFlags == SHGDN_FORPARSING)` with `if (dwFlags & SHGDN_FORPARSING)`.

## TODO

- [x] Do tests.

## Comparison

Win2k3:
![win2k3-windir-fonts](https://github.com/reactos/reactos/assets/2107452/0d8bcf9f-0473-4807-bf18-13c71733bd76)

BEFORE:
![before](https://github.com/reactos/reactos/assets/2107452/7f6268ca-e323-4401-ba26-e1a151a797e1)

AFTER:
![after](https://github.com/reactos/reactos/assets/2107452/034abe8e-b817-42b5-81ee-4821382e8f8f)