### PR TITLE
[BROWSEUI][SHELL32] Ignore navigation requests during browser destruction

### DIFF
--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -3227,6 +3227,8 @@ HRESULT CDefView::LoadViewState()
 
 HRESULT CDefView::SaveViewState(IStream *pStream)
 {
+    if (!m_ListView.m_hWnd)
+        return E_UNEXPECTED;
     int sortcol = MapListColumnToFolderColumn(m_sortInfo.ListColumn);
     PERSISTCLASSICVIEWSTATE cvs;
     cvs.SortColId = sortcol >= 0 ? (WORD)sortcol : 0;


### PR DESCRIPTION
PR #7141 causes calls to `IShellBrowser::BrowseObject` while the shell browser is in the middle of destruction and the ShellView ListView has already been destroyed and DefView is not prepared for this.

Notes:
- `m_mtxBlockNavigate` in explorerband.cpp could probably be used to block `CExplorerBand::OnSelectionChanged` during `TreeView_DeleteAllItems` in `CExplorerBand::DestroyExplorerBand` but putting the protection in the shell browser instead should protect us from similar situations with other bands in the future.
- The protection in CDefView is not strictly required when hosted by our IShellBrowser after this but better safe than sorry.