### PR TITLE
[NTOS][HAL] Improve x64 trap handling code

### DIFF
--- a/hal/halx86/apic/apic.c
+++ b/hal/halx86/apic/apic.c
@@ -743,7 +743,6 @@ HalDisableSystemInterrupt(
     IOApicWrite(IOAPIC_REDTBL + 2 * Index, ReDirReg.Long0);
 }
 
-#ifndef _M_AMD64
 BOOLEAN
 NTAPI
 HalBeginSystemInterrupt(
@@ -826,6 +825,7 @@ HalEndSystemInterrupt(
 
 /* IRQL MANAGEMENT ************************************************************/
 
+#ifndef _M_AMD64
 KIRQL
 NTAPI
 KeGetCurrentIrql(VOID)

--- a/hal/halx86/apic/rtctimer.c
+++ b/hal/halx86/apic/rtctimer.c
@@ -156,7 +156,10 @@ HalpClockInterruptHandler(IN PKTRAP_FRAME TrapFrame)
     if (!HalBeginSystemInterrupt(CLOCK_LEVEL, APIC_CLOCK_VECTOR, &Irql))
     {
         /* Spurious, just end the interrupt */
+#ifdef _M_IX86
         KiEoiHelper(TrapFrame);
+#endif
+        return;
     }
 
     /* Read register C, so that the next interrupt can happen */
@@ -207,7 +210,10 @@ HalpClockIpiHandler(IN PKTRAP_FRAME TrapFrame)
     if (!HalBeginSystemInterrupt(CLOCK_LEVEL, CLOCK_IPI_VECTOR, &Irql))
     {
         /* Spurious, just end the interrupt */
+#ifdef _M_IX86
         KiEoiHelper(TrapFrame);
+#endif
+        return;
     }
 
     /* Call the kernel to update runtimes */

--- a/hal/halx86/apic/rtctimer.c
+++ b/hal/halx86/apic/rtctimer.c
@@ -191,6 +191,9 @@ HalpClockInterruptHandler(IN PKTRAP_FRAME TrapFrame)
 
     /* Update the system time -- on x86 the kernel will exit this trap  */
     KeUpdateSystemTime(TrapFrame, LastIncrement, Irql);
+
+    /* End the interrupt */
+    KiEndInterrupt(Irql, TrapFrame);
 }
 
 VOID

--- a/hal/halx86/include/halp.h
+++ b/hal/halx86/include/halp.h
@@ -586,7 +586,6 @@ HalInitializeBios(
 #ifdef _M_AMD64
 #define KfLowerIrql KeLowerIrql
 #define KiEnterInterruptTrap(TrapFrame) /* We do all neccessary in asm code */
-#define HalBeginSystemInterrupt(Irql, Vector, OldIrql) ((*(OldIrql) = PASSIVE_LEVEL), TRUE)
 #endif // _M_AMD64
 
 extern BOOLEAN HalpNMIInProgress;

--- a/hal/halx86/include/halp.h
+++ b/hal/halx86/include/halp.h
@@ -586,7 +586,6 @@ HalInitializeBios(
 #ifdef _M_AMD64
 #define KfLowerIrql KeLowerIrql
 #define KiEnterInterruptTrap(TrapFrame) /* We do all neccessary in asm code */
-#define KiEoiHelper(TrapFrame) return /* Just return to the caller */
 #define HalBeginSystemInterrupt(Irql, Vector, OldIrql) ((*(OldIrql) = PASSIVE_LEVEL), TRUE)
 #endif // _M_AMD64
 

--- a/ntoskrnl/include/internal/amd64/ke.h
+++ b/ntoskrnl/include/internal/amd64/ke.h
@@ -356,7 +356,10 @@ KiEndInterrupt(IN KIRQL Irql,
 {
     /* Make sure this is from the clock handler */
     ASSERT(TrapFrame->ErrorCode == 0xc10c4);
-    //KeLowerIrql(Irql);
+
+    /* Disable interrupts and end the interrupt */
+    _disable();
+    HalEndSystemInterrupt(Irql, TrapFrame);
 }
 
 FORCEINLINE

--- a/ntoskrnl/ke/amd64/trap.S
+++ b/ntoskrnl/ke/amd64/trap.S
@@ -23,8 +23,9 @@ EXTERN KiDpcInterruptHandler:PROC
 EXTERN PsConvertToGuiThread:PROC
 EXTERN MmCreateKernelStack:PROC
 EXTERN MmDeleteKernelStack:PROC
-
 EXTERN KdSetOwedBreakpoints:PROC
+EXTERN KeAcquireSpinLockAtDpcLevel:PROC
+EXTERN KeReleaseSpinLockFromDpcLevel:PROC
 
 
 /* Helper Macros *************************************************************/
@@ -744,11 +745,13 @@ FUNC KiInterruptDispatch
     movzx rax, byte ptr [rbx + KINTERRUPT_SynchronizeIrql]
     mov cr8, rax
 
+    /* Enable interrupts */
+    sti
+
 #ifdef CONFIG_SMP
     /* Acquire interrupt lock */
-    mov r8, [rbx + KINTERRUPT_ActualLock]
-
-    //KxAcquireSpinLock(Interrupt->ActualLock);
+    mov rcx, [rbx + KINTERRUPT_ActualLock]
+    call KeAcquireSpinLockAtDpcLevel
 #endif
 
     /* Call the ISR */
@@ -758,10 +761,12 @@ FUNC KiInterruptDispatch
 
 #ifdef CONFIG_SMP
     /* Release interrupt lock */
-    //KxReleaseSpinLock(Interrupt->ActualLock);
+    mov rcx, [rbx + KINTERRUPT_ActualLock]
+    call KeReleaseSpinLockFromDpcLevel
 #endif
 
-    /* Go back to old irql */
+    /* Disable interrupts and go back to old irql */
+    cli
     movzx rax, byte ptr [rbp + KTRAP_FRAME_PreviousIrql]
     mov cr8, rax
 

--- a/ntoskrnl/ke/time.c
+++ b/ntoskrnl/ke/time.c
@@ -77,7 +77,10 @@ KeUpdateSystemTime(IN PKTRAP_FRAME TrapFrame,
 
         /* Increase interrupt count and end the interrupt */
         Prcb->InterruptCount++;
+
+#ifdef _M_IX86 // x86 optimization
         KiEndInterrupt(Irql, TrapFrame);
+#endif
 
         /* Note: non-x86 return back to the caller! */
         return;
@@ -131,8 +134,10 @@ KeUpdateSystemTime(IN PKTRAP_FRAME TrapFrame,
         Prcb->InterruptCount++;
     }
 
+#ifdef _M_IX86 // x86 optimization
     /* Disable interrupts and end the interrupt */
     KiEndInterrupt(Irql, TrapFrame);
+#endif
 }
 
 VOID


### PR DESCRIPTION
## Purpose

Improve some x64 trap handling code.

## Proposed changes

- [NTOS:KE/X64] Fix KiInterruptDispatch
- [HAL] Remove KiEoiHelper hack
- [NTOS][HAL:APIC] Call HalBegin/EndSystemInterrupt from clock handler

## Tests

- KVM x86: https://reactos.org/testman/compare.php?ids=99107,99130,99127
- KVM x64: https://reactos.org/testman/compare.php?ids=99108,99111
