### PR TITLE
[NETSHELL][SHELL32] Make NetShell PIDL format more Windows compatible

### DIFF
--- a/dll/shellext/netshell/precomp.h
+++ b/dll/shellext/netshell/precomp.h
@@ -55,16 +55,26 @@ WINE_DEFAULT_DEBUG_CHANNEL(shell);
 extern HINSTANCE netshell_hInstance;
 
 /* enumlist.c */
+#include <pshpack1.h>
+#define NETCONIDSTRUCT_SIG 0x4EFF
 typedef struct tagNETCONIDSTRUCT
 {
-    BYTE             type;
+    WORD             Signature;
+    BYTE             Unknown[8];
+    CLSID            clsidThisObject;
     GUID             guidId;
-    NETCON_STATUS    Status;
-    NETCON_MEDIATYPE MediaType;
     DWORD            dwCharacter;
-    ULONG_PTR        uNameOffset;
-    ULONG_PTR        uDeviceNameOffset;
+    NETCON_MEDIATYPE MediaType;
+    NETCON_STATUS    Status;
+    ULONG            uNameOffset;
+    ULONG            uDeviceNameOffset;
 } NETCONIDSTRUCT, *PNETCONIDSTRUCT;
+#include <poppack.h>
+
+C_ASSERT(2 + FIELD_OFFSET(NETCONIDSTRUCT, clsidThisObject) == 2 + (2 + 8));
+C_ASSERT(2 + FIELD_OFFSET(NETCONIDSTRUCT, guidId) == 2 + (2 + 8 + 16));
+C_ASSERT(2 + FIELD_OFFSET(NETCONIDSTRUCT, dwCharacter) == 2 + (2 + 8 + 32));
+C_ASSERT(2 + FIELD_OFFSET(NETCONIDSTRUCT, MediaType) == 2 + (2 + 8 + 36));
 
 PNETCONIDSTRUCT ILGetConnData(PCITEMID_CHILD pidl);
 PWCHAR ILGetConnName(PCITEMID_CHILD pidl);

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -1290,15 +1290,29 @@ PCUITEMID_CHILD CDefView::_PidlByItem(LVITEM& lvItem)
 
 int CDefView::LV_FindItemByPidl(PCUITEMID_CHILD pidl)
 {
-    ASSERT(m_ListView);
+    ASSERT(m_ListView && m_pSFParent);
 
     int cItems = m_ListView.GetItemCount();
-
-    for (int i = 0; i<cItems; i++)
+    LPARAM lParam = m_pSF2Parent ? SHCIDS_CANONICALONLY : 0;
+    for (int i = 0; i < cItems; i++)
     {
         PCUITEMID_CHILD currentpidl = _PidlByItem(i);
-        if (ILIsEqual(pidl, currentpidl))
-            return i;
+        HRESULT hr = m_pSFParent->CompareIDs(lParam, pidl, currentpidl);
+        if (SUCCEEDED(hr))
+        {
+            if (hr == 0)
+                return i;
+        }
+        else
+        {
+            for (i = 0; i < cItems; i++)
+            {
+                currentpidl = _PidlByItem(i);
+                if (ILIsEqual(pidl, currentpidl))
+                    return i;
+            }
+            break;
+        }
     }
     return -1;
 }

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -1300,7 +1300,7 @@ int CDefView::LV_FindItemByPidl(PCUITEMID_CHILD pidl)
         HRESULT hr = m_pSFParent->CompareIDs(lParam, pidl, currentpidl);
         if (SUCCEEDED(hr))
         {
-            if (hr == 0)
+            if (hr == S_EQUAL)
                 return i;
         }
         else

--- a/dll/win32/shell32/debughlp.cpp
+++ b/dll/win32/shell32/debughlp.cpp
@@ -379,7 +379,6 @@ BOOL pcheck( LPCITEMIDLIST pidl )
                 case PT_YAGUID:
                 case PT_IESPECIAL2:
                 case PT_SHARE:
-                case 0x99:      /* Network Connection pidl type */
                     break;
                 default:
                     ERR("unknown IDLIST %p [%p] size=%u type=%x\n",

--- a/dll/win32/shell32/wine/pidl.c
+++ b/dll/win32/shell32/wine/pidl.c
@@ -557,7 +557,13 @@ BOOL WINAPI ILIsEqual(LPCITEMIDLIST pidl1, LPCITEMIDLIST pidl2)
      * so we can only check here
      */
     if (!pcheck(pidl1) || !pcheck (pidl2))
+#ifdef __REACTOS__
+    {
+        /* We don't understand the PIDL content but that does not mean it's invalid */
+    }
+#else
         return FALSE;
+#endif
 
     pdump (pidl1);
     pdump (pidl2);

--- a/sdk/include/reactos/shellfolderutils.h
+++ b/sdk/include/reactos/shellfolderutils.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include "shellutils.h"
+
 #ifdef __cplusplus
 
 template <BOOL LOGICALCMP = TRUE>
@@ -36,7 +38,7 @@ static HRESULT ShellFolderImpl_CompareItemIDs(IShellFolder2 *psf, LPARAM lParam,
     if (CANONICAL >= 0 && (lParam & SHCIDS_CANONICALONLY))
     {
         hr = ShellFolderImpl_CompareItemColumn<LOGICALCMP>(psf, CANONICAL, pidl1, pidl2);
-        if (hr == 0 || !(lParam & SHCIDS_ALLFIELDS) || FAILED(hr))
+        if (hr == S_EQUAL || !(lParam & SHCIDS_ALLFIELDS) || FAILED(hr))
             return hr;
     }
     if (lParam & SHCIDS_ALLFIELDS)
@@ -44,7 +46,7 @@ static HRESULT ShellFolderImpl_CompareItemIDs(IShellFolder2 *psf, LPARAM lParam,
         for (UINT i = 0; i < COLCOUNT; ++i)
         {
             hr = ShellFolderImpl_CompareItemColumn<LOGICALCMP>(psf, i, pidl1, pidl2);
-            if (hr && SUCCEEDED(hr))
+            if (hr && SUCCEEDED(hr)) // Only stop if we successfully found a difference
                 break;
         }
         return hr;

--- a/sdk/include/reactos/shellfolderutils.h
+++ b/sdk/include/reactos/shellfolderutils.h
@@ -1,0 +1,60 @@
+/*
+ * LICENSE:     LGPL-2.1+ (https://spdx.org/licenses/LGPL-2.1+)
+ * PURPOSE:     Utility functions for IShellFolder implementations
+ * COPYRIGHT:   Copyright 2024 Whindmar Saksit <whindsaks@proton.me>
+ */
+
+#pragma once
+
+#ifdef __cplusplus
+
+template <BOOL LOGICALCMP = TRUE>
+static HRESULT ShellFolderImpl_CompareItemColumn(IShellFolder2 *psf, UINT column, PCUITEMID_CHILD pidl1, PCUITEMID_CHILD pidl2)
+{
+    SHELLDETAILS details1, details2;
+    LPWSTR str1, str2;
+    HRESULT hr;
+    if (SUCCEEDED(hr = psf->GetDetailsOf(pidl1, column, &details1)))
+    {
+        if (SUCCEEDED(hr = StrRetToStrW(&details1.str, pidl1, &str1)))
+        {
+            if (SUCCEEDED(hr = psf->GetDetailsOf(pidl2, column, &details2)))
+            {
+                if (SUCCEEDED(hr = StrRetToStrW(&details2.str, pidl2, &str2)))
+                {
+                    int res = LOGICALCMP ? StrCmpLogicalW(str1, str2) : lstrcmpiW(str1, str2);
+                    hr = MAKE_COMPARE_HRESULT(res);
+                    SHFree(str2);
+                }
+            }
+            SHFree(str1);
+        }
+    }
+    return hr;
+}
+
+template <UINT COLCOUNT, int CANONICAL, BOOL LOGICALCMP = TRUE>
+static HRESULT ShellFolderImpl_CompareItemIDs(IShellFolder2 *psf, LPARAM lParam, PCUITEMID_CHILD pidl1, PCUITEMID_CHILD pidl2)
+{
+    HRESULT hr;
+    if (CANONICAL >= 0 && (lParam & SHCIDS_CANONICALONLY))
+    {
+        hr = ShellFolderImpl_CompareItemColumn<LOGICALCMP>(psf, CANONICAL, pidl1, pidl2);
+        if (hr == 0 || !(lParam & SHCIDS_ALLFIELDS) || FAILED(hr))
+            return hr;
+    }
+    if (lParam & SHCIDS_ALLFIELDS)
+    {
+        for (UINT i = 0; i < COLCOUNT; ++i)
+        {
+            hr = ShellFolderImpl_CompareItemColumn<LOGICALCMP>(psf, i, pidl1, pidl2);
+            if (hr && SUCCEEDED(hr))
+                break;
+        }
+        return hr;
+    }
+    const UINT column = (UINT)(lParam & SHCIDS_COLUMNMASK);
+    return ShellFolderImpl_CompareItemColumn<LOGICALCMP>(psf, column, pidl1, pidl2);
+}
+
+#endif // __cplusplus

--- a/sdk/include/reactos/shellfolderutils.h
+++ b/sdk/include/reactos/shellfolderutils.h
@@ -14,21 +14,17 @@ static HRESULT ShellFolderImpl_CompareItemColumn(IShellFolder2 *psf, UINT column
     SHELLDETAILS details1, details2;
     LPWSTR str1, str2;
     HRESULT hr;
-    if (SUCCEEDED(hr = psf->GetDetailsOf(pidl1, column, &details1)))
+    if (SUCCEEDED(hr = psf->GetDetailsOf(pidl1, column, &details1)) &&
+        SUCCEEDED(hr = StrRetToStrW(&details1.str, pidl1, &str1)))
     {
-        if (SUCCEEDED(hr = StrRetToStrW(&details1.str, pidl1, &str1)))
+        if (SUCCEEDED(hr = psf->GetDetailsOf(pidl2, column, &details2)) &&
+            SUCCEEDED(hr = StrRetToStrW(&details2.str, pidl2, &str2)))
         {
-            if (SUCCEEDED(hr = psf->GetDetailsOf(pidl2, column, &details2)))
-            {
-                if (SUCCEEDED(hr = StrRetToStrW(&details2.str, pidl2, &str2)))
-                {
-                    int res = LOGICALCMP ? StrCmpLogicalW(str1, str2) : lstrcmpiW(str1, str2);
-                    hr = MAKE_COMPARE_HRESULT(res);
-                    SHFree(str2);
-                }
-            }
-            SHFree(str1);
+            int res = LOGICALCMP ? StrCmpLogicalW(str1, str2) : lstrcmpiW(str1, str2);
+            hr = MAKE_COMPARE_HRESULT(res);
+            SHFree(str2);
         }
+        SHFree(str1);
     }
     return hr;
 }


### PR DESCRIPTION
The NetShell (Connections folder) PIDL format needs to match Windows for the wlanwiz work @SigmaTel71 is doing (specifically, matching the GUID from INetConnection properties with the GUID inside the PIDL).

Notes:
- The PIDL format needs to be Windows compatible so that wlanwiz can check the connection GUID.
- `SHELL32::ILIsEqual` cannot deem PIDL formats it does not understand as invalid.
- DefView must ask the folder when comparing PIDLs.