### PR TITLE
[SHLWAPI][SHLWAPI_APITEST] Optimize StrRetToStrW WSTR handling

### DIFF
--- a/dll/win32/shlwapi/string.c
+++ b/dll/win32/shlwapi/string.c
@@ -1635,8 +1635,14 @@ HRESULT WINAPI StrRetToStrW(LPSTRRET lpStrRet, const ITEMIDLIST *pidl, LPWSTR *p
   switch (lpStrRet->uType)
   {
   case STRRET_WSTR:
+#ifdef __REACTOS__
+    hRet = lpStrRet->u.pOleStr ? S_OK : E_FAIL;
+    *ppszName = lpStrRet->u.pOleStr;
+    lpStrRet->u.pOleStr = NULL; /* Windows does this, presumably in case someone calls SHFree */
+#else
     hRet = SHStrDupW(lpStrRet->u.pOleStr, ppszName);
     CoTaskMemFree(lpStrRet->u.pOleStr);
+#endif
     break;
 
   case STRRET_CSTR:

--- a/modules/rostests/apitests/shlwapi/StrDup.c
+++ b/modules/rostests/apitests/shlwapi/StrDup.c
@@ -39,8 +39,25 @@ static void TEST_StrDupW(void)
         LocalFree(ptrW);
 }
 
+static void TEST_StrRet(void)
+{
+    LPWSTR input, output;
+    if (SUCCEEDED(SHStrDupW(L"Test", &input)))
+    {
+        STRRET strret;
+        strret.uType = STRRET_WSTR;
+        U(strret).pOleStr = input;
+        output = NULL;
+        ok_int(StrRetToStrW(&strret, NULL, &output), S_OK);
+        ok_ptr(U(strret).pOleStr, NULL);
+        ok_ptr(input, output);
+        CoTaskMemFree(output);
+    }
+}
+
 START_TEST(StrDup)
 {
     TEST_StrDupA();
     TEST_StrDupW();
+    TEST_StrRet();
 }


### PR DESCRIPTION
This avoids Alloc/Free while also matching the Windows behavior.