### PR TITLE
Investigate why KVM x64 bot hangs when loading the wuauserv service.

### DIFF
--- a/base/system/services/rpcserver.c
+++ b/base/system/services/rpcserver.c
@@ -777,8 +777,9 @@ ScmCanonDriverImagePath(DWORD dwStartType,
 }
 
 
-/* Recursively search for every dependency on every service */
-DWORD
+/* Internal recursive function */
+/* Need to search for every dependency on every service */
+static DWORD
 Int_EnumDependentServicesW(HKEY hServicesKey,
                            PSERVICE lpService,
                            DWORD dwServiceState,
@@ -938,6 +939,10 @@ RCloseServiceHandle(
     PMANAGER_HANDLE hManager;
     PSERVICE_HANDLE hService;
     PSERVICE lpService;
+    HKEY hServicesKey;
+    DWORD dwError;
+    DWORD pcbBytesNeeded = 0;
+    DWORD dwServicesReturned = 0;
 
     DPRINT("RCloseServiceHandle() called\n");
 
@@ -981,9 +986,68 @@ RCloseServiceHandle(
         HeapFree(GetProcessHeap(), 0, hService);
         hService = NULL;
 
+        ASSERT(lpService->dwRefCount > 0);
 
-        DPRINT("Closing service %S with %d references\n", lpService->lpServiceName, lpService->RefCount);
-        ScmDereferenceService(lpService);
+        lpService->dwRefCount--;
+        DPRINT("CloseServiceHandle - lpService->dwRefCount %u\n",
+               lpService->dwRefCount);
+
+        if (lpService->dwRefCount == 0)
+        {
+            /* If this service has been marked for deletion */
+            if (lpService->bDeleted &&
+                lpService->Status.dwCurrentState == SERVICE_STOPPED)
+            {
+                /* Open the Services Reg key */
+                dwError = RegOpenKeyExW(HKEY_LOCAL_MACHINE,
+                                        L"System\\CurrentControlSet\\Services",
+                                        0,
+                                        KEY_SET_VALUE | KEY_READ,
+                                        &hServicesKey);
+                if (dwError != ERROR_SUCCESS)
+                {
+                    DPRINT("Failed to open services key\n");
+                    ScmUnlockDatabase();
+                    return dwError;
+                }
+
+                /* Call the internal function with NULL, just to get bytes we need */
+                Int_EnumDependentServicesW(hServicesKey,
+                                           lpService,
+                                           SERVICE_ACTIVE,
+                                           NULL,
+                                           &pcbBytesNeeded,
+                                           &dwServicesReturned);
+
+                /* If pcbBytesNeeded returned a value then there are services running that are dependent on this service */
+                if (pcbBytesNeeded)
+                {
+                    DPRINT("Deletion failed due to running dependencies\n");
+                    RegCloseKey(hServicesKey);
+                    ScmUnlockDatabase();
+                    return ERROR_SUCCESS;
+                }
+
+                /* There are no references and no running dependencies,
+                   it is now safe to delete the service */
+
+                /* Delete the Service Key */
+                dwError = ScmDeleteRegKey(hServicesKey,
+                                          lpService->lpServiceName);
+
+                RegCloseKey(hServicesKey);
+
+                if (dwError != ERROR_SUCCESS)
+                {
+                    DPRINT("Failed to Delete the Service Registry key\n");
+                    ScmUnlockDatabase();
+                    return dwError;
+                }
+
+                /* Delete the Service */
+                ScmDeleteServiceRecord(lpService);
+            }
+        }
 
         ScmUnlockDatabase();
 
@@ -1608,81 +1672,6 @@ ScmIsValidServiceState(DWORD dwCurrentState)
     }
 }
 
-static
-DWORD
-WINAPI
-ScmStopThread(PVOID pParam)
-{
-    PSERVICE lpService = (PSERVICE)pParam;
-    WCHAR szLogBuffer[80];
-    LPCWSTR lpLogStrings[2];
-
-    /* Check if we are about to stop this service */
-    if (lpService->lpImage->dwImageRunCount == 1)
-    {
-        /* Stop the dispatcher thread.
-         * We must not send a control message while holding the database lock, otherwise it can cause timeouts
-         * We are sure that the service won't be deleted in the meantime because we still have a reference to it. */
-        DPRINT("Stopping the dispatcher thread for service %S\n", lpService->lpServiceName);
-        ScmControlService(lpService->lpImage->hControlPipe,
-                          L"",
-                          (SERVICE_STATUS_HANDLE)lpService,
-                          SERVICE_CONTROL_STOP);
-    }
-
-    /* Lock the service database exclusively */
-    ScmLockDatabaseExclusive();
-
-    DPRINT("Service %S image count:%d\n", lpService->lpServiceName, lpService->lpImage->dwImageRunCount);
-
-    /* Decrement the image run counter */
-    lpService->lpImage->dwImageRunCount--;
-
-    /* If we just stopped the last running service... */
-    if (lpService->lpImage->dwImageRunCount == 0)
-    {
-        /* Remove the service image */
-        DPRINT("Removing service image for %S\n", lpService->lpServiceName);
-        ScmRemoveServiceImage(lpService->lpImage);
-        lpService->lpImage = NULL;
-    }
-
-    /* Report the results of the status change here */
-    if (lpService->Status.dwWin32ExitCode != ERROR_SUCCESS)
-    {
-        /* Log a failed service stop */
-        StringCchPrintfW(szLogBuffer, ARRAYSIZE(szLogBuffer),
-                         L"%lu", lpService->Status.dwWin32ExitCode);
-        lpLogStrings[0] = lpService->lpDisplayName;
-        lpLogStrings[1] = szLogBuffer;
-
-        ScmLogEvent(EVENT_SERVICE_EXIT_FAILED,
-                    EVENTLOG_ERROR_TYPE,
-                    ARRAYSIZE(lpLogStrings),
-                    lpLogStrings);
-    }
-    else
-    {
-        /* Log a successful service status change */
-        LoadStringW(GetModuleHandle(NULL), IDS_SERVICE_STOPPED, szLogBuffer, ARRAYSIZE(szLogBuffer));
-        lpLogStrings[0] = lpService->lpDisplayName;
-        lpLogStrings[1] = szLogBuffer;
-
-        ScmLogEvent(EVENT_SERVICE_STATUS_SUCCESS,
-                    EVENTLOG_INFORMATION_TYPE,
-                    ARRAYSIZE(lpLogStrings),
-                    lpLogStrings);
-    }
-
-    /* Remove the reference that was added when the service started */
-    DPRINT("Service %S has %d references while stoping\n", lpService->lpServiceName, lpService->RefCount);
-    ScmDereferenceService(lpService);
-
-    /* Unlock the service database */
-    ScmUnlockDatabase();
-
-    return 0;
-}
 
 /* Function 7 */
 DWORD
@@ -1765,62 +1754,58 @@ RSetServiceStatus(
     /* Restore the previous service type */
     lpService->Status.dwServiceType = dwPreviousType;
 
-    DPRINT("Service %S changed state %d to %d\n", lpService->lpServiceName, dwPreviousState, lpServiceStatus->dwCurrentState);
-
-    if (lpServiceStatus->dwCurrentState != SERVICE_STOPPED &&
-        dwPreviousState == SERVICE_STOPPED)
+    /* Dereference a stopped service */
+    if ((lpServiceStatus->dwServiceType & SERVICE_WIN32) &&
+        (lpServiceStatus->dwCurrentState == SERVICE_STOPPED))
     {
-        /* Keep a reference on all non stopped services */
-        ScmReferenceService(lpService);
-        DPRINT("Service %S has %d references after starting\n", lpService->lpServiceName, lpService->RefCount);
-    }
+        /* Decrement the image run counter */
+        lpService->lpImage->dwImageRunCount--;
 
-    /* Check if the service just stopped */
-    if (lpServiceStatus->dwCurrentState == SERVICE_STOPPED &&
-        dwPreviousState != SERVICE_STOPPED)
-    {
-        HANDLE hStopThread;
-        DWORD dwStopThreadId;
-        DPRINT("Service %S, currentstate: %d, prev: %d\n", lpService->lpServiceName, lpServiceStatus->dwCurrentState, dwPreviousState);
+        /* If we just stopped the last running service... */
+        if (lpService->lpImage->dwImageRunCount == 0)
+        {
+            /* Stop the dispatcher thread */
+            ScmControlService(lpService->lpImage->hControlPipe,
+                              L"",
+                              (SERVICE_STATUS_HANDLE)lpService,
+                              SERVICE_CONTROL_STOP);
 
-        /*
-         * The service just changed its status to stopped.
-         * Create a thread that will complete the stop sequence.
-         * This thread will remove the reference that was added when the service started.
-         * This will ensure that the service will remain valid as long as this reference is still held.
-         */
-        hStopThread = CreateThread(NULL,
-                                   0,
-                                   ScmStopThread,
-                                   (LPVOID)lpService,
-                                   0,
-                                   &dwStopThreadId);
-        if (hStopThread == NULL)
-        {
-            DPRINT1("Failed to create thread to complete service stop\n");
-            /* We can't leave without releasing the reference.
-             * We also can't remove it without holding the lock. */
-            ScmDereferenceService(lpService);
-            DPRINT1("Service %S has %d references after stop\n", lpService->lpServiceName, lpService->RefCount);
-        }
-        else
-        {
-            CloseHandle(hStopThread);
+            /* Remove the service image */
+            ScmRemoveServiceImage(lpService->lpImage);
+            lpService->lpImage = NULL;
         }
     }
 
     /* Unlock the service database */
     ScmUnlockDatabase();
 
-    /* Don't log any events here regarding a service stop as it can become invalid at any time */
+    if ((lpServiceStatus->dwCurrentState == SERVICE_STOPPED) &&
+        (dwPreviousState != SERVICE_STOPPED) &&
+        (lpServiceStatus->dwWin32ExitCode != ERROR_SUCCESS))
+    {
+        /* Log a failed service stop */
+        StringCchPrintfW(szLogBuffer, ARRAYSIZE(szLogBuffer),
+                         L"%lu", lpServiceStatus->dwWin32ExitCode);
+        lpLogStrings[0] = lpService->lpDisplayName;
+        lpLogStrings[1] = szLogBuffer;
 
-    if (lpServiceStatus->dwCurrentState != dwPreviousState &&
-        (lpServiceStatus->dwCurrentState == SERVICE_RUNNING ||
-         lpServiceStatus->dwCurrentState == SERVICE_PAUSED))
+        ScmLogEvent(EVENT_SERVICE_EXIT_FAILED,
+                    EVENTLOG_ERROR_TYPE,
+                    2,
+                    lpLogStrings);
+    }
+    else if (lpServiceStatus->dwCurrentState != dwPreviousState &&
+             (lpServiceStatus->dwCurrentState == SERVICE_STOPPED ||
+              lpServiceStatus->dwCurrentState == SERVICE_RUNNING ||
+              lpServiceStatus->dwCurrentState == SERVICE_PAUSED))
     {
         /* Log a successful service status change */
         switch(lpServiceStatus->dwCurrentState)
         {
+            case SERVICE_STOPPED:
+                uID = IDS_SERVICE_STOPPED;
+                break;
+
             case SERVICE_RUNNING:
                 uID = IDS_SERVICE_RUNNING;
                 break;
@@ -2232,7 +2217,7 @@ RChangeServiceConfigW(
                     DPRINT1("ScmDecryptPassword failed (Error %lu)\n", dwError);
                     goto done;
                 }
-                DPRINT("Clear text password: %S\n", lpClearTextPassword);
+                DPRINT1("Clear text password: %S\n", lpClearTextPassword);
 
                 /* Write the password */
                 dwError = ScmSetServicePassword(lpService->szServiceName,
@@ -2656,12 +2641,12 @@ RCreateServiceW(
     if (dwError != ERROR_SUCCESS)
         goto done;
 
-    ScmReferenceService(lpService);
+    lpService->dwRefCount = 1;
 
     /* Get the service tag (if Win32) */
     ScmGenerateServiceTag(lpService);
 
-    DPRINT("CreateService - lpService->RefCount %u\n", lpService->RefCount);
+    DPRINT("CreateService - lpService->dwRefCount %u\n", lpService->dwRefCount);
 
 done:
     /* Unlock the service database */
@@ -2996,8 +2981,8 @@ ROpenServiceW(
         goto Done;
     }
 
-    ScmReferenceService(lpService);
-    DPRINT("OpenService %S - lpService->RefCount %u\n", lpService->lpServiceName, lpService->RefCount);
+    lpService->dwRefCount++;
+    DPRINT("OpenService - lpService->dwRefCount %u\n",lpService->dwRefCount);
 
     *lpServiceHandle = (SC_RPC_HANDLE)hHandle;
     DPRINT("*hService = %p\n", *lpServiceHandle);
@@ -6740,7 +6725,7 @@ RI_ScValidatePnPService(
     hManager = ScmGetServiceManagerFromHandle(hSCManager);
     if (hManager == NULL)
     {
-        DPRINT1("Invalid handle\n");
+        DPRINT1("Invalid handle!\n");
         return ERROR_INVALID_HANDLE;
     }
 
@@ -6750,7 +6735,7 @@ RI_ScValidatePnPService(
     if (!RtlAreAllAccessesGranted(hManager->Handle.DesiredAccess,
                                   SC_MANAGER_CONNECT))
     {
-        DPRINT1("No SC_MANAGER_CONNECT access\n");
+        DPRINT1("No SC_MANAGER_CONNECT access!\n");
         return ERROR_ACCESS_DENIED;
     }
 

--- a/base/system/services/services.h
+++ b/base/system/services/services.h
@@ -65,7 +65,7 @@ typedef struct _SERVICE
     PSERVICE_IMAGE lpImage;
     BOOL bDeleted;
     DWORD dwResumeCount;
-    LONG RefCount;
+    DWORD dwRefCount;
 
     SERVICE_STATUS Status;
     DWORD dwStartType;
@@ -185,9 +185,6 @@ VOID ScmAutoShutdownServices(VOID);
 DWORD ScmStartService(PSERVICE Service,
                       DWORD argc,
                       LPWSTR *argv);
-
-DWORD ScmReferenceService(PSERVICE lpService);
-DWORD ScmDereferenceService(PSERVICE lpService);
 
 VOID ScmRemoveServiceImage(PSERVICE_IMAGE pServiceImage);
 PSERVICE ScmGetServiceEntryByName(LPCWSTR lpServiceName);


### PR DESCRIPTION
## Purpose

Investigate why KVM x64 bot hangs when loading the wuauserv service.
```
fixme:(win32ss\printing\providers\localspl\printerdrivers.c:110) DriverPath : C:\ReactOS\System32\spool\drivers\x64\3\UniDrv.dll
err:(base\services\wkssvc\wkssvc.c:82) ServiceInit()
err:(base\services\wkssvc\rpcserver.c:61) RpcServerListen() failed (Status 6b1)
(base\services\w32time\w32time.c:171) Entered SetTime.
(base\services\w32time\w32time.c:192) Time Server is 'pool.ntp.org'.
(base\services\w32time\w32time.c:309) W32Time Service failed to set clock: 0x0000001F
err:(base\services\srvsvc\rpcserver.c:64) RpcServerListen() failed (Status 6b1)
(base\services\wuauserv\wuauserv.c:45) WU UpdateServiceStatus() called
[SYSREG] timeout
```

Revert "[SERVICES] Fix services delay on stopping (#7375)"
This reverts commit 2f824a4a185f367090fd86727ab86b23948ed674.

# _NOTE that this PR is NOT MEANT to be merged!!_