### PR TITLE
[BROWSEUI] Fix confusion of StrDupW and SHStrDupW

### DIFF
--- a/dll/win32/browseui/parsecmdline.cpp
+++ b/dll/win32/browseui/parsecmdline.cpp
@@ -402,7 +402,7 @@ SHExplorerParseCmdLine(_Out_ PEXPLORER_CMDLINE_PARSE_RESULTS pInfo)
                     // The path could not be parsed into an ID List,
                     // so pass it on as a plain string.
 
-                    PWSTR field = StrDupW(strField);
+                    PWSTR field = SHStrDupW(strField);
                     pInfo->strPath = field;
                     if (field)
                     {

--- a/dll/win32/browseui/parsecmdline.cpp
+++ b/dll/win32/browseui/parsecmdline.cpp
@@ -402,7 +402,8 @@ SHExplorerParseCmdLine(_Out_ PEXPLORER_CMDLINE_PARSE_RESULTS pInfo)
                     // The path could not be parsed into an ID List,
                     // so pass it on as a plain string.
 
-                    PWSTR field = SHStrDupW(strField);
+                    PWSTR field;
+                    SHStrDupW(strField, &field);
                     pInfo->strPath = field;
                     if (field)
                     {

--- a/dll/win32/browseui/shellfind/CFindFolder.cpp
+++ b/dll/win32/browseui/shellfind/CFindFolder.cpp
@@ -428,11 +428,15 @@ static UINT RecursiveFind(LPCWSTR lpPath, _SearchData *pSearchData)
                 FileNameMatch(FindData.cFileName, pSearchData) &&
                 AttribHiddenMatch(FindData.dwFileAttributes, pSearchData))
             {
-                PostMessageW(pSearchData->hwnd, WM_SEARCH_ADD_RESULT, 0, (LPARAM)SHStrDupW(szPath));
+                LPWSTR pszPathDup;
+                SHStrDupW(szPath, &pszPathDup);
+                PostMessageW(pSearchData->hwnd, WM_SEARCH_ADD_RESULT, 0, (LPARAM)pszPathDup);
                 uTotalFound++;
             }
             status.Format(IDS_SEARCH_FOLDER, FindData.cFileName);
-            PostMessageW(pSearchData->hwnd, WM_SEARCH_UPDATE_STATUS, 0, (LPARAM)SHStrDupW(status.GetBuffer()));
+            LPWSTR pszStatusDup;
+            SHStrDupW(status.GetBuffer(), &pszStatusDup);
+            PostMessageW(pSearchData->hwnd, WM_SEARCH_UPDATE_STATUS, 0, (LPARAM)pszStatusDup);
 
             uTotalFound += RecursiveFind(szPath, pSearchData);
         }
@@ -441,7 +445,9 @@ static UINT RecursiveFind(LPCWSTR lpPath, _SearchData *pSearchData)
                 && ContentsMatch(szPath, pSearchData))
         {
             uTotalFound++;
-            PostMessageW(pSearchData->hwnd, WM_SEARCH_ADD_RESULT, 0, (LPARAM)SHStrDupW(szPath));
+            LPWSTR pszPathDup;
+            SHStrDupW(szPath, &pszPathDup);
+            PostMessageW(pSearchData->hwnd, WM_SEARCH_ADD_RESULT, 0, (LPARAM)pszPathDup);
         }
     }
 
@@ -465,7 +471,9 @@ DWORD WINAPI CFindFolder::SearchThreadProc(LPVOID lpParameter)
 
     CStringW status;
     status.Format(IDS_SEARCH_FILES_FOUND, uTotalFound);
-    ::PostMessageW(data->hwnd, WM_SEARCH_UPDATE_STATUS, 0, (LPARAM)SHStrDupW(status.GetBuffer()));
+    LPWSTR pszStatusDup;
+    SHStrDupW(status.GetBuffer(), &pszStatusDup);
+    ::PostMessageW(data->hwnd, WM_SEARCH_UPDATE_STATUS, 0, (LPARAM)pszStatusDup);
     ::SendMessageW(data->hwnd, WM_SEARCH_STOP, 0, 0);
 
     CloseHandle(data->hStopEvent);

--- a/dll/win32/browseui/shellfind/CFindFolder.cpp
+++ b/dll/win32/browseui/shellfind/CFindFolder.cpp
@@ -428,11 +428,11 @@ static UINT RecursiveFind(LPCWSTR lpPath, _SearchData *pSearchData)
                 FileNameMatch(FindData.cFileName, pSearchData) &&
                 AttribHiddenMatch(FindData.dwFileAttributes, pSearchData))
             {
-                PostMessageW(pSearchData->hwnd, WM_SEARCH_ADD_RESULT, 0, (LPARAM) StrDupW(szPath));
+                PostMessageW(pSearchData->hwnd, WM_SEARCH_ADD_RESULT, 0, (LPARAM)SHStrDupW(szPath));
                 uTotalFound++;
             }
             status.Format(IDS_SEARCH_FOLDER, FindData.cFileName);
-            PostMessageW(pSearchData->hwnd, WM_SEARCH_UPDATE_STATUS, 0, (LPARAM) StrDupW(status.GetBuffer()));
+            PostMessageW(pSearchData->hwnd, WM_SEARCH_UPDATE_STATUS, 0, (LPARAM)SHStrDupW(status.GetBuffer()));
 
             uTotalFound += RecursiveFind(szPath, pSearchData);
         }
@@ -441,7 +441,7 @@ static UINT RecursiveFind(LPCWSTR lpPath, _SearchData *pSearchData)
                 && ContentsMatch(szPath, pSearchData))
         {
             uTotalFound++;
-            PostMessageW(pSearchData->hwnd, WM_SEARCH_ADD_RESULT, 0, (LPARAM) StrDupW(szPath));
+            PostMessageW(pSearchData->hwnd, WM_SEARCH_ADD_RESULT, 0, (LPARAM)SHStrDupW(szPath));
         }
     }
 
@@ -465,7 +465,7 @@ DWORD WINAPI CFindFolder::SearchThreadProc(LPVOID lpParameter)
 
     CStringW status;
     status.Format(IDS_SEARCH_FILES_FOUND, uTotalFound);
-    ::PostMessageW(data->hwnd, WM_SEARCH_UPDATE_STATUS, 0, (LPARAM) StrDupW(status.GetBuffer()));
+    ::PostMessageW(data->hwnd, WM_SEARCH_UPDATE_STATUS, 0, (LPARAM)SHStrDupW(status.GetBuffer()));
     ::SendMessageW(data->hwnd, WM_SEARCH_STOP, 0, 0);
 
     CloseHandle(data->hStopEvent);


### PR DESCRIPTION
## Purpose

Fix memory leaks. `SHStrDupW` uses `CoTaskMemAlloc`. `StrDupW` uses `LocalAlloc`. They are different.

JIRA issue: N/A

## Proposed changes

- Use `SHStrDupW` instead of `StrDupW`.