### PR TITLE
[SHELL32] ShellExecCmdLine: Use SearchPathW

### DIFF
--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -2710,6 +2710,10 @@ HRESULT WINAPI ShellExecCmdLine(
         {
             StringCchCopyW(szFile, _countof(szFile), szFile2);
         }
+        else if (SearchPathW(NULL, szFile, NULL, _countof(szFile2), szFile2, NULL))
+        {
+            StringCchCopyW(szFile, _countof(szFile), szFile2);
+        }
 
         apPathList[0] = pwszStartDir;
         apPathList[1] = NULL;

--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -2704,13 +2704,10 @@ HRESULT WINAPI ShellExecCmdLine(
             SetCurrentDirectoryW(pwszStartDir);
         }
 
-        if (PathIsRelativeW(szFile) &&
-            GetFullPathNameW(szFile, _countof(szFile2), szFile2, NULL) &&
-            PathFileExistsW(szFile2))
-        {
-            StringCchCopyW(szFile, _countof(szFile), szFile2);
-        }
-        else if (SearchPathW(NULL, szFile, NULL, _countof(szFile2), szFile2, NULL))
+        if ((PathIsRelativeW(szFile) &&
+             GetFullPathNameW(szFile, _countof(szFile2), szFile2, NULL) &&
+             PathFileExistsW(szFile2)) ||
+            SearchPathW(NULL, szFile, NULL, _countof(szFile2), szFile2, NULL))
         {
             StringCchCopyW(szFile, _countof(szFile), szFile2);
         }


### PR DESCRIPTION
## Purpose
Based on @Doug-Lyons `shlexec-winR-fonts.patch`. #4932 (f691efefc) introduced some regression.
JIRA issue: [CORE-19688](https://jira.reactos.org/browse/CORE-19688)

## Proposed changes

- Call `SearchPathW` function before `PathFindOnPathExW` call in `ShellExecCmdLine` function.

## TODO

- [x] Do small tests.
- [x] Do big tests.

## Comparison

BEFORE:
![before](https://github.com/user-attachments/assets/126c85e1-cee2-4cbe-991e-c8e92dbd819c)
`Win+R fonts` cannot open `Fonts`.

AFTER:
![after](https://github.com/user-attachments/assets/b062831d-5ad2-4589-b734-3dc460cecf4f)
`Win+R fonts` can open `Fonts`.