### PR TITLE
[USER32] Use SEH when calling CALL_EXTERN_WNDPROC ...

### DIFF
--- a/win32ss/user/user32/windows/message.c
+++ b/win32ss/user/user32/windows/message.c
@@ -1543,10 +1543,6 @@ IntCallWindowProcW(BOOL IsAnsiProc,
 
       if (PreResult) goto Exit;
 
-      if (!Dialog)
-      Result = CALL_EXTERN_WNDPROC(WndProc, hWnd, Msg, wParam, lParam);
-      else
-      {
       _SEH2_TRY
       {
          Result = CALL_EXTERN_WNDPROC(WndProc, hWnd, Msg, wParam, lParam);
@@ -1556,7 +1552,6 @@ IntCallWindowProcW(BOOL IsAnsiProc,
          ERR("Exception Dialog unicode %p Msg %d pti %p Wndpti %p\n",WndProc, Msg,GetW32ThreadInfo(),pWnd->head.pti);
       }
       _SEH2_END;
-      }
 
       if (Hook && (MsgOverride || DlgOverride))
       {


### PR DESCRIPTION
in IntCallWindowProcW when IsAnsiProc is FALSE

## Purpose

_Fix crash in WPS Office 2016 install._

JIRA issue: [CORE-12033](https://jira.reactos.org/browse/CORE-12033)

## Proposed changes

_Use SEH2 in CALL_EXTERN_WNDPROC in IntCallWindowProcW when IsAnsiProc is FALSE._
_This supercedes PR #6870._