### PR TITLE
[FREELDR/x64] Fix the Multiboot Pointer Size

### DIFF
--- a/boot/freeldr/freeldr/arch/i386/multiboot.S
+++ b/boot/freeldr/freeldr/arch/i386/multiboot.S
@@ -213,7 +213,11 @@ idtptr:
 
 PUBLIC _MultibootInfoPtr
 _MultibootInfoPtr:
+#ifdef _M_IX86
     .long 0
+#else
+    .quad 0
+#endif
 
 MultibootInfo:
     .space MB_INFO_SIZE


### PR DESCRIPTION
## Purpose

Fix the `_MultibootInfoPtr` pointer size for amd64