### PR TITLE
[NTOS:KE/x64] Improve exception handling

### DIFF
--- a/ntoskrnl/ke/amd64/trap.S
+++ b/ntoskrnl/ke/amd64/trap.S
@@ -461,8 +461,11 @@ IntsDisabled:
 
 PageFaultError:
 
-    /* Set parameter 1 to error code */
+    /* Set parameter 1 to write/execute flag.
+       See https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-exception_record */
     mov r9d, [rbp + KTRAP_FRAME_ErrorCode]
+    shr r9d, 1
+    and r9d, 9
 
     /* Set parameter 2 to faulting address */
     mov r10, cr2  // Param2 = faulting address

--- a/sdk/lib/rtl/amd64/unwind.c
+++ b/sdk/lib/rtl/amd64/unwind.c
@@ -679,7 +679,7 @@ RtlpUnwindInternal(
     ULONG64 ImageBase, EstablisherFrame;
     CONTEXT UnwindContext;
 
-    /* Get the current stack limits and registration frame */
+    /* Get the current stack limits */
     RtlpGetStackLimits(&StackLow, &StackHigh);
 
     /* If we have a target frame, then this is our high limit */
@@ -708,8 +708,11 @@ RtlpUnwindInternal(
             UnwindContext.Rip = *(DWORD64*)UnwindContext.Rsp;
             UnwindContext.Rsp += sizeof(DWORD64);
 
-            /* Copy the context back for the next iteration */
-            *ContextRecord = UnwindContext;
+            if (HandlerType == UNW_FLAG_UHANDLER)
+            {
+                /* Copy the context back for the next iteration */
+                *ContextRecord = UnwindContext;
+            }
             continue;
         }
 
@@ -756,7 +759,7 @@ RtlpUnwindInternal(
 
             /* Log the exception if it's enabled */
             RtlpCheckLogException(ExceptionRecord,
-                                  ContextRecord,
+                                  &UnwindContext,
                                   &DispatcherContext,
                                   sizeof(DispatcherContext));
 
@@ -844,8 +847,11 @@ RtlpUnwindInternal(
             break;
         }
 
-        /* We have successfully unwound a frame. Copy the unwind context back. */
-        *ContextRecord = UnwindContext;
+        if (HandlerType == UNW_FLAG_UHANDLER)
+        {
+            /* We have successfully unwound a frame. Copy the unwind context back. */
+            *ContextRecord = UnwindContext;
+        }
     }
 
     if (ExceptionRecord->ExceptionCode != STATUS_UNWIND_CONSOLIDATE)


### PR DESCRIPTION
## Purpose

Improve handling of exceptions.

## Proposed changes

- [NTOS:KE/x64] Do not overwrite the original context during exception handling
- [NTOS:KE/x64] Fix exception information on page faults

## Tests
- ✅ KVM x64: https://reactos.org/testman/compare.php?ids=97756,97760,97774,97782
