### PR TITLE
[NTOS:EX:KD64] Implement KdSystemDebugControl and NtSystemDebugControl

### DIFF
--- a/ntoskrnl/ex/dbgctrl.c
+++ b/ntoskrnl/ex/dbgctrl.c
@@ -218,6 +218,10 @@ NtSystemDebugControl(
     ULONG Length = 0;
     NTSTATUS Status;
 
+    /* Debugger controlling requires the debug privilege */
+    if (!SeSinglePrivilegeCheck(SeDebugPrivilege, PreviousMode))
+        return STATUS_ACCESS_DENIED;
+
     _SEH2_TRY
     {
         if (PreviousMode != KernelMode)

--- a/ntoskrnl/ex/dbgctrl.c
+++ b/ntoskrnl/ex/dbgctrl.c
@@ -267,7 +267,17 @@ NtSystemDebugControl(
             case SysDbgWriteBusData:
             case SysDbgCheckLowMemory:
                 /* Those are implemented in KdSystemDebugControl */
-                Status = STATUS_NOT_IMPLEMENTED;
+                if (InitIsWinPEMode)
+                {
+                    Status = KdSystemDebugControl(Command,
+                                                  InputBuffer, InputBufferLength,
+                                                  OutputBuffer, OutputBufferLength,
+                                                  &Length, PreviousMode);
+                }
+                else
+                {
+                    Status = STATUS_NOT_IMPLEMENTED;
+                }
                 break;
 
             case SysDbgBreakPoint:

--- a/ntoskrnl/ex/dbgctrl.c
+++ b/ntoskrnl/ex/dbgctrl.c
@@ -185,12 +185,13 @@ ExpDebuggerWorker(
  *--*/
 NTSTATUS
 NTAPI
-NtSystemDebugControl(SYSDBG_COMMAND ControlCode,
-                     PVOID InputBuffer,
-                     ULONG InputBufferLength,
-                     PVOID OutputBuffer,
-                     ULONG OutputBufferLength,
-                     PULONG ReturnLength)
+NtSystemDebugControl(
+    _In_ SYSDBG_COMMAND ControlCode,
+    _In_reads_bytes_(InputBufferLength) PVOID InputBuffer,
+    _In_ ULONG InputBufferLength,
+    _Out_writes_bytes_(OutputBufferLength) PVOID OutputBuffer,
+    _In_ ULONG OutputBufferLength,
+    _Out_opt_ PULONG ReturnLength)
 {
     switch (ControlCode)
     {

--- a/ntoskrnl/ex/dbgctrl.c
+++ b/ntoskrnl/ex/dbgctrl.c
@@ -319,6 +319,18 @@ NtSystemDebugControl(
                 break;
 
             case SysDbgGetPrintBufferSize:
+                if (OutputBufferLength != sizeof(ULONG))
+                {
+                    Status = STATUS_INFO_LENGTH_MISMATCH;
+                }
+                else
+                {
+                    /* Return buffer size only if KD is enabled */
+                    *(PULONG)OutputBuffer = KdPitchDebugger ? 0 : KdPrintBufferSize;
+                    Status = STATUS_SUCCESS;
+                }
+                break;
+
             case SysDbgSetPrintBufferSize:
             case SysDbgGetKdUmExceptionEnable:
             case SysDbgSetKdUmExceptionEnable:

--- a/ntoskrnl/ex/dbgctrl.c
+++ b/ntoskrnl/ex/dbgctrl.c
@@ -367,10 +367,29 @@ NtSystemDebugControl(
                 break;
 
             case SysDbgGetTriageDump:
-            case SysDbgGetKdBlockEnable:
-            case SysDbgSetKdBlockEnable:
                 UNIMPLEMENTED;
                 Status = STATUS_NOT_IMPLEMENTED;
+                break;
+
+            case SysDbgGetKdBlockEnable:
+                if (OutputBufferLength != sizeof(BOOLEAN))
+                {
+                    Status = STATUS_INFO_LENGTH_MISMATCH;
+                }
+                else
+                {
+                    *(PBOOLEAN)OutputBuffer = KdBlockEnable;
+                    Status = STATUS_SUCCESS;
+                }
+                break;
+
+            case SysDbgSetKdBlockEnable:
+                Status = KdChangeOption(KD_OPTION_SET_BLOCK_ENABLE,
+                                        InputBufferLength,
+                                        InputBuffer,
+                                        OutputBufferLength,
+                                        OutputBuffer,
+                                        &Length);
                 break;
 
             default:

--- a/ntoskrnl/ex/dbgctrl.c
+++ b/ntoskrnl/ex/dbgctrl.c
@@ -283,7 +283,13 @@ NtSystemDebugControl(
                 break;
 
             case SysDbgEnableKernelDebugger:
+                Status = KdEnableDebugger();
+                break;
+
             case SysDbgDisableKernelDebugger:
+                Status = KdDisableDebugger();
+                break;
+
             case SysDbgGetAutoKdEnable:
             case SysDbgSetAutoKdEnable:
             case SysDbgGetPrintBufferSize:

--- a/ntoskrnl/ex/dbgctrl.c
+++ b/ntoskrnl/ex/dbgctrl.c
@@ -332,8 +332,40 @@ NtSystemDebugControl(
                 break;
 
             case SysDbgSetPrintBufferSize:
+                UNIMPLEMENTED;
+                Status = STATUS_NOT_IMPLEMENTED;
+                break;
+
             case SysDbgGetKdUmExceptionEnable:
+                if (OutputBufferLength != sizeof(BOOLEAN))
+                {
+                    Status = STATUS_INFO_LENGTH_MISMATCH;
+                }
+                else
+                {
+                    /* Unfortunately, the internal flag says if UM exceptions are disabled */
+                    *(PBOOLEAN)OutputBuffer = !KdIgnoreUmExceptions;
+                    Status = STATUS_SUCCESS;
+                }
+                break;
+
             case SysDbgSetKdUmExceptionEnable:
+                if (InputBufferLength != sizeof(BOOLEAN))
+                {
+                    Status = STATUS_INFO_LENGTH_MISMATCH;
+                }
+                else if (KdPitchDebugger)
+                {
+                    Status = STATUS_ACCESS_DENIED;
+                }
+                else
+                {
+                    /* Unfortunately, the internal flag says if UM exceptions are disabled */
+                    KdIgnoreUmExceptions = !*(PBOOLEAN)InputBuffer;
+                    Status = STATUS_SUCCESS;
+                }
+                break;
+
             case SysDbgGetTriageDump:
             case SysDbgGetKdBlockEnable:
             case SysDbgSetKdBlockEnable:

--- a/ntoskrnl/ex/dbgctrl.c
+++ b/ntoskrnl/ex/dbgctrl.c
@@ -291,7 +291,33 @@ NtSystemDebugControl(
                 break;
 
             case SysDbgGetAutoKdEnable:
+                if (OutputBufferLength != sizeof(BOOLEAN))
+                {
+                    Status = STATUS_INFO_LENGTH_MISMATCH;
+                }
+                else
+                {
+                    *(PBOOLEAN)OutputBuffer = KdAutoEnableOnEvent;
+                    Status = STATUS_SUCCESS;
+                }
+                break;
+
             case SysDbgSetAutoKdEnable:
+                if (InputBufferLength != sizeof(BOOLEAN))
+                {
+                    Status = STATUS_INFO_LENGTH_MISMATCH;
+                }
+                else if (KdPitchDebugger)
+                {
+                    Status = STATUS_ACCESS_DENIED;
+                }
+                else
+                {
+                    KdAutoEnableOnEvent = *(PBOOLEAN)InputBuffer;
+                    Status = STATUS_SUCCESS;
+                }
+                break;
+
             case SysDbgGetPrintBufferSize:
             case SysDbgSetPrintBufferSize:
             case SysDbgGetKdUmExceptionEnable:

--- a/ntoskrnl/ex/dbgctrl.c
+++ b/ntoskrnl/ex/dbgctrl.c
@@ -271,6 +271,17 @@ NtSystemDebugControl(
                 break;
 
             case SysDbgBreakPoint:
+                if (KdDebuggerEnabled)
+                {
+                    DbgBreakPointWithStatus(DBG_STATUS_DEBUG_CONTROL);
+                    Status = STATUS_SUCCESS;
+                }
+                else
+                {
+                    Status = STATUS_UNSUCCESSFUL;
+                }
+                break;
+
             case SysDbgEnableKernelDebugger:
             case SysDbgDisableKernelDebugger:
             case SysDbgGetAutoKdEnable:

--- a/ntoskrnl/ex/sysinfo.c
+++ b/ntoskrnl/ex/sysinfo.c
@@ -208,7 +208,7 @@ ExLockUserBuffer(
     PMDL *OutMdl)
 {
     PMDL Mdl;
-    PAGED_CODE();
+    ASSERT(KeGetCurrentIrql() <= DISPATCH_LEVEL);
 
     *MappedSystemVa = NULL;
     *OutMdl = NULL;

--- a/ntoskrnl/include/internal/ex.h
+++ b/ntoskrnl/include/internal/ex.h
@@ -1510,6 +1510,20 @@ ExTimerRundown(
     VOID
 );
 
+VOID
+NTAPI
+ExUnlockUserBuffer(PMDL Mdl);
+
+NTSTATUS
+NTAPI
+ExLockUserBuffer(
+    PVOID BaseAddress,
+    ULONG Length,
+    KPROCESSOR_MODE AccessMode,
+    LOCK_OPERATION Operation,
+    PVOID *MappedSystemVa,
+    PMDL *OutMdl);
+
 CODE_SEG("INIT")
 VOID
 NTAPI

--- a/ntoskrnl/include/internal/kd64.h
+++ b/ntoskrnl/include/internal/kd64.h
@@ -401,13 +401,13 @@ NTSTATUS
 NTAPI
 KdpSysReadMsr(
     _In_ ULONG Msr,
-    _Out_ PLARGE_INTEGER MsrValue);
+    _Out_ PULONGLONG MsrValue);
 
 NTSTATUS
 NTAPI
 KdpSysWriteMsr(
     _In_ ULONG Msr,
-    _In_ PLARGE_INTEGER MsrValue);
+    _In_ PULONGLONG MsrValue);
 
 //
 // Bus

--- a/ntoskrnl/include/internal/kd64.h
+++ b/ntoskrnl/include/internal/kd64.h
@@ -375,8 +375,7 @@ KdpZeroMemory(
 VOID
 NTAPI
 KdpSysGetVersion(
-    IN PDBGKD_GET_VERSION64 Version
-);
+    _Out_ PDBGKD_GET_VERSION64 Version);
 
 //
 // Context
@@ -401,16 +400,14 @@ KdpSetContextState(
 NTSTATUS
 NTAPI
 KdpSysReadMsr(
-    IN ULONG Msr,
-    OUT PLARGE_INTEGER MsrValue
-);
+    _In_ ULONG Msr,
+    _Out_ PLARGE_INTEGER MsrValue);
 
 NTSTATUS
 NTAPI
 KdpSysWriteMsr(
-    IN ULONG Msr,
-    IN PLARGE_INTEGER MsrValue
-);
+    _In_ ULONG Msr,
+    _In_ PLARGE_INTEGER MsrValue);
 
 //
 // Bus
@@ -418,26 +415,24 @@ KdpSysWriteMsr(
 NTSTATUS
 NTAPI
 KdpSysReadBusData(
-    IN ULONG BusDataType,
-    IN ULONG BusNumber,
-    IN ULONG SlotNumber,
-    IN ULONG Offset,
-    IN PVOID Buffer,
-    IN ULONG Length,
-    OUT PULONG ActualLength
-);
+    _In_ BUS_DATA_TYPE BusDataType,
+    _In_ ULONG BusNumber,
+    _In_ ULONG SlotNumber,
+    _In_ ULONG Offset,
+    _Out_writes_bytes_(Length) PVOID Buffer,
+    _In_ ULONG Length,
+    _Out_ PULONG ActualLength);
 
 NTSTATUS
 NTAPI
 KdpSysWriteBusData(
-    IN ULONG BusDataType,
-    IN ULONG BusNumber,
-    IN ULONG SlotNumber,
-    IN ULONG Offset,
-    IN PVOID Buffer,
-    IN ULONG Length,
-    OUT PULONG ActualLength
-);
+    _In_ BUS_DATA_TYPE BusDataType,
+    _In_ ULONG BusNumber,
+    _In_ ULONG SlotNumber,
+    _In_ ULONG Offset,
+    _In_reads_bytes_(Length) PVOID Buffer,
+    _In_ ULONG Length,
+    _Out_ PULONG ActualLength);
 
 //
 // Control Space
@@ -445,22 +440,20 @@ KdpSysWriteBusData(
 NTSTATUS
 NTAPI
 KdpSysReadControlSpace(
-    IN ULONG Processor,
-    IN ULONG64 BaseAddress,
-    IN PVOID Buffer,
-    IN ULONG Length,
-    OUT PULONG ActualLength
-);
+    _In_ ULONG Processor,
+    _In_ ULONG64 BaseAddress,
+    _Out_writes_bytes_(Length) PVOID Buffer,
+    _In_ ULONG Length,
+    _Out_ PULONG ActualLength);
 
 NTSTATUS
 NTAPI
 KdpSysWriteControlSpace(
-    IN ULONG Processor,
-    IN ULONG64 BaseAddress,
-    IN PVOID Buffer,
-    IN ULONG Length,
-    OUT PULONG ActualLength
-);
+    _In_ ULONG Processor,
+    _In_ ULONG64 BaseAddress,
+    _In_reads_bytes_(Length) PVOID Buffer,
+    _In_ ULONG Length,
+    _Out_ PULONG ActualLength);
 
 //
 // I/O Space
@@ -468,26 +461,24 @@ KdpSysWriteControlSpace(
 NTSTATUS
 NTAPI
 KdpSysReadIoSpace(
-    IN ULONG InterfaceType,
-    IN ULONG BusNumber,
-    IN ULONG AddressSpace,
-    IN ULONG64 IoAddress,
-    IN PVOID DataValue,
-    IN ULONG DataSize,
-    OUT PULONG ActualDataSize
-);
+    _In_ INTERFACE_TYPE InterfaceType,
+    _In_ ULONG BusNumber,
+    _In_ ULONG AddressSpace,
+    _In_ ULONG64 IoAddress,
+    _Out_writes_bytes_(DataSize) PVOID DataValue,
+    _In_ ULONG DataSize,
+    _Out_ PULONG ActualDataSize);
 
 NTSTATUS
 NTAPI
 KdpSysWriteIoSpace(
-    IN ULONG InterfaceType,
-    IN ULONG BusNumber,
-    IN ULONG AddressSpace,
-    IN ULONG64 IoAddress,
-    IN PVOID DataValue,
-    IN ULONG DataSize,
-    OUT PULONG ActualDataSize
-);
+    _In_ INTERFACE_TYPE InterfaceType,
+    _In_ ULONG BusNumber,
+    _In_ ULONG AddressSpace,
+    _In_ ULONG64 IoAddress,
+    _In_reads_bytes_(DataSize) PVOID DataValue,
+    _In_ ULONG DataSize,
+    _Out_ PULONG ActualDataSize);
 
 //
 // Low Memory

--- a/ntoskrnl/kd64/amd64/kdx64.c
+++ b/ntoskrnl/kd64/amd64/kdx64.c
@@ -95,12 +95,12 @@ NTSTATUS
 NTAPI
 KdpSysReadMsr(
     _In_ ULONG Msr,
-    _Out_ PLARGE_INTEGER MsrValue)
+    _Out_ PULONGLONG MsrValue)
 {
     /* Use SEH to protect from invalid MSRs */
     _SEH2_TRY
     {
-        MsrValue->QuadPart = __readmsr(Msr);
+        *MsrValue = __readmsr(Msr);
     }
     _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
     {
@@ -115,12 +115,12 @@ NTSTATUS
 NTAPI
 KdpSysWriteMsr(
     _In_ ULONG Msr,
-    _In_ PLARGE_INTEGER MsrValue)
+    _In_ PULONGLONG MsrValue)
 {
     /* Use SEH to protect from invalid MSRs */
     _SEH2_TRY
     {
-        __writemsr(Msr, MsrValue->QuadPart);
+        __writemsr(Msr, *MsrValue);
     }
     _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
     {

--- a/ntoskrnl/kd64/amd64/kdx64.c
+++ b/ntoskrnl/kd64/amd64/kdx64.c
@@ -93,8 +93,9 @@ KdpSetContextState(IN PDBGKD_ANY_WAIT_STATE_CHANGE WaitStateChange,
 
 NTSTATUS
 NTAPI
-KdpSysReadMsr(IN ULONG Msr,
-              OUT PLARGE_INTEGER MsrValue)
+KdpSysReadMsr(
+    _In_ ULONG Msr,
+    _Out_ PLARGE_INTEGER MsrValue)
 {
     /* Use SEH to protect from invalid MSRs */
     _SEH2_TRY
@@ -112,8 +113,9 @@ KdpSysReadMsr(IN ULONG Msr,
 
 NTSTATUS
 NTAPI
-KdpSysWriteMsr(IN ULONG Msr,
-               IN PLARGE_INTEGER MsrValue)
+KdpSysWriteMsr(
+    _In_ ULONG Msr,
+    _In_ PLARGE_INTEGER MsrValue)
 {
     /* Use SEH to protect from invalid MSRs */
     _SEH2_TRY
@@ -131,13 +133,14 @@ KdpSysWriteMsr(IN ULONG Msr,
 
 NTSTATUS
 NTAPI
-KdpSysReadBusData(IN ULONG BusDataType,
-                  IN ULONG BusNumber,
-                  IN ULONG SlotNumber,
-                  IN ULONG Offset,
-                  IN PVOID Buffer,
-                  IN ULONG Length,
-                  OUT PULONG ActualLength)
+KdpSysReadBusData(
+    _In_ BUS_DATA_TYPE BusDataType,
+    _In_ ULONG BusNumber,
+    _In_ ULONG SlotNumber,
+    _In_ ULONG Offset,
+    _Out_writes_bytes_(Length) PVOID Buffer,
+    _In_ ULONG Length,
+    _Out_ PULONG ActualLength)
 {
     UNIMPLEMENTED;
     return STATUS_UNSUCCESSFUL;
@@ -145,13 +148,14 @@ KdpSysReadBusData(IN ULONG BusDataType,
 
 NTSTATUS
 NTAPI
-KdpSysWriteBusData(IN ULONG BusDataType,
-                   IN ULONG BusNumber,
-                   IN ULONG SlotNumber,
-                   IN ULONG Offset,
-                   IN PVOID Buffer,
-                   IN ULONG Length,
-                   OUT PULONG ActualLength)
+KdpSysWriteBusData(
+    _In_ BUS_DATA_TYPE BusDataType,
+    _In_ ULONG BusNumber,
+    _In_ ULONG SlotNumber,
+    _In_ ULONG Offset,
+    _In_reads_bytes_(Length) PVOID Buffer,
+    _In_ ULONG Length,
+    _Out_ PULONG ActualLength)
 {
     UNIMPLEMENTED;
     return STATUS_UNSUCCESSFUL;
@@ -159,11 +163,12 @@ KdpSysWriteBusData(IN ULONG BusDataType,
 
 NTSTATUS
 NTAPI
-KdpSysReadControlSpace(IN ULONG Processor,
-                       IN ULONG64 BaseAddress,
-                       IN PVOID Buffer,
-                       IN ULONG Length,
-                       OUT PULONG ActualLength)
+KdpSysReadControlSpace(
+    _In_ ULONG Processor,
+    _In_ ULONG64 BaseAddress,
+    _Out_writes_bytes_(Length) PVOID Buffer,
+    _In_ ULONG Length,
+    _Out_ PULONG ActualLength)
 {
     PVOID ControlStart;
     PKPRCB Prcb = KiProcessorBlock[Processor];
@@ -210,11 +215,12 @@ KdpSysReadControlSpace(IN ULONG Processor,
 
 NTSTATUS
 NTAPI
-KdpSysWriteControlSpace(IN ULONG Processor,
-                        IN ULONG64 BaseAddress,
-                        IN PVOID Buffer,
-                        IN ULONG Length,
-                        OUT PULONG ActualLength)
+KdpSysWriteControlSpace(
+    _In_ ULONG Processor,
+    _In_ ULONG64 BaseAddress,
+    _In_reads_bytes_(Length) PVOID Buffer,
+    _In_ ULONG Length,
+    _Out_ PULONG ActualLength)
 {
     PVOID ControlStart;
     PKPRCB Prcb = KiProcessorBlock[Processor];
@@ -241,13 +247,14 @@ KdpSysWriteControlSpace(IN ULONG Processor,
 
 NTSTATUS
 NTAPI
-KdpSysReadIoSpace(IN ULONG InterfaceType,
-                  IN ULONG BusNumber,
-                  IN ULONG AddressSpace,
-                  IN ULONG64 IoAddress,
-                  OUT PVOID DataValue,
-                  IN ULONG DataSize,
-                  OUT PULONG ActualDataSize)
+KdpSysReadIoSpace(
+    _In_ INTERFACE_TYPE InterfaceType,
+    _In_ ULONG BusNumber,
+    _In_ ULONG AddressSpace,
+    _In_ ULONG64 IoAddress,
+    _Out_writes_bytes_(DataSize) PVOID DataValue,
+    _In_ ULONG DataSize,
+    _Out_ PULONG ActualDataSize)
 {
     /* Verify parameters */
     if (InterfaceType != Isa || BusNumber != 0 || AddressSpace != 1)
@@ -297,13 +304,14 @@ KdpSysReadIoSpace(IN ULONG InterfaceType,
 
 NTSTATUS
 NTAPI
-KdpSysWriteIoSpace(IN ULONG InterfaceType,
-                   IN ULONG BusNumber,
-                   IN ULONG AddressSpace,
-                   IN ULONG64 IoAddress,
-                   IN PVOID DataValue,
-                   IN ULONG DataSize,
-                   OUT PULONG ActualDataSize)
+KdpSysWriteIoSpace(
+    _In_ INTERFACE_TYPE InterfaceType,
+    _In_ ULONG BusNumber,
+    _In_ ULONG AddressSpace,
+    _In_ ULONG64 IoAddress,
+    _In_reads_bytes_(DataSize) PVOID DataValue,
+    _In_ ULONG DataSize,
+    _Out_ PULONG ActualDataSize)
 {
     /* Verify parameters */
     if (InterfaceType != Isa || BusNumber != 0 || AddressSpace != 1)

--- a/ntoskrnl/kd64/arm/kdarm.c
+++ b/ntoskrnl/kd64/arm/kdarm.c
@@ -35,8 +35,9 @@ KdpSetContextState(IN PDBGKD_ANY_WAIT_STATE_CHANGE WaitStateChange,
 
 NTSTATUS
 NTAPI
-KdpSysReadMsr(IN ULONG Msr,
-              OUT PLARGE_INTEGER MsrValue)
+KdpSysReadMsr(
+    _In_ ULONG Msr,
+    _Out_ PLARGE_INTEGER MsrValue)
 {
     UNIMPLEMENTED;
     return STATUS_UNSUCCESSFUL;
@@ -44,8 +45,9 @@ KdpSysReadMsr(IN ULONG Msr,
 
 NTSTATUS
 NTAPI
-KdpSysWriteMsr(IN ULONG Msr,
-               IN PLARGE_INTEGER MsrValue)
+KdpSysWriteMsr(
+    _In_ ULONG Msr,
+    _In_ PLARGE_INTEGER MsrValue)
 {
     UNIMPLEMENTED;
     return STATUS_UNSUCCESSFUL;
@@ -53,13 +55,14 @@ KdpSysWriteMsr(IN ULONG Msr,
 
 NTSTATUS
 NTAPI
-KdpSysReadBusData(IN ULONG BusDataType,
-                  IN ULONG BusNumber,
-                  IN ULONG SlotNumber,
-                  IN ULONG Offset,
-                  IN PVOID Buffer,
-                  IN ULONG Length,
-                  OUT PULONG ActualLength)
+KdpSysReadBusData(
+    _In_ BUS_DATA_TYPE BusDataType,
+    _In_ ULONG BusNumber,
+    _In_ ULONG SlotNumber,
+    _In_ ULONG Offset,
+    _Out_writes_bytes_(Length) PVOID Buffer,
+    _In_ ULONG Length,
+    _Out_ PULONG ActualLength)
 {
     UNIMPLEMENTED;
     return STATUS_UNSUCCESSFUL;
@@ -67,13 +70,14 @@ KdpSysReadBusData(IN ULONG BusDataType,
 
 NTSTATUS
 NTAPI
-KdpSysWriteBusData(IN ULONG BusDataType,
-                   IN ULONG BusNumber,
-                   IN ULONG SlotNumber,
-                   IN ULONG Offset,
-                   IN PVOID Buffer,
-                   IN ULONG Length,
-                   OUT PULONG ActualLength)
+KdpSysWriteBusData(
+    _In_ BUS_DATA_TYPE BusDataType,
+    _In_ ULONG BusNumber,
+    _In_ ULONG SlotNumber,
+    _In_ ULONG Offset,
+    _In_reads_bytes_(Length) PVOID Buffer,
+    _In_ ULONG Length,
+    _Out_ PULONG ActualLength)
 {
     UNIMPLEMENTED;
     return STATUS_UNSUCCESSFUL;
@@ -81,11 +85,12 @@ KdpSysWriteBusData(IN ULONG BusDataType,
 
 NTSTATUS
 NTAPI
-KdpSysReadControlSpace(IN ULONG Processor,
-                       IN ULONG64 BaseAddress,
-                       IN PVOID Buffer,
-                       IN ULONG Length,
-                       OUT PULONG ActualLength)
+KdpSysReadControlSpace(
+    _In_ ULONG Processor,
+    _In_ ULONG64 BaseAddress,
+    _Out_writes_bytes_(Length) PVOID Buffer,
+    _In_ ULONG Length,
+    _Out_ PULONG ActualLength)
 {
     UNIMPLEMENTED;
     return STATUS_UNSUCCESSFUL;
@@ -93,11 +98,12 @@ KdpSysReadControlSpace(IN ULONG Processor,
 
 NTSTATUS
 NTAPI
-KdpSysWriteControlSpace(IN ULONG Processor,
-                        IN ULONG64 BaseAddress,
-                        IN PVOID Buffer,
-                        IN ULONG Length,
-                        OUT PULONG ActualLength)
+KdpSysWriteControlSpace(
+    _In_ ULONG Processor,
+    _In_ ULONG64 BaseAddress,
+    _In_reads_bytes_(Length) PVOID Buffer,
+    _In_ ULONG Length,
+    _Out_ PULONG ActualLength)
 {
     UNIMPLEMENTED;
     return STATUS_UNSUCCESSFUL;
@@ -105,13 +111,14 @@ KdpSysWriteControlSpace(IN ULONG Processor,
 
 NTSTATUS
 NTAPI
-KdpSysReadIoSpace(IN ULONG InterfaceType,
-                  IN ULONG BusNumber,
-                  IN ULONG AddressSpace,
-                  IN ULONG64 IoAddress,
-                  IN PVOID DataValue,
-                  IN ULONG DataSize,
-                  OUT PULONG ActualDataSize)
+KdpSysReadIoSpace(
+    _In_ INTERFACE_TYPE InterfaceType,
+    _In_ ULONG BusNumber,
+    _In_ ULONG AddressSpace,
+    _In_ ULONG64 IoAddress,
+    _Out_writes_bytes_(DataSize) PVOID DataValue,
+    _In_ ULONG DataSize,
+    _Out_ PULONG ActualDataSize)
 {
     UNIMPLEMENTED;
     return STATUS_UNSUCCESSFUL;
@@ -119,13 +126,14 @@ KdpSysReadIoSpace(IN ULONG InterfaceType,
 
 NTSTATUS
 NTAPI
-KdpSysWriteIoSpace(IN ULONG InterfaceType,
-                   IN ULONG BusNumber,
-                   IN ULONG AddressSpace,
-                   IN ULONG64 IoAddress,
-                   IN PVOID DataValue,
-                   IN ULONG DataSize,
-                   OUT PULONG ActualDataSize)
+KdpSysWriteIoSpace(
+    _In_ INTERFACE_TYPE InterfaceType,
+    _In_ ULONG BusNumber,
+    _In_ ULONG AddressSpace,
+    _In_ ULONG64 IoAddress,
+    _In_reads_bytes_(DataSize) PVOID DataValue,
+    _In_ ULONG DataSize,
+    _Out_ PULONG ActualDataSize)
 {
     UNIMPLEMENTED;
     return STATUS_UNSUCCESSFUL;

--- a/ntoskrnl/kd64/arm/kdarm.c
+++ b/ntoskrnl/kd64/arm/kdarm.c
@@ -37,7 +37,7 @@ NTSTATUS
 NTAPI
 KdpSysReadMsr(
     _In_ ULONG Msr,
-    _Out_ PLARGE_INTEGER MsrValue)
+    _Out_ PULONGLONG MsrValue)
 {
     UNIMPLEMENTED;
     return STATUS_UNSUCCESSFUL;
@@ -47,7 +47,7 @@ NTSTATUS
 NTAPI
 KdpSysWriteMsr(
     _In_ ULONG Msr,
-    _In_ PLARGE_INTEGER MsrValue)
+    _In_ PULONGLONG MsrValue)
 {
     UNIMPLEMENTED;
     return STATUS_UNSUCCESSFUL;

--- a/ntoskrnl/kd64/i386/kdx86.c
+++ b/ntoskrnl/kd64/i386/kdx86.c
@@ -91,8 +91,9 @@ KdpSetContextState(IN PDBGKD_ANY_WAIT_STATE_CHANGE WaitStateChange,
 
 NTSTATUS
 NTAPI
-KdpSysReadMsr(IN ULONG Msr,
-              OUT PLARGE_INTEGER MsrValue)
+KdpSysReadMsr(
+    _In_ ULONG Msr,
+    _Out_ PLARGE_INTEGER MsrValue)
 {
     /* Wrap this in SEH in case the MSR doesn't exist */
     _SEH2_TRY
@@ -113,8 +114,9 @@ KdpSysReadMsr(IN ULONG Msr,
 
 NTSTATUS
 NTAPI
-KdpSysWriteMsr(IN ULONG Msr,
-               IN PLARGE_INTEGER MsrValue)
+KdpSysWriteMsr(
+    _In_ ULONG Msr,
+    _In_ PLARGE_INTEGER MsrValue)
 {
     /* Wrap this in SEH in case the MSR doesn't exist */
     _SEH2_TRY
@@ -135,13 +137,14 @@ KdpSysWriteMsr(IN ULONG Msr,
 
 NTSTATUS
 NTAPI
-KdpSysReadBusData(IN ULONG BusDataType,
-                  IN ULONG BusNumber,
-                  IN ULONG SlotNumber,
-                  IN ULONG Offset,
-                  IN PVOID Buffer,
-                  IN ULONG Length,
-                  OUT PULONG ActualLength)
+KdpSysReadBusData(
+    _In_ BUS_DATA_TYPE BusDataType,
+    _In_ ULONG BusNumber,
+    _In_ ULONG SlotNumber,
+    _In_ ULONG Offset,
+    _Out_writes_bytes_(Length) PVOID Buffer,
+    _In_ ULONG Length,
+    _Out_ PULONG ActualLength)
 {
     /* Just forward to HAL */
     *ActualLength = HalGetBusDataByOffset(BusDataType,
@@ -157,13 +160,14 @@ KdpSysReadBusData(IN ULONG BusDataType,
 
 NTSTATUS
 NTAPI
-KdpSysWriteBusData(IN ULONG BusDataType,
-                   IN ULONG BusNumber,
-                   IN ULONG SlotNumber,
-                   IN ULONG Offset,
-                   IN PVOID Buffer,
-                   IN ULONG Length,
-                   OUT PULONG ActualLength)
+KdpSysWriteBusData(
+    _In_ BUS_DATA_TYPE BusDataType,
+    _In_ ULONG BusNumber,
+    _In_ ULONG SlotNumber,
+    _In_ ULONG Offset,
+    _In_reads_bytes_(Length) PVOID Buffer,
+    _In_ ULONG Length,
+    _Out_ PULONG ActualLength)
 {
     /* Just forward to HAL */
     *ActualLength = HalSetBusDataByOffset(BusDataType,
@@ -179,11 +183,12 @@ KdpSysWriteBusData(IN ULONG BusDataType,
 
 NTSTATUS
 NTAPI
-KdpSysReadControlSpace(IN ULONG Processor,
-                       IN ULONG64 BaseAddress,
-                       IN PVOID Buffer,
-                       IN ULONG Length,
-                       OUT PULONG ActualLength)
+KdpSysReadControlSpace(
+    _In_ ULONG Processor,
+    _In_ ULONG64 BaseAddress,
+    _Out_writes_bytes_(Length) PVOID Buffer,
+    _In_ ULONG Length,
+    _Out_ PULONG ActualLength)
 {
     PVOID ControlStart;
     ULONG RealLength;
@@ -219,11 +224,12 @@ KdpSysReadControlSpace(IN ULONG Processor,
 
 NTSTATUS
 NTAPI
-KdpSysWriteControlSpace(IN ULONG Processor,
-                        IN ULONG64 BaseAddress,
-                        IN PVOID Buffer,
-                        IN ULONG Length,
-                        OUT PULONG ActualLength)
+KdpSysWriteControlSpace(
+    _In_ ULONG Processor,
+    _In_ ULONG64 BaseAddress,
+    _In_reads_bytes_(Length) PVOID Buffer,
+    _In_ ULONG Length,
+    _Out_ PULONG ActualLength)
 {
     PVOID ControlStart;
 
@@ -254,13 +260,14 @@ KdpSysWriteControlSpace(IN ULONG Processor,
 
 NTSTATUS
 NTAPI
-KdpSysReadIoSpace(IN ULONG InterfaceType,
-                  IN ULONG BusNumber,
-                  IN ULONG AddressSpace,
-                  IN ULONG64 IoAddress,
-                  IN PVOID DataValue,
-                  IN ULONG DataSize,
-                  OUT PULONG ActualDataSize)
+KdpSysReadIoSpace(
+    _In_ INTERFACE_TYPE InterfaceType,
+    _In_ ULONG BusNumber,
+    _In_ ULONG AddressSpace,
+    _In_ ULONG64 IoAddress,
+    _Out_writes_bytes_(DataSize) PVOID DataValue,
+    _In_ ULONG DataSize,
+    _Out_ PULONG ActualDataSize)
 {
     NTSTATUS Status;
 
@@ -335,13 +342,14 @@ KdpSysReadIoSpace(IN ULONG InterfaceType,
 
 NTSTATUS
 NTAPI
-KdpSysWriteIoSpace(IN ULONG InterfaceType,
-                   IN ULONG BusNumber,
-                   IN ULONG AddressSpace,
-                   IN ULONG64 IoAddress,
-                   IN PVOID DataValue,
-                   IN ULONG DataSize,
-                   OUT PULONG ActualDataSize)
+KdpSysWriteIoSpace(
+    _In_ INTERFACE_TYPE InterfaceType,
+    _In_ ULONG BusNumber,
+    _In_ ULONG AddressSpace,
+    _In_ ULONG64 IoAddress,
+    _In_reads_bytes_(DataSize) PVOID DataValue,
+    _In_ ULONG DataSize,
+    _Out_ PULONG ActualDataSize)
 {
     NTSTATUS Status;
 

--- a/ntoskrnl/kd64/kdapi.c
+++ b/ntoskrnl/kd64/kdapi.c
@@ -430,7 +430,8 @@ KdpSetCommonState(IN ULONG NewState,
 
 VOID
 NTAPI
-KdpSysGetVersion(IN PDBGKD_GET_VERSION64 Version)
+KdpSysGetVersion(
+    _Out_ PDBGKD_GET_VERSION64 Version)
 {
     /* Copy the version block */
     KdpMoveMemory(Version,

--- a/ntoskrnl/kd64/kdapi.c
+++ b/ntoskrnl/kd64/kdapi.c
@@ -2222,6 +2222,9 @@ KdSystemDebugControl(
     _Out_opt_ PULONG ReturnLength,
     _In_ KPROCESSOR_MODE PreviousMode)
 {
+    NTSTATUS Status;
+    ULONG Length = 0;
+
     /* Handle some internal commands */
     switch ((ULONG)Command)
     {
@@ -2285,9 +2288,35 @@ KdSystemDebugControl(
             break;
     }
 
-    /* Local kernel debugging is not yet supported */
-    DbgPrint("KdSystemDebugControl is unimplemented!\n");
-    return STATUS_NOT_IMPLEMENTED;
+    switch (Command)
+    {
+        case SysDbgQueryVersion:
+        case SysDbgReadVirtual:
+        case SysDbgWriteVirtual:
+        case SysDbgReadPhysical:
+        case SysDbgWritePhysical:
+        case SysDbgReadControlSpace:
+        case SysDbgWriteControlSpace:
+        case SysDbgReadIoSpace:
+        case SysDbgWriteIoSpace:
+        case SysDbgReadMsr:
+        case SysDbgWriteMsr:
+        case SysDbgReadBusData:
+        case SysDbgWriteBusData:
+        case SysDbgCheckLowMemory:
+            UNIMPLEMENTED;
+            Status = STATUS_NOT_IMPLEMENTED;
+            break;
+
+        default:
+            Status = STATUS_INVALID_INFO_CLASS;
+            break;
+    }
+
+    if (ReturnLength)
+        *ReturnLength = Length;
+
+    return Status;
 }
 
 /*

--- a/ntoskrnl/kd64/kdapi.c
+++ b/ntoskrnl/kd64/kdapi.c
@@ -1952,7 +1952,8 @@ KdExitDebugger(IN BOOLEAN Enable)
 {
     ULONG TimeSlip;
 
-    /* Restore the state and unlock the port */
+    /* Reset the debugger entered flag, restore the port state and unlock it */
+    KdEnteredDebugger = FALSE;
     KdRestore(FALSE);
     if (KdpPortLocked) KdpPortUnlock();
 

--- a/ntoskrnl/kd64/kdapi.c
+++ b/ntoskrnl/kd64/kdapi.c
@@ -2178,11 +2178,11 @@ NTSTATUS
 NTAPI
 KdSystemDebugControl(
     _In_ SYSDBG_COMMAND Command,
-    _In_ PVOID InputBuffer,
+    _In_reads_bytes_(InputBufferLength) PVOID InputBuffer,
     _In_ ULONG InputBufferLength,
-    _Out_ PVOID OutputBuffer,
+    _Out_writes_bytes_(OutputBufferLength) PVOID OutputBuffer,
     _In_ ULONG OutputBufferLength,
-    _Inout_ PULONG ReturnLength,
+    _Out_opt_ PULONG ReturnLength,
     _In_ KPROCESSOR_MODE PreviousMode)
 {
     /* Handle some internal commands */

--- a/ntoskrnl/kd64/kdapi.c
+++ b/ntoskrnl/kd64/kdapi.c
@@ -2304,6 +2304,35 @@ KdSystemDebugControl(
 
         case SysDbgReadVirtual:
         case SysDbgWriteVirtual:
+            if (InputBufferLength != sizeof(SYSDBG_VIRTUAL))
+            {
+                Status = STATUS_INFO_LENGTH_MISMATCH;
+            }
+            else
+            {
+                SYSDBG_VIRTUAL Request = *(PSYSDBG_VIRTUAL)InputBuffer;
+                PVOID LockedBuffer;
+                PMDL LockVariable;
+
+                Status = ExLockUserBuffer(Request.Buffer,
+                                          Request.Request,
+                                          PreviousMode,
+                                          Command == SysDbgReadVirtual ? IoWriteAccess : IoReadAccess,
+                                          &LockedBuffer,
+                                          &LockVariable);
+                if (NT_SUCCESS(Status))
+                {
+                    Status = KdpCopyMemoryChunks((ULONG64)(ULONG_PTR)Request.Address,
+                                                 Request.Buffer,
+                                                 Request.Request,
+                                                 0,
+                                                 Command == SysDbgReadVirtual ? 0 : MMDBG_COPY_WRITE,
+                                                 &Length);
+                    ExUnlockUserBuffer(LockVariable);
+                }
+            }
+            break;
+
         case SysDbgReadPhysical:
         case SysDbgWritePhysical:
         case SysDbgReadControlSpace:

--- a/ntoskrnl/kd64/kdapi.c
+++ b/ntoskrnl/kd64/kdapi.c
@@ -2365,7 +2365,63 @@ KdSystemDebugControl(
             break;
 
         case SysDbgReadControlSpace:
+            if (InputBufferLength != sizeof(SYSDBG_CONTROL_SPACE))
+            {
+                Status = STATUS_INFO_LENGTH_MISMATCH;
+            }
+            else
+            {
+                SYSDBG_CONTROL_SPACE Request = *(PSYSDBG_CONTROL_SPACE)InputBuffer;
+                PVOID LockedBuffer;
+                PMDL LockVariable;
+
+                Status = ExLockUserBuffer(Request.Buffer,
+                                          Request.Request,
+                                          PreviousMode,
+                                          IoWriteAccess,
+                                          &LockedBuffer,
+                                          &LockVariable);
+                if (NT_SUCCESS(Status))
+                {
+                    Status = KdpSysReadControlSpace(Request.Processor,
+                                                    Request.Address,
+                                                    LockedBuffer,
+                                                    Request.Request,
+                                                    &Length);
+                    ExUnlockUserBuffer(LockVariable);
+                }
+            }
+            break;
+
         case SysDbgWriteControlSpace:
+            if (InputBufferLength != sizeof(SYSDBG_CONTROL_SPACE))
+            {
+                Status = STATUS_INFO_LENGTH_MISMATCH;
+            }
+            else
+            {
+                SYSDBG_CONTROL_SPACE Request = *(PSYSDBG_CONTROL_SPACE)InputBuffer;
+                PVOID LockedBuffer;
+                PMDL LockVariable;
+
+                Status = ExLockUserBuffer(Request.Buffer,
+                                          Request.Request,
+                                          PreviousMode,
+                                          IoReadAccess,
+                                          &LockedBuffer,
+                                          &LockVariable);
+                if (NT_SUCCESS(Status))
+                {
+                    Status = KdpSysWriteControlSpace(Request.Processor,
+                                                     Request.Address,
+                                                     LockedBuffer,
+                                                     Request.Request,
+                                                     &Length);
+                    ExUnlockUserBuffer(LockVariable);
+                }
+            }
+            break;
+
         case SysDbgReadIoSpace:
         case SysDbgWriteIoSpace:
         case SysDbgReadMsr:

--- a/ntoskrnl/kd64/kdapi.c
+++ b/ntoskrnl/kd64/kdapi.c
@@ -2291,6 +2291,17 @@ KdSystemDebugControl(
     switch (Command)
     {
         case SysDbgQueryVersion:
+            if (OutputBufferLength != sizeof(DBGKD_GET_VERSION64))
+            {
+                Status = STATUS_INFO_LENGTH_MISMATCH;
+            }
+            else
+            {
+                KdpSysGetVersion((PDBGKD_GET_VERSION64)OutputBuffer);
+                Status = STATUS_SUCCESS;
+            }
+            break;
+
         case SysDbgReadVirtual:
         case SysDbgWriteVirtual:
         case SysDbgReadPhysical:

--- a/ntoskrnl/kd64/kdapi.c
+++ b/ntoskrnl/kd64/kdapi.c
@@ -2571,8 +2571,7 @@ KdSystemDebugControl(
             break;
 
         case SysDbgCheckLowMemory:
-            UNIMPLEMENTED;
-            Status = STATUS_NOT_IMPLEMENTED;
+            Status = KdpSysCheckLowMemory(0);
             break;
 
         default:

--- a/ntoskrnl/kd64/kdapi.c
+++ b/ntoskrnl/kd64/kdapi.c
@@ -2423,7 +2423,67 @@ KdSystemDebugControl(
             break;
 
         case SysDbgReadIoSpace:
+            if (InputBufferLength != sizeof(SYSDBG_IO_SPACE))
+            {
+                Status = STATUS_INFO_LENGTH_MISMATCH;
+            }
+            else
+            {
+                SYSDBG_IO_SPACE Request = *(PSYSDBG_IO_SPACE)InputBuffer;
+                PVOID LockedBuffer;
+                PMDL LockVariable;
+
+                Status = ExLockUserBuffer(Request.Buffer,
+                                          Request.Request,
+                                          PreviousMode,
+                                          IoWriteAccess,
+                                          &LockedBuffer,
+                                          &LockVariable);
+                if (NT_SUCCESS(Status))
+                {
+                    Status = KdpSysReadIoSpace(Request.InterfaceType,
+                                               Request.BusNumber,
+                                               Request.AddressSpace,
+                                               Request.Address,
+                                               LockedBuffer,
+                                               Request.Request,
+                                               &Length);
+                    ExUnlockUserBuffer(LockVariable);
+                }
+            }
+            break;
+
         case SysDbgWriteIoSpace:
+            if (InputBufferLength != sizeof(SYSDBG_IO_SPACE))
+            {
+                Status = STATUS_INFO_LENGTH_MISMATCH;
+            }
+            else
+            {
+                SYSDBG_IO_SPACE Request = *(PSYSDBG_IO_SPACE)InputBuffer;
+                PVOID LockedBuffer;
+                PMDL LockVariable;
+
+                Status = ExLockUserBuffer(Request.Buffer,
+                                          Request.Request,
+                                          PreviousMode,
+                                          IoReadAccess,
+                                          &LockedBuffer,
+                                          &LockVariable);
+                if (NT_SUCCESS(Status))
+                {
+                    Status = KdpSysWriteIoSpace(Request.InterfaceType,
+                                                Request.BusNumber,
+                                                Request.AddressSpace,
+                                                Request.Address,
+                                                LockedBuffer,
+                                                Request.Request,
+                                                &Length);
+                    ExUnlockUserBuffer(LockVariable);
+                }
+            }
+            break;
+
         case SysDbgReadMsr:
         case SysDbgWriteMsr:
         case SysDbgReadBusData:

--- a/ntoskrnl/kd64/kdapi.c
+++ b/ntoskrnl/kd64/kdapi.c
@@ -2485,7 +2485,29 @@ KdSystemDebugControl(
             break;
 
         case SysDbgReadMsr:
+            if (InputBufferLength != sizeof(SYSDBG_MSR))
+            {
+                Status = STATUS_INFO_LENGTH_MISMATCH;
+            }
+            else
+            {
+                PSYSDBG_MSR Request = (PSYSDBG_MSR)InputBuffer;
+                Status = KdpSysReadMsr(Request->Address, &Request->Data);
+            }
+            break;
+
         case SysDbgWriteMsr:
+            if (InputBufferLength != sizeof(SYSDBG_MSR))
+            {
+                Status = STATUS_INFO_LENGTH_MISMATCH;
+            }
+            else
+            {
+                PSYSDBG_MSR Request = (PSYSDBG_MSR)InputBuffer;
+                Status = KdpSysWriteMsr(Request->Address, &Request->Data);
+            }
+            break;
+
         case SysDbgReadBusData:
         case SysDbgWriteBusData:
         case SysDbgCheckLowMemory:

--- a/ntoskrnl/kd64/kdapi.c
+++ b/ntoskrnl/kd64/kdapi.c
@@ -2171,9 +2171,46 @@ KdDisableDebugger(VOID)
     return KdDisableDebuggerWithLock(TRUE);
 }
 
-/*
- * @unimplemented
- */
+/**
+ * @brief
+ * Perform various queries to the kernel debugger.
+ *
+ * @param[in]   Command
+ * A SYSDBG_COMMAND value describing the kernel debugger command to perform.
+ *
+ * @param[in]   InputBuffer
+ * Pointer to a user-provided input command-specific buffer, whose length
+ * is given by InputBufferLength.
+ *
+ * @param[in]   InputBufferLength
+ * The size (in bytes) of the buffer pointed by InputBuffer.
+ *
+ * @param[out]  OutputBuffer
+ * Pointer to a user-provided command-specific output buffer, whose length
+ * is given by OutputBufferLength.
+ *
+ * @param[in]   OutputBufferLength
+ * The size (in bytes) of the buffer pointed by OutputBuffer.
+ *
+ * @param[out]  ReturnLength
+ * Optional pointer to a ULONG variable that receives the actual length of
+ * data written written in the output buffer. It is always zero, except for
+ * the live dump commands where an actual non-zero length is returned.
+ *
+ * @param[in]   PreviousMode
+ * The processor mode (KernelMode or UserMode) in which the command is being executed.
+ *
+ * @return
+ * STATUS_SUCCESS in case of success, or a proper error code otherwise.
+ *
+ * @remarks
+ * - This is a kernel-mode function, accessible only by kernel-mode drivers.
+ *
+ * @note
+ * See: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2004-2339
+ *
+ * @see NtSystemDebugControl()
+ **/
 NTSTATUS
 NTAPI
 KdSystemDebugControl(

--- a/ntoskrnl/kd64/kdapi.c
+++ b/ntoskrnl/kd64/kdapi.c
@@ -2335,6 +2335,35 @@ KdSystemDebugControl(
 
         case SysDbgReadPhysical:
         case SysDbgWritePhysical:
+            if (InputBufferLength != sizeof(SYSDBG_PHYSICAL))
+            {
+                Status = STATUS_INFO_LENGTH_MISMATCH;
+            }
+            else
+            {
+                SYSDBG_PHYSICAL Request = *(PSYSDBG_PHYSICAL)InputBuffer;
+                PVOID LockedBuffer;
+                PMDL LockVariable;
+
+                Status = ExLockUserBuffer(Request.Buffer,
+                                          Request.Request,
+                                          PreviousMode,
+                                          Command == SysDbgReadVirtual ? IoWriteAccess : IoReadAccess,
+                                          &LockedBuffer,
+                                          &LockVariable);
+                if (NT_SUCCESS(Status))
+                {
+                    Status = KdpCopyMemoryChunks(Request.Address.QuadPart,
+                                                 Request.Buffer,
+                                                 Request.Request,
+                                                 0,
+                                                 MMDBG_COPY_PHYSICAL | (Command == SysDbgReadVirtual ? 0 : MMDBG_COPY_WRITE),
+                                                 &Length);
+                    ExUnlockUserBuffer(LockVariable);
+                }
+            }
+            break;
+
         case SysDbgReadControlSpace:
         case SysDbgWriteControlSpace:
         case SysDbgReadIoSpace:

--- a/ntoskrnl/kd64/kdapi.c
+++ b/ntoskrnl/kd64/kdapi.c
@@ -2509,7 +2509,67 @@ KdSystemDebugControl(
             break;
 
         case SysDbgReadBusData:
+            if (InputBufferLength != sizeof(SYSDBG_BUS_DATA))
+            {
+                Status = STATUS_INFO_LENGTH_MISMATCH;
+            }
+            else
+            {
+                SYSDBG_BUS_DATA Request = *(PSYSDBG_BUS_DATA)InputBuffer;
+                PVOID LockedBuffer;
+                PMDL LockVariable;
+
+                Status = ExLockUserBuffer(Request.Buffer,
+                                          Request.Request,
+                                          PreviousMode,
+                                          IoWriteAccess,
+                                          &LockedBuffer,
+                                          &LockVariable);
+                if (NT_SUCCESS(Status))
+                {
+                    Status = KdpSysReadBusData(Request.BusDataType,
+                                               Request.BusNumber,
+                                               Request.SlotNumber,
+                                               Request.Address,
+                                               LockedBuffer,
+                                               Request.Request,
+                                               &Length);
+                    ExUnlockUserBuffer(LockVariable);
+                }
+            }
+            break;
+
         case SysDbgWriteBusData:
+            if (InputBufferLength != sizeof(SYSDBG_BUS_DATA))
+            {
+                Status = STATUS_INFO_LENGTH_MISMATCH;
+            }
+            else
+            {
+                SYSDBG_BUS_DATA Request = *(PSYSDBG_BUS_DATA)InputBuffer;
+                PVOID LockedBuffer;
+                PMDL LockVariable;
+
+                Status = ExLockUserBuffer(Request.Buffer,
+                                          Request.Request,
+                                          PreviousMode,
+                                          IoReadAccess,
+                                          &LockedBuffer,
+                                          &LockVariable);
+                if (NT_SUCCESS(Status))
+                {
+                    Status = KdpSysWriteBusData(Request.BusDataType,
+                                                Request.BusNumber,
+                                                Request.SlotNumber,
+                                                Request.Address,
+                                                LockedBuffer,
+                                                Request.Request,
+                                                &Length);
+                    ExUnlockUserBuffer(LockVariable);
+                }
+            }
+            break;
+
         case SysDbgCheckLowMemory:
             UNIMPLEMENTED;
             Status = STATUS_NOT_IMPLEMENTED;

--- a/ntoskrnl/kd64/kdtrap.c
+++ b/ntoskrnl/kd64/kdtrap.c
@@ -318,7 +318,6 @@ KdIsThisAKdTrap(IN PEXCEPTION_RECORD ExceptionRecord,
                 IN PCONTEXT Context,
                 IN KPROCESSOR_MODE PreviousMode)
 {
-#ifdef _WINKD_
     /*
      * Determine if this is a valid debug service call and make sure that
      * it isn't a software breakpoint
@@ -335,8 +334,4 @@ KdIsThisAKdTrap(IN PEXCEPTION_RECORD ExceptionRecord,
         /* We don't have to handle it */
         return FALSE;
     }
-#else
-    /* KDBG has its own mechanism for ignoring user mode exceptions */
-    return FALSE;
-#endif
 }

--- a/ntoskrnl/mm/ARM3/mmdbg.c
+++ b/ntoskrnl/mm/ARM3/mmdbg.c
@@ -132,7 +132,15 @@ MmDbgCopyMemory(IN ULONG64 Address,
     PVOID CopyDestination, CopySource;
 
     /* No local kernel debugging support yet, so don't worry about locking */
-    ASSERT(Flags & MMDBG_COPY_UNSAFE);
+    if (!(Flags & MMDBG_COPY_UNSAFE))
+    {
+        static BOOLEAN Warned = FALSE;
+        if (!Warned)
+        {
+            KdpDprintf("MmDbgCopyMemory: not providing MMDBG_COPY_UNSAFE is UNIMPLEMENTED\n");
+            Warned = TRUE;
+        }
+    }
 
     /* We only handle 1, 2, 4 and 8 byte requests */
     if ((Size != 1) &&

--- a/sdk/include/ndk/kdfuncs.h
+++ b/sdk/include/ndk/kdfuncs.h
@@ -34,11 +34,11 @@ NTSTATUS
 NTAPI
 KdSystemDebugControl(
     _In_ SYSDBG_COMMAND Command,
-    _In_ PVOID InputBuffer,
+    _In_reads_bytes_(InputBufferLength) PVOID InputBuffer,
     _In_ ULONG InputBufferLength,
-    _Out_ PVOID OutputBuffer,
+    _Out_writes_bytes_(OutputBufferLength) PVOID OutputBuffer,
     _In_ ULONG OutputBufferLength,
-    _Inout_ PULONG ReturnLength,
+    _Out_opt_ PULONG ReturnLength,
     _In_ KPROCESSOR_MODE PreviousMode
 );
 
@@ -74,12 +74,12 @@ NTSYSCALLAPI
 NTSTATUS
 NTAPI
 NtSystemDebugControl(
-    SYSDBG_COMMAND ControlCode,
-    PVOID InputBuffer,
-    ULONG InputBufferLength,
-    PVOID OutputBuffer,
-    ULONG OutputBufferLength,
-    PULONG ReturnLength
+    _In_ SYSDBG_COMMAND Command,
+    _In_reads_bytes_(InputBufferLength) PVOID InputBuffer,
+    _In_ ULONG InputBufferLength,
+    _Out_writes_bytes_(OutputBufferLength) PVOID OutputBuffer,
+    _In_ ULONG OutputBufferLength,
+    _Out_opt_ PULONG ReturnLength
 );
 
 NTSYSAPI
@@ -103,11 +103,11 @@ NTSYSAPI
 NTSTATUS
 NTAPI
 ZwSystemDebugControl(
-    SYSDBG_COMMAND ControlCode,
-    PVOID InputBuffer,
-    ULONG InputBufferLength,
-    PVOID OutputBuffer,
-    ULONG OutputBufferLength,
-    PULONG ReturnLength
+    _In_ SYSDBG_COMMAND Command,
+    _In_reads_bytes_(InputBufferLength) PVOID InputBuffer,
+    _In_ ULONG InputBufferLength,
+    _Out_writes_bytes_(OutputBufferLength) PVOID OutputBuffer,
+    _In_ ULONG OutputBufferLength,
+    _Out_opt_ PULONG ReturnLength
 );
 #endif

--- a/sdk/include/ndk/kdtypes.h
+++ b/sdk/include/ndk/kdtypes.h
@@ -101,6 +101,9 @@ typedef enum _SYSDBG_COMMAND
 #if (NTDDI_VERSION >= NTDDI_WINBLUE) // NTDDI_WIN81
     SysDbgGetLiveKernelDump = 37,
 #endif
+#if (NTDDI_VERSION >= NTDDI_WIN10_VB)
+    SysDbgKdPullRemoteFile = 38,
+#endif
 } SYSDBG_COMMAND;
 
 //
@@ -247,6 +250,15 @@ typedef struct _SYSDBG_LIVEDUMP_CONTROL
 } SYSDBG_LIVEDUMP_CONTROL, *PSYSDBG_LIVEDUMP_CONTROL;
 
 #endif // (NTDDI_VERSION >= NTDDI_WINBLUE)
+
+#if (NTDDI_VERSION >= NTDDI_WIN10_VB)
+
+typedef struct _SYSDBG_KD_PULL_REMOTE_FILE
+{
+    UNICODE_STRING ImageFileName;
+} SYSDBG_KD_PULL_REMOTE_FILE, *PSYSDBG_KD_PULL_REMOTE_FILE;
+
+#endif
 
 //
 // KD Structures

--- a/sdk/include/ndk/kdtypes.h
+++ b/sdk/include/ndk/kdtypes.h
@@ -91,11 +91,13 @@ typedef enum _SYSDBG_COMMAND
     SysDbgGetTriageDump = 29,
     SysDbgGetKdBlockEnable = 30,
     SysDbgSetKdBlockEnable = 31,
+#if (NTDDI_VERSION >= NTDDI_VISTA)
     SysDbgRegisterForUmBreakInfo = 32,
     SysDbgGetUmBreakPid = 33,
     SysDbgClearUmBreakPid = 34,
     SysDbgGetUmAttachPid = 35,
     SysDbgClearUmAttachPid = 36,
+#endif
 } SYSDBG_COMMAND;
 
 //

--- a/sdk/include/ndk/kdtypes.h
+++ b/sdk/include/ndk/kdtypes.h
@@ -98,6 +98,9 @@ typedef enum _SYSDBG_COMMAND
     SysDbgGetUmAttachPid = 35,
     SysDbgClearUmAttachPid = 36,
 #endif
+#if (NTDDI_VERSION >= NTDDI_WINBLUE) // NTDDI_WIN81
+    SysDbgGetLiveKernelDump = 37,
+#endif
 } SYSDBG_COMMAND;
 
 //
@@ -163,6 +166,87 @@ typedef struct _SYSDBG_TRIAGE_DUMP
     ULONG ThreadHandles;
     PHANDLE Handles;
 } SYSDBG_TRIAGE_DUMP, *PSYSDBG_TRIAGE_DUMP;
+
+#if (NTDDI_VERSION >= NTDDI_WINBLUE) // NTDDI_WIN81
+
+typedef union _SYSDBG_LIVEDUMP_CONTROL_FLAGS
+{
+    struct
+    {
+        ULONG UseDumpStorageStack : 1;
+        ULONG CompressMemoryPagesData : 1;
+        ULONG IncludeUserSpaceMemoryPages : 1;
+#if (NTDDI_VERSION >= NTDDI_WIN10_RS4)
+        ULONG AbortIfMemoryPressure : 1;
+#if (NTDDI_VERSION >= NTDDI_WIN11)
+        ULONG SelectiveDump : 1;
+        ULONG Reserved : 27;
+#else
+        ULONG Reserved : 28;
+#endif // (NTDDI_VERSION >= NTDDI_WIN11)
+#else
+        ULONG Reserved : 29;
+#endif // (NTDDI_VERSION >= NTDDI_WIN10_RS4)
+    };
+    ULONG AsUlong;
+} SYSDBG_LIVEDUMP_CONTROL_FLAGS;
+
+typedef union _SYSDBG_LIVEDUMP_CONTROL_ADDPAGES
+{
+    struct
+    {
+        ULONG HypervisorPages : 1;
+#if (NTDDI_VERSION >= NTDDI_WIN11)
+        ULONG NonEssentialHypervisorPages : 1;
+        ULONG Reserved : 30;
+#else
+        ULONG Reserved : 31;
+#endif
+    };
+    ULONG AsUlong;
+} SYSDBG_LIVEDUMP_CONTROL_ADDPAGES;
+
+#if (NTDDI_VERSION >= NTDDI_WIN11)
+
+typedef struct _SYSDBG_LIVEDUMP_SELECTIVE_CONTROL
+{
+    ULONG Version;
+    ULONG Size;
+    union
+    {
+        ULONGLONG Flags;
+        struct
+        {
+            ULONGLONG ThreadKernelStacks : 1;
+            ULONGLONG ReservedFlags : 63;
+        };
+    };
+    ULONGLONG Reserved[4];
+} SYSDBG_LIVEDUMP_SELECTIVE_CONTROL, *PSYSDBG_LIVEDUMP_SELECTIVE_CONTROL;
+
+#define SYSDBG_LIVEDUMP_CONTROL_VERSION         1
+#define SYSDBG_LIVEDUMP_CONTROL_VERSION_WIN11   2
+
+#endif // (NTDDI_VERSION >= NTDDI_WIN11)
+
+typedef struct _SYSDBG_LIVEDUMP_CONTROL
+{
+    ULONG Version;
+    ULONG BugCheckCode;
+    ULONG_PTR BugCheckParam1;
+    ULONG_PTR BugCheckParam2;
+    ULONG_PTR BugCheckParam3;
+    ULONG_PTR BugCheckParam4;
+    PVOID DumpFileHandle;
+    PVOID CancelEventHandle;
+    SYSDBG_LIVEDUMP_CONTROL_FLAGS Flags;
+    SYSDBG_LIVEDUMP_CONTROL_ADDPAGES AddPagesControl;
+#if (NTDDI_VERSION >= NTDDI_WIN11)
+    PSYSDBG_LIVEDUMP_SELECTIVE_CONTROL SelectiveControl;
+#endif
+} SYSDBG_LIVEDUMP_CONTROL, *PSYSDBG_LIVEDUMP_CONTROL;
+
+#endif // (NTDDI_VERSION >= NTDDI_WINBLUE)
 
 //
 // KD Structures


### PR DESCRIPTION
## Purpose

The KdSystemDebugControl and NtSystemDebugControl routines are used by WinDbg to implement local kernel debugging.
KMTests for these routines can be found in PR #7424.

The vast majority of the implementation has been done by @hpoussin .

## Proposed changes

The commits titles tell what the proposed changes are.

## TODO

- [x] Run these on our build/testbots once our infra is back online. -- _**See results at https://github.com/reactos/reactos/pull/7424#issue-2564885102**_
- [x] Test with WinDbg itself. So far, these routines have been tested with the `kdbgctrl.exe` tool. -- Works with WinDbg, see the video in my comment down below.
