### PR TITLE
[FREELDR] Add missing breakline in amd64 frldr16

### DIFF
--- a/boot/freeldr/freeldr/arch/realmode/amd64.S
+++ b/boot/freeldr/freeldr/arch/realmode/amd64.S
@@ -53,7 +53,7 @@ Startup:
 
 Msg_Unsupported:
     .ascii "This CPU is not supported.", CR, LF
-    .ascii "Press any key to reboot...", NUL
+    .ascii "Press any key to reboot...", CR, LF, NUL
 
 Msg_Starting:
     .ascii "Starting FreeLoader...", CR, LF, NUL


### PR DESCRIPTION
## Purpose

Add the `\n` and `\r` to make the cursor below the message.

JIRA issue: None
