### PR TITLE
[NTOS:PS] Fix returned flags for QUOTA_LIMITS_EX query

### DIFF
--- a/ntoskrnl/ps/query.c
+++ b/ntoskrnl/ps/query.c
@@ -212,9 +212,13 @@ NtQueryInformationProcess(
             /* Get additional information, if needed */
             if (Extended)
             {
+                QuotaLimits.Flags |= (Process->Vm.Flags.MaximumWorkingSetHard ?
+                    QUOTA_LIMITS_HARDWS_MAX_ENABLE : QUOTA_LIMITS_HARDWS_MAX_DISABLE);
+                QuotaLimits.Flags |= (Process->Vm.Flags.MinimumWorkingSetHard ?
+                    QUOTA_LIMITS_HARDWS_MIN_ENABLE : QUOTA_LIMITS_HARDWS_MIN_DISABLE);
+
                 /* FIXME: Get the correct information */
                 //QuotaLimits.WorkingSetLimit = (SIZE_T)-1; // Not used on Win2k3, it is set to 0
-                QuotaLimits.Flags = QUOTA_LIMITS_HARDWS_MIN_DISABLE | QUOTA_LIMITS_HARDWS_MAX_DISABLE;
                 QuotaLimits.CpuRateLimit.RateData = 0;
             }
 


### PR DESCRIPTION
## Purpose
Use the information from `EPROCESS::Vm`.
Addendum to commit 1e06829961cb597f7e1927a5e35b66febe674a96.

Tests result doesn't change.
![VirtualBox_ReactOS_2_30_12_2024_00_19_54](https://github.com/user-attachments/assets/1bc68186-7ef7-4fc2-a1e6-be15a354e451)