### PR TITLE
[EVENTVWR] Fix ro-RO.rc typo error in last commit of eventvwr/lang

### DIFF
--- a/base/applications/mscutils/eventvwr/lang/ro-RO.rc
+++ b/base/applications/mscutils/eventvwr/lang/ro-RO.rc
@@ -179,7 +179,7 @@ BEGIN
 EventVwr [numele computerului] [/L:<fișier de jurnal de evenimente>] [/?]\n\
 \n\
 ""numele computerului"" : Specifică computerul de la distanță unde să se conecteze\n\
-\pentru a prelua evenimentele de afișat. Dacă nu este specificat niciun nume,\n\
+\tpentru a prelua evenimentele de afișat. Dacă nu este specificat niciun nume,\n\
 \tcomputerul local este folosit.\n\
 \n\
 /L:<fișier de jurnal de evenimente> : Specifică deschiderea unui fișier.\n\


### PR DESCRIPTION
## Purpose

_Fix typo in PR #7352 and 0.4.16-dev-323-gc212c18._

JIRA issue: GCC shows compiler error as follows:
Building RC object base/appl...MakeFiles/eventvwr.dir/eventvwr.rc.obj
D:/ReactO/reactos/base/applications/mscutils/eventvwr/lang/ro-RO.rc:177: unrecognized escape sequence

## Proposed changes

_In help file one line began with '\pentru' and this should have been '\tpentru'._
Co-authored-by: George Bișoc <george.bisoc@reactos.org>