### PR TITLE
[NTUSER] Combo box outline fix after 515f998. CORE-19869.

### DIFF
--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -1221,28 +1221,31 @@ co_IntSetParent(PWND Wnd, PWND WndNewParent)
 
    if (WndOldParent) UserReferenceObject(WndOldParent); /* Caller must deref */
 
-   /* Even if WndNewParent == WndOldParent continue because the
-    * child window (Wnd) should be moved to the top of the z-order */
-
-   /* Unlink the window from the siblings list */
-   IntUnlinkWindow(Wnd);
-   Wnd->ExStyle2 &= ~WS_EX2_LINKED;
-
-   /* Set the new parent */
-   WndSetParent(Wnd, WndNewParent);
-
-   if (Wnd->style & WS_CHILD &&
-       Wnd->spwndOwner &&
-       Wnd->spwndOwner->ExStyle & WS_EX_TOPMOST)
+   if (!(WndNewParent->ExStyle & WS_EX_TOOLWINDOW))
    {
-      ERR("SetParent Top Most from Pop up\n");
-      Wnd->ExStyle |= WS_EX_TOPMOST;
-   }
+      /* Even if WndNewParent == WndOldParent continue because the
+       * child window (Wnd) should be moved to the top of the z-order */
 
-   /* Link the window with its new siblings */
-   IntLinkHwnd(Wnd,
-               ((0 == (Wnd->ExStyle & WS_EX_TOPMOST) &&
-               UserIsDesktopWindow(WndNewParent)) ? HWND_TOP : HWND_TOPMOST));
+      /* Unlink the window from the siblings list */
+      IntUnlinkWindow(Wnd);
+      Wnd->ExStyle2 &= ~WS_EX2_LINKED;
+
+      /* Set the new parent */
+      WndSetParent(Wnd, WndNewParent);
+
+      if (Wnd->style & WS_CHILD &&
+          Wnd->spwndOwner &&
+          Wnd->spwndOwner->ExStyle & WS_EX_TOPMOST)
+      {
+         ERR("SetParent Top Most from Pop up\n");
+         Wnd->ExStyle |= WS_EX_TOPMOST;
+      }
+
+      /* Link the window with its new siblings */
+      IntLinkHwnd(Wnd,
+                  ((0 == (Wnd->ExStyle & WS_EX_TOPMOST) &&
+                  UserIsDesktopWindow(WndNewParent)) ? HWND_TOP : HWND_TOPMOST));
+   }
 
    if ( WndNewParent == co_GetDesktopWindow(Wnd) &&
        !(Wnd->style & WS_CLIPSIBLINGS) )


### PR DESCRIPTION
## Purpose

_This fixes a regression caused by commit 515f998._

JIRA issue: [CORE-19869](https://jira.reactos.org/browse/CORE-19869)

## Proposed changes

_Fix changes to setting window new parent to require new parent's ExStyle not having WS_EX_TOOLWINDOW flag set._

Testbot Results of [wordpad-combo-fix-02.patch](https://jira.reactos.org/secure/attachment/69308/69308_wordpad-combo-fix-02.patch)
wordpad-combo-fix-02.patch JID69308 on 0.4.16-dev-258-g81860b4

KVM: https://reactos.org/testman/compare.php?ids=98742,98749 LGTM

Before:
![wordpad_pull-downs-bad](https://github.com/user-attachments/assets/5760b822-b233-47b0-9d96-b4937d2cf8cc)

After:
![wordpad_pull-downs-OK1](https://github.com/user-attachments/assets/781bf9ef-b6c2-4faa-9a0c-31b500eda18d)
