### PR TITLE
[VIRTIO] Misc fixes

### DIFF
--- a/sdk/lib/drivers/virtio/CMakeLists.txt
+++ b/sdk/lib/drivers/virtio/CMakeLists.txt
@@ -7,7 +7,7 @@ list(APPEND SOURCE
     VirtIORing-Packed.c)
 
 add_library(virtio ${SOURCE})
-add_dependencies(virtio xdk)
+add_dependencies(virtio bugcodes xdk)
 
 if(NOT MSVC)
     target_compile_options(virtio PRIVATE

--- a/sdk/lib/drivers/virtio/linux/virtio_config.h
+++ b/sdk/lib/drivers/virtio/linux/virtio_config.h
@@ -62,7 +62,7 @@
 /* v1.0 compliant. */
 #define VIRTIO_F_VERSION_1              32
 
-#define VIRTIO_F_IOMMU_PLATFORM         33
+#define VIRTIO_F_ACCESS_PLATFORM          33
 
 /* This feature indicates support for the packed virtqueue layout. */
 #define VIRTIO_F_RING_PACKED            34


### PR DESCRIPTION
- Add bugcodes dependency, fixes a rare build failure
- Fix for the sync part of commit 823fdb19d75b29352b1621e16f5c955153d90ed3, somehow it didn't pick up the change from the upstream commit https://github.com/virtio-win/kvm-guest-drivers-windows/commit/b22efbb8b80f76a81627396ed54bfbf4b02f80dc