### PR TITLE
[DXDIAG] Update Romanian (ro-RO) translation

### DIFF
--- a/base/applications/dxdiag/lang/ro-RO.rc
+++ b/base/applications/dxdiag/lang/ro-RO.rc
@@ -241,7 +241,7 @@ BEGIN
     IDS_DDTEST_DESCRIPTION "Acesta va porni testarea interfeței DirectDraw. Doriți să continuați?"
     IDS_DDPRIMARY_DESCRIPTION "Acest test va folosi DirectDraw pentru a desena pe suprafața principală.\Ar trebui desenate dreptunghiuri alb-negru. Doriți să continuați?"
     IDS_DDPRIMARY_RESULT "Ați văzut dreptunghiuri alb-negru?"
-    IDS_DDOFFSCREEN_DESCRIPTION "Acest test va folosi DirectDraw pentru a desena un buffer în afara ecranului. Ar trebui desenat un dreptunghi alb în mișcare. Doriți să continuați?"
+    IDS_DDOFFSCREEN_DESCRIPTION "Acest test va folosi DirectDraw pentru a desena un tampon în afara ecranului. Ar trebui desenat un dreptunghi alb în mișcare. Doriți să continuați?"
     IDS_DDOFFSCREEN_RESULT "Ați văzut dreptunghi alb în mișcare?"
     IDS_DDFULLSCREEN_DESCRIPTION "Acest test va folosi DirectDraw pentru a desena în modul ecran complet. Ar trebui desenat un dreptunghi alb în mișcare. Doriți să continuați?"
     IDS_DDFULLSCREEN_RESULT "Ați văzut dreptunghi alb în mișcare în modul ecran complet?"

--- a/base/applications/dxdiag/lang/ro-RO.rc
+++ b/base/applications/dxdiag/lang/ro-RO.rc
@@ -193,7 +193,7 @@ BEGIN
     LTEXT "Încă nu găsiți informațiile pe care le căutați? Iată câteva lucruri suplimentare pe care le puteți face:", IDC_STATIC, 5, 0, 300, 10
     PUSHBUTTON "Informații de sistem", IDC_BUTTON_SYSINFO, 5, 20, 80, 14, WS_DISABLED
     LTEXT "Afișează informații suplimentare de sistem", IDC_STATIC, 90, 23, 300, 10
-    PUSHBUTTON "Suprascriere a ratei de reîmprospătare", IDC_BUTTON_DDRAW_REFRESH, 5, 40, 80, 14, WS_DISABLED
+    PUSHBUTTON "Ajust. rata de împrosp.", IDC_BUTTON_DDRAW_REFRESH, 5, 40, 80, 14, WS_DISABLED
     LTEXT "Ignoră rata de reîmprospătare pentru DirectDraw", IDC_STATIC, 90, 43, 300, 10
 END
 

--- a/base/applications/dxdiag/lang/ro-RO.rc
+++ b/base/applications/dxdiag/lang/ro-RO.rc
@@ -3,7 +3,7 @@
  * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
  * PURPOSE:     Romanian resource file
  * TRANSLATORS: Copyright 2011-2019 Ștefan Fulea <stefan.fulea@mail.com>
- *              Copyright 2023-2024 Andrei Miloiu <miloiuandrei@gmail.com>
+ *              Copyright 2023-2025 Andrei Miloiu <miloiuandrei@gmail.com>
  */
 
 LANGUAGE LANG_ROMANIAN, SUBLANG_NEUTRAL

--- a/base/applications/dxdiag/lang/ro-RO.rc
+++ b/base/applications/dxdiag/lang/ro-RO.rc
@@ -3,7 +3,7 @@
  * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
  * PURPOSE:     Romanian resource file
  * TRANSLATORS: Copyright 2011-2019 Ștefan Fulea <stefan.fulea@mail.com>
- *              Copyright 2023 Andrei Miloiu <miloiuandrei@gmail.com>
+ *              Copyright 2023-2024 Andrei Miloiu <miloiuandrei@gmail.com>
  */
 
 LANGUAGE LANG_ROMANIAN, SUBLANG_NEUTRAL
@@ -11,22 +11,22 @@ LANGUAGE LANG_ROMANIAN, SUBLANG_NEUTRAL
 IDD_MAIN_DIALOG DIALOGEX 0, 0, 478, 280
 STYLE DS_SHELLFONT | DS_CENTER | WS_MINIMIZEBOX | WS_POPUP |
       WS_CLIPSIBLINGS | WS_CLIPCHILDREN | WS_CAPTION | WS_SYSMENU
-CAPTION "Diagnostic ReactX"
+CAPTION "Instrument de diagnosticare ReactX"
 FONT 8, "MS Shell Dlg"
 BEGIN
     CONTROL "Tab1", IDC_TAB_CONTROL, "SysTabControl32", WS_TABSTOP, 2, 2, 474, 250
-    PUSHBUTTON "&Manual…", IDC_BUTTON_HELP, 2, 260, 50, 14, WS_CHILD | WS_VISIBLE | WS_TABSTOP | WS_DISABLED
-    DEFPUSHBUTTON "&Următorul compartiment", IDC_BUTTON_NEXT, 187, 260, 120, 14, WS_CHILD | WS_VISIBLE | WS_TABSTOP
-    PUSHBUTTON "S&alvare informații…", IDC_BUTTON_SAVE_INFO, 311, 260, 110, 14, WS_CHILD | WS_VISIBLE | WS_TABSTOP | WS_DISABLED
-    PUSHBUTTON "Î&nchide", IDC_BUTTON_EXIT, 425, 260, 50, 14, WS_CHILD | WS_VISIBLE | WS_TABSTOP
+    PUSHBUTTON "&Ajutor", IDC_BUTTON_HELP, 2, 260, 50, 14, WS_CHILD | WS_VISIBLE | WS_TABSTOP | WS_DISABLED
+    DEFPUSHBUTTON "&Pagina următoare", IDC_BUTTON_NEXT, 187, 260, 120, 14, WS_CHILD | WS_VISIBLE | WS_TABSTOP
+    PUSHBUTTON "&Salvare a tuturor informațiilor…", IDC_BUTTON_SAVE_INFO, 311, 260, 110, 14, WS_CHILD | WS_VISIBLE | WS_TABSTOP | WS_DISABLED
+    PUSHBUTTON "Î&nchidere", IDC_BUTTON_EXIT, 425, 260, 50, 14, WS_CHILD | WS_VISIBLE | WS_TABSTOP
 END
 
 IDD_SYSTEM_DIALOG DIALOGEX 0, 0, 462, 220
 STYLE DS_SHELLFONT | DS_CONTROL | WS_CHILD | WS_CLIPCHILDREN
 FONT 8, "MS Shell Dlg"
 BEGIN
-    LTEXT "Acest instrument oferă informații detaliate despre componentele ReactX și drivere instalate în sistem.", IDC_STATIC, 5, 0, 443, 17
-    LTEXT "Dacă aveți la cunoștință careva probleme la o anumită categorie, mergeți la compartimentul corespunzător de mai sus. Altfel, puteți utiliza butonul „Următorul compartiment” de mai jos pentru a trece secvențial prin fiecare categorie.", IDC_STATIC, 5, 15, 443, 25
+    LTEXT "Acest instrument raportează informații detaliate despre componentele ReactX și driverele instalate pe sistem.", IDC_STATIC, 5, 0, 443, 17
+    LTEXT "Dacă întâmpinați o problemă cu ReactX și știți ce este, atunci faceți clic pe fila corespunzătoare de mai sus. Dacă nu, puteți face clic pe butonul ""Pagina următoare"" de mai jos pentru a vizita fiecare pagină în succesiune.", IDC_STATIC, 5, 15, 443, 25
     GROUPBOX "Informații despre sistem", IDC_STATIC, 5, 35, 452, 150, SS_RIGHT
     LTEXT "Data/Ora curentă:", IDC_STATIC, 70, 50, 80, 10, SS_RIGHT
     LTEXT "Numele calculatorului:", IDC_STATIC, 70, 60, 80, 10, SS_RIGHT
@@ -60,11 +60,11 @@ BEGIN
     GROUPBOX "Dispozitiv", IDC_STATIC, 5, 0, 250, 95
     RTEXT "Nume:", IDC_STATIC, 20, 10, 70, 10
     RTEXT "Producător:", IDC_STATIC, 20, 20, 70, 10
-    RTEXT "Tipul cipului:", IDC_STATIC, 20, 30, 70, 10
-    RTEXT "Tipul CDA:", IDC_STATIC, 20, 40, 70, 10
-    RTEXT "Memorie aprox.:", IDC_STATIC, 20, 50, 70, 10
-    RTEXT "Afișare curentă:", IDC_STATIC, 20, 60, 70, 10
-    RTEXT "Ecran:", IDC_STATIC, 20, 70, 70, 10
+    RTEXT "Tipul chip-ului:", IDC_STATIC, 20, 30, 70, 10
+    RTEXT "Tipul DAC:", IDC_STATIC, 20, 40, 70, 10
+    RTEXT "Mem. tot. aprox.:", IDC_STATIC, 20, 50, 70, 10
+    RTEXT "Mod afișare curentă:", IDC_STATIC, 20, 60, 70, 10
+    RTEXT "Monitor:", IDC_STATIC, 20, 70, 70, 10
     EDITTEXT IDC_STATIC_ADAPTER_ID, 95, 10, 150, 10, ES_LEFT | ES_READONLY | NOT WS_BORDER | NOT WS_TABSTOP | ES_AUTOHSCROLL
     EDITTEXT IDC_STATIC_ADAPTER_VENDOR, 95, 20, 150, 10, ES_LEFT | ES_READONLY | NOT WS_BORDER | NOT WS_TABSTOP | ES_AUTOHSCROLL
     EDITTEXT IDC_STATIC_ADAPTER_CHIP, 95, 30, 150, 10, ES_LEFT | ES_READONLY | NOT WS_BORDER | NOT WS_TABSTOP | ES_AUTOHSCROLL
@@ -73,10 +73,10 @@ BEGIN
     EDITTEXT IDC_STATIC_ADAPTER_MODE, 95, 60, 150, 10, ES_LEFT | ES_READONLY | NOT WS_BORDER | NOT WS_TABSTOP | ES_AUTOHSCROLL
     EDITTEXT IDC_STATIC_ADAPTER_MONITOR, 95, 70, 150, 10, ES_LEFT | ES_READONLY | NOT WS_BORDER | NOT WS_TABSTOP | ES_AUTOHSCROLL
     GROUPBOX "Driver", IDC_STATIC, 260, 0, 197, 95
-    RTEXT "Driver primar:", IDC_STATIC, 275, 10, 55, 10
+    RTEXT "Driver principal:", IDC_STATIC, 275, 10, 55, 10
     RTEXT "Versiune:", IDC_STATIC, 275, 20, 55, 10
     RTEXT "Dată:", IDC_STATIC, 275, 30, 55, 10
-    RTEXT "Semnăt. WHQL:", IDC_STATIC, 275, 40, 55, 10
+    RTEXT "Logo WHQL:", IDC_STATIC, 275, 40, 55, 10
     RTEXT "Mini-VDD:", IDC_STATIC, 275, 50, 55, 10
     RTEXT "VDD:", IDC_STATIC, 275, 60, 55, 10
     RTEXT "Versiune DDI:", IDC_STATIC, 275, 70, 55, 10
@@ -87,18 +87,18 @@ BEGIN
     EDITTEXT IDC_STATIC_ADAPTER_MINIVDD, 335, 50, 120, 10, ES_LEFT | ES_READONLY | NOT WS_BORDER | NOT WS_TABSTOP | ES_AUTOHSCROLL
     EDITTEXT IDC_STATIC_ADAPTER_VDD, 335, 60, 120, 10, ES_LEFT | ES_READONLY | NOT WS_BORDER | NOT WS_TABSTOP | ES_AUTOHSCROLL
     EDITTEXT IDC_STATIC_ADAPTER_DDI, 335, 70, 120, 10, ES_LEFT | ES_READONLY | NOT WS_BORDER | NOT WS_TABSTOP | ES_AUTOHSCROLL
-    GROUPBOX "Funcționalități ReactX", IDC_STATIC, 5, 97, 452, 70
+    GROUPBOX "Caracteristici ReactX", IDC_STATIC, 5, 97, 452, 70
     RTEXT "Accelerare DirectDraw:", IDC_STATIC, 15, 115, 110, 12
     RTEXT "Accelerare Direct3D:", IDC_STATIC, 15, 130, 110, 12
-    RTEXT "Accelerare Textură AGP:", IDC_STATIC, 15, 145, 110, 12
+    RTEXT "Accelerare a texturilor AGP:", IDC_STATIC, 15, 145, 110, 12
     LTEXT "", IDC_STATIC_DDSTATE, 130, 115, 40, 10
     LTEXT "", IDC_STATIC_D3DSTATE, 130, 130, 40, 10
     LTEXT "", IDC_STATIC_AGPSTATE, 130, 145, 40, 10
-    PUSHBUTTON "Activează", IDC_BUTTON_DDRAW, 170, 112, 60, 14, WS_DISABLED
-    PUSHBUTTON "Activează", IDC_BUTTON_D3D, 170, 128, 60, 14, WS_DISABLED
-    PUSHBUTTON "Activează", IDC_BUTTON_AGP, 170, 144, 60, 14, WS_DISABLED
-    PUSHBUTTON "Testează DirectDraw", IDC_BUTTON_TESTDD, 250, 112, 80, 14
-    PUSHBUTTON "Testează Direct3D", IDC_BUTTON_TEST3D, 250, 128, 80, 14
+    PUSHBUTTON "Activare", IDC_BUTTON_DDRAW, 170, 112, 60, 14, WS_DISABLED
+    PUSHBUTTON "Activare", IDC_BUTTON_D3D, 170, 128, 60, 14, WS_DISABLED
+    PUSHBUTTON "Activare", IDC_BUTTON_AGP, 170, 144, 60, 14, WS_DISABLED
+    PUSHBUTTON "Testare DirectDraw", IDC_BUTTON_TESTDD, 250, 112, 80, 14
+    PUSHBUTTON "Testare Direct3D", IDC_BUTTON_TEST3D, 250, 128, 80, 14
     GROUPBOX "Note", IDC_STATIC, 5, 170, 452, 50
     EDITTEXT IDC_TEXT_INFO, 15, 182, 432, 30, ES_LEFT | WS_BORDER | ES_READONLY | WS_TABSTOP
 END
@@ -124,7 +124,7 @@ BEGIN
     RTEXT "Nume:", IDC_STATIC, 275, 10, 55, 10
     RTEXT "Versiune:", IDC_STATIC, 275, 20, 55, 10
     RTEXT "Dată:", IDC_STATIC, 275, 30, 55, 10
-    RTEXT "Semnătură WHQL:", IDC_STATIC, 275, 40, 55, 10
+    RTEXT "Logo WHQL:", IDC_STATIC, 275, 40, 55, 10
     RTEXT "Alte fișiere:", IDC_STATIC, 275, 50, 55, 10
     RTEXT "Furnizor:", IDC_STATIC, 275, 60, 55, 10
     EDITTEXT IDC_STATIC_DSOUND_DRIVER, 335, 10, 100, 10, ES_LEFT | ES_READONLY | NOT WS_BORDER | NOT WS_TABSTOP | ES_AUTOHSCROLL
@@ -133,10 +133,10 @@ BEGIN
     EDITTEXT IDC_STATIC_DSOUND_LOGO, 335, 40, 100, 10, ES_LEFT | ES_READONLY | NOT WS_BORDER | NOT WS_TABSTOP | ES_AUTOHSCROLL
     EDITTEXT IDC_STATIC_DSOUND_FILES, 335, 50, 100, 10, ES_LEFT | ES_READONLY | NOT WS_BORDER | NOT WS_TABSTOP | ES_AUTOHSCROLL
     EDITTEXT IDC_STATIC_ADAPTER_PROVIDER, 335, 60, 100, 10, ES_LEFT | ES_READONLY | NOT WS_BORDER | NOT WS_TABSTOP | ES_AUTOHSCROLL
-    GROUPBOX "Funcționalități ReactX", IDC_STATIC, 5, 97, 452, 70
+    GROUPBOX "Caracteristici ReactX", IDC_STATIC, 5, 97, 452, 70
     CONTROL "", IDC_SLIDER_DSOUND, "msctls_trackbar32", TBS_BOTTOM | TBS_AUTOTICKS | WS_TABSTOP, 110, 125, 80, 17
-    RTEXT "Echipament de sunet\nNivel de accelerare::", IDC_STATIC, 10, 125, 90, 20, WS_DISABLED
-    PUSHBUTTON "Testează DirectSound", IDC_BUTTON_TESTDSOUND, 270, 125, 80, 14, WS_DISABLED
+    RTEXT "Hardware de sunet\nNivel de accelerare:", IDC_STATIC, 10, 125, 90, 20, WS_DISABLED
+    PUSHBUTTON "Testare DirectSound", IDC_BUTTON_TESTDSOUND, 270, 125, 80, 14, WS_DISABLED
     GROUPBOX "Note", IDC_STATIC, 5, 170, 452, 50
     EDITTEXT IDC_TEXT_DSOUNDINFO, 15, 182, 432, 30, ES_LEFT | WS_BORDER | ES_READONLY | WS_TABSTOP
 END
@@ -148,13 +148,13 @@ BEGIN
     RTEXT "Colecție de MIDI DLS generală:", IDC_STATIC, 0, 0, 100, 10
     EDITTEXT IDC_MIDI_DLS_COLLECTION, 105, 0, 250, 10, ES_LEFT | ES_READONLY | NOT WS_BORDER | NOT WS_TABSTOP | ES_AUTOHSCROLL
     GROUPBOX "Porturi de muzică", IDC_STATIC, 5, 10, 452, 85
-    GROUPBOX "Funcționalități ReactX", IDC_STATIC, 5, 97, 452, 70
+    GROUPBOX "Caracteristici ReactX", IDC_STATIC, 5, 97, 452, 70
     LTEXT "Port de accelerare implicit:", IDC_STATIC, 15, 120, 95, 17
     LTEXT "", IDC_STATIC_DEFAULT_PORT_ACCELERATION, 115, 120, 50, 10
     PUSHBUTTON "Dezactivează", IDC_BUTTON_DISABLEDMUSIC, 75, 135, 80, 14, WS_DISABLED
     LTEXT "Testare utilizare port:", IDC_STATIC, 180, 105, 100, 10
     LISTBOX IDC_DMUSIC_TEST_LIST, 180, 115, 180, 45, LBS_NOINTEGRALHEIGHT | LBS_EXTENDEDSEL | WS_VSCROLL | WS_TABSTOP
-    PUSHBUTTON "Testează DirectMusic", IDC_BUTTON_TESTDMUSIC, 370, 145, 80, 14, WS_DISABLED
+    PUSHBUTTON "Testare DirectMusic", IDC_BUTTON_TESTDMUSIC, 370, 145, 80, 14, WS_DISABLED
     GROUPBOX "Note", IDC_STATIC, 5, 170, 452, 50
     EDITTEXT IDC_MUSIC_NOTES, 15, 182, 432, 30, ES_LEFT | WS_BORDER | ES_READONLY | WS_TABSTOP
 END
@@ -176,12 +176,12 @@ IDD_NETWORK_DIALOG DIALOGEX 0, 0, 462, 220
 STYLE DS_SHELLFONT | DS_CONTROL | WS_CHILD | WS_CLIPCHILDREN
 FONT 8, "MS Shell Dlg"
 BEGIN
-    GROUPBOX "Furnizori înregistrați de servicii DirectPlay", IDC_STATIC, 5, 0, 452, 75
+    GROUPBOX "Furnizori de servicii DirectPlay înregistrați", IDC_STATIC, 5, 0, 452, 75
     CONTROL "", IDC_LIST_PROVIDER, "SysListView32", LVS_REPORT | WS_CHILD | WS_BORDER | WS_TABSTOP, 15, 12, 432, 55
-    GROUPBOX "Aplicații înregistrate pentru DirectPlay", IDC_STATIC, 5, 77, 452, 55
-    GROUPBOX "Funcționalități ReactX", IDC_STATIC, 5, 133, 452, 35
+    GROUPBOX "Aplicații Lobbyable DirectPlay înregistrate", IDC_STATIC, 5, 77, 452, 55
+    GROUPBOX "Caracteristici ReactX", IDC_STATIC, 5, 133, 452, 35
     PUSHBUTTON "Opțiuni de voce DirectPlay", IDC_BUTTON_VOICE_OPTIONS, 10, 145, 90, 14, WS_DISABLED
-    PUSHBUTTON "Testează DirectPlay", IDC_BUTTON_TESTDPLAY, 130, 145, 80, 14, WS_DISABLED
+    PUSHBUTTON "Testare DirectPlay", IDC_BUTTON_TESTDPLAY, 130, 145, 80, 14, WS_DISABLED
     GROUPBOX "Note", IDC_STATIC, 5, 170, 452, 50
     EDITTEXT IDC_NETWORK_NOTES, 15, 182, 432, 30, ES_LEFT | WS_BORDER | ES_READONLY | WS_TABSTOP
 END
@@ -190,73 +190,73 @@ IDD_HELP_DIALOG DIALOGEX 0, 0, 462, 220
 STYLE DS_SHELLFONT | DS_CONTROL | WS_CHILD | WS_CLIPCHILDREN
 FONT 8, "MS Shell Dlg"
 BEGIN
-    LTEXT "Încă nu ați găsit informația necesară? Iată câteva lucruri suplimentare pe care le puteți face:", IDC_STATIC, 5, 0, 300, 10
+    LTEXT "Încă nu găsiți informațiile pe care le căutați? Iată câteva lucruri suplimentare pe care le puteți face:", IDC_STATIC, 5, 0, 300, 10
     PUSHBUTTON "Informații de sistem", IDC_BUTTON_SYSINFO, 5, 20, 80, 14, WS_DISABLED
-    LTEXT "Afișează informații suplimantare de sistem", IDC_STATIC, 90, 23, 300, 10
-    PUSHBUTTON "Ajustează rata de împrospătare", IDC_BUTTON_DDRAW_REFRESH, 5, 40, 80, 14, WS_DISABLED
-    LTEXT "Ajustează rata de împrospătare pentru DirectDraw", IDC_STATIC, 90, 43, 300, 10
+    LTEXT "Afișează informații suplimentare de sistem", IDC_STATIC, 90, 23, 300, 10
+    PUSHBUTTON "Suprascriere a ratei de reîmprospătare", IDC_BUTTON_DDRAW_REFRESH, 5, 40, 80, 14, WS_DISABLED
+    LTEXT "Ignoră rata de reîmprospătare pentru DirectDraw", IDC_STATIC, 90, 43, 300, 10
 END
 
 STRINGTABLE
 BEGIN
-    IDS_MAIN_DIALOG "Diagnostic ReactX"
+    IDS_MAIN_DIALOG "Instrument de diagnosticare ReactX"
     IDS_SYSTEM_DIALOG "Sistem"
-    IDS_DISPLAY_DIALOG "Ecran"
+    IDS_DISPLAY_DIALOG "Afișaj"
     IDS_SOUND_DIALOG "Sunet"
     IDS_MUSIC_DIALOG "Muzică"
-    IDS_INPUT_DIALOG "Intrări"
+    IDS_INPUT_DIALOG "Intrare"
     IDS_NETWORK_DIALOG "Rețea"
-    IDS_HELP_DIALOG "Asistență"
-    IDS_FORMAT_MB "%I64u Mo memorie"
-    IDS_FORMAT_SWAP "%I64u Mo utilizată, %I64u Mo disponibilă"
-    IDS_FORMAT_UNIPROC "%s (%u procesor)"
-    IDS_FORMAT_MPPROC "%s (%u procesoare)"
-    IDS_VERSION_UNKNOWN "Versiune neidentificată"
+    IDS_HELP_DIALOG "Ajutor"
+    IDS_FORMAT_MB "%I64uMB de RAM"
+    IDS_FORMAT_SWAP "%I64u (de) MB folosit (folosiți), %I64u (de) MB disponibil(i)"
+    IDS_FORMAT_UNIPROC "%s (%u CPU)"
+    IDS_FORMAT_MPPROC "%s (%u CPUs)"
+    IDS_VERSION_UNKNOWN "Versiune necunoscută"
     IDS_DEVICE_STATUS_ATTACHED "Conectat"
     IDS_DEVICE_STATUS_MISSING "Deconectat"
-    IDS_DEVICE_STATUS_UNKNOWN "Neidentificat"
-    IDS_DEVICE_NAME "Nume dispozitiv"
+    IDS_DEVICE_STATUS_UNKNOWN "Necunoscut"
+    IDS_DEVICE_NAME "Numele dispozitivului"
     IDS_DEVICE_STATUS "Stare"
-    IDS_DEVICE_CONTROLLER "ID controlor"
-    IDS_DEVICE_MANUFACTURER "ID producător"
-    IDS_DEVICE_PRODUCT "ID produs"
-    IDS_DEVICE_FORCEFEEDBACK "Forțează reacția driverului"
+    IDS_DEVICE_CONTROLLER "ID controller-ului"
+    IDS_DEVICE_MANUFACTURER "ID-ul producătorului"
+    IDS_DEVICE_PRODUCT "ID-ul produsului"
+    IDS_DEVICE_FORCEFEEDBACK "Forțare a driverului de feedback"
     IDS_NOT_APPLICABLE "n/a"
     IDS_OPTION_YES "Da"
     IDS_DIRECTPLAY_COL_NAME1 "Nume"
     IDS_DIRECTPLAY_COL_NAME2 "Registru"
     IDS_DIRECTPLAY_COL_NAME3 "Fișier"
     IDS_DIRECTPLAY_COL_NAME4 "Versiune"
-    IDS_DIRECTPLAY8_MODEMSP "Furnizor de serviciu Modem-DirectPlay8"
-    IDS_DIRECTPLAY8_SERIALSP "Furnizor de serviciu Serial-DirectPlay8"
-    IDS_DIRECTPLAY8_IPXSP "Furnizor de serviciu IPX-DirectPlay8"
-    IDS_DIRECTPLAY8_TCPSP "Furnizor de serviciu TCP/IP-DirectPlay8"
+    IDS_DIRECTPLAY8_MODEMSP "Furnizor de servicii de modem DirectPlay8"
+    IDS_DIRECTPLAY8_SERIALSP "Furnizor de servicii seriale DirectPlay8"
+    IDS_DIRECTPLAY8_IPXSP "Furnizor de servicii DirectPlay8 IPX"
+    IDS_DIRECTPLAY8_TCPSP "DirectPlay8 TCP/IP Service Provider"
     IDS_DIRECTPLAY_TCPCONN "Conexiune de Internet TCP/IP pentru DirectPlay"
     IDS_DIRECTPLAY_IPXCONN "Conexiune IPX pentru DirectPlay"
-    IDS_DIRECTPLAY_MODEMCONN "Conexiune Modem pentru DirectPlay"
-    IDS_DIRECTPLAY_SERIALCONN "Conexiune Serială pentru DirectPlay"
-    IDS_REG_SUCCESS "Î&nchide"
+    IDS_DIRECTPLAY_MODEMCONN "Conexiune de modem pentru DirectPlay"
+    IDS_DIRECTPLAY_SERIALCONN "Conexiune serială pentru DirectPlay"
+    IDS_REG_SUCCESS "OK"
     IDS_REG_FAIL "Eroare"
-    IDS_DDTEST_ERROR "Testul a eșuat!"
-    IDS_DDTEST_DESCRIPTION "Urmează testele de interfață DirectDraw. Continuați?"
-    IDS_DDPRIMARY_DESCRIPTION "Testul următor va utiliza DirectDraw pentru a desena dreptunghiuri albe și negre pe suprafața primară. Continuați?"
-    IDS_DDPRIMARY_RESULT "Dreptunghiurile albe și negre au fost vizibile?"
-    IDS_DDOFFSCREEN_DESCRIPTION "Testul următor va utiliza DirectDraw pentru desenarea unui dreptunghi alb în mișcare utilizând o memorie tampon din afara ecranului. Continuați?"
-    IDS_DDOFFSCREEN_RESULT "Dreptunghiul alb în mișcare a fost vizibil?"
-    IDS_DDFULLSCREEN_DESCRIPTION "Testul următor va utiliza DirectDraw pentru desenarea unui dreptunghi alb în mișcare utilizând tot ecranul. Continuați?"
-    IDS_DDFULLSCREEN_RESULT "Pe ecranul complet, dreptunghiul alb în mișcare a fost vizibil?"
-    IDS_FORMAT_ADAPTER_MEM "%u Mo"
-    IDS_FORMAT_ADAPTER_MODE "%d x %d (%u biți)(%uHz)"
+    IDS_DDTEST_ERROR "Testul de randare DirectDraw a eșuat.\nVă rugăm să consultați notele pentru mai multe informații."
+    IDS_DDTEST_DESCRIPTION "Acesta va porni testarea interfeței DirectDraw. Doriți să continuați?"
+    IDS_DDPRIMARY_DESCRIPTION "Acest test va folosi DirectDraw pentru a desena pe suprafața principală.\Ar trebui desenate dreptunghiuri alb-negru. Doriți să continuați?"
+    IDS_DDPRIMARY_RESULT "Ați văzut dreptunghiuri alb-negru?"
+    IDS_DDOFFSCREEN_DESCRIPTION "Acest test va folosi DirectDraw pentru a desena un buffer în afara ecranului. Ar trebui desenat un dreptunghi alb în mișcare. Doriți să continuați?"
+    IDS_DDOFFSCREEN_RESULT "Ați văzut dreptunghi alb în mișcare?"
+    IDS_DDFULLSCREEN_DESCRIPTION "Acest test va folosi DirectDraw pentru a desena în modul ecran complet. Ar trebui desenat un dreptunghi alb în mișcare. Doriți să continuați?"
+    IDS_DDFULLSCREEN_RESULT "Ați văzut dreptunghi alb în mișcare în modul ecran complet?"
+    IDS_FORMAT_ADAPTER_MEM "%u (de) MB"
+    IDS_FORMAT_ADAPTER_MODE "%d x %d (%u (de) biți)(%uHz)"
     IDS_OPTION_NO "Nu"
-    IDS_D3DTEST_DESCRIPTION "Urmează testul de interfață Direct3D. Continuați?"
-    IDS_D3DTEST_D3Dx "Testul următor va utiliza interfața Direct3D %u cu accelerare de echipament fizic."
-    IDS_OS_VERSION "%s %s (%d.%d, Build %d)"
+    IDS_D3DTEST_DESCRIPTION "Acesta va porni testarea interfeței Direct3D. Doriți să continuați?"
+    IDS_D3DTEST_D3Dx "Acest test va folosi interfața Direct3D %u accelerată hardware."
+    IDS_OS_VERSION "%s %s (%d.%d, Subversiunea %d)"
     IDS_DMUSIC_DESC "Descriere"
     IDS_DMUSIC_TYPE "Tip"
-    IDS_DMUSIC_KERNEL "Mod nucleu"
-    IDS_DMUSIC_IO "In/Ex"
-    IDS_DMUSIC_DLS "DLS de suport"
+    IDS_DMUSIC_KERNEL "Modul nucleu"
+    IDS_DMUSIC_IO "I/E"
+    IDS_DMUSIC_DLS "Suportă DLS"
     IDS_DMUSIC_EXT "Extern"
     IDS_DMUSIC_PORT "Port implicit"
-    IDS_DDDISABLE_MSG "Accelerările fizice DirectDraw vor fi dezactivate pentru toate dispozitivele.\nDoriți să continuați?\n"
+    IDS_DDDISABLE_MSG "Acesta va dezactiva toată accelerarea hardware pentru DirectDraw pe toate dispozitivele de afișare.\nDoriți să continuați?\n"
 END


### PR DESCRIPTION
Improvements based on recent Romanian translation document revision 06e89b2.

This file was not translated in Romanian language in any Win version (neither XP/2k3+, nor in the previous ones). I tried to translate this file as close as possible in the way I did in the previous PRs.