### PR TITLE
[SHELL32][BROWSEUI] Set DefView InvokeCommand directory

### DIFF
--- a/dll/win32/browseui/shellfind/CFindFolder.cpp
+++ b/dll/win32/browseui/shellfind/CFindFolder.cpp
@@ -937,6 +937,22 @@ STDMETHODIMP CFindFolder::MessageSFVCB(UINT uMsg, WPARAM wParam, LPARAM lParam)
             CComVariant searchBar(pwszGuid);
             return pWebBrowser2->ShowBrowserBar(&searchBar, NULL, NULL);
         }
+        case SFVM_GETCOMMANDDIR:
+        {
+            HRESULT hr = E_FAIL;
+            if (m_shellFolderView)
+            {
+                PCUITEMID_CHILD *apidl;
+                UINT cidl = 0;
+                if (SUCCEEDED(hr = m_shellFolderView->GetSelectedObjects(&apidl, &cidl)))
+                {
+                    if (cidl)
+                        hr = StringCchCopyW((PWSTR)lParam, wParam, _ILGetPath(apidl[0]));
+                    LocalFree(apidl);
+                }
+            }
+            return hr;
+        }
     }
     return E_NOTIMPL;
 }

--- a/dll/win32/shell32/folders/CDesktopFolder.cpp
+++ b/dll/win32/shell32/folders/CDesktopFolder.cpp
@@ -1069,6 +1069,13 @@ HRESULT WINAPI CDesktopFolderViewCB::MessageSFVCB(UINT uMsg, WPARAM wParam, LPAR
         case SFVM_VIEWRELEASE:
             m_pShellView = NULL;
             return S_OK;
+        case SFVM_GETCOMMANDDIR:
+        {
+            WCHAR buf[MAX_PATH];
+            if (SHGetSpecialFolderPathW(NULL, buf, CSIDL_DESKTOPDIRECTORY, TRUE))
+                return StringCchCopyW((PWSTR)lParam, wParam, buf);
+            break;
+        }
     }
     return E_NOTIMPL;
 }

--- a/dll/win32/shell32/folders/CFSFolder.cpp
+++ b/dll/win32/shell32/folders/CFSFolder.cpp
@@ -2076,6 +2076,10 @@ HRESULT WINAPI CFSFolder::MessageSFVCB(UINT uMsg, WPARAM wParam, LPARAM lParam)
     case SFVM_GET_CUSTOMVIEWINFO:
         hr = GetCustomViewInfo((ULONG)wParam, (SFVM_CUSTOMVIEWINFO_DATA *)lParam);
         break;
+    case SFVM_GETCOMMANDDIR:
+        if (m_sPathTarget)
+            hr = StringCchCopyW((PWSTR)lParam, wParam, m_sPathTarget);
+        break;
     }
     return hr;
 }


### PR DESCRIPTION
If a .lnk shortcut does not specify a working directory, it should use the directory provided by the `InvokeCommand` caller.

JIRA issue: [CORE-19855](https://jira.reactos.org/browse/CORE-19855)