### PR TITLE
[SETUPLIB][USETUP] Move IsValidPath() back into setuplib for reusability

### DIFF
--- a/base/setup/lib/setuplib.c
+++ b/base/setup/lib/setuplib.c
@@ -712,6 +712,51 @@ InitSystemPartition(
     return TRUE;
 }
 
+BOOLEAN
+IsValidInstallDirectory(
+    _In_ PCWSTR InstallDir)
+{
+    UINT i, Length;
+
+    Length = wcslen(InstallDir);
+
+    // TODO: Add check for 8.3 too.
+
+    /* Path must be at least 2 characters long */
+//    if (Length < 2)
+//        return FALSE;
+
+    /* Path must start with a backslash */
+//    if (InstallDir[0] != L'\\')
+//        return FALSE;
+
+    /* Path must not end with a backslash */
+    if (InstallDir[Length - 1] == L'\\')
+        return FALSE;
+
+    /* Path must not contain whitespace characters */
+    for (i = 0; i < Length; i++)
+    {
+        if (iswspace(InstallDir[i]))
+            return FALSE;
+    }
+
+    /* Path component must not end with a dot */
+    for (i = 0; i < Length; i++)
+    {
+        if (InstallDir[i] == L'\\' && i > 0)
+        {
+            if (InstallDir[i - 1] == L'.')
+                return FALSE;
+        }
+    }
+
+    if (InstallDir[Length - 1] == L'.')
+        return FALSE;
+
+    return TRUE;
+}
+
 NTSTATUS
 InitDestinationPaths(
     IN OUT PUSETUP_DATA pSetupData,

--- a/base/setup/lib/setuplib.h
+++ b/base/setup/lib/setuplib.h
@@ -177,6 +177,13 @@ InitSystemPartition(
     _In_opt_ PFSVOL_CALLBACK FsVolCallback,
     _In_opt_ PVOID Context);
 
+#define IS_VALID_INSTALL_PATH_CHAR(c) \
+    (iswalnum(c) || (c) == L'.' || (c) == L'\\' || (c) == L'-' || (c) == L'_')
+
+BOOLEAN
+IsValidInstallDirectory(
+    _In_ PCWSTR InstallDir);
+
 NTSTATUS
 InitDestinationPaths(
     IN OUT PUSETUP_DATA pSetupData,

--- a/base/setup/usetup/usetup.c
+++ b/base/setup/usetup/usetup.c
@@ -2866,52 +2866,6 @@ FsVolCallback(
 }
 
 
-static BOOLEAN
-IsValidPath(
-    IN PCWSTR InstallDir)
-{
-    UINT i, Length;
-
-    Length = wcslen(InstallDir);
-
-    // TODO: Add check for 8.3 too.
-
-    /* Path must be at least 2 characters long */
-//    if (Length < 2)
-//        return FALSE;
-
-    /* Path must start with a backslash */
-//    if (InstallDir[0] != L'\\')
-//        return FALSE;
-
-    /* Path must not end with a backslash */
-    if (InstallDir[Length - 1] == L'\\')
-        return FALSE;
-
-    /* Path must not contain whitespace characters */
-    for (i = 0; i < Length; i++)
-    {
-        if (iswspace(InstallDir[i]))
-            return FALSE;
-    }
-
-    /* Path component must not end with a dot */
-    for (i = 0; i < Length; i++)
-    {
-        if (InstallDir[i] == L'\\' && i > 0)
-        {
-            if (InstallDir[i - 1] == L'.')
-                return FALSE;
-        }
-    }
-
-    if (InstallDir[Length - 1] == L'.')
-        return FALSE;
-
-    return TRUE;
-}
-
-
 /*
  * Displays the InstallDirectoryPage.
  *
@@ -2951,7 +2905,7 @@ InstallDirectoryPage(PINPUT_RECORD Ir)
      * of an invalid path, or we are in regular setup), display the UI and allow
      * the user to specify a new installation path.
      */
-    if ((RepairUpdateFlag || IsUnattendedSetup) && IsValidPath(InstallDir))
+    if ((RepairUpdateFlag || IsUnattendedSetup) && IsValidInstallDirectory(InstallDir))
     {
         Status = InitDestinationPaths(&USetupData, InstallDir, InstallPartition);
         if (!NT_SUCCESS(Status))
@@ -3059,7 +3013,7 @@ InstallDirectoryPage(PINPUT_RECORD Ir)
              * Check for the validity of the installation directory and pop up
              * an error if it is not the case. Then the user can fix its input.
              */
-            if (!IsValidPath(InstallDir))
+            if (!IsValidInstallDirectory(InstallDir))
             {
                 MUIDisplayError(ERROR_DIRECTORY_NAME, Ir, POPUP_WAIT_ENTER);
                 return INSTALL_DIRECTORY_PAGE;
@@ -3106,8 +3060,11 @@ InstallDirectoryPage(PINPUT_RECORD Ir)
         {
             if (Length < 50)
             {
+                /* Only accept valid characters for installation path
+                 * (alpha-numeric, '.', '\', '-' and '_'). Note that
+                 * spaces are not accepted. */
                 c = (WCHAR)Ir->Event.KeyEvent.uChar.AsciiChar;
-                if (iswalpha(c) || iswdigit(c) || c == '.' || c == '\\' || c == '-' || c == '_')
+                if (IS_VALID_INSTALL_PATH_CHAR(c))
                 {
                     if (Pos < Length)
                         memmove(&InstallDir[Pos + 1],


### PR DESCRIPTION
## Purpose

Move IsValidPath() back into setuplib for reusability (in the GUI setup).

## Proposed changes

Reverts the `IsValidPath()` move done in commit 9c64b57dc.

- Turn `IsValidPath()` into a `IsValidInstallDirectory()` helper function
  available in the setuplib, so that it can also be used in the GUI setup.

- Introduce a `IS_VALID_INSTALL_PATH_CHAR()` macro.
