### PR TITLE
[CMAKE][SPEC2DEF] Improve debug handling

### DIFF
--- a/dll/ntdll/def/ntdll.spec
+++ b/dll/ntdll/def/ntdll.spec
@@ -1767,8 +1767,8 @@
 @ cdecl -arch=i386 -ret64 _alldiv(double double)
 @ cdecl -arch=i386 _alldvrm()
 @ cdecl -arch=i386 -ret64 _allmul(double double)
-@ cdecl -arch=i386 -norelay _alloca_probe()
-@ cdecl -version=0x600+ -arch=i386 _alloca_probe_16()
+@ cdecl -arch=i386 -norelay -private _alloca_probe()
+@ cdecl -version=0x600+ -arch=i386 -private _alloca_probe_16()
 @ stub -version=0x600+ -arch=i386 _alloca_probe_8
 @ cdecl -arch=i386 -ret64 _allrem(double double)
 @ cdecl -arch=i386 _allshl()

--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -1584,9 +1584,9 @@ LRESULT CAutoComplete::OnNCDestroy(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL
     m_hwndSizeBox.m_pDropDown = NULL;
 
     // destroy controls
-    m_hwndList.DestroyWindow();
-    m_hwndScrollBar.DestroyWindow();
-    m_hwndSizeBox.DestroyWindow();
+    if (m_hwndList) m_hwndList.DestroyWindow();
+    if (m_hwndScrollBar) m_hwndScrollBar.DestroyWindow();
+    if (m_hwndSizeBox) m_hwndSizeBox.DestroyWindow();
 
     // clean up
     m_hwndCombo = NULL;

--- a/dll/win32/iernonce/registry.cpp
+++ b/dll/win32/iernonce/registry.cpp
@@ -311,8 +311,11 @@ BOOL RunOnceExInstance::Exec(_In_opt_ HWND hwnd)
         m_SectionList[i].CloseAndDelete(m_RegKey);
     }
 
-    m_RegKey.DeleteValue(L"Title");
-    m_RegKey.DeleteValue(L"Flags");
+    if (m_RegKey)
+    {
+        m_RegKey.DeleteValue(L"Title");
+        m_RegKey.DeleteValue(L"Flags");
+    }
 
     // Notify the dialog all sections are handled.
     if (hwnd)

--- a/modules/rosapps/applications/explorer-old/shell/fatfs.cpp
+++ b/modules/rosapps/applications/explorer-old/shell/fatfs.cpp
@@ -141,7 +141,7 @@ void FATDirectory::read_directory(int scan_flags)
 			s = (const char*)p->Ent->B;	// no change of the pointer, just to avoid overung warnings in code checkers
 
 			 // read long file name
-			TCHAR lname[] = {s[1], s[3], s[5], s[7], s[9], s[14], s[16], s[18], s[20], s[22], s[24], s[28], s[30]};
+			char lname[] = {s[1], s[3], s[5], s[7], s[9], s[14], s[16], s[18], s[20], s[22], s[24], s[28], s[30]};
 
 			long_name = String(lname, 13) + long_name;
 		}
@@ -397,7 +397,7 @@ bool FATDirectory::read_dir()
 				}
 			}
 
-		buf->dat[0] = 0;	 // Endekennzeichen für Rekurs setzen
+		buf->dat[0] = 0;	 // Endekennzeichen fÃ¼r Rekurs setzen
 	}
 
 	return true;

--- a/sdk/cmake/gcc.cmake
+++ b/sdk/cmake/gcc.cmake
@@ -373,11 +373,16 @@ function(fixup_load_config _target)
         DEPENDS native-pefixup)
 endfunction()
 
+if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR
+   CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+    set(__spec2def_dbg_arg "--dbg")
+endif()
+
 function(generate_import_lib _libname _dllname _spec_file __version_arg)
     # Generate the def for the import lib
     add_custom_command(
         OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${_libname}_implib.def
-        COMMAND native-spec2def ${__version_arg} -n=${_dllname} -a=${ARCH2} ${ARGN} --implib -d=${CMAKE_CURRENT_BINARY_DIR}/${_libname}_implib.def ${CMAKE_CURRENT_SOURCE_DIR}/${_spec_file}
+        COMMAND native-spec2def ${__version_arg} ${__spec2def_dbg_arg} -n=${_dllname} -a=${ARCH2} ${ARGN} --implib -d=${CMAKE_CURRENT_BINARY_DIR}/${_libname}_implib.def ${CMAKE_CURRENT_SOURCE_DIR}/${_spec_file}
         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${_spec_file} native-spec2def)
 
     # With this, we let DLLTOOL create an import library
@@ -450,7 +455,7 @@ function(spec2def _dllname _spec_file)
     # Generate exports def and C stubs file for the DLL
     add_custom_command(
         OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${_file}.def ${CMAKE_CURRENT_BINARY_DIR}/${_file}_stubs.c
-        COMMAND native-spec2def -n=${_dllname} -a=${ARCH2} -d=${CMAKE_CURRENT_BINARY_DIR}/${_file}.def -s=${CMAKE_CURRENT_BINARY_DIR}/${_file}_stubs.c ${__with_relay_arg} ${__version_arg} ${CMAKE_CURRENT_SOURCE_DIR}/${_spec_file}
+        COMMAND native-spec2def -n=${_dllname} -a=${ARCH2} -d=${CMAKE_CURRENT_BINARY_DIR}/${_file}.def -s=${CMAKE_CURRENT_BINARY_DIR}/${_file}_stubs.c ${__with_relay_arg} ${__version_arg} ${__spec2def_dbg_arg} ${CMAKE_CURRENT_SOURCE_DIR}/${_spec_file}
         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${_spec_file} native-spec2def)
 
     # Do not use precompiled headers for the stub file

--- a/sdk/cmake/host-tools.cmake
+++ b/sdk/cmake/host-tools.cmake
@@ -91,6 +91,10 @@ function(setup_host_tools)
             )
     endif()
 
+    if(NOT DEFINED HOST_BUILD_TYPE)
+        set(HOST_BUILD_TYPE Release)
+    endif()
+
     ExternalProject_Add(host-tools
         SOURCE_DIR ${REACTOS_SOURCE_DIR}
         PREFIX ${REACTOS_BINARY_DIR}/host-tools
@@ -102,6 +106,8 @@ function(setup_host_tools)
             -DCMAKE_INSTALL_PREFIX=${REACTOS_BINARY_DIR}/host-tools
             -DTOOLS_FOLDER=${REACTOS_BINARY_DIR}/host-tools/bin
             -DTARGET_COMPILER_ID=${CMAKE_C_COMPILER_ID}
+            -DTARGET_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+            -DCMAKE_BUILD_TYPE=${HOST_BUILD_TYPE}
             ${CMAKE_HOST_TOOLS_EXTRA_ARGS}
         BUILD_ALWAYS TRUE
         INSTALL_COMMAND ${CMAKE_COMMAND} -E true

--- a/sdk/cmake/msvc.cmake
+++ b/sdk/cmake/msvc.cmake
@@ -155,7 +155,7 @@ endif()
 if(NOT (_PREFAST_ OR _VS_ANALYZE_))
     add_compile_options($<$<CONFIG:Debug>:/Zi>)
 endif()
-add_compile_definitions($<$<CONFIG:Release>:NDEBUG>)
+add_compile_definitions($<$<CONFIG:Release>:NDEBUG=>)
 
 # Hotpatchable images
 if(ARCH STREQUAL "i386")

--- a/sdk/cmake/msvc.cmake
+++ b/sdk/cmake/msvc.cmake
@@ -320,6 +320,11 @@ function(fixup_load_config _target)
     # msvc knows how to generate a load_config so no hacks here
 endfunction()
 
+if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR
+   CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+    set(__spec2def_dbg_arg "--dbg")
+endif()
+
 function(generate_import_lib _libname _dllname _spec_file __version_arg)
 
     set(_def_file ${CMAKE_CURRENT_BINARY_DIR}/${_libname}_implib.def)
@@ -329,7 +334,7 @@ function(generate_import_lib _libname _dllname _spec_file __version_arg)
     # Generate the def, asm stub and alias files
     add_custom_command(
         OUTPUT ${_asm_stubs_file} ${_def_file} ${_asm_impalias_file}
-        COMMAND native-spec2def --ms ${__version_arg} -a=${SPEC2DEF_ARCH} --implib -n=${_dllname} -d=${_def_file} -l=${_asm_stubs_file} -i=${_asm_impalias_file} ${CMAKE_CURRENT_SOURCE_DIR}/${_spec_file}
+        COMMAND native-spec2def --ms ${__version_arg} ${__spec2def_dbg_arg} -a=${SPEC2DEF_ARCH} --implib -n=${_dllname} -d=${_def_file} -l=${_asm_stubs_file} -i=${_asm_impalias_file} ${CMAKE_CURRENT_SOURCE_DIR}/${_spec_file}
         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${_spec_file} native-spec2def)
 
     # Compile the generated asm stub file
@@ -402,7 +407,7 @@ function(spec2def _dllname _spec_file)
     # Generate exports def and C stubs file for the DLL
     add_custom_command(
         OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${_file}.def ${CMAKE_CURRENT_BINARY_DIR}/${_file}_stubs.c
-        COMMAND native-spec2def --ms -a=${SPEC2DEF_ARCH} -n=${_dllname} -d=${CMAKE_CURRENT_BINARY_DIR}/${_file}.def -s=${CMAKE_CURRENT_BINARY_DIR}/${_file}_stubs.c ${__with_relay_arg} ${__version_arg} ${CMAKE_CURRENT_SOURCE_DIR}/${_spec_file}
+        COMMAND native-spec2def --ms -a=${SPEC2DEF_ARCH} -n=${_dllname} -d=${CMAKE_CURRENT_BINARY_DIR}/${_file}.def -s=${CMAKE_CURRENT_BINARY_DIR}/${_file}_stubs.c ${__with_relay_arg} ${__version_arg} ${__spec2def_dbg_arg} ${CMAKE_CURRENT_SOURCE_DIR}/${_spec_file}
         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${_spec_file} native-spec2def)
 
     # Do not use precompiled headers for the stub file

--- a/sdk/include/crt/crtdbg.h
+++ b/sdk/include/crt/crtdbg.h
@@ -4,6 +4,7 @@
  * No warranty is given; refer to the file DISCLAIMER within this package.
  */
 #include <corecrt.h>
+#include <intrin.h>
 
 #ifndef _INC_CRTDBG
 #define _INC_CRTDBG

--- a/sdk/tools/CMakeLists.txt
+++ b/sdk/tools/CMakeLists.txt
@@ -48,6 +48,10 @@ if ((ARCH STREQUAL "amd64") AND (TARGET_COMPILER_ID STREQUAL "GNU"))
     add_subdirectory(gcc_plugin_seh)
 endif()
 
+if (TARGET_BUILD_TYPE)
+    # Silence warning about unused variable
+endif()
+
 if(NOT MSVC)
     add_host_tool(pefixup pefixup.c)
     if (ARCH STREQUAL "amd64" OR ARCH STREQUAL "arm64")

--- a/sdk/tools/spec2def/spec2def.c
+++ b/sdk/tools/spec2def/spec2def.c
@@ -67,6 +67,7 @@ int gbImportLib = 0;
 int gbNotPrivateNoWarn = 0;
 int gbTracing = 0;
 int giArch = ARCH_X86;
+int gbDbgExports = 0;
 char *pszArchString = "i386";
 char *pszArchString2;
 char *pszSourceFileName = NULL;
@@ -1162,6 +1163,13 @@ ParseFile(char* pcStart, FILE *fileDest, unsigned *cExports)
 
                 } while (*pc == ',');
             }
+            else if (CompareToken(pc, "-dbg"))
+            {
+                if (!gbDbgExports)
+                {
+                    included = 0;
+                }
+            }
             else if (CompareToken(pc, "-private"))
             {
                 exp.uFlags |= FL_PRIVATE;
@@ -1505,6 +1513,7 @@ void usage(void)
            "  -s=<file>               generate a stub file\n"
            "  -i=<file>               generate an import alias file\n"
            "  --ms                    MSVC compatibility\n"
+           "  --dbg                   Enable debug exports\n"
            "  -n=<name>               name of the dll\n"
            "  --version=<version>     Sets the version to create exports for\n"
            "  --implib                generate a def file for an import library\n"
@@ -1570,6 +1579,10 @@ int main(int argc, char *argv[])
         else if (strcasecmp(argv[i], "--ms") == 0)
         {
             gbMSComp = 1;
+        }
+        else if (strcasecmp(argv[i], "--dbg") == 0)
+        {
+            gbDbgExports = 1;
         }
         else if (strcasecmp(argv[i], "--no-private-warnings") == 0)
         {


### PR DESCRIPTION
## Purpose

A few changes to improve the handling of Debug vs Release builds.

## Proposed changes

- [CMAKE] Fix definition of NDEBUG on MSVC release builds
- [CMAKE] Build host-tools as release by default
- [SPEC2DEF] Implement support for debug-only exports

Update:
Removed "[REACTOS] Globally define _DEBUG", because it still causes assertion failures. Needs more investigation.

## Tests
- ✅ KVM x86: https://reactos.org/testman/compare.php?ids=99848,99853,99856