### PR TITLE
[FS_REC] Rename Ext2 recognizer to Ext recognizer

### DIFF
--- a/drivers/filesystems/fs_rec/CMakeLists.txt
+++ b/drivers/filesystems/fs_rec/CMakeLists.txt
@@ -2,7 +2,7 @@ list(APPEND SOURCE
     blockdev.c
     btrfs.c
     cdfs.c
-    ext2.c
+    ext.c
     fat.c
     fatx.c
     ffs.c

--- a/drivers/filesystems/fs_rec/ext.c
+++ b/drivers/filesystems/fs_rec/ext.c
@@ -1,8 +1,8 @@
 /*
  * COPYRIGHT:        See COPYING in the top level directory
  * PROJECT:          ReactOS File System Recognizer
- * FILE:             drivers/filesystems/fs_rec/ext2.c
- * PURPOSE:          EXT2 Recognizer
+ * FILE:             drivers/filesystems/fs_rec/ext.c
+ * PURPOSE:          EXT Recognizer
  * PROGRAMMER:       Eric Kohl
  *                   Pierre Schweitzer (pierre@reactos.org)
  */
@@ -10,7 +10,7 @@
 /* INCLUDES *****************************************************************/
 
 #include "fs_rec.h"
-#include "ext2.h"
+#include "ext.h"
 
 #define NDEBUG
 #include <debug.h>
@@ -19,21 +19,21 @@
 
 BOOLEAN
 NTAPI
-FsRecIsExt2Volume(IN PEXT2_SUPER_BLOCK SuperBlock)
+FsRecIsExtVolume(IN PEXT_SUPER_BLOCK SuperBlock)
 {
     /* Just check for magic */
-    return (SuperBlock->Magic == EXT2_SUPER_MAGIC);
+    return (SuperBlock->Magic == EXT_SUPER_MAGIC);
 }
 
 NTSTATUS
 NTAPI
-FsRecExt2FsControl(IN PDEVICE_OBJECT DeviceObject,
-                   IN PIRP Irp)
+FsRecExtFsControl(IN PDEVICE_OBJECT DeviceObject,
+                  IN PIRP Irp)
 {
     PIO_STACK_LOCATION Stack;
     NTSTATUS Status;
     PDEVICE_OBJECT MountDevice;
-    PEXT2_SUPER_BLOCK Spb = NULL;
+    PEXT_SUPER_BLOCK Spb = NULL;
     ULONG SectorSize;
     LARGE_INTEGER Offset;
     BOOLEAN DeviceError = FALSE;
@@ -53,16 +53,16 @@ FsRecExt2FsControl(IN PDEVICE_OBJECT DeviceObject,
             if (FsRecGetDeviceSectorSize(MountDevice, &SectorSize))
             {
                 /* Try to read the superblock */
-                Offset.QuadPart = EXT2_SB_OFFSET;
+                Offset.QuadPart = EXT_SB_OFFSET;
                 if (FsRecReadBlock(MountDevice,
                                    &Offset,
-                                   EXT2_SB_SIZE,
+                                   EXT_SB_SIZE,
                                    SectorSize,
                                    (PVOID)&Spb,
                                    &DeviceError))
                 {
-                    /* Check if it's an actual EXT2 volume */
-                    if (FsRecIsExt2Volume(Spb))
+                    /* Check if it's an actual EXT volume */
+                    if (FsRecIsExtVolume(Spb))
                     {
                         /* It is! */
                         Status = STATUS_FS_DRIVER_REQUIRED;

--- a/drivers/filesystems/fs_rec/ext.h
+++ b/drivers/filesystems/fs_rec/ext.h
@@ -1,13 +1,13 @@
 /*
  * COPYRIGHT:        See COPYING in the top level directory
  * PROJECT:          ReactOS File System Recognizer
- * FILE:             drivers/filesystems/fs_rec/ext2.h
- * PURPOSE:          EXT2 Header File
+ * FILE:             drivers/filesystems/fs_rec/ext.h
+ * PURPOSE:          EXT Header File
  * PROGRAMMER:       Pierre Schweitzer (pierre@reactos.org)
  */
 
 #include <pshpack1.h>
-typedef struct _EXT2_SUPER_BLOCK {
+typedef struct _EXT_SUPER_BLOCK {
     ULONG InodesCount;
     ULONG BlocksCount;
     ULONG ReservedBlocksCount;
@@ -34,15 +34,15 @@ typedef struct _EXT2_SUPER_BLOCK {
     USHORT DefResUid;
     USHORT DefResGid;
         // Partial
-} EXT2_SUPER_BLOCK, *PEXT2_SUPER_BLOCK;
+} EXT_SUPER_BLOCK, *PEXT_SUPER_BLOCK;
 #include <poppack.h>
 
-C_ASSERT(FIELD_OFFSET(EXT2_SUPER_BLOCK, FreeInodesCount) == 0x10);
-C_ASSERT(FIELD_OFFSET(EXT2_SUPER_BLOCK, BlocksPerGroup) == 0x20);
-C_ASSERT(FIELD_OFFSET(EXT2_SUPER_BLOCK, WriteTime) == 0x30);
-C_ASSERT(FIELD_OFFSET(EXT2_SUPER_BLOCK, LastCheck) == 0x40);
-C_ASSERT(FIELD_OFFSET(EXT2_SUPER_BLOCK, DefResUid) == 0x50);
+C_ASSERT(FIELD_OFFSET(EXT_SUPER_BLOCK, FreeInodesCount) == 0x10);
+C_ASSERT(FIELD_OFFSET(EXT_SUPER_BLOCK, BlocksPerGroup) == 0x20);
+C_ASSERT(FIELD_OFFSET(EXT_SUPER_BLOCK, WriteTime) == 0x30);
+C_ASSERT(FIELD_OFFSET(EXT_SUPER_BLOCK, LastCheck) == 0x40);
+C_ASSERT(FIELD_OFFSET(EXT_SUPER_BLOCK, DefResUid) == 0x50);
 
-#define EXT2_SUPER_MAGIC 0xEF53
-#define EXT2_SB_OFFSET 0x400
-#define EXT2_SB_SIZE 0x400
+#define EXT_SUPER_MAGIC 0xEF53
+#define EXT_SB_OFFSET 0x400
+#define EXT_SB_SIZE 0x400

--- a/drivers/filesystems/fs_rec/fs_rec.c
+++ b/drivers/filesystems/fs_rec/fs_rec.c
@@ -158,10 +158,10 @@ FsRecFsControl(IN PDEVICE_OBJECT DeviceObject,
             Status = FsRecUdfsFsControl(DeviceObject, Irp);
             break;
 
-        case FS_TYPE_EXT2:
+        case FS_TYPE_EXT:
 
-            /* Send EXT2 command */
-            Status = FsRecExt2FsControl(DeviceObject, Irp);
+            /* Send EXT command */
+            Status = FsRecExtFsControl(DeviceObject, Irp);
             break;
 
         case FS_TYPE_BTRFS:
@@ -430,13 +430,13 @@ DriverEntry(IN PDRIVER_OBJECT DriverObject,
                              0);
     if (NT_SUCCESS(Status)) DeviceCount++;
 
-    /* Register EXT2 */
+    /* Register EXT */
     Status = FsRecRegisterFs(DriverObject,
                              NULL,
                              NULL,
-                             L"\\Ext2fs",
-                             L"\\FileSystem\\Ext2Recognizer",
-                             FS_TYPE_EXT2,
+                             L"\\Extfs",
+                             L"\\FileSystem\\ExtRecognizer",
+                             FS_TYPE_EXT,
                              FILE_DEVICE_DISK_FILE_SYSTEM,
                              0);
     if (NT_SUCCESS(Status)) DeviceCount++;

--- a/drivers/filesystems/fs_rec/fs_rec.c
+++ b/drivers/filesystems/fs_rec/fs_rec.c
@@ -329,6 +329,7 @@ DriverEntry(IN PDRIVER_OBJECT DriverObject,
     PDEVICE_OBJECT CdfsObject;
     PDEVICE_OBJECT UdfsObject;
     PDEVICE_OBJECT FatObject;
+    PDEVICE_OBJECT ExtObject;
 
     PAGED_CODE();
 
@@ -433,11 +434,22 @@ DriverEntry(IN PDRIVER_OBJECT DriverObject,
     /* Register EXT */
     Status = FsRecRegisterFs(DriverObject,
                              NULL,
-                             NULL,
+                             &ExtObject,
                              L"\\Extfs",
                              L"\\FileSystem\\ExtRecognizer",
                              FS_TYPE_EXT,
                              FILE_DEVICE_DISK_FILE_SYSTEM,
+                             0);
+    if (NT_SUCCESS(Status)) DeviceCount++;
+
+    /* Register EXT for CDs */
+    Status = FsRecRegisterFs(DriverObject,
+                             ExtObject,
+                             NULL,
+                             L"\\ExtfsCdrom",
+                             L"\\FileSystem\\ExtCdRomRecognizer",
+                             FS_TYPE_EXT,
+                             FILE_DEVICE_CD_ROM_FILE_SYSTEM,
                              0);
     if (NT_SUCCESS(Status)) DeviceCount++;
 

--- a/drivers/filesystems/fs_rec/fs_rec.h
+++ b/drivers/filesystems/fs_rec/fs_rec.h
@@ -173,7 +173,7 @@ typedef enum _FILE_SYSTEM_TYPE
     FS_TYPE_NTFS,
     FS_TYPE_CDFS,
     FS_TYPE_UDFS,
-    FS_TYPE_EXT2,
+    FS_TYPE_EXT,
     FS_TYPE_BTRFS,
     FS_TYPE_REISERFS,
     FS_TYPE_FFS,
@@ -227,7 +227,7 @@ FsRecUdfsFsControl(
 
 NTSTATUS
 NTAPI
-FsRecExt2FsControl(
+FsRecExtFsControl(
     IN PDEVICE_OBJECT DeviceObject,
     IN PIRP Irp
 );


### PR DESCRIPTION
## Purpose
Rename the Ext2 recognizer to a more generic Ext to be more future-proof with a possible upcoming ext4 support.  
Also, it already makes no sense to use the name ext2 as it already recognizes all the FS of the "Ext family".

JIRA issue: None
## Proposed changes
- rename the Recognizer
- add missing Ext CDs recognizer
