### PR TITLE
[GDIPLUS] Fix for gdiplus/graphics.c regression with upgrade to GCC 8.4.0.

### DIFF
--- a/dll/win32/gdiplus/graphics.c
+++ b/dll/win32/gdiplus/graphics.c
@@ -3264,7 +3264,11 @@ GpStatus WINGDIPAPI GdipDrawImagePointsRect(GpGraphics *graphics, GpImage *image
 
             if (do_resampling)
             {
+#ifdef __REACTOS__  // CORE-19456
+                DOUBLE delta_xx, delta_xy, delta_yx, delta_yy;
+#else
                 REAL delta_xx, delta_xy, delta_yx, delta_yy;
+#endif
 
                 /* Transform the bits as needed to the destination. */
                 dst_data = dst_dyn_data = heap_alloc_zero(sizeof(ARGB) * (dst_area.right - dst_area.left) * (dst_area.bottom - dst_area.top));


### PR DESCRIPTION
This occurs on the ribbon bar when running Super Finder XT 1.6.3.2 from rapps

CORE-19456

## Purpose

_When the GCC compiler was updated from version 4.7.2 to 8.4.0 this was a regression._

JIRA issue: [CORE-19456](https://jira.reactos.org/browse/CORE-19456)

## Proposed changes

_Due to some tiny rounding errors in the least significant digits of some math a comparison started to fail._
_As a workaround, I was able to fix this by increasing the precision of some of the calculations._
_Four REAL defined variables were changed to DOUBLE and this made the comparison work again._
_This occurs at the boundary line between two separate graphic objects._
_The upper area is a consistent fill and the lower one is a gradient fill._
_This is visible in the screen captures below._

Testbot Results:
refs/pull/7348/merge on 0.4.16-dev-37-gfd3c571

KVM:  https://reactos.org/testman/compare.php?ids=97944,97951 LGTM
VBox: https://reactos.org/testman/compare.php?ids=97943,97953 LGTM

Before:

![Super_Finder_XT_Bad](https://github.com/user-attachments/assets/a599aae4-bd84-41a9-919b-5dfa38768bda)

After:

![Super_Finder_XT_Good](https://github.com/user-attachments/assets/727046f0-07a7-48ad-827c-9745fc0930e1)
