### PR TITLE
[SHELL32][SHELL32_APITEST] Fix ShellExecuteEx IDLIST folder

### DIFF
--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -287,11 +287,12 @@ static BOOL SHELL_ArgifyW(WCHAR* out, DWORD len, const WCHAR* fmt, const WCHAR* 
                         else
                             cmd = lpFile;
 
-                        used += wcslen(cmd);
+                        SIZE_T cmdlen = wcslen(cmd);
+                        used += cmdlen;
                         if (used < len)
                         {
                             wcscpy(res, cmd);
-                            res += wcslen(cmd);
+                            res += cmdlen;
                         }
                     }
                     found_p1 = TRUE;
@@ -1730,7 +1731,7 @@ static BOOL SHELL_translate_idlist(LPSHELLEXECUTEINFOW sei, LPWSTR wszParameters
 
             sei->fMask &= ~SEE_MASK_INVOKEIDLIST;
         } else {
-            WCHAR target[MAX_PATH];
+            WCHAR target[max(MAX_PATH, _countof(buffer))];
             DWORD attribs;
             DWORD resultLen;
             /* Check if we're executing a directory and if so use the
@@ -1744,10 +1745,19 @@ static BOOL SHELL_translate_idlist(LPSHELLEXECUTEINFOW sei, LPWSTR wszParameters
                                            buffer, sizeof(buffer))) {
                 SHELL_ArgifyW(wszApplicationName, dwApplicationNameLen,
                               buffer, target, (LPITEMIDLIST)sei->lpIDList, NULL, &resultLen,
-                              (sei->lpDirectory && *sei->lpDirectory) ? sei->lpDirectory : NULL);
+                              !StrIsNullOrEmpty(sei->lpDirectory) ? sei->lpDirectory : NULL);
                 if (resultLen > dwApplicationNameLen)
-                    ERR("Argify buffer not large enough... truncating\n");
+                    ERR("Argify buffer not large enough... truncating\n"); // FIXME: Report this to the caller?
                 appKnownSingular = FALSE;
+                // HACKFIX: We really want the !appKnownSingular code in SHELL_execute to split the
+                // parameters for us but we cannot guarantee that the exe in the registry is quoted.
+                // We have now turned 'explorer.exe "%1" into 'explorer.exe "c:\path\from\pidl"' and
+                // need to split to application and parameters.
+                LPCWSTR params = PathGetArgsW(wszApplicationName);
+                lstrcpynW(wszParameters, params, parametersLen);
+                PathRemoveArgsW(wszApplicationName);
+                PathUnquoteSpacesW(wszApplicationName);
+                appKnownSingular = TRUE;
             }
             sei->fMask &= ~SEE_MASK_INVOKEIDLIST;
         }

--- a/modules/rostests/apitests/shell32/closewnd.cpp
+++ b/modules/rostests/apitests/shell32/closewnd.cpp
@@ -37,6 +37,33 @@ void GetWindowList(PWINDOW_LIST pList)
     EnumWindows(EnumWindowsProc, (LPARAM)pList);
 }
 
+void GetWindowListForClose(PWINDOW_LIST pList)
+{
+    for (UINT tries = 5; tries--;)
+    {
+        if (tries)
+            FreeWindowList(pList);
+        GetWindowList(pList);
+        Sleep(500);
+        WINDOW_LIST list;
+        GetWindowList(&list);
+        SIZE_T count = list.m_chWnds;
+        FreeWindowList(&list);
+        if (count == pList->m_chWnds)
+            break;
+    }
+}
+
+static HWND FindInWindowList(const WINDOW_LIST &list, HWND hWnd)
+{
+    for (SIZE_T i = 0; i < list.m_chWnds; ++i)
+    {
+        if (list.m_phWnds[i] == hWnd)
+            return hWnd;
+    }
+    return NULL;
+}
+
 HWND FindNewWindow(PWINDOW_LIST List1, PWINDOW_LIST List2)
 {
     for (SIZE_T i2 = 0; i2 < List2->m_chWnds; ++i2)
@@ -61,30 +88,31 @@ HWND FindNewWindow(PWINDOW_LIST List1, PWINDOW_LIST List2)
     return NULL;
 }
 
-#define TRIALS_COUNT 8
+static void WaitForForegroundWindow(HWND hWnd, UINT wait = 1500)
+{
+    for (UINT waited = 0, interval = 50; waited < wait; waited += interval)
+    {
+        if (GetForegroundWindow() == hWnd || !IsWindowVisible(hWnd))
+            return;
+        Sleep(interval);
+    }
+}
 
 void CloseNewWindows(PWINDOW_LIST List1, PWINDOW_LIST List2)
 {
-    INT cDiff = List2->m_chWnds - List1->m_chWnds;
-    for (INT j = 0; j < cDiff; ++j)
+    for (SIZE_T i = 0; i < List2->m_chWnds; ++i)
     {
-        HWND hWnd = FindNewWindow(List1, List2);
-        if (!hWnd)
-            break;
+        HWND hWnd = List2->m_phWnds[i];
+        if (!IsWindow(hWnd) || FindInWindowList(*List1, hWnd))
+            continue;
 
-        for (INT i = 0; i < TRIALS_COUNT; ++i)
+        SwitchToThisWindow(hWnd, TRUE);
+        WaitForForegroundWindow(hWnd);
+
+        if (!PostMessageW(hWnd, WM_SYSCOMMAND, SC_CLOSE, 0))
         {
-            if (!IsWindow(hWnd))
-                break;
-
-            SwitchToThisWindow(hWnd, TRUE);
-
-            // Alt+F4
-            keybd_event(VK_MENU, 0x38, 0, 0);
-            keybd_event(VK_F4, 0x3E, 0, 0);
-            keybd_event(VK_F4, 0x3E, KEYEVENTF_KEYUP, 0);
-            keybd_event(VK_MENU, 0x38, KEYEVENTF_KEYUP, 0);
-            Sleep(100);
+            DWORD_PTR result;
+            SendMessageTimeoutW(hWnd, WM_SYSCOMMAND, SC_CLOSE, 0, 0, 3000, &result);
         }
     }
 }

--- a/modules/rostests/apitests/shell32/closewnd.cpp
+++ b/modules/rostests/apitests/shell32/closewnd.cpp
@@ -88,7 +88,7 @@ HWND FindNewWindow(PWINDOW_LIST List1, PWINDOW_LIST List2)
     return NULL;
 }
 
-static void WaitForForegroundWindow(HWND hWnd, UINT wait = 1500)
+static void WaitForForegroundWindow(HWND hWnd, UINT wait = 250)
 {
     for (UINT waited = 0, interval = 50; waited < wait; waited += interval)
     {

--- a/modules/rostests/apitests/shell32/closewnd.h
+++ b/modules/rostests/apitests/shell32/closewnd.h
@@ -14,6 +14,7 @@ typedef struct WINDOW_LIST
 } WINDOW_LIST, *PWINDOW_LIST;
 
 void GetWindowList(PWINDOW_LIST pList);
+void GetWindowListForClose(PWINDOW_LIST pList);
 HWND FindNewWindow(PWINDOW_LIST List1, PWINDOW_LIST List2);
 void CloseNewWindows(PWINDOW_LIST List1, PWINDOW_LIST List2);
 void FreeWindowList(PWINDOW_LIST pList);


### PR DESCRIPTION
This is mainly to fix the shell32 apitest, a better way to handle `SEE_MASK_IDLIST` should be investigated in the future. ShellExecuteEx with a PIDL that points to a folder should be handled the same as ShellExecuteEx with lpFile set to a folder path, there is no need for all this special handling.

The api test close window code seems to be more robust like this and hopefully fixes the Notepad issue discovered in chat today.

Testbot results:

refs/pull/7464/merge on 0.4.16-dev-149-g5797340

WHS: https://reactos.org/testman/compare.php?ids=98388,98390 LGTM