### PR TITLE
[DDRAW] Fix taskbar visibilty when switching to fullscreen

### DIFF
--- a/dll/directx/wine/ddraw/ddraw.c
+++ b/dll/directx/wine/ddraw/ddraw.c
@@ -1145,6 +1145,10 @@ static HRESULT WINAPI ddraw7_SetDisplayMode(IDirectDraw7 *iface, DWORD width, DW
                 ddrawformat_from_wined3dformat(&ddraw->primary->surface_desc.u4.ddpfPixelFormat, mode.format_id);
         }
         ddraw->flags |= DDRAW_RESTORE_MODE;
+#ifdef __REACTOS__
+        if (ddraw->cooperative_level & DDSCL_EXCLUSIVE)
+            SetWindowPos(ddraw->dest_window, HWND_TOP, 0, 0, width, height, SWP_SHOWWINDOW | SWP_NOACTIVATE);
+#endif
     }
 
     InterlockedCompareExchange(&ddraw->device_state, DDRAW_DEVICE_STATE_NOT_RESTORED, DDRAW_DEVICE_STATE_OK);


### PR DESCRIPTION
## Purpose

Fix taskbar being displayed when switching to fullscreen when using DirectDraw 

Note that this is still a working fix unlike claimed here:

https://github.com/reactos/reactos/pull/4728#issuecomment-1722302390 | https://jira.reactos.org/browse/CORE-19171 

JIRA issue: 
[CORE-16140](https://jira.reactos.org/browse/CORE-16140)
[CORE-16148](https://jira.reactos.org/browse/CORE-16148)
[CORE-16321](https://jira.reactos.org/browse/CORE-16321)
[CORE-18644](https://jira.reactos.org/browse/CORE-18644)
[CORE-17799](https://jira.reactos.org/browse/CORE-17799)
possibly more?

Games fixed that do not have a Jira ticket:

- Future Cop L.A.P.D.
- Jazz Jackrabbit 2
- Command and Conquer Tiberian Sun
- Raptor: Call of Shadows
- Need For Speed Carbon
