### PR TITLE
[CMD] Convert to explicitly unicode

### DIFF
--- a/base/shell/cmd/console.c
+++ b/base/shell/cmd/console.c
@@ -78,21 +78,18 @@ VOID ConInKey(PINPUT_RECORD lpBuffer)
     while (TRUE);
 }
 
-VOID ConInString(LPTSTR lpInput, DWORD dwLength)
+VOID ConInString(LPWSTR lpInput, DWORD dwLength)
 {
     DWORD dwOldMode;
     DWORD dwRead = 0;
     HANDLE hFile;
 
-    LPTSTR p;
+    LPWSTR p;
     PCHAR pBuf;
 
-#ifdef _UNICODE
     pBuf = (PCHAR)cmd_alloc(dwLength - 1);
-#else
-    pBuf = lpInput;
-#endif
-    ZeroMemory(lpInput, dwLength * sizeof(TCHAR));
+
+    ZeroMemory(lpInput, dwLength * sizeof(WCHAR));
     hFile = GetStdHandle(STD_INPUT_HANDLE);
     GetConsoleMode(hFile, &dwOldMode);
 
@@ -100,15 +97,14 @@ VOID ConInString(LPTSTR lpInput, DWORD dwLength)
 
     ReadFile(hFile, (PVOID)pBuf, dwLength - 1, &dwRead, NULL);
 
-#ifdef _UNICODE
     MultiByteToWideChar(InputCodePage, 0, pBuf, dwRead, lpInput, dwLength - 1);
     cmd_free(pBuf);
-#endif
+
     for (p = lpInput; *p; p++)
     {
-        if (*p == _T('\r')) // Terminate at the carriage-return.
+        if (*p == L'\r') // Terminate at the carriage-return.
         {
-            *p = _T('\0');
+            *p = L'\0';
             break;
         }
     }
@@ -120,12 +116,12 @@ VOID ConInString(LPTSTR lpInput, DWORD dwLength)
 
 /******************** Console STREAM OUT utility functions ********************/
 
-VOID ConOutChar(TCHAR c)
+VOID ConOutChar(WCHAR c)
 {
     ConWrite(StdOut, &c, 1);
 }
 
-VOID ConErrChar(TCHAR c)
+VOID ConErrChar(WCHAR c)
 {
     ConWrite(StdErr, &c, 1);
 }
@@ -152,23 +148,23 @@ VOID __cdecl ConFormatMessage(PCON_STREAM Stream, DWORD MessageId, ...)
 
 /************************** Console PAGER functions ***************************/
 
-BOOL ConPrintfVPaging(PCON_PAGER Pager, BOOL StartPaging, LPTSTR szFormat, va_list arg_ptr)
+BOOL ConPrintfVPaging(PCON_PAGER Pager, BOOL StartPaging, LPWSTR szFormat, va_list arg_ptr)
 {
     // INT len;
-    TCHAR szOut[OUTPUT_BUFFER_SIZE];
+    WCHAR szOut[OUTPUT_BUFFER_SIZE];
 
     /* Return if no string has been given */
     if (szFormat == NULL)
         return TRUE;
 
-    /*len =*/ _vstprintf(szOut, szFormat, arg_ptr);
+    /*len =*/ vswprintf(szOut, szFormat, arg_ptr);
 
     // return ConPutsPaging(Pager, PagePrompt, StartPaging, szOut);
     return ConWritePaging(Pager, PagePrompt, StartPaging,
                           szOut, wcslen(szOut));
 }
 
-BOOL __cdecl ConOutPrintfPaging(BOOL StartPaging, LPTSTR szFormat, ...)
+BOOL __cdecl ConOutPrintfPaging(BOOL StartPaging, LPWSTR szFormat, ...)
 {
     BOOL bRet;
     va_list arg_ptr;
@@ -277,7 +273,7 @@ BOOL ConGetDefaultAttributes(PWORD pwDefAttr)
 #endif
 
 
-BOOL ConSetTitle(IN LPCTSTR lpConsoleTitle)
+BOOL ConSetTitle(IN LPCWSTR lpConsoleTitle)
 {
     /* Now really set the console title */
     return SetConsoleTitle(lpConsoleTitle);

--- a/base/shell/cmd/error.c
+++ b/base/shell/cmd/error.c
@@ -25,11 +25,11 @@
 VOID
 ErrorMessage(
     IN DWORD dwErrorCode,
-    IN PCTSTR szFormat OPTIONAL,
+    IN PCWSTR szFormat OPTIONAL,
     ...)
 {
     va_list arg_ptr;
-    PTSTR szError;
+    PWSTR szError;
     TCHAR szMsg[RC_STRING_MAX_SIZE];
     TCHAR szMessage[1024];
 
@@ -40,7 +40,7 @@ ErrorMessage(
     if (szFormat)
     {
         va_start(arg_ptr, szFormat);
-        _vstprintf(szMessage, szFormat, arg_ptr);
+        vswprintf(szMessage, szFormat, arg_ptr);
         va_end(arg_ptr);
     }
 
@@ -62,21 +62,21 @@ ErrorMessage(
         ConErrPrintf(_T("%s\n"), szMsg);
 }
 
-VOID error_parameter_format(TCHAR ch)
+VOID error_parameter_format(WCHAR ch)
 {
     ConErrResPrintf(STRING_ERROR_PARAMETERF_ERROR, ch);
     nErrorLevel = 1;
 }
 
 
-VOID error_invalid_switch(TCHAR ch)
+VOID error_invalid_switch(WCHAR ch)
 {
     ConErrResPrintf(STRING_ERROR_INVALID_SWITCH, ch);
     nErrorLevel = 1;
 }
 
 
-VOID error_too_many_parameters(PCTSTR s)
+VOID error_too_many_parameters(PCWSTR s)
 {
     ConErrResPrintf(STRING_ERROR_TOO_MANY_PARAMETERS, s);
     nErrorLevel = 1;
@@ -97,7 +97,7 @@ VOID error_file_not_found(VOID)
 }
 
 
-VOID error_sfile_not_found(PCTSTR s)
+VOID error_sfile_not_found(PCWSTR s)
 {
     TCHAR szMsg[RC_STRING_MAX_SIZE];
 
@@ -121,7 +121,7 @@ VOID error_invalid_drive(VOID)
 }
 
 
-VOID error_bad_command(PCTSTR s)
+VOID error_bad_command(PCWSTR s)
 {
     ConErrResPrintf(STRING_ERROR_BADCOMMAND, s);
     nErrorLevel = 9009;
@@ -142,16 +142,16 @@ VOID error_out_of_memory(VOID)
 }
 
 
-VOID error_invalid_parameter_format(PCTSTR s)
+VOID error_invalid_parameter_format(PCWSTR s)
 {
     ConErrResPrintf(STRING_ERROR_INVALID_PARAM_FORMAT, s);
     nErrorLevel = 1;
 }
 
 
-VOID error_syntax(PCTSTR s)
+VOID error_syntax(PCWSTR s)
 {
-    TCHAR szMsg[RC_STRING_MAX_SIZE];
+    WCHAR szMsg[RC_STRING_MAX_SIZE];
 
     LoadString(CMD_ModuleHandle, STRING_ERROR_ERROR2, szMsg, ARRAYSIZE(szMsg));
 


### PR DESCRIPTION
## Purpose

Use unicode APIs explicitly instead of deprecated TCHAR APIs.

This helps avoid weirdness with non-standard functions in TCHAR apis:
_vstprintf is defined to either vsprintf (which has 3 arguments), or vswprintf, which has 4 arguments in the standard-conforming definition and 3 arguments in the legacy definition.
