### PR TITLE
[SHELL32] Don't display non-enumerable nor non-folder items in Explorer tree

### DIFF
--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -231,6 +231,7 @@ private:
     CComPtr<IShellFolderViewCB> m_pShellFolderViewCB;
     CComPtr<IShellBrowser>    m_pShellBrowser;
     CComPtr<ICommDlgBrowser>  m_pCommDlgBrowser;
+    CComPtr<IFolderFilter>    m_pFolderFilter;
     CComPtr<IShellFolderViewDual> m_pShellFolderViewDual;
     CListView                 m_ListView;
     HWND                      m_hWndParent;
@@ -636,14 +637,16 @@ HRESULT WINAPI CDefView::Initialize(IShellFolder *shellFolder)
 HRESULT CDefView::IncludeObject(PCUITEMID_CHILD pidl)
 {
     HRESULT ret = S_OK;
-
     if (m_pCommDlgBrowser && !(GetCommDlgViewFlags() & CDB2GVF_NOINCLUDEITEM))
     {
         TRACE("ICommDlgBrowser::IncludeObject pidl=%p\n", pidl);
         ret = m_pCommDlgBrowser->IncludeObject(this, pidl);
         TRACE("-- returns 0x%08x\n", ret);
     }
-
+    else if (m_pFolderFilter)
+    {
+        ret = m_pFolderFilter->ShouldShow(m_pSFParent, m_pidlParent, pidl);
+    }
     return ret;
 }
 
@@ -4006,6 +4009,9 @@ HRESULT STDMETHODCALLTYPE CDefView::SetCallback(IShellFolderViewCB  *new_cb, ISh
         *old_cb = m_pShellFolderViewCB.Detach();
 
     m_pShellFolderViewCB = new_cb;
+    m_pFolderFilter = NULL;
+    if (new_cb)
+        new_cb->QueryInterface(IID_PPV_ARG(IFolderFilter, &m_pFolderFilter));
     return S_OK;
 }
 

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -1484,7 +1484,7 @@ HRESULT CDefView::FillList(BOOL IsRefreshCommand)
     DWORD         dwFetched;
     HRESULT       hRes;
     HDPA          hdpa;
-    DWORD         dFlags = SHCONTF_NONFOLDERS | SHCONTF_FOLDERS;
+    DWORD         dFlags = SHCONTF_NONFOLDERS | ((m_FolderSettings.fFlags & FWF_NOSUBFOLDERS) ? 0 : SHCONTF_FOLDERS);
 
     TRACE("%p\n", this);
 

--- a/dll/win32/shell32/CEnumIDListBase.cpp
+++ b/dll/win32/shell32/CEnumIDListBase.cpp
@@ -96,33 +96,6 @@ BOOL CEnumIDListBase::DeleteList()
     return TRUE;
 }
 
-/**************************************************************************
- *  HasItemWithCLSID()
- */
-BOOL CEnumIDListBase::HasItemWithCLSID(LPITEMIDLIST pidl)
-{
-    ENUMLIST *pCur;
-    IID *ptr = _ILGetGUIDPointer(pidl);
-
-    if (ptr)
-    {
-        REFIID refid = *ptr;
-        pCur = mpFirst;
-
-        while(pCur)
-        {
-            LPGUID curid = _ILGetGUIDPointer(pCur->pidl);
-            if (curid && IsEqualGUID(*curid, refid))
-            {
-                return TRUE;
-            }
-            pCur = pCur->pNext;
-        }
-    }
-
-    return FALSE;
-}
-
 HRESULT CEnumIDListBase::AppendItemsFromEnumerator(IEnumIDList* pEnum)
 {
     LPITEMIDLIST pidl;

--- a/dll/win32/shell32/CEnumIDListBase.h
+++ b/dll/win32/shell32/CEnumIDListBase.h
@@ -27,7 +27,7 @@ class CEnumIDListBase :
 	public CComObjectRootEx<CComMultiThreadModelNoCS>,
 	public IEnumIDList
 {
-private:
+protected:
 	ENUMLIST				*mpFirst;
 	ENUMLIST				*mpLast;
 	ENUMLIST				*mpCurrent;
@@ -37,7 +37,19 @@ public:
 	BOOL AddToEnumList(LPITEMIDLIST pidl);
 	BOOL DeleteList();
 	BOOL HasItemWithCLSID(LPITEMIDLIST pidl);
-    HRESULT AppendItemsFromEnumerator(IEnumIDList* pEnum);
+	HRESULT AppendItemsFromEnumerator(IEnumIDList* pEnum);
+
+	template <class T> BOOL HasItemWithCLSIDImpl(LPCITEMIDLIST pidl)
+	{
+		const CLSID * const pClsid = static_cast<T*>(this)->GetPidlClsid((PCUITEMID_CHILD)pidl);
+		for (ENUMLIST *pCur = mpFirst; pClsid && pCur; pCur = pCur->pNext)
+		{
+			const CLSID * const pEnumClsid = static_cast<T*>(this)->GetPidlClsid((PCUITEMID_CHILD)pCur->pidl);
+			if (pEnumClsid && IsEqualCLSID(*pClsid, *pEnumClsid))
+				return TRUE;
+		}
+		return FALSE;
+	}
 
 	// *** IEnumIDList methods ***
 	STDMETHOD(Next)(ULONG celt, LPITEMIDLIST *rgelt, ULONG *pceltFetched) override;

--- a/dll/win32/shell32/folders/CControlPanelFolder.cpp
+++ b/dll/win32/shell32/folders/CControlPanelFolder.cpp
@@ -23,6 +23,13 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(shell);
 
+static const REGFOLDERINFO g_RegFolderInfo = {
+    PT_CONTROLS_NEWREGITEM,
+    0, NULL,
+    CLSID_ControlPanel,
+    L"ControlPanel",
+};
+
 /***********************************************************************
 *   control panel implementation in shell namespace
 */
@@ -627,11 +634,11 @@ HRESULT WINAPI CControlPanelFolder::Initialize(PCIDLIST_ABSOLUTE pidl)
     pidlRoot = ILClone(pidl);
 
     /* Create the inner reg folder */
+    REGFOLDERINITDATA RegInit = { static_cast<IShellFolder*>(this), &g_RegFolderInfo };
     HRESULT hr;
-    hr = CRegFolder_CreateInstance(&CLSID_ControlPanel,
+    hr = CRegFolder_CreateInstance(&RegInit,
                                    pidlRoot,
                                    L"::{20D04FE0-3AEA-1069-A2D8-08002B30309D}\\::{21EC2020-3AEA-1069-A2DD-08002B30309D}",
-                                   L"ControlPanel",
                                    IID_PPV_ARG(IShellFolder2, &m_regFolder));
     if (FAILED_UNEXPECTEDLY(hr))
         return hr;

--- a/dll/win32/shell32/folders/CControlPanelFolder.cpp
+++ b/dll/win32/shell32/folders/CControlPanelFolder.cpp
@@ -27,6 +27,7 @@ static const REGFOLDERINFO g_RegFolderInfo = {
     PT_CONTROLS_NEWREGITEM,
     0, NULL,
     CLSID_ControlPanel,
+    L"::{20D04FE0-3AEA-1069-A2D8-08002B30309D}\\::{21EC2020-3AEA-1069-A2DD-08002B30309D}",
     L"ControlPanel",
 };
 
@@ -638,7 +639,6 @@ HRESULT WINAPI CControlPanelFolder::Initialize(PCIDLIST_ABSOLUTE pidl)
     HRESULT hr;
     hr = CRegFolder_CreateInstance(&RegInit,
                                    pidlRoot,
-                                   L"::{20D04FE0-3AEA-1069-A2D8-08002B30309D}\\::{21EC2020-3AEA-1069-A2DD-08002B30309D}",
                                    IID_PPV_ARG(IShellFolder2, &m_regFolder));
     if (FAILED_UNEXPECTEDLY(hr))
         return hr;

--- a/dll/win32/shell32/folders/CControlPanelFolder.cpp
+++ b/dll/win32/shell32/folders/CControlPanelFolder.cpp
@@ -23,7 +23,8 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(shell);
 
-static const REGFOLDERINFO g_RegFolderInfo = {
+static const REGFOLDERINFO g_RegFolderInfo =
+{
     PT_CONTROLS_NEWREGITEM,
     0, NULL,
     CLSID_ControlPanel,

--- a/dll/win32/shell32/folders/CDesktopFolder.cpp
+++ b/dll/win32/shell32/folders/CDesktopFolder.cpp
@@ -265,7 +265,7 @@ class CDesktopFolderEnum :
                 ILFree(pidl);
         }
 
-        HRESULT WINAPI Initialize(IShellFolder *pRegFolder, DWORD dwFlags, IEnumIDList *pRegEnumerator,
+        HRESULT WINAPI Initialize(IShellFolder *pRegFolder, SHCONTF dwFlags, IEnumIDList *pRegEnumerator,
                                   IEnumIDList *pDesktopEnumerator, IEnumIDList *pCommonDesktopEnumerator)
         {
             BOOL ret = TRUE;
@@ -283,7 +283,7 @@ class CDesktopFolderEnum :
                 if (IsNamespaceExtensionHidden(MyDocumentsClassString) < 1)
                     AddToEnumList(_ILCreateMyDocuments());
                 if (IsNamespaceExtensionHidden(InternetClassString) < 1)
-                    TryAddRegItemToEnumList(pRegFolder, _ILCreateIExplore(), (SHCONTF)dwFlags);
+                    TryAddRegItemToEnumList(pRegFolder, _ILCreateIExplore(), dwFlags);
 
                 DWORD dwFetched;
                 while((S_OK == pRegEnumerator->Next(1, &pidl, &dwFetched)) && dwFetched)
@@ -645,7 +645,7 @@ HRESULT WINAPI CDesktopFolder::EnumObjects(HWND hwndOwner, DWORD dwFlags, LPENUM
     if (FAILED(hr))
         ERR("EnumObjects for shared desktop fs folder failed\n");
 
-    return ShellObjectCreatorInit<CDesktopFolderEnum>(m_regFolder, dwFlags,pRegEnumerator, pDesktopEnumerator,
+    return ShellObjectCreatorInit<CDesktopFolderEnum>(m_regFolder, dwFlags, pRegEnumerator, pDesktopEnumerator,
                                                       pCommonDesktopEnumerator, IID_PPV_ARG(IEnumIDList, ppEnumIDList));
 }
 

--- a/dll/win32/shell32/folders/CDesktopFolder.cpp
+++ b/dll/win32/shell32/folders/CDesktopFolder.cpp
@@ -652,7 +652,7 @@ HRESULT WINAPI CDesktopFolder::CreateViewObject(
         CComPtr<CDesktopFolderViewCB> sfviewcb;
         if (SUCCEEDED(hr = ShellObjectCreator(sfviewcb)))
         {
-            SFV_CREATE create = { sizeof(SFV_CREATE), this, NULL, sfviewcb };
+            SFV_CREATE create = { sizeof(create), this, NULL, sfviewcb };
             hr = SHCreateShellFolderView(&create, (IShellView**)ppvOut);
             if (SUCCEEDED(hr))
                 sfviewcb->Initialize((IShellView*)*ppvOut);
@@ -1046,7 +1046,7 @@ bool CDesktopFolderViewCB::IsProgmanHostedBrowser()
     enum { Uninitialized = 0, NotHosted, IsHosted };
     C_ASSERT(Uninitialized == 0);
     if (m_IsProgmanHosted == Uninitialized)
-        m_IsProgmanHosted = m_ShellView && IsProgmanHostedBrowser(m_ShellView) ? IsHosted : NotHosted;
+        m_IsProgmanHosted = m_pShellView && IsProgmanHostedBrowser(m_pShellView) ? IsHosted : NotHosted;
     return m_IsProgmanHosted == IsHosted;
 }
 
@@ -1067,7 +1067,7 @@ HRESULT WINAPI CDesktopFolderViewCB::MessageSFVCB(UINT uMsg, WPARAM wParam, LPAR
     switch (uMsg)
     {
         case SFVM_VIEWRELEASE:
-            m_ShellView = NULL;
+            m_pShellView = NULL;
             return S_OK;
     }
     return E_NOTIMPL;

--- a/dll/win32/shell32/folders/CDesktopFolder.cpp
+++ b/dll/win32/shell32/folders/CDesktopFolder.cpp
@@ -1044,9 +1044,11 @@ bool CDesktopFolderViewCB::IsProgmanHostedBrowser(IShellView *psv)
 
 bool CDesktopFolderViewCB::IsProgmanHostedBrowser()
 {
-    if (!m_IsProgmanHosted)
-        m_IsProgmanHosted = 1 + (m_ShellView && IsProgmanHostedBrowser(m_ShellView));
-    return !!(m_IsProgmanHosted - 1);
+    enum { Uninitialized = 0, NotHosted, IsHosted };
+    C_ASSERT(Uninitialized == 0);
+    if (m_IsProgmanHosted == Uninitialized)
+        m_IsProgmanHosted = m_ShellView && IsProgmanHostedBrowser(m_ShellView) ? IsHosted : NotHosted;
+    return m_IsProgmanHosted == IsHosted;
 }
 
 HRESULT WINAPI CDesktopFolderViewCB::ShouldShow(IShellFolder *psf, PCIDLIST_ABSOLUTE pidlFolder, PCUITEMID_CHILD pidlItem)

--- a/dll/win32/shell32/folders/CDesktopFolder.cpp
+++ b/dll/win32/shell32/folders/CDesktopFolder.cpp
@@ -649,14 +649,13 @@ HRESULT WINAPI CDesktopFolder::CreateViewObject(
     }
     else if (IsEqualIID (riid, IID_IShellView))
     {
-        CComPtr<IShellFolderViewCB> sfviewcb;
-        hr = ShellObjectCreator<CDesktopFolderViewCB>(IID_PPV_ARG(IShellFolderViewCB, &sfviewcb));
-        if (SUCCEEDED(hr))
+        CComPtr<CDesktopFolderViewCB> sfviewcb;
+        if (SUCCEEDED(hr = ShellObjectCreator(sfviewcb)))
         {
-            SFV_CREATE sfvparams = { sizeof(SFV_CREATE), this, NULL, sfviewcb };
-            hr = SHCreateShellFolderView(&sfvparams, (IShellView**)ppvOut);
+            SFV_CREATE create = { sizeof(SFV_CREATE), this, NULL, sfviewcb };
+            hr = SHCreateShellFolderView(&create, (IShellView**)ppvOut);
             if (SUCCEEDED(hr))
-                static_cast<CDesktopFolderViewCB*>(sfviewcb.p)->Initialize((IShellView*)*ppvOut);
+                sfviewcb->Initialize((IShellView*)*ppvOut);
         }
     }
     TRACE ("-- (%p)->(interface=%p)\n", this, ppvOut);

--- a/dll/win32/shell32/folders/CDesktopFolder.cpp
+++ b/dll/win32/shell32/folders/CDesktopFolder.cpp
@@ -25,16 +25,18 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(shell);
 
-static const REQUIREDREGITEM g_RequiredItems[] = 
+static const REQUIREDREGITEM g_RequiredItems[] =
 {
     { CLSID_MyComputer, "sysdm.cpl", 0x50 },
     { CLSID_NetworkPlaces, "ncpa.cpl", 0x58 },
     { CLSID_Internet, "inetcpl.cpl", 0x68 },
 };
-static const REGFOLDERINFO g_RegFolderInfo = {
+static const REGFOLDERINFO g_RegFolderInfo =
+{
     PT_DESKTOP_REGITEM,
     _countof(g_RequiredItems), g_RequiredItems,
     CLSID_ShellDesktop,
+    L"",
     L"Desktop",
 };
 
@@ -263,7 +265,7 @@ class CDesktopFolderEnum :
                 ILFree(pidl);
         }
 
-        HRESULT WINAPI Initialize(IShellFolder *pRegFolder, DWORD dwFlags,IEnumIDList * pRegEnumerator,
+        HRESULT WINAPI Initialize(IShellFolder *pRegFolder, DWORD dwFlags, IEnumIDList *pRegEnumerator,
                                   IEnumIDList *pDesktopEnumerator, IEnumIDList *pCommonDesktopEnumerator)
         {
             BOOL ret = TRUE;
@@ -363,7 +365,6 @@ HRESULT WINAPI CDesktopFolder::FinalConstruct()
     REGFOLDERINITDATA RegInit = { static_cast<IShellFolder*>(this), &g_RegFolderInfo };
     hr = CRegFolder_CreateInstance(&RegInit,
                                    pidlRoot,
-                                   L"",
                                    IID_PPV_ARG(IShellFolder2, &m_regFolder));
     if (FAILED_UNEXPECTEDLY(hr))
         return hr;

--- a/dll/win32/shell32/folders/CDesktopFolder.h
+++ b/dll/win32/shell32/folders/CDesktopFolder.h
@@ -150,11 +150,12 @@ class CDesktopFolderViewCB :
     public IShellFolderViewCB,
     public IFolderFilter
 {
-        CComPtr<IShellView> m_ShellView;
+        IShellView *m_pShellView; // Not ref-counted!
         UINT8 m_IsProgmanHosted;
+
     public:
         CDesktopFolderViewCB() : m_IsProgmanHosted(0) {}
-        void Initialize(IShellView *psv) { m_ShellView = psv; }
+        void Initialize(IShellView *psv) { m_pShellView = psv; }
         static bool IsProgmanHostedBrowser(IShellView *psv);
         bool IsProgmanHostedBrowser();
 

--- a/dll/win32/shell32/folders/CDesktopFolder.h
+++ b/dll/win32/shell32/folders/CDesktopFolder.h
@@ -145,4 +145,32 @@ class CDesktopFolder :
         END_COM_MAP()
 };
 
+class CDesktopFolderViewCB :
+    public CComObjectRootEx<CComMultiThreadModelNoCS>,
+    public IShellFolderViewCB,
+    public IFolderFilter
+{
+        CComPtr<IShellView> m_ShellView;
+        UINT8 m_IsProgmanHosted;
+    public:
+        CDesktopFolderViewCB() : m_IsProgmanHosted(0) {}
+        void Initialize(IShellView *psv) { m_ShellView = psv; }
+        static bool IsProgmanHostedBrowser(IShellView *psv);
+        bool IsProgmanHostedBrowser();
+
+        // IShellFolderViewCB
+        STDMETHOD(MessageSFVCB)(UINT uMsg, WPARAM wParam, LPARAM lParam) override;
+
+        // IFolderFilter
+        STDMETHOD(ShouldShow)(IShellFolder *psf, PCIDLIST_ABSOLUTE pidlFolder, PCUITEMID_CHILD pidlItem) override;
+        STDMETHODIMP GetEnumFlags(IShellFolder*, PCIDLIST_ABSOLUTE, HWND*, DWORD*) override { return E_NOTIMPL; }
+
+        DECLARE_NO_REGISTRY()
+        DECLARE_NOT_AGGREGATABLE(CDesktopFolderViewCB)
+        BEGIN_COM_MAP(CDesktopFolderViewCB)
+        COM_INTERFACE_ENTRY_IID(IID_IShellFolderViewCB, IShellFolderViewCB)
+        COM_INTERFACE_ENTRY_IID(IID_IFolderFilter, IFolderFilter)
+        END_COM_MAP()
+};
+
 #endif /* _CDESKTOPFOLDER_H_ */

--- a/dll/win32/shell32/folders/CDrivesFolder.cpp
+++ b/dll/win32/shell32/folders/CDrivesFolder.cpp
@@ -953,9 +953,13 @@ HRESULT WINAPI CDrivesFolder::GetAttributesOf(UINT cidl, PCUITEMID_CHILD_ARRAY a
                 *rgfInOut &= dwControlPanelAttributes;
             }
             else if (_ILIsSpecialFolder(*apidl))
+            {
                 m_regFolder->GetAttributesOf(1, &apidl[i], rgfInOut);
+            }
             else
+            {
                 ERR("Got unknown pidl type!\n");
+            }
         }
     }
 

--- a/dll/win32/shell32/folders/CDrivesFolder.cpp
+++ b/dll/win32/shell32/folders/CDrivesFolder.cpp
@@ -55,14 +55,16 @@ static int iDriveTypeIds[7] = { IDS_DRIVE_FIXED,       /* DRIVE_UNKNOWN */
                                 IDS_DRIVE_FIXED        /* DRIVE_RAMDISK*/
                                 };
 
-static const REQUIREDREGITEM g_RequiredItems[] = 
+static const REQUIREDREGITEM g_RequiredItems[] =
 {
     { CLSID_ControlPanel, 0, 0x50 },
 };
-static const REGFOLDERINFO g_RegFolderInfo = {
+static const REGFOLDERINFO g_RegFolderInfo =
+{
     PT_COMPUTER_REGITEM,
     _countof(g_RequiredItems), g_RequiredItems,
     CLSID_MyComputer,
+    L"::{20D04FE0-3AEA-1069-A2D8-08002B30309D}",
     L"MyComputer",
 };
 
@@ -657,7 +659,6 @@ HRESULT WINAPI CDrivesFolder::FinalConstruct()
     REGFOLDERINITDATA RegInit = { static_cast<IShellFolder*>(this), &g_RegFolderInfo };
     HRESULT hr = CRegFolder_CreateInstance(&RegInit,
                                            pidlRoot,
-                                           L"::{20D04FE0-3AEA-1069-A2D8-08002B30309D}",
                                            IID_PPV_ARG(IShellFolder2, &m_regFolder));
 
     return hr;

--- a/dll/win32/shell32/folders/CDrivesFolder.cpp
+++ b/dll/win32/shell32/folders/CDrivesFolder.cpp
@@ -68,6 +68,16 @@ static const REGFOLDERINFO g_RegFolderInfo =
     L"MyComputer",
 };
 
+static const CLSID* IsRegItem(PCUITEMID_CHILD pidl)
+{
+    if (pidl && pidl->mkid.cb == 2 + 2 + sizeof(CLSID))
+    {
+        if (pidl->mkid.abID[0] == PT_SHELLEXT || pidl->mkid.abID[0] == PT_GUID) // FIXME: Remove PT_GUID when CRegFolder is fixed
+            return (const CLSID*)(&pidl->mkid.abID[2]);
+    }
+    return NULL;
+}
+
 BOOL _ILGetDriveType(LPCITEMIDLIST pidl)
 {
     WCHAR szDrive[8];
@@ -77,6 +87,16 @@ BOOL _ILGetDriveType(LPCITEMIDLIST pidl)
         return DRIVE_UNKNOWN;
     }
     return ::GetDriveTypeW(szDrive);
+}
+
+BOOL SHELL32_IsShellFolderNamespaceItemHidden(LPCWSTR SubKey, REFCLSID Clsid)
+{
+    // If this function returns true, the item should be hidden in DefView but not in the Explorer folder tree.
+    WCHAR path[MAX_PATH], name[CHARS_IN_GUID];
+    wsprintfW(path, L"%s\\%s", REGSTR_PATH_EXPLORER, SubKey);
+    SHELL32_GUIDToStringW(Clsid, name);
+    DWORD data = 0, size = sizeof(data);
+    return !RegGetValueW(HKEY_CURRENT_USER, path, name, RRF_RT_DWORD, NULL, &data, &size) && data;
 }
 
 /***********************************************************************
@@ -913,7 +933,7 @@ HRESULT WINAPI CDrivesFolder::CreateViewObject(HWND hwndOwner, REFIID riid, LPVO
     }
     else if (IsEqualIID(riid, IID_IShellView))
     {
-            SFV_CREATE sfvparams = {sizeof(SFV_CREATE), this};
+            SFV_CREATE sfvparams = { sizeof(SFV_CREATE), this, NULL, static_cast<IShellFolderViewCB*>(this) };
             hr = SHCreateShellFolderView(&sfvparams, (IShellView**)ppvOut);
     }
     TRACE("-- (%p)->(interface=%p)\n", this, ppvOut);
@@ -1317,6 +1337,16 @@ HRESULT WINAPI CDrivesFolder::GetCurFolder(PIDLIST_ABSOLUTE *pidl)
         return E_INVALIDARG; /* xp doesn't have this check and crashes on NULL */
 
     *pidl = ILClone(pidlRoot);
+    return S_OK;
+}
+
+/**************************************************************************
+ *    CDrivesFolder::ShouldShow
+ */
+HRESULT WINAPI CDrivesFolder::ShouldShow(IShellFolder *psf, PCIDLIST_ABSOLUTE pidlFolder, PCUITEMID_CHILD pidlItem)
+{
+    if (const CLSID* pClsid = IsRegItem(pidlItem))
+        return SHELL32_IsShellFolderNamespaceItemHidden(L"HideMyComputerIcons", *pClsid) ? S_FALSE : S_OK;
     return S_OK;
 }
 

--- a/dll/win32/shell32/folders/CDrivesFolder.h
+++ b/dll/win32/shell32/folders/CDrivesFolder.h
@@ -28,7 +28,9 @@ class CDrivesFolder :
     public CComObjectRootEx<CComMultiThreadModelNoCS>,
     public IShellFolder2,
     public IPersistFolder2,
-    public IContextMenuCB
+    public IContextMenuCB,
+    public IShellFolderViewCB, // Only exists so DefView can get IFolderFilter
+    public IFolderFilter
 {
     private:
         /* both paths are parsible from the desktop */
@@ -73,6 +75,13 @@ class CDrivesFolder :
         // IContextMenuCB
         STDMETHOD(CallBack)(IShellFolder *psf, HWND hwndOwner, IDataObject *pdtobj, UINT uMsg, WPARAM wParam, LPARAM lParam) override;
 
+        // IShellFolderViewCB
+        STDMETHODIMP MessageSFVCB(UINT uMsg, WPARAM wParam, LPARAM lParam) override { return E_NOTIMPL; }
+
+        // IFolderFilter
+        STDMETHOD(ShouldShow)(IShellFolder *psf, PCIDLIST_ABSOLUTE pidlFolder, PCUITEMID_CHILD pidlItem) override;
+        STDMETHODIMP GetEnumFlags(IShellFolder*, PCIDLIST_ABSOLUTE, HWND*, DWORD*) override { return E_NOTIMPL; }
+
         DECLARE_REGISTRY_RESOURCEID(IDR_MYCOMPUTER)
         DECLARE_CENTRAL_INSTANCE_NOT_AGGREGATABLE(CDrivesFolder)
 
@@ -85,6 +94,8 @@ class CDrivesFolder :
         COM_INTERFACE_ENTRY_IID(IID_IPersistFolder2, IPersistFolder2)
         COM_INTERFACE_ENTRY_IID(IID_IPersist, IPersist)
         COM_INTERFACE_ENTRY_IID(IID_IContextMenuCB, IContextMenuCB)
+        COM_INTERFACE_ENTRY_IID(IID_IShellFolderViewCB, IShellFolderViewCB)
+        COM_INTERFACE_ENTRY_IID(IID_IFolderFilter, IFolderFilter)
         END_COM_MAP()
 };
 

--- a/dll/win32/shell32/folders/CFSFolder.cpp
+++ b/dll/win32/shell32/folders/CFSFolder.cpp
@@ -599,16 +599,14 @@ HRESULT SHELL32_GetFSItemAttributes(IShellFolder * psf, LPCITEMIDLIST pidl, LPDW
     if (SFGAO_VALIDATE & *pdwAttributes)
     {
         STRRET strret;
-        if (SUCCEEDED(psf->GetDisplayNameOf(pidl, SHGDN_FORPARSING, &strret)))
+        LPWSTR path;
+        if (SUCCEEDED(psf->GetDisplayNameOf(pidl, SHGDN_FORPARSING, &strret)) &&
+            SUCCEEDED(StrRetToStrW(&strret, pidl, &path)))
         {
-            LPWSTR path;
-            if (SUCCEEDED(StrRetToStrW(&strret, pidl, &path)))
-            {
-                BOOL exists = PathFileExistsW(path);
-                SHFree(path);
-                if (!exists)
-                    return E_FAIL;
-            }
+            BOOL exists = PathFileExistsW(path);
+            SHFree(path);
+            if (!exists)
+                return E_FAIL;
         }
     }
 
@@ -619,7 +617,8 @@ HRESULT SHELL32_GetFSItemAttributes(IShellFolder * psf, LPCITEMIDLIST pidl, LPDW
         LPWSTR pExtension;
         BOOL hasName = _ILSimpleGetTextW(pidl, szFileName, _countof(szFileName));
 
-        // Hidden files with a leading tilde treated as super-hidden (devblogs.microsoft.com/oldnewthing/20170526-00/?p=96235#)
+        // Vista+ feature: Hidden files with a leading tilde treated as super-hidden
+        // See https://devblogs.microsoft.com/oldnewthing/20170526-00/?p=96235
         if (hasName && szFileName[0] == '~' && (dwFileAttributes & FILE_ATTRIBUTE_HIDDEN))
             dwShellAttributes |= SFGAO_HIDDEN | SFGAO_SYSTEM;
 

--- a/dll/win32/shell32/folders/CRegFolder.cpp
+++ b/dll/win32/shell32/folders/CRegFolder.cpp
@@ -86,7 +86,8 @@ static bool HasCLSIDShellFolderValue(REFCLSID clsid, LPCWSTR Value)
     return SHELL_QueryCLSIDValue(clsid, L"ShellFolder", Value, NULL, NULL) == ERROR_SUCCESS;
 }
 
-struct CRegFolderInfo {
+struct CRegFolderInfo
+{
     const REGFOLDERINFO *m_pInfo;
 
     void InitializeFolderInfo(const REGFOLDERINFO *pInfo)
@@ -234,7 +235,7 @@ HRESULT CRegFolderEnum::Initialize(const REGFOLDERINFO *pInfo, IShellFolder *pSF
         return S_OK;
 
     WCHAR KeyName[MAX_PATH];
-    HRESULT hr = StringCchPrintfW(KeyName, MAX_PATH,
+    HRESULT hr = StringCchPrintfW(KeyName, _countof(KeyName),
                                   L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\%s\\Namespace",
                                   pInfo->pszEnumKeyName);
     if (FAILED_UNEXPECTEDLY(hr))

--- a/dll/win32/shell32/folders/CRegFolder.cpp
+++ b/dll/win32/shell32/folders/CRegFolder.cpp
@@ -40,7 +40,7 @@ HRESULT FormatGUIDKey(LPWSTR KeyName, SIZE_T KeySize, LPCWSTR RegPath, const GUI
     return StringCchPrintfW(KeyName, KeySize, RegPath, xriid);
 }
 
-static DWORD SHELL_QueryCLSIDValue(REFCLSID clsid, LPCWSTR SubKey, LPCWSTR Value, void *pData, DWORD *pSize)
+static DWORD SHELL_QueryCLSIDValue(_In_ REFCLSID clsid, _In_opt_ LPCWSTR SubKey, _In_opt_ LPCWSTR Value, _In_opt_ PVOID pData, _In_opt_ PDWORD pSize)
 {
     WCHAR Path[MAX_PATH];
     wcscpy(Path, L"CLSID\\");
@@ -262,10 +262,10 @@ class CRegFolder :
         HRESULT WINAPI Initialize(PREGFOLDERINITDATA pInit, LPCITEMIDLIST pidlRoot);
 
         inline LPCWSTR GetParsingPath() const { return m_pInfo->pszParsingPath; }
-        inline UINT GetCLSIDOffset() { return GetRegItemCLSIDOffset(m_pInfo->PidlType); }
-        const CLSID* IsRegItem(LPCITEMIDLIST pidl)
+        inline UINT GetCLSIDOffset() const { return GetRegItemCLSIDOffset(m_pInfo->PidlType); }
+        const CLSID* IsRegItem(LPCITEMIDLIST pidl) const
         {
-            if (pidl && pidl->mkid.cb >= 4 + sizeof(GUID))
+            if (pidl && pidl->mkid.cb >= sizeof(WORD) + 1 + 1 + sizeof(GUID))
             {
                 if (pidl->mkid.abID[0] == m_pInfo->PidlType)
                     return (CLSID*)(SIZE_T(pidl) + GetCLSIDOffset());
@@ -275,11 +275,11 @@ class CRegFolder :
             if (const IID* pIID = _ILGetGUIDPointer(pidl))
             {
                 FIXME("Unexpected GUID PIDL type %#x\n", pidl->mkid.abID[0]);
-                return pIID;
+                return pIID; // FIXME: Remove this when all folders have been fixed
             }
             return NULL;
         }
-        const REQUIREDREGITEM* IsRequiredItem(LPCITEMIDLIST pidl)
+        const REQUIREDREGITEM* IsRequiredItem(LPCITEMIDLIST pidl) const
         {
             const CLSID* const pCLSID = IsRegItem(pidl);
             for (UINT i = 0; pCLSID && i < m_pInfo->Count; ++i)

--- a/dll/win32/shell32/shelldesktop/CDesktopBrowser.cpp
+++ b/dll/win32/shell32/shelldesktop/CDesktopBrowser.cpp
@@ -226,8 +226,7 @@ HRESULT CDesktopBrowser::Initialize(IShellDesktopTray *ShellDesk)
     if (!m_hWnd)
         return E_FAIL;
 
-    CSFV csfv = {sizeof(CSFV), psfDesktop};
-    hRet = SHCreateShellFolderViewEx(&csfv, &m_ShellView);
+    hRet = psfDesktop->CreateViewObject(m_hWnd, IID_PPV_ARG(IShellView, &m_ShellView));
     if (FAILED_UNEXPECTEDLY(hRet))
         return hRet;
 

--- a/dll/win32/shell32/shfldr.h
+++ b/dll/win32/shell32/shfldr.h
@@ -48,26 +48,30 @@ https://learn.microsoft.com/en-us/windows/win32/api/shobjidl_core/nf-shobjidl_co
 #define SHFSF_COL_COMMENT       5
 
 #define MAXREQUIREDREGITEMS 3
-typedef struct {
+typedef struct _REQUIREDREGITEM
+{
     REFCLSID clsid;
     LPCSTR pszCpl;
     BYTE Order; // According to Geoff Chappell, required items have a fixed sort order
 } REQUIREDREGITEM;
 
-typedef struct {
+typedef struct _REGFOLDERINFO
+{
     PIDLTYPE PidlType;
     BYTE Count; // Count of required items
     const REQUIREDREGITEM *Items;
     REFCLSID clsid;
+    LPCWSTR pszParsingPath;
     LPCWSTR pszEnumKeyName;
 } REGFOLDERINFO;
 
-typedef struct {
+typedef struct _REGFOLDERINITDATA
+{
     IShellFolder *psfOuter;
     const REGFOLDERINFO *pInfo;
-} REGFOLDERINITDATA, *LPREGFOLDERINITDATA;
+} REGFOLDERINITDATA, *PREGFOLDERINITDATA;
 
-HRESULT CRegFolder_CreateInstance(LPREGFOLDERINITDATA pInit, LPCITEMIDLIST pidlRoot, LPCWSTR lpszPath, REFIID riid, void **ppv);
+HRESULT CRegFolder_CreateInstance(PREGFOLDERINITDATA pInit, LPCITEMIDLIST pidlRoot, REFIID riid, void **ppv);
 
 #define GET_SHGDN_FOR(dwFlags)         ((DWORD)dwFlags & (DWORD)0x0000FF00)
 #define GET_SHGDN_RELATION(dwFlags)    ((DWORD)dwFlags & (DWORD)0x000000FF)

--- a/dll/win32/shell32/shfldr.h
+++ b/dll/win32/shell32/shfldr.h
@@ -47,7 +47,6 @@ https://learn.microsoft.com/en-us/windows/win32/api/shobjidl_core/nf-shobjidl_co
 #define SHFSF_COL_FATTS         4 // File attributes
 #define SHFSF_COL_COMMENT       5
 
-#define MAXREQUIREDREGITEMS 3
 typedef struct _REQUIREDREGITEM
 {
     REFCLSID clsid;

--- a/dll/win32/shell32/shfldr.h
+++ b/dll/win32/shell32/shfldr.h
@@ -47,10 +47,49 @@ https://learn.microsoft.com/en-us/windows/win32/api/shobjidl_core/nf-shobjidl_co
 #define SHFSF_COL_FATTS         4 // File attributes
 #define SHFSF_COL_COMMENT       5
 
+#define MAXREQUIREDREGITEMS 3
+typedef struct {
+    REFCLSID clsid;
+    LPCSTR pszCpl;
+    BYTE Order; // According to Geoff Chappell, required items have a fixed sort order
+} REQUIREDREGITEM;
+
+typedef struct {
+    PIDLTYPE PidlType;
+    BYTE Count; // Count of required items
+    const REQUIREDREGITEM *Items;
+    REFCLSID clsid;
+    LPCWSTR pszEnumKeyName;
+} REGFOLDERINFO;
+
+typedef struct {
+    IShellFolder *psfOuter;
+    const REGFOLDERINFO *pInfo;
+} REGFOLDERINITDATA, *LPREGFOLDERINITDATA;
+
+HRESULT CRegFolder_CreateInstance(LPREGFOLDERINITDATA pInit, LPCITEMIDLIST pidlRoot, LPCWSTR lpszPath, REFIID riid, void **ppv);
+
 #define GET_SHGDN_FOR(dwFlags)         ((DWORD)dwFlags & (DWORD)0x0000FF00)
 #define GET_SHGDN_RELATION(dwFlags)    ((DWORD)dwFlags & (DWORD)0x000000FF)
 #define IS_SHGDN_FOR_PARSING(flags) ( ((flags) & (SHGDN_FORADDRESSBAR | SHGDN_FORPARSING)) == SHGDN_FORPARSING)
 #define IS_SHGDN_DESKTOPABSOLUTEPARSING(flags) ( ((flags) & (SHGDN_FORADDRESSBAR | SHGDN_FORPARSING | 0xFF)) == SHGDN_FORPARSING)
+
+static inline SFGAOF 
+SHELL_CreateFolderEnumItemAttributeQuery(SHCONTF Flags, BOOL ForRegItem)
+{
+    SFGAOF query = SFGAO_FOLDER | (ForRegItem ? SFGAO_NONENUMERATED : 0);
+    if (!(Flags & SHCONTF_INCLUDEHIDDEN))
+        query |= SFGAO_HIDDEN;
+    if (!(Flags & SHCONTF_INCLUDESUPERHIDDEN))
+        query |= SFGAO_HIDDEN | SFGAO_SYSTEM;
+    return query;
+}
+
+SHCONTF
+SHELL_GetDefaultFolderEnumSHCONTF();
+
+BOOL
+SHELL_IncludeItemInFolderEnum(IShellFolder *pSF, PCUITEMID_CHILD pidl, SFGAOF Query, SHCONTF Flags);
 
 HRESULT
 Shell_NextElement(

--- a/dll/win32/shell32/shlfolder.cpp
+++ b/dll/win32/shell32/shlfolder.cpp
@@ -28,14 +28,14 @@ WINE_DEFAULT_DEBUG_CHANNEL(shell);
 
 SHCONTF SHELL_GetDefaultFolderEnumSHCONTF()
 {
-    DWORD Flags = SHCONTF_FOLDERS | SHCONTF_NONFOLDERS;
+    SHCONTF Flags = SHCONTF_FOLDERS | SHCONTF_NONFOLDERS;
     SHELLSTATE ss;
     SHGetSetSettings(&ss, SSF_SHOWALLOBJECTS | SSF_SHOWSUPERHIDDEN, FALSE);
     if (ss.fShowAllObjects)
         Flags |= SHCONTF_INCLUDEHIDDEN;
     if (ss.fShowSuperHidden)
         Flags |= SHCONTF_INCLUDESUPERHIDDEN;
-     return (SHCONTF)Flags;
+     return Flags;
 }
 
 BOOL SHELL_IncludeItemInFolderEnum(IShellFolder *pSF, PCUITEMID_CHILD pidl, SFGAOF Query, SHCONTF Flags)

--- a/dll/win32/shell32/shlfolder.cpp
+++ b/dll/win32/shell32/shlfolder.cpp
@@ -26,6 +26,34 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(shell);
 
+SHCONTF SHELL_GetDefaultFolderEnumSHCONTF()
+{
+    DWORD Flags = SHCONTF_FOLDERS | SHCONTF_NONFOLDERS;
+    SHELLSTATE ss;
+    SHGetSetSettings(&ss, SSF_SHOWALLOBJECTS | SSF_SHOWSUPERHIDDEN, FALSE);
+    if (ss.fShowAllObjects)
+        Flags |= SHCONTF_INCLUDEHIDDEN;
+    if (ss.fShowSuperHidden)
+        Flags |= SHCONTF_INCLUDESUPERHIDDEN;
+     return (SHCONTF)Flags;
+}
+
+BOOL SHELL_IncludeItemInFolderEnum(IShellFolder *pSF, PCUITEMID_CHILD pidl, SFGAOF Query, SHCONTF Flags)
+{
+    if (SUCCEEDED(pSF->GetAttributesOf(1, &pidl, &Query)))
+    {
+        if (Query & SFGAO_NONENUMERATED)
+            return FALSE;
+        if ((Query & SFGAO_HIDDEN) && !(Flags & SHCONTF_INCLUDEHIDDEN))
+            return FALSE;
+        if ((Query & (SFGAO_HIDDEN | SFGAO_SYSTEM)) == (SFGAO_HIDDEN | SFGAO_SYSTEM) && !(Flags & SHCONTF_INCLUDESUPERHIDDEN))
+            return FALSE;
+        if ((Flags & (SHCONTF_FOLDERS | SHCONTF_NONFOLDERS)) != (SHCONTF_FOLDERS | SHCONTF_NONFOLDERS))
+            return (Flags & SHCONTF_FOLDERS) ? (Query & SFGAO_FOLDER) : !(Query & SFGAO_FOLDER);
+    }
+    return TRUE;
+}
+
 HRESULT
 Shell_NextElement(
     _Inout_ LPWSTR *ppch,

--- a/dll/win32/shell32/wine/pidl.c
+++ b/dll/win32/shell32/wine/pidl.c
@@ -1767,7 +1767,6 @@ LPITEMIDLIST _ILCreateGuidFromStrA(LPCSTR szGUID)
     }
     return _ILCreateGuid(PT_GUID, &iid);
 }
-#endif
 
 LPITEMIDLIST _ILCreateGuidFromStrW(LPCWSTR szGUID)
 {
@@ -1784,6 +1783,7 @@ LPITEMIDLIST _ILCreateGuidFromStrW(LPCWSTR szGUID)
     }
     return _ILCreateGuid(PT_GUID, &iid);
 }
+#endif /* __REACTOS__ */
 
 LPITEMIDLIST _ILCreateFromFindDataW( const WIN32_FIND_DATAW *wfd )
 {

--- a/dll/win32/shell32/wine/pidl.h
+++ b/dll/win32/shell32/wine/pidl.h
@@ -111,7 +111,7 @@ extern "C" {
 #define PT_FS_FOLDER_FLAG       0x01
 #define PT_FS_FILE_FLAG         0x02
 #define PT_FS_UNICODE_FLAG      0x04
-//define PT_NET_REGITEM         0x4? // => SHDID_NET_OTHER
+//      PT_NET_REGITEM          0x4? // => SHDID_NET_OTHER
 #define PT_CONTROLS_OLDREGITEM  0x70
 #define PT_CONTROLS_NEWREGITEM  0x71
 #endif
@@ -275,9 +275,11 @@ BOOL    _ILIsEmpty              (LPCITEMIDLIST pidl) { return _ILIsDesktop(pidl)
  */
 LPITEMIDLIST	_ILCreateGuid(PIDLTYPE type, REFIID guid) DECLSPEC_HIDDEN;
 
+#ifndef __REACTOS__
 /* Like _ILCreateGuid, but using the string szGUID. */
 LPITEMIDLIST	_ILCreateGuidFromStrA(LPCSTR szGUID) DECLSPEC_HIDDEN;
 LPITEMIDLIST	_ILCreateGuidFromStrW(LPCWSTR szGUID) DECLSPEC_HIDDEN;
+#endif
 
 /* Commonly used PIDLs representing file system objects. */
 LPITEMIDLIST	_ILCreateDesktop	(void) DECLSPEC_HIDDEN;

--- a/dll/win32/shell32/wine/pidl.h
+++ b/dll/win32/shell32/wine/pidl.h
@@ -104,6 +104,18 @@ extern "C" {
 #define PT_IESPECIAL2	0xb1
 #define PT_SHARE	0xc3
 
+#ifdef __REACTOS__
+#define PT_DESKTOP_REGITEM      0x1F // => SHDID_ROOT_REGITEM
+#define PT_COMPUTER_REGITEM     0x2E // => SHDID_COMPUTER_OTHER
+#define PT_FS                   0x30 // Win95 SHSimpleIDListFromPath
+#define PT_FS_FOLDER_FLAG       0x01
+#define PT_FS_FILE_FLAG         0x02
+#define PT_FS_UNICODE_FLAG      0x04
+//define PT_NET_REGITEM         0x4? // => SHDID_NET_OTHER
+#define PT_CONTROLS_OLDREGITEM  0x70
+#define PT_CONTROLS_NEWREGITEM  0x71
+#endif
+
 #include "pshpack1.h"
 typedef BYTE PIDLTYPE;
 

--- a/dll/win32/shell32/wine/shell32_main.h
+++ b/dll/win32/shell32/wine/shell32_main.h
@@ -90,10 +90,6 @@ HRESULT WINAPI IFileSystemBindData_Constructor(const WIN32_FIND_DATAW *pfd, LPBC
 HRESULT WINAPI CPanel_ExtractIconA(LPITEMIDLIST pidl, LPCSTR pszFile, UINT nIconIndex, HICON *phiconLarge, HICON *phiconSmall, UINT nIconSize) DECLSPEC_HIDDEN;
 HRESULT WINAPI CPanel_ExtractIconW(LPITEMIDLIST pidl, LPCWSTR pszFile, UINT nIconIndex, HICON *phiconLarge, HICON *phiconSmall, UINT nIconSize) DECLSPEC_HIDDEN;
 
-#ifndef __REACTOS__
-HRESULT CRegFolder_CreateInstance(const GUID *pGuid, LPCITEMIDLIST pidlRoot, LPCWSTR lpszPath, LPCWSTR lpszEnumKeyName, REFIID riid, void **ppv);
-#endif
-
 /* initialisation for FORMATETC */
 #define InitFormatEtc(fe, cf, med) \
 	{\

--- a/dll/win32/shell32/wine/shell32_main.h
+++ b/dll/win32/shell32/wine/shell32_main.h
@@ -90,7 +90,9 @@ HRESULT WINAPI IFileSystemBindData_Constructor(const WIN32_FIND_DATAW *pfd, LPBC
 HRESULT WINAPI CPanel_ExtractIconA(LPITEMIDLIST pidl, LPCSTR pszFile, UINT nIconIndex, HICON *phiconLarge, HICON *phiconSmall, UINT nIconSize) DECLSPEC_HIDDEN;
 HRESULT WINAPI CPanel_ExtractIconW(LPITEMIDLIST pidl, LPCWSTR pszFile, UINT nIconIndex, HICON *phiconLarge, HICON *phiconSmall, UINT nIconSize) DECLSPEC_HIDDEN;
 
+#ifndef __REACTOS__
 HRESULT CRegFolder_CreateInstance(const GUID *pGuid, LPCITEMIDLIST pidlRoot, LPCWSTR lpszPath, LPCWSTR lpszEnumKeyName, REFIID riid, void **ppv);
+#endif
 
 /* initialisation for FORMATETC */
 #define InitFormatEtc(fe, cf, med) \

--- a/sdk/include/psdk/shobjidl.idl
+++ b/sdk/include/psdk/shobjidl.idl
@@ -195,6 +195,7 @@ interface IShellFolder : IUnknown
     cpp_quote("#define SFGAO_HASPROPSHEET      0x00000040L")
     cpp_quote("#define SFGAO_DROPTARGET        0x00000100L")
     cpp_quote("#define SFGAO_CAPABILITYMASK    0x00000177L")
+    cpp_quote("#define SFGAO_SYSTEM            0x00001000L")
     cpp_quote("#define SFGAO_ENCRYPTED         0x00002000L")
     cpp_quote("#define SFGAO_ISSLOW            0x00004000L")
     cpp_quote("#define SFGAO_GHOSTED           0x00008000L")

--- a/sdk/include/psdk/shobjidl.idl
+++ b/sdk/include/psdk/shobjidl.idl
@@ -1487,6 +1487,38 @@ interface ICommDlgBrowser3 : ICommDlgBrowser2
 }
 
 /*****************************************************************************
+ * IFolderFilterSite & IFolderFilter interfaces
+ */
+[
+    object,
+    uuid(C0A651F5-B48B-11d2-B5ED-006097C686F6),
+    pointer_default(unique)
+]
+interface IFolderFilterSite : IUnknown
+{
+    HRESULT SetFilter([in] IUnknown* punk);
+}
+
+[
+    object,
+    uuid(9CC22886-DC8E-11d2-B1D0-00C04F8EEB3E),
+    pointer_default(unique)
+]
+interface IFolderFilter : IUnknown
+{
+    HRESULT ShouldShow(
+        [in] IShellFolder* psf,
+        [in, unique] PCIDLIST_ABSOLUTE pidlFolder,
+        [in] PCUITEMID_CHILD pidlItem);
+
+    HRESULT GetEnumFlags(
+        [in] IShellFolder* psf,
+        [in] PCIDLIST_ABSOLUTE pidlFolder,
+        [out] HWND *phwnd,
+        [in, out] DWORD *pgrfFlags);
+}
+
+/*****************************************************************************
  * IDockingWindow interface
  */
 [

--- a/sdk/include/reactos/shellutils.h
+++ b/sdk/include/reactos/shellutils.h
@@ -298,7 +298,7 @@ HRESULT inline ShellObjectCreator(CComPtr<T> &objref)
 {
     _CComObject<T> *pobj;
     HRESULT hResult = _CComObject<T>::CreateInstance(&pobj);
-    objref = pobj; // AddRef()
+    objref = pobj; // AddRef() gets called here
     if (FAILED(hResult))
         return hResult;
     return S_OK;

--- a/sdk/include/reactos/shellutils.h
+++ b/sdk/include/reactos/shellutils.h
@@ -294,6 +294,17 @@ HRESULT inline ShellDebugObjectCreator(REFIID riid, R ** ppv)
 }
 
 template<class T>
+HRESULT inline ShellObjectCreator(CComPtr<T> &objref)
+{
+    _CComObject<T> *pobj;
+    HRESULT hResult = _CComObject<T>::CreateInstance(&pobj);
+    objref = pobj; // AddRef()
+    if (FAILED(hResult))
+        return hResult;
+    return S_OK;
+}
+
+template<class T>
 HRESULT inline ShellObjectCreator(REFIID riid, void ** ppv)
 {
     _CComObject<T> *pobj;


### PR DESCRIPTION
This partially implements RegFolder required items [as described by Geoff Chappell](https://www.geoffchappell.com/studies/windows/shell/shell32/classes/regfolder.htm).

Fixes JIRA issues CORE-14060, CORE-14061, [CORE-19176](https://jira.reactos.org/browse/CORE-19176) and also fixes the Internet properties menu item.

Notes:
- There is a ton of code in the shell that assumes RegFolder PIDLs all have the same size and that its pidl types are interchangeable. This is not true (the types are per folder and the Control Panel items are larger). This PR starts to untangle this mess but leaves the old behavior intact (for now).
- `REGFOLDERINITDATA` is used as a non-const extra step to pass in the outer folder instance. It is known that the Windows RegFolder implementation uses COM aggregation instead of the hacks ROS is using and can probably pass the constant data directly.
- I'm not sure why RegItems and FileSystem items seem to handle `SFGAO_NONENUMERATED` differently on Windows. I believe `SFGAO_NONENUMERATED` is used to hide RegItems when they are deleted by the user ([HideAsDeletePerUser/HideAsDelete](https://learn.microsoft.com/en-us/windows/win32/shell/nse-implement#registering-an-extension)).

Only DefView on the Desktop and in MyComputer is supposed to filter away the GUIDs in the "HideXyzIcons" registry keys, they must remain visible everywhere else where **folders** are enumerated:

![screenshot](https://github.com/user-attachments/assets/baa56495-e419-4ed6-b2e1-784b4e9607d8)