### PR TITLE
[SDK] Fix naming of a CPUID structure

### DIFF
--- a/ntoskrnl/ke/amd64/cpu.c
+++ b/ntoskrnl/ke/amd64/cpu.c
@@ -255,7 +255,7 @@ KiGetFeatureBits(VOID)
     if (signature.MaxLeaf >= CPUID_EXTENDED_STATE)
     {
         /* Read CPUID_EXTENDED_STATE */
-        CPUID_EXTENDED_STATE_SUB_LEAF_EAX_REGS ExtStateSub;
+        CPUID_EXTENDED_STATE_SUB_LEAF_REGS ExtStateSub;
         __cpuidex(ExtStateSub.AsInt32,
             CPUID_EXTENDED_STATE,
             CPUID_EXTENDED_STATE_SUB_LEAF);

--- a/sdk/include/reactos/x86x64/Cpuid.h
+++ b/sdk/include/reactos/x86x64/Cpuid.h
@@ -112,7 +112,7 @@ typedef union
         CPUID_EXTENDED_STATE_SUB_LEAF_ECX Ecx;
         UINT32 Edx; // Reports the supported bits of the upper 32 bits of the IA32_XSS MSR. IA32_XSS[n + 32] can be set to 1 only if EDX[n] is 1.
     };
-} CPUID_EXTENDED_STATE_SUB_LEAF_EAX_REGS;
+} CPUID_EXTENDED_STATE_SUB_LEAF_REGS;
 
 // CPUID_EXTENDED_CPU_SIG (0x80000001)
 typedef union


### PR DESCRIPTION
## Purpose

Fix a typo.
