### PR TITLE
[SETUPLIB][REACTOS][USETUP] Turn setuplib into a DLL shared between TUI and GUI 1st-stage setups

### DIFF
--- a/base/setup/lib/CMakeLists.txt
+++ b/base/setup/lib/CMakeLists.txt
@@ -3,8 +3,11 @@ add_definitions(${I18N_DEFS})
 if(_WINKD_)
     add_definitions(-D_WINKD_)
 endif()
+add_definitions(-D_SETUPLIB_)
 
 include_directories(spapisup utils)
+
+spec2def(setuplib.dll setuplib.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
     spapisup/fileqsup.c
@@ -32,6 +35,15 @@ list(APPEND SOURCE
     setuplib.c
     precomp.h)
 
-add_library(setuplib ${SOURCE})
+add_library(setuplib SHARED
+    ${SOURCE}
+    setuplib.rc
+    ${CMAKE_CURRENT_BINARY_DIR}/setuplib.def)
+
 add_pch(setuplib precomp.h SOURCE)
 add_dependencies(setuplib xdk) # psdk
+
+set_module_type(setuplib nativedll)
+target_link_libraries(setuplib ext2lib vfatlib btrfslib ${PSEH_LIB})
+add_importlibs(setuplib ntdll)
+add_cd_file(TARGET setuplib DESTINATION reactos/system32 NO_CAB FOR bootcd regtest)

--- a/base/setup/lib/bootsup.c
+++ b/base/setup/lib/bootsup.c
@@ -19,7 +19,7 @@
 #include "bootcode.h"
 #include "fsutil.h"
 
-#include "setuplib.h" // HAXX for IsUnattendedSetup!!
+#include "setuplib.h" // HACK for IsUnattendedSetup
 
 #include "bootsup.h"
 
@@ -1658,6 +1658,7 @@ GetDeviceInfo(
  * @return  An NTSTATUS code indicating success or failure.
  **/
 NTSTATUS
+NTAPI
 InstallBootManagerAndBootEntries(
     _In_ ARCHITECTURE_TYPE ArchType,
     _In_ PCUNICODE_STRING SystemRootPath,
@@ -1813,6 +1814,7 @@ Quit:
 }
 
 NTSTATUS
+NTAPI
 InstallBootcodeToRemovable(
     _In_ ARCHITECTURE_TYPE ArchType,
     _In_ PCUNICODE_STRING RemovableRootPath,

--- a/base/setup/lib/bootsup.h
+++ b/base/setup/lib/bootsup.h
@@ -8,6 +8,7 @@
 #pragma once
 
 NTSTATUS
+NTAPI
 InstallBootManagerAndBootEntries(
     _In_ ARCHITECTURE_TYPE ArchType,
     _In_ PCUNICODE_STRING SystemRootPath,
@@ -16,6 +17,7 @@ InstallBootManagerAndBootEntries(
     _In_ ULONG_PTR Options);
 
 NTSTATUS
+NTAPI
 InstallBootcodeToRemovable(
     _In_ ARCHITECTURE_TYPE ArchType,
     _In_ PCUNICODE_STRING RemovableRootPath,

--- a/base/setup/lib/fsutil.c
+++ b/base/setup/lib/fsutil.c
@@ -179,6 +179,7 @@ static FILE_SYSTEM RegisteredFileSystems[] =
 
 /** QueryAvailableFileSystemFormat() **/
 BOOLEAN
+NTAPI
 GetRegisteredFileSystems(
     IN ULONG Index,
     OUT PCWSTR* FileSystemName)
@@ -241,6 +242,7 @@ GetFileSystemByName(
 
 /** ChkdskEx() **/
 NTSTATUS
+NTAPI
 ChkdskFileSystem_UStr(
     _In_ PUNICODE_STRING DriveRoot,
     _In_ PCWSTR FileSystemName,
@@ -284,6 +286,7 @@ ChkdskFileSystem_UStr(
 }
 
 NTSTATUS
+NTAPI
 ChkdskFileSystem(
     _In_ PCWSTR DriveRoot,
     _In_ PCWSTR FileSystemName,
@@ -308,6 +311,7 @@ ChkdskFileSystem(
 
 /** FormatEx() **/
 NTSTATUS
+NTAPI
 FormatFileSystem_UStr(
     _In_ PUNICODE_STRING DriveRoot,
     _In_ PCWSTR FileSystemName,
@@ -373,6 +377,7 @@ FormatFileSystem_UStr(
 }
 
 NTSTATUS
+NTAPI
 FormatFileSystem(
     _In_ PCWSTR DriveRoot,
     _In_ PCWSTR FileSystemName,
@@ -754,6 +759,7 @@ Quit:
 //
 
 NTSTATUS
+NTAPI
 ChkdskVolume(
     _In_ PVOLINFO Volume,
     _In_ BOOLEAN FixErrors,
@@ -778,6 +784,7 @@ ChkdskVolume(
 }
 
 NTSTATUS
+NTAPI
 ChkdskPartition(
     _In_ PPARTENTRY PartEntry,
     _In_ BOOLEAN FixErrors,
@@ -801,6 +808,7 @@ ChkdskPartition(
 }
 
 NTSTATUS
+NTAPI
 FormatVolume(
     _In_ PVOLINFO Volume,
     _In_ PCWSTR FileSystemName,
@@ -839,6 +847,7 @@ FormatVolume(
 }
 
 NTSTATUS
+NTAPI
 FormatPartition(
     _In_ PPARTENTRY PartEntry,
     _In_ PCWSTR FileSystemName,
@@ -1084,6 +1093,7 @@ GetNextUnformattedVolume(
 }
 
 BOOLEAN
+NTAPI
 FsVolCommitOpsQueue(
     _In_ PPARTLIST PartitionList,
     _In_ PVOLENTRY SystemVolume,

--- a/base/setup/lib/fsutil.h
+++ b/base/setup/lib/fsutil.h
@@ -12,6 +12,7 @@
 
 /** QueryAvailableFileSystemFormat() **/
 BOOLEAN
+NTAPI
 GetRegisteredFileSystems(
     IN ULONG Index,
     OUT PCWSTR* FileSystemName);
@@ -19,6 +20,7 @@ GetRegisteredFileSystems(
 
 /** ChkdskEx() **/
 NTSTATUS
+NTAPI
 ChkdskFileSystem_UStr(
     _In_ PUNICODE_STRING DriveRoot,
     _In_ PCWSTR FileSystemName,
@@ -29,6 +31,7 @@ ChkdskFileSystem_UStr(
     _In_opt_ PFMIFSCALLBACK Callback);
 
 NTSTATUS
+NTAPI
 ChkdskFileSystem(
     _In_ PCWSTR DriveRoot,
     _In_ PCWSTR FileSystemName,
@@ -41,6 +44,7 @@ ChkdskFileSystem(
 
 /** FormatEx() **/
 NTSTATUS
+NTAPI
 FormatFileSystem_UStr(
     _In_ PUNICODE_STRING DriveRoot,
     _In_ PCWSTR FileSystemName,
@@ -51,6 +55,7 @@ FormatFileSystem_UStr(
     _In_opt_ PFMIFSCALLBACK Callback);
 
 NTSTATUS
+NTAPI
 FormatFileSystem(
     _In_ PCWSTR DriveRoot,
     _In_ PCWSTR FileSystemName,
@@ -109,6 +114,7 @@ InstallNtfsBootCode(
 //
 
 NTSTATUS
+NTAPI
 ChkdskPartition(
     _In_ PPARTENTRY PartEntry,
     _In_ BOOLEAN FixErrors,
@@ -118,6 +124,7 @@ ChkdskPartition(
     _In_opt_ PFMIFSCALLBACK Callback);
 
 NTSTATUS
+NTAPI
 FormatPartition(
     _In_ PPARTENTRY PartEntry,
     _In_ PCWSTR FileSystemName,
@@ -200,6 +207,7 @@ typedef FSVOL_OP
     _In_ ULONG_PTR Param2);
 
 BOOLEAN
+NTAPI
 FsVolCommitOpsQueue(
     _In_ PPARTLIST PartitionList,
     _In_ PVOLENTRY SystemVolume,

--- a/base/setup/lib/install.c
+++ b/base/setup/lib/install.c
@@ -13,7 +13,7 @@
 #include "filesup.h"
 #include "infsupp.h"
 
-#include "setuplib.h" // HAXX for USETUP_DATA!!
+#include "setuplib.h" // HACK for USETUP_DATA
 
 #include "install.h"
 
@@ -681,6 +681,7 @@ PrepareCopyInfFile(
 // #define USE_CABINET_INF
 
 BOOLEAN // ERROR_NUMBER
+NTAPI
 PrepareFileCopy(
     IN OUT PUSETUP_DATA pSetupData,
     IN PFILE_COPY_STATUS_ROUTINE StatusRoutine OPTIONAL)
@@ -823,6 +824,7 @@ PrepareFileCopy(
 }
 
 BOOLEAN
+NTAPI
 DoFileCopy(
     IN OUT PUSETUP_DATA pSetupData,
     IN PSP_FILE_CALLBACK_W MsgHandler,

--- a/base/setup/lib/install.h
+++ b/base/setup/lib/install.h
@@ -27,11 +27,13 @@ PrepareCopyInfFile(
 #endif
 
 BOOLEAN // ERROR_NUMBER
+NTAPI
 PrepareFileCopy(
     IN OUT PUSETUP_DATA pSetupData,
     IN PFILE_COPY_STATUS_ROUTINE StatusRoutine OPTIONAL);
 
 BOOLEAN
+NTAPI
 DoFileCopy(
     IN OUT PUSETUP_DATA pSetupData,
     IN PSP_FILE_CALLBACK_W MsgHandler,

--- a/base/setup/lib/precomp.h
+++ b/base/setup/lib/precomp.h
@@ -29,9 +29,13 @@
 
 #include <ntstrsafe.h>
 
-
 /* Filesystem headers */
 #include <reactos/rosioctl.h>   // For extra partition IDs
+
+
+#ifndef SPLIBAPI
+#define SPLIBAPI
+#endif
 
 //
 ///* Internal Headers */
@@ -50,7 +54,6 @@
 //#include "cabinet.h"
 //#include "filesup.h"
 //#include "genlist.h"
-
 
 extern HANDLE ProcessHeap;
 

--- a/base/setup/lib/setuplib.h
+++ b/base/setup/lib/setuplib.h
@@ -7,6 +7,16 @@
 
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef _SETUPLIB_
+#define SPLIBAPI DECLSPEC_IMPORT
+#else
+#define SPLIBAPI
+#endif
+
 /* INCLUDES *****************************************************************/
 
 /* Needed PSDK headers when using this library */
@@ -20,9 +30,9 @@
 
 #endif
 
-/* NOTE: Please keep the header inclusion order! */
+extern SPLIBAPI BOOLEAN IsUnattendedSetup; // HACK
 
-extern HANDLE ProcessHeap;
+/* NOTE: Please keep the header inclusion order! */
 
 #include "errorcode.h"
 #include "spapisup/fileqsup.h"
@@ -153,19 +163,17 @@ typedef struct _USETUP_DATA
 #include "install.h"
 
 
-// HACK!!
-extern BOOLEAN IsUnattendedSetup;
-
-
 /* FUNCTIONS ****************************************************************/
 
 #include "substset.h"
 
 VOID
+NTAPI
 CheckUnattendedSetup(
     IN OUT PUSETUP_DATA pSetupData);
 
 VOID
+NTAPI
 InstallSetupInfFile(
     IN OUT PUSETUP_DATA pSetupData);
 
@@ -182,6 +190,7 @@ LoadSetupInf(
 #define ERROR_SYSTEM_PARTITION_NOT_FOUND    (ERROR_LAST_ERROR_CODE + 1)
 
 BOOLEAN
+NTAPI
 InitSystemPartition(
     /**/_In_ PPARTLIST PartitionList,       /* HACK HACK! */
     /**/_In_ PPARTENTRY InstallPartition,   /* HACK HACK! */
@@ -200,10 +209,12 @@ InitSystemPartition(
     (isalnum(c) || (c) == L'.' || (c) == L'\\' || (c) == L'-' || (c) == L'_')
 
 BOOLEAN
+NTAPI
 IsValidInstallDirectory(
     _In_ PCWSTR InstallDir);
 
 NTSTATUS
+NTAPI
 InitDestinationPaths(
     _Inout_ PUSETUP_DATA pSetupData,
     _In_ PCWSTR InstallationDir,
@@ -211,11 +222,15 @@ InitDestinationPaths(
 
 // NTSTATUS
 ERROR_NUMBER
+NTAPI
 InitializeSetup(
-    IN OUT PUSETUP_DATA pSetupData,
-    IN ULONG InitPhase);
+    _Inout_ PUSETUP_DATA pSetupData,
+    _In_opt_ PSETUP_ERROR_ROUTINE ErrorRoutine,
+    _In_ PSPFILE_EXPORTS pSpFileExports,
+    _In_ PSPINF_EXPORTS pSpInfExports);
 
 VOID
+NTAPI
 FinishSetup(
     IN OUT PUSETUP_DATA pSetupData);
 
@@ -236,6 +251,7 @@ typedef VOID
 (__cdecl *PREGISTRY_STATUS_ROUTINE)(IN REGISTRY_STATUS, ...);
 
 ERROR_NUMBER
+NTAPI
 UpdateRegistry(
     IN OUT PUSETUP_DATA pSetupData,
     /**/IN BOOLEAN RepairUpdateFlag,     /* HACK HACK! */
@@ -244,5 +260,9 @@ UpdateRegistry(
     /**/IN PCWSTR SelectedLanguageId,    /* HACK HACK! */
     IN PREGISTRY_STATUS_ROUTINE StatusRoutine OPTIONAL,
     IN PFONTSUBSTSETTINGS SubstSettings OPTIONAL);
+
+#ifdef __cplusplus
+}
+#endif
 
 /* EOF */

--- a/base/setup/lib/setuplib.rc
+++ b/base/setup/lib/setuplib.rc
@@ -1,0 +1,16 @@
+/*
+ * PROJECT:     ReactOS Setup Library
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Resources
+ * COPYRIGHT:   Copyright 2003-2024 ReactOS Team
+ */
+
+#include <windef.h>
+
+LANGUAGE LANG_NEUTRAL, SUBLANG_NEUTRAL
+
+#define REACTOS_VERSION_DLL
+#define REACTOS_STR_FILE_DESCRIPTION    "ReactOS Setup Library DLL"
+#define REACTOS_STR_INTERNAL_NAME       "setuplib"
+#define REACTOS_STR_ORIGINAL_FILENAME   "setuplib.dll"
+#include <reactos/version.rc>

--- a/base/setup/lib/setuplib.spec
+++ b/base/setup/lib/setuplib.spec
@@ -1,0 +1,83 @@
+
+@ extern IsUnattendedSetup
+@ extern MbrPartitionTypes
+@ extern GptPartitionTypes
+
+;; fileqsup and infsupp function pointers to be initialized by the user of this library
+;;@ extern SpFileExports
+;;@ extern SpInfExports
+
+;; infsupp
+@ cdecl INF_GetDataField(ptr long ptr)  ## -private
+
+
+;; filesup
+@ cdecl ConcatPathsV(ptr long long ptr)
+@ cdecl CombinePathsV(ptr long long ptr)
+@ varargs ConcatPaths(ptr long long)
+@ varargs CombinePaths(ptr long long)
+@ cdecl SetupCopyFile(wstr wstr long)
+@ cdecl SetupDeleteFile(wstr long)
+@ cdecl SetupMoveFile(wstr wstr long)
+
+;; genlist
+@ stdcall CreateGenericList()
+@ stdcall DestroyGenericList(ptr long)
+@ stdcall GetCurrentListEntry(ptr)
+@ stdcall GetFirstListEntry(ptr)
+@ stdcall GetNextListEntry(ptr)
+@ stdcall GetListEntryData(ptr)
+@ stdcall GetNumberOfListEntries(ptr)
+@ stdcall SetCurrentListEntry(ptr ptr)
+
+;; partlist
+@ stdcall CreatePartitionList()
+@ stdcall CreatePartition(ptr ptr int64 ptr)
+@ stdcall DeletePartition(ptr ptr ptr)
+@ stdcall DestroyPartitionList(ptr)
+@ stdcall GetNextPartition(ptr ptr)
+@ stdcall GetPrevPartition(ptr ptr)
+@ stdcall GetAdjUnpartitionedEntry(ptr long)
+@ stdcall PartitionCreateChecks(ptr int64 ptr)
+@ cdecl -ret64 RoundingDivide(int64 int64)
+;;;;
+@ cdecl IsPartitionActive(ptr)          ## -private
+@ cdecl SelectPartition(ptr long long)
+
+;; osdetect
+@ stdcall CreateNTOSInstallationsList(ptr)
+@ stdcall FindSubStrI(wstr wstr)
+
+;; settings
+@ cdecl CreateComputerTypeList(ptr)
+@ cdecl CreateDisplayDriverList(ptr)
+@ cdecl CreateKeyboardDriverList(ptr)
+@ cdecl CreateKeyboardLayoutList(ptr wstr ptr)
+@ cdecl CreateLanguageList(ptr ptr)
+@ cdecl GetDefaultLanguageIndex()
+
+;; mui
+@ cdecl MUIDefaultKeyboardLayout(wstr)
+@ cdecl MUIGetOEMCodePage(wstr)         ## -private
+
+;; setuplib
+@ stdcall CheckUnattendedSetup(ptr)
+@ stdcall FinishSetup(ptr)
+@ stdcall IsValidInstallDirectory(wstr)
+@ stdcall InitDestinationPaths(ptr wstr ptr)
+@ stdcall InitializeSetup(ptr ptr ptr ptr)
+@ stdcall InitSystemPartition(ptr ptr ptr ptr ptr)
+@ stdcall InstallSetupInfFile(ptr)
+@ stdcall UpdateRegistry(ptr long ptr long wstr ptr ptr)
+
+;; fsutil
+@ stdcall FsVolCommitOpsQueue(ptr ptr ptr ptr ptr)
+@ stdcall GetRegisteredFileSystems(long ptr)
+
+;; install
+@ stdcall PrepareFileCopy(ptr ptr)
+@ stdcall DoFileCopy(ptr ptr ptr)
+
+;; bootsup
+@ stdcall InstallBootManagerAndBootEntries(long ptr ptr ptr ptr)
+@ stdcall InstallBootcodeToRemovable(long ptr ptr ptr)

--- a/base/setup/lib/spapisup/fileqsup.c
+++ b/base/setup/lib/spapisup/fileqsup.c
@@ -20,15 +20,6 @@
  * These externs should be defined by the user of this library.
  * They are kept there for reference and ease of usage.
  */
-#if 0
-
-pSpFileQueueOpen   SpFileQueueOpen   = NULL;
-pSpFileQueueClose  SpFileQueueClose  = NULL;
-pSpFileQueueCopy   SpFileQueueCopy   = NULL;
-pSpFileQueueDelete SpFileQueueDelete = NULL;
-pSpFileQueueRename SpFileQueueRename = NULL;
-pSpFileQueueCommit SpFileQueueCommit = NULL;
-
-#endif
+SPFILE_EXPORTS SpFileExports = {NULL};
 
 /* EOF */

--- a/base/setup/lib/spapisup/fileqsup.h
+++ b/base/setup/lib/spapisup/fileqsup.h
@@ -51,7 +51,7 @@
 #define FILEOP_NEWPATH                  4
 
 
-/* TYPES ********************************************************************/
+/* TYPES *********************************************************************/
 
 typedef PVOID HSPFILEQ;
 
@@ -72,20 +72,16 @@ typedef UINT (CALLBACK* PSP_FILE_CALLBACK_W)(
 #endif
 
 
-/* FUNCTIONS ****************************************************************/
+/* FUNCTIONS *****************************************************************/
 
 // #define SetupOpenFileQueue
 typedef HSPFILEQ
 (WINAPI* pSpFileQueueOpen)(VOID);
 
-extern pSpFileQueueOpen SpFileQueueOpen;
-
 // #define SetupCloseFileQueue
 typedef BOOL
 (WINAPI* pSpFileQueueClose)(
     IN HSPFILEQ QueueHandle);
-
-extern pSpFileQueueClose SpFileQueueClose;
 
 // #define SetupQueueCopyW
 typedef BOOL
@@ -101,16 +97,12 @@ typedef BOOL
     IN PCWSTR TargetFileName OPTIONAL,
     IN ULONG CopyStyle);
 
-extern pSpFileQueueCopy SpFileQueueCopy;
-
 // #define SetupQueueDeleteW
 typedef BOOL
 (WINAPI* pSpFileQueueDelete)(
     IN HSPFILEQ QueueHandle,
     IN PCWSTR PathPart1,
     IN PCWSTR PathPart2 OPTIONAL);
-
-extern pSpFileQueueDelete SpFileQueueDelete;
 
 // #define SetupQueueRenameW
 typedef BOOL
@@ -121,8 +113,6 @@ typedef BOOL
     IN PCWSTR TargetPath OPTIONAL,
     IN PCWSTR TargetFileName);
 
-extern pSpFileQueueRename SpFileQueueRename;
-
 // #define SetupCommitFileQueueW
 typedef BOOL
 (WINAPI* pSpFileQueueCommit)(
@@ -131,6 +121,23 @@ typedef BOOL
     IN PSP_FILE_CALLBACK_W MsgHandler,
     IN PVOID Context OPTIONAL);
 
-extern pSpFileQueueCommit SpFileQueueCommit;
+typedef struct _SPFILE_EXPORTS
+{
+    pSpFileQueueOpen   SpFileQueueOpen;
+    pSpFileQueueClose  SpFileQueueClose;
+    pSpFileQueueCopy   SpFileQueueCopy;
+    pSpFileQueueDelete SpFileQueueDelete;
+    pSpFileQueueRename SpFileQueueRename;
+    pSpFileQueueCommit SpFileQueueCommit;
+} SPFILE_EXPORTS, *PSPFILE_EXPORTS;
+
+extern /*SPLIBAPI*/ SPFILE_EXPORTS SpFileExports;
+
+#define SpFileQueueOpen     (SpFileExports.SpFileQueueOpen)
+#define SpFileQueueClose    (SpFileExports.SpFileQueueClose)
+#define SpFileQueueCopy     (SpFileExports.SpFileQueueCopy)
+#define SpFileQueueDelete   (SpFileExports.SpFileQueueDelete)
+#define SpFileQueueRename   (SpFileExports.SpFileQueueRename)
+#define SpFileQueueCommit   (SpFileExports.SpFileQueueCommit)
 
 /* EOF */

--- a/base/setup/lib/spapisup/infsupp.c
+++ b/base/setup/lib/spapisup/infsupp.c
@@ -21,20 +21,7 @@
  * These externs should be defined by the user of this library.
  * They are kept there for reference and ease of usage.
  */
-#if 0
-
-pSpInfCloseInfFile  SpInfCloseInfFile  = NULL;
-pSpInfFindFirstLine SpInfFindFirstLine = NULL;
-pSpInfFindNextLine  SpInfFindNextLine  = NULL;
-pSpInfGetFieldCount SpInfGetFieldCount = NULL;
-pSpInfGetBinaryField  SpInfGetBinaryField  = NULL;
-pSpInfGetIntField     SpInfGetIntField     = NULL;
-pSpInfGetMultiSzField SpInfGetMultiSzField = NULL;
-pSpInfGetStringField  SpInfGetStringField  = NULL;
-pSpInfGetField    SpInfGetField    = NULL;
-pSpInfOpenInfFile SpInfOpenInfFile = NULL;
-
-#endif
+SPINF_EXPORTS SpInfExports = {NULL};
 
 /* HELPER FUNCTIONS **********************************************************/
 

--- a/base/setup/lib/spapisup/infsupp.h
+++ b/base/setup/lib/spapisup/infsupp.h
@@ -29,6 +29,8 @@ typedef struct _INFCONTEXT
 
 #endif
 
+C_ASSERT(sizeof(INFCONTEXT) == 2 * sizeof(HINF) + 2 * sizeof(UINT));
+
 /* Lower the MAX_INF_STRING_LENGTH value in order to avoid too much stack usage */
 #undef MAX_INF_STRING_LENGTH
 #define MAX_INF_STRING_LENGTH   1024 // Still larger than in infcommon.h
@@ -41,26 +43,13 @@ typedef struct _INFCONTEXT
 #define INF_STYLE_WIN4  0x00000002
 #endif
 
-#if 0
-typedef PVOID HINF;
-typedef struct _INFCONTEXT
-{
-    HINF Inf;
-    HINF CurrentInf;
-    UINT Section;
-    UINT Line;
-} INFCONTEXT, *PINFCONTEXT;
-#endif
 
-C_ASSERT(sizeof(INFCONTEXT) == 2 * sizeof(HINF) + 2 * sizeof(UINT));
-
+/* FUNCTIONS *****************************************************************/
 
 // #define SetupCloseInfFile InfCloseFile
 typedef VOID
 (WINAPI* pSpInfCloseInfFile)(
     IN HINF InfHandle);
-
-extern pSpInfCloseInfFile SpInfCloseInfFile;
 
 // #define SetupFindFirstLineW InfpFindFirstLineW
 typedef BOOL
@@ -70,22 +59,16 @@ typedef BOOL
     IN PCWSTR Key,
     IN OUT PINFCONTEXT Context);
 
-extern pSpInfFindFirstLine SpInfFindFirstLine;
-
 // #define SetupFindNextLine InfFindNextLine
 typedef BOOL
 (WINAPI* pSpInfFindNextLine)(
     IN  PINFCONTEXT ContextIn,
     OUT PINFCONTEXT ContextOut);
 
-extern pSpInfFindNextLine SpInfFindNextLine;
-
 // #define SetupGetFieldCount InfGetFieldCount
 typedef ULONG
 (WINAPI* pSpInfGetFieldCount)(
     IN PINFCONTEXT Context);
-
-extern pSpInfGetFieldCount SpInfGetFieldCount;
 
 // #define SetupGetBinaryField InfGetBinaryField
 typedef BOOL
@@ -96,16 +79,12 @@ typedef BOOL
     IN  ULONG ReturnBufferSize,
     OUT PULONG RequiredSize);
 
-extern pSpInfGetBinaryField SpInfGetBinaryField;
-
 // #define SetupGetIntField InfGetIntField
 typedef BOOL
 (WINAPI* pSpInfGetIntField)(
     IN PINFCONTEXT Context,
     IN ULONG FieldIndex,
     OUT INT *IntegerValue); // PINT
-
-extern pSpInfGetIntField SpInfGetIntField;
 
 // #define SetupGetMultiSzFieldW InfGetMultiSzField
 typedef BOOL
@@ -116,8 +95,6 @@ typedef BOOL
     IN  ULONG ReturnBufferSize,
     OUT PULONG RequiredSize);
 
-extern pSpInfGetMultiSzField SpInfGetMultiSzField;
-
 // #define SetupGetStringFieldW InfGetStringField
 typedef BOOL
 (WINAPI* pSpInfGetStringField)(
@@ -127,15 +104,11 @@ typedef BOOL
     IN  ULONG ReturnBufferSize,
     OUT PULONG RequiredSize);
 
-extern pSpInfGetStringField SpInfGetStringField;
-
 // #define pSetupGetField
 typedef PCWSTR
 (WINAPI* pSpInfGetField)(
     IN PINFCONTEXT Context,
     IN ULONG FieldIndex);
-
-extern pSpInfGetField SpInfGetField;
 
 /* A version of SetupOpenInfFileW with support for a user-provided LCID */
 // #define SetupOpenInfFileExW InfpOpenInfFileW
@@ -147,8 +120,32 @@ typedef HINF
     IN LCID LocaleId,
     OUT PUINT ErrorLine);
 
-extern pSpInfOpenInfFile SpInfOpenInfFile;
+typedef struct _SPINF_EXPORTS
+{
+    pSpInfCloseInfFile    SpInfCloseInfFile;
+    pSpInfFindFirstLine   SpInfFindFirstLine;
+    pSpInfFindNextLine    SpInfFindNextLine;
+    pSpInfGetFieldCount   SpInfGetFieldCount;
+    pSpInfGetBinaryField  SpInfGetBinaryField;
+    pSpInfGetIntField     SpInfGetIntField;
+    pSpInfGetMultiSzField SpInfGetMultiSzField;
+    pSpInfGetStringField  SpInfGetStringField;
+    pSpInfGetField        SpInfGetField;
+    pSpInfOpenInfFile     SpInfOpenInfFile;
+} SPINF_EXPORTS, *PSPINF_EXPORTS;
 
+extern /*SPLIBAPI*/ SPINF_EXPORTS SpInfExports;
+
+#define SpInfCloseInfFile       (SpInfExports.SpInfCloseInfFile)
+#define SpInfFindFirstLine      (SpInfExports.SpInfFindFirstLine)
+#define SpInfFindNextLine       (SpInfExports.SpInfFindNextLine)
+#define SpInfGetFieldCount      (SpInfExports.SpInfGetFieldCount)
+#define SpInfGetBinaryField     (SpInfExports.SpInfGetBinaryField)
+#define SpInfGetIntField        (SpInfExports.SpInfGetIntField)
+#define SpInfGetMultiSzField    (SpInfExports.SpInfGetMultiSzField)
+#define SpInfGetStringField     (SpInfExports.SpInfGetStringField)
+#define SpInfGetField           (SpInfExports.SpInfGetField)
+#define SpInfOpenInfFile        (SpInfExports.SpInfOpenInfFile)
 
 /* HELPER FUNCTIONS **********************************************************/
 

--- a/base/setup/lib/utils/genlist.c
+++ b/base/setup/lib/utils/genlist.c
@@ -17,6 +17,7 @@
 /* FUNCTIONS ****************************************************************/
 
 PGENERIC_LIST
+NTAPI
 CreateGenericList(VOID)
 {
     PGENERIC_LIST List;
@@ -33,6 +34,7 @@ CreateGenericList(VOID)
 }
 
 VOID
+NTAPI
 DestroyGenericList(
     IN OUT PGENERIC_LIST List,
     IN BOOLEAN FreeData)
@@ -59,6 +61,7 @@ DestroyGenericList(
 }
 
 BOOLEAN
+NTAPI
 AppendGenericListEntry(
     IN OUT PGENERIC_LIST List,
     IN PVOID Data,
@@ -84,6 +87,7 @@ AppendGenericListEntry(
 }
 
 VOID
+NTAPI
 SetCurrentListEntry(
     IN PGENERIC_LIST List,
     IN PGENERIC_LIST_ENTRY Entry)
@@ -94,6 +98,7 @@ SetCurrentListEntry(
 }
 
 PGENERIC_LIST_ENTRY
+NTAPI
 GetCurrentListEntry(
     IN PGENERIC_LIST List)
 {
@@ -101,6 +106,7 @@ GetCurrentListEntry(
 }
 
 PGENERIC_LIST_ENTRY
+NTAPI
 GetFirstListEntry(
     IN PGENERIC_LIST List)
 {
@@ -111,6 +117,7 @@ GetFirstListEntry(
 }
 
 PGENERIC_LIST_ENTRY
+NTAPI
 GetNextListEntry(
     IN PGENERIC_LIST_ENTRY Entry)
 {
@@ -123,6 +130,7 @@ GetNextListEntry(
 }
 
 PVOID
+NTAPI
 GetListEntryData(
     IN PGENERIC_LIST_ENTRY Entry)
 {
@@ -137,6 +145,7 @@ GetListEntryUiData(
 }
 
 ULONG
+NTAPI
 GetNumberOfListEntries(
     IN PGENERIC_LIST List)
 {

--- a/base/setup/lib/utils/genlist.h
+++ b/base/setup/lib/utils/genlist.h
@@ -24,37 +24,45 @@ typedef struct _GENERIC_LIST
 
 
 PGENERIC_LIST
+NTAPI
 CreateGenericList(VOID);
 
 VOID
+NTAPI
 DestroyGenericList(
     IN OUT PGENERIC_LIST List,
     IN BOOLEAN FreeData);
 
 BOOLEAN
+NTAPI
 AppendGenericListEntry(
     IN OUT PGENERIC_LIST List,
     IN PVOID Data,
     IN BOOLEAN Current);
 
 VOID
+NTAPI
 SetCurrentListEntry(
     IN PGENERIC_LIST List,
     IN PGENERIC_LIST_ENTRY Entry);
 
 PGENERIC_LIST_ENTRY
+NTAPI
 GetCurrentListEntry(
     IN PGENERIC_LIST List);
 
 PGENERIC_LIST_ENTRY
+NTAPI
 GetFirstListEntry(
     IN PGENERIC_LIST List);
 
 PGENERIC_LIST_ENTRY
+NTAPI
 GetNextListEntry(
     IN PGENERIC_LIST_ENTRY Entry);
 
 PVOID
+NTAPI
 GetListEntryData(
     IN PGENERIC_LIST_ENTRY Entry);
 
@@ -63,6 +71,7 @@ GetListEntryUiData(
     IN PGENERIC_LIST_ENTRY Entry);
 
 ULONG
+NTAPI
 GetNumberOfListEntries(
     IN PGENERIC_LIST List);
 

--- a/base/setup/lib/utils/osdetect.c
+++ b/base/setup/lib/utils/osdetect.c
@@ -209,12 +209,16 @@ EnumerateInstallations(
     return STATUS_SUCCESS;
 }
 
-/*
- * FindSubStrI(PCWSTR str, PCWSTR strSearch) :
- *    Searches for a sub-string 'strSearch' inside 'str', similarly to what
- *    wcsstr(str, strSearch) does, but ignores the case during the comparisons.
- */
-PCWSTR FindSubStrI(PCWSTR str, PCWSTR strSearch)
+/**
+ * @brief
+ * Finds the first occurrence of a sub-string 'strSearch' inside 'str',
+ * using case-insensitive comparisons.
+ **/
+PCWSTR
+NTAPI
+FindSubStrI(
+    _In_ PCWSTR str,
+    _In_ PCWSTR strSearch)
 {
     PCWSTR cp = str;
     PCWSTR s1, s2;
@@ -760,6 +764,7 @@ FindNTOSInstallations(
  **/
 // EnumerateNTOSInstallations
 PGENERIC_LIST
+NTAPI
 CreateNTOSInstallationsList(
     _In_ PPARTLIST PartList)
 {

--- a/base/setup/lib/utils/osdetect.h
+++ b/base/setup/lib/utils/osdetect.h
@@ -30,14 +30,14 @@ typedef struct _NTOS_INSTALLATION
 
 // EnumerateNTOSInstallations
 PGENERIC_LIST
+NTAPI
 CreateNTOSInstallationsList(
     _In_ PPARTLIST PartList);
 
-/*
- * FindSubStrI(PCWSTR str, PCWSTR strSearch) :
- *    Searches for a sub-string 'strSearch' inside 'str', similarly to what
- *    wcsstr(str, strSearch) does, but ignores the case during the comparisons.
- */
-PCWSTR FindSubStrI(PCWSTR str, PCWSTR strSearch);
+PCWSTR
+NTAPI
+FindSubStrI(
+    _In_ PCWSTR str,
+    _In_ PCWSTR strSearch);
 
 /* EOF */

--- a/base/setup/lib/utils/partinfo.h
+++ b/base/setup/lib/utils/partinfo.h
@@ -16,7 +16,7 @@ typedef struct _MBR_PARTITION_TYPE
 } MBR_PARTITION_TYPE, *PMBR_PARTITION_TYPE;
 
 #define NUM_MBR_PARTITION_TYPES 153
-extern const MBR_PARTITION_TYPE MbrPartitionTypes[NUM_MBR_PARTITION_TYPES];
+extern SPLIBAPI const MBR_PARTITION_TYPE MbrPartitionTypes[NUM_MBR_PARTITION_TYPES];
 
 /* GPT PARTITION TYPES ******************************************************/
 
@@ -27,6 +27,6 @@ typedef struct _GPT_PARTITION_TYPE
 } GPT_PARTITION_TYPE, *PGPT_PARTITION_TYPE;
 
 #define NUM_GPT_PARTITION_TYPES 177
-extern const GPT_PARTITION_TYPE GptPartitionTypes[NUM_GPT_PARTITION_TYPES];
+extern SPLIBAPI const GPT_PARTITION_TYPE GptPartitionTypes[NUM_GPT_PARTITION_TYPES];
 
 /* EOF */

--- a/base/setup/lib/utils/partlist.c
+++ b/base/setup/lib/utils/partlist.c
@@ -1984,6 +1984,7 @@ GetActiveDiskPartition(
 }
 
 PPARTLIST
+NTAPI
 CreatePartitionList(VOID)
 {
     PPARTLIST List;
@@ -2069,6 +2070,7 @@ CreatePartitionList(VOID)
 }
 
 VOID
+NTAPI
 DestroyPartitionList(
     IN PPARTLIST List)
 {
@@ -2288,6 +2290,7 @@ SelectPartition(
 }
 
 PPARTENTRY
+NTAPI
 GetNextPartition(
     IN PPARTLIST List,
     IN PPARTENTRY CurrentPart OPTIONAL)
@@ -2380,6 +2383,7 @@ GetNextPartition(
 }
 
 PPARTENTRY
+NTAPI
 GetPrevPartition(
     IN PPARTLIST List,
     IN PPARTENTRY CurrentPart OPTIONAL)
@@ -2783,6 +2787,7 @@ UpdateDiskLayout(
  * @return  The adjacent unpartitioned region, if it exists, or NULL.
  **/
 PPARTENTRY
+NTAPI
 GetAdjUnpartitionedEntry(
     _In_ PPARTENTRY PartEntry,
     _In_ BOOLEAN Direction)
@@ -2872,6 +2877,7 @@ MBRPartitionCreateChecks(
 }
 
 ERROR_NUMBER
+NTAPI
 PartitionCreateChecks(
     _In_ PPARTENTRY PartEntry,
     _In_opt_ ULONGLONG SizeBytes,
@@ -2900,6 +2906,7 @@ PartitionCreateChecks(
 // (see VDS::CREATE_PARTITION_PARAMETERS and PPARTITION_INFORMATION_MBR/GPT for example)
 // So far we only use it as the optional type of the partition to create.
 BOOLEAN
+NTAPI
 CreatePartition(
     _In_ PPARTLIST List,
     _Inout_ PPARTENTRY PartEntry,
@@ -2990,6 +2997,7 @@ DismountPartition(
 }
 
 BOOLEAN
+NTAPI
 DeletePartition(
     _In_ PPARTLIST List,
     _In_ PPARTENTRY PartEntry,

--- a/base/setup/lib/utils/partlist.h
+++ b/base/setup/lib/utils/partlist.h
@@ -283,9 +283,11 @@ IsPartitionActive(
     IN PPARTENTRY PartEntry);
 
 PPARTLIST
+NTAPI
 CreatePartitionList(VOID);
 
 VOID
+NTAPI
 DestroyPartitionList(
     IN PPARTLIST List);
 
@@ -323,27 +325,32 @@ SelectPartition(
     _In_ ULONG PartitionNumber);
 
 PPARTENTRY
+NTAPI
 GetNextPartition(
     IN PPARTLIST List,
     IN PPARTENTRY CurrentPart OPTIONAL);
 
 PPARTENTRY
+NTAPI
 GetPrevPartition(
     IN PPARTLIST List,
     IN PPARTENTRY CurrentPart OPTIONAL);
 
 PPARTENTRY
+NTAPI
 GetAdjUnpartitionedEntry(
     _In_ PPARTENTRY PartEntry,
     _In_ BOOLEAN Direction);
 
 ERROR_NUMBER
+NTAPI
 PartitionCreateChecks(
     _In_ PPARTENTRY PartEntry,
     _In_opt_ ULONGLONG SizeBytes,
     _In_opt_ ULONG_PTR PartitionInfo);
 
 BOOLEAN
+NTAPI
 CreatePartition(
     _In_ PPARTLIST List,
     _Inout_ PPARTENTRY PartEntry,
@@ -351,6 +358,7 @@ CreatePartition(
     _In_opt_ ULONG_PTR PartitionInfo);
 
 BOOLEAN
+NTAPI
 DeletePartition(
     _In_ PPARTLIST List,
     _In_ PPARTENTRY PartEntry,

--- a/base/setup/reactos/CMakeLists.txt
+++ b/base/setup/reactos/CMakeLists.txt
@@ -17,9 +17,10 @@ list(APPEND SOURCE
 file(GLOB reactos_rc_deps res/*.*)
 add_rc_deps(reactos.rc ${reactos_rc_deps})
 add_executable(reactos ${SOURCE} reactos.rc)
+
 add_pch(reactos reactos.h SOURCE)
 set_module_type(reactos win32gui UNICODE)
-target_link_libraries(reactos uuid setuplib ext2lib vfatlib btrfslib ${PSEH_LIB})
+target_link_libraries(reactos uuid)
 target_link_libraries(reactos zlib_solo) ## We use USETUP's cabinet implementation
-add_importlibs(reactos advapi32 gdi32 user32 comctl32 shlwapi setupapi msvcrt kernel32 ntdll)
+add_importlibs(reactos advapi32 gdi32 user32 comctl32 shlwapi setupapi setuplib msvcrt kernel32 ntdll)
 add_cd_file(TARGET reactos DESTINATION reactos NO_CAB FOR bootcd)

--- a/base/setup/reactos/reactos.c
+++ b/base/setup/reactos/reactos.c
@@ -38,7 +38,6 @@
 /* GLOBALS ******************************************************************/
 
 HANDLE ProcessHeap;
-BOOLEAN IsUnattendedSetup = FALSE;
 SETUPDATA SetupData;
 
 /* The partition where to perform the installation */
@@ -2826,11 +2825,9 @@ _tWinMain(HINSTANCE hInst,
     /* Initialize the NT to Win32 path prefix mapping list */
     InitNtToWin32PathMappingList(&SetupData.MappingList);
 
-    /* Initialize Setup, phase 0 */
-    InitializeSetup(&SetupData.USetupData, 0);
-
-    /* Initialize Setup, phase 1 */
-    Error = InitializeSetup(&SetupData.USetupData, 1);
+    /* Initialize Setup */
+    Error = InitializeSetup(&SetupData.USetupData, NULL,
+                            &SpFileExports, &SpInfExports);
     if (Error != ERROR_SUCCESS)
     {
         //

--- a/base/setup/reactos/reactos.h
+++ b/base/setup/reactos/reactos.h
@@ -163,8 +163,6 @@ typedef struct _SETUPDATA
 } SETUPDATA, *PSETUPDATA;
 
 extern HANDLE ProcessHeap;
-extern BOOLEAN IsUnattendedSetup;
-
 extern SETUPDATA SetupData;
 
 extern PPARTENTRY InstallPartition;

--- a/base/setup/reactos/spapisup/fileqsup.c
+++ b/base/setup/reactos/spapisup/fileqsup.c
@@ -173,12 +173,15 @@ SpFileQueueRename_NtToWin32(
 
 /* GLOBALS *******************************************************************/
 
-pSpFileQueueOpen   SpFileQueueOpen   = SetupOpenFileQueue;
-pSpFileQueueClose  SpFileQueueClose  = SetupCloseFileQueue;
-pSpFileQueueCopy   SpFileQueueCopy   = SpFileQueueCopy_NtToWin32;
-pSpFileQueueDelete SpFileQueueDelete = SpFileQueueDelete_NtToWin32;
-pSpFileQueueRename SpFileQueueRename = SpFileQueueRename_NtToWin32;
-pSpFileQueueCommit SpFileQueueCommit = SetupCommitFileQueueW;
+SPFILE_EXPORTS SpFileExports =
+{
+    SetupOpenFileQueue,
+    SetupCloseFileQueue,
+    SpFileQueueCopy_NtToWin32,
+    SpFileQueueDelete_NtToWin32,
+    SpFileQueueRename_NtToWin32,
+    SetupCommitFileQueueW
+};
 
 #endif
 

--- a/base/setup/reactos/spapisup/infsupp.c
+++ b/base/setup/reactos/spapisup/infsupp.c
@@ -83,16 +83,19 @@ SetupOpenInfFileExW(
 
 /* GLOBALS *******************************************************************/
 
-pSpInfCloseInfFile  SpInfCloseInfFile  = SetupCloseInfFile;
-pSpInfFindFirstLine SpInfFindFirstLine = SetupFindFirstLineW;
-pSpInfFindNextLine  SpInfFindNextLine  = SetupFindNextLine;
-pSpInfGetFieldCount SpInfGetFieldCount = SetupGetFieldCount;
-pSpInfGetBinaryField  SpInfGetBinaryField  = SetupGetBinaryField;
-pSpInfGetIntField     SpInfGetIntField     = SetupGetIntField;
-pSpInfGetMultiSzField SpInfGetMultiSzField = SetupGetMultiSzFieldW;
-pSpInfGetStringField  SpInfGetStringField  = SetupGetStringFieldW;
-pSpInfGetField    SpInfGetField    = pSetupGetField;
-pSpInfOpenInfFile SpInfOpenInfFile = SetupOpenInfFileExW;
+SPINF_EXPORTS SpInfExports =
+{
+    SetupCloseInfFile,
+    SetupFindFirstLineW,
+    SetupFindNextLine,
+    SetupGetFieldCount,
+    SetupGetBinaryField,
+    SetupGetIntField,
+    SetupGetMultiSzFieldW,
+    SetupGetStringFieldW,
+    pSetupGetField,
+    SetupOpenInfFileExW
+};
 
 
 /* HELPER FUNCTIONS **********************************************************/

--- a/base/setup/usetup/CMakeLists.txt
+++ b/base/setup/usetup/CMakeLists.txt
@@ -35,6 +35,6 @@ endif()
 
 add_pch(usetup usetup.h SOURCE)
 set_module_type(usetup nativecui)
-target_link_libraries(usetup inflib setuplib zlib_solo ext2lib vfatlib btrfslib chkstk ${PSEH_LIB})
-add_importlibs(usetup ntdll)
+target_link_libraries(usetup inflib zlib_solo chkstk)
+add_importlibs(usetup setuplib ntdll)
 add_cd_file(TARGET usetup DESTINATION reactos/system32 NO_CAB NAME_ON_CD smss.exe FOR bootcd regtest)

--- a/base/setup/usetup/spapisup/fileqsup.c
+++ b/base/setup/usetup/spapisup/fileqsup.c
@@ -997,11 +997,14 @@ Quit:
 
 /* GLOBALS *******************************************************************/
 
-pSpFileQueueOpen   SpFileQueueOpen   = SetupOpenFileQueue;
-pSpFileQueueClose  SpFileQueueClose  = SetupCloseFileQueue;
-pSpFileQueueCopy   SpFileQueueCopy   = SetupQueueCopyWithCab;
-pSpFileQueueDelete SpFileQueueDelete = SetupQueueDeleteW;
-pSpFileQueueRename SpFileQueueRename = SetupQueueRenameW;
-pSpFileQueueCommit SpFileQueueCommit = SetupCommitFileQueueW;
+SPFILE_EXPORTS SpFileExports =
+{
+    SetupOpenFileQueue,
+    SetupCloseFileQueue,
+    SetupQueueCopyWithCab,
+    SetupQueueDeleteW,
+    SetupQueueRenameW,
+    SetupCommitFileQueueW
+};
 
 /* EOF */

--- a/base/setup/usetup/spapisup/infsupp.c
+++ b/base/setup/usetup/spapisup/infsupp.c
@@ -228,16 +228,19 @@ SetupOpenInfFileExW(
 
 /* GLOBALS *******************************************************************/
 
-pSpInfCloseInfFile  SpInfCloseInfFile  = SetupCloseInfFile;
-pSpInfFindFirstLine SpInfFindFirstLine = SetupFindFirstLineW;
-pSpInfFindNextLine  SpInfFindNextLine  = SetupFindNextLine;
-pSpInfGetFieldCount SpInfGetFieldCount = SetupGetFieldCount;
-pSpInfGetBinaryField  SpInfGetBinaryField  = SetupGetBinaryField;
-pSpInfGetIntField     SpInfGetIntField     = SetupGetIntField;
-pSpInfGetMultiSzField SpInfGetMultiSzField = SetupGetMultiSzFieldW;
-pSpInfGetStringField  SpInfGetStringField  = SetupGetStringFieldW;
-pSpInfGetField    SpInfGetField    = pSetupGetField;
-pSpInfOpenInfFile SpInfOpenInfFile = SetupOpenInfFileExW;
+SPINF_EXPORTS SpInfExports =
+{
+    SetupCloseInfFile,
+    SetupFindFirstLineW,
+    SetupFindNextLine,
+    SetupGetFieldCount,
+    SetupGetBinaryField,
+    SetupGetIntField,
+    SetupGetMultiSzFieldW,
+    SetupGetStringFieldW,
+    pSetupGetField,
+    SetupOpenInfFileExW
+};
 
 
 /* HELPER FUNCTIONS **********************************************************/

--- a/base/setup/usetup/usetup.h
+++ b/base/setup/usetup/usetup.h
@@ -70,7 +70,6 @@
 
 
 extern HANDLE ProcessHeap;
-extern BOOLEAN IsUnattendedSetup;
 extern PCWSTR SelectedLanguageId;
 
 typedef enum _PAGE_NUMBER

--- a/modules/rostests/unittests/setuplib/CMakeLists.txt
+++ b/modules/rostests/unittests/setuplib/CMakeLists.txt
@@ -11,8 +11,7 @@ list(APPEND SOURCE
     precomp.h)
 
 add_executable(setuplib_unittest ${SOURCE})
-target_link_libraries(setuplib_unittest setuplib ${PSEH_LIB})
 set_module_type(setuplib_unittest win32cui)
-add_importlibs(setuplib_unittest msvcrt kernel32 ntdll)
+add_importlibs(setuplib_unittest setuplib msvcrt kernel32)
 #add_pch(setuplib_unittest precomp.h SOURCE)
 add_rostests_file(TARGET setuplib_unittest)

--- a/modules/rostests/unittests/setuplib/IsValidInstallDirectory.c
+++ b/modules/rostests/unittests/setuplib/IsValidInstallDirectory.c
@@ -7,24 +7,8 @@
 
 #include "precomp.h"
 
-//
-// FIXME: Temporary symbols defined to make linking work.
-// They will be defined to something once INF file testing is implemented.
-//
-pSpInfCloseInfFile  SpInfCloseInfFile  = NULL;
-pSpInfFindFirstLine SpInfFindFirstLine = NULL;
-pSpInfFindNextLine  SpInfFindNextLine  = NULL;
-pSpInfGetFieldCount SpInfGetFieldCount = NULL;
-pSpInfGetBinaryField  SpInfGetBinaryField  = NULL;
-pSpInfGetIntField     SpInfGetIntField     = NULL;
-pSpInfGetMultiSzField SpInfGetMultiSzField = NULL;
-pSpInfGetStringField  SpInfGetStringField  = NULL;
-pSpInfGetField    SpInfGetField    = NULL;
-pSpInfOpenInfFile SpInfOpenInfFile = NULL;
-
-BOOLEAN IsUnattendedSetup = FALSE;
-HANDLE ProcessHeap;
-
+// SPFILE_EXPORTS SpFileExports = {NULL};
+// SPINF_EXPORTS SpInfExports = {NULL};
 
 START_TEST(IsValidInstallDirectory)
 {
@@ -92,8 +76,6 @@ START_TEST(IsValidInstallDirectory)
     };
 
 #define BOOL_TO_STR(b) ((b) ? "TRUE" : "FALSE")
-
-    ProcessHeap = GetProcessHeap();
 
     UINT i;
     for (i = 0; i < _countof(tests); ++i)


### PR DESCRIPTION
## Purpose

Turn setuplib into a DLL shared between TUI and GUI 1st-stage setups, so that the binaries (usetup.exe and the 1st-stage GUI reactos.exe setup) can share code.

_**NOTE:** Since the setuplib itself is work-in-progress, some exported functions may change/be removed or added._

JIRA issue: [CORE-13525](https://jira.reactos.org/browse/CORE-13525)

## Observations

- I've turned most of the exported functions from default cdecl to explicit stdcall / "NTAPI".
- I've collapsed the two phases of `InitializeSetup()` to make the initialization simpler.

## Sizes reductions

**NOTE 1:** All sizes are in bytes.
**NOTE 2:** "Before" is commit e51e5de1f.
**NOTE 2:** `% Reduction = 100 * (Before - After) / Before`

### gcc-i386-Debug-0x502
| File         | Before    | After     | % Reduction |
| :---         | :---      | :---      | :---        |
| reactos.exe  | 1,601,024 | 1,039,872 | 35.05       |
| smss.exe     | 1,364,480 | 805,888   | 40.94       |
| setuplib.dll | 0         | 580,096   |             |
| **Total**    | 2,965,504 | 2,425,856 | 18.20       |

### gcc-i386-Release-0x502
| File         | Before    | After     | % Reduction |
| :---         | :---      | :---      | :---        |
| reactos.exe  | 1,144,250 | 879,444   | 23.14       |
| smss.exe     | 981,545   | 723,268   | 26.31       |
| setuplib.dll | 0         | 297,328   |             |
| **Total**    | 2,125,795 | 1,900,040 | 10.62       |

### gcc-amd64-Debug-0x502
| File         | Before    | After     | % Reduction |
| :---         | :---      | :---      | :---        |
| reactos.exe  | 2,449,708 | 1,372,805 | 43.96       |
| smss.exe     | 2,405,674 | 1,320,478 | 45.11       |
| setuplib.dll | 0         | 1,101,655 |             |
| **Total**    | 4,855,382 | 3,794,938 | 21.84       |

### gcc-amd64-Release-0x502
| File         | Before    | After     | % Reduction |
| :---         | :---      | :---      | :---        |
| reactos.exe  | 1,094,739 | 842,674   | 23.03       |
| smss.exe     | 1,078,998 | 833,237   | 22.78       |
| setuplib.dll | 0         | 283,874   |             |
| **Total**    | 2,173,737 | 1,959,785 | 9.84        |

### msvc14.2-i386-Debug-0x502
| File         | Before    | After     | % Reduction |
| :---         | :---      | :---      | :---        |
| reactos.exe  | 1,236,480 | 803,840   | 34.99       |
| smss.exe     | 1,101,824 | 676,864   | 38.57       |
| setuplib.dll | 0         | 443,904   |             |
| **Total**    | 2,338,304 | 1,924,608 | 17.69       |

### msvc14.2-i386-Release-0x502
| File         | Before    | After     | % Reduction |
| :---         | :---      | :---      | :---        |
| reactos.exe  | 907,264   | 712,704   | 21.44       |
| smss.exe     | 795,136   | 607,232   | 23.63       |
| setuplib.dll | 0         | 203,264   |             |
| **Total**    | 1,702,400 | 1,523,200 | 10.53       |

### msvc14.2-amd64-Debug-0x502
| File         | Before    | After     | % Reduction |
| :---         | :---      | :---      | :---        |
| reactos.exe  | 1,401,344 | 879,104   | 37.27       |
| smss.exe     | 1,351,168 | 836,608   | 38.08       |
| setuplib.dll | 0         | 536,576   |             |
| **Total**    | 2,752,512 | 2,252,288 | 18.17       |

### msvc14.2-amd64-Release-0x502
| File         | Before    | After     | % Reduction |
| :---         | :---      | :---      | :---        |
| reactos.exe  | 950,784   | 735,744   | 22.62       |
| smss.exe     | 946,176   | 739,840   | 21.81       |
| setuplib.dll | 0         | 226,304   |             |
| **Total**    | 1,896,960 | 1,701,888 | 10.28       |
