### PR TITLE
Clang build fixes/improvements

### DIFF
--- a/base/services/nfsd/CMakeLists.txt
+++ b/base/services/nfsd/CMakeLists.txt
@@ -55,6 +55,9 @@ else()
     # FIXME: Tons of warnings.
     target_compile_options(nfsd PRIVATE "-w")
 endif()
+if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
+    target_compile_options(nfsd PRIVATE -Wno-incompatible-function-pointer-types)
+endif()
 
 target_link_libraries(nfsd oldnames)
 

--- a/dll/directx/wine/d3drm/CMakeLists.txt
+++ b/dll/directx/wine/d3drm/CMakeLists.txt
@@ -28,3 +28,7 @@ target_link_libraries(d3drm dxguid uuid wine)
 add_importlibs(d3drm ddraw d3dxof msvcrt kernel32 ntdll)
 add_pch(d3drm precomp.h SOURCE)
 add_cd_file(TARGET d3drm DESTINATION reactos/system32 FOR all)
+
+if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
+    target_compile_options(d3drm PRIVATE -Wno-incompatible-function-pointer-types)
+endif()

--- a/dll/win32/msxml3/CMakeLists.txt
+++ b/dll/win32/msxml3/CMakeLists.txt
@@ -81,6 +81,10 @@ if(MSVC)
     target_compile_options(msxml3 PRIVATE /wd4090)
 endif()
 
+if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
+    target_compile_options(msxml3 PRIVATE -Wno-incompatible-function-pointer-types)
+endif()
+
 add_importlibs(msxml3 urlmon ws2_32 shlwapi oleaut32 ole32 user32 msvcrt kernel32 ntdll)
 add_dependencies(msxml3 xmlparser_idlheader stdole2) # msxml3_v1.tlb needs stdole2.tlb
 add_pch(msxml3 precomp.h "${PCH_SKIP_SOURCE}")

--- a/drivers/filesystems/fastfat/create.c
+++ b/drivers/filesystems/fastfat/create.c
@@ -2356,7 +2356,7 @@ Return Value:
         if ((CreateDisposition != FILE_OPEN) &&
             (CreateDisposition != FILE_OPEN_IF)) {
 
-            try_return( Iosb.Status = STATUS_ACCESS_DENIED );
+            try_return( Status = STATUS_ACCESS_DENIED );
         }
 
         //
@@ -2389,7 +2389,7 @@ Return Value:
             if (!FlagOn(ShareAccess, FILE_SHARE_READ) &&
                 !FatIsHandleCountZero( IrpContext, Vcb )) {
 
-                try_return( Iosb.Status = STATUS_SHARING_VIOLATION );
+                try_return( Status = STATUS_SHARING_VIOLATION );
             }
 
             //
@@ -2412,14 +2412,14 @@ Return Value:
 
                 if (Vcb->OpenFileCount != 0) {
 
-                    try_return( Iosb.Status = STATUS_SHARING_VIOLATION );
+                    try_return( Status = STATUS_SHARING_VIOLATION );
                 }
 
             } else {
 
                 if (Vcb->ReadOnlyCount != Vcb->OpenFileCount) {
 
-                    try_return( Iosb.Status = STATUS_SHARING_VIOLATION );
+                    try_return( Status = STATUS_SHARING_VIOLATION );
                 }
             }
 
@@ -2487,13 +2487,13 @@ Return Value:
 
         if (Vcb->DirectAccessOpenCount > 0) {
 
-            if (!NT_SUCCESS(Iosb.Status = IoCheckShareAccess( *DesiredAccess,
+            if (!NT_SUCCESS(Status = IoCheckShareAccess( *DesiredAccess,
                                                               ShareAccess,
                                                               FileObject,
                                                               &Vcb->ShareAccess,
                                                               TRUE ))) {
 
-                try_return( Iosb.Status );
+                try_return( NOTHING );
             }
 
         } else {
@@ -2546,7 +2546,7 @@ Return Value:
         //  And set our status to success
         //
 
-        Iosb.Status = STATUS_SUCCESS;
+        Status = STATUS_SUCCESS;
         Iosb.Information = FILE_OPENED;
 
     try_exit: NOTHING;
@@ -2558,7 +2558,7 @@ Return Value:
         //  If this is an abnormal termination then undo our work
         //
 
-        if (_SEH2_AbnormalTermination() || !NT_SUCCESS(Iosb.Status)) {
+        if (_SEH2_AbnormalTermination() || !NT_SUCCESS(Status)) {
 
             if (UnwindCounts) {
                 Vcb->DirectAccessOpenCount -= 1;
@@ -2570,9 +2570,10 @@ Return Value:
             if (UnwindVolumeLock) { Vcb->VcbState &= ~VCB_STATE_FLAG_LOCKED; }
         }
 
-        DebugTrace(-1, Dbg, "FatOpenVolume -> Iosb.Status = %08lx\n", Iosb.Status);
+        DebugTrace(-1, Dbg, "FatOpenVolume -> Iosb.Status = %08lx\n", Status);
     } _SEH2_END;
 
+    Iosb.Status = Status;
     return Iosb;
 }
 

--- a/drivers/filesystems/udfs/CMakeLists.txt
+++ b/drivers/filesystems/udfs/CMakeLists.txt
@@ -25,7 +25,7 @@ list(APPEND SOURCE
     mem.cpp
     misc.cpp
     namesup.cpp
-    pnp.cpp
+    #pnp.cpp
     read.cpp
     secursup.cpp
     shutdown.cpp

--- a/drivers/wdm/audio/drivers/CMIDriver/CMakeLists.txt
+++ b/drivers/wdm/audio/drivers/CMIDriver/CMakeLists.txt
@@ -30,6 +30,10 @@ if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
     target_compile_options(cmipci PRIVATE -Wno-write-strings -Wno-switch)
 endif()
 
+if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
+    target_compile_options(cmipci PRIVATE -Wno-enum-constexpr-conversion)
+endif()
+
 add_pch(cmipci precomp.h "${PCH_SKIP_SOURCE}")
 add_cd_file(TARGET cmipci DESTINATION reactos/system32/drivers FOR all)
 

--- a/sdk/cmake/gcc.cmake
+++ b/sdk/cmake/gcc.cmake
@@ -115,22 +115,22 @@ add_compile_options(-march=${OARCH} -mtune=${TUNE})
 # Warnings, errors
 if((NOT CMAKE_BUILD_TYPE STREQUAL "Release") AND (NOT CMAKE_C_COMPILER_ID STREQUAL Clang))
     add_compile_options(-Werror)
-else()
-    if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
-        add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Werror=unknown-warning-option>)
-    endif()
 endif()
 
 add_compile_options(-Wall -Wpointer-arith)
-add_compile_options(-Wno-char-subscripts -Wno-multichar -Wno-unused-value)
-add_compile_options(-Wno-unused-const-variable)
-add_compile_options(-Wno-unused-local-typedefs)
-add_compile_options(-Wno-deprecated)
-add_compile_options(-Wno-unused-result) # FIXME To be removed when CORE-17637 is resolved
 
-if(NOT CMAKE_C_COMPILER_ID STREQUAL "Clang")
-    add_compile_options(-Wno-maybe-uninitialized)
-endif()
+# Disable some overzealous warnings
+add_compile_options(
+    -Wno-unknown-warning-option
+    -Wno-char-subscripts
+    -Wno-multichar
+    -Wno-unused-value
+    -Wno-unused-const-variable
+    -Wno-unused-local-typedefs
+    -Wno-deprecated
+    -Wno-unused-result # FIXME To be removed when CORE-17637 is resolved
+    -Wno-maybe-uninitialized
+)
 
 if(ARCH STREQUAL "amd64")
     add_compile_options(-Wno-format)

--- a/sdk/cmake/msvc.cmake
+++ b/sdk/cmake/msvc.cmake
@@ -147,8 +147,20 @@ endif()
 add_compile_options(/w14115)
 
 if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
-    add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Werror=unknown-warning-option>)
-    add_compile_options("$<$<COMPILE_LANGUAGE:C,CXX>:-nostdinc;-Wno-multichar;-Wno-char-subscripts;-Wno-microsoft-enum-forward-reference;-Wno-pragma-pack;-Wno-microsoft-anon-tag;-Wno-parentheses-equality;-Wno-unknown-pragmas>")
+    add_compile_options("$<$<COMPILE_LANGUAGE:C,CXX>:-nostdinc>")
+    add_compile_options(
+        -Wno-unknown-warning-option
+        -Wno-multichar
+        -Wno-char-subscripts
+        -Wno-microsoft-enum-forward-reference
+        -Wno-pragma-pack
+        -Wno-microsoft-anon-tag
+        -Wno-parentheses-equality
+        -Wno-unknown-pragmas
+        -Wno-ignored-pragmas
+        -Wno-ignored-pragma-intrinsic
+        -Wno-microsoft-exception-spec
+    )
 endif()
 
 # Debugging

--- a/sdk/include/crt/math.h
+++ b/sdk/include/crt/math.h
@@ -99,7 +99,7 @@ _Check_return_ _CRT_JIT_INTRINSIC double __cdecl sqrt(_In_ double x);
 _Check_return_ double __cdecl tan(_In_ double x);
 _Check_return_ double __cdecl tanh(_In_ double x);
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__)
 /* Prevent the compiler from generating calls to _CIatan2 */
 #pragma function(atan2)
 #ifdef _M_AMD64
@@ -148,7 +148,7 @@ _Check_return_ _CRTIMP int __cdecl _set_SSE2_enable(_In_ int flag);
 _Check_return_ _CRTIMP float __cdecl _nextafterf(_In_ float x, _In_ float y);
 _Check_return_ _CRTIMP int __cdecl _isnanf(_In_ float x);
 _Check_return_ _CRTIMP int __cdecl _fpclassf(_In_ float x);
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__)
 /* Prevent the compiler from generating calls to __vdecl_floor2 */
 #pragma function(floor)
 #endif
@@ -202,7 +202,7 @@ _Check_return_ float __cdecl sqrtf(_In_ float x);
 _Check_return_ float __cdecl tanf(_In_ float x);
 _Check_return_ float __cdecl tanhf(_In_ float x);
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !defined(__clang__)
 /* Make sure intrinsics don't get in our way */
 #if defined(_M_AMD64) || defined(_M_ARM) || defined(_M_ARM64)
 #pragma function(acosf,asinf,atanf,atan2f,ceilf,cosf,coshf,expf,floorf,fmodf,logf,log10f,powf,sinf,sinhf,sqrtf,tanf,tanhf)
@@ -269,7 +269,7 @@ _Check_return_ __CRT_INLINE long double ldexpl(_In_ long double x, _In_ int y) {
 _Check_return_ __CRT_INLINE long double modfl(_In_ long double x, _Out_ long double *y) { return (long double)modf((double)x, (double *)y); }
 
 /* Support for some functions, not exported in MSVCRT */
-#if (_MSC_VER >= 1929)
+#if (_MSC_VER >= 1929) && !defined(__clang__)
 _Check_return_ long lrint(_In_ double x);
 _Check_return_ long lrintf(_In_ float x);
 _Check_return_ long lrintl(_In_ long double x);

--- a/sdk/include/crt/stdlib.h
+++ b/sdk/include/crt/stdlib.h
@@ -1428,7 +1428,7 @@ extern "C" {
 
   __MINGW_EXTENSION _Check_return_ lldiv_t __cdecl lldiv(_In_ long long, _In_ long long);
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !defined(__clang__)
   _Check_return_ long long __cdecl llabs(_In_ long long _j);
   #pragma function(llabs)
 #endif

--- a/sdk/include/psdk/rpc.h
+++ b/sdk/include/psdk/rpc.h
@@ -5,10 +5,6 @@
 #endif /* _INC_WINDOWS */
 #endif
 
-#if defined(__USE_PSEH2__) && !defined(RC_INVOKED)
-#include  <pseh/pseh2.h>
-#endif
-
 #ifndef __RPC_H__
 #define __RPC_H__
 

--- a/sdk/include/reactos/wine/exception.h
+++ b/sdk/include/reactos/wine/exception.h
@@ -3,10 +3,7 @@
 
 #include <setjmp.h>
 #include <intrin.h>
-#ifdef __USE_PSEH2__
-# include <pseh/pseh2.h>
-# include <pseh/excpt.h>
-#endif
+#include <excpt.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -63,7 +60,7 @@ typedef struct _WINE_EXCEPTION_REGISTRATION_RECORD
 #define __EXCEPT(func) _SEH2_EXCEPT(func(_SEH2_GetExceptionInformation()))
 #define __EXCEPT_CTX(func, ctx) _SEH2_EXCEPT((func)(GetExceptionInformation(), ctx))
 #define __EXCEPT_PAGE_FAULT _SEH2_EXCEPT(_SEH2_GetExceptionCode() == STATUS_ACCESS_VIOLATION)
-#define __EXCEPT_ALL _SEH2_EXCEPT(_SEH_EXECUTE_HANDLER)
+#define __EXCEPT_ALL _SEH2_EXCEPT(1)
 #define __ENDTRY _SEH2_END
 #define __FINALLY(func) _SEH2_FINALLY { func(!_SEH2_AbnormalTermination()); }
 #define __FINALLY_CTX(func, ctx) _SEH2_FINALLY { func(!_SEH2_AbnormalTermination(), ctx); }; _SEH2_END

--- a/sdk/include/vcruntime/excpt.h
+++ b/sdk/include/vcruntime/excpt.h
@@ -74,7 +74,7 @@ typedef enum _EXCEPTION_DISPOSITION
 
 #endif
 
-#if defined(_MSC_VER) || (defined(__clang__) && defined(__SEH__))
+#if (defined(_MSC_VER) || (defined(__clang__) && defined(__SEH__))) && !defined(_exception_code)
   unsigned long __cdecl _exception_code(void);
   void *__cdecl _exception_info(void);
   int __cdecl _abnormal_termination(void);

--- a/sdk/include/vcruntime/mingw32/intrin_x86.h
+++ b/sdk/include/vcruntime/mingw32/intrin_x86.h
@@ -95,14 +95,14 @@ __INTRIN_INLINE void _ReadWriteBarrier(void)
 #define _ReadBarrier _ReadWriteBarrier
 #define _WriteBarrier _ReadWriteBarrier
 
-#if !HAS_BUILTIN(_mm_mfence)
+#if !HAS_BUILTIN(_mm_mfence) && !defined(__clang__)
 __INTRIN_INLINE void _mm_mfence(void)
 {
 	__asm__ __volatile__("mfence" : : : "memory");
 }
 #endif
 
-#if !HAS_BUILTIN(_mm_lfence)
+#if !HAS_BUILTIN(_mm_lfence)&& !defined(__clang__)
 __INTRIN_INLINE void _mm_lfence(void)
 {
 	_ReadBarrier();
@@ -1301,8 +1301,13 @@ __INTRIN_INLINE unsigned long __cdecl _lrotr(unsigned long value, int shift)
 }
 #endif
 
-#ifdef __x86_64__
-__INTRIN_INLINE unsigned long long __ll_lshift(unsigned long long Mask, int Bit)
+#if defined __x86_64__
+#if defined(__clang__) && defined(_MSC_VER) // stupid hack because clang is broken
+static inline __attribute__((__always_inline__))
+#else
+__INTRIN_INLINE
+#endif
+unsigned long long __ll_lshift(unsigned long long Mask, int Bit)
 {
     unsigned long long retval;
     unsigned char shift = Bit & 0x3F;
@@ -1348,7 +1353,12 @@ __INTRIN_INLINE unsigned long long __ull_rshift(unsigned long long Mask, int Bit
 	just confuses it. Also we declare Bit as an int and then truncate it to
 	match Visual C++ behavior
 */
-__INTRIN_INLINE unsigned long long __ll_lshift(unsigned long long Mask, int Bit)
+#if defined(__clang__) && defined(_MSC_VER) // stupid hack because clang is broken
+static inline __attribute__((__always_inline__))
+#else
+__INTRIN_INLINE
+#endif
+unsigned long long __ll_lshift(unsigned long long Mask, int Bit)
 {
 	unsigned long long retval = Mask;
 
@@ -1641,15 +1651,19 @@ __INTRIN_INLINE unsigned long __cdecl _outpd(unsigned short Port, unsigned long 
 
 /*** System information ***/
 
+#if !HAS_BUILTIN(__cpuid)
 __INTRIN_INLINE void __cpuid(int CPUInfo[4], int InfoType)
 {
 	__asm__ __volatile__("cpuid" : "=a" (CPUInfo[0]), "=b" (CPUInfo[1]), "=c" (CPUInfo[2]), "=d" (CPUInfo[3]) : "a" (InfoType));
 }
+#endif
 
+#if !HAS_BUILTIN(__cpuidex)
 __INTRIN_INLINE void __cpuidex(int CPUInfo[4], int InfoType, int ECXValue)
 {
 	__asm__ __volatile__("cpuid" : "=a" (CPUInfo[0]), "=b" (CPUInfo[1]), "=c" (CPUInfo[2]), "=d" (CPUInfo[3]) : "a" (InfoType), "c" (ECXValue));
 }
+#endif
 
 #if !HAS_BUILTIN(__rdtsc)
 __INTRIN_INLINE unsigned long long __rdtsc(void)
@@ -1972,8 +1986,12 @@ __INTRIN_INLINE void __invlpg(void *Address)
 
 
 /*** System operations ***/
-
-__INTRIN_INLINE unsigned long long __readmsr(unsigned long reg)
+#if defined(__clang__) && defined(_MSC_VER) // stupid hack because clang is broken
+static inline __attribute__((__always_inline__))
+#else
+__INTRIN_INLINE
+#endif
+unsigned long long __readmsr(unsigned long reg)
 {
 #ifdef __x86_64__
 	unsigned long low, high;
@@ -1986,7 +2004,12 @@ __INTRIN_INLINE unsigned long long __readmsr(unsigned long reg)
 #endif
 }
 
-__INTRIN_INLINE void __writemsr(unsigned long Register, unsigned long long Value)
+#if defined(__clang__) && defined(_MSC_VER) // stupid hack because clang is broken
+static inline __attribute__((__always_inline__))
+#else
+__INTRIN_INLINE
+#endif
+void __writemsr(unsigned long Register, unsigned long long Value)
 {
 #ifdef __x86_64__
 	__asm__ __volatile__("wrmsr" : : "a" (Value), "d" (Value >> 32), "c" (Register));

--- a/sdk/include/vcruntime/vcruntime.h
+++ b/sdk/include/vcruntime/vcruntime.h
@@ -25,7 +25,7 @@
 #define _CRT_UNPARENTHESIZE_(...) __VA_ARGS__
 #define _CRT_UNPARENTHESIZE(...)  _CRT_UNPARENTHESIZE_ __VA_ARGS__
 
-#ifndef _MSC_VER
+#if !defined(_MSC_VER) && !defined(__pragma)
 #define __pragma(x) _Pragma(_CRT_STRINGIZE(x))
 #endif
 

--- a/sdk/include/vcruntime/xmmintrin.h
+++ b/sdk/include/vcruntime/xmmintrin.h
@@ -531,14 +531,14 @@ do {                                              \
 
 /* Use inline functions on GCC/Clang */
 
-#if !HAS_BUILTIN(_mm_getcsr)
+#if !HAS_BUILTIN(_mm_getcsr) && !defined(_MSC_VER)
 __INTRIN_INLINE_SSE unsigned int _mm_getcsr(void)
 {
     return __builtin_ia32_stmxcsr();
 }
 #endif
 
-#if !HAS_BUILTIN(_mm_setcsr)
+#if !HAS_BUILTIN(_mm_setcsr) && !defined(_MSC_VER)
 __INTRIN_INLINE_SSE void _mm_setcsr(unsigned int a)
 {
     __builtin_ia32_ldmxcsr(a);
@@ -1136,7 +1136,7 @@ __INTRIN_INLINE_SSE void _mm_stream_ps(float *__p, __m128 __a)
 #endif
 }
 
-#if !HAS_BUILTIN(_mm_sfence)
+#if !HAS_BUILTIN(_mm_sfence) && !defined(_MSC_VER)
 __INTRIN_INLINE_SSE void _mm_sfence(void)
 {
     __builtin_ia32_sfence();

--- a/sdk/lib/3rdparty/zlib/CMakeLists.txt
+++ b/sdk/lib/3rdparty/zlib/CMakeLists.txt
@@ -31,6 +31,9 @@ list(APPEND MINIZIP_SOURCE
     contrib/minizip/zip.c
     contrib/minizip/zip.h)
 
+if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
+    add_compile_options(-Wno-deprecated-non-prototype)
+endif()
 
 if(CMAKE_CROSSCOMPILING)
     add_library(zlib ${SOURCE} ${SOLO_SOURCE})

--- a/sdk/lib/pseh/CMakeLists.txt
+++ b/sdk/lib/pseh/CMakeLists.txt
@@ -57,5 +57,4 @@ target_include_directories(pseh INTERFACE include)
 # Make it clear that we are using PSEH2
 if ((CMAKE_C_COMPILER_ID STREQUAL "GNU") OR
     ((CMAKE_C_COMPILER_ID STREQUAL "Clang") AND (NOT (ARCH STREQUAL "amd64"))))
-    target_compile_definitions(pseh INTERFACE __USE_PSEH2__)
 endif()

--- a/sdk/lib/pseh/include/pseh/pseh2.h
+++ b/sdk/lib/pseh/include/pseh/pseh2.h
@@ -25,7 +25,7 @@
 
 #define __USE_PSEH2__
 
-#if defined(_USE_NATIVE_SEH) || (defined(_MSC_VER) && !(defined(__clang__) && defined(_M_AMD64)))
+#if defined(_USE_NATIVE_SEH) || defined(_MSC_VER)
 
 #define _SEH2_TRY __try
 #define _SEH2_FINALLY __finally

--- a/sdk/lib/pseh/include/pseh/pseh2.h
+++ b/sdk/lib/pseh/include/pseh/pseh2.h
@@ -23,6 +23,8 @@
 #ifndef KJK_PSEH2_H_
 #define KJK_PSEH2_H_
 
+#define __USE_PSEH2__
+
 #if defined(_USE_NATIVE_SEH) || (defined(_MSC_VER) && !(defined(__clang__) && defined(_M_AMD64)))
 
 #define _SEH2_TRY __try
@@ -85,6 +87,14 @@ _Pragma("GCC diagnostic pop")
 #define _SEH2_YIELD(STMT_) STMT_
 #define _SEH2_LEAVE goto __seh2_scope_end__;
 #define _SEH2_VOLATILE volatile
+
+#define __try _SEH2_TRY
+#define __except _SEH2_EXCEPT
+#define __finally _SEH2_FINALLY
+#define __endtry _SEH2_END
+#define __leave _SEH2_LEAVE
+#define _exception_code() 0
+#define _exception_info() ((void*)0)
 
 #elif defined(_USE_PSEH3)
 


### PR DESCRIPTION
## Purpose

A number of fixes and improvements for clang build.

## Proposed changes

- Fix build with clang-cl 17 (shipped with VS 2022)
- Fix PSEH usage with clang
- Silence a number of warnings

## Tests
- ✅ KVM x86: https://reactos.org/testman/compare.php?ids=99304,99487,99493,99506,99512