### PR TITLE
[BROWSEUI] Add checkmark for Explorer bar menu items

### DIFF
--- a/dll/win32/browseui/shellbrowser.cpp
+++ b/dll/win32/browseui/shellbrowser.cpp
@@ -1823,6 +1823,19 @@ void CShellBrowser::UpdateViewMenu(HMENU theMenu)
         SetMenuItemInfo(theMenu, IDM_VIEW_TOOLBARS, FALSE, &menuItemInfo);
     }
     SHCheckMenuItem(theMenu, IDM_VIEW_STATUSBAR, m_settings.fStatusBarVisible ? TRUE : FALSE);
+
+    // Check the menu items for Explorer bar
+    BOOL bSearchBand = (IsEqualCLSID(CLSID_SH_SearchBand, fCurrentVertBar) ||
+                        IsEqualCLSID(CLSID_SearchBand, fCurrentVertBar) ||
+                        IsEqualCLSID(CLSID_IE_SearchBand, fCurrentVertBar) ||
+                        IsEqualCLSID(CLSID_FileSearchBand, fCurrentVertBar));
+    BOOL bHistory = IsEqualCLSID(CLSID_SH_HistBand, fCurrentVertBar);
+    BOOL bFavorites = IsEqualCLSID(CLSID_SH_FavBand, fCurrentVertBar);
+    BOOL bFolders = IsEqualCLSID(CLSID_ExplorerBand, fCurrentVertBar);
+    SHCheckMenuItem(theMenu, IDM_EXPLORERBAR_SEARCH, bSearchBand);
+    SHCheckMenuItem(theMenu, IDM_EXPLORERBAR_HISTORY, bHistory);
+    SHCheckMenuItem(theMenu, IDM_EXPLORERBAR_FAVORITES, bFavorites);
+    SHCheckMenuItem(theMenu, IDM_EXPLORERBAR_FOLDERS, bFolders);
 }
 
 HRESULT CShellBrowser::BuildExplorerBandMenu()
@@ -3746,19 +3759,6 @@ LRESULT CShellBrowser::OnInitMenuPopup(UINT uMsg, WPARAM wParam, LPARAM lParam, 
     {
         menuIndex = 5;
     }
-
-    // Check the menu items for Explorer bar
-    BOOL bSearchBand = (IsEqualCLSID(CLSID_SH_SearchBand, fCurrentVertBar) ||
-                        IsEqualCLSID(CLSID_SearchBand, fCurrentVertBar) ||
-                        IsEqualCLSID(CLSID_IE_SearchBand, fCurrentVertBar) ||
-                        IsEqualCLSID(CLSID_FileSearchBand, fCurrentVertBar));
-    BOOL bHistory = IsEqualCLSID(CLSID_SH_HistBand, fCurrentVertBar);
-    BOOL bFavorites = IsEqualCLSID(CLSID_SH_FavBand, fCurrentVertBar);
-    BOOL bFolders = IsEqualCLSID(CLSID_ExplorerBand, fCurrentVertBar);
-    ::CheckMenuItem(theMenu, IDM_EXPLORERBAR_SEARCH, (bSearchBand ? MF_CHECKED : MF_UNCHECKED));
-    ::CheckMenuItem(theMenu, IDM_EXPLORERBAR_HISTORY, (bHistory ? MF_CHECKED : MF_UNCHECKED));
-    ::CheckMenuItem(theMenu, IDM_EXPLORERBAR_FAVORITES, (bFavorites ? MF_CHECKED : MF_UNCHECKED));
-    ::CheckMenuItem(theMenu, IDM_EXPLORERBAR_FOLDERS, (bFolders ? MF_CHECKED : MF_UNCHECKED));
 
     LRESULT ret = RelayMsgToShellView(uMsg, wParam, menuIndex, bHandled);
 

--- a/dll/win32/browseui/shellbrowser.cpp
+++ b/dll/win32/browseui/shellbrowser.cpp
@@ -3747,6 +3747,19 @@ LRESULT CShellBrowser::OnInitMenuPopup(UINT uMsg, WPARAM wParam, LPARAM lParam, 
         menuIndex = 5;
     }
 
+    // Check the menu items for Explorer bar
+    BOOL bSearchBand = (IsEqualCLSID(CLSID_SH_SearchBand, fCurrentVertBar) ||
+                        IsEqualCLSID(CLSID_SearchBand, fCurrentVertBar) ||
+                        IsEqualCLSID(CLSID_IE_SearchBand, fCurrentVertBar) ||
+                        IsEqualCLSID(CLSID_FileSearchBand, fCurrentVertBar));
+    BOOL bHistory = IsEqualCLSID(CLSID_SH_HistBand, fCurrentVertBar);
+    BOOL bFavorites = IsEqualCLSID(CLSID_SH_FavBand, fCurrentVertBar);
+    BOOL bFolders = IsEqualCLSID(CLSID_ExplorerBand, fCurrentVertBar);
+    ::CheckMenuItem(theMenu, IDM_EXPLORERBAR_SEARCH, (bSearchBand ? MF_CHECKED : MF_UNCHECKED));
+    ::CheckMenuItem(theMenu, IDM_EXPLORERBAR_HISTORY, (bHistory ? MF_CHECKED : MF_UNCHECKED));
+    ::CheckMenuItem(theMenu, IDM_EXPLORERBAR_FAVORITES, (bFavorites ? MF_CHECKED : MF_UNCHECKED));
+    ::CheckMenuItem(theMenu, IDM_EXPLORERBAR_FOLDERS, (bFolders ? MF_CHECKED : MF_UNCHECKED));
+
     LRESULT ret = RelayMsgToShellView(uMsg, wParam, menuIndex, bHandled);
 
     return ret;


### PR DESCRIPTION
## Purpose

Improve UI/UX.
JIRA issue: [CORE-19689](https://jira.reactos.org/browse/CORE-19689)

## Proposed changes

- In the `CShellBrowser::OnInitMenuPopup` method, check/uncheck menu items depending on `fCurrentVertBar`.

## TODO

- [x] Do tests.

## Comparison

Win2k3:
![win2k3](https://github.com/user-attachments/assets/36645595-f5fa-4402-9533-c86fe33ecc13)

BEFORE:
![before](https://github.com/user-attachments/assets/0572167a-ea32-4945-a9fe-0bde070fda60)

AFTER:
![after](https://github.com/user-attachments/assets/835f205e-df2a-4b7b-810a-524ae5fe97ad)