### PR TITLE
[SHELL32] CDefaultContextMenu::InvokeCommand must forward the .lnk path

### DIFF
--- a/dll/win32/shell32/CDefaultContextMenu.cpp
+++ b/dll/win32/shell32/CDefaultContextMenu.cpp
@@ -1350,6 +1350,9 @@ CDefaultContextMenu::InvokePidl(LPCMINVOKECOMMANDINFOEX lpcmi, LPCITEMIDLIST pid
     else if (!StrIsNullOrEmpty(lpcmi->lpParameters) && __SHCloneStrAtoW(&pszParamsW, lpcmi->lpParameters))
         sei.lpParameters = pszParamsW;
 
+    if (!sei.lpClass && (lpcmi->fMask & (CMIC_MASK_HASLINKNAME | CMIC_MASK_HASTITLE)) && unicode)
+        sei.lpClass = lpcmi->lpTitleW; // Forward .lnk path from CShellLink::DoOpen (for consrv STARTF_TITLEISLINKNAME)
+
     ShellExecuteExW(&sei);
     ILFree(pidlFull);
 


### PR DESCRIPTION
Forward the .lnk path (if any) so consrv gets `STARTF_TITLEISLINKNAME` and can apply console properties and icon from the shortcut.

This has always worked for shortcuts without a proper PIDL and must also work for PIDLs that now pass through `IContextMenu`.