### PR TITLE
[REACTOS] Fix 'writting' typos

### DIFF
--- a/modules/rosapps/applications/sysutils/pedump/pedump.c
+++ b/modules/rosapps/applications/sysutils/pedump/pedump.c
@@ -3906,7 +3906,7 @@ GetSeparateDebugHeader (
 // I tried to immitate the output of w32dasm disassembler.
 // which is a pretty good program.
 // but I am disappointed with this program and I myself
-// am writting a disassembler.
+// am writing a disassembler.
 // This PEdump program is a byproduct of that project.
 // so enjoy this program and I hope we will have a little more
 // knowledge on windows programming world.

--- a/modules/rosapps/applications/sysutils/regexpl/ShellCommandValue.cpp
+++ b/modules/rosapps/applications/sysutils/regexpl/ShellCommandValue.cpp
@@ -390,7 +390,7 @@ CheckValueArgument:
         DWORD dwBytesWritten;
         if (!WriteFile(hFile,pDataBuffer,dwValueSize,&dwBytesWritten,NULL))
         {
-          rConsole.Write(_T("Error writting file.\n"));
+          rConsole.Write(_T("Error writing file.\n"));
           VERIFY(CloseHandle(hFile));
           goto SkipValueCommand;
         }

--- a/modules/rostests/tests/sertest/sertest.c
+++ b/modules/rostests/tests/sertest/sertest.c
@@ -97,7 +97,7 @@ int main(int argc, char *argv[])
         rxBuffer[i] = 0xFF;
     }
     printf("\n");
-    printf("Writting transmit buffer to the serial port\n");
+    printf("Writing transmit buffer to the serial port\n");
     bResult = WriteFile(hPort, txBuffer, BUFSIZE, &dwNumWritten, NULL);
     if (!bResult) {
         printf("ERROR: failed to write to the serial port: %lx\n", (DWORD)bResult);

--- a/sdk/lib/drivers/copysup/copysup.c
+++ b/sdk/lib/drivers/copysup/copysup.c
@@ -330,7 +330,7 @@ FsRtlCopyWrite2(
                 return FALSE;
             }
 
-            /* And that we're not writting beyond allocation size */
+            /* And that we're not writing beyond allocation size */
             if (Fcb->AllocationSize.QuadPart < LastOffset.QuadPart)
             {
                 ExReleaseResourceLite(Fcb->Resource);
@@ -561,7 +561,7 @@ FsRtlCopyWrite2(
                 return FALSE;
             }
 
-            /* And that we're not writting beyond allocation size
+            /* And that we're not writing beyond allocation size
              * and that we're not going above 4GB
              */
             if ((Fcb->AllocationSize.LowPart < LastOffset.LowPart) ||

--- a/sdk/lib/drivers/rdbsslib/rdbss.c
+++ b/sdk/lib/drivers/rdbsslib/rdbss.c
@@ -4047,7 +4047,7 @@ RxCommonWrite(
         return STATUS_INVALID_PARAMETER;
     }
 
-    /* Are we writting to EOF? */
+    /* Are we writing to EOF? */
     WriteToEof = ((ByteOffset.LowPart == FILE_WRITE_TO_END_OF_FILE) && (ByteOffset.HighPart == -1));
     /* FIXME: validate length/offset */
 


### PR DESCRIPTION
## Purpose

Fix typos in comments or log outputs.

JIRA issue: None.

## Proposed changes

- Writting -> Writing

Same typos in 3rd-party files are not modified:
- base\services\nfsd\service.h
- boot\environ\include\efi\BlockIo.h
- boot\environ\include\efi\UgaDraw.h
- dll\opengl\mesa\pb.c