### PR TITLE
[FREELDR] Load windows files without case sensitive in NTFS driver

### DIFF
--- a/boot/freeldr/freeldr/include/fs.h
+++ b/boot/freeldr/freeldr/include/fs.h
@@ -34,6 +34,8 @@ typedef struct tagDEVVTBL
 #define MAX_FDS 60
 #define INVALID_FILE_ID ((ULONG)-1)
 
+extern BOOLEAN FSFileNameCaseSensitive;
+
 ARC_STATUS ArcOpen(CHAR* Path, OPENMODE OpenMode, ULONG* FileId);
 ARC_STATUS ArcClose(ULONG FileId);
 ARC_STATUS ArcRead(ULONG FileId, VOID* Buffer, ULONG N, ULONG* Count);

--- a/boot/freeldr/freeldr/lib/fs/fs.c
+++ b/boot/freeldr/freeldr/lib/fs/fs.c
@@ -51,6 +51,8 @@ typedef struct tagDEVICE
 static FILEDATA FileData[MAX_FDS];
 static LIST_ENTRY DeviceListHead;
 
+BOOLEAN FSFileNameCaseSensitive = TRUE;
+
 #define IS_VALID_FILEID(FileId) \
     ((ULONG)(FileId) < _countof(FileData) && FileData[(ULONG)(FileId)].FuncTable)
 

--- a/boot/freeldr/freeldr/lib/fs/ntfs.c
+++ b/boot/freeldr/freeldr/lib/fs/ntfs.c
@@ -526,7 +526,7 @@ static BOOLEAN NtfsCompareFileName(PCHAR FileName, PNTFS_INDEX_ENTRY IndexEntry)
         return FALSE;
 
     /* Do case-sensitive compares for Posix file names. */
-    if (IndexEntry->FileName.FileNameType == NTFS_FILE_NAME_POSIX)
+    if (IndexEntry->FileName.FileNameType == NTFS_FILE_NAME_POSIX && FSFileNameCaseSensitive)
     {
         for (i = 0; i < EntryFileNameLength; i++)
             if (EntryFileName[i] != FileName[i])


### PR DESCRIPTION
## Purpose

This PR resolve the loading error of "SYSTEM" hive when the hive name is "system" in NTFS filesystem.
In my tests, the Windows Vista/XP Bootloader doesn't care if file paths are lowercase or uppercase when loading Windows.

JIRA issue: [CORE-19766](https://jira.reactos.org/browse/CORE-19766)