### PR TITLE
[CRT] Introduce corecrt.h

### DIFF
--- a/sdk/include/crt/assert.h
+++ b/sdk/include/crt/assert.h
@@ -6,7 +6,7 @@
 #ifndef __ASSERT_H_
 #define __ASSERT_H_
 
-#include <crtdefs.h>
+#include <corecrt.h>
 
 #ifdef NDEBUG
 

--- a/sdk/include/crt/complex.h
+++ b/sdk/include/crt/complex.h
@@ -26,7 +26,7 @@
 #ifndef _COMPLEX_H_
 #define _COMPLEX_H_
 
-#include <crtdefs.h>
+#include <corecrt.h>
 
 #if (defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L) \
      || !defined __STRICT_ANSI__

--- a/sdk/include/crt/conio.h
+++ b/sdk/include/crt/conio.h
@@ -6,7 +6,7 @@
 #ifndef _INC_CONIO
 #define _INC_CONIO
 
-#include <crtdefs.h>
+#include <corecrt.h>
 
 #define __need___va_list
 #include <stdarg.h>

--- a/sdk/include/crt/corecrt.h
+++ b/sdk/include/crt/corecrt.h
@@ -1,0 +1,25 @@
+
+#pragma once
+
+#include <crtdefs.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef _CRTRESTRICT
+#define _CRTRESTRICT
+#endif
+
+#ifndef DEFINED_localeinfo_struct
+typedef struct localeinfo_struct
+{
+    pthreadlocinfo locinfo;
+    pthreadmbcinfo mbcinfo;
+} _locale_tstruct, *_locale_t;
+#define DEFINED_localeinfo_struct 1
+#endif
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/sdk/include/crt/crtdbg.h
+++ b/sdk/include/crt/crtdbg.h
@@ -3,7 +3,7 @@
  * This file is part of the w64 mingw-runtime package.
  * No warranty is given; refer to the file DISCLAIMER within this package.
  */
-#include <crtdefs.h>
+#include <corecrt.h>
 
 #ifndef _INC_CRTDBG
 #define _INC_CRTDBG

--- a/sdk/include/crt/crtdefs.h
+++ b/sdk/include/crt/crtdefs.h
@@ -159,10 +159,6 @@
 #define _CRTNOALIAS
 #endif
 
-#ifndef _CRTRESTRICT
-#define _CRTRESTRICT
-#endif
-
 #ifndef __CRTDECL
 #define __CRTDECL __cdecl
 #endif
@@ -437,14 +433,6 @@ typedef struct threadmbcinfostruct *pthreadmbcinfo;
 #endif
 
 struct __lc_time_data;
-
-#ifndef DEFINED_localeinfo_struct
-typedef struct localeinfo_struct {
-    pthreadlocinfo locinfo;
-    pthreadmbcinfo mbcinfo;
-}_locale_tstruct,*_locale_t;
-#define DEFINED_localeinfo_struct 1
-#endif
 
 #ifdef __cplusplus
 }

--- a/sdk/include/crt/ctype.h
+++ b/sdk/include/crt/ctype.h
@@ -6,7 +6,7 @@
 #ifndef _INC_CTYPE
 #define _INC_CTYPE
 
-#include <crtdefs.h>
+#include <corecrt.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/sdk/include/crt/direct.h
+++ b/sdk/include/crt/direct.h
@@ -6,7 +6,7 @@
 #ifndef _INC_DIRECT
 #define _INC_DIRECT
 
-#include <crtdefs.h>
+#include <corecrt.h>
 #include <io.h>
 
 #pragma pack(push,_CRT_PACKING)

--- a/sdk/include/crt/dos.h
+++ b/sdk/include/crt/dos.h
@@ -6,7 +6,7 @@
 #ifndef _INC_DOS
 #define _INC_DOS
 
-#include <crtdefs.h>
+#include <corecrt.h>
 #include <io.h>
 
 #pragma pack(push,_CRT_PACKING)

--- a/sdk/include/crt/dvec.h
+++ b/sdk/include/crt/dvec.h
@@ -14,7 +14,7 @@
 #include <emmintrin.h>
 #include <assert.h>
 #include <fvec.h>
-#include <crtdefs.h>
+#include <corecrt.h>
 
 #pragma pack(push,_CRT_PACKING)
 

--- a/sdk/include/crt/eh.h
+++ b/sdk/include/crt/eh.h
@@ -3,7 +3,7 @@
  * This file is part of the w64 mingw-runtime package.
  * No warranty is given; refer to the file DISCLAIMER within this package.
  */
-#include <crtdefs.h>
+#include <corecrt.h>
 
 #ifndef _EH_H_
 #define _EH_H_

--- a/sdk/include/crt/errno.h
+++ b/sdk/include/crt/errno.h
@@ -6,7 +6,7 @@
 #ifndef _INC_ERRNO
 #define _INC_ERRNO
 
-#include <crtdefs.h>
+#include <corecrt.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/sdk/include/crt/fcntl.h
+++ b/sdk/include/crt/fcntl.h
@@ -3,7 +3,7 @@
  * This file is part of the w64 mingw-runtime package.
  * No warranty is given; refer to the file DISCLAIMER within this package.
  */
-#include <crtdefs.h>
+#include <corecrt.h>
 
 #ifndef _INC_FCNTL
 #define _INC_FCNTL

--- a/sdk/include/crt/float.h
+++ b/sdk/include/crt/float.h
@@ -27,7 +27,7 @@
 #error
 #endif
 
-#include <crtdefs.h>
+#include <corecrt.h>
 
 /*
  * Functions and definitions for controlling the FPU.

--- a/sdk/include/crt/fpieee.h
+++ b/sdk/include/crt/fpieee.h
@@ -6,7 +6,7 @@
 #ifndef _INC_FPIEEE
 #define _INC_FPIEEE
 
-#include <crtdefs.h>
+#include <corecrt.h>
 
 #pragma pack(push,_CRT_PACKING)
 

--- a/sdk/include/crt/fvec.h
+++ b/sdk/include/crt/fvec.h
@@ -14,7 +14,7 @@
 #include <xmmintrin.h>
 #include <assert.h>
 #include <ivec.h>
-#include <crtdefs.h>
+#include <corecrt.h>
 
 #if defined(_ENABLE_VEC_DEBUG)
 #include <iostream>

--- a/sdk/include/crt/inttypes.h
+++ b/sdk/include/crt/inttypes.h
@@ -8,7 +8,7 @@
 #ifndef _INTTYPES_H_
 #define _INTTYPES_H_
 
-#include <crtdefs.h>
+#include <corecrt.h>
 #include <stdint.h>
 #define __need_wchar_t
 #include <stddef.h>

--- a/sdk/include/crt/io.h
+++ b/sdk/include/crt/io.h
@@ -7,7 +7,7 @@
 #ifndef _IO_H_
 #define _IO_H_
 
-#include <crtdefs.h>
+#include <corecrt.h>
 #include <string.h>
 
 #pragma pack(push,_CRT_PACKING)

--- a/sdk/include/crt/ivec.h
+++ b/sdk/include/crt/ivec.h
@@ -14,7 +14,7 @@
 #include <intrin.h>
 #include <assert.h>
 #include <dvec.h>
-#include <crtdefs.h>
+#include <corecrt.h>
 
 #pragma pack(push,_CRT_PACKING)
 

--- a/sdk/include/crt/libgen.h
+++ b/sdk/include/crt/libgen.h
@@ -14,7 +14,7 @@
 #define _LIBGEN_H_
 
 /* All the headers include this file. */
-#include <crtdefs.h>
+#include <corecrt.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/sdk/include/crt/locale.h
+++ b/sdk/include/crt/locale.h
@@ -6,7 +6,7 @@
 #ifndef _INC_LOCALE
 #define _INC_LOCALE
 
-#include <crtdefs.h>
+#include <corecrt.h>
 
 #pragma pack(push,_CRT_PACKING)
 

--- a/sdk/include/crt/malloc.h
+++ b/sdk/include/crt/malloc.h
@@ -6,7 +6,7 @@
 #ifndef _INC_MALLOC
 #define _INC_MALLOC
 
-#include <crtdefs.h>
+#include <corecrt.h>
 
 #pragma pack(push,_CRT_PACKING)
 

--- a/sdk/include/crt/math.h
+++ b/sdk/include/crt/math.h
@@ -4,7 +4,7 @@
 #ifndef _INC_MATH
 #define _INC_MATH
 
-#include "crtdefs.h"
+#include <corecrt.h>
 
 #pragma pack(push,_CRT_PACKING)
 

--- a/sdk/include/crt/mbctype.h
+++ b/sdk/include/crt/mbctype.h
@@ -6,7 +6,7 @@
 #ifndef _INC_MBCTYPE
 #define _INC_MBCTYPE
 
-#include <crtdefs.h>
+#include <corecrt.h>
 #include <ctype.h>
 
 #ifdef __cplusplus

--- a/sdk/include/crt/mbstring.h
+++ b/sdk/include/crt/mbstring.h
@@ -7,7 +7,7 @@
 #ifndef _INC_MBSTRING
 #define _INC_MBSTRING
 
-#include <crtdefs.h>
+#include <corecrt.h>
 
 #pragma pack(push,_CRT_PACKING)
 

--- a/sdk/include/crt/memory.h
+++ b/sdk/include/crt/memory.h
@@ -6,7 +6,7 @@
 #ifndef _INC_MEMORY
 #define _INC_MEMORY
 
-#include <crtdefs.h>
+#include <corecrt.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/sdk/include/crt/process.h
+++ b/sdk/include/crt/process.h
@@ -6,7 +6,7 @@
 #ifndef _INC_PROCESS
 #define _INC_PROCESS
 
-#include <crtdefs.h>
+#include <corecrt.h>
 
 /* Includes a definition of _pid_t and pid_t */
 #include <sys/types.h>

--- a/sdk/include/crt/search.h
+++ b/sdk/include/crt/search.h
@@ -7,7 +7,7 @@
 #ifndef _INC_SEARCH
 #define _INC_SEARCH
 
-#include <crtdefs.h>
+#include <corecrt.h>
 #include <stddef.h>
 
 #ifdef __cplusplus

--- a/sdk/include/crt/signal.h
+++ b/sdk/include/crt/signal.h
@@ -6,7 +6,7 @@
 #ifndef _INC_SIGNAL
 #define _INC_SIGNAL
 
-#include <crtdefs.h>
+#include <corecrt.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/sdk/include/crt/stddef.h
+++ b/sdk/include/crt/stddef.h
@@ -4,7 +4,7 @@
  * No warranty is given; refer to the file DISCLAIMER within this package.
  */
 
-#include <crtdefs.h>
+#include <corecrt.h>
 
 #ifndef _INC_STDDEF
 #define _INC_STDDEF

--- a/sdk/include/crt/stdexcpt.h
+++ b/sdk/include/crt/stdexcpt.h
@@ -3,7 +3,7 @@
  * This file is part of the w64 mingw-runtime package.
  * No warranty is given; refer to the file DISCLAIMER within this package.
  */
-#include <crtdefs.h>
+#include <corecrt.h>
 
 #ifndef _INC_STDEXCPT
 #define _INC_STDEXCPT

--- a/sdk/include/crt/stdio.h
+++ b/sdk/include/crt/stdio.h
@@ -6,7 +6,7 @@
 #ifndef _INC_STDIO
 #define _INC_STDIO
 
-#include <crtdefs.h>
+#include <corecrt.h>
 
 #define __need___va_list
 #include <stdarg.h>

--- a/sdk/include/crt/stdlib.h
+++ b/sdk/include/crt/stdlib.h
@@ -6,7 +6,7 @@
 #ifndef _INC_STDLIB
 #define _INC_STDLIB
 
-#include <crtdefs.h>
+#include <corecrt.h>
 #include <limits.h>
 
 #pragma pack(push,_CRT_PACKING)

--- a/sdk/include/crt/string.h
+++ b/sdk/include/crt/string.h
@@ -6,7 +6,7 @@
 #ifndef _INC_STRING
 #define _INC_STRING
 
-#include <crtdefs.h>
+#include <corecrt.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/sdk/include/crt/tchar.h
+++ b/sdk/include/crt/tchar.h
@@ -3,7 +3,7 @@
  * This file is part of the w64 mingw-runtime package.
  * No warranty is given; refer to the file DISCLAIMER within this package.
  */
-#include <crtdefs.h>
+#include <corecrt.h>
 
 #ifndef _INC_TCHAR
 #define _INC_TCHAR

--- a/sdk/include/crt/time.h
+++ b/sdk/include/crt/time.h
@@ -7,7 +7,7 @@
 #ifndef _TIME_H_
 #define _TIME_H_
 
-#include <crtdefs.h>
+#include <corecrt.h>
 
 #ifndef _WIN32
 #error Only Win32 target is supported!

--- a/sdk/include/crt/typeinfo.h
+++ b/sdk/include/crt/typeinfo.h
@@ -3,7 +3,7 @@
  * This file is part of the w64 mingw-runtime package.
  * No warranty is given; refer to the file DISCLAIMER within this package.
  */
-#include <crtdefs.h>
+#include <corecrt.h>
 
 #ifndef _INC_TYPEINFO
 #define _INC_TYPEINFO

--- a/sdk/include/crt/wchar.h
+++ b/sdk/include/crt/wchar.h
@@ -6,7 +6,7 @@
 #ifndef _INC_WCHAR
 #define _INC_WCHAR
 
-#include <crtdefs.h>
+#include <corecrt.h>
 
 #define __need___va_list
 #include <stdarg.h>

--- a/sdk/include/crt/wctype.h
+++ b/sdk/include/crt/wctype.h
@@ -10,7 +10,7 @@
 #error Only Win32 target is supported!
 #endif
 
-#include <crtdefs.h>
+#include <corecrt.h>
 
 #pragma pack(push,_CRT_PACKING)
 

--- a/sdk/include/crt/yvals.h
+++ b/sdk/include/crt/yvals.h
@@ -7,10 +7,8 @@
 #define _YVALS
 
 #include <_mingw.h>
-/* TODO, don't include crtdef.h.  */
-#include <crtdefs.h>
 
-#pragma pack(push,_CRT_PACKING)
+#pragma pack(push,8)
 
 #define _CPPLIB_VER 405
 #define __PURE_APPDOMAIN_GLOBAL

--- a/sdk/lib/crt/include/internal/locale.h
+++ b/sdk/lib/crt/include/internal/locale.h
@@ -1,6 +1,8 @@
 #ifndef __CRT_INTERNAL_LOCALE_H
 #define __CRT_INTERNAL_LOCALE_H
 
+#include <crtdefs.h> // for LC_ID
+
 typedef struct MSVCRT_threadlocaleinfostruct {
     LONG refcount;
     unsigned int lc_codepage;


### PR DESCRIPTION
## Purpose

Include this instead of crtdefs.h.
This is for compatibility with MS headers.
