### PR TITLE
Freeldr: Some minor refactoring in fs.c code, before fixes

### DIFF
--- a/boot/freeldr/freeldr/include/fs.h
+++ b/boot/freeldr/freeldr/include/fs.h
@@ -32,6 +32,7 @@ typedef struct tagDEVVTBL
 } DEVVTBL;
 
 #define MAX_FDS 60
+#define INVALID_FILE_ID ((ULONG)-1)
 
 ARC_STATUS ArcOpen(CHAR* Path, OPENMODE OpenMode, ULONG* FileId);
 ARC_STATUS ArcClose(ULONG FileId);

--- a/boot/freeldr/freeldr/include/fs.h
+++ b/boot/freeldr/freeldr/include/fs.h
@@ -52,7 +52,11 @@ FsOpenFile(
 ULONG FsGetNumPathParts(PCSTR Path);
 VOID  FsGetFirstNameFromPath(PCHAR Buffer, PCSTR Path);
 
-VOID FsRegisterDevice(CHAR* Prefix, const DEVVTBL* FuncTable);
+VOID
+FsRegisterDevice(
+    _In_ PCSTR DeviceName,
+    _In_ const DEVVTBL* FuncTable);
+
 PCWSTR FsGetServiceName(ULONG FileId);
 VOID  FsSetDeviceSpecific(ULONG FileId, VOID* Specific);
 VOID* FsGetDeviceSpecific(ULONG FileId);


### PR DESCRIPTION
## Purpose

The `ArcOpen()` function has a bug in how direct opening of storage devices is done.
In addition, both `ArcOpen()` and `ArcClose()` need some fixes, regarding (de)referencing of the device and file handles.
These problems will be addressed in PR #7414, but for that, I need some prerequisite ground-work to be done: this is the purpose of the current PR.

## Proposed changes

- ### `[FREELDR] fs.c: Move the list of filesystem mount routines into a table.`

    This allows to make the code better extendable: adding a new FS
    mount routine into the table, instead of duplicating also a whole
    `if (!FileFuncTable) ...` check.

    Later, this table will be made dynamic, so that new filesystems could be
    dynamically registered at runtime, and a filesystem could be forced to
    be mounted by the user (using a specific syntax).

- ### `[FREELDR] fs.c: Simplify FileId checks; add INVALID_FILE_ID; add missing DeviceId invalidation.`

    - Replace a lot of `MAX_FDS` by `_countof(FileData)`;

    - The duplicated FileId validation logic is wrapped with
      the `IS_VALID_FILEID()` macro.

    - When returning an invalid FileId value on purpose, use
      `INVALID_FILE_ID` instead of `MAX_FDS` (that could vary
      if the file handle table gets extended).
      And replace the `(ULONG)-1` also used for that purpose
      by `INVALID_FILE_ID`.

    - Add missing DeviceId invalidation:
      * when failing to open a file handle in `ArcOpen()`;
      * when registering a new device in `FsRegisterDevice()`.
        There, having DeviceId always set to zero would tell
        the code that the corresponding device's file ID is
        the first one in the table, which is a BUG. (Many devices
        would have the same file ID...)

    - In addition: massage a bit some indicial for-loops.

- ### `[FREELDR] fs.c: Move the "()" -> "(0)" ARC path normalization code into a function.`

    This function will be useful in other places later.

- ### `[FREELDR] fs.c: Minor refactoring in ArcOpen(); fix a memory leak.`

    - `ArcOpen()`: flatten the registered-device search for-loop.
      Limit it to just the device search, and exit early.
      The rest of the initialization is now done outside the loop.

    - The `DeviceName` string pointer may have been allocated from
      the heap, for path normalization (see `NormalizeArcDeviceName()`).
      This pointer is then only used in the device search loop and not
      nused anymore afterwards. The old code didn't free this pointer
      and memory could leak. This is now fixed easily, thanks to the
      loop flattening.

    - Rename `DEVICE` member `Prefix` to `DeviceName`; SAL-annotate
      `FsRegisterDevice()`.
