### PR TITLE
[NTGDI:FREETYPE] Account for spaces in x-dimension of IntExtTextOutW function

### DIFF
--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -6795,9 +6795,9 @@ IntExtTextOutW(
     FONT_CACHE_ENTRY Cache;
     FT_Matrix mat;
     BOOL bNoTransform;
-    DWORD ch0, ch1;
+    DWORD ch0, ch1, etx = 3; // etx is End of Text
     FONTLINK_CHAIN Chain;
-    SIZE sz;
+    SIZE spaceWidth;
 
     /* Check if String is valid */
     if (Count > 0xFFFF || (Count > 0 && String == NULL))
@@ -7063,19 +7063,19 @@ IntExtTextOutW(
         bitSize.cx = realglyph->bitmap.width;
         bitSize.cy = realglyph->bitmap.rows;
 
-        /* Do characters other than space return a bitSize.cx of zero? */
-        if (ch0 != 32 && bitSize.cx == 0)
+        /* Do chars other than space and etx have a bitSize.cx of zero? */
+        if (ch0 != L' ' && ch0 != etx && bitSize.cx == 0)
             DPRINT1("WARNING: WChar 0x%04x has a bitSize.cx of zero\n", ch0);
 
         /* Don't ignore spaces when computing offset.
-         * This completes the fix of CORE-11787.*/
-        if ((pdcattr->flTextAlign & TA_UPDATECP) && ch0 == 32 && bitSize.cx == 0)
+         * This completes the fix of CORE-11787. */
+        if ((pdcattr->flTextAlign & TA_UPDATECP) && ch0 == L' ' && bitSize.cx == 0)
         { 
             IntUnLockFreeType();
             /* Get the width of the space character */
-            TextIntGetTextExtentPoint(dc, TextObj, L" ", 1, 0, NULL, 0, &sz, 0);
+            TextIntGetTextExtentPoint(dc, TextObj, L" ", 1, 0, NULL, 0, &spaceWidth, 0);
             IntLockFreeType();
-            bitSize.cx = sz.cx;
+            bitSize.cx = spaceWidth.cx;
             realglyph->left = 0;
         }
 
@@ -7184,7 +7184,7 @@ IntExtTextOutW(
         previous = glyph_index;
     }
     /* Don't update position if String == NULL. Fixes CORE-19721. */
-    if (pdcattr->flTextAlign & TA_UPDATECP && String)
+    if ((pdcattr->flTextAlign & TA_UPDATECP) && String)
         pdcattr->ptlCurrent.x = DestRect.right - dc->ptlDCOrig.x;
 
     if (plf->lfUnderline || plf->lfStrikeOut) /* Underline or strike-out? */

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -6795,7 +6795,7 @@ IntExtTextOutW(
     FONT_CACHE_ENTRY Cache;
     FT_Matrix mat;
     BOOL bNoTransform;
-    DWORD ch0, ch1, etx = 3; // etx is End of Text
+    DWORD ch0, ch1, etx = 3; // etx is ASCII End of Text
     FONTLINK_CHAIN Chain;
     SIZE spaceWidth;
 


### PR DESCRIPTION
@I_Kill_Bugs fix.

## Purpose

_For function IntExtTextOutW with space character, the x-dimension should be taken into account._
_Fixes HexEdit 1.2.1 right side of display window not being cleared._

JIRA issue: [CORE-11787](https://jira.reactos.org/browse/CORE-11787)
JIRA issue: [CORE-17721](https://jira.reactos.org/browse/CORE-17721)
JIRA issue: [CORE-19721](https://jira.reactos.org/browse/CORE-19721)

## Proposed changes

_Get x-dimension of space and add it into length in IntExtTextOutW._
_Account for x-dimension if TA_UPDATECP flag set and 'String' is not NULL._

Testbot Results:

refs/pull/7274/merge on top of 0.4.15-dev-8570-g938adaa

VBox: https://reactos.org/testman/compare.php?ids=97385,97388,97392 LGTM
KVM:  https://reactos.org/testman/compare.php?ids=97384,97387,97393 LGTM