### PR TITLE
[NTUSER] Add multiple hwnd/pwnd to one DC

### DIFF
--- a/win32ss/user/ntuser/dce.h
+++ b/win32ss/user/ntuser/dce.h
@@ -14,21 +14,22 @@ typedef enum
     DCE_WINDOW_DC   /* This is a window DC (style CS_OWNDC) */
 } DCE_TYPE, *PDCE_TYPE;
 
+typedef struct _DCEPWND_TYPE
+{
+    LIST_ENTRY Entry;
+    HWND hwnd;
+    PWND pwnd;
+} DCEPWND_TYPE, *PDCEPWND_TYPE;
+
 typedef struct tagDCE
 {
     LIST_ENTRY   List;
     HDC          hDC;
-    HWND         hwndCurrent;
-    PWND         pwndOrg;
-    PWND         pwndClip;
-    PWND         pwndRedirect;
+    LIST_ENTRY listPwndCurrent;
     HRGN         hrgnClip;
-    HRGN         hrgnClipPublic;
-    HRGN         hrgnSavedVis;
     DWORD        DCXFlags;
     PTHREADINFO  ptiOwner;
     PPROCESSINFO ppiOwner;
-    struct _MONITOR* pMonitor;
 } DCE, *PDCE;
 
 /* internal DCX flags, see psdk/winuser.h for the rest */

--- a/win32ss/user/ntuser/dce.h
+++ b/win32ss/user/ntuser/dce.h
@@ -25,7 +25,7 @@ typedef struct tagDCE
 {
     LIST_ENTRY   List;
     HDC          hDC;
-    LIST_ENTRY listPwndCurrent;
+    LIST_ENTRY   listPwndCurrent;
     HRGN         hrgnClip;
     DWORD        DCXFlags;
     PTHREADINFO  ptiOwner;

--- a/win32ss/user/ntuser/windc.c
+++ b/win32ss/user/ntuser/windc.c
@@ -483,10 +483,7 @@ DceReleaseDCHwnd(DCE *dce, HWND hwnd, BOOL EndPaint)
       if (!(dce->DCXFlags & DCX_NORESETATTRS))
       {
           // Clean the DC
-          if (!IntGdiCleanDC(dce->hDC))
-          {
-              return 0;
-          }
+         if (!IntGdiCleanDC(dce->hDC)) return 0;
 
          if (dce->DCXFlags & DCX_DCEDIRTY)
          {

--- a/win32ss/user/ntuser/windc.c
+++ b/win32ss/user/ntuser/windc.c
@@ -677,7 +677,6 @@ UserGetDCEx(PWND Wnd OPTIONAL, HANDLE ClipRegion, ULONG Flags)
          Dce = DceAllocDCE(NULL, DCE_CACHE_DC);
       }
       if (Dce == NULL) return NULL;
-      
       StructDceInit(Dce);
       StructDceAddPwnd(Dce, Wnd);
    }


### PR DESCRIPTION
## Purpose

While searching for bugs in GetDCEx, I found that reactos now only saves the first hwnd/pwnd to DC. Based on tests with windows, I found that this is not the correct implementation. E.g. when a DC exists for two hwnd and the original hwnd disappears, in many cases the hwnd for that DC should change to the next hwnd. Before this patch the extended https://github.com/reactos/reactos/pull/7296 show 40 failures, after this patch 19/21 failures(two errors only appear sometimes).

## Proposed changes

In dce.h I changed the format of the DCE header to listPwndCurrent instead of hwndCurrent, and removed the unused items (if anyone thinks they make sense, we can return them).
I added functions to windc.c that work with the given sheet, add/remove/delete/return the given hwnd/pwnd in the DC sheet and replaced them at the given places in the code.
