### PR TITLE
[NOTEPAD] Don't leave junk behind when opening smaller file

### DIFF
--- a/base/applications/notepad/dialog.c
+++ b/base/applications/notepad/dialog.c
@@ -343,6 +343,7 @@ VOID DoOpenFile(LPCTSTR szFileName)
         return;
 
     WaitCursor(TRUE);
+    SetWindowText(Globals.hEdit, NULL);
 
     hFile = CreateFile(szFileName, GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL,
                        OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);


### PR DESCRIPTION
Steps to reproduce:

1. In the open dialog, open `Command Prompt.lnk`.
2. In the open dialog, right-click and create new text file. Open `New text document.txt`.

Notes:
- `DIALOG_FileNew` already has this fix.
