### PR TITLE
[INF][BOOTDATA][SETUPAPI] Use Inf instead of Cmd.exe to register IExplore

### DIFF
--- a/boot/bootdata/hivesft.inf
+++ b/boot/bootdata/hivesft.inf
@@ -457,7 +457,7 @@ HKLM,"SOFTWARE\Microsoft\Windows\CurrentVersion\Shell Extensions",,0x00000012
 HKLM,"SOFTWARE\Microsoft\Windows\CurrentVersion\ShellServiceObjectDelayLoad",,0x00000012
 
 ; FIXME - Setup doesn't handle extra paths
-HKLM,"SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnceEx\Finalize","1",,"||RUNDLL32.EXE SETUPAPI.DLL,InstallHinfSection Finalize 128 %systemroot%\inf\syssetup.inf"
+HKLM,"SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnceEx\Finalize","1",,"||rundll32.exe setupapi.dll,InstallHinfSection Finalize 128 %systemroot%\inf\syssetup.inf"
 
 HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\HideDesktopIcons",,0x00000012
 HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\HideDesktopIcons\ClassicStartMenu",,0x00000012

--- a/boot/bootdata/hivesft.inf
+++ b/boot/bootdata/hivesft.inf
@@ -457,9 +457,7 @@ HKLM,"SOFTWARE\Microsoft\Windows\CurrentVersion\Shell Extensions",,0x00000012
 HKLM,"SOFTWARE\Microsoft\Windows\CurrentVersion\ShellServiceObjectDelayLoad",,0x00000012
 
 ; FIXME - Setup doesn't handle extra paths
-HKLM,"SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnce","",0x00000000,"cmd /c md ""%programfiles%\Internet Explorer\"" && move %windir%\iexplore.exe ""%programfiles%\Internet Explorer\"" && ""%programfiles%\Internet Explorer\iexplore.exe"" /RegServer"
-; Create .NET Framework InstallRoot key, reg_sz & full path
-HKLM,"SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnce","InstallRoot.NET",0x00000000,"cmd /c reg add HKLM\SOFTWARE\Microsoft\.NETFramework /v InstallRoot /t REG_SZ /d %SystemRoot%\Microsoft.NET\Framework\"
+HKLM,"SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnceEx\Finalize","1",,"||RUNDLL32.EXE SETUPAPI.DLL,InstallHinfSection Finalize 128 %systemroot%\inf\syssetup.inf"
 
 HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\HideDesktopIcons",,0x00000012
 HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\HideDesktopIcons\ClassicStartMenu",,0x00000012

--- a/dll/win32/setupapi/install.c
+++ b/dll/win32/setupapi/install.c
@@ -533,9 +533,7 @@ static BOOL do_register_dll( const struct register_dll_info *info, const WCHAR *
     HMODULE module;
     HRESULT res;
     SP_REGISTER_CONTROL_STATUSW status;
-#ifdef __WINESRC__
     IMAGE_NT_HEADERS *nt;
-#endif
 
     status.cbSize = sizeof(status);
     status.FileName = path;
@@ -565,7 +563,6 @@ static BOOL do_register_dll( const struct register_dll_info *info, const WCHAR *
         goto done;
     }
 
-#ifdef __WINESRC__
     if ((nt = RtlImageNtHeader( module )) && !(nt->FileHeader.Characteristics & IMAGE_FILE_DLL))
     {
         /* file is an executable, not a dll */
@@ -604,7 +601,6 @@ static BOOL do_register_dll( const struct register_dll_info *info, const WCHAR *
         CloseHandle( info.hProcess );
         goto done;
     }
-#endif // __WINESRC__
 
     if (flags & FLG_REGSVR_DLLREGISTER)
     {

--- a/dll/win32/setupapi/install.c
+++ b/dll/win32/setupapi/install.c
@@ -693,7 +693,12 @@ static BOOL register_dlls_callback( HINF hinf, PCWSTR field, void *arg )
         if (!SetupGetIntField( &context, 4, &flags )) flags = 0;
 
         /* get timeout */
+#ifdef __REACTOS__
+        /* "11,,cmd.exe,,,/K dir" means default timeout, not a timeout of zero */
+        if (!SetupGetIntField( &context, 5, &timeout ) || timeout == 0) timeout = 60;
+#else
         if (!SetupGetIntField( &context, 5, &timeout )) timeout = 60;
+#endif
 
         /* get command line */
         args = NULL;

--- a/media/inf/syssetup.inf
+++ b/media/inf/syssetup.inf
@@ -144,22 +144,19 @@ Control="System\CurrentControlSet\Control"
 
 [Classes]
 HKLM,%CurrentVersion%\Installer,"InstallerLocation",,"%11%"
+HKLM,Software\Microsoft\.NETFramework,InstallRoot,,"%10%\Microsoft.NET\Framework\"
 
 [DestinationDirs]
 IECopy=16422,Internet Explorer
 
 [Finalize] ; Executed by RunOnceEx on first normal boot
 ; FIXME: This should be moved to ie.inf,DefaultInstall and executed by [Infs.Always]
-AddReg=FinalizeAddReg
 CopyFiles=IECopy
 RegisterDlls=IEReg
-
-[FinalizeAddReg]
-HKLM,SOFTWARE\Microsoft\.NETFramework,InstallRoot,,"%10%\Microsoft.NET\Framework\"
 
 [IECopy]
 iexplore.exe,..\iexplore.exe,,0x00002000
 
 [IEReg]
 16422,Internet Explorer,iexplore.exe
-11,,rundll32.exe,,99,"advpack.dll,DelNodeRunDLL32 ""%10%\iexplore.exe"""
+11,,rundll32.exe,,,"advpack.dll,DelNodeRunDLL32 ""%10%\iexplore.exe"""

--- a/media/inf/syssetup.inf
+++ b/media/inf/syssetup.inf
@@ -144,3 +144,21 @@ Control="System\CurrentControlSet\Control"
 
 [Classes]
 HKLM,%CurrentVersion%\Installer,"InstallerLocation",,"%11%"
+
+[DestinationDirs]
+IECopy=16422,Internet Explorer
+
+[Finalize] ; Executed by RunOnce on first normal boot
+AddReg=FinalizeAddReg
+CopyFiles=IECopy
+RegisterDlls=IEReg
+
+[FinalizeAddReg]
+HKLM,SOFTWARE\Microsoft\.NETFramework,InstallRoot,,"%10%\Microsoft.NET\Framework\"
+
+[IECopy]
+iexplore.exe,..\iexplore.exe,,0x00002000
+
+[IEReg]
+16422,Internet Explorer,iexplore.exe
+11,,rundll32.exe,,99,"advpack.dll,DelNodeRunDLL32 ""%10%\iexplore.exe"""

--- a/media/inf/syssetup.inf
+++ b/media/inf/syssetup.inf
@@ -148,7 +148,8 @@ HKLM,%CurrentVersion%\Installer,"InstallerLocation",,"%11%"
 [DestinationDirs]
 IECopy=16422,Internet Explorer
 
-[Finalize] ; Executed by RunOnce on first normal boot
+[Finalize] ; Executed by RunOnceEx on first normal boot
+; FIXME: This should be moved to ie.inf,DefaultInstall and executed by [Infs.Always]
 AddReg=FinalizeAddReg
 CopyFiles=IECopy
 RegisterDlls=IEReg


### PR DESCRIPTION
This avoids the console popups on first boot.

Notes:
- I changed it from RunOnce to RunOnceEx because that is executed first.
- I have tested the code from RunOnceEx to completion but not on a real bootcd.
- I don't know if it is acceptable to add these entries to syssetup.inf but it was the most suitable existing inf file.