### PR TITLE
[USER32_APITEST] Add scrollbar showing/hiding testcase

### DIFF
--- a/modules/rostests/apitests/user32/CMakeLists.txt
+++ b/modules/rostests/apitests/user32/CMakeLists.txt
@@ -41,6 +41,7 @@ list(APPEND SOURCE
     RedrawWindow.c
     RegisterClassEx.c
     RegisterHotKey.c
+    ScrollBarRedraw.c
     ScrollBarWndExtra.c
     ScrollDC.c
     ScrollWindowEx.c

--- a/modules/rostests/apitests/user32/ScrollBarRedraw.c
+++ b/modules/rostests/apitests/user32/ScrollBarRedraw.c
@@ -1,6 +1,6 @@
 /*
- * PROJECT:     ReactOS api tests
- * LICENSE:     ISC (https://spdx.org/licenses/ISC)
+ * PROJECT:     ReactOS API tests
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
  * PURPOSE:     Tests window redrawing when scrollbars appear or disappear
  * COPYRIGHT:   Copyright 2024 Marek Benc <benc.marek.elektro98@proton.me>
  */

--- a/modules/rostests/apitests/user32/ScrollBarRedraw.c
+++ b/modules/rostests/apitests/user32/ScrollBarRedraw.c
@@ -597,7 +597,10 @@ static int OnPaint(HWND Window)
     if(!FillRgn(hdc, Region, ColorBrushes[CurrentColor]))
     {
         skip("Failed to paint the window\n");
+        DeleteObject(Region);
+        EndPaint(Window, &ps);
         DestroyWindow(Window);
+        return 0;
     }
 
     DeleteObject(Region);
@@ -666,8 +669,7 @@ static LRESULT CALLBACK WindowProc(HWND Window, UINT Message, WPARAM wParam, LPA
                     return 0;
                 }
             }
-            OnPaint(Window);
-            break;
+            return OnPaint(Window);
 
         case WM_SIZE:
         {

--- a/modules/rostests/apitests/user32/ScrollBarRedraw.c
+++ b/modules/rostests/apitests/user32/ScrollBarRedraw.c
@@ -1,39 +1,29 @@
 /*
- * Copyright (c) 2024 Marek Benc <benc.marek.elektro98@proton.me>
- *
- * Permission to use, copy, modify, and distribute this software for any
- * purpose with or without fee is hereby granted, provided that the above
- * copyright notice and this permission notice appear in all copies.
- *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
- * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
- * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
- * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ * PROJECT:     ReactOS api tests
+ * LICENSE:     ISC (https://spdx.org/licenses/ISC)
+ * PURPOSE:     Tests window redrawing when scrollbars appear or disappear
+ * COPYRIGHT:   Copyright 2024 Marek Benc <benc.marek.elektro98@proton.me>
  */
 
 #include <windows.h>
 #include "wine/test.h"
 
-#define TEST_CLASS_NAME   "scrollbar_redraw"
-#define TEST_WINDOW_TITLE "scrollbar_redraw"
+#define TEST_CLASS_NAME   "ScrollBarRedraw"
+#define TEST_WINDOW_TITLE "ScrollBarRedraw"
 
 EXTERN_C IMAGE_DOS_HEADER __ImageBase;
 #define HINST_THISCOMPONENT ((HINSTANCE)&__ImageBase)
 
-static LRESULT CALLBACK
-proc_cb(HWND window, UINT message, WPARAM w_param, LPARAM l_param);
+static LRESULT CALLBACK WindowProc(HWND Window, UINT Message, WPARAM wParam, LPARAM lParam);
 
 #define TEST_COLOR_COUNT 16
-static COLORREF colors[TEST_COLOR_COUNT] = { 0 };
-static HBRUSH   color_brushes[TEST_COLOR_COUNT] = { 0 };
+static COLORREF Colors[TEST_COLOR_COUNT] = { 0 };
+static HBRUSH   ColorBrushes[TEST_COLOR_COUNT] = { 0 };
 
-static BOOL have_hredraw = FALSE;
-static BOOL have_vredraw = FALSE;
+static BOOL HaveHRedraw = FALSE;
+static BOOL HaveVRedraw = FALSE;
 
-enum fsm_state
+typedef enum
 {
     FSM_STATE_START,
     FSM_STATE_VSCR_SHOWN,
@@ -49,69 +39,67 @@ enum fsm_state
     FSM_STATE_BOTH_SHRUNK,
     FSM_STATE_BOTH_EXPANDED,
     FSM_STATE_END
-};
+} FSM_STATE;
 
-static UINT_PTR fsm_timer = 0;
-static unsigned int current_color = 0;
-static enum fsm_state fsm_state = FSM_STATE_START;
+static UINT_PTR FsmTimer = 0;
+static UINT CurrentColor = 0;
+static FSM_STATE FsmState = FSM_STATE_START;
 
-static int client_width = 0;
-static int client_height = 0;
+static int ClientWidth = 0;
+static int ClientHeight = 0;
 
-static int orig_width = 0;
-static int orig_height = 0;
-static int small_width = 0;
-static int small_height = 0;
+static int OrigWidth = 0;
+static int OrigHeight = 0;
+static int SmallWidth = 0;
+static int SmallHeight = 0;
 
-static void
-colors_cleanup()
+static void ColorsCleanup()
 {
-    unsigned int iter;
+    UINT Iter;
 
-    for (iter = 0; iter < TEST_COLOR_COUNT; iter++)
+    for (Iter = 0; Iter < TEST_COLOR_COUNT; Iter++)
     {
-        if (color_brushes[iter] != NULL)
+        if (ColorBrushes[Iter] != NULL)
         {
-            DeleteObject(color_brushes[iter]);
-            color_brushes[iter] = NULL;
+            DeleteObject(ColorBrushes[Iter]);
+            ColorBrushes[Iter] = NULL;
         }
     }
 }
 
-static BOOL
-colors_init(void)
+static BOOL ColorsInit(void)
 {
-    unsigned int iter;
+    UINT Iter;
 
     if (TEST_COLOR_COUNT != 16)
     {
         return FALSE;
     }
 
-    /* Standard Windows 16-color VGA color palette. */
-    colors[0]  = RGB(0x00, 0x00, 0x00);  /* Black */
-    colors[1]  = RGB(0x00, 0x00, 0x80);  /* Dark Blue */
-    colors[2]  = RGB(0x00, 0x80, 0x00);  /* Dark Green */
-    colors[3]  = RGB(0x00, 0x80, 0x80);  /* Dark Cyan */
-    colors[4]  = RGB(0x80, 0x00, 0x00);  /* Dark Red */
-    colors[5]  = RGB(0x80, 0x00, 0x80);  /* Dark Magenta */
-    colors[6]  = RGB(0x80, 0x80, 0x00);  /* Dark Yellow */
-    colors[7]  = RGB(0xC0, 0xC0, 0xC0);  /* Light Gray */
-    colors[8]  = RGB(0x80, 0x80, 0x80);  /* Dark Gray */
-    colors[9]  = RGB(0x00, 0x00, 0xFF);  /* Blue */
-    colors[10] = RGB(0x00, 0xFF, 0x00);  /* Green */
-    colors[11] = RGB(0x00, 0xFF, 0xFF);  /* Cyan */
-    colors[12] = RGB(0xFF, 0x00, 0x00);  /* Red */
-    colors[13] = RGB(0xFF, 0x00, 0xFF);  /* Magenta */
-    colors[14] = RGB(0xFF, 0xFF, 0x00);  /* Yellow */
-    colors[15] = RGB(0xFF, 0xFF, 0xFF);  /* White */
+    /* Standard Windows 16-Color VGA Color palette. */
+    Colors[0]  = RGB(0x00, 0x00, 0x00);  /* Black */
+    Colors[1]  = RGB(0x00, 0x00, 0x80);  /* Dark Blue */
+    Colors[2]  = RGB(0x00, 0x80, 0x00);  /* Dark Green */
+    Colors[3]  = RGB(0x00, 0x80, 0x80);  /* Dark Cyan */
+    Colors[4]  = RGB(0x80, 0x00, 0x00);  /* Dark Red */
+    Colors[5]  = RGB(0x80, 0x00, 0x80);  /* Dark Magenta */
+    Colors[6]  = RGB(0x80, 0x80, 0x00);  /* Dark Yellow */
+    Colors[7]  = RGB(0xC0, 0xC0, 0xC0);  /* Light Gray */
+    Colors[8]  = RGB(0x80, 0x80, 0x80);  /* Dark Gray */
+    Colors[9]  = RGB(0x00, 0x00, 0xFF);  /* Blue */
+    Colors[10] = RGB(0x00, 0xFF, 0x00);  /* Green */
+    Colors[11] = RGB(0x00, 0xFF, 0xFF);  /* Cyan */
+    Colors[12] = RGB(0xFF, 0x00, 0x00);  /* Red */
+    Colors[13] = RGB(0xFF, 0x00, 0xFF);  /* Magenta */
+    Colors[14] = RGB(0xFF, 0xFF, 0x00);  /* Yellow */
+    Colors[15] = RGB(0xFF, 0xFF, 0xFF);  /* White */
 
-    for (iter = 0; iter < TEST_COLOR_COUNT; iter++)
+    for (Iter = 0; Iter < TEST_COLOR_COUNT; Iter++)
     {
-        color_brushes[iter] = CreateSolidBrush(colors[iter]);
-        if (color_brushes[iter] == NULL)
+        ColorBrushes[Iter] = CreateSolidBrush(Colors[Iter]);
+        if (ColorBrushes[Iter] == NULL)
         {
-            colors_cleanup();
+            ColorsCleanup();
             return FALSE;
         }
     }
@@ -119,570 +107,595 @@ colors_init(void)
     return TRUE;
 }
 
-static void
-run_test_window(const char *class_name, const char *window_title, UINT class_style)
+static void RunTestWindow(const char *ClassName, const char *WindowTitle, UINT ClassStyle)
 {
-    WNDCLASS class = { 0 };
-    HWND window;
-    MSG  msg;
-    ATOM class_atom;
+    WNDCLASS Class = { 0 };
+    HWND Window;
+    MSG  Message;
+    ATOM ClassAtom;
 
-    current_color = 0;
+    CurrentColor = 0;
 
-    class.style         = class_style;
-    class.lpfnWndProc   = proc_cb;
-    class.cbClsExtra    = 0;
-    class.cbWndExtra    = 0;
-    class.hInstance     = HINST_THISCOMPONENT;
-    class.hIcon         = LoadIcon(NULL, IDI_APPLICATION);
-    class.hCursor       = LoadCursor(NULL, IDC_ARROW);
-    class.hbrBackground = color_brushes[current_color];
-    class.lpszMenuName  = NULL;
-    class.lpszClassName = class_name;
+    Class.style         = ClassStyle;
+    Class.lpfnWndProc   = WindowProc;
+    Class.cbClsExtra    = 0;
+    Class.cbWndExtra    = 0;
+    Class.hInstance     = HINST_THISCOMPONENT;
+    Class.hIcon         = LoadIcon(NULL, IDI_APPLICATION);
+    Class.hCursor       = LoadCursor(NULL, IDC_ARROW);
+    Class.hbrBackground = ColorBrushes[CurrentColor];
+    Class.lpszMenuName  = NULL;
+    Class.lpszClassName = ClassName;
 
-    class_atom = RegisterClass(&class);
-    ok(class_atom != 0, "Failed to register window class \"%s\", code: %ld\n", class_name, GetLastError());
-    if (class_atom == 0)
+    ClassAtom = RegisterClass(&Class);
+
+    ok(ClassAtom != 0,
+       "Failed to register window class \"%s\", code: %ld\n",
+       ClassName, GetLastError());
+
+    if (ClassAtom == 0)
     {
         return;
     }
 
-    window = CreateWindow(
-            class_name,
-            window_title,
-            WS_OVERLAPPEDWINDOW | WS_VSCROLL | WS_HSCROLL,
-            CW_USEDEFAULT,
-            CW_USEDEFAULT,
-            CW_USEDEFAULT,
-            CW_USEDEFAULT,
-            NULL,
-            NULL,
-            HINST_THISCOMPONENT,
-            NULL);
+    Window = CreateWindow(ClassName,
+                          WindowTitle,
+                          WS_OVERLAPPEDWINDOW | WS_VSCROLL | WS_HSCROLL,
+                          CW_USEDEFAULT,
+                          CW_USEDEFAULT,
+                          CW_USEDEFAULT,
+                          CW_USEDEFAULT,
+                          NULL,
+                          NULL,
+                          HINST_THISCOMPONENT,
+                          NULL);
 
-    ok(window != NULL, "Failed to create window of class \"%s\", code: %ld\n", class_name, GetLastError());
-    if (window == NULL)
+    ok(Window != NULL,
+       "Failed to create window of class \"%s\", code: %ld\n",
+       ClassName, GetLastError());
+
+    if (Window == NULL)
     {
         return;
     }
 
-    ShowWindow(window, SW_SHOWNORMAL);
-    UpdateWindow(window);
+    ShowWindow(Window, SW_SHOWNORMAL);
+    UpdateWindow(Window);
 
-    while (GetMessage(&msg, NULL, 0, 0))
+    while (GetMessage(&Message, NULL, 0, 0))
     {
-        TranslateMessage(&msg);
-        DispatchMessage(&msg);
+        TranslateMessage(&Message);
+        DispatchMessage(&Message);
     }
 }
 
 START_TEST(ScrollBarRedraw)
 {
-    BOOL bool_ret;
+    BOOL BoolRC;
 
-    bool_ret = colors_init();
-    ok(bool_ret, "Failed to initialize colors and solid color brushes\n");
-    if (!bool_ret)
+    BoolRC = ColorsInit();
+    ok(BoolRC, "Failed to initialize colors and solid color brushes\n");
+    if (!BoolRC)
     {
         return;
     }
 
     trace("Running test without specifying either CS_HREDRAW or CS_HREDRAW\n");
-    have_hredraw = FALSE;
-    have_vredraw = FALSE;
-    run_test_window(
-            TEST_CLASS_NAME   "_noredraw",
-            TEST_WINDOW_TITLE "_noredraw",
-            0);
+    HaveHRedraw = FALSE;
+    HaveVRedraw = FALSE;
+    RunTestWindow(TEST_CLASS_NAME   "NoRedraw",
+                  TEST_WINDOW_TITLE " (No Redraw Flags)",
+                  0);
 
     trace("Running test with CS_HREDRAW\n");
-    have_hredraw = TRUE;
-    have_vredraw = FALSE;
-    run_test_window(
-            TEST_CLASS_NAME   "_hredraw",
-            TEST_WINDOW_TITLE "_hredraw",
-            CS_HREDRAW);
+    HaveHRedraw = TRUE;
+    HaveVRedraw = FALSE;
+    RunTestWindow(TEST_CLASS_NAME   "HRedraw",
+                  TEST_WINDOW_TITLE " (CS_HREDRAW)",
+                  CS_HREDRAW);
 
     trace("Running test with CS_VREDRAW\n");
-    have_hredraw = FALSE;
-    have_vredraw = TRUE;
-    run_test_window(
-            TEST_CLASS_NAME   "_vredraw",
-            TEST_WINDOW_TITLE "_vredraw",
-            CS_VREDRAW);
+    HaveHRedraw = FALSE;
+    HaveVRedraw = TRUE;
+    RunTestWindow(TEST_CLASS_NAME   "VRedraw",
+                  TEST_WINDOW_TITLE " (CS_VREDRAW)",
+                  CS_VREDRAW);
 
     trace("Running test with both CS_HREDRAW and CS_VREDRAW\n");
-    have_hredraw = TRUE;
-    have_vredraw = TRUE;
-    run_test_window(
-            TEST_CLASS_NAME   "_hredraw_vredraw",
-            TEST_WINDOW_TITLE "_hredraw_vredraw",
-            CS_HREDRAW | CS_VREDRAW);
+    HaveHRedraw = TRUE;
+    HaveVRedraw = TRUE;
+    RunTestWindow(TEST_CLASS_NAME   "HRedrawVRedraw",
+                  TEST_WINDOW_TITLE " (CS_HREDRAW | CS_VREDRAW)",
+                  CS_HREDRAW | CS_VREDRAW);
 
     trace("Test complete\n");
-    colors_cleanup();
+    ColorsCleanup();
 }
 
-static void
-hide_vert_scroll_bar(HWND window)
+static void HideVertScrollBar(HWND Window)
 {
-    SCROLLINFO scroll_info;
+    SCROLLINFO ScrollInfo;
 
-    scroll_info.cbSize = sizeof(scroll_info);
-    scroll_info.fMask = SIF_RANGE | SIF_PAGE | SIF_POS;
-    scroll_info.nPage = client_height;
+    ScrollInfo.cbSize = sizeof(ScrollInfo);
+    ScrollInfo.fMask = SIF_RANGE | SIF_PAGE | SIF_POS;
+    ScrollInfo.nPage = ClientHeight;
 
-    scroll_info.nMin = 0;
-    scroll_info.nMax = client_height-1;
-    scroll_info.nPos = 0;
+    ScrollInfo.nMin = 0;
+    ScrollInfo.nMax = ClientHeight - 1;
+    ScrollInfo.nPos = 0;
 
-    SetScrollInfo(window, SB_VERT, &scroll_info, TRUE);
+    SetScrollInfo(Window, SB_VERT, &ScrollInfo, TRUE);
 }
 
-static void
-show_vert_scroll_bar(HWND window)
+static void ShowVertScrollBar(HWND Window)
 {
-    SCROLLINFO scroll_info;
+    SCROLLINFO ScrollInfo;
 
-    scroll_info.cbSize = sizeof(scroll_info);
-    scroll_info.fMask = SIF_RANGE | SIF_PAGE | SIF_POS;
-    scroll_info.nPage = client_height;
+    ScrollInfo.cbSize = sizeof(ScrollInfo);
+    ScrollInfo.fMask = SIF_RANGE | SIF_PAGE | SIF_POS;
+    ScrollInfo.nPage = ClientHeight;
 
-    scroll_info.nMin = 0;
-    scroll_info.nMax = (3*client_height)-1;
-    scroll_info.nPos = 0;
+    ScrollInfo.nMin = 0;
+    ScrollInfo.nMax = (3 * ClientHeight) - 1;
+    ScrollInfo.nPos = 0;
 
-    SetScrollInfo(window, SB_VERT, &scroll_info, TRUE);
+    SetScrollInfo(Window, SB_VERT, &ScrollInfo, TRUE);
 }
 
-static void
-hide_horz_scroll_bar(HWND window)
+static void HideHorzScrollBar(HWND Window)
 {
-    SCROLLINFO scroll_info;
+    SCROLLINFO ScrollInfo;
 
-    scroll_info.cbSize = sizeof(scroll_info);
-    scroll_info.fMask = SIF_RANGE | SIF_PAGE | SIF_POS;
-    scroll_info.nPage = client_width;
+    ScrollInfo.cbSize = sizeof(ScrollInfo);
+    ScrollInfo.fMask = SIF_RANGE | SIF_PAGE | SIF_POS;
+    ScrollInfo.nPage = ClientWidth;
 
-    scroll_info.nMin = 0;
-    scroll_info.nMax = client_width-1;
-    scroll_info.nPos = 0;
+    ScrollInfo.nMin = 0;
+    ScrollInfo.nMax = ClientWidth - 1;
+    ScrollInfo.nPos = 0;
 
-    SetScrollInfo(window, SB_HORZ, &scroll_info, TRUE);
+    SetScrollInfo(Window, SB_HORZ, &ScrollInfo, TRUE);
 }
 
-static void
-show_horz_scroll_bar(HWND window)
+static void ShowHorzScrollBar(HWND Window)
 {
-    SCROLLINFO scroll_info;
+    SCROLLINFO ScrollInfo;
 
-    scroll_info.cbSize = sizeof(scroll_info);
-    scroll_info.fMask = SIF_RANGE | SIF_PAGE | SIF_POS;
-    scroll_info.nPage = client_width;
+    ScrollInfo.cbSize = sizeof(ScrollInfo);
+    ScrollInfo.fMask = SIF_RANGE | SIF_PAGE | SIF_POS;
+    ScrollInfo.nPage = ClientWidth;
 
-    scroll_info.nMin = 0;
-    scroll_info.nMax = (3*client_width)-1;
-    scroll_info.nPos = 0;
+    ScrollInfo.nMin = 0;
+    ScrollInfo.nMax = (3 * ClientWidth) - 1;
+    ScrollInfo.nPos = 0;
 
-    SetScrollInfo(window, SB_HORZ, &scroll_info, TRUE);
+    SetScrollInfo(Window, SB_HORZ, &ScrollInfo, TRUE);
 }
 
-static int
-fsm_transition(HWND window)
+static int FsmStep(HWND Window)
 {
-    static COLORREF prev_color = CLR_INVALID;
-    COLORREF color = CLR_INVALID;
-    HDC dev_ctx = NULL;
+    static COLORREF PrevColor = CLR_INVALID;
+    COLORREF Color = CLR_INVALID;
+    HDC hdc = NULL;
 
-    if (fsm_state != FSM_STATE_END)
+    if (FsmState != FSM_STATE_END)
     {
-        dev_ctx = GetDC(window);
+        hdc = GetDC(Window);
 
-        ok(dev_ctx != NULL, "Failed to get device context\n");
-        if (dev_ctx == NULL)
+        ok(hdc != NULL, "Failed to get device context\n");
+        if (hdc == NULL)
         {
-            DestroyWindow(window);
-            fsm_state = FSM_STATE_END;
+            DestroyWindow(Window);
+            FsmState = FSM_STATE_END;
         }
         else
         {
-            color = GetPixel(dev_ctx, client_width / 4, client_height / 4);
-            ok(color != CLR_INVALID, "Failed to get window color\n");
+            Color = GetPixel(hdc, ClientWidth / 4, ClientHeight / 4);
+            ok(Color != CLR_INVALID, "Failed to get window color\n");
         }
     }
 
-    trace("fsm_state: %d, color: 0x%.8lX\n", fsm_state, color);
+    trace("FsmState: %d, Color: 0x%.8lX\n", FsmState, Color);
 
-    switch (fsm_state)
+    switch (FsmState)
     {
-    case FSM_STATE_START:
+        case FSM_STATE_START:
 
-        show_vert_scroll_bar(window);
-        fsm_state = FSM_STATE_VSCR_SHOWN;
-        break;
+            ShowVertScrollBar(Window);
+            FsmState = FSM_STATE_VSCR_SHOWN;
+            break;
 
-    case FSM_STATE_VSCR_SHOWN:
+        case FSM_STATE_VSCR_SHOWN:
 
-        if (have_hredraw)
-        {
-            ok(color != prev_color,
-               "CS_HREDRAW specified, but appearence of vertical scroll bar didn't trigger redraw, prev_color: 0x%.8lX, color: 0x%.8lX\n",
-               prev_color, color);
-        }
-        else
-        {
-            ok(color == prev_color,
-               "CS_HREDRAW not specified, but appearence of vertical scroll bar triggered unneccessary redraw, prev_color: 0x%.8lX, color: 0x%.8lX\n",
-               prev_color, color);
-        }
+            if (HaveHRedraw)
+            {
+                ok(Color != PrevColor,
+                   "CS_HREDRAW specified, but appearence of vertical scroll bar"
+                   " didn't trigger redraw, PrevColor: 0x%.8lX, Color: 0x%.8lX\n",
+                   PrevColor, Color);
+            }
+            else
+            {
+                ok(Color == PrevColor,
+                   "CS_HREDRAW not specified, but appearence of vertical scroll bar"
+                   " triggered unneccessary redraw, PrevColor: 0x%.8lX, Color: 0x%.8lX\n",
+                   PrevColor, Color);
+            }
 
-        hide_vert_scroll_bar(window);
-        fsm_state = FSM_STATE_VSCR_HIDDEN;
+            HideVertScrollBar(Window);
+            FsmState = FSM_STATE_VSCR_HIDDEN;
 
-        break;
+            break;
 
-    case FSM_STATE_VSCR_HIDDEN:
+        case FSM_STATE_VSCR_HIDDEN:
 
-        if (have_hredraw)
-        {
-            ok(color != prev_color,
-               "CS_HREDRAW specified, but disappearence of vertical scroll bar didn't trigger redraw, prev_color: 0x%.8lX, color: 0x%.8lX\n",
-               prev_color, color);
-        }
-        else
-        {
-            ok(color == prev_color,
-               "CS_HREDRAW not specified, but disappearence of vertical scroll bar triggered unneccessary redraw, prev_color: 0x%.8lX, color: 0x%.8lX\n",
-               prev_color, color);
-        }
+            if (HaveHRedraw)
+            {
+                ok(Color != PrevColor,
+                   "CS_HREDRAW specified, but disappearence of vertical scroll bar"
+                   " didn't trigger redraw, PrevColor: 0x%.8lX, Color: 0x%.8lX\n",
+                   PrevColor, Color);
+            }
+            else
+            {
+                ok(Color == PrevColor,
+                   "CS_HREDRAW not specified, but disappearence of vertical scroll bar"
+                   " triggered unneccessary redraw, PrevColor: 0x%.8lX, Color: 0x%.8lX\n",
+                   PrevColor, Color);
+            }
 
-        show_horz_scroll_bar(window);
-        fsm_state = FSM_STATE_HSCR_SHOWN;
-        break;
+            ShowHorzScrollBar(Window);
+            FsmState = FSM_STATE_HSCR_SHOWN;
+            break;
 
-    case FSM_STATE_HSCR_SHOWN:
+        case FSM_STATE_HSCR_SHOWN:
 
-        if (have_vredraw)
-        {
-            ok(color != prev_color,
-               "CS_VREDRAW specified, but appearence of horizontal scroll bar didn't trigger redraw, prev_color: 0x%.8lX, color: 0x%.8lX\n",
-               prev_color, color);
-        }
-        else
-        {
-            ok(color == prev_color,
-               "CS_VREDRAW not specified, but appearence of horizontal scroll bar triggered unneccessary redraw, prev_color: 0x%.8lX, color: 0x%.8lX\n",
-               prev_color, color);
-        }
+            if (HaveVRedraw)
+            {
+                ok(Color != PrevColor,
+                   "CS_VREDRAW specified, but appearence of horizontal scroll bar"
+                   " didn't trigger redraw, PrevColor: 0x%.8lX, Color: 0x%.8lX\n",
+                   PrevColor, Color);
+            }
+            else
+            {
+                ok(Color == PrevColor,
+                   "CS_VREDRAW not specified, but appearence of horizontal scroll bar"
+                   " triggered unneccessary redraw, PrevColor: 0x%.8lX, Color: 0x%.8lX\n",
+                   PrevColor, Color);
+            }
 
-        hide_horz_scroll_bar(window);
-        fsm_state = FSM_STATE_HSCR_HIDDEN;
-        break;
+            HideHorzScrollBar(Window);
+            FsmState = FSM_STATE_HSCR_HIDDEN;
+            break;
 
-    case FSM_STATE_HSCR_HIDDEN:
+        case FSM_STATE_HSCR_HIDDEN:
 
-        if (have_vredraw)
-        {
-            ok(color != prev_color,
-               "CS_VREDRAW specified, but disappearence of horizontal scroll bar didn't trigger redraw, prev_color: 0x%.8lX, color: 0x%.8lX\n",
-               prev_color, color);
-        }
-        else
-        {
-            ok(color == prev_color,
-               "CS_VREDRAW not specified, but disappearence of horizontal scroll bar triggered unneccessary redraw, prev_color: 0x%.8lX, color: 0x%.8lX\n",
-               prev_color, color);
-        }
+            if (HaveVRedraw)
+            {
+                ok(Color != PrevColor,
+                   "CS_VREDRAW specified, but disappearence of horizontal scroll bar"
+                   " didn't trigger redraw, PrevColor: 0x%.8lX, Color: 0x%.8lX\n",
+                   PrevColor, Color);
+            }
+            else
+            {
+                ok(Color == PrevColor,
+                   "CS_VREDRAW not specified, but disappearence of horizontal scroll bar"
+                   " triggered unneccessary redraw, PrevColor: 0x%.8lX, Color: 0x%.8lX\n",
+                   PrevColor, Color);
+            }
 
-        show_vert_scroll_bar(window);
-        show_horz_scroll_bar(window);
+            ShowVertScrollBar(Window);
+            ShowHorzScrollBar(Window);
 
-        fsm_state = FSM_STATE_BSCR_SHOWN;
-        break;
+            FsmState = FSM_STATE_BSCR_SHOWN;
+            break;
 
-    case FSM_STATE_BSCR_SHOWN:
+        case FSM_STATE_BSCR_SHOWN:
 
-        if (have_hredraw || have_vredraw)
-        {
-            ok(color != prev_color,
-               "CS_HREDRAW or CS_VREDRAW specified, but appearence of both scroll bars didn't trigger redraw, prev_color: 0x%.8lX, color: 0x%.8lX\n",
-               prev_color, color);
-        }
-        else
-        {
-            ok(color == prev_color,
-               "Neither CS_HREDRAW nor CS_VREDRAW specified, but appearence of both scroll bars triggered unneccessary redraw, prev_color: 0x%.8lX, color: 0x%.8lX\n",
-               prev_color, color);
-        }
+            if (HaveHRedraw || HaveVRedraw)
+            {
+                ok(Color != PrevColor,
+                   "CS_HREDRAW or CS_VREDRAW specified, but appearence of both scroll bars"
+                   " didn't trigger redraw, PrevColor: 0x%.8lX, Color: 0x%.8lX\n",
+                   PrevColor, Color);
+            }
+            else
+            {
+                ok(Color == PrevColor,
+                   "Neither CS_HREDRAW nor CS_VREDRAW specified, but appearence"
+                   " of both scroll bars triggered unneccessary redraw,"
+                   " PrevColor: 0x%.8lX, Color: 0x%.8lX\n",
+                   PrevColor, Color);
+            }
 
-        hide_vert_scroll_bar(window);
-        hide_horz_scroll_bar(window);
+            HideVertScrollBar(Window);
+            HideHorzScrollBar(Window);
 
-        fsm_state = FSM_STATE_BSCR_HIDDEN;
-        break;
+            FsmState = FSM_STATE_BSCR_HIDDEN;
+            break;
 
-    case FSM_STATE_BSCR_HIDDEN:
+        case FSM_STATE_BSCR_HIDDEN:
 
-        if (have_hredraw || have_vredraw)
-        {
-            ok(color != prev_color,
-               "CS_HREDRAW or CS_VREDRAW specified, but disappearence of both scroll bars didn't trigger redraw, prev_color: 0x%.8lX, color: 0x%.8lX\n",
-               prev_color, color);
-        }
-        else
-        {
-            ok(color == prev_color,
-               "Neither CS_HREDRAW nor CS_VREDRAW specified, but disappearence of both scroll bars triggered unneccessary redraw, prev_color: 0x%.8lX, color: 0x%.8lX\n",
-               prev_color, color);
-        }
+            if (HaveHRedraw || HaveVRedraw)
+            {
+                ok(Color != PrevColor,
+                   "CS_HREDRAW or CS_VREDRAW specified, but disappearence of both scroll bars"
+                   " didn't trigger redraw, PrevColor: 0x%.8lX, Color: 0x%.8lX\n",
+                   PrevColor, Color);
+            }
+            else
+            {
+                ok(Color == PrevColor,
+                   "Neither CS_HREDRAW nor CS_VREDRAW specified, but disappearence"
+                   " of both scroll bars triggered unneccessary redraw,"
+                   " PrevColor: 0x%.8lX, Color: 0x%.8lX\n",
+                   PrevColor, Color);
+            }
 
-        SetWindowPos(window, HWND_TOPMOST, 0, 0, small_width, orig_height, SWP_NOMOVE);
-        fsm_state = FSM_STATE_WIDTH_SHRUNK;
-        break;
+            SetWindowPos(Window, HWND_TOPMOST, 0, 0, SmallWidth, OrigHeight, SWP_NOMOVE);
+            FsmState = FSM_STATE_WIDTH_SHRUNK;
+            break;
 
-    case FSM_STATE_WIDTH_SHRUNK:
+        case FSM_STATE_WIDTH_SHRUNK:
 
-        if (have_hredraw)
-        {
-            ok(color != prev_color,
-               "CS_HREDRAW specified, but horizontal window shrinkage didn't trigger redraw, prev_color: 0x%.8lX, color: 0x%.8lX\n",
-               prev_color, color);
-        }
-        else
-        {
-            ok(color == prev_color,
-               "CS_HREDRAW not specified, but horizontal window shrinkage triggered unneccessary redraw, prev_color: 0x%.8lX, color: 0x%.8lX\n",
-               prev_color, color);
-        }
+            if (HaveHRedraw)
+            {
+                ok(Color != PrevColor,
+                   "CS_HREDRAW specified, but horizontal window shrinkage"
+                   " didn't trigger redraw, PrevColor: 0x%.8lX, Color: 0x%.8lX\n",
+                   PrevColor, Color);
+            }
+            else
+            {
+                ok(Color == PrevColor,
+                   "CS_HREDRAW not specified, but horizontal window shrinkage"
+                   " triggered unneccessary redraw, PrevColor: 0x%.8lX, Color: 0x%.8lX\n",
+                   PrevColor, Color);
+            }
 
-        SetWindowPos(window, HWND_TOPMOST, 0, 0, orig_width, orig_height, SWP_NOMOVE);
-        fsm_state = FSM_STATE_WIDTH_EXPANDED;
-        break;
+            SetWindowPos(Window, HWND_TOPMOST, 0, 0, OrigWidth, OrigHeight, SWP_NOMOVE);
+            FsmState = FSM_STATE_WIDTH_EXPANDED;
+            break;
 
-    case FSM_STATE_WIDTH_EXPANDED:
+        case FSM_STATE_WIDTH_EXPANDED:
 
-        if (have_hredraw)
-        {
-            ok(color != prev_color,
-               "CS_HREDRAW specified, but horizontal window expansion didn't trigger redraw, prev_color: 0x%.8lX, color: 0x%.8lX\n",
-               prev_color, color);
-        }
-        else
-        {
-            ok(color == prev_color,
-               "CS_HREDRAW not specified, but horizontal window expansion triggered unneccessary redraw, prev_color: 0x%.8lX, color: 0x%.8lX\n",
-               prev_color, color);
-        }
+            if (HaveHRedraw)
+            {
+                ok(Color != PrevColor,
+                   "CS_HREDRAW specified, but horizontal window expansion"
+                   " didn't trigger redraw, PrevColor: 0x%.8lX, Color: 0x%.8lX\n",
+                   PrevColor, Color);
+            }
+            else
+            {
+                ok(Color == PrevColor,
+                   "CS_HREDRAW not specified, but horizontal window expansion"
+                   " triggered unneccessary redraw, PrevColor: 0x%.8lX, Color: 0x%.8lX\n",
+                   PrevColor, Color);
+            }
 
-        SetWindowPos(window, HWND_TOPMOST, 0, 0, orig_width, small_height, SWP_NOMOVE);
-        fsm_state = FSM_STATE_HEIGHT_SHRUNK;
-        break;
+            SetWindowPos(Window, HWND_TOPMOST, 0, 0, OrigWidth, SmallHeight, SWP_NOMOVE);
+            FsmState = FSM_STATE_HEIGHT_SHRUNK;
+            break;
 
-    case FSM_STATE_HEIGHT_SHRUNK:
+        case FSM_STATE_HEIGHT_SHRUNK:
 
-        if (have_vredraw)
-        {
-            ok(color != prev_color,
-               "CS_VREDRAW specified, but vertical window shrinkage didn't trigger redraw, prev_color: 0x%.8lX, color: 0x%.8lX\n",
-               prev_color, color);
-        }
-        else
-        {
-            ok(color == prev_color,
-               "CS_VREDRAW not specified, but vertical window shrinkage triggered unneccessary redraw, prev_color: 0x%.8lX, color: 0x%.8lX\n",
-               prev_color, color);
-        }
+            if (HaveVRedraw)
+            {
+                ok(Color != PrevColor,
+                   "CS_VREDRAW specified, but vertical window shrinkage"
+                   " didn't trigger redraw, PrevColor: 0x%.8lX, Color: 0x%.8lX\n",
+                   PrevColor, Color);
+            }
+            else
+            {
+                ok(Color == PrevColor,
+                   "CS_VREDRAW not specified, but vertical window shrinkage"
+                   " triggered unneccessary redraw, PrevColor: 0x%.8lX, Color: 0x%.8lX\n",
+                   PrevColor, Color);
+            }
 
-        SetWindowPos(window, HWND_TOPMOST, 0, 0, orig_width, orig_height, SWP_NOMOVE);
-        fsm_state = FSM_STATE_HEIGHT_EXPANDED;
-        break;
+            SetWindowPos(Window, HWND_TOPMOST, 0, 0, OrigWidth, OrigHeight, SWP_NOMOVE);
+            FsmState = FSM_STATE_HEIGHT_EXPANDED;
+            break;
 
-    case FSM_STATE_HEIGHT_EXPANDED:
+        case FSM_STATE_HEIGHT_EXPANDED:
 
-        if (have_vredraw)
-        {
-            ok(color != prev_color,
-               "CS_VREDRAW specified, but vertical window expansion didn't trigger redraw, prev_color: 0x%.8lX, color: 0x%.8lX\n",
-               prev_color, color);
-        }
-        else
-        {
-            ok(color == prev_color,
-               "CS_VREDRAW not specified, but vertical window expansion triggered unneccessary redraw, prev_color: 0x%.8lX, color: 0x%.8lX\n",
-               prev_color, color);
-        }
+            if (HaveVRedraw)
+            {
+                ok(Color != PrevColor,
+                   "CS_VREDRAW specified, but vertical window expansion"
+                   " didn't trigger redraw, PrevColor: 0x%.8lX, Color: 0x%.8lX\n",
+                   PrevColor, Color);
+            }
+            else
+            {
+                ok(Color == PrevColor,
+                   "CS_VREDRAW not specified, but vertical window expansion"
+                   " triggered unneccessary redraw, PrevColor: 0x%.8lX, Color: 0x%.8lX\n",
+                   PrevColor, Color);
+            }
 
-        SetWindowPos(window, HWND_TOPMOST, 0, 0, small_width, small_height, SWP_NOMOVE);
+            SetWindowPos(Window, HWND_TOPMOST, 0, 0, SmallWidth, SmallHeight, SWP_NOMOVE);
 
-        fsm_state = FSM_STATE_BOTH_SHRUNK;
-        break;
+            FsmState = FSM_STATE_BOTH_SHRUNK;
+            break;
 
-    case FSM_STATE_BOTH_SHRUNK:
+        case FSM_STATE_BOTH_SHRUNK:
 
-        if (have_hredraw || have_vredraw)
-        {
-            ok(color != prev_color,
-               "CS_HREDRAW or CS_VREDRAW specified, but combined vertical/horizontal shrinkage didn't trigger redraw, prev_color: 0x%.8lX, color: 0x%.8lX\n",
-               prev_color, color);
-        }
-        else
-        {
-            ok(color == prev_color,
-               "Neither CS_HREDRAW nor CS_VREDRAW specified, but combined vertical/horizontal shrinkage triggered unneccessary redraw, prev_color: 0x%.8lX, color: 0x%.8lX\n",
-               prev_color, color);
-        }
+            if (HaveHRedraw || HaveVRedraw)
+            {
+                ok(Color != PrevColor,
+                   "CS_HREDRAW or CS_VREDRAW specified, but combined"
+                   " vertical/horizontal shrinkage didn't trigger redraw,"
+                   " PrevColor: 0x%.8lX, Color: 0x%.8lX\n",
+                   PrevColor, Color);
+            }
+            else
+            {
+                ok(Color == PrevColor,
+                   "Neither CS_HREDRAW nor CS_VREDRAW specified, but combined"
+                   " vertical/horizontal shrinkage triggered unneccessary redraw,"
+                   " PrevColor: 0x%.8lX, Color: 0x%.8lX\n",
+                   PrevColor, Color);
+            }
 
-        SetWindowPos(window, HWND_TOPMOST, 0, 0, orig_width, orig_height, SWP_NOMOVE);
+            SetWindowPos(Window, HWND_TOPMOST, 0, 0, OrigWidth, OrigHeight, SWP_NOMOVE);
 
-        fsm_state = FSM_STATE_BOTH_EXPANDED;
-        break;
+            FsmState = FSM_STATE_BOTH_EXPANDED;
+            break;
 
-    case FSM_STATE_BOTH_EXPANDED:
+        case FSM_STATE_BOTH_EXPANDED:
 
-        if (have_hredraw || have_vredraw)
-        {
-            ok(color != prev_color,
-               "CS_HREDRAW or CS_VREDRAW specified, but combined vertical/horizontal expansion didn't trigger redraw, prev_color: 0x%.8lX, color: 0x%.8lX\n",
-               prev_color, color);
-        }
-        else
-        {
-            ok(color == prev_color,
-               "Neither CS_HREDRAW nor CS_VREDRAW specified, but combined vertical/horizontal expansion triggered unneccessary redraw, prev_color: 0x%.8lX, color: 0x%.8lX\n",
-               prev_color, color);
-        }
+            if (HaveHRedraw || HaveVRedraw)
+            {
+                ok(Color != PrevColor,
+                   "CS_HREDRAW or CS_VREDRAW specified, but combined"
+                   " vertical/horizontal expansion didn't trigger redraw,"
+                   " PrevColor: 0x%.8lX, Color: 0x%.8lX\n",
+                   PrevColor, Color);
+            }
+            else
+            {
+                ok(Color == PrevColor,
+                   "Neither CS_HREDRAW nor CS_VREDRAW specified, but combined"
+                   " vertical/horizontal expansion triggered unneccessary redraw,"
+                   " PrevColor: 0x%.8lX, Color: 0x%.8lX\n",
+                   PrevColor, Color);
+            }
 
-        DestroyWindow(window);
-        fsm_state = FSM_STATE_END;
-        break;
+            DestroyWindow(Window);
 
-    case FSM_STATE_END:
-        break;
+            FsmState = FSM_STATE_END;
+            break;
+
+        case FSM_STATE_END:
+            break;
     }
 
-    if (dev_ctx != NULL)
+    if (hdc != NULL)
     {
-        prev_color = color;
-        ReleaseDC(window, dev_ctx);
+        PrevColor = Color;
+        ReleaseDC(Window, hdc);
     }
 
     return 0;
 }
 
-static int
-on_resize(HWND window, int new_width, int new_height)
+static int OnResize(HWND Window, int NewWidth, int NewHeight)
 {
-    current_color = (current_color + 1) % TEST_COLOR_COUNT;
+    CurrentColor = (CurrentColor + 1) % TEST_COLOR_COUNT;
     SetClassLongPtr(
-            window,
+            Window,
             GCLP_HBRBACKGROUND,
-            (LONG_PTR)color_brushes[current_color]);
+            (LONG_PTR)ColorBrushes[CurrentColor]);
 
     trace("New window size: %d x %d, new color: 0x%.8lX\n",
-          new_width, new_height, colors[current_color]);
+          NewWidth, NewHeight, Colors[CurrentColor]);
 
     return 0;
 }
 
-static LRESULT CALLBACK
-proc_cb(HWND window, UINT message, WPARAM w_param, LPARAM l_param)
+static LRESULT CALLBACK WindowProc(HWND Window, UINT Message, WPARAM wParam, LPARAM lParam)
 {
-    RECT rect;
-    BOOL bool_ret;
-    int width;
-    int height;
+    RECT Rect;
+    BOOL BoolRC;
+    int Width;
+    int Height;
 
-    switch (message)
+    switch (Message)
     {
-    case WM_CREATE:
+        case WM_CREATE:
 
-        /* It's important for the test that the entire window is visible. */
-        bool_ret = SetWindowPos(window, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
-        ok(bool_ret, "Failed to set window as top-most, code: %ld\n", GetLastError());
+            /* It's important for the test that the entire Window is visible. */
+            BoolRC = SetWindowPos(Window, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
+            ok(BoolRC, "Failed to set window as top-most, code: %ld\n", GetLastError());
 
-        bool_ret = GetClientRect(window, &rect);
-        ok(bool_ret, "Failed to retrieve client window dimensions, code: %ld\n", GetLastError());
+            BoolRC = GetClientRect(Window, &Rect);
+            ok(BoolRC, "Failed to retrieve client area dimensions, code: %ld\n", GetLastError());
 
-        if (bool_ret)
-        {
-            client_width = rect.right;
-            client_height = rect.bottom;
-        }
-        else
-        {
-            return -1;
-        }
+            if (BoolRC)
+            {
+                ClientWidth = Rect.right;
+                ClientHeight = Rect.bottom;
+            }
+            else
+            {
+                return -1;
+            }
 
-        bool_ret = GetWindowRect(window, &rect);
-        ok(bool_ret, "Failed to retrieve window dimensions, code: %ld\n", GetLastError());
+            BoolRC = GetWindowRect(Window, &Rect);
+            ok(BoolRC, "Failed to retrieve window dimensions, code: %ld\n", GetLastError());
 
-        if (bool_ret)
-        {
-            orig_width  = rect.right - rect.left;
-            orig_height = rect.bottom - rect.top;
-        }
-        else
-        {
-            return -1;
-        }
+            if (BoolRC)
+            {
+                OrigWidth  = Rect.right - Rect.left;
+                OrigHeight = Rect.bottom - Rect.top;
+            }
+            else
+            {
+                return -1;
+            }
 
-        small_width  = max((orig_width  * 3) / 4, 1);
-        small_height = max((orig_height * 3) / 4, 1);
-        orig_width   = max(orig_width,  small_width+1);
-        orig_height  = max(orig_height, small_height+1);
+            SmallWidth  = max((OrigWidth  * 3) / 4, 1);
+            SmallHeight = max((OrigHeight * 3) / 4, 1);
+            OrigWidth   = max(OrigWidth,  SmallWidth+1);
+            OrigHeight  = max(OrigHeight, SmallHeight+1);
 
-        trace("orig_width: %d, orig_height: %d, small_width: %d, small_height: %d\n",
-              orig_width, orig_height, small_width, small_height);
+            trace("OrigWidth: %d, OrigHeight: %d, SmallWidth: %d, SmallHeight: %d\n",
+                  OrigWidth, OrigHeight, SmallWidth, SmallHeight);
 
-        hide_vert_scroll_bar(window);
-        hide_horz_scroll_bar(window);
+            HideVertScrollBar(Window);
+            HideHorzScrollBar(Window);
 
-        fsm_state = FSM_STATE_START;
-        fsm_timer = SetTimer(window, 1, 500, NULL);
-        ok(fsm_timer != 0, "Failed to initialize FSM timer, code: %ld\n", GetLastError());
+            FsmState = FSM_STATE_START;
+            FsmTimer = SetTimer(Window, 1, 500, NULL);
+            ok(FsmTimer != 0, "Failed to initialize FSM timer, code: %ld\n", GetLastError());
 
-        if (fsm_timer == 0)
-        {
-            return -1;
-        }
-        return 0;
+            if (FsmTimer == 0)
+            {
+                return -1;
+            }
+            return 0;
 
-    case WM_SIZE:
+        case WM_SIZE:
 
-        width = LOWORD(l_param);
-        height = HIWORD(l_param);
+            Width = LOWORD(lParam);
+            Height = HIWORD(lParam);
 
-        if (width != 0 && height != 0 &&
-            (width != client_width || height != client_height))
-        {
-            return on_resize(window, width, height);
+            if (Width != 0 && Height != 0 &&
+                (Width != ClientWidth || Height != ClientHeight))
+            {
+                return OnResize(Window, Width, Height);
 
-            client_width = width;
-            client_height = height;
-        }
-        return 0;
+                ClientWidth = Width;
+                ClientHeight = Height;
+            }
+            return 0;
 
-    case WM_TIMER:
+        case WM_TIMER:
 
-        if (w_param != 0 && w_param == fsm_timer)
-        {
-            return fsm_transition(window);
-        }
-        break;
+            if (wParam != 0 && wParam == FsmTimer)
+            {
+                return FsmStep(Window);
+            }
+            break;
 
-    case WM_NCDESTROY:
+        case WM_NCDESTROY:
 
-        if (fsm_timer != 0)
-        {
-            KillTimer(window, fsm_timer);
-            fsm_timer = 0;
-        }
-        return 0;
+            if (FsmTimer != 0)
+            {
+                KillTimer(Window, FsmTimer);
+                FsmTimer = 0;
+            }
+            return 0;
 
-    case WM_DESTROY:
+        case WM_DESTROY:
 
-        PostQuitMessage(0);
-        return 0;
+            PostQuitMessage(0);
+            return 0;
     }
-    return DefWindowProc(window, message, w_param, l_param);
+    return DefWindowProc(Window, Message, wParam, lParam);
 }

--- a/modules/rostests/apitests/user32/ScrollBarRedraw.c
+++ b/modules/rostests/apitests/user32/ScrollBarRedraw.c
@@ -694,7 +694,8 @@ static LRESULT CALLBACK WindowProc(HWND Window, UINT Message, WPARAM wParam, LPA
         }
 
         case WM_ERASEBKGND:
-            return 1; /* We use WM_PAINT instead. */
+            /* We use WM_PAINT instead, since WM_ERASEBKGND is issued before WM_SIZE. */
+            return 1;
 
         case WM_TIMER:
             if (wParam != 0 && wParam == FsmTimer)

--- a/modules/rostests/apitests/user32/ScrollBarRedraw.c
+++ b/modules/rostests/apitests/user32/ScrollBarRedraw.c
@@ -590,7 +590,7 @@ static int OnPaint(HWND Window)
         return 0;
     }
 
-    if(!FillRgn(hdc, Region, ColorBrushes[CurrentColor]))
+    if (!FillRgn(hdc, Region, ColorBrushes[CurrentColor]))
     {
         skip("Failed to paint the window\n");
         DeleteObject(Region);

--- a/modules/rostests/apitests/user32/ScrollBarRedraw.c
+++ b/modules/rostests/apitests/user32/ScrollBarRedraw.c
@@ -5,9 +5,7 @@
  * COPYRIGHT:   Copyright 2024 Marek Benc <benc.marek.elektro98@proton.me>
  */
 
-#include <assert.h>
-#include <windows.h>
-#include "wine/test.h"
+#include "precomp.h"
 
 #define TEST_CLASS_NAME   L"ScrollBarRedraw"
 #define TEST_WINDOW_TITLE L"ScrollBarRedraw"

--- a/modules/rostests/apitests/user32/ScrollBarRedraw.c
+++ b/modules/rostests/apitests/user32/ScrollBarRedraw.c
@@ -275,8 +275,8 @@ static int FsmStep(HWND Window)
         {
             skip("Failed to get device context\n");
 
-            DestroyWindow(Window);
             FsmState = FSM_STATE_END;
+            DestroyWindow(Window);
 
             return 0;
         }
@@ -289,8 +289,8 @@ static int FsmStep(HWND Window)
         {
             skip("Failed to get window color\n");
 
-            DestroyWindow(Window);
             FsmState = FSM_STATE_END;
+            DestroyWindow(Window);
 
             return 0;
         }
@@ -553,9 +553,8 @@ static int FsmStep(HWND Window)
                    PrevColor, Color);
             }
 
-            DestroyWindow(Window);
-
             FsmState = FSM_STATE_END;
+            DestroyWindow(Window);
             break;
 
         case FSM_STATE_END:
@@ -707,6 +706,11 @@ static LRESULT CALLBACK WindowProc(HWND Window, UINT Message, WPARAM wParam, LPA
             {
                 KillTimer(Window, FsmTimer);
                 FsmTimer = 0;
+
+                if (FsmState != FSM_STATE_END)
+                {
+                    skip("Window was closed before test concluded, FsmState: %d, FSM_STATE_END: %d.\n", FsmState, FSM_STATE_END);
+                }
             }
             return 0;
 

--- a/modules/rostests/apitests/user32/ScrollBarRedraw.c
+++ b/modules/rostests/apitests/user32/ScrollBarRedraw.c
@@ -41,6 +41,8 @@ typedef enum
     FSM_STATE_END
 } FSM_STATE;
 
+#define FSM_STEP_PERIOD_MS 250
+
 static UINT_PTR FsmTimer = 0;
 static UINT CurrentColor = 0;
 static FSM_STATE FsmState = FSM_STATE_START;
@@ -651,7 +653,7 @@ static LRESULT CALLBACK WindowProc(HWND Window, UINT Message, WPARAM wParam, LPA
             HideHorzScrollBar(Window);
 
             FsmState = FSM_STATE_START;
-            FsmTimer = SetTimer(Window, 1, 500, NULL);
+            FsmTimer = SetTimer(Window, 1, FSM_STEP_PERIOD_MS, NULL);
             ok(FsmTimer != 0, "Failed to initialize FSM timer, code: %ld\n", GetLastError());
 
             if (FsmTimer == 0)

--- a/modules/rostests/apitests/user32/ScrollBarRedraw.c
+++ b/modules/rostests/apitests/user32/ScrollBarRedraw.c
@@ -301,13 +301,11 @@ static int FsmStep(HWND Window)
     switch (FsmState)
     {
         case FSM_STATE_START:
-
             ShowVertScrollBar(Window);
             FsmState = FSM_STATE_VSCR_SHOWN;
             break;
 
         case FSM_STATE_VSCR_SHOWN:
-
             if (HaveHRedraw)
             {
                 ok(Color != PrevColor,
@@ -329,7 +327,6 @@ static int FsmStep(HWND Window)
             break;
 
         case FSM_STATE_VSCR_HIDDEN:
-
             if (HaveHRedraw)
             {
                 ok(Color != PrevColor,
@@ -350,7 +347,6 @@ static int FsmStep(HWND Window)
             break;
 
         case FSM_STATE_HSCR_SHOWN:
-
             if (HaveVRedraw)
             {
                 ok(Color != PrevColor,
@@ -371,7 +367,6 @@ static int FsmStep(HWND Window)
             break;
 
         case FSM_STATE_HSCR_HIDDEN:
-
             if (HaveVRedraw)
             {
                 ok(Color != PrevColor,
@@ -394,7 +389,6 @@ static int FsmStep(HWND Window)
             break;
 
         case FSM_STATE_BSCR_SHOWN:
-
             if (HaveHRedraw || HaveVRedraw)
             {
                 ok(Color != PrevColor,
@@ -418,7 +412,6 @@ static int FsmStep(HWND Window)
             break;
 
         case FSM_STATE_BSCR_HIDDEN:
-
             if (HaveHRedraw || HaveVRedraw)
             {
                 ok(Color != PrevColor,
@@ -440,7 +433,6 @@ static int FsmStep(HWND Window)
             break;
 
         case FSM_STATE_WIDTH_SHRUNK:
-
             if (HaveHRedraw)
             {
                 ok(Color != PrevColor,
@@ -461,7 +453,6 @@ static int FsmStep(HWND Window)
             break;
 
         case FSM_STATE_WIDTH_EXPANDED:
-
             if (HaveHRedraw)
             {
                 ok(Color != PrevColor,
@@ -482,7 +473,6 @@ static int FsmStep(HWND Window)
             break;
 
         case FSM_STATE_HEIGHT_SHRUNK:
-
             if (HaveVRedraw)
             {
                 ok(Color != PrevColor,
@@ -503,7 +493,6 @@ static int FsmStep(HWND Window)
             break;
 
         case FSM_STATE_HEIGHT_EXPANDED:
-
             if (HaveVRedraw)
             {
                 ok(Color != PrevColor,
@@ -525,7 +514,6 @@ static int FsmStep(HWND Window)
             break;
 
         case FSM_STATE_BOTH_SHRUNK:
-
             if (HaveHRedraw || HaveVRedraw)
             {
                 ok(Color != PrevColor,
@@ -549,7 +537,6 @@ static int FsmStep(HWND Window)
             break;
 
         case FSM_STATE_BOTH_EXPANDED:
-
             if (HaveHRedraw || HaveVRedraw)
             {
                 ok(Color != PrevColor,
@@ -577,7 +564,6 @@ static int FsmStep(HWND Window)
     }
 
     PrevColor = Color;
-
     return 0;
 }
 
@@ -603,7 +589,6 @@ static LRESULT CALLBACK WindowProc(HWND Window, UINT Message, WPARAM wParam, LPA
     switch (Message)
     {
         case WM_CREATE:
-
             /* It's important for the test that the entire Window is visible. */
             if (!SetWindowPos(Window, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE))
             {
@@ -629,8 +614,8 @@ static LRESULT CALLBACK WindowProc(HWND Window, UINT Message, WPARAM wParam, LPA
 
             SmallWidth  = max((OrigWidth  * 3) / 4, 1);
             SmallHeight = max((OrigHeight * 3) / 4, 1);
-            OrigWidth   = max(OrigWidth,  SmallWidth+1);
-            OrigHeight  = max(OrigHeight, SmallHeight+1);
+            OrigWidth   = max(OrigWidth,  SmallWidth  + 1);
+            OrigHeight  = max(OrigHeight, SmallHeight + 1);
 
             trace("OrigWidth: %d, OrigHeight: %d, SmallWidth: %d, SmallHeight: %d\n",
                   OrigWidth, OrigHeight, SmallWidth, SmallHeight);
@@ -644,7 +629,6 @@ static LRESULT CALLBACK WindowProc(HWND Window, UINT Message, WPARAM wParam, LPA
             return 0;
 
         case WM_PAINT:
-
             if (FsmTimer == 0)
             {
                 FsmTimer = SetTimer(Window, 1, FSM_STEP_PERIOD_MS, NULL);
@@ -659,7 +643,6 @@ static LRESULT CALLBACK WindowProc(HWND Window, UINT Message, WPARAM wParam, LPA
             break;
 
         case WM_SIZE:
-
             Width = LOWORD(lParam);
             Height = HIWORD(lParam);
 
@@ -674,7 +657,6 @@ static LRESULT CALLBACK WindowProc(HWND Window, UINT Message, WPARAM wParam, LPA
             return 0;
 
         case WM_TIMER:
-
             if (wParam != 0 && wParam == FsmTimer)
             {
                 return FsmStep(Window);
@@ -682,7 +664,6 @@ static LRESULT CALLBACK WindowProc(HWND Window, UINT Message, WPARAM wParam, LPA
             break;
 
         case WM_NCDESTROY:
-
             if (FsmTimer != 0)
             {
                 KillTimer(Window, FsmTimer);
@@ -691,7 +672,6 @@ static LRESULT CALLBACK WindowProc(HWND Window, UINT Message, WPARAM wParam, LPA
             return 0;
 
         case WM_DESTROY:
-
             PostQuitMessage(0);
             return 0;
     }

--- a/modules/rostests/apitests/user32/ScrollBarRedraw.c
+++ b/modules/rostests/apitests/user32/ScrollBarRedraw.c
@@ -282,11 +282,13 @@ static int FsmStep(HWND Window)
         }
         Color = GetPixel(hdc, ClientWidth / 4, ClientHeight / 4);
 
+        ReleaseDC(Window, hdc);
+        hdc = NULL;
+
         if (Color == CLR_INVALID)
         {
             skip("Failed to get window color\n");
 
-            ReleaseDC(Window, hdc);
             DestroyWindow(Window);
             FsmState = FSM_STATE_END;
 
@@ -574,11 +576,7 @@ static int FsmStep(HWND Window)
             break;
     }
 
-    if (hdc != NULL)
-    {
-        PrevColor = Color;
-        ReleaseDC(Window, hdc);
-    }
+    PrevColor = Color;
 
     return 0;
 }

--- a/modules/rostests/apitests/user32/ScrollBarRedraw.c
+++ b/modules/rostests/apitests/user32/ScrollBarRedraw.c
@@ -122,7 +122,7 @@ colors_init(void)
 static void
 run_test_window(const char *class_name, const char *window_title, UINT class_style)
 {
-    WNDCLASS class;
+    WNDCLASS class = { 0 };
     HWND window;
     MSG  msg;
     ATOM class_atom;

--- a/modules/rostests/apitests/user32/ScrollBarRedraw.c
+++ b/modules/rostests/apitests/user32/ScrollBarRedraw.c
@@ -589,10 +589,9 @@ static int FsmStep(HWND Window)
 static int OnResize(HWND Window, int NewWidth, int NewHeight)
 {
     CurrentColor = (CurrentColor + 1) % TEST_COLOR_COUNT;
-    SetClassLongPtr(
-            Window,
-            GCLP_HBRBACKGROUND,
-            (LONG_PTR)ColorBrushes[CurrentColor]);
+    SetClassLongPtr(Window,
+                    GCLP_HBRBACKGROUND,
+                    (LONG_PTR)ColorBrushes[CurrentColor]);
 
     trace("New window size: %d x %d, new color: 0x%.8lX\n",
           NewWidth, NewHeight, Colors[CurrentColor]);

--- a/modules/rostests/apitests/user32/ScrollBarRedraw.c
+++ b/modules/rostests/apitests/user32/ScrollBarRedraw.c
@@ -1,0 +1,688 @@
+/*
+ * Copyright (c) 2024 Marek Benc <benc.marek.elektro98@proton.me>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <windows.h>
+#include "wine/test.h"
+
+#define TEST_CLASS_NAME   "scrollbar_redraw"
+#define TEST_WINDOW_TITLE "scrollbar_redraw"
+
+EXTERN_C IMAGE_DOS_HEADER __ImageBase;
+#define HINST_THISCOMPONENT ((HINSTANCE)&__ImageBase)
+
+static LRESULT CALLBACK
+proc_cb(HWND window, UINT message, WPARAM w_param, LPARAM l_param);
+
+#define TEST_COLOR_COUNT 16
+static COLORREF colors[TEST_COLOR_COUNT] = { 0 };
+static HBRUSH   color_brushes[TEST_COLOR_COUNT] = { 0 };
+
+static BOOL have_hredraw = FALSE;
+static BOOL have_vredraw = FALSE;
+
+enum fsm_state
+{
+    FSM_STATE_START,
+    FSM_STATE_VSCR_SHOWN,
+    FSM_STATE_VSCR_HIDDEN,
+    FSM_STATE_HSCR_SHOWN,
+    FSM_STATE_HSCR_HIDDEN,
+    FSM_STATE_BSCR_SHOWN,
+    FSM_STATE_BSCR_HIDDEN,
+    FSM_STATE_WIDTH_SHRUNK,
+    FSM_STATE_WIDTH_EXPANDED,
+    FSM_STATE_HEIGHT_SHRUNK,
+    FSM_STATE_HEIGHT_EXPANDED,
+    FSM_STATE_BOTH_SHRUNK,
+    FSM_STATE_BOTH_EXPANDED,
+    FSM_STATE_END
+};
+
+static UINT_PTR fsm_timer = 0;
+static unsigned int current_color = 0;
+static enum fsm_state fsm_state = FSM_STATE_START;
+
+static int client_width = 0;
+static int client_height = 0;
+
+static int orig_width = 0;
+static int orig_height = 0;
+static int small_width = 0;
+static int small_height = 0;
+
+static void
+colors_cleanup()
+{
+    unsigned int iter;
+
+    for (iter = 0; iter < TEST_COLOR_COUNT; iter++)
+    {
+        if (color_brushes[iter] != NULL)
+        {
+            DeleteObject(color_brushes[iter]);
+            color_brushes[iter] = NULL;
+        }
+    }
+}
+
+static BOOL
+colors_init(void)
+{
+    unsigned int iter;
+
+    if (TEST_COLOR_COUNT != 16)
+    {
+        return FALSE;
+    }
+
+    /* Standard Windows 16-color VGA color palette. */
+    colors[0]  = RGB(0x00, 0x00, 0x00);  /* Black */
+    colors[1]  = RGB(0x00, 0x00, 0x80);  /* Dark Blue */
+    colors[2]  = RGB(0x00, 0x80, 0x00);  /* Dark Green */
+    colors[3]  = RGB(0x00, 0x80, 0x80);  /* Dark Cyan */
+    colors[4]  = RGB(0x80, 0x00, 0x00);  /* Dark Red */
+    colors[5]  = RGB(0x80, 0x00, 0x80);  /* Dark Magenta */
+    colors[6]  = RGB(0x80, 0x80, 0x00);  /* Dark Yellow */
+    colors[7]  = RGB(0xC0, 0xC0, 0xC0);  /* Light Gray */
+    colors[8]  = RGB(0x80, 0x80, 0x80);  /* Dark Gray */
+    colors[9]  = RGB(0x00, 0x00, 0xFF);  /* Blue */
+    colors[10] = RGB(0x00, 0xFF, 0x00);  /* Green */
+    colors[11] = RGB(0x00, 0xFF, 0xFF);  /* Cyan */
+    colors[12] = RGB(0xFF, 0x00, 0x00);  /* Red */
+    colors[13] = RGB(0xFF, 0x00, 0xFF);  /* Magenta */
+    colors[14] = RGB(0xFF, 0xFF, 0x00);  /* Yellow */
+    colors[15] = RGB(0xFF, 0xFF, 0xFF);  /* White */
+
+    for (iter = 0; iter < TEST_COLOR_COUNT; iter++)
+    {
+        color_brushes[iter] = CreateSolidBrush(colors[iter]);
+        if (color_brushes[iter] == NULL)
+        {
+            colors_cleanup();
+            return FALSE;
+        }
+    }
+
+    return TRUE;
+}
+
+static void
+run_test_window(const char *class_name, const char *window_title, UINT class_style)
+{
+    WNDCLASS class = { };
+    HWND window;
+    MSG  msg;
+    ATOM class_atom;
+
+    current_color = 0;
+
+    class.style         = class_style;
+    class.lpfnWndProc   = proc_cb;
+    class.cbClsExtra    = 0;
+    class.cbWndExtra    = 0;
+    class.hInstance     = HINST_THISCOMPONENT;
+    class.hIcon         = LoadIcon(NULL, IDI_APPLICATION);
+    class.hCursor       = LoadCursor(NULL, IDC_ARROW);
+    class.hbrBackground = color_brushes[current_color];
+    class.lpszMenuName  = NULL;
+    class.lpszClassName = class_name;
+
+    class_atom = RegisterClass(&class);
+    ok(class_atom != 0, "Failed to register window class \"%s\", code: %ld\n", class_name, GetLastError());
+    if (class_atom == 0)
+    {
+        return;
+    }
+
+    window = CreateWindow(
+            class_name,
+            window_title,
+            WS_OVERLAPPEDWINDOW | WS_VSCROLL | WS_HSCROLL,
+            CW_USEDEFAULT,
+            CW_USEDEFAULT,
+            CW_USEDEFAULT,
+            CW_USEDEFAULT,
+            NULL,
+            NULL,
+            HINST_THISCOMPONENT,
+            NULL);
+
+    ok(window != NULL, "Failed to create window of class \"%s\", code: %ld\n", class_name, GetLastError());
+    if (window == NULL)
+    {
+        return;
+    }
+
+    ShowWindow(window, SW_SHOWNORMAL);
+    UpdateWindow(window);
+
+    while (GetMessage(&msg, NULL, 0, 0))
+    {
+        TranslateMessage(&msg);
+        DispatchMessage(&msg);
+    }
+}
+
+START_TEST(ScrollBarRedraw)
+{
+    BOOL bool_ret;
+
+    bool_ret = colors_init();
+    ok(bool_ret, "Failed to initialize colors and solid color brushes\n");
+    if (!bool_ret)
+    {
+        return;
+    }
+
+    trace("Running test without specifying either CS_HREDRAW or CS_HREDRAW\n");
+    have_hredraw = FALSE;
+    have_vredraw = FALSE;
+    run_test_window(
+            TEST_CLASS_NAME   "_noredraw",
+            TEST_WINDOW_TITLE "_noredraw",
+            0);
+
+    trace("Running test with CS_HREDRAW\n");
+    have_hredraw = TRUE;
+    have_vredraw = FALSE;
+    run_test_window(
+            TEST_CLASS_NAME   "_hredraw",
+            TEST_WINDOW_TITLE "_hredraw",
+            CS_HREDRAW);
+
+    trace("Running test with CS_VREDRAW\n");
+    have_hredraw = FALSE;
+    have_vredraw = TRUE;
+    run_test_window(
+            TEST_CLASS_NAME   "_vredraw",
+            TEST_WINDOW_TITLE "_vredraw",
+            CS_VREDRAW);
+
+    trace("Running test with both CS_HREDRAW and CS_VREDRAW\n");
+    have_hredraw = TRUE;
+    have_vredraw = TRUE;
+    run_test_window(
+            TEST_CLASS_NAME   "_hredraw_vredraw",
+            TEST_WINDOW_TITLE "_hredraw_vredraw",
+            CS_HREDRAW | CS_VREDRAW);
+
+    trace("Test complete\n");
+    colors_cleanup();
+}
+
+static void
+hide_vert_scroll_bar(HWND window)
+{
+    SCROLLINFO scroll_info;
+
+    scroll_info.cbSize = sizeof(scroll_info);
+    scroll_info.fMask = SIF_RANGE | SIF_PAGE | SIF_POS;
+    scroll_info.nPage = client_height;
+
+    scroll_info.nMin = 0;
+    scroll_info.nMax = client_height-1;
+    scroll_info.nPos = 0;
+
+    SetScrollInfo(window, SB_VERT, &scroll_info, TRUE);
+}
+
+static void
+show_vert_scroll_bar(HWND window)
+{
+    SCROLLINFO scroll_info;
+
+    scroll_info.cbSize = sizeof(scroll_info);
+    scroll_info.fMask = SIF_RANGE | SIF_PAGE | SIF_POS;
+    scroll_info.nPage = client_height;
+
+    scroll_info.nMin = 0;
+    scroll_info.nMax = (3*client_height)-1;
+    scroll_info.nPos = 0;
+
+    SetScrollInfo(window, SB_VERT, &scroll_info, TRUE);
+}
+
+static void
+hide_horz_scroll_bar(HWND window)
+{
+    SCROLLINFO scroll_info;
+
+    scroll_info.cbSize = sizeof(scroll_info);
+    scroll_info.fMask = SIF_RANGE | SIF_PAGE | SIF_POS;
+    scroll_info.nPage = client_width;
+
+    scroll_info.nMin = 0;
+    scroll_info.nMax = client_width-1;
+    scroll_info.nPos = 0;
+
+    SetScrollInfo(window, SB_HORZ, &scroll_info, TRUE);
+}
+
+static void
+show_horz_scroll_bar(HWND window)
+{
+    SCROLLINFO scroll_info;
+
+    scroll_info.cbSize = sizeof(scroll_info);
+    scroll_info.fMask = SIF_RANGE | SIF_PAGE | SIF_POS;
+    scroll_info.nPage = client_width;
+
+    scroll_info.nMin = 0;
+    scroll_info.nMax = (3*client_width)-1;
+    scroll_info.nPos = 0;
+
+    SetScrollInfo(window, SB_HORZ, &scroll_info, TRUE);
+}
+
+static int
+fsm_transition(HWND window)
+{
+    static COLORREF prev_color = CLR_INVALID;
+    COLORREF color = CLR_INVALID;
+    HDC dev_ctx = NULL;
+
+    if (fsm_state != FSM_STATE_END)
+    {
+        dev_ctx = GetDC(window);
+
+        ok(dev_ctx != NULL, "Failed to get device context\n");
+        if (dev_ctx == NULL)
+        {
+            DestroyWindow(window);
+            fsm_state = FSM_STATE_END;
+        }
+        else
+        {
+            color = GetPixel(dev_ctx, client_width / 4, client_height / 4);
+            ok(color != CLR_INVALID, "Failed to get window color\n");
+        }
+    }
+
+    trace("fsm_state: %d, color: 0x%.8lX\n", fsm_state, color);
+
+    switch (fsm_state)
+    {
+    case FSM_STATE_START:
+
+        show_vert_scroll_bar(window);
+        fsm_state = FSM_STATE_VSCR_SHOWN;
+        break;
+
+    case FSM_STATE_VSCR_SHOWN:
+
+        if (have_hredraw)
+        {
+            ok(color != prev_color,
+               "CS_HREDRAW specified, but appearence of vertical scroll bar didn't trigger redraw, prev_color: 0x%.8lX, color: 0x%.8lX\n",
+               prev_color, color);
+        }
+        else
+        {
+            ok(color == prev_color,
+               "CS_HREDRAW not specified, but appearence of vertical scroll bar triggered unneccessary redraw, prev_color: 0x%.8lX, color: 0x%.8lX\n",
+               prev_color, color);
+        }
+
+        hide_vert_scroll_bar(window);
+        fsm_state = FSM_STATE_VSCR_HIDDEN;
+
+        break;
+
+    case FSM_STATE_VSCR_HIDDEN:
+
+        if (have_hredraw)
+        {
+            ok(color != prev_color,
+               "CS_HREDRAW specified, but disappearence of vertical scroll bar didn't trigger redraw, prev_color: 0x%.8lX, color: 0x%.8lX\n",
+               prev_color, color);
+        }
+        else
+        {
+            ok(color == prev_color,
+               "CS_HREDRAW not specified, but disappearence of vertical scroll bar triggered unneccessary redraw, prev_color: 0x%.8lX, color: 0x%.8lX\n",
+               prev_color, color);
+        }
+
+        show_horz_scroll_bar(window);
+        fsm_state = FSM_STATE_HSCR_SHOWN;
+        break;
+
+    case FSM_STATE_HSCR_SHOWN:
+
+        if (have_vredraw)
+        {
+            ok(color != prev_color,
+               "CS_VREDRAW specified, but appearence of horizontal scroll bar didn't trigger redraw, prev_color: 0x%.8lX, color: 0x%.8lX\n",
+               prev_color, color);
+        }
+        else
+        {
+            ok(color == prev_color,
+               "CS_VREDRAW not specified, but appearence of horizontal scroll bar triggered unneccessary redraw, prev_color: 0x%.8lX, color: 0x%.8lX\n",
+               prev_color, color);
+        }
+
+        hide_horz_scroll_bar(window);
+        fsm_state = FSM_STATE_HSCR_HIDDEN;
+        break;
+
+    case FSM_STATE_HSCR_HIDDEN:
+
+        if (have_vredraw)
+        {
+            ok(color != prev_color,
+               "CS_VREDRAW specified, but disappearence of horizontal scroll bar didn't trigger redraw, prev_color: 0x%.8lX, color: 0x%.8lX\n",
+               prev_color, color);
+        }
+        else
+        {
+            ok(color == prev_color,
+               "CS_VREDRAW not specified, but disappearence of horizontal scroll bar triggered unneccessary redraw, prev_color: 0x%.8lX, color: 0x%.8lX\n",
+               prev_color, color);
+        }
+
+        show_vert_scroll_bar(window);
+        show_horz_scroll_bar(window);
+
+        fsm_state = FSM_STATE_BSCR_SHOWN;
+        break;
+
+    case FSM_STATE_BSCR_SHOWN:
+
+        if (have_hredraw || have_vredraw)
+        {
+            ok(color != prev_color,
+               "CS_HREDRAW or CS_VREDRAW specified, but appearence of both scroll bars didn't trigger redraw, prev_color: 0x%.8lX, color: 0x%.8lX\n",
+               prev_color, color);
+        }
+        else
+        {
+            ok(color == prev_color,
+               "Neither CS_HREDRAW nor CS_VREDRAW specified, but appearence of both scroll bars triggered unneccessary redraw, prev_color: 0x%.8lX, color: 0x%.8lX\n",
+               prev_color, color);
+        }
+
+        hide_vert_scroll_bar(window);
+        hide_horz_scroll_bar(window);
+
+        fsm_state = FSM_STATE_BSCR_HIDDEN;
+        break;
+
+    case FSM_STATE_BSCR_HIDDEN:
+
+        if (have_hredraw || have_vredraw)
+        {
+            ok(color != prev_color,
+               "CS_HREDRAW or CS_VREDRAW specified, but disappearence of both scroll bars didn't trigger redraw, prev_color: 0x%.8lX, color: 0x%.8lX\n",
+               prev_color, color);
+        }
+        else
+        {
+            ok(color == prev_color,
+               "Neither CS_HREDRAW nor CS_VREDRAW specified, but disappearence of both scroll bars triggered unneccessary redraw, prev_color: 0x%.8lX, color: 0x%.8lX\n",
+               prev_color, color);
+        }
+
+        SetWindowPos(window, HWND_TOPMOST, 0, 0, small_width, orig_height, SWP_NOMOVE);
+        fsm_state = FSM_STATE_WIDTH_SHRUNK;
+        break;
+
+    case FSM_STATE_WIDTH_SHRUNK:
+
+        if (have_hredraw)
+        {
+            ok(color != prev_color,
+               "CS_HREDRAW specified, but horizontal window shrinkage didn't trigger redraw, prev_color: 0x%.8lX, color: 0x%.8lX\n",
+               prev_color, color);
+        }
+        else
+        {
+            ok(color == prev_color,
+               "CS_HREDRAW not specified, but horizontal window shrinkage triggered unneccessary redraw, prev_color: 0x%.8lX, color: 0x%.8lX\n",
+               prev_color, color);
+        }
+
+        SetWindowPos(window, HWND_TOPMOST, 0, 0, orig_width, orig_height, SWP_NOMOVE);
+        fsm_state = FSM_STATE_WIDTH_EXPANDED;
+        break;
+
+    case FSM_STATE_WIDTH_EXPANDED:
+
+        if (have_hredraw)
+        {
+            ok(color != prev_color,
+               "CS_HREDRAW specified, but horizontal window expansion didn't trigger redraw, prev_color: 0x%.8lX, color: 0x%.8lX\n",
+               prev_color, color);
+        }
+        else
+        {
+            ok(color == prev_color,
+               "CS_HREDRAW not specified, but horizontal window expansion triggered unneccessary redraw, prev_color: 0x%.8lX, color: 0x%.8lX\n",
+               prev_color, color);
+        }
+
+        SetWindowPos(window, HWND_TOPMOST, 0, 0, orig_width, small_height, SWP_NOMOVE);
+        fsm_state = FSM_STATE_HEIGHT_SHRUNK;
+        break;
+
+    case FSM_STATE_HEIGHT_SHRUNK:
+
+        if (have_vredraw)
+        {
+            ok(color != prev_color,
+               "CS_VREDRAW specified, but vertical window shrinkage didn't trigger redraw, prev_color: 0x%.8lX, color: 0x%.8lX\n",
+               prev_color, color);
+        }
+        else
+        {
+            ok(color == prev_color,
+               "CS_VREDRAW not specified, but vertical window shrinkage triggered unneccessary redraw, prev_color: 0x%.8lX, color: 0x%.8lX\n",
+               prev_color, color);
+        }
+
+        SetWindowPos(window, HWND_TOPMOST, 0, 0, orig_width, orig_height, SWP_NOMOVE);
+        fsm_state = FSM_STATE_HEIGHT_EXPANDED;
+        break;
+
+    case FSM_STATE_HEIGHT_EXPANDED:
+
+        if (have_vredraw)
+        {
+            ok(color != prev_color,
+               "CS_VREDRAW specified, but vertical window expansion didn't trigger redraw, prev_color: 0x%.8lX, color: 0x%.8lX\n",
+               prev_color, color);
+        }
+        else
+        {
+            ok(color == prev_color,
+               "CS_VREDRAW not specified, but vertical window expansion triggered unneccessary redraw, prev_color: 0x%.8lX, color: 0x%.8lX\n",
+               prev_color, color);
+        }
+
+        SetWindowPos(window, HWND_TOPMOST, 0, 0, small_width, small_height, SWP_NOMOVE);
+
+        fsm_state = FSM_STATE_BOTH_SHRUNK;
+        break;
+
+    case FSM_STATE_BOTH_SHRUNK:
+
+        if (have_hredraw || have_vredraw)
+        {
+            ok(color != prev_color,
+               "CS_HREDRAW or CS_VREDRAW specified, but combined vertical/horizontal shrinkage didn't trigger redraw, prev_color: 0x%.8lX, color: 0x%.8lX\n",
+               prev_color, color);
+        }
+        else
+        {
+            ok(color == prev_color,
+               "Neither CS_HREDRAW nor CS_VREDRAW specified, but combined vertical/horizontal shrinkage triggered unneccessary redraw, prev_color: 0x%.8lX, color: 0x%.8lX\n",
+               prev_color, color);
+        }
+
+        SetWindowPos(window, HWND_TOPMOST, 0, 0, orig_width, orig_height, SWP_NOMOVE);
+
+        fsm_state = FSM_STATE_BOTH_EXPANDED;
+        break;
+
+    case FSM_STATE_BOTH_EXPANDED:
+
+        if (have_hredraw || have_vredraw)
+        {
+            ok(color != prev_color,
+               "CS_HREDRAW or CS_VREDRAW specified, but combined vertical/horizontal expansion didn't trigger redraw, prev_color: 0x%.8lX, color: 0x%.8lX\n",
+               prev_color, color);
+        }
+        else
+        {
+            ok(color == prev_color,
+               "Neither CS_HREDRAW nor CS_VREDRAW specified, but combined vertical/horizontal expansion triggered unneccessary redraw, prev_color: 0x%.8lX, color: 0x%.8lX\n",
+               prev_color, color);
+        }
+
+        DestroyWindow(window);
+        fsm_state = FSM_STATE_END;
+        break;
+
+    case FSM_STATE_END:
+        break;
+    }
+
+    if (dev_ctx != NULL)
+    {
+        prev_color = color;
+        ReleaseDC(window, dev_ctx);
+    }
+
+    return 0;
+}
+
+static int
+on_resize(HWND window, int new_width, int new_height)
+{
+    current_color = (current_color + 1) % TEST_COLOR_COUNT;
+    SetClassLongPtr(
+            window,
+            GCLP_HBRBACKGROUND,
+            (LONG_PTR)color_brushes[current_color]);
+
+    trace("New window size: %d x %d, new color: 0x%.8lX\n",
+          new_width, new_height, colors[current_color]);
+
+    return 0;
+}
+
+static LRESULT CALLBACK
+proc_cb(HWND window, UINT message, WPARAM w_param, LPARAM l_param)
+{
+    RECT rect;
+    BOOL bool_ret;
+    int width;
+    int height;
+
+    switch (message)
+    {
+    case WM_CREATE:
+
+        /* It's important for the test that the entire window is visible. */
+        bool_ret = SetWindowPos(window, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
+        ok(bool_ret, "Failed to set window as top-most, code: %ld\n", GetLastError());
+
+        bool_ret = GetClientRect(window, &rect);
+        ok(bool_ret, "Failed to retrieve client window dimensions, code: %ld\n", GetLastError());
+
+        if (bool_ret)
+        {
+            client_width = rect.right;
+            client_height = rect.bottom;
+        }
+        else
+        {
+            return -1;
+        }
+
+        bool_ret = GetWindowRect(window, &rect);
+        ok(bool_ret, "Failed to retrieve window dimensions, code: %ld\n", GetLastError());
+
+        if (bool_ret)
+        {
+            orig_width  = rect.right - rect.left;
+            orig_height = rect.bottom - rect.top;
+        }
+        else
+        {
+            return -1;
+        }
+
+        small_width  = max((orig_width  * 3) / 4, 1);
+        small_height = max((orig_height * 3) / 4, 1);
+        orig_width   = max(orig_width,  small_width+1);
+        orig_height  = max(orig_height, small_height+1);
+
+        trace("orig_width: %d, orig_height: %d, small_width: %d, small_height: %d\n",
+              orig_width, orig_height, small_width, small_height);
+
+        hide_vert_scroll_bar(window);
+        hide_horz_scroll_bar(window);
+
+        fsm_state = FSM_STATE_START;
+        fsm_timer = SetTimer(window, 1, 500, NULL);
+        ok(fsm_timer != 0, "Failed to initialize FSM timer, code: %ld\n", GetLastError());
+
+        if (fsm_timer == 0)
+        {
+            return -1;
+        }
+        return 0;
+
+    case WM_SIZE:
+
+        width = LOWORD(l_param);
+        height = HIWORD(l_param);
+
+        if (width != 0 && height != 0 &&
+            (width != client_width || height != client_height))
+        {
+            return on_resize(window, width, height);
+
+            client_width = width;
+            client_height = height;
+        }
+        return 0;
+
+    case WM_TIMER:
+
+        if (w_param != 0 && w_param == fsm_timer)
+        {
+            return fsm_transition(window);
+        }
+        break;
+
+    case WM_NCDESTROY:
+
+        if (fsm_timer != 0)
+        {
+            KillTimer(window, fsm_timer);
+            fsm_timer = 0;
+        }
+        return 0;
+
+    case WM_DESTROY:
+
+        PostQuitMessage(0);
+        return 0;
+    }
+    return DefWindowProc(window, message, w_param, l_param);
+}

--- a/modules/rostests/apitests/user32/ScrollBarRedraw.c
+++ b/modules/rostests/apitests/user32/ScrollBarRedraw.c
@@ -323,7 +323,6 @@ static int FsmStep(HWND Window)
 
             HideVertScrollBar(Window);
             FsmState = FSM_STATE_VSCR_HIDDEN;
-
             break;
 
         case FSM_STATE_VSCR_HIDDEN:
@@ -585,7 +584,6 @@ static int OnPaint(HWND Window)
                            ps.rcPaint.top,
                            ps.rcPaint.right,
                            ps.rcPaint.bottom);
-
     if (Region == NULL)
     {
         skip("Failed to create drawing region\n");

--- a/modules/rostests/apitests/user32/ScrollBarRedraw.c
+++ b/modules/rostests/apitests/user32/ScrollBarRedraw.c
@@ -9,8 +9,8 @@
 #include <windows.h>
 #include "wine/test.h"
 
-#define TEST_CLASS_NAME   "ScrollBarRedraw"
-#define TEST_WINDOW_TITLE "ScrollBarRedraw"
+#define TEST_CLASS_NAME   L"ScrollBarRedraw"
+#define TEST_WINDOW_TITLE L"ScrollBarRedraw"
 
 static LRESULT CALLBACK WindowProc(HWND Window, UINT Message, WPARAM wParam, LPARAM lParam);
 
@@ -106,9 +106,9 @@ static BOOL ColorsInit(void)
     return TRUE;
 }
 
-static void RunTestWindow(PCSTR ClassName, PCSTR WindowTitle, UINT ClassStyle)
+static void RunTestWindow(PCWSTR ClassName, PCWSTR WindowTitle, UINT ClassStyle)
 {
-    WNDCLASSA Class = { 0 };
+    WNDCLASSW Class = { 0 };
     HWND Window;
     MSG  Message;
 
@@ -118,21 +118,21 @@ static void RunTestWindow(PCSTR ClassName, PCSTR WindowTitle, UINT ClassStyle)
     Class.lpfnWndProc   = WindowProc;
     Class.cbClsExtra    = 0;
     Class.cbWndExtra    = 0;
-    Class.hInstance     = GetModuleHandleA(NULL);
-    Class.hIcon         = LoadIconA(NULL, IDI_APPLICATION);
-    Class.hCursor       = LoadCursorA(NULL, IDC_ARROW);
+    Class.hInstance     = GetModuleHandleW(NULL);
+    Class.hIcon         = LoadIcon(NULL, IDI_APPLICATION);
+    Class.hCursor       = LoadCursor(NULL, IDC_ARROW);
     Class.hbrBackground = ColorBrushes[CurrentColor];
     Class.lpszMenuName  = NULL;
     Class.lpszClassName = ClassName;
 
-    if (!RegisterClassA(&Class))
+    if (!RegisterClassW(&Class))
     {
-        skip("Failed to register window class \"%s\", code: %ld\n",
+        skip("Failed to register window class \"%ls\", code: %ld\n",
              ClassName, GetLastError());
         return;
     }
 
-    Window = CreateWindowA(ClassName,
+    Window = CreateWindowW(ClassName,
                            WindowTitle,
                            WS_OVERLAPPEDWINDOW | WS_VSCROLL | WS_HSCROLL,
                            CW_USEDEFAULT,
@@ -141,12 +141,12 @@ static void RunTestWindow(PCSTR ClassName, PCSTR WindowTitle, UINT ClassStyle)
                            CW_USEDEFAULT,
                            NULL,
                            NULL,
-                           GetModuleHandleA(NULL),
+                           GetModuleHandleW(NULL),
                            NULL);
 
     if (Window == NULL)
     {
-        skip("Failed to create window of class \"%s\", code: %ld\n",
+        skip("Failed to create window of class \"%ls\", code: %ld\n",
              ClassName, GetLastError());
         return;
     }
@@ -154,10 +154,10 @@ static void RunTestWindow(PCSTR ClassName, PCSTR WindowTitle, UINT ClassStyle)
     ShowWindow(Window, SW_SHOWNORMAL);
     UpdateWindow(Window);
 
-    while (GetMessage(&Message, NULL, 0, 0))
+    while (GetMessageW(&Message, NULL, 0, 0))
     {
         TranslateMessage(&Message);
-        DispatchMessage(&Message);
+        DispatchMessageW(&Message);
     }
 }
 
@@ -172,29 +172,29 @@ START_TEST(ScrollBarRedraw)
     trace("Running test without specifying either CS_HREDRAW or CS_HREDRAW\n");
     HaveHRedraw = FALSE;
     HaveVRedraw = FALSE;
-    RunTestWindow(TEST_CLASS_NAME   "NoRedraw",
-                  TEST_WINDOW_TITLE " (No Redraw Flags)",
+    RunTestWindow(TEST_CLASS_NAME   L"NoRedraw",
+                  TEST_WINDOW_TITLE L" (No Redraw Flags)",
                   0);
 
     trace("Running test with CS_HREDRAW\n");
     HaveHRedraw = TRUE;
     HaveVRedraw = FALSE;
-    RunTestWindow(TEST_CLASS_NAME   "HRedraw",
-                  TEST_WINDOW_TITLE " (CS_HREDRAW)",
+    RunTestWindow(TEST_CLASS_NAME   L"HRedraw",
+                  TEST_WINDOW_TITLE L" (CS_HREDRAW)",
                   CS_HREDRAW);
 
     trace("Running test with CS_VREDRAW\n");
     HaveHRedraw = FALSE;
     HaveVRedraw = TRUE;
-    RunTestWindow(TEST_CLASS_NAME   "VRedraw",
-                  TEST_WINDOW_TITLE " (CS_VREDRAW)",
+    RunTestWindow(TEST_CLASS_NAME   L"VRedraw",
+                  TEST_WINDOW_TITLE L" (CS_VREDRAW)",
                   CS_VREDRAW);
 
     trace("Running test with both CS_HREDRAW and CS_VREDRAW\n");
     HaveHRedraw = TRUE;
     HaveVRedraw = TRUE;
-    RunTestWindow(TEST_CLASS_NAME   "HRedrawVRedraw",
-                  TEST_WINDOW_TITLE " (CS_HREDRAW | CS_VREDRAW)",
+    RunTestWindow(TEST_CLASS_NAME   L"HRedrawVRedraw",
+                  TEST_WINDOW_TITLE L" (CS_HREDRAW | CS_VREDRAW)",
                   CS_HREDRAW | CS_VREDRAW);
 
     trace("Test complete\n");
@@ -678,9 +678,9 @@ static LRESULT CALLBACK WindowProc(HWND Window, UINT Message, WPARAM wParam, LPA
                 (NewWidth != ClientWidth || NewHeight != ClientHeight))
             {
                 CurrentColor = (CurrentColor + 1) % TEST_COLOR_COUNT;
-                SetClassLongPtr(Window,
-                                GCLP_HBRBACKGROUND,
-                                (LONG_PTR)ColorBrushes[CurrentColor]);
+                SetClassLongPtrW(Window,
+                                 GCLP_HBRBACKGROUND,
+                                 (LONG_PTR)ColorBrushes[CurrentColor]);
 
                 trace("New window size: %d x %d, new color: 0x%.8lX\n",
                       NewWidth, NewHeight, Colors[CurrentColor]);
@@ -714,5 +714,5 @@ static LRESULT CALLBACK WindowProc(HWND Window, UINT Message, WPARAM wParam, LPA
             PostQuitMessage(0);
             return 0;
     }
-    return DefWindowProc(Window, Message, wParam, lParam);
+    return DefWindowProcW(Window, Message, wParam, lParam);
 }

--- a/modules/rostests/apitests/user32/ScrollBarRedraw.c
+++ b/modules/rostests/apitests/user32/ScrollBarRedraw.c
@@ -122,7 +122,7 @@ colors_init(void)
 static void
 run_test_window(const char *class_name, const char *window_title, UINT class_style)
 {
-    WNDCLASS class = { };
+    WNDCLASS class;
     HWND window;
     MSG  msg;
     ATOM class_atom;

--- a/modules/rostests/apitests/user32/ScrollBarRedraw.c
+++ b/modules/rostests/apitests/user32/ScrollBarRedraw.c
@@ -109,14 +109,16 @@ static void RunTestWindow(PCWSTR ClassName, PCWSTR WindowTitle, UINT ClassStyle)
     WNDCLASSW Class = { 0 };
     HWND Window;
     MSG  Message;
+    HINSTANCE hInst;
 
     CurrentColor = 0;
+    hInst = GetModuleHandleW(NULL);
 
     Class.style         = ClassStyle;
     Class.lpfnWndProc   = WindowProc;
     Class.cbClsExtra    = 0;
     Class.cbWndExtra    = 0;
-    Class.hInstance     = GetModuleHandleW(NULL);
+    Class.hInstance     = hInst;
     Class.hIcon         = LoadIcon(NULL, IDI_APPLICATION);
     Class.hCursor       = LoadCursor(NULL, IDC_ARROW);
     Class.hbrBackground = ColorBrushes[CurrentColor];
@@ -139,7 +141,7 @@ static void RunTestWindow(PCWSTR ClassName, PCWSTR WindowTitle, UINT ClassStyle)
                            CW_USEDEFAULT,
                            NULL,
                            NULL,
-                           GetModuleHandleW(NULL),
+                           hInst,
                            NULL);
 
     if (Window == NULL)

--- a/modules/rostests/apitests/user32/ScrollBarRedraw.c
+++ b/modules/rostests/apitests/user32/ScrollBarRedraw.c
@@ -652,14 +652,24 @@ static LRESULT CALLBACK WindowProc(HWND Window, UINT Message, WPARAM wParam, LPA
             HideHorzScrollBar(Window);
 
             FsmState = FSM_STATE_START;
-            FsmTimer = SetTimer(Window, 1, FSM_STEP_PERIOD_MS, NULL);
-            ok(FsmTimer != 0, "Failed to initialize FSM timer, code: %ld\n", GetLastError());
+            FsmTimer = 0;
+
+            return 0;
+
+        case WM_PAINT:
 
             if (FsmTimer == 0)
             {
-                return -1;
+                FsmTimer = SetTimer(Window, 1, FSM_STEP_PERIOD_MS, NULL);
+                ok(FsmTimer != 0, "Failed to initialize FSM timer, code: %ld\n", GetLastError());
+
+                if (FsmTimer == 0)
+                {
+                    DestroyWindow(Window);
+                    return 0;
+                }
             }
-            return 0;
+            break;
 
         case WM_SIZE:
 

--- a/modules/rostests/apitests/user32/ScrollBarRedraw.c
+++ b/modules/rostests/apitests/user32/ScrollBarRedraw.c
@@ -127,7 +127,7 @@ static void RunTestWindow(PCWSTR ClassName, PCWSTR WindowTitle, UINT ClassStyle)
 
     if (!RegisterClassW(&Class))
     {
-        skip("Failed to register window class \"%ls\", code: %ld\n",
+        skip("Failed to register window class '%ls', code: %ld\n",
              ClassName, GetLastError());
         return;
     }
@@ -143,10 +143,9 @@ static void RunTestWindow(PCWSTR ClassName, PCWSTR WindowTitle, UINT ClassStyle)
                            NULL,
                            hInst,
                            NULL);
-
     if (Window == NULL)
     {
-        skip("Failed to create window of class \"%ls\", code: %ld\n",
+        skip("Failed to create window of class '%ls', code: %ld\n",
              ClassName, GetLastError());
         return;
     }
@@ -270,7 +269,6 @@ static int FsmStep(HWND Window)
     if (FsmState != FSM_STATE_END)
     {
         hdc = GetDC(Window);
-
         if (hdc == NULL)
         {
             skip("Failed to get device context\n");
@@ -658,7 +656,6 @@ static LRESULT CALLBACK WindowProc(HWND Window, UINT Message, WPARAM wParam, LPA
             if (FsmTimer == 0)
             {
                 FsmTimer = SetTimer(Window, 1, FSM_STEP_PERIOD_MS, NULL);
-
                 if (FsmTimer == 0)
                 {
                     skip("Failed to initialize FSM timer, code: %ld\n", GetLastError());
@@ -709,7 +706,8 @@ static LRESULT CALLBACK WindowProc(HWND Window, UINT Message, WPARAM wParam, LPA
 
                 if (FsmState != FSM_STATE_END)
                 {
-                    skip("Window was closed before test concluded, FsmState: %d, FSM_STATE_END: %d.\n", FsmState, FSM_STATE_END);
+                    skip("Window closed before test concluded, FsmState: %d, FSM_STATE_END: %d.\n",
+                         FsmState, FSM_STATE_END);
                 }
             }
             return 0;

--- a/modules/rostests/apitests/user32/testlist.c
+++ b/modules/rostests/apitests/user32/testlist.c
@@ -42,6 +42,7 @@ extern void func_RealGetWindowClass(void);
 extern void func_RedrawWindow(void);
 extern void func_RegisterHotKey(void);
 extern void func_RegisterClassEx(void);
+extern void func_ScrollBarRedraw(void);
 extern void func_ScrollBarWndExtra(void);
 extern void func_ScrollDC(void);
 extern void func_ScrollWindowEx(void);
@@ -104,6 +105,7 @@ const struct test winetest_testlist[] =
     { "RedrawWindow", func_RedrawWindow },
     { "RegisterHotKey", func_RegisterHotKey },
     { "RegisterClassEx", func_RegisterClassEx },
+    { "ScrollBarRedraw", func_ScrollBarRedraw },
     { "ScrollBarWndExtra", func_ScrollBarWndExtra },
     { "ScrollDC", func_ScrollDC },
     { "ScrollWindowEx", func_ScrollWindowEx },


### PR DESCRIPTION
## Purpose

Check [CORE-19669](https://jira.reactos.org/browse/CORE-19669) to make sure that CS_HREDRAW and CS_VREDRAW are respected when the client area of a window changes due to the scrollbar disappearing or re-appearing.

JIRA issue: [ROSTESTS-397](https://jira.reactos.org/browse/ROSTESTS-397)

## Proposed changes

Add a new rostests testcase that performs the above-mentioned check.

It works by creating a window, changing its color any time the WM_SIZE handler detects a change in the window's client area size (it switches through the standard 16 VGA colors available in 16-color mode).

The window has a timer which triggers a state transition in a state machine every 500ms, this state machine examines what happens when it makes the scroll bars disappear and re-appear, and it also tries shrinking and growing the window.

The test creates 4 windows, for each possible combination of CS_VREDRAW and CS_HREDRAW.