### PR TITLE
[DESK] Fix 3dtext screensaver restart high CPU usage after opening settings

### DIFF
--- a/dll/cpl/desk/screensaver.c
+++ b/dll/cpl/desk/screensaver.c
@@ -223,7 +223,7 @@ SetScreenSaverPreviewBox(HWND hwndDlg, PDATA pData)
     }
 }
 
-static BOOL
+static VOID
 WaitForSettingsDialog(HWND hwndDlg,
                       HANDLE hProcess)
 {
@@ -243,22 +243,18 @@ WaitForSettingsDialog(HWND hwndDlg,
             {
                 if (msg.message == WM_QUIT)
                 {
-                    return FALSE;
+                    return;
                 }
-                if (IsDialogMessage(hwndDlg, &msg))
+                if (!IsDialogMessage(hwndDlg, &msg))
                 {
                     TranslateMessage(&msg);
                     DispatchMessage(&msg);
                 }
             }
         }
-        else if (dwResult == WAIT_OBJECT_0)
-        {
-            return TRUE;
-        }
         else
         {
-            return FALSE;
+            return;
         }
     }
 }
@@ -308,8 +304,8 @@ ScreenSaverConfig(HWND hwndDlg, PDATA pData)
             pData->PrevWindowPi.hThread = pData->PrevWindowPi.hProcess = NULL;
         }
 
-        if (WaitForSettingsDialog(hwndDlg, pi.hProcess))
-            SetScreenSaverPreviewBox(hwndDlg, pData);
+        WaitForSettingsDialog(hwndDlg, pi.hProcess);
+        SetScreenSaverPreviewBox(hwndDlg, pData);
 
         CloseHandle(pi.hProcess);
         CloseHandle(pi.hThread);


### PR DESCRIPTION
Partial I_Kill_Bugs fix.

## Purpose

_Fix high CPU usage for 3dtext screensaver after calling 'settings'._
_Fix small screensaver preview not restarting after calling 'settings'._
_Fix changed settings not displaying new 'settings' value upon return from 'settings'._

JIRA issue: [CORE-18745](https://jira.reactos.org/browse/CORE-18745)

## Proposed changes

_Change function type of WaitForSettingsDialog to VOID._
_Always call function SetScreenSaverPreviewBox after calling 'settings'._
_Fix IsDialogMessage call to test for its negative return in the message loop._
_+ This last fix is courtesy of I_Kill_Bugs._