### PR TITLE
[USBSTOR] Don't assert on clean up if initialization didn't finish

### DIFF
--- a/drivers/usb/usbstor/fdo.c
+++ b/drivers/usb/usbstor/fdo.c
@@ -118,22 +118,16 @@ USBSTOR_FdoHandleRemoveDevice(
     }
 
     // Freeing everything in DeviceExtension
-    ASSERT(
-        DeviceExtension->DeviceDescriptor &&
-        DeviceExtension->ConfigurationDescriptor &&
-        DeviceExtension->InterfaceInformation &&
-        DeviceExtension->ResetDeviceWorkItem
-    );
-
-    ExFreePoolWithTag(DeviceExtension->DeviceDescriptor, USB_STOR_TAG);
-    ExFreePoolWithTag(DeviceExtension->ConfigurationDescriptor, USB_STOR_TAG);
-    ExFreePoolWithTag(DeviceExtension->InterfaceInformation, USB_STOR_TAG);
-    IoFreeWorkItem(DeviceExtension->ResetDeviceWorkItem);
-
+    if (DeviceExtension->DeviceDescriptor)
+        ExFreePoolWithTag(DeviceExtension->DeviceDescriptor, USB_STOR_TAG);
+    if (DeviceExtension->ConfigurationDescriptor)
+        ExFreePoolWithTag(DeviceExtension->ConfigurationDescriptor, USB_STOR_TAG);
+    if (DeviceExtension->InterfaceInformation)
+        ExFreePoolWithTag(DeviceExtension->InterfaceInformation, USB_STOR_TAG);
+    if (DeviceExtension->ResetDeviceWorkItem)
+        IoFreeWorkItem(DeviceExtension->ResetDeviceWorkItem);
     if (DeviceExtension->SerialNumber)
-    {
         ExFreePoolWithTag(DeviceExtension->SerialNumber, USB_STOR_TAG);
-    }
 
     // Send the IRP down the stack
     IoSkipCurrentIrpStackLocation(Irp);


### PR DESCRIPTION
During investigation into some of the USB stack issues we've been running into I've found that when a USB storage device is already plugged in during boot and removed before it finishes initialization we run into this assert.

The logic in this function removes the pools made for the following entries in DeviceExtension indiscriminately this makes debugging a bit more difficult. Instead of depending on this behavior of ALWAYS being filled with valid data, let's free the following pools ONLY if they're initialized. This change prevents us from bugchecking when USB flash drives are removed early during boot. This makes the debugging experience a little more sane.