### PR TITLE
[NOTEPAD] Display error code if no error string is available

### DIFF
--- a/base/applications/notepad/dialog.c
+++ b/base/applications/notepad/dialog.c
@@ -48,7 +48,8 @@ VOID ShowLastError(VOID)
     if (error != NO_ERROR)
     {
         LPTSTR lpMsgBuf = NULL;
-        TCHAR szTitle[MAX_STRING_LEN], szFallback[42], *pszMessage = szFallback;
+        TCHAR szTitle[MAX_STRING_LEN];
+        TCHAR szFallback[42], *pszMessage = szFallback;
 
         LoadString(Globals.hInstance, STRING_ERROR, szTitle, _countof(szTitle));
 
@@ -63,7 +64,7 @@ VOID ShowLastError(VOID)
         if (lpMsgBuf)
             pszMessage = lpMsgBuf;
         else
-            wsprintfW(szFallback, L"%d\n", error);
+            wsprintfW(szFallback, L"%d", error);
 
         MessageBox(Globals.hMainWnd, pszMessage, szTitle, MB_OK | MB_ICONERROR);
         LocalFree(lpMsgBuf);

--- a/base/applications/notepad/dialog.c
+++ b/base/applications/notepad/dialog.c
@@ -48,7 +48,7 @@ VOID ShowLastError(VOID)
     if (error != NO_ERROR)
     {
         LPTSTR lpMsgBuf = NULL;
-        TCHAR szTitle[MAX_STRING_LEN];
+        TCHAR szTitle[MAX_STRING_LEN], szFallback[42], *pszMessage = szFallback;
 
         LoadString(Globals.hInstance, STRING_ERROR, szTitle, _countof(szTitle));
 
@@ -60,7 +60,12 @@ VOID ShowLastError(VOID)
                       0,
                       NULL);
 
-        MessageBox(Globals.hMainWnd, lpMsgBuf, szTitle, MB_OK | MB_ICONERROR);
+        if (lpMsgBuf)
+            pszMessage = lpMsgBuf;
+        else
+            wsprintfW(szFallback, L"%d\n", error);
+
+        MessageBox(Globals.hMainWnd, pszMessage, szTitle, MB_OK | MB_ICONERROR);
         LocalFree(lpMsgBuf);
     }
 }


### PR DESCRIPTION
When `FormatMessage` is unable to find a string for the error, just displaying the error code is much better than an empty string.

![Error](https://github.com/user-attachments/assets/f5c5c4cc-bd22-443c-b8d2-9983a8c897f8)
