### PR TITLE
[SHELL32] Fix BrowseForFolder unable to expand a folder when it contains a zip

### DIFF
--- a/dll/win32/shell32/brfolder.cpp
+++ b/dll/win32/shell32/brfolder.cpp
@@ -408,8 +408,7 @@ BrFolder_Expand(
     ULONG ulFetched;
     while (S_OK == pEnum->Next(1, &pidlTemp, &ulFetched))
     {
-        if (!BrFolder_InsertItem(info, lpsf, pidlTemp, pidlFull, hParent))
-            break;
+        BrFolder_InsertItem(info, lpsf, pidlTemp, pidlFull, hParent);
         pidlTemp.Free(); // Finally, free the pidl that the shell gave us...
     }
 

--- a/dll/win32/shell32/brfolder.cpp
+++ b/dll/win32/shell32/brfolder.cpp
@@ -408,6 +408,7 @@ BrFolder_Expand(
     ULONG ulFetched;
     while (S_OK == pEnum->Next(1, &pidlTemp, &ulFetched))
     {
+        /* We need to ignore the return value of BrFolder_InsertItem to process next folders */
         BrFolder_InsertItem(info, lpsf, pidlTemp, pidlFull, hParent);
         pidlTemp.Free(); // Finally, free the pidl that the shell gave us...
     }

--- a/dll/win32/shell32/brfolder.cpp
+++ b/dll/win32/shell32/brfolder.cpp
@@ -408,7 +408,7 @@ BrFolder_Expand(
     ULONG ulFetched;
     while (S_OK == pEnum->Next(1, &pidlTemp, &ulFetched))
     {
-        /* We need to ignore the return value of BrFolder_InsertItem to process next folders */
+        /* Ignore return value of BrFolder_InsertItem to avoid incomplete folder listing */
         BrFolder_InsertItem(info, lpsf, pidlTemp, pidlFull, hParent);
         pidlTemp.Free(); // Finally, free the pidl that the shell gave us...
     }


### PR DESCRIPTION
## Purpose

The PR #7437 was for fixing the JIRA issue [CORE-19751](https://jira.reactos.org/browse/CORE-19751). I agree with the bugfix, however it introduced a side effect that made impossible to expand a folder when it contained both a ZIP file and subfolders. Fix this by ignoring the return value of `BrFolder_InsertItem` and free the pidlTemp explicitly in all cases.

Jira issue: [CORE-19955](https://jira.reactos.org/browse/CORE-19955)