### PR TITLE
[SHELL32] Pass and expand .lnk working directory

### DIFF
--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -1555,9 +1555,10 @@ static HRESULT ShellExecute_ContextMenuVerb(LPSHELLEXECUTEINFOW sei)
     if (FAILED_UNEXPECTEDLY(hr))
         return hr;
 
-    CComHeapPtr<char> verb, parameters;
+    CComHeapPtr<char> verb, parameters, dir;
     __SHCloneStrWtoA(&verb, sei->lpVerb);
     __SHCloneStrWtoA(&parameters, sei->lpParameters);
+    __SHCloneStrWtoA(&dir, sei->lpDirectory);
 
     BOOL fDefault = StrIsNullOrEmpty(sei->lpVerb);
     CMINVOKECOMMANDINFOEX ici = { sizeof(ici) };
@@ -1571,6 +1572,8 @@ static HRESULT ShellExecute_ContextMenuVerb(LPSHELLEXECUTEINFOW sei)
     ici.hwnd = sei->hwnd;
     ici.lpParameters = parameters;
     ici.lpParametersW = sei->lpParameters;
+    ici.lpDirectory = dir;
+    ici.lpDirectoryW = sei->lpDirectory;
     ici.dwHotKey = sei->dwHotKey;
     ici.hIcon = sei->hIcon;
     if (ici.fMask & (CMIC_MASK_HASLINKNAME | CMIC_MASK_HASTITLE))


### PR DESCRIPTION
Recent (unrelated) changes to execute shortcut targets with SEE_MASK_INVOKEIDLIST instead of SEE_MASK_IDLIST exposed a bug in shlexec.cpp where the directory was not passed along. In the uncommon case where the shortcut has no PIDL, we manually expand the directory in the one case where that matters.