### PR TITLE
[WIN32K:ENG] Fix return value in EngAlphaBlend

### DIFF
--- a/win32ss/gdi/eng/alphablend.c
+++ b/win32ss/gdi/eng/alphablend.c
@@ -131,6 +131,7 @@ EngAlphaBlend(
             break;
 
         case DC_RECT:
+            Ret = TRUE;
             ClipRect.left = ClipRegion->rclBounds.left + Translate.x;
             ClipRect.right = ClipRegion->rclBounds.right + Translate.x;
             ClipRect.top = ClipRegion->rclBounds.top + Translate.y;


### PR DESCRIPTION
## Purpose

Fixes the return value, when the clip rect and the output rect do not intersect.

## Tests
- ✅ KVM x86: https://reactos.org/testman/compare.php?ids=97706,97709,97712,97715
- 