### PR TITLE
[SHELL32] Fix keyboard input selection in setup

### DIFF
--- a/dll/win32/shell32/wine/control.c
+++ b/dll/win32/shell32/wine/control.c
@@ -1202,11 +1202,9 @@ void WINAPI Control_RunDLLW(HWND hWnd, HINSTANCE hInst, LPCWSTR cmd, DWORD nCmdS
 
     ptr2 = wcschr(cmd, dot);
     if (ptr2)
-    {
         wcsncpy(ext, ptr2 + 1, 3);
-    }
 
-    GoodExt = wcsicmp(ext, L"DLL") == 0 || wcscmp(ext, L"CPL") == 0;
+    GoodExt = wcsicmp(ext, L"DLL") == 0 || wcsicmp(ext, L"CPL") == 0;
 
 #else
 

--- a/dll/win32/shell32/wine/control.c
+++ b/dll/win32/shell32/wine/control.c
@@ -1183,7 +1183,8 @@ void WINAPI Control_RunDLLW(HWND hWnd, HINSTANCE hInst, LPCWSTR cmd, DWORD nCmdS
     TRACE("(%p, %p, %s, 0x%08x)\n",
           hWnd, hInst, debugstr_w(cmd), nCmdShow);
 
-/* If DLL search 'cmd' for first comma. If the remaining length is 2(@1 or ,1) or 3(,@1)
+/* Search 'cmd' for first comma. If the remaining length is either
+ * 0(only ext or , only), 1(,, or ,1), 2(,,1 or ,@1) or 3(,,@1),
  * then replace char after the extention with UNICODE_NULL. */
 
     buffer = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(*buffer) * (nLen + 1));
@@ -1216,7 +1217,7 @@ void WINAPI Control_RunDLLW(HWND hWnd, HINSTANCE hInst, LPCWSTR cmd, DWORD nCmdS
         Control_DoWindow(&panel, hWnd, hInst);
     } else {
 #ifdef __REACTOS__
-    if ((nLen == 2 || nLen == 3) && bDLLExt)
+    if ((nLen >= 0 && nLen < 4) && bDLLExt)
     {
         /* buffer char at size of cmd + .ext */
         buffer[ptr2 - cmd + (UINT_PTR)lstrlenW(L".ext")] = UNICODE_NULL;


### PR DESCRIPTION
## Purpose

_Enable Control_RunDLL for .DLL files to ignore multiple comma separated formats._

JIRA issue: [CORE-19580](https://jira.reactos.org/browse/CORE-19580)

## Proposed changes

_Enable all three of the options below to display the input settings control panel._
1) rundll32.exe shell32.dll,Control_RunDLL input.dll
2) rundll32.exe shell32.dll,Control_RunDLL input.dll,@1
3) rundll32.exe shell32.dll,Control_RunDLL input.dll,,@1

Testbot Results:
refs/pull/7300/merge on top of 0.4.15-dev-8610-g814f3a1

KVM:  https://reactos.org/testman/compare.php?ids=97557,97568,97570 LGTM
VBox: https://reactos.org/testman/compare.php?ids=97558,97569,97574 LGTM