### PR TITLE
[PSDK] intsafe.h: Define MIN/MAX macros the same way as in stdint.h

### DIFF
--- a/sdk/include/psdk/intsafe.h
+++ b/sdk/include/psdk/intsafe.h
@@ -117,9 +117,9 @@ C_ASSERT(sizeof(DWORD) == 4);
 C_ASSERT(sizeof(UINT_PTR) == sizeof(ULONG_PTR));
 
 /* Integer range margins (use (x-1) to prevent warnings) */
-#define INT8_MIN ((signed char)(-127 - 1))
+#define INT8_MIN (-128)
 #define SHORT_MIN (-32768)
-#define INT16_MIN ((short)(-32767 - 1))
+#define INT16_MIN (-32768)
 #define INT_MIN (-2147483647 - 1)
 #define INT32_MIN (-2147483647 - 1)
 #define LONG_MIN (-2147483647L - 1)
@@ -139,18 +139,18 @@ C_ASSERT(sizeof(UINT_PTR) == sizeof(ULONG_PTR));
 #define SSIZE_T_MIN (-2147483647L - 1)
 #endif /* _WIN64 */
 
-#define INT8_MAX ((signed char)127)
-#define UINT8_MAX ((unsigned char)0xffU)
-#define BYTE_MAX ((unsigned char)0xff)
-#define SHORT_MAX ((short)32767)
-#define INT16_MAX ((short)32767)
-#define USHORT_MAX ((unsigned short)0xffff)
-#define UINT16_MAX ((unsigned short)0xffff)
-#define WORD_MAX ((unsigned short)0xffff)
+#define INT8_MAX 127
+#define UINT8_MAX 0xff /* 255U */
+#define BYTE_MAX 0xff /* 255U */
+#define SHORT_MAX 32767
+#define INT16_MAX 32767
+#define USHORT_MAX 0xffff /* 65535U */
+#define UINT16_MAX 0xffff /* 65535U */
+#define WORD_MAX 0xffff /* 65535U */
 #define INT_MAX 2147483647
 #define INT32_MAX 2147483647
 #define UINT_MAX 0xffffffff
-#define UINT32_MAX 0xffffffffU
+#define UINT32_MAX 0xffffffff  /* 4294967295U */
 #define LONG_MAX 2147483647L
 #define ULONG_MAX 0xffffffffUL
 #define DWORD_MAX 0xffffffffUL
@@ -161,7 +161,7 @@ C_ASSERT(sizeof(UINT_PTR) == sizeof(ULONG_PTR));
 #define DWORDLONG_MAX 0xffffffffffffffffULL
 #define ULONG64_MAX 0xffffffffffffffffULL
 #define DWORD64_MAX 0xffffffffffffffffULL
-#define UINT64_MAX 0xffffffffffffffffULL
+#define UINT64_MAX 0xffffffffffffffffULL /* 18446744073709551615ULL */
 #define INT128_MAX 170141183460469231731687303715884105727i128
 #define UINT128_MAX 0xffffffffffffffffffffffffffffffffui128
 #undef SIZE_T_MAX


### PR DESCRIPTION
This avoids redefinition warnings.
