### PR TITLE
[NTUSER] Fix memory leak in co_WinPosSetWindowPos().

### DIFF
--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -2071,11 +2071,6 @@ co_WinPosSetWindowPos(
             RgnType = IntGdiCombineRgn(CopyRgn, VisAfter, VisBeforeJustClient, RGN_AND);
          }
 
-         if (VisBeforeJustClient != NULL)
-         {
-             REGION_Delete(VisBeforeJustClient);
-         }
-
          /* Now use in copying bits which are in the update region. */
          if (Window->hrgnUpdate != NULL)
          {
@@ -2223,11 +2218,6 @@ co_WinPosSetWindowPos(
          }
       }
 
-      if (CopyRgn != NULL)
-      {
-         REGION_Delete(CopyRgn);
-      }
-
       /* Expose what was covered before but not covered anymore */
       if (VisBefore != NULL)
       {
@@ -2248,12 +2238,6 @@ co_WinPosSetWindowPos(
              }
              REGION_Delete(ExposedRgn);
          }
-         REGION_Delete(VisBefore);
-      }
-
-      if (VisAfter != NULL)
-      {
-         REGION_Delete(VisAfter);
       }
    }
 
@@ -2299,6 +2283,27 @@ co_WinPosSetWindowPos(
    {
       TRACE("No drawing, set no Z order and no redraw!\n");
       WinPos.flags |= SWP_NOZORDER|SWP_NOREDRAW;
+   }
+
+   if (VisBefore != NULL)
+   {
+      REGION_Delete(VisBefore);
+      VisBefore = NULL;
+   }
+   if (VisBeforeJustClient != NULL)
+   {
+      REGION_Delete(VisBeforeJustClient);
+      VisBeforeJustClient = NULL;
+   }
+   if (VisAfter != NULL)
+   {
+      REGION_Delete(VisAfter);
+      VisAfter = NULL;
+   }
+   if (CopyRgn != NULL)
+   {
+      REGION_Delete(CopyRgn);
+      CopyRgn = NULL;
    }
 
    if(!(flags & SWP_DEFERERASE))


### PR DESCRIPTION
## Purpose

Fix a memory leak in `co_WinPosSetWindowPos()` with `VisBefore` and `VisBeforeJustClient`, tidy up the code a bit.

JIRA issue: [CORE-19723](https://jira.reactos.org/browse/CORE-19723)

## Proposed changes

There are certain situations where `REGION_Delete()` may not be called for `VisBefore` and `VisBeforeJustClient`.  Particularly, when `SWP_AGG_NOPOSCHANGE` is the only "AGG status flag" specified, or when `SWP_NOCOPYBITS` is specified to `SetWindowPos()`, both `VisBefore` and `VisBeforeJustClient` could potentially leak.

Additionally, if `VisAfter` fails to initialize, or if `(WvrFlags & WVR_REDRAW)` evaluates to true, `VisBeforeJustClient` leaks.

This patch does a minor clean-up where it moves the deletion of 4 top-level-scope `PREGION` variables into the top level scope, instead of nested inside of various if statements.  This makes it easier to understand when those variables are valid, and avoids the above-mentioned memory leak issues.