### PR TITLE
[SHELL32] CRecycleBin: Add backshash if path is drive only

### DIFF
--- a/dll/win32/shell32/folders/CRecycleBin.cpp
+++ b/dll/win32/shell32/folders/CRecycleBin.cpp
@@ -768,7 +768,9 @@ HRESULT WINAPI CRecycleBin::GetDetailsOf(PCUITEMID_CHILD pidl, UINT iColumn, LPS
             pszBackslash = wcsrchr(pFileDetails->szName, L'\\');
             Length = (pszBackslash - pFileDetails->szName);
             memcpy((LPVOID)buffer, pFileDetails->szName, Length * sizeof(WCHAR));
-            buffer[Length] = L'\0';
+            buffer[Length] = UNICODE_NULL;
+            if (buffer[0] && buffer[1] == L':' && !buffer[2])
+                PathAddBackslashW(buffer);
             break;
         case COLUMN_SIZE:
             StrFormatKBSizeW(pFileDetails->FileSize.QuadPart, buffer, MAX_PATH);


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-18006](https://jira.reactos.org/browse/CORE-18006)

## Comparison

BEFORE:
![before](https://github.com/user-attachments/assets/2515e277-6eaa-4916-9519-cf3a32977b67)

AFTER:
![after](https://github.com/user-attachments/assets/3cc6ad24-163b-4d14-af7b-0c59596f306b)