### PR TITLE
[RAPPS] Use different mutex and title for AppWiz mode

### DIFF
--- a/base/applications/rapps/gui.cpp
+++ b/base/applications/rapps/gui.cpp
@@ -749,8 +749,7 @@ CMainWindow::GetWndClassInfo()
 HWND
 CMainWindow::Create()
 {
-    CStringW szWindowName;
-    szWindowName.LoadStringW(m_bAppwizMode ? IDS_APPWIZ_TITLE : IDS_APPTITLE);
+    const CStringW szWindowName(MAKEINTRESOURCEW(m_bAppwizMode ? IDS_APPWIZ_TITLE : IDS_APPTITLE));
 
     RECT r = {
         (SettingsInfo.bSaveWndPos ? SettingsInfo.Left : CW_USEDEFAULT),

--- a/base/applications/rapps/gui.cpp
+++ b/base/applications/rapps/gui.cpp
@@ -750,7 +750,7 @@ HWND
 CMainWindow::Create()
 {
     CStringW szWindowName;
-    szWindowName.LoadStringW(IDS_APPTITLE);
+    szWindowName.LoadStringW(m_bAppwizMode ? IDS_APPWIZ_TITLE : IDS_APPTITLE);
 
     RECT r = {
         (SettingsInfo.bSaveWndPos ? SettingsInfo.Left : CW_USEDEFAULT),

--- a/base/applications/rapps/unattended.cpp
+++ b/base/applications/rapps/unattended.cpp
@@ -350,15 +350,18 @@ ParseCmdAndExecute(LPWSTR lpCmdLine, BOOL bIsFirstLaunch, int nCmdShow)
     {
         // Check whether the RAPPS MainWindow is already launched in another process
         HANDLE hMutex;
+        WCHAR szWindowText[200];
+        LPCWSTR pszMutex = bAppwizMode ? L"RAPPSAPPWIZ" : szWindowClass;
+        LoadStringW(hInst, bAppwizMode ? IDS_APPWIZ_TITLE : IDS_APPTITLE, szWindowText, _countof(szWindowText));
 
-        hMutex = CreateMutexW(NULL, FALSE, szWindowClass);
+        hMutex = CreateMutexW(NULL, FALSE, pszMutex);
         if ((!hMutex) || (GetLastError() == ERROR_ALREADY_EXISTS))
         {
             /* If already started, find its window */
             HWND hWindow;
             for (int wait = 2500, inter = 250; wait > 0; wait -= inter)
             {
-                if ((hWindow = FindWindowW(szWindowClass, NULL)) != NULL)
+                if ((hWindow = FindWindowW(szWindowClass, szWindowText)) != NULL)
                     break;
                 Sleep(inter);
             }

--- a/base/applications/rapps/unattended.cpp
+++ b/base/applications/rapps/unattended.cpp
@@ -350,9 +350,8 @@ ParseCmdAndExecute(LPWSTR lpCmdLine, BOOL bIsFirstLaunch, int nCmdShow)
     {
         // Check whether the RAPPS MainWindow is already launched in another process
         HANDLE hMutex;
-        WCHAR szWindowText[200];
+        CStringW szWindowText(MAKEINTRESOURCEW(bAppwizMode ? IDS_APPWIZ_TITLE : IDS_APPTITLE));
         LPCWSTR pszMutex = bAppwizMode ? L"RAPPSAPPWIZ" : szWindowClass;
-        LoadStringW(hInst, bAppwizMode ? IDS_APPWIZ_TITLE : IDS_APPTITLE, szWindowText, _countof(szWindowText));
 
         hMutex = CreateMutexW(NULL, FALSE, pszMutex);
         if ((!hMutex) || (GetLastError() == ERROR_ALREADY_EXISTS))
@@ -379,6 +378,7 @@ ParseCmdAndExecute(LPWSTR lpCmdLine, BOOL bIsFirstLaunch, int nCmdShow)
                 return FALSE;
             }
         }
+        szWindowText.Empty();
 
         CMainWindow wnd(&db, bAppwizMode);
         MainWindowLoop(&wnd, nCmdShow);

--- a/base/applications/rapps/unattended.cpp
+++ b/base/applications/rapps/unattended.cpp
@@ -349,11 +349,10 @@ ParseCmdAndExecute(LPWSTR lpCmdLine, BOOL bIsFirstLaunch, int nCmdShow)
     if (argc == 1 || bAppwizMode) // RAPPS is launched without options or APPWIZ mode is requested
     {
         // Check whether the RAPPS MainWindow is already launched in another process
-        HANDLE hMutex;
         CStringW szWindowText(MAKEINTRESOURCEW(bAppwizMode ? IDS_APPWIZ_TITLE : IDS_APPTITLE));
         LPCWSTR pszMutex = bAppwizMode ? L"RAPPSAPPWIZ" : szWindowClass;
 
-        hMutex = CreateMutexW(NULL, FALSE, pszMutex);
+        HANDLE hMutex = CreateMutexW(NULL, FALSE, pszMutex);
         if ((!hMutex) || (GetLastError() == ERROR_ALREADY_EXISTS))
         {
             /* If already started, find its window */

--- a/base/applications/rapps/unattended.cpp
+++ b/base/applications/rapps/unattended.cpp
@@ -350,7 +350,7 @@ ParseCmdAndExecute(LPWSTR lpCmdLine, BOOL bIsFirstLaunch, int nCmdShow)
     {
         // Check whether the RAPPS MainWindow is already launched in another process
         CStringW szWindowText(MAKEINTRESOURCEW(bAppwizMode ? IDS_APPWIZ_TITLE : IDS_APPTITLE));
-        LPCWSTR pszMutex = bAppwizMode ? L"RAPPSAPPWIZ" : szWindowClass;
+        LPCWSTR pszMutex = bAppwizMode ? L"RAPPWIZ" : szWindowClass;
 
         HANDLE hMutex = CreateMutexW(NULL, FALSE, pszMutex);
         if ((!hMutex) || (GetLastError() == ERROR_ALREADY_EXISTS))


### PR DESCRIPTION
This is a follow up to PR #6655. The two different modes needs separate mutex and window titles, otherwise you can end up stuck in AppWiz mode:

1) Run Rapps.exe /AppWiz (and don't close the window).
2) Run Rapps.exe. Opens existing instance, stuck in AppWiz mode.