### PR TITLE
[MMEBUDDY][MMENT4][SNDBLST] Add missing \n to SND_*() calls

### DIFF
--- a/dll/win32/sndblst/sndblst.c
+++ b/dll/win32/sndblst/sndblst.c
@@ -224,7 +224,7 @@ DriverProc(
 
         case DRV_QUERYCONFIGURE :
         {
-            SND_TRACE(L"DRV_QUERYCONFIGURE");
+            SND_TRACE(L"DRV_QUERYCONFIGURE\n");
             return 0L;
         }
         case DRV_CONFIGURE :

--- a/sdk/lib/drivers/sound/mmebuddy/devicelist.c
+++ b/sdk/lib/drivers/sound/mmebuddy/devicelist.c
@@ -51,7 +51,7 @@ FreeSoundDevice(
 {
     SND_ASSERT( SoundDevice );
 
-    SND_TRACE(L"Freeing a SOUND_DEVICE structure");
+    SND_TRACE(L"Freeing a SOUND_DEVICE structure\n");
 
     /* For safety the whole struct gets zeroed */
     ZeroMemory(SoundDevice, sizeof(SOUND_DEVICE));

--- a/sdk/lib/drivers/sound/mmebuddy/mmewrap.c
+++ b/sdk/lib/drivers/sound/mmebuddy/mmewrap.c
@@ -142,7 +142,7 @@ MmeOpenDevice(
     PSOUND_DEVICE_INSTANCE SoundDeviceInstance;
     LPWAVEFORMATEX Format = NULL;
 
-    SND_TRACE(L"Opening device");
+    SND_TRACE(L"Opening device\n");
 
     VALIDATE_MMSYS_PARAMETER( IS_WAVE_DEVICE_TYPE(DeviceType) || IS_MIXER_DEVICE_TYPE(DeviceType) || IS_MIDI_DEVICE_TYPE(DeviceType) );    /* FIXME? wave in too? */
     VALIDATE_MMSYS_PARAMETER( OpenParameters );

--- a/sdk/lib/drivers/sound/mment4/control.c
+++ b/sdk/lib/drivers/sound/mment4/control.c
@@ -33,7 +33,7 @@ OpenNt4KernelSoundDevice(
     Result = GetSoundDeviceIdentifier(SoundDevice, (PVOID*) &Path);
     if ( ! MMSUCCESS(Result) )
     {
-        SND_ERR(L"Unable to get sound device path");
+        SND_ERR(L"Unable to get sound device path\n");
         return TranslateInternalMmResult(Result);
     }
 
@@ -122,7 +122,7 @@ GetNt4SoundDeviceCapabilities(
 
     if ( ! MMSUCCESS(Result) )
     {
-        SND_ERR(L"Failed to open device");
+        SND_ERR(L"Failed to open device\n");
         return TranslateInternalMmResult(Result);
     }
 


### PR DESCRIPTION
## Purpose

Trivial debug log fix.

## Proposed changes

- Add missing \n to SND_*() calls