### PR TITLE
[MSPAINT] it-IT.rc: Fix compiler warning

### DIFF
--- a/base/applications/mspaint/lang/it-IT.rc
+++ b/base/applications/mspaint/lang/it-IT.rc
@@ -264,7 +264,7 @@ BEGIN
     IDS_PERCENTAGE "La percentuale deve essere compresa tra 1 e 500."
     IDS_ANGLE "L'angolo deve essere compreso tra -89 e 89."
     IDS_LOADERRORTEXT "l file %s non può essere caricato."
-    IDS_ENLARGEPROMPTTEXT "L'immagine negli appunti è più grande della tela.\La si vuole allargare?"
+    IDS_ENLARGEPROMPTTEXT "L'immagine negli appunti è più grande della tela.\nLa si vuole allargare?"
     IDS_BOLD "Grossivo"
     IDS_ITALIC "Italico"
     IDS_UNDERLINE "Sottolineato"


### PR DESCRIPTION
GCC8.4.0dbg warns about:
C:/ros/reactos/base/applications/mspaint/lang/it-IT.rc:267: unrecognized escape sequence

Fix that.

the regression was introduced by
0.4.15-dev-8555-g fbcbbd8768b8a3dda9013dfe3553867176c521b1 from (#7248)

## Purpose

Before-pic:
![image](https://github.com/user-attachments/assets/b47a2332-2abc-4d0b-a7b0-5de7adc06753)


After-pic:
![image](https://github.com/user-attachments/assets/ace31bcb-3fd3-46da-8e46-6d580329dc6b)
