### PR TITLE
[SHELL32_APITEST] SHParseDisplayName: Enhance for shell:windows\system32

### DIFF
--- a/modules/rostests/apitests/shell32/SHParseDisplayName.cpp
+++ b/modules/rostests/apitests/shell32/SHParseDisplayName.cpp
@@ -63,6 +63,8 @@ struct test_data Tests[] =
     {__LINE__, L"shell:personal", NULL, CSIDL_MYDOCUMENTS, S_OK, T_PRE_VISTA},
     {__LINE__, L"shell:programs", NULL, CSIDL_PROGRAMS, S_OK, T_PRE_VISTA},
     {__LINE__, L"shell:programfiles", NULL, CSIDL_PROGRAM_FILES, S_OK, T_PRE_VISTA},
+    {__LINE__, L"shell:windows\\system32", NULL, CSIDL_SYSTEM, S_OK, T_PRE_VISTA},
+    {__LINE__, L"shell:windows\\fonts", NULL, CSIDL_FONTS, S_OK, T_PRE_VISTA},
     /* The following tests are confusing. They don't work for SHParseDisplayName but work on psfDesktop->ParseDisplayName */
     {__LINE__, L"shell:desktop", NULL, 0, HRESULT_FROM_WIN32(ERROR_PATH_NOT_FOUND), T_VISTA_PLUS},
     {__LINE__, L"shell:windows",  NULL, 0, HRESULT_FROM_WIN32(ERROR_PATH_NOT_FOUND), T_VISTA_PLUS},
@@ -70,6 +72,8 @@ struct test_data Tests[] =
     {__LINE__, L"shell:personal",  NULL, 0, HRESULT_FROM_WIN32(ERROR_PATH_NOT_FOUND), T_VISTA_PLUS},
     {__LINE__, L"shell:programs",  NULL, 0, HRESULT_FROM_WIN32(ERROR_PATH_NOT_FOUND), T_VISTA_PLUS},
     {__LINE__, L"shell:programfiles",  NULL, 0, HRESULT_FROM_WIN32(ERROR_PATH_NOT_FOUND), T_VISTA_PLUS},
+    {__LINE__, L"shell:windows\\system32", NULL, 0, HRESULT_FROM_WIN32(ERROR_PATH_NOT_FOUND), T_VISTA_PLUS},
+    {__LINE__, L"shell:windows\\fonts", NULL, 0, HRESULT_FROM_WIN32(ERROR_PATH_NOT_FOUND), T_VISTA_PLUS},
     /* Tests for CInternet */
     {__LINE__, L"aa:", NULL, 0, E_INVALIDARG, T_PRE_VISTA},
     {__LINE__, L"garbage:", NULL, 0, E_INVALIDARG, T_PRE_VISTA},


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-19693](https://jira.reactos.org/browse/CORE-19693)

## Proposed changes

- Add tests for `shell:windows\system32` and `shell:windows\fonts`.

## TODO

- [x] Do tests.

## Comparison

WinXP:
![WinXP](https://github.com/user-attachments/assets/49c824a0-50e0-49de-b39c-3961de805046)
Successful.

Win2k3:
![Win2k3](https://github.com/user-attachments/assets/5e672a16-0f4d-4adb-9642-4d64893b8951)
Successful.

Win10:
![Win10](https://github.com/user-attachments/assets/c1a82fa2-4474-465c-981b-46bf733497ef)
Successful.