### PR TITLE
[NTUSER] Fix window not updating when scrollbars created.

### DIFF
--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -1814,6 +1814,7 @@ co_WinPosSetWindowPos(
    RECTL CopyRect;
    PWND Ancestor;
    BOOL bPointerInWindow, PosChanged = FALSE;
+   BOOL fullRedraw = FALSE;
    PTHREADINFO pti = PsGetCurrentThreadWin32Thread();
 
    ASSERT_REFS_CO(Window);
@@ -1936,6 +1937,11 @@ co_WinPosSetWindowPos(
 //      valid_rects[0].left,valid_rects[0].top,valid_rects[0].right,valid_rects[0].bottom,
 //      valid_rects[1].left,valid_rects[1].top,valid_rects[1].right,valid_rects[1].bottom);
 
+   if (WvrFlags & (WVR_HREDRAW | WVR_VREDRAW))
+   {
+       fullRedraw = TRUE;
+   }
+
    /* Validate link windows. (also take into account shell window in hwndShellWindow) */
    if (!(WinPos.flags & SWP_NOZORDER) && WinPos.hwnd != UserGetShellWindow())
    {
@@ -2048,7 +2054,7 @@ co_WinPosSetWindowPos(
        * change.
        */
       if ( ( VisBefore != NULL &&
-             VisAfter != NULL &&
+             VisAfter != NULL && !fullRedraw &&
             !(WinPos.flags & SWP_NOCOPYBITS) &&
             ((WinPos.flags & SWP_NOSIZE) || !(WvrFlags & WVR_REDRAW)) &&
             !(Window->ExStyle & WS_EX_TRANSPARENT) ) )

--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -1938,10 +1938,7 @@ co_WinPosSetWindowPos(
 //      valid_rects[1].left,valid_rects[1].top,valid_rects[1].right,valid_rects[1].bottom);
 
    if (WvrFlags & (WVR_HREDRAW | WVR_VREDRAW))
-   {
        fullRedraw = TRUE;
-   }
-
    /* Validate link windows. (also take into account shell window in hwndShellWindow) */
    if (!(WinPos.flags & SWP_NOZORDER) && WinPos.hwnd != UserGetShellWindow())
    {

--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -1814,7 +1814,6 @@ co_WinPosSetWindowPos(
    RECTL CopyRect;
    PWND Ancestor;
    BOOL bPointerInWindow, PosChanged = FALSE;
-   BOOL fullRedraw = FALSE;
    PTHREADINFO pti = PsGetCurrentThreadWin32Thread();
 
    ASSERT_REFS_CO(Window);
@@ -1937,8 +1936,6 @@ co_WinPosSetWindowPos(
 //      valid_rects[0].left,valid_rects[0].top,valid_rects[0].right,valid_rects[0].bottom,
 //      valid_rects[1].left,valid_rects[1].top,valid_rects[1].right,valid_rects[1].bottom);
 
-   if (WvrFlags & (WVR_HREDRAW | WVR_VREDRAW))
-       fullRedraw = TRUE;
    /* Validate link windows. (also take into account shell window in hwndShellWindow) */
    if (!(WinPos.flags & SWP_NOZORDER) && WinPos.hwnd != UserGetShellWindow())
    {
@@ -2051,7 +2048,7 @@ co_WinPosSetWindowPos(
        * change.
        */
       if ( ( VisBefore != NULL &&
-             VisAfter != NULL && !fullRedraw &&
+             VisAfter != NULL && !(WvrFlags & WVR_REDRAW) &&
             !(WinPos.flags & SWP_NOCOPYBITS) &&
             ((WinPos.flags & SWP_NOSIZE) || !(WvrFlags & WVR_REDRAW)) &&
             !(Window->ExStyle & WS_EX_TRANSPARENT) ) )

--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -2047,11 +2047,11 @@ co_WinPosSetWindowPos(
        * class need to be completely repainted on (horizontal/vertical) size
        * change.
        */
-      if ( ( VisBefore != NULL &&
-             VisAfter != NULL && !(WvrFlags & WVR_REDRAW) &&
-            !(WinPos.flags & SWP_NOCOPYBITS) &&
-            ((WinPos.flags & SWP_NOSIZE) || !(WvrFlags & WVR_REDRAW)) &&
-            !(Window->ExStyle & WS_EX_TRANSPARENT) ) )
+      if (VisBefore != NULL &&
+          VisAfter != NULL &&
+          !(WvrFlags & WVR_REDRAW) &&
+          !(WinPos.flags & SWP_NOCOPYBITS) &&
+          !(Window->ExStyle & WS_EX_TRANSPARENT))
       {
 
          /*


### PR DESCRIPTION
I_Kill_Bugs patch.

## Purpose

_Fix text overwritten and not updated by scrollbars when scrollbars created._

JIRA issue: [CORE-19669](https://jira.reactos.org/browse/CORE-19669)

## Proposed changes

_Check winpos.c for change in WVR_HREDRAW or WVR_VREDRAW in function co_WinPosSetWindowPos._
_If one occurs then redraw full window._

Testbot Results:
winpos_min.patch JID68658 on top of 0.4.15-dev-8531-gd5f6b8c

KVM:  https://reactos.org/testman/compare.php?ids=97159,97165
VBox: https://reactos.org/testman/compare.php?ids=97162,97164