### PR TITLE
[SETUPLIB][REACTOS][USETUP] Split FS-volume-specific functionality from partitions

### DIFF
--- a/base/setup/lib/CMakeLists.txt
+++ b/base/setup/lib/CMakeLists.txt
@@ -11,6 +11,7 @@ list(APPEND SOURCE
     spapisup/infsupp.c
     utils/arcname.c
     utils/bldrsup.c
+    utils/devutils.c
     utils/filesup.c
     utils/fsrec.c
     utils/genlist.c

--- a/base/setup/lib/CMakeLists.txt
+++ b/base/setup/lib/CMakeLists.txt
@@ -21,6 +21,7 @@ list(APPEND SOURCE
     utils/partinfo.c
     utils/partlist.c
     utils/regutil.c
+    utils/volutil.c
     bootcode.c
     bootsup.c
     fsutil.c

--- a/base/setup/lib/fsutil.h
+++ b/base/setup/lib/fsutil.h
@@ -163,7 +163,7 @@ typedef enum _FSVOL_OP
 
 typedef struct _FORMAT_VOLUME_INFO
 {
-    PPARTENTRY PartEntry;
+    PVOLENTRY Volume;
     // PCWSTR NtPathPartition;
     NTSTATUS ErrorStatus;
 
@@ -179,7 +179,7 @@ typedef struct _FORMAT_VOLUME_INFO
 
 typedef struct _CHECK_VOLUME_INFO
 {
-    PPARTENTRY PartEntry;
+    PVOLENTRY Volume;
     // PCWSTR NtPathPartition;
     NTSTATUS ErrorStatus;
 
@@ -202,8 +202,8 @@ typedef FSVOL_OP
 BOOLEAN
 FsVolCommitOpsQueue(
     _In_ PPARTLIST PartitionList,
-    _In_ PPARTENTRY SystemPartition,
-    _In_ PPARTENTRY InstallPartition,
+    _In_ PVOLENTRY SystemVolume,
+    _In_ PVOLENTRY InstallVolume,
     _In_opt_ PFSVOL_CALLBACK FsVolCallback,
     _In_opt_ PVOID Context);
 

--- a/base/setup/lib/setuplib.h
+++ b/base/setup/lib/setuplib.h
@@ -204,9 +204,9 @@ IsValidInstallDirectory(
 
 NTSTATUS
 InitDestinationPaths(
-    IN OUT PUSETUP_DATA pSetupData,
-    IN PCWSTR InstallationDir,
-    IN PPARTENTRY PartEntry);   // FIXME: HACK!
+    _Inout_ PUSETUP_DATA pSetupData,
+    _In_ PCWSTR InstallationDir,
+    _In_ PVOLENTRY Volume);
 
 // NTSTATUS
 ERROR_NUMBER

--- a/base/setup/lib/utils/devutils.c
+++ b/base/setup/lib/utils/devutils.c
@@ -1,0 +1,87 @@
+/*
+ * PROJECT:     ReactOS Setup Library
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Device utility functions
+ * COPYRIGHT:   Copyright 2024 Hermès Bélusca-Maïto <hermes.belusca-maito@reactos.org>
+ */
+
+#include "precomp.h"
+#include "devutils.h"
+
+/* FUNCTIONS *****************************************************************/
+
+/**
+ * @brief
+ * Open an existing device given by its NT-style path, which is assumed to be
+ * for a disk device or a partition. The open is for synchronous I/O access.
+ *
+ * @param[in]   DevicePath
+ * Supplies the NT-style path to the device to open.
+ *
+ * @param[out]  DeviceHandle
+ * If successful, receives the NT handle of the opened device.
+ * Once the handle is no longer in use, call NtClose() to close it.
+ *
+ * @param[in]   DesiredAccess
+ * An ACCESS_MASK value combination that determines the requested access
+ * to the device. Because the open is for synchronous access, SYNCHRONIZE
+ * is automatically added to the access mask.
+ *
+ * @param[in]   ShareAccess
+ * Specifies the type of share access for the device.
+ *
+ * @return  An NTSTATUS code indicating success or failure.
+ **/
+NTSTATUS
+pOpenDeviceEx(
+    _In_ PCWSTR DevicePath,
+    _Out_ PHANDLE DeviceHandle,
+    _In_ ACCESS_MASK DesiredAccess,
+    _In_ ULONG ShareAccess)
+{
+    UNICODE_STRING Name;
+    OBJECT_ATTRIBUTES ObjectAttributes;
+    IO_STATUS_BLOCK IoStatusBlock;
+
+    RtlInitUnicodeString(&Name, DevicePath);
+    InitializeObjectAttributes(&ObjectAttributes,
+                               &Name,
+                               OBJ_CASE_INSENSITIVE,
+                               NULL,
+                               NULL);
+    return NtOpenFile(DeviceHandle,
+                      DesiredAccess | SYNCHRONIZE,
+                      &ObjectAttributes,
+                      &IoStatusBlock,
+                      ShareAccess,
+                      /* FILE_NON_DIRECTORY_FILE | */
+                      FILE_SYNCHRONOUS_IO_NONALERT);
+}
+
+/**
+ * @brief
+ * Open an existing device given by its NT-style path, which is assumed to be
+ * for a disk device or a partition. The open is share read/write/delete, for
+ * synchronous I/O and read access.
+ *
+ * @param[in]   DevicePath
+ * @param[out]  DeviceHandle
+ * See the DevicePath and DeviceHandle parameters of pOpenDeviceEx().
+ *
+ * @return  An NTSTATUS code indicating success or failure.
+ *
+ * @see pOpenDeviceEx()
+ **/
+NTSTATUS
+pOpenDevice(
+    _In_ PCWSTR DevicePath,
+    _Out_ PHANDLE DeviceHandle)
+{
+    return pOpenDeviceEx(DevicePath,
+                         DeviceHandle,
+                         FILE_READ_DATA | FILE_READ_ATTRIBUTES,
+                         FILE_SHARE_VALID_FLAGS // FILE_SHARE_READ,WRITE,DELETE
+                         );
+}
+
+/* EOF */

--- a/base/setup/lib/utils/devutils.h
+++ b/base/setup/lib/utils/devutils.h
@@ -1,0 +1,24 @@
+/*
+ * PROJECT:     ReactOS Setup Library
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Device utility functions
+ * COPYRIGHT:   Copyright 2024 Hermès Bélusca-Maïto <hermes.belusca-maito@reactos.org>
+ */
+
+#pragma once
+
+/* FUNCTIONS *****************************************************************/
+
+NTSTATUS
+pOpenDeviceEx(
+    _In_ PCWSTR DevicePath,
+    _Out_ PHANDLE DeviceHandle,
+    _In_ ACCESS_MASK DesiredAccess,
+    _In_ ULONG ShareAccess);
+
+NTSTATUS
+pOpenDevice(
+    _In_ PCWSTR DevicePath,
+    _Out_ PHANDLE DeviceHandle);
+
+/* EOF */

--- a/base/setup/lib/utils/osdetect.h
+++ b/base/setup/lib/utils/osdetect.h
@@ -1,9 +1,9 @@
 /*
  * PROJECT:     ReactOS Setup Library
- * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
  * PURPOSE:     NT 5.x family (MS Windows <= 2003, and ReactOS)
  *              operating systems detection code.
- * COPYRIGHT:   Copyright 2017-2018 Hermes Belusca-Maito
+ * COPYRIGHT:   Copyright 2017-2024 Hermès Bélusca-Maïto <hermes.belusca-maito@reactos.org>
  */
 
 #pragma once
@@ -22,7 +22,7 @@ typedef struct _NTOS_INSTALLATION
     PCWSTR PathComponent;           // Pointer inside SystemNtPath.Buffer
     ULONG DiskNumber;
     ULONG PartitionNumber;
-    PPARTENTRY PartEntry;
+    PVOLENTRY Volume; // PVOLINFO
     WCHAR InstallationName[MAX_PATH];
     WCHAR VendorName[MAX_PATH];
     // CHAR Data[ANYSIZE_ARRAY];
@@ -31,7 +31,7 @@ typedef struct _NTOS_INSTALLATION
 // EnumerateNTOSInstallations
 PGENERIC_LIST
 CreateNTOSInstallationsList(
-    IN PPARTLIST List);
+    _In_ PPARTLIST PartList);
 
 /*
  * FindSubStrI(PCWSTR str, PCWSTR strSearch) :

--- a/base/setup/lib/utils/partlist.h
+++ b/base/setup/lib/utils/partlist.h
@@ -1,9 +1,9 @@
 /*
  * PROJECT:     ReactOS Setup Library
- * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
  * PURPOSE:     Partition list functions
  * COPYRIGHT:   Copyright 2003-2019 Casper S. Hornstrup (chorns@users.sourceforge.net)
- *              Copyright 2018-2019 Hermes Belusca-Maito
+ *              Copyright 2018-2024 Hermès Bélusca-Maïto <hermes.belusca-maito@reactos.org>
  */
 
 #pragma once
@@ -34,9 +34,29 @@ typedef enum _FORMATSTATE
     Unformatted,
     UnformattedOrDamaged,
     UnknownFormat,
-    Preformatted,
     Formatted
 } FORMATSTATE, *PFORMATSTATE;
+
+#include "volutil.h"
+
+typedef struct _PARTENTRY PARTENTRY, *PPARTENTRY;
+typedef struct _VOLENTRY
+{
+    LIST_ENTRY ListEntry; ///< Entry in VolumesList
+
+    VOLINFO Info;
+    FORMATSTATE FormatState;
+
+    /* Volume must be checked */
+    BOOLEAN NeedsCheck;
+    /* Volume is new and has not yet been actually formatted and mounted */
+    BOOLEAN New;
+
+    // union {
+    //     PVOLUME_DISK_EXTENTS pExtents;
+        PPARTENTRY PartEntry;
+    // };
+} VOLENTRY, *PVOLENTRY;
 
 typedef struct _PARTENTRY
 {
@@ -54,24 +74,25 @@ typedef struct _PARTENTRY
     ULONG OnDiskPartitionNumber; /* Enumerated partition number (primary partitions first, excluding the extended partition container, then the logical partitions) */
     ULONG PartitionNumber;       /* Current partition number, only valid for the currently running NTOS instance */
     ULONG PartitionIndex;        /* Index in the LayoutBuffer->PartitionEntry[] cached array of the corresponding DiskEntry */
-
-    WCHAR DriveLetter;
-    WCHAR VolumeLabel[20];
-    WCHAR FileSystem[MAX_PATH+1];
-    FORMATSTATE FormatState;
+    WCHAR DeviceName[MAX_PATH];  ///< NT device name: "\Device\HarddiskM\PartitionN"
 
     BOOLEAN LogicalPartition;
 
     /* Partition is partitioned disk space */
     BOOLEAN IsPartitioned;
 
-/** The following three properties may be replaced by flags **/
-
     /* Partition is new, table does not exist on disk yet */
     BOOLEAN New;
 
-    /* Partition must be checked */
-    BOOLEAN NeedsCheck;
+    /*
+     * Volume-related properties:
+     * NULL: No volume is associated to this partition (either because it is
+     *       an empty disk region, or the partition type is unrecognized).
+     * 0x1 : TBD.
+     * Valid pointer: A basic volume associated to this partition is (or will)
+     *       be mounted by the PARTMGR and enumerated by the MOUNTMGR.
+     */
+    PVOLENTRY Volume;
 
 } PARTENTRY, *PPARTENTRY;
 
@@ -162,9 +183,12 @@ typedef struct _PARTLIST
     LIST_ENTRY DiskListHead;
     LIST_ENTRY BiosDiskListHead;
 
+    /* (Basic) Volumes management */
+    LIST_ENTRY VolumesList;
+
 } PARTLIST, *PPARTLIST;
 
-#define  PARTITION_TBL_SIZE 4
+#define PARTITION_TBL_SIZE  4
 
 #define PARTITION_MAGIC     0xAA55
 
@@ -307,10 +331,6 @@ CreatePartition(
     _In_opt_ ULONGLONG SizeBytes,
     _In_opt_ ULONG_PTR PartitionInfo);
 
-NTSTATUS
-DismountVolume(
-    IN PPARTENTRY PartEntry);
-
 BOOLEAN
 DeletePartition(
     _In_ PPARTLIST List,
@@ -339,14 +359,8 @@ WritePartitionsToDisk(
     IN PPARTLIST List);
 
 BOOLEAN
-SetMountedDeviceValue(
-    IN WCHAR Letter,
-    IN ULONG Signature,
-    IN LARGE_INTEGER StartingOffset);
-
-BOOLEAN
 SetMountedDeviceValues(
-    IN PPARTLIST List);
+    _In_ PPARTLIST List);
 
 VOID
 SetMBRPartitionType(

--- a/base/setup/lib/utils/volutil.c
+++ b/base/setup/lib/utils/volutil.c
@@ -1,0 +1,226 @@
+/*
+ * PROJECT:     ReactOS Setup Library
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Volume utility functions
+ * COPYRIGHT:   Copyright 2024 Hermès Bélusca-Maïto <hermes.belusca-maito@reactos.org>
+ */
+
+/* INCLUDES ******************************************************************/
+
+#include "precomp.h"
+
+#include "volutil.h"
+#include "fsrec.h"
+#include "devutils.h"
+
+#define NDEBUG
+#include <debug.h>
+
+
+/* FUNCTIONS *****************************************************************/
+
+NTSTATUS
+MountVolume(
+    _Inout_ PVOLINFO Volume,
+    _In_opt_ UCHAR MbrPartitionType)
+{
+    NTSTATUS Status;
+    HANDLE VolumeHandle;
+
+    /* If the volume is already mounted, just return success */
+    if (*Volume->FileSystem)
+        return STATUS_SUCCESS;
+
+    /* Try to open the volume so as to mount it */
+    VolumeHandle = NULL;
+    Status = pOpenDevice(Volume->DeviceName, &VolumeHandle);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("pOpenDevice() failed, Status 0x%08lx\n", Status);
+
+        /* We failed, reset some data and bail out */
+        Volume->DriveLetter = UNICODE_NULL;
+        Volume->VolumeLabel[0] = UNICODE_NULL;
+        Volume->FileSystem[0] = UNICODE_NULL;
+
+        return Status;
+    }
+    ASSERT(VolumeHandle);
+
+    /* We don't have a FS, try to guess one */
+    Status = InferFileSystem(NULL, VolumeHandle,
+                             Volume->FileSystem,
+                             sizeof(Volume->FileSystem));
+    if (!NT_SUCCESS(Status))
+        DPRINT1("InferFileSystem() failed, Status 0x%08lx\n", Status);
+
+    if (*Volume->FileSystem)
+    {
+        /*
+         * Handle volume mounted with RawFS: it is
+         * either unformatted or has an unknown format.
+         */
+        if (IsUnformatted(Volume)) // FileSystem is "RAW"
+        {
+            /*
+             * True unformatted partitions on NT are created with their
+             * partition type set to either one of the following values,
+             * and are mounted with RawFS. This is done this way since we
+             * are assured to have FAT support, which is the only FS that
+             * uses these partition types. Therefore, having a partition
+             * mounted with RawFS and with these partition types means that
+             * the FAT FS was unable to mount it beforehand and thus the
+             * partition is unformatted.
+             * However, any partition mounted by RawFS that does NOT have
+             * any of these partition types must be considered as having
+             * an unknown format.
+             */
+            if (MbrPartitionType == PARTITION_FAT_12 ||
+                MbrPartitionType == PARTITION_FAT_16 ||
+                MbrPartitionType == PARTITION_HUGE   ||
+                MbrPartitionType == PARTITION_XINT13 ||
+                MbrPartitionType == PARTITION_FAT32  ||
+                MbrPartitionType == PARTITION_FAT32_XINT13)
+            {
+                /* The volume is unformatted */
+            }
+            else
+            {
+                /* Close the volume before dismounting */
+                NtClose(VolumeHandle);
+                VolumeHandle = NULL;
+                /*
+                 * Dismount the volume since RawFS owns it, and reset its
+                 * format (it is unknown, may or may not be actually formatted).
+                 */
+                DismountVolume(Volume, TRUE);
+                Volume->FileSystem[0] = UNICODE_NULL;
+            }
+        }
+        /* Else, the volume is formatted */
+    }
+    /* Else, the volume has an unknown format */
+
+    /* Retrieve the volume label */
+    if (VolumeHandle)
+    {
+        IO_STATUS_BLOCK IoStatusBlock;
+        struct
+        {
+            FILE_FS_VOLUME_INFORMATION;
+            WCHAR Data[255];
+        } LabelInfo;
+
+        Status = NtQueryVolumeInformationFile(VolumeHandle,
+                                              &IoStatusBlock,
+                                              &LabelInfo,
+                                              sizeof(LabelInfo),
+                                              FileFsVolumeInformation);
+        if (NT_SUCCESS(Status))
+        {
+            /* Copy the (possibly truncated) volume label and NULL-terminate it */
+            RtlStringCbCopyNW(Volume->VolumeLabel, sizeof(Volume->VolumeLabel),
+                              LabelInfo.VolumeLabel, LabelInfo.VolumeLabelLength);
+        }
+        else
+        {
+            DPRINT1("NtQueryVolumeInformationFile() failed, Status 0x%08lx\n", Status);
+        }
+    }
+
+    /* Close the volume */
+    if (VolumeHandle)
+        NtClose(VolumeHandle);
+
+    return STATUS_SUCCESS;
+}
+
+/**
+ * @brief
+ * Attempts to dismount the designated volume.
+ *
+ * @param[in,out]   Volume
+ * The volume to dismount.
+ *
+ * @param[in]   Force
+ * Whether the volume is forcibly dismounted, even
+ * if there are open handles to files on this volume.
+ *
+ * @return  An NTSTATUS code indicating success or failure.
+ **/
+NTSTATUS
+DismountVolume(
+    _Inout_ PVOLINFO Volume,
+    _In_ BOOLEAN Force)
+{
+    NTSTATUS Status, LockStatus;
+    IO_STATUS_BLOCK IoStatusBlock;
+    HANDLE VolumeHandle;
+
+    /* If the volume is not mounted, just return success */
+    if (!*Volume->FileSystem)
+        return STATUS_SUCCESS;
+
+    /* Open the volume */
+    Status = pOpenDeviceEx(Volume->DeviceName, &VolumeHandle,
+                           GENERIC_READ | GENERIC_WRITE,
+                           FILE_SHARE_READ | FILE_SHARE_WRITE);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("ERROR: Cannot open volume %S for dismounting! (Status 0x%lx)\n",
+                Volume->DeviceName, Status);
+        return Status;
+    }
+
+    /* Lock the volume (succeeds only if there are no open handles to files) */
+    LockStatus = NtFsControlFile(VolumeHandle,
+                                 NULL, NULL, NULL,
+                                 &IoStatusBlock,
+                                 FSCTL_LOCK_VOLUME,
+                                 NULL, 0,
+                                 NULL, 0);
+    if (!NT_SUCCESS(LockStatus))
+        DPRINT1("WARNING: Failed to lock volume (Status 0x%lx)\n", LockStatus);
+
+    /* Dismount the volume (succeeds even when lock fails and there are open handles) */
+    Status = STATUS_ACCESS_DENIED; // Suppose dismount failure.
+    if (NT_SUCCESS(LockStatus) || Force)
+    {
+        Status = NtFsControlFile(VolumeHandle,
+                                 NULL, NULL, NULL,
+                                 &IoStatusBlock,
+                                 FSCTL_DISMOUNT_VOLUME,
+                                 NULL, 0,
+                                 NULL, 0);
+        if (!NT_SUCCESS(Status))
+            DPRINT1("Failed to unmount volume (Status 0x%lx)\n", Status);
+    }
+
+    /* Unlock the volume */
+    if (NT_SUCCESS(LockStatus))
+    {
+        LockStatus = NtFsControlFile(VolumeHandle,
+                                     NULL, NULL, NULL,
+                                     &IoStatusBlock,
+                                     FSCTL_UNLOCK_VOLUME,
+                                     NULL, 0,
+                                     NULL, 0);
+        if (!NT_SUCCESS(LockStatus))
+            DPRINT1("Failed to unlock volume (Status 0x%lx)\n", LockStatus);
+    }
+
+    /* Close the volume */
+    NtClose(VolumeHandle);
+
+    /* Reset some data only if dismount succeeded */
+    if (NT_SUCCESS(Status))
+    {
+        Volume->DriveLetter = UNICODE_NULL;
+        Volume->VolumeLabel[0] = UNICODE_NULL;
+        Volume->FileSystem[0] = UNICODE_NULL;
+    }
+
+    return Status;
+}
+
+/* EOF */

--- a/base/setup/lib/utils/volutil.h
+++ b/base/setup/lib/utils/volutil.h
@@ -1,0 +1,48 @@
+/*
+ * PROJECT:     ReactOS Setup Library
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Volume utility functions
+ * COPYRIGHT:   Copyright 2024 Hermès Bélusca-Maïto <hermes.belusca-maito@reactos.org>
+ */
+
+#pragma once
+
+typedef struct _VOLINFO
+{
+    // WCHAR VolumeName[MAX_PATH]; ///< Name in the DOS/Win32 namespace: "\??\Volume{GUID}\"
+    WCHAR DeviceName[MAX_PATH]; ///< NT device name: "\Device\HarddiskVolumeN"
+
+    WCHAR DriveLetter;
+    WCHAR VolumeLabel[20];
+    WCHAR FileSystem[MAX_PATH+1];
+
+    // VOLUME_TYPE VolumeType;
+    // ULARGE_INTEGER Size;
+    // PVOLUME_DISK_EXTENTS Extents;
+} VOLINFO, *PVOLINFO;
+
+/* RawFS "RAW" file system name */
+#define IS_RAWFS(fs) \
+    ((fs)[0] == 'R' && (fs)[1] == 'A' && (fs)[2] == 'W' && (fs)[3] == 0)
+
+#define IsUnknown(VolInfo) \
+    (!*(VolInfo)->FileSystem)
+
+#define IsUnformatted(VolInfo) \
+    IS_RAWFS((VolInfo)->FileSystem)
+
+#define IsFormatted(VolInfo) \
+    (!IsUnknown(VolInfo) && !IsUnformatted(VolInfo))
+
+
+NTSTATUS
+MountVolume(
+    _Inout_ PVOLINFO Volume,
+    _In_opt_ UCHAR MbrPartitionType);
+
+NTSTATUS
+DismountVolume(
+    _Inout_ PVOLINFO Volume,
+    _In_ BOOLEAN Force);
+
+/* EOF */

--- a/base/setup/reactos/drivepage.c
+++ b/base/setup/reactos/drivepage.c
@@ -571,6 +571,7 @@ PrintPartitionData(
     IN PDISKENTRY DiskEntry,
     IN PPARTENTRY PartEntry)
 {
+    PVOLINFO VolInfo = (PartEntry->Volume ? &PartEntry->Volume->Info : NULL);
     LARGE_INTEGER PartSize;
     HTLITEM htiPart;
     CHAR PartTypeString[32];
@@ -589,9 +590,9 @@ PrintPartitionData(
         StringCchPrintfW(LineBuffer, ARRAYSIZE(LineBuffer),
                          // MUIGetString(STRING_HDDINFOUNK5),
                          L"%s (%c%c)",
-                         *PartEntry->VolumeLabel ? PartEntry->VolumeLabel : L"Partition",
-                         (PartEntry->DriveLetter == 0) ? L'-' : PartEntry->DriveLetter,
-                         (PartEntry->DriveLetter == 0) ? L'-' : L':');
+                         (VolInfo && *VolInfo->VolumeLabel) ? VolInfo->VolumeLabel : L"Partition",
+                         !(VolInfo && VolInfo->DriveLetter) ? L'-' : VolInfo->DriveLetter,
+                         !(VolInfo && VolInfo->DriveLetter) ? L'-' : L':');
     }
 
     htiPart = TreeListAddItem(hWndList, htiParent, LineBuffer,
@@ -1001,8 +1002,8 @@ DriveDlgProc(
 
                             if (PartEntry->IsPartitioned &&
                                 !IsContainerPartition(PartEntry->PartitionType) /* alternatively: PartEntry->PartitionNumber != 0 */ &&
-                                // !PartEntry->New &&
-                                (PartEntry->FormatState == Preformatted /* || PartEntry->FormatState == Formatted */))
+                                PartEntry->Volume && // !PartEntry->Volume->New &&
+                                (PartEntry->Volume->FormatState == Formatted))
                             {
                                 PropSheet_SetWizButtons(GetParent(hwndDlg), PSWIZB_BACK | PSWIZB_NEXT);
                             }
@@ -1079,11 +1080,12 @@ DisableWizNext:
                     DiskEntry.HwFixedDiskNumber = 0;
                     PartEntry.DiskEntry = &DiskEntry;
                     PartEntry.PartitionNumber = 1; // 4;
+                    PartEntry.Volume = NULL;
                     /****/
 
                     Status = InitDestinationPaths(&pSetupData->USetupData,
                                                   NULL, // pSetupData->USetupData.InstallationDirectory,
-                                                  &PartEntry);
+                                                  PartEntry.Volume);
 
                     if (!NT_SUCCESS(Status))
                     {

--- a/base/setup/reactos/reactos.c
+++ b/base/setup/reactos/reactos.c
@@ -596,14 +596,14 @@ AddNTOSInstallationItem(
     IN SIZE_T cchBufferSize)
 {
     PNTOS_INSTALLATION NtOsInstall = (PNTOS_INSTALLATION)GetListEntryData(Entry);
-    PPARTENTRY PartEntry = NtOsInstall->PartEntry;
+    PVOLINFO VolInfo = (NtOsInstall->Volume ? &NtOsInstall->Volume->Info : NULL);
 
-    if (PartEntry && PartEntry->DriveLetter)
+    if (VolInfo && VolInfo->DriveLetter)
     {
         /* We have retrieved a partition that is mounted */
         StringCchPrintfW(Buffer, cchBufferSize,
                          L"%c:%s",
-                         PartEntry->DriveLetter,
+                         VolInfo->DriveLetter,
                          NtOsInstall->PathComponent);
     }
     else

--- a/base/setup/usetup/usetup.c
+++ b/base/setup/usetup/usetup.c
@@ -46,6 +46,8 @@ static USETUP_DATA USetupData;
 
 /* The partition where to perform the installation */
 static PPARTENTRY InstallPartition = NULL;
+// static PVOLENTRY InstallVolume = NULL;
+#define InstallVolume (InstallPartition->Volume)
 /*
  * The system partition we will actually use. It can be different from
  * PartitionList->SystemPartition in case we don't support it, or we install
@@ -57,6 +59,8 @@ static PPARTENTRY InstallPartition = NULL;
  * operation on them).
  */
 static PPARTENTRY SystemPartition = NULL;
+// static PVOLENTRY SystemVolume = NULL;
+#define SystemVolume (SystemPartition->Volume)
 
 
 /* OTHER Stuff *****/
@@ -77,8 +81,8 @@ static enum {
     PartTypeExtended // MBR-disk container
 } PartCreateType = PartTypeData;
 
-/* Flag set in PARTENTRY::New when a partition is created automatically */
-#define PARTITION_NEW_AUTOCREATE    0x80
+/* Flag set in VOLENTRY::New when a partition/volume is created automatically */
+#define VOLUME_NEW_AUTOCREATE   0x80
 
 /* List of supported file systems for the partition to be formatted */
 static PFILE_SYSTEM_LIST FileSystemList = NULL;
@@ -508,14 +512,14 @@ GetNTOSInstallationName(
     IN SIZE_T cchBufferSize)
 {
     PNTOS_INSTALLATION NtOsInstall = (PNTOS_INSTALLATION)GetListEntryData(Entry);
-    PPARTENTRY PartEntry = NtOsInstall->PartEntry;
+    PVOLINFO VolInfo = (NtOsInstall->Volume ? &NtOsInstall->Volume->Info : NULL);
 
-    if (PartEntry && PartEntry->DriveLetter)
+    if (VolInfo && VolInfo->DriveLetter)
     {
         /* We have retrieved a partition that is mounted */
         return RtlStringCchPrintfA(Buffer, cchBufferSize,
                                    "%C:%S  \"%S\"",
-                                   PartEntry->DriveLetter,
+                                   VolInfo->DriveLetter,
                                    NtOsInstall->PathComponent,
                                    NtOsInstall->InstallationName);
     }
@@ -1568,7 +1572,6 @@ SelectPartitionPage(PINPUT_RECORD Ir)
             DPRINT1("RepairUpdateFlag == TRUE, SelectPartition() returned FALSE, assert!\n");
             ASSERT(FALSE);
         }
-        ASSERT(!IsContainerPartition(InstallPartition->PartitionType));
 
         return START_PARTITION_OPERATIONS_PAGE;
     }
@@ -1603,7 +1606,8 @@ SelectPartitionPage(PINPUT_RECORD Ir)
                                 CurrentPartition,
                                 0ULL,
                                 0);
-                CurrentPartition->New |= PARTITION_NEW_AUTOCREATE;
+                if (CurrentPartition->Volume)
+                    CurrentPartition->Volume->New |= VOLUME_NEW_AUTOCREATE;
 
 // FIXME?? Aren't we going to enter an infinite loop, if this test fails??
                 if (!IsPartitionLargeEnough(CurrentPartition))
@@ -1735,7 +1739,8 @@ SelectPartitionPage(PINPUT_RECORD Ir)
                                 CurrentPartition,
                                 0ULL,
                                 0);
-                CurrentPartition->New |= PARTITION_NEW_AUTOCREATE;
+                if (CurrentPartition->Volume)
+                    CurrentPartition->Volume->New |= VOLUME_NEW_AUTOCREATE;
             }
 
             if (!IsPartitionLargeEnough(CurrentPartition))
@@ -1781,28 +1786,23 @@ SelectPartitionPage(PINPUT_RECORD Ir)
         }
         else if (Ir->Event.KeyEvent.wVirtualKeyCode == 'D')  /* D */
         {
-            UNICODE_STRING CurrentPartitionU;
-            WCHAR PathBuffer[MAX_PATH];
-
             ASSERT(CurrentPartition != NULL);
 
             /* Ignore deletion in case this is not a partitioned entry */
             if (!CurrentPartition->IsPartitioned)
-            {
                 continue;
-            }
 
 // TODO: Do something similar before trying to format the partition?
-            if (!CurrentPartition->New &&
-                !IsContainerPartition(CurrentPartition->PartitionType) &&
-                CurrentPartition->FormatState != Unformatted)
+            if (CurrentPartition->Volume && !CurrentPartition->Volume->New &&
+                (CurrentPartition->Volume->FormatState != Unformatted))
             {
+                UNICODE_STRING CurrentPartitionU;
+                WCHAR PathBuffer[RTL_NUMBER_OF_FIELD(VOLINFO, DeviceName) + 1];
+
                 ASSERT(CurrentPartition->PartitionNumber != 0);
 
-                RtlStringCchPrintfW(PathBuffer, ARRAYSIZE(PathBuffer),
-                        L"\\Device\\Harddisk%lu\\Partition%lu\\",
-                        CurrentPartition->DiskEntry->DiskNumber,
-                        CurrentPartition->PartitionNumber);
+                RtlStringCchPrintfW(PathBuffer, _countof(PathBuffer),
+                                    L"%s\\", CurrentPartition->Volume->Info.DeviceName);
                 RtlInitUnicodeString(&CurrentPartitionU, PathBuffer);
 
                 /*
@@ -2286,16 +2286,16 @@ StartPartitionOperationsPage(PINPUT_RECORD Ir)
     //
 
     /* Set the AUTOCREATE flag if the system partition was automatically created */
-    if (SystemPartition->New)
-        SystemPartition->New |= PARTITION_NEW_AUTOCREATE;
+    if (SystemPartition->New && SystemVolume)
+        SystemVolume->New |= VOLUME_NEW_AUTOCREATE;
 
     CONSOLE_ClearScreen();
     CONSOLE_Flush();
 
     /* Apply all pending operations on partitions: formatting and checking */
     Success = FsVolCommitOpsQueue(PartitionList,
-                                  SystemPartition,
-                                  InstallPartition,
+                                  SystemVolume,
+                                  InstallVolume,
                                   FsVolCallback,
                                   &FsVolContext);
     if (!Success)
@@ -2358,41 +2358,43 @@ ResetFileSystemList(VOID)
 
 static FSVOL_OP
 SelectFileSystemPage(
-    IN PFSVOL_CONTEXT FsVolContext,
-    IN PPARTENTRY PartEntry)
+    _In_ PFSVOL_CONTEXT FsVolContext,
+    _In_ PVOLENTRY Volume)
 {
     PINPUT_RECORD Ir = FsVolContext->Ir;
+    PPARTENTRY PartEntry = Volume->PartEntry;
     PDISKENTRY DiskEntry = PartEntry->DiskEntry;
     PCWSTR DefaultFs;
+    BOOLEAN ForceFormat;
     CHAR LineBuffer[100];
 
     DPRINT("SelectFileSystemPage()\n");
 
-    ASSERT(PartEntry->IsPartitioned && PartEntry->PartitionNumber != 0);
+    ForceFormat = (Volume->New || Volume->FormatState == Unformatted);
 
 Restart:
-    /* Reset the file system list for each partition that is to be formatted */
+    /* Reset the file system list for each volume that is to be formatted */
     ResetFileSystemList();
 
     CONSOLE_ClearScreen();
     CONSOLE_Flush();
     MUIDisplayPage(SELECT_FILE_SYSTEM_PAGE);
 
-    if (PartEntry->New & PARTITION_NEW_AUTOCREATE)
+    if (Volume->New & VOLUME_NEW_AUTOCREATE)
     {
-        PartEntry->New &= ~PARTITION_NEW_AUTOCREATE;
+        Volume->New &= ~VOLUME_NEW_AUTOCREATE;
 
         CONSOLE_SetTextXY(6, 8, MUIGetString(STRING_NEWPARTITION));
     }
-    else if (PartEntry->New)
+    else if (Volume->New)
     {
         ULONG uID;
 
-        if (PartEntry == SystemPartition)       // FormatSystemPartition
+        if (Volume == SystemVolume)
             uID = STRING_NONFORMATTEDSYSTEMPART;
-        else if (PartEntry == InstallPartition) // FormatInstallPartition
+        else if (Volume == InstallVolume)
             uID = STRING_NONFORMATTEDPART;
-        else                                    // FormatOtherPartition
+        else
             uID = STRING_NONFORMATTEDOTHERPART;
 
         CONSOLE_SetTextXY(6, 8, MUIGetString(uID));
@@ -2410,7 +2412,7 @@ Restart:
                         LineBuffer);
 
     /* Show "This Partition will be formatted next" only if it is unformatted */
-    if (PartEntry->New || PartEntry->FormatState == Unformatted)
+    if (ForceFormat)
         CONSOLE_SetTextXY(6, 14, MUIGetString(STRING_PARTFORMAT));
 
     ASSERT(!FileSystemList);
@@ -2439,11 +2441,8 @@ Restart:
     }
 
     /* Create the file system list */
-    // TODO: Display only the FSes compatible with the selected partition!
-    FileSystemList = CreateFileSystemList(6, 26,
-                                          PartEntry->New ||
-                                          PartEntry->FormatState == Unformatted,
-                                          DefaultFs);
+    // TODO: Display only the FSes compatible with the selected volume!
+    FileSystemList = CreateFileSystemList(6, 26, ForceFormat, DefaultFs);
     if (!FileSystemList)
     {
         /* FIXME: show an error dialog */
@@ -2493,23 +2492,21 @@ Restart:
         {
             if (!FileSystemList->Selected->FileSystem)
             {
-                ASSERT(!PartEntry->New && PartEntry->FormatState != Unformatted);
+                /* The 'Keep existing filesystem' entry was chosen,
+                 * the volume must be already formatted */
+                ASSERT(!ForceFormat);
 
-                /*
-                 * Skip formatting this partition. We will also ignore
+                /* Skip formatting this volume. We will also ignore
                  * file system checks on it, unless it is either the
-                 * system or the installation partition.
-                 */
-                if (PartEntry != SystemPartition &&
-                    PartEntry != InstallPartition)
-                {
-                    PartEntry->NeedsCheck = FALSE;
-                }
+                 * system or the installation volume. */
+                if ((Volume != SystemVolume) && (Volume != InstallVolume))
+                    Volume->NeedsCheck = FALSE;
+
                 return FSVOL_SKIP;
             }
             else
             {
-                /* Format this partition */
+                /* Format this volume */
                 return FSVOL_DOIT;
             }
         }
@@ -2520,10 +2517,11 @@ Restart:
 
 static FSVOL_OP
 FormatPartitionPage(
-    IN PFSVOL_CONTEXT FsVolContext,
-    IN PPARTENTRY PartEntry)
+    _In_ PFSVOL_CONTEXT FsVolContext,
+    _In_ PVOLENTRY Volume)
 {
     PINPUT_RECORD Ir = FsVolContext->Ir;
+    PPARTENTRY PartEntry = Volume->PartEntry;
     PDISKENTRY DiskEntry = PartEntry->DiskEntry;
     CHAR LineBuffer[100];
 
@@ -2571,8 +2569,9 @@ Restart:
 
 static VOID
 CheckFileSystemPage(
-    IN PPARTENTRY PartEntry)
+    _In_ PVOLENTRY Volume)
 {
+    PPARTENTRY PartEntry = Volume->PartEntry;
     PDISKENTRY DiskEntry = PartEntry->DiskEntry;
     CHAR LineBuffer[100];
 
@@ -2693,7 +2692,8 @@ FsVolCallback(
         if (FmtInfo->ErrorStatus == STATUS_UNRECOGNIZED_VOLUME)
         {
             /* FIXME: show an error dialog */
-            // MUIDisplayError(ERROR_FORMATTING_PARTITION, Ir, POPUP_WAIT_ANY_KEY, PathBuffer);
+            // MUIDisplayError(ERROR_FORMATTING_PARTITION, Ir, POPUP_WAIT_ANY_KEY,
+            //                 FmtInfo->Volume->Info.DeviceName);
             FsVolContext->NextPageOnAbort = QUIT_PAGE;
             return FSVOL_ABORT;
         }
@@ -2737,16 +2737,9 @@ FsVolCallback(
         }
         else if (!NT_SUCCESS(FmtInfo->ErrorStatus))
         {
-            WCHAR PathBuffer[MAX_PATH];
-
-            /** HACK!! **/
-            RtlStringCchPrintfW(PathBuffer, ARRAYSIZE(PathBuffer),
-                                L"\\Device\\Harddisk%lu\\Partition%lu",
-                                FmtInfo->PartEntry->DiskEntry->DiskNumber,
-                                FmtInfo->PartEntry->PartitionNumber);
-
             DPRINT1("FormatPartition() failed: Status 0x%08lx\n", FmtInfo->ErrorStatus);
-            MUIDisplayError(ERROR_FORMATTING_PARTITION, Ir, POPUP_WAIT_ANY_KEY, PathBuffer);
+            MUIDisplayError(ERROR_FORMATTING_PARTITION, Ir, POPUP_WAIT_ANY_KEY,
+                            FmtInfo->Volume->Info.DeviceName);
             FsVolContext->NextPageOnAbort = QUIT_PAGE;
             return FSVOL_ABORT;
         }
@@ -2766,7 +2759,7 @@ FsVolCallback(
                                "\n"
                                "  \x07  Press ENTER to continue Setup.\n"
                                "  \x07  Press F3 to quit Setup.",
-                               ChkInfo->PartEntry->FileSystem);
+                               ChkInfo->Volume->Info.FileSystem);
 
             PopupError(Buffer,
                        MUIGetString(STRING_QUITCONTINUE),
@@ -2820,12 +2813,12 @@ FsVolCallback(
         ASSERT((FSVOL_OP)Param2 == FSVOL_FORMAT);
 
         /* Select the file system */
-        Result = SelectFileSystemPage(FsVolContext, FmtInfo->PartEntry);
+        Result = SelectFileSystemPage(FsVolContext, FmtInfo->Volume);
         if (Result != FSVOL_DOIT)
             return Result;
 
         /* Display the formatting page */
-        Result = FormatPartitionPage(FsVolContext, FmtInfo->PartEntry);
+        Result = FormatPartitionPage(FsVolContext, FmtInfo->Volume);
         if (Result != FSVOL_DOIT)
             return Result;
 
@@ -2849,7 +2842,7 @@ FsVolCallback(
 
         ASSERT((FSVOL_OP)Param2 == FSVOL_CHECK);
 
-        CheckFileSystemPage(ChkInfo->PartEntry);
+        CheckFileSystemPage(ChkInfo->Volume);
         StartCheck(ChkInfo);
         return FSVOL_DOIT;
     }
@@ -2907,7 +2900,7 @@ InstallDirectoryPage(PINPUT_RECORD Ir)
      */
     if ((RepairUpdateFlag || IsUnattendedSetup) && IsValidInstallDirectory(InstallDir))
     {
-        Status = InitDestinationPaths(&USetupData, InstallDir, InstallPartition);
+        Status = InitDestinationPaths(&USetupData, InstallDir, InstallVolume);
         if (!NT_SUCCESS(Status))
         {
             DPRINT1("InitDestinationPaths() failed: Status 0x%lx\n", Status);
@@ -3019,7 +3012,7 @@ InstallDirectoryPage(PINPUT_RECORD Ir)
                 return INSTALL_DIRECTORY_PAGE;
             }
 
-            Status = InitDestinationPaths(&USetupData, InstallDir, InstallPartition);
+            Status = InitDestinationPaths(&USetupData, InstallDir, InstallVolume);
             if (!NT_SUCCESS(Status))
             {
                 DPRINT1("InitDestinationPaths() failed: Status 0x%lx\n", Status);
@@ -3426,7 +3419,7 @@ RegistryPage(PINPUT_RECORD Ir)
     Error = UpdateRegistry(&USetupData,
                            RepairUpdateFlag,
                            PartitionList,
-                           InstallPartition->DriveLetter,
+                           InstallVolume->Info.DriveLetter,
                            SelectedLanguageId,
                            RegistryStatus,
                            &s_SubstSettings);
@@ -3667,11 +3660,11 @@ BootLoaderHardDiskPage(PINPUT_RECORD Ir)
         Status = InstallVBRToPartition(&USetupData.SystemRootPath,
                                        &USetupData.SourceRootPath,
                                        &USetupData.DestinationArcPath,
-                                       SystemPartition->FileSystem);
+                                       SystemVolume->Info.FileSystem);
         if (!NT_SUCCESS(Status))
         {
             MUIDisplayError(ERROR_WRITE_BOOT, Ir, POPUP_WAIT_ENTER,
-                            SystemPartition->FileSystem);
+                            SystemVolume->Info.FileSystem);
             return FALSE;
         }
 
@@ -3697,11 +3690,11 @@ BootLoaderHardDiskPage(PINPUT_RECORD Ir)
         Status = InstallVBRToPartition(&USetupData.SystemRootPath,
                                        &USetupData.SourceRootPath,
                                        &USetupData.DestinationArcPath,
-                                       SystemPartition->FileSystem);
+                                       SystemVolume->Info.FileSystem);
         if (!NT_SUCCESS(Status))
         {
             MUIDisplayError(ERROR_WRITE_BOOT, Ir, POPUP_WAIT_ENTER,
-                            SystemPartition->FileSystem);
+                            SystemVolume->Info.FileSystem);
             return FALSE;
         }
     }


### PR DESCRIPTION
### _Required for PR #7159_

## Purpose

This greatly helps in reducing code complexity in some areas: code that
previously iterated over all partitions of a given disk, just to find
which ones were partitioned and contained a valid file system, now just
have to iterate over mounted volumes.
See in particular, lib/utils/osdetect.c and lib/fsutil.c .

JIRA issue: [CORE-13525](https://jira.reactos.org/browse/CORE-13525)

## Proposed changes

- Add some device utility functions; to be used later.
- Remove FORMATSTATE "Preformatted" enum value;
- Cleanup osdetect code after introducing Volume support;
- Some simplifications for FormatState.

- Differentiate between 'new' partition and 'new' volume:

  * "New" partition: it has been created and added in the cached list,
    but not yet actually written into the disk.

  * "New" volume: newly-created volume (may be backed by a partition or
    not), not yet formatted. May exist on either new, or not new partition,
    or elsewhere.

- Cache partition and volume NT device names.

  These do not change across repartitioning operations, as long as the
  partition or the filesystem volume hasn't been deleted/recreated.
  This avoids doing \Device\Harddisk%u\Partition%u sprintf's everytime
  we need to retrieve the given partition or volume device name.

  When a partition/fileysystem volume is "virtually" created (i.e. in
  the partition list, but not yet committed to disk and exposed to the
  OS), no device partition number and device name are available yet.
  In particular, validate that no manipulation of \Device\HarddiskM\Partition0
  (i.e. the whole disk) is being made.
