### PR TITLE
[SHELL32][SHELL32_APITEST] ShellExecute should accept invalid directory

### DIFF
--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -2012,8 +2012,7 @@ static BOOL SHELL_execute(LPSHELLEXECUTEINFOW sei, SHELL_ExecuteW32 execfunc)
         wszDir = dirBuffer;
     }
     // NOTE: ShellExecute should accept the invalid working directory for historical reason.
-    // NOTE: ".\\" is a special case.
-    if (!PathIsDirectoryW(wszDir) || lstrcmpiW(wszDir, L".\\") == 0)
+    if (!PathIsDirectoryW(wszDir))
     {
         INT iDrive = PathGetDriveNumberW(wszDir);
         if (iDrive >= 0)

--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -2011,8 +2011,8 @@ static BOOL SHELL_execute(LPSHELLEXECUTEINFOW sei, SHELL_ExecuteW32 execfunc)
         ::GetCurrentDirectoryW(_countof(dirBuffer), dirBuffer);
         wszDir = dirBuffer;
     }
-    // NOTE: ShellExecute should accept the invalid working directory
-    // NOTE: ".\\" is a special case
+    // NOTE: ShellExecute should accept the invalid working directory for historical reason.
+    // NOTE: ".\\" is a special case.
     if (!PathIsDirectoryW(wszDir) || lstrcmpiW(wszDir, L".\\") == 0)
     {
         INT iDrive = PathGetDriveNumberW(wszDir);

--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -2007,6 +2007,7 @@ static BOOL SHELL_execute(LPSHELLEXECUTEINFOW sei, SHELL_ExecuteW32 execfunc)
         }
     }
     // NOTE: ShellExecute should accept the invalid working directory
+    // NOTE: ".\\" is a special case
     if (!PathIsDirectoryW(wszDir) || lstrcmpiW(wszDir, L".\\") == 0)
     {
         INT iDrive = PathGetDriveNumberW(wszDir);

--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -1983,7 +1983,7 @@ static BOOL SHELL_execute(LPSHELLEXECUTEINFOW sei, SHELL_ExecuteW32 execfunc)
     else
         *wszParameters = L'\0';
 
-    // Get the working directory.
+    // Get the working directory
     WCHAR dirBuffer[MAX_PATH];
     LPWSTR wszDir = dirBuffer;
     ::GetCurrentDirectoryW(_countof(dirBuffer), dirBuffer);
@@ -2002,7 +2002,8 @@ static BOOL SHELL_execute(LPSHELLEXECUTEINFOW sei, SHELL_ExecuteW32 execfunc)
         else
         {
             __SHCloneStrW(&wszDirAlloc, sei_tmp.lpDirectory);
-            wszDir = wszDirAlloc;
+            if (wszDirAlloc)
+                wszDir = wszDirAlloc;
         }
     }
     // NOTE: ShellExecute should accept the invalid working directory

--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -1986,7 +1986,7 @@ static BOOL SHELL_execute(LPSHELLEXECUTEINFOW sei, SHELL_ExecuteW32 execfunc)
     // Get the working directory
     WCHAR dirBuffer[MAX_PATH];
     LPWSTR wszDir = dirBuffer;
-    ::GetCurrentDirectoryW(_countof(dirBuffer), dirBuffer);
+    wszDir[0] = UNICODE_NULL;
     CHeapPtr<WCHAR, CLocalAllocator> wszDirAlloc;
     if (sei_tmp.lpDirectory && *sei_tmp.lpDirectory)
     {
@@ -2005,6 +2005,11 @@ static BOOL SHELL_execute(LPSHELLEXECUTEINFOW sei, SHELL_ExecuteW32 execfunc)
             if (wszDirAlloc)
                 wszDir = wszDirAlloc;
         }
+    }
+    if (!wszDir[0])
+    {
+        ::GetCurrentDirectoryW(_countof(dirBuffer), dirBuffer);
+        wszDir = dirBuffer;
     }
     // NOTE: ShellExecute should accept the invalid working directory
     // NOTE: ".\\" is a special case

--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -1986,6 +1986,7 @@ static BOOL SHELL_execute(LPSHELLEXECUTEINFOW sei, SHELL_ExecuteW32 execfunc)
     // Get the working directory.
     WCHAR dirBuffer[MAX_PATH];
     LPWSTR wszDir = dirBuffer;
+    ::GetCurrentDirectoryW(_countof(dirBuffer), dirBuffer);
     CHeapPtr<WCHAR, CLocalAllocator> wszDirAlloc;
     if (sei_tmp.lpDirectory && *sei_tmp.lpDirectory)
     {
@@ -2004,22 +2005,19 @@ static BOOL SHELL_execute(LPSHELLEXECUTEINFOW sei, SHELL_ExecuteW32 execfunc)
             wszDir = wszDirAlloc;
         }
     }
-    else
-    {
-        ::GetCurrentDirectoryW(_countof(dirBuffer), dirBuffer);
-    }
-
-    // NOTE: ShellExecute should accept an invalid working directory
+    // NOTE: ShellExecute should accept the invalid working directory
     if (!PathIsDirectoryW(wszDir) || lstrcmpiW(wszDir, L".\\") == 0)
     {
         INT iDrive = PathGetDriveNumberW(wszDir);
         if (iDrive >= 0)
+        {
             PathStripToRootW(wszDir);
-    }
-    if (!PathIsDirectoryW(wszDir))
-    {
-        ::GetWindowsDirectoryW(dirBuffer, _countof(dirBuffer));
-        wszDir = dirBuffer;
+            if (!PathIsDirectoryW(wszDir))
+            {
+                ::GetWindowsDirectoryW(dirBuffer, _countof(dirBuffer));
+                wszDir = dirBuffer;
+            }
+        }
     }
 
     /* adjust string pointers to point to the new buffers */

--- a/modules/rostests/apitests/shell32/ShellExecuteEx.cpp
+++ b/modules/rostests/apitests/shell32/ShellExecuteEx.cpp
@@ -457,13 +457,10 @@ static void test_DoInvalidDir(void)
     sei.nShow = SW_SHOWNORMAL;
 
     // Test invalid path on sei.lpDirectory
-    WCHAR szInvalidPath[MAX_PATH];
-    GetWindowsDirectoryW(szInvalidPath, _countof(szInvalidPath));
-    PathAppendW(szInvalidPath, L"M:\\This is an invalid path\n");
+    WCHAR szInvalidPath[MAX_PATH] = L"M:\\This is an invalid path\n";
     sei.lpDirectory = szInvalidPath;
     ok_int(ShellExecuteExW(&sei), TRUE);
-    if (WaitForSingleObject(sei.hProcess, 5 * 1000) == WAIT_TIMEOUT)
-        TerminateProcess(sei.hProcess, -1);
+    WaitForSingleObject(sei.hProcess, 5 * 1000);
     GetExitCodeProcess(sei.hProcess, &dwExitCode);
     ok_long(dwExitCode, 0);
     CloseHandle(sei.hProcess);

--- a/modules/rostests/apitests/shell32/ShellExecuteEx.cpp
+++ b/modules/rostests/apitests/shell32/ShellExecuteEx.cpp
@@ -460,7 +460,7 @@ static void test_DoInvalidDir(void)
     WCHAR szInvalidPath[MAX_PATH] = L"M:\\This is an invalid path\n";
     sei.lpDirectory = szInvalidPath;
     ok_int(ShellExecuteExW(&sei), TRUE);
-    WaitForSingleObject(sei.hProcess, 5 * 1000);
+    WaitForSingleObject(sei.hProcess, 20 * 1000);
     GetExitCodeProcess(sei.hProcess, &dwExitCode);
     ok_long(dwExitCode, 0);
     CloseHandle(sei.hProcess);


### PR DESCRIPTION
## Purpose
The following program should successfully open notepad:
```c
#include <windows.h>
int main(void)
{
    ShellExecuteA(NULL, NULL, "notepad", NULL, "(An invalid directory)", SW_SHOWNORMAL);
}
```

JIRA issue: N/A

## Proposed changes

- Implement parsing `SHELLEXECUTEINFO.lpDirectory`.
- Enhance `ShellExecuteEx` testcase for invalid directory.

## TODO

- [x] Do tests.