### PR TITLE
[NTUSER] Optimize BroadcastSystemMessage a bit. Follow-up of #6884

### DIFF
--- a/win32ss/user/ntuser/message.c
+++ b/win32ss/user/ntuser/message.c
@@ -453,7 +453,7 @@ CopyMsgToKernelMem(MSG *KernelModeMsg, MSG *UserModeMsg, PMSGMEMORY MsgMemoryEnt
     NTSTATUS Status;
 
     PVOID KernelMem;
-    UINT Size, i;
+    UINT Size;
 
     *KernelModeMsg = *UserModeMsg;
 
@@ -497,15 +497,8 @@ CopyMsgToKernelMem(MSG *KernelModeMsg, MSG *UserModeMsg, PMSGMEMORY MsgMemoryEnt
                 }
                 _SEH2_END;
 
-                /* Make sure that the last WCHAR is a UNICODE_NULL */
-                for (i = 0; i < ARRAYSIZE(lParamMsg); ++i)
-                {
-                    if (lParamMsg[i] == 0)
-                        break;
-                }
-                /* If we did not find a UNICODE_NULL, then set last WCHAR to one */
-                if (i == ARRAYSIZE(lParamMsg))
-                    lParamMsg[_countof(StrUserKernel[0])] = UNICODE_NULL;
+                /* Make sure that we have a UNICODE_NULL within lParamMsg */
+                lParamMsg[_countof(StrUserKernel[0])] = UNICODE_NULL;
 
                 if (!UserModeMsg->wParam && PosInArray(lParamMsg) >= 0)
                 {

--- a/win32ss/user/ntuser/message.c
+++ b/win32ss/user/ntuser/message.c
@@ -483,8 +483,10 @@ CopyMsgToKernelMem(MSG *KernelModeMsg, MSG *UserModeMsg, PMSGMEMORY MsgMemoryEnt
         {
             TRACE("Copy Message %u from usermode buffer\n", KernelModeMsg->message);
             /* Don't do extra testing for 1 word messages. For examples see
-             * https://wiki.winehq.org/List_Of_Windows_Messages. */
-            if ((Size > 1) && UserModeMsg->lParam)
+             * https://wiki.winehq.org/List_Of_Windows_Messages and
+             * we are just handling WM_WININICHANGE here. */
+            if (Size > 1 && UserModeMsg->lParam &&
+                KernelModeMsg->message == WM_WININICHANGE)
             {
                 WCHAR lParamMsg[_countof(StrUserKernel[0]) + 1] = { 0 };
                 _SEH2_TRY
@@ -498,7 +500,7 @@ CopyMsgToKernelMem(MSG *KernelModeMsg, MSG *UserModeMsg, PMSGMEMORY MsgMemoryEnt
                 _SEH2_END;
 
                 /* Make sure that we have a UNICODE_NULL within lParamMsg */
-                lParamMsg[_countof(StrUserKernel[0])] = UNICODE_NULL;
+                lParamMsg[ARRAYSIZE(lParamMsg) - 1] = UNICODE_NULL;
 
                 if (!UserModeMsg->wParam && PosInArray(lParamMsg) >= 0)
                 {


### PR DESCRIPTION
## Purpose

_Optimize BroadcastSystemMessage with Environment parameter._

JIRA issue: [CORE-19372](https://jira.reactos.org/browse/CORE-19372)

## Proposed changes

_Minimize processing when UserModeMsg->lParam is NULL and KernelModeMsg->message != WM_WININICHANGE._
_Follow-up of #6884._