### PR TITLE
[STOBJECT] Display the estimated battery time when hovering the battery icon

### DIFF
--- a/dll/shellext/stobject/power.cpp
+++ b/dll/shellext/stobject/power.cpp
@@ -29,6 +29,8 @@ typedef struct _PWRSCHEMECONTEXT
 CString  g_strTooltip;
 static HICON g_hIconBattery = NULL;
 
+#define HOUR_IN_SECS    3600
+#define MIN_IN_SECS     60
 
 /*++
 * @name Quantize
@@ -78,6 +80,7 @@ static HICON DynamicLoadIcon(HINSTANCE hinst)
 {
     SYSTEM_POWER_STATUS PowerStatus;
     HICON hBatIcon;
+    UINT uiHour, uiMin;
     UINT index = -1;
 
     if (!GetSystemPowerStatus(&PowerStatus) ||
@@ -107,7 +110,25 @@ static HICON DynamicLoadIcon(HINSTANCE hinst)
     {
         index = Quantize(PowerStatus.BatteryLifePercent);
         hBatIcon = LoadIcon(hinst, MAKEINTRESOURCE(br_icons[index]));
-        g_strTooltip.Format(IDS_PWR_PERCENT_REMAINING, PowerStatus.BatteryLifePercent);
+
+        if (PowerStatus.BatteryLifeTime != BATTERY_UNKNOWN_TIME)
+        {
+            uiHour = PowerStatus.BatteryLifeTime / HOUR_IN_SECS;
+            uiMin = (PowerStatus.BatteryLifeTime % HOUR_IN_SECS) / MIN_IN_SECS;
+
+            if (uiHour != 0)
+            {
+                g_strTooltip.Format(IDS_PWR_HOURS_REMAINING, uiHour, uiMin, PowerStatus.BatteryLifePercent);
+            }
+            else
+            {
+                g_strTooltip.Format(IDS_PWR_MINUTES_REMAINING, uiMin, PowerStatus.BatteryLifePercent);
+            }
+        }
+        else
+        {
+            g_strTooltip.Format(IDS_PWR_PERCENT_REMAINING, PowerStatus.BatteryLifePercent);
+        }
     }
     else
     {


### PR DESCRIPTION
## Purpose
We do have **IDS_PWR_HOURS_REMAINING** and **IDS_PWR_MINUTES_REMAINING** string resources but they're never used programmatically. Display the estimated battery time ONLY if the returned time is not unknown.

This patch is needed for the development of the Power Manager (#5719) to continue.

## Jira Issues
[CORE-18969](https://jira.reactos.org/browse/CORE-18969)
[CORE-19452](https://jira.reactos.org/browse/CORE-19452)
