### PR TITLE
[SHELL32] Don't add the file to the parameters if the registry command did not ask for a file

### DIFF
--- a/dll/win32/shell32/CDefaultContextMenu.cpp
+++ b/dll/win32/shell32/CDefaultContextMenu.cpp
@@ -1302,8 +1302,7 @@ CDefaultContextMenu::TryToBrowse(
 HRESULT
 CDefaultContextMenu::InvokePidl(LPCMINVOKECOMMANDINFOEX lpcmi, LPCITEMIDLIST pidl, PStaticShellEntry pEntry)
 {
-    BOOL unicode = lpcmi->cbSize >= FIELD_OFFSET(CMINVOKECOMMANDINFOEX, ptInvoke) &&
-                   (lpcmi->fMask & CMIC_MASK_UNICODE);
+    const BOOL unicode = IsUnicode(*lpcmi);
 
     LPITEMIDLIST pidlFull = ILCombine(m_pidlFolder, pidl);
     if (pidlFull == NULL)
@@ -1327,7 +1326,7 @@ CDefaultContextMenu::InvokePidl(LPCMINVOKECOMMANDINFOEX lpcmi, LPCITEMIDLIST pid
     sei.hIcon = lpcmi->hIcon;
     sei.lpDirectory = wszDir;
 
-    if (IsUnicode(*lpcmi) && !StrIsNullOrEmpty(lpcmi->lpDirectoryW))
+    if (unicode && !StrIsNullOrEmpty(lpcmi->lpDirectoryW))
     {
         sei.lpDirectory = lpcmi->lpDirectoryW;
     }

--- a/dll/win32/shell32/CShellLink.cpp
+++ b/dll/win32/shell32/CShellLink.cpp
@@ -2592,8 +2592,7 @@ HRESULT STDMETHODCALLTYPE CShellLink::InvokeCommand(LPCMINVOKECOMMANDINFO lpici)
 
 HRESULT CShellLink::DoOpen(LPCMINVOKECOMMANDINFO lpici)
 {
-    BOOL unicode = lpici->cbSize >= FIELD_OFFSET(CMINVOKECOMMANDINFOEX, ptInvoke) &&
-                   (lpici->fMask & CMIC_MASK_UNICODE);
+    const BOOL unicode = IsUnicode(*lpici);
 
     CStringW args;
     if (m_sArgs)

--- a/dll/win32/shell32/precomp.h
+++ b/dll/win32/shell32/precomp.h
@@ -163,6 +163,7 @@ static inline UINT SeeFlagsToCmicFlags(UINT flags)
     return flags & SEE_CMIC_COMMON_FLAGS;
 }
 
+
 // CStubWindow32 --- The owner window of file property sheets.
 // This window hides taskbar button of property sheet.
 class CStubWindow32 : public CWindowImpl<CStubWindow32>

--- a/dll/win32/shell32/precomp.h
+++ b/dll/win32/shell32/precomp.h
@@ -155,6 +155,14 @@ UINT
 GetDfmCmd(_In_ IContextMenu *pCM, _In_ LPCSTR verba);
 #define SHELL_ExecuteControlPanelCPL(hwnd, cpl) SHRunControlPanel((cpl), (hwnd))
 
+#define CmicFlagsToSeeFlags(flags)  ((flags) & SEE_CMIC_COMMON_FLAGS)
+static inline UINT SeeFlagsToCmicFlags(UINT flags)
+{
+    if (flags & SEE_MASK_CLASSNAME)
+        flags &= ~(SEE_MASK_HASLINKNAME | SEE_MASK_HASTITLE);
+    return flags & SEE_CMIC_COMMON_FLAGS;
+}
+
 // CStubWindow32 --- The owner window of file property sheets.
 // This window hides taskbar button of property sheet.
 class CStubWindow32 : public CWindowImpl<CStubWindow32>

--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -1568,13 +1568,10 @@ static HRESULT ShellExecute_ContextMenuVerb(LPSHELLEXECUTEINFOW sei)
     ici.hwnd = sei->hwnd;
     ici.lpParameters = parameters;
     ici.lpParametersW = sei->lpParameters;
-    if ((sei->fMask & (SEE_MASK_HASLINKNAME | SEE_MASK_CLASSNAME)) == SEE_MASK_HASLINKNAME)
-    {
-        ici.fMask |= CMIC_MASK_HASLINKNAME;
-        ici.lpTitleW = sei->lpClass;
-    }
     ici.dwHotKey = sei->dwHotKey;
     ici.hIcon = sei->hIcon;
+    if (ici.fMask & (CMIC_MASK_HASLINKNAME | CMIC_MASK_HASTITLE))
+        ici.lpTitleW = sei->lpClass;
 
     enum { idFirst = 1, idLast = 0x7fff };
     HMENU hMenu = CreatePopupMenu();

--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -1558,7 +1558,8 @@ static HRESULT ShellExecute_ContextMenuVerb(LPSHELLEXECUTEINFOW sei)
     __SHCloneStrWtoA(&parameters, sei->lpParameters);
 
     BOOL fDefault = StrIsNullOrEmpty(sei->lpVerb);
-    CMINVOKECOMMANDINFOEX ici = { sizeof(ici), SeeFlagsToCmicFlags(sei->fMask) | CMIC_MASK_UNICODE };
+    CMINVOKECOMMANDINFOEX ici = { sizeof(ici) };
+    ici.fMask = SeeFlagsToCmicFlags(sei->fMask) | CMIC_MASK_UNICODE;
     ici.nShow = sei->nShow;
     if (!fDefault)
     {

--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -1557,7 +1557,7 @@ static HRESULT ShellExecute_ContextMenuVerb(LPSHELLEXECUTEINFOW sei)
     __SHCloneStrWtoA(&verb, sei->lpVerb);
     __SHCloneStrWtoA(&parameters, sei->lpParameters);
 
-    BOOL fDefault = !sei->lpVerb || !sei->lpVerb[0];
+    BOOL fDefault = StrIsNullOrEmpty(sei->lpVerb);
     CMINVOKECOMMANDINFOEX ici = { sizeof(ici), SeeFlagsToCmicFlags(sei->fMask) | CMIC_MASK_UNICODE };
     ici.nShow = sei->nShow;
     if (!fDefault)

--- a/sdk/include/reactos/shellutils.h
+++ b/sdk/include/reactos/shellutils.h
@@ -633,6 +633,17 @@ static inline PCUIDLIST_RELATIVE HIDA_GetPIDLItem(CIDA const* pida, SIZE_T i)
 
 #ifdef __cplusplus
 
+static inline bool IsUnicode(const CMINVOKECOMMANDINFOEX &ici)
+{
+    const UINT minsize = FIELD_OFFSET(CMINVOKECOMMANDINFOEX, ptInvoke);
+    return (ici.fMask & CMIC_MASK_UNICODE) && ici.cbSize >= minsize;
+}
+
+static inline bool IsUnicode(const CMINVOKECOMMANDINFO &ici)
+{
+    return IsUnicode(*(CMINVOKECOMMANDINFOEX*)&ici);
+}
+
 DECLSPEC_SELECTANY CLIPFORMAT g_cfHIDA = NULL;
 DECLSPEC_SELECTANY CLIPFORMAT g_cfShellIdListOffsets = NULL;
 
@@ -788,17 +799,6 @@ DataObject_SetOffset(IDataObject* pDataObject, POINT* point)
     }
 
     return DataObject_SetData(pDataObject, g_cfShellIdListOffsets, point, sizeof(point[0]));
-}
-
-static inline bool IsUnicode(CMINVOKECOMMANDINFOEX &ici)
-{
-    const UINT minsize = FIELD_OFFSET(CMINVOKECOMMANDINFOEX, ptInvoke);
-    return (ici.fMask & CMIC_MASK_UNICODE) && ici.cbSize >= minsize;
-}
-
-static inline bool IsUnicode(CMINVOKECOMMANDINFO &ici)
-{
-    return IsUnicode(*(CMINVOKECOMMANDINFOEX*)&ici);
 }
 
 #endif // __cplusplus

--- a/sdk/include/reactos/shellutils.h
+++ b/sdk/include/reactos/shellutils.h
@@ -633,6 +633,7 @@ static inline PCUIDLIST_RELATIVE HIDA_GetPIDLItem(CIDA const* pida, SIZE_T i)
 
 #ifdef __cplusplus
 
+#ifdef CMIC_MASK_UNICODE
 static inline bool IsUnicode(const CMINVOKECOMMANDINFOEX &ici)
 {
     const UINT minsize = FIELD_OFFSET(CMINVOKECOMMANDINFOEX, ptInvoke);
@@ -643,6 +644,7 @@ static inline bool IsUnicode(const CMINVOKECOMMANDINFO &ici)
 {
     return IsUnicode(*(CMINVOKECOMMANDINFOEX*)&ici);
 }
+#endif // CMIC_MASK_UNICODE
 
 DECLSPEC_SELECTANY CLIPFORMAT g_cfHIDA = NULL;
 DECLSPEC_SELECTANY CLIPFORMAT g_cfShellIdListOffsets = NULL;

--- a/sdk/include/reactos/shellutils.h
+++ b/sdk/include/reactos/shellutils.h
@@ -633,7 +633,7 @@ static inline PCUIDLIST_RELATIVE HIDA_GetPIDLItem(CIDA const* pida, SIZE_T i)
 
 #ifdef __cplusplus
 
-#ifdef CMIC_MASK_UNICODE
+#if defined(CMIC_MASK_UNICODE) && defined(SEE_MASK_UNICODE)
 static inline bool IsUnicode(const CMINVOKECOMMANDINFOEX &ici)
 {
     const UINT minsize = FIELD_OFFSET(CMINVOKECOMMANDINFOEX, ptInvoke);

--- a/sdk/include/reactos/shellutils.h
+++ b/sdk/include/reactos/shellutils.h
@@ -609,6 +609,12 @@ struct CCoInit
 #define S_GREATERTHAN S_FALSE
 #define MAKE_COMPARE_HRESULT(x) ((x)>0 ? S_GREATERTHAN : ((x)<0 ? S_LESSTHAN : S_EQUAL))
 
+#define SEE_CMIC_COMMON_BASICFLAGS (SEE_MASK_NOASYNC | SEE_MASK_ASYNCOK | SEE_MASK_UNICODE | \
+                                    SEE_MASK_NO_CONSOLE | SEE_MASK_FLAG_NO_UI | SEE_MASK_FLAG_SEPVDM | \
+                                    SEE_MASK_FLAG_LOG_USAGE | SEE_MASK_NOZONECHECKS)
+#define SEE_CMIC_COMMON_FLAGS      (SEE_CMIC_COMMON_BASICFLAGS | SEE_MASK_HOTKEY | SEE_MASK_ICON | \
+                                    SEE_MASK_HASLINKNAME | SEE_MASK_HASTITLE)
+
 static inline BOOL ILIsSingle(LPCITEMIDLIST pidl)
 {
     return pidl == ILFindLastID(pidl);
@@ -784,7 +790,18 @@ DataObject_SetOffset(IDataObject* pDataObject, POINT* point)
     return DataObject_SetData(pDataObject, g_cfShellIdListOffsets, point, sizeof(point[0]));
 }
 
-#endif
+static inline bool IsUnicode(CMINVOKECOMMANDINFOEX &ici)
+{
+    const UINT minsize = FIELD_OFFSET(CMINVOKECOMMANDINFOEX, ptInvoke);
+    return (ici.fMask & CMIC_MASK_UNICODE) && ici.cbSize >= minsize;
+}
+
+static inline bool IsUnicode(CMINVOKECOMMANDINFO &ici)
+{
+    return IsUnicode(*(CMINVOKECOMMANDINFOEX*)&ici);
+}
+
+#endif // __cplusplus
 
 #ifdef __cplusplus
 struct SHELL_GetSettingImpl


### PR DESCRIPTION
Bugs fixed:

- fDefault detection of default verb is flawed because it checks the `ici` struct after conversion instead of the source `sei` struct.
- The command to execute should not have the filename appended just because %1 nor %L did not appear in the registry command template.

This is a draft simply because I'd like some feedback on the removal of the filename. The existing code is not correct in the cases I have tested but it has been here and in wine for a long time.