### PR TITLE
[FREELDR] Fix wrong segment register at `lgdt` instruction in amd64.S

### DIFF
--- a/boot/freeldr/freeldr/arch/realmode/amd64.S
+++ b/boot/freeldr/freeldr/arch/realmode/amd64.S
@@ -67,11 +67,7 @@ Msg_LongModeSupported:
     call writestr
 
     /* Load the GDT */
-#ifdef _USE_ML
-    lgdt fword ptr [gdtptr]
-#else
-    lgdt cs:[gdtptr]
-#endif
+    lgdt lXdtPrefix ds:[gdtptr]
 
     /* Build the startup page tables */
     call BuildPageTables


### PR DESCRIPTION
## Purpose

Fix the crash with the new ext2/3 bootsector at PR (#7544)

JIRA issue: None
