### PR TITLE
[SHELL32] Refresh SHELLSTATE before writing it

### DIFF
--- a/dll/win32/shell32/wine/shellord.c
+++ b/dll/win32/shell32/wine/shellord.c
@@ -279,6 +279,11 @@ VOID WINAPI SHGetSetSettings(LPSHELLSTATE lpss, DWORD dwMask, BOOL bSet)
     if (bSet)
     {
         DWORD changed = 0;
+        if (dwMask & ~g_CachedSSF)
+        {
+            SHELLSTATE tempstate;
+            SHGetSetSettings(&tempstate, dwMask, FALSE); // Read entries that are not in g_CachedSSF
+        }
 
 #define SHGSS_WriteAdv(name, value, SSF) \
     do { \


### PR DESCRIPTION
We should read the items we have not cached yet in case we write REGSHELLSTATE for the first time before Explorer does it.