### PR TITLE
[PSDK] Add structures and enumeration describing radio power state

### DIFF
--- a/sdk/include/psdk/wlanapi.h
+++ b/sdk/include/psdk/wlanapi.h
@@ -32,6 +32,16 @@ extern "C" {
 /* Enumerations */
 
 #if defined(__midl) || defined(__WIDL__)
+typedef [v1_enum] enum _DOT11_RADIO_STATE {
+#else
+typedef enum _DOT11_RADIO_STATE {
+#endif
+    dot11_radio_state_unknown = 0,
+    dot11_radio_state_on,
+    dot11_radio_state_off
+} DOT11_RADIO_STATE; /* HACK: WIDL is broken, *PDOT11_RADIO_STATE; */
+
+#if defined(__midl) || defined(__WIDL__)
 typedef [v1_enum] enum _WLAN_OPCODE_VALUE_TYPE {
 #else
 typedef enum _WLAN_OPCODE_VALUE_TYPE {
@@ -174,6 +184,17 @@ typedef struct _WLAN_INTERFACE_CAPABILITY {
     DWORD dwNumberOfSupportedPhys;
     /* enum32 */ long dot11PhyTypes[WLAN_MAX_PHY_INDEX];
 } WLAN_INTERFACE_CAPABILITY, *PWLAN_INTERFACE_CAPABILITY;
+
+typedef struct _WLAN_PHY_RADIO_STATE {
+    DWORD dwPhyIndex;
+    DOT11_RADIO_STATE dot11SoftwareRadioState;
+    DOT11_RADIO_STATE dot11HardwareRadioState;
+} WLAN_PHY_RADIO_STATE, *PWLAN_PHY_RADIO_STATE;
+
+typedef struct _WLAN_RADIO_STATE {
+    DWORD dwNumberOfPhys;
+    WLAN_PHY_RADIO_STATE PhyRadioState[WLAN_MAX_PHY_INDEX];
+} WLAN_RADIO_STATE, *PWLAN_RADIO_STATE;
 
 typedef struct _WLAN_RAW_DATA {
     DWORD dwDataSize;


### PR DESCRIPTION
## Purpose

Be able to tell if the WLAN adapter's radio is turned off from ReactOS (software) or from a button/toggle on device (hardware). All three proposed pieces are available at least as of Windows SDK 6.0A (Visual Studio 2008).
Used by [`WlanQueryInterface`](https://learn.microsoft.com/en-us/windows/win32/api/wlanapi/nf-wlanapi-wlanqueryinterface) with `wlan_intf_opcode_radio_state` opcode.

JIRA issue: [CORE-6905](https://jira.reactos.org/browse/CORE-6905)
Example use case: [wlanwiz.dll, `OnScanNetworks`](https://github.com/SigmaTel71/reactos/blob/b5f603b5c47f772c28e76074a407d02ea6ced7fd/dll/shellext/wlanwiz/scan.cpp#L37)

## Proposed changes

- Add [WLAN_PHY_RADIO_STATE](https://learn.microsoft.com/en-us/windows/win32/api/wlanapi/ns-wlanapi-wlan_phy_radio_state) struct
- Add [WLAN_RADIO_STATE](https://learn.microsoft.com/en-us/windows/win32/api/wlanapi/ns-wlanapi-wlan_radio_state) struct 
- Add [DOT11_RADIO_STATE](https://learn.microsoft.com/en-us/windows/win32/api/wlanapi/ne-wlanapi-dot11_radio_state-r1) enumeration