### PR TITLE
[UXTHEME] Add Portuguese Portugal (pt-PT) and Portuguese Brazil (pt-BR) translation

### DIFF
--- a/dll/win32/uxtheme/lang/pt-BR.rc
+++ b/dll/win32/uxtheme/lang/pt-BR.rc
@@ -2,7 +2,7 @@
  * PROJECT:     ReactOS uxtheme.dll
  * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
  * PURPOSE:     Portuguese (Brazil) resource file
- * TRANSLATOR: Copyright 2024 Daniel Victor <ilauncherdeveloper@gmail.com>
+ * TRANSLATOR:  Copyright 2024 Daniel Victor <ilauncherdeveloper@gmail.com>
  */
 
 LANGUAGE LANG_PORTUGUESE, SUBLANG_PORTUGUESE_BRAZILIAN

--- a/dll/win32/uxtheme/lang/pt-BR.rc
+++ b/dll/win32/uxtheme/lang/pt-BR.rc
@@ -1,0 +1,19 @@
+/*
+ * PROJECT:     ReactOS uxtheme.dll
+ * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
+ * PURPOSE:     Portuguese (Brazil) resource file
+ * TRANSLATOR: Copyright 2024 Daniel Victor <ilauncherdeveloper@gmail.com>
+ */
+
+LANGUAGE LANG_PORTUGUESE, SUBLANG_PORTUGUESE_BRAZILIAN
+
+/* Strings */
+
+STRINGTABLE
+BEGIN
+    IDS_MESSAGEBOX "Caixa de mensagem"
+    IDS_ACTIVEWIN "Janela ativa"
+    IDS_INACTIVEWIN "Janela inativa"
+    IDS_OK "OK"
+    IDS_WINTEXT "Texto da janela"
+END

--- a/dll/win32/uxtheme/lang/pt-PT.rc
+++ b/dll/win32/uxtheme/lang/pt-PT.rc
@@ -1,0 +1,19 @@
+/*
+ * PROJECT:     ReactOS uxtheme.dll
+ * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
+ * PURPOSE:     Portuguese (Portugal) resource file
+ * TRANSLATOR: Copyright 2024 Daniel Victor <ilauncherdeveloper@gmail.com>
+ */
+
+LANGUAGE LANG_PORTUGUESE, SUBLANG_PORTUGUESE
+
+/* Strings */
+
+STRINGTABLE
+BEGIN
+    IDS_MESSAGEBOX "Caixa de mensagem"
+    IDS_ACTIVEWIN "Janela activa"
+    IDS_INACTIVEWIN "Janela inactiva"
+    IDS_OK "OK"
+    IDS_WINTEXT "Texto da janela"
+END

--- a/dll/win32/uxtheme/lang/pt-PT.rc
+++ b/dll/win32/uxtheme/lang/pt-PT.rc
@@ -2,7 +2,7 @@
  * PROJECT:     ReactOS uxtheme.dll
  * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
  * PURPOSE:     Portuguese (Portugal) resource file
- * TRANSLATOR: Copyright 2024 Daniel Victor <ilauncherdeveloper@gmail.com>
+ * TRANSLATOR:  Copyright 2024 Daniel Victor <ilauncherdeveloper@gmail.com>
  */
 
 LANGUAGE LANG_PORTUGUESE, SUBLANG_PORTUGUESE

--- a/dll/win32/uxtheme/uxtheme.rc
+++ b/dll/win32/uxtheme/uxtheme.rc
@@ -28,6 +28,12 @@
 #ifdef LANGUAGE_EN_US
     #include "lang/en-US.rc"
 #endif
+#ifdef LANGUAGE_PT_BR
+    #include "lang/pt-BR.rc"
+#endif
+#ifdef LANGUAGE_PT_PT
+    #include "lang/pt-PT.rc"
+#endif
 #ifdef LANGUAGE_RU_RU
     #include "lang/ru-RU.rc"
 #endif


### PR DESCRIPTION
## Purpose
Add pt-PT.rc and pt-BR.rc translation files for Uxtheme

## Tests
pt-BR:
![pt-BR](https://github.com/user-attachments/assets/9bd233e8-4f4f-4a05-a8a4-c925eb4b7065)

pt-PT: 
![pt-PT](https://github.com/user-attachments/assets/abf0ccd0-2402-461a-9213-179a988c9e98)
