### PR TITLE
[RAPPS] Fix AppInfo panel WM_SYSCOLORCHANGE bug

### DIFF
--- a/base/applications/rapps/appview.cpp
+++ b/base/applications/rapps/appview.cpp
@@ -792,6 +792,11 @@ CAppInfoDisplay::ProcessWindowMessage(
             }
             break;
         }
+        case WM_SYSCOLORCHANGE:
+        {
+            RichEdit->SendMessageW(EM_SETBKGNDCOLOR, 0, GetSysColor(COLOR_BTNFACE));
+            break;
+        }
     }
 
     return FALSE;
@@ -1596,7 +1601,7 @@ CApplicationView::ProcessWindowMessage(
         {
             /* Forward WM_SYSCOLORCHANGE to common controls */
             m_ListView->SendMessageW(WM_SYSCOLORCHANGE, wParam, lParam);
-            m_ListView->SendMessageW(EM_SETBKGNDCOLOR, 0, GetSysColor(COLOR_BTNFACE));
+            m_AppsInfo->SendMessageW(WM_SYSCOLORCHANGE, wParam, lParam);
             m_Toolbar->SendMessageW(WM_SYSCOLORCHANGE, wParam, lParam);
             m_ComboBox->SendMessageW(WM_SYSCOLORCHANGE, wParam, lParam);
         }


### PR DESCRIPTION
The AppInfo panel (bottom info pane) does not update its color when the system color scheme is changed. Sending `EM_SETBKGNDCOLOR` to a ListView was obviously never going to work.