### PR TITLE
[FREELDR] Print arch + buildnumber on crash-screen

### DIFF
--- a/boot/freeldr/freeldr/arch/i386/i386bug.c
+++ b/boot/freeldr/freeldr/arch/i386/i386bug.c
@@ -1,6 +1,7 @@
 
 #include <freeldr.h>
 
+#include <reactos/buildno.h>
 #include <debug.h>
 
 typedef struct _FRAME
@@ -115,7 +116,7 @@ i386PrintExceptionText(ULONG TrapIndex, PKTRAP_FRAME TrapFrame, PKSPECIAL_REGIST
     i386_ScreenPosX = 0;
     i386_ScreenPosY = 0;
 
-    PrintText("An error occured in " VERSION "\n"
+    PrintText("FreeLdr " KERNEL_VERSION_STR " " KERNEL_VERSION_BUILD_STR "\n"
               "Report this error on the ReactOS Bug Tracker: https://jira.reactos.org\n\n"
               "0x%02lx: %s\n\n", TrapIndex, i386ExceptionDescriptionText[TrapIndex]);
 


### PR DESCRIPTION
Recreation of #7269 rebased on last 0.4.15-dev-commit before the branching 945e856031137b566e616248e2f80c92be807c45
to get those stupid MSVC builders green.

Maybe we should have done this way of writing out the version 10 years ago already, because
JIRA issue: all the 100 tickets linked against CORE-6762 (I intentionally did not want this to create a link to that)

See https://jira.reactos.org/browse/CORE-19716?focusedId=143079&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-143079

After pic: (yes, the L in FreeLdr would be capitalized actually) (shows arch, builddate, short-rev):
![image](https://github.com/user-attachments/assets/6fe4f706-16f0-4737-aa81-951ea2f04d63)
