### PR TITLE
WIP: [SETUP] add Ext2 boot support

### DIFF
--- a/base/setup/lib/bootsup.c
+++ b/base/setup/lib/bootsup.c
@@ -1275,6 +1275,110 @@ InstallBtrfsBootcodeToPartition(
     return STATUS_SUCCESS;
 }
 
+
+static
+NTSTATUS
+InstallExt2BootcodeToPartition(
+    IN PUNICODE_STRING SystemRootPath,
+    IN PUNICODE_STRING SourceRootPath,
+    IN PUNICODE_STRING DestinationArcPath)
+{
+    NTSTATUS Status;
+    BOOLEAN DoesFreeLdrExist;
+    WCHAR SrcPath[MAX_PATH];
+    WCHAR DstPath[MAX_PATH];
+
+    /* EXT2 partition */
+    DPRINT("System path: '%wZ'\n", SystemRootPath);
+
+    /* Copy FreeLoader to the system partition, always overwriting the older version */
+    CombinePaths(SrcPath, ARRAYSIZE(SrcPath), 2, SourceRootPath->Buffer, L"\\loader\\freeldr.sys");
+    CombinePaths(DstPath, ARRAYSIZE(DstPath), 2, SystemRootPath->Buffer, L"freeldr.sys");
+
+    DPRINT("Copy: %S ==> %S\n", SrcPath, DstPath);
+    Status = SetupCopyFile(SrcPath, DstPath, FALSE);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("SetupCopyFile() failed (Status %lx)\n", Status);
+        return Status;
+    }
+
+    /* Prepare for possibly updating 'freeldr.ini' */
+    DoesFreeLdrExist = DoesFileExist_2(SystemRootPath->Buffer, L"freeldr.ini");
+    if (DoesFreeLdrExist)
+    {
+        /* Update existing 'freeldr.ini' */
+        DPRINT1("Update existing 'freeldr.ini'\n");
+        Status = UpdateFreeLoaderIni(SystemRootPath->Buffer, DestinationArcPath->Buffer);
+        if (!NT_SUCCESS(Status))
+        {
+            DPRINT1("UpdateFreeLoaderIni() failed (Status %lx)\n", Status);
+            return Status;
+        }
+    }
+
+    /* Check for *nix bootloaders */
+
+    /* Create or update 'freeldr.ini' */
+    if (DoesFreeLdrExist == FALSE)
+    {
+        /* Create new 'freeldr.ini' */
+        DPRINT1("Create new 'freeldr.ini'\n");
+
+        /* Certainly SysLinux, GRUB, LILO... or an unknown boot loader */
+        DPRINT1("*nix or unknown boot loader found\n");
+
+        if (IsThereAValidBootSector(SystemRootPath->Buffer))
+        {
+            PCWSTR BootSector = L"BOOTSECT.OLD";
+
+            Status = CreateFreeLoaderIniForReactOSAndBootSector(
+                         SystemRootPath->Buffer, DestinationArcPath->Buffer,
+                         L"Linux", L"\"Linux\"",
+                         L"hd0", L"1", BootSector);
+            if (!NT_SUCCESS(Status))
+            {
+                DPRINT1("CreateFreeLoaderIniForReactOSAndBootSector() failed (Status %lx)\n", Status);
+                return Status;
+            }
+
+            /* Save current bootsector */
+            CombinePaths(DstPath, ARRAYSIZE(DstPath), 2, SystemRootPath->Buffer, BootSector);
+
+            DPRINT1("Save bootsector: %S ==> %S\n", SystemRootPath->Buffer, DstPath);
+            Status = SaveBootSector(SystemRootPath->Buffer, DstPath, BTRFS_BOOTSECTOR_SIZE);
+            if (!NT_SUCCESS(Status))
+            {
+                DPRINT1("SaveBootSector() failed (Status %lx)\n", Status);
+                return Status;
+            }
+        }
+        else
+        {
+            Status = CreateFreeLoaderIniForReactOS(SystemRootPath->Buffer, DestinationArcPath->Buffer);
+            if (!NT_SUCCESS(Status))
+            {
+                DPRINT1("CreateFreeLoaderIniForReactOS() failed (Status %lx)\n", Status);
+                return Status;
+            }
+        }
+
+        /* Install new bootsector on the disk */
+        /* Install Ext2 bootcode */
+        CombinePaths(SrcPath, ARRAYSIZE(SrcPath), 2, SourceRootPath->Buffer, L"\\loader\\ext2.bin");
+
+        DPRINT1("Install Ext2 bootcode: %S ==> %S\n", SrcPath, SystemRootPath->Buffer);
+        Status = InstallBootCodeToDisk(SrcPath, SystemRootPath->Buffer, InstallExt2BootCode);
+        if (!NT_SUCCESS(Status))
+        {
+            DPRINT1("InstallBootCodeToDisk(Ext2) failed (Status %lx)\n", Status);
+            return Status;
+        }
+    }
+
+    return STATUS_SUCCESS;
+}
+
 static
 NTSTATUS
 InstallNtfsBootcodeToPartition(
@@ -1404,14 +1508,17 @@ InstallVBRToPartition(
                                                SourceRootPath,
                                                DestinationArcPath);
     }
-    /*
-    else if (wcsicmp(FileSystemName, L"EXT2")  == 0 ||
-             wcsicmp(FileSystemName, L"EXT3")  == 0 ||
+    else if (wcsicmp(FileSystemName, L"EXT2")  == 0)
+    {
+        return InstallExt2BootcodeToPartition(SystemRootPath,
+                                               SourceRootPath,
+                                               DestinationArcPath);
+    }
+    else if (wcsicmp(FileSystemName, L"EXT3")  == 0 ||
              wcsicmp(FileSystemName, L"EXT4")  == 0)
     {
         return STATUS_NOT_SUPPORTED;
     }
-    */
     else
     {
         /* Unknown file system */

--- a/base/setup/lib/bootsup.c
+++ b/base/setup/lib/bootsup.c
@@ -1335,7 +1335,7 @@ InstallExt2BootcodeToPartition(
             Status = CreateFreeLoaderIniForReactOSAndBootSector(
                          SystemRootPath->Buffer, DestinationArcPath->Buffer,
                          L"Linux", L"\"Linux\"",
-                         L"hd0", L"1", BootSector);
+                         SystemRootPath->Buffer, BootSector);
             if (!NT_SUCCESS(Status))
             {
                 DPRINT1("CreateFreeLoaderIniForReactOSAndBootSector() failed (Status %lx)\n", Status);

--- a/base/setup/lib/fsutil.c
+++ b/base/setup/lib/fsutil.c
@@ -750,16 +750,21 @@ InstallExt2BootCode(
     ((PEXT2_BOOTSECTOR)NewBootSector.BootCode)->Ext2FirstDataBlock = ((PEXT2_BOOTSECTOR)OrigBootSector.BootCode)->Ext2FirstDataBlock;
     ((PEXT2_BOOTSECTOR)NewBootSector.BootCode)->Ext2InodesPerGroup = ((PEXT2_BOOTSECTOR)OrigBootSector.BootCode)->Ext2InodesPerGroup;
     ((PEXT2_BOOTSECTOR)NewBootSector.BootCode)->Ext2InodesPerBlock = ((PEXT2_BOOTSECTOR)OrigBootSector.BootCode)->Ext2InodesPerBlock;
-    //DPRINT("bootsup: NewBootSector %ld\n", sizeof(*NewBootSector));
-    DPRINT("bootsup: StartSector %ld\n", ((PEXT2_BOOTSECTOR)NewBootSector.BootCode)->Ext2VolumeStartSector);
-    DPRINT("bootsup: BlockSizeInBytes %ld\n", ((PEXT2_BOOTSECTOR)NewBootSector.BootCode)->Ext2BlockSizeInBytes);
-    DPRINT("bootsup: BlockSize %ld\n", ((PEXT2_BOOTSECTOR)NewBootSector.BootCode)->Ext2BlockSize);
-    DPRINT("bootsup: PointersPerBlock %ld\n", ((PEXT2_BOOTSECTOR)NewBootSector.BootCode)->Ext2PointersPerBlock);
-    DPRINT("bootsup: GroupDescPerBlock %ld\n", ((PEXT2_BOOTSECTOR)NewBootSector.BootCode)->Ext2GroupDescPerBlock);
-    DPRINT("bootsup: FirstDataBlock %ld\n", ((PEXT2_BOOTSECTOR)NewBootSector.BootCode)->Ext2FirstDataBlock);
-    DPRINT("bootsup: InodesPerGroup %ld\n", ((PEXT2_BOOTSECTOR)NewBootSector.BootCode)->Ext2InodesPerGroup);
-    DPRINT("bootsup: InodesPerBlock %ld\n", ((PEXT2_BOOTSECTOR)NewBootSector.BootCode)->Ext2InodesPerBlock);
-    DPRINT("bootsup: BootSectorMagic %x\n", ((PEXT2_BOOTSECTOR)NewBootSector.BootCode)->BootSectorMagic);
+    // ((PEXT2_BOOTSECTOR)NewBootSector.BootCode)->BootSectorMagic will be 0xAA55;
+
+
+    DPRINT1("bootsup: NewBootSector %ld\n", sizeof((PEXT2_BOOTSECTOR)NewBootSector.BootCode));
+    // bootsup: BootDrive 80h
+    DPRINT1("bootsup: BootDrive %02X\n", ((PEXT2_BOOTSECTOR)NewBootSector.BootCode)->BootDrive);
+    DPRINT1("bootsup: BootPartition %ld\n", ((PEXT2_BOOTSECTOR)NewBootSector.BootCode)->BootPartition);
+    DPRINT1("bootsup: BlockSizeInBytes %ld\n", ((PEXT2_BOOTSECTOR)NewBootSector.BootCode)->Ext2BlockSizeInBytes);
+    DPRINT1("bootsup: BlockSize %ld\n", ((PEXT2_BOOTSECTOR)NewBootSector.BootCode)->Ext2BlockSize);
+    DPRINT1("bootsup: PointersPerBlock %ld\n", ((PEXT2_BOOTSECTOR)NewBootSector.BootCode)->Ext2PointersPerBlock);
+    DPRINT1("bootsup: GroupDescPerBlock %ld\n", ((PEXT2_BOOTSECTOR)NewBootSector.BootCode)->Ext2GroupDescPerBlock);
+    DPRINT1("bootsup: FirstDataBlock %ld\n", ((PEXT2_BOOTSECTOR)NewBootSector.BootCode)->Ext2FirstDataBlock);
+    DPRINT1("bootsup: InodesPerGroup %ld\n", ((PEXT2_BOOTSECTOR)NewBootSector.BootCode)->Ext2InodesPerGroup);
+    DPRINT1("bootsup: InodesPerBlock %ld\n", ((PEXT2_BOOTSECTOR)NewBootSector.BootCode)->Ext2InodesPerBlock);
+    DPRINT1("bootsup: BootSectorMagic %x\n", ((PEXT2_BOOTSECTOR)NewBootSector.BootCode)->BootSectorMagic);
 
 
     /* Free the original bootsector */
@@ -773,29 +778,10 @@ InstallExt2BootCode(
                          NULL,
                          &IoStatusBlock,
                          NewBootSector.BootCode,
-                         FAT32_BOOTSECTOR_SIZE,
+                         NewBootSector.Length,
                          &FileOffset,
                          NULL);
-#if 0
 
-    if (!NT_SUCCESS(Status))
-    {
-        DPRINT1("NtWriteFile() failed (Status %lx)\n", Status);
-        FreeBootCode(&NewBootSector);
-        return Status;
-    }
-       /* Write sector 1 */
-    FileOffset.QuadPart = SECTORSIZE;
-    Status = NtWriteFile(FileHandle,
-                         NULL,
-                         NULL,
-                         NULL,
-                         &IoStatusBlock,
-                         NewBootSector,
-                         sizeof(EXT2_BOOTSECTOR),
-                         &FileOffset,
-                         NULL);
-#endif
     if (!NT_SUCCESS(Status))
     {
         DPRINT1("NtWriteFile() failed (Status %lx)\n", Status);

--- a/base/setup/lib/fsutil.c
+++ b/base/setup/lib/fsutil.c
@@ -23,7 +23,7 @@
 
 #include <fslib/vfatlib.h>
 #include <fslib/btrfslib.h>
-// #include <fslib/ext2lib.h>
+#include <fslib/ext2lib.h>
 // #include <fslib/ntfslib.h>
 
 #define NDEBUG
@@ -111,6 +111,26 @@ typedef struct _BTRFS_BOOTSECTOR
 } BTRFS_BOOTSECTOR, *PBTRFS_BOOTSECTOR;
 C_ASSERT(sizeof(BTRFS_BOOTSECTOR) == BTRFS_BOOTSECTOR_SIZE);
 
+ typedef struct _EXT2_BOOTSECTOR
+ {
+    UCHAR		JmpBoot[3];
+    UCHAR		BootDrive;
+    ULONG		Ext2VolumeStartSector;		// Start sector of the ext2 volume
+    ULONG		Ext2BlockSize;				// Block size in sectors
+    ULONG		Ext2BlockSizeInBytes;		// Block size in bytes
+    ULONG		Ext2PointersPerBlock;		// Number of block pointers that can be contained in one block
+    ULONG		Ext2GroupDescPerBlock;		// Number of group descriptors per block
+    ULONG		Ext2FirstDataBlock;			// First data block (1 for 1024-byte blocks, 0 for bigger sizes)
+    ULONG		Ext2InodesPerGroup;			// Number of inodes per group
+    ULONG		Ext2InodesPerBlock;			// Number of inodes per block
+    UCHAR		BootCodeAndData[473];		// The remainder of the boot sector
+    UCHAR		BootPartition;
+    USHORT		BootSectorMagic;			// 0xAA55
+    UCHAR		BootCodeAndData2[512];		// Second boot sector
+ } EXT2_BOOTSECTOR, *PEXT2_BOOTSECTOR;
+C_ASSERT(sizeof(EXT2_BOOTSECTOR) == EXT2_BOOTSECTOR_SIZE);
+
+
 typedef struct _NTFS_BOOTSECTOR
 {
     UCHAR Jump[3];
@@ -167,8 +187,8 @@ static FILE_SYSTEM RegisteredFileSystems[] =
     { L"NTFS" , NtfsFormat, NtfsChkdsk },
 #endif
     { L"BTRFS", BtrfsFormat, BtrfsChkdsk },
-#if 0
     { L"EXT2" , Ext2Format, Ext2Chkdsk },
+#if 0
     { L"EXT3" , Ext2Format, Ext2Chkdsk },
     { L"EXT4" , Ext2Format, Ext2Chkdsk },
 #endif
@@ -680,6 +700,105 @@ Quit:
     if (!NT_SUCCESS(LockStatus))
     {
         DPRINT1("Failed to unlock BTRFS volume (Status 0x%lx)\n", LockStatus);
+    }
+
+    /* Free the new bootsector */
+    FreeBootCode(&NewBootSector);
+
+    return Status;
+}
+
+NTSTATUS
+InstallExt2BootCode(
+    IN PCWSTR SrcPath,          // Ext2 bootsector source file (on the installation medium)
+    IN HANDLE DstPath,          // Where to save the bootsector built from the source + partition information
+    IN HANDLE RootPartition)    // Partition holding the (old) FAT32 information
+{
+    NTSTATUS Status;
+    UNICODE_STRING Name;
+    IO_STATUS_BLOCK IoStatusBlock;
+    LARGE_INTEGER FileOffset;
+    BOOTCODE OrigBootSector = {0};
+    BOOTCODE NewBootSector  = {0};
+
+    /* Allocate and read the current original partition bootsector */
+    Status = ReadBootCodeByHandle(&OrigBootSector,
+                                  RootPartition,
+                                  EXT2_BOOTSECTOR_SIZE);
+    if (!NT_SUCCESS(Status))
+        return Status;
+
+    /* Allocate and read the new bootsector (2 sectors) from SrcPath */
+    RtlInitUnicodeString(&Name, SrcPath);
+    Status = ReadBootCodeFromFile(&NewBootSector,
+                                  &Name,
+                                  EXT2_BOOTSECTOR_SIZE);
+    if (!NT_SUCCESS(Status))
+    {
+        FreeBootCode(&OrigBootSector);
+        return Status;
+    }
+
+    /* Adjust bootsector (copy old BPB) */
+    ((PEXT2_BOOTSECTOR)NewBootSector.BootCode)->BootDrive = 0xff;
+    ((PEXT2_BOOTSECTOR)NewBootSector.BootCode)->BootPartition = 0x00;
+    ((PEXT2_BOOTSECTOR)NewBootSector.BootCode)->Ext2VolumeStartSector = ((PEXT2_BOOTSECTOR)OrigBootSector.BootCode)->Ext2VolumeStartSector;
+    ((PEXT2_BOOTSECTOR)NewBootSector.BootCode)->Ext2BlockSizeInBytes = ((PEXT2_BOOTSECTOR)OrigBootSector.BootCode)->Ext2BlockSizeInBytes;
+    ((PEXT2_BOOTSECTOR)NewBootSector.BootCode)->Ext2BlockSize = ((PEXT2_BOOTSECTOR)OrigBootSector.BootCode)->Ext2BlockSize;
+    ((PEXT2_BOOTSECTOR)NewBootSector.BootCode)->Ext2PointersPerBlock = ((PEXT2_BOOTSECTOR)OrigBootSector.BootCode)->Ext2PointersPerBlock;
+    ((PEXT2_BOOTSECTOR)NewBootSector.BootCode)->Ext2GroupDescPerBlock = ((PEXT2_BOOTSECTOR)OrigBootSector.BootCode)->Ext2GroupDescPerBlock;
+    ((PEXT2_BOOTSECTOR)NewBootSector.BootCode)->Ext2FirstDataBlock = ((PEXT2_BOOTSECTOR)OrigBootSector.BootCode)->Ext2FirstDataBlock;
+    ((PEXT2_BOOTSECTOR)NewBootSector.BootCode)->Ext2InodesPerGroup = ((PEXT2_BOOTSECTOR)OrigBootSector.BootCode)->Ext2InodesPerGroup;
+    ((PEXT2_BOOTSECTOR)NewBootSector.BootCode)->Ext2InodesPerBlock = ((PEXT2_BOOTSECTOR)OrigBootSector.BootCode)->Ext2InodesPerBlock;
+    //DPRINT("bootsup: NewBootSector %ld\n", sizeof(*NewBootSector));
+    DPRINT("bootsup: StartSector %ld\n", ((PEXT2_BOOTSECTOR)NewBootSector.BootCode)->Ext2VolumeStartSector);
+    DPRINT("bootsup: BlockSizeInBytes %ld\n", ((PEXT2_BOOTSECTOR)NewBootSector.BootCode)->Ext2BlockSizeInBytes);
+    DPRINT("bootsup: BlockSize %ld\n", ((PEXT2_BOOTSECTOR)NewBootSector.BootCode)->Ext2BlockSize);
+    DPRINT("bootsup: PointersPerBlock %ld\n", ((PEXT2_BOOTSECTOR)NewBootSector.BootCode)->Ext2PointersPerBlock);
+    DPRINT("bootsup: GroupDescPerBlock %ld\n", ((PEXT2_BOOTSECTOR)NewBootSector.BootCode)->Ext2GroupDescPerBlock);
+    DPRINT("bootsup: FirstDataBlock %ld\n", ((PEXT2_BOOTSECTOR)NewBootSector.BootCode)->Ext2FirstDataBlock);
+    DPRINT("bootsup: InodesPerGroup %ld\n", ((PEXT2_BOOTSECTOR)NewBootSector.BootCode)->Ext2InodesPerGroup);
+    DPRINT("bootsup: InodesPerBlock %ld\n", ((PEXT2_BOOTSECTOR)NewBootSector.BootCode)->Ext2InodesPerBlock);
+    DPRINT("bootsup: BootSectorMagic %x\n", ((PEXT2_BOOTSECTOR)NewBootSector.BootCode)->BootSectorMagic);
+
+
+    /* Free the original bootsector */
+    FreeBootCode(&OrigBootSector);
+
+    /* Write the first sector of the new bootcode to DstPath sector 0 */
+    FileOffset.QuadPart = 0ULL;
+    Status = NtWriteFile(DstPath,
+                         NULL,
+                         NULL,
+                         NULL,
+                         &IoStatusBlock,
+                         NewBootSector.BootCode,
+                         FAT32_BOOTSECTOR_SIZE,
+                         &FileOffset,
+                         NULL);
+#if 0
+
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("NtWriteFile() failed (Status %lx)\n", Status);
+        FreeBootCode(&NewBootSector);
+        return Status;
+    }
+       /* Write sector 1 */
+    FileOffset.QuadPart = SECTORSIZE;
+    Status = NtWriteFile(FileHandle,
+                         NULL,
+                         NULL,
+                         NULL,
+                         &IoStatusBlock,
+                         NewBootSector,
+                         sizeof(EXT2_BOOTSECTOR),
+                         &FileOffset,
+                         NULL);
+#endif
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("NtWriteFile() failed (Status %lx)\n", Status);
     }
 
     /* Free the new bootsector */

--- a/base/setup/lib/fsutil.h
+++ b/base/setup/lib/fsutil.h
@@ -68,6 +68,7 @@ FormatFileSystem(
 #define FAT_BOOTSECTOR_SIZE     (1 * SECTORSIZE)
 #define FAT32_BOOTSECTOR_SIZE   (1 * SECTORSIZE) // Counts only the primary sector.
 #define BTRFS_BOOTSECTOR_SIZE   (3 * SECTORSIZE)
+#define EXT2_BOOTSECTOR_SIZE    (2 * SECTORSIZE)
 #define NTFS_BOOTSECTOR_SIZE   (16 * SECTORSIZE)
 
 typedef NTSTATUS
@@ -93,6 +94,12 @@ InstallFat32BootCode(
 
 NTSTATUS
 InstallBtrfsBootCode(
+    IN PCWSTR SrcPath,
+    IN HANDLE DstPath,
+    IN HANDLE RootPartition);
+
+NTSTATUS
+InstallExt2BootCode(
     IN PCWSTR SrcPath,
     IN HANDLE DstPath,
     IN HANDLE RootPartition);

--- a/boot/bootdata/txtsetup.sif
+++ b/boot/bootdata/txtsetup.sif
@@ -125,6 +125,7 @@ scsiport.sys = 1,,,,,,,4,,,,1,4
 storport.sys = 1,,,,,,,4,,,,1,4
 fastfat.sys  = 1,,,,,,x,4,,,,1,4
 btrfs.sys    = 1,,,,,,x,4,,,,1,4
+ext2fs.sys   = 1,,,,,,x,4,,,,1,4
 ramdisk.sys  = 1,,,,,,x,4,,,,1,4
 pciide.sys   = 1,,,,,,,4,,,,1,4
 pciidex.sys  = 1,,,,,,,4,,,,1,4

--- a/boot/freeldr/bootsect/CMakeLists.txt
+++ b/boot/freeldr/bootsect/CMakeLists.txt
@@ -4,7 +4,7 @@ include_directories(${REACTOS_SOURCE_DIR}/boot/freeldr)
 if(ARCH STREQUAL "i386" OR ARCH STREQUAL "amd64")
 
     CreateBootSectorTarget(dosmbr ${CMAKE_CURRENT_SOURCE_DIR}/dosmbr.S ${CMAKE_CURRENT_BINARY_DIR}/dosmbr.bin 7c00)
-    CreateBootSectorTarget(ext2 ${CMAKE_CURRENT_SOURCE_DIR}/ext2.S ${CMAKE_CURRENT_BINARY_DIR}/ext2.bin 0)
+    CreateBootSectorTarget(ext2 ${CMAKE_CURRENT_SOURCE_DIR}/ext2.S ${CMAKE_CURRENT_BINARY_DIR}/ext2.bin 7c00)
 
     CreateBootSectorTarget(fat ${CMAKE_CURRENT_SOURCE_DIR}/fat.S ${CMAKE_CURRENT_BINARY_DIR}/fat.bin 7c00)
     CreateBootSectorTarget(fat32 ${CMAKE_CURRENT_SOURCE_DIR}/fat32.S ${CMAKE_CURRENT_BINARY_DIR}/fat32.bin 7c00)

--- a/boot/freeldr/bootsect/CMakeLists.txt
+++ b/boot/freeldr/bootsect/CMakeLists.txt
@@ -4,7 +4,7 @@ include_directories(${REACTOS_SOURCE_DIR}/boot/freeldr)
 if(ARCH STREQUAL "i386" OR ARCH STREQUAL "amd64")
 
     CreateBootSectorTarget(dosmbr ${CMAKE_CURRENT_SOURCE_DIR}/dosmbr.S ${CMAKE_CURRENT_BINARY_DIR}/dosmbr.bin 7c00)
-    CreateBootSectorTarget(ext2 ${CMAKE_CURRENT_SOURCE_DIR}/ext2.S ${CMAKE_CURRENT_BINARY_DIR}/ext2.bin 7c00)
+    CreateBootSectorTarget(ext2vbr ${CMAKE_CURRENT_SOURCE_DIR}/ext2.S ${CMAKE_CURRENT_BINARY_DIR}/ext2.bin 7c00)
 
     CreateBootSectorTarget(fat ${CMAKE_CURRENT_SOURCE_DIR}/fat.S ${CMAKE_CURRENT_BINARY_DIR}/fat.bin 7c00)
     CreateBootSectorTarget(fat32 ${CMAKE_CURRENT_SOURCE_DIR}/fat32.S ${CMAKE_CURRENT_BINARY_DIR}/fat32.bin 7c00)
@@ -31,7 +31,7 @@ if(ARCH STREQUAL "i386" OR ARCH STREQUAL "amd64")
     CreateBootSectorTarget(isombr ${CMAKE_CURRENT_SOURCE_DIR}/isombr.S ${CMAKE_CURRENT_BINARY_DIR}/isombr.bin 7000)
 
     add_cd_file(TARGET dosmbr DESTINATION loader NO_CAB FILE ${CMAKE_CURRENT_BINARY_DIR}/dosmbr.bin FOR bootcd regtest)
-    add_cd_file(TARGET ext2 DESTINATION loader NO_CAB FILE ${CMAKE_CURRENT_BINARY_DIR}/ext2.bin FOR bootcd regtest)
+    add_cd_file(TARGET ext2vbr DESTINATION loader NO_CAB FILE ${CMAKE_CURRENT_BINARY_DIR}/ext2.bin FOR bootcd regtest)
     add_cd_file(TARGET btrfsvbr DESTINATION loader NO_CAB FILE ${CMAKE_CURRENT_BINARY_DIR}/btrfs.bin FOR bootcd regtest)
     add_cd_file(TARGET fat DESTINATION loader NO_CAB FILE ${CMAKE_CURRENT_BINARY_DIR}/fat.bin FOR bootcd regtest)
     add_cd_file(TARGET fat32 DESTINATION loader NO_CAB FILE ${CMAKE_CURRENT_BINARY_DIR}/fat32.bin FOR bootcd regtest)

--- a/boot/freeldr/bootsect/ext2.S
+++ b/boot/freeldr/bootsect/ext2.S
@@ -8,7 +8,11 @@
 // [bp-0x10] Here we will store the number of LBA sectors read
 
 #include <asm.inc>
+#include <freeldr/include/arch/pc/x86common.h>
 .code16
+
+#define BP_REL(x) [bp+x-offset start]
+#define BP_REL_SP(x) [bp-x]
 
 SECTORS_PER_TRACK		= HEX(04)
 NUMBER_OF_HEADS			= HEX(08)
@@ -34,12 +38,12 @@ BootDrive:
 //SectorsPerTrack		db 63					// Moved to [bp-SECTORS_PER_TRACK]
 //NumberOfHeads			dw 16					// Moved to [bp-NUMBER_OF_HEADS]
 //BiosCHSDriveSize		dd (1024 * 1024 * 63)	// Moved to [bp-BIOS_CHS_DRIVE_SIZE]
-//LBASectorsRead			dd 0					// Moved to [bp-LBA_SECTORS_READ]
+//LBASectorsRead		dd 0					// Moved to [bp-LBA_SECTORS_READ]
 
 Ext2VolumeStartSector:
-	.long 263088				// Start sector of the ext2 volume
+	.long 63					// Start sector of the ext2 volume
 Ext2BlockSize:
-	.long 2					// Block size in sectors
+	.long 2						// Block size in sectors
 Ext2BlockSizeInBytes:
 	.long 1024					// Block size in bytes
 Ext2PointersPerBlock:
@@ -47,11 +51,11 @@ Ext2PointersPerBlock:
 Ext2GroupDescPerBlock:
 	.long 32					// Number of group descriptors per block
 Ext2FirstDataBlock:
-	.long 1					// First data block (1 for 1024-byte blocks, 0 for bigger sizes)
+	.long 1						// First data block (1 for 1024-byte blocks, 0 for bigger sizes)
 Ext2InodesPerGroup:
-	.long 2048					// Number of inodes per group
+	.long 1024					// Number of inodes per group
 Ext2InodesPerBlock:
-	.long 8					// Number of inodes per block
+	.long 8						// Number of inodes per block
 
 Ext2ReadEntireFileLoadSegment:
 	.word	0
@@ -71,17 +75,17 @@ main:
         mov sp, HEX(7b00)            // Setup a stack
 
         mov si, offset BootDrive
-		cmp byte ptr [si], HEX(0ff)	// If they have specified a boot drive then use it
+		cmp byte ptr ds:[si], HEX(0ff)	// If they have specified a boot drive then use it
 		jne GetDriveParameters
 
-        mov [si],dl				// Save the boot drive
+        mov ds:[si],dl				// Save the boot drive
 
 
 GetDriveParameters:
 		mov  ah, 8
-		mov  dl,[si]					// Get boot drive in dl
-		int  HEX(13)									// Request drive parameters from the bios
-		jnc  CalcDriveSize							// If the call succeeded then calculate the drive size
+		mov  dl,ds:[si]				// Get boot drive in dl
+		int  HEX(13)				// Request drive parameters from the bios
+		jnc  CalcDriveSize			// If the call succeeded then calculate the drive size
 
 		// If we get here then the call to the BIOS failed
 		// so just set CHS equal to the maximum addressable
@@ -95,21 +99,21 @@ CalcDriveSize:
 		mov  bl,ch								// Put the low 8-bits of the cylinder count into BL
 		mov  bh,cl								// Put the high 2-bits in BH
 		shr  bh,6								// Shift them into position, now BX contains the cylinder count
-		and  cl, HEX(3f)								// Mask off cylinder bits from sector count
+		and  cl, HEX(3f)						// Mask off cylinder bits from sector count
 		// CL now contains sectors per track and DH contains head count
 		movzx eax,dh							// Move the heads into EAX
 		movzx ebx,bx							// Move the cylinders into EBX
 		movzx ecx,cl							// Move the sectors per track into ECX
 		inc   eax								// Make it one based because the bios returns it zero based
-		mov   [bp-NUMBER_OF_HEADS],eax		// Save number of heads
-		mov   [bp-SECTORS_PER_TRACK],ecx	// Save number of sectors per track
+		mov   dword ptr BP_REL_SP(NUMBER_OF_HEADS),eax	// Save number of heads
+		mov   dword ptr BP_REL_SP(SECTORS_PER_TRACK),ecx	// Save number of sectors per track
 		inc   ebx								// Make the cylinder count one based also
 		mul   ecx								// Multiply heads with the sectors per track, result in edx:eax
 		mul   ebx								// Multiply the cylinders with (heads * sectors) [stored in edx:eax already]
 
 		// We now have the total number of sectors as reported
 		// by the bios in eax, so store it in our variable
-		mov   [bp-BIOS_CHS_DRIVE_SIZE],eax
+		mov   dword ptr BP_REL_SP(BIOS_CHS_DRIVE_SIZE),eax
 
 
 LoadExtraBootCode:
@@ -119,7 +123,7 @@ LoadExtraBootCode:
 		xor  eax,eax
 		inc  eax								// Read logical sector 1, EAX now = 1
 		mov  cx,1								// Read one sector
-		mov  bx, HEX(7e00)							// Read sector to [0000:7e00h]
+		mov  bx, HEX(7e00)						// Read sector to [0000:7e00h]
 		call ReadSectors
 
 		jmp  LoadRootDirectory
@@ -133,8 +137,8 @@ LoadExtraBootCode:
 Ext2ReadGroupDesc:
 		shl   eax,5										// Group = (Group * sizeof(GROUP_DESCRIPTOR) /* 32 */)
 		xor   edx,edx
-		div   dword ptr [bp+Ext2GroupDescPerBlock]		// Group = (Group / Ext2GroupDescPerBlock)
-		add   eax, dword ptr [bp+Ext2FirstDataBlock]	// Group = Group + Ext2FirstDataBlock + 1
+		div   dword ptr BP_REL(Ext2GroupDescPerBlock)	// Group = (Group / Ext2GroupDescPerBlock)
+		add   eax, dword ptr BP_REL(Ext2FirstDataBlock)	// Group = Group + Ext2FirstDataBlock + 1
 		inc   eax										// EAX now has the group descriptor block number
 														// EDX now has the group descriptor offset in the block
 
@@ -154,7 +158,7 @@ Ext2ReadGroupDesc:
 // Reads ext2 block into ES:[BX]
 // EAX has logical block number to read
 Ext2ReadBlock:
-		mov   ecx, dword ptr [bp+Ext2BlockSize]
+		mov   ecx, dword ptr BP_REL(Ext2BlockSize)
 		mul   ecx
 		jmp   ReadSectors
 
@@ -165,11 +169,14 @@ Ext2ReadBlock:
 Ext2ReadInode:
 		dec   eax										// Inode = Inode - 1
 		xor   edx,edx
-		div   dword ptr [bp+Ext2InodesPerGroup]		// Inode = (Inode / Ext2InodesPerGroup)
-		mov   ebx,eax									// EBX now has the inode group number
-		mov   eax,edx
-		xor   edx,edx
-		div   dword ptr [bp+Ext2InodesPerBlock]		// Inode = (Inode / Ext2InodesPerBlock)
+		div   dword ptr BP_REL(Ext2InodesPerGroup)		// Inode = (Inode / Ext2InodesPerGroup)
+		push  edx										// Push remainder of the division
+		mul   dword ptr BP_REL(Ext2InodesPerGroup)		// Group = Group * Ext2InodesPerGroup
+		mul   dword ptr BP_REL(Ext2InodesPerBlock)		// Group = Group * Ext2InodesPerBlock
+		mov   ebx,eax									// EBX now has the inode group block number
+		pop   eax										// Pop reminder in eax
+		// xor   edx,edx									// Skip 
+		div   dword ptr BP_REL(Ext2InodesPerBlock)		// Inode = (Inode / Ext2InodesPerBlock)
 		shl   edx,7										// FIXME: InodeOffset *= 128 (make the array index a byte offset)
 														// EAX now has the inode offset block number from inode table
 														// EDX now has the inode offset in the block
@@ -179,7 +186,9 @@ Ext2ReadInode:
 		push  edx
 		push  eax
 		mov   eax,ebx
+		push  ebx
 		call  Ext2ReadGroupDesc
+		pop   ebx
 
 		// Group descriptor has been read, now
 		// grab the inode table block number from it
@@ -187,7 +196,8 @@ Ext2ReadInode:
 		pop   es
 		mov   di, HEX(8008)
 		pop   eax										// Restore inode offset block number from stack
-		add   eax, es:[di]							// Add the inode table start block
+		add   eax, ebx									// Add the group start block number
+		add   eax, es:[di]								// Add the inode table start block
 
 		// Adjust the read offset so that the
 		// inode we want is read to 6000:8000
@@ -206,8 +216,8 @@ Ext2ReadInode:
 // EAX has logical sector number to read
 // CX has number of sectors to read
 ReadSectors:
-        add  eax, dword ptr [bp+Ext2VolumeStartSector]	// Add the start of the volume
-		cmp  eax, [bp-BIOS_CHS_DRIVE_SIZE]		// Check if they are reading a sector outside CHS range
+        add  eax, dword ptr BP_REL(Ext2VolumeStartSector)	// Add the start of the volume
+		cmp  eax, dword ptr BP_REL_SP(BIOS_CHS_DRIVE_SIZE)	// Check if they are reading a sector outside CHS range
 		jae  ReadSectorsLBA						// Yes - go to the LBA routine
 												// If at all possible we want to use LBA routines because
 												// They are optimized to read more than 1 sector per read
@@ -217,7 +227,7 @@ ReadSectors:
 CheckInt13hExtensions:							// Now check if this computer supports extended reads
 		mov  ah, HEX(41)						// AH = 41h
 		mov  bx, HEX(55aa)						// BX = 55AAh
-		mov  dl, byte ptr [bp+BootDrive]					// DL = drive (80h-FFh)
+		mov  dl, byte ptr BP_REL(BootDrive)		// DL = drive (80h-FFh)
 		int  HEX(13)							// IBM/MS INT 13 Extensions - INSTALLATION CHECK
 		jc   ReadSectorsCHS						// CF set on error (extensions not supported)
 		cmp  bx, HEX(0aa55)						// BX = AA55h if installed
@@ -230,13 +240,13 @@ CheckInt13hExtensions:							// Now check if this computer supports extended rea
 ReadSectorsLBA:
 		pushad									// Save logical sector number & sector count
 
-		cmp  cx, 64							// Since the LBA calls only support 0x7F sectors at a time we will limit ourselves to 64
+		cmp  cx, 64								// Since the LBA calls only support 0x7F sectors at a time we will limit ourselves to 64
 		jbe  ReadSectorsSetupDiskAddressPacket	// If we are reading less than 65 sectors then just do the read
 		mov  cx,64								// Otherwise read only 64 sectors on this loop iteration
 
 ReadSectorsSetupDiskAddressPacket:
-		mov  [bp-LBA_SECTORS_READ],cx
-		mov  word ptr [bp-LBA_SECTORS_READ+2],0
+		mov  word ptr BP_REL_SP(LBA_SECTORS_READ),cx
+		mov  word ptr BP_REL_SP(LBA_SECTORS_READ+2),0
 		data32 push 0
 		push eax								// Put 64-bit logical block address on stack
 		push es									// Put transfer segment on stack
@@ -246,9 +256,9 @@ ReadSectorsSetupDiskAddressPacket:
 		mov  si,sp								// Setup disk address packet on stack
 
 
-        mov  dl, byte ptr [bp+BootDrive]					// Drive number
-		mov  ah, HEX(42)								// Int 13h, AH = 42h - Extended Read
-		int  HEX(13)								// Call BIOS
+        mov  dl, byte ptr BP_REL(BootDrive)		// Drive number
+		mov  ah, HEX(42)						// Int 13h, AH = 42h - Extended Read
+		int  HEX(13)							// Call BIOS
 		jc   PrintDiskError						// If the read failed then abort
 
 		add  sp, 16								// Remove disk address packet from stack
@@ -256,7 +266,7 @@ ReadSectorsSetupDiskAddressPacket:
 		popad									// Restore sector count & logical sector number
 
 		push bx
-		mov  ebx, [bp-LBA_SECTORS_READ]
+		mov  ebx, dword ptr BP_REL_SP(LBA_SECTORS_READ)
         add  eax,ebx							// Increment sector to read
 		shl  ebx,5
         mov  dx,es
@@ -264,7 +274,7 @@ ReadSectorsSetupDiskAddressPacket:
         mov  es,dx
 		pop  bx
 
-		sub  cx,[bp-LBA_SECTORS_READ]
+		sub  cx,word ptr BP_REL_SP(LBA_SECTORS_READ)
         jnz  ReadSectorsLBA						// Read next sector
 
         ret
@@ -279,15 +289,15 @@ ReadSectorsCHS:
 ReadSectorsCHSLoop:
         pushad
         xor   edx,edx
-		mov   ecx, [bp-SECTORS_PER_TRACK]
+		mov   ecx, dword ptr BP_REL_SP(SECTORS_PER_TRACK)
 		div   ecx									// Divide logical by SectorsPerTrack
         inc   dl									// Sectors numbering starts at 1 not 0
 		mov   cl,dl									// Sector in CL
 		mov   edx,eax
 		shr   edx,16
-        div   word ptr [bp-NUMBER_OF_HEADS]		// Divide logical by number of heads
+        div   word ptr BP_REL_SP(NUMBER_OF_HEADS)	// Divide logical by number of heads
         mov   dh,dl									// Head in DH
-        mov   dl, byte ptr [bp+BootDrive]				// Drive number in DL
+        mov   dl, byte ptr BP_REL(BootDrive)		// Drive number in DL
         mov   ch,al									// Cylinder in CX
         ror   ah,2									// Low 8 bits of cylinder in CH, high 2 bits
                 									//  in CL shifted to bits 6 & 7
@@ -318,12 +328,12 @@ ReadSectorsCHSLoop:
 // Displays a disk error message
 // And reboots
 PrintDiskError:
-        mov  si,msgDiskError			// Bad boot disk message
-        call PutChars					// Display it
+        mov  si,offset msgDiskError			// Bad boot disk message
+        call PutChars						// Display it
 
 Reboot:
-        mov  si,msgAnyKey				// Press any key message
-        call PutChars					// Display it
+        mov  si,offset msgAnyKey			// Press any key message
+        call PutChars						// Display it
         xor ax,ax
         int HEX(16)							// Wait for a keypress
         int HEX(19)							// Reboot
@@ -349,11 +359,11 @@ Done:
 
 
 msgDiskError:
-    .ascii "Disk error", NUL
+    .ascii "Err", NUL
 // Sorry, need the space...
 //msgAnyKey			db 'Press any key to restart',0
 msgAnyKey:
-    .ascii "Press key", NUL
+    .ascii "Key", NUL
 
 //    times 509-($-$$) db 0   // Pad to 509 bytes
     .org 509
@@ -388,14 +398,14 @@ LoadRootDirectory:
 		push eax
 
 		// Now that the inode has been read in load
-		// the root directory file data to 0000:8000
+		// the root directory file data to 0000:F800
 		call Ext2ReadEntireFile
 
-		// Since the root directory was loaded to 0000:8000
-		// then add 8000h to the root directory's size
+		// Since the root directory was loaded to 0000:F800
+		// then add F800h to the root directory's size
 		pop  eax
-		mov  edx, HEX(8000)					// Set EDX to the current offset in the root directory
-		add  eax,edx					// Initially add 8000h to the size of the root directory
+		mov  edx, HEX(F800)				// Set EDX to the current offset in the root directory
+		add  eax,edx					// Initially add F800h to the size of the root directory
 
 SearchRootDirectory:
 		push edx						// Save current offset in root directory
@@ -410,9 +420,9 @@ SearchRootDirectory:
 		mov  es,ax
 		mov  di,dx
 		push di							// Save the start of the directory entry
-		add  di, 8					// Add the offset to the filename
-		mov  si,filename
-		mov  cl,11
+		add  di, 8						// Add the offset to the filename
+		mov  si,offset msgFreeLdr		// Filename is contained in the message
+		mov  cx,11						// In first 11 bytes
 		repe cmpsb						// Compare the file names
 		pop  di
 		pop  eax
@@ -437,53 +447,66 @@ FoundFile:
 		pop  es
 		pop  di							// These were saved earlier
 
-		mov  cx, es:[di]					// Get the file mode so we can make sure it's a regular file
+		mov  cx, es:[di]				// Get the file mode so we can make sure it's a regular file
 		and  ch,EXT2_S_IFMT				// Mask off everything but the file type
 		cmp  ch,EXT2_S_IFREG			// Make sure it's a regular file
 		je   LoadFreeLoader
 		jmp  PrintRegFileError
 
 LoadFreeLoader:
-        mov  si,msgLoading				// "Loading FreeLoader..." message
-        call PutChars					// Display it
+		mov  si,offset msgLoading		// "Loading FreeLoader..." message
+		call PutChars					// Display it
 
-		call Ext2ReadEntireFile			// Read freeldr.sys to 0000:8000
+		call Ext2ReadEntireFile			// Read freeldr.sys to 0000:F800
 
-        mov  dl, byte ptr [bp+BootDrive]
-		mov  dh, byte ptr [bp+BootPartition]
-		push 0						// push segment (0x0000)
-		mov eax, [HEX(8000) + HEX(0A8)]	// load the RVA of the EntryPoint into eax
-		add eax, HEX(8000)				// RVA -> VA
-		push ax						// push offset
-		retf						// Transfer control to FreeLoader
+		mov  dl, byte ptr BP_REL(BootDrive)
+		mov  dh, byte ptr BP_REL(BootPartition)
+		/* Transfer execution to the bootloader */
+		ljmp16 0, FREELDR_BASE
 
 
 
 
 
-// Reads ext2 file data into [0000:8000]
+// Reads ext2 file data into [0000:F800]
 // This function assumes that the file's
 // inode has been read in to 6000:8000 *and*
 // ES:DI points to 6000:8000
 // This will load all the blocks up to
 // and including the double-indirect pointers.
 // This should be sufficient because it
-// allows for ~64MB which is much bigger
+// allows for ~64MB file which is much bigger
 // than we need for a boot loader.
+// Problem is that space in memory is "only"
+// 0000:F800-6000:8000 which is 362,496 bytes
+// 0000:F800 is the start address for freeldr
+// 6000:8000 is the space where inode data is read
+// 7000:0000-7000:8000 temporary data (indirect
+// list pointers that point to the actual sectors)
+// 7000:8000-8000:0000 temporary data (indirect
+// sector data to be moved to proper memory location)
+// MSVC currently produces 376,832 bytes
+// GCC  currently produces 346,112 bytes
+// for freeldr.sys so basically we either
+// have to "optimize" for space MSVC or
+// free some space by moving data reads up
+// (for example to 8000:0000 and 8000:8000)
+// I think at 9000:0000 something else starts
+// and we will have 460,800 bytes in memory
 Ext2ReadEntireFile:
 
 		// Reset the load segment
-		mov word ptr [bp+Ext2ReadEntireFileLoadSegment], HEX(800)
+		mov word ptr BP_REL(Ext2ReadEntireFileLoadSegment), FREELDR_BASE / 16
 
 		// Now we must calculate how
 		// many blocks to read in
 		// We will do this by rounding the
 		// file size up to the next block
 		// size and then dividing by the block size
-		mov  eax, dword ptr [bp+Ext2BlockSizeInBytes]		// Get the block size in bytes
+		mov  eax, dword ptr BP_REL(Ext2BlockSizeInBytes)	// Get the block size in bytes
 		push eax
 		dec  eax											// Ext2BlockSizeInBytes -= 1
-		add  eax, es:[di+4]							// Add the file size
+		add  eax, es:[di+4]									// Add the file size
 		xor  edx,edx
 		pop  ecx											// Divide by the block size in bytes
 		div  ecx											// EAX now contains the number of blocks to load
@@ -496,10 +519,10 @@ Ext2ReadEntireFile:
 
 Ext2ReadEntireFile2:
 		// Save the indirect & double indirect pointers
-		mov  edx, es:[di+ HEX(58)]							// Get indirect pointer
-		mov dword ptr [bp+Ext2InodeIndirectPointer], edx			// Save indirect pointer
-		mov  edx, es:[di+ HEX(5c)]							// Get double indirect pointer
-		mov dword ptr [bp+Ext2InodeDoubleIndirectPointer],edx	// Save double indirect pointer
+		mov  edx, dword ptr es:[di+ HEX(58)]						// Get indirect pointer
+		mov dword ptr BP_REL(Ext2InodeIndirectPointer), edx			// Save indirect pointer
+		mov  edx, dword ptr es:[di+ HEX(5c)]						// Get double indirect pointer
+		mov dword ptr BP_REL(Ext2InodeDoubleIndirectPointer),edx	// Save double indirect pointer
 
 		// Now copy the direct pointers to 7000:0000
 		// so that we can call Ext2ReadDirectBlocks
@@ -529,8 +552,8 @@ Ext2ReadEntireFile2:
 		// Now we have read all the direct blocks in
 		// the inode. So now we have to read the indirect
 		// block and read all it's direct blocks
-		push eax											// Save the total block count
-		mov  eax, dword ptr [bp+Ext2InodeIndirectPointer]	// Get the indirect block pointer
+		push eax												// Save the total block count
+		mov  eax, dword ptr BP_REL(Ext2InodeIndirectPointer)	// Get the indirect block pointer
 		push HEX(7000)
 		pop  es
 		xor  bx,bx											// Set the load address to 7000:0000
@@ -539,7 +562,7 @@ Ext2ReadEntireFile2:
 		// Now we have all the block pointers from the
 		// indirect block in the right location so read them in
 		pop  eax											// Restore the total block count
-		mov  ecx, dword ptr [bp+Ext2PointersPerBlock]		// Get the number of block pointers that one block contains
+		mov  ecx, dword ptr BP_REL(Ext2PointersPerBlock)	// Get the number of block pointers that one block contains
 		call Ext2ReadDirectBlockList
 
 		// Check to see if we actually have
@@ -552,8 +575,8 @@ Ext2ReadEntireFile2:
 		// we have to read the double indirect block
 		// and read all it's indirect blocks
 		// (whew, it's a good thing I don't support triple indirect blocks)
-		mov dword ptr [bp+Ext2BlocksLeftToRead],eax				// Save the total block count
-		mov eax, dword ptr [bp+Ext2InodeDoubleIndirectPointer]	// Get the double indirect block pointer
+		mov dword ptr BP_REL(Ext2BlocksLeftToRead),eax				// Save the total block count
+		mov eax, dword ptr BP_REL(Ext2InodeDoubleIndirectPointer)	// Get the double indirect block pointer
 		push HEX(7800)
 		pop  es
 		push es												// Save an extra copy of this value on the stack
@@ -576,10 +599,10 @@ Ext2ReadIndirectBlock:
 
 		// Now we have all the block pointers from the
 		// indirect block in the right location so read them in
-		mov  eax, dword ptr [bp+Ext2BlocksLeftToRead]		// Restore the total block count
-		mov  ecx, dword ptr [bp+Ext2PointersPerBlock]		// Get the number of block pointers that one block contains
+		mov  eax, dword ptr BP_REL(Ext2BlocksLeftToRead)		// Restore the total block count
+		mov  ecx, dword ptr BP_REL(Ext2PointersPerBlock)		// Get the number of block pointers that one block contains
 		call Ext2ReadDirectBlockList
-		mov  dword ptr [bp+Ext2BlocksLeftToRead],eax				// Save the total block count
+		mov  dword ptr BP_REL(Ext2BlocksLeftToRead),eax			// Save the total block count
 		pop  di
 		pop  es
 
@@ -622,17 +645,17 @@ Ext2ReadDirectBlocks:
 
 Ext2ReadDirectBlocksLoop:
 		mov  eax,es:[di]									// Get direct block pointer from array
-		add  di, 4										// Update DI for next array index
+		add  di, 4											// Update DI for next array index
 
 		push cx												// Save number of direct blocks left
 		push es												// Save array segment
 		push di												// Save array offset
-		mov  es,[bp+Ext2ReadEntireFileLoadSegment]
+		mov  es, word ptr BP_REL(Ext2ReadEntireFileLoadSegment)
 		xor  bx,bx											// Setup load address for next read
 
 		call Ext2ReadBlock									// Read the block (this updates ES for the next read)
 
-		mov  [bp+Ext2ReadEntireFileLoadSegment],es		// Save updated ES
+		mov  word ptr BP_REL(Ext2ReadEntireFileLoadSegment),es		// Save updated ES
 
 		pop  di												// Restore the array offset
 		pop  es												// Restore the array segment
@@ -650,21 +673,21 @@ Ext2ReadDirectBlocksLoop:
 // Displays a file not found error message
 // And reboots
 PrintFileNotFound:
-        mov  si,msgFreeLdr      // FreeLdr not found message
+        mov  si,offset msgFreeLdr      // FreeLdr not found message
 		jmp short DisplayItAndReboot
 
 // Displays a file size is 0 error
 // And reboots
 PrintFileSizeError:
-        mov  si,msgFileSize     // Error message
+        mov  si,offset msgFileSize     // Error message
 		jmp short DisplayItAndReboot
 
 // Displays a file is not a regular file error
 // And reboots
 PrintRegFileError:
-        mov  si,msgRegFile      // Error message
+        mov  si,offset msgRegFile      // Error message
 DisplayItAndReboot:
-        call PutChars           // Display it
+        call PutChars                  // Display it
 		jmp  Reboot
 
 msgFreeLdr:
@@ -672,9 +695,7 @@ msgFreeLdr:
 msgFileSize:
     .ascii "File size 0", NUL
 msgRegFile:
-    .ascii "freeldr.sys isnt a regular file", NUL
-filename:
-    .ascii "freeldr.sys"
+    .ascii "freeldr.sys isn't a regular file", NUL
 msgLoading:
     .ascii "Loading...", NUL
 

--- a/boot/freeldr/bootsect/ext2.S
+++ b/boot/freeldr/bootsect/ext2.S
@@ -8,11 +8,7 @@
 // [bp-0x10] Here we will store the number of LBA sectors read
 
 #include <asm.inc>
-#include <freeldr/include/arch/pc/x86common.h>
 .code16
-
-#define BP_REL(x) [bp+x-offset start]
-#define BP_REL_SP(x) [bp-x]
 
 SECTORS_PER_TRACK		= HEX(04)
 NUMBER_OF_HEADS			= HEX(08)
@@ -38,12 +34,12 @@ BootDrive:
 //SectorsPerTrack		db 63					// Moved to [bp-SECTORS_PER_TRACK]
 //NumberOfHeads			dw 16					// Moved to [bp-NUMBER_OF_HEADS]
 //BiosCHSDriveSize		dd (1024 * 1024 * 63)	// Moved to [bp-BIOS_CHS_DRIVE_SIZE]
-//LBASectorsRead		dd 0					// Moved to [bp-LBA_SECTORS_READ]
+//LBASectorsRead			dd 0					// Moved to [bp-LBA_SECTORS_READ]
 
 Ext2VolumeStartSector:
-	.long 63					// Start sector of the ext2 volume
+	.long 263088				// Start sector of the ext2 volume
 Ext2BlockSize:
-	.long 2						// Block size in sectors
+	.long 2					// Block size in sectors
 Ext2BlockSizeInBytes:
 	.long 1024					// Block size in bytes
 Ext2PointersPerBlock:
@@ -51,11 +47,11 @@ Ext2PointersPerBlock:
 Ext2GroupDescPerBlock:
 	.long 32					// Number of group descriptors per block
 Ext2FirstDataBlock:
-	.long 1						// First data block (1 for 1024-byte blocks, 0 for bigger sizes)
+	.long 1					// First data block (1 for 1024-byte blocks, 0 for bigger sizes)
 Ext2InodesPerGroup:
-	.long 1024					// Number of inodes per group
+	.long 2048					// Number of inodes per group
 Ext2InodesPerBlock:
-	.long 8						// Number of inodes per block
+	.long 8					// Number of inodes per block
 
 Ext2ReadEntireFileLoadSegment:
 	.word	0
@@ -75,17 +71,17 @@ main:
         mov sp, HEX(7b00)            // Setup a stack
 
         mov si, offset BootDrive
-		cmp byte ptr ds:[si], HEX(0ff)	// If they have specified a boot drive then use it
+		cmp byte ptr [si], HEX(0ff)	// If they have specified a boot drive then use it
 		jne GetDriveParameters
 
-        mov ds:[si],dl				// Save the boot drive
+        mov [si],dl				// Save the boot drive
 
 
 GetDriveParameters:
 		mov  ah, 8
-		mov  dl,ds:[si]				// Get boot drive in dl
-		int  HEX(13)				// Request drive parameters from the bios
-		jnc  CalcDriveSize			// If the call succeeded then calculate the drive size
+		mov  dl,[si]					// Get boot drive in dl
+		int  HEX(13)									// Request drive parameters from the bios
+		jnc  CalcDriveSize							// If the call succeeded then calculate the drive size
 
 		// If we get here then the call to the BIOS failed
 		// so just set CHS equal to the maximum addressable
@@ -99,21 +95,21 @@ CalcDriveSize:
 		mov  bl,ch								// Put the low 8-bits of the cylinder count into BL
 		mov  bh,cl								// Put the high 2-bits in BH
 		shr  bh,6								// Shift them into position, now BX contains the cylinder count
-		and  cl, HEX(3f)						// Mask off cylinder bits from sector count
+		and  cl, HEX(3f)								// Mask off cylinder bits from sector count
 		// CL now contains sectors per track and DH contains head count
 		movzx eax,dh							// Move the heads into EAX
 		movzx ebx,bx							// Move the cylinders into EBX
 		movzx ecx,cl							// Move the sectors per track into ECX
 		inc   eax								// Make it one based because the bios returns it zero based
-		mov   dword ptr BP_REL_SP(NUMBER_OF_HEADS),eax	// Save number of heads
-		mov   dword ptr BP_REL_SP(SECTORS_PER_TRACK),ecx	// Save number of sectors per track
+		mov   [bp-NUMBER_OF_HEADS],eax		// Save number of heads
+		mov   [bp-SECTORS_PER_TRACK],ecx	// Save number of sectors per track
 		inc   ebx								// Make the cylinder count one based also
 		mul   ecx								// Multiply heads with the sectors per track, result in edx:eax
 		mul   ebx								// Multiply the cylinders with (heads * sectors) [stored in edx:eax already]
 
 		// We now have the total number of sectors as reported
 		// by the bios in eax, so store it in our variable
-		mov   dword ptr BP_REL_SP(BIOS_CHS_DRIVE_SIZE),eax
+		mov   [bp-BIOS_CHS_DRIVE_SIZE],eax
 
 
 LoadExtraBootCode:
@@ -123,7 +119,7 @@ LoadExtraBootCode:
 		xor  eax,eax
 		inc  eax								// Read logical sector 1, EAX now = 1
 		mov  cx,1								// Read one sector
-		mov  bx, HEX(7e00)						// Read sector to [0000:7e00h]
+		mov  bx, HEX(7e00)							// Read sector to [0000:7e00h]
 		call ReadSectors
 
 		jmp  LoadRootDirectory
@@ -137,8 +133,8 @@ LoadExtraBootCode:
 Ext2ReadGroupDesc:
 		shl   eax,5										// Group = (Group * sizeof(GROUP_DESCRIPTOR) /* 32 */)
 		xor   edx,edx
-		div   dword ptr BP_REL(Ext2GroupDescPerBlock)	// Group = (Group / Ext2GroupDescPerBlock)
-		add   eax, dword ptr BP_REL(Ext2FirstDataBlock)	// Group = Group + Ext2FirstDataBlock + 1
+		div   dword ptr [bp+Ext2GroupDescPerBlock]		// Group = (Group / Ext2GroupDescPerBlock)
+		add   eax, dword ptr [bp+Ext2FirstDataBlock]	// Group = Group + Ext2FirstDataBlock + 1
 		inc   eax										// EAX now has the group descriptor block number
 														// EDX now has the group descriptor offset in the block
 
@@ -158,7 +154,7 @@ Ext2ReadGroupDesc:
 // Reads ext2 block into ES:[BX]
 // EAX has logical block number to read
 Ext2ReadBlock:
-		mov   ecx, dword ptr BP_REL(Ext2BlockSize)
+		mov   ecx, dword ptr [bp+Ext2BlockSize]
 		mul   ecx
 		jmp   ReadSectors
 
@@ -169,14 +165,11 @@ Ext2ReadBlock:
 Ext2ReadInode:
 		dec   eax										// Inode = Inode - 1
 		xor   edx,edx
-		div   dword ptr BP_REL(Ext2InodesPerGroup)		// Inode = (Inode / Ext2InodesPerGroup)
-		push  edx										// Push remainder of the division
-		mul   dword ptr BP_REL(Ext2InodesPerGroup)		// Group = Group * Ext2InodesPerGroup
-		mul   dword ptr BP_REL(Ext2InodesPerBlock)		// Group = Group * Ext2InodesPerBlock
-		mov   ebx,eax									// EBX now has the inode group block number
-		pop   eax										// Pop reminder in eax
-		// xor   edx,edx									// Skip 
-		div   dword ptr BP_REL(Ext2InodesPerBlock)		// Inode = (Inode / Ext2InodesPerBlock)
+		div   dword ptr [bp+Ext2InodesPerGroup]		// Inode = (Inode / Ext2InodesPerGroup)
+		mov   ebx,eax									// EBX now has the inode group number
+		mov   eax,edx
+		xor   edx,edx
+		div   dword ptr [bp+Ext2InodesPerBlock]		// Inode = (Inode / Ext2InodesPerBlock)
 		shl   edx,7										// FIXME: InodeOffset *= 128 (make the array index a byte offset)
 														// EAX now has the inode offset block number from inode table
 														// EDX now has the inode offset in the block
@@ -186,9 +179,7 @@ Ext2ReadInode:
 		push  edx
 		push  eax
 		mov   eax,ebx
-		push  ebx
 		call  Ext2ReadGroupDesc
-		pop   ebx
 
 		// Group descriptor has been read, now
 		// grab the inode table block number from it
@@ -196,8 +187,7 @@ Ext2ReadInode:
 		pop   es
 		mov   di, HEX(8008)
 		pop   eax										// Restore inode offset block number from stack
-		add   eax, ebx									// Add the group start block number
-		add   eax, es:[di]								// Add the inode table start block
+		add   eax, es:[di]							// Add the inode table start block
 
 		// Adjust the read offset so that the
 		// inode we want is read to 6000:8000
@@ -216,8 +206,8 @@ Ext2ReadInode:
 // EAX has logical sector number to read
 // CX has number of sectors to read
 ReadSectors:
-        add  eax, dword ptr BP_REL(Ext2VolumeStartSector)	// Add the start of the volume
-		cmp  eax, dword ptr BP_REL_SP(BIOS_CHS_DRIVE_SIZE)	// Check if they are reading a sector outside CHS range
+        add  eax, dword ptr [bp+Ext2VolumeStartSector]	// Add the start of the volume
+		cmp  eax, [bp-BIOS_CHS_DRIVE_SIZE]		// Check if they are reading a sector outside CHS range
 		jae  ReadSectorsLBA						// Yes - go to the LBA routine
 												// If at all possible we want to use LBA routines because
 												// They are optimized to read more than 1 sector per read
@@ -227,7 +217,7 @@ ReadSectors:
 CheckInt13hExtensions:							// Now check if this computer supports extended reads
 		mov  ah, HEX(41)						// AH = 41h
 		mov  bx, HEX(55aa)						// BX = 55AAh
-		mov  dl, byte ptr BP_REL(BootDrive)		// DL = drive (80h-FFh)
+		mov  dl, byte ptr [bp+BootDrive]					// DL = drive (80h-FFh)
 		int  HEX(13)							// IBM/MS INT 13 Extensions - INSTALLATION CHECK
 		jc   ReadSectorsCHS						// CF set on error (extensions not supported)
 		cmp  bx, HEX(0aa55)						// BX = AA55h if installed
@@ -240,13 +230,13 @@ CheckInt13hExtensions:							// Now check if this computer supports extended rea
 ReadSectorsLBA:
 		pushad									// Save logical sector number & sector count
 
-		cmp  cx, 64								// Since the LBA calls only support 0x7F sectors at a time we will limit ourselves to 64
+		cmp  cx, 64							// Since the LBA calls only support 0x7F sectors at a time we will limit ourselves to 64
 		jbe  ReadSectorsSetupDiskAddressPacket	// If we are reading less than 65 sectors then just do the read
 		mov  cx,64								// Otherwise read only 64 sectors on this loop iteration
 
 ReadSectorsSetupDiskAddressPacket:
-		mov  word ptr BP_REL_SP(LBA_SECTORS_READ),cx
-		mov  word ptr BP_REL_SP(LBA_SECTORS_READ+2),0
+		mov  [bp-LBA_SECTORS_READ],cx
+		mov  word ptr [bp-LBA_SECTORS_READ+2],0
 		data32 push 0
 		push eax								// Put 64-bit logical block address on stack
 		push es									// Put transfer segment on stack
@@ -256,9 +246,9 @@ ReadSectorsSetupDiskAddressPacket:
 		mov  si,sp								// Setup disk address packet on stack
 
 
-        mov  dl, byte ptr BP_REL(BootDrive)		// Drive number
-		mov  ah, HEX(42)						// Int 13h, AH = 42h - Extended Read
-		int  HEX(13)							// Call BIOS
+        mov  dl, byte ptr [bp+BootDrive]					// Drive number
+		mov  ah, HEX(42)								// Int 13h, AH = 42h - Extended Read
+		int  HEX(13)								// Call BIOS
 		jc   PrintDiskError						// If the read failed then abort
 
 		add  sp, 16								// Remove disk address packet from stack
@@ -266,7 +256,7 @@ ReadSectorsSetupDiskAddressPacket:
 		popad									// Restore sector count & logical sector number
 
 		push bx
-		mov  ebx, dword ptr BP_REL_SP(LBA_SECTORS_READ)
+		mov  ebx, [bp-LBA_SECTORS_READ]
         add  eax,ebx							// Increment sector to read
 		shl  ebx,5
         mov  dx,es
@@ -274,7 +264,7 @@ ReadSectorsSetupDiskAddressPacket:
         mov  es,dx
 		pop  bx
 
-		sub  cx,word ptr BP_REL_SP(LBA_SECTORS_READ)
+		sub  cx,[bp-LBA_SECTORS_READ]
         jnz  ReadSectorsLBA						// Read next sector
 
         ret
@@ -289,15 +279,15 @@ ReadSectorsCHS:
 ReadSectorsCHSLoop:
         pushad
         xor   edx,edx
-		mov   ecx, dword ptr BP_REL_SP(SECTORS_PER_TRACK)
+		mov   ecx, [bp-SECTORS_PER_TRACK]
 		div   ecx									// Divide logical by SectorsPerTrack
         inc   dl									// Sectors numbering starts at 1 not 0
 		mov   cl,dl									// Sector in CL
 		mov   edx,eax
 		shr   edx,16
-        div   word ptr BP_REL_SP(NUMBER_OF_HEADS)	// Divide logical by number of heads
+        div   word ptr [bp-NUMBER_OF_HEADS]		// Divide logical by number of heads
         mov   dh,dl									// Head in DH
-        mov   dl, byte ptr BP_REL(BootDrive)		// Drive number in DL
+        mov   dl, byte ptr [bp+BootDrive]				// Drive number in DL
         mov   ch,al									// Cylinder in CX
         ror   ah,2									// Low 8 bits of cylinder in CH, high 2 bits
                 									//  in CL shifted to bits 6 & 7
@@ -328,12 +318,12 @@ ReadSectorsCHSLoop:
 // Displays a disk error message
 // And reboots
 PrintDiskError:
-        mov  si,offset msgDiskError			// Bad boot disk message
-        call PutChars						// Display it
+        mov  si,msgDiskError			// Bad boot disk message
+        call PutChars					// Display it
 
 Reboot:
-        mov  si,offset msgAnyKey			// Press any key message
-        call PutChars						// Display it
+        mov  si,msgAnyKey				// Press any key message
+        call PutChars					// Display it
         xor ax,ax
         int HEX(16)							// Wait for a keypress
         int HEX(19)							// Reboot
@@ -359,11 +349,11 @@ Done:
 
 
 msgDiskError:
-    .ascii "Err", NUL
+    .ascii "Disk error", NUL
 // Sorry, need the space...
 //msgAnyKey			db 'Press any key to restart',0
 msgAnyKey:
-    .ascii "Key", NUL
+    .ascii "Press key", NUL
 
 //    times 509-($-$$) db 0   // Pad to 509 bytes
     .org 509
@@ -398,14 +388,14 @@ LoadRootDirectory:
 		push eax
 
 		// Now that the inode has been read in load
-		// the root directory file data to 0000:F800
+		// the root directory file data to 0000:8000
 		call Ext2ReadEntireFile
 
-		// Since the root directory was loaded to 0000:F800
-		// then add F800h to the root directory's size
+		// Since the root directory was loaded to 0000:8000
+		// then add 8000h to the root directory's size
 		pop  eax
-		mov  edx, HEX(F800)				// Set EDX to the current offset in the root directory
-		add  eax,edx					// Initially add F800h to the size of the root directory
+		mov  edx, HEX(8000)					// Set EDX to the current offset in the root directory
+		add  eax,edx					// Initially add 8000h to the size of the root directory
 
 SearchRootDirectory:
 		push edx						// Save current offset in root directory
@@ -420,9 +410,9 @@ SearchRootDirectory:
 		mov  es,ax
 		mov  di,dx
 		push di							// Save the start of the directory entry
-		add  di, 8						// Add the offset to the filename
-		mov  si,offset msgFreeLdr		// Filename is contained in the message
-		mov  cx,11						// In first 11 bytes
+		add  di, 8					// Add the offset to the filename
+		mov  si,filename
+		mov  cl,11
 		repe cmpsb						// Compare the file names
 		pop  di
 		pop  eax
@@ -447,66 +437,53 @@ FoundFile:
 		pop  es
 		pop  di							// These were saved earlier
 
-		mov  cx, es:[di]				// Get the file mode so we can make sure it's a regular file
+		mov  cx, es:[di]					// Get the file mode so we can make sure it's a regular file
 		and  ch,EXT2_S_IFMT				// Mask off everything but the file type
 		cmp  ch,EXT2_S_IFREG			// Make sure it's a regular file
 		je   LoadFreeLoader
 		jmp  PrintRegFileError
 
 LoadFreeLoader:
-		mov  si,offset msgLoading		// "Loading FreeLoader..." message
-		call PutChars					// Display it
+        mov  si,msgLoading				// "Loading FreeLoader..." message
+        call PutChars					// Display it
 
-		call Ext2ReadEntireFile			// Read freeldr.sys to 0000:F800
+		call Ext2ReadEntireFile			// Read freeldr.sys to 0000:8000
 
-		mov  dl, byte ptr BP_REL(BootDrive)
-		mov  dh, byte ptr BP_REL(BootPartition)
-		/* Transfer execution to the bootloader */
-		ljmp16 0, FREELDR_BASE
+        mov  dl, byte ptr [bp+BootDrive]
+		mov  dh, byte ptr [bp+BootPartition]
+		push 0						// push segment (0x0000)
+		mov eax, [HEX(8000) + HEX(0A8)]	// load the RVA of the EntryPoint into eax
+		add eax, HEX(8000)				// RVA -> VA
+		push ax						// push offset
+		retf						// Transfer control to FreeLoader
 
 
 
 
 
-// Reads ext2 file data into [0000:F800]
+// Reads ext2 file data into [0000:8000]
 // This function assumes that the file's
 // inode has been read in to 6000:8000 *and*
 // ES:DI points to 6000:8000
 // This will load all the blocks up to
 // and including the double-indirect pointers.
 // This should be sufficient because it
-// allows for ~64MB file which is much bigger
+// allows for ~64MB which is much bigger
 // than we need for a boot loader.
-// Problem is that space in memory is "only"
-// 0000:F800-6000:8000 which is 362,496 bytes
-// 0000:F800 is the start address for freeldr
-// 6000:8000 is the space where inode data is read
-// 7000:0000-7000:8000 temporary data (indirect
-// list pointers that point to the actual sectors)
-// 7000:8000-8000:0000 temporary data (indirect
-// sector data to be moved to proper memory location)
-// MSVC currently produces 376,832 bytes
-// GCC  currently produces 346,112 bytes
-// for freeldr.sys so basically we either
-// have to "optimize" for space MSVC or
-// free some space by moving data reads up
-// (for example to 8000:0000 and 8000:8000)
-// I think at 9000:0000 something else starts
-// and we will have 460,800 bytes in memory
 Ext2ReadEntireFile:
 
 		// Reset the load segment
-		mov word ptr BP_REL(Ext2ReadEntireFileLoadSegment), FREELDR_BASE / 16
+		mov word ptr [bp+Ext2ReadEntireFileLoadSegment], HEX(800)
 
 		// Now we must calculate how
 		// many blocks to read in
 		// We will do this by rounding the
 		// file size up to the next block
 		// size and then dividing by the block size
-		mov  eax, dword ptr BP_REL(Ext2BlockSizeInBytes)	// Get the block size in bytes
+		mov  eax, dword ptr [bp+Ext2BlockSizeInBytes]		// Get the block size in bytes
 		push eax
 		dec  eax											// Ext2BlockSizeInBytes -= 1
-		add  eax, es:[di+4]									// Add the file size
+		add  eax, es:[di+4]							// Add the file size
 		xor  edx,edx
 		pop  ecx											// Divide by the block size in bytes
 		div  ecx											// EAX now contains the number of blocks to load
@@ -519,10 +496,10 @@ Ext2ReadEntireFile:
 
 Ext2ReadEntireFile2:
 		// Save the indirect & double indirect pointers
-		mov  edx, dword ptr es:[di+ HEX(58)]						// Get indirect pointer
-		mov dword ptr BP_REL(Ext2InodeIndirectPointer), edx			// Save indirect pointer
-		mov  edx, dword ptr es:[di+ HEX(5c)]						// Get double indirect pointer
-		mov dword ptr BP_REL(Ext2InodeDoubleIndirectPointer),edx	// Save double indirect pointer
+		mov  edx, es:[di+ HEX(58)]							// Get indirect pointer
+		mov dword ptr [bp+Ext2InodeIndirectPointer], edx			// Save indirect pointer
+		mov  edx, es:[di+ HEX(5c)]							// Get double indirect pointer
+		mov dword ptr [bp+Ext2InodeDoubleIndirectPointer],edx	// Save double indirect pointer
 
 		// Now copy the direct pointers to 7000:0000
 		// so that we can call Ext2ReadDirectBlocks
@@ -552,8 +529,8 @@ Ext2ReadEntireFile2:
 		// Now we have read all the direct blocks in
 		// the inode. So now we have to read the indirect
 		// block and read all it's direct blocks
-		push eax												// Save the total block count
-		mov  eax, dword ptr BP_REL(Ext2InodeIndirectPointer)	// Get the indirect block pointer
+		push eax											// Save the total block count
+		mov  eax, dword ptr [bp+Ext2InodeIndirectPointer]	// Get the indirect block pointer
 		push HEX(7000)
 		pop  es
 		xor  bx,bx											// Set the load address to 7000:0000
@@ -562,7 +539,7 @@ Ext2ReadEntireFile2:
 		// Now we have all the block pointers from the
 		// indirect block in the right location so read them in
 		pop  eax											// Restore the total block count
-		mov  ecx, dword ptr BP_REL(Ext2PointersPerBlock)	// Get the number of block pointers that one block contains
+		mov  ecx, dword ptr [bp+Ext2PointersPerBlock]		// Get the number of block pointers that one block contains
 		call Ext2ReadDirectBlockList
 
 		// Check to see if we actually have
@@ -575,8 +552,8 @@ Ext2ReadEntireFile2:
 		// we have to read the double indirect block
 		// and read all it's indirect blocks
 		// (whew, it's a good thing I don't support triple indirect blocks)
-		mov dword ptr BP_REL(Ext2BlocksLeftToRead),eax				// Save the total block count
-		mov eax, dword ptr BP_REL(Ext2InodeDoubleIndirectPointer)	// Get the double indirect block pointer
+		mov dword ptr [bp+Ext2BlocksLeftToRead],eax				// Save the total block count
+		mov eax, dword ptr [bp+Ext2InodeDoubleIndirectPointer]	// Get the double indirect block pointer
 		push HEX(7800)
 		pop  es
 		push es												// Save an extra copy of this value on the stack
@@ -599,10 +576,10 @@ Ext2ReadIndirectBlock:
 
 		// Now we have all the block pointers from the
 		// indirect block in the right location so read them in
-		mov  eax, dword ptr BP_REL(Ext2BlocksLeftToRead)		// Restore the total block count
-		mov  ecx, dword ptr BP_REL(Ext2PointersPerBlock)		// Get the number of block pointers that one block contains
+		mov  eax, dword ptr [bp+Ext2BlocksLeftToRead]		// Restore the total block count
+		mov  ecx, dword ptr [bp+Ext2PointersPerBlock]		// Get the number of block pointers that one block contains
 		call Ext2ReadDirectBlockList
-		mov  dword ptr BP_REL(Ext2BlocksLeftToRead),eax			// Save the total block count
+		mov  dword ptr [bp+Ext2BlocksLeftToRead],eax				// Save the total block count
 		pop  di
 		pop  es
 
@@ -645,17 +622,17 @@ Ext2ReadDirectBlocks:
 
 Ext2ReadDirectBlocksLoop:
 		mov  eax,es:[di]									// Get direct block pointer from array
-		add  di, 4											// Update DI for next array index
+		add  di, 4										// Update DI for next array index
 
 		push cx												// Save number of direct blocks left
 		push es												// Save array segment
 		push di												// Save array offset
-		mov  es, word ptr BP_REL(Ext2ReadEntireFileLoadSegment)
+		mov  es,[bp+Ext2ReadEntireFileLoadSegment]
 		xor  bx,bx											// Setup load address for next read
 
 		call Ext2ReadBlock									// Read the block (this updates ES for the next read)
 
-		mov  word ptr BP_REL(Ext2ReadEntireFileLoadSegment),es		// Save updated ES
+		mov  [bp+Ext2ReadEntireFileLoadSegment],es		// Save updated ES
 
 		pop  di												// Restore the array offset
 		pop  es												// Restore the array segment
@@ -673,21 +650,21 @@ Ext2ReadDirectBlocksLoop:
 // Displays a file not found error message
 // And reboots
 PrintFileNotFound:
-        mov  si,offset msgFreeLdr      // FreeLdr not found message
+        mov  si,msgFreeLdr      // FreeLdr not found message
 		jmp short DisplayItAndReboot
 
 // Displays a file size is 0 error
 // And reboots
 PrintFileSizeError:
-        mov  si,offset msgFileSize     // Error message
+        mov  si,msgFileSize     // Error message
 		jmp short DisplayItAndReboot
 
 // Displays a file is not a regular file error
 // And reboots
 PrintRegFileError:
-        mov  si,offset msgRegFile      // Error message
+        mov  si,msgRegFile      // Error message
 DisplayItAndReboot:
-        call PutChars                  // Display it
+        call PutChars           // Display it
 		jmp  Reboot
 
 msgFreeLdr:
@@ -695,7 +672,9 @@ msgFreeLdr:
 msgFileSize:
     .ascii "File size 0", NUL
 msgRegFile:
-    .ascii "freeldr.sys isn't a regular file", NUL
+    .ascii "freeldr.sys isnt a regular file", NUL
+filename:
+    .ascii "freeldr.sys"
 msgLoading:
     .ascii "Loading...", NUL
 

--- a/drivers/filesystems/ext2/CMakeLists.txt
+++ b/drivers/filesystems/ext2/CMakeLists.txt
@@ -113,5 +113,5 @@ set_module_type(ext2fs kernelmodedriver)
 add_importlibs(ext2fs ntoskrnl hal)
 add_pch(ext2fs inc/ext2fs.h SOURCE)
 
-add_cd_file(TARGET ext2fs DESTINATION reactos/system32/drivers FOR all)
+add_cd_file(TARGET ext2fs DESTINATION reactos/system32/drivers NO_CAB FOR all)
 add_registry_inf(ext2fs_reg.inf)


### PR DESCRIPTION
## Purpose

add the possibility to install ReactOS on an ext2 partition. 
Entirely based on the patch provided in the JIRA issue, rebased and adapted to the latest changes in the setup.

JIRA issue: [CORE-14235](https://jira.reactos.org/browse/CORE-14235)

## Proposed changes

- add ext2 driver as part of the boot/setup image
- add support in the setup to install ext2 bootcode

![Screenshot from 2024-10-11 22-46-01](https://github.com/user-attachments/assets/b9ba3252-54d7-460d-b7d8-c3a93486f218)


## TODO

_Use a TODO when your pull request is Work in Progress._

- [X] correctly detect ext2 partition in setup
- [X] correctly install the OS on a ext2 partition (no corruption, etc...)
- [ ] fix bootcode/reach Freeldr entry menu <= that's where I'm currently stuck
- [ ] reach UI setup/desktop
- [ ] investigate if [install script](https://github.com/reactos/reactos/blob/master/boot/freeldr/install/linux/finstext2.c) is still relevant 