### PR TITLE
[NTOS:MM] MmPurgeSegment: Fix missing MmDereferenceSegment cleanup

### DIFF
--- a/ntoskrnl/mm/section.c
+++ b/ntoskrnl/mm/section.c
@@ -4838,18 +4838,18 @@ MmPurgeSegment(
     LARGE_INTEGER PurgeStart, PurgeEnd;
     PMM_SECTION_SEGMENT Segment;
 
-    Segment = MiGrabDataSection(SectionObjectPointer);
-    if (!Segment)
-    {
-        /* Nothing to purge */
-        return TRUE;
-    }
-
     PurgeStart.QuadPart = Offset ? Offset->QuadPart : 0LL;
     if (Length && Offset)
     {
         if (!NT_SUCCESS(RtlLongLongAdd(PurgeStart.QuadPart, Length, &PurgeEnd.QuadPart)))
             return FALSE;
+    }
+
+    Segment = MiGrabDataSection(SectionObjectPointer);
+    if (!Segment)
+    {
+        /* Nothing to purge */
+        return TRUE;
     }
 
     MmLockSectionSegment(Segment);


### PR DESCRIPTION
## Purpose
`MiGrabDataSection` adds a refcount. There is a missing `MmDereferenceSegment` cleanup in case of range check error.

## Proposed changes
Move `MiGrabDataSection` calling code to after range check.