### PR TITLE
[NTOS:MM] Implement MmAllocate/FreeMappingAddress

### DIFF
--- a/ntoskrnl/mm/ARM3/miarm.h
+++ b/ntoskrnl/mm/ARM3/miarm.h
@@ -155,6 +155,14 @@ C_ASSERT(SYSTEM_PD_SIZE == PAGE_SIZE);
 #endif
 
 //
+// Some internal SYSTEM_PTE_MISUSE bugcheck subcodes
+//
+#define PTE_MAPPING_NONE        0x100
+#define PTE_MAPPING_NOT_OWNED   0x101
+#define PTE_MAPPING_EMPTY       0x102
+#define PTE_MAPPING_RESERVED    0x103
+
+//
 // Mask for image section page protection
 //
 #define IMAGE_SCN_PROTECTION_MASK (IMAGE_SCN_MEM_WRITE | IMAGE_SCN_MEM_READ | IMAGE_SCN_MEM_EXECUTE)

--- a/ntoskrnl/mm/ARM3/pool.c
+++ b/ntoskrnl/mm/ARM3/pool.c
@@ -1552,27 +1552,137 @@ MmReturnPoolQuota(
 
 /* PUBLIC FUNCTIONS ***********************************************************/
 
-/*
- * @unimplemented
+/**
+ * @brief
+ * Reserves the specified amount of memory in system virtual address space.
+ *
+ * @param[in] NumberOfBytes
+ * Size, in bytes, of memory to reserve.
+ *
+ * @param[in] PoolTag
+ * Pool Tag identifying the buffer. Usually consists from 4 characters in reversed order.
+ *
+ * @return
+ * A pointer to the 1st memory block of the reserved buffer in case of success, NULL otherwise.
+ *
+ * @remarks Must be called at IRQL <= APC_LEVEL
  */
+_Must_inspect_result_
+_IRQL_requires_max_(APC_LEVEL)
+_Ret_maybenull_
 PVOID
 NTAPI
-MmAllocateMappingAddress(IN SIZE_T NumberOfBytes,
-                         IN ULONG PoolTag)
+MmAllocateMappingAddress(
+    _In_ SIZE_T NumberOfBytes,
+    _In_ ULONG PoolTag)
 {
-    UNIMPLEMENTED;
-    return NULL;
+    PFN_NUMBER SizeInPages;
+    PMMPTE PointerPte;
+    MMPTE TempPte;
+
+    /* How many PTEs does the caller want? */
+    SizeInPages = BYTES_TO_PAGES(NumberOfBytes);
+    if (SizeInPages == 0)
+    {
+        KeBugCheckEx(SYSTEM_PTE_MISUSE,
+                     PTE_MAPPING_NONE, /* Requested 0 mappings */
+                     SizeInPages,
+                     PoolTag,
+                     (ULONG_PTR)_ReturnAddress());
+    }
+
+    /* We need two extra PTEs to store size and pool tag in */
+    SizeInPages += 2;
+
+    /* Reserve our PTEs */
+    PointerPte = MiReserveSystemPtes(SizeInPages, SystemPteSpace);
+    if (!PointerPte)
+    {
+        /* Failed to reserve PTEs */
+        DPRINT1("Failed to reserve system PTEs\n");
+        return NULL;
+    }
+
+    ASSERT(SizeInPages <= MM_EMPTY_PTE_LIST);
+    TempPte.u.Long = 0;
+    TempPte.u.List.NextEntry = SizeInPages;
+    MI_WRITE_INVALID_PTE(&PointerPte[0], TempPte);
+    TempPte.u.Long = PoolTag;
+    TempPte.u.Hard.Valid = 0;
+    MI_WRITE_INVALID_PTE(&PointerPte[1], TempPte);
+    return MiPteToAddress(PointerPte + 2);
 }
 
-/*
- * @unimplemented
+/**
+ * @brief
+ * Frees previously reserved amount of memory in system virtual address space.
+ *
+ * @param[in] BaseAddress
+ * A pointer to the 1st memory block of the reserved buffer.
+ *
+ * @param[in] PoolTag
+ * Pool Tag identifying the buffer. Usually consists from 4 characters in reversed order.
+ *
+ * @return
+ * Nothing.
+ *
+ * @see MmAllocateMappingAddress
+ *
+ * @remarks Must be called at IRQL <= APC_LEVEL
  */
+_IRQL_requires_max_(APC_LEVEL)
 VOID
 NTAPI
-MmFreeMappingAddress(IN PVOID BaseAddress,
-                     IN ULONG PoolTag)
+MmFreeMappingAddress(
+    _In_ __drv_freesMem(Mem) _Post_invalid_ PVOID BaseAddress,
+    _In_ ULONG PoolTag)
 {
-    UNIMPLEMENTED;
+    PMMPTE PointerPte;
+    MMPTE TempPte;
+    PFN_NUMBER SizeInPages;
+    PFN_NUMBER i;
+
+    /* Get the first PTE we reserved */
+    PointerPte = MiAddressToPte(BaseAddress) - 2;
+
+    /* Verify that the pool tag matches */
+    TempPte.u.Long = PoolTag;
+    TempPte.u.Hard.Valid = 0;
+    if (PointerPte[1].u.Long != TempPte.u.Long)
+    {
+        KeBugCheckEx(SYSTEM_PTE_MISUSE,
+                     PTE_MAPPING_NOT_OWNED, /* Trying to free an address it does not own */
+                     (ULONG_PTR)BaseAddress,
+                     PoolTag,
+                     PointerPte[1].u.Long);
+    }
+
+    /* We must have a size */
+    SizeInPages = PointerPte[0].u.List.NextEntry;
+    if (SizeInPages < 3)
+    {
+        KeBugCheckEx(SYSTEM_PTE_MISUSE,
+                     PTE_MAPPING_EMPTY, /* Mapping apparently empty */
+                     (ULONG_PTR)BaseAddress,
+                     PoolTag,
+                     (ULONG_PTR)_ReturnAddress());
+    }
+    
+    /* Enumerate all PTEs and make sure they are empty */
+    for (i = 2; i < SizeInPages; i++)
+    {
+        if (PointerPte[i].u.Long != 0)
+        {
+            KeBugCheckEx(SYSTEM_PTE_MISUSE,
+                         PTE_MAPPING_RESERVED, /* Mapping address still reserved */
+                         (ULONG_PTR)PointerPte,
+                         PoolTag,
+                         SizeInPages - 2);
+        }
+    }
+
+    /* Release the PTEs */
+    MiReleaseSystemPtes(PointerPte, SizeInPages, SystemPteSpace);
 }
 
 /* EOF */

--- a/sdk/include/xdk/mmfuncs.h
+++ b/sdk/include/xdk/mmfuncs.h
@@ -633,7 +633,7 @@ MmAdvanceMdl(
 
 _Must_inspect_result_
 _IRQL_requires_max_(APC_LEVEL)
-_When_ (return != NULL, _Out_writes_bytes_opt_ (NumberOfBytes))
+_Ret_maybenull_
 NTKERNELAPI
 PVOID
 NTAPI
@@ -646,7 +646,7 @@ NTKERNELAPI
 VOID
 NTAPI
 MmFreeMappingAddress(
-  _In_ PVOID BaseAddress,
+  _In_ __drv_freesMem(Mem) _Post_invalid_ PVOID BaseAddress,
   _In_ ULONG PoolTag);
 
 _IRQL_requires_max_ (APC_LEVEL)


### PR DESCRIPTION
## Purpose

Implement `MmAllocateMappingAddress` and `MmFreeMappingAddress` routines.
Based on mm-implement-mappingaddress.patch by @ThFabba  with some suggestions from @zefklop applied.
Split from #3654.
Required by Microsoft NTFS driver (from Windows Server 2003 SP2 only, the one from Windows XP SP3 does not need them) and by NDIS & TDI drivers (both from Windows XP SP3 and Windows Server 2003 SP2). Also they are called when using Dr. Web Security Space 8 filter drivers together with MS FltMgr & TDI.
Fortunately, this part (these two routines) are enough to get the drivers working in all cases, and others (partially incomplete) routines are not badly required, so they can be finished and committed later.

JIRA issue: [CORE-10147](https://jira.reactos.org/browse/CORE-10147), [CORE-14635](https://jira.reactos.org/browse/CORE-14635), [CORE-17409](https://jira.reactos.org/browse/CORE-17409), [CORE-19318](https://jira.reactos.org/browse/CORE-19318)

## Proposed changes

- Add original implementations from the patch.
- Apply the following suggestions from Jerome:
    - Use a definitions for the `SYSTEM_PTE_MISUSE` bugcheck sub-codes in some sanity checks of these routines. Add them in internal miarm.h header.
    - Add the correct comment for the last sanity check in `MmFreeMappingAddress`, which checks whether any of the PTEs in array is reserved, before calling a corresponding internal function, which does the actual work.
- Update the prototypes of the functions:
    - Add SAL2 annotations.
    - Add return checks from the public declarations in mmfuncs.h.
- Add Doxygen documentation for both functions.