### PR TITLE
[NEWDEV] Bad use of PropSheet_SetCurSelByID

### DIFF
--- a/dll/win32/newdev/wizard.c
+++ b/dll/win32/newdev/wizard.c
@@ -545,9 +545,9 @@ WelcomeDlgProc(
                     if (SendDlgItemMessage(hwndDlg, IDC_RADIO_AUTO, BM_GETCHECK, (WPARAM)0, (LPARAM)0) == BST_CHECKED)
                     {
                         if (PrepareFoldersToScan(DevInstData, TRUE, FALSE, NULL))
-                            PropSheet_SetCurSelByID(GetParent(hwndDlg), IDD_SEARCHDRV);
+                            SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, IDD_SEARCHDRV);
                         else
-                            PropSheet_SetCurSelByID(GetParent(hwndDlg), IDD_INSTALLFAILED);
+                            SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, IDD_INSTALLFAILED);
                     }
                     return TRUE;
 
@@ -759,11 +759,11 @@ CHSourceDlgProc(
                             IsDlgButtonChecked(hwndDlg, IDC_CHECK_PATH),
                             GetDlgItem(hwndDlg, IDC_COMBO_PATH)))
                         {
-                            PropSheet_SetCurSelByID(GetParent(hwndDlg), IDD_SEARCHDRV);
+                            SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, IDD_SEARCHDRV);
                         }
                         else
                         {
-                            PropSheet_SetCurSelByID(GetParent(hwndDlg), IDD_INSTALLFAILED);
+                            SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, IDD_INSTALLFAILED);
                         }
                     }
                     else
@@ -1059,7 +1059,7 @@ NoDriverDlgProc(
                     hwndControl = GetDlgItem(GetParent(hwndDlg), IDCANCEL);
                     ShowWindow(hwndControl, SW_SHOW);
                     EnableWindow(hwndControl, TRUE);
-                    PropSheet_SetCurSelByID(GetParent(hwndDlg), IDD_CHSOURCE);
+                    SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, IDD_CHSOURCE);
                     return TRUE;
 
                 case PSN_WIZFINISH:


### PR DESCRIPTION
## Purpose

Fonction PropSheet_SetCurSelByID was badly called in response of PSN_WIZBACK or PSN_WIZNEXT notifications. See article Microsoft on these notification codes :

> Returns 0 to allow the wizard to go to the previous page. Returns -1 to prevent the wizard from changing pages. To display a particular page, return its dialog resource identifier.
> (...)
> To set the return value, the dialog box procedure for the page must call the SetWindowLong function with the DWL_MSGRESULT value and return TRUE.
> 

This bug sometimes causes the wrong page to appear (e.g. "Previous" in IDD_NODRIVER should come back in IDD_CHSOURCE, but goes in IDD_WELCOME).

JIRA issue: none

