### PR TITLE
[NTOS:CC] CcRosCreateVacb: Return error code on pool allocation failure

### DIFF
--- a/ntoskrnl/cc/view.c
+++ b/ntoskrnl/cc/view.c
@@ -812,6 +812,10 @@ CcRosCreateVacb (
     DPRINT("CcRosCreateVacb()\n");
 
     current = ExAllocateFromNPagedLookasideList(&VacbLookasideList);
+    if (!current)
+    {
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
     current->BaseAddress = NULL;
     current->Dirty = FALSE;
     current->PageOut = FALSE;


### PR DESCRIPTION
## Proposed changes
`ExAllocateFromNPagedLookasideList` returns NULL on failure so return `STATUS_INSUFFICIENT_RESOURCES` error code instead of accessing the invalid pointer.