### PR TITLE
[SHELL32] CompareIDs canonical column fallback for stable sorting

### DIFF
--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -65,12 +65,14 @@ struct LISTVIEW_SORT_INFO
     bool    bColumnIsFolderColumn;
     UINT8   Reserved; // Unused
     INT     ListColumn;
+    INT     DefaultFolderColumn;
 
     enum { UNSPECIFIEDCOLUMN = -1 };
     void Reset()
     {
         *(UINT*)this = 0;
         ListColumn = UNSPECIFIEDCOLUMN;
+        DefaultFolderColumn = 0;
     }
 };
 
@@ -315,6 +317,8 @@ public:
     void UpdateListColors();
     BOOL InitList();
     static INT CALLBACK ListViewCompareItems(LPARAM lParam1, LPARAM lParam2, LPARAM lpData);
+    HRESULT CompareIDsWithFallback(LPARAM Rules, PCUIDLIST_RELATIVE pidl1, PCUIDLIST_RELATIVE pidl2);
+    HRESULT GetDefaultFolderSortColumn();
 
     HRESULT MapFolderColumnToListColumn(UINT FoldCol);
     HRESULT MapListColumnToFolderColumn(UINT ListCol);
@@ -1239,6 +1243,30 @@ void CDefView::ColumnListChanged()
     m_ListView.InvalidateRect(NULL, TRUE);
 }
 
+HRESULT CDefView::CompareIDsWithFallback(LPARAM Rule, PCUIDLIST_RELATIVE pidl1, PCUIDLIST_RELATIVE pidl2)
+{
+    UINT Flags = m_pSF2Parent ? (Rule & SHCIDS_BITMASK) : 0;
+    HRESULT hr = m_pSFParent->CompareIDs(Rule, pidl1, pidl2);
+    if (hr != 0)
+        return hr;
+    if (hr == 0 && m_sortInfo.DefaultFolderColumn > 0)
+        hr = m_pSFParent->CompareIDs(m_sortInfo.DefaultFolderColumn | Flags, pidl1, pidl2);
+    if (hr == 0 && (Rule & SHCIDS_COLUMNMASK) != 0)
+        hr = m_pSFParent->CompareIDs(0 | Flags, pidl1, pidl2);
+    if (hr == 0 && !(Rule & SHCIDS_ALLFIELDS) && m_pSF2Parent)
+        hr = m_pSFParent->CompareIDs(0 | SHCIDS_ALLFIELDS, pidl1, pidl2);
+    return hr;
+}
+
+HRESULT CDefView::GetDefaultFolderSortColumn()
+{
+    if (!m_pSF2Parent)
+        return E_NOTIMPL;
+    ULONG folderSortCol = ~ULONG(0), dummy;
+    HRESULT hr = m_pSF2Parent->GetDefaultColumn(0, &folderSortCol, &dummy);
+    return (folderSortCol == ~ULONG(0) && SUCCEEDED(hr)) ? E_FAIL : hr;
+}
+
 /*************************************************************************
  * ShellView_ListViewCompareItems
  *
@@ -1259,11 +1287,9 @@ INT CALLBACK CDefView::ListViewCompareItems(LPARAM lParam1, LPARAM lParam2, LPAR
     PCUIDLIST_RELATIVE pidl1 = reinterpret_cast<PCUIDLIST_RELATIVE>(lParam1);
     PCUIDLIST_RELATIVE pidl2 = reinterpret_cast<PCUIDLIST_RELATIVE>(lParam2);
     CDefView *pThis = reinterpret_cast<CDefView*>(lpData);
-
-    HRESULT hres = pThis->m_pSFParent->CompareIDs(pThis->m_sortInfo.ListColumn, pidl1, pidl2);
+    HRESULT hres = pThis->CompareIDsWithFallback(pThis->m_sortInfo.ListColumn, pidl1, pidl2);
     if (FAILED_UNEXPECTEDLY(hres))
         return 0;
-
     SHORT nDiff = HRESULT_CODE(hres);
     return nDiff * pThis->m_sortInfo.Direction;
 }
@@ -1317,6 +1343,7 @@ BOOL CDefView::_Sort(int Col)
 
     /* Sort the list, using the current values of ListColumn and bIsAscending */
     ASSERT(m_sortInfo.Direction == 1 || m_sortInfo.Direction == -1);
+    m_sortInfo.DefaultFolderColumn = GetDefaultFolderSortColumn();
     return m_ListView.SortItems(ListViewCompareItems, this);
 }
 
@@ -1593,15 +1620,11 @@ HRESULT CDefView::FillList(BOOL IsRefreshCommand)
     {
         m_sortInfo.Direction = 0;
         sortCol = 0; // In case the folder does not know/care
-        if (m_pSF2Parent)
-        {
-            ULONG folderSortCol = sortCol, dummy;
-            HRESULT hr = m_pSF2Parent->GetDefaultColumn(NULL, &folderSortCol, &dummy);
-            if (SUCCEEDED(hr))
-                hr = MapFolderColumnToListColumn(folderSortCol);
-            if (SUCCEEDED(hr))
-                sortCol = (int) hr;
-        }
+        HRESULT hr = GetDefaultFolderSortColumn();
+        if (SUCCEEDED(hr))
+            hr = MapFolderColumnToListColumn(hr);
+        if (SUCCEEDED(hr))
+            sortCol = (int) hr;
     }
     _Sort(sortCol);
 

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -1246,14 +1246,12 @@ void CDefView::ColumnListChanged()
 HRESULT CDefView::CompareIDsWithFallback(LPARAM Rule, PCUIDLIST_RELATIVE pidl1, PCUIDLIST_RELATIVE pidl2)
 {
     const UINT Flags = m_pSF2Parent ? (Rule & SHCIDS_BITMASK) : 0;
-    int Col = (Rule & SHCIDS_COLUMNMASK);
+    const int Col = (Rule & SHCIDS_COLUMNMASK), DefCol = m_sortInfo.DefaultFolderColumn;
     HRESULT hr = m_pSFParent->CompareIDs(Rule, pidl1, pidl2);
-    if (hr != 0)
+    if (hr != 0 && SUCCEEDED(hr))
         return hr;
-    if (hr == 0 && m_sortInfo.DefaultFolderColumn > 0)
-        hr = m_pSFParent->CompareIDs(m_sortInfo.DefaultFolderColumn | Flags, pidl1, pidl2);
-    if (hr == 0 && Col != 0 && Col != m_sortInfo.DefaultFolderColumn)
-        hr = m_pSFParent->CompareIDs(0 | Flags, pidl1, pidl2); // Try SHFSF_COL_NAME
+    if (hr == 0 && Col != DefCol)
+        hr = m_pSFParent->CompareIDs((DefCol >= 0 ? DefCol : 0) | Flags, pidl1, pidl2);
     if (hr == 0 && !(Rule & SHCIDS_ALLFIELDS) && m_pSF2Parent)
         hr = m_pSFParent->CompareIDs(0 | SHCIDS_ALLFIELDS, pidl1, pidl2);
     return hr;
@@ -1261,11 +1259,11 @@ HRESULT CDefView::CompareIDsWithFallback(LPARAM Rule, PCUIDLIST_RELATIVE pidl1, 
 
 HRESULT CDefView::GetDefaultFolderSortColumn()
 {
-    if (!m_pSF2Parent)
-        return E_NOTIMPL;
     ULONG folderSortCol = ~0UL, dummy;
-    HRESULT hr = m_pSF2Parent->GetDefaultColumn(0, &folderSortCol, &dummy);
-    return (folderSortCol == ~0UL && SUCCEEDED(hr)) ? E_FAIL : hr;
+    HRESULT hr = m_pSF2Parent ? m_pSF2Parent->GetDefaultColumn(0, &folderSortCol, &dummy) : E_FAIL;
+    if (_DoFolderViewCB(SFVM_GETSORTDEFAULTS, (WPARAM)&dummy, (LPARAM)&folderSortCol) == S_OK)
+        hr = S_OK;
+    return (folderSortCol == ~0UL && SUCCEEDED(hr)) ? E_FAIL : folderSortCol;
 }
 
 /*************************************************************************
@@ -1621,11 +1619,9 @@ HRESULT CDefView::FillList(BOOL IsRefreshCommand)
     if (!IsRefreshCommand && !m_sortInfo.bLoadedFromViewState) // Are we loading for the first time?
     {
         m_sortInfo.Direction = 0;
-        sortCol = 0; // In case the folder does not know/care
+        sortCol = 0; // In case the folder nor view-callback does not know/care
         HRESULT hr = GetDefaultFolderSortColumn();
-        if (SUCCEEDED(hr))
-            hr = MapFolderColumnToListColumn(hr);
-        if (SUCCEEDED(hr))
+        if (SUCCEEDED(hr) && SUCCEEDED(hr = MapFolderColumnToListColumn(hr)))
             sortCol = (int)hr;
     }
     _Sort(sortCol);

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -1245,7 +1245,7 @@ void CDefView::ColumnListChanged()
 
 HRESULT CDefView::CompareIDsWithFallback(LPARAM Rule, PCUIDLIST_RELATIVE pidl1, PCUIDLIST_RELATIVE pidl2)
 {
-    UINT Flags = m_pSF2Parent ? (Rule & SHCIDS_BITMASK) : 0;
+    const UINT Flags = m_pSF2Parent ? (Rule & SHCIDS_BITMASK) : 0;
     HRESULT hr = m_pSFParent->CompareIDs(Rule, pidl1, pidl2);
     if (hr != 0)
         return hr;
@@ -1290,6 +1290,7 @@ INT CALLBACK CDefView::ListViewCompareItems(LPARAM lParam1, LPARAM lParam2, LPAR
     HRESULT hres = pThis->CompareIDsWithFallback(pThis->m_sortInfo.ListColumn, pidl1, pidl2);
     if (FAILED_UNEXPECTEDLY(hres))
         return 0;
+
     SHORT nDiff = HRESULT_CODE(hres);
     return nDiff * pThis->m_sortInfo.Direction;
 }
@@ -1624,7 +1625,7 @@ HRESULT CDefView::FillList(BOOL IsRefreshCommand)
         if (SUCCEEDED(hr))
             hr = MapFolderColumnToListColumn(hr);
         if (SUCCEEDED(hr))
-            sortCol = (int) hr;
+            sortCol = (int)hr;
     }
     _Sort(sortCol);
 

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -1246,13 +1246,14 @@ void CDefView::ColumnListChanged()
 HRESULT CDefView::CompareIDsWithFallback(LPARAM Rule, PCUIDLIST_RELATIVE pidl1, PCUIDLIST_RELATIVE pidl2)
 {
     const UINT Flags = m_pSF2Parent ? (Rule & SHCIDS_BITMASK) : 0;
+    int Col = (Rule & SHCIDS_COLUMNMASK);
     HRESULT hr = m_pSFParent->CompareIDs(Rule, pidl1, pidl2);
     if (hr != 0)
         return hr;
     if (hr == 0 && m_sortInfo.DefaultFolderColumn > 0)
         hr = m_pSFParent->CompareIDs(m_sortInfo.DefaultFolderColumn | Flags, pidl1, pidl2);
-    if (hr == 0 && (Rule & SHCIDS_COLUMNMASK) != 0)
-        hr = m_pSFParent->CompareIDs(0 | Flags, pidl1, pidl2);
+    if (hr == 0 && Col != 0 && Col != m_sortInfo.DefaultFolderColumn)
+        hr = m_pSFParent->CompareIDs(0 | Flags, pidl1, pidl2); // Try SHFSF_COL_NAME
     if (hr == 0 && !(Rule & SHCIDS_ALLFIELDS) && m_pSF2Parent)
         hr = m_pSFParent->CompareIDs(0 | SHCIDS_ALLFIELDS, pidl1, pidl2);
     return hr;
@@ -1262,9 +1263,9 @@ HRESULT CDefView::GetDefaultFolderSortColumn()
 {
     if (!m_pSF2Parent)
         return E_NOTIMPL;
-    ULONG folderSortCol = ~ULONG(0), dummy;
+    ULONG folderSortCol = ~0UL, dummy;
     HRESULT hr = m_pSF2Parent->GetDefaultColumn(0, &folderSortCol, &dummy);
-    return (folderSortCol == ~ULONG(0) && SUCCEEDED(hr)) ? E_FAIL : hr;
+    return (folderSortCol == ~0UL && SUCCEEDED(hr)) ? E_FAIL : hr;
 }
 
 /*************************************************************************

--- a/dll/win32/shell32/folders/CDrivesFolder.cpp
+++ b/dll/win32/shell32/folders/CDrivesFolder.cpp
@@ -840,8 +840,8 @@ HRESULT WINAPI CDrivesFolder::CompareIDs(LPARAM lParam, PCUIDLIST_RELATIVE pidl1
     }
 
     if (HRESULT_CODE(hres) == 0)
-        return SHELL_FolderImplCompareIDsTiebreaker(this, lParam, pidl1, pidl2,
-                                                    _countof(MyComputerSFHeader), IDS_SHV_COLUMN_NAME);
+        return SHELL32_FolderImplCompareIDsTiebreaker(this, lParam, pidl1, pidl2,
+                                                      _countof(MyComputerSFHeader), IDS_SHV_COLUMN_NAME);
 
     return hres;
 }

--- a/dll/win32/shell32/folders/CDrivesFolder.cpp
+++ b/dll/win32/shell32/folders/CDrivesFolder.cpp
@@ -840,7 +840,8 @@ HRESULT WINAPI CDrivesFolder::CompareIDs(LPARAM lParam, PCUIDLIST_RELATIVE pidl1
     }
 
     if (HRESULT_CODE(hres) == 0)
-        return SHELL32_CompareChildren(this, lParam, pidl1, pidl2);
+        return SHELL_FolderImplCompareIDsTiebreaker(this, lParam, pidl1, pidl2,
+                                                    _countof(MyComputerSFHeader), IDS_SHV_COLUMN_NAME);
 
     return hres;
 }

--- a/dll/win32/shell32/folders/CFSFolder.cpp
+++ b/dll/win32/shell32/folders/CFSFolder.cpp
@@ -1179,8 +1179,8 @@ HRESULT WINAPI CFSFolder::CompareIDs(LPARAM lParam,
     }
 
     if (result == 0)
-        return SHELL_FolderImplCompareIDsTiebreaker(this, lParam, pidl1, pidl2,
-                                                    GENERICSHELLVIEWCOLUMNS, SHFSF_COL_NAME);
+        return SHELL32_FolderImplCompareIDsTiebreaker(this, lParam, pidl1, pidl2,
+                                                      GENERICSHELLVIEWCOLUMNS, SHFSF_COL_NAME);
     return MAKE_COMPARE_HRESULT(result);
 }
 

--- a/dll/win32/shell32/folders/CFSFolder.cpp
+++ b/dll/win32/shell32/folders/CFSFolder.cpp
@@ -1166,7 +1166,7 @@ HRESULT WINAPI CFSFolder::CompareIDs(LPARAM lParam,
         case SHFSF_COL_FATTS:
             result = SHELL32_CompareDetails(this, lParam, pidl1, pidl2);
             if (result == 0)
-                result = pData1->u.file.uFileAttribs - pData1->u.file.uFileAttribs; // Attributes without a "UI letter"
+                result = pData1->u.file.uFileAttribs - pData1->u.file.uFileAttribs; // Attributes without a "UI letter" (R/A/S/H)
             break;
         case SHFSF_COL_COMMENT:
             result = SHELL32_CompareDetails(this, lParam, pidl1, pidl2);

--- a/dll/win32/shell32/folders/CRegFolder.cpp
+++ b/dll/win32/shell32/folders/CRegFolder.cpp
@@ -565,7 +565,7 @@ HRESULT WINAPI CRegFolder::CompareIDs(LPARAM lParam, PCUIDLIST_RELATIVE pidl1, P
                 return hrCmpOrder;
         }
         if (memcmp(clsid1, clsid2, sizeof(GUID)) == 0)
-            return SHELL32_CompareChildren(this, lParam, pidl1, pidl2);
+            return SHELL32_CompareChildren(this, lParam & SHCIDS_BITMASK, pidl1, pidl2);
 
         return SHELL32_CompareDetails(this, lParam, pidl1, pidl2);
     }

--- a/dll/win32/shell32/shfldr.h
+++ b/dll/win32/shell32/shfldr.h
@@ -134,8 +134,8 @@ HRESULT SHELL32_CompareDetails(IShellFolder2* isf, LPARAM lParam, LPCITEMIDLIST 
 HRESULT SHELL32_CompareChildren(IShellFolder2* psf, LPARAM lParam, LPCITEMIDLIST pidl1, LPCITEMIDLIST pidl2);
 
 HRESULT SHELL32_FolderImplCompareIDsTiebreaker(IShellFolder2* psf, LPARAM lParam,
-                                             LPCITEMIDLIST pidl1, LPCITEMIDLIST pidl2,
-                                             UINT Count, int Canonical);
+                                               LPCITEMIDLIST pidl1, LPCITEMIDLIST pidl2,
+                                               UINT Count, int Canonical);
 
 #ifdef __cplusplus
 HRESULT SHELL32_CoCreateInitSF (LPCITEMIDLIST pidlRoot, PERSIST_FOLDER_TARGET_INFO* ppfti,

--- a/dll/win32/shell32/shfldr.h
+++ b/dll/win32/shell32/shfldr.h
@@ -133,6 +133,10 @@ HRESULT SHELL32_CompareDetails(IShellFolder2* isf, LPARAM lParam, LPCITEMIDLIST 
 
 HRESULT SHELL32_CompareChildren(IShellFolder2* psf, LPARAM lParam, LPCITEMIDLIST pidl1, LPCITEMIDLIST pidl2);
 
+HRESULT SHELL_FolderImplCompareIDsTiebreaker(IShellFolder2* psf, LPARAM lParam,
+                                             LPCITEMIDLIST pidl1, LPCITEMIDLIST pidl2,
+                                             UINT Count, int Canonical);
+
 #ifdef __cplusplus
 HRESULT SHELL32_CoCreateInitSF (LPCITEMIDLIST pidlRoot, PERSIST_FOLDER_TARGET_INFO* ppfti,
                 LPCITEMIDLIST pidlChild, const GUID* clsid, REFIID riid, LPVOID *ppvOut);

--- a/dll/win32/shell32/shfldr.h
+++ b/dll/win32/shell32/shfldr.h
@@ -133,7 +133,7 @@ HRESULT SHELL32_CompareDetails(IShellFolder2* isf, LPARAM lParam, LPCITEMIDLIST 
 
 HRESULT SHELL32_CompareChildren(IShellFolder2* psf, LPARAM lParam, LPCITEMIDLIST pidl1, LPCITEMIDLIST pidl2);
 
-HRESULT SHELL_FolderImplCompareIDsTiebreaker(IShellFolder2* psf, LPARAM lParam,
+HRESULT SHELL32_FolderImplCompareIDsTiebreaker(IShellFolder2* psf, LPARAM lParam,
                                              LPCITEMIDLIST pidl1, LPCITEMIDLIST pidl2,
                                              UINT Count, int Canonical);
 

--- a/dll/win32/shell32/shlfolder.cpp
+++ b/dll/win32/shell32/shlfolder.cpp
@@ -431,7 +431,8 @@ HRESULT SHELL_FolderImplCompareIDsTiebreaker(IShellFolder2* psf, LPARAM lParam,
         if (hr && SUCCEEDED(hr))
             return hr;
     }
-    return SHELL32_CompareChildren(psf, lParam, pidl1, pidl2);
+    // We are not passing the column index because the columns in a child folder might not have the same meaning
+    return SHELL32_CompareChildren(psf, lParam & SHCIDS_BITMASK, pidl1, pidl2);
 }
 
 void CloseRegKeyArray(HKEY* array, UINT cKeys)

--- a/dll/win32/shell32/shlfolder.cpp
+++ b/dll/win32/shell32/shlfolder.cpp
@@ -414,11 +414,11 @@ HRESULT SHELL_CompareAllFields(IShellFolder* psf,
     return MAKE_COMPARE_HRESULT(0);
 }
 
-HRESULT SHELL_FolderImplCompareIDsTiebreaker(IShellFolder2* psf, LPARAM lParam,
+HRESULT SHELL32_FolderImplCompareIDsTiebreaker(IShellFolder2* psf, LPARAM lParam,
                                              LPCITEMIDLIST pidl1, LPCITEMIDLIST pidl2,
                                              UINT Count, int Canonical)
 {
-    if ((lParam & SHCIDS_COLUMNMASK) != Canonical && Canonical >= 0)
+    if ((lParam & SHCIDS_COLUMNMASK) != Canonical && Canonical >= 0 && LOBYTE(GetVersion()) < 6)
     {
         LPARAM flags = (lParam & SHCIDS_BITMASK) & ~SHCIDS_ALLFIELDS;
         HRESULT hr = psf->CompareIDs(Canonical | flags, pidl1, pidl2);
@@ -427,7 +427,7 @@ HRESULT SHELL_FolderImplCompareIDsTiebreaker(IShellFolder2* psf, LPARAM lParam,
     }
     if (lParam & SHCIDS_ALLFIELDS)
     {
-        HRESULT hr = SHELL_CompareAllFields(psf, pidl1, pidl2, Count, Canonical);
+        HRESULT hr = SHELL_CompareAllFields(psf, pidl1, pidl2, Count, lParam & SHCIDS_COLUMNMASK);
         if (hr && SUCCEEDED(hr))
             return hr;
     }

--- a/dll/win32/shell32/shlfolder.cpp
+++ b/dll/win32/shell32/shlfolder.cpp
@@ -400,8 +400,8 @@ HRESULT SHELL32_CompareDetails(IShellFolder2* isf, LPARAM lParam, LPCITEMIDLIST 
 }
 
 HRESULT SHELL_CompareAllFields(IShellFolder* psf,
-                                 LPCITEMIDLIST pidl1, LPCITEMIDLIST pidl2,
-                                 UINT Count, int Skip)
+                               LPCITEMIDLIST pidl1, LPCITEMIDLIST pidl2,
+                               UINT Count, int Skip)
 {
     for (UINT i = 0; i < Count; ++i)
     {
@@ -414,9 +414,18 @@ HRESULT SHELL_CompareAllFields(IShellFolder* psf,
     return MAKE_COMPARE_HRESULT(0);
 }
 
+/***********************************************************************
+ *    SHELL32_FolderImplCompareIDsTiebreaker
+ *
+ * Used to compare other columns if the intial column passed to
+ * IShellFolder::CompareIDs compared equal.
+ * NT5 compares the name column first in this case.
+ * Next, all columns are compared if the caller requested ALLFIELDS.
+ * Finally, compare the children (if any).
+ */
 HRESULT SHELL32_FolderImplCompareIDsTiebreaker(IShellFolder2* psf, LPARAM lParam,
-                                             LPCITEMIDLIST pidl1, LPCITEMIDLIST pidl2,
-                                             UINT Count, int Canonical)
+                                               LPCITEMIDLIST pidl1, LPCITEMIDLIST pidl2,
+                                               UINT Count, int Canonical)
 {
     if ((lParam & SHCIDS_COLUMNMASK) != Canonical && Canonical >= 0 && LOBYTE(GetVersion()) < 6)
     {

--- a/dll/win32/shell32/shlfolder.cpp
+++ b/dll/win32/shell32/shlfolder.cpp
@@ -374,7 +374,7 @@ HRESULT SHELL32_CompareDetails(IShellFolder2* isf, LPARAM lParam, LPCITEMIDLIST 
     SHELLDETAILS sd;
     WCHAR wszItem1[MAX_PATH], wszItem2[MAX_PATH];
     HRESULT hres;
-    UINT col = LOWORD(lParam & SHCIDS_COLUMNMASK); // Column index without SHCIDS_* flags
+    UINT col = (UINT)(lParam & SHCIDS_COLUMNMASK); // Column index without SHCIDS_* flags
 
     hres = isf->GetDetailsOf(pidl1, col, &sd);
     if (FAILED(hres))
@@ -417,7 +417,7 @@ HRESULT SHELL_CompareAllFields(IShellFolder* psf,
 /***********************************************************************
  *    SHELL32_FolderImplCompareIDsTiebreaker
  *
- * Used to compare other columns if the intial column passed to
+ * Used to compare other columns if the initial column passed to
  * IShellFolder::CompareIDs compared equal.
  * NT5 compares the name column first in this case.
  * Next, all columns are compared if the caller requested ALLFIELDS.


### PR DESCRIPTION
This should fix the issue of columns like "Type" not sorting the same every time.