### PR TITLE
[RAPPS] Respect partial settings configuration

### DIFF
--- a/base/applications/rapps/settings.cpp
+++ b/base/applications/rapps/settings.cpp
@@ -202,7 +202,6 @@ ValidateStringSettings(PSETTINGS_INFO pSettingsInfo)
 
         CStringW::CopyChars(pSettingsInfo->szDownloadDir, _countof(pSettingsInfo->szDownloadDir),
                             szDownloadDir.GetString(), szDownloadDir.GetLength() + 1);
-
     }
 }
 

--- a/base/applications/rapps/settings.cpp
+++ b/base/applications/rapps/settings.cpp
@@ -208,7 +208,7 @@ ValidateStringSettings(PSETTINGS_INFO pSettingsInfo)
 VOID
 FillDefaultSettings(PSETTINGS_INFO pSettingsInfo)
 {
-    ZeroMemory(pSettingsInfo, sizeof(SETTINGS_INFO));
+    ZeroMemory(pSettingsInfo, sizeof(*pSettingsInfo));
 
     pSettingsInfo->bSaveWndPos = TRUE;
     pSettingsInfo->bUpdateAtStart = FALSE;

--- a/base/applications/rapps/winmain.cpp
+++ b/base/applications/rapps/winmain.cpp
@@ -40,12 +40,7 @@ wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdLine, INT nSh
     }
 
     hInst = hInstance;
-
     BOOL bIsFirstLaunch = !LoadSettings(&SettingsInfo);
-    if (bIsFirstLaunch)
-    {
-        FillDefaultSettings(&SettingsInfo);
-    }
 
     InitLogs();
     InitCommonControls();


### PR DESCRIPTION
Instead of defaulting all settings if any setting is missing, only set everything to their defaults if all settings are missing and respect any setting that is already set.

Also fixes a bug where szDownloadDir is treated as valid even if the string empty.

I'll admit I'm scratching my own itch here, I want to set bDelInstaller=1 in unattended setup.