### PR TITLE
[NTOS:MM] Implement MmProbeAndLockProcessPages

### DIFF
--- a/ntoskrnl/mm/ARM3/mdlsup.c
+++ b/ntoskrnl/mm/ARM3/mdlsup.c
@@ -1671,19 +1671,59 @@ MmProtectMdlSystemAddress(IN PMDL MemoryDescriptorList,
     return STATUS_NOT_IMPLEMENTED;
 }
 
-/*
- * @unimplemented
+/**
+ * @brief
+ * Probes and locks virtual pages in memory for the specified process.
+ *
+ * @param[in,out] MemoryDescriptorList
+ * Memory Descriptor List (MDL) containing the buffer to be probed and locked.
+ *
+ * @param[in] Process
+ * The process for which the buffer should be probed and locked.
+ *
+ * @param[in] AccessMode
+ * Access mode for probing the pages. Can be KernelMode or UserMode.
+ *
+ * @param[in] LockOperation
+ * The type of the probing and locking operation. Can be IoReadAccess, IoWriteAccess or IoModifyAccess.
+ *
+ * @return
+ * Nothing.
+ *
+ * @see MmProbeAndLockPages
+ *
+ * @remarks Must be called at IRQL <= APC_LEVEL
  */
+_IRQL_requires_max_(APC_LEVEL)
 VOID
 NTAPI
-MmProbeAndLockProcessPages(IN OUT PMDL MemoryDescriptorList,
-                           IN PEPROCESS Process,
-                           IN KPROCESSOR_MODE AccessMode,
-                           IN LOCK_OPERATION Operation)
+MmProbeAndLockProcessPages(
+    _Inout_ PMDL MemoryDescriptorList,
+    _In_ PEPROCESS Process,
+    _In_ KPROCESSOR_MODE AccessMode,
+    _In_ LOCK_OPERATION Operation)
 {
-    UNIMPLEMENTED;
-}
+    KAPC_STATE ApcState;
+    BOOLEAN IsAttached = FALSE;
 
+    if (Process != PsGetCurrentProcess())
+    {
+        KeStackAttachProcess(&Process->Pcb, &ApcState);
+        IsAttached = TRUE;
+    }
+
+    /* Protect in try/finally to ensure we detach even if MmProbeAndLockPages() throws an exception */
+    _SEH2_TRY
+    {
+        MmProbeAndLockPages(MemoryDescriptorList, AccessMode, Operation);
+    }
+    _SEH2_FINALLY
+    {
+        if (IsAttached)
+            KeUnstackDetachProcess(&ApcState);
+    }
+    _SEH2_END;
+}
 
 /*
  * @unimplemented


### PR DESCRIPTION
## Purpose

Implement undocumented `MmProbeAndLockProcessPages` routine. Based on mm-implement-mappingaddress.patch by @ThFabba from [CORE-10147](https://jira.reactos.org/browse/10147), with some improvements from me.
Split from my old #3654 PR.
It's badly required by FltMgr.sys driver from Windows XP/Server 2003 and closely used by a lot of apps those are depending on this driver (e. g., Avast Free Antivirus several versions, Avira Antivir Personal 8.2 etc. etc.).
Fixes several asserts from MDL support routines when the 3rd-party minifilter drivers are loading FltMgr.

JIRA issue: [CORE-14157](https://jira.reactos.org/browse/CORE-14157)

## Proposed changes

Implement `MmProbeAndLockProcessPages` as follows:

- First check whether an input `EPROCESS` points to the current process, and if so, attach it to the stack.
- Then, call the normal `MmProbeAndLockPages` routine inside a try block.
- After that, detach the process from the stack in case it was previously attached.
- **Improvement from me**: don't check whether `EPROCESS` equals to the current process on detach, as it may be (and actually becomes) equal at that point. So then attach is performed, but detach isn't, what causes bugckeck 0x01 APC_INDEX_MISMATCH (it actually occurs). Use a `BOOLEAN` variable instead, which remembers the previous attach status. In case attach was performed, it's `TRUE`, otherwise `FALSE`. Detach the process from the stack **only in case** it was previously attached. This actually fixes the bugcheck mentioned above.

## TODO

- [x] (**EDIT: done now.**) Perhaps add Doxygen documentation and SAL2 annotations (or this is not necessarily for undocumented functions? :thinking: ).

## Result

After my changes, the following antivirus programs are working better with MS FltMgr driver installed and loaded:

Avast Free Antivirus 7.0 (2012):
![avast!](https://github.com/user-attachments/assets/e6456745-9618-43c4-9f74-cfe65d845bde)

Avira AntiVir Personal 8.2 (2008):
![avira-everything-works](https://github.com/user-attachments/assets/3d104c0f-6532-482f-83a1-10e086daf805)

:white_check_mark: I can confirm: asserts mentioned in the ticket are no longer occurring after my changes.
Other similar apps might be also fixed as well. :slightly_smiling_face: However I did not test them yet.

## Analysis

As visible on the following screenshot, the driver imports that function, so it acually uses that:
![ms-fltmgr](https://github.com/user-attachments/assets/4bc7a902-c167-4bb9-be8f-ffe2548b0be1)