### PR TITLE
[NTUSER] Fix region updating in IntScrollWindowEx() for Abiword

### DIFF
--- a/win32ss/user/ntuser/painting.c
+++ b/win32ss/user/ntuser/painting.c
@@ -938,8 +938,6 @@ co_UserRedrawWindow(
           {
              REGION_bOffsetRgn(TmpRgn, Window->rcClient.left, Window->rcClient.top);
           }
-        
-          REGION_SetRectRgn(TmpRgn, Window->rcClient.left, Window->rcClient.top, Window->rcClient.right, Window->rcClient.bottom);
       }
       else
       {

--- a/win32ss/user/ntuser/painting.c
+++ b/win32ss/user/ntuser/painting.c
@@ -938,8 +938,8 @@ co_UserRedrawWindow(
           {
              REGION_bOffsetRgn(TmpRgn, Window->rcClient.left, Window->rcClient.top);
           }
-		  
-		  REGION_SetRectRgn(TmpRgn, Window->rcClient.left, Window->rcClient.top, Window->rcClient.right, Window->rcClient.bottom);
+        
+          REGION_SetRectRgn(TmpRgn, Window->rcClient.left, Window->rcClient.top, Window->rcClient.right, Window->rcClient.bottom);
       }
       else
       {

--- a/win32ss/user/ntuser/painting.c
+++ b/win32ss/user/ntuser/painting.c
@@ -938,6 +938,8 @@ co_UserRedrawWindow(
           {
              REGION_bOffsetRgn(TmpRgn, Window->rcClient.left, Window->rcClient.top);
           }
+		  
+		  REGION_SetRectRgn(TmpRgn, Window->rcClient.left, Window->rcClient.top, Window->rcClient.right, Window->rcClient.bottom);
       }
       else
       {

--- a/win32ss/user/ntuser/scrollex.c
+++ b/win32ss/user/ntuser/scrollex.c
@@ -409,16 +409,15 @@ IntScrollWindowEx(
 
    if (flags & (SW_INVALIDATE | SW_ERASE))
    {
-      PREGION RgnClip = IntSysCreateRectpRgnIndirect(&rcClip);
-      if (RgnClip)
-      {
-          co_UserRedrawWindow( Window,
+      co_UserRedrawWindow( Window,
                            NULL,
-                           RgnClip,
+                           RgnUpdate,
                            rdw_flags |                                    /*    HACK    */
                           ((flags & SW_SCROLLCHILDREN) ? RDW_ALLCHILDREN : RDW_NOCHILDREN) );
-          REGION_Delete(RgnClip);
-      }
+
+      PREGION RgnClip = IntSysCreateRectpRgnIndirect(&rcClip);
+      IntInvalidateWindows(Window, RgnClip, rdw_flags);
+      REGION_Delete(RgnClip);
    }
 
    if (hwndCaret && (CaretWnd = UserGetWindowObject(hwndCaret)))

--- a/win32ss/user/ntuser/scrollex.c
+++ b/win32ss/user/ntuser/scrollex.c
@@ -409,11 +409,16 @@ IntScrollWindowEx(
 
    if (flags & (SW_INVALIDATE | SW_ERASE))
    {
-      co_UserRedrawWindow( Window,
+      PREGION RgnClip = IntSysCreateRectpRgnIndirect(&rcClip);
+      if (RgnClip)
+      {
+          co_UserRedrawWindow( Window,
                            NULL,
-                           RgnUpdate,
+                           RgnClip,
                            rdw_flags |                                    /*    HACK    */
                           ((flags & SW_SCROLLCHILDREN) ? RDW_ALLCHILDREN : RDW_NOCHILDREN) );
+          REGION_Delete(RgnClip);
+      }
    }
 
    if (hwndCaret && (CaretWnd = UserGetWindowObject(hwndCaret)))

--- a/win32ss/user/ntuser/scrollex.c
+++ b/win32ss/user/ntuser/scrollex.c
@@ -414,10 +414,6 @@ IntScrollWindowEx(
                            RgnUpdate,
                            rdw_flags |                                    /*    HACK    */
                           ((flags & SW_SCROLLCHILDREN) ? RDW_ALLCHILDREN : RDW_NOCHILDREN) );
-
-      PREGION RgnClip = IntSysCreateRectpRgnIndirect(&rcClip);
-      IntInvalidateWindows(Window, RgnClip, rdw_flags);
-      REGION_Delete(RgnClip);
    }
 
    if (hwndCaret && (CaretWnd = UserGetWindowObject(hwndCaret)))

--- a/win32ss/user/ntuser/scrollex.c
+++ b/win32ss/user/ntuser/scrollex.c
@@ -414,6 +414,10 @@ IntScrollWindowEx(
                            RgnUpdate,
                            rdw_flags |                                    /*    HACK    */
                           ((flags & SW_SCROLLCHILDREN) ? RDW_ALLCHILDREN : RDW_NOCHILDREN) );
+
+      PREGION RgnClip = IntSysCreateRectpRgnIndirect(&rcClip);
+      IntInvalidateWindows(Window, RgnClip, rdw_flags);
+      REGION_Delete(RgnClip);
    }
 
    if (hwndCaret && (CaretWnd = UserGetWindowObject(hwndCaret)))

--- a/win32ss/user/ntuser/vis.c
+++ b/win32ss/user/ntuser/vis.c
@@ -148,6 +148,7 @@ co_VIS_WindowLayoutChanged(
 {
    PWND Parent;
    USER_REFERENCE_ENTRY Ref;
+   int rdw_flags;
 
    ASSERT_REFS_CO(Wnd);
 
@@ -164,13 +165,17 @@ co_VIS_WindowLayoutChanged(
                          Wnd->rcWindow.left - Parent->rcClient.left,
                          Wnd->rcWindow.top - Parent->rcClient.top);
 
-       UserRefObjectCo(Parent, &Ref);
-       co_UserRedrawWindow(Parent, NULL, TempRgn,
-                           RDW_FRAME | RDW_ERASE | RDW_INVALIDATE |
-                           RDW_ALLCHILDREN);
+       rdw_flags = RDW_FRAME | RDW_ERASE | RDW_INVALIDATE | RDW_ALLCHILDREN;
+      
+       UserRefObjectCo(Parent, &Ref);      
+       co_UserRedrawWindow(Parent, NULL, TempRgn, rdw_flags);
        UserDerefObjectCo(Parent);
 
        REGION_Delete(TempRgn);
+      
+       PREGION RgnClip = IntSysCreateRectpRgnIndirect(&Parent->rcClient);
+       IntInvalidateWindows(Parent, RgnClip, rdw_flags);
+       REGION_Delete(RgnClip);
    }
 }
 


### PR DESCRIPTION
## Purpose

I found out that the problem with redrawing in Abiword is in the `IntScrollWindowEx()` function. It should update the window part after scrolling. Ideally scroll part of the graphic and redraw the missing piece. Apparently the function also sets the area to be redrawn in the future.
And at least that was the problem after running this function, most of the window stopped updating(when typing or cursor blinking) because the area to update was set to only the missing piece of graphics. 
In this patch I set the redraw area to the whole region, instead of just that region.
I'm not sure exactly how the code is supposed to work, and whether this is unnecessarily rendering an already rendered region. However, this solves the Abiword problem.
And in the future, this part will need to be revised anyway - analyze all the variations of behavior in Win, add regression tests (ideally on the graphical part), etc. Unfortunately, I don't have enough experience to do it right now.

JIRA issue: [CORE-13149](https://jira.reactos.org/browse/CORE-13149)

## Proposed changes

The `RgnUpdate` area was originally sent to the `co_UserRedrawWindow()` function - that is, the part of the rendered window that needs to be filled in after descrolling. I have replaced this with the entire area for drawing the window (`RgnClip`).

## TODO

