### PR TITLE
[FREELDR] peloader.c: Fix PE import binding

### DIFF
--- a/boot/freeldr/freeldr/lib/peloader.c
+++ b/boot/freeldr/freeldr/lib/peloader.c
@@ -136,15 +136,15 @@ PeLdrpLoadAndScanReferencedDll(
 
 static BOOLEAN
 PeLdrpBindImportName(
-    IN OUT PLIST_ENTRY ModuleListHead,
-    IN PVOID DllBase,
-    IN PVOID ImageBase,
-    IN PIMAGE_THUNK_DATA ThunkData,
-    IN PIMAGE_EXPORT_DIRECTORY ExportDirectory,
-    IN ULONG ExportSize,
-    IN BOOLEAN ProcessForwards,
-    IN PCSTR DirectoryPath,
-    IN PLIST_ENTRY Parent)
+    _Inout_ PLIST_ENTRY ModuleListHead,
+    _In_ PVOID DllBase,
+    _In_ PVOID ImageBase,
+    _Inout_ PIMAGE_THUNK_DATA ThunkData,
+    _In_ PIMAGE_EXPORT_DIRECTORY ExportDirectory,
+    _In_ ULONG ExportSize,
+    _In_ BOOLEAN ProcessForwards,
+    _In_ PCSTR DirectoryPath,
+    _In_ PLIST_ENTRY Parent)
 {
     ULONG Ordinal;
     PULONG NameTable, FunctionTable;
@@ -448,12 +448,12 @@ PeLdrpLoadAndScanReferencedDll(
 
 static BOOLEAN
 PeLdrpScanImportAddressTable(
-    IN OUT PLIST_ENTRY ModuleListHead,
-    IN PVOID DllBase,
-    IN PVOID ImageBase,
-    IN PIMAGE_THUNK_DATA ThunkData,
-    IN PCSTR DirectoryPath,
-    IN PLIST_ENTRY Parent)
+    _Inout_ PLIST_ENTRY ModuleListHead,
+    _In_ PVOID DllBase,
+    _In_ PVOID ImageBase,
+    _Inout_ PIMAGE_THUNK_DATA ThunkData,
+    _In_ PCSTR DirectoryPath,
+    _In_ PLIST_ENTRY Parent)
 {
     PIMAGE_EXPORT_DIRECTORY ExportDirectory = NULL;
     BOOLEAN Success;


### PR DESCRIPTION
## Purpose / Proposed changes

Use the PE import table's OriginalFirstThunk array when scanning and
resolving imports during DLL binding.

It points to an array of pointer-sized IMAGE_THUNK_DATA structures
which describe the functions being imported. On the other hand, the
FirstThunk points to an array of pointers, whose initial values are
a copy of those pointed to by OriginalFirstThunk, but are replaced
by the actual function pointers determined at runtime, when a DLL
is loaded (see PeLdrpBindImportName() function).
If we were to use the FirstThunk array to find again later the imports
by name or ordinal, we would fail because these are replaced by the
addresses of the corresponding functions.

This fixes loading kdcom.dll from Windows XP x64 with FreeLDR when
testing on ReactOS x64.

```diff
 (freeldr\freeldr\lib\peloader.c:498) trace: PeLdrpScanImportAddressTable() ---- Calling PeLdrpBindImportName() in a loop
 (freeldr\freeldr\lib\peloader.c:501) trace: *** ThunkName->u1.AddressOfData = 00000000000070F0
 (freeldr\freeldr\lib\peloader.c:502) trace: *** ThunkData->u1.AddressOfData = 0000000000573780
 (freeldr\freeldr\lib\peloader.c:209) trace:   !!! ExportDirectory->NumberOfNames 1504
-(freeldr\freeldr\lib\peloader.c:210) trace:   !!! ImportHint 0 - ExportName 'CcCanIWrite' - ImportDataName ''
+(freeldr\freeldr\lib\peloader.c:210) trace:   !!! ImportHint 282 - ExportName 'HalPrivateDispatchTable' - ImportDataName 'HalPrivateDispatchTable'
 ....
-(freeldr\freeldr\lib\peloader.c:268) err: Did not find export ''!
-(freeldr\freeldr\lib\peloader.c:709) err: PeLdrpScanImportAddressTable() failed: ImportName = 'ntoskrnl.exe', DirectoryPath = 'multi(0)disk(0)rdisk(0)partition(2)\ReactOS\system32\'
```
('-': lines before the fix; '+': lines after the fix)

Code has been adapted based from the following functions:
ntdll/ldr/ldrpe.c!LdrpSnapThunk() and LdrpSnapIAT()
ntoskrnl/mm/ARM3/sysldr.c!MiSnapThunk() and MiResolveImageReferences()

References:
https://devblogs.microsoft.com/oldnewthing/20231129-00/?p=109077
https://devblogs.microsoft.com/oldnewthing/20231130-00/?p=109084
https://stackoverflow.com/questions/42413937/why-pe-need-original-first-thunkoft
