### PR TITLE
[NTOS:KE] Clear NpxThread on rundown for SMP as well

### DIFF
--- a/ntoskrnl/include/internal/i386/ke.h
+++ b/ntoskrnl/include/internal/i386/ke.h
@@ -386,7 +386,6 @@ FORCEINLINE
 VOID
 KiRundownThread(IN PKTHREAD Thread)
 {
-#ifndef CONFIG_SMP
     /* Check if this is the NPX Thread */
     if (KeGetCurrentPrcb()->NpxThread == Thread)
     {
@@ -394,9 +393,6 @@ KiRundownThread(IN PKTHREAD Thread)
         KeGetCurrentPrcb()->NpxThread = NULL;
         Ke386FnInit();
     }
-#else
-    /* Nothing to do */
-#endif
 }
 
 CODE_SEG("INIT")


### PR DESCRIPTION
## Purpose

clear NpxThread on rundown for SMP as well
Fixes the crash whenever a usermode thread is destroyed on x86

## Proposed changes

- clear NpxThread on rundown for SMP as well

