### PR TITLE
[SHELL32] Create link must ask for a parsing name for file targets

### DIFF
--- a/dll/win32/shell32/droptargets/CFSDropTarget.cpp
+++ b/dll/win32/shell32/droptargets/CFSDropTarget.cpp
@@ -588,12 +588,18 @@ HRESULT CFSDropTarget::_DoDrop(IDataObject *pDataObject,
             /* We need to create a link for each pidl in the copied items, so step through the pidls from the clipboard */
             for (UINT i = 0; i < lpcida->cidl; i++)
             {
+                SFGAOF att = SHGetAttributes(psfFrom, apidl[i], SFGAO_FOLDER | SFGAO_STREAM | SFGAO_FILESYSTEM);
                 CComHeapPtr<ITEMIDLIST_ABSOLUTE> pidlFull;
                 hr = SHILCombine(pidl, apidl[i], &pidlFull);
 
                 WCHAR targetName[MAX_PATH];
                 if (SUCCEEDED(hr))
-                    hr = Shell_DisplayNameOf(psfFrom, apidl[i], SHGDN_FOREDITING | SHGDN_INFOLDER, targetName, _countof(targetName));
+                {
+                    // If the target is a FS item, we use SHGDN_FORPARSING because "NeverShowExt" will hide the ".lnk" extension.
+                    // If the target is a virtual item, we ask for the friendly name because SHGDN_FORPARSING will return a GUID.
+                    DWORD shgdnfor = (att & SFGAO_FILESYSTEM) ? SHGDN_FORPARSING : SHGDN_FOREDITING;
+                    hr = Shell_DisplayNameOf(psfFrom, apidl[i], shgdnfor | SHGDN_INFOLDER, targetName, _countof(targetName));
+                }
                 if (FAILED_UNEXPECTEDLY(hr))
                 {
                     SHELL_ErrorBox(m_hwndSite, hr);
@@ -605,7 +611,6 @@ HRESULT CFSDropTarget::_DoDrop(IDataObject *pDataObject,
                 PathCombineW(wszCombined, m_sPathTarget, targetName);
 
                 // Check to see if the source is a link
-                SFGAOF att = SHGetAttributes(psfFrom, apidl[i], SFGAO_FOLDER | SFGAO_STREAM | SFGAO_FILESYSTEM);
                 BOOL fSourceIsLink = FALSE;
                 if (!wcsicmp(PathFindExtensionW(targetName), L".lnk") && (att & (SFGAO_FOLDER | SFGAO_STREAM)) != SFGAO_FOLDER)
                 {

--- a/dll/win32/shell32/droptargets/CFSDropTarget.cpp
+++ b/dll/win32/shell32/droptargets/CFSDropTarget.cpp
@@ -595,10 +595,11 @@ HRESULT CFSDropTarget::_DoDrop(IDataObject *pDataObject,
                 WCHAR targetName[MAX_PATH];
                 if (SUCCEEDED(hr))
                 {
-                    // If the target is a FS item, we use SHGDN_FORPARSING because "NeverShowExt" will hide the ".lnk" extension.
+                    // If the target is a file, we use SHGDN_FORPARSING because "NeverShowExt" will hide the ".lnk" extension.
                     // If the target is a virtual item, we ask for the friendly name because SHGDN_FORPARSING will return a GUID.
-                    DWORD shgdnfor = (att & SFGAO_FILESYSTEM) ? SHGDN_FORPARSING : SHGDN_FOREDITING;
-                    hr = Shell_DisplayNameOf(psfFrom, apidl[i], shgdnfor | SHGDN_INFOLDER, targetName, _countof(targetName));
+                    BOOL UseParsing = (att & (SFGAO_FILESYSTEM | SFGAO_FOLDER)) == SFGAO_FILESYSTEM;
+                    DWORD ShgdnFor = UseParsing ? SHGDN_FORPARSING : SHGDN_FOREDITING;
+                    hr = Shell_DisplayNameOf(psfFrom, apidl[i], ShgdnFor | SHGDN_INFOLDER, targetName, _countof(targetName));
                 }
                 if (FAILED_UNEXPECTEDLY(hr))
                 {

--- a/dll/win32/shell32/folders/CRegFolder.cpp
+++ b/dll/win32/shell32/folders/CRegFolder.cpp
@@ -541,12 +541,6 @@ HRESULT WINAPI CRegFolder::CompareIDs(LPARAM lParam, PCUIDLIST_RELATIVE pidl1, P
 
 HRESULT WINAPI CRegFolder::CreateViewObject(HWND hwndOwner, REFIID riid, LPVOID *ppvOut)
 {
-
-    CComPtr<IShellFolder> pOuterSF;
-    SHBindToObject(NULL, m_pidlRoot, IID_PPV_ARG(IShellFolder, &pOuterSF));
-    if (pOuterSF.p)
-        return pOuterSF->CreateViewObject(hwndOwner, riid, ppvOut);
-
     return E_NOTIMPL;
 }
 

--- a/dll/win32/shell32/folders/CRegFolder.cpp
+++ b/dll/win32/shell32/folders/CRegFolder.cpp
@@ -541,6 +541,12 @@ HRESULT WINAPI CRegFolder::CompareIDs(LPARAM lParam, PCUIDLIST_RELATIVE pidl1, P
 
 HRESULT WINAPI CRegFolder::CreateViewObject(HWND hwndOwner, REFIID riid, LPVOID *ppvOut)
 {
+
+    CComPtr<IShellFolder> pOuterSF;
+    SHBindToObject(NULL, m_pidlRoot, IID_PPV_ARG(IShellFolder, &pOuterSF));
+    if (pOuterSF.p)
+        return pOuterSF->CreateViewObject(hwndOwner, riid, ppvOut);
+
     return E_NOTIMPL;
 }
 


### PR DESCRIPTION
For .lnk to .lnk detection, we need the parsing name. We still want a friendlier name for RegItems.

Fixes a bug discussed in PR #7264