### PR TITLE
[CALC] de-DE: add menu-accels, *.rc: Portu, CTRL->Ctrl, STRG->Strg

### DIFF
--- a/base/applications/calc/lang/bg-BG.rc
+++ b/base/applications/calc/lang/bg-BG.rc
@@ -315,8 +315,8 @@ IDR_MENU_SCIENTIFIC_1 MENU
 BEGIN
     POPUP "&Обработка"
     BEGIN
-        MENUITEM "Запомняне\tCTRL-C", IDM_EDIT_COPY
-        MENUITEM "Поставяне\tCTRL-V", IDM_EDIT_PASTE
+        MENUITEM "Запомняне\tCtrl-C", IDM_EDIT_COPY
+        MENUITEM "Поставяне\tCtrl-V", IDM_EDIT_PASTE
     END
     POPUP "Изглед"
     BEGIN
@@ -347,8 +347,8 @@ IDR_MENU_SCIENTIFIC_2 MENU
 BEGIN
     POPUP "&Обработка"
     BEGIN
-        MENUITEM "Запомняне\tCTRL-C", IDM_EDIT_COPY
-        MENUITEM "Поставяне\tCTRL-V", IDM_EDIT_PASTE
+        MENUITEM "Запомняне\tCtrl-C", IDM_EDIT_COPY
+        MENUITEM "Поставяне\tCtrl-V", IDM_EDIT_PASTE
     END
     POPUP "Изглед"
     BEGIN
@@ -380,8 +380,8 @@ IDR_MENU_STANDARD MENU
 BEGIN
     POPUP "&Обработка"
     BEGIN
-        MENUITEM "Запомняне\tCTRL-C", IDM_EDIT_COPY
-        MENUITEM "Поставяне\tCTRL-V", IDM_EDIT_PASTE
+        MENUITEM "Запомняне\tCtrl-C", IDM_EDIT_COPY
+        MENUITEM "Поставяне\tCtrl-V", IDM_EDIT_PASTE
     END
     POPUP "Изглед"
     BEGIN

--- a/base/applications/calc/lang/cs-CZ.rc
+++ b/base/applications/calc/lang/cs-CZ.rc
@@ -314,8 +314,8 @@ IDR_MENU_SCIENTIFIC_1 MENU
 BEGIN
     POPUP "Úpravy"
     BEGIN
-        MENUITEM "Kopírovat\tCTRL-C", IDM_EDIT_COPY
-        MENUITEM "Vložit\tCTRL-V", IDM_EDIT_PASTE
+        MENUITEM "Kopírovat\tCtrl-C", IDM_EDIT_COPY
+        MENUITEM "Vložit\tCtrl-V", IDM_EDIT_PASTE
     END
     POPUP "Zobrazit"
     BEGIN
@@ -346,8 +346,8 @@ IDR_MENU_SCIENTIFIC_2 MENU
 BEGIN
     POPUP "Úpravy"
     BEGIN
-        MENUITEM "Kopírovat\tCTRL-C", IDM_EDIT_COPY
-        MENUITEM "Vložit\tCTRL-V", IDM_EDIT_PASTE
+        MENUITEM "Kopírovat\tCtrl-C", IDM_EDIT_COPY
+        MENUITEM "Vložit\tCtrl-V", IDM_EDIT_PASTE
     END
     POPUP "Zobrazit"
     BEGIN
@@ -379,8 +379,8 @@ IDR_MENU_STANDARD MENU
 BEGIN
     POPUP "Úpravy"
     BEGIN
-        MENUITEM "Kopírovat\tCTRL-C", IDM_EDIT_COPY
-        MENUITEM "Vložit\tCTRL-V", IDM_EDIT_PASTE
+        MENUITEM "Kopírovat\tCtrl-C", IDM_EDIT_COPY
+        MENUITEM "Vložit\tCtrl-V", IDM_EDIT_PASTE
     END
     POPUP "Zobrazit"
     BEGIN

--- a/base/applications/calc/lang/de-DE.rc
+++ b/base/applications/calc/lang/de-DE.rc
@@ -307,89 +307,89 @@ END
 
 IDR_MENU_SCIENTIFIC_1 MENU
 BEGIN
-    POPUP "Bearbeiten"
+    POPUP "&Bearbeiten"
     BEGIN
-        MENUITEM "Kopieren\tSTRG-C", IDM_EDIT_COPY
-        MENUITEM "Einfügen\tSTRG-V", IDM_EDIT_PASTE
+        MENUITEM "&Kopieren\tStrg-C", IDM_EDIT_COPY
+        MENUITEM "&Einfügen\tStrg-V", IDM_EDIT_PASTE
     END
-    POPUP "Ansicht"
+    POPUP "&Ansicht"
     BEGIN
-        MENUITEM "Standard", IDM_VIEW_STANDARD
-        MENUITEM "Wissenschaftlich", IDM_VIEW_SCIENTIFIC
-        MENUITEM "Konversion", IDM_VIEW_CONVERSION
+        MENUITEM "&Standard", IDM_VIEW_STANDARD
+        MENUITEM "&Wissenschaftlich", IDM_VIEW_SCIENTIFIC
+        MENUITEM "&Konversion", IDM_VIEW_CONVERSION
         MENUITEM SEPARATOR
-        MENUITEM "Hex\tF5", IDM_VIEW_HEX, CHECKED
-        MENUITEM "Dezimal\tF6", IDM_VIEW_DEC, CHECKED
-        MENUITEM "Oktal\tF7", IDM_VIEW_OCT, CHECKED
-        MENUITEM "Binär\tF8", IDM_VIEW_BIN, CHECKED
+        MENUITEM "&Hex\tF5", IDM_VIEW_HEX, CHECKED
+        MENUITEM "De&zimal\tF6", IDM_VIEW_DEC, CHECKED
+        MENUITEM "O&ktal\tF7", IDM_VIEW_OCT, CHECKED
+        MENUITEM "&Binär\tF8", IDM_VIEW_BIN, CHECKED
         MENUITEM SEPARATOR
-        MENUITEM "Degree\tF2", IDM_VIEW_DEG, CHECKED
-        MENUITEM "Radiant\tF3", IDM_VIEW_RAD, CHECKED
-        MENUITEM "Grad\tF4", IDM_VIEW_GRAD, CHECKED
+        MENUITEM "&Deg\tF2", IDM_VIEW_DEG, CHECKED
+        MENUITEM "&Rad\tF3", IDM_VIEW_RAD, CHECKED
+        MENUITEM "&Grad\tF4", IDM_VIEW_GRAD, CHECKED
         MENUITEM SEPARATOR
-        MENUITEM "Zifferngruppierung", IDM_VIEW_GROUP, CHECKED
+        MENUITEM "Zifferngr&uppierung", IDM_VIEW_GROUP, CHECKED
     END
-    POPUP "Hilfe"
+    POPUP "&?"
     BEGIN
-        MENUITEM "Hilfethemen", IDM_HELP_HELP
+        MENUITEM "&Hilfethemen", IDM_HELP_HELP
         MENUITEM SEPARATOR
-        MENUITEM "Info", IDM_HELP_ABOUT
+        MENUITEM "&Info", IDM_HELP_ABOUT
     END
 END
 
 IDR_MENU_SCIENTIFIC_2 MENU
 BEGIN
-    POPUP "Bearbeiten"
+    POPUP "&Bearbeiten"
     BEGIN
-        MENUITEM "Kopieren\tSTRG-C", IDM_EDIT_COPY
-        MENUITEM "Einfügen\tSTRG-V", IDM_EDIT_PASTE
+        MENUITEM "&Kopieren\tStrg-C", IDM_EDIT_COPY
+        MENUITEM "&Einfügen\tStrg-V", IDM_EDIT_PASTE
     END
-    POPUP "Ansicht"
+    POPUP "&Ansicht"
     BEGIN
-        MENUITEM "Standard", IDM_VIEW_STANDARD
-        MENUITEM "Wissenschaftlich", IDM_VIEW_SCIENTIFIC
-        MENUITEM "Konversion", IDM_VIEW_CONVERSION
+        MENUITEM "&Standard", IDM_VIEW_STANDARD
+        MENUITEM "&Wissenschaftlich", IDM_VIEW_SCIENTIFIC
+        MENUITEM "&Konversion", IDM_VIEW_CONVERSION
         MENUITEM SEPARATOR
-        MENUITEM "Hex\tF5", IDM_VIEW_HEX, CHECKED
-        MENUITEM "Dezimal\tF6", IDM_VIEW_DEC, CHECKED
-        MENUITEM "Oktal\tF7", IDM_VIEW_OCT, CHECKED
-        MENUITEM "Binär\tF8", IDM_VIEW_BIN, CHECKED
+        MENUITEM "&Hex\tF5", IDM_VIEW_HEX, CHECKED
+        MENUITEM "&Dezimal\tF6", IDM_VIEW_DEC, CHECKED
+        MENUITEM "O&ktal\tF7", IDM_VIEW_OCT, CHECKED
+        MENUITEM "Bi&när\tF8", IDM_VIEW_BIN, CHECKED
         MENUITEM SEPARATOR
-        MENUITEM "Qword\tF12", IDM_VIEW_QWORD, CHECKED
-        MENUITEM "Dword\tF2", IDM_VIEW_DWORD, CHECKED
-        MENUITEM "Word\tF3", IDM_VIEW_WORD, CHECKED
-        MENUITEM "Byte\tF4", IDM_VIEW_BYTE, CHECKED
+        MENUITEM "&Qword\tF12", IDM_VIEW_QWORD, CHECKED
+        MENUITEM "Dw&ord\tF2", IDM_VIEW_DWORD, CHECKED
+        MENUITEM "Wo&rd\tF3", IDM_VIEW_WORD, CHECKED
+        MENUITEM "&Byte\tF4", IDM_VIEW_BYTE, CHECKED
         MENUITEM SEPARATOR
-        MENUITEM "Zifferngruppierung", IDM_VIEW_GROUP, CHECKED
+        MENUITEM "Zifferngr&uppierung", IDM_VIEW_GROUP, CHECKED
     END
-    POPUP "Hilfe"
+    POPUP "&?"
     BEGIN
-        MENUITEM "Hilfethemen", IDM_HELP_HELP
+        MENUITEM "&Hilfethemen", IDM_HELP_HELP
         MENUITEM SEPARATOR
-        MENUITEM "Über ReactOS Rechner", IDM_HELP_ABOUT
+        MENUITEM "&Info", IDM_HELP_ABOUT
     END
 END
 
 IDR_MENU_STANDARD MENU
 BEGIN
-    POPUP "Bearbeiten"
+    POPUP "&Bearbeiten"
     BEGIN
-        MENUITEM "Kopieren\tSTRG-C", IDM_EDIT_COPY
-        MENUITEM "Einfügen\tSTRG-V", IDM_EDIT_PASTE
+        MENUITEM "&Kopieren\tStrg-C", IDM_EDIT_COPY
+        MENUITEM "&Einfügen\tStrg-V", IDM_EDIT_PASTE
     END
-    POPUP "Ansicht"
+    POPUP "&Ansicht"
     BEGIN
-        MENUITEM "Standard", IDM_VIEW_STANDARD
-        MENUITEM "Wissenschaftlich", IDM_VIEW_SCIENTIFIC
-        MENUITEM "Konversion", IDM_VIEW_CONVERSION
+        MENUITEM "&Standard", IDM_VIEW_STANDARD
+        MENUITEM "&Wissenschaftlich", IDM_VIEW_SCIENTIFIC
+        MENUITEM "&Konversion", IDM_VIEW_CONVERSION
         MENUITEM SEPARATOR
-        MENUITEM "Zifferngruppierung", IDM_VIEW_GROUP, CHECKED
+        MENUITEM "Zifferngr&uppierung", IDM_VIEW_GROUP, CHECKED
     END
-    POPUP "Hilfe"
+    POPUP "&?"
     BEGIN
-        MENUITEM "Hilfethemen", IDM_HELP_HELP
+        MENUITEM "&Hilfethemen", IDM_HELP_HELP
         MENUITEM SEPARATOR
-        MENUITEM "Über ReactOS Rechner", IDM_HELP_ABOUT
+        MENUITEM "&Info", IDM_HELP_ABOUT
     END
 END
 

--- a/base/applications/calc/lang/de-DE.rc
+++ b/base/applications/calc/lang/de-DE.rc
@@ -316,7 +316,7 @@ BEGIN
     BEGIN
         MENUITEM "&Standard", IDM_VIEW_STANDARD
         MENUITEM "&Wissenschaftlich", IDM_VIEW_SCIENTIFIC
-        MENUITEM "&Konversion", IDM_VIEW_CONVERSION
+        MENUITEM "Kon&version", IDM_VIEW_CONVERSION
         MENUITEM SEPARATOR
         MENUITEM "&Hex\tF5", IDM_VIEW_HEX, CHECKED
         MENUITEM "De&zimal\tF6", IDM_VIEW_DEC, CHECKED
@@ -348,7 +348,7 @@ BEGIN
     BEGIN
         MENUITEM "&Standard", IDM_VIEW_STANDARD
         MENUITEM "&Wissenschaftlich", IDM_VIEW_SCIENTIFIC
-        MENUITEM "&Konversion", IDM_VIEW_CONVERSION
+        MENUITEM "Kon&version", IDM_VIEW_CONVERSION
         MENUITEM SEPARATOR
         MENUITEM "&Hex\tF5", IDM_VIEW_HEX, CHECKED
         MENUITEM "&Dezimal\tF6", IDM_VIEW_DEC, CHECKED
@@ -381,7 +381,7 @@ BEGIN
     BEGIN
         MENUITEM "&Standard", IDM_VIEW_STANDARD
         MENUITEM "&Wissenschaftlich", IDM_VIEW_SCIENTIFIC
-        MENUITEM "&Konversion", IDM_VIEW_CONVERSION
+        MENUITEM "Kon&version", IDM_VIEW_CONVERSION
         MENUITEM SEPARATOR
         MENUITEM "Zifferngr&uppierung", IDM_VIEW_GROUP, CHECKED
     END

--- a/base/applications/calc/lang/el-GR.rc
+++ b/base/applications/calc/lang/el-GR.rc
@@ -309,8 +309,8 @@ IDR_MENU_SCIENTIFIC_1 MENU
 BEGIN
     POPUP "Επεξεργασία"
     BEGIN
-        MENUITEM "Αντιγραφή\tCTRL-C", IDM_EDIT_COPY
-        MENUITEM "Επικόλληση\tCTRL-V", IDM_EDIT_PASTE
+        MENUITEM "Αντιγραφή\tCtrl-C", IDM_EDIT_COPY
+        MENUITEM "Επικόλληση\tCtrl-V", IDM_EDIT_PASTE
     END
     POPUP "View"
     BEGIN
@@ -341,8 +341,8 @@ IDR_MENU_SCIENTIFIC_2 MENU
 BEGIN
     POPUP "Επεξεργασία"
     BEGIN
-        MENUITEM "Αντιγραφή\tCTRL-C", IDM_EDIT_COPY
-        MENUITEM "Επικόλληση\tCTRL-V", IDM_EDIT_PASTE
+        MENUITEM "Αντιγραφή\tCtrl-C", IDM_EDIT_COPY
+        MENUITEM "Επικόλληση\tCtrl-V", IDM_EDIT_PASTE
     END
     POPUP "View"
     BEGIN
@@ -374,8 +374,8 @@ IDR_MENU_STANDARD MENU
 BEGIN
     POPUP "Επεξεργασία"
     BEGIN
-        MENUITEM "Αντιγραφή\tCTRL-C", IDM_EDIT_COPY
-        MENUITEM "Επικόλληση\tCTRL-V", IDM_EDIT_PASTE
+        MENUITEM "Αντιγραφή\tCtrl-C", IDM_EDIT_COPY
+        MENUITEM "Επικόλληση\tCtrl-V", IDM_EDIT_PASTE
     END
     POPUP "View"
     BEGIN

--- a/base/applications/calc/lang/es-ES.rc
+++ b/base/applications/calc/lang/es-ES.rc
@@ -315,8 +315,8 @@ IDR_MENU_SCIENTIFIC_1 MENU
 BEGIN
     POPUP "Edición"
     BEGIN
-        MENUITEM "Copiar\tCTRL-C", IDM_EDIT_COPY
-        MENUITEM "Pegar\tCTRL-V", IDM_EDIT_PASTE
+        MENUITEM "Copiar\tCtrl-C", IDM_EDIT_COPY
+        MENUITEM "Pegar\tCtrl-V", IDM_EDIT_PASTE
     END
     POPUP "Ver"
     BEGIN
@@ -347,8 +347,8 @@ IDR_MENU_SCIENTIFIC_2 MENU
 BEGIN
     POPUP "Edición"
     BEGIN
-        MENUITEM "Copiar\tCTRL-C", IDM_EDIT_COPY
-        MENUITEM "Pegar\tCTRL-V", IDM_EDIT_PASTE
+        MENUITEM "Copiar\tCtrl-C", IDM_EDIT_COPY
+        MENUITEM "Pegar\tCtrl-V", IDM_EDIT_PASTE
     END
     POPUP "Ver"
     BEGIN
@@ -380,8 +380,8 @@ IDR_MENU_STANDARD MENU
 BEGIN
     POPUP "Edición"
     BEGIN
-        MENUITEM "Copiar\tCTRL-C", IDM_EDIT_COPY
-        MENUITEM "Pegar\tCTRL-V", IDM_EDIT_PASTE
+        MENUITEM "Copiar\tCtrl-C", IDM_EDIT_COPY
+        MENUITEM "Pegar\tCtrl-V", IDM_EDIT_PASTE
     END
     POPUP "Ver"
     BEGIN

--- a/base/applications/calc/lang/fr-FR.rc
+++ b/base/applications/calc/lang/fr-FR.rc
@@ -309,8 +309,8 @@ IDR_MENU_SCIENTIFIC_1 MENU
 BEGIN
     POPUP "Édition"
     BEGIN
-        MENUITEM "Copier\tCTRL-C", IDM_EDIT_COPY
-        MENUITEM "Coller\tCTRL-V", IDM_EDIT_PASTE
+        MENUITEM "Copier\tCtrl-C", IDM_EDIT_COPY
+        MENUITEM "Coller\tCtrl-V", IDM_EDIT_PASTE
     END
     POPUP "Affichage"
     BEGIN
@@ -341,8 +341,8 @@ IDR_MENU_SCIENTIFIC_2 MENU
 BEGIN
     POPUP "Édition"
     BEGIN
-        MENUITEM "Copier\tCTRL-C", IDM_EDIT_COPY
-        MENUITEM "Coller\tCTRL-V", IDM_EDIT_PASTE
+        MENUITEM "Copier\tCtrl-C", IDM_EDIT_COPY
+        MENUITEM "Coller\tCtrl-V", IDM_EDIT_PASTE
     END
     POPUP "Affichage"
     BEGIN
@@ -374,8 +374,8 @@ IDR_MENU_STANDARD MENU
 BEGIN
     POPUP "Édition"
     BEGIN
-        MENUITEM "Copier\tCTRL-C", IDM_EDIT_COPY
-        MENUITEM "Coller\tCTRL-V", IDM_EDIT_PASTE
+        MENUITEM "Copier\tCtrl-C", IDM_EDIT_COPY
+        MENUITEM "Coller\tCtrl-V", IDM_EDIT_PASTE
     END
     POPUP "Affichage"
     BEGIN

--- a/base/applications/calc/lang/it-IT.rc
+++ b/base/applications/calc/lang/it-IT.rc
@@ -309,8 +309,8 @@ IDR_MENU_SCIENTIFIC_1 MENU
 BEGIN
     POPUP "Modifica"
     BEGIN
-        MENUITEM "Copia\tCTRL-C", IDM_EDIT_COPY
-        MENUITEM "Incolla\tCTRL-V", IDM_EDIT_PASTE
+        MENUITEM "Copia\tCtrl-C", IDM_EDIT_COPY
+        MENUITEM "Incolla\tCtrl-V", IDM_EDIT_PASTE
     END
     POPUP "Visualizza"
     BEGIN
@@ -341,8 +341,8 @@ IDR_MENU_SCIENTIFIC_2 MENU
 BEGIN
     POPUP "Modifica"
     BEGIN
-        MENUITEM "Copia\tCTRL-C", IDM_EDIT_COPY
-        MENUITEM "Incolla\tCTRL-V", IDM_EDIT_PASTE
+        MENUITEM "Copia\tCtrl-C", IDM_EDIT_COPY
+        MENUITEM "Incolla\tCtrl-V", IDM_EDIT_PASTE
     END
     POPUP "Visualizza"
     BEGIN
@@ -374,8 +374,8 @@ IDR_MENU_STANDARD MENU
 BEGIN
     POPUP "Modifica"
     BEGIN
-        MENUITEM "Copia\tCTRL-C", IDM_EDIT_COPY
-        MENUITEM "Incolla\tCTRL-V", IDM_EDIT_PASTE
+        MENUITEM "Copia\tCtrl-C", IDM_EDIT_COPY
+        MENUITEM "Incolla\tCtrl-V", IDM_EDIT_PASTE
     END
     POPUP "Visualizza"
     BEGIN

--- a/base/applications/calc/lang/ko-KR.rc
+++ b/base/applications/calc/lang/ko-KR.rc
@@ -311,8 +311,8 @@ IDR_MENU_SCIENTIFIC_1 MENU
 BEGIN
     POPUP "편집"
     BEGIN
-        MENUITEM "복사\tCTRL-C", IDM_EDIT_COPY
-        MENUITEM "붙여넣기\tCTRL-V", IDM_EDIT_PASTE
+        MENUITEM "복사\tCtrl-C", IDM_EDIT_COPY
+        MENUITEM "붙여넣기\tCtrl-V", IDM_EDIT_PASTE
     END
     POPUP "보기"
     BEGIN
@@ -343,8 +343,8 @@ IDR_MENU_SCIENTIFIC_2 MENU
 BEGIN
     POPUP "편집"
     BEGIN
-        MENUITEM "복사\tCTRL-C", IDM_EDIT_COPY
-        MENUITEM "붙여넣기\tCTRL-V", IDM_EDIT_PASTE
+        MENUITEM "복사\tCtrl-C", IDM_EDIT_COPY
+        MENUITEM "붙여넣기\tCtrl-V", IDM_EDIT_PASTE
     END
     POPUP "보기"
     BEGIN
@@ -376,8 +376,8 @@ IDR_MENU_STANDARD MENU
 BEGIN
     POPUP "편집"
     BEGIN
-        MENUITEM "복사\tCTRL-C", IDM_EDIT_COPY
-        MENUITEM "붙여넣기\tCTRL-V", IDM_EDIT_PASTE
+        MENUITEM "복사\tCtrl-C", IDM_EDIT_COPY
+        MENUITEM "붙여넣기\tCtrl-V", IDM_EDIT_PASTE
     END
     POPUP "보기"
     BEGIN
@@ -506,7 +506,7 @@ BEGIN
     IDS_CURRENCY_LITHUANIAN_LITAS "Lithuanian litas"
     IDS_CURRENCY_LUXEMBOURG_FRANC "Luxembourg franc"
     IDS_CURRENCY_MALTESE_LIRA "Maltese lira"
-    IDS_CURRENCY_PORTOGUESE_ESCUDO "Portoguese escudo"
+    IDS_CURRENCY_PORTOGUESE_ESCUDO "Portuguese escudo"
     IDS_CURRENCY_SLOVAK_KORUNA "Slovak koruna"
     IDS_CURRENCY_SLOVENIAN_TOLAR "Slovenian tolar"
     IDS_CURRENCY_SPANISH_PESETA "Spanish peseta"

--- a/base/applications/calc/lang/nl-NL.rc
+++ b/base/applications/calc/lang/nl-NL.rc
@@ -309,8 +309,8 @@ IDR_MENU_SCIENTIFIC_1 MENU
 BEGIN
     POPUP "Bewerken"
     BEGIN
-        MENUITEM "Kopiëren\tCTRL-C", IDM_EDIT_COPY
-        MENUITEM "Plakken\tCTRL-V", IDM_EDIT_PASTE
+        MENUITEM "Kopiëren\tCtrl-C", IDM_EDIT_COPY
+        MENUITEM "Plakken\tCtrl-V", IDM_EDIT_PASTE
     END
     POPUP "Beeld"
     BEGIN
@@ -341,8 +341,8 @@ IDR_MENU_SCIENTIFIC_2 MENU
 BEGIN
     POPUP "Edit"
     BEGIN
-        MENUITEM "Kopiëren\tCTRL-C", IDM_EDIT_COPY
-        MENUITEM "Plakken\tCTRL-V", IDM_EDIT_PASTE
+        MENUITEM "Kopiëren\tCtrl-C", IDM_EDIT_COPY
+        MENUITEM "Plakken\tCtrl-V", IDM_EDIT_PASTE
     END
     POPUP "Beeld"
     BEGIN
@@ -374,8 +374,8 @@ IDR_MENU_STANDARD MENU
 BEGIN
     POPUP "Edit"
     BEGIN
-        MENUITEM "Kopiëren\tCTRL-C", IDM_EDIT_COPY
-        MENUITEM "Plakken\tCTRL-V", IDM_EDIT_PASTE
+        MENUITEM "Kopiëren\tCtrl-C", IDM_EDIT_COPY
+        MENUITEM "Plakken\tCtrl-V", IDM_EDIT_PASTE
     END
     POPUP "View"
     BEGIN

--- a/base/applications/calc/lang/no-NO.rc
+++ b/base/applications/calc/lang/no-NO.rc
@@ -309,8 +309,8 @@ IDR_MENU_SCIENTIFIC_1 MENU
 BEGIN
     POPUP "Rediger"
     BEGIN
-        MENUITEM "Kopier\tCTRL-C", IDM_EDIT_COPY
-        MENUITEM "Lim inn\tCTRL-V", IDM_EDIT_PASTE
+        MENUITEM "Kopier\tCtrl-C", IDM_EDIT_COPY
+        MENUITEM "Lim inn\tCtrl-V", IDM_EDIT_PASTE
     END
     POPUP "Vis"
     BEGIN
@@ -341,8 +341,8 @@ IDR_MENU_SCIENTIFIC_2 MENU
 BEGIN
     POPUP "Rediger"
     BEGIN
-        MENUITEM "Kopier\tCTRL-C", IDM_EDIT_COPY
-        MENUITEM "Lim inn\tCTRL-V", IDM_EDIT_PASTE
+        MENUITEM "Kopier\tCtrl-C", IDM_EDIT_COPY
+        MENUITEM "Lim inn\tCtrl-V", IDM_EDIT_PASTE
     END
     POPUP "Vis"
     BEGIN
@@ -374,8 +374,8 @@ IDR_MENU_STANDARD MENU
 BEGIN
     POPUP "Rediger"
     BEGIN
-        MENUITEM "Kopier\tCTRL-C", IDM_EDIT_COPY
-        MENUITEM "Lim inn\tCTRL-V", IDM_EDIT_PASTE
+        MENUITEM "Kopier\tCtrl-C", IDM_EDIT_COPY
+        MENUITEM "Lim inn\tCtrl-V", IDM_EDIT_PASTE
     END
     POPUP "Vis"
     BEGIN

--- a/base/applications/calc/lang/pl-PL.rc
+++ b/base/applications/calc/lang/pl-PL.rc
@@ -318,8 +318,8 @@ IDR_MENU_SCIENTIFIC_1 MENU
 BEGIN
     POPUP "Edycja"
     BEGIN
-        MENUITEM "Kopiuj\tCTRL-C", IDM_EDIT_COPY
-        MENUITEM "Wklej\tCTRL-V", IDM_EDIT_PASTE
+        MENUITEM "Kopiuj\tCtrl-C", IDM_EDIT_COPY
+        MENUITEM "Wklej\tCtrl-V", IDM_EDIT_PASTE
     END
     POPUP "Wygląd"
     BEGIN
@@ -350,8 +350,8 @@ IDR_MENU_SCIENTIFIC_2 MENU
 BEGIN
     POPUP "Edycja"
     BEGIN
-        MENUITEM "Kopiuj\tCTRL-C", IDM_EDIT_COPY
-        MENUITEM "Wklej\tCTRL-V", IDM_EDIT_PASTE
+        MENUITEM "Kopiuj\tCtrl-C", IDM_EDIT_COPY
+        MENUITEM "Wklej\tCtrl-V", IDM_EDIT_PASTE
     END
     POPUP "Wygląd"
     BEGIN
@@ -383,8 +383,8 @@ IDR_MENU_STANDARD MENU
 BEGIN
     POPUP "Edycja"
     BEGIN
-        MENUITEM "Kopiuj\tCTRL-C", IDM_EDIT_COPY
-        MENUITEM "Wklej\tCTRL-V", IDM_EDIT_PASTE
+        MENUITEM "Kopiuj\tCtrl-C", IDM_EDIT_COPY
+        MENUITEM "Wklej\tCtrl-V", IDM_EDIT_PASTE
     END
     POPUP "Wygląd"
     BEGIN

--- a/base/applications/calc/lang/ro-RO.rc
+++ b/base/applications/calc/lang/ro-RO.rc
@@ -350,8 +350,8 @@ IDR_MENU_SCIENTIFIC_2 MENU
 BEGIN
     POPUP "&Editare"
     BEGIN
-        MENUITEM "&Copiere\tCTRL-C", IDM_EDIT_COPY
-        MENUITEM "&Lipire\tCTRL-V", IDM_EDIT_PASTE
+        MENUITEM "&Copiere\tCtrl-C", IDM_EDIT_COPY
+        MENUITEM "&Lipire\tCtrl-V", IDM_EDIT_PASTE
     END
     POPUP "&Vizualizare"
     BEGIN
@@ -383,8 +383,8 @@ IDR_MENU_STANDARD MENU
 BEGIN
     POPUP "&Editare"
     BEGIN
-        MENUITEM "&Copiere\tCTRL-C", IDM_EDIT_COPY
-        MENUITEM "&Lipire\tCTRL-V", IDM_EDIT_PASTE
+        MENUITEM "&Copiere\tCtrl-C", IDM_EDIT_COPY
+        MENUITEM "&Lipire\tCtrl-V", IDM_EDIT_PASTE
     END
     POPUP "&Vizualizare"
     BEGIN

--- a/base/applications/calc/lang/ru-RU.rc
+++ b/base/applications/calc/lang/ru-RU.rc
@@ -309,8 +309,8 @@ IDR_MENU_SCIENTIFIC_1 MENU
 BEGIN
     POPUP "&Правка"
     BEGIN
-        MENUITEM "&Копировать\tCTRL-C", IDM_EDIT_COPY
-        MENUITEM "Вст&авить\tCTRL-V", IDM_EDIT_PASTE
+        MENUITEM "&Копировать\tCtrl-C", IDM_EDIT_COPY
+        MENUITEM "Вст&авить\tCtrl-V", IDM_EDIT_PASTE
     END
     POPUP "В&ид"
     BEGIN
@@ -341,8 +341,8 @@ IDR_MENU_SCIENTIFIC_2 MENU
 BEGIN
     POPUP "&Правка"
     BEGIN
-        MENUITEM "&Копировать\tCTRL-C", IDM_EDIT_COPY
-        MENUITEM "Вст&авить\tCTRL-V", IDM_EDIT_PASTE
+        MENUITEM "&Копировать\tCtrl-C", IDM_EDIT_COPY
+        MENUITEM "Вст&авить\tCtrl-V", IDM_EDIT_PASTE
     END
     POPUP "В&ид"
     BEGIN
@@ -374,8 +374,8 @@ IDR_MENU_STANDARD MENU
 BEGIN
     POPUP "&Правка"
     BEGIN
-        MENUITEM "&Копировать\tCTRL-C", IDM_EDIT_COPY
-        MENUITEM "Вст&авить\tCTRL-V", IDM_EDIT_PASTE
+        MENUITEM "&Копировать\tCtrl-C", IDM_EDIT_COPY
+        MENUITEM "Вст&авить\tCtrl-V", IDM_EDIT_PASTE
     END
     POPUP "В&ид"
     BEGIN

--- a/base/applications/calc/lang/sk-SK.rc
+++ b/base/applications/calc/lang/sk-SK.rc
@@ -316,8 +316,8 @@ IDR_MENU_SCIENTIFIC_1 MENU
 BEGIN
     POPUP "Úpravy"
     BEGIN
-        MENUITEM "Kopírovať\tCTRL-C", IDM_EDIT_COPY
-        MENUITEM "Prilepiť\tCTRL-V", IDM_EDIT_PASTE
+        MENUITEM "Kopírovať\tCtrl-C", IDM_EDIT_COPY
+        MENUITEM "Prilepiť\tCtrl-V", IDM_EDIT_PASTE
     END
     POPUP "Zobraziť"
     BEGIN
@@ -348,8 +348,8 @@ IDR_MENU_SCIENTIFIC_2 MENU
 BEGIN
     POPUP "Úpravy"
     BEGIN
-        MENUITEM "Kopírovať\tCTRL-C", IDM_EDIT_COPY
-        MENUITEM "Prilepiť\tCTRL-V", IDM_EDIT_PASTE
+        MENUITEM "Kopírovať\tCtrl-C", IDM_EDIT_COPY
+        MENUITEM "Prilepiť\tCtrl-V", IDM_EDIT_PASTE
     END
     POPUP "Zobraziť"
     BEGIN
@@ -381,8 +381,8 @@ IDR_MENU_STANDARD MENU
 BEGIN
     POPUP "Úpravy"
     BEGIN
-        MENUITEM "Kopírovať\tCTRL-C", IDM_EDIT_COPY
-        MENUITEM "Prilepiť\tCTRL-V", IDM_EDIT_PASTE
+        MENUITEM "Kopírovať\tCtrl-C", IDM_EDIT_COPY
+        MENUITEM "Prilepiť\tCtrl-V", IDM_EDIT_PASTE
     END
     POPUP "Zobraziť"
     BEGIN

--- a/base/applications/calc/lang/sv-SE.rc
+++ b/base/applications/calc/lang/sv-SE.rc
@@ -316,8 +316,8 @@ IDR_MENU_SCIENTIFIC_1 MENU
 BEGIN
     POPUP "Redigera"
     BEGIN
-        MENUITEM "Kopiera\tCTRL-C", IDM_EDIT_COPY
-        MENUITEM "Klistra in\tCTRL-V", IDM_EDIT_PASTE
+        MENUITEM "Kopiera\tCtrl-C", IDM_EDIT_COPY
+        MENUITEM "Klistra in\tCtrl-V", IDM_EDIT_PASTE
     END
     POPUP "Visa"
     BEGIN
@@ -348,8 +348,8 @@ IDR_MENU_SCIENTIFIC_2 MENU
 BEGIN
     POPUP "Redigera"
     BEGIN
-        MENUITEM "Kopiera\tCTRL-C", IDM_EDIT_COPY
-        MENUITEM "Klistra in\tCTRL-V", IDM_EDIT_PASTE
+        MENUITEM "Kopiera\tCtrl-C", IDM_EDIT_COPY
+        MENUITEM "Klistra in\tCtrl-V", IDM_EDIT_PASTE
     END
     POPUP "Vis"
     BEGIN
@@ -381,8 +381,8 @@ IDR_MENU_STANDARD MENU
 BEGIN
     POPUP "Redigera"
     BEGIN
-        MENUITEM "Kopiera\tCTRL-C", IDM_EDIT_COPY
-        MENUITEM "Klistra in\tCTRL-V", IDM_EDIT_PASTE
+        MENUITEM "Kopiera\tCtrl-C", IDM_EDIT_COPY
+        MENUITEM "Klistra in\tCtrl-V", IDM_EDIT_PASTE
     END
     POPUP "Visa"
     BEGIN

--- a/base/applications/calc/lang/th-TH.rc
+++ b/base/applications/calc/lang/th-TH.rc
@@ -309,8 +309,8 @@ IDR_MENU_SCIENTIFIC_1 MENU
 BEGIN
     POPUP "แ&ก้ไข"
     BEGIN
-        MENUITEM "คัดลอก\tCTRL-C", IDM_EDIT_COPY
-        MENUITEM "วาง\tCTRL-V", IDM_EDIT_PASTE
+        MENUITEM "คัดลอก\tCtrl-C", IDM_EDIT_COPY
+        MENUITEM "วาง\tCtrl-V", IDM_EDIT_PASTE
     END
     POPUP "&มุมมอง"
     BEGIN
@@ -341,8 +341,8 @@ IDR_MENU_SCIENTIFIC_2 MENU
 BEGIN
     POPUP "แ&ก้ไข"
     BEGIN
-        MENUITEM "คัดลอก\tCTRL-C", IDM_EDIT_COPY
-        MENUITEM "วาง\tCTRL-V", IDM_EDIT_PASTE
+        MENUITEM "คัดลอก\tCtrl-C", IDM_EDIT_COPY
+        MENUITEM "วาง\tCtrl-V", IDM_EDIT_PASTE
     END
     POPUP "&มุมมอง"
     BEGIN
@@ -374,8 +374,8 @@ IDR_MENU_STANDARD MENU
 BEGIN
     POPUP "แ&ก้ไข"
     BEGIN
-        MENUITEM "คัดลอก\tCTRL-C", IDM_EDIT_COPY
-        MENUITEM "วาง\tCTRL-V", IDM_EDIT_PASTE
+        MENUITEM "คัดลอก\tCtrl-C", IDM_EDIT_COPY
+        MENUITEM "วาง\tCtrl-V", IDM_EDIT_PASTE
     END
     POPUP "&มุมมอง"
     BEGIN
@@ -504,7 +504,7 @@ BEGIN
     IDS_CURRENCY_LITHUANIAN_LITAS "Lithuanian litas"
     IDS_CURRENCY_LUXEMBOURG_FRANC "Luxembourg franc"
     IDS_CURRENCY_MALTESE_LIRA "Maltese lira"
-    IDS_CURRENCY_PORTOGUESE_ESCUDO "Portoguese escudo"
+    IDS_CURRENCY_PORTOGUESE_ESCUDO "Portuguese escudo"
     IDS_CURRENCY_SLOVAK_KORUNA "Slovak koruna"
     IDS_CURRENCY_SLOVENIAN_TOLAR "Slovenian tolar"
     IDS_CURRENCY_SPANISH_PESETA "Spanish peseta"

--- a/base/applications/calc/lang/uk-UA.rc
+++ b/base/applications/calc/lang/uk-UA.rc
@@ -317,8 +317,8 @@ IDR_MENU_SCIENTIFIC_1 MENU
 BEGIN
     POPUP "Правка"
     BEGIN
-        MENUITEM "Копіювати\tCTRL-C", IDM_EDIT_COPY
-        MENUITEM "Вставити\tCTRL-V", IDM_EDIT_PASTE
+        MENUITEM "Копіювати\tCtrl-C", IDM_EDIT_COPY
+        MENUITEM "Вставити\tCtrl-V", IDM_EDIT_PASTE
     END
     POPUP "Вигляд"
     BEGIN
@@ -349,8 +349,8 @@ IDR_MENU_SCIENTIFIC_2 MENU
 BEGIN
     POPUP "Правка"
     BEGIN
-        MENUITEM "Копіювати\tCTRL-C", IDM_EDIT_COPY
-        MENUITEM "Вставити\tCTRL-V", IDM_EDIT_PASTE
+        MENUITEM "Копіювати\tCtrl-C", IDM_EDIT_COPY
+        MENUITEM "Вставити\tCtrl-V", IDM_EDIT_PASTE
     END
     POPUP "Вигляд"
     BEGIN
@@ -382,8 +382,8 @@ IDR_MENU_STANDARD MENU
 BEGIN
     POPUP "Правка"
     BEGIN
-        MENUITEM "Копіювати\tCTRL-C", IDM_EDIT_COPY
-        MENUITEM "Вставити\tCTRL-V", IDM_EDIT_PASTE
+        MENUITEM "Копіювати\tCtrl-C", IDM_EDIT_COPY
+        MENUITEM "Вставити\tCtrl-V", IDM_EDIT_PASTE
     END
     POPUP "Вигляд"
     BEGIN


### PR DESCRIPTION
- de-DE: add accelerators for the menus, inspired by german XPSP3
- *.rc: It is portuguese, not portoguese (this has been fixed in en-US earlier already, but was forgotten to be merged into other languages
- *.rc: CTRL is not used in capital manner by MS, but MS used Ctrl, and MS did not use STRG but Strg for de-DE. Our en-US respected that already, but again stuff was not synced into other languages when it was improved earlier in ros

Therefore this PR has absolutely no changes for en-US because that was good already.

JIRA issue: none
