### PR TITLE
[SHELL32] Don't display .zip files in BrowseForFolder

### DIFF
--- a/dll/win32/shell32/brfolder.cpp
+++ b/dll/win32/shell32/brfolder.cpp
@@ -343,6 +343,13 @@ BrFolder_InsertItem(
     _In_ PCIDLIST_ABSOLUTE pidlParent,
     _In_ HTREEITEM hParent)
 {
+    if (!(BrowseFlagsToSHCONTF(info->lpBrowseInfo->ulFlags) & SHCONTF_NONFOLDERS))
+#ifdef BIF_BROWSEFILEJUNCTIONS
+        if (!(info->lpBrowseInfo->ulFlags & BIF_BROWSEFILEJUNCTIONS))
+#endif
+            if (SHGetAttributes(lpsf, pidlChild, SFGAO_STREAM) & SFGAO_STREAM)
+                return NULL; // .zip files have both FOLDER and STREAM attributes set
+
     WCHAR szName[MAX_PATH];
     if (!BrFolder_GetName(lpsf, pidlChild, SHGDN_NORMAL, szName))
         return NULL;

--- a/dll/win32/shell32/brfolder.cpp
+++ b/dll/win32/shell32/brfolder.cpp
@@ -344,11 +344,13 @@ BrFolder_InsertItem(
     _In_ HTREEITEM hParent)
 {
     if (!(BrowseFlagsToSHCONTF(info->lpBrowseInfo->ulFlags) & SHCONTF_NONFOLDERS))
+    {
 #ifdef BIF_BROWSEFILEJUNCTIONS
         if (!(info->lpBrowseInfo->ulFlags & BIF_BROWSEFILEJUNCTIONS))
 #endif
             if (SHGetAttributes(lpsf, pidlChild, SFGAO_STREAM) & SFGAO_STREAM)
                 return NULL; // .zip files have both FOLDER and STREAM attributes set
+    }
 
     WCHAR szName[MAX_PATH];
     if (!BrFolder_GetName(lpsf, pidlChild, SHGDN_NORMAL, szName))

--- a/dll/win32/shell32/folders/CFSFolder.cpp
+++ b/dll/win32/shell32/folders/CFSFolder.cpp
@@ -624,6 +624,7 @@ HRESULT SHELL32_GetFSItemAttributes(IShellFolder * psf, LPCITEMIDLIST pidl, LPDW
         WCHAR szFileName[MAX_PATH];
         LPWSTR pExtension;
         BOOL hasName = _ILSimpleGetTextW(pidl, szFileName, _countof(szFileName));
+        dwShellAttributes |= SFGAO_STREAM;
 
         // Vista+ feature: Hidden files with a leading tilde treated as super-hidden
         // See https://devblogs.microsoft.com/oldnewthing/20170526-00/?p=96235
@@ -671,10 +672,6 @@ HRESULT SHELL32_GetFSItemAttributes(IShellFolder * psf, LPCITEMIDLIST pidl, LPDW
         {
             dwShellAttributes |= (SFGAO_FILESYSANCESTOR | SFGAO_STORAGEANCESTOR);
         }
-    }
-    else
-    {
-        dwShellAttributes |= SFGAO_STREAM;
     }
 
     if (dwFileAttributes & FILE_ATTRIBUTE_HIDDEN)


### PR DESCRIPTION

JIRA issue: [CORE-19751](https://jira.reactos.org/browse/CORE-19751)

Notes:
- This changes how SFGAO_STREAM is assigned to "Shellfolder" files. [Zip files are both](https://devblogs.microsoft.com/oldnewthing/20171101-00/?p=97325) folders and streams.