### PR TITLE
[CMAKE] Enable proper definition of __cplusplus macro on MSVC

### DIFF
--- a/sdk/cmake/msvc.cmake
+++ b/sdk/cmake/msvc.cmake
@@ -32,6 +32,9 @@ endif()
 
 add_definitions(/D__STDC__=1)
 
+# Enable correct values of __cplusplus macro for newer standards
+add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/Zc:__cplusplus>)
+
 # Ignore any "standard" include paths, and do not use any default CRT library.
 if(CMAKE_C_COMPILER_ID STREQUAL "MSVC")
     add_compile_options(/X /Zl)


### PR DESCRIPTION
MSVC defaults to always reporting 199711L to satisfy broken C++ code. You have to add a command line argument to make it work correctly. See https://learn.microsoft.com/en-us/cpp/build/reference/zc-cplusplus?view=msvc-170
