### PR TITLE
[NTUSER] Redraw issues on window without draw background

### DIFF
--- a/win32ss/user/ntuser/defwnd.c
+++ b/win32ss/user/ntuser/defwnd.c
@@ -1068,6 +1068,7 @@ IntDefWindowProc(
          }
          break;
 
+      case WM_CREATE:
       case WM_ERASEBKGND:
       case WM_ICONERASEBKGND:
       {

--- a/win32ss/user/ntuser/defwnd.c
+++ b/win32ss/user/ntuser/defwnd.c
@@ -1069,6 +1069,28 @@ IntDefWindowProc(
          break;
 
       case WM_CREATE:
+      {
+         RECT Rect;
+         HBRUSH hBrush = Wnd->pcls->hbrBackground;
+         if (!hBrush) return 0;
+         if (hBrush <= (HBRUSH)COLOR_MENUBAR)
+         {
+            hBrush = IntGetSysColorBrush(HandleToUlong(hBrush));
+         }
+         if (Wnd->pcls->style & CS_PARENTDC)
+         {
+             can't use GetClipBox with a parent DC or we fill the whole parent 
+            IntGetClientRect(Wnd, &Rect);
+            GreDPtoLP((HDC)wParam, (LPPOINT)&Rect, 2);
+         }
+         else
+         {
+            GdiGetClipBox((HDC)wParam, &Rect);
+         }
+         FillRect((HDC)wParam, &Rect, hBrush);
+         return (0);
+      }
+
       case WM_ERASEBKGND:
       case WM_ICONERASEBKGND:
       {

--- a/win32ss/user/ntuser/defwnd.c
+++ b/win32ss/user/ntuser/defwnd.c
@@ -1069,28 +1069,6 @@ IntDefWindowProc(
          break;
 
       case WM_CREATE:
-      {
-         RECT Rect;
-         HBRUSH hBrush = Wnd->pcls->hbrBackground;
-         if (!hBrush) return 0;
-         if (hBrush <= (HBRUSH)COLOR_MENUBAR)
-         {
-            hBrush = IntGetSysColorBrush(HandleToUlong(hBrush));
-         }
-         if (Wnd->pcls->style & CS_PARENTDC)
-         {
-            /* can't use GetClipBox with a parent DC or we fill the whole parent */
-            IntGetClientRect(Wnd, &Rect);
-            GreDPtoLP((HDC)wParam, (LPPOINT)&Rect, 2);
-         }
-         else
-         {
-            GdiGetClipBox((HDC)wParam, &Rect);
-         }
-         FillRect((HDC)wParam, &Rect, hBrush);
-         return (0);
-      }
-
       case WM_ERASEBKGND:
       case WM_ICONERASEBKGND:
       {
@@ -1112,7 +1090,7 @@ IntDefWindowProc(
             GdiGetClipBox((HDC)wParam, &Rect);
          }
          FillRect((HDC)wParam, &Rect, hBrush);
-         return (1);
+         return (Msg == WM_CREATE) ? 0 : 1;
       }
 
       case WM_GETHOTKEY:

--- a/win32ss/user/ntuser/defwnd.c
+++ b/win32ss/user/ntuser/defwnd.c
@@ -1079,7 +1079,7 @@ IntDefWindowProc(
          }
          if (Wnd->pcls->style & CS_PARENTDC)
          {
-             can't use GetClipBox with a parent DC or we fill the whole parent 
+            /* can't use GetClipBox with a parent DC or we fill the whole parent */
             IntGetClientRect(Wnd, &Rect);
             GreDPtoLP((HDC)wParam, (LPPOINT)&Rect, 2);
          }


### PR DESCRIPTION
## Purpose

Some apps don't render the background on startup and don't set the rendering area correctly. The application relies on the OS to initialize the window on startup. This initialization is missing in ReactOS.

JIRA issue: [CORE-18800](https://jira.reactos.org/browse/CORE-18800)

## Proposed changes

I added WM_CREATE to the background rendering section of defwnd.c.


## TODO

_Use a TODO when your pull request is Work in Progress._

- [ ] 
- [ ] 
