### PR TITLE
FreeLdr / MiniHal: Streamline PCI bus support + add /PCIENUM switch

### DIFF
--- a/boot/freeldr/freeldr/CMakeLists.txt
+++ b/boot/freeldr/freeldr/CMakeLists.txt
@@ -29,10 +29,12 @@ list(APPEND FREELDR_ARC_SOURCE
     arcname.c
     arch/arcemul.c
     arch/archwsup.c
+    arch/i386/halstub.c
+    arch/i386/ntoskrnl.c
     disk/disk.c
     disk/partition.c
-    disk/ramdisk.c)
-    # disk/scsiport.c
+    disk/ramdisk.c
+    disk/scsiport.c)
     # lib/fs/pxe.c
 
 list(APPEND FREELDR_BOOTLIB_SOURCE
@@ -77,6 +79,7 @@ list(APPEND FREELDR_NTLDR_SOURCE
     ${REACTOS_SOURCE_DIR}/ntoskrnl/config/cmboot.c
     ntldr/conversion.c
     ntldr/registry.c
+    ntldr/setupldr.c
     ntldr/winldr.c
     ntldr/wlmemory.c
     ntldr/wlregistry.c)
@@ -88,10 +91,7 @@ if(ARCH STREQUAL "i386")
         # arch/i386/linux.S
 
     list(APPEND FREELDR_ARC_SOURCE
-        arch/i386/i386bug.c
-        arch/i386/halstub.c
-        arch/i386/ntoskrnl.c
-        disk/scsiport.c)
+        arch/i386/i386bug.c)
 
     list(APPEND FREELDR_NTLDR_SOURCE
         ntldr/arch/i386/winldr.c
@@ -103,8 +103,7 @@ elseif(ARCH STREQUAL "amd64")
         # arch/amd64/linux.S
 
     list(APPEND FREELDR_ARC_SOURCE
-        arch/i386/i386bug.c
-        arch/i386/ntoskrnl.c)
+        arch/i386/i386bug.c)
 
     list(APPEND FREELDR_NTLDR_SOURCE
         ntldr/arch/amd64/winldr.c)
@@ -120,19 +119,13 @@ endif()
 list(APPEND FREELDR_BASE_SOURCE
     bootmgr.c # This file is compiled with custom definitions
     freeldr.c
-    ntldr/setupldr.c ## Strangely enough this file is needed in GCC builds
-                     ## even if ${FREELDR_NTLDR_SOURCE} is not added,
-                     ## otherwise we get linking errors with Rtl**Bitmap** APIs.
-                     ## Do not happen on MSVC builds however...
     ntldr/inffile.c
     ntldr/ntldropts.c
     lib/rtl/libsupp.c)
 
-if(ARCH STREQUAL "i386")
-    # Must be included together with disk/scsiport.c
-    list(APPEND FREELDR_BASE_SOURCE
-        ${CMAKE_CURRENT_BINARY_DIR}/freeldr_pe.def)
-endif()
+# Must be included together with disk/scsiport.c
+list(APPEND FREELDR_BASE_SOURCE
+    ${CMAKE_CURRENT_BINARY_DIR}/freeldr_pe.def)
 
 include(pcat.cmake)
 if(NOT ARCH STREQUAL "i386" OR NOT (SARCH STREQUAL "pc98" OR SARCH STREQUAL "xbox"))

--- a/boot/freeldr/freeldr/arch/i386/hwpci.c
+++ b/boot/freeldr/freeldr/arch/i386/hwpci.c
@@ -19,6 +19,7 @@
  */
 
 #include <freeldr.h>
+#include "../../ntldr/ntldropts.h"
 
 #include <debug.h>
 DBG_DEFAULT_CHANNEL(HWDETECT);
@@ -112,7 +113,7 @@ PcFindPciBios(
 }
 
 static
-VOID
+PCONFIGURATION_COMPONENT_DATA
 DetectPciIrqRoutingTable(
     _In_ PCONFIGURATION_COMPONENT_DATA BusKey)
 {
@@ -124,7 +125,7 @@ DetectPciIrqRoutingTable(
 
     Table = GetPciIrqRoutingTable();
     if (!Table)
-        return;
+        return NULL;
 
     TRACE("Table size: %u\n", Table->TableSize);
 
@@ -135,7 +136,7 @@ DetectPciIrqRoutingTable(
     if (PartialResourceList == NULL)
     {
         ERR("Failed to allocate resource descriptor\n");
-        return;
+        return NULL;
     }
 
     /* Initialize resource descriptor */
@@ -155,9 +156,9 @@ DetectPciIrqRoutingTable(
     PartialDescriptor->ShareDisposition = CmResourceShareUndetermined;
     PartialDescriptor->u.DeviceSpecificData.DataSize = Table->TableSize;
 
-    memcpy(&PartialResourceList->PartialDescriptors[2],
-           Table,
-           Table->TableSize);
+    RtlCopyMemory(&PartialResourceList->PartialDescriptors[2],
+                  Table,
+                  Table->TableSize);
 
     FldrCreateComponentKey(BusKey,
                            PeripheralClass,
@@ -169,20 +170,162 @@ DetectPciIrqRoutingTable(
                            PartialResourceList,
                            Size,
                            &TableKey);
+
+    return TableKey;
 }
+
+
+#include <pshpack1.h>
+
+typedef struct _PCI_REGISTRY_DEVICE
+{
+    union
+    {
+        struct
+        {
+            USHORT FunctionNumber : 3;
+            USHORT DeviceNumber   : 5;
+            USHORT BusNumber      : 8;
+        } bits;
+        USHORT AsUSHORT;
+    } Address;
+
+    PCI_COMMON_CONFIG PciConfig;
+} PCI_REGISTRY_DEVICE, *PPCI_REGISTRY_DEVICE;
+
+#include <poppack.h>
+
+/**
+ * @brief
+ * Retrieves the next PCI device on the specified bus,
+ * and obtain its standard configuration information.
+ *
+ * @param[in]   BusNumber
+ * The PCI bus number where to enumerate PCI devices.
+ *
+ * @param[in,out]   NextSlotNumber
+ * In input, specifies the slot where to restart the enumeration.
+ * In output, receives the next slot where enumeration can be restarted.
+ *
+ * @param[out]  PciConfig
+ * Optional pointer to a PCI_COMMON_CONFIG buffer receiving
+ * the PCI device configuration data.
+ *
+ * @param[out]  ConfigSize
+ * Optional pointer to a ULONG that receives the actual
+ * length of the retrieved configuration data.
+ *
+ * @return
+ * The next PCI device slot number on the given bus, or -1 if none.
+ *
+ * @note    See SpiGetPciConfigData().
+ **/
+ULONG
+GetNextPciDevice(
+    _In_ ULONG BusNumber,
+    _Inout_ PPCI_SLOT_NUMBER NextSlotNumber,
+    _Out_opt_ PPCI_COMMON_CONFIG PciConfig,
+    _Out_opt_ PULONG ConfigSize)
+{
+    ULONG DeviceNumber;
+    ULONG FunctionNumber;
+    PCI_COMMON_CONFIG PciData;
+    ULONG DataSize;
+
+    /* Loop through all devices */
+    for (DeviceNumber = NextSlotNumber->u.bits.DeviceNumber;
+         DeviceNumber < PCI_MAX_DEVICES;
+         DeviceNumber++)
+    {
+        /* Loop through all functions */
+        for (FunctionNumber = NextSlotNumber->u.bits.FunctionNumber;
+             FunctionNumber < PCI_MAX_FUNCTION;
+             FunctionNumber++)
+        {
+            PCI_SLOT_NUMBER SlotNumber = {0};
+            SlotNumber.u.bits.DeviceNumber   = DeviceNumber;
+            SlotNumber.u.bits.FunctionNumber = FunctionNumber;
+
+            /* Retrieve PCI configuration data */
+            RtlZeroMemory(&PciData, sizeof(PciData));
+            DataSize = (PciConfig ? sizeof(PciData) : PCI_COMMON_HDR_LENGTH);
+            DataSize = HalGetBusDataByOffset(PCIConfiguration,
+                                             BusNumber,
+                                             SlotNumber.u.AsULONG,
+                                             &PciData,
+                                             0,
+                                             DataSize);
+
+            /* If the returned size is 0, then the bus is wrong */
+            if (DataSize == 0)
+            {
+                ERR("HalGetBusDataByOffset(%02x:%02x.%x) failed\n",
+                    BusNumber, DeviceNumber, FunctionNumber);
+                return -1;
+            }
+
+            /* If the result is PCI_INVALID_VENDORID, then this
+             * device has no more "Functions" */
+            if (PciData.VendorID == PCI_INVALID_VENDORID)
+                break;
+
+#if 0
+            /* Print out the data */
+            DbgPrint("%02x:%02x.%x [%02x%02x]: [%04x:%04x] (rev %02x)\n",
+                     BusNumber, DeviceNumber, FunctionNumber,
+                     PciData.BaseClass,
+                     PciData.SubClass,
+                     PciData.VendorID,
+                     PciData.DeviceID,
+                     PciData.RevisionID);
+
+            if ((PciData.HeaderType & ~PCI_MULTIFUNCTION) == PCI_DEVICE_TYPE)
+            {
+                DbgPrint("\tSubsystem: [%04x:%04x]\n",
+                         PciData.u.type0.SubVendorID,
+                         PciData.u.type0.SubSystemID);
+            }
+#endif
+
+            /* Setup the device and function numbers for the next run */
+            NextSlotNumber->u.bits.DeviceNumber   = DeviceNumber;
+            NextSlotNumber->u.bits.FunctionNumber = FunctionNumber + 1;
+
+            /* Return the PCI configuration data to the caller */
+            if (PciConfig)
+                RtlCopyMemory(PciConfig, &PciData, DataSize);
+            if (ConfigSize)
+                *ConfigSize = DataSize;
+
+            /* And return the slot number of this valid device/function */
+            SlotNumber.u.bits.Reserved = 1; // Set it as valid.
+            return SlotNumber.u.AsULONG;
+        }
+
+        /* Go to the next device and reset the function number */
+        NextSlotNumber->u.bits.FunctionNumber = 0;
+    }
+
+    /* We are done enumerating */
+    NextSlotNumber->u.bits.DeviceNumber = 0;
+    return -1;
+}
+
 
 VOID
 DetectPciBios(
+    _In_opt_ PCSTR Options,
     _In_ PCONFIGURATION_COMPONENT_DATA SystemKey,
     _Out_ PULONG BusNumber)
 {
     PCM_PARTIAL_RESOURCE_LIST PartialResourceList;
     PCM_PARTIAL_RESOURCE_DESCRIPTOR PartialDescriptor;
-    PCI_REGISTRY_INFO BusData;
     PCONFIGURATION_COMPONENT_DATA BiosKey;
-    ULONG Size;
     PCONFIGURATION_COMPONENT_DATA BusKey;
+    PCI_REGISTRY_INFO BusData;
+    ULONG Size;
     ULONG i;
+    BOOLEAN PciEnum;
 
     /* Report the PCI BIOS */
     if (!FindPciBios(&BusData))
@@ -217,6 +360,9 @@ DetectPciBios(
 
     DetectPciIrqRoutingTable(BiosKey);
 
+    /* Check whether to enumerate PCI devices during buses enumeration */
+    PciEnum = !!NtLdrGetOption(Options, "PCIENUM");
+
     /* Report PCI buses */
     for (i = 0; i < (ULONG)BusData.NoBuses; i++)
     {
@@ -224,8 +370,7 @@ DetectPciBios(
         if (i == 0)
         {
             /* Set 'Configuration Data' value */
-            Size = FIELD_OFFSET(CM_PARTIAL_RESOURCE_LIST,
-                                PartialDescriptors) +
+            Size = FIELD_OFFSET(CM_PARTIAL_RESOURCE_LIST, PartialDescriptors) +
                    sizeof(CM_PARTIAL_RESOURCE_DESCRIPTOR) +
                    sizeof(PCI_REGISTRY_INFO);
             PartialResourceList = FrLdrHeapAlloc(Size, TAG_HW_RESOURCE_LIST);
@@ -245,15 +390,14 @@ DetectPciBios(
             PartialDescriptor->Type = CmResourceTypeDeviceSpecific;
             PartialDescriptor->ShareDisposition = CmResourceShareUndetermined;
             PartialDescriptor->u.DeviceSpecificData.DataSize = sizeof(PCI_REGISTRY_INFO);
-            memcpy(&PartialResourceList->PartialDescriptors[1],
-                   &BusData,
-                   sizeof(PCI_REGISTRY_INFO));
+            RtlCopyMemory(&PartialResourceList->PartialDescriptors[1],
+                          &BusData,
+                          sizeof(PCI_REGISTRY_INFO));
         }
         else
         {
             /* Set 'Configuration Data' value */
-            Size = FIELD_OFFSET(CM_PARTIAL_RESOURCE_LIST,
-                                PartialDescriptors);
+            Size = FIELD_OFFSET(CM_PARTIAL_RESOURCE_LIST, PartialDescriptors);
             PartialResourceList = FrLdrHeapAlloc(Size, TAG_HW_RESOURCE_LIST);
             if (!PartialResourceList)
             {
@@ -280,6 +424,76 @@ DetectPciBios(
 
         /* Increment bus number */
         (*BusNumber)++;
+
+        if (PciEnum)
+        {
+            ULONG PciDevicesNumber, Device;
+            ULONG DataSize;
+            PPCI_REGISTRY_DEVICE PciDevice;
+            PCONFIGURATION_COMPONENT_DATA DataKey;
+
+            PCI_SLOT_NUMBER SlotNumber, NextSlotNumber;
+
+            /* Count all the PCI devices on this bus */
+            PciDevicesNumber = 0;
+            NextSlotNumber.u.AsULONG = 0;
+            while (GetNextPciDevice(i, &NextSlotNumber,
+                                    NULL, NULL) != -1)
+            {
+                ++PciDevicesNumber;
+            }
+            DataSize = (PciDevicesNumber * sizeof(PCI_REGISTRY_DEVICE));
+
+            /* Set 'Configuration Data' value */
+            Size = sizeof(CM_PARTIAL_RESOURCE_LIST) + DataSize;
+            PartialResourceList = FrLdrHeapAlloc(Size, TAG_HW_RESOURCE_LIST);
+            if (!PartialResourceList)
+            {
+                /* Ignore since this is optional */
+                continue;
+            }
+
+            /* Initialize resource descriptor */
+            RtlZeroMemory(PartialResourceList, Size);
+            PartialResourceList->Version = 1;
+            PartialResourceList->Revision = 1;
+            PartialResourceList->Count = 1;
+
+            PartialDescriptor = &PartialResourceList->PartialDescriptors[0];
+            PartialDescriptor->Type = CmResourceTypeDeviceSpecific;
+            PartialDescriptor->ShareDisposition = CmResourceShareUndetermined;
+            PartialDescriptor->u.DeviceSpecificData.DataSize = DataSize;
+
+            /* Get pointer to PCI device data */
+            // &PartialResourceList->PartialDescriptors[1]
+            PciDevice = (PVOID)(((ULONG_PTR)PartialResourceList) + sizeof(CM_PARTIAL_RESOURCE_LIST));
+
+            /* Retrieve all the devices data on this PCI bus */
+            Device = 0;
+            NextSlotNumber.u.AsULONG = 0;
+            while ((Device < PciDevicesNumber) &&
+                   (SlotNumber.u.AsULONG = GetNextPciDevice(i, &NextSlotNumber,
+                                                            &PciDevice->PciConfig, NULL)) != -1)
+            {
+                PciDevice->Address.bits.BusNumber = i;
+                PciDevice->Address.bits.DeviceNumber   = SlotNumber.u.bits.DeviceNumber;
+                PciDevice->Address.bits.FunctionNumber = SlotNumber.u.bits.FunctionNumber;
+                ++PciDevice;
+                ++Device;
+            }
+
+            /* Create the PCI devices configuration enumeration key */
+            FldrCreateComponentKey(BusKey,
+                                   PeripheralClass,
+                                   RealModePCIEnumeration,
+                                   0,
+                                   0,
+                                   0xFFFFFFFF,
+                                   "PCI Devices",
+                                   PartialResourceList,
+                                   Size,
+                                   &DataKey);
+        }
     }
 }
 

--- a/boot/freeldr/freeldr/arch/i386/pc/machpc.c
+++ b/boot/freeldr/freeldr/arch/i386/pc/machpc.c
@@ -1705,7 +1705,7 @@ PcHwDetect(
     FindPciBios = PcFindPciBios;
 
     /* Detect buses */
-    DetectPciBios(SystemKey, &BusNumber);
+    DetectPciBios(Options, SystemKey, &BusNumber);
     DetectApmBios(SystemKey, &BusNumber);
     DetectPnpBios(SystemKey, &BusNumber);
     DetectIsaBios(Options, SystemKey, &BusNumber); // TODO: Detect first EISA or MCA, before ISA
@@ -1773,6 +1773,8 @@ VOID __cdecl ChainLoadBiosBootSectorCode(
 
 /* FIXME: Abstract things better so we don't need to place define here */
 #if !defined(SARCH_XBOX)
+VOID NTAPI HalpInitBusHandlers(VOID);
+
 VOID
 MachInit(const char *CmdLine)
 {
@@ -1807,7 +1809,11 @@ MachInit(const char *CmdLine)
     MachVtbl.HwDetect = PcHwDetect;
     MachVtbl.HwIdle = PcHwIdle;
 
+    /* Setup busy waiting */
     HalpCalibrateStallExecution();
+
+    /* Initialize bus handlers */
+    HalpInitBusHandlers();
 }
 
 VOID

--- a/boot/freeldr/freeldr/arch/i386/pc98/machpc98.c
+++ b/boot/freeldr/freeldr/arch/i386/pc98/machpc98.c
@@ -113,6 +113,8 @@ Pc98ArchTest(VOID)
     return RegsOut.w.ax != 0x1000;
 }
 
+VOID NTAPI HalpInitBusHandlers(VOID);
+
 VOID
 MachInit(const char *CmdLine)
 {
@@ -161,6 +163,12 @@ MachInit(const char *CmdLine)
 
     HiResoMachine = *(PUCHAR)MEM_BIOS_FLAG1 & HIGH_RESOLUTION_FLAG;
 
+    /* Setup busy waiting */
     HalpCalibrateStallExecution();
+
+    /* Initialize bus handlers */
+    HalpInitBusHandlers();
+
+    /* Initialize video */
     Pc98VideoInit();
 }

--- a/boot/freeldr/freeldr/arch/i386/pc98/pc98hw.c
+++ b/boot/freeldr/freeldr/arch/i386/pc98/pc98hw.c
@@ -1195,7 +1195,7 @@ Pc98HwDetect(
     FindPciBios = PcFindPciBios;
 
     /* Detect buses */
-    DetectPciBios(SystemKey, &BusNumber);
+    DetectPciBios(Options, SystemKey, &BusNumber);
     DetectApmBios(SystemKey, &BusNumber);
     DetectPnpBios(SystemKey, &BusNumber);
     DetectNesaBios(SystemKey, &BusNumber);

--- a/boot/freeldr/freeldr/arch/i386/xbox/machxbox.c
+++ b/boot/freeldr/freeldr/arch/i386/xbox/machxbox.c
@@ -285,7 +285,7 @@ XboxHwDetect(
     FindPciBios = XboxFindPciBios;
 
     /* TODO: Build actual xbox's hardware configuration tree */
-    DetectPciBios(SystemKey, &BusNumber);
+    DetectPciBios(Options, SystemKey, &BusNumber);
     DetectIsaBios(Options, SystemKey, &BusNumber);
 
     TRACE("DetectHardware() Done\n");
@@ -299,6 +299,8 @@ VOID XboxHwIdle(VOID)
 
 
 /******************************************************************************/
+
+VOID NTAPI HalpInitBusHandlers(VOID);
 
 VOID
 MachInit(const char *CmdLine)
@@ -366,14 +368,18 @@ MachInit(const char *CmdLine)
     MachVtbl.HwDetect = XboxHwDetect;
     MachVtbl.HwIdle = XboxHwIdle;
 
-    /* Initialize our stuff */
+    /* Setup busy waiting */
+    HalpCalibrateStallExecution();
+
+    /* Initialize bus handlers */
+    HalpInitBusHandlers();
+
+    /* Initialize memory and video */
     XboxMemInit();
     XboxVideoInit();
 
     /* Set LEDs to orange after init */
     XboxSetLED("oooo");
-
-    HalpCalibrateStallExecution();
 }
 
 VOID

--- a/boot/freeldr/freeldr/arch/uefi/uefisetup.c
+++ b/boot/freeldr/freeldr/arch/uefi/uefisetup.c
@@ -17,6 +17,8 @@ extern EFI_HANDLE GlobalImageHandle;
 
 /* FUNCTIONS ******************************************************************/
 
+VOID NTAPI HalpInitBusHandlers(VOID);
+
 VOID
 MachInit(const char *CmdLine)
 {
@@ -50,6 +52,9 @@ MachInit(const char *CmdLine)
     MachVtbl.InitializeBootDevices = UefiInitializeBootDevices;
     MachVtbl.HwDetect = UefiHwDetect;
     MachVtbl.HwIdle = UefiHwIdle;
+
+    /* Initialize bus handlers */
+    HalpInitBusHandlers();
 
     /* Setup GOP */
     if (UefiInitializeVideo() != EFI_SUCCESS)

--- a/boot/freeldr/freeldr/disk/partition.c
+++ b/boot/freeldr/freeldr/disk/partition.c
@@ -438,7 +438,6 @@ DiskGetPartitionEntry(
     return FALSE;
 }
 
-#ifndef _M_AMD64
 NTSTATUS
 NTAPI
 IopReadBootRecord(
@@ -585,5 +584,4 @@ IoReadPartitionTable(
     *PartitionBuffer = Partitions;
     return STATUS_SUCCESS;
 }
-#endif // _M_AMD64
 #endif

--- a/boot/freeldr/freeldr/disk/scsiport.c
+++ b/boot/freeldr/freeldr/disk/scsiport.c
@@ -563,7 +563,12 @@ ScsiPortGetBusData(
     IN PVOID Buffer,
     IN ULONG Length)
 {
-    return HalGetBusDataByOffset(BusDataType, SystemIoBusNumber, SlotNumber, Buffer, 0, Length);
+    return HalGetBusDataByOffset(BusDataType,
+                                 SystemIoBusNumber,
+                                 SlotNumber,
+                                 Buffer,
+                                 0,
+                                 Length);
 }
 
 PVOID
@@ -806,7 +811,6 @@ ScsiPortGetUncachedExtension(
 
     /* Allocate a common DMA buffer */
     Status = SpiAllocateCommonBuffer(DeviceExtension, NumberOfBytes);
-
     if (!NT_SUCCESS(Status))
     {
         TRACE("SpiAllocateCommonBuffer() failed with Status = 0x%08X!\n", Status);
@@ -1059,13 +1063,12 @@ SpiGetPciConfigData(
             SlotNumber.u.bits.FunctionNumber = FunctionNumber;
 
             /* Get PCI config bytes */
-            DataSize = HalGetBusDataByOffset(
-                PCIConfiguration,
-                BusNumber,
-                SlotNumber.u.AsULONG,
-                &PciConfig,
-                0,
-                sizeof(ULONG));
+            DataSize = HalGetBusDataByOffset(PCIConfiguration,
+                                             BusNumber,
+                                             SlotNumber.u.AsULONG,
+                                             &PciConfig,
+                                             0,
+                                             sizeof(PciConfig));
 
             /* If result of HalGetBusData is 0, then the bus is wrong */
             if (DataSize == 0)
@@ -1099,7 +1102,6 @@ SpiGetPciConfigData(
                                             BusNumber,
                                             SlotNumber.u.AsULONG,
                                             &ResourceList);
-
             if (!NT_SUCCESS(Status))
                 break;
 
@@ -1219,7 +1221,7 @@ ScsiPortInitialize(
 
             if (!SpiGetPciConfigData(HwInitializationData,
                                      &PortConfig,
-                                     0, /* FIXME */
+                                     0, /* FIXME */ // PortConfig.SystemIoBusNumber
                                      &SlotNumber))
             {
                 /* Continue to the next bus, nothing here */
@@ -1362,7 +1364,7 @@ ScsiPortReadPortBufferUchar(
     OUT PUCHAR Buffer,
     IN ULONG Count)
 {
-    __inbytestring(H2I(Port), Buffer, Count);
+    READ_PORT_BUFFER_UCHAR(Port, Buffer, Count);
 }
 
 VOID
@@ -1372,7 +1374,7 @@ ScsiPortReadPortBufferUlong(
     OUT PULONG Buffer,
     IN ULONG Count)
 {
-    __indwordstring(H2I(Port), Buffer, Count);
+    READ_PORT_BUFFER_ULONG(Port, Buffer, Count);
 }
 
 VOID
@@ -1382,7 +1384,7 @@ ScsiPortReadPortBufferUshort(
     OUT PUSHORT Buffer,
     IN ULONG Count)
 {
-    __inwordstring(H2I(Port), Buffer, Count);
+    READ_PORT_BUFFER_USHORT(Port, Buffer, Count);
 }
 
 UCHAR
@@ -1390,8 +1392,6 @@ NTAPI
 ScsiPortReadPortUchar(
     IN PUCHAR Port)
 {
-    TRACE("ScsiPortReadPortUchar(%p)\n", Port);
-
     return READ_PORT_UCHAR(Port);
 }
 
@@ -1418,8 +1418,7 @@ ScsiPortReadRegisterBufferUchar(
     IN PUCHAR Buffer,
     IN ULONG Count)
 {
-    // FIXME
-    UNIMPLEMENTED;
+    READ_REGISTER_BUFFER_UCHAR(Register, Buffer, Count);
 }
 
 VOID
@@ -1429,8 +1428,7 @@ ScsiPortReadRegisterBufferUlong(
     IN PULONG Buffer,
     IN ULONG Count)
 {
-    // FIXME
-    UNIMPLEMENTED;
+    READ_REGISTER_BUFFER_ULONG(Register, Buffer, Count);
 }
 
 VOID
@@ -1440,8 +1438,7 @@ ScsiPortReadRegisterBufferUshort(
     IN PUSHORT Buffer,
     IN ULONG Count)
 {
-    // FIXME
-    UNIMPLEMENTED;
+    READ_REGISTER_BUFFER_USHORT(Register, Buffer, Count);
 }
 
 UCHAR
@@ -1479,9 +1476,12 @@ ScsiPortSetBusDataByOffset(
     IN ULONG Offset,
     IN ULONG Length)
 {
-    // FIXME
-    UNIMPLEMENTED;
-    return 0;
+    return HalSetBusDataByOffset(BusDataType,
+                                 SystemIoBusNumber,
+                                 SlotNumber,
+                                 Buffer,
+                                 Offset,
+                                 Length);
 }
 
 VOID
@@ -1507,10 +1507,6 @@ ScsiPortValidateRange(
     return TRUE;
 }
 
-#if 0
-// ScsiPortWmi*
-#endif
-
 
 VOID
 NTAPI
@@ -1519,7 +1515,7 @@ ScsiPortWritePortBufferUchar(
     IN PUCHAR Buffer,
     IN ULONG Count)
 {
-    __outbytestring(H2I(Port), Buffer, Count);
+    WRITE_PORT_BUFFER_UCHAR(Port, Buffer, Count);
 }
 
 VOID
@@ -1529,7 +1525,7 @@ ScsiPortWritePortBufferUlong(
     IN PULONG Buffer,
     IN ULONG Count)
 {
-    __outdwordstring(H2I(Port), Buffer, Count);
+    WRITE_PORT_BUFFER_ULONG(Port, Buffer, Count);
 }
 
 VOID
@@ -1539,7 +1535,7 @@ ScsiPortWritePortBufferUshort(
     IN PUSHORT Buffer,
     IN ULONG Count)
 {
-    __outwordstring(H2I(Port), Buffer, Count);
+    WRITE_PORT_BUFFER_USHORT(Port, Buffer, Count);
 }
 
 VOID
@@ -1576,8 +1572,7 @@ ScsiPortWriteRegisterBufferUchar(
     IN PUCHAR Buffer,
     IN ULONG Count)
 {
-    // FIXME
-    UNIMPLEMENTED;
+    WRITE_REGISTER_BUFFER_UCHAR(Register, Buffer, Count);
 }
 
 VOID
@@ -1587,8 +1582,7 @@ ScsiPortWriteRegisterBufferUlong(
     IN PULONG Buffer,
     IN ULONG Count)
 {
-    // FIXME
-    UNIMPLEMENTED;
+    WRITE_REGISTER_BUFFER_ULONG(Register, Buffer, Count);
 }
 
 VOID
@@ -1598,8 +1592,7 @@ ScsiPortWriteRegisterBufferUshort(
     IN PUSHORT Buffer,
     IN ULONG Count)
 {
-    // FIXME
-    UNIMPLEMENTED;
+    WRITE_REGISTER_BUFFER_USHORT(Register, Buffer, Count);
 }
 
 VOID

--- a/boot/freeldr/freeldr/disk/scsiport.c
+++ b/boot/freeldr/freeldr/disk/scsiport.c
@@ -57,11 +57,6 @@ DBG_DEFAULT_CHANNEL(SCSIPORT);
 
 /* GLOBALS ********************************************************************/
 
-#ifdef _M_IX86
-VOID NTAPI HalpInitializePciStubs(VOID);
-VOID NTAPI HalpInitBusHandler(VOID);
-#endif
-
 typedef struct
 {
     PVOID NonCachedExtension;
@@ -1636,12 +1631,6 @@ LoadBootDeviceDriver(VOID)
     PVOID ImageBase = NULL;
     ULONG (NTAPI *EntryPoint)(IN PVOID DriverObject, IN PVOID RegistryPath);
     BOOLEAN Success;
-
-    // FIXME: Must be done *INSIDE* the HAL!
-#ifdef _M_IX86
-    HalpInitializePciStubs();
-    HalpInitBusHandler();
-#endif
 
     /* Initialize the loaded module list */
     InitializeListHead(&ModuleListHead);

--- a/boot/freeldr/freeldr/include/arch/pc/hardware.h
+++ b/boot/freeldr/freeldr/include/arch/pc/hardware.h
@@ -79,7 +79,11 @@ VOID DetectAcpiBios(PCONFIGURATION_COMPONENT_DATA SystemKey, ULONG *BusNumber);
 VOID DetectApmBios(PCONFIGURATION_COMPONENT_DATA SystemKey, ULONG *BusNumber);
 
 /* hwpci.c */
-VOID DetectPciBios(PCONFIGURATION_COMPONENT_DATA SystemKey, ULONG *BusNumber);
+VOID
+DetectPciBios(
+    _In_opt_ PCSTR Options,
+    _In_ PCONFIGURATION_COMPONENT_DATA SystemKey,
+    _Out_ PULONG BusNumber);
 
 /* i386pnp.S */
 ULONG_PTR __cdecl PnpBiosSupported(VOID);

--- a/boot/freeldr/freeldr/pcat.cmake
+++ b/boot/freeldr/freeldr/pcat.cmake
@@ -48,7 +48,6 @@ if(ARCH STREQUAL "i386")
         arch/i386/linux.S)
 
     list(APPEND PCATLDR_ARC_SOURCE
-        # disk/scsiport.c
         lib/fs/pxe.c
         arch/i386/drivemap.c
         arch/i386/hwacpi.c
@@ -170,12 +169,8 @@ set(PCH_SOURCE
     ${FREELDR_NTLDR_SOURCE})
 
 add_pch(freeldr_common include/freeldr.h PCH_SOURCE)
+#target_link_libraries(freeldr_common mini_hal)
 add_dependencies(freeldr_common bugcodes asm xdk)
-
-## GCC builds need this extra thing for some reason...
-if(ARCH STREQUAL "i386" AND NOT MSVC)
-    target_link_libraries(freeldr_common mini_hal)
-endif()
 
 add_asm_files(freeldr_base_asm ${PCATLDR_BASE_ASM_SOURCE})
 
@@ -214,9 +209,7 @@ set_image_base(freeldr_pe 0x10000)
 set_subsystem(freeldr_pe native)
 set_entrypoint(freeldr_pe RealEntryPoint)
 
-if(ARCH STREQUAL "i386")
-    target_link_libraries(freeldr_pe mini_hal)
-endif()
+target_link_libraries(freeldr_common mini_hal)
 
 target_link_libraries(freeldr_pe freeldr_common cportlib blcmlib blrtl libcntpr)
 

--- a/boot/freeldr/freeldr/uefi.cmake
+++ b/boot/freeldr/freeldr/uefi.cmake
@@ -66,12 +66,8 @@ set(PCH_SOURCE
     ${FREELDR_NTLDR_SOURCE})
 
 add_pch(uefifreeldr_common include/arch/uefi/uefildr.h PCH_SOURCE)
+#target_link_libraries(uefifreeldr_common mini_hal)
 add_dependencies(uefifreeldr_common bugcodes asm xdk)
-
-## GCC builds need this extra thing for some reason...
-if(ARCH STREQUAL "i386" AND NOT MSVC)
-    target_link_libraries(uefifreeldr_common mini_hal)
-endif()
 
 
 spec2def(uefildr.exe freeldr.spec)
@@ -81,11 +77,9 @@ list(APPEND UEFILDR_BASE_SOURCE
     arch/uefi/uefildr.c
     ${FREELDR_BASE_SOURCE})
 
-if(ARCH STREQUAL "i386")
-    # Must be included together with disk/scsiport.c
-    list(APPEND UEFILDR_BASE_SOURCE
-        ${CMAKE_CURRENT_BINARY_DIR}/uefildr.def)
-endif()
+# Must be included together with disk/scsiport.c
+list(APPEND UEFILDR_BASE_SOURCE
+    ${CMAKE_CURRENT_BINARY_DIR}/uefildr.def)
 
 add_executable(uefildr ${UEFILDR_BASE_SOURCE})
 set_target_properties(uefildr PROPERTIES SUFFIX ".efi")
@@ -121,9 +115,7 @@ endif()
 
 set_entrypoint(uefildr EfiEntry)
 
-if(ARCH STREQUAL "i386")
-    target_link_libraries(uefildr mini_hal)
-endif()
+target_link_libraries(uefildr mini_hal)
 
 target_link_libraries(uefildr uefifreeldr_common cportlib blcmlib blrtl libcntpr)
 

--- a/hal/halx86/CMakeLists.txt
+++ b/hal/halx86/CMakeLists.txt
@@ -40,6 +40,9 @@ function(add_hal _halname)
     endif()
 endfunction()
 
+# Mini-HAL library for the OS loader
+add_subdirectory(minihal)
+
 # The components
 include(generic.cmake)
 include(acpi.cmake)
@@ -53,7 +56,6 @@ if(ARCH STREQUAL "i386")
     include(pic.cmake)
     include(xbox.cmake)
     include(pc98.cmake)
-    add_subdirectory(minihal)
 
     remove_definitions(-DSARCH_XBOX)
     remove_definitions(-DSARCH_PC98)

--- a/hal/halx86/acpi/busemul.c
+++ b/hal/halx86/acpi/busemul.c
@@ -16,6 +16,7 @@
 
 /* PRIVATE FUNCTIONS **********************************************************/
 
+#ifndef _MINIHAL_
 CODE_SEG("INIT")
 VOID
 NTAPI
@@ -26,7 +27,6 @@ HalpRegisterKdSupportFunctions(VOID)
     KdReleasePciDeviceforDebugging = HalpReleasePciDeviceForDebugging;
 
     /* Register memory functions */
-#ifndef _MINIHAL_
 #if (NTDDI_VERSION >= NTDDI_VISTA)
     KdMapPhysicalMemory64 = HalpMapPhysicalMemory64Vista;
     KdUnmapVirtualAddress = HalpUnmapVirtualAddressVista;
@@ -34,11 +34,11 @@ HalpRegisterKdSupportFunctions(VOID)
     KdMapPhysicalMemory64 = HalpMapPhysicalMemory64;
     KdUnmapVirtualAddress = HalpUnmapVirtualAddress;
 #endif
-#endif
 
     /* Register ACPI stub */
     KdCheckPowerButton = HalpCheckPowerButton;
 }
+#endif // _MINIHAL_
 
 NTSTATUS
 NTAPI
@@ -109,6 +109,7 @@ HalpFindBusAddressTranslation(IN PHYSICAL_ADDRESS BusAddress,
 
 /* PUBLIC FUNCTIONS **********************************************************/
 
+#ifndef _MINIHAL_
 /*
  * @implemented
  */
@@ -119,6 +120,7 @@ HalAdjustResourceList(IN OUT PIO_RESOURCE_REQUIREMENTS_LIST* pRequirementsList)
     /* Deprecated, return success */
     return STATUS_SUCCESS;
 }
+#endif // _MINIHAL_
 
 /*
  * @implemented
@@ -227,6 +229,7 @@ HalGetBusDataByOffset(IN BUS_DATA_TYPE BusDataType,
     return 0;
 }
 
+#ifndef _MINIHAL_
 /*
  * @implemented
  */
@@ -245,6 +248,7 @@ HalGetInterruptVector(IN INTERFACE_TYPE InterfaceType,
                                       Irql,
                                       Affinity);
 }
+#endif // _MINIHAL_
 
 /*
  * @implemented

--- a/hal/halx86/acpi/busemul.c
+++ b/hal/halx86/acpi/busemul.c
@@ -55,10 +55,11 @@ HalpAssignSlotResources(IN PUNICODE_STRING RegistryPath,
     PAGED_CODE();
 
     /* Only PCI is supported */
-    if (BusType != PCIBus) return STATUS_NOT_IMPLEMENTED;
+    if (BusType != PCIBus)
+        return STATUS_NOT_IMPLEMENTED;
 
     /* Setup fake PCI Bus handler */
-    RtlCopyMemory(&BusHandler, &HalpFakePciBusHandler, sizeof(BUS_HANDLER));
+    RtlCopyMemory(&BusHandler, &HalpFakePciBusHandler, sizeof(BusHandler));
     BusHandler.BusNumber = BusNumber;
 
     /* Call the PCI function */
@@ -94,10 +95,12 @@ HalpFindBusAddressTranslation(IN PHYSICAL_ADDRESS BusAddress,
                               IN BOOLEAN NextBus)
 {
     /* Make sure we have a context */
-    if (!Context) return FALSE;
+    if (!Context)
+        return FALSE;
 
     /* If we have data in the context, then this shouldn't be a new lookup */
-    if ((*Context != 0) && (NextBus != FALSE)) return FALSE;
+    if ((*Context != 0) && (NextBus != FALSE))
+        return FALSE;
 
     /* Return bus data */
     TranslatedAddress->QuadPart = BusAddress.QuadPart;
@@ -136,6 +139,8 @@ HalAssignSlotResources(IN PUNICODE_STRING RegistryPath,
                        IN ULONG SlotNumber,
                        IN OUT PCM_RESOURCE_LIST *AllocatedResources)
 {
+    PAGED_CODE();
+
     /* Check the bus type */
     if (BusType != PCIBus)
     {
@@ -195,9 +200,7 @@ HalGetBusDataByOffset(IN BUS_DATA_TYPE BusDataType,
                       IN ULONG Offset,
                       IN ULONG Length)
 {
-    BUS_HANDLER BusHandler;
-
-    /* Look as the bus type */
+    /* Look at the bus type */
     if (BusDataType == Cmos)
     {
         /* Call CMOS Function */
@@ -208,12 +211,12 @@ HalGetBusDataByOffset(IN BUS_DATA_TYPE BusDataType,
         /* FIXME: TODO */
         ASSERT(FALSE);
     }
-    else if ((BusDataType == PCIConfiguration) &&
-             (HalpPCIConfigInitialized) &&
+    else if ((BusDataType == PCIConfiguration) && HalpPCIConfigInitialized &&
              ((BusNumber >= HalpMinPciBus) && (BusNumber <= HalpMaxPciBus)))
     {
         /* Setup fake PCI Bus handler */
-        RtlCopyMemory(&BusHandler, &HalpFakePciBusHandler, sizeof(BUS_HANDLER));
+        BUS_HANDLER BusHandler;
+        RtlCopyMemory(&BusHandler, &HalpFakePciBusHandler, sizeof(BusHandler));
         BusHandler.BusNumber = BusNumber;
 
         /* Call PCI function */
@@ -282,18 +285,17 @@ HalSetBusDataByOffset(IN BUS_DATA_TYPE BusDataType,
                       IN ULONG Offset,
                       IN ULONG Length)
 {
-    BUS_HANDLER BusHandler;
-
-    /* Look as the bus type */
+    /* Look at the bus type */
     if (BusDataType == Cmos)
     {
         /* Call CMOS Function */
         return HalpSetCmosData(0, SlotNumber, Buffer, Length);
     }
-    else if ((BusDataType == PCIConfiguration) && (HalpPCIConfigInitialized))
+    else if ((BusDataType == PCIConfiguration) && HalpPCIConfigInitialized)
     {
         /* Setup fake PCI Bus handler */
-        RtlCopyMemory(&BusHandler, &HalpFakePciBusHandler, sizeof(BUS_HANDLER));
+        BUS_HANDLER BusHandler;
+        RtlCopyMemory(&BusHandler, &HalpFakePciBusHandler, sizeof(BusHandler));
         BusHandler.BusNumber = BusNumber;
 
         /* Call PCI function */
@@ -320,7 +322,7 @@ HalTranslateBusAddress(IN INTERFACE_TYPE InterfaceType,
                        IN OUT PULONG AddressSpace,
                        OUT PPHYSICAL_ADDRESS TranslatedAddress)
 {
-    /* Look as the bus type */
+    /* Look at the bus type */
     if (InterfaceType == PCIBus)
     {
         /* Call the PCI registered function */
@@ -332,6 +334,13 @@ HalTranslateBusAddress(IN INTERFACE_TYPE InterfaceType,
     }
     else
     {
+#if 0
+        return HalpTranslateBusAddress(InterfaceType,
+                                       BusNumber,
+                                       BusAddress,
+                                       AddressSpace,
+                                       TranslatedAddress);
+#endif
         /* Translation is easy */
         TranslatedAddress->QuadPart = BusAddress.QuadPart;
         return TRUE;

--- a/hal/halx86/legacy/bus/bushndlr.c
+++ b/hal/halx86/legacy/bus/bushndlr.c
@@ -467,7 +467,8 @@ HalpInitBusHandler(VOID)
 #endif
     HalPciAssignSlotResources = HalpAssignSlotResources;
     HalPciTranslateBusAddress = HaliTranslateBusAddress; /* PCI Driver can override */
-    if (!HalFindBusAddressTranslation) HalFindBusAddressTranslation = HaliFindBusAddressTranslation;
+    if (!HalFindBusAddressTranslation)
+        HalFindBusAddressTranslation = HaliFindBusAddressTranslation;
 }
 
 /* EOF */

--- a/hal/halx86/legacy/bus/pcibus.c
+++ b/hal/halx86/legacy/bus/pcibus.c
@@ -19,7 +19,9 @@ ULONG HalpBusType;
 
 BOOLEAN HalpPCIConfigInitialized;
 ULONG HalpMinPciBus, HalpMaxPciBus;
+#ifndef _MINIHAL_
 KSPIN_LOCK HalpPCIConfigLock;
+#endif
 PCI_CONFIG_HANDLER PCIConfigHandler;
 
 /* PCI Operation Matrix */
@@ -127,9 +129,11 @@ HalpPCISynchronizeType1(IN PBUS_HANDLER BusHandler,
     PciCfg1->u.bits.FunctionNumber = Slot.u.bits.FunctionNumber;
     PciCfg1->u.bits.Enable = TRUE;
 
+#ifndef _MINIHAL_
     /* Acquire the lock */
     KeRaiseIrql(HIGH_LEVEL, OldIrql);
     KeAcquireSpinLockAtDpcLevel(&HalpPCIConfigLock);
+#endif
 }
 
 VOID
@@ -144,8 +148,10 @@ HalpPCIReleaseSynchronzationType1(IN PBUS_HANDLER BusHandler,
     WRITE_PORT_ULONG(((PPCIPBUSDATA)BusHandler->BusData)->Config.Type1.Address,
                      PciCfg1.u.AsULONG);
 
+#ifndef _MINIHAL_
     /* Release the lock */
     KeReleaseSpinLock(&HalpPCIConfigLock, OldIrql);
+#endif
 }
 
 TYPE1_READ(HalpPCIReadUcharType1, UCHAR)
@@ -172,9 +178,11 @@ HalpPCISynchronizeType2(IN PBUS_HANDLER BusHandler,
     PciCfg->u.bits.Agent = (USHORT)Slot.u.bits.DeviceNumber;
     PciCfg->u.bits.AddressBase = (USHORT)BusData->Config.Type2.Base;
 
+#ifndef _MINIHAL_
     /* Acquire the lock */
     KeRaiseIrql(HIGH_LEVEL, OldIrql);
     KeAcquireSpinLockAtDpcLevel(&HalpPCIConfigLock);
+#endif
 
     /* Setup the CSE Register */
     PciCfg2Cse.u.AsUCHAR = 0;
@@ -201,8 +209,10 @@ HalpPCIReleaseSynchronizationType2(IN PBUS_HANDLER BusHandler,
     WRITE_PORT_UCHAR(BusData->Config.Type2.CSE, PciCfg2Cse.u.AsUCHAR);
     WRITE_PORT_UCHAR(BusData->Config.Type2.Forward, 0);
 
+#ifndef _MINIHAL_
     /* Release the lock */
     KeReleaseSpinLock(&HalpPCIConfigLock, OldIrql);
+#endif
 }
 
 TYPE2_READ(HalpPCIReadUcharType2, UCHAR)
@@ -652,6 +662,7 @@ HalpSetPCIData(IN PBUS_HANDLER BusHandler,
     /* Update the total length read */
     return Len;
 }
+
 #ifndef _MINIHAL_
 ULONG
 NTAPI
@@ -1219,8 +1230,10 @@ HalpInitializePciStubs(VOID)
         ExFreePoolWithTag(PciRegistryInfo, TAG_HAL);
     }
 
+#ifndef _MINIHAL_
     /* Initialize the PCI lock */
     KeInitializeSpinLock(&HalpPCIConfigLock);
+#endif
 
     /* Check the type of PCI bus */
     switch (PciType)
@@ -1304,4 +1317,3 @@ HalpInitializePciStubs(VOID)
 }
 
 /* EOF */
-

--- a/hal/halx86/legacy/bussupp.c
+++ b/hal/halx86/legacy/bussupp.c
@@ -12,92 +12,6 @@
 #define NDEBUG
 #include <debug.h>
 
-CODE_SEG("INIT")
-PBUS_HANDLER
-NTAPI
-HalpAllocateAndInitPciBusHandler(
-    IN ULONG PciType,
-    IN ULONG BusNo,
-    IN BOOLEAN TestAllocation
-);
-
-CODE_SEG("INIT")
-VOID
-NTAPI
-HalpFixupPciSupportedRanges(
-    IN ULONG BusCount
-);
-
-CODE_SEG("INIT")
-NTSTATUS
-NTAPI
-HalpGetChipHacks(
-    IN USHORT VendorId,
-    IN USHORT DeviceId,
-    IN UCHAR RevisionId,
-    IN PULONG HackFlags
-);
-
-CODE_SEG("INIT")
-BOOLEAN
-NTAPI
-HalpGetPciBridgeConfig(
-    IN ULONG PciType,
-    IN PUCHAR BusCount
-);
-
-CODE_SEG("INIT")
-BOOLEAN
-NTAPI
-HalpIsBridgeDevice(
-    IN PPCI_COMMON_CONFIG PciData
-);
-
-CODE_SEG("INIT")
-BOOLEAN
-NTAPI
-HalpIsIdeDevice(
-    IN PPCI_COMMON_CONFIG PciData
-);
-
-CODE_SEG("INIT")
-BOOLEAN
-NTAPI
-HalpIsRecognizedCard(
-    IN PPCI_REGISTRY_INFO_INTERNAL PciRegistryInfo,
-    IN PPCI_COMMON_CONFIG PciData,
-    IN ULONG Flags
-);
-
-CODE_SEG("INIT")
-BOOLEAN
-NTAPI
-HalpIsValidPCIDevice(
-    IN PBUS_HANDLER BusHandler,
-    IN PCI_SLOT_NUMBER Slot
-);
-
-CODE_SEG("INIT")
-NTSTATUS
-NTAPI
-HalpMarkChipsetDecode(
-    IN BOOLEAN OverrideEnable
-);
-
-CODE_SEG("INIT")
-VOID
-NTAPI
-HalpRegisterInternalBusHandlers(
-    VOID
-);
-
-CODE_SEG("INIT")
-VOID
-NTAPI
-ShowSize(
-    IN ULONG Size
-);
-
 /* GLOBALS ********************************************************************/
 
 extern KSPIN_LOCK HalpPCIConfigLock;
@@ -105,6 +19,7 @@ ULONG HalpPciIrqMask;
 
 /* PRIVATE FUNCTIONS **********************************************************/
 
+#ifndef _MINIHAL_
 PBUS_HANDLER
 NTAPI
 HalpAllocateBusHandler(IN INTERFACE_TYPE InterfaceType,
@@ -152,7 +67,6 @@ HalpAllocateBusHandler(IN INTERFACE_TYPE InterfaceType,
     return Bus;
 }
 
-#ifndef _MINIHAL_
 CODE_SEG("INIT")
 VOID
 NTAPI
@@ -226,13 +140,11 @@ HalpRegisterInternalBusHandlers(VOID)
     /* No support for EISA or MCA */
     ASSERT(HalpBusType == MACHINE_TYPE_ISA);
 }
-#endif // _MINIHAL_
 
-#ifndef _MINIHAL_
 CODE_SEG("INIT")
 NTSTATUS
 NTAPI
-HalpMarkChipsetDecode(BOOLEAN OverrideEnable)
+HalpMarkChipsetDecode(IN BOOLEAN OverrideEnable)
 {
     NTSTATUS Status;
     UNICODE_STRING KeyString;
@@ -421,8 +333,6 @@ HalpIsValidPCIDevice(IN PBUS_HANDLER BusHandler,
     /* Header, interrupt and address data all make sense */
     return TRUE;
 }
-
-static BOOLEAN WarningsGiven[5];
 
 CODE_SEG("INIT")
 NTSTATUS
@@ -636,6 +546,8 @@ HalpIsBridgeDevice(IN PPCI_COMMON_CONFIG PciData)
              (PciData->SubClass == PCI_SUBCLASS_BR_CARDBUS)));
 }
 
+static BOOLEAN WarningsGiven[5];
+
 CODE_SEG("INIT")
 BOOLEAN
 NTAPI
@@ -756,9 +668,8 @@ HalpFixupPciSupportedRanges(IN ULONG BusCount)
 }
 
 CODE_SEG("INIT")
-VOID
-NTAPI
-ShowSize(ULONG x)
+static VOID
+ShowSize(IN ULONG x)
 {
     if (!x) return;
     DbgPrint(" [size=");
@@ -1015,7 +926,7 @@ HalpDebugPciDumpBus(IN PBUS_HANDLER BusHandler,
         }
     }
 }
-#endif
+#endif // _MINIHAL_
 
 CODE_SEG("INIT")
 VOID
@@ -1276,14 +1187,12 @@ HalpRegisterKdSupportFunctions(VOID)
     KdReleasePciDeviceforDebugging = HalpReleasePciDeviceForDebugging;
 
     /* Register memory functions */
-#ifndef _MINIHAL_
 #if (NTDDI_VERSION >= NTDDI_VISTA)
     KdMapPhysicalMemory64 = HalpMapPhysicalMemory64Vista;
     KdUnmapVirtualAddress = HalpUnmapVirtualAddressVista;
 #else
     KdMapPhysicalMemory64 = HalpMapPhysicalMemory64;
     KdUnmapVirtualAddress = HalpUnmapVirtualAddress;
-#endif
 #endif
 
     /* Register ACPI stub */

--- a/hal/halx86/legacy/halpcat.c
+++ b/hal/halx86/legacy/halpcat.c
@@ -96,7 +96,7 @@ HalReportResourceUsage(VOID)
     /* Initialize PCI bus. */
     HalpInitializePciBus();
 
-    /* Initialize the stubs */
+    /* Setup the PCI stub support */
     HalpInitializePciStubs();
 
     /* What kind of bus is this? */

--- a/hal/halx86/minihal/CMakeLists.txt
+++ b/hal/halx86/minihal/CMakeLists.txt
@@ -1,11 +1,5 @@
 
 list(APPEND MINI_HAL_SOURCE
-    ../generic/portio.c
-    ../legacy/bus/bushndlr.c
-    ../legacy/bus/cmosbus.c
-    ../legacy/bus/isabus.c
-    ../legacy/bus/pcibus.c
-    ../legacy/bussupp.c
     ../generic/dma.c
     ../generic/drive.c
     ../generic/misc.c
@@ -13,22 +7,52 @@ list(APPEND MINI_HAL_SOURCE
     ../generic/spinlock.c
     ../generic/timer.c
     ../generic/usage.c
-    ../pic/pic.c
+    ../legacy/bus/pcibus.c
     ../include/hal.h
     halinit.c)
 
-if(SARCH STREQUAL "xbox")
+if(ARCH STREQUAL "i386")
     list(APPEND MINI_HAL_SOURCE
-        ../generic/beep.c
-        ../generic/cmos.c
-        ../xbox/clock.c
-        ../xbox/reboot.c)
-elseif(SARCH STREQUAL "pc98")
+        ../legacy/bussupp.c
+        ../legacy/bus/bushndlr.c
+        ../legacy/bus/cmosbus.c
+        ../legacy/bus/isabus.c)
+else()
     list(APPEND MINI_HAL_SOURCE
-        ../pc98/beep.c
-        ../pc98/clock.c
-        ../pc98/cmos.c
-        ../pc98/reboot.c)
+        ../acpi/busemul.c)
+endif()
+
+if(ARCH STREQUAL "i386")
+    list(APPEND MINI_HAL_SOURCE
+        ../generic/portio.c
+        ../pic/pic.c)
+    list(APPEND MINI_HAL_ASM_SOURCE
+        ${REACTOS_SOURCE_DIR}/ntoskrnl/ex/i386/ioport.S)
+
+    if(SARCH STREQUAL "xbox")
+        list(APPEND MINI_HAL_SOURCE
+            ../generic/beep.c
+            ../generic/cmos.c
+            ../xbox/clock.c
+            ../xbox/reboot.c)
+        list(APPEND MINI_HAL_ASM_SOURCE
+            ../generic/systimer.S)
+    elseif(SARCH STREQUAL "pc98")
+        list(APPEND MINI_HAL_SOURCE
+            ../pc98/beep.c
+            ../pc98/clock.c
+            ../pc98/cmos.c
+            ../pc98/delay.c
+            ../pc98/reboot.c)
+    else()
+        list(APPEND MINI_HAL_SOURCE
+            ../generic/beep.c
+            ../generic/clock.c
+            ../generic/cmos.c
+            ../generic/reboot.c)
+        list(APPEND MINI_HAL_ASM_SOURCE
+            ../generic/systimer.S)
+    endif()
 else()
     list(APPEND MINI_HAL_SOURCE
         ../generic/beep.c
@@ -37,7 +61,7 @@ else()
         ../generic/reboot.c)
 endif()
 
-add_asm_files(mini_hal_asm ../generic/systimer.S)
+add_asm_files(mini_hal_asm ${MINI_HAL_ASM_SOURCE})
 add_library(mini_hal ${MINI_HAL_SOURCE} ${mini_hal_asm})
 target_compile_definitions(mini_hal PRIVATE _MINIHAL_ _BLDR_ _NTSYSTEM_)
 add_dependencies(mini_hal psdk bugcodes asm)

--- a/hal/halx86/minihal/halinit.c
+++ b/hal/halx86/minihal/halinit.c
@@ -5,45 +5,22 @@
  * COPYRIGHT:   Copyright 1998 David Welch <welch@cwcom.net>
  */
 
-/* INCLUDES *****************************************************************/
+/* INCLUDES *******************************************************************/
 
 #include <hal.h>
-#define NDEBUG
-#include <debug.h>
 
-/* FUNCTIONS ***************************************************************/
+/* FUNCTIONS ******************************************************************/
 
-VOID
-NTAPI
-HalpInitProcessor(
-    IN ULONG ProcessorNumber,
-    IN PLOADER_PARAMETER_BLOCK LoaderBlock)
-{
-}
-
-VOID
-HalpInitPhase0(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
-{
-}
-
-VOID
-HalpInitPhase1(VOID)
-{
-}
-
-CODE_SEG("INIT")
-NTSTATUS
-NTAPI
-HalpSetupAcpiPhase0(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
-{
-    return STATUS_SUCCESS;
-}
+#if 0
 
 VOID
 NTAPI
-HalpInitializePICs(IN BOOLEAN EnableInterrupts)
+HalpInitializePICs(
+    IN BOOLEAN EnableInterrupts)
 {
 }
+
+#endif
 
 PDMA_ADAPTER
 NTAPI
@@ -53,13 +30,6 @@ HalpGetDmaAdapter(
     OUT PULONG NumberOfMapRegisters)
 {
     return NULL;
-}
-
-BOOLEAN
-NTAPI
-HalpBiosDisplayReset(VOID)
-{
-    return FALSE;
 }
 
 /* EOF */

--- a/hal/halx86/minihal/halinit.c
+++ b/hal/halx86/minihal/halinit.c
@@ -32,4 +32,17 @@ HalpGetDmaAdapter(
     return NULL;
 }
 
+CODE_SEG("INIT")
+VOID
+NTAPI
+HalpInitBusHandlers(VOID)
+{
+    /* Initialize the PCI bus */
+    // HalpInitializePciBus();
+    HalpInitializePciStubs();
+
+    // /* Register root support */
+    // HalpInitBusHandler();
+}
+
 /* EOF */

--- a/ntoskrnl/io/iomgr/iorsrce.c
+++ b/ntoskrnl/io/iomgr/iorsrce.c
@@ -12,7 +12,7 @@
 /* INCLUDES *****************************************************************/
 
 #include <ntoskrnl.h>
-#define NDEBUG
+//#define NDEBUG
 #include <debug.h>
 
 #ifndef NDEBUG
@@ -886,7 +886,7 @@ IopStoreSystemPartitionInformation(
                                       &ObjectAttributes);
     if (!NT_SUCCESS(Status))
     {
-        DPRINT("Failed to open symlink %wZ, Status=%lx\n", NtSystemPartitionDeviceName, Status);
+        DPRINT1("Failed to open symlink %wZ, Status=%lx\n", NtSystemPartitionDeviceName, Status);
         return;
     }
 
@@ -903,7 +903,7 @@ IopStoreSystemPartitionInformation(
 
     if (!NT_SUCCESS(Status))
     {
-        DPRINT("Failed querying symlink %wZ, Status=%lx\n", NtSystemPartitionDeviceName, Status);
+        DPRINT1("Failed querying symlink %wZ, Status=%lx\n", NtSystemPartitionDeviceName, Status);
         return;
     }
 
@@ -917,7 +917,7 @@ IopStoreSystemPartitionInformation(
                                   KEY_ALL_ACCESS);
     if (!NT_SUCCESS(Status))
     {
-        DPRINT("Failed to open HKLM\\SYSTEM, Status=%lx\n", Status);
+        DPRINT1("Failed to open HKLM\\SYSTEM, Status=%lx\n", Status);
         return;
     }
 
@@ -936,7 +936,7 @@ IopStoreSystemPartitionInformation(
 
     if (!NT_SUCCESS(Status))
     {
-        DPRINT("Failed opening/creating Setup key, Status=%lx\n", Status);
+        DPRINT1("Failed opening/creating Setup key, Status=%lx\n", Status);
         return;
     }
 
@@ -952,7 +952,7 @@ IopStoreSystemPartitionInformation(
                            LinkTarget.Length + sizeof(WCHAR));
     if (!NT_SUCCESS(Status))
     {
-        DPRINT("Failed writing SystemPartition value, Status=%lx\n", Status);
+        DPRINT1("Failed writing SystemPartition value, Status=%lx\n", Status);
     }
 
     /* Prepare for second data writing */
@@ -975,7 +975,7 @@ IopStoreSystemPartitionInformation(
                            OsLoaderPathName->Length + sizeof(UNICODE_NULL));
     if (!NT_SUCCESS(Status))
     {
-        DPRINT("Failed writing OsLoaderPath value, Status=%lx\n", Status);
+        DPRINT1("Failed writing OsLoaderPath value, Status=%lx\n", Status);
     }
 
     /* We're finally done! */


### PR DESCRIPTION
### _NOTE: This PR is draft but feedback/comments are more than welcome._

## Purpose

The purpose of this PR is:
- allow supporting the freeldr SCSI driver on any architecture where it could make sense (and not just on x86);
- and doing the same for PCI bus support, since also the SCSI driver uses the HAL bus functions to read and write from/to the PCI bus. For this, the bus support in the mini_hal library needs some rework.

In addition, add support for the undocumented /PCIENUM boot option in FreeLdr. Its effect is to dump some PCI configuration in the `PCI BIOS\PCI\PCI Devices` hardware registry key. (You can test this switch on Windows 2003 as well.)

## Proposed changes

_TBD, but the commit titles/logs should give a pretty decent overview of the proposed changes._

## TODO

- [ ] Get feedback/discussion with @DarkFire01 , @binarymaster , @disean for BIOS-based PC, as well as other (XBOX, PC-98, UEFI? and some ARM32? ...) platforms where PCI support makes sense.
- [ ] Fix compilation on any platform these changes have influenced.
- [ ] Fix GCC compilation.
- [ ] Make it actually work (I know there is work to be done to fix PCI bus init from the HAL when invoked by freeldr. See `HalpQueryPciRegistryInfo()` that needs to be changed in minihal.)
- [ ] ...
