### PR TITLE
[RTL] Fix overflow case in vDbgPrintExWithPrefixInternal

### DIFF
--- a/sdk/lib/rtl/debug.c
+++ b/sdk/lib/rtl/debug.c
@@ -102,10 +102,11 @@ vDbgPrintExWithPrefixInternal(IN PCCH Prefix,
     if (Length == MAXULONG)
     {
         /* Terminate it if we went over-board */
-        Buffer[sizeof(Buffer) - 1] = '\n';
+        Buffer[sizeof(Buffer) - 2] = '\n';
+        Buffer[sizeof(Buffer) - 1] = '\0';
 
         /* Put maximum */
-        Length = sizeof(Buffer);
+        Length = sizeof(Buffer) - 1;
     }
     else
     {


### PR DESCRIPTION
The string should always be NULL terminated.
