### PR TITLE
ReactOS 1st-stage GUI Setup Advanced Installation options (bootloader) - Part 2

### DIFF
--- a/base/setup/lib/setuplib.c
+++ b/base/setup/lib/setuplib.c
@@ -154,13 +154,13 @@ CheckUnattendedSetup(
     IsUnattendedSetup = TRUE;
     DPRINT("Running unattended setup\n");
 
-    /* Search for 'MBRInstallType' in the 'Unattend' section */
-    pSetupData->MBRInstallType = -1;
-    if (SpInfFindFirstLine(UnattendInf, L"Unattend", L"MBRInstallType", &Context))
+    /* Search for 'BootLoaderLocation' in the 'Unattend' section */
+    pSetupData->BootLoaderLocation = 2; // Default to "system partition"
+    if (SpInfFindFirstLine(UnattendInf, L"Unattend", L"BootLoaderLocation", &Context))
     {
         if (SpInfGetIntField(&Context, 1, &IntValue))
         {
-            pSetupData->MBRInstallType = IntValue;
+            pSetupData->BootLoaderLocation = IntValue;
         }
     }
 

--- a/base/setup/lib/setuplib.c
+++ b/base/setup/lib/setuplib.c
@@ -1028,6 +1028,17 @@ InitializeSetup(
         DPRINT1("SourceRootPath (2): '%wZ'\n", &pSetupData->SourceRootPath);
         DPRINT1("SourceRootDir (2): '%wZ'\n", &pSetupData->SourceRootDir);
 
+        /* Retrieve the target machine architecture type */
+        // FIXME: This should be determined at runtime!!
+        // FIXME: Allow for (pre-)installing on an architecture
+        //        different from the current one?
+#if defined(SARCH_XBOX)
+        pSetupData->ArchType = ARCH_Xbox;
+// #elif defined(SARCH_PC98)
+#else // TODO: Arc, UEFI
+        pSetupData->ArchType = (IsNEC_98 ? ARCH_NEC98x86 : ARCH_PcAT);
+#endif
+
         return ERROR_SUCCESS;
     }
 

--- a/base/setup/lib/setuplib.c
+++ b/base/setup/lib/setuplib.c
@@ -731,8 +731,7 @@ IsValidInstallDirectory(
     if (!*p || (IS_PATH_SEPARATOR(*p) && !*(p + 1)))
         return FALSE;
 
-    /* The path must contain only valid characters (alpha-numeric,
-     * '.', '\\', '-' and '_'). Spaces are not accepted. */
+    /* The path must contain only valid characters */
     for (p = InstallDir; *p; ++p)
     {
         if (!IS_VALID_INSTALL_PATH_CHAR(*p))

--- a/base/setup/lib/setuplib.h
+++ b/base/setup/lib/setuplib.h
@@ -110,7 +110,7 @@ typedef struct _USETUP_DATA
     LONG DestinationDiskNumber;
     LONG DestinationPartitionNumber;
 
-    LONG MBRInstallType;
+    LONG BootLoaderLocation;
     LONG FormatPartition;
     LONG AutoPartition;
     LONG FsType;

--- a/base/setup/lib/setuplib.h
+++ b/base/setup/lib/setuplib.h
@@ -66,6 +66,16 @@ struct _USETUP_DATA;
 typedef VOID
 (__cdecl *PSETUP_ERROR_ROUTINE)(IN struct _USETUP_DATA*, ...);
 
+typedef enum _ARCHITECTURE_TYPE
+{
+    ARCH_PcAT,      //< Standard BIOS-based PC-AT
+    ARCH_NEC98x86,  //< NEC PC-98
+    ARCH_Xbox,      //< Original Xbox
+    ARCH_Arc,       //< ARC-based (MIPS, SGI)
+    ARCH_Efi,       //< EFI and UEFI
+// Place other architectures supported by the Setup below.
+} ARCHITECTURE_TYPE;
+
 typedef struct _USETUP_DATA
 {
 /* Error handling *****/
@@ -123,6 +133,7 @@ typedef struct _USETUP_DATA
     PGENERIC_LIST LanguageList;
 
 /* Settings *****/
+    ARCHITECTURE_TYPE ArchType; //< Target architecture (MachineType)
     PCWSTR ComputerType;
     PCWSTR DisplayType;
     // PCWSTR KeyboardDriver;

--- a/base/setup/lib/setuplib.h
+++ b/base/setup/lib/setuplib.h
@@ -177,8 +177,15 @@ InitSystemPartition(
     _In_opt_ PFSVOL_CALLBACK FsVolCallback,
     _In_opt_ PVOID Context);
 
+/**
+ * @brief
+ * Defines the class of characters valid for the installation directory.
+ *
+ * The valid characters are: ASCII alphanumericals (a-z, A-Z, 0-9),
+ * and: '.', '\\', '-', '_' . Spaces are not allowed.
+ **/
 #define IS_VALID_INSTALL_PATH_CHAR(c) \
-    (iswalnum(c) || (c) == L'.' || (c) == L'\\' || (c) == L'-' || (c) == L'_')
+    (isalnum(c) || (c) == L'.' || (c) == L'\\' || (c) == L'-' || (c) == L'_')
 
 BOOLEAN
 IsValidInstallDirectory(

--- a/base/setup/reactos/drivepage.c
+++ b/base/setup/reactos/drivepage.c
@@ -48,6 +48,182 @@ static const INT  column_alignment[MAX_LIST_COLUMNS] = {LVCFMT_LEFT, LVCFMT_LEFT
 
 /* FUNCTIONS ****************************************************************/
 
+/**
+ * @brief
+ * Sanitize a given string in-place, by
+ * removing any invalid character found in it.
+ **/
+static BOOL
+DoSanitizeText(
+    _Inout_ PWSTR pszSanitized)
+{
+    PWCHAR pch1, pch2;
+    BOOL bSanitized = FALSE;
+
+    for (pch1 = pch2 = pszSanitized; *pch1; ++pch1)
+    {
+        /* Skip any invalid character found */
+        if (!IS_VALID_INSTALL_PATH_CHAR(*pch1))
+        {
+            bSanitized = TRUE;
+            continue;
+        }
+
+        /* Copy over the valid ones */
+        *pch2 = *pch1;
+        ++pch2;
+    }
+    *pch2 = 0;
+
+    return bSanitized;
+}
+
+/**
+ * @brief
+ * Sanitize in-place any text found in the clipboard.
+ **/
+static BOOL
+DoSanitizeClipboard(
+    _In_ HWND hWnd)
+{
+    HGLOBAL hData;
+    LPWSTR pszText, pszSanitized;
+    BOOL bSanitized;
+
+    /* Protect read-only edit control from modification */
+    if (GetWindowLongPtrW(hWnd, GWL_STYLE) & ES_READONLY)
+        return FALSE;
+
+    if (!OpenClipboard(hWnd))
+        return FALSE;
+
+    hData = GetClipboardData(CF_UNICODETEXT);
+    pszText = GlobalLock(hData);
+    if (!pszText)
+    {
+        CloseClipboard();
+        return FALSE;
+    }
+
+    pszSanitized = _wcsdup(pszText);
+    GlobalUnlock(hData);
+    bSanitized = (pszSanitized && DoSanitizeText(pszSanitized));
+    if (bSanitized)
+    {
+        /* Update clipboard text */
+        SIZE_T cbData = (wcslen(pszSanitized) + 1) * sizeof(WCHAR);
+        hData = GlobalAlloc(GMEM_MOVEABLE | GMEM_SHARE, cbData);
+        pszText = GlobalLock(hData);
+        if (pszText)
+        {
+            CopyMemory(pszText, pszSanitized, cbData);
+            GlobalUnlock(hData);
+            SetClipboardData(CF_UNICODETEXT, hData);
+        }
+    }
+    free(pszSanitized);
+
+    CloseClipboard();
+    return bSanitized;
+}
+
+static VOID
+ShowErrorTip(
+    _In_ HWND hEdit)
+{
+    EDITBALLOONTIP balloon;
+    WCHAR szTitle[512];
+    WCHAR szText[512];
+
+    /* Load the resources */
+    LoadStringW(SetupData.hInstance, IDS_ERROR_INVALID_INSTALLDIR_CHAR_TITLE, szTitle, _countof(szTitle));
+    LoadStringW(SetupData.hInstance, IDS_ERROR_INVALID_INSTALLDIR_CHAR, szText, _countof(szText));
+
+    /* Show a warning balloon */
+    balloon.cbStruct = sizeof(balloon);
+    balloon.pszTitle = szTitle;
+    balloon.pszText  = szText;
+#if (_WIN32_WINNT < _WIN32_WINNT_VISTA)
+    balloon.ttiIcon  = TTI_ERROR;
+#else
+    balloon.ttiIcon  = TTI_ERROR_LARGE;
+#endif
+
+    MessageBeep(MB_ICONERROR);
+    Edit_ShowBalloonTip(hEdit, &balloon);
+
+    // NOTE: There is no need to hide it when other keys are pressed;
+    // the EDIT control will deal with that itself.
+}
+
+/**
+ * @brief
+ * Subclass edit window procedure to filter allowed characters
+ * for the ReactOS installation directory.
+ **/
+static LRESULT
+CALLBACK
+InstallDirEditProc(
+    _In_ HWND hWnd,
+    _In_ UINT uMsg,
+    _In_ WPARAM wParam,
+    _In_ LPARAM lParam)
+{
+    WNDPROC orgEditProc = (WNDPROC)GetWindowLongPtrW(hWnd, GWLP_USERDATA);
+
+    switch (uMsg)
+    {
+    case WM_UNICHAR:
+        if (wParam == UNICODE_NOCHAR)
+            return TRUE;
+        __fallthrough;
+
+    case WM_IME_CHAR:
+    case WM_CHAR:
+    {
+        WCHAR wch = (WCHAR)wParam;
+
+        /* Let the EDIT control deal with Control characters.
+         * It won't emit them as raw data in the text. */
+        if (wParam < ' ')
+            break;
+
+        /* Ignore Ctrl-Backspace */
+        if (wParam == '\x7F')
+            return 0;
+
+        /* Protect read-only edit control from modification */
+        if (GetWindowLongPtrW(hWnd, GWL_STYLE) & ES_READONLY)
+            break;
+
+        if (uMsg == WM_IME_CHAR)
+        {
+            if (!IsWindowUnicode(hWnd) && HIBYTE(wch) != 0)
+            {
+                CHAR data[] = {HIBYTE(wch), LOBYTE(wch)};
+                MultiByteToWideChar(CP_ACP, 0, data, 2, &wch, 1);
+            }
+        }
+
+        /* Show an error and ignore input character if it's invalid */
+        if (!IS_VALID_INSTALL_PATH_CHAR(wch))
+        {
+            ShowErrorTip(hWnd);
+            return 0;
+        }
+        break;
+    }
+
+    case WM_PASTE:
+        /* Verify the text being pasted; if it was sanitized, show an error */
+        if (DoSanitizeClipboard(hWnd))
+            ShowErrorTip(hWnd);
+        break;
+    }
+
+    return CallWindowProcW(orgEditProc, hWnd, uMsg, wParam, lParam);
+}
+
 static INT_PTR
 CALLBACK
 MoreOptDlgProc(
@@ -65,6 +241,8 @@ MoreOptDlgProc(
     {
         case WM_INITDIALOG:
         {
+            HWND hEdit;
+            WNDPROC orgEditProc;
             BOOL bIsBIOS;
             UINT uID;
             INT iItem, iCurrent = CB_ERR, iDefault = 0;
@@ -74,8 +252,14 @@ MoreOptDlgProc(
             pSetupData = (PSETUPDATA)lParam;
             SetWindowLongPtrW(hDlg, GWLP_USERDATA, (LONG_PTR)pSetupData);
 
-            SetDlgItemTextW(hDlg, IDC_PATH,
-                            pSetupData->USetupData.InstallationDirectory);
+            /* Subclass the install-dir edit control */
+            hEdit = GetDlgItem(hDlg, IDC_PATH);
+            orgEditProc = (WNDPROC)GetWindowLongPtrW(hEdit, GWLP_WNDPROC);
+            SetWindowLongPtrW(hEdit, GWLP_USERDATA, (LONG_PTR)orgEditProc);
+            SetWindowLongPtrW(hEdit, GWLP_WNDPROC, (LONG_PTR)InstallDirEditProc);
+
+            /* Set the current installation directory */
+            SetWindowTextW(hEdit, pSetupData->USetupData.InstallationDirectory);
 
 
             /* Initialize the list of available bootloader locations */
@@ -112,18 +296,48 @@ MoreOptDlgProc(
             break;
         }
 
+        case WM_DESTROY:
+        {
+            /* Unsubclass the edit control */
+            HWND hEdit = GetDlgItem(hDlg, IDC_PATH);
+            WNDPROC orgEditProc = (WNDPROC)GetWindowLongPtrW(hEdit, GWLP_USERDATA);
+            if (orgEditProc) SetWindowLongPtrW(hEdit, GWLP_WNDPROC, (LONG_PTR)orgEditProc);
+            break;
+        }
+
         case WM_COMMAND:
             switch (LOWORD(wParam))
             {
                 case IDOK:
                 {
+                    HWND hEdit;
+                    BOOL bIsValid;
+                    WCHAR InstallDir[MAX_PATH];
                     INT iItem;
                     UINT uBldrLoc = CB_ERR;
 
-                    /* Retrieve the installation path */
-                    GetDlgItemTextW(hDlg, IDC_PATH,
-                                    pSetupData->USetupData.InstallationDirectory,
-                                    ARRAYSIZE(pSetupData->USetupData.InstallationDirectory));
+                    /*
+                     * Retrieve the installation path and verify its validity.
+                     * Check for the validity of the installation directory and
+                     * pop up an error if this is not the case.
+                     */
+                    hEdit = GetDlgItem(hDlg, IDC_PATH);
+                    bIsValid = (GetWindowTextLengthW(hEdit) < _countof(InstallDir)); // && IsValidInstallDirectory(InstallDir);
+                    GetWindowTextW(hEdit, InstallDir, _countof(InstallDir));
+                    bIsValid = bIsValid && IsValidInstallDirectory(InstallDir);
+
+                    if (!bIsValid)
+                    {
+                        // ERROR_DIRECTORY_NAME
+                        DisplayError(hDlg,
+                                     IDS_ERROR_DIRECTORY_NAME_TITLE,
+                                     IDS_ERROR_DIRECTORY_NAME);
+                        break; // Go back to the dialog.
+                    }
+
+                    StringCchCopyW(pSetupData->USetupData.InstallationDirectory,
+                                   _countof(pSetupData->USetupData.InstallationDirectory),
+                                   InstallDir);
 
                     /* Retrieve the bootloader location */
                     iItem = SendDlgItemMessageW(hDlg, IDC_INSTFREELDR, CB_GETCURSEL, 0, 0);

--- a/base/setup/reactos/lang/bg-BG.rc
+++ b/base/setup/reactos/lang/bg-BG.rc
@@ -1,5 +1,7 @@
 LANGUAGE LANG_BULGARIAN, SUBLANG_DEFAULT
 
+/* Dialogs */
+
 IDD_STARTPAGE DIALOGEX 0, 0, 317, 193
 STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
 CAPTION "Настройка на РеактОС"
@@ -138,6 +140,8 @@ BEGIN
     LTEXT "Ако в устройството има КД, го извадете. След това натиснете „Приключване“, за да презапуснете компютъра.", IDC_STATIC, 115, 169, 195, 17
 END
 
+/* Strings */
+
 STRINGTABLE
 BEGIN
     IDS_TYPETITLE "РеактОС ви приветства!"
@@ -180,4 +184,19 @@ BEGIN
     IDS_BOOTLOADER_SYSTEM "System partition (Default)"
     IDS_BOOTLOADER_MBRVBR "MBR и VBR (Default)"
     IDS_BOOTLOADER_VBRONLY "Само VBR"
+END
+
+/* Error Strings */
+
+STRINGTABLE
+BEGIN
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR_TITLE "Invalid character"
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR "The only valid characters are:\n\
+alphanumericals (a-z, A-Z, 0-9), and\n . \\ - _\n\
+Spaces are not allowed."
+
+// ERROR_DIRECTORY_NAME
+    IDS_ERROR_DIRECTORY_NAME_TITLE "Invalid installation path"
+    IDS_ERROR_DIRECTORY_NAME "The ReactOS installation path must follow the DOS 8.3 naming scheme, \
+and only contain letters, digits, dashes and periods. Spaces are not allowed."
 END

--- a/base/setup/reactos/lang/bg-BG.rc
+++ b/base/setup/reactos/lang/bg-BG.rc
@@ -76,19 +76,18 @@ BEGIN
     PUSHBUTTON "&Отказ", IDCANCEL, 87, 68, 47, 15, WS_VISIBLE | WS_TABSTOP
 END
 
-IDD_BOOTOPTIONS DIALOGEX 0, 0, 305, 116
+IDD_ADVINSTOPTS DIALOGEX 0, 0, 305, 135
 STYLE DS_SHELLFONT | WS_VISIBLE | WS_CAPTION
-CAPTION "Разширени дялови настройски"
+CAPTION "Advanced Installation Options"
 FONT 8, "MS Shell Dlg"
 BEGIN
-    CONTROL "Папка за слагане", IDC_STATIC, "Button", BS_GROUPBOX, 4, 1, 298, 30
-    EDITTEXT IDC_PATH, 10, 11, 278, 13, WS_VISIBLE
-    CONTROL "Слагане на зареждач", IDC_STATIC, "Button", BS_GROUPBOX, 4, 36, 298, 52
-    CONTROL "Слагане на начален зареждач (MBR и VBR) на твърдия диск", IDC_INSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 46, 278, 11
-    CONTROL "Слагане на начален зареждач (само VBR) на твърдия диск", IDC_INSTVBRONLY, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 57, 278, 11
-    CONTROL "Без слагане на начален зареждач", IDC_NOINSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP | WS_DISABLED, 10, 68, 278, 11
-    PUSHBUTTON "&Добре", IDOK, 180, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
-    PUSHBUTTON "&Отказ", IDCANCEL, 240, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
+    LTEXT "Choose the &directory where you want to install ReactOS:", IDC_STATIC, 7, 9, 291, 10
+    EDITTEXT IDC_PATH, 7, 23, 291, 13, WS_VISIBLE
+    GROUPBOX "Bootloader", IDC_STATIC, 7, 45, 291, 60
+    LTEXT "Select the location where the FreeLoader\nbootloader should be installed.\n\nBy default, it is installed on the system partition of the boot disk (and either in the Master or the Volume Boot Record for BIOS-based computers).", IDC_STATIC, 13, 57, 279, 44
+    COMBOBOX IDC_INSTFREELDR, 150, 58, 142, 45, WS_VSCROLL | WS_TABSTOP | CBS_DROPDOWNLIST
+    PUSHBUTTON "Добре", IDOK, 193, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
+    PUSHBUTTON "Отказ", IDCANCEL, 248, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
 END
 
 IDD_SUMMARYPAGE DIALOGEX 0, 0, 317, 143
@@ -172,4 +171,13 @@ BEGIN
     IDS_PARTITION_TYPE "Type"
     IDS_PARTITION_SIZE "Size"
     IDS_PARTITION_STATUS "Status"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_BOOTLOADER_NOINST "No installation"
+    IDS_BOOTLOADER_REMOVABLE "Removable media"
+    IDS_BOOTLOADER_SYSTEM "System partition (Default)"
+    IDS_BOOTLOADER_MBRVBR "MBR и VBR (Default)"
+    IDS_BOOTLOADER_VBRONLY "Само VBR"
 END

--- a/base/setup/reactos/lang/cs-CZ.rc
+++ b/base/setup/reactos/lang/cs-CZ.rc
@@ -6,6 +6,8 @@
 
 LANGUAGE LANG_CZECH, SUBLANG_DEFAULT
 
+/* Dialogs */
+
 IDD_STARTPAGE DIALOGEX 0, 0, 317, 193
 STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
 CAPTION "Instalace systému ReactOS"
@@ -144,6 +146,8 @@ BEGIN
     LTEXT "Pokud je v mechanice instalační CD, vyjměte jej. Poté kliknutím na Dokončit restartujte počítač.", IDC_STATIC, 115, 169, 195, 17
 END
 
+/* Strings */
+
 STRINGTABLE
 BEGIN
     IDS_TYPETITLE "Vítejte v průvodci instalace systému ReactOS"
@@ -186,4 +190,19 @@ BEGIN
     IDS_BOOTLOADER_SYSTEM "System partition (Default)"
     IDS_BOOTLOADER_MBRVBR "MBR a VBR (Default)"
     IDS_BOOTLOADER_VBRONLY "Jen VBR"
+END
+
+/* Error Strings */
+
+STRINGTABLE
+BEGIN
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR_TITLE "Invalid character"
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR "The only valid characters are:\n\
+alphanumericals (a-z, A-Z, 0-9), and\n . \\ - _\n\
+Spaces are not allowed."
+
+// ERROR_DIRECTORY_NAME
+    IDS_ERROR_DIRECTORY_NAME_TITLE "Invalid installation path"
+    IDS_ERROR_DIRECTORY_NAME "The ReactOS installation path must follow the DOS 8.3 naming scheme, \
+and only contain letters, digits, dashes and periods. Spaces are not allowed."
 END

--- a/base/setup/reactos/lang/cs-CZ.rc
+++ b/base/setup/reactos/lang/cs-CZ.rc
@@ -82,19 +82,18 @@ BEGIN
     PUSHBUTTON "&Storno", IDCANCEL, 87, 68, 47, 15, WS_VISIBLE | WS_TABSTOP
 END
 
-IDD_BOOTOPTIONS DIALOGEX 0, 0, 305, 116
+IDD_ADVINSTOPTS DIALOGEX 0, 0, 305, 135
 STYLE DS_SHELLFONT | WS_VISIBLE | WS_CAPTION
-CAPTION "Pokročilá nastavení oddílu"
+CAPTION "Advanced Installation Options"
 FONT 8, "MS Shell Dlg"
 BEGIN
-    CONTROL "Instalační složka", IDC_STATIC, "Button", BS_GROUPBOX, 4, 1, 298, 30
-    EDITTEXT IDC_PATH, 10, 11, 278, 13, WS_VISIBLE
-    CONTROL "Instalace zavaděče", IDC_STATIC, "Button", BS_GROUPBOX, 4, 36, 298, 52
-    CONTROL "Nainstalovat zavaděč na pevný disk (MBR a VBR)", IDC_INSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 46, 278, 11
-    CONTROL "Nainstalovat zavaděč na pevný disk (jen VBR)", IDC_INSTVBRONLY, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 57, 278, 11
-    CONTROL "Zavaděč neinstalovat", IDC_NOINSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP | WS_DISABLED, 10, 68, 278, 11
-    PUSHBUTTON "&OK", IDOK, 180, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
-    PUSHBUTTON "&Storno", IDCANCEL, 240, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
+    LTEXT "Choose the &directory where you want to install ReactOS:", IDC_STATIC, 7, 9, 291, 10
+    EDITTEXT IDC_PATH, 7, 23, 291, 13, WS_VISIBLE
+    GROUPBOX "Bootloader", IDC_STATIC, 7, 45, 291, 60
+    LTEXT "Select the location where the FreeLoader\nbootloader should be installed.\n\nBy default, it is installed on the system partition of the boot disk (and either in the Master or the Volume Boot Record for BIOS-based computers).", IDC_STATIC, 13, 57, 279, 44
+    COMBOBOX IDC_INSTFREELDR, 150, 58, 142, 45, WS_VSCROLL | WS_TABSTOP | CBS_DROPDOWNLIST
+    PUSHBUTTON "OK", IDOK, 193, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
+    PUSHBUTTON "Storno", IDCANCEL, 248, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
 END
 
 IDD_SUMMARYPAGE DIALOGEX 0, 0, 317, 143
@@ -178,4 +177,13 @@ BEGIN
     IDS_PARTITION_TYPE "Type"
     IDS_PARTITION_SIZE "Size"
     IDS_PARTITION_STATUS "Status"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_BOOTLOADER_NOINST "No installation"
+    IDS_BOOTLOADER_REMOVABLE "Removable media"
+    IDS_BOOTLOADER_SYSTEM "System partition (Default)"
+    IDS_BOOTLOADER_MBRVBR "MBR a VBR (Default)"
+    IDS_BOOTLOADER_VBRONLY "Jen VBR"
 END

--- a/base/setup/reactos/lang/de-DE.rc
+++ b/base/setup/reactos/lang/de-DE.rc
@@ -76,19 +76,18 @@ BEGIN
     PUSHBUTTON "&Abbrechen", IDCANCEL, 87, 68, 47, 15, WS_VISIBLE | WS_TABSTOP
 END
 
-IDD_BOOTOPTIONS DIALOGEX 0, 0, 305, 116
+IDD_ADVINSTOPTS DIALOGEX 0, 0, 305, 135
 STYLE DS_SHELLFONT | WS_VISIBLE | WS_CAPTION
-CAPTION "Erweiterte Partitionseinstellungen"
+CAPTION "Erweiterte Installationseinstellungen"
 FONT 8, "MS Shell Dlg"
 BEGIN
-    CONTROL "Installationsverzeichnis", IDC_STATIC, "Button", BS_GROUPBOX, 4, 1, 298, 30
-    EDITTEXT IDC_PATH, 10, 11, 278, 13, WS_VISIBLE
-    CONTROL "Bootloader-Installation", IDC_STATIC, "Button", BS_GROUPBOX, 4, 36, 298, 52
-    CONTROL "Installiere Bootloader auf Festplatte (MBR und VBR)", IDC_INSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 46, 278, 11
-    CONTROL "Installiere Bootloader auf Festplatte (nur VBR)", IDC_INSTVBRONLY, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 57, 278, 11
-    CONTROL "Keine Bootloader-Installation", IDC_NOINSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP | WS_DISABLED, 10, 68, 278, 11
-    PUSHBUTTON "&OK", IDOK, 180, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
-    PUSHBUTTON "&Abbrechen", IDCANCEL, 240, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
+    LTEXT "Choose the &directory where you want to install ReactOS:", IDC_STATIC, 7, 9, 291, 10
+    EDITTEXT IDC_PATH, 7, 23, 291, 13, WS_VISIBLE
+    GROUPBOX "Bootloader", IDC_STATIC, 7, 45, 291, 60
+    LTEXT "Select the location where the FreeLoader\nbootloader should be installed.\n\nBy default, it is installed on the system partition of the boot disk (and either in the Master or the Volume Boot Record for BIOS-based computers).", IDC_STATIC, 13, 57, 279, 44
+    COMBOBOX IDC_INSTFREELDR, 150, 58, 142, 45, WS_VSCROLL | WS_TABSTOP | CBS_DROPDOWNLIST
+    PUSHBUTTON "OK", IDOK, 193, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
+    PUSHBUTTON "Abbrechen", IDCANCEL, 248, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
 END
 
 IDD_SUMMARYPAGE DIALOGEX 0, 0, 317, 143
@@ -172,4 +171,13 @@ BEGIN
     IDS_PARTITION_TYPE "Type"
     IDS_PARTITION_SIZE "Size"
     IDS_PARTITION_STATUS "Status"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_BOOTLOADER_NOINST "Keine Installation"
+    IDS_BOOTLOADER_REMOVABLE "Removable media"
+    IDS_BOOTLOADER_SYSTEM "System partition (Default)"
+    IDS_BOOTLOADER_MBRVBR "MBR und VBR (Default)"
+    IDS_BOOTLOADER_VBRONLY "Nur VBR"
 END

--- a/base/setup/reactos/lang/de-DE.rc
+++ b/base/setup/reactos/lang/de-DE.rc
@@ -1,5 +1,7 @@
 LANGUAGE LANG_GERMAN, SUBLANG_NEUTRAL
 
+/* Dialogs */
+
 IDD_STARTPAGE DIALOGEX 0, 0, 317, 193
 STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
 CAPTION "ReactOS-Setup"
@@ -138,6 +140,8 @@ BEGIN
     LTEXT "Wenn eine CD im Laufwerk ist, entfernen Sie diese. Klicken Sie zum Neustart auf Beenden.", IDC_STATIC, 115, 169, 195, 17
 END
 
+/* Strings */
+
 STRINGTABLE
 BEGIN
     IDS_TYPETITLE "Willkommen zum ReactOS-Setup"
@@ -180,4 +184,19 @@ BEGIN
     IDS_BOOTLOADER_SYSTEM "System partition (Default)"
     IDS_BOOTLOADER_MBRVBR "MBR und VBR (Default)"
     IDS_BOOTLOADER_VBRONLY "Nur VBR"
+END
+
+/* Error Strings */
+
+STRINGTABLE
+BEGIN
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR_TITLE "Invalid character"
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR "The only valid characters are:\n\
+alphanumericals (a-z, A-Z, 0-9), and\n . \\ - _\n\
+Spaces are not allowed."
+
+// ERROR_DIRECTORY_NAME
+    IDS_ERROR_DIRECTORY_NAME_TITLE "Invalid installation path"
+    IDS_ERROR_DIRECTORY_NAME "The ReactOS installation path must follow the DOS 8.3 naming scheme, \
+and only contain letters, digits, dashes and periods. Spaces are not allowed."
 END

--- a/base/setup/reactos/lang/el-GR.rc
+++ b/base/setup/reactos/lang/el-GR.rc
@@ -1,5 +1,7 @@
 LANGUAGE LANG_GREEK, SUBLANG_DEFAULT
 
+/* Dialogs */
+
 IDD_STARTPAGE DIALOGEX 0, 0, 317, 193
 STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
 CAPTION "Εγκατάσταση του ReactOS"
@@ -138,6 +140,8 @@ BEGIN
     LTEXT "Αν υπάρχει κάποιο CD, αφαιρέστε το. Έπειτα, για να γίνει επανεκκίνηση, πατήστε Ολοκλήρωση.", IDC_STATIC, 115, 169, 195, 17
 END
 
+/* Strings */
+
 STRINGTABLE
 BEGIN
     IDS_TYPETITLE "Καλώς ήλθατε στην Εγκατάσταση του ReactOS"
@@ -180,4 +184,19 @@ BEGIN
     IDS_BOOTLOADER_SYSTEM "System partition (Default)"
     IDS_BOOTLOADER_MBRVBR "MBR and VBR (Default)"
     IDS_BOOTLOADER_VBRONLY "VBR only"
+END
+
+/* Error Strings */
+
+STRINGTABLE
+BEGIN
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR_TITLE "Invalid character"
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR "The only valid characters are:\n\
+alphanumericals (a-z, A-Z, 0-9), and\n . \\ - _\n\
+Spaces are not allowed."
+
+// ERROR_DIRECTORY_NAME
+    IDS_ERROR_DIRECTORY_NAME_TITLE "Invalid installation path"
+    IDS_ERROR_DIRECTORY_NAME "The ReactOS installation path must follow the DOS 8.3 naming scheme, \
+and only contain letters, digits, dashes and periods. Spaces are not allowed."
 END

--- a/base/setup/reactos/lang/el-GR.rc
+++ b/base/setup/reactos/lang/el-GR.rc
@@ -76,19 +76,18 @@ BEGIN
     PUSHBUTTON "&Άκυρο", IDCANCEL, 87, 68, 47, 15, WS_VISIBLE | WS_TABSTOP
 END
 
-IDD_BOOTOPTIONS DIALOGEX 0, 0, 305, 116
+IDD_ADVINSTOPTS DIALOGEX 0, 0, 305, 135
 STYLE DS_SHELLFONT | WS_VISIBLE | WS_CAPTION
-CAPTION "Ρυθμίσεις Partition για προχωρημένους"
+CAPTION "Advanced Installation Options"
 FONT 8, "MS Shell Dlg"
 BEGIN
-    CONTROL "Φάκελος εγκατάστασης", IDC_STATIC, "Button", BS_GROUPBOX, 4, 1, 298, 30
-    EDITTEXT IDC_PATH, 10, 11, 278, 13, WS_VISIBLE
-    CONTROL "Εγκατάσταση Boot loader", IDC_STATIC, "Button", BS_GROUPBOX, 4, 36, 298, 52
-    CONTROL "Εγκατάσταση boot loader στο σκληρό δίσκο (MBR and VBR)", IDC_INSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 46, 278, 11
-    CONTROL "Εγκατάσταση boot loader στο σκληρό δίσκο (VBR only)", IDC_INSTVBRONLY, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 57, 278, 11
-    CONTROL "Να μη γίνει εγκατάσταση του bootloader", IDC_NOINSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP | WS_DISABLED, 10, 68, 278, 11
-    PUSHBUTTON "&OK", IDOK, 180, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
-    PUSHBUTTON "&Άκυρο", IDCANCEL, 240, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
+    LTEXT "Choose the &directory where you want to install ReactOS:", IDC_STATIC, 7, 9, 291, 10
+    EDITTEXT IDC_PATH, 7, 23, 291, 13, WS_VISIBLE
+    GROUPBOX "Bootloader", IDC_STATIC, 7, 45, 291, 60
+    LTEXT "Select the location where the FreeLoader\nbootloader should be installed.\n\nBy default, it is installed on the system partition of the boot disk (and either in the Master or the Volume Boot Record for BIOS-based computers).", IDC_STATIC, 13, 57, 279, 44
+    COMBOBOX IDC_INSTFREELDR, 150, 58, 142, 45, WS_VSCROLL | WS_TABSTOP | CBS_DROPDOWNLIST
+    PUSHBUTTON "OK", IDOK, 193, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
+    PUSHBUTTON "Άκυρο", IDCANCEL, 248, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
 END
 
 IDD_SUMMARYPAGE DIALOGEX 0, 0, 317, 143
@@ -146,9 +145,9 @@ BEGIN
     IDS_DEVICETITLE "Setup the basic devices"
     IDS_DEVICESUBTITLE "Ορισμός ρυθμίσεων για εμφάνιση και πληκτρολόγιο."
     IDS_DRIVETITLE "Ρύθμιση του partition εγκατάστασης και του φακέλου συστήματος"
-    IDS_DRIVESUBTITLE "Προετοιμασία του partition εγκατάστασης, φακέλου συστήματος και boot loader."
+    IDS_DRIVESUBTITLE "Προετοιμασία του partition εγκατάστασης, φακέλου συστήματος και bootloader."
     IDS_PROCESSTITLE "Prepare partition, copy files and setup system"
-    IDS_PROCESSSUBTITLE "Create and format partition, copy files, install and setup boot loader"
+    IDS_PROCESSSUBTITLE "Create and format partition, copy files, install and setup bootloader"
     IDS_RESTARTTITLE "Το πρώτο στάδιο της εγκατάστασης ολοκληρώθηκε"
     IDS_RESTARTSUBTITLE "Το πρώτο στάδιο της εγκατάστασης ολοκληρώθηκε, κάντε επανεκκίνηση για να συνεχίσετε με το δεύτερο στάδιο."
     IDS_SUMMARYTITLE "Installation Summary"
@@ -172,4 +171,13 @@ BEGIN
     IDS_PARTITION_TYPE "Type"
     IDS_PARTITION_SIZE "Size"
     IDS_PARTITION_STATUS "Status"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_BOOTLOADER_NOINST "No installation"
+    IDS_BOOTLOADER_REMOVABLE "Removable media"
+    IDS_BOOTLOADER_SYSTEM "System partition (Default)"
+    IDS_BOOTLOADER_MBRVBR "MBR and VBR (Default)"
+    IDS_BOOTLOADER_VBRONLY "VBR only"
 END

--- a/base/setup/reactos/lang/en-US.rc
+++ b/base/setup/reactos/lang/en-US.rc
@@ -76,19 +76,18 @@ BEGIN
     PUSHBUTTON "&Cancel", IDCANCEL, 87, 68, 47, 15, WS_VISIBLE | WS_TABSTOP
 END
 
-IDD_BOOTOPTIONS DIALOGEX 0, 0, 305, 116
+IDD_ADVINSTOPTS DIALOGEX 0, 0, 305, 135
 STYLE DS_SHELLFONT | WS_VISIBLE | WS_CAPTION
-CAPTION "Advanced Partition Settings"
+CAPTION "Advanced Installation Options"
 FONT 8, "MS Shell Dlg"
 BEGIN
-    CONTROL "Installation folder", IDC_STATIC, "Button", BS_GROUPBOX, 4, 1, 298, 30
-    EDITTEXT IDC_PATH, 10, 11, 278, 13, WS_VISIBLE
-    CONTROL "Boot loader installation", IDC_STATIC, "Button", BS_GROUPBOX, 4, 36, 298, 52
-    CONTROL "Install boot loader on the hard disk (MBR and VBR)", IDC_INSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 46, 278, 11
-    CONTROL "Install boot loader on the hard disk (VBR only)", IDC_INSTVBRONLY, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 57, 278, 11
-    CONTROL "No installation of bootloader", IDC_NOINSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP | WS_DISABLED, 10, 68, 278, 11
-    PUSHBUTTON "&OK", IDOK, 180, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
-    PUSHBUTTON "&Cancel", IDCANCEL, 240, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
+    LTEXT "Choose the &directory where you want to install ReactOS:", IDC_STATIC, 7, 9, 291, 10
+    EDITTEXT IDC_PATH, 7, 23, 291, 13, WS_VISIBLE
+    GROUPBOX "Bootloader", IDC_STATIC, 7, 45, 291, 60
+    LTEXT "Select the location where the FreeLoader\nbootloader should be installed.\n\nBy default, it is installed on the system partition of the boot disk (and either in the Master or the Volume Boot Record for BIOS-based computers).", IDC_STATIC, 13, 57, 279, 44
+    COMBOBOX IDC_INSTFREELDR, 150, 58, 142, 45, WS_VSCROLL | WS_TABSTOP | CBS_DROPDOWNLIST
+    PUSHBUTTON "OK", IDOK, 193, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
+    PUSHBUTTON "Cancel", IDCANCEL, 248, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
 END
 
 IDD_SUMMARYPAGE DIALOGEX 0, 0, 317, 143
@@ -146,9 +145,9 @@ BEGIN
     IDS_DEVICETITLE "Setup the basic devices"
     IDS_DEVICESUBTITLE "Set the settings of display and keyboard."
     IDS_DRIVETITLE "Setup the installation partition and system folder"
-    IDS_DRIVESUBTITLE "Prepare installation partition, system folder and boot loader."
+    IDS_DRIVESUBTITLE "Prepare installation partition, system folder and bootloader."
     IDS_PROCESSTITLE "Setup partition, copy files and setup system"
-    IDS_PROCESSSUBTITLE "Create and format partition, copy files, install and setup boot loader"
+    IDS_PROCESSSUBTITLE "Create and format partition, copy files, install and setup bootloader"
     IDS_RESTARTTITLE "First stage of setup finished"
     IDS_RESTARTSUBTITLE "The first stage of setup has been completed, restart to continue with second stage"
     IDS_SUMMARYTITLE "Installation Summary"
@@ -172,4 +171,13 @@ BEGIN
     IDS_PARTITION_TYPE "Type"
     IDS_PARTITION_SIZE "Size"
     IDS_PARTITION_STATUS "Status"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_BOOTLOADER_NOINST "No installation"
+    IDS_BOOTLOADER_REMOVABLE "Removable media"
+    IDS_BOOTLOADER_SYSTEM "System partition (Default)"
+    IDS_BOOTLOADER_MBRVBR "MBR and VBR (Default)"
+    IDS_BOOTLOADER_VBRONLY "VBR only"
 END

--- a/base/setup/reactos/lang/en-US.rc
+++ b/base/setup/reactos/lang/en-US.rc
@@ -1,5 +1,7 @@
 LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
 
+/* Dialogs */
+
 IDD_STARTPAGE DIALOGEX 0, 0, 317, 193
 STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
 CAPTION "ReactOS Setup"
@@ -138,6 +140,8 @@ BEGIN
     LTEXT "If there is a CD in a drive, remove it. Then, to restart your computer, click Finish.", IDC_STATIC, 115, 169, 195, 17
 END
 
+/* Strings */
+
 STRINGTABLE
 BEGIN
     IDS_TYPETITLE "Welcome to ReactOS Setup"
@@ -180,4 +184,19 @@ BEGIN
     IDS_BOOTLOADER_SYSTEM "System partition (Default)"
     IDS_BOOTLOADER_MBRVBR "MBR and VBR (Default)"
     IDS_BOOTLOADER_VBRONLY "VBR only"
+END
+
+/* Error Strings */
+
+STRINGTABLE
+BEGIN
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR_TITLE "Invalid character"
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR "The only valid characters are:\n\
+alphanumericals (a-z, A-Z, 0-9), and\n . \\ - _\n\
+Spaces are not allowed."
+
+// ERROR_DIRECTORY_NAME
+    IDS_ERROR_DIRECTORY_NAME_TITLE "Invalid installation path"
+    IDS_ERROR_DIRECTORY_NAME "The ReactOS installation path must follow the DOS 8.3 naming scheme, \
+and only contain letters, digits, dashes and periods. Spaces are not allowed."
 END

--- a/base/setup/reactos/lang/es-ES.rc
+++ b/base/setup/reactos/lang/es-ES.rc
@@ -9,6 +9,8 @@
 
 LANGUAGE LANG_SPANISH, SUBLANG_NEUTRAL
 
+/* Dialogs */
+
 IDD_STARTPAGE DIALOGEX 0, 0, 317, 193
 STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
 CAPTION "Instalación de ReactOS"
@@ -147,6 +149,8 @@ BEGIN
     LTEXT "Si tiene CDs en alguna unidad, retírelos. Luego, reinicie el equipo haciendo clic en Finalizar.", IDC_STATIC, 115, 169, 195, 17
 END
 
+/* Strings */
+
 STRINGTABLE
 BEGIN
     IDS_TYPETITLE "Bienvenido a la instalación de ReactOS"
@@ -189,4 +193,19 @@ BEGIN
     IDS_BOOTLOADER_SYSTEM "System partition (Default)"
     IDS_BOOTLOADER_MBRVBR "MBR y VBR (Default)"
     IDS_BOOTLOADER_VBRONLY "Solo VBR"
+END
+
+/* Error Strings */
+
+STRINGTABLE
+BEGIN
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR_TITLE "Invalid character"
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR "The only valid characters are:\n\
+alphanumericals (a-z, A-Z, 0-9), and\n . \\ - _\n\
+Spaces are not allowed."
+
+// ERROR_DIRECTORY_NAME
+    IDS_ERROR_DIRECTORY_NAME_TITLE "Invalid installation path"
+    IDS_ERROR_DIRECTORY_NAME "The ReactOS installation path must follow the DOS 8.3 naming scheme, \
+and only contain letters, digits, dashes and periods. Spaces are not allowed."
 END

--- a/base/setup/reactos/lang/es-ES.rc
+++ b/base/setup/reactos/lang/es-ES.rc
@@ -85,19 +85,18 @@ BEGIN
     PUSHBUTTON "&Cancelar", IDCANCEL, 87, 68, 47, 15, WS_VISIBLE | WS_TABSTOP
 END
 
-IDD_BOOTOPTIONS DIALOGEX 0, 0, 305, 116
+IDD_ADVINSTOPTS DIALOGEX 0, 0, 305, 135
 STYLE DS_SHELLFONT | WS_VISIBLE | WS_CAPTION
-CAPTION "Ajustes avanzados de la partición"
+CAPTION "Advanced Installation Options"
 FONT 8, "MS Shell Dlg"
 BEGIN
-    CONTROL "Carpeta de instalación", IDC_STATIC, "Button", BS_GROUPBOX, 4, 1, 298, 30
-    EDITTEXT IDC_PATH, 10, 11, 278, 13, WS_VISIBLE
-    CONTROL "Instalación del cargador de arranque", IDC_STATIC, "Button", BS_GROUPBOX, 4, 36, 298, 52
-    CONTROL "Instalar el cargador de arranque en el disco duro (MBR y VBR)", IDC_INSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 46, 278, 11
-    CONTROL "Instalar el cargador de arranque en el disco duro (solo VBR)", IDC_INSTVBRONLY, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 57, 278, 11
-    CONTROL "No instalar el cargador de arranque", IDC_NOINSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP | WS_DISABLED, 10, 68, 278, 11
-    PUSHBUTTON "&Aceptar", IDOK, 180, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
-    PUSHBUTTON "&Cancelar", IDCANCEL, 240, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
+    LTEXT "Choose the &directory where you want to install ReactOS:", IDC_STATIC, 7, 9, 291, 10
+    EDITTEXT IDC_PATH, 7, 23, 291, 13, WS_VISIBLE
+    GROUPBOX "Cargador de arranque", IDC_STATIC, 7, 45, 291, 60
+    LTEXT "Select the location where the FreeLoader\nbootloader should be installed.\n\nBy default, it is installed on the system partition of the boot disk (and either in the Master or the Volume Boot Record for BIOS-based computers).", IDC_STATIC, 13, 57, 279, 44
+    COMBOBOX IDC_INSTFREELDR, 150, 58, 142, 45, WS_VSCROLL | WS_TABSTOP | CBS_DROPDOWNLIST
+    PUSHBUTTON "Aceptar", IDOK, 193, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
+    PUSHBUTTON "Cancelar", IDCANCEL, 248, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
 END
 
 IDD_SUMMARYPAGE DIALOGEX 0, 0, 317, 143
@@ -181,4 +180,13 @@ BEGIN
     IDS_PARTITION_TYPE "Tipo"
     IDS_PARTITION_SIZE "Tamaño"
     IDS_PARTITION_STATUS "Estado"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_BOOTLOADER_NOINST "No instalar"
+    IDS_BOOTLOADER_REMOVABLE "Removable media"
+    IDS_BOOTLOADER_SYSTEM "System partition (Default)"
+    IDS_BOOTLOADER_MBRVBR "MBR y VBR (Default)"
+    IDS_BOOTLOADER_VBRONLY "Solo VBR"
 END

--- a/base/setup/reactos/lang/et-EE.rc
+++ b/base/setup/reactos/lang/et-EE.rc
@@ -76,19 +76,18 @@ BEGIN
     PUSHBUTTON "&Tühista", IDCANCEL, 87, 68, 47, 15, WS_VISIBLE | WS_TABSTOP
 END
 
-IDD_BOOTOPTIONS DIALOGEX 0, 0, 305, 116
+IDD_ADVINSTOPTS DIALOGEX 0, 0, 305, 135
 STYLE DS_SHELLFONT | WS_VISIBLE | WS_CAPTION
-CAPTION "Täpsemad vormindamise seaded"
+CAPTION "Advanced Installation Options"
 FONT 8, "MS Shell Dlg"
 BEGIN
-    CONTROL "Paigaldamise kaust", IDC_STATIC, "Button", BS_GROUPBOX, 4, 1, 298, 30
-    EDITTEXT IDC_PATH, 10, 11, 278, 13, WS_VISIBLE
-    CONTROL "Alglaaduri paigaldamine", IDC_STATIC, "Button", BS_GROUPBOX, 4, 36, 298, 52
-    CONTROL "Paigalda alglaadur kõvakettale (MBR ja VBR)", IDC_INSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 46, 278, 11
-    CONTROL "Paigalda alglaadur kõvakettale (ainult VBR)", IDC_INSTVBRONLY, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 57, 278, 11
-    CONTROL "Ära paigalda alglaadurit", IDC_NOINSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP | WS_DISABLED, 10, 68, 278, 11
-    PUSHBUTTON "&Olgu", IDOK, 180, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
-    PUSHBUTTON "&Tühista", IDCANCEL, 240, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
+    LTEXT "Choose the &directory where you want to install ReactOS:", IDC_STATIC, 7, 9, 291, 10
+    EDITTEXT IDC_PATH, 7, 23, 291, 13, WS_VISIBLE
+    GROUPBOX "Bootloader", IDC_STATIC, 7, 45, 291, 60
+    LTEXT "Select the location where the FreeLoader\nbootloader should be installed.\n\nBy default, it is installed on the system partition of the boot disk (and either in the Master or the Volume Boot Record for BIOS-based computers).", IDC_STATIC, 13, 57, 279, 44
+    COMBOBOX IDC_INSTFREELDR, 150, 58, 142, 45, WS_VSCROLL | WS_TABSTOP | CBS_DROPDOWNLIST
+    PUSHBUTTON "Olgu", IDOK, 193, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
+    PUSHBUTTON "Tühista", IDCANCEL, 248, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
 END
 
 IDD_SUMMARYPAGE DIALOGEX 0, 0, 317, 143
@@ -172,4 +171,13 @@ BEGIN
     IDS_PARTITION_TYPE "Tüüp"
     IDS_PARTITION_SIZE "Suurus"
     IDS_PARTITION_STATUS "Olek"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_BOOTLOADER_NOINST "No installation"
+    IDS_BOOTLOADER_REMOVABLE "Removable media"
+    IDS_BOOTLOADER_SYSTEM "System partition (Default)"
+    IDS_BOOTLOADER_MBRVBR "MBR ja VBR (Default)"
+    IDS_BOOTLOADER_VBRONLY "Ainult VBR"
 END

--- a/base/setup/reactos/lang/et-EE.rc
+++ b/base/setup/reactos/lang/et-EE.rc
@@ -1,5 +1,7 @@
 LANGUAGE LANG_ESTONIAN, SUBLANG_DEFAULT
 
+/* Dialogs */
+
 IDD_STARTPAGE DIALOGEX 0, 0, 317, 193
 STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
 CAPTION "ReactOS'i paigaldamine"
@@ -138,6 +140,8 @@ BEGIN
     LTEXT "Võta CD välja ja vajuta Lõpeta, et arvuti taaskäivitada.", IDC_STATIC, 115, 169, 195, 17
 END
 
+/* Strings */
+
 STRINGTABLE
 BEGIN
     IDS_TYPETITLE "Tere tulemast ReactOS'i paigaldama"
@@ -180,4 +184,19 @@ BEGIN
     IDS_BOOTLOADER_SYSTEM "System partition (Default)"
     IDS_BOOTLOADER_MBRVBR "MBR ja VBR (Default)"
     IDS_BOOTLOADER_VBRONLY "Ainult VBR"
+END
+
+/* Error Strings */
+
+STRINGTABLE
+BEGIN
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR_TITLE "Invalid character"
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR "The only valid characters are:\n\
+alphanumericals (a-z, A-Z, 0-9), and\n . \\ - _\n\
+Spaces are not allowed."
+
+// ERROR_DIRECTORY_NAME
+    IDS_ERROR_DIRECTORY_NAME_TITLE "Invalid installation path"
+    IDS_ERROR_DIRECTORY_NAME "The ReactOS installation path must follow the DOS 8.3 naming scheme, \
+and only contain letters, digits, dashes and periods. Spaces are not allowed."
 END

--- a/base/setup/reactos/lang/eu-ES.rc
+++ b/base/setup/reactos/lang/eu-ES.rc
@@ -83,19 +83,18 @@ BEGIN
     PUSHBUTTON "&Cancelar", IDCANCEL, 87, 68, 47, 15, WS_VISIBLE | WS_TABSTOP
 END
 
-IDD_BOOTOPTIONS DIALOGEX 0, 0, 305, 116
+IDD_ADVINSTOPTS DIALOGEX 0, 0, 305, 135
 STYLE DS_SHELLFONT | WS_VISIBLE | WS_CAPTION
-CAPTION "Ajustes avanzados de la partición"
+CAPTION "Advanced Installation Options"
 FONT 8, "MS Shell Dlg"
 BEGIN
-    CONTROL "Carpeta de instalación", IDC_STATIC, "Button", BS_GROUPBOX, 4, 1, 298, 30
-    EDITTEXT IDC_PATH, 10, 11, 278, 13, WS_VISIBLE
-    CONTROL "Instalación del cargador de arranque", IDC_STATIC, "Button", BS_GROUPBOX, 4, 36, 298, 52
-    CONTROL "Instalar el cargador de arranque en el disco duro (MBR y VBR)", IDC_INSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 46, 278, 11
-    CONTROL "Instalar el cargador de arranque en el disco duro (solo VBR)", IDC_INSTVBRONLY, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 57, 278, 11
-    CONTROL "No instalar el cargador de arranque", IDC_NOINSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP | WS_DISABLED, 10, 68, 278, 11
-    PUSHBUTTON "&Aceptar", IDOK, 180, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
-    PUSHBUTTON "&Cancelar", IDCANCEL, 240, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
+    LTEXT "Choose the &directory where you want to install ReactOS:", IDC_STATIC, 7, 9, 291, 10
+    EDITTEXT IDC_PATH, 7, 23, 291, 13, WS_VISIBLE
+    GROUPBOX "Cargador de arranque", IDC_STATIC, 7, 45, 291, 60
+    LTEXT "Select the location where the FreeLoader\nbootloader should be installed.\n\nBy default, it is installed on the system partition of the boot disk (and either in the Master or the Volume Boot Record for BIOS-based computers).", IDC_STATIC, 13, 57, 279, 44
+    COMBOBOX IDC_INSTFREELDR, 150, 58, 142, 45, WS_VSCROLL | WS_TABSTOP | CBS_DROPDOWNLIST
+    PUSHBUTTON "Aceptar", IDOK, 193, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
+    PUSHBUTTON "Cancelar", IDCANCEL, 248, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
 END
 
 IDD_SUMMARYPAGE DIALOGEX 0, 0, 317, 143
@@ -179,4 +178,13 @@ BEGIN
     IDS_PARTITION_TYPE "Tipo"
     IDS_PARTITION_SIZE "Tamaño"
     IDS_PARTITION_STATUS "Estado"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_BOOTLOADER_NOINST "No instalar"
+    IDS_BOOTLOADER_REMOVABLE "Removable media"
+    IDS_BOOTLOADER_SYSTEM "System partition (Default)"
+    IDS_BOOTLOADER_MBRVBR "MBR y VBR (Default)"
+    IDS_BOOTLOADER_VBRONLY "Solo VBR"
 END

--- a/base/setup/reactos/lang/eu-ES.rc
+++ b/base/setup/reactos/lang/eu-ES.rc
@@ -7,6 +7,8 @@
 
 LANGUAGE LANG_BASQUE, SUBLANG_NEUTRAL
 
+/* Dialogs */
+
 IDD_STARTPAGE DIALOGEX 0, 0, 317, 193
 STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
 CAPTION "Instalación de ReactOS"
@@ -145,6 +147,8 @@ BEGIN
     LTEXT "Si tiene CDs en alguna unidad, retírelos. Luego, reinicie el equipo haciendo clic en Finalizar.", IDC_STATIC, 115, 169, 195, 17
 END
 
+/* Strings */
+
 STRINGTABLE
 BEGIN
     IDS_TYPETITLE "Bienvenido a la instalación de ReactOS"
@@ -187,4 +191,19 @@ BEGIN
     IDS_BOOTLOADER_SYSTEM "System partition (Default)"
     IDS_BOOTLOADER_MBRVBR "MBR y VBR (Default)"
     IDS_BOOTLOADER_VBRONLY "Solo VBR"
+END
+
+/* Error Strings */
+
+STRINGTABLE
+BEGIN
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR_TITLE "Invalid character"
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR "The only valid characters are:\n\
+alphanumericals (a-z, A-Z, 0-9), and\n . \\ - _\n\
+Spaces are not allowed."
+
+// ERROR_DIRECTORY_NAME
+    IDS_ERROR_DIRECTORY_NAME_TITLE "Invalid installation path"
+    IDS_ERROR_DIRECTORY_NAME "The ReactOS installation path must follow the DOS 8.3 naming scheme, \
+and only contain letters, digits, dashes and periods. Spaces are not allowed."
 END

--- a/base/setup/reactos/lang/fi-FI.rc
+++ b/base/setup/reactos/lang/fi-FI.rc
@@ -76,19 +76,18 @@ BEGIN
     PUSHBUTTON "&Cancel", IDCANCEL, 87, 68, 47, 15, WS_VISIBLE | WS_TABSTOP
 END
 
-IDD_BOOTOPTIONS DIALOGEX 0, 0, 305, 116
+IDD_ADVINSTOPTS DIALOGEX 0, 0, 305, 135
 STYLE DS_SHELLFONT | WS_VISIBLE | WS_CAPTION
-CAPTION "Advanced Partition Settings"
+CAPTION "Advanced Installation Options"
 FONT 8, "MS Shell Dlg"
 BEGIN
-    CONTROL "Installation folder", IDC_STATIC, "Button", BS_GROUPBOX, 4, 1, 298, 30
-    EDITTEXT IDC_PATH, 10, 11, 278, 13, WS_VISIBLE
-    CONTROL "Boot loader installation", IDC_STATIC, "Button", BS_GROUPBOX, 4, 36, 298, 52
-    CONTROL "Install boot loader on the hard disk (MBR and VBR)", IDC_INSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 46, 278, 11
-    CONTROL "Install boot loader on the hard disk (VBR only)", IDC_INSTVBRONLY, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 57, 278, 11
-    CONTROL "No installation of bootloader", IDC_NOINSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP | WS_DISABLED, 10, 68, 278, 11
-    PUSHBUTTON "&OK", IDOK, 180, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
-    PUSHBUTTON "&Cancel", IDCANCEL, 240, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
+    LTEXT "Choose the &directory where you want to install ReactOS:", IDC_STATIC, 7, 9, 291, 10
+    EDITTEXT IDC_PATH, 7, 23, 291, 13, WS_VISIBLE
+    GROUPBOX "Bootloader", IDC_STATIC, 7, 45, 291, 60
+    LTEXT "Select the location where the FreeLoader\nbootloader should be installed.\n\nBy default, it is installed on the system partition of the boot disk (and either in the Master or the Volume Boot Record for BIOS-based computers).", IDC_STATIC, 13, 57, 279, 44
+    COMBOBOX IDC_INSTFREELDR, 150, 58, 142, 45, WS_VSCROLL | WS_TABSTOP | CBS_DROPDOWNLIST
+    PUSHBUTTON "OK", IDOK, 193, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
+    PUSHBUTTON "Cancel", IDCANCEL, 248, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
 END
 
 IDD_SUMMARYPAGE DIALOGEX 0, 0, 317, 143
@@ -146,9 +145,9 @@ BEGIN
     IDS_DEVICETITLE "Setup the basic devices"
     IDS_DEVICESUBTITLE "Set the settings of display and keyboard."
     IDS_DRIVETITLE "Setup the installation partition and system folder"
-    IDS_DRIVESUBTITLE "Prepare installation partition, system folder and boot loader."
+    IDS_DRIVESUBTITLE "Prepare installation partition, system folder and bootloader."
     IDS_PROCESSTITLE "Setup partition, copy files and setup system"
-    IDS_PROCESSSUBTITLE "Create and format partition, copy files, install and setup boot loader"
+    IDS_PROCESSSUBTITLE "Create and format partition, copy files, install and setup bootloader"
     IDS_RESTARTTITLE "First stage of setup finished"
     IDS_RESTARTSUBTITLE "The first stage of setup has been completed, restart to continue with second stage"
     IDS_SUMMARYTITLE "Installation Summary"
@@ -172,4 +171,13 @@ BEGIN
     IDS_PARTITION_TYPE "Type"
     IDS_PARTITION_SIZE "Size"
     IDS_PARTITION_STATUS "Status"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_BOOTLOADER_NOINST "No installation"
+    IDS_BOOTLOADER_REMOVABLE "Removable media"
+    IDS_BOOTLOADER_SYSTEM "System partition (Default)"
+    IDS_BOOTLOADER_MBRVBR "MBR and VBR (Default)"
+    IDS_BOOTLOADER_VBRONLY "VBR only"
 END

--- a/base/setup/reactos/lang/fi-FI.rc
+++ b/base/setup/reactos/lang/fi-FI.rc
@@ -1,5 +1,7 @@
 LANGUAGE LANG_FINNISH, SUBLANG_DEFAULT
 
+/* Dialogs */
+
 IDD_STARTPAGE DIALOGEX 0, 0, 317, 193
 STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
 CAPTION "ReactOS Asennus"
@@ -138,6 +140,8 @@ BEGIN
     LTEXT "If there is a CD in a drive, remove it. Then, to restart your computer, click Finish.", IDC_STATIC, 115, 169, 195, 17
 END
 
+/* Strings */
+
 STRINGTABLE
 BEGIN
     IDS_TYPETITLE "Welcome to ReactOS Setup"
@@ -180,4 +184,19 @@ BEGIN
     IDS_BOOTLOADER_SYSTEM "System partition (Default)"
     IDS_BOOTLOADER_MBRVBR "MBR and VBR (Default)"
     IDS_BOOTLOADER_VBRONLY "VBR only"
+END
+
+/* Error Strings */
+
+STRINGTABLE
+BEGIN
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR_TITLE "Invalid character"
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR "The only valid characters are:\n\
+alphanumericals (a-z, A-Z, 0-9), and\n . \\ - _\n\
+Spaces are not allowed."
+
+// ERROR_DIRECTORY_NAME
+    IDS_ERROR_DIRECTORY_NAME_TITLE "Invalid installation path"
+    IDS_ERROR_DIRECTORY_NAME "The ReactOS installation path must follow the DOS 8.3 naming scheme, \
+and only contain letters, digits, dashes and periods. Spaces are not allowed."
 END

--- a/base/setup/reactos/lang/fr-FR.rc
+++ b/base/setup/reactos/lang/fr-FR.rc
@@ -76,19 +76,18 @@ BEGIN
     PUSHBUTTON "&Annuler", IDCANCEL, 87, 68, 47, 15, WS_VISIBLE | WS_TABSTOP
 END
 
-IDD_BOOTOPTIONS DIALOGEX 0, 0, 305, 116
+IDD_ADVINSTOPTS DIALOGEX 0, 0, 305, 135
 STYLE DS_SHELLFONT | WS_VISIBLE | WS_CAPTION
-CAPTION "Paramètres de partition avancés"
+CAPTION "Paramètres d'installation avancés"
 FONT 8, "MS Shell Dlg"
 BEGIN
-    CONTROL "Dossier d'installation", IDC_STATIC, "Button", BS_GROUPBOX, 4, 1, 298, 30
-    EDITTEXT IDC_PATH, 10, 11, 278, 13, WS_VISIBLE
-    CONTROL "Installation du chargeur de démarrage", IDC_STATIC, "Button", BS_GROUPBOX, 4, 36, 298, 52
-    CONTROL "Installer le chargeur de démarrage sur le disque dur (MBR et VBR)", IDC_INSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 46, 278, 11
-    CONTROL "Installer le chargeur de démarrage sur le disque dur (VBR uniquement)", IDC_INSTVBRONLY, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 57, 278, 11
-    CONTROL "Ne pas installer le chargeur de démarrage", IDC_NOINSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP | WS_DISABLED, 10, 68, 278, 11
-    PUSHBUTTON "&OK", IDOK, 180, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
-    PUSHBUTTON "&Annuler", IDCANCEL, 240, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
+    LTEXT "Choisissez un &répertoire où vous voulez installer ReactOS :", IDC_STATIC, 7, 9, 291, 10
+    EDITTEXT IDC_PATH, 7, 23, 291, 13, WS_VISIBLE
+    GROUPBOX "Chargeur de démarrage", IDC_STATIC, 7, 45, 291, 60
+    LTEXT "Sélectionnez l'endroit où le chargeur de\ndémarrage FreeLoader doit être installé.\n\nPar défaut, il est installé sur la partition système du disque de démarrage (et sur le Master ou le Volume Boot Record pour les ordinateurs basés sur le BIOS).", IDC_STATIC, 13, 57, 279, 44
+    COMBOBOX IDC_INSTFREELDR, 150, 58, 142, 45, WS_VSCROLL | WS_TABSTOP | CBS_DROPDOWNLIST
+    PUSHBUTTON "OK", IDOK, 193, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
+    PUSHBUTTON "Annuler", IDCANCEL, 248, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
 END
 
 IDD_SUMMARYPAGE DIALOGEX 0, 0, 317, 143
@@ -172,4 +171,13 @@ BEGIN
     IDS_PARTITION_TYPE "Type"
     IDS_PARTITION_SIZE "Taille"
     IDS_PARTITION_STATUS "Statut"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_BOOTLOADER_NOINST "Ne pas installer"
+    IDS_BOOTLOADER_REMOVABLE "Média amovible"
+    IDS_BOOTLOADER_SYSTEM "Partition système (par défaut)"
+    IDS_BOOTLOADER_MBRVBR "MBR et VBR (par défaut)"
+    IDS_BOOTLOADER_VBRONLY "VBR seulement"
 END

--- a/base/setup/reactos/lang/fr-FR.rc
+++ b/base/setup/reactos/lang/fr-FR.rc
@@ -1,5 +1,7 @@
 LANGUAGE LANG_FRENCH, SUBLANG_NEUTRAL
 
+/* Dialogs */
+
 IDD_STARTPAGE DIALOGEX 0, 0, 317, 193
 STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
 CAPTION "Installation de ReactOS"
@@ -138,6 +140,8 @@ BEGIN
     LTEXT "S'il y a un CD dans le lecteur, retirez le. Appuyez ensuite sur Terminer pour redémarrer votre ordinateur.", IDC_STATIC, 115, 169, 195, 17
 END
 
+/* Strings */
+
 STRINGTABLE
 BEGIN
     IDS_TYPETITLE "Bienvenue dans l'installation de ReactOS"
@@ -180,4 +184,19 @@ BEGIN
     IDS_BOOTLOADER_SYSTEM "Partition système (par défaut)"
     IDS_BOOTLOADER_MBRVBR "MBR et VBR (par défaut)"
     IDS_BOOTLOADER_VBRONLY "VBR seulement"
+END
+
+/* Error Strings */
+
+STRINGTABLE
+BEGIN
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR_TITLE "Caractère invalide"
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR "Les seuls caractères valides sont :\n\
+alphanumériques (a-z, A-Z, 0-9), et\n . \\ - _\n\
+Les caractères d'espacement ne sont pas autorisés."
+
+// ERROR_DIRECTORY_NAME
+    IDS_ERROR_DIRECTORY_NAME_TITLE "Chemin d'installation invalide"
+    IDS_ERROR_DIRECTORY_NAME "Le chemin d'installation de ReactOS doit être au format DOS de noms 8.3, \
+et contenir seulement des lettres, chiffres, tirets et points. Les caractères d'espacement ne sont pas autorisés."
 END

--- a/base/setup/reactos/lang/he-IL.rc
+++ b/base/setup/reactos/lang/he-IL.rc
@@ -78,19 +78,18 @@ BEGIN
     PUSHBUTTON "ביטול", IDCANCEL, 87, 68, 47, 15, WS_VISIBLE | WS_TABSTOP
 END
 
-IDD_BOOTOPTIONS DIALOGEX 0, 0, 305, 116
+IDD_ADVINSTOPTS DIALOGEX 0, 0, 305, 135
 STYLE DS_SHELLFONT | WS_VISIBLE | WS_CAPTION
-CAPTION "הגדרות מחיצה מתקדמות"
+CAPTION "Advanced Installation Options"
 FONT 8, "MS Shell Dlg"
 BEGIN
-    CONTROL "תיקיית התקנה", IDC_STATIC, "Button", BS_GROUPBOX, 4, 1, 298, 30
-    EDITTEXT IDC_PATH, 10, 11, 278, 13, WS_VISIBLE
-    CONTROL "Boot loader installation", IDC_STATIC, "Button", BS_GROUPBOX, 4, 36, 298, 52
-    CONTROL "Install boot loader on the hard disk (MBR and VBR)", IDC_INSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 46, 278, 11
-    CONTROL "Install boot loader on the hard disk (VBR only)", IDC_INSTVBRONLY, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 57, 278, 11
-    CONTROL "No installation of bootloader", IDC_NOINSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP | WS_DISABLED, 10, 68, 278, 11
-    PUSHBUTTON "אישור", IDOK, 180, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
-    PUSHBUTTON "ביטול", IDCANCEL, 240, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
+    LTEXT "Choose the &directory where you want to install ReactOS:", IDC_STATIC, 7, 9, 291, 10
+    EDITTEXT IDC_PATH, 7, 23, 291, 13, WS_VISIBLE
+    GROUPBOX "Bootloader", IDC_STATIC, 7, 45, 291, 60
+    LTEXT "Select the location where the FreeLoader\nbootloader should be installed.\n\nBy default, it is installed on the system partition of the boot disk (and either in the Master or the Volume Boot Record for BIOS-based computers).", IDC_STATIC, 13, 57, 279, 44
+    COMBOBOX IDC_INSTFREELDR, 150, 58, 142, 45, WS_VSCROLL | WS_TABSTOP | CBS_DROPDOWNLIST
+    PUSHBUTTON "אישור", IDOK, 193, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
+    PUSHBUTTON "ביטול", IDCANCEL, 248, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
 END
 
 IDD_SUMMARYPAGE DIALOGEX 0, 0, 317, 143
@@ -148,9 +147,9 @@ BEGIN
     IDS_DEVICETITLE "Setup the basic devices"
     IDS_DEVICESUBTITLE "Set the settings of display and keyboard."
     IDS_DRIVETITLE "Setup the installation partition and system folder"
-    IDS_DRIVESUBTITLE "Prepare installation partition, system folder and boot loader."
+    IDS_DRIVESUBTITLE "Prepare installation partition, system folder and bootloader."
     IDS_PROCESSTITLE "Setup partition, copy files and setup system"
-    IDS_PROCESSSUBTITLE "Create and format partition, copy files, install and setup boot loader"
+    IDS_PROCESSSUBTITLE "Create and format partition, copy files, install and setup bootloader"
     IDS_RESTARTTITLE "First stage of setup finished"
     IDS_RESTARTSUBTITLE "The first stage of setup has been completed, restart to continue with second stage"
     IDS_SUMMARYTITLE "סיכום ההתקנה"
@@ -174,4 +173,13 @@ BEGIN
     IDS_PARTITION_TYPE "סוג"
     IDS_PARTITION_SIZE "גודל"
     IDS_PARTITION_STATUS "מצב"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_BOOTLOADER_NOINST "No installation"
+    IDS_BOOTLOADER_REMOVABLE "Removable media"
+    IDS_BOOTLOADER_SYSTEM "System partition (Default)"
+    IDS_BOOTLOADER_MBRVBR "MBR and VBR (Default)"
+    IDS_BOOTLOADER_VBRONLY "VBR only"
 END

--- a/base/setup/reactos/lang/he-IL.rc
+++ b/base/setup/reactos/lang/he-IL.rc
@@ -2,6 +2,8 @@
 
 LANGUAGE LANG_HEBREW, SUBLANG_DEFAULT
 
+/* Dialogs */
+
 IDD_STARTPAGE DIALOGEX 0, 0, 317, 193
 STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
 CAPTION "התקנת ReactOS"
@@ -140,6 +142,8 @@ BEGIN
     LTEXT "'אם יש דיסק בכונן, הסר אותו ואז, בשביל מחדש את המחשב לחץ על 'סיום", IDC_STATIC, 115, 169, 195, 17
 END
 
+/* Strings */
+
 STRINGTABLE
 BEGIN
     IDS_TYPETITLE "ברוכים הבאים לתוכנית ההתקנה של ReactOS"
@@ -182,4 +186,19 @@ BEGIN
     IDS_BOOTLOADER_SYSTEM "System partition (Default)"
     IDS_BOOTLOADER_MBRVBR "MBR and VBR (Default)"
     IDS_BOOTLOADER_VBRONLY "VBR only"
+END
+
+/* Error Strings */
+
+STRINGTABLE
+BEGIN
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR_TITLE "Invalid character"
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR "The only valid characters are:\n\
+alphanumericals (a-z, A-Z, 0-9), and\n . \\ - _\n\
+Spaces are not allowed."
+
+// ERROR_DIRECTORY_NAME
+    IDS_ERROR_DIRECTORY_NAME_TITLE "Invalid installation path"
+    IDS_ERROR_DIRECTORY_NAME "The ReactOS installation path must follow the DOS 8.3 naming scheme, \
+and only contain letters, digits, dashes and periods. Spaces are not allowed."
 END

--- a/base/setup/reactos/lang/hi-IN.rc
+++ b/base/setup/reactos/lang/hi-IN.rc
@@ -72,19 +72,18 @@ BEGIN
     PUSHBUTTON "&रद्द करे", IDCANCEL, 87, 68, 47, 15, WS_VISIBLE | WS_TABSTOP
 END
 
-IDD_BOOTOPTIONS DIALOGEX 0, 0, 305, 116
+IDD_ADVINSTOPTS DIALOGEX 0, 0, 305, 135
 STYLE DS_SHELLFONT | WS_VISIBLE | WS_CAPTION
-CAPTION "उन्नत विभाजन सेटिंग्स"
+CAPTION "Advanced Installation Options"
 FONT 8, "MS Shell Dlg"
 BEGIN
-    CONTROL "इन्स्टलेशन फ़ोल्डर", IDC_STATIC, "Button", BS_GROUPBOX, 4, 1, 298, 30
-    EDITTEXT IDC_PATH, 10, 11, 278, 13, WS_VISIBLE
-    CONTROL "बूट लोडर इन्स्टलेशन", IDC_STATIC, "Button", BS_GROUPBOX, 4, 36, 298, 52
-    CONTROL "हार्ड डिस्क पर बूट लोडर इंस्टॉल करें (MBR और VBR)", IDC_INSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 46, 278, 11
-    CONTROL "हार्ड डिस्क पर बूट लोडर इंस्टॉल करें (केवल VBR)", IDC_INSTVBRONLY, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 57, 278, 11
-    CONTROL "बूटलोडर की कोई इन्स्टलेशन नहीं", IDC_NOINSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP | WS_DISABLED, 10, 68, 278, 11
-    PUSHBUTTON "&ओके", IDOK, 180, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
-    PUSHBUTTON "&रद्द करे", IDCANCEL, 240, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
+    LTEXT "Choose the &directory where you want to install ReactOS:", IDC_STATIC, 7, 9, 291, 10
+    EDITTEXT IDC_PATH, 7, 23, 291, 13, WS_VISIBLE
+    GROUPBOX "Bootloader", IDC_STATIC, 7, 45, 291, 60
+    LTEXT "Select the location where the FreeLoader\nbootloader should be installed.\n\nBy default, it is installed on the system partition of the boot disk (and either in the Master or the Volume Boot Record for BIOS-based computers).", IDC_STATIC, 13, 57, 279, 44
+    COMBOBOX IDC_INSTFREELDR, 150, 58, 142, 45, WS_VSCROLL | WS_TABSTOP | CBS_DROPDOWNLIST
+    PUSHBUTTON "ओके", IDOK, 193, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
+    PUSHBUTTON "रद्द करे", IDCANCEL, 248, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
 END
 
 IDD_SUMMARYPAGE DIALOGEX 0, 0, 317, 143
@@ -142,4 +141,13 @@ BEGIN
     IDS_PARTITION_NAME "नाम"
     IDS_PARTITION_SIZE "साइज़"
     IDS_PARTITION_TYPE "प्रकार"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_BOOTLOADER_NOINST "No installation"
+    IDS_BOOTLOADER_REMOVABLE "Removable media"
+    IDS_BOOTLOADER_SYSTEM "System partition (Default)"
+    IDS_BOOTLOADER_MBRVBR "MBR और VBR (Default)"
+    IDS_BOOTLOADER_VBRONLY "केवल VBR"
 END

--- a/base/setup/reactos/lang/hi-IN.rc
+++ b/base/setup/reactos/lang/hi-IN.rc
@@ -7,6 +7,8 @@
 
 LANGUAGE LANG_HINDI, SUBLANG_HINDI_INDIA
 
+/* Dialogs */
+
 IDD_STARTPAGE DIALOGEX 0, 0, 317, 193
 STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
 CAPTION "रिऐक्ट ओएस सेटअप"
@@ -116,6 +118,8 @@ BEGIN
     LTEXT "यदि ड्राइव में सीडी है, तो इसे हटा दें। फिर, अपने कंप्यूटर को पुनरारंभ करने के लिए, समाप्त क्लिक करें।", IDC_STATIC, 115, 169, 195, 17
 END
 
+/* Strings */
+
 STRINGTABLE
 BEGIN
     IDS_TYPETITLE "रिऐक्ट ओएस सेटअप में आपका स्वागत है"
@@ -150,4 +154,19 @@ BEGIN
     IDS_BOOTLOADER_SYSTEM "System partition (Default)"
     IDS_BOOTLOADER_MBRVBR "MBR और VBR (Default)"
     IDS_BOOTLOADER_VBRONLY "केवल VBR"
+END
+
+/* Error Strings */
+
+STRINGTABLE
+BEGIN
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR_TITLE "Invalid character"
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR "The only valid characters are:\n\
+alphanumericals (a-z, A-Z, 0-9), and\n . \\ - _\n\
+Spaces are not allowed."
+
+// ERROR_DIRECTORY_NAME
+    IDS_ERROR_DIRECTORY_NAME_TITLE "Invalid installation path"
+    IDS_ERROR_DIRECTORY_NAME "The ReactOS installation path must follow the DOS 8.3 naming scheme, \
+and only contain letters, digits, dashes and periods. Spaces are not allowed."
 END

--- a/base/setup/reactos/lang/hu-HU.rc
+++ b/base/setup/reactos/lang/hu-HU.rc
@@ -78,19 +78,18 @@ BEGIN
     PUSHBUTTON "&Cancel", IDCANCEL, 87, 68, 47, 15, WS_VISIBLE | WS_TABSTOP
 END
 
-IDD_BOOTOPTIONS DIALOGEX 0, 0, 305, 116
+IDD_ADVINSTOPTS DIALOGEX 0, 0, 305, 135
 STYLE DS_SHELLFONT | WS_VISIBLE | WS_CAPTION
-CAPTION "Advanced Partition Settings"
+CAPTION "Advanced Installation Options"
 FONT 8, "MS Shell Dlg"
 BEGIN
-    CONTROL "Installation folder", IDC_STATIC, "Button", BS_GROUPBOX, 4, 1, 298, 30
-    EDITTEXT IDC_PATH, 10, 11, 278, 13, WS_VISIBLE
-    CONTROL "Boot loader installation", IDC_STATIC, "Button", BS_GROUPBOX, 4, 36, 298, 52
-    CONTROL "Install boot loader on the hard disk (MBR and VBR)", IDC_INSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 46, 278, 11
-    CONTROL "Install boot loader on the hard disk (VBR only)", IDC_INSTVBRONLY, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 57, 278, 11
-    CONTROL "No installation of bootloader", IDC_NOINSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP | WS_DISABLED, 10, 68, 278, 11
-    PUSHBUTTON "&OK", IDOK, 180, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
-    PUSHBUTTON "&Cancel", IDCANCEL, 240, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
+    LTEXT "Choose the &directory where you want to install ReactOS:", IDC_STATIC, 7, 9, 291, 10
+    EDITTEXT IDC_PATH, 7, 23, 291, 13, WS_VISIBLE
+    GROUPBOX "Bootloader", IDC_STATIC, 7, 45, 291, 60
+    LTEXT "Select the location where the FreeLoader\nbootloader should be installed.\n\nBy default, it is installed on the system partition of the boot disk (and either in the Master or the Volume Boot Record for BIOS-based computers).", IDC_STATIC, 13, 57, 279, 44
+    COMBOBOX IDC_INSTFREELDR, 150, 58, 142, 45, WS_VSCROLL | WS_TABSTOP | CBS_DROPDOWNLIST
+    PUSHBUTTON "OK", IDOK, 193, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
+    PUSHBUTTON "Cancel", IDCANCEL, 248, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
 END
 
 IDD_SUMMARYPAGE DIALOGEX 0, 0, 317, 143
@@ -148,9 +147,9 @@ BEGIN
     IDS_DEVICETITLE "Setup the basic devices"
     IDS_DEVICESUBTITLE "Set the settings of display and keyboard."
     IDS_DRIVETITLE "Setup the installation partition and system folder"
-    IDS_DRIVESUBTITLE "Prepare installation partition, system folder and boot loader."
+    IDS_DRIVESUBTITLE "Prepare installation partition, system folder and bootloader."
     IDS_PROCESSTITLE "Setup partition, copy files and setup system"
-    IDS_PROCESSSUBTITLE "Create and format partition, copy files, install and setup boot loader"
+    IDS_PROCESSSUBTITLE "Create and format partition, copy files, install and setup bootloader"
     IDS_RESTARTTITLE "First stage of setup finished"
     IDS_RESTARTSUBTITLE "The first stage of setup has been completed, restart to continue with second stage"
     IDS_SUMMARYTITLE "Installation Summary"
@@ -174,4 +173,13 @@ BEGIN
     IDS_PARTITION_TYPE "Type"
     IDS_PARTITION_SIZE "Size"
     IDS_PARTITION_STATUS "Status"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_BOOTLOADER_NOINST "No installation"
+    IDS_BOOTLOADER_REMOVABLE "Removable media"
+    IDS_BOOTLOADER_SYSTEM "System partition (Default)"
+    IDS_BOOTLOADER_MBRVBR "MBR and VBR (Default)"
+    IDS_BOOTLOADER_VBRONLY "VBR only"
 END

--- a/base/setup/reactos/lang/hu-HU.rc
+++ b/base/setup/reactos/lang/hu-HU.rc
@@ -2,6 +2,8 @@
 
 LANGUAGE LANG_HUNGARIAN, SUBLANG_DEFAULT
 
+/* Dialogs */
+
 IDD_STARTPAGE DIALOGEX 0, 0, 317, 193
 STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
 CAPTION "ReactOS telepítõ"
@@ -140,6 +142,8 @@ BEGIN
     LTEXT "If there is a CD in a drive, remove it. Then, to restart your computer, click Finish.", IDC_STATIC, 115, 169, 195, 17
 END
 
+/* Strings */
+
 STRINGTABLE
 BEGIN
     IDS_TYPETITLE "Welcome to ReactOS Setup"
@@ -182,4 +186,19 @@ BEGIN
     IDS_BOOTLOADER_SYSTEM "System partition (Default)"
     IDS_BOOTLOADER_MBRVBR "MBR and VBR (Default)"
     IDS_BOOTLOADER_VBRONLY "VBR only"
+END
+
+/* Error Strings */
+
+STRINGTABLE
+BEGIN
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR_TITLE "Invalid character"
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR "The only valid characters are:\n\
+alphanumericals (a-z, A-Z, 0-9), and\n . \\ - _\n\
+Spaces are not allowed."
+
+// ERROR_DIRECTORY_NAME
+    IDS_ERROR_DIRECTORY_NAME_TITLE "Invalid installation path"
+    IDS_ERROR_DIRECTORY_NAME "The ReactOS installation path must follow the DOS 8.3 naming scheme, \
+and only contain letters, digits, dashes and periods. Spaces are not allowed."
 END

--- a/base/setup/reactos/lang/id-ID.rc
+++ b/base/setup/reactos/lang/id-ID.rc
@@ -1,5 +1,7 @@
 LANGUAGE LANG_INDONESIAN, SUBLANG_DEFAULT
 
+/* Dialogs */
+
 IDD_STARTPAGE DIALOGEX 0, 0, 317, 193
 STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
 CAPTION "Penyetelan ReactOS"
@@ -138,6 +140,8 @@ BEGIN
     LTEXT "Jika terdapat CD pada drive, keluarkan. Lalu, untuk memulai ulang komputer, klik Selesai.", IDC_STATIC, 115, 169, 195, 17
 END
 
+/* Strings */
+
 STRINGTABLE
 BEGIN
     IDS_TYPETITLE "Selamat datang di Penyetelan ReactOS"
@@ -180,4 +184,19 @@ BEGIN
     IDS_BOOTLOADER_SYSTEM "System partition (Default)"
     IDS_BOOTLOADER_MBRVBR "MBR dan VBR (Default)"
     IDS_BOOTLOADER_VBRONLY "Hanya VBR"
+END
+
+/* Error Strings */
+
+STRINGTABLE
+BEGIN
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR_TITLE "Invalid character"
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR "The only valid characters are:\n\
+alphanumericals (a-z, A-Z, 0-9), and\n . \\ - _\n\
+Spaces are not allowed."
+
+// ERROR_DIRECTORY_NAME
+    IDS_ERROR_DIRECTORY_NAME_TITLE "Invalid installation path"
+    IDS_ERROR_DIRECTORY_NAME "The ReactOS installation path must follow the DOS 8.3 naming scheme, \
+and only contain letters, digits, dashes and periods. Spaces are not allowed."
 END

--- a/base/setup/reactos/lang/id-ID.rc
+++ b/base/setup/reactos/lang/id-ID.rc
@@ -76,19 +76,18 @@ BEGIN
     PUSHBUTTON "&Batal", IDCANCEL, 87, 68, 47, 15, WS_VISIBLE | WS_TABSTOP
 END
 
-IDD_BOOTOPTIONS DIALOGEX 0, 0, 305, 116
+IDD_ADVINSTOPTS DIALOGEX 0, 0, 305, 135
 STYLE DS_SHELLFONT | WS_VISIBLE | WS_CAPTION
-CAPTION "Pengaturan Partisi Tingkat Lanjut"
+CAPTION "Advanced Installation Options"
 FONT 8, "MS Shell Dlg"
 BEGIN
-    CONTROL "Folder pemasangan", IDC_STATIC, "Button", BS_GROUPBOX, 4, 1, 298, 30
-    EDITTEXT IDC_PATH, 10, 11, 278, 13, WS_VISIBLE
-    CONTROL "Pemasangan bootloader", IDC_STATIC, "Button", BS_GROUPBOX, 4, 36, 298, 52
-    CONTROL "Pasang bootloader pada hard disk (MBR dan VBR)", IDC_INSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 46, 278, 11
-    CONTROL "Pasang bootloader pada hard disk (hanya VBR)", IDC_INSTVBRONLY, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 57, 278, 11
-    CONTROL "Tidak ada pemasangan bootloader", IDC_NOINSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP | WS_DISABLED, 10, 68, 278, 11
-    PUSHBUTTON "&OK", IDOK, 180, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
-    PUSHBUTTON "&Batal", IDCANCEL, 240, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
+    LTEXT "Choose the &directory where you want to install ReactOS:", IDC_STATIC, 7, 9, 291, 10
+    EDITTEXT IDC_PATH, 7, 23, 291, 13, WS_VISIBLE
+    GROUPBOX "Bootloader", IDC_STATIC, 7, 45, 291, 60
+    LTEXT "Select the location where the FreeLoader\nbootloader should be installed.\n\nBy default, it is installed on the system partition of the boot disk (and either in the Master or the Volume Boot Record for BIOS-based computers).", IDC_STATIC, 13, 57, 279, 44
+    COMBOBOX IDC_INSTFREELDR, 150, 58, 142, 45, WS_VSCROLL | WS_TABSTOP | CBS_DROPDOWNLIST
+    PUSHBUTTON "OK", IDOK, 193, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
+    PUSHBUTTON "Batal", IDCANCEL, 248, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
 END
 
 IDD_SUMMARYPAGE DIALOGEX 0, 0, 317, 143
@@ -172,4 +171,13 @@ BEGIN
     IDS_PARTITION_TYPE "Jenis"
     IDS_PARTITION_SIZE "Ukuran"
     IDS_PARTITION_STATUS "Status"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_BOOTLOADER_NOINST "No installation"
+    IDS_BOOTLOADER_REMOVABLE "Removable media"
+    IDS_BOOTLOADER_SYSTEM "System partition (Default)"
+    IDS_BOOTLOADER_MBRVBR "MBR dan VBR (Default)"
+    IDS_BOOTLOADER_VBRONLY "Hanya VBR"
 END

--- a/base/setup/reactos/lang/it-IT.rc
+++ b/base/setup/reactos/lang/it-IT.rc
@@ -76,19 +76,18 @@ BEGIN
     PUSHBUTTON "&Annulla", IDCANCEL, 87, 68, 47, 15, WS_VISIBLE | WS_TABSTOP
 END
 
-IDD_BOOTOPTIONS DIALOGEX 0, 0, 305, 116
+IDD_ADVINSTOPTS DIALOGEX 0, 0, 305, 135
 STYLE DS_SHELLFONT | WS_VISIBLE | WS_CAPTION
-CAPTION "Impostazioni avanzate delle partizioni"
+CAPTION "Advanced Installation Options"
 FONT 8, "MS Shell Dlg"
 BEGIN
-    CONTROL "Cartella di installazione", IDC_STATIC, "Button", BS_GROUPBOX, 4, 1, 298, 30
-    EDITTEXT IDC_PATH, 10, 11, 278, 13, WS_VISIBLE
-    CONTROL "Installazione del Boot loader", IDC_STATIC, "Button", BS_GROUPBOX, 4, 36, 298, 52
-    CONTROL "Installazione del Boot loader sul disco fisso (MBR e VBR)", IDC_INSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 46, 278, 11
-    CONTROL "Installazione del Boot loader sul disco fisso (solo VBR)", IDC_INSTVBRONLY, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 57, 278, 11
-    CONTROL "Non installare il Boot loader", IDC_NOINSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP | WS_DISABLED, 10, 68, 278, 11
-    PUSHBUTTON "&OK", IDOK, 180, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
-    PUSHBUTTON "&Annulla", IDCANCEL, 240, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
+    LTEXT "Choose the &directory where you want to install ReactOS:", IDC_STATIC, 7, 9, 291, 10
+    EDITTEXT IDC_PATH, 7, 23, 291, 13, WS_VISIBLE
+    GROUPBOX "Bootloader", IDC_STATIC, 7, 45, 291, 60
+    LTEXT "Select the location where the FreeLoader\nbootloader should be installed.\n\nBy default, it is installed on the system partition of the boot disk (and either in the Master or the Volume Boot Record for BIOS-based computers).", IDC_STATIC, 13, 57, 279, 44
+    COMBOBOX IDC_INSTFREELDR, 150, 58, 142, 45, WS_VSCROLL | WS_TABSTOP | CBS_DROPDOWNLIST
+    PUSHBUTTON "OK", IDOK, 193, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
+    PUSHBUTTON "Annulla", IDCANCEL, 248, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
 END
 
 IDD_SUMMARYPAGE DIALOGEX 0, 0, 317, 143
@@ -146,9 +145,9 @@ BEGIN
     IDS_DEVICETITLE "Impostazione dei dispositivi di base"
     IDS_DEVICESUBTITLE "Impostazione di monitor e tastiera."
     IDS_DRIVETITLE "Impostazione della partizione e della cartella per la installazione"
-    IDS_DRIVESUBTITLE "Preparazione di partizione, cartella di sistema e Boot loader."
+    IDS_DRIVESUBTITLE "Preparazione di partizione, cartella di sistema e Bootloader."
     IDS_PROCESSTITLE "Preparazione della partizione, copia dei file e configurazione del sistema"
-    IDS_PROCESSSUBTITLE "Creazione e formattazione della partizione, copia dei file, installazione del Boot loader"
+    IDS_PROCESSSUBTITLE "Creazione e formattazione della partizione, copia dei file, installazione del Bootloader"
     IDS_RESTARTTITLE "Prima fase della installazione completata"
     IDS_RESTARTSUBTITLE "La prima fase della installazione è stata completata, riavviare il computer per procedere alla seconda fase"
     IDS_SUMMARYTITLE "Sintesi della installazione"
@@ -172,4 +171,13 @@ BEGIN
     IDS_PARTITION_TYPE "Tipo"
     IDS_PARTITION_SIZE "Dimensione"
     IDS_PARTITION_STATUS "Status"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_BOOTLOADER_NOINST "Non installare"
+    IDS_BOOTLOADER_REMOVABLE "Removable media"
+    IDS_BOOTLOADER_SYSTEM "System partition (Default)"
+    IDS_BOOTLOADER_MBRVBR "MBR e VBR (Default)"
+    IDS_BOOTLOADER_VBRONLY "Solo VBR"
 END

--- a/base/setup/reactos/lang/it-IT.rc
+++ b/base/setup/reactos/lang/it-IT.rc
@@ -1,5 +1,7 @@
 LANGUAGE LANG_ITALIAN, SUBLANG_NEUTRAL
 
+/* Dialogs */
+
 IDD_STARTPAGE DIALOGEX 0, 0, 317, 193
 STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
 CAPTION "Installazione di ReactOS"
@@ -138,6 +140,8 @@ BEGIN
     LTEXT "Se presente rimuovere il CD dal lettore e cliccare Fine per riavviare il computer.", IDC_STATIC, 115, 169, 195, 17
 END
 
+/* Strings */
+
 STRINGTABLE
 BEGIN
     IDS_TYPETITLE "Benvenuti nell'installazione di ReactOS"
@@ -180,4 +184,19 @@ BEGIN
     IDS_BOOTLOADER_SYSTEM "System partition (Default)"
     IDS_BOOTLOADER_MBRVBR "MBR e VBR (Default)"
     IDS_BOOTLOADER_VBRONLY "Solo VBR"
+END
+
+/* Error Strings */
+
+STRINGTABLE
+BEGIN
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR_TITLE "Invalid character"
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR "The only valid characters are:\n\
+alphanumericals (a-z, A-Z, 0-9), and\n . \\ - _\n\
+Spaces are not allowed."
+
+// ERROR_DIRECTORY_NAME
+    IDS_ERROR_DIRECTORY_NAME_TITLE "Invalid installation path"
+    IDS_ERROR_DIRECTORY_NAME "The ReactOS installation path must follow the DOS 8.3 naming scheme, \
+and only contain letters, digits, dashes and periods. Spaces are not allowed."
 END

--- a/base/setup/reactos/lang/ja-JP.rc
+++ b/base/setup/reactos/lang/ja-JP.rc
@@ -1,5 +1,7 @@
 LANGUAGE LANG_JAPANESE, SUBLANG_DEFAULT
 
+/* Dialogs */
+
 IDD_STARTPAGE DIALOGEX 0, 0, 317, 193
 STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
 CAPTION "ReactOS セットアップ"
@@ -138,6 +140,8 @@ BEGIN
     LTEXT "もしCDがドライブにあれば、取り除いて下さい。その後、あなたのコンピュータを再起動するには、完了をクリックして下さい。", IDC_STATIC, 115, 169, 195, 17
 END
 
+/* Strings */
+
 STRINGTABLE
 BEGIN
     IDS_TYPETITLE "ReactOS セットアップにようこそ"
@@ -180,4 +184,19 @@ BEGIN
     IDS_BOOTLOADER_SYSTEM "System partition (Default)"
     IDS_BOOTLOADER_MBRVBR "MBRとVBR (Default)"
     IDS_BOOTLOADER_VBRONLY "VBRのみ"
+END
+
+/* Error Strings */
+
+STRINGTABLE
+BEGIN
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR_TITLE "Invalid character"
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR "The only valid characters are:\n\
+alphanumericals (a-z, A-Z, 0-9), and\n . \\ - _\n\
+Spaces are not allowed."
+
+// ERROR_DIRECTORY_NAME
+    IDS_ERROR_DIRECTORY_NAME_TITLE "Invalid installation path"
+    IDS_ERROR_DIRECTORY_NAME "The ReactOS installation path must follow the DOS 8.3 naming scheme, \
+and only contain letters, digits, dashes and periods. Spaces are not allowed."
 END

--- a/base/setup/reactos/lang/ja-JP.rc
+++ b/base/setup/reactos/lang/ja-JP.rc
@@ -76,19 +76,18 @@ BEGIN
     PUSHBUTTON "キャンセル(&C)", IDCANCEL, 89, 68, 55, 15, WS_VISIBLE | WS_TABSTOP
 END
 
-IDD_BOOTOPTIONS DIALOGEX 0, 0, 305, 116
+IDD_ADVINSTOPTS DIALOGEX 0, 0, 305, 135
 STYLE DS_SHELLFONT | WS_VISIBLE | WS_CAPTION
-CAPTION "上級者向けパーティション設定"
+CAPTION "Advanced Installation Options"
 FONT 9, "MS UI Gothic"
 BEGIN
-    CONTROL "インストール先フォルダ", IDC_STATIC, "Button", BS_GROUPBOX, 4, 1, 298, 30
-    EDITTEXT IDC_PATH, 10, 11, 278, 13, WS_VISIBLE
-    CONTROL "ブートローダのインストール", IDC_STATIC, "Button", BS_GROUPBOX, 4, 36, 298, 52
-    CONTROL "ハードディスクにブートローダをインストールする (MBRとVBR)", IDC_INSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 46, 278, 11
-    CONTROL "ハードディスクにブートローダをインストールする (VBRのみ)", IDC_INSTVBRONLY, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 57, 278, 11
-    CONTROL "ブートローダをインストールしない", IDC_NOINSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP | WS_DISABLED, 10, 68, 278, 11
-    PUSHBUTTON "&OK", IDOK, 180, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
-    PUSHBUTTON "キャンセル(&C)", IDCANCEL, 240, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
+    LTEXT "Choose the &directory where you want to install ReactOS:", IDC_STATIC, 7, 9, 291, 10
+    EDITTEXT IDC_PATH, 7, 23, 291, 13, WS_VISIBLE
+    GROUPBOX "Bootloader", IDC_STATIC, 7, 45, 291, 60
+    LTEXT "Select the location where the FreeLoader\nbootloader should be installed.\n\nBy default, it is installed on the system partition of the boot disk (and either in the Master or the Volume Boot Record for BIOS-based computers).", IDC_STATIC, 13, 57, 279, 44
+    COMBOBOX IDC_INSTFREELDR, 150, 58, 142, 45, WS_VSCROLL | WS_TABSTOP | CBS_DROPDOWNLIST
+    PUSHBUTTON "OK", IDOK, 193, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
+    PUSHBUTTON "キャンセル", IDCANCEL, 248, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
 END
 
 IDD_SUMMARYPAGE DIALOGEX 0, 0, 317, 143
@@ -172,4 +171,13 @@ BEGIN
     IDS_PARTITION_TYPE "種類"
     IDS_PARTITION_SIZE "サイズ"
     IDS_PARTITION_STATUS "状態"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_BOOTLOADER_NOINST "No installation"
+    IDS_BOOTLOADER_REMOVABLE "Removable media"
+    IDS_BOOTLOADER_SYSTEM "System partition (Default)"
+    IDS_BOOTLOADER_MBRVBR "MBRとVBR (Default)"
+    IDS_BOOTLOADER_VBRONLY "VBRのみ"
 END

--- a/base/setup/reactos/lang/ms-MY.rc
+++ b/base/setup/reactos/lang/ms-MY.rc
@@ -78,19 +78,18 @@ BEGIN
     PUSHBUTTON "Batal(&C)", IDCANCEL, 87, 68, 47, 15, WS_VISIBLE | WS_TABSTOP
 END
 
-IDD_BOOTOPTIONS DIALOGEX 0, 0, 305, 116
+IDD_ADVINSTOPTS DIALOGEX 0, 0, 305, 135
 STYLE DS_SHELLFONT | WS_VISIBLE | WS_CAPTION
-CAPTION "Seting lanjutan Partition"
+CAPTION "Advanced Installation Options"
 FONT 8, "MS Shell Dlg"
 BEGIN
-    CONTROL "Folder pemasangan", IDC_STATIC, "Button", BS_GROUPBOX, 4, 1, 298, 30
-    EDITTEXT IDC_PATH, 10, 11, 278, 13, WS_VISIBLE
-    CONTROL "Boot loader pemasangan", IDC_STATIC, "Button", BS_GROUPBOX, 4, 36, 298, 52
-    CONTROL "Memasang boot loader pada cakera keras (MBR dan VBR)", IDC_INSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 46, 278, 11
-    CONTROL "Memasang boot loader pada cakera keras (VBR sahaja)", IDC_INSTVBRONLY, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 57, 278, 11
-    CONTROL "Tiada pemasangan boot loader", IDC_NOINSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP | WS_DISABLED, 10, 68, 278, 11
-    PUSHBUTTON "&OK", IDOK, 180, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
-    PUSHBUTTON "Batal(&C)", IDCANCEL, 240, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
+    LTEXT "Choose the &directory where you want to install ReactOS:", IDC_STATIC, 7, 9, 291, 10
+    EDITTEXT IDC_PATH, 7, 23, 291, 13, WS_VISIBLE
+    GROUPBOX "Bootloader", IDC_STATIC, 7, 45, 291, 60
+    LTEXT "Select the location where the FreeLoader\nbootloader should be installed.\n\nBy default, it is installed on the system partition of the boot disk (and either in the Master or the Volume Boot Record for BIOS-based computers).", IDC_STATIC, 13, 57, 279, 44
+    COMBOBOX IDC_INSTFREELDR, 150, 58, 142, 45, WS_VSCROLL | WS_TABSTOP | CBS_DROPDOWNLIST
+    PUSHBUTTON "OK", IDOK, 193, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
+    PUSHBUTTON "Batal", IDCANCEL, 248, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
 END
 
 IDD_SUMMARYPAGE DIALOGEX 0, 0, 317, 143
@@ -148,9 +147,9 @@ BEGIN
     IDS_DEVICETITLE "Sediakan peranti asas"
     IDS_DEVICESUBTITLE "Setkan seting paparan dan papan kekunci."
     IDS_DRIVETITLE "Sediakan folder pemasangan partition dan sistem"
-    IDS_DRIVESUBTITLE "Menyediakan pemasangan partition, folder sistem dan boot loader."
+    IDS_DRIVESUBTITLE "Menyediakan pemasangan partition, folder sistem dan bootloader."
     IDS_PROCESSTITLE "Persediaan partition, salinan fail dan sistem persediaan"
-    IDS_PROCESSSUBTITLE "Cipta dan format partition, menyalin fail, memasang dan sediakan boot loader"
+    IDS_PROCESSSUBTITLE "Cipta dan format partition, menyalin fail, memasang dan sediakan bootloader"
     IDS_RESTARTTITLE "Tahap pertama Persediaan selesai"
     IDS_RESTARTSUBTITLE "Tahap pertama persediaan telah selesai, mula semula untuk meneruskan peringkat kedua"
     IDS_SUMMARYTITLE "Ringkasan pemasangan"
@@ -174,4 +173,13 @@ BEGIN
     IDS_PARTITION_TYPE "Type"
     IDS_PARTITION_SIZE "Size"
     IDS_PARTITION_STATUS "Status"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_BOOTLOADER_NOINST "Tiada pemasangan"
+    IDS_BOOTLOADER_REMOVABLE "Removable media"
+    IDS_BOOTLOADER_SYSTEM "System partition (Default)"
+    IDS_BOOTLOADER_MBRVBR "MBR dan VBR (Default)"
+    IDS_BOOTLOADER_VBRONLY "VBR sahaja"
 END

--- a/base/setup/reactos/lang/ms-MY.rc
+++ b/base/setup/reactos/lang/ms-MY.rc
@@ -2,6 +2,8 @@
 
 LANGUAGE LANG_MALAY, SUBLANG_DEFAULT
 
+/* Dialogs */
+
 IDD_STARTPAGE DIALOGEX 0, 0, 317, 193
 STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
 CAPTION "ReactOS Persediaan"
@@ -140,6 +142,8 @@ BEGIN
     LTEXT "Jika ada CD ke dalam pemacu, mengeluarkannya. Kemudian, untuk memulakan semula komputer anda, klik selesai.", IDC_STATIC, 115, 169, 195, 17
 END
 
+/* Strings */
+
 STRINGTABLE
 BEGIN
     IDS_TYPETITLE "Selamat datang ke persediaan ReactOS"
@@ -182,4 +186,19 @@ BEGIN
     IDS_BOOTLOADER_SYSTEM "System partition (Default)"
     IDS_BOOTLOADER_MBRVBR "MBR dan VBR (Default)"
     IDS_BOOTLOADER_VBRONLY "VBR sahaja"
+END
+
+/* Error Strings */
+
+STRINGTABLE
+BEGIN
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR_TITLE "Invalid character"
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR "The only valid characters are:\n\
+alphanumericals (a-z, A-Z, 0-9), and\n . \\ - _\n\
+Spaces are not allowed."
+
+// ERROR_DIRECTORY_NAME
+    IDS_ERROR_DIRECTORY_NAME_TITLE "Invalid installation path"
+    IDS_ERROR_DIRECTORY_NAME "The ReactOS installation path must follow the DOS 8.3 naming scheme, \
+and only contain letters, digits, dashes and periods. Spaces are not allowed."
 END

--- a/base/setup/reactos/lang/no-NO.rc
+++ b/base/setup/reactos/lang/no-NO.rc
@@ -76,19 +76,18 @@ BEGIN
     PUSHBUTTON "&Avbryt", IDCANCEL, 87, 68, 47, 15, WS_VISIBLE | WS_TABSTOP
 END
 
-IDD_BOOTOPTIONS DIALOGEX 0, 0, 305, 116
+IDD_ADVINSTOPTS DIALOGEX 0, 0, 305, 135
 STYLE DS_SHELLFONT | WS_VISIBLE | WS_CAPTION
-CAPTION "Avansert partisjon innstillinger"
+CAPTION "Advanced Installation Options"
 FONT 8, "MS Shell Dlg"
 BEGIN
-    CONTROL "Installasjon mappe", IDC_STATIC, "Button", BS_GROUPBOX, 4, 1, 298, 30
-    EDITTEXT IDC_PATH, 10, 11, 278, 13, WS_VISIBLE
-    CONTROL "Oppstartslaster installasjon", IDC_STATIC, "Button", BS_GROUPBOX, 4, 36, 298, 52
-    CONTROL "Installer oppstartslaster på harddiskens (MBR og VBR)", IDC_INSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 46, 278, 11
-    CONTROL "Installer oppstartslaster på harddiskens (bare VBR)", IDC_INSTVBRONLY, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 57, 278, 11
-    CONTROL "Ikke installer oppstartslaster", IDC_NOINSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP | WS_DISABLED, 10, 68, 278, 11
-    PUSHBUTTON "&OK", IDOK, 180, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
-    PUSHBUTTON "&Avbryt", IDCANCEL, 240, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
+    LTEXT "Choose the &directory where you want to install ReactOS:", IDC_STATIC, 7, 9, 291, 10
+    EDITTEXT IDC_PATH, 7, 23, 291, 13, WS_VISIBLE
+    GROUPBOX "Oppstartslaster", IDC_STATIC, 7, 45, 291, 60
+    LTEXT "Select the location where the FreeLoader\nbootloader should be installed.\n\nBy default, it is installed on the system partition of the boot disk (and either in the Master or the Volume Boot Record for BIOS-based computers).", IDC_STATIC, 13, 57, 279, 44
+    COMBOBOX IDC_INSTFREELDR, 150, 58, 142, 45, WS_VSCROLL | WS_TABSTOP | CBS_DROPDOWNLIST
+    PUSHBUTTON "OK", IDOK, 193, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
+    PUSHBUTTON "Avbryt", IDCANCEL, 248, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
 END
 
 IDD_SUMMARYPAGE DIALOGEX 0, 0, 317, 143
@@ -172,4 +171,13 @@ BEGIN
     IDS_PARTITION_TYPE "Type"
     IDS_PARTITION_SIZE "Size"
     IDS_PARTITION_STATUS "Status"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_BOOTLOADER_NOINST "No installation"
+    IDS_BOOTLOADER_REMOVABLE "Removable media"
+    IDS_BOOTLOADER_SYSTEM "System partition (Default)"
+    IDS_BOOTLOADER_MBRVBR "MBR og VBR (Default)"
+    IDS_BOOTLOADER_VBRONLY "Bare VBR"
 END

--- a/base/setup/reactos/lang/no-NO.rc
+++ b/base/setup/reactos/lang/no-NO.rc
@@ -1,5 +1,7 @@
 LANGUAGE LANG_NORWEGIAN, SUBLANG_NEUTRAL
 
+/* Dialogs */
+
 IDD_STARTPAGE DIALOGEX 0, 0, 317, 193
 STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
 CAPTION "ReactOS installering"
@@ -138,6 +140,8 @@ BEGIN
     LTEXT "Hvis du fortsatt har CD platen i stasjon, fjern denne. For å starte din datamaskin på nytt, trykk på Fullført.", IDC_STATIC, 115, 169, 195, 17
 END
 
+/* Strings */
+
 STRINGTABLE
 BEGIN
     IDS_TYPETITLE "Velkommen til ReactOS installering"
@@ -180,4 +184,19 @@ BEGIN
     IDS_BOOTLOADER_SYSTEM "System partition (Default)"
     IDS_BOOTLOADER_MBRVBR "MBR og VBR (Default)"
     IDS_BOOTLOADER_VBRONLY "Bare VBR"
+END
+
+/* Error Strings */
+
+STRINGTABLE
+BEGIN
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR_TITLE "Invalid character"
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR "The only valid characters are:\n\
+alphanumericals (a-z, A-Z, 0-9), and\n . \\ - _\n\
+Spaces are not allowed."
+
+// ERROR_DIRECTORY_NAME
+    IDS_ERROR_DIRECTORY_NAME_TITLE "Invalid installation path"
+    IDS_ERROR_DIRECTORY_NAME "The ReactOS installation path must follow the DOS 8.3 naming scheme, \
+and only contain letters, digits, dashes and periods. Spaces are not allowed."
 END

--- a/base/setup/reactos/lang/pl-PL.rc
+++ b/base/setup/reactos/lang/pl-PL.rc
@@ -87,19 +87,18 @@ BEGIN
     PUSHBUTTON "&Anuluj", IDCANCEL, 87, 68, 47, 15, WS_VISIBLE | WS_TABSTOP
 END
 
-IDD_BOOTOPTIONS DIALOGEX 0, 0, 305, 116
+IDD_ADVINSTOPTS DIALOGEX 0, 0, 305, 135
 STYLE DS_SHELLFONT | WS_VISIBLE | WS_CAPTION
-CAPTION "Zaawansowane ustawienia partycji"
+CAPTION "Advanced Installation Options"
 FONT 8, "MS Shell Dlg"
 BEGIN
-    CONTROL "Folder instalacji", IDC_STATIC, "Button", BS_GROUPBOX, 4, 1, 298, 30
-    EDITTEXT IDC_PATH, 10, 11, 278, 13, WS_VISIBLE
-    CONTROL "Instalacja menedżera rozruchu", IDC_STATIC, "Button", BS_GROUPBOX, 4, 36, 298, 52
-    CONTROL "Instaluj menedżer rozruchu na dysku twardym (MBR i VBR)", IDC_INSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 46, 278, 11
-    CONTROL "Instaluj menedżer rozruchu na dysku twardym (tylko VBR)", IDC_INSTVBRONLY, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 57, 278, 11
-    CONTROL "Pomiń instalację menedżera rozruchu", IDC_NOINSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP | WS_DISABLED, 10, 68, 278, 11
-    PUSHBUTTON "&OK", IDOK, 180, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
-    PUSHBUTTON "&Anuluj", IDCANCEL, 240, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
+    LTEXT "Choose the &directory where you want to install ReactOS:", IDC_STATIC, 7, 9, 291, 10
+    EDITTEXT IDC_PATH, 7, 23, 291, 13, WS_VISIBLE
+    GROUPBOX "Bootloader", IDC_STATIC, 7, 45, 291, 60
+    LTEXT "Select the location where the FreeLoader\nbootloader should be installed.\n\nBy default, it is installed on the system partition of the boot disk (and either in the Master or the Volume Boot Record for BIOS-based computers).", IDC_STATIC, 13, 57, 279, 44
+    COMBOBOX IDC_INSTFREELDR, 150, 58, 142, 45, WS_VSCROLL | WS_TABSTOP | CBS_DROPDOWNLIST
+    PUSHBUTTON "OK", IDOK, 193, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
+    PUSHBUTTON "Anuluj", IDCANCEL, 248, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
 END
 
 IDD_SUMMARYPAGE DIALOGEX 0, 0, 317, 143
@@ -183,4 +182,13 @@ BEGIN
     IDS_PARTITION_TYPE "Rodzaj"
     IDS_PARTITION_SIZE "Rozmiar"
     IDS_PARTITION_STATUS "Stan"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_BOOTLOADER_NOINST "Pomiń instalację"
+    IDS_BOOTLOADER_REMOVABLE "Removable media"
+    IDS_BOOTLOADER_SYSTEM "System partition (Default)"
+    IDS_BOOTLOADER_MBRVBR "MBR i VBR (Default)"
+    IDS_BOOTLOADER_VBRONLY "Tylko VBR"
 END

--- a/base/setup/reactos/lang/pl-PL.rc
+++ b/base/setup/reactos/lang/pl-PL.rc
@@ -11,6 +11,8 @@
 
 LANGUAGE LANG_POLISH, SUBLANG_DEFAULT
 
+/* Dialogs */
+
 IDD_STARTPAGE DIALOGEX 0, 0, 317, 193
 STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
 CAPTION "Instalator systemu ReactOS"
@@ -149,6 +151,8 @@ BEGIN
     LTEXT "Jeśli w napędzie jest płyta CD, wyjmij ją. Następnie Kliknij Zakończ, aby ponownie uruchomić komputer.", IDC_STATIC, 115, 169, 195, 17
 END
 
+/* Strings */
+
 STRINGTABLE
 BEGIN
     IDS_TYPETITLE "Witamy w Kreatorze instalacji systemu ReactOS"
@@ -191,4 +195,19 @@ BEGIN
     IDS_BOOTLOADER_SYSTEM "System partition (Default)"
     IDS_BOOTLOADER_MBRVBR "MBR i VBR (Default)"
     IDS_BOOTLOADER_VBRONLY "Tylko VBR"
+END
+
+/* Error Strings */
+
+STRINGTABLE
+BEGIN
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR_TITLE "Invalid character"
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR "The only valid characters are:\n\
+alphanumericals (a-z, A-Z, 0-9), and\n . \\ - _\n\
+Spaces are not allowed."
+
+// ERROR_DIRECTORY_NAME
+    IDS_ERROR_DIRECTORY_NAME_TITLE "Invalid installation path"
+    IDS_ERROR_DIRECTORY_NAME "The ReactOS installation path must follow the DOS 8.3 naming scheme, \
+and only contain letters, digits, dashes and periods. Spaces are not allowed."
 END

--- a/base/setup/reactos/lang/pt-BR.rc
+++ b/base/setup/reactos/lang/pt-BR.rc
@@ -1,5 +1,7 @@
 LANGUAGE LANG_PORTUGUESE, SUBLANG_PORTUGUESE_BRAZILIAN
 
+/* Dialogs */
+
 IDD_STARTPAGE DIALOGEX 0, 0, 317, 193
 STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
 CAPTION "Instalação do ReactOS"
@@ -138,6 +140,8 @@ BEGIN
     LTEXT "Se houver um CD no drive, remova-o. Após isto, clique em Finalizar para reiniciar o computador.", IDC_STATIC, 115, 169, 195, 17
 END
 
+/* Strings */
+
 STRINGTABLE
 BEGIN
     IDS_TYPETITLE "Bem-vindo(a) a Instalação do ReactOS"
@@ -180,4 +184,19 @@ BEGIN
     IDS_BOOTLOADER_SYSTEM "System partition (Default)"
     IDS_BOOTLOADER_MBRVBR "MBR e VBR (Default)"
     IDS_BOOTLOADER_VBRONLY "Apenas VBR"
+END
+
+/* Error Strings */
+
+STRINGTABLE
+BEGIN
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR_TITLE "Invalid character"
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR "The only valid characters are:\n\
+alphanumericals (a-z, A-Z, 0-9), and\n . \\ - _\n\
+Spaces are not allowed."
+
+// ERROR_DIRECTORY_NAME
+    IDS_ERROR_DIRECTORY_NAME_TITLE "Invalid installation path"
+    IDS_ERROR_DIRECTORY_NAME "The ReactOS installation path must follow the DOS 8.3 naming scheme, \
+and only contain letters, digits, dashes and periods. Spaces are not allowed."
 END

--- a/base/setup/reactos/lang/pt-BR.rc
+++ b/base/setup/reactos/lang/pt-BR.rc
@@ -76,19 +76,18 @@ BEGIN
     PUSHBUTTON "&Cancelar", IDCANCEL, 87, 68, 47, 15, WS_VISIBLE | WS_TABSTOP
 END
 
-IDD_BOOTOPTIONS DIALOGEX 0, 0, 305, 116
+IDD_ADVINSTOPTS DIALOGEX 0, 0, 305, 135
 STYLE DS_SHELLFONT | WS_VISIBLE | WS_CAPTION
-CAPTION "Configurações Avançadas de Particionamento"
+CAPTION "Advanced Installation Options"
 FONT 8, "MS Shell Dlg"
 BEGIN
-    CONTROL "Pasta de instalação", IDC_STATIC, "Button", BS_GROUPBOX, 4, 1, 298, 30
-    EDITTEXT IDC_PATH, 10, 11, 278, 13, WS_VISIBLE
-    CONTROL "Instalação do boot loader", IDC_STATIC, "Button", BS_GROUPBOX, 4, 36, 298, 52
-    CONTROL "Instalar boot loader no disco rígido (MBR e VBR)", IDC_INSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 46, 278, 11
-    CONTROL "Instalar boot loader no disco rígido (apenas VBR)", IDC_INSTVBRONLY, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 57, 278, 11
-    CONTROL "Não instalar boot loader", IDC_NOINSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP | WS_DISABLED, 10, 68, 278, 11
-    PUSHBUTTON "&OK", IDOK, 180, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
-    PUSHBUTTON "&Cancelar", IDCANCEL, 240, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
+    LTEXT "Choose the &directory where you want to install ReactOS:", IDC_STATIC, 7, 9, 291, 10
+    EDITTEXT IDC_PATH, 7, 23, 291, 13, WS_VISIBLE
+    GROUPBOX "Bootloader", IDC_STATIC, 7, 45, 291, 60
+    LTEXT "Select the location where the FreeLoader\nbootloader should be installed.\n\nBy default, it is installed on the system partition of the boot disk (and either in the Master or the Volume Boot Record for BIOS-based computers).", IDC_STATIC, 13, 57, 279, 44
+    COMBOBOX IDC_INSTFREELDR, 150, 58, 142, 45, WS_VSCROLL | WS_TABSTOP | CBS_DROPDOWNLIST
+    PUSHBUTTON "OK", IDOK, 193, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
+    PUSHBUTTON "Cancelar", IDCANCEL, 248, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
 END
 
 IDD_SUMMARYPAGE DIALOGEX 0, 0, 317, 143
@@ -146,9 +145,9 @@ BEGIN
     IDS_DEVICETITLE "Instalar dispositivos básicos"
     IDS_DEVICESUBTITLE "Definir as configurações de monitor e teclado."
     IDS_DRIVETITLE "Configurar a partição de instalação e pasta do sistema"
-    IDS_DRIVESUBTITLE "Preparando partição de instalação, pasta do sistema e boot loader."
+    IDS_DRIVESUBTITLE "Preparando partição de instalação, pasta do sistema e bootloader."
     IDS_PROCESSTITLE "Preparar partição, copiar arquivos e configurar sistema"
-    IDS_PROCESSSUBTITLE "Criar e formatar partição, copiar arquivos, instalar e configurar boot loader"
+    IDS_PROCESSSUBTITLE "Criar e formatar partição, copiar arquivos, instalar e configurar bootloader"
     IDS_RESTARTTITLE "Primeira etapa de instalação finalizada"
     IDS_RESTARTSUBTITLE "A primeira etapada da instalação foi completada, reinicie o computador para prosseguir com a segunda estapa"
     IDS_SUMMARYTITLE "Sumário de Instalação"
@@ -172,4 +171,13 @@ BEGIN
     IDS_PARTITION_TYPE "Type"
     IDS_PARTITION_SIZE "Size"
     IDS_PARTITION_STATUS "Status"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_BOOTLOADER_NOINST "Não instalar"
+    IDS_BOOTLOADER_REMOVABLE "Removable media"
+    IDS_BOOTLOADER_SYSTEM "System partition (Default)"
+    IDS_BOOTLOADER_MBRVBR "MBR e VBR (Default)"
+    IDS_BOOTLOADER_VBRONLY "Apenas VBR"
 END

--- a/base/setup/reactos/lang/pt-PT.rc
+++ b/base/setup/reactos/lang/pt-PT.rc
@@ -76,19 +76,18 @@ BEGIN
     PUSHBUTTON "&Cancelar", IDCANCEL, 87, 68, 47, 15, WS_VISIBLE | WS_TABSTOP
 END
 
-IDD_BOOTOPTIONS DIALOGEX 0, 0, 305, 116
+IDD_ADVINSTOPTS DIALOGEX 0, 0, 305, 135
 STYLE DS_SHELLFONT | WS_VISIBLE | WS_CAPTION
-CAPTION "Configurações Avançadas de Particionamento"
+CAPTION "Advanced Installation Options"
 FONT 8, "MS Shell Dlg"
 BEGIN
-    CONTROL "Pasta de instalação", IDC_STATIC, "Button", BS_GROUPBOX, 4, 1, 298, 30
-    EDITTEXT IDC_PATH, 10, 11, 278, 13, WS_VISIBLE
-    CONTROL "Instalação do boot loader", IDC_STATIC, "Button", BS_GROUPBOX, 4, 36, 298, 52
-    CONTROL "Instalar boot loader no disco rígido (MBR e VBR)", IDC_INSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 46, 278, 11
-    CONTROL "Instalar boot loader no disco rígido (apenas VBR)", IDC_INSTVBRONLY, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 57, 278, 11
-    CONTROL "Não instalar boot loader", IDC_NOINSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP | WS_DISABLED, 10, 68, 278, 11
-    PUSHBUTTON "&OK", IDOK, 180, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
-    PUSHBUTTON "&Cancelar", IDCANCEL, 240, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
+    LTEXT "Choose the &directory where you want to install ReactOS:", IDC_STATIC, 7, 9, 291, 10
+    EDITTEXT IDC_PATH, 7, 23, 291, 13, WS_VISIBLE
+    GROUPBOX "Bootloader", IDC_STATIC, 7, 45, 291, 60
+    LTEXT "Select the location where the FreeLoader\nbootloader should be installed.\n\nBy default, it is installed on the system partition of the boot disk (and either in the Master or the Volume Boot Record for BIOS-based computers).", IDC_STATIC, 13, 57, 279, 44
+    COMBOBOX IDC_INSTFREELDR, 150, 58, 142, 45, WS_VSCROLL | WS_TABSTOP | CBS_DROPDOWNLIST
+    PUSHBUTTON "OK", IDOK, 193, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
+    PUSHBUTTON "Cancelar", IDCANCEL, 248, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
 END
 
 IDD_SUMMARYPAGE DIALOGEX 0, 0, 317, 143
@@ -146,9 +145,9 @@ BEGIN
     IDS_DEVICETITLE "Instalar dispositivos básicos"
     IDS_DEVICESUBTITLE "Definir as configurações de monitor e teclado."
     IDS_DRIVETITLE "Configurar a partição de instalação e pasta do sistema"
-    IDS_DRIVESUBTITLE "A preparar a partição de instalação, pasta do sistema e boot loader."
+    IDS_DRIVESUBTITLE "A preparar a partição de instalação, pasta do sistema e bootloader."
     IDS_PROCESSTITLE "Preparar partição, copiar arquivos e configurar sistema"
-    IDS_PROCESSSUBTITLE "Criar e formatar partição, copiar arquivos, instalar e configurar boot loader"
+    IDS_PROCESSSUBTITLE "Criar e formatar partição, copiar arquivos, instalar e configurar bootloader"
     IDS_RESTARTTITLE "Primeira etapa de instalação finalizada"
     IDS_RESTARTSUBTITLE "A primeira etapada da instalação foi completada, reinicie o computador para prosseguir com a segunda estapa"
     IDS_SUMMARYTITLE "Sumário de Instalação"
@@ -172,4 +171,13 @@ BEGIN
     IDS_PARTITION_TYPE "Tipo"
     IDS_PARTITION_SIZE "Tamanho"
     IDS_PARTITION_STATUS "Estado"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_BOOTLOADER_NOINST "Não instalar"
+    IDS_BOOTLOADER_REMOVABLE "Removable media"
+    IDS_BOOTLOADER_SYSTEM "System partition (Default)"
+    IDS_BOOTLOADER_MBRVBR "MBR e VBR (Default)"
+    IDS_BOOTLOADER_VBRONLY "Apenas VBR"
 END

--- a/base/setup/reactos/lang/pt-PT.rc
+++ b/base/setup/reactos/lang/pt-PT.rc
@@ -1,5 +1,7 @@
 LANGUAGE LANG_PORTUGUESE, SUBLANG_NEUTRAL
 
+/* Dialogs */
+
 IDD_STARTPAGE DIALOGEX 0, 0, 317, 193
 STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
 CAPTION "Instalação do ReactOS"
@@ -138,6 +140,8 @@ BEGIN
     LTEXT "Se houver um CD no drive, remova-o. Após isto, clique em Finalizar para reiniciar o computador.", IDC_STATIC, 115, 169, 195, 17
 END
 
+/* Strings */
+
 STRINGTABLE
 BEGIN
     IDS_TYPETITLE "Bem-vindo(a) a Instalação do ReactOS"
@@ -180,4 +184,19 @@ BEGIN
     IDS_BOOTLOADER_SYSTEM "System partition (Default)"
     IDS_BOOTLOADER_MBRVBR "MBR e VBR (Default)"
     IDS_BOOTLOADER_VBRONLY "Apenas VBR"
+END
+
+/* Error Strings */
+
+STRINGTABLE
+BEGIN
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR_TITLE "Invalid character"
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR "The only valid characters are:\n\
+alphanumericals (a-z, A-Z, 0-9), and\n . \\ - _\n\
+Spaces are not allowed."
+
+// ERROR_DIRECTORY_NAME
+    IDS_ERROR_DIRECTORY_NAME_TITLE "Invalid installation path"
+    IDS_ERROR_DIRECTORY_NAME "The ReactOS installation path must follow the DOS 8.3 naming scheme, \
+and only contain letters, digits, dashes and periods. Spaces are not allowed."
 END

--- a/base/setup/reactos/lang/ro-RO.rc
+++ b/base/setup/reactos/lang/ro-RO.rc
@@ -85,19 +85,18 @@ BEGIN
     PUSHBUTTON "&Revocare", IDCANCEL, 87, 68, 47, 15, WS_VISIBLE | WS_TABSTOP
 END
 
-IDD_BOOTOPTIONS DIALOGEX 0, 0, 305, 116
+IDD_ADVINSTOPTS DIALOGEX 0, 0, 305, 135
 STYLE DS_SHELLFONT | WS_VISIBLE | WS_CAPTION
-CAPTION "Opțiuni avansate partiție"
+CAPTION "Advanced Installation Options"
 FONT 8, "MS Shell Dlg"
 BEGIN
-    CONTROL "Folderul de instalare", IDC_STATIC, "Button", BS_GROUPBOX, 4, 1, 298, 30
-    EDITTEXT IDC_PATH, 10, 11, 278, 13, WS_VISIBLE
-    CONTROL "Instalare secvență de inițializare", IDC_STATIC, "Button", BS_GROUPBOX, 4, 36, 298, 52
-    CONTROL "Instalează inițializatorul pe hard disc (MBR și VBR)", IDC_INSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 46, 278, 11
-    CONTROL "Instalează inițializatorul pe hard disc (numai VBR)", IDC_INSTVBRONLY, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 57, 278, 11
-    CONTROL "Omite instalarea inițializatorului", IDC_NOINSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP | WS_DISABLED, 10, 68, 278, 11
-    PUSHBUTTON "&OK", IDOK, 180, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
-    PUSHBUTTON "&Revocare", IDCANCEL, 240, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
+    LTEXT "Choose the &directory where you want to install ReactOS:", IDC_STATIC, 7, 9, 291, 10
+    EDITTEXT IDC_PATH, 7, 23, 291, 13, WS_VISIBLE
+    GROUPBOX "Bootloader", IDC_STATIC, 7, 45, 291, 60
+    LTEXT "Select the location where the FreeLoader\nbootloader should be installed.\n\nBy default, it is installed on the system partition of the boot disk (and either in the Master or the Volume Boot Record for BIOS-based computers).", IDC_STATIC, 13, 57, 279, 44
+    COMBOBOX IDC_INSTFREELDR, 150, 58, 142, 45, WS_VSCROLL | WS_TABSTOP | CBS_DROPDOWNLIST
+    PUSHBUTTON "OK", IDOK, 193, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
+    PUSHBUTTON "Revocare", IDCANCEL, 248, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
 END
 
 IDD_SUMMARYPAGE DIALOGEX 0, 0, 317, 143
@@ -181,4 +180,13 @@ BEGIN
     IDS_PARTITION_TYPE "Tip"
     IDS_PARTITION_SIZE "Dimensiune"
     IDS_PARTITION_STATUS "Stare"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_BOOTLOADER_NOINST "No installation"
+    IDS_BOOTLOADER_REMOVABLE "Removable media"
+    IDS_BOOTLOADER_SYSTEM "System partition (Default)"
+    IDS_BOOTLOADER_MBRVBR "MBR și VBR (Default)"
+    IDS_BOOTLOADER_VBRONLY "Numai VBR"
 END

--- a/base/setup/reactos/lang/ro-RO.rc
+++ b/base/setup/reactos/lang/ro-RO.rc
@@ -9,6 +9,8 @@
 
 LANGUAGE LANG_ROMANIAN, SUBLANG_NEUTRAL
 
+/* Dialogs */
+
 IDD_STARTPAGE DIALOGEX 0, 0, 317, 193
 STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
 CAPTION "Expert de instalare ReactOS"
@@ -147,6 +149,8 @@ BEGIN
     LTEXT "Dacă aveți vreun CD în calculator, scoateți-l, după care apăsați Sfârșit pentru a reporni.", IDC_STATIC, 115, 169, 195, 17
 END
 
+/* Strings */
+
 STRINGTABLE
 BEGIN
     IDS_TYPETITLE "Bun venit la instalarea ReactOS"
@@ -189,4 +193,19 @@ BEGIN
     IDS_BOOTLOADER_SYSTEM "System partition (Default)"
     IDS_BOOTLOADER_MBRVBR "MBR și VBR (Default)"
     IDS_BOOTLOADER_VBRONLY "Numai VBR"
+END
+
+/* Error Strings */
+
+STRINGTABLE
+BEGIN
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR_TITLE "Invalid character"
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR "The only valid characters are:\n\
+alphanumericals (a-z, A-Z, 0-9), and\n . \\ - _\n\
+Spaces are not allowed."
+
+// ERROR_DIRECTORY_NAME
+    IDS_ERROR_DIRECTORY_NAME_TITLE "Invalid installation path"
+    IDS_ERROR_DIRECTORY_NAME "The ReactOS installation path must follow the DOS 8.3 naming scheme, \
+and only contain letters, digits, dashes and periods. Spaces are not allowed."
 END

--- a/base/setup/reactos/lang/ru-RU.rc
+++ b/base/setup/reactos/lang/ru-RU.rc
@@ -1,5 +1,7 @@
 LANGUAGE LANG_RUSSIAN, SUBLANG_DEFAULT
 
+/* Dialogs */
+
 IDD_STARTPAGE DIALOGEX 0, 0, 317, 193
 STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
 CAPTION "Установка ReactOS"
@@ -138,6 +140,8 @@ BEGIN
     LTEXT "Вы можете извлечь установочный диск. Для перезагрузки компьютера нажмите клавишу ""Завершить"".", IDC_STATIC, 115, 169, 195, 17
 END
 
+/* Strings */
+
 STRINGTABLE
 BEGIN
     IDS_TYPETITLE "Вас приветствует программа установки ReactOS"
@@ -180,4 +184,19 @@ BEGIN
     IDS_BOOTLOADER_SYSTEM "System partition (Default)"
     IDS_BOOTLOADER_MBRVBR "MBR и VBR (Default)"
     IDS_BOOTLOADER_VBRONLY "Только VBR"
+END
+
+/* Error Strings */
+
+STRINGTABLE
+BEGIN
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR_TITLE "Invalid character"
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR "The only valid characters are:\n\
+alphanumericals (a-z, A-Z, 0-9), and\n . \\ - _\n\
+Spaces are not allowed."
+
+// ERROR_DIRECTORY_NAME
+    IDS_ERROR_DIRECTORY_NAME_TITLE "Invalid installation path"
+    IDS_ERROR_DIRECTORY_NAME "The ReactOS installation path must follow the DOS 8.3 naming scheme, \
+and only contain letters, digits, dashes and periods. Spaces are not allowed."
 END

--- a/base/setup/reactos/lang/ru-RU.rc
+++ b/base/setup/reactos/lang/ru-RU.rc
@@ -76,19 +76,18 @@ BEGIN
     PUSHBUTTON "&Отставить", IDCANCEL, 87, 68, 47, 15, WS_VISIBLE | WS_TABSTOP
 END
 
-IDD_BOOTOPTIONS DIALOGEX 0, 0, 305, 116
+IDD_ADVINSTOPTS DIALOGEX 0, 0, 305, 135
 STYLE DS_SHELLFONT | WS_VISIBLE | WS_CAPTION
-CAPTION "Дополнительные параметры установки"
+CAPTION "Advanced Installation Options"
 FONT 8, "MS Shell Dlg"
 BEGIN
-    CONTROL "Основной каталог", IDC_STATIC, "Button", BS_GROUPBOX, 4, 1, 298, 30
-    EDITTEXT IDC_PATH, 10, 12, 283, 14, WS_VISIBLE
-    CONTROL "Установка загрузчика", IDC_STATIC, "Button", BS_GROUPBOX, 4, 36, 298, 52
-    CONTROL "Установить загрузчик на диск (MBR и VBR)", IDC_INSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 49, 278, 11
-    CONTROL "Установить загрузчик на диск (только VBR)", IDC_INSTVBRONLY, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 59, 278, 11
-    CONTROL "Не устанавливать загрузчик", IDC_NOINSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP | WS_DISABLED, 10, 69, 278, 11
-    PUSHBUTTON "&OK", IDOK, 184, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
-    PUSHBUTTON "&Отмена", IDCANCEL, 244, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
+    LTEXT "Choose the &directory where you want to install ReactOS:", IDC_STATIC, 7, 9, 291, 10
+    EDITTEXT IDC_PATH, 7, 23, 291, 13, WS_VISIBLE
+    GROUPBOX "Загрузчик", IDC_STATIC, 7, 45, 291, 60
+    LTEXT "Select the location where the FreeLoader\nbootloader should be installed.\n\nBy default, it is installed on the system partition of the boot disk (and either in the Master or the Volume Boot Record for BIOS-based computers).", IDC_STATIC, 13, 57, 279, 44
+    COMBOBOX IDC_INSTFREELDR, 150, 58, 142, 45, WS_VSCROLL | WS_TABSTOP | CBS_DROPDOWNLIST
+    PUSHBUTTON "ОК", IDOK, 193, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
+    PUSHBUTTON "Отмена", IDCANCEL, 248, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
 END
 
 IDD_SUMMARYPAGE DIALOGEX 0, 0, 317, 143
@@ -172,4 +171,13 @@ BEGIN
     IDS_PARTITION_TYPE "Тип"
     IDS_PARTITION_SIZE "Размер"
     IDS_PARTITION_STATUS "Status"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_BOOTLOADER_NOINST "Не устанавливать"
+    IDS_BOOTLOADER_REMOVABLE "Removable media"
+    IDS_BOOTLOADER_SYSTEM "System partition (Default)"
+    IDS_BOOTLOADER_MBRVBR "MBR и VBR (Default)"
+    IDS_BOOTLOADER_VBRONLY "Только VBR"
 END

--- a/base/setup/reactos/lang/sk-SK.rc
+++ b/base/setup/reactos/lang/sk-SK.rc
@@ -5,6 +5,8 @@
 
 LANGUAGE LANG_SLOVAK, SUBLANG_DEFAULT
 
+/* Dialogs */
+
 IDD_STARTPAGE DIALOGEX 0, 0, 317, 193
 STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
 CAPTION "Inštalácia systému ReactOS" //ReactOS Setup
@@ -143,6 +145,8 @@ BEGIN
     LTEXT "If there is a CD in a drive, remove it. Then, to restart your computer, click Finish.", IDC_STATIC, 115, 169, 195, 17
 END
 
+/* Strings */
+
 STRINGTABLE
 BEGIN
     IDS_TYPETITLE "Víta Vás inštalátor systému ReactOS" //Welcome to ReactOS Setup
@@ -185,4 +189,19 @@ BEGIN
     IDS_BOOTLOADER_SYSTEM "System partition (Default)"
     IDS_BOOTLOADER_MBRVBR "MBR a VBR (Default)"
     IDS_BOOTLOADER_VBRONLY "Iba VBR"
+END
+
+/* Error Strings */
+
+STRINGTABLE
+BEGIN
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR_TITLE "Invalid character"
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR "The only valid characters are:\n\
+alphanumericals (a-z, A-Z, 0-9), and\n . \\ - _\n\
+Spaces are not allowed."
+
+// ERROR_DIRECTORY_NAME
+    IDS_ERROR_DIRECTORY_NAME_TITLE "Invalid installation path"
+    IDS_ERROR_DIRECTORY_NAME "The ReactOS installation path must follow the DOS 8.3 naming scheme, \
+and only contain letters, digits, dashes and periods. Spaces are not allowed."
 END

--- a/base/setup/reactos/lang/sk-SK.rc
+++ b/base/setup/reactos/lang/sk-SK.rc
@@ -81,19 +81,18 @@ BEGIN
     PUSHBUTTON "&Zrušiť", IDCANCEL, 87, 68, 47, 15, WS_VISIBLE | WS_TABSTOP
 END
 
-IDD_BOOTOPTIONS DIALOGEX 0, 0, 305, 116
+IDD_ADVINSTOPTS DIALOGEX 0, 0, 305, 135
 STYLE DS_SHELLFONT | WS_VISIBLE | WS_CAPTION
-CAPTION "Rozšírené nastavenia partície"
+CAPTION "Advanced Installation Options"
 FONT 8, "MS Shell Dlg"
 BEGIN
-    CONTROL "Inštalačný priečinok", IDC_STATIC, "Button", BS_GROUPBOX, 4, 1, 298, 30
-    EDITTEXT IDC_PATH, 10, 11, 278, 13, WS_VISIBLE
-    CONTROL "Inštalácia zavádzača systému", IDC_STATIC, "Button", BS_GROUPBOX, 4, 36, 298, 52
-    CONTROL "Nainštalovať zavádzač systému na pevný disk (MBR a VBR)", IDC_INSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 46, 278, 11
-    CONTROL "Nainštalovať zavádzač systému na pevný disk (iba VBR)", IDC_INSTVBRONLY, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 57, 278, 11
-    CONTROL "Nenainštalovať zavádzač systému", IDC_NOINSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP | WS_DISABLED, 10, 68, 278, 11
-    PUSHBUTTON "&OK", IDOK, 180, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
-    PUSHBUTTON "&Zrušiť", IDCANCEL, 240, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
+    LTEXT "Choose the &directory where you want to install ReactOS:", IDC_STATIC, 7, 9, 291, 10
+    EDITTEXT IDC_PATH, 7, 23, 291, 13, WS_VISIBLE
+    GROUPBOX "Zavádzač systému", IDC_STATIC, 7, 45, 291, 60
+    LTEXT "Select the location where the FreeLoader\nbootloader should be installed.\n\nBy default, it is installed on the system partition of the boot disk (and either in the Master or the Volume Boot Record for BIOS-based computers).", IDC_STATIC, 13, 57, 279, 44
+    COMBOBOX IDC_INSTFREELDR, 150, 58, 142, 45, WS_VSCROLL | WS_TABSTOP | CBS_DROPDOWNLIST
+    PUSHBUTTON "OK", IDOK, 193, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
+    PUSHBUTTON "Zrušiť", IDCANCEL, 248, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
 END
 
 IDD_SUMMARYPAGE DIALOGEX 0, 0, 317, 143
@@ -151,9 +150,9 @@ BEGIN
     IDS_DEVICETITLE "Setup the basic devices"
     IDS_DEVICESUBTITLE "Set the settings of display and keyboard."
     IDS_DRIVETITLE "Setup the installation partition and system folder"
-    IDS_DRIVESUBTITLE "Prepare installation partition, system folder and boot loader."
+    IDS_DRIVESUBTITLE "Prepare installation partition, system folder and bootloader."
     IDS_PROCESSTITLE "Prepare partition, copy files and setup system"
-    IDS_PROCESSSUBTITLE "Create and format partition, copy files, install and setup boot loader"
+    IDS_PROCESSSUBTITLE "Create and format partition, copy files, install and setup bootloader"
     IDS_RESTARTTITLE "First stage of setup finished"
     IDS_RESTARTSUBTITLE "The first stage of setup has been completed, restart to continue with second stage"
     IDS_SUMMARYTITLE "Zhrnutie inštalácie"
@@ -177,4 +176,13 @@ BEGIN
     IDS_PARTITION_TYPE "Type"
     IDS_PARTITION_SIZE "Size"
     IDS_PARTITION_STATUS "Status"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_BOOTLOADER_NOINST "No installation"
+    IDS_BOOTLOADER_REMOVABLE "Removable media"
+    IDS_BOOTLOADER_SYSTEM "System partition (Default)"
+    IDS_BOOTLOADER_MBRVBR "MBR a VBR (Default)"
+    IDS_BOOTLOADER_VBRONLY "Iba VBR"
 END

--- a/base/setup/reactos/lang/sq-AL.rc
+++ b/base/setup/reactos/lang/sq-AL.rc
@@ -78,19 +78,18 @@ BEGIN
     PUSHBUTTON "&Anulo", IDCANCEL, 87, 68, 47, 15, WS_VISIBLE | WS_TABSTOP
 END
 
-IDD_BOOTOPTIONS DIALOGEX 0, 0, 305, 116
+IDD_ADVINSTOPTS DIALOGEX 0, 0, 305, 135
 STYLE DS_SHELLFONT | WS_VISIBLE | WS_CAPTION
-CAPTION "Krijimi i Avancuar i Particioneve"
+CAPTION "Advanced Installation Options"
 FONT 8, "MS Shell Dlg"
 BEGIN
-    CONTROL "Skeda e Instalimit", IDC_STATIC, "Button", BS_GROUPBOX, 4, 1, 298, 30
-    EDITTEXT IDC_PATH, 10, 11, 278, 13, WS_VISIBLE
-    CONTROL "Instalimi i Boot loaderit", IDC_STATIC, "Button", BS_GROUPBOX, 4, 36, 298, 52
-    CONTROL "Instalo boot loaderin në hard disk (MBR dhe VBR)", IDC_INSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 46, 278, 11
-    CONTROL "Instalo boot loaderin në hard disk (VBR veq)", IDC_INSTVBRONLY, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 57, 278, 11
-    CONTROL "Mos instalo bootloader", IDC_NOINSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP | WS_DISABLED, 10, 68, 278, 11
-    PUSHBUTTON "&Dakord", IDOK, 180, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
-    PUSHBUTTON "&Anulo", IDCANCEL, 240, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
+    LTEXT "Choose the &directory where you want to install ReactOS:", IDC_STATIC, 7, 9, 291, 10
+    EDITTEXT IDC_PATH, 7, 23, 291, 13, WS_VISIBLE
+    GROUPBOX "Bootloader", IDC_STATIC, 7, 45, 291, 60
+    LTEXT "Select the location where the FreeLoader\nbootloader should be installed.\n\nBy default, it is installed on the system partition of the boot disk (and either in the Master or the Volume Boot Record for BIOS-based computers).", IDC_STATIC, 13, 57, 279, 44
+    COMBOBOX IDC_INSTFREELDR, 150, 58, 142, 45, WS_VSCROLL | WS_TABSTOP | CBS_DROPDOWNLIST
+    PUSHBUTTON "OK", IDOK, 193, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
+    PUSHBUTTON "Anulo", IDCANCEL, 248, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
 END
 
 IDD_SUMMARYPAGE DIALOGEX 0, 0, 317, 143
@@ -148,9 +147,9 @@ BEGIN
     IDS_DEVICETITLE "Instaloni pajisjet themelore"
     IDS_DEVICESUBTITLE "Vendos parametrat e ekranit dhe tastieres."
     IDS_DRIVETITLE "Konfiguro particionet për instalim dhe dosjet e sistemit"
-    IDS_DRIVESUBTITLE "Pergatit particionet për instalim, dosjet e sistemit dhe boot loaderin."
+    IDS_DRIVESUBTITLE "Pergatit particionet për instalim, dosjet e sistemit dhe bootloaderin."
     IDS_PROCESSTITLE "Konfiguro particionet, kopjo dokumentat dhe konfiguro sistemin"
-    IDS_PROCESSSUBTITLE "Krijo dhe formato particionet, kopjo dokumentat, insalo dhe konfiguro book loaderin"
+    IDS_PROCESSSUBTITLE "Krijo dhe formato particionet, kopjo dokumentat, insalo dhe konfiguro bootloaderin"
     IDS_RESTARTTITLE "Faza e pare e instalimit ka perfunduar"
     IDS_RESTARTSUBTITLE "Faza e pare e instalimit ka perfunduar, rinisni për të vazhduar me fazen e dytë"
     IDS_SUMMARYTITLE "Përmbajtja e instalimit"
@@ -174,4 +173,13 @@ BEGIN
     IDS_PARTITION_TYPE "Type"
     IDS_PARTITION_SIZE "Size"
     IDS_PARTITION_STATUS "Status"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_BOOTLOADER_NOINST "Mos instalo"
+    IDS_BOOTLOADER_REMOVABLE "Removable media"
+    IDS_BOOTLOADER_SYSTEM "System partition (Default)"
+    IDS_BOOTLOADER_MBRVBR "MBR dhe VBR (Default)"
+    IDS_BOOTLOADER_VBRONLY "VBR veq"
 END

--- a/base/setup/reactos/lang/sq-AL.rc
+++ b/base/setup/reactos/lang/sq-AL.rc
@@ -2,6 +2,8 @@
 
 LANGUAGE LANG_ALBANIAN, SUBLANG_NEUTRAL
 
+/* Dialogs */
+
 IDD_STARTPAGE DIALOGEX 0, 0, 317, 193
 STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
 CAPTION "Instalimi i ReactOS"
@@ -140,6 +142,8 @@ BEGIN
     LTEXT "Nëse keni nje CD në drive, hiqeni. Pastaj, për ta rinist kompjuterin tuaj, klikoni mbaroj.", IDC_STATIC, 115, 169, 195, 17
 END
 
+/* Strings */
+
 STRINGTABLE
 BEGIN
     IDS_TYPETITLE "Mirë se vini në instalimin e ReactOS"
@@ -182,4 +186,19 @@ BEGIN
     IDS_BOOTLOADER_SYSTEM "System partition (Default)"
     IDS_BOOTLOADER_MBRVBR "MBR dhe VBR (Default)"
     IDS_BOOTLOADER_VBRONLY "VBR veq"
+END
+
+/* Error Strings */
+
+STRINGTABLE
+BEGIN
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR_TITLE "Invalid character"
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR "The only valid characters are:\n\
+alphanumericals (a-z, A-Z, 0-9), and\n . \\ - _\n\
+Spaces are not allowed."
+
+// ERROR_DIRECTORY_NAME
+    IDS_ERROR_DIRECTORY_NAME_TITLE "Invalid installation path"
+    IDS_ERROR_DIRECTORY_NAME "The ReactOS installation path must follow the DOS 8.3 naming scheme, \
+and only contain letters, digits, dashes and periods. Spaces are not allowed."
 END

--- a/base/setup/reactos/lang/tr-TR.rc
+++ b/base/setup/reactos/lang/tr-TR.rc
@@ -83,19 +83,18 @@ BEGIN
     PUSHBUTTON "İptal", IDCANCEL, 87, 68, 47, 15, WS_VISIBLE | WS_TABSTOP
 END
 
-IDD_BOOTOPTIONS DIALOGEX 0, 0, 305, 116
+IDD_ADVINSTOPTS DIALOGEX 0, 0, 305, 135
 STYLE DS_SHELLFONT | WS_VISIBLE | WS_CAPTION
-CAPTION "Gelişmiş Bölümlendirme Seçenekleri"
+CAPTION "Advanced Installation Options"
 FONT 8, "MS Shell Dlg"
 BEGIN
-    CONTROL "Kurulum Dizini", IDC_STATIC, "Button", BS_GROUPBOX, 4, 1, 298, 30
-    EDITTEXT IDC_PATH, 10, 11, 278, 13, WS_VISIBLE
-    CONTROL "Önyükleyici Kurulumu", IDC_STATIC, "Button", BS_GROUPBOX, 4, 36, 298, 52
-    CONTROL "Önyükleyiciyi sabit diskin üzerine kur. (MBR ve VBR)", IDC_INSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 46, 278, 11
-    CONTROL "Önyükleyiciyi sabit diskin üzerine kur. (Yalnızca VBR)", IDC_INSTVBRONLY, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 57, 278, 11
-    CONTROL "Önyükleyici kurulumunu atla.", IDC_NOINSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP | WS_DISABLED, 10, 68, 278, 11
-    PUSHBUTTON "Tamam", IDOK, 180, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
-    PUSHBUTTON "İptal", IDCANCEL, 240, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
+    LTEXT "Choose the &directory where you want to install ReactOS:", IDC_STATIC, 7, 9, 291, 10
+    EDITTEXT IDC_PATH, 7, 23, 291, 13, WS_VISIBLE
+    GROUPBOX "Bootloader", IDC_STATIC, 7, 45, 291, 60
+    LTEXT "Select the location where the FreeLoader\nbootloader should be installed.\n\nBy default, it is installed on the system partition of the boot disk (and either in the Master or the Volume Boot Record for BIOS-based computers).", IDC_STATIC, 13, 57, 279, 44
+    COMBOBOX IDC_INSTFREELDR, 150, 58, 142, 45, WS_VSCROLL | WS_TABSTOP | CBS_DROPDOWNLIST
+    PUSHBUTTON "Tamam", IDOK, 193, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
+    PUSHBUTTON "İptal", IDCANCEL, 248, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
 END
 
 IDD_SUMMARYPAGE DIALOGEX 0, 0, 317, 143
@@ -179,4 +178,13 @@ BEGIN
     IDS_PARTITION_TYPE "Tür"
     IDS_PARTITION_SIZE "Boyut"
     IDS_PARTITION_STATUS "Durum"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_BOOTLOADER_NOINST "No installation"
+    IDS_BOOTLOADER_REMOVABLE "Removable media"
+    IDS_BOOTLOADER_SYSTEM "System partition (Default)"
+    IDS_BOOTLOADER_MBRVBR "MBR ve VBR (Default)"
+    IDS_BOOTLOADER_VBRONLY "Yalnızca VBR"
 END

--- a/base/setup/reactos/lang/tr-TR.rc
+++ b/base/setup/reactos/lang/tr-TR.rc
@@ -7,6 +7,8 @@
 
 LANGUAGE LANG_TURKISH, SUBLANG_DEFAULT
 
+/* Dialogs */
+
 IDD_STARTPAGE DIALOGEX 0, 0, 317, 193
 STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
 CAPTION "ReactOS Kur"
@@ -145,6 +147,8 @@ BEGIN
     LTEXT "Eğer bir sürücüde bir CD varsa onu çıkartınız. Sonra, bilgisayarınızı yeniden başlatmak için Bitir'e tıklayınız.", IDC_STATIC, 115, 169, 195, 17
 END
 
+/* Strings */
+
 STRINGTABLE
 BEGIN
     IDS_TYPETITLE "ReactOS Kurulum Yöneticisine Hoş Geldiniz"
@@ -187,4 +191,19 @@ BEGIN
     IDS_BOOTLOADER_SYSTEM "System partition (Default)"
     IDS_BOOTLOADER_MBRVBR "MBR ve VBR (Default)"
     IDS_BOOTLOADER_VBRONLY "Yalnızca VBR"
+END
+
+/* Error Strings */
+
+STRINGTABLE
+BEGIN
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR_TITLE "Invalid character"
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR "The only valid characters are:\n\
+alphanumericals (a-z, A-Z, 0-9), and\n . \\ - _\n\
+Spaces are not allowed."
+
+// ERROR_DIRECTORY_NAME
+    IDS_ERROR_DIRECTORY_NAME_TITLE "Invalid installation path"
+    IDS_ERROR_DIRECTORY_NAME "The ReactOS installation path must follow the DOS 8.3 naming scheme, \
+and only contain letters, digits, dashes and periods. Spaces are not allowed."
 END

--- a/base/setup/reactos/lang/uk-UA.rc
+++ b/base/setup/reactos/lang/uk-UA.rc
@@ -8,6 +8,8 @@
 
 LANGUAGE LANG_UKRAINIAN, SUBLANG_DEFAULT
 
+/* Dialogs */
+
 IDD_STARTPAGE DIALOGEX 0, 0, 317, 193
 STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
 CAPTION "Встановлення ReactOS"
@@ -146,6 +148,8 @@ BEGIN
     LTEXT "Ви можете витягнути інсталяційний диск. Для перезавантаження комп'ютера натисніть Завершити", IDC_STATIC, 115, 169, 195, 17
 END
 
+/* Strings */
+
 STRINGTABLE
 BEGIN
     IDS_TYPETITLE "Вас вітає програма встановлення ReactOS"
@@ -188,4 +192,19 @@ BEGIN
     IDS_BOOTLOADER_SYSTEM "System partition (Default)"
     IDS_BOOTLOADER_MBRVBR "MBR та VBR (Default)"
     IDS_BOOTLOADER_VBRONLY "Лише VBR"
+END
+
+/* Error Strings */
+
+STRINGTABLE
+BEGIN
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR_TITLE "Invalid character"
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR "The only valid characters are:\n\
+alphanumericals (a-z, A-Z, 0-9), and\n . \\ - _\n\
+Spaces are not allowed."
+
+// ERROR_DIRECTORY_NAME
+    IDS_ERROR_DIRECTORY_NAME_TITLE "Invalid installation path"
+    IDS_ERROR_DIRECTORY_NAME "The ReactOS installation path must follow the DOS 8.3 naming scheme, \
+and only contain letters, digits, dashes and periods. Spaces are not allowed."
 END

--- a/base/setup/reactos/lang/uk-UA.rc
+++ b/base/setup/reactos/lang/uk-UA.rc
@@ -84,19 +84,18 @@ BEGIN
     PUSHBUTTON "&Скасувати", IDCANCEL, 87, 68, 47, 15, WS_VISIBLE | WS_TABSTOP
 END
 
-IDD_BOOTOPTIONS DIALOGEX 0, 0, 305, 116
+IDD_ADVINSTOPTS DIALOGEX 0, 0, 305, 135
 STYLE DS_SHELLFONT | WS_VISIBLE | WS_CAPTION
-CAPTION "Розширені параметри розділу"
+CAPTION "Advanced Installation Options"
 FONT 8, "MS Shell Dlg"
 BEGIN
-    CONTROL "Тека встановлення", IDC_STATIC, "Button", BS_GROUPBOX, 4, 1, 298, 30
-    EDITTEXT IDC_PATH, 10, 11, 278, 13, WS_VISIBLE
-    CONTROL "Встановлення завантажувача", IDC_STATIC, "Button", BS_GROUPBOX, 4, 36, 298, 52
-    CONTROL "Встановити завантажувач на жосткий диск (MBR та VBR)", IDC_INSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 46, 278, 11
-    CONTROL "Встановити завантажувач на жосткий диск (лише VBR)", IDC_INSTVBRONLY, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 57, 278, 11
-    CONTROL "Не встановлювати завантажувач", IDC_NOINSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP | WS_DISABLED, 10, 68, 278, 11
-    PUSHBUTTON "&OK", IDOK, 180, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
-    PUSHBUTTON "&Скасувати", IDCANCEL, 240, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
+    LTEXT "Choose the &directory where you want to install ReactOS:", IDC_STATIC, 7, 9, 291, 10
+    EDITTEXT IDC_PATH, 7, 23, 291, 13, WS_VISIBLE
+    GROUPBOX "Завантажувач", IDC_STATIC, 7, 45, 291, 60
+    LTEXT "Select the location where the FreeLoader\nbootloader should be installed.\n\nBy default, it is installed on the system partition of the boot disk (and either in the Master or the Volume Boot Record for BIOS-based computers).", IDC_STATIC, 13, 57, 279, 44
+    COMBOBOX IDC_INSTFREELDR, 150, 58, 142, 45, WS_VSCROLL | WS_TABSTOP | CBS_DROPDOWNLIST
+    PUSHBUTTON "OK", IDOK, 193, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
+    PUSHBUTTON "Скасувати", IDCANCEL, 248, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
 END
 
 IDD_SUMMARYPAGE DIALOGEX 0, 0, 317, 143
@@ -180,4 +179,13 @@ BEGIN
     IDS_PARTITION_TYPE "Type"
     IDS_PARTITION_SIZE "Size"
     IDS_PARTITION_STATUS "Status"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_BOOTLOADER_NOINST "Не встановлювати"
+    IDS_BOOTLOADER_REMOVABLE "Removable media"
+    IDS_BOOTLOADER_SYSTEM "System partition (Default)"
+    IDS_BOOTLOADER_MBRVBR "MBR та VBR (Default)"
+    IDS_BOOTLOADER_VBRONLY "Лише VBR"
 END

--- a/base/setup/reactos/lang/vi-VN.rc
+++ b/base/setup/reactos/lang/vi-VN.rc
@@ -1,5 +1,7 @@
 LANGUAGE LANG_VIETNAMESE, SUBLANG_VIETNAMESE_VIETNAM
 
+/* Dialogs */
+
 IDD_STARTPAGE DIALOGEX 0, 0, 317, 193
 STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
 CAPTION "Cài đặt ReactOS"
@@ -138,6 +140,8 @@ BEGIN
     LTEXT "Nếu ổ đĩa của bạn còn chứa dĩa CD cài đặt, hãy lấy nó ra. Sau đó, ấn Hoàn tất để khởi động lại máy tính của bạn.", IDC_STATIC, 115, 169, 195, 17
 END
 
+/* Strings */
+
 STRINGTABLE
 BEGIN
     IDS_TYPETITLE "Chào mừng tới trình Thiết lập ReactOS"
@@ -180,4 +184,19 @@ BEGIN
     IDS_BOOTLOADER_SYSTEM "System partition (Default)"
     IDS_BOOTLOADER_MBRVBR "MBR và VBR (Default)"
     IDS_BOOTLOADER_VBRONLY "Chỉ VBR"
+END
+
+/* Error Strings */
+
+STRINGTABLE
+BEGIN
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR_TITLE "Invalid character"
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR "The only valid characters are:\n\
+alphanumericals (a-z, A-Z, 0-9), and\n . \\ - _\n\
+Spaces are not allowed."
+
+// ERROR_DIRECTORY_NAME
+    IDS_ERROR_DIRECTORY_NAME_TITLE "Invalid installation path"
+    IDS_ERROR_DIRECTORY_NAME "The ReactOS installation path must follow the DOS 8.3 naming scheme, \
+and only contain letters, digits, dashes and periods. Spaces are not allowed."
 END

--- a/base/setup/reactos/lang/vi-VN.rc
+++ b/base/setup/reactos/lang/vi-VN.rc
@@ -76,19 +76,18 @@ BEGIN
     PUSHBUTTON "&Hủy", IDCANCEL, 87, 68, 47, 15, WS_VISIBLE | WS_TABSTOP
 END
 
-IDD_BOOTOPTIONS DIALOGEX 0, 0, 305, 116
+IDD_ADVINSTOPTS DIALOGEX 0, 0, 305, 135
 STYLE DS_SHELLFONT | WS_VISIBLE | WS_CAPTION
-CAPTION "Tùy chọn phân chia ổ đĩa nâng cao"
+CAPTION "Advanced Installation Options"
 FONT 8, "MS Shell Dlg"
 BEGIN
-    CONTROL "Thư mục cài đặt", IDC_STATIC, "Button", BS_GROUPBOX, 4, 1, 298, 30
-    EDITTEXT IDC_PATH, 10, 11, 278, 13, WS_VISIBLE
-    CONTROL "Cài đặt Boot loader", IDC_STATIC, "Button", BS_GROUPBOX, 4, 36, 298, 52
-    CONTROL "Cài boot loader trên ổ cứng  (MBR-MasterBootRecord- và VBR-VolumeBootRecord)", IDC_INSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 46, 278, 11
-    CONTROL "Cài boot loader  (chỉ VBR)", IDC_INSTVBRONLY, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 57, 278, 11
-    CONTROL "Không cài bootloader", IDC_NOINSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP | WS_DISABLED, 10, 68, 278, 11
-    PUSHBUTTON "&Đồng ý", IDOK, 180, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
-    PUSHBUTTON "&Hủy", IDCANCEL, 240, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
+    LTEXT "Choose the &directory where you want to install ReactOS:", IDC_STATIC, 7, 9, 291, 10
+    EDITTEXT IDC_PATH, 7, 23, 291, 13, WS_VISIBLE
+    GROUPBOX "Bootloader", IDC_STATIC, 7, 45, 291, 60
+    LTEXT "Select the location where the FreeLoader\nbootloader should be installed.\n\nBy default, it is installed on the system partition of the boot disk (and either in the Master or the Volume Boot Record for BIOS-based computers).", IDC_STATIC, 13, 57, 279, 44
+    COMBOBOX IDC_INSTFREELDR, 150, 58, 142, 45, WS_VSCROLL | WS_TABSTOP | CBS_DROPDOWNLIST
+    PUSHBUTTON "Đồng ý", IDOK, 193, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
+    PUSHBUTTON "Hủy", IDCANCEL, 248, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
 END
 
 IDD_SUMMARYPAGE DIALOGEX 0, 0, 317, 143
@@ -146,9 +145,9 @@ BEGIN
     IDS_DEVICETITLE "Thiết lập các thiết bị cơ bản"
     IDS_DEVICESUBTITLE "Chọn những cài đặt cho màn hình và bàn phím."
     IDS_DRIVETITLE "Thiết lập phần ổ cứng để cài đặt và thư mục hệ thống"
-    IDS_DRIVESUBTITLE "Chuẩn bị phần ổ cứng, thư mục hệ thống và boot loader."
+    IDS_DRIVESUBTITLE "Chuẩn bị phần ổ cứng, thư mục hệ thống và bootloader."
     IDS_PROCESSTITLE "Thiết lập phần ổ cứng, sao chép tập tin và thiết lập hệ thống"
-    IDS_PROCESSSUBTITLE "Tạo và định dạng phần ổ đĩa, sao chép thư  mục, cài đặt và thiết lập boot loader"
+    IDS_PROCESSSUBTITLE "Tạo và định dạng phần ổ đĩa, sao chép thư  mục, cài đặt và thiết lập bootloader"
     IDS_RESTARTTITLE "Giai đoạn đầu của việc thiết lập đã hoàn tất"
     IDS_RESTARTSUBTITLE "Giai đoạn đầu của việc thiết lập đã được hoàn thành, khởi động lại máy tính để tiếp tuc với giai đoạn hai"
     IDS_SUMMARYTITLE "Tóm lược quá trình cài đặt"
@@ -172,4 +171,13 @@ BEGIN
     IDS_PARTITION_TYPE "Loại định dạng"
     IDS_PARTITION_SIZE "Kích cỡ"
     IDS_PARTITION_STATUS "Status"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_BOOTLOADER_NOINST "No installation"
+    IDS_BOOTLOADER_REMOVABLE "Removable media"
+    IDS_BOOTLOADER_SYSTEM "System partition (Default)"
+    IDS_BOOTLOADER_MBRVBR "MBR và VBR (Default)"
+    IDS_BOOTLOADER_VBRONLY "Chỉ VBR"
 END

--- a/base/setup/reactos/lang/zh-CN.rc
+++ b/base/setup/reactos/lang/zh-CN.rc
@@ -1,5 +1,7 @@
 LANGUAGE LANG_CHINESE, SUBLANG_CHINESE_SIMPLIFIED
 
+/* Dialogs */
+
 IDD_STARTPAGE DIALOGEX 0, 0, 317, 193
 STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
 CAPTION "ReactOS 安装程序"
@@ -138,6 +140,8 @@ BEGIN
     LTEXT "请从光盘驱动器取出所有光盘。然后点击完成来重启您的电脑。", IDC_STATIC, 115, 169, 195, 17
 END
 
+/* Strings */
+
 STRINGTABLE
 BEGIN
     IDS_TYPETITLE "ReactOS 安装程序"
@@ -180,4 +184,19 @@ BEGIN
     IDS_BOOTLOADER_SYSTEM "System partition (Default)"
     IDS_BOOTLOADER_MBRVBR "MBR 和 VBR (Default)"
     IDS_BOOTLOADER_VBRONLY "仅 VBR"
+END
+
+/* Error Strings */
+
+STRINGTABLE
+BEGIN
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR_TITLE "Invalid character"
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR "The only valid characters are:\n\
+alphanumericals (a-z, A-Z, 0-9), and\n . \\ - _\n\
+Spaces are not allowed."
+
+// ERROR_DIRECTORY_NAME
+    IDS_ERROR_DIRECTORY_NAME_TITLE "Invalid installation path"
+    IDS_ERROR_DIRECTORY_NAME "The ReactOS installation path must follow the DOS 8.3 naming scheme, \
+and only contain letters, digits, dashes and periods. Spaces are not allowed."
 END

--- a/base/setup/reactos/lang/zh-CN.rc
+++ b/base/setup/reactos/lang/zh-CN.rc
@@ -76,19 +76,18 @@ BEGIN
     PUSHBUTTON "取消(&C)", IDCANCEL, 87, 68, 47, 15, WS_VISIBLE | WS_TABSTOP
 END
 
-IDD_BOOTOPTIONS DIALOGEX 0, 0, 305, 116
+IDD_ADVINSTOPTS DIALOGEX 0, 0, 305, 135
 STYLE DS_SHELLFONT | WS_VISIBLE | WS_CAPTION
-CAPTION "高级分区设置"
+CAPTION "Advanced Installation Options"
 FONT 9, "宋体"
 BEGIN
-    CONTROL "安装文件夹", IDC_STATIC, "Button", BS_GROUPBOX, 4, 1, 298, 30
-    EDITTEXT IDC_PATH, 10, 11, 278, 13, WS_VISIBLE
-    CONTROL "引导程序安装", IDC_STATIC, "Button", BS_GROUPBOX, 4, 36, 298, 52
-    CONTROL "安装引导程序到硬盘 (MBR 和 VBR)", IDC_INSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 46, 278, 11
-    CONTROL "安装引导程序到硬盘 (仅 VBR)", IDC_INSTVBRONLY, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 57, 278, 11
-    CONTROL "不安装引导程序", IDC_NOINSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP | WS_DISABLED, 10, 68, 278, 11
-    PUSHBUTTON "确定(&O)", IDOK, 180, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
-    PUSHBUTTON "取消(&C)", IDCANCEL, 240, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
+    LTEXT "Choose the &directory where you want to install ReactOS:", IDC_STATIC, 7, 9, 291, 10
+    EDITTEXT IDC_PATH, 7, 23, 291, 13, WS_VISIBLE
+    GROUPBOX "Bootloader", IDC_STATIC, 7, 45, 291, 60
+    LTEXT "Select the location where the FreeLoader\nbootloader should be installed.\n\nBy default, it is installed on the system partition of the boot disk (and either in the Master or the Volume Boot Record for BIOS-based computers).", IDC_STATIC, 13, 57, 279, 44
+    COMBOBOX IDC_INSTFREELDR, 150, 58, 142, 45, WS_VSCROLL | WS_TABSTOP | CBS_DROPDOWNLIST
+    PUSHBUTTON "确定", IDOK, 193, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
+    PUSHBUTTON "取消", IDCANCEL, 248, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
 END
 
 IDD_SUMMARYPAGE DIALOGEX 0, 0, 317, 143
@@ -172,4 +171,13 @@ BEGIN
     IDS_PARTITION_TYPE "类型"
     IDS_PARTITION_SIZE "大小"
     IDS_PARTITION_STATUS "状态"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_BOOTLOADER_NOINST "No installation"
+    IDS_BOOTLOADER_REMOVABLE "Removable media"
+    IDS_BOOTLOADER_SYSTEM "System partition (Default)"
+    IDS_BOOTLOADER_MBRVBR "MBR 和 VBR (Default)"
+    IDS_BOOTLOADER_VBRONLY "仅 VBR"
 END

--- a/base/setup/reactos/lang/zh-HK.rc
+++ b/base/setup/reactos/lang/zh-HK.rc
@@ -84,19 +84,18 @@ BEGIN
     PUSHBUTTON "取消(&C)", IDCANCEL, 87, 68, 47, 15, WS_VISIBLE | WS_TABSTOP
 END
 
-IDD_BOOTOPTIONS DIALOGEX 0, 0, 305, 116
+IDD_ADVINSTOPTS DIALOGEX 0, 0, 305, 135
 STYLE DS_SHELLFONT | WS_VISIBLE | WS_CAPTION
-CAPTION "進階磁碟區設定"
+CAPTION "Advanced Installation Options"
 FONT 9, "新細明體"
 BEGIN
-    CONTROL "安裝資料夾", IDC_STATIC, "Button", BS_GROUPBOX, 4, 1, 298, 30
-    EDITTEXT IDC_PATH, 10, 11, 278, 13, WS_VISIBLE
-    CONTROL "安裝啟動程式", IDC_STATIC, "Button", BS_GROUPBOX, 4, 36, 298, 52
-    CONTROL "安裝啟動程式到硬碟（MBR 和 VBR）", IDC_INSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 46, 278, 11
-    CONTROL "安裝啟動程式到硬碟（僅 VBR）", IDC_INSTVBRONLY, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 57, 278, 11
-    CONTROL "不安裝啟動程式", IDC_NOINSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP | WS_DISABLED, 10, 68, 278, 11
-    PUSHBUTTON "確定(&O)", IDOK, 180, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
-    PUSHBUTTON "取消(&C)", IDCANCEL, 240, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
+    LTEXT "Choose the &directory where you want to install ReactOS:", IDC_STATIC, 7, 9, 291, 10
+    EDITTEXT IDC_PATH, 7, 23, 291, 13, WS_VISIBLE
+    GROUPBOX "Bootloader", IDC_STATIC, 7, 45, 291, 60
+    LTEXT "Select the location where the FreeLoader\nbootloader should be installed.\n\nBy default, it is installed on the system partition of the boot disk (and either in the Master or the Volume Boot Record for BIOS-based computers).", IDC_STATIC, 13, 57, 279, 44
+    COMBOBOX IDC_INSTFREELDR, 150, 58, 142, 45, WS_VSCROLL | WS_TABSTOP | CBS_DROPDOWNLIST
+    PUSHBUTTON "確定", IDOK, 193, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
+    PUSHBUTTON "取消", IDCANCEL, 248, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
 END
 
 IDD_SUMMARYPAGE DIALOGEX 0, 0, 317, 143
@@ -180,4 +179,13 @@ BEGIN
     IDS_PARTITION_TYPE "類型"
     IDS_PARTITION_SIZE "大小"
     IDS_PARTITION_STATUS "狀態"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_BOOTLOADER_NOINST "No installation"
+    IDS_BOOTLOADER_REMOVABLE "Removable media"
+    IDS_BOOTLOADER_SYSTEM "System partition (Default)"
+    IDS_BOOTLOADER_MBRVBR "MBR 和 VBR (Default)"
+    IDS_BOOTLOADER_VBRONLY "僅 VBR"
 END

--- a/base/setup/reactos/lang/zh-HK.rc
+++ b/base/setup/reactos/lang/zh-HK.rc
@@ -8,6 +8,8 @@
 
 LANGUAGE LANG_CHINESE, SUBLANG_CHINESE_HONGKONG
 
+/* Dialogs */
+
 IDD_STARTPAGE DIALOGEX 0, 0, 317, 193
 STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
 CAPTION "ReactOS 安裝程式"
@@ -146,6 +148,8 @@ BEGIN
     LTEXT "如果光碟機內仍然有光碟，請將其取出。然後按［完成］，重新啟動您的電腦。", IDC_STATIC, 115, 169, 195, 17
 END
 
+/* Strings */
+
 STRINGTABLE
 BEGIN
     IDS_TYPETITLE "ReactOS 安裝程式"
@@ -188,4 +192,19 @@ BEGIN
     IDS_BOOTLOADER_SYSTEM "System partition (Default)"
     IDS_BOOTLOADER_MBRVBR "MBR 和 VBR (Default)"
     IDS_BOOTLOADER_VBRONLY "僅 VBR"
+END
+
+/* Error Strings */
+
+STRINGTABLE
+BEGIN
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR_TITLE "Invalid character"
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR "The only valid characters are:\n\
+alphanumericals (a-z, A-Z, 0-9), and\n . \\ - _\n\
+Spaces are not allowed."
+
+// ERROR_DIRECTORY_NAME
+    IDS_ERROR_DIRECTORY_NAME_TITLE "Invalid installation path"
+    IDS_ERROR_DIRECTORY_NAME "The ReactOS installation path must follow the DOS 8.3 naming scheme, \
+and only contain letters, digits, dashes and periods. Spaces are not allowed."
 END

--- a/base/setup/reactos/lang/zh-TW.rc
+++ b/base/setup/reactos/lang/zh-TW.rc
@@ -85,19 +85,18 @@ BEGIN
     PUSHBUTTON "取消(&C)", IDCANCEL, 87, 68, 47, 15, WS_VISIBLE | WS_TABSTOP
 END
 
-IDD_BOOTOPTIONS DIALOGEX 0, 0, 305, 116
+IDD_ADVINSTOPTS DIALOGEX 0, 0, 305, 135
 STYLE DS_SHELLFONT | WS_VISIBLE | WS_CAPTION
-CAPTION "進階磁碟區設定"
+CAPTION "Advanced Installation Options"
 FONT 9, "新細明體"
 BEGIN
-    CONTROL "安裝資料夾", IDC_STATIC, "Button", BS_GROUPBOX, 4, 1, 298, 30
-    EDITTEXT IDC_PATH, 10, 11, 278, 13, WS_VISIBLE
-    CONTROL "安裝啟動程式", IDC_STATIC, "Button", BS_GROUPBOX, 4, 36, 298, 52
-    CONTROL "安裝啟動程式到硬碟（MBR 和 VBR）", IDC_INSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 46, 278, 11
-    CONTROL "安裝啟動程式到硬碟（僅 VBR）", IDC_INSTVBRONLY, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 10, 57, 278, 11
-    CONTROL "不安裝啟動程式", IDC_NOINSTFREELDR, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP | WS_DISABLED, 10, 68, 278, 11
-    PUSHBUTTON "確定(&O)", IDOK, 180, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
-    PUSHBUTTON "取消(&C)", IDCANCEL, 240, 94, 50, 15, WS_TABSTOP | WS_VISIBLE
+    LTEXT "Choose the &directory where you want to install ReactOS:", IDC_STATIC, 7, 9, 291, 10
+    EDITTEXT IDC_PATH, 7, 23, 291, 13, WS_VISIBLE
+    GROUPBOX "Bootloader", IDC_STATIC, 7, 45, 291, 60
+    LTEXT "Select the location where the FreeLoader\nbootloader should be installed.\n\nBy default, it is installed on the system partition of the boot disk (and either in the Master or the Volume Boot Record for BIOS-based computers).", IDC_STATIC, 13, 57, 279, 44
+    COMBOBOX IDC_INSTFREELDR, 150, 58, 142, 45, WS_VSCROLL | WS_TABSTOP | CBS_DROPDOWNLIST
+    PUSHBUTTON "確定", IDOK, 193, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
+    PUSHBUTTON "取消", IDCANCEL, 248, 113, 50, 14, WS_TABSTOP | WS_VISIBLE
 END
 
 IDD_SUMMARYPAGE DIALOGEX 0, 0, 317, 143
@@ -181,4 +180,13 @@ BEGIN
     IDS_PARTITION_TYPE "類型"
     IDS_PARTITION_SIZE "大小"
     IDS_PARTITION_STATUS "狀態"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_BOOTLOADER_NOINST "No installation"
+    IDS_BOOTLOADER_REMOVABLE "Removable media"
+    IDS_BOOTLOADER_SYSTEM "System partition (Default)"
+    IDS_BOOTLOADER_MBRVBR "MBR 和 VBR (Default)"
+    IDS_BOOTLOADER_VBRONLY "僅 VBR"
 END

--- a/base/setup/reactos/lang/zh-TW.rc
+++ b/base/setup/reactos/lang/zh-TW.rc
@@ -9,6 +9,8 @@
 
 LANGUAGE LANG_CHINESE, SUBLANG_CHINESE_TRADITIONAL
 
+/* Dialogs */
+
 IDD_STARTPAGE DIALOGEX 0, 0, 317, 193
 STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
 CAPTION "ReactOS 安裝程式"
@@ -147,6 +149,8 @@ BEGIN
     LTEXT "如果光碟機裡還有光碟，請將其取出。然後按［完成］，重新啟動您的電腦。", IDC_STATIC, 115, 169, 195, 17
 END
 
+/* Strings */
+
 STRINGTABLE
 BEGIN
     IDS_TYPETITLE "ReactOS 安裝程式"
@@ -189,4 +193,19 @@ BEGIN
     IDS_BOOTLOADER_SYSTEM "System partition (Default)"
     IDS_BOOTLOADER_MBRVBR "MBR 和 VBR (Default)"
     IDS_BOOTLOADER_VBRONLY "僅 VBR"
+END
+
+/* Error Strings */
+
+STRINGTABLE
+BEGIN
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR_TITLE "Invalid character"
+    IDS_ERROR_INVALID_INSTALLDIR_CHAR "The only valid characters are:\n\
+alphanumericals (a-z, A-Z, 0-9), and\n . \\ - _\n\
+Spaces are not allowed."
+
+// ERROR_DIRECTORY_NAME
+    IDS_ERROR_DIRECTORY_NAME_TITLE "Invalid installation path"
+    IDS_ERROR_DIRECTORY_NAME "The ReactOS installation path must follow the DOS 8.3 naming scheme, \
+and only contain letters, digits, dashes and periods. Spaces are not allowed."
 END

--- a/base/setup/reactos/reactos.c
+++ b/base/setup/reactos/reactos.c
@@ -92,17 +92,145 @@ CreateTitleFont(VOID)
     return hFont;
 }
 
-INT DisplayError(
-    IN HWND hParentWnd OPTIONAL,
-    IN UINT uIDTitle,
-    IN UINT uIDMessage)
+INT
+DisplayMessageV(
+    _In_opt_ HWND hWnd,
+    _In_ UINT uType,
+    _In_opt_ PCWSTR pszTitle,
+    _In_opt_ PCWSTR pszFormatMessage,
+    _In_ va_list args)
 {
-    WCHAR message[512], caption[64];
+    INT iRes;
+    HINSTANCE hInstance = NULL;
+    MSGBOXPARAMSW mb = {0};
+    LPWSTR Format;
+    size_t MsgLen;
+    WCHAR  StaticBuffer[256];
+    LPWSTR Buffer = StaticBuffer; // Use the static buffer by default.
 
-    LoadStringW(SetupData.hInstance, uIDMessage, message, ARRAYSIZE(message));
-    LoadStringW(SetupData.hInstance, uIDTitle, caption, ARRAYSIZE(caption));
+    /* We need to retrieve the current module's instance handle if either
+     * the title or the format message is specified by a resource ID */
+    if ((pszTitle && IS_INTRESOURCE(pszTitle)) || IS_INTRESOURCE(pszFormatMessage))
+        hInstance = GetModuleHandleW(NULL); // SetupData.hInstance;
 
-    return MessageBoxW(hParentWnd, message, caption, MB_OK | MB_ICONERROR);
+    /* Retrieve the format message string if this is a resource */
+    if (pszFormatMessage && IS_INTRESOURCE(pszFormatMessage)) do
+    {
+        // LoadAllocStringW()
+        PCWSTR pStr;
+
+        /* Try to load the string from the resource */
+        MsgLen = LoadStringW(hInstance, PtrToUlong(pszFormatMessage), (LPWSTR)&pStr, 0);
+        if (MsgLen == 0)
+        {
+            /* No resource string was found, return NULL */
+            Format = NULL;
+            break;
+        }
+
+        /* Allocate a new buffer, adding a NULL-terminator */
+        Format = HeapAlloc(GetProcessHeap(), 0, (MsgLen + 1) * sizeof(WCHAR));
+        if (!Format)
+        {
+            MsgLen = 0;
+            break;
+        }
+
+        /* Copy the string, NULL-terminated */
+        StringCchCopyNW(Format, MsgLen + 1, pStr, MsgLen);
+    } while (0);
+    else
+    {
+        Format = (LPWSTR)pszFormatMessage;
+    }
+
+    if (Format)
+    {
+        /*
+         * Retrieve the message length. If it is too long, allocate
+         * an auxiliary buffer; otherwise use the static buffer.
+         * The string is built to be NULL-terminated.
+         */
+        MsgLen = _vscwprintf(Format, args);
+        if (MsgLen >= _countof(StaticBuffer))
+        {
+            Buffer = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, (MsgLen + 1) * sizeof(WCHAR));
+            if (!Buffer)
+            {
+                /* Allocation failed, use the original format string verbatim */
+                Buffer = Format;
+            }
+        }
+        if (Buffer != Format)
+        {
+            /* Do the printf as we use the caller's format string */
+            StringCchVPrintfW(Buffer, MsgLen + 1, Format, args);
+        }
+    }
+    else
+    {
+        Format = (LPWSTR)pszFormatMessage;
+        Buffer = Format;
+    }
+
+    /* Display the message */
+    mb.cbSize = sizeof(mb);
+    mb.hwndOwner = hWnd;
+    mb.hInstance = hInstance;
+    mb.lpszText = Buffer;
+    mb.lpszCaption = pszTitle;
+    mb.dwStyle = uType;
+    mb.dwLanguageId = MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT);
+    iRes = MessageBoxIndirectW(&mb);
+
+    /* Free the buffers if needed */
+    if ((Buffer != StaticBuffer) && (Buffer != Format))
+        HeapFree(GetProcessHeap(), 0, Buffer);
+
+    if (Format && (Format != pszFormatMessage))
+        HeapFree(GetProcessHeap(), 0, Format);
+
+    return iRes;
+}
+
+INT
+__cdecl
+DisplayMessage(
+    _In_opt_ HWND hWnd,
+    _In_ UINT uType,
+    _In_opt_ PCWSTR pszTitle,
+    _In_opt_ PCWSTR pszFormatMessage,
+    ...)
+{
+    INT iRes;
+    va_list args;
+
+    va_start(args, pszFormatMessage);
+    iRes = DisplayMessageV(hWnd, uType, pszTitle, pszFormatMessage, args);
+    va_end(args);
+
+    return iRes;
+}
+
+INT
+__cdecl
+DisplayError(
+    _In_opt_ HWND hWnd,
+    _In_ UINT uIDTitle,
+    _In_ UINT uIDMessage,
+    ...)
+{
+    INT iRes;
+    va_list args;
+
+    va_start(args, uIDMessage);
+    iRes = DisplayMessageV(hWnd, MB_OK | MB_ICONERROR,
+                           MAKEINTRESOURCEW(uIDTitle),
+                           MAKEINTRESOURCEW(uIDMessage),
+                           args);
+    va_end(args);
+
+    return iRes;
 }
 
 static INT_PTR CALLBACK

--- a/base/setup/reactos/reactos.h
+++ b/base/setup/reactos/reactos.h
@@ -166,6 +166,17 @@ ConvertNtPathToWin32Path(
 
 /* drivepage.c */
 
+INT_PTR
+CALLBACK
+DriveDlgProc(
+    HWND hwndDlg,
+    UINT uMsg,
+    WPARAM wParam,
+    LPARAM lParam);
+
+
+/* reactos.c */
+
 BOOL
 CreateListViewColumns(
     IN HINSTANCE hInstance,
@@ -175,14 +186,31 @@ CreateListViewColumns(
     IN const INT* pColsAlign,
     IN UINT nNumOfColumns);
 
-INT_PTR
-CALLBACK
-DriveDlgProc(
-    HWND hwndDlg,
-    UINT uMsg,
-    WPARAM wParam,
-    LPARAM lParam);
+INT
+DisplayMessageV(
+    _In_opt_ HWND hWnd,
+    _In_ UINT uType,
+    _In_opt_ PCWSTR pszTitle,
+    _In_opt_ PCWSTR pszFormatMessage,
+    _In_ va_list args);
+
+INT
+__cdecl
+DisplayMessage(
+    _In_opt_ HWND hWnd,
+    _In_ UINT uType,
+    _In_opt_ PCWSTR pszTitle,
+    _In_opt_ PCWSTR pszFormatMessage,
+    ...);
+
+INT
+__cdecl
+DisplayError(
+    _In_opt_ HWND hWnd,
+    _In_ UINT uIDTitle,
+    _In_ UINT uIDMessage,
+    ...);
 
 #endif /* _REACTOS_PCH_ */
 
-/* EOP */
+/* EOF */

--- a/base/setup/reactos/resource.h
+++ b/base/setup/reactos/resource.h
@@ -61,11 +61,9 @@
 #define IDC_RESTART_PROGRESS 2072
 #define IDC_PARTMOREOPTS     2073
 
-#define IDD_BOOTOPTIONS      2080
+#define IDD_ADVINSTOPTS      2080
 #define IDC_PATH             2081
 #define IDC_INSTFREELDR      2082
-#define IDC_INSTVBRONLY      2083
-#define IDC_NOINSTFREELDR    2084
 
 #define IDD_PARTITION        2090
 #define IDC_UPDOWN1          2091
@@ -100,3 +98,10 @@
 #define IDS_PARTITION_TYPE   5201
 #define IDS_PARTITION_SIZE   5202
 #define IDS_PARTITION_STATUS 5203
+
+// WARNING: These IDs *MUST* stay in increasing order!
+#define IDS_BOOTLOADER_NOINST       5300
+#define IDS_BOOTLOADER_REMOVABLE    5301
+#define IDS_BOOTLOADER_SYSTEM       5302    // For non-MBR disks
+#define IDS_BOOTLOADER_MBRVBR       5303    // For MBR disks only
+#define IDS_BOOTLOADER_VBRONLY      5304    // ""

--- a/base/setup/reactos/resource.h
+++ b/base/setup/reactos/resource.h
@@ -105,3 +105,12 @@
 #define IDS_BOOTLOADER_SYSTEM       5302    // For non-MBR disks
 #define IDS_BOOTLOADER_MBRVBR       5303    // For MBR disks only
 #define IDS_BOOTLOADER_VBRONLY      5304    // ""
+
+
+/* Error Strings */
+#define IDS_ERROR_INVALID_INSTALLDIR_CHAR_TITLE 5400
+#define IDS_ERROR_INVALID_INSTALLDIR_CHAR       5401
+
+// ERROR_DIRECTORY_NAME
+#define IDS_ERROR_DIRECTORY_NAME_TITLE          5402
+#define IDS_ERROR_DIRECTORY_NAME                5403

--- a/base/setup/usetup/usetup.c
+++ b/base/setup/usetup/usetup.c
@@ -3060,9 +3060,7 @@ InstallDirectoryPage(PINPUT_RECORD Ir)
         {
             if (Length < 50)
             {
-                /* Only accept valid characters for installation path
-                 * (alpha-numeric, '.', '\', '-' and '_'). Note that
-                 * spaces are not accepted. */
+                /* Only accept valid characters for the installation path */
                 c = (WCHAR)Ir->Event.KeyEvent.uChar.AsciiChar;
                 if (IS_VALID_INSTALL_PATH_CHAR(c))
                 {

--- a/base/setup/usetup/usetup.c
+++ b/base/setup/usetup/usetup.c
@@ -3470,15 +3470,15 @@ BootLoaderSelectPage(PINPUT_RECORD Ir)
      */
     if (RepairUpdateFlag)
     {
-        USetupData.MBRInstallType = 0;
+        USetupData.BootLoaderLocation = 0;
         goto Quit;
     }
 
     /* For unattended setup, skip MBR installation or install on removable disk if needed */
     if (IsUnattendedSetup)
     {
-        if ((USetupData.MBRInstallType == 0) ||
-            (USetupData.MBRInstallType == 1))
+        if ((USetupData.BootLoaderLocation == 0) ||
+            (USetupData.BootLoaderLocation == 1))
         {
             goto Quit;
         }
@@ -3493,7 +3493,7 @@ BootLoaderSelectPage(PINPUT_RECORD Ir)
     if ((SystemPartition->DiskEntry->DiskStyle != PARTITION_STYLE_MBR) ||
         !IsRecognizedPartition(SystemPartition->PartitionType))
     {
-        USetupData.MBRInstallType = 1;
+        USetupData.BootLoaderLocation = 1;
         goto Quit;
     }
 #endif
@@ -3501,8 +3501,8 @@ BootLoaderSelectPage(PINPUT_RECORD Ir)
     /* Is it an unattended install on hdd? */
     if (IsUnattendedSetup)
     {
-        if ((USetupData.MBRInstallType == 2) ||
-            (USetupData.MBRInstallType == 3))
+        if ((USetupData.BootLoaderLocation == 2) ||
+            (USetupData.BootLoaderLocation == 3))
         {
             goto Quit;
         }
@@ -3574,25 +3574,25 @@ BootLoaderSelectPage(PINPUT_RECORD Ir)
             if (Line == 12)
             {
                 /* Install on both MBR and VBR */
-                USetupData.MBRInstallType = 2;
+                USetupData.BootLoaderLocation = 2;
                 break;
             }
             else if (Line == 13)
             {
                 /* Install on VBR only */
-                USetupData.MBRInstallType = 3;
+                USetupData.BootLoaderLocation = 3;
                 break;
             }
             else if (Line == 14)
             {
                 /* Install on removable disk */
-                USetupData.MBRInstallType = 1;
+                USetupData.BootLoaderLocation = 1;
                 break;
             }
             else if (Line == 15)
             {
                 /* Skip installation */
-                USetupData.MBRInstallType = 0;
+                USetupData.BootLoaderLocation = 0;
                 break;
             }
 
@@ -3661,7 +3661,7 @@ BootLoaderHardDiskPage(PINPUT_RECORD Ir)
     NTSTATUS Status;
     WCHAR DestinationDevicePathBuffer[MAX_PATH];
 
-    if (USetupData.MBRInstallType == 2)
+    if (USetupData.BootLoaderLocation == 2)
     {
         /* Step 1: Write the VBR */
         Status = InstallVBRToPartition(&USetupData.SystemRootPath,
@@ -3737,10 +3737,10 @@ BootLoaderInstallPage(PINPUT_RECORD Ir)
     RtlCreateUnicodeString(&USetupData.SystemRootPath, PathBuffer);
     DPRINT1("SystemRootPath: %wZ\n", &USetupData.SystemRootPath);
 
-    if (USetupData.MBRInstallType != 0)
+    if (USetupData.BootLoaderLocation != 0)
         MUIDisplayPage(BOOTLOADER_INSTALL_PAGE);
 
-    switch (USetupData.MBRInstallType)
+    switch (USetupData.BootLoaderLocation)
     {
         /* Skip installation */
         case 0:

--- a/boot/bootdata/bootcd/unattend.inf
+++ b/boot/bootdata/bootcd/unattend.inf
@@ -11,10 +11,11 @@ DestinationDiskNumber = 0
 DestinationPartitionNumber = 1
 InstallationDirectory=ReactOS
 
-; MBRInstallType=0  skips MBR installation
-; MBRInstallType=1  install MBR on floppy
-; MBRInstallType=2  install MBR on hdd
-MBRInstallType=2
+; BootLoaderLocation=0  Skip installation
+; BootLoaderLocation=1  Install on removable media (floppy)
+; BootLoaderLocation=2  Install on system partition (for MBR disks: MBR and VBR)
+; BootLoaderLocation=3  Install on VBR only (for MBR disks)
+BootLoaderLocation=2
 
 FullName="MyName"
 ;OrgName="MyOrg"

--- a/boot/bootdata/bootcdregtest/unattend.inf
+++ b/boot/bootdata/bootcdregtest/unattend.inf
@@ -11,10 +11,11 @@ DestinationDiskNumber = 0
 DestinationPartitionNumber = 1
 InstallationDirectory=ReactOS
 
-; MBRInstallType=0  skips MBR installation
-; MBRInstallType=1  install MBR on floppy 
-; MBRInstallType=2  install MBR on hdd
-MBRInstallType=2
+; BootLoaderLocation=0  Skip installation
+; BootLoaderLocation=1  Install on removable media (floppy)
+; BootLoaderLocation=2  Install on system partition (for MBR disks: MBR and VBR)
+; BootLoaderLocation=3  Install on VBR only (for MBR disks)
+BootLoaderLocation=2
 
 FullName="MyName"
 ;OrgName="MyOrg"


### PR DESCRIPTION
### _NOTE: To be reviewed commit by commit._

## Purpose

The purpose of this PR is to make the bootloader installation choice list dynamic, depending on whether the installation is for a BIOS-based PC machine, an (U)EFI one, etc., as shown in https://reactos.org/blogs/gui-setup-part3-first-testing-problems .

JIRA issue: [CORE-13525](https://jira.reactos.org/browse/CORE-13525)

BEFORE:
![guisetup_old_advopts](https://reactos.org/img/blogs/hbelusca_gui-setup/guisetup_old_advopts.png)

AFTER:
![guisetup_advopts](https://reactos.org/img/blogs/hbelusca_gui-setup/guisetup_advopts.png)

## Proposed changes

- ### Rename `"MBRInstallType"` to `"BootLoaderLocation"` unattended installation values.
  Less hardcoded references to "MBR" for code that should be generic is always better.

- ### Move the initialization of other default values into InitializeSetup()
  This is mainly a bug-fix for the initialization of some of these values.

- ### Store a machine architecture type to determine e.g. how the bootloader has to be installed, etc.
  Currently hardcoded for BIOS-based PC-AT; will be determined at runtime in the future.
It will be used in later commits.

- ### Redesign the "Advanced Installation Options" dialog.
  In particular, use now a dynamic combo-box for listing the possible locations where the bootloader can be installed.
This is the main purpose of this PR, and depends on the previous points.

- <details><summary>
  <h3>Add validation of the installation path. <ins><i>(Click for examples and screenshots...)</i></ins></h3>
  </summary>

  * Error when entering an invalid character:
  ![installdir_error_invalid_input_char](https://github.com/user-attachments/assets/c94d2aa0-d488-447f-91c8-0f288dbf3b79)
  * Error when pasting a path string containing invalid characters:
  ![installdir_error_invalid_paste](https://github.com/user-attachments/assets/da082de2-40da-4c9b-a916-fdf17089b5e9)
  * Error when (some components of) the path are not valid 8.3 names:
  ![installdir_error_invalid_8dot3](https://github.com/user-attachments/assets/178c4e9a-2b1d-4eeb-b0dc-d0574041b0a3)
  </details>

## TODO

- [x] Localize some hardcoded message strings that have been added here.
- [x] ~Merge the install path validation commit with the previous one once the feature is fully finalized (_**AFTER**_ PR review!)~ Will be kept in a separate commit (this looks cleaner).
