### PR TITLE
[SHELL32] Implement SSF_NOCONFIRMRECYCLE recycler setting

### DIFF
--- a/dll/win32/shell32/dialogs/recycler_prop.cpp
+++ b/dll/win32/shell32/dialogs/recycler_prop.cpp
@@ -290,6 +290,7 @@ RecycleBinDlg(
         case WM_INITDIALOG:
             page = (PROPSHEETPAGE*)lParam;
             InitializeRecycleBinDlg(hwndDlg, (WCHAR)page->lParam);
+            SendDlgItemMessage(hwndDlg, 14004, BM_SETCHECK, !SHELL_GetSetting(SSF_NOCONFIRMRECYCLE, fNoConfirmRecycle), 0);
             dwStyle = (DWORD) SendDlgItemMessage(hwndDlg, 14000, LVM_GETEXTENDEDLISTVIEWSTYLE, 0, 0);
             dwStyle = dwStyle | LVS_EX_FULLROWSELECT;
             SendDlgItemMessage(hwndDlg, 14000, LVM_SETEXTENDEDLISTVIEWSTYLE, 0, dwStyle);
@@ -324,6 +325,10 @@ RecycleBinDlg(
             lppl = (LPNMLISTVIEW) lParam;
             if (lppsn->hdr.code == PSN_APPLY)
             {
+                SHELLSTATE ss;
+                ss.fNoConfirmRecycle = SendDlgItemMessage(hwndDlg, 14004, BM_GETCHECK, 0, 0) == BST_UNCHECKED;
+                SHGetSetSettings(&ss, SSF_NOCONFIRMRECYCLE, TRUE);
+
                 if (GetDefaultItem(hwndDlg, &li) > -1)
                 {
                     pItem = (PDRIVE_ITEM_CONTEXT)li.lParam;

--- a/dll/win32/shell32/shlfileop.cpp
+++ b/dll/win32/shell32/shlfileop.cpp
@@ -1596,7 +1596,10 @@ static HRESULT delete_files(FILE_OPERATION *op, const FILE_LIST *flFrom)
     bTrash = (op->req->fFlags & FOF_ALLOWUNDO)
         && TRASH_CanTrashFile(flFrom->feFiles[0].szFullPath);
 
-    if (!(op->req->fFlags & FOF_NOCONFIRMATION) || (!bTrash && op->req->fFlags & FOF_WANTNUKEWARNING))
+    BOOL confirm = !(op->req->fFlags & FOF_NOCONFIRMATION);
+    if (bTrash && SHELL_GetSetting(SSF_NOCONFIRMRECYCLE, fNoConfirmRecycle))
+        confirm = FALSE;
+    if (confirm || (!bTrash && op->req->fFlags & FOF_WANTNUKEWARNING))
         if (!confirm_delete_list(op->req->hwnd, op->req->fFlags, bTrash, flFrom))
         {
             op->req->fAnyOperationsAborted = TRUE;


### PR DESCRIPTION
Allow the user to disable the delete confirmation dialog (in recycle bin properties) when files are deleted to the recycle bin.