### PR TITLE
[SHELL32] Exclude executable extensions from File Types dialog

### DIFF
--- a/dll/win32/shell32/dialogs/filetypes.cpp
+++ b/dll/win32/shell32/dialogs/filetypes.cpp
@@ -745,7 +745,7 @@ FileTypesDlg_InsertToLV(HWND hListView, LPCWSTR Assoc, INT iItem, PFILE_TYPE_GLO
     {
         if (PathIsExeW(Assoc))
         {
-        exclude:
+exclude:
             HeapFree(pG->hHeap, 0, Entry);
             RegCloseKey(hKey);
             return NULL;
@@ -764,17 +764,13 @@ FileTypesDlg_InsertToLV(HWND hListView, LPCWSTR Assoc, INT iItem, PFILE_TYPE_GLO
         }
 #else
         if (!Entry->ClassKey[0])
-        {
             goto exclude;
-        }
 #endif
     }
 
     Entry->EditFlags = GetRegDWORD(hKey, L"EditFlags", 0);
     if (Entry->EditFlags & FTA_Exclude)
-    {
         goto exclude;
-    }
 
     wcscpy(Entry->FileExtension, Assoc);
 


### PR DESCRIPTION
PathIsExeW is used and will exclude exe, com, pif, cmd, bat, scf and scr. The previous #6122 PR added support for the FTA_Exclude flag and that will exclude .lnk files.

[before_PR7452.webm](https://github.com/user-attachments/assets/235fa69d-de20-4fa5-b400-c091c65631f9)

JIRA issue: [CORE-19805](https://jira.reactos.org/browse/CORE-19805)