### PR TITLE
[PSDK] Add defines for dwFlags used by WlanGetAvailableNetworkList

### DIFF
--- a/sdk/include/psdk/wlanapi.h
+++ b/sdk/include/psdk/wlanapi.h
@@ -16,6 +16,9 @@ extern "C" {
 #define WLAN_MAX_PHY_INDEX 64
 #define WLAN_MAX_NAME_LENGTH 256
 
+#define WLAN_AVAILABLE_NETWORK_INCLUDE_ALL_ADHOC_PROFILES         0x00000001
+#define WLAN_AVAILABLE_NETWORK_INCLUDE_ALL_MANUAL_HIDDEN_PROFILES 0x00000002
+
 /* Enumerations */
 
 #if defined(__midl) || defined(__WIDL__)


### PR DESCRIPTION
## Purpose

Avoid using 'magic numbers' for specifying types of Wi-Fi networks to be included into the scan results. The function of subject is used in Wireless LAN Wizard ([wlanwiz](https://github.com/SigmaTel71/reactos/tree/wlanwiz)) I develop specifically for ReactOS. In future more PRs like this one to fill missing defines will appear, so taking small steps might be better for the moment.

Reference: [Microsoft Learn](https://learn.microsoft.com/en-us/windows/win32/api/wlanapi/nf-wlanapi-wlangetavailablenetworklist)
JIRA issue: [CORE-6905](https://jira.reactos.org/browse/CORE-6905)

## Proposed changes

- Add definitions of possible values for `dwFlags` applicable to `WlanGetAvailableNetworkList` function.