### PR TITLE
[SHELL32_APITEST] Basic ILIsEqual tests

### DIFF
--- a/modules/rostests/apitests/shell32/ItemIDList.cpp
+++ b/modules/rostests/apitests/shell32/ItemIDList.cpp
@@ -213,9 +213,8 @@ START_TEST(ILIsEqual)
     p1 = p2 = NULL;
     ok_int(ILIsEqual(p1, p2), TRUE);
 
-    ITEMIDLIST emptyitem = {};
-    p1 = p2 = &emptyitem;
-    ok_int(ILIsEqual(p1, p2), TRUE);
+    ITEMIDLIST emptyitem = {}, emptyitem2 = {};
+    ok_int(ILIsEqual(&emptyitem, &emptyitem2), TRUE);
 
     ok_int(ILIsEqual(NULL, &emptyitem), FALSE); // These two are not equal for some reason
 

--- a/modules/rostests/apitests/shell32/ItemIDList.cpp
+++ b/modules/rostests/apitests/shell32/ItemIDList.cpp
@@ -214,6 +214,8 @@ START_TEST(ILIsEqual)
     p1 = p2 = &emptyitem;
     ok_int(ILIsEqual(p1, p2), TRUE);
 
+    ok_int(ILIsEqual(NULL, &emptyitem), FALSE); // These two are not equal for some reason
+
     p1 = SHCloneSpecialIDList(NULL, CSIDL_DRIVES, FALSE);
     p2 = SHCloneSpecialIDList(NULL, CSIDL_DRIVES, FALSE);
     if (p1 && p2)

--- a/modules/rostests/apitests/shell32/ItemIDList.cpp
+++ b/modules/rostests/apitests/shell32/ItemIDList.cpp
@@ -9,7 +9,10 @@
 #include "shelltest.h"
 #include <shellutils.h>
 
-enum { DIRBIT = 1, FILEBIT = 2 };
+enum { 
+    DIRBIT = 1, FILEBIT = 2,
+    PT_COMPUTER_REGITEM = 0x2E,
+};
 
 static BYTE GetPIDLType(LPCITEMIDLIST pidl)
 {
@@ -221,12 +224,12 @@ START_TEST(ILIsEqual)
     if (p1 && p2)
     {
         ok_int(ILIsEqual(p1, p2), TRUE);
-        p1->mkid.abID[0] = 0x2E; // Convert Desktop RegItem to Computer RegItem
+        p1->mkid.abID[0] = PT_COMPUTER_REGITEM; // RegItem in wrong parent
         ok_int(ILIsEqual(p1, p2), FALSE);
     }
     else
     {
-        skip("?\n");
+        skip("Unable to initialize test\n");
     }
     ILFree(p1);
     ILFree(p2);
@@ -248,12 +251,12 @@ START_TEST(ILIsEqual)
         ILRemoveLastID(p2);
         ok_int(ILIsParent(p1, p2, TRUE), TRUE); // Immediate child
 
-        p1->mkid.abID[0] = 0x2E; // Convert Desktop RegItem to Computer RegItem
+        p1->mkid.abID[0] = PT_COMPUTER_REGITEM; // RegItem in wrong parent
         ok_int(ILIsParent(p1, p2, FALSE), FALSE);
     }
     else
     {
-        skip("?\n");
+        skip("Unable to initialize test\n");
     }
     ILFree(p1);
     ILFree(p2);

--- a/modules/rostests/apitests/shell32/ItemIDList.cpp
+++ b/modules/rostests/apitests/shell32/ItemIDList.cpp
@@ -231,15 +231,22 @@ START_TEST(ILIsEqual)
     ILFree(p1);
     ILFree(p2);
 
-
+    // ILIsParent must compare like ILIsEqual
     p1 = SHSimpleIDListFromPath(L"c:\\");
     p2 = SHSimpleIDListFromPath(L"c:\\dir\\file");
     if (p1 && p2)
     {
-        ok_int(ILIsParent(p1, p2, FALSE), TRUE);
-        ok_int(ILIsParent(p1, p2, TRUE), FALSE);
+        ok_int(ILIsParent(NULL, p1, FALSE), FALSE); // NULL is always false
+        ok_int(ILIsParent(p1, NULL, FALSE), FALSE); // NULL is always false
+        ok_int(ILIsParent(NULL, NULL, FALSE), FALSE); // NULL is always false
+        ok_int(ILIsParent(p1, p1, FALSE), TRUE); // I'm my own parent
+        ok_int(ILIsParent(p1, p1, TRUE), FALSE); // Self is not immediate
+        ok_int(ILIsParent(p1, p2, FALSE), TRUE); // Grandchild
+        ok_int(ILIsParent(p1, p2, TRUE), FALSE); // Grandchild is not immediate
         ok_ptr(ILFindChild(p1, p2), ILGetNext(ILGetNext(p2))); // Child is "dir\\file", skip MyComputer and C:
         ok_int(ILIsEmpty(pidl = ILFindChild(p1, p1)) && pidl, TRUE); // Self
+        ILRemoveLastID(p2);
+        ok_int(ILIsParent(p1, p2, TRUE), TRUE); // Immediate child
 
         p1->mkid.abID[0] = 0x2E; // Convert Desktop RegItem to Computer RegItem
         ok_int(ILIsParent(p1, p2, FALSE), FALSE);

--- a/modules/rostests/apitests/shell32/ItemIDList.cpp
+++ b/modules/rostests/apitests/shell32/ItemIDList.cpp
@@ -205,7 +205,7 @@ START_TEST(PIDL)
 
 START_TEST(ILIsEqual)
 {
-    LPITEMIDLIST p1, p2;
+    LPITEMIDLIST p1, p2, pidl;
 
     p1 = p2 = NULL;
     ok_int(ILIsEqual(p1, p2), TRUE);
@@ -223,6 +223,26 @@ START_TEST(ILIsEqual)
         ok_int(ILIsEqual(p1, p2), TRUE);
         p1->mkid.abID[0] = 0x2E; // Convert Desktop RegItem to Computer RegItem
         ok_int(ILIsEqual(p1, p2), FALSE);
+    }
+    else
+    {
+        skip("?\n");
+    }
+    ILFree(p1);
+    ILFree(p2);
+
+
+    p1 = SHSimpleIDListFromPath(L"c:\\");
+    p2 = SHSimpleIDListFromPath(L"c:\\dir\\file");
+    if (p1 && p2)
+    {
+        ok_int(ILIsParent(p1, p2, FALSE), TRUE);
+        ok_int(ILIsParent(p1, p2, TRUE), FALSE);
+        ok_ptr(ILFindChild(p1, p2), ILGetNext(ILGetNext(p2))); // Child is "dir\\file", skip MyComputer and C:
+        ok_int(ILIsEmpty(pidl = ILFindChild(p1, p1)) && pidl, TRUE); // Self
+
+        p1->mkid.abID[0] = 0x2E; // Convert Desktop RegItem to Computer RegItem
+        ok_int(ILIsParent(p1, p2, FALSE), FALSE);
     }
     else
     {

--- a/modules/rostests/apitests/shell32/ItemIDList.cpp
+++ b/modules/rostests/apitests/shell32/ItemIDList.cpp
@@ -202,3 +202,30 @@ START_TEST(PIDL)
         skip("?\n");
     ILFree(pidl);
 }
+
+START_TEST(ILIsEqual)
+{
+    LPITEMIDLIST p1, p2;
+
+    p1 = p2 = NULL;
+    ok_int(ILIsEqual(p1, p2), TRUE);
+
+    ITEMIDLIST emptyitem = {};
+    p1 = p2 = &emptyitem;
+    ok_int(ILIsEqual(p1, p2), TRUE);
+
+    p1 = SHCloneSpecialIDList(NULL, CSIDL_DRIVES, FALSE);
+    p2 = SHCloneSpecialIDList(NULL, CSIDL_DRIVES, FALSE);
+    if (p1 && p2)
+    {
+        ok_int(ILIsEqual(p1, p2), TRUE);
+        p1->mkid.abID[0] = 0x2E; // Convert Desktop RegItem to Computer RegItem
+        ok_int(ILIsEqual(p1, p2), FALSE);
+    }
+    else
+    {
+        skip("?\n");
+    }
+    ILFree(p1);
+    ILFree(p2);
+}

--- a/modules/rostests/apitests/shell32/testlist.c
+++ b/modules/rostests/apitests/shell32/testlist.c
@@ -19,6 +19,7 @@ extern void func_FindExecutable(void);
 extern void func_GetDisplayNameOf(void);
 extern void func_GUIDFromString(void);
 extern void func_ILCreateFromPath(void);
+extern void func_ILIsEqual(void);
 extern void func_Int64ToString(void);
 extern void func_IShellFolderViewCB(void);
 extern void func_menu(void);
@@ -63,6 +64,7 @@ const struct test winetest_testlist[] =
     { "GetDisplayNameOf", func_GetDisplayNameOf },
     { "GUIDFromString", func_GUIDFromString },
     { "ILCreateFromPath", func_ILCreateFromPath },
+    { "ILIsEqual", func_ILIsEqual },
     { "Int64ToString", func_Int64ToString },
     { "IShellFolderViewCB", func_IShellFolderViewCB },
     { "menu", func_menu },


### PR DESCRIPTION
ROS `ILIsEqual` is rather broken, it compares each item id without context.
