### PR TITLE
[FREELDR:NTFS] Always compare file name without case-sensitive

### DIFF
--- a/boot/freeldr/freeldr/lib/fs/ntfs.c
+++ b/boot/freeldr/freeldr/lib/fs/ntfs.c
@@ -525,19 +525,10 @@ static BOOLEAN NtfsCompareFileName(PCHAR FileName, PNTFS_INDEX_ENTRY IndexEntry)
     if (strlen(FileName) != EntryFileNameLength)
         return FALSE;
 
-    /* Do case-sensitive compares for Posix file names. */
-    if (IndexEntry->FileName.FileNameType == NTFS_FILE_NAME_POSIX)
-    {
-        for (i = 0; i < EntryFileNameLength; i++)
-            if (EntryFileName[i] != FileName[i])
-                return FALSE;
-    }
-    else
-    {
-        for (i = 0; i < EntryFileNameLength; i++)
-            if (tolower(EntryFileName[i]) != tolower(FileName[i]))
-                return FALSE;
-    }
+    /* Hack fix */
+    for (i = 0; i < EntryFileNameLength; i++)
+        if (tolower(EntryFileName[i]) != tolower(FileName[i]))
+            return FALSE;
 
     return TRUE;
 }


### PR DESCRIPTION
## Purpose

This hack-fix resolve the loading error of "SYSTEM" hive when the hive name is "system" in NTFS filesystem.

JIRA issue: [CORE-19766](https://jira.reactos.org/browse/CORE-19766)

## Proposed changes

- Always compare file name without case-sensitive in freeldr NTFS driver.
