### PR TITLE
[SHELL32] Fix Control_RunDLL single comma syntax out of range dialogbox numbers

### DIFF
--- a/dll/win32/shell32/wine/control.c
+++ b/dll/win32/shell32/wine/control.c
@@ -1104,7 +1104,7 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
             }
         }
 
-        if (sp >= applet->count && wszDialogBoxName[0] == L'\0')
+        if (sp >= applet->count && (wszDialogBoxName[0] == L'\0' || wszDialogBoxName[0] == L'@'))
         {
             sp = 0;
         }


### PR DESCRIPTION
If an out of range dialog box number was given in a single comma syntax for Control_RunDLL, it should be set to 0 to launch the default dialog box instead of failing. 

## Purpose

Should fix [CORE-19580](https://jira.reactos.org/browse/CORE-19580)