### PR TITLE
[FREELDR] Less outdated version-hardcodes

### DIFF
--- a/boot/freeldr/freeldr/freeldr.c
+++ b/boot/freeldr/freeldr/freeldr.c
@@ -26,6 +26,12 @@ DBG_DEFAULT_CHANNEL(WARNING);
 
 /* GLOBALS ********************************************************************/
 
+#define TOSTRING_(X) #X
+#define TOSTRING(X) TOSTRING_(X)
+
+const PCSTR FrLdrVersionString =
+    "FreeLoader v" TOSTRING(FREELOADER_MAJOR_VERSION) "." TOSTRING(FREELOADER_MINOR_VERSION);
+
 CCHAR FrLdrBootPath[MAX_PATH] = "";
 
 /* FUNCTIONS ******************************************************************/

--- a/boot/freeldr/freeldr/freeldr.c
+++ b/boot/freeldr/freeldr/freeldr.c
@@ -26,12 +26,6 @@ DBG_DEFAULT_CHANNEL(WARNING);
 
 /* GLOBALS ********************************************************************/
 
-#define TOSTRING_(X) #X
-#define TOSTRING(X) TOSTRING_(X)
-
-const PCSTR FrLdrVersionString =
-    "FreeLoader v" TOSTRING(FREELOADER_MAJOR_VERSION) "." TOSTRING(FREELOADER_MINOR_VERSION);
-
 CCHAR FrLdrBootPath[MAX_PATH] = "";
 
 /* FUNCTIONS ******************************************************************/

--- a/boot/freeldr/freeldr/freeldr.c
+++ b/boot/freeldr/freeldr/freeldr.c
@@ -26,16 +26,6 @@ DBG_DEFAULT_CHANNEL(WARNING);
 
 /* GLOBALS ********************************************************************/
 
-#define TOSTRING_(X) #X
-#define TOSTRING(X) TOSTRING_(X)
-
-const PCSTR FrLdrVersionString =
-#if (FREELOADER_PATCH_VERSION == 0)
-    "FreeLoader v" TOSTRING(FREELOADER_MAJOR_VERSION) "." TOSTRING(FREELOADER_MINOR_VERSION);
-#else
-    "FreeLoader v" TOSTRING(FREELOADER_MAJOR_VERSION) "." TOSTRING(FREELOADER_MINOR_VERSION) "." TOSTRING(FREELOADER_PATCH_VERSION);
-#endif
-
 CCHAR FrLdrBootPath[MAX_PATH] = "";
 
 /* FUNCTIONS ******************************************************************/

--- a/boot/freeldr/freeldr/include/ver.h
+++ b/boot/freeldr/freeldr/include/ver.h
@@ -19,15 +19,10 @@
 
 #pragma once
 
-#define COPYRIGHT       "Copyright (C) 1996-" COPYRIGHT_YEAR " ReactOS Project"
-#define AUTHOR_EMAIL    "<www.reactos.org>"
-#define BY_AUTHOR       "by ReactOS Project"
-
 // FreeLoader version defines
 // If you add features then you increment the minor version
 // If you add major functionality then you increment the major version and zero the minor version
-#define FREELOADER_MAJOR_VERSION    3
-#define FREELOADER_MINOR_VERSION    2
-#define TOSTRING_(X) #X
-#define TOSTRING(X) TOSTRING_(X)
-#define VERSION "FreeLoader v" TOSTRING(FREELOADER_MAJOR_VERSION) "." TOSTRING(FREELOADER_MINOR_VERSION)
+#define VERSION         "FreeLoader v3.2"
+#define COPYRIGHT       "Copyright (C) 1996-" COPYRIGHT_YEAR " ReactOS Project"
+#define AUTHOR_EMAIL    "<www.reactos.org>"
+#define BY_AUTHOR       "by ReactOS Project"

--- a/boot/freeldr/freeldr/include/ver.h
+++ b/boot/freeldr/freeldr/include/ver.h
@@ -19,6 +19,15 @@
 
 #pragma once
 
+#define VERSION         "FreeLoader v3.2"
 #define COPYRIGHT       "Copyright (C) 1996-" COPYRIGHT_YEAR " ReactOS Project"
 #define AUTHOR_EMAIL    "<www.reactos.org>"
 #define BY_AUTHOR       "by ReactOS Project"
+
+// FreeLoader version defines
+// If you add features then you increment the minor version
+// If you add major functionality then you increment the major version and zero the minor version
+#define FREELOADER_MAJOR_VERSION    3
+#define FREELOADER_MINOR_VERSION    2
+
+extern const PCSTR FrLdrVersionString;

--- a/boot/freeldr/freeldr/include/ver.h
+++ b/boot/freeldr/freeldr/include/ver.h
@@ -19,7 +19,6 @@
 
 #pragma once
 
-#define VERSION         "FreeLoader v3.2"
 #define COPYRIGHT       "Copyright (C) 1996-" COPYRIGHT_YEAR " ReactOS Project"
 #define AUTHOR_EMAIL    "<www.reactos.org>"
 #define BY_AUTHOR       "by ReactOS Project"
@@ -29,5 +28,6 @@
 // If you add major functionality then you increment the major version and zero the minor version
 #define FREELOADER_MAJOR_VERSION    3
 #define FREELOADER_MINOR_VERSION    2
-
-extern const PCSTR FrLdrVersionString;
+#define TOSTRING_(X) #X
+#define TOSTRING(X) TOSTRING_(X)
+#define VERSION "FreeLoader v" TOSTRING(FREELOADER_MAJOR_VERSION) "." TOSTRING(FREELOADER_MINOR_VERSION)

--- a/boot/freeldr/freeldr/include/ver.h
+++ b/boot/freeldr/freeldr/include/ver.h
@@ -19,21 +19,6 @@
 
 #pragma once
 
-/* Just some stuff */
-#define VERSION         "FreeLoader v3.2"
 #define COPYRIGHT       "Copyright (C) 1996-" COPYRIGHT_YEAR " ReactOS Project"
 #define AUTHOR_EMAIL    "<www.reactos.org>"
 #define BY_AUTHOR       "by ReactOS Project"
-
-// FreeLoader version defines
-//
-// NOTE:
-// If you fix bugs then you increment the patch version
-// If you add features then you increment the minor version and zero the patch version
-// If you add major functionality then you increment the major version and zero the minor & patch versions
-//
-#define FREELOADER_MAJOR_VERSION    3
-#define FREELOADER_MINOR_VERSION    2
-#define FREELOADER_PATCH_VERSION    0
-
-extern const PCSTR FrLdrVersionString;

--- a/boot/freeldr/freeldr/ui/tui.c
+++ b/boot/freeldr/freeldr/ui/tui.c
@@ -293,7 +293,7 @@ VOID TuiDrawBackdrop(VOID)
     /* Draw version text */
     TuiDrawText(2,
                 1,
-                FrLdrVersionString,
+                VERSION,
                 ATTR(UiTitleBoxFgColor, UiTitleBoxBgColor));
 
     /* Draw copyright */

--- a/boot/freeldr/freeldr/ui/tui.c
+++ b/boot/freeldr/freeldr/ui/tui.c
@@ -290,6 +290,12 @@ VOID TuiDrawBackdrop(VOID)
                FALSE,
                ATTR(UiTitleBoxFgColor, UiTitleBoxBgColor));
 
+    /* Draw version text */
+    TuiDrawText(2,
+                1,
+                FrLdrVersionString,
+                ATTR(UiTitleBoxFgColor, UiTitleBoxBgColor));
+
     /* Draw copyright */
     TuiDrawText(2,
                 2,

--- a/boot/freeldr/freeldr/ui/tui.c
+++ b/boot/freeldr/freeldr/ui/tui.c
@@ -290,12 +290,6 @@ VOID TuiDrawBackdrop(VOID)
                FALSE,
                ATTR(UiTitleBoxFgColor, UiTitleBoxBgColor));
 
-    /* Draw version text */
-    TuiDrawText(2,
-                1,
-                FrLdrVersionString,
-                ATTR(UiTitleBoxFgColor, UiTitleBoxBgColor));
-
     /* Draw copyright */
     TuiDrawText(2,
                 2,


### PR DESCRIPTION

Those strings haven't been groomed anymore for more than 10 years. We had many thousands of different freeldr builds with different behavior and bugs each since then, but nobody ever did have the slightest motivation to update those hardcoded FREELOADER_MAJOR_VERSION, FREELOADER_MINOR_VERSION, FREELOADER_PATCH_VERSION from ver.h. And that is logical, because touching other modules will change the behavior of freeldr as well, so it is absolutely impossible to groom anything like that correctly. Instead we should simply do what we started to do in #7382, which will at least give some information (the actual sources it was built from) instead of some misleading voodoo-version.

This might slightly shrink the size of freeldr as well, but I was too lazy to measure by how much.

JIRA issue: none
