### PR TITLE
[HALX86] Clean up MADT slightly and properly detect the BSP.

### DIFF
--- a/hal/halx86/apic/apic.c
+++ b/hal/halx86/apic/apic.c
@@ -28,7 +28,7 @@ ULONG ApicVersion;
 UCHAR HalpVectorToIndex[256];
 
 ULONG
-HalpGetCurrentProcessorHwID()
+HalpGetCurrentProcessorHwID(VOID)
 {
     return ApicRead(APIC_ID);
 }

--- a/hal/halx86/apic/apic.c
+++ b/hal/halx86/apic/apic.c
@@ -27,6 +27,12 @@
 ULONG ApicVersion;
 UCHAR HalpVectorToIndex[256];
 
+ULONG
+HalpGetCurrentProcessorHwID()
+{
+    return ApicRead(APIC_ID);
+}
+
 #ifndef _M_AMD64
 const UCHAR
 HalpIRQLtoTPR[32] =

--- a/hal/halx86/apic/apicsmp.c
+++ b/hal/halx86/apic/apicsmp.c
@@ -16,7 +16,7 @@
 #include <debug.h>
 
 
-extern PPROCESSOR_IDENTITY HalpProcessorIdentity;
+extern PROCESSOR_IDENTITY HalpProcessorIdentity[MAXIMUM_PROCESSORS];
 
 /* INTERNAL FUNCTIONS *********************************************************/
 

--- a/hal/halx86/apic/halinit.c
+++ b/hal/halx86/apic/halinit.c
@@ -44,9 +44,8 @@ HalpInitPhase0(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
             (HalpBuildType & PRCB_BUILD_UNIPROCESSOR) ? "UP" : "SMP",
             (HalpBuildType & PRCB_BUILD_DEBUG) ? "DBG" : "REL");
 
-    /* This works as InitPhase0 happens before secondary processors are spun-up.*/
+    /* This works because InitPhase0 happens before secondary processors are spun-up */
     HalpParseApicTables(LoaderBlock);
-    HalpPrintApicTables();
 
     /* Enable clock interrupt handler */
     HalpEnableInterruptHandler(IDT_INTERNAL,

--- a/hal/halx86/apic/halinit.c
+++ b/hal/halx86/apic/halinit.c
@@ -25,11 +25,6 @@ HalpInitProcessor(
     IN ULONG ProcessorNumber,
     IN PLOADER_PARAMETER_BLOCK LoaderBlock)
 {
-    if (ProcessorNumber == 0)
-    {
-        HalpParseApicTables(LoaderBlock);
-    }
-
     HalpSetupProcessorsTable(ProcessorNumber);
 
     /* Initialize the local APIC for this cpu */
@@ -49,6 +44,8 @@ HalpInitPhase0(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
             (HalpBuildType & PRCB_BUILD_UNIPROCESSOR) ? "UP" : "SMP",
             (HalpBuildType & PRCB_BUILD_DEBUG) ? "DBG" : "REL");
 
+    /* This works as InitPhase0 happens before secondary processors are spun-up.*/
+    HalpParseApicTables(LoaderBlock);
     HalpPrintApicTables();
 
     /* Enable clock interrupt handler */

--- a/hal/halx86/pic/pic.c
+++ b/hal/halx86/pic/pic.c
@@ -18,7 +18,7 @@ HalpEndSoftwareInterrupt(IN KIRQL OldIrql,
                          IN PKTRAP_FRAME TrapFrame);
 
 ULONG
-HalpGetCurrentProcessorHwID()
+HalpGetCurrentProcessorHwID(VOID)
 {
     return 0;
 }

--- a/hal/halx86/pic/pic.c
+++ b/hal/halx86/pic/pic.c
@@ -17,6 +17,12 @@ NTAPI
 HalpEndSoftwareInterrupt(IN KIRQL OldIrql,
                          IN PKTRAP_FRAME TrapFrame);
 
+ULONG
+HalpGetCurrentProcessorHwID()
+{
+    return 0;
+}
+
 /* GLOBALS ********************************************************************/
 
 #ifndef _MINIHAL_

--- a/hal/halx86/smp/i386/spinup.c
+++ b/hal/halx86/smp/i386/spinup.c
@@ -16,7 +16,6 @@
 
 /* GLOBALS *******************************************************************/
 
-extern PPROCESSOR_IDENTITY HalpProcessorIdentity;
 extern PHYSICAL_ADDRESS HalpLowStubPhysicalAddress;
 extern PVOID HalpLowStub;
 
@@ -26,7 +25,7 @@ extern PVOID HalpAPEntryData;
 extern PVOID HalpAPEntry32;
 extern PVOID HalpAPEntry16End;
 extern HALP_APIC_INFO_TABLE HalpApicInfoTable;
-extern PPROCESSOR_IDENTITY HalpProcessorIdentity;
+extern PROCESSOR_IDENTITY HalpProcessorIdentity[MAXIMUM_PROCESSORS];
 
 ULONG HalpStartedProcessorCount = 0;
 

--- a/hal/halx86/smp/i386/spinup.c
+++ b/hal/halx86/smp/i386/spinup.c
@@ -26,8 +26,9 @@ extern PVOID HalpAPEntryData;
 extern PVOID HalpAPEntry32;
 extern PVOID HalpAPEntry16End;
 extern HALP_APIC_INFO_TABLE HalpApicInfoTable;
+extern PPROCESSOR_IDENTITY HalpProcessorIdentity;
 
-ULONG HalpStartedProcessorCount = 1;
+ULONG HalpStartedProcessorCount = 0;
 
 #ifndef Add2Ptr
 #define Add2Ptr(P,I) ((PVOID)((PUCHAR)(P) + (I)))
@@ -90,6 +91,12 @@ HalStartNextProcessor(
 {
     if (HalpStartedProcessorCount == HalpApicInfoTable.ProcessorCount)
         return FALSE;
+
+    if (HalpProcessorIdentity[HalpStartedProcessorCount].BSPCheck == TRUE)
+    {
+        // SKIP the BSP
+        HalpStartedProcessorCount++;
+    }
 
     // Initalize the temporary page table
     // TODO: clean it up after an AP boots successfully

--- a/hal/halx86/smp/mps/mps.c
+++ b/hal/halx86/smp/mps/mps.c
@@ -18,8 +18,7 @@
 static // TODO: While HalpParseApicTables() is UNIMPLEMENTED.
 ULONG PhysicalProcessorCount;
 
-static PROCESSOR_IDENTITY HalpStaticProcessorIdentity[MAXIMUM_PROCESSORS];
-const PPROCESSOR_IDENTITY HalpProcessorIdentity = HalpStaticProcessorIdentity;
+PROCESSOR_IDENTITY HalpProcessorIdentity[MAXIMUM_PROCESSORS];
 
 /* FUNCTIONS ******************************************************************/
 

--- a/hal/halx86/smp/smp.c
+++ b/hal/halx86/smp/smp.c
@@ -16,7 +16,7 @@
 
 /* GLOBALS *******************************************************************/
 
-extern PPROCESSOR_IDENTITY HalpProcessorIdentity;
+extern PROCESSOR_IDENTITY HalpProcessorIdentity[MAXIMUM_PROCESSORS];
 
 /* FUNCTIONS *****************************************************************/
 


### PR DESCRIPTION
In x86/x64 the CPU starting up the system doesn't have to have an ID of zero, The original intention of HalpProcessorIdentity
is to make sure that no matter if we have an ID from NT or a HW ID we know what the specific of that processor are in context to the HAL.
(An example of this is the Intel 4000 series which has several systems that start with a weird choice of processor when hyperthreading is enabled)
This just adds a quick ID read from the APIC so we can skip it and no longer require the crappy start from 1 hack.

Also do some janitorial work on the MADT code and move it to a spot where DPRINTs function

Finally i added a note about GSIs which will be implemented in an upcoming PR.