### PR TITLE
[SHELL32] Invoke the ItemIDList of shortcuts

### DIFF
--- a/dll/win32/shell32/CDefaultContextMenu.cpp
+++ b/dll/win32/shell32/CDefaultContextMenu.cpp
@@ -110,6 +110,21 @@ static int FindVerbInDefaultVerbList(LPCWSTR List, LPCWSTR Verb)
     return -1;
 }
 
+EXTERN_C HRESULT SHELL32_EnumDefaultVerbList(LPCWSTR List, UINT Index, LPWSTR Verb, SIZE_T cchMax)
+{
+    for (UINT i = 0; *List; ++i)
+    {
+        while (IsVerbListSeparator(*List))
+            List++;
+        LPCWSTR Start = List;
+        while (*List && !IsVerbListSeparator(*List))
+            List++;
+        if (List > Start && i == Index)
+            return StringCchCopyNW(Verb, cchMax, Start, List - Start);
+    }
+    return HRESULT_FROM_WIN32(ERROR_NO_MORE_ITEMS);
+}
+
 class CDefaultContextMenu :
     public CComObjectRootEx<CComMultiThreadModelNoCS>,
     public IContextMenu3,

--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -1553,14 +1553,12 @@ static HRESULT ShellExecute_ContextMenuVerb(LPSHELLEXECUTEINFOW sei)
     if (FAILED_UNEXPECTEDLY(hr))
         return hr;
 
-    BOOL fDefault = !sei->lpVerb || !sei->lpVerb[0];
-
     CComHeapPtr<char> verb, parameters;
     __SHCloneStrWtoA(&verb, sei->lpVerb);
     __SHCloneStrWtoA(&parameters, sei->lpParameters);
 
-    CMINVOKECOMMANDINFOEX ici = {};
-    ici.cbSize = sizeof ici;
+    BOOL fDefault = !sei->lpVerb || !sei->lpVerb[0];
+    CMINVOKECOMMANDINFOEX ici = { sizeof(ici) };
     ici.fMask = (sei->fMask & (SEE_MASK_NO_CONSOLE | SEE_MASK_ASYNCOK | SEE_MASK_FLAG_NO_UI)) | CMIC_MASK_UNICODE;
     ici.nShow = sei->nShow;
     if (!fDefault)

--- a/dll/win32/shell32/wine/classes.c
+++ b/dll/win32/shell32/wine/classes.c
@@ -130,9 +130,11 @@ BOOL HCR_MapTypeToValueA(LPCSTR szExtension, LPSTR szFileType, LONG len, BOOL bP
 	return TRUE;
 }
 
+EXTERN_C HRESULT SHELL32_EnumDefaultVerbList(LPCWSTR List, UINT Index, LPWSTR Verb, SIZE_T cchMax);
+
 BOOL HCR_GetDefaultVerbW( HKEY hkeyClass, LPCWSTR szVerb, LPWSTR szDest, DWORD len )
 {
-        WCHAR sTemp[MAX_PATH];
+        WCHAR sTemp[MAX_PATH], verbs[MAX_PATH];
         LONG size;
         HKEY hkey;
 
@@ -144,21 +146,25 @@ BOOL HCR_GetDefaultVerbW( HKEY hkeyClass, LPCWSTR szVerb, LPWSTR szDest, DWORD l
             return TRUE;
         }
 
-        size=len;
-        *szDest='\0';
-        if (!RegQueryValueW(hkeyClass, L"shell\\", szDest, &size) && *szDest)
+        /* MSDN says to first try the default verb */
+        size = _countof(verbs);
+        if (!RegQueryValueW(hkeyClass, L"shell", verbs, &size) && *verbs)
         {
-            /* The MSDN says to first try the default verb */
-            lstrcpyW(sTemp, L"shell\\");
-            lstrcatW(sTemp, szDest);
-            lstrcatW(sTemp, L"\\command");
-            if (!RegOpenKeyExW(hkeyClass, sTemp, 0, KEY_READ, &hkey))
+            for (UINT i = 0;; ++i)
             {
-                RegCloseKey(hkey);
-                TRACE("default verb=%s\n", debugstr_w(szDest));
-                return TRUE;
+                if (FAILED(SHELL32_EnumDefaultVerbList(verbs, i, szDest, len)))
+                    break;
+                if (FAILED(StringCchPrintfW(sTemp, _countof(sTemp), L"shell\\%s\\command", szDest)))
+                    break;
+                if (!RegOpenKeyExW(hkeyClass, sTemp, 0, KEY_READ, &hkey))
+                {
+                    RegCloseKey(hkey);
+                    TRACE("default verb=%s\n", debugstr_w(szDest));
+                    return TRUE;
+                }
             }
         }
+        *szDest = UNICODE_NULL;
 
         /* then fallback to 'open' */
         lstrcpyW(sTemp, L"shell\\open\\command");


### PR DESCRIPTION
Invoking the IDList as if the target was double-clicked in Explorer fixes shortcuts to control panel items (both .cpl and ShellFolder types).

Notes:
 - The shortcut has to be created by #6999 for shortcuts to .cpl files to work correctly.

JIRA issue: [CORE-19690](https://jira.reactos.org/browse/CORE-19690)