### PR TITLE
[NTOS:KE/x64] Fix handling of PCR::UserRsp

### DIFF
--- a/ntoskrnl/ke/amd64/traphandler.c
+++ b/ntoskrnl/ke/amd64/traphandler.c
@@ -159,9 +159,8 @@ KiSystemCallHandler(
     /* We don't have an exception frame yet */
     TrapFrame->ExceptionFrame = 0;
 
-    /* Before enabling interrupts get the user rsp from the KPCR */
-    UserRsp = __readgsqword(FIELD_OFFSET(KIPCR, UserRsp));
-    TrapFrame->Rsp = UserRsp;
+    /* Get the user Stack pointer */
+    UserRsp = TrapFrame->Rsp;
 
     /* Enable interrupts */
     _enable();

--- a/ntoskrnl/ke/amd64/usercall.c
+++ b/ntoskrnl/ke/amd64/usercall.c
@@ -318,9 +318,6 @@ KeUserModeCallback(
 
     /* Restore stack and return */
     *UserStackPointer = OldStack;
-#ifdef _M_AMD64 // could probably  move the update to TrapFrame->Rsp from the C handler to the asm code
-    __writegsqword(FIELD_OFFSET(KIPCR, UserRsp), OldStack);
-#endif
     return CallbackStatus;
 }
 


### PR DESCRIPTION
This is a temporary helper for the system call entry point to store the user mode stack, before switching to the kernel mode stack. Initially it was copied to the trap frame inside KiSystemCallHandler. This has been moved to the system call entry point, but some remnants remained. The problem is that KiSystemCallHandler can be called twice in a system call (when the call is the first GUI call and the stack needs to be extended). In that scenario, when the thread was preempted, a new value could be saved in the PCR before running KiSystemCallHandler again, and then overwriting the proper value with a bogus one from a different thread. This rarely seemed to happen on UP, but happens a lot with SMP.
