### PR TITLE
[EXPLORER] Fix behavior from Show Desktop button

### DIFF
--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -3243,10 +3243,11 @@ HandleTrayContextMenu:
             }
         }
 
-        g_MinimizedAll.RemoveAll();
-
-        if (!bDestroyed)
+        if (bDestroyed)
+            g_MinimizedAll.RemoveAll();
+        else
             ::SetForegroundWindow(hwndActive);
+
     }
 
     LRESULT OnPulse(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -3247,7 +3247,6 @@ HandleTrayContextMenu:
             g_MinimizedAll.RemoveAll();
         else
             ::SetForegroundWindow(hwndActive);
-
     }
 
     LRESULT OnPulse(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)


### PR DESCRIPTION
## Purpose

Fix behavior from Show Desktop button.
JIRA issues: [CORE-19703](https://jira.reactos.org/browse/CORE-19703), [CORE-15369](https://jira.reactos.org/browse/CORE-15369)
Addendum to https://github.com/reactos/reactos/commit/70d7009ad958da5b0952b6e5af5194337a387459

## Observed behavior:

On the second click to "Show desktop" button, the minimized windows are not restored.

This happens because after the first click and the addition to `CSimpleArray<MINWNDPOS> g_MinimizedAll`, a call to `RestoreMinimizedNonTaskWnds()` via `HSHELL_WINDOWACTIVATED` message, emptied the list of minimized windows.

Don't empty `g_MinimizedAll` while processing HSHELL_WINDOWCREATED or HSHELL_WINDOWACTIVATED message. 
(bDestroyed=FALSE).
Empty  `g_MinimizedAll` only when SendPulseToTray is called with bDestroyed=TRUE.
