### PR TITLE
[SERVICES] Use pointers to const string (PCWSTR) instead of non-const for argv

### DIFF
--- a/base/system/services/database.c
+++ b/base/system/services/database.c
@@ -1421,7 +1421,7 @@ ScmControlServiceEx(
     _In_ SERVICE_STATUS_HANDLE hServiceStatus,
     _In_opt_ DWORD dwServiceTag,
     _In_opt_ DWORD argc,
-    _In_reads_opt_(argc) PWSTR* argv)
+    _In_reads_opt_(argc) const PCWSTR* argv)
 {
     DWORD dwError = ERROR_SUCCESS;
     BOOL bResult;
@@ -1760,7 +1760,7 @@ ScmWaitForServiceConnect(PSERVICE Service)
 static DWORD
 ScmStartUserModeService(PSERVICE Service,
                         DWORD argc,
-                        LPWSTR* argv)
+                        const PCWSTR* argv)
 {
     PROCESS_INFORMATION ProcessInformation;
     STARTUPINFOW StartupInfo;
@@ -1910,7 +1910,7 @@ Quit:
 static DWORD
 ScmLoadService(PSERVICE Service,
                DWORD argc,
-               LPWSTR* argv)
+               const PCWSTR* argv)
 {
     PSERVICE_GROUP Group = Service->lpGroup;
     DWORD dwError = ERROR_SUCCESS;
@@ -2023,7 +2023,7 @@ ScmLoadService(PSERVICE Service,
 DWORD
 ScmStartService(PSERVICE Service,
                 DWORD argc,
-                LPWSTR* argv)
+                const PCWSTR* argv)
 {
     DWORD dwError = ERROR_SUCCESS;
     SC_RPC_LOCK Lock = NULL;
@@ -2042,7 +2042,8 @@ ScmStartService(PSERVICE Service,
     if (!ScmInitialize)
     {
         dwError = ScmAcquireServiceStartLock(TRUE, &Lock);
-        if (dwError != ERROR_SUCCESS) goto done;
+        if (dwError != ERROR_SUCCESS)
+            goto done;
     }
 
     /* Really start the service */

--- a/base/system/services/rpcserver.c
+++ b/base/system/services/rpcserver.c
@@ -3320,7 +3320,7 @@ RStartServiceW(
         return ERROR_SERVICE_MARKED_FOR_DELETE;
 
     /* Start the service */
-    dwError = ScmStartService(lpService, argc, (LPWSTR*)argv);
+    dwError = ScmStartService(lpService, argc, (PCWSTR*)argv);
 
     return dwError;
 }
@@ -4378,7 +4378,7 @@ RStartServiceA(
     DWORD dwError = ERROR_SUCCESS;
     PSERVICE_HANDLE hSvc;
     PSERVICE lpService = NULL;
-    LPWSTR *lpVector = NULL;
+    PWSTR* pVector = NULL;
     DWORD i;
     DWORD dwLength;
 
@@ -4417,25 +4417,25 @@ RStartServiceA(
     /* Build a Unicode argument vector */
     if (argc > 0)
     {
-        lpVector = HeapAlloc(GetProcessHeap(),
-                             HEAP_ZERO_MEMORY,
-                             argc * sizeof(LPWSTR));
-        if (lpVector == NULL)
+        pVector = HeapAlloc(GetProcessHeap(),
+                            HEAP_ZERO_MEMORY,
+                            argc * sizeof(PWSTR));
+        if (!pVector)
             return ERROR_NOT_ENOUGH_MEMORY;
 
         for (i = 0; i < argc; i++)
         {
             dwLength = MultiByteToWideChar(CP_ACP,
                                            0,
-                                           ((LPSTR*)argv)[i],
+                                           argv[i].StringPtr,
                                            -1,
                                            NULL,
                                            0);
 
-            lpVector[i] = HeapAlloc(GetProcessHeap(),
-                                    HEAP_ZERO_MEMORY,
-                                    dwLength * sizeof(WCHAR));
-            if (lpVector[i] == NULL)
+            pVector[i] = HeapAlloc(GetProcessHeap(),
+                                   HEAP_ZERO_MEMORY,
+                                   dwLength * sizeof(WCHAR));
+            if (!pVector[i])
             {
                 dwError = ERROR_NOT_ENOUGH_MEMORY;
                 goto done;
@@ -4443,26 +4443,26 @@ RStartServiceA(
 
             MultiByteToWideChar(CP_ACP,
                                 0,
-                                ((LPSTR*)argv)[i],
+                                argv[i].StringPtr,
                                 -1,
-                                lpVector[i],
+                                pVector[i],
                                 dwLength);
         }
     }
 
     /* Start the service */
-    dwError = ScmStartService(lpService, argc, lpVector);
+    dwError = ScmStartService(lpService, argc, (PCWSTR*)pVector);
 
 done:
     /* Free the Unicode argument vector */
-    if (lpVector != NULL)
+    if (pVector)
     {
         for (i = 0; i < argc; i++)
         {
-            if (lpVector[i] != NULL)
-                HeapFree(GetProcessHeap(), 0, lpVector[i]);
+            if (pVector[i])
+                HeapFree(GetProcessHeap(), 0, pVector[i]);
         }
-        HeapFree(GetProcessHeap(), 0, lpVector);
+        HeapFree(GetProcessHeap(), 0, pVector);
     }
 
     return dwError;

--- a/base/system/services/services.h
+++ b/base/system/services/services.h
@@ -186,7 +186,7 @@ VOID ScmAutoStartServices(VOID);
 VOID ScmAutoShutdownServices(VOID);
 DWORD ScmStartService(PSERVICE Service,
                       DWORD argc,
-                      LPWSTR *argv);
+                      const PCWSTR* argv);
 
 DWORD ScmReferenceService(PSERVICE lpService);
 DWORD ScmDereferenceService(PSERVICE lpService);


### PR DESCRIPTION
## Purpose

Use pointers to const string (PCWSTR) instead of non-const for argv

## TODO

- [x] Rebase on top of master once PR #7392 gets merged.
