### PR TITLE
[NTUSER] IntSetTimer(): Update HintIndex on each call (update)

### DIFF
--- a/win32ss/user/ntuser/timer.c
+++ b/win32ss/user/ntuser/timer.c
@@ -236,7 +236,7 @@ IntSetTimer( PWND Window,
       }
 
       ASSERT(ulBitmapIndex < NUM_WINDOW_LESS_TIMERS);
-      IDEvent = NUM_WINDOW_LESS_TIMERS - ulBitmapIndex;
+      IDEvent = NUM_WINDOW_MAX_TIMERS - ulBitmapIndex;
       Ret = IDEvent;
 
       IntUnlockWindowlessTimerBitmap();

--- a/win32ss/user/ntuser/timer.c
+++ b/win32ss/user/ntuser/timer.c
@@ -80,11 +80,11 @@ RemoveTimer(PTIMER pTmr)
      RemoveEntryList(&pTmr->ptmrList);
      if ((pTmr->pWnd == NULL) && (!(pTmr->flags & TMRF_SYSTEM))) // System timers are reusable.
      {
-        UINT_PTR IDEvent;
+        ULONG ulBitmapIndex;
 
-        IDEvent = NUM_WINDOW_MAX_TIMERS - pTmr->nID;
+        ulBitmapIndex = NUM_WINDOW_MAX_TIMERS - pTmr->nID;
         IntLockWindowlessTimerBitmap();
-        RtlClearBit(&WindowLessTimersBitMap, IDEvent);
+        RtlClearBit(&WindowLessTimersBitMap, ulBitmapIndex);
         IntUnlockWindowlessTimerBitmap();
      }
      UserDereferenceObject(pTmr);

--- a/win32ss/user/ntuser/timer.c
+++ b/win32ss/user/ntuser/timer.c
@@ -19,7 +19,7 @@ static LONG TimeLast = 0;
 /* Windows 2000 has room for 32768 window-less timers */
 /* These values give timer IDs [256,32767], same as on Windows */
 #define NUM_WINDOW_MAX_TIMERS   (32768 - 1)
-#define NUM_WINDOW_LESS_TIMERS  (32768 - 256)
+#define MAX_WINDOW_LESS_TIMER_ID  (32768 - 256)
 
 #define HINTINDEX_BEGIN_VALUE   0
 
@@ -226,7 +226,7 @@ IntSetTimer( PWND Window,
       IntLockWindowlessTimerBitmap();
 
       ulBitmapIndex = RtlFindClearBitsAndSet(&WindowLessTimersBitMap, 1, HintIndex);
-      HintIndex = (ulBitmapIndex + 1) % NUM_WINDOW_LESS_TIMERS;
+      HintIndex = (ulBitmapIndex + 1) % MAX_WINDOW_LESS_TIMER_ID;
       if (ulBitmapIndex == ULONG_MAX)
       {
          IntUnlockWindowlessTimerBitmap();
@@ -235,7 +235,7 @@ IntSetTimer( PWND Window,
          return 0;
       }
 
-      ASSERT(ulBitmapIndex < NUM_WINDOW_LESS_TIMERS);
+      ASSERT(ulBitmapIndex < MAX_WINDOW_LESS_TIMER_ID);
       IDEvent = NUM_WINDOW_MAX_TIMERS - ulBitmapIndex;
       Ret = IDEvent;
 
@@ -610,7 +610,7 @@ InitTimerImpl(VOID)
 
    ExInitializeFastMutex(Mutex);
 
-   BitmapBytes = ALIGN_UP_BY(NUM_WINDOW_LESS_TIMERS, sizeof(ULONG) * 8) / 8;
+   BitmapBytes = ALIGN_UP_BY(MAX_WINDOW_LESS_TIMER_ID, sizeof(ULONG) * 8) / 8;
    WindowLessTimersBitMapBuffer = ExAllocatePoolWithTag(NonPagedPool, BitmapBytes, TAG_TIMERBMP);
    if (WindowLessTimersBitMapBuffer == NULL)
    {
@@ -619,7 +619,7 @@ InitTimerImpl(VOID)
 
    RtlInitializeBitMap(&WindowLessTimersBitMap,
                        WindowLessTimersBitMapBuffer,
-                       NUM_WINDOW_LESS_TIMERS);
+                       MAX_WINDOW_LESS_TIMER_ID);
 
    /* Yes we need this, since ExAllocatePoolWithTag isn't supposed to zero out allocated memory */
    RtlClearAllBits(&WindowLessTimersBitMap);

--- a/win32ss/user/ntuser/timer.c
+++ b/win32ss/user/ntuser/timer.c
@@ -19,7 +19,7 @@ static LONG TimeLast = 0;
 /* Windows 2000 has room for 32768 window-less timers */
 /* These values give timer IDs [256,32767], same as on Windows */
 #define NUM_WINDOW_MAX_TIMERS   (32768 - 1)
-#define MAX_WINDOW_LESS_TIMER_ID  (32768 - 256)
+#define NUM_WINDOW_LESS_TIMERS  (32768 - 256)
 
 #define HINTINDEX_BEGIN_VALUE   0
 
@@ -226,7 +226,7 @@ IntSetTimer( PWND Window,
       IntLockWindowlessTimerBitmap();
 
       ulBitmapIndex = RtlFindClearBitsAndSet(&WindowLessTimersBitMap, 1, HintIndex);
-      HintIndex = (ulBitmapIndex + 1) % MAX_WINDOW_LESS_TIMER_ID;
+      HintIndex = (ulBitmapIndex + 1) % NUM_WINDOW_LESS_TIMERS;
       if (ulBitmapIndex == ULONG_MAX)
       {
          IntUnlockWindowlessTimerBitmap();
@@ -235,7 +235,7 @@ IntSetTimer( PWND Window,
          return 0;
       }
 
-      ASSERT(ulBitmapIndex < MAX_WINDOW_LESS_TIMER_ID);
+      ASSERT(ulBitmapIndex < NUM_WINDOW_LESS_TIMERS);
       IDEvent = NUM_WINDOW_MAX_TIMERS - ulBitmapIndex;
       Ret = IDEvent;
 
@@ -610,7 +610,7 @@ InitTimerImpl(VOID)
 
    ExInitializeFastMutex(Mutex);
 
-   BitmapBytes = ALIGN_UP_BY(MAX_WINDOW_LESS_TIMER_ID, sizeof(ULONG) * 8) / 8;
+   BitmapBytes = ALIGN_UP_BY(NUM_WINDOW_LESS_TIMERS, sizeof(ULONG) * 8) / 8;
    WindowLessTimersBitMapBuffer = ExAllocatePoolWithTag(NonPagedPool, BitmapBytes, TAG_TIMERBMP);
    if (WindowLessTimersBitMapBuffer == NULL)
    {
@@ -619,7 +619,7 @@ InitTimerImpl(VOID)
 
    RtlInitializeBitMap(&WindowLessTimersBitMap,
                        WindowLessTimersBitMapBuffer,
-                       MAX_WINDOW_LESS_TIMER_ID);
+                       NUM_WINDOW_LESS_TIMERS);
 
    /* Yes we need this, since ExAllocatePoolWithTag isn't supposed to zero out allocated memory */
    RtlClearAllBits(&WindowLessTimersBitMap);

--- a/win32ss/user/ntuser/timer.c
+++ b/win32ss/user/ntuser/timer.c
@@ -18,7 +18,7 @@ static LONG TimeLast = 0;
 
 /* Windows 2000 has room for 32768 window-less timers */
 /* These values give timer IDs [256,32767], same as on Windows */
-#define NUM_WINDOW_MAX_TIMERS   (32768 - 1)
+#define MAX_WINDOW_LESS_TIMER_ID   (32768 - 1)
 #define NUM_WINDOW_LESS_TIMERS  (32768 - 256)
 
 #define HINTINDEX_BEGIN_VALUE   0
@@ -82,8 +82,8 @@ RemoveTimer(PTIMER pTmr)
      {
         ULONG ulBitmapIndex;
 
-        ASSERT(pTmr->nID <= NUM_WINDOW_MAX_TIMERS);
-        ulBitmapIndex = (ULONG)(NUM_WINDOW_MAX_TIMERS - pTmr->nID);
+        ASSERT(pTmr->nID <= MAX_WINDOW_LESS_TIMER_ID);
+        ulBitmapIndex = (ULONG)(MAX_WINDOW_LESS_TIMER_ID - pTmr->nID);
         IntLockWindowlessTimerBitmap();
         RtlClearBit(&WindowLessTimersBitMap, ulBitmapIndex);
         IntUnlockWindowlessTimerBitmap();
@@ -236,7 +236,7 @@ IntSetTimer( PWND Window,
       }
 
       ASSERT(ulBitmapIndex < NUM_WINDOW_LESS_TIMERS);
-      IDEvent = NUM_WINDOW_MAX_TIMERS - ulBitmapIndex;
+      IDEvent = MAX_WINDOW_LESS_TIMER_ID - ulBitmapIndex;
       Ret = IDEvent;
 
       IntUnlockWindowlessTimerBitmap();

--- a/win32ss/user/ntuser/timer.c
+++ b/win32ss/user/ntuser/timer.c
@@ -18,8 +18,8 @@ static LONG TimeLast = 0;
 
 /* Windows 2000 has room for 32768 window-less timers */
 /* These values give timer IDs [256,32767], same as on Windows */
-#define MAX_WINDOW_LESS_TIMER_ID   (32768 - 1)
-#define NUM_WINDOW_LESS_TIMERS  (32768 - 256)
+#define MAX_WINDOW_LESS_TIMER_ID  (32768 - 1)
+#define NUM_WINDOW_LESS_TIMERS    (32768 - 256)
 
 #define HINTINDEX_BEGIN_VALUE   0
 

--- a/win32ss/user/ntuser/timer.c
+++ b/win32ss/user/ntuser/timer.c
@@ -82,7 +82,8 @@ RemoveTimer(PTIMER pTmr)
      {
         ULONG ulBitmapIndex;
 
-        ulBitmapIndex = NUM_WINDOW_MAX_TIMERS - pTmr->nID;
+        ASSERT(pTmr->nID <= NUM_WINDOW_MAX_TIMERS);
+        ulBitmapIndex = (ULONG)(NUM_WINDOW_MAX_TIMERS - pTmr->nID);
         IntLockWindowlessTimerBitmap();
         RtlClearBit(&WindowLessTimersBitMap, ulBitmapIndex);
         IntUnlockWindowlessTimerBitmap();


### PR DESCRIPTION
## Purpose

Based on the [Doug-Lyons](https://github.com/Doug-Lyons) test, I found that my previous fix stopped working partially. Or rather, it would only work until the 32767 indexes were exhausted. It seems to me that the behavior of the bitfield has changed, because when I published the previous patch, it passed my tests.

Previous patch versions: #7087

## Proposed changes

- Bit array generates free ID cyclically, in the previous code after 32767 indexes expired the same index was returned, because of this the previous fix would stop working after expiration, so I changed the logic of calculating the next index.
- I changed the index range to 256-32767 to match Windows, indexes 0-255 can theoretically be used as fixed for system purposes.
