### PR TITLE
[MORE] PagePrompt(): Optimize check to load string resources

### DIFF
--- a/base/applications/cmdutils/more/more.c
+++ b/base/applications/cmdutils/more/more.c
@@ -176,19 +176,20 @@ PagePrompt(PCON_PAGER Pager, DWORD Done, DWORD Total)
     static WCHAR StrLineAt[80]  = L"";
     static WCHAR StrOptions[80] = L"";
     static WCHAR StrLines[80]   = L"";
+    static BOOL AreStrLoaded = FALSE;
 
     WCHAR szPercent[80] = L"";
     WCHAR szLineAt[80]  = L"";
 
     /* Load the prompt strings */
-    if (!*StrPercent)
+    if (!AreStrLoaded)
+    {
         K32LoadStringW(NULL, IDS_CONTINUE_PERCENT, StrPercent, ARRAYSIZE(StrPercent));
-    if (!*StrLineAt)
         K32LoadStringW(NULL, IDS_CONTINUE_LINE_AT, StrLineAt, ARRAYSIZE(StrLineAt));
-    if (!*StrOptions)
         K32LoadStringW(NULL, IDS_CONTINUE_OPTIONS, StrOptions, ARRAYSIZE(StrOptions));
-    if (!*StrLines)
         K32LoadStringW(NULL, IDS_CONTINUE_LINES, StrLines, ARRAYSIZE(StrLines));
+        AreStrLoaded = TRUE;
+    }
 
     /*
      * Check whether the pager is prompting, but we have actually finished


### PR DESCRIPTION
## Purpose

It is useless to check individually and to try to load again.

Follow-up to 2dbbfe8 (0.4.15-dev-2691).

## Proposed changes

- Use a common flag.
