### PR TITLE
[SHELL32][MKSHELLLINK] Support EXP_SPECIAL_FOLDER datablock in shortcuts

### DIFF
--- a/dll/win32/shell32/CShellLink.cpp
+++ b/dll/win32/shell32/CShellLink.cpp
@@ -746,6 +746,25 @@ HRESULT STDMETHODCALLTYPE CShellLink::Load(IStream *stm)
     if (FAILED(hr)) // FIXME: Should we fail?
         return hr;
 
+    if (DATABLOCK_HEADER *pDB = SHFindDataBlock(m_pDBList, EXP_SPECIAL_FOLDER_SIG))
+    {
+        EXP_SPECIAL_FOLDER &special = *(EXP_SPECIAL_FOLDER*)pDB;
+        if (LPITEMIDLIST folder = SHCloneSpecialIDList(NULL, special.idSpecialFolder, FALSE))
+        {
+            if (special.cbSize == sizeof(special) && ILGetSize(m_pPidl) > special.cbOffset)
+            {
+                LPITEMIDLIST pidl = ILCombine(folder, (LPITEMIDLIST)((char*)m_pPidl + special.cbOffset));
+                if (pidl)
+                {
+                    ILFree(m_pPidl);
+                    m_pPidl = pidl;
+                    TRACE("Replaced pidl base with CSIDL %u up to %ub.\n", special.idSpecialFolder, special.cbOffset);
+                }
+            }
+            ILFree(folder);
+        }
+    }
+
     if (TRACE_ON(shell))
     {
 #if (NTDDI_VERSION < NTDDI_LONGHORN)

--- a/dll/win32/shell32/folders/CFSFolder.cpp
+++ b/dll/win32/shell32/folders/CFSFolder.cpp
@@ -14,7 +14,7 @@ WINE_DEFAULT_DEBUG_CHANNEL (shell);
 
 static HRESULT SHELL32_GetCLSIDForDirectory(LPCWSTR pwszDir, LPCWSTR KeyName, CLSID* pclsidFolder);
 
-static LPCWSTR GetItemFileNamePtrW(PCUITEMID_CHILD pidl)
+static LPCWSTR GetItemFileName(PCUITEMID_CHILD pidl, LPWSTR Buf, UINT cchMax)
 {
     FileStructW* pDataW = _ILGetFileStructW(pidl);
     if (pDataW)
@@ -22,15 +22,9 @@ static LPCWSTR GetItemFileNamePtrW(PCUITEMID_CHILD pidl)
     LPPIDLDATA pdata = _ILGetDataPointer(pidl);
     if ((pdata->type & PT_VALUEW) == PT_VALUEW)
         return (LPWSTR)pdata->u.file.szNames;
-    return NULL;
-}
-
-static LPCWSTR GetItemFileName(PCUITEMID_CHILD pidl, LPWSTR Buf, UINT cchMax)
-{
-    LPCWSTR name = GetItemFileNamePtrW(pidl);
-    if (!name && _ILSimpleGetTextW(pidl, Buf, cchMax))
+    if (_ILSimpleGetTextW(pidl, Buf, cchMax))
         return Buf;
-    return name;
+    return NULL;
 }
 
 static HKEY OpenKeyFromFileType(LPCWSTR pExtension, LPCWSTR KeyName)

--- a/sdk/tools/mkshelllink/mkshelllink.c
+++ b/sdk/tools/mkshelllink/mkshelllink.c
@@ -18,8 +18,14 @@ typedef unsigned __int16 uint16_t;
 typedef unsigned __int32 uint32_t;
 #endif
 
+#ifdef _WIN32
+#define strcasecmp _stricmp
+#endif
+
 #define SW_SHOWNORMAL 1
 #define SW_SHOWMINNOACTIVE 7
+#define CSIDL_WINDOWS 0x24
+#define CSIDL_SYSTEM 0x25
 
 typedef struct _GUID
 {
@@ -125,14 +131,57 @@ typedef struct _ID_LIST_DRIVE
     uint16_t unknown;
 } ID_LIST_DRIVE;
 
+#define EXP_SPECIAL_FOLDER_SIG 0xA0000005
+typedef struct _EXP_SPECIAL_FOLDER
+{
+    uint32_t cbSize, dwSignature, idSpecialFolder, cbOffset;
+} EXP_SPECIAL_FOLDER;
+
 #pragma pack(pop)
+
+struct SPECIALFOLDER {
+    unsigned char csidl;
+    const char* name;
+} g_specialfolders[] = {
+    { CSIDL_WINDOWS, "windows" },
+    { CSIDL_SYSTEM, "system" },
+    { 0, NULL}
+};
+
+static unsigned int is_path_separator(unsigned int c)
+{
+    return c == '\\' || c == '/';
+}
+
+static struct SPECIALFOLDER* get_special_folder(const char *target)
+{
+    char buf[256];
+    strncpy(buf, target, sizeof(buf));
+    buf[sizeof("shell:") - 1] = '\0';
+    if (strcasecmp("shell:", buf))
+        return NULL;
+
+    target += sizeof("shell:") - 1;
+    for (unsigned long i = 0;; ++i)
+    {
+        unsigned long len;
+        struct SPECIALFOLDER *special = &g_specialfolders[i];
+        if (!special->name)
+            return NULL;
+        len = strlen(special->name);
+        strncpy(buf, target, sizeof(buf));
+        buf[len] = '\0';
+        if (!strcasecmp(special->name, buf) && (is_path_separator(target[len]) || !target[len]))
+            return &g_specialfolders[i];
+    }
+}
 
 int main(int argc, const char *argv[])
 {
     int i;
     const char *pszOutputPath = "shortcut.lnk";
     const char *pszTarget = NULL;
-    const char *pszDescription = "Description";
+    const char *pszDescription = NULL;
     const char *pszWorkingDir = NULL;
     const char *pszCmdLineArgs = NULL;
     const char *pszIcon = NULL;
@@ -143,6 +192,7 @@ int main(int argc, const char *argv[])
     LNK_HEADER Header;
     uint16_t uhTmp;
     uint32_t dwTmp;
+    EXP_SPECIAL_FOLDER CsidlBlock, *pCsidlBlock = NULL;
 
     for (i = 1; i < argc; ++i)
     {
@@ -226,14 +276,27 @@ int main(int argc, const char *argv[])
         ID_LIST_DRIVE IdListDrive;
         unsigned cbListSize = sizeof(IdListGuid) + sizeof(uint16_t), cchName;
         const char *pszName = pszTarget;
+        int index = 1, specialindex = -1;
+        struct SPECIALFOLDER *special = get_special_folder(pszTarget);
 
         // ID list
         // It seems explorer does not accept links without id list. List is relative to desktop.
 
-        pszName = pszTarget;
-
-        if (pszName[0] && pszName[1] == ':')
+        if (special)
         {
+            Header.Flags &= ~LINK_RELATIVE_PATH;
+            CsidlBlock.cbSize = sizeof(CsidlBlock);
+            CsidlBlock.dwSignature = EXP_SPECIAL_FOLDER_SIG;
+            CsidlBlock.idSpecialFolder = special->csidl;
+            specialindex = 3; // Skip GUID, drive and fake windows/reactos folder
+            pszTarget += sizeof("shell:") - 1 + strlen(special->name) - 10;
+            memcpy((char*)pszTarget, "x:\\reactos\\", 11); // cast away const (we are really writing to argv)
+            pszName = pszTarget;
+        }
+
+        if (pszName[0] && pszName[0] != ':' && pszName[1] == ':')
+        {
+            ++index;
             cbListSize += sizeof(IdListDrive);
             pszName += 2;
             while (*pszName == '\\' || *pszName == '/')
@@ -248,6 +311,12 @@ int main(int argc, const char *argv[])
 
             if (cchName != 1 || pszName[0] != '.')
                 cbListSize += sizeof(IdListFile) + 2 * (cchName + 1);
+
+            if (++index == specialindex)
+            {
+                CsidlBlock.cbOffset = cbListSize - sizeof(uint16_t);
+                pCsidlBlock = &CsidlBlock;
+            }
 
             pszName += cchName;
             while (*pszName == '\\' || *pszName == '/')
@@ -309,7 +378,7 @@ int main(int argc, const char *argv[])
 
     if (Header.Flags & LINK_DESCRIPTION)
     {
-        // Dscription
+        // Description
         uhTmp = strlen(pszDescription);
         fwrite(&uhTmp, sizeof(uhTmp), 1, pFile);
         fputs(pszDescription, pFile);
@@ -348,6 +417,8 @@ int main(int argc, const char *argv[])
     }
 
     // Extra stuff
+    if (pCsidlBlock)
+        fwrite(pCsidlBlock, sizeof(*pCsidlBlock), 1, pFile);
     dwTmp = 0;
     fwrite(&dwTmp, sizeof(dwTmp), 1, pFile);
 

--- a/sdk/tools/mkshelllink/mkshelllink.c
+++ b/sdk/tools/mkshelllink/mkshelllink.c
@@ -185,6 +185,7 @@ int main(int argc, const char *argv[])
     const char *pszWorkingDir = NULL;
     const char *pszCmdLineArgs = NULL;
     const char *pszIcon = NULL;
+    char targetpath[260];
     int IconNr = 0;
     GUID Guid = CLSID_MyComputer;
     int bHelp = 0, bMinimized = 0;
@@ -289,9 +290,8 @@ int main(int argc, const char *argv[])
             CsidlBlock.dwSignature = EXP_SPECIAL_FOLDER_SIG;
             CsidlBlock.idSpecialFolder = special->csidl;
             specialindex = 3; // Skip GUID, drive and fake windows/reactos folder
-            pszTarget += sizeof("shell:") - 1 + strlen(special->name) - 10;
-            memcpy((char*)pszTarget, "x:\\reactos\\", 11); // cast away const (we are really writing to argv)
-            pszName = pszTarget;
+            sprintf(targetpath, "x:\\reactos\\%s", pszTarget + sizeof("shell:") + strlen(special->name));
+            pszName = pszTarget = targetpath;
         }
 
         if (pszName[0] && pszName[0] != ':' && pszName[1] == ':')

--- a/sdk/tools/mkshelllink/mkshelllink.c
+++ b/sdk/tools/mkshelllink/mkshelllink.c
@@ -139,7 +139,7 @@ typedef struct _EXP_SPECIAL_FOLDER
 
 #pragma pack(pop)
 
-struct SPECIALFOLDER {
+static const struct SPECIALFOLDER {
     unsigned char csidl;
     const char* name;
 } g_specialfolders[] = {
@@ -153,7 +153,7 @@ static unsigned int is_path_separator(unsigned int c)
     return c == '\\' || c == '/';
 }
 
-static struct SPECIALFOLDER* get_special_folder(const char *target)
+static const struct SPECIALFOLDER* get_special_folder(const char *target)
 {
     char buf[256];
     strncpy(buf, target, sizeof(buf));
@@ -165,7 +165,7 @@ static struct SPECIALFOLDER* get_special_folder(const char *target)
     for (unsigned long i = 0;; ++i)
     {
         unsigned long len;
-        struct SPECIALFOLDER *special = &g_specialfolders[i];
+        const struct SPECIALFOLDER *special = &g_specialfolders[i];
         if (!special->name)
             return NULL;
         len = strlen(special->name);
@@ -277,7 +277,7 @@ int main(int argc, const char *argv[])
         unsigned cbListSize = sizeof(IdListGuid) + sizeof(uint16_t), cchName;
         const char *pszName = pszTarget;
         int index = 1, specialindex = -1;
-        struct SPECIALFOLDER *special = get_special_folder(pszTarget);
+        const struct SPECIALFOLDER *special = get_special_folder(pszTarget);
 
         // ID list
         // It seems explorer does not accept links without id list. List is relative to desktop.


### PR DESCRIPTION
[EXP_SPECIAL_FOLDER](https://learn.microsoft.com/en-us/windows/win32/api/shlobj_core/ns-shlobj_core-exp_special_folder) allows parts of a shortcuts pidl to be overridden by a special folder.

This will allow #7154 to call `mkshelllink -o Readme.lnk shell:windows\Readme.txt` to create correct shortcuts for the LiveCD.

JIRA issue: [CORE-19692](https://jira.reactos.org/browse/CORE-19692)