### PR TITLE
[SERVICES] Fix services delay on stopping

### DIFF
--- a/base/system/services/database.c
+++ b/base/system/services/database.c
@@ -943,11 +943,11 @@ ScmDereferenceService(PSERVICE lpService)
     ASSERT(lpService->RefCount > 0);
 
     ref = InterlockedDecrement(&lpService->RefCount);
-#if 0
-    /* Service should not be automatically deleted here. */
-    if (ref == 0 && lpService->bDeleted)
+
+    if (ref == 0 && lpService->bDeleted &&
+        lpService->Status.dwCurrentState == SERVICE_STOPPED)
+
         ScmDeleteService(lpService);
-#endif
 
     return ref;
 }

--- a/base/system/services/database.c
+++ b/base/system/services/database.c
@@ -877,7 +877,7 @@ DWORD ScmDeleteService(PSERVICE lpService)
                             &hServicesKey);
     if (dwError != ERROR_SUCCESS)
     {
-        DPRINT("Failed to open services key\n");
+        DPRINT1("Failed to open services key\n");
         return dwError;
     }
 
@@ -907,7 +907,7 @@ DWORD ScmDeleteService(PSERVICE lpService)
 
     if (dwError != ERROR_SUCCESS)
     {
-        DPRINT("Failed to Delete the Service Registry key\n");
+        DPRINT1("Failed to Delete the Service Registry key\n");
         return dwError;
     }
 
@@ -1467,7 +1467,7 @@ ScmControlService(HANDLE hControlPipe,
                         &Overlapped);
     if (bResult == FALSE)
     {
-        DPRINT("WriteFile(%S, %d) returned FALSE\n", pServiceName, dwControl);
+        DPRINT1("WriteFile(%S, %d) returned FALSE\n", pServiceName, dwControl);
 
         dwError = GetLastError();
         if (dwError == ERROR_IO_PENDING)
@@ -1484,7 +1484,7 @@ ScmControlService(HANDLE hControlPipe,
                 bResult = CancelIo(hControlPipe);
                 if (bResult == FALSE)
                 {
-                    DPRINT("CancelIo(%S, %d) failed (Error: %lu)\n", pServiceName, dwControl, GetLastError());
+                    DPRINT1("CancelIo(%S, %d) failed (Error: %lu)\n", pServiceName, dwControl, GetLastError());
                 }
 
                 dwError = ERROR_SERVICE_REQUEST_TIMEOUT;
@@ -1499,7 +1499,7 @@ ScmControlService(HANDLE hControlPipe,
                 if (bResult == FALSE)
                 {
                     dwError = GetLastError();
-                    DPRINT("GetOverlappedResult(%S, %d) failed (Error %lu)\n", pServiceName, dwControl, dwError);
+                    DPRINT1("GetOverlappedResult(%S, %d) failed (Error %lu)\n", pServiceName, dwControl, dwError);
 
                     goto Done;
                 }
@@ -1507,7 +1507,7 @@ ScmControlService(HANDLE hControlPipe,
         }
         else
         {
-            DPRINT("WriteFile(%S, %d) failed (Error %lu)\n", pServiceName, dwControl, dwError);
+            DPRINT1("WriteFile(%S, %d) failed (Error %lu)\n", pServiceName, dwControl, dwError);
             goto Done;
         }
     }
@@ -1522,7 +1522,7 @@ ScmControlService(HANDLE hControlPipe,
                        &Overlapped);
     if (bResult == FALSE)
     {
-        DPRINT("ReadFile(%S, %d) returned FALSE\n", pServiceName, dwControl);
+        DPRINT1("ReadFile(%S, %d) returned FALSE\n", pServiceName, dwControl);
 
         dwError = GetLastError();
         if (dwError == ERROR_IO_PENDING)
@@ -1535,11 +1535,11 @@ ScmControlService(HANDLE hControlPipe,
 
             if (dwError == WAIT_TIMEOUT)
             {
-                DPRINT1("WaitForSingleObject(%S, %d) timed out\n", pServiceName, dwControl, dwError);
+                DPRINT("WaitForSingleObject(%S, %d) timed out\n", pServiceName, dwControl, dwError);
                 bResult = CancelIo(hControlPipe);
                 if (bResult == FALSE)
                 {
-                    DPRINT("CancelIo(%S, %d) failed (Error: %lu)\n", pServiceName, dwControl, GetLastError());
+                    DPRINT1("CancelIo(%S, %d) failed (Error: %lu)\n", pServiceName, dwControl, GetLastError());
                 }
 
                 dwError = ERROR_SERVICE_REQUEST_TIMEOUT;
@@ -1554,7 +1554,7 @@ ScmControlService(HANDLE hControlPipe,
                 if (bResult == FALSE)
                 {
                     dwError = GetLastError();
-                    DPRINT("GetOverlappedResult(%S, %d) failed (Error %lu)\n", pServiceName, dwControl, dwError);
+                    DPRINT1("GetOverlappedResult(%S, %d) failed (Error %lu)\n", pServiceName, dwControl, dwError);
 
                     goto Done;
                 }
@@ -1562,7 +1562,7 @@ ScmControlService(HANDLE hControlPipe,
         }
         else
         {
-            DPRINT("ReadFile(%S, %d) failed (Error %lu)\n", pServiceName, dwControl, dwError);
+            DPRINT1("ReadFile(%S, %d) failed (Error %lu)\n", pServiceName, dwControl, dwError);
             goto Done;
         }
     }

--- a/base/system/services/database.c
+++ b/base/system/services/database.c
@@ -907,7 +907,7 @@ DWORD ScmDeleteService(PSERVICE lpService)
 
     if (dwError != ERROR_SUCCESS)
     {
-        DPRINT1("Failed to Delete the Service Registry key\n");
+        DPRINT1("Failed to delete the Service Registry key\n");
         return dwError;
     }
 
@@ -938,7 +938,7 @@ ScmReferenceService(PSERVICE lpService)
 DWORD
 ScmDereferenceService(PSERVICE lpService)
 {
-    ULONG ref;
+    DWORD ref;
 
     ASSERT(lpService->RefCount > 0);
 
@@ -946,9 +946,9 @@ ScmDereferenceService(PSERVICE lpService)
 
     if (ref == 0 && lpService->bDeleted &&
         lpService->Status.dwCurrentState == SERVICE_STOPPED)
-
+    {
         ScmDeleteService(lpService);
-
+    }
     return ref;
 }
 
@@ -1410,8 +1410,8 @@ ScmGetBootAndSystemDriverState(VOID)
 
 
 /*
- * ScmControlService must never be called with the database lock being held
- * The service passed must always be referenced instead
+ * ScmControlService must never be called with the database lock being held.
+ * The service passed must always be referenced instead.
  */
 DWORD
 ScmControlService(HANDLE hControlPipe,
@@ -1535,7 +1535,7 @@ ScmControlService(HANDLE hControlPipe,
 
             if (dwError == WAIT_TIMEOUT)
             {
-                DPRINT("WaitForSingleObject(%S, %d) timed out\n", pServiceName, dwControl, dwError);
+                DPRINT1("WaitForSingleObject(%S, %d) timed out\n", pServiceName, dwControl, dwError);
                 bResult = CancelIo(hControlPipe);
                 if (bResult == FALSE)
                 {

--- a/base/system/services/database.c
+++ b/base/system/services/database.c
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * PROJECT:     ReactOS Service Control Manager
  * LICENSE:     GPL - See COPYING in the top level directory
  * FILE:        base/system/services/database.c

--- a/base/system/services/database.c
+++ b/base/system/services/database.c
@@ -894,7 +894,7 @@ DWORD ScmDeleteService(PSERVICE lpService)
     {
         DPRINT1("Deletion failed due to running dependencies\n");
         RegCloseKey(hServicesKey);
-        return ERROR_SUCCESS;
+        return ERROR_DEPENDENT_SERVICES_RUNNING;
     }
 
     /* There are no references and no running dependencies,

--- a/base/system/services/database.c
+++ b/base/system/services/database.c
@@ -924,7 +924,7 @@ DWORD ScmDeleteService(PSERVICE lpService)
  * A running service will keep a reference for the whole time it is not SERVICE_STOPPED.
  * A service handle will also keep a reference to a service. Keeping a reference is
  * really needed so that ScmControlService can be called without keeping the database locked.
- * This means that eventually the correct order of operations to send a control message to 
+ * This means that eventually the correct order of operations to send a control message to
  * a service looks like: lock, reference, unlock, send control, lock, dereference, unlock.
  */
 DWORD
@@ -1409,8 +1409,8 @@ ScmGetBootAndSystemDriverState(VOID)
 }
 
 
-/* 
- * ScmControlService must never be called with the database lock being held 
+/*
+ * ScmControlService must never be called with the database lock being held
  * The service passed must always be referenced instead
  */
 DWORD

--- a/base/system/services/database.c
+++ b/base/system/services/database.c
@@ -892,7 +892,7 @@ DWORD ScmDeleteService(PSERVICE lpService)
     /* If pcbBytesNeeded returned a value then there are services running that are dependent on this service */
     if (pcbBytesNeeded)
     {
-        DPRINT("Deletion failed due to running dependencies\n");
+        DPRINT1("Deletion failed due to running dependencies\n");
         RegCloseKey(hServicesKey);
         return ERROR_SUCCESS;
     }

--- a/base/system/services/rpcserver.c
+++ b/base/system/services/rpcserver.c
@@ -116,7 +116,7 @@ ScmStartRpcServer(VOID)
                                     NULL);
     if (Status != RPC_S_OK)
     {
-        DPRINT("RpcServerUseProtseqEpW() failed (Status %lx)\n", Status);
+        DPRINT1("RpcServerUseProtseqEpW() failed (Status %lx)\n", Status);
         return;
     }
 
@@ -125,14 +125,14 @@ ScmStartRpcServer(VOID)
                                  NULL);
     if (Status != RPC_S_OK)
     {
-        DPRINT("RpcServerRegisterIf() failed (Status %lx)\n", Status);
+        DPRINT1("RpcServerRegisterIf() failed (Status %lx)\n", Status);
         return;
     }
 
     Status = RpcServerListen(1, 20, TRUE);
     if (Status != RPC_S_OK)
     {
-        DPRINT("RpcServerListen() failed (Status %lx)\n", Status);
+        DPRINT1("RpcServerListen() failed (Status %lx)\n", Status);
         return;
     }
 
@@ -210,7 +210,7 @@ ScmGetServiceManagerFromHandle(SC_RPC_HANDLE Handle)
     }
     _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
     {
-        DPRINT("Exception: Invalid Service Manager handle\n");
+        DPRINT1("Exception: Invalid Service Manager handle\n");
     }
     _SEH2_END;
 
@@ -230,7 +230,7 @@ ScmGetServiceFromHandle(SC_RPC_HANDLE Handle)
     }
     _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
     {
-        DPRINT("Exception: Invalid Service handle\n");
+        DPRINT1("Exception: Invalid Service handle\n");
     }
     _SEH2_END;
 
@@ -390,7 +390,7 @@ cleanup:
     }
     else
     {
-        DPRINT("Failed to assign new tag to service %S, error=%lu\n",
+        DPRINT1("Failed to assign new tag to service %S, error=%lu\n",
                 lpService->lpServiceName, dwError);
     }
 
@@ -1030,7 +1030,7 @@ RControlService(
     hSvc = ScmGetServiceFromHandle(hService);
     if (hSvc == NULL)
     {
-        DPRINT("Invalid service handle\n");
+        DPRINT1("Invalid service handle\n");
         return ERROR_INVALID_HANDLE;
     }
 
@@ -1038,7 +1038,7 @@ RControlService(
     lpService = hSvc->ServiceEntry;
     if (lpService == NULL)
     {
-        DPRINT("lpService == NULL\n");
+        DPRINT1("lpService == NULL\n");
         return ERROR_INVALID_HANDLE;
     }
 
@@ -1253,7 +1253,7 @@ RDeleteService(
     hSvc = ScmGetServiceFromHandle(hService);
     if (hSvc == NULL)
     {
-        DPRINT("Invalid service handle\n");
+        DPRINT1("Invalid service handle\n");
         return ERROR_INVALID_HANDLE;
     }
 
@@ -1309,7 +1309,7 @@ RLockServiceDatabase(
     hMgr = ScmGetServiceManagerFromHandle(hSCManager);
     if (hMgr == NULL)
     {
-        DPRINT("Invalid service manager handle\n");
+        DPRINT1("Invalid service manager handle\n");
         return ERROR_INVALID_HANDLE;
     }
 
@@ -1343,7 +1343,7 @@ RQueryServiceObjectSecurity(
     hSvc = ScmGetServiceFromHandle(hService);
     if (hSvc == NULL)
     {
-        DPRINT("Invalid service handle\n");
+        DPRINT1("Invalid service handle\n");
         return ERROR_INVALID_HANDLE;
     }
 
@@ -1428,7 +1428,7 @@ RSetServiceObjectSecurity(
     hSvc = ScmGetServiceFromHandle(hService);
     if (hSvc == NULL)
     {
-        DPRINT("Invalid service handle\n");
+        DPRINT1("Invalid service handle\n");
         return ERROR_INVALID_HANDLE;
     }
 
@@ -1466,14 +1466,14 @@ RSetServiceObjectSecurity(
     if (!RtlAreAllAccessesGranted(hSvc->Handle.DesiredAccess,
                                   DesiredAccess))
     {
-        DPRINT("Insufficient access rights! 0x%lx\n", hSvc->Handle.DesiredAccess);
+        DPRINT1("Insufficient access rights! 0x%lx\n", hSvc->Handle.DesiredAccess);
         return ERROR_ACCESS_DENIED;
     }
 
     lpService = hSvc->ServiceEntry;
     if (lpService == NULL)
     {
-        DPRINT("lpService == NULL\n");
+        DPRINT1("lpService == NULL\n");
         return ERROR_INVALID_HANDLE;
     }
 
@@ -1557,7 +1557,7 @@ RQueryServiceStatus(
     hSvc = ScmGetServiceFromHandle(hService);
     if (hSvc == NULL)
     {
-        DPRINT("Invalid service handle\n");
+        DPRINT1("Invalid service handle\n");
         return ERROR_INVALID_HANDLE;
     }
 
@@ -1802,7 +1802,7 @@ RSetServiceStatus(
             /* We can't leave without releasing the reference.
              * We also can't remove it without holding the lock. */
             ScmDereferenceService(lpService);
-            DPRINT("Service %S has %d references after stoping\n", lpService->lpServiceName, lpService->RefCount);
+            DPRINT1("Service %S has %d references after stoping\n", lpService->lpServiceName, lpService->RefCount);
         }
         else
         {
@@ -1841,6 +1841,7 @@ RSetServiceStatus(
                     lpLogStrings);
     }
 
+    DPRINT("Set %S to %lu\n", lpService->lpDisplayName, lpService->Status.dwCurrentState);
     DPRINT("RSetServiceStatus() done\n");
 
     return ERROR_SUCCESS;
@@ -1972,7 +1973,7 @@ RChangeServiceConfigW(
     hSvc = ScmGetServiceFromHandle(hService);
     if (hSvc == NULL)
     {
-        DPRINT("Invalid service handle\n");
+        DPRINT1("Invalid service handle\n");
         return ERROR_INVALID_HANDLE;
     }
 
@@ -2229,7 +2230,7 @@ RChangeServiceConfigW(
                                              &lpClearTextPassword);
                 if (dwError != ERROR_SUCCESS)
                 {
-                    DPRINT("ScmDecryptPassword failed (Error %lu)\n", dwError);
+                    DPRINT1("ScmDecryptPassword failed (Error %lu)\n", dwError);
                     goto done;
                 }
                 DPRINT("Clear text password: %S\n", lpClearTextPassword);
@@ -2239,7 +2240,7 @@ RChangeServiceConfigW(
                                                 lpClearTextPassword);
                 if (dwError != ERROR_SUCCESS)
                 {
-                    DPRINT("ScmSetServicePassword failed (Error %lu)\n", dwError);
+                    DPRINT1("ScmSetServicePassword failed (Error %lu)\n", dwError);
                     goto done;
                 }
             }
@@ -2253,7 +2254,7 @@ RChangeServiceConfigW(
 
                 if (dwError != ERROR_SUCCESS)
                 {
-                    DPRINT("ScmSetServicePassword failed (Error %lu)\n", dwError);
+                    DPRINT1("ScmSetServicePassword failed (Error %lu)\n", dwError);
                     goto done;
                 }
             }
@@ -2328,7 +2329,7 @@ RCreateServiceW(
     hManager = ScmGetServiceManagerFromHandle(hSCManager);
     if (hManager == NULL)
     {
-        DPRINT("Invalid service manager handle\n");
+        DPRINT1("Invalid service manager handle\n");
         return ERROR_INVALID_HANDLE;
     }
 
@@ -2745,7 +2746,7 @@ REnumDependentServicesW(
     hSvc = ScmGetServiceFromHandle(hService);
     if (hSvc == NULL)
     {
-        DPRINT("Invalid service handle\n");
+        DPRINT1("Invalid service handle\n");
         return ERROR_INVALID_HANDLE;
     }
 
@@ -2792,7 +2793,7 @@ REnumDependentServicesW(
                                 (dwServicesReturned + 1) * sizeof(PSERVICE));
     if (!lpServicesArray)
     {
-        DPRINT("Could not allocate buffer\n");
+        DPRINT1("Could not allocate buffer\n");
         dwError = ERROR_NOT_ENOUGH_MEMORY;
         goto Done;
     }
@@ -2955,7 +2956,7 @@ ROpenServiceW(
     hManager = ScmGetServiceManagerFromHandle(hSCManager);
     if (hManager == NULL)
     {
-        DPRINT("Invalid service manager handle\n");
+        DPRINT1("Invalid service manager handle\n");
         return ERROR_INVALID_HANDLE;
     }
 
@@ -3041,7 +3042,7 @@ RQueryServiceConfigW(
     hSvc = ScmGetServiceFromHandle(hService);
     if (hSvc == NULL)
     {
-        DPRINT("Invalid service handle\n");
+        DPRINT1("Invalid service handle\n");
         return ERROR_INVALID_HANDLE;
     }
 
@@ -3239,7 +3240,7 @@ RQueryServiceLockStatusW(
     hMgr = ScmGetServiceManagerFromHandle(hSCManager);
     if (hMgr == NULL)
     {
-        DPRINT("Invalid service manager handle\n");
+        DPRINT1("Invalid service manager handle\n");
         return ERROR_INVALID_HANDLE;
     }
 
@@ -3295,7 +3296,7 @@ RStartServiceW(
     hSvc = ScmGetServiceFromHandle(hService);
     if (hSvc == NULL)
     {
-        DPRINT("Invalid service handle\n");
+        DPRINT1("Invalid service handle\n");
         return ERROR_INVALID_HANDLE;
     }
 
@@ -3783,7 +3784,7 @@ REnumDependentServicesA(
     hSvc = ScmGetServiceFromHandle(hService);
     if (hSvc == NULL)
     {
-        DPRINT("Invalid service handle\n");
+        DPRINT1("Invalid service handle\n");
         return ERROR_INVALID_HANDLE;
     }
 
@@ -4112,7 +4113,7 @@ RQueryServiceConfigA(
     hSvc = ScmGetServiceFromHandle(hService);
     if (hSvc == NULL)
     {
-        DPRINT("Invalid service handle\n");
+        DPRINT1("Invalid service handle\n");
         return ERROR_INVALID_HANDLE;
     }
 
@@ -4343,7 +4344,7 @@ RQueryServiceLockStatusA(
     hMgr = ScmGetServiceManagerFromHandle(hSCManager);
     if (hMgr == NULL)
     {
-        DPRINT("Invalid service manager handle\n");
+        DPRINT1("Invalid service manager handle\n");
         return ERROR_INVALID_HANDLE;
     }
 
@@ -4390,7 +4391,7 @@ RStartServiceA(
     hSvc = ScmGetServiceFromHandle(hService);
     if (hSvc == NULL)
     {
-        DPRINT("Invalid service handle\n");
+        DPRINT1("Invalid service handle\n");
         return ERROR_INVALID_HANDLE;
     }
 
@@ -4725,7 +4726,7 @@ RI_ScGetCurrentGroupStateW(
     hManager = ScmGetServiceManagerFromHandle(hSCManager);
     if (hManager == NULL)
     {
-        DPRINT("Invalid service manager handle\n");
+        DPRINT1("Invalid service manager handle\n");
         return ERROR_INVALID_HANDLE;
     }
 
@@ -4797,7 +4798,7 @@ REnumServiceGroupW(
     hManager = ScmGetServiceManagerFromHandle(hSCManager);
     if (hManager == NULL)
     {
-        DPRINT("Invalid service manager handle\n");
+        DPRINT1("Invalid service manager handle\n");
         return ERROR_INVALID_HANDLE;
     }
 
@@ -5599,7 +5600,7 @@ RQueryServiceConfig2A(
     hSvc = ScmGetServiceFromHandle(hService);
     if (hSvc == NULL)
     {
-        DPRINT("Invalid service handle\n");
+        DPRINT1("Invalid service handle\n");
         return ERROR_INVALID_HANDLE;
     }
 
@@ -5845,7 +5846,7 @@ RQueryServiceConfig2W(
     hSvc = ScmGetServiceFromHandle(hService);
     if (hSvc == NULL)
     {
-        DPRINT("Invalid service handle\n");
+        DPRINT1("Invalid service handle\n");
         return ERROR_INVALID_HANDLE;
     }
 
@@ -6062,7 +6063,7 @@ RQueryServiceStatusEx(
     hSvc = ScmGetServiceFromHandle(hService);
     if (hSvc == NULL)
     {
-        DPRINT("Invalid service handle\n");
+        DPRINT1("Invalid service handle\n");
         return ERROR_INVALID_HANDLE;
     }
 
@@ -6283,7 +6284,7 @@ REnumServicesStatusExW(
     hManager = ScmGetServiceManagerFromHandle(hSCManager);
     if (hManager == NULL)
     {
-        DPRINT("Invalid service manager handle\n");
+        DPRINT1("Invalid service manager handle\n");
         return ERROR_INVALID_HANDLE;
     }
 
@@ -6740,7 +6741,7 @@ RI_ScValidatePnPService(
     hManager = ScmGetServiceManagerFromHandle(hSCManager);
     if (hManager == NULL)
     {
-        DPRINT("Invalid handle\n");
+        DPRINT1("Invalid handle\n");
         return ERROR_INVALID_HANDLE;
     }
 
@@ -6750,7 +6751,7 @@ RI_ScValidatePnPService(
     if (!RtlAreAllAccessesGranted(hManager->Handle.DesiredAccess,
                                   SC_MANAGER_CONNECT))
     {
-        DPRINT("No SC_MANAGER_CONNECT access\n");
+        DPRINT1("No SC_MANAGER_CONNECT access\n");
         return ERROR_ACCESS_DENIED;
     }
 

--- a/base/system/services/rpcserver.c
+++ b/base/system/services/rpcserver.c
@@ -1802,7 +1802,7 @@ RSetServiceStatus(
             /* We can't leave without releasing the reference.
              * We also can't remove it without holding the lock. */
             ScmDereferenceService(lpService);
-            DPRINT1("Service %S has %d references after stoping\n", lpService->lpServiceName, lpService->RefCount);
+            DPRINT1("Service %S has %d references after stop\n", lpService->lpServiceName, lpService->RefCount);
         }
         else
         {

--- a/base/system/services/rpcserver.c
+++ b/base/system/services/rpcserver.c
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * PROJECT:     ReactOS Service Control Manager
  * LICENSE:     GPL - See COPYING in the top level directory
  * FILE:        base/system/services/rpcserver.c

--- a/base/system/services/rpcserver.c
+++ b/base/system/services/rpcserver.c
@@ -777,8 +777,7 @@ ScmCanonDriverImagePath(DWORD dwStartType,
 }
 
 
-/* Recursive function */
-/* Need to search for every dependency on every service */
+/* Recursively search for every dependency on every service */
 DWORD
 Int_EnumDependentServicesW(HKEY hServicesKey,
                            PSERVICE lpService,

--- a/base/system/services/rpcserver.c
+++ b/base/system/services/rpcserver.c
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * PROJECT:     ReactOS Service Control Manager
  * LICENSE:     GPL - See COPYING in the top level directory
  * FILE:        base/system/services/rpcserver.c
@@ -1186,7 +1186,7 @@ RControlService(
         }
 
         /* Send control code to the service */
-        dwError = ScmControlService(lpService,
+        dwError = ScmControlService(lpService->lpImage->hControlPipe,
                                     lpService->lpServiceName,
                                     (SERVICE_STATUS_HANDLE)lpService,
                                     dwControl);
@@ -1625,7 +1625,7 @@ ScmStopThread(PVOID pParam)
          * We must not send a control message while holding the database lock, otherwise it can cause timeouts
          * We are sure that the service won't be deleted in the meantime because we still have a reference to it. */
         DPRINT("Stopping the dispatcher thread for service %S\n", lpService->lpServiceName);
-        ScmControlService(lpService,
+        ScmControlService(lpService->lpImage->hControlPipe,
                           L"",
                           (SERVICE_STATUS_HANDLE)lpService,
                           SERVICE_CONTROL_STOP);

--- a/base/system/services/rpcserver.c
+++ b/base/system/services/rpcserver.c
@@ -6740,7 +6740,7 @@ RI_ScValidatePnPService(
     hManager = ScmGetServiceManagerFromHandle(hSCManager);
     if (hManager == NULL)
     {
-        DPRINT("Invalid handle!\n");
+        DPRINT("Invalid handle\n");
         return ERROR_INVALID_HANDLE;
     }
 
@@ -6750,7 +6750,7 @@ RI_ScValidatePnPService(
     if (!RtlAreAllAccessesGranted(hManager->Handle.DesiredAccess,
                                   SC_MANAGER_CONNECT))
     {
-        DPRINT("No SC_MANAGER_CONNECT access!\n");
+        DPRINT("No SC_MANAGER_CONNECT access\n");
         return ERROR_ACCESS_DENIED;
     }
 

--- a/base/system/services/rpcserver.c
+++ b/base/system/services/rpcserver.c
@@ -1698,8 +1698,6 @@ RSetServiceStatus(
     LPCWSTR lpLogStrings[2];
     WCHAR szLogBuffer[80];
     UINT uID;
-    HANDLE hStopThread;
-    DWORD dwStopThreadId;
 
     DPRINT("RSetServiceStatus() called\n");
     DPRINT("hServiceStatus = %lu\n", hServiceStatus);
@@ -1782,6 +1780,8 @@ RSetServiceStatus(
     if (lpServiceStatus->dwCurrentState == SERVICE_STOPPED &&
         dwPreviousState != SERVICE_STOPPED)
     {
+        HANDLE hStopThread;
+        DWORD dwStopThreadId;
         DPRINT("Service %S, currentstate: %d, prev: %d\n", lpService->lpServiceName, lpServiceStatus->dwCurrentState, dwPreviousState);
 
         /* 

--- a/base/system/services/rpcserver.c
+++ b/base/system/services/rpcserver.c
@@ -1662,7 +1662,7 @@ ScmStopThread(PVOID pParam)
                     ARRAYSIZE(lpLogStrings),
                     lpLogStrings);
     }
-    else 
+    else
     {
         /* Log a successful service status change */
         LoadStringW(GetModuleHandle(NULL), IDS_SERVICE_STOPPED, szLogBuffer, ARRAYSIZE(szLogBuffer));
@@ -1784,7 +1784,7 @@ RSetServiceStatus(
         DWORD dwStopThreadId;
         DPRINT("Service %S, currentstate: %d, prev: %d\n", lpService->lpServiceName, lpServiceStatus->dwCurrentState, dwPreviousState);
 
-        /* 
+        /*
          * The service just changed its status to stopped.
          * Create a thread that will complete the stop sequence.
          * This thread will remove the reference that was added when the service started.

--- a/base/system/services/services.h
+++ b/base/system/services/services.h
@@ -65,7 +65,7 @@ typedef struct _SERVICE
     PSERVICE_IMAGE lpImage;
     BOOL bDeleted;
     DWORD dwResumeCount;
-    DWORD dwRefCount;
+    LONG RefCount;
 
     SERVICE_STATUS Status;
     DWORD dwStartType;
@@ -186,6 +186,9 @@ DWORD ScmStartService(PSERVICE Service,
                       DWORD argc,
                       LPWSTR *argv);
 
+DWORD ScmReferenceService(PSERVICE lpService);
+DWORD ScmDereferenceService(PSERVICE lpService);
+
 VOID ScmRemoveServiceImage(PSERVICE_IMAGE pServiceImage);
 PSERVICE ScmGetServiceEntryByName(LPCWSTR lpServiceName);
 PSERVICE ScmGetServiceEntryByDisplayName(LPCWSTR lpDisplayName);
@@ -197,10 +200,11 @@ DWORD ScmCreateNewServiceRecord(LPCWSTR lpServiceName,
 VOID ScmDeleteServiceRecord(PSERVICE lpService);
 DWORD ScmMarkServiceForDelete(PSERVICE pService);
 
-DWORD ScmControlService(HANDLE hControlPipe,
-                        PWSTR pServiceName,
-                        SERVICE_STATUS_HANDLE hServiceStatus,
-                        DWORD dwControl);
+DWORD
+ScmControlService(PSERVICE lpService,
+    PWSTR pServiceName,
+    SERVICE_STATUS_HANDLE hServiceStatus,
+    DWORD dwControl);
 
 BOOL ScmLockDatabaseExclusive(VOID);
 BOOL ScmLockDatabaseShared(VOID);

--- a/base/system/services/services.h
+++ b/base/system/services/services.h
@@ -201,7 +201,7 @@ VOID ScmDeleteServiceRecord(PSERVICE lpService);
 DWORD ScmMarkServiceForDelete(PSERVICE pService);
 
 DWORD
-ScmControlService(PSERVICE lpService,
+ScmControlService(HANDLE hControlPipe,
     PWSTR pServiceName,
     SERVICE_STATUS_HANDLE hServiceStatus,
     DWORD dwControl);

--- a/base/system/services/services.h
+++ b/base/system/services/services.h
@@ -200,11 +200,10 @@ DWORD ScmCreateNewServiceRecord(LPCWSTR lpServiceName,
 VOID ScmDeleteServiceRecord(PSERVICE lpService);
 DWORD ScmMarkServiceForDelete(PSERVICE pService);
 
-DWORD
-ScmControlService(HANDLE hControlPipe,
-    PWSTR pServiceName,
-    SERVICE_STATUS_HANDLE hServiceStatus,
-    DWORD dwControl);
+DWORD ScmControlService(HANDLE hControlPipe,
+                        PWSTR pServiceName,
+                        SERVICE_STATUS_HANDLE hServiceStatus,
+                        DWORD dwControl);
 
 BOOL ScmLockDatabaseExclusive(VOID);
 BOOL ScmLockDatabaseShared(VOID);


### PR DESCRIPTION
## Purpose

_Fix services delay on stopping. Retry of PR #1225._

JIRA issue: [CORE-16949](https://jira.reactos.org/browse/CORE-16949)
and [CORE-15064](https://jira.reactos.org/browse/CORE-15064)

## Proposed changes

_Retry of @yagoulas services PR #1225 with small fixes from the original PR._

Some tests can be found here: https://github.com/reactos/reactos/pull/7375#discussion_r1779273121

Testbot Results:
refs/pull/7375/merge on 0.4.16-dev-92-g0c2cdca

KVM:  https://reactos.org/testman/compare.php?ids=98133,98135 LGTM
VBox:  https://reactos.org/testman/compare.php?ids=98132,98140 LGTM

KVM:  Total Test Time 41.1/34.9 minutes (6 minutes less)
VBox: Total Test Time 38.5/33.5 minutes (5 minutes less)

Note two previous VBox runs had an extra reboot/[SYSREG] timeout in user32:sysparams
VBox: https://reactos.org/testman/compare.php?ids=98136,98138