### PR TITLE
[NTOS:PS][NTDLL_APITEST] Add query support for QUOTA_LIMITS_EX

### DIFF
--- a/modules/rostests/apitests/ntdll/NtQueryInformationProcess.c
+++ b/modules/rostests/apitests/ntdll/NtQueryInformationProcess.c
@@ -307,6 +307,226 @@ Test_ProcessBasicInformation(void)
 
 static
 void
+Test_ProcessQuotaLimits(void)
+{
+    NTSTATUS Status;
+    ULONG Length;
+    QUOTA_LIMITS QuotaLimits;
+
+    /* Everything is NULL */
+    Status = NtQueryInformationProcess(NULL,
+                                       ProcessQuotaLimits,
+                                       NULL,
+                                       0,
+                                       NULL);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* Right size, invalid process handle */
+    Status = NtQueryInformationProcess(NULL,
+                                       ProcessQuotaLimits,
+                                       NULL,
+                                       sizeof(QuotaLimits),
+                                       NULL);
+    ok_hex(Status, STATUS_INVALID_HANDLE);
+
+    /* Valid process handle, no buffer */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessQuotaLimits,
+                                       NULL,
+                                       0,
+                                       NULL);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* Unaligned buffer, wrong size */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessQuotaLimits,
+                                       (PVOID)2,
+                                       0,
+                                       NULL);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* Unaligned buffer, correct size */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessQuotaLimits,
+                                       (PVOID)2,
+                                       sizeof(QuotaLimits),
+                                       NULL);
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+
+    /* Buffer too small */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessQuotaLimits,
+                                       NULL,
+                                       sizeof(QuotaLimits) - 1,
+                                       NULL);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* Right buffer size but NULL pointer */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessQuotaLimits,
+                                       NULL,
+                                       sizeof(QuotaLimits),
+                                       NULL);
+    ok_hex(Status, STATUS_ACCESS_VIOLATION);
+
+    /* Buffer too large */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessQuotaLimits,
+                                       NULL,
+                                       sizeof(QuotaLimits) + 1,
+                                       NULL);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* Buffer too small, ask for length */
+    Length = 0x55555555;
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessQuotaLimits,
+                                       NULL,
+                                       sizeof(QuotaLimits) - 1,
+                                       &Length);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+    ok_dec(Length, 0x55555555);
+
+    /* Valid parameters, no return length */
+    RtlFillMemory(&QuotaLimits, sizeof(QuotaLimits), 0x55);
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessQuotaLimits,
+                                       &QuotaLimits,
+                                       sizeof(QuotaLimits),
+                                       NULL);
+    ok_hex(Status, STATUS_SUCCESS);
+
+    /* Trace the returned data (1) */
+    trace("[1] QuotaLimits.PagedPoolLimit = %Iu\n", QuotaLimits.PagedPoolLimit);
+    trace("[1] QuotaLimits.NonPagedPoolLimit = %Iu\n", QuotaLimits.NonPagedPoolLimit);
+    trace("[1] QuotaLimits.MinimumWorkingSetSize = %Iu\n", QuotaLimits.MinimumWorkingSetSize);
+    trace("[1] QuotaLimits.MaximumWorkingSetSize = %Iu\n", QuotaLimits.MaximumWorkingSetSize);
+    trace("[1] QuotaLimits.PagefileLimit = %Iu\n", QuotaLimits.PagefileLimit);
+    trace("[1] QuotaLimits.TimeLimit = %I64d\n", QuotaLimits.TimeLimit.QuadPart);
+
+    /* Again, this time with a return length */
+    Length = 0x55555555;
+    RtlFillMemory(&QuotaLimits, sizeof(QuotaLimits), 0x55);
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessQuotaLimits,
+                                       &QuotaLimits,
+                                       sizeof(QuotaLimits),
+                                       &Length);
+    ok_hex(Status, STATUS_SUCCESS);
+    ok_dec(Length, sizeof(QuotaLimits));
+
+    /* Trace the returned data (2) */
+    trace("[2] QuotaLimits.PagedPoolLimit = %Iu\n", QuotaLimits.PagedPoolLimit);
+    trace("[2] QuotaLimits.NonPagedPoolLimit = %Iu\n", QuotaLimits.NonPagedPoolLimit);
+    trace("[2] QuotaLimits.MinimumWorkingSetSize = %Iu\n", QuotaLimits.MinimumWorkingSetSize);
+    trace("[2] QuotaLimits.MaximumWorkingSetSize = %Iu\n", QuotaLimits.MaximumWorkingSetSize);
+    trace("[2] QuotaLimits.PagefileLimit = %Iu\n", QuotaLimits.PagefileLimit);
+    trace("[2] QuotaLimits.TimeLimit = %I64d\n", QuotaLimits.TimeLimit.QuadPart);
+}
+
+static
+void
+Test_ProcessQuotaLimitsEx(void)
+{
+    NTSTATUS Status;
+    ULONG Length;
+    QUOTA_LIMITS_EX QuotaLimitsEx;
+
+    /* Right size, invalid process handle */
+    Status = NtQueryInformationProcess(NULL,
+                                       ProcessQuotaLimits,
+                                       NULL,
+                                       sizeof(QuotaLimitsEx),
+                                       NULL);
+    ok_hex(Status, STATUS_INVALID_HANDLE);
+
+    /* Unaligned buffer, correct size */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessQuotaLimits,
+                                       (PVOID)2,
+                                       sizeof(QuotaLimitsEx),
+                                       NULL);
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+
+    /* Buffer too small */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessQuotaLimits,
+                                       NULL,
+                                       sizeof(QuotaLimitsEx) - 1,
+                                       NULL);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* Right buffer size but NULL pointer */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessQuotaLimits,
+                                       NULL,
+                                       sizeof(QuotaLimitsEx),
+                                       NULL);
+    ok_hex(Status, STATUS_ACCESS_VIOLATION);
+
+    /* Buffer too large */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessQuotaLimits,
+                                       NULL,
+                                       sizeof(QuotaLimitsEx) + 1,
+                                       NULL);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* Buffer too small, ask for length */
+    Length = 0x55555555;
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessQuotaLimits,
+                                       NULL,
+                                       sizeof(QuotaLimitsEx) - 1,
+                                       &Length);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+    ok_dec(Length, 0x55555555);
+
+    /* Valid parameters, no return length */
+    RtlFillMemory(&QuotaLimitsEx, sizeof(QuotaLimitsEx), 0x55);
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessQuotaLimits,
+                                       &QuotaLimitsEx,
+                                       sizeof(QuotaLimitsEx),
+                                       NULL);
+    ok_hex(Status, STATUS_SUCCESS);
+
+    /* Trace the returned data (1) */
+    trace("[1] QuotaLimitsEx.PagedPoolLimit = %Iu\n", QuotaLimitsEx.PagedPoolLimit);
+    trace("[1] QuotaLimitsEx.NonPagedPoolLimit = %Iu\n", QuotaLimitsEx.NonPagedPoolLimit);
+    trace("[1] QuotaLimitsEx.MinimumWorkingSetSize = %Iu\n", QuotaLimitsEx.MinimumWorkingSetSize);
+    trace("[1] QuotaLimitsEx.MaximumWorkingSetSize = %Iu\n", QuotaLimitsEx.MaximumWorkingSetSize);
+    trace("[1] QuotaLimitsEx.PagefileLimit = %Iu\n", QuotaLimitsEx.PagefileLimit);
+    trace("[1] QuotaLimitsEx.TimeLimit = %I64d\n", QuotaLimitsEx.TimeLimit.QuadPart);
+    //trace("[1] QuotaLimitsEx.WorkingSetLimit = %Iu\n", QuotaLimitsEx.WorkingSetLimit); // Not used on Win2k3
+    trace("[1] QuotaLimitsEx.Flags = %lx\n", QuotaLimitsEx.Flags);
+    trace("[1] QuotaLimitsEx.CpuRateLimit.RateData = %lx\n", QuotaLimitsEx.CpuRateLimit.RateData);
+
+    /* Again, this time with a return length */
+    Length = 0x55555555;
+    RtlFillMemory(&QuotaLimitsEx, sizeof(QuotaLimitsEx), 0x55);
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessQuotaLimits,
+                                       &QuotaLimitsEx,
+                                       sizeof(QuotaLimitsEx),
+                                       &Length);
+    ok_hex(Status, STATUS_SUCCESS);
+    ok_dec(Length, sizeof(QuotaLimitsEx));
+
+    /* Trace the returned data (2) */
+    trace("[2] QuotaLimitsEx.PagedPoolLimit = %Iu\n", QuotaLimitsEx.PagedPoolLimit);
+    trace("[2] QuotaLimitsEx.NonPagedPoolLimit = %Iu\n", QuotaLimitsEx.NonPagedPoolLimit);
+    trace("[2] QuotaLimitsEx.MinimumWorkingSetSize = %Iu\n", QuotaLimitsEx.MinimumWorkingSetSize);
+    trace("[2] QuotaLimitsEx.MaximumWorkingSetSize = %Iu\n", QuotaLimitsEx.MaximumWorkingSetSize);
+    trace("[2] QuotaLimitsEx.PagefileLimit = %Iu\n", QuotaLimitsEx.PagefileLimit);
+    trace("[2] QuotaLimitsEx.TimeLimit = %I64d\n", QuotaLimitsEx.TimeLimit.QuadPart);
+    //trace("[2] QuotaLimitsEx.WorkingSetLimit = %Iu\n", QuotaLimitsEx.WorkingSetLimit); // Not used on Win2k3
+    trace("[2] QuotaLimitsEx.Flags = %lx\n", QuotaLimitsEx.Flags);
+    trace("[2] QuotaLimitsEx.CpuRateLimit.RateData = %lx\n", QuotaLimitsEx.CpuRateLimit.RateData);
+}
+
+static
+void
 Test_ProcessPriorityClassAlignment(void)
 {
     NTSTATUS Status;
@@ -496,6 +716,8 @@ START_TEST(NtQueryInformationProcess)
 
     Test_ProcessTimes();
     Test_ProcessBasicInformation();
+    Test_ProcessQuotaLimits();
+    Test_ProcessQuotaLimitsEx();
     Test_ProcessPriorityClassAlignment();
     Test_ProcessWx86Information();
     Test_ProcQueryAlignmentProbe();

--- a/ntoskrnl/include/internal/ps_i.h
+++ b/ntoskrnl/include/internal/ps_i.h
@@ -27,7 +27,9 @@ static const INFORMATION_CLASS_INFO PsProcessInfoClass[] =
     (
         QUOTA_LIMITS,
         ULONG,
-        ICIF_QUERY | ICIF_SET | ICIF_SET_SIZE_VARIABLE
+
+        /* NOTE: ICIF_SIZE_VARIABLE is for QUOTA_LIMITS_EX support */
+        ICIF_QUERY | ICIF_SET | ICIF_SIZE_VARIABLE
     ),
 
     /* ProcessIoCounters */

--- a/ntoskrnl/ps/query.c
+++ b/ntoskrnl/ps/query.c
@@ -67,23 +67,7 @@ NtQueryInformationProcess(
     KPROCESSOR_MODE PreviousMode = ExGetPreviousMode();
     NTSTATUS Status;
     ULONG Length = 0;
-    HANDLE DebugPort = 0;
-    PPROCESS_BASIC_INFORMATION ProcessBasicInfo =
-        (PPROCESS_BASIC_INFORMATION)ProcessInformation;
-    PKERNEL_USER_TIMES ProcessTime = (PKERNEL_USER_TIMES)ProcessInformation;
-    ULONG UserTime, KernelTime;
-    PPROCESS_PRIORITY_CLASS PsPriorityClass = (PPROCESS_PRIORITY_CLASS)ProcessInformation;
-    ULONG HandleCount;
-    PPROCESS_SESSION_INFORMATION SessionInfo =
-        (PPROCESS_SESSION_INFORMATION)ProcessInformation;
-    PVM_COUNTERS VmCounters = (PVM_COUNTERS)ProcessInformation;
-    PIO_COUNTERS IoCounters = (PIO_COUNTERS)ProcessInformation;
-    PQUOTA_LIMITS QuotaLimits = (PQUOTA_LIMITS)ProcessInformation;
-    PUNICODE_STRING ImageName;
-    ULONG Cookie, ExecuteOptions = 0;
-    ULONG_PTR Wow64 = 0;
-    PROCESS_VALUES ProcessValues;
-    ULONG Flags;
+
     PAGED_CODE();
 
     /* Verify Information Class validity */
@@ -119,6 +103,8 @@ NtQueryInformationProcess(
     {
         /* Basic process information */
         case ProcessBasicInformation:
+        {
+            PPROCESS_BASIC_INFORMATION ProcessBasicInfo = (PPROCESS_BASIC_INFORMATION)ProcessInformation;
 
             if (ProcessInformationLength != sizeof(PROCESS_BASIC_INFORMATION))
             {
@@ -162,9 +148,12 @@ NtQueryInformationProcess(
             /* Dereference the process */
             ObDereferenceObject(Process);
             break;
+        }
 
         /* Process quota limits */
         case ProcessQuotaLimits:
+        {
+            PQUOTA_LIMITS QuotaLimits = (PQUOTA_LIMITS)ProcessInformation;
 
             if (ProcessInformationLength != sizeof(QUOTA_LIMITS))
             {
@@ -227,8 +216,12 @@ NtQueryInformationProcess(
             /* Dereference the process */
             ObDereferenceObject(Process);
             break;
+        }
 
         case ProcessIoCounters:
+        {
+            PIO_COUNTERS IoCounters = (PIO_COUNTERS)ProcessInformation;
+            PROCESS_VALUES ProcessValues;
 
             if (ProcessInformationLength != sizeof(IO_COUNTERS))
             {
@@ -266,9 +259,13 @@ NtQueryInformationProcess(
             /* Dereference the process */
             ObDereferenceObject(Process);
             break;
+        }
 
         /* Timing */
         case ProcessTimes:
+        {
+            PKERNEL_USER_TIMES ProcessTime = (PKERNEL_USER_TIMES)ProcessInformation;
+            ULONG UserTime, KernelTime;
 
             /* Set the return length */
             if (ProcessInformationLength != sizeof(KERNEL_USER_TIMES))
@@ -308,6 +305,7 @@ NtQueryInformationProcess(
             /* Dereference the process */
             ObDereferenceObject(Process);
             break;
+        }
 
         /* Process Debug Port */
         case ProcessDebugPort:
@@ -349,6 +347,8 @@ NtQueryInformationProcess(
             break;
 
         case ProcessHandleCount:
+        {
+            ULONG HandleCount;
 
             if (ProcessInformationLength != sizeof(ULONG))
             {
@@ -387,9 +387,12 @@ NtQueryInformationProcess(
             /* Dereference the process */
             ObDereferenceObject(Process);
             break;
+        }
 
         /* Session ID for the process */
         case ProcessSessionInformation:
+        {
+            PPROCESS_SESSION_INFORMATION SessionInfo = (PPROCESS_SESSION_INFORMATION)ProcessInformation;
 
             if (ProcessInformationLength != sizeof(PROCESS_SESSION_INFORMATION))
             {
@@ -425,9 +428,12 @@ NtQueryInformationProcess(
             /* Dereference the process */
             ObDereferenceObject(Process);
             break;
+        }
 
         /* Virtual Memory Statistics */
         case ProcessVmCounters:
+        {
+            PVM_COUNTERS VmCounters = (PVM_COUNTERS)ProcessInformation;
 
             /* Validate the input length */
             if ((ProcessInformationLength != sizeof(VM_COUNTERS)) &&
@@ -477,6 +483,7 @@ NtQueryInformationProcess(
             /* Dereference the process */
             ObDereferenceObject(Process);
             break;
+        }
 
         /* Hard Error Processing Mode */
         case ProcessDefaultHardErrorMode:
@@ -558,6 +565,8 @@ NtQueryInformationProcess(
 
         /* DOS Device Map */
         case ProcessDeviceMap:
+        {
+            ULONG Flags;
 
             if (ProcessInformationLength == sizeof(PROCESS_DEVICEMAP_INFORMATION_EX))
             {
@@ -617,9 +626,12 @@ NtQueryInformationProcess(
             /* Dereference the process */
             ObDereferenceObject(Process);
             break;
+        }
 
         /* Priority class */
         case ProcessPriorityClass:
+        {
+            PPROCESS_PRIORITY_CLASS PsPriorityClass = (PPROCESS_PRIORITY_CLASS)ProcessInformation;
 
             if (ProcessInformationLength != sizeof(PROCESS_PRIORITY_CLASS))
             {
@@ -656,8 +668,11 @@ NtQueryInformationProcess(
             /* Dereference the process */
             ObDereferenceObject(Process);
             break;
+        }
 
         case ProcessImageFileName:
+        {
+            PUNICODE_STRING ImageName;
 
             /* Reference the process */
             Status = ObReferenceObjectByHandle(ProcessHandle,
@@ -710,6 +725,7 @@ NtQueryInformationProcess(
             /* Dereference the process */
             ObDereferenceObject(Process);
             break;
+        }
 
         case ProcessDebugFlags:
 
@@ -787,6 +803,8 @@ NtQueryInformationProcess(
 
         /* Per-process security cookie */
         case ProcessCookie:
+        {
+            ULONG Cookie;
 
             if (ProcessInformationLength != sizeof(ULONG))
             {
@@ -836,6 +854,7 @@ NtQueryInformationProcess(
             }
             _SEH2_END;
             break;
+        }
 
         case ProcessImageInformation:
 
@@ -866,6 +885,8 @@ NtQueryInformationProcess(
             break;
 
         case ProcessDebugObjectHandle:
+        {
+            HANDLE DebugPort = 0;
 
             if (ProcessInformationLength != sizeof(HANDLE))
             {
@@ -904,6 +925,7 @@ NtQueryInformationProcess(
             }
             _SEH2_END;
             break;
+        }
 
         case ProcessHandleTracing:
             DPRINT1("Handle tracing Not implemented: %lx\n", ProcessInformationClass);
@@ -976,6 +998,8 @@ NtQueryInformationProcess(
             break;
 
         case ProcessWow64Information:
+        {
+            ULONG_PTR Wow64 = 0;
 
             if (ProcessInformationLength != sizeof(ULONG_PTR))
             {
@@ -1024,8 +1048,11 @@ NtQueryInformationProcess(
             /* Dereference the process */
             ObDereferenceObject(Process);
             break;
+        }
 
         case ProcessExecuteFlags:
+        {
+            ULONG ExecuteOptions = 0;
 
             if (ProcessInformationLength != sizeof(ULONG))
             {
@@ -1059,6 +1086,7 @@ NtQueryInformationProcess(
                 _SEH2_END;
             }
             break;
+        }
 
         case ProcessLdtInformation:
             DPRINT1("VDM/16-bit not implemented: %lx\n", ProcessInformationClass);


### PR DESCRIPTION
## Purpose
Fix length mismatch error log spam while running sysinternals Process Explorer.

## Proposed changes
- `NtQueryInformationProcess`: Move process info-specific variables to their own scope.
- Add query support for `ProcessQuotaLimits` info class with `QUOTA_LIMITS_EX`.
- `NtQueryInformationProcess`: Add api tests for `ProcessBasicInformation` and `ProcessQuotaLimits` info classes.

## Test results
Test Win2k3:
![NTQIP_Win2k3_3](https://github.com/user-attachments/assets/412fd63f-c2d9-4929-b1ce-cf7ddd5d3add)

ReactOS Before:
![NTQIP_ROS_Before_2](https://github.com/user-attachments/assets/b0acb9e3-f761-42b8-8734-69d5195fd788)

ReactOS After:
![NTQIP_ROS_After_2](https://github.com/user-attachments/assets/a70aa5df-7a43-4ebf-9f6f-2e18215717d9)