### PR TITLE
[USER32_APITEST] Improve RedrawWindow API test. Follow up of #7160

### DIFF
--- a/modules/rostests/apitests/user32/RedrawWindow.c
+++ b/modules/rostests/apitests/user32/RedrawWindow.c
@@ -254,7 +254,7 @@ void TestRedrawWindow(STRUCT_TestRedrawWindow* ptestRW)
     wc.hInstance = GetModuleHandle(NULL);
     wc.lpszClassName = ptestRW->testName;
     RegisterClassW(&wc);
-    RECT rectWin = { 0, 0, 800, 600 };
+    RECT rectWin = { 0, 0, 700, 500 };
     style = WS_OVERLAPPEDWINDOW;
     AdjustWindowRectEx(&rectWin, style, FALSE, 0);
     width = rectWin.right - rectWin.left;
@@ -293,7 +293,7 @@ void TestRedrawWindow(STRUCT_TestRedrawWindow* ptestRW)
     }
 
     HDC hdc = GetDC(hwnd);
-    RECT drect = { 0, 0, 800, 600 };
+    RECT drect = { 0, 0, 700, 500 };
     DrawContent(hdc, &drect, RGB(255, 0, 0));
     ReleaseDC(hwnd, hdc);
 

--- a/modules/rostests/apitests/user32/RedrawWindow.c
+++ b/modules/rostests/apitests/user32/RedrawWindow.c
@@ -54,7 +54,7 @@ void GetMessageRedrawWindowTest(void)
 
     while (PeekMessageW(&msg, NULL, 0, 0, PM_REMOVE))
     {
-        DispatchMessageW( &msg );
+        DispatchMessageW(&msg);
     }
 
     ok(got_paint == TRUE, "Did not process WM_PAINT message\n");

--- a/modules/rostests/apitests/user32/RedrawWindow.c
+++ b/modules/rostests/apitests/user32/RedrawWindow.c
@@ -438,17 +438,20 @@ void FlagsRedrawWindowTest(void)
     testRW.testPixelPre1x = 50;
     testRW.testPixelPre1y = 50;
     testRW.testPixelPre2x = 50;
-    testRW.testPixelPre2y = 550;
+    testRW.testPixelPre2y = 400;
     testRW.testPixelPost1x = 50;
     testRW.testPixelPost1y = 50;
     testRW.testPixelPost2x = 50;
-    testRW.testPixelPost2y = 550;
+    testRW.testPixelPost2y = 400;
+    
+    trace("Screen Width/Height (%dx%d)\n",
+          GetSystemMetrics(SM_CXSCREEN), GetSystemMetrics(SM_CYSCREEN));
     
     // RDW_ERASE tests    
     testRW.testName = L"Test1";
     testRW.flags = 0;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 700, 500);
+    SetRect(&testRW.regRect, 0, 300, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -468,7 +471,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test2";
     testRW.flags = RDW_ERASE;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 700, 500);
+    SetRect(&testRW.regRect, 0, 300, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -488,7 +491,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test3";
     testRW.flags = RDW_INVALIDATE;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 700, 500);
+    SetRect(&testRW.regRect, 0, 300, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -498,7 +501,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 300, 700, 500);
     testRWcompare.resultNeedsUpdate = TRUE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -508,7 +511,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test4";
     testRW.flags = RDW_INVALIDATE | RDW_ERASE;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 700, 500);
+    SetRect(&testRW.regRect, 0, 300, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -518,7 +521,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 300, 700, 500);
     testRWcompare.resultNeedsUpdate = TRUE;
     testRWcompare.resultWmEraseGnd = TRUE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -529,7 +532,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test5";
     testRW.flags = RDW_FRAME;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 700, 500);
+    SetRect(&testRW.regRect, 0, 300, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -539,7 +542,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x000000FF;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 300, 700, 500);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -549,7 +552,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test6";
     testRW.flags = RDW_INVALIDATE | RDW_FRAME;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 700, 500);
+    SetRect(&testRW.regRect, 0, 300, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -559,7 +562,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 300, 700, 500);
     testRWcompare.resultNeedsUpdate = TRUE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = TRUE;
@@ -570,7 +573,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test7";
     testRW.flags = RDW_INTERNALPAINT;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 700, 500);
+    SetRect(&testRW.regRect, 0, 300, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -580,7 +583,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x000000FF;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 300, 700, 500);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -590,7 +593,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test8";
     testRW.flags = RDW_INVALIDATE | RDW_INTERNALPAINT;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 700, 500);
+    SetRect(&testRW.regRect, 0, 300, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -600,7 +603,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 300, 700, 500);
     testRWcompare.resultNeedsUpdate = TRUE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -611,7 +614,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test9";
     testRW.flags = RDW_NOERASE;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 700, 500);
+    SetRect(&testRW.regRect, 0, 300, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -621,7 +624,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x000000FF;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 300, 700, 500);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -631,7 +634,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test10";
     testRW.flags = RDW_INVALIDATE | RDW_NOERASE;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 700, 500);
+    SetRect(&testRW.regRect, 0, 300, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -641,7 +644,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 300, 700, 500);
     testRWcompare.resultNeedsUpdate = TRUE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -651,7 +654,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test11";
     testRW.flags = RDW_NOERASE | RDW_ERASE;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 700, 500);
+    SetRect(&testRW.regRect, 0, 300, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -661,7 +664,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x000000FF;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 300, 700, 500);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -671,7 +674,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test12";
     testRW.flags = RDW_INVALIDATE | RDW_NOERASE | RDW_ERASE;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 700, 500);
+    SetRect(&testRW.regRect, 0, 300, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -681,7 +684,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 300, 700, 500);
     testRWcompare.resultNeedsUpdate = TRUE;
     testRWcompare.resultWmEraseGnd = TRUE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -692,7 +695,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test13";
     testRW.flags = RDW_NOFRAME;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 700, 500);
+    SetRect(&testRW.regRect, 0, 300, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -702,7 +705,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x000000FF;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 300, 700, 500);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -712,7 +715,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test14";
     testRW.flags = RDW_INVALIDATE | RDW_NOFRAME;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 700, 500);
+    SetRect(&testRW.regRect, 0, 300, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -722,7 +725,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 300, 700, 500);
     testRWcompare.resultNeedsUpdate = TRUE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -732,7 +735,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test15";
     testRW.flags = RDW_INVALIDATE | RDW_VALIDATE | RDW_NOFRAME;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 700, 500);
+    SetRect(&testRW.regRect, 0, 300, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -742,7 +745,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 300, 700, 500);
     testRWcompare.resultNeedsUpdate = TRUE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -752,7 +755,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test16";
     testRW.flags = RDW_VALIDATE | RDW_NOFRAME;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 700, 500);
+    SetRect(&testRW.regRect, 0, 300, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -762,7 +765,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x000000FF;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 300, 700, 500);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -773,7 +776,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test17";
     testRW.flags = RDW_NOINTERNALPAINT;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 700, 500);
+    SetRect(&testRW.regRect, 0, 300, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -783,7 +786,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x000000FF;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 300, 700, 500);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -793,7 +796,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test18";
     testRW.flags = RDW_INVALIDATE | RDW_NOINTERNALPAINT;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 700, 500);
+    SetRect(&testRW.regRect, 0, 300, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -803,7 +806,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 300, 700, 500);
     testRWcompare.resultNeedsUpdate = TRUE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -813,7 +816,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test19";
     testRW.flags = RDW_VALIDATE | RDW_NOINTERNALPAINT;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 700, 500);
+    SetRect(&testRW.regRect, 0, 300, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -823,7 +826,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x000000FF;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 300, 700, 500);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -834,7 +837,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test20";
     testRW.flags = RDW_ERASENOW;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 700, 500);
+    SetRect(&testRW.regRect, 0, 300, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -844,7 +847,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x000000FF;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 300, 700, 500);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -854,7 +857,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test21";
     testRW.flags = RDW_INVALIDATE | RDW_ERASENOW;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 700, 500);
+    SetRect(&testRW.regRect, 0, 300, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -864,7 +867,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 300, 700, 500);
     testRWcompare.resultNeedsUpdate = TRUE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -874,7 +877,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test22";
     testRW.flags = RDW_VALIDATE | RDW_ERASENOW;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 700, 500);
+    SetRect(&testRW.regRect, 0, 300, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -884,7 +887,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x000000FF;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 300, 700, 500);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -895,7 +898,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test23";
     testRW.flags = RDW_UPDATENOW;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 700, 500);
+    SetRect(&testRW.regRect, 0, 300, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -905,7 +908,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x000000FF;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 300, 700, 500);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -915,7 +918,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test24";
     testRW.flags = RDW_INVALIDATE | RDW_UPDATENOW;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 700, 500);
+    SetRect(&testRW.regRect, 0, 300, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -925,7 +928,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x0000FF00;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 300, 700, 500);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -935,7 +938,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test25";
     testRW.flags = RDW_VALIDATE | RDW_UPDATENOW;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 700, 500);
+    SetRect(&testRW.regRect, 0, 300, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -945,7 +948,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x000000FF;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 300, 700, 500);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -956,7 +959,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test26";
     testRW.flags = RDW_NOCHILDREN;
     testRW.useRegion = FALSE;
-    SetRect(&testRW.regRect, 0, 500, 700, 500);
+    SetRect(&testRW.regRect, 0, 300, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -966,7 +969,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x0000FF00;
     testRWcompare.resultColorPost1 = 0x00FF0000;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 300, 700, 500);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -976,7 +979,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test27";
     testRW.flags = RDW_INVALIDATE | RDW_NOCHILDREN;
     testRW.useRegion = FALSE;
-    SetRect(&testRW.regRect, 0, 500, 700, 500);
+    SetRect(&testRW.regRect, 0, 300, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -986,7 +989,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x0000FF00;
     testRWcompare.resultColorPost1 = 0x0000FF00;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 300, 700, 500);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -996,7 +999,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test28";
     testRW.flags = RDW_VALIDATE | RDW_NOCHILDREN;
     testRW.useRegion = FALSE;
-    SetRect(&testRW.regRect, 0, 500, 700, 500);
+    SetRect(&testRW.regRect, 0, 300, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -1006,7 +1009,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x0000FF00;
     testRWcompare.resultColorPost1 = 0x00FF0000;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 300, 700, 500);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -1016,7 +1019,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test29";
     testRW.flags = RDW_ALLCHILDREN;
     testRW.useRegion = FALSE;
-    SetRect(&testRW.regRect, 0, 500, 700, 500);
+    SetRect(&testRW.regRect, 0, 300, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -1026,7 +1029,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x0000FF00;
     testRWcompare.resultColorPost1 = 0x00FF0000;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 300, 700, 500);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -1036,7 +1039,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test30";
     testRW.flags = RDW_INVALIDATE | RDW_ALLCHILDREN;
     testRW.useRegion = FALSE;
-    SetRect(&testRW.regRect, 0, 500, 700, 500);
+    SetRect(&testRW.regRect, 0, 300, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -1046,7 +1049,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x0000FF00;
     testRWcompare.resultColorPre1 = 0x00FF0000;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 300, 700, 500);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -1056,7 +1059,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test31";
     testRW.flags = RDW_VALIDATE | RDW_ALLCHILDREN;
     testRW.useRegion = FALSE;
-    SetRect(&testRW.regRect, 0, 500, 700, 500);
+    SetRect(&testRW.regRect, 0, 300, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -1066,7 +1069,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x0000FF00;
     testRWcompare.resultColorPost1 = 0x00FF0000;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 300, 700, 500);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -1076,7 +1079,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test32";
     testRW.flags = RDW_NOCHILDREN;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 700, 500);
+    SetRect(&testRW.regRect, 0, 300, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -1086,7 +1089,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x0000FF00;
     testRWcompare.resultColorPost1 = 0x00FF0000;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 300, 700, 500);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -1096,7 +1099,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test33";
     testRW.flags = RDW_INVALIDATE | RDW_NOCHILDREN;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 700, 500);
+    SetRect(&testRW.regRect, 0, 300, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -1106,7 +1109,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x0000FF00;
     testRWcompare.resultColorPre1 = 0x00FF0000;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 300, 700, 500);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -1116,7 +1119,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test34";
     testRW.flags = RDW_VALIDATE | RDW_NOCHILDREN;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 700, 500);
+    SetRect(&testRW.regRect, 0, 300, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -1126,7 +1129,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x0000FF00;
     testRWcompare.resultColorPost1 = 0x00FF0000;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 300, 700, 500);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -1137,9 +1140,9 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test35";
     testRW.flags = 0;
     testRW.useRegion = FALSE;
-    SetRect(&testRW.regRect, 0, 500, 700, 500);
+    SetRect(&testRW.regRect, 0, 300, 700, 500);
     testRW.useRect = TRUE;
-    SetRect(&testRW.rectRect, 0, 500, 700, 500);
+    SetRect(&testRW.rectRect, 0, 300, 700, 500);
     testRW.forcePaint = TRUE;
     testRW.testChild = FALSE;
 
@@ -1157,9 +1160,9 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test36";
     testRW.flags = RDW_INVALIDATE | RDW_ERASENOW;
     testRW.useRegion = FALSE;
-    SetRect(&testRW.regRect, 0, 500, 700, 500);
+    SetRect(&testRW.regRect, 0, 300, 700, 500);
     testRW.useRect = TRUE;
-    SetRect(&testRW.rectRect, 0, 500, 700, 500);
+    SetRect(&testRW.rectRect, 0, 300, 700, 500);
     testRW.forcePaint = TRUE;
     testRW.testChild = FALSE;
 
@@ -1167,7 +1170,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 300, 700, 500);
     testRWcompare.resultNeedsUpdate = TRUE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;

--- a/modules/rostests/apitests/user32/RedrawWindow.c
+++ b/modules/rostests/apitests/user32/RedrawWindow.c
@@ -52,7 +52,7 @@ void GetMessageRedrawWindowTest(void)
 
     ShowWindow(hWnd, SW_SHOW);
 
-    while (PeekMessageW( &msg, 0, 0, 0, PM_REMOVE ))
+    while (PeekMessageW(&msg, NULL, 0, 0, PM_REMOVE))
     {
         DispatchMessageW( &msg );
     }

--- a/modules/rostests/apitests/user32/RedrawWindow.c
+++ b/modules/rostests/apitests/user32/RedrawWindow.c
@@ -430,14 +430,6 @@ UINT TestRedrawWindow2(STRUCT_TestRedrawWindow* ptestRW, STRUCT_TestRedrawWindow
     return countErrors;
 }
 
-void InitRect(RECT *rect, int left, int top, int right, int bottom)
-{
-    rect->left = left;
-    rect->top = top;
-    rect->right = right;
-    rect->bottom = bottom;
-}
-
 void FlagsRedrawWindowTest(void)
 {
     STRUCT_TestRedrawWindow testRW;
@@ -456,9 +448,9 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test1";
     testRW.flags = 0;
     testRW.useRegion = TRUE;
-    InitRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 800, 600);
     testRW.useRect = FALSE;
-    InitRect(&testRW.rectRect, 0, 0, 200, 200);
+    SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
     testRW.testChild = FALSE;
 
@@ -466,7 +458,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x000000FF;
-    InitRect(&testRWcompare.resultUpdateRect, 0, 0, 200, 200);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 0, 200, 200);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -476,9 +468,9 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test2";
     testRW.flags = RDW_ERASE;
     testRW.useRegion = TRUE;
-    InitRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 800, 600);
     testRW.useRect = FALSE;
-    InitRect(&testRW.rectRect, 0, 0, 200, 200);
+    SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
     testRW.testChild = FALSE;
 
@@ -486,7 +478,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x000000FF;
-    InitRect(&testRWcompare.resultUpdateRect, 0, 0, 200, 200);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 0, 200, 200);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -496,9 +488,9 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test3";
     testRW.flags = RDW_INVALIDATE;
     testRW.useRegion = TRUE;
-    InitRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 800, 600);
     testRW.useRect = FALSE;
-    InitRect(&testRW.rectRect, 0, 0, 200, 200);
+    SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
     testRW.testChild = FALSE;
 
@@ -506,7 +498,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    InitRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
     testRWcompare.resultNeedsUpdate = TRUE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -516,9 +508,9 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test4";
     testRW.flags = RDW_INVALIDATE | RDW_ERASE;
     testRW.useRegion = TRUE;
-    InitRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 800, 600);
     testRW.useRect = FALSE;
-    InitRect(&testRW.rectRect, 0, 0, 200, 200);
+    SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
     testRW.testChild = FALSE;
 
@@ -526,7 +518,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    InitRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
     testRWcompare.resultNeedsUpdate = TRUE;
     testRWcompare.resultWmEraseGnd = TRUE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -537,9 +529,9 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test5";
     testRW.flags = RDW_FRAME;
     testRW.useRegion = TRUE;
-    InitRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 800, 600);
     testRW.useRect = FALSE;
-    InitRect(&testRW.rectRect, 0, 0, 200, 200);
+    SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
     testRW.testChild = FALSE;
 
@@ -547,7 +539,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x000000FF;
-    InitRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -557,9 +549,9 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test6";
     testRW.flags = RDW_INVALIDATE | RDW_FRAME;
     testRW.useRegion = TRUE;
-    InitRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 800, 600);
     testRW.useRect = FALSE;
-    InitRect(&testRW.rectRect, 0, 0, 200, 200);
+    SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
     testRW.testChild = FALSE;
 
@@ -567,7 +559,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    InitRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
     testRWcompare.resultNeedsUpdate = TRUE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = TRUE;
@@ -578,9 +570,9 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test7";
     testRW.flags = RDW_INTERNALPAINT;
     testRW.useRegion = TRUE;
-    InitRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 800, 600);
     testRW.useRect = FALSE;
-    InitRect(&testRW.rectRect, 0, 0, 200, 200);
+    SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
     testRW.testChild = FALSE;
 
@@ -588,7 +580,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x000000FF;
-    InitRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -598,9 +590,9 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test8";
     testRW.flags = RDW_INVALIDATE | RDW_INTERNALPAINT;
     testRW.useRegion = TRUE;
-    InitRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 800, 600);
     testRW.useRect = FALSE;
-    InitRect(&testRW.rectRect, 0, 0, 200, 200);
+    SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
     testRW.testChild = FALSE;
 
@@ -608,7 +600,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    InitRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
     testRWcompare.resultNeedsUpdate = TRUE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -619,9 +611,9 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test9";
     testRW.flags = RDW_NOERASE;
     testRW.useRegion = TRUE;
-    InitRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 800, 600);
     testRW.useRect = FALSE;
-    InitRect(&testRW.rectRect, 0, 0, 200, 200);
+    SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
     testRW.testChild = FALSE;
 
@@ -629,7 +621,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x000000FF;
-    InitRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -639,9 +631,9 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test10";
     testRW.flags = RDW_INVALIDATE | RDW_NOERASE;
     testRW.useRegion = TRUE;
-    InitRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 800, 600);
     testRW.useRect = FALSE;
-    InitRect(&testRW.rectRect, 0, 0, 200, 200);
+    SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
     testRW.testChild = FALSE;
 
@@ -649,7 +641,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    InitRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
     testRWcompare.resultNeedsUpdate = TRUE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -659,9 +651,9 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test11";
     testRW.flags = RDW_NOERASE | RDW_ERASE;
     testRW.useRegion = TRUE;
-    InitRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 800, 600);
     testRW.useRect = FALSE;
-    InitRect(&testRW.rectRect, 0, 0, 200, 200);
+    SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
     testRW.testChild = FALSE;
 
@@ -669,7 +661,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x000000FF;
-    InitRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -679,9 +671,9 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test12";
     testRW.flags = RDW_INVALIDATE | RDW_NOERASE | RDW_ERASE;
     testRW.useRegion = TRUE;
-    InitRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 800, 600);
     testRW.useRect = FALSE;
-    InitRect(&testRW.rectRect, 0, 0, 200, 200);
+    SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
     testRW.testChild = FALSE;
 
@@ -689,7 +681,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    InitRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
     testRWcompare.resultNeedsUpdate = TRUE;
     testRWcompare.resultWmEraseGnd = TRUE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -700,9 +692,9 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test13";
     testRW.flags = RDW_NOFRAME;
     testRW.useRegion = TRUE;
-    InitRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 800, 600);
     testRW.useRect = FALSE;
-    InitRect(&testRW.rectRect, 0, 0, 200, 200);
+    SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
     testRW.testChild = FALSE;
 
@@ -710,7 +702,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x000000FF;
-    InitRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -720,9 +712,9 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test14";
     testRW.flags = RDW_INVALIDATE | RDW_NOFRAME;
     testRW.useRegion = TRUE;
-    InitRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 800, 600);
     testRW.useRect = FALSE;
-    InitRect(&testRW.rectRect, 0, 0, 200, 200);
+    SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
     testRW.testChild = FALSE;
 
@@ -730,7 +722,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    InitRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
     testRWcompare.resultNeedsUpdate = TRUE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -740,9 +732,9 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test15";
     testRW.flags = RDW_INVALIDATE | RDW_VALIDATE | RDW_NOFRAME;
     testRW.useRegion = TRUE;
-    InitRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 800, 600);
     testRW.useRect = FALSE;
-    InitRect(&testRW.rectRect, 0, 0, 200, 200);
+    SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
     testRW.testChild = FALSE;
 
@@ -750,7 +742,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    InitRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
     testRWcompare.resultNeedsUpdate = TRUE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -760,9 +752,9 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test16";
     testRW.flags = RDW_VALIDATE | RDW_NOFRAME;
     testRW.useRegion = TRUE;
-    InitRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 800, 600);
     testRW.useRect = FALSE;
-    InitRect(&testRW.rectRect, 0, 0, 200, 200);
+    SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
     testRW.testChild = FALSE;
 
@@ -770,7 +762,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x000000FF;
-    InitRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -781,9 +773,9 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test17";
     testRW.flags = RDW_NOINTERNALPAINT;
     testRW.useRegion = TRUE;
-    InitRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 800, 600);
     testRW.useRect = FALSE;
-    InitRect(&testRW.rectRect, 0, 0, 200, 200);
+    SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
     testRW.testChild = FALSE;
 
@@ -791,7 +783,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x000000FF;
-    InitRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -801,9 +793,9 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test18";
     testRW.flags = RDW_INVALIDATE | RDW_NOINTERNALPAINT;
     testRW.useRegion = TRUE;
-    InitRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 800, 600);
     testRW.useRect = FALSE;
-    InitRect(&testRW.rectRect, 0, 0, 200, 200);
+    SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
     testRW.testChild = FALSE;
 
@@ -811,7 +803,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    InitRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
     testRWcompare.resultNeedsUpdate = TRUE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -821,9 +813,9 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test19";
     testRW.flags = RDW_VALIDATE | RDW_NOINTERNALPAINT;
     testRW.useRegion = TRUE;
-    InitRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 800, 600);
     testRW.useRect = FALSE;
-    InitRect(&testRW.rectRect, 0, 0, 200, 200);
+    SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
     testRW.testChild = FALSE;
 
@@ -831,7 +823,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x000000FF;
-    InitRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -842,9 +834,9 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test20";
     testRW.flags = RDW_ERASENOW;
     testRW.useRegion = TRUE;
-    InitRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 800, 600);
     testRW.useRect = FALSE;
-    InitRect(&testRW.rectRect, 0, 0, 200, 200);
+    SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
     testRW.testChild = FALSE;
 
@@ -852,7 +844,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x000000FF;
-    InitRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -862,9 +854,9 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test21";
     testRW.flags = RDW_INVALIDATE | RDW_ERASENOW;
     testRW.useRegion = TRUE;
-    InitRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 800, 600);
     testRW.useRect = FALSE;
-    InitRect(&testRW.rectRect, 0, 0, 200, 200);
+    SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
     testRW.testChild = FALSE;
 
@@ -872,7 +864,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    InitRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
     testRWcompare.resultNeedsUpdate = TRUE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -882,9 +874,9 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test22";
     testRW.flags = RDW_VALIDATE | RDW_ERASENOW;
     testRW.useRegion = TRUE;
-    InitRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 800, 600);
     testRW.useRect = FALSE;
-    InitRect(&testRW.rectRect, 0, 0, 200, 200);
+    SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
     testRW.testChild = FALSE;
 
@@ -892,7 +884,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x000000FF;
-    InitRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -903,9 +895,9 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test23";
     testRW.flags = RDW_UPDATENOW;
     testRW.useRegion = TRUE;
-    InitRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 800, 600);
     testRW.useRect = FALSE;
-    InitRect(&testRW.rectRect, 0, 0, 200, 200);
+    SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
     testRW.testChild = FALSE;
 
@@ -913,7 +905,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x000000FF;
-    InitRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -923,9 +915,9 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test24";
     testRW.flags = RDW_INVALIDATE | RDW_UPDATENOW;
     testRW.useRegion = TRUE;
-    InitRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 800, 600);
     testRW.useRect = FALSE;
-    InitRect(&testRW.rectRect, 0, 0, 200, 200);
+    SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
     testRW.testChild = FALSE;
 
@@ -933,7 +925,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x0000FF00;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    InitRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -943,9 +935,9 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test25";
     testRW.flags = RDW_VALIDATE | RDW_UPDATENOW;
     testRW.useRegion = TRUE;
-    InitRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 800, 600);
     testRW.useRect = FALSE;
-    InitRect(&testRW.rectRect, 0, 0, 200, 200);
+    SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
     testRW.testChild = FALSE;
 
@@ -953,7 +945,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x000000FF;
-    InitRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -964,9 +956,9 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test26";
     testRW.flags = RDW_NOCHILDREN;
     testRW.useRegion = FALSE;
-    InitRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 800, 600);
     testRW.useRect = FALSE;
-    InitRect(&testRW.rectRect, 0, 0, 200, 200);
+    SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
     testRW.testChild = TRUE;
 
@@ -974,7 +966,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x0000FF00;
     testRWcompare.resultColorPost1 = 0x00FF0000;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    InitRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -984,9 +976,9 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test27";
     testRW.flags = RDW_INVALIDATE | RDW_NOCHILDREN;
     testRW.useRegion = FALSE;
-    InitRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 800, 600);
     testRW.useRect = FALSE;
-    InitRect(&testRW.rectRect, 0, 0, 200, 200);
+    SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
     testRW.testChild = TRUE;
 
@@ -994,7 +986,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x0000FF00;
     testRWcompare.resultColorPost1 = 0x0000FF00;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    InitRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -1004,9 +996,9 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test28";
     testRW.flags = RDW_VALIDATE | RDW_NOCHILDREN;
     testRW.useRegion = FALSE;
-    InitRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 800, 600);
     testRW.useRect = FALSE;
-    InitRect(&testRW.rectRect, 0, 0, 200, 200);
+    SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
     testRW.testChild = TRUE;
 
@@ -1014,7 +1006,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x0000FF00;
     testRWcompare.resultColorPost1 = 0x00FF0000;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    InitRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -1024,9 +1016,9 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test29";
     testRW.flags = RDW_ALLCHILDREN;
     testRW.useRegion = FALSE;
-    InitRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 800, 600);
     testRW.useRect = FALSE;
-    InitRect(&testRW.rectRect, 0, 0, 200, 200);
+    SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
     testRW.testChild = TRUE;
 
@@ -1034,7 +1026,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x0000FF00;
     testRWcompare.resultColorPost1 = 0x00FF0000;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    InitRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -1044,9 +1036,9 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test30";
     testRW.flags = RDW_INVALIDATE | RDW_ALLCHILDREN;
     testRW.useRegion = FALSE;
-    InitRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 800, 600);
     testRW.useRect = FALSE;
-    InitRect(&testRW.rectRect, 0, 0, 200, 200);
+    SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
     testRW.testChild = TRUE;
 
@@ -1054,7 +1046,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x0000FF00;
     testRWcompare.resultColorPre1 = 0x00FF0000;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    InitRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -1064,9 +1056,9 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test31";
     testRW.flags = RDW_VALIDATE | RDW_ALLCHILDREN;
     testRW.useRegion = FALSE;
-    InitRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 800, 600);
     testRW.useRect = FALSE;
-    InitRect(&testRW.rectRect, 0, 0, 200, 200);
+    SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
     testRW.testChild = TRUE;
 
@@ -1074,7 +1066,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x0000FF00;
     testRWcompare.resultColorPost1 = 0x00FF0000;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    InitRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -1084,9 +1076,9 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test32";
     testRW.flags = RDW_NOCHILDREN;
     testRW.useRegion = TRUE;
-    InitRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 800, 600);
     testRW.useRect = FALSE;
-    InitRect(&testRW.rectRect, 0, 0, 200, 200);
+    SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
     testRW.testChild = TRUE;
 
@@ -1094,7 +1086,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x0000FF00;
     testRWcompare.resultColorPost1 = 0x00FF0000;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    InitRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -1104,9 +1096,9 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test33";
     testRW.flags = RDW_INVALIDATE | RDW_NOCHILDREN;
     testRW.useRegion = TRUE;
-    InitRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 800, 600);
     testRW.useRect = FALSE;
-    InitRect(&testRW.rectRect, 0, 0, 200, 200);
+    SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
     testRW.testChild = TRUE;
 
@@ -1114,7 +1106,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x0000FF00;
     testRWcompare.resultColorPre1 = 0x00FF0000;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    InitRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -1124,9 +1116,9 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test34";
     testRW.flags = RDW_VALIDATE | RDW_NOCHILDREN;
     testRW.useRegion = TRUE;
-    InitRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 800, 600);
     testRW.useRect = FALSE;
-    InitRect(&testRW.rectRect, 0, 0, 200, 200);
+    SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
     testRW.testChild = TRUE;
 
@@ -1134,7 +1126,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x0000FF00;
     testRWcompare.resultColorPost1 = 0x00FF0000;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    InitRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -1145,9 +1137,9 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test35";
     testRW.flags = 0;
     testRW.useRegion = FALSE;
-    InitRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 800, 600);
     testRW.useRect = TRUE;
-    InitRect(&testRW.rectRect, 0, 500, 800, 600);
+    SetRect(&testRW.rectRect, 0, 500, 800, 600);
     testRW.forcePaint = TRUE;
     testRW.testChild = FALSE;
 
@@ -1155,7 +1147,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x000000FF;
-    InitRect(&testRWcompare.resultUpdateRect, 0, 0, 200, 200);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 0, 200, 200);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -1165,9 +1157,9 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test36";
     testRW.flags = RDW_INVALIDATE | RDW_ERASENOW;
     testRW.useRegion = FALSE;
-    InitRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 800, 600);
     testRW.useRect = TRUE;
-    InitRect(&testRW.rectRect, 0, 500, 800, 600);
+    SetRect(&testRW.rectRect, 0, 500, 800, 600);
     testRW.forcePaint = TRUE;
     testRW.testChild = FALSE;
 
@@ -1175,7 +1167,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    InitRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
     testRWcompare.resultNeedsUpdate = TRUE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;

--- a/modules/rostests/apitests/user32/RedrawWindow.c
+++ b/modules/rostests/apitests/user32/RedrawWindow.c
@@ -34,7 +34,7 @@ WndProc(
     return DefWindowProcW(hWnd, message, wParam, lParam);
 }
 
-void GetMessageRedrawWindowTest()
+void GetMessageRedrawWindowTest(void)
 {
     HWND hWnd;
     MSG msg;
@@ -52,9 +52,9 @@ void GetMessageRedrawWindowTest()
 
     ShowWindow(hWnd, SW_SHOW);
 
-    while (PeekMessage( &msg, 0, 0, 0, PM_REMOVE ))
+    while (PeekMessageW( &msg, 0, 0, 0, PM_REMOVE ))
     {
-        DispatchMessageA( &msg );
+        DispatchMessageW( &msg );
     }
 
     ok(got_paint == TRUE, "Did not process WM_PAINT message\n");
@@ -66,7 +66,7 @@ void GetMessageRedrawWindowTest()
     ok(ret == TRUE, "RedrawWindow failed\n");
 
     i = 0;
-    while (PeekMessage( &msg, 0, 0, 0, PM_REMOVE ))
+    while (PeekMessageW( &msg, 0, 0, 0, PM_REMOVE ))
     {
         RECORD_MESSAGE(1, msg.message, POST, 0, 0);
         if (msg.message == WM_PAINT)
@@ -79,7 +79,7 @@ void GetMessageRedrawWindowTest()
         }
         if (msg.message != WM_PAINT || i >= 10)
         {
-            DispatchMessageA( &msg );
+            DispatchMessageW( &msg );
         }
     }
 
@@ -136,12 +136,13 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
             return 0;
         }
     }
-    return DefWindowProc(hwnd, uMsg, wParam, lParam);
+    return DefWindowProcW(hwnd, uMsg, wParam, lParam);
 }
 
 LRESULT CALLBACK ChildWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-    switch (uMsg) {
+    switch (uMsg)
+    {
         case WM_SYNCPAINT:
         {
             PAINTSTRUCT ps;
@@ -168,7 +169,7 @@ LRESULT CALLBACK ChildWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPa
             return 0;
         }
     }
-    return DefWindowProc(hwnd, uMsg, wParam, lParam);
+    return DefWindowProcW(hwnd, uMsg, wParam, lParam);
 }
 
 typedef struct STRUCT_TestRedrawWindow
@@ -223,10 +224,10 @@ void ServeSomeMessages(int messageTime, int messageCount)
     startTime = GetTickCount();
     while (GetTickCount() - startTime < messageTime * messageCount)
     {
-        if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
+        if (PeekMessageW(&msg, NULL, 0, 0, PM_REMOVE))
         {
             TranslateMessage(&msg);
-            DispatchMessage(&msg);
+            DispatchMessageW(&msg);
         }
         else
         {
@@ -235,7 +236,8 @@ void ServeSomeMessages(int messageTime, int messageCount)
     }
 }
 
-void TestRedrawWindow(STRUCT_TestRedrawWindow* ptestRW) {
+void TestRedrawWindow(STRUCT_TestRedrawWindow* ptestRW)
+{
     DWORD style;
     int width;
     int height;
@@ -285,6 +287,8 @@ void TestRedrawWindow(STRUCT_TestRedrawWindow* ptestRW) {
             GetModuleHandle(NULL),
             NULL
         );
+        if (hChildWnd == NULL)
+            return;
     }
 
     HDC hdc = GetDC(hwnd);
@@ -298,7 +302,7 @@ void TestRedrawWindow(STRUCT_TestRedrawWindow* ptestRW) {
         RgnUpdate = CreateRectRgn(ptestRW->regRect.left, ptestRW->regRect.top, ptestRW->regRect.right, ptestRW->regRect.bottom);
     }
 
-    prect=NULL;
+    prect = NULL;
     if (ptestRW->useRect)
     {
         prect = &ptestRW->rectRect;
@@ -337,7 +341,8 @@ void TestRedrawWindow(STRUCT_TestRedrawWindow* ptestRW) {
     ptestRW->resultWmNcPaint = resultWmNcPaint;
     ptestRW->resultPaintIndex = paintIndex;
 
-    if (RgnUpdate) DeleteObject(RgnUpdate);
+    if (RgnUpdate)
+        DeleteObject(RgnUpdate);
 
     if (hChildWnd != NULL)
         DestroyWindow(hChildWnd);
@@ -425,14 +430,15 @@ UINT TestRedrawWindow2(STRUCT_TestRedrawWindow* ptestRW, STRUCT_TestRedrawWindow
     return countErrors;
 }
 
-void InitRect(RECT *rect, int left, int top, int right, int bottom) {
+void InitRect(RECT *rect, int left, int top, int right, int bottom)
+{
     rect->left = left;
     rect->top = top;
     rect->right = right;
     rect->bottom = bottom;
 }
 
-void FlagsRedrawWindowTest()
+void FlagsRedrawWindowTest(void)
 {
     STRUCT_TestRedrawWindow testRW;
     STRUCT_TestRedrawWindowCompare testRWcompare;

--- a/modules/rostests/apitests/user32/RedrawWindow.c
+++ b/modules/rostests/apitests/user32/RedrawWindow.c
@@ -448,7 +448,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test1";
     testRW.flags = 0;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -468,7 +468,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test2";
     testRW.flags = RDW_ERASE;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -488,7 +488,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test3";
     testRW.flags = RDW_INVALIDATE;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -498,7 +498,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
     testRWcompare.resultNeedsUpdate = TRUE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -508,7 +508,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test4";
     testRW.flags = RDW_INVALIDATE | RDW_ERASE;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -518,7 +518,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
     testRWcompare.resultNeedsUpdate = TRUE;
     testRWcompare.resultWmEraseGnd = TRUE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -529,7 +529,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test5";
     testRW.flags = RDW_FRAME;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -539,7 +539,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x000000FF;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -549,7 +549,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test6";
     testRW.flags = RDW_INVALIDATE | RDW_FRAME;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -559,7 +559,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
     testRWcompare.resultNeedsUpdate = TRUE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = TRUE;
@@ -570,7 +570,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test7";
     testRW.flags = RDW_INTERNALPAINT;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -580,7 +580,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x000000FF;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -590,7 +590,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test8";
     testRW.flags = RDW_INVALIDATE | RDW_INTERNALPAINT;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -600,7 +600,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
     testRWcompare.resultNeedsUpdate = TRUE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -611,7 +611,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test9";
     testRW.flags = RDW_NOERASE;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -621,7 +621,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x000000FF;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -631,7 +631,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test10";
     testRW.flags = RDW_INVALIDATE | RDW_NOERASE;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -641,7 +641,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
     testRWcompare.resultNeedsUpdate = TRUE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -651,7 +651,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test11";
     testRW.flags = RDW_NOERASE | RDW_ERASE;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -661,7 +661,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x000000FF;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -671,7 +671,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test12";
     testRW.flags = RDW_INVALIDATE | RDW_NOERASE | RDW_ERASE;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -681,7 +681,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
     testRWcompare.resultNeedsUpdate = TRUE;
     testRWcompare.resultWmEraseGnd = TRUE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -692,7 +692,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test13";
     testRW.flags = RDW_NOFRAME;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -702,7 +702,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x000000FF;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -712,7 +712,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test14";
     testRW.flags = RDW_INVALIDATE | RDW_NOFRAME;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -722,7 +722,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
     testRWcompare.resultNeedsUpdate = TRUE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -732,7 +732,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test15";
     testRW.flags = RDW_INVALIDATE | RDW_VALIDATE | RDW_NOFRAME;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -742,7 +742,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
     testRWcompare.resultNeedsUpdate = TRUE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -752,7 +752,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test16";
     testRW.flags = RDW_VALIDATE | RDW_NOFRAME;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -762,7 +762,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x000000FF;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -773,7 +773,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test17";
     testRW.flags = RDW_NOINTERNALPAINT;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -783,7 +783,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x000000FF;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -793,7 +793,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test18";
     testRW.flags = RDW_INVALIDATE | RDW_NOINTERNALPAINT;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -803,7 +803,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
     testRWcompare.resultNeedsUpdate = TRUE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -813,7 +813,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test19";
     testRW.flags = RDW_VALIDATE | RDW_NOINTERNALPAINT;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -823,7 +823,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x000000FF;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -834,7 +834,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test20";
     testRW.flags = RDW_ERASENOW;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -844,7 +844,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x000000FF;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -854,7 +854,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test21";
     testRW.flags = RDW_INVALIDATE | RDW_ERASENOW;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -864,7 +864,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
     testRWcompare.resultNeedsUpdate = TRUE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -874,7 +874,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test22";
     testRW.flags = RDW_VALIDATE | RDW_ERASENOW;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -884,7 +884,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x000000FF;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -895,7 +895,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test23";
     testRW.flags = RDW_UPDATENOW;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -905,7 +905,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x000000FF;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -915,7 +915,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test24";
     testRW.flags = RDW_INVALIDATE | RDW_UPDATENOW;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -925,7 +925,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x0000FF00;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -935,7 +935,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test25";
     testRW.flags = RDW_VALIDATE | RDW_UPDATENOW;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -945,7 +945,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x000000FF;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -956,7 +956,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test26";
     testRW.flags = RDW_NOCHILDREN;
     testRW.useRegion = FALSE;
-    SetRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -966,7 +966,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x0000FF00;
     testRWcompare.resultColorPost1 = 0x00FF0000;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -976,7 +976,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test27";
     testRW.flags = RDW_INVALIDATE | RDW_NOCHILDREN;
     testRW.useRegion = FALSE;
-    SetRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -986,7 +986,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x0000FF00;
     testRWcompare.resultColorPost1 = 0x0000FF00;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -996,7 +996,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test28";
     testRW.flags = RDW_VALIDATE | RDW_NOCHILDREN;
     testRW.useRegion = FALSE;
-    SetRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -1006,7 +1006,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x0000FF00;
     testRWcompare.resultColorPost1 = 0x00FF0000;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -1016,7 +1016,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test29";
     testRW.flags = RDW_ALLCHILDREN;
     testRW.useRegion = FALSE;
-    SetRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -1026,7 +1026,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x0000FF00;
     testRWcompare.resultColorPost1 = 0x00FF0000;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -1036,7 +1036,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test30";
     testRW.flags = RDW_INVALIDATE | RDW_ALLCHILDREN;
     testRW.useRegion = FALSE;
-    SetRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -1046,7 +1046,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x0000FF00;
     testRWcompare.resultColorPre1 = 0x00FF0000;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -1056,7 +1056,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test31";
     testRW.flags = RDW_VALIDATE | RDW_ALLCHILDREN;
     testRW.useRegion = FALSE;
-    SetRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -1066,7 +1066,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x0000FF00;
     testRWcompare.resultColorPost1 = 0x00FF0000;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -1076,7 +1076,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test32";
     testRW.flags = RDW_NOCHILDREN;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -1086,7 +1086,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x0000FF00;
     testRWcompare.resultColorPost1 = 0x00FF0000;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -1096,7 +1096,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test33";
     testRW.flags = RDW_INVALIDATE | RDW_NOCHILDREN;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -1106,7 +1106,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x0000FF00;
     testRWcompare.resultColorPre1 = 0x00FF0000;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -1116,7 +1116,7 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test34";
     testRW.flags = RDW_VALIDATE | RDW_NOCHILDREN;
     testRW.useRegion = TRUE;
-    SetRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 700, 500);
     testRW.useRect = FALSE;
     SetRect(&testRW.rectRect, 0, 0, 200, 200);
     testRW.forcePaint = TRUE;
@@ -1126,7 +1126,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x0000FF00;
     testRWcompare.resultColorPost1 = 0x00FF0000;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
     testRWcompare.resultNeedsUpdate = FALSE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;
@@ -1137,9 +1137,9 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test35";
     testRW.flags = 0;
     testRW.useRegion = FALSE;
-    SetRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 700, 500);
     testRW.useRect = TRUE;
-    SetRect(&testRW.rectRect, 0, 500, 800, 600);
+    SetRect(&testRW.rectRect, 0, 500, 700, 500);
     testRW.forcePaint = TRUE;
     testRW.testChild = FALSE;
 
@@ -1157,9 +1157,9 @@ void FlagsRedrawWindowTest(void)
     testRW.testName = L"Test36";
     testRW.flags = RDW_INVALIDATE | RDW_ERASENOW;
     testRW.useRegion = FALSE;
-    SetRect(&testRW.regRect, 0, 500, 800, 600);
+    SetRect(&testRW.regRect, 0, 500, 700, 500);
     testRW.useRect = TRUE;
-    SetRect(&testRW.rectRect, 0, 500, 800, 600);
+    SetRect(&testRW.rectRect, 0, 500, 700, 500);
     testRW.forcePaint = TRUE;
     testRW.testChild = FALSE;
 
@@ -1167,7 +1167,7 @@ void FlagsRedrawWindowTest(void)
     testRWcompare.resultColorPre2 = 0x000000FF;
     testRWcompare.resultColorPost1 = 0x000000FF;
     testRWcompare.resultColorPost2 = 0x0000FF00;
-    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 800, 600);
+    SetRect(&testRWcompare.resultUpdateRect, 0, 500, 700, 500);
     testRWcompare.resultNeedsUpdate = TRUE;
     testRWcompare.resultWmEraseGnd = FALSE;
     testRWcompare.resultWmNcPaint = FALSE;

--- a/modules/rostests/apitests/user32/RedrawWindow.c
+++ b/modules/rostests/apitests/user32/RedrawWindow.c
@@ -263,6 +263,7 @@ void TestRedrawWindow(STRUCT_TestRedrawWindow* ptestRW)
         CW_USEDEFAULT, CW_USEDEFAULT, width, height, NULL, NULL, GetModuleHandle(NULL), NULL);
     if (hwnd == NULL)
         return;
+    MoveWindow(hwnd, 10, 10, width, height, TRUE);
 
     ShowWindow(hwnd, SW_SHOW);
     if(!ptestRW->testChild)

--- a/modules/rostests/apitests/user32/RedrawWindow.c
+++ b/modules/rostests/apitests/user32/RedrawWindow.c
@@ -66,7 +66,7 @@ void GetMessageRedrawWindowTest(void)
     ok(ret == TRUE, "RedrawWindow failed\n");
 
     i = 0;
-    while (PeekMessageW( &msg, 0, 0, 0, PM_REMOVE ))
+    while (PeekMessageW(&msg, NULL, 0, 0, PM_REMOVE))
     {
         RECORD_MESSAGE(1, msg.message, POST, 0, 0);
         if (msg.message == WM_PAINT)

--- a/modules/rostests/apitests/user32/RedrawWindow.c
+++ b/modules/rostests/apitests/user32/RedrawWindow.c
@@ -79,7 +79,7 @@ void GetMessageRedrawWindowTest(void)
         }
         if (msg.message != WM_PAINT || i >= 10)
         {
-            DispatchMessageW( &msg );
+            DispatchMessageW(&msg);
         }
     }
 


### PR DESCRIPTION
## Purpose

This is a continuation of: https://github.com/reactos/reactos/pull/7160

As part of fixing some bugs, they extend the tests to include more detailed testing of rendering functions. In this PR, I am extending the RedrawWindow testing to include tests of all flags. As part of the testing, I am also testing the 2-point states of the render areas.

## Proposed changes

I left the original test unchanged in a separate function GetMessageRedrawWindowTest. For the flag tests I created the FlagsRedrawWindowTest function.The function sequentially tests the RedrawWindow with different flag combinations and compares the results with those found from Windows XP/Windows 11 (the values for both versions are identical).

The API test turned out well in ReactOS, the only deviation was that in many cases (whenever the RDW_INVALIDATE flag is present) a WM_ERASEBKGND message is received after the window is rendered without rendering with the RDW_ERASE flag.
(This is what I'm focusing on now in https://github.com/turican0/reactos/tree/fix-RDW_ERASE-in-co_UserRedrawWindow, but before I merge it, I want to create more API tests.)

## TODO

- [ ] Review [test results](https://github.com/reactos/reactos/pull/7297#issuecomment-2484171986).
