### PR TITLE
[SHELL32] Make Recycle Bin PIDL data handling more robust

### DIFF
--- a/dll/win32/shell32/folders/CRecycleBin.cpp
+++ b/dll/win32/shell32/folders/CRecycleBin.cpp
@@ -782,7 +782,7 @@ HRESULT WINAPI CRecycleBin::GetDetailsOf(PCUITEMID_CHILD pidl, UINT iColumn, LPS
                 memcpy((LPVOID)buffer, pFileDetails->szName, Length * sizeof(WCHAR));
             }
             buffer[Length] = UNICODE_NULL;
-            if (!buffer[2] && buffer[0] && buffer[1] == L':')
+            if (buffer[0] && buffer[1] == L':' && !buffer[2])
             {
                 buffer[2] = L'\\';
                 buffer[3] = UNICODE_NULL;


### PR DESCRIPTION
Notes:
- This does not fix the underlying issue of the Recycle Bin not working correctly in recent builds. It simply prevents Explorer from crashing when given an invalid PIDL. The core issue is from https://github.com/reactos/reactos/commit/22b913928f4a1d13120b0ec7a1c6889d37ec0e3a #7173 

