### PR TITLE
[CLB] Update Romanian (ro-RO) translation

### DIFF
--- a/base/applications/regedit/clb/lang/ro-RO.rc
+++ b/base/applications/regedit/clb/lang/ro-RO.rc
@@ -1,28 +1,34 @@
-/* Translator: Ștefan Fulea (stefan dot fulea at mail dot com) */
+/*
+ * PROJECT:     ReactOS Column List Box
+ * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
+ * PURPOSE:     Romanian resource file
+ * TRANSLATORS: Copyright 2011-2018 Ștefan Fulea <stefan.fulea@mail.com>
+ *              Copyright 2023-2024 Andrei Miloiu <miloiuandrei@gmail.com>
+ */
 
 LANGUAGE LANG_ROMANIAN, SUBLANG_NEUTRAL
 
 IDD_COLUMNLISTBOXSTYLES DIALOGEX 0, 0, 227, 215
 STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
-CAPTION "Stiluri de câmp-listă coloană"
+CAPTION "Stiluri de casete pentru listele de coloane"
 FONT 8, "MS Shell Dlg", 0, 0, 0x0
 BEGIN
-   GROUPBOX "Stiluri de câmp-listă coloană", -1, 6, 7, 158, 71
-   CHECKBOX "Stan&dard", 1710, 10, 20, 42, 10, BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP
+   GROUPBOX "Stiluri de casete pentru listele de coloane", -1, 6, 7, 158, 71
+   CHECKBOX "&Standard", 1710, 10, 20, 42, 10, BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP
    CHECKBOX "&Margine", 1713, 10, 30, 34, 10, BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP
-   CHECKBOX "&Ordonat", 1705, 10, 40, 26, 10, BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP
-   CHECKBOX "Notifi&cantă", 1706, 10, 50, 32, 10, BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP
-   CHECKBOX "De&rulantă verticală", 1707, 10, 60, 64, 10, BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP
+   CHECKBOX "S&ortare", 1705, 10, 40, 26, 10, BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP
+   CHECKBOX "&Notificare", 1706, 10, 50, 32, 10, BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP
+   CHECKBOX "&Derulantă verticală", 1707, 10, 60, 64, 10, BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP
    CHECKBOX "Selecție m&ultiplă", -1, 79, 20, 72, 10, BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP | WS_DISABLED
    CHECKBOX "Selecție e&xtinsă", -1, 79, 30, 77, 10, BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP | WS_DISABLED
    CHECKBOX "Titluri &evidente", 1714, 79, 40, 68, 10, BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP
-   CHECKBOX "Coloane flexi&bile", 1715, 79, 50, 66, 10, BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP
+   CHECKBOX "&Coloane elastice", 1715, 79, 50, 66, 10, BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP
    GROUPBOX "Stiluri de bază", -1, 6, 80, 158, 34
    CHECKBOX "&Vizibil", 1701, 10, 92, 34, 10, BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP
    CHECKBOX "De&zactivat", 1702, 10, 102, 41, 10, BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP
    CHECKBOX "&Grup", 1703, 79, 92, 32, 10, BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP
-   CHECKBOX "N&avigare tab", 1704, 79, 102, 44, 10, BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP
-   PUSHBUTTON "Con&firmă", IDOK, 37, 125, 40, 14, BS_DEFPUSHBUTTON | WS_GROUP | WS_TABSTOP
-   PUSHBUTTON "A&nulează", IDCANCEL, 93, 125, 40, 14, BS_PUSHBUTTON | WS_GROUP | WS_TABSTOP
-   CHECKBOX "Bloc&hează controlul derulării", 1708, 79, 60, 66, 10, BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP
+   CHECKBOX "O&prire tab", 1704, 79, 102, 44, 10, BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP
+   PUSHBUTTON "OK", IDOK, 37, 125, 40, 14, BS_DEFPUSHBUTTON | WS_GROUP | WS_TABSTOP
+   PUSHBUTTON "Revocare", IDCANCEL, 93, 125, 40, 14, BS_PUSHBUTTON | WS_GROUP | WS_TABSTOP
+   CHECKBOX "Op&rire derulare", 1708, 79, 60, 66, 10, BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP
 END


### PR DESCRIPTION
Improvements based on recent Romanian translation document revision 06e89b2.

This files was not translated in Romanian language in any Win version (neither XP/2k3+, nor in the previous ones). I tried to translate this file as close as possible in the way I did in the previous PRs.