### PR TITLE
[SERVICES] Merge ScmControlService() and ScmSendStartCommand() together

### DIFF
--- a/base/system/services/rpcserver.c
+++ b/base/system/services/rpcserver.c
@@ -1187,8 +1187,8 @@ RControlService(
         /* Send control code to the service */
         dwError = ScmControlService(lpService->lpImage->hControlPipe,
                                     lpService->lpServiceName,
-                                    (SERVICE_STATUS_HANDLE)lpService,
-                                    dwControl);
+                                    dwControl,
+                                    (SERVICE_STATUS_HANDLE)lpService);
 
         /* Return service status information */
         RtlCopyMemory(lpServiceStatus,
@@ -1626,8 +1626,8 @@ ScmStopThread(PVOID pParam)
         DPRINT("Stopping the dispatcher thread for service %S\n", lpService->lpServiceName);
         ScmControlService(lpService->lpImage->hControlPipe,
                           L"",
-                          (SERVICE_STATUS_HANDLE)lpService,
-                          SERVICE_CONTROL_STOP);
+                          SERVICE_CONTROL_STOP,
+                          (SERVICE_STATUS_HANDLE)lpService);
     }
 
     /* Lock the service database exclusively */

--- a/base/system/services/services.h
+++ b/base/system/services/services.h
@@ -18,10 +18,12 @@
 #include <winreg.h>
 #include <winuser.h>
 #include <netevent.h>
+
 #define NTOS_MODE_USER
 #include <ndk/setypes.h>
 #include <ndk/obfuncs.h>
 #include <ndk/rtlfuncs.h>
+
 #include <services/services.h>
 #include <svcctl_s.h>
 
@@ -200,10 +202,12 @@ DWORD ScmCreateNewServiceRecord(LPCWSTR lpServiceName,
 VOID ScmDeleteServiceRecord(PSERVICE lpService);
 DWORD ScmMarkServiceForDelete(PSERVICE pService);
 
-DWORD ScmControlService(HANDLE hControlPipe,
-                        PWSTR pServiceName,
-                        SERVICE_STATUS_HANDLE hServiceStatus,
-                        DWORD dwControl);
+DWORD
+ScmControlService(
+    _In_ HANDLE hControlPipe,
+    _In_ PCWSTR pServiceName,
+    _In_ DWORD dwControl,
+    _In_ SERVICE_STATUS_HANDLE hServiceStatus);
 
 BOOL ScmLockDatabaseExclusive(VOID);
 BOOL ScmLockDatabaseShared(VOID);


### PR DESCRIPTION
## Purpose

Collapse ScmControlService() and ScmSendStartCommand() implementations together, this greatly simplifies the code.
And SAL2-annotate ScmControlService() as well.

(commit from Feb 25, 2018)

## Proposed changes

- Merge both these functions.

In addition:

- Acquire ControlServiceCriticalSection just before doing the pipe
  operations, and release it just after.

- SAL2-annotate ScmControlService().

- Re-order the ScmControlService() parameters in a more natural way
  (1st: service name; 2nd: comm pipe; 3rd: control code; 4th+: arguments
  for the control command).
