### PR TITLE
[REGEDIT] Handle Ctrl+Backspace in AddressBar

### DIFF
--- a/base/applications/regedit/childwnd.c
+++ b/base/applications/regedit/childwnd.c
@@ -425,8 +425,8 @@ LRESULT CALLBACK ChildWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lPa
 
         if (SUCCEEDED(CoCreateInstance(&CLSID_AutoComplete, NULL, CLSCTX_INPROC_SERVER, &IID_IAutoComplete, (void**)&pAutoComplete)))
         {
-            pAutoComplete->lpVtbl->Init(pAutoComplete, g_pChildWnd->hAddressBarWnd, (IUnknown*)&g_DummyEnumStrings, NULL, NULL);
-            pAutoComplete->lpVtbl->Release(pAutoComplete);
+            IAutoComplete_Init(pAutoComplete, g_pChildWnd->hAddressBarWnd, (IUnknown*)&g_DummyEnumStrings, NULL, NULL);
+            IAutoComplete_Release(pAutoComplete);
         }
 
         GetClientRect(hWnd, &rc);

--- a/base/applications/regedit/main.c
+++ b/base/applications/regedit/main.c
@@ -216,7 +216,7 @@ int WINAPI wWinMain(HINSTANCE hInstance,
 
     UNREFERENCED_PARAMETER(hPrevInstance);
 
-    OleInitialize(0);
+    OleInitialize(NULL);
 
     /* Initialize global strings */
     LoadStringW(hInstance, IDS_APP_TITLE, szTitle, ARRAY_SIZE(szTitle));

--- a/base/applications/regedit/main.c
+++ b/base/applications/regedit/main.c
@@ -182,60 +182,7 @@ static BOOL InLabelEdit(HWND hWnd, UINT Msg)
     return hEdit && IsWindowVisible(hEdit);
 }
 
-static BOOL IsAddressBarSpecialChar(WCHAR c)
-{
-    return c && c <= 127 && !iswalnum(c);
-}
-
-static BOOL HandleAddressBarMessage(PMSG msg)
-{
-    BOOL handled = FALSE, ctrl = FALSE;
-    if (msg->message != WM_KEYDOWN || msg->hwnd != g_pChildWnd->hAddressBarWnd)
-        return handled;
-
-    ctrl = GetKeyState(VK_CONTROL) < 0;
-    if (ctrl && msg->wParam == VK_BACK)
-    {
-        LPWSTR text;
-        UINT cch = GetWindowTextLengthW(msg->hwnd);
-        UINT iSelStart = 0, iSelEnd;
-        SendMessageW(msg->hwnd, EM_GETSEL, (WPARAM)&iSelStart, (LPARAM)&iSelEnd);
-        text = (cch && iSelStart && iSelStart == iSelEnd) ? malloc(++cch * sizeof(*text)) : NULL;
-        if (text)
-        {
-            if (GetWindowTextW(msg->hwnd, text, cch))
-            {
-                LPWSTR any = NULL, start, end;
-                start = end = &text[iSelStart];
-
-                /* Delete special and/or normal characters backwards from the caret */
-                if (IsAddressBarSpecialChar(start[-1]))
-                {
-                    --start;
-                    while (start > text && IsAddressBarSpecialChar(*start))
-                        --start;
-                }
-                while (start > text && !IsAddressBarSpecialChar(*start))
-                        any = --start;
-                /* "undelete" the character we just skipped (unless it's the first character) */
-                start += any != NULL && start > text;
-
-                if (start != end)
-                {
-                    MoveMemory(start, end, (wcslen(end) + 1) * sizeof(*end));
-                    SetWindowText(msg->hwnd, text);
-                    SendMessageW(msg->hwnd, EM_SETSEL, start - text, start - text);
-                    handled = TRUE;
-                }
-            }
-            free(text);
-        }
-    }
-
-    return handled;
-}
-
-BOOL TranslateChildTabMessage(PMSG msg)
+static BOOL TranslateChildTabMessage(PMSG msg)
 {
     if (msg->message != WM_KEYDOWN) return FALSE;
     if (msg->wParam != VK_TAB) return FALSE;
@@ -248,8 +195,6 @@ static BOOL TranslateRegeditAccelerator(HWND hWnd, HACCEL hAccTable, PMSG msg)
 {
     if (msg->message == WM_KEYDOWN)
     {
-        if (HandleAddressBarMessage(msg))
-            return TRUE;
         if (msg->wParam == VK_DELETE)
         {
             if (g_pChildWnd->hAddressBarWnd == msg->hwnd)
@@ -270,6 +215,8 @@ int WINAPI wWinMain(HINSTANCE hInstance,
     HACCEL hAccel;
 
     UNREFERENCED_PARAMETER(hPrevInstance);
+
+    OleInitialize(0);
 
     /* Initialize global strings */
     LoadStringW(hInstance, IDS_APP_TITLE, szTitle, ARRAY_SIZE(szTitle));

--- a/base/applications/regedit/regedit.h
+++ b/base/applications/regedit/regedit.h
@@ -1,6 +1,7 @@
 #ifndef _REGEDIT_H
 #define _REGEDIT_H
 
+#define COBJMACROS
 #define WIN32_LEAN_AND_MEAN     /* Exclude rarely-used stuff from Windows headers */
 #define WIN32_NO_STATUS
 #include <windows.h>


### PR DESCRIPTION
Handle <kbd>Ctrl</kbd><kbd>Backspace</kbd> in the AddressBar like Windows 10 by deleting spans of special and/or normal characters.

Notes:
- Also fixes a bug where <kbd>Del</kbd> does not work in the AddressBar nor during Tree/List label edit because it gets eaten by the accelerator.
- Removed the code that handles <kbd>Ctrl</kbd><kbd>A</kbd> in the AddressBar because the Edit control does this out of the box.