### PR TITLE
[FREELDR][NDK][X64] Remove KIP0PCRADDRESS definition and mapping

### DIFF
--- a/boot/freeldr/freeldr/include/arch/amd64/amd64.h
+++ b/boot/freeldr/freeldr/include/arch/amd64/amd64.h
@@ -22,10 +22,6 @@
 #pragma once
 #endif
 
-// This is needed because headers define wrong one for ReactOS
-#undef KIP0PCRADDRESS
-#define KIP0PCRADDRESS                      0xFFFFF78000001000ULL /* FIXME!!! */
-
 #define VA_MASK 0x0000FFFFFFFFFFFFUL
 
 #define PtrToPfn(p) \

--- a/sdk/include/ndk/amd64/ketypes.h
+++ b/sdk/include/ndk/amd64/ketypes.h
@@ -81,17 +81,6 @@ Author:
 #define KF_CAT_BIT                      44 // From ksamd64.inc (0x2C -> 0x100000000000)
 
 //
-// KPCR Access for non-IA64 builds
-//
-//#define K0IPCR                  ((ULONG_PTR)(KIP0PCRADDRESS))
-//#define PCR                     ((volatile KPCR * const)K0IPCR)
-#define PCR ((volatile KPCR * const)__readgsqword(FIELD_OFFSET(KPCR, Self)))
-//#if defined(CONFIG_SMP) || defined(NT_BUILD)
-//#undef  KeGetPcr
-//#define KeGetPcr()              ((volatile KPCR * const)__readfsdword(0x1C))
-//#endif
-
-//
 // Double fault stack size
 //
 #define DOUBLE_FAULT_STACK_SIZE 0x2000


### PR DESCRIPTION
It is not used by either ReactOS or Windows.

We are saving 4KB of memory!1!11
