### PR TITLE
[NTOS:PS] Basic support for jobs in the kernel: Create/Open/Assign/Remove/Terminate/Delete

### DIFF
--- a/dll/win32/kernel32/client/job.c
+++ b/dll/win32/kernel32/client/job.c
@@ -74,9 +74,9 @@ OpenJobObjectA(_In_ DWORD dwDesiredAccess,
  */
 BOOL
 WINAPI
-IsProcessInJob(IN HANDLE ProcessHandle,
-               IN HANDLE JobHandle,
-               OUT PBOOL Result)
+IsProcessInJob(_In_ HANDLE ProcessHandle,
+               _In_opt_ HANDLE JobHandle,
+               _Out_ PBOOL Result)
 {
     NTSTATUS Status;
 

--- a/dll/win32/kernel32/client/job.c
+++ b/dll/win32/kernel32/client/job.c
@@ -116,11 +116,13 @@ AssignProcessToJobObject(_In_ HANDLE hJob,
  */
 BOOL
 WINAPI
-QueryInformationJobObject(IN HANDLE hJob,
-                          IN JOBOBJECTINFOCLASS JobObjectInformationClass,
-                          IN LPVOID lpJobObjectInformation,
-                          IN DWORD cbJobObjectInformationLength,
-                          OUT LPDWORD lpReturnLength)
+QueryInformationJobObject(
+    _In_opt_ HANDLE hJob,
+    _In_ JOBOBJECTINFOCLASS JobObjectInformationClass,
+    _Out_writes_bytes_to_(cbJobObjectInformationLength, *lpReturnLength) LPVOID
+    lpJobObjectInformation,
+    _In_ DWORD cbJobObjectInformationLength,
+    _Out_opt_ LPDWORD lpReturnLength)
 {
     NTSTATUS Status;
     PVOID JobInfo;
@@ -209,10 +211,11 @@ QueryInformationJobObject(IN HANDLE hJob,
  */
 BOOL
 WINAPI
-SetInformationJobObject(_In_ HANDLE hJob,
-                        _In_ JOBOBJECTINFOCLASS JobObjectInformationClass,
-                        _In_reads_bytes_(cbJobObjectInformationLength) LPVOID lpJobObjectInformation,
-                        _In_ DWORD cbJobObjectInformationLength)
+SetInformationJobObject(
+    _In_ HANDLE hJob,
+    _In_ JOBOBJECTINFOCLASS JobObjectInformationClass,
+    _In_reads_bytes_(cbJobObjectInformationLength) LPVOID lpJobObjectInformation,
+    _In_ DWORD cbJobObjectInformationLength)
 {
     NTSTATUS Status;
     PVOID JobInfo;

--- a/dll/win32/kernel32/client/job.c
+++ b/dll/win32/kernel32/client/job.c
@@ -315,8 +315,8 @@ SetInformationJobObject(IN HANDLE hJob,
  */
 BOOL
 WINAPI
-TerminateJobObject(IN HANDLE hJob,
-                   IN UINT uExitCode)
+TerminateJobObject(_In_ HANDLE hJob,
+                   _In_ UINT uExitCode)
 {
     NTSTATUS Status;
 

--- a/dll/win32/kernel32/client/job.c
+++ b/dll/win32/kernel32/client/job.c
@@ -23,8 +23,8 @@
  */
 HANDLE
 WINAPI
-CreateJobObjectA(IN LPSECURITY_ATTRIBUTES lpJobAttributes,
-                 IN LPCSTR lpName)
+CreateJobObjectA(_In_ LPSECURITY_ATTRIBUTES lpJobAttributes,
+                 _In_ LPCSTR lpName)
 {
     /* Call the W(ide) function */
     ConvertWin32AnsiObjectApiToUnicodeApi(JobObject, lpName, lpJobAttributes);
@@ -35,8 +35,8 @@ CreateJobObjectA(IN LPSECURITY_ATTRIBUTES lpJobAttributes,
  */
 HANDLE
 WINAPI
-CreateJobObjectW(IN LPSECURITY_ATTRIBUTES lpJobAttributes,
-                 IN LPCWSTR lpName)
+CreateJobObjectW(_In_ LPSECURITY_ATTRIBUTES lpJobAttributes,
+                 _In_ LPCWSTR lpName)
 {
     /* Create the NT object */
     CreateNtObjectFromWin32Api(JobObject, JobObject, JOB_OBJECT_ALL_ACCESS, lpJobAttributes, lpName);
@@ -47,9 +47,9 @@ CreateJobObjectW(IN LPSECURITY_ATTRIBUTES lpJobAttributes,
  */
 HANDLE
 WINAPI
-OpenJobObjectW(IN DWORD dwDesiredAccess,
-               IN BOOL bInheritHandle,
-               IN LPCWSTR lpName)
+OpenJobObjectW(_In_ DWORD dwDesiredAccess,
+               _In_ BOOL bInheritHandle,
+               _In_ LPCWSTR lpName)
 {
     /* Open the NT object */
     OpenNtObjectFromWin32Api(JobObject, dwDesiredAccess, bInheritHandle, lpName);
@@ -61,9 +61,9 @@ OpenJobObjectW(IN DWORD dwDesiredAccess,
  */
 HANDLE
 WINAPI
-OpenJobObjectA(IN DWORD dwDesiredAccess,
-               IN BOOL bInheritHandle,
-               IN LPCSTR lpName)
+OpenJobObjectA(_In_ DWORD dwDesiredAccess,
+               _In_ BOOL bInheritHandle,
+               _In_ LPCSTR lpName)
 {
     /* Call the W(ide) function */
     ConvertOpenWin32AnsiObjectApiToUnicodeApi(JobObject, dwDesiredAccess, bInheritHandle, lpName);

--- a/dll/win32/kernel32/client/job.c
+++ b/dll/win32/kernel32/client/job.c
@@ -209,10 +209,10 @@ QueryInformationJobObject(IN HANDLE hJob,
  */
 BOOL
 WINAPI
-SetInformationJobObject(IN HANDLE hJob,
-                        IN JOBOBJECTINFOCLASS JobObjectInformationClass,
-                        IN LPVOID lpJobObjectInformation,
-                        IN DWORD cbJobObjectInformationLength)
+SetInformationJobObject(_In_ HANDLE hJob,
+                        _In_ JOBOBJECTINFOCLASS JobObjectInformationClass,
+                        _In_reads_bytes_(cbJobObjectInformationLength) LPVOID lpJobObjectInformation,
+                        _In_ DWORD cbJobObjectInformationLength)
 {
     NTSTATUS Status;
     PVOID JobInfo;

--- a/dll/win32/kernel32/client/job.c
+++ b/dll/win32/kernel32/client/job.c
@@ -96,8 +96,8 @@ IsProcessInJob(IN HANDLE ProcessHandle,
  */
 BOOL
 WINAPI
-AssignProcessToJobObject(IN HANDLE hJob,
-                         IN HANDLE hProcess)
+AssignProcessToJobObject(_In_ HANDLE hJob,
+                         _In_ HANDLE hProcess)
 {
     NTSTATUS Status;
 

--- a/dll/win32/kernel32/client/job.c
+++ b/dll/win32/kernel32/client/job.c
@@ -23,8 +23,9 @@
  */
 HANDLE
 WINAPI
-CreateJobObjectA(_In_ LPSECURITY_ATTRIBUTES lpJobAttributes,
-                 _In_ LPCSTR lpName)
+CreateJobObjectA(
+    _In_ LPSECURITY_ATTRIBUTES lpJobAttributes,
+    _In_ LPCSTR lpName)
 {
     /* Call the W(ide) function */
     ConvertWin32AnsiObjectApiToUnicodeApi(JobObject, lpName, lpJobAttributes);
@@ -35,8 +36,9 @@ CreateJobObjectA(_In_ LPSECURITY_ATTRIBUTES lpJobAttributes,
  */
 HANDLE
 WINAPI
-CreateJobObjectW(_In_ LPSECURITY_ATTRIBUTES lpJobAttributes,
-                 _In_ LPCWSTR lpName)
+CreateJobObjectW(
+    _In_ LPSECURITY_ATTRIBUTES lpJobAttributes,
+    _In_ LPCWSTR lpName)
 {
     /* Create the NT object */
     CreateNtObjectFromWin32Api(JobObject, JobObject, JOB_OBJECT_ALL_ACCESS, lpJobAttributes, lpName);
@@ -47,9 +49,10 @@ CreateJobObjectW(_In_ LPSECURITY_ATTRIBUTES lpJobAttributes,
  */
 HANDLE
 WINAPI
-OpenJobObjectW(_In_ DWORD dwDesiredAccess,
-               _In_ BOOL bInheritHandle,
-               _In_ LPCWSTR lpName)
+OpenJobObjectW(
+    _In_ DWORD dwDesiredAccess,
+    _In_ BOOL bInheritHandle,
+    _In_ LPCWSTR lpName)
 {
     /* Open the NT object */
     OpenNtObjectFromWin32Api(JobObject, dwDesiredAccess, bInheritHandle, lpName);
@@ -61,9 +64,10 @@ OpenJobObjectW(_In_ DWORD dwDesiredAccess,
  */
 HANDLE
 WINAPI
-OpenJobObjectA(_In_ DWORD dwDesiredAccess,
-               _In_ BOOL bInheritHandle,
-               _In_ LPCSTR lpName)
+OpenJobObjectA(
+    _In_ DWORD dwDesiredAccess,
+    _In_ BOOL bInheritHandle,
+    _In_ LPCSTR lpName)
 {
     /* Call the W(ide) function */
     ConvertOpenWin32AnsiObjectApiToUnicodeApi(JobObject, dwDesiredAccess, bInheritHandle, lpName);
@@ -74,9 +78,10 @@ OpenJobObjectA(_In_ DWORD dwDesiredAccess,
  */
 BOOL
 WINAPI
-IsProcessInJob(_In_ HANDLE ProcessHandle,
-               _In_opt_ HANDLE JobHandle,
-               _Out_ PBOOL Result)
+IsProcessInJob(
+    _In_ HANDLE ProcessHandle,
+    _In_opt_ HANDLE JobHandle,
+    _Out_ PBOOL Result)
 {
     NTSTATUS Status;
 
@@ -96,8 +101,9 @@ IsProcessInJob(_In_ HANDLE ProcessHandle,
  */
 BOOL
 WINAPI
-AssignProcessToJobObject(_In_ HANDLE hJob,
-                         _In_ HANDLE hProcess)
+AssignProcessToJobObject(
+    _In_ HANDLE hJob,
+    _In_ HANDLE hProcess)
 {
     NTSTATUS Status;
 
@@ -119,8 +125,8 @@ WINAPI
 QueryInformationJobObject(
     _In_opt_ HANDLE hJob,
     _In_ JOBOBJECTINFOCLASS JobObjectInformationClass,
-    _Out_writes_bytes_to_(cbJobObjectInformationLength, *lpReturnLength) LPVOID
-    lpJobObjectInformation,
+    _Out_writes_bytes_to_(cbJobObjectInformationLength, *lpReturnLength)
+        LPVOID lpJobObjectInformation,
     _In_ DWORD cbJobObjectInformationLength,
     _Out_opt_ LPDWORD lpReturnLength)
 {
@@ -318,8 +324,9 @@ SetInformationJobObject(
  */
 BOOL
 WINAPI
-TerminateJobObject(_In_ HANDLE hJob,
-                   _In_ UINT uExitCode)
+TerminateJobObject(
+    _In_ HANDLE hJob,
+    _In_ UINT uExitCode)
 {
     NTSTATUS Status;
 

--- a/dll/win32/kernel32/client/proc.c
+++ b/dll/win32/kernel32/client/proc.c
@@ -3808,10 +3808,11 @@ StartScan:
                                                       NULL);
     }
 
-    /* Check if we're going to be debugged */
-    if (dwCreationFlags & DEBUG_PROCESS)
+    /* Check if CREATE_BREAKAWAY_FROM_JOB is set, this flag allows the child process
+       to break away from the job associated with the calling process */
+    if (dwCreationFlags & CREATE_BREAKAWAY_FROM_JOB)
     {
-        /* Set process flag */
+        /* Set the corresponding process flag */
         Flags |= PROCESS_CREATE_FLAGS_BREAKAWAY;
     }
 

--- a/dll/win32/kernel32/client/proc.c
+++ b/dll/win32/kernel32/client/proc.c
@@ -3808,11 +3808,10 @@ StartScan:
                                                       NULL);
     }
 
-    /* Check if CREATE_BREAKAWAY_FROM_JOB is set, this flag allows the child process
-       to break away from the job associated with the calling process */
+    /* CREATE_BREAKAWAY_FROM_JOB allows the child process to break
+       away from the job associated with the calling process */
     if (dwCreationFlags & CREATE_BREAKAWAY_FROM_JOB)
     {
-        /* Set the corresponding process flag */
         Flags |= PROCESS_CREATE_FLAGS_BREAKAWAY;
     }
 

--- a/dll/win32/kernel32/client/proc.c
+++ b/dll/win32/kernel32/client/proc.c
@@ -3809,7 +3809,7 @@ StartScan:
     }
 
     /* CREATE_BREAKAWAY_FROM_JOB allows the child process to break
-       away from the job associated with the calling process */
+     * away from the job associated with the calling process */
     if (dwCreationFlags & CREATE_BREAKAWAY_FROM_JOB)
     {
         Flags |= PROCESS_CREATE_FLAGS_BREAKAWAY;

--- a/ntoskrnl/include/internal/ps.h
+++ b/ntoskrnl/include/internal/ps.h
@@ -403,7 +403,8 @@ NTAPI
 PspEnumerateProcessesInJob(
     _In_ PEJOB Job,
     _In_ PJOB_ENUMERATOR_CALLBACK Callback,
-    _In_opt_ PVOID Context
+    _In_opt_ PVOID Context,
+    _In_ BOOLEAN BreakOnCallbackFailure
 );
 
 NTSTATUS

--- a/ntoskrnl/include/internal/ps.h
+++ b/ntoskrnl/include/internal/ps.h
@@ -371,6 +371,20 @@ PspQueryDescriptorThread(
 //
 // Job Routines
 //
+typedef NTSTATUS
+(*PJOB_ENUMERATOR_CALLBACK)(
+    _In_ PEPROCESS Process,
+    _In_opt_ PVOID Context
+);
+
+NTSTATUS
+NTAPI
+PspEnumerateProcessesInJob(
+    _In_ PEJOB Job,
+    _In_ PJOB_ENUMERATOR_CALLBACK Callback,
+    _In_opt_ PVOID Context
+);
+
 VOID
 NTAPI
 PspExitProcessFromJob(

--- a/ntoskrnl/include/internal/ps.h
+++ b/ntoskrnl/include/internal/ps.h
@@ -82,8 +82,19 @@
 // These are based on the layout of bit fields in the Flags2 set introduced in
 // version 6.0
 //
+// More information:
+// https://www.geoffchappell.com/studies/windows/km/ntoskrnl/inc/ntos/ps/eprocess/flags2.htm
+//
 #define JOB_NOT_REALLY_ACTIVE   0x00000001
 #define ACCOUNTING_FOLDED       0x00000002
+
+//
+// Job Flags
+//
+// More information:
+// https://www.geoffchappell.com/studies/windows/km/ntoskrnl/inc/ntos/ps/ejob/jobflags.htm
+//
+#define JOB_OBJECT_CLOSE_DONE                   0x1
 
 //
 // Thread "Set/Get Context" Context Structure

--- a/ntoskrnl/include/internal/ps.h
+++ b/ntoskrnl/include/internal/ps.h
@@ -94,7 +94,8 @@
 // More information:
 // https://www.geoffchappell.com/studies/windows/km/ntoskrnl/inc/ntos/ps/ejob/jobflags.htm
 //
-#define JOB_OBJECT_CLOSE_DONE                   0x1
+#define JOB_OBJECT_CLOSE_DONE                   0x00000001
+#define JOB_OBJECT_TERMINATING                  0x00000080
 
 //
 // Thread "Set/Get Context" Context Structure

--- a/ntoskrnl/include/internal/ps.h
+++ b/ntoskrnl/include/internal/ps.h
@@ -374,15 +374,15 @@ PspQueryDescriptorThread(
 VOID
 NTAPI
 PspExitProcessFromJob(
-    IN PEJOB Job,
-    IN PEPROCESS Process
+    _In_ PEJOB Job,
+    _In_ PEPROCESS Process
 );
 
 VOID
 NTAPI
 PspRemoveProcessFromJob(
-    IN PEPROCESS Process,
-    IN PEJOB Job
+    _In_ PEPROCESS Process,
+    _In_ PEJOB Job
 );
 
 CODE_SEG("INIT")
@@ -394,8 +394,18 @@ PspInitializeJobStructures(
 
 VOID
 NTAPI
+PspCloseJob(
+    _In_ PEPROCESS Process,
+    _In_ PVOID ObjectBody,
+    _In_ ACCESS_MASK GrantedAccess,
+    _In_ ULONG HandleCount,
+    _In_ ULONG SystemHandleCount
+);
+
+VOID
+NTAPI
 PspDeleteJob(
-    IN PVOID ObjectBody
+    _In_ PVOID ObjectBody
 );
 
 //

--- a/ntoskrnl/include/internal/ps.h
+++ b/ntoskrnl/include/internal/ps.h
@@ -77,6 +77,15 @@
 #define PSP_PAGED_POOL_QUOTA_THRESHOLD                  0x80000
 
 //
+// Flags for JobStatus in EPROCESS
+//
+// These are based on the layout of bit fields in the Flags2 set introduced in
+// version 6.0
+//
+#define JOB_NOT_REALLY_ACTIVE   0x00000001
+#define ACCOUNTING_FOLDED       0x00000002
+
+//
 // Thread "Set/Get Context" Context Structure
 //
 typedef struct _GET_SET_CTX_CONTEXT

--- a/ntoskrnl/include/internal/ps.h
+++ b/ntoskrnl/include/internal/ps.h
@@ -385,6 +385,13 @@ PspEnumerateProcessesInJob(
     _In_opt_ PVOID Context
 );
 
+NTSTATUS
+NTAPI
+PspAssignProcessToJob(
+    _In_ PEPROCESS Process,
+    _In_ PEJOB Job
+);
+
 VOID
 NTAPI
 PspExitProcessFromJob(

--- a/ntoskrnl/include/internal/ps.h
+++ b/ntoskrnl/include/internal/ps.h
@@ -438,8 +438,8 @@ PspCloseJob(
     _In_ PEPROCESS Process,
     _In_ PVOID ObjectBody,
     _In_ ACCESS_MASK GrantedAccess,
-    _In_ ULONG HandleCount,
-    _In_ ULONG SystemHandleCount
+    _In_ ULONG_PTR ProcessHandleCount,
+    _In_ ULONG_PTR SystemHandleCount
 );
 
 VOID

--- a/ntoskrnl/include/internal/ps.h
+++ b/ntoskrnl/include/internal/ps.h
@@ -403,8 +403,7 @@ NTAPI
 PspEnumerateProcessesInJob(
     _In_ PEJOB Job,
     _In_ PJOB_ENUMERATOR_CALLBACK Callback,
-    _In_opt_ PVOID Context,
-    _In_ BOOLEAN BreakOnCallbackFailure
+    _In_opt_ PVOID Context
 );
 
 NTSTATUS
@@ -417,15 +416,13 @@ PspAssignProcessToJob(
 VOID
 NTAPI
 PspExitProcessFromJob(
-    _In_ PEJOB Job,
     _In_ PEPROCESS Process
 );
 
 VOID
 NTAPI
 PspRemoveProcessFromJob(
-    _In_ PEPROCESS Process,
-    _In_ PEJOB Job
+    _In_ PEPROCESS Process
 );
 
 CODE_SEG("INIT")
@@ -449,6 +446,15 @@ VOID
 NTAPI
 PspDeleteJob(
     _In_ PVOID ObjectBody
+);
+
+NTSTATUS
+NTAPI
+PspSendJobMessageLocked(
+    _In_ PEJOB Job,
+    _In_ ULONG Message,
+    _In_opt_ PVOID CompletionValue,
+    _In_ BOOLEAN Quota
 );
 
 //

--- a/ntoskrnl/include/internal/ps.h
+++ b/ntoskrnl/include/internal/ps.h
@@ -66,9 +66,32 @@
 #define PSP_MAX_CREATE_PROCESS_NOTIFY           8
 
 //
-// Maximum Job Scheduling Classes
+// Job Scheduling Classes
 //
+// The default is 5 per Yosifovich, P., "Windows 10 System Programming, Part 1"
+#define PSP_JOB_SCHEDULING_CLASS_DEFAULT        5
 #define PSP_JOB_SCHEDULING_CLASSES              10
+
+//
+// Valid Job Object Limits
+//
+#define PSP_JOB_BASIC_LIMIT_VALID_FLAGS     \
+    (JOB_OBJECT_LIMIT_WORKINGSET |          \
+     JOB_OBJECT_LIMIT_PROCESS_TIME |        \
+     JOB_OBJECT_LIMIT_JOB_TIME |            \
+     JOB_OBJECT_LIMIT_ACTIVE_PROCESS |      \
+     JOB_OBJECT_LIMIT_AFFINITY |            \
+     JOB_OBJECT_LIMIT_PRIORITY_CLASS |      \
+     JOB_OBJECT_LIMIT_PRESERVE_JOB_TIME |   \
+     JOB_OBJECT_LIMIT_SCHEDULING_CLASS)
+#define PSP_JOB_EXTENDED_LIMIT_VALID_FLAGS          \
+    (PSP_JOB_BASIC_LIMIT_VALID_FLAGS |              \
+     JOB_OBJECT_LIMIT_PROCESS_MEMORY |              \
+     JOB_OBJECT_LIMIT_JOB_MEMORY |                  \
+     JOB_OBJECT_LIMIT_DIE_ON_UNHANDLED_EXCEPTION |  \
+     JOB_OBJECT_LIMIT_BREAKAWAY_OK |                \
+     JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK |         \
+     JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE)
 
 //
 // Process Quota Threshold Values
@@ -85,8 +108,8 @@
 // More information:
 // https://www.geoffchappell.com/studies/windows/km/ntoskrnl/inc/ntos/ps/eprocess/flags2.htm
 //
-#define JOB_NOT_REALLY_ACTIVE   0x00000001
-#define ACCOUNTING_FOLDED       0x00000002
+#define PSP_JOB_NOT_REALLY_ACTIVE   0x00000001
+#define PSP_JOB_ACCOUNTING_FOLDED   0x00000002
 
 //
 // Job Flags
@@ -94,8 +117,8 @@
 // More information:
 // https://www.geoffchappell.com/studies/windows/km/ntoskrnl/inc/ntos/ps/ejob/jobflags.htm
 //
-#define JOB_OBJECT_CLOSE_DONE                   0x00000001
-#define JOB_OBJECT_TERMINATING                  0x00000080
+#define PSP_JOB_CLOSE_DONE      0x00000001
+#define PSP_JOB_TERMINATING     0x00000080
 
 //
 // Thread "Set/Get Context" Context Structure
@@ -393,7 +416,7 @@ PspQueryDescriptorThread(
 // Job Routines
 //
 typedef NTSTATUS
-(*PJOB_ENUMERATOR_CALLBACK)(
+(NTAPI *PJOB_ENUMERATOR_CALLBACK)(
     _In_ PEPROCESS Process,
     _In_opt_ PVOID Context
 );

--- a/ntoskrnl/include/internal/ps.h
+++ b/ntoskrnl/include/internal/ps.h
@@ -79,8 +79,8 @@
 //
 // Flags for JobStatus in EPROCESS
 //
-// These are based on the layout of bit fields in the Flags2 set introduced in
-// version 6.0
+// These are based on the layout of bit fields in the Flags2 set
+// introduced in version 6.0
 //
 // More information:
 // https://www.geoffchappell.com/studies/windows/km/ntoskrnl/inc/ntos/ps/eprocess/flags2.htm

--- a/ntoskrnl/ps/job.c
+++ b/ntoskrnl/ps/job.c
@@ -513,7 +513,6 @@ PspExitProcessFromJob(
  */
 static
 NTSTATUS
-NTAPI
 PspTerminateProcessCallback(
     _In_ PEPROCESS Process,
     _In_opt_ PVOID Context
@@ -635,7 +634,6 @@ PspCloseJob(
     _In_ ULONG SystemHandleCount
 )
 {
-    NTSTATUS Status;
     PEJOB Job = (PEJOB)ObjectBody;
 
     PAGED_CODE();
@@ -664,7 +662,7 @@ PspCloseJob(
     /* If the job is set to kill on close, terminate all associated processes */
     if (Job->LimitFlags & JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE)
     {
-        Status = PspTerminateJobObject(Job, STATUS_SUCCESS);
+        NTSTATUS Status = PspTerminateJobObject(Job, STATUS_SUCCESS);
         ASSERT(NT_SUCCESS(Status));
     }
 
@@ -1884,7 +1882,6 @@ NtQueryInformationJobObject(
     NTSTATUS Status;
     BOOLEAN NoOutput;
     PVOID JobInfoBuffer;
-    PLIST_ENTRY NextEntry;
     PKTHREAD CurrentThread;
     KPROCESSOR_MODE PreviousMode;
     JOBOBJECT_EXTENDED_LIMIT_INFORMATION ExtendedLimit;

--- a/ntoskrnl/ps/job.c
+++ b/ntoskrnl/ps/job.c
@@ -682,6 +682,8 @@ PspDeleteJob(_In_ PVOID ObjectBody)
 
     PAGED_CODE();
 
+    Job->LimitFlags = 0;
+
     /* Remove the reference to the completion port if associated */
     if (Job->CompletionPort != NULL)
     {
@@ -732,7 +734,6 @@ PspSetJobLimitsBasicOrExtended(
     _In_ BOOLEAN IsExtendedLimit
 )
 {
-    NTSTATUS Status;
     ULONG AllowedFlags;
     KPROCESSOR_MODE PreviousMode = ExGetPreviousMode();
 
@@ -913,7 +914,7 @@ PspSetJobLimitsBasicOrExtended(
     KeReleaseGuardedMutexUnsafe(&Job->MemoryLimitsLock);
     ExReleaseResourceLite(&Job->JobLock);
 
-    return Status;
+    return STATUS_SUCCESS;
 }
 
 /*!

--- a/ntoskrnl/ps/job.c
+++ b/ntoskrnl/ps/job.c
@@ -473,17 +473,6 @@ PspExitProcessFromJob(
             InterlockedOr((PLONG)&Process->JobStatus, JOB_NOT_REALLY_ACTIVE);
         }
 
-        /* If the job has a completion port, notify it of the process exit */
-        if (Job->CompletionPort)
-        {
-            IoSetIoCompletion(Job->CompletionPort,
-                              Job->CompletionKey,
-                              NULL,
-                              STATUS_SUCCESS,
-                              JOB_OBJECT_MSG_EXIT_PROCESS,
-                              FALSE);
-        }
-
         /* If no active processes remain, notify the job completion port */
         if (Job->ActiveProcesses == 0 && Job->CompletionPort)
         {

--- a/ntoskrnl/ps/job.c
+++ b/ntoskrnl/ps/job.c
@@ -145,10 +145,26 @@ PspAssignProcessToJob(
     /* Check if the job has a limit on the number of active processes */
     if (Job->LimitFlags & JOB_OBJECT_LIMIT_ACTIVE_PROCESS)
     {
-        if (Job->ActiveProcesses >= Job->ActiveProcessLimit)
+        /* Check if job limit on active processes has been reached */
+        if (Job->ActiveProcesses > Job->ActiveProcessLimit)
         {
-            /* Job limit on active processes has been reached */
-            /* TODO */
+            if (Job->CompletionPort)
+            {
+                /* If the job has a completion port, notify the job that the limit
+                   on the number of active processes has been exceeded */
+                Status = IoSetIoCompletion(Job->CompletionPort,
+                                           Job->CompletionKey,
+                                           NULL,
+                                           STATUS_SUCCESS,
+                                           JOB_OBJECT_MSG_ACTIVE_PROCESS_LIMIT,
+                                           TRUE);
+            }
+            else
+            {
+                Status = STATUS_QUOTA_EXCEEDED;
+            }
+
+            return Status;
         }
     }
 

--- a/ntoskrnl/ps/job.c
+++ b/ntoskrnl/ps/job.c
@@ -1074,7 +1074,7 @@ PspQueryLimitInformation(
 }
 
 /*!
- * Callback function used by to collect the process IDs for all active processes
+ * Callback function used to collect the process IDs for all active processes
  * in a job object.
  *
  * @param[in] Process
@@ -1244,7 +1244,6 @@ PsSetJobUIRestrictionsClass(PEJOB Job,
 {
     ASSERT(Job);
     (void)InterlockedExchangeUL(&Job->UIRestrictionsClass, UIRestrictionsClass);
-    /* FIXME - walk through the job process list and update the restrictions? */
 }
 
 /*!

--- a/ntoskrnl/ps/job.c
+++ b/ntoskrnl/ps/job.c
@@ -95,7 +95,7 @@ ULONG PspJobInfoAlign[] =
  * @param[in] ExitStatus
  *     The exit status to be used for all terminated processes.
  */
-typedef struct _TERMINATE_PROCESS_CONTEXT
+typedef struct TERMINATE_PROCESS_CONTEXT
 {
     PEJOB Job;
     NTSTATUS ExitStatus;
@@ -324,7 +324,8 @@ PspRemoveProcessFromJob(
  * @param[in] Process
  *     A pointer to the process that is exiting the job.
  *
- * @remark This function is called from PspExitThread() as the last thread exits.
+ * @remark This function is called from PspExitThread() as the last thread
+ *         exits.
  */
 VOID
 NTAPI
@@ -897,7 +898,8 @@ NtAssignProcessToJobObject(
         /* Try to atomically compare-and-exchange the job pointer */
         if (InterlockedCompareExchangePointer((PVOID)&Process->Job, Job, NULL))
         {
-            ObDereferenceObject(Job);
+            /* At this point, the job was referenced twice */
+            ObDereferenceObjectEx(Job, 2);
             Status = STATUS_ACCESS_DENIED;
         }
         else
@@ -928,11 +930,12 @@ NtAssignProcessToJobObject(
  *     A handle to the process being queried.
  *
  * @param[in, optional] JobHandle
- *     An optional handle to the job object being compared. If NULL, the function
- *     checks if the process is associated with any job.
+ *     An optional handle to the job object being compared. If NULL,
+ *     the function checks if the process is associated with any job.
  *
  * @returns
- *     STATUS_PROCESS_IN_JOB if the process is in the job or any job (when JobHandle is NULL).
+ *     STATUS_PROCESS_IN_JOB if the process is in the job or any job (when
+ *     JobHandle is NULL).
  *     STATUS_PROCESS_NOT_IN_JOB if the process is not in the job or any job.
  *     Otherwise, an appropriate NTSTATUS error code.
  */

--- a/ntoskrnl/ps/job.c
+++ b/ntoskrnl/ps/job.c
@@ -352,7 +352,8 @@ PspAssignProcessToJob(
        when AssignProcessToJob is called, the function fails" */
     if (Job->JobFlags & JOB_OBJECT_TERMINATING)
     {
-        return STATUS_INVALID_PARAMETER;
+        Status = STATUS_INVALID_PARAMETER;
+        goto Exit;
     }
 
     /* Prevent processes from being added to the job if it is flagged for
@@ -360,7 +361,8 @@ PspAssignProcessToJob(
     if (Job->LimitFlags & JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE &&
         Job->JobFlags & JOB_OBJECT_CLOSE_DONE)
     {
-        return STATUS_INVALID_PARAMETER;
+        Status = STATUS_INVALID_PARAMETER;
+        goto Exit;
     }
 
     /* Assign process to job object by inserting into the job's process list */
@@ -381,6 +383,8 @@ PspAssignProcessToJob(
                                    JOB_OBJECT_MSG_NEW_PROCESS,
                                    FALSE);
     }
+
+Exit:
 
     ExReleaseResourceAndLeaveCriticalRegion(&Job->JobLock);
 

--- a/ntoskrnl/ps/job.c
+++ b/ntoskrnl/ps/job.c
@@ -1782,7 +1782,7 @@ NtIsProcessInJob(
     }
 
     /* Dereference the process object if it was referenced */
-    if (ProcessHandle == PsGetCurrentProcess())
+    if (ProcessHandle != PsGetCurrentProcess())
     {
         ObDereferenceObject(Process);
     }

--- a/ntoskrnl/ps/job.c
+++ b/ntoskrnl/ps/job.c
@@ -765,14 +765,16 @@ PspSetJobLimitsBasicOrExtended(
     /* Validate flags */
     if (ExtendedLimit->BasicLimitInformation.LimitFlags & ~AllowedFlags)
     {
-        DPRINT1("Invalid LimitFlags specified\n");
+        DPRINT1("Invalid LimitFlags specified: 0x%08X\n",
+                (ExtendedLimit->BasicLimitInformation.LimitFlags & ~AllowedFlags));
         return STATUS_INVALID_PARAMETER;
     }
 
     if ((ExtendedLimit->BasicLimitInformation.LimitFlags & JOB_OBJECT_LIMIT_PRESERVE_JOB_TIME) &&
         (ExtendedLimit->BasicLimitInformation.LimitFlags & JOB_OBJECT_LIMIT_JOB_TIME))
     {
-        DPRINT1("Invalid LimitFlags combination specified\n");
+        DPRINT1("Invalid LimitFlags combination specified "
+                "(PRESERVE_JOB_TIME and JOB_TIME are mutually exclusive)\n");
         return STATUS_INVALID_PARAMETER;
     }
 

--- a/ntoskrnl/ps/job.c
+++ b/ntoskrnl/ps/job.c
@@ -275,6 +275,7 @@ PspEnumerateProcessesInJob(
             AnyCallbackFailed = TRUE;
             if (BreakOnCallbackFailure)
             {
+                ObDereferenceObject(Process);
                 break;
             }
         }

--- a/ntoskrnl/ps/job.c
+++ b/ntoskrnl/ps/job.c
@@ -308,7 +308,7 @@ PspAssignProcessToJob(
 
     /* Check if the job has a limit on the number of active processes */
     if (Job->LimitFlags & JOB_OBJECT_LIMIT_ACTIVE_PROCESS &&
-        Job->ActiveProcesses > Job->ActiveProcessLimit)
+        Job->ActiveProcesses >= Job->ActiveProcessLimit)
     {
         /* Check if job limit on active processes has been reached */
         if (Job->CompletionPort)
@@ -1683,6 +1683,13 @@ NtAssignProcessToJobObject(
 
         /* Assign the process to the job */
         Status = PspAssignProcessToJob(Process, Job);
+
+        /* If the assignment causes the active process count to exceed
+           ActiveProcessLimit, the process is terminated */
+        if (Status == STATUS_QUOTA_EXCEEDED)
+        {
+            Status = PsTerminateProcess(Process, STATUS_QUOTA_EXCEEDED);
+        }
 
         /* TODO: UI restrictions class */
     }

--- a/ntoskrnl/ps/job.c
+++ b/ntoskrnl/ps/job.c
@@ -331,19 +331,16 @@ PspAssignProcessToJob(
             {
                 /* If the job has a completion port, notify the job that the
                    limit on the number of active processes has been exceeded */
-                Status = IoSetIoCompletion(Job->CompletionPort,
-                                           Job->CompletionKey,
-                                           NULL,
-                                           STATUS_SUCCESS,
-                                           JOB_OBJECT_MSG_ACTIVE_PROCESS_LIMIT,
-                                           TRUE);
-            }
-            else
-            {
-                Status = STATUS_QUOTA_EXCEEDED;
+                IoSetIoCompletion(Job->CompletionPort,
+                                  Job->CompletionKey,
+                                  NULL,
+                                  STATUS_SUCCESS,
+                                  JOB_OBJECT_MSG_ACTIVE_PROCESS_LIMIT,
+                                  TRUE);
             }
 
-            return Status;
+            Status = STATUS_QUOTA_EXCEEDED;
+            goto Exit;
         }
     }
 

--- a/ntoskrnl/ps/job.c
+++ b/ntoskrnl/ps/job.c
@@ -777,7 +777,7 @@ PspSetJobLimitsBasicOrExtended(
     }
 
     /* Acquire the job lock */
-    ExAcquireResourceSharedLite(&Job->JobLock, TRUE);
+    ExAcquireResourceExclusiveLite(&Job->JobLock, TRUE);
 
     /*
      * Basic Limits
@@ -1034,6 +1034,7 @@ PspAssociateCompletionPortWithJob(
     Context.CompletionPort = Job->CompletionPort;
     Context.CompletionKey = Job->CompletionKey;
 
+    /* Inform all processes in the job about the association. */
     Status = PspEnumerateProcessesInJob(Job,
                                         PspAssociateCompletionPortCallback,
                                         &Context,

--- a/ntoskrnl/ps/job.c
+++ b/ntoskrnl/ps/job.c
@@ -635,6 +635,7 @@ PspCloseJob(
 )
 {
     PEJOB Job = (PEJOB)ObjectBody;
+    PVOID CompletionPort;
 
     PAGED_CODE();
 
@@ -666,8 +667,11 @@ PspCloseJob(
         ASSERT(NT_SUCCESS(Status));
     }
 
-    /* Set the completion port to NULL to clean up */
-    Job->CompletionPort = NULL;
+    if (Job->CompletionPort)
+    {
+        ObDereferenceObject(Job->CompletionPort);
+        Job->CompletionPort = NULL;
+    }
 }
 
 /*!

--- a/ntoskrnl/ps/job.c
+++ b/ntoskrnl/ps/job.c
@@ -429,6 +429,17 @@ PspRemoveProcessFromJob(
 
     /* TODO: Ensure that job limits are respected */
 
+    /* If no active processes remain, notify the job completion port */
+    if (Job->ActiveProcesses == 0 && Job->CompletionPort)
+    {
+        IoSetIoCompletion(Job->CompletionPort,
+                          Job->CompletionKey,
+                          NULL,
+                          STATUS_SUCCESS,
+                          JOB_OBJECT_MSG_ACTIVE_PROCESS_ZERO,
+                          FALSE);
+    }
+
     ExReleaseResourceAndLeaveCriticalRegion(&Job->JobLock);
 }
 

--- a/ntoskrnl/ps/job.c
+++ b/ntoskrnl/ps/job.c
@@ -654,6 +654,8 @@ PspCloseJob(
     /* Proceed only when the last handle is left */
     if (SystemHandleCount != 1)
     {
+        DPRINT1("PspJobClose called with unexpected SystemHandleCount: %lu\n",
+                SystemHandleCount);
         return;
     }
 

--- a/ntoskrnl/ps/job.c
+++ b/ntoskrnl/ps/job.c
@@ -797,10 +797,7 @@ PspSetJobLimitsBasicOrExtended(
                 ExtendedLimit->BasicLimitInformation.MaximumWorkingSetSize <= 0)
             ||
             (ExtendedLimit->BasicLimitInformation.MaximumWorkingSetSize <
-                ExtendedLimit->BasicLimitInformation.MinimumWorkingSetSize)
-            ||
-            (!ExtendedLimit->BasicLimitInformation.MaximumWorkingSetSize &&
-                ExtendedLimit->BasicLimitInformation.MaximumWorkingSetSize))
+                ExtendedLimit->BasicLimitInformation.MinimumWorkingSetSize))
         {
             Status = STATUS_INVALID_PARAMETER;
             goto ExitFromBasicLimits;

--- a/ntoskrnl/ps/job.c
+++ b/ntoskrnl/ps/job.c
@@ -549,7 +549,20 @@ PspTerminateProcessCallback(
             {
                 /* If so, notify anyone waiting for the job object
                    by signaling completion */
+
+                /* It is intended that the event is set to a signaled
+                   state only in the termination path */
                 KeSetEvent(&Job->Event, IO_NO_INCREMENT, FALSE);
+
+                if (Job->CompletionPort)
+                {
+                    IoSetIoCompletion(Job->CompletionPort,
+                                      Job->CompletionKey,
+                                      NULL,
+                                      STATUS_SUCCESS,
+                                      JOB_OBJECT_MSG_ACTIVE_PROCESS_ZERO,
+                                      FALSE);
+                }
             }
         }
     }

--- a/ntoskrnl/ps/job.c
+++ b/ntoskrnl/ps/job.c
@@ -648,7 +648,6 @@ PspCloseJob(
 )
 {
     PEJOB Job = (PEJOB)ObjectBody;
-    PVOID CompletionPort;
 
     PAGED_CODE();
 

--- a/ntoskrnl/ps/job.c
+++ b/ntoskrnl/ps/job.c
@@ -537,7 +537,7 @@ PspAssignProcessToJob(
     /* https://learn.microsoft.com/en-us/windows/win32/api/jobapi2/nf-jobapi2-assignprocesstojobobject:
        "If the job or any of its parent jobs in the job chain is terminating
        when AssignProcessToJob is called, the function fails" */
-    if (Job->JobFlags & JOB_OBJECT_TERMINATING)
+    if (BooleanFlagOn(Job->JobFlags, JOB_OBJECT_TERMINATING))
     {
         Status = STATUS_INVALID_PARAMETER;
         goto Exit;
@@ -545,15 +545,15 @@ PspAssignProcessToJob(
 
     /* Prevent processes from being added to the job if it is flagged
        for closing and has a limit on process termination on closing */
-    if (Job->LimitFlags & JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE &&
-        Job->JobFlags & JOB_OBJECT_CLOSE_DONE)
+    if (BooleanFlagOn(Job->LimitFlags, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE) &&
+        BooleanFlagOn(Job->JobFlags, JOB_OBJECT_CLOSE_DONE))
     {
         Status = STATUS_INVALID_PARAMETER;
         goto Exit;
     }
 
     /* Check if the job has a limit on the number of active processes */
-    if (Job->LimitFlags & JOB_OBJECT_LIMIT_ACTIVE_PROCESS &&
+    if (BooleanFlagOn(Job->LimitFlags, JOB_OBJECT_LIMIT_ACTIVE_PROCESS) &&
         Job->ActiveProcesses >= Job->ActiveProcessLimit)
     {
         /* Check if job limit on active processes has been reached */
@@ -650,7 +650,7 @@ PspDeactivateProcessFromJobLocked(
     ASSERT(ExIsResourceAcquiredExclusiveLite(&Job->JobLock) != 0);
 #endif
 
-    if (Process->JobStatus & JOB_NOT_REALLY_ACTIVE)
+    if (BooleanFlagOn(Process->JobStatus, JOB_NOT_REALLY_ACTIVE))
     {
         return FALSE;
     }
@@ -795,7 +795,7 @@ PspTerminateProcessCallback(
        completed its active job transition */
     ExEnterCriticalRegionAndAcquireResourceExclusive(&Job->JobLock);
 
-    if (Process->JobStatus & JOB_NOT_REALLY_ACTIVE)
+    if (BooleanFlagOn(Process->JobStatus, JOB_NOT_REALLY_ACTIVE))
     {
         goto Exit;
     }
@@ -943,7 +943,7 @@ PspCloseJob(
     ExEnterCriticalRegionAndAcquireResourceExclusive(&Job->JobLock);
 
     /* If the job is set to kill on close, terminate all associated processes */
-    if (Job->LimitFlags & JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE)
+    if (BooleanFlagOn(Job->LimitFlags, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE))
     {
         /* Keep the completion port associated during termination so that
            final job messages can still be delivered */
@@ -1085,8 +1085,7 @@ PspSetJobLimitsBasicOrExtended(
         /* https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-jobobject_basic_limit_information:
            "If MaximumWorkingSetSize is nonzero, MinimumWorkingSetSize cannot be zero"
            "If MinimumWorkingSetSize is nonzero, MaximumWorkingSetSize cannot be zero"
-           Also check that the minimum doesn't exceed the maximum or both aren't
-           equal to zero. */
+           Also check that the minimum doesn't exceed the maximum or both aren't equal to zero. */
         if ((ExtendedLimit->BasicLimitInformation.MaximumWorkingSetSize > 0 &&
                 ExtendedLimit->BasicLimitInformation.MinimumWorkingSetSize <= 0)
             ||
@@ -1264,7 +1263,7 @@ PspAssociateCompletionPortCallback(
 #endif
 
     /* Ensure the process is active and has a valid unique process ID */
-    if (!(Process->JobStatus & JOB_NOT_REALLY_ACTIVE) &&
+    if (!BooleanFlagOn(Process->JobStatus, JOB_NOT_REALLY_ACTIVE) &&
         Process->UniqueProcessId)
     {
         (VOID)PspSendJobMessageLocked(Job,
@@ -1329,7 +1328,7 @@ PspAssociateCompletionPortWithJob(
     ExAcquireResourceExclusiveLite(&Job->JobLock, TRUE);
 
     /* Check if the job already has a completion port or is in a final state */
-    if (Job->CompletionPort || (Job->JobFlags & JOB_OBJECT_CLOSE_DONE) != 0)
+    if (Job->CompletionPort || BooleanFlagOn(Job->JobFlags, JOB_OBJECT_CLOSE_DONE))
     {
         ExReleaseResourceLite(&Job->JobLock);
         ObDereferenceObject(IoCompletion);
@@ -1381,8 +1380,7 @@ PspQueryBasicAccountingInfo(
     PROCESS_VALUES Values;
 
     /* Zero the basic accounting information */
-    RtlZeroMemory(&BasicAndIo->BasicInfo,
-                  sizeof(JOBOBJECT_BASIC_ACCOUNTING_INFORMATION));
+    RtlZeroMemory(&BasicAndIo->BasicInfo, sizeof(BasicAndIo->BasicInfo));
 
     /* Lock the job object */
     ExEnterCriticalRegionAndAcquireResourceShared(&Job->JobLock);
@@ -1491,7 +1489,7 @@ PspQueryLimitInformation(
         KeReleaseGuardedMutexUnsafe(&Job->MemoryLimitsLock);
 
         /* Zero out IoInfo to avoid kernel memory leaks */
-        RtlZeroMemory(&ExtendedLimit->IoInfo, sizeof(IO_COUNTERS));
+        RtlZeroMemory(&ExtendedLimit->IoInfo, sizeof(ExtendedLimit->IoInfo));
     }
 
     /* Release the job lock */
@@ -1528,7 +1526,7 @@ PspQueryJobProcessIdListCallback(
     PPSP_QUERY_JOB_PROCESS_ID_CONTEXT QueryContext = (PPSP_QUERY_JOB_PROCESS_ID_CONTEXT)Context;
 
     /* Skip processes that are not really active */
-    if (Process->JobStatus & JOB_NOT_REALLY_ACTIVE)
+    if (BooleanFlagOn(Process->JobStatus, JOB_NOT_REALLY_ACTIVE))
     {
         /* Continue to the next process */
         return STATUS_SUCCESS;
@@ -1752,7 +1750,7 @@ NtCreateJobObject(
     {
         /* Initialize the job object */
 
-        RtlZeroMemory(Job, sizeof(EJOB));
+        RtlZeroMemory(Job, sizeof(*Job));
 
         InitializeListHead(&Job->JobSetLinks);
         InitializeListHead(&Job->ProcessListHead);

--- a/ntoskrnl/ps/job.c
+++ b/ntoskrnl/ps/job.c
@@ -1,16 +1,15 @@
 /*
- * COPYRIGHT:       See COPYING in the top level directory
- * PROJECT:         ReactOS kernel
- * FILE:            ntoskrnl/ps/job.c
- * PURPOSE:         Core functions for managing Job Objects, a kernel mechanism
- *                  for managing multiple processes as a single unit.
- * PROGRAMMERS:     2004-2012 Alex Ionescu (alex@relsoft.net) (stubs)
- *                  2004-2005 Thomas Weidenmueller <w3seek@reactos.com>
- *                  2015-2016 Samuel Serapión Vega (encoded@reactos.org)
- *                  2017 Mark Jansen (mark.jansen@reactos.org)
- *                  2018 Pierre Schweitzer (pierre@reactos.org)
- *                  2022 Timo Kreuzer (timo.kreuzer@reactos.org)
- *                  2024-2026 Gleb Surikov (glebs.surikovs@gmail.com)
+ * PROJECT:     ReactOS Kernel
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Core functions for managing Job Objects, a kernel mechanism
+ *              for managing multiple processes as a single unit.
+ * COPYRIGHT:   Copyright 2004-2012 Alex Ionescu (alex@relsoft.net) (stubs)
+ *              Copyright 2004-2005 Thomas Weidenmueller <w3seek@reactos.com>
+ *              Copyright 2015-2016 Samuel Serapión Vega <encoded@reactos.org>
+ *              Copyright 2017 Mark Jansen <mark.jansen@reactos.org>
+ *              Copyright 2018 Pierre Schweitzer <pierre@reactos.org>
+ *              Copyright 2022 Timo Kreuzer <timo.kreuzer@reactos.org>
+ *              Copyright 2024-2026 Gleb Surikov <glebs.surikovs@gmail.com>
  */
 
 /* INCLUDES ******************************************************************/
@@ -295,13 +294,12 @@ PspEnumerateProcessesInJob(
 )
 {
     NTSTATUS Status = STATUS_SUCCESS;
-    PEPROCESS Process = NULL;
-
-    /* Get the first process from the job */
-    Process = PspGetNextProcessInJob(Job, NULL);
+    PEPROCESS Process;
 
     /* Iterate through all processes in the job */
-    while (Process != NULL)
+    for (Process = PspGetNextProcessInJob(Job, NULL);
+         Process != NULL;
+         Process = PspGetNextProcessInJob(Job, Process))
     {
         Status = Callback(Process, Context);
         if (!NT_SUCCESS(Status))
@@ -313,9 +311,6 @@ PspEnumerateProcessesInJob(
             ObDereferenceObject(Process);
             break;
         }
-
-        /* Move to the next process */
-        Process = PspGetNextProcessInJob(Job, Process);
     }
 
     return Status;
@@ -356,13 +351,15 @@ PspEnumerateProcessesInJobLocked(
 )
 {
     NTSTATUS Status = STATUS_SUCCESS;
-    PEPROCESS Process = NULL;
+    PEPROCESS Process;
 
     ASSERT(ExIsResourceAcquiredSharedLite(&Job->JobLock) != 0 ||
            ExIsResourceAcquiredExclusiveLite(&Job->JobLock) != 0);
 
     /* Iterate through all processes in the job */
-    while ((Process = PspGetNextProcessInJobLocked(Job, Process)) != NULL)
+    for (Process = PspGetNextProcessInJobLocked(Job, NULL);
+         Process != NULL;
+         Process = PspGetNextProcessInJobLocked(Job, Process))
     {
         Status = Callback(Process, Context);
         if (!NT_SUCCESS(Status))
@@ -404,21 +401,17 @@ PspSendJobMessageLocked(
     _In_ BOOLEAN Quota
 )
 {
-    NTSTATUS Status;
-
     ASSERT(Job->CompletionPort != NULL);
 
     ASSERT(ExIsResourceAcquiredSharedLite(&Job->JobLock) != 0 ||
            ExIsResourceAcquiredExclusiveLite(&Job->JobLock) != 0);
 
-    Status = IoSetIoCompletion(Job->CompletionPort,
-                               Job->CompletionKey,
-                               CompletionValue,
-                               STATUS_SUCCESS,
-                               Message,
-                               Quota);
-
-    return Status;
+    return IoSetIoCompletion(Job->CompletionPort,
+                             Job->CompletionKey,
+                             CompletionValue,
+                             STATUS_SUCCESS,
+                             Message,
+                             Quota);
 }
 
 /*!
@@ -454,7 +447,7 @@ PspAssignProcessToJob(
     /* https://learn.microsoft.com/en-us/windows/win32/api/jobapi2/nf-jobapi2-assignprocesstojobobject:
        "If the job or any of its parent jobs in the job chain is terminating
        when AssignProcessToJob is called, the function fails" */
-    if (FlagOn(Job->JobFlags, JOB_OBJECT_TERMINATING))
+    if (FlagOn(Job->JobFlags, PSP_JOB_TERMINATING))
     {
         Status = STATUS_INVALID_PARAMETER;
         goto Exit;
@@ -463,7 +456,7 @@ PspAssignProcessToJob(
     /* Prevent processes from being added to the job if it is flagged
        for closing and has a limit on process termination on closing */
     if (FlagOn(Job->LimitFlags, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE) &&
-        FlagOn(Job->JobFlags, JOB_OBJECT_CLOSE_DONE))
+        FlagOn(Job->JobFlags, PSP_JOB_CLOSE_DONE))
     {
         Status = STATUS_INVALID_PARAMETER;
         goto Exit;
@@ -565,7 +558,7 @@ PspDeactivateProcessFromJobLocked(
 
     ASSERT(ExIsResourceAcquiredExclusiveLite(&Job->JobLock) != 0);
 
-    if (FlagOn(Process->JobStatus, JOB_NOT_REALLY_ACTIVE))
+    if (FlagOn(Process->JobStatus, PSP_JOB_NOT_REALLY_ACTIVE))
     {
         return FALSE;
     }
@@ -574,7 +567,7 @@ PspDeactivateProcessFromJobLocked(
 
     Job->ActiveProcesses--;
 
-    InterlockedOr((PLONG)&Process->JobStatus, JOB_NOT_REALLY_ACTIVE);
+    InterlockedOr((PLONG)&Process->JobStatus, PSP_JOB_NOT_REALLY_ACTIVE);
 
     return Job->ActiveProcesses == 0;
 }
@@ -692,6 +685,7 @@ PspExitProcessFromJob(
  */
 static
 NTSTATUS
+NTAPI
 PspTerminateProcessCallback(
     _In_ PEPROCESS Process,
     _In_ PVOID Context
@@ -710,7 +704,7 @@ PspTerminateProcessCallback(
        completed its active job transition */
     ExEnterCriticalRegionAndAcquireResourceExclusive(&Job->JobLock);
 
-    if (FlagOn(Process->JobStatus, JOB_NOT_REALLY_ACTIVE))
+    if (FlagOn(Process->JobStatus, PSP_JOB_NOT_REALLY_ACTIVE))
     {
         goto Exit;
     }
@@ -778,10 +772,10 @@ PspTerminateJobObject(
     LONG PreviousFlags;
     PSP_TERMINATE_PROCESS_CONTEXT Context;
 
-    PreviousFlags = InterlockedOr((PLONG)&Job->JobFlags, JOB_OBJECT_TERMINATING);
+    PreviousFlags = InterlockedOr((PLONG)&Job->JobFlags, PSP_JOB_TERMINATING);
 
     /* Termination is idempotent, another caller already owns the traversal */
-    if (PreviousFlags & JOB_OBJECT_TERMINATING)
+    if (PreviousFlags & PSP_JOB_TERMINATING)
     {
         return STATUS_SUCCESS;
     }
@@ -797,7 +791,7 @@ PspTerminateJobObject(
        per-process termination failures are handled locally */
     ASSERT(NT_SUCCESS(Status));
 
-    InterlockedAnd((PLONG)&Job->JobFlags, ~JOB_OBJECT_TERMINATING);
+    InterlockedAnd((PLONG)&Job->JobFlags, ~PSP_JOB_TERMINATING);
 
     return Status;
 }
@@ -845,7 +839,7 @@ PspCloseJob(
     UNREFERENCED_PARAMETER(ProcessHandleCount);
 
     /* Proceed only when the last handle is left */
-    if (SystemHandleCount != 1)
+    if (SystemHandleCount > 1)
     {
         DPRINT1("PspJobClose called with unexpected SystemHandleCount: %lu\n",
                 SystemHandleCount);
@@ -853,7 +847,7 @@ PspCloseJob(
     }
 
     /* Flag the job as closed */
-    InterlockedOr((PLONG)&Job->JobFlags, JOB_OBJECT_CLOSE_DONE);
+    InterlockedOr((PLONG)&Job->JobFlags, PSP_JOB_CLOSE_DONE);
 
     ExEnterCriticalRegionAndAcquireResourceExclusive(&Job->JobLock);
 
@@ -937,7 +931,6 @@ PspDeleteJob(_In_ PVOID ObjectBody)
  * @returns
  *     STATUS_SUCCESS if the job limits are successfully set.
  *     Otherwise, an appropriate NTSTATUS error code.
- *
  */
 static
 NTSTATUS
@@ -953,35 +946,20 @@ PspSetJobLimitsBasicOrExtended(
 
     ASSERT(KeAreAllApcsDisabled());
 
-    const ULONG AllowedBasicFlags = JOB_OBJECT_LIMIT_WORKINGSET |
-        JOB_OBJECT_LIMIT_PROCESS_TIME |
-        JOB_OBJECT_LIMIT_JOB_TIME |
-        JOB_OBJECT_LIMIT_ACTIVE_PROCESS |
-        JOB_OBJECT_LIMIT_AFFINITY |
-        JOB_OBJECT_LIMIT_PRIORITY_CLASS |
-        JOB_OBJECT_LIMIT_PRESERVE_JOB_TIME |
-        JOB_OBJECT_LIMIT_SCHEDULING_CLASS;
-
-    const ULONG AllowedExtendedFlags = AllowedBasicFlags |
-        JOB_OBJECT_LIMIT_BREAKAWAY_OK |
-        JOB_OBJECT_LIMIT_DIE_ON_UNHANDLED_EXCEPTION |
-        JOB_OBJECT_LIMIT_PROCESS_MEMORY |
-        JOB_OBJECT_LIMIT_JOB_MEMORY |
-        JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK |
-        JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
-
-    AllowedFlags = IsExtendedLimit ? AllowedExtendedFlags : AllowedBasicFlags;
+    AllowedFlags = IsExtendedLimit
+                       ? PSP_JOB_EXTENDED_LIMIT_VALID_FLAGS
+                       : PSP_JOB_BASIC_LIMIT_VALID_FLAGS;
 
     /* Validate flags */
     if (ExtendedLimit->BasicLimitInformation.LimitFlags & ~AllowedFlags)
     {
         DPRINT1("Invalid LimitFlags specified: 0x%08X\n",
-                (ExtendedLimit->BasicLimitInformation.LimitFlags & ~AllowedFlags));
+                ExtendedLimit->BasicLimitInformation.LimitFlags & ~AllowedFlags);
         return STATUS_INVALID_PARAMETER;
     }
 
-    if ((ExtendedLimit->BasicLimitInformation.LimitFlags & JOB_OBJECT_LIMIT_PRESERVE_JOB_TIME) &&
-        (ExtendedLimit->BasicLimitInformation.LimitFlags & JOB_OBJECT_LIMIT_JOB_TIME))
+    if (ExtendedLimit->BasicLimitInformation.LimitFlags & JOB_OBJECT_LIMIT_PRESERVE_JOB_TIME &&
+        ExtendedLimit->BasicLimitInformation.LimitFlags & JOB_OBJECT_LIMIT_JOB_TIME)
     {
         DPRINT1("Invalid LimitFlags combination specified "
                 "(PRESERVE_JOB_TIME and JOB_TIME are mutually exclusive)\n");
@@ -1007,8 +985,8 @@ PspSetJobLimitsBasicOrExtended(
             (ExtendedLimit->BasicLimitInformation.MinimumWorkingSetSize > 0 &&
                 ExtendedLimit->BasicLimitInformation.MaximumWorkingSetSize <= 0)
             ||
-            (ExtendedLimit->BasicLimitInformation.MaximumWorkingSetSize <
-                ExtendedLimit->BasicLimitInformation.MinimumWorkingSetSize))
+            ExtendedLimit->BasicLimitInformation.MaximumWorkingSetSize <
+            ExtendedLimit->BasicLimitInformation.MinimumWorkingSetSize)
         {
             Status = STATUS_INVALID_PARAMETER;
             goto ExitFromBasicLimits;
@@ -1042,7 +1020,8 @@ PspSetJobLimitsBasicOrExtended(
            by calling the GetProcessAffinityMask function"
            The lpSystemAffinityMask obtained with GetProcessAffinityMask() corresponds
            to ActiveProcessorsAffinityMask, which in turn corresponds to KeActiveProcessors */
-        if (ExtendedLimit->BasicLimitInformation.Affinity != (ExtendedLimit->BasicLimitInformation.Affinity & KeActiveProcessors))
+        if (ExtendedLimit->BasicLimitInformation.Affinity !=
+            (ExtendedLimit->BasicLimitInformation.Affinity & KeActiveProcessors))
         {
             Status = STATUS_INVALID_PARAMETER;
             goto ExitFromBasicLimits;
@@ -1088,7 +1067,7 @@ PspSetJobLimitsBasicOrExtended(
         /* https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-jobobject_basic_limit_information:
            "To use a scheduling class greater than 5, the calling process must
            enable the SE_INC_BASE_PRIORITY_NAME privilege" */
-        if (ExtendedLimit->BasicLimitInformation.SchedulingClass > 5)
+        if (ExtendedLimit->BasicLimitInformation.SchedulingClass > PSP_JOB_SCHEDULING_CLASS_DEFAULT)
         {
             if (SeCheckPrivilegedObject(SeIncreaseBasePriorityPrivilege,
                                         Job,
@@ -1162,6 +1141,7 @@ ExitFromBasicLimits:
  */
 static
 NTSTATUS
+NTAPI
 PspAssociateCompletionPortCallback(
     _In_ PEPROCESS Process,
     _In_ PVOID Context)
@@ -1176,7 +1156,7 @@ PspAssociateCompletionPortCallback(
     ASSERT(ExIsResourceAcquiredExclusiveLite(&Job->JobLock) != 0);
 
     /* Ensure the process is active and has a valid unique process ID */
-    if (!FlagOn(Process->JobStatus, JOB_NOT_REALLY_ACTIVE) &&
+    if (!FlagOn(Process->JobStatus, PSP_JOB_NOT_REALLY_ACTIVE) &&
         Process->UniqueProcessId)
     {
         (VOID)PspSendJobMessageLocked(Job,
@@ -1241,7 +1221,7 @@ PspAssociateCompletionPortWithJob(
     ExAcquireResourceExclusiveLite(&Job->JobLock, TRUE);
 
     /* Check if the job already has a completion port or is in a final state */
-    if (Job->CompletionPort || FlagOn(Job->JobFlags, JOB_OBJECT_CLOSE_DONE))
+    if (Job->CompletionPort || FlagOn(Job->JobFlags, PSP_JOB_CLOSE_DONE))
     {
         ExReleaseResourceLite(&Job->JobLock);
         ObDereferenceObject(IoCompletion);
@@ -1262,8 +1242,9 @@ PspAssociateCompletionPortWithJob(
 
     ExReleaseResourceLite(&Job->JobLock);
 
-    /* The completion port is already associated. A notification allocation
-       failure can't safely roll back the association. */
+    /* The completion port association is committed at this point. Initial process
+       notifications are best-effort and a failure to queue one must not turn
+       a successful association into a failure. */
     return STATUS_SUCCESS;
 }
 
@@ -1324,7 +1305,7 @@ PspQueryJobBasicAccountingInfo(
         PEPROCESS Process = CONTAINING_RECORD(NextEntry, EPROCESS, JobLinks);
 
         /* Skip folded accounting processes */
-        if (!FlagOn(Process->JobStatus, ACCOUNTING_FOLDED))
+        if (!FlagOn(Process->JobStatus, PSP_JOB_ACCOUNTING_FOLDED))
         {
             KeQueryValuesProcess(&Process->Pcb, &Values);
 
@@ -1431,6 +1412,7 @@ PspQueryJobLimitInformation(
  */
 static
 NTSTATUS
+NTAPI
 PspQueryJobProcessIdListCallback(
     _In_ PEPROCESS Process,
     _Inout_ PVOID Context
@@ -1439,7 +1421,7 @@ PspQueryJobProcessIdListCallback(
     PPSP_QUERY_JOB_PROCESS_ID_CONTEXT QueryContext = (PPSP_QUERY_JOB_PROCESS_ID_CONTEXT)Context;
 
     /* Skip processes that are not really active */
-    if (FlagOn(Process->JobStatus, JOB_NOT_REALLY_ACTIVE))
+    if (FlagOn(Process->JobStatus, PSP_JOB_NOT_REALLY_ACTIVE))
     {
         /* Continue to the next process */
         return STATUS_SUCCESS;
@@ -1688,9 +1670,8 @@ NtCreateJobObject(
     /* Initialize the event object within the job */
     KeInitializeEvent(&Job->Event, NotificationEvent, FALSE);
 
-    /* Set the scheduling class. The default is '5' per Yosifovich, P.,
-       "Windows 10 System Programming, Part 1", p.264, (2020) */
-    Job->SchedulingClass = 5;
+    /* Set the scheduling class */
+    Job->SchedulingClass = PSP_JOB_SCHEDULING_CLASS_DEFAULT;
 
     /* Link the object into the global job list */
     ExAcquireFastMutex(&PsJobListLock);
@@ -1841,7 +1822,7 @@ NtAssignProcessToJobObject(
                                        PreviousMode,
                                        (PVOID *)&Job,
                                        NULL);
-    if (!(NT_SUCCESS(Status)))
+    if (!NT_SUCCESS(Status))
     {
         return Status;
     }
@@ -1854,7 +1835,7 @@ NtAssignProcessToJobObject(
                                        PreviousMode,
                                        (PVOID *)&Process,
                                        NULL);
-    if (!(NT_SUCCESS(Status)))
+    if (!NT_SUCCESS(Status))
     {
         ObDereferenceObject(Job);
         return Status;
@@ -1934,7 +1915,7 @@ NtIsProcessInJob(
                                            PreviousMode,
                                            (PVOID *)&Process,
                                            NULL);
-        if (!(NT_SUCCESS(Status)))
+        if (!NT_SUCCESS(Status))
         {
             return Status;
         }
@@ -2125,11 +2106,11 @@ NtQueryInformationJobObject(
     /* If the request is coming from user mode, probe the user buffer */
     if (PreviousMode != KernelMode)
     {
-        ASSERT(((RequiredAlign) == 1) ||
-               ((RequiredAlign) == 2) ||
-               ((RequiredAlign) == 4) ||
-               ((RequiredAlign) == 8) ||
-               ((RequiredAlign) == 16));
+        ASSERT(RequiredAlign == 1 ||
+               RequiredAlign == 2 ||
+               RequiredAlign == 4 ||
+               RequiredAlign == 8 ||
+               RequiredAlign == 16);
 
         _SEH2_TRY
         {
@@ -2197,7 +2178,7 @@ NtQueryInformationJobObject(
     case JobObjectExtendedLimitInformation:
     {
         Status = PspQueryJobLimitInformation(Job,
-                                             (JobInformationClass == JobObjectExtendedLimitInformation),
+                                             JobInformationClass == JobObjectExtendedLimitInformation,
                                              &ExtendedLimit);
         JobInfoBuffer = &ExtendedLimit;
         break;
@@ -2324,11 +2305,11 @@ NtSetInformationJobObject(
     /* If the request is coming from user mode, probe the user buffer */
     if (PreviousMode != KernelMode)
     {
-        ASSERT(((RequiredAlign) == 1) ||
-               ((RequiredAlign) == 2) ||
-               ((RequiredAlign) == 4) ||
-               ((RequiredAlign) == 8) ||
-               ((RequiredAlign) == 16));
+        ASSERT(RequiredAlign == 1 ||
+               RequiredAlign == 2 ||
+               RequiredAlign == 4 ||
+               RequiredAlign == 8 ||
+               RequiredAlign == 16);
 
         _SEH2_TRY
         {
@@ -2372,7 +2353,13 @@ NtSetInformationJobObject(
         return Status;
     }
 
-    /* And set the information */
+    /* And set the information.
+     *
+     * N.B. Disable APC delivery for the set operation. The handlers below may
+     * acquire locks using unsafe variants which expect the caller to have
+     * already established this state.
+     */
+
     KeEnterGuardedRegionThread(CurrentThread);
 
     switch (JobInformationClass)
@@ -2386,7 +2373,7 @@ NtSetInformationJobObject(
         _SEH2_TRY
         {
             /* If asking for extending limits */
-            if (JobInformationClass == JobObjectExtendedLimitInformation)
+            if (IsExtendedLimit)
             {
                 ExtendedLimit = *(PJOBOBJECT_EXTENDED_LIMIT_INFORMATION)JobInformation;
             }

--- a/ntoskrnl/ps/job.c
+++ b/ntoskrnl/ps/job.c
@@ -822,7 +822,7 @@ PspTerminateJobObject(
  * @param[in] GrantedAccess
  *     Unused.
  *
- * @param[in] HandleCount
+ * @param[in] ProcessHandleCount
  *     Unused.
  *
  * @param[in] SystemHandleCount
@@ -838,8 +838,8 @@ PspCloseJob(
     _In_ PEPROCESS Process,
     _In_ PVOID ObjectBody,
     _In_ ACCESS_MASK GrantedAccess,
-    _In_ ULONG HandleCount,
-    _In_ ULONG SystemHandleCount
+    _In_ ULONG_PTR ProcessHandleCount,
+    _In_ ULONG_PTR SystemHandleCount
 )
 {
     NTSTATUS Status;
@@ -850,7 +850,7 @@ PspCloseJob(
 
     UNREFERENCED_PARAMETER(Process);
     UNREFERENCED_PARAMETER(GrantedAccess);
-    UNREFERENCED_PARAMETER(HandleCount);
+    UNREFERENCED_PARAMETER(ProcessHandleCount);
 
     /* Proceed only when the last handle is left */
     if (SystemHandleCount != 1)

--- a/ntoskrnl/ps/job.c
+++ b/ntoskrnl/ps/job.c
@@ -414,10 +414,8 @@ PspSendJobMessageLocked(
 
     ASSERT(Job->CompletionPort != NULL);
 
-#if DBG
     ASSERT(ExIsResourceAcquiredSharedLite(&Job->JobLock) != 0 ||
            ExIsResourceAcquiredExclusiveLite(&Job->JobLock) != 0);
-#endif
 
     Status = IoSetIoCompletion(Job->CompletionPort,
                                Job->CompletionKey,
@@ -573,9 +571,7 @@ PspDeactivateProcessFromJobLocked(
 {
     ASSERT(Process->Job == Job);
 
-#if DBG
     ASSERT(ExIsResourceAcquiredExclusiveLite(&Job->JobLock) != 0);
-#endif
 
     if (FlagOn(Process->JobStatus, JOB_NOT_REALLY_ACTIVE))
     {
@@ -1185,9 +1181,7 @@ PspAssociateCompletionPortCallback(
     ASSERT(Process->Job == Job);
     ASSERT(Job->CompletionPort != NULL);
 
-#if DBG
     ASSERT(ExIsResourceAcquiredExclusiveLite(&Job->JobLock) != 0);
-#endif
 
     /* Ensure the process is active and has a valid unique process ID */
     if (!FlagOn(Process->JobStatus, JOB_NOT_REALLY_ACTIVE) &&
@@ -1657,7 +1651,7 @@ NtCreateJobObject(
         }
         _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
         {
-            _SEH2_YIELD(return _SEH2_GetExceptionCode());
+            return _SEH2_GetExceptionCode();
         }
         _SEH2_END;
     }
@@ -1673,61 +1667,64 @@ NtCreateJobObject(
                             0,
                             (PVOID *)&Job);
 
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("Failed to create job object, Status 0x%08lx\n", Status);
+        return Status;
+    }
+
+    /* Initialize the job object */
+
+    RtlZeroMemory(Job, sizeof(*Job));
+
+    InitializeListHead(&Job->JobSetLinks);
+    InitializeListHead(&Job->ProcessListHead);
+
+    /* Make sure that early destruction doesn't attempt to remove
+       the object from the list before it even gets added */
+    InitializeListHead(&Job->JobLinks);
+
+    /* Inherit the session ID from the caller */
+    Job->SessionId = PsGetProcessSessionId(CurrentProcess);
+
+    /* Initialize the job limits lock */
+    KeInitializeGuardedMutex(&Job->MemoryLimitsLock);
+
+    /* Initialize the job lock */
+    (VOID)ExInitializeResource(&Job->JobLock);
+
+    /* Initialize the event object within the job */
+    KeInitializeEvent(&Job->Event, NotificationEvent, FALSE);
+
+    /* Set the scheduling class. The default is '5' per Yosifovich, P.,
+       "Windows 10 System Programming, Part 1", p.264, (2020) */
+    Job->SchedulingClass = 5;
+
+    /* Link the object into the global job list */
+    ExAcquireFastMutex(&PsJobListLock);
+    InsertTailList(&PsJobListHead, &Job->JobLinks);
+    ExReleaseFastMutex(&PsJobListLock);
+
+    /* Insert the job object into the object table  */
+    Status = ObInsertObject(Job,
+                            NULL,
+                            DesiredAccess,
+                            0,
+                            NULL,
+                            &Handle);
+
     if (NT_SUCCESS(Status))
     {
-        /* Initialize the job object */
-
-        RtlZeroMemory(Job, sizeof(*Job));
-
-        InitializeListHead(&Job->JobSetLinks);
-        InitializeListHead(&Job->ProcessListHead);
-
-        /* Make sure that early destruction doesn't attempt to remove
-           the object from the list before it even gets added */
-        InitializeListHead(&Job->JobLinks);
-
-        /* Inherit the session ID from the caller */
-        Job->SessionId = PsGetProcessSessionId(CurrentProcess);
-
-        /* Initialize the job limits lock */
-        KeInitializeGuardedMutex(&Job->MemoryLimitsLock);
-
-        /* Initialize the job lock */
-        (VOID)ExInitializeResource(&Job->JobLock);
-
-        /* Initialize the event object within the job */
-        KeInitializeEvent(&Job->Event, NotificationEvent, FALSE);
-
-        /* Set the scheduling class. The default is '5' per Yosifovich, P.,
-           "Windows 10 System Programming, Part 1", p.264, (2020) */
-        Job->SchedulingClass = 5;
-
-        /* Link the object into the global job list */
-        ExAcquireFastMutex(&PsJobListLock);
-        InsertTailList(&PsJobListHead, &Job->JobLinks);
-        ExReleaseFastMutex(&PsJobListLock);
-
-        /* Insert the job object into the object table  */
-        Status = ObInsertObject(Job,
-                                NULL,
-                                DesiredAccess,
-                                0,
-                                NULL,
-                                &Handle);
-
-        if (NT_SUCCESS(Status))
+        /* Pass the handle back to the caller */
+        _SEH2_TRY
         {
-            /* Pass the handle back to the caller */
-            _SEH2_TRY
-            {
-                *JobHandle = Handle;
-            }
-            _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
-            {
-                Status = _SEH2_GetExceptionCode();
-            }
-            _SEH2_END;
+            *JobHandle = Handle;
         }
+        _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+        {
+            Status = _SEH2_GetExceptionCode();
+        }
+        _SEH2_END;
     }
 
     return Status;
@@ -2208,8 +2205,8 @@ NtQueryInformationJobObject(
     case JobObjectExtendedLimitInformation:
     {
         Status = PspQueryJobLimitInformation(Job,
-                                          (JobInformationClass == JobObjectExtendedLimitInformation),
-                                          &ExtendedLimit);
+                                             (JobInformationClass == JobObjectExtendedLimitInformation),
+                                             &ExtendedLimit);
         JobInfoBuffer = &ExtendedLimit;
         break;
     }

--- a/ntoskrnl/ps/job.c
+++ b/ntoskrnl/ps/job.c
@@ -10,7 +10,7 @@
  *                  2017 Mark Jansen (mark.jansen@reactos.org)
  *                  2018 Pierre Schweitzer (pierre@reactos.org)
  *                  2022 Timo Kreuzer (timo.kreuzer@reactos.org)
- *                  2024 Gleb Surikov (glebs.surikovs@gmail.com)
+ *                  2024-2026 Gleb Surikov (glebs.surikovs@gmail.com)
  */
 
 /* INCLUDES ******************************************************************/
@@ -78,13 +78,34 @@ ULONG PspJobInfoAlign[] =
     sizeof(ULONG),
     sizeof(ULONG),
     sizeof(ULONG),
-    sizeof(ULONG),
+    sizeof(HANDLE),
     sizeof(ULONG),
     sizeof(ULONG),
     sizeof(ULONG)
 };
 
 /* DATA TYPE DEFINITIONS *****************************************************/
+
+/*!
+ * Iterator structure used to enumerate processes directly assigned to a job
+ * while the job lock is held.
+ *
+ * @param[in] Job
+ *     A pointer to the job object being enumerated.
+ *
+ * @param[in] NextEntry
+ *     A pointer to the next process list entry to be returned.
+ *
+ * @remarks
+ *     The iterator does not acquire or release the job lock and does not
+ *     reference returned process objects. The caller must hold the job lock
+ *     for the entire lifetime of the iterator.
+ */
+typedef struct PSP_JOB_ITERATOR
+{
+    PEJOB Job;
+    PLIST_ENTRY NextEntry;
+} PSP_JOB_ITERATOR, *PPSP_JOB_ITERATOR;
 
 /*!
  * Context structure used to pass the job object and exit status to
@@ -96,37 +117,30 @@ ULONG PspJobInfoAlign[] =
  * @param[in] ExitStatus
  *     The exit status to be used for all terminated processes.
  */
-typedef struct TERMINATE_PROCESS_CONTEXT
+typedef struct PSP_TERMINATE_PROCESS_CONTEXT
 {
     PEJOB Job;
     NTSTATUS ExitStatus;
-} TERMINATE_PROCESS_CONTEXT, *PTERMINATE_PROCESS_CONTEXT;
+} PSP_TERMINATE_PROCESS_CONTEXT, *PPSP_TERMINATE_PROCESS_CONTEXT;
 
 /*!
  * Context structure used to collect process IDs for a job object.
  *
- * @param[in, out] ProcIdList
- *     A pointer to the structure that holds the process IDs and the count of
- *     assigned processes.
+ * @param[in, out] ProcessIdList
+ *     A pointer to the output process identifier list.
  *
- * @param[in, out] ListLength
- *     The remaining length of the process ID list buffer, adjusted as process
- *     IDs are added.
+ * @param[in, out] NextProcessId
+ *     A pointer to the next output array entry.
  *
- * @param[in, out] IdListArray
- *     A pointer to the position in the process ID array where the next process
- *     ID will be added.
- *
- * @param[in, out] Status
- *     Holds the status of the process ID collection operation.
+ * @param[in, out] RemainingLength
+ *     The number of bytes remaining in the output array.
  */
-typedef struct QUERY_JOB_PROCESS_ID_CONTEXT
+typedef struct PSP_QUERY_JOB_PROCESS_ID_CONTEXT
 {
-    PJOBOBJECT_BASIC_PROCESS_ID_LIST ProcIdList;
-    ULONG ListLength;
-    ULONG_PTR *IdListArray;
-    NTSTATUS Status;
-} QUERY_JOB_PROCESS_ID_CONTEXT, *PQUERY_JOB_PROCESS_ID_CONTEXT;
+    PJOBOBJECT_BASIC_PROCESS_ID_LIST ProcessIdList;
+    PULONG_PTR NextProcessId;
+    SIZE_T RemainingLength;
+} PSP_QUERY_JOB_PROCESS_ID_CONTEXT, *PPSP_QUERY_JOB_PROCESS_ID_CONTEXT;
 
 /* FUNCTIONS *****************************************************************/
 
@@ -140,18 +154,140 @@ PspInitializeJobStructures(VOID)
 }
 
 /*!
- * Advances the job enumerator to the next process in the job's process list.
+ * Initializes an iterator for the processes directly assigned to a job.
  *
- * @param Job
- *     Pointer to the job object containing the process list.
+ * @param[in] Job
+ *     A pointer to the job object whose process list will be enumerated.
  *
- * @param Process
- *     Pointer to the current process obtained from a previous call to
- *     PspAdvanceJobEnumerator.
+ * @param[in, optional] PreviousProcess
+ *     A pointer to the process after which enumeration should begin, or NULL
+ *     to begin with the first process in the job.
+ *
+ * @param[out] Iterator
+ *     A pointer to the iterator to initialize.
+ *
+ * @remarks
+ *     The caller must hold tje job lock shared or exclusive.
+ *
+ *     PreviousProcess is borrowed and is not referenced or dereferenced by
+ *     this function.
+ */
+static
+VOID
+PspInitializeJobIteratorLocked(
+    _In_ PEJOB Job,
+    _In_opt_ PEPROCESS PreviousProcess,
+    _Out_ PPSP_JOB_ITERATOR Iterator
+)
+{
+    ASSERT(Iterator != NULL);
+
+#if DBG
+    ASSERT(ExIsResourceAcquiredSharedLite(&Job->JobLock) != 0 ||
+           ExIsResourceAcquiredExclusiveLite(&Job->JobLock) != 0);
+#endif
+
+    Iterator->Job = Job;
+
+    if (PreviousProcess != NULL)
+    {
+        ASSERT(PreviousProcess->Job == Job);
+        ASSERT(!IsListEmpty(&PreviousProcess->JobLinks));
+
+        Iterator->NextEntry = PreviousProcess->JobLinks.Flink;
+    }
+    else
+    {
+        Iterator->NextEntry = Job->ProcessListHead.Flink;
+    }
+}
+
+/*!
+ * Advances a job process iterator.
+ *
+ * @param[in, out] Iterator
+ *     A pointer to an initialized job process iterator.
  *
  * @return
- *     Pointer to the next valid process, or NULL if no more processes are
- *     available.
+ *     A borrowed pointer to the next directly assigned process, or NULL if
+ *     enumeration has completed.
+ *
+ * @remarks
+ *     The caller must continue holding Iterator->Job->JobLock.
+ *
+ *     The returned process is borrowed and may already be entering object
+ *     deletion. The caller may access only fields that remain valid while the
+ *     process is linked to the job.
+ */
+static
+PEPROCESS
+PspAdvanceJobIteratorLocked(
+    _Inout_ PPSP_JOB_ITERATOR Iterator
+)
+{
+    PEJOB Job;
+    PLIST_ENTRY Entry;
+    PEPROCESS Process;
+
+    ASSERT(Iterator->Job != NULL);
+
+    Job = Iterator->Job;
+
+#if DBG
+    ASSERT(ExIsResourceAcquiredSharedLite(&Job->JobLock) != 0 ||
+           ExIsResourceAcquiredExclusiveLite(&Job->JobLock) != 0);
+#endif
+
+    ASSERT(Iterator->NextEntry != NULL);
+
+    Entry = Iterator->NextEntry;
+
+    if (Entry == &Job->ProcessListHead)
+    {
+        return NULL;
+    }
+
+#if DBG
+    ASSERT(Entry->Flink != NULL);
+    ASSERT(Entry->Blink != NULL);
+    ASSERT(Entry->Flink->Blink == Entry);
+    ASSERT(Entry->Blink->Flink == Entry);
+#endif
+
+    /* Advance the cursor before returning the process. This keeps iterator
+       state independent from modifications to non-list process fields made by
+       the callback. */
+    Iterator->NextEntry = Entry->Flink;
+
+    Process = CONTAINING_RECORD(Entry, EPROCESS, JobLinks);
+
+    ASSERT(Process->Job == Job);
+
+    return Process;
+}
+
+/*!
+ * Advances the job enumerator to the next process in the job's process list.
+ *
+ * @param[in] Job
+ *     A pointer to the job object whose directly assigned processes are being
+ *     enumerated.
+ *
+ * @param[in, optional] Process
+ *     A referenced process returned by a previous call to this function, or
+ *     NULL to start the enumeration. When non-NULL, the reference is consumed
+ *     by this function regardless of whether another process is returned.
+ *
+ * @return
+ *     A referenced pointer to the next process, or NULL if no more processes
+ *     are available.
+ *
+ * @remarks
+ *     The returned process reference must either be passed to a subsequent
+ *     call to this function or released with ObDereferenceObject().
+ *
+ *     This implementation relies on job membership remaining fixed
+ *     until process object deletion.
  */
 static
 PEPROCESS
@@ -160,46 +296,35 @@ PspAdvanceJobEnumerator(
     _In_opt_ PEPROCESS Process
 )
 {
-    PLIST_ENTRY Entry;
-    PEPROCESS Next;
+    PSP_JOB_ITERATOR Iterator;
+    PEPROCESS Next = NULL;
+    PEPROCESS Candidate;
 
-    ExEnterCriticalRegionAndAcquireResourceExclusive(&Job->JobLock);
-
-    /* If Process is NULL, the enumeration starts from the first process.
-       Otherwise, continue from the next process */
-    if (Process)
+    if (Process != NULL)
     {
-        Entry = Process->JobLinks.Flink;
-    }
-    else
-    {
-        Entry = Job->ProcessListHead.Flink;
+        ASSERT(Process->Job == Job);
+        ASSERT(!IsListEmpty(&Process->JobLinks));
     }
 
-    /* Iterate through the job's process list */
-    while (Entry != &Job->ProcessListHead)
-    {
-        Next = CONTAINING_RECORD(Entry, EPROCESS, JobLinks);
+    ExEnterCriticalRegionAndAcquireResourceShared(&Job->JobLock);
 
-        /* We use the safe variant because it returns FALSE if
-           the object is being deleted */
-        if (ObReferenceObjectSafe(Next))
+    PspInitializeJobIteratorLocked(Job, Process, &Iterator);
+
+    while ((Candidate = PspAdvanceJobIteratorLocked(&Iterator)) != NULL)
+    {
+        /* Skip process objects whose deletion has already begun */
+        if (ObReferenceObjectSafe(Candidate))
         {
-            goto Found;
+            Next = Candidate;
+            break;
         }
-
-        /* Move to the next entry in the lsit */
-        Entry = Entry->Flink;
     }
-
-    /* Reached the end */
-    Next = NULL;
-
-Found:
 
     ExReleaseResourceAndLeaveCriticalRegion(&Job->JobLock);
 
-    if (Process)
+    /* This must occur after releasing the job lock: the dereference can invoke the
+       process delete procedure, which removes JobLinks under the same lock */
+    if (Process != NULL)
     {
         ObDereferenceObject(Process);
     }
@@ -215,36 +340,31 @@ Found:
  *     A pointer to the job object whose processes are to be enumerated.
  *
  * @param[in] Callback
- *     A pointer to the PJOB_ENUMERATOR_CALLBACK callback function to be
- *     called for each process.
+ *     A pointer to the callback invoked for each referenced process.
  *
  * @param[in, optional] Context
- *     An optional pointer to a context to be passed to the callback function.
- *
- * @param[in] BreakOnCallbackFailure
- *     A boolean that, if TRUE, indicates that enumeration should stop early if
- *     the callback function returns an error. If FALSE, the enumeration
- *     continues even if the callback function fails.
+ *     An optional context pointer passed to the callback.
  *
  * @returns
- *     STATUS_SUCCESS if the enumeration completed successfully.
- *     An appropriate NTSTATUS error code otherwise.
+ *     STATUS_SUCCESS if every callback succeeds. Otherwise, the first
+ *     unsuccessful callback status is returned.
  *
  * @remarks
- *     If BreakOnCallbackFailure is TRUE and not all callbacks returned success,
- *     the function may still return STATUS_SUCCESS.
+ *     Enumeration stops when a callback returns an unsuccessful status.
+ *
+ *     The callback is invoked _without_ the job lock held. It borrows the
+ *     enumerator's process reference and must acquire an additional reference
+ *     if it retains the process pointer.
  */
 NTSTATUS
 NTAPI
 PspEnumerateProcessesInJob(
     _In_ PEJOB Job,
     _In_ PJOB_ENUMERATOR_CALLBACK Callback,
-    _In_opt_ PVOID Context,
-    _In_ BOOLEAN BreakOnCallbackFailure
+    _In_opt_ PVOID Context
 )
 {
     NTSTATUS Status = STATUS_SUCCESS;
-    BOOLEAN AnyCallbackFailed = FALSE;
     PEPROCESS Process;
 
     /* Get the first process from the job */
@@ -255,34 +375,138 @@ PspEnumerateProcessesInJob(
     {
         /* Call the provided callback */
         Status = Callback(Process, Context);
+
         if (!NT_SUCCESS(Status))
         {
-            AnyCallbackFailed = TRUE;
-            if (BreakOnCallbackFailure)
-            {
-                ObDereferenceObject(Process);
-                break;
-            }
+            /* On successful iteration, PspAdvanceJobEnumerator consumes this
+               reference. On failure, it must be released explicitly. */
+            ObDereferenceObject(Process);
+            break;
         }
 
         /* Move to the next process */
         Process = PspAdvanceJobEnumerator(Job, Process);
     }
 
-    if (NT_SUCCESS(Status) && AnyCallbackFailed)
+    return Status;
+}
+
+/*!
+ * Enumerates all directly assigned processes while the caller holds the job
+ * lock and invokes a callback for each process.
+ *
+ * @param[in] Job
+ *     A pointer to the job object whose processes are to be enumerated.
+ *
+ * @param[in] Callback
+ *     A pointer to the callback invoked for each process.
+ *
+ * @param[in, optional] Context
+ *     An optional context pointer passed to the callback.
+ *
+ * @return
+ *     STATUS_SUCCESS if every callback succeeds. Otherwise, the first
+ *     unsuccessful callback status is returned.
+ *
+ * @remarks
+ *     Enumeration stops when a callback returns an unsuccessful status.
+ *
+ *     The caller must hold the job lock shared or exclusive for the complete
+ *     call.
+ *
+ *     The callback receives a borrowed process pointer. It must not release
+ *     the job lock, recursively acquire the job lock, modify direct job
+ *     membership, dereference the process object, or retain the process
+ *     pointer after returning.
+ */
+static
+NTSTATUS
+PspEnumerateProcessesInJobLocked(
+    _In_ PEJOB Job,
+    _In_ PJOB_ENUMERATOR_CALLBACK Callback,
+    _In_opt_ PVOID Context
+)
+{
+    PSP_JOB_ITERATOR Iterator;
+    NTSTATUS Status = STATUS_SUCCESS;
+    PEPROCESS Process;
+
+#if DBG
+    ASSERT(ExIsResourceAcquiredSharedLite(&Job->JobLock) != 0 ||
+           ExIsResourceAcquiredExclusiveLite(&Job->JobLock) != 0);
+#endif
+
+    PspInitializeJobIteratorLocked(Job, NULL, &Iterator);
+
+    /* Iterate through all processes in the job */
+    while ((Process = PspAdvanceJobIteratorLocked(&Iterator)) != NULL)
     {
-        DPRINT1("PspEnumerateProcessesInJob(Job: %p, Callback: %p, Context: %p,"
-                " BreakOnCallbackFailure: %u) - Partial success report, not all"
-                " callbacks returned success\n",
-                Job, Callback, Context, BreakOnCallbackFailure);
+        /* Call the provided callback */
+        Status = Callback(Process, Context);
+
+        if (!NT_SUCCESS(Status))
+        {
+            break;
+        }
     }
 
     return Status;
 }
 
 /*!
- * Assigns a process to a job object.
+ * Queues a message to a job's completion port.
  *
+ * @param[in] Job
+ *     A pointer to the job receiving the notification.
+ *
+ * @param[in] Message
+ *     The job notification message (JOB_OBJECT_MSG_*).
+ *
+ * @param[in, optional] CompletionValue
+ *     The message specific completion value.
+ *
+ * @param[in] Quota
+ *     Specifies whether the completion packet is charged as quota.
+ *
+ * @return
+ *     STATUS_SUCCESS if the message was queued successfully.
+ *     Otherwise, an appropriate NTSTATUS error code.
+ *
+ * @remarks
+ *     The caller must hold the job lock shared or exclusive.
+ *     The caller must ensure that the job has an associated completion port.
+ */
+NTSTATUS
+NTAPI
+PspSendJobMessageLocked(
+    _In_ PEJOB Job,
+    _In_ ULONG Message,
+    _In_opt_ PVOID CompletionValue,
+    _In_ BOOLEAN Quota
+)
+{
+    NTSTATUS Status;
+
+    ASSERT(Job->CompletionPort != NULL);
+
+#if DBG
+    ASSERT(ExIsResourceAcquiredSharedLite(&Job->JobLock) != 0 ||
+           ExIsResourceAcquiredExclusiveLite(&Job->JobLock) != 0);
+#endif
+
+    Status = IoSetIoCompletion(Job->CompletionPort,
+                               Job->CompletionKey,
+                               CompletionValue,
+                               STATUS_SUCCESS,
+                               Message,
+                               Quota);
+
+    return Status;
+}
+
+/*!
+ * Assigns a process to a job object.
+ 
  * @param[in] Process
  *     Pointer to the process to be assigned to the job.
  *
@@ -301,31 +525,14 @@ PspAssignProcessToJob(
 )
 {
     NTSTATUS Status = STATUS_SUCCESS;
+    PVOID PreviousJob;
 
-    DPRINT1("PspAssignProcessToJob(Process: %p, Job: %p)\n", Process, Job);
+    if (!ExAcquireRundownProtection(&Process->RundownProtect))
+    {
+        return STATUS_PROCESS_IS_TERMINATING;
+    }
 
     ExEnterCriticalRegionAndAcquireResourceExclusive(&Job->JobLock);
-
-    /* Check if the job has a limit on the number of active processes */
-    if (Job->LimitFlags & JOB_OBJECT_LIMIT_ACTIVE_PROCESS &&
-        Job->ActiveProcesses >= Job->ActiveProcessLimit)
-    {
-        /* Check if job limit on active processes has been reached */
-        if (Job->CompletionPort)
-        {
-            /* If the job has a completion port, notify the job that the
-               limit on the number of active processes has been exceeded */
-            IoSetIoCompletion(Job->CompletionPort,
-                              Job->CompletionKey,
-                              NULL,
-                              STATUS_SUCCESS,
-                              JOB_OBJECT_MSG_ACTIVE_PROCESS_LIMIT,
-                              TRUE);
-        }
-
-        Status = STATUS_QUOTA_EXCEEDED;
-        goto Exit;
-    }
 
     /* https://learn.microsoft.com/en-us/windows/win32/api/jobapi2/nf-jobapi2-assignprocesstojobobject:
        "If the job or any of its parent jobs in the job chain is terminating
@@ -345,11 +552,51 @@ PspAssignProcessToJob(
         goto Exit;
     }
 
-    /* Assign the process to the job object by inserting into
-       the job's process list */
+    /* Check if the job has a limit on the number of active processes */
+    if (Job->LimitFlags & JOB_OBJECT_LIMIT_ACTIVE_PROCESS &&
+        Job->ActiveProcesses >= Job->ActiveProcessLimit)
+    {
+        /* Check if job limit on active processes has been reached */
+        if (Job->CompletionPort)
+        {
+            /* If the job has a completion port, notify the job that the
+               limit on the number of active processes has been exceeded */
+            (VOID)PspSendJobMessageLocked(Job,
+                                          JOB_OBJECT_MSG_ACTIVE_PROCESS_LIMIT,
+                                          NULL,
+                                          TRUE);
+        }
+
+        Status = STATUS_QUOTA_EXCEEDED;
+        goto Exit;
+    }
+
+    /* Acquire the reference owned by the process for as long as
+       Process->Job points to Job */
+    ObReferenceObject(Job);
+
+    /* JobLock protects the target job, but another caller may simultaneously
+       hold a different job's lock while trying to assign the same process */
+    PreviousJob = InterlockedCompareExchangePointer((PVOID)&Process->Job,
+                                                    Job,
+                                                    NULL);
+    if (PreviousJob)
+    {
+        ObDereferenceObject(Job);
+        Status = STATUS_ACCESS_DENIED;
+        goto Exit;
+    }
+
+    /* Assignment is committed at this point. No subsequent structural
+       operation may fail.
+
+       Readers of Job->ProcessListHead are blocked by JobLock until the list
+       and counters are complete. */
+
+    ASSERT(IsListEmpty(&Process->JobLinks));
+
     InsertTailList(&Job->ProcessListHead, &Process->JobLinks);
 
-    /* Increment the job's process counters */
     Job->TotalProcesses++;
     Job->ActiveProcesses++;
 
@@ -357,17 +604,17 @@ PspAssignProcessToJob(
     {
         /* If the job has a completion port and the process has a unique ID,
            notify the job of the new process */
-        Status = IoSetIoCompletion(Job->CompletionPort,
-                                   Job->CompletionKey,
-                                   Process->UniqueProcessId,
-                                   STATUS_SUCCESS,
-                                   JOB_OBJECT_MSG_NEW_PROCESS,
-                                   FALSE);
+        (VOID)PspSendJobMessageLocked(Job,
+                                      JOB_OBJECT_MSG_NEW_PROCESS,
+                                      Process->UniqueProcessId,
+                                      FALSE);
     }
 
 Exit:
 
     ExReleaseResourceAndLeaveCriticalRegion(&Job->JobLock);
+
+    ExReleaseRundownProtection(&Process->RundownProtect);
 
     /* TODO: Ensure that job limits are respected */
 
@@ -375,55 +622,93 @@ Exit:
 }
 
 /*!
- * Removes a process from the specified job object.
- *
- * @param[in] Process
- *     A pointer to the process to be removed from the job.
+ * Marks a process inactive in its assigned job.
  *
  * @param[in] Job
- *     A pointer to the job object from which the process is to be removed.
+ *     A pointer to the process's assigned job.
  *
- * @remark This function is called from PspDeleteProcess() as the process
- *         is destroyed.
+ * @param[in] Process
+ *     A pointer to the process being marked inactive.
+ *
+ * @return
+ *     TRUE if this call performed the active-to-inactive transition and
+ *     reduced the job's active process count to zero; otherwise, FALSE.
+ *
+ * @remarks
+ *     The caller must hold the job lock exclusively.
+ */
+static 
+BOOLEAN
+PspDeactivateProcessFromJobLocked(
+    _In_ PEJOB Job,
+    _In_ PEPROCESS Process
+)
+{
+    ASSERT(Process->Job == Job);
+
+#if DBG
+    ASSERT(ExIsResourceAcquiredExclusiveLite(&Job->JobLock) != 0);
+#endif
+
+    if (Process->JobStatus & JOB_NOT_REALLY_ACTIVE)
+    {
+        return FALSE;
+    }
+
+    ASSERT(Job->ActiveProcesses != 0);
+
+    Job->ActiveProcesses--;
+
+    InterlockedOr((PLONG)&Process->JobStatus, JOB_NOT_REALLY_ACTIVE);
+
+    return Job->ActiveProcesses == 0;
+}
+
+/*!
+ * Removes a process from its assigned job.
+ *
+ * @param[in] Process
+ *     A pointer to the process being removed from its assigned job.
+ *
+ * @remarks
+ *     This function is called from PspDeleteProcess() during process object
+ *     deletion. The process must still be linked to its assigned job.
  */
 VOID
 NTAPI
 PspRemoveProcessFromJob(
-    _In_ PEPROCESS Process,
-    _In_ PEJOB Job
+    _In_ PEPROCESS Process
 )
 {
-    DPRINT1("PspRemoveProcessFromJob(Process: %p, Job: %p)\n", Process, Job);
+    PEJOB Job;
+    BOOLEAN ActiveProcessZero;
+
+    Job = Process->Job;
+    ASSERT(Job != NULL);
 
     ExEnterCriticalRegionAndAcquireResourceExclusive(&Job->JobLock);
 
+    ASSERT(Process->Job == Job);
+    ASSERT(Process->JobLinks.Flink != NULL);
+    ASSERT(Process->JobLinks.Blink != NULL);
+    ASSERT(!IsListEmpty(&Process->JobLinks));
+
     /* Remove the process from the job's process list */
     RemoveEntryList(&Process->JobLinks);
+    InitializeListHead(&Process->JobLinks);
 
     /* Decrement the job's active process count if it is still active */
-    if (!(Process->JobStatus & JOB_NOT_REALLY_ACTIVE))
-    {
-        /* Assert that the job's active process count does not underflow */
-        ASSERT((Job->ActiveProcesses - 1) < Job->ActiveProcesses);
-
-        Job->ActiveProcesses--;
-
-        /* Flag this process as inactive to prevent the number of active
-           processes from repeatedly decrementing */
-        InterlockedOr((PLONG)&Process->JobStatus, JOB_NOT_REALLY_ACTIVE);
-    }
+    ActiveProcessZero = PspDeactivateProcessFromJobLocked(Job, Process);
 
     /* TODO: Ensure that job limits are respected */
 
     /* If no active processes remain, notify the job completion port */
-    if (Job->ActiveProcesses == 0 && Job->CompletionPort)
+    if (ActiveProcessZero && Job->CompletionPort)
     {
-        IoSetIoCompletion(Job->CompletionPort,
-                          Job->CompletionKey,
-                          NULL,
-                          STATUS_SUCCESS,
-                          JOB_OBJECT_MSG_ACTIVE_PROCESS_ZERO,
-                          FALSE);
+        (VOID)PspSendJobMessageLocked(Job,
+                                      JOB_OBJECT_MSG_ACTIVE_PROCESS_ZERO,
+                                      NULL,
+                                      FALSE);
     }
 
     ExReleaseResourceAndLeaveCriticalRegion(&Job->JobLock);
@@ -432,59 +717,44 @@ PspRemoveProcessFromJob(
 /*!
  * Handles the exit of a process from the specified job object.
  *
- * @param[in] Job
- *     A pointer to the job object from which the process is exiting.
- *
  * @param[in] Process
  *     A pointer to the process that is exiting the job.
  *
- * @remark This function is called from PspExitThread() as the last thread
- *         exits.
+ * @remark
+ *     This function is called from PspExitThread() when the last thread exits.
+ *     The process must be assigned to a job.
  */
 VOID
 NTAPI
 PspExitProcessFromJob(
-    _In_ PEJOB Job,
     _In_ PEPROCESS Process
 )
 {
-    DPRINT1("PspExitProcessFromJob(Job: %p, Process: %p)\n", Job, Process);
+    PEJOB Job;
+    BOOLEAN ActiveProcessZero;
 
-    /* Make sure we are not interrupted */
+    Job = Process->Job;
+    ASSERT(Job != NULL);
+
     ExEnterCriticalRegionAndAcquireResourceExclusive(&Job->JobLock);
 
-    /* Check if the process is part of the specified job */
-    if (Process->Job == Job)
+    /* Job membership is immutable in the current implementation */
+    ASSERT(Process->Job == Job);
+
+    /* Decrement the job's active process count if the process is still active */
+    ActiveProcessZero = PspDeactivateProcessFromJobLocked(Job, Process);
+
+    /* If no active processes remain, notify the job completion port */
+    if (ActiveProcessZero && Job->CompletionPort)
     {
-        /* Decrement the job's active process count if the process is still
-           active */
-        if (!(Process->JobStatus & JOB_NOT_REALLY_ACTIVE))
-        {
-            /* Assert that the job's active process count does not underflow */
-            ASSERT((Job->ActiveProcesses - 1) < Job->ActiveProcesses);
-
-            Job->ActiveProcesses--;
-
-            /* Flag this process as inactive to prevent the number of active
-               processes from repeatedly decrementing */
-            InterlockedOr((PLONG)&Process->JobStatus, JOB_NOT_REALLY_ACTIVE);
-        }
-
-        /* If no active processes remain, notify the job completion port */
-        if (Job->ActiveProcesses == 0 && Job->CompletionPort)
-        {
-            IoSetIoCompletion(Job->CompletionPort,
-                              Job->CompletionKey,
-                              NULL,
-                              STATUS_SUCCESS,
-                              JOB_OBJECT_MSG_ACTIVE_PROCESS_ZERO,
-                              FALSE);
-        }
+        (VOID)PspSendJobMessageLocked(Job,
+                                      JOB_OBJECT_MSG_ACTIVE_PROCESS_ZERO,
+                                      NULL,
+                                      FALSE);
     }
 
     /* TODO: Ensure that job limits are respected */
 
-    /* Resume APCs and release lock */
     ExReleaseResourceAndLeaveCriticalRegion(&Job->JobLock);
 }
 
@@ -495,81 +765,78 @@ PspExitProcessFromJob(
  * @param[in] Process
  *     A pointer to the process object to be terminated.
  *
- * @param[in, optional] Context
- *     An optional pointer to a context, in this case, a structure containing
- *     the job object and the exit status.
+ * @param[in] Context
+ *     A pointer to a PSP_TERMINATE_PROCESS_CONTEXT structure.
  *
  * @returns
- *     STATUS_SUCCESS if the process was successfully terminated.
- *     Otherwise, an appropriate NTSTATUS error code.
+ *     STATUS_SUCCESS.
  *
  * @remark
- *     When this callback function is executed, the job lock is held by
- *     PspEnumerateProcessesInJob(). It releases the lock after the callback
- *     returns.
+ *     The callback is invoked _without_ the job lock held. Process carries the
+ *     reference acquired by the job enumerator for the duration of the call.
  */
 static
 NTSTATUS
 PspTerminateProcessCallback(
     _In_ PEPROCESS Process,
-    _In_opt_ PVOID Context
+    _In_ PVOID Context
 )
 {
     NTSTATUS Status;
-    PTERMINATE_PROCESS_CONTEXT TerminateContext = (PTERMINATE_PROCESS_CONTEXT)Context;
+    BOOLEAN ActiveProcessZero;
+    PPSP_TERMINATE_PROCESS_CONTEXT TerminateContext = (PPSP_TERMINATE_PROCESS_CONTEXT)Context;
     PEJOB Job = TerminateContext->Job;
     NTSTATUS ExitStatus = TerminateContext->ExitStatus;
 
-    /* If the process is already inactive, no need to terminate */
+    ASSERT(Job != NULL);
+    ASSERT(Process->Job == Job);
+
+    /* Avoid entering process termination when the process has already
+       completed its active job transition */
+    ExEnterCriticalRegionAndAcquireResourceExclusive(&Job->JobLock);
+
     if (Process->JobStatus & JOB_NOT_REALLY_ACTIVE)
     {
-        return STATUS_INVALID_PARAMETER;
+        goto Exit;
     }
-
-    ExEnterCriticalRegionAndAcquireResourceExclusive(&Job->JobLock);
 
     /* Terminate the process */
     Status = PsTerminateProcess(Process, ExitStatus);
 
-    if (NT_SUCCESS(Status))
+    /* PsTerminateProcess can return STATUS_NOTHING_TO_TERMINATE
+       when it finds no threads (the ordinary process exit remains
+       responsible for completing job accounting in that case),
+       that should be treated as a no-op for job traversal */
+    if (!NT_SUCCESS(Status))
     {
-        /* Decrement the job's active process count, but only if the process is
-           still active */
-        if (!(Process->JobStatus & JOB_NOT_REALLY_ACTIVE))
+        goto Exit;
+    }
+
+    /* Decrement the job's active process count if the process is still active */
+    ActiveProcessZero = PspDeactivateProcessFromJobLocked(Job, Process);
+
+    /* If there are no active processes left in the job, notify anyone waiting
+       for the job object by signaling completion */
+    if (ActiveProcessZero)
+    {
+        /* It is intended that the event is set to a signaled
+           state only in the termination path */
+        KeSetEvent(&Job->Event, IO_NO_INCREMENT, FALSE);
+
+        if (Job->CompletionPort)
         {
-            Job->ActiveProcesses--;
-
-            /* Flag this process as inactive to prevent the number of active
-               processes from repeatedly decrementing */
-            InterlockedOr((PLONG)&Process->JobStatus,
-                          JOB_NOT_REALLY_ACTIVE);
-
-            /* Check if there are no active processes left in the job */
-            if (Job->ActiveProcesses == 0)
-            {
-                /* If so, notify anyone waiting for the job object
-                   by signaling completion */
-
-                /* It is intended that the event is set to a signaled
-                   state only in the termination path */
-                KeSetEvent(&Job->Event, IO_NO_INCREMENT, FALSE);
-
-                if (Job->CompletionPort)
-                {
-                    IoSetIoCompletion(Job->CompletionPort,
-                                      Job->CompletionKey,
-                                      NULL,
-                                      STATUS_SUCCESS,
-                                      JOB_OBJECT_MSG_ACTIVE_PROCESS_ZERO,
-                                      FALSE);
-                }
-            }
+            (VOID)PspSendJobMessageLocked(Job,
+                                          JOB_OBJECT_MSG_ACTIVE_PROCESS_ZERO,
+                                          NULL,
+                                          FALSE);
         }
     }
 
+Exit:
+
     ExReleaseResourceAndLeaveCriticalRegion(&Job->JobLock);
 
-    return Status;
+    return STATUS_SUCCESS;
 }
 
 /*!
@@ -593,20 +860,27 @@ PspTerminateJobObject(
 )
 {
     NTSTATUS Status;
-    TERMINATE_PROCESS_CONTEXT Context;
+    LONG PreviousFlags;
+    PSP_TERMINATE_PROCESS_CONTEXT Context;
+
+    PreviousFlags = InterlockedOr((PLONG)&Job->JobFlags, JOB_OBJECT_TERMINATING);
+
+    /* Termination is idempotent, another caller already owns the traversal */
+    if (PreviousFlags & JOB_OBJECT_TERMINATING)
+    {
+        return STATUS_SUCCESS;
+    }
+
     Context.Job = Job;
     Context.ExitStatus = ExitStatus;
 
-    DPRINT1("PspTerminateJobObject(Job: %p, ExitStatus: %x)\n",
-            Job,
-            ExitStatus);
-
-    InterlockedOr((PLONG)&Job->JobFlags, JOB_OBJECT_TERMINATING);
-
     Status = PspEnumerateProcessesInJob(Job,
                                         PspTerminateProcessCallback,
-                                        &Context,
-                                        FALSE);
+                                        &Context);
+
+    /* The termination callback always returns STATUS_SUCCESS because
+       per-process termination failures are handled locally */
+    ASSERT(NT_SUCCESS(Status));
 
     InterlockedAnd((PLONG)&Job->JobFlags, ~JOB_OBJECT_TERMINATING);
 
@@ -645,21 +919,15 @@ PspCloseJob(
     _In_ ULONG SystemHandleCount
 )
 {
+    NTSTATUS Status;
     PEJOB Job = (PEJOB)ObjectBody;
+    PVOID CompletionPort = NULL;
 
     PAGED_CODE();
 
     UNREFERENCED_PARAMETER(Process);
     UNREFERENCED_PARAMETER(GrantedAccess);
     UNREFERENCED_PARAMETER(HandleCount);
-
-    DPRINT1("PspCloseJob(Process: %p, ObjectBody: %p, GrantedAccess: %x, "
-            "HandleCount: %u, SystemHandleCount: %u)\n",
-            Process,
-            ObjectBody,
-            GrantedAccess,
-            HandleCount,
-            SystemHandleCount);
 
     /* Proceed only when the last handle is left */
     if (SystemHandleCount != 1)
@@ -672,18 +940,30 @@ PspCloseJob(
     /* Flag the job as closed */
     InterlockedOr((PLONG)&Job->JobFlags, JOB_OBJECT_CLOSE_DONE);
 
+    ExEnterCriticalRegionAndAcquireResourceExclusive(&Job->JobLock);
+
     /* If the job is set to kill on close, terminate all associated processes */
     if (Job->LimitFlags & JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE)
     {
-        NTSTATUS Status = PspTerminateJobObject(Job, STATUS_SUCCESS);
+        /* Keep the completion port associated during termination so that
+           final job messages can still be delivered */
+        ExReleaseResourceAndLeaveCriticalRegion(&Job->JobLock);
+
+        Status = PspTerminateJobObject(Job, STATUS_SUCCESS);
         ASSERT(NT_SUCCESS(Status));
+
+        ExEnterCriticalRegionAndAcquireResourceExclusive(&Job->JobLock);
     }
 
-    /* Remove the reference to the completion port if associated */
-    if (Job->CompletionPort)
+    CompletionPort = Job->CompletionPort;
+    Job->CompletionPort = NULL;
+    Job->CompletionKey = NULL;
+
+    ExReleaseResourceAndLeaveCriticalRegion(&Job->JobLock);
+
+    if (CompletionPort)
     {
-        ObDereferenceObject(Job->CompletionPort);
-        Job->CompletionPort = NULL;
+        ObDereferenceObject(CompletionPort);
     }
 }
 
@@ -699,14 +979,12 @@ PspDeleteJob(_In_ PVOID ObjectBody)
 {
     PEJOB Job = (PEJOB)ObjectBody;
 
-    DPRINT1("PspDeleteJob(ObjectBody: %p)\n", ObjectBody);
-
     PAGED_CODE();
 
     Job->LimitFlags = 0;
 
     /* Remove the reference to the completion port if associated */
-    if (Job->CompletionPort != NULL)
+    if (Job->CompletionPort)
     {
         ObDereferenceObject(Job->CompletionPort);
         Job->CompletionPort = NULL;
@@ -757,6 +1035,8 @@ PspSetJobLimitsBasicOrExtended(
     NTSTATUS Status = STATUS_SUCCESS;
     ULONG AllowedFlags;
     KPROCESSOR_MODE PreviousMode = ExGetPreviousMode();
+
+    ASSERT(KeAreAllApcsDisabled());
 
     const ULONG AllowedBasicFlags = JOB_OBJECT_LIMIT_WORKINGSET |
         JOB_OBJECT_LIMIT_PROCESS_TIME |
@@ -949,43 +1229,51 @@ ExitFromBasicLimits:
 }
 
 /*!
- * Callback function to associate an I/O completion port with a process.
+ * Queues an initial new-process notification for a process already assigned
+ * to a job.
  *
  * @param[in] Process
- *     A pointer to the process.
+ *     A borrowed pointer to the process being notified.
  *
- * @param[in, optional] Context
- *     A pointer to a context structure containing the I/O completion port and
- *     its associated key. This is passed in by the caller of the enumeration.
+ * @param[in] Context
+ *     A pointer to the job associated with the completion port.
  *
  * @return
- *     STATUS_SUCCESS if the I/O completion port was successfully associated
- *     with the process.
- *     Otherwise, an appropriate NTSTATUS error code.
+ *     STATUS_SUCCESS.
+ *
+ * @remarks
+ *     The callback is invoked while the job lock is held exclusively.
+ *     Notification failures are recorded for diagnostic purposes and do not
+ *     undo the completion port association.
  */
 static
 NTSTATUS
 PspAssociateCompletionPortCallback(
     _In_ PEPROCESS Process,
-    _In_opt_ PVOID Context
-)
+    _In_ PVOID Context)
 {
-    NTSTATUS Status = STATUS_SUCCESS;
-    PEJOB Job = (PEJOB)Context;
+    PEJOB Job;
+
+    Job = (PEJOB)Context;
+
+    ASSERT(Process->Job == Job);
+    ASSERT(Job->CompletionPort != NULL);
+
+#if DBG
+    ASSERT(ExIsResourceAcquiredExclusiveLite(&Job->JobLock) != 0);
+#endif
 
     /* Ensure the process is active and has a valid unique process ID */
     if (!(Process->JobStatus & JOB_NOT_REALLY_ACTIVE) &&
         Process->UniqueProcessId)
     {
-        Status = IoSetIoCompletion(Job->CompletionPort,
-                                   Job->CompletionKey,
-                                   Process->UniqueProcessId,
-                                   STATUS_SUCCESS,
-                                   JOB_OBJECT_MSG_NEW_PROCESS,
-                                   FALSE);
+        (VOID)PspSendJobMessageLocked(Job,
+                                      JOB_OBJECT_MSG_NEW_PROCESS,
+                                      Process->UniqueProcessId,
+                                      FALSE);
     }
 
-    return Status;
+    return STATUS_SUCCESS;
 }
 
 /*!
@@ -1001,9 +1289,13 @@ PspAssociateCompletionPortCallback(
  *     with a job (the handle of the I/O completion port and the key).
  *
  * @return
- *     STATUS_SUCCESS if the I/O completion port was successfully associated
- *     with the job and its processes.
+ *     STATUS_SUCCESS if the completion port was associated with the job.
  *     Otherwise, an appropriate NTSTATUS error code.
+ *
+ * @remarks
+ *     Once the completion port is installed, failure to queue an initial
+ *     process notification is recorded diagnostically and does not undo the
+ *     association.
  */
 static
 NTSTATUS
@@ -1012,9 +1304,11 @@ PspAssociateCompletionPortWithJob(
     _In_ PJOBOBJECT_ASSOCIATE_COMPLETION_PORT AssociateCpInfo
 )
 {
-    NTSTATUS Status = STATUS_SUCCESS;
+    NTSTATUS Status;
     KPROCESSOR_MODE PreviousMode = ExGetPreviousMode();
     HANDLE IoCompletion;
+
+    ASSERT(KeAreAllApcsDisabled());
 
     if (!AssociateCpInfo->CompletionPort)
     {
@@ -1027,7 +1321,6 @@ PspAssociateCompletionPortWithJob(
                                        PreviousMode,
                                        &IoCompletion,
                                        NULL);
-
     if (!NT_SUCCESS(Status))
     {
         return Status;
@@ -1038,23 +1331,28 @@ PspAssociateCompletionPortWithJob(
     /* Check if the job already has a completion port or is in a final state */
     if (Job->CompletionPort || (Job->JobFlags & JOB_OBJECT_CLOSE_DONE) != 0)
     {
-        ObDereferenceObject(IoCompletion);
         ExReleaseResourceLite(&Job->JobLock);
+        ObDereferenceObject(IoCompletion);
         return STATUS_INVALID_PARAMETER;
     }
 
     Job->CompletionKey = AssociateCpInfo->CompletionKey;
     Job->CompletionPort = IoCompletion;
 
-    /* Inform all processes in the job about the association. */
-    Status = PspEnumerateProcessesInJob(Job,
-                                        PspAssociateCompletionPortCallback,
-                                        &Job,
-                                        FALSE);
+    /* Inform all processes in the job about the association
+       N.B. Assignment is serialized by JobLock; a process is therefore covered
+       either by this enumeration or by the normal assignment path */
+    Status = PspEnumerateProcessesInJobLocked(Job,
+                                              PspAssociateCompletionPortCallback,
+                                              Job);
+
+    ASSERT(NT_SUCCESS(Status));
 
     ExReleaseResourceLite(&Job->JobLock);
 
-    return Status;
+    /* The completion port is already associated. A notification allocation
+       failure can't safely roll back the association. */
+    return STATUS_SUCCESS;
 }
 
 /*!
@@ -1210,7 +1508,7 @@ PspQueryLimitInformation(
  * @param[in] Process
  *     A pointer to the process whose ID is being added to the process list.
  *
- * @param[in, out, optional] Context
+ * @param[in, out] Context
  *     A pointer to the context structure that tracks the process ID collection.
  *     This context holds the list of process IDs, the length of the buffer,
  *     and the status of the collection operation.
@@ -1224,10 +1522,10 @@ static
 NTSTATUS
 PspQueryJobProcessIdListCallback(
     _In_ PEPROCESS Process,
-    _In_opt_ PVOID Context
+    _Inout_ PVOID Context
 )
 {
-    PQUERY_JOB_PROCESS_ID_CONTEXT ProcContext = (PQUERY_JOB_PROCESS_ID_CONTEXT)Context;
+    PPSP_QUERY_JOB_PROCESS_ID_CONTEXT QueryContext = (PPSP_QUERY_JOB_PROCESS_ID_CONTEXT)Context;
 
     /* Skip processes that are not really active */
     if (Process->JobStatus & JOB_NOT_REALLY_ACTIVE)
@@ -1236,28 +1534,27 @@ PspQueryJobProcessIdListCallback(
         return STATUS_SUCCESS;
     }
 
-    /* Check if there is enough space in the list to add another process ID */
-    if (ProcContext->ListLength >= sizeof(ULONG_PTR))
+    /* An active process may be linked before its process identifier has been
+       assigned - such a process is not representable in this information class */
+    if (Process->UniqueProcessId == NULL)
     {
-        if (ExAcquireRundownProtection(&Process->RundownProtect))
-        {
-            /* Add the process ID to the list */
-            *ProcContext->IdListArray++ = (ULONG_PTR)Process->UniqueProcessId;
+        ASSERT(QueryContext->ProcessIdList->NumberOfAssignedProcesses != 0);
 
-            /* Adjust the remaining buffer space and increment the process
-               count */
-            ProcContext->ListLength -= sizeof(ULONG_PTR);
-            ProcContext->ProcIdList->NumberOfProcessIdsInList++;
+        QueryContext->ProcessIdList->NumberOfAssignedProcesses--;
 
-            ExReleaseRundownProtection(&Process->RundownProtect);
-        }
+        return STATUS_SUCCESS;
     }
-    else
+
+    if (QueryContext->RemainingLength < sizeof(ULONG_PTR))
     {
-        /* Break the enumeration on buffer overflow */
-        ProcContext->Status = STATUS_BUFFER_OVERFLOW;
-        return ProcContext->Status;
+        return STATUS_BUFFER_OVERFLOW;
     }
+
+    *QueryContext->NextProcessId++ = (ULONG_PTR)Process->UniqueProcessId;
+
+    QueryContext->RemainingLength -= sizeof(ULONG_PTR);
+
+    QueryContext->ProcessIdList->NumberOfProcessIdsInList++;
 
     return STATUS_SUCCESS;
 }
@@ -1295,8 +1592,8 @@ PspQueryJobProcessIdList(
     _Out_ PULONG ReturnRequiredLength
 )
 {
-    NTSTATUS Status = STATUS_SUCCESS;
-    QUERY_JOB_PROCESS_ID_CONTEXT ProcContext;
+    NTSTATUS Status;
+    PSP_QUERY_JOB_PROCESS_ID_CONTEXT QueryContext;
 
     /* Check if the buffer provided is large enough to hold at least the
        fixed portion of JOBOBJECT_BASIC_PROCESS_ID_LIST */
@@ -1305,32 +1602,43 @@ PspQueryJobProcessIdList(
         return STATUS_INFO_LENGTH_MISMATCH;
     }
 
-    /* Initialize the process context */
-    ProcContext.ProcIdList = ProcIdList;
-    ProcContext.ListLength =
-        JobInformationLength - FIELD_OFFSET(JOBOBJECT_BASIC_PROCESS_ID_LIST,
-                                            ProcessIdList);
-    ProcContext.IdListArray = &ProcIdList->ProcessIdList[0];
-    ProcContext.Status = STATUS_SUCCESS;
+    QueryContext.ProcessIdList = ProcIdList;
+    QueryContext.NextProcessId = &ProcIdList->ProcessIdList[0];
+    QueryContext.RemainingLength = JobInformationLength - FIELD_OFFSET(JOBOBJECT_BASIC_PROCESS_ID_LIST,
+                                                                       ProcessIdList);
 
-    /* Fill in the number of assigned processes */
-    ProcIdList->NumberOfAssignedProcesses = Job->ActiveProcesses;
-    ProcIdList->NumberOfProcessIdsInList = 0;
+    Status = STATUS_SUCCESS;
 
-    /* Use the enumerator to collect the process IDs
-       N.B. The enumeration will stop if the callback fails */
-    Status = PspEnumerateProcessesInJob(Job,
-                                        PspQueryJobProcessIdListCallback,
-                                        &ProcContext,
-                                        TRUE);
+    ExEnterCriticalRegionAndAcquireResourceShared(&Job->JobLock);
 
-    /* Calculate how much of the buffer was used */
-    *ReturnRequiredLength = JobInformationLength - ProcContext.ListLength;
+    _SEH2_TRY
+    {
+        ProcIdList->NumberOfAssignedProcesses = Job->ActiveProcesses;
+        ProcIdList->NumberOfProcessIdsInList = 0;
 
-    /* Ensure the right error is propagated if the buffer was too small */
-    return ProcContext.Status == STATUS_BUFFER_OVERFLOW
-               ? STATUS_BUFFER_OVERFLOW
-               : Status;
+        Status = PspEnumerateProcessesInJobLocked(Job,
+                                                  PspQueryJobProcessIdListCallback,
+                                                  &QueryContext);
+    }
+    _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+    {
+        Status = _SEH2_GetExceptionCode();
+    }
+    _SEH2_END;
+
+    ExReleaseResourceAndLeaveCriticalRegion(&Job->JobLock);
+
+    if (NT_SUCCESS(Status) || Status == STATUS_BUFFER_OVERFLOW)
+    {
+        /* Report the bytes actually written */
+        *ReturnRequiredLength = (ULONG)(JobInformationLength - QueryContext.RemainingLength);
+    }
+    else
+    {
+        *ReturnRequiredLength = 0;
+    }
+
+    return Status;
 }
 
 /*
@@ -1410,8 +1718,6 @@ NtCreateJobObject(
     PEPROCESS CurrentProcess;
     NTSTATUS Status;
 
-    DPRINT1("NtCreateJobObject(JobHandle: %p)\n", JobHandle);
-
     PAGED_CODE();
 
     PreviousMode = ExGetPreviousMode();
@@ -1462,13 +1768,7 @@ NtCreateJobObject(
         KeInitializeGuardedMutex(&Job->MemoryLimitsLock);
 
         /* Initialize the job lock */
-        Status = ExInitializeResource(&Job->JobLock);
-        if (!NT_SUCCESS(Status))
-        {
-            DPRINT1("Failed to initialize job lock\n");
-            ObDereferenceObject(Job);
-            return Status;
-        }
+        (VOID)ExInitializeResource(&Job->JobLock);
 
         /* Initialize the event object within the job */
         KeInitializeEvent(&Job->Event, NotificationEvent, FALSE);
@@ -1632,11 +1932,10 @@ NtAssignProcessToJobObject(
         return Status;
     }
 
-    /* Reference the process. Make sure we have enough rights, especially to
-       terminate the process. Otherwise, one could abuse job objects to
-       terminate processes without having the rights to do so */
+    /* Reference the process. The handle must have the PROCESS_SET_QUOTA and 
+       PROCESS_TERMINATE access rights. */
     Status = ObReferenceObjectByHandle(ProcessHandle,
-                                       PROCESS_TERMINATE,
+                                       PROCESS_SET_QUOTA | PROCESS_TERMINATE,
                                        PsProcessType,
                                        PreviousMode,
                                        (PVOID *)&Process,
@@ -1659,43 +1958,12 @@ NtAssignProcessToJobObject(
         return STATUS_ACCESS_DENIED;
     }
 
-    if (ExAcquireRundownProtection(&Process->RundownProtect))
+    Status = PspAssignProcessToJob(Process, Job);
+
+    if (Status == STATUS_QUOTA_EXCEEDED)
     {
-        /* Ensure the process is not already assigned to a job */
-        ASSERT(Process->Job == NULL);
-
-        /* Capture a reference for the process lifetime */
-        ObReferenceObject(Job);
-
-        /* Try to atomically compare-and-exchange the job pointer */
-        if (InterlockedCompareExchangePointer((PVOID)&Process->Job, Job, NULL))
-        {
-            ExReleaseRundownProtection(&Process->RundownProtect);
-
-            /* At this point, the job was referenced twice */
-            ObDereferenceObjectEx(Job, 2);
-            ObDereferenceObject(Process);
-
-            return STATUS_ACCESS_DENIED;
-        }
-
-        ExReleaseRundownProtection(&Process->RundownProtect);
-
-        /* Assign the process to the job */
-        Status = PspAssignProcessToJob(Process, Job);
-
-        /* If the assignment causes the active process count to exceed
-           ActiveProcessLimit, the process is terminated */
-        if (Status == STATUS_QUOTA_EXCEEDED)
-        {
-            Status = PsTerminateProcess(Process, STATUS_QUOTA_EXCEEDED);
-        }
-
-        /* TODO: UI restrictions class */
-    }
-    else
-    {
-        Status = STATUS_PROCESS_IS_TERMINATING;
+        /* Preserve the assignment failure */
+        (VOID)PsTerminateProcess(Process, STATUS_QUOTA_EXCEEDED);
     }
 
     ObDereferenceObject(Job);
@@ -1732,10 +2000,6 @@ NtIsProcessInJob(
     PEJOB ProcessJob;
     PEJOB JobObjectFromHandle;
     NTSTATUS Status;
-
-    DPRINT1("NtIsProcessInJob(ProcessHandle: %p, JobHandle: %p)\n",
-            ProcessHandle,
-            JobHandle);
 
     PreviousMode = ExGetPreviousMode();
 
@@ -1958,9 +2222,7 @@ NtQueryInformationJobObject(
             /* Probe the buffer */
             if (JobInformation != NULL)
             {
-                ProbeForWrite(JobInformation,
-                              JobInformationLength,
-                              RequiredAlign);
+                ProbeForWrite(JobInformation, JobInformationLength, RequiredAlign);
             }
 
             /* Probe the return length if required */
@@ -1983,7 +2245,7 @@ NtQueryInformationJobObject(
                                            JOB_OBJECT_QUERY,
                                            PsJobType,
                                            PreviousMode,
-                                           (PVOID*)&Job,
+                                           (PVOID *)&Job,
                                            NULL);
         if (!NT_SUCCESS(Status))
         {
@@ -2159,9 +2421,7 @@ NtSetInformationJobObject(
             /* Probe out buffer for read */
             if (JobInformationLength != 0)
             {
-                ProbeForRead(JobInformation,
-                             JobInformationLength,
-                             RequiredAlign);
+                ProbeForRead(JobInformation, JobInformationLength, RequiredAlign);
             }
         }
         _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
@@ -2191,7 +2451,7 @@ NtSetInformationJobObject(
                                        DesiredAccess,
                                        PsJobType,
                                        PreviousMode,
-                                       (PVOID*)&Job,
+                                       (PVOID *)&Job,
                                        NULL);
     if (!NT_SUCCESS(Status))
     {

--- a/ntoskrnl/ps/job.c
+++ b/ntoskrnl/ps/job.c
@@ -3,7 +3,7 @@
  * PROJECT:         ReactOS kernel
  * FILE:            ntoskrnl/ps/job.c
  * PURPOSE:         Core functions for managing Job Objects, a kernel mechanism
- *                  for managing multiple processes as a single unit
+ *                  for managing multiple processes as a single unit.
  * PROGRAMMERS:     2004-2012 Alex Ionescu (alex@relsoft.net) (stubs)
  *                  2004-2005 Thomas Weidenmueller <w3seek@reactos.com>
  *                  2015-2016 Samuel Serapión Vega (encoded@reactos.org)
@@ -194,9 +194,7 @@ PspGetNextProcessInJobLocked(
     ASSERT(Entry->Blink->Flink == Entry);
 
     Process = CONTAINING_RECORD(Entry, EPROCESS, JobLinks);
-
     ASSERT(Process->Job == Job);
-
     return Process;
 }
 
@@ -306,12 +304,11 @@ PspEnumerateProcessesInJob(
     while (Process != NULL)
     {
         Status = Callback(Process, Context);
-
         if (!NT_SUCCESS(Status))
         {
             /*
-             * On successful iteration, PspGetNextProcessInJob consumes this
-             * reference. On failure, it must be released explicitly.
+             * On successful iteration, PspGetNextProcessInJob consumes
+             * this reference. On failure, it must be released explicitly.
              */
             ObDereferenceObject(Process);
             break;
@@ -368,11 +365,8 @@ PspEnumerateProcessesInJobLocked(
     while ((Process = PspGetNextProcessInJobLocked(Job, Process)) != NULL)
     {
         Status = Callback(Process, Context);
-
         if (!NT_SUCCESS(Status))
-        {
             break;
-        }
     }
 
     return Status;
@@ -536,9 +530,7 @@ PspAssignProcessToJob(
     }
 
 Exit:
-
     ExReleaseResourceAndLeaveCriticalRegion(&Job->JobLock);
-
     ExReleaseRundownProtection(&Process->RundownProtect);
 
     /* TODO: Ensure that job limits are respected */

--- a/ntoskrnl/ps/job.c
+++ b/ntoskrnl/ps/job.c
@@ -87,27 +87,6 @@ ULONG PspJobInfoAlign[] =
 /* DATA TYPE DEFINITIONS *****************************************************/
 
 /*!
- * Iterator structure used to enumerate processes directly assigned to a job
- * while the job lock is held.
- *
- * @param[in] Job
- *     A pointer to the job object being enumerated.
- *
- * @param[in] NextEntry
- *     A pointer to the next process list entry to be returned.
- *
- * @remarks
- *     The iterator does not acquire or release the job lock and does not
- *     reference returned process objects. The caller must hold the job lock
- *     for the entire lifetime of the iterator.
- */
-typedef struct PSP_JOB_ITERATOR
-{
-    PEJOB Job;
-    PLIST_ENTRY NextEntry;
-} PSP_JOB_ITERATOR, *PPSP_JOB_ITERATOR;
-
-/*!
  * Context structure used to pass the job object and exit status to
  * the process termination callback.
  *
@@ -154,110 +133,65 @@ PspInitializeJobStructures(VOID)
 }
 
 /*!
- * Initializes an iterator for the processes directly assigned to a job.
+ * Returns the next process directly assigned to a job while the job lock is
+ * held.
  *
  * @param[in] Job
- *     A pointer to the job object whose process list will be enumerated.
+ *     A pointer to the job object being enumerated.
  *
  * @param[in, optional] PreviousProcess
- *     A pointer to the process after which enumeration should begin, or NULL
- *     to begin with the first process in the job.
+ *     A pointer to the process after which enumeration should
+ *     continue, or NULL to return the first process.
  *
- * @param[out] Iterator
- *     A pointer to the iterator to initialize.
+ * @return
+ *     A pointer to the next assigned process, or NULL if enumeration has completed.
  *
  * @remarks
- *     The caller must hold tje job lock shared or exclusive.
+ *     The caller must hold the job lock shared or exclusive.
  *
- *     PreviousProcess is borrowed and is not referenced or dereferenced by
- *     this function.
+ *     Neither PreviousProcess nor the returned process is referenced by this
+ *     function. The caller must ensure that PreviousProcess remains linked to
+ *     the job and that direct job membership isn't modified during the
+ *     enumeration.
  */
 static
-VOID
-PspInitializeJobIteratorLocked(
+PEPROCESS
+PspGetNextProcessInJobLocked(
     _In_ PEJOB Job,
-    _In_opt_ PEPROCESS PreviousProcess,
-    _Out_ PPSP_JOB_ITERATOR Iterator
+    _In_opt_ PEPROCESS PreviousProcess
 )
 {
-    ASSERT(Iterator != NULL);
+    PLIST_ENTRY Entry;
+    PEPROCESS Process;
 
-#if DBG
     ASSERT(ExIsResourceAcquiredSharedLite(&Job->JobLock) != 0 ||
            ExIsResourceAcquiredExclusiveLite(&Job->JobLock) != 0);
-#endif
 
-    Iterator->Job = Job;
-
+    /* Check if we're already starting somewhere */
     if (PreviousProcess != NULL)
     {
         ASSERT(PreviousProcess->Job == Job);
         ASSERT(!IsListEmpty(&PreviousProcess->JobLinks));
 
-        Iterator->NextEntry = PreviousProcess->JobLinks.Flink;
+        /* Start where we left off */
+        Entry = PreviousProcess->JobLinks.Flink;
     }
     else
     {
-        Iterator->NextEntry = Job->ProcessListHead.Flink;
+        /* Start at the beginning */
+        Entry = Job->ProcessListHead.Flink;
     }
-}
 
-/*!
- * Advances a job process iterator.
- *
- * @param[in, out] Iterator
- *     A pointer to an initialized job process iterator.
- *
- * @return
- *     A borrowed pointer to the next directly assigned process, or NULL if
- *     enumeration has completed.
- *
- * @remarks
- *     The caller must continue holding Iterator->Job->JobLock.
- *
- *     The returned process is borrowed and may already be entering object
- *     deletion. The caller may access only fields that remain valid while the
- *     process is linked to the job.
- */
-static
-PEPROCESS
-PspAdvanceJobIteratorLocked(
-    _Inout_ PPSP_JOB_ITERATOR Iterator
-)
-{
-    PEJOB Job;
-    PLIST_ENTRY Entry;
-    PEPROCESS Process;
-
-    ASSERT(Iterator->Job != NULL);
-
-    Job = Iterator->Job;
-
-#if DBG
-    ASSERT(ExIsResourceAcquiredSharedLite(&Job->JobLock) != 0 ||
-           ExIsResourceAcquiredExclusiveLite(&Job->JobLock) != 0);
-#endif
-
-    ASSERT(Iterator->NextEntry != NULL);
-
-    Entry = Iterator->NextEntry;
-
+    /* Check if enumeration has completed */
     if (Entry == &Job->ProcessListHead)
     {
         return NULL;
     }
 
-#if DBG
     ASSERT(Entry->Flink != NULL);
     ASSERT(Entry->Blink != NULL);
     ASSERT(Entry->Flink->Blink == Entry);
     ASSERT(Entry->Blink->Flink == Entry);
-#endif
-
-    /* Advance the cursor before returning the process. This keeps iterator
-       state independent from modifications to non-list process fields made by
-       the callback. */
-    Iterator->NextEntry = Entry->Flink;
 
     Process = CONTAINING_RECORD(Entry, EPROCESS, JobLinks);
 
@@ -267,74 +201,74 @@ PspAdvanceJobIteratorLocked(
 }
 
 /*!
- * Advances the job enumerator to the next process in the job's process list.
+ * Returns the next referenced process directly assigned to a job.
  *
  * @param[in] Job
- *     A pointer to the job object whose directly assigned processes are being
- *     enumerated.
+ *     A pointer to the job object being enumerated.
  *
- * @param[in, optional] Process
- *     A referenced process returned by a previous call to this function, or
- *     NULL to start the enumeration. When non-NULL, the reference is consumed
- *     by this function regardless of whether another process is returned.
+ * @param[in, optional] PreviousProcess
+ *     A referenced process returned by the previous call, or NULL to start
+ *     enumeration. When non-NULL, its reference is consumed by this function,
+ *     regardless of whether another process is returned.
  *
  * @return
- *     A referenced pointer to the next process, or NULL if no more processes
- *     are available.
+ *     A referenced pointer to the next process, or NULL if enumeration has
+ *     completed.
  *
  * @remarks
- *     The returned process reference must either be passed to a subsequent
- *     call to this function or released with ObDereferenceObject().
+ *     The returned reference must either be passed to the next call or
+ *     released with ObDereferenceObject().
  *
- *     This implementation relies on job membership remaining fixed
- *     until process object deletion.
+ *     The job lock is not held when this function returns.
+ *
+ *     This relies on job membership remaining fixed until process object deletion.
+ *     The reference to PreviousProcess therefore keeps its JobLinks valid until
+ *     the next process has been selected.
  */
 static
 PEPROCESS
-PspAdvanceJobEnumerator(
+PspGetNextProcessInJob(
     _In_ PEJOB Job,
-    _In_opt_ PEPROCESS Process
+    _In_opt_ PEPROCESS PreviousProcess
 )
 {
-    PSP_JOB_ITERATOR Iterator;
-    PEPROCESS Next = NULL;
     PEPROCESS Candidate;
-
-    if (Process != NULL)
-    {
-        ASSERT(Process->Job == Job);
-        ASSERT(!IsListEmpty(&Process->JobLinks));
-    }
+    PEPROCESS NextProcess = NULL;
 
     ExEnterCriticalRegionAndAcquireResourceShared(&Job->JobLock);
 
-    PspInitializeJobIteratorLocked(Job, Process, &Iterator);
+    Candidate = PreviousProcess;
 
-    while ((Candidate = PspAdvanceJobIteratorLocked(&Iterator)) != NULL)
+    while ((Candidate = PspGetNextProcessInJobLocked(Job, Candidate)) != NULL)
     {
-        /* Skip process objects whose deletion has already begun */
+        /*
+         * Skip processes whose deletion has begun. JobLinks remains valid
+         * while the job lock is held, allowing enumeration to continue.
+         */
         if (ObReferenceObjectSafe(Candidate))
         {
-            Next = Candidate;
+            NextProcess = Candidate;
             break;
         }
     }
 
     ExReleaseResourceAndLeaveCriticalRegion(&Job->JobLock);
 
-    /* This must occur after releasing the job lock: the dereference can invoke the
-       process delete procedure, which removes JobLinks under the same lock */
-    if (Process != NULL)
+    /*
+     * This must occur after releasing the job lock. The dereference can invoke
+     * the process delete procedure, which removes JobLinks under the same lock.
+     */
+    if (PreviousProcess != NULL)
     {
-        ObDereferenceObject(Process);
+        ObDereferenceObject(PreviousProcess);
     }
 
-    return Next;
+    return NextProcess;
 }
 
 /*!
  * Enumerates all processes currently associated with the specified job object
- * and calls the provided callback function for each process.
+ * and invokes a callback for each process.
  *
  * @param[in] Job
  *     A pointer to the job object whose processes are to be enumerated.
@@ -345,16 +279,14 @@ PspAdvanceJobEnumerator(
  * @param[in, optional] Context
  *     An optional context pointer passed to the callback.
  *
- * @returns
+ * @return
  *     STATUS_SUCCESS if every callback succeeds. Otherwise, the first
  *     unsuccessful callback status is returned.
  *
  * @remarks
  *     Enumeration stops when a callback returns an unsuccessful status.
  *
- *     The callback is invoked _without_ the job lock held. It borrows the
- *     enumerator's process reference and must acquire an additional reference
- *     if it retains the process pointer.
+ *     The callback is invoked _without_ the job lock held.
  */
 NTSTATUS
 NTAPI
@@ -365,34 +297,35 @@ PspEnumerateProcessesInJob(
 )
 {
     NTSTATUS Status = STATUS_SUCCESS;
-    PEPROCESS Process;
+    PEPROCESS Process = NULL;
 
     /* Get the first process from the job */
-    Process = PspAdvanceJobEnumerator(Job, NULL);
+    Process = PspGetNextProcessInJob(Job, NULL);
 
     /* Iterate through all processes in the job */
-    while (Process)
+    while (Process != NULL)
     {
-        /* Call the provided callback */
         Status = Callback(Process, Context);
 
         if (!NT_SUCCESS(Status))
         {
-            /* On successful iteration, PspAdvanceJobEnumerator consumes this
-               reference. On failure, it must be released explicitly. */
+            /*
+             * On successful iteration, PspGetNextProcessInJob consumes this
+             * reference. On failure, it must be released explicitly.
+             */
             ObDereferenceObject(Process);
             break;
         }
 
         /* Move to the next process */
-        Process = PspAdvanceJobEnumerator(Job, Process);
+        Process = PspGetNextProcessInJob(Job, Process);
     }
 
     return Status;
 }
 
 /*!
- * Enumerates all directly assigned processes while the caller holds the job
+ * Enumerates all assigned processes while the caller holds the job
  * lock and invokes a callback for each process.
  *
  * @param[in] Job
@@ -411,13 +344,11 @@ PspEnumerateProcessesInJob(
  * @remarks
  *     Enumeration stops when a callback returns an unsuccessful status.
  *
- *     The caller must hold the job lock shared or exclusive for the complete
- *     call.
+ *     The caller must hold the job lock shared or exclusive.
  *
- *     The callback receives a borrowed process pointer. It must not release
- *     the job lock, recursively acquire the job lock, modify direct job
- *     membership, dereference the process object, or retain the process
- *     pointer after returning.
+ *     The callback must not release or recursively acquire the job lock,
+ *     modify job membership, dereference the process object, or retain
+ *     the process pointer after returning.
  */
 static
 NTSTATUS
@@ -427,21 +358,15 @@ PspEnumerateProcessesInJobLocked(
     _In_opt_ PVOID Context
 )
 {
-    PSP_JOB_ITERATOR Iterator;
     NTSTATUS Status = STATUS_SUCCESS;
-    PEPROCESS Process;
+    PEPROCESS Process = NULL;
 
-#if DBG
     ASSERT(ExIsResourceAcquiredSharedLite(&Job->JobLock) != 0 ||
            ExIsResourceAcquiredExclusiveLite(&Job->JobLock) != 0);
-#endif
-
-    PspInitializeJobIteratorLocked(Job, NULL, &Iterator);
 
     /* Iterate through all processes in the job */
-    while ((Process = PspAdvanceJobIteratorLocked(&Iterator)) != NULL)
+    while ((Process = PspGetNextProcessInJobLocked(Job, Process)) != NULL)
     {
-        /* Call the provided callback */
         Status = Callback(Process, Context);
 
         if (!NT_SUCCESS(Status))
@@ -537,7 +462,7 @@ PspAssignProcessToJob(
     /* https://learn.microsoft.com/en-us/windows/win32/api/jobapi2/nf-jobapi2-assignprocesstojobobject:
        "If the job or any of its parent jobs in the job chain is terminating
        when AssignProcessToJob is called, the function fails" */
-    if (BooleanFlagOn(Job->JobFlags, JOB_OBJECT_TERMINATING))
+    if (FlagOn(Job->JobFlags, JOB_OBJECT_TERMINATING))
     {
         Status = STATUS_INVALID_PARAMETER;
         goto Exit;
@@ -545,15 +470,15 @@ PspAssignProcessToJob(
 
     /* Prevent processes from being added to the job if it is flagged
        for closing and has a limit on process termination on closing */
-    if (BooleanFlagOn(Job->LimitFlags, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE) &&
-        BooleanFlagOn(Job->JobFlags, JOB_OBJECT_CLOSE_DONE))
+    if (FlagOn(Job->LimitFlags, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE) &&
+        FlagOn(Job->JobFlags, JOB_OBJECT_CLOSE_DONE))
     {
         Status = STATUS_INVALID_PARAMETER;
         goto Exit;
     }
 
     /* Check if the job has a limit on the number of active processes */
-    if (BooleanFlagOn(Job->LimitFlags, JOB_OBJECT_LIMIT_ACTIVE_PROCESS) &&
+    if (FlagOn(Job->LimitFlags, JOB_OBJECT_LIMIT_ACTIVE_PROCESS) &&
         Job->ActiveProcesses >= Job->ActiveProcessLimit)
     {
         /* Check if job limit on active processes has been reached */
@@ -571,8 +496,10 @@ PspAssignProcessToJob(
         goto Exit;
     }
 
-    /* Acquire the reference owned by the process for as long as
-       Process->Job points to Job */
+    /* Acquire the reference owned by Process->Job before publishing the pointer.
+       This ensures that every observable non-NULL Process->Job is already
+       backed by its lifetime reference. If another assignment wins the race,
+       release the unused reference. */
     ObReferenceObject(Job);
 
     /* JobLock protects the target job, but another caller may simultaneously
@@ -650,7 +577,7 @@ PspDeactivateProcessFromJobLocked(
     ASSERT(ExIsResourceAcquiredExclusiveLite(&Job->JobLock) != 0);
 #endif
 
-    if (BooleanFlagOn(Process->JobStatus, JOB_NOT_REALLY_ACTIVE))
+    if (FlagOn(Process->JobStatus, JOB_NOT_REALLY_ACTIVE))
     {
         return FALSE;
     }
@@ -795,7 +722,7 @@ PspTerminateProcessCallback(
        completed its active job transition */
     ExEnterCriticalRegionAndAcquireResourceExclusive(&Job->JobLock);
 
-    if (BooleanFlagOn(Process->JobStatus, JOB_NOT_REALLY_ACTIVE))
+    if (FlagOn(Process->JobStatus, JOB_NOT_REALLY_ACTIVE))
     {
         goto Exit;
     }
@@ -943,7 +870,7 @@ PspCloseJob(
     ExEnterCriticalRegionAndAcquireResourceExclusive(&Job->JobLock);
 
     /* If the job is set to kill on close, terminate all associated processes */
-    if (BooleanFlagOn(Job->LimitFlags, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE))
+    if (FlagOn(Job->LimitFlags, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE))
     {
         /* Keep the completion port associated during termination so that
            final job messages can still be delivered */
@@ -1263,7 +1190,7 @@ PspAssociateCompletionPortCallback(
 #endif
 
     /* Ensure the process is active and has a valid unique process ID */
-    if (!BooleanFlagOn(Process->JobStatus, JOB_NOT_REALLY_ACTIVE) &&
+    if (!FlagOn(Process->JobStatus, JOB_NOT_REALLY_ACTIVE) &&
         Process->UniqueProcessId)
     {
         (VOID)PspSendJobMessageLocked(Job,
@@ -1328,7 +1255,7 @@ PspAssociateCompletionPortWithJob(
     ExAcquireResourceExclusiveLite(&Job->JobLock, TRUE);
 
     /* Check if the job already has a completion port or is in a final state */
-    if (Job->CompletionPort || BooleanFlagOn(Job->JobFlags, JOB_OBJECT_CLOSE_DONE))
+    if (Job->CompletionPort || FlagOn(Job->JobFlags, JOB_OBJECT_CLOSE_DONE))
     {
         ExReleaseResourceLite(&Job->JobLock);
         ObDereferenceObject(IoCompletion);
@@ -1371,7 +1298,7 @@ PspAssociateCompletionPortWithJob(
  */
 static
 NTSTATUS
-PspQueryBasicAccountingInfo(
+PspQueryJobBasicAccountingInfo(
     _In_ PEJOB Job,
     _Out_ PJOBOBJECT_BASIC_AND_IO_ACCOUNTING_INFORMATION BasicAndIo
 )
@@ -1411,7 +1338,7 @@ PspQueryBasicAccountingInfo(
         PEPROCESS Process = CONTAINING_RECORD(NextEntry, EPROCESS, JobLinks);
 
         /* Skip folded accounting processes */
-        if (!BooleanFlagOn(Process->JobStatus, ACCOUNTING_FOLDED))
+        if (!FlagOn(Process->JobStatus, ACCOUNTING_FOLDED))
         {
             KeQueryValuesProcess(&Process->Pcb, &Values);
 
@@ -1453,7 +1380,7 @@ PspQueryBasicAccountingInfo(
  */
 static
 NTSTATUS
-PspQueryLimitInformation(
+PspQueryJobLimitInformation(
     _In_ PEJOB Job,
     _In_ BOOLEAN Extended,
     _Out_ PJOBOBJECT_EXTENDED_LIMIT_INFORMATION ExtendedLimit
@@ -1526,7 +1453,7 @@ PspQueryJobProcessIdListCallback(
     PPSP_QUERY_JOB_PROCESS_ID_CONTEXT QueryContext = (PPSP_QUERY_JOB_PROCESS_ID_CONTEXT)Context;
 
     /* Skip processes that are not really active */
-    if (BooleanFlagOn(Process->JobStatus, JOB_NOT_REALLY_ACTIVE))
+    if (FlagOn(Process->JobStatus, JOB_NOT_REALLY_ACTIVE))
     {
         /* Continue to the next process */
         return STATUS_SUCCESS;
@@ -2273,14 +2200,14 @@ NtQueryInformationJobObject(
     case JobObjectBasicAccountingInformation:
     case JobObjectBasicAndIoAccountingInformation:
     {
-        Status = PspQueryBasicAccountingInfo(Job, &BasicAndIo);
+        Status = PspQueryJobBasicAccountingInfo(Job, &BasicAndIo);
         JobInfoBuffer = &BasicAndIo;
         break;
     }
     case JobObjectBasicLimitInformation:
     case JobObjectExtendedLimitInformation:
     {
-        Status = PspQueryLimitInformation(Job,
+        Status = PspQueryJobLimitInformation(Job,
                                           (JobInformationClass == JobObjectExtendedLimitInformation),
                                           &ExtendedLimit);
         JobInfoBuffer = &ExtendedLimit;

--- a/ntoskrnl/ps/kill.c
+++ b/ntoskrnl/ps/kill.c
@@ -1127,7 +1127,7 @@ PspExitProcess(IN BOOLEAN LastThread,
             /* Check if we are part of a Job that has a completion port
                and do I/O completion if needed */
             if (Process->Job->CompletionPort &&
-                !BooleanFlagOn(Process->JobStatus, JOB_NOT_REALLY_ACTIVE))
+                !FlagOn(Process->JobStatus, JOB_NOT_REALLY_ACTIVE))
             {
                 (VOID)PspSendJobMessageLocked(Process->Job,
                                               JOB_OBJECT_MSG_EXIT_PROCESS,

--- a/ntoskrnl/ps/kill.c
+++ b/ntoskrnl/ps/kill.c
@@ -282,7 +282,7 @@ PspDeleteProcess(IN PVOID ObjectBody)
     if (Process->Job)
     {
         /* Remove the process from the job */
-        PspRemoveProcessFromJob(Process, Process->Job);
+        PspRemoveProcessFromJob(Process);
 
         /* Dereference it */
         ObDereferenceObject(Process->Job);
@@ -849,7 +849,7 @@ PspExitThread(IN NTSTATUS ExitStatus)
         if (CurrentProcess->Job)
         {
             /* Remove the process from the job */
-            PspExitProcessFromJob(CurrentProcess->Job, CurrentProcess);
+            PspExitProcessFromJob(CurrentProcess);
         }
     }
 
@@ -1120,20 +1120,20 @@ PspExitProcess(IN BOOLEAN LastThread,
             ZwSetTimerResolution(KeMaximumIncrement, 0, &Actual);
         }
 
-        /* Check if we are part of a Job that has a completion port
-           and do I/O completion if needed */
-        if (Process->Job &&
-            Process->Job->CompletionPort &&
-            !(Process->JobStatus & JOB_NOT_REALLY_ACTIVE))
+        if (Process->Job)
         {
-            ExEnterCriticalRegionAndAcquireResourceShared(&Process->Job->JobLock);
+            ExEnterCriticalRegionAndAcquireResourceExclusive(&Process->Job->JobLock);
 
-            IoSetIoCompletion(Process->Job->CompletionPort,
-                              Process->Job->CompletionKey,
-                              Process->UniqueProcessId,
-                              STATUS_SUCCESS,
-                              JOB_OBJECT_MSG_EXIT_PROCESS,
-                              FALSE);
+            /* Check if we are part of a Job that has a completion port
+               and do I/O completion if needed */
+            if (Process->Job->CompletionPort &&
+                !(Process->JobStatus & JOB_NOT_REALLY_ACTIVE))
+            {
+                (VOID)PspSendJobMessageLocked(Process->Job,
+                                              JOB_OBJECT_MSG_EXIT_PROCESS,
+                                              Process->UniqueProcessId,
+                                              FALSE);
+            }
 
             ExReleaseResourceAndLeaveCriticalRegion(&Process->Job->JobLock);
         }

--- a/ntoskrnl/ps/kill.c
+++ b/ntoskrnl/ps/kill.c
@@ -1127,7 +1127,7 @@ PspExitProcess(IN BOOLEAN LastThread,
             /* Check if we are part of a Job that has a completion port
                and do I/O completion if needed */
             if (Process->Job->CompletionPort &&
-                !(Process->JobStatus & JOB_NOT_REALLY_ACTIVE))
+                !BooleanFlagOn(Process->JobStatus, JOB_NOT_REALLY_ACTIVE))
             {
                 (VOID)PspSendJobMessageLocked(Process->Job,
                                               JOB_OBJECT_MSG_EXIT_PROCESS,

--- a/ntoskrnl/ps/kill.c
+++ b/ntoskrnl/ps/kill.c
@@ -1124,10 +1124,10 @@ PspExitProcess(IN BOOLEAN LastThread,
         {
             ExEnterCriticalRegionAndAcquireResourceExclusive(&Process->Job->JobLock);
 
-            /* Check if we are part of a Job that has a completion port
+            /* Check if we are part of a job that has a completion port
                and do I/O completion if needed */
             if (Process->Job->CompletionPort &&
-                !FlagOn(Process->JobStatus, JOB_NOT_REALLY_ACTIVE))
+                !FlagOn(Process->JobStatus, PSP_JOB_NOT_REALLY_ACTIVE))
             {
                 (VOID)PspSendJobMessageLocked(Process->Job,
                                               JOB_OBJECT_MSG_EXIT_PROCESS,

--- a/ntoskrnl/ps/process.c
+++ b/ntoskrnl/ps/process.c
@@ -722,15 +722,15 @@ PspCreateProcess(OUT PHANDLE ProcessHandle,
      *  c) parent's job does NOT allow silent breakaway
      */
     if (Parent && Parent->Job &&
-        !(Parent->Job->LimitFlags & JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK))
+        !BooleanFlagOn(Parent->Job->LimitFlags, JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK))
     {
         ParentJob = Parent->Job;
 
         /* If caller explicitly requested breakaway from the job */
-        if (Flags & PROCESS_CREATE_FLAGS_BREAKAWAY)
+        if (BooleanFlagOn(Flags, PROCESS_CREATE_FLAGS_BREAKAWAY))
         {
             /* Deny if the job forbids breakaway */
-            if (!(ParentJob->LimitFlags & JOB_OBJECT_LIMIT_BREAKAWAY_OK))
+            if (!BooleanFlagOn(ParentJob->LimitFlags, JOB_OBJECT_LIMIT_BREAKAWAY_OK))
             {
                 Status = STATUS_ACCESS_DENIED;
                 goto CleanupWithRef;

--- a/ntoskrnl/ps/process.c
+++ b/ntoskrnl/ps/process.c
@@ -722,15 +722,15 @@ PspCreateProcess(OUT PHANDLE ProcessHandle,
      *  c) parent's job does NOT allow silent breakaway
      */
     if (Parent && Parent->Job &&
-        !BooleanFlagOn(Parent->Job->LimitFlags, JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK))
+        !FlagOn(Parent->Job->LimitFlags, JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK))
     {
         ParentJob = Parent->Job;
 
         /* If caller explicitly requested breakaway from the job */
-        if (BooleanFlagOn(Flags, PROCESS_CREATE_FLAGS_BREAKAWAY))
+        if (FlagOn(Flags, PROCESS_CREATE_FLAGS_BREAKAWAY))
         {
             /* Deny if the job forbids breakaway */
-            if (!BooleanFlagOn(ParentJob->LimitFlags, JOB_OBJECT_LIMIT_BREAKAWAY_OK))
+            if (!FlagOn(ParentJob->LimitFlags, JOB_OBJECT_LIMIT_BREAKAWAY_OK))
             {
                 Status = STATUS_ACCESS_DENIED;
                 goto CleanupWithRef;

--- a/ntoskrnl/ps/process.c
+++ b/ntoskrnl/ps/process.c
@@ -442,6 +442,9 @@ PspCreateProcess(OUT PHANDLE ProcessHandle,
     /* Setup the Thread List Head */
     InitializeListHead(&Process->ThreadListHead);
 
+    /* Initialize the job process list entry */
+    InitializeListHead(&Process->JobLinks);
+
     /* Set up the Quota Block from the Parent */
     PspInheritQuota(Process, Parent);
 
@@ -736,16 +739,9 @@ PspCreateProcess(OUT PHANDLE ProcessHandle,
         else
         {
             /* Under normal conditions, child should join a parent's job */
-
-            ObReferenceObject(ParentJob);
-
-            Process->Job = ParentJob;
-
             Status = PspAssignProcessToJob(Process, ParentJob);
             if (!NT_SUCCESS(Status))
             {
-                ObDereferenceObject(ParentJob);
-                Process->Job = NULL;
                 goto CleanupWithRef;
             }
         }

--- a/ntoskrnl/ps/process.c
+++ b/ntoskrnl/ps/process.c
@@ -376,7 +376,6 @@ PspCreateProcess(OUT PHANDLE ProcessHandle,
     SECURITY_SUBJECT_CONTEXT SubjectContext;
     BOOLEAN NeedsPeb = FALSE;
     INITIAL_PEB InitialPeb;
-    PEJOB ParentJob;
 
     PAGED_CODE();
 
@@ -719,12 +718,12 @@ PspCreateProcess(OUT PHANDLE ProcessHandle,
      * Attach the process to parent's job if:
      *  a) parent exists,
      *  b) parent has a job,
-     *  c) parent's job does NOT allow silent breakaway
+     *  c) parent's job does NOT allow silent breakaway.
      */
     if (Parent && Parent->Job &&
         !FlagOn(Parent->Job->LimitFlags, JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK))
     {
-        ParentJob = Parent->Job;
+        PEJOB ParentJob = Parent->Job;
 
         /* If caller explicitly requested breakaway from the job */
         if (FlagOn(Flags, PROCESS_CREATE_FLAGS_BREAKAWAY))

--- a/ntoskrnl/ps/psmgr.c
+++ b/ntoskrnl/ps/psmgr.c
@@ -434,6 +434,7 @@ PspInitPhase0(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
     ObjectTypeInitializer.GenericMapping = PspJobMapping;
     ObjectTypeInitializer.InvalidAttributes = 0;
     ObjectTypeInitializer.ValidAccessMask = JOB_OBJECT_ALL_ACCESS;
+    ObjectTypeInitializer.CloseProcedure = PspCloseJob;
     ObjectTypeInitializer.DeleteProcedure = PspDeleteJob;
     ObCreateObjectType(&Name, &ObjectTypeInitializer, NULL, &PsJobType);
 

--- a/sdk/include/ndk/pstypes.h
+++ b/sdk/include/ndk/pstypes.h
@@ -1004,6 +1004,74 @@ typedef struct _THREAD_BASIC_INFORMATION
 #ifndef NTOS_MODE_USER
 
 //
+// Job message flags
+//
+
+#define JOB_OBJECT_MSG_END_OF_JOB_TIME          1
+#define JOB_OBJECT_MSG_END_OF_PROCESS_TIME      2
+#define JOB_OBJECT_MSG_ACTIVE_PROCESS_LIMIT     3
+#define JOB_OBJECT_MSG_ACTIVE_PROCESS_ZERO      4
+#define JOB_OBJECT_MSG_NEW_PROCESS              6
+#define JOB_OBJECT_MSG_EXIT_PROCESS             7
+#define JOB_OBJECT_MSG_ABNORMAL_EXIT_PROCESS    8
+#define JOB_OBJECT_MSG_PROCESS_MEMORY_LIMIT     9
+#define JOB_OBJECT_MSG_JOB_MEMORY_LIMIT         10
+#define JOB_OBJECT_MSG_NOTIFICATION_LIMIT       11
+#define JOB_OBJECT_MSG_JOB_CYCLE_TIME_LIMIT     12
+
+//
+// Job Information Structures for NtQuery/SetInformationJobObject
+//
+
+typedef struct _JOBOBJECT_BASIC_ACCOUNTING_INFORMATION
+{
+    LARGE_INTEGER TotalUserTime;
+    LARGE_INTEGER TotalKernelTime;
+    LARGE_INTEGER ThisPeriodTotalUserTime;
+    LARGE_INTEGER ThisPeriodTotalKernelTime;
+    ULONG TotalPageFaultCount;
+    ULONG TotalProcesses;
+    ULONG ActiveProcesses;
+    ULONG TotalTerminatedProcesses;
+} JOBOBJECT_BASIC_ACCOUNTING_INFORMATION, *PJOBOBJECT_BASIC_ACCOUNTING_INFORMATION;
+
+typedef struct _JOBOBJECT_BASIC_LIMIT_INFORMATION
+{
+    LARGE_INTEGER PerProcessUserTimeLimit;
+    LARGE_INTEGER PerJobUserTimeLimit;
+    ULONG LimitFlags;
+    SIZE_T MinimumWorkingSetSize;
+    SIZE_T MaximumWorkingSetSize;
+    ULONG ActiveProcessLimit;
+    ULONG_PTR Affinity;
+    ULONG PriorityClass;
+    ULONG SchedulingClass;
+} JOBOBJECT_BASIC_LIMIT_INFORMATION, *PJOBOBJECT_BASIC_LIMIT_INFORMATION;
+
+typedef struct _JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+{
+    JOBOBJECT_BASIC_LIMIT_INFORMATION BasicLimitInformation;
+    IO_COUNTERS IoInfo;
+    SIZE_T ProcessMemoryLimit;
+    SIZE_T JobMemoryLimit;
+    SIZE_T PeakProcessMemoryUsed;
+    SIZE_T PeakJobMemoryUsed;
+} JOBOBJECT_EXTENDED_LIMIT_INFORMATION, *PJOBOBJECT_EXTENDED_LIMIT_INFORMATION;
+
+typedef struct _JOBOBJECT_BASIC_PROCESS_ID_LIST
+{
+    ULONG NumberOfAssignedProcesses;
+    ULONG NumberOfProcessIdsInList;
+    ULONG_PTR ProcessIdList[1];
+} JOBOBJECT_BASIC_PROCESS_ID_LIST, *PJOBOBJECT_BASIC_PROCESS_ID_LIST;
+
+typedef struct _JOBOBJECT_ASSOCIATE_COMPLETION_PORT
+{
+    PVOID CompletionKey;
+    HANDLE CompletionPort;
+} JOBOBJECT_ASSOCIATE_COMPLETION_PORT, *PJOBOBJECT_ASSOCIATE_COMPLETION_PORT;
+
+//
 // Job Set Array
 //
 typedef struct _JOB_SET_ARRAY

--- a/sdk/include/ndk/pstypes.h
+++ b/sdk/include/ndk/pstypes.h
@@ -207,14 +207,6 @@ extern POBJECT_TYPE NTSYSAPI PsJobType;
                                                  31)
 
 //
-// Job Flags
-//
-// More information:
-// https://www.geoffchappell.com/studies/windows/km/ntoskrnl/inc/ntos/ps/ejob/jobflags.htm
-//
-#define JOB_OBJECT_CLOSE_DONE                   0x1
-
-//
 // Job Limit Flags
 //
 #define JOB_OBJECT_LIMIT_WORKINGSET             0x1

--- a/sdk/include/ndk/pstypes.h
+++ b/sdk/include/ndk/pstypes.h
@@ -207,6 +207,14 @@ extern POBJECT_TYPE NTSYSAPI PsJobType;
                                                  31)
 
 //
+// Job Flags
+//
+// More information:
+// https://www.geoffchappell.com/studies/windows/km/ntoskrnl/inc/ntos/ps/ejob/jobflags.htm
+//
+#define JOB_OBJECT_CLOSE_DONE                   0x1
+
+//
 // Job Limit Flags
 //
 #define JOB_OBJECT_LIMIT_WORKINGSET             0x1

--- a/sdk/include/ndk/pstypes.h
+++ b/sdk/include/ndk/pstypes.h
@@ -233,6 +233,22 @@ extern POBJECT_TYPE NTSYSAPI PsJobType;
 #define JOB_OBJECT_SECURITY_FILTER_TOKENS       0x0008
 
 //
+// Job message flags
+//
+
+#define JOB_OBJECT_MSG_END_OF_JOB_TIME          1
+#define JOB_OBJECT_MSG_END_OF_PROCESS_TIME      2
+#define JOB_OBJECT_MSG_ACTIVE_PROCESS_LIMIT     3
+#define JOB_OBJECT_MSG_ACTIVE_PROCESS_ZERO      4
+#define JOB_OBJECT_MSG_NEW_PROCESS              6
+#define JOB_OBJECT_MSG_EXIT_PROCESS             7
+#define JOB_OBJECT_MSG_ABNORMAL_EXIT_PROCESS    8
+#define JOB_OBJECT_MSG_PROCESS_MEMORY_LIMIT     9
+#define JOB_OBJECT_MSG_JOB_MEMORY_LIMIT         10
+#define JOB_OBJECT_MSG_NOTIFICATION_LIMIT       11
+#define JOB_OBJECT_MSG_JOB_CYCLE_TIME_LIMIT     12
+
+//
 // Cross Thread Flags
 //
 #define CT_TERMINATED_BIT                       0x1
@@ -1002,74 +1018,6 @@ typedef struct _THREAD_BASIC_INFORMATION
 } THREAD_BASIC_INFORMATION, *PTHREAD_BASIC_INFORMATION;
 
 #ifndef NTOS_MODE_USER
-
-//
-// Job message flags
-//
-
-#define JOB_OBJECT_MSG_END_OF_JOB_TIME          1
-#define JOB_OBJECT_MSG_END_OF_PROCESS_TIME      2
-#define JOB_OBJECT_MSG_ACTIVE_PROCESS_LIMIT     3
-#define JOB_OBJECT_MSG_ACTIVE_PROCESS_ZERO      4
-#define JOB_OBJECT_MSG_NEW_PROCESS              6
-#define JOB_OBJECT_MSG_EXIT_PROCESS             7
-#define JOB_OBJECT_MSG_ABNORMAL_EXIT_PROCESS    8
-#define JOB_OBJECT_MSG_PROCESS_MEMORY_LIMIT     9
-#define JOB_OBJECT_MSG_JOB_MEMORY_LIMIT         10
-#define JOB_OBJECT_MSG_NOTIFICATION_LIMIT       11
-#define JOB_OBJECT_MSG_JOB_CYCLE_TIME_LIMIT     12
-
-//
-// Job Information Structures for NtQuery/SetInformationJobObject
-//
-
-typedef struct _JOBOBJECT_BASIC_ACCOUNTING_INFORMATION
-{
-    LARGE_INTEGER TotalUserTime;
-    LARGE_INTEGER TotalKernelTime;
-    LARGE_INTEGER ThisPeriodTotalUserTime;
-    LARGE_INTEGER ThisPeriodTotalKernelTime;
-    ULONG TotalPageFaultCount;
-    ULONG TotalProcesses;
-    ULONG ActiveProcesses;
-    ULONG TotalTerminatedProcesses;
-} JOBOBJECT_BASIC_ACCOUNTING_INFORMATION, *PJOBOBJECT_BASIC_ACCOUNTING_INFORMATION;
-
-typedef struct _JOBOBJECT_BASIC_LIMIT_INFORMATION
-{
-    LARGE_INTEGER PerProcessUserTimeLimit;
-    LARGE_INTEGER PerJobUserTimeLimit;
-    ULONG LimitFlags;
-    SIZE_T MinimumWorkingSetSize;
-    SIZE_T MaximumWorkingSetSize;
-    ULONG ActiveProcessLimit;
-    ULONG_PTR Affinity;
-    ULONG PriorityClass;
-    ULONG SchedulingClass;
-} JOBOBJECT_BASIC_LIMIT_INFORMATION, *PJOBOBJECT_BASIC_LIMIT_INFORMATION;
-
-typedef struct _JOBOBJECT_EXTENDED_LIMIT_INFORMATION
-{
-    JOBOBJECT_BASIC_LIMIT_INFORMATION BasicLimitInformation;
-    IO_COUNTERS IoInfo;
-    SIZE_T ProcessMemoryLimit;
-    SIZE_T JobMemoryLimit;
-    SIZE_T PeakProcessMemoryUsed;
-    SIZE_T PeakJobMemoryUsed;
-} JOBOBJECT_EXTENDED_LIMIT_INFORMATION, *PJOBOBJECT_EXTENDED_LIMIT_INFORMATION;
-
-typedef struct _JOBOBJECT_BASIC_PROCESS_ID_LIST
-{
-    ULONG NumberOfAssignedProcesses;
-    ULONG NumberOfProcessIdsInList;
-    ULONG_PTR ProcessIdList[1];
-} JOBOBJECT_BASIC_PROCESS_ID_LIST, *PJOBOBJECT_BASIC_PROCESS_ID_LIST;
-
-typedef struct _JOBOBJECT_ASSOCIATE_COMPLETION_PORT
-{
-    PVOID CompletionKey;
-    HANDLE CompletionPort;
-} JOBOBJECT_ASSOCIATE_COMPLETION_PORT, *PJOBOBJECT_ASSOCIATE_COMPLETION_PORT;
 
 //
 // Job Set Array

--- a/sdk/include/ndk/pstypes.h
+++ b/sdk/include/ndk/pstypes.h
@@ -235,7 +235,6 @@ extern POBJECT_TYPE NTSYSAPI PsJobType;
 //
 // Job message flags
 //
-
 #define JOB_OBJECT_MSG_END_OF_JOB_TIME          1
 #define JOB_OBJECT_MSG_END_OF_PROCESS_TIME      2
 #define JOB_OBJECT_MSG_ACTIVE_PROCESS_LIMIT     3

--- a/sdk/include/ndk/pstypes.h
+++ b/sdk/include/ndk/pstypes.h
@@ -233,7 +233,7 @@ extern POBJECT_TYPE NTSYSAPI PsJobType;
 #define JOB_OBJECT_SECURITY_FILTER_TOKENS       0x0008
 
 //
-// Job message flags
+// Job Messages
 //
 #define JOB_OBJECT_MSG_END_OF_JOB_TIME          1
 #define JOB_OBJECT_MSG_END_OF_PROCESS_TIME      2


### PR DESCRIPTION
## Abstract

Jobs are kernel objects that allow processes to be grouped and manipulated as a single entity (for example, in order to apply constraints to them and the threads they contain). If a process is in a job, then all processes’ threads that those processes create will also be in the job, with no escape.

## Background

This PR supersedes the old WIP PR #40 by  Mark Jansen and is partially based on it (which in turn was based on the patch by Samuel Serapión Vega). Moreover, the implementation of `JobObjectBasicLimitInformation` and `JobObjectExtendedLimitInformation` limits in `NtSetInformationJobObject()` is based on  Timo Kreuzer's patch.

This PR adds basic support for pre-Windows 8 job objects to the kernel. It adapts the previous patch part-by-part, gradually adding to its unfinished parts as well fixing some things (like handling job status flags or fixing input validation) because the patch did not produce satisfactory results when running WINE tests, and adds more functionality on top of it. 

This is not the final version of what functional job support should look like; some features are intentionally left untouched in this PR.

## Current status

- Creating a job object (`NtCreateJobObject`)
- Opening a job object (`NtOpenJobObject`)
- Adding a process to a job (`NtAssignProcessToJobObject`, `PspAssignProcessToJob`)
- Removing a process from a job (`PspRemoveProcessFromJob`)
- Exiting a process from a job (`PspExitProcessFromJob`)
- Checking if a process is in the job (`NtIsProcessInJob`)
- Terminating processes in a job (`NtTerminateJobObject`, `PspTerminateJobObject`)
- Enumeration of processes in a job (`PspEnumerateProcessesInJob`)
- Closing a job object (`PspCloseJob`)
- Deleting a job object (`PspDeleteJob`)
- Querying job object information (`NtQueryInformationJobObject`)
  - `JobObjectBasicAccountingInformation`, `JobObjectBasicAndIoAccountingInformation`, `JobObjectBasicLimitInformation`, `JobObjectExtendedLimitInformation`, `JobObjectBasicProcessIdList`
- Setting job object information (`NtSetInformationJobObject`)
  - `JobObjectBasicLimitInformation`, `JobObjectExtendedLimitInformation`, `JobObjectAssociateCompletionPortInformation`

Job-related tests from the WINE kernel32 test suite:

<details>
  <summary>Before (60 failures):</summary>

  ![kernel32_winetest process - before](https://imgur.com/A6ulmtm.jpg)
</details>

<details>
  <summary>After (0 failures):</summary>

  ![kernel32_winetest process - after](https://i.imgur.com/yQkbOB2.png)
</details>

## TODO

Plans for future commits/PRs:
- Add support for job limits (support more job information classes in `NtQueryInformationJobObject`/`NtSetInformationJobObject`).
- Add support for job sets.
- Figure out and support more job/job status flags.
- 100% pass rate of job related tests in the WINE kernel32 test suite. This implies:
  - [x] Support for associating a completion port with a job.
  - [x] Fixing breakaway scenarios.

KVM: https://reactos.org/testman/compare.php?ids=109446,109453,109454
KVM_x64: https://reactos.org/testman/compare.php?ids=109508,109510,109513