### PR TITLE
[WIN32K] Prevent infinite recursion

### DIFF
--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -263,7 +263,7 @@ SelectWindowRgn(PWND Window, HRGN hRgnClip)
         /* Delete no longer needed region handle */
         IntGdiSetRegionOwner(Window->hrgnClip, GDI_OBJ_HMGR_POWNED);
         GreDeleteObject(Window->hrgnClip);
-        Window->hrgnClip = NULL;       
+        Window->hrgnClip = NULL;
     }
 
     if (hRgnClip > HRGN_WINDOW)
@@ -915,7 +915,7 @@ UserGetWindowBorders(DWORD Style, DWORD ExStyle, SIZE *Size, BOOL WithClient)
 
 //
 // Fix CORE-5177
-// See winetests:user32:win.c:wine_AdjustWindowRectEx, 
+// See winetests:user32:win.c:wine_AdjustWindowRectEx,
 // Simplified version.
 //
 DWORD IntGetWindowBorders(DWORD Style, DWORD ExStyle)
@@ -2256,7 +2256,10 @@ co_WinPosSetWindowPos(
             //ERR("WPSWP : set active window\n");
             if (!(Window->state & WNDS_BEINGACTIVATED)) // Inside SAW?
             {
+               // Set state flag to prevent recursions.
+               Window->state |= WNDS_BEINGACTIVATED;
                co_IntSetForegroundWindow(Window); // Fixes SW_HIDE issues. Wine win test_SetActiveWindow & test_SetForegroundWindow.
+               Window->state &= ~WNDS_BEINGACTIVATED;
             }
          }
       }
@@ -2264,7 +2267,7 @@ co_WinPosSetWindowPos(
 
    if ( !PosChanged &&
          (WinPos.flags & SWP_FRAMECHANGED) &&
-        !(WinPos.flags & SWP_DEFERERASE) &&    // Prevent sending WM_SYNCPAINT message. 
+        !(WinPos.flags & SWP_DEFERERASE) &&    // Prevent sending WM_SYNCPAINT message.
          VisAfter )
    {
        PWND Parent = Window->spwndParent;
@@ -3915,7 +3918,7 @@ co_IntCalculateSnapPosition(PWND Wnd, UINT Edge, OUT RECT *Pos)
     {
     case HTTOP: /* Maximized (Calculate RECT snap preview for SC_MOVE) */
         height = min(Pos->bottom - Pos->top, maxs.y);
-        break; 
+        break;
     case HTLEFT:
         Pos->right = width;
         break;

--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -2257,9 +2257,10 @@ co_WinPosSetWindowPos(
             if (!(Window->state & WNDS_BEINGACTIVATED)) // Inside SAW?
             {
                // Set state flag to prevent recursions.
+               BOOL WasBeingActivated = (Window->state & WNDS_BEINGACTIVATED) != 0;
                Window->state |= WNDS_BEINGACTIVATED;
                co_IntSetForegroundWindow(Window); // Fixes SW_HIDE issues. Wine win test_SetActiveWindow & test_SetForegroundWindow.
-               Window->state &= ~WNDS_BEINGACTIVATED;
+               if (!WasBeingActivated) Window->state &= ~WNDS_BEINGACTIVATED;
             }
          }
       }


### PR DESCRIPTION
## Purpose

Prevent infinite recursion in win32k.

Jira: https://jira.reactos.org/browse/CORE-18799

Stack:
```
ab fffff880`03d8e3f0 fffff880`04a741b1     win32k!co_IntSetForegroundMessageQueue(struct _WND * Wnd = 0xfffff97f`de3cbd40, struct _THREADINFO * pti = 0xfffffa80`51f57c80, int MouseActivate = 0n0, unsigned long Type = 0)+0x4bc [C:\ReactOS\reactos\win32ss\user\ntuser\focus.c @ 881] 
ac fffff880`03d8e570 fffff880`04a74a1a     win32k!co_IntSetForegroundAndFocusWindow(struct _WND * Wnd = 0xfffff97f`de3cbd40, int MouseActivate = 0n0, int bFlash = 0n1)+0x391 [C:\ReactOS\reactos\win32ss\user\ntuser\focus.c @ 987] 
ad fffff880`03d8e690 fffff880`04af8cb1     win32k!co_IntSetForegroundWindow(struct _WND * Window = 0xfffff97f`de3cbd40)+0xaa [C:\ReactOS\reactos\win32ss\user\ntuser\focus.c @ 1557] 
ae fffff880`03d8e6e0 fffff880`04a7483c     win32k!co_WinPosSetWindowPos(struct _WND * Window = 0xfffff97f`de3cbd40, struct HWND__ * WndInsertAfter = 0x00000000`00000000, int x = 0n0, int y = 0n0, int cx = 0n0, int cy = 0n0, unsigned int flags = 3)+0x1691 [C:\ReactOS\reactos\win32ss\user\ntuser\winpos.c @ 2259] 
af fffff880`03d8ea10 fffff880`04a741b1     win32k!co_IntSetForegroundMessageQueue(struct _WND * Wnd = 0xfffff97f`de3cbd40, struct _THREADINFO * pti = 0xfffffa80`51f57c80, int MouseActivate = 0n0, unsigned long Type = 0)+0x4bc [C:\ReactOS\reactos\win32ss\user\ntuser\focus.c @ 881] 
b0 fffff880`03d8eb90 fffff880`04a74a1a     win32k!co_IntSetForegroundAndFocusWindow(struct _WND * Wnd = 0xfffff97f`de3cbd40, int MouseActivate = 0n0, int bFlash = 0n1)+0x391 [C:\ReactOS\reactos\win32ss\user\ntuser\focus.c @ 987] 
b1 fffff880`03d8ecb0 fffff880`04af8cb1     win32k!co_IntSetForegroundWindow(struct _WND * Window = 0xfffff97f`de3cbd40)+0xaa [C:\ReactOS\reactos\win32ss\user\ntuser\focus.c @ 1557] 
b2 fffff880`03d8ed00 fffff880`04a7483c     win32k!co_WinPosSetWindowPos(struct _WND * Window = 0xfffff97f`de3cbd40, struct HWND__ * WndInsertAfter = 0x00000000`00000000, int x = 0n0, int y = 0n0, int cx = 0n0, int cy = 0n0, unsigned int flags = 3)+0x1691 [C:\ReactOS\reactos\win32ss\user\ntuser\winpos.c @ 2259] 
b3 fffff880`03d8f030 fffff880`04a741b1     win32k!co_IntSetForegroundMessageQueue(struct _WND * Wnd = 0xfffff97f`de3cbd40, struct _THREADINFO * pti = 0xfffffa80`51f57c80, int MouseActivate = 0n0, unsigned long Type = 0)+0x4bc [C:\ReactOS\reactos\win32ss\user\ntuser\focus.c @ 881] 
b4 fffff880`03d8f1b0 fffff880`04a74a1a     win32k!co_IntSetForegroundAndFocusWindow(struct _WND * Wnd = 0xfffff97f`de3cbd40, int MouseActivate = 0n0, int bFlash = 0n1)+0x391 [C:\ReactOS\reactos\win32ss\user\ntuser\focus.c @ 987] 
b5 fffff880`03d8f2d0 fffff880`04af8cb1     win32k!co_IntSetForegroundWindow(struct _WND * Window = 0xfffff97f`de3cbd40)+0xaa [C:\ReactOS\reactos\win32ss\user\ntuser\focus.c @ 1557] 
b6 fffff880`03d8f320 fffff880`04a7483c     win32k!co_WinPosSetWindowPos(struct _WND * Window = 0xfffff97f`de3cbd40, struct HWND__ * WndInsertAfter = 0x00000000`00000000, int x = 0n0, int y = 0n0, int cx = 0n0, int cy = 0n0, unsigned int flags = 3)+0x1691 [C:\ReactOS\reactos\win32ss\user\ntuser\winpos.c @ 2259] 
b7 fffff880`03d8f650 fffff880`04a741b1     win32k!co_IntSetForegroundMessageQueue(struct _WND * Wnd = 0xfffff97f`de3cbd40, struct _THREADINFO * pti = 0xfffffa80`51f57c80, int MouseActivate = 0n0, unsigned long Type = 0)+0x4bc [C:\ReactOS\reactos\win32ss\user\ntuser\focus.c @ 881] 
b8 fffff880`03d8f7d0 fffff880`04a74a1a     win32k!co_IntSetForegroundAndFocusWindow(struct _WND * Wnd = 0xfffff97f`de3cbd40, int MouseActivate = 0n0, int bFlash = 0n1)+0x391 [C:\ReactOS\reactos\win32ss\user\ntuser\focus.c @ 987] 
b9 fffff880`03d8f8f0 fffff880`04af8cb1     win32k!co_IntSetForegroundWindow(struct _WND * Window = 0xfffff97f`de3cbd40)+0xaa [C:\ReactOS\reactos\win32ss\user\ntuser\focus.c @ 1557] 
ba fffff880`03d8f940 fffff880`04af9e33     win32k!co_WinPosSetWindowPos(struct _WND * Window = 0xfffff97f`de3cbd40, struct HWND__ * WndInsertAfter = 0x00000000`00000000, int x = 0n0, int y = 0n0, int cx = 0n0, int cy = 0n0, unsigned int flags = 0x43)+0x1691 [C:\ReactOS\reactos\win32ss\user\ntuser\winpos.c @ 2259] 
bb fffff880`03d8fc70 fffff880`04af27f6     win32k!co_WinPosShowWindow(struct _WND * Wnd = 0xfffff97f`de3cbd40, int Cmd = 0n1)+0xa13 [C:\ReactOS\reactos\win32ss\user\ntuser\winpos.c @ 2797] 
bc fffff880`03d8fd70 fffff800`0040568b     win32k!NtUserShowWindow(struct HWND__ * hWnd = 0x00000000`00020756, long nCmdShow = 0n1)+0x166 [C:\ReactOS\reactos\win32ss\user\ntuser\winpos.c @ 3833] 
bd fffff880`03d8fdf0 000007ff`b20a95c7     nt!KiSystemCallEntry64+0xe0
be 00000000`0012e548 00000000`00000000     user32!NtUserShowWindow+0xa

```

## Tests
- 🟥 KVM x86: https://reactos.org/testman/compare.php?ids=99193,99198,99206,99219
