### PR TITLE
[NTOS:KD64] KdInitSystem(): Poll for break-in on symbol load *ONLY* at boot-time.

### DIFF
--- a/ntoskrnl/kd64/kdinit.c
+++ b/ntoskrnl/kd64/kdinit.c
@@ -208,7 +208,7 @@ KdInitSystem(
         KdVersionBlock.Unused[0] = 0;
 
         /* Link us in the KPCR */
-        KeGetPcr()->KdVersionBlock =  &KdVersionBlock;
+        KeGetPcr()->KdVersionBlock = &KdVersionBlock;
     }
 
     /* Check if we have a loader block */
@@ -445,10 +445,11 @@ KdInitSystem(
                 NextEntry = NextEntry->Flink;
                 i++;
             }
-        }
 
-        /* Check for incoming breakin and break on symbol load if we have it */
-        KdBreakAfterSymbolLoad = KdPollBreakIn();
+            /* Check for incoming break-in and break on symbol load
+             * if requested, see ex/init.c!ExpLoadBootSymbols() */
+            KdBreakAfterSymbolLoad = KdPollBreakIn();
+        }
     }
     else
     {


### PR DESCRIPTION
### _Necessary for PR #7424 and #7426 (`SysDbgDisableKernelDebugger` and `SysDbgEnableKernelDebugger`)_

## Purpose / Proposed changes

In KdInitSystem(), polling for break-in on symbol load should be done _only_ after symbols are loaded at boot-time,
i.e. when LoaderBlock != NULL and we have loaded the initial hal and ntoskrnl symbols. KdBreakAfterSymbolLoad is then checked for when the other boot symbols have been loaded by ex/init.c!ExpLoadBootSymbols(), invoked by ExpInitializeExecutive().
