### PR TITLE
[RAPPS] Uninstall empty directories after its children

### DIFF
--- a/base/applications/rapps/geninst.cpp
+++ b/base/applications/rapps/geninst.cpp
@@ -370,15 +370,12 @@ InstallFiles(const CStringW &SourceDirBase, const CStringW &Spec,
                 {
                     success = !ErrorBox(Info.Error);
                 }
-                else
-                {
-                    success = AddEntry(UNOP_EMPTYDIR, uninstpath);
-                }
 
                 if (success)
                 {
                     success = InstallFiles(from, filespec, to);
                 }
+                AddEntry(UNOP_EMPTYDIR, uninstpath);
             }
         }
         else


### PR DESCRIPTION
In deep directory trees, remove the empty parent directories after the children.

Notes:
- Not updating the `success` variable because cleaning up empty directories is "best-effort".