### PR TITLE
[BATTC] Fix the wait timeout conversion

### DIFF
--- a/drivers/battery/battc/battc.c
+++ b/drivers/battery/battc/battc.c
@@ -223,7 +223,7 @@ BatteryClassIoctl(PVOID ClassData,
 
             WaitTime = IrpSp->Parameters.DeviceIoControl.InputBufferLength == sizeof(ULONG) ? *(PULONG)Irp->AssociatedIrp.SystemBuffer : 0;
 
-            Timeout.QuadPart = Int32x32To64(WaitTime, -1000);
+            Timeout.QuadPart = Int32x32To64(WaitTime, -10000);
 
             Status = BattClass->MiniportInfo.QueryTag(BattClass->MiniportInfo.Context,
                                                       (PULONG)Irp->AssociatedIrp.SystemBuffer);
@@ -272,7 +272,7 @@ BatteryClassIoctl(PVOID ClassData,
 
             BattWait = *(PBATTERY_WAIT_STATUS)Irp->AssociatedIrp.SystemBuffer;
 
-            Timeout.QuadPart = Int32x32To64(BattWait.Timeout, -1000);
+            Timeout.QuadPart = Int32x32To64(BattWait.Timeout, -10000);
 
             BattStatus = Irp->AssociatedIrp.SystemBuffer;
             Status = BattClass->MiniportInfo.QueryStatus(BattClass->MiniportInfo.Context,


### PR DESCRIPTION
## Purpose

`KeWaitForSingleObject` takes 100ns unit for timeout. Both **IOCTL_BATTERY_QUERY_TAG** and **IOCTL_BATTERY_QUERY_STATUS** take a wait for the timeout in milliseconds. Supposedly a miniport driver wants to supply a wait of **5000 ms** (which is equivalent to **5 s**), the miniport driver **WON'T BE WAITING** 5 seconds but 0.5!!!

I discovered this bug when I was implementing battery support in ReactOS and I noticed when supplying a timeout to one of the IOCTLs like 3000, the thread did not way for 3 seconds.

This patch is needed for the development of Power Manager (#5719) to continue. Stay tuned for further updates!

## Jira Issues

[CORE-18969](https://jira.reactos.org/browse/CORE-18969)
[CORE-19452](https://jira.reactos.org/browse/CORE-19452)