### PR TITLE
[NOTEPAD] Don't handle main window accelerators in Find dialog

### DIFF
--- a/base/applications/notepad/main.c
+++ b/base/applications/notepad/main.c
@@ -637,8 +637,8 @@ int WINAPI _tWinMain(HINSTANCE hInstance, HINSTANCE prev, LPTSTR cmdline, int sh
 
     while (GetMessage(&msg, NULL, 0, 0))
     {
-        if (!TranslateAccelerator(Globals.hMainWnd, hAccel, &msg) &&
-            !IsDialogMessage(Globals.hFindReplaceDlg, &msg))
+        if ((!Globals.hFindReplaceDlg || !IsDialogMessage(Globals.hFindReplaceDlg, &msg)) &&
+            !TranslateAccelerator(Globals.hMainWnd, hAccel, &msg))
         {
             TranslateMessage(&msg);
             DispatchMessage(&msg);


### PR DESCRIPTION
Ctrl+A,Z,C,X etc. must not be handled by the main window when the Find dialog is active.