### PR TITLE
[BATTC] Signal the wait battery tag event when notifying Battery Class

### DIFF
--- a/drivers/battery/battc/battc.c
+++ b/drivers/battery/battc/battc.c
@@ -76,11 +76,13 @@ BatteryClassQueryWmiDataBlock(PVOID ClassData,
 BCLASSAPI
 NTSTATUS
 NTAPI
-BatteryClassStatusNotify(PVOID ClassData)
+BatteryClassStatusNotify(
+    _In_ PVOID ClassData)
 {
     PBATTERY_CLASS_DATA BattClass;
     PBATTERY_WAIT_STATUS BattWait;
     BATTERY_STATUS BattStatus;
+    ULONG Tag;
     NTSTATUS Status;
 
     DPRINT("Received battery status notification from %p\n", ClassData);
@@ -99,7 +101,14 @@ BatteryClassStatusNotify(PVOID ClassData)
     {
         case EVENT_BATTERY_TAG:
             ExReleaseFastMutex(&BattClass->Mutex);
-            DPRINT1("Waiting for battery is UNIMPLEMENTED!\n");
+            Status = BattClass->MiniportInfo.QueryTag(BattClass->MiniportInfo.Context,
+                                                      &Tag);
+            if (!NT_SUCCESS(Status))
+                return Status;
+
+            ExAcquireFastMutex(&BattClass->Mutex);
+            KeSetEvent(&BattClass->WaitEvent, IO_NO_INCREMENT, FALSE);
+            ExReleaseFastMutex(&BattClass->Mutex);
             break;
 
         case EVENT_BATTERY_STATUS:


### PR DESCRIPTION
## Purpose

`BatteryClassStatusNotify` is used by battery miniport drivers to notify the Battery Class of a status change. This can either be a battery status change or battery tag assignation, depending on what the device extension (namely the composite battery) waits for.

We do have implementation for **EVENT_BATTERY_STATUS** but not for **EVENT_BATTERY_TAG**. What happens is when `BatteryClassIoctl` fails to query the battery tag because it has not yet been assigned, the thread is stuck on waiting for the event object to be signaled, forever. This typically happens when a timeout of -1 (meaning the calling thread must wait indefinitely) is supplied. The **composite battery driver (COMPBATT)** is responsible to signal the **Battery Class** when a **CM (Control Method) ACPI battery** receives a tag, which then this function will signal the event.

A schema is shown below which summarizes the mechanism of the battery components that communicate with each other.
![figure](https://github.com/user-attachments/assets/e6700eea-4679-470f-bf88-89ef70b322e7)

This patch is needed for the development of the Power Manager (#5719) to continue. Stay tuned for further updates!

## Proposed Changes
- Signal the wait event if the query tag request has succeeded
- Annotate `BatteryClassStatusNotify` with SAL2

## Jira Issues
[CORE-18969](https://jira.reactos.org/browse/CORE-18969)
[CORE-19452](https://jira.reactos.org/browse/CORE-19452)