### PR TITLE
[SHELL32] No new menu and working properties in Drives and NetHood background menu

### DIFF
--- a/dll/win32/shell32/folders/CDrivesFolder.cpp
+++ b/dll/win32/shell32/folders/CDrivesFolder.cpp
@@ -915,20 +915,7 @@ HRESULT WINAPI CDrivesFolder::CreateViewObject(HWND hwndOwner, REFIID riid, LPVO
     }
     else if (IsEqualIID(riid, IID_IContextMenu))
     {
-        HKEY hKeys[16];
-        UINT cKeys = 0;
-        AddClassKeyToArray(L"Directory\\Background", hKeys, &cKeys);
-
-        DEFCONTEXTMENU dcm;
-        dcm.hwnd = hwndOwner;
-        dcm.pcmcb = this;
-        dcm.pidlFolder = pidlRoot;
-        dcm.psf = this;
-        dcm.cidl = 0;
-        dcm.apidl = NULL;
-        dcm.cKeys = cKeys;
-        dcm.aKeys = hKeys;
-        dcm.punkAssociationInfo = NULL;
+        DEFCONTEXTMENU dcm = { hwndOwner, this, pidlRoot, this };
         hr = SHCreateDefaultContextMenu(&dcm, riid, ppvOut);
     }
     else if (IsEqualIID(riid, IID_IShellView))
@@ -1364,7 +1351,7 @@ HRESULT WINAPI CDrivesFolder::CallBack(IShellFolder *psf, HWND hwndOwner, IDataO
             // "System" properties
             return SHELL_ExecuteControlPanelCPL(hwndOwner, L"sysdm.cpl") ? S_OK : E_FAIL;
         }
-        else if (uMsg == DFM_MERGECONTEXTMENU)
+        else if (uMsg == DFM_MERGECONTEXTMENU) // TODO: DFM_MERGECONTEXTMENU_BOTTOM
         {
             QCMINFO *pqcminfo = (QCMINFO *)lParam;
             HMENU hpopup = CreatePopupMenu();

--- a/dll/win32/shell32/folders/CNetFolder.h
+++ b/dll/win32/shell32/folders/CNetFolder.h
@@ -28,7 +28,8 @@ class CNetFolder :
     public CComCoClass<CNetFolder, &CLSID_NetworkPlaces>,
     public CComObjectRootEx<CComMultiThreadModelNoCS>,
     public IShellFolder2,
-    public IPersistFolder2
+    public IPersistFolder2,
+    public IContextMenuCB
 {
     private:
         /* both paths are parsible from the desktop */
@@ -67,6 +68,9 @@ class CNetFolder :
         // IPersistFolder2
         STDMETHOD(GetCurFolder)(PIDLIST_ABSOLUTE * pidl) override;
 
+        // IContextMenuCB
+        STDMETHOD(CallBack)(IShellFolder *psf, HWND hwndOwner, IDataObject *pdtobj, UINT uMsg, WPARAM wParam, LPARAM lParam) override;
+
         DECLARE_REGISTRY_RESOURCEID(IDR_NETWORKPLACES)
         DECLARE_NOT_AGGREGATABLE(CNetFolder)
 
@@ -78,6 +82,7 @@ class CNetFolder :
         COM_INTERFACE_ENTRY_IID(IID_IPersistFolder, IPersistFolder)
         COM_INTERFACE_ENTRY_IID(IID_IPersistFolder2, IPersistFolder2)
         COM_INTERFACE_ENTRY_IID(IID_IPersist, IPersist)
+        COM_INTERFACE_ENTRY_IID(IID_IContextMenuCB, IContextMenuCB)
         END_COM_MAP()
 };
 

--- a/dll/win32/shell32/folders/CNetFolder.h
+++ b/dll/win32/shell32/folders/CNetFolder.h
@@ -28,8 +28,7 @@ class CNetFolder :
     public CComCoClass<CNetFolder, &CLSID_NetworkPlaces>,
     public CComObjectRootEx<CComMultiThreadModelNoCS>,
     public IShellFolder2,
-    public IPersistFolder2,
-    public IContextMenuCB
+    public IPersistFolder2
 {
     private:
         /* both paths are parsible from the desktop */
@@ -68,9 +67,6 @@ class CNetFolder :
         // IPersistFolder2
         STDMETHOD(GetCurFolder)(PIDLIST_ABSOLUTE * pidl) override;
 
-        // IContextMenuCB
-        STDMETHOD(CallBack)(IShellFolder *psf, HWND hwndOwner, IDataObject *pdtobj, UINT uMsg, WPARAM wParam, LPARAM lParam) override;
-
         DECLARE_REGISTRY_RESOURCEID(IDR_NETWORKPLACES)
         DECLARE_NOT_AGGREGATABLE(CNetFolder)
 
@@ -82,7 +78,6 @@ class CNetFolder :
         COM_INTERFACE_ENTRY_IID(IID_IPersistFolder, IPersistFolder)
         COM_INTERFACE_ENTRY_IID(IID_IPersistFolder2, IPersistFolder2)
         COM_INTERFACE_ENTRY_IID(IID_IPersist, IPersist)
-        COM_INTERFACE_ENTRY_IID(IID_IContextMenuCB, IContextMenuCB)
         END_COM_MAP()
 };
 


### PR DESCRIPTION
- Don't add a class to the My Computer context menu so the "New" item is not added (not a filesystem folder, cannot create new items here).
- Add Properties item to My Network Places context menu.