### PR TITLE
[COMCTL32] Fix comctl32 edit control caret positioning in notepad

### DIFF
--- a/dll/win32/comctl32/edit.c
+++ b/dll/win32/comctl32/edit.c
@@ -1050,7 +1050,15 @@ static LRESULT EDIT_EM_PosFromChar(EDITSTATE *es, INT index, BOOL after_wrap)
 		lw = line_def->width;
 		w = es->format_rect.right - es->format_rect.left;
 		if (line_def->ssa)
+#ifdef __REACTOS__ /* CORE-19731 & match win32ss/user/user32/controls/edit.c */
+		{
 			ScriptStringCPtoX(line_def->ssa, (index - 1) - li, TRUE, &x);
+			x -= es->x_offset;
+		}
+		else
+#else
+			ScriptStringCPtoX(line_def->ssa, (index - 1) - li, TRUE, &x);
+#endif
 #ifdef __REACTOS__ /* CORE-15780 */
 		x = (lw > 0 ? es->x_offset : x - es->x_offset);
 #else


### PR DESCRIPTION
## Purpose

_Fix comctl32 edit.c caret positioning regression from Wine Sync to Wine 5.0 affecting notepad._

JIRA issue: [CORE-19731](https://jira.reactos.org/browse/CORE-19731)

## Proposed changes

_Restore older Wine code that handles caret position with ReactOS better._