### PR TITLE
[RAPPS] Fix CAB codepage handling

### DIFF
--- a/base/applications/rapps/cabinet.cpp
+++ b/base/applications/rapps/cabinet.cpp
@@ -9,9 +9,6 @@
 
 #include <fdi.h>
 #include <fcntl.h>
-#ifndef cffile_A_NAME_IS_UTF
-#define cffile_A_NAME_IS_UTF (0x80)
-#endif
 
 /*
  * HACK: treat any input strings as Unicode (UTF-8)
@@ -163,7 +160,7 @@ FNFDINOTIFY(fnNotify)
 
             // Append the destination directory to the file name.
             MultiByteToWide(pND->OutputDir, szExtractDir, CP_UTF8);
-            UINT codepage = (pfdin->attribs & cffile_A_NAME_IS_UTF) ? CP_UTF8 : CP_ACP;
+            UINT codepage = (pfdin->attribs & _A_NAME_IS_UTF) ? CP_UTF8 : CP_ACP;
             MultiByteToWide(pfdin->psz1, szCabFileName, codepage);
 
             if (!NotifyFileExtractCallback(szCabFileName, pfdin->cb, pfdin->attribs,

--- a/base/applications/rapps/cabinet.cpp
+++ b/base/applications/rapps/cabinet.cpp
@@ -9,6 +9,9 @@
 
 #include <fdi.h>
 #include <fcntl.h>
+#ifndef cffile_A_NAME_IS_UTF
+#define cffile_A_NAME_IS_UTF (0x80)
+#endif
 
 /*
  * HACK: treat any input strings as Unicode (UTF-8)
@@ -47,7 +50,7 @@ MultiByteToWide(const CStringA &szSource, CStringW &szDest, UINT Codepage)
         return FALSE;
 
     // do the actual conversion
-    sz = MultiByteToWideChar(CP_UTF8, 0, szSource, -1, szDest.GetBuffer(sz), sz);
+    sz = MultiByteToWideChar(Codepage, 0, szSource, -1, szDest.GetBuffer(sz), sz);
 
     szDest.ReleaseBuffer();
     return sz != 0;
@@ -160,7 +163,8 @@ FNFDINOTIFY(fnNotify)
 
             // Append the destination directory to the file name.
             MultiByteToWide(pND->OutputDir, szExtractDir, CP_UTF8);
-            MultiByteToWide(pfdin->psz1, szCabFileName, CP_ACP);
+            UINT codepage = (pfdin->attribs & cffile_A_NAME_IS_UTF) ? CP_UTF8 : CP_ACP;
+            MultiByteToWide(pfdin->psz1, szCabFileName, codepage);
 
             if (!NotifyFileExtractCallback(szCabFileName, pfdin->cb, pfdin->attribs,
                                            pND->Callback, pND->CallerCookie))


### PR DESCRIPTION
- `MultiByteToWide`  had a bug where it calculated the WCHAR size using the codepage passed in but always used `CP_UTF8` for the actual conversion.
- Use CP_UTF8 to convert cab filenames if [the UTF attribute](https://msdn.microsoft.com/en-us/library/bb267310.aspx#cffile) is set.
