### PR TITLE
[EXPLORER] Execute RunOnce[Ex] before desktop is created

### DIFF
--- a/base/shell/explorer/explorer.cpp
+++ b/base/shell/explorer/explorer.cpp
@@ -169,7 +169,7 @@ StartWithDesktop(IN HINSTANCE hInstance)
         ProcessStartupItems();
         DoFinishStartupItems();
     }
-    ReleaseStartupMutex();
+    ReleaseStartupMutex(); // For ProcessRunOnceItems
 #endif
 
     if (Tray != NULL)

--- a/base/shell/explorer/explorer.cpp
+++ b/base/shell/explorer/explorer.cpp
@@ -154,6 +154,8 @@ StartWithDesktop(IN HINSTANCE hInstance)
     buttons to work right) */
     HideMinimizedWindows(TRUE);
 
+    ProcessRunOnceItems(); // Must be executed before the desktop is created
+
     HANDLE hShellDesktop = NULL;
     if (Tray != NULL)
         hShellDesktop = DesktopCreateWindow(Tray);
@@ -167,6 +169,7 @@ StartWithDesktop(IN HINSTANCE hInstance)
         ProcessStartupItems();
         DoFinishStartupItems();
     }
+    ReleaseStartupMutex();
 #endif
 
     if (Tray != NULL)

--- a/base/shell/explorer/precomp.h
+++ b/base/shell/explorer/precomp.h
@@ -255,6 +255,8 @@ HRESULT ShutdownShellServices(HDPA hdpa);
 BOOL DoStartStartupItems(ITrayWindow *Tray);
 INT ProcessStartupItems(VOID);
 BOOL DoFinishStartupItems(VOID);
+VOID ProcessRunOnceItems(VOID);
+VOID ReleaseStartupMutex(VOID);
 
 /*
  * trayprop.h

--- a/base/shell/explorer/precomp.h
+++ b/base/shell/explorer/precomp.h
@@ -252,11 +252,12 @@ HRESULT ShutdownShellServices(HDPA hdpa);
  * startup.cpp
  */
 
+VOID ReleaseStartupMutex();
+VOID ProcessRunOnceItems();
 BOOL DoStartStartupItems(ITrayWindow *Tray);
-INT ProcessStartupItems(VOID);
-BOOL DoFinishStartupItems(VOID);
-VOID ProcessRunOnceItems(VOID);
-VOID ReleaseStartupMutex(VOID);
+INT ProcessStartupItems(BOOL bRunOnce);
+static inline INT ProcessStartupItems() { return ProcessStartupItems(FALSE); }
+static inline VOID DoFinishStartupItems() { ReleaseStartupMutex(); }
 
 /*
  * trayprop.h

--- a/base/shell/explorer/startup.cpp
+++ b/base/shell/explorer/startup.cpp
@@ -510,12 +510,7 @@ INT ProcessStartupItems(BOOL bRunOnce)
     return res ? 0 : 101;
 }
 
-INT ProcessStartupItems(VOID)
-{
-    return ProcessStartupItems(FALSE);
-}
-
-VOID ReleaseStartupMutex(VOID)
+VOID ReleaseStartupMutex()
 {
     if (s_hStartupMutex)
     {
@@ -525,7 +520,7 @@ VOID ReleaseStartupMutex(VOID)
     }
 }
 
-static BOOL InitializeStartupMutex(VOID)
+static BOOL InitializeStartupMutex()
 {
     if (!bExplorerIsShell)
         return FALSE;
@@ -548,12 +543,6 @@ static BOOL InitializeStartupMutex(VOID)
         ReleaseStartupMutex();
         return FALSE;
     }
-    return TRUE;
-}
-
-BOOL DoFinishStartupItems(VOID)
-{
-    ReleaseStartupMutex();
     return TRUE;
 }
 
@@ -596,8 +585,8 @@ BOOL DoStartStartupItems(ITrayWindow *Tray)
     return TRUE;
 }
 
-VOID ProcessRunOnceItems(VOID)
+VOID ProcessRunOnceItems()
 {
-    if (IsUserAnAdmin() && InitializeStartupMutex())
+    if (bExplorerIsShell && IsUserAnAdmin() && InitializeStartupMutex())
         ProcessStartupItems(TRUE);
 }

--- a/base/shell/explorer/startup.cpp
+++ b/base/shell/explorer/startup.cpp
@@ -450,7 +450,7 @@ AutoStartupApplications(INT nCSIDL_Folder)
     return TRUE;
 }
 
-INT ProcessStartupItems(VOID)
+INT ProcessStartupItems(BOOL bRunOnce)
 {
     /* TODO: ProcessRunKeys already checks SM_CLEANBOOT -- items prefixed with * should probably run even in safe mode */
     BOOL bNormalBoot = GetSystemMetrics(SM_CLEANBOOT) == 0; /* Perform the operations that are performed every boot */
@@ -478,11 +478,16 @@ INT ProcessStartupItems(VOID)
      */
     res = TRUE;
 
-    if (res && bNormalBoot)
-        ProcessRunOnceEx(HKEY_LOCAL_MACHINE);
+    if (bRunOnce)
+    {
+        if (res && bNormalBoot)
+            ProcessRunOnceEx(HKEY_LOCAL_MACHINE);
 
-    if (res && (SHRestricted(REST_NOLOCALMACHINERUNONCE) == 0))
-        res = ProcessRunKeys(HKEY_LOCAL_MACHINE, L"RunOnce", TRUE, TRUE);
+        if (res && (SHRestricted(REST_NOLOCALMACHINERUNONCE) == 0))
+            res = ProcessRunKeys(HKEY_LOCAL_MACHINE, L"RunOnce", TRUE, TRUE);
+
+        return !res;
+    }
 
     if (res && bNormalBoot && (SHRestricted(REST_NOLOCALMACHINERUN) == 0))
         res = ProcessRunKeys(HKEY_LOCAL_MACHINE, L"Run", FALSE, FALSE);
@@ -505,7 +510,12 @@ INT ProcessStartupItems(VOID)
     return res ? 0 : 101;
 }
 
-BOOL DoFinishStartupItems(VOID)
+INT ProcessStartupItems(VOID)
+{
+    return ProcessStartupItems(FALSE);
+}
+
+VOID ReleaseStartupMutex(VOID)
 {
     if (s_hStartupMutex)
     {
@@ -513,13 +523,10 @@ BOOL DoFinishStartupItems(VOID)
         CloseHandle(s_hStartupMutex);
         s_hStartupMutex = NULL;
     }
-    return TRUE;
 }
 
-BOOL DoStartStartupItems(ITrayWindow *Tray)
+static BOOL InitializeStartupMutex(VOID)
 {
-    DWORD dwWait;
-
     if (!bExplorerIsShell)
         return FALSE;
 
@@ -532,15 +539,28 @@ BOOL DoStartStartupItems(ITrayWindow *Tray)
             return FALSE;
     }
 
-    dwWait = WaitForSingleObject(s_hStartupMutex, INFINITE);
+    DWORD dwWait = WaitForSingleObject(s_hStartupMutex, INFINITE);
     TRACE("dwWait: 0x%08lX\n", dwWait);
     if (dwWait != WAIT_OBJECT_0)
     {
         TRACE("LastError: %ld\n", GetLastError());
 
-        DoFinishStartupItems();
+        ReleaseStartupMutex();
         return FALSE;
     }
+    return TRUE;
+}
+
+BOOL DoFinishStartupItems(VOID)
+{
+    ReleaseStartupMutex();
+    return TRUE;
+}
+
+BOOL DoStartStartupItems(ITrayWindow *Tray)
+{
+    if (!bExplorerIsShell || !InitializeStartupMutex())
+        return FALSE;
 
     const DWORD dwWaitTotal = 3000;     // in milliseconds
     DWORD dwTick = GetTickCount();
@@ -574,4 +594,10 @@ BOOL DoStartStartupItems(ITrayWindow *Tray)
     }
 
     return TRUE;
+}
+
+VOID ProcessRunOnceItems(VOID)
+{
+    if (IsUserAnAdmin() && InitializeStartupMutex())
+        ProcessStartupItems(TRUE);
 }


### PR DESCRIPTION
Windows executes RunOnce[Ex] before creating the desktop. To verify, turn off the welcome screen (so you see what is going on) and add a RunOnce entry that executes `cmd.exe /C ping example.com`.

Notes:
- RunOnce[Ex] is [not executed by normal users](https://support.microsoft.com/en-us/topic/876472b8-238c-8302-eb9d-ae38226ee76d).
- Fixes JIRA issue [CORE-19501](https://jira.reactos.org/browse/CORE-19501) for the BootCD case. `iexplore.exe /RegServer` creates the icon entry in the registry and since creating the desktop happens after, the icon path is now available in the registry.
