### PR TITLE
[SHELL32] Don't leak SetProp ATOM

### DIFF
--- a/dll/win32/shell32/brfolder.cpp
+++ b/dll/win32/shell32/brfolder.cpp
@@ -681,7 +681,7 @@ BrFolder_OnInitDialog(HWND hWnd, BrFolder *info)
     LPBROWSEINFOW lpBrowseInfo = info->lpBrowseInfo;
 
     info->hWnd = hWnd;
-    SetPropW(hWnd, L"__WINE_BRSFOLDERDLG_INFO", info);
+    SetWindowLongPtrW(hWnd, DWLP_USER, (LONG_PTR)info);
 
     if (lpBrowseInfo->ulFlags & BIF_NEWDIALOGSTYLE)
         FIXME("flags BIF_NEWDIALOGSTYLE partially implemented\n");
@@ -1225,7 +1225,7 @@ BrFolderDlgProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
     if (uMsg == WM_INITDIALOG)
         return BrFolder_OnInitDialog(hWnd, (BrFolder *)lParam);
 
-    BrFolder *info = (BrFolder *)GetPropW(hWnd, L"__WINE_BRSFOLDERDLG_INFO");
+    BrFolder *info = (BrFolder *)GetWindowLongPtrW(hWnd, DWLP_USER);
     if (!info)
         return 0;
 

--- a/dll/win32/shell32/shlfileop.cpp
+++ b/dll/win32/shell32/shlfileop.cpp
@@ -135,7 +135,7 @@ static INT_PTR ConfirmMsgBox_Paint(HWND hDlg)
     /* this will remap the rect to dialog coords */
     MapWindowPoints(GetDlgItem(hDlg, IDC_YESTOALL_MESSAGE), hDlg, (LPPOINT)&r, 2);
     hOldFont = (HFONT)SelectObject(hdc, (HFONT)SendDlgItemMessageW(hDlg, IDC_YESTOALL_MESSAGE, WM_GETFONT, 0, 0));
-    DrawTextW(hdc, (LPWSTR)GetPropW(hDlg, L"WINE_CONFIRM"), -1, &r, DT_NOPREFIX | DT_PATH_ELLIPSIS | DT_WORDBREAK);
+    DrawTextW(hdc, (LPWSTR)GetWindowLongPtrW(hDlg, DWLP_USER), -1, &r, DT_NOPREFIX | DT_PATH_ELLIPSIS | DT_WORDBREAK);
     SelectObject(hdc, hOldFont);
     EndPaint(hDlg, &ps);
 
@@ -153,7 +153,7 @@ static INT_PTR ConfirmMsgBox_Init(HWND hDlg, LPARAM lParam)
 
     SetWindowTextW(hDlg, info->lpszCaption);
     ShowWindow(GetDlgItem(hDlg, IDC_YESTOALL_MESSAGE), SW_HIDE);
-    SetPropW(hDlg, L"WINE_CONFIRM", info->lpszText);
+    SetWindowLongPtrW(hDlg, DWLP_USER, (LONG_PTR)info->lpszText);
     SendDlgItemMessageW(hDlg, IDC_YESTOALL_ICON, STM_SETICON, (WPARAM)info->hIcon, 0);
 
     /* compute the text height and resize the dialog */


### PR DESCRIPTION
MSDN says "The application must use the RemoveProp function to remove the entries" but SHELL32 fails to do this. In these two cases, using `SetProp` is pointless anyway since we own the dialog and can use `SetWindowLongPtr`.

On Windows, `SHBrowseForFolder` seems to use `GWLP_USERDATA` or `DWLP_USER` depending on if `BIF_NEWDIALOGSTYLE` is set. `DWLP_DLGPROC` is also different between the two so I'm guessing they have two separate implementations of that dialog.