### PR TITLE
[LICCPA] Update Romanian (ro-RO) translation

### DIFF
--- a/dll/cpl/liccpa/lang/ro-RO.rc
+++ b/dll/cpl/liccpa/lang/ro-RO.rc
@@ -1,33 +1,35 @@
 /*
- * FILE:       dll/cpl/liccpa/lang/ro-RO.rc
- *             ReactOS Project (https://reactos.org)
- * TRANSLATOR: Ștefan Fulea (stefan dot fulea at mail dot com)
+ * PROJECT:     ReactOS Exploitation System
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Romanian resource file
+ * TRANSLATORS: Copyright 2011-2018 Ștefan Fulea <stefan.fulea@mail.com>
+ *              Copyright 2024 Andrei Miloiu <miloiuandrei@gmail.com>
  */
 
 LANGUAGE LANG_ROMANIAN, SUBLANG_NEUTRAL
 
 IDD_PROPPAGE1 DIALOGEX 20, 40, 315, 104
 STYLE DS_SHELLFONT | DS_MODALFRAME | WS_OVERLAPPED | WS_CAPTION | WS_VISIBLE | WS_SYSMENU
-CAPTION "Alegeți modul de licențiere"
+CAPTION "Alegere a modului de licențiere"
 FONT 8, "MS Shell Dlg"
 BEGIN
-    CONTROL "Mod de licențiere client", 100, "BUTTON", BS_GROUPBOX | WS_CHILD | WS_VISIBLE, 4, 4, 239, 94
+    CONTROL "Mod de licențiere a clientului", 100, "BUTTON", BS_GROUPBOX | WS_CHILD | WS_VISIBLE, 4, 4, 239, 94
     CONTROL "Per dispozitiv sau per utilizator", 102, "BUTTON", BS_AUTORADIOBUTTON | WS_CHILD | WS_VISIBLE, 13, 79, 147, 12
-    CONTROL "Per server. Numărul de conexiuni paralele:", 103, "BUTTON", BS_AUTORADIOBUTTON | WS_CHILD | WS_VISIBLE, 13, 38, 163, 9
+    CONTROL "Per server. Numărul de conexiuni simultane:", 103, "BUTTON", BS_AUTORADIOBUTTON | WS_CHILD | WS_VISIBLE, 13, 38, 163, 9
     CONTROL "Produs:", 105, "STATIC", SS_LEFT | WS_CHILD | WS_VISIBLE, 13, 20, 31, 8
     CONTROL "", 106, "COMBOBOX", CBS_DROPDOWNLIST | CBS_SORT | WS_VSCROLL | WS_TABSTOP, 49, 20, 171, 12
-    CONTROL "Con&firmă", 107, "BUTTON", BS_PUSHBUTTON | WS_CHILD | WS_VISIBLE | WS_TABSTOP, 263, 7, 46, 14
-    CONTROL "A&nulează", 108, "BUTTON", BS_PUSHBUTTON | WS_CHILD | WS_VISIBLE | WS_TABSTOP, 263, 27, 46, 14
-    CONTROL "Informații", 109, "BUTTON", BS_PUSHBUTTON | WS_CHILD | WS_VISIBLE | WS_TABSTOP, 263, 48, 46, 14
+    CONTROL "OK", 107, "BUTTON", BS_PUSHBUTTON | WS_CHILD | WS_VISIBLE | WS_TABSTOP, 263, 7, 46, 14
+    CONTROL "Revocare", 108, "BUTTON", BS_PUSHBUTTON | WS_CHILD | WS_VISIBLE | WS_TABSTOP, 263, 27, 46, 14
+    CONTROL "Ajutor", 109, "BUTTON", BS_PUSHBUTTON | WS_CHILD | WS_VISIBLE | WS_TABSTOP, 263, 48, 46, 14
     CONTROL "Replicare…", 110, "BUTTON", BS_PUSHBUTTON | WS_CHILD | WS_VISIBLE | WS_TABSTOP, 263, 68, 46, 14
-    CONTROL "Adaugă licențe", 111, "BUTTON", BS_PUSHBUTTON | WS_CHILD | WS_VISIBLE | WS_TABSTOP, 30, 56, 65, 15
-    CONTROL "Elimină licențe", 112, "BUTTON", BS_PUSHBUTTON | WS_CHILD | WS_VISIBLE | WS_TABSTOP, 112, 56, 61, 16
+    CONTROL "Adăugare de licențe", 111, "BUTTON", BS_PUSHBUTTON | WS_CHILD | WS_VISIBLE | WS_TABSTOP, 30, 56, 65, 15
+    CONTROL "Eliminare de licențe", 112, "BUTTON", BS_PUSHBUTTON | WS_CHILD | WS_VISIBLE | WS_TABSTOP, 112, 56, 61, 16
     CONTROL "", 114, "EDIT", ES_LEFT | ES_AUTOHSCROLL | WS_CHILD | WS_VISIBLE | WS_BORDER | WS_TABSTOP, 187, 39, 32, 12
 END
 
 STRINGTABLE
 BEGIN
-    IDS_CPLNAME_1 "Gestionar de licențe"
-    IDS_CPLDESCRIPTION_1 "Gestionar de licențe"
+    IDS_CPLNAME_1 "Manager de licențe"
+    IDS_CPLDESCRIPTION_1 "Manager de licențe"
     IDS_REACTOS "ReactOS - S.O. Public"
 END


### PR DESCRIPTION
Improvements based on recent Romanian translation document revision 06e89b2. 

This files was not translated in Romanian language in any Win version (neither XP/2k3+, nor in the previous ones). I tried to translate this file as close as possible in the way I did in the previous PRs with this attendum.