### PR TITLE
[KEYBOARD] Fix left key code in extended_key_names

### DIFF
--- a/dll/keyboard/kbdbe/kbdbe.c
+++ b/dll/keyboard/kbdbe/kbdbe.c
@@ -348,7 +348,7 @@ ROSDATA VSC_LPWSTR extended_key_names[] = {
   { 0x47, L"Home" },
   { 0x48, L"Up" },
   { 0x49, L"Page Up" },
-  { 0x4a, L"Left" },
+  { 0x4b, L"Left" },
   { 0x4c, L"Center" },
   { 0x4d, L"Right" },
   { 0x4f, L"End" },

--- a/dll/keyboard/kbddv/kbddv.c
+++ b/dll/keyboard/kbddv/kbddv.c
@@ -334,7 +334,7 @@ ROSDATA VSC_LPWSTR extended_key_names[] = {
   { 0x47, L"Home" },
   { 0x48, L"Up" },
   { 0x49, L"Page Up" },
-  { 0x4a, L"Left" },
+  { 0x4b, L"Left" },
   { 0x4c, L"Center" },
   { 0x4d, L"Right" },
   { 0x4f, L"End" },

--- a/dll/keyboard/kbdest/kbdest.c
+++ b/dll/keyboard/kbdest/kbdest.c
@@ -335,7 +335,7 @@ ROSDATA VSC_LPWSTR extended_key_names[] = {
   { 0x47, L"Home" },
   { 0x48, L"Up" },
   { 0x49, L"Page Up" },
-  { 0x4a, L"Left" },
+  { 0x4b, L"Left" },
   { 0x4c, L"Center" },
   { 0x4d, L"Right" },
   { 0x4f, L"End" },

--- a/dll/keyboard/kbdfr/kbdfr.c
+++ b/dll/keyboard/kbdfr/kbdfr.c
@@ -408,7 +408,7 @@ ROSDATA VSC_LPWSTR extended_key_names[] = {
   { 0x47, L"Home" },
   { 0x48, L"Up" },
   { 0x49, L"Page Up" },
-  { 0x4a, L"Left" },
+  { 0x4b, L"Left" },
   { 0x4c, L"Center" },
   { 0x4d, L"Right" },
   { 0x4f, L"End" },

--- a/dll/keyboard/kbdhe/kbdhe.c
+++ b/dll/keyboard/kbdhe/kbdhe.c
@@ -366,7 +366,7 @@ ROSDATA VSC_LPWSTR extended_key_names[] = {
   { 0x47, L"Home" },
   { 0x48, L"Up" },
   { 0x49, L"Page Up" },
-  { 0x4a, L"Left" },
+  { 0x4b, L"Left" },
   { 0x4c, L"Center" },
   { 0x4d, L"Right" },
   { 0x4f, L"End" },

--- a/dll/keyboard/kbdheb/kbdheb.c
+++ b/dll/keyboard/kbdheb/kbdheb.c
@@ -457,7 +457,7 @@ ROSDATA VSC_LPWSTR extended_key_names[] =
   { 0x47, L"Home" },
   { 0x48, L"Up" },
   { 0x49, L"Page Up" },
-  { 0x4a, L"Left" },
+  { 0x4b, L"Left" },
   { 0x4c, L"Center" },
   { 0x4d, L"Right" },
   { 0x4f, L"End" },

--- a/dll/keyboard/kbdhu/kbdhu.c
+++ b/dll/keyboard/kbdhu/kbdhu.c
@@ -341,7 +341,7 @@ ROSDATA VSC_LPWSTR extended_key_names[] = {
   { 0x47, L"Home" },
   { 0x48, L"Up" },
   { 0x49, L"Page Up" },
-  { 0x4a, L"Left" },
+  { 0x4b, L"Left" },
   { 0x4c, L"Center" },
   { 0x4d, L"Right" },
   { 0x4f, L"End" },

--- a/dll/keyboard/kbdit/kbdit.c
+++ b/dll/keyboard/kbdit/kbdit.c
@@ -395,7 +395,7 @@ ROSDATA VSC_LPWSTR extended_key_names[] = {
   { 0x47, L"Home" },
   { 0x48, L"Up" },
   { 0x49, L"Page Up" },
-  { 0x4a, L"Left" },
+  { 0x4b, L"Left" },
   { 0x4c, L"Center" },
   { 0x4d, L"Right" },
   { 0x4f, L"End" },

--- a/dll/keyboard/kbdkor/kbdkor.c
+++ b/dll/keyboard/kbdkor/kbdkor.c
@@ -341,7 +341,7 @@ ROSDATA VSC_LPWSTR extended_key_names[] = {
   { 0x47, L"Home" },
   { 0x48, L"Up" },
   { 0x49, L"Page Up" },
-  { 0x4a, L"Left" },
+  { 0x4b, L"Left" },
   { 0x4c, L"Center" },
   { 0x4d, L"Right" },
   { 0x4f, L"End" },

--- a/dll/keyboard/kbdlt1/kbdlt1.c
+++ b/dll/keyboard/kbdlt1/kbdlt1.c
@@ -333,7 +333,7 @@ ROSDATA VSC_LPWSTR extended_key_names[] = {
   { 0x47, L"Home" },
   { 0x48, L"Up" },
   { 0x49, L"Page Up" },
-  { 0x4a, L"Left" },
+  { 0x4b, L"Left" },
   { 0x4c, L"Center" },
   { 0x4d, L"Right" },
   { 0x4f, L"End" },

--- a/dll/keyboard/kbdlv/kbdlv.c
+++ b/dll/keyboard/kbdlv/kbdlv.c
@@ -337,7 +337,7 @@ ROSDATA VSC_LPWSTR extended_key_names[] = {
   { 0x47, L"Home" },
   { 0x48, L"Up" },
   { 0x49, L"Page Up" },
-  { 0x4a, L"Left" },
+  { 0x4b, L"Left" },
   { 0x4c, L"Center" },
   { 0x4d, L"Right" },
   { 0x4f, L"End" },

--- a/dll/keyboard/kbdpl/kbdpl.c
+++ b/dll/keyboard/kbdpl/kbdpl.c
@@ -341,7 +341,7 @@ ROSDATA VSC_LPWSTR extended_key_names[] = {
   { 0x47, L"Home" },
   { 0x48, L"Up" },
   { 0x49, L"Page Up" },
-  { 0x4a, L"Left" },
+  { 0x4b, L"Left" },
   { 0x4c, L"Center" },
   { 0x4d, L"Right" },
   { 0x4f, L"End" },

--- a/dll/keyboard/kbdpl1/kbdpl1.c
+++ b/dll/keyboard/kbdpl1/kbdpl1.c
@@ -347,7 +347,7 @@ ROSDATA VSC_LPWSTR extended_key_names[] = {
   { 0x47, L"Home" },
   { 0x48, L"Up" },
   { 0x49, L"Page Up" },
-  { 0x4a, L"Left" },
+  { 0x4b, L"Left" },
   { 0x4c, L"Center" },
   { 0x4d, L"Right" },
   { 0x4f, L"End" },

--- a/dll/keyboard/kbdsf/kbdsf.c
+++ b/dll/keyboard/kbdsf/kbdsf.c
@@ -358,7 +358,7 @@ ROSDATA VSC_LPWSTR extended_key_names[] = {
   { 0x47, L"Home" },
   { 0x48, L"Up" },
   { 0x49, L"Page Up" },
-  { 0x4a, L"Left" },
+  { 0x4b, L"Left" },
   { 0x4c, L"Center" },
   { 0x4d, L"Right" },
   { 0x4f, L"End" },

--- a/dll/keyboard/kbdsl/kbdsl.c
+++ b/dll/keyboard/kbdsl/kbdsl.c
@@ -343,7 +343,7 @@ ROSDATA VSC_LPWSTR extended_key_names[] = {
   { 0x47, L"Home" },
   { 0x48, L"Up" },
   { 0x49, L"Page Up" },
-  { 0x4a, L"Left" },
+  { 0x4b, L"Left" },
   { 0x4c, L"Center" },
   { 0x4d, L"Right" },
   { 0x4f, L"End" },

--- a/dll/keyboard/kbdsl1/kbdsl1.c
+++ b/dll/keyboard/kbdsl1/kbdsl1.c
@@ -343,7 +343,7 @@ ROSDATA VSC_LPWSTR extended_key_names[] = {
   { 0x47, L"Home" },
   { 0x48, L"Up" },
   { 0x49, L"Page Up" },
-  { 0x4a, L"Left" },
+  { 0x4b, L"Left" },
   { 0x4c, L"Center" },
   { 0x4d, L"Right" },
   { 0x4f, L"End" },

--- a/dll/keyboard/kbduk/kbduk.c
+++ b/dll/keyboard/kbduk/kbduk.c
@@ -346,7 +346,7 @@ ROSDATA VSC_LPWSTR extended_key_names[] = {
   { 0x47, L"Home" },
   { 0x48, L"Up" },
   { 0x49, L"Page Up" },
-  { 0x4a, L"Left" },
+  { 0x4b, L"Left" },
   { 0x4c, L"Center" },
   { 0x4d, L"Right" },
   { 0x4f, L"End" },


### PR DESCRIPTION
I found this bug while testing random games, the left key didn't work. After switching to other keyboard layouts (German, English) the problem disappeared. There are games (e.g. Doom 3 demo, Tomb Raider 2 demo) that somehow use this code from extended_key_names to determine which key the user pressed. It might be a good idea to check other keyboard layouts too, since I found that table inconsistent across languages.

JIRA issue: none
