### PR TITLE
[FREELDR] Change base address for NTLDR compatibility

### DIFF
--- a/boot/freeldr/bootsect/btrfs.S
+++ b/boot/freeldr/bootsect/btrfs.S
@@ -376,17 +376,17 @@ FreeLdrFound:
     call ConvertAddress
     pop cx
 
+    mov bx, FREELDR_BASE / 16
+    mov es, bx
     xor bx, bx
     mov ds, bx
-    mov es, bx
-    mov bx, FREELDR_BASE
     call ReadSectors
 
-    mov  dl, byte ptr [BootDrive]     // Load boot drive into DL
+    mov  dl, byte ptr fs:[BootDrive]     // Load boot drive into DL
     //mov  dh, 0    // Load boot partition into DH (not needed, FreeLbr detects it itself)
 
     /* Transfer execution to the bootloader */
-    ljmp16 0, FREELDR_BASE
+    ljmp16 FREELDR_BASE / 16, 0
 
 
 // Insert chunk into chunk map (located at DS:[CHUNK_MAP_OFFSET])

--- a/boot/freeldr/bootsect/fat.S
+++ b/boot/freeldr/bootsect/fat.S
@@ -228,7 +228,7 @@ FoundFreeLoader:
     // to the helper code. Skip the first three bytes
     // because they contain a jump instruction to skip
     // over the helper code in the FreeLoader image.
-    ljmp16 0, FREELDR_BASE + 3
+    ljmp16 FREELDR_BASE / 16, 3
 
 
 

--- a/boot/freeldr/bootsect/fat.S
+++ b/boot/freeldr/bootsect/fat.S
@@ -29,7 +29,7 @@
 // of the PutChars function in the boot sector.
 //
 // When it locates freeldr.sys on the disk it will
-// load the first sector of the file to 0000:F800
+// load the first sector of the file to FREELDR_BASE
 // With the help of this sector we should be able
 // to load the entire file off the disk, no matter
 // how fragmented it is.
@@ -207,12 +207,12 @@ SearchRootDirSector:
 FoundFreeLoader:
     // We found freeldr.sys on the disk
     // so we need to load the first 512
-    // bytes of it to 0000:F800
+    // bytes of it to FREELDR_BASE
     // ES:DI has dir entry (ES:DI == 07E0:XXXX)
     mov ax, word ptr es:[di + HEX(1a)]      // Get start cluster
     push ax                                 // Save start cluster
     push FREELDR_BASE / 16                  // Put load segment on the stack and load it
-    pop es                                  // Into ES so that we load the cluster at 0000:F800
+    pop es                                  // Into ES so that we load the cluster at FREELDR_BASE
     call ReadCluster                        // Read the cluster
     pop ax                                  // Restore start cluster of FreeLoader
 
@@ -224,7 +224,7 @@ FoundFreeLoader:
 
     // Now AX has start cluster of FreeLoader and we
     // have loaded the helper code in the first 512 bytes
-    // of FreeLoader to 0000:F800. Now transfer control
+    // of FreeLoader to FREELDR_BASE. Now transfer control
     // to the helper code. Skip the first three bytes
     // because they contain a jump instruction to skip
     // over the helper code in the FreeLoader image.

--- a/boot/freeldr/bootsect/fat32.S
+++ b/boot/freeldr/bootsect/fat32.S
@@ -425,7 +425,7 @@ LoadFileDone:
     mov  dh, byte ptr ds:[BootPartition]    // Load boot partition into DH
 
     /* Transfer execution to the bootloader */
-    ljmp16 0, FREELDR_BASE
+    ljmp16 FREELDR_BASE / 16, 0
 
 // Returns the FAT entry for a given cluster number
 // On entry EAX has cluster number

--- a/boot/freeldr/bootsect/faty.S
+++ b/boot/freeldr/bootsect/faty.S
@@ -400,7 +400,7 @@ main:
 
     /* Now the complete freeldr imag is loaded.
        Jump to the realmode entry point. */
-    ljmp16 0, FREELDR_BASE
+    ljmp16 FREELDR_BASE / 16, 0
 
 
 

--- a/boot/freeldr/bootsect/isoboot.S
+++ b/boot/freeldr/bootsect/isoboot.S
@@ -303,7 +303,7 @@ found_drive:
 
 .jump_to_freeldr:
     // Transfer execution to the bootloader.
-    ljmp16 0, FREELDR_BASE
+    ljmp16 FREELDR_BASE / 16, 0
 
 
 /* FUNCTIONS *****************************************************************/

--- a/boot/freeldr/bootsect/ntfs.S
+++ b/boot/freeldr/bootsect/ntfs.S
@@ -417,7 +417,7 @@ StartSearch:
 
     mov    dl, byte ptr [BootDrive]
     mov    dh, byte ptr [BootPartition]
-    ljmp16 0, FREELDR_BASE
+    ljmp16 FREELDR_BASE / 16, 0
 
 // Error message if Freeldr is compressed, encrypted or sparse
 CompressedFreeldr:

--- a/boot/freeldr/bootsect/pc98/fat12fdd.S
+++ b/boot/freeldr/bootsect/pc98/fat12fdd.S
@@ -256,7 +256,7 @@ FoundFreeLoader:
      * because they contain a jump instruction to skip
      * over the helper code in the FreeLoader image
      */
-    ljmp16 0, FREELDR_BASE + 3
+    ljmp16 FREELDR_BASE / 16, 3
 
 /*
  * Reads cluster number in AX into [ES:BX]

--- a/boot/freeldr/bootsect/pc98/fat12fdd.S
+++ b/boot/freeldr/bootsect/pc98/fat12fdd.S
@@ -230,13 +230,13 @@ SearchRootDirSector:
 FoundFreeLoader:
     /*
      * We found freeldr.sys on the disk
-     * so we need to load the first 512 bytes of it to [0000:F800]
+     * so we need to load the first 512 bytes of it to FREELDR_BASE
      * ES:DI has dir entry (ES:DI == 07E0:XXXX)
      */
     mov ax, word ptr es:[di + HEX(1A)]          // Get start cluster
     push ax                                     // Save start cluster
     push FREELDR_BASE / 16                      // Put load segment on the stack and load it
-    pop es                                      // Into ES so that we load the cluster at [0000:F800]
+    pop es                                      // Into ES so that we load the cluster at FREELDR_BASE
     call ReadCluster                            // Read the cluster
     pop ax                                      // Restore start cluster of FreeLoader
 
@@ -251,7 +251,7 @@ FoundFreeLoader:
     /*
      * Now AX has start cluster of FreeLoader and we
      * have loaded the helper code in the first 512 bytes
-     * of FreeLoader to 0000:F800. Now transfer control
+     * of FreeLoader to FREELDR_BASE. Now transfer control
      * to the helper code. Skip the first three bytes
      * because they contain a jump instruction to skip
      * over the helper code in the FreeLoader image

--- a/boot/freeldr/freeldr/arch/amd64/entry.S
+++ b/boot/freeldr/freeldr/arch/amd64/entry.S
@@ -208,13 +208,21 @@ SwitchToRealCompSegment:
     and eax, HEX(7fffffff) //~0x80000000, upper bits cleared
     mov cr0, rax
 
+    /* Set sane segments */
+    mov eax, L_RMODE_DS
+    mov ds, ax
+    mov es, ax
+    mov fs, ax
+    mov gs, ax
+    mov ss, ax
+
 //    mov word ptr [HEX(0b800a)], HEX(0e00) + '5'
 
     /* Step 3 - jump to 16-bit segment to set the limit correctly */
     .byte HEX(0EA) // 32bit long jmp
 AddressOfRealModeEntryPoint:
     .long 0 // receives address of RealModeEntryPoint
-    .word HEX(20)//RMODE_CS
+    .word L_RMODE_CS
     nop
 
 CallRealMode_return:

--- a/boot/freeldr/freeldr/arch/i386/entry.S
+++ b/boot/freeldr/freeldr/arch/i386/entry.S
@@ -214,16 +214,16 @@ i386CallRealMode_return:
  * bx must be set to the ID of the realmode function to call. */
 PUBLIC SwitchToReal
 SwitchToReal:
+    /* Save 32-bit stack pointer */
+    mov dword ptr ds:[stack32], esp
+
     /* Set sane segments */
-    mov ax, PMODE_DS
+    mov ax, RMODE_DS
     mov ds, ax
     mov es, ax
     mov fs, ax
     mov gs, ax
     mov ss, ax
-
-    /* Save 32-bit stack pointer */
-    mov dword ptr ds:[stack32], esp
 
     /* jmp to 16-bit segment to set the limit correctly */
     .byte HEX(0ea) // jmp far RMODE_CS:switch_to_real16

--- a/boot/freeldr/freeldr/arch/i386/multiboot.S
+++ b/boot/freeldr/freeldr/arch/i386/multiboot.S
@@ -33,7 +33,7 @@
  * multiboot kernels above 1MB. So we let GRUB load us
  * there and then relocate ourself to FREELDR_BASE.
  */
-#define INITIAL_BASE HEX(200000)
+#define INITIAL_BASE TEMPCODE_BASE
 
 
 #ifdef _M_IX86
@@ -190,7 +190,7 @@ mb4:
     mov cr0, rax
 
     /* Jump to real entry point */
-    ljmp16 0, FREELDR_BASE
+    ljmp16 FREELDR_BASE / 16, 0
 
 
     /* Force 8-byte alignment */

--- a/boot/freeldr/freeldr/arch/realmode/amd64.S
+++ b/boot/freeldr/freeldr/arch/realmode/amd64.S
@@ -29,11 +29,19 @@ Startup:
     mov byte ptr ds:[BSS_BootPartition], dh
 
     /* Setup a real mode stack */
-    mov sp, word ptr ds:[stack16]
+    mov sp, word ptr cs:[stack16]
+
+    /* Prepare ds for writestr */
+    mov ax, cs
+    mov ds, ax
 
     /* Output first status */
     mov si, offset Msg_Starting
     call writestr
+
+    /* Restore ds */
+    xor ax, ax
+    mov ds, ax
 
     /* Enable A20 address line */
     call EnableA20
@@ -43,9 +51,17 @@ Startup:
     test al, al
     jnz .LongModeSupported
 
+    /* Prepare ds for writestr */
+    mov ax, cs
+    mov ds, ax
+
     /* Output failure message */
     mov si, offset Msg_Unsupported
     call writestr
+
+    /* Restore ds */
+    xor ax, ax
+    mov ds, ax
 
     /* Wait for a keypress */
     int HEX(16)
@@ -60,20 +76,17 @@ Msg_Starting:
 
 .LongModeSupported:
     /* Load the GDT */
-#ifdef _USE_ML
-    lgdt fword ptr [gdtptr]
-#else
-    lgdt cs:[gdtptr]
-#endif
+    lgdt lXdtPrefix cs:[gdtptr]
 
     /* Build the startup page tables */
     call BuildPageTables
 
     /* Store real mode entry point in shared memory */
-    mov dword ptr ds:[BSS_RealModeEntry], offset RealModeEntryPoint
+    mov dword ptr ds:[BSS_RealModeEntry], offset RealModeEntryPoint + FREELDR_BASE
 
     /* Address the image with es segment */
-    mov ax, FREELDR_PE_BASE / 16
+    mov ax, cs
+    add ax, (FREELDR_PE_BASE - FREELDR_BASE) / 16
     mov es, ax
 
     /* Get address of optional header */
@@ -85,7 +98,7 @@ Msg_Starting:
     add eax, FREELDR_PE_BASE
 
     /* Save entry point */
-    mov dword ptr ds:[LongModeEntryPoint], eax
+    mov dword ptr cs:[LongModeEntryPoint], eax
 
     /* Restore es */
     xor ax, ax
@@ -99,17 +112,17 @@ gdt:
     .word HEX(0000), HEX(0000), HEX(0000), HEX(0000) /* 08:  */
     .word HEX(0000), HEX(0000), HEX(9800), HEX(0020) /* 10: long mode CS */
     .word HEX(FFFF), HEX(0000), HEX(F300), HEX(00CF) /* 18: long mode DS */
-    .word HEX(FFFF), HEX(0000), HEX(9E00), HEX(0000) /* 20: 16-bit real mode CS */
+    .word HEX(FFFF), HEX(0000), HEX(9B00), HEX(008F) /* 20: 16-bit flat CS (!) */
     .word HEX(FFFF), HEX(0000), HEX(9200), HEX(0000) /* 28: 16-bit real mode DS */
     .word HEX(FFFF), HEX(0000), HEX(9B00), HEX(00CF) /* 30: compat mode CS */
 
 /* GDT table pointer */
 gdtptr:
-    .word HEX(37)       /* Limit */
+    .word HEX(37)                   /* Limit */
 #ifdef _USE_ML
-    .long offset gdt    /* Base Address */
+    .long offset gdt + FREELDR_BASE /* Base Address */
 #else
-    .long gdt           /* Base Address */
+    .long gdt + FREELDR_BASE        /* Base Address */
 #endif
 
 
@@ -222,7 +235,6 @@ BuildPageTables:
 /******************************************************************************/
 
 #define MSR_EFER HEX(C0000080)
-#define LMODE_CS HEX(10)
 
 /* This is the entry point from long mode */
 RealModeEntryPoint:
@@ -244,7 +256,7 @@ RealModeEntryPoint:
     mov cr0, eax
 
     /* Clear prefetch queue & correct CS */
-    ljmp16 0, InRealMode
+    ljmp16 FREELDR_BASE / 16, InRealMode
 
 InRealMode:
 
@@ -269,28 +281,44 @@ InRealMode:
     xor esp, esp
 
     /* Restore real mode stack */
-    mov sp, word ptr ds:[stack16]
+    mov sp, word ptr cs:[stack16]
 
     // sti /* These are ok now */
 
     /* Do the callback, specified by bx */
     shl bx, 1
-    call word ptr ds:CallbackTable[bx]
+    call word ptr cs:CallbackTable[bx]
 
 ExitToLongMode:
     /* Disable interrupts */
     cli
 
     /* Set correct segment registers */
-    xor ax,ax
-    mov ds,ax
-    mov es,ax
-    mov fs,ax
-    mov gs,ax
-    mov ss,ax
+    xor ax, ax
+    mov ds, ax
+    mov es, ax
+    mov fs, ax
+    mov gs, ax
+    mov ss, ax
 
     /* Save current stack pointer */
-    mov word ptr ds:[stack16], sp
+    mov word ptr cs:[stack16], sp
+
+    /* Set ds to cs segment */
+    mov ax, cs
+    mov ds, ax
+
+    /* Copy the protected mode code to a low address */
+    mov cx, offset LongModeEntryPointEnd - InLongMode
+    mov si, offset InLongMode
+    mov di, TEMPCODE16_BASE
+
+    /* Start the copy */
+    rep movsb
+
+    /* Clear ds */
+    xor ax, ax
+    mov ds, ax
 
     /* Set PAE and PGE: 10100000b */
     mov eax, cr4
@@ -314,7 +342,7 @@ ExitToLongMode:
     mov cr0, eax
 
     /* Clear prefetch queue & correct CS */
-    ljmp16 LMODE_CS, InLongMode
+    ljmp16 LMODE_CS, TEMPCODE16_BASE
 InLongMode:
     //DB 66h, 0B8h, 18h, 00h // mov ax, LMODE_DS
     //DB 66h, 8Eh, 0D8h // mov ds, ax
@@ -326,9 +354,7 @@ InLongMode:
     nop
 LongModeEntryPoint:
     .long 0, 0
-
-    int HEX(16)
-    jmp Reboot
+LongModeEntryPointEnd:
 
 /* FNID_* functions */
 CallbackTable:

--- a/boot/freeldr/freeldr/arch/realmode/amd64.S
+++ b/boot/freeldr/freeldr/arch/realmode/amd64.S
@@ -58,14 +58,7 @@ Msg_Unsupported:
 Msg_Starting:
     .ascii "Starting FreeLoader...", CR, LF, NUL
 
-Msg_LongModeSupported:
-    .ascii "Long mode support detected.", CR, LF, NUL
-
 .LongModeSupported:
-    /* Output status */
-    mov si, offset Msg_LongModeSupported
-    call writestr
-
     /* Load the GDT */
 #ifdef _USE_ML
     lgdt fword ptr [gdtptr]
@@ -98,14 +91,7 @@ Msg_LongModeSupported:
     xor ax, ax
     mov es, ax
 
-    /* Output status */
-    mov si, offset Msg_SwitchToLongMode
-    call writestr
-
     jmp ExitToLongMode
-
-Msg_SwitchToLongMode:
-    .ascii "Switching to long mode....", CR, LF, NUL
 
 .align 8
 gdt:
@@ -141,14 +127,9 @@ CheckFor64BitSupport:
     cmp eax, ebx
     jnz .CheckForPAE
 
-    mov si, offset .Msg_NoCpuidSupport
-    call writestr
     popad
     xor al, al
     ret
-
-.Msg_NoCpuidSupport:
-    .ascii "The system doesn't support CPUID.", CR, LF, NUL
 
 .CheckForPAE:
     /* CPUID support detected - getting the PAE/PGE */
@@ -158,14 +139,9 @@ CheckFor64BitSupport:
     cmp edx, HEX(00A0)
     je .CheckForLongMode
 
-    mov si, offset .Msg_NoPAE
-    call writestr
     popad
     xor al, al
     ret
-
-.Msg_NoPAE:
-    .ascii "PAE or PGE not set.", CR, LF, NUL
 
 .CheckForLongMode:
     /* Check whether extended functions are supported */
@@ -182,14 +158,9 @@ CheckFor64BitSupport:
     jnz .Success
 
 .NoLongMode:
-    mov si, offset .Msg_NoLongMode
-    call writestr
     popad
     xor al, al
     ret
-
-.Msg_NoLongMode:
-    .ascii "Long mode is not supported.", CR, LF, NUL
 
 .Success:
     popad

--- a/boot/freeldr/freeldr/arch/realmode/fathelp.inc
+++ b/boot/freeldr/freeldr/arch/realmode/fathelp.inc
@@ -64,9 +64,19 @@ FatHelperEntryPoint:
     /* First save AX - the start cluster of freeldr.sys */
     push ax
 
+    /* Save ds */
+    push ds
+
+    /* Prepare ds for output message */
+    mov bx, cs
+    mov ds, bx
+
     /* Display "Loading FreeLoader..." message */
     mov si, offset msgLoading
     call word ptr [bp-PutCharsOffset]
+
+    /* Restore ds */
+    pop ds
 
     call ReadFatIntoMemory
 

--- a/boot/freeldr/freeldr/arch/realmode/fathelp.inc
+++ b/boot/freeldr/freeldr/arch/realmode/fathelp.inc
@@ -49,8 +49,8 @@
 
 PUBLIC start
 start:
-    // This code is loaded at 0000:F800 so we have to
-    // encode a jmp instruction to jump to 0000:FA00
+    // This code is loaded at FREELDR_BASE so we have to
+    // encode a jmp instruction to jump to FREELDR_BASE + 0x200
     .byte HEX(e9), HEX(fd), HEX(01)
 
 // Now starts the extra boot code that we will store

--- a/boot/freeldr/freeldr/arch/realmode/helpers.inc
+++ b/boot/freeldr/freeldr/arch/realmode/helpers.inc
@@ -144,7 +144,7 @@ Relocator16Boot:
     and cx, not (EFLAGS_CF or EFLAGS_ZF or EFLAGS_SF)
 
     /* Get flags CF, ZF and SF from the REGS structure */
-    mov ax, word ptr cs:[BSS_RegisterSet + REGS_EFLAGS]
+    mov ax, word ptr ss:[BSS_RegisterSet + REGS_EFLAGS]
     and ax, (EFLAGS_CF or EFLAGS_ZF or EFLAGS_SF)
 
     /* Combine flags and set them */
@@ -153,35 +153,37 @@ Relocator16Boot:
     popf
 
     /* Setup the segment registers */
-    mov ax, word ptr cs:[BSS_RegisterSet + REGS_DS]
+    mov ax, word ptr ss:[BSS_RegisterSet + REGS_DS]
     mov ds, ax
-    mov ax, word ptr cs:[BSS_RegisterSet + REGS_ES]
+    mov ax, word ptr ss:[BSS_RegisterSet + REGS_ES]
     mov es, ax
-    mov ax, word ptr cs:[BSS_RegisterSet + REGS_FS]
+    mov ax, word ptr ss:[BSS_RegisterSet + REGS_FS]
     mov fs, ax
-    mov ax, word ptr cs:[BSS_RegisterSet + REGS_GS]
+    mov ax, word ptr ss:[BSS_RegisterSet + REGS_GS]
     mov gs, ax
 
     /* Patch the jump address (segment:offset) */
-    mov eax, dword ptr cs:[BSS_RealModeEntry]
+    mov eax, dword ptr ss:[BSS_RealModeEntry]
     mov dword ptr cs:[Relocator16Address], eax
 
-    /* Switch the stack (segment:offset) */
-    mov eax, dword ptr cs:[BSS_CallbackReturn]
+    /* Switch the stack (offset) */
+    mov eax, dword ptr ss:[BSS_CallbackReturn]
     shr eax, 16
-    mov ss, ax
-    mov eax, dword ptr cs:[BSS_CallbackReturn]
+    mov eax, dword ptr ss:[BSS_CallbackReturn]
     and eax, HEX(0FFFF)
     mov esp, eax
 
     /* Setup the registers */
-    mov eax, dword ptr cs:[BSS_RegisterSet + REGS_EAX]
-    mov ebx, dword ptr cs:[BSS_RegisterSet + REGS_EBX]
-    mov ecx, dword ptr cs:[BSS_RegisterSet + REGS_ECX]
-    mov edx, dword ptr cs:[BSS_RegisterSet + REGS_EDX]
-    mov esi, dword ptr cs:[BSS_RegisterSet + REGS_ESI]
-    mov edi, dword ptr cs:[BSS_RegisterSet + REGS_EDI]
+    mov eax, dword ptr ss:[BSS_RegisterSet + REGS_EAX]
+    mov ebx, dword ptr ss:[BSS_RegisterSet + REGS_EBX]
+    mov ecx, dword ptr ss:[BSS_RegisterSet + REGS_ECX]
+    mov edx, dword ptr ss:[BSS_RegisterSet + REGS_EDX]
+    mov esi, dword ptr ss:[BSS_RegisterSet + REGS_ESI]
+    mov edi, dword ptr ss:[BSS_RegisterSet + REGS_EDI]
     // Don't setup ebp, we only use it as output! <-- FIXME!
+
+    /* Switch the stack (segment) */
+    mov ss, ax
 
     /* Jump to the new CS:IP (e.g. jump to bootsector code...) */
     .byte HEX(0EA) // ljmp16 segment:offset

--- a/boot/freeldr/freeldr/arch/realmode/helpers_pc98.inc
+++ b/boot/freeldr/freeldr/arch/realmode/helpers_pc98.inc
@@ -198,7 +198,7 @@ Relocator16Boot:
     and cx, not (EFLAGS_CF or EFLAGS_ZF or EFLAGS_SF)
 
     /* Get flags CF, ZF and SF from the REGS structure */
-    mov ax, word ptr cs:[BSS_RegisterSet + REGS_EFLAGS]
+    mov ax, word ptr ss:[BSS_RegisterSet + REGS_EFLAGS]
     and ax, (EFLAGS_CF or EFLAGS_ZF or EFLAGS_SF)
 
     /* Combine flags and set them */
@@ -207,35 +207,37 @@ Relocator16Boot:
     popf
 
     /* Setup the segment registers */
-    mov ax, word ptr cs:[BSS_RegisterSet + REGS_DS]
+    mov ax, word ptr ss:[BSS_RegisterSet + REGS_DS]
     mov ds, ax
-    mov ax, word ptr cs:[BSS_RegisterSet + REGS_ES]
+    mov ax, word ptr ss:[BSS_RegisterSet + REGS_ES]
     mov es, ax
-    mov ax, word ptr cs:[BSS_RegisterSet + REGS_FS]
+    mov ax, word ptr ss:[BSS_RegisterSet + REGS_FS]
     mov fs, ax
-    mov ax, word ptr cs:[BSS_RegisterSet + REGS_GS]
+    mov ax, word ptr ss:[BSS_RegisterSet + REGS_GS]
     mov gs, ax
 
     /* Patch the jump address (segment:offset) */
-    mov eax, dword ptr cs:[BSS_RealModeEntry]
+    mov eax, dword ptr ss:[BSS_RealModeEntry]
     mov dword ptr cs:[Relocator16Address], eax
 
-    /* Switch the stack (segment:offset) */
-    mov eax, dword ptr cs:[BSS_CallbackReturn]
+    /* Switch the stack (offset) */
+    mov eax, dword ptr ss:[BSS_CallbackReturn]
     shr eax, 16
-    mov ss, ax
-    mov eax, dword ptr cs:[BSS_CallbackReturn]
+    mov eax, dword ptr ss:[BSS_CallbackReturn]
     and eax, HEX(0FFFF)
     mov esp, eax
 
     /* Setup the registers */
-    mov eax, dword ptr cs:[BSS_RegisterSet + REGS_EAX]
-    mov ebx, dword ptr cs:[BSS_RegisterSet + REGS_EBX]
-    mov ecx, dword ptr cs:[BSS_RegisterSet + REGS_ECX]
-    mov edx, dword ptr cs:[BSS_RegisterSet + REGS_EDX]
-    mov esi, dword ptr cs:[BSS_RegisterSet + REGS_ESI]
-    mov edi, dword ptr cs:[BSS_RegisterSet + REGS_EDI]
-    mov ebp, dword ptr cs:[BSS_RegisterSet + REGS_EBP]
+    mov eax, dword ptr ss:[BSS_RegisterSet + REGS_EAX]
+    mov ebx, dword ptr ss:[BSS_RegisterSet + REGS_EBX]
+    mov ecx, dword ptr ss:[BSS_RegisterSet + REGS_ECX]
+    mov edx, dword ptr ss:[BSS_RegisterSet + REGS_EDX]
+    mov esi, dword ptr ss:[BSS_RegisterSet + REGS_ESI]
+    mov edi, dword ptr ss:[BSS_RegisterSet + REGS_EDI]
+    mov ebp, dword ptr ss:[BSS_RegisterSet + REGS_EBP]
+
+    /* Switch the stack (segment) */
+    mov ss, ax
 
     /* Jump to the new CS:IP */
     .byte HEX(0EA) /* ljmp16 segment:offset */

--- a/boot/freeldr/freeldr/arch/realmode/i386.S
+++ b/boot/freeldr/freeldr/arch/realmode/i386.S
@@ -25,16 +25,29 @@ RealModeEntryPoint:
     mov ss, ax
 
     /* Setup the stack */
-    mov sp, word ptr ds:[stack16]
+    mov sp, word ptr cs:[stack16]
+
+    /* Prepare ds for writestr */
+    mov ax, cs
+    mov ds, ax
+
+    /* Output first status */
+    mov si, offset Msg_Starting
+    call writestr
+
+    /* Restore ds */
+    xor ax, ax
+    mov ds, ax
 
     /* Enable A20 address line */
     call EnableA20
 
     /* Save real mode entry point in shared memory */
-    mov dword ptr ds:[BSS_RealModeEntry], offset switch_to_real16
+    mov dword ptr ds:[BSS_RealModeEntry], offset switch_to_real16 + FREELDR_BASE
 
     /* Address the image with es segment */
-    mov ax, FREELDR_PE_BASE / 16
+    mov ax, cs
+    add ax, (FREELDR_PE_BASE - FREELDR_BASE) / 16
     mov es, ax
 
     /* Get address of optional header */
@@ -46,7 +59,7 @@ RealModeEntryPoint:
     add eax, FREELDR_PE_BASE
 
     /* Save entry point */
-    mov dword ptr ds:[pm_entrypoint], eax
+    mov dword ptr cs:[pm_entrypoint], eax
 
     /* Restore es */
     xor ax, ax
@@ -54,25 +67,18 @@ RealModeEntryPoint:
 
     jmp exit_to_protected
 
+Msg_Starting:
+    .ascii "Starting FreeLoader...", CR, LF, NUL
 
 /* This is the entry point from protected mode */
 switch_to_real16:
-
-    /* Restore segment registers to correct limit */
-    mov ax, RMODE_DS
-    mov ds, ax
-    mov es, ax
-    mov fs, ax
-    mov gs, ax
-    mov ss, ax
-
     /* Disable Protected Mode */
     mov eax, cr0
     and eax, CR0_PE_CLR
     mov cr0, eax
 
     /* Clear prefetch queue & correct CS */
-    ljmp16 0, inrmode
+    ljmp16 FREELDR_BASE / 16, inrmode
 
 inrmode:
     /* Set real mode segments */
@@ -92,20 +98,16 @@ inrmode:
     xor esp, esp
 
     /* Restore real mode stack */
-    mov sp, word ptr ds:[stack16]
+    mov sp, word ptr cs:[stack16]
 
     /* Load IDTR with real mode value */
-#ifdef _USE_ML
-    lidt fword ptr rmode_idtptr
-#else
-    lidt rmode_idtptr
-#endif
+    lidt lXdtPrefix cs:[rmode_idtptr]
 
     sti /* These are ok now */
 
     /* Do the callback, specified by bx */
     shl bx, 1
-    call word ptr ds:CallbackTable[bx]
+    call word ptr cs:CallbackTable[bx]
 
 
 /*
@@ -117,14 +119,26 @@ exit_to_protected:
     cli
 
     /* Save current stack pointer */
-    mov word ptr ds:[stack16], sp
+    mov word ptr cs:[stack16], sp
 
     /* Load the GDT */
-#ifdef _USE_ML
-    lgdt fword ptr gdtptr
-#else
-    lgdt gdtptr
-#endif
+    lgdt lXdtPrefix cs:[gdtptr]
+
+    /* Set ds to cs segment */
+    mov ax, cs
+    mov ds, ax
+
+    /* Copy the protected mode code to a low address */
+    mov cx, offset pm_entrypoint_end - inpmode
+    mov si, offset inpmode
+    mov di, TEMPCODE16_BASE
+
+    /* Start the copy */
+    rep movsb
+
+    /* Clear ds */
+    xor ax, ax
+    mov ds, ax
 
     /* Enable Protected Mode */
     mov eax, cr0
@@ -132,13 +146,17 @@ exit_to_protected:
     mov cr0, eax
 
     /* Clear prefetch queue & correct CS */
-    ljmp16 PMODE_CS, inpmode
+    ljmp16 PMODE_CS, TEMPCODE16_BASE
 inpmode:
     .byte HEX(0ff), HEX(25) // opcode of indirect jump
-    .word pm_entrypoint, 0
+#ifdef _USE_ML
+    .long (offset pm_entrypoint - inpmode) + TEMPCODE16_BASE
+#else
+    .long (pm_entrypoint - inpmode) + TEMPCODE16_BASE
+#endif
 pm_entrypoint:
     .long 0 // receives address of PE entry point
-    nop
+pm_entrypoint_end:
 
 /* FNID_* functions */
 CallbackTable:
@@ -176,27 +194,31 @@ gdt:
     .word HEX(9200)
     .word HEX(00CF)
 
-    /* 16-bit real mode CS */
+    /* 16-bit flat CS (!) */
     .word HEX(FFFF)
     .word HEX(0000)
-    .word HEX(9E00)
-    .word HEX(0000)
+    .word HEX(9B00)
+    .word HEX(008F)
 
     /* 16-bit real mode DS */
     .word HEX(FFFF)
     .word HEX(0000)
-    .word HEX(9200)
+    .word HEX(9300)
     .word HEX(0000)
 
 /* GDT table pointer */
 gdtptr:
-    .word HEX(27)       /* Limit */
-    .word gdt, 0        /* Base Address */
+    .word HEX(27)                   /* Limit */
+#ifdef _USE_ML
+    .long offset gdt + FREELDR_BASE /* Base Address */
+#else
+    .long gdt + FREELDR_BASE        /* Base Address */
+#endif
 
 /* Real-mode IDT pointer */
 rmode_idtptr:
-    .word HEX(3FF)      /* Limit */
-    .long 0             /* Base Address */
+    .word HEX(3FF)                  /* Limit */
+    .long 0                         /* Base Address */
 
 #include "int386.inc"
 #if defined(SARCH_PC98)

--- a/boot/freeldr/freeldr/arch/realmode/int386.inc
+++ b/boot/freeldr/freeldr/arch/realmode/int386.inc
@@ -10,8 +10,8 @@ Int386:
     pushad
 
     /* Get the interrupt vector and patch the opcode */
-    mov al, byte ptr ds:[BSS_IntVector]
-    mov byte ptr ds:[Int386_vector_opcode], al
+    mov al, byte ptr ss:[BSS_IntVector]
+    mov byte ptr cs:[Int386_vector_opcode], al
 
     /* Get current EFLAGS and mask CF, ZF and SF */
     pushf
@@ -19,7 +19,7 @@ Int386:
     and cx, not (EFLAGS_CF or EFLAGS_ZF or EFLAGS_SF)
 
     /* Get flags CF, ZF and SF from the REGS structure */
-    mov ax, word ptr cs:[BSS_RegisterSet + REGS_EFLAGS]
+    mov ax, word ptr ss:[BSS_RegisterSet + REGS_EFLAGS]
     and ax, (EFLAGS_CF or EFLAGS_ZF or EFLAGS_SF)
 
     /* Combine flags and set them */
@@ -28,33 +28,33 @@ Int386:
     popf
 
     /* Setup the registers */
-    mov ax, word ptr cs:[BSS_RegisterSet + REGS_DS]
+    mov ax, word ptr ss:[BSS_RegisterSet + REGS_DS]
     mov ds, ax
-    mov ax, word ptr cs:[BSS_RegisterSet + REGS_ES]
+    mov ax, word ptr ss:[BSS_RegisterSet + REGS_ES]
     mov es, ax
-    mov ax, word ptr cs:[BSS_RegisterSet + REGS_FS]
+    mov ax, word ptr ss:[BSS_RegisterSet + REGS_FS]
     mov fs, ax
-    mov ax, word ptr cs:[BSS_RegisterSet + REGS_GS]
+    mov ax, word ptr ss:[BSS_RegisterSet + REGS_GS]
     mov gs, ax
 
     /* Setup ebp only if EBP != 0, otherwise use it only as output */
-    mov eax, dword ptr cs:[BSS_RegisterSet + REGS_EBP]
+    mov eax, dword ptr ss:[BSS_RegisterSet + REGS_EBP]
     test eax, eax
     jz Int386_set_registers
     mov ebp, eax
 
 Int386_set_registers:
-    mov eax, dword ptr cs:[BSS_RegisterSet + REGS_EAX]
-    mov ebx, dword ptr cs:[BSS_RegisterSet + REGS_EBX]
-    mov ecx, dword ptr cs:[BSS_RegisterSet + REGS_ECX]
-    mov edx, dword ptr cs:[BSS_RegisterSet + REGS_EDX]
-    mov esi, dword ptr cs:[BSS_RegisterSet + REGS_ESI]
-    mov edi, dword ptr cs:[BSS_RegisterSet + REGS_EDI]
+    mov eax, dword ptr ss:[BSS_RegisterSet + REGS_EAX]
+    mov ebx, dword ptr ss:[BSS_RegisterSet + REGS_EBX]
+    mov ecx, dword ptr ss:[BSS_RegisterSet + REGS_ECX]
+    mov edx, dword ptr ss:[BSS_RegisterSet + REGS_EDX]
+    mov esi, dword ptr ss:[BSS_RegisterSet + REGS_ESI]
+    mov edi, dword ptr ss:[BSS_RegisterSet + REGS_EDI]
 #if defined(SARCH_PC98)
     /* Always set EBP register even if its equals zero.
      * Otherwise the DISK BIOS calls will store garbage data in a output buffer.
      */
-    mov ebp, dword ptr cs:[BSS_RegisterSet + REGS_EBP]
+    mov ebp, dword ptr ss:[BSS_RegisterSet + REGS_EBP]
 #endif
 
     /* Call the interrupt vector */
@@ -64,25 +64,25 @@ Int386_vector_opcode:
     .byte 00
 
     /* Save the registers */
-    mov dword ptr cs:[BSS_RegisterSet + REGS_EAX], eax
-    mov dword ptr cs:[BSS_RegisterSet + REGS_EBX], ebx
-    mov dword ptr cs:[BSS_RegisterSet + REGS_ECX], ecx
-    mov dword ptr cs:[BSS_RegisterSet + REGS_EDX], edx
-    mov dword ptr cs:[BSS_RegisterSet + REGS_ESI], esi
-    mov dword ptr cs:[BSS_RegisterSet + REGS_EDI], edi
-    mov dword ptr cs:[BSS_RegisterSet + REGS_EBP], ebp
+    mov dword ptr ss:[BSS_RegisterSet + REGS_EAX], eax
+    mov dword ptr ss:[BSS_RegisterSet + REGS_EBX], ebx
+    mov dword ptr ss:[BSS_RegisterSet + REGS_ECX], ecx
+    mov dword ptr ss:[BSS_RegisterSet + REGS_EDX], edx
+    mov dword ptr ss:[BSS_RegisterSet + REGS_ESI], esi
+    mov dword ptr ss:[BSS_RegisterSet + REGS_EDI], edi
+    mov dword ptr ss:[BSS_RegisterSet + REGS_EBP], ebp
 
     mov ax, ds
-    mov word ptr cs:[BSS_RegisterSet + REGS_DS], ax
+    mov word ptr ss:[BSS_RegisterSet + REGS_DS], ax
     mov ax, es
-    mov word ptr cs:[BSS_RegisterSet + REGS_ES], ax
+    mov word ptr ss:[BSS_RegisterSet + REGS_ES], ax
     mov ax, fs
-    mov word ptr cs:[BSS_RegisterSet + REGS_FS], ax
+    mov word ptr ss:[BSS_RegisterSet + REGS_FS], ax
     mov ax, gs
-    mov word ptr cs:[BSS_RegisterSet + REGS_GS], ax
+    mov word ptr ss:[BSS_RegisterSet + REGS_GS], ax
 
     pushfd
-    pop dword ptr cs:[BSS_RegisterSet + REGS_EFLAGS]
+    pop dword ptr ss:[BSS_RegisterSet + REGS_EFLAGS]
 
     /* Restore all registers + segment registers */
     popad

--- a/boot/freeldr/freeldr/include/arch/pc/x86common.h
+++ b/boot/freeldr/freeldr/include/arch/pc/x86common.h
@@ -75,7 +75,9 @@
 #define RMODE_DS    HEX(20)    /* RMode data selector, base 0 limit 64k */
 //#else
 /* Long mode selectors */
-#define LMODE_CS HEX(10)
-#define LMODE_DS HEX(18)
-#define CMODE_CS HEX(30)
+#define LMODE_CS    HEX(10)
+#define LMODE_DS    HEX(18)
+#define L_RMODE_CS  HEX(20)
+#define L_RMODE_DS  HEX(28)
+#define CMODE_CS    HEX(30)
 //#endif

--- a/boot/freeldr/freeldr/include/arch/pc/x86common.h
+++ b/boot/freeldr/freeldr/include/arch/pc/x86common.h
@@ -12,11 +12,13 @@
 #define BIOSCALLBUFFER      HEX(4000) /* Buffer to store temporary data for any Int386() call */
 #define STACK16ADDR         HEX(6F00) /* The 16-bit stack top will be at 0000:6F00 */
 #define BSS_START           HEX(6F00)
-#define STACKLOW            HEX(7000)
+#define STACKLOW            HEX(8000)
 #define STACKADDR           HEX(F000) /* The 32/64-bit stack top will be at 0000:F000, or 0xF000 */
-#define FREELDR_BASE        HEX(F800)
-#define FREELDR_PE_BASE    HEX(10000)
-#define MEMORY_MARGIN      HEX(88000) /* We need this much memory */
+#define FREELDR_BASE        HEX(20000)
+#define FREELDR_PE_BASE     HEX(30000)
+#define TEMPCODE_BASE       HEX(200000)
+#define TEMPCODE16_BASE     HEX(7000)
+#define MEMORY_MARGIN       HEX(99000) /* We need this much memory */
 
 #define BIOSCALLBUFSEGMENT (BIOSCALLBUFFER/16) /* Buffer to store temporary data for any Int386() call */
 #define BIOSCALLBUFOFFSET   HEX(0000) /* Buffer to store temporary data for any Int386() call */

--- a/boot/freeldr/freeldr/pcat.cmake
+++ b/boot/freeldr/freeldr/pcat.cmake
@@ -9,16 +9,18 @@
 ##              Copyright 2023 Hermès Bélusca-Maïto <hermes.belusca-maito@reactos.org>
 ##
 
+set(FRLDR16_BASE 0000)
+
 if(ARCH STREQUAL "i386")
     CreateBootSectorTarget(frldr16
         ${CMAKE_CURRENT_SOURCE_DIR}/arch/realmode/i386.S
         ${CMAKE_CURRENT_BINARY_DIR}/frldr16.bin
-        F800)
+        ${FRLDR16_BASE})
 elseif(ARCH STREQUAL "amd64")
     CreateBootSectorTarget(frldr16
         ${CMAKE_CURRENT_SOURCE_DIR}/arch/realmode/amd64.S
         ${CMAKE_CURRENT_BINARY_DIR}/frldr16.bin
-        F800)
+        ${FRLDR16_BASE})
 endif()
 
 
@@ -197,7 +199,7 @@ if(MSVC)
     if(ARCH STREQUAL "arm")
         target_link_options(freeldr_pe PRIVATE /ignore:4078 /ignore:4254 /DRIVER)
     else()
-        target_link_options(freeldr_pe PRIVATE /ignore:4078 /ignore:4254 /DYNAMICBASE:NO /FIXED /FILEALIGN:512 /ALIGN:512)
+        target_link_options(freeldr_pe PRIVATE /ignore:4078 /ignore:4254 /DRIVER /FIXED /FILEALIGN:512 /ALIGN:512)
         add_linker_script(freeldr_pe freeldr_i386.msvc.lds)
     endif()
     # We don't need hotpatching
@@ -213,7 +215,7 @@ else()
                     COMMAND ${CMAKE_STRIP} --strip-all $<TARGET_FILE:freeldr_pe>)
 endif()
 
-set_image_base(freeldr_pe 0x10000)
+set_image_base(freeldr_pe 0x30000)
 set_subsystem(freeldr_pe native)
 set_entrypoint(freeldr_pe RealEntryPoint)
 

--- a/boot/freeldr/freeldr/pcat.cmake
+++ b/boot/freeldr/freeldr/pcat.cmake
@@ -159,13 +159,16 @@ add_library(freeldr_common
     ${PCATLDR_BOOTMGR_SOURCE}
     ${FREELDR_NTLDR_SOURCE})
 
-if(MSVC AND CMAKE_C_COMPILER_ID STREQUAL "Clang")
+if(MSVC)
     # We need to reduce the binary size
     target_compile_options(freeldr_common PRIVATE "/Os")
 endif()
 if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
     # Prevent using SSE (no support in freeldr)
     target_compile_options(freeldr_common PUBLIC -mno-sse)
+
+    # We need to reduce the binary size
+    target_compile_options(freeldr_common PUBLIC -Os)
 endif()
 
 set(PCH_SOURCE

--- a/boot/freeldr/notes.txt
+++ b/boot/freeldr/notes.txt
@@ -21,16 +21,16 @@ FreeLoader Boot Process
 FAT 12/16/32 Boot Sector
 
     The BIOS loads the boot sector at 0000:7C00. The FAT12/16 boot sector just
-searches for FREELDR.SYS and loads its first 512 bytes to 0000:F800. This extra
+searches for FREELDR.SYS and loads its first 512 bytes to 0002:0000. This extra
 helper code enables it to fully navigate the file allocation table. The boot
 sector then jumps to FREELDR.SYS entry point at 0000:F803 and the helper code
 takes the relay. It finishes loading the FREELDR.SYS image and finally jumps to
-its final entry point at 0000:FA00.
+its final entry point at 0002:0200.
     The FAT32 boot sector loads its extra sector at 0000:7E00 and looks for
-FREELDR.SYS on the file system. Once found it loads FREELDR.SYS to 0000:F800
+FREELDR.SYS on the file system. Once found it loads FREELDR.SYS to 0002:0000
 and jumps to its entry point at the same address. This allows it to jump over
 the FAT12/16 extra helper code situated at this address, and go to the final
-entry point at 0000:FA00.
+entry point at 0002:0200.
 
 
 ISO-9660 (CD-ROM) Boot Sector
@@ -38,8 +38,8 @@ ISO-9660 (CD-ROM) Boot Sector
     The BIOS loads the boot sector (2048 bytes) at 0000:7C00. First, the
 boot sector relocates itself to 0000:7000 (up to 0000:7800). Then it looks
 for the LOADER directory and makes it the current directory. Next it looks
-for FREELDR.SYS and loads it at 0000:F800. Finally it restores the boot drive
-number in the DL register and jumps to FreeLoader's entry point at 0000:F800.
+for FREELDR.SYS and loads it at 0002:0000. Finally it restores the boot drive
+number in the DL register and jumps to FreeLoader's entry point at 0002:0000.
 
 
 Multiboot
@@ -48,7 +48,7 @@ Multiboot
 multiboot-compliant loader (like GRUB). The multiboot header instructs the
 primary loader to load FREELDR.SYS at 0x200000 (needs to be above 1MB). Control
 is then transferred to the multiboot entry point. Since FREELDR.SYS expects to
-be loaded at a base address 0000:F800 it will start by relocating itself there
+be loaded at a base address 0002:0000 it will start by relocating itself there
 and then jumping to the relocated copy.
 
 


### PR DESCRIPTION
## Purpose

This PR has the same purpose as #7501 but it changes the base address instead of "that relocation haxxory".

JIRA issue: [CORE-19882](https://jira.reactos.org/browse/CORE-19882)

## TODO

- [x] Prepare amd64 to base address change
- [ ] Resolve the unaligned base address that happens only with MSVC <= I'm currently stuck here
- [x] Adapt bootsectors
