### PR TITLE
[BROWSEUI][SHELL32] Fix shell path parsing

### DIFF
--- a/dll/win32/browseui/aclistisf.cpp
+++ b/dll/win32/browseui/aclistisf.cpp
@@ -254,7 +254,7 @@ STDMETHODIMP CACListISF::Next(ULONG celt, LPOLESTR *rgelt, ULONG *pceltFetched)
             LPCITEMIDLIST pidlRef = pidlChild;
             hr = m_pShellFolder->GetAttributesOf(1, &pidlRef, &attrs);
             if (FAILED_UNEXPECTEDLY(hr))
-                return hr;
+                continue;
 
             if ((m_dwOptions & ACLO_FILESYSDIRS) && !(attrs & SFGAO_FOLDER))
                 continue;

--- a/dll/win32/browseui/aclistisf.cpp
+++ b/dll/win32/browseui/aclistisf.cpp
@@ -147,13 +147,10 @@ HRESULT CACListISF::SetLocation(LPITEMIDLIST pidl)
         ERR("EnumObjects failed: 0x%lX\n", hr);
         hr = E_FAIL;
     }
-
     return hr;
 }
 
-HRESULT CACListISF::GetDisplayName(
-    _In_ LPCITEMIDLIST pidlChild,
-    _Out_ CComHeapPtr<WCHAR>& pszChild)
+HRESULT CACListISF::GetDisplayName(LPCITEMIDLIST pidlChild, CComHeapPtr<WCHAR>& pszChild)
 {
     TRACE("(%p, %p)\n", this, pidlChild);
     pszChild.Free();
@@ -245,7 +242,6 @@ STDMETHODIMP CACListISF::Next(ULONG celt, LPOLESTR *rgelt, ULONG *pceltFetched)
 
             pszRawPath.Free();
             pszExpanded.Free();
-
             GetPaths(pidlChild, pszRawPath, pszExpanded);
             if (!pszRawPath || !pszExpanded)
                 continue;
@@ -350,11 +346,11 @@ STDMETHODIMP CACListISF::Expand(LPCOLESTR pszExpand)
         if (PathIsRelativeW(pszExpand) &&
             SHGetPathFromIDListW(m_pidlCurDir, szPath1) &&
             PathCombineW(szPath2, szPath1, pszExpand) &&
-            PathFileExistsW(pszExpand))
+            PathFileExistsW(szPath2))
         {
             pszExpand = szPath2;
         }
-        if (PathFileExistsW(pszExpand))
+        else if (PathFileExistsW(pszExpand))
         {
             GetFullPathNameW(pszExpand, _countof(szPath1), szPath1, NULL);
             pszExpand = szPath1;

--- a/dll/win32/browseui/aclistisf.h
+++ b/dll/win32/browseui/aclistisf.h
@@ -57,12 +57,9 @@ public:
 
     HRESULT NextLocation();
     HRESULT SetLocation(LPITEMIDLIST pidl);
-    HRESULT GetDisplayName(
-        _In_ LPCITEMIDLIST pidlChild,
-        _Out_ CComHeapPtr<WCHAR>& pszChild,
-        _Inout_ DWORD& attrs);
+    HRESULT GetDisplayName(LPCITEMIDLIST pidlChild, CComHeapPtr<WCHAR>& pszChild);
     HRESULT GetPaths(LPCITEMIDLIST pidlChild, CComHeapPtr<WCHAR>& pszRaw,
-                     CComHeapPtr<WCHAR>& pszExpanded, DWORD& attrs);
+                     CComHeapPtr<WCHAR>& pszExpanded);
 
     // *** IEnumString methods ***
     STDMETHOD(Next)(ULONG celt, LPOLESTR *rgelt, ULONG *pceltFetched) override;

--- a/dll/win32/browseui/aclistisf.h
+++ b/dll/win32/browseui/aclistisf.h
@@ -57,9 +57,12 @@ public:
 
     HRESULT NextLocation();
     HRESULT SetLocation(LPITEMIDLIST pidl);
-    HRESULT GetDisplayName(LPCITEMIDLIST pidlChild, CComHeapPtr<WCHAR>& pszChild);
+    HRESULT GetDisplayName(
+        _In_ LPCITEMIDLIST pidlChild,
+        _Out_ CComHeapPtr<WCHAR>& pszChild,
+        _Inout_ DWORD& attrs);
     HRESULT GetPaths(LPCITEMIDLIST pidlChild, CComHeapPtr<WCHAR>& pszRaw,
-                     CComHeapPtr<WCHAR>& pszExpanded);
+                     CComHeapPtr<WCHAR>& pszExpanded, DWORD& attrs);
 
     // *** IEnumString methods ***
     STDMETHOD(Next)(ULONG celt, LPOLESTR *rgelt, ULONG *pceltFetched) override;

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -1866,7 +1866,7 @@ INT Shell_ParseSpecialFolder(_In_ LPCWSTR pszStart, _Out_ LPWSTR *ppch, _Out_ IN
     {
         *ppch = (LPWSTR)(pchBackslash + 1);
         *pcch = (pchBackslash - pszStart) + 1;
-        StrCpyNW(szPath, pszStart, max(*pcch, _countof(szPath)));
+        StrCpyNW(szPath, pszStart, min(*pcch, _countof(szPath)));
         pszPath = szPath;
     }
     else


### PR DESCRIPTION
## Purpose

Fix shell path parsing.
JIRA issue: [CORE-19693](https://jira.reactos.org/browse/CORE-19693)
JIRA issue: [CORE-19694](https://jira.reactos.org/browse/CORE-19694)

## Proposed changes

- Fix `CACListISF` class by using PIDL attributes.
- Use `min` macro instead of `max` macro in `Shell_ParseSpecialFolder` function.

## TODO

- [x] Do tests.

## Comparison

BEFORE:
![before](https://github.com/user-attachments/assets/16f75fdf-cf2a-41b9-a206-0d861adb0a3a)
10 failures.

AFTER:
![after](https://github.com/user-attachments/assets/9cdd6d74-4811-4614-83f4-f372ea64e243)
6 failures.

AFTER:
![after2](https://github.com/user-attachments/assets/940635cb-6d5c-4476-b237-d178f0d0fd9b)
Able to open `"shell:windows\fonts"`.

AFTER:
![after3](https://github.com/user-attachments/assets/3271ff09-b1b5-4747-b8ae-ef6186a9ccb2)
AutoComplete is working on `shell:windows\system32\`.