### PR TITLE
[NTOS:CC] Rewrite cache flushing synchronization

### DIFF
--- a/ntoskrnl/include/internal/cc.h
+++ b/ntoskrnl/include/internal/cc.h
@@ -193,6 +193,7 @@ typedef struct _ROS_SHARED_CACHE_MAP
     LIST_ENTRY CacheMapVacbListHead;
     BOOLEAN PinAccess;
     KSPIN_LOCK CacheMapLock;
+    KEVENT FlushEvent;
 #if DBG
     BOOLEAN Trace; /* enable extra trace output for this cache map and it's VACBs */
 #endif
@@ -201,7 +202,6 @@ typedef struct _ROS_SHARED_CACHE_MAP
 #define READAHEAD_DISABLED 0x1
 #define WRITEBEHIND_DISABLED 0x2
 #define SHARED_CACHE_MAP_IN_CREATION 0x4
-#define SHARED_CACHE_MAP_IN_LAZYWRITE 0x8
 
 typedef struct _ROS_VACB
 {

--- a/ntoskrnl/include/internal/cc.h
+++ b/ntoskrnl/include/internal/cc.h
@@ -193,7 +193,6 @@ typedef struct _ROS_SHARED_CACHE_MAP
     LIST_ENTRY CacheMapVacbListHead;
     BOOLEAN PinAccess;
     KSPIN_LOCK CacheMapLock;
-    KGUARDED_MUTEX FlushCacheLock;
 #if DBG
     BOOLEAN Trace; /* enable extra trace output for this cache map and it's VACBs */
 #endif


### PR DESCRIPTION
## Purpose
Fix race-conditions between concurrent cache flushes.

JIRA issue: [CORE-19664](https://jira.reactos.org/browse/CORE-19664)

## Proposed changes
- Revert commit [cf4138fa](https://git.reactos.org/?p=reactos.git;a=commit;h=cf4138fa2433373081854b44c4bb76541d4fe0cc)
- Add a per-file event for cache flushing synchronization
- Replace `SHARED_CACHE_MAP_IN_LAZYWRITE` flag checking with the newly added event

## TODO
- [ ] Do realhw tests (Dell OptiPlex 380)
- [ ] Add documentation