### PR TITLE
[BROWSEUI][SHDOCVW][SDK] Fix INamespaceProxy interface

### DIFF
--- a/dll/win32/browseui/explorerband.cpp
+++ b/dll/win32/browseui/explorerband.cpp
@@ -1458,23 +1458,23 @@ HRESULT STDMETHODCALLTYPE CExplorerBand::Select(long paramC)
 
 /// Returns the ITEMIDLIST that should be navigated when an item is invoked.
 STDMETHODIMP CExplorerBand::GetNavigateTarget(
-    IN PCIDLIST_ABSOLUTE pidl,
-    OUT PIDLIST_ABSOLUTE ppidlTarget,
-    OUT ULONG *pulAttrib)
+    _In_ PCIDLIST_ABSOLUTE pidl,
+    _Out_ PIDLIST_ABSOLUTE ppidlTarget,
+    _Out_ ULONG *pulAttrib)
 {
     UNIMPLEMENTED;
     return E_NOTIMPL;
 }
 
 /// Handles a user action on an item.
-STDMETHODIMP CExplorerBand::Invoke(IN PCIDLIST_ABSOLUTE pidl)
+STDMETHODIMP CExplorerBand::Invoke(_In_ PCIDLIST_ABSOLUTE pidl)
 {
     UNIMPLEMENTED;
     return E_NOTIMPL;
 }
 
 /// Called when the user has selected an item.
-STDMETHODIMP CExplorerBand::OnSelectionChanged(IN PCIDLIST_ABSOLUTE pidl)
+STDMETHODIMP CExplorerBand::OnSelectionChanged(_In_ PCIDLIST_ABSOLUTE pidl)
 {
     UNIMPLEMENTED;
     return E_NOTIMPL;
@@ -1482,15 +1482,15 @@ STDMETHODIMP CExplorerBand::OnSelectionChanged(IN PCIDLIST_ABSOLUTE pidl)
 
 /// Returns flags used to update the tree control.
 STDMETHODIMP CExplorerBand::RefreshFlags(
-    OUT DWORD *pdwStyle,
-    OUT DWORD *pdwExStyle,
-    OUT DWORD *dwEnum)
+    _Out_ DWORD *pdwStyle,
+    _Out_ DWORD *pdwExStyle,
+    _Out_ DWORD *dwEnum)
 {
     UNIMPLEMENTED;
     return E_NOTIMPL;
 }
 
-STDMETHODIMP CExplorerBand::CacheItem(IN PCIDLIST_ABSOLUTE pidl)
+STDMETHODIMP CExplorerBand::CacheItem(_In_ PCIDLIST_ABSOLUTE pidl)
 {
     UNIMPLEMENTED;
     return E_NOTIMPL;

--- a/dll/win32/browseui/explorerband.cpp
+++ b/dll/win32/browseui/explorerband.cpp
@@ -1455,6 +1455,8 @@ HRESULT STDMETHODCALLTYPE CExplorerBand::Select(long paramC)
 }
 
 // *** INamespaceProxy ***
+
+/// Returns the ITEMIDLIST that should be navigated when an item is invoked.
 STDMETHODIMP CExplorerBand::GetNavigateTarget(
     IN PCIDLIST_ABSOLUTE pidl,
     OUT PIDLIST_ABSOLUTE ppidlTarget,
@@ -1464,18 +1466,21 @@ STDMETHODIMP CExplorerBand::GetNavigateTarget(
     return E_NOTIMPL;
 }
 
+/// Handles a user action on an item.
 STDMETHODIMP CExplorerBand::Invoke(IN PCIDLIST_ABSOLUTE pidl)
 {
     UNIMPLEMENTED;
     return E_NOTIMPL;
 }
 
+/// Called when the user has selected an item.
 STDMETHODIMP CExplorerBand::OnSelectionChanged(IN PCIDLIST_ABSOLUTE pidl)
 {
     UNIMPLEMENTED;
     return E_NOTIMPL;
 }
 
+/// Returns flags used to update the tree control.
 STDMETHODIMP CExplorerBand::RefreshFlags(
     OUT DWORD *pdwStyle,
     OUT DWORD *pdwExStyle,

--- a/dll/win32/browseui/explorerband.cpp
+++ b/dll/win32/browseui/explorerband.cpp
@@ -1455,31 +1455,37 @@ HRESULT STDMETHODCALLTYPE CExplorerBand::Select(long paramC)
 }
 
 // *** INamespaceProxy ***
-HRESULT STDMETHODCALLTYPE CExplorerBand::GetNavigateTarget(long paramC, long param10, long param14)
+STDMETHODIMP CExplorerBand::GetNavigateTarget(
+    PCIDLIST_ABSOLUTE pidl,
+    PIDLIST_ABSOLUTE ppidlTarget,
+    PULONG pulAttrib)
 {
     UNIMPLEMENTED;
     return E_NOTIMPL;
 }
 
-HRESULT STDMETHODCALLTYPE CExplorerBand::Invoke(long paramC)
+STDMETHODIMP CExplorerBand::Invoke(PCIDLIST_ABSOLUTE pidl)
 {
     UNIMPLEMENTED;
     return E_NOTIMPL;
 }
 
-HRESULT STDMETHODCALLTYPE CExplorerBand::OnSelectionChanged(long paramC)
+STDMETHODIMP CExplorerBand::OnSelectionChanged(PCIDLIST_ABSOLUTE pidl)
 {
     UNIMPLEMENTED;
     return E_NOTIMPL;
 }
 
-HRESULT STDMETHODCALLTYPE CExplorerBand::RefreshFlags(long paramC, long param10, long param14)
+STDMETHODIMP CExplorerBand::RefreshFlags(
+    PULONG pdwStyle,
+    PULONG pdwExStyle,
+    PULONG dwEnum)
 {
     UNIMPLEMENTED;
     return E_NOTIMPL;
 }
 
-HRESULT STDMETHODCALLTYPE CExplorerBand::CacheItem(long paramC)
+STDMETHODIMP CExplorerBand::Reserved1(PCIDLIST_ABSOLUTE pidl)
 {
     UNIMPLEMENTED;
     return E_NOTIMPL;

--- a/dll/win32/browseui/explorerband.cpp
+++ b/dll/win32/browseui/explorerband.cpp
@@ -1456,36 +1456,36 @@ HRESULT STDMETHODCALLTYPE CExplorerBand::Select(long paramC)
 
 // *** INamespaceProxy ***
 STDMETHODIMP CExplorerBand::GetNavigateTarget(
-    PCIDLIST_ABSOLUTE pidl,
-    PIDLIST_ABSOLUTE ppidlTarget,
-    PULONG pulAttrib)
+    IN PCIDLIST_ABSOLUTE pidl,
+    OUT PIDLIST_ABSOLUTE ppidlTarget,
+    OUT ULONG *pulAttrib)
 {
     UNIMPLEMENTED;
     return E_NOTIMPL;
 }
 
-STDMETHODIMP CExplorerBand::Invoke(PCIDLIST_ABSOLUTE pidl)
+STDMETHODIMP CExplorerBand::Invoke(IN PCIDLIST_ABSOLUTE pidl)
 {
     UNIMPLEMENTED;
     return E_NOTIMPL;
 }
 
-STDMETHODIMP CExplorerBand::OnSelectionChanged(PCIDLIST_ABSOLUTE pidl)
+STDMETHODIMP CExplorerBand::OnSelectionChanged(IN PCIDLIST_ABSOLUTE pidl)
 {
     UNIMPLEMENTED;
     return E_NOTIMPL;
 }
 
 STDMETHODIMP CExplorerBand::RefreshFlags(
-    PULONG pdwStyle,
-    PULONG pdwExStyle,
-    PULONG dwEnum)
+    OUT DWORD *pdwStyle,
+    OUT DWORD *pdwExStyle,
+    OUT DWORD *dwEnum)
 {
     UNIMPLEMENTED;
     return E_NOTIMPL;
 }
 
-STDMETHODIMP CExplorerBand::Reserved1(PCIDLIST_ABSOLUTE pidl)
+STDMETHODIMP CExplorerBand::CacheItem(IN PCIDLIST_ABSOLUTE pidl)
 {
     UNIMPLEMENTED;
     return E_NOTIMPL;

--- a/dll/win32/browseui/explorerband.h
+++ b/dll/win32/browseui/explorerband.h
@@ -161,16 +161,16 @@ public:
 
     // *** INamespaceProxy ***
     STDMETHOD(GetNavigateTarget)(
-        PCIDLIST_ABSOLUTE pidl,
-        PIDLIST_ABSOLUTE ppidlTarget,
-        PULONG pulAttrib) override;
-    STDMETHOD(Invoke)(PCIDLIST_ABSOLUTE pidl) override;
-    STDMETHOD(OnSelectionChanged)(PCIDLIST_ABSOLUTE pidl) override;
+        IN PCIDLIST_ABSOLUTE pidl,
+        OUT PIDLIST_ABSOLUTE ppidlTarget,
+        OUT ULONG *pulAttrib) override;
+    STDMETHOD(Invoke)(IN PCIDLIST_ABSOLUTE pidl) override;
+    STDMETHOD(OnSelectionChanged)(IN PCIDLIST_ABSOLUTE pidl) override;
     STDMETHOD(RefreshFlags)(
-        PULONG pdwStyle,
-        PULONG pdwExStyle,
-        PULONG dwEnum) override;
-    STDMETHOD(Reserved1)(PCIDLIST_ABSOLUTE pidl) override;
+        OUT DWORD *pdwStyle,
+        OUT DWORD *pdwExStyle,
+        OUT DWORD *dwEnum) override;
+    STDMETHOD(CacheItem)(IN PCIDLIST_ABSOLUTE pidl) override;
 
     // *** IDispatch methods ***
     STDMETHOD(GetTypeInfoCount)(UINT *pctinfo) override;

--- a/dll/win32/browseui/explorerband.h
+++ b/dll/win32/browseui/explorerband.h
@@ -161,16 +161,16 @@ public:
 
     // *** INamespaceProxy ***
     STDMETHOD(GetNavigateTarget)(
-        IN PCIDLIST_ABSOLUTE pidl,
-        OUT PIDLIST_ABSOLUTE ppidlTarget,
-        OUT ULONG *pulAttrib) override;
-    STDMETHOD(Invoke)(IN PCIDLIST_ABSOLUTE pidl) override;
-    STDMETHOD(OnSelectionChanged)(IN PCIDLIST_ABSOLUTE pidl) override;
+        _In_ PCIDLIST_ABSOLUTE pidl,
+        _Out_ PIDLIST_ABSOLUTE ppidlTarget,
+        _Out_ ULONG *pulAttrib) override;
+    STDMETHOD(Invoke)(_In_ PCIDLIST_ABSOLUTE pidl) override;
+    STDMETHOD(OnSelectionChanged)(_In_ PCIDLIST_ABSOLUTE pidl) override;
     STDMETHOD(RefreshFlags)(
-        OUT DWORD *pdwStyle,
-        OUT DWORD *pdwExStyle,
-        OUT DWORD *dwEnum) override;
-    STDMETHOD(CacheItem)(IN PCIDLIST_ABSOLUTE pidl) override;
+        _Out_ DWORD *pdwStyle,
+        _Out_ DWORD *pdwExStyle,
+        _Out_ DWORD *dwEnum) override;
+    STDMETHOD(CacheItem)(_In_ PCIDLIST_ABSOLUTE pidl) override;
 
     // *** IDispatch methods ***
     STDMETHOD(GetTypeInfoCount)(UINT *pctinfo) override;

--- a/dll/win32/browseui/explorerband.h
+++ b/dll/win32/browseui/explorerband.h
@@ -160,11 +160,17 @@ public:
     STDMETHOD(Select)(long paramC) override;
 
     // *** INamespaceProxy ***
-    STDMETHOD(GetNavigateTarget)(long paramC, long param10, long param14) override;
-    STDMETHOD(Invoke)(long paramC) override;
-    STDMETHOD(OnSelectionChanged)(long paramC) override;
-    STDMETHOD(RefreshFlags)(long paramC, long param10, long param14) override;
-    STDMETHOD(CacheItem)(long paramC) override;
+    STDMETHOD(GetNavigateTarget)(
+        PCIDLIST_ABSOLUTE pidl,
+        PIDLIST_ABSOLUTE ppidlTarget,
+        PULONG pulAttrib) override;
+    STDMETHOD(Invoke)(PCIDLIST_ABSOLUTE pidl) override;
+    STDMETHOD(OnSelectionChanged)(PCIDLIST_ABSOLUTE pidl) override;
+    STDMETHOD(RefreshFlags)(
+        PULONG pdwStyle,
+        PULONG pdwExStyle,
+        PULONG dwEnum) override;
+    STDMETHOD(Reserved1)(PCIDLIST_ABSOLUTE pidl) override;
 
     // *** IDispatch methods ***
     STDMETHOD(GetTypeInfoCount)(UINT *pctinfo) override;

--- a/dll/win32/shdocvw/CFavBand.cpp
+++ b/dll/win32/shdocvw/CFavBand.cpp
@@ -532,23 +532,23 @@ STDMETHODIMP CFavBand::Select(long paramC)
 
 /// Returns the ITEMIDLIST that should be navigated when an item is invoked.
 STDMETHODIMP CFavBand::GetNavigateTarget(
-    IN PCIDLIST_ABSOLUTE pidl,
-    OUT PIDLIST_ABSOLUTE ppidlTarget,
-    OUT ULONG *pulAttrib)
+    _In_ PCIDLIST_ABSOLUTE pidl,
+    _Out_ PIDLIST_ABSOLUTE ppidlTarget,
+    _Out_ ULONG *pulAttrib)
 {
     UNIMPLEMENTED;
     return E_NOTIMPL;
 }
 
 /// Handles a user action on an item.
-STDMETHODIMP CFavBand::Invoke(IN PCIDLIST_ABSOLUTE pidl)
+STDMETHODIMP CFavBand::Invoke(_In_ PCIDLIST_ABSOLUTE pidl)
 {
     UNIMPLEMENTED;
     return E_NOTIMPL;
 }
 
 /// Called when the user has selected an item.
-STDMETHODIMP CFavBand::OnSelectionChanged(IN PCIDLIST_ABSOLUTE pidl)
+STDMETHODIMP CFavBand::OnSelectionChanged(_In_ PCIDLIST_ABSOLUTE pidl)
 {
     UNIMPLEMENTED;
     return E_NOTIMPL;
@@ -556,16 +556,16 @@ STDMETHODIMP CFavBand::OnSelectionChanged(IN PCIDLIST_ABSOLUTE pidl)
 
 /// Returns flags used to update the tree control.
 STDMETHODIMP CFavBand::RefreshFlags(
-    OUT DWORD *pdwStyle,
-    OUT DWORD *pdwExStyle,
-    OUT DWORD *dwEnum)
+    _Out_ DWORD *pdwStyle,
+    _Out_ DWORD *pdwExStyle,
+    _Out_ DWORD *dwEnum)
 {
     UNIMPLEMENTED;
     return E_NOTIMPL;
 }
 
 STDMETHODIMP CFavBand::CacheItem(
-    IN PCIDLIST_ABSOLUTE pidl)
+    _In_ PCIDLIST_ABSOLUTE pidl)
 {
     UNIMPLEMENTED;
     return E_NOTIMPL;

--- a/dll/win32/shdocvw/CFavBand.cpp
+++ b/dll/win32/shdocvw/CFavBand.cpp
@@ -530,31 +530,38 @@ STDMETHODIMP CFavBand::Select(long paramC)
 
 // *** INamespaceProxy ***
 
-STDMETHODIMP CFavBand::GetNavigateTarget(long paramC, long param10, long param14)
+STDMETHODIMP CFavBand::GetNavigateTarget(
+    PCIDLIST_ABSOLUTE pidl,
+    PIDLIST_ABSOLUTE ppidlTarget,
+    PULONG pulAttrib)
 {
     UNIMPLEMENTED;
     return E_NOTIMPL;
 }
 
-STDMETHODIMP CFavBand::Invoke(long paramC)
+STDMETHODIMP CFavBand::Invoke(PCIDLIST_ABSOLUTE pidl)
 {
     UNIMPLEMENTED;
     return E_NOTIMPL;
 }
 
-STDMETHODIMP CFavBand::OnSelectionChanged(long paramC)
+STDMETHODIMP CFavBand::OnSelectionChanged(PCIDLIST_ABSOLUTE pidl)
 {
     UNIMPLEMENTED;
     return E_NOTIMPL;
 }
 
-STDMETHODIMP CFavBand::RefreshFlags(long paramC, long param10, long param14)
+STDMETHODIMP CFavBand::RefreshFlags(
+    PULONG pdwStyle,
+    PULONG pdwExStyle,
+    PULONG dwEnum)
 {
     UNIMPLEMENTED;
     return E_NOTIMPL;
 }
 
-STDMETHODIMP CFavBand::CacheItem(long paramC)
+STDMETHODIMP CFavBand::Reserved1(
+    PCIDLIST_ABSOLUTE pidl)
 {
     UNIMPLEMENTED;
     return E_NOTIMPL;

--- a/dll/win32/shdocvw/CFavBand.cpp
+++ b/dll/win32/shdocvw/CFavBand.cpp
@@ -531,37 +531,37 @@ STDMETHODIMP CFavBand::Select(long paramC)
 // *** INamespaceProxy ***
 
 STDMETHODIMP CFavBand::GetNavigateTarget(
-    PCIDLIST_ABSOLUTE pidl,
-    PIDLIST_ABSOLUTE ppidlTarget,
-    PULONG pulAttrib)
+    IN PCIDLIST_ABSOLUTE pidl,
+    OUT PIDLIST_ABSOLUTE ppidlTarget,
+    OUT ULONG *pulAttrib)
 {
     UNIMPLEMENTED;
     return E_NOTIMPL;
 }
 
-STDMETHODIMP CFavBand::Invoke(PCIDLIST_ABSOLUTE pidl)
+STDMETHODIMP CFavBand::Invoke(IN PCIDLIST_ABSOLUTE pidl)
 {
     UNIMPLEMENTED;
     return E_NOTIMPL;
 }
 
-STDMETHODIMP CFavBand::OnSelectionChanged(PCIDLIST_ABSOLUTE pidl)
+STDMETHODIMP CFavBand::OnSelectionChanged(IN PCIDLIST_ABSOLUTE pidl)
 {
     UNIMPLEMENTED;
     return E_NOTIMPL;
 }
 
 STDMETHODIMP CFavBand::RefreshFlags(
-    PULONG pdwStyle,
-    PULONG pdwExStyle,
-    PULONG dwEnum)
+    OUT DWORD *pdwStyle,
+    OUT DWORD *pdwExStyle,
+    OUT DWORD *dwEnum)
 {
     UNIMPLEMENTED;
     return E_NOTIMPL;
 }
 
-STDMETHODIMP CFavBand::Reserved1(
-    PCIDLIST_ABSOLUTE pidl)
+STDMETHODIMP CFavBand::CacheItem(
+    IN PCIDLIST_ABSOLUTE pidl)
 {
     UNIMPLEMENTED;
     return E_NOTIMPL;

--- a/dll/win32/shdocvw/CFavBand.cpp
+++ b/dll/win32/shdocvw/CFavBand.cpp
@@ -530,6 +530,7 @@ STDMETHODIMP CFavBand::Select(long paramC)
 
 // *** INamespaceProxy ***
 
+/// Returns the ITEMIDLIST that should be navigated when an item is invoked.
 STDMETHODIMP CFavBand::GetNavigateTarget(
     IN PCIDLIST_ABSOLUTE pidl,
     OUT PIDLIST_ABSOLUTE ppidlTarget,
@@ -539,18 +540,21 @@ STDMETHODIMP CFavBand::GetNavigateTarget(
     return E_NOTIMPL;
 }
 
+/// Handles a user action on an item.
 STDMETHODIMP CFavBand::Invoke(IN PCIDLIST_ABSOLUTE pidl)
 {
     UNIMPLEMENTED;
     return E_NOTIMPL;
 }
 
+/// Called when the user has selected an item.
 STDMETHODIMP CFavBand::OnSelectionChanged(IN PCIDLIST_ABSOLUTE pidl)
 {
     UNIMPLEMENTED;
     return E_NOTIMPL;
 }
 
+/// Returns flags used to update the tree control.
 STDMETHODIMP CFavBand::RefreshFlags(
     OUT DWORD *pdwStyle,
     OUT DWORD *pdwExStyle,

--- a/dll/win32/shdocvw/CFavBand.h
+++ b/dll/win32/shdocvw/CFavBand.h
@@ -100,16 +100,16 @@ public:
 
     // *** INamespaceProxy methods ***
     STDMETHODIMP GetNavigateTarget(
-        IN PCIDLIST_ABSOLUTE pidl,
-        OUT PIDLIST_ABSOLUTE ppidlTarget,
-        OUT ULONG *pulAttrib) override;
-    STDMETHODIMP Invoke(IN PCIDLIST_ABSOLUTE pidl) override;
-    STDMETHODIMP OnSelectionChanged(IN PCIDLIST_ABSOLUTE pidl) override;
+        _In_ PCIDLIST_ABSOLUTE pidl,
+        _Out_ PIDLIST_ABSOLUTE ppidlTarget,
+        _Out_ ULONG *pulAttrib) override;
+    STDMETHODIMP Invoke(_In_ PCIDLIST_ABSOLUTE pidl) override;
+    STDMETHODIMP OnSelectionChanged(_In_ PCIDLIST_ABSOLUTE pidl) override;
     STDMETHODIMP RefreshFlags(
-        OUT DWORD *pdwStyle,
-        OUT DWORD *pdwExStyle,
-        OUT DWORD *dwEnum) override;
-    STDMETHODIMP CacheItem(IN PCIDLIST_ABSOLUTE pidl) override;
+        _Out_ DWORD *pdwStyle,
+        _Out_ DWORD *pdwExStyle,
+        _Out_ DWORD *dwEnum) override;
+    STDMETHODIMP CacheItem(_In_ PCIDLIST_ABSOLUTE pidl) override;
 
     // *** IDispatch methods ***
     STDMETHODIMP GetTypeInfoCount(UINT *pctinfo) override;

--- a/dll/win32/shdocvw/CFavBand.h
+++ b/dll/win32/shdocvw/CFavBand.h
@@ -99,11 +99,14 @@ public:
     STDMETHODIMP Select(long paramC) override;
 
     // *** INamespaceProxy methods ***
-    STDMETHODIMP GetNavigateTarget(long paramC, long param10, long param14) override;
-    STDMETHODIMP Invoke(long paramC) override;
-    STDMETHODIMP OnSelectionChanged(long paramC) override;
-    STDMETHODIMP RefreshFlags(long paramC, long param10, long param14) override;
-    STDMETHODIMP CacheItem(long paramC) override;
+    STDMETHODIMP GetNavigateTarget(
+        PCIDLIST_ABSOLUTE pidl,
+        PIDLIST_ABSOLUTE ppidlTarget,
+        PULONG pulAttrib) override;
+    STDMETHODIMP Invoke(PCIDLIST_ABSOLUTE pidl) override;
+    STDMETHODIMP OnSelectionChanged(PCIDLIST_ABSOLUTE pidl) override;
+    STDMETHODIMP RefreshFlags(PULONG pdwStyle, PULONG pdwExStyle, PULONG dwEnum) override;
+    STDMETHODIMP Reserved1(PCIDLIST_ABSOLUTE pidl) override;
 
     // *** IDispatch methods ***
     STDMETHODIMP GetTypeInfoCount(UINT *pctinfo) override;

--- a/dll/win32/shdocvw/CFavBand.h
+++ b/dll/win32/shdocvw/CFavBand.h
@@ -100,13 +100,16 @@ public:
 
     // *** INamespaceProxy methods ***
     STDMETHODIMP GetNavigateTarget(
-        PCIDLIST_ABSOLUTE pidl,
-        PIDLIST_ABSOLUTE ppidlTarget,
-        PULONG pulAttrib) override;
-    STDMETHODIMP Invoke(PCIDLIST_ABSOLUTE pidl) override;
-    STDMETHODIMP OnSelectionChanged(PCIDLIST_ABSOLUTE pidl) override;
-    STDMETHODIMP RefreshFlags(PULONG pdwStyle, PULONG pdwExStyle, PULONG dwEnum) override;
-    STDMETHODIMP Reserved1(PCIDLIST_ABSOLUTE pidl) override;
+        IN PCIDLIST_ABSOLUTE pidl,
+        OUT PIDLIST_ABSOLUTE ppidlTarget,
+        OUT ULONG *pulAttrib) override;
+    STDMETHODIMP Invoke(IN PCIDLIST_ABSOLUTE pidl) override;
+    STDMETHODIMP OnSelectionChanged(IN PCIDLIST_ABSOLUTE pidl) override;
+    STDMETHODIMP RefreshFlags(
+        OUT DWORD *pdwStyle,
+        OUT DWORD *pdwExStyle,
+        OUT DWORD *dwEnum) override;
+    STDMETHODIMP CacheItem(IN PCIDLIST_ABSOLUTE pidl) override;
 
     // *** IDispatch methods ***
     STDMETHODIMP GetTypeInfoCount(UINT *pctinfo) override;

--- a/sdk/include/reactos/shlobj_undoc.h
+++ b/sdk/include/reactos/shlobj_undoc.h
@@ -528,11 +528,11 @@ DECLARE_INTERFACE_(INamespaceProxy, IUnknown)
 	STDMETHOD_(ULONG,AddRef)(THIS) PURE;
 	STDMETHOD_(ULONG,Release)(THIS) PURE;
 	 /*** INamespaceProxy ***/
-	STDMETHOD(GetNavigateTarget)(THIS_ PCIDLIST_ABSOLUTE pidl, PIDLIST_ABSOLUTE ppidlTarget, PULONG pulAttrib) PURE;
-	STDMETHOD(Invoke)(THIS_ PCIDLIST_ABSOLUTE pidl) PURE;
-	STDMETHOD(OnSelectionChanged)(THIS_ PCIDLIST_ABSOLUTE pidl) PURE;
-	STDMETHOD(RefreshFlags)(THIS_ PULONG pdwStyle, PULONG pdwExStyle, PULONG dwEnum) PURE;
-	STDMETHOD(Reserved1)(THIS_ PCIDLIST_ABSOLUTE pidl) PURE;
+	STDMETHOD(GetNavigateTarget)(THIS_ IN PCIDLIST_ABSOLUTE pidl, OUT PIDLIST_ABSOLUTE ppidlTarget, OUT ULONG *pulAttrib) PURE;
+	STDMETHOD(Invoke)(THIS_ IN PCIDLIST_ABSOLUTE pidl) PURE;
+	STDMETHOD(OnSelectionChanged)(THIS_ IN PCIDLIST_ABSOLUTE pidl) PURE;
+	STDMETHOD(RefreshFlags)(THIS_ OUT DWORD *pdwStyle, OUT DWORD *pdwExStyle, OUT DWORD *dwEnum) PURE;
+	STDMETHOD(CacheItem)(THIS_ IN PCIDLIST_ABSOLUTE pidl) PURE;
 };
 #undef INTERFACE
 
@@ -544,7 +544,7 @@ DECLARE_INTERFACE_(INamespaceProxy, IUnknown)
 #define INamespaceProxy_Invoke(T,a) (T)->lpVtbl->Invoke(T,a)
 #define INamespaceProxy_OnSelectionChanged(T,a) (T)->lpVtbl->OnSelectionChanged(T,a)
 #define INamespaceProxy_RefreshFlags(T,a,b,c) (T)->lpVtbl->RefreshFlags(T,a,b,c)
-#define INamespaceProxy_Reserved1(T,a) (T)->lpVtbl->Reserved1(T,a)
+#define INamespaceProxy_CacheItem(T,a) (T)->lpVtbl->CacheItem(T,a)
 #endif
 
 /*****************************************************************************

--- a/sdk/include/reactos/shlobj_undoc.h
+++ b/sdk/include/reactos/shlobj_undoc.h
@@ -528,11 +528,11 @@ DECLARE_INTERFACE_(INamespaceProxy, IUnknown)
 	STDMETHOD_(ULONG,AddRef)(THIS) PURE;
 	STDMETHOD_(ULONG,Release)(THIS) PURE;
 	 /*** INamespaceProxy ***/
-	STDMETHOD(GetNavigateTarget)(THIS_ IN PCIDLIST_ABSOLUTE pidl, OUT PIDLIST_ABSOLUTE ppidlTarget, OUT ULONG *pulAttrib) PURE;
-	STDMETHOD(Invoke)(THIS_ IN PCIDLIST_ABSOLUTE pidl) PURE;
-	STDMETHOD(OnSelectionChanged)(THIS_ IN PCIDLIST_ABSOLUTE pidl) PURE;
-	STDMETHOD(RefreshFlags)(THIS_ OUT DWORD *pdwStyle, OUT DWORD *pdwExStyle, OUT DWORD *dwEnum) PURE;
-	STDMETHOD(CacheItem)(THIS_ IN PCIDLIST_ABSOLUTE pidl) PURE;
+	STDMETHOD(GetNavigateTarget)(THIS_ _In_ PCIDLIST_ABSOLUTE pidl, _Out_ PIDLIST_ABSOLUTE ppidlTarget, _Out_ ULONG *pulAttrib) PURE;
+	STDMETHOD(Invoke)(THIS_ _In_ PCIDLIST_ABSOLUTE pidl) PURE;
+	STDMETHOD(OnSelectionChanged)(THIS_ _In_ PCIDLIST_ABSOLUTE pidl) PURE;
+	STDMETHOD(RefreshFlags)(THIS_ _Out_ DWORD *pdwStyle, _Out_ DWORD *pdwExStyle, _Out_ DWORD *dwEnum) PURE;
+	STDMETHOD(CacheItem)(THIS_ _In_ PCIDLIST_ABSOLUTE pidl) PURE;
 };
 #undef INTERFACE
 

--- a/sdk/include/reactos/shlobj_undoc.h
+++ b/sdk/include/reactos/shlobj_undoc.h
@@ -528,11 +528,11 @@ DECLARE_INTERFACE_(INamespaceProxy, IUnknown)
 	STDMETHOD_(ULONG,AddRef)(THIS) PURE;
 	STDMETHOD_(ULONG,Release)(THIS) PURE;
 	 /*** INamespaceProxy ***/
-	STDMETHOD(GetNavigateTarget)(THIS_ long paramC, long param10, long param14) PURE;
-	STDMETHOD(Invoke)(THIS_ long paramC) PURE;
-	STDMETHOD(OnSelectionChanged)(THIS_ long paramC) PURE;
-	STDMETHOD(RefreshFlags)(THIS_ long paramC, long param10, long param14) PURE;
-	STDMETHOD(CacheItem)(THIS_ long paramC) PURE;
+	STDMETHOD(GetNavigateTarget)(THIS_ PCIDLIST_ABSOLUTE pidl, PIDLIST_ABSOLUTE ppidlTarget, PULONG pulAttrib) PURE;
+	STDMETHOD(Invoke)(THIS_ PCIDLIST_ABSOLUTE pidl) PURE;
+	STDMETHOD(OnSelectionChanged)(THIS_ PCIDLIST_ABSOLUTE pidl) PURE;
+	STDMETHOD(RefreshFlags)(THIS_ PULONG pdwStyle, PULONG pdwExStyle, PULONG dwEnum) PURE;
+	STDMETHOD(Reserved1)(THIS_ PCIDLIST_ABSOLUTE pidl) PURE;
 };
 #undef INTERFACE
 
@@ -544,7 +544,7 @@ DECLARE_INTERFACE_(INamespaceProxy, IUnknown)
 #define INamespaceProxy_Invoke(T,a) (T)->lpVtbl->Invoke(T,a)
 #define INamespaceProxy_OnSelectionChanged(T,a) (T)->lpVtbl->OnSelectionChanged(T,a)
 #define INamespaceProxy_RefreshFlags(T,a,b,c) (T)->lpVtbl->RefreshFlags(T,a,b,c)
-#define INamespaceProxy_CacheItem(T,a) (T)->lpVtbl->CacheItem(T,a)
+#define INamespaceProxy_Reserved1(T,a) (T)->lpVtbl->Reserved1(T,a)
 #endif
 
 /*****************************************************************************


### PR DESCRIPTION
## Purpose

Use correct interface definition for standardization.
JIRA issue: [CORE-19686](https://jira.reactos.org/browse/CORE-19686)

## Proposed changes

- Use `INamespaceProxy` interface that is documented in the Microsoft official site ( https://learn.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/platform-apis/ee318424%28v=vs.85%29 ) and Windows 10 PSDK (see um/ienamespacecontrol.idl file).

## TODO

- [x] Do check.