### PR TITLE
[NTUSER] Fix popup menu placement when part way off right edge of screen

### DIFF
--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -2988,10 +2988,6 @@ static BOOL FASTCALL MENU_ShowPopup(PWND pwndOwner, PMENU menu, UINT id, UINT fl
     DebugPoint(x, y, RGB(0, 0, 255));
 #endif
     monitor = UserMonitorFromPoint( ptx, MONITOR_DEFAULTTONEAREST );
-    TRACE("RECT is (%d,%d)-(%d,%d)\n", monitor->rcMonitor.left,
-          monitor->rcMonitor.top, monitor->rcMonitor.right, monitor->rcMonitor.bottom);
-    /* The above shows 'RECT is (0,0)-(800,600)' for an 800x600 pixel screen.
-     * So the x and y values in this case start at 0 and end at 799 and 599. */
 
     /* We are off the right side of the screen */
     if (x + width > monitor->rcMonitor.right)

--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -2988,18 +2988,22 @@ static BOOL FASTCALL MENU_ShowPopup(PWND pwndOwner, PMENU menu, UINT id, UINT fl
     DebugPoint(x, y, RGB(0, 0, 255));
 #endif
     monitor = UserMonitorFromPoint( ptx, MONITOR_DEFAULTTONEAREST );
+    TRACE("RECT is (%d,%d)-(%d,%d)\n", monitor->rcMonitor.left,
+          monitor->rcMonitor.top, monitor->rcMonitor.right, monitor->rcMonitor.bottom);
+    /* The above shows 'RECT is (0,0)-(800,600)' for an 800x600 pixel screen.
+     * So the x and y values in this case start at 0 and end at 799 and 599. */
 
     /* We are off the right side of the screen */
     if (x + width > monitor->rcMonitor.right)
     {
-        /* Position menu at right edge of screen */
-        x = monitor->rcMonitor.right - width + 1;
+        /* Position menu at right edge of the screen */
+        x = monitor->rcMonitor.right - width;
     }
 
     /* We are off the left side of the screen */
     if (x < monitor->rcMonitor.left)
     {
-        /* Position menu at left edge of screen */
+        /* Position menu at left edge of the screen */
         x = 0;
 
         if (x < monitor->rcMonitor.left || x >= monitor->rcMonitor.right || bIsPopup)

--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -2992,10 +2992,8 @@ static BOOL FASTCALL MENU_ShowPopup(PWND pwndOwner, PMENU menu, UINT id, UINT fl
     /* We are off the right side of the screen */
     if (x + width > monitor->rcMonitor.right)
     {
-        if ((x - width) < monitor->rcMonitor.left || x >= monitor->rcMonitor.right)
-            x = monitor->rcMonitor.right - width;
-        else
-            x -= width;
+        /* Position menu at right edge of screen */
+        x = monitor->rcMonitor.right - width;
     }
 
     /* We are off the left side of the screen */

--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -2993,7 +2993,7 @@ static BOOL FASTCALL MENU_ShowPopup(PWND pwndOwner, PMENU menu, UINT id, UINT fl
     if (x + width > monitor->rcMonitor.right)
     {
         /* Position menu at right edge of screen */
-        x = monitor->rcMonitor.right - width;
+        x = monitor->rcMonitor.right - width + 1;
     }
 
     /* We are off the left side of the screen */


### PR DESCRIPTION
## Purpose

_Fix popup menu placement when menu is part way off right edge of screen._

JIRA issue: [CORE-19706](https://jira.reactos.org/browse/CORE-19706)

## Proposed changes

_Revise calculation of MENU_ShowPopup in menu.c._