### PR TITLE
[SHELL32] ShellExecuteW must call ShellExecuteExW

### DIFF
--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -2341,6 +2341,8 @@ HINSTANCE WINAPI ShellExecuteA(HWND hWnd, LPCSTR lpVerb, LPCSTR lpFile,
     sei.dwHotKey = 0;
     sei.hProcess = 0;
 
+    if (!(SHGetAppCompatFlags(GACF_WIN95SHLEXEC) & GACF_WIN95SHLEXEC))
+        sei.fMask |= SEE_MASK_NOASYNC;
     ShellExecuteExA(&sei);
     return sei.hInstApp;
 }
@@ -2479,9 +2481,6 @@ ShellExecuteExW(LPSHELLEXECUTEINFOW sei)
 
 /*************************************************************************
  * ShellExecuteW            [SHELL32.294]
- * from shellapi.h
- * WINSHELLAPI HINSTANCE APIENTRY ShellExecuteW(HWND hwnd, LPCWSTR lpVerb,
- * LPCWSTR lpFile, LPCWSTR lpParameters, LPCWSTR lpDirectory, INT nShowCmd);
  */
 HINSTANCE WINAPI ShellExecuteW(HWND hwnd, LPCWSTR lpVerb, LPCWSTR lpFile,
                                LPCWSTR lpParameters, LPCWSTR lpDirectory, INT nShowCmd)
@@ -2503,7 +2502,9 @@ HINSTANCE WINAPI ShellExecuteW(HWND hwnd, LPCWSTR lpVerb, LPCWSTR lpFile,
     sei.dwHotKey = 0;
     sei.hProcess = 0;
 
-    SHELL_execute(&sei, SHELL_ExecuteW);
+    if (!(SHGetAppCompatFlags(GACF_WIN95SHLEXEC) & GACF_WIN95SHLEXEC))
+        sei.fMask |= SEE_MASK_NOASYNC;
+    ShellExecuteExW(&sei);
     return sei.hInstApp;
 }
 

--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -2341,7 +2341,7 @@ HINSTANCE WINAPI ShellExecuteA(HWND hWnd, LPCSTR lpVerb, LPCSTR lpFile,
     sei.dwHotKey = 0;
     sei.hProcess = 0;
 
-    if (!(SHGetAppCompatFlags(GACF_WIN95SHLEXEC) & GACF_WIN95SHLEXEC))
+    if (!(SHGetAppCompatFlags(SHACF_WIN95SHLEXEC) & SHACF_WIN95SHLEXEC))
         sei.fMask |= SEE_MASK_NOASYNC;
     ShellExecuteExA(&sei);
     return sei.hInstApp;
@@ -2502,7 +2502,7 @@ HINSTANCE WINAPI ShellExecuteW(HWND hwnd, LPCWSTR lpVerb, LPCWSTR lpFile,
     sei.dwHotKey = 0;
     sei.hProcess = 0;
 
-    if (!(SHGetAppCompatFlags(GACF_WIN95SHLEXEC) & GACF_WIN95SHLEXEC))
+    if (!(SHGetAppCompatFlags(SHACF_WIN95SHLEXEC) & SHACF_WIN95SHLEXEC))
         sei.fMask |= SEE_MASK_NOASYNC;
     ShellExecuteExW(&sei);
     return sei.hInstApp;

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -69,6 +69,9 @@ SHRestrictionLookup(
     _In_ const POLICYDATA *polTable,
     _Inout_ LPDWORD polArr);
 
+#define GACF_WIN95SHLEXEC 0x00000200 /* Geoff Chappell */
+DWORD WINAPI SHGetAppCompatFlags(DWORD dwMask);
+
 BOOL WINAPI SHAboutInfoA(LPSTR lpszDest, DWORD dwDestLen);
 BOOL WINAPI SHAboutInfoW(LPWSTR lpszDest, DWORD dwDestLen);
 #ifdef UNICODE

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -69,9 +69,6 @@ SHRestrictionLookup(
     _In_ const POLICYDATA *polTable,
     _Inout_ LPDWORD polArr);
 
-#define SHACF_WIN95SHLEXEC 0x00000200 /* Geoff Chappell */
-DWORD WINAPI SHGetAppCompatFlags(DWORD dwMask);
-
 BOOL WINAPI SHAboutInfoA(LPSTR lpszDest, DWORD dwDestLen);
 BOOL WINAPI SHAboutInfoW(LPWSTR lpszDest, DWORD dwDestLen);
 #ifdef UNICODE
@@ -366,6 +363,9 @@ IContextMenu_Invoke(
     _In_ UINT uFlags);
 
 DWORD WINAPI SHGetObjectCompatFlags(IUnknown *pUnk, const CLSID *clsid);
+
+#define SHACF_WIN95SHLEXEC 0x00000200 /* Geoff Chappell */
+DWORD WINAPI SHGetAppCompatFlags(DWORD dwMask);
 
 /*
  * HACK! These functions are conflicting with <shobjidl.h> inline functions...

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -69,7 +69,7 @@ SHRestrictionLookup(
     _In_ const POLICYDATA *polTable,
     _Inout_ LPDWORD polArr);
 
-#define GACF_WIN95SHLEXEC 0x00000200 /* Geoff Chappell */
+#define SHACF_WIN95SHLEXEC 0x00000200 /* Geoff Chappell */
 DWORD WINAPI SHGetAppCompatFlags(DWORD dwMask);
 
 BOOL WINAPI SHAboutInfoA(LPSTR lpszDest, DWORD dwDestLen);


### PR DESCRIPTION
`ShellExecuteA` correctly calls `ShellExecuteExA` but `ShellExecuteW` somehow skipped `ShellExecuteExW` and called the internal function directly. This means it missed out on the MaximizeApps registry setting, the RunDLL32 handling and CoInitialize.

Also adds the DDEWAIT/NOASYNC flag for 99% of callers (unless the [WIN95SHLEXEC](https://www.geoffchappell.com/studies/windows/shell/shlwapi/api/util/getappcompatflags.htm) compatibility flag is active for the current process).

JIRA issue: [CORE-19952](https://jira.reactos.org/browse/CORE-19952)
