### PR TITLE
[FREELDR] Make it more compatible with w2k3 ini file

### DIFF
--- a/boot/freeldr/freeldr/lib/inifile/ini_init.c
+++ b/boot/freeldr/freeldr/lib/inifile/ini_init.c
@@ -38,8 +38,15 @@ BOOLEAN IniFileInitialize(VOID)
     if (Status != ESUCCESS)
     {
         ERR("Error while opening freeldr.ini, Status: %d\n", Status);
-        UiMessageBoxCritical("Error opening freeldr.ini or file not found.\nYou need to re-install FreeLoader.");
-        return FALSE;
+
+        /* Try to open boot.ini */
+        Status = FsOpenFile("boot.ini", FrLdrBootPath, OpenReadOnly, &FileId);
+        if (Status != ESUCCESS)
+        {
+            ERR("Error while opening boot.ini, Status: %d\n", Status);
+            UiMessageBoxCritical("Error opening freeldr.ini/boot.ini or file not found.\nYou need to re-install FreeLoader.");
+            return FALSE;
+        }
     }
 
     /* Get the file size */

--- a/boot/freeldr/freeldr/settings.c
+++ b/boot/freeldr/freeldr/settings.c
@@ -126,12 +126,35 @@ LoadSettings(
         return;
     }
 
-    /* Open the [FreeLoader] section and load the settings */
-    if ((BootMgrInfo.FrLdrSection == 0) &&
-        !IniOpenSection("FreeLoader", &BootMgrInfo.FrLdrSection))
+    BOOLEAN FoundLoaderSection = FALSE;
+    PCSTR LoaderSections[] = {
+        "FreeLoader",
+        "Boot Loader",
+        "FlexBoot",
+        "MultiBoot",
+    };
+
+    /* Search for the first section in LoaderSections and load the settings, 
+     * prioritizing the order in the file.
+     * If a section is already loaded, skip further checks. */
+    if (!BootMgrInfo.FrLdrSection)
     {
-        UiMessageBoxCritical("Section [FreeLoader] not found in freeldr.ini");
-        return;
+        for (ULONG i = 0; i < sizeof(LoaderSections) / sizeof(LoaderSections[0]); i++)
+        {
+            PCSTR Section = LoaderSections[i];
+
+            if (IniOpenSection(Section, &BootMgrInfo.FrLdrSection))
+            {
+                FoundLoaderSection = TRUE;
+                break;
+            }
+        }
+
+        if (!FoundLoaderSection)
+        {
+            UiMessageBoxCritical("Bootloader Section not found in freeldr.ini");
+            return;
+        }
     }
 
     /* Get the debug string. Always override it with the one from freeldr.ini */


### PR DESCRIPTION
## Purpose

Make freeldr more compatible with w2k3 ini file.

Fall back to using boot.ini file (from NTLDR) if freeldr.ini doesn't exist.

JIRA issue: None

## TODO

- [x] Make sure it doesn't break [FreeLoader] section
