### PR TITLE
[SHELL32] Don't use ShellExecute_ContextMenuVerb

### DIFF
--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -1678,25 +1678,25 @@ SHELL_InvokePidl(
     CComHeapPtr<char> pszParams;
     if (sei->lpParameters && sei->lpParameters[0])
     {
-        ici.lpParametersW = sei->lpParameters;
         __SHCloneStrWtoA(&pszParams, sei->lpParameters);
         ici.lpParameters = pszParams;
+        ici.lpParametersW = sei->lpParameters;
     }
 
     CComHeapPtr<char> pszDir;
     if (sei->lpDirectory && sei->lpDirectory[0])
     {
-        ici.lpDirectoryW = sei->lpDirectory;
         __SHCloneStrWtoA(&pszDir, sei->lpDirectory);
         ici.lpDirectory = pszDir;
+        ici.lpDirectoryW = sei->lpDirectory;
     }
 
     CComHeapPtr<char> pszVerb;
     if (sei->lpVerb && sei->lpVerb[0])
     {
-        ici.lpVerbW = sei->lpVerb;
         __SHCloneStrWtoA(&pszVerb, sei->lpVerb);
         ici.lpVerb = pszVerb;
+        ici.lpVerbW = sei->lpVerb;
     }
     else // The default verb?
     {
@@ -1715,6 +1715,7 @@ SHELL_InvokePidl(
             nDefaultID = idCmdFirst;
 
         ici.lpVerb = MAKEINTRESOURCEA(nDefaultID - idCmdFirst);
+        ici.lpVerbW = MAKEINTRESOURCEW(nDefaultID - idCmdFirst);
     }
 
     hr = pCM->InvokeCommand((CMINVOKECOMMANDINFO*)&ici);

--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -1676,25 +1676,25 @@ SHELL_InvokePidl(
 
     // Convert Unicode strings to ANSI
     CComHeapPtr<char> pszParams;
-    ici.lpParametersW = sei->lpParameters;
     if (sei->lpParameters && sei->lpParameters[0])
     {
+        ici.lpParametersW = sei->lpParameters;
         __SHCloneStrWtoA(&pszParams, sei->lpParameters);
         ici.lpParameters = pszParams;
     }
 
     CComHeapPtr<char> pszDir;
-    ici.lpDirectoryW = sei->lpDirectory;
     if (sei->lpDirectory && sei->lpDirectory[0])
     {
+        ici.lpDirectoryW = sei->lpDirectory;
         __SHCloneStrWtoA(&pszDir, sei->lpDirectory);
         ici.lpDirectory = pszDir;
     }
 
     CComHeapPtr<char> pszVerb;
-    ici.lpVerbW = sei->lpVerb;
     if (sei->lpVerb && sei->lpVerb[0])
     {
+        ici.lpVerbW = sei->lpVerb;
         __SHCloneStrWtoA(&pszVerb, sei->lpVerb);
         ici.lpVerb = pszVerb;
     }


### PR DESCRIPTION
## Purpose
Reduce and simplify code. Refactoring.
JIRA issue: [CORE-19688](https://jira.reactos.org/browse/CORE-19688)

## Proposed changes

- Delete `shellex_get_contextmenu` and `ShellExecute_ContextMenuVerb` helper functions.
- Enhance `SHELL_InvokePidl` helper function for directory and parameters.
- Use `SHELL_InvokePidl` instead of `ShellExecute_ContextMenuVerb`.

## TODO

- [x] Do small tests.
- [ ] Do big tests.