### PR TITLE
[ATL] CComCriticalSection destructor should not be virtual

### DIFF
--- a/sdk/lib/atl/atlcore.h
+++ b/sdk/lib/atl/atlcore.h
@@ -55,7 +55,7 @@ public:
         memset(&m_sec, 0, sizeof(CRITICAL_SECTION));
     }
 
-    virtual ~CComCriticalSection()
+    ~CComCriticalSection()
     {
     }
 


### PR DESCRIPTION
## Purpose

Fixes GCC 13 build of shdocvw
