### PR TITLE
[RAPPS] Add new Let's Encrypt issuer certificate

### DIFF
--- a/base/applications/rapps/loaddlg.cpp
+++ b/base/applications/rapps/loaddlg.cpp
@@ -52,8 +52,8 @@
 #include "unattended.h"
 
 #ifdef USE_CERT_PINNING
-#define CERT_ISSUER_INFO_OLD "US\r\nLet's Encrypt\r\nLet's Encrypt Authority X3"
-#define CERT_ISSUER_INFO_NEW "US\r\nLet's Encrypt\r\nR3"
+#define CERT_ISSUER_INFO_OLD "US\r\nLet's Encrypt\r\nR3"
+#define CERT_ISSUER_INFO_NEW "US\r\nLet's Encrypt\r\nR11"
 #define CERT_SUBJECT_INFO "rapps.reactos.org"
 #endif
 


### PR DESCRIPTION
CORE-19666

Should be good until 2027: https://crt.sh/?id=12396132897