### PR TITLE
[NTUSER] Correctly store original unsnap position

### DIFF
--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -3937,7 +3937,7 @@ co_IntSnapWindow(PWND Wnd, UINT Edge)
         co_IntSendMessage(UserHMGetHandle(Wnd), WM_SYSCOMMAND, SC_MAXIMIZE, 0);
         return;
     }
-    else if (Edge)
+    else if (Edge != HTNOWHERE)
     {
         UserRefObjectCo(Wnd, &ref);
         hasRef = TRUE;
@@ -3951,7 +3951,7 @@ co_IntSnapWindow(PWND Wnd, UINT Edge)
             IntSetSnapEdge(Wnd, HTNOWHERE);
             return;
         }
-        newPos = Wnd->InternalPos.NormalRect;
+        newPos = Wnd->InternalPos.NormalRect; /* Copy RECT now before it is lost */
         IntSetSnapInfo(Wnd, HTNOWHERE, NULL);
     }
     else
@@ -4000,7 +4000,7 @@ IntSetSnapInfo(PWND Wnd, UINT Edge, IN const RECT *Pos OPTIONAL)
 {
     RECT r;
     IntSetSnapEdge(Wnd, Edge);
-    if (Edge != HTNOWHERE)
+    if (Edge == HTNOWHERE)
     {
         RECTL_vSetEmptyRect(&r);
         Pos = (Wnd->style & WS_MINIMIZE) ? NULL : &r;

--- a/win32ss/user/ntuser/winpos.h
+++ b/win32ss/user/ntuser/winpos.h
@@ -81,7 +81,7 @@ VOID FASTCALL IntSetSnapInfo(PWND Wnd, UINT Edge, IN const RECT *Pos OPTIONAL);
 FORCEINLINE VOID
 co_IntUnsnapWindow(PWND Wnd)
 {
-    co_IntSnapWindow(Wnd, 0);
+    co_IntSnapWindow(Wnd, HTNOWHERE);
 }
 
 FORCEINLINE BOOLEAN


### PR DESCRIPTION
[A small change](https://github.com/reactos/reactos/pull/5705#discussion_r1679758645) before PR #5705 was merged caused a severe downgrade in the snap/unsnap handling. Win key handling should work correctly now.

JIRA issue: [CORE-19165](https://jira.reactos.org/browse/CORE-19165) [CORE-19166](https://jira.reactos.org/browse/CORE-19166)