### PR TITLE
[USETUP] InstallDirectoryPage(): Pressing ESC erases the whole path line

### DIFF
--- a/base/setup/usetup/usetup.c
+++ b/base/setup/usetup/usetup.c
@@ -3043,6 +3043,14 @@ InstallDirectoryPage(PINPUT_RECORD Ir)
                 CONSOLE_SetCursorXY(8 + Pos, 11);
             }
         }
+        else if (Ir->Event.KeyEvent.wVirtualKeyCode == VK_ESCAPE)  /* ESC */
+        {
+            /* Erase the whole line */
+            *InstallDir = UNICODE_NULL;
+            Pos = Length = 0;
+            CONSOLE_SetInputTextXY(8, 11, 51, InstallDir);
+            CONSOLE_SetCursorXY(8 + Pos, 11);
+        }
         else if (Ir->Event.KeyEvent.uChar.AsciiChar == 0x0D) /* ENTER */
         {
             CONSOLE_SetCursorType(TRUE, FALSE);


### PR DESCRIPTION
## Purpose

InstallDirectoryPage(): Pressing ESC erases the whole path line.

A similar behaviour exists in Windows <= 2003 text-mode setup, on this screen:
![image](https://github.com/user-attachments/assets/5185916e-b44f-4041-be48-a7cebd935ed6)

## Proposed changes

When the user presses ESC key, zero out `InstallDir` buffer and set the cursor position to zero before redrawing the input line and reading keyboard input.
