### PR TITLE
[SPEC2DEF] Use explicit ordinals on MSVC, too

### DIFF
--- a/sdk/tools/spec2def/spec2def.c
+++ b/sdk/tools/spec2def/spec2def.c
@@ -781,8 +781,8 @@ OutputLine_def(FILE *fileDest, EXPORT *pexp)
     else
         OutputLine_def_GCC(fileDest, pexp);
 
-    /* On GCC builds we force ordinals */
-    if ((pexp->uFlags & FL_ORDINAL) || (!gbMSComp && !gbImportLib))
+    /* If it is not an import lib, we force ordinals */
+    if ((pexp->uFlags & FL_ORDINAL) || !gbImportLib)
     {
         fprintf(fileDest, " @%d", pexp->nOrdinal);
     }
@@ -1421,6 +1421,7 @@ ApplyOrdinals(EXPORT* pexports, unsigned cExports)
 {
     unsigned short i, j;
     char* used;
+    unsigned short firstOrdinal = 0xFFFF, firstIndex = 0;
 
     /* Allocate a table to mark used ordinals */
     used = malloc(65536);
@@ -1442,11 +1443,28 @@ ApplyOrdinals(EXPORT* pexports, unsigned cExports)
                 return -1;
             }
             used[pexports[i].nOrdinal] = 1;
+            if (pexports[i].nOrdinal < firstOrdinal)
+            {
+                firstOrdinal = pexports[i].nOrdinal;
+                firstIndex = i;
+            }
         }
     }
 
+    /* Check if we found an ordinal and it's larger than it's index */
+    if ((firstOrdinal != 0xFFFF) && (firstOrdinal > firstIndex))
+    {
+        /* We did. Calculate an appropriate starting ordinal. */
+        firstOrdinal -= firstIndex;
+    }
+    else
+    {
+        /* We didn't, so start with 1 */
+        firstOrdinal = 1;
+    }
+
     /* Pass 2: apply available ordinals */
-    for (i = 0, j = 1; i < cExports; i++)
+    for (i = 0, j = firstOrdinal; i < cExports; i++)
     {
         if ((pexports[i].uFlags & FL_ORDINAL) == 0 && pexports[i].bVersionIncluded)
         {
@@ -1640,13 +1658,10 @@ int main(int argc, char *argv[])
         return -1;
     }
 
-    if (!gbMSComp)
+    if (ApplyOrdinals(pexports, cExports) < 0)
     {
-        if (ApplyOrdinals(pexports, cExports) < 0)
-        {
-            fprintf(stderr, "error: could not apply ordinals!\n");
-            return -1;
-        }
+        fprintf(stderr, "error: could not apply ordinals!\n");
+        return -1;
     }
 
     if (pszDefFileName)


### PR DESCRIPTION
This prevents MSVC from reordering the exports in a way that doesn't match our spec file. Also improve the algorithm to apply ordinals, by starting with the first specified ordinal, possibly reserving ordinals for anything declared without an ordinal before.

Windows:
![grafik](https://github.com/user-attachments/assets/d6be885c-a34c-474d-a8b3-4f8393dc4ca8)

MSVC before:
![grafik](https://github.com/user-attachments/assets/09bb23c6-0e1c-4b55-805d-01517f0618d4)

MSVC after:
![grafik](https://github.com/user-attachments/assets/4573f6bb-0058-4644-a4ff-310c44ee9fab)

## Tests
- ✅ KVM x86: https://reactos.org/testman/compare.php?ids=98330,98340,98343,98346
- ✅ KVM x64: https://reactos.org/testman/compare.php?ids=98333,98341,98348,98349

