### PR TITLE
[SDK] Import MIT-licensed WDDM headers from libdxg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,6 +233,8 @@ Enable this if the module uses typeid or dynamic_cast. You will probably need to
                     -D_WIN32_WINDOWS=0x502
                     -D_SETUPAPI_VER=0x502
                     -DMINGW_HAS_SECURE_API=1
+                    -DD3D_UMD_INTERFACE_VERSION=0x000C # Vista
+                    -DDXGKDDI_INTERFACE_VERSION=0x1052 # Vista
                     -DDLL_EXPORT_VERSION=${DLL_EXPORT_VERSION})
 
     # Arch Options

--- a/media/doc/3rd Party Files.txt
+++ b/media/doc/3rd Party Files.txt
@@ -295,3 +295,11 @@ Path: modules/rosapps/lib/vfdlib
 Used Version: 2.1.2008.206
 License: GPL-2.0 (https://spdx.org/licenses/GPL-2.0.html)
 URL: https://vfd.sourceforge.net/
+
+Title: libdxg - WDDM Headers
+Path: sdk/include/psdk/d3dukmdt.h
+Path: sdk/include/psdk/d3dkmdt.h
+Path: sdk/include/ddk/d3dkmthk.h
+Used Version: git commit 045831e
+License: MIT (https://spdx.org/licenses/MIT.html)
+URL: https://github.com/microsoft/libdxg

--- a/sdk/cmake/gcc.cmake
+++ b/sdk/cmake/gcc.cmake
@@ -50,6 +50,7 @@ add_compile_options(-mlong-double-64)
 add_compile_options("$<$<NOT:$<COMPILE_LANGUAGE:CXX>>:-nostdinc>")
 
 if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+    add_compile_options("-Wno-unknown-pragmas")
     add_compile_options(-fno-aggressive-loop-optimizations)
     if (DBG)
         add_compile_options("$<$<COMPILE_LANGUAGE:C>:-Wold-style-declaration>")

--- a/sdk/include/ddk/d3dkmthk.h
+++ b/sdk/include/ddk/d3dkmthk.h
@@ -1,55 +1,6036 @@
-/*
- * Copyright 2016 Henri Verbeet for CodeWeavers
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
- */
+/******************************Module*Header**********************************\
+*
+* Module Name: d3dkmthk.h
+*
+* Content: Windows Display Driver Model (WDDM) kernel mode thunk interfaces
+*
+* Copyright (c) Microsoft Corporation.
+* Licensed under the MIT License.
+*
+\*****************************************************************************/
+#ifndef _D3DKMTHK_H_
+#define _D3DKMTHK_H_
 
-#ifndef __WINE_D3DKMTHK_H
-#define __WINE_D3DKMTHK_H
+#include <d3dkmdt.h>
 
-#include <d3dukmdt.h>
+#pragma region Desktop Family
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+
+#pragma warning(push)
+#pragma warning(disable:4201) // anonymous unions warning
+#pragma warning(disable:4200) // zero-sized array in struct/union
+#pragma warning(disable:4214)   // nonstandard extension used: bit field types other than int
+
+
+typedef struct _OBJECT_ATTRIBUTES OBJECT_ATTRIBUTES;
+typedef OBJECT_ATTRIBUTES *POBJECT_ATTRIBUTES;
+
+//
+// Available only for Vista (LONGHORN) and later and for
+// multiplatform tools such as debugger extensions
+//
+#if (NTDDI_VERSION >= NTDDI_LONGHORN) || defined(D3DKMDT_SPECIAL_MULTIPLATFORM_TOOL)
+
+typedef struct _D3DKMT_CREATEDEVICEFLAGS
+{
+    UINT    LegacyMode               :  1;   // 0x00000001
+    UINT    RequestVSync             :  1;   // 0x00000002
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8)
+    UINT    DisableGpuTimeout        :  1;   // 0x00000004
+    UINT    Reserved                 : 29;   // 0xFFFFFFF8
+#else
+    UINT    Reserved                 : 30;   // 0xFFFFFFFC
+#endif
+} D3DKMT_CREATEDEVICEFLAGS;
+
+typedef struct _D3DKMT_CREATEDEVICE
+{
+    union
+    {
+        D3DKMT_HANDLE           hAdapter;           // in: identifies the adapter for user-mode creation
+        VOID*                   pAdapter;           // in: identifies the adapter for kernel-mode creation
+        D3DKMT_PTR_HELPER(pAdapter_Align)
+    };
+
+    D3DKMT_CREATEDEVICEFLAGS    Flags;
+
+    D3DKMT_HANDLE               hDevice;                // out: Identifies the device
+    D3DKMT_PTR(VOID*,           pCommandBuffer);        // out: D3D10 compatibility.
+    UINT                        CommandBufferSize;      // out: D3D10 compatibility.
+    D3DKMT_PTR(D3DDDI_ALLOCATIONLIST*, pAllocationList); // out: D3D10 compatibility.
+    UINT                        AllocationListSize;     // out: D3D10 compatibility.
+    D3DKMT_PTR(D3DDDI_PATCHLOCATIONLIST*, pPatchLocationList); // out: D3D10 compatibility.
+    UINT                        PatchLocationListSize;  // out: D3D10 compatibility.
+} D3DKMT_CREATEDEVICE;
+
+typedef struct _D3DKMT_DESTROYDEVICE
+{
+    D3DKMT_HANDLE     hDevice;              // in: Indentifies the device
+}D3DKMT_DESTROYDEVICE;
+
+typedef enum _D3DKMT_CLIENTHINT
+{
+    D3DKMT_CLIENTHINT_UNKNOWN        = 0,
+    D3DKMT_CLIENTHINT_OPENGL         = 1,
+    D3DKMT_CLIENTHINT_CDD            = 2,       // Internal
+    D3DKMT_CLIENTHINT_OPENCL         = 3,
+    D3DKMT_CLIENTHINT_VULKAN         = 4,
+    D3DKMT_CLIENTHINT_CUDA           = 5,
+    D3DKMT_CLIENTHINT_RESERVED       = 6,
+    D3DKMT_CLIENTHINT_DX7            = 7,
+    D3DKMT_CLIENTHINT_DX8            = 8,
+    D3DKMT_CLIENTHINT_DX9            = 9,
+    D3DKMT_CLIENTHINT_DX10           = 10,
+    D3DKMT_CLIENTHINT_DX11           = 11,
+    D3DKMT_CLIENTHINT_DX12           = 12,
+    D3DKMT_CLIENTHINT_9ON12          = 13,
+    D3DKMT_CLIENTHINT_11ON12         = 14,
+    D3DKMT_CLIENTHINT_MFT_ENCODE     = 15,
+    D3DKMT_CLIENTHINT_GLON12         = 16,
+    D3DKMT_CLIENTHINT_CLON12         = 17,
+    D3DKMT_CLIENTHINT_DML_TENSORFLOW = 18,
+    D3DKMT_CLIENTHINT_ONEAPI_LEVEL0  = 19,
+    D3DKMT_CLIENTHINT_MAX
+} D3DKMT_CLIENTHINT;
+
+typedef struct _D3DKMT_CREATECONTEXT
+{
+    D3DKMT_HANDLE               hDevice;                    // in:  Handle to the device owning this context.
+    UINT                        NodeOrdinal;                // in:  Identifier for the node targetted by this context.
+    UINT                        EngineAffinity;             // in:  Engine affinity within the specified node.
+    D3DDDI_CREATECONTEXTFLAGS   Flags;                      // in:  Context creation flags.
+    D3DKMT_PTR(VOID*,           pPrivateDriverData);        // in:  Private driver data
+    UINT                        PrivateDriverDataSize;      // in:  Size of private driver data
+    D3DKMT_CLIENTHINT           ClientHint;                 // in:  Hints which client is creating this
+    D3DKMT_HANDLE               hContext;                   // out: Handle of the created context.
+    D3DKMT_PTR(VOID*,           pCommandBuffer);            // out: Pointer to the first command buffer.
+    UINT                        CommandBufferSize;          // out: Command buffer size (bytes).
+    D3DKMT_PTR(D3DDDI_ALLOCATIONLIST*, pAllocationList);    // out: Pointer to the first allocation list.
+    UINT                        AllocationListSize;         // out: Allocation list size (elements).
+    D3DKMT_PTR(D3DDDI_PATCHLOCATIONLIST*, pPatchLocationList); // out: Pointer to the first patch location list.
+    UINT                        PatchLocationListSize;      // out: Patch location list size (elements).
+    D3DGPU_VIRTUAL_ADDRESS      CommandBuffer;              // out: GPU virtual address of the command buffer. _ADVSCH_
+} D3DKMT_CREATECONTEXT;
+
+typedef struct _D3DKMT_DESTROYCONTEXT
+{
+    D3DKMT_HANDLE               hContext;                   // in:  Identifies the context being destroyed.
+} D3DKMT_DESTROYCONTEXT;
+
+typedef struct _D3DKMT_CREATESYNCHRONIZATIONOBJECT
+{
+    D3DKMT_HANDLE                           hDevice;        // in:  Handle to the device.
+    D3DDDI_SYNCHRONIZATIONOBJECTINFO        Info;           // in:  Attributes of the synchronization object.
+    D3DKMT_HANDLE                           hSyncObject;    // out: Handle to the synchronization object created.
+} D3DKMT_CREATESYNCHRONIZATIONOBJECT;
+
+typedef struct _D3DKMT_CREATESYNCHRONIZATIONOBJECT2
+{
+    D3DKMT_HANDLE                           hDevice;        // in:  Handle to the device.
+    D3DDDI_SYNCHRONIZATIONOBJECTINFO2       Info;           // in/out: Attributes of the synchronization object.
+    D3DKMT_HANDLE                           hSyncObject;    // out: Handle to the synchronization object created.
+} D3DKMT_CREATESYNCHRONIZATIONOBJECT2;
+
+typedef struct _D3DKMT_DESTROYSYNCHRONIZATIONOBJECT
+{
+    D3DKMT_HANDLE               hSyncObject;                // in:  Identifies the synchronization objects being destroyed.
+} D3DKMT_DESTROYSYNCHRONIZATIONOBJECT;
+
+typedef struct _D3DKMT_OPENSYNCHRONIZATIONOBJECT
+{
+    D3DKMT_HANDLE               hSharedHandle;              // in: shared handle to synchronization object to be opened.
+    D3DKMT_HANDLE               hSyncObject;                // out: Handle to sync object in this process.
+
+    D3DKMT_ALIGN64 UINT64       Reserved[8];
+} D3DKMT_OPENSYNCHRONIZATIONOBJECT;
+
+typedef struct _D3DKMT_WAITFORSYNCHRONIZATIONOBJECT
+{
+    D3DKMT_HANDLE             hContext;                   // in: Identifies the context that needs to wait.
+    UINT                      ObjectCount;                // in: Specifies the number of object to wait on.
+    D3DKMT_HANDLE             ObjectHandleArray[D3DDDI_MAX_OBJECT_WAITED_ON]; // in: Specifies the object to wait on.
+} D3DKMT_WAITFORSYNCHRONIZATIONOBJECT;
+
+typedef struct _D3DKMT_WAITFORSYNCHRONIZATIONOBJECT2
+{
+    D3DKMT_HANDLE             hContext;                   // in: Identifies the context that needs to wait.
+    UINT                      ObjectCount;                // in: Specifies the number of object to wait on.
+    D3DKMT_HANDLE             ObjectHandleArray[D3DDDI_MAX_OBJECT_WAITED_ON]; // in: Specifies the object to wait on.
+    union
+    {
+        struct {
+            D3DKMT_ALIGN64 UINT64 FenceValue;             // in: fence value to be waited.
+        } Fence;
+        D3DKMT_ALIGN64 UINT64     Reserved[8];
+    };
+} D3DKMT_WAITFORSYNCHRONIZATIONOBJECT2;
+
+typedef struct _D3DKMT_SIGNALSYNCHRONIZATIONOBJECT
+{
+    D3DKMT_HANDLE             hContext;           // in: Identifies the context that needs to signal.
+    UINT                      ObjectCount;        // in: Specifies the number of object to signal.
+    D3DKMT_HANDLE             ObjectHandleArray[D3DDDI_MAX_OBJECT_SIGNALED]; // in: Specifies the object to be signaled.
+    D3DDDICB_SIGNALFLAGS      Flags;                                         // in: Specifies signal behavior.
+} D3DKMT_SIGNALSYNCHRONIZATIONOBJECT;
+
+typedef struct _D3DKMT_SIGNALSYNCHRONIZATIONOBJECT2
+{
+    D3DKMT_HANDLE             hContext;           // in: Identifies the context that needs to signal.
+    UINT                      ObjectCount;        // in: Specifies the number of object to signal.
+    D3DKMT_HANDLE             ObjectHandleArray[D3DDDI_MAX_OBJECT_SIGNALED]; // in: Specifies the object to be signaled.
+    D3DDDICB_SIGNALFLAGS      Flags;                  // in: Specifies signal behavior.
+    ULONG                     BroadcastContextCount;  // in: Specifies the number of context
+                                                      //     to broadcast this command buffer to.
+    D3DKMT_HANDLE             BroadcastContext[D3DDDI_MAX_BROADCAST_CONTEXT]; // in: Specifies the handle of the context to
+                                                                              //     broadcast to.
+    union
+    {
+        struct {
+            D3DKMT_ALIGN64 UINT64 FenceValue;             // in: fence value to be signaled;
+        } Fence;
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8)
+        HANDLE                CpuEventHandle;         // in: handle of a CPU event to be signaled
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8)
+        D3DKMT_ALIGN64 UINT64 Reserved[8];
+    };
+} D3DKMT_SIGNALSYNCHRONIZATIONOBJECT2;
+
+typedef struct _D3DKMT_LOCK
+{
+    D3DKMT_HANDLE       hDevice;            // in: identifies the device
+    D3DKMT_HANDLE       hAllocation;        // in: allocation to lock
+                                            // out: New handle representing the allocation after the lock.
+    UINT                PrivateDriverData;  // in: Used by UMD for AcquireAperture
+    UINT                NumPages;
+    D3DKMT_PTR(CONST UINT*, pPages);
+    D3DKMT_PTR(VOID*,   pData);             // out: pointer to memory
+    D3DDDICB_LOCKFLAGS  Flags;              // in: Bit field defined by D3DDDI_LOCKFLAGS
+    D3DGPU_VIRTUAL_ADDRESS GpuVirtualAddress; // out: GPU's Virtual Address of locked allocation. _ADVSCH_
+} D3DKMT_LOCK;
+
+typedef struct _D3DKMT_UNLOCK
+{
+    D3DKMT_HANDLE           hDevice;        // in: Identifies the device
+    UINT                    NumAllocations; // in: Number of allocations in the array
+    D3DKMT_PTR(CONST D3DKMT_HANDLE*, phAllocations); // in: array of allocations to unlock
+} D3DKMT_UNLOCK;
+
+typedef enum _D3DKMDT_MODE_PRUNING_REASON
+{
+    D3DKMDT_MPR_UNINITIALIZED                               = 0, // mode was pruned or is supported because of:
+    D3DKMDT_MPR_ALLCAPS                                     = 1, //   all of the monitor caps (only used to imply lack of support - for support, specific reason is always indicated)
+    D3DKMDT_MPR_DESCRIPTOR_MONITOR_SOURCE_MODE              = 2, //   monitor source mode in the monitor descriptor
+    D3DKMDT_MPR_DESCRIPTOR_MONITOR_FREQUENCY_RANGE          = 3, //   monitor frequency range in the monitor descriptor
+    D3DKMDT_MPR_DESCRIPTOR_OVERRIDE_MONITOR_SOURCE_MODE     = 4, //   monitor source mode in the monitor descriptor override
+    D3DKMDT_MPR_DESCRIPTOR_OVERRIDE_MONITOR_FREQUENCY_RANGE = 5, //   monitor frequency range in the monitor descriptor override
+    D3DKMDT_MPR_DEFAULT_PROFILE_MONITOR_SOURCE_MODE         = 6, //   monitor source mode in the default monitor profile
+    D3DKMDT_MPR_DRIVER_RECOMMENDED_MONITOR_SOURCE_MODE      = 7, //   monitor source mode recommended by the driver
+    D3DKMDT_MPR_MONITOR_FREQUENCY_RANGE_OVERRIDE            = 8, //   monitor frequency range override
+    D3DKMDT_MPR_CLONE_PATH_PRUNED                           = 9, //   Mode is pruned because other path(s) in clone cluster has(have) no mode supported by monitor
+    D3DKMDT_MPR_MAXVALID                                    = 10
+}
+D3DKMDT_MODE_PRUNING_REASON;
+
+// This structure takes 8 bytes.
+// The unnamed UINT of size 0 forces alignment of the structure to
+// make it exactly occupy 8 bytes, see MSDN docs on C++ bitfields
+// for more details
+typedef struct _D3DKMDT_DISPLAYMODE_FLAGS
+{
+#if (DXGKDDI_INTERFACE_VERSION < DXGKDDI_INTERFACE_VERSION_WIN8)
+    BOOLEAN                      ValidatedAgainstMonitorCaps  : 1;
+    BOOLEAN                      RoundedFakeMode              : 1;
+    D3DKMDT_MODE_PRUNING_REASON  ModePruningReason            : 4;
+    UINT                         Reserved                     : 28;
+#else
+    UINT                         ValidatedAgainstMonitorCaps  : 1;
+    UINT                         RoundedFakeMode              : 1;
+    UINT                                                      : 0;
+    D3DKMDT_MODE_PRUNING_REASON  ModePruningReason            : 4;
+    UINT                         Stereo                       : 1;
+    UINT                         AdvancedScanCapable          : 1;
+#if (DXGKDDI_INTERFACE_VERSION < DXGKDDI_INTERFACE_VERSION_WDDM2_0)
+    UINT                         Reserved                     : 26;
+#else
+    UINT                         PreferredTiming              : 1;
+    UINT                         PhysicalModeSupported        : 1;
+#if (DXGKDDI_INTERFACE_VERSION < DXGKDDI_INTERFACE_VERSION_WDDM2_9)
+    UINT                         Reserved                     : 24;
+#else
+    UINT                         VirtualRefreshRate           : 1;
+    UINT                         Reserved                     : 23;
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_9
+#endif
+#endif
+}
+D3DKMDT_DISPLAYMODE_FLAGS;
+
+typedef struct _D3DKMT_DISPLAYMODE
+{
+    UINT                                   Width;
+    UINT                                   Height;
+    D3DDDIFORMAT                           Format;
+    UINT                                   IntegerRefreshRate;
+    D3DDDI_RATIONAL                        RefreshRate;
+    D3DDDI_VIDEO_SIGNAL_SCANLINE_ORDERING  ScanLineOrdering;
+    D3DDDI_ROTATION                        DisplayOrientation;
+    UINT                                   DisplayFixedOutput;
+    D3DKMDT_DISPLAYMODE_FLAGS              Flags;
+} D3DKMT_DISPLAYMODE;
+
+typedef struct _D3DKMT_GETDISPLAYMODELIST
+{
+    D3DKMT_HANDLE                   hAdapter;       // in: adapter handle
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID  VidPnSourceId;  // in: adapter's VidPN source ID
+    D3DKMT_PTR(D3DKMT_DISPLAYMODE*, pModeList);      // out:
+    UINT                            ModeCount;      // in/out:
+} D3DKMT_GETDISPLAYMODELIST;
+
+typedef struct _D3DKMT_DISPLAYMODELIST
+{
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID  VidPnSourceId;
+    UINT                            ModeCount;
+    D3DKMT_DISPLAYMODE              pModeList[0];
+} D3DKMT_DISPLAYMODELIST;
+
+typedef struct _D3DKMT_SETDISPLAYMODE_FLAGS
+{
+    BOOLEAN  PreserveVidPn   : 1;
+    UINT     Reserved       : 31;
+}
+D3DKMT_SETDISPLAYMODE_FLAGS;
+
+typedef struct _D3DKMT_SETDISPLAYMODE
+{
+    D3DKMT_HANDLE                          hDevice;                         // in: Identifies the device
+    D3DKMT_HANDLE                          hPrimaryAllocation;              // in:
+    D3DDDI_VIDEO_SIGNAL_SCANLINE_ORDERING  ScanLineOrdering;                // in:
+    D3DDDI_ROTATION                        DisplayOrientation;              // in:
+    UINT                                   PrivateDriverFormatAttribute;    // out: Private Format Attribute of the current primary surface if DxgkSetDisplayMode failed with STATUS_GRAPHICS_INCOMPATIBLE_PRIVATE_FORMAT
+    D3DKMT_SETDISPLAYMODE_FLAGS            Flags;                           // in:
+} D3DKMT_SETDISPLAYMODE;
+
+
+typedef struct _D3DKMT_MULTISAMPLEMETHOD
+{
+    UINT    NumSamples;
+    UINT    NumQualityLevels;
+    UINT    Reserved;   //workaround for NTRAID#Longhorn-1124385-2005/03/14-kanqiu
+} D3DKMT_MULTISAMPLEMETHOD;
+
+typedef struct _D3DKMT_GETMULTISAMPLEMETHODLIST
+{
+    D3DKMT_HANDLE                   hAdapter;       // in: adapter handle
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID  VidPnSourceId;  // in: adapter's VidPN source ID
+    UINT                            Width;          // in:
+    UINT                            Height;         // in:
+    D3DDDIFORMAT                    Format;         // in:
+    D3DKMT_PTR(D3DKMT_MULTISAMPLEMETHOD*, pMethodList); // out:
+    UINT                            MethodCount;    // in/out:
+} D3DKMT_GETMULTISAMPLEMETHODLIST;
+
+typedef struct _D3DKMT_PRESENTFLAGS
+{
+    union
+    {
+        struct
+        {
+            UINT    Blt                         : 1;        // 0x00000001
+            UINT    ColorFill                   : 1;        // 0x00000002
+            UINT    Flip                        : 1;        // 0x00000004
+            UINT    FlipDoNotFlip               : 1;        // 0x00000008
+            UINT    FlipDoNotWait               : 1;        // 0x00000010
+            UINT    FlipRestart                 : 1;        // 0x00000020
+            UINT    DstRectValid                : 1;        // 0x00000040
+            UINT    SrcRectValid                : 1;        // 0x00000080
+            UINT    RestrictVidPnSource         : 1;        // 0x00000100
+            UINT    SrcColorKey                 : 1;        // 0x00000200
+            UINT    DstColorKey                 : 1;        // 0x00000400
+            UINT    LinearToSrgb                : 1;        // 0x00000800
+            UINT    PresentCountValid           : 1;        // 0x00001000
+            UINT    Rotate                      : 1;        // 0x00002000
+            UINT    PresentToBitmap             : 1;        // 0x00004000
+            UINT    RedirectedFlip              : 1;        // 0x00008000
+            UINT    RedirectedBlt               : 1;        // 0x00010000
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8)
+            UINT    FlipStereo                  : 1;        // 0x00020000   // This is a flip from a stereo alloc. Used in addition to Flip.
+            UINT    FlipStereoTemporaryMono     : 1;        // 0x00040000   // This is a flip from a stereo alloc. The left image should used to produce both images. Used in addition to Flip.
+            UINT    FlipStereoPreferRight       : 1;        // 0x00080000   // This is a flip from a stereo alloc. Use the right image when cloning to a mono monitor. Used in addition to Flip.
+            UINT    BltStereoUseRight           : 1;        // 0x00100000   // This is a Blt from a stereo alloc to a mono alloc. The right image should be used.
+            UINT    PresentHistoryTokenOnly     : 1;        // 0x00200000   // Submit Present History Token only.
+            UINT    PresentRegionsValid         : 1;        // 0x00400000   // Ptr to present regions is valid
+            UINT    PresentDDA                  : 1;        // 0x00800000   // Present from a DDA swapchain
+            UINT    ProtectedContentBlankedOut  : 1;        // 0x01000000
+            UINT    RemoteSession               : 1;        // 0x02000000
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM1_3)
+            UINT    CrossAdapter                : 1;        // 0x04000000
+            UINT    DurationValid               : 1;        // 0x08000000
+            UINT    PresentIndirect             : 1;        // 0x10000000   // Present to an indirect-display adapter
+            UINT    PresentHMD                  : 1;        // 0x20000000   // Present from an HMD swapchain.
+            UINT    Reserved                    : 2;        // 0xC0000000
+#else
+            UINT    Reserved                    : 6;        // 0xFC000000
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM1_3)
+#else
+            UINT    Reserved                    : 15;       // 0xFFFE0000
+#endif
+        };
+        UINT    Value;
+    };
+} D3DKMT_PRESENTFLAGS;
+
+typedef enum _D3DKMT_PRESENT_MODEL
+{
+    D3DKMT_PM_UNINITIALIZED       = 0,
+    D3DKMT_PM_REDIRECTED_GDI       = 1,
+    D3DKMT_PM_REDIRECTED_FLIP      = 2,
+    D3DKMT_PM_REDIRECTED_BLT       = 3,
+    D3DKMT_PM_REDIRECTED_VISTABLT  = 4,
+    D3DKMT_PM_SCREENCAPTUREFENCE   = 5,
+    D3DKMT_PM_REDIRECTED_GDI_SYSMEM  = 6,
+    D3DKMT_PM_REDIRECTED_COMPOSITION = 7,
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_1)
+    D3DKMT_PM_SURFACECOMPLETE        = 8,
+#endif
+    D3DKMT_PM_FLIPMANAGER            = 9,
+} D3DKMT_PRESENT_MODEL;
+
+typedef enum _D3DKMT_FLIPMODEL_INDEPENDENT_FLIP_STAGE
+{
+    D3DKMT_FLIPMODEL_INDEPENDENT_FLIP_STAGE_FLIP_SUBMITTED = 0,
+    D3DKMT_FLIPMODEL_INDEPENDENT_FLIP_STAGE_FLIP_COMPLETE = 1
+} D3DKMT_FLIPMODEL_INDEPENDENT_FLIP_STAGE;
+
+typedef struct _D3DKMT_FLIPMODEL_PRESENTHISTORYTOKENFLAGS
+{
+    union
+    {
+        struct
+        {
+            UINT  Video                         :  1;   // 0x00000001
+            UINT  RestrictedContent             :  1;   // 0x00000002
+            UINT  ClipToView                    :  1;   // 0x00000004
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8)
+            UINT  StereoPreferRight             :  1;   // 0x00000008
+            UINT  TemporaryMono                 :  1;   // 0x00000010
+            UINT  FlipRestart                   :  1;   // 0x00000020
+            UINT  HDRMetaDataChanged            :  1;   // 0x00000040
+            UINT  AlphaMode                     :  2;   // 0x00000180
+            UINT  SignalLimitOnTokenCompletion  :  1;   // 0x00000200
+            UINT  YCbCrFlags                    :  3;   // 0x00001C00
+            UINT  IndependentFlip               :  1;   // 0x00002000
+            D3DKMT_FLIPMODEL_INDEPENDENT_FLIP_STAGE IndependentFlipStage : 2;   // 0x0000C000
+            UINT  IndependentFlipReleaseCount   :  2;   // 0x00030000
+            UINT  IndependentFlipForceNotifyDwm :  1;   // 0x00040000
+            UINT  UseCustomDuration             :  1;   // 0x00080000
+            UINT  IndependentFlipRequestDwmConfirm:1;   // 0x00100000
+            UINT  IndependentFlipCandidate      :  1;   // 0x00200000
+            UINT  IndependentFlipCheckNeeded    :  1;   // 0x00400000
+            UINT  IndependentFlipTrueImmediate  :  1;   // 0x00800000
+            UINT  IndependentFlipRequestDwmExit :  1;   // 0x01000000
+            UINT  CompSurfaceNotifiedEarly      :  1;   // 0x02000000
+            UINT  IndependentFlipDoNotFlip      :  1;   // 0x04000000
+            UINT  RequirePairedToken            :  1;   // 0x08000000
+            UINT  VariableRefreshOverrideEligible :1;   // 0x10000000
+            UINT  Reserved                      :  3;   // 0xE0000000
+#else
+            UINT  Reserved                      : 29;   // 0xFFFFFFF8
+#endif
+        };
+
+        UINT  Value;
+    };
+} D3DKMT_FLIPMODEL_PRESENTHISTORYTOKENFLAGS;
+
+#define D3DKMT_MAX_PRESENT_HISTORY_RECTS 16
+
+typedef struct _D3DKMT_DIRTYREGIONS
+{
+    UINT  NumRects;
+    RECT  Rects[D3DKMT_MAX_PRESENT_HISTORY_RECTS];
+} D3DKMT_DIRTYREGIONS;
+
+typedef struct _D3DKMT_COMPOSITION_PRESENTHISTORYTOKEN
+{
+    D3DKMT_ALIGN64 ULONG64 hPrivateData;
+} D3DKMT_COMPOSITION_PRESENTHISTORYTOKEN;
+
+typedef struct _D3DKMT_FLIPMANAGER_PRESENTHISTORYTOKEN
+{
+    D3DKMT_ALIGN64 ULONG64 hPrivateData;
+    D3DKMT_ALIGN64 ULONGLONG PresentAtQpc;
+    union
+    {
+        struct
+        {
+            UINT Discard   : 1;
+            UINT PresentAt : 1;
+            UINT hPrivateDataIsPointer : 1;
+            UINT Reserved  : 29;
+        };
+        UINT Value;
+    }Flags;
+} D3DKMT_FLIPMANAGER_PRESENTHISTORYTOKEN;
+
+typedef enum _D3DKMT_AUXILIARYPRESENTINFO_TYPE
+{
+    D3DKMT_AUXILIARYPRESENTINFO_TYPE_FLIPMANAGER = 0
+} D3DKMT_AUXILIARYPRESENTINFO_TYPE;
+
+typedef struct _D3DKMT_AUXILIARYPRESENTINFO
+{
+    UINT size;
+    D3DKMT_AUXILIARYPRESENTINFO_TYPE type;
+} D3DKMT_AUXILIARYPRESENTINFO;
+
+typedef struct _D3DKMT_FLIPMANAGER_AUXILIARYPRESENTINFO
+{
+    // in: Base information
+    D3DKMT_AUXILIARYPRESENTINFO auxiliaryPresentInfo;
+
+    // in: Tracing ID of owner flip manager
+    UINT flipManagerTracingId;
+
+    // in: Whether or not the application requested a different custom duration
+    // than the previous present
+    BOOL customDurationChanged;
+
+    // out: The adapter LUID/VidPn source of the flip output
+    LUID FlipAdapterLuid;
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID VidPnSourceId;
+
+    // out: Independent flip stage
+    D3DKMT_FLIPMODEL_INDEPENDENT_FLIP_STAGE independentFlipStage;
+
+    // out: The DPC frame time of the frame on which the flip was completed
+    D3DKMT_ALIGN64 ULONGLONG FlipCompletedQpc;
+
+    // out: The approved frame duration
+    UINT HwPresentDurationQpc;
+
+    // out: Whether or not the present was canceled in the scheduler
+    BOOL WasCanceled;
+} D3DKMT_FLIPMANAGER_AUXILIARYPRESENTINFO;
+
+typedef struct _D3DKMT_GDIMODEL_PRESENTHISTORYTOKEN
+{
+    D3DKMT_ALIGN64 ULONG64 hLogicalSurface;
+    D3DKMT_ALIGN64 ULONG64 hPhysicalSurface;
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8)
+    RECT                 ScrollRect;
+    POINT                ScrollOffset;
+#endif
+    D3DKMT_DIRTYREGIONS  DirtyRegions;
+} D3DKMT_GDIMODEL_PRESENTHISTORYTOKEN;
+
+typedef struct _D3DKMT_GDIMODEL_SYSMEM_PRESENTHISTORYTOKEN
+{
+    D3DKMT_ALIGN64 ULONG64 hlsurf;
+    DWORD dwDirtyFlags;
+    D3DKMT_ALIGN64 UINT64 uiCookie;
+} D3DKMT_GDIMODEL_SYSMEM_PRESENTHISTORYTOKEN;
+
+typedef ULONGLONG  D3DKMT_VISTABLTMODEL_PRESENTHISTORYTOKEN;
+
+typedef struct _D3DKMT_FENCE_PRESENTHISTORYTOKEN
+{
+    D3DKMT_ALIGN64 UINT64 Key;
+} D3DKMT_FENCE_PRESENTHISTORYTOKEN;
+
+typedef struct _D3DKMT_BLTMODEL_PRESENTHISTORYTOKEN
+{
+    D3DKMT_ALIGN64 ULONG64 hLogicalSurface;
+    D3DKMT_ALIGN64 ULONG64 hPhysicalSurface;
+    D3DKMT_ALIGN64 ULONG64 EventId;
+    D3DKMT_DIRTYREGIONS                 DirtyRegions;
+} D3DKMT_BLTMODEL_PRESENTHISTORYTOKEN;
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8)
+#define D3DKMT_MAX_PRESENT_HISTORY_SCATTERBLTS 12
+
+typedef struct _D3DKMT_SCATTERBLT
+{
+    D3DKMT_ALIGN64 ULONG64 hLogicalSurfaceDestination;
+    D3DKMT_ALIGN64 LONG64  hDestinationCompSurfDWM;
+    D3DKMT_ALIGN64 UINT64  DestinationCompositionBindingId;
+    RECT    SourceRect;
+    POINT   DestinationOffset;
+} D3DKMT_SCATTERBLT;
+
+typedef struct _D3DKMT_SCATTERBLTS
+{
+    UINT NumBlts;
+    D3DKMT_SCATTERBLT Blts[D3DKMT_MAX_PRESENT_HISTORY_SCATTERBLTS];
+} D3DKMT_SCATTERBLTS;
+#endif
+
+typedef struct _D3DKMT_FLIPMODEL_PRESENTHISTORYTOKEN
+{
+    D3DKMT_ALIGN64 UINT64                      FenceValue;
+    D3DKMT_ALIGN64 ULONG64                     hLogicalSurface;
+    D3DKMT_ALIGN64 D3DKMT_UINT_PTR             dxgContext;
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID             VidPnSourceId;
+    UINT                                       SwapChainIndex;
+    D3DKMT_ALIGN64 UINT64                      PresentLimitSemaphoreId;
+    D3DDDI_FLIPINTERVAL_TYPE                   FlipInterval;
+    D3DKMT_FLIPMODEL_PRESENTHISTORYTOKENFLAGS  Flags;
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8)
+    D3DKMT_ALIGN64 LONG64                      hCompSurf;
+    LUID                                       compSurfLuid;
+    D3DKMT_ALIGN64 UINT64                      confirmationCookie;
+    D3DKMT_ALIGN64 UINT64                      CompositionSyncKey;
+    UINT                                       RemainingTokens;
+    RECT                                       ScrollRect;
+    POINT                                      ScrollOffset;
+    UINT                                       PresentCount;
+    FLOAT                                      RevealColor[4]; // index 0 == R, ... , 3 == A
+    D3DDDI_ROTATION                            Rotation;
+    union
+    {
+        D3DKMT_SCATTERBLTS                     ScatterBlts;     // Unused
+        struct
+        {
+            HANDLE                             hSyncObject;     // NT handle to FlipEx fence.
+            D3DDDI_HDR_METADATA_TYPE           HDRMetaDataType;
+            union
+            {
+                D3DDDI_HDR_METADATA_HDR10      HDRMetaDataHDR10;
+                D3DDDI_HDR_METADATA_HDR10PLUS  HDRMetaDataHDR10Plus;
+            };
+        };
+    };
+    UINT                                       InkCookie;
+    RECT                                       SourceRect;
+    UINT                                       DestWidth;
+    UINT                                       DestHeight;
+    RECT                                       TargetRect;
+    // DXGI_MATRIX_3X2_F: _11 _12 _21 _22 _31 _32
+    FLOAT                                      Transform[6];
+    UINT                                       CustomDuration;
+    D3DDDI_FLIPINTERVAL_TYPE                   CustomDurationFlipInterval;
+    UINT                                       PlaneIndex;
+#endif
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0)
+    D3DDDI_COLOR_SPACE_TYPE                    ColorSpace;
+#endif
+    D3DKMT_DIRTYREGIONS                        DirtyRegions;
+} D3DKMT_FLIPMODEL_PRESENTHISTORYTOKEN;
+
+// User mode timeout is in milliseconds, kernel mode timeout is in 100 nanoseconds
+#define FLIPEX_TIMEOUT_USER     (2000)
+#define FLIPEX_TIMEOUT_KERNEL   (FLIPEX_TIMEOUT_USER*10000)
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_1)
+typedef struct _D3DKMT_SURFACECOMPLETE_PRESENTHISTORYTOKEN
+{
+    D3DKMT_ALIGN64 ULONG64 hLogicalSurface;
+} D3DKMT_SURFACECOMPLETE_PRESENTHISTORYTOKEN;
+#endif
+
+typedef struct _D3DKMT_PRESENTHISTORYTOKEN
+{
+    D3DKMT_PRESENT_MODEL  Model;
+    // The size of the present history token in bytes including Model.
+    // Should be set to zero by when submitting a token.
+    // It will be initialized when reading present history and can be used to
+    // go to the next token in the present history buffer.
+    UINT                  TokenSize;
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8)
+    // The binding id as specified by the Composition Surface
+    UINT64                CompositionBindingId;
+#endif
+
+    union
+    {
+        D3DKMT_FLIPMODEL_PRESENTHISTORYTOKEN        Flip;
+        D3DKMT_BLTMODEL_PRESENTHISTORYTOKEN         Blt;
+        D3DKMT_VISTABLTMODEL_PRESENTHISTORYTOKEN    VistaBlt;
+        D3DKMT_GDIMODEL_PRESENTHISTORYTOKEN         Gdi;
+        D3DKMT_FENCE_PRESENTHISTORYTOKEN            Fence;
+        D3DKMT_GDIMODEL_SYSMEM_PRESENTHISTORYTOKEN  GdiSysMem;
+        D3DKMT_COMPOSITION_PRESENTHISTORYTOKEN      Composition;
+        D3DKMT_FLIPMANAGER_PRESENTHISTORYTOKEN      FlipManager;
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_1)
+        D3DKMT_SURFACECOMPLETE_PRESENTHISTORYTOKEN  SurfaceComplete;
+#endif
+    }
+    Token;
+} D3DKMT_PRESENTHISTORYTOKEN;
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8)
+typedef struct _D3DKMT_PRESENT_RGNS
+{
+    UINT DirtyRectCount;
+    D3DKMT_PTR(_Field_size_( DirtyRectCount ) const RECT*, pDirtyRects);
+    UINT MoveRectCount;
+    D3DKMT_PTR(_Field_size_( MoveRectCount ) const D3DKMT_MOVE_RECT*, pMoveRects);
+}D3DKMT_PRESENT_RGNS;
+#endif
+
+typedef struct _D3DKMT_PRESENT
+{
+    union
+    {
+        D3DKMT_HANDLE               hDevice;            // in: D3D10 compatibility.
+        D3DKMT_HANDLE               hContext;           // in: Indentifies the context
+    };
+    D3DKMT_PTR(HWND,                hWindow);           // in: window to present to
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID  VidPnSourceId;      // in: VidPn source ID if RestrictVidPnSource is flagged
+    D3DKMT_HANDLE                   hSource;            // in: Source allocation to present from
+    D3DKMT_HANDLE                   hDestination;       // in: Destination allocation whenever non-zero
+    UINT                            Color;              // in: color value in ARGB 32 bit format
+    RECT                            DstRect;            // in: unclipped dest rect
+    RECT                            SrcRect;            // in: unclipped src rect
+    UINT                            SubRectCnt;         // in: count of sub rects
+    D3DKMT_PTR(CONST RECT*,         pSrcSubRects);      // in: sub rects in source space
+    UINT                            PresentCount;       // in: present counter
+    D3DDDI_FLIPINTERVAL_TYPE        FlipInterval;       // in: flip interval
+    D3DKMT_PRESENTFLAGS             Flags;              // in:
+    ULONG                           BroadcastContextCount;                          // in: Specifies the number of context
+                                                                                    //     to broadcast this command buffer to.
+    D3DKMT_HANDLE                   BroadcastContext[D3DDDI_MAX_BROADCAST_CONTEXT]; // in: Specifies the handle of the context to
+                                                                                    //     broadcast to.
+    HANDLE                          PresentLimitSemaphore;
+    D3DKMT_PRESENTHISTORYTOKEN      PresentHistoryToken;
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8)
+    D3DKMT_PRESENT_RGNS*            pPresentRegions;
+#endif
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM1_3)
+    union
+    {
+        D3DKMT_HANDLE               hAdapter;           // in: iGpu adapter for PHT redirection. Valid only when the CrossAdapter flag is set.
+        D3DKMT_HANDLE               hIndirectContext;   // in: indirect adapter context for redirecting through the DoD present path. Only
+                                                        //     valid if PresentIndirect flag is set.
+    };
+    UINT                            Duration;           // in: Per-present duration. Valid only when the DurationValid flag is set.
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0)
+    D3DKMT_PTR(_Field_size_(BroadcastContextCount)
+    D3DKMT_HANDLE*,                 BroadcastSrcAllocation);                    // in: LDA
+    D3DKMT_PTR(_Field_size_opt_(BroadcastContextCount)
+    D3DKMT_HANDLE*,                 BroadcastDstAllocation);                    // in: LDA
+    UINT                            PrivateDriverDataSize;                      // in:
+    D3DKMT_PTR(_Field_size_bytes_(PrivateDriverDataSize)
+    PVOID,                          pPrivateDriverData);                        // in: Private driver data to pass to DdiPresent and DdiSetVidPnSourceAddress
+    BOOLEAN                         bOptimizeForComposition;                    // out: DWM is involved in composition
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0)
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM1_3)
+} D3DKMT_PRESENT;
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_3)
+typedef struct _D3DKMT_PRESENT_REDIRECTEDS_FLAGS
+{
+    union
+    {
+        struct
+        {
+            UINT Reserved : 32; // 0xFFFFFFFF
+        };
+        UINT Value;
+    };
+}D3DKMT_PRESENT_REDIRECTED_FLAGS;
+
+typedef struct _D3DKMT_PRESENT_REDIRECTED
+{
+    D3DKMT_HANDLE                   hSyncObj;              // in: Sync object PHT waits on
+    D3DKMT_HANDLE                   hDevice;               // in: Device associated with the present
+    D3DKMT_ALIGN64 ULONGLONG        WaitedFenceValue;      // in: Fence value of hSyncObj that PHT waits on
+    D3DKMT_PRESENTHISTORYTOKEN      PresentHistoryToken;
+    D3DKMT_PRESENT_REDIRECTED_FLAGS Flags;
+    D3DKMT_HANDLE                   hSource;               // in: Source allocation to present from
+    UINT                            PrivateDriverDataSize; // in:
+    D3DKMT_PTR(_Field_size_bytes_(PrivateDriverDataSize)
+    PVOID,                          pPrivateDriverData);   // in: Private driver data to pass to DdiPresent and DdiSetVidPnSourceAddress
+}D3DKMT_PRESENT_REDIRECTED;
+#endif
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM3_0)
+typedef struct _D3DKMT_CANCEL_PRESENTS_FLAGS
+{
+    union
+    {
+        // D3DKMT_CANCEL_PRESENTS_OPERATION_REPROGRAM_INTERRUPT flags
+        struct
+        {
+            UINT NewVSyncInterruptState :  1;
+            UINT Reserved               : 31;
+        } ReprogramInterrupt;
+
+        UINT Value;
+    };
+}D3DKMT_CANCEL_PRESENTS_FLAGS;
+
+
+typedef enum D3DKMT_CANCEL_PRESENTS_OPERATION
+{
+    D3DKMT_CANCEL_PRESENTS_OPERATION_CANCEL_FROM            = 0,
+    D3DKMT_CANCEL_PRESENTS_OPERATION_REPROGRAM_INTERRUPT    = 1
+} D3DKMT_CANCEL_PRESENTS_OPERATION;
+
+typedef struct _D3DKMT_CANCEL_PRESENTS
+{
+    UINT                                cbSize;
+    D3DKMT_HANDLE                       hDevice;
+    D3DKMT_CANCEL_PRESENTS_FLAGS        Flags;
+    D3DKMT_CANCEL_PRESENTS_OPERATION    Operation;
+    D3DKMT_ALIGN64 UINT64               CancelFromPresentId;
+    LUID                                CompSurfaceLuid;
+    D3DKMT_ALIGN64 UINT64               BindId;
+}D3DKMT_CANCEL_PRESENTS;
+#endif
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_4)
+
+typedef struct _D3DKMT_SUBMITPRESENTBLTTOHWQUEUE
+{
+    D3DKMT_HANDLE         hHwQueue;
+    D3DKMT_ALIGN64 UINT64 HwQueueProgressFenceId;
+    D3DKMT_PRESENT        PrivatePresentData;
+} D3DKMT_SUBMITPRESENTBLTTOHWQUEUE;
+
+#endif
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_5)
+
+typedef struct _D3DKMT_SUBMITPRESENTTOHWQUEUE
+{
+    D3DKMT_PTR(_Field_size_(PrivatePresentData.BroadcastContextCount + 1)
+    D3DKMT_HANDLE*, hHwQueues);
+    D3DKMT_PRESENT  PrivatePresentData;
+} D3DKMT_SUBMITPRESENTTOHWQUEUE;
+
+#endif
+
+#define D3DKMT_MAX_MULTIPLANE_OVERLAY_PLANES                   8
+#define D3DKMT_MAX_MULTIPLANE_OVERLAY_ALLOCATIONS_PER_PLANE   256
+
+typedef enum D3DKMT_MULTIPLANE_OVERLAY_FLAGS
+{
+    D3DKMT_MULTIPLANE_OVERLAY_FLAG_VERTICAL_FLIP               = 0x1,
+    D3DKMT_MULTIPLANE_OVERLAY_FLAG_HORIZONTAL_FLIP             = 0x2,
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM3_0)
+    D3DKMT_MULTIPLANE_OVERLAY_FLAG_STATIC_CHECK                = 0x4,
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM3_0
+} D3DKMT_MULTIPLANE_OVERLAY_FLAGS;
+
+typedef enum D3DKMT_MULTIPLANE_OVERLAY_BLEND
+{
+    D3DKMT_MULTIPLANE_OVERLAY_BLEND_OPAQUE     = 0x0,
+    D3DKMT_MULTIPLANE_OVERLAY_BLEND_ALPHABLEND = 0x1,
+} D3DKMT_MULTIPLANE_OVERLAY_BLEND;
+
+typedef enum D3DKMT_MULTIPLANE_OVERLAY_VIDEO_FRAME_FORMAT
+{
+    D3DKMT_MULIIPLANE_OVERLAY_VIDEO_FRAME_FORMAT_PROGRESSIVE  = 0,
+    D3DKMT_MULTIPLANE_OVERLAY_VIDEO_FRAME_FORMAT_INTERLACED_TOP_FIELD_FIRST   = 1,
+    D3DKMT_MULTIPLANE_OVERLAY_VIDEO_FRAME_FORMAT_INTERLACED_BOTTOM_FIELD_FIRST    = 2
+} D3DKMT_MULTIPLANE_OVERLAY_VIDEO_FRAME_FORMAT;
+
+typedef enum D3DKMT_MULTIPLANE_OVERLAY_YCbCr_FLAGS
+{
+    D3DKMT_MULTIPLANE_OVERLAY_YCbCr_FLAG_NOMINAL_RANGE = 0x1, // 16 - 235 vs. 0 - 255
+    D3DKMT_MULTIPLANE_OVERLAY_YCbCr_FLAG_BT709         = 0x2, // BT.709 vs. BT.601
+    D3DKMT_MULTIPLANE_OVERLAY_YCbCr_FLAG_xvYCC         = 0x4, // xvYCC vs. conventional YCbCr
+} D3DKMT_MULTIPLANE_OVERLAY_YCbCr_FLAGS;
+
+typedef enum D3DKMT_MULTIPLANE_OVERLAY_STEREO_FORMAT
+{
+    DXGKMT_MULTIPLANE_OVERLAY_STEREO_FORMAT_MONO               = 0,
+    D3DKMT_MULTIPLANE_OVERLAY_STEREO_FORMAT_HORIZONTAL         = 1,
+    D3DKMT_MULTIPLANE_OVERLAY_STEREO_FORMAT_VERTICAL           = 2,
+    DXGKMT_MULTIPLANE_OVERLAY_STEREO_FORMAT_SEPARATE           = 3,
+    DXGKMT_MULTIPLANE_OVERLAY_STEREO_FORMAT_MONO_OFFSET        = 4,
+    DXGKMT_MULTIPLANE_OVERLAY_STEREO_FORMAT_ROW_INTERLEAVED    = 5,
+    DXGKMT_MULTIPLANE_OVERLAY_STEREO_FORMAT_COLUMN_INTERLEAVED = 6,
+    DXGKMT_MULTIPLANE_OVERLAY_STEREO_FORMAT_CHECKERBOARD       = 7
+} D3DKMT_MULTIPLANE_OVERLAY_STEREO_FORMAT;
+
+typedef enum _DXGKMT_MULTIPLANE_OVERLAY_STEREO_FLIP_MODE
+{
+    DXGKMT_MULTIPLANE_OVERLAY_STEREO_FLIP_NONE   = 0,
+    DXGKMT_MULTIPLANE_OVERLAY_STEREO_FLIP_FRAME0 = 1,
+    DXGKMT_MULTIPLANE_OVERLAY_STEREO_FLIP_FRAME1 = 2,
+} DXGKMT_MULTIPLANE_OVERLAY_STEREO_FLIP_MODE;
+
+typedef enum _DXGKMT_MULTIPLANE_OVERLAY_STRETCH_QUALITY
+{
+    DXGKMT_MULTIPLANE_OVERLAY_STRETCH_QUALITY_BILINEAR        = 0x1,  // Bilinear
+    DXGKMT_MULTIPLANE_OVERLAY_STRETCH_QUALITY_HIGH            = 0x2,  // Maximum
+} DXGKMT_MULTIPLANE_OVERLAY_STRETCH_QUALITY;
+
+typedef struct D3DKMT_MULTIPLANE_OVERLAY_ATTRIBUTES
+{
+    UINT                                         Flags;      // D3DKMT_MULTIPLANE_OVERLAY_FLAGS
+    RECT                                         SrcRect;
+    RECT                                         DstRect;
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM1_3)
+    RECT                                         ClipRect;
+#endif
+    D3DDDI_ROTATION                              Rotation;
+    D3DKMT_MULTIPLANE_OVERLAY_BLEND              Blend;
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM1_3)
+    UINT                                         DirtyRectCount;
+    D3DKMT_PTR(RECT*,                            pDirtyRects);
+#else
+    UINT                                         NumFilters;
+    D3DKMT_PTR(void*,                            pFilters);
+#endif
+    D3DKMT_MULTIPLANE_OVERLAY_VIDEO_FRAME_FORMAT VideoFrameFormat;
+    UINT                                         YCbCrFlags; // D3DKMT_MULTIPLANE_OVERLAY_YCbCr_FLAGS
+    D3DKMT_MULTIPLANE_OVERLAY_STEREO_FORMAT      StereoFormat;
+    BOOL                                         StereoLeftViewFrame0;
+    BOOL                                         StereoBaseViewFrame0;
+    DXGKMT_MULTIPLANE_OVERLAY_STEREO_FLIP_MODE   StereoFlipMode;
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM1_3)
+    DXGKMT_MULTIPLANE_OVERLAY_STRETCH_QUALITY    StretchQuality;
+#endif
+} D3DKMT_MULTIPLANE_OVERLAY_ATTRIBUTES;
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM_1_3)
+typedef struct D3DKMT_CHECK_MULTIPLANE_OVERLAY_PLANE
+{
+    D3DKMT_HANDLE                        hResource;
+    LUID                                 CompSurfaceLuid;
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID       VidPnSourceId;
+    D3DKMT_MULTIPLANE_OVERLAY_ATTRIBUTES PlaneAttributes;
+} D3DKMT_CHECK_MULTIPLANE_OVERLAY_PLANE;
+
+typedef struct D3DKMT_CHECK_MULTIPLANE_OVERLAY_SUPPORT_RETURN_INFO
+{
+    union
+    {
+        struct
+        {
+            UINT    FailingPlane        : 4;   // The 0 based index of the first plane that could not be supported
+            UINT    TryAgain            : 1;   // The configuration is not supported due to a transition condition, which should shortly go away
+            UINT    Reserved            : 27;
+        };
+        UINT    Value;
+    };
+} D3DKMT_CHECK_MULTIPLANE_OVERLAY_SUPPORT_RETURN_INFO;
+
+typedef struct _D3DKMT_CHECKMULTIPLANEOVERLAYSUPPORT
+{
+    D3DKMT_HANDLE                                       hDevice;            // in : Indentifies the device
+    UINT                                                PlaneCount;         // in : Number of resources to pin
+    D3DKMT_PTR(D3DKMT_CHECK_MULTIPLANE_OVERLAY_PLANE*,  pOverlayPlanes);    // in : Array of resource handles to pin
+    BOOL                                                Supported;
+    D3DKMT_CHECK_MULTIPLANE_OVERLAY_SUPPORT_RETURN_INFO ReturnInfo;
+} D3DKMT_CHECKMULTIPLANEOVERLAYSUPPORT;
+#endif
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM_2_0)
+typedef struct _D3DKMT_MULTIPLANE_OVERLAY_ATTRIBUTES2
+{
+    UINT                                         Flags;     // D3DKMT_MULTIPLANE_OVERLAY_FLAGS
+    RECT                                         SrcRect;   // Specifies the source rectangle, of type RECT, relative to the source resource.
+    RECT                                         DstRect;   // Specifies the destination rectangle, of type RECT, relative to the monitor resolution.
+    RECT                                         ClipRect;  // Specifies any additional clipping, of type RECT, relative to the DstRect rectangle,
+                                                            // after the data has been stretched according to the values of SrcRect and DstRect.
+
+                                                            // The driver and hardware can use the ClipRect member to apply a common stretch factor
+                                                            // as the clipping changes when an app occludes part of the DstRect destination rectangle.
+    D3DDDI_ROTATION                              Rotation;  // Specifies the clockwise rotation of the overlay plane, given as a value from the D3DDDI_ROTATION enumeration.
+    D3DKMT_MULTIPLANE_OVERLAY_BLEND              Blend;     // Specifies the blend mode that applies to this overlay plane and the plane beneath it, given as a value from the DXGK_MULTIPLANE_OVERLAY_BLEND enumeration.
+    UINT                                         DirtyRectCount;
+    D3DKMT_PTR(RECT*,                            pDirtyRects);
+    D3DKMT_MULTIPLANE_OVERLAY_VIDEO_FRAME_FORMAT VideoFrameFormat;  // DXGK_MULTIPLANE_OVERLAY_VIDEO_FRAME_FORMAT
+    D3DDDI_COLOR_SPACE_TYPE                      ColorSpace;
+    D3DKMT_MULTIPLANE_OVERLAY_STEREO_FORMAT      StereoFormat;      // DXGK_MULTIPLANE_OVERLAY_STEREO_FORMAT
+    BOOL                                         StereoLeftViewFrame0;  // Reserved for system use. Must always be FALSE.
+    BOOL                                         StereoBaseViewFrame0;  // Reserved for system use. Must always be FALSE.
+    DXGKMT_MULTIPLANE_OVERLAY_STEREO_FLIP_MODE   StereoFlipMode;        // DXGK_MULTIPLANE_OVERLAY_STEREO_FLIP_MODE
+    DXGKMT_MULTIPLANE_OVERLAY_STRETCH_QUALITY    StretchQuality;        // DXGK_MULTIPLANE_OVERLAY_STRETCH_QUALITY
+    UINT                                         Reserved1;
+} D3DKMT_MULTIPLANE_OVERLAY_ATTRIBUTES2;
+
+typedef struct _D3DKMT_CHECK_MULTIPLANE_OVERLAY_PLANE2
+{
+    UINT                                  LayerIndex;
+    D3DKMT_HANDLE                         hResource;
+    LUID                                  CompSurfaceLuid;
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID        VidPnSourceId;
+    D3DKMT_MULTIPLANE_OVERLAY_ATTRIBUTES2 PlaneAttributes;
+} D3DKMT_CHECK_MULTIPLANE_OVERLAY_PLANE2;
+
+typedef struct _D3DKMT_CHECKMULTIPLANEOVERLAYSUPPORT2
+{
+    D3DKMT_HANDLE                                       hAdapter;           // in: adapter handle
+    D3DKMT_HANDLE                                       hDevice;            // in : Indentifies the device
+    UINT                                                PlaneCount;         // in : Number of resources to pin
+    D3DKMT_PTR(D3DKMT_CHECK_MULTIPLANE_OVERLAY_PLANE2*, pOverlayPlanes);    // in : Array of resource handles to pin
+    BOOL                                                Supported;
+    D3DKMT_CHECK_MULTIPLANE_OVERLAY_SUPPORT_RETURN_INFO ReturnInfo;
+} D3DKMT_CHECKMULTIPLANEOVERLAYSUPPORT2;
+
+typedef struct _D3DKMT_MULTIPLANE_OVERLAY2
+{
+    UINT                                  LayerIndex;
+    BOOL                                  Enabled;
+    D3DKMT_HANDLE                         hAllocation;
+    D3DKMT_MULTIPLANE_OVERLAY_ATTRIBUTES2 PlaneAttributes;
+} D3DKMT_MULTIPLANE_OVERLAY2;
+
+typedef struct _D3DKMT_PRESENT_MULTIPLANE_OVERLAY2
+{
+    D3DKMT_HANDLE                   hAdapter;           // in: adapter handle
+    union
+    {
+        D3DKMT_HANDLE               hDevice;            // in: D3D10 compatibility.
+        D3DKMT_HANDLE               hContext;           // in: Indentifies the context
+    };
+    ULONG                           BroadcastContextCount;                          // in: Specifies the number of context
+                                                                                    //     to broadcast this command buffer to.
+    D3DKMT_HANDLE                   BroadcastContext[D3DDDI_MAX_BROADCAST_CONTEXT]; // in: Specifies the handle of the context to
+                                                                                    //     broadcast to.
+
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID  VidPnSourceId;      // in: VidPn source ID if RestrictVidPnSource is flagged
+    UINT                            PresentCount;       // in: present counter
+    D3DDDI_FLIPINTERVAL_TYPE        FlipInterval;       // in: flip interval
+    D3DKMT_PRESENTFLAGS             Flags;              // in:
+
+    UINT                            PresentPlaneCount;
+    D3DKMT_PTR(D3DKMT_MULTIPLANE_OVERLAY2*, pPresentPlanes);
+    UINT                            Duration;
+} D3DKMT_PRESENT_MULTIPLANE_OVERLAY2;
+#endif  // DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_1)
+typedef struct _D3DKMT_MULTIPLANE_OVERLAY_ATTRIBUTES3
+{
+    UINT                                         Flags;     // D3DKMT_MULTIPLANE_OVERLAY_FLAGS
+    RECT                                         SrcRect;   // Specifies the source rectangle, of type RECT, relative to the source resource.
+    RECT                                         DstRect;   // Specifies the destination rectangle, of type RECT, relative to the monitor resolution.
+    RECT                                         ClipRect;  // Specifies any additional clipping, of type RECT, relative to the DstRect rectangle,
+                                                            // after the data has been stretched according to the values of SrcRect and DstRect.
+
+                                                            // The driver and hardware can use the ClipRect member to apply a common stretch factor
+                                                            // as the clipping changes when an app occludes part of the DstRect destination rectangle.
+    D3DDDI_ROTATION                              Rotation;  // Specifies the clockwise rotation of the overlay plane, given as a value from the D3DDDI_ROTATION enumeration.
+    D3DKMT_MULTIPLANE_OVERLAY_BLEND              Blend;     // Specifies the blend mode that applies to this overlay plane and the plane beneath it, given as a value from the DXGK_MULTIPLANE_OVERLAY_BLEND enumeration.
+    UINT                                         DirtyRectCount;
+    D3DKMT_PTR(_Field_size_(DirtyRectCount) RECT*, pDirtyRects);
+    D3DDDI_COLOR_SPACE_TYPE                      ColorSpace;
+    DXGKMT_MULTIPLANE_OVERLAY_STRETCH_QUALITY    StretchQuality;        // DXGK_MULTIPLANE_OVERLAY_STRETCH_QUALITY
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_3)
+    UINT                                         SDRWhiteLevel;
+#endif
+} D3DKMT_MULTIPLANE_OVERLAY_ATTRIBUTES3;
+
+typedef struct _D3DKMT_CHECK_MULTIPLANE_OVERLAY_PLANE3
+{
+    UINT                                  LayerIndex;
+    D3DKMT_HANDLE                         hResource;
+    LUID                                  CompSurfaceLuid;
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID        VidPnSourceId;
+    D3DKMT_PTR(D3DKMT_MULTIPLANE_OVERLAY_ATTRIBUTES3*, pPlaneAttributes);
+} D3DKMT_CHECK_MULTIPLANE_OVERLAY_PLANE3;
+
+typedef struct _D3DKMT_MULTIPLANE_OVERLAY_POST_COMPOSITION_FLAGS
+{
+    union
+    {
+        struct
+        {
+            UINT VerticalFlip              : 1;   // 0x00000001
+            UINT HorizontalFlip            : 1;   // 0x00000002
+            UINT Reserved                  :30;   // 0xFFFFFFFC
+        };
+        UINT Value;
+    };
+} D3DKMT_MULTIPLANE_OVERLAY_POST_COMPOSITION_FLAGS;
+
+typedef struct _D3DKMT_MULTIPLANE_OVERLAY_POST_COMPOSITION
+{
+    D3DKMT_MULTIPLANE_OVERLAY_POST_COMPOSITION_FLAGS    Flags;
+    RECT                                                SrcRect;
+    RECT                                                DstRect;
+    D3DDDI_ROTATION                                     Rotation;
+} D3DKMT_MULTIPLANE_OVERLAY_POST_COMPOSITION;
+
+typedef struct _D3DKMT_MULTIPLANE_OVERLAY_POST_COMPOSITION_WITH_SOURCE
+{
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID             VidPnSourceId;
+    D3DKMT_MULTIPLANE_OVERLAY_POST_COMPOSITION PostComposition;
+} D3DKMT_MULTIPLANE_OVERLAY_POST_COMPOSITION_WITH_SOURCE;
+
+typedef struct _D3DKMT_CHECKMULTIPLANEOVERLAYSUPPORT3
+{
+    D3DKMT_HANDLE                                            hAdapter;           // in: adapter handle
+    D3DKMT_HANDLE                                            hDevice;            // in : Indentifies the device
+    UINT                                                     PlaneCount;         // in : Number of resources to pin
+    // Note: Array-of-pointers don't work in 32bit WSL
+    _Field_size_(PlaneCount)
+    D3DKMT_CHECK_MULTIPLANE_OVERLAY_PLANE3**                 ppOverlayPlanes;    // in : Array of pointers to overlay planes
+    UINT                                                     PostCompositionCount; // in : Number of resources to pin
+    _Field_size_(PostCompositionCount)
+    D3DKMT_MULTIPLANE_OVERLAY_POST_COMPOSITION_WITH_SOURCE** ppPostComposition;    // in : Array of pointers to overlay planes
+    BOOL                                                     Supported;
+    D3DKMT_CHECK_MULTIPLANE_OVERLAY_SUPPORT_RETURN_INFO      ReturnInfo;
+} D3DKMT_CHECKMULTIPLANEOVERLAYSUPPORT3;
+
+typedef struct _D3DKMT_PLANE_SPECIFIC_INPUT_FLAGS
+{
+    union
+    {
+        struct
+        {
+            UINT Enabled                   : 1;   // 0x00000001
+            UINT Reserved                  :31;   // 0xFFFFFFFE
+        };
+        UINT Value;
+    };
+} D3DKMT_PLANE_SPECIFIC_INPUT_FLAGS;
+
+typedef struct _D3DKMT_PLANE_SPECIFIC_OUTPUT_FLAGS
+{
+    union
+    {
+        struct
+        {
+            UINT FlipConvertedToImmediate  : 1;   // 0x00000001
+            UINT Reserved                  :31;   // 0xFFFFFFFE
+        };
+        UINT Value;
+    };
+} D3DKMT_PLANE_SPECIFIC_OUTPUT_FLAGS;
+
+typedef struct _D3DKMT_MULTIPLANE_OVERLAY3
+{
+    UINT                                         LayerIndex;
+    D3DKMT_PLANE_SPECIFIC_INPUT_FLAGS            InputFlags;
+    D3DDDI_FLIPINTERVAL_TYPE                     FlipInterval;
+    UINT                                         MaxImmediateFlipLine;
+    UINT                                         AllocationCount;
+    D3DKMT_PTR(_Field_size_(AllocationCount)
+    D3DKMT_HANDLE*,                              pAllocationList);
+    UINT                                         DriverPrivateDataSize;
+    D3DKMT_PTR(_Field_size_bytes_(DriverPrivateDataSize)
+    VOID*,                                       pDriverPrivateData);
+    D3DKMT_PTR(const D3DKMT_MULTIPLANE_OVERLAY_ATTRIBUTES3*, pPlaneAttributes);
+    D3DKMT_HANDLE                                hFlipToFence;
+    D3DKMT_HANDLE                                hFlipAwayFence;
+    D3DKMT_ALIGN64 UINT64                        FlipToFenceValue;
+    D3DKMT_ALIGN64 UINT64                        FlipAwayFenceValue;
+} D3DKMT_MULTIPLANE_OVERLAY3;
+
+typedef struct _D3DKMT_PRESENT_MULTIPLANE_OVERLAY_FLAGS
+{
+    union
+    {
+        struct
+        {
+            UINT FlipStereo                 : 1;    // 0x00000001 This is a flip from a stereo alloc. Used in addition to FlipImmediate or FlipOnNextVSync.
+            UINT FlipStereoTemporaryMono    : 1;    // 0x00000002 This is a flip from a stereo alloc. The left image should used. Used in addition to FlipImmediate or FlipOnNextVSync.
+            UINT FlipStereoPreferRight      : 1;    // 0x00000004 This is a flip from a stereo alloc. The right image should used when cloning to a mono monitor. Used in addition to FlipImmediate or FlipOnNextVSync.
+            UINT FlipDoNotWait              : 1;    // 0x00000008
+            UINT FlipDoNotFlip              : 1;    // 0x00000010
+            UINT FlipRestart                : 1;    // 0x00000020
+            UINT DurationValid              : 1;    // 0x00000040
+            UINT HDRMetaDataValid           : 1;    // 0x00000080
+            UINT HMD                        : 1;    // 0x00000100
+            UINT TrueImmediate              : 1;    // 0x00000200 If a present interval is 0, allow tearing rather than override a previously queued flip
+            UINT Reserved                   :22;    // 0xFFFFFE00
+        };
+        UINT Value;
+    };
+} D3DKMT_PRESENT_MULTIPLANE_OVERLAY_FLAGS;
+
+typedef struct _D3DKMT_PRESENT_MULTIPLANE_OVERLAY3
+{
+    D3DKMT_HANDLE                               hAdapter;           // in: adapter handle
+    UINT                                        ContextCount;
+    D3DKMT_PTR(_Field_size_(ContextCount)
+    D3DKMT_HANDLE*,                             pContextList);
+
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID              VidPnSourceId;      // in: VidPn source ID if RestrictVidPnSource is flagged
+    UINT                                        PresentCount;       // in: present counter
+    D3DKMT_PRESENT_MULTIPLANE_OVERLAY_FLAGS     Flags;              // in:
+
+    UINT                                        PresentPlaneCount;
+    // Note: Array-of-pointers don't work in 32bit WSL
+    _Field_size_(PresentPlaneCount)
+    D3DKMT_MULTIPLANE_OVERLAY3**                ppPresentPlanes;
+    D3DKMT_PTR(D3DKMT_MULTIPLANE_OVERLAY_POST_COMPOSITION*, pPostComposition);
+    UINT                                        Duration;
+    D3DDDI_HDR_METADATA_TYPE                    HDRMetaDataType;
+    UINT                                        HDRMetaDataSize;
+    D3DKMT_PTR(_Field_size_bytes_(HDRMetaDataSize)
+    const VOID*,                                pHDRMetaData);
+    UINT                                        BoostRefreshRateMultiplier;
+} D3DKMT_PRESENT_MULTIPLANE_OVERLAY3;
+#endif  // DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_1
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_2)
+typedef struct _D3DKMT_MULTIPLANE_OVERLAY_CAPS
+{
+    union
+    {
+        struct
+        {
+            UINT Rotation                        : 1;    // Full rotation
+            UINT RotationWithoutIndependentFlip  : 1;    // Rotation, but without simultaneous IndependentFlip support
+            UINT VerticalFlip                    : 1;    // Can flip the data vertically
+            UINT HorizontalFlip                  : 1;    // Can flip the data horizontally
+            UINT StretchRGB                      : 1;    // Supports stretching RGB formats
+            UINT StretchYUV                      : 1;    // Supports stretching YUV formats
+            UINT BilinearFilter                  : 1;    // Blinear filtering
+            UINT HighFilter                      : 1;    // Better than bilinear filtering
+            UINT Shared                          : 1;    // MPO resources are shared across VidPnSources
+            UINT Immediate                       : 1;    // Immediate flip support
+            UINT Plane0ForVirtualModeOnly        : 1;    // Stretching plane 0 will also stretch the HW cursor and should only be used for virtual mode support
+            UINT Version3DDISupport              : 1;    // Driver supports the 2.2 MPO DDIs
+            UINT Reserved                        : 20;
+        };
+        UINT Value;
+    };
+} D3DKMT_MULTIPLANE_OVERLAY_CAPS;
+
+typedef struct _D3DKMT_GET_MULTIPLANE_OVERLAY_CAPS
+{
+    D3DKMT_HANDLE                          hAdapter;             // in: adapter handle
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID         VidPnSourceId;        // in
+    UINT                                   MaxPlanes;            // out: Total number of planes currently supported
+    UINT                                   MaxRGBPlanes;         // out: Number of RGB planes currently supported
+    UINT                                   MaxYUVPlanes;         // out: Number of YUV planes currently supported
+    D3DKMT_MULTIPLANE_OVERLAY_CAPS         OverlayCaps;          // out: Overlay capabilities
+    float                                  MaxStretchFactor;     // out
+    float                                  MaxShrinkFactor;      // out
+} D3DKMT_GET_MULTIPLANE_OVERLAY_CAPS;
+
+typedef struct _D3DKMT_GET_POST_COMPOSITION_CAPS
+{
+    D3DKMT_HANDLE                          hAdapter;             // in: adapter handle
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID         VidPnSourceId;        // in
+    float                                  MaxStretchFactor;     // out
+    float                                  MaxShrinkFactor;      // out
+} D3DKMT_GET_POST_COMPOSITION_CAPS;
+
+typedef struct _D3DKMT_MULTIPLANEOVERLAY_STRETCH_SUPPORT
+{
+    UINT VidPnSourceId;
+    BOOL Update;
+    BOOL Supported;
+} D3DKMT_MULTIPLANEOVERLAY_STRETCH_SUPPORT;
+#endif  // DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_2
+
+typedef struct D3DKMT_MULTIPLANE_OVERLAY
+{
+    UINT                                 LayerIndex;
+    BOOL                                 Enabled;
+    D3DKMT_HANDLE                        hAllocation;
+    D3DKMT_MULTIPLANE_OVERLAY_ATTRIBUTES PlaneAttributes;
+} D3DKMT_MULTIPLANE_OVERLAY;
+
+typedef struct D3DKMT_PRESENT_MULTIPLANE_OVERLAY
+{
+    union
+    {
+        D3DKMT_HANDLE               hDevice;            // in: D3D10 compatibility.
+        D3DKMT_HANDLE               hContext;           // in: Indentifies the context
+    };
+    ULONG                           BroadcastContextCount;                          // in: Specifies the number of context
+                                                                                    //     to broadcast this command buffer to.
+    D3DKMT_HANDLE                   BroadcastContext[D3DDDI_MAX_BROADCAST_CONTEXT]; // in: Specifies the handle of the context to
+                                                                                    //     broadcast to.
+
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID  VidPnSourceId;      // in: VidPn source ID if RestrictVidPnSource is flagged
+    UINT                            PresentCount;       // in: present counter
+    D3DDDI_FLIPINTERVAL_TYPE        FlipInterval;       // in: flip interval
+    D3DKMT_PRESENTFLAGS             Flags;              // in:
+
+    UINT                            PresentPlaneCount;
+    D3DKMT_MULTIPLANE_OVERLAY*      pPresentPlanes;
+    UINT                            Duration;
+} D3DKMT_PRESENT_MULTIPLANE_OVERLAY;
+
+typedef struct _D3DKMT_RENDERFLAGS
+{
+    UINT    ResizeCommandBuffer     :  1;  // 0x00000001
+    UINT    ResizeAllocationList    :  1;  // 0x00000002
+    UINT    ResizePatchLocationList :  1;  // 0x00000004
+    UINT    NullRendering           :  1;  // 0x00000008
+    UINT    PresentRedirected       :  1;  // 0x00000010
+    UINT    RenderKm                :  1;  // 0x00000020    Cannot be used with DxgkRender
+    UINT    RenderKmReadback        :  1;  // 0x00000040    Cannot be used with DxgkRender
+    UINT    Reserved                : 25;  // 0xFFFFFF80
+} D3DKMT_RENDERFLAGS;
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8)
+typedef struct _D3DKMT_OUTPUTDUPLPRESENTFLAGS
+{
+    union
+    {
+        struct
+        {
+            UINT                ProtectedContentBlankedOut  :  1;
+            UINT                RemoteSession               :  1;
+            UINT                FullScreenPresent           :  1;
+            UINT                PresentIndirect             :  1;
+            UINT                Reserved                    : 28;
+        };
+        UINT    Value;
+    };
+}D3DKMT_OUTPUTDUPLPRESENTFLAGS;
+
+typedef struct _D3DKMT_OUTPUTDUPLPRESENT
+{
+    D3DKMT_HANDLE                   hContext;           // in: Indentifies the context
+    D3DKMT_HANDLE                   hSource;            // in: Source allocation to present from
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID  VidPnSourceId;
+    ULONG                           BroadcastContextCount;                          // in: Specifies the number of context
+    D3DKMT_HANDLE                   BroadcastContext[D3DDDI_MAX_BROADCAST_CONTEXT]; // in: Specifies the handle of the context to
+    D3DKMT_PRESENT_RGNS             PresentRegions;     // in: Dirty and move regions
+    D3DKMT_OUTPUTDUPLPRESENTFLAGS   Flags;
+    D3DKMT_HANDLE                   hIndirectContext;
+} D3DKMT_OUTPUTDUPLPRESENT;
+#endif
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_6)
+
+typedef struct _D3DKMT_OUTPUTDUPLPRESENTTOHWQUEUE
+{
+    D3DKMT_HANDLE                   hSource;            // in: Source allocation to present from
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID  VidPnSourceId;
+    ULONG                           BroadcastHwQueueCount;
+    D3DKMT_PTR(_Field_size_(BroadcastHwQueueCount)
+    D3DKMT_HANDLE*,                 hHwQueues);
+    D3DKMT_PRESENT_RGNS             PresentRegions;     // in: Dirty and move regions
+    D3DKMT_OUTPUTDUPLPRESENTFLAGS   Flags;
+    D3DKMT_HANDLE                   hIndirectHwQueue;
+} D3DKMT_OUTPUTDUPLPRESENTTOHWQUEUE;
+
+#endif
+
+typedef struct _D3DKMT_RENDER
+{
+    union
+    {
+        D3DKMT_HANDLE               hDevice;                    // in: D3D10 compatibility.
+        D3DKMT_HANDLE               hContext;                   // in: Indentifies the context
+    };
+    UINT                            CommandOffset;              // in: offset in bytes from start
+    UINT                            CommandLength;              // in: number of bytes
+    UINT                            AllocationCount;            // in: Number of allocations in allocation list.
+    UINT                            PatchLocationCount;         // in: Number of patch locations in patch allocation list.
+    D3DKMT_PTR(VOID*,               pNewCommandBuffer);         // out: Pointer to the next command buffer to use.
+                                                                // in: When RenderKm flag is set, it points to a command buffer.
+    UINT                            NewCommandBufferSize;       // in: Size requested for the next command buffer.
+                                                                // out: Size of the next command buffer to use.
+    D3DKMT_PTR(D3DDDI_ALLOCATIONLIST*, pNewAllocationList);     // out: Pointer to the next allocation list to use.
+                                                                // in: When RenderKm flag is set, it points to an allocation list.
+    UINT                            NewAllocationListSize;      // in: Size requested for the next allocation list.
+                                                                // out: Size of the new allocation list.
+    D3DKMT_PTR(D3DDDI_PATCHLOCATIONLIST*, pNewPatchLocationList); // out: Pointer to the next patch location list.
+    UINT                            NewPatchLocationListSize;   // in: Size requested for the next patch location list.
+                                                                // out: Size of the new patch location list.
+    D3DKMT_RENDERFLAGS              Flags;                      // in:
+    D3DKMT_ALIGN64 ULONGLONG        PresentHistoryToken;        // in: Present history token for redirected present calls
+    ULONG                           BroadcastContextCount;                          // in: Specifies the number of context
+                                                                                    //     to broadcast this command buffer to.
+    D3DKMT_HANDLE                   BroadcastContext[D3DDDI_MAX_BROADCAST_CONTEXT]; // in: Specifies the handle of the context to
+                                                                                    //     broadcast to.
+    ULONG                           QueuedBufferCount;          // out: Number of DMA buffer queued to this context after this submission.
+    D3DKMT_ALIGN64 D3DGPU_VIRTUAL_ADDRESS NewCommandBuffer;     // out: GPU virtual address of next command buffer to use. _ADVSCH_
+    D3DKMT_PTR(VOID*,               pPrivateDriverData);        // in: pointer to private driver data. _ADVSCH_
+    UINT                            PrivateDriverDataSize;      // in: size of private driver data. _ADVSCH_
+} D3DKMT_RENDER;
+
+
+typedef enum _D3DKMT_STANDARDALLOCATIONTYPE
+{
+    D3DKMT_STANDARDALLOCATIONTYPE_EXISTINGHEAP = 1,
+    D3DKMT_STANDARDALLOCATIONTYPE_INTERNALBACKINGSTORE = 2,
+    D3DKMT_STANDARDALLOCATIONTYPE_MAX,
+} D3DKMT_STANDARDALLOCATIONTYPE;
+
+typedef struct _D3DKMT_STANDARDALLOCATION_EXISTINGHEAP
+{
+    D3DKMT_ALIGN64 D3DKMT_SIZE_T Size;        // in: Size in bytes of existing heap
+} D3DKMT_STANDARDALLOCATION_EXISTINGHEAP;
+
+typedef struct _D3DKMT_CREATESTANDARDALLOCATIONFLAGS
+{
+    union
+    {
+        struct
+        {
+            UINT Reserved : 32; // 0xFFFFFFFF
+        };
+        UINT Value;
+    };
+} D3DKMT_CREATESTANDARDALLOCATIONFLAGS;
+
+typedef struct _D3DKMT_CREATESTANDARDALLOCATION
+{
+    //
+    // update onecoreuap/windows/core/ntuser/inc/whwin32.tpl when adding new memeber
+    // to this struct
+    //
+    D3DKMT_STANDARDALLOCATIONTYPE Type;
+    union
+    {
+        D3DKMT_STANDARDALLOCATION_EXISTINGHEAP ExistingHeapData;
+    };
+    D3DKMT_CREATESTANDARDALLOCATIONFLAGS Flags;
+} D3DKMT_CREATESTANDARDALLOCATION;
+
+typedef struct _D3DKMT_CREATEALLOCATIONFLAGS
+{
+    UINT    CreateResource              :  1;    // 0x00000001
+    UINT    CreateShared                :  1;    // 0x00000002
+    UINT    NonSecure                   :  1;    // 0x00000004
+    UINT    CreateProtected             :  1;    // 0x00000008 Cannot be used when allocation is created from the user mode.
+    UINT    RestrictSharedAccess        :  1;    // 0x00000010
+    UINT    ExistingSysMem              :  1;    // 0x00000020 Cannot be used when allocation is created from the user mode.
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8)
+    UINT    NtSecuritySharing           :  1;    // 0x00000040
+    UINT    ReadOnly                    :  1;    // 0x00000080
+    UINT    CreateWriteCombined         :  1;    // 0x00000100 Cannot be used when allocation is created from the user mode.
+    UINT    CreateCached                :  1;    // 0x00000200 Cannot be used when allocation is created from the user mode.
+    UINT    SwapChainBackBuffer         :  1;    // 0x00000400 Specifies whether an allocation corresponds to a swap chain back buffer.
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM1_3)
+    UINT    CrossAdapter                :  1;    // 0x00000800
+    UINT    OpenCrossAdapter            :  1;    // 0x00001000 Cannot be used when allocation is created from the user mode.
+    UINT    PartialSharedCreation       :  1;    // 0x00002000
+    UINT    Zeroed                      :  1;    // 0x00004000  // out: set when allocation fulfilled by zero pages
+    UINT    WriteWatch                  :  1;    // 0x00008000  // in: request Mm to track writes to pages of this allocation
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_3)
+    UINT    StandardAllocation          :  1;    // 0x00010000  // in: use pStandardAllocation instead of pPrivateDriverData
+    UINT    ExistingSection             :  1;    // 0x00020000  // in: Use Section Handle instead of SysMem in D3DDI_ALLOCATIONINFO2
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_6)
+    UINT    AllowNotZeroed              :  1;    // 0x00040000  // in: indicate zeroed pages are not required
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_7)
+    UINT    PhysicallyContiguous        :  1;    // 0x00080000  // in: indicate allocation must be physically contguous
+    UINT    NoKmdAccess                 :  1;    // 0x00100000  // in: KMD is not notified about the allocation
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM3_0)
+    UINT    SharedDisplayable           :  1;    // 0x00200000
+    UINT    Reserved                    : 10;    // 0xFFC00000
+#else
+    UINT    Reserved                    : 11;    // 0xFFE00000
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM3_0)
+#else
+    UINT    Reserved                    : 13;    // 0xFFF80000
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_7)
+#else
+    UINT    Reserved                    : 14;    // 0xFFFC0000
+#endif //(DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_6)
+#else
+    UINT    Reserved                    : 16;    // 0xFFFF0000
+#endif //(DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_3)
+#else
+    UINT    Reserved                    : 21;    // 0xFFFFF800
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM1_3)
+#else
+    UINT    Reserved                    : 26;    // 0xFFFFFFC0
+#endif
+} D3DKMT_CREATEALLOCATIONFLAGS;
+
+typedef struct _D3DKMT_CREATEALLOCATION
+{
+    D3DKMT_HANDLE                   hDevice;
+    D3DKMT_HANDLE                   hResource;      //in/out:valid only within device
+    D3DKMT_HANDLE                   hGlobalShare;   //out:Shared handle if CreateShared and not NtSecuritySharing
+    D3DKMT_PTR(_Field_size_bytes_(PrivateRuntimeDataSize)
+    CONST VOID*,                    pPrivateRuntimeData);
+    UINT                            PrivateRuntimeDataSize;
+    union
+    {
+        //
+        // update onecoreuap/windows/core/ntuser/inc/whwin32.tpl when adding new memeber
+        // to this union
+        //
+        D3DKMT_CREATESTANDARDALLOCATION* pStandardAllocation;
+        _Field_size_bytes_(PrivateDriverDataSize)
+        CONST VOID*                      pPrivateDriverData;
+        D3DKMT_PTR_HELPER(               AlignUnionTo64_1)
+    };
+    UINT                            PrivateDriverDataSize;
+    UINT                            NumAllocations;
+    union
+    {
+        _Field_size_(NumAllocations)       D3DDDI_ALLOCATIONINFO*   pAllocationInfo;
+#if ((DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN7) || \
+     (D3D_UMD_INTERFACE_VERSION >= D3D_UMD_INTERFACE_VERSION_WIN7))
+        _Field_size_(NumAllocations)       D3DDDI_ALLOCATIONINFO2*  pAllocationInfo2; // _ADVSCH_
+#endif
+        D3DKMT_PTR_HELPER(                                          AlignUnionTo64_2)
+    };
+    D3DKMT_CREATEALLOCATIONFLAGS    Flags;
+    D3DKMT_PTR(HANDLE,              hPrivateRuntimeResourceHandle); // opaque handle used for event tracing
+} D3DKMT_CREATEALLOCATION;
+
+typedef struct _D3DKMT_OPENRESOURCE
+{
+                                                        D3DKMT_HANDLE               hDevice;                            // in : Indentifies the device
+                                                        D3DKMT_HANDLE               hGlobalShare;                       // in : Shared resource handle
+                                                        UINT                        NumAllocations;                     // in : Number of allocations associated with the resource
+   union {
+    _Field_size_(NumAllocations)                      D3DDDI_OPENALLOCATIONINFO*  pOpenAllocationInfo;                // in : Array of open allocation structs
+#if ((DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN7) || \
+     (D3D_UMD_INTERFACE_VERSION >= D3D_UMD_INTERFACE_VERSION_WIN7))
+    _Field_size_(NumAllocations)                      D3DDDI_OPENALLOCATIONINFO2* pOpenAllocationInfo2;                // in : Array of open allocation structs // _ADVSCH_
+#endif
+    D3DKMT_PTR_HELPER(AlignUnionTo64)
+   };
+    D3DKMT_PTR(_Field_size_bytes_(PrivateRuntimeDataSize) VOID*,                    pPrivateRuntimeData);               // in : Caller supplied buffer where the runtime private data associated with this resource will be copied
+                                                        UINT                        PrivateRuntimeDataSize;             // in : Size in bytes of the pPrivateRuntimeData buffer
+    D3DKMT_PTR(_Field_size_bytes_(ResourcePrivateDriverDataSize) VOID*,             pResourcePrivateDriverData);        // in : Caller supplied buffer where the driver private data associated with the resource will be copied
+                                                        UINT                        ResourcePrivateDriverDataSize;      // in : Size in bytes of the pResourcePrivateDriverData buffer
+    D3DKMT_PTR(_Field_size_bytes_(TotalPrivateDriverDataBufferSize) VOID*,          pTotalPrivateDriverDataBuffer);     // in : Caller supplied buffer where the Driver private data will be stored
+                                                        UINT                        TotalPrivateDriverDataBufferSize;   // in/out : Size in bytes of pTotalPrivateDriverDataBuffer / Size in bytes of data written to pTotalPrivateDriverDataBuffer
+                                                        D3DKMT_HANDLE               hResource;                          // out : Handle for this resource in this process
+}D3DKMT_OPENRESOURCE;
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8)
+typedef struct _D3DKMT_OPENRESOURCEFROMNTHANDLE
+{
+                                                        D3DKMT_HANDLE               hDevice;                            // in : Indentifies the device
+    D3DKMT_PTR(                                         HANDLE,                     hNtHandle);                         // in : Process's NT handle
+                                                        UINT                        NumAllocations;                     // in : Number of allocations associated with the resource
+    D3DKMT_PTR(_Field_size_(NumAllocations)             D3DDDI_OPENALLOCATIONINFO2*, pOpenAllocationInfo2);             // in : Array of open allocation structs // _ADVSCH_
+                                                        UINT                        PrivateRuntimeDataSize;             // in : Size in bytes of the pPrivateRuntimeData buffer
+    D3DKMT_PTR(_Field_size_bytes_(PrivateRuntimeDataSize) VOID*,                    pPrivateRuntimeData);               // in : Caller supplied buffer where the runtime private data associated with this resource will be copied
+                                                        UINT                        ResourcePrivateDriverDataSize;      // in : Size in bytes of the pResourcePrivateDriverData buffer
+    D3DKMT_PTR(_Field_size_bytes_(ResourcePrivateDriverDataSize) VOID*,             pResourcePrivateDriverData);        // in : Caller supplied buffer where the driver private data associated with the resource will be copied
+                                                        UINT                        TotalPrivateDriverDataBufferSize;   // in/out : Size in bytes of pTotalPrivateDriverDataBuffer / Size in bytes of data written to pTotalPrivateDriverDataBuffer
+    D3DKMT_PTR(_Field_size_bytes_(TotalPrivateDriverDataBufferSize) VOID*,          pTotalPrivateDriverDataBuffer);     // in : Caller supplied buffer where the Driver private data will be stored
+                                                        D3DKMT_HANDLE               hResource;                          // out : Handle for this resource in this process
+
+                                                        D3DKMT_HANDLE               hKeyedMutex;                        // out: Handle to the keyed mutex in this process
+    D3DKMT_PTR(_In_reads_bytes_opt_(PrivateRuntimeDataSize) VOID*,                  pKeyedMutexPrivateRuntimeData);     // in:  Buffer containing initial private data.
+                                                                                                                        //      If NULL then PrivateRuntimeDataSize must be 0.
+                                                                                                                        //      It will only be copied if the keyed mutex does not already have private data.
+                                                        UINT                        KeyedMutexPrivateRuntimeDataSize;   // in:  Size in bytes of pPrivateRuntimeData.
+                                                        D3DKMT_HANDLE               hSyncObject;                        // out: Handle to sync object in this process.
+} D3DKMT_OPENRESOURCEFROMNTHANDLE;
+
+typedef struct _D3DKMT_OPENSYNCOBJECTFROMNTHANDLE
+{
+    D3DKMT_PTR(HANDLE, hNtHandle);                      // in : NT handle for the sync object.
+    D3DKMT_HANDLE   hSyncObject;                        // out: Handle to sync object in this process.
+} D3DKMT_OPENSYNCOBJECTFROMNTHANDLE;
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0)
+
+typedef struct _D3DKMT_OPENSYNCOBJECTFROMNTHANDLE2
+{
+    D3DKMT_PTR(HANDLE,                  hNtHandle);     // in : NT handle for the sync object.
+    D3DKMT_HANDLE                       hDevice;        // in : Device handle to use this sync object on.
+    D3DDDI_SYNCHRONIZATIONOBJECT_FLAGS  Flags;          // in : specifies sync object behavior for this device.
+    D3DKMT_HANDLE                       hSyncObject;    // out: Handle to sync object in this process.
+
+    union
+    {
+
+        struct
+        {
+            D3DKMT_PTR(VOID*,       FenceValueCPUVirtualAddress);           // out: Read-only mapping of the fence value for the CPU
+            D3DKMT_ALIGN64 D3DGPU_VIRTUAL_ADDRESS FenceValueGPUVirtualAddress; // out: Read/write mapping of the fence value for the GPU
+            UINT                    EngineAffinity;                         // in: Defines physical adapters where the GPU VA should be mapped
+        } MonitoredFence;
+
+        D3DKMT_ALIGN64 UINT64       Reserved[8];
+    };
+
+} D3DKMT_OPENSYNCOBJECTFROMNTHANDLE2;
+
+typedef struct _D3DKMT_OPENSYNCOBJECTNTHANDLEFROMNAME
+{
+    DWORD                          dwDesiredAccess;
+    D3DKMT_PTR(OBJECT_ATTRIBUTES*, pObjAttrib);
+    D3DKMT_PTR(HANDLE,             hNtHandle);
+} D3DKMT_OPENSYNCOBJECTNTHANDLEFROMNAME;
+
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_0
+
+typedef struct _D3DKMT_OPENNTHANDLEFROMNAME
+{
+    DWORD                          dwDesiredAccess;
+    D3DKMT_PTR(OBJECT_ATTRIBUTES*, pObjAttrib);
+    D3DKMT_PTR(HANDLE,             hNtHandle);
+} D3DKMT_OPENNTHANDLEFROMNAME;
+
+#define SHARED_ALLOCATION_WRITE         0x1
+#define SHARED_ALLOCATION_ALL_ACCESS    (STANDARD_RIGHTS_REQUIRED | SHARED_ALLOCATION_WRITE)
+
+typedef struct _D3DKMT_QUERYRESOURCEINFOFROMNTHANDLE
+{
+    D3DKMT_HANDLE      hDevice;                        // in : Indentifies the device
+    D3DKMT_PTR(HANDLE, hNtHandle);                     // in : Global resource handle to open
+    D3DKMT_PTR(VOID*,  pPrivateRuntimeData);           // in : Ptr to buffer that will receive runtime private data for the resource
+    UINT               PrivateRuntimeDataSize;         // in/out : Size in bytes of buffer passed in for runtime private data / If pPrivateRuntimeData was NULL then size in bytes of buffer required for the runtime private data otherwise size in bytes of runtime private data copied into the buffer
+    UINT               TotalPrivateDriverDataSize;     // out : Size in bytes of buffer required to hold all the DriverPrivate data for all of the allocations associated withe the resource
+    UINT               ResourcePrivateDriverDataSize;  // out : Size in bytes of the driver's resource private data
+    UINT               NumAllocations;                 // out : Number of allocations associated with this resource
+}D3DKMT_QUERYRESOURCEINFOFROMNTHANDLE;
+
+#endif
+
+typedef struct _D3DKMT_QUERYRESOURCEINFO
+{
+    D3DKMT_HANDLE   hDevice;                        // in : Indentifies the device
+    D3DKMT_HANDLE   hGlobalShare;                   // in : Global resource handle to open
+    D3DKMT_PTR(VOID*, pPrivateRuntimeData);         // in : Ptr to buffer that will receive runtime private data for the resource
+    UINT            PrivateRuntimeDataSize;         // in/out : Size in bytes of buffer passed in for runtime private data / If pPrivateRuntimeData was NULL then size in bytes of buffer required for the runtime private data otherwise size in bytes of runtime private data copied into the buffer
+    UINT            TotalPrivateDriverDataSize;     // out : Size in bytes of buffer required to hold all the DriverPrivate data for all of the allocations associated withe the resource
+    UINT            ResourcePrivateDriverDataSize;  // out : Size in bytes of the driver's resource private data
+    UINT            NumAllocations;                 // out : Number of allocations associated with this resource
+}D3DKMT_QUERYRESOURCEINFO;
+
+typedef struct _D3DKMT_DESTROYALLOCATION
+{
+    D3DKMT_HANDLE           hDevice;            // in: Indentifies the device
+    D3DKMT_HANDLE           hResource;
+    D3DKMT_PTR(CONST D3DKMT_HANDLE*, phAllocationList);   // in: pointer to an array allocation handles to destroy
+    UINT                    AllocationCount;    // in: Number of allocations in phAllocationList
+} D3DKMT_DESTROYALLOCATION;
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0)
+
+typedef struct _D3DKMT_DESTROYALLOCATION2
+{
+    D3DKMT_HANDLE                       hDevice;            // in: Indentifies the device
+    D3DKMT_HANDLE                       hResource;
+    D3DKMT_PTR(CONST D3DKMT_HANDLE*,    phAllocationList);  // in: pointer to an array allocation handles to destroy
+    UINT                                AllocationCount;    // in: Number of allocations in phAllocationList
+    D3DDDICB_DESTROYALLOCATION2FLAGS    Flags;              // in: Bit field defined by D3DDDICB_DESTROYALLOCATION2FLAGS
+} D3DKMT_DESTROYALLOCATION2;
+
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_0
+
+typedef struct _D3DKMT_SETALLOCATIONPRIORITY
+{
+    D3DKMT_HANDLE           hDevice;            // in: Indentifies the device
+    D3DKMT_HANDLE           hResource;          // in: Specify the resource to set priority to.
+    D3DKMT_PTR(CONST D3DKMT_HANDLE*, phAllocationList);   // in: pointer to an array allocation handles to destroy
+    UINT                    AllocationCount;    // in: Number of allocations in phAllocationList
+    D3DKMT_PTR(CONST UINT*, pPriorities);       // in: New priority for each of the allocation in the array.
+} D3DKMT_SETALLOCATIONPRIORITY;
+
+typedef enum _D3DKMT_ALLOCATIONRESIDENCYSTATUS
+{
+    D3DKMT_ALLOCATIONRESIDENCYSTATUS_RESIDENTINGPUMEMORY=1,
+    D3DKMT_ALLOCATIONRESIDENCYSTATUS_RESIDENTINSHAREDMEMORY=2,
+    D3DKMT_ALLOCATIONRESIDENCYSTATUS_NOTRESIDENT=3,
+} D3DKMT_ALLOCATIONRESIDENCYSTATUS;
+
+typedef struct _D3DKMT_QUERYALLOCATIONRESIDENCY
+{
+    D3DKMT_HANDLE                       hDevice;            // in: Indentifies the device
+    D3DKMT_HANDLE                       hResource;          // in: pointer to resource owning the list of allocation.
+    D3DKMT_PTR(CONST D3DKMT_HANDLE*,    phAllocationList);  // in: pointer to an array allocation to get residency status.
+    UINT                                AllocationCount;    // in: Number of allocations in phAllocationList
+    D3DKMT_PTR(D3DKMT_ALLOCATIONRESIDENCYSTATUS*, pResidencyStatus); // out: Residency status of each allocation in the array.
+} D3DKMT_QUERYALLOCATIONRESIDENCY;
+
+typedef struct _D3DKMT_GETRUNTIMEDATA
+{
+    D3DKMT_HANDLE       hAdapter;
+    D3DKMT_HANDLE       hGlobalShare;       // in: shared handle
+    D3DKMT_PTR(VOID*,   pRuntimeData);      // out: in: for a version?
+    UINT                RuntimeDataSize;    // in:
+} D3DKMT_GETRUNTIMEDATA;
+
+typedef enum _KMTUMDVERSION
+{
+    KMTUMDVERSION_DX9 = 0,
+    KMTUMDVERSION_DX10,
+    KMTUMDVERSION_DX11,
+    KMTUMDVERSION_DX12,
+    NUM_KMTUMDVERSIONS
+} KMTUMDVERSION;
+
+typedef struct _D3DKMT_UMDFILENAMEINFO
+{
+    KMTUMDVERSION       Version;                // In: UMD version
+    WCHAR               UmdFileName[MAX_PATH];  // Out: UMD file name
+} D3DKMT_UMDFILENAMEINFO;
+
+#define D3DKMT_COMPONENTIZED_INDICATOR  L'#'
+#define D3DKMT_SUBKEY_DX9               L"DX9"
+#define D3DKMT_SUBKEY_OPENGL            L"OpenGL"
+
+typedef struct _D3DKMT_OPENGLINFO
+{
+    WCHAR               UmdOpenGlIcdFileName[MAX_PATH];
+    ULONG               Version;
+    ULONG               Flags;
+} D3DKMT_OPENGLINFO;
+
+typedef struct _D3DKMT_SEGMENTSIZEINFO
+{
+    D3DKMT_ALIGN64 ULONGLONG           DedicatedVideoMemorySize;
+    D3DKMT_ALIGN64 ULONGLONG           DedicatedSystemMemorySize;
+    D3DKMT_ALIGN64 ULONGLONG           SharedSystemMemorySize;
+} D3DKMT_SEGMENTSIZEINFO;
+
+typedef struct _D3DKMT_SEGMENTGROUPSIZEINFO
+{
+    UINT32 PhysicalAdapterIndex;
+    D3DKMT_SEGMENTSIZEINFO LegacyInfo;
+    D3DKMT_ALIGN64 ULONGLONG LocalMemory;
+    D3DKMT_ALIGN64 ULONGLONG NonLocalMemory;
+    D3DKMT_ALIGN64 ULONGLONG NonBudgetMemory;
+} D3DKMT_SEGMENTGROUPSIZEINFO;
+
+typedef struct _D3DKMT_WORKINGSETFLAGS
+{
+    UINT    UseDefault   :  1;   // 0x00000001
+    UINT    Reserved     : 31;   // 0xFFFFFFFE
+} D3DKMT_WORKINGSETFLAGS;
+
+typedef struct _D3DKMT_WORKINGSETINFO
+{
+    D3DKMT_WORKINGSETFLAGS Flags;
+    ULONG MinimumWorkingSetPercentile;
+    ULONG MaximumWorkingSetPercentile;
+} D3DKMT_WORKINGSETINFO;
+
+typedef struct _D3DKMT_FLIPINFOFLAGS
+{
+    UINT                FlipInterval :  1; // 0x00000001 // Set when kmd driver support FlipInterval natively
+    UINT                Reserved     : 31; // 0xFFFFFFFE
+} D3DKMT_FLIPINFOFLAGS;
+
+typedef struct _D3DKMT_FLIPQUEUEINFO
+{
+    UINT                 MaxHardwareFlipQueueLength; // Max flip can be queued for hardware flip queue.
+    UINT                 MaxSoftwareFlipQueueLength; // Max flip can be queued for software flip queue for non-legacy device.
+    D3DKMT_FLIPINFOFLAGS FlipFlags;
+} D3DKMT_FLIPQUEUEINFO;
+
+typedef struct _D3DKMT_ADAPTERADDRESS
+{
+    UINT   BusNumber;              // Bus number on which the physical device is located.
+    UINT   DeviceNumber;           // Index of the physical device on the bus.
+    UINT   FunctionNumber;         // Function number of the adapter on the physical device.
+} D3DKMT_ADAPTERADDRESS;
+
+typedef struct _D3DKMT_ADAPTERREGISTRYINFO
+{
+    WCHAR   AdapterString[MAX_PATH];
+    WCHAR   BiosString[MAX_PATH];
+    WCHAR   DacType[MAX_PATH];
+    WCHAR   ChipType[MAX_PATH];
+} D3DKMT_ADAPTERREGISTRYINFO;
+
+typedef struct _D3DKMT_CURRENTDISPLAYMODE
+{
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID VidPnSourceId;
+    D3DKMT_DISPLAYMODE DisplayMode;
+} D3DKMT_CURRENTDISPLAYMODE;
+
+typedef struct _D3DKMT_VIRTUALADDRESSFLAGS // _ADVSCH_
+{
+    UINT   VirtualAddressSupported :  1;
+    UINT   Reserved                : 31;
+} D3DKMT_VIRTUALADDRESSFLAGS;
+
+typedef struct _D3DKMT_VIRTUALADDRESSINFO // _ADVSCH_
+{
+    D3DKMT_VIRTUALADDRESSFLAGS VirtualAddressFlags;
+} D3DKMT_VIRTUALADDRESSINFO;
+
+typedef enum _QAI_DRIVERVERSION
+{
+    KMT_DRIVERVERSION_WDDM_1_0               = 1000,
+    KMT_DRIVERVERSION_WDDM_1_1_PRERELEASE    = 1102,
+    KMT_DRIVERVERSION_WDDM_1_1               = 1105,
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8)
+    KMT_DRIVERVERSION_WDDM_1_2               = 1200,
+#endif
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM1_3)
+    KMT_DRIVERVERSION_WDDM_1_3               = 1300,
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM1_3
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0)
+    KMT_DRIVERVERSION_WDDM_2_0               = 2000,
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_0
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_1)
+    KMT_DRIVERVERSION_WDDM_2_1               = 2100,
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_1
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_2)
+    KMT_DRIVERVERSION_WDDM_2_2 = 2200,
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_2
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_3)
+    KMT_DRIVERVERSION_WDDM_2_3 = 2300,
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_3
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_4)
+    KMT_DRIVERVERSION_WDDM_2_4 = 2400,
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_4
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_5)
+    KMT_DRIVERVERSION_WDDM_2_5 = 2500,
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_5
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_6)
+    KMT_DRIVERVERSION_WDDM_2_6 = 2600,
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_6
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_7)
+    KMT_DRIVERVERSION_WDDM_2_7 = 2700,
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_7
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_8)
+    KMT_DRIVERVERSION_WDDM_2_8 = 2800,
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_8
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_9)
+    KMT_DRIVERVERSION_WDDM_2_9 = 2900,
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_9
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM3_0)
+    KMT_DRIVERVERSION_WDDM_3_0 = 3000
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM3_0
+} D3DKMT_DRIVERVERSION;
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8)
+typedef struct _D3DKMT_ADAPTERTYPE
+{
+    union
+    {
+        struct
+        {
+            UINT   RenderSupported       :  1;
+            UINT   DisplaySupported      :  1;
+            UINT   SoftwareDevice        :  1;
+            UINT   PostDevice            :  1;
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM1_3)
+            UINT   HybridDiscrete        :  1;
+            UINT   HybridIntegrated      :  1;
+            UINT   IndirectDisplayDevice :  1;
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_3)
+            UINT   Paravirtualized              :  1;
+            UINT   ACGSupported                 :  1;
+            UINT   SupportSetTimingsFromVidPn   :  1;
+            UINT   Detachable                   :  1;
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_6)
+            UINT   ComputeOnly                  :  1;
+            UINT   Prototype                    :  1;
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_9)
+            UINT   RuntimePowerManagement       :  1;
+            UINT   Reserved                     : 18;
+#else
+            UINT   Reserved                     : 19;
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_9)
+#else
+            UINT   Reserved              : 21;
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_6)
+#else
+            UINT   Reserved              : 25;
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_3)
+#else
+            UINT   Reserved              : 28;
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM1_3)
+        };
+        UINT Value;
+    };
+} D3DKMT_ADAPTERTYPE;
+
+typedef struct _D3DKMT_OUTPUTDUPLCONTEXTSCOUNT
+{
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID VidPnSourceId;
+    UINT OutputDuplicationCount;
+} D3DKMT_OUTPUTDUPLCONTEXTSCOUNT;
+
+typedef struct _D3DKMT_UMD_DRIVER_VERSION
+{
+    D3DKMT_ALIGN64 LARGE_INTEGER DriverVersion;
+} D3DKMT_UMD_DRIVER_VERSION;
+
+typedef struct _D3DKMT_KMD_DRIVER_VERSION
+{
+    D3DKMT_ALIGN64 LARGE_INTEGER DriverVersion;
+} D3DKMT_KMD_DRIVER_VERSION;
+
+typedef struct _D3DKMT_DIRECTFLIP_SUPPORT
+{
+    BOOL Supported;
+} D3DKMT_DIRECTFLIP_SUPPORT;
+
+typedef struct _D3DKMT_MULTIPLANEOVERLAY_SUPPORT
+{
+    BOOL Supported;
+} D3DKMT_MULTIPLANEOVERLAY_SUPPORT;
+#endif
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM1_3_PATH_INDEPENDENT_ROTATION)
+typedef struct _D3DKMT_MULTIPLANEOVERLAY_HUD_SUPPORT
+{
+    UINT VidPnSourceId; // Not yet used.
+    BOOL Update;
+    BOOL KernelSupported;
+    BOOL HudSupported;
+} D3DKMT_MULTIPLANEOVERLAY_HUD_SUPPORT;
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM1_3_PATH_INDEPENDENT_ROTATION
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM1_3)
+
+typedef struct _D3DKMT_DLIST_DRIVER_NAME
+{
+    WCHAR DListFileName[MAX_PATH];  // Out: DList driver file name
+} D3DKMT_DLIST_DRIVER_NAME;
+
+typedef struct _D3DKMT_CPDRIVERNAME
+{
+    WCHAR  ContentProtectionFileName[MAX_PATH];
+} D3DKMT_CPDRIVERNAME;
+
+typedef struct _D3DKMT_MIRACASTCOMPANIONDRIVERNAME
+{
+    WCHAR  MiracastCompanionDriverName[MAX_PATH];
+} D3DKMT_MIRACASTCOMPANIONDRIVERNAME;
+
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM1_3
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0)
+
+typedef struct _D3DKMT_XBOX
+{
+    BOOL IsXBOX;
+} D3DKMT_XBOX;
+
+typedef struct _D3DKMT_INDEPENDENTFLIP_SUPPORT
+{
+    BOOL Supported;
+} D3DKMT_INDEPENDENTFLIP_SUPPORT;
+
+typedef struct _D3DKMT_MULTIPLANEOVERLAY_DECODE_SUPPORT
+{
+    BOOL Supported;
+} D3DKMT_MULTIPLANEOVERLAY_DECODE_SUPPORT;
+
+typedef struct _D3DKMT_ISBADDRIVERFORHWPROTECTIONDISABLED
+{
+    BOOL Disabled;
+} D3DKMT_ISBADDRIVERFORHWPROTECTIONDISABLED;
+
+typedef struct _D3DKMT_MULTIPLANEOVERLAY_SECONDARY_SUPPORT
+{
+    BOOL Supported;
+} D3DKMT_MULTIPLANEOVERLAY_SECONDARY_SUPPORT;
+
+typedef struct _D3DKMT_INDEPENDENTFLIP_SECONDARY_SUPPORT
+{
+    BOOL Supported;
+} D3DKMT_INDEPENDENTFLIP_SECONDARY_SUPPORT;
+
+typedef struct _D3DKMT_PANELFITTER_SUPPORT
+{
+    BOOL Supported;
+} D3DKMT_PANELFITTER_SUPPORT;
+
+typedef struct _D3DKMT_PHYSICAL_ADAPTER_COUNT
+{
+    UINT Count;
+} D3DKMT_PHYSICAL_ADAPTER_COUNT;
+
+typedef struct _D3DKMT_DEVICE_IDS
+{
+    UINT VendorID;
+    UINT DeviceID;
+    UINT SubVendorID;
+    UINT SubSystemID;
+    UINT RevisionID;
+    UINT BusType;
+} D3DKMT_DEVICE_IDS;
+
+typedef struct _D3DKMT_QUERY_DEVICE_IDS
+{
+    UINT              PhysicalAdapterIndex; // in:
+    D3DKMT_DEVICE_IDS DeviceIds;            // out:
+} D3DKMT_QUERY_DEVICE_IDS;
+
+typedef enum _D3DKMT_PNP_KEY_TYPE
+{
+    D3DKMT_PNP_KEY_HARDWARE = 1,
+    D3DKMT_PNP_KEY_SOFTWARE = 2
+} D3DKMT_PNP_KEY_TYPE;
+
+typedef struct _D3DKMT_QUERY_PHYSICAL_ADAPTER_PNP_KEY
+{
+    UINT PhysicalAdapterIndex;
+    D3DKMT_PNP_KEY_TYPE PnPKeyType;
+    D3DKMT_PTR(_Field_size_opt_(*pCchDest) WCHAR*, pDest);
+    D3DKMT_PTR(UINT*, pCchDest);
+} D3DKMT_QUERY_PHYSICAL_ADAPTER_PNP_KEY;
+
+typedef enum _D3DKMT_MIRACAST_DRIVER_TYPE
+{
+    D3DKMT_MIRACAST_DRIVER_NOT_SUPPORTED = 0,
+    D3DKMT_MIRACAST_DRIVER_IHV = 1,
+    D3DKMT_MIRACAST_DRIVER_MS = 2,
+} D3DKMT_MIRACAST_DRIVER_TYPE;
+
+typedef struct _D3DKMT_QUERY_MIRACAST_DRIVER_TYPE
+{
+    D3DKMT_MIRACAST_DRIVER_TYPE MiracastDriverType;
+} D3DKMT_QUERY_MIRACAST_DRIVER_TYPE;
+
+typedef struct _D3DKMT_GPUMMU_CAPS
+{
+    union
+    {
+        struct
+        {
+            UINT ReadOnlyMemorySupported                : 1;
+            UINT NoExecuteMemorySupported               : 1;
+            UINT CacheCoherentMemorySupported           : 1;
+            UINT Reserved                               : 29;
+        };
+        UINT        Value;
+    } Flags;
+    UINT                        VirtualAddressBitCount;
+} D3DKMT_GPUMMU_CAPS;
+
+typedef struct _D3DKMT_QUERY_GPUMMU_CAPS
+{
+    UINT PhysicalAdapterIndex; // in:
+    D3DKMT_GPUMMU_CAPS Caps;   // out:
+} D3DKMT_QUERY_GPUMMU_CAPS;
+
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_0
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_2)
+
+typedef struct _D3DKMT_MPO3DDI_SUPPORT
+{
+    BOOL Supported;
+} D3DKMT_MPO3DDI_SUPPORT;
+
+typedef struct _D3DKMT_HWDRM_SUPPORT
+{
+    BOOLEAN Supported;
+} D3DKMT_HWDRM_SUPPORT;
+
+typedef struct _D3DKMT_MPOKERNELCAPS_SUPPORT
+{
+    BOOL Supported;
+} D3DKMT_MPOKERNELCAPS_SUPPORT;
+
+typedef struct _D3DKMT_GET_DEVICE_VIDPN_OWNERSHIP_INFO
+{
+    D3DKMT_HANDLE hDevice;                           // in : Indentifies the device
+    BOOLEAN bFailedDwmAcquireVidPn;                  // out : True if Dwm Acquire VidPn failed due to another Dwm device having ownership
+} D3DKMT_GET_DEVICE_VIDPN_OWNERSHIP_INFO;
+
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_2
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_4)
+
+typedef struct _D3DKMT_BLOCKLIST_INFO
+{
+    UINT Size;
+    WCHAR BlockList[1];
+} D3DKMT_BLOCKLIST_INFO;
+
+typedef struct _D3DKMT_QUERY_ADAPTER_UNIQUE_GUID
+{
+    WCHAR AdapterUniqueGUID[40];
+} D3DKMT_QUERY_ADAPTER_UNIQUE_GUID;
+
+typedef struct _D3DKMT_NODE_PERFDATA
+{
+    UINT32          NodeOrdinal;            // in: Node ordinal of the requested engine.
+    UINT32          PhysicalAdapterIndex;   // in: The physical adapter index, in an LDA chain
+    D3DKMT_ALIGN64 ULONGLONG Frequency;     // out: Clock frequency of the engine in hertz
+    D3DKMT_ALIGN64 ULONGLONG MaxFrequency;  // out: Max engine clock frequency
+    D3DKMT_ALIGN64 ULONGLONG MaxFrequencyOC;// out: Max engine over clock frequency
+    ULONG           Voltage;                // out: Voltage of the engine in milli volts mV
+    ULONG           VoltageMax;             // out: Max voltage levels in milli volts.
+    ULONG           VoltageMaxOC;           // out: Max voltage level while overclocked in milli volts.
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_5)
+    D3DKMT_ALIGN64 ULONGLONG MaxTransitionLatency;   // out: Max transition latency to change the frequency in 100 nanoseconds
+#else
+    D3DKMT_ALIGN64 ULONGLONG Reserved;
+#endif
+} D3DKMT_NODE_PERFDATA;
+
+typedef struct _D3DKMT_ADAPTER_PERFDATA
+{
+    UINT32          PhysicalAdapterIndex;   // in: The physical adapter index, in an LDA chain
+    D3DKMT_ALIGN64 ULONGLONG MemoryFrequency;        // out: Clock frequency of the memory in hertz
+    D3DKMT_ALIGN64 ULONGLONG MaxMemoryFrequency;     // out: Max memory clock frequency
+    D3DKMT_ALIGN64 ULONGLONG MaxMemoryFrequencyOC;   // out: Clock frequency of the memory while overclocked in hertz.
+    D3DKMT_ALIGN64 ULONGLONG MemoryBandwidth;        // out: Amount of memory transferred in bytes
+    D3DKMT_ALIGN64 ULONGLONG PCIEBandwidth;          // out: Amount of memory transferred over PCI-E in bytes
+    ULONG           FanRPM;                 // out: Fan rpm
+    ULONG           Power;                  // out: Power draw of the adapter in tenths of a percentage
+    ULONG           Temperature;            // out: Temperature in deci-Celsius 1 = 0.1C
+    UCHAR           PowerStateOverride;     // out: Overrides dxgkrnls power view of linked adapters.
+} D3DKMT_ADAPTER_PERFDATA;
+
+typedef struct _D3DKMT_ADAPTER_PERFDATACAPS
+{
+    UINT32      PhysicalAdapterIndex;   // in: The physical adapter index, in an LDA chain
+    D3DKMT_ALIGN64 ULONGLONG MaxMemoryBandwidth;     // out: Max memory bandwidth in bytes for 1 second
+    D3DKMT_ALIGN64 ULONGLONG MaxPCIEBandwidth;       // out: Max pcie bandwidth in bytes for 1 second
+    ULONG       MaxFanRPM;              // out: Max fan rpm
+    ULONG       TemperatureMax;         // out: Max temperature before damage levels
+    ULONG       TemperatureWarning;     // out: The temperature level where throttling begins.
+} D3DKMT_ADAPTER_PERFDATACAPS;
+
+#define DXGK_MAX_GPUVERSION_NAME_LENGTH 32
+typedef struct _D3DKMT_GPUVERSION
+{
+    UINT32          PhysicalAdapterIndex;                             // in: The physical adapter index, in an LDA chain
+    WCHAR           BiosVersion[DXGK_MAX_GPUVERSION_NAME_LENGTH];     //out: The gpu bios version
+    WCHAR           GpuArchitecture[DXGK_MAX_GPUVERSION_NAME_LENGTH]; //out: The gpu architectures name.
+} D3DKMT_GPUVERSION;
+
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_4
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_6)
+
+typedef struct _D3DKMT_DRIVER_DESCRIPTION
+{
+    WCHAR           DriverDescription[4096];     //out: The driver description
+} D3DKMT_DRIVER_DESCRIPTION;
+
+typedef struct _D3DKMT_QUERY_SCANOUT_CAPS
+{
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID VidPnSourceId;
+    UINT Caps;
+} D3DKMT_QUERY_SCANOUT_CAPS;
+
+typedef enum _KMT_DISPLAY_UMD_VERSION
+{
+    KMT_DISPLAY_UMDVERSION_1 = 0,
+    NUM_KMT_DISPLAY_UMDVERSIONS
+} KMT_DISPLAY_UMD_VERSION;
+
+typedef struct _D3DKMT_DISPLAY_UMD_FILENAMEINFO
+{
+    KMT_DISPLAY_UMD_VERSION Version;                // In: UMD version
+    WCHAR                   UmdFileName[MAX_PATH];  // Out: UMD file name
+} D3DKMT_DISPLAY_UMD_FILENAMEINFO;
+
+typedef struct _D3DKMT_PARAVIRTUALIZATION
+{
+    // This adapter property originates from the VM/ Container, and is currently replicated on adapters.
+    // It precludes extended device functions (i.e. Escapes) for paravirtualized devices which not known at all,
+    // and therefore assumed not to be secure enough for demanding server scenarios.
+    BOOLEAN SecureContainer;
+} D3DKMT_PARAVIRTUALIZATION;
+
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_6
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_8)
+
+typedef struct _D3DKMT_HYBRID_DLIST_DLL_SUPPORT
+{
+    BOOL Supported;
+} D3DKMT_HYBRID_DLIST_DLL_SUPPORT;
+
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_8
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_9)
+
+
+typedef enum _D3DKMT_CROSSADAPTERRESOURCE_SUPPORT_TIER
+{
+    D3DKMT_CROSSADAPTERRESOURCE_SUPPORT_TIER_NONE    = 0,
+    D3DKMT_CROSSADAPTERRESOURCE_SUPPORT_TIER_COPY    = 1,
+    D3DKMT_CROSSADAPTERRESOURCE_SUPPORT_TIER_TEXTURE = 2,
+    D3DKMT_CROSSADAPTERRESOURCE_SUPPORT_TIER_SCANOUT = 3,
+} D3DKMT_CROSSADAPTERRESOURCE_SUPPORT_TIER;
+
+typedef struct _D3DKMT_CROSSADAPTERRESOURCE_SUPPORT
+{
+    D3DKMT_CROSSADAPTERRESOURCE_SUPPORT_TIER SupportTier;
+} D3DKMT_CROSSADAPTERRESOURCE_SUPPORT;
+
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_9
+
+typedef enum _KMTQUERYADAPTERINFOTYPE
+{
+     KMTQAITYPE_UMDRIVERPRIVATE         =  0,
+     KMTQAITYPE_UMDRIVERNAME            =  1,
+     KMTQAITYPE_UMOPENGLINFO            =  2,
+     KMTQAITYPE_GETSEGMENTSIZE          =  3,
+     KMTQAITYPE_ADAPTERGUID             =  4,
+     KMTQAITYPE_FLIPQUEUEINFO           =  5,
+     KMTQAITYPE_ADAPTERADDRESS          =  6,
+     KMTQAITYPE_SETWORKINGSETINFO       =  7,
+     KMTQAITYPE_ADAPTERREGISTRYINFO     =  8,
+     KMTQAITYPE_CURRENTDISPLAYMODE      =  9,
+     KMTQAITYPE_MODELIST                = 10,
+     KMTQAITYPE_CHECKDRIVERUPDATESTATUS = 11,
+     KMTQAITYPE_VIRTUALADDRESSINFO      = 12, // _ADVSCH_
+     KMTQAITYPE_DRIVERVERSION           = 13,
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8)
+     KMTQAITYPE_ADAPTERTYPE             = 15,
+     KMTQAITYPE_OUTPUTDUPLCONTEXTSCOUNT = 16,
+     KMTQAITYPE_WDDM_1_2_CAPS           = 17,
+     KMTQAITYPE_UMD_DRIVER_VERSION      = 18,
+     KMTQAITYPE_DIRECTFLIP_SUPPORT      = 19,
+#endif
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM1_3)
+     KMTQAITYPE_MULTIPLANEOVERLAY_SUPPORT = 20,
+     KMTQAITYPE_DLIST_DRIVER_NAME       = 21,
+     KMTQAITYPE_WDDM_1_3_CAPS           = 22,
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM1_3
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM1_3_PATH_INDEPENDENT_ROTATION)
+     KMTQAITYPE_MULTIPLANEOVERLAY_HUD_SUPPORT = 23,
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM1_3_PATH_INDEPENDENT_ROTATION
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0)
+     KMTQAITYPE_WDDM_2_0_CAPS           = 24,
+     KMTQAITYPE_NODEMETADATA            = 25,
+     KMTQAITYPE_CPDRIVERNAME            = 26,
+     KMTQAITYPE_XBOX                    = 27,
+     KMTQAITYPE_INDEPENDENTFLIP_SUPPORT = 28,
+     KMTQAITYPE_MIRACASTCOMPANIONDRIVERNAME = 29,
+     KMTQAITYPE_PHYSICALADAPTERCOUNT    = 30,
+     KMTQAITYPE_PHYSICALADAPTERDEVICEIDS = 31,
+     KMTQAITYPE_DRIVERCAPS_EXT          = 32,
+     KMTQAITYPE_QUERY_MIRACAST_DRIVER_TYPE = 33,
+     KMTQAITYPE_QUERY_GPUMMU_CAPS       = 34,
+     KMTQAITYPE_QUERY_MULTIPLANEOVERLAY_DECODE_SUPPORT = 35,
+     KMTQAITYPE_QUERY_HW_PROTECTION_TEARDOWN_COUNT = 36,
+     KMTQAITYPE_QUERY_ISBADDRIVERFORHWPROTECTIONDISABLED = 37,
+     KMTQAITYPE_MULTIPLANEOVERLAY_SECONDARY_SUPPORT = 38,
+     KMTQAITYPE_INDEPENDENTFLIP_SECONDARY_SUPPORT = 39,
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_0
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_1)
+     KMTQAITYPE_PANELFITTER_SUPPORT     = 40,
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_1
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_2)
+     KMTQAITYPE_PHYSICALADAPTERPNPKEY   = 41,
+     KMTQAITYPE_GETSEGMENTGROUPSIZE     = 42,
+     KMTQAITYPE_MPO3DDI_SUPPORT         = 43,
+     KMTQAITYPE_HWDRM_SUPPORT           = 44,
+     KMTQAITYPE_MPOKERNELCAPS_SUPPORT   = 45,
+     KMTQAITYPE_MULTIPLANEOVERLAY_STRETCH_SUPPORT = 46,
+     KMTQAITYPE_GET_DEVICE_VIDPN_OWNERSHIP_INFO = 47,
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_2
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_4)
+     KMTQAITYPE_QUERYREGISTRY           = 48,
+     KMTQAITYPE_KMD_DRIVER_VERSION      = 49,
+     KMTQAITYPE_BLOCKLIST_KERNEL        = 50,
+     KMTQAITYPE_BLOCKLIST_RUNTIME       = 51,
+     KMTQAITYPE_ADAPTERGUID_RENDER              = 52,
+     KMTQAITYPE_ADAPTERADDRESS_RENDER           = 53,
+     KMTQAITYPE_ADAPTERREGISTRYINFO_RENDER      = 54,
+     KMTQAITYPE_CHECKDRIVERUPDATESTATUS_RENDER  = 55,
+     KMTQAITYPE_DRIVERVERSION_RENDER            = 56,
+     KMTQAITYPE_ADAPTERTYPE_RENDER              = 57,
+     KMTQAITYPE_WDDM_1_2_CAPS_RENDER            = 58,
+     KMTQAITYPE_WDDM_1_3_CAPS_RENDER            = 59,
+     KMTQAITYPE_QUERY_ADAPTER_UNIQUE_GUID = 60,
+     KMTQAITYPE_NODEPERFDATA            = 61,
+     KMTQAITYPE_ADAPTERPERFDATA         = 62,
+     KMTQAITYPE_ADAPTERPERFDATA_CAPS    = 63,
+     KMTQUITYPE_GPUVERSION              = 64,
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_4
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_6)
+     KMTQAITYPE_DRIVER_DESCRIPTION        = 65,
+     KMTQAITYPE_DRIVER_DESCRIPTION_RENDER = 66,
+     KMTQAITYPE_SCANOUT_CAPS              = 67,
+     KMTQAITYPE_DISPLAY_UMDRIVERNAME      = 71, // Added in 19H2
+     KMTQAITYPE_PARAVIRTUALIZATION_RENDER = 68,
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_6
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_7)
+     KMTQAITYPE_SERVICENAME = 69,
+     KMTQAITYPE_WDDM_2_7_CAPS = 70,
+     KMTQAITYPE_TRACKEDWORKLOAD_SUPPORT = 72,
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_7
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_8)
+     KMTQAITYPE_HYBRID_DLIST_DLL_SUPPORT = 73,
+     KMTQAITYPE_DISPLAY_CAPS             = 74,
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_8
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_9)
+     KMTQAITYPE_WDDM_2_9_CAPS                = 75,
+     KMTQAITYPE_CROSSADAPTERRESOURCE_SUPPORT = 76,
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_9
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM3_0)
+     KMTQAITYPE_WDDM_3_0_CAPS                = 77,
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM3_0
+// If a new enum will be used by DXGI or D3D11 software driver code, update the test content in the area.
+// Search for KMTQAITYPE_PARAVIRTUALIZATION_RENDER in directx\dxg\dxgi\unittests for references.
+} KMTQUERYADAPTERINFOTYPE;
+
+typedef struct _D3DKMT_QUERYADAPTERINFO
+{
+    D3DKMT_HANDLE           hAdapter;
+    KMTQUERYADAPTERINFOTYPE Type;
+    D3DKMT_PTR(VOID*,       pPrivateDriverData);
+    UINT                    PrivateDriverDataSize;
+} D3DKMT_QUERYADAPTERINFO;
+
+typedef struct _D3DKMT_OPENADAPTERFROMHDC
+{
+    D3DKMT_PTR(HDC,                 hDc);           // in:  DC that maps to a single display
+    D3DKMT_HANDLE                   hAdapter;       // out: adapter handle
+    LUID                            AdapterLuid;    // out: adapter LUID
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID  VidPnSourceId;  // out: VidPN source ID for that particular display
+} D3DKMT_OPENADAPTERFROMHDC;
+
+typedef struct _D3DKMT_OPENADAPTERFROMGDIDISPLAYNAME
+{
+    WCHAR                           DeviceName[32]; // in:  Name of GDI device from which to open an adapter instance
+    D3DKMT_HANDLE                   hAdapter;       // out: adapter handle
+    LUID                            AdapterLuid;    // out: adapter LUID
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID  VidPnSourceId;  // out: VidPN source ID for that particular display
+} D3DKMT_OPENADAPTERFROMGDIDISPLAYNAME;
+
+typedef struct _D3DKMT_OPENADAPTERFROMDEVICENAME
+{
+    D3DKMT_PTR(PCWSTR,              pDeviceName);   // in:  NULL terminated string containing the device name to open
+    D3DKMT_HANDLE                   hAdapter;       // out: adapter handle
+    LUID                            AdapterLuid;    // out: adapter LUID
+} D3DKMT_OPENADAPTERFROMDEVICENAME;
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8)
+
+#define MAX_ENUM_ADAPTERS   16
+
+typedef struct _D3DKMT_ADAPTERINFO
+{
+    D3DKMT_HANDLE       hAdapter;
+    LUID                AdapterLuid;
+    ULONG               NumOfSources;
+    BOOL                bPrecisePresentRegionsPreferred;
+} D3DKMT_ADAPTERINFO;
+
+typedef struct _D3DKMT_ENUMADAPTERS
+{
+    _In_range_(0, MAX_ENUM_ADAPTERS) ULONG  NumAdapters;
+    D3DKMT_ADAPTERINFO                      Adapters[MAX_ENUM_ADAPTERS];
+} D3DKMT_ENUMADAPTERS;
+
+typedef struct _D3DKMT_ENUMADAPTERS2
+{
+    ULONG                 NumAdapters;           // in/out: On input, the count of the pAdapters array buffer.  On output, the number of adapters enumerated.
+    D3DKMT_PTR(D3DKMT_ADAPTERINFO*, pAdapters);  // out: Array of enumerated adapters containing NumAdapters elements
+} D3DKMT_ENUMADAPTERS2;
+
+typedef struct _D3DKMT_OPENADAPTERFROMLUID
+{
+    LUID            AdapterLuid;
+    D3DKMT_HANDLE   hAdapter;
+} D3DKMT_OPENADAPTERFROMLUID;
+
+typedef struct _D3DKMT_QUERYREMOTEVIDPNSOURCEFROMGDIDISPLAYNAME
+{
+    WCHAR                           DeviceName[32]; // in:  Name of GDI device from which to open an adapter instance
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID  VidPnSourceId;  // out: VidPN source ID for that particular display
+} D3DKMT_QUERYREMOTEVIDPNSOURCEFROMGDIDISPLAYNAME;
+#endif
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_7)
+typedef union _D3DKMT_ENUMADAPTERS_FILTER
+{
+    // Setting none of these flags will still enumerate adapters,
+    // but there are fewer adapters than EnumAdapters2 enumerates.
+    // ComputeOnly adapters are left out of the default enumeration, to avoid breaking applications.
+    // DisplayOnly adapters are also left out of the default enumeration.
+    struct
+    {
+        ULONGLONG IncludeComputeOnly            : 1;
+        ULONGLONG IncludeDisplayOnly            : 1;
+        ULONGLONG Reserved                      : 62;
+    };
+    D3DKMT_ALIGN64 ULONGLONG Value;
+} D3DKMT_ENUMADAPTERS_FILTER;
+
+typedef struct _D3DKMT_ENUMADAPTERS3
+{
+    D3DKMT_ENUMADAPTERS_FILTER      Filter;      // in: Defines the filter
+    ULONG                           NumAdapters; // in/out: On input, the count of the pAdapters array buffer.  On output, the number of adapters enumerated.
+    D3DKMT_PTR(D3DKMT_ADAPTERINFO*, pAdapters);  // out: Array of enumerated adapters containing NumAdapters elements
+} D3DKMT_ENUMADAPTERS3;
+#endif
+
+typedef struct _D3DKMT_CLOSEADAPTER
+{
+    D3DKMT_HANDLE   hAdapter;   // in: adapter handle
+} D3DKMT_CLOSEADAPTER;
+
+typedef struct _D3DKMT_GETSHAREDPRIMARYHANDLE
+{
+    D3DKMT_HANDLE                   hAdapter;       // in: adapter handle
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID  VidPnSourceId;  // in: adapter's VidPN source ID
+    D3DKMT_HANDLE                   hSharedPrimary; // out: global shared primary handle (if one exists currently)
+} D3DKMT_GETSHAREDPRIMARYHANDLE;
+
+typedef struct _D3DKMT_SHAREDPRIMARYLOCKNOTIFICATION
+{
+    LUID                            AdapterLuid;
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID  VidPnSourceId;
+    RECTL                           LockRect;               // in: If zero rect then we are locking the whole primary else the lock sub-rect
+} D3DKMT_SHAREDPRIMARYLOCKNOTIFICATION;
+
+typedef struct _D3DKMT_SHAREDPRIMARYUNLOCKNOTIFICATION
+{
+    LUID                            AdapterLuid;
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID  VidPnSourceId;
+} D3DKMT_SHAREDPRIMARYUNLOCKNOTIFICATION;
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8)
+typedef struct _D3DKMT_PINDIRECTFLIPRESOURCES
+{
+    D3DKMT_HANDLE               hDevice;                           // in : Indentifies the device
+    UINT                        ResourceCount;                     // in : Number of resources to pin
+    D3DKMT_PTR(_Field_size_(ResourceCount)  D3DKMT_HANDLE*, pResourceList);     // in : Array of resource handles to pin
+} D3DKMT_PINDIRECTFLIPRESOURCES;
+
+typedef struct _D3DKMT_UNPINDIRECTFLIPRESOURCES
+{
+    D3DKMT_HANDLE               hDevice;                           // in : Indentifies the device
+    UINT                        ResourceCount;                     // in : Number of resources to unpin
+    D3DKMT_PTR(_Field_size_(ResourceCount) D3DKMT_HANDLE*, pResourceList);     // in : Array of resource handles to unpin
+} D3DKMT_UNPINDIRECTFLIPRESOURCES;
+#endif
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_7)
+typedef union _D3DKMT_PINRESOURCEFLAGS
+{
+    struct
+    {
+        UINT DirectFlipResources  :  1; // Used by DWM to indicate the resources are DirectFlip resources
+                                        // and should be pinned in-place.
+        UINT Reserved             : 31;
+    };
+    UINT Value;
+} D3DKMT_PINRESOURCEFLAGS;
+
+typedef struct _D3DKMT_PINRESOURCES
+{
+    D3DKMT_HANDLE                hDevice;                           // in : Indentifies the device
+    UINT                         ResourceCount;                     // in : Number of resources to pin
+    D3DKMT_PTR(_Field_size_(ResourceCount) D3DKMT_HANDLE*, pResourceList);     // in : Array of resource handles to pin
+    D3DKMT_PINRESOURCEFLAGS      Flags;                             // in : Flags
+    D3DKMT_HANDLE                hPagingQueue;                      // in opt : Handle to a paging queue used to synchronize the operation
+    D3DKMT_ALIGN64 UINT64        PagingFence;                       // out : Fence value returned if hPagingQueue is not NULL
+} D3DKMT_PINRESOURCES;
+
+typedef struct _D3DKMT_UNPINRESOURCES
+{
+    D3DKMT_HANDLE                hDevice;                           // in : Indentifies the device
+    UINT                         ResourceCount;                     // in : Number of resources to unpin
+    D3DKMT_PTR(_Field_size_(ResourceCount) D3DKMT_HANDLE*, pResourceList);     // in : Array of resource handles to unpin
+    UINT                         Reserved;
+} D3DKMT_UNPINRESOURCES;
+#endif
+
+typedef enum _D3DKMT_ESCAPETYPE
+{
+    D3DKMT_ESCAPE_DRIVERPRIVATE                 =  0,
+    D3DKMT_ESCAPE_VIDMM                         =  1,
+    D3DKMT_ESCAPE_TDRDBGCTRL                    =  2,
+    D3DKMT_ESCAPE_VIDSCH                        =  3,
+    D3DKMT_ESCAPE_DEVICE                        =  4,
+    D3DKMT_ESCAPE_DMM                           =  5,
+    D3DKMT_ESCAPE_DEBUG_SNAPSHOT                =  6,
+    // unused (7 was previously used to set driver update in-progress status, D3DKMT_ESCAPE_SETDRIVERUPDATESTATUS)
+    D3DKMT_ESCAPE_DRT_TEST                      =  8,
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8)
+    D3DKMT_ESCAPE_DIAGNOSTICS                   =  9,
+    D3DKMT_ESCAPE_OUTPUTDUPL_SNAPSHOT           = 10,
+    D3DKMT_ESCAPE_OUTPUTDUPL_DIAGNOSTICS        = 11,
+    D3DKMT_ESCAPE_BDD_PNP                       = 12,
+    D3DKMT_ESCAPE_BDD_FALLBACK                  = 13,
+    D3DKMT_ESCAPE_ACTIVATE_SPECIFIC_DIAG        = 14,
+    D3DKMT_ESCAPE_MODES_PRUNED_OUT              = 15,
+    D3DKMT_ESCAPE_WHQL_INFO                     = 16,
+    D3DKMT_ESCAPE_BRIGHTNESS                    = 17,
+    D3DKMT_ESCAPE_EDID_CACHE                    = 18,
+    // unused (19 was previously D3DKMT_ESCAPE_GENERIC_ADAPTER_DIAG_INFO)
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM1_3)
+    D3DKMT_ESCAPE_MIRACAST_DISPLAY_REQUEST      = 20,
+    D3DKMT_ESCAPE_HISTORY_BUFFER_STATUS         = 21,
+    // 22 can be reused for future needs as it was never exposed for external purposes
+    D3DKMT_ESCAPE_MIRACAST_ADAPTER_DIAG_INFO    = 23,
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0)
+    D3DKMT_ESCAPE_FORCE_BDDFALLBACK_HEADLESS    = 24,
+    D3DKMT_ESCAPE_REQUEST_MACHINE_CRASH         = 25,
+    // unused (26 was previously D3DKMT_ESCAPE_HMD_GET_EDID_BASE_BLOCK)
+    D3DKMT_ESCAPE_SOFTGPU_ENABLE_DISABLE_HMD    = 27,
+    D3DKMT_ESCAPE_PROCESS_VERIFIER_OPTION       = 28,
+    D3DKMT_ESCAPE_ADAPTER_VERIFIER_OPTION       = 29,
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_1)
+    D3DKMT_ESCAPE_IDD_REQUEST                   = 30,
+    D3DKMT_ESCAPE_DOD_SET_DIRTYRECT_MODE        = 31,
+    D3DKMT_ESCAPE_LOG_CODEPOINT_PACKET          = 32,
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_2)
+    D3DKMT_ESCAPE_LOG_USERMODE_DAIG_PACKET      = 33,
+    D3DKMT_ESCAPE_GET_EXTERNAL_DIAGNOSTICS      = 34,
+    // unused (35 previously was D3DKMT_ESCAPE_GET_PREFERRED_MODE)
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_3)
+    D3DKMT_ESCAPE_GET_DISPLAY_CONFIGURATIONS    = 36,
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_4)
+    D3DKMT_ESCAPE_QUERY_IOMMU_STATUS            = 37,
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_6)
+    D3DKMT_ESCAPE_CCD_DATABASE                  = 38,
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM3_0)
+    D3DKMT_ESCAPE_QUERY_DMA_REMAPPING_STATUS    = 39,
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM3_0
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_6
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_4
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_3
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_2
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_1
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_0
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM1_3
+
+    D3DKMT_ESCAPE_WIN32K_START                  = 1024,
+    D3DKMT_ESCAPE_WIN32K_HIP_DEVICE_INFO        = 1024,
+    D3DKMT_ESCAPE_WIN32K_QUERY_CD_ROTATION_BLOCK = 1025,
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM1_3)
+    D3DKMT_ESCAPE_WIN32K_DPI_INFO               = 1026, // Use hContext for the desired hdev
+    D3DKMT_ESCAPE_WIN32K_PRESENTER_VIEW_INFO    = 1027,
+    D3DKMT_ESCAPE_WIN32K_SYSTEM_DPI             = 1028,
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0)
+    D3DKMT_ESCAPE_WIN32K_BDD_FALLBACK           = 1029,
+    D3DKMT_ESCAPE_WIN32K_DDA_TEST_CTL           = 1030,
+    D3DKMT_ESCAPE_WIN32K_USER_DETECTED_BLACK_SCREEN = 1031,
+    // unused (1032 was previously D3DKMT_ESCAPE_WIN32K_HMD_ENUM)
+    // unused (1033 was previously D3DKMT_ESCAPE_WIN32K_HMD_CONTROL)
+    // unused (1034 was previously D3DKMT_ESCAPE_WIN32K_LPMDISPLAY_CONTROL)
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_5)
+    D3DKMT_ESCAPE_WIN32K_DISPBROKER_TEST        = 1035,
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_6)
+    D3DKMT_ESCAPE_WIN32K_COLOR_PROFILE_INFO     = 1036,
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_7)
+    D3DKMT_ESCAPE_WIN32K_SET_DIMMED_STATE       = 1037,
+    D3DKMT_ESCAPE_WIN32K_SPECIALIZED_DISPLAY_TEST = 1038,
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_7
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_6
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_5
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_0
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM1_3
+#endif // DXGKDDI_INTERFACE_VERSION_WIN8
+} D3DKMT_ESCAPETYPE;
+
+typedef struct _D3DKMT_DOD_SET_DIRTYRECT_MODE
+{
+    BOOL bForceFullScreenDirty;      // in: indicates if this adapter should always give full screen dirty for every Dod present
+}D3DKMT_DOD_SET_DIRTYRECT_MODE;
+
+typedef enum _D3DKMT_TDRDBGCTRLTYPE
+{
+    D3DKMT_TDRDBGCTRLTYPE_FORCETDR          = 0, //Simulate a TDR
+    D3DKMT_TDRDBGCTRLTYPE_DISABLEBREAK      = 1, //Disable DebugBreak on timeout
+    D3DKMT_TDRDBGCTRLTYPE_ENABLEBREAK       = 2, //Enable DebugBreak on timeout
+    D3DKMT_TDRDBGCTRLTYPE_UNCONDITIONAL     = 3, //Disables all safety conditions (e.g. check for consecutive recoveries)
+    D3DKMT_TDRDBGCTRLTYPE_VSYNCTDR          = 4, //Simulate a Vsync TDR
+    D3DKMT_TDRDBGCTRLTYPE_GPUTDR            = 5, //Simulate a GPU TDR
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8)
+    D3DKMT_TDRDBGCTRLTYPE_FORCEDODTDR       = 6, //Simulate a Display Only Present TDR
+    D3DKMT_TDRDBGCTRLTYPE_FORCEDODVSYNCTDR  = 7, //Simulate a Display Only Vsync TDR
+    D3DKMT_TDRDBGCTRLTYPE_ENGINETDR         = 8, //Simulate an engine TDR
+#endif
+} D3DKMT_TDRDBGCTRLTYPE;
+
+typedef enum _D3DKMT_VIDMMESCAPETYPE
+{
+    D3DKMT_VIDMMESCAPETYPE_SETFAULT                     = 0,
+    D3DKMT_VIDMMESCAPETYPE_RUN_COHERENCY_TEST           = 1,
+    D3DKMT_VIDMMESCAPETYPE_RUN_UNMAP_TO_DUMMY_PAGE_TEST = 2,
+    D3DKMT_VIDMMESCAPETYPE_APERTURE_CORRUPTION_CHECK    = 3,
+    D3DKMT_VIDMMESCAPETYPE_SUSPEND_CPU_ACCESS_TEST      = 4,
+    D3DKMT_VIDMMESCAPETYPE_EVICT                        = 5,
+    D3DKMT_VIDMMESCAPETYPE_EVICT_BY_NT_HANDLE           = 6,
+    D3DKMT_VIDMMESCAPETYPE_GET_VAD_INFO                 = 7,
+    D3DKMT_VIDMMESCAPETYPE_SET_BUDGET                   = 8,
+    D3DKMT_VIDMMESCAPETYPE_SUSPEND_PROCESS              = 9,
+    D3DKMT_VIDMMESCAPETYPE_RESUME_PROCESS               = 10,
+    D3DKMT_VIDMMESCAPETYPE_GET_BUDGET                   = 11,
+    D3DKMT_VIDMMESCAPETYPE_SET_TRIM_INTERVALS           = 12,
+    D3DKMT_VIDMMESCAPETYPE_EVICT_BY_CRITERIA            = 13,
+    D3DKMT_VIDMMESCAPETYPE_WAKE                         = 14,
+    D3DKMT_VIDMMESCAPETYPE_DEFRAG                       = 15,
+    D3DKMT_VIDMMESCAPETYPE_DELAYEXECUTION               = 16,
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_7)
+    D3DKMT_VIDMMESCAPETYPE_VALIDATE_INTEGRITY           = 17,
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_9)
+    D3DKMT_VIDMMESCAPETYPE_SET_EVICTION_CONFIG          = 18,
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_9
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_7
+} D3DKMT_VIDMMESCAPETYPE;
+
+typedef enum _D3DKMT_VIDSCHESCAPETYPE
+{
+    D3DKMT_VIDSCHESCAPETYPE_PREEMPTIONCONTROL    = 0, //Enable/Disable preemption
+    D3DKMT_VIDSCHESCAPETYPE_SUSPENDSCHEDULER     = 1, //Suspend/Resume scheduler (obsolate)
+    D3DKMT_VIDSCHESCAPETYPE_TDRCONTROL           = 2, //Tdr control
+    D3DKMT_VIDSCHESCAPETYPE_SUSPENDRESUME        = 3, //Suspend/Resume scheduler
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8)
+    D3DKMT_VIDSCHESCAPETYPE_ENABLECONTEXTDELAY   = 4, //Enable/Disable context delay
+#endif
+    D3DKMT_VIDSCHESCAPETYPE_CONFIGURE_TDR_LIMIT  = 5, // Configure TdrLimitCount and TdrLimitTime
+    D3DKMT_VIDSCHESCAPETYPE_VGPU_RESET           = 6, // Trigger VGPU reset
+    D3DKMT_VIDSCHESCAPETYPE_PFN_CONTROL          = 7, // Periodic frame notification control
+    D3DKMT_VIDSCHESCAPETYPE_VIRTUAL_REFRESH_RATE = 8,
+} D3DKMT_VIDSCHESCAPETYPE;
+
+typedef enum _D3DKMT_DMMESCAPETYPE
+{
+    D3DKMT_DMMESCAPETYPE_UNINITIALIZED                       =  0,
+    D3DKMT_DMMESCAPETYPE_GET_SUMMARY_INFO                    =  1,
+    D3DKMT_DMMESCAPETYPE_GET_VIDEO_PRESENT_SOURCES_INFO      =  2,
+    D3DKMT_DMMESCAPETYPE_GET_VIDEO_PRESENT_TARGETS_INFO      =  3,
+    D3DKMT_DMMESCAPETYPE_GET_ACTIVEVIDPN_INFO                =  4,
+    D3DKMT_DMMESCAPETYPE_GET_MONITORS_INFO                   =  5,
+    D3DKMT_DMMESCAPETYPE_RECENTLY_COMMITTED_VIDPNS_INFO      =  6,
+    D3DKMT_DMMESCAPETYPE_RECENT_MODECHANGE_REQUESTS_INFO     =  7,
+    D3DKMT_DMMESCAPETYPE_RECENTLY_RECOMMENDED_VIDPNS_INFO    =  8,
+    D3DKMT_DMMESCAPETYPE_RECENT_MONITOR_PRESENCE_EVENTS_INFO =  9,
+    D3DKMT_DMMESCAPETYPE_ACTIVEVIDPN_SOURCEMODESET_INFO      = 10,
+    D3DKMT_DMMESCAPETYPE_ACTIVEVIDPN_COFUNCPATHMODALITY_INFO = 11,
+    D3DKMT_DMMESCAPETYPE_GET_LASTCLIENTCOMMITTEDVIDPN_INFO   = 12,
+    D3DKMT_DMMESCAPETYPE_GET_VERSION_INFO                    = 13,
+    D3DKMT_DMMESCAPETYPE_VIDPN_MGR_DIAGNOSTICS               = 14
+} D3DKMT_DMMESCAPETYPE;
+
+typedef struct _D3DKMT_HISTORY_BUFFER_STATUS
+{
+    BOOLEAN Enabled;
+    UINT Reserved;
+} D3DKMT_HISTORY_BUFFER_STATUS;
+
+typedef enum _D3DKMT_VAD_ESCAPE_COMMAND
+{
+    D3DKMT_VAD_ESCAPE_GETNUMVADS,
+    D3DKMT_VAD_ESCAPE_GETVAD,
+    D3DKMT_VAD_ESCAPE_GETVADRANGE,
+    D3DKMT_VAD_ESCAPE_GET_PTE,
+    D3DKMT_VAD_ESCAPE_GET_GPUMMU_CAPS,
+    D3DKMT_VAD_ESCAPE_GET_SEGMENT_CAPS,
+} D3DKMT_VAD_ESCAPE_COMMAND;
+
+typedef struct _D3DKMT_VAD_DESC
+{
+    UINT                  VadIndex;           // in: 0xFFFFFFFF to use the VAD address
+    D3DKMT_ALIGN64 UINT64 VadAddress;         // in
+    UINT                  NumMappedRanges;    // out
+    UINT                  VadType;            // out: 0 - reserved, 1 - Mapped
+    D3DKMT_ALIGN64 UINT64 StartAddress;       // out
+    D3DKMT_ALIGN64 UINT64 EndAddress;         // out
+} D3DKMT_VAD_DESC;
+
+typedef struct _D3DKMT_VA_RANGE_DESC
+{
+    D3DKMT_ALIGN64 UINT64 VadAddress;             // in
+    UINT                  VaRangeIndex;           // in
+    UINT                  PhysicalAdapterIndex;   // in
+    D3DKMT_ALIGN64 UINT64 StartAddress;           // out
+    D3DKMT_ALIGN64 UINT64 EndAddress;             // out
+    D3DKMT_ALIGN64 UINT64 DriverProtection;       // out
+    UINT                  OwnerType;              // out: VIDMM_VAD_OWNER_TYPE
+    D3DKMT_ALIGN64 UINT64 pOwner;                 // out
+    D3DKMT_ALIGN64 UINT64 OwnerOffset;            // out
+    UINT                  Protection;             // out: D3DDDIGPUVIRTUALADDRESS_PROTECTION_TYPE
+} D3DKMT_VA_RANGE_DESC;
+
+typedef struct _D3DKMT_EVICTION_CRITERIA
+{
+    D3DKMT_ALIGN64 UINT64 MinimumSize;
+    D3DKMT_ALIGN64 UINT64 MaximumSize;
+    struct
+    {
+        union
+        {
+            struct
+            {
+                UINT Primary  :  1; // 0x00000001
+                UINT Reserved : 31; // 0xFFFFFFFE
+            } Flags;
+            UINT Value;
+        };
+    };
+} D3DKMT_EVICTION_CRITERIA;
+
+typedef enum _D3DKMT_DEFRAG_ESCAPE_OPERATION
+{
+    D3DKMT_DEFRAG_ESCAPE_GET_FRAGMENTATION_STATS       =  0,
+    D3DKMT_DEFRAG_ESCAPE_DEFRAG_UPWARD                 =  1,
+    D3DKMT_DEFRAG_ESCAPE_DEFRAG_DOWNWARD               =  2,
+    D3DKMT_DEFRAG_ESCAPE_DEFRAG_PASS                   =  3,
+    D3DKMT_DEFRAG_ESCAPE_VERIFY_TRANSFER               =  4,
+} D3DKMT_DEFRAG_ESCAPE_OPERATION;
+
+typedef struct _D3DKMT_PAGE_TABLE_LEVEL_DESC
+{
+    UINT                  IndexBitCount;
+    D3DKMT_ALIGN64 UINT64 IndexMask;
+    D3DKMT_ALIGN64 UINT64 IndexShift;
+    D3DKMT_ALIGN64 UINT64 LowerLevelsMask;
+    D3DKMT_ALIGN64 UINT64 EntryCoverageInPages;
+} D3DKMT_PAGE_TABLE_LEVEL_DESC;
+
+typedef struct _DXGK_ESCAPE_GPUMMUCAPS
+{
+    BOOLEAN ReadOnlyMemorySupported;
+    BOOLEAN NoExecuteMemorySupported;
+    BOOLEAN ZeroInPteSupported;
+    BOOLEAN CacheCoherentMemorySupported;
+    BOOLEAN LargePageSupported;
+    BOOLEAN DualPteSupported;
+    BOOLEAN AllowNonAlignedLargePageAddress;
+    UINT    VirtualAddressBitCount;
+    UINT    PageTableLevelCount;
+    D3DKMT_PAGE_TABLE_LEVEL_DESC PageTableLevelDesk[DXGK_MAX_PAGE_TABLE_LEVEL_COUNT];
+} DXGK_ESCAPE_GPUMMUCAPS;
+
+typedef struct _D3DKMT_GET_GPUMMU_CAPS
+{
+    UINT                    PhysicalAdapterIndex;   // In
+    DXGK_ESCAPE_GPUMMUCAPS  GpuMmuCaps;             // Out
+} D3DKMT_GET_GPUMMU_CAPS;
+
+#define D3DKMT_GET_PTE_MAX 64
+
+typedef struct _D3DKMT_GET_PTE
+{
+    UINT        PhysicalAdapterIndex;                               // In
+    UINT        PageTableLevel;                                     // In
+    UINT        PageTableIndex[DXGK_MAX_PAGE_TABLE_LEVEL_COUNT];    // In
+    BOOLEAN     b64KBPte;                                           // In - Valid only when dual PTEs are supported. Out - PT is 64KB.
+    UINT        NumPtes;                                            // In - Number of PTEs to fill. Out - number of filled PTEs
+    DXGK_PTE    Pte[D3DKMT_GET_PTE_MAX];                            // Out
+    UINT        NumValidEntries;                                    // Out
+} D3DKMT_GET_PTE;
+
+#define D3DKMT_MAX_SEGMENT_COUNT 32
+
+typedef enum _D3DKMT_MEMORY_SEGMENT_GROUP
+{
+    D3DKMT_MEMORY_SEGMENT_GROUP_LOCAL = 0,
+    D3DKMT_MEMORY_SEGMENT_GROUP_NON_LOCAL = 1
+} D3DKMT_MEMORY_SEGMENT_GROUP;
+
+typedef struct _D3DKMT_SEGMENT_CAPS
+{
+    D3DKMT_ALIGN64 UINT64 Size;
+    UINT    PageSize;
+    ULONG   SegmentId;
+    BOOLEAN bAperture;
+    BOOLEAN bReservedSysMem;
+    D3DKMT_MEMORY_SEGMENT_GROUP BudgetGroup;
+} D3DKMT_SEGMENT_CAPS;
+
+typedef struct _D3DKMT_GET_SEGMENT_CAPS
+{
+    UINT        PhysicalAdapterIndex;                               // In
+    UINT        NumSegments;                                        // Out
+    D3DKMT_SEGMENT_CAPS SegmentCaps[D3DKMT_MAX_SEGMENT_COUNT];      // Out
+} D3DKMT_GET_SEGMENT_CAPS;
+
+typedef enum _D3DKMT_ESCAPE_PFN_CONTROL_COMMAND
+{
+    D3DKMT_ESCAPE_PFN_CONTROL_DEFAULT,
+    D3DKMT_ESCAPE_PFN_CONTROL_FORCE_CPU,
+    D3DKMT_ESCAPE_PFN_CONTROL_FORCE_GPU
+} D3DKMT_ESCAPE_PFN_CONTROL_COMMAND;
+
+// params for D3DKMT_VIDSCHESCAPETYPE_VIRTUAL_REFRESH_RATE
+typedef enum _D3DKMT_ESCAPE_VIRTUAL_REFRESH_RATE_TYPE
+{
+    D3DKMT_ESCAPE_VIRTUAL_REFRESH_RATE_TYPE_SET_BASE_DESKTOP_DURATION = 0,
+    D3DKMT_ESCAPE_VIRTUAL_REFRESH_RATE_TYPE_SET_VSYNC_MULTIPLIER = 1,
+    D3DKMT_ESCAPE_VIRTUAL_REFRESH_RATE_TYPE_SET_PROCESS_BOOST_ELIGIBLE = 2,
+} D3DKMT_ESCAPE_VIRTUAL_REFRESH_RATE_TYPE;
+
+typedef struct _D3DKMT_ESCAPE_VIRTUAL_REFRESH_RATE
+{
+    D3DKMT_ESCAPE_VIRTUAL_REFRESH_RATE_TYPE Type;
+    UINT     VidPnSourceId;
+    BOOLEAN  ProcessBoostEligible;
+    UINT     VSyncMultiplier;
+    UINT     BaseDesktopDuration;
+    UCHAR    Reserved[16];
+} D3DKMT_ESCAPE_VIRTUAL_REFRESH_RATE;
+
+typedef struct _D3DKMT_VIDMM_ESCAPE
+{
+    D3DKMT_VIDMMESCAPETYPE Type;
+    union
+    {
+        struct
+        {
+            union
+            {
+                struct
+                {
+                    ULONG ProbeAndLock : 1;
+                    ULONG SplitPoint : 1;
+                    ULONG NoDemotion : 1;
+                    ULONG SwizzlingAperture : 1;
+                    ULONG PagingPathLockSubRange : 1;
+                    ULONG PagingPathLockMinRange : 1;
+                    ULONG ComplexLock : 1;
+                    ULONG FailVARotation : 1;
+                    ULONG NoWriteCombined : 1;
+                    ULONG NoPrePatching : 1;
+                    ULONG AlwaysRepatch : 1;
+                    ULONG ExpectPreparationFailure : 1;
+                    ULONG FailUserModeVAMapping : 1;
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8)
+                    ULONG NeverDiscardOfferedAllocation : 1;
+                    ULONG AlwaysDiscardOfferedAllocation : 1;
+                    ULONG Reserved : 17;
+#else
+                    ULONG Reserved : 19;
+#endif
+                };
+                ULONG Value;
+            };
+        } SetFault;
+        struct
+        {
+            D3DKMT_HANDLE ResourceHandle;
+            D3DKMT_HANDLE AllocationHandle;
+            D3DKMT_PTR(HANDLE, hProcess);        // 0 to evict memory for the current process, otherwise it is a process handle from OpenProcess(PROCESS_ALL_ACCESS, FALSE, ProcessId).
+        } Evict;
+        struct
+        {
+            D3DKMT_ALIGN64 UINT64 NtHandle;           // Used by D3DKMT_VIDMMESCAPETYPE_EVICT_BY_NT_HANDLE
+        } EvictByNtHandle;
+        struct
+        {
+            union
+            {
+                struct
+                {
+                    UINT NumVads;
+                } GetNumVads;
+                D3DKMT_VAD_DESC GetVad;
+                D3DKMT_VA_RANGE_DESC GetVadRange;
+                D3DKMT_GET_GPUMMU_CAPS GetGpuMmuCaps;
+                D3DKMT_GET_PTE  GetPte;
+                D3DKMT_GET_SEGMENT_CAPS GetSegmentCaps;
+            };
+            D3DKMT_VAD_ESCAPE_COMMAND Command;      // in
+            NTSTATUS    Status;                     // out
+        } GetVads;
+        struct
+        {
+            D3DKMT_ALIGN64 ULONGLONG LocalMemoryBudget;
+            D3DKMT_ALIGN64 ULONGLONG SystemMemoryBudget;
+        } SetBudget;
+        struct
+        {
+            D3DKMT_PTR(HANDLE, hProcess);
+            BOOL bAllowWakeOnSubmission;
+        } SuspendProcess;
+        struct
+        {
+            D3DKMT_PTR(HANDLE, hProcess);
+        } ResumeProcess;
+        struct
+        {
+            D3DKMT_ALIGN64 UINT64 NumBytesToTrim;
+        } GetBudget;
+        struct
+        {
+            ULONG MinTrimInterval; // In 100ns units
+            ULONG MaxTrimInterval; // In 100ns units
+            ULONG IdleTrimInterval; // In 100ns units
+        } SetTrimIntervals;
+        D3DKMT_EVICTION_CRITERIA EvictByCriteria;
+        struct
+        {
+            BOOL bFlush;
+        } Wake;
+        struct
+        {
+            D3DKMT_DEFRAG_ESCAPE_OPERATION  Operation;
+
+            UINT                            SegmentId;
+
+            D3DKMT_ALIGN64 ULONGLONG                       TotalCommitted;
+            D3DKMT_ALIGN64 ULONGLONG                       TotalFree;
+            D3DKMT_ALIGN64 ULONGLONG                       LargestGapBefore;
+            D3DKMT_ALIGN64 ULONGLONG                       LargestGapAfter;
+        } Defrag;
+        struct
+        {
+            D3DKMT_HANDLE hPagingQueue;
+            UINT PhysicalAdapterIndex;
+            ULONG Milliseconds;
+            D3DKMT_ALIGN64 ULONGLONG PagingFenceValue;
+        } DelayExecution;
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_7)
+        struct
+        {
+            UINT SegmentId;
+        } VerifyIntegrity;
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_9)
+        struct
+        {
+            D3DKMT_ALIGN64 LONGLONG TimerValue;
+        } DelayedEvictionConfig;
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_9
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_7
+    };
+} D3DKMT_VIDMM_ESCAPE;
+
+typedef struct _D3DKMT_VIDSCH_ESCAPE
+{
+    D3DKMT_VIDSCHESCAPETYPE Type;
+    union
+    {
+        BOOL PreemptionControl; // enable/disable preemption
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8)
+        BOOL EnableContextDelay; // enable/disable context delay
+        struct
+        {
+            ULONG TdrControl;   // control tdr
+            union
+            {
+                ULONG NodeOrdinal;  // valid if TdrControl is set to D3DKMT_TDRDBGCTRLTYPE_ENGINETDR
+            };
+        } TdrControl2;
+#endif
+        BOOL SuspendScheduler;  // suspend/resume scheduler (obsolate)
+        ULONG TdrControl;       // control tdr
+        ULONG SuspendTime;      // time period to suspend.
+        struct
+        {
+            UINT Count;
+            UINT Time; // In seconds
+        } TdrLimit;
+
+        D3DKMT_ESCAPE_PFN_CONTROL_COMMAND  PfnControl;   // periodic frame notification control
+    };
+    D3DKMT_ESCAPE_VIRTUAL_REFRESH_RATE VirtualRefreshRateControl;
+} D3DKMT_VIDSCH_ESCAPE;
+
+typedef struct _D3DKMT_TDRDBGCTRL_ESCAPE
+{
+    D3DKMT_TDRDBGCTRLTYPE TdrControl;   // control tdr
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8)
+    union
+    {
+        ULONG NodeOrdinal;  // valid if TdrControl is set to D3DKMT_TDRDBGCTRLTYPE_ENGINETDR
+    };
+#endif
+} D3DKMT_TDRDBGCTRL_ESCAPE;
+
+// Upper boundary on the DMM escape data size (in bytes).
+enum
+{
+    D3DKMT_MAX_DMM_ESCAPE_DATASIZE = 100*1024
+};
+
+// NOTE: If (ProvidedBufferSize >= MinRequiredBufferSize), then MinRequiredBufferSize = size of the actual complete data set in the Data[] array.
+typedef struct _D3DKMT_DMM_ESCAPE
+{
+    _In_  D3DKMT_DMMESCAPETYPE  Type;
+    _In_  D3DKMT_ALIGN64 D3DKMT_SIZE_T ProvidedBufferSize;     // actual size of Data[] array, in bytes.
+    _Out_ D3DKMT_ALIGN64 D3DKMT_SIZE_T MinRequiredBufferSize;  // minimum required size of Data[] array to contain requested data.
+    _Out_writes_bytes_(ProvidedBufferSize) UCHAR  Data[1];
+} D3DKMT_DMM_ESCAPE;
+
+typedef enum _D3DKMT_BRIGHTNESS_INFO_TYPE
+{
+    D3DKMT_BRIGHTNESS_INFO_GET_POSSIBLE_LEVELS  = 1,
+    D3DKMT_BRIGHTNESS_INFO_GET                  = 2,
+    D3DKMT_BRIGHTNESS_INFO_SET                  = 3,
+    D3DKMT_BRIGHTNESS_INFO_GET_CAPS             = 4,
+    D3DKMT_BRIGHTNESS_INFO_SET_STATE            = 5,
+    D3DKMT_BRIGHTNESS_INFO_SET_OPTIMIZATION     = 6,
+    D3DKMT_BRIGHTNESS_INFO_GET_REDUCTION        = 7,
+    D3DKMT_BRIGHTNESS_INFO_BEGIN_MANUAL_MODE    = 8,
+    D3DKMT_BRIGHTNESS_INFO_END_MANUAL_MODE      = 9,
+    D3DKMT_BRIGHTNESS_INFO_TOGGLE_LOGGING       = 10,
+    D3DKMT_BRIGHTNESS_INFO_GET_NIT_RANGES       = 11,
+} D3DKMT_BRIGHTNESS_INFO_TYPE;
+
+typedef struct _D3DKMT_BRIGHTNESS_POSSIBLE_LEVELS
+{
+    UCHAR LevelCount;
+    UCHAR BrightnessLevels[256];
+} D3DKMT_BRIGHTNESS_POSSIBLE_LEVELS;
+
+typedef struct _D3DKMT_BRIGHTNESS_INFO
+{
+    D3DKMT_BRIGHTNESS_INFO_TYPE    Type;
+    ULONG                          ChildUid;
+    union
+    {
+        D3DKMT_BRIGHTNESS_POSSIBLE_LEVELS   PossibleLevels;
+        UCHAR                               Brightness;
+        DXGK_BRIGHTNESS_CAPS                BrightnessCaps;
+        DXGK_BRIGHTNESS_STATE               BrightnessState;
+        DXGK_BACKLIGHT_OPTIMIZATION_LEVEL   OptimizationLevel;
+        DXGK_BACKLIGHT_INFO                 ReductionInfo;
+        BOOLEAN                             VerboseLogging;
+        DXGK_BRIGHTNESS_GET_NIT_RANGES_OUT  NitRanges;
+        DXGK_BRIGHTNESS_GET_OUT             GetBrightnessMillinits;
+        DXGK_BRIGHTNESS_SET_IN              SetBrightnessMillinits;
+    };
+} D3DKMT_BRIGHTNESS_INFO;
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0)
+typedef struct _D3DKMT_BDDFALLBACK_CTL
+{
+    BOOLEAN ForceBddHeadlessNextFallback;
+} D3DKMT_BDDFALLBACK_CTL;
+
+typedef struct _D3DKMT_REQUEST_MACHINE_CRASH_ESCAPE
+{
+    D3DKMT_ALIGN64 D3DKMT_ULONG_PTR Param1;
+    D3DKMT_ALIGN64 D3DKMT_ULONG_PTR Param2;
+    D3DKMT_ALIGN64 D3DKMT_ULONG_PTR Param3;
+} D3DKMT_REQUEST_MACHINE_CRASH_ESCAPE;
+
+//
+// VERIFIER OPTIONS
+//
+typedef enum _D3DKMT_VERIFIER_OPTION_MODE
+{
+    D3DKMT_VERIFIER_OPTION_QUERY,
+    D3DKMT_VERIFIER_OPTION_SET
+} D3DKMT_VERIFIER_OPTION_MODE;
+
+typedef enum _D3DKMT_PROCESS_VERIFIER_OPTION_TYPE
+{
+    //
+    // Dxgkrnl (0xxx)
+    //
+
+    //
+    // VidMm (1xxx)
+    //
+    D3DKMT_PROCESS_VERIFIER_OPTION_VIDMM_FLAGS              = 1000,
+    D3DKMT_PROCESS_VERIFIER_OPTION_VIDMM_RESTRICT_BUDGET    = 1001,
+
+    //
+    // VidSch (2xxx)
+    //
+
+} D3DKMT_PROCESS_VERIFIER_OPTION_TYPE;
+
+typedef union _D3DKMT_PROCESS_VERIFIER_VIDMM_FLAGS
+{
+    struct
+    {
+        UINT ForceSynchronousEvict        : 1;
+        UINT NeverDeferEvictions          : 1;
+        UINT AlwaysFailCommitOnReclaim    : 1;
+        UINT AlwaysPlaceInDemotedLocation : 1;
+        UINT Reserved : 28;
+    };
+    UINT32 Value;
+} D3DKMT_PROCESS_VERIFIER_VIDMM_FLAGS;
+
+typedef struct _D3DKMT_PROCESS_VERIFIER_VIDMM_RESTRICT_BUDGET
+{
+    D3DKMT_ALIGN64 UINT64 LocalBudget;
+    D3DKMT_ALIGN64 UINT64 NonLocalBudget;
+} D3DKMT_PROCESS_VERIFIER_VIDMM_RESTRICT_BUDGET;
+
+typedef union _D3DKMT_PROCESS_VERIFIER_OPTION_DATA
+{
+    D3DKMT_PROCESS_VERIFIER_VIDMM_FLAGS VidMmFlags;
+    D3DKMT_PROCESS_VERIFIER_VIDMM_RESTRICT_BUDGET VidMmRestrictBudget;
+} D3DKMT_PROCESS_VERIFIER_OPTION_DATA;
+
+typedef struct _D3DKMT_PROCESS_VERIFIER_OPTION
+{
+    D3DKMT_PTR(HANDLE, hProcess);
+    D3DKMT_PROCESS_VERIFIER_OPTION_TYPE Type;
+    D3DKMT_VERIFIER_OPTION_MODE Mode;
+    D3DKMT_PROCESS_VERIFIER_OPTION_DATA Data;
+} D3DKMT_PROCESS_VERIFIER_OPTION;
+
+typedef enum _D3DKMT_ADAPTER_VERIFIER_OPTION_TYPE
+{
+    //
+    // Dxgkrnl (0xxx)
+    //
+
+    //
+    // VidMm (1xxx)
+    //
+    D3DKMT_ADAPTER_VERIFIER_OPTION_VIDMM_FLAGS          = 1000,
+    D3DKMT_ADAPTER_VERIFIER_OPTION_VIDMM_TRIM_INTERVAL  = 1001,
+
+    //
+    // VidSch (2xxx)
+    //
+} D3DKMT_ADAPTER_VERIFIER_OPTION_TYPE;
+
+typedef union _D3DKMT_ADAPTER_VERIFIER_VIDMM_FLAGS
+{
+    struct
+    {
+        UINT AlwaysRepatch                      : 1;
+        UINT FailSharedPrimary                  : 1;
+        UINT FailProbeAndLock                   : 1;
+        UINT AlwaysDiscardOffer                 : 1;
+        UINT NeverDiscardOffer                  : 1;
+        UINT ForceComplexLock                   : 1;
+        UINT NeverPrepatch                      : 1;
+        UINT ExpectPreparationFailure           : 1;
+        UINT TakeSplitPoint                     : 1;
+        UINT FailAcquireSwizzlingRange          : 1;
+        UINT PagingPathLockSubrange             : 1;
+        UINT PagingPathLockMinrange             : 1;
+        UINT FailVaRotation                     : 1;
+        UINT NoDemotion                         : 1;
+        UINT FailDefragPass                     : 1;
+        UINT AlwaysProcessOfferList             : 1;
+        UINT AlwaysDecommitOffer                : 1;
+        UINT NeverMoveDefrag                    : 1;
+        UINT AlwaysRelocateDisplayableResources : 1;
+        UINT AlwaysFailGrowVPRMoves             : 1;
+        UINT Reserved                           : 12;
+    };
+    UINT32 Value;
+} D3DKMT_ADAPTER_VERIFIER_VIDMM_FLAGS;
+
+typedef struct _D3DKMT_ADAPTER_VERIFIER_VIDMM_TRIM_INTERVAL
+{
+    D3DKMT_ALIGN64 UINT64 MinimumTrimInterval;
+    D3DKMT_ALIGN64 UINT64 MaximumTrimInterval;
+    D3DKMT_ALIGN64 UINT64 IdleTrimInterval;
+} D3DKMT_ADAPTER_VERIFIER_VIDMM_TRIM_INTERVAL;
+
+typedef union _D3DKMT_ADAPTER_VERIFIER_OPTION_DATA
+{
+    D3DKMT_ADAPTER_VERIFIER_VIDMM_FLAGS VidMmFlags;
+    D3DKMT_ADAPTER_VERIFIER_VIDMM_TRIM_INTERVAL VidMmTrimInterval;
+} D3DKMT_ADAPTER_VERIFIER_OPTION_DATA;
+
+typedef struct _D3DKMT_ADAPTER_VERIFIER_OPTION
+{
+    D3DKMT_ADAPTER_VERIFIER_OPTION_TYPE Type;
+    D3DKMT_VERIFIER_OPTION_MODE Mode;
+    D3DKMT_ADAPTER_VERIFIER_OPTION_DATA Data;
+} D3DKMT_ADAPTER_VERIFIER_OPTION;
+
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_0
+
+typedef enum _D3DKMT_DEVICEESCAPE_TYPE
+{
+    D3DKMT_DEVICEESCAPE_VIDPNFROMALLOCATION = 0,
+    D3DKMT_DEVICEESCAPE_RESTOREGAMMA        = 1,
+} D3DKMT_DEVICEESCAPE_TYPE;
+
+typedef struct _D3DKMT_DEVICE_ESCAPE
+{
+    D3DKMT_DEVICEESCAPE_TYPE Type;
+    union
+    {
+        struct
+        {
+            D3DKMT_HANDLE                   hPrimaryAllocation; // in: Primary allocation handle
+            D3DDDI_VIDEO_PRESENT_SOURCE_ID  VidPnSourceId;      // out: VidPnSoureId of primary allocation
+        } VidPnFromAllocation;
+    };
+} D3DKMT_DEVICE_ESCAPE;
+
+typedef struct _D3DKMT_DEBUG_SNAPSHOT_ESCAPE
+{
+    ULONG Length;   // out: Actual length of the snapshot written in Buffer
+    BYTE Buffer[1]; // out: Buffer to place snapshot
+} D3DKMT_DEBUG_SNAPSHOT_ESCAPE;
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8)
+#ifndef DXGK_DIAG_PROCESS_NAME_LENGTH
+#define DXGK_DIAG_PROCESS_NAME_LENGTH 16
+#endif
+
+typedef enum _OUTPUTDUPL_CONTEXT_DEBUG_STATUS
+{
+    OUTPUTDUPL_CONTEXT_DEBUG_STATUS_INACTIVE = 0,
+    OUTPUTDUPL_CONTEXT_DEBUG_STATUS_ACTIVE = 1,
+    OUTPUTDUPL_CONTEXT_DEBUG_STATUS_PENDING_DESTROY = 2,
+    OUTPUTDUPL_CONTEXT_DEBUG_STATUS_FORCE_UINT32 = 0xffffffff
+}OUTPUTDUPL_CONTEXT_DEBUG_STATUS;
+
+typedef struct _OUTPUTDUPL_CONTEXT_DEBUG_INFO
+{
+    OUTPUTDUPL_CONTEXT_DEBUG_STATUS Status;
+    D3DKMT_PTR(HANDLE,              ProcessID);
+    UINT32                          AccumulatedPresents;
+    D3DKMT_ALIGN64 LARGE_INTEGER    LastPresentTime;
+    D3DKMT_ALIGN64 LARGE_INTEGER    LastMouseTime;
+    CHAR                            ProcessName[DXGK_DIAG_PROCESS_NAME_LENGTH];
+} OUTPUTDUPL_CONTEXT_DEBUG_INFO;
+
+#define GET_OUTPUT_DUPL_DEBUG_INFO_FROM_SNAPSHOT(pSnapshot, VidPnSource, OutputDuplContextIndex) \
+    (pSnapshot->OutputDuplDebugInfos[(VidPnSource * pSnapshot->NumOutputDuplContexts) + OutputDuplContextIndex])
+
+typedef struct _D3DKMT_OUTPUTDUPL_SNAPSHOT
+{
+    UINT Size;                          // _In_/out: Size of entire structure
+
+    UINT SessionProcessCount;           // _Out_: Number of processes currently duplicating output in this session (max possible will be equal to NumOutputDuplContexts)
+    UINT SessionActiveConnectionsCount; // _Out_: Total number of active contexts in this session, may be more than number active in 2D array because that is per adapter
+
+    UINT NumVidPnSources;               // _Out_: Max of first array index
+    UINT NumOutputDuplContexts;         // _Out_: Max of second array index
+
+    UINT Padding;
+
+    // This field is in reality a two dimensional array, use GET_OUTPUT_DUPL_DEBUG_INFO_FROM_SNAPSHOT macro to get a specific one
+    _Field_size_bytes_(Size - sizeof(_D3DKMT_OUTPUTDUPL_SNAPSHOT)) OUTPUTDUPL_CONTEXT_DEBUG_INFO OutputDuplDebugInfos[0];
+} D3DKMT_OUTPUTDUPL_SNAPSHOT;
+#endif
+
+typedef enum _D3DKMT_ACTIVATE_SPECIFIC_DIAG_TYPE
+{
+    D3DKMT_ACTIVATE_SPECIFIC_DIAG_TYPE_EXTRA_CCD_DATABASE_INFO = 0,
+    D3DKMT_ACTIVATE_SPECIFIC_DIAG_TYPE_MODES_PRUNED            = 15,
+}D3DKMT_ACTIVATE_SPECIFIC_DIAG_TYPE;
+
+typedef struct _D3DKMT_ACTIVATE_SPECIFIC_DIAG_ESCAPE
+{
+    D3DKMT_ACTIVATE_SPECIFIC_DIAG_TYPE  Type;     // The escape type that needs to be (de)activated
+    BOOL                                Activate; // FALSE means deactivate
+} D3DKMT_ACTIVATE_SPECIFIC_DIAG_ESCAPE;
+
+typedef struct _D3DKMT_ESCAPE
+{
+    D3DKMT_HANDLE       hAdapter;               // in: adapter handle
+    D3DKMT_HANDLE       hDevice;                // in: device handle [Optional]
+    D3DKMT_ESCAPETYPE   Type;                   // in: escape type.
+    D3DDDI_ESCAPEFLAGS  Flags;                  // in: flags
+    D3DKMT_PTR(VOID*,   pPrivateDriverData);    // in/out: escape data
+    UINT                PrivateDriverDataSize;  // in: size of escape data
+    D3DKMT_HANDLE       hContext;               // in: context handle [Optional]
+} D3DKMT_ESCAPE;
+
+//
+// begin D3DKMT_QUERYSTATISTICS
+//
+
+typedef enum _D3DKMT_QUERYRESULT_PREEMPTION_ATTEMPT_RESULT
+{
+    D3DKMT_PreemptionAttempt                               = 0,
+    D3DKMT_PreemptionAttemptSuccess                        = 1,
+    D3DKMT_PreemptionAttemptMissNoCommand                  = 2,
+    D3DKMT_PreemptionAttemptMissNotEnabled                 = 3,
+    D3DKMT_PreemptionAttemptMissNextFence                  = 4,
+    D3DKMT_PreemptionAttemptMissPagingCommand              = 5,
+    D3DKMT_PreemptionAttemptMissSplittedCommand            = 6,
+    D3DKMT_PreemptionAttemptMissFenceCommand               = 7,
+    D3DKMT_PreemptionAttemptMissRenderPendingFlip          = 8,
+    D3DKMT_PreemptionAttemptMissNotMakingProgress          = 9,
+    D3DKMT_PreemptionAttemptMissLessPriority               = 10,
+    D3DKMT_PreemptionAttemptMissRemainingQuantum           = 11,
+    D3DKMT_PreemptionAttemptMissRemainingPreemptionQuantum = 12,
+    D3DKMT_PreemptionAttemptMissAlreadyPreempting          = 13,
+    D3DKMT_PreemptionAttemptMissGlobalBlock                = 14,
+    D3DKMT_PreemptionAttemptMissAlreadyRunning             = 15,
+    D3DKMT_PreemptionAttemptStatisticsMax                  = 16,
+} D3DKMT_QUERYRESULT_PREEMPTION_ATTEMPT_RESULT;
+
+//
+// WOW will not allow enum member as array length, so define it as a constant
+//
+#define D3DKMT_QUERYRESULT_PREEMPTION_ATTEMPT_RESULT_MAX 16
+C_ASSERT(D3DKMT_QUERYRESULT_PREEMPTION_ATTEMPT_RESULT_MAX == D3DKMT_PreemptionAttemptStatisticsMax);
+
+//
+// Command packet type
+//
+typedef enum _D3DKMT_QUERYSTATISTICS_DMA_PACKET_TYPE {
+    D3DKMT_ClientRenderBuffer       = 0, // (Dma packet) should be 0 base.
+    D3DKMT_ClientPagingBuffer       = 1, // (Dma packet)
+    D3DKMT_SystemPagingBuffer       = 2, // (Dma packet)
+    D3DKMT_SystemPreemptionBuffer   = 3, // (Dma packet)
+    D3DKMT_DmaPacketTypeMax         = 4
+} D3DKMT_QUERYSTATISTICS_DMA_PACKET_TYPE;
+
+//
+// WOW will not allow enum member as array length, so define it as a constant
+//
+#define D3DKMT_QUERYSTATISTICS_DMA_PACKET_TYPE_MAX 4
+C_ASSERT(D3DKMT_QUERYSTATISTICS_DMA_PACKET_TYPE_MAX == D3DKMT_DmaPacketTypeMax);
+
+typedef enum _D3DKMT_QUERYSTATISTICS_QUEUE_PACKET_TYPE {
+    D3DKMT_RenderCommandBuffer      = 0, // (Queue Packet) should be 0 base.
+    D3DKMT_DeferredCommandBuffer    = 1, // (Queue Packet)
+    D3DKMT_SystemCommandBuffer      = 2, // (Queue Packet)
+    D3DKMT_MmIoFlipCommandBuffer    = 3, // (Queue Packet)
+    D3DKMT_WaitCommandBuffer        = 4, // (Queue Packet)
+    D3DKMT_SignalCommandBuffer      = 5, // (Queue Packet)
+    D3DKMT_DeviceCommandBuffer      = 6, // (Queue Packet)
+    D3DKMT_SoftwareCommandBuffer    = 7, // (Queue Packet)
+    D3DKMT_QueuePacketTypeMax       = 8
+} D3DKMT_QUERYSTATISTICS_QUEUE_PACKET_TYPE;
+
+//
+// WOW will not allow enum member as array length, so define it as a constant
+//
+#define D3DKMT_QUERYSTATISTICS_QUEUE_PACKET_TYPE_MAX 8
+C_ASSERT(D3DKMT_QUERYSTATISTICS_QUEUE_PACKET_TYPE_MAX == D3DKMT_QueuePacketTypeMax);
+
+typedef enum _D3DKMT_QUERYSTATISTICS_ALLOCATION_PRIORITY_CLASS
+{
+    D3DKMT_AllocationPriorityClassMinimum = 0,
+    D3DKMT_AllocationPriorityClassLow = 1,
+    D3DKMT_AllocationPriorityClassNormal = 2,
+    D3DKMT_AllocationPriorityClassHigh = 3,
+    D3DKMT_AllocationPriorityClassMaximum = 4,
+    D3DKMT_MaxAllocationPriorityClass = 5
+} D3DKMT_QUERYSTATISTICS_ALLOCATION_PRIORITY_CLASS;
+
+//
+// WOW will not allow enum member as array length, so define it as a constant
+//
+
+#define D3DKMT_QUERYSTATISTICS_ALLOCATION_PRIORITY_CLASS_MAX 5
+C_ASSERT(D3DKMT_QUERYSTATISTICS_ALLOCATION_PRIORITY_CLASS_MAX == D3DKMT_MaxAllocationPriorityClass);
+
+//
+// Allocation segment preference set can contain 5 preferences
+//
+#define D3DKMT_QUERYSTATISTICS_SEGMENT_PREFERENCE_MAX 5
+
+typedef struct _D3DKMT_QUERYSTATISTICS_COUNTER
+{
+    ULONG Count;
+    ULONGLONG Bytes;
+} D3DKMT_QUERYSTATISTICS_COUNTER;
+
+typedef struct _D3DKMT_QUERYSTATISTICS_DMA_PACKET_TYPE_INFORMATION {
+    ULONG PacketSubmited;
+    ULONG PacketCompleted;
+    ULONG PacketPreempted;
+    ULONG PacketFaulted;
+} D3DKMT_QUERYSTATISTICS_DMA_PACKET_TYPE_INFORMATION;
+
+typedef struct _D3DKMT_QUERYSTATISTICS_QUEUE_PACKET_TYPE_INFORMATION {
+    ULONG  PacketSubmited;
+    ULONG  PacketCompleted;
+} D3DKMT_QUERYSTATISTICS_QUEUE_PACKET_TYPE_INFORMATION;
+
+typedef struct _D3DKMT_QUERYSTATISTICS_PACKET_INFORMATION {
+  D3DKMT_QUERYSTATISTICS_QUEUE_PACKET_TYPE_INFORMATION QueuePacket[D3DKMT_QUERYSTATISTICS_QUEUE_PACKET_TYPE_MAX];  //Size = D3DKMT_QueuePacketTypeMax
+  D3DKMT_QUERYSTATISTICS_DMA_PACKET_TYPE_INFORMATION   DmaPacket[D3DKMT_QUERYSTATISTICS_DMA_PACKET_TYPE_MAX];    //Size = D3DKMT_DmaPacketTypeMax
+} D3DKMT_QUERYSTATISTICS_PACKET_INFORMATION;
+
+typedef struct _D3DKMT_QUERYSTATISTICS_PREEMPTION_INFORMATION {
+    ULONG PreemptionCounter[D3DKMT_QUERYRESULT_PREEMPTION_ATTEMPT_RESULT_MAX];
+} D3DKMT_QUERYSTATISTICS_PREEMPTION_INFORMATION;
+
+typedef struct _D3DKMT_QUERYSTATISTICS_PROCESS_NODE_INFORMATION {
+    D3DKMT_ALIGN64 LARGE_INTEGER                  RunningTime;          // Running time in micro-second.
+    ULONG                                         ContextSwitch;
+    D3DKMT_QUERYSTATISTICS_PREEMPTION_INFORMATION PreemptionStatistics;
+    D3DKMT_QUERYSTATISTICS_PACKET_INFORMATION     PacketStatistics;
+    D3DKMT_ALIGN64 UINT64                         Reserved[8];
+} D3DKMT_QUERYSTATISTICS_PROCESS_NODE_INFORMATION;
+
+typedef struct _D3DKMT_QUERYSTATISTICS_NODE_INFORMATION {
+    D3DKMT_QUERYSTATISTICS_PROCESS_NODE_INFORMATION GlobalInformation; //Global statistics
+    D3DKMT_QUERYSTATISTICS_PROCESS_NODE_INFORMATION SystemInformation; //Statistics for system thread
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_4)
+    D3DKMT_NODE_PERFDATA                            NodePerfData;
+    UINT32                                          Reserved[3];
+#else
+    D3DKMT_ALIGN64 UINT64                           Reserved[8];
+#endif
+} D3DKMT_QUERYSTATISTICS_NODE_INFORMATION;
+
+typedef struct _D3DKMT_QUERYSTATISTICS_PROCESS_VIDPNSOURCE_INFORMATION {
+    ULONG  Frame;          // both by Blt and Flip.
+    ULONG  CancelledFrame; // by restart (flip only).
+    ULONG  QueuedPresent;  // queued present.
+    UINT   Padding;
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_7)
+    D3DKMT_ALIGN64 UINT64 IsVSyncEnabled;
+    D3DKMT_ALIGN64 UINT64 VSyncOnTotalTimeMs;
+    D3DKMT_ALIGN64 UINT64 VSyncOffKeepPhaseTotalTimeMs;
+    D3DKMT_ALIGN64 UINT64 VSyncOffNoPhaseTotalTimeMs;
+    D3DKMT_ALIGN64 UINT64 Reserved[4];
+#else
+    D3DKMT_ALIGN64 UINT64 Reserved[8];
+#endif
+
+} D3DKMT_QUERYSTATISTICS_PROCESS_VIDPNSOURCE_INFORMATION;
+
+typedef struct _D3DKMT_QUERYSTATISTICS_VIDPNSOURCE_INFORMATION {
+    D3DKMT_QUERYSTATISTICS_PROCESS_VIDPNSOURCE_INFORMATION GlobalInformation;   //Global statistics
+    D3DKMT_QUERYSTATISTICS_PROCESS_VIDPNSOURCE_INFORMATION SystemInformation;   //Statistics for system thread
+    D3DKMT_ALIGN64 UINT64 Reserved[8];
+} D3DKMT_QUERYSTATISTICS_VIDPNSOURCE_INFORMATION;
+
+typedef struct _D3DKMT_QUERYSTATSTICS_REFERENCE_DMA_BUFFER
+{
+    ULONG NbCall;
+    ULONG NbAllocationsReferenced;
+    ULONG MaxNbAllocationsReferenced;
+    ULONG NbNULLReference;
+    ULONG NbWriteReference;
+    ULONG NbRenamedAllocationsReferenced;
+    ULONG NbIterationSearchingRenamedAllocation;
+    ULONG NbLockedAllocationReferenced;
+    ULONG NbAllocationWithValidPrepatchingInfoReferenced;
+    ULONG NbAllocationWithInvalidPrepatchingInfoReferenced;
+    ULONG NbDMABufferSuccessfullyPrePatched;
+    ULONG NbPrimariesReferencesOverflow;
+    ULONG NbAllocationWithNonPreferredResources;
+    ULONG NbAllocationInsertedInMigrationTable;
+} D3DKMT_QUERYSTATSTICS_REFERENCE_DMA_BUFFER;
+
+typedef struct _D3DKMT_QUERYSTATSTICS_RENAMING
+{
+    ULONG NbAllocationsRenamed;
+    ULONG NbAllocationsShrinked;
+    ULONG NbRenamedBuffer;
+    ULONG MaxRenamingListLength;
+    ULONG NbFailuresDueToRenamingLimit;
+    ULONG NbFailuresDueToCreateAllocation;
+    ULONG NbFailuresDueToOpenAllocation;
+    ULONG NbFailuresDueToLowResource;
+    ULONG NbFailuresDueToNonRetiredLimit;
+} D3DKMT_QUERYSTATSTICS_RENAMING;
+
+typedef struct _D3DKMT_QUERYSTATSTICS_PREPRATION
+{
+    ULONG BroadcastStall;
+    ULONG NbDMAPrepared;
+    ULONG NbDMAPreparedLongPath;
+    ULONG ImmediateHighestPreparationPass;
+    D3DKMT_QUERYSTATISTICS_COUNTER AllocationsTrimmed;
+} D3DKMT_QUERYSTATSTICS_PREPRATION;
+
+typedef struct _D3DKMT_QUERYSTATSTICS_PAGING_FAULT
+{
+    D3DKMT_QUERYSTATISTICS_COUNTER Faults;
+    D3DKMT_QUERYSTATISTICS_COUNTER FaultsFirstTimeAccess;
+    D3DKMT_QUERYSTATISTICS_COUNTER FaultsReclaimed;
+    D3DKMT_QUERYSTATISTICS_COUNTER FaultsMigration;
+    D3DKMT_QUERYSTATISTICS_COUNTER FaultsIncorrectResource;
+    D3DKMT_QUERYSTATISTICS_COUNTER FaultsLostContent;
+    D3DKMT_QUERYSTATISTICS_COUNTER FaultsEvicted;
+    D3DKMT_QUERYSTATISTICS_COUNTER AllocationsMEM_RESET;
+    D3DKMT_QUERYSTATISTICS_COUNTER AllocationsUnresetSuccess;
+    D3DKMT_QUERYSTATISTICS_COUNTER AllocationsUnresetFail;
+    ULONG AllocationsUnresetSuccessRead;
+    ULONG AllocationsUnresetFailRead;
+
+    D3DKMT_QUERYSTATISTICS_COUNTER Evictions;
+    D3DKMT_QUERYSTATISTICS_COUNTER EvictionsDueToPreparation;
+    D3DKMT_QUERYSTATISTICS_COUNTER EvictionsDueToLock;
+    D3DKMT_QUERYSTATISTICS_COUNTER EvictionsDueToClose;
+    D3DKMT_QUERYSTATISTICS_COUNTER EvictionsDueToPurge;
+    D3DKMT_QUERYSTATISTICS_COUNTER EvictionsDueToSuspendCPUAccess;
+} D3DKMT_QUERYSTATSTICS_PAGING_FAULT;
+
+typedef struct _D3DKMT_QUERYSTATSTICS_PAGING_TRANSFER
+{
+    D3DKMT_ALIGN64 ULONGLONG BytesFilled;
+    D3DKMT_ALIGN64 ULONGLONG BytesDiscarded;
+    D3DKMT_ALIGN64 ULONGLONG BytesMappedIntoAperture;
+    D3DKMT_ALIGN64 ULONGLONG BytesUnmappedFromAperture;
+    D3DKMT_ALIGN64 ULONGLONG BytesTransferredFromMdlToMemory;
+    D3DKMT_ALIGN64 ULONGLONG BytesTransferredFromMemoryToMdl;
+    D3DKMT_ALIGN64 ULONGLONG BytesTransferredFromApertureToMemory;
+    D3DKMT_ALIGN64 ULONGLONG BytesTransferredFromMemoryToAperture;
+} D3DKMT_QUERYSTATSTICS_PAGING_TRANSFER;
+
+typedef struct _D3DKMT_QUERYSTATSTICS_SWIZZLING_RANGE
+{
+    ULONG NbRangesAcquired;
+    ULONG NbRangesReleased;
+} D3DKMT_QUERYSTATSTICS_SWIZZLING_RANGE;
+
+typedef struct _D3DKMT_QUERYSTATSTICS_LOCKS
+{
+    ULONG NbLocks;
+    ULONG NbLocksWaitFlag;
+    ULONG NbLocksDiscardFlag;
+    ULONG NbLocksNoOverwrite;
+    ULONG NbLocksNoReadSync;
+    ULONG NbLocksLinearization;
+    ULONG NbComplexLocks;
+} D3DKMT_QUERYSTATSTICS_LOCKS;
+
+typedef struct _D3DKMT_QUERYSTATSTICS_ALLOCATIONS
+{
+    D3DKMT_QUERYSTATISTICS_COUNTER Created;
+    D3DKMT_QUERYSTATISTICS_COUNTER Destroyed;
+    D3DKMT_QUERYSTATISTICS_COUNTER Opened;
+    D3DKMT_QUERYSTATISTICS_COUNTER Closed;
+    D3DKMT_QUERYSTATISTICS_COUNTER MigratedSuccess;
+    D3DKMT_QUERYSTATISTICS_COUNTER MigratedFail;
+    D3DKMT_QUERYSTATISTICS_COUNTER MigratedAbandoned;
+} D3DKMT_QUERYSTATSTICS_ALLOCATIONS;
+
+typedef struct _D3DKMT_QUERYSTATSTICS_TERMINATIONS
+{
+    //
+    // We separate shared / nonshared because for nonshared we know that every alloc
+    // terminated will lead cause a global alloc destroyed, but not for nonshared.
+    //
+    D3DKMT_QUERYSTATISTICS_COUNTER TerminatedShared;
+    D3DKMT_QUERYSTATISTICS_COUNTER TerminatedNonShared;
+    D3DKMT_QUERYSTATISTICS_COUNTER DestroyedShared;
+    D3DKMT_QUERYSTATISTICS_COUNTER DestroyedNonShared;
+} D3DKMT_QUERYSTATSTICS_TERMINATIONS;
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_1)
+typedef struct _D3DKMT_QUERYSTATISTICS_ADAPTER_INFORMATION_FLAGS
+{
+    union
+    {
+        struct
+        {
+            UINT64 NumberOfMemoryGroups : 2;
+            UINT64 SupportsDemotion     : 1;
+            UINT64 Reserved             :61;
+        };
+        D3DKMT_ALIGN64 UINT64 Value;
+    };
+} D3DKMT_QUERYSTATISTICS_ADAPTER_INFORMATION_FLAGS;
+#endif
+
+typedef struct _D3DKMT_QUERYSTATISTICS_ADAPTER_INFORMATION
+{
+    ULONG NbSegments;
+    ULONG NodeCount;
+    ULONG VidPnSourceCount;
+
+    ULONG VSyncEnabled;
+    ULONG TdrDetectedCount;
+
+    D3DKMT_ALIGN64 LONGLONG ZeroLengthDmaBuffers;
+    D3DKMT_ALIGN64 ULONGLONG RestartedPeriod;
+
+    D3DKMT_QUERYSTATSTICS_REFERENCE_DMA_BUFFER ReferenceDmaBuffer;
+    D3DKMT_QUERYSTATSTICS_RENAMING Renaming;
+    D3DKMT_QUERYSTATSTICS_PREPRATION Preparation;
+    D3DKMT_QUERYSTATSTICS_PAGING_FAULT PagingFault;
+    D3DKMT_QUERYSTATSTICS_PAGING_TRANSFER PagingTransfer;
+    D3DKMT_QUERYSTATSTICS_SWIZZLING_RANGE SwizzlingRange;
+    D3DKMT_QUERYSTATSTICS_LOCKS Locks;
+    D3DKMT_QUERYSTATSTICS_ALLOCATIONS Allocations;
+    D3DKMT_QUERYSTATSTICS_TERMINATIONS Terminations;
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_2)
+    D3DKMT_QUERYSTATISTICS_ADAPTER_INFORMATION_FLAGS Flags;
+    D3DKMT_ALIGN64 UINT64 Reserved[7];
+#else
+    D3DKMT_ALIGN64 UINT64 Reserved[8];
+#endif
+} D3DKMT_QUERYSTATISTICS_ADAPTER_INFORMATION;
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_4)
+typedef struct _D3DKMT_QUERYSTATISTICS_PHYSICAL_ADAPTER_INFORMATION
+{
+    D3DKMT_ADAPTER_PERFDATA      AdapterPerfData;
+    D3DKMT_ADAPTER_PERFDATACAPS  AdapterPerfDataCaps;
+    D3DKMT_GPUVERSION            GpuVersion;
+} D3DKMT_QUERYSTATISTICS_PHYSICAL_ADAPTER_INFORMATION;
+#endif
+
+typedef struct _D3DKMT_QUERYSTATISTICS_SYSTEM_MEMORY
+{
+    D3DKMT_ALIGN64 ULONGLONG BytesAllocated;
+    D3DKMT_ALIGN64 ULONGLONG BytesReserved;
+    ULONG SmallAllocationBlocks;
+    ULONG LargeAllocationBlocks;
+    D3DKMT_ALIGN64 ULONGLONG WriteCombinedBytesAllocated;
+    D3DKMT_ALIGN64 ULONGLONG WriteCombinedBytesReserved;
+    D3DKMT_ALIGN64 ULONGLONG CachedBytesAllocated;
+    D3DKMT_ALIGN64 ULONGLONG CachedBytesReserved;
+    D3DKMT_ALIGN64 ULONGLONG SectionBytesAllocated;
+    D3DKMT_ALIGN64 ULONGLONG SectionBytesReserved;
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_4)
+    D3DKMT_ALIGN64 ULONGLONG BytesZeroed;
+#else
+    D3DKMT_ALIGN64 ULONGLONG Reserved;
+#endif
+} D3DKMT_QUERYSTATISTICS_SYSTEM_MEMORY;
+
+typedef struct _D3DKMT_QUERYSTATISTICS_PROCESS_INFORMATION
+{
+    ULONG NodeCount;
+    ULONG VidPnSourceCount;
+
+    D3DKMT_QUERYSTATISTICS_SYSTEM_MEMORY SystemMemory;
+
+    D3DKMT_ALIGN64 UINT64 Reserved[7];
+} D3DKMT_QUERYSTATISTICS_PROCESS_INFORMATION;
+
+typedef struct _D3DKMT_QUERYSTATISTICS_DMA_BUFFER
+{
+    D3DKMT_QUERYSTATISTICS_COUNTER Size;
+    ULONG AllocationListBytes;
+    ULONG PatchLocationListBytes;
+} D3DKMT_QUERYSTATISTICS_DMA_BUFFER;
+
+typedef struct _D3DKMT_QUERYSTATISTICS_COMMITMENT_DATA
+{
+    D3DKMT_ALIGN64 UINT64          TotalBytesEvictedFromProcess;
+    D3DKMT_ALIGN64 UINT64          BytesBySegmentPreference[D3DKMT_QUERYSTATISTICS_SEGMENT_PREFERENCE_MAX];
+} D3DKMT_QUERYSTATISTICS_COMMITMENT_DATA;
+
+typedef struct _D3DKMT_QUERYSTATISTICS_POLICY
+{
+    D3DKMT_ALIGN64 ULONGLONG PreferApertureForRead[D3DKMT_QUERYSTATISTICS_ALLOCATION_PRIORITY_CLASS_MAX];
+    D3DKMT_ALIGN64 ULONGLONG PreferAperture[D3DKMT_QUERYSTATISTICS_ALLOCATION_PRIORITY_CLASS_MAX];
+    D3DKMT_ALIGN64 ULONGLONG MemResetOnPaging;
+    D3DKMT_ALIGN64 ULONGLONG RemovePagesFromWorkingSetOnPaging;
+    D3DKMT_ALIGN64 ULONGLONG MigrationEnabled;
+} D3DKMT_QUERYSTATISTICS_POLICY;
+
+// Process interference counters indicate how much this process GPU workload interferes with packets
+// attempting to preempt it. 9 buckets will be exposed based on how long preemption took:
+// [0] 100 microseconds <= preemption time < 250 microseconds
+// [1] 250 microseconds <= preemption time < 500 microseconds
+// [2] 500 microseconds <= preemption time < 1 milliseconds
+// [3] 1 milliseconds   <= preemption time < 2.5 milliseconds
+// [4] 2.5 milliseconds <= preemption time < 5 milliseconds
+// [5] 5 milliseconds   <= preemption time < 10 milliseconds
+// [6] 10 milliseconds  <= preemption time < 25 milliseconds
+// [7] 25 milliseconds  <= preemption time < 50 milliseconds
+// [8] 50 milliseconds  <= preemption time
+//
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_1)
+#define D3DKMT_QUERYSTATISTICS_PROCESS_INTERFERENCE_BUCKET_COUNT 9
+
+typedef struct _D3DKMT_QUERYSTATISTICS_PROCESS_INTERFERENCE_COUNTERS
+{
+    D3DKMT_ALIGN64 UINT64 InterferenceCount[D3DKMT_QUERYSTATISTICS_PROCESS_INTERFERENCE_BUCKET_COUNT];
+} D3DKMT_QUERYSTATISTICS_PROCESS_INTERFERENCE_COUNTERS;
+#endif
+
+typedef struct _D3DKMT_QUERYSTATISTICS_PROCESS_ADAPTER_INFORMATION
+{
+    ULONG NbSegments;
+    ULONG NodeCount;
+    ULONG VidPnSourceCount;
+
+    //
+    // Virtual address space used by vidmm for this process
+    //
+    ULONG VirtualMemoryUsage;
+
+    D3DKMT_QUERYSTATISTICS_DMA_BUFFER DmaBuffer;
+    D3DKMT_QUERYSTATISTICS_COMMITMENT_DATA CommitmentData;
+    D3DKMT_QUERYSTATISTICS_POLICY _Policy;
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_1)
+    D3DKMT_QUERYSTATISTICS_PROCESS_INTERFERENCE_COUNTERS ProcessInterferenceCounters;
+#else
+    D3DKMT_ALIGN64 UINT64 Reserved[9];
+#endif
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_9)
+    D3DKMT_CLIENTHINT       ClientHint;
+#else
+    UINT Reserve;
+#endif
+} D3DKMT_QUERYSTATISTICS_PROCESS_ADAPTER_INFORMATION;
+
+typedef struct _D3DKMT_QUERYSTATISTICS_MEMORY
+{
+    D3DKMT_ALIGN64 ULONGLONG TotalBytesEvicted;
+    ULONG AllocsCommitted;
+    ULONG AllocsResident;
+} D3DKMT_QUERYSTATISTICS_MEMORY;
+
+typedef struct _D3DKMT_QUERYSTATISTICS_SEGMENT_INFORMATION
+{
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8)
+    D3DKMT_ALIGN64 ULONGLONG CommitLimit;
+    D3DKMT_ALIGN64 ULONGLONG BytesCommitted;
+    D3DKMT_ALIGN64 ULONGLONG BytesResident;
+#else
+    ULONG CommitLimit;
+    ULONG BytesCommitted;
+    ULONG BytesResident;
+#endif
+
+    D3DKMT_QUERYSTATISTICS_MEMORY Memory;
+
+    //
+    // Boolean, whether this is an aperture segment
+    //
+    ULONG Aperture;
+
+    //
+    // Breakdown of bytes evicted by priority class
+    //
+    D3DKMT_ALIGN64 ULONGLONG TotalBytesEvictedByPriority[D3DKMT_QUERYSTATISTICS_ALLOCATION_PRIORITY_CLASS_MAX];   //Size = D3DKMT_MaxAllocationPriorityClass
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8)
+    D3DKMT_ALIGN64 UINT64 SystemMemoryEndAddress;
+    struct D3DKMT_ALIGN64
+    {
+        UINT64 PreservedDuringStandby : 1;
+        UINT64 PreservedDuringHibernate : 1;
+        UINT64 PartiallyPreservedDuringHibernate : 1;
+        UINT64 Reserved : 61;
+    } PowerFlags;
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_9)
+    struct D3DKMT_ALIGN64
+    {
+        UINT64 SystemMemory : 1;
+        UINT64 PopulatedByReservedDDRByFirmware : 1;
+        UINT64 Reserved : 62;
+    } SegmentProperties;
+    D3DKMT_ALIGN64 UINT64 Reserved[5];
+#else
+    D3DKMT_ALIGN64 UINT64 Reserved[6];
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_9)
+#else
+    D3DKMT_ALIGN64 UINT64 Reserved[8];
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8)
+} D3DKMT_QUERYSTATISTICS_SEGMENT_INFORMATION;
+
+//
+// Video memory statistics.
+//
+typedef struct _D3DKMT_QUERYSTATISTICS_VIDEO_MEMORY
+{
+    ULONG AllocsCommitted;
+    D3DKMT_QUERYSTATISTICS_COUNTER AllocsResidentInP[D3DKMT_QUERYSTATISTICS_SEGMENT_PREFERENCE_MAX];
+    D3DKMT_QUERYSTATISTICS_COUNTER AllocsResidentInNonPreferred;
+    D3DKMT_ALIGN64 ULONGLONG TotalBytesEvictedDueToPreparation;
+} D3DKMT_QUERYSTATISTICS_VIDEO_MEMORY;
+
+//
+// VidMM Policies
+//
+typedef struct _D3DKMT_QUERYSTATISTICS_PROCESS_SEGMENT_POLICY
+{
+    D3DKMT_ALIGN64 ULONGLONG UseMRU;
+} D3DKMT_QUERYSTATISTICS_PROCESS_SEGMENT_POLICY;
+
+typedef struct _D3DKMT_QUERYSTATISTICS_PROCESS_SEGMENT_INFORMATION
+{
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8)
+    D3DKMT_ALIGN64 ULONGLONG BytesCommitted;
+    D3DKMT_ALIGN64 ULONGLONG MaximumWorkingSet;
+    D3DKMT_ALIGN64 ULONGLONG MinimumWorkingSet;
+
+    ULONG NbReferencedAllocationEvictedInPeriod;
+    UINT Padding;
+#else
+    ULONG BytesCommitted;
+    ULONG NbReferencedAllocationEvictedInPeriod;
+    ULONG MaximumWorkingSet;
+    ULONG MinimumWorkingSet;
+#endif
+
+    D3DKMT_QUERYSTATISTICS_VIDEO_MEMORY VideoMemory;
+    D3DKMT_QUERYSTATISTICS_PROCESS_SEGMENT_POLICY _Policy;
+
+    D3DKMT_ALIGN64 UINT64 Reserved[8];
+} D3DKMT_QUERYSTATISTICS_PROCESS_SEGMENT_INFORMATION;
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_1)
+typedef struct _D3DKMT_QUERYSTATISTICS_PROCESS_SEGMENT_GROUP_INFORMATION
+{
+    D3DKMT_ALIGN64 UINT64 Budget;
+    D3DKMT_ALIGN64 UINT64 Requested;
+    D3DKMT_ALIGN64 UINT64 Usage;
+    D3DKMT_ALIGN64 UINT64 Demoted[D3DKMT_QUERYSTATISTICS_ALLOCATION_PRIORITY_CLASS_MAX];
+} D3DKMT_QUERYSTATISTICS_PROCESS_SEGMENT_GROUP_INFORMATION;
+#endif
+
+typedef enum _D3DKMT_QUERYSTATISTICS_TYPE
+{
+    D3DKMT_QUERYSTATISTICS_ADAPTER                = 0,
+    D3DKMT_QUERYSTATISTICS_PROCESS                = 1,
+    D3DKMT_QUERYSTATISTICS_PROCESS_ADAPTER        = 2,
+    D3DKMT_QUERYSTATISTICS_SEGMENT                = 3,
+    D3DKMT_QUERYSTATISTICS_PROCESS_SEGMENT        = 4,
+    D3DKMT_QUERYSTATISTICS_NODE                   = 5,
+    D3DKMT_QUERYSTATISTICS_PROCESS_NODE           = 6,
+    D3DKMT_QUERYSTATISTICS_VIDPNSOURCE            = 7,
+    D3DKMT_QUERYSTATISTICS_PROCESS_VIDPNSOURCE    = 8,
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_1)
+    D3DKMT_QUERYSTATISTICS_PROCESS_SEGMENT_GROUP  = 9,
+#endif
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_4)
+    D3DKMT_QUERYSTATISTICS_PHYSICAL_ADAPTER       = 10,
+#endif
+} D3DKMT_QUERYSTATISTICS_TYPE;
+
+typedef struct _D3DKMT_QUERYSTATISTICS_QUERY_SEGMENT
+{
+    ULONG SegmentId; // in: id of node to get statistics for
+} D3DKMT_QUERYSTATISTICS_QUERY_SEGMENT;
+
+typedef struct _D3DKMT_QUERYSTATISTICS_QUERY_NODE
+{
+    ULONG NodeId;
+} D3DKMT_QUERYSTATISTICS_QUERY_NODE;
+
+typedef struct _D3DKMT_QUERYSTATISTICS_QUERY_VIDPNSOURCE
+{
+    ULONG VidPnSourceId; // in: id of segment to get statistics for
+} D3DKMT_QUERYSTATISTICS_QUERY_VIDPNSOURCE;
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_4)
+typedef struct _D3DKMT_QUERYSTATISTICS_QUERY_PHYSICAL_ADAPTER
+{
+    ULONG PhysicalAdapterIndex;
+} D3DKMT_QUERYSTATISTICS_QUERY_PHYSICAL_ADAPTER;
+#endif
+
+typedef union _D3DKMT_QUERYSTATISTICS_RESULT
+{
+    D3DKMT_QUERYSTATISTICS_ADAPTER_INFORMATION AdapterInformation;                          // out: result of D3DKMT_QUERYSTATISTICS_ADAPTER query
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_4)
+    D3DKMT_QUERYSTATISTICS_PHYSICAL_ADAPTER_INFORMATION PhysAdapterInformation;             // out: result of D3DKMT_QUERYSTATISTICS_PHYSICAL_ADAPTER query
+#endif
+    D3DKMT_QUERYSTATISTICS_SEGMENT_INFORMATION SegmentInformation;                          // out: result of D3DKMT_QUERYSTATISTICS_SEGMENT query
+    D3DKMT_QUERYSTATISTICS_NODE_INFORMATION NodeInformation;                                // out: result of D3DKMT_QUERYSTATISTICS_NODE query
+    D3DKMT_QUERYSTATISTICS_VIDPNSOURCE_INFORMATION VidPnSourceInformation;                  // out: result of D3DKMT_QUERYSTATISTICS_VIDPNSOURCE query
+    D3DKMT_QUERYSTATISTICS_PROCESS_INFORMATION ProcessInformation;                          // out: result of D3DKMT_QUERYSTATISTICS_PROCESS query
+    D3DKMT_QUERYSTATISTICS_PROCESS_ADAPTER_INFORMATION ProcessAdapterInformation;           // out: result of D3DKMT_QUERYSTATISTICS_PROCESS_ADAPTER query
+    D3DKMT_QUERYSTATISTICS_PROCESS_SEGMENT_INFORMATION ProcessSegmentInformation;           // out: result of D3DKMT_QUERYSTATISTICS_PROCESS_SEGMENT query
+    D3DKMT_QUERYSTATISTICS_PROCESS_NODE_INFORMATION ProcessNodeInformation;                 // out: result of D3DKMT_QUERYSTATISTICS_PROCESS_NODE query
+    D3DKMT_QUERYSTATISTICS_PROCESS_VIDPNSOURCE_INFORMATION ProcessVidPnSourceInformation;   // out: result of D3DKMT_QUERYSTATISTICS_PROCESS_VIDPNSOURCE query
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_1)
+    D3DKMT_QUERYSTATISTICS_PROCESS_SEGMENT_GROUP_INFORMATION ProcessSegmentGroupInformation;// out: result of D3DKMT_QUERYSTATISTICS_PROCESS_SEGMENT_GROUP query
+#endif
+} D3DKMT_QUERYSTATISTICS_RESULT;
+
+typedef struct _D3DKMT_QUERYSTATISTICS
+{
+    D3DKMT_QUERYSTATISTICS_TYPE   Type;        // in: type of data requested
+    LUID                          AdapterLuid; // in: adapter to get export / statistics from
+    D3DKMT_PTR(HANDLE,            hProcess);   // in: process to get statistics for, if required for this query type
+    D3DKMT_QUERYSTATISTICS_RESULT QueryResult; // out: requested data
+
+    union
+    {
+        D3DKMT_QUERYSTATISTICS_QUERY_SEGMENT QuerySegment;                // in: id of segment to get statistics for
+        D3DKMT_QUERYSTATISTICS_QUERY_SEGMENT QueryProcessSegment;         // in: id of segment to get statistics for
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_1)
+        D3DKMT_MEMORY_SEGMENT_GROUP QueryProcessSegmentGroup;             // in: id of segment group to get statistics for
+#endif
+        D3DKMT_QUERYSTATISTICS_QUERY_NODE QueryNode;                      // in: id of node to get statistics for
+        D3DKMT_QUERYSTATISTICS_QUERY_NODE QueryProcessNode;               // in: id of node to get statistics for
+        D3DKMT_QUERYSTATISTICS_QUERY_VIDPNSOURCE QueryVidPnSource;        // in: id of vidpnsource to get statistics for
+        D3DKMT_QUERYSTATISTICS_QUERY_VIDPNSOURCE QueryProcessVidPnSource; // in: id of vidpnsource to get statistics for
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_4)
+        D3DKMT_QUERYSTATISTICS_QUERY_PHYSICAL_ADAPTER QueryPhysAdapter;   // in: id of physical adapter to get statistics for
+#endif
+    };
+} D3DKMT_QUERYSTATISTICS;
+#if defined(_AMD64_)
+C_ASSERT(sizeof(D3DKMT_QUERYSTATISTICS) == 0x328);
+#endif
+
+//
+// end D3DKMT_QUERYSTATISTICS
+//
+
+
+typedef struct _D3DKMT_PRESENT_STATS_DWM2
+{
+    ULONG                        cbSize; // in: size of struct for versioning
+    UINT                         PresentCount;
+    UINT                         PresentRefreshCount;
+    D3DKMT_ALIGN64 LARGE_INTEGER PresentQPCTime;
+    UINT                         SyncRefreshCount;
+    D3DKMT_ALIGN64 LARGE_INTEGER SyncQPCTime;
+    UINT                         CustomPresentDuration;
+    UINT                         VirtualSyncRefreshCount;
+    D3DKMT_ALIGN64 LARGE_INTEGER VirtualSyncQPCTime;
+} D3DKMT_PRESENT_STATS_DWM2;
+
+
+typedef enum _D3DKMT_VIDPNSOURCEOWNER_TYPE
+{
+     D3DKMT_VIDPNSOURCEOWNER_UNOWNED        = 0,    //Has no owner or GDI is the owner
+     D3DKMT_VIDPNSOURCEOWNER_SHARED         = 1,    //Has shared owner, that is owner can yield to any exclusive owner, not available to legacy devices
+     D3DKMT_VIDPNSOURCEOWNER_EXCLUSIVE      = 2,    //Has exclusive owner without shared gdi primary,
+     D3DKMT_VIDPNSOURCEOWNER_EXCLUSIVEGDI   = 3,    //Has exclusive owner with shared gdi primary and must be exclusive owner of all VidPn sources, only available to legacy devices
+     D3DKMT_VIDPNSOURCEOWNER_EMULATED       = 4,    //Does not have real primary ownership, but allows the device to set gamma on its owned sources
+} D3DKMT_VIDPNSOURCEOWNER_TYPE;
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8)
+typedef struct _D3DKMT_VIDPNSOURCEOWNER_FLAGS
+{
+    union
+    {
+        struct
+        {
+            UINT AllowOutputDuplication : 1;
+            UINT DisableDWMVirtualMode  : 1;
+            UINT UseNtHandles           : 1;
+            UINT Reserved               : 29;
+        };
+        UINT Value;
+    };
+} D3DKMT_VIDPNSOURCEOWNER_FLAGS;
+#endif
+
+typedef struct _D3DKMT_SETVIDPNSOURCEOWNER
+{
+    D3DKMT_HANDLE                           hDevice;            // in: Device handle
+    D3DKMT_PTR(CONST D3DKMT_VIDPNSOURCEOWNER_TYPE*, pType);     // in: OwnerType array
+    D3DKMT_PTR(CONST D3DDDI_VIDEO_PRESENT_SOURCE_ID*, pVidPnSourceId); // in: VidPn source ID array
+    UINT                                    VidPnSourceCount;   // in: Number of valid entries in above array
+} D3DKMT_SETVIDPNSOURCEOWNER;
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8)
+typedef struct _D3DKMT_SETVIDPNSOURCEOWNER1
+{
+    D3DKMT_SETVIDPNSOURCEOWNER              Version0;
+    D3DKMT_VIDPNSOURCEOWNER_FLAGS           Flags;
+} D3DKMT_SETVIDPNSOURCEOWNER1;
+#endif
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_3)
+typedef struct _D3DKMT_SETVIDPNSOURCEOWNER2
+{
+    D3DKMT_SETVIDPNSOURCEOWNER1             Version1;
+    D3DKMT_PTR(CONST D3DKMT_PTR_TYPE*,      pVidPnSourceNtHandles); // in: VidPn source owner DispMgr NT handles
+} D3DKMT_SETVIDPNSOURCEOWNER2;
+#endif
+
+typedef struct _D3DKMT_CHECKVIDPNEXCLUSIVEOWNERSHIP
+{
+    D3DKMT_HANDLE                           hAdapter;           // in: Adapter handle
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID          VidPnSourceId;      // in: VidPn source ID array
+} D3DKMT_CHECKVIDPNEXCLUSIVEOWNERSHIP;
+
+#define D3DKMT_GETPRESENTHISTORY_MAXTOKENS  2048
+
+typedef struct _D3DKMT_GETPRESENTHISTORY
+{
+    D3DKMT_HANDLE                                             hAdapter;     // in: Handle to adapter
+    UINT                                                      ProvidedSize; // in: Size of provided buffer
+    UINT                                                      WrittenSize;  // out: Copied token size or required size for first token
+    D3DKMT_PTR(_Field_size_bytes_(ProvidedSize) D3DKMT_PRESENTHISTORYTOKEN*, pTokens); // in: Pointer to buffer.
+    UINT                                                      NumTokens;    // out: Number of copied token
+} D3DKMT_GETPRESENTHISTORY;
+
+typedef struct _D3DKMT_CREATEOVERLAY
+{
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID  VidPnSourceId;      // in
+    D3DKMT_HANDLE                   hDevice;            // in: Indentifies the device
+    D3DDDI_KERNELOVERLAYINFO        OverlayInfo;        // in
+    D3DKMT_HANDLE                   hOverlay;           // out: Kernel overlay handle
+} D3DKMT_CREATEOVERLAY;
+
+typedef struct _D3DKMT_UPDATEOVERLAY
+{
+    D3DKMT_HANDLE            hDevice;           // in: Indentifies the device
+    D3DKMT_HANDLE            hOverlay;          // in: Kernel overlay handle
+    D3DDDI_KERNELOVERLAYINFO OverlayInfo;       // in
+} D3DKMT_UPDATEOVERLAY;
+
+typedef struct _D3DKMT_FLIPOVERLAY
+{
+    D3DKMT_HANDLE        hDevice;               // in: Indentifies the device
+    D3DKMT_HANDLE        hOverlay;              // in: Kernel overlay handle
+    D3DKMT_HANDLE        hSource;               // in: Allocation currently displayed
+    D3DKMT_PTR(VOID*,    pPrivateDriverData);   // in: Private driver data
+    UINT                 PrivateDriverDataSize; // in: Size of private driver data
+} D3DKMT_FLIPOVERLAY;
+
+typedef struct _D3DKMT_GETOVERLAYSTATE
+{
+    D3DKMT_HANDLE        hDevice;               // in: Indentifies the device
+    D3DKMT_HANDLE        hOverlay;              // in: Kernel overlay handle
+    BOOLEAN              OverlayEnabled;
+} D3DKMT_GETOVERLAYSTATE;
+
+typedef struct _D3DKMT_DESTROYOVERLAY
+{
+    D3DKMT_HANDLE        hDevice;               // in: Indentifies the device
+    D3DKMT_HANDLE        hOverlay;              // in: Kernel overlay handle
+} D3DKMT_DESTROYOVERLAY;
+
+typedef struct _D3DKMT_WAITFORVERTICALBLANKEVENT
+{
+    D3DKMT_HANDLE                   hAdapter;      // in: adapter handle
+    D3DKMT_HANDLE                   hDevice;       // in: device handle [Optional]
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID  VidPnSourceId; // in: adapter's VidPN Source ID
+} D3DKMT_WAITFORVERTICALBLANKEVENT;
+
+#define D3DKMT_MAX_WAITFORVERTICALBLANK_OBJECTS 8
+
+typedef struct _D3DKMT_WAITFORVERTICALBLANKEVENT2
+{
+    D3DKMT_HANDLE                   hAdapter;      // in: adapter handle
+    D3DKMT_HANDLE                   hDevice;       // in: device handle [Optional]
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID  VidPnSourceId; // in: adapter's VidPN Source ID
+    UINT                            NumObjects;
+    D3DKMT_PTR_TYPE                 ObjectHandleArray[D3DKMT_MAX_WAITFORVERTICALBLANK_OBJECTS]; // in: Specifies the objects to wait on.
+} D3DKMT_WAITFORVERTICALBLANKEVENT2;
+
+typedef struct _D3DKMT_GETVERTICALBLANKEVENT
+{
+    D3DKMT_HANDLE                   hAdapter;      // in: adapter handle
+    D3DKMT_HANDLE                   hDevice;       // in: device handle [Optional]
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID  VidPnSourceId; // in: adapter's VidPN Source ID
+    D3DKMT_PTR(D3DKMT_PTR_TYPE*,    phEvent);
+} D3DKMT_GETVERTICALBLANKEVENT;
+
+typedef struct _D3DKMT_SETSYNCREFRESHCOUNTWAITTARGET
+{
+    D3DKMT_HANDLE                   hAdapter;      // in: adapter handle
+    D3DKMT_HANDLE                   hDevice;       // in: device handle [Optional]
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID  VidPnSourceId; // in: adapter's VidPN Source ID
+    UINT                            TargetSyncRefreshCount;
+} D3DKMT_SETSYNCREFRESHCOUNTWAITTARGET;
+
+typedef struct _D3DKMT_SETGAMMARAMP
+{
+    D3DKMT_HANDLE                   hDevice;       // in: device handle
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID  VidPnSourceId; // in: adapter's VidPN Source ID
+    D3DDDI_GAMMARAMP_TYPE           Type;          // in: Gamma ramp type
+
+    union
+    {
+        D3DDDI_GAMMA_RAMP_RGB256x3x16* pGammaRampRgb256x3x16;
+        D3DDDI_GAMMA_RAMP_DXGI_1*      pGammaRampDXGI1;
+        D3DKMT_PTR_HELPER(             AlignUnionTo64)
+    };
+    UINT                            Size;
+} D3DKMT_SETGAMMARAMP;
+
+typedef struct _D3DKMT_ADJUSTFULLSCREENGAMMA
+{
+    D3DKMT_HANDLE                   hAdapter;      // in: adapter handle
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID  VidPnSourceId; // in: adapter's VidPN Source ID
+    D3DDDI_DXGI_RGB                 Scale;
+    D3DDDI_DXGI_RGB                 Offset;
+} D3DKMT_ADJUSTFULLSCREENGAMMA;
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_3)
+
+typedef struct _D3DKMT_SET_COLORSPACE_TRANSFORM
+{
+    _In_ LUID  AdapterLuid;
+    _In_ D3DDDI_VIDEO_PRESENT_TARGET_ID  VidPnTargetId;
+    _In_ D3DDDI_GAMMARAMP_TYPE  Type;
+    _In_ UINT  Size;
+    union
+    {
+        _In_reads_bytes_opt_(Size) D3DKMDT_3x4_COLORSPACE_TRANSFORM*  pColorSpaceTransform;
+        D3DKMT_PTR_HELPER(                                            AlignUnionTo64)
+    };
+} D3DKMT_SET_COLORSPACE_TRANSFORM;
+
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_3
+
+typedef struct _D3DKMT_SETVIDPNSOURCEHWPROTECTION
+{
+    D3DKMT_HANDLE                   hAdapter;      // in: adapter handle
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID  VidPnSourceId; // in: adapter's VidPN Source ID
+    BOOL                            HwProtected;   // in: HW protection status
+} D3DKMT_SETVIDPNSOURCEHWPROTECTION;
+
+typedef struct _D3DKMT_SETHWPROTECTIONTEARDOWNRECOVERY
+{
+    D3DKMT_HANDLE                   hAdapter;      // in: adapter handle
+    BOOL                            Recovered;     // in: HW protection teardown recovery
+} D3DKMT_SETHWPROTECTIONTEARDOWNRECOVERY;
+
+typedef enum _D3DKMT_DEVICEEXECUTION_STATE
+{
+    D3DKMT_DEVICEEXECUTION_ACTIVE               = 1,
+    D3DKMT_DEVICEEXECUTION_RESET                = 2,
+    D3DKMT_DEVICEEXECUTION_HUNG                 = 3,
+    D3DKMT_DEVICEEXECUTION_STOPPED              = 4,
+    D3DKMT_DEVICEEXECUTION_ERROR_OUTOFMEMORY    = 5,
+    D3DKMT_DEVICEEXECUTION_ERROR_DMAFAULT       = 6,
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0)
+    D3DKMT_DEVICEEXECUTION_ERROR_DMAPAGEFAULT   = 7,
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0)
+} D3DKMT_DEVICEEXECUTION_STATE;
+
+typedef struct _D3DKMT_DEVICERESET_STATE
+{
+    union
+    {
+        struct
+        {
+            UINT    DesktopSwitched : 1;        // 0x00000001
+            UINT    Reserved        :31;        // 0xFFFFFFFE
+        };
+        UINT    Value;
+    };
+} D3DKMT_DEVICERESET_STATE;
+
+typedef struct _D3DKMT_PRESENT_STATS
+{
+    UINT PresentCount;
+    UINT PresentRefreshCount;
+    UINT SyncRefreshCount;
+    D3DKMT_ALIGN64 LARGE_INTEGER SyncQPCTime;
+    D3DKMT_ALIGN64 LARGE_INTEGER SyncGPUTime;
+} D3DKMT_PRESENT_STATS;
+
+typedef struct _D3DKMT_DEVICEPRESENT_STATE
+{
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID VidPnSourceId; // in: present source id
+    D3DKMT_PRESENT_STATS           PresentStats;  // out: present stats
+} D3DKMT_DEVICEPRESENT_STATE;
+
+typedef struct _D3DKMT_PRESENT_STATS_DWM
+{
+    UINT PresentCount;
+    UINT PresentRefreshCount;
+    D3DKMT_ALIGN64 LARGE_INTEGER PresentQPCTime;
+    UINT SyncRefreshCount;
+    D3DKMT_ALIGN64 LARGE_INTEGER SyncQPCTime;
+    UINT CustomPresentDuration;
+} D3DKMT_PRESENT_STATS_DWM;
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0)
+
+typedef struct _D3DKMT_DEVICEPAGEFAULT_STATE
+{
+    D3DKMT_ALIGN64 UINT64       FaultedPrimitiveAPISequenceNumber; // when per draw fence write is enabled, identifies the draw that caused the page fault, or DXGK_PRIMITIVE_API_SEQUENCE_NUMBER_UNKNOWN if such information is not available.
+    DXGK_RENDER_PIPELINE_STAGE  FaultedPipelineStage;   // render pipeline stage during which the fault was generated, or DXGK_RENDER_PIPELINE_STAGE_UNKNOWN if such information is not available.
+    UINT                        FaultedBindTableEntry;  // a bind table index of a resource being accessed at the time of the fault, or DXGK_BIND_TABLE_ENTRY_UNKNOWN if such information is not available.
+    DXGK_PAGE_FAULT_FLAGS       PageFaultFlags;         // flags specifying the nature of the fault
+    DXGK_FAULT_ERROR_CODE       FaultErrorCode;         // Structure that contains error code describing the fault.
+    D3DKMT_ALIGN64 D3DGPU_VIRTUAL_ADDRESS FaultedVirtualAddress;  // virtual address of faulting resource, or D3DGPU_NULL if such information is not available.
+} D3DKMT_DEVICEPAGEFAULT_STATE;
+
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0)
+
+typedef struct _D3DKMT_DEVICEPRESENT_STATE_DWM
+{
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID VidPnSourceId; // in: present source id
+    D3DKMT_PRESENT_STATS_DWM       PresentStatsDWM; // out: present stats rev 2
+} D3DKMT_DEVICEPRESENT_STATE_DWM;
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_1)
+
+typedef struct _D3DKMT_DEVICEPRESENT_QUEUE_STATE
+{
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID VidPnSourceId; // in: present source id
+    BOOLEAN bQueuedPresentLimitReached;           // out: whether the queued present limit has been reached
+} D3DKMT_DEVICEPRESENT_QUEUE_STATE;
+
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_1)
+
+typedef enum _D3DKMT_DEVICESTATE_TYPE
+{
+    D3DKMT_DEVICESTATE_EXECUTION = 1,
+    D3DKMT_DEVICESTATE_PRESENT   = 2,
+    D3DKMT_DEVICESTATE_RESET     = 3,
+    D3DKMT_DEVICESTATE_PRESENT_DWM = 4,
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0)
+
+    D3DKMT_DEVICESTATE_PAGE_FAULT = 5,
+
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0)
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_1)
+
+    D3DKMT_DEVICESTATE_PRESENT_QUEUE = 6,
+
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_1
+} D3DKMT_DEVICESTATE_TYPE;
+
+typedef struct _D3DKMT_GETDEVICESTATE
+{
+    D3DKMT_HANDLE                   hDevice;       // in: device handle
+    D3DKMT_DEVICESTATE_TYPE         StateType;     // in: device state type
+    union
+    {
+        D3DKMT_DEVICEEXECUTION_STATE ExecutionState; // out: device state
+        D3DKMT_DEVICEPRESENT_STATE   PresentState;   // in/out: present state
+        D3DKMT_DEVICERESET_STATE     ResetState;     // out: reset state
+        D3DKMT_DEVICEPRESENT_STATE_DWM  PresentStateDWM;  // in/out: present state
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0)
+
+        D3DKMT_DEVICEPAGEFAULT_STATE PageFaultState; // out: page fault state
+
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0)
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_1)
+
+        D3DKMT_DEVICEPRESENT_QUEUE_STATE PresentQueueState; // in/out: present queue state
+
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_1
+    };
+} D3DKMT_GETDEVICESTATE;
 
 typedef struct _D3DKMT_CREATEDCFROMMEMORY
 {
-    void *pMemory;
-    D3DDDIFORMAT Format;
-    UINT Width;
-    UINT Height;
-    UINT Pitch;
-    HDC hDeviceDc;
-    PALETTEENTRY *pColorTable;
-    HDC hDc;
-    HANDLE hBitmap;
+    D3DKMT_PTR(VOID*,               pMemory);      // in: memory for DC
+    D3DDDIFORMAT                    Format;        // in: Memory pixel format
+    UINT                            Width;         // in: Memory Width
+    UINT                            Height;        // in: Memory Height
+    UINT                            Pitch;         // in: Memory pitch
+    D3DKMT_PTR(HDC,                 hDeviceDc);    // in: DC describing the device
+    D3DKMT_PTR(PALETTEENTRY*,       pColorTable);  // in: Palette
+    D3DKMT_PTR(HDC,                 hDc);          // out: HDC
+    D3DKMT_PTR(HANDLE,              hBitmap);      // out: Handle to bitmap
 } D3DKMT_CREATEDCFROMMEMORY;
 
 typedef struct _D3DKMT_DESTROYDCFROMMEMORY
 {
-    HDC hDc;
-    HANDLE hBitmap;
+    D3DKMT_PTR(HDC,    hDc);           // in:
+    D3DKMT_PTR(HANDLE, hBitmap);       // in:
 } D3DKMT_DESTROYDCFROMMEMORY;
+
+#define D3DKMT_SETCONTEXTSCHEDULINGPRIORITY_ABSOLUTE 0x40000000
+
+typedef struct _D3DKMT_SETCONTEXTSCHEDULINGPRIORITY
+{
+    D3DKMT_HANDLE                   hContext;      // in: context handle
+    INT                             Priority;      // in: context priority
+} D3DKMT_SETCONTEXTSCHEDULINGPRIORITY;
+
+typedef struct _D3DKMT_SETCONTEXTINPROCESSSCHEDULINGPRIORITY
+{
+    D3DKMT_HANDLE                   hContext;      // in: context handle
+    INT                             Priority;      // in: context priority
+} D3DKMT_SETCONTEXTINPROCESSSCHEDULINGPRIORITY;
+
+typedef struct _D3DKMT_CHANGESURFACEPOINTER
+{
+    D3DKMT_PTR(HDC,                 hDC);            // in: dc handle
+    D3DKMT_PTR(HANDLE,              hBitmap);        // in: bitmap handle
+    D3DKMT_PTR(LPVOID,              pSurfacePointer);// in: new surface pointer
+    UINT                            Width;           // in: Memory Width
+    UINT                            Height;          // in: Memory Height
+    UINT                            Pitch;           // in: Memory pitch
+} D3DKMT_CHANGESURFACEPOINTER;
+
+typedef struct _D3DKMT_GETCONTEXTSCHEDULINGPRIORITY
+{
+    D3DKMT_HANDLE                   hContext;      // in: context handle
+    INT                             Priority;      // out: context priority
+} D3DKMT_GETCONTEXTSCHEDULINGPRIORITY;
+
+typedef struct _D3DKMT_GETCONTEXTINPROCESSSCHEDULINGPRIORITY
+{
+    D3DKMT_HANDLE                   hContext;      // in: context handle
+    INT                             Priority;      // out: context priority
+} D3DKMT_GETCONTEXTINPROCESSSCHEDULINGPRIORITY;
+
+typedef enum _D3DKMT_SCHEDULINGPRIORITYCLASS
+{
+    D3DKMT_SCHEDULINGPRIORITYCLASS_IDLE         = 0,
+    D3DKMT_SCHEDULINGPRIORITYCLASS_BELOW_NORMAL = 1,
+    D3DKMT_SCHEDULINGPRIORITYCLASS_NORMAL       = 2,
+    D3DKMT_SCHEDULINGPRIORITYCLASS_ABOVE_NORMAL = 3,
+    D3DKMT_SCHEDULINGPRIORITYCLASS_HIGH         = 4,
+    D3DKMT_SCHEDULINGPRIORITYCLASS_REALTIME     = 5,
+} D3DKMT_SCHEDULINGPRIORITYCLASS;
+
+typedef struct _D3DKMT_GETSCANLINE
+{
+    D3DKMT_HANDLE                   hAdapter;           // in: Adapter handle
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID  VidPnSourceId;      // in: Adapter's VidPN Source ID
+    BOOLEAN                         InVerticalBlank;    // out: Within vertical blank
+    UINT                            ScanLine;           // out: Current scan line
+} D3DKMT_GETSCANLINE;
+
+typedef enum _D3DKMT_QUEUEDLIMIT_TYPE
+{
+    D3DKMT_SET_QUEUEDLIMIT_PRESENT     = 1,
+    D3DKMT_GET_QUEUEDLIMIT_PRESENT     = 2,
+} D3DKMT_QUEUEDLIMIT_TYPE;
+
+typedef struct _D3DKMT_SETQUEUEDLIMIT
+{
+    D3DKMT_HANDLE                   hDevice;            // in: device handle
+    D3DKMT_QUEUEDLIMIT_TYPE         Type;               // in: limit type
+    union
+    {
+        UINT                        QueuedPresentLimit; // in (or out): queued present limit
+        struct
+        {
+            D3DDDI_VIDEO_PRESENT_SOURCE_ID VidPnSourceId;          // in: adapter's VidPN source ID
+            UINT                           QueuedPendingFlipLimit; // in (or out): flip pending limit
+        };
+    };
+} D3DKMT_SETQUEUEDLIMIT;
+
+typedef struct _D3DKMT_POLLDISPLAYCHILDREN
+{
+    D3DKMT_HANDLE                   hAdapter;                 // in: Adapter handle
+    UINT                            NonDestructiveOnly :  1;  // in: 0x00000001 Destructive or not
+    UINT                            SynchronousPolling :  1;  // in: 0x00000002 Synchronous polling or not
+    UINT                            DisableModeReset   :  1;  // in: 0x00000004 Disable DMM mode reset on monitor event
+    UINT                            PollAllAdapters    :  1;  // in: 0x00000008 Poll all adapters
+    UINT                            PollInterruptible  :  1;  // in: 0x00000010 Poll interruptible targets as well.
+    UINT                            Reserved           : 27;  // in: 0xffffffc0
+} D3DKMT_POLLDISPLAYCHILDREN;
+
+typedef struct _D3DKMT_INVALIDATEACTIVEVIDPN
+{
+    D3DKMT_HANDLE                   hAdapter;               // in: Adapter handle
+    D3DKMT_PTR(VOID*,               pPrivateDriverData);    // in: Private driver data
+    UINT                            PrivateDriverDataSize;  // in: Size of private driver data
+} D3DKMT_INVALIDATEACTIVEVIDPN;
+
+typedef struct _D3DKMT_CHECKOCCLUSION
+{
+    D3DKMT_PTR(HWND,            hWindow);        // in:  Destination window handle
+} D3DKMT_CHECKOCCLUSION;
+
+typedef struct _D3DKMT_WAITFORIDLE
+{
+    D3DKMT_HANDLE   hDevice;        // in:  Device to wait for idle
+} D3DKMT_WAITFORIDLE;
+
+typedef struct _D3DKMT_CHECKMONITORPOWERSTATE
+{
+    D3DKMT_HANDLE    hAdapter;    // in: Adapter to check on
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID  VidPnSourceId;      // in: Adapter's VidPN Source ID
+} D3DKMT_CHECKMONITORPOWERSTATE;
+
+typedef struct _D3DKMT_SETDISPLAYPRIVATEDRIVERFORMAT
+{
+    D3DKMT_HANDLE                   hDevice;                         // in: Identifies the device
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID  VidPnSourceId;                   // in: Identifies which VidPn we are changing the private driver format attribute for
+    UINT                            PrivateDriverFormatAttribute;    // In: Requested private format attribute for VidPn specified
+} D3DKMT_SETDISPLAYPRIVATEDRIVERFORMAT;
+
+typedef struct _D3DKMT_CREATEKEYEDMUTEX
+{
+    D3DKMT_ALIGN64 UINT64                   InitialValue;               // in:  Initial value to release to
+    D3DKMT_HANDLE                           hSharedHandle;              // out:  Global handle to keyed mutex
+    D3DKMT_HANDLE                           hKeyedMutex;                // out: Handle to the keyed mutex in this process
+} D3DKMT_CREATEKEYEDMUTEX;
+
+typedef struct _D3DKMT_OPENKEYEDMUTEX
+{
+    D3DKMT_HANDLE                           hSharedHandle;              // in:  Global handle to keyed mutex
+    D3DKMT_HANDLE                           hKeyedMutex;                // out: Handle to the keyed mutex in this process
+} D3DKMT_OPENKEYEDMUTEX;
+
+typedef struct _D3DKMT_DESTROYKEYEDMUTEX
+{
+    D3DKMT_HANDLE                           hKeyedMutex;                // in:  Identifies the keyed mutex being destroyed.
+} D3DKMT_DESTROYKEYEDMUTEX;
+
+typedef struct _D3DKMT_ACQUIREKEYEDMUTEX
+{
+    D3DKMT_HANDLE                           hKeyedMutex;                // in: Handle to the keyed mutex
+    D3DKMT_ALIGN64 UINT64                   Key;                        // in: Key value to Acquire
+    D3DKMT_PTR(PLARGE_INTEGER,              pTimeout);                  // in: NT-style timeout value
+    D3DKMT_ALIGN64 UINT64                   FenceValue;                 // out: Current fence value of the GPU sync object
+} D3DKMT_ACQUIREKEYEDMUTEX;
+
+typedef struct _D3DKMT_RELEASEKEYEDMUTEX
+{
+    D3DKMT_HANDLE                           hKeyedMutex;                // in: Handle to the keyed mutex
+    D3DKMT_ALIGN64 UINT64                   Key;                        // in: Key value to Release to
+    D3DKMT_ALIGN64 UINT64                   FenceValue;                 // in: New fence value to use for GPU sync object
+} D3DKMT_RELEASEKEYEDMUTEX;
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8)
+
+typedef struct _D3DKMT_CREATEKEYEDMUTEX2_FLAGS
+{
+    union
+    {
+        struct
+        {
+            UINT NtSecuritySharing      : 1;    // If set, the keyed mutex will be shared using DxgkShareObjects instead of D3DKMT_CREATEKEYEDMUTEX2::hSharedHandle
+            UINT Reserved               : 31;
+        };
+        UINT Value;
+    };
+} D3DKMT_CREATEKEYEDMUTEX2_FLAGS;
+
+typedef struct _D3DKMT_CREATEKEYEDMUTEX2
+{
+    D3DKMT_ALIGN64 UINT64                         InitialValue;           // in:  Initial value to release to
+    D3DKMT_HANDLE                                 hSharedHandle;          // out: Global handle to keyed mutex, NULL if NtSecuritySharing is set.
+    D3DKMT_HANDLE                                 hKeyedMutex;            // out: Handle to the keyed mutex in this process
+    D3DKMT_PTR(_In_reads_bytes_opt_(PrivateRuntimeDataSize)
+    VOID*,                                        pPrivateRuntimeData);   // in:  Buffer containing initial private data.
+                                                                          //      If NULL then PrivateRuntimeDataSize must be 0.
+    UINT                                          PrivateRuntimeDataSize; // in:  Size in bytes of pPrivateRuntimeData.
+    D3DKMT_CREATEKEYEDMUTEX2_FLAGS                Flags;                  // in:  Creation flags.
+} D3DKMT_CREATEKEYEDMUTEX2;
+
+typedef struct _D3DKMT_OPENKEYEDMUTEX2
+{
+    D3DKMT_HANDLE                                 hSharedHandle;          // in:  Global handle to keyed mutex
+    D3DKMT_HANDLE                                 hKeyedMutex;            // out: Handle to the keyed mutex in this process
+    D3DKMT_PTR(_In_reads_bytes_opt_(PrivateRuntimeDataSize)
+    VOID*,                                        pPrivateRuntimeData);   // in:  Buffer containing initial private data.
+                                                                          //      If NULL then PrivateRuntimeDataSize must be 0.
+                                                                          //      It will only be copied if the keyed mutex does not already have private data.
+    UINT                                          PrivateRuntimeDataSize; // in:  Size in bytes of pPrivateRuntimeData.
+} D3DKMT_OPENKEYEDMUTEX2;
+
+typedef struct _D3DKMT_OPENKEYEDMUTEXFROMNTHANDLE
+{
+    D3DKMT_PTR(HANDLE,                            hNtHandle);             // in:  NT handle to keyed mutex
+    D3DKMT_HANDLE                                 hKeyedMutex;            // out: Handle to the keyed mutex in this process
+    D3DKMT_PTR(_In_reads_bytes_opt_(PrivateRuntimeDataSize)
+    VOID*,                                        pPrivateRuntimeData);   // in:  Buffer containing initial private data.
+                                                                          //      If NULL then PrivateRuntimeDataSize must be 0.
+                                                                          //      It will only be copied if the keyed mutex does not already have private data.
+    UINT                                          PrivateRuntimeDataSize; // in:  Size in bytes of pPrivateRuntimeData.
+} D3DKMT_OPENKEYEDMUTEXFROMNTHANDLE;
+
+typedef struct _D3DKMT_ACQUIREKEYEDMUTEX2
+{
+    D3DKMT_HANDLE                                       hKeyedMutex;            // in:  Handle to the keyed mutex
+    D3DKMT_ALIGN64 UINT64                               Key;                    // in:  Key value to Acquire
+    D3DKMT_PTR(PLARGE_INTEGER,                          pTimeout);              // in:  NT-style timeout value
+    D3DKMT_ALIGN64 UINT64                               FenceValue;             // out: Current fence value of the GPU sync object
+    D3DKMT_PTR(_Out_writes_bytes_all_opt_(PrivateRuntimeDataSize)
+    VOID*,                                              pPrivateRuntimeData);   // out: Buffer to copy private data to.
+                                                                                //      If NULL then PrivateRuntimeDataSize must be 0.
+    UINT                                                PrivateRuntimeDataSize; // in:  Size in bytes of pPrivateRuntimeData.
+} D3DKMT_ACQUIREKEYEDMUTEX2;
+
+typedef struct _D3DKMT_RELEASEKEYEDMUTEX2
+{
+    D3DKMT_HANDLE                                 hKeyedMutex;            // in: Handle to the keyed mutex
+    D3DKMT_ALIGN64 UINT64                         Key;                    // in: Key value to Release to
+    D3DKMT_ALIGN64 UINT64                         FenceValue;             // in: New fence value to use for GPU sync object
+    D3DKMT_PTR(_In_reads_bytes_opt_(PrivateRuntimeDataSize)
+    VOID*,                                        pPrivateRuntimeData);   // in: Buffer containing new private data.
+                                                                          //     If NULL then PrivateRuntimeDataSize must be 0.
+    UINT                                          PrivateRuntimeDataSize; // in: Size in bytes of pPrivateRuntimeData.
+} D3DKMT_RELEASEKEYEDMUTEX2;
+#endif
+
+
+typedef struct _D3DKMT_CONFIGURESHAREDRESOURCE
+{
+    D3DKMT_HANDLE   hDevice;        // in:  Device that created the resource
+    D3DKMT_HANDLE   hResource;      // in: Handle for shared resource
+    BOOLEAN         IsDwm;          // in: TRUE when the process is DWM
+    D3DKMT_PTR(HANDLE, hProcess);   // in: Process handle for the non-DWM case
+    BOOLEAN         AllowAccess;    // in: Indicates whereh the process is allowed access
+} D3DKMT_CONFIGURESHAREDRESOURCE;
+
+typedef struct _D3DKMT_CHECKSHAREDRESOURCEACCESS
+{
+    D3DKMT_HANDLE   hResource;      // in: Handle for the resource
+    UINT            ClientPid;      // in: Client process PID
+} D3DKMT_CHECKSHAREDRESOURCEACCESS;
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8)
+typedef enum _D3DKMT_OFFER_PRIORITY
+{
+    D3DKMT_OFFER_PRIORITY_LOW=1,    // Content is not useful
+    D3DKMT_OFFER_PRIORITY_NORMAL,   // Content is useful but easy to regenerate
+    D3DKMT_OFFER_PRIORITY_HIGH,     // Content is useful and difficult to regenerate
+    D3DKMT_OFFER_PRIORITY_AUTO,     // Let VidMm decide offer priority based on eviction priority
+} D3DKMT_OFFER_PRIORITY;
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0)
+typedef struct _D3DKMT_OFFER_FLAGS
+{
+    union
+    {
+        struct
+        {
+            UINT OfferImmediately :  1; // 0x00000001
+            UINT AllowDecommit    :  1; // 0x00000002
+            UINT Reserved         : 30; // 0xFFFFFFFC
+        };
+        UINT Value;
+    };
+} D3DKMT_OFFER_FLAGS;
+#endif // DXGKDDI_INTERFACE_VERSION
+
+typedef struct _D3DKMT_OFFERALLOCATIONS
+{
+    D3DKMT_HANDLE hDevice;                        // in: Device that created the allocations
+    D3DKMT_PTR(D3DKMT_HANDLE*, pResources);       // in: array of D3D runtime resource handles.
+    D3DKMT_PTR(CONST D3DKMT_HANDLE*, HandleList); // in: array of allocation handles. If non-NULL, pResources must be NULL.
+    UINT NumAllocations;                          // in: number of items in whichever of pResources or HandleList is non-NULL.
+    D3DKMT_OFFER_PRIORITY Priority;               // in: priority with which to offer the allocations
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0)
+    D3DKMT_OFFER_FLAGS Flags;                     // in: various flags for determining offer behavior
+#endif // DXGKDDI_INTERFACE_VERSION
+} D3DKMT_OFFERALLOCATIONS;
+
+typedef struct _D3DKMT_RECLAIMALLOCATIONS
+{
+    D3DKMT_HANDLE hDevice;                        // in:  Device that created the allocations
+    D3DKMT_PTR(D3DKMT_HANDLE*, pResources);       // in: array of D3D runtime resource handles.
+    D3DKMT_PTR(CONST D3DKMT_HANDLE*, HandleList); // in: array of allocation handles. If non-NULL, pResources must be NULL.
+    D3DKMT_PTR(BOOL*, pDiscarded);                // out: optional array of booleans specifying whether each resource or allocation was discarded.
+    UINT NumAllocations;                          // in:  number of items in pDiscarded and whichever of pResources or HandleList is non-NULL.
+} D3DKMT_RECLAIMALLOCATIONS;
+
+typedef struct _D3DKMT_RECLAIMALLOCATIONS2
+{
+    D3DKMT_HANDLE hPagingQueue;                   // in:  Device that created the allocations
+    UINT NumAllocations;                          // in:  number of items in pDiscarded and whichever of pResources or HandleList is non-NULL.
+    D3DKMT_PTR(D3DKMT_HANDLE*, pResources);       // in: array of D3D runtime resource handles.
+    D3DKMT_PTR(CONST D3DKMT_HANDLE*, HandleList); // in: array of allocation handles. If non-NULL, pResources must be NULL.
+#if(DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_1 || \
+    D3D_UMD_INTERFACE_VERSION >= D3D_UMD_INTERFACE_VERSION_WDDM2_1)
+    union
+    {
+        BOOL* pDiscarded;                   // out: optional array of booleans specifying whether each resource or allocation was discarded.
+        D3DDDI_RECLAIM_RESULT* pResults;    // out: array of results specifying whether each resource or allocation is OK, discarded, or has no commitment.
+        D3DKMT_PTR_HELPER(AlignUnionTo64)
+    };
+#else
+    D3DKMT_PTR(BOOL*, pDiscarded);          // out: optional array of booleans specifying whether each resource or allocation was discarded.
+#endif // (DXGKDDI_INTERFACE_VERSION || D3D_UMD_INTERFACE_VERSION)
+    D3DKMT_ALIGN64 UINT64 PagingFenceValue; // out: The paging fence to synchronize against before submitting work to the GPU which
+                                            //      references any of the resources or allocations in the provided arrays
+} D3DKMT_RECLAIMALLOCATIONS2;
+
+typedef struct _D3DKMT_OUTPUTDUPLCREATIONFLAGS
+{
+    union
+    {
+        struct
+        {
+            UINT    CompositionUiCaptureOnly : 1;
+            UINT    Reserved : 31;
+        };
+        UINT    Value;
+    };
+} D3DKMT_OUTPUTDUPLCREATIONFLAGS;
+
+typedef struct _D3DKMT_OUTPUTDUPL_KEYEDMUTEX
+{
+    D3DKMT_PTR(HANDLE, hSharedSurfaceNt);
+}D3DKMT_OUTPUTDUPL_KEYEDMUTEX;
+
+#define OUTPUTDUPL_CREATE_MAX_KEYEDMUTXES 3
+typedef struct _D3DKMT_CREATE_OUTPUTDUPL
+{
+    D3DKMT_HANDLE                   hAdapter;
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID  VidPnSourceId;
+    UINT                            KeyedMutexCount;            // in : If zero then means is this the pre-create check
+    UINT                            RequiredKeyedMutexCount;    // out: The number of keyed mutexs needed
+    D3DKMT_OUTPUTDUPL_KEYEDMUTEX    KeyedMutexs[OUTPUTDUPL_CREATE_MAX_KEYEDMUTXES];
+    D3DKMT_OUTPUTDUPLCREATIONFLAGS  Flags;
+} D3DKMT_CREATE_OUTPUTDUPL;
+
+typedef struct _D3DKMT_DESTROY_OUTPUTDUPL
+{
+    D3DKMT_HANDLE                   hAdapter;
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID  VidPnSourceId;
+    BOOL                            bDestroyAllContexts;
+} D3DKMT_DESTROY_OUTPUTDUPL;
+
+typedef struct _D3DKMT_OUTPUTDUPL_POINTER_POSITION
+{
+    POINT   Position;
+    BOOL    Visible;
+} D3DKMT_OUTPUTDUPL_POINTER_POSITION;
+
+typedef struct _D3DKMT_OUTPUTDUPL_FRAMEINFO
+{
+    D3DKMT_ALIGN64 LARGE_INTEGER        LastPresentTime;
+    D3DKMT_ALIGN64 LARGE_INTEGER        LastMouseUpdateTime;
+    UINT                                AccumulatedFrames;
+    BOOL                                RectsCoalesced;
+    BOOL                                ProtectedContentMaskedOut;
+    D3DKMT_OUTPUTDUPL_POINTER_POSITION  PointerPosition;
+    UINT                                TotalMetadataBufferSize;
+    UINT                                PointerShapeBufferSize;
+} D3DKMT_OUTPUTDUPL_FRAMEINFO;
+
+typedef struct _D3DKMT_OUTPUTDUPL_GET_FRAMEINFO
+{
+    D3DKMT_HANDLE                   hAdapter;
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID  VidPnSourceId;
+    D3DKMT_OUTPUTDUPL_FRAMEINFO     FrameInfo;
+} D3DKMT_OUTPUTDUPL_GET_FRAMEINFO;
+
+typedef enum _D3DKMT_OUTPUTDUPL_METADATATYPE
+{
+    D3DKMT_OUTPUTDUPL_METADATATYPE_DIRTY_RECTS = 0,
+    D3DKMT_OUTPUTDUPL_METADATATYPE_MOVE_RECTS  = 1
+} D3DKMT_OUTPUTDUPL_METADATATYPE;
+
+typedef struct _D3DKMT_OUTPUTDUPL_METADATA
+{
+    D3DKMT_HANDLE                                                       hAdapter;
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID                                      VidPnSourceId;
+    D3DKMT_OUTPUTDUPL_METADATATYPE                                      Type;
+    UINT                                                                BufferSizeSupplied;
+    D3DKMT_PTR(_Field_size_bytes_part_(BufferSizeSupplied, BufferSizeRequired) PVOID, pBuffer);
+    UINT                                                                BufferSizeRequired;
+} D3DKMT_OUTPUTDUPL_METADATA;
+
+typedef enum _D3DKMT_OUTDUPL_POINTER_SHAPE_TYPE
+{
+    D3DKMT_OUTDUPL_POINTER_SHAPE_TYPE_MONOCHROME     = 0x00000001,
+    D3DKMT_OUTDUPL_POINTER_SHAPE_TYPE_COLOR          = 0x00000002,
+    D3DKMT_OUTDUPL_POINTER_SHAPE_TYPE_MASKED_COLOR   = 0x00000004
+} D3DKMT_OUTDUPL_POINTER_SHAPE_TYPE;
+
+typedef struct _D3DKMT_OUTDUPL_POINTER_SHAPE_INFO
+{
+    D3DKMT_OUTDUPL_POINTER_SHAPE_TYPE   Type;
+    UINT                                Width;
+    UINT                                Height;
+    UINT                                Pitch;
+    POINT                               HotSpot;
+} D3DKMT_OUTDUPL_POINTER_SHAPE_INFO;
+
+typedef struct _D3DKMT_OUTPUTDUPL_GET_POINTER_SHAPE_DATA
+{
+    D3DKMT_HANDLE                                                       hAdapter;
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID                                      VidPnSourceId;
+    UINT                                                                BufferSizeSupplied;
+    D3DKMT_PTR(_Field_size_bytes_part_(BufferSizeSupplied, BufferSizeRequired) PVOID, pShapeBuffer);
+    UINT                                                                BufferSizeRequired;
+    D3DKMT_OUTDUPL_POINTER_SHAPE_INFO                                   ShapeInfo;
+} D3DKMT_OUTPUTDUPL_GET_POINTER_SHAPE_DATA;
+
+typedef struct _D3DKMT_OUTPUTDUPL_RELEASE_FRAME
+{
+    D3DKMT_HANDLE                   hAdapter;
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID  VidPnSourceId;
+    UINT                            NextKeyMutexIdx;    // out : index of the next keyed mutex to use
+} D3DKMT_OUTPUTDUPL_RELEASE_FRAME;
+
+
+#define D3DKMT_MAX_OBJECTS_PER_HANDLE 3
+
+#define D3DKMT_MAX_BUNDLE_OBJECTS_PER_HANDLE 16
+
+#define D3DKMT_GDI_STYLE_HANDLE_DECORATION 0x2
+
+typedef struct _D3DKMT_GETSHAREDRESOURCEADAPTERLUID
+{
+    D3DKMT_HANDLE hGlobalShare;    // in : Shared resource handle
+    D3DKMT_PTR(HANDLE, hNtHandle); // in : Process's NT handle
+    LUID AdapterLuid;              // out: adapter LUID
+} D3DKMT_GETSHAREDRESOURCEADAPTERLUID;
+
+typedef enum _D3DKMT_GPU_PREFERENCE_QUERY_STATE
+{
+    D3DKMT_GPU_PREFERENCE_STATE_UNINITIALIZED,
+    D3DKMT_GPU_PREFERENCE_STATE_HIGH_PERFORMANCE,
+    D3DKMT_GPU_PREFERENCE_STATE_MINIMUM_POWER,
+    D3DKMT_GPU_PREFERENCE_STATE_UNSPECIFIED,
+    D3DKMT_GPU_PREFERENCE_STATE_NOT_FOUND,
+    D3DKMT_GPU_PREFERENCE_STATE_USER_SPECIFIED_GPU
+} D3DKMT_GPU_PREFERENCE_QUERY_STATE;
+
+typedef enum _D3DKMT_GPU_PREFERENCE_QUERY_TYPE
+{
+    D3DKMT_GPU_PREFERENCE_TYPE_IHV_DLIST,
+    D3DKMT_GPU_PREFERENCE_TYPE_DX_DATABASE,
+    D3DKMT_GPU_PREFERENCE_TYPE_USER_PREFERENCE
+} D3DKMT_GPU_PREFERENCE_QUERY_TYPE;
+
+typedef struct _D3DKMT_HYBRID_LIST
+{
+    D3DKMT_GPU_PREFERENCE_QUERY_STATE State;    // Gpu preference query state
+    LUID AdapterLuid;                           // in,opt: Adapter luid to per-adapter DList state. Optional if QueryType == D3DKMT_GPU_PREFERENCE_TYPE_IHV_DLIST
+    BOOL bUserPreferenceQuery;                  // Whether referring to user gpu preference, or per-adapter DList query
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_6)
+    D3DKMT_GPU_PREFERENCE_QUERY_TYPE QueryType; // Replaced bUserPreferenceQuery, for referring to which D3DKMT_GPU_PREFERENCE_QUERY_TYPE
+#endif
+} D3DKMT_HYBRID_LIST;
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM1_3)
+typedef struct
+{
+    DXGK_MIRACAST_CHUNK_INFO ChunkInfo;
+    UINT                     PrivateDriverDataSize; // Size of private data
+    BYTE                     PrivateDriverData[1];  // Private data buffer
+} D3DKMT_MIRACAST_CHUNK_DATA;
+
+typedef enum
+{
+    MiracastStopped = 0,
+    MiracastStartPending = 1,
+    MiracastStarted = 2,
+    MiracastStopPending = 3,
+} D3DKMT_MIRACAST_DISPLAY_DEVICE_STATE;
+
+typedef enum
+{
+    D3DKMT_MIRACAST_DEVICE_STATUS_SUCCESS                   = 0,
+    D3DKMT_MIRACAST_DEVICE_STATUS_SUCCESS_NO_MONITOR        = 1,
+    D3DKMT_MIRACAST_DEVICE_STATUS_PENDING                   = 2,
+    D3DKMT_MIRACAST_DEVICE_STATUS_UNKOWN_ERROR              = 0x80000001,
+    D3DKMT_MIRACAST_DEVICE_STATUS_GPU_RESOURCE_IN_USE       = 0x80000002,
+    D3DKMT_MIRACAST_DEVICE_STATUS_DEVICE_ERROR              = 0x80000003,
+    D3DKMT_MIRACAST_DEVICE_STATUS_UNKOWN_PAIRING            = 0x80000004,
+    D3DKMT_MIRACAST_DEVICE_STATUS_REMOTE_SESSION            = 0x80000005,
+    D3DKMT_MIRACAST_DEVICE_STATUS_DEVICE_NOT_FOUND          = 0x80000006,
+    D3DKMT_MIRACAST_DEVICE_STATUS_DEVICE_NOT_STARTED        = 0x80000007,
+    D3DKMT_MIRACAST_DEVICE_STATUS_INVALID_PARAMETER         = 0x80000008,
+    D3DKMT_MIRACAST_DEVICE_STATUS_INSUFFICIENT_BANDWIDTH    = 0x80000009,
+    D3DKMT_MIRACAST_DEVICE_STATUS_INSUFFICIENT_MEMORY       = 0x8000000A,
+    D3DKMT_MIRACAST_DEVICE_STATUS_CANCELLED                 = 0x8000000B,
+} D3DKMT_MIRACAST_DEVICE_STATUS;
+
+typedef struct _D3DKMT_MIRACAST_DISPLAY_DEVICE_STATUS
+{
+    //
+    // Miracast display device state.
+    //
+    D3DKMT_MIRACAST_DISPLAY_DEVICE_STATE State;
+} D3DKMT_MIRACAST_DISPLAY_DEVICE_STATUS, *PD3DKMT_MIRACAST_DISPLAY_DEVICE_STATUS;
+
+typedef struct _D3DKMT_MIRACAST_DISPLAY_DEVICE_CAPS
+{
+    BOOLEAN HdcpSupported;
+    ULONG DefaultControlPort;
+    BOOLEAN UsesIhvSolution;
+} D3DKMT_MIRACAST_DISPLAY_DEVICE_CAPS, *PD3DKMT_MIRACAST_DISPLAY_DEVICE_CAPS;
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0)
+typedef struct _D3DKMT_MIRACAST_DISPLAY_STOP_SESSIONS
+{
+    LUID AdapterLuid;
+    D3DDDI_VIDEO_PRESENT_TARGET_ID TargetId;
+    UINT StopReason;
+} D3DKMT_MIRACAST_DISPLAY_STOP_SESSIONS, *PD3DKMT_MIRACAST_DISPLAY_STOP_SESSIONS;
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0)
+
+
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM1_3)
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0)
+
+typedef struct _D3DKMT_WAITFORSYNCHRONIZATIONOBJECTFROMCPU
+{
+    D3DKMT_HANDLE           hDevice;                        // in: Handle to the device.
+    UINT                    ObjectCount;                    // in: Number of objects to wait on.
+
+    D3DKMT_PTR(_Field_size_(ObjectCount)
+    const D3DKMT_HANDLE*,   ObjectHandleArray);             // in: Handle to monitored fence synchronization objects to wait on.
+
+    D3DKMT_PTR(_Field_size_(ObjectCount)
+    const UINT64*,          FenceValueArray);               // in: Fence values to be waited on.
+
+    D3DKMT_PTR(HANDLE,      hAsyncEvent);                   // in: Event to be signaled when the wait condition is satisfied.
+                                                            // When set to NULL, the call will not return until the wait condition is satisfied.
+
+    D3DDDI_WAITFORSYNCHRONIZATIONOBJECTFROMCPU_FLAGS Flags; // in: Flags that specify the wait mode.
+} D3DKMT_WAITFORSYNCHRONIZATIONOBJECTFROMCPU;
+
+typedef struct _D3DKMT_SIGNALSYNCHRONIZATIONOBJECTFROMCPU
+{
+    D3DKMT_HANDLE           hDevice;            // in: Handle to the device.
+    UINT                    ObjectCount;        // in: Number of objects to signal.
+
+    D3DKMT_PTR(_Field_size_(ObjectCount)
+    const D3DKMT_HANDLE*,   ObjectHandleArray); // in: Handle to monitored fence synchronization objects to signal.
+
+    D3DKMT_PTR(_Field_size_(ObjectCount)
+    const UINT64*,          FenceValueArray);   // in: Fence values to be signaled.
+
+    D3DDDICB_SIGNALFLAGS    Flags;              // in: Specifies signal behavior.
+} D3DKMT_SIGNALSYNCHRONIZATIONOBJECTFROMCPU;
+
+typedef struct _D3DKMT_WAITFORSYNCHRONIZATIONOBJECTFROMGPU
+{
+    D3DKMT_HANDLE           hContext;                   // in: Specify the context that should be waiting.
+    UINT                    ObjectCount;                // in: Number of object to wait on.
+
+    D3DKMT_PTR(_Field_size_(ObjectCount)
+    const D3DKMT_HANDLE*,   ObjectHandleArray);         // in: Handles to synchronization objects to wait on.
+
+    union
+    {
+        _Field_size_(ObjectCount)
+        const UINT64*       MonitoredFenceValueArray;   // in: monitored fence values to be waited.
+
+        D3DKMT_ALIGN64 UINT64 FenceValue;               // in: fence value to be waited.
+
+        D3DKMT_ALIGN64 UINT64 Reserved[8];
+    };
+} D3DKMT_WAITFORSYNCHRONIZATIONOBJECTFROMGPU;
+
+typedef struct _D3DKMT_SIGNALSYNCHRONIZATIONOBJECTFROMGPU
+{
+    D3DKMT_HANDLE           hContext;           // in: Identifies the context that the signal is being submitted to.
+    UINT                    ObjectCount;        // in: Specifies the number of objects to signal.
+
+    D3DKMT_PTR(_Field_size_(ObjectCount)
+    const D3DKMT_HANDLE*,   ObjectHandleArray); // in: Specifies the objects to signal.
+
+    union
+    {
+        _Field_size_(ObjectCount)
+        const UINT64*   MonitoredFenceValueArray; // in: monitored fence values to be signaled
+
+        D3DKMT_ALIGN64 UINT64 Reserved[8];
+    };
+} D3DKMT_SIGNALSYNCHRONIZATIONOBJECTFROMGPU;
+
+typedef struct _D3DKMT_SIGNALSYNCHRONIZATIONOBJECTFROMGPU2
+{
+    UINT                    ObjectCount;            // in: Specifies the number of objects to signal.
+
+    D3DKMT_PTR(_Field_size_(ObjectCount)
+    const D3DKMT_HANDLE*,   ObjectHandleArray);     // in: Specifies the objects to signal.
+
+    D3DDDICB_SIGNALFLAGS    Flags;                  // in: Specifies signal behavior.
+
+    ULONG                   BroadcastContextCount;  // in: Specifies the number of contexts to broadcast this signal to.
+
+    D3DKMT_PTR(_Field_size_(BroadcastContextCount)
+    const D3DKMT_HANDLE*,   BroadcastContextArray); // in: Specifies context handles to broadcast to.
+
+    union
+    {
+        D3DKMT_ALIGN64 UINT64 FenceValue;           // in: fence value to be signaled;
+
+        HANDLE              CpuEventHandle;         // in: handle of a CPU event to be signaled if Flags.EnqueueCpuEvent flag is set.
+
+        _Field_size_(ObjectCount)
+        const UINT64*       MonitoredFenceValueArray; // in: monitored fence values to be signaled
+
+        D3DKMT_ALIGN64 UINT64 Reserved[8];
+    };
+} D3DKMT_SIGNALSYNCHRONIZATIONOBJECTFROMGPU2;
+
+typedef struct _D3DKMT_CREATEPAGINGQUEUE
+{
+    D3DKMT_HANDLE               hDevice;                        // in: Handle to the device.
+    D3DDDI_PAGINGQUEUE_PRIORITY Priority;                       // in: scheduling priority relative to other paging queues on this device
+    D3DKMT_HANDLE               hPagingQueue;                   // out: handle to the paging queue used to synchronize paging operations for this device.
+    D3DKMT_HANDLE               hSyncObject;                    // out: handle to the monitored fence object used to synchronize paging operations for this paging queue.
+    D3DKMT_PTR(VOID*,           FenceValueCPUVirtualAddress);   // out: Read-only mapping of the fence value for the CPU
+    UINT                        PhysicalAdapterIndex;           // in: Physical adapter index (engine ordinal)
+} D3DKMT_CREATEPAGINGQUEUE;
+
+typedef struct _D3DKMT_EVICT
+{
+    D3DKMT_HANDLE               hDevice;            // in: Device that created the allocations
+    UINT                        NumAllocations;     // in: number of allocation handles
+    D3DKMT_PTR(CONST D3DKMT_HANDLE*, AllocationList); // in: an array of NumAllocations allocation handles
+    D3DDDI_EVICT_FLAGS          Flags;              // in: eviction flags
+    D3DKMT_ALIGN64 UINT64       NumBytesToTrim;     // out: This value indicates how much to trim in order to satisfy the new budget.
+} D3DKMT_EVICT;
+
+typedef struct _D3DKMT_LOCK2
+{
+    D3DKMT_HANDLE       hDevice;            // in: Handle to the device.
+    D3DKMT_HANDLE       hAllocation;        // in: allocation to lock
+    D3DDDICB_LOCK2FLAGS Flags;              // in: Bit field defined by D3DDDI_LOCK2FLAGS
+    D3DKMT_PTR(PVOID,   pData);             // out: Virtual address of the locked allocation
+} D3DKMT_LOCK2;
+
+typedef struct _D3DKMT_UNLOCK2
+{
+    D3DKMT_HANDLE           hDevice;        // in: Handle to the device.
+    D3DKMT_HANDLE           hAllocation;    // in: allocation to unlock
+} D3DKMT_UNLOCK2;
+
+typedef struct _D3DKMT_INVALIDATECACHE
+{
+    D3DKMT_HANDLE   hDevice;
+    D3DKMT_HANDLE   hAllocation;
+    D3DKMT_ALIGN64 D3DKMT_SIZE_T   Offset;
+    D3DKMT_ALIGN64 D3DKMT_SIZE_T   Length;
+} D3DKMT_INVALIDATECACHE;
+
+typedef struct _D3DKMT_FREEGPUVIRTUALADDRESS
+{
+    D3DKMT_HANDLE           hAdapter;                               // in: Handle to an adapter.
+    D3DKMT_ALIGN64 D3DGPU_VIRTUAL_ADDRESS  BaseAddress;                            // in: Start of a virtual address range in bytes
+    D3DKMT_ALIGN64 D3DGPU_SIZE_T           Size;                                   // in: Size of the virtual address range in bytes
+} D3DKMT_FREEGPUVIRTUALADDRESS;
+
+typedef struct _D3DKMT_UPDATEGPUVIRTUALADDRESS
+{
+    D3DKMT_HANDLE                               hDevice;
+    D3DKMT_HANDLE                               hContext;
+    D3DKMT_HANDLE                               hFenceObject;
+    UINT                                        NumOperations;
+    D3DKMT_PTR(D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION*, Operations);
+    D3DKMT_ALIGN64 D3DKMT_SIZE_T                Reserved0;
+    D3DKMT_ALIGN64 UINT64                       Reserved1;
+    D3DKMT_ALIGN64 UINT64                       FenceValue;
+    union
+    {
+       struct
+       {
+           UINT  DoNotWait  :  1;
+           UINT  Reserved   : 31;
+       };
+       UINT Value;
+    } Flags;
+} D3DKMT_UPDATEGPUVIRTUALADDRESS;
+
+typedef struct _D3DKMT_CREATECONTEXTVIRTUAL
+{
+    D3DKMT_HANDLE               hDevice;                        // in:
+    UINT                        NodeOrdinal;                    // in:
+    UINT                        EngineAffinity;                 // in:
+    D3DDDI_CREATECONTEXTFLAGS   Flags;                          // in:
+    D3DKMT_PTR(VOID*,           pPrivateDriverData);            // in:
+    UINT                        PrivateDriverDataSize;          // in:
+    D3DKMT_CLIENTHINT           ClientHint;                     // in:  Hints which client is creating the context
+    D3DKMT_HANDLE               hContext;                       // out:
+} D3DKMT_CREATECONTEXTVIRTUAL;
+
+typedef struct _D3DKMT_SUBMITCOMMANDFLAGS
+{
+    UINT    NullRendering           :  1;  // 0x00000001
+    UINT    PresentRedirected       :  1;  // 0x00000002
+    UINT    NoKmdAccess             :  1;  // 0x00000004
+    UINT    Reserved                : 29;  // 0xFFFFFFF8
+} D3DKMT_SUBMITCOMMANDFLAGS;
+
+typedef struct _D3DKMT_SUBMITCOMMAND
+{
+    D3DKMT_ALIGN64 D3DGPU_VIRTUAL_ADDRESS Commands;
+    UINT                        CommandLength;
+    D3DKMT_SUBMITCOMMANDFLAGS   Flags;
+    D3DKMT_ALIGN64 ULONGLONG    PresentHistoryToken;                            // in: Present history token for redirected present calls
+    UINT                        BroadcastContextCount;
+    D3DKMT_HANDLE               BroadcastContext[D3DDDI_MAX_BROADCAST_CONTEXT];
+    D3DKMT_PTR(VOID*,           pPrivateDriverData);
+    UINT                        PrivateDriverDataSize;
+    UINT                        NumPrimaries;
+    D3DKMT_HANDLE               WrittenPrimaries[D3DDDI_MAX_WRITTEN_PRIMARIES];
+    UINT                        NumHistoryBuffers;
+    D3DKMT_PTR(D3DKMT_HANDLE*,  HistoryBufferArray);
+} D3DKMT_SUBMITCOMMAND;
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_2)
+
+typedef struct _D3DKMT_SUBMITCOMMANDTOHWQUEUE
+{
+    D3DKMT_HANDLE               hHwQueue;               // in: Context queue to submit the command to.
+
+    D3DKMT_ALIGN64 UINT64       HwQueueProgressFenceId; // in: Hardware queue progress fence value that will be signaled once the command is finished.
+
+    D3DKMT_ALIGN64 D3DGPU_VIRTUAL_ADDRESS CommandBuffer;// in: GPU VA of the command buffer to be executed on the GPU.
+    UINT                        CommandLength;          // in: Length in bytes of the command buffer.
+
+    UINT                        PrivateDriverDataSize;  // in: Size of private driver data in bytes.
+
+    D3DKMT_PTR(_Field_size_bytes_(PrivateDriverDataSize)
+    VOID*,                      pPrivateDriverData);    // in: Pointer to the private driver data.
+
+    UINT                        NumPrimaries;           // in: The number of primaries written by this command buffer.
+
+    D3DKMT_PTR(_Field_size_    (NumPrimaries)
+    D3DKMT_HANDLE CONST*,       WrittenPrimaries);      // in: The array of primaries written by this command buffer.
+} D3DKMT_SUBMITCOMMANDTOHWQUEUE;
+
+typedef struct _D3DKMT_SUBMITWAITFORSYNCOBJECTSTOHWQUEUE
+{
+    D3DKMT_HANDLE           hHwQueue;               // in: Context queue to submit the command to.
+
+    UINT                    ObjectCount;            // in: Number of objects to wait on.
+
+    D3DKMT_PTR(_Field_size_(ObjectCount)
+    const D3DKMT_HANDLE*,   ObjectHandleArray);     // in: Handles to monitored fence synchronization objects to wait on.
+
+    D3DKMT_PTR(_Field_size_(ObjectCount)
+    const UINT64*,          FenceValueArray);       // in: monitored fence values to be waited.
+} D3DKMT_SUBMITWAITFORSYNCOBJECTSTOHWQUEUE;
+
+typedef struct _D3DKMT_SUBMITSIGNALSYNCOBJECTSTOHWQUEUE
+{
+    D3DDDICB_SIGNALFLAGS    Flags;                  // in: Specifies signal behavior.
+
+    ULONG                   BroadcastHwQueueCount;  // in: Specifies the number of hardware queues to broadcast this signal to.
+
+    D3DKMT_PTR(_Field_size_(BroadcastHwQueueCount)
+    const D3DKMT_HANDLE*,   BroadcastHwQueueArray); // in: Specifies hardware queue handles to broadcast to.
+
+    UINT                    ObjectCount;            // in: Number of objects to signal.
+
+    D3DKMT_PTR(_Field_size_(ObjectCount)
+    const D3DKMT_HANDLE*,   ObjectHandleArray);     // in: Handles to monitored fence synchronization objects to signal.
+
+    D3DKMT_PTR(_Field_size_(ObjectCount)
+    const UINT64*,          FenceValueArray);       // in: monitored fence values to signal.
+} D3DKMT_SUBMITSIGNALSYNCOBJECTSTOHWQUEUE;
+
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_2)
+
+typedef struct _D3DKMT_QUERYVIDEOMEMORYINFO
+{
+    D3DKMT_PTR(HANDLE,          hProcess);                  // in,opt: A handle to a process. If NULL, the current process is used.
+                                                            //         The process handle must be opened with PROCESS_QUERY_INFORMATION privileges
+    D3DKMT_HANDLE               hAdapter;                   // in : The adapter to query for this process
+    D3DKMT_MEMORY_SEGMENT_GROUP MemorySegmentGroup;         // in : The memory segment group to query.
+    D3DKMT_ALIGN64 UINT64       Budget;                     // out: Total memory the application may use
+    D3DKMT_ALIGN64 UINT64       CurrentUsage;               // out: Current memory usage of the device
+    D3DKMT_ALIGN64 UINT64       CurrentReservation;         // out: Current reservation of the device
+    D3DKMT_ALIGN64 UINT64       AvailableForReservation;    // out: Total that the device may reserve
+    UINT                        PhysicalAdapterIndex;       // in : Zero based physical adapter index in the LDA configuration.
+} D3DKMT_QUERYVIDEOMEMORYINFO;
+
+typedef struct _D3DKMT_CHANGEVIDEOMMEMORYRESERVATION
+{
+    D3DKMT_PTR(HANDLE,          hProcess);                  // in,opt: A handle to a process. If NULL, the current process is used.
+                                                            //         The process handle must be opened with PROCESS_SET_INFORMATION privileges
+    D3DKMT_HANDLE               hAdapter;                   // in : The adapter to change reservation for.
+    D3DKMT_MEMORY_SEGMENT_GROUP MemorySegmentGroup;         // in : The memory segment group to change reservation for.
+    D3DKMT_ALIGN64 UINT64       Reservation;                // in : Desired reservation in the range between 0 and AvailableForReservation returned by QueryVideoMemoryInfo.
+    UINT                        PhysicalAdapterIndex;       // in : Zero based physical adapter index in the LDA configuration.
+} D3DKMT_CHANGEVIDEOMEMORYRESERVATION;
+
+typedef struct _D3DKMT_SETSTABLEPOWERSTATE
+{
+    D3DKMT_HANDLE   hAdapter;   // in: The adapter to enable or disable stable power for
+    BOOL            Enabled;    // in: Whether or not stable power is being requested on or off.
+} D3DKMT_SETSTABLEPOWERSTATE;
+
+// Used by Linux ioctl
+typedef struct _D3DKMT_SHAREOBJECTS {
+    UINT                    ObjectCount;                // in
+    D3DKMT_PTR(_Field_size_(ObjectCount)
+    CONST D3DKMT_HANDLE*,   ObjectHandleArray);         // in
+    D3DKMT_PTR(PVOID,       pObjectAttributes);         // in
+    DWORD                   DesiredAccess;              // in
+    D3DKMT_PTR(HANDLE*,     pSharedNtHandle);           // out
+} D3DKMT_SHAREOBJECTS;
+
+typedef struct _D3DKMT_SHAREOBJECTWITHHOST
+{
+    D3DKMT_HANDLE           hDevice;                // in
+    D3DKMT_HANDLE           hObject;                // in
+    D3DKMT_ALIGN64 UINT64   Reserved;               // in Must be zero. Reserved for future use
+    D3DKMT_ALIGN64 UINT64   hVailProcessNtHandle;   // out
+} D3DKMT_SHAREOBJECTWITHHOST;
+
+//
+// This API is used to support sync_file in Android.
+// A sync_file is a wrapper around the given monitored fence and the fence value.
+// When a sync_file is created, a wait for sync object on CPU is issued
+// and a file descriptor (FD) it returned to the app. The app can wait on the FD,
+// which will be unblocked when the sync object with this fence value is signaled.
+//
+typedef struct _D3DKMT_CREATESYNCFILE
+{
+	D3DKMT_HANDLE           hDevice;                // in:  Device owner of the monitored fence.
+	D3DKMT_HANDLE           hMonitoredFence;        // in:  Monitored fence object
+	D3DKMT_ALIGN64 UINT64   FenceValue;             // in:  Fence value to wait for
+	D3DKMT_ALIGN64 UINT64   hSyncFile;	            // out: File descriptor on Android or a NT handle on Windows (when implemented)
+} D3DKMT_CREATESYNCFILE;
+
+typedef struct _D3DKMT_TRIMNOTIFICATION
+{
+    D3DKMT_PTR(VOID*,                  Context);        // In: context at Register
+    D3DDDI_TRIMRESIDENCYSET_FLAGS      Flags;           // In: trim flags
+    D3DKMT_ALIGN64 UINT64              NumBytesToTrim;  // In: When TrimToBudget flag is set, this value indicates how much VidMm
+                                                        // requests the app to trim to fit in the new budget.
+} D3DKMT_TRIMNOTIFICATION;
+
+typedef VOID (APIENTRY *PFND3DKMT_TRIMNOTIFICATIONCALLBACK)(_Inout_ D3DKMT_TRIMNOTIFICATION*);
+
+typedef struct _D3DKMT_REGISTERTRIMNOTIFICATION
+{
+    LUID                               AdapterLuid;
+    D3DKMT_HANDLE                      hDevice;
+    PFND3DKMT_TRIMNOTIFICATIONCALLBACK Callback;
+    D3DKMT_PTR(VOID*,                  Context); // In: callback context
+    D3DKMT_PTR(VOID*,                  Handle);  // Out: for Unregister
+} D3DKMT_REGISTERTRIMNOTIFICATION;
+
+typedef struct _D3DKMT_UNREGISTERTRIMNOTIFICATION
+{
+    D3DKMT_PTR(VOID*,                              Handle);   // In: Handle returned from RegisterTrimNotification,
+                                                              // or NULL to unregister all Callback instances.
+    D3DKMT_PTR(PFND3DKMT_TRIMNOTIFICATIONCALLBACK, Callback); // In: When Handle is NULL, this parameter specifies that all registered instances of Callback
+                                                              // should be unregistered. This unregistration method should only be used
+                                                              // in DLL unload scenarios when the DLL being unloaded cannot guarantee that
+                                                              // all trim callbacks are unregistered through their handles.
+} D3DKMT_UNREGISTERTRIMNOTIFICATION;
+
+typedef struct _D3DKMT_BUDGETCHANGENOTIFICATION
+{
+    D3DKMT_PTR(VOID*,     Context);   // In: context at Register
+    D3DKMT_ALIGN64 UINT64 Budget;     // In: new budget
+} D3DKMT_BUDGETCHANGENOTIFICATION;
+
+typedef VOID (APIENTRY *PFND3DKMT_BUDGETCHANGENOTIFICATIONCALLBACK)(_In_ D3DKMT_BUDGETCHANGENOTIFICATION*);
+
+typedef struct _D3DKMT_REGISTERBUDGETCHANGENOTIFICATION
+{
+    D3DKMT_HANDLE                                  hDevice;
+    D3DKMT_PTR(PFND3DKMT_BUDGETCHANGENOTIFICATIONCALLBACK, Callback);
+    D3DKMT_PTR(VOID*,                              Context);  // In: callback context
+    D3DKMT_PTR(VOID*,                              Handle);   // Out: for Unregister
+} D3DKMT_REGISTERBUDGETCHANGENOTIFICATION;
+
+typedef struct _D3DKMT_UNREGISTERBUDGETCHANGENOTIFICATION
+{
+    D3DKMT_PTR(VOID*,                              Handle);   // In: from register
+} D3DKMT_UNREGISTERBUDGETCHANGENOTIFICATION;
+
+typedef struct _D3DKMT_QUERYVIDPNEXCLUSIVEOWNERSHIP
+{
+    D3DKMT_PTR(HANDLE,              hProcess);      // In: Process handle
+    D3DKMT_PTR(HWND,                hWindow);       // In: Window handle
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID  VidPnSourceId;  // Out: VidPn source ID
+    LUID                            AdapterLuid;    // Out: Adapter LUID
+    D3DKMT_VIDPNSOURCEOWNER_TYPE    OwnerType;      // Out: Owner Type
+} D3DKMT_QUERYVIDPNEXCLUSIVEOWNERSHIP;
+
+
+typedef enum _D3DKMT_DEVICE_ERROR_REASON {
+    D3DKMT_DEVICE_ERROR_REASON_GENERIC           = 0x80000000,
+    D3DKMT_DEVICE_ERROR_REASON_DRIVER_ERROR      = 0x80000006,
+} D3DKMT_DEVICE_ERROR_REASON;
+
+typedef struct _D3DKMT_MARKDEVICEASERROR
+{
+    D3DKMT_HANDLE              hDevice; // in: Device handle
+    D3DKMT_DEVICE_ERROR_REASON Reason;  // in: Status code
+} D3DKMT_MARKDEVICEASERROR;
+
+typedef struct _D3DKMT_FLUSHHEAPTRANSITIONS
+{
+    D3DKMT_HANDLE              hAdapter;
+} D3DKMT_FLUSHHEAPTRANSITIONS;
+
+typedef struct _D3DKMT_QUERYPROCESSOFFERINFO
+{
+    _In_ ULONG cbSize;
+    D3DKMT_PTR(_In_ HANDLE, hProcess);
+    _Out_ D3DKMT_ALIGN64 UINT64 DecommitUniqueness;
+    _Out_ D3DKMT_ALIGN64 UINT64 DecommittableBytes;
+} D3DKMT_QUERYPROCESSOFFERINFO;
+
+typedef union _D3DKMT_TRIMPROCESSCOMMITMENT_FLAGS
+{
+    struct
+    {
+        UINT Lazy           :  1;
+        UINT OnlyRepurposed :  1;
+        UINT Reserved       : 30;
+    };
+    UINT Value;
+} D3DKMT_TRIMPROCESSCOMMITMENT_FLAGS;
+
+typedef struct _D3DKMT_TRIMPROCESSCOMMITMENT
+{
+    _In_ ULONG cbSize;
+    D3DKMT_PTR(_In_ HANDLE, hProcess);
+    _In_ D3DKMT_TRIMPROCESSCOMMITMENT_FLAGS Flags;
+    _In_ D3DKMT_ALIGN64 UINT64 DecommitRequested;
+    _Out_ D3DKMT_ALIGN64 UINT64 NumBytesDecommitted;
+} D3DKMT_TRIMPROCESSCOMMITMENT;
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_2)
+
+typedef struct _D3DKMT_CREATEHWCONTEXT
+{
+    D3DKMT_HANDLE               hDevice;                // in:  Handle to the device owning this context.
+    UINT                        NodeOrdinal;            // in:  Identifier for the node targetted by this context.
+    UINT                        EngineAffinity;         // in:  Engine affinity within the specified node.
+    D3DDDI_CREATEHWCONTEXTFLAGS Flags;                  // in:  Context creation flags.
+    UINT                        PrivateDriverDataSize;  // in:  Size of private driver data
+    D3DKMT_PTR(_Inout_
+    _Field_size_bytes_         (PrivateDriverDataSize)
+    VOID*,                      pPrivateDriverData);    // in/out:  Private driver data
+    D3DKMT_HANDLE               hHwContext;             // out: Handle of the created context.
+} D3DKMT_CREATEHWCONTEXT;
+
+typedef struct _D3DKMT_DESTROYHWCONTEXT
+{
+    D3DKMT_HANDLE               hHwContext;             // in:  Identifies the context being destroyed.
+} D3DKMT_DESTROYHWCONTEXT;
+
+typedef struct _D3DKMT_CREATEHWQUEUE
+{
+    D3DKMT_HANDLE               hHwContext;                             // in:  Handle to the hardware context the queue is associated with.
+    D3DDDI_CREATEHWQUEUEFLAGS   Flags;                                  // in:  Hardware queue creation flags.
+    UINT                        PrivateDriverDataSize;                  // in:  Size of private driver data
+    D3DKMT_PTR(_Inout_
+    _Field_size_bytes_         (PrivateDriverDataSize)
+    VOID*,                      pPrivateDriverData);                    // in/out:  Private driver data
+    D3DKMT_HANDLE               hHwQueue;                               // out: handle to the hardware queue object to submit work to.
+    D3DKMT_HANDLE               hHwQueueProgressFence;                  // out: handle to the monitored fence object used to monitor the queue progress.
+    D3DKMT_PTR(VOID*,           HwQueueProgressFenceCPUVirtualAddress); // out: Read-only mapping of the queue progress fence value for the CPU
+    D3DKMT_ALIGN64 D3DGPU_VIRTUAL_ADDRESS HwQueueProgressFenceGPUVirtualAddress;  // out: Read/write mapping of the queue progress fence value for the GPU
+} D3DKMT_CREATEHWQUEUE;
+
+typedef struct _D3DKMT_DESTROYHWQUEUE
+{
+    D3DKMT_HANDLE               hHwQueue;   // in: handle to the hardware queue to be destroyed.
+} D3DKMT_DESTROYHWQUEUE;
+
+typedef struct _D3DKMT_GETALLOCATIONPRIORITY
+{
+    D3DKMT_HANDLE           hDevice;            // in: Indentifies the device
+    D3DKMT_HANDLE           hResource;          // in: Specify the resource to get priority of.
+    D3DKMT_PTR(CONST D3DKMT_HANDLE*, phAllocationList); // in: pointer to an array allocation to get priorities of.
+    UINT                    AllocationCount;    // in: Number of allocations in phAllocationList
+    D3DKMT_PTR(UINT*,       pPriorities);       // out: Priority for each of the allocation in the array.
+} D3DKMT_GETALLOCATIONPRIORITY;
+
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_2)
+
+
+
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0)
+
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8)
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_1)
+typedef union _D3DKMT_SETFSEBLOCKFLAGS
+{
+    struct
+    {
+        UINT Block : 1;
+        UINT Reserved : 31;
+    };
+    UINT Value;
+} D3DKMT_SETFSEBLOCKFLAGS;
+
+typedef struct _D3DKMT_SETFSEBLOCK
+{
+    LUID                            AdapterLuid;
+    D3DKMT_HANDLE                   hAdapter;
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID  VidPnSourceId;
+    D3DKMT_SETFSEBLOCKFLAGS         Flags;
+} D3DKMT_SETFSEBLOCK;
+
+typedef union _D3DKMT_QUERYFSEFLAGS
+{
+    struct
+    {
+        UINT Blocked : 1;
+        UINT Reserved : 31;
+    };
+    UINT Value;
+} D3DKMT_QUERYFSEBLOCKFLAGS;
+
+typedef struct _D3DKMT_QUERYFSEBLOCK
+{
+    LUID                            AdapterLuid;
+    D3DKMT_HANDLE                   hAdapter;
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID  VidPnSourceId;
+    D3DKMT_QUERYFSEBLOCKFLAGS       Flags;
+} D3DKMT_QUERYFSEBLOCK;
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_1)
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_2)
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_2)
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_3)
+
+typedef struct _D3DKMT_CREATEPROTECTEDSESSION
+{
+    D3DKMT_HANDLE                                           hDevice;                // in: device handle
+    D3DKMT_HANDLE                                           hSyncObject;            // in: monitored fence handle associated to this session (kernel handle)
+    D3DKMT_PTR(_Field_size_bytes_(PrivateDriverDataSize)
+    CONST VOID*,                                            pPrivateDriverData);    // in: Private driver data
+    UINT                                                    PrivateDriverDataSize;  // in: Size of private runtime data
+    D3DKMT_PTR(_Field_size_bytes_(PrivateRuntimeDataSize)
+    CONST VOID*,                                            pPrivateRuntimeData);   // in: Private runtime data
+    UINT                                                    PrivateRuntimeDataSize; // in: Size of private runtime data
+
+    D3DKMT_HANDLE                                           hHandle;                // out: protected session handle (kernel handle)
+
+} D3DKMT_CREATEPROTECTEDSESSION;
+
+typedef struct _D3DKMT_DESTROYPROTECTEDSESSION
+{
+    D3DKMT_HANDLE                                           hHandle; // in: protected session handle (kernel handle)
+
+} D3DKMT_DESTROYPROTECTEDSESSION;
+
+typedef enum _D3DKMT_PROTECTED_SESSION_STATUS
+{
+    D3DKMT_PROTECTED_SESSION_STATUS_OK         = 0,
+    D3DKMT_PROTECTED_SESSION_STATUS_INVALID    = 1,
+} D3DKMT_PROTECTED_SESSION_STATUS;
+
+typedef struct _D3DKMT_QUERYPROTECTEDSESSIONSTATUS
+{
+    D3DKMT_HANDLE                                           hHandle; // in: protected session handle (kernel handle)
+    D3DKMT_PROTECTED_SESSION_STATUS                         Status;  // out: protected session status
+
+} D3DKMT_QUERYPROTECTEDSESSIONSTATUS;
+
+typedef struct _D3DKMT_QUERYPROTECTEDSESSIONINFOFROMNTHANDLE
+{
+    D3DKMT_PTR(HANDLE,                                      hNtHandle);             // in: protected session handle (NT handle)
+    D3DKMT_PTR(_Field_size_bytes_(PrivateDriverDataSize)
+    CONST VOID*,                                            pPrivateDriverData);    // in: Private driver data
+    UINT                                                    PrivateDriverDataSize;  // in/out: Size of private runtime data
+    D3DKMT_PTR(_Field_size_bytes_(PrivateRuntimeDataSize)
+    CONST VOID*,                                            pPrivateRuntimeData);   // in: Private runtime data
+    UINT                                                    PrivateRuntimeDataSize; // in/out: Size of private runtime data
+
+} D3DKMT_QUERYPROTECTEDSESSIONINFOFROMNTHANDLE;
+
+typedef struct _D3DKMT_OPENPROTECTEDSESSIONFROMNTHANDLE
+{
+    D3DKMT_PTR(HANDLE,                                      hNtHandle);// in: protected session handle (NT handle)
+    D3DKMT_HANDLE                                           hHandle;   // out: protected session handle (kernel handle)
+
+} D3DKMT_OPENPROTECTEDSESSIONFROMNTHANDLE;
+
+
+typedef struct _D3DKMT_GETPROCESSDEVICEREMOVALSUPPORT
+{
+    D3DKMT_PTR(HANDLE, hProcess);    // in: Process handle
+    LUID    AdapterLuid; // in: Luid of Adapter that is potentially being detached
+    BOOLEAN Support;     // out: Whether or not the process using the adapter can recover from graphics device removal
+
+} D3DKMT_GETPROCESSDEVICEREMOVALSUPPORT;
+
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_3)
+
+
+// All tracked workload functionality is accessible just by the D3D11 and D3D12 runtimes
+typedef enum _D3DKMT_TRACKEDWORKLOADPOLICY
+{
+       D3DKMT_TRACKEDWORKLOADPOLICY_NORMAL           = 0,
+       D3DKMT_TRACKEDWORKLOADPOLICY_ENERGY_EFFICIENT = 1,
+       D3DKMT_TRACKEDWORKLOADPOLICY_HIGH_SPEED       = 2
+} D3DKMT_TRACKEDWORKLOADPOLICY;
+
+typedef enum _D3DKMT_TRACKEDWORKLOADDEADLINETYPE
+{
+       D3DKMT_TRACKEDWORKLOADDEADLINETYPE_ABSOLUTE = 0,
+       D3DKMT_TRACKEDWORKLOADDEADLINETYPE_VBLANK = 1,
+} D3DKMT_TRACKEDWORKLOADDEADLINETYPE;
+
+typedef struct _D3DKMT_TRACKEDWORKLOADDEADLINE {
+    union {
+        D3DKMT_ALIGN64 UINT64 VBlankOffsetHundredsNS;
+        D3DKMT_ALIGN64 UINT64 AbsoluteQPC;
+    };
+} D3DKMT_TRACKEDWORKLOADDEADLINE;
+
+typedef struct _D3DKMT_TRACKEDWORKLOADFLAGS
+{
+    union
+    {
+        struct
+        {
+            UINT Periodic    : 1;                   // 0x00000001 - workload instances occur at a periodic rate
+            UINT SimilarLoad : 1;                   // 0x00000002 - workload instances have a similar load
+            UINT Reserved    : 30;
+        };
+        UINT Value;
+    };
+} D3DKMT_TRACKEDWORKLOADFLAGS;
+
+#define D3DKMT_MAX_TRACKED_WORKLOAD_INSTANCE_PAIRS 32
+
+typedef struct _D3DKMT_CREATETRACKEDWORKLOAD
+{
+    ULONG                              cbSize;                   // in: size of structure for versioning
+    ULONG                              ContextCount;             // in: Specifies the number of contexts to create the workload
+    D3DKMT_PTR(_Field_size_(ContextCount)
+    const D3DKMT_HANDLE*,              ContextArray);            // in: Specifies context handles in which to create the workload
+    D3DKMT_TRACKEDWORKLOADDEADLINETYPE DeadlineType;             // in: Specifies the deadline type of the tracked workload
+    UINT32                             VidPnTargetId;            // in: Specifies the target ID. Needed for VBLANK DEADLINETYPE
+    D3DKMT_TRACKEDWORKLOADFLAGS        Flags;                    // in: Flags to create the workload with
+    D3DKMT_TRACKEDWORKLOADPOLICY       Policy;                   // in: Which policy to use
+    UINT                               MaxInstances;             // in: maximum number of instances this workload can have
+    UINT                               MaxInstancePairs;         // in: maximum number of instance pairs this workload can have (includes suspend/resume)
+    D3DKMT_HANDLE                      hResourceQueryTimestamps; // in: buffer which will contain the resolved query timestamps for the tracked workloads
+    D3DKMT_HANDLE                      hTrackedWorkload;         // out: the tracked workload handle
+} D3DKMT_CREATETRACKEDWORKLOAD;
+
+typedef struct _D3DKMT_DESTROYTRACKEDWORKLOAD
+{
+    ULONG                        cbSize;                   // in: size of structure for versioning
+    D3DKMT_HANDLE                hTrackedWorkload;         // in: tracked workload handle
+} D3DKMT_DESTROYTRACKEDWORKLOAD;
+
+typedef struct _D3DKMT_UPDATETRACKEDWORKLOAD
+{
+    ULONG                           cbSize;                   // in: size of structure for versioning
+    D3DKMT_HANDLE                   hTrackedWorkload;         // in: tracked workload handle
+    D3DKMT_TRACKEDWORKLOADDEADLINE  FinishDeadline;           // in: specifies the deadline by which this workload should be finished
+    UINT                            BeginTrackedWorkloadIndex;// in: slot for the timestamp for the start of this workload pair (index in buffer pointed to by hResourceQueryTimestamps)
+    UINT                            EndTrackedWorkloadIndex;  // in: slot for the timestamp for the end of this workload pair (index in buffer pointed to by hResourceQueryTimestamps)
+    BOOL                            Resume;                   // in: TRUE if the start of this workload pair is a Resume instead of a Begin
+    BOOL                            Suspend;                  // in: TRUE if the end of this workload pair is a Suspend instead of an End
+    D3DKMT_ALIGN64 UINT64           PairID;                   // in: identifier for the Begin/End tracked workload pair (should include any suspend/resume in the pair)
+    D3DKMT_ALIGN64 UINT64           FenceSubmissionValue;     // in: fence value for the submission of this workload
+    D3DKMT_ALIGN64 UINT64           FenceCompletedValue;      // in: fence value for the completed workloads
+    D3DKMT_ALIGN64 UINT64           GPUTimestampFrequency;    // in: GPU timestamp frequency for resolving query timestamps
+    D3DKMT_ALIGN64 UINT64           GPUCalibrationTimestamp;  // in: value of the GPU calibration timestamp counter
+    D3DKMT_ALIGN64 UINT64           CPUCalibrationTimestamp;  // in: value of the CPU calibration timestamp counter
+    D3DKMT_ALIGN64 UINT64           TimestampArray[D3DKMT_MAX_TRACKED_WORKLOAD_INSTANCE_PAIRS * 2];           // in: specifies the already read timestamp data (D3D11 only)
+    BOOL                            TimestampArrayProcessed;  // out: TRUE if the timestamp array entries were processed (D3D11 only)
+} D3DKMT_UPDATETRACKEDWORKLOAD;
+
+typedef struct _D3DKMT_GETAVAILABLETRACKEDWORKLOADINDEX
+{
+    ULONG                        cbSize;                        // in: size of structure for versioning
+    D3DKMT_HANDLE                hTrackedWorkload;              // in: tracked workload handle
+    D3DKMT_ALIGN64 UINT64        FenceCompletedValue;           // in: fence value for the completed workloads
+    D3DKMT_ALIGN64 UINT64        TimestampArray[D3DKMT_MAX_TRACKED_WORKLOAD_INSTANCE_PAIRS * 2];           // in: specifies the already read timestamp data (D3D11 only)
+    UINT                         AvailableTrackedWorkloadIndex; // out: first available tracked workload slot
+    BOOL                         TimestampArrayProcessed;       // out: TRUE if the timestamp array entries were processed (D3D11 only)
+} D3DKMT_GETAVAILABLETRACKEDWORKLOADINDEX;
+
+typedef struct _D3DKMT_TRACKEDWORKLOADSTATEFLAGS
+{
+    union
+    {
+        struct
+        {
+            UINT Saturated : 1;                      // 0x00000001 - in the current state of execution, tracked workload cannot meet its deadline.
+            UINT NotEnoughSamples: 1;                // 0x00000002 - we don't have enough samples to produce stats yet
+            UINT Reserved  : 30;
+        };
+        UINT Value;
+    };
+} D3DKMT_TRACKEDWORKLOADSTATEFLAGS;
+
+typedef struct _D3DKMT_TRACKEDWORKLOAD_STATISTICS
+{
+    D3DKMT_ALIGN64 INT64 Mean;
+    D3DKMT_ALIGN64 INT64 Minimum;
+    D3DKMT_ALIGN64 INT64 Maximum;
+    D3DKMT_ALIGN64 INT64 Variance;
+    D3DKMT_ALIGN64 UINT64 Count;
+} D3DKMT_TRACKEDWORKLOAD_STATISTICS;
+
+typedef struct _D3DKMT_GETTRACKEDWORKLOADSTATISTICS
+{
+    ULONG                              cbSize;                       // in: size of structure for versioning
+    D3DKMT_HANDLE                      hTrackedWorkload;             // in: tracked workload handle
+    D3DKMT_ALIGN64 UINT64              FenceCompletedValue;          // in: fence value for the completed workloads
+    D3DKMT_ALIGN64 UINT64              TimestampArray[D3DKMT_MAX_TRACKED_WORKLOAD_INSTANCE_PAIRS * 2];  // in: specifies the already read timestamp data (D3D11 only)
+    BOOL                               TimestampArrayProcessed;      // out: TRUE if the timestamp array entries were processed (D3D11 only)
+    D3DKMT_TRACKEDWORKLOAD_STATISTICS  DeadlineOffsetHundredsNS;     // out: statistics for the offset of the deadline achieved of the tracked workload in hundreds of nanosecs
+    D3DKMT_ALIGN64 UINT64              MissedDeadlines;              // out: count of missed deadlines
+    D3DKMT_TRACKEDWORKLOADSTATEFLAGS   Flags;                        // out: current state flags
+} D3DKMT_GETTRACKEDWORKLOADSTATISTICS;
+
+typedef struct _D3DKMT_RESETTRACKEDWORKLOADSTATISTICS
+{
+    ULONG                            cbSize;              // in: size of structure for versioning
+    D3DKMT_HANDLE                    hTrackedWorkload;    // in: tracked workload handle
+} D3DKMT_RESETTRACKEDWORKLOADSTATISTICS;
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_7)
+
+
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_7
+
+
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_CREATEALLOCATION)(_Inout_ D3DKMT_CREATEALLOCATION*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_CREATEALLOCATION2)(_Inout_ D3DKMT_CREATEALLOCATION*); // _ADVSCH_
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_QUERYRESOURCEINFO)(_Inout_ D3DKMT_QUERYRESOURCEINFO*);
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8)
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_QUERYRESOURCEINFOFROMNTHANDLE)(_Inout_ D3DKMT_QUERYRESOURCEINFOFROMNTHANDLE*);
+
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_SHAREOBJECTS)(
+    _In_range_(1, D3DKMT_MAX_OBJECTS_PER_HANDLE) UINT   cObjects,
+    _In_reads_(cObjects) CONST D3DKMT_HANDLE *          hObjects,
+    _In_ POBJECT_ATTRIBUTES                             pObjectAttributes,
+    _In_ DWORD                                          dwDesiredAccess,
+    _Out_ HANDLE *                                      phSharedNtHandle
+    );
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_OPENNTHANDLEFROMNAME)(_Inout_ D3DKMT_OPENNTHANDLEFROMNAME*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_OPENRESOURCEFROMNTHANDLE)(_Inout_ D3DKMT_OPENRESOURCEFROMNTHANDLE*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_OPENSYNCOBJECTFROMNTHANDLE)(_Inout_ D3DKMT_OPENSYNCOBJECTFROMNTHANDLE*);
+#endif
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_OPENRESOURCE)(_Inout_ D3DKMT_OPENRESOURCE*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_OPENRESOURCE2)(_Inout_ D3DKMT_OPENRESOURCE*); // _ADVSCH_
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_DESTROYALLOCATION)(_In_ CONST D3DKMT_DESTROYALLOCATION*);
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0)
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_DESTROYALLOCATION2)(_In_ CONST D3DKMT_DESTROYALLOCATION2*);
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_0
+
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_SETALLOCATIONPRIORITY)(_In_ CONST D3DKMT_SETALLOCATIONPRIORITY*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_QUERYALLOCATIONRESIDENCY)(_In_ CONST D3DKMT_QUERYALLOCATIONRESIDENCY*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_CREATEDEVICE)(_Inout_ D3DKMT_CREATEDEVICE*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_DESTROYDEVICE)(_In_ CONST D3DKMT_DESTROYDEVICE*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_CREATECONTEXT)(_Inout_ D3DKMT_CREATECONTEXT*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_DESTROYCONTEXT)(_In_ CONST D3DKMT_DESTROYCONTEXT*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_CREATESYNCHRONIZATIONOBJECT)(_Inout_ D3DKMT_CREATESYNCHRONIZATIONOBJECT*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_CREATESYNCHRONIZATIONOBJECT2)(_Inout_ D3DKMT_CREATESYNCHRONIZATIONOBJECT2*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_OPENSYNCHRONIZATIONOBJECT)(_Inout_ D3DKMT_OPENSYNCHRONIZATIONOBJECT*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_DESTROYSYNCHRONIZATIONOBJECT)(_In_ CONST D3DKMT_DESTROYSYNCHRONIZATIONOBJECT*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_WAITFORSYNCHRONIZATIONOBJECT)(_In_ CONST D3DKMT_WAITFORSYNCHRONIZATIONOBJECT*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_WAITFORSYNCHRONIZATIONOBJECT2)(_In_ CONST D3DKMT_WAITFORSYNCHRONIZATIONOBJECT2*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_SIGNALSYNCHRONIZATIONOBJECT)(_In_ CONST D3DKMT_SIGNALSYNCHRONIZATIONOBJECT*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_SIGNALSYNCHRONIZATIONOBJECT2)(_In_ CONST D3DKMT_SIGNALSYNCHRONIZATIONOBJECT2*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_LOCK)(_Inout_ D3DKMT_LOCK*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_UNLOCK)(_In_ CONST D3DKMT_UNLOCK*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_GETDISPLAYMODELIST)(_Inout_ D3DKMT_GETDISPLAYMODELIST*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_SETDISPLAYMODE)(_Inout_ CONST D3DKMT_SETDISPLAYMODE*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_GETMULTISAMPLEMETHODLIST)(_Inout_ D3DKMT_GETMULTISAMPLEMETHODLIST*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_PRESENT)(_Inout_ D3DKMT_PRESENT*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_RENDER)(_Inout_ D3DKMT_RENDER*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_GETRUNTIMEDATA)(_Inout_ CONST D3DKMT_GETRUNTIMEDATA*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_QUERYADAPTERINFO)(_Inout_ CONST D3DKMT_QUERYADAPTERINFO*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_OPENADAPTERFROMHDC)(_Inout_ D3DKMT_OPENADAPTERFROMHDC*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_OPENADAPTERFROMGDIDISPLAYNAME)(_Inout_ D3DKMT_OPENADAPTERFROMGDIDISPLAYNAME*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_OPENADAPTERFROMDEVICENAME)(_Inout_ D3DKMT_OPENADAPTERFROMDEVICENAME*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_CLOSEADAPTER)(_In_ CONST D3DKMT_CLOSEADAPTER*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_GETSHAREDPRIMARYHANDLE)(_Inout_ D3DKMT_GETSHAREDPRIMARYHANDLE*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_ESCAPE)(_In_ CONST D3DKMT_ESCAPE*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_QUERYSTATISTICS)(_In_ CONST D3DKMT_QUERYSTATISTICS*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_SETVIDPNSOURCEOWNER)(_In_ CONST D3DKMT_SETVIDPNSOURCEOWNER*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_GETPRESENTHISTORY)(_Inout_ D3DKMT_GETPRESENTHISTORY*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_CREATEOVERLAY)(_Inout_ D3DKMT_CREATEOVERLAY*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_UPDATEOVERLAY)(_In_ CONST D3DKMT_UPDATEOVERLAY*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_FLIPOVERLAY)(_In_ CONST D3DKMT_FLIPOVERLAY*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_DESTROYOVERLAY)(_In_ CONST D3DKMT_DESTROYOVERLAY*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_WAITFORVERTICALBLANKEVENT)(_In_ CONST D3DKMT_WAITFORVERTICALBLANKEVENT*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_SETGAMMARAMP)(_In_ CONST D3DKMT_SETGAMMARAMP*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_GETDEVICESTATE)(_Inout_ D3DKMT_GETDEVICESTATE*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_CREATEDCFROMMEMORY)(_Inout_ D3DKMT_CREATEDCFROMMEMORY*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_DESTROYDCFROMMEMORY)(_In_ CONST D3DKMT_DESTROYDCFROMMEMORY*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_SETCONTEXTSCHEDULINGPRIORITY)(_In_ CONST D3DKMT_SETCONTEXTSCHEDULINGPRIORITY*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_GETCONTEXTSCHEDULINGPRIORITY)(_Inout_ D3DKMT_GETCONTEXTSCHEDULINGPRIORITY*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_SETPROCESSSCHEDULINGPRIORITYCLASS)(_In_ HANDLE, _In_ D3DKMT_SCHEDULINGPRIORITYCLASS);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_GETPROCESSSCHEDULINGPRIORITYCLASS)(_In_ HANDLE, _Out_ D3DKMT_SCHEDULINGPRIORITYCLASS*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_RELEASEPROCESSVIDPNSOURCEOWNERS)(_In_ HANDLE);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_GETSCANLINE)(_Inout_ D3DKMT_GETSCANLINE*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_CHANGESURFACEPOINTER)(_In_ CONST D3DKMT_CHANGESURFACEPOINTER*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_SETQUEUEDLIMIT)(_In_ CONST D3DKMT_SETQUEUEDLIMIT*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_POLLDISPLAYCHILDREN)(_In_ CONST D3DKMT_POLLDISPLAYCHILDREN*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_INVALIDATEACTIVEVIDPN)(_In_ CONST D3DKMT_INVALIDATEACTIVEVIDPN*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_CHECKOCCLUSION)(_In_ CONST D3DKMT_CHECKOCCLUSION*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_WAITFORIDLE)(_In_ CONST D3DKMT_WAITFORIDLE*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_CHECKMONITORPOWERSTATE)(_In_ CONST D3DKMT_CHECKMONITORPOWERSTATE*);
+typedef _Check_return_ BOOLEAN  (APIENTRY *PFND3DKMT_CHECKEXCLUSIVEOWNERSHIP)();
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_CHECKVIDPNEXCLUSIVEOWNERSHIP)(_In_ CONST D3DKMT_CHECKVIDPNEXCLUSIVEOWNERSHIP*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_SETDISPLAYPRIVATEDRIVERFORMAT)(_In_ CONST D3DKMT_SETDISPLAYPRIVATEDRIVERFORMAT*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_SHAREDPRIMARYLOCKNOTIFICATION)(_In_ CONST D3DKMT_SHAREDPRIMARYLOCKNOTIFICATION*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_SHAREDPRIMARYUNLOCKNOTIFICATION)(_In_ CONST D3DKMT_SHAREDPRIMARYUNLOCKNOTIFICATION*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_CREATEKEYEDMUTEX)(_Inout_ D3DKMT_CREATEKEYEDMUTEX*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_OPENKEYEDMUTEX)(_Inout_ D3DKMT_OPENKEYEDMUTEX*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_DESTROYKEYEDMUTEX)(_In_ CONST D3DKMT_DESTROYKEYEDMUTEX*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_ACQUIREKEYEDMUTEX)(_Inout_ D3DKMT_ACQUIREKEYEDMUTEX*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_RELEASEKEYEDMUTEX)(_Inout_ D3DKMT_RELEASEKEYEDMUTEX*);
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8)
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_CREATEKEYEDMUTEX2)(_Inout_ D3DKMT_CREATEKEYEDMUTEX2*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_OPENKEYEDMUTEX2)(_Inout_ D3DKMT_OPENKEYEDMUTEX2*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_ACQUIREKEYEDMUTEX2)(_Inout_ D3DKMT_ACQUIREKEYEDMUTEX2*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_RELEASEKEYEDMUTEX2)(_Inout_ D3DKMT_RELEASEKEYEDMUTEX2*);
+#endif
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_CONFIGURESHAREDRESOURCE)(_In_ CONST D3DKMT_CONFIGURESHAREDRESOURCE*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_GETOVERLAYSTATE)(_Inout_ D3DKMT_GETOVERLAYSTATE*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_CHECKSHAREDRESOURCEACCESS)(_In_ CONST D3DKMT_CHECKSHAREDRESOURCEACCESS*);
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8)
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_OFFERALLOCATIONS)(_In_ CONST D3DKMT_OFFERALLOCATIONS*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_RECLAIMALLOCATIONS)(_Inout_ CONST D3DKMT_RECLAIMALLOCATIONS*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_CREATEOUTPUTDUPL)(_In_ CONST D3DKMT_CREATE_OUTPUTDUPL*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_DESTROYOUTPUTDUPL)(_In_ CONST D3DKMT_DESTROY_OUTPUTDUPL*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_OUTPUTDUPLGETFRAMEINFO)(_Inout_ D3DKMT_OUTPUTDUPL_GET_FRAMEINFO*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_OUTPUTDUPLGETMETADATA)(_Inout_ D3DKMT_OUTPUTDUPL_METADATA*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_OUTPUTDUPLGETPOINTERSHAPEDATA)(_Inout_ D3DKMT_OUTPUTDUPL_GET_POINTER_SHAPE_DATA*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_OUTPUTDUPLRELEASEFRAME)(_In_ D3DKMT_OUTPUTDUPL_RELEASE_FRAME*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_OUTPUTDUPLPRESENT)(_In_ CONST D3DKMT_OUTPUTDUPLPRESENT*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_ENUMADAPTERS)(_Inout_ CONST D3DKMT_ENUMADAPTERS*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_ENUMADAPTERS2)(_Inout_ CONST D3DKMT_ENUMADAPTERS2*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_OPENADAPTERFROMLUID)(_Inout_ D3DKMT_OPENADAPTERFROMLUID*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_QUERYREMOTEVIDPNSOURCEFROMGDIDISPLAYNAME)(_Inout_ D3DKMT_QUERYREMOTEVIDPNSOURCEFROMGDIDISPLAYNAME*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_SETVIDPNSOURCEOWNER1)(_In_ CONST D3DKMT_SETVIDPNSOURCEOWNER1*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_PINDIRECTFLIPRESOURCES)(_In_ CONST D3DKMT_PINDIRECTFLIPRESOURCES*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_UNPINDIRECTFLIPRESOURCES)(_In_ CONST D3DKMT_UNPINDIRECTFLIPRESOURCES*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_WAITFORVERTICALBLANKEVENT2)(_In_ CONST D3DKMT_WAITFORVERTICALBLANKEVENT2*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_GETDWMVERTICALBLANKEVENT)(_In_ CONST D3DKMT_GETVERTICALBLANKEVENT*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_SETSYNCREFRESHCOUNTWAITTARGET)(_In_ CONST D3DKMT_SETSYNCREFRESHCOUNTWAITTARGET*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_SETCONTEXTINPROCESSSCHEDULINGPRIORITY)(_In_ CONST D3DKMT_SETCONTEXTINPROCESSSCHEDULINGPRIORITY*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_GETCONTEXTINPROCESSSCHEDULINGPRIORITY)(_Inout_ D3DKMT_GETCONTEXTINPROCESSSCHEDULINGPRIORITY*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_PRESENTMULTIPLANEOVERLAY)(_In_ CONST D3DKMT_PRESENT_MULTIPLANE_OVERLAY*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_GETSHAREDRESOURCEADAPTERLUID)(_Inout_ D3DKMT_GETSHAREDRESOURCEADAPTERLUID*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_SETSTEREOENABLED)(_In_ BOOL);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_QUERYHYBRIDLISTVALUE)(_Inout_ D3DKMT_HYBRID_LIST*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_SETHYBRIDLISTVVALUE)(_Inout_ D3DKMT_HYBRID_LIST*);
+#endif
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM1_3)
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_CHECKMULTIPLANEOVERLAYSUPPORT)(_Inout_ D3DKMT_CHECKMULTIPLANEOVERLAYSUPPORT*);
+#endif
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0)
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_MAKERESIDENT)(_Inout_ D3DDDI_MAKERESIDENT*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_EVICT)(_Inout_ D3DKMT_EVICT*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_WAITFORSYNCHRONIZATIONOBJECTFROMCPU)(_In_ CONST D3DKMT_WAITFORSYNCHRONIZATIONOBJECTFROMCPU*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_SIGNALSYNCHRONIZATIONOBJECTFROMCPU)(_In_ CONST D3DKMT_SIGNALSYNCHRONIZATIONOBJECTFROMCPU*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_WAITFORSYNCHRONIZATIONOBJECTFROMGPU)(_In_ CONST D3DKMT_WAITFORSYNCHRONIZATIONOBJECTFROMGPU*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_SIGNALSYNCHRONIZATIONOBJECTFROMGPU)(_In_ CONST D3DKMT_SIGNALSYNCHRONIZATIONOBJECTFROMGPU*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_SIGNALSYNCHRONIZATIONOBJECTFROMGPU2)(_In_ CONST D3DKMT_SIGNALSYNCHRONIZATIONOBJECTFROMGPU2*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_CREATEPAGINGQUEUE)(_Inout_ D3DKMT_CREATEPAGINGQUEUE*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_DESTROYPAGINGQUEUE)(_Inout_ D3DDDI_DESTROYPAGINGQUEUE*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_LOCK2)(_Inout_ D3DKMT_LOCK2*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_UNLOCK2)(_In_ CONST D3DKMT_UNLOCK2*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_INVALIDATECACHE)(_In_ const D3DKMT_INVALIDATECACHE*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_RESERVEGPUVIRTUALADDRESS)(_Inout_ D3DDDI_RESERVEGPUVIRTUALADDRESS*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_MAPGPUVIRTUALADDRESS)(_Inout_ D3DDDI_MAPGPUVIRTUALADDRESS*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_FREEGPUVIRTUALADDRESS)(_In_ CONST D3DKMT_FREEGPUVIRTUALADDRESS*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_UPDATEGPUVIRTUALADDRESS)(_In_ CONST D3DKMT_UPDATEGPUVIRTUALADDRESS*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_GETRESOURCEPRESENTPRIVATEDRIVERDATA)(_Inout_ D3DDDI_GETRESOURCEPRESENTPRIVATEDRIVERDATA*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_CREATECONTEXTVIRTUAL)(_Inout_ D3DKMT_CREATECONTEXTVIRTUAL*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_SUBMITCOMMAND)(_In_ CONST D3DKMT_SUBMITCOMMAND*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_OPENSYNCOBJECTFROMNTHANDLE2)(_Inout_ D3DKMT_OPENSYNCOBJECTFROMNTHANDLE2*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_OPENSYNCOBJECTNTHANDLEFROMNAME)(_Inout_ D3DKMT_OPENSYNCOBJECTNTHANDLEFROMNAME*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_QUERYVIDEOMEMORYINFO)(_Inout_ D3DKMT_QUERYVIDEOMEMORYINFO*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_CHANGEVIDEOMEMORYRESERVATION)(_In_ CONST D3DKMT_CHANGEVIDEOMEMORYRESERVATION*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_REGISTERTRIMNOTIFICATION)(_Inout_ D3DKMT_REGISTERTRIMNOTIFICATION*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_UNREGISTERTRIMNOTIFICATION)(_Inout_ D3DKMT_UNREGISTERTRIMNOTIFICATION*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_REGISTERBUDGETCHANGENOTIFICATION)(_Inout_ D3DKMT_REGISTERBUDGETCHANGENOTIFICATION*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_UNREGISTERBUDGETCHANGENOTIFICATION)(_Inout_ D3DKMT_UNREGISTERBUDGETCHANGENOTIFICATION*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_CHECKMULTIPLANEOVERLAYSUPPORT2)(_Inout_ D3DKMT_CHECKMULTIPLANEOVERLAYSUPPORT2*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_PRESENTMULTIPLANEOVERLAY2)(_In_ CONST D3DKMT_PRESENT_MULTIPLANE_OVERLAY2*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_RECLAIMALLOCATIONS2)(_Inout_ D3DKMT_RECLAIMALLOCATIONS2*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_SETSTABLEPOWERSTATE)(_In_ CONST D3DKMT_SETSTABLEPOWERSTATE*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_QUERYCLOCKCALIBRATION)(_Inout_ D3DKMT_QUERYCLOCKCALIBRATION*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_QUERYVIDPNEXCLUSIVEOWNERSHIP)(_Inout_ D3DKMT_QUERYVIDPNEXCLUSIVEOWNERSHIP*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_ADJUSTFULLSCREENGAMMA)(_In_ D3DKMT_ADJUSTFULLSCREENGAMMA*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_SETVIDPNSOURCEHWPROTECTION)(_In_ D3DKMT_SETVIDPNSOURCEHWPROTECTION*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_MARKDEVICEASERROR)(_In_ D3DKMT_MARKDEVICEASERROR*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_FLUSHHEAPTRANSITIONS)(_In_ D3DKMT_FLUSHHEAPTRANSITIONS*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_SETHWPROTECTIONTEARDOWNRECOVERY)(_In_ D3DKMT_SETHWPROTECTIONTEARDOWNRECOVERY*);
+#endif
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_1)
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_QUERYPROCESSOFFERINFO)(_Inout_ D3DKMT_QUERYPROCESSOFFERINFO*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_TRIMPROCESSCOMMITMENT)(_Inout_ D3DKMT_TRIMPROCESSCOMMITMENT*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_UPDATEALLOCATIONPROPERTY)(_Inout_ D3DDDI_UPDATEALLOCPROPERTY*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_CHECKMULTIPLANEOVERLAYSUPPORT3)(_Inout_ D3DKMT_CHECKMULTIPLANEOVERLAYSUPPORT3*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_PRESENTMULTIPLANEOVERLAY3)(_In_ CONST D3DKMT_PRESENT_MULTIPLANE_OVERLAY3*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_SETFSEBLOCK)(_In_ CONST D3DKMT_SETFSEBLOCK*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_QUERYFSEBLOCK)(_Inout_ D3DKMT_QUERYFSEBLOCK*);
+#endif
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_2)
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_GETALLOCATIONPRIORITY)(_In_ CONST D3DKMT_GETALLOCATIONPRIORITY*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_GETMULTIPLANEOVERLAYCAPS)(_Inout_ D3DKMT_GET_MULTIPLANE_OVERLAY_CAPS*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_GETPOSTCOMPOSITIONCAPS)(_Inout_ D3DKMT_GET_POST_COMPOSITION_CAPS*);
+#endif
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_3)
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_SETVIDPNSOURCEOWNER2)(_In_ CONST D3DKMT_SETVIDPNSOURCEOWNER2*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_GETPROCESSDEVICEREMOVALSUPPORT)(_Inout_ D3DKMT_GETPROCESSDEVICEREMOVALSUPPORT*);
+
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_CREATEPROTECTEDSESSION)(_Inout_ D3DKMT_CREATEPROTECTEDSESSION*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_DESTROYPROTECTEDSESSION)(_Inout_ D3DKMT_DESTROYPROTECTEDSESSION*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_QUERYPROTECTEDSESSIONSTATUS)(_Inout_ D3DKMT_QUERYPROTECTEDSESSIONSTATUS*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_QUERYPROTECTEDSESSIONINFOFROMNTHANDLE)(_Inout_ D3DKMT_QUERYPROTECTEDSESSIONINFOFROMNTHANDLE*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_OPENPROTECTEDSESSIONFROMNTHANDLE)(_Inout_ D3DKMT_OPENPROTECTEDSESSIONFROMNTHANDLE*);
+
+
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_OPENKEYEDMUTEXFROMNTHANDLE)(_Inout_ D3DKMT_OPENKEYEDMUTEXFROMNTHANDLE*);
+
+#endif
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_4)
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_CREATEHWQUEUE)(_Inout_ D3DKMT_CREATEHWQUEUE*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_DESTROYHWQUEUE)(_In_ CONST D3DKMT_DESTROYHWQUEUE*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_SUBMITCOMMANDTOHWQUEUE)(_In_ CONST D3DKMT_SUBMITCOMMANDTOHWQUEUE*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_SUBMITWAITFORSYNCOBJECTSTOHWQUEUE)(_In_ CONST D3DKMT_SUBMITWAITFORSYNCOBJECTSTOHWQUEUE*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_SUBMITSIGNALSYNCOBJECTSTOHWQUEUE)(_In_ CONST D3DKMT_SUBMITSIGNALSYNCOBJECTSTOHWQUEUE*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_SUBMITPRESENTBLTTOHWQUEUE)(_In_ CONST D3DKMT_SUBMITPRESENTBLTTOHWQUEUE*);
+#endif
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_5)
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_SUBMITPRESENTTOHWQUEUE)(_Inout_ D3DKMT_SUBMITPRESENTTOHWQUEUE*);
+#endif  // DXGKDDI_INTERFACE_VERSION_WDDM2_5
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_6)
+
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_OUTPUTDUPLPRESENTTOHWQUEUE)(_In_ CONST D3DKMT_OUTPUTDUPLPRESENTTOHWQUEUE*);
+
+
+#endif  // DXGKDDI_INTERFACE_VERSION_WDDM2_6
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_7)
+
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_ENUMADAPTERS3)(_Inout_ D3DKMT_ENUMADAPTERS3*);
+
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_PINRESOURCES)(_Inout_ D3DKMT_PINRESOURCES*);
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_UNPINRESOURCES)(_In_ CONST D3DKMT_UNPINRESOURCES*);
+#ifdef _WIN32
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_DISPLAYPORT_OPERATION)(_Inout_ D3DKMT_DISPLAYPORT_OPERATION_HEADER*);
+#endif // _WIN32
+
+#endif
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_9)
+
+
+#endif
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM3_0)
+
+typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_CANCELPRESENTS)(_In_ D3DKMT_CANCEL_PRESENTS*);
+
+#endif
+
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTShareObjectWithHost(_Inout_ D3DKMT_SHAREOBJECTWITHHOST*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTCreateSyncFile(_Inout_ D3DKMT_CREATESYNCFILE*);
+
+// Used in WSL to close the internal file descriptor to /dev/dxg
+EXTERN_C VOID APIENTRY D3DKMTCloseDxCoreDevice();
+
+#if !defined(D3DKMDT_SPECIAL_MULTIPLATFORM_TOOL)
 
 #ifdef __cplusplus
 extern "C"
 {
-#endif /* __cplusplus */
+#endif
 
-DWORD APIENTRY D3DKMTCreateDCFromMemory(_Inout_ D3DKMT_CREATEDCFROMMEMORY*);
-DWORD APIENTRY D3DKMTDestroyDCFromMemory(_In_ CONST D3DKMT_DESTROYDCFROMMEMORY*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTCreateAllocation(_Inout_ D3DKMT_CREATEALLOCATION*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTCreateAllocation2(_Inout_ D3DKMT_CREATEALLOCATION*); // _ADVSCH_
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTQueryResourceInfo(_Inout_ D3DKMT_QUERYRESOURCEINFO*);
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8)
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTQueryResourceInfoFromNtHandle(_Inout_ D3DKMT_QUERYRESOURCEINFOFROMNTHANDLE*);
+
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTShareObjects(
+    _In_range_(1, D3DKMT_MAX_OBJECTS_PER_HANDLE) UINT   cObjects,
+    _In_reads_(cObjects) CONST D3DKMT_HANDLE *          hObjects,
+    _In_ POBJECT_ATTRIBUTES                             pObjectAttributes,
+    _In_ DWORD                                          dwDesiredAccess,
+    _Out_ HANDLE *                                      phSharedNtHandle
+    );
+
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTOpenNtHandleFromName(_Inout_ D3DKMT_OPENNTHANDLEFROMNAME*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTOpenResourceFromNtHandle(_Inout_ D3DKMT_OPENRESOURCEFROMNTHANDLE*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTOpenSyncObjectFromNtHandle(_Inout_ D3DKMT_OPENSYNCOBJECTFROMNTHANDLE*);
+#endif
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTOpenResource(_Inout_ D3DKMT_OPENRESOURCE*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTOpenResource2(_Inout_ D3DKMT_OPENRESOURCE*); // _ADVSCH_
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTDestroyAllocation(_In_ CONST D3DKMT_DESTROYALLOCATION*);
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0)
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTDestroyAllocation2(_In_ CONST D3DKMT_DESTROYALLOCATION2*);
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_0
+
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTSetAllocationPriority(_In_ CONST D3DKMT_SETALLOCATIONPRIORITY*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTQueryAllocationResidency(_In_ CONST D3DKMT_QUERYALLOCATIONRESIDENCY*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTCreateDevice(_Inout_ D3DKMT_CREATEDEVICE*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTDestroyDevice(_In_ CONST D3DKMT_DESTROYDEVICE*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTCreateContext(_Inout_ D3DKMT_CREATECONTEXT*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTDestroyContext(_In_ CONST D3DKMT_DESTROYCONTEXT*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTCreateSynchronizationObject(_Inout_ D3DKMT_CREATESYNCHRONIZATIONOBJECT*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTCreateSynchronizationObject2(_Inout_ D3DKMT_CREATESYNCHRONIZATIONOBJECT2*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTOpenSynchronizationObject(_Inout_ D3DKMT_OPENSYNCHRONIZATIONOBJECT*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTDestroySynchronizationObject(_In_ CONST D3DKMT_DESTROYSYNCHRONIZATIONOBJECT*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTWaitForSynchronizationObject(_In_ CONST D3DKMT_WAITFORSYNCHRONIZATIONOBJECT*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTWaitForSynchronizationObject2(_In_ CONST D3DKMT_WAITFORSYNCHRONIZATIONOBJECT2*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTSignalSynchronizationObject(_In_ CONST D3DKMT_SIGNALSYNCHRONIZATIONOBJECT*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTSignalSynchronizationObject2(_In_ CONST D3DKMT_SIGNALSYNCHRONIZATIONOBJECT2*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTLock(_Inout_ D3DKMT_LOCK*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTUnlock(_In_ CONST D3DKMT_UNLOCK*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTGetDisplayModeList(_Inout_ D3DKMT_GETDISPLAYMODELIST*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTSetDisplayMode(_Inout_ CONST D3DKMT_SETDISPLAYMODE*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTGetMultisampleMethodList(_Inout_ D3DKMT_GETMULTISAMPLEMETHODLIST*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTPresent(_Inout_ D3DKMT_PRESENT*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTRender(_Inout_ D3DKMT_RENDER*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTGetRuntimeData(_Inout_ CONST D3DKMT_GETRUNTIMEDATA*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTQueryAdapterInfo(_Inout_ CONST D3DKMT_QUERYADAPTERINFO*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTOpenAdapterFromHdc(_Inout_ D3DKMT_OPENADAPTERFROMHDC*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTOpenAdapterFromGdiDisplayName(_Inout_ D3DKMT_OPENADAPTERFROMGDIDISPLAYNAME*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTOpenAdapterFromDeviceName(_Inout_ D3DKMT_OPENADAPTERFROMDEVICENAME*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTCloseAdapter(_In_ CONST D3DKMT_CLOSEADAPTER*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTGetSharedPrimaryHandle(_Inout_ D3DKMT_GETSHAREDPRIMARYHANDLE*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTEscape(_In_ CONST D3DKMT_ESCAPE*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTQueryStatistics(_In_ CONST D3DKMT_QUERYSTATISTICS*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTSetVidPnSourceOwner(_In_ CONST D3DKMT_SETVIDPNSOURCEOWNER*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTGetPresentHistory(_Inout_ D3DKMT_GETPRESENTHISTORY*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTGetPresentQueueEvent(_In_ D3DKMT_HANDLE hAdapter, _Inout_ HANDLE*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTCreateOverlay(_Inout_ D3DKMT_CREATEOVERLAY*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTUpdateOverlay(_In_ CONST D3DKMT_UPDATEOVERLAY*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTFlipOverlay(_In_ CONST D3DKMT_FLIPOVERLAY*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTDestroyOverlay(_In_ CONST D3DKMT_DESTROYOVERLAY*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTWaitForVerticalBlankEvent(_In_ CONST D3DKMT_WAITFORVERTICALBLANKEVENT*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTSetGammaRamp(_In_ CONST D3DKMT_SETGAMMARAMP*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTGetDeviceState(_Inout_ D3DKMT_GETDEVICESTATE*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTCreateDCFromMemory(_Inout_ D3DKMT_CREATEDCFROMMEMORY*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTDestroyDCFromMemory(_In_ CONST D3DKMT_DESTROYDCFROMMEMORY*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTSetContextSchedulingPriority(_In_ CONST D3DKMT_SETCONTEXTSCHEDULINGPRIORITY*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTGetContextSchedulingPriority(_Inout_ D3DKMT_GETCONTEXTSCHEDULINGPRIORITY*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTSetProcessSchedulingPriorityClass(_In_ HANDLE, _In_ D3DKMT_SCHEDULINGPRIORITYCLASS);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTGetProcessSchedulingPriorityClass(_In_ HANDLE, _Out_ D3DKMT_SCHEDULINGPRIORITYCLASS*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTReleaseProcessVidPnSourceOwners(_In_ HANDLE);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTGetScanLine(_Inout_ D3DKMT_GETSCANLINE*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTChangeSurfacePointer(_In_ CONST D3DKMT_CHANGESURFACEPOINTER*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTSetQueuedLimit(_In_ CONST D3DKMT_SETQUEUEDLIMIT*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTPollDisplayChildren(_In_ CONST D3DKMT_POLLDISPLAYCHILDREN*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTInvalidateActiveVidPn(_In_ CONST D3DKMT_INVALIDATEACTIVEVIDPN*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTCheckOcclusion(_In_ CONST D3DKMT_CHECKOCCLUSION*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTWaitForIdle(IN CONST D3DKMT_WAITFORIDLE*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTCheckMonitorPowerState(_In_ CONST D3DKMT_CHECKMONITORPOWERSTATE*);
+EXTERN_C _Check_return_ BOOLEAN  APIENTRY D3DKMTCheckExclusiveOwnership(VOID);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTCheckVidPnExclusiveOwnership(_In_ CONST D3DKMT_CHECKVIDPNEXCLUSIVEOWNERSHIP*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTSetDisplayPrivateDriverFormat(_In_ CONST D3DKMT_SETDISPLAYPRIVATEDRIVERFORMAT*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTSharedPrimaryLockNotification(_In_ CONST D3DKMT_SHAREDPRIMARYLOCKNOTIFICATION*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTSharedPrimaryUnLockNotification(_In_ CONST D3DKMT_SHAREDPRIMARYUNLOCKNOTIFICATION*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTCreateKeyedMutex(_Inout_ D3DKMT_CREATEKEYEDMUTEX*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTOpenKeyedMutex(_Inout_ D3DKMT_OPENKEYEDMUTEX*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTDestroyKeyedMutex(_In_ CONST D3DKMT_DESTROYKEYEDMUTEX*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTAcquireKeyedMutex(_Inout_ D3DKMT_ACQUIREKEYEDMUTEX*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTReleaseKeyedMutex(_Inout_ D3DKMT_RELEASEKEYEDMUTEX*);
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8)
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTCreateKeyedMutex2(_Inout_ D3DKMT_CREATEKEYEDMUTEX2*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTOpenKeyedMutex2(_Inout_ D3DKMT_OPENKEYEDMUTEX2*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTAcquireKeyedMutex2(_Inout_ D3DKMT_ACQUIREKEYEDMUTEX2*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTReleaseKeyedMutex2(_Inout_ D3DKMT_RELEASEKEYEDMUTEX2*);
+#endif
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTConfigureSharedResource(_In_ CONST D3DKMT_CONFIGURESHAREDRESOURCE*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTGetOverlayState(_Inout_ D3DKMT_GETOVERLAYSTATE*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTCheckSharedResourceAccess(_In_ CONST D3DKMT_CHECKSHAREDRESOURCEACCESS*);
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8)
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTOfferAllocations(_In_ CONST D3DKMT_OFFERALLOCATIONS*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTReclaimAllocations(_Inout_ CONST D3DKMT_RECLAIMALLOCATIONS*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTCreateOutputDupl(_In_ CONST D3DKMT_CREATE_OUTPUTDUPL*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTDestroyOutputDupl(_In_ CONST D3DKMT_DESTROY_OUTPUTDUPL*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTOutputDuplGetFrameInfo(_Inout_ D3DKMT_OUTPUTDUPL_GET_FRAMEINFO*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTOutputDuplGetMetaData(_Inout_ D3DKMT_OUTPUTDUPL_METADATA*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTOutputDuplGetPointerShapeData(_Inout_ D3DKMT_OUTPUTDUPL_GET_POINTER_SHAPE_DATA*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTOutputDuplReleaseFrame(_Inout_ D3DKMT_OUTPUTDUPL_RELEASE_FRAME*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTOutputDuplPresent(_In_ CONST D3DKMT_OUTPUTDUPLPRESENT*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTEnumAdapters(_Inout_ CONST D3DKMT_ENUMADAPTERS*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTEnumAdapters2(_Inout_ CONST D3DKMT_ENUMADAPTERS2*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTOpenAdapterFromLuid(_Inout_ CONST D3DKMT_OPENADAPTERFROMLUID*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTQueryRemoteVidPnSourceFromGdiDisplayName(_Inout_ D3DKMT_QUERYREMOTEVIDPNSOURCEFROMGDIDISPLAYNAME*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTSetVidPnSourceOwner1(_In_ CONST D3DKMT_SETVIDPNSOURCEOWNER1*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTWaitForVerticalBlankEvent2(_In_ CONST D3DKMT_WAITFORVERTICALBLANKEVENT2*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTSetSyncRefreshCountWaitTarget(_In_ CONST D3DKMT_SETSYNCREFRESHCOUNTWAITTARGET*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTGetDWMVerticalBlankEvent(_In_ CONST D3DKMT_GETVERTICALBLANKEVENT*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTPresentMultiPlaneOverlay(_In_ CONST D3DKMT_PRESENT_MULTIPLANE_OVERLAY*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTGetSharedResourceAdapterLuid(_Inout_ D3DKMT_GETSHAREDRESOURCEADAPTERLUID*);
+#endif
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM1_3)
+
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTCheckMultiPlaneOverlaySupport(_Inout_ D3DKMT_CHECKMULTIPLANEOVERLAYSUPPORT*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTSetContextInProcessSchedulingPriority(_In_ CONST D3DKMT_SETCONTEXTINPROCESSSCHEDULINGPRIORITY*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTGetContextInProcessSchedulingPriority(_Inout_ D3DKMT_GETCONTEXTINPROCESSSCHEDULINGPRIORITY*);
+#endif
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0)
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTMakeResident(_Inout_ D3DDDI_MAKERESIDENT*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTEvict(_Inout_ D3DKMT_EVICT*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTWaitForSynchronizationObjectFromCpu(_In_ CONST D3DKMT_WAITFORSYNCHRONIZATIONOBJECTFROMCPU*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTSignalSynchronizationObjectFromCpu(_In_ CONST D3DKMT_SIGNALSYNCHRONIZATIONOBJECTFROMCPU*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTWaitForSynchronizationObjectFromGpu(_In_ CONST D3DKMT_WAITFORSYNCHRONIZATIONOBJECTFROMGPU*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTSignalSynchronizationObjectFromGpu(_In_ CONST D3DKMT_SIGNALSYNCHRONIZATIONOBJECTFROMGPU*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTSignalSynchronizationObjectFromGpu2(_In_ CONST D3DKMT_SIGNALSYNCHRONIZATIONOBJECTFROMGPU2*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTCreatePagingQueue(_Inout_ D3DKMT_CREATEPAGINGQUEUE*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTDestroyPagingQueue(_Inout_ D3DDDI_DESTROYPAGINGQUEUE*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTLock2(_Inout_ D3DKMT_LOCK2*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTUnlock2(_In_ CONST D3DKMT_UNLOCK2*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTInvalidateCache(_In_ CONST D3DKMT_INVALIDATECACHE*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTMapGpuVirtualAddress(_Inout_ D3DDDI_MAPGPUVIRTUALADDRESS*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTReserveGpuVirtualAddress(_Inout_ D3DDDI_RESERVEGPUVIRTUALADDRESS*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTFreeGpuVirtualAddress(_In_ CONST D3DKMT_FREEGPUVIRTUALADDRESS*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTUpdateGpuVirtualAddress(_In_ CONST D3DKMT_UPDATEGPUVIRTUALADDRESS*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTGetResourcePresentPrivateDriverData(_Inout_ D3DDDI_GETRESOURCEPRESENTPRIVATEDRIVERDATA*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTCreateContextVirtual(_In_ D3DKMT_CREATECONTEXTVIRTUAL*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTSubmitCommand(_In_ CONST D3DKMT_SUBMITCOMMAND*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTOpenSyncObjectFromNtHandle2(_Inout_ D3DKMT_OPENSYNCOBJECTFROMNTHANDLE2*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTOpenSyncObjectNtHandleFromName(_Inout_ D3DKMT_OPENSYNCOBJECTNTHANDLEFROMNAME*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTQueryVideoMemoryInfo(_Inout_ D3DKMT_QUERYVIDEOMEMORYINFO*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTChangeVideoMemoryReservation(_In_ CONST D3DKMT_CHANGEVIDEOMEMORYRESERVATION*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTRegisterTrimNotification(_Inout_ D3DKMT_REGISTERTRIMNOTIFICATION*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTUnregisterTrimNotification(_Inout_ D3DKMT_UNREGISTERTRIMNOTIFICATION*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTCheckMultiPlaneOverlaySupport2(_Inout_ D3DKMT_CHECKMULTIPLANEOVERLAYSUPPORT2*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTPresentMultiPlaneOverlay2(_In_ CONST D3DKMT_PRESENT_MULTIPLANE_OVERLAY2*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTReclaimAllocations2(_Inout_ D3DKMT_RECLAIMALLOCATIONS2*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTSetStablePowerState(_In_ CONST D3DKMT_SETSTABLEPOWERSTATE*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTQueryClockCalibration(_Inout_ D3DKMT_QUERYCLOCKCALIBRATION*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTQueryVidPnExclusiveOwnership(_Inout_ D3DKMT_QUERYVIDPNEXCLUSIVEOWNERSHIP*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTAdjustFullscreenGamma(_In_ D3DKMT_ADJUSTFULLSCREENGAMMA*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTSetVidPnSourceHwProtection(_In_ D3DKMT_SETVIDPNSOURCEHWPROTECTION*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTMarkDeviceAsError(_In_ D3DKMT_MARKDEVICEASERROR*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTFlushHeapTransitions(_In_ D3DKMT_FLUSHHEAPTRANSITIONS*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTSetHwProtectionTeardownRecovery(_In_ D3DKMT_SETHWPROTECTIONTEARDOWNRECOVERY*);
+#endif
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_1)
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTQueryProcessOfferInfo(_Inout_ D3DKMT_QUERYPROCESSOFFERINFO*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTTrimProcessCommitment(_Inout_ D3DKMT_TRIMPROCESSCOMMITMENT*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTUpdateAllocationProperty(_Inout_ D3DDDI_UPDATEALLOCPROPERTY*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTCheckMultiPlaneOverlaySupport3(_Inout_ D3DKMT_CHECKMULTIPLANEOVERLAYSUPPORT3*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTPresentMultiPlaneOverlay3(_In_ CONST D3DKMT_PRESENT_MULTIPLANE_OVERLAY3*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTSetFSEBlock(_In_ CONST D3DKMT_SETFSEBLOCK*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTQueryFSEBlock(_Inout_ D3DKMT_QUERYFSEBLOCK*);
+#endif
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_2)
+
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTCreateHwContext(_Inout_ D3DKMT_CREATEHWCONTEXT*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTDestroyHwContext(_In_ CONST D3DKMT_DESTROYHWCONTEXT*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTCreateHwQueue(_Inout_ D3DKMT_CREATEHWQUEUE*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTDestroyHwQueue(_In_ CONST D3DKMT_DESTROYHWQUEUE*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTSubmitCommandToHwQueue(_In_ CONST D3DKMT_SUBMITCOMMANDTOHWQUEUE*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTSubmitWaitForSyncObjectsToHwQueue(_In_ CONST D3DKMT_SUBMITWAITFORSYNCOBJECTSTOHWQUEUE*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTSubmitSignalSyncObjectsToHwQueue(_In_ CONST D3DKMT_SUBMITSIGNALSYNCOBJECTSTOHWQUEUE*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTGetAllocationPriority(_In_ CONST D3DKMT_GETALLOCATIONPRIORITY*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTGetMultiPlaneOverlayCaps(_Inout_ D3DKMT_GET_MULTIPLANE_OVERLAY_CAPS*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTGetPostCompositionCaps(_Inout_ D3DKMT_GET_POST_COMPOSITION_CAPS*);
+
+#endif
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_3)
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTPresentRedirected(_In_ D3DKMT_PRESENT_REDIRECTED*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTSetVidPnSourceOwner2(_In_ CONST D3DKMT_SETVIDPNSOURCEOWNER2*);
+
+
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTSetMonitorColorSpaceTransform(_In_ D3DKMT_SET_COLORSPACE_TRANSFORM*);
+
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTCreateProtectedSession(_Inout_ D3DKMT_CREATEPROTECTEDSESSION*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTDestroyProtectedSession(_Inout_ D3DKMT_DESTROYPROTECTEDSESSION*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTQueryProtectedSessionStatus(_Inout_ D3DKMT_QUERYPROTECTEDSESSIONSTATUS*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTQueryProtectedSessionInfoFromNtHandle(_Inout_ D3DKMT_QUERYPROTECTEDSESSIONINFOFROMNTHANDLE*);
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTOpenProtectedSessionFromNtHandle(_Inout_ D3DKMT_OPENPROTECTEDSESSIONFROMNTHANDLE*);
+
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTGetProcessDeviceRemovalSupport(_Inout_ D3DKMT_GETPROCESSDEVICEREMOVALSUPPORT*);
+
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTOpenKeyedMutexFromNtHandle(_Inout_ D3DKMT_OPENKEYEDMUTEXFROMNTHANDLE*);
+
+#endif
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_4)
+
+
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTSubmitPresentBltToHwQueue(_In_ CONST D3DKMT_SUBMITPRESENTBLTTOHWQUEUE*);
+
+#endif
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_5)
+
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTSubmitPresentToHwQueue(_Inout_ D3DKMT_SUBMITPRESENTTOHWQUEUE*);
+
+#endif
+
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_6)
+
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTOutputDuplPresentToHwQueue(_In_ CONST D3DKMT_OUTPUTDUPLPRESENTTOHWQUEUE*);
+
+
+#endif
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_7)
+
+
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTEnumAdapters3(_Inout_ D3DKMT_ENUMADAPTERS3*);
+
+
+#endif
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_9)
+
+
+#endif
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM3_0)
+
+EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTCancelPresents(_In_ D3DKMT_CANCEL_PRESENTS*);
+
+
+#endif
+
+//
+// Interface used for shared power component management
+// {ea5c6870-e93c-4588-bef1-fec42fc9429a}
+//
+
+DEFINE_GUID(GUID_DEVINTERFACE_GRAPHICSPOWER, 0xea5c6870, 0xe93c, 0x4588, 0xbe, 0xf1, 0xfe, 0xc4, 0x2f, 0xc9, 0x42, 0x9a);
+
+#define IOCTL_INTERNAL_GRAPHICSPOWER_REGISTER \
+    CTL_CODE(FILE_DEVICE_VIDEO, 0xa01, METHOD_NEITHER, FILE_ANY_ACCESS)
+
+#define DXGK_GRAPHICSPOWER_VERSION_1_0 0x1000
+#define DXGK_GRAPHICSPOWER_VERSION_1_1 0x1001
+#define DXGK_GRAPHICSPOWER_VERSION_1_2 0x1002
+#define DXGK_GRAPHICSPOWER_VERSION DXGK_GRAPHICSPOWER_VERSION_1_2
+
+typedef
+    _IRQL_requires_max_(PASSIVE_LEVEL)
+VOID
+(*PDXGK_POWER_NOTIFICATION)(
+    PVOID GraphicsDeviceHandle,
+    DEVICE_POWER_STATE NewGrfxPowerState,
+    BOOLEAN PreNotification,
+    PVOID PrivateHandle
+    );
+
+typedef
+    _IRQL_requires_max_(PASSIVE_LEVEL)
+VOID
+(*PDXGK_REMOVAL_NOTIFICATION)(
+    PVOID GraphicsDeviceHandle,
+    PVOID PrivateHandle
+    );
+
+typedef
+    _IRQL_requires_max_(DISPATCH_LEVEL)
+VOID
+(*PDXGK_FSTATE_NOTIFICATION)(
+    PVOID GraphicsDeviceHandle,
+    ULONG ComponentIndex,
+    UINT NewFState,
+    BOOLEAN PreNotification,
+    PVOID PrivateHandle
+    );
+
+typedef
+    _IRQL_requires_(DISPATCH_LEVEL)
+VOID
+(*PDXGK_INITIAL_COMPONENT_STATE) (
+    PVOID GraphicsDeviceHandle,
+    PVOID PrivateHandle,
+    ULONG ComponentIndex,
+    BOOLEAN IsBlockingType,
+    UINT InitialFState,
+    GUID ComponentGuid,
+    UINT PowerComponentMappingFlag
+);
+
+
+typedef struct _DXGK_GRAPHICSPOWER_REGISTER_INPUT_V_1_2 {
+    ULONG Version;
+    PVOID PrivateHandle;
+    PDXGK_POWER_NOTIFICATION PowerNotificationCb;
+    PDXGK_REMOVAL_NOTIFICATION RemovalNotificationCb;
+    PDXGK_FSTATE_NOTIFICATION FStateNotificationCb;
+    PDXGK_INITIAL_COMPONENT_STATE InitialComponentStateCb;
+} DXGK_GRAPHICSPOWER_REGISTER_INPUT_V_1_2, *PDXGK_GRAPHICSPOWER_REGISTER_INPUT_V_1_2;
+
+typedef DXGK_GRAPHICSPOWER_REGISTER_INPUT_V_1_2 DXGK_GRAPHICSPOWER_REGISTER_INPUT;
+typedef DXGK_GRAPHICSPOWER_REGISTER_INPUT *PDXGK_GRAPHICSPOWER_REGISTER_INPUT;
+
+typedef
+    _Check_return_
+    _IRQL_requires_max_(APC_LEVEL)
+NTSTATUS
+(*PDXGK_SET_SHARED_POWER_COMPONENT_STATE)(
+    PVOID DeviceHandle,
+    PVOID PrivateHandle,
+    ULONG ComponentIndex,
+    BOOLEAN Active
+    );
+
+typedef
+    _Check_return_
+    _IRQL_requires_max_(APC_LEVEL)
+NTSTATUS
+(*PDXGK_GRAPHICSPOWER_UNREGISTER)(
+    PVOID DeviceHandle,
+    PVOID PrivateHandle
+    );
+
+typedef struct _DXGK_GRAPHICSPOWER_REGISTER_OUTPUT
+{
+    PVOID DeviceHandle;
+    DEVICE_POWER_STATE InitialGrfxPowerState;
+    PDXGK_SET_SHARED_POWER_COMPONENT_STATE SetSharedPowerComponentStateCb;
+    PDXGK_GRAPHICSPOWER_UNREGISTER UnregisterCb;
+} DXGK_GRAPHICSPOWER_REGISTER_OUTPUT, *PDXGK_GRAPHICSPOWER_REGISTER_OUTPUT;
+
+typedef enum _DXGKMT_POWER_SHARED_TYPE
+{
+    DXGKMT_POWER_SHARED_TYPE_AUDIO   = 0,
+} DXGKMT_POWER_SHARED_TYPE;
 
 #ifdef __cplusplus
 }
-#endif /* __cplusplus */
+#endif
 
-#endif /* __WINE_D3DKMTHK_H */
+#endif // !defined(D3DKMDT_SPECIAL_MULTIPLATFORM_TOOL)
+
+#endif // (NTDDI_VERSION >= NTDDI_LONGHORN) || defined(D3DKMDT_SPECIAL_MULTIPLATFORM_TOOL)
+
+
+#pragma warning(pop)
+
+#endif /* WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) */
+#pragma endregion
+
+#endif /* _D3DKMTHK_H_ */
+

--- a/sdk/include/ddk/d3dkmthk.h
+++ b/sdk/include/ddk/d3dkmthk.h
@@ -29,7 +29,7 @@ typedef OBJECT_ATTRIBUTES *POBJECT_ATTRIBUTES;
 // Available only for Vista (LONGHORN) and later and for
 // multiplatform tools such as debugger extensions
 //
-#if (NTDDI_VERSION >= NTDDI_LONGHORN) || defined(D3DKMDT_SPECIAL_MULTIPLATFORM_TOOL)
+#if defined(__REACTOS__) || ((NTDDI_VERSION >= NTDDI_LONGHORN) || defined(D3DKMDT_SPECIAL_MULTIPLATFORM_TOOL))
 
 typedef struct _D3DKMT_CREATEDEVICEFLAGS
 {
@@ -5649,11 +5649,15 @@ typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_CANCELPRESENTS)(_In_ D3DKMT
 
 #endif
 
+#ifdef __REACTOS__
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_2)
 EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTShareObjectWithHost(_Inout_ D3DKMT_SHAREOBJECTWITHHOST*);
 EXTERN_C _Check_return_ NTSTATUS APIENTRY D3DKMTCreateSyncFile(_Inout_ D3DKMT_CREATESYNCFILE*);
 
 // Used in WSL to close the internal file descriptor to /dev/dxg
 EXTERN_C VOID APIENTRY D3DKMTCloseDxCoreDevice();
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM3_0
+#endif // __REACTOS__
 
 #if !defined(D3DKMDT_SPECIAL_MULTIPLATFORM_TOOL)
 

--- a/sdk/include/psdk/d3dkmdt.h
+++ b/sdk/include/psdk/d3dkmdt.h
@@ -1,0 +1,2476 @@
+/******************************Module*Header**********************************\
+*
+* Module Name: d3dkmdt.h
+*
+* Content: Windows Display Driver Model (WDDM) kernel mode
+*          data type definitions
+*
+* Copyright (c) Microsoft Corporation.
+* Licensed under the MIT License.
+*
+\*****************************************************************************/
+#ifndef _D3DKMDT_H
+#define _D3DKMDT_H
+
+#if !defined(_D3DKMDDI_H_)      && \
+    !defined(_D3DKMDDI_PEXT_H_) && \
+    !defined(_DXGDMM_H_)        && \
+    !defined(_VIDPRIV_H_)       && \
+    !defined(_DISPMPRT_H_)      && \
+    !defined(_DMM_DIAG_H_)      && \
+    !defined(_D3DKMTHK_H_)
+   #error This header should not be included directly!
+#endif
+
+#include "d3dukmdt.h"
+
+#define NTSTATUS                int32_t
+
+/*
+ * Some of the Windows return codes, which needs to be translated to Linux
+ * IOCTL return codes. Positive values are success codes and need to be
+ * returned from the driver IOCTLs. libdxcore.so depends on returning
+ * specific return codes.
+ */
+#define STATUS_SUCCESS					((NTSTATUS)(0))
+#define	STATUS_OBJECT_NAME_INVALID		((NTSTATUS)(0xC0000033L))
+#define	STATUS_DEVICE_REMOVED			((NTSTATUS)(0xC00002B6L))
+#define	STATUS_INVALID_HANDLE			((NTSTATUS)(0xC0000008L))
+#define	STATUS_ILLEGAL_INSTRUCTION		((NTSTATUS)(0xC000001DL))
+#define	STATUS_NOT_IMPLEMENTED			((NTSTATUS)(0xC0000002L))
+#define	STATUS_PENDING					((NTSTATUS)(0x00000103L))
+#define	STATUS_ACCESS_DENIED			((NTSTATUS)(0xC0000022L))
+#define	STATUS_BUFFER_TOO_SMALL			((NTSTATUS)(0xC0000023L))
+#define	STATUS_OBJECT_TYPE_MISMATCH		((NTSTATUS)(0xC0000024L))
+#define	STATUS_GRAPHICS_ALLOCATION_BUSY	((NTSTATUS)(0xC01E0102L))
+#define	STATUS_NOT_SUPPORTED			((NTSTATUS)(0xC00000BBL))
+#define	STATUS_TIMEOUT					((NTSTATUS)(0x00000102L))
+#define	STATUS_INVALID_PARAMETER		((NTSTATUS)(0xC000000DL))
+#define	STATUS_NO_MEMORY				((NTSTATUS)(0xC0000017L))
+#define	STATUS_OBJECT_NAME_COLLISION	((NTSTATUS)(0xC0000035L))
+#define STATUS_OBJECT_NAME_NOT_FOUND	((NTSTATUS)(0xC0000034L))
+#define STATUS_UNSUCCESSFUL             ((NTSTATUS)(0xC0000001L))
+#define STATUS_INVALID_PARAMETER        ((NTSTATUS)(0xC000000DL))
+#define NT_SUCCESS(status)              (status >= 0)
+
+typedef enum {
+    PowerActionNone = 0,
+    PowerActionReserved,
+    PowerActionSleep,
+    PowerActionHibernate,
+    PowerActionShutdown,
+    PowerActionShutdownReset,
+    PowerActionShutdownOff,
+    PowerActionWarmEject,
+    PowerActionDisplayOff
+} POWER_ACTION, *PPOWER_ACTION;
+
+typedef enum _DEVICE_POWER_STATE {
+    PowerDeviceUnspecified = 0,
+    PowerDeviceD0,
+    PowerDeviceD1,
+    PowerDeviceD2,
+    PowerDeviceD3,
+    PowerDeviceMaximum
+} DEVICE_POWER_STATE, *PDEVICE_POWER_STATE;
+
+#pragma region Desktop Family
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+
+#pragma warning(push)
+#pragma warning(disable:4201) // anonymous unions warning
+#pragma warning(disable:4214)   // nonstandard extension used: bit field types other than int
+
+//
+// Available only for Vista (LONGHORN) and later and for
+// multiplatform tools such as debugger extensions
+//
+#if (NTDDI_VERSION >= NTDDI_LONGHORN) || defined(D3DKMDT_SPECIAL_MULTIPLATFORM_TOOL)
+
+//
+// Hardcoded overlay count
+//
+#define D3DKMDT_MAX_OVERLAYS_BITCOUNT           2
+#define D3DKMDT_MAX_OVERLAYS                    (1 << D3DKMDT_MAX_OVERLAYS_BITCOUNT)
+
+
+//////////////////// VidPN management DDI handles /////////////////////////////////////////////////////////
+DECLARE_HANDLE(D3DKMDT_HVIDPN);
+DECLARE_HANDLE(D3DKMDT_HVIDEOPRESENTSOURCESET);
+DECLARE_HANDLE(D3DKMDT_HVIDEOPRESENTTARGETSET);
+DECLARE_HANDLE(D3DKMDT_HVIDPNTOPOLOGY);
+DECLARE_HANDLE(D3DKMDT_HVIDPNSOURCEMODESET);
+DECLARE_HANDLE(D3DKMDT_HVIDPNTARGETMODESET);
+DECLARE_HANDLE(D3DKMDT_HMONITORSOURCEMODESET);
+DECLARE_HANDLE(D3DKMDT_HMONITORFREQUENCYRANGESET);
+DECLARE_HANDLE(D3DKMDT_HMONITORDESCRIPTORSET);
+
+// Alias VOID* to make LDDM kernel mode interface prototypes using adapter handles self-explanatory.
+typedef VOID* D3DKMDT_ADAPTER;
+
+
+
+//////////////////// VidPN management DDI constants /////////////////////////////////////////////////////////
+
+// Special values representing that given variable has not been initialized to a valid value intended
+// to catch development time errors. A valid parameter should never have this value.
+#define D3DKMDT_DIMENSION_UNINITIALIZED  (UINT)(~0)
+#define D3DKMDT_FREQUENCY_UNINITIALIZED  (UINT)(~0)
+
+// Special values representing that given parameter is not-specified.
+// A parameter having this value should be ignored.
+#define D3DKMDT_DIMENSION_NOTSPECIFIED  (UINT)(~1)
+#define D3DKMDT_FREQUENCY_NOTSPECIFIED  (UINT)(~1)
+
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Purpose: Video mode standard descriptor type, listing standards that are explicitly supported by Windows.
+//
+// Remarks: This enum specifies based on which standard the video signal timing parameters should be computed.
+//          Note that NTSC, PAL, and SECAM mode variants are treated as individual groups to avoid complicating
+//          the DDI with the notion of "sub-standard" (because they don't differ from each other in the parameters
+//          used to describe the video signal in the DDI and the parameters that they do differ in are of no
+//          interest to us in DMM).
+//
+typedef enum _D3DKMDT_VIDEO_SIGNAL_STANDARD
+{
+    D3DKMDT_VSS_UNINITIALIZED =  0,
+
+    // VESA standards
+    D3DKMDT_VSS_VESA_DMT      =  1,    // See VESA Display Monitor Timings specification
+    D3DKMDT_VSS_VESA_GTF      =  2,    // See VESA Generalized Timing Formula standard
+    D3DKMDT_VSS_VESA_CVT      =  3,    // See VESA Coordinated Video Timings standard
+
+    // De-facto standards
+    D3DKMDT_VSS_IBM           =  4,
+    D3DKMDT_VSS_APPLE         =  5,
+
+    // Legacy STV standards                 W  x H{i|p} @ (  VR        /      HR       )
+    D3DKMDT_VSS_NTSC_M        =  6,    //  720 x 525i   @ (59.94  [Hz] /  15,734.27[Hz])
+    D3DKMDT_VSS_NTSC_J        =  7,    //  720 x 525i   @ (59.94  [Hz] /  15,734.27[Hz])
+    D3DKMDT_VSS_NTSC_443      =  8,    //  720 x 525i   @ (59.94  [Hz] /  15,734.27[Hz])
+    D3DKMDT_VSS_PAL_B         =  9,    //  720 x 625i   @ (50     [Hz] /  15,625   [Hz])
+    D3DKMDT_VSS_PAL_B1        = 10,    //  720 x 625i   @ (50     [Hz] /  15,625   [Hz])
+    D3DKMDT_VSS_PAL_G         = 11,    //  720 x 625i   @ (50     [Hz] /  15,625   [Hz])
+    D3DKMDT_VSS_PAL_H         = 12,    //  720 x 625i   @ (50     [Hz] /  15,625   [Hz])
+    D3DKMDT_VSS_PAL_I         = 13,    //  720 x 625i   @ (50     [Hz] /  15,625   [Hz])
+    D3DKMDT_VSS_PAL_D         = 14,    //  720 x 625i   @ (50     [Hz] /  15,625   [Hz])
+    D3DKMDT_VSS_PAL_N         = 15,    //  720 x 625i   @ (50     [Hz] /  15,625   [Hz])
+    D3DKMDT_VSS_PAL_NC        = 16,    //  720 x 625i   @ (50     [Hz] /  15,625   [Hz])
+    D3DKMDT_VSS_SECAM_B       = 17,    //  720 x 625i   @ (50     [Hz] /  15,625   [Hz])
+    D3DKMDT_VSS_SECAM_D       = 18,    //  720 x 625i   @ (50     [Hz] /  15,625   [Hz])
+    D3DKMDT_VSS_SECAM_G       = 19,    //  720 x 625i   @ (50     [Hz] /  15,625   [Hz])
+    D3DKMDT_VSS_SECAM_H       = 20,    //  720 x 625i   @ (50     [Hz] /  15,625   [Hz])
+    D3DKMDT_VSS_SECAM_K       = 21,    //  720 x 625i   @ (50     [Hz] /  15,625   [Hz])
+    D3DKMDT_VSS_SECAM_K1      = 22,    //  720 x 625i   @ (50     [Hz] /  15,625   [Hz])
+    D3DKMDT_VSS_SECAM_L       = 23,    //  720 x 625i   @ (50     [Hz] /  15,625   [Hz])
+    D3DKMDT_VSS_SECAM_L1      = 24,    //  720 x 625i   @ (50     [Hz] /  15,625   [Hz])
+
+    // CEA/EIA standards
+    D3DKMDT_VSS_EIA_861       = 25,
+    D3DKMDT_VSS_EIA_861A      = 26,
+    D3DKMDT_VSS_EIA_861B      = 27,
+
+    // More legacy STV standards
+    D3DKMDT_VSS_PAL_K         = 28,    //  720 x 625i   @ (50     [Hz] /  15,625   [Hz])
+    D3DKMDT_VSS_PAL_K1        = 29,    //  720 x 625i   @ (50     [Hz] /  15,625   [Hz])
+    D3DKMDT_VSS_PAL_L         = 30,    //  720 x 625i   @ (50     [Hz] /  15,625   [Hz])
+    D3DKMDT_VSS_PAL_M         = 31,    //  720 x 525i   @ (59.94  [Hz] /  15,734   [Hz])
+
+    D3DKMDT_VSS_OTHER         = 255
+}
+D3DKMDT_VIDEO_SIGNAL_STANDARD;
+
+
+
+//////////////////// Video present sources //////////////////////////////////////////////////////////////////
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Purpose: Video present source descriptor type.
+//
+typedef struct _D3DKMDT_VIDEO_PRESENT_SOURCE
+{
+    // Unique ID used to reference the respective video present source by the miniport and the OS.
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID  Id;
+
+    // Other video present source descriptor properties go here.
+    DWORD  dwReserved;
+}
+D3DKMDT_VIDEO_PRESENT_SOURCE;
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Purpose: VidPN source mode enumeration type descriptor type.
+//
+// Remarks: This type is used to specify whether a VidPN source mode is a graphics or a text mode
+//          (see VIDEO_PRESENT_SOURCE_MODE for more details).
+//
+typedef enum _D3DKMDT_VIDPN_SOURCE_MODE_TYPE
+{
+    D3DKMDT_RMT_UNINITIALIZED                 = 0,
+    D3DKMDT_RMT_GRAPHICS                      = 1,
+    D3DKMDT_RMT_TEXT                          = 2,
+    D3DKMDT_RMT_GRAPHICS_STEREO               = 3,
+    D3DKMDT_RMT_GRAPHICS_STEREO_ADVANCED_SCAN = 4
+}
+D3DKMDT_VIDPN_SOURCE_MODE_TYPE;
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Purpose: Pixel value access mode descriptor type.
+//
+// Remarks: Use Direct to represent VidPN source modes with colors stored directly in the primary surface.
+//          Use PresetPalette to represent VidPN source modes with colors' indices stored in the primary
+//          surface and actual color values stored in a palette specific to the video card, that must
+//          be queried from the video miniport.
+//          Use SettablePalette to represent VidPN source modes with colors' indices stored in the primary
+//          surface and actual color values stored in a settable palette that can be dynamically set on
+//          the video card, by specifying it to the video miniport.
+//
+typedef enum _D3DKMDT_PIXEL_VALUE_ACCESS_MODE
+{
+    D3DKMDT_PVAM_UNINITIALIZED   = 0,
+    D3DKMDT_PVAM_DIRECT          = 1,
+    D3DKMDT_PVAM_PRESETPALETTE   = 2,
+    D3DKMDT_PVAM_SETTABLEPALETTE = 3,
+}
+D3DKMDT_PIXEL_VALUE_ACCESS_MODE;
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Purpose: Descriptor type of the color basis with respect to which the pixels' colors are expanded,
+//          or conversely, based on which the color values are synthesized.
+//
+// Remarks: The commonly used color bases in graphics industry are RGB, which has the basis (red, green, blue),
+//          as well as YPbPr and YCbCr, which have scaled variants of basis:
+//          (1, blue-1, red-1)*intensity(red,green,blue).
+//          Tri-stimulus linear RGB is well suited for real-time rendering, since most filtering algorithms
+//          use tri-stimulus values to approximate light's spectral transformations caused by its interaction
+//          with the environment, primarily due to the fact that there is a linear relationship between the
+//          perceived light level and the light's spectral intensity. Ideally, all processing of video content
+//          (i.e. scaling, filtering, etc) should be performed in a linear RGB space.
+//          Y'PbPr spaces store data using a nonlinear curve which is approximately the inverse of a gamma
+//          2.2 curve (i.e. x^0.45).  This allows more precision to be stored in darker intensities where the
+//          human eye is more sensitive.
+//          sRGB (more accurately, sR'G'B') stores light intensities relative to a gamma curve.
+//          scRGB stores linear values and requires much higher precision to represent the same perceptually
+//          similar signal.
+//          The light-intensity based YPbPr and YCbCr is better suited for persistence of pre-rendered content,
+//          such as video streaming. This is due to the fact that a human visual system is more responsive to
+//          small differences in photons' intensity rather than frequency (i.e. perceived color), and, hence,
+//          a light-intensity based color expansion over a finite dynamic range, yields a better perceptual
+//          image quality for the human eye than a tri-stimulus based color expansion in that same range
+//          (e.g  non-linear Y8Cb8Cr8 appears slightly better than R8G8B8 and is comparable to R9G9B9).
+//          To represent monochrome modes, use Intensity. Grayscale imaging is heavily used in medical imaging.
+//          Note: the apostrophe notation Y'PbPr is used to remind you that you are working with non-linear data.
+//
+typedef enum _D3DKMDT_COLOR_BASIS
+{
+    D3DKMDT_CB_UNINITIALIZED = 0,
+    D3DKMDT_CB_INTENSITY     = 1,
+    D3DKMDT_CB_SRGB          = 2,
+    D3DKMDT_CB_SCRGB         = 3,
+    D3DKMDT_CB_YCBCR         = 4,
+    D3DKMDT_CB_YPBPR         = 5,
+}
+D3DKMDT_COLOR_BASIS;
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Purpose: Descriptor type of the color coefficients dynamic range, whose linear combination with the
+//          respective color basis produces final pixel values.
+//
+// Remarks: Examples include (5,6,5,0) for R5G6B5, (8,8,8,8) for R8G8B8A8, and (24, 0, 0, 0) for 24-bit
+//          grayscale pixel encoding format.
+//          NOTE: Currently this is only used for target modes, none of which has the 4th channel (e.g. alpha).
+//                We are keeping the 4th field for extensibility purpose to avoid miniport interface revision
+//                if 4-channel video interfaces became available between display adapter and monitor.
+//
+typedef struct _D3DKMDT_COLOR_COEFF_DYNAMIC_RANGES
+{
+    UINT  FirstChannel;
+    UINT  SecondChannel;
+    UINT  ThirdChannel;
+    UINT  FourthChannel;
+}
+D3DKMDT_COLOR_COEFF_DYNAMIC_RANGES;
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Purpose: 2D region descriptor type.
+//
+// Remarks: We define our own rather than reusing SIZE type to avoid dependency on SDK headers.
+//
+typedef struct _D3DKMDT_2DREGION
+{
+    UINT cx;
+    UINT cy;
+}
+D3DKMDT_2DREGION;
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Purpose: 2D offset descriptor type.
+//
+// Remarks: We define our own rather than reusing SIZE type to avoid dependency on SDK headers.
+//
+typedef D3DKMDT_2DREGION  D3DKMDT_2DOFFSET;
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Purpose: Graphics video present source mode descriptor type.
+//
+// Remarks: Graphics video present source mode is the dominantly used subtype of the video present source
+//          modes (other being the text video present source mode).
+//          Note that whenever video present source mode's visible size,
+//          VIDEO_PRESENT_SOURCE_MODE.GRAPHICS_RENDERING_FORMAT.sizeVisible is not equal to the respective
+//          video mode's visible size, VIDEO_PRESENT_TARGET_MODE.sizeVisible, h/w scaling is undertaken by
+//          the video output codec.
+//
+//          Miniport is free to support any D3D pixel format for its graphics modes that is meaningful
+//          as a primary surface pixel format.
+//
+typedef struct _D3DKMDT_GRAPHICS_RENDERING_FORMAT
+{
+    // Size of the primary surface required for this VidPN source mode.
+    D3DKMDT_2DREGION  PrimSurfSize;
+
+    // Size of the visible part of the primary surface, used for panned modes including zoom modes.
+    // The visible region size is required to be the same as the primary surface
+    D3DKMDT_2DREGION  VisibleRegionSize;
+
+    // Number of bytes between the start of one scan line and the next.
+    DWORD  Stride;
+
+    // Pixel format type
+    D3DDDIFORMAT  PixelFormat;
+
+    // Color basis with respect to which rendering client encodes pixel values.
+    D3DKMDT_COLOR_BASIS  ColorBasis;
+
+    // Access mode for the pixel value information.
+    D3DKMDT_PIXEL_VALUE_ACCESS_MODE  PixelValueAccessMode;
+}
+D3DKMDT_GRAPHICS_RENDERING_FORMAT;
+
+
+typedef enum _D3DKMDT_TEXT_RENDERING_FORMAT
+{
+    D3DKMDT_TRF_UNINITIALIZED = 0
+}
+D3DKMDT_TEXT_RENDERING_FORMAT;
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Purpose: Video present source mode ID type.
+typedef UINT  D3DKMDT_VIDEO_PRESENT_SOURCE_MODE_ID;
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Purpose: VidPN source mode descriptor type.
+//
+// Remarks: VidPN source (rendering) mode is the mode of operation of a given video present source and determines
+//          the format of this source's primary surface to which the graphics subsystem is rendering
+//          the visual image to be presented to the user, and from which the video output codec is reading
+//          the visual image content to be converted into a respective video mode signal.
+//
+typedef struct _D3DKMDT_VIDPN_SOURCE_MODE
+{
+    D3DKMDT_VIDEO_PRESENT_SOURCE_MODE_ID  Id;
+
+    // Specifies whether the mode is a graphics or a text rendering mode.
+    D3DKMDT_VIDPN_SOURCE_MODE_TYPE  Type;
+
+    union
+    {
+        // Descriptor of the graphics rendering mode (valid only if Type==D3DKMDT_RMT_GRAPHICS).
+        D3DKMDT_GRAPHICS_RENDERING_FORMAT  Graphics;
+
+        // Descriptor of the text rendering mode (valid only if Type==D3DKMDT_RMT_TEXT).
+        D3DKMDT_TEXT_RENDERING_FORMAT  Text;
+    }
+    Format;
+}
+D3DKMDT_VIDPN_SOURCE_MODE;
+
+
+
+//////////////////////// Video present targets///////////////////////////////////////////////////////////////
+
+
+// NOTE: Child device (e.g. video output) HPD awareness is used to represent the level of external
+//       device (e.g. monitor) connectivity sensed by a display adapter. Child device can either be
+//       always connected to an external device (e.g. integrated LCD in a mobile system) or have:
+//         1. No HPD-awareness iff miniport is *not* aware of external device arrivals/departures
+//            whether through interrupts or polling,
+//         2. Polled HPD-awareness iff miniport can not asynchronously notify the OS about external
+//            device arrivals/departures, but OS can sporadically poll for its presence, and of a
+//            monitor, causing visual artifacts on each poll.
+//         3. Interruptible HPD-awareness iff miniport can asynchronously notify the OS about
+//            external device arrivals/departures.
+typedef enum _DXGK_CHILD_DEVICE_HPD_AWARENESS {
+    HpdAwarenessUninitialized   = 0,
+    HpdAwarenessAlwaysConnected = 1,
+    HpdAwarenessNone            = 2,
+    HpdAwarenessPolled          = 3,
+    HpdAwarenessInterruptible   = 4
+} DXGK_CHILD_DEVICE_HPD_AWARENESS, *PDXGK_CHILD_DEVICE_HPD_AWARENESS;
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Purpose: Monitor orientation descriptor type.
+//
+typedef enum _D3DKMDT_MONITOR_ORIENTATION
+{
+    D3DKMDT_MO_UNINITIALIZED = 0,
+    D3DKMDT_MO_0DEG          = 1,
+    D3DKMDT_MO_90DEG         = 2,
+    D3DKMDT_MO_180DEG        = 3,
+    D3DKMDT_MO_270DEG        = 4
+}
+D3DKMDT_MONITOR_ORIENTATION;
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Purpose: Video output technology descriptor type.
+//
+// Remarks: Video output technology is used to determine the hard-coded list of video modes supported
+//          by the monitor, when monitor descriptor is not available.
+//
+typedef enum _D3DKMDT_VIDEO_OUTPUT_TECHNOLOGY
+{
+    D3DKMDT_VOT_UNINITIALIZED            = -2,
+    D3DKMDT_VOT_OTHER                    = -1,
+    D3DKMDT_VOT_HD15                     =  0,
+    D3DKMDT_VOT_SVIDEO                   =  1,
+    D3DKMDT_VOT_COMPOSITE_VIDEO          =  2,
+    D3DKMDT_VOT_COMPONENT_VIDEO          =  3,
+    D3DKMDT_VOT_DVI                      =  4,
+    D3DKMDT_VOT_HDMI                     =  5,
+    D3DKMDT_VOT_LVDS                     =  6,
+    D3DKMDT_VOT_D_JPN                    =  8,
+    D3DKMDT_VOT_SDI                      =  9,
+    D3DKMDT_VOT_DISPLAYPORT_EXTERNAL     = 10,
+    D3DKMDT_VOT_DISPLAYPORT_EMBEDDED     = 11,
+    D3DKMDT_VOT_UDI_EXTERNAL             = 12,
+    D3DKMDT_VOT_UDI_EMBEDDED             = 13,
+    D3DKMDT_VOT_SDTVDONGLE               = 14,
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM1_3_M1)
+    D3DKMDT_VOT_MIRACAST                 = 15,
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_1)
+    D3DKMDT_VOT_INDIRECT_WIRED           = 16,
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_1)
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM1_3_M1)
+    D3DKMDT_VOT_INTERNAL                 = 0x80000000,
+
+    // Remove when DDI is unlocked.
+    D3DKMDT_VOT_SVIDEO_4PIN          = D3DKMDT_VOT_SVIDEO,
+    D3DKMDT_VOT_SVIDEO_7PIN          = D3DKMDT_VOT_SVIDEO,
+    D3DKMDT_VOT_RF                   = D3DKMDT_VOT_COMPOSITE_VIDEO,
+    D3DKMDT_VOT_RCA_3COMPONENT       = D3DKMDT_VOT_COMPONENT_VIDEO,
+    D3DKMDT_VOT_BNC                  = D3DKMDT_VOT_COMPONENT_VIDEO,
+}
+D3DKMDT_VIDEO_OUTPUT_TECHNOLOGY;
+
+typedef enum _DXGKMDT_OPM_CONNECTOR_TYPE
+{
+    DXGKMDT_OPM_CONNECTOR_TYPE_OTHER                                = -1,
+    DXGKMDT_OPM_CONNECTOR_TYPE_HD15                                 =  0,
+    DXGKMDT_OPM_CONNECTOR_TYPE_SVIDEO                               =  1,
+    DXGKMDT_OPM_CONNECTOR_TYPE_COMPOSITE_VIDEO                      =  2,
+    DXGKMDT_OPM_CONNECTOR_TYPE_COMPONENT_VIDEO                      =  3,
+    DXGKMDT_OPM_CONNECTOR_TYPE_DVI                                  =  4,
+    DXGKMDT_OPM_CONNECTOR_TYPE_HDMI                                 =  5,
+    DXGKMDT_OPM_CONNECTOR_TYPE_LVDS                                 =  6,
+    DXGKMDT_OPM_CONNECTOR_TYPE_D_JPN                                =  8,
+    DXGKMDT_OPM_CONNECTOR_TYPE_SDI                                  =  9,
+    DXGKMDT_OPM_CONNECTOR_TYPE_DISPLAYPORT_EXTERNAL                 = 10,
+    DXGKMDT_OPM_CONNECTOR_TYPE_DISPLAYPORT_EMBEDDED                 = 11,
+    DXGKMDT_OPM_CONNECTOR_TYPE_UDI_EXTERNAL                         = 12,
+    DXGKMDT_OPM_CONNECTOR_TYPE_UDI_EMBEDDED                         = 13,
+    DXGKMDT_OPM_CONNECTOR_TYPE_RESERVED                             = 14,
+    DXGKMDT_OPM_CONNECTOR_TYPE_MIRACAST                             = 15,
+    DXGKMDT_OPM_CONNECTOR_TYPE_TRANSPORT_AGNOSTIC_DIGITAL_MODE_A    = 16,
+    DXGKMDT_OPM_CONNECTOR_TYPE_TRANSPORT_AGNOSTIC_DIGITAL_MODE_B    = 17,
+    DXGKMDT_OPM_COPP_COMPATIBLE_CONNECTOR_TYPE_INTERNAL = 0x80000000
+} DXGKMDT_OPM_CONNECTOR_TYPE;
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Purpose: Monitor orientation awareness descriptor type.
+//
+typedef enum _D3DKMDT_MONITOR_ORIENTATION_AWARENESS
+{
+    D3DKMDT_MOA_UNINITIALIZED = 0,
+    D3DKMDT_MOA_NONE          = 1,
+    D3DKMDT_MOA_POLLED        = 2,
+    D3DKMDT_MOA_INTERRUPTIBLE = 3
+}
+D3DKMDT_MONITOR_ORIENTATION_AWARENESS;
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Purpose: Video present target descriptor type.
+//
+typedef struct _D3DKMDT_VIDEO_PRESENT_TARGET
+{
+    // Unique ID used to reference the respective video present target by the miniport and the OS.
+    D3DDDI_VIDEO_PRESENT_TARGET_ID  Id;
+
+    // Type of the video output technology (see D3DKMDT_VIDEO_OUTPUT_TECHNOLOGY for more details).
+    D3DKMDT_VIDEO_OUTPUT_TECHNOLOGY  VideoOutputTechnology;
+
+    // Type of the video output's HPD awareness (see D3DKMDT_VIDEO_OUTPUT_HPD_AWARENESS for more details).
+    DXGK_CHILD_DEVICE_HPD_AWARENESS  VideoOutputHpdAwareness;
+
+    D3DKMDT_MONITOR_ORIENTATION_AWARENESS  MonitorOrientationAwareness;
+
+    // NOTE: On monitor arrival, OS will leave monitor mode set empty for monitors connected to video outputs
+    //       supporting SDTV modes, expecting miniport to populate modes it wants to expose for that monitor.
+    //
+    // NOTE: This predicate is also used when selecting video output for presentation on a TV via
+    //       APIs that don't support explicit specification of monitors/video outputs (e.g. VIDEOPARAMETERS).
+    //
+    // Predicate specifying whether corresponding video output supports SDTV modes.
+    BOOLEAN  SupportsSdtvModes;
+}
+D3DKMDT_VIDEO_PRESENT_TARGET;
+
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Purpose: Video present target mode GTF compliance descriptor type.
+typedef enum _D3DKMDT_GTFCOMPLIANCE
+{
+    D3DKMDT_GTF_UNINITIALIZED = 0,
+    D3DKMDT_GTF_COMPLIANT     = 1,
+    D3DKMDT_GTF_NOTCOMPLIANT  = 2
+}
+D3DKMDT_GTFCOMPLIANCE;
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Purpose: VidPN target mode preference descriptor type.
+
+typedef enum _D3DKMDT_MODE_PREFERENCE
+{
+    D3DKMDT_MP_UNINITIALIZED = 0,
+    D3DKMDT_MP_PREFERRED     = 1,
+    D3DKMDT_MP_NOTPREFERRED  = 2,
+}
+D3DKMDT_MODE_PREFERENCE;
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Purpose: Video signal info descriptor type.
+//
+// Remarks: Video signal info is the mode of operation of a given video output that's driving a connected
+//          moitor and is driven by an internal video output codec.
+//          Note that this descriptor supersedes subset of the XDDM's VIDEO_MODE_INFORMATION structure
+//          related to video mode. In XDDM, both video and rendering modes were described in this struct.
+//          LDDM separates these two notions, and hence their descriptors.
+//          The video standard field, vidStandard, should be used for video mode comparisons, when it's
+//          set to a well-defined video standard. Note that most of the standard modes do not comply with
+//          the VESA GTF frequency constraints.
+//
+//          If color basis of the target mode does not correspond to that of the source mode, appropriate
+//          color conversion is performed by the respective video output codec.
+//
+typedef struct _D3DKMDT_VIDEO_SIGNAL_INFO
+{
+    // Video mode standard this mode is defined by (if any).
+    D3DKMDT_VIDEO_SIGNAL_STANDARD  VideoStandard;
+
+    // Video signal's size in pixels (i.e. HTotal & VTotal).
+    D3DKMDT_2DREGION  TotalSize;
+
+    // Presented image's size in active pixels (i.e. HActive & VActive).
+    D3DKMDT_2DREGION  ActiveSize;
+
+    // Vertical refresh frequency (in Hz).
+    D3DDDI_RATIONAL  VSyncFreq;
+
+    // Horizontal refresh frequency (in Hz).
+    D3DDDI_RATIONAL  HSyncFreq;
+
+    // Pixel clock rate (in Hz).
+    SIZE_T  PixelRate;
+
+    union
+    {
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM1_3_M1)
+        struct
+        {
+            // Scan line ordering (e.g. progressive, interlaced).
+            D3DDDI_VIDEO_SIGNAL_SCANLINE_ORDERING ScanLineOrdering : 3;
+
+            // Vertical refresh frequency divider
+            UINT VSyncFreqDivider               : 6;
+
+            UINT Reserved                       : 23;
+
+        } AdditionalSignalInfo;
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM1_3_M1
+
+        // Scan line ordering (e.g. progressive, interlaced).
+        D3DDDI_VIDEO_SIGNAL_SCANLINE_ORDERING  ScanLineOrdering;
+    };
+}
+D3DKMDT_VIDEO_SIGNAL_INFO;
+
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_2)
+
+#define D3DKMDT_BITS_PER_COMPONENT_06 0x01
+#define D3DKMDT_BITS_PER_COMPONENT_08 0x02
+#define D3DKMDT_BITS_PER_COMPONENT_10 0x04
+#define D3DKMDT_BITS_PER_COMPONENT_12 0x08
+#define D3DKMDT_BITS_PER_COMPONENT_14 0x10
+#define D3DKMDT_BITS_PER_COMPONENT_16 0x20
+
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_2)
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Purpose: Video present target mode ID type.
+typedef UINT  D3DKMDT_VIDEO_PRESENT_TARGET_MODE_ID;
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Purpose: Describe bit-fields for wire format and preference
+//  In the D3DKMDT_VIDPN_TARGET_MODE structure all fields are valid and the wire format fields indicate
+//  supported bit depts per color encoding format.
+//  In the DXGK_SET_TIMING_PATH_INFO structure the Preference field is unused so should be ignored by the
+//  driver and will be set to zero by the OS in case of future usage.  The wire format fields are used to
+//  indicate which wire format has been selected so only one bit across the five fields will be set.
+//
+
+typedef union _D3DKMDT_WIRE_FORMAT_AND_PREFERENCE
+{
+    struct
+    {
+        D3DKMDT_MODE_PREFERENCE Preference  : 2;
+
+        // Flags indicating supported formats of color components transmitted between source and target
+        UINT                    Rgb         : 6;
+        UINT                    YCbCr444    : 6;
+        UINT                    YCbCr422    : 6;
+        UINT                    YCbCr420    : 6;
+        UINT                    Intensity   : 6;
+    };
+    UINT Value;
+} D3DKMDT_WIRE_FORMAT_AND_PREFERENCE, *PD3DKMDT_WIRE_FORMAT_AND_PREFERENCE;
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Purpose: Video present target mode descriptor type.
+typedef struct _D3DKMDT_VIDPN_TARGET_MODE
+{
+    // Identifier unique within the set this mode is part of.
+    D3DKMDT_VIDEO_PRESENT_TARGET_MODE_ID  Id;
+
+    // Video signal parameters.
+    D3DKMDT_VIDEO_SIGNAL_INFO  VideoSignalInfo;
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_2)
+    union
+    {
+        D3DKMDT_WIRE_FORMAT_AND_PREFERENCE  WireFormatAndPreference;
+        struct
+        {
+            D3DKMDT_MODE_PREFERENCE Preference  : 2;
+            UINT                                :30;
+        };
+    };
+#else
+    // Predicate specifying whether this mode is preferred by the adapter given the mode pinned on
+    // the source of the respective present path.
+    D3DKMDT_MODE_PREFERENCE  Preference;
+#endif // (DXGKDDI_INTERFACE_VERSION < DXGKDDI_INTERFACE_VERSION_WDDM2_2)
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_9)
+
+    D3DDDI_RATIONAL MinimumVSyncFreq;
+
+#endif // (DXGKDDI_INTERFACE_VERSION < DXGKDDI_INTERFACE_VERSION_WDDM2_9)
+
+}
+D3DKMDT_VIDPN_TARGET_MODE;
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Purpose: VESA Display ID detailed timing type I.
+
+#pragma pack(push, 1)
+#define DISPLAYID_DETAILED_TIMING_TYPE_I_SIZE     20
+
+// Enum specifying monitor's aspect ratio (see DISPLAYID_DETAILED_TIMING_TYPE_I.AspectRatio)
+enum _DISPLAYID_DETAILED_TIMING_TYPE_I_ASPECT_RATIO
+{
+    DIDDT1_AspectRatio_1x1   = 0,               // 000 = 1:1
+    DIDDT1_AspectRatio_5x4   = 1,               // 001 = 5:4
+    DIDDT1_AspectRatio_4x3   = 2,               // 010 = 4:3
+    DIDDT1_AspectRatio_15x9  = 3,               // 011 = 15:9
+    DIDDT1_AspectRatio_16x9  = 4,               // 100 = 16:9
+    DIDDT1_AspectRatio_16x10 = 5,               // 101 = 16:10
+};
+
+enum _DISPLAYID_DETAILED_TIMING_TYPE_I_SCANNING_MODE
+{
+    DIDDT1_Progressive       = 0,               // 0 = Progressive mode
+    DIDDT1_Interlaced        = 1,               // 1 = Interlaced mode
+};
+
+enum _DISPLAYID_DETAILED_TIMING_TYPE_I_STEREO_MODE
+{
+    DIDDT1_Monoscopic        = 0,               // 00 = Monoscopic (no stereo) mode
+    DIDDT1_Stereo            = 1,               // 01 = Stereo mode
+    DIDDT1_Dependent         = 2,               // 10 = Stereo mode despends on user action
+};
+
+enum _DISPLAYID_DETAILED_TIMING_TYPE_I_SYNC_POLARITY
+{
+    DIDDT1_Sync_Positive     = 0,
+    DIDDT1_Sync_Negative     = 1,
+};
+
+typedef struct _DISPLAYID_DETAILED_TIMING_TYPE_I
+{
+    struct
+    {
+        ULONG  PixelClock       : 24;           // Pixel clock / 10000
+        ULONG  AspectRatio      :  3;           // Aspect ratio
+        ULONG  Reserved         :  1;
+        ULONG  ScanningType     :  1;           // Frame scanning type
+        ULONG  StereoMode       :  2;           // 3D stereo mode
+        ULONG  PreferredTiming  :  1;           // preferred timing
+    };
+
+    USHORT  HorizontalActivePixels;             // Horizontal active image pixel number
+    USHORT  HorizontalBlankPixels;              // Horizontal blank pixel number
+    struct
+    {
+        USHORT  HorizontalFrontPorch    : 15;   // Horizontal offset (front porch) pixel number
+        USHORT  HorizontalSyncPolarity  :  1;   // Horizontal sync polarity
+    };
+    USHORT  HorizontalSyncWidth;                // Horizontal sync pixel number
+
+    USHORT  VerticalActiveLines;                // Number of lines of vertical active image
+    USHORT  VerticalBlankLines;                 // Number of lines of vertical blank
+    struct
+    {
+        USHORT  VerticalFrontPorch    : 15;     // Number of lines of vertical offset (front porch)
+        USHORT  VerticalSyncPolarity  :  1;     // Vertical sync polarity
+    };
+    USHORT  VerticalSyncWidth;                  // Number of lines of vertical sync
+}DISPLAYID_DETAILED_TIMING_TYPE_I;
+
+C_ASSERT(sizeof(DISPLAYID_DETAILED_TIMING_TYPE_I) == DISPLAYID_DETAILED_TIMING_TYPE_I_SIZE);
+
+#pragma pack(pop)
+
+typedef struct _DXGK_TARGETMODE_DETAIL_TIMING
+{
+    // Video standard this detail timing comes from.
+    D3DKMDT_VIDEO_SIGNAL_STANDARD       VideoStandard;
+
+    // ID of this detail timing in VideoStandard.
+    UINT                                TimingId;
+
+    // Detail timing.
+    DISPLAYID_DETAILED_TIMING_TYPE_I    DetailTiming;
+}DXGK_TARGETMODE_DETAIL_TIMING;
+
+
+// Structure of hardware capability
+typedef struct _D3DKMDT_VIDPN_HW_CAPABILITY
+{
+    UINT DriverRotation             : 1;
+    UINT DriverScaling              : 1;
+    UINT DriverCloning              : 1;
+    UINT DriverColorConvert         : 1;
+    UINT DriverLinkedAdapaterOutput : 1;
+    UINT DriverRemoteDisplay        : 1;
+    UINT Reserved                   : 26;
+}
+D3DKMDT_VIDPN_HW_CAPABILITY;
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Purpose: Video present target mode ID type.
+typedef UINT  D3DKMDT_MONITOR_SOURCE_MODE_ID;
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Purpose: Monitor capability origin type.
+typedef enum _D3DKMDT_MONITOR_CAPABILITIES_ORIGIN
+{
+    D3DKMDT_MCO_UNINITIALIZED                      = 0, // mode information is coming from the:
+    D3DKMDT_MCO_DEFAULTMONITORPROFILE              = 1, //  + default monitor profile.
+    D3DKMDT_MCO_MONITORDESCRIPTOR                  = 2, //  + monitor's descriptor.
+    D3DKMDT_MCO_MONITORDESCRIPTOR_REGISTRYOVERRIDE = 3, //  + registry override of the monitor descriptor.
+    D3DKMDT_MCO_SPECIFICCAP_REGISTRYOVERRIDE       = 4, //  + registry override of a specific capability.
+    D3DKMDT_MCO_DRIVER                             = 5, //  + display adapter driver.
+}
+D3DKMDT_MONITOR_CAPABILITIES_ORIGIN;
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Purpose: Monitor timing type.
+typedef enum _D3DKMDT_MONITOR_TIMING_TYPE
+{
+    D3DKMDT_MTT_UNINITIALIZED         = 0, // mode timing information is coming from:
+    D3DKMDT_MTT_ESTABLISHED           = 1, //  + established timings block.
+    D3DKMDT_MTT_STANDARD              = 2, //  + standard timings block.
+    D3DKMDT_MTT_EXTRASTANDARD         = 3, //  + extra standard timings block.
+    D3DKMDT_MTT_DETAILED              = 4, //  + detailed timings block.
+    D3DKMDT_MTT_DEFAULTMONITORPROFILE = 5, //  + default monitor profile.
+    D3DKMDT_MTT_DRIVER                = 6, //  + display adapter driver.
+}
+D3DKMDT_MONITOR_TIMING_TYPE;
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Purpose: Video present target mode descriptor type.
+typedef struct _D3DKMDT_MONITOR_SOURCE_MODE
+{
+    // Identifier unique within the set this mode is part of.
+    D3DKMDT_MONITOR_SOURCE_MODE_ID  Id;
+
+    // Video signal parameters.
+    D3DKMDT_VIDEO_SIGNAL_INFO  VideoSignalInfo;
+
+    // Color basis with respect to which monitor is presenting the pixels sampled from the video signal.
+    D3DKMDT_COLOR_BASIS  ColorBasis;
+
+    // Supported dynamic range of each of the pixel color component coefficients by the monitor's
+    // presentational technology - e.g. for a DFP LCD with 12-bit bit-depth, this will be (4, 4, 4, 0).
+    // A TV supporting 10-bit per component YCbCr this will be (10, 10, 10, 0) regardless of chroma compression.
+    D3DKMDT_COLOR_COEFF_DYNAMIC_RANGES  ColorCoeffDynamicRanges;
+
+    // Origins of the monitor source mode information.
+    D3DKMDT_MONITOR_CAPABILITIES_ORIGIN  Origin;
+
+    // Predicate specifying whether this mode is preferred by the monitor connected to the respective video output.
+    D3DKMDT_MODE_PREFERENCE  Preference;
+}
+D3DKMDT_MONITOR_SOURCE_MODE;
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Purpose: Frequency range type.
+typedef struct _D3DKMDT_FREQUENCY_RANGE
+{
+    // Minimum vertical refresh frequency (in Hz) supported by the monitor.
+    D3DDDI_RATIONAL  MinVSyncFreq;
+
+    // Maximum vertical refresh frequency (in Hz) supported by the monitor.
+    D3DDDI_RATIONAL  MaxVSyncFreq;
+
+    // Minimum horizontal refresh frequency (in Hz) supported by the monitor.
+    D3DDDI_RATIONAL  MinHSyncFreq;
+
+    // Maximum horizontal refresh frequency (in Hz) supported by the monitor.
+    D3DDDI_RATIONAL  MaxHSyncFreq;
+}
+D3DKMDT_FREQUENCY_RANGE;
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Purpose: Monitor frequency range constraint type.
+typedef enum _D3DKMDT_MONITOR_FREQUENCY_RANGE_CONSTRAINT
+{
+    D3DKMDT_MFRC_UNINITIALIZED = 0,
+    D3DKMDT_MFRC_ACTIVESIZE    = 1,
+    D3DKMDT_MFRC_MAXPIXELRATE  = 2
+}
+D3DKMDT_MONITOR_FREQUENCY_RANGE_CONSTRAINT;
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Purpose: Monitor frequency range type.
+typedef struct _D3DKMDT_MONITOR_FREQUENCY_RANGE
+{
+    // Origins of the monitor frequency range information.
+    D3DKMDT_MONITOR_CAPABILITIES_ORIGIN  Origin;
+
+    // Frequency range limits.
+    D3DKMDT_FREQUENCY_RANGE  RangeLimits;
+
+    // Type of the frequency range constraint.
+    D3DKMDT_MONITOR_FREQUENCY_RANGE_CONSTRAINT  ConstraintType;
+
+    // Constraint under which this frequency range is supported.
+    union
+    {
+        // Active region size this frequency range applies to.
+        D3DKMDT_2DREGION  ActiveSize;
+
+        // Maximum pixel clock rate (in Hz) to which this pixel rate applies.
+        SIZE_T  MaxPixelRate;
+
+    } Constraint;
+}
+D3DKMDT_MONITOR_FREQUENCY_RANGE;
+
+
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// VidPN present paths
+
+// VidPN present path index used during enumeration of paths satisfying certain criteria
+// (e.g. originating from the same source).
+typedef SIZE_T  D3DKMDT_VIDPN_PRESENT_PATH_INDEX;
+
+// Purpose: VidPN present path scaling type.
+typedef enum _D3DKMDT_VIDPN_PRESENT_PATH_SCALING
+{
+    D3DKMDT_VPPS_UNINITIALIZED           = 0,
+
+    // For the following transformation, spatial resolutions must be equal on both the source and the target.
+
+    // Source content is not modified in any way.
+    D3DKMDT_VPPS_IDENTITY                = 1,
+
+    // For the following three transformations, spatial resolution of the source differs from that of the target.
+
+    // Source content is centered on the target.
+    D3DKMDT_VPPS_CENTERED                = 2,
+
+    // Source content is scaled to fit the target, no aspect ratio preserving.
+    D3DKMDT_VPPS_STRETCHED               = 3,
+
+    // Source content is scaled to fit the target. Aspect ratio preserving.
+    D3DKMDT_VPPS_ASPECTRATIOCENTEREDMAX  = 4,
+
+    // Scaling that cannot be described by any other D3DKMDT_VPPS_XXX value
+    D3DKMDT_VPPS_CUSTOM                  = 5,
+
+
+    // Reserved for internal OS use
+    D3DKMDT_VPPS_RESERVED1               = 253,
+
+    // Source content scaling mode is not pinned.
+    D3DKMDT_VPPS_UNPINNED                = 254,
+
+    // OS does not specify the scaling mode, and miniport should decide based on its own settings.
+    D3DKMDT_VPPS_NOTSPECIFIED            = 255
+}
+D3DKMDT_VIDPN_PRESENT_PATH_SCALING;
+
+
+// Purpose: VidPN present path rotation type.
+typedef enum _D3DKMDT_VIDPN_PRESENT_PATH_ROTATION
+{
+    D3DKMDT_VPPR_UNINITIALIZED = 0,
+
+    // Source content is not modified in any way.
+    D3DKMDT_VPPR_IDENTITY      = 1,
+
+    // Source content is rotated 90 degrees.
+    D3DKMDT_VPPR_ROTATE90      = 2,
+
+    // Source content is rotated 180 degrees.
+    D3DKMDT_VPPR_ROTATE180     = 3,
+
+    // Source content is rotated 270 degrees.
+    D3DKMDT_VPPR_ROTATE270     = 4,
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM1_3_PATH_INDEPENDENT_ROTATION)
+    // Source content is not modified in any way. Driver should rotate this content an extra 90 degrees.
+    D3DKMDT_VPPR_IDENTITY_OFFSET90      = 5,
+
+    // Source content is rotated 90 degrees. Driver should rotate this content an extra 90 degrees.
+    D3DKMDT_VPPR_ROTATE90_OFFSET90      = 6,
+
+    // Source content is rotated 180 degrees. Driver should rotate this content an extra 90 degrees.
+    D3DKMDT_VPPR_ROTATE180_OFFSET90     = 7,
+
+    // Source content is rotated 270 degrees. Driver should rotate this content an extra 90 degrees.
+    D3DKMDT_VPPR_ROTATE270_OFFSET90     = 8,
+
+    // Source content is not modified in any way. Driver should rotate this content an extra 180 degrees.
+    D3DKMDT_VPPR_IDENTITY_OFFSET180      = 9,
+
+    // Source content is rotated 90 degrees. Driver should rotate this content an extra 180 degrees.
+    D3DKMDT_VPPR_ROTATE90_OFFSET180      = 10,
+
+    // Source content is rotated 180 degrees. Driver should rotate this content an extra 180 degrees.
+    D3DKMDT_VPPR_ROTATE180_OFFSET180     = 11,
+
+    // Source content is rotated 270 degrees. Driver should rotate this content an extra 180 degrees.
+    D3DKMDT_VPPR_ROTATE270_OFFSET180     = 12,
+
+    // Source content is not modified in any way. Driver should rotate this content an extra 270 degrees.
+    D3DKMDT_VPPR_IDENTITY_OFFSET270      = 13,
+
+    // Source content is rotated 90 degrees. Driver should rotate this content an extra 270 degrees.
+    D3DKMDT_VPPR_ROTATE90_OFFSET270      = 14,
+
+    // Source content is rotated 180 degrees. Driver should rotate this content an extra 270 degrees.
+    D3DKMDT_VPPR_ROTATE180_OFFSET270     = 15,
+
+    // Source content is rotated 270 degrees. Driver should rotate this content an extra 270 degrees.
+    D3DKMDT_VPPR_ROTATE270_OFFSET270     = 16,
+#endif // DXGKDDI_INTERFACE_VERSION
+
+    // Source content rotation setting is not pinned.
+    D3DKMDT_VPPR_UNPINNED      = 254,
+
+    // OS does not specify the rotation mode, and miniport should decide based on its own settings.
+    D3DKMDT_VPPR_NOTSPECIFIED  = 255
+}
+D3DKMDT_VIDPN_PRESENT_PATH_ROTATION;
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM1_3_PATH_INDEPENDENT_ROTATION)
+
+__inline
+D3DKMDT_VIDPN_PRESENT_PATH_ROTATION D3DKMDT_VPPR_GET_OFFSET_ROTATION(D3DKMDT_VIDPN_PRESENT_PATH_ROTATION Rotation)
+{
+    if ((Rotation >= D3DKMDT_VPPR_IDENTITY) &&
+        (Rotation <= D3DKMDT_VPPR_ROTATE270_OFFSET270))
+    {
+        Rotation = (D3DKMDT_VIDPN_PRESENT_PATH_ROTATION)(((Rotation - 1) / 4) + 1);
+    }
+    return Rotation;
+}
+
+__inline
+D3DKMDT_VIDPN_PRESENT_PATH_ROTATION D3DKMDT_VPPR_GET_CONTENT_ROTATION_PART(D3DKMDT_VIDPN_PRESENT_PATH_ROTATION Rotation)
+{
+    if ((Rotation >= D3DKMDT_VPPR_IDENTITY_OFFSET90) &&
+        (Rotation <= D3DKMDT_VPPR_ROTATE270_OFFSET270))
+    {
+        Rotation = (D3DKMDT_VIDPN_PRESENT_PATH_ROTATION)(((Rotation - 1) % 4) + 1);
+    }
+    return Rotation;
+}
+
+__inline
+D3DKMDT_VIDPN_PRESENT_PATH_ROTATION D3DKMDT_VPPR_GET_CONTENT_ROTATION(D3DKMDT_VIDPN_PRESENT_PATH_ROTATION Rotation)
+{
+    if ((Rotation >= D3DKMDT_VPPR_IDENTITY_OFFSET90) &&
+        (Rotation <= D3DKMDT_VPPR_ROTATE270_OFFSET270))
+    {
+        D3DKMDT_VIDPN_PRESENT_PATH_ROTATION ContentPart = D3DKMDT_VPPR_GET_CONTENT_ROTATION_PART(Rotation);
+        D3DKMDT_VIDPN_PRESENT_PATH_ROTATION OffsetPart = D3DKMDT_VPPR_GET_OFFSET_ROTATION(Rotation);
+        Rotation = (D3DKMDT_VIDPN_PRESENT_PATH_ROTATION)((((ContentPart - 1) + (OffsetPart - 1)) % 4) + 1);
+    }
+    return Rotation;
+}
+#endif // DXGKDDI_INTERFACE_VERSION
+
+
+#define D3DKMDT_SCALING_SUPPORT_MASK 0x1f;
+
+// Purpose: Specifies what scaling modes are supported given current path configuration.
+typedef struct _D3DKMDT_VIDPN_PRESENT_PATH_SCALING_SUPPORT
+{
+    UINT Identity                 : 1;
+    UINT Centered                 : 1;
+    UINT Stretched                : 1;
+    UINT AspectRatioCenteredMax   : 1;
+    UINT Custom                   : 1;
+} D3DKMDT_VIDPN_PRESENT_PATH_SCALING_SUPPORT;
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM1_3_PATH_INDEPENDENT_ROTATION)
+#define D3DKMDT_ROTATION_SUPPORT_MASK 0xff;
+#else
+#define D3DKMDT_ROTATION_SUPPORT_MASK 0xf;
+#endif // DXGKDDI_INTERFACE_VERSION
+
+// Purpose: Specifies what rotation modes are supported given current path configuration.
+typedef struct _D3DKMDT_VIDPN_PRESENT_PATH_ROTATION_SUPPORT
+{
+    UINT Identity   : 1;
+    UINT Rotate90   : 1;
+    UINT Rotate180  : 1;
+    UINT Rotate270  : 1;
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM1_3_PATH_INDEPENDENT_ROTATION)
+    UINT Offset0    : 1;
+    UINT Offset90   : 1;
+    UINT Offset180  : 1;
+    UINT Offset270  : 1;
+#endif // DXGKDDI_INTERFACE_VERSION
+} D3DKMDT_VIDPN_PRESENT_PATH_ROTATION_SUPPORT;
+
+// Purpose: Combines all the transformation related fields into one structure.
+typedef struct _D3DKMDT_VIDPN_PRESENT_PATH_TRANSFORMATION
+{
+    // Scaling applied to the content presented on this video present path.
+    D3DKMDT_VIDPN_PRESENT_PATH_SCALING  Scaling;
+
+    // Scaling support given the currently pinned modes.
+    D3DKMDT_VIDPN_PRESENT_PATH_SCALING_SUPPORT ScalingSupport;
+
+    // Rotation applied to the content presented on this video present path.
+    D3DKMDT_VIDPN_PRESENT_PATH_ROTATION Rotation;
+
+    // Rotation support given the currently pinned modes.
+    D3DKMDT_VIDPN_PRESENT_PATH_ROTATION_SUPPORT RotationSupport;
+} D3DKMDT_VIDPN_PRESENT_PATH_TRANSFORMATION;
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Purpose: VidPN present path importance ordinal type.
+//
+// Note: Higher order importance ordinals can be used (upto 255), but only the first 10 have been explicitly named.
+//
+typedef enum _D3DKMDT_VIDPN_PRESENT_PATH_IMPORTANCE
+{
+    D3DKMDT_VPPI_UNINITIALIZED = 0,
+    D3DKMDT_VPPI_PRIMARY       = 1,
+    D3DKMDT_VPPI_SECONDARY     = 2,
+    D3DKMDT_VPPI_TERTIARY      = 3,
+    D3DKMDT_VPPI_QUATERNARY    = 4,
+    D3DKMDT_VPPI_QUINARY       = 5,
+    D3DKMDT_VPPI_SENARY        = 6,
+    D3DKMDT_VPPI_SEPTENARY     = 7,
+    D3DKMDT_VPPI_OCTONARY      = 8,
+    D3DKMDT_VPPI_NONARY        = 9,
+    D3DKMDT_VPPI_DENARY        = 10,
+}
+D3DKMDT_VIDPN_PRESENT_PATH_IMPORTANCE;
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Purpose: VidPN present path content ordinal type.
+//
+// Indicates whether the content being displayed is video or graphics.
+//
+typedef enum _D3DKMDT_VIDPN_PRESENT_PATH_CONTENT
+{
+    D3DKMDT_VPPC_UNINITIALIZED = 0,
+
+    // Miniport should optimize presentation of the present path for graphics content.
+    D3DKMDT_VPPC_GRAPHICS      = 1,
+
+    // Miniport should optimize presentation of the present path for video content.
+    D3DKMDT_VPPC_VIDEO         = 2,
+
+    // OS does not specify the content type, and miniport should decide based on its own settings.
+    D3DKMDT_VPPC_NOTSPECIFIED  = 255
+}
+D3DKMDT_VIDPN_PRESENT_PATH_CONTENT;
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Purpose: VidPN present path macrovision information.
+//
+// Contains macrovision caps and controls.
+//
+typedef enum _D3DKMDT_VIDPN_PRESENT_PATH_COPYPROTECTION_TYPE
+{
+    D3DKMDT_VPPMT_UNINITIALIZED             = 0,
+
+    D3DKMDT_VPPMT_NOPROTECTION              = 1,
+
+    D3DKMDT_VPPMT_MACROVISION_APSTRIGGER    = 2,
+
+    D3DKMDT_VPPMT_MACROVISION_FULLSUPPORT   = 3,
+
+}
+D3DKMDT_VIDPN_PRESENT_PATH_COPYPROTECTION_TYPE;
+
+typedef struct _D3DKMDT_VIDPN_PRESENT_PATH_COPYPROTECTION_SUPPORT
+{
+    UINT NoProtection          : 1;
+    UINT MacroVisionApsTrigger : 1;
+    UINT MacroVisionFull       : 1;
+    UINT Reserved              : 29;
+}
+D3DKMDT_VIDPN_PRESENT_PATH_COPYPROTECTION_SUPPORT;
+
+#define D3DKMDT_MACROVISION_OEMCOPYPROTECTION_SIZE  256
+
+typedef struct _D3DKMDT_VIDPN_PRESENT_PATH_COPYPROTECTION
+{
+    // Macrovision controls.
+    D3DKMDT_VIDPN_PRESENT_PATH_COPYPROTECTION_TYPE CopyProtectionType;
+    UINT                                           APSTriggerBits;
+    BYTE                                           OEMCopyProtection[D3DKMDT_MACROVISION_OEMCOPYPROTECTION_SIZE];
+
+    // Level of available copy protection support.
+    D3DKMDT_VIDPN_PRESENT_PATH_COPYPROTECTION_SUPPORT CopyProtectionSupport;
+} D3DKMDT_VIDPN_PRESENT_PATH_COPYPROTECTION;
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Purpose: VidPN present path gamma ramp descriptor type.
+//
+typedef struct _D3DKMDT_GAMMA_RAMP
+{
+    D3DDDI_GAMMARAMP_TYPE    Type;
+    SIZE_T                   DataSize;
+
+    // If (Type == D3DDDI_GAMMARAMP_DEFAULT), (DataSize == 0) and (Data.pRaw == NULL )
+    union
+    {
+        D3DDDI_GAMMA_RAMP_RGB256x3x16*      pRgb256x3x16;       // Type == D3DDDI_GAMMARAMP_RGB256x3x16.
+        D3DDDI_GAMMA_RAMP_DXGI_1*           pDxgi1;             // Type == D3DDDI_GAMMARAMP_DXGI_1.
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_3)
+        D3DKMDT_3x4_COLORSPACE_TRANSFORM*   p3x4;               // Type == D3DDDI_GAMMARAMP_MATRIX_3x4.
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_3
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_6)
+        D3DKMDT_COLORSPACE_TRANSFORM_MATRIX_V2* pMatrixV2;     // Type == D3DDDI_GAMMARAMP_MATRIX_V2.
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_6
+        VOID*                               pRaw;
+    }
+    Data;
+}
+D3DKMDT_GAMMA_RAMP;
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Purpose: Video present target to source mapping.
+//
+// Remarks: This type is used to describe a mapping from a single video present target to a single
+//          video present source in a VidPN topology.
+//
+typedef struct _D3DKMDT_VIDPN_PRESENT_PATH
+{
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID  VidPnSourceId;
+
+    D3DDDI_VIDEO_PRESENT_TARGET_ID  VidPnTargetId;
+
+    // Video present path importance ordinal (e.g. path presenting the primary view may have higher
+    // importance set on it in order to guarantee that it gets the best source/target mode sets).
+    D3DKMDT_VIDPN_PRESENT_PATH_IMPORTANCE  ImportanceOrdinal;
+
+    // Contains all the transformation related fields.
+    D3DKMDT_VIDPN_PRESENT_PATH_TRANSFORMATION ContentTransformation;
+
+    // Storing deltas for visible/active pixels mapping rather than visible pixels'
+    // size & offset has the added benefit of ideal/default state being zeros.
+
+    // Monitor screen's offset of visible pixels' top-left corner from
+    // video signal's active pixels top-left corner.
+    // Note: Default = (0,0).
+    D3DKMDT_2DOFFSET  VisibleFromActiveTLOffset;
+
+    // Monitor screen's offset of visible pixels' bottom-right corner from
+    // video signal's active pixels bottom-right corner.
+    // Note: Default = (0,0).
+    D3DKMDT_2DOFFSET  VisibleFromActiveBROffset;
+
+    // Video signal color basis with respect to which video output codec encodes the pixels from the respective
+    // source's primary surface (e.g. on HDMI this can be either RGB or YCbCr).
+    D3DKMDT_COLOR_BASIS  VidPnTargetColorBasis;
+
+    // Supported dynamic range of each of the color bases' coefficients by the video output codec's output
+    // E.g. With a DAC scaning out A2R10G10B10 primary surface at R8G8B8 color resolution, this would be (8,8,8,0),
+    D3DKMDT_COLOR_COEFF_DYNAMIC_RANGES  VidPnTargetColorCoeffDynamicRanges;
+
+    // Indicates the content being diplayed.  The driver can use this to determine whether the flicker filter
+    // and overscan should be enabled or disabled.
+    D3DKMDT_VIDPN_PRESENT_PATH_CONTENT Content;
+
+    // Contains all the copy protection related fields.
+    D3DKMDT_VIDPN_PRESENT_PATH_COPYPROTECTION CopyProtection;
+
+    // A lookup table (LUT) used to compensate intensity of presented content for the color response of the monitor
+    // connected to present path's target.
+    D3DKMDT_GAMMA_RAMP  GammaRamp;
+}
+D3DKMDT_VIDPN_PRESENT_PATH;
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Purpose: Specifies whether to ignore monitor connectivity checks or enforce them.
+//
+typedef enum _D3DKMDT_MONITOR_CONNECTIVITY_CHECKS
+{
+    D3DKMDT_MCC_UNINITIALIZED = 0,
+    D3DKMDT_MCC_IGNORE        = 1,
+    D3DKMDT_MCC_ENFORCE       = 2
+}
+D3DKMDT_MONITOR_CONNECTIVITY_CHECKS;
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Purpose: Type of the owner whose mode set does not change during an enumeration.
+//
+// Remarks: When OS pins/unpins a mode in one of VidPN's mode sets, the only mode set that is guaranteed to
+//          stay the same is the mode set whose mode was pinned/unpinned. Enumeration pivot lets the OS
+//          specify to the miniport which mode set it should not update (because this mode set could not have
+//          been invalidated as a result of the change the OS made to the VidPN.
+//
+typedef enum _D3DKMDT_ENUMCOFUNCMODALITY_PIVOT_TYPE
+{
+    D3DKMDT_EPT_UNINITIALIZED,
+    D3DKMDT_EPT_VIDPNSOURCE,
+    D3DKMDT_EPT_VIDPNTARGET,
+    D3DKMDT_EPT_SCALING,
+    D3DKMDT_EPT_ROTATION,
+    D3DKMDT_EPT_NOPIVOT
+}
+D3DKMDT_ENUMCOFUNCMODALITY_PIVOT_TYPE;
+
+//
+// Monitor descriptor related types.
+//
+
+typedef UINT  D3DKMDT_MONITOR_DESCRIPTOR_ID;
+
+typedef enum _D3DKMDT_MONITOR_DESCRIPTOR_TYPE
+{
+    D3DKMDT_MDT_UNINITIALIZED          = 0,
+    D3DKMDT_MDT_VESA_EDID_V1_BASEBLOCK = 1,
+    D3DKMDT_MDT_VESA_EDID_V1_BLOCKMAP  = 2,
+    D3DKMDT_MDT_OTHER                  = 255
+}
+D3DKMDT_MONITOR_DESCRIPTOR_TYPE;
+
+typedef struct _D3DKMDT_MONITOR_DESCRIPTOR
+{
+    D3DKMDT_MONITOR_DESCRIPTOR_ID        Id;
+    D3DKMDT_MONITOR_DESCRIPTOR_TYPE      Type;
+    SIZE_T                               DataSize;
+    VOID*                                pData;
+    D3DKMDT_MONITOR_CAPABILITIES_ORIGIN  Origin;
+}
+D3DKMDT_MONITOR_DESCRIPTOR;
+
+
+typedef enum _D3DKMDT_STANDARDALLOCATION_TYPE
+{
+    D3DKMDT_STANDARDALLOCATION_SHAREDPRIMARYSURFACE  = 1,
+    D3DKMDT_STANDARDALLOCATION_SHADOWSURFACE         = 2,
+    D3DKMDT_STANDARDALLOCATION_STAGINGSURFACE        = 3,
+    D3DKMDT_STANDARDALLOCATION_GDISURFACE            = 4,
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_1)
+    D3DKMDT_STANDARDALLOCATION_VGPU                  = 5,
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_1)
+} D3DKMDT_STANDARDALLOCATION_TYPE;
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8)
+typedef enum _D3DKMDT_GRAPHICS_PREEMPTION_GRANULARITY
+{
+    D3DKMDT_GRAPHICS_PREEMPTION_NONE                = 0,
+    D3DKMDT_GRAPHICS_PREEMPTION_DMA_BUFFER_BOUNDARY = 100,
+    D3DKMDT_GRAPHICS_PREEMPTION_PRIMITIVE_BOUNDARY  = 200,
+    D3DKMDT_GRAPHICS_PREEMPTION_TRIANGLE_BOUNDARY   = 300,
+    D3DKMDT_GRAPHICS_PREEMPTION_PIXEL_BOUNDARY      = 400,
+    D3DKMDT_GRAPHICS_PREEMPTION_SHADER_BOUNDARY     = 500,
+} D3DKMDT_GRAPHICS_PREEMPTION_GRANULARITY;
+
+typedef enum _D3DKMDT_COMPUTE_PREEMPTION_GRANULARITY
+{
+    D3DKMDT_COMPUTE_PREEMPTION_NONE                     = 0,
+    D3DKMDT_COMPUTE_PREEMPTION_DMA_BUFFER_BOUNDARY      = 100,
+    D3DKMDT_COMPUTE_PREEMPTION_DISPATCH_BOUNDARY        = 200,
+    D3DKMDT_COMPUTE_PREEMPTION_THREAD_GROUP_BOUNDARY    = 300,
+    D3DKMDT_COMPUTE_PREEMPTION_THREAD_BOUNDARY          = 400,
+    D3DKMDT_COMPUTE_PREEMPTION_SHADER_BOUNDARY          = 500,
+} D3DKMDT_COMPUTE_PREEMPTION_GRANULARITY;
+
+typedef struct _D3DKMDT_PREEMPTION_CAPS
+{
+    D3DKMDT_GRAPHICS_PREEMPTION_GRANULARITY GraphicsPreemptionGranularity;
+    D3DKMDT_COMPUTE_PREEMPTION_GRANULARITY  ComputePreemptionGranularity;
+} D3DKMDT_PREEMPTION_CAPS;
+
+typedef struct _D3DKMT_WDDM_1_2_CAPS
+{
+    D3DKMDT_PREEMPTION_CAPS PreemptionCaps;
+    union
+    {
+        struct
+        {
+            UINT SupportNonVGA : 1;
+            UINT SupportSmoothRotation : 1;
+            UINT SupportPerEngineTDR : 1;
+            UINT SupportKernelModeCommandBuffer : 1;
+            UINT SupportCCD : 1;
+            UINT SupportSoftwareDeviceBitmaps : 1;
+            UINT SupportGammaRamp : 1;
+            UINT SupportHWCursor : 1;
+            UINT SupportHWVSync : 1;
+            UINT SupportSurpriseRemovalInHibernation : 1;
+            UINT Reserved : 22;
+        };
+        UINT Value;
+    };
+} D3DKMT_WDDM_1_2_CAPS;
+
+
+#endif // DXGKDDI_INTERFACE_VERSION
+
+typedef struct _D3DKMDT_SHAREDPRIMARYSURFACEDATA
+{
+    UINT                            Width;
+    UINT                            Height;
+    D3DDDIFORMAT                    Format;
+    D3DDDI_RATIONAL                 RefreshRate;
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID  VidPnSourceId;
+} D3DKMDT_SHAREDPRIMARYSURFACEDATA;
+
+typedef struct _D3DKMDT_SHADOWSURFACEDATA
+{
+    UINT                            Width;
+    UINT                            Height;
+    D3DDDIFORMAT                    Format;
+    UINT                            Pitch;      //out: Driver must return Pitch as this allocation will be lockabale
+} D3DKMDT_SHADOWSURFACEDATA;
+
+//Staging Surface is a surface created potentially
+//during present when a direct Blt to primary is
+//not possible in cases like multimon or sprites.
+//This surface is always in the format of D3DDDIFMT_X8R8G8B8
+
+typedef struct _D3DKMDT_STAGINGSURFACEDATA
+{
+    UINT                            Width;      //in: Width of the staging buffer
+    UINT                            Height;     //in: Height of the staging buffer
+    UINT                            Pitch;      //out: Driver must return Pitch as this allocation will be lockabale
+} D3DKMDT_STAGINGSURFACEDATA;
+
+typedef struct _D3DKMDT_GDISURFACEFLAGS
+{
+    union
+    {
+        struct
+        {
+            UINT Reserved       : 32;
+        };
+        UINT Value;
+    };
+} D3DKMDT_GDISURFACEFLAGS;
+
+typedef enum _D3DKMDT_GDISURFACETYPE
+{
+    D3DKMDT_GDISURFACE_INVALID              = 0,
+    D3DKMDT_GDISURFACE_TEXTURE              = 1,
+    D3DKMDT_GDISURFACE_STAGING_CPUVISIBLE   = 2,
+    D3DKMDT_GDISURFACE_STAGING              = 3,
+    D3DKMDT_GDISURFACE_LOOKUPTABLE          = 4,
+    D3DKMDT_GDISURFACE_EXISTINGSYSMEM       = 5,
+    D3DKMDT_GDISURFACE_TEXTURE_CPUVISIBLE   = 6,
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM1_3_M1)
+    D3DKMDT_GDISURFACE_TEXTURE_CROSSADAPTER = 7,
+    D3DKMDT_GDISURFACE_TEXTURE_CPUVISIBLE_CROSSADAPTER = 8,     // Reserved for OS
+#endif // DXGKDDI_INTERFACE_VERSION
+} D3DKMDT_GDISURFACETYPE;
+
+typedef struct _D3DKMDT_GDISURFACEDATA
+{
+    UINT                    Width;
+    UINT                    Height;
+    D3DDDIFORMAT            Format;
+    D3DKMDT_GDISURFACETYPE  Type;
+    D3DKMDT_GDISURFACEFLAGS Flags;
+    UINT                    Pitch;          // out: The driver must return pitch if allocation is CPU visible
+} D3DKMDT_GDISURFACEDATA;
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_1)
+
+typedef struct _D3DKMDT_VIRTUALGPUSURFACEDATA
+{
+    UINT64                  Size;
+    UINT                    Alignment;
+    UINT                    DriverSegmentId;
+    UINT                    PrivateDriverData;
+} D3DKMDT_VIRTUALGPUSURFACEDATA;
+
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_1)
+
+typedef struct _D3DKMDT_PALETTEDATA
+{
+    BYTE    Red;
+    BYTE    Green;
+    BYTE    Blue;
+    BYTE    Unused;
+} D3DKMDT_PALETTEDATA;
+
+//
+//Red - Bits to be put in the Red portion of the color registers.
+//
+//Green - Bits to be put in the Green portion of the color registers.
+//
+//Blue - Bits to be put in the Blue portion of the color registers.
+//
+
+typedef struct _DXGKARG_SETPALETTE
+{
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID  VidPnSourceId;
+    UINT                            FirstEntry;
+    UINT                            NumEntries;
+    D3DKMDT_PALETTEDATA*            pLookupTable;
+} DXGKARG_SETPALETTE;
+
+//
+//NumEntries - Number of entries in the LookupTable of color values.
+//
+//FirstEntry - Location in the device palette to which the first entry in the
+//    LookupTable of colors should be copied to. The other entries in the
+//    LookupTable should be copied sequentially, from this starting point into
+//    the device's palette.
+//
+//pLookupTable - Array of color entries to copy into the device's color
+//    registers/palette. The color entries can be accessed as a genric 32 bit
+//    value or as Red/Green/Blue/Unused fields.
+//
+
+typedef struct _D3DKMT_MOVE_RECT
+{
+    POINT   SourcePoint;
+    RECT    DestRect;
+}D3DKMT_MOVE_RECT;
+
+//
+// Display information structure.
+//
+
+#ifndef PHYSICAL_ADDRESS
+typedef LARGE_INTEGER PHYSICAL_ADDRESS;
+#endif
+
+typedef struct _DXGK_DISPLAY_INFORMATION
+{
+    UINT Width;
+    UINT Height;
+    UINT Pitch;
+    D3DDDIFORMAT ColorFormat;
+    PHYSICAL_ADDRESS PhysicAddress;
+    D3DDDI_VIDEO_PRESENT_TARGET_ID TargetId;
+    ULONG AcpiId;
+} DXGK_DISPLAY_INFORMATION, *PDXGK_DISPLAY_INFORMATION;
+
+
+//////////////////// I2C ////////////////////////////////////////////////////////////////////////////////////
+
+#define DXGKMDT_I2C_NO_FLAGS                     0
+#define DXGKMDT_I2C_DEVICE_TRANSMITS_DATA_LENGTH 1
+
+//////////////////// OPM (Output Protection Manager) ////////////////////////////////////////////////////////
+
+#pragma pack( push, 1 )
+
+#define DXGKMDT_OPM_OMAC_SIZE                       16
+#define DXGKMDT_OPM_128_BIT_RANDOM_NUMBER_SIZE      16
+#define DXGKMDT_OPM_ENCRYPTED_PARAMETERS_SIZE       256
+#define DXGKMDT_OPM_CONFIGURE_SETTING_DATA_SIZE     4056
+#define DXGKMDT_OPM_GET_INFORMATION_PARAMETERS_SIZE 4056
+#define DXGKMDT_OPM_REQUESTED_INFORMATION_SIZE      4076
+#define DXGKMDT_OPM_HDCP_KEY_SELECTION_VECTOR_SIZE  5
+#define DXGKMDT_OPM_PROTECTION_TYPE_SIZE            4
+
+DEFINE_GUID(DXGKMDT_OPM_GET_CURRENT_HDCP_SRM_VERSION,              0x99c5ceff, 0x5f1d, 0x4879, 0x81, 0xc1, 0xc5, 0x24, 0x43, 0xc9, 0x48, 0x2b);
+DEFINE_GUID(DXGKMDT_OPM_GET_CONNECTED_HDCP_DEVICE_INFORMATION,     0x0db59d74, 0xa992, 0x492e, 0xa0, 0xbd, 0xc2, 0x3f, 0xda, 0x56, 0x4e, 0x00);
+DEFINE_GUID(DXGKMDT_OPM_GET_CONNECTOR_TYPE,                        0x81d0bfd5, 0x6afe, 0x48c2, 0x99, 0xc0, 0x95, 0xa0, 0x8f, 0x97, 0xc5, 0xda);
+DEFINE_GUID(DXGKMDT_OPM_GET_SUPPORTED_PROTECTION_TYPES,            0x38f2a801, 0x9a6c, 0x48bb, 0x91, 0x07, 0xb6, 0x69, 0x6e, 0x6f, 0x17, 0x97);
+DEFINE_GUID(DXGKMDT_OPM_GET_VIRTUAL_PROTECTION_LEVEL,              0xb2075857, 0x3eda, 0x4d5d, 0x88, 0xdb, 0x74, 0x8f, 0x8c, 0x1a, 0x05, 0x49);
+DEFINE_GUID(DXGKMDT_OPM_GET_ACTUAL_PROTECTION_LEVEL,               0x1957210a, 0x7766, 0x452a, 0xb9, 0x9a, 0xd2, 0x7a, 0xed, 0x54, 0xf0, 0x3a);
+DEFINE_GUID(DXGKMDT_OPM_GET_ACTUAL_OUTPUT_FORMAT,                  0xd7bf1ba3, 0xad13, 0x4f8e, 0xaf, 0x98, 0x0d, 0xcb, 0x3c, 0xa2, 0x04, 0xcc);
+DEFINE_GUID(DXGKMDT_OPM_GET_ADAPTER_BUS_TYPE,                      0xc6f4d673, 0x6174, 0x4184, 0x8e, 0x35, 0xf6, 0xdb, 0x52, 0x0,  0xbc, 0xba);
+DEFINE_GUID(DXGKMDT_OPM_GET_ACP_AND_CGMSA_SIGNALING,               0x6629a591, 0x3b79, 0x4cf3, 0x92, 0x4a, 0x11, 0xe8, 0xe7, 0x81, 0x16, 0x71);
+DEFINE_GUID(DXGKMDT_OPM_GET_OUTPUT_ID,                             0x72cb6df3, 0x244f, 0x40ce, 0xb0, 0x9e, 0x20, 0x50, 0x6a, 0xf6, 0x30, 0x2f);
+DEFINE_GUID(DXGKMDT_OPM_GET_DVI_CHARACTERISTICS,                   0xa470b3bb, 0x5dd7, 0x4172, 0x83, 0x9c, 0x3d, 0x37, 0x76, 0xe0, 0xeb, 0xf5);
+DEFINE_GUID(DXGKMDT_OPM_GET_OUTPUT_HARDWARE_PROTECTION_SUPPORT,    0x3b129589, 0x2af8, 0x4ef0, 0x96, 0xa2, 0x70, 0x4a, 0x84, 0x5a, 0x21, 0x8e);
+DEFINE_GUID(DXGKMDT_OPM_GET_CODEC_INFO,                            0x4f374491, 0x8f5f, 0x4445, 0x9d, 0xba, 0x95, 0x58, 0x8f, 0x6b, 0x58, 0xb4);
+DEFINE_GUID(DXGKMDT_OPM_SET_PROTECTION_LEVEL,                      0x9bb9327c, 0x4eb5, 0x4727, 0x9f, 0x00, 0xb4, 0x2b, 0x09, 0x19, 0xc0, 0xda);
+DEFINE_GUID(DXGKMDT_OPM_SET_ACP_AND_CGMSA_SIGNALING,               0x09a631a5, 0xd684, 0x4c60, 0x8e, 0x4d, 0xd3, 0xbb, 0x0f, 0x0b, 0xe3, 0xee);
+DEFINE_GUID(DXGKMDT_OPM_SET_HDCP_SRM,                              0x8b5ef5d1, 0xc30d, 0x44ff, 0x84, 0xa5, 0xea, 0x71, 0xdc, 0xe7, 0x8f, 0x13);
+DEFINE_GUID(DXGKMDT_OPM_SET_PROTECTION_LEVEL_ACCORDING_TO_CSS_DVD, 0x39ce333e, 0x4cc0, 0x44ae, 0xbf, 0xcc, 0xda, 0x50, 0xb5, 0xf8, 0x2e, 0x72);
+
+typedef enum _DXGKMDT_CERTIFICATE_TYPE
+{
+    DXGKMDT_OPM_CERTIFICATE  = 0,
+    DXGKMDT_COPP_CERTIFICATE = 1,
+    DXGKMDT_UAB_CERTIFICATE  = 2,
+    DXGKMDT_INDIRECT_DISPLAY_CERTIFICATE  = 3,
+    DXGKMDT_FORCE_ULONG      = 0xFFFFFFFF
+} DXGKMDT_CERTIFICATE_TYPE;
+
+typedef enum _DXGKMDT_OPM_VIDEO_OUTPUT_SEMANTICS
+{
+    DXGKMDT_OPM_VOS_COPP_SEMANTICS = 0,
+    DXGKMDT_OPM_VOS_OPM_SEMANTICS  = 1,
+    DXGKMDT_OPM_VOS_OPM_INDIRECT_DISPLAY = 2
+} DXGKMDT_OPM_VIDEO_OUTPUT_SEMANTICS;
+
+typedef enum _DXGKMDT_DPCP_PROTECTION_LEVEL
+{
+    DXGKMDT_OPM_DPCP_OFF            = 0,
+    DXGKMDT_OPM_DPCP_ON             = 1,
+    DXGKMDT_OPM_DPCP_FORCE_ULONG    = 0x7fffffff
+
+} DXGKMDT_OPM_DPCP_PROTECTION_LEVEL;
+
+typedef enum _DXGKMDT_OPM_HDCP_FLAG
+{
+    DXGKMDT_OPM_HDCP_FLAG_NONE           = 0x00,
+    DXGKMDT_OPM_HDCP_FLAG_REPEATER       = 0x01
+} DXGKMDT_OPM_HDCP_FLAG;
+
+typedef enum _DXGKMDT_OPM_STATUS
+{
+    DXGKMDT_OPM_STATUS_NORMAL                           = 0x00,
+    DXGKMDT_OPM_STATUS_LINK_LOST                        = 0x01,
+    DXGKMDT_OPM_STATUS_RENEGOTIATION_REQUIRED           = 0x02,
+    DXGKMDT_OPM_STATUS_TAMPERING_DETECTED               = 0x04,
+    DXGKMDT_OPM_STATUS_REVOKED_HDCP_DEVICE_ATTACHED     = 0x08
+} DXGKMDT_OPM_STATUS;
+
+// NUAE stands for Non-User Accessible Enclosure
+typedef enum _DXGKMDT_OPM_BUS_TYPE_AND_IMPLEMENTATION
+{
+    DXGKMDT_OPM_BUS_TYPE_OTHER                                                       = 0x00000000,
+    DXGKMDT_OPM_BUS_TYPE_PCI                                                         = 0x00000001,
+    DXGKMDT_OPM_BUS_TYPE_PCIX                                                        = 0x00000002,
+    DXGKMDT_OPM_BUS_TYPE_PCIEXPRESS                                                  = 0x00000003,
+    DXGKMDT_OPM_BUS_TYPE_AGP                                                         = 0x00000004,
+    DXGKMDT_OPM_BUS_IMPLEMENTATION_MODIFIER_INSIDE_OF_CHIPSET                        = 0x00010000,
+    DXGKMDT_OPM_BUS_IMPLEMENTATION_MODIFIER_TRACKS_ON_MOTHER_BOARD_TO_CHIP           = 0x00020000,
+    DXGKMDT_OPM_BUS_IMPLEMENTATION_MODIFIER_TRACKS_ON_MOTHER_BOARD_TO_SOCKET         = 0x00030000,
+    DXGKMDT_OPM_BUS_IMPLEMENTATION_MODIFIER_DAUGHTER_BOARD_CONNECTOR                 = 0x00040000,
+    DXGKMDT_OPM_BUS_IMPLEMENTATION_MODIFIER_DAUGHTER_BOARD_CONNECTOR_INSIDE_OF_NUAE  = 0x00050000,
+    DXGKMDT_OPM_BUS_IMPLEMENTATION_MODIFIER_NON_STANDARD                             = 0x80000000,
+    DXGKMDT_OPM_COPP_COMPATIBLE_BUS_TYPE_INTEGRATED                                  = 0x80000000
+} DXGKMDT_OPM_BUS_TYPE_AND_IMPLEMENTATION;
+
+typedef enum _DXGKMDT_OPM_HDCP_PROTECTION_LEVEL
+{
+    DXGKMDT_OPM_HDCP_OFF            = 0,
+    DXGKMDT_OPM_HDCP_ON             = 1,
+    DXGKMDT_OPM_HDCP_FORCE_ULONG    = 0x7fffffff
+} DXGKMDT_OPM_HDCP_PROTECTION_LEVEL;
+
+typedef enum _DXGKMDT_OPM_TYPE_ENFORCEMENT_HDCP_PROTECTION_LEVEL
+{
+    DXGKMDT_OPM_TYPE_ENFORCEMENT_HDCP_OFF                         = DXGKMDT_OPM_HDCP_OFF,
+    DXGKMDT_OPM_TYPE_ENFORCEMENT_HDCP_ON_WITH_NO_TYPE_RESTRICTION = DXGKMDT_OPM_HDCP_ON,       // No Type restriction on output topology nodes
+    DXGKMDT_OPM_TYPE_ENFORCEMENT_HDCP_ON_WITH_TYPE1_RESTRICTION   = DXGKMDT_OPM_HDCP_ON + 1,   // Restrict to Type 1 compliant output topology nodes
+    DXGKMDT_OPM_TYPE_ENFORCEMENT_HDCP_FORCE_ULONG                 = 0x7fffffff
+} DXGKMDT_OPM_TYPE_ENFORCEMENT_HDCP_PROTECTION_LEVEL;
+
+typedef enum _DXGKMDT_OPM_CGMSA
+{
+    DXGKMDT_OPM_CGMSA_OFF                                           = 0,
+    DXGKMDT_OPM_CGMSA_COPY_FREELY                                   = 1,
+    DXGKMDT_OPM_CGMSA_COPY_NO_MORE                                  = 2,
+    DXGKMDT_OPM_CGMSA_COPY_ONE_GENERATION                           = 3,
+    DXGKMDT_OPM_CGMSA_COPY_NEVER                                    = 4,
+    DXGKMDT_OPM_REDISTRIBUTION_CONTROL_REQUIRED                     = 0x08,
+} DXGKMDT_OPM_CGMSA;
+
+typedef enum _DXGKMDT_OPM_ACP_PROTECTION_LEVEL
+{
+    DXGKMDT_OPM_ACP_OFF             = 0,
+    DXGKMDT_OPM_ACP_LEVEL_ONE       = 1,
+    DXGKMDT_OPM_ACP_LEVEL_TWO       = 2,
+    DXGKMDT_OPM_ACP_LEVEL_THREE     = 3,
+    DXGKMDT_OPM_ACP_FORCE_ULONG     = 0x7fffffff
+} DXGKMDT_OPM_ACP_PROTECTION_LEVEL;
+
+typedef enum _DXGKMDT_OPM_PROTECTION_TYPE
+{
+    DXGKMDT_OPM_PROTECTION_TYPE_OTHER                       = 0x80000000,
+    DXGKMDT_OPM_PROTECTION_TYPE_NONE                        = 0x00000000,
+    DXGKMDT_OPM_PROTECTION_TYPE_COPP_COMPATIBLE_HDCP        = 0x00000001,
+    DXGKMDT_OPM_PROTECTION_TYPE_ACP                         = 0x00000002,
+    DXGKMDT_OPM_PROTECTION_TYPE_CGMSA                       = 0x00000004,
+    DXGKMDT_OPM_PROTECTION_TYPE_HDCP                        = 0x00000008,
+    DXGKMDT_OPM_PROTECTION_TYPE_DPCP                        = 0x00000010,
+    DXGKMDT_OPM_PROTECTION_TYPE_TYPE_ENFORCEMENT_HDCP       = 0x00000020,
+    DXGKMDT_OPM_PROTECTION_TYPE_MASK                        = 0x8000003F
+} DXGKMDT_OPM_PROTECTION_TYPE;
+
+typedef enum _DXGKMDT_OPM_PROTECTION_STANDARD
+{
+    DXGKMDT_OPM_PROTECTION_STANDARD_OTHER                   = 0x80000000,
+    DXGKMDT_OPM_PROTECTION_STANDARD_NONE                    = 0x00000000,
+    DXGKMDT_OPM_PROTECTION_STANDARD_IEC61880_525I           = 0x00000001,
+    DXGKMDT_OPM_PROTECTION_STANDARD_IEC61880_2_525I         = 0x00000002,
+    DXGKMDT_OPM_PROTECTION_STANDARD_IEC62375_625P           = 0x00000004,
+    DXGKMDT_OPM_PROTECTION_STANDARD_EIA608B_525             = 0x00000008,
+    DXGKMDT_OPM_PROTECTION_STANDARD_EN300294_625I           = 0x00000010,
+    DXGKMDT_OPM_PROTECTION_STANDARD_CEA805A_TYPEA_525P      = 0x00000020,
+    DXGKMDT_OPM_PROTECTION_STANDARD_CEA805A_TYPEA_750P      = 0x00000040,
+    DXGKMDT_OPM_PROTECTION_STANDARD_CEA805A_TYPEA_1125I     = 0x00000080,
+    DXGKMDT_OPM_PROTECTION_STANDARD_CEA805A_TYPEB_525P      = 0x00000100,
+    DXGKMDT_OPM_PROTECTION_STANDARD_CEA805A_TYPEB_750P      = 0x00000200,
+    DXGKMDT_OPM_PROTECTION_STANDARD_CEA805A_TYPEB_1125I     = 0x00000400,
+    DXGKMDT_OPM_PROTECTION_STANDARD_ARIBTRB15_525I          = 0x00000800,
+    DXGKMDT_OPM_PROTECTION_STANDARD_ARIBTRB15_525P          = 0x00001000,
+    DXGKMDT_OPM_PROTECTION_STANDARD_ARIBTRB15_750P          = 0x00002000,
+    DXGKMDT_OPM_PROTECTION_STANDARD_ARIBTRB15_1125I         = 0x00004000,
+} DXGKMDT_OPM_PROTECTION_STANDARD;
+
+typedef enum _DXGKMDT_OPM_IMAGE_ASPECT_RATIO_EN300294
+{
+    DXGKMDT_OPM_ASPECT_RATIO_EN300294_FULL_FORMAT_4_BY_3                        = 0,
+    DXGKMDT_OPM_ASPECT_RATIO_EN300294_BOX_14_BY_9_CENTER                        = 1,
+    DXGKMDT_OPM_ASPECT_RATIO_EN300294_BOX_14_BY_9_TOP                           = 2,
+    DXGKMDT_OPM_ASPECT_RATIO_EN300294_BOX_16_BY_9_CENTER                        = 3,
+    DXGKMDT_OPM_ASPECT_RATIO_EN300294_BOX_16_BY_9_TOP                           = 4,
+    DXGKMDT_OPM_ASPECT_RATIO_EN300294_BOX_GT_16_BY_9_CENTER                     = 5,
+    DXGKMDT_OPM_ASPECT_RATIO_EN300294_FULL_FORMAT_4_BY_3_PROTECTED_CENTER       = 6,
+    DXGKMDT_OPM_ASPECT_RATIO_EN300294_FULL_FORMAT_16_BY_9_ANAMORPHIC            = 7,
+    DXGKMDT_OPM_ASPECT_RATIO_FORCE_ULONG                                        = 0x7FFFFFFF
+} DXGKMDT_OPM_IMAGE_ASPECT_RATIO_EN300294;
+
+typedef enum _DXGKMDT_OPM_INTERLEAVE_FORMAT
+{
+    DXGKMDT_OPM_INTERLEAVE_FORMAT_OTHER = 0,
+    DXGKMDT_OPM_INTERLEAVE_FORMAT_PROGRESSIVE = 2,
+    DXGKMDT_OPM_INTERLEAVE_FORMAT_INTERLEAVED_EVEN_FIRST = 3,
+    DXGKMDT_OPM_INTERLEAVE_FORMAT_INTERLEAVED_ODD_FIRST = 4,
+    DXGKMDT_OPM_INTERLEAVE_FORMAT_FORCE_ULONG = 0xFFFFFFFF
+
+} DXGKMDT_OPM_INTERLEAVE_FORMAT;
+
+typedef enum _DXGKDT_OPM_DVI_CHARACTERISTICS
+{
+    DXGKMDT_OPM_DVI_CHARACTERISTIC_1_0                      = 1,
+    DXGKMDT_OPM_DVI_CHARACTERISTIC_1_1_OR_ABOVE             = 2,
+    DXGKMDT_OPM_DVI_CHARACTERISTICS_FORCE_ULONG             = 0xFFFFFFFF
+} DXGKDT_OPM_DVI_CHARACTERISTICS;
+
+typedef enum _DXGKMDT_OPM_OUTPUT_HARDWARE_PROTECTION
+{
+    DXGKMDT_OPM_OUTPUT_HARDWARE_PROTECTION_NOT_SUPPORTED = 0x0,
+    DXGKMDT_OPM_OUTPUT_HARDWARE_PROTECTION_SUPPORTED     = 0x1
+} DXGKMDT_OPM_OUTPUT_HARDWARE_PROTECTION;
+
+typedef struct _DXGKMDT_OPM_RANDOM_NUMBER
+{
+    BYTE abRandomNumber[DXGKMDT_OPM_128_BIT_RANDOM_NUMBER_SIZE];
+} DXGKMDT_OPM_RANDOM_NUMBER, *PDXGKMDT_OPM_RANDOM_NUMBER;
+
+typedef struct _DXGKMDT_OPM_OMAC
+{
+    BYTE abOMAC[DXGKMDT_OPM_OMAC_SIZE];
+} DXGKMDT_OPM_OMAC, *PDXGKMDT_OPM_OMAC;
+
+typedef struct _DXGKMDT_OPM_ENCRYPTED_PARAMETERS
+{
+    BYTE abEncryptedParameters[DXGKMDT_OPM_ENCRYPTED_PARAMETERS_SIZE];
+} DXGKMDT_OPM_ENCRYPTED_PARAMETERS, *PDXGKMDT_OPM_ENCRYPTED_PARAMETERS;
+
+typedef struct _DXGKMDT_OPM_GET_INFO_PARAMETERS
+{
+    DXGKMDT_OPM_OMAC omac;
+    DXGKMDT_OPM_RANDOM_NUMBER rnRandomNumber;
+    GUID guidInformation;
+    ULONG ulSequenceNumber;
+    ULONG cbParametersSize;
+    BYTE abParameters[DXGKMDT_OPM_GET_INFORMATION_PARAMETERS_SIZE];
+} DXGKMDT_OPM_GET_INFO_PARAMETERS, *PDXGKMDT_OPM_GET_INFO_PARAMETERS;
+
+typedef struct _DXGKMDT_OPM_COPP_COMPATIBLE_GET_INFO_PARAMETERS
+{
+    DXGKMDT_OPM_RANDOM_NUMBER rnRandomNumber;
+    GUID guidInformation;
+    ULONG ulSequenceNumber;
+    ULONG cbParametersSize;
+    BYTE abParameters[DXGKMDT_OPM_GET_INFORMATION_PARAMETERS_SIZE];
+} DXGKMDT_OPM_COPP_COMPATIBLE_GET_INFO_PARAMETERS, *PDXGKMDT_OPM_COPP_COMPATIBLE_GET_INFO_PARAMETERS;
+
+typedef struct _DXGKMDT_OPM_HDCP_KEY_SELECTION_VECTOR
+{
+    BYTE abKeySelectionVector[DXGKMDT_OPM_HDCP_KEY_SELECTION_VECTOR_SIZE];
+} DXGKMDT_OPM_HDCP_KEY_SELECTION_VECTOR;
+
+typedef struct _DXGKMDT_OPM_CONNECTED_HDCP_DEVICE_INFORMATION
+{
+    DXGKMDT_OPM_RANDOM_NUMBER rnRandomNumber;
+    ULONG ulStatusFlags;
+    ULONG ulHDCPFlags;
+    DXGKMDT_OPM_HDCP_KEY_SELECTION_VECTOR ksvB;
+    BYTE Reserved[11];
+    BYTE Reserved2[16];
+    BYTE Reserved3[16];
+} DXGKMDT_OPM_CONNECTED_HDCP_DEVICE_INFORMATION;
+
+typedef struct _DXGKMDT_OPM_REQUESTED_INFORMATION
+{
+    DXGKMDT_OPM_OMAC omac;
+    ULONG cbRequestedInformationSize;
+    BYTE abRequestedInformation[DXGKMDT_OPM_REQUESTED_INFORMATION_SIZE];
+} DXGKMDT_OPM_REQUESTED_INFORMATION, *PDXGKMDT_OPM_REQUESTED_INFORMATION;
+
+typedef struct _DXGKMDT_OPM_STANDARD_INFORMATION
+{
+    DXGKMDT_OPM_RANDOM_NUMBER rnRandomNumber;
+    ULONG ulStatusFlags;
+    ULONG ulInformation;
+    ULONG ulReserved;
+    ULONG ulReserved2;
+} DXGKMDT_OPM_STANDARD_INFORMATION;
+
+typedef struct _DXGKMDT_OPM_ACTUAL_OUTPUT_FORMAT
+{
+    DXGKMDT_OPM_RANDOM_NUMBER rnRandomNumber;
+    ULONG ulStatusFlags;
+    ULONG ulDisplayWidth;
+    ULONG ulDisplayHeight;
+    DXGKMDT_OPM_INTERLEAVE_FORMAT ifInterleaveFormat;
+    ULONG d3dFormat;
+    ULONG ulFrequencyNumerator;
+    ULONG ulFrequencyDenominator;
+} DXGKMDT_OPM_ACTUAL_OUTPUT_FORMAT;
+
+typedef struct _DXGKMDT_OPM_ACP_AND_CGMSA_SIGNALING
+{
+    DXGKMDT_OPM_RANDOM_NUMBER rnRandomNumber;
+    ULONG ulStatusFlags;
+    ULONG ulAvailableTVProtectionStandards;
+    ULONG ulActiveTVProtectionStandard;
+    ULONG ulReserved;
+    ULONG ulAspectRatioValidMask1;
+    ULONG ulAspectRatioData1;
+    ULONG ulAspectRatioValidMask2;
+    ULONG ulAspectRatioData2;
+    ULONG ulAspectRatioValidMask3;
+    ULONG ulAspectRatioData3;
+    ULONG ulReserved2[4];
+    ULONG ulReserved3[4];
+} DXGKMDT_OPM_ACP_AND_CGMSA_SIGNALING;
+
+typedef struct _DXGKMDT_OPM_OUTPUT_ID
+{
+    DXGKMDT_OPM_RANDOM_NUMBER rnRandomNumber;
+    ULONG ulStatusFlags;
+    UINT64 OutputId;
+} DXGKMDT_OPM_OUTPUT_ID;
+
+typedef struct _DXGKMDT_OPM_CONFIGURE_PARAMETERS
+{
+    DXGKMDT_OPM_OMAC omac;
+    GUID guidSetting;
+    ULONG ulSequenceNumber;
+    ULONG cbParametersSize;
+    BYTE abParameters[DXGKMDT_OPM_CONFIGURE_SETTING_DATA_SIZE];
+} DXGKMDT_OPM_CONFIGURE_PARAMETERS, *PDXGKMDT_OPM_CONFIGURE_PARAMETERS;
+
+typedef struct _DXGKMDT_OPM_SET_PROTECTION_LEVEL_PARAMETERS
+{
+    ULONG ulProtectionType;
+    ULONG ulProtectionLevel;
+    ULONG Reserved;
+    ULONG Reserved2;
+} DXGKMDT_OPM_SET_PROTECTION_LEVEL_PARAMETERS;
+
+typedef struct _DXGKMDT_OPM_SET_ACP_AND_CGMSA_SIGNALING_PARAMETERS
+{
+    ULONG ulNewTVProtectionStandard;
+    ULONG ulAspectRatioChangeMask1;
+    ULONG ulAspectRatioData1;
+    ULONG ulAspectRatioChangeMask2;
+    ULONG ulAspectRatioData2;
+    ULONG ulAspectRatioChangeMask3;
+    ULONG ulAspectRatioData3;
+    ULONG ulReserved[4];
+    ULONG ulReserved2[4];
+    ULONG ulReserved3;
+} DXGKMDT_OPM_SET_ACP_AND_CGMSA_SIGNALING_PARAMETERS;
+
+typedef struct _DXGKMDT_OPM_SET_HDCP_SRM_PARAMETERS
+{
+    ULONG ulSRMVersion;
+} DXGKMDT_OPM_SET_HDCP_SRM_PARAMETERS;
+
+typedef struct _DXGKMDT_OPM_CREATE_VIDEO_OUTPUT_FOR_TARGET_PARAMETERS
+{
+	LUID AdapterLuid;
+	D3DDDI_VIDEO_PRESENT_TARGET_ID TargetId;
+	DXGKMDT_OPM_VIDEO_OUTPUT_SEMANTICS Vos;
+} DXGKMDT_OPM_CREATE_VIDEO_OUTPUT_FOR_TARGET_PARAMETERS;
+
+typedef struct _DXGK_BRIGHTNESS_CAPS
+{
+    union
+    {
+        struct
+        {
+            UINT SmoothBrightness   :    1;  // 0x00000001
+            UINT AdaptiveBrightness :    1;  // 0x00000002
+            UINT NitsBrightness     :    1;  // 0x00000004
+            UINT Reserved           :    29; // 0xFFFFFFF8
+        };
+
+        UINT  Value;
+    };
+} DXGK_BRIGHTNESS_CAPS;
+
+typedef struct _DXGK_BRIGHTNESS_STATE
+{
+    union
+    {
+        struct
+        {
+            UINT SmoothBrightness   :    1; // 0x00000001
+            UINT Reserved           :   31; // 0xFFFFFFFE
+        };
+
+        UINT  Value;
+    };
+} DXGK_BRIGHTNESS_STATE;
+
+typedef enum
+{
+    DxgkBacklightOptimizationDisable    = 0,
+    DxgkBacklightOptimizationDesktop    = 1,
+    DxgkBacklightOptimizationDynamic    = 2,
+    DxgkBacklightOptimizationDimmed     = 3,
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_2)
+    DxgkBacklightOptimizationEDR        = 4,
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_2
+} DXGK_BACKLIGHT_OPTIMIZATION_LEVEL;
+
+typedef struct _DXGK_BACKLIGHT_INFO
+{
+    OUT USHORT                          BacklightUsersetting;
+    OUT USHORT                          BacklightEffective;
+    OUT D3DDDI_GAMMA_RAMP_RGB256x3x16   GammaRamp;
+} DXGK_BACKLIGHT_INFO;
+
+typedef struct _DXGK_BRIGHTNESS_SENSOR_DATA_CHROMATICITY
+{
+    float ChromaticityX;
+    float ChromaticityY;
+} DXGK_BRIGHTNESS_SENSOR_DATA_CHROMATICITY;
+
+typedef struct _DXGK_BRIGHTNESS_SENSOR_DATA
+{
+    UINT32    Size;
+    union
+    {
+        struct
+        {
+            UINT AlsReadingValid : 1;
+            UINT ChromaticityValid : 1;
+            UINT ColorTemperatureValid : 1;
+            UINT Reserved : 29;
+        } Flags;
+        UINT ValidSensorValues;
+    };
+    float  AlsReading;
+    DXGK_BRIGHTNESS_SENSOR_DATA_CHROMATICITY Chromaticity;
+    float ColorTemperature;
+} DXGK_BRIGHTNESS_SENSOR_DATA;
+
+
+typedef struct _DXGK_BRIGHTNESS_SET_IN
+{
+    UINT32                             BrightnessMillinits;
+    UINT32                             TransitionTimeMs;
+    DXGK_BRIGHTNESS_SENSOR_DATA        SensorReadings;
+} DXGK_BRIGHTNESS_SET_IN, *PDXGK_BRIGHTNESS_SET_IN;
+
+typedef struct _DXGK_BRIGHTNESS_GET_OUT
+{
+    UINT32 CurrentBrightnessMillinits;
+    UINT32 TargetBrightnessMillinits;
+} DXGK_BRIGHTNESS_GET_OUT, *PDXGK_BRIGHTNESS_GET_OUT;
+
+typedef struct _DXGK_BRIGHTNESS_NIT_RANGE
+{
+    UINT32 MinimumLevelMillinit;
+    UINT32 MaximumLevelMillinit;
+    UINT32 StepSizeMillinit;
+} DXGK_BRIGHTNESS_NIT_RANGE;
+
+#define DXGK_BRIGHTNESS_MAXIMUM_NIT_RANGE_COUNT 16
+
+typedef struct _DXGK_BRIGHTNESS_GET_NIT_RANGES_OUT
+{
+    UINT32                      NormalRangeCount;
+    UINT32                      RangeCount;
+    UINT32                      PreferredMaximumBrightness;
+    DXGK_BRIGHTNESS_NIT_RANGE   SupportedRanges[DXGK_BRIGHTNESS_MAXIMUM_NIT_RANGE_COUNT];
+} DXGK_BRIGHTNESS_GET_NIT_RANGES_OUT, *PDXGK_BRIGHTNESS_GET_NIT_RANGES_OUT;
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM1_3)
+
+typedef struct _D3DKMT_WDDM_1_3_CAPS
+{
+    union
+    {
+        struct
+        {
+            UINT SupportMiracast : 1;
+            UINT IsHybridIntegratedGPU : 1;
+            UINT IsHybridDiscreteGPU : 1;
+            UINT SupportPowerManagementPStates : 1;
+            UINT SupportVirtualModes : 1;
+            UINT SupportCrossAdapterResource : 1;
+            UINT Reserved : 26;
+        };
+        UINT Value;
+    };
+} D3DKMT_WDDM_1_3_CAPS;
+
+#define DXGK_MAX_METADATA_NAME_LENGTH 32
+typedef enum
+{
+    DXGK_ENGINE_TYPE_OTHER,
+    DXGK_ENGINE_TYPE_3D,
+    DXGK_ENGINE_TYPE_VIDEO_DECODE,
+    DXGK_ENGINE_TYPE_VIDEO_ENCODE,
+    DXGK_ENGINE_TYPE_VIDEO_PROCESSING,
+    DXGK_ENGINE_TYPE_SCENE_ASSEMBLY,
+    DXGK_ENGINE_TYPE_COPY,
+    DXGK_ENGINE_TYPE_OVERLAY,
+    DXGK_ENGINE_TYPE_CRYPTO,
+    DXGK_ENGINE_TYPE_MAX
+} DXGK_ENGINE_TYPE;
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_2)
+
+typedef struct _DXGK_NODEMETADATA_FLAGS
+{
+    union
+    {
+        struct
+        {
+            UINT ContextSchedulingSupported :  1;
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_5)
+
+            UINT RingBufferFenceRelease     :  1;
+            UINT SupportTrackedWorkload     :  1;
+            UINT Reserved                   : 13;
+
+            UINT MaxInFlightHwQueueBuffers  : 16;
+
+#else
+
+            UINT Reserved                   : 31;
+
+#endif // !(DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_5)
+
+        };
+        UINT32 Value;
+    };
+} DXGK_NODEMETADATA_FLAGS;
+
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_2)
+
+typedef struct _DXGK_NODEMETADATA
+{
+    DXGK_ENGINE_TYPE EngineType;
+    WCHAR            FriendlyName[DXGK_MAX_METADATA_NAME_LENGTH];
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_2)
+    DXGK_NODEMETADATA_FLAGS Flags;
+#else
+    UINT32           Reserved;
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_2)
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0)
+    BOOLEAN          GpuMmuSupported;
+    BOOLEAN          IoMmuSupported;
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0)
+} DXGK_NODEMETADATA;
+
+typedef DXGK_NODEMETADATA DXGKARG_GETNODEMETADATA;
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_4)
+
+typedef struct _DXGK_GPUCLOCKDATA_FLAGS
+{
+    union
+    {
+        struct
+        {
+            UINT ContextManagementProcessor :  1;
+            UINT Reserved                   : 31;
+        };
+        UINT32 Value;
+    };
+} DXGK_GPUCLOCKDATA_FLAGS;
+
+typedef struct _DXGK_NODE_PERFDATA
+{
+    ULONGLONG       Frequency;              // out: Clock frequency of the engine in hertz
+    ULONGLONG       MaxFrequency;           // out: Max engine clock frequency
+    ULONGLONG       MaxFrequencyOC;         // out: Max engine over clock frequency
+    ULONG           Voltage;                // out: Voltage of the engine in milli volts mV
+    ULONG           VoltageMax;             // out: Max voltage levels in milli volts.
+    ULONG           VoltageMaxOC;           // out: Max voltage level while overclocked in milli volts.
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_5)
+    ULONGLONG       MaxTransitionLatency;   // out: Max transition latency to change the frequency in 100 nanoseconds
+#endif
+} DXGK_NODE_PERFDATA;
+
+typedef struct _DXGK_ADAPTER_PERFDATA
+{
+    ULONGLONG       MemoryFrequency;        // out: Clock frequency of the memory in hertz
+    ULONGLONG       MaxMemoryFrequency;     // out: Max memory clock frequency
+    ULONGLONG       MaxMemoryFrequencyOC;   // out: Clock frequency of the memory while overclocked in hertz.
+    ULONGLONG       MemoryBandwidth;        // out: Amount of memory transferred in bytes
+    ULONGLONG       PCIEBandwidth;          // out: Amount of memory transferred over PCI-E in bytes
+    ULONG           FanRPM;                 // out: Fan rpm
+    ULONG           Power;                  // out: Power draw of the adapter in tenths of a percentage
+    ULONG           Temperature;            // out: Temperature in deci-Celsius 1 = 0.1C
+    UCHAR           PowerStateOverride;     // out: Overrides dxgkrnls power view of linked adapters.
+} DXGK_ADAPTER_PERFDATA;
+
+typedef struct _DXGK_ADAPTER_PERFDATACAPS
+{
+    ULONGLONG   MaxMemoryBandwidth;     // out: Max memory bandwidth in bytes for 1 second
+    ULONGLONG   MaxPCIEBandwidth;       // out: Max pcie bandwidth in bytes for 1 second
+    ULONG       MaxFanRPM;              // out: Max fan rpm
+    ULONG       TemperatureMax;         // out: Max temperature before damage levels
+    ULONG       TemperatureWarning;     // out: The temperature level where throttling begins.
+} DXGK_ADAPTER_PERFDATACAPS;
+
+#define DXGK_MAX_GPUVERSION_NAME_LENGTH 32
+typedef struct _DXGK_GPUVERSION
+{
+    WCHAR           BiosVersion[DXGK_MAX_GPUVERSION_NAME_LENGTH];     //out: The gpu bios version
+    WCHAR           GpuArchitecture[DXGK_MAX_GPUVERSION_NAME_LENGTH]; //out: The gpu architectures name.
+} DXGK_GPUVERSION;
+
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_4)
+
+typedef struct _DXGK_GPUCLOCKDATA
+{
+    ULONGLONG               GpuFrequency;
+    ULONGLONG               GpuClockCounter;
+    ULONGLONG               CpuClockCounter;
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_4)
+    DXGK_GPUCLOCKDATA_FLAGS Flags;
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_4)
+} DXGK_GPUCLOCKDATA;
+
+typedef DXGK_GPUCLOCKDATA DXGKARG_CALIBRATEGPUCLOCK;
+
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM1_3)
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0)
+
+typedef struct _D3DKMT_WDDM_2_0_CAPS
+{
+    union
+    {
+        struct
+        {
+            UINT Support64BitAtomics       : 1;
+            UINT GpuMmuSupported           : 1;
+            UINT IoMmuSupported            : 1;
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_4)
+            UINT FlipOverwriteSupported    : 1;
+            UINT SupportContextlessPresent : 1;
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_5)
+            UINT SupportSurpriseRemoval    : 1;
+            UINT Reserved                  : 26;
+#else
+            UINT Reserved                  : 27;
+#endif // !(DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_5)
+#else
+            UINT Reserved                  : 29;
+#endif // !(DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_4)
+        };
+        UINT Value;
+    };
+} D3DKMT_WDDM_2_0_CAPS;
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_7)
+
+typedef struct _D3DKMT_WDDM_2_7_CAPS
+{
+    union
+    {
+        struct
+        {
+            UINT HwSchSupported               :  1;    // Specifies whether the GPU supports hardware scheduling
+            UINT HwSchEnabled                 :  1;    // Specifies whether the hardware scheduling is currently enabled for this GPU
+            UINT HwSchEnabledByDefault        :  1;    // Set to 1 if the OS default policy is to enable hardware scheduling for this GPU
+            UINT IndependentVidPnVSyncControl :  1;
+            UINT Reserved                     : 28;
+        };
+        UINT Value;
+    };
+} D3DKMT_WDDM_2_7_CAPS;
+
+#endif
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_9)
+
+// DXGK_FEATURE_SUPPORT constants
+
+// When a driver doesn't support a feature, it doesn't call into QueryFeatureSupport with that feature ID.
+// This value is provided for implementation convenience of enumerating possible driver support states
+// for a particular feature.
+#define DXGK_FEATURE_SUPPORT_ALWAYS_OFF ((UINT)0)
+
+// Driver support for a feature is in the experimental state
+#define DXGK_FEATURE_SUPPORT_EXPERIMENTAL ((UINT)1)
+
+// Driver support for a feature is in the stable state
+#define DXGK_FEATURE_SUPPORT_STABLE ((UINT)2)
+
+// Driver support for a feature is in the always on state,
+// and it doesn't operate without this feature enabled.
+#define DXGK_FEATURE_SUPPORT_ALWAYS_ON ((UINT)3)
+
+typedef struct _D3DKMT_WDDM_2_9_CAPS
+{
+    union
+    {
+        struct
+        {
+            _Field_range_(DXGK_FEATURE_SUPPORT_ALWAYS_OFF, DXGK_FEATURE_SUPPORT_ALWAYS_ON)
+            UINT    HwSchSupportState           :  2;   // DXGK_FEATURE_SUPPORT_* value that specifies driver support state for GPU supports hardware scheduling
+            UINT    HwSchEnabled                :  1;   // Specifies whether the hardware scheduling is currently enabled for this GPU
+            UINT    SelfRefreshMemorySupported  :  1;   // Specifies whether Self Refresh Memory is supported for this GPU
+            UINT    Reserved                    : 28;
+        };
+        UINT Value;
+    };
+} D3DKMT_WDDM_2_9_CAPS;
+
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_9)
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM3_0)
+
+typedef struct _D3DKMT_WDDM_3_0_CAPS
+{
+    union
+    {
+        struct
+        {
+            _Field_range_(DXGK_FEATURE_SUPPORT_ALWAYS_OFF, DXGK_FEATURE_SUPPORT_ALWAYS_ON)
+            UINT    HwFlipQueueSupportState     :  2;   // DXGK_FEATURE_SUPPORT_* value that specifies driver support state for GPU supports hardware flip queue
+            UINT    HwFlipQueueEnabled          :  1;   // Specifies whether the hardware flip queue is currently enabled for this GPU
+            UINT    DisplayableSupported        :  1;   // Specifies whether displayable feature is supported
+            UINT    Reserved                    : 28;
+        };
+        UINT Value;
+    };
+} D3DKMT_WDDM_3_0_CAPS;
+
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM3_0)
+
+
+typedef struct _D3DKMT_TRACKEDWORKLOAD_SUPPORT
+{
+    _In_ UINT PhysicalAdapterIndex;
+    _In_ DXGK_ENGINE_TYPE EngineType;
+    _Out_ BOOL Support;
+} D3DKMT_TRACKEDWORKLOAD_SUPPORT;
+
+typedef struct _D3DKMT_NODEMETADATA
+{
+    _In_ UINT NodeOrdinalAndAdapterIndex;     // WDDMv2: High word is physical adapter index, low word is node ordinal
+    _Out_ DXGK_NODEMETADATA NodeData;
+} D3DKMT_NODEMETADATA;
+
+typedef struct _D3DKMT_QUERYCLOCKCALIBRATION
+{
+    D3DKMT_HANDLE   hAdapter;               // in: The adapter to query clock information for
+    UINT32          NodeOrdinal;            // in: Node ordinal of the requested engine.
+    UINT32          PhysicalAdapterIndex;   // in: The physical adapter index, in an LDA chain
+    DXGK_GPUCLOCKDATA ClockData;            // out: Output frequency, Gpu clock, and Cpu clock on the specified engine
+} D3DKMT_QUERYCLOCKCALIBRATION;
+
+typedef enum _DXGK_RENDER_PIPELINE_STAGE
+{
+    DXGK_RENDER_PIPELINE_STAGE_UNKNOWN = 0,
+    DXGK_RENDER_PIPELINE_STAGE_INPUT_ASSEMBLER = 1,
+    DXGK_RENDER_PIPELINE_STAGE_VERTEX_SHADER = 2,
+    DXGK_RENDER_PIPELINE_STAGE_GEOMETRY_SHADER = 3,
+    DXGK_RENDER_PIPELINE_STAGE_STREAM_OUTPUT = 4,
+    DXGK_RENDER_PIPELINE_STAGE_RASTERIZER = 5,
+    DXGK_RENDER_PIPELINE_STAGE_PIXEL_SHADER = 6,
+    DXGK_RENDER_PIPELINE_STAGE_OUTPUT_MERGER = 7,
+} DXGK_RENDER_PIPELINE_STAGE;
+
+typedef enum _DXGK_PAGE_FAULT_FLAGS
+{
+    DXGK_PAGE_FAULT_WRITE                   = 0x1,  // when set, indicates that a write to a GPU virtual address failed
+    DXGK_PAGE_FAULT_FENCE_INVALID           = 0x2,  // when set, indicates that a fence value for the packet that generated
+                                                    // the page fault could not be determined
+    DXGK_PAGE_FAULT_ADAPTER_RESET_REQUIRED  = 0x4,  // when set, indicates that the page fault put the GPU in a state that requires a full adapter reset
+    DXGK_PAGE_FAULT_ENGINE_RESET_REQUIRED   = 0x8,  // when set, indicates that the page fault put the GPU in a state that requires GPU engine reset
+    DXGK_PAGE_FAULT_FATAL_HARDWARE_ERROR    = 0x10, // when set, indicates that the system hardware, not just the GPU, cannot continue,
+                                                    // and the OS should issue a bugcheck
+    DXGK_PAGE_FAULT_IOMMU                   = 0x20, // when set, indicates that the faulting GPU virtual address was mapped using IoMmu,
+                                                    // when not set, the faulting GPU virtual address was mapped using GPU memory management unit.
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_2)
+
+    DXGK_PAGE_FAULT_HW_CONTEXT_VALID        = 0x40, // when set, indicates that the faulting hardware queue was not identified, but faulting HW context was.
+    DXGK_PAGE_FAULT_PROCESS_HANDLE_VALID    = 0x80, // when set, indicates that the faulting hardware queue or context was not identified,
+                                                    // but process handle that submitted the faulted buffer was.
+
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_2)
+
+} DXGK_PAGE_FAULT_FLAGS;
+
+typedef enum _DXGK_GENERAL_ERROR_CODE
+{
+    DXGK_GENERAL_ERROR_PAGE_FAULT = 0,
+    DXGK_GENERAL_ERROR_INVALID_INSTRUCTION = 1,
+} DXGK_GENERAL_ERROR_CODE;
+
+typedef struct _DXGK_FAULT_ERROR_CODE
+{
+    union
+    {
+        struct
+        {
+            UINT IsDeviceSpecificCode                :  1;  // when set to 1, indicates the low 31 bits correspond to a device specific error code.
+                                                            // when set to 0, indicates the low 31 bits correspond to a code defined by DXGK_GENERAL_ERROR_CODE.
+            DXGK_GENERAL_ERROR_CODE GeneralErrorCode : 31;  // General error code defined by DXGK_GENERAL_ERROR_CODE.
+        };
+        struct
+        {
+            UINT IsDeviceSpecificCodeReservedBit     :  1;  // Same as IsDeviceSpecificCode member above:
+                                                            // when set to 1, indicates the low 31 bits correspond to a device specific error code.
+                                                            // when set to 0, indicates the low 31 bits correspond to a code defined by DXGK_GENERAL_ERROR_CODE.
+            UINT DeviceSpecificCode                  : 31;  // A device specific error code.
+        };
+    };
+} DXGK_FAULT_ERROR_CODE;
+
+typedef struct _D3DKMT_DRIVERCAPS_EXT
+{
+    union
+    {
+        struct
+        {
+            UINT VirtualModeSupport     : 1;
+            UINT Usb4MonitorSupport     : 1;
+            UINT Reserved               : 30;
+        };
+        UINT Value;
+    };
+} D3DKMT_DRIVERCAPS_EXT;
+
+#define DXGK_PRIMITIVE_API_SEQUENCE_NUMBER_UNKNOWN  ULONGLONG_MAX
+#define DXGK_BIND_TABLE_ENTRY_UNKNOWN               UINT_MAX
+
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0)
+
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_1)
+
+typedef union _DXGK_MONITORLINKINFO_USAGEHINTS
+{
+    struct
+    {
+        UINT Hidden             : 1;    // 0x00000001
+        UINT Reserved           :31;    // 0xFFFFFFFE
+    };
+    UINT Value;
+} DXGK_MONITORLINKINFO_USAGEHINTS, *PDXGK_MONITORLINKINFO_USAGEHINTS;
+
+typedef union _DXGK_MONITORLINKINFO_CAPABILITIES
+{
+    struct
+    {
+        UINT Stereo                     : 1;    // 0x00000001
+        UINT WideColorSpace             : 1;    // 0x00000002
+        UINT HighColorSpace             : 1;    // 0x00000004
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_2)
+        UINT DynamicColorSpace          : 1;    // 0x00000008
+        UINT DynamicBitsPerColorChannel : 1;    // 0x00000010
+        UINT DynamicColorEncodingFormat : 1;    // 0x00000020
+        UINT DedicatedTimingGeneration  : 1;    // 0x00000040
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_2
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_4)
+        UINT TargetIndependentPrimary   : 1;    // 0x00000080
+        UINT SyncLockIdentical          : 1;    // 0x00000100
+        UINT Hdr10Plus                  : 1;    // 0x00000200
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_4
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_5)
+        UINT DolbyVisionLowLatency      : 1;    // 0x00000400
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_5
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_6)
+        UINT VariableRefresh            : 1;    // 0x00000800
+#endif // DXGKDDI_INTERFACE_VERSION_WDDM2_6
+
+#if   (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_6)
+        UINT Reserved                   :20;    // 0xFFFFF000
+#elif (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_5)
+        UINT Reserved                   :21;    // 0xFFFFF800
+#elif (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_4)
+        UINT Reserved                   :22;    // 0xFFFFFC00
+#elif (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_2)
+        UINT Reserved                   :25;    // 0xFFFFFF80
+#else
+        UINT Reserved                   :29;    // 0xFFFFFFF8
+#endif // DXGKDDI_INTERFACE_VERSION
+    };
+    UINT Value;
+} DXGK_MONITORLINKINFO_CAPABILITIES, *PDXGK_MONITORLINKINFO_CAPABILITIES;
+
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_1)
+
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_2)
+
+#if defined(__cplusplus) && !defined(SORTPP_PASS)
+
+typedef enum _DXGK_DISPLAY_USAGE : BYTE
+{
+    DXGK_DU_INVALID     = 0,
+    DXGK_DU_GENERIC     = 1,
+    DXGK_DU_AR          = 2,
+    DXGK_DU_VR          = 3,
+    DXGK_DU_MEDICAL_IMAGING = 4,
+    DXGK_DU_ACCESSORY   = 5,
+    DXGK_DU_MAX         = 6
+} DXGK_DISPLAY_USAGE, *PDXGK_DISPLAY_USAGE;
+
+typedef enum _DXGK_DISPLAY_TECHNOLOGY : BYTE
+{
+    DXGK_DT_INVALID     = 0,
+    DXGK_DT_OTHER       = 1,
+    DXGK_DT_LCD         = 2,
+    DXGK_DT_OLED        = 3,
+    DXGK_DT_PROJECTOR   = 4,
+    DXGK_DT_MAX         = 5
+} DXGK_DISPLAY_TECHNOLOGY, *PDXGK_DISPLAY_TECHNOLOGY;
+
+typedef enum _DXGK_DISPLAY_DESCRIPTOR_TYPE: BYTE
+{
+    DXGK_DDT_INVALID = 0,
+    DXGK_DDT_EDID,
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_5)
+    DXGK_DDT_DISPLAYID,
+#endif
+} DXGK_DISPLAY_DESCRIPTOR_TYPE, *PDXGK_DISPLAY_DESCRIPTOR_TYPE;
+
+#else
+typedef BYTE DXGK_DISPLAY_USAGE;
+typedef BYTE DXGK_DISPLAY_TECHNOLOGY;
+typedef BYTE DXGK_DISPLAY_DESCRIPTOR_TYPE;
+#endif // defined(__cplusplus) && !defined(SORTPP_PASS)
+
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_2)
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_5)
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Capabilities, preferences and other information reported by display only capable adapters.
+
+typedef struct _D3DKMT_DISPLAY_CAPS
+{
+    union
+    {
+        struct
+        {
+            UINT64 PreferPhysicallyContiguous : 1;
+            UINT64 Reserved : 63;
+        };
+        UINT64 Value;
+    };
+} D3DKMT_DISPLAY_CAPS;
+
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_5)
+
+#pragma pack( pop )
+
+#endif // (NTDDI_VERSION >= NTDDI_LONGHORN) || defined(D3DKMDT_SPECIAL_MULTIPLATFORM_TOOL)
+
+#pragma warning(pop)
+
+
+#endif /* WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) */
+#pragma endregion
+
+#endif /* _D3DKMDT_H */
+
+

--- a/sdk/include/psdk/d3dkmdt.h
+++ b/sdk/include/psdk/d3dkmdt.h
@@ -24,6 +24,8 @@
 
 #include "d3dukmdt.h"
 
+#ifndef __REACTOS__
+
 #define NTSTATUS                int32_t
 
 /*
@@ -74,6 +76,14 @@ typedef enum _DEVICE_POWER_STATE {
     PowerDeviceMaximum
 } DEVICE_POWER_STATE, *PDEVICE_POWER_STATE;
 
+#else
+
+#ifndef NTSTATUS
+typedef LONG NTSTATUS;
+#endif
+
+#endif // !__REACTOS__
+
 #pragma region Desktop Family
 #if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
 
@@ -85,7 +95,7 @@ typedef enum _DEVICE_POWER_STATE {
 // Available only for Vista (LONGHORN) and later and for
 // multiplatform tools such as debugger extensions
 //
-#if (NTDDI_VERSION >= NTDDI_LONGHORN) || defined(D3DKMDT_SPECIAL_MULTIPLATFORM_TOOL)
+#if defined(__REACTOS__) || ((NTDDI_VERSION >= NTDDI_LONGHORN) || defined(D3DKMDT_SPECIAL_MULTIPLATFORM_TOOL))
 
 //
 // Hardcoded overlay count
@@ -600,7 +610,11 @@ typedef struct _D3DKMDT_VIDEO_SIGNAL_INFO
         struct
         {
             // Scan line ordering (e.g. progressive, interlaced).
+#ifdef __REACTOS__
+            UINT ScanLineOrdering : 3; // D3DDDI_VIDEO_SIGNAL_SCANLINE_ORDERING
+#else
             D3DDDI_VIDEO_SIGNAL_SCANLINE_ORDERING ScanLineOrdering : 3;
+#endif
 
             // Vertical refresh frequency divider
             UINT VSyncFreqDivider               : 6;

--- a/sdk/include/psdk/d3dukmdt.h
+++ b/sdk/include/psdk/d3dukmdt.h
@@ -194,7 +194,7 @@ typedef union _D3DKMT_PTR_TYPE
 // Available only for Vista (LONGHORN) and later and for
 // multiplatform tools such as debugger extensions
 //
-#if (NTDDI_VERSION >= NTDDI_LONGHORN) || defined(D3DKMDT_SPECIAL_MULTIPLATFORM_TOOL)
+#if defined(__REACTOS__) || ((NTDDI_VERSION >= NTDDI_LONGHORN) || defined(D3DKMDT_SPECIAL_MULTIPLATFORM_TOOL))
 
 typedef ULONGLONG D3DGPU_VIRTUAL_ADDRESS;
 typedef ULONGLONG D3DGPU_SIZE_T;

--- a/sdk/include/psdk/d3dukmdt.h
+++ b/sdk/include/psdk/d3dukmdt.h
@@ -1,139 +1,1950 @@
-/*
- * Copyright 2016 Henri Verbeet for CodeWeavers
+/******************************Module*Header************************************\
+*
+* Module Name: d3dukmdt.h
+*
+* Content: Windows Display Driver Model (WDDM) user/kernel mode
+*          shared data type definitions.
+*
+* Copyright (c) Microsoft Corporation.
+* Licensed under the MIT License.
+*
+\*******************************************************************************/
+#ifndef _D3DUKMDT_H_
+#define _D3DUKMDT_H_
+#include <winapifamily.h>
+
+#pragma region Desktop Family
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+
+#if !defined(_D3DKMDT_H)       && \
+    !defined(_D3DKMTHK_H_)     && \
+    !defined(_D3DUMDDI_H_)     && \
+    !defined(__DXGKRNLETW_H__)
+   #error This header should not be included directly!
+#endif
+
+#pragma warning(push)
+#pragma warning(disable:4201) // anonymous unions warning
+#pragma warning(disable:4214)   // nonstandard extension used: bit field types other than int
+
+
+//
+// WDDM DDI Interface Version
+//
+
+#define DXGKDDI_INTERFACE_VERSION_VISTA      0x1052
+#define DXGKDDI_INTERFACE_VERSION_VISTA_SP1  0x1053
+#define DXGKDDI_INTERFACE_VERSION_WIN7       0x2005
+#define DXGKDDI_INTERFACE_VERSION_WIN8       0x300E
+#define DXGKDDI_INTERFACE_VERSION_WDDM1_3    0x4002
+#define DXGKDDI_INTERFACE_VERSION_WDDM1_3_PATH_INDEPENDENT_ROTATION  0x4003
+#define DXGKDDI_INTERFACE_VERSION_WDDM2_0    0x5023
+#define DXGKDDI_INTERFACE_VERSION_WDDM2_1    0x6003
+#define DXGKDDI_INTERFACE_VERSION_WDDM2_1_5  0x6010     // Used in RS1.7 for GPU-P
+#define DXGKDDI_INTERFACE_VERSION_WDDM2_1_6  0x6011     // Used in RS1.8 for GPU-P
+#define DXGKDDI_INTERFACE_VERSION_WDDM2_2    0x700A
+#define DXGKDDI_INTERFACE_VERSION_WDDM2_3    0x8001
+#define DXGKDDI_INTERFACE_VERSION_WDDM2_4    0x9006
+#define DXGKDDI_INTERFACE_VERSION_WDDM2_5    0xA00B
+#define DXGKDDI_INTERFACE_VERSION_WDDM2_6    0xB004
+#define DXGKDDI_INTERFACE_VERSION_WDDM2_7    0xC004
+#define DXGKDDI_INTERFACE_VERSION_WDDM2_8    0xD001
+#define DXGKDDI_INTERFACE_VERSION_WDDM2_9    0xE003
+#define DXGKDDI_INTERFACE_VERSION_WDDM3_0    0xF003
+
+
+#define IS_OFFICIAL_DDI_INTERFACE_VERSION(version)                 \
+            (((version) == DXGKDDI_INTERFACE_VERSION_VISTA) ||     \
+             ((version) == DXGKDDI_INTERFACE_VERSION_VISTA_SP1) || \
+             ((version) == DXGKDDI_INTERFACE_VERSION_WIN7) ||      \
+             ((version) == DXGKDDI_INTERFACE_VERSION_WIN8) ||      \
+             ((version) == DXGKDDI_INTERFACE_VERSION_WDDM1_3) ||   \
+             ((version) == DXGKDDI_INTERFACE_VERSION_WDDM1_3_PATH_INDEPENDENT_ROTATION) || \
+             ((version) == DXGKDDI_INTERFACE_VERSION_WDDM2_0) ||   \
+             ((version) == DXGKDDI_INTERFACE_VERSION_WDDM2_1) ||   \
+             ((version) == DXGKDDI_INTERFACE_VERSION_WDDM2_1_5) || \
+             ((version) == DXGKDDI_INTERFACE_VERSION_WDDM2_1_6) || \
+             ((version) == DXGKDDI_INTERFACE_VERSION_WDDM2_2) ||   \
+             ((version) == DXGKDDI_INTERFACE_VERSION_WDDM2_3) ||   \
+             ((version) == DXGKDDI_INTERFACE_VERSION_WDDM2_4) ||   \
+             ((version) == DXGKDDI_INTERFACE_VERSION_WDDM2_5) ||   \
+             ((version) == DXGKDDI_INTERFACE_VERSION_WDDM2_6) ||   \
+             ((version) == DXGKDDI_INTERFACE_VERSION_WDDM2_7) ||   \
+             ((version) == DXGKDDI_INTERFACE_VERSION_WDDM2_8) ||   \
+             ((version) == DXGKDDI_INTERFACE_VERSION_WDDM2_9) ||   \
+             ((version) == DXGKDDI_INTERFACE_VERSION_WDDM3_0)      \
+            )
+
+#if !defined(DXGKDDI_INTERFACE_VERSION)
+#define DXGKDDI_INTERFACE_VERSION           DXGKDDI_INTERFACE_VERSION_WDDM3_0
+#endif // !defined(DXGKDDI_INTERFACE_VERSION)
+
+#define D3D_UMD_INTERFACE_VERSION_VISTA      0x000C
+#define D3D_UMD_INTERFACE_VERSION_WIN7       0x2003
+#define D3D_UMD_INTERFACE_VERSION_WIN8_M3    0x3001
+#define D3D_UMD_INTERFACE_VERSION_WIN8_CP    0x3002
+#define D3D_UMD_INTERFACE_VERSION_WIN8_RC    0x3003
+#define D3D_UMD_INTERFACE_VERSION_WIN8       0x3004
+#define D3D_UMD_INTERFACE_VERSION_WDDM1_3    0x4002
+
+#define D3D_UMD_INTERFACE_VERSION_WDDM2_0_M1    0x5000
+#define D3D_UMD_INTERFACE_VERSION_WDDM2_0_M1_3  0x5001
+#define D3D_UMD_INTERFACE_VERSION_WDDM2_0_M2_2  0x5002
+#define D3D_UMD_INTERFACE_VERSION_WDDM2_0       0x5002
+
+#define D3D_UMD_INTERFACE_VERSION_WDDM2_1_1     0x6000
+#define D3D_UMD_INTERFACE_VERSION_WDDM2_1_2     0x6001
+#define D3D_UMD_INTERFACE_VERSION_WDDM2_1_3     0x6002
+#define D3D_UMD_INTERFACE_VERSION_WDDM2_1_4     0x6003
+#define D3D_UMD_INTERFACE_VERSION_WDDM2_1       D3D_UMD_INTERFACE_VERSION_WDDM2_1_4
+
+#define D3D_UMD_INTERFACE_VERSION_WDDM2_2_1     0x7000
+#define D3D_UMD_INTERFACE_VERSION_WDDM2_2_2     0x7001
+#define D3D_UMD_INTERFACE_VERSION_WDDM2_2       D3D_UMD_INTERFACE_VERSION_WDDM2_2_2
+
+#define D3D_UMD_INTERFACE_VERSION_WDDM2_3_1     0x8000
+#define D3D_UMD_INTERFACE_VERSION_WDDM2_3_2     0x8001
+#define D3D_UMD_INTERFACE_VERSION_WDDM2_3       D3D_UMD_INTERFACE_VERSION_WDDM2_3_2
+
+#define D3D_UMD_INTERFACE_VERSION_WDDM2_4_1     0x9000
+#define D3D_UMD_INTERFACE_VERSION_WDDM2_4_2     0x9001
+#define D3D_UMD_INTERFACE_VERSION_WDDM2_4       D3D_UMD_INTERFACE_VERSION_WDDM2_4_2
+
+#define D3D_UMD_INTERFACE_VERSION_WDDM2_5_1     0xA000
+#define D3D_UMD_INTERFACE_VERSION_WDDM2_5_2     0xA001
+#define D3D_UMD_INTERFACE_VERSION_WDDM2_5_3     0xA002
+#define D3D_UMD_INTERFACE_VERSION_WDDM2_5       D3D_UMD_INTERFACE_VERSION_WDDM2_5_3
+
+#define D3D_UMD_INTERFACE_VERSION_WDDM2_6_1     0xB000
+#define D3D_UMD_INTERFACE_VERSION_WDDM2_6_2     0xB001
+#define D3D_UMD_INTERFACE_VERSION_WDDM2_6_3     0xB002
+#define D3D_UMD_INTERFACE_VERSION_WDDM2_6_4     0xB003
+#define D3D_UMD_INTERFACE_VERSION_WDDM2_6       D3D_UMD_INTERFACE_VERSION_WDDM2_6_4
+
+#define D3D_UMD_INTERFACE_VERSION_WDDM2_7_1     0xC000
+#define D3D_UMD_INTERFACE_VERSION_WDDM2_7_2     0xC001
+#define D3D_UMD_INTERFACE_VERSION_WDDM2_7       D3D_UMD_INTERFACE_VERSION_WDDM2_7_2
+
+#define D3D_UMD_INTERFACE_VERSION_WDDM2_8_1     0xD000
+#define D3D_UMD_INTERFACE_VERSION_WDDM2_8       D3D_UMD_INTERFACE_VERSION_WDDM2_8_1
+
+#define D3D_UMD_INTERFACE_VERSION_WDDM2_9_1     0xE000
+#define D3D_UMD_INTERFACE_VERSION_WDDM2_9       D3D_UMD_INTERFACE_VERSION_WDDM2_9_1
+
+#define D3D_UMD_INTERFACE_VERSION_WDDM3_0_1     0xF000
+#define D3D_UMD_INTERFACE_VERSION_WDDM3_0       D3D_UMD_INTERFACE_VERSION_WDDM3_0_1
+
+// Components which depend on D3D_UMD_INTERFACE_VERSION need to be updated, static assert validation present.
+// Search for D3D_UMD_INTERFACE_VERSION across all depots to ensure all dependencies are updated.
+
+#if !defined(D3D_UMD_INTERFACE_VERSION)
+#define D3D_UMD_INTERFACE_VERSION           D3D_UMD_INTERFACE_VERSION_WDDM3_0
+#endif // !defined(D3D_UMD_INTERFACE_VERSION)
+
+//
+// These macros are used to enable non-Windows 32-bit usermode to fill out a fixed-size
+// structure for D3DKMT structures, so that they can be sent to a 64-bit kernel
+// without a thunking layer for translation.
+//
+// Note that a thunking layer is still used for wchar_t translation, where Windows uses
+// 16-bit characters and non-Windows uses 32-bit characters.
+//
+// If brace initialization is used (e.g. D3DKMT_FOO foo = { a, b, c }), be aware that for
+// non-Windows, pointers will be unioned such that a 64-bit integer is the member that is
+// initialized. It is not possible to achieve both type safety and proper zero-initialization
+// of the high bits of pointers with brace initialization in this model. Use D3DKMT_PTR_INIT(ptr)
+// to appropriately cast to a 64-bit integer for non-Windows, or to pass the pointer unchanged for
+// Windows. To maintain type safety, manually assign the fields after zero-initializing the struct.
+//
+#ifdef _WIN32
+// For Windows, don't enforce any unnatural alignment or data sizes/types.
+// The WOW64 thunking layer will handle translation.
+#define D3DKMT_ALIGN64
+#define D3DKMT_PTR_HELPER(Name)
+#define D3DKMT_PTR(Type, Name) Type Name
+#define D3DKMT_PTR_INIT(x) (x)
+typedef SIZE_T D3DKMT_SIZE_T;
+typedef UINT_PTR D3DKMT_UINT_PTR;
+typedef ULONG_PTR D3DKMT_ULONG_PTR;
+typedef HANDLE D3DKMT_PTR_TYPE;
+#else
+// For other platforms, struct layout should be fixed-size, x64-compatible
+#if __cplusplus >= 201103L
+ #define D3DKMT_ALIGN64 alignas(8)
+#else
+ #define D3DKMT_ALIGN64 __attribute__((aligned(8)))
+#endif
+#define D3DKMT_PTR_HELPER(Name) D3DKMT_ALIGN64 UINT64 Name;
+#define D3DKMT_PTR(Type, Name)       \
+union D3DKMT_ALIGN64                 \
+{                                    \
+    D3DKMT_PTR_HELPER(Name##_Align)  \
+    Type Name;                       \
+}
+#define D3DKMT_PTR_INIT(x) { (UINT64)(SIZE_T)(x) }
+typedef UINT64 D3DKMT_SIZE_T, D3DKMT_UINT_PTR, D3DKMT_ULONG_PTR;
+typedef union _D3DKMT_PTR_TYPE
+{
+    D3DKMT_PTR_HELPER(Ptr_Align);
+    HANDLE Ptr;
+} D3DKMT_PTR_TYPE;
+#endif
+
+//
+// Available only for Vista (LONGHORN) and later and for
+// multiplatform tools such as debugger extensions
+//
+#if (NTDDI_VERSION >= NTDDI_LONGHORN) || defined(D3DKMDT_SPECIAL_MULTIPLATFORM_TOOL)
+
+typedef ULONGLONG D3DGPU_VIRTUAL_ADDRESS;
+typedef ULONGLONG D3DGPU_SIZE_T;
+#define D3DGPU_UNIQUE_DRIVER_PROTECTION 0x8000000000000000ULL
+
+#define DXGK_MAX_PAGE_TABLE_LEVEL_COUNT 6
+#define DXGK_MIN_PAGE_TABLE_LEVEL_COUNT 2
+
+//
+// IOCTL_GPUP_DRIVER_ESCAPE - The user mode emulation DLL calls this IOCTL
+// to exchange information with the kernel mode driver.
+//
+#define IOCTL_GPUP_DRIVER_ESCAPE CTL_CODE(FILE_DEVICE_UNKNOWN, (8 + 0x910), METHOD_BUFFERED, FILE_READ_DATA)
+typedef struct _GPUP_DRIVER_ESCAPE_INPUT
+{
+   LUID        vfLUID; //LUID that was returned from SET_PARTITION_DETAILS
+} GPUP_DRIVER_ESCAPE_INPUT, *PGPUP_DRIVER_ESCAPE_INPUT;
+
+typedef enum _DXGKVGPU_ESCAPE_TYPE
+{
+    DXGKVGPU_ESCAPE_TYPE_READ_PCI_CONFIG            = 0,
+    DXGKVGPU_ESCAPE_TYPE_WRITE_PCI_CONFIG           = 1,
+    DXGKVGPU_ESCAPE_TYPE_INITIALIZE                 = 2,
+    DXGKVGPU_ESCAPE_TYPE_RELEASE                    = 3,
+    DXGKVGPU_ESCAPE_TYPE_GET_VGPU_TYPE              = 4,
+    DXGKVGPU_ESCAPE_TYPE_POWERTRANSITIONCOMPLETE    = 5,
+} DXGKVGPU_ESCAPE_TYPE;
+
+typedef struct _DXGKVGPU_ESCAPE_HEAD
+{
+    GPUP_DRIVER_ESCAPE_INPUT    Luid;
+    DXGKVGPU_ESCAPE_TYPE        Type;
+} DXGKVGPU_ESCAPE_HEAD;
+
+typedef struct _DXGKVGPU_ESCAPE_READ_PCI_CONFIG
+{
+    DXGKVGPU_ESCAPE_HEAD Header;
+
+    UINT  Offset;           // Offset in bytes in the PCI config space
+    UINT  Size;             // Size in bytes to read
+} DXGKVGPU_ESCAPE_READ_PCI_CONFIG;
+
+typedef struct _DXGKVGPU_ESCAPE_WRITE_PCI_CONFIG
+{
+    DXGKVGPU_ESCAPE_HEAD Header;
+
+    UINT  Offset;           // Offset in bytes in the PCI config space
+    UINT  Size;             // Size in bytes to write
+    // "Size" number of bytes follow
+} DXGKVGPU_ESCAPE_WRITE_PCI_CONFIG;
+
+typedef struct _DXGKVGPU_ESCAPE_READ_VGPU_TYPE
+{
+    DXGKVGPU_ESCAPE_HEAD Header;
+} DXGKVGPU_ESCAPE_READ_VGPU_TYPE;
+
+typedef struct _DXGKVGPU_ESCAPE_POWERTRANSITIONCOMPLETE
+{
+    DXGKVGPU_ESCAPE_HEAD Header;
+    UINT PowerState;
+} DXGKVGPU_ESCAPE_POWERTRANSITIONCOMPLETE;
+
+typedef struct _DXGKVGPU_ESCAPE_INITIALIZE
+{
+    DXGKVGPU_ESCAPE_HEAD    Header;
+    GUID                    VmGuid;
+} DXGKVGPU_ESCAPE_INITIALIZE;
+
+typedef struct _DXGKVGPU_ESCAPE_RELEASE
+{
+    DXGKVGPU_ESCAPE_HEAD Header;
+} DXGKVGPU_ESCAPE_RELEASE;
+
+
+typedef enum _DXGK_PTE_PAGE_SIZE
+{
+    DXGK_PTE_PAGE_TABLE_PAGE_4KB       = 0,
+    DXGK_PTE_PAGE_TABLE_PAGE_64KB      = 1,
+} DXGK_PTE_PAGE_SIZE;
+
+//
+//  Page Table Entry structure. Contains segment/physical address pointing to a page
+//
+
+typedef struct _DXGK_PTE
+{
+    union
+    {
+        struct
+        {
+            ULONGLONG Valid                 :  1;
+            ULONGLONG Zero                  :  1;
+            ULONGLONG CacheCoherent         :  1;
+            ULONGLONG ReadOnly              :  1;
+            ULONGLONG NoExecute             :  1;
+            ULONGLONG Segment               :  5;
+            ULONGLONG LargePage             :  1;
+            ULONGLONG PhysicalAdapterIndex  :  6;
+            ULONGLONG PageTablePageSize     :  2;       // DXGK_PTE_PAGE_SIZE
+            ULONGLONG SystemReserved0       :  1;
+            ULONGLONG Reserved              :  44;
+        };
+        ULONGLONG Flags;
+    };
+    union
+    {
+        ULONGLONG PageAddress;      // High 52 bits of 64 bit physical address. Low 12 bits are zero.
+        ULONGLONG PageTableAddress; // High 52 bits of 64 bit physical address. Low 12 bits are zero.
+    };
+} DXGK_PTE;
+
+#define D3DGPU_NULL 0
+#define D3DDDI_MAX_WRITTEN_PRIMARIES 16
+#define D3DDDI_MAX_MPO_PRESENT_DIRTY_RECTS  0xFFF
+
+typedef struct _D3DGPU_PHYSICAL_ADDRESS
+{
+    UINT    SegmentId;
+    UINT    Padding;
+    UINT64  SegmentOffset;
+} D3DGPU_PHYSICAL_ADDRESS;
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Purpose: Video present source unique identification number descriptor type
+//
+
+typedef UINT  D3DDDI_VIDEO_PRESENT_SOURCE_ID;
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Purpose: Video present source unique identification number descriptor type.
+//
+typedef UINT  D3DDDI_VIDEO_PRESENT_TARGET_ID;
+
+//
+// DDI level handle that represents a kernel mode object (allocation, device, etc)
+//
+typedef UINT D3DKMT_HANDLE;
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Purpose: Video present target mode fractional frequency descriptor type.
+//
+// Remarks: Fractional value used to represent vertical and horizontal frequencies of a video mode
+//          (i.e. VSync and HSync). Vertical frequencies are stored in Hz. Horizontal frequencies
+//          are stored in Hz.
+//          The dynamic range of this encoding format, given 10^-7 resolution is {0..(2^32 - 1) / 10^7},
+//          which translates to {0..428.4967296} [Hz] for vertical frequencies and {0..428.4967296} [Hz]
+//          for horizontal frequencies. This sub-microseconds precision range should be acceptable even
+//          for a pro-video application (error in one microsecond for video signal synchronization would
+//          imply a time drift with a cycle of 10^7/(60*60*24) = 115.741 days.
+//
+//          If rational number with a finite fractional sequence, use denominator of form 10^(length of fractional sequence).
+//          If rational number without a finite fractional sequence, or a sequence exceeding the precision allowed by the
+//          dynamic range of the denominator, or an irrational number, use an appropriate ratio of integers which best
+//          represents the value.
+//
+typedef struct _D3DDDI_RATIONAL
+{
+    UINT    Numerator;
+    UINT    Denominator;
+} D3DDDI_RATIONAL;
+
+typedef struct _D3DDDI_ALLOCATIONINFO
+{
+    D3DKMT_HANDLE                   hAllocation;           // out: Private driver data for allocation
+    D3DKMT_PTR(CONST VOID*,         pSystemMem);           // in: Pointer to pre-allocated sysmem
+    D3DKMT_PTR(VOID*,               pPrivateDriverData);   // in(out optional): Private data for each allocation
+    UINT                            PrivateDriverDataSize; // in: Size of the private data
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID  VidPnSourceId;         // in: VidPN source ID if this is a primary
+    union
+    {
+        struct
+        {
+            UINT    Primary         : 1;    // 0x00000001
+#if ((DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8) || \
+     (D3D_UMD_INTERFACE_VERSION >= D3D_UMD_INTERFACE_VERSION_WIN8))
+            UINT    Stereo          : 1;    // 0x00000002
+            UINT    Reserved        :30;    // 0xFFFFFFFC
+#else
+            UINT    Reserved        :31;    // 0xFFFFFFFE
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8)
+        };
+        UINT        Value;
+    } Flags;
+} D3DDDI_ALLOCATIONINFO;
+
+#if ((DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN7) || \
+     (D3D_UMD_INTERFACE_VERSION >= D3D_UMD_INTERFACE_VERSION_WIN7))
+
+typedef struct _D3DDDI_ALLOCATIONINFO2
+{
+    D3DKMT_HANDLE                   hAllocation;           // out: Private driver data for allocation
+    union D3DKMT_ALIGN64
+    {
+        D3DKMT_PTR_HELPER(pSystemMem_hSection_Align)
+        HANDLE                      hSection;              // in: Handle to valid section object
+        CONST VOID*                 pSystemMem;            // in: Pointer to pre-allocated sysmem
+    };
+    D3DKMT_PTR(VOID*,               pPrivateDriverData);   // in(out optional): Private data for each allocation
+    UINT                            PrivateDriverDataSize; // in: Size of the private data
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID  VidPnSourceId;         // in: VidPN source ID if this is a primary
+    union
+    {
+        struct
+        {
+            UINT    Primary          : 1;    // 0x00000001
+#if ((DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8) || \
+     (D3D_UMD_INTERFACE_VERSION >= D3D_UMD_INTERFACE_VERSION_WIN8))
+            UINT    Stereo           : 1;    // 0x00000002
+#if ((DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_2) || \
+     (D3D_UMD_INTERFACE_VERSION >= D3D_UMD_INTERFACE_VERSION_WDDM2_2))
+            UINT    OverridePriority : 1;    // 0x00000004
+            UINT    Reserved         : 29;   // 0xFFFFFFF8
+#else
+            UINT    Reserved         : 30;    // 0xFFFFFFFC
+#endif
+#else
+            UINT    Reserved          :31;    // 0xFFFFFFFE
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8)
+        };
+        UINT        Value;
+    } Flags;
+    D3DKMT_ALIGN64 D3DGPU_VIRTUAL_ADDRESS GpuVirtualAddress;    // out: GPU Virtual address of the allocation created.
+#if ((DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_2) || \
+     (D3D_UMD_INTERFACE_VERSION >= D3D_UMD_INTERFACE_VERSION_WDDM2_2))
+    union
+    {
+        UINT                        Priority;             // in: priority of allocation
+        D3DKMT_ALIGN64 ULONG_PTR    Unused;
+    };
+    D3DKMT_ALIGN64 ULONG_PTR        Reserved[5];          // Reserved
+#else
+    D3DKMT_ALIGN64 ULONG_PTR        Reserved[6];          // Reserved
+#endif
+} D3DDDI_ALLOCATIONINFO2;
+
+#endif
+
+typedef struct _D3DDDI_OPENALLOCATIONINFO
+{
+    D3DKMT_HANDLE   hAllocation;                // in: Handle for this allocation in this process
+    D3DKMT_PTR(CONST VOID*, pPrivateDriverData);         // in: Ptr to driver private buffer for this allocations
+    UINT            PrivateDriverDataSize;      // in: Size in bytes of driver private buffer for this allocations
+
+} D3DDDI_OPENALLOCATIONINFO;
+
+#if ((DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN7) || \
+     (D3D_UMD_INTERFACE_VERSION >= D3D_UMD_INTERFACE_VERSION_WIN7))
+
+typedef struct _D3DDDI_OPENALLOCATIONINFO2
+{
+    D3DKMT_HANDLE   hAllocation;                // in: Handle for this allocation in this process
+    D3DKMT_PTR(CONST VOID*, pPrivateDriverData);// in: Ptr to driver private buffer for this allocations
+    UINT            PrivateDriverDataSize;      // in: Size in bytes of driver private buffer for this allocations
+    D3DKMT_ALIGN64 D3DGPU_VIRTUAL_ADDRESS GpuVirtualAddress;   // out: GPU Virtual address of the allocation opened.
+    D3DKMT_ALIGN64 ULONG_PTR Reserved[6];       // Reserved
+} D3DDDI_OPENALLOCATIONINFO2;
+
+#endif
+
+#if ((DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8) || \
+     (D3D_UMD_INTERFACE_VERSION >= D3D_UMD_INTERFACE_VERSION_WIN8))
+
+typedef enum _D3DDDI_OFFER_PRIORITY
+{
+    D3DDDI_OFFER_PRIORITY_NONE=0,               // Do not offer
+    D3DDDI_OFFER_PRIORITY_LOW=1,                // Content is not useful
+    D3DDDI_OFFER_PRIORITY_NORMAL,               // Content is useful but easy to regenerate
+    D3DDDI_OFFER_PRIORITY_HIGH,                 // Content is useful and difficult to regenerate
+    D3DDDI_OFFER_PRIORITY_AUTO,                 // Let VidMm decide offer priority based on eviction priority
+} D3DDDI_OFFER_PRIORITY;
+
+#endif
+
+typedef struct _D3DDDI_ALLOCATIONLIST
+{
+    D3DKMT_HANDLE       hAllocation;
+    union
+    {
+        struct
+        {
+            UINT                  WriteOperation      : 1; // 0x00000001
+            UINT                  DoNotRetireInstance : 1; // 0x00000002
+
+#if ((DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8) || \
+     (D3D_UMD_INTERFACE_VERSION >= D3D_UMD_INTERFACE_VERSION_WIN8))
+            UINT                  OfferPriority       : 3; // 0x0000001C D3DDDI_OFFER_PRIORITY
+            UINT                  Reserved            :27; // 0xFFFFFFE0
+#else
+            UINT                  Reserved            :30; // 0xFFFFFFFC
+#endif
+        };
+        UINT                Value;
+    };
+} D3DDDI_ALLOCATIONLIST;
+
+typedef struct _D3DDDI_PATCHLOCATIONLIST
+{
+    UINT                AllocationIndex;
+    union
+    {
+        struct
+        {
+            UINT            SlotId          : 24;   // 0x00FFFFFF
+            UINT            Reserved        : 8;    // 0xFF000000
+        };
+        UINT                Value;
+    };
+    UINT                DriverId;
+    UINT                AllocationOffset;
+    UINT                PatchOffset;
+    UINT                SplitOffset;
+} D3DDDI_PATCHLOCATIONLIST;
+
+typedef struct _D3DDDICB_LOCKFLAGS
+{
+    union
+    {
+        struct
+        {
+            UINT    ReadOnly            : 1;    // 0x00000001
+            UINT    WriteOnly           : 1;    // 0x00000002
+            UINT    DonotWait           : 1;    // 0x00000004
+            UINT    IgnoreSync          : 1;    // 0x00000008
+            UINT    LockEntire          : 1;    // 0x00000010
+            UINT    DonotEvict          : 1;    // 0x00000020
+            UINT    AcquireAperture     : 1;    // 0x00000040
+            UINT    Discard             : 1;    // 0x00000080
+            UINT    NoExistingReference : 1;    // 0x00000100
+            UINT    UseAlternateVA      : 1;    // 0x00000200
+            UINT    IgnoreReadSync      : 1;    // 0x00000400
+            UINT    Reserved            :21;    // 0xFFFFF800
+        };
+        UINT        Value;
+    };
+} D3DDDICB_LOCKFLAGS;
+
+typedef struct _D3DDDICB_LOCK2FLAGS
+{
+    union
+    {
+        struct
+        {
+            UINT    Reserved            : 32;    // 0xFFFFFFFF
+        };
+        UINT        Value;
+    };
+} D3DDDICB_LOCK2FLAGS;
+
+typedef struct _D3DDDICB_DESTROYALLOCATION2FLAGS
+{
+    union
+    {
+        struct
+        {
+            UINT    AssumeNotInUse      :  1;    // 0x00000001
+            UINT    SynchronousDestroy  :  1;    // 0x00000002
+            UINT    Reserved            : 29;    // 0x7FFFFFFC
+            UINT    SystemUseOnly       :  1;    // 0x80000000  // Should not be set by the UMD
+        };
+        UINT        Value;
+    };
+} D3DDDICB_DESTROYALLOCATION2FLAGS;
+
+typedef struct _D3DDDI_ESCAPEFLAGS
+{
+    union
+    {
+        struct
+        {
+            UINT    HardwareAccess      : 1;    // 0x00000001
+#if ((DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM1_3) || \
+     (D3D_UMD_INTERFACE_VERSION >= D3D_UMD_INTERFACE_VERSION_WDDM1_3))
+            UINT    DeviceStatusQuery   : 1;    // 0x00000002
+            UINT    ChangeFrameLatency  : 1;    // 0x00000004
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0)
+            UINT    NoAdapterSynchronization    : 1; // 0x00000008
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_2)
+            UINT    Reserved            : 1;    // 0x00000010   Used internally by DisplayOnly present
+            UINT    VirtualMachineData  : 1;    // 0x00000020   Cannot be set from user mode
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_5)
+            UINT    DriverKnownEscape   : 1;    // 0x00000040       // Driver private data points to a well known structure
+            UINT    DriverCommonEscape  : 1;    // 0x00000080       // Private data points runtime defined structure
+            UINT    Reserved2           :24;    // 0xFFFFFF00
+#else  // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_5)
+            UINT    Reserved2           :26;    // 0xFFFFFFC0
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_5)
+#else
+            UINT    Reserved            :28;    // 0xFFFFFFF0
+#endif //  (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_2)
+#else
+            UINT    Reserved            :29;    // 0xFFFFFFF8
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0)
+#else
+            UINT    Reserved            :31;    // 0xFFFFFFFE
+#endif // WDDM1_3
+        };
+        UINT        Value;
+    };
+} D3DDDI_ESCAPEFLAGS;
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_5)
+
+typedef enum _D3DDDI_DRIVERESCAPETYPE
+{
+    D3DDDI_DRIVERESCAPETYPE_TRANSLATEALLOCATIONHANDLE   = 0,
+    D3DDDI_DRIVERESCAPETYPE_TRANSLATERESOURCEHANDLE     = 1,
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM3_0)
+    D3DDDI_DRIVERESCAPETYPE_CPUEVENTUSAGE               = 2,
+#endif
+    D3DDDI_DRIVERESCAPETYPE_MAX,
+} D3DDDI_DRIVERESCAPETYPE;
+
+typedef struct _D3DDDI_DRIVERESCAPE_TRANSLATEALLOCATIONEHANDLE
+{
+     D3DDDI_DRIVERESCAPETYPE  EscapeType;
+     D3DKMT_HANDLE            hAllocation;
+} D3DDDI_DRIVERESCAPE_TRANSLATEALLOCATIONEHANDLE;
+
+typedef struct _D3DDDI_DRIVERESCAPE_TRANSLATERESOURCEHANDLE
+{
+    D3DDDI_DRIVERESCAPETYPE  EscapeType;
+    D3DKMT_HANDLE            hResource;
+} D3DDDI_DRIVERESCAPE_TRANSLATERESOURCEHANDLE;
+
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_5)
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM3_0)
+
+typedef struct _D3DDDI_DRIVERESCAPE_CPUEVENTUSAGE
+{
+    D3DDDI_DRIVERESCAPETYPE EscapeType;
+    D3DKMT_HANDLE           hSyncObject;
+    D3DKMT_ALIGN64 UINT64   hKmdCpuEvent;
+    UINT                    Usage[8];
+} D3DDDI_DRIVERESCAPE_CPUEVENTUSAGE;
+
+#endif
+
+typedef struct _D3DDDI_CREATECONTEXTFLAGS
+{
+    union
+    {
+        struct
+        {
+            UINT    NullRendering       : 1;      // 0x00000001
+            UINT    InitialData         : 1;      // 0x00000002
+#if ((DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0) || \
+     (D3D_UMD_INTERFACE_VERSION >= D3D_UMD_INTERFACE_VERSION_WDDM2_0))
+            UINT    DisableGpuTimeout   : 1;      // 0x00000004
+            UINT    SynchronizationOnly : 1;      // 0x00000008
+#if ((DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_3) || \
+     (D3D_UMD_INTERFACE_VERSION >= D3D_UMD_INTERFACE_VERSION_WDDM2_3_1))
+            UINT    HwQueueSupported    : 1;      // 0x00000010
+            UINT    NoKmdAccess         : 1;      // 0x00000020
+            UINT    Reserved            :26;      // 0xFFFFFFC0
+#else
+            UINT    Reserved            :28;      // 0xFFFFFFF0
+#endif // DXGKDDI_INTERFACE_VERSION
+
+#else
+            UINT    Reserved            :30;      // 0xFFFFFFFC
+#endif // DXGKDDI_INTERFACE_VERSION
+        };
+        UINT Value;
+    };
+} D3DDDI_CREATECONTEXTFLAGS;
+
+#if ((DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_2) || \
+     (D3D_UMD_INTERFACE_VERSION >= D3D_UMD_INTERFACE_VERSION_WDDM2_2_1))
+
+typedef struct _D3DDDI_CREATEHWCONTEXTFLAGS
+{
+    union
+    {
+        struct
+        {
+            UINT    Reserved            :32;      // 0xFFFFFFFF
+        };
+        UINT Value;
+    };
+} D3DDDI_CREATEHWCONTEXTFLAGS;
+
+typedef struct _D3DDDI_CREATEHWQUEUEFLAGS
+{
+    union
+    {
+        struct
+        {
+            UINT    DisableGpuTimeout   : 1;      // 0x00000001
+            UINT    NoBroadcastSignal   : 1;      // 0x00000002
+            UINT    NoBroadcastWait     : 1;      // 0x00000004
+            UINT    NoKmdAccess         : 1;      // 0x00000008
+            UINT    Reserved            :28;      // 0xFFFFFFF0
+        };
+        UINT Value;
+    };
+} D3DDDI_CREATEHWQUEUEFLAGS;
+
+#endif // ((DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_2)
+
+typedef struct _D3DDDI_SEGMENTPREFERENCE
+{
+    union
+    {
+        struct
+        {
+            UINT SegmentId0 : 5;                // 0x0000001F
+            UINT Direction0 : 1;                // 0x00000020
+            UINT SegmentId1 : 5;                // 0x000007C0
+            UINT Direction1 : 1;                // 0x00000800
+            UINT SegmentId2 : 5;                // 0x0001F000
+            UINT Direction2 : 1;                // 0x00020000
+            UINT SegmentId3 : 5;                // 0x007C0000
+            UINT Direction3 : 1;                // 0x00800000
+            UINT SegmentId4 : 5;                // 0x1F000000
+            UINT Direction4 : 1;                // 0x20000000
+            UINT Reserved   : 2;                // 0xC0000000
+        };
+        UINT Value;
+    };
+} D3DDDI_SEGMENTPREFERENCE;
+
+/* Formats
+ * Most of these names have the following convention:
+ *      A = Alpha
+ *      R = Red
+ *      G = Green
+ *      B = Blue
+ *      X = Unused Bits
+ *      P = Palette
+ *      L = Luminance
+ *      U = dU coordinate for BumpMap
+ *      V = dV coordinate for BumpMap
+ *      S = Stencil
+ *      D = Depth (e.g. Z or W buffer)
+ *      C = Computed from other channels (typically on certain read operations)
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
+ *      Further, the order of the pieces are from MSB first; hence
+ *      D3DFMT_A8L8 indicates that the high byte of this two byte
+ *      format is alpha.
  *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
+ *      D16 indicates:
+ *           - An integer 16-bit value.
+ *           - An app-lockable surface.
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *      All Depth/Stencil formats except D3DFMT_D16_LOCKABLE indicate:
+ *          - no particular bit ordering per pixel, and
+ *          - are not app lockable, and
+ *          - the driver is allowed to consume more than the indicated
+ *            number of bits per Depth channel (but not Stencil channel).
  */
-
-#ifndef __WINE_D3DUKMDT_H
-#define __WINE_D3DUKMDT_H
-
 #ifndef MAKEFOURCC
-#define MAKEFOURCC(ch0, ch1, ch2, ch3) \
-        ((DWORD)(BYTE)(ch0) | ((DWORD)(BYTE)(ch1) << 8) | \
-        ((DWORD)(BYTE)(ch2) << 16) | ((DWORD)(BYTE)(ch3) << 24))
-#endif /* MAKEFOURCC */
+    #define MAKEFOURCC(ch0, ch1, ch2, ch3)                              \
+                ((DWORD)(BYTE)(ch0) | ((DWORD)(BYTE)(ch1) << 8) |       \
+                ((DWORD)(BYTE)(ch2) << 16) | ((DWORD)(BYTE)(ch3) << 24 ))
+#endif /* defined(MAKEFOURCC) */
+
 
 typedef enum _D3DDDIFORMAT
 {
-    D3DDDIFMT_UNKNOWN                 = 0,
-    D3DDDIFMT_R8G8B8                  = 0x14,
-    D3DDDIFMT_A8R8G8B8                = 0x15,
-    D3DDDIFMT_X8R8G8B8                = 0x16,
-    D3DDDIFMT_R5G6B5                  = 0x17,
-    D3DDDIFMT_X1R5G5B5                = 0x18,
-    D3DDDIFMT_A1R5G5B5                = 0x19,
-    D3DDDIFMT_A4R4G4B4                = 0x1a,
-    D3DDDIFMT_R3G3B2                  = 0x1b,
-    D3DDDIFMT_A8                      = 0x1c,
-    D3DDDIFMT_A8R3G3B2                = 0x1d,
-    D3DDDIFMT_X4R4G4B4                = 0x1e,
-    D3DDDIFMT_A2B10G10R10             = 0x1f,
-    D3DDDIFMT_A8B8G8R8                = 0x20,
-    D3DDDIFMT_X8B8G8R8                = 0x21,
-    D3DDDIFMT_G16R16                  = 0x22,
-    D3DDDIFMT_A2R10G10B10             = 0x23,
-    D3DDDIFMT_A16B16G16R16            = 0x24,
-    D3DDDIFMT_A8P8                    = 0x28,
-    D3DDDIFMT_P8                      = 0x29,
-    D3DDDIFMT_L8                      = 0x32,
-    D3DDDIFMT_A8L8                    = 0x33,
-    D3DDDIFMT_A4L4                    = 0x34,
-    D3DDDIFMT_V8U8                    = 0x3c,
-    D3DDDIFMT_L6V5U5                  = 0x3d,
-    D3DDDIFMT_X8L8V8U8                = 0x3e,
-    D3DDDIFMT_Q8W8V8U8                = 0x3f,
-    D3DDDIFMT_V16U16                  = 0x40,
-    D3DDDIFMT_W11V11U10               = 0x41,
-    D3DDDIFMT_A2W10V10U10             = 0x43,
-    D3DDDIFMT_D16_LOCKABLE            = 0x46,
-    D3DDDIFMT_D32                     = 0x47,
-    D3DDDIFMT_S1D15                   = 0x48,
-    D3DDDIFMT_D15S1                   = 0x49,
-    D3DDDIFMT_S8D24                   = 0x4a,
-    D3DDDIFMT_D24S8                   = 0x4b,
-    D3DDDIFMT_X8D24                   = 0x4c,
-    D3DDDIFMT_D24X8                   = 0x4d,
-    D3DDDIFMT_X4S4D24                 = 0x4e,
-    D3DDDIFMT_D24X4S4                 = 0x4f,
-    D3DDDIFMT_D16                     = 0x50,
-    D3DDDIFMT_L16                     = 0x51,
-    D3DDDIFMT_D32F_LOCKABLE           = 0x52,
-    D3DDDIFMT_D24FS8                  = 0x53,
-    D3DDDIFMT_D32_LOCKABLE            = 0x54,
-    D3DDDIFMT_S8_LOCKABLE             = 0x55,
-    D3DDDIFMT_G8R8                    = 0x5b,
-    D3DDDIFMT_R8                      = 0x5c,
-    D3DDDIFMT_VERTEXDATA              = 0x64,
-    D3DDDIFMT_INDEX16                 = 0x65,
-    D3DDDIFMT_INDEX32                 = 0x66,
-    D3DDDIFMT_Q16W16V16U16            = 0x6e,
-    D3DDDIFMT_R16F                    = 0x6f,
-    D3DDDIFMT_G16R16F                 = 0x70,
-    D3DDDIFMT_A16B16G16R16F           = 0x71,
-    D3DDDIFMT_R32F                    = 0x72,
-    D3DDDIFMT_G32R32F                 = 0x73,
-    D3DDDIFMT_A32B32G32R32F           = 0x74,
-    D3DDDIFMT_CxV8U8                  = 0x75,
-    D3DDDIFMT_A1                      = 0x76,
-    D3DDDIFMT_A2B10G10R10_XR_BIAS     = 0x77,
-    D3DDDIFMT_DXVACOMPBUFFER_BASE     = 0x96,
-    D3DDDIFMT_PICTUREPARAMSDATA       = D3DDDIFMT_DXVACOMPBUFFER_BASE + 0,
-    D3DDDIFMT_MACROBLOCKDATA          = D3DDDIFMT_DXVACOMPBUFFER_BASE + 0x01,
-    D3DDDIFMT_RESIDUALDIFFERENCEDATA  = D3DDDIFMT_DXVACOMPBUFFER_BASE + 0x02,
-    D3DDDIFMT_DEBLOCKINGDATA          = D3DDDIFMT_DXVACOMPBUFFER_BASE + 0x03,
-    D3DDDIFMT_INVERSEQUANTIZATIONDATA = D3DDDIFMT_DXVACOMPBUFFER_BASE + 0x04,
-    D3DDDIFMT_SLICECONTROLDATA        = D3DDDIFMT_DXVACOMPBUFFER_BASE + 0x05,
-    D3DDDIFMT_BITSTREAMDATA           = D3DDDIFMT_DXVACOMPBUFFER_BASE + 0x06,
-    D3DDDIFMT_MOTIONVECTORBUFFER      = D3DDDIFMT_DXVACOMPBUFFER_BASE + 0x07,
-    D3DDDIFMT_FILMGRAINBUFFER         = D3DDDIFMT_DXVACOMPBUFFER_BASE + 0x08,
-    D3DDDIFMT_DXVA_RESERVED9          = D3DDDIFMT_DXVACOMPBUFFER_BASE + 0x09,
-    D3DDDIFMT_DXVA_RESERVED10         = D3DDDIFMT_DXVACOMPBUFFER_BASE + 0x0a,
-    D3DDDIFMT_DXVA_RESERVED11         = D3DDDIFMT_DXVACOMPBUFFER_BASE + 0x0b,
-    D3DDDIFMT_DXVA_RESERVED12         = D3DDDIFMT_DXVACOMPBUFFER_BASE + 0x0c,
-    D3DDDIFMT_DXVA_RESERVED13         = D3DDDIFMT_DXVACOMPBUFFER_BASE + 0x0d,
-    D3DDDIFMT_DXVA_RESERVED14         = D3DDDIFMT_DXVACOMPBUFFER_BASE + 0x0e,
-    D3DDDIFMT_DXVA_RESERVED15         = D3DDDIFMT_DXVACOMPBUFFER_BASE + 0x0f,
-    D3DDDIFMT_DXVA_RESERVED16         = D3DDDIFMT_DXVACOMPBUFFER_BASE + 0x10,
-    D3DDDIFMT_DXVA_RESERVED17         = D3DDDIFMT_DXVACOMPBUFFER_BASE + 0x11,
-    D3DDDIFMT_DXVA_RESERVED18         = D3DDDIFMT_DXVACOMPBUFFER_BASE + 0x12,
-    D3DDDIFMT_DXVA_RESERVED19         = D3DDDIFMT_DXVACOMPBUFFER_BASE + 0x13,
-    D3DDDIFMT_DXVA_RESERVED20         = D3DDDIFMT_DXVACOMPBUFFER_BASE + 0x14,
-    D3DDDIFMT_DXVA_RESERVED21         = D3DDDIFMT_DXVACOMPBUFFER_BASE + 0x15,
-    D3DDDIFMT_DXVA_RESERVED22         = D3DDDIFMT_DXVACOMPBUFFER_BASE + 0x16,
-    D3DDDIFMT_DXVA_RESERVED23         = D3DDDIFMT_DXVACOMPBUFFER_BASE + 0x17,
-    D3DDDIFMT_DXVA_RESERVED24         = D3DDDIFMT_DXVACOMPBUFFER_BASE + 0x18,
-    D3DDDIFMT_DXVA_RESERVED25         = D3DDDIFMT_DXVACOMPBUFFER_BASE + 0x19,
-    D3DDDIFMT_DXVA_RESERVED26         = D3DDDIFMT_DXVACOMPBUFFER_BASE + 0x1a,
-    D3DDDIFMT_DXVA_RESERVED27         = D3DDDIFMT_DXVACOMPBUFFER_BASE + 0x1b,
-    D3DDDIFMT_DXVA_RESERVED28         = D3DDDIFMT_DXVACOMPBUFFER_BASE + 0x1c,
-    D3DDDIFMT_DXVA_RESERVED29         = D3DDDIFMT_DXVACOMPBUFFER_BASE + 0x1d,
-    D3DDDIFMT_DXVA_RESERVED30         = D3DDDIFMT_DXVACOMPBUFFER_BASE + 0x1e,
-    D3DDDIFMT_DXVA_RESERVED31         = D3DDDIFMT_DXVACOMPBUFFER_BASE + 0x1f,
+
+    D3DDDIFMT_UNKNOWN           =  0,
+
+    D3DDDIFMT_R8G8B8            = 20,
+    D3DDDIFMT_A8R8G8B8          = 21,
+    D3DDDIFMT_X8R8G8B8          = 22,
+    D3DDDIFMT_R5G6B5            = 23,
+    D3DDDIFMT_X1R5G5B5          = 24,
+    D3DDDIFMT_A1R5G5B5          = 25,
+    D3DDDIFMT_A4R4G4B4          = 26,
+    D3DDDIFMT_R3G3B2            = 27,
+    D3DDDIFMT_A8                = 28,
+    D3DDDIFMT_A8R3G3B2          = 29,
+    D3DDDIFMT_X4R4G4B4          = 30,
+    D3DDDIFMT_A2B10G10R10       = 31,
+    D3DDDIFMT_A8B8G8R8          = 32,
+    D3DDDIFMT_X8B8G8R8          = 33,
+    D3DDDIFMT_G16R16            = 34,
+    D3DDDIFMT_A2R10G10B10       = 35,
+    D3DDDIFMT_A16B16G16R16      = 36,
+
+    D3DDDIFMT_A8P8              = 40,
+    D3DDDIFMT_P8                = 41,
+
+    D3DDDIFMT_L8                = 50,
+    D3DDDIFMT_A8L8              = 51,
+    D3DDDIFMT_A4L4              = 52,
+
+    D3DDDIFMT_V8U8              = 60,
+    D3DDDIFMT_L6V5U5            = 61,
+    D3DDDIFMT_X8L8V8U8          = 62,
+    D3DDDIFMT_Q8W8V8U8          = 63,
+    D3DDDIFMT_V16U16            = 64,
+    D3DDDIFMT_W11V11U10         = 65,
+    D3DDDIFMT_A2W10V10U10       = 67,
+
+    D3DDDIFMT_UYVY              = MAKEFOURCC('U', 'Y', 'V', 'Y'),
+    D3DDDIFMT_R8G8_B8G8         = MAKEFOURCC('R', 'G', 'B', 'G'),
+    D3DDDIFMT_YUY2              = MAKEFOURCC('Y', 'U', 'Y', '2'),
+    D3DDDIFMT_G8R8_G8B8         = MAKEFOURCC('G', 'R', 'G', 'B'),
+    D3DDDIFMT_DXT1              = MAKEFOURCC('D', 'X', 'T', '1'),
+    D3DDDIFMT_DXT2              = MAKEFOURCC('D', 'X', 'T', '2'),
+    D3DDDIFMT_DXT3              = MAKEFOURCC('D', 'X', 'T', '3'),
+    D3DDDIFMT_DXT4              = MAKEFOURCC('D', 'X', 'T', '4'),
+    D3DDDIFMT_DXT5              = MAKEFOURCC('D', 'X', 'T', '5'),
+
+    D3DDDIFMT_D16_LOCKABLE      = 70,
+    D3DDDIFMT_D32               = 71,
+    D3DDDIFMT_D15S1             = 73,
+    D3DDDIFMT_D24S8             = 75,
+    D3DDDIFMT_D24X8             = 77,
+    D3DDDIFMT_D24X4S4           = 79,
+    D3DDDIFMT_D16               = 80,
+
+    D3DDDIFMT_D32F_LOCKABLE     = 82,
+    D3DDDIFMT_D24FS8            = 83,
+
+    D3DDDIFMT_D32_LOCKABLE      = 84,
+    D3DDDIFMT_S8_LOCKABLE       = 85,
+
+    D3DDDIFMT_S1D15             = 72,
+    D3DDDIFMT_S8D24             = 74,
+    D3DDDIFMT_X8D24             = 76,
+    D3DDDIFMT_X4S4D24           = 78,
+
+    D3DDDIFMT_L16               = 81,
+#if (D3D_UMD_INTERFACE_VERSION >= D3D_UMD_INTERFACE_VERSION_WDDM1_3) // M1
+    D3DDDIFMT_G8R8              = 91,
+    D3DDDIFMT_R8                = 92,
+#endif
+
+    D3DDDIFMT_VERTEXDATA        =100,
+    D3DDDIFMT_INDEX16           =101,
+    D3DDDIFMT_INDEX32           =102,
+
+    D3DDDIFMT_Q16W16V16U16      =110,
+
+    D3DDDIFMT_MULTI2_ARGB8      = MAKEFOURCC('M','E','T','1'),
+
+    // Floating point surface formats
+
+    // s10e5 formats (16-bits per channel)
+    D3DDDIFMT_R16F              = 111,
+    D3DDDIFMT_G16R16F           = 112,
+    D3DDDIFMT_A16B16G16R16F     = 113,
+
+    // IEEE s23e8 formats (32-bits per channel)
+    D3DDDIFMT_R32F              = 114,
+    D3DDDIFMT_G32R32F           = 115,
+    D3DDDIFMT_A32B32G32R32F     = 116,
+
+    D3DDDIFMT_CxV8U8            = 117,
+
+    // Monochrome 1 bit per pixel format
+    D3DDDIFMT_A1                = 118,
+
+    // 2.8 biased fixed point
+    D3DDDIFMT_A2B10G10R10_XR_BIAS = 119,
+
+    // Decode compressed buffer formats
+    D3DDDIFMT_DXVACOMPBUFFER_BASE     = 150,
+    D3DDDIFMT_PICTUREPARAMSDATA       = D3DDDIFMT_DXVACOMPBUFFER_BASE+0,    // 150
+    D3DDDIFMT_MACROBLOCKDATA          = D3DDDIFMT_DXVACOMPBUFFER_BASE+1,    // 151
+    D3DDDIFMT_RESIDUALDIFFERENCEDATA  = D3DDDIFMT_DXVACOMPBUFFER_BASE+2,    // 152
+    D3DDDIFMT_DEBLOCKINGDATA          = D3DDDIFMT_DXVACOMPBUFFER_BASE+3,    // 153
+    D3DDDIFMT_INVERSEQUANTIZATIONDATA = D3DDDIFMT_DXVACOMPBUFFER_BASE+4,    // 154
+    D3DDDIFMT_SLICECONTROLDATA        = D3DDDIFMT_DXVACOMPBUFFER_BASE+5,    // 155
+    D3DDDIFMT_BITSTREAMDATA           = D3DDDIFMT_DXVACOMPBUFFER_BASE+6,    // 156
+    D3DDDIFMT_MOTIONVECTORBUFFER      = D3DDDIFMT_DXVACOMPBUFFER_BASE+7,    // 157
+    D3DDDIFMT_FILMGRAINBUFFER         = D3DDDIFMT_DXVACOMPBUFFER_BASE+8,    // 158
+    D3DDDIFMT_DXVA_RESERVED9          = D3DDDIFMT_DXVACOMPBUFFER_BASE+9,    // 159
+    D3DDDIFMT_DXVA_RESERVED10         = D3DDDIFMT_DXVACOMPBUFFER_BASE+10,   // 160
+    D3DDDIFMT_DXVA_RESERVED11         = D3DDDIFMT_DXVACOMPBUFFER_BASE+11,   // 161
+    D3DDDIFMT_DXVA_RESERVED12         = D3DDDIFMT_DXVACOMPBUFFER_BASE+12,   // 162
+    D3DDDIFMT_DXVA_RESERVED13         = D3DDDIFMT_DXVACOMPBUFFER_BASE+13,   // 163
+    D3DDDIFMT_DXVA_RESERVED14         = D3DDDIFMT_DXVACOMPBUFFER_BASE+14,   // 164
+    D3DDDIFMT_DXVA_RESERVED15         = D3DDDIFMT_DXVACOMPBUFFER_BASE+15,   // 165
+    D3DDDIFMT_DXVA_RESERVED16         = D3DDDIFMT_DXVACOMPBUFFER_BASE+16,   // 166
+    D3DDDIFMT_DXVA_RESERVED17         = D3DDDIFMT_DXVACOMPBUFFER_BASE+17,   // 167
+    D3DDDIFMT_DXVA_RESERVED18         = D3DDDIFMT_DXVACOMPBUFFER_BASE+18,   // 168
+    D3DDDIFMT_DXVA_RESERVED19         = D3DDDIFMT_DXVACOMPBUFFER_BASE+19,   // 169
+    D3DDDIFMT_DXVA_RESERVED20         = D3DDDIFMT_DXVACOMPBUFFER_BASE+20,   // 170
+    D3DDDIFMT_DXVA_RESERVED21         = D3DDDIFMT_DXVACOMPBUFFER_BASE+21,   // 171
+    D3DDDIFMT_DXVA_RESERVED22         = D3DDDIFMT_DXVACOMPBUFFER_BASE+22,   // 172
+    D3DDDIFMT_DXVA_RESERVED23         = D3DDDIFMT_DXVACOMPBUFFER_BASE+23,   // 173
+    D3DDDIFMT_DXVA_RESERVED24         = D3DDDIFMT_DXVACOMPBUFFER_BASE+24,   // 174
+    D3DDDIFMT_DXVA_RESERVED25         = D3DDDIFMT_DXVACOMPBUFFER_BASE+25,   // 175
+    D3DDDIFMT_DXVA_RESERVED26         = D3DDDIFMT_DXVACOMPBUFFER_BASE+26,   // 176
+    D3DDDIFMT_DXVA_RESERVED27         = D3DDDIFMT_DXVACOMPBUFFER_BASE+27,   // 177
+    D3DDDIFMT_DXVA_RESERVED28         = D3DDDIFMT_DXVACOMPBUFFER_BASE+28,   // 178
+    D3DDDIFMT_DXVA_RESERVED29         = D3DDDIFMT_DXVACOMPBUFFER_BASE+29,   // 179
+    D3DDDIFMT_DXVA_RESERVED30         = D3DDDIFMT_DXVACOMPBUFFER_BASE+30,   // 180
+    D3DDDIFMT_DXVA_RESERVED31         = D3DDDIFMT_DXVACOMPBUFFER_BASE+31,   // 181
     D3DDDIFMT_DXVACOMPBUFFER_MAX      = D3DDDIFMT_DXVA_RESERVED31,
-    D3DDDIFMT_BINARYBUFFER            = 0xc7,
-    D3DDDIFMT_DXT1                    = MAKEFOURCC('D', 'X', 'T', '1'),
-    D3DDDIFMT_DXT2                    = MAKEFOURCC('D', 'X', 'T', '2'),
-    D3DDDIFMT_DXT3                    = MAKEFOURCC('D', 'X', 'T', '3'),
-    D3DDDIFMT_DXT4                    = MAKEFOURCC('D', 'X', 'T', '4'),
-    D3DDDIFMT_DXT5                    = MAKEFOURCC('D', 'X', 'T', '5'),
-    D3DDDIFMT_G8R8_G8B8               = MAKEFOURCC('G', 'R', 'G', 'B'),
-    D3DDDIFMT_MULTI2_ARGB8            = MAKEFOURCC('M', 'E', 'T', '1'),
-    D3DDDIFMT_R8G8_B8G8               = MAKEFOURCC('R', 'G', 'B', 'G'),
-    D3DDDIFMT_UYVY                    = MAKEFOURCC('U', 'Y', 'V', 'Y'),
-    D3DDDIFMT_YUY2                    = MAKEFOURCC('Y', 'U', 'Y', '2'),
-    D3DDDIFMT_FORCE_UINT              = 0x7fffffff,
+
+    D3DDDIFMT_BINARYBUFFER            = 199,
+
+    D3DDDIFMT_FORCE_UINT        =0x7fffffff
 } D3DDDIFORMAT;
 
-#endif /* __WINE_D3DUKMDT_H */
+typedef enum D3DDDI_COLOR_SPACE_TYPE
+{
+    D3DDDI_COLOR_SPACE_RGB_FULL_G22_NONE_P709             = 0,
+    D3DDDI_COLOR_SPACE_RGB_FULL_G10_NONE_P709             = 1,
+    D3DDDI_COLOR_SPACE_RGB_STUDIO_G22_NONE_P709           = 2,
+    D3DDDI_COLOR_SPACE_RGB_STUDIO_G22_NONE_P2020          = 3,
+    D3DDDI_COLOR_SPACE_RESERVED                           = 4,
+    D3DDDI_COLOR_SPACE_YCBCR_FULL_G22_NONE_P709_X601      = 5,
+    D3DDDI_COLOR_SPACE_YCBCR_STUDIO_G22_LEFT_P601         = 6,
+    D3DDDI_COLOR_SPACE_YCBCR_FULL_G22_LEFT_P601           = 7,
+    D3DDDI_COLOR_SPACE_YCBCR_STUDIO_G22_LEFT_P709         = 8,
+    D3DDDI_COLOR_SPACE_YCBCR_FULL_G22_LEFT_P709           = 9,
+    D3DDDI_COLOR_SPACE_YCBCR_STUDIO_G22_LEFT_P2020        = 10,
+    D3DDDI_COLOR_SPACE_YCBCR_FULL_G22_LEFT_P2020          = 11,
+    D3DDDI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020          = 12,
+    D3DDDI_COLOR_SPACE_YCBCR_STUDIO_G2084_LEFT_P2020      = 13,
+    D3DDDI_COLOR_SPACE_RGB_STUDIO_G2084_NONE_P2020        = 14,
+    D3DDDI_COLOR_SPACE_YCBCR_STUDIO_G22_TOPLEFT_P2020     = 15,
+    D3DDDI_COLOR_SPACE_YCBCR_STUDIO_G2084_TOPLEFT_P2020   = 16,
+    D3DDDI_COLOR_SPACE_RGB_FULL_G22_NONE_P2020            = 17,
+    D3DDDI_COLOR_SPACE_YCBCR_STUDIO_GHLG_TOPLEFT_P2020    = 18,
+    D3DDDI_COLOR_SPACE_YCBCR_FULL_GHLG_TOPLEFT_P2020      = 19,
+    D3DDDI_COLOR_SPACE_RGB_STUDIO_G24_NONE_P709           = 20,
+    D3DDDI_COLOR_SPACE_RGB_STUDIO_G24_NONE_P2020          = 21,
+    D3DDDI_COLOR_SPACE_YCBCR_STUDIO_G24_LEFT_P709         = 22,
+    D3DDDI_COLOR_SPACE_YCBCR_STUDIO_G24_LEFT_P2020        = 23,
+    D3DDDI_COLOR_SPACE_YCBCR_STUDIO_G24_TOPLEFT_P2020     = 24,
+    D3DDDI_COLOR_SPACE_CUSTOM                             = 0xFFFFFFFF
+} D3DDDI_COLOR_SPACE_TYPE;
+
+//
+// Note: This enum is intended to specify the final wire signaling
+// colorspace values. Do not mix it with enum values defined in
+// D3DDDI_COLOR_SPACE_TYPE which are used to specify
+// input colorspace for MPOs and other surfaces.
+//
+typedef enum _D3DDDI_OUTPUT_WIRE_COLOR_SPACE_TYPE
+{
+    // We are using the same values for these first two enums for
+    // backward compatibility to WDDM2.2 drivers which used
+    // to get these 2 values from D3DDDI_COLOR_SPACE_TYPE
+    D3DDDI_OUTPUT_WIRE_COLOR_SPACE_G22_P709               = 0,
+    D3DDDI_OUTPUT_WIRE_COLOR_SPACE_RESERVED               = 4,
+    D3DDDI_OUTPUT_WIRE_COLOR_SPACE_G2084_P2020            = 12,
+
+    // We are starting the new enum value at 30 just to make sure it
+    // is not confused with the existing D3DDDI_COLOR_SPACE_TYPE
+    // in the short term
+    D3DDDI_OUTPUT_WIRE_COLOR_SPACE_G22_P709_WCG           = 30,
+
+    // OS only intend to use the _G22_P2020 value in future,
+    // for now graphics drivers should not expect it.
+    D3DDDI_OUTPUT_WIRE_COLOR_SPACE_G22_P2020              = 31,
+
+    // OS only intend to use the _G2084_P2020_HDR10PLUS value in future,
+    // for now graphics drivers should not expect it.
+    D3DDDI_OUTPUT_WIRE_COLOR_SPACE_G2084_P2020_HDR10PLUS  = 32,
+
+    // OS only intend to use the _G2084_P2020_DVLL value in future,
+    // for now graphics drivers should not expect it.
+    D3DDDI_OUTPUT_WIRE_COLOR_SPACE_G2084_P2020_DVLL       = 33,
+} D3DDDI_OUTPUT_WIRE_COLOR_SPACE_TYPE;
+
+typedef struct _D3DDDIRECT
+{
+    LONG left;
+    LONG top;
+    LONG right;
+    LONG bottom;
+} D3DDDIRECT;
+
+typedef struct _D3DDDI_KERNELOVERLAYINFO
+{
+    D3DKMT_HANDLE        hAllocation;           // in: Allocation to be displayed
+    D3DDDIRECT           DstRect;               // in: Dest rect
+    D3DDDIRECT           SrcRect;               // in: Source rect
+    D3DKMT_PTR(VOID*,    pPrivateDriverData);   // in: Private driver data
+    UINT                 PrivateDriverDataSize; // in: Size of private driver data
+} D3DDDI_KERNELOVERLAYINFO;
+
+typedef enum _D3DDDI_GAMMARAMP_TYPE
+{
+    D3DDDI_GAMMARAMP_UNINITIALIZED = 0,
+    D3DDDI_GAMMARAMP_DEFAULT       = 1,
+    D3DDDI_GAMMARAMP_RGB256x3x16   = 2,
+    D3DDDI_GAMMARAMP_DXGI_1        = 3,
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_3)
+    D3DDDI_GAMMARAMP_MATRIX_3x4    = 4,
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_3)
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_6)
+    D3DDDI_GAMMARAMP_MATRIX_V2     = 5,
+#endif // DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_6
+} D3DDDI_GAMMARAMP_TYPE;
+
+typedef struct _D3DDDI_GAMMA_RAMP_RGB256x3x16
+{
+    USHORT  Red[256];
+    USHORT  Green[256];
+    USHORT  Blue[256];
+} D3DDDI_GAMMA_RAMP_RGB256x3x16;
+
+typedef struct D3DDDI_DXGI_RGB
+{
+    float   Red;
+    float   Green;
+    float   Blue;
+} D3DDDI_DXGI_RGB;
+
+typedef struct _D3DDDI_GAMMA_RAMP_DXGI_1
+{
+    D3DDDI_DXGI_RGB    Scale;
+    D3DDDI_DXGI_RGB    Offset;
+    D3DDDI_DXGI_RGB    GammaCurve[1025];
+} D3DDDI_GAMMA_RAMP_DXGI_1;
+
+typedef struct _D3DKMDT_3X4_COLORSPACE_TRANSFORM
+{
+    float               ColorMatrix3x4[3][4];
+    float               ScalarMultiplier;
+    D3DDDI_DXGI_RGB     LookupTable1D[4096];
+} D3DKMDT_3x4_COLORSPACE_TRANSFORM, *PD3DDDI_3x4_COLORSPACE_TRANSFORM;
+
+typedef enum _D3DKMDT_COLORSPACE_TRANSFORM_STAGE_CONTROL
+{
+    D3DKMDT_COLORSPACE_TRANSFORM_STAGE_CONTROL_NO_CHANGE = 0,
+    D3DKMDT_COLORSPACE_TRANSFORM_STAGE_CONTROL_ENABLE    = 1,
+    D3DKMDT_COLORSPACE_TRANSFORM_STAGE_CONTROL_BYPASS    = 2,
+}D3DKMDT_COLORSPACE_TRANSFORM_STAGE_CONTROL, *PD3DKMDT_COLORSPACE_TRANSFORM_STAGE_CONTROL;
+
+typedef struct _D3DKMDT_COLORSPACE_TRANSFORM_MATRIX_V2
+{
+    // stage of 1D Degamma.
+    D3DKMDT_COLORSPACE_TRANSFORM_STAGE_CONTROL  StageControlLookupTable1DDegamma;
+    D3DDDI_DXGI_RGB                             LookupTable1DDegamma[4096];
+
+    // stage of 3x3 matrix
+    D3DKMDT_COLORSPACE_TRANSFORM_STAGE_CONTROL  StageControlColorMatrix3x3;
+    float                                       ColorMatrix3x3[3][3];
+
+    // stage of 1D Regamma.
+    D3DKMDT_COLORSPACE_TRANSFORM_STAGE_CONTROL  StageControlLookupTable1DRegamma;
+    D3DDDI_DXGI_RGB                             LookupTable1DRegamma[4096];
+} D3DKMDT_COLORSPACE_TRANSFORM_MATRIX_V2, *PD3DKMDT_COLORSPACE_TRANSFORM_MATRIX_V2;
+
+typedef enum _D3DDDI_HDR_METADATA_TYPE
+{
+    D3DDDI_HDR_METADATA_TYPE_NONE               = 0,
+    D3DDDI_HDR_METADATA_TYPE_HDR10              = 1,
+    D3DDDI_HDR_METADATA_TYPE_HDR10PLUS         = 2,
+} D3DDDI_HDR_METADATA_TYPE;
+
+typedef struct _D3DDDI_HDR_METADATA_HDR10
+{
+    // Color gamut
+    UINT16 RedPrimary[2];
+    UINT16 GreenPrimary[2];
+    UINT16 BluePrimary[2];
+    UINT16 WhitePoint[2];
+
+    // Luminance
+    UINT   MaxMasteringLuminance;
+    UINT   MinMasteringLuminance;
+    UINT16 MaxContentLightLevel;
+    UINT16 MaxFrameAverageLightLevel;
+} D3DDDI_HDR_METADATA_HDR10;
+
+typedef struct D3DDDI_HDR_METADATA_HDR10PLUS
+{
+    BYTE Data[72];
+} D3DDDI_HDR_METADATA_HDR10PLUS;
+
+// Used as a value for D3DDDI_VIDEO_PRESENT_SOURCE_ID and D3DDDI_VIDEO_PRESENT_TARGET_ID types to specify
+// that the respective video present source/target ID hasn't been initialized.
+#define D3DDDI_ID_UNINITIALIZED (UINT)(~0)
+
+// TODO:[mmilirud] Define this as (UINT)(~1) to avoid collision with valid source ID equal to 0.
+//
+// Used as a value for D3DDDI_VIDEO_PRESENT_SOURCE_ID and D3DDDI_VIDEO_PRESENT_TARGET_ID types to specify
+// that the respective video present source/target ID isn't applicable for the given execution context.
+#define D3DDDI_ID_NOTAPPLICABLE (UINT)(0)
+
+// Indicates that a resource can be associated with "any" VidPn source, even none at all.
+#define D3DDDI_ID_ANY (UINT)(~1)
+
+// Used as a value for D3DDDI_VIDEO_PRESENT_SOURCE_ID and D3DDDI_VIDEO_PRESENT_TARGET_ID types to specify
+// that the respective video present source/target ID describes every VidPN source/target in question.
+#define D3DDDI_ID_ALL (UINT)(~2)
+
+//
+// Hardcoded VidPnSource count
+//
+#define D3DKMDT_MAX_VIDPN_SOURCES_BITCOUNT      4
+#define D3DKMDT_MAX_VIDPN_SOURCES               (1 << D3DKMDT_MAX_VIDPN_SOURCES_BITCOUNT)
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Purpose: Multi-sampling method descriptor type.
+//
+// Remarks: Driver is free to partition its quality levels for a given multi-sampling method into as many
+//          increments as it likes, with the condition that each incremental step does noticably improve
+//          quality of the presented image.
+//
+typedef struct _D3DDDI_MULTISAMPLINGMETHOD
+{
+    // Number of sub-pixels employed in this multi-sampling method (e.g. 2 for 2x and 8 for 8x multi-sampling)
+    UINT  NumSamples;
+
+    // Upper bound on the quality range supported for this multi-sampling method. The range starts from 0
+    // and goes upto and including the reported maximum quality setting.
+    UINT  NumQualityLevels;
+}
+D3DDDI_MULTISAMPLINGMETHOD;
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Purpose: Video signal scan line ordering descriptor type.
+//
+// Remarks: Scan-line ordering of the video mode, specifies whether each field contains the entire
+//          content of a frame, or only half of it (i.e. even/odd lines interchangeably).
+//          Note that while for standard interlaced modes, what field comes first can be inferred
+//          from the mode, specifying this characteristic explicitly with an enum both frees up the
+//          client from having to maintain mode-based look-up tables and is extensible for future
+//          standard modes not listed in the D3DKMDT_VIDEO_SIGNAL_STANDARD enum.
+//
+typedef enum _D3DDDI_VIDEO_SIGNAL_SCANLINE_ORDERING
+{
+    D3DDDI_VSSLO_UNINITIALIZED              = 0,
+    D3DDDI_VSSLO_PROGRESSIVE                = 1,
+    D3DDDI_VSSLO_INTERLACED_UPPERFIELDFIRST = 2,
+    D3DDDI_VSSLO_INTERLACED_LOWERFIELDFIRST = 3,
+    D3DDDI_VSSLO_OTHER                      = 255
+}
+D3DDDI_VIDEO_SIGNAL_SCANLINE_ORDERING;
+
+
+typedef enum D3DDDI_FLIPINTERVAL_TYPE
+{
+    D3DDDI_FLIPINTERVAL_IMMEDIATE = 0,
+    D3DDDI_FLIPINTERVAL_ONE       = 1,
+    D3DDDI_FLIPINTERVAL_TWO       = 2,
+    D3DDDI_FLIPINTERVAL_THREE     = 3,
+    D3DDDI_FLIPINTERVAL_FOUR      = 4,
+
+    // This value is only valid for the D3D9 runtime PresentCb SyncIntervalOverride field.
+    // For this field, IMMEDIATE means the API semantic of sync interval 0, where
+    // IMMEDIATE_ALLOW_TEARING is equivalent to the addition of the DXGI ALLOW_TEARING API flags.
+    D3DDDI_FLIPINTERVAL_IMMEDIATE_ALLOW_TEARING = 5,
+} D3DDDI_FLIPINTERVAL_TYPE;
+
+
+typedef enum _D3DDDI_POOL
+{
+     D3DDDIPOOL_SYSTEMMEM      = 1,
+     D3DDDIPOOL_VIDEOMEMORY    = 2,
+     D3DDDIPOOL_LOCALVIDMEM    = 3,
+     D3DDDIPOOL_NONLOCALVIDMEM = 4,
+#if (D3D_UMD_INTERFACE_VERSION >= D3D_UMD_INTERFACE_VERSION_WDDM1_3) // M1
+     D3DDDIPOOL_STAGINGMEM     = 5,
+#endif
+} D3DDDI_POOL;
+
+
+typedef enum _D3DDDIMULTISAMPLE_TYPE
+{
+    D3DDDIMULTISAMPLE_NONE         =  0,
+    D3DDDIMULTISAMPLE_NONMASKABLE  =  1,
+    D3DDDIMULTISAMPLE_2_SAMPLES    =  2,
+    D3DDDIMULTISAMPLE_3_SAMPLES    =  3,
+    D3DDDIMULTISAMPLE_4_SAMPLES    =  4,
+    D3DDDIMULTISAMPLE_5_SAMPLES    =  5,
+    D3DDDIMULTISAMPLE_6_SAMPLES    =  6,
+    D3DDDIMULTISAMPLE_7_SAMPLES    =  7,
+    D3DDDIMULTISAMPLE_8_SAMPLES    =  8,
+    D3DDDIMULTISAMPLE_9_SAMPLES    =  9,
+    D3DDDIMULTISAMPLE_10_SAMPLES   = 10,
+    D3DDDIMULTISAMPLE_11_SAMPLES   = 11,
+    D3DDDIMULTISAMPLE_12_SAMPLES   = 12,
+    D3DDDIMULTISAMPLE_13_SAMPLES   = 13,
+    D3DDDIMULTISAMPLE_14_SAMPLES   = 14,
+    D3DDDIMULTISAMPLE_15_SAMPLES   = 15,
+    D3DDDIMULTISAMPLE_16_SAMPLES   = 16,
+
+    D3DDDIMULTISAMPLE_FORCE_UINT   = 0x7fffffff
+} D3DDDIMULTISAMPLE_TYPE;
+
+typedef struct _D3DDDI_RESOURCEFLAGS
+{
+    union
+    {
+        struct
+        {
+            UINT    RenderTarget            : 1;    // 0x00000001
+            UINT    ZBuffer                 : 1;    // 0x00000002
+            UINT    Dynamic                 : 1;    // 0x00000004
+            UINT    HintStatic              : 1;    // 0x00000008
+            UINT    AutogenMipmap           : 1;    // 0x00000010
+            UINT    DMap                    : 1;    // 0x00000020
+            UINT    WriteOnly               : 1;    // 0x00000040
+            UINT    NotLockable             : 1;    // 0x00000080
+            UINT    Points                  : 1;    // 0x00000100
+            UINT    RtPatches               : 1;    // 0x00000200
+            UINT    NPatches                : 1;    // 0x00000400
+            UINT    SharedResource          : 1;    // 0x00000800
+            UINT    DiscardRenderTarget     : 1;    // 0x00001000
+            UINT    Video                   : 1;    // 0x00002000
+            UINT    CaptureBuffer           : 1;    // 0x00004000
+            UINT    Primary                 : 1;    // 0x00008000
+            UINT    Texture                 : 1;    // 0x00010000
+            UINT    CubeMap                 : 1;    // 0x00020000
+            UINT    Volume                  : 1;    // 0x00040000
+            UINT    VertexBuffer            : 1;    // 0x00080000
+            UINT    IndexBuffer             : 1;    // 0x00100000
+            UINT    DecodeRenderTarget      : 1;    // 0x00200000
+            UINT    DecodeCompressedBuffer  : 1;    // 0x00400000
+            UINT    VideoProcessRenderTarget: 1;    // 0x00800000
+            UINT    CpuOptimized            : 1;    // 0x01000000
+            UINT    MightDrawFromLocked     : 1;    // 0x02000000
+            UINT    Overlay                 : 1;    // 0x04000000
+            UINT    MatchGdiPrimary         : 1;    // 0x08000000
+            UINT    InterlacedRefresh       : 1;    // 0x10000000
+            UINT    TextApi                 : 1;    // 0x20000000
+            UINT    RestrictedContent       : 1;    // 0x40000000
+            UINT    RestrictSharedAccess    : 1;    // 0x80000000
+        };
+        UINT        Value;
+    };
+} D3DDDI_RESOURCEFLAGS;
+
+typedef struct _D3DDDI_SURFACEINFO
+{
+    UINT                Width;              // in: For linear, surface and volume
+    UINT                Height;             // in: For surface and volume
+    UINT                Depth;              // in: For volume
+    CONST VOID*         pSysMem;
+    UINT                SysMemPitch;
+    UINT                SysMemSlicePitch;
+} D3DDDI_SURFACEINFO;
+
+typedef enum _D3DDDI_ROTATION
+{
+    D3DDDI_ROTATION_IDENTITY        = 1,    // No rotation.
+    D3DDDI_ROTATION_90              = 2,    // Rotated 90 degrees.
+    D3DDDI_ROTATION_180             = 3,    // Rotated 180 degrees.
+    D3DDDI_ROTATION_270             = 4     // Rotated 270 degrees.
+} D3DDDI_ROTATION;
+
+typedef enum D3DDDI_SCANLINEORDERING
+{
+    D3DDDI_SCANLINEORDERING_UNKNOWN                    = 0,
+    D3DDDI_SCANLINEORDERING_PROGRESSIVE                = 1,
+    D3DDDI_SCANLINEORDERING_INTERLACED                 = 2,
+} D3DDDI_SCANLINEORDERING;
+
+typedef struct _D3DDDIARG_CREATERESOURCE
+{
+    D3DDDIFORMAT                    Format;
+    D3DDDI_POOL                     Pool;
+    D3DDDIMULTISAMPLE_TYPE          MultisampleType;
+    UINT                            MultisampleQuality;
+    CONST D3DDDI_SURFACEINFO*       pSurfList;          // in: List of sub resource objects to create
+    UINT                            SurfCount;          // in: Number of sub resource objects
+    UINT                            MipLevels;
+    UINT                            Fvf;                // in: FVF format for vertex buffers
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID  VidPnSourceId;      // in: VidPnSourceId on which the primary surface is created
+    D3DDDI_RATIONAL                 RefreshRate;        // in: RefreshRate that this primary surface is to be used with
+    HANDLE                          hResource;          // in/out: D3D runtime handle/UM driver handle
+    D3DDDI_RESOURCEFLAGS            Flags;
+    D3DDDI_ROTATION                 Rotation;           // in: The orientation of the resource. (0, 90, 180, 270)
+} D3DDDIARG_CREATERESOURCE;
+
+#if ((DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8) || \
+     (D3D_UMD_INTERFACE_VERSION >= D3D_UMD_INTERFACE_VERSION_WIN8))
+
+typedef struct _D3DDDI_RESOURCEFLAGS2
+{
+    union
+    {
+        struct
+        {
+            UINT    VideoEncoder            : 1;    // 0x00000001
+            UINT    UserMemory              : 1;    // 0x00000002
+#if ((DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM1_3) || \
+     (D3D_UMD_INTERFACE_VERSION >= D3D_UMD_INTERFACE_VERSION_WDDM1_3)) // M1
+            UINT    CrossAdapter            : 1;    // 0x00000004
+#if ((DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0) || \
+        (D3D_UMD_INTERFACE_VERSION >= D3D_UMD_INTERFACE_VERSION_WDDM2_0))
+            UINT    IsDisplayable           : 1;    // 0x00000008
+            UINT    Reserved                : 28;
+#else
+            UINT    Reserved                : 29;
+#endif
+#else
+            UINT    Reserved                : 30;
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM1_3)
+         };
+        UINT        Value;
+    };
+} D3DDDI_RESOURCEFLAGS2;
+
+
+typedef struct _D3DDDIARG_CREATERESOURCE2
+{
+    D3DDDIFORMAT                    Format;
+    D3DDDI_POOL                     Pool;
+    D3DDDIMULTISAMPLE_TYPE          MultisampleType;
+    UINT                            MultisampleQuality;
+    CONST D3DDDI_SURFACEINFO*       pSurfList;          // in: List of sub resource objects to create
+    UINT                            SurfCount;          // in: Number of sub resource objects
+    UINT                            MipLevels;
+    UINT                            Fvf;                // in: FVF format for vertex buffers
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID  VidPnSourceId;      // in: VidPnSourceId on which the primary surface is created
+    D3DDDI_RATIONAL                 RefreshRate;        // in: RefreshRate that this primary surface is to be used with
+    HANDLE                          hResource;          // in/out: D3D runtime handle/UM driver handle
+    D3DDDI_RESOURCEFLAGS            Flags;
+    D3DDDI_ROTATION                 Rotation;           // in: The orientation of the resource. (0, 90, 180, 270)
+    D3DDDI_RESOURCEFLAGS2           Flags2;
+} D3DDDIARG_CREATERESOURCE2;
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8)
+
+typedef struct _D3DDDICB_SIGNALFLAGS
+{
+    union
+    {
+        struct
+        {
+            UINT SignalAtSubmission : 1;
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8)
+            UINT EnqueueCpuEvent    : 1;
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0)
+            UINT AllowFenceRewind   : 1;
+            UINT Reserved           : 28;
+            UINT DXGK_SIGNAL_FLAG_INTERNAL0 : 1;
+#else
+            UINT Reserved           : 30;
+#endif
+#else
+            UINT Reserved           : 31;
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WIN8)
+        };
+        UINT Value;
+    };
+} D3DDDICB_SIGNALFLAGS;
+
+#define D3DDDI_MAX_OBJECT_WAITED_ON 32
+#define D3DDDI_MAX_OBJECT_SIGNALED  32
+
+typedef enum _D3DDDI_SYNCHRONIZATIONOBJECT_TYPE
+{
+    D3DDDI_SYNCHRONIZATION_MUTEX    = 1,
+    D3DDDI_SEMAPHORE                = 2,
+    D3DDDI_FENCE                    = 3,
+    D3DDDI_CPU_NOTIFICATION         = 4,
+
+#if ((DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0) || \
+     (D3D_UMD_INTERFACE_VERSION >= D3D_UMD_INTERFACE_VERSION_WDDM2_0))
+    D3DDDI_MONITORED_FENCE          = 5,
+#endif // DXGKDDI_INTERFACE_VERSION
+
+#if ((DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_2) || \
+     (D3D_UMD_INTERFACE_VERSION >= D3D_UMD_INTERFACE_VERSION_WDDM2_2))
+    D3DDDI_PERIODIC_MONITORED_FENCE = 6,
+#endif // DXGKDDI_INTERFACE_VERSION
+
+    D3DDDI_SYNCHRONIZATION_TYPE_LIMIT
+
+} D3DDDI_SYNCHRONIZATIONOBJECT_TYPE;
+
+#if ((DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0) || \
+     (D3D_UMD_INTERFACE_VERSION >= D3D_UMD_INTERFACE_VERSION_WDDM2_0))
+
+#define D3DDDI_SYNC_OBJECT_WAIT    0x1
+#define D3DDDI_SYNC_OBJECT_SIGNAL  0x2
+#define D3DDDI_SYNC_OBJECT_ALL_ACCESS  (STANDARD_RIGHTS_REQUIRED | SYNCHRONIZE | D3DDDI_SYNC_OBJECT_WAIT | D3DDDI_SYNC_OBJECT_SIGNAL)
+
+#endif // DXGKDDI_INTERFACE_VERSION
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM1_3)
+
+typedef union
+{
+    struct
+    {
+        UINT64 FrameNumber : 40;
+        UINT64 PartNumber  : 24;
+    };
+    UINT64 Value;
+}DXGK_MIRACAST_CHUNK_ID;
+
+typedef enum _DXGK_MIRACAST_CHUNK_TYPE
+{
+    DXGK_MIRACAST_CHUNK_TYPE_UNKNOWN = 0,
+    DXGK_MIRACAST_CHUNK_TYPE_COLOR_CONVERT_COMPLETE = 1,
+    DXGK_MIRACAST_CHUNK_TYPE_ENCODE_COMPLETE = 2,
+    DXGK_MIRACAST_CHUNK_TYPE_FRAME_START = 3,
+    DXGK_MIRACAST_CHUNK_TYPE_FRAME_DROPPED = 4,
+    DXGK_MIRACAST_CHUNK_TYPE_ENCODE_DRIVER_DEFINED_1 = 0x80000000,
+    DXGK_MIRACAST_CHUNK_TYPE_ENCODE_DRIVER_DEFINED_2 = 0x80000001,
+} DXGK_MIRACAST_CHUNK_TYPE;
+
+typedef struct
+{
+    DXGK_MIRACAST_CHUNK_TYPE ChunkType; // Type of chunk info
+    DXGK_MIRACAST_CHUNK_ID ChunkId;     // Identifier for this chunk
+    UINT  ProcessingTime;               // Time the process took to complete in microsecond
+    UINT  EncodeRate;                   // Encode bitrate driver reported for the chunk, kilobits per second
+} DXGK_MIRACAST_CHUNK_INFO;
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM1_3)
+
+#if ((DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0) || \
+     (D3D_UMD_INTERFACE_VERSION >= D3D_UMD_INTERFACE_VERSION_WDDM2_0))
+
+typedef enum D3DDDI_PAGINGQUEUE_PRIORITY
+{
+    D3DDDI_PAGINGQUEUE_PRIORITY_BELOW_NORMAL = -1,
+    D3DDDI_PAGINGQUEUE_PRIORITY_NORMAL = 0,
+    D3DDDI_PAGINGQUEUE_PRIORITY_ABOVE_NORMAL = 1,
+} D3DDDI_PAGINGQUEUE_PRIORITY;
+
+typedef struct D3DDDI_MAKERESIDENT_FLAGS
+{
+    union
+    {
+        struct
+        {
+            UINT CantTrimFurther    : 1;    // When set, MakeResidentCb will succeed even if the request puts the application over the current budget.
+                                            // MakeResidentCb will still fail if the request puts the application over the maximum budget.
+            UINT MustSucceed        : 1;    // When set, instructs MakeResidentCb to put the device in error if the resource cannot be made resident.
+            UINT Reserved           : 30;
+        };
+        UINT Value;
+    };
+} D3DDDI_MAKERESIDENT_FLAGS;
+
+typedef struct D3DDDI_MAKERESIDENT
+{
+    D3DKMT_HANDLE               hPagingQueue;       // [in] Handle to the paging queue used to synchronize paging operations for this call.
+    UINT                        NumAllocations;     // [in/out] On input, the number of allocation handles om the AllocationList array. On output,
+                                                    //          the number of allocations successfully made resident.
+    D3DKMT_PTR(_Field_size_(NumAllocations)
+    CONST D3DKMT_HANDLE*,       AllocationList);    // [in] An array of NumAllocations allocation handles
+    D3DKMT_PTR(CONST UINT*,     PriorityList);      // [in] Residency priority array for each of the allocations in the resource or allocation list
+    D3DDDI_MAKERESIDENT_FLAGS   Flags;              // [in] Residency flags
+    D3DKMT_ALIGN64 UINT64       PagingFenceValue;   // [out] Paging fence value to synchronize on before submitting the command
+                                                    //      that uses above resources to the GPU. This value applies to the monitored fence
+                                                    //      synchronization object associated with hPagingQueue.
+    D3DKMT_ALIGN64 UINT64       NumBytesToTrim;     // [out] When MakeResident fails due to being over budget, this value
+                                                    //      indicates how much to trim in order for the call to succeed on a retry.
+} D3DDDI_MAKERESIDENT;
+
+typedef struct D3DDDI_EVICT_FLAGS
+{
+    union
+    {
+        struct
+        {
+            UINT EvictOnlyIfNecessary   : 1;
+            UINT NotWrittenTo           : 1;
+            UINT Reserved               : 30;
+        };
+        UINT Value;
+    };
+} D3DDDI_EVICT_FLAGS;
+
+typedef struct D3DDDI_TRIMRESIDENCYSET_FLAGS
+{
+    union
+    {
+        struct
+        {
+            UINT PeriodicTrim           : 1;    // When PeriodicTrim flag is set, the driver is required to performed the following operations:
+                                                // a) trim all allocations that were not referenced since the previous periodic trim request
+                                                // by comparing the allocation last referenced fence with the last periodic trim context fence
+                                                // b) Refresh the last periodic trim context fence with the last completed context fence.
+            UINT RestartPeriodicTrim    : 1;    // May not be set together with PeriodicTrim flag.
+                                                // Reset the last periodic trim context fence to the last completed context fence.
+            UINT TrimToBudget           : 1;    // Indicates that the application usage is over the memory budget,
+                                                // and NumBytesToTrim bytes should be trimmed to fit in the new memory budget.
+            UINT Reserved               : 29;
+        };
+        UINT Value;
+    };
+} D3DDDI_TRIMRESIDENCYSET_FLAGS;
+
+typedef struct _D3DDDIGPUVIRTUALADDRESS_PROTECTION_TYPE
+{
+    union
+    {
+        struct
+        {
+            UINT64 Write            : 1;
+            UINT64 Execute          : 1;
+            UINT64 Zero             : 1;
+            UINT64 NoAccess         : 1;
+            UINT64 SystemUseOnly    : 1;    // Should not be set by the UMD
+            UINT64 Reserved         : 59;
+        };
+        D3DKMT_ALIGN64 UINT64 Value;
+    };
+} D3DDDIGPUVIRTUALADDRESS_PROTECTION_TYPE;
+
+typedef enum _D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_TYPE
+{
+   D3DDDI_UPDATEGPUVIRTUALADDRESS_MAP               = 0,
+   D3DDDI_UPDATEGPUVIRTUALADDRESS_UNMAP             = 1,
+   D3DDDI_UPDATEGPUVIRTUALADDRESS_COPY              = 2,
+   D3DDDI_UPDATEGPUVIRTUALADDRESS_MAP_PROTECT       = 3,
+} D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_TYPE;
+
+typedef struct _D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION
+{
+    D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_TYPE OperationType;
+    union
+    {
+        struct
+        {
+            D3DKMT_ALIGN64 D3DGPU_VIRTUAL_ADDRESS  BaseAddress;
+            D3DKMT_ALIGN64 D3DGPU_SIZE_T           SizeInBytes;
+            D3DKMT_HANDLE                          hAllocation;
+            D3DKMT_ALIGN64 D3DGPU_SIZE_T           AllocationOffsetInBytes;
+            D3DKMT_ALIGN64 D3DGPU_SIZE_T           AllocationSizeInBytes;
+        } Map;
+        struct
+        {
+            D3DKMT_ALIGN64 D3DGPU_VIRTUAL_ADDRESS  BaseAddress;
+            D3DKMT_ALIGN64 D3DGPU_SIZE_T           SizeInBytes;
+            D3DKMT_HANDLE                          hAllocation;
+            D3DKMT_ALIGN64 D3DGPU_SIZE_T           AllocationOffsetInBytes;
+            D3DKMT_ALIGN64 D3DGPU_SIZE_T           AllocationSizeInBytes;
+            D3DDDIGPUVIRTUALADDRESS_PROTECTION_TYPE Protection;
+            D3DKMT_ALIGN64 UINT64                  DriverProtection;
+        } MapProtect;
+        struct
+        {
+            D3DKMT_ALIGN64 D3DGPU_VIRTUAL_ADDRESS  BaseAddress;
+            D3DKMT_ALIGN64 D3DGPU_SIZE_T           SizeInBytes;
+            D3DDDIGPUVIRTUALADDRESS_PROTECTION_TYPE Protection;
+        } Unmap;    // Used for UNMAP_NOACCESS as well
+        struct
+        {
+            D3DKMT_ALIGN64 D3DGPU_VIRTUAL_ADDRESS  SourceAddress;
+            D3DKMT_ALIGN64 D3DGPU_SIZE_T           SizeInBytes;
+            D3DKMT_ALIGN64 D3DGPU_VIRTUAL_ADDRESS  DestAddress;
+        } Copy;
+    };
+} D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION;
+
+typedef enum _D3DDDIGPUVIRTUALADDRESS_RESERVATION_TYPE
+{
+    D3DDDIGPUVIRTUALADDRESS_RESERVE_NO_ACCESS  = 0,
+    D3DDDIGPUVIRTUALADDRESS_RESERVE_ZERO       = 1,
+    D3DDDIGPUVIRTUALADDRESS_RESERVE_NO_COMMIT  = 2      // Reserved for system use
+} D3DDDIGPUVIRTUALADDRESS_RESERVATION_TYPE;
+
+typedef struct D3DDDI_MAPGPUVIRTUALADDRESS
+{
+    D3DKMT_HANDLE                   hPagingQueue;                   // in: Paging queue to synchronize the operation on.
+    D3DKMT_ALIGN64 D3DGPU_VIRTUAL_ADDRESS BaseAddress;              // in_opt: Base virtual address to map
+    D3DKMT_ALIGN64 D3DGPU_VIRTUAL_ADDRESS MinimumAddress;           // in_opt: Minimum virtual address
+    D3DKMT_ALIGN64 D3DGPU_VIRTUAL_ADDRESS MaximumAddress;           // in_opt: Maximum virtual address
+    D3DKMT_HANDLE                   hAllocation;                    // in: Allocation handle to map
+    D3DKMT_ALIGN64 D3DGPU_SIZE_T    OffsetInPages;                  // in: Offset in 4 KB pages from the start of the allocation
+    D3DKMT_ALIGN64 D3DGPU_SIZE_T    SizeInPages;                    // in: Size in 4 KB pages to map
+    D3DDDIGPUVIRTUALADDRESS_PROTECTION_TYPE    Protection;          // in: Virtual address protection
+    D3DKMT_ALIGN64 UINT64           DriverProtection;               // in: Driver specific protection
+    UINT                            Reserved0;                      // in:
+    D3DKMT_ALIGN64 UINT64           Reserved1;                      // in:
+    D3DKMT_ALIGN64 D3DGPU_VIRTUAL_ADDRESS VirtualAddress;           // out: Virtual address
+    D3DKMT_ALIGN64 UINT64           PagingFenceValue;               // out: Paging fence Id for synchronization
+} D3DDDI_MAPGPUVIRTUALADDRESS;
+
+typedef struct D3DDDI_RESERVEGPUVIRTUALADDRESS
+{
+    union
+    {
+        D3DKMT_HANDLE               hPagingQueue;                   // in: Paging queue to synchronize the operation on.
+        D3DKMT_HANDLE               hAdapter;                       // in: DXG adapter handle. (M2)
+    };
+    D3DKMT_ALIGN64 D3DGPU_VIRTUAL_ADDRESS          BaseAddress;     // in_opt: Base virtual address to map
+    D3DKMT_ALIGN64 D3DGPU_VIRTUAL_ADDRESS          MinimumAddress;  // in_opt: Minimum virtual address
+    D3DKMT_ALIGN64 D3DGPU_VIRTUAL_ADDRESS          MaximumAddress;  // in_opt: Maximum virtual address
+    D3DKMT_ALIGN64 D3DGPU_SIZE_T                   Size;            // in: Size to reserve in bytes
+    union
+    {
+        D3DDDIGPUVIRTUALADDRESS_RESERVATION_TYPE   ReservationType; // in: Reservation type
+        UINT                        Reserved0;                      // M2
+    };
+    union
+    {
+        D3DKMT_ALIGN64 UINT64                      DriverProtection;// in: Driver specific protection
+        D3DKMT_ALIGN64 UINT64                      Reserved1;       // M2
+    };
+    D3DKMT_ALIGN64 D3DGPU_VIRTUAL_ADDRESS          VirtualAddress;  // out: Virtual address
+    union
+    {
+        D3DKMT_ALIGN64 UINT64                      PagingFenceValue;// out: Paging fence Id for synchronization
+        D3DKMT_ALIGN64 UINT64                      Reserved2;       // M2
+    };
+} D3DDDI_RESERVEGPUVIRTUALADDRESS;
+
+typedef struct _D3DDDI_GETRESOURCEPRESENTPRIVATEDRIVERDATA
+{
+    D3DKMT_HANDLE    hResource;
+    UINT             PrivateDriverDataSize;
+    D3DKMT_PTR(PVOID, pPrivateDriverData);
+} D3DDDI_GETRESOURCEPRESENTPRIVATEDRIVERDATA;
+
+typedef struct D3DDDI_DESTROYPAGINGQUEUE
+{
+    D3DKMT_HANDLE           hPagingQueue;   // in: handle to the paging queue to destroy
+} D3DDDI_DESTROYPAGINGQUEUE;
+
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0)
+
+#if ((DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_1) || \
+     (D3D_UMD_INTERFACE_VERSION >= D3D_UMD_INTERFACE_VERSION_WDDM2_1_1))
+
+typedef struct D3DDDI_UPDATEALLOCPROPERTY_FLAGS
+{
+    union
+    {
+        struct
+        {
+            UINT AccessedPhysically :  1; // The new value for AccessedPhysically on an allocation
+            UINT Unmoveable         :  1; // Indicates an allocation cannot be moved while pinned in a memory segment
+            UINT Reserved           : 30;
+        };
+        UINT Value;
+    };
+} D3DDDI_UPDATEALLOCPROPERTY_FLAGS;
+
+typedef struct D3DDDI_UPDATEALLOCPROPERTY
+{
+    D3DKMT_HANDLE                       hPagingQueue;           // [in] Handle to the paging queue used to synchronize paging operations for this call.
+    D3DKMT_HANDLE                       hAllocation;            // [in] Handle to the allocation to be updated.
+    UINT                                SupportedSegmentSet;    // [in] New supported segment set, ignored if the same.
+    D3DDDI_SEGMENTPREFERENCE            PreferredSegment;       // [in] New preferred segment set, ignored if the same.
+    D3DDDI_UPDATEALLOCPROPERTY_FLAGS    Flags;                  // [in] Flags to set on the allocation, ignored if the same.
+    D3DKMT_ALIGN64 UINT64               PagingFenceValue;       // [out] Paging fence value to synchronize on before using the above allocation.
+                                                                //       This value applies to the monitored fence synchronization
+                                                                //       object associated with hPagingQueue.
+    union
+    {
+        struct
+        {
+            UINT SetAccessedPhysically  :  1; // [in] When set to 1, will set AccessedPhysically to new value
+            UINT SetSupportedSegmentSet :  1; // [in] When set to 1, will set SupportedSegmentSet to new value
+            UINT SetPreferredSegment    :  1; // [in] When set to 1, will set PreferredSegment to new value
+            UINT SetUnmoveable          :  1; // [in] When set to 1, will set Unmoveable to new value
+            UINT Reserved               : 28;
+        };
+        UINT PropertyMaskValue;
+    };
+} D3DDDI_UPDATEALLOCPROPERTY;
+
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_1)
+
+#if(D3D_UMD_INTERFACE_VERSION >= D3D_UMD_INTERFACE_VERSION_WDDM2_1_1)
+
+typedef struct D3DDDI_OFFER_FLAGS
+{
+    union
+    {
+        struct
+        {
+            UINT AllowDecommit :  1;
+            UINT Reserved      : 31;
+        };
+        UINT Value;
+    };
+} D3DDDI_OFFER_FLAGS;
+
+#endif // (D3D_UMD_INTERFACE_VERSION >= D3D_UMD_INTERFACE_VERSION_WDDM2_1_1)
+
+#if(DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_1 || \
+    D3D_UMD_INTERFACE_VERSION >= D3D_UMD_INTERFACE_VERSION_WDDM2_1)
+
+typedef enum _D3DDDI_RECLAIM_RESULT
+{
+    D3DDDI_RECLAIM_RESULT_OK = 0,
+    D3DDDI_RECLAIM_RESULT_DISCARDED = 1,
+    D3DDDI_RECLAIM_RESULT_NOT_COMMITTED = 2,
+} D3DDDI_RECLAIM_RESULT;
+
+#endif
+
+typedef struct _D3DDDI_SYNCHRONIZATIONOBJECTINFO
+{
+    D3DDDI_SYNCHRONIZATIONOBJECT_TYPE    Type;      // in: Type of synchronization object to create.
+    union
+    {
+        struct
+        {
+            BOOL InitialState;                      // in: Initial state of a synchronization mutex.
+        } SynchronizationMutex;
+
+        struct
+        {
+            UINT MaxCount;                          // in: Max count of the semaphore.
+            UINT InitialCount;                      // in: Initial count of the semaphore.
+        } Semaphore;
+
+
+        struct
+        {
+            UINT Reserved[16];                      // Reserved for future use.
+        } Reserved;
+    };
+} D3DDDI_SYNCHRONIZATIONOBJECTINFO;
+
+#ifndef D3DDDI_SYNCHRONIZATIONOBJECT_FLAGS_EXT
+#define D3DDDI_SYNCHRONIZATIONOBJECT_FLAGS_EXT
+#define D3DDDI_SYNCHRONIZATIONOBJECT_FLAGS_RESERVED0        Reserved0
+#endif
+
+typedef struct _D3DDDI_SYNCHRONIZATIONOBJECT_FLAGS
+{
+    union
+    {
+        struct
+        {
+            UINT Shared                                         :  1;
+            UINT NtSecuritySharing                              :  1;
+#if ((DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM1_3) || \
+     (D3D_UMD_INTERFACE_VERSION >= D3D_UMD_INTERFACE_VERSION_WDDM1_3)) // M1
+
+            UINT CrossAdapter                                   :  1;
+
+#if ((DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0) || \
+     (D3D_UMD_INTERFACE_VERSION >= D3D_UMD_INTERFACE_VERSION_WDDM2_0))
+
+            // When set, the sync object is signaled as soon as the contents of command buffers preceding it
+            // is entirely copied to the GPU pipeline, but not necessarily completed execution.
+            // This flag can be set in order to start reusing command buffers as soon as possible.
+            UINT TopOfPipeline                                  :  1;
+
+            // When set, the device this sync object is created or opened on
+            // can only submit wait commands for it.
+            UINT NoSignal                                       :  1;
+
+            // When set, the device this sync object is created or opened on
+            // can only submit signal commands for it. This flag cannot be set
+            // simultaneously with NoSignal.
+            UINT NoWait                                         :  1;
+
+            // When set, instructs the GPU scheduler to bypass signaling of the monitored fence
+            // to the maximum value when the device is affected by the GPU reset.
+            UINT NoSignalMaxValueOnTdr                          :  1;
+
+            // When set, the fence will not be mapped into the GPU virtual address space.
+            // Only packet-based signal/wait operations are supported
+            // When this is set, the fence is always stored as a 64-bit value (regardless of adapter caps)
+            UINT NoGPUAccess                                    :  1;
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM3_0)
+            // When set, the fence can be signaled by KMD.
+            // The flag can be used only with D3DDDI_CPU_NOTIFICATION objects.
+            UINT SignalByKmd                                    :  1;
+            UINT Reserved                                       : 22;
+#else
+            UINT Reserved                                       : 23;
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM3_0)
+
+#else
+            UINT Reserved                                       : 28;
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0)
+
+#else
+            UINT Reserved                                       : 29;
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM1_3)
+            UINT D3DDDI_SYNCHRONIZATIONOBJECT_FLAGS_RESERVED0   :  1;
+        };
+        UINT Value;
+    };
+} D3DDDI_SYNCHRONIZATIONOBJECT_FLAGS;
+
+typedef struct _D3DDDI_SYNCHRONIZATIONOBJECTINFO2
+{
+    D3DDDI_SYNCHRONIZATIONOBJECT_TYPE    Type;      // in: Type of synchronization object to create.
+    D3DDDI_SYNCHRONIZATIONOBJECT_FLAGS   Flags;     // in: flags.
+    union
+    {
+        struct
+        {
+            BOOL InitialState;                      // in: Initial state of a synchronization mutex.
+        } SynchronizationMutex;
+
+        struct
+        {
+            UINT MaxCount;                          // in: Max count of the semaphore.
+            UINT InitialCount;                      // in: Initial count of the semaphore.
+        } Semaphore;
+
+        struct
+        {
+            D3DKMT_ALIGN64 UINT64 FenceValue;       // in: inital fence value.
+        } Fence;
+
+        struct
+        {
+            D3DKMT_PTR(HANDLE, Event);                           // in: Handle to the event
+        } CPUNotification;
+
+#if ((DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0) || \
+     (D3D_UMD_INTERFACE_VERSION >= D3D_UMD_INTERFACE_VERSION_WDDM2_0))
+        struct
+        {
+            D3DKMT_ALIGN64 UINT64   InitialFenceValue;                      // in: inital fence value.
+            D3DKMT_PTR(VOID*,       FenceValueCPUVirtualAddress);           // out: Read-only mapping of the fence value for the CPU
+            D3DKMT_ALIGN64 D3DGPU_VIRTUAL_ADDRESS FenceValueGPUVirtualAddress; // out: Read/write mapping of the fence value for the GPU
+            UINT                    EngineAffinity;                         // in: Defines physical adapters where the GPU VA will be mapped
+            UINT                    Padding;
+        } MonitoredFence;
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0)
+
+#if ((DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_2) || \
+     (D3D_UMD_INTERFACE_VERSION >= D3D_UMD_INTERFACE_VERSION_WDDM2_2))
+        struct
+        {
+            D3DKMT_HANDLE                   hAdapter;                               // in: A handle to the adapter associated with VidPnTargetId
+            D3DDDI_VIDEO_PRESENT_TARGET_ID  VidPnTargetId;                          // in: The output that the compositor wishes to receive notifications for
+            D3DKMT_ALIGN64 UINT64           Time;                                   // in: Represents an offset before the VSync.
+                                                                                    // The Time value may not be longer than a VSync interval. In units of 100ns.
+            D3DKMT_PTR(VOID*,               FenceValueCPUVirtualAddress);           // out: Read-only mapping of the fence value for the CPU
+            D3DKMT_ALIGN64 D3DGPU_VIRTUAL_ADDRESS FenceValueGPUVirtualAddress;      // out: Read-only mapping of the fence value for the GPU
+            UINT                            EngineAffinity;                         // in: Defines physical adapters where the GPU VA will be mapped
+            UINT                            Padding;
+        } PeriodicMonitoredFence;
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_2)
+
+
+        struct
+        {
+            D3DKMT_ALIGN64 UINT64 Reserved[8];                     // Reserved for future use.
+        } Reserved;
+    };
+
+    D3DKMT_HANDLE  SharedHandle;                    // out: global shared handle (when requested to be shared)
+
+} D3DDDI_SYNCHRONIZATIONOBJECTINFO2;
+
+#if ((DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0) || \
+     (D3D_UMD_INTERFACE_VERSION >= D3D_UMD_INTERFACE_VERSION_WDDM2_0))
+
+typedef struct _D3DDDI_WAITFORSYNCHRONIZATIONOBJECTFROMCPU_FLAGS
+{
+    union
+    {
+        struct
+        {
+            UINT WaitAny        : 1;    // when waiting for multiple objects, signal the wait event if any
+                                        // of the wait array conditions is satisfied as opposed to all conditions.
+            UINT Reserved       : 31;
+        };
+        UINT Value;
+    };
+} D3DDDI_WAITFORSYNCHRONIZATIONOBJECTFROMCPU_FLAGS;
+
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_0)
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_4)
+
+typedef struct _D3DDDI_QUERYREGISTRY_FLAGS
+{
+    union
+    {
+        struct
+        {
+            UINT   TranslatePath    :  1;
+            UINT   MutableValue     :  1;
+            UINT   Reserved         : 30;
+        };
+        UINT Value;
+    };
+} D3DDDI_QUERYREGISTRY_FLAGS;
+
+typedef enum _D3DDDI_QUERYREGISTRY_TYPE
+{
+   D3DDDI_QUERYREGISTRY_SERVICEKEY      = 0,
+   D3DDDI_QUERYREGISTRY_ADAPTERKEY      = 1,
+   D3DDDI_QUERYREGISTRY_DRIVERSTOREPATH = 2,
+   D3DDDI_QUERYREGISTRY_DRIVERIMAGEPATH = 3,
+   D3DDDI_QUERYREGISTRY_MAX,
+} D3DDDI_QUERYREGISTRY_TYPE;
+
+typedef enum _D3DDDI_QUERYREGISTRY_STATUS
+{
+   D3DDDI_QUERYREGISTRY_STATUS_SUCCESS              = 0,
+   D3DDDI_QUERYREGISTRY_STATUS_BUFFER_OVERFLOW      = 1,
+   D3DDDI_QUERYREGISTRY_STATUS_FAIL                 = 2,
+   D3DDDI_QUERYREGISTRY_STATUS_MAX,
+} D3DDDI_QUERYREGISTRY_STATUS;
+
+//
+// Output data value follows this structure.
+// PrivateDriverSize must be sizeof(D3DDDI_QUERYREGISTRY_INFO) + (size of the the key value in bytes)
+//
+typedef struct _D3DDDI_QUERYREGISTRY_INFO
+{
+   D3DDDI_QUERYREGISTRY_TYPE    QueryType;              // In
+   D3DDDI_QUERYREGISTRY_FLAGS   QueryFlags;             // In
+   WCHAR                        ValueName[MAX_PATH];    // In
+   ULONG                        ValueType;              // In
+   ULONG                        PhysicalAdapterIndex;   // In
+   ULONG                        OutputValueSize;        // Out. Number of bytes written to the output value or required in case of D3DDDI_QUERYREGISTRY_STATUS_BUFFER_OVERFLOW.
+   D3DDDI_QUERYREGISTRY_STATUS  Status;                 // Out
+   union {
+        DWORD   OutputDword;                            // Out
+        D3DKMT_ALIGN64 UINT64  OutputQword;             // Out
+        WCHAR   OutputString[1];                        // Out. Dynamic array
+        BYTE    OutputBinary[1];                        // Out. Dynamic array
+   };
+ } D3DDDI_QUERYREGISTRY_INFO;
+
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM2_4)
+
+//
+// Defines the maximum number of context a particular command buffer can
+// be broadcast to.
+//
+#define D3DDDI_MAX_BROADCAST_CONTEXT        64
+
+//
+// Allocation priorities.
+//
+#define D3DDDI_ALLOCATIONPRIORITY_MINIMUM       0x28000000
+#define D3DDDI_ALLOCATIONPRIORITY_LOW           0x50000000
+#define D3DDDI_ALLOCATIONPRIORITY_NORMAL        0x78000000
+#define D3DDDI_ALLOCATIONPRIORITY_HIGH          0xa0000000
+#define D3DDDI_ALLOCATIONPRIORITY_MAXIMUM       0xc8000000
+
+#if (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM1_3)
+
+// Cross adapter resource pitch alignment in bytes.
+// Must be power of 2.
+//
+#define D3DKMT_CROSS_ADAPTER_RESOURCE_PITCH_ALIGNMENT 128
+
+// Cross adapter resource height alignment in rows.
+//
+#define D3DKMT_CROSS_ADAPTER_RESOURCE_HEIGHT_ALIGNMENT 4
+
+#endif // (DXGKDDI_INTERFACE_VERSION >= DXGKDDI_INTERFACE_VERSION_WDDM1_3)
+
+#endif // (NTDDI_VERSION >= NTDDI_LONGHORN) || defined(D3DKMDT_SPECIAL_MULTIPLATFORM_TOOL)
+
+#pragma warning(pop)
+
+
+#endif /* WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) */
+#pragma endregion
+
+#endif /* _D3DUKMDT_H_ */
+

--- a/win32ss/gdi/gdi32_vista/dc.c
+++ b/win32ss/gdi/gdi32_vista/dc.c
@@ -15,12 +15,12 @@
 /***********************************************************************
  *           D3DKMTCreateDCFromMemory    (GDI32.@)
  */
-DWORD WINAPI D3DKMTCreateDCFromMemory( D3DKMT_CREATEDCFROMMEMORY *desc )
+NTSTATUS APIENTRY D3DKMTCreateDCFromMemory(_Inout_ D3DKMT_CREATEDCFROMMEMORY* desc)
 {
     return NtGdiDdDDICreateDCFromMemory( desc );
 }
 
-DWORD WINAPI D3DKMTDestroyDCFromMemory( const D3DKMT_DESTROYDCFROMMEMORY *desc )
+NTSTATUS APIENTRY D3DKMTDestroyDCFromMemory(_In_ CONST D3DKMT_DESTROYDCFROMMEMORY* desc)
 {
     return NtGdiDdDDIDestroyDCFromMemory( desc );
 }


### PR DESCRIPTION
As mentioned, MS released variants of 3/4 WDDM headers under MIT under this repo.
Pulled from commit:
https://github.com/microsoft/libdxg/commit/045831efab4b1e50db2b658dc9e129f11b84b549
Source:
https://github.com/microsoft/libdxg/tree/045831efab4b1e50db2b658dc9e129f11b84b549/include
This PR just imports them