### PR TITLE
[GITHUB] labeler.yml: Add 'input method' label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -43,3 +43,10 @@ Win32SS:
 - changed-files:
   - any-glob-to-any-file:
     - win32ss/**
+
+"input method":
+- changed-files:
+  - any-glob-to-any-file:
+    - dll/win32/imm32/**
+    - win32ss/user/ntuser/ime.c
+    - win32ss/user/user32/misc/imm.c

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -47,6 +47,9 @@ Win32SS:
 "input method":
 - changed-files:
   - any-glob-to-any-file:
+    - dll/ime/**
     - dll/win32/imm32/**
+    - dll/win32/msctf/**
+    - dll/win32/msutb/**
     - win32ss/user/ntuser/ime.c
     - win32ss/user/user32/misc/imm.c


### PR DESCRIPTION
## Purpose
Automatically add `input method` label.

JIRA issue: [CORE-19268](https://jira.reactos.org/browse/CORE-19268)

## Proposed changes

- Modify `.github/labeler.yml`.