### PR TITLE
[FREELDR] Fix boot timeout regression on AMD64

### DIFF
--- a/boot/freeldr/freeldr/settings.c
+++ b/boot/freeldr/freeldr/settings.c
@@ -15,7 +15,7 @@
 
 static CCHAR DebugString[256];
 static CCHAR DefaultOs[256];
-BOOTMGRINFO BootMgrInfo = {0};
+BOOTMGRINFO BootMgrInfo = {NULL, NULL, -1, 0};
 
 /* FUNCTIONS ******************************************************************/
 
@@ -25,12 +25,6 @@ CmdLineParse(
 {
     PCHAR End, Setting;
     ULONG_PTR Length, Offset = 0;
-
-    /* Set defaults */
-    BootMgrInfo.DebugString = NULL;
-    BootMgrInfo.DefaultOs = NULL;
-    BootMgrInfo.TimeOut = -1;
-    // BootMgrInfo.FrLdrSection = 0;
 
     /*
      * Get the debug string, in the following format:


### PR DESCRIPTION
Initialize the BootMgrInfo struct globally, so the TimeOut value is guaranteed to be negative when no Multiboot cmdline is provided. Fixes the boot timeout regression introduced in commit 7bee32d2372feb55949714eec5c92ca7ef2754bf which occured only on AMD64 builds.