### PR TITLE
[NTOS:KD64] Fix the handling of the debugging banners invoked by KdInitSystem()

### DIFF
--- a/ntoskrnl/kd64/kdinit.c
+++ b/ntoskrnl/kd64/kdinit.c
@@ -11,8 +11,17 @@
 
 #include <ntoskrnl.h>
 #include <reactos/buildno.h>
+
 #define NDEBUG
 #include <debug.h>
+
+/*
+ * Override DbgPrint(), used by the debugger banner DPRINTs below,
+ * because KdInitSystem() can be called under the debugger lock by
+ * KdEnableDebugger(WithLock)().
+ */
+#define DbgPrint(fmt, ...) (KdpDprintf(fmt, ##__VA_ARGS__), 0)
+#define DbgPrintEx(cmpid, lvl, fmt, ...) (KdpDprintf(fmt, ##__VA_ARGS__), 0)
 
 /* UTILITY FUNCTIONS *********************************************************/
 


### PR DESCRIPTION
### _Necessary for PR #7424 and #7426 (`SysDbgDisableKernelDebugger` and `SysDbgEnableKernelDebugger`)_

## Purpose / Proposed changes

- ### `[NTOS:KD64] Fix usage of the debugging banner code, based on when KdInitSystem() is called.`

  - The debugging banner helpers *CANNOT* be in the INIT section, because
    it is possible for KdInitSystem() to enable the debugger **MUCH LATER**
    after boot time. (Reverts part of commit https://github.com/reactos/reactos/commit/f239ca0f0456b7586edd2e6e546db7bdbd651ceb (r72922).)

    This can happen in two situations:

    * When the debugger is in CRASHDEBUG mode, i.e. initialized at boot
      time but not immediately enabled, and a BSOD happens later that
      enables the debugger with a `KdInitSystem(0, NULL)` call.

    * When the debugger was possibly manually disabled with a
      KdDisableDebugger() call, then later re-enabled with a
      KdEnableDebugger() call.

  - In the same cases as described above, the KeLoaderBlock is freed after
    boot time. Thus, KdpGetMemorySizeInMBs() cannot use it and enumerate
    the MemoryDescriptors to evaluate the number of physical memory pages
    available on the system. Instead, we can use what the memory manager
    has already computed, since the latter is already initialized by now.

  These two fixes avoid (invisible) crashes when (re-)enabling
  the debugger at non-boot run time.

- ### `[NTOS:KD64] Use KdpDprintf() instead of DbgPrint() for the debugger banner DPRINTs`

  Override DbgPrint(), used by the debugger banner DPRINTs,
  because KdInitSystem() can be called under the debugger lock
  by KdEnableDebugger(WithLock)().

  In this case, when DbgPrint() (re-)enters the debugger via an
  interrupt and acquires the debugger lock, a deadlock occurs.
