### PR TITLE
[FMIFS][FORMAT][SDK] Improve/Fix QueryDeviceInformation() and related code

### DIFF
--- a/base/system/format/format.c
+++ b/base/system/format/format.c
@@ -360,7 +360,7 @@ static VOID Usage(LPWSTR ProgramName)
 int wmain(int argc, WCHAR *argv[])
 {
     int badArg;
-    DEVICE_INFORMATION DeviceInformation = {0};
+    DEVICE_INFORMATION DeviceInformation;
     FMIFS_MEDIA_FLAG media = FMIFS_HARDDISK;
     DWORD driveType;
     WCHAR fileSystem[1024];
@@ -485,9 +485,11 @@ int wmain(int argc, WCHAR *argv[])
 
     ConResPrintf(StdOut, STRING_FILESYSTEM, fileSystem);
 
-    if (QueryDeviceInformation(RootDirectory,
-                               &DeviceInformation,
-                               sizeof(DeviceInformation)))
+    if (!QueryDeviceInformation(RootDirectory, &DeviceInformation, sizeof(DeviceInformation)))
+    {
+        totalNumberOfBytes.QuadPart = 0;
+    }
+    else
     {
         totalNumberOfBytes.QuadPart = DeviceInformation.SectorSize *
                                       DeviceInformation.SectorCount.QuadPart;

--- a/base/system/format/format.c
+++ b/base/system/format/format.c
@@ -364,7 +364,7 @@ int wmain(int argc, WCHAR *argv[])
     FMIFS_MEDIA_FLAG media = FMIFS_HARDDISK;
     DWORD driveType;
     WCHAR fileSystem[1024];
-    WCHAR volumeName[1024] = {0};
+    WCHAR volumeName[1024];
     WCHAR input[1024];
     DWORD serialNumber;
     ULARGE_INTEGER totalNumberOfBytes, totalNumberOfFreeBytes;
@@ -473,6 +473,8 @@ int wmain(int argc, WCHAR *argv[])
         dwError = GetLastError();
         if (dwError == ERROR_UNRECOGNIZED_VOLUME)
         {
+            // Unformatted volume
+            volumeName[0] = UNICODE_NULL;
             wcscpy(fileSystem, L"RAW");
         }
         else

--- a/dll/win32/fmifs/query.c
+++ b/dll/win32/fmifs/query.c
@@ -57,27 +57,27 @@ QueryAvailableFileSystemFormat(
  * @param[in] DriveRoot
  * String which contains a DOS device name,
  *
- * @param[in,out] DeviceInformation
- * Pointer to buffer with DEVICE_INFORMATION structure which will receive data.
+ * @param[out] DeviceInformation
+ * Pointer to buffer which will receive DEVICE_INFORMATION data.
  *
  * @param[in] BufferSize
- * Size of buffer in bytes.
+ * Size of DeviceInformation buffer, in bytes.
  *
  * @return
- * TRUE if the buffer was large enough and was filled with
+ * TRUE if the buffer was large enough (pre-Vista at least, Vista+ if possible) and was filled with
  * the requested information, FALSE otherwise.
  *
  * @remarks
- * The returned information is mostly related to Sony Memory Stick devices.
- * On Vista+ the returned information is disk sector size and volume length in sectors,
+ * The returned flags are mostly related to Sony Memory Stick devices.
+ * On Vista+, the returned information is disk sector size and volume length in sectors,
  * regardless of the type of disk.
- * ReactOS implementation returns DEVICE_HOTPLUG flag if inspected device is a hotplug device
+ * ReactOS returns DEVICE_HOTPLUG flag if inspected device is a hotplug device,
  * as well as sector size and volume length of disk device.
  */
 BOOL
 NTAPI
 QueryDeviceInformation(
-    _In_ PWCHAR DriveRoot,
+    _In_ PCWSTR DriveRoot,
     _Out_ PVOID DeviceInformation,
     _In_ ULONG BufferSize)
 {
@@ -94,7 +94,7 @@ QueryDeviceInformation(
     WCHAR DriveName[MAX_PATH];
 
     /* Buffer should be able to at least hold DeviceFlags */
-    if (BufferSize < sizeof(ULONG) ||
+    if (BufferSize < RTL_SIZEOF_THROUGH_FIELD(DEVICE_INFORMATION, DeviceFlags) ||
         !NT_SUCCESS(RtlStringCchCopyW(DriveName, ARRAYSIZE(DriveName), DriveRoot)))
     {
         return FALSE;
@@ -157,10 +157,10 @@ QueryDeviceInformation(
         DeviceInfo->DeviceFlags |= DEVICE_HOTPLUG;
     }
 
-    /* Other flags that would be set here are related to Sony "Memory Stick"
-     * type of devices which we do not have any special support for */
+    /* UNIMPLEMENTED: Other flags that would be set here are related to Sony "Memory Stick"
+     * type of devices, which we do not have any special support for */
 
-    if (BufferSize >= sizeof(DEVICE_INFORMATION))
+    if (BufferSize >= RTL_SIZEOF_THROUGH_FIELD(DEVICE_INFORMATION, SectorCount))
     {
         /* This is the Vista+ version of the structure.
          * We need to also provide disk sector size and volume length in sectors. */

--- a/sdk/include/reactos/libs/fmifs/fmifs.h
+++ b/sdk/include/reactos/libs/fmifs/fmifs.h
@@ -37,6 +37,7 @@ typedef struct
 typedef struct _DEVICE_INFORMATION
 {
     ULONG DeviceFlags;
+    // Vista+ fields.
     ULONG SectorSize;
     LARGE_INTEGER SectorCount;
 } DEVICE_INFORMATION, *PDEVICE_INFORMATION;
@@ -180,7 +181,7 @@ QueryAvailableFileSystemFormat(
 BOOL
 NTAPI
 QueryDeviceInformation(
-    _In_ PWCHAR DriveRoot,
+    _In_ PCWSTR DriveRoot,
     _Out_ PVOID DeviceInformation,
     _In_ ULONG BufferSize);
 


### PR DESCRIPTION
## Purpose

Improve/Fix QueryDeviceInformation() and related code

## Proposed changes

- [FMIFS][SDK] QueryDeviceInformation(): Use more specific types
and improve documentation.
Follow-up to 4838d7b (0.4.16-dev-95).
- [FORMAT] wmain(): Zero the correct variable
Addendum to c5a9f22 (0.4.16-dev-96).
- [FORMAT] wmain(): No need to zero the whole volumeName array
Follow-up to 358fecd (0.4.16-dev-97).
