### PR TITLE
[RTL][KERNEL32][ROSAUTOTEST] Disable debug prompts during autotest

### DIFF
--- a/dll/win32/kernel32/client/proc.c
+++ b/dll/win32/kernel32/client/proc.c
@@ -1628,6 +1628,12 @@ FatalExit(IN int ExitCode)
     CHAR Action[2];
     DbgPrint("FatalExit...\n\n");
 
+    /* Check for reactos specific flag (set by rosautotest) */
+    if (RtlGetNtGlobalFlags() & FLG_DISABLE_DEBUG_PROMPTS)
+    {
+        RtlRaiseStatus(STATUS_FATAL_APP_EXIT);
+    }
+
     while (TRUE)
     {
         DbgPrompt("A (Abort), B (Break), I (Ignore)? ", Action, sizeof(Action));

--- a/sdk/include/ndk/pstypes.h
+++ b/sdk/include/ndk/pstypes.h
@@ -83,7 +83,8 @@ extern POBJECT_TYPE NTSYSAPI PsJobType;
 #define FLG_ENABLE_HANDLE_TYPE_TAGGING          0x01000000
 #define FLG_HEAP_PAGE_ALLOCS                    0x02000000
 #define FLG_DEBUG_INITIAL_COMMAND_EX            0x04000000
-#define FLG_VALID_BITS                          0x07FFFFFF
+#define FLG_DISABLE_DEBUG_PROMPTS               0x08000000 // ReactOS-specific
+#define FLG_VALID_BITS                          0x0FFFFFFF
 
 //
 // Flags for NtCreateProcessEx

--- a/sdk/lib/rtl/assert.c
+++ b/sdk/lib/rtl/assert.c
@@ -42,6 +42,12 @@ RtlAssert(IN PVOID FailedAssertion,
                  (PSTR)FileName,
                  LineNumber);
 
+        /* Check for reactos specific flag (set by rosautotest) */
+        if (RtlGetNtGlobalFlags() & FLG_DISABLE_DEBUG_PROMPTS)
+        {
+            RtlRaiseStatus(STATUS_ASSERTION_FAILURE);
+        }
+
         /* Prompt for action */
         DbgPrompt("Break repeatedly, break Once, Ignore, "
                   "terminate Process or terminate Thread (boipt)? ",


### PR DESCRIPTION
This fixes timeouts + reboots for user mode assertion failures on the testbots. As a bonus it now shows a backtrace.
