### PR TITLE
[NTOS:MM][NTOS:CC] Rewrite some cache memory management functions

### DIFF
--- a/ntoskrnl/cc/copy.c
+++ b/ntoskrnl/cc/copy.c
@@ -653,7 +653,9 @@ CcCopyWrite (
             CurrentOffset += VacbLength;
 
             /* Tell Mm */
-            Status = MmMakePagesDirty(NULL, Add2Ptr(Vacb->BaseAddress, VacbOffset), VacbLength);
+            Status = MmMakeSegmentDirty(FileObject->SectionObjectPointer,
+                                        Vacb->FileOffset.QuadPart + VacbOffset,
+                                        VacbLength);
             if (!NT_SUCCESS(Status))
                 ExRaiseStatus(Status);
         }
@@ -913,7 +915,9 @@ CcZeroData (
             Length -= VacbLength;
 
             /* Tell Mm */
-            Status = MmMakePagesDirty(NULL, Add2Ptr(Vacb->BaseAddress, VacbOffset), VacbLength);
+            Status = MmMakeSegmentDirty(FileObject->SectionObjectPointer,
+                                        Vacb->FileOffset.QuadPart + VacbOffset,
+                                        VacbLength);
             if (!NT_SUCCESS(Status))
                 ExRaiseStatus(Status);
         }

--- a/ntoskrnl/cc/pin.c
+++ b/ntoskrnl/cc/pin.c
@@ -551,17 +551,18 @@ CcSetDirtyPinnedData (
     IN PLARGE_INTEGER Lsn)
 {
     PINTERNAL_BCB iBcb = CONTAINING_RECORD(Bcb, INTERNAL_BCB, PFCB);
+    PROS_VACB Vacb = iBcb->Vacb;
 
     CCTRACE(CC_API_DEBUG, "Bcb=%p Lsn=%p\n", Bcb, Lsn);
 
     /* Tell Mm */
-    MmMakePagesDirty(NULL,
-                     Add2Ptr(iBcb->Vacb->BaseAddress, iBcb->PFCB.MappedFileOffset.QuadPart - iBcb->Vacb->FileOffset.QuadPart),
-                     iBcb->PFCB.MappedLength);
+    MmMakeSegmentDirty(Vacb->SharedCacheMap->FileObject->SectionObjectPointer,
+                       iBcb->PFCB.MappedFileOffset.QuadPart,
+                       iBcb->PFCB.MappedLength);
 
-    if (!iBcb->Vacb->Dirty)
+    if (!Vacb->Dirty)
     {
-        CcRosMarkDirtyVacb(iBcb->Vacb);
+        CcRosMarkDirtyVacb(Vacb);
     }
 }
 

--- a/ntoskrnl/cc/view.c
+++ b/ntoskrnl/cc/view.c
@@ -936,22 +936,22 @@ CcRosEnsureVacbResident(
     _In_ ULONG Length
 )
 {
-    PVOID BaseAddress;
+    PROS_SHARED_CACHE_MAP SharedCacheMap = Vacb->SharedCacheMap;
 
     ASSERT((Offset + Length) <= VACB_MAPPING_GRANULARITY);
 
 #if 0
-    if ((Vacb->FileOffset.QuadPart + Offset) > Vacb->SharedCacheMap->SectionSize.QuadPart)
+    if ((Vacb->FileOffset.QuadPart + Offset) > SharedCacheMap->SectionSize.QuadPart)
     {
         DPRINT1("Vacb read beyond the file size!\n");
         return FALSE;
     }
 #endif
 
-    BaseAddress = (PVOID)((ULONG_PTR)Vacb->BaseAddress + Offset);
-
     /* Check if the pages are resident */
-    if (!MmArePagesResident(NULL, BaseAddress, Length))
+    if (!MmIsDataSectionResident(SharedCacheMap->FileObject->SectionObjectPointer,
+                                 Vacb->FileOffset.QuadPart + Offset,
+                                 Length))
     {
         if (!Wait)
         {
@@ -960,7 +960,6 @@ CcRosEnsureVacbResident(
 
         if (!NoRead)
         {
-            PROS_SHARED_CACHE_MAP SharedCacheMap = Vacb->SharedCacheMap;
             NTSTATUS Status = MmMakeDataSectionResident(SharedCacheMap->FileObject->SectionObjectPointer,
                                                         Vacb->FileOffset.QuadPart + Offset,
                                                         Length,

--- a/ntoskrnl/include/internal/mm.h
+++ b/ntoskrnl/include/internal/mm.h
@@ -1509,9 +1509,9 @@ MmIsDataSectionResident(
 
 NTSTATUS
 NTAPI
-MmMakePagesDirty(
-    _In_ PEPROCESS Process,
-    _In_ PVOID Address,
+MmMakeSegmentDirty(
+    _In_ PSECTION_OBJECT_POINTERS SectionObjectPointer,
+    _In_ LONGLONG Offset,
     _In_ ULONG Length);
 
 NTSTATUS

--- a/ntoskrnl/include/internal/mm.h
+++ b/ntoskrnl/include/internal/mm.h
@@ -1502,9 +1502,9 @@ MmMapViewInSystemSpaceEx(
 
 BOOLEAN
 NTAPI
-MmArePagesResident(
-    _In_ PEPROCESS Process,
-    _In_ PVOID BaseAddress,
+MmIsDataSectionResident(
+    _In_ PSECTION_OBJECT_POINTERS SectionObjectPointer,
+    _In_ LONGLONG Offset,
     _In_ ULONG Length);
 
 NTSTATUS

--- a/ntoskrnl/mm/section.c
+++ b/ntoskrnl/mm/section.c
@@ -5093,8 +5093,8 @@ MmFlushSegment(
         FlushEnd.QuadPart = PageTable->FileOffset.QuadPart + _countof(PageTable->PageEntries) * PAGE_SIZE;
     }
 
-    FlushStart.QuadPart >>= PAGE_SHIFT;
-    FlushStart.QuadPart <<= PAGE_SHIFT;
+    /* Find byte offset of the page to start */
+    FlushStart.QuadPart = PAGE_ROUND_DOWN(FlushStart.QuadPart);
 
     while (FlushStart.QuadPart < FlushEnd.QuadPart)
     {

--- a/ntoskrnl/mm/section.c
+++ b/ntoskrnl/mm/section.c
@@ -4775,7 +4775,8 @@ MmCreateSection (OUT PVOID  * Section,
     return Status;
 }
 
-/* This function is not used. It is left for reference only */
+/* This function is not used. It is left for future use, when per-process
+ * address space is considered. */
 #if 0
 BOOLEAN
 NTAPI
@@ -5302,7 +5303,8 @@ MmCheckDirtySegment(
     return FALSE;
 }
 
-/* This function is not used. It is left for reference only */
+/* This function is not used. It is left for future use, when per-process
+ * address space is considered. */
 #if 0
 NTSTATUS
 NTAPI

--- a/ntoskrnl/mm/section.c
+++ b/ntoskrnl/mm/section.c
@@ -4862,9 +4862,9 @@ MmPurgeSegment(
         /* We must calculate the length for ourselves */
         /* FIXME: All of this is suboptimal */
         ULONG ElemCount = RtlNumberGenericTableElements(&Segment->PageTable);
-        /* No page. Nothing to purge */
         if (!ElemCount)
         {
+            /* No page. Nothing to purge */
             MmUnlockSectionSegment(Segment);
             MmDereferenceSegment(Segment);
             return TRUE;
@@ -4873,6 +4873,9 @@ MmPurgeSegment(
         PCACHE_SECTION_PAGE_TABLE PageTable = RtlGetElementGenericTable(&Segment->PageTable, ElemCount - 1);
         PurgeEnd.QuadPart = PageTable->FileOffset.QuadPart + _countof(PageTable->PageEntries) * PAGE_SIZE;
     }
+
+    /* Find byte offset of the page to start */
+    PurgeStart.QuadPart = PAGE_ROUND_DOWN(PurgeStart.QuadPart);
 
     while (PurgeStart.QuadPart < PurgeEnd.QuadPart)
     {


### PR DESCRIPTION
## Purpose
Use section object pointer with byte offset instead of using base address. This simplifies the Mm functions themselves and also the code in Cc that calls them.

## Proposed changes
Replace Mm functions:
`MmArePagesResident` -> `MmIsDataSectionResident`
`MmMakePagesDirty` -> `MmMakeSegmentDirty`

Also adds minor fixes for `MmFlushSegment` and `MmPurgeSegment`.