### PR TITLE
[NTUSER] Use co_UserActivateKeyboardLayout in loading

### DIFF
--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -722,7 +722,7 @@ co_UserActivateKeyboardLayout(
         ClientInfo->hKL = pKL->hkl;
     }
 
-    // Send shell message if necessary
+    /* Send shell message if necessary */
     if (gptiForeground && (gptiForeground->ppi == pti->ppi) && ISITHOOKED(WH_SHELL))
     {
         if (ghKLSentToShell != pKL->hkl) // Already sent HKL?

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -667,7 +667,7 @@ HKL APIENTRY
 co_UserActivateKeyboardLayout(
     _Inout_ PKL     pKL,
     _In_    ULONG   uFlags,
-    _Inout_opt_ PWND pWnd)
+    _In_opt_ PWND pWnd)
 {
     HKL hOldKL = NULL;
     PKL pOldKL;
@@ -783,7 +783,7 @@ co_IntActivateKeyboardLayout(
     _Inout_ PWINSTATION_OBJECT pWinSta,
     _In_ HKL hKL,
     _In_ ULONG uFlags,
-    _Inout_opt_ PWND pWnd)
+    _In_opt_ PWND pWnd)
 {
     PKL pKL;
     PTHREADINFO pti = PsGetCurrentThreadWin32Thread();

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -725,7 +725,8 @@ co_UserActivateKeyboardLayout(
     /* Send shell message if necessary */
     if (gptiForeground && (gptiForeground->ppi == pti->ppi) && ISITHOOKED(WH_SHELL))
     {
-        if (ghKLSentToShell != pKL->hkl) // Already sent HKL?
+        /* Send the HKL if needed and remember it */
+        if (ghKLSentToShell != pKL->hkl)
         {
             co_IntShellHookNotify(HSHELL_LANGUAGE, 0, (LPARAM)pKL->hkl);
             ghKLSentToShell = pKL->hkl; // Remember

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -729,7 +729,7 @@ co_UserActivateKeyboardLayout(
         if (ghKLSentToShell != pKL->hkl)
         {
             co_IntShellHookNotify(HSHELL_LANGUAGE, 0, (LPARAM)pKL->hkl);
-            ghKLSentToShell = pKL->hkl; // Remember
+            ghKLSentToShell = pKL->hkl;
         }
     }
 


### PR DESCRIPTION
## Purpose

Refactoring on keyboard layout.
JIRA issue: [CORE-19268](https://jira.reactos.org/browse/CORE-19268)

## Proposed changes

- Delete `co_UserActivateKbl` function.
- Use `co_UserActivateKeyboardLayout` function instead of `co_UserActivateKbl` in `co_IntLoadKeyboardLayoutEx` function.
- Improve `co_UserActivateKeyboardLayout`.

## TODO

- [x] Do tests.
