### PR TITLE
[COMCTL32] Fix a heap corruption in EDIT_EM_ReplaceSel

### DIFF
--- a/dll/win32/comctl32/edit.c
+++ b/dll/win32/comctl32/edit.c
@@ -2592,7 +2592,7 @@ static void EDIT_EM_ReplaceSel(EDITSTATE *es, BOOL can_undo, const WCHAR *lpsz_r
 		/* remove chars that don't fit */
 		if (honor_limit && !(es->style & ES_AUTOHSCROLL) && (es->text_width > fw)) {
 			while ((es->text_width > fw) && s + strl > 0) {
-                lstrcpyW(es->text + s + strl - 1, es->text + s + strl);
+				lstrcpyW(es->text + s + strl - 1, es->text + s + strl);
 				strl--;
 				es->text_length = -1;
 				EDIT_InvalidateUniscribeData(es);

--- a/dll/win32/comctl32/edit.c
+++ b/dll/win32/comctl32/edit.c
@@ -2591,7 +2591,11 @@ static void EDIT_EM_ReplaceSel(EDITSTATE *es, BOOL can_undo, const WCHAR *lpsz_r
 		EDIT_CalcLineWidth_SL(es);
 		/* remove chars that don't fit */
 		if (honor_limit && !(es->style & ES_AUTOHSCROLL) && (es->text_width > fw)) {
+#ifdef __REACTOS__
 			while ((es->text_width > fw) && s + strl > 0) {
+#else
+			while ((es->text_width > fw) && s + strl >= s) {
+#endif
 				lstrcpyW(es->text + s + strl - 1, es->text + s + strl);
 				strl--;
 				es->text_length = -1;

--- a/dll/win32/comctl32/edit.c
+++ b/dll/win32/comctl32/edit.c
@@ -2591,15 +2591,8 @@ static void EDIT_EM_ReplaceSel(EDITSTATE *es, BOOL can_undo, const WCHAR *lpsz_r
 		EDIT_CalcLineWidth_SL(es);
 		/* remove chars that don't fit */
 		if (honor_limit && !(es->style & ES_AUTOHSCROLL) && (es->text_width > fw)) {
-			while ((es->text_width > fw) && s + strl >= s) {
-				int len = wcslen(es->text);
-                for (int i = s + strl - 1; i < len; i++) 
-                {
-                    if (i >= 0)
-                    {
-                        es->text[i] = es->text[i + 1];
-                    }
-                }
+			while ((es->text_width > fw) && s + strl > 0) {
+                lstrcpyW(es->text + s + strl - 1, es->text + s + strl);
 				strl--;
 				es->text_length = -1;
 				EDIT_InvalidateUniscribeData(es);

--- a/dll/win32/comctl32/edit.c
+++ b/dll/win32/comctl32/edit.c
@@ -2592,7 +2592,14 @@ static void EDIT_EM_ReplaceSel(EDITSTATE *es, BOOL can_undo, const WCHAR *lpsz_r
 		/* remove chars that don't fit */
 		if (honor_limit && !(es->style & ES_AUTOHSCROLL) && (es->text_width > fw)) {
 			while ((es->text_width > fw) && s + strl >= s) {
-				lstrcpyW(es->text + s + strl - 1, es->text + s + strl);
+				int len = wcslen(es->text);
+                for (int i = s + strl - 1; i < len; i++) 
+                {
+                    if (i >= 0)
+                    {
+                        es->text[i] = es->text[i + 1];
+                    }
+                }
 				strl--;
 				es->text_length = -1;
 				EDIT_InvalidateUniscribeData(es);


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-19743](https://jira.reactos.org/browse/CORE-19743)

## Proposed changes
Prevent moving `es->text` with a negative offset into the heap structures.

EDIT: #7638 hides the bug in regedit, but it does not fix the underlying issue. 

