### PR TITLE
[DESK] de-DE.rc: Tweak AUTOCHECKBOXES

### DIFF
--- a/dll/cpl/desk/lang/de-DE.rc
+++ b/dll/cpl/desk/lang/de-DE.rc
@@ -44,8 +44,7 @@ BEGIN
     CONTROL "", IDC_SCREENS_TIME, UPDOWN_CLASS, UDS_SETBUDDYINT | UDS_ALIGNRIGHT |
             UDS_AUTOBUDDY | UDS_ARROWKEYS | WS_BORDER | WS_GROUP, 56, 123, 12, 13
     LTEXT "Minuten", IDC_MINTEXT, 70, 125, 26, 9
-    CONTROL "&Passwort nach Reaktivierung", IDC_SCREENS_USEPASSCHK, "button",
-            BS_AUTOCHECKBOX | WS_TABSTOP, 108, 120, 117, 19
+    AUTOCHECKBOX "&Passwort nach Reaktivierung", IDC_SCREENS_USEPASSCHK, 108, 120, 117, 19
     GROUPBOX "Energiesparfunktionen des Monitors", IDC_SCREENS_DUMMY2, 8, 150, 230, 41
     LTEXT "Um die Energieoptionen des Monitors zu editieren, wählen Sie Energieoptionen.", IDC_STATIC, 16, 161, 146, 27
     PUSHBUTTON "E&nergieoptionen...", IDC_SCREENS_POWER_BUTTON, 157, 165, 69, 15
@@ -108,24 +107,17 @@ EXSTYLE WS_EX_DLGMODALFRAME | WS_EX_WINDOWEDGE
 CAPTION "Effekte"
 FONT 8, "MS Shell Dlg"
 BEGIN
-    CONTROL "&Verwende folgenden Übergangseffekt für Menüs und Tooltips:",
-            IDC_EFFAPPEARANCE_ANIMATION, "button", BS_AUTOCHECKBOX | WS_TABSTOP, 10, 5, 267, 19
+    AUTOCHECKBOX "&Verwende folgenden Übergangseffekt für Menüs und Tooltips:", IDC_EFFAPPEARANCE_ANIMATION, 10, 5, 267, 19
     COMBOBOX IDC_EFFAPPEARANCE_ANIMATIONTYPE, 20, 25, 95, 19, CBS_DROPDOWNLIST |
              CBS_HASSTRINGS | WS_VSCROLL | WS_TABSTOP
-    CONTROL "V&erwende folgende Kantenglättungsmethode für Bildschirmschriften:", IDC_EFFAPPEARANCE_SMOOTHING,
-            "button", BS_AUTOCHECKBOX | WS_TABSTOP, 10, 42, 267, 19
+    AUTOCHECKBOX "V&erwende folgende Kantenglättungsmethode für Bildschirmschriften:", IDC_EFFAPPEARANCE_SMOOTHING, 10, 42, 267, 19
     COMBOBOX IDC_EFFAPPEARANCE_SMOOTHINGTYPE, 20, 62, 95, 19, CBS_DROPDOWNLIST |
              CBS_HASSTRINGS | WS_VSCROLL | WS_TABSTOP
-    CONTROL "Ve&rwende große Icons", IDC_EFFAPPEARANCE_LARGEICONS, "button",
-            BS_AUTOCHECKBOX | WS_TABSTOP | WS_DISABLED, 10, 80, 267, 19
-    CONTROL "Zeige Menüsch&atten", IDC_EFFAPPEARANCE_SETDROPSHADOW,
-            "button", BS_AUTOCHECKBOX | WS_TABSTOP, 10, 95, 267, 19
-    CONTROL "Zeige &Fensterinhalt beim Verschieben", IDC_EFFAPPEARANCE_DRAGFULLWINDOWS,
-            "button", BS_AUTOCHECKBOX | WS_TABSTOP, 10, 110, 267, 19
-    CONTROL "Ver&stecke Unterstrich der Tastaturnavigation bis zum Druck der Alt-Taste",
-            IDC_EFFAPPEARANCE_KEYBOARDCUES, "button", BS_AUTOCHECKBOX | WS_TABSTOP, 10, 125, 267, 19
-    CONTROL "Ver&wende flache Menüs", IDC_EFFAPPEARANCE_FLATMENUS,
-            "button", BS_AUTOCHECKBOX | WS_TABSTOP, 10, 140, 267, 19
+    AUTOCHECKBOX "Ve&rwende große Icons", IDC_EFFAPPEARANCE_LARGEICONS, 10, 80, 267, 19, WS_TABSTOP | WS_DISABLED
+    AUTOCHECKBOX "Zeige Menüsch&atten", IDC_EFFAPPEARANCE_SETDROPSHADOW, 10, 95, 267, 19
+    AUTOCHECKBOX "Zeige &Fensterinhalt beim Verschieben", IDC_EFFAPPEARANCE_DRAGFULLWINDOWS, 10, 110, 267, 19
+    AUTOCHECKBOX "Ver&stecke Unterstrich der Tastaturnavigation bis zum Druck der Alt-Taste", IDC_EFFAPPEARANCE_KEYBOARDCUES, 10, 125, 267, 19
+    AUTOCHECKBOX "Ver&wende flache Menüs", IDC_EFFAPPEARANCE_FLATMENUS, 10, 140, 267, 19
     PUSHBUTTON "Abbrechen", IDCANCEL, 226, 165, 50, 14
     DEFPUSHBUTTON "OK", IDOK, 172, 165, 50, 14
 END
@@ -158,14 +150,10 @@ CAPTION "Allgemein"
 FONT 8, "MS Shell Dlg"
 BEGIN
     GROUPBOX "Desktopsymbole", IDC_STATIC, 6, 4, 212, 40
-    CONTROL "&Eigene Dateien", IDC_ICONS_MYDOCS, "button",
-            BS_AUTOCHECKBOX | WS_TABSTOP, 14, 14, 100, 12
-    CONTROL "&Netzwerkumgebung", IDC_ICONS_MYNET, "button",
-            BS_AUTOCHECKBOX | WS_TABSTOP, 116, 14, 100, 12
-    CONTROL "A&rbeitsplatz", IDC_ICONS_MYCOMP, "button",
-            BS_AUTOCHECKBOX | WS_TABSTOP, 14, 28, 100, 12
-    CONTROL "&Internet Browser", IDC_ICONS_INTERNET, "button",
-            BS_AUTOCHECKBOX | WS_TABSTOP, 116, 28, 100, 12
+    AUTOCHECKBOX "&Eigene Dateien", IDC_ICONS_MYDOCS, 14, 14, 100, 12
+    AUTOCHECKBOX "&Netzwerkumgebung", IDC_ICONS_MYNET, 116, 14, 100, 12
+    AUTOCHECKBOX "A&rbeitsplatz", IDC_ICONS_MYCOMP, 14, 28, 100, 12
+    AUTOCHECKBOX "&Internet Browser", IDC_ICONS_INTERNET, 116, 28, 100, 12
     CONTROL "", IDC_ICONS_LISTVIEW, "SysListView32",
             LVS_ICON | LVS_ALIGNLEFT | LVS_AUTOARRANGE | LVS_SINGLESEL | WS_BORDER | WS_TABSTOP | WS_HSCROLL,
             6, 60, 212, 56


### PR DESCRIPTION

## Purpose
- Tweaks all AUTORADIOBUTTONs in desk.cpl
- no functional change intended, it seems to work well when testing it locally
- Makes the rcs shorter
- When structurally applied, I do expect it to make the binaries a few bytes smaller
- it prettifies also the display in reshacker:

Before-pic:
![desk_before](https://github.com/user-attachments/assets/16d5c050-6e00-4f96-87db-28b6bc520de8)


After-pic:
![desk_after](https://github.com/user-attachments/assets/71c90ced-22fc-4436-8d30-8a08e391a3f7)


## TODO

- [ ] I will do all the other languages as well, in this PR
