### PR TITLE
[SDK][NTUSER] s/KLF_UNLOAD/KL_UNLOAD/

### DIFF
--- a/sdk/include/reactos/undocuser.h
+++ b/sdk/include/reactos/undocuser.h
@@ -175,6 +175,10 @@ extern "C" {
 #define SBRG_PAGEDOWNLEFT  4 /* the page down or page left region */
 #define SBRG_BOTTOMLEFTBTN 5 /* the bottom or left button */
 
+// Keyboard Layout undocumented flags
+#define KL_UNLOAD 0x20000000
+#define KL_NOACTIVATENEXT 0x80000000
+
 BOOL WINAPI UpdatePerUserSystemParameters(DWORD dwReserved, BOOL bEnable);
 BOOL WINAPI SetLogonNotifyWindow(HWND Wnd);
 BOOL WINAPI KillSystemTimer(HWND,UINT_PTR);

--- a/sdk/include/reactos/undocuser.h
+++ b/sdk/include/reactos/undocuser.h
@@ -177,7 +177,9 @@ extern "C" {
 
 // Keyboard Layout undocumented flags
 #define KL_UNLOAD 0x20000000
-#define KL_NOACTIVATENEXT 0x80000000
+
+// co_IntUnloadKeyboardLayoutEx undocumented flags
+#define UKL_NOACTIVATENEXT 0x80000000
 
 BOOL WINAPI UpdatePerUserSystemParameters(DWORD dwReserved, BOOL bEnable);
 BOOL WINAPI SetLogonNotifyWindow(HWND Wnd);

--- a/win32ss/user/ntuser/input.h
+++ b/win32ss/user/ntuser/input.h
@@ -47,9 +47,6 @@ typedef struct _ATTACHINFO
 
 extern PATTACHINFO gpai;
 
-/* Keyboard layout undocumented flags */
-#define KLF_UNLOAD 0x20000000
-
 /* Key States */
 #define KS_DOWN_BIT      0x80
 #define KS_LOCK_BIT      0x01

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -32,7 +32,6 @@ typedef PVOID (*PFN_KBDLAYERDESCRIPTOR)(VOID);
 /*
  * Retrieves a PKL by an input locale identifier (HKL).
  * @implemented
- * Win: HKLtoPKL
  */
 PKL FASTCALL IntHKLtoPKL(_Inout_ PTHREADINFO pti, _In_ HKL hKL)
 {
@@ -92,7 +91,6 @@ PKL FASTCALL IntHKLtoPKL(_Inout_ PTHREADINFO pti, _In_ HKL hKL)
 /*
  * A helper function for NtUserGetKeyboardLayoutList.
  * @implemented
- * Win: _GetKeyboardLayoutList
  */
 static UINT APIENTRY
 IntGetKeyboardLayoutList(
@@ -556,7 +554,6 @@ UserHklToKbl(HKL hKl)
     return NULL;
 }
 
-// Win: ReorderKeyboardLayouts
 VOID FASTCALL
 IntReorderKeyboardLayouts(
     _Inout_ PWINSTATION_OBJECT pWinSta,
@@ -813,7 +810,6 @@ co_UserActivateKeyboardLayout(
     return hOldKL;
 }
 
-/* Win: xxxActivateKeyboardLayout */
 HKL APIENTRY
 co_IntActivateKeyboardLayout(
     _Inout_ PWINSTATION_OBJECT pWinSta,
@@ -837,7 +833,6 @@ co_IntActivateKeyboardLayout(
     return co_UserActivateKeyboardLayout(pKL, uFlags, pWnd);
 }
 
-// Win: xxxInternalUnloadKeyboardLayout
 static BOOL APIENTRY
 co_IntUnloadKeyboardLayoutEx(
     _Inout_ PWINSTATION_OBJECT pWinSta,
@@ -885,7 +880,6 @@ co_IntUnloadKeyboardLayoutEx(
     return TRUE;
 }
 
-// Win: xxxUnloadKeyboardLayout
 static BOOL APIENTRY
 IntUnloadKeyboardLayout(_Inout_ PWINSTATION_OBJECT pWinSta, _In_ HKL hKL)
 {

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -50,7 +50,7 @@ PKL FASTCALL IntHKLtoPKL(_Inout_ PTHREADINFO pti, _In_ HKL hKL)
         do
         {
             pKL = pKL->pklNext;
-            if (!(pKL->dwKL_Flags & KLF_UNLOAD))
+            if (!(pKL->dwKL_Flags & KL_UNLOAD))
                 return pKL;
         } while (pKL != pFirstKL);
     }
@@ -59,13 +59,13 @@ PKL FASTCALL IntHKLtoPKL(_Inout_ PTHREADINFO pti, _In_ HKL hKL)
         do
         {
             pKL = pKL->pklPrev;
-            if (!(pKL->dwKL_Flags & KLF_UNLOAD))
+            if (!(pKL->dwKL_Flags & KL_UNLOAD))
                 return pKL;
         } while (pKL != pFirstKL);
     }
     else if (HIWORD(hKL)) /* hKL is a full input locale identifier */
     {
-        /* No KLF_UNLOAD check */
+        /* No KL_UNLOAD check */
         do
         {
             if (pKL->hkl == hKL)
@@ -76,7 +76,7 @@ PKL FASTCALL IntHKLtoPKL(_Inout_ PTHREADINFO pti, _In_ HKL hKL)
     }
     else  /* Language only specified */
     {
-        /* No KLF_UNLOAD check */
+        /* No KL_UNLOAD check */
         do
         {
             if (LOWORD(pKL->hkl) == LOWORD(hKL)) /* Low word is language ID */
@@ -114,7 +114,7 @@ IntGetKeyboardLayoutList(
         /* Count the effective PKLs */
         do
         {
-            if (!(pKL->dwKL_Flags & KLF_UNLOAD))
+            if (!(pKL->dwKL_Flags & KL_UNLOAD))
                 ++ret;
             pKL = pKL->pklNext;
         } while (pKL != pFirstKL);
@@ -124,7 +124,7 @@ IntGetKeyboardLayoutList(
         /* Copy the effective HKLs to pHklBuff */
         do
         {
-            if (!(pKL->dwKL_Flags & KLF_UNLOAD))
+            if (!(pKL->dwKL_Flags & KL_UNLOAD))
             {
                 *pHklBuff = pKL->hkl;
                 ++pHklBuff;
@@ -489,7 +489,7 @@ UserUnloadKbl(PKL pKl)
     if (pKl->head.cLockObj > 1)
     {
         /* Layout is used by other threads */
-        pKl->dwKL_Flags |= KLF_UNLOAD;
+        pKl->dwKL_Flags |= KL_UNLOAD;
         return FALSE;
     }
 
@@ -521,7 +521,7 @@ W32kGetDefaultKeyLayout(VOID)
     /* Return not unloaded layout */
     do
     {
-        if (!(pKl->dwKL_Flags & KLF_UNLOAD))
+        if (!(pKl->dwKL_Flags & KL_UNLOAD))
             return pKl;
 
         pKl = pKl->pklPrev; /* Confirmed on Win2k */
@@ -855,7 +855,7 @@ co_IntUnloadKeyboardLayoutEx(
 
     /* Regard as unloaded */
     UserMarkObjectDestroy(pKL);
-    pKL->dwKL_Flags |= KLF_UNLOAD;
+    pKL->dwKL_Flags |= KL_UNLOAD;
 
     if (!(dwFlags & 0x80000000) && pti->KeyboardLayout == pKL)
     {
@@ -957,7 +957,7 @@ co_IntLoadKeyboardLayoutEx(
         {
             /* Find last not unloaded layout */
             PKL pLastKL = gspklBaseLayout->pklPrev;
-            while (pLastKL != gspklBaseLayout && (pLastKL->dwKL_Flags & KLF_UNLOAD))
+            while (pLastKL != gspklBaseLayout && (pLastKL->dwKL_Flags & KL_UNLOAD))
                 pLastKL = pLastKL->pklPrev;
 
             /* Add new layout to the list */
@@ -978,7 +978,7 @@ co_IntLoadKeyboardLayoutEx(
     }
 
     /* If this layout was prepared to unload, undo it */
-    pNewKL->dwKL_Flags &= ~KLF_UNLOAD;
+    pNewKL->dwKL_Flags &= ~KL_UNLOAD;
 
     /* Reorder if necessary */
     if (Flags & KLF_REORDER)

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -848,7 +848,7 @@ co_IntUnloadKeyboardLayoutEx(
     USER_REFERENCE_ENTRY Ref1, Ref2;
     PTHREADINFO pti = gptiCurrent;
 
-    if (pKL == gspklBaseLayout && !(dwFlags & 0x80000000))
+    if (pKL == gspklBaseLayout && !(dwFlags & KL_NOACTIVATENEXT))
         return FALSE;
 
     UserRefObjectCo(pKL, &Ref1); /* Add reference */
@@ -857,7 +857,7 @@ co_IntUnloadKeyboardLayoutEx(
     UserMarkObjectDestroy(pKL);
     pKL->dwKL_Flags |= KL_UNLOAD;
 
-    if (!(dwFlags & 0x80000000) && pti->KeyboardLayout == pKL)
+    if (!(dwFlags & KL_NOACTIVATENEXT) && pti->KeyboardLayout == pKL)
     {
         pNextKL = IntHKLtoPKL(pti, UlongToHandle(HKL_NEXT));
         if (pNextKL)

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -843,7 +843,7 @@ co_IntUnloadKeyboardLayoutEx(
     USER_REFERENCE_ENTRY Ref1, Ref2;
     PTHREADINFO pti = gptiCurrent;
 
-    if (pKL == gspklBaseLayout && !(dwFlags & KL_NOACTIVATENEXT))
+    if (pKL == gspklBaseLayout && !(dwFlags & UKL_NOACTIVATENEXT))
         return FALSE;
 
     UserRefObjectCo(pKL, &Ref1); /* Add reference */
@@ -852,7 +852,7 @@ co_IntUnloadKeyboardLayoutEx(
     UserMarkObjectDestroy(pKL);
     pKL->dwKL_Flags |= KL_UNLOAD;
 
-    if (!(dwFlags & KL_NOACTIVATENEXT) && pti->KeyboardLayout == pKL)
+    if (!(dwFlags & UKL_NOACTIVATENEXT) && pti->KeyboardLayout == pKL)
     {
         pNextKL = IntHKLtoPKL(pti, UlongToHandle(HKL_NEXT));
         if (pNextKL)

--- a/win32ss/user/ntuser/keyboard.c
+++ b/win32ss/user/ntuser/keyboard.c
@@ -807,7 +807,7 @@ IntGetNextKL(
     {
         pKL = (bNext ? pKL->pklNext : pKL->pklPrev);
 
-        if (!(pKL->dwKL_Flags & KLF_UNLOAD) && bSameLang == (LangID == LOWORD(pKL->hkl)))
+        if (!(pKL->dwKL_Flags & KL_UNLOAD) && bSameLang == (LangID == LOWORD(pKL->hkl)))
             return pKL;
     } while (pKL != pFirstKL);
 


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-19268](https://jira.reactos.org/browse/CORE-19268)

## Proposed changes

- Rename `KLF_UNLOAD` as `KL_UNLOAD`.
- Move it from `win32ss/user/ntuser/input.h` to `sdk/include/reactos/undocuser.h`.
- Add `UKL_NOACTIVATENEXT` constant and use it.