### PR TITLE
[NTOS:EX] Fix SAL notations, `Timeout` parameter should be optional

### DIFF
--- a/ntoskrnl/ex/keyedevt.c
+++ b/ntoskrnl/ex/keyedevt.c
@@ -114,7 +114,7 @@ ExpReleaseOrWaitForKeyedEvent(
     _Inout_ PEX_KEYED_EVENT KeyedEvent,
     _In_ PVOID KeyedWaitValue,
     _In_ BOOLEAN Alertable,
-    _In_ PLARGE_INTEGER Timeout,
+    _In_opt_ PLARGE_INTEGER Timeout,
     _In_ BOOLEAN Release)
 {
     PETHREAD Thread, CurrentThread;
@@ -242,7 +242,7 @@ ExpWaitForKeyedEvent(
     _Inout_ PEX_KEYED_EVENT KeyedEvent,
     _In_ PVOID KeyedWaitValue,
     _In_ BOOLEAN Alertable,
-    _In_ PLARGE_INTEGER Timeout)
+    _In_opt_ PLARGE_INTEGER Timeout)
 {
     /* Call the generic internal function */
     return ExpReleaseOrWaitForKeyedEvent(KeyedEvent,


### PR DESCRIPTION
## Purpose

Fix warnings:
>E:\3rdRepo\ReactOS_Fork4\ntoskrnl\ex\keyedevt.c(458): warning C6387: 'Timeout' could be '0':  this does not adhere to the specification for the function 'ExpWaitForKeyedEvent'. 
E:\3rdRepo\ReactOS_Fork4\ntoskrnl\ex\keyedevt.c(527): warning C6387: 'Timeout' could be '0':  this does not adhere to the specification for the function 'ExpReleaseKeyedEvent'. 

JIRA issue: None.

## Proposed changes

`Timeout` parameter of those two functions should be optional.