### PR TITLE
[VERSION] Fix VerQueryValue when return Value is NULL.

### DIFF
--- a/dll/win32/version/version.c
+++ b/dll/win32/version/version.c
@@ -979,6 +979,14 @@ static BOOL VersionInfo32_QueryValue( const VS_VERSION_INFO_STRUCT32 *info, LPCW
 
     /* Return value */
     *lplpBuffer = VersionInfo32_Value( info );
+
+#ifdef __REACTOS__
+    /* If the wValueLength is zero, then set a UNICODE_NULL only return string.
+     * Use the NULL terminator from the key string for that. This is what Windows does, too. */
+    if (!info->wValueLength)
+      *lplpBuffer = (PVOID)(info->szKey + wcslen(info->szKey));
+#endif
+
     if (puLen)
         *puLen = info->wValueLength;
     if (pbText)


### PR DESCRIPTION
CORE-19783
Co-authored-by: Timo Kreuzer <timo.kreuzer@reactos.org>

## Purpose

_Fix VerQueryValueW that returns bad Value data when it should return NULL._

JIRA issue: [CORE-19783](https://jira.reactos.org/browse/CORE-19783)

## Proposed changes

_If the wValueLength is zero, then set a UNICODE_NULL only return string._
_Use the NULL terminator from the key string for that. This is what Windows does, too._