### PR TITLE
[COMPBATT] Resuscitate the Composite Battery driver

### DIFF
--- a/drivers/bus/acpi/compbatt/compbatt.c
+++ b/drivers/bus/acpi/compbatt/compbatt.c
@@ -1,9 +1,9 @@
 /*
- * PROJECT:         ReactOS Composite Battery Driver
- * LICENSE:         BSD - See COPYING.ARM in the top level directory
- * FILE:            boot/drivers/bus/acpi/compbatt/compbatt.c
- * PURPOSE:         Main Initialization Code and IRP Handling
- * PROGRAMMERS:     ReactOS Portable Systems Group
+ * PROJECT:     ReactOS Composite Battery Driver
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     Main Initialization Code and IRP Handling
+ * COPYRIGHT:   Copyright 2010 ReactOS Portable Systems Group <ros.arm@reactos.org>
+ *              Copyright 2024 George Bișoc <george.bisoc@reactos.org>
  */
 
 /* INCLUDES *******************************************************************/

--- a/drivers/bus/acpi/compbatt/compbatt.c
+++ b/drivers/bus/acpi/compbatt/compbatt.c
@@ -25,7 +25,7 @@ CompBattOpenClose(
     _In_ PIRP Irp)
 {
     PAGED_CODE();
-    if (CompBattDebug & 0x100) DbgPrint("CompBatt: ENTERING OpenClose\n");
+    if (CompBattDebug & COMPBATT_DEBUG_TRACE) DbgPrint("CompBatt: ENTERING OpenClose\n");
 
     /* Complete the IRP with success */
     Irp->IoStatus.Status = STATUS_SUCCESS;
@@ -33,7 +33,7 @@ CompBattOpenClose(
     IoCompleteRequest(Irp, IO_NO_INCREMENT);
 
     /* Return success */
-    if (CompBattDebug & 0x100) DbgPrint("CompBatt: Exiting OpenClose\n");
+    if (CompBattDebug & COMPBATT_DEBUG_TRACE) DbgPrint("CompBatt: Exiting OpenClose\n");
     return STATUS_SUCCESS;
 }
 
@@ -46,7 +46,7 @@ CompBattSystemControl(
     PCOMPBATT_DEVICE_EXTENSION DeviceExtension = DeviceObject->DeviceExtension;
     NTSTATUS Status;
     PAGED_CODE();
-    if (CompBattDebug & 1) DbgPrint("CompBatt: ENTERING System Control\n");
+    if (CompBattDebug & COMPBATT_DEBUG_TRACE) DbgPrint("CompBatt: ENTERING System Control\n");
 
     /* Are we attached yet? */
     if (DeviceExtension->AttachedDevice)
@@ -95,7 +95,7 @@ CompBattRecalculateTag(
     PCOMPBATT_BATTERY_DATA BatteryData;
     ULONG Tag;
     PLIST_ENTRY ListHead, NextEntry;
-    if (CompBattDebug & 0x100) DbgPrint("CompBatt: ENTERING CompBattRecalculateTag\n");
+    if (CompBattDebug & COMPBATT_DEBUG_TRACE) DbgPrint("CompBatt: ENTERING CompBattRecalculateTag\n");
 
     /* Loop the battery list */
     ExAcquireFastMutex(&DeviceExtension->Lock);
@@ -122,7 +122,7 @@ CompBattRecalculateTag(
 
     /* We're done */
     ExReleaseFastMutex(&DeviceExtension->Lock);
-    if (CompBattDebug & 0x100) DbgPrint("CompBatt: EXITING CompBattRecalculateTag\n");
+    if (CompBattDebug & COMPBATT_DEBUG_TRACE) DbgPrint("CompBatt: EXITING CompBattRecalculateTag\n");
 }
 
 NTSTATUS
@@ -133,7 +133,7 @@ CompBattIoctl(
 {
     PCOMPBATT_DEVICE_EXTENSION DeviceExtension = DeviceObject->DeviceExtension;
     NTSTATUS Status;
-    if (CompBattDebug & 1) DbgPrint("CompBatt: ENTERING Ioctl\n");
+    if (CompBattDebug & COMPBATT_DEBUG_TRACE) DbgPrint("CompBatt: ENTERING Ioctl\n");
 
     /* Let the class driver handle it */
     Status = BatteryClassIoctl(DeviceExtension->ClassData, Irp);
@@ -146,7 +146,7 @@ CompBattIoctl(
     }
 
     /* Return status */
-    if (CompBattDebug & 1) DbgPrint("CompBatt: EXITING Ioctl\n");
+    if (CompBattDebug & COMPBATT_DEBUG_TRACE) DbgPrint("CompBatt: EXITING Ioctl\n");
     return Status;
 }
 
@@ -158,7 +158,7 @@ CompBattQueryTag(
 {
     NTSTATUS Status;
     PAGED_CODE();
-    if (CompBattDebug & 0x100) DbgPrint("CompBatt: ENTERING QueryTag\n");
+    if (CompBattDebug & COMPBATT_DEBUG_TRACE) DbgPrint("CompBatt: ENTERING QueryTag\n");
 
     /* Was a tag assigned? */
     if (!(DeviceExtension->Flags & COMPBATT_TAG_ASSIGNED))
@@ -182,7 +182,7 @@ CompBattQueryTag(
     }
 
     /* Return status */
-    if (CompBattDebug & 0x100) DbgPrint("CompBatt: EXITING QueryTag\n");
+    if (CompBattDebug & COMPBATT_DEBUG_TRACE) DbgPrint("CompBatt: EXITING QueryTag\n");
     return Status;
 }
 
@@ -193,7 +193,7 @@ CompBattDisableStatusNotify(
 {
     PCOMPBATT_BATTERY_DATA BatteryData;
     PLIST_ENTRY ListHead, NextEntry;
-    if (CompBattDebug & 0x100) DbgPrint("CompBatt: ENTERING DisableStatusNotify\n");
+    if (CompBattDebug & COMPBATT_DEBUG_TRACE) DbgPrint("CompBatt: ENTERING DisableStatusNotify\n");
 
     /* Loop the battery list */
     ExAcquireFastMutex(&DeviceExtension->Lock);
@@ -210,7 +210,7 @@ CompBattDisableStatusNotify(
 
     /* Done */
     ExReleaseFastMutex(&DeviceExtension->Lock);
-    if (CompBattDebug & 0x100) DbgPrint("CompBatt: EXITING DisableStatusNotify\n");
+    if (CompBattDebug & COMPBATT_DEBUG_TRACE) DbgPrint("CompBatt: EXITING DisableStatusNotify\n");
     return STATUS_SUCCESS;
 }
 
@@ -246,7 +246,7 @@ CompBattGetBatteryInformation(
     BATTERY_QUERY_INFORMATION InputBuffer;
     PCOMPBATT_BATTERY_DATA BatteryData;
     PLIST_ENTRY ListHead, NextEntry;
-    if (CompBattDebug & 1) DbgPrint("CompBatt: ENTERING GetBatteryInformation\n");
+    if (CompBattDebug & COMPBATT_DEBUG_TRACE) DbgPrint("CompBatt: ENTERING GetBatteryInformation\n");
 
     /* Set defaults */
     BatteryInfo->DefaultAlert1 = 0;
@@ -298,7 +298,7 @@ CompBattGetBatteryInformation(
 
                     /* Next time we can use the static copy */
                     BatteryData->Flags |= COMPBATT_BATTERY_INFORMATION_PRESENT;
-                    if (CompBattDebug & 2)
+                    if (CompBattDebug & COMPBATT_DEBUG_INFO)
                         DbgPrint("CompBattGetBatteryInformation: Read individual BATTERY_INFORMATION\n"
                                  "--------  Capabilities = %x\n--------  Technology = %x\n"
                                  "--------  Chemistry[4] = %x\n--------  DesignedCapacity = %x\n"
@@ -364,7 +364,7 @@ CompBattGetBatteryInformation(
         }
 
         /* Print out final combined data */
-        if (CompBattDebug & 2)
+        if (CompBattDebug & COMPBATT_DEBUG_INFO)
             DbgPrint("CompBattGetBatteryInformation: Returning BATTERY_INFORMATION\n"
                      "--------  Capabilities = %x\n--------  Technology = %x\n"
                      "--------  Chemistry[4] = %x\n--------  DesignedCapacity = %x\n"
@@ -389,7 +389,7 @@ CompBattGetBatteryInformation(
     }
 
     /* We are done */
-    if (CompBattDebug & 1) DbgPrint("CompBatt: EXITING GetBatteryInformation\n");
+    if (CompBattDebug & COMPBATT_DEBUG_TRACE) DbgPrint("CompBatt: EXITING GetBatteryInformation\n");
     return Status;
 }
 
@@ -405,7 +405,7 @@ CompBattGetBatteryGranularity(
     BATTERY_REPORTING_SCALE BatteryScale[4];
     PLIST_ENTRY ListHead, NextEntry;
     ULONG i;
-    if (CompBattDebug & 1) DbgPrint("CompBatt: ENTERING GetBatteryGranularity\n");
+    if (CompBattDebug & COMPBATT_DEBUG_TRACE) DbgPrint("CompBatt: ENTERING GetBatteryGranularity\n");
 
     /* Set defaults */
     ReportingScale[0].Granularity = -1;
@@ -476,7 +476,7 @@ CompBattGetBatteryGranularity(
 
     /* All done */
     ExReleaseFastMutex(&DeviceExtension->Lock);
-    if (CompBattDebug & 1) DbgPrint("CompBatt: EXITING GetBatteryGranularity\n");
+    if (CompBattDebug & COMPBATT_DEBUG_TRACE) DbgPrint("CompBatt: EXITING GetBatteryGranularity\n");
     return STATUS_SUCCESS;
 }
 
@@ -510,7 +510,7 @@ CompBattQueryInformation(
     ULONG QueryLength = 0;
     NTSTATUS Status = STATUS_SUCCESS;
     PAGED_CODE();
-    if (CompBattDebug & 1)  DbgPrint("CompBatt: ENTERING QueryInformation\n");
+    if (CompBattDebug & COMPBATT_DEBUG_TRACE)  DbgPrint("CompBatt: ENTERING QueryInformation\n");
 
     /* Check for valid/correct tag */
     if ((Tag != DeviceExtension->Tag) ||
@@ -601,7 +601,7 @@ CompBattQueryInformation(
     if ((NT_SUCCESS(Status)) && (QueryData)) RtlCopyMemory(Buffer, QueryData, QueryLength);
 
     /* Return function result */
-    if (CompBattDebug & 1) DbgPrint("CompBatt: EXITING QueryInformation\n");
+    if (CompBattDebug & COMPBATT_DEBUG_TRACE) DbgPrint("CompBatt: EXITING QueryInformation\n");
     return Status;
 }
 

--- a/drivers/bus/acpi/compbatt/compbatt.c
+++ b/drivers/bus/acpi/compbatt/compbatt.c
@@ -20,8 +20,9 @@ ULONG CompBattDebug;
 
 NTSTATUS
 NTAPI
-CompBattOpenClose(IN PDEVICE_OBJECT DeviceObject,
-                  IN PIRP Irp)
+CompBattOpenClose(
+    _In_ PDEVICE_OBJECT DeviceObject,
+    _In_ PIRP Irp)
 {
     PAGED_CODE();
     if (CompBattDebug & 0x100) DbgPrint("CompBatt: ENTERING OpenClose\n");
@@ -38,8 +39,9 @@ CompBattOpenClose(IN PDEVICE_OBJECT DeviceObject,
 
 NTSTATUS
 NTAPI
-CompBattSystemControl(IN PDEVICE_OBJECT DeviceObject,
-                      IN PIRP Irp)
+CompBattSystemControl(
+    _In_ PDEVICE_OBJECT DeviceObject,
+    _In_ PIRP Irp)
 {
     PCOMPBATT_DEVICE_EXTENSION DeviceExtension = DeviceObject->DeviceExtension;
     NTSTATUS Status;
@@ -67,17 +69,10 @@ CompBattSystemControl(IN PDEVICE_OBJECT DeviceObject,
 
 NTSTATUS
 NTAPI
-CompBattMonitorIrpComplete(IN PDEVICE_OBJECT DeviceObject,
-                           IN PIRP Irp,
-                           IN PKEVENT Event)
-{
-    UNIMPLEMENTED;
-    return STATUS_NOT_IMPLEMENTED;
-}
-
-NTSTATUS
-NTAPI
-CompBattMonitorIrpCompleteWorker(IN PCOMPBATT_BATTERY_DATA BatteryData)
+CompBattMonitorIrpComplete(
+    _In_ PDEVICE_OBJECT DeviceObject,
+    _In_ PIRP Irp,
+    _In_ PVOID Context)
 {
     UNIMPLEMENTED;
     return STATUS_NOT_IMPLEMENTED;
@@ -85,7 +80,17 @@ CompBattMonitorIrpCompleteWorker(IN PCOMPBATT_BATTERY_DATA BatteryData)
 
 VOID
 NTAPI
-CompBattRecalculateTag(IN PCOMPBATT_DEVICE_EXTENSION DeviceExtension)
+CompBattMonitorIrpCompleteWorker(
+    _In_ PCOMPBATT_BATTERY_DATA BatteryData)
+{
+    UNIMPLEMENTED;
+    return STATUS_NOT_IMPLEMENTED;
+}
+
+VOID
+NTAPI
+CompBattRecalculateTag(
+    _In_ PCOMPBATT_DEVICE_EXTENSION DeviceExtension)
 {
     PCOMPBATT_BATTERY_DATA BatteryData;
     ULONG Tag;
@@ -122,8 +127,9 @@ CompBattRecalculateTag(IN PCOMPBATT_DEVICE_EXTENSION DeviceExtension)
 
 NTSTATUS
 NTAPI
-CompBattIoctl(IN PDEVICE_OBJECT DeviceObject,
-              IN PIRP Irp)
+CompBattIoctl(
+    _In_ PDEVICE_OBJECT DeviceObject,
+    _In_ PIRP Irp)
 {
     PCOMPBATT_DEVICE_EXTENSION DeviceExtension = DeviceObject->DeviceExtension;
     NTSTATUS Status;
@@ -146,8 +152,9 @@ CompBattIoctl(IN PDEVICE_OBJECT DeviceObject,
 
 NTSTATUS
 NTAPI
-CompBattQueryTag(IN PCOMPBATT_DEVICE_EXTENSION DeviceExtension,
-                 OUT PULONG Tag)
+CompBattQueryTag(
+    _In_ PCOMPBATT_DEVICE_EXTENSION DeviceExtension,
+    _Out_ PULONG Tag)
 {
     NTSTATUS Status;
     PAGED_CODE();
@@ -181,7 +188,8 @@ CompBattQueryTag(IN PCOMPBATT_DEVICE_EXTENSION DeviceExtension,
 
 NTSTATUS
 NTAPI
-CompBattDisableStatusNotify(IN PCOMPBATT_DEVICE_EXTENSION DeviceExtension)
+CompBattDisableStatusNotify(
+    _In_ PCOMPBATT_DEVICE_EXTENSION DeviceExtension)
 {
     PCOMPBATT_BATTERY_DATA BatteryData;
     PLIST_ENTRY ListHead, NextEntry;
@@ -208,9 +216,10 @@ CompBattDisableStatusNotify(IN PCOMPBATT_DEVICE_EXTENSION DeviceExtension)
 
 NTSTATUS
 NTAPI
-CompBattSetStatusNotify(IN PCOMPBATT_DEVICE_EXTENSION DeviceExtension,
-                        IN ULONG BatteryTag,
-                        IN PBATTERY_NOTIFY BatteryNotify)
+CompBattSetStatusNotify(
+    _In_ PCOMPBATT_DEVICE_EXTENSION DeviceExtension,
+    _In_ ULONG BatteryTag,
+    _In_ PBATTERY_NOTIFY BatteryNotify)
 {
     UNIMPLEMENTED;
     return STATUS_NOT_IMPLEMENTED;
@@ -218,9 +227,10 @@ CompBattSetStatusNotify(IN PCOMPBATT_DEVICE_EXTENSION DeviceExtension,
 
 NTSTATUS
 NTAPI
-CompBattQueryStatus(IN PCOMPBATT_DEVICE_EXTENSION DeviceExtension,
-                    IN ULONG Tag,
-                    IN PBATTERY_STATUS BatteryStatus)
+CompBattQueryStatus(
+    _In_ PCOMPBATT_DEVICE_EXTENSION DeviceExtension,
+    _In_ ULONG Tag,
+    _Out_ PBATTERY_STATUS BatteryStatus)
 {
     UNIMPLEMENTED;
     return STATUS_NOT_IMPLEMENTED;
@@ -228,8 +238,9 @@ CompBattQueryStatus(IN PCOMPBATT_DEVICE_EXTENSION DeviceExtension,
 
 NTSTATUS
 NTAPI
-CompBattGetBatteryInformation(OUT PBATTERY_INFORMATION BatteryInfo,
-                              IN PCOMPBATT_DEVICE_EXTENSION DeviceExtension)
+CompBattGetBatteryInformation(
+    _Out_ PBATTERY_INFORMATION BatteryInfo,
+    _In_ PCOMPBATT_DEVICE_EXTENSION DeviceExtension)
 {
     NTSTATUS Status = STATUS_SUCCESS;
     BATTERY_QUERY_INFORMATION InputBuffer;
@@ -384,8 +395,9 @@ CompBattGetBatteryInformation(OUT PBATTERY_INFORMATION BatteryInfo,
 
 NTSTATUS
 NTAPI
-CompBattGetBatteryGranularity(OUT PBATTERY_REPORTING_SCALE ReportingScale,
-                              IN PCOMPBATT_DEVICE_EXTENSION DeviceExtension)
+CompBattGetBatteryGranularity(
+    _Out_ PBATTERY_REPORTING_SCALE ReportingScale,
+    _In_ PCOMPBATT_DEVICE_EXTENSION DeviceExtension)
 {
     NTSTATUS Status = STATUS_SUCCESS;
     BATTERY_QUERY_INFORMATION InputBuffer;
@@ -470,8 +482,9 @@ CompBattGetBatteryGranularity(OUT PBATTERY_REPORTING_SCALE ReportingScale,
 
 NTSTATUS
 NTAPI
-CompBattGetEstimatedTime(OUT PULONG Time,
-                         IN PCOMPBATT_DEVICE_EXTENSION DeviceExtension)
+CompBattGetEstimatedTime(
+    _Out_ PULONG Time,
+    _In_ PCOMPBATT_DEVICE_EXTENSION DeviceExtension)
 {
     UNIMPLEMENTED;
     return STATUS_NOT_IMPLEMENTED;
@@ -479,13 +492,14 @@ CompBattGetEstimatedTime(OUT PULONG Time,
 
 NTSTATUS
 NTAPI
-CompBattQueryInformation(IN PCOMPBATT_DEVICE_EXTENSION DeviceExtension,
-                         IN ULONG Tag,
-                         IN BATTERY_QUERY_INFORMATION_LEVEL InfoLevel,
-                         IN OPTIONAL LONG AtRate,
-                         IN PVOID Buffer,
-                         IN ULONG BufferLength,
-                         OUT PULONG ReturnedLength)
+CompBattQueryInformation(
+    _In_ PCOMPBATT_DEVICE_EXTENSION DeviceExtension,
+    _In_ ULONG Tag,
+    _In_ BATTERY_QUERY_INFORMATION_LEVEL InfoLevel,
+    _In_opt_ LONG AtRate,
+    _In_ PVOID Buffer,
+    _In_ ULONG BufferLength,
+    _Out_ PULONG ReturnedLength)
 {
     BATTERY_INFORMATION BatteryInfo;
     BATTERY_REPORTING_SCALE BatteryGranularity[4];
@@ -593,8 +607,9 @@ CompBattQueryInformation(IN PCOMPBATT_DEVICE_EXTENSION DeviceExtension,
 
 NTSTATUS
 NTAPI
-DriverEntry(IN PDRIVER_OBJECT DriverObject,
-            IN PUNICODE_STRING RegistryPath)
+DriverEntry(
+    _In_ PDRIVER_OBJECT DriverObject,
+    _In_ PUNICODE_STRING RegistryPath)
 {
     /* Register add device routine */
     DriverObject->DriverExtension->AddDevice = CompBattAddDevice;

--- a/drivers/bus/acpi/compbatt/compbatt.c
+++ b/drivers/bus/acpi/compbatt/compbatt.c
@@ -261,7 +261,7 @@ CompBattGetBatteryInformation(
     {
         /* Try to acquire the remove lock */
         BatteryData = CONTAINING_RECORD(NextEntry, COMPBATT_BATTERY_DATA, BatteryLink);
-        if (NT_SUCCESS(IoAcquireRemoveLock(&BatteryData->RemoveLock, 0)))
+        if (NT_SUCCESS(IoAcquireRemoveLock(&BatteryData->RemoveLock, BatteryData->Irp)))
         {
             /* Now release the device lock since the battery can't go away */
             ExReleaseFastMutex(&DeviceExtension->Lock);
@@ -292,7 +292,7 @@ CompBattGetBatteryInformation(
                         /* Fail if the query had a problem */
                         if (Status == STATUS_DEVICE_REMOVED) Status = STATUS_NO_SUCH_DEVICE;
                         ExAcquireFastMutex(&DeviceExtension->Lock);
-                        IoReleaseRemoveLock(&BatteryData->RemoveLock, 0);
+                        IoReleaseRemoveLock(&BatteryData->RemoveLock, BatteryData->Irp);
                         break;
                     }
 
@@ -346,7 +346,7 @@ CompBattGetBatteryInformation(
 
             /* Re-acquire the device extension lock and release the remove lock */
             ExAcquireFastMutex(&DeviceExtension->Lock);
-            IoReleaseRemoveLock(&BatteryData->RemoveLock, 0);
+            IoReleaseRemoveLock(&BatteryData->RemoveLock, BatteryData->Irp);
         }
 
         /* Next entry */
@@ -421,7 +421,7 @@ CompBattGetBatteryGranularity(
     {
         /* Try to acquire the remove lock */
         BatteryData = CONTAINING_RECORD(NextEntry, COMPBATT_BATTERY_DATA, BatteryLink);
-        if (NT_SUCCESS(IoAcquireRemoveLock(&BatteryData->RemoveLock, 0)))
+        if (NT_SUCCESS(IoAcquireRemoveLock(&BatteryData->RemoveLock, BatteryData->Irp)))
         {
             /* Now release the device lock since the battery can't go away */
             ExReleaseFastMutex(&DeviceExtension->Lock);
@@ -447,7 +447,7 @@ CompBattGetBatteryGranularity(
                 {
                     /* Fail if the query had a problem */
                     ExAcquireFastMutex(&DeviceExtension->Lock);
-                    IoReleaseRemoveLock(&BatteryData->RemoveLock, 0);
+                    IoReleaseRemoveLock(&BatteryData->RemoveLock, BatteryData->Irp);
                     break;
                 }
 
@@ -467,7 +467,7 @@ CompBattGetBatteryGranularity(
 
             /* Re-acquire the device extension lock and release the remove lock */
             ExAcquireFastMutex(&DeviceExtension->Lock);
-            IoReleaseRemoveLock(&BatteryData->RemoveLock, 0);
+            IoReleaseRemoveLock(&BatteryData->RemoveLock, BatteryData->Irp);
         }
 
         /* Next entry */

--- a/drivers/bus/acpi/compbatt/compbatt.c
+++ b/drivers/bus/acpi/compbatt/compbatt.c
@@ -286,7 +286,7 @@ CompBattGetBatteryInformation(
                                           sizeof(InputBuffer),
                                           &BatteryData->BatteryInformation,
                                           sizeof(BatteryData->BatteryInformation),
-                                          0);
+                                          FALSE);
                     if (!NT_SUCCESS(Status))
                     {
                         /* Fail if the query had a problem */
@@ -442,7 +442,7 @@ CompBattGetBatteryGranularity(
                                       sizeof(InputBuffer),
                                       &BatteryScale,
                                       sizeof(BatteryScale),
-                                      0);
+                                      FALSE);
                 if (!NT_SUCCESS(Status))
                 {
                     /* Fail if the query had a problem */

--- a/drivers/bus/acpi/compbatt/compbatt.h
+++ b/drivers/bus/acpi/compbatt/compbatt.h
@@ -1,10 +1,12 @@
 /*
- * PROJECT:         ReactOS Composite Battery Driver
- * LICENSE:         BSD - See COPYING.ARM in the top level directory
- * FILE:            boot/drivers/bus/acpi/compbatt/compbatt.h
- * PURPOSE:         Main Header File
- * PROGRAMMERS:     ReactOS Portable Systems Group
+ * PROJECT:     ReactOS Composite Battery Driver
+ * LICENSE:     BSD - See COPYING.ARM in the top level directory
+ * PURPOSE:     Composite battery main header file
+ * COPYRIGHT:   Copyright 2010 ReactOS Portable Systems Group
+ *              Copyright 2024 George Bișoc <george.bisoc@reactos.org>
  */
+
+/* INCLUDES *******************************************************************/
 
 #ifndef _COMPBATT_PCH_
 #define _COMPBATT_PCH_
@@ -12,9 +14,68 @@
 #include <wdm.h>
 #include <batclass.h>
 
+/* DEFINES ********************************************************************/
+
+//
+// I/O remove lock allocate tag
+//
+#define COMPBATT_TAG                            'aBoC'
+
+//
+// Composite battery flags
+//
 #define COMPBATT_BATTERY_INFORMATION_PRESENT    0x04
+#define COMPBATT_STATUS_NOTIFY_SET              0x10
 #define COMPBATT_TAG_ASSIGNED                   0x80
 
+//
+// IRP complete worker mode states
+//
+#define COMPBATT_QUERY_TAG                      1
+#define COMPBATT_READ_STATUS                    2
+
+//
+// Low/High capacity wait constants
+//
+#define COMPBATT_WAIT_MIN_LOW_CAPACITY          0
+#define COMPBATT_WAIT_MAX_HIGH_CAPACITY         0x7FFFFFFF
+
+//
+// One hour in seconds, used to calculate the total rate of each battery for time estimation
+//
+#define COMPBATT_ATRATE_HOUR_IN_SECS            3600
+
+//
+// Time constant of which the battery status data is considered fresh (50000000 * 100ns == 5s)
+//
+#define COMPBATT_FRESH_STATUS_TIME              50000000
+
+//
+// Macro that calculates the delta of a battery's capacity
+//
+#define COMPUTE_BATT_CAP_DELTA(LowDiff, Batt, TotalRate)            \
+    ((ULONG)(((LONGLONG)LowDiff * (Batt)->BatteryStatus.Rate) / TotalRate))
+
+//
+// Macro that calculates the "At Rate" time drain of the battery
+//
+#define COMPUTE_ATRATE_DRAIN(Batt, Time)                            \
+    ((LONG)((Batt)->BatteryStatus.Capacity) * COMPBATT_ATRATE_HOUR_IN_SECS / Time)
+
+//
+// Composite battery debug levels
+//
+#define COMPBATT_DEBUG_INFO                     0x1
+#define COMPBATT_DEBUG_TRACE                    0x2
+#define COMPBATT_DEBUG_WARN                     0x4
+#define COMPBATT_DEBUG_ERR                      0x10
+#define COMPBATT_DEBUG_ALL_LEVELS               (COMPBATT_DEBUG_INFO | COMPBATT_DEBUG_TRACE | COMPBATT_DEBUG_WARN | COMPBATT_DEBUG_ERR)
+
+/* STRUCTURES *****************************************************************/
+
+//
+// Individual ACPI battery data
+//
 typedef struct _COMPBATT_BATTERY_DATA
 {
     LIST_ENTRY BatteryLink;
@@ -22,13 +83,14 @@ typedef struct _COMPBATT_BATTERY_DATA
     PDEVICE_OBJECT DeviceObject;
     PIRP Irp;
     WORK_QUEUE_ITEM WorkItem;
-    BOOLEAN WaitFlag;
+    UCHAR Mode;
     BATTERY_WAIT_STATUS WaitStatus;
     union
     {
         BATTERY_WAIT_STATUS WorkerWaitStatus;
         BATTERY_STATUS WorkerStatus;
-    };
+        ULONG WorkerTag;
+    } WorkerBuffer;
     ULONG Tag;
     ULONG Flags;
     BATTERY_INFORMATION BatteryInformation;
@@ -37,6 +99,9 @@ typedef struct _COMPBATT_BATTERY_DATA
     UNICODE_STRING BatteryName;
 } COMPBATT_BATTERY_DATA, *PCOMPBATT_BATTERY_DATA;
 
+//
+// Composite battery device extension data
+//
 typedef struct _COMPBATT_DEVICE_EXTENSION
 {
     PVOID ClassData;
@@ -47,110 +112,124 @@ typedef struct _COMPBATT_DEVICE_EXTENSION
     ULONG Flags;
     BATTERY_INFORMATION BatteryInformation;
     BATTERY_STATUS BatteryStatus;
+    BATTERY_WAIT_STATUS WaitNotifyStatus;
     ULONGLONG InterruptTime;
-    POWER_STATE PowerState;
-    ULONG LowCapacity;
-    ULONG HighCapacity;
     PDEVICE_OBJECT AttachedDevice;
     PDEVICE_OBJECT DeviceObject;
     PVOID NotificationEntry;
 } COMPBATT_DEVICE_EXTENSION, *PCOMPBATT_DEVICE_EXTENSION;
 
+/* PROTOTYPES *****************************************************************/
+
 NTSTATUS
 NTAPI
 CompBattAddDevice(
-    IN PDRIVER_OBJECT DriverObject,
-    IN PDEVICE_OBJECT PdoDeviceObject
+    _In_ PDRIVER_OBJECT DriverObject,
+    _In_ PDEVICE_OBJECT PdoDeviceObject
 );
 
 NTSTATUS
 NTAPI
 CompBattPowerDispatch(
-    IN PDEVICE_OBJECT DeviceObject,
-    IN PIRP Irp
+    _In_ PDEVICE_OBJECT DeviceObject,
+    _In_ PIRP Irp
 );
 
 NTSTATUS
 NTAPI
 CompBattPnpDispatch(
-    IN PDEVICE_OBJECT DeviceObject,
-    IN PIRP Irp
+    _In_ PDEVICE_OBJECT DeviceObject,
+    _In_ PIRP Irp
 );
 
 NTSTATUS
 NTAPI
 CompBattQueryInformation(
-    IN PCOMPBATT_DEVICE_EXTENSION FdoExtension,
-    IN ULONG Tag,
-    IN BATTERY_QUERY_INFORMATION_LEVEL InfoLevel,
-    IN OPTIONAL LONG AtRate,
-    IN PVOID Buffer,
-    IN ULONG BufferLength,
-    OUT PULONG ReturnedLength
+    _In_ PCOMPBATT_DEVICE_EXTENSION FdoExtension,
+    _In_ ULONG Tag,
+    _In_ BATTERY_QUERY_INFORMATION_LEVEL InfoLevel,
+    _In_opt_ LONG AtRate,
+    _In_ PVOID Buffer,
+    _In_ ULONG BufferLength,
+    _Out_ PULONG ReturnedLength
 );
 
 NTSTATUS
 NTAPI
 CompBattQueryStatus(
-    IN PCOMPBATT_DEVICE_EXTENSION DeviceExtension,
-    IN ULONG Tag,
-    IN PBATTERY_STATUS BatteryStatus
+    _In_ PCOMPBATT_DEVICE_EXTENSION DeviceExtension,
+    _In_ ULONG Tag,
+    _Out_ PBATTERY_STATUS BatteryStatus
+);
+
+NTSTATUS
+NTAPI
+CompBattGetEstimatedTime(
+    _Out_ PULONG Time,
+    _In_ PCOMPBATT_DEVICE_EXTENSION DeviceExtension
 );
 
 NTSTATUS
 NTAPI
 CompBattSetStatusNotify(
-    IN PCOMPBATT_DEVICE_EXTENSION DeviceExtension,
-    IN ULONG BatteryTag,
-    IN PBATTERY_NOTIFY BatteryNotify
+    _In_ PCOMPBATT_DEVICE_EXTENSION DeviceExtension,
+    _In_ ULONG BatteryTag,
+    _In_ PBATTERY_NOTIFY BatteryNotify
 );
 
 NTSTATUS
 NTAPI
 CompBattDisableStatusNotify(
-    IN PCOMPBATT_DEVICE_EXTENSION DeviceExtension
+    _In_ PCOMPBATT_DEVICE_EXTENSION DeviceExtension
 );
 
 NTSTATUS
 NTAPI
 CompBattQueryTag(
-    IN PCOMPBATT_DEVICE_EXTENSION DeviceExtension,
-    OUT PULONG Tag
+    _In_ PCOMPBATT_DEVICE_EXTENSION DeviceExtension,
+    _Out_ PULONG Tag
 );
 
 NTSTATUS
 NTAPI
 CompBattMonitorIrpComplete(
-    IN PDEVICE_OBJECT DeviceObject,
-    IN PIRP Irp,
-    IN PKEVENT Event
+    _In_ PDEVICE_OBJECT DeviceObject,
+    _In_ PIRP Irp,
+    _In_ PVOID Context
 );
 
-NTSTATUS
+VOID
 NTAPI
 CompBattMonitorIrpCompleteWorker(
-    IN PCOMPBATT_BATTERY_DATA BatteryData
+    _In_ PCOMPBATT_BATTERY_DATA BatteryData
 );
 
 NTSTATUS
 NTAPI
 CompBattGetDeviceObjectPointer(
-    IN PUNICODE_STRING DeviceName,
-    IN ACCESS_MASK DesiredAccess,
-    OUT PFILE_OBJECT *FileObject,
-    OUT PDEVICE_OBJECT *DeviceObject
+    _In_ PUNICODE_STRING DeviceName,
+    _In_ ACCESS_MASK DesiredAccess,
+    _Out_ PFILE_OBJECT *FileObject,
+    _Out_ PDEVICE_OBJECT *DeviceObject
 );
 
 NTSTATUS
 NTAPI
 BatteryIoctl(
-    IN ULONG IoControlCode,
-    IN PDEVICE_OBJECT DeviceObject,
-    IN PVOID InputBuffer,
-    IN ULONG InputBufferLength,
-    IN PVOID OutputBuffer,
-    IN ULONG OutputBufferLength,
-    IN BOOLEAN InternalDeviceIoControl
+    _In_ ULONG IoControlCode,
+    _In_ PDEVICE_OBJECT DeviceObject,
+    _In_ PVOID InputBuffer,
+    _In_ ULONG InputBufferLength,
+    _Out_ PVOID OutputBuffer,
+    _Inout_ ULONG OutputBufferLength,
+    _In_ BOOLEAN InternalDeviceIoControl
+);
+
+NTSTATUS
+NTAPI
+CompBattRemoveBattery(
+    _In_ PUNICODE_STRING BatteryName,
+    _In_ PCOMPBATT_DEVICE_EXTENSION DeviceExtension
 );
 
 extern ULONG CompBattDebug;

--- a/drivers/bus/acpi/compbatt/compbatt.h
+++ b/drivers/bus/acpi/compbatt/compbatt.h
@@ -1,8 +1,8 @@
 /*
  * PROJECT:     ReactOS Composite Battery Driver
- * LICENSE:     BSD - See COPYING.ARM in the top level directory
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
  * PURPOSE:     Composite battery main header file
- * COPYRIGHT:   Copyright 2010 ReactOS Portable Systems Group
+ * COPYRIGHT:   Copyright 2010 ReactOS Portable Systems Group <ros.arm@reactos.org>
  *              Copyright 2024 George Bișoc <george.bisoc@reactos.org>
  */
 

--- a/drivers/bus/acpi/compbatt/compmisc.c
+++ b/drivers/bus/acpi/compbatt/compmisc.c
@@ -1,9 +1,8 @@
 /*
- * PROJECT:         ReactOS Composite Battery Driver
- * LICENSE:         BSD - See COPYING.ARM in the top level directory
- * FILE:            boot/drivers/bus/acpi/compbatt/compmisc.c
- * PURPOSE:         Miscellaneous Support Routines
- * PROGRAMMERS:     ReactOS Portable Systems Group
+ * PROJECT:     ReactOS Composite Battery Driver
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     Miscellaneous Support Routines
+ * COPYRIGHT:   Copyright 2010 ReactOS Portable Systems Group <ros.arm@reactos.org>
  */
 
 /* INCLUDES *******************************************************************/

--- a/drivers/bus/acpi/compbatt/compmisc.c
+++ b/drivers/bus/acpi/compbatt/compmisc.c
@@ -14,13 +14,14 @@
 
 NTSTATUS
 NTAPI
-BatteryIoctl(IN ULONG IoControlCode,
-             IN PDEVICE_OBJECT DeviceObject,
-             IN PVOID InputBuffer,
-             IN ULONG InputBufferLength,
-             IN PVOID OutputBuffer,
-             IN ULONG OutputBufferLength,
-             IN BOOLEAN InternalDeviceIoControl)
+BatteryIoctl(
+    _In_ ULONG IoControlCode,
+    _In_ PDEVICE_OBJECT DeviceObject,
+    _In_ PVOID InputBuffer,
+    _In_ ULONG InputBufferLength,
+    _Out_ PVOID OutputBuffer,
+    _Inout_ ULONG OutputBufferLength,
+    _In_ BOOLEAN InternalDeviceIoControl)
 {
     IO_STATUS_BLOCK IoStatusBlock;
     KEVENT Event;
@@ -71,10 +72,11 @@ BatteryIoctl(IN ULONG IoControlCode,
 
 NTSTATUS
 NTAPI
-CompBattGetDeviceObjectPointer(IN PUNICODE_STRING DeviceName,
-                               IN ACCESS_MASK DesiredAccess,
-                               OUT PFILE_OBJECT *FileObject,
-                               OUT PDEVICE_OBJECT *DeviceObject)
+CompBattGetDeviceObjectPointer(
+    _In_ PUNICODE_STRING DeviceName,
+    _In_ ACCESS_MASK DesiredAccess,
+    _Out_ PFILE_OBJECT *FileObject,
+    _Out_ PDEVICE_OBJECT *DeviceObject)
 {
     NTSTATUS Status;
     OBJECT_ATTRIBUTES ObjectAttributes;

--- a/drivers/bus/acpi/compbatt/compmisc.c
+++ b/drivers/bus/acpi/compbatt/compmisc.c
@@ -28,7 +28,7 @@ BatteryIoctl(
     NTSTATUS Status;
     PIRP Irp;
     PAGED_CODE();
-    if (CompBattDebug & 0x100) DbgPrint("CompBatt: ENTERING BatteryIoctl\n");
+    if (CompBattDebug & COMPBATT_DEBUG_TRACE) DbgPrint("CompBatt: ENTERING BatteryIoctl\n");
 
     /* Initialize the event and IRP */
     KeInitializeEvent(&Event, SynchronizationEvent, 0);
@@ -53,16 +53,16 @@ BatteryIoctl(
         }
 
         /* Print failure */
-        if (!(NT_SUCCESS(Status)) && (CompBattDebug & 8))
+        if (!(NT_SUCCESS(Status)) && (CompBattDebug & COMPBATT_DEBUG_ERR))
             DbgPrint("BatteryIoctl: Irp failed - %x\n", Status);
 
         /* Done */
-        if (CompBattDebug & 0x100) DbgPrint("CompBatt: EXITING BatteryIoctl\n");
+        if (CompBattDebug & COMPBATT_DEBUG_TRACE) DbgPrint("CompBatt: EXITING BatteryIoctl\n");
     }
     else
     {
         /* Out of memory */
-        if (CompBattDebug & 8) DbgPrint("BatteryIoctl: couldn't create Irp\n");
+        if (CompBattDebug & COMPBATT_DEBUG_ERR) DbgPrint("BatteryIoctl: couldn't create Irp\n");
         Status = STATUS_INSUFFICIENT_RESOURCES;
     }
 

--- a/drivers/bus/acpi/compbatt/comppnp.c
+++ b/drivers/bus/acpi/compbatt/comppnp.c
@@ -177,7 +177,7 @@ CompBattAddNewBattery(
                     ExReleaseFastMutex(&DeviceExtension->Lock);
 
                     /* Initialize the work item and delete lock */
-                    IoInitializeRemoveLock(&BatteryData->RemoveLock, 0, 0, 0);
+                    IoInitializeRemoveLock(&BatteryData->RemoveLock, COMPBATT_TAG, 0, 0);
                     ExInitializeWorkItem(&BatteryData->WorkItem,
                                          (PVOID)CompBattMonitorIrpCompleteWorker,
                                          BatteryData);

--- a/drivers/bus/acpi/compbatt/comppnp.c
+++ b/drivers/bus/acpi/compbatt/comppnp.c
@@ -16,8 +16,9 @@
 
 NTSTATUS
 NTAPI
-CompBattPowerDispatch(IN PDEVICE_OBJECT DeviceObject,
-                      IN PIRP Irp)
+CompBattPowerDispatch(
+    _In_ PDEVICE_OBJECT DeviceObject,
+    _In_ PIRP Irp)
 {
     PCOMPBATT_DEVICE_EXTENSION DeviceExtension = DeviceObject->DeviceExtension;
     if (CompBattDebug & 1) DbgPrint("CompBatt: PowerDispatch received power IRP.\n");
@@ -32,8 +33,9 @@ CompBattPowerDispatch(IN PDEVICE_OBJECT DeviceObject,
 
 PCOMPBATT_BATTERY_DATA
 NTAPI
-RemoveBatteryFromList(IN PCUNICODE_STRING BatteryName,
-                      IN PCOMPBATT_DEVICE_EXTENSION DeviceExtension)
+RemoveBatteryFromList(
+    _In_ PCUNICODE_STRING BatteryName,
+    _In_ PCOMPBATT_DEVICE_EXTENSION DeviceExtension)
 {
     PLIST_ENTRY ListHead, NextEntry;
     PCOMPBATT_BATTERY_DATA BatteryData;
@@ -74,8 +76,9 @@ RemoveBatteryFromList(IN PCUNICODE_STRING BatteryName,
 
 BOOLEAN
 NTAPI
-IsBatteryAlreadyOnList(IN PCUNICODE_STRING BatteryName,
-                       IN PCOMPBATT_DEVICE_EXTENSION DeviceExtension)
+IsBatteryAlreadyOnList(
+    _In_ PCUNICODE_STRING BatteryName,
+    _In_ PCOMPBATT_DEVICE_EXTENSION DeviceExtension)
 {
     PLIST_ENTRY ListHead, NextEntry;
     PCOMPBATT_BATTERY_DATA BatteryData;
@@ -110,8 +113,9 @@ IsBatteryAlreadyOnList(IN PCUNICODE_STRING BatteryName,
 
 NTSTATUS
 NTAPI
-CompBattAddNewBattery(IN PUNICODE_STRING BatteryName,
-                      IN PCOMPBATT_DEVICE_EXTENSION DeviceExtension)
+CompBattAddNewBattery(
+    _In_ PUNICODE_STRING BatteryName,
+    _In_ PCOMPBATT_DEVICE_EXTENSION DeviceExtension)
 {
     NTSTATUS Status = STATUS_SUCCESS;
     PCOMPBATT_BATTERY_DATA BatteryData;
@@ -220,8 +224,9 @@ CompBattAddNewBattery(IN PUNICODE_STRING BatteryName,
 
 NTSTATUS
 NTAPI
-CompBattRemoveBattery(IN PCUNICODE_STRING BatteryName,
-                      IN PCOMPBATT_DEVICE_EXTENSION DeviceExtension)
+CompBattRemoveBattery(
+    _In_ PCUNICODE_STRING BatteryName,
+    _In_ PCOMPBATT_DEVICE_EXTENSION DeviceExtension)
 {
     PCOMPBATT_BATTERY_DATA BatteryData;
     if (CompBattDebug & 1) DbgPrint("CompBatt: RemoveBattery\n");
@@ -245,7 +250,8 @@ CompBattRemoveBattery(IN PCUNICODE_STRING BatteryName,
 
 NTSTATUS
 NTAPI
-CompBattGetBatteries(IN PCOMPBATT_DEVICE_EXTENSION DeviceExtension)
+CompBattGetBatteries(
+    _In_ PCOMPBATT_DEVICE_EXTENSION DeviceExtension)
 {
     PWCHAR p;
     NTSTATUS Status;
@@ -286,8 +292,9 @@ CompBattGetBatteries(IN PCOMPBATT_DEVICE_EXTENSION DeviceExtension)
 
 NTSTATUS
 NTAPI
-CompBattPnpEventHandler(IN PDEVICE_INTERFACE_CHANGE_NOTIFICATION Notification,
-                        IN PCOMPBATT_DEVICE_EXTENSION DeviceExtension)
+CompBattPnpEventHandler(
+    _In_ PDEVICE_INTERFACE_CHANGE_NOTIFICATION Notification,
+    _In_ PCOMPBATT_DEVICE_EXTENSION DeviceExtension)
 {
     if (CompBattDebug & 1) DbgPrint("CompBatt: ENTERING PnpEventHandler\n");
     if (CompBattDebug & 2) DbgPrint("CompBatt: Received device interface change notification\n");
@@ -319,8 +326,9 @@ CompBattPnpEventHandler(IN PDEVICE_INTERFACE_CHANGE_NOTIFICATION Notification,
 
 NTSTATUS
 NTAPI
-CompBattAddDevice(IN PDRIVER_OBJECT DriverObject,
-                  IN PDEVICE_OBJECT PdoDeviceObject)
+CompBattAddDevice(
+    _In_ PDRIVER_OBJECT DriverObject,
+    _In_ PDEVICE_OBJECT PdoDeviceObject)
 {
     NTSTATUS Status;
     UNICODE_STRING DeviceName;
@@ -402,8 +410,9 @@ CompBattAddDevice(IN PDRIVER_OBJECT DriverObject,
 
 NTSTATUS
 NTAPI
-CompBattPnpDispatch(IN PDEVICE_OBJECT DeviceObject,
-                    IN PIRP Irp)
+CompBattPnpDispatch(
+    _In_ PDEVICE_OBJECT DeviceObject,
+    _In_ PIRP Irp)
 {
     PIO_STACK_LOCATION IoStackLocation = IoGetCurrentIrpStackLocation(Irp);
     NTSTATUS Status;

--- a/drivers/bus/acpi/compbatt/comppnp.c
+++ b/drivers/bus/acpi/compbatt/comppnp.c
@@ -183,7 +183,7 @@ CompBattAddNewBattery(
                                          BatteryData);
 
                     /* Setup the IRP work entry */
-                    CompBattMonitorIrpComplete(BatteryData->DeviceObject, Irp, 0);
+                    CompBattMonitorIrpComplete(BatteryData->DeviceObject, Irp, NULL);
                     Status = STATUS_SUCCESS;
                 }
                 else

--- a/drivers/bus/acpi/compbatt/comppnp.c
+++ b/drivers/bus/acpi/compbatt/comppnp.c
@@ -225,7 +225,7 @@ CompBattAddNewBattery(
 NTSTATUS
 NTAPI
 CompBattRemoveBattery(
-    _In_ PCUNICODE_STRING BatteryName,
+    _In_ PUNICODE_STRING BatteryName,
     _In_ PCOMPBATT_DEVICE_EXTENSION DeviceExtension)
 {
     PCOMPBATT_BATTERY_DATA BatteryData;

--- a/drivers/bus/acpi/compbatt/comppnp.c
+++ b/drivers/bus/acpi/compbatt/comppnp.c
@@ -1,9 +1,8 @@
 /*
- * PROJECT:         ReactOS Composite Battery Driver
- * LICENSE:         BSD - See COPYING.ARM in the top level directory
- * FILE:            boot/drivers/bus/acpi/compbatt/comppnp.c
- * PURPOSE:         Plug-and-Play IOCTL/IRP Handling
- * PROGRAMMERS:     ReactOS Portable Systems Group
+ * PROJECT:     ReactOS Composite Battery Driver
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     Plug-and-Play IOCTL/IRP Handling
+ * COPYRIGHT:   Copyright 2010 ReactOS Portable Systems Group <ros.arm@reactos.org>
  */
 
 /* INCLUDES *******************************************************************/

--- a/drivers/bus/acpi/compbatt/comppnp.c
+++ b/drivers/bus/acpi/compbatt/comppnp.c
@@ -165,7 +165,6 @@ CompBattAddNewBattery(IN PUNICODE_STRING BatteryName,
                     /* Set IRP data */
                     IoSetNextIrpStackLocation(Irp);
                     Irp->IoStatus.Status = STATUS_DEVICE_NOT_CONNECTED;
-                    BatteryData->WaitFlag = 0;
 
                     /* Insert this battery in the list */
                     ExAcquireFastMutex(&DeviceExtension->Lock);


### PR DESCRIPTION
## Purpose
This PR is an attempt to resuscitate the **Composite Battery** driver which is broken, barely usable and it even asserts the kernel because it improperly uses a function with incorrect parameter(s). Nevertheless there are several unimplemented functions which makes the entire driver useless.

With this PR now it can properly talk with the **Battery Class** and **Control Method Battery** drivers via IOCTLs, it can query battery status of each individual ACPI battery and gather static information.

The PR must shall be reviewed by commit, I'll signal everyone that is ready to review once I finished the TODOs. The PR is needed for the development of the Power Manager (#5719) to continue.

## Proposed Changes

- Implement `CompBattSetStatusNotify`
- Implement `CompBattQueryStatus`
- Implement `CompBattGetEstimatedTime`
- Implement battery monitor IRP worker
- Annotate every function with SAL2
- Miscellaneous fixes
- Document the  related structures and newly added code
- Relicense the driver as MIT

## TODO

- [x] Add documentation for newly added code
- [x] Document `COMPBATT_BATTERY_DATA` and `COMPBATT_DEVICE_EXTENSION`

## Jira Issues
[CORE-18969](https://jira.reactos.org/browse/CORE-18969)
[CORE-19452](https://jira.reactos.org/browse/CORE-19452)
[CORE-19888](https://jira.reactos.org/browse/CORE-19888)