### PR TITLE
[REGEDIT] *.rc: Dedupe ID_HELP_HELPTOPICS & ID_HELP_ABOUT

### DIFF
--- a/base/applications/regedit/lang/bg-BG.rc
+++ b/base/applications/regedit/lang/bg-BG.rc
@@ -442,7 +442,7 @@ BEGIN
     ID_REGISTRY_CONNECTNETWORKREGISTRY "Свързва се с регистъра на далечен компютър"
     ID_REGISTRY_DISCONNECTNETWORKREGISTRY "Разкача се от регистъра на отдалечен компютър"
     ID_REGISTRY_PRINT "Разпечатва регистъра или част от него"
-/*    ID_HELP_HELPTOPICS "Отваря помощта за регистърен обработчик" */
+//    ID_HELP_HELPTOPICS "Отваря помощта за регистърен обработчик"
     ID_HELP_ABOUT "Показва сведения за приложението, версия и възпроизводствени права"
 END
 
@@ -717,12 +717,3 @@ BEGIN
     DEFPUSHBUTTON "Отказ", IDCANCEL, 93, 29, 45, 14
     LTEXT "Претърсване на регистъра...", IDC_STATIC, 33, 12, 105, 8
 END
-
-/* String Table */
-/*
- *STRINGTABLE
- *BEGIN
- *    ID_HELP_HELPTOPICS "Отваря помощта за Регистърния обработчик."
- *    ID_HELP_ABOUT "Показва сведения за приложението, версията и възпроизводственото право."
- *END
- */

--- a/base/applications/regedit/lang/cs-CZ.rc
+++ b/base/applications/regedit/lang/cs-CZ.rc
@@ -439,7 +439,7 @@ BEGIN
     ID_REGISTRY_CONNECTNETWORKREGISTRY "Připojí se ke vzdálenému registru jiného počítače"
     ID_REGISTRY_DISCONNECTNETWORKREGISTRY "Odpojí se od vzdálenému registru jiného počítače"
     ID_REGISTRY_PRINT "Vytiskne všechny části registru"
-/*    ID_HELP_HELPTOPICS "Otevře témata nápovědy pro editor registru" */
+//    ID_HELP_HELPTOPICS "Otevře nápovědu pro editor registru"
     ID_HELP_ABOUT "Zobrazí informace o aplikaci, verzi a copyright"
 END
 
@@ -714,12 +714,3 @@ BEGIN
     DEFPUSHBUTTON "Storno", IDCANCEL, 93, 29, 45, 14
     LTEXT "Probíhá prohledávání registru...", IDC_STATIC, 33, 12, 83, 8
 END
-
-/* String Table */
-/*
- *STRINGTABLE
- *BEGIN
- *    ID_HELP_HELPTOPICS "Otevře nápovědu pro editor registru."
- *    ID_HELP_ABOUT "Zobrazí informace o aplikaci, verzi a copyright."
- *END
- */

--- a/base/applications/regedit/lang/de-DE.rc
+++ b/base/applications/regedit/lang/de-DE.rc
@@ -439,8 +439,8 @@ BEGIN
     ID_REGISTRY_CONNECTNETWORKREGISTRY "Verbindet zu einer Registry eines Fremdcomputers"
     ID_REGISTRY_DISCONNECTNETWORKREGISTRY "Trennt die Verbindung zu der Registry eines Fremdcomputers"
     ID_REGISTRY_PRINT "Druckt die gesamte Registry oder Teile davon aus"
-/*    ID_HELP_HELPTOPICS "Öffnet die Hilfe" */
-    ID_HELP_ABOUT "Zeigt Versions- und Copyright-Informationen an"
+//    ID_HELP_HELPTOPICS "Öffnet die Hilfe"
+    ID_HELP_ABOUT "Zeigt Programmname, Version und Copyright an"
 END
 
 STRINGTABLE
@@ -714,12 +714,3 @@ BEGIN
     DEFPUSHBUTTON "Abbrechen", IDCANCEL, 93, 29, 45, 14
     LTEXT "Durchsuche die Registry...", IDC_STATIC, 33, 12, 85, 8
 END
-
-/* String Table */
-/*
- *STRINGTABLE
- *BEGIN
- *    ID_HELP_HELPTOPICS "Öffnet die Hilfe."
- *    ID_HELP_ABOUT "Zeigt Programmname, Version und Copyright an"
- *END
- */

--- a/base/applications/regedit/lang/el-GR.rc
+++ b/base/applications/regedit/lang/el-GR.rc
@@ -439,7 +439,7 @@ BEGIN
     ID_REGISTRY_CONNECTNETWORKREGISTRY "Συνδέεεται στη registry ενός απομακρυσμένου υπολογιστή"
     ID_REGISTRY_DISCONNECTNETWORKREGISTRY "Αποσυνδέεεται από τη registry ενός απομακρυσμένου υπολογιστή"
     ID_REGISTRY_PRINT "Εκτυπώνει όλο το κομμάτι της registry"
-/*    ID_HELP_HELPTOPICS "Opens registry editor help" */
+//    ID_HELP_HELPTOPICS "Opens registry editor help"
     ID_HELP_ABOUT "Εμφανίζει τις πληροφορίες προγράμματος, τον αριθμό έκδοσης και τα δικαιώματα"
 END
 
@@ -714,12 +714,3 @@ BEGIN
     DEFPUSHBUTTON "Ακύρωση", IDCANCEL, 93, 29, 45, 14
     LTEXT "Γίνεται αναζήτηση στη registry...", IDC_STATIC, 33, 12, 83, 8
 END
-
-/* String Table */
-/*
- *STRINGTABLE
- *BEGIN
- *    ID_HELP_HELPTOPICS "Opens Registry Editor Help."
- *    ID_HELP_ABOUT "Displays program information, version number, and copyright."
- *END
- */

--- a/base/applications/regedit/lang/en-US.rc
+++ b/base/applications/regedit/lang/en-US.rc
@@ -439,7 +439,7 @@ BEGIN
     ID_REGISTRY_CONNECTNETWORKREGISTRY "Connects to a remote computer's registry"
     ID_REGISTRY_DISCONNECTNETWORKREGISTRY "Disconnects from a remote computer's registry"
     ID_REGISTRY_PRINT "Prints all or part of the registry"
-/*    ID_HELP_HELPTOPICS "Opens registry editor help" */
+//    ID_HELP_HELPTOPICS "Opens registry editor help"
     ID_HELP_ABOUT "Displays program information, version number and copyright"
 END
 
@@ -714,12 +714,3 @@ BEGIN
     DEFPUSHBUTTON "Cancel", IDCANCEL, 93, 29, 45, 14
     LTEXT "Searching the registry...", IDC_STATIC, 33, 12, 83, 8
 END
-
-/* String Table */
-/*
- *STRINGTABLE
- *BEGIN
- *    ID_HELP_HELPTOPICS "Opens Registry Editor Help."
- *    ID_HELP_ABOUT "Displays program information, version number, and copyright."
- *END
- */

--- a/base/applications/regedit/lang/es-ES.rc
+++ b/base/applications/regedit/lang/es-ES.rc
@@ -442,8 +442,8 @@ BEGIN
     ID_REGISTRY_CONNECTNETWORKREGISTRY "Se conecta al Registro de un ordenador remoto"
     ID_REGISTRY_DISCONNECTNETWORKREGISTRY "Se desconecta del Registro de un ordenador remoto"
     ID_REGISTRY_PRINT "Imprime todo o parte del Registro"
-/*    ID_HELP_HELPTOPICS "Opens registry editor help" */
-    ID_HELP_ABOUT "Muestra información del programa, número de versión y derechos de autor"
+//    ID_HELP_HELPTOPICS "Abre la ayuda del Editor de registro"
+    ID_HELP_ABOUT "Despliega información del programa, versión y licencia"
 END
 
 STRINGTABLE
@@ -717,12 +717,3 @@ BEGIN
     DEFPUSHBUTTON "Cancelar", IDCANCEL, 93, 29, 45, 14
     LTEXT "Buscando en el Registro...", IDC_STATIC, 33, 12, 83, 8
 END
-
-/* String Table */
-/*
- *STRINGTABLE
- *BEGIN
- *    ID_HELP_HELPTOPICS "Abre la ayuda del Editor de registro."
- *    ID_HELP_ABOUT "Despliega información del programa, versión y licencia."
- *END
- */

--- a/base/applications/regedit/lang/fr-FR.rc
+++ b/base/applications/regedit/lang/fr-FR.rc
@@ -439,7 +439,7 @@ BEGIN
     ID_REGISTRY_CONNECTNETWORKREGISTRY "Connecte aux registres d'un ordinateur distant"
     ID_REGISTRY_DISCONNECTNETWORKREGISTRY "Déconnecte des registres d'un ordinateur distant"
     ID_REGISTRY_PRINT "Imprime tout ou une partie des registres"
-/*    ID_HELP_HELPTOPICS "Ouvre l'aide de l'éditeur de registres" */
+//    ID_HELP_HELPTOPICS "Ouvre l'aide de l'éditeur de registres"
     ID_HELP_ABOUT "Affiche de l'information sur le programme, le numéro de version et le copyright"
 END
 
@@ -714,12 +714,3 @@ BEGIN
     DEFPUSHBUTTON "Annuler", IDCANCEL, 93, 29, 45, 14
     LTEXT "Recherche dans le registre...", IDC_STATIC, 33, 12, 83, 8
 END
-
-/* String Table */
-/*
- *STRINGTABLE
- *BEGIN
- *    ID_HELP_HELPTOPICS "Ouvre l'aide de l'éditeur de registres."
- *    ID_HELP_ABOUT "Affiche de l'information sur le programme, le numéro de version et le copyright."
- *END
- */

--- a/base/applications/regedit/lang/he-IL.rc
+++ b/base/applications/regedit/lang/he-IL.rc
@@ -439,7 +439,7 @@ BEGIN
     ID_REGISTRY_CONNECTNETWORKREGISTRY "Connects to a remote computer's registry"
     ID_REGISTRY_DISCONNECTNETWORKREGISTRY "Disconnects from a remote computer's registry"
     ID_REGISTRY_PRINT "Prints all or part of the registry"
-/*    ID_HELP_HELPTOPICS "Opens registry editor help" */
+//    ID_HELP_HELPTOPICS "Opens registry editor help"
     ID_HELP_ABOUT "Displays program information, version number and copyright"
 END
 
@@ -714,12 +714,3 @@ BEGIN
     DEFPUSHBUTTON "ביטול", IDCANCEL, 93, 29, 45, 14
     LTEXT "מחפש ברשום...", IDC_STATIC, 33, 12, 83, 8
 END
-
-/* String Table */
-/*
- *STRINGTABLE
- *BEGIN
- *    ID_HELP_HELPTOPICS "Opens Registry Editor Help."
- *    ID_HELP_ABOUT "Displays program information, version number, and copyright."
- *END
- */

--- a/base/applications/regedit/lang/hu-HU.rc
+++ b/base/applications/regedit/lang/hu-HU.rc
@@ -439,7 +439,7 @@ BEGIN
     ID_REGISTRY_CONNECTNETWORKREGISTRY "Connects to a remote computer's registry"
     ID_REGISTRY_DISCONNECTNETWORKREGISTRY "Disconnects from a remote computer's registry"
     ID_REGISTRY_PRINT "Prints all or part of the registry"
-/*    ID_HELP_HELPTOPICS "Opens registry editor help" */
+//    ID_HELP_HELPTOPICS "Opens registry editor help"
     ID_HELP_ABOUT "Displays program information, version number and copyright"
 END
 
@@ -714,12 +714,3 @@ BEGIN
     DEFPUSHBUTTON "Cancel", IDCANCEL, 93, 29, 45, 14
     LTEXT "Searching the registry...", IDC_STATIC, 33, 12, 83, 8
 END
-
-/* String Table */
-/*
- *STRINGTABLE
- *BEGIN
- *    ID_HELP_HELPTOPICS "Opens Registry Editor Help."
- *    ID_HELP_ABOUT "Displays program information, version number, and copyright."
- *END
- */

--- a/base/applications/regedit/lang/id-ID.rc
+++ b/base/applications/regedit/lang/id-ID.rc
@@ -439,7 +439,7 @@ BEGIN
     ID_REGISTRY_CONNECTNETWORKREGISTRY "Menyambungkan ke registri komputer lain"
     ID_REGISTRY_DISCONNECTNETWORKREGISTRY "Memutuskan dari registri komputer lain"
     ID_REGISTRY_PRINT "Mecetak semua atau sebagian registri"
-/*    ID_HELP_HELPTOPICS "Opens registry editor help" */
+//    ID_HELP_HELPTOPICS "Opens registry editor help"
     ID_HELP_ABOUT "Menampilkan informasi program, nomor versi, dan hak cipta"
 END
 
@@ -714,12 +714,3 @@ BEGIN
     DEFPUSHBUTTON "Batal", IDCANCEL, 93, 29, 45, 14
     LTEXT "Mencari registri...", IDC_STATIC, 33, 12, 83, 8
 END
-
-/* String Table */
-/*
- *STRINGTABLE
- *BEGIN
- *    ID_HELP_HELPTOPICS "Opens Registry Editor Help."
- *    ID_HELP_ABOUT "Displays program information, version number, and copyright."
- *END
- */

--- a/base/applications/regedit/lang/it-IT.rc
+++ b/base/applications/regedit/lang/it-IT.rc
@@ -97,7 +97,7 @@ BEGIN
         MENUITEM SEPARATOR
         POPUP "&Nuovo"
         BEGIN
-            MENUITEM "Chiave", ID_EDIT_NEW_KEY
+            MENUITEM "&Chiave", ID_EDIT_NEW_KEY
             MENUITEM SEPARATOR
             MENUITEM "Valore &stringa", ID_EDIT_NEW_STRINGVALUE
             MENUITEM "Valore &binario", ID_EDIT_NEW_BINARYVALUE
@@ -209,9 +209,9 @@ STYLE DS_SHELLFONT | DS_MODALFRAME | DS_NOIDLEMSG | DS_CONTEXTHELP | WS_POPUP | 
 CAPTION "Edit String"
 FONT 8, "MS Shell Dlg"
 BEGIN
-    LTEXT "Nome:", IDC_STATIC, 5, 5, 119, 8
+    LTEXT "&Nome:", IDC_STATIC, 5, 5, 119, 8
     EDITTEXT IDC_VALUE_NAME, 5, 15, 239, 12, ES_AUTOHSCROLL | ES_READONLY
-    LTEXT "Dati:", IDC_STATIC, 5, 30, 119, 8
+    LTEXT "&Dati:", IDC_STATIC, 5, 30, 119, 8
     EDITTEXT IDC_VALUE_DATA, 5, 40, 239, 12, ES_AUTOHSCROLL
     DEFPUSHBUTTON "OK", IDOK, 142, 64, 50, 14
     PUSHBUTTON "Annulla", IDCANCEL, 196, 64, 50, 14
@@ -447,7 +447,7 @@ BEGIN
     ID_REGISTRY_CONNECTNETWORKREGISTRY "Si connette al Registro di un computer remoto"
     ID_REGISTRY_DISCONNECTNETWORKREGISTRY "Si disconnette dal Registro di un computer remoto"
     ID_REGISTRY_PRINT "Stampa tutto o parte del Registro"
-/*    ID_HELP_HELPTOPICS "Apre l'aiuto dell'Editor del Registro" */
+//    ID_HELP_HELPTOPICS "Apre l'aiuto dell'Editor del Registro"
     ID_HELP_ABOUT "Visualizza informazioni sul programma, numero di versione e copyright"
 END
 
@@ -722,12 +722,3 @@ BEGIN
     DEFPUSHBUTTON "Annulla", IDCANCEL, 93, 29, 45, 14
     LTEXT "Ricerca in corso nel registro...", IDC_STATIC, 33, 12, 83, 8
 END
-
-/* String Table */
-/*
- *STRINGTABLE
- *BEGIN
- *    ID_HELP_HELPTOPICS "Opens Registry Editor Help."
- *    ID_HELP_ABOUT "Displays program information, version number, and copyright."
- *END
- */

--- a/base/applications/regedit/lang/ja-JP.rc
+++ b/base/applications/regedit/lang/ja-JP.rc
@@ -417,45 +417,45 @@ END
 
 STRINGTABLE
 BEGIN
-    ID_REGISTRY_MENU "レジストリ全体で使用するコマンドです。"
-    ID_EDIT_MENU "値やキーを編集するコマンドです。"
-    ID_VIEW_MENU "レジストリ ウィンドウをカスタマイズするコマンドです。"
-    ID_FAVOURITES_MENU "頻繁に使用されるキーにアクセスするコマンドです。"
-    ID_HELP_MENU "ヘルプとレジストリ エディタのバージョン情報を表示するコマンドです。"
-    ID_EDIT_NEW_MENU "新しいキーや値を作成するコマンドです。"
+    ID_REGISTRY_MENU "レジストリ全体で使用するコマンドです"
+    ID_EDIT_MENU "値やキーを編集するコマンドです"
+    ID_VIEW_MENU "レジストリ ウィンドウをカスタマイズするコマンドです"
+    ID_FAVOURITES_MENU "頻繁に使用されるキーにアクセスするコマンドです"
+    ID_HELP_MENU "ヘルプとレジストリ エディタのバージョン情報を表示するコマンドです"
+    ID_EDIT_NEW_MENU "新しいキーや値を作成するコマンドです"
 END
 
 STRINGTABLE
 BEGIN
-    ID_EDIT_MODIFY "値のデータを変更します。"
-    ID_EDIT_NEW_KEY "新しいキーを追加します。"
-    ID_EDIT_NEW_STRINGVALUE "新しい文字列値を追加します。"
-    ID_EDIT_NEW_BINARYVALUE "新しいバイナリ値を追加します。"
-    ID_EDIT_NEW_DWORDVALUE "新しい DWORD 値を追加します。"
-    ID_REGISTRY_IMPORTREGISTRYFILE "テキスト ファイルをレジストリにインポートします。"
-    ID_REGISTRY_EXPORTREGISTRYFILE "レジストリの一部または全体をテキスト ファイルにエクスポートします。"
-    ID_REGISTRY_LOADHIVE "ハイブ ファイルをレジストリに読み込みます。"
-    ID_REGISTRY_UNLOADHIVE "レジストリからハイブをアンロードします。"
-    ID_REGISTRY_CONNECTNETWORKREGISTRY "リモート コンピュータのレジストリに接続します。"
-    ID_REGISTRY_DISCONNECTNETWORKREGISTRY "リモート コンピュータのレジストリを切断します。"
-    ID_REGISTRY_PRINT "レジストリの一部または全体を印刷します。"
-/*    ID_HELP_HELPTOPICS "レジストリ エディタのヘルプを開きます。" */
-    ID_HELP_ABOUT "プログラムの情報、バージョン番号および著作権を表示します。"
+    ID_EDIT_MODIFY "値のデータを変更します"
+    ID_EDIT_NEW_KEY "新しいキーを追加します"
+    ID_EDIT_NEW_STRINGVALUE "新しい文字列値を追加します"
+    ID_EDIT_NEW_BINARYVALUE "新しいバイナリ値を追加します"
+    ID_EDIT_NEW_DWORDVALUE "新しい DWORD 値を追加します"
+    ID_REGISTRY_IMPORTREGISTRYFILE "テキスト ファイルをレジストリにインポートします"
+    ID_REGISTRY_EXPORTREGISTRYFILE "レジストリの一部または全体をテキスト ファイルにエクスポートします"
+    ID_REGISTRY_LOADHIVE "ハイブ ファイルをレジストリに読み込みます"
+    ID_REGISTRY_UNLOADHIVE "レジストリからハイブをアンロードします"
+    ID_REGISTRY_CONNECTNETWORKREGISTRY "リモート コンピュータのレジストリに接続します"
+    ID_REGISTRY_DISCONNECTNETWORKREGISTRY "リモート コンピュータのレジストリを切断します"
+    ID_REGISTRY_PRINT "レジストリの一部または全体を印刷します"
+//    ID_HELP_HELPTOPICS "レジストリ エディタのヘルプを開きます"
+    ID_HELP_ABOUT "プログラムの情報、バージョン番号および著作権を表示します"
 END
 
 STRINGTABLE
 BEGIN
-    ID_REGISTRY_EXIT "レジストリ エディタを終了します。"
-    ID_FAVOURITES_ADDTOFAVOURITES "お気に入りの一覧にキーを追加します。"
-    ID_FAVOURITES_REMOVEFAVOURITE "お気に入りの一覧からキーを削除します。"
-    ID_VIEW_STATUSBAR "ステータス バーの表示/非表示を切り替えます。"
-    ID_VIEW_SPLIT "2つのパネルの境界の位置を変更します。"
-    ID_VIEW_REFRESH "ウィンドウの内容を最新の情報に更新します。"
-    ID_EDIT_DELETE "選択範囲を削除します。"
-    ID_EDIT_RENAME "名前を変更します。"
-    ID_EDIT_COPYKEYNAME "選択されたキー名をクリップボードにコピーします。"
-    ID_EDIT_FIND "キー、値、データの中のテキストを検索します。"
-    ID_EDIT_FINDNEXT "前回と同じ条件で次の項目を検索します。"
+    ID_REGISTRY_EXIT "レジストリ エディタを終了します"
+    ID_FAVOURITES_ADDTOFAVOURITES "お気に入りの一覧にキーを追加します"
+    ID_FAVOURITES_REMOVEFAVOURITE "お気に入りの一覧からキーを削除します"
+    ID_VIEW_STATUSBAR "ステータス バーの表示/非表示を切り替えます"
+    ID_VIEW_SPLIT "2つのパネルの境界の位置を変更します"
+    ID_VIEW_REFRESH "ウィンドウの内容を最新の情報に更新します"
+    ID_EDIT_DELETE "選択範囲を削除します"
+    ID_EDIT_RENAME "名前を変更します"
+    ID_EDIT_COPYKEYNAME "選択されたキー名をクリップボードにコピーします"
+    ID_EDIT_FIND "キー、値、データの中のテキストを検索します"
+    ID_EDIT_FINDNEXT "前回と同じ条件で次の項目を検索します"
 END
 
 STRINGTABLE
@@ -714,12 +714,3 @@ BEGIN
     DEFPUSHBUTTON "キャンセル", IDCANCEL, 93, 29, 45, 14
     LTEXT "レジストリの検索中...", IDC_STATIC, 33, 12, 83, 8
 END
-
-/* String Table */
-/*
- *STRINGTABLE
- *BEGIN
- *    ID_HELP_HELPTOPICS "レジストリ エディタのヘルプを開きます。"
- *    ID_HELP_ABOUT "プログラムの情報、バージョン番号および著作権を表示します。"
- *END
- */

--- a/base/applications/regedit/lang/ko-KR.rc
+++ b/base/applications/regedit/lang/ko-KR.rc
@@ -441,7 +441,7 @@ BEGIN
     ID_REGISTRY_CONNECTNETWORKREGISTRY "원격 컴퓨터의 레지스트리로 접속합니다"
     ID_REGISTRY_DISCONNECTNETWORKREGISTRY "원격 컴퓨터의 레지스트리로의 접속을 끊습니다"
     ID_REGISTRY_PRINT "레지스트리의 전체나 일부를 인쇄합니다"
-/*    ID_HELP_HELPTOPICS "레지스트리 편집기의 도움말을 표시합니다" */
+//    ID_HELP_HELPTOPICS "레지스트리 편집기의 도움말을 표시합니다"
     ID_HELP_ABOUT "프로그램 정보, 벼젼과 라이센스를 표시합니다"
 END
 
@@ -716,12 +716,3 @@ BEGIN
     DEFPUSHBUTTON "취소", IDCANCEL, 93, 29, 45, 14
     LTEXT "레지스트리를 검색중...", IDC_STATIC, 33, 12, 83, 8
 END
-
-/* String Table */
-/*
- *STRINGTABLE
- *BEGIN
- *    ID_HELP_HELPTOPICS "Opens Registry Editor Help."
- *    ID_HELP_ABOUT "Displays program information, version number, and copyright."
- *END
- */

--- a/base/applications/regedit/lang/nl-NL.rc
+++ b/base/applications/regedit/lang/nl-NL.rc
@@ -439,7 +439,7 @@ BEGIN
     ID_REGISTRY_CONNECTNETWORKREGISTRY "Een verbinding maken met het register van een externe computer"
     ID_REGISTRY_DISCONNECTNETWORKREGISTRY "De verbinding met het register van een externe computer verbreken"
     ID_REGISTRY_PRINT "Het register of een gedeelte ervan afdrukken"
-/*    ID_HELP_HELPTOPICS "Help voor de Register-editor openen" */
+//    ID_HELP_HELPTOPICS "Help voor de Register-editor openen"
     ID_HELP_ABOUT "Programmagegevens, versienummer en copyrightgegevens weergeven"
 END
 
@@ -714,12 +714,3 @@ BEGIN
     DEFPUSHBUTTON "Cancel", IDCANCEL, 93, 29, 45, 14
     LTEXT "Searching the registry...", IDC_STATIC, 33, 12, 83, 8
 END
-
-/* String Table */
-/*
- *STRINGTABLE
- *BEGIN
- *    ID_HELP_HELPTOPICS "Opens Registry Editor Help."
- *    ID_HELP_ABOUT "Displays program information, version number, and copyright."
- *END
- */

--- a/base/applications/regedit/lang/no-NO.rc
+++ b/base/applications/regedit/lang/no-NO.rc
@@ -439,7 +439,7 @@ BEGIN
     ID_REGISTRY_CONNECTNETWORKREGISTRY "Kobler til Registret på en annen datamaskin"
     ID_REGISTRY_DISCONNECTNETWORKREGISTRY "Kobler fra Registret på en annen datamaskin"
     ID_REGISTRY_PRINT "Skriver ut hele eller deler av Registret"
-/*    ID_HELP_HELPTOPICS "Opens registry editor help" */
+//    ID_HELP_HELPTOPICS "Åpne registerredigering hjelpen"
     ID_HELP_ABOUT "Viser informasjon om program, version og opphavsrett"
 END
 
@@ -714,12 +714,3 @@ BEGIN
     DEFPUSHBUTTON "Avbryt", IDCANCEL, 93, 29, 45, 14
     LTEXT "Søker i registret...", IDC_STATIC, 33, 12, 83, 8
 END
-
-/* String Table */
-/*
- *STRINGTABLE
- *BEGIN
- *    ID_HELP_HELPTOPICS "Åpne registerredigering hjelpen."
- *    ID_HELP_ABOUT "Vis program informasjon, versjon nummer, og enerett."
- *END
- */

--- a/base/applications/regedit/lang/pl-PL.rc
+++ b/base/applications/regedit/lang/pl-PL.rc
@@ -447,8 +447,8 @@ BEGIN
     ID_REGISTRY_CONNECTNETWORKREGISTRY "Połączenie z rejestrem zdalnego komputera"
     ID_REGISTRY_DISCONNECTNETWORKREGISTRY "Odłącza od rejestru zdalnego komputera"
     ID_REGISTRY_PRINT "Drukuje całość lub część rejestru"
-/*    ID_HELP_HELPTOPICS "Otwiera Pomoc Edytora rejestru" */
-    ID_HELP_ABOUT "Wyświetla informacje o programie, numerze wersji i prawach autorskich"
+//    ID_HELP_HELPTOPICS "Otwiera Pomoc Edytora rejestru"
+    ID_HELP_ABOUT "Wyświetla informacje o programie, numerze wersji, licencji"
 END
 
 STRINGTABLE
@@ -722,12 +722,3 @@ BEGIN
     DEFPUSHBUTTON "Anuluj", IDCANCEL, 93, 29, 45, 14
     LTEXT "Przeszukiwanie rejestru...", IDC_STATIC, 33, 12, 83, 8
 END
-
-/* String Table */
-/*
- *STRINGTABLE
- *BEGIN
- *    ID_HELP_HELPTOPICS "Otwiera pomoc Edytora Rejestru."
- *    ID_HELP_ABOUT "Wyświetla informacje o programie, numerze wersji, licencji."
- *END
- */

--- a/base/applications/regedit/lang/pt-BR.rc
+++ b/base/applications/regedit/lang/pt-BR.rc
@@ -439,8 +439,8 @@ BEGIN
     ID_REGISTRY_CONNECTNETWORKREGISTRY "Conecta-se ao Registro de um computador remoto"
     ID_REGISTRY_DISCONNECTNETWORKREGISTRY "Desconecta-se do Registro de um computador remoto"
     ID_REGISTRY_PRINT "Imprime parte ou todo registro"
-/*    ID_HELP_HELPTOPICS "Abre ajuda do Editor do Registro" */
-    ID_HELP_ABOUT "Exibe informações sobre o programa, número da versão e direitos autorais."
+//    ID_HELP_HELPTOPICS "Abre ajuda do Editor do Registro"
+    ID_HELP_ABOUT "Exibe informações sobre o programa, número da versão e direitos autorais"
 END
 
 STRINGTABLE
@@ -714,12 +714,3 @@ BEGIN
     DEFPUSHBUTTON "Cancelar", IDCANCEL, 93, 29, 45, 14
     LTEXT "Pesquisando o registro...", IDC_STATIC, 33, 12, 83, 8
 END
-
-/* String Table */
-/*
- *STRINGTABLE
- *BEGIN
- *    ID_HELP_HELPTOPICS "Abre ajuda do Editor do Registro."
- *    ID_HELP_ABOUT "Exibe informações sobre o programa, número da versão e direitos autorais."
- *END
- */

--- a/base/applications/regedit/lang/pt-PT.rc
+++ b/base/applications/regedit/lang/pt-PT.rc
@@ -427,45 +427,45 @@ END
 
 STRINGTABLE
 BEGIN
-    ID_REGISTRY_MENU "Contém comandos para trabalhar com o Registo inteiro."
-    ID_EDIT_MENU "Contém comandos para edição de valores ou chaves."
-    ID_VIEW_MENU "Contém comandos para personalização da janela do Registo."
-    ID_FAVOURITES_MENU "Contém comandos para acessar chaves frequentemente usadas."
-    ID_HELP_MENU "Contém comandos para exibição da ajuda e informações sobre o Editor do Registo."
+    ID_REGISTRY_MENU "Contém comandos para trabalhar com o Registo inteiro"
+    ID_EDIT_MENU "Contém comandos para edição de valores ou chaves"
+    ID_VIEW_MENU "Contém comandos para personalização da janela do Registo"
+    ID_FAVOURITES_MENU "Contém comandos para acessar chaves frequentemente usadas"
+    ID_HELP_MENU "Contém comandos para exibição da ajuda e informações sobre o Editor do Registo"
     ID_EDIT_NEW_MENU "Contém comandos para criação de novas chaves ou valores"
 END
 
 STRINGTABLE
 BEGIN
-    ID_EDIT_MODIFY "Modifica os dados do valor."
+    ID_EDIT_MODIFY "Modifica os dados do valor"
     ID_EDIT_NEW_KEY "Adiciona uma nova chave"
-    ID_EDIT_NEW_STRINGVALUE "Adiciona um novo valor texto."
-    ID_EDIT_NEW_BINARYVALUE "Adiciona um novo valor binário."
-    ID_EDIT_NEW_DWORDVALUE "Adiciona um novo valor DWORD."
-    ID_REGISTRY_IMPORTREGISTRYFILE "Importa um ficheiro de texto para o registo."
-    ID_REGISTRY_EXPORTREGISTRYFILE "Exporta todo ou parte do registo para um ficheiro de texto."
+    ID_EDIT_NEW_STRINGVALUE "Adiciona um novo valor texto"
+    ID_EDIT_NEW_BINARYVALUE "Adiciona um novo valor binário"
+    ID_EDIT_NEW_DWORDVALUE "Adiciona um novo valor DWORD"
+    ID_REGISTRY_IMPORTREGISTRYFILE "Importa um ficheiro de texto para o registo"
+    ID_REGISTRY_EXPORTREGISTRYFILE "Exporta todo ou parte do registo para um ficheiro de texto"
     ID_REGISTRY_LOADHIVE "Carrega um ficheiro de secção no registo"
     ID_REGISTRY_UNLOADHIVE "Descarrega um ficheiro de secção no registo"
-    ID_REGISTRY_CONNECTNETWORKREGISTRY "Liga a um registo num computador remoto."
-    ID_REGISTRY_DISCONNECTNETWORKREGISTRY "Desliga um registo de um computador remoto."
-    ID_REGISTRY_PRINT "Imprime todo ou parte do registo."
-/*    ID_HELP_HELPTOPICS "Abre a ajuda do Editor do Registo." */
-    ID_HELP_ABOUT "Mostra informações do programa, número da versão e copyright."
+    ID_REGISTRY_CONNECTNETWORKREGISTRY "Liga a um registo num computador remoto"
+    ID_REGISTRY_DISCONNECTNETWORKREGISTRY "Desliga um registo de um computador remoto"
+    ID_REGISTRY_PRINT "Imprime todo ou parte do registo"
+//    ID_HELP_HELPTOPICS "Abre a ajuda do Editor do Registo"
+    ID_HELP_ABOUT "Mostra informações do programa, número da versão e copyright"
 END
 
 STRINGTABLE
 BEGIN
-    ID_REGISTRY_EXIT "Encerra o Editor do Registo."
-    ID_FAVOURITES_ADDTOFAVOURITES "Adiciona chaves na lista de favoritos."
-    ID_FAVOURITES_REMOVEFAVOURITE "Remove chaves da lista de favoritos."
-    ID_VIEW_STATUSBAR "Mostra ou oculta a barra de estado."
-    ID_VIEW_SPLIT "Altera a posição da divisão entre os painéis."
-    ID_VIEW_REFRESH "Actualiza a janela."
-    ID_EDIT_DELETE "Exclui a seleccão."
-    ID_EDIT_RENAME "Renomeia a seleccão."
-    ID_EDIT_COPYKEYNAME "Copia o nome da chave seleccionada para a área de transferência."
-    ID_EDIT_FIND "Localiza um texto numa chave, valor ou dado."
-    ID_EDIT_FINDNEXT "Localiza a próxima ocorrência do texto especificado na pesquisa anterior."
+    ID_REGISTRY_EXIT "Encerra o Editor do Registo"
+    ID_FAVOURITES_ADDTOFAVOURITES "Adiciona chaves na lista de favoritos"
+    ID_FAVOURITES_REMOVEFAVOURITE "Remove chaves da lista de favoritos"
+    ID_VIEW_STATUSBAR "Mostra ou oculta a barra de estado"
+    ID_VIEW_SPLIT "Altera a posição da divisão entre os painéis"
+    ID_VIEW_REFRESH "Actualiza a janela"
+    ID_EDIT_DELETE "Exclui a seleccão"
+    ID_EDIT_RENAME "Renomeia a seleccão"
+    ID_EDIT_COPYKEYNAME "Copia o nome da chave seleccionada para a área de transferência"
+    ID_EDIT_FIND "Localiza um texto numa chave, valor ou dado"
+    ID_EDIT_FINDNEXT "Localiza a próxima ocorrência do texto especificado na pesquisa anterior"
 END
 
 STRINGTABLE
@@ -724,12 +724,3 @@ BEGIN
     DEFPUSHBUTTON "Cancelar", IDCANCEL, 93, 29, 45, 14
     LTEXT "Procurar no registo...", IDC_STATIC, 33, 12, 83, 8
 END
-
-/* String Table */
-/*
- *STRINGTABLE
- *BEGIN
- *    ID_HELP_HELPTOPICS "Opens Registry Editor Help."
- *    ID_HELP_ABOUT "Displays program information, version number, and copyright."
- *END
- */

--- a/base/applications/regedit/lang/ro-RO.rc
+++ b/base/applications/regedit/lang/ro-RO.rc
@@ -449,7 +449,7 @@ BEGIN
     ID_REGISTRY_CONNECTNETWORKREGISTRY "Conectare la registrul unui calculator din rețea"
     ID_REGISTRY_DISCONNECTNETWORKREGISTRY "Deconectare de la registrul calculatorului din rețea"
     ID_REGISTRY_PRINT "Imprimă toate părțile unui registru"
-/*    ID_HELP_HELPTOPICS "Deschide manualul editorului de registru" */
+//    ID_HELP_HELPTOPICS "Deschide manualul editorului de registru"
     ID_HELP_ABOUT "Prezintă informații despre program, numărul versiunii și drepturi de autor"
 END
 
@@ -724,12 +724,3 @@ BEGIN
     DEFPUSHBUTTON "Anulare", IDCANCEL, 93, 29, 45, 14
     LTEXT "Căutare în registru…", IDC_STATIC, 33, 12, 83, 8
 END
-
-/* String Table */
-/*
- *STRINGTABLE
- *BEGIN
- *    ID_HELP_HELPTOPICS "Deschide Ajutor pentru Editorul de registru."
- *    ID_HELP_ABOUT "Afișează informații despre program, numărul versiunii și marca înregistrată."
- *END
- */

--- a/base/applications/regedit/lang/ru-RU.rc
+++ b/base/applications/regedit/lang/ru-RU.rc
@@ -452,7 +452,7 @@ BEGIN
     ID_REGISTRY_CONNECTNETWORKREGISTRY "Подключается к реестру удалённого компьютера"
     ID_REGISTRY_DISCONNECTNETWORKREGISTRY "Отключается от реестра удалённого компьютера"
     ID_REGISTRY_PRINT "Печатает весь реестр или его часть"
-/*    ID_HELP_HELPTOPICS "Открывает справку редактора реестра" */
+//    ID_HELP_HELPTOPICS "Открывает справку редактора реестра"
     ID_HELP_ABOUT "Отображает информацию о программе, номер версии и авторские права"
 END
 
@@ -727,12 +727,3 @@ BEGIN
     DEFPUSHBUTTON "Отмена", IDCANCEL, 93, 29, 45, 14
     LTEXT "Поиск в реестре...", IDC_STATIC, 33, 12, 83, 8
 END
-
-/* String Table */
-/*
- *STRINGTABLE
- *BEGIN
- *    ID_HELP_HELPTOPICS "Открывает справку редактора реестра."
- *    ID_HELP_ABOUT "Отображает информацию о программе, номер версии и авторские права."
- *END
- */

--- a/base/applications/regedit/lang/sk-SK.rc
+++ b/base/applications/regedit/lang/sk-SK.rc
@@ -442,8 +442,8 @@ BEGIN
     ID_REGISTRY_CONNECTNETWORKREGISTRY "Connects to a remote computer's registry"
     ID_REGISTRY_DISCONNECTNETWORKREGISTRY "Disconnects from a remote computer's registry"
     ID_REGISTRY_PRINT "Prints all or part of the registry"
-/*    ID_HELP_HELPTOPICS "Opens registry editor help" */
-    ID_HELP_ABOUT "Displays program information, version number and copyright"
+//    ID_HELP_HELPTOPICS "Otvorí pomocníka pre Editor registrov"
+    ID_HELP_ABOUT "Zobrazuje informácie programu, číslo verzie a autorské práva"
 END
 
 STRINGTABLE
@@ -717,12 +717,3 @@ BEGIN
     DEFPUSHBUTTON "Zrušiť", IDCANCEL, 93, 29, 45, 14
     LTEXT "Searching the registry...", IDC_STATIC, 33, 12, 83, 8
 END
-
-/* String Table */
-/*
- *STRINGTABLE
- *BEGIN
- *    ID_HELP_HELPTOPICS "Otvorí pomocníka pre Editor registrov."
- *    ID_HELP_ABOUT "Zobrazuje informácie programu, číslo verzie a autorské práva."
- *END
- */

--- a/base/applications/regedit/lang/sl-SI.rc
+++ b/base/applications/regedit/lang/sl-SI.rc
@@ -439,7 +439,7 @@ BEGIN
     ID_REGISTRY_CONNECTNETWORKREGISTRY "Vzpostavi povezavo z registrom oddaljenega raèunalnika"
     ID_REGISTRY_DISCONNECTNETWORKREGISTRY "Prekine povezavo z registrom oddaljenega raèunalnika"
     ID_REGISTRY_PRINT "Natisne registrsko datoteko ali njen del"
-/*    ID_HELP_HELPTOPICS "Odpre pomoC" */
+//    ID_HELP_HELPTOPICS "Odpre pomoC"
     ID_HELP_ABOUT "Informacije o programu, številki razlièice in avtorskih pravicah"
 END
 
@@ -714,12 +714,3 @@ BEGIN
     DEFPUSHBUTTON "Cancel", IDCANCEL, 93, 29, 45, 14
     LTEXT "Searching the registry...", IDC_STATIC, 33, 12, 83, 8
 END
-
-/* String Table */
-/*
- *STRINGTABLE
- *BEGIN
- *    ID_HELP_HELPTOPICS "Odpre pomoè."
- *    ID_HELP_ABOUT "Informacije o programu, številki razlièice in avtorskih pravicah."
- *END
- */

--- a/base/applications/regedit/lang/sq-AL.rc
+++ b/base/applications/regedit/lang/sq-AL.rc
@@ -442,7 +442,7 @@ BEGIN
     ID_REGISTRY_CONNECTNETWORKREGISTRY "Lidhet me regjistrin e një kompjuteri largët"
     ID_REGISTRY_DISCONNECTNETWORKREGISTRY "Shkëputet nga regjistri një kompjuter në distancë të"
     ID_REGISTRY_PRINT "Shtyp tërë ose pjesë të regjistrit"
-/*    ID_HELP_HELPTOPICS "Hap editor regjistrit ndihmë" */
+//    ID_HELP_HELPTOPICS "Hap editor regjistrit ndihmë"
     ID_HELP_ABOUT "Displays informacion rreth programit, versionin dhe të drejtat e autorit"
 END
 
@@ -717,12 +717,3 @@ BEGIN
     DEFPUSHBUTTON "Anulo", IDCANCEL, 93, 29, 45, 14
     LTEXT "Kerko ne regjister...", IDC_STATIC, 33, 12, 83, 8
 END
-
-/* String Table */
-/*
- *STRINGTABLE
- *BEGIN
- *    ID_HELP_HELPTOPICS "Opens Registry Editor Help."
- *    ID_HELP_ABOUT "Displays program information, version number, and copyright."
- *END
- */

--- a/base/applications/regedit/lang/sv-SE.rc
+++ b/base/applications/regedit/lang/sv-SE.rc
@@ -439,7 +439,7 @@ BEGIN
     ID_REGISTRY_CONNECTNETWORKREGISTRY "Ansluter till en annan dators register"
     ID_REGISTRY_DISCONNECTNETWORKREGISTRY "Kopplar ifrån en annan dators register"
     ID_REGISTRY_PRINT "Skriver ut hela eller en del av registret"
-/*    ID_HELP_HELPTOPICS "Öppnar hjälpen för Registereditorn" */
+//    ID_HELP_HELPTOPICS "Öppnar hjälpen för Registereditorn"
     ID_HELP_ABOUT "Visar programinformation, versionsnummer, och upphovsrätt"
 END
 
@@ -714,12 +714,3 @@ BEGIN
     DEFPUSHBUTTON "Avbryt", IDCANCEL, 93, 29, 45, 14
     LTEXT "Sök i registret...", IDC_STATIC, 33, 12, 83, 8
 END
-
-/* String Table */
-/*
- *STRINGTABLE
- *BEGIN
- *    ID_HELP_HELPTOPICS "Öppnar hjälpen för Registereditorn."
- *    ID_HELP_ABOUT "Visar programinformation, versionsnummer, och upphovsrätt."
- *END
- */

--- a/base/applications/regedit/lang/th-TH.rc
+++ b/base/applications/regedit/lang/th-TH.rc
@@ -441,7 +441,7 @@ BEGIN
     ID_REGISTRY_CONNECTNETWORKREGISTRY "Connects to a remote computer's registry"
     ID_REGISTRY_DISCONNECTNETWORKREGISTRY "Disconnects from a remote computer's registry"
     ID_REGISTRY_PRINT "Prints all or part of the registry"
-/*    ID_HELP_HELPTOPICS "Opens registry editor help" */
+//    ID_HELP_HELPTOPICS "Opens registry editor help"
     ID_HELP_ABOUT "Displays program information, version number and copyright"
 END
 
@@ -716,12 +716,3 @@ BEGIN
     DEFPUSHBUTTON "Cancel", IDCANCEL, 93, 29, 45, 14
     LTEXT "Searching the registry...", IDC_STATIC, 33, 12, 83, 8
 END
-
-/* String Table */
-/*
- *STRINGTABLE
- *BEGIN
- *    ID_HELP_HELPTOPICS "Opens Registry Editor Help."
- *    ID_HELP_ABOUT "Displays program information, version number, and copyright."
- *END
- */

--- a/base/applications/regedit/lang/tr-TR.rc
+++ b/base/applications/regedit/lang/tr-TR.rc
@@ -419,45 +419,45 @@ END
 
 STRINGTABLE
 BEGIN
-    ID_REGISTRY_MENU "Bütün Kayıt Defteri ile çalışma komutlarını içerir."
-    ID_EDIT_MENU "Anahtar veya değerleri düzenleme komutlarını içerir."
-    ID_VIEW_MENU "Kayıt Defteri penceresinin özelleştirme komutlarını içerir."
-    ID_FAVOURITES_MENU "Sık kullanılan anahtarları kullanma komutlarını içerir."
-    ID_HELP_MENU "Kayıt Defteri Düzenleyicisi ile ilgili bilgiyi ya da yardımı görüntüleme komutlarını içerir."
-    ID_EDIT_NEW_MENU "Yeni bir anahtar ya da yeni bir değer oluşturma komutlarını içerir."
+    ID_REGISTRY_MENU "Bütün Kayıt Defteri ile çalışma komutlarını içerir"
+    ID_EDIT_MENU "Anahtar veya değerleri düzenleme komutlarını içerir"
+    ID_VIEW_MENU "Kayıt Defteri penceresinin özelleştirme komutlarını içerir"
+    ID_FAVOURITES_MENU "Sık kullanılan anahtarları kullanma komutlarını içerir"
+    ID_HELP_MENU "Kayıt Defteri Düzenleyicisi ile ilgili bilgiyi ya da yardımı görüntüleme komutlarını içerir"
+    ID_EDIT_NEW_MENU "Yeni bir anahtar ya da yeni bir değer oluşturma komutlarını içerir"
 END
 
 STRINGTABLE
 BEGIN
-    ID_EDIT_MODIFY "Değerin verisini değiştirir."
-    ID_EDIT_NEW_KEY "Yeni bir anahtar ekler."
-    ID_EDIT_NEW_STRINGVALUE "Yeni bir dizi değeri ekler."
-    ID_EDIT_NEW_BINARYVALUE "Yeni bir ikili değer ekler."
-    ID_EDIT_NEW_DWORDVALUE "Yeni bir DWORD değeri ekler."
-    ID_REGISTRY_IMPORTREGISTRYFILE "Bir metin dosyasını Kayıt Defteri'ne alır."
-    ID_REGISTRY_EXPORTREGISTRYFILE "Kayıt Defteri'nin tümünü ya da bir bölümünü bir metin dosyasına verir."
-    ID_REGISTRY_LOADHIVE "Kayıt Defteri'ne bir yığın dosyasını yükler."
-    ID_REGISTRY_UNLOADHIVE "Kayıt Defteri'nden bir yığın kaldırır."
-    ID_REGISTRY_CONNECTNETWORKREGISTRY "Uzaktaki bir bilgisayarın Kayıt Defteri'ne bağlanır."
-    ID_REGISTRY_DISCONNECTNETWORKREGISTRY "Uzaktaki bir bilgisayarın Kayıt Defteri'ne olan bağlantıyı keser."
-    ID_REGISTRY_PRINT "Kayıt Defteri'nin tümünü ya da bir bölümünü yazdırır."
-/*  ID_HELP_HELPTOPICS "Kayıt Defteri Düzenleyicisi Yardımı'nı açar."  */
-    ID_HELP_ABOUT "Programla ilgili bilgi, sürüm numarası ve telif hakkı görüntüler."
+    ID_EDIT_MODIFY "Değerin verisini değiştirir"
+    ID_EDIT_NEW_KEY "Yeni bir anahtar ekler"
+    ID_EDIT_NEW_STRINGVALUE "Yeni bir dizi değeri ekler"
+    ID_EDIT_NEW_BINARYVALUE "Yeni bir ikili değer ekler"
+    ID_EDIT_NEW_DWORDVALUE "Yeni bir DWORD değeri ekler"
+    ID_REGISTRY_IMPORTREGISTRYFILE "Bir metin dosyasını Kayıt Defteri'ne alır"
+    ID_REGISTRY_EXPORTREGISTRYFILE "Kayıt Defteri'nin tümünü ya da bir bölümünü bir metin dosyasına verir"
+    ID_REGISTRY_LOADHIVE "Kayıt Defteri'ne bir yığın dosyasını yükler"
+    ID_REGISTRY_UNLOADHIVE "Kayıt Defteri'nden bir yığın kaldırır"
+    ID_REGISTRY_CONNECTNETWORKREGISTRY "Uzaktaki bir bilgisayarın Kayıt Defteri'ne bağlanır"
+    ID_REGISTRY_DISCONNECTNETWORKREGISTRY "Uzaktaki bir bilgisayarın Kayıt Defteri'ne olan bağlantıyı keser"
+    ID_REGISTRY_PRINT "Kayıt Defteri'nin tümünü ya da bir bölümünü yazdırır"
+//  ID_HELP_HELPTOPICS "Kayıt Defteri Düzenleyicisi Yardımı'nı açar"
+    ID_HELP_ABOUT "Programla ilgili bilgi, sürüm numarası ve telif hakkı görüntüler"
 END
 
 STRINGTABLE
 BEGIN
-    ID_REGISTRY_EXIT "Kayıt Defteri Düzenleyicisi'nden çıkar."
-    ID_FAVOURITES_ADDTOFAVOURITES "Anahtarları yer imleri listesine ekler."
-    ID_FAVOURITES_REMOVEFAVOURITE "Anahtarları yer imleri listesinden kaldırır."
-    ID_VIEW_STATUSBAR "Durum çubuğunu gösterir ya da gizler."
-    ID_VIEW_SPLIT "İki levha arasındaki ayırıcının konumunu değiştirir."
-    ID_VIEW_REFRESH "Pencereyi yeniler."
-    ID_EDIT_DELETE "Seçileni siler."
-    ID_EDIT_RENAME "Seçilenin adını değiştirir."
-    ID_EDIT_COPYKEYNAME "Seçilen anahtarın adını panoya çoğaltır."
-    ID_EDIT_FIND "Bir dizeyi anahtarların adlarında, değer adlarında veya değer verilerinde arar."
-    ID_EDIT_FINDNEXT "Önceki aramada belirtilmiş metni sonraki aramada arar."
+    ID_REGISTRY_EXIT "Kayıt Defteri Düzenleyicisi'nden çıkar"
+    ID_FAVOURITES_ADDTOFAVOURITES "Anahtarları yer imleri listesine ekler"
+    ID_FAVOURITES_REMOVEFAVOURITE "Anahtarları yer imleri listesinden kaldırır"
+    ID_VIEW_STATUSBAR "Durum çubuğunu gösterir ya da gizler"
+    ID_VIEW_SPLIT "İki levha arasındaki ayırıcının konumunu değiştirir"
+    ID_VIEW_REFRESH "Pencereyi yeniler"
+    ID_EDIT_DELETE "Seçileni siler"
+    ID_EDIT_RENAME "Seçilenin adını değiştirir"
+    ID_EDIT_COPYKEYNAME "Seçilen anahtarın adını panoya çoğaltır"
+    ID_EDIT_FIND "Bir dizeyi anahtarların adlarında, değer adlarında veya değer verilerinde arar"
+    ID_EDIT_FINDNEXT "Önceki aramada belirtilmiş metni sonraki aramada arar"
 END
 
 STRINGTABLE
@@ -716,12 +716,3 @@ BEGIN
     DEFPUSHBUTTON "İptal", IDCANCEL, 93, 29, 45, 14
     LTEXT "Kayıt Defteri Aranıyor...", IDC_STATIC, 33, 12, 83, 8
 END
-
-/* String Table */
-/*
- *STRINGTABLE
- *BEGIN
- *    ID_HELP_HELPTOPICS "Kayıt Defteri Düzenleyicisi Yardımı'nı açar."
- *    ID_HELP_ABOUT "İzlenceyle ilgili bilgi, sürüm numarası ve telif hakkı görüntüler."
- *END
- */

--- a/base/applications/regedit/lang/uk-UA.rc
+++ b/base/applications/regedit/lang/uk-UA.rc
@@ -441,7 +441,7 @@ BEGIN
     ID_REGISTRY_CONNECTNETWORKREGISTRY "Підключається до реєстру віддаленого комп'ютера"
     ID_REGISTRY_DISCONNECTNETWORKREGISTRY "Відключається від реєстру віддаленого комп'ютера"
     ID_REGISTRY_PRINT "Друкує весь реєстр або його частину"
-/*    ID_HELP_HELPTOPICS "Відкриває довідку редактора реєстра" */
+//    ID_HELP_HELPTOPICS "Відкриває довідку редактора реєстра"
     ID_HELP_ABOUT "Відображає інформацію про програму, номер версії та авторство"
 END
 
@@ -716,12 +716,3 @@ BEGIN
     DEFPUSHBUTTON "Скасувати", IDCANCEL, 93, 29, 45, 14
     LTEXT "Пошук у реєстрі...", IDC_STATIC, 33, 12, 83, 8
 END
-
-/* String Table */
-/*
- *STRINGTABLE
- *BEGIN
- *    ID_HELP_HELPTOPICS "Відкриває довідку редактора реєстра."
- *    ID_HELP_ABOUT "Відображає інформацію про програму, номер версії, та авторські права."
- *END
- */

--- a/base/applications/regedit/lang/zh-CN.rc
+++ b/base/applications/regedit/lang/zh-CN.rc
@@ -427,45 +427,45 @@ END
 
 STRINGTABLE
 BEGIN
-    ID_REGISTRY_MENU "包含操作整个注册表的命令。"
-    ID_EDIT_MENU "包含编辑值或键的命令。"
-    ID_VIEW_MENU "包含定制注册表窗口的命令。"
-    ID_FAVOURITES_MENU "包含访问常用键时所用的命令。"
-    ID_HELP_MENU "包含显示帮助以及注册表编辑器有关信息的命令。"
-    ID_EDIT_NEW_MENU "包含创建新键或值的命令。"
+    ID_REGISTRY_MENU "包含操作整个注册表的命令"
+    ID_EDIT_MENU "包含编辑值或键的命令"
+    ID_VIEW_MENU "包含定制注册表窗口的命令"
+    ID_FAVOURITES_MENU "包含访问常用键时所用的命令"
+    ID_HELP_MENU "包含显示帮助以及注册表编辑器有关信息的命令"
+    ID_EDIT_NEW_MENU "包含创建新键或值的命令"
 END
 
 STRINGTABLE
 BEGIN
-    ID_EDIT_MODIFY "修改该值的数据。"
-    ID_EDIT_NEW_KEY "添加新键。"
-    ID_EDIT_NEW_STRINGVALUE "添加新字符串值。"
-    ID_EDIT_NEW_BINARYVALUE "添加新二进制值。"
-    ID_EDIT_NEW_DWORDVALUE "添加新 DWORD 值。"
-    ID_REGISTRY_IMPORTREGISTRYFILE "将文本文件导入到注册表中。"
-    ID_REGISTRY_EXPORTREGISTRYFILE "将注册表全部或部分导出到文件中。"
-    ID_REGISTRY_LOADHIVE "加載配置单元到注册表中。"
-    ID_REGISTRY_UNLOADHIVE "从注册表中卸載配置单元。"
-    ID_REGISTRY_CONNECTNETWORKREGISTRY "连接到远程计算机的注册表。"
-    ID_REGISTRY_DISCONNECTNETWORKREGISTRY "与远程计算机注册表断开连接。"
-    ID_REGISTRY_PRINT "打印所有或部分注册表。"
-/*    ID_HELP_HELPTOPICS "打开注册表编辑器帮助。" */
-    ID_HELP_ABOUT "显示程序信息、版本和版权。"
+    ID_EDIT_MODIFY "修改该值的数据"
+    ID_EDIT_NEW_KEY "添加新键"
+    ID_EDIT_NEW_STRINGVALUE "添加新字符串值"
+    ID_EDIT_NEW_BINARYVALUE "添加新二进制值"
+    ID_EDIT_NEW_DWORDVALUE "添加新 DWORD 值"
+    ID_REGISTRY_IMPORTREGISTRYFILE "将文本文件导入到注册表中"
+    ID_REGISTRY_EXPORTREGISTRYFILE "将注册表全部或部分导出到文件中"
+    ID_REGISTRY_LOADHIVE "加載配置单元到注册表中"
+    ID_REGISTRY_UNLOADHIVE "从注册表中卸載配置单元"
+    ID_REGISTRY_CONNECTNETWORKREGISTRY "连接到远程计算机的注册表"
+    ID_REGISTRY_DISCONNECTNETWORKREGISTRY "与远程计算机注册表断开连接"
+    ID_REGISTRY_PRINT "打印所有或部分注册表"
+//    ID_HELP_HELPTOPICS "打开注册表编辑器帮助"
+    ID_HELP_ABOUT "显示程序信息、版本和版权"
 END
 
 STRINGTABLE
 BEGIN
-    ID_REGISTRY_EXIT "退出注册表编辑器。"
-    ID_FAVOURITES_ADDTOFAVOURITES "将键添加到收藏夹列表中。"
-    ID_FAVOURITES_REMOVEFAVOURITE "将键从收藏夹列表中删除。"
-    ID_VIEW_STATUSBAR "显示或隐藏状态栏。"
-    ID_VIEW_SPLIT "改变两个面板的拆分位置。"
-    ID_VIEW_REFRESH "刷新窗口。"
-    ID_EDIT_DELETE "删除所选内容。"
-    ID_EDIT_RENAME "重命名选定内容。"
-    ID_EDIT_COPYKEYNAME "将选定键的名称复制到剪贴板上。"
-    ID_EDIT_FIND "在键、值或数据里找到文本字符串。"
-    ID_EDIT_FINDNEXT "继续查找上次搜索的文本。"
+    ID_REGISTRY_EXIT "退出注册表编辑器"
+    ID_FAVOURITES_ADDTOFAVOURITES "将键添加到收藏夹列表中"
+    ID_FAVOURITES_REMOVEFAVOURITE "将键从收藏夹列表中删除"
+    ID_VIEW_STATUSBAR "显示或隐藏状态栏"
+    ID_VIEW_SPLIT "改变两个面板的拆分位置"
+    ID_VIEW_REFRESH "刷新窗口"
+    ID_EDIT_DELETE "删除所选内容"
+    ID_EDIT_RENAME "重命名选定内容"
+    ID_EDIT_COPYKEYNAME "将选定键的名称复制到剪贴板上"
+    ID_EDIT_FIND "在键、值或数据里找到文本字符串"
+    ID_EDIT_FINDNEXT "继续查找上次搜索的文本"
 END
 
 STRINGTABLE
@@ -724,12 +724,3 @@ BEGIN
     DEFPUSHBUTTON "取消", IDCANCEL, 93, 29, 45, 14
     LTEXT "正在搜索注册表...", IDC_STATIC, 33, 12, 83, 8
 END
-
-/* String Table */
-/*
- *STRINGTABLE
- *BEGIN
- *    ID_HELP_HELPTOPICS "Opens Registry Editor Help."
- *    ID_HELP_ABOUT "Displays program information, version number, and copyright."
- *END
- */

--- a/base/applications/regedit/lang/zh-HK.rc
+++ b/base/applications/regedit/lang/zh-HK.rc
@@ -437,45 +437,45 @@ END
 
 STRINGTABLE
 BEGIN
-    ID_REGISTRY_MENU "包含與整個登錄工作相關的命令。"
-    ID_EDIT_MENU "包含編輯值或機碼的命令。"
-    ID_VIEW_MENU "包含自訂登錄視窗的命令。"
-    ID_FAVOURITES_MENU "包含訪問常用機碼時所用的命令。"
-    ID_HELP_MENU "包含顯示説明以及登錄編輯程式有關資訊的命令。"
-    ID_EDIT_NEW_MENU "包含新增機碼或值的命令。"
+    ID_REGISTRY_MENU "包含與整個登錄工作相關的命令"
+    ID_EDIT_MENU "包含編輯值或機碼的命令"
+    ID_VIEW_MENU "包含自訂登錄視窗的命令"
+    ID_FAVOURITES_MENU "包含訪問常用機碼時所用的命令"
+    ID_HELP_MENU "包含顯示説明以及登錄編輯程式有關資訊的命令"
+    ID_EDIT_NEW_MENU "包含新增機碼或值的命令"
 END
 
 STRINGTABLE
 BEGIN
-    ID_EDIT_MODIFY "修改該值的資料。"
-    ID_EDIT_NEW_KEY "新增新機碼。"
-    ID_EDIT_NEW_STRINGVALUE "新增新的字串值。"
-    ID_EDIT_NEW_BINARYVALUE "新增新二進制值。"
-    ID_EDIT_NEW_DWORDVALUE "新增新 DWORD 值。"
-    ID_REGISTRY_IMPORTREGISTRYFILE "將檔案匯入到登錄中。"
-    ID_REGISTRY_EXPORTREGISTRYFILE "將登錄全部或部分匯出到檔案中。"
-    ID_REGISTRY_LOADHIVE "載入 Hive 控制檔到登錄中。"
-    ID_REGISTRY_UNLOADHIVE "從登錄中解除載入 Hive 控制檔。"
-    ID_REGISTRY_CONNECTNETWORKREGISTRY "連線到遠端電腦的登錄。"
-    ID_REGISTRY_DISCONNECTNETWORKREGISTRY "斷開與遠端電腦登錄的連線。"
-    ID_REGISTRY_PRINT "列印所有或部分登錄。"
-/*    ID_HELP_HELPTOPICS "開啟登錄編輯程式説明。" */
-    ID_HELP_ABOUT "顯示程式資訊、版本號和版權。"
+    ID_EDIT_MODIFY "修改該值的資料"
+    ID_EDIT_NEW_KEY "新增新機碼"
+    ID_EDIT_NEW_STRINGVALUE "新增新的字串值"
+    ID_EDIT_NEW_BINARYVALUE "新增新二進制值"
+    ID_EDIT_NEW_DWORDVALUE "新增新 DWORD 值"
+    ID_REGISTRY_IMPORTREGISTRYFILE "將檔案匯入到登錄中"
+    ID_REGISTRY_EXPORTREGISTRYFILE "將登錄全部或部分匯出到檔案中"
+    ID_REGISTRY_LOADHIVE "載入 Hive 控制檔到登錄中"
+    ID_REGISTRY_UNLOADHIVE "從登錄中解除載入 Hive 控制檔"
+    ID_REGISTRY_CONNECTNETWORKREGISTRY "連線到遠端電腦的登錄"
+    ID_REGISTRY_DISCONNECTNETWORKREGISTRY "斷開與遠端電腦登錄的連線"
+    ID_REGISTRY_PRINT "列印所有或部分登錄"
+//    ID_HELP_HELPTOPICS "開啟登錄編輯程式説明"
+    ID_HELP_ABOUT "顯示程式資訊、版本號和版權"
 END
 
 STRINGTABLE
 BEGIN
-    ID_REGISTRY_EXIT "結束登錄編輯程式。"
-    ID_FAVOURITES_ADDTOFAVOURITES "將機碼新增到我的最愛列表中。"
-    ID_FAVOURITES_REMOVEFAVOURITE "將機碼從我的最愛列表中刪除。"
-    ID_VIEW_STATUSBAR "顯示或隱藏狀態列。"
-    ID_VIEW_SPLIT "變更兩個窗格之間的分隔線位置。"
-    ID_VIEW_REFRESH "重新整理視窗。"
-    ID_EDIT_DELETE "刪除已選取內容。"
-    ID_EDIT_RENAME "重新命名已選取內容。"
-    ID_EDIT_COPYKEYNAME "將已選取機碼的名稱複製到剪貼簿。"
-    ID_EDIT_FIND "在機碼、值或資料裡找到文字字串。"
-    ID_EDIT_FINDNEXT "繼續搜尋上次搜尋的文字。"
+    ID_REGISTRY_EXIT "結束登錄編輯程式"
+    ID_FAVOURITES_ADDTOFAVOURITES "將機碼新增到我的最愛列表中"
+    ID_FAVOURITES_REMOVEFAVOURITE "將機碼從我的最愛列表中刪除"
+    ID_VIEW_STATUSBAR "顯示或隱藏狀態列"
+    ID_VIEW_SPLIT "變更兩個窗格之間的分隔線位置"
+    ID_VIEW_REFRESH "重新整理視窗"
+    ID_EDIT_DELETE "刪除已選取內容"
+    ID_EDIT_RENAME "重新命名已選取內容"
+    ID_EDIT_COPYKEYNAME "將已選取機碼的名稱複製到剪貼簿"
+    ID_EDIT_FIND "在機碼、值或資料裡找到文字字串"
+    ID_EDIT_FINDNEXT "繼續搜尋上次搜尋的文字"
 END
 
 STRINGTABLE
@@ -734,12 +734,3 @@ BEGIN
     DEFPUSHBUTTON "取消", IDCANCEL, 93, 29, 45, 14
     LTEXT "正在搜尋登錄...", IDC_STATIC, 33, 12, 83, 8
 END
-
-/* String Table */
-/*
- *STRINGTABLE
- *BEGIN
- *    ID_HELP_HELPTOPICS "開啟登錄編輯程式説明。"
- *    ID_HELP_ABOUT "顯示程式資訊、版本號碼和版權。"
- *END
- */

--- a/base/applications/regedit/lang/zh-TW.rc
+++ b/base/applications/regedit/lang/zh-TW.rc
@@ -426,45 +426,45 @@ END
 
 STRINGTABLE
 BEGIN
-    ID_REGISTRY_MENU "包含與整個登錄工作相關的命令。"
-    ID_EDIT_MENU "包含編輯值或機碼的命令。"
-    ID_VIEW_MENU "包含自訂登錄視窗的命令。"
-    ID_FAVOURITES_MENU "包含訪問常用機碼時所用的命令。"
-    ID_HELP_MENU "包含顯示說明以及登錄編輯程式有關資訊的命令。"
-    ID_EDIT_NEW_MENU "包含新增機碼或值的命令。"
+    ID_REGISTRY_MENU "包含與整個登錄工作相關的命令"
+    ID_EDIT_MENU "包含編輯值或機碼的命令"
+    ID_VIEW_MENU "包含自訂登錄視窗的命令"
+    ID_FAVOURITES_MENU "包含訪問常用機碼時所用的命令"
+    ID_HELP_MENU "包含顯示說明以及登錄編輯程式有關資訊的命令"
+    ID_EDIT_NEW_MENU "包含新增機碼或值的命令"
 END
 
 STRINGTABLE
 BEGIN
-    ID_EDIT_MODIFY "修改該值的資料。"
-    ID_EDIT_NEW_KEY "新增新的機碼。"
-    ID_EDIT_NEW_STRINGVALUE "新增新的字元串值。"
-    ID_EDIT_NEW_BINARYVALUE "新增新的二進制值。"
-    ID_EDIT_NEW_DWORDVALUE "新增新的 DWORD 值。"
-    ID_REGISTRY_IMPORTREGISTRYFILE "將檔案匯入到登錄中。"
-    ID_REGISTRY_EXPORTREGISTRYFILE "將登錄全部或部分匯出到檔案中。"
-    ID_REGISTRY_LOADHIVE "載入 Hive 控制檔到登錄中。"
-    ID_REGISTRY_UNLOADHIVE "從登錄中卸載 Hive 控制檔。"
-    ID_REGISTRY_CONNECTNETWORKREGISTRY "連線到遠端電腦的登錄。"
-    ID_REGISTRY_DISCONNECTNETWORKREGISTRY "斷開與遠端電腦登錄的連線。"
-    ID_REGISTRY_PRINT "列印所有或部分登錄。"
-/*    ID_HELP_HELPTOPICS "開啟登錄編輯程式說明。" */
-    ID_HELP_ABOUT "顯示程式資訊、版本號和著作權。"
+    ID_EDIT_MODIFY "修改該值的資料"
+    ID_EDIT_NEW_KEY "新增新的機碼"
+    ID_EDIT_NEW_STRINGVALUE "新增新的字元串值"
+    ID_EDIT_NEW_BINARYVALUE "新增新的二進制值"
+    ID_EDIT_NEW_DWORDVALUE "新增新的 DWORD 值"
+    ID_REGISTRY_IMPORTREGISTRYFILE "將檔案匯入到登錄中"
+    ID_REGISTRY_EXPORTREGISTRYFILE "將登錄全部或部分匯出到檔案中"
+    ID_REGISTRY_LOADHIVE "載入 Hive 控制檔到登錄中"
+    ID_REGISTRY_UNLOADHIVE "從登錄中卸載 Hive 控制檔"
+    ID_REGISTRY_CONNECTNETWORKREGISTRY "連線到遠端電腦的登錄"
+    ID_REGISTRY_DISCONNECTNETWORKREGISTRY "斷開與遠端電腦登錄的連線"
+    ID_REGISTRY_PRINT "列印所有或部分登錄"
+//    ID_HELP_HELPTOPICS "開啟登錄編輯程式說明"
+    ID_HELP_ABOUT "顯示程式資訊、版本號和著作權"
 END
 
 STRINGTABLE
 BEGIN
-    ID_REGISTRY_EXIT "結束登錄編輯程式。"
-    ID_FAVOURITES_ADDTOFAVOURITES "將機碼新增到我的最愛列表中。"
-    ID_FAVOURITES_REMOVEFAVOURITE "將機碼從我的最愛列表中刪除。"
-    ID_VIEW_STATUSBAR "顯示或隱藏狀態列。"
-    ID_VIEW_SPLIT "變更兩個窗格之間的分隔線位置。"
-    ID_VIEW_REFRESH "重新整理視窗。"
-    ID_EDIT_DELETE "刪除已選取內容。"
-    ID_EDIT_RENAME "重新命名已選取內容。"
-    ID_EDIT_COPYKEYNAME "將已選取機碼的名稱複製到剪貼簿。"
-    ID_EDIT_FIND "在機碼、值或資料裡找到文字字串。"
-    ID_EDIT_FINDNEXT "繼續搜尋上次搜尋的文字。"
+    ID_REGISTRY_EXIT "結束登錄編輯程式"
+    ID_FAVOURITES_ADDTOFAVOURITES "將機碼新增到我的最愛列表中"
+    ID_FAVOURITES_REMOVEFAVOURITE "將機碼從我的最愛列表中刪除"
+    ID_VIEW_STATUSBAR "顯示或隱藏狀態列"
+    ID_VIEW_SPLIT "變更兩個窗格之間的分隔線位置"
+    ID_VIEW_REFRESH "重新整理視窗"
+    ID_EDIT_DELETE "刪除已選取內容"
+    ID_EDIT_RENAME "重新命名已選取內容"
+    ID_EDIT_COPYKEYNAME "將已選取機碼的名稱複製到剪貼簿"
+    ID_EDIT_FIND "在機碼、值或資料裡找到文字字串"
+    ID_EDIT_FINDNEXT "繼續搜尋上次搜尋的文字"
 END
 
 STRINGTABLE
@@ -723,12 +723,3 @@ BEGIN
     DEFPUSHBUTTON "取消", IDCANCEL, 93, 29, 45, 14
     LTEXT "正在搜尋登錄...", IDC_STATIC, 33, 12, 83, 8
 END
-
-/* String Table */
-/*
- *STRINGTABLE
- *BEGIN
- *    ID_HELP_HELPTOPICS "開啟登錄編輯程式說明。"
- *    ID_HELP_ABOUT "顯示程式資訊、版本號碼和著作權。"
- *END
- */


### PR DESCRIPTION

ID_HELP_HELPTOPICS & ID_HELP_ABOUT are statusbar helptexts, and they do exist twice for no good reason since 10+ years. Dedupe that.

Also add a few missing accelerators for it-IT.rc

Also strip the trailing dots for some languages for the statusbar helptexts (5 langs: ja-JP,tr-TR,zh-*) Vast majority of languages did not have them at all (24 languages). Also en-US was such a good role-model.

Some had it just for some of those texts, but for others not (e.g. pt-PT). Inconsistent.

All statusbar helptexts are within those exact 3 STRINGTABLEs now.

JIRA issue: none
