### PR TITLE
[RTL] vDbgPrintExWithPrefixInternal(): Fix a warning about strncpy()

### DIFF
--- a/sdk/lib/rtl/debug.c
+++ b/sdk/lib/rtl/debug.c
@@ -81,7 +81,7 @@ vDbgPrintExWithPrefixInternal(IN PCCH Prefix,
         if (PrefixLength > sizeof(Buffer)) PrefixLength = sizeof(Buffer);
 
         /* Copy it */
-        strncpy(Buffer, Prefix, PrefixLength);
+        memcpy(Buffer, Prefix, PrefixLength);
 
         /* Do the printf */
         Length = _vsnprintf(Buffer + PrefixLength,
@@ -125,6 +125,7 @@ vDbgPrintExWithPrefixInternal(IN PCCH Prefix,
         ExceptionRecord.ExceptionRecord = NULL;
         ExceptionRecord.NumberParameters = 2;
         ExceptionRecord.ExceptionFlags = 0;
+        /* FIXME: '+ 1' looks wrong when Length == sizeof(Buffer) */
         ExceptionRecord.ExceptionInformation[0] = DebugString.Length + 1;
         ExceptionRecord.ExceptionInformation[1] = (ULONG_PTR)DebugString.Buffer;
 


### PR DESCRIPTION
## Purpose

Fix
```
build-linux (gcc, i386, Release, 0x502)

2024-08-15T22:07:33.8691704Z ../src/sdk/lib/rtl/debug.c: In function 'vDbgPrintExWithPrefixInternal':
2024-08-15T22:07:33.8700576Z ../src/sdk/lib/rtl/debug.c:84:9: warning: 'strncpy' specified bound depends on the length of the source argument [-Wstringop-overflow=]
2024-08-15T22:07:33.8701986Z          strncpy(Buffer, Prefix, PrefixLength);
2024-08-15T22:07:33.8702629Z          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2024-08-15T22:07:33.8703401Z ../src/sdk/lib/rtl/debug.c:80:24: note: length computed here
2024-08-15T22:07:33.8704158Z          PrefixLength = strlen(Prefix);
2024-08-15T22:07:33.8704712Z                         ^~~~~~~~~~~~~~
```

## Proposed changes

- Simply use memcpy() instead.
- Add a FIXME.