### PR TITLE
[SHELL32] Don't update statusbar during drag operation

### DIFF
--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -2587,13 +2587,17 @@ LRESULT CDefView::OnNotify(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandl
             break;
         case LVN_ITEMCHANGED:
             TRACE("-- LVN_ITEMCHANGED %p\n", this);
-            OnStateChange(CDBOSC_SELCHANGE); // browser will get the IDataObject
-            if (!m_ScheduledStatusbarUpdate)
+            if ((lpnmlv->uOldState ^ lpnmlv->uNewState) & (LVIS_SELECTED | LVIS_FOCUSED))
             {
-                m_ScheduledStatusbarUpdate = true;
-                PostMessage(SHV_UPDATESTATUSBAR, 0, 0);
+                OnStateChange(CDBOSC_SELCHANGE); // browser will get the IDataObject
+                // FIXME: Use LVIS_DROPHILITED instead in drag_notify_subitem
+                if (!m_ScheduledStatusbarUpdate && (m_iDragOverItem == -1 || m_pCurDropTarget == NULL))
+                {
+                    m_ScheduledStatusbarUpdate = true;
+                    PostMessage(SHV_UPDATESTATUSBAR, 0, 0);
+                }
+                _DoFolderViewCB(SFVM_SELECTIONCHANGED, NULL/* FIXME */, NULL/* FIXME */);
             }
-            _DoFolderViewCB(SFVM_SELECTIONCHANGED, NULL/* FIXME */, NULL/* FIXME */);
             break;
         case LVN_BEGINDRAG:
         case LVN_BEGINRDRAG:


### PR DESCRIPTION
The statusbar should not be updated during drag operations.

There is still a problem with selection changes during drag&drop (sometimes leaves a folder selected on aborted drop) but that should be solved by using `LVIS_DROPHILITED` (I'll look into that after the comctl32 wine merge is completed).