### PR TITLE
[SDK][WINE] Fixes for __ROS_LONG64__ define

### DIFF
--- a/dll/directx/wine/d3drm/CMakeLists.txt
+++ b/dll/directx/wine/d3drm/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_definitions(-D__WINESRC__)
+add_definitions(-D__WINESRC__ -D__ROS_LONG64__)
 include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(d3drm.dll d3drm.spec ADD_IMPORTLIB)
 

--- a/dll/directx/wine/d3dxof/CMakeLists.txt
+++ b/dll/directx/wine/d3dxof/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_definitions(-D__WINESRC__)
+add_definitions(-D__WINESRC__ -D__ROS_LONG64__)
 include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(d3dxof.dll d3dxof.spec ADD_IMPORTLIB)
 

--- a/dll/win32/comdlg32/CMakeLists.txt
+++ b/dll/win32/comdlg32/CMakeLists.txt
@@ -1,7 +1,8 @@
 
 add_definitions(
     -D__WINESRC__
-    -D_WINE)
+    -D_WINE
+    -D__ROS_LONG64__)
 
 include_directories(BEFORE ${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(comdlg32.dll comdlg32.spec ADD_IMPORTLIB)

--- a/dll/win32/cryptui/CMakeLists.txt
+++ b/dll/win32/cryptui/CMakeLists.txt
@@ -1,7 +1,8 @@
 
 add_definitions(
     -D__WINESRC__
-    -D_WINE)
+    -D_WINE
+    -D__ROS_LONG64__)
 
 include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(cryptui.dll cryptui.spec ADD_IMPORTLIB)

--- a/dll/win32/ieframe/CMakeLists.txt
+++ b/dll/win32/ieframe/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
-add_definitions(-D__WINESRC__)
+add_definitions(-D__WINESRC__ -D__ROS_LONG64__)
 spec2def(ieframe.dll ieframe.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE

--- a/dll/win32/inetcomm/CMakeLists.txt
+++ b/dll/win32/inetcomm/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_definitions(-D__WINESRC__)
+add_definitions(-D__WINESRC__ -D__ROS_LONG64__)
 include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(inetcomm.dll inetcomm.spec ADD_IMPORTLIB)
 

--- a/dll/win32/wininet/CMakeLists.txt
+++ b/dll/win32/wininet/CMakeLists.txt
@@ -8,7 +8,8 @@ add_definitions(
 
 add_definitions(
     -D__WINESRC__
-    -D_WINE)
+    -D_WINE
+    -D__ROS_LONG64__)
 
 spec2def(wininet.dll wininet.spec ADD_IMPORTLIB)
 

--- a/sdk/include/psdk/basetsd.h
+++ b/sdk/include/psdk/basetsd.h
@@ -6,8 +6,8 @@
 #include <msvctarget.h>
 #endif
 
-#if defined(__LP64__) || (!defined(_M_AMD64) && defined(__WINESRC__))
-#if !defined(__ROS_LONG64__)
+#if (defined(_LP64) || defined(__LP64__)) && !defined(_M_AMD64)
+#ifndef __ROS_LONG64__
 #define __ROS_LONG64__
 #endif
 #endif
@@ -161,7 +161,7 @@ static inline void* ULongToPtr( const unsigned long ul )
     { return( (void*)(ULONG_PTR)ul ); }
 #endif /* !__midl */
 #else /*  !_WIN64 */
-#if !defined(__ROS_LONG64__)
+#ifndef __ROS_LONG64__
 typedef int INT_PTR, *PINT_PTR;
 typedef unsigned int UINT_PTR, *PUINT_PTR;
 #else

--- a/sdk/include/psdk/windef.h
+++ b/sdk/include/psdk/windef.h
@@ -14,8 +14,8 @@
 #pragma warning(disable:4255)
 #endif
 
-#if defined(__LP64__) || (!defined(_M_AMD64) && defined(__WINESRC__))
-#if !defined(__ROS_LONG64__)
+#if (defined(_LP64) || defined(__LP64__)) && !defined(_M_AMD64)
+#ifndef __ROS_LONG64__
 #define __ROS_LONG64__
 #endif
 #endif
@@ -166,9 +166,9 @@ typedef BOOL *LPBOOL;
 typedef unsigned char BYTE;
 typedef unsigned short WORD;
 #ifndef __ROS_LONG64__
-    typedef unsigned long DWORD;
+typedef unsigned long DWORD;
 #else
-    typedef unsigned int DWORD;
+typedef unsigned int DWORD;
 #endif
 typedef float FLOAT;
 typedef FLOAT *PFLOAT;

--- a/sdk/include/psdk/winsock.h
+++ b/sdk/include/psdk/winsock.h
@@ -15,8 +15,8 @@
 #include <windows.h>
 #endif
 
-#if defined(__LP64__) || (!defined(_M_AMD64) && defined(__WINESRC__))
-#if !defined(__ROS_LONG64__)
+#if (defined(_LP64) || defined(__LP64__)) && !defined(_M_AMD64)
+#ifndef __ROS_LONG64__
 #define __ROS_LONG64__
 #endif
 #endif

--- a/sdk/include/psdk/winsock2.h
+++ b/sdk/include/psdk/winsock2.h
@@ -39,8 +39,8 @@
 #endif
 #endif
 
-#if defined(__LP64__) || (!defined(_M_AMD64) && defined(__WINESRC__))
-#if !defined(__ROS_LONG64__)
+#if (defined(_LP64) || defined(__LP64__)) && !defined(_M_AMD64)
+#ifndef __ROS_LONG64__
 #define __ROS_LONG64__
 #endif
 #endif

--- a/sdk/include/xdk/winnt.template.h
+++ b/sdk/include/xdk/winnt.template.h
@@ -28,8 +28,8 @@
 #error Compiler too old!
 #endif
 
-#if defined(__LP64__) || (!defined(_M_AMD64) && defined(__WINESRC__))
-#if !defined(__ROS_LONG64__)
+#if (defined(_LP64) || defined(__LP64__)) && !defined(_M_AMD64)
+#ifndef __ROS_LONG64__
 #define __ROS_LONG64__
 #endif
 #endif


### PR DESCRIPTION
## Purpose

- ### `Fix the automatic definition of __ROS_LONG64__`

  It is not wishable anymore to automatically define __ROS_LONG64__
  whenever __WINESRC__ is defined. Indeed, Wine now has started to
  introduce the possibility to "Enable compilation with long types".

  Thus, for these modules we import from them, we want to be able to
  define __WINESRC__ without __ROS_LONG64__ automatically defined.

Addendum to commits 89c3520c86 (r73383) and 75eeb2a7e4 (r38872).

- ### `Add explicit missing __ROS_LONG64__ for Wine modules (fix build).`

  When these get synced with more recent Wine version, you can remove
  this define once you get past a "Enable compilation with long types"
  Wine commit or similar.
