### PR TITLE
[USER32][IMM32][NTUSER] Fix USER handle index calculation

### DIFF
--- a/dll/win32/imm32/utils.c
+++ b/dll/win32/imm32/utils.c
@@ -355,7 +355,7 @@ LPVOID FASTCALL ValidateHandleNoErr(HANDLE hObject, UINT uType)
     ASSERT(gSharedInfo.ulSharedDelta != 0);
     he = (PUSER_HANDLE_ENTRY)((ULONG_PTR)ht->handles - gSharedInfo.ulSharedDelta);
 
-    index = (LOWORD(hObject) - FIRST_USER_HANDLE) >> 1;
+    index = LOWORD(hObject);
     if ((INT)index < 0 || ht->nb_handles <= index || he[index].type != uType)
         return NULL;
 

--- a/win32ss/include/ntuser.h
+++ b/win32ss/include/ntuser.h
@@ -7,7 +7,7 @@ struct _DESKTOP;
 struct _WND;
 struct tagPOPUPMENU;
 
-#define FIRST_USER_HANDLE 0x0020 /* first possible value for low word of user handle */
+//#define FIRST_USER_HANDLE 0x0020 /* first possible value for low word of user handle */
 #define LAST_USER_HANDLE 0xffef /* last possible value for low word of user handle */
 
 #define HANDLEENTRY_DESTROY 1

--- a/win32ss/user/ntuser/object.c
+++ b/win32ss/user/ntuser/object.c
@@ -341,7 +341,7 @@ void DbgUserDumpHandleTable(VOID)
 PUSER_HANDLE_ENTRY handle_to_entry(PUSER_HANDLE_TABLE ht, HANDLE handle )
 {
    unsigned short generation;
-   int index = (LOWORD(handle) - FIRST_USER_HANDLE) >> 1;
+   int index = LOWORD(handle);
    if (index < 0 || index >= ht->nb_handles)
       return NULL;
    if (!ht->handles[index].type)
@@ -355,7 +355,7 @@ PUSER_HANDLE_ENTRY handle_to_entry(PUSER_HANDLE_TABLE ht, HANDLE handle )
 __inline static HANDLE entry_to_handle(PUSER_HANDLE_TABLE ht, PUSER_HANDLE_ENTRY ptr )
 {
    int index = ptr - ht->handles;
-   return (HANDLE)((((INT_PTR)index << 1) + FIRST_USER_HANDLE) + (ptr->generation << 16));
+   return (HANDLE)(((INT_PTR)index) | ((ULONG)ptr->generation << 16));
 }
 
 __inline static PUSER_HANDLE_ENTRY alloc_user_entry(PUSER_HANDLE_TABLE ht)

--- a/win32ss/user/user32/misc/misc.c
+++ b/win32ss/user/user32/misc/misc.c
@@ -180,8 +180,8 @@ TestState(PWND pWnd, UINT Flag)
     bit = 1 << LOWORD(Flag);
     switch(HIWORD(Flag))
     {
-       case 0: 
-          return (pWnd->state & bit); 
+       case 0:
+          return (pWnd->state & bit);
        case 1:
           return (pWnd->state2 & bit);
        case 2:
@@ -199,7 +199,7 @@ GetUser32Handle(HANDLE handle)
 
     if (!handle) return NULL;
 
-    Index = (((UINT_PTR)handle & 0xffff) - FIRST_USER_HANDLE) >> 1;
+    Index = ((UINT_PTR)handle & 0xffff);
 
     if (Index < 0 || Index >= gHandleTable->nb_handles)
         return NULL;


### PR DESCRIPTION
This now works like Windows. It is required to be able to the maximum of handles, which is 64k on Windows.
