### PR TITLE
[ATL] Implement CAtlList::AddHeadList and CAtlList::AddTailList

### DIFF
--- a/modules/rostests/apitests/atl/CAtlList.cpp
+++ b/modules/rostests/apitests/atl/CAtlList.cpp
@@ -113,9 +113,54 @@ test_SwapElements()
     ok_list(list, "3,1,2,");
 }
 
+static void
+test_AppendListToTail()
+{
+    CAtlList<int> list;
+    list.AddTail(1);
+    list.AddTail(2);
+    list.AddTail(0);
+    ok_list(list, "1,2,0,");
+
+    CAtlList<int> list_tail;
+    list_tail.AddTail(8);
+    list_tail.AddTail(1);
+    list_tail.AddTail(0);
+    ok_list(list_tail, "8,1,0,");
+
+    list.AddTailList(&list_tail);
+    ok_list(list, "1,2,0,8,1,0,");
+
+    list_tail.AddTailList(&list);
+    ok_list(list_tail, "8,1,0,1,2,0,8,1,0,");
+}
+
+static void
+test_AppendListToHead()
+{
+    CAtlList<int> list_head;
+    list_head.AddHead(0);
+    list_head.AddHead(0);
+    list_head.AddHead(2);
+    ok_list(list_head, "2,0,0,");
+
+    CAtlList<int> list;
+    list.AddHead(8);
+    list.AddHead(9);
+    list.AddHead(7);
+    ok_list(list, "7,9,8,");
+
+    list.AddHeadList(&list_head);
+    ok_list(list, "2,0,0,7,9,8,");
+
+    list_head.AddHeadList(&list);
+    ok_list(list_head, "2,0,0,7,9,8,2,0,0,");
+}
 
 START_TEST(CAtlList)
 {
     test_BasicCases();
     test_SwapElements();
+    test_AppendListToTail();
+    test_AppendListToHead();
 }

--- a/sdk/lib/atl/atlcoll.h
+++ b/sdk/lib/atl/atlcoll.h
@@ -480,6 +480,9 @@ public:
     POSITION AddHead(INARGTYPE element);
     POSITION AddTail(INARGTYPE element);
 
+    void AddHeadList(_In_ const CAtlList<E, ETraits>* plNew);
+    void AddTailList(_In_ const CAtlList<E, ETraits>* plNew);
+
     E RemoveHead();
     E RemoveTail();
 
@@ -637,6 +640,24 @@ POSITION CAtlList<E, ETraits>::AddTail(INARGTYPE element)
     m_TailNode = Node;
 
     return (POSITION)Node;
+}
+
+template <typename E, class ETraits>
+void CAtlList<E, ETraits>::AddHeadList(_In_ const CAtlList<E, ETraits>* plNew)
+{
+    ATLASSERT(plNew != NULL && plNew != this);
+    POSITION pos = plNew->GetTailPosition();
+    while (pos)
+        AddHead(plNew->GetPrev(pos));
+}
+
+template <typename E, class ETraits>
+void CAtlList<E, ETraits>::AddTailList(_In_ const CAtlList<E, ETraits>* plNew)
+{
+    ATLASSERT(plNew != NULL && plNew != this);
+    POSITION pos = plNew->GetHeadPosition();
+    while (pos)
+        AddTail(plNew->GetNext(pos));
 }
 
 template<typename E, class ETraits>


### PR DESCRIPTION
## Purpose

Reduce difference between our ATL and official ATL and provide a convenient way to append `CAtlList` at the same time. Both functions exist as of Visual Studio 2005 (at ~~list~~ least; \*ba dum tss*).

JIRA issue: None
Reference: Microsoft Learn
- [AddTailList](https://learn.microsoft.com/en-us/cpp/atl/reference/catllist-class?view=msvc-170#addtaillist)
- [AddHeadList](https://learn.microsoft.com/en-us/cpp/atl/reference/catllist-class?view=msvc-170#addheadlist)

## Proposed changes
- Implement `CAtlList::AddHeadList` and `CAtlList::AddTailList` functions
- Add API tests for new functions

## Side notes
'no squash merge' label is recommended.