### PR TITLE
[SHELL32] ILLoadFromStream must allow loading unknown pidl formats

### DIFF
--- a/dll/win32/shell32/wine/pidl.c
+++ b/dll/win32/shell32/wine/pidl.c
@@ -2032,11 +2032,12 @@ DWORD _ILGetDrive(LPCITEMIDLIST pidl, LPWSTR pOut, UINT uSize)
  */
 BOOL _ILIsUnicode(LPCITEMIDLIST pidl)
 {
-    LPPIDLDATA lpPData = _ILGetDataPointer(pidl);
+    const BYTE bits = PT_FS | PT_FS_UNICODE_FLAG;
+    BYTE type = _ILGetType(pidl);
 
     TRACE("(%p)\n",pidl);
 
-    return (pidl && lpPData && PT_VALUEW == lpPData->type);
+    return (type & bits) == bits;
 }
 
 BOOL _ILIsDesktop(LPCITEMIDLIST pidl)

--- a/dll/win32/shell32/wine/pidl.c
+++ b/dll/win32/shell32/wine/pidl.c
@@ -2032,12 +2032,9 @@ DWORD _ILGetDrive(LPCITEMIDLIST pidl, LPWSTR pOut, UINT uSize)
  */
 BOOL _ILIsUnicode(LPCITEMIDLIST pidl)
 {
-    const BYTE bits = PT_FS | PT_FS_UNICODE_FLAG;
-    BYTE type = _ILGetType(pidl);
-
     TRACE("(%p)\n",pidl);
 
-    return (type & bits) == bits;
+    return (_ILGetFSType(pidl) & PT_FS_UNICODE_FLAG) != 0;
 }
 
 BOOL _ILIsDesktop(LPCITEMIDLIST pidl)

--- a/dll/win32/shell32/wine/pidl.c
+++ b/dll/win32/shell32/wine/pidl.c
@@ -333,8 +333,10 @@ HRESULT WINAPI ILLoadFromStream (IStream * pStream, LPITEMIDLIST * ppPidl)
     if (*ppPidl && !pcheck(*ppPidl))
     {
         WARN("Check failed\n");
+#ifndef __REACTOS__ /* We don't know all pidl formats, must allow loading unknown */
         SHFree(*ppPidl);
         *ppPidl = NULL;
+#endif
     }
 
     IStream_Release (pStream);


### PR DESCRIPTION
This is related to [CORE-19944](https://jira.reactos.org/browse/CORE-19944) where the created shortcut cannot load the stored PIDL because it's a custom format.