### PR TITLE
[SETUPLIB] Add unit-tests for the setuplib. Improve IsValidInstallDirectory() behaviour.

### DIFF
--- a/base/setup/lib/CMakeLists.txt
+++ b/base/setup/lib/CMakeLists.txt
@@ -33,3 +33,9 @@ list(APPEND SOURCE
 add_library(setuplib ${SOURCE})
 add_pch(setuplib precomp.h SOURCE)
 add_dependencies(setuplib xdk) # psdk
+
+
+## Unit-tests
+if(ENABLE_ROSTESTS)
+    add_subdirectory(unittests)
+endif()

--- a/base/setup/lib/setuplib.c
+++ b/base/setup/lib/setuplib.c
@@ -712,50 +712,98 @@ InitSystemPartition(
     return TRUE;
 }
 
+
+#define IS_PATH_SEPARATOR(c)    ((c) == L'\\' || (c) == L'/')
+
+/**
+ * @brief
+ * Verify whether the given directory is suitable for ReactOS installation.
+ * Each path component must be a valid 8.3 name.
+ **/
 BOOLEAN
 IsValidInstallDirectory(
     _In_ PCWSTR InstallDir)
 {
-    UINT i, Length;
+    PCWCH p;
 
-    Length = wcslen(InstallDir);
-
-    // TODO: Add check for 8.3 too.
-
-    /* Path must be at least 2 characters long */
-//    if (Length < 2)
-//        return FALSE;
-
-    /* Path must start with a backslash */
-//    if (InstallDir[0] != L'\\')
-//        return FALSE;
-
-    /* Path must not end with a backslash */
-    if (InstallDir[Length - 1] == L'\\')
+    /* As with the NT installer, fail if the path is empty or "\\" */
+    p = InstallDir;
+    if (!*p || (IS_PATH_SEPARATOR(*p) && !*(p + 1)))
         return FALSE;
 
-    /* Path must not contain whitespace characters */
-    for (i = 0; i < Length; i++)
+    /* The path must contain only valid characters (alpha-numeric,
+     * '.', '\\', '-' and '_'). Spaces are not accepted. */
+    for (p = InstallDir; *p; ++p)
     {
-        if (iswspace(InstallDir[i]))
+        if (!IS_VALID_INSTALL_PATH_CHAR(*p))
             return FALSE;
     }
 
-    /* Path component must not end with a dot */
-    for (i = 0; i < Length; i++)
+    /*
+     * Loop over each path component and verify that each is a valid 8.3 name.
+     */
+    for (p = InstallDir; *p;)
     {
-        if (InstallDir[i] == L'\\' && i > 0)
-        {
-            if (InstallDir[i - 1] == L'.')
-                return FALSE;
-        }
-    }
+        PCWSTR Path;
+        SIZE_T Length;
+        UNICODE_STRING Name;
+        BOOLEAN IsNameLegal, SpacesInName;
 
-    if (InstallDir[Length - 1] == L'.')
-        return FALSE;
+        /* Skip any first separator */
+        if (IS_PATH_SEPARATOR(*p))
+            ++p;
+
+        /* Now skip past the path component until we reach the next separator */
+        Path = p;
+        while (*p && !IS_PATH_SEPARATOR(*p))
+            ++p;
+        if (p == Path)
+        {
+            /* Succeed if nothing else follows this separator; otherwise
+             * it's a separator and consecutive ones are not supported */
+            return (!*p);
+        }
+
+        /* Calculate the path component length */
+        Length = p - Path;
+
+        /* As with the NT installer, fail for '.' and '..';
+         * RtlIsNameLegalDOS8Dot3() would succeed otherwise */
+        if ((Length == 1 && *Path == '.') || (Length == 2 && *Path == '.' && *(Path + 1) == '.'))
+            return FALSE;
+
+        /* As with the NT installer, allow _only ONE trailing_ dot in
+         * the path component (but not 2 or more), by reducing Length
+         * in that case; RtlIsNameLegalDOS8Dot3() would fail otherwise */
+        if (Length > 1 && *(p - 2) != L'.' && *(p - 1) == L'.')
+            --Length;
+
+        if (Length == 0)
+            return FALSE;
+
+        /* Verify that the path component is a valid 8.3 name */
+        // if (Length > 8+1+3)
+        //     return FALSE;
+        Name.Length = Name.MaximumLength = (USHORT)(Length * sizeof(WCHAR));
+        Name.Buffer = (PWCHAR)Path;
+        SpacesInName = FALSE;
+        IsNameLegal = RtlIsNameLegalDOS8Dot3(&Name, NULL, &SpacesInName);
+
+        /* If it isn't legal or contain spaces, fail */
+        if (!IsNameLegal || SpacesInName)
+        {
+            DPRINT("'%wZ' is %s 8.3 filename %s spaces\n",
+                   &Name,
+                   (IsNameLegal ? "a valid" : "an invalid"),
+                   (SpacesInName ? "with" : "without"));
+            return FALSE;
+        }
+        /* Go to the next path component */
+    }
 
     return TRUE;
 }
+
 
 NTSTATUS
 InitDestinationPaths(

--- a/base/setup/lib/unittests/CMakeLists.txt
+++ b/base/setup/lib/unittests/CMakeLists.txt
@@ -1,0 +1,17 @@
+
+PROJECT(setuplib_unittest)
+
+include_directories(${REACTOS_SOURCE_DIR}/modules/rostests/apitests/include)
+
+list(APPEND TEST_SOURCE
+    IsValidInstallDirectory.c
+    testlist.c
+    precomp.h)
+
+add_executable(setuplib_unittest ${TEST_SOURCE})
+
+target_link_libraries(setuplib_unittest setuplib ${PSEH_LIB})
+set_module_type(setuplib_unittest win32cui)
+add_importlibs(setuplib_unittest msvcrt kernel32 ntdll)
+#add_pch(setuplib_unittest precomp.h TEST_SOURCE)
+add_rostests_file(TARGET setuplib_unittest)

--- a/base/setup/lib/unittests/IsValidInstallDirectory.c
+++ b/base/setup/lib/unittests/IsValidInstallDirectory.c
@@ -1,0 +1,110 @@
+/*
+ * PROJECT:     ReactOS Setup Library - Unit-tests
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Test for IsValidInstallDirectory
+ * COPYRIGHT:   Copyright 2024 Hermès Bélusca-Maïto <hermes.belusca-maito@reactos.org>
+ */
+
+#include "precomp.h"
+
+//
+// FIXME: Temporary symbols defined to make linking work.
+// They will be defined to something once INF file testing is implemented.
+//
+pSpInfCloseInfFile  SpInfCloseInfFile  = NULL;
+pSpInfFindFirstLine SpInfFindFirstLine = NULL;
+pSpInfFindNextLine  SpInfFindNextLine  = NULL;
+pSpInfGetFieldCount SpInfGetFieldCount = NULL;
+pSpInfGetBinaryField  SpInfGetBinaryField  = NULL;
+pSpInfGetIntField     SpInfGetIntField     = NULL;
+pSpInfGetMultiSzField SpInfGetMultiSzField = NULL;
+pSpInfGetStringField  SpInfGetStringField  = NULL;
+pSpInfGetField    SpInfGetField    = NULL;
+pSpInfOpenInfFile SpInfOpenInfFile = NULL;
+
+BOOLEAN IsUnattendedSetup = FALSE;
+HANDLE ProcessHeap;
+
+
+START_TEST(IsValidInstallDirectory)
+{
+    static const struct
+    {
+        PCWSTR path;
+        BOOLEAN result;
+    } tests[] =
+    {
+        { L"",              FALSE },
+        { L" ",             FALSE },
+        { L"\\",            FALSE },
+        { L"\\\\",          FALSE },
+        { L".",             FALSE },
+        { L"..",            FALSE },
+        { L"...",           FALSE },
+        { L"....",          FALSE },
+        { L" WINNT",        FALSE },
+        { L"WINNT ",        FALSE },
+        { L".WINNT",        FALSE },
+        { L"..WINNT",       FALSE },
+        { L"W.INNT",        FALSE },
+        { L"WI.NNT",        TRUE  },
+        { L"WIN.NT",        TRUE  },
+        { L"WINNT.",        TRUE  },
+        { L"WINNT..",       FALSE },
+        { L"WINNT. ",       FALSE },
+        { L"WINNT.e e",     FALSE },
+        { L"WIN^`NT",       FALSE },
+
+        { L"WINNT",         TRUE  },
+        { L"\\WINNT",       TRUE  },
+        { L"\\WINNT\\",     TRUE  },
+        { L"\\WINNT\\.",    FALSE },
+        { L"WIN\\NT",       TRUE  },
+        { L"WIN\\NT.",      TRUE  },
+        { L"\\WIN\\NT\\",   TRUE  },
+        { L"\\WIN\\NT.\\",  TRUE  },
+        { L"\\WIN.\\NT52",  TRUE  },
+        { L"\\WIN\\.\\NT52",    FALSE },
+        { L"\\WIN\\..\\NT52",   FALSE },
+        { L"\\WIN\\...\\NT52",  FALSE },
+        { L"\\WIN\\....\\NT52", FALSE },
+
+        { L"win.nt.5",      FALSE },
+        { L"win.ntX5",      FALSE },
+        { L"winn.tX5",      TRUE  },
+        { L"winnt.X5",      TRUE  },
+        { L"winntX.5",      TRUE  },
+        { L"winntX5.",      TRUE  },
+        { L"filenamee.xte", FALSE },
+        { L"filenamee.xt",  FALSE },
+        { L"filename.ext",  TRUE  },
+        { L"file.ame.ext",  FALSE },
+        { L"filenam.eext",  FALSE },
+
+        { L"1 3 5 7 .abc",  FALSE },
+        { L"12345678.  c",  FALSE },
+        { L"123456789.a",   FALSE },
+        { L"12345.abcd",    FALSE },
+        { L"12345.ab d",    FALSE },
+        { L".abc",          FALSE },
+        { L"12.abc.d",      FALSE },
+        { L"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", FALSE },
+    };
+
+#define BOOL_TO_STR(b) ((b) ? "TRUE" : "FALSE")
+
+    ProcessHeap = GetProcessHeap();
+
+    UINT i;
+    for (i = 0; i < _countof(tests); ++i)
+    {
+        BOOLEAN ret = IsValidInstallDirectory(tests[i].path);
+        ok(ret == tests[i].result,
+           "Unexpected result for '%S', got %s, expected %s\n",
+           tests[i].path, BOOL_TO_STR(ret), BOOL_TO_STR(tests[i].result));
+    }
+
+#undef BOOL_TO_STR
+}
+
+/* EOF */

--- a/base/setup/lib/unittests/precomp.h
+++ b/base/setup/lib/unittests/precomp.h
@@ -1,0 +1,29 @@
+/*
+ * PROJECT:     ReactOS Setup Library - Unit-tests
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Precompiled header
+ * COPYRIGHT:   Copyright 2024 Hermès Bélusca-Maïto <hermes.belusca-maito@reactos.org>
+ */
+
+#pragma once
+
+#include <apitest.h>
+
+/* C Headers */
+#include <stdio.h>
+
+/* PSDK/NDK */
+#define WIN32_NO_STATUS
+#define _INC_WINDOWS
+#define COM_NO_WINDOWS_H
+
+#include <windef.h>
+#include <winbase.h>
+//#include <strsafe.h>
+
+#define NTOS_MODE_USER
+#include <ndk/rtlfuncs.h>
+
+#include <../setuplib.h>
+
+/* EOF */

--- a/base/setup/lib/unittests/testlist.c
+++ b/base/setup/lib/unittests/testlist.c
@@ -1,0 +1,10 @@
+#define STANDALONE
+#include <apitest.h>
+
+extern void func_IsValidInstallDirectory(void);
+
+const struct test winetest_testlist[] =
+{
+    { "IsValidInstallDirectory", func_IsValidInstallDirectory },
+    { 0, 0 }
+};


### PR DESCRIPTION
## Purpose & Proposed changes

- Add unit-tests for the setuplib.
- Improve IsValidInstallDirectory() behaviour.

See also commits d329fbebf (r66995), 7c3f4c94a (r68307), and 16daf6700.

The function verifies that each path component of the directory is
a valid 8.3 name, not . or .. nor empty. This behaviour is compatible
with what can be observed from Windows XP/2003 installer.
(To reliably test this with the Windows installer, you need to modify
the TXTSETUP.SIF DefaultPath value in the [SetupData] section.)

JIRA issues: [CORE-6149](https://jira.reactos.org/browse/CORE-6149), [CORE-6179](https://jira.reactos.org/browse/CORE-6179), [CORE-9529](https://jira.reactos.org/browse/CORE-9529)
