### PR TITLE
[FREELDR] Print arch + buildnumber on crash-screen

### DIFF
--- a/boot/freeldr/freeldr/arch/i386/i386bug.c
+++ b/boot/freeldr/freeldr/arch/i386/i386bug.c
@@ -1,6 +1,7 @@
 
 #include <freeldr.h>
 
+#include <reactos/buildno.h>
 #include <debug.h>
 
 typedef struct _FRAME
@@ -115,9 +116,11 @@ i386PrintExceptionText(ULONG TrapIndex, PKTRAP_FRAME TrapFrame, PKSPECIAL_REGIST
     i386_ScreenPosX = 0;
     i386_ScreenPosY = 0;
 
-    PrintText("An error occured in " VERSION "\n"
+    PrintText("Error in %s %s\n"
               "Report this error on the ReactOS Bug Tracker: https://jira.reactos.org\n\n"
-              "0x%02lx: %s\n\n", TrapIndex, i386ExceptionDescriptionText[TrapIndex]);
+              "0x%02lx: %s\n\n",
+              KERNEL_VERSION_STR, KERNEL_VERSION_BUILD_STR,
+              TrapIndex, i386ExceptionDescriptionText[TrapIndex]);
 
 #ifdef _M_IX86
     PrintText("EAX: %.8lx        ESP: %.8lx        CR0: %.8lx        DR0: %.8lx\n",

--- a/boot/freeldr/freeldr/arch/i386/i386bug.c
+++ b/boot/freeldr/freeldr/arch/i386/i386bug.c
@@ -116,11 +116,9 @@ i386PrintExceptionText(ULONG TrapIndex, PKTRAP_FRAME TrapFrame, PKSPECIAL_REGIST
     i386_ScreenPosX = 0;
     i386_ScreenPosY = 0;
 
-    PrintText("Error in %s %s\n"
+    PrintText("Freeldr " KERNEL_VERSION_STR " " KERNEL_VERSION_BUILD_STR "\n"
               "Report this error on the ReactOS Bug Tracker: https://jira.reactos.org\n\n"
-              "0x%02lx: %s\n\n",
-              KERNEL_VERSION_STR, KERNEL_VERSION_BUILD_STR,
-              TrapIndex, i386ExceptionDescriptionText[TrapIndex]);
+              "0x%02lx: %s\n\n", TrapIndex, i386ExceptionDescriptionText[TrapIndex]);
 
 #ifdef _M_IX86
     PrintText("EAX: %.8lx        ESP: %.8lx        CR0: %.8lx        DR0: %.8lx\n",

--- a/boot/freeldr/freeldr/arch/i386/i386bug.c
+++ b/boot/freeldr/freeldr/arch/i386/i386bug.c
@@ -116,9 +116,11 @@ i386PrintExceptionText(ULONG TrapIndex, PKTRAP_FRAME TrapFrame, PKSPECIAL_REGIST
     i386_ScreenPosX = 0;
     i386_ScreenPosY = 0;
 
-    PrintText("Freeldr " KERNEL_VERSION_STR " " KERNEL_VERSION_BUILD_STR "\n"
+    PrintText("FreeLdr %s %s\n"
               "Report this error on the ReactOS Bug Tracker: https://jira.reactos.org\n\n"
-              "0x%02lx: %s\n\n", TrapIndex, i386ExceptionDescriptionText[TrapIndex]);
+              "0x%02lx: %s\n\n",
+              KERNEL_VERSION_STR, KERNEL_VERSION_BUILD_STR,
+              TrapIndex, i386ExceptionDescriptionText[TrapIndex]);
 
 #ifdef _M_IX86
     PrintText("EAX: %.8lx        ESP: %.8lx        CR0: %.8lx        DR0: %.8lx\n",


### PR DESCRIPTION
## Purpose

Maybe we should have done this 10 years ago already.

JIRA issue: all the 100 tickets linked against CORE-6762 (I intentionally did not want this to create a link to that)

See https://jira.reactos.org/browse/CORE-19716?focusedId=143079&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-143079

After pic (shows arch, builddate, short-rev):
![image](https://github.com/user-attachments/assets/5056f7a4-8adc-445c-9fe5-beff0cc38059)


After pic2 (after Hermes suggestion. Brings "Freeldr" term back, and without the need for %s %s):
![image](https://github.com/user-attachments/assets/6fe4f706-16f0-4737-aa81-951ea2f04d63)
