### PR TITLE
[VIDEOPRT] HACK the resource conflict

### DIFF
--- a/win32ss/drivers/miniport/vbe/vbemp_reg.inf
+++ b/win32ss/drivers/miniport/vbe/vbemp_reg.inf
@@ -6,7 +6,6 @@ HKLM,"SYSTEM\CurrentControlSet\Services\vga","ImagePath",0x00020000,"system32\dr
 HKLM,"SYSTEM\CurrentControlSet\Services\vga","Start",0x00010001,0x00000001
 HKLM,"SYSTEM\CurrentControlSet\Services\vga","Type",0x00010001,0x00000001
 HKLM,"SYSTEM\CurrentControlSet\Services\vga","Tag",0x00010001,0x00000001
-HKLM,"SYSTEM\CurrentControlSet\Services\vga\Video","Service",0x00000000,"vga"
 
 HKLM,"SYSTEM\CurrentControlSet\Services\vga\Device0","InstalledDisplayDrivers",0x00010000,"framebuf"
 HKLM,"SYSTEM\CurrentControlSet\Services\vga\Device0","DefaultSettings.VRefresh",0x00010001,1

--- a/win32ss/drivers/miniport/vga/vga_reg.inf
+++ b/win32ss/drivers/miniport/vga/vga_reg.inf
@@ -6,7 +6,6 @@ HKLM,"SYSTEM\CurrentControlSet\Services\VgaSave","ImagePath",0x00020000,"system3
 HKLM,"SYSTEM\CurrentControlSet\Services\VgaSave","Start",0x00010001,0x00000004
 HKLM,"SYSTEM\CurrentControlSet\Services\VgaSave","Type",0x00010001,0x00000001
 HKLM,"SYSTEM\CurrentControlSet\Services\VgaSave","Tag",0x00010001,0x00000002
-HKLM,"SYSTEM\CurrentControlSet\Services\VgaSave\Video","Service",0x00000000,"VgaSave"
 HKLM,"SYSTEM\CurrentControlSet\Services\VgaSave\Device0","VgaCompatible",0x00010001,1
 
 HKLM,"SYSTEM\CurrentControlSet\Services\VgaSave\Device0","InstalledDisplayDrivers",0x00010000,"vgaddi"

--- a/win32ss/drivers/videoprt/resource.c
+++ b/win32ss/drivers/videoprt/resource.c
@@ -995,7 +995,10 @@ VideoPortVerifyAccessRanges(
     ExFreePoolWithTag(ResourceList, TAG_VIDEO_PORT);
 
     if (!NT_SUCCESS(Status) || ConflictDetected)
-        return ERROR_INVALID_PARAMETER;
+    {
+        DPRINT1("Videoprt - IoConflict has occured. HACK!");
+        return NO_ERROR; //Should Return: ERROR_INVALID_PARAMETER;
+    }
     else
         return NO_ERROR;
 }


### PR DESCRIPTION
## Purpose

 HACK! the resource conflict

So why am i proposing this terrible hack?
ReactOS has no way to resolve this conflicts and this function reports honestly about the situation. 
The problem is on real hardware this will never succeed at the moment.

The symptom is a fat regression that's been plaguing ReactOS for awhile

This fixes the video driver initialization for pre 181.22 Nvidia GPUs and AMD cards.

Tests on:
R9 370
R9 270
HD 4770
Intel GMA 945 (Needs an extra hack)
Intel HD 3000 (needs two extra hacks)
and several more.

We have a hack in a similar vein here:
https://github.com/reactos/reactos/blob/b82bf8ce167ae96dff2868461e82136b90b8c45f/ntoskrnl/io/pnpmgr/pnpres.c#L699-L700