### PR TITLE
[SHELL32] Force FileType OpenWith default verb

### DIFF
--- a/dll/win32/shell32/COpenWithMenu.cpp
+++ b/dll/win32/shell32/COpenWithMenu.cpp
@@ -771,7 +771,22 @@ BOOL COpenWithList::SetDefaultHandler(SApp *pApp, LPCWSTR pwszFilename)
 
     /* Copy static verbs from Classes\Applications key */
     /* FIXME: SHCopyKey does not copy the security attributes of the keys */
+    /* FIXME: Windows does not actually copy the verb keys */
+    /* FIXME: Should probably delete any existing DelegateExecute/DropTarget/DDE verb information first */
     LSTATUS Result = SHCopyKeyW(hSrcKey, NULL, hDestKey, 0);
+#ifdef __REACTOS__
+    // FIXME: When OpenWith is used to set a new default on Windows, the FileExts key
+    // is changed to force this association. ROS does not support this. The best
+    // we can do is to try to set the verb we (incorrectly) copied as the new default.
+    HKEY hAppKey;
+    StringCbPrintfW(wszBuf, sizeof(wszBuf), L"Applications\\%s", pApp->wszFilename);
+    if (Result == ERROR_SUCCESS && !RegOpenKeyExW(HKEY_CLASSES_ROOT, wszBuf, 0, KEY_READ, &hAppKey))
+    {
+        if (HCR_GetDefaultVerbW(hAppKey, NULL, wszBuf, _countof(wszBuf)) && *wszBuf)
+            RegSetString(hDestKey, NULL, wszBuf, REG_SZ);
+        RegCloseKey(hAppKey);
+    }
+#endif // __REACTOS__
     RegCloseKey(hDestKey);
     RegCloseKey(hSrcKey);
     RegCloseKey(hKey);


### PR DESCRIPTION
Unlike Windows, ROS OpenWith does not fully take over the association by redirecting the ProgId. The best we can do is try to make the new verb the default.

Notes:
 - ROS only implements Windows 95 style ProgId handling and cannot behave like XP OpenWith at this point in time.
 - The change to FriendlyTypeName allows the user to customize the type description for extensions without a ProgId. We could allow the user to always override it for extensions with a ProgId as well but Windows does not allow that for types with a  FriendlyTypeName already set.
 - No longer writes the default icon string if the icon was not changed by the user.

JIRA issue: [CORE-19816](https://jira.reactos.org/browse/CORE-19816)