### PR TITLE
[SHELL32] shlexec: Do not expand without SEE_MASK_DOENVSUBST

### DIFF
--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -2154,16 +2154,6 @@ static BOOL SHELL_execute(LPSHELLEXECUTEINFOW sei, SHELL_ExecuteW32 execfunc)
         wszApplicationName.Attach(buf.Detach());
         sei_tmp.lpFile = wszApplicationName;
     }
-    else /* or expand environment strings (not both!) */
-    {
-        LPWSTR tmp = expand_environment(sei_tmp.lpFile);
-        if (tmp)
-        {
-            wszApplicationName.Attach(tmp);
-            /* appKnownSingular unmodified */
-            sei_tmp.lpFile = wszApplicationName;
-        }
-    }
 
     /* Else, try to execute the filename */
     TRACE("execute: %s,%s,%s\n", debugstr_w(wszApplicationName), debugstr_w(wszParameters), debugstr_w(wszDir));

--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -2066,7 +2066,7 @@ static BOOL SHELL_execute(LPSHELLEXECUTEINFOW sei, SHELL_ExecuteW32 execfunc)
         TRACE("-- idlist=%p (%s)\n", sei_tmp.lpIDList, debugstr_w(wszApplicationName));
     }
 
-    if ((sei_tmp.fMask & SEE_MASK_DOENVSUBST) && sei_tmp.lpFile && sei_tmp.lpFile[0])
+    if ((sei_tmp.fMask & SEE_MASK_DOENVSUBST) && !StrIsNullOrEmpty(sei_tmp.lpFile))
     {
         WCHAR *tmp = expand_environment(sei_tmp.lpFile);
         if (tmp)

--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -2066,20 +2066,13 @@ static BOOL SHELL_execute(LPSHELLEXECUTEINFOW sei, SHELL_ExecuteW32 execfunc)
         TRACE("-- idlist=%p (%s)\n", sei_tmp.lpIDList, debugstr_w(wszApplicationName));
     }
 
-    if (sei_tmp.fMask & SEE_MASK_DOENVSUBST)
+    if ((sei_tmp.fMask & SEE_MASK_DOENVSUBST) && sei_tmp.lpFile && sei_tmp.lpFile[0])
     {
         WCHAR *tmp = expand_environment(sei_tmp.lpFile);
         if (tmp)
         {
             wszApplicationName.Attach(tmp);
             sei_tmp.lpFile = wszApplicationName;
-        }
-
-        tmp = expand_environment(sei_tmp.lpDirectory);
-        if (tmp)
-        {
-            wszDirAlloc.Attach(tmp);
-            sei_tmp.lpDirectory = wszDir = wszDirAlloc;
         }
     }
 
@@ -2092,7 +2085,6 @@ static BOOL SHELL_execute(LPSHELLEXECUTEINFOW sei, SHELL_ExecuteW32 execfunc)
             return TRUE;
         }
     }
-
 
     if (ERROR_SUCCESS == ShellExecute_FromContextMenuHandlers(&sei_tmp))
     {


### PR DESCRIPTION
## Purpose

JIRA issue: N/A

## Proposed changes

- Don't expand the application name unless `SEE_MASK_DOENVSUBST` is not specified.
