### PR TITLE
[RAPPS] Correctly update the Install/Uninstall/... buttons

### DIFF
--- a/base/applications/rapps/appview.cpp
+++ b/base/applications/rapps/appview.cpp
@@ -1644,6 +1644,11 @@ CApplicationView::ProcessWindowMessage(
                                 ItemCheckStateChanged(FALSE, (LPVOID)pnic->lParam);
                             }
                         }
+
+                        /* Ensure that if there are any items still focused/selected,
+                         * the ID_INSTALL menu item and toolbar button stay enabled */
+                        if ((pnic->uChanged & LVIF_STATE) && !m_MainWindow->bUpdating)
+                            _UpdateInstallBtn();
                     }
                     break;
 
@@ -2039,25 +2044,19 @@ BOOL
 CApplicationView::SetDisplayAppType(APPLICATION_VIEW_TYPE AppType)
 {
     if (!m_ListView->SetDisplayAppType(AppType))
-    {
         return FALSE;
-    }
+
     ApplicationViewType = AppType;
     m_AppsInfo->SetWelcomeText(m_MainWindow->m_bAppwizMode);
 
-    HMENU hMenu = ::GetMenu(m_hWnd);
+    HMENU hMenu = GetMenu();
     switch (AppType)
     {
         case AppViewTypeInstalledApps:
         {
             EnableMenuItem(hMenu, ID_INSTALL, MF_GRAYED);
-            EnableMenuItem(hMenu, ID_UNINSTALL, MF_ENABLED);
-            EnableMenuItem(hMenu, ID_MODIFY, MF_ENABLED);
-            EnableMenuItem(hMenu, ID_REGREMOVE, MF_ENABLED);
-
             m_Toolbar->SendMessageW(TB_ENABLEBUTTON, ID_INSTALL, FALSE);
-            m_Toolbar->SendMessageW(TB_ENABLEBUTTON, ID_UNINSTALL, TRUE);
-            m_Toolbar->SendMessageW(TB_ENABLEBUTTON, ID_MODIFY, TRUE);
+
             m_Toolbar->SendMessageW(TB_ENABLEBUTTON, ID_CHECK_ALL, FALSE);
             break;
         }
@@ -2067,18 +2066,22 @@ CApplicationView::SetDisplayAppType(APPLICATION_VIEW_TYPE AppType)
             // We shouldn't get there in APPWIZ-mode.
             ATLASSERT(!m_MainWindow->m_bAppwizMode);
 
-            EnableMenuItem(hMenu, ID_INSTALL, MF_ENABLED);
-            EnableMenuItem(hMenu, ID_UNINSTALL, MF_GRAYED);
-            EnableMenuItem(hMenu, ID_MODIFY, MF_GRAYED);
-            EnableMenuItem(hMenu, ID_REGREMOVE, MF_GRAYED);
+            /* Even if no ListView item is focused at this point, enable
+             * or disable ID_INSTALL if there are selected applications. */
+            _UpdateInstallBtn();
 
-            m_Toolbar->SendMessageW(TB_ENABLEBUTTON, ID_INSTALL, TRUE);
-            m_Toolbar->SendMessageW(TB_ENABLEBUTTON, ID_UNINSTALL, FALSE);
-            m_Toolbar->SendMessageW(TB_ENABLEBUTTON, ID_MODIFY, FALSE);
             m_Toolbar->SendMessageW(TB_ENABLEBUTTON, ID_CHECK_ALL, TRUE);
             break;
         }
     }
+
+    /* Always disable these items by default */
+    EnableMenuItem(hMenu, ID_UNINSTALL, MF_GRAYED);
+    EnableMenuItem(hMenu, ID_MODIFY, MF_GRAYED);
+    EnableMenuItem(hMenu, ID_REGREMOVE, MF_GRAYED);
+    m_Toolbar->SendMessageW(TB_ENABLEBUTTON, ID_UNINSTALL, FALSE);
+    m_Toolbar->SendMessageW(TB_ENABLEBUTTON, ID_MODIFY, FALSE);
+
     return TRUE;
 }
 
@@ -2163,30 +2166,70 @@ CApplicationView::RefreshDetailsPane(CAppInfo &Info, bool OnlyUpdateText)
     m_AppsInfo->ShowAppInfo(Info, OnlyUpdateText);
 }
 
-// this function is called when a item of listview get focus.
-// CallbackParam is the param passed to listview when adding the item (the one getting focus now).
-VOID
-CApplicationView::ItemGetFocus(LPVOID CallbackParam)
+void
+CApplicationView::_UpdateInstallBtn()
 {
-    if (CallbackParam)
+    if (ApplicationViewType == AppViewTypeInstalledApps)
     {
-        CAppInfo *Info = static_cast<CAppInfo *>(CallbackParam);
-        RefreshDetailsPane(*Info);
+        EnableMenuItem(GetMenu(), ID_INSTALL, MF_GRAYED);
+        m_Toolbar->SendMessageW(TB_ENABLEBUTTON, ID_INSTALL, FALSE);
+    }
+    else if (ApplicationViewType == AppViewTypeAvailableApps)
+    {
+        // We shouldn't get there in APPWIZ-mode.
+        ATLASSERT(!m_MainWindow->m_bAppwizMode);
 
-        if (ApplicationViewType == AppViewTypeInstalledApps)
-        {
-            HMENU hMenu = ::GetMenu(m_hWnd);
-
-            BOOL CanModify = Info->CanModify();
-
-            EnableMenuItem(hMenu, ID_MODIFY, CanModify ? MF_ENABLED : MF_GRAYED);
-            m_Toolbar->SendMessageW(TB_ENABLEBUTTON, ID_MODIFY, CanModify);
-        }
+        /* Even if no ListView item is focused at this point, enable
+         * or disable ID_INSTALL if there are selected applications. */
+        BOOL CanInstall = !m_MainWindow->m_Selected.IsEmpty();
+        CanInstall = CanInstall || (m_ListView->GetSelectedCount() > 0);
+        EnableMenuItem(GetMenu(), ID_INSTALL, CanInstall ? MF_ENABLED : MF_GRAYED);
+        m_Toolbar->SendMessageW(TB_ENABLEBUTTON, ID_INSTALL, CanInstall);
     }
 }
 
-// this function is called when a item of listview is checked/unchecked
-// CallbackParam is the param passed to listview when adding the item (the one getting changed now).
+// This function is called when a ListView item gets the focus.
+// CallbackParam is the param passed to the ListView when adding the item (the one getting focus now).
+VOID
+CApplicationView::ItemGetFocus(LPVOID CallbackParam)
+{
+    if (!CallbackParam)
+        return;
+
+    CAppInfo *Info = static_cast<CAppInfo *>(CallbackParam);
+    RefreshDetailsPane(*Info);
+
+    HMENU hMenu = GetMenu();
+    if (ApplicationViewType == AppViewTypeInstalledApps)
+    {
+        /* ID_INSTALL is left disabled */
+
+        EnableMenuItem(hMenu, ID_UNINSTALL, MF_ENABLED);
+        m_Toolbar->SendMessageW(TB_ENABLEBUTTON, ID_UNINSTALL, TRUE);
+
+        BOOL CanModify = Info->CanModify();
+        EnableMenuItem(hMenu, ID_MODIFY, CanModify ? MF_ENABLED : MF_GRAYED);
+        m_Toolbar->SendMessageW(TB_ENABLEBUTTON, ID_MODIFY, CanModify);
+
+        EnableMenuItem(hMenu, ID_REGREMOVE, MF_ENABLED);
+    }
+    else if (ApplicationViewType == AppViewTypeAvailableApps)
+    {
+        // We shouldn't get there in APPWIZ-mode.
+        ATLASSERT(!m_MainWindow->m_bAppwizMode);
+
+        EnableMenuItem(hMenu, ID_INSTALL, MF_ENABLED);
+        m_Toolbar->SendMessageW(TB_ENABLEBUTTON, ID_INSTALL, TRUE);
+
+        /* ID_UNINSTALL, ID_MODIFY and ID_REGREMOVE are left disabled */
+        // TODO: When we are able to detect whether this selected available
+        // application is already installed (could be an older version),
+        // do also what's done in the AppViewTypeInstalledApps case above.
+    }
+}
+
+// This function is called when a ListView item (an application) is checked/unchecked.
+// CallbackParam is the param passed to the ListView when adding the item (the one getting changed now).
 VOID
 CApplicationView::ItemCheckStateChanged(BOOL bChecked, LPVOID CallbackParam)
 {

--- a/base/applications/rapps/include/appview.h
+++ b/base/applications/rapps/include/appview.h
@@ -376,6 +376,9 @@ class CApplicationView : public CUiWindow<CWindowImpl<CApplicationView>>
     VOID
     OnCommand(WPARAM wParam, LPARAM lParam);
 
+    void
+    _UpdateInstallBtn();
+
   public:
     CApplicationView(CMainWindow *MainWindow);
     ~CApplicationView();
@@ -420,13 +423,9 @@ class CApplicationView : public CUiWindow<CWindowImpl<CApplicationView>>
     VOID
     RefreshDetailsPane(CAppInfo &Info, bool OnlyUpdateText = false);
 
-    // this function is called when a item of listview get focus.
-    // CallbackParam is the param passed to listview when adding the item (the one getting focus now).
     VOID
     ItemGetFocus(LPVOID CallbackParam);
 
-    // this function is called when a item of listview is checked/unchecked
-    // CallbackParam is the param passed to listview when adding the item (the one getting focus now).
     VOID
     ItemCheckStateChanged(BOOL bChecked, LPVOID CallbackParam);
 };


### PR DESCRIPTION
## Purpose

The Install/Uninstall/Modify/... buttons stay disabled by default, unless:

- For installed apps: when an app item is selected, Uninstall (and Registry-remove) are enabled, and modify is enabled under certain conditions.

- For available apps:
  * Modify, Uninstall and Registry-remove are always disabled.
  * When an app item is selected, Install is enabled.
  * Install is also enabled if there is at least one application selected for installation (box checked), in which case the button stays enabled even while changing across apps categories.
