### PR TITLE
[BOOTDATA] LiveCD: Fix Internet Browser icon

### DIFF
--- a/boot/bootdata/livecd.inf
+++ b/boot/bootdata/livecd.inf
@@ -83,6 +83,25 @@ HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontSubstitutes","PMingLiU",0
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontSubstitutes","SimHei",0x00000000,"Droid Sans Fallback"
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontSubstitutes","SimSun",0x00000000,"Droid Sans Fallback"
 
+; For "Internet Browser" icon.
+; CLSID_Internet == {871C5380-42A0-1069-A2EA-08002B30309D}
+; FIXME: Implement CLSID_Internet in ieframe.dll (see CORE-18625)
+; https://git.reactos.org/?p=reactos.git;a=blob;f=modules/rostests/apitests/com/ieframe.c;hb=bf2cec186cc7655e062ec0e53ccfac860bcae70d#l35
+HKCR,"CLSID\{871C5380-42A0-1069-A2EA-08002B30309D}",,,"Internet Browser"
+HKCR,"CLSID\{871C5380-42A0-1069-A2EA-08002B30309D}","InfoTip",0x00020000,"@%SystemRoot%\system32\ieframe.dll,-881"
+HKCR,"CLSID\{871C5380-42A0-1069-A2EA-08002B30309D}","LocalizedString",0x00020000,"@%SystemRoot%\system32\ieframe.dll,-880"
+HKCR,"CLSID\{871C5380-42A0-1069-A2EA-08002B30309D}\DefaultIcon",,0x00020000,"%SystemRoot%\system32\shell32.dll,-512"
+; FIXME: should be "OpenHomePage" action
+HKCR,"CLSID\{871C5380-42A0-1069-A2EA-08002B30309D}\Shell",,,"open"
+HKCR,"CLSID\{871C5380-42A0-1069-A2EA-08002B30309D}\Shell\open",,,""
+HKCR,"CLSID\{871C5380-42A0-1069-A2EA-08002B30309D}\Shell\open\Command",,,"rundll32.exe url,OpenURL https://google.com"
+HKCR,"CLSID\{871C5380-42A0-1069-A2EA-08002B30309D}\ShellFolder","",,"@%SystemRoot%\system32\shell32.dll,-512"
+HKCR,"CLSID\{871C5380-42A0-1069-A2EA-08002B30309D}\ShellFolder","Attributes",0x10001,0x24
+HKCR,"CLSID\{871C5380-42A0-1069-A2EA-08002B30309D}\ShellFolder","HideAsDeletePerUser",,""
+HKCR,"CLSID\{871C5380-42A0-1069-A2EA-08002B30309D}\ShellFolder","HideFolderVerbs",,""
+HKCR,"CLSID\{871C5380-42A0-1069-A2EA-08002B30309D}\ShellFolder","HideOnDesktopPerUser",,""
+HKCR,"CLSID\{871C5380-42A0-1069-A2EA-08002B30309D}\ShellFolder","WantsParseDisplayName",,""
+
 ; FIXME: Registration
 
 ; IRemUnknown


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-19202](https://jira.reactos.org/browse/CORE-19202)

## Proposed changes

- Add `CLSID_Internet` settings to `boot/bootdata/livecd.inf`.

## TODO

- [x] Do tests.

## Screenshots

BootCD (AFTER):
![bootcd](https://github.com/user-attachments/assets/dbed6ab1-2abf-4a1c-bb63-87b7850e1e24)
Correctly displayed.
![bootcd2](https://github.com/user-attachments/assets/b80b2282-381e-40b8-9dee-1f4f733742f0)
`Comments` is OK.

LiveCD (AFTER):
![livecd](https://github.com/user-attachments/assets/12ad835f-3ee2-416f-8349-5a7f76dabce4)
Correctly displayed.
![livecd2](https://github.com/user-attachments/assets/55134265-54dc-4040-9bb9-f56ed07548ee)
`Comments` is OK.