### PR TITLE
[APPHELP] Fix MAX_GUID_STRING_LEN define; use it for one buffer

### DIFF
--- a/dll/appcompat/apphelp/apphelp.c
+++ b/dll/appcompat/apphelp/apphelp.c
@@ -26,7 +26,8 @@ const UNICODE_STRING InstalledSDBKeyName = RTL_CONSTANT_STRING(L"\\Registry\\Mac
 /* from dpfilter.h */
 #define DPFLTR_APPCOMPAT_ID 123
 
-#define MAX_GUID_STRING_LEN     sizeof("{12345678-1234-1234-0123-456789abcdef}")
+#define MAX_GUID_STRING_LEN   RTL_NUMBER_OF("{12345678-1234-1234-0123-456789abcdef}")
+C_ASSERT(MAX_GUID_STRING_LEN == 39); // See psdk/cfgmgr32.h
 
 #ifndef NT_SUCCESS
 #define NT_SUCCESS(StatCode)  ((NTSTATUS)(StatCode) >= 0)
@@ -405,7 +406,7 @@ BOOL WINAPI SdbRegisterDatabase(
  */
 BOOL WINAPI SdbUnregisterDatabase(_In_ const GUID *pguidDB)
 {
-    WCHAR KeyBuffer[MAX_PATH], GuidBuffer[50];
+    WCHAR KeyBuffer[MAX_PATH], GuidBuffer[MAX_GUID_STRING_LEN];
     UNICODE_STRING KeyName;
     ACCESS_MASK KeyAccess;
     OBJECT_ATTRIBUTES ObjectKey = RTL_INIT_OBJECT_ATTRIBUTES(&KeyName, OBJ_CASE_INSENSITIVE);

--- a/dll/appcompat/apphelp/sdbapi.c
+++ b/dll/appcompat/apphelp/sdbapi.c
@@ -414,7 +414,7 @@ BOOL WINAPI SdbGUIDToString(CONST GUID *Guid, PWSTR GuidString, SIZE_T Length)
     UNICODE_STRING GuidString_u;
     if (NT_SUCCESS(RtlStringFromGUID(Guid, &GuidString_u)))
     {
-        HRESULT hr = StringCchCopyNW(GuidString, Length, GuidString_u.Buffer, GuidString_u.Length / 2);
+        HRESULT hr = StringCchCopyNW(GuidString, Length, GuidString_u.Buffer, GuidString_u.Length / sizeof(WCHAR));
         RtlFreeUnicodeString(&GuidString_u);
         return SUCCEEDED(hr);
     }


### PR DESCRIPTION
## Purpose

- Fix MAX_GUID_STRING_LEN define; use it for one buffer
- SdbGUIDToString(): use sizeof(WCHAR) instead of '2'
