### PR TITLE
[SETUPLIB] SetupCreateDirectory(): Don't assume the form of the directory prefix

### DIFF
--- a/base/setup/lib/utils/filesup.c
+++ b/base/setup/lib/utils/filesup.c
@@ -39,14 +39,6 @@ SetupCreateSingleDirectory(
         return STATUS_NO_MEMORY;
 
     if (PathName.Length > sizeof(WCHAR) &&
-        PathName.Buffer[PathName.Length / sizeof(WCHAR) - 2] == L'\\' &&
-        PathName.Buffer[PathName.Length / sizeof(WCHAR) - 1] == L'.')
-    {
-        PathName.Length -= sizeof(WCHAR);
-        PathName.Buffer[PathName.Length / sizeof(WCHAR)] = UNICODE_NULL;
-    }
-
-    if (PathName.Length > sizeof(WCHAR) &&
         PathName.Buffer[PathName.Length / sizeof(WCHAR) - 1] == L'\\')
     {
         PathName.Length -= sizeof(WCHAR);

--- a/base/setup/lib/utils/filesup.h
+++ b/base/setup/lib/utils/filesup.h
@@ -10,7 +10,7 @@
 
 NTSTATUS
 SetupCreateDirectory(
-    IN PCWSTR DirectoryName);
+    _In_ PCWSTR PathName);
 
 NTSTATUS
 SetupDeleteFile(
@@ -66,10 +66,16 @@ CombinePaths(
     IN /* PCWSTR */ ...);
 
 BOOLEAN
+DoesPathExist_UStr(
+    _In_opt_ HANDLE RootDirectory,
+    _In_ PCUNICODE_STRING PathName,
+    _In_ BOOLEAN IsDirectory);
+
+BOOLEAN
 DoesPathExist(
-    IN HANDLE RootDirectory OPTIONAL,
-    IN PCWSTR PathName,
-    IN BOOLEAN IsDirectory);
+    _In_opt_ HANDLE RootDirectory,
+    _In_ PCWSTR PathName,
+    _In_ BOOLEAN IsDirectory);
 
 #define DoesDirExist(RootDirectory, DirName)    \
     DoesPathExist((RootDirectory), (DirName), TRUE)


### PR DESCRIPTION
### _Required for PR #7159_

## Purpose

Don't suppose the form of the directory prefix.

Addendum to commit 32e6eed760 (r63715)

JIRA issue: [CORE-5982](https://jira.reactos.org/browse/CORE-5982)

The function assumed that the directory path name to be created always starts with a harddisk-partition root device name of the form:
```
  \Device\HarddiskX\PartitionY\
```
Indeed, it can be (when using the volume manager) of the form:
```
  \Device\HarddiskVolumeN\
```
and could even have a different format if trying to install ReactOS on an external removable drive or other weird device.

![ROS_install_in_subdir](https://github.com/user-attachments/assets/cc13bc92-5c5a-48e2-abf5-9b3e1059d5ea)

## Proposed changes

Since the format of this prefix is not 100% always the same, a different way to create the sub-directories is needed. The nested-directory creation algorithm is changed as follows:

Suppose that the directory to be created is:
```
  \Device\HarddiskVolume1\ReactOS\system32\drivers
```
The function first loops backwards each path component in order to find the deepest existing sub-directory: it will try to verify whether each of the following sub-directories exist, successively:
```
  \Device\HarddiskVolume1\ReactOS\system32\drivers
  \Device\HarddiskVolume1\ReactOS\system32\
  \Device\HarddiskVolume1\ReactOS\
  \Device\HarddiskVolume1\
```
(Notice the trailing path separators kept in this step.) In principle, this root device FS directory must exist (since the volume has been formatted previously). Once found, the function will then create each of the sub-directories in turn:
```
  \Device\HarddiskVolume1\ReactOS
  \Device\HarddiskVolume1\ReactOS\system32
  \Device\HarddiskVolume1\ReactOS\system32\drivers
```

----

An alternative to the fix could be to always specify the root device name in a separate parameter, but this hasn't been pursued here so as to not modify all the callers of this function.


## In addition...

[SETUPLIB] SetupCreateSingleDirectory(): Remove '\.' trailing sequence handling hack

It was introduced in commit 703eb5e8c9 (r7756) in order to hack around the "dot"-path added in the reactos.dff generator file by the earlier commit 3bd689f185 (r7269).
Its aim was to describe the installation directory itself, instead of one of its sub-directories.

That _invalid_ "dot"-path was removed later by commit 027e2bfa3a (r15423); however the '\.' hack stayed for quite a while in our code.

The correct way to describe the installation directory itself is to use instead "\", compatible with Windows' setup, as was originally done in txtsetup.sif, and fixed in reactos.dff(.in) in commit 97bb83fcd9 (r66604).

This matches also Windows' setup program behaviour, that does not support these "dot" paths:
![win2k3_setup_no_dot_dir](https://github.com/user-attachments/assets/d6531bdd-70ee-4e59-a587-d192ca9c8251)
Notice that the second dot in the error message is a sentence ending full-stop (and not part of the constructed path):
this can be proven by observing it stays there for other invalid paths as well: for example,
![win2k3_setup_no_invalid_chars_dir](https://github.com/user-attachments/assets/ca6e44e9-3316-4462-825a-da60bc28b006)

Side-note: the installer doesn't support paths with consecutive separators in them (we don't as well):
![win2k3_setup_no_consecutive_separators_dir](https://github.com/user-attachments/assets/910af4d3-5d67-4a67-907a-ee469a21dfac)
