### PR TITLE
[WINMM] PlaySound: Fix user environment variables handling

### DIFF
--- a/dll/win32/winmm/CMakeLists.txt
+++ b/dll/win32/winmm/CMakeLists.txt
@@ -30,7 +30,7 @@ endif()
 
 set_module_type(winmm win32dll)
 target_link_libraries(winmm wine ${PSEH_LIB} oldnames)
-add_importlibs(winmm advapi32 user32 msvcrt kernel32 ntdll)
+add_importlibs(winmm userenv advapi32 user32 msvcrt kernel32 ntdll)
 add_pch(winmm winemm.h SOURCE)
 add_cd_file(TARGET winmm DESTINATION reactos/system32 FOR all)
 


### PR DESCRIPTION
## Purpose
Currently, if the user environment variables (for example: `%Temp%`) are specified in the path of a system sound. The `PlaySound` function still use the system environment variables when impersonating (for example: `%Temp%` will be expanded to `C:\ReactOS\Temp` instead of the user's Temp folder). This is incorrect.

JIRA issue: [CORE-13951](https://jira.reactos.org/browse/CORE-13951)