### PR TITLE
[NTOS:KD64] KdpAllowDisable(): Fix DR7 check in x86; implement the function for x64

### DIFF
--- a/ntoskrnl/kd64/amd64/kdx64.c
+++ b/ntoskrnl/kd64/amd64/kdx64.c
@@ -363,8 +363,21 @@ NTSTATUS
 NTAPI
 KdpAllowDisable(VOID)
 {
-    UNIMPLEMENTED;
-    return STATUS_ACCESS_DENIED;
+    ULONG i;
+
+    /* Loop every processor */
+    for (i = 0; i < KeNumberProcessors; i++)
+    {
+        PKPROCESSOR_STATE ProcessorState = &KiProcessorBlock[i]->ProcessorState;
+
+        /* If any processor breakpoints are active,
+         * we can't allow running without a debugger */
+        if (ProcessorState->SpecialRegisters.KernelDr7 & 0xFF)
+            return STATUS_ACCESS_DENIED;
+    }
+
+    /* No processor breakpoints, allow disabling the debugger */
+    return STATUS_SUCCESS;
 }
 
 /* EOF */

--- a/ntoskrnl/kd64/i386/kdx86.c
+++ b/ntoskrnl/kd64/i386/kdx86.c
@@ -426,23 +426,19 @@ NTSTATUS
 NTAPI
 KdpAllowDisable(VOID)
 {
-    LONG i;
-    ULONG Dr7;
+    ULONG i;
 
     /* Loop every processor */
     for (i = 0; i < KeNumberProcessors; i++)
     {
-        /* Get its DR7 */
-        Dr7 =  KiProcessorBlock[i]->ProcessorState.SpecialRegisters.KernelDr7;
+        PKPROCESSOR_STATE ProcessorState = &KiProcessorBlock[i]->ProcessorState;
 
-        /* Check if any processor breakpoints are active */
-        if (Dr7 != 0)
-        {
-            /* We can't allow running without a debugger then */
+        /* If any processor breakpoints are active,
+         * we can't allow running without a debugger */
+        if (ProcessorState->SpecialRegisters.KernelDr7 & 0xFF)
             return STATUS_ACCESS_DENIED;
-        }
     }
 
-    /* No processor breakpoints; allow disabling the debugger */
+    /* No processor breakpoints, allow disabling the debugger */
     return STATUS_SUCCESS;
 }


### PR DESCRIPTION
### _Necessary for PR #7424 and #7426 (`SysDbgDisableKernelDebugger` and `SysDbgEnableKernelDebugger`)_

## Purpose / Proposed changes

- ### `[NTOS:KD64] kdx86.c: Fix the Dr7 check to verify whether disabling the debugger is allowed.`

  Don't check the whole Dr7 value, but only the first 8 bits that
  correspond to the local/global enable breakpoints.

  We cannot check the whole value because some of the Dr7 bits are
  reserved always set to 1 (bit 10), or describe other debug state.

- ### `[NTOS:KD64] kdx64.c: Implement KdpAllowDisable() the same as in x86.`

  AMD64 has the same DR7 register as x86 with the same bits meanings,
  thus the same implementation can be used.

## References

- https://en.wikipedia.org/wiki/X86_debug_register#DR7_-_Debug_control

- AMD64 Architecture Programmer’s Manual, Volume 2: System Programming
  https://www.amd.com/content/dam/amd/en/documents/processor-tech-docs/programmer-references/24593.pdf
  Section "13.1.1.4 Debug-Control Register (DR7)"
  pgs. 393-396 (pgs. 455-458 of the PDF)

- Intel® 64 and IA-32 Architectures Software Developer’s Manual,
  Volume 3 (3A, 3B, 3C, & 3D): System Programming Guide
  https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html
  Section "19.2.4 Debug Control Register (DR7)" (pgs. 644-646)
  Section "19.2.6 Debug Registers and Intel® 64 Processors" (pg. 647)
