### PR TITLE
[NTOS:FSRTL] FsRtlAcquireFileExclusiveCommon: don't return before acquiring a file resource, except special cases

### DIFF
--- a/ntoskrnl/fsrtl/fastio.c
+++ b/ntoskrnl/fsrtl/fastio.c
@@ -1605,7 +1605,11 @@ FsRtlAcquireFileExclusiveCommon(IN PFILE_OBJECT FileObject,
             FilterCallbacks->PostAcquireForSectionSynchronization(&CbData, Status, CompletionContext);
         }
 
-        return Status;
+        /* Return here only in specific status cases */
+        if (Status == STATUS_FILE_LOCKED_WITH_ONLY_READERS ||
+            Status == STATUS_FSFILTER_OP_COMPLETED_SUCCESSFULLY ||
+            Status == STATUS_FILE_LOCKED_WITH_WRITERS)
+            return Status;
     }
 
     FastDispatch = DeviceObject->DriverObject->FastIoDispatch;

--- a/ntoskrnl/fsrtl/fastio.c
+++ b/ntoskrnl/fsrtl/fastio.c
@@ -1606,8 +1606,8 @@ FsRtlAcquireFileExclusiveCommon(IN PFILE_OBJECT FileObject,
         }
 
         /* Return here when the status is based on the synchonization type and write access to the file */
-        if (Status == STATUS_FILE_LOCKED_WITH_ONLY_READERS ||
-            Status == STATUS_FSFILTER_OP_COMPLETED_SUCCESSFULLY ||
+        if (Status == STATUS_FSFILTER_OP_COMPLETED_SUCCESSFULLY ||
+            Status == STATUS_FILE_LOCKED_WITH_ONLY_READERS ||
             Status == STATUS_FILE_LOCKED_WITH_WRITERS)
         {
             return Status;

--- a/ntoskrnl/fsrtl/fastio.c
+++ b/ntoskrnl/fsrtl/fastio.c
@@ -1605,7 +1605,7 @@ FsRtlAcquireFileExclusiveCommon(IN PFILE_OBJECT FileObject,
             FilterCallbacks->PostAcquireForSectionSynchronization(&CbData, Status, CompletionContext);
         }
 
-        /* Return here only in specific status cases */
+        /* Return here when the status is based on the synchonization type and write access to the file */
         if (Status == STATUS_FILE_LOCKED_WITH_ONLY_READERS ||
             Status == STATUS_FSFILTER_OP_COMPLETED_SUCCESSFULLY ||
             Status == STATUS_FILE_LOCKED_WITH_WRITERS)

--- a/ntoskrnl/fsrtl/fastio.c
+++ b/ntoskrnl/fsrtl/fastio.c
@@ -1609,7 +1609,9 @@ FsRtlAcquireFileExclusiveCommon(IN PFILE_OBJECT FileObject,
         if (Status == STATUS_FILE_LOCKED_WITH_ONLY_READERS ||
             Status == STATUS_FSFILTER_OP_COMPLETED_SUCCESSFULLY ||
             Status == STATUS_FILE_LOCKED_WITH_WRITERS)
+        {
             return Status;
+        }
     }
 
     FastDispatch = DeviceObject->DriverObject->FastIoDispatch;


### PR DESCRIPTION
## Purpose

Don't return before file object's resource is acquired in `FsRtlAcquireFileExclusiveCommon`, except some special return cases, when return is required.
Based on hpoussin_filter_extra.patch by Hervé Poussineau (@hpoussin) with improved comment, which matches the actual behaviour now.
This is required by fltmgr.sys driver from Windows XP/Server 2003 to work correctly, so this change fixes asserts/exceptions when releasing the file via `FsRtlReleaseFile` after acquiring, when using 3rd party filter drivers from several antivirus programs (e. g., Avast Free Antivirus all versions, AVG Antivirus Free 18.8, Avira AntiVir Personal 8.2, Dr. Web Security Space 8.0, Kaspersky Antivirus 2012, etc.).

JIRA issue: [CORE-14157](https://jira.reactos.org/browse/CORE-14157), [CORE-14635](https://jira.reactos.org/browse/CORE-14635), [CORE-19318](https://jira.reactos.org/browse/CORE-19318)

## Proposed changes

Return the status before acquiring the resource only in cases the status is the one of the following:

- `STATUS_FILE_LOCKED_WITH_ONLY_READERS`.
- `STATUS_FSFILTER_OP_COMPLETED_SUCCESSFULLY`.
- `STATUS_FILE_LOCKED_WITH_WRITERS`.

(Expected to be returned by the corresponding FltMgr routines.)
Don't do it (simply continue an execution) for all other return cases.

## Result

This fix is required by (and hence allows to work better) the following apps (**Note this is not everything required by them, to get the state working as on screenshots! More fixes are coming soon.** :smirk: ):

Avast Free Antivirus 7.0 (2012) (same as other (newer) versions as well):
![avast!](https://github.com/user-attachments/assets/695edc9c-4d6b-403e-8681-3be83113059e)

Avira AntiVir Personal 8.2 (2008):
![avira-everything-works](https://github.com/user-attachments/assets/875bfcb4-3b16-4828-89d8-602a16d6929d)

Kaspersky Antivirus 2012:
![kaspersky-antivirus-2012](https://github.com/user-attachments/assets/66474f5a-2de8-4b32-9dd0-6cbe1838eab1)

Also it fixes an assert caused by Dr. Web Security Space 8.0 installer, so now it goes further at least. :slightly_smiling_face: 