### PR TITLE
[FREELDR] Add helpers for loading external PE images from FreeLdr.

### DIFF
--- a/boot/freeldr/freeldr/include/disk.h
+++ b/boot/freeldr/freeldr/include/disk.h
@@ -152,4 +152,4 @@ DiskGetPartitionEntry(
 /*
  * SCSI support (disk/scsiport.c)
  */
-ULONG LoadBootDeviceDriver(VOID);
+ARC_STATUS LoadBootDeviceDriver(VOID);

--- a/boot/freeldr/freeldr/include/peloader.h
+++ b/boot/freeldr/freeldr/include/peloader.h
@@ -60,3 +60,24 @@ PeLdrCheckForLoadedDll(
 PVOID
 PeLdrInitSecurityCookie(
     _In_ PLDR_DATA_TABLE_ENTRY LdrEntry);
+
+
+
+extern LIST_ENTRY FrLdrModuleList;
+extern PLDR_DATA_TABLE_ENTRY FreeldrDTE;
+
+ARC_STATUS
+FldrpLoadImage(
+    _In_ PCSTR ImageFilePath,
+    _In_opt_ PCSTR ImportName,
+    _In_ TYPE_OF_MEMORY MemoryType,
+    _Out_ PLDR_DATA_TABLE_ENTRY* ImageEntry,
+    _Out_opt_ PVOID* ImageBasePA);
+
+BOOLEAN
+FldrpUnloadImage(
+    _Inout_ PLDR_DATA_TABLE_ENTRY ImageEntry);
+
+ARC_STATUS
+FldrpStartImage(
+    _In_ PLDR_DATA_TABLE_ENTRY ImageEntry);

--- a/boot/freeldr/freeldr/lib/peloader.c
+++ b/boot/freeldr/freeldr/lib/peloader.c
@@ -25,6 +25,9 @@ DBG_DEFAULT_CHANNEL(PELOADER);
 
 /* GLOBALS *******************************************************************/
 
+LIST_ENTRY FrLdrModuleList;
+PLDR_DATA_TABLE_ENTRY FreeldrDTE;
+
 PELDR_IMPORTDLL_LOAD_CALLBACK PeLdrImportDllLoadCallback = NULL;
 
 #ifdef _WIN64
@@ -36,6 +39,44 @@ PELDR_IMPORTDLL_LOAD_CALLBACK PeLdrImportDllLoadCallback = NULL;
 
 
 /* PRIVATE FUNCTIONS *********************************************************/
+
+static BOOLEAN
+FrLdrInitImageSupport(VOID)
+{
+// extern char __ImageBase;
+    BOOLEAN Success;
+
+    if (FreeldrDTE)
+    {
+        /* Already initialized, bail out */
+        return TRUE;
+    }
+
+    /* Initialize the loaded module list */
+    InitializeListHead(&FrLdrModuleList);
+
+    /*
+     * Add freeldr.sys to the list of loaded executables, as it
+     * contains exports that may be imported by the loaded image.
+     * For example, ScsiPort* exports, imported by ntbootdd.sys.
+     */
+    Success = PeLdrAllocateDataTableEntry(&FrLdrModuleList,
+                                          "freeldr.sys",
+                                          "FREELDR.SYS",
+                                          &__ImageBase,
+                                          &FreeldrDTE);
+    if (!Success)
+    {
+        /* Cleanup and bail out */
+        ERR("PeLdrAllocateDataTableEntry('%s') failed\n", "FREELDR.SYS");
+        return FALSE; // ENOMEM;
+    }
+
+    /* Now unlink the DTEs, they won't be valid later */
+    // RemoveEntryList(&FreeldrDTE->InLoadOrderLinks);
+
+    return Success;
+}
 
 static PVOID
 PeLdrpFetchAddressOfSecurityCookie(PVOID BaseAddress, ULONG SizeOfImage)
@@ -1008,4 +1049,149 @@ Failure:
     /* Cleanup and bail out */
     MmFreeMemory(PhysicalBase);
     return FALSE;
+}
+
+
+/**
+ * @brief
+ * External FreeLdr PE image loader.
+ **/
+ARC_STATUS
+FldrpLoadImage(
+    _In_ PCSTR ImageFilePath,
+    _In_opt_ PCSTR ImportName,
+    _In_ TYPE_OF_MEMORY MemoryType,
+    _Out_ PLDR_DATA_TABLE_ENTRY* ImageEntry,
+    _Out_opt_ PVOID* ImageBasePA)
+{
+    ARC_STATUS Status;
+    BOOLEAN Success;
+    PVOID ImageBase = NULL;
+    PLDR_DATA_TABLE_ENTRY ImageDTE;
+    PIMAGE_NT_HEADERS NtHeaders;
+    PIMAGE_IMPORT_DESCRIPTOR ImportTable;
+    ULONG ImportTableSize;
+
+    /* Initialize image loading support */
+    // if (!FreeldrDTE)
+    if (!FrLdrInitImageSupport())
+    {
+        ERR("Cannot initialize Image Support\n");
+        return ENOEXEC;
+    }
+
+    /* Load the image */
+    Success = PeLdrLoadImage(ImageFilePath, MemoryType, &ImageBase);
+    if (!Success)
+    {
+        ERR("PeLdrLoadImage('%s') failed\n", ImageFilePath);
+        return ENOEXEC;
+    }
+
+    if (!ImportName)
+    {
+        /* Get the file name from the path */
+        ImportName = strrchr(ImageFilePath, '\\');
+        if (ImportName)
+        {
+            /* Name is past the path separator */
+            ImportName++;
+        }
+        else
+        {
+            /* No directory, just use the given path */
+            ImportName = ImageFilePath;
+        }
+    }
+
+    /* Allocate a DTE for it */
+    Success = PeLdrAllocateDataTableEntry(&FrLdrModuleList,
+                                          ImportName,
+                                          ImageFilePath,
+                                          ImageBase,
+                                          &ImageDTE);
+    if (!Success)
+    {
+        /* Cleanup and bail out */
+        ERR("PeLdrAllocateDataTableEntry('%s') failed\n", ImageFilePath);
+        MmFreeMemory(ImageBase);
+        return ENOMEM;
+    }
+
+    /* Reset ImageBase */
+    ASSERT(VaToPa(ImageDTE->DllBase) == ImageBase);
+    // ImageBase = VaToPa(ImageDTE->DllBase);
+
+    /* Load any other referenced DLLs for the loaded image */
+    Success = PeLdrScanImportDescriptorTable(&FrLdrModuleList, ""/*DirPath*/, ImageDTE);
+    if (!Success)
+    {
+        /* Cleanup and bail out */
+        ERR("PeLdrScanImportDescriptorTable('%s') failed\n", ImageFilePath);
+        Status = EIO;
+        goto Failure;
+    }
+
+    // /* Now unlink the DTEs, they won't be valid later */
+    // RemoveEntryList(&FreeldrDTE->InLoadOrderLinks);
+    // RemoveEntryList(&ImageDTE->InLoadOrderLinks);
+
+    /* Change imports to PA */
+    ImportTable =
+        (PIMAGE_IMPORT_DESCRIPTOR)RtlImageDirectoryEntryToData(ImageBase,
+                                                               TRUE,
+                                                               IMAGE_DIRECTORY_ENTRY_IMPORT,
+                                                               &ImportTableSize);
+    for (; (ImportTable->Name != 0) && (ImportTable->FirstThunk != 0); ImportTable++)
+    {
+        PIMAGE_THUNK_DATA ThunkData = (PIMAGE_THUNK_DATA)VaToPa(RVA(ImageDTE->DllBase, ImportTable->FirstThunk));
+
+        while (((PIMAGE_THUNK_DATA)ThunkData)->u1.AddressOfData != 0)
+        {
+            ThunkData->u1.Function = (ULONG_PTR)VaToPa((PVOID)ThunkData->u1.Function);
+            ThunkData++;
+        }
+    }
+
+    NtHeaders = RtlImageNtHeader(ImageBase);
+    ASSERT(NtHeaders); // PeLdrLoadImage succeeded, so the image was valid and had a header...
+    // ASSERT(NtHeaders->OptionalHeader.Magic == IMAGE_NT_OPTIONAL_HDR_MAGIC);
+
+    /* Relocate image to PA */
+    Success = (BOOLEAN)LdrRelocateImageWithBias(ImageBase,
+                                                NtHeaders->OptionalHeader.ImageBase - (ULONG_PTR)ImageDTE->DllBase,
+                                                "FreeLdr",
+                                                TRUE,
+                                                TRUE, /* In case of conflict still return success */
+                                                FALSE);
+    if (!Success)
+    {
+        Status = EIO;
+        goto Failure;
+    }
+
+    *ImageEntry = ImageDTE;
+    if (ImageBasePA)
+        *ImageBasePA = ImageBase;
+
+    return ESUCCESS;
+
+Failure:
+    /* We failed, cleanup */
+    FldrpUnloadImage(ImageDTE);
+    return Status;
+}
+
+/**
+ * @brief
+ * Unload a loaded external FreeLdr PE image.
+ **/
+BOOLEAN
+FldrpUnloadImage(
+    _Inout_ PLDR_DATA_TABLE_ENTRY ImageEntry)
+{
+    PVOID ImageBase = VaToPa(ImageEntry->DllBase);
+    PeLdrFreeDataTableEntry(ImageEntry);
+    MmFreeMemory(ImageBase);
+    return TRUE;
 }


### PR DESCRIPTION
## Purpose

Implements what corresponds to the "TODO" of @tkreuzer PR #7420
```
[FREELDR] Implement PeLdrLoadImageEx

This allows to load an image as freeldr extension code.
TODO:
- Add global bootloader DTE list
- Add wrapper function that also processes imports
- Use this for scsiport
```

## Proposed changes

- Add global bootloader DTE list `FreeldrDTE` and module list `FrLdrModuleList`;
- Add wrapper function that also processes imports `FldrpLoadImage()`;
- Use this for scsiport.
