### PR TITLE
[NTGDI:FREETYPE] Account for non-breaking spaces in x-dim of IntExtTextOutW

### DIFF
--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -6795,8 +6795,8 @@ IntExtTextOutW(
     FONT_CACHE_ENTRY Cache;
     FT_Matrix mat;
     BOOL bNoTransform;
-    DWORD ch0, ch1, nbsp = 0xa0; // nbsp is a non-breaking space
-    DWORD del = 0x7f; // DEL is ASCII DELETE
+    DWORD ch0, ch1;
+    const DWORD del = 0x7f, nbsp = 0xa0; // DEL is ASCII DELETE and nbsp is a non-breaking space
     FONTLINK_CHAIN Chain;
     SIZE spaceWidth;
 


### PR DESCRIPTION
CORE-19768
Follow up of PR #7274. This stops WARN's from FF 28 as well on ASCII 0x007f (del characters).
Addendum to https://github.com/reactos/reactos/commit/a1bff5b94efa36b9e48d37f91b56428131c10531

## Purpose

_Account for x-dimension for non-breaking space characters._

JIRA issue: [CORE-19768](https://jira.reactos.org/browse/CORE-19768)

## Proposed changes

_Test for ASCII char 0x00a0 and account for typical space character in x-dimension._
_Ignore ASCII chars less that space (0x0020) since they are normally control characters._
_Ignore ASCII char 'del' (0x007f) because this is a 'DELETE' character and should have no width._