### PR TITLE
[FREELDR] fs.c: Fix handling of file handles, (de)referencing, and direct-device access

### DIFF
--- a/boot/freeldr/freeldr/include/fs.h
+++ b/boot/freeldr/freeldr/include/fs.h
@@ -35,7 +35,11 @@ typedef struct tagDEVVTBL
 #define INVALID_FILE_ID ((ULONG)-1)
 
 ARC_STATUS ArcOpen(CHAR* Path, OPENMODE OpenMode, ULONG* FileId);
-ARC_STATUS ArcClose(ULONG FileId);
+
+ARC_STATUS
+ArcClose(
+    _In_ ULONG FileId);
+
 ARC_STATUS ArcRead(ULONG FileId, VOID* Buffer, ULONG N, ULONG* Count);
 ARC_STATUS ArcSeek(ULONG FileId, LARGE_INTEGER* Position, SEEKMODE SeekMode);
 ARC_STATUS ArcGetFileInformation(ULONG FileId, FILEINFORMATION* Information);
@@ -58,7 +62,7 @@ FsRegisterDevice(
     _In_ const DEVVTBL* FuncTable);
 
 PCWSTR FsGetServiceName(ULONG FileId);
-VOID  FsSetDeviceSpecific(ULONG FileId, VOID* Specific);
-VOID* FsGetDeviceSpecific(ULONG FileId);
+VOID  FsSetDeviceSpecific(ULONG FileId, PVOID Specific);
+PVOID FsGetDeviceSpecific(ULONG FileId);
 ULONG FsGetDeviceId(ULONG FileId);
 VOID  FsInit(VOID);

--- a/boot/freeldr/freeldr/lib/fs/ext2.c
+++ b/boot/freeldr/freeldr/lib/fs/ext2.c
@@ -216,6 +216,9 @@ BOOLEAN Ext2LookupFile(PEXT2_VOLUME_INFO Volume, PCSTR FileName, PEXT2_FILE_INFO
 
     RtlZeroMemory(Ext2FileInfo, sizeof(EXT2_FILE_INFO));
 
+    /* Skip leading path separator, if any */
+    if (*FileName == '\\' || *FileName == '/')
+        ++FileName;
     //
     // Figure out how many sub-directories we are nested in
     //

--- a/boot/freeldr/freeldr/lib/fs/fat.c
+++ b/boot/freeldr/freeldr/lib/fs/fat.c
@@ -785,6 +785,9 @@ ARC_STATUS FatLookupFile(PFAT_VOLUME_INFO Volume, PCSTR FileName, PFAT_FILE_INFO
 
     RtlZeroMemory(FatFileInfoPointer, sizeof(FAT_FILE_INFO));
 
+    /* Skip leading path separator, if any */
+    if (*FileName == '\\' || *FileName == '/')
+        ++FileName;
     //
     // Figure out how many sub-directories we are nested in
     //

--- a/boot/freeldr/freeldr/lib/fs/iso.c
+++ b/boot/freeldr/freeldr/lib/fs/iso.c
@@ -182,6 +182,9 @@ static ARC_STATUS IsoLookupFile(PCSTR FileName, ULONG DeviceId, PISO_FILE_INFO I
     DirectorySector = Pvd->RootDirRecord.ExtentLocationL;
     DirectoryLength = Pvd->RootDirRecord.DataLengthL;
 
+    /* Skip leading path separator, if any */
+    if (*FileName == '\\' || *FileName == '/')
+        ++FileName;
     //
     // Figure out how many sub-directories we are nested in
     //

--- a/boot/freeldr/freeldr/lib/fs/ntfs.c
+++ b/boot/freeldr/freeldr/lib/fs/ntfs.c
@@ -718,6 +718,11 @@ static BOOLEAN NtfsLookupFile(PNTFS_VOLUME_INFO Volume, PCSTR FileName, PNTFS_MF
     TRACE("NtfsLookupFile() FileName = %s\n", FileName);
 
     CurrentMFTIndex = NTFS_FILE_ROOT;
+
+    /* Skip leading path separator, if any */
+    if (*FileName == '\\' || *FileName == '/')
+        ++FileName;
+
     NumberOfPathParts = FsGetNumPathParts(FileName);
     for (i = 0; i < NumberOfPathParts; i++)
     {

--- a/boot/freeldr/freeldr/lib/fs/pxe.c
+++ b/boot/freeldr/freeldr/lib/fs/pxe.c
@@ -155,10 +155,18 @@ static ARC_STATUS PxeOpen(CHAR* Path, OPENMODE OpenMode, ULONG* FileId)
     if (OpenMode != OpenReadOnly)
         return EACCES;
 
-    /* Retrieve the path length without NULL terminator */
-    PathLen = (Path ? min(strlen(Path), sizeof(_OpenFileName) - 1) : 0);
+    /* Skip leading path separator, if any, so as to ensure that
+     * we always lookup the file at the root of the TFTP server's
+     * file space ("virtual root"), even if the server doesn't
+     * support this, and NOT from the root of the file system. */
+    if (*Path == '\\' || *Path == '/')
+        ++Path;
 
-    /* Lowercase the path and always use slashes as separators */
+    /* Retrieve the path length without NULL terminator */
+    PathLen = min(strlen(Path), sizeof(_OpenFileName) - 1);
+
+    /* Lowercase the path and always use slashes as separators,
+     * for supporting TFTP servers on POSIX systems */
     for (i = 0; i < PathLen; i++)
     {
         if (Path[i] == '\\')


### PR DESCRIPTION
## Purpose & Proposed changes

- Original code was just incrementing the reference counts (RefCounts)
  of the device objects or the device/file handles, without decrementing
  them when closing the handles. This is now fixed.

  Notice the following:

  * When opening a file on a device (disk), the device's (and its
    handle's) RefCount is incremented, and the file handle's RefCount
    is incremented as well.

  * When closing a file, the file handle's RefCount is decremented
    (and the file closed if the RefCount reaches zero), and the file's
    parent device handle is also closed, recursively.
    This has the effect of decrementing the parent device handle's
    RefCount, and the device's own RefCount is decremented as well.

- Fix opening a device (disk) in direct access, when this device is
  already opened. Indeed, previously we allowed direct access only if
  the device was opened as such for the very first time (its RefCount
  = 0 originally); no filesystem mounting was attempted as well.
  Then for any later open operations on this device (while keeping an
  already-opened handle to it), filesystem access was supposed.

  Thus, this problem would show up in two ways:

  * Either the device is first opened for direct access, this succeeded
    and no filesystem was mounted. Then, for any other open operations,
    the filesystem was NOT mounted, and opening files on it would fail.
    Direct accesses would succeed but would create an unnecessary second
    file handle.

  * Or, the device is first opened for file access: a filesystem was
    mounted and file opening would succeed. Any other file opening
    operation would succeed as well (if the file exists). But, a direct
    access open operation would fail, because now any open operations on
    the device would be assumed to be a file opening.

  This is now correctly fixed. If direct open is requested, just do it.
  If this is a file opening, we open the device, then try to mount a
  filesystem on it (if not already done), then we try to open the file.

  If file opening fails, derereference the device.

- Pass the file path to the filesystem-specific Open() functions without
  truncating the leading path separator, if any. This has to be handled
  by the filesystem routines themselves.

## TODOs

- [x] Remove debug leftovers once everything gets validated on our testbots.
