### PR TITLE
[USETUP] Fix handling of 0 sized files in the cab

### DIFF
--- a/base/setup/usetup/spapisup/cabinet.c
+++ b/base/setup/usetup/spapisup/cabinet.c
@@ -1104,6 +1104,48 @@ CabinetExtractFile(
             }
         }
 
+        if (!ConvertDosDateTimeToFileTime(Search->File->FileDate,
+                                          Search->File->FileTime,
+                                          &FileTime))
+        {
+            DPRINT1("DosDateTimeToFileTime() failed\n");
+            Status = CAB_STATUS_CANNOT_WRITE;
+            goto CloseDestFile;
+        }
+
+        NtStatus = NtQueryInformationFile(DestFile,
+                                          &IoStatusBlock,
+                                          &FileBasic,
+                                          sizeof(FILE_BASIC_INFORMATION),
+                                          FileBasicInformation);
+        if (!NT_SUCCESS(NtStatus))
+        {
+            DPRINT("NtQueryInformationFile() failed (%x)\n", NtStatus);
+        }
+        else
+        {
+            memcpy(&FileBasic.LastAccessTime, &FileTime, sizeof(FILETIME));
+
+            NtStatus = NtSetInformationFile(DestFile,
+                                            &IoStatusBlock,
+                                            &FileBasic,
+                                            sizeof(FILE_BASIC_INFORMATION),
+                                            FileBasicInformation);
+            if (!NT_SUCCESS(NtStatus))
+            {
+                DPRINT("NtSetInformationFile() failed (%x)\n", NtStatus);
+            }
+        }
+
+        SetAttributesOnFile(Search->File, DestFile);
+
+        /* Nothing more to do for 0 sized files */
+        if (Search->File->FileSize == 0)
+        {
+            Status = CAB_STATUS_SUCCESS;
+            goto CloseDestFile;
+        }
+
         MaxDestFileSize.QuadPart = Search->File->FileSize;
         NtStatus = NtCreateSection(&DestFileSection,
                                    SECTION_ALL_ACCESS,
@@ -1139,40 +1181,6 @@ CabinetExtractFile(
         }
 
         CurrentDestBuffer = DestFileBuffer;
-        if (!ConvertDosDateTimeToFileTime(Search->File->FileDate,
-                                          Search->File->FileTime,
-                                          &FileTime))
-        {
-            DPRINT1("DosDateTimeToFileTime() failed\n");
-            Status = CAB_STATUS_CANNOT_WRITE;
-            goto UnmapDestFile;
-        }
-
-        NtStatus = NtQueryInformationFile(DestFile,
-                                          &IoStatusBlock,
-                                          &FileBasic,
-                                          sizeof(FILE_BASIC_INFORMATION),
-                                          FileBasicInformation);
-        if (!NT_SUCCESS(NtStatus))
-        {
-            DPRINT("NtQueryInformationFile() failed (%x)\n", NtStatus);
-        }
-        else
-        {
-            memcpy(&FileBasic.LastAccessTime, &FileTime, sizeof(FILETIME));
-
-            NtStatus = NtSetInformationFile(DestFile,
-                                            &IoStatusBlock,
-                                            &FileBasic,
-                                            sizeof(FILE_BASIC_INFORMATION),
-                                            FileBasicInformation);
-            if (!NT_SUCCESS(NtStatus))
-            {
-                DPRINT("NtSetInformationFile() failed (%x)\n", NtStatus);
-            }
-        }
-
-        SetAttributesOnFile(Search->File, DestFile);
     }
 
     /* Call extract event handler */


### PR DESCRIPTION
## Purpose

Fixes copying files of size 0 (like foobar.exe.local) from the cab during install.

## Test
✅ KVM x86: https://reactos.org/testman/compare.php?ids=98071,98073,98077

