### PR TITLE
[WINETESTS] Fix warnings when compiling comctl32_winetest

### DIFF
--- a/modules/rostests/winetests/comctl32/CMakeLists.txt
+++ b/modules/rostests/winetests/comctl32/CMakeLists.txt
@@ -47,6 +47,11 @@ if(MSVC AND ARCH STREQUAL "amd64")
     target_compile_options(comctl32_winetest PRIVATE /wd4334)
 endif()
 
+if(MSVC)
+    #  warning C4045: 'large_truncated_80_w': array bounds overflow
+    target_compile_options(comctl32_winetest PRIVATE /wd4045)
+endif()
+
 target_compile_options(comctl32_winetest PRIVATE $<$<NOT:$<C_COMPILER_ID:MSVC>>:-Wno-format>)
 
 set_module_type(comctl32_winetest win32cui)

--- a/modules/rostests/winetests/comctl32/rebar.c
+++ b/modules/rostests/winetests/comctl32/rebar.c
@@ -18,6 +18,10 @@
  */
 
 /* make sure the structures work with a comctl32 v5.x */
+#ifdef __REACTOS__
+#undef _WIN32_WINNT
+#undef _WIN32_IE
+#endif
 #define _WIN32_WINNT 0x500
 #define _WIN32_IE 0x500
 

--- a/modules/rostests/winetests/comctl32/static.c
+++ b/modules/rostests/winetests/comctl32/static.c
@@ -20,7 +20,9 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#ifndef __REACTOS__
 #define STRICT
+#endif
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include "commctrl.h"


### PR DESCRIPTION
## Purpose

fix warnings when compiling comctl32_winetest
the comctl32 winetest just does a few things so properly mark the ros diff.

```
[5960/7554] Building C object modules\...iles\comctl32_winetest.dir\pager.c.obj
modules\rostests\winetests\comctl32\pager.c(43): warning C4045: 'large_truncated_80_w': array bounds overflow

[5961/7554] Building C object modules\...iles\comctl32_winetest.dir\rebar.c.obj
modules\rostests\winetests\comctl32\rebar.c(21): warning C4005: '_WIN32_WINNT': macro redefinition
sdk\include\psdk\sdkddkver.h(156): note: see previous definition of '_WIN32_WINNT'
modules\rostests\winetests\comctl32\rebar.c(22): warning C4005: '_WIN32_IE': macro redefinition
sdk\include\psdk\sdkddkver.h(189): note: see previous definition of '_WIN32_IE'

[5962/7554] Building C object modules\...les\comctl32_winetest.dir\static.c.obj
modules\rostests\winetests\comctl32\static.c(23): warning C4005: 'STRICT': macro redefinition
sdk\include\psdk\windef.h(25): note: see previous definition of 'STRICT'
```


Addendum to #6789 
