### PR TITLE
Add shim to force “Aero” theme name

### DIFF
--- a/dll/appcompat/shims/layer/CMakeLists.txt
+++ b/dll/appcompat/shims/layer/CMakeLists.txt
@@ -4,6 +4,7 @@ include_directories(${SHIMLIB_DIR})
 spec2def(aclayers.dll layer.spec)
 
 list(APPEND SOURCE
+    aero.c
     dispmode.c
     forcedxsetupsuccess.c
     ignoreloadlibrary.c

--- a/dll/appcompat/shims/layer/aero.c
+++ b/dll/appcompat/shims/layer/aero.c
@@ -1,0 +1,34 @@
+/*
+ * PROJECT:     ReactOS 'Layers' Shim library
+ * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
+ * PURPOSE:     Display settings related shims
+ * COPYRIGHT:   Copyright 2024 William Kent (wjk011@gmail.com)
+ */
+
+#include "string.h"
+#define WIN32_NO_STATUS
+#include <windef.h>
+#include <winbase.h>
+#include <shimlib.h>
+#include <strsafe.h>
+
+#define SHIM_NS             AeroThemeName
+#include <setup_shim.inl>
+
+HRESULT WINAPI SHIM_OBJ_NAME(GetCurrentThemeNameRedirect)(
+    LPWSTR pszThemeName, int cchThemeName,
+    LPWSTR pszColor, int cchColor,
+    LPWSTR pszSize, int cchSize)
+{
+    StringCbCopyW(pszThemeName, cchThemeName, L"Aero");
+    if (pszColor != NULL) StringCbCopyW(pszColor, cchColor, L"NormalColor");
+    if (pszSize != NULL) StringCbCopyW(pszSize, cchSize, L"Normal");
+
+    return S_OK;
+}
+
+#define SHIM_NUM_HOOKS 1
+#define SHIM_SETUP_HOOKS \
+    SHIM_HOOK(0, "UXTHEME.DLL", "GetCurrentThemeName", SHIM_OBJ_NAME(GetCurrentThemeNameRedirect))
+
+#include <implement_shim.inl>


### PR DESCRIPTION
## Purpose

Some programs designed to run on Windows Vista and later assume that the theme is always named "Aero". On ReactOS the theme name can be anything. One example of such a program is WPF (both the .NET Framework and .NET 8/9 versions). Without a shim like this one, WPF would not be able to determine its default resources and programs that use it would suffer severe visual issues, if not outright crash.

JIRA issue: none

## Proposed changes

- Add a shim that overrides `uxtheme!GetCurrentThemeName` to always return `Aero`/`NormalColor`.

## TODO

I am not 100% sure that the size returned by Windows is `Normal`, but I do not have access to a Windows machine to check.