### PR TITLE
[SHELL32] Forward CDefaultContextMenu::InvokeCommand parameters to ShellExecute

### DIFF
--- a/dll/win32/shell32/CShellLink.cpp
+++ b/dll/win32/shell32/CShellLink.cpp
@@ -2602,7 +2602,7 @@ HRESULT CShellLink::DoOpen(LPCMINVOKECOMMANDINFO lpici)
     if (unicode)
     {
         LPCMINVOKECOMMANDINFOEX iciex = (LPCMINVOKECOMMANDINFOEX)lpici;
-        if (iciex->lpParametersW && iciex->lpParametersW[0])
+        if (!StrIsNullOrEmpty(iciex->lpParametersW))
         {
             args += L' ';
             args += iciex->lpParametersW;
@@ -2611,7 +2611,7 @@ HRESULT CShellLink::DoOpen(LPCMINVOKECOMMANDINFO lpici)
     else
     {
         CComHeapPtr<WCHAR> pszParams;
-        if (lpici->lpParameters && lpici->lpParameters[0] && __SHCloneStrAtoW(&pszParams, lpici->lpParameters))
+        if (!StrIsNullOrEmpty(lpici->lpParameters) && __SHCloneStrAtoW(&pszParams, lpici->lpParameters))
         {
             args += L' ';
             args += pszParams;

--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -1670,8 +1670,8 @@ static UINT_PTR SHELL_execute_class(LPCWSTR wszApplicationName, LPSHELLEXECUTEIN
         TRACE("SEE_MASK_CLASSNAME->%s, doc->%s\n", debugstr_w(execCmd), debugstr_w(wszApplicationName));
 
         wcmd[0] = '\0';
-        done = SHELL_ArgifyW(wcmd, ARRAY_SIZE(wcmd), execCmd, wszApplicationName, (LPITEMIDLIST)psei->lpIDList, NULL, &resultLen,
-                             (psei->lpDirectory && *psei->lpDirectory) ? psei->lpDirectory : NULL);
+        done = SHELL_ArgifyW(wcmd, ARRAY_SIZE(wcmd), execCmd, wszApplicationName, (LPITEMIDLIST)psei->lpIDList, psei->lpParameters,
+                             &resultLen, (psei->lpDirectory && *psei->lpDirectory) ? psei->lpDirectory : NULL);
         if (!done && wszApplicationName[0])
         {
             strcatW(wcmd, L" ");

--- a/sdk/include/reactos/shellutils.h
+++ b/sdk/include/reactos/shellutils.h
@@ -456,6 +456,8 @@ template<class B, class R> static HRESULT SHILCombine(B base, PCUIDLIST_RELATIVE
     return r ? S_OK : E_OUTOFMEMORY;
 }
 
+template<class T> static inline bool StrIsNullOrEmpty(T str) { return !str || !*str; }
+
 HRESULT inline SHSetStrRet(LPSTRRET pStrRet, LPCSTR pstrValue)
 {
     pStrRet->uType = STRRET_CSTR;

--- a/sdk/include/reactos/shellutils.h
+++ b/sdk/include/reactos/shellutils.h
@@ -456,7 +456,8 @@ template<class B, class R> static HRESULT SHILCombine(B base, PCUIDLIST_RELATIVE
     return r ? S_OK : E_OUTOFMEMORY;
 }
 
-template<class T> static inline bool StrIsNullOrEmpty(T str) { return !str || !*str; }
+static inline bool StrIsNullOrEmpty(LPCSTR str) { return !str || !*str; }
+static inline bool StrIsNullOrEmpty(LPCWSTR str) { return !str || !*str; }
 
 HRESULT inline SHSetStrRet(LPSTRRET pStrRet, LPCSTR pstrValue)
 {


### PR DESCRIPTION
The parameters must be propagated. CShellLink is the most extreme case: `ShellExecuteExW(SEE_MASK_INVOKEIDLIST)` ➜ `CDefaultContextMenu::InvokeCommand` ➜ `ShellExecuteExW(SEE_MASK_IDLIST)`.