### PR TITLE
[EXPLORER] Check registry key for default shell

### DIFF
--- a/base/shell/explorer/explorer.cpp
+++ b/base/shell/explorer/explorer.cpp
@@ -107,25 +107,19 @@ IsExplorerSystemShell()
     }
     else
     {
-        DWORD cbShell;
         LSTATUS Status;
+        DWORD dwType;
+        WCHAR szShell[MAX_PATH];
+        DWORD cbShell = sizeof(szShell);
 
-        // Get length of the "Shell" key
-        Status = RegQueryValueExW(hKeyWinlogon, L"Shell", 0, NULL, NULL, &cbShell);
+        // TODO: Add support for paths longer than MAX_PATH
+        Status = RegQueryValueExW(hKeyWinlogon, L"Shell", 0, &dwType, (LPBYTE)szShell, &cbShell);
         if (Status == ERROR_SUCCESS)
         {
-            DWORD dwType;
-            WCHAR szShell[MAX_PATH];
-
-            // TODO: Add support for paths longer than MAX_PATH
-            Status = RegQueryValueExW(hKeyWinlogon, L"Shell", 0, &dwType, (LPBYTE)szShell, &cbShell);
-            if (Status == ERROR_SUCCESS)
-            {
-                if ((dwType == REG_SZ || dwType == REG_EXPAND_SZ) && StrStrI(szShell, szExplorer))
-                    bIsSystemShell = TRUE;
-                else
-                    bIsSystemShell = FALSE;
-            }
+            if ((dwType == REG_SZ || dwType == REG_EXPAND_SZ) && StrStrI(szShell, szExplorer))
+                bIsSystemShell = TRUE;
+            else
+                bIsSystemShell = FALSE;
         }
 
         RegCloseKey(hKeyWinlogon);

--- a/base/shell/explorer/explorer.cpp
+++ b/base/shell/explorer/explorer.cpp
@@ -101,7 +101,7 @@ IsExplorerSystemShell()
     if (!GetModuleFileName(NULL, szPath, MAX_PATH))
         return FALSE;
 
-    szExplorer = PathFindFileName((LPWSTR)szPath);
+    szExplorer = PathFindFileNameW(szPath);
 
     if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, L"Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon",
         0, KEY_READ, &hKeyWinlogon) != ERROR_SUCCESS)

--- a/base/shell/explorer/explorer.cpp
+++ b/base/shell/explorer/explorer.cpp
@@ -116,11 +116,10 @@ IsExplorerSystemShell()
 
         if (Status == ERROR_SUCCESS)
         {
-            LPWSTR szShell;
+            WCHAR szShell[MAX_PATH];
             DWORD dwType;
 
-            szShell = new WCHAR[cbShell / sizeof(WCHAR)];
-
+            // TODO: Add support for paths longer than MAX_PATH
             Status = RegQueryValueExW(hKeyWinlogon, L"Shell", 0, &dwType, (LPBYTE)szShell, &cbShell);
 
             if (Status == ERROR_SUCCESS)
@@ -130,8 +129,6 @@ IsExplorerSystemShell()
                 else
                     bIsSystemShell = FALSE;
             }
-
-            delete[] szShell;
         }
 
         RegCloseKey(hKeyWinlogon);

--- a/base/shell/explorer/explorer.cpp
+++ b/base/shell/explorer/explorer.cpp
@@ -92,9 +92,17 @@ IsExplorerSystemShell()
 {
     HKEY hKeyWinlogon;
 	WCHAR szShell[256];
-    WCHAR szExplorer[] = L"explorer";
+	WCHAR szPath[MAX_PATH];
+    LPWSTR szExplorer = NULL;
 	DWORD dwType;
 	DWORD dwBufferSize = sizeof(szShell);
+
+    if (!GetModuleFileName(NULL, szPath, MAX_PATH))
+        return FALSE;
+
+    szExplorer = PathFindFileName((LPWSTR)szPath);
+
+    PathRemoveExtension(szExplorer);
 
 	if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, L"Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon",
 		0, KEY_READ, &hKeyWinlogon) != ERROR_SUCCESS)
@@ -113,7 +121,7 @@ IsExplorerSystemShell()
 		else
 			return FALSE;
 	}
-    
+
 	// Unable to query value.
 	return FALSE;
 }

--- a/base/shell/explorer/explorer.cpp
+++ b/base/shell/explorer/explorer.cpp
@@ -109,7 +109,7 @@ IsExplorerSystemShell()
     else
     {
         DWORD cbShell;
-        LSTATUS Status;
+        LSTATUS status;
 
         // Get length of the "Shell" key
         status = RegQueryValueExW(hKeyWinlogon, L"Shell", 0, NULL, NULL, &cbShell);

--- a/base/shell/explorer/explorer.cpp
+++ b/base/shell/explorer/explorer.cpp
@@ -90,18 +90,17 @@ HideMinimizedWindows(IN BOOL bHide)
 static BOOL
 IsExplorerSystemShell()
 {
-    HKEY hKeyWinlogon;
-    WCHAR szPath[MAX_PATH];
-    LPWSTR szExplorer;
     BOOL bIsSystemShell = TRUE; // Assume we are the system shell by default.
+    WCHAR szPath[MAX_PATH];
 
     if (!GetModuleFileNameW(NULL, szPath, _countof(szPath)))
         return FALSE;
 
-    szExplorer = PathFindFileNameW(szPath);
+    LPWSTR szExplorer = PathFindFileNameW(szPath);
 
+    HKEY hKeyWinlogon;
     if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, L"Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon",
-        0, KEY_READ, &hKeyWinlogon) != ERROR_SUCCESS)
+                      0, KEY_READ, &hKeyWinlogon) != ERROR_SUCCESS)
     {
         // No registry access.
         bIsSystemShell = TRUE;
@@ -113,15 +112,13 @@ IsExplorerSystemShell()
 
         // Get length of the "Shell" key
         Status = RegQueryValueExW(hKeyWinlogon, L"Shell", 0, NULL, NULL, &cbShell);
-
         if (Status == ERROR_SUCCESS)
         {
-            WCHAR szShell[MAX_PATH];
             DWORD dwType;
+            WCHAR szShell[MAX_PATH];
 
             // TODO: Add support for paths longer than MAX_PATH
             Status = RegQueryValueExW(hKeyWinlogon, L"Shell", 0, &dwType, (LPBYTE)szShell, &cbShell);
-
             if (Status == ERROR_SUCCESS)
             {
                 if ((dwType == REG_SZ || dwType == REG_EXPAND_SZ) && StrStrI(szShell, szExplorer))

--- a/base/shell/explorer/explorer.cpp
+++ b/base/shell/explorer/explorer.cpp
@@ -91,11 +91,8 @@ static BOOL
 IsExplorerSystemShell()
 {
     HKEY hKeyWinlogon;
-    WCHAR szShell[256];
     WCHAR szPath[MAX_PATH];
-    LPWSTR szExplorer = NULL;
-    DWORD dwType;
-    DWORD dwBufferSize = sizeof(szShell);
+    LPWSTR szExplorer;
     BOOL bIsSystemShell = TRUE; // Assume we are the system shell by default.
 
     if (!GetModuleFileName(NULL, szPath, MAX_PATH))
@@ -111,6 +108,10 @@ IsExplorerSystemShell()
     }
     else
     {
+        WCHAR szShell[256];
+        DWORD dwType;
+        DWORD dwBufferSize = sizeof(szShell);
+
         if (RegQueryValueEx(hKeyWinlogon, L"Shell", 0, &dwType,
             (LPBYTE)szShell, &dwBufferSize) == ERROR_SUCCESS)
         {

--- a/base/shell/explorer/explorer.cpp
+++ b/base/shell/explorer/explorer.cpp
@@ -96,7 +96,7 @@ IsExplorerSystemShell()
     LPWSTR szExplorer = NULL;
     DWORD dwType;
     DWORD dwBufferSize = sizeof(szShell);
-    BOOL bIsSystemShell = TRUE;
+    BOOL bIsSystemShell = TRUE; // Assume we are the system shell by default.
 
     if (!GetModuleFileName(NULL, szPath, MAX_PATH))
         return FALSE;

--- a/base/shell/explorer/explorer.cpp
+++ b/base/shell/explorer/explorer.cpp
@@ -91,11 +91,11 @@ static BOOL
 IsExplorerSystemShell()
 {
     HKEY hKeyWinlogon;
-	WCHAR szShell[256];
-	WCHAR szPath[MAX_PATH];
+    WCHAR szShell[256];
+    WCHAR szPath[MAX_PATH];
     LPWSTR szExplorer = NULL;
-	DWORD dwType;
-	DWORD dwBufferSize = sizeof(szShell);
+    DWORD dwType;
+    DWORD dwBufferSize = sizeof(szShell);
     BOOL bIsSystemShell = TRUE;
 
     if (!GetModuleFileName(NULL, szPath, MAX_PATH))
@@ -103,8 +103,8 @@ IsExplorerSystemShell()
 
     szExplorer = PathFindFileName((LPWSTR)szPath);
 
-	if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, L"Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon",
-		0, KEY_READ, &hKeyWinlogon) != ERROR_SUCCESS)
+    if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, L"Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon",
+        0, KEY_READ, &hKeyWinlogon) != ERROR_SUCCESS)
     {
         // No registry access.
         bIsSystemShell = TRUE;
@@ -123,7 +123,7 @@ IsExplorerSystemShell()
         RegCloseKey(hKeyWinlogon);
     }
 
-	return bIsSystemShell;
+    return bIsSystemShell;
 }
 
 #if !WIN7_COMPAT_MODE

--- a/base/shell/explorer/explorer.cpp
+++ b/base/shell/explorer/explorer.cpp
@@ -114,7 +114,7 @@ IsExplorerSystemShell()
 	{
 		RegCloseKey(hKeyWinlogon);
 
-		if (StrStr(szShell, szExplorer))
+		if (StrStrI(szShell, szExplorer))
 			return TRUE;
 		else
 			return FALSE;

--- a/base/shell/explorer/explorer.cpp
+++ b/base/shell/explorer/explorer.cpp
@@ -95,7 +95,7 @@ IsExplorerSystemShell()
     LPWSTR szExplorer;
     BOOL bIsSystemShell = TRUE; // Assume we are the system shell by default.
 
-    if (!GetModuleFileName(NULL, szPath, MAX_PATH))
+    if (!GetModuleFileNameW(NULL, szPath, _countof(szPath)))
         return FALSE;
 
     szExplorer = PathFindFileNameW(szPath);

--- a/base/shell/explorer/explorer.cpp
+++ b/base/shell/explorer/explorer.cpp
@@ -108,7 +108,7 @@ IsExplorerSystemShell()
 		0, KEY_READ, &hKeyWinlogon) != ERROR_SUCCESS)
     {
         // No registry access.
-        return FALSE;
+        return TRUE;
     }
 
     if (RegQueryValueEx(hKeyWinlogon, L"Shell", 0, &dwType,

--- a/base/shell/explorer/explorer.cpp
+++ b/base/shell/explorer/explorer.cpp
@@ -112,13 +112,13 @@ IsExplorerSystemShell()
     if (RegQueryValueEx(hKeyWinlogon, L"Shell", 0, &dwType,
 		(LPBYTE)szShell, &dwBufferSize) == ERROR_SUCCESS)
 	{
-		RegCloseKey(hKeyWinlogon);
-
 		if (StrStrI(szShell, szExplorer))
 			return TRUE;
 		else
 			return FALSE;
 	}
+
+    RegCloseKey(hKeyWinlogon);
 
 	// Unable to query value.
 	return FALSE;

--- a/base/shell/explorer/explorer.cpp
+++ b/base/shell/explorer/explorer.cpp
@@ -100,7 +100,7 @@ IsExplorerSystemShell()
 
     szExplorer = PathFindFileNameW(szPath);
 
-    if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, L"Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon",
+    if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, L"Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon",
         0, KEY_READ, &hKeyWinlogon) != ERROR_SUCCESS)
     {
         // No registry access.
@@ -112,7 +112,7 @@ IsExplorerSystemShell()
         DWORD dwType;
         DWORD dwBufferSize = sizeof(szShell);
 
-        if (RegQueryValueEx(hKeyWinlogon, L"Shell", 0, &dwType,
+        if (RegQueryValueExW(hKeyWinlogon, L"Shell", 0, &dwType,
             (LPBYTE)szShell, &dwBufferSize) == ERROR_SUCCESS)
         {
             if (StrStrI(szShell, szExplorer))

--- a/base/shell/explorer/explorer.cpp
+++ b/base/shell/explorer/explorer.cpp
@@ -102,8 +102,6 @@ IsExplorerSystemShell()
 
     szExplorer = PathFindFileName((LPWSTR)szPath);
 
-    PathRemoveExtension(szExplorer);
-
 	if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, L"Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon",
 		0, KEY_READ, &hKeyWinlogon) != ERROR_SUCCESS)
     {

--- a/base/shell/explorer/explorer.cpp
+++ b/base/shell/explorer/explorer.cpp
@@ -119,7 +119,7 @@ IsExplorerSystemShell()
             LPWSTR szShell;
             DWORD dwType;
 
-            szShell = (LPWSTR)malloc(cbShell);
+            szShell = new WCHAR[cbShell / sizeof(WCHAR)];
 
             status = RegQueryValueExW(hKeyWinlogon, L"Shell", 0, &dwType, (LPBYTE)szShell, &cbShell);
 
@@ -131,7 +131,7 @@ IsExplorerSystemShell()
                     bIsSystemShell = FALSE;
             }
 
-            free(szShell);
+            delete[] szShell;
         }
 
         RegCloseKey(hKeyWinlogon);

--- a/base/shell/explorer/explorer.cpp
+++ b/base/shell/explorer/explorer.cpp
@@ -115,7 +115,7 @@ IsExplorerSystemShell()
         if (RegQueryValueExW(hKeyWinlogon, L"Shell", 0, &dwType,
             (LPBYTE)szShell, &dwBufferSize) == ERROR_SUCCESS)
         {
-            if (StrStrI(szShell, szExplorer))
+            if ((dwType == REG_SZ || dwType == REG_EXPAND_SZ) && StrStrI(szShell, szExplorer))
                 bIsSystemShell = TRUE;
             else
                 bIsSystemShell = FALSE;

--- a/base/shell/explorer/explorer.cpp
+++ b/base/shell/explorer/explorer.cpp
@@ -96,6 +96,7 @@ IsExplorerSystemShell()
     LPWSTR szExplorer = NULL;
 	DWORD dwType;
 	DWORD dwBufferSize = sizeof(szShell);
+    BOOL bIsSystemShell = TRUE;
 
     if (!GetModuleFileName(NULL, szPath, MAX_PATH))
         return FALSE;
@@ -106,22 +107,23 @@ IsExplorerSystemShell()
 		0, KEY_READ, &hKeyWinlogon) != ERROR_SUCCESS)
     {
         // No registry access.
-        return TRUE;
+        bIsSystemShell = TRUE;
+    }
+    else
+    {
+        if (RegQueryValueEx(hKeyWinlogon, L"Shell", 0, &dwType,
+            (LPBYTE)szShell, &dwBufferSize) == ERROR_SUCCESS)
+        {
+            if (StrStrI(szShell, szExplorer))
+                bIsSystemShell = TRUE;
+            else
+                bIsSystemShell = FALSE;
+        }
+
+        RegCloseKey(hKeyWinlogon);
     }
 
-    if (RegQueryValueEx(hKeyWinlogon, L"Shell", 0, &dwType,
-		(LPBYTE)szShell, &dwBufferSize) == ERROR_SUCCESS)
-	{
-		if (StrStrI(szShell, szExplorer))
-			return TRUE;
-		else
-			return FALSE;
-	}
-
-    RegCloseKey(hKeyWinlogon);
-
-	// Unable to query value.
-	return TRUE;
+	return bIsSystemShell;
 }
 
 #if !WIN7_COMPAT_MODE

--- a/base/shell/explorer/explorer.cpp
+++ b/base/shell/explorer/explorer.cpp
@@ -109,7 +109,7 @@ IsExplorerSystemShell()
     else
     {
         DWORD cbShell;
-        LSTATUS status;
+        LSTATUS Status;
 
         // Get length of the "Shell" key
         status = RegQueryValueExW(hKeyWinlogon, L"Shell", 0, NULL, NULL, &cbShell);

--- a/base/shell/explorer/explorer.cpp
+++ b/base/shell/explorer/explorer.cpp
@@ -109,21 +109,21 @@ IsExplorerSystemShell()
     else
     {
         DWORD cbShell;
-        LSTATUS status;
+        LSTATUS Status;
 
         // Get length of the "Shell" key
-        status = RegQueryValueExW(hKeyWinlogon, L"Shell", 0, NULL, NULL, &cbShell);
+        Status = RegQueryValueExW(hKeyWinlogon, L"Shell", 0, NULL, NULL, &cbShell);
 
-        if (status == ERROR_SUCCESS)
+        if (Status == ERROR_SUCCESS)
         {
             LPWSTR szShell;
             DWORD dwType;
 
             szShell = new WCHAR[cbShell / sizeof(WCHAR)];
 
-            status = RegQueryValueExW(hKeyWinlogon, L"Shell", 0, &dwType, (LPBYTE)szShell, &cbShell);
+            Status = RegQueryValueExW(hKeyWinlogon, L"Shell", 0, &dwType, (LPBYTE)szShell, &cbShell);
 
-            if (status == ERROR_SUCCESS)
+            if (Status == ERROR_SUCCESS)
             {
                 if ((dwType == REG_SZ || dwType == REG_EXPAND_SZ) && StrStrI(szShell, szExplorer))
                     bIsSystemShell = TRUE;

--- a/base/shell/explorer/explorer.cpp
+++ b/base/shell/explorer/explorer.cpp
@@ -108,17 +108,30 @@ IsExplorerSystemShell()
     }
     else
     {
-        WCHAR szShell[256];
-        DWORD dwType;
-        DWORD dwBufferSize = sizeof(szShell);
+        DWORD cbShell;
+        LSTATUS status;
 
-        if (RegQueryValueExW(hKeyWinlogon, L"Shell", 0, &dwType,
-            (LPBYTE)szShell, &dwBufferSize) == ERROR_SUCCESS)
+        // Get length of the "Shell" key
+        status = RegQueryValueExW(hKeyWinlogon, L"Shell", 0, NULL, NULL, &cbShell);
+
+        if (status == ERROR_SUCCESS)
         {
-            if ((dwType == REG_SZ || dwType == REG_EXPAND_SZ) && StrStrI(szShell, szExplorer))
-                bIsSystemShell = TRUE;
-            else
-                bIsSystemShell = FALSE;
+            LPWSTR szShell;
+            DWORD dwType;
+
+            szShell = (LPWSTR)malloc(cbShell);
+
+            status = RegQueryValueExW(hKeyWinlogon, L"Shell", 0, &dwType, (LPBYTE)szShell, &cbShell);
+
+            if (status == ERROR_SUCCESS)
+            {
+                if ((dwType == REG_SZ || dwType == REG_EXPAND_SZ) && StrStrI(szShell, szExplorer))
+                    bIsSystemShell = TRUE;
+                else
+                    bIsSystemShell = FALSE;
+            }
+
+            free(szShell);
         }
 
         RegCloseKey(hKeyWinlogon);

--- a/base/shell/explorer/explorer.cpp
+++ b/base/shell/explorer/explorer.cpp
@@ -121,7 +121,7 @@ IsExplorerSystemShell()
     RegCloseKey(hKeyWinlogon);
 
 	// Unable to query value.
-	return FALSE;
+	return TRUE;
 }
 
 #if !WIN7_COMPAT_MODE


### PR DESCRIPTION
## Purpose

Improved detection of Explorer being the default shell.

JIRA issue: [CORE-19887](https://jira.reactos.org/browse/CORE-19887)

## Proposed changes

_Describe what you propose to change/add/fix with this pull request._

- Check the "Software\Microsoft\Windows NT\CurrentVersion\Winlogon" key to see if Explorer is the default shell.
- Use this check to determine whether to start the desktop & taskbar or only open a file browser window.
