### PR TITLE
FreeLoader: a selection of disk bug fixes (Part 1)

### DIFF
--- a/boot/freeldr/freeldr/arch/i386/pc/pcdisk.c
+++ b/boot/freeldr/freeldr/arch/i386/pc/pcdisk.c
@@ -338,14 +338,15 @@ DiskGetExtendedDriveParameters(
     TRACE("number of physical cylinders on drive:   %u\n", *(PULONG)&Ptr[2]);
     TRACE("number of physical heads on drive:       %u\n", *(PULONG)&Ptr[4]);
     TRACE("number of physical sectors per track:    %u\n", *(PULONG)&Ptr[6]);
-    TRACE("total number of sectors on drive:        %I64u\n", *(unsigned long long*)&Ptr[8]);
+    TRACE("total number of sectors on drive:        %I64u\n", *(PULONGLONG)&Ptr[8]);
     TRACE("bytes per sector:                        %u\n", Ptr[12]);
     if (Ptr[0] >= 0x1e)
     {
-        TRACE("EED configuration parameters:            %x:%x\n", Ptr[13], Ptr[14]);
+        // Ptr[13]: offset, Ptr[14]: segment
+        TRACE("EDD configuration parameters:            %x:%x\n", Ptr[14], Ptr[13]);
         if (Ptr[13] != 0xffff && Ptr[14] != 0xffff)
         {
-            PUCHAR SpecPtr = (PUCHAR)(ULONG_PTR)((Ptr[13] << 4) + Ptr[14]);
+            PUCHAR SpecPtr = (PUCHAR)(ULONG_PTR)((Ptr[14] << 4) + Ptr[13]);
             TRACE("SpecPtr:                                 %x\n", SpecPtr);
             TRACE("physical I/O port base address:          %x\n", *(PUSHORT)&SpecPtr[0]);
             TRACE("disk-drive control port address:         %x\n", *(PUSHORT)&SpecPtr[2]);

--- a/boot/freeldr/freeldr/include/fs/iso.h
+++ b/boot/freeldr/freeldr/include/fs/iso.h
@@ -20,82 +20,80 @@
 #pragma once
 
 #include <pshpack1.h>
-struct _DIR_RECORD
+typedef struct _DIR_RECORD
 {
-  UCHAR  RecordLength;            // 1
-  UCHAR  ExtAttrRecordLength;        // 2
-  ULONG  ExtentLocationL;        // 3-6
-  ULONG  ExtentLocationM;        // 7-10
-  ULONG  DataLengthL;            // 11-14
-  ULONG  DataLengthM;            // 15-18
-  UCHAR  Year;                // 19
-  UCHAR  Month;                // 20
-  UCHAR  Day;                // 21
-  UCHAR  Hour;                // 22
-  UCHAR  Minute;            // 23
-  UCHAR  Second;            // 24
-  UCHAR  TimeZone;            // 25
-  UCHAR  FileFlags;            // 26
-  UCHAR  FileUnitSize;            // 27
-  UCHAR  InterleaveGapSize;        // 28
-  ULONG  VolumeSequenceNumber;        // 29-32
-  UCHAR  FileIdLength;            // 33
-  UCHAR  FileId[1];            // 34
-};
-typedef struct _DIR_RECORD DIR_RECORD, *PDIR_RECORD;
+    UCHAR  RecordLength;            // 1
+    UCHAR  ExtAttrRecordLength;     // 2
+    ULONG  ExtentLocationL;         // 3-6
+    ULONG  ExtentLocationM;         // 7-10
+    ULONG  DataLengthL;             // 11-14
+    ULONG  DataLengthM;             // 15-18
+    UCHAR  Year;                    // 19
+    UCHAR  Month;                   // 20
+    UCHAR  Day;                     // 21
+    UCHAR  Hour;                    // 22
+    UCHAR  Minute;                  // 23
+    UCHAR  Second;                  // 24
+    UCHAR  TimeZone;                // 25
+    UCHAR  FileFlags;               // 26
+    UCHAR  FileUnitSize;            // 27
+    UCHAR  InterleaveGapSize;       // 28
+    ULONG  VolumeSequenceNumber;    // 29-32
+    UCHAR  FileIdLength;            // 33
+    UCHAR  FileId[1];               // 34
+} DIR_RECORD, *PDIR_RECORD;
 
 
-/* Volume Descriptor header*/
-struct _VD_HEADER
+/* Volume Descriptor header */
+typedef struct _VD_HEADER
 {
-  UCHAR  VdType;            // 1
-  UCHAR  StandardId[5];            // 2-6
-  UCHAR  VdVersion;            // 7
-};
-typedef struct _VD_HEADER VD_HEADER, *PVD_HEADER;
+    UCHAR  VdType;          // 1
+    UCHAR  StandardId[5];   // 2-6
+    UCHAR  VdVersion;       // 7
+} VD_HEADER, *PVD_HEADER;
 
 
-/* Primary Volume Descriptor */
-struct _PVD
+/*
+ * Primary Volume Descriptor
+ * See also cdfs/cd.h RAW_ISO_VD
+ */
+typedef struct _PVD
 {
-  UCHAR  VdType;            // 1
-  CHAR  StandardId[5];            // 2-6
-  UCHAR  VdVersion;            // 7
-  UCHAR  unused0;            // 8
-  CHAR  SystemId[32];            // 9-40
-  CHAR  VolumeId[32];            // 41-72
-  UCHAR  unused1[8];            // 73-80
-  ULONG  VolumeSpaceSizeL;        // 81-84
-  ULONG  VolumeSpaceSizeM;        // 85-88
-  UCHAR  unused2[32];            // 89-120
-  ULONG  VolumeSetSize;            // 121-124
-  ULONG  VolumeSequenceNumber;        // 125-128
-  ULONG  LogicalBlockSize;        // 129-132
-  ULONG  PathTableSizeL;        // 133-136
-  ULONG  PathTableSizeM;        // 137-140
-  ULONG  LPathTablePos;            // 141-144
-  ULONG  LOptPathTablePos;        // 145-148
-  ULONG  MPathTablePos;            // 149-152
-  ULONG  MOptPathTablePos;        // 153-156
-  DIR_RECORD RootDirRecord;        // 157-190
-  CHAR  VolumeSetIdentifier[128];    // 191-318
-  CHAR  PublisherIdentifier[128];    // 319-446
+    UCHAR  VdType;                      // 1
+    CHAR   StandardId[5];               // 2-6
+    UCHAR  VdVersion;                   // 7
+    UCHAR  unused0;                     // 8
+    CHAR   SystemId[32];                // 9-40
+    CHAR   VolumeId[32];                // 41-72
+    UCHAR  unused1[8];                  // 73-80
+    ULONG  VolumeSpaceSizeL;            // 81-84
+    ULONG  VolumeSpaceSizeM;            // 85-88
+    UCHAR  unused2[32];                 // 89-120
+    ULONG  VolumeSetSize;               // 121-124
+    ULONG  VolumeSequenceNumber;        // 125-128
+    ULONG  LogicalBlockSize;            // 129-132
+    ULONG  PathTableSizeL;              // 133-136
+    ULONG  PathTableSizeM;              // 137-140
+    ULONG  LPathTablePos;               // 141-144
+    ULONG  LOptPathTablePos;            // 145-148
+    ULONG  MPathTablePos;               // 149-152
+    ULONG  MOptPathTablePos;            // 153-156
+    DIR_RECORD RootDirRecord;           // 157-190
+    CHAR   VolumeSetIdentifier[128];    // 191-318
+    CHAR   PublisherIdentifier[128];    // 319-446
 
-  /* more data ... */
-
-};
+    /* more data ... */
+} PVD, *PPVD;
 #include <poppack.h>
-typedef struct _PVD PVD, *PPVD;
 
 
-
-typedef struct
+typedef struct _ISO_FILE_INFO
 {
-    ULONG        FileStart;        // File start sector
-    ULONG        FileSize;        // File size
-    ULONG        FilePointer;        // File pointer
-    BOOLEAN    Directory;
-    ULONG        DriveNumber;
-} ISO_FILE_INFO, * PISO_FILE_INFO;
+    ULONG FileStart;    // File start sector
+    ULONG FileSize;     // File size
+    ULONG FilePointer;  // File pointer
+    BOOLEAN Directory;
+    ULONG DriveNumber;
+} ISO_FILE_INFO, *PISO_FILE_INFO;
 
 const DEVVTBL* IsoMount(ULONG DeviceId);

--- a/boot/freeldr/freeldr/include/fs/iso.h
+++ b/boot/freeldr/freeldr/include/fs/iso.h
@@ -60,18 +60,21 @@ typedef struct _VD_HEADER
 typedef struct _PVD
 {
     UCHAR  VdType;                      // 1
-    CHAR   StandardId[5];               // 2-6
+    UCHAR  StandardId[5];               // 2-6
     UCHAR  VdVersion;                   // 7
     UCHAR  unused0;                     // 8
-    CHAR   SystemId[32];                // 9-40
-    CHAR   VolumeId[32];                // 41-72
+    UCHAR  SystemId[32];                // 9-40
+    UCHAR  VolumeId[32];                // 41-72
     UCHAR  unused1[8];                  // 73-80
     ULONG  VolumeSpaceSizeL;            // 81-84
     ULONG  VolumeSpaceSizeM;            // 85-88
     UCHAR  unused2[32];                 // 89-120
-    ULONG  VolumeSetSize;               // 121-124
-    ULONG  VolumeSequenceNumber;        // 125-128
-    ULONG  LogicalBlockSize;            // 129-132
+    USHORT VolumeSetSizeL;              // 121-122
+    USHORT VolumeSetSizeM;              // 123-124
+    USHORT VolumeSeqNumberL;            // 125-126
+    USHORT VolumeSeqNumberM;            // 127-128
+    USHORT LogicalBlockSizeL;           // 129-130
+    USHORT LogicalBlockSizeM;           // 131-132
     ULONG  PathTableSizeL;              // 133-136
     ULONG  PathTableSizeM;              // 137-140
     ULONG  LPathTablePos;               // 141-144
@@ -79,8 +82,8 @@ typedef struct _PVD
     ULONG  MPathTablePos;               // 149-152
     ULONG  MOptPathTablePos;            // 153-156
     DIR_RECORD RootDirRecord;           // 157-190
-    CHAR   VolumeSetIdentifier[128];    // 191-318
-    CHAR   PublisherIdentifier[128];    // 319-446
+    UCHAR  VolumeSetIdentifier[128];    // 191-318
+    UCHAR  PublisherIdentifier[128];    // 319-446
 
     /* more data ... */
 } PVD, *PPVD;

--- a/boot/freeldr/freeldr/lib/fs/iso.c
+++ b/boot/freeldr/freeldr/lib/fs/iso.c
@@ -168,7 +168,7 @@ static ARC_STATUS IsoLookupFile(PCSTR FileName, ULONG DeviceId, PISO_FILE_INFO I
     RtlZeroMemory(&IsoFileInfo, sizeof(ISO_FILE_INFO));
 
     //
-    // Read The Primary Volume Descriptor
+    // Read the Primary Volume Descriptor
     //
     Position.HighPart = 0;
     Position.LowPart = 16 * SECTORSIZE;
@@ -502,9 +502,9 @@ const DEVVTBL* IsoMount(ULONG DeviceId)
 
     TRACE("Enter IsoMount(%lu)\n", DeviceId);
 
-    //
-    // Read The Primary Volume Descriptor
-    //
+    /*
+     * Read the Primary Volume Descriptor
+     */
     Position.HighPart = 0;
     Position.LowPart = 16 * SECTORSIZE;
     Status = ArcSeek(DeviceId, &Position, SeekAbsolute);
@@ -514,16 +514,24 @@ const DEVVTBL* IsoMount(ULONG DeviceId)
     if (Status != ESUCCESS || Count < sizeof(PVD))
         return NULL;
 
-    //
-    // Check if PVD is valid. If yes, return ISO9660 function table
-    //
-    if (Pvd->VdType == 1 && RtlEqualMemory(Pvd->StandardId, "CD001", 5))
+    /* Check if the PVD is valid */
+    if (!(Pvd->VdType == 1 && RtlEqualMemory(Pvd->StandardId, "CD001", 5) && Pvd->VdVersion == 1))
     {
-        TRACE("IsoMount(%lu) success\n", DeviceId);
-        return &Iso9660FuncTable;
+        WARN("Unrecognized CDROM format\n");
+        return NULL;
+    }
+    if (Pvd->LogicalBlockSizeL != SECTORSIZE)
+    {
+        ERR("Unsupported LogicalBlockSize %u\n", Pvd->LogicalBlockSizeL);
+        return NULL;
     }
 
-    return NULL;
+    Count = (ULONG)((ULONGLONG)Pvd->VolumeSpaceSizeL * SECTORSIZE / 1024 / 1024);
+    TRACE("Recognized ISO9660 drive, size %lu MB (%lu sectors)\n",
+          Count, Pvd->VolumeSpaceSizeL);
+
+    /* Everything OK, return the ISO9660 function table */
+    return &Iso9660FuncTable;
 }
 
 #endif


### PR DESCRIPTION
## Purpose

Some bugs I've encountered while testing aspects of FreeLoader.

## Proposed changes

- ### `[FREELDR] include/fs/iso.h: Fix definition of the "Primary Volume Descriptor" PVD structure`

    For reference, see the cdfs/cd.h RAW_ISO_VD structure.

    Each of the old "VolumeSetSize", "VolumeSequenceNumber" and "LogicalBlockSize"
    ULONG fields actually correspond to pairs of USHORT fields:
    "VolumeSetSizeL" and "VolumeSetSizeM", etc., where the "L" one contains
    the value in little-endian format, while the "M" one contains the same
    value in big-endian format.

    Additionally, use UCHARs for the character arrays.

- ### `[FREELDR] fs/iso.c: Perform extra validation before mounting the ISO filesystem.`

    Validate the primary volume descriptor version and its reported
    logical block size.

- ### `[FREELDR] Fix the retrieval of seg:off values when dumping the extended drive parameters.`

    See the corresponding commit log for more details.

- ### `[FREELDR] i386/pc/pcdisk.c: Fix LBA reads retry loop`

    When the Int 13h AH=42h "Extended read" function fails, the disk address
    packet's LBA block count is reset to the number of blocks that have been
    successfully transferred. This is more or less fine, unless one wants to
    ensure the exact number of sectors gets read.

    If the function fails so that zero sectors were read, the retry loop is
    restarted, but with the packet's LBA block count member reset, as per
    the documentation. (In this example, it is reset to zero.) Then, at the
    next retry attempt, zero sectors are requested to be read, and this time
    of course, the call succeeds... Wrongly, of course, this is not what's
    expected.

    Therefore, for each retry, the LBA block count member should be set
    again to the correct number of sectors to read. There are maximum 3
    retries, so the retry loop will stop anyway, but the LBA read will now
    correctly fail and return FALSE, as expected.

    This problem doesn't exist in the retry loop for the
    Int 13h, AH=02h "Read Disk Sectors" CHS function, because here, the call
    is made only using registers, and we use a pair of RegsIn/RegsOut.
    RegsOut will receive the modified register values, but the input RegsIn
    remain unchanged.

For testing the last commit, you can, for example, apply the following patch:
```diff
diff --git a/boot/freeldr/freeldr/arch/i386/pc/pcdisk.c b/boot/freeldr/freeldr/arch/i386/pc/pcdisk.c
index 4d53bf61caf..7229f89df10 100644
--- a/boot/freeldr/freeldr/arch/i386/pc/pcdisk.c
+++ b/boot/freeldr/freeldr/arch/i386/pc/pcdisk.c
@@ -569,6 +569,7 @@ PcDiskReadLogicalSectorsLBA(
     REGS RegsIn, RegsOut;
     ULONG RetryCount;
     PI386_DISK_ADDRESS_PACKET Packet = (PI386_DISK_ADDRESS_PACKET)(BIOSCALLBUFFER);
+static BOOLEAN HitError = FALSE;
 
     /* Setup disk address packet */
     RtlZeroMemory(Packet, sizeof(*Packet));
@@ -595,6 +596,7 @@ PcDiskReadLogicalSectorsLBA(
     RegsIn.x.ds = BIOSCALLBUFSEGMENT;   // DS:SI -> disk address packet
     RegsIn.w.si = BIOSCALLBUFOFFSET;
 
+ERR("--> PcDiskReadLogicalSectorsLBA(0x%x)\n", DriveNumber);
     /* Retry 3 times */
     for (RetryCount = 0; RetryCount < 3; ++RetryCount)
     {
@@ -603,22 +605,43 @@ PcDiskReadLogicalSectorsLBA(
          * transferred (and which could be zero). */
         Packet->LBABlockCount = (USHORT)SectorCount;
 
+ERR("Packet->LBABlockCount: %u\n", Packet->LBABlockCount);
+ERR("Packet->LBAStartBlock: %u\n", Packet->LBAStartBlock);
+ERR("RegsIn:\n");
+DbgDumpBuffer(DPRINT_DISK, &RegsIn, sizeof(RegsIn));
+
         Int386(0x13, &RegsIn, &RegsOut);
 
+ERR("Packet->LBABlockCount: %u\n", Packet->LBABlockCount);
+ERR("Packet->LBAStartBlock: %u\n", Packet->LBAStartBlock);
+ERR("RegsOut:\n");
+DbgDumpBuffer(DPRINT_DISK, &RegsOut, sizeof(RegsOut));
+
         /* If it worked return TRUE */
         if (INT386_SUCCESS(RegsOut))
         {
+if (HitError)
+{
+ERR("<-- PcDiskReadLogicalSectorsLBA(0x%x) - Got read error but return TRUE now?\n", DriveNumber);
+__debugbreak();
+}
             return TRUE;
         }
         /* If it was a corrected ECC error then the data is still good */
         else if (RegsOut.b.ah == 0x11)
         {
+if (HitError)
+{
+ERR("<-- PcDiskReadLogicalSectorsLBA(0x%x) - Got read error but return TRUE now?\n", DriveNumber);
+__debugbreak();
+}
             return TRUE;
         }
         /* If it failed then do the next retry */
         else
         {
             DiskResetController(DriveNumber);
+            HitError = TRUE;
             continue;
         }
     }
@@ -629,6 +652,7 @@ PcDiskReadLogicalSectorsLBA(
         RegsOut.b.ah, DiskGetErrorCodeString(RegsOut.b.ah),
         DriveNumber, SectorNumber, SectorCount);
 
+    HitError = FALSE;
     return FALSE;
 }
 
```
and keep enabled (fix applied), or disable (original buggy behaviour) the line 604:
```c
Packet->LBABlockCount = (USHORT)SectorCount;
```

We obtain for example:

1. Original buggy behaviour:
```
(pcdisk.c:816) err: --> PcDiskReadLogicalSectorsLBA(0xe0)
(pcdisk.c:825) err: Packet->LBABlockCount: 1           // <-- Number of sectors to read
(pcdisk.c:826) err: Packet->LBAStartBlock: 4294967295  // <-- Reading at some buggy LBA
(pcdisk.c:827) err: RegsIn:
Dumping buffer at 0000EDF8 with length of 40 bytes:
0000:   cc 42 cc cc cc cc cc cc-cc cc cc cc e0 cc cc cc
0010:   00 00 cc cc cc cc cc cc-cc cc cc cc 00 04 cc cc
0020:   cc cc cc cc cc cc cc cc-
(pcdisk.c:832) err: Packet->LBABlockCount: 0           // <-- Zero sectors were read, but this is again used
                                                       // as the number of sectors to read for retry... (the BUG)
(pcdisk.c:833) err: Packet->LBAStartBlock: 4294967295
(pcdisk.c:834) err: RegsOut:
Dumping buffer at 0000EDC8 with length of 40 bytes:
0000:   cc 0c cc cc cc cc cc cc-cc cc cc cc e0 cc cc cc
0010:   00 00 cc cc cc cc cc cc-cc cc cc cc 00 04 cc cc
0020:   cc cc cc cc 87 02 00 00-
(pcdisk.c:188) err: DiskResetController(0xe0) DISK OPERATION FAILED -- RESETTING CONTROLLER
(pcdisk.c:825) err: Packet->LBABlockCount: 0
(pcdisk.c:826) err: Packet->LBAStartBlock: 4294967295
(pcdisk.c:827) err: RegsIn:
Dumping buffer at 0000EDF8 with length of 40 bytes:
0000:   cc 42 cc cc cc cc cc cc-cc cc cc cc e0 cc cc cc
0010:   00 00 cc cc cc cc cc cc-cc cc cc cc 00 04 cc cc
0020:   cc cc cc cc cc cc cc cc-
(pcdisk.c:832) err: Packet->LBABlockCount: 0
(pcdisk.c:833) err: Packet->LBAStartBlock: 4294967295
(pcdisk.c:834) err: RegsOut:
Dumping buffer at 0000EDC8 with length of 40 bytes:
0000:   cc 00 cc cc cc cc cc cc-cc cc cc cc e0 cc cc cc
0010:   00 00 cc cc cc cc cc cc-cc cc cc cc 00 04 cc cc
0020:   cc cc cc cc 86 02 00 00-
(pcdisk.c:842) err: <-- PcDiskReadLogicalSectorsLBA(0xe0) - Got read error but return TRUE now?
```

2. Fixed behaviour:
```
(pcdisk.c:816) err: --> PcDiskReadLogicalSectorsLBA(0xe0)
(pcdisk.c:825) err: Packet->LBABlockCount: 1           // <-- Number of sectors to read
(pcdisk.c:826) err: Packet->LBAStartBlock: 49667       // <-- Reading at some (other) buggy LBA
(pcdisk.c:827) err: RegsIn:
Dumping buffer at 0000EDF8 with length of 40 bytes:
0000:   cc 42 cc cc cc cc cc cc-cc cc cc cc e0 cc cc cc
0010:   00 00 cc cc cc cc cc cc-cc cc cc cc 00 04 cc cc
0020:   cc cc cc cc cc cc cc cc-
(pcdisk.c:832) err: Packet->LBABlockCount: 0           // <-- Zero sectors were read (OK)
(pcdisk.c:833) err: Packet->LBAStartBlock: 49667
(pcdisk.c:834) err: RegsOut:
Dumping buffer at 0000EDC8 with length of 40 bytes:
0000:   cc 0c cc cc cc cc cc cc-cc cc cc cc e0 cc cc cc
0010:   00 00 cc cc cc cc cc cc-cc cc cc cc 00 04 cc cc
0020:   cc cc cc cc 87 02 00 00-
(pcdisk.c:188) err: DiskResetController(0xe0) DISK OPERATION FAILED -- RESETTING CONTROLLER
(pcdisk.c:825) err: Packet->LBABlockCount: 1           // <-- The count is now correctly reset to the original value (OK)
(pcdisk.c:826) err: Packet->LBAStartBlock: 49667
(pcdisk.c:827) err: RegsIn:
Dumping buffer at 0000EDF8 with length of 40 bytes:
0000:   cc 42 cc cc cc cc cc cc-cc cc cc cc e0 cc cc cc
0010:   00 00 cc cc cc cc cc cc-cc cc cc cc 00 04 cc cc
0020:   cc cc cc cc cc cc cc cc-
(pcdisk.c:832) err: Packet->LBABlockCount: 0
(pcdisk.c:833) err: Packet->LBAStartBlock: 49667
(pcdisk.c:834) err: RegsOut:
Dumping buffer at 0000EDC8 with length of 40 bytes:
0000:   cc 0c cc cc cc cc cc cc-cc cc cc cc e0 cc cc cc
0010:   00 00 cc cc cc cc cc cc-cc cc cc cc 00 04 cc cc
0020:   cc cc cc cc 87 02 00 00-
(pcdisk.c:188) err: DiskResetController(0xe0) DISK OPERATION FAILED -- RESETTING CONTROLLER
(pcdisk.c:825) err: Packet->LBABlockCount: 1
(pcdisk.c:826) err: Packet->LBAStartBlock: 49667
(pcdisk.c:827) err: RegsIn:
Dumping buffer at 0000EDF8 with length of 40 bytes:
0000:   cc 42 cc cc cc cc cc cc-cc cc cc cc e0 cc cc cc
0010:   00 00 cc cc cc cc cc cc-cc cc cc cc 00 04 cc cc
0020:   cc cc cc cc cc cc cc cc-
(pcdisk.c:832) err: Packet->LBABlockCount: 0
(pcdisk.c:833) err: Packet->LBAStartBlock: 49667
(pcdisk.c:834) err: RegsOut:
Dumping buffer at 0000EDC8 with length of 40 bytes:
0000:   cc 0c cc cc cc cc cc cc-cc cc cc cc e0 cc cc cc
0010:   00 00 cc cc cc cc cc cc-cc cc cc cc 00 04 cc cc
0020:   cc cc cc cc 87 02 00 00-
(pcdisk.c:188) err: DiskResetController(0xe0) DISK OPERATION FAILED -- RESETTING CONTROLLER
(pcdisk.c:870) err: Disk Read Failed in LBA mode: c (unsupported track/invalid media) (DriveNumber: 0xe0 SectorNumber: 49667 SectorCount: 1)
```
Now we observe that we obtain the three (retries) expected `DISK OPERATION FAILED -- RESETTING CONTROLLER` errors, and then the `PcDiskReadLogicalSectorsLBA()` function fails as expected: `Disk Read Failed in LBA mode ...`.
