### PR TITLE
Fix some GCC13.2.0+GCC8.4.0 host-tools warnings for our code, that happen on the Linux-builders

### DIFF
--- a/sdk/lib/cmlib/cmcheck.c
+++ b/sdk/lib/cmlib/cmcheck.c
@@ -318,7 +318,7 @@ CmpValidateValueListByCount(
                                          ValueListData,
                                          FixHive))
             {
-                DPRINT1("The value cell is NIL (at index %lu, list count %lu)\n",
+                DPRINT1("The value cell is NIL (at index %u, list count %u)\n",
                         ListCountIndex, ListCount);
                 return CM_CHECK_REGISTRY_VALUE_CELL_NIL;
             }
@@ -338,7 +338,7 @@ CmpValidateValueListByCount(
                                          ValueListData,
                                          FixHive))
             {
-                DPRINT1("The value cell is not allocated (at index %lu, list count %lu)\n",
+                DPRINT1("The value cell is not allocated (at index %u, list count %u)\n",
                         ListCountIndex, ListCount);
                 return CM_CHECK_REGISTRY_VALUE_CELL_UNALLOCATED;
             }
@@ -354,7 +354,7 @@ CmpValidateValueListByCount(
         ValueData = (PCELL_DATA)HvGetCell(Hive, ValueCell);
         if (!ValueData)
         {
-            DPRINT1("Cell data of the value cell not found (at index %lu, value count %lu)\n",
+            DPRINT1("Cell data of the value cell not found (at index %u, value count %u)\n",
                     ListCountIndex, ListCount);
             return CM_CHECK_REGISTRY_VALUE_CELL_DATA_NOT_FOUND;
         }
@@ -371,7 +371,7 @@ CmpValidateValueListByCount(
                                          ValueListData,
                                          FixHive))
             {
-                DPRINT1("The total size is bigger than the actual cell size (total size %lu, cell size %lu, at index %lu)\n",
+                DPRINT1("The total size is bigger than the actual cell size (total size %u, cell size %u, at index %u)\n",
                         TotalValueNameLength, ValueDataSize, ListCountIndex);
                 return CM_CHECK_REGISTRY_VALUE_CELL_SIZE_NOT_SANE;
             }
@@ -551,7 +551,7 @@ CmpValidateValueList(
         TotalValueLength = ValueListCount * sizeof(HCELL_INDEX);
         if (TotalValueLength > ValueSize)
         {
-            DPRINT1("The value list is bigger than the cell (value list size %lu, cell size %lu)\n",
+            DPRINT1("The value list is bigger than the cell (value list size %u, cell size %u)\n",
                     TotalValueLength, ValueSize);
             return CM_CHECK_REGISTRY_VALUE_LIST_SIZE_NOT_SANE;
         }
@@ -576,7 +576,7 @@ CmpValidateValueList(
         /* Log how much values have been removed */
         if (ValuesRemoved > 0)
         {
-            DPRINT1("Values removed in the list -- %lu\n", ValuesRemoved);
+            DPRINT1("%u values removed in the list\n", ValuesRemoved);
         }
     }
 
@@ -730,7 +730,7 @@ CmpValidateSubKeyList(
                                            CellData,
                                            FixHive))
                 {
-                    DPRINT1("The subkeys list has invalid count (subkeys count %lu, root key index count %lu)\n",
+                    DPRINT1("The subkeys list has invalid count (subkeys count %u, root key index count %u)\n",
                             SubKeyCounts, RootKeyIndex->Count);
                     return CM_CHECK_REGISTRY_BAD_SUBKEY_COUNT;
                 }
@@ -757,7 +757,7 @@ CmpValidateSubKeyList(
                 KeyIndexCell = RootKeyIndex->List[RootIndex];
                 if (!HvIsCellAllocated(Hive, KeyIndexCell))
                 {
-                    DPRINT1("The key index cell is not allocated at index %lu\n", RootIndex);
+                    DPRINT1("The key index cell is not allocated at index %u\n", RootIndex);
                     *DoRepair = TRUE;
                     return CM_CHECK_REGISTRY_KEY_INDEX_CELL_UNALLOCATED;
                 }
@@ -798,7 +798,7 @@ CmpValidateSubKeyList(
                                            CellData,
                                            FixHive))
                 {
-                    DPRINT1("The subkeys list has invalid count (subkeys count %lu, total leaf count %lu)\n",
+                    DPRINT1("The subkeys list has invalid count (subkeys count %u, total leaf count %u)\n",
                             SubKeyCounts, TotalLeafCount);
                     return CM_CHECK_REGISTRY_BAD_SUBKEY_COUNT;
                 }
@@ -981,7 +981,7 @@ CmpValidateKey(
     CellSize = HvGetCellSize(Hive, CellData);
     if (CellSize > CMP_KEY_SIZE_THRESHOLD)
     {
-        DPRINT1("The cell size is above the threshold size (size %lu)\n", CellSize);
+        DPRINT1("The cell size is above the threshold size (size %u)\n", CellSize);
         return CM_CHECK_REGISTRY_CELL_SIZE_NOT_SANE;
     }
 
@@ -1000,7 +1000,8 @@ CmpValidateKey(
     TotalKeyNameLength = NameLength + FIELD_OFFSET(CM_KEY_NODE, Name);
     if (TotalKeyNameLength > CellSize)
     {
-        DPRINT1("The key is too big than the cell (key size %lu, cell size %lu)\n", TotalKeyNameLength, CellSize);
+        DPRINT1("The key is too big than the cell (key size %u, cell size %u)\n",
+                TotalKeyNameLength, CellSize);
         return CM_CHECK_REGISTRY_KEY_TOO_BIG_THAN_CELL;
     }
 
@@ -1248,7 +1249,7 @@ RestartValidation:
                  */
                 if (!CmpRepairParentKey(Hive, CurrentCell, ParentCell, FixHive))
                 {
-                    DPRINT1("The key is corrupt (current cell %lu, parent cell %lu)\n",
+                    DPRINT1("The key is corrupt (current cell 0x%x, parent cell 0x%x)\n",
                             CurrentCell, ParentCell);
                     CmpFree(WorkState, WorkStateLength);
                     return CmStatusCode;
@@ -1279,8 +1280,8 @@ RestartValidation:
                          */
                         if (!CmpRepairParentKey(Hive, CurrentCell, ParentCell, FixHive))
                         {
-                            DPRINT1("The lexicographical order is invalid (sibling %lu, current cell %lu)\n",
-                            CurrentCell, WorkState[StackDepth - CMP_PRIOR_STACK].Sibling);
+                            DPRINT1("The lexicographical order is invalid (sibling 0x%x, current cell 0x%x)\n",
+                                    CurrentCell, WorkState[StackDepth - CMP_PRIOR_STACK].Sibling);
                             CmpFree(WorkState, WorkStateLength);
                             return CM_CHECK_REGISTRY_BAD_LEXICOGRAPHICAL_ORDER;
                         }
@@ -1300,7 +1301,7 @@ RestartValidation:
         KeyNode = (PCM_KEY_NODE)HvGetCell(Hive, CurrentCell);
         if (!KeyNode)
         {
-            DPRINT1("Couldn't get the node of key (current cell %lu)\n", CurrentCell);
+            DPRINT1("Couldn't get the node of key (current cell 0x%x)\n", CurrentCell);
             CmpFree(WorkState, WorkStateLength);
             return CM_CHECK_REGISTRY_NODE_NOT_FOUND;
         }
@@ -1323,7 +1324,7 @@ RestartValidation:
             ChildSubKeyCell = CmpFindSubKeyByNumber(Hive, KeyNode, WorkState[StackDepth].ChildCellIndex);
             if (ChildSubKeyCell == HCELL_NIL)
             {
-                DPRINT1("Couldn't get the child subkey cell (at stack index %lu)\n", StackDepth);
+                DPRINT1("Couldn't get the child subkey cell (at stack index %d)\n", StackDepth);
                 CmpFree(WorkState, WorkStateLength);
                 return CM_CHECK_REGISTRY_SUBKEY_NOT_FOUND;
             }
@@ -1455,7 +1456,7 @@ HvValidateBin(
                  * free space (aka Size == 0) which is a
                  * no go for a bin.
                  */
-                DPRINT1("The free cell exceeds the bin size or cell size equal to 0 (cell 0x%p, cell size %d, bin size %lu)\n",
+                DPRINT1("The free cell exceeds the bin size or cell size equal to 0 (cell 0x%p, cell size %d, bin size %u)\n",
                         Cell, Cell->Size, Bin->Size);
                 return CM_CHECK_REGISTRY_BAD_FREE_CELL;
             }
@@ -1473,7 +1474,7 @@ HvValidateBin(
                  * that exceeds the boundary of the
                  * bin size.
                  */
-                DPRINT1("The allocated cell exceeds the bin size (cell 0x%p, cell size %d, bin size %lu)\n",
+                DPRINT1("The allocated cell exceeds the bin size (cell 0x%p, cell size %d, bin size %u)\n",
                         Cell, abs(Cell->Size), Bin->Size);
                 return CM_CHECK_REGISTRY_BAD_ALLOC_CELL;
             }
@@ -1518,7 +1519,7 @@ HvValidateHive(
     /* Is the hive signature valid? */
     if (Hive->Signature != HV_HHIVE_SIGNATURE)
     {
-        DPRINT1("Hive's signature corrupted (signature %lu)\n", Hive->Signature);
+        DPRINT1("Hive's signature corrupted (signature %u)\n", Hive->Signature);
         return CM_CHECK_REGISTRY_HIVE_CORRUPT_SIGNATURE;
     }
 
@@ -1548,7 +1549,7 @@ HvValidateHive(
             if (Bin->Size > (StorageLength * HBLOCK_SIZE) ||
                 (Bin->FileOffset / HBLOCK_SIZE) != BlockIndex)
             {
-                DPRINT1("Bin size or offset is corrupt (bin size %lu, file offset %lu, storage length %lu)\n",
+                DPRINT1("Bin size or offset is corrupt (bin size %u, file offset %u, storage length %u)\n",
                         Bin->Size, Bin->FileOffset, StorageLength);
                 return CM_CHECK_REGISTRY_BIN_SIZE_OR_OFFSET_CORRUPT;
             }
@@ -1667,7 +1668,7 @@ CmCheckRegistry(
                   CM_CHECK_REGISTRY_VALIDATE_HIVE              |
                   CM_CHECK_REGISTRY_FIX_HIVE))
     {
-        DPRINT1("Invalid flag for registry check given (flag %lu)\n", Flags);
+        DPRINT1("Invalid flag for registry check given (flag %u)\n", Flags);
         return CM_CHECK_REGISTRY_INVALID_PARAMETER;
     }
 
@@ -1681,7 +1682,8 @@ CmCheckRegistry(
         CmStatusCode = HvValidateHive(Hive);
         if (!CM_CHECK_REGISTRY_SUCCESS(CmStatusCode))
         {
-            DPRINT1("The hive is not valid (hive 0x%p, check status code %lu)\n", Hive, CmStatusCode);
+            DPRINT1("The hive is not valid (hive 0x%p, check status code %u)\n",
+                    Hive, CmStatusCode);
             return CmStatusCode;
         }
     }
@@ -1708,7 +1710,8 @@ CmCheckRegistry(
     CmStatusCode = CmpValidateRegistryInternal(Hive, Flags, FALSE, ShouldFixHive);
     if (!CM_CHECK_REGISTRY_SUCCESS(CmStatusCode))
     {
-        DPRINT1("The hive is not valid (hive 0x%p, check status code %lu)\n", Hive, CmStatusCode);
+        DPRINT1("The hive is not valid (hive 0x%p, check status code %u)\n",
+                Hive, CmStatusCode);
         return CmStatusCode;
     }
 

--- a/sdk/lib/cmlib/cmheal.c
+++ b/sdk/lib/cmlib/cmheal.c
@@ -220,7 +220,7 @@ CmpRemoveSubkeyInRoot(
                     HvReleaseCell(Hive, LeafCell);
                     HvMarkCellDirty(Hive, LeafCell, FALSE);
                     CmpRemoveFastIndexKeyCell(FastIndex, LeafCountIndex, TRUE);
-                    DPRINT1("The offending key cell has BEEN FOUND in fast index (fast index 0x%p, index %lu)\n",
+                    DPRINT1("The offending key cell has BEEN FOUND in fast index (fast index 0x%p, index %u)\n",
                             FastIndex, LeafCountIndex);
                     return TRUE;
                 }
@@ -237,7 +237,7 @@ CmpRemoveSubkeyInRoot(
                     HvReleaseCell(Hive, LeafCell);
                     HvMarkCellDirty(Hive, LeafCell, FALSE);
                     CmpRemoveIndexKeyCell(Leaf, LeafCountIndex);
-                    DPRINT1("The offending key cell has BEEN FOUND in leaf (leaf 0x%p, index %lu)\n",
+                    DPRINT1("The offending key cell has BEEN FOUND in leaf (leaf 0x%p, index %u)\n",
                             Leaf, LeafCountIndex);
                     return TRUE;
                 }
@@ -316,7 +316,7 @@ CmpRemoveSubKeyInLeaf(
                  * rather than that of the fast index.
                  */
                 Leaf->Count--;
-                DPRINT1("The offending key cell has BEEN FOUND in fast index (fast index 0x%p, leaf index %lu)\n",
+                DPRINT1("The offending key cell has BEEN FOUND in fast index (fast index 0x%p, leaf index %u)\n",
                         FastIndex, LeafIndex);
                 return TRUE;
             }
@@ -332,7 +332,7 @@ CmpRemoveSubKeyInLeaf(
             {
                 HvMarkCellDirty(Hive, KeyNode->SubKeyLists[Stable], FALSE);
                 CmpRemoveIndexKeyCell(Leaf, LeafIndex);
-                DPRINT1("The offending key cell has BEEN FOUND in leaf (leaf 0x%p, index %lu)\n",
+                DPRINT1("The offending key cell has BEEN FOUND in leaf (leaf 0x%p, index %u)\n",
                         Leaf, LeafIndex);
                 return TRUE;
             }
@@ -477,7 +477,8 @@ CmpRepairParentKey(
          * if for whatever reason we reach here then something
          * is seriously wrong.
          */
-        DPRINT1("The key index signature is invalid (KeyIndex->Signature == %lu)", KeyIndex->Signature);
+        DPRINT1("The key index signature is invalid (KeyIndex->Signature == %u)",
+                KeyIndex->Signature);
         ASSERT(FALSE);
     }
 

--- a/sdk/lib/cmlib/hivecell.c
+++ b/sdk/lib/cmlib/hivecell.c
@@ -26,7 +26,7 @@ HvpGetCellHeader(
 {
     PVOID Block;
 
-    CMLTRACE(CMLIB_HCELL_DEBUG, "%s - Hive %p, CellIndex %08lx\n",
+    CMLTRACE(CMLIB_HCELL_DEBUG, "%s - Hive 0x%p, CellIndex 0x%x\n",
              __FUNCTION__, RegistryHive, CellIndex);
 
     ASSERT(CellIndex != HCELL_NIL);
@@ -116,7 +116,7 @@ HvMarkCellDirty(
 
     ASSERT(RegistryHive->ReadOnly == FALSE);
 
-    CMLTRACE(CMLIB_HCELL_DEBUG, "%s - Hive %p, CellIndex %08lx, HoldingLock %u\n",
+    CMLTRACE(CMLIB_HCELL_DEBUG, "%s - Hive 0x%p, CellIndex 0x%x, HoldingLock %u\n",
              __FUNCTION__, RegistryHive, CellIndex, HoldingLock);
 
     if (HvGetCellType(CellIndex) != Stable)
@@ -367,7 +367,7 @@ HvAllocateCell(
 
     ASSERT(RegistryHive->ReadOnly == FALSE);
 
-    CMLTRACE(CMLIB_HCELL_DEBUG, "%s - Hive %p, Size %x, %s, Vicinity %08lx\n",
+    CMLTRACE(CMLIB_HCELL_DEBUG, "%s - Hive 0x%p, Size 0x%x, %s, Vicinity 0x%x\n",
              __FUNCTION__, RegistryHive, Size, (Storage == 0) ? "Stable" : "Volatile", Vicinity);
 
     /* Round to 16 bytes multiple. */
@@ -411,7 +411,7 @@ HvAllocateCell(
     FreeCell->Size = -FreeCell->Size;
     RtlZeroMemory(FreeCell + 1, Size - sizeof(HCELL));
 
-    CMLTRACE(CMLIB_HCELL_DEBUG, "%s - CellIndex %08lx\n",
+    CMLTRACE(CMLIB_HCELL_DEBUG, "%s - CellIndex 0x%x\n",
              __FUNCTION__, FreeCellOffset);
 
     return FreeCellOffset;
@@ -431,7 +431,7 @@ HvReallocateCell(
 
     ASSERT(CellIndex != HCELL_NIL);
 
-    CMLTRACE(CMLIB_HCELL_DEBUG, "%s - Hive %p, CellIndex %08lx, Size %x\n",
+    CMLTRACE(CMLIB_HCELL_DEBUG, "%s - Hive 0x%p, CellIndex 0x%x, Size 0x%x\n",
              __FUNCTION__, RegistryHive, CellIndex, Size);
 
     Storage = HvGetCellType(CellIndex);
@@ -477,7 +477,7 @@ HvFreeCell(
 
     ASSERT(RegistryHive->ReadOnly == FALSE);
 
-    CMLTRACE(CMLIB_HCELL_DEBUG, "%s - Hive %p, CellIndex %08lx\n",
+    CMLTRACE(CMLIB_HCELL_DEBUG, "%s - Hive 0x%p, CellIndex 0x%x\n",
              __FUNCTION__, RegistryHive, CellIndex);
 
     Free = HvpGetCellHeader(RegistryHive, CellIndex);

--- a/sdk/lib/cmlib/hiveinit.c
+++ b/sdk/lib/cmlib/hiveinit.c
@@ -973,7 +973,7 @@ HvpRecoverDataFromLog(
                                  HBLOCK_SIZE);
         if (!Success)
         {
-            DPRINT1("Failed to read the dirty block (index %lu)\n", BlockIndex);
+            DPRINT1("Failed to read the dirty block (index %u)\n", BlockIndex);
             return Fail;
         }
 
@@ -985,7 +985,7 @@ HvpRecoverDataFromLog(
                                   HBLOCK_SIZE);
         if (!Success)
         {
-            DPRINT1("Failed to write dirty block to hive (index %lu)\n", BlockIndex);
+            DPRINT1("Failed to write dirty block to hive (index %u)\n", BlockIndex);
             return Fail;
         }
 
@@ -1489,7 +1489,7 @@ HvInitialize(
 
         default:
         {
-            DPRINT1("Invalid operation type (OperationType = %lu)\n", OperationType);
+            DPRINT1("Invalid operation type (OperationType = %u)\n", OperationType);
             return STATUS_INVALID_PARAMETER;
         }
     }

--- a/sdk/tools/cabman/cabinet.h
+++ b/sdk/tools/cabman/cabinet.h
@@ -36,10 +36,15 @@
 #define C_ASSERT(expr) extern char (*c_assert(void)) [(expr) ? 1 : -1]
 #endif
 
+#ifndef _countof
+#define _countof(_Array) (sizeof(_Array) / sizeof(_Array[0]))
+#endif
+
 #if defined(_WIN32)
 #define DIR_SEPARATOR_CHAR '\\'
 #define DIR_SEPARATOR_STRING "\\"
 
+#define snprintf _snprintf
 #define strcasecmp _stricmp
 #define strdup _strdup
 #else

--- a/sdk/tools/cabman/dfp.cxx
+++ b/sdk/tools/cabman/dfp.cxx
@@ -1031,7 +1031,7 @@ ULONG CDFParser::PerformFileCopy()
     char ch;
     char SrcName[PATH_MAX];
     char DstName[PATH_MAX];
-    char InfLine[PATH_MAX];
+    char InfLine[PATH_MAX*2+1]; // To hold: GetFileName(SrcName) "=" DstName
     char Options[128];
     char BaseFilename[PATH_MAX];
 
@@ -1076,7 +1076,7 @@ ULONG CDFParser::PerformFileCopy()
     }
 
     // options (it may be empty)
-    SkipSpaces ();
+    SkipSpaces();
 
     if (CurrentToken != TokenEnd)
     {
@@ -1133,12 +1133,13 @@ ULONG CDFParser::PerformFileCopy()
     switch (Status)
     {
         case CAB_STATUS_SUCCESS:
-            sprintf(InfLine, "%s=%s", GetFileName(SrcName).c_str(), DstName);
+            snprintf(InfLine, _countof(InfLine) - 1,
+                     "%s=%s", GetFileName(SrcName).c_str(), DstName);
             WriteInfLine(InfLine);
             break;
 
         case CAB_STATUS_CANNOT_OPEN:
-            if (strstr(Options,"optional"))
+            if (strstr(Options, "optional"))
             {
                 Status = CAB_STATUS_SUCCESS;
                 printf("Optional file skipped (does not exist): %s.\n", SrcName);


### PR DESCRIPTION
## Purpose

Compiling ReactOS' host-tools on GCC 13.x and also GCC8.4.0 emit new warnings (compared to GCC 8.x and MSVC builds).
In this PR I attempt to fix these for our own (not 3rd-party) code.
Those warnings do happen only on our Linux builders, but they do not happen on our Windows-builders.

JIRA issue: [CORE-19724](https://jira.reactos.org/browse/CORE-19724)

## Proposed changes

- ### `[CABMAN] Fix GCC13.2.0/GCC8.4.0-Linux buffer format overflow warning`
```
    sdk/tools/cabman/dfp.cxx: In member function 'ULONG CDFParser::PerformFileCopy()':
    sdk/tools/cabman/dfp.cxx:1136:36: warning: 'sprintf' may write a terminating nul past the end of the destination [-Wformat-overflow=]
     1136 |             sprintf(InfLine, "%s=%s", GetFileName(SrcName).c_str(), DstName);
          |                                    ^
    sdk/tools/cabman/dfp.cxx:1136:20: note: 'sprintf' output 2 or more bytes (assuming 4097) into a destination of size 4096
     1136 |             sprintf(InfLine, "%s=%s", GetFileName(SrcName).c_str(), DstName);
          |             ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
To fix this, I increased the size of the `InfLine` buffer and used `snprintf`.

- ### `[CMLIB] Fix GCC13.2.0/GCC8.4.0-Linux print formatting '%lu' warning`

    - `sdk/lib/cmlib/cmcheck.c`: Print the `HCELL_INDEX` indices in hexadecimal.
    - Attempt to fix the `%lu` warnings for variables in `cmcheck.c`, `cmheal.c`, `hiveinit.c`
