### PR TITLE
[SHELL32] Clone properties IDataObject for unlimited lifetime

### DIFF
--- a/dll/win32/shell32/precomp.h
+++ b/dll/win32/shell32/precomp.h
@@ -297,6 +297,7 @@ HRESULT SHILAppend(_Inout_ LPITEMIDLIST pidl, _Inout_ LPITEMIDLIST *ppidl);
 
 PIDLIST_ABSOLUTE SHELL_CIDA_ILCloneFull(_In_ const CIDA *pCIDA, _In_ UINT Index);
 PIDLIST_ABSOLUTE SHELL_DataObject_ILCloneFullItem(_In_ IDataObject *pDO, _In_ UINT Index);
+HRESULT SHELL_CloneDataObject(_In_ IDataObject *pDO, _Out_ IDataObject **ppDO);
 
 EXTERN_C HRESULT
 IUnknown_InitializeCommand(

--- a/dll/win32/shell32/shldataobject.cpp
+++ b/dll/win32/shell32/shldataobject.cpp
@@ -111,3 +111,22 @@ PIDLIST_ABSOLUTE SHELL_DataObject_ILCloneFullItem(_In_ IDataObject *pDO, _In_ UI
     CDataObjectHIDA cida(pDO);
     return SUCCEEDED(cida.hr()) ? SHELL_CIDA_ILCloneFull(cida, Index) : NULL;
 }
+
+HRESULT SHELL_CloneDataObject(_In_ IDataObject *pDO, _Out_ IDataObject **ppDO)
+{
+    *ppDO = NULL;
+    CDataObjectHIDA cida(pDO);
+    HRESULT hr = cida.hr();
+    if (SUCCEEDED(hr))
+    {
+        PCUITEMID_CHILD items = HIDA_GetPIDLItem(cida, 0);
+        hr = SHCreateFileDataObject(HIDA_GetPIDLFolder(cida), cida->cidl, &items, NULL, ppDO);
+        if (SUCCEEDED(hr))
+        {
+            POINT pt;
+            if (SUCCEEDED(DataObject_GetOffset(pDO, &pt)))
+                DataObject_SetOffset(*ppDO, &pt);
+        }
+    }
+    return hr;
+}


### PR DESCRIPTION
Addendum to PR #7571. Because SHOpenPropSheetW is modal, there is no way for us to keep COM alive on the original thread until the dialog completes, so a cloned data object is used instead so that the property sheet handlers may access the object even after ShellExeute has returned (this is only relevant for callers like Taskmgr that does not initialize COM even though MSDN says they should).

[CORE-19933](https://jira.reactos.org/browse/CORE-19933)