### PR TITLE
[STOBJECT] Do not report the remaining battery capacity if it is unknown

### DIFF
--- a/dll/shellext/stobject/power.cpp
+++ b/dll/shellext/stobject/power.cpp
@@ -90,6 +90,12 @@ static HICON DynamicLoadIcon(HINSTANCE hinst)
     }
 
     if (((PowerStatus.BatteryFlag & BATTERY_FLAG_NO_BATTERY) == 0) &&
+        (PowerStatus.BatteryLifePercent == BATTERY_PERCENTAGE_UNKNOWN))
+    {
+        hBatIcon = LoadIcon(hinst, MAKEINTRESOURCE(IDI_BATTCAP_ERR));
+        g_strTooltip.LoadStringW(IDS_PWR_UNKNOWN_REMAINING);
+    }
+    else if (((PowerStatus.BatteryFlag & BATTERY_FLAG_NO_BATTERY) == 0) &&
         ((PowerStatus.BatteryFlag & BATTERY_FLAG_CHARGING) == BATTERY_FLAG_CHARGING))
     {
         index = Quantize(PowerStatus.BatteryLifePercent);


### PR DESCRIPTION
Support for system batteries in ReactOS is really minimal to the point of non-existing. We are detecting the presence of any upcoming battery but since there's lacking in critical code that deals with communication between PO and the battery class driver as the battery systray icon uses `GetSystemPowerStatus` to gather battery info which in turn inquires the power manager via `NtPowerInformation(SystemBatteryState)`, we have to report to the user that the remaining capacity is unknown rather than returning a pseudo capacity value.

Technically this so called "pesudo" value is just a construct denoted as **BATTERY_PERCENTAGE_UNKNOWN**. Not reporting the actual remaining capacity makes sense, as there could be a scenario where the battery may not properly report its real datum, therefore it's best to be honest to the user what's really going on.

The aim of this patch is to slightly improve the information that is passed visually to the user as "255% remaining" is simply confusing to the user and it does not tell the real information that the remaining capacity of the battery is simply unknown.

[CORE-19452](https://jira.reactos.org/browse/CORE-19452)
[CORE-18969](https://jira.reactos.org/browse/CORE-18969)

## Documentation
A composite battery is a power policy device just like thermal zones, control switches, memory devices, etc, that are registered via PnP notifications of which the Power Manager will connect to such devices and perform I/O requests based upon what is there needed to do. Here's a dummy representation of how such communication between PO and the composite battery device driver looks like:
![Draw](https://github.com/user-attachments/assets/f8bb50b4-c16d-44eb-84f8-8a0fc0c927d3) 