### PR TITLE
[PSDK] Fix BATTERY_UNKNOWN_TIME value constant

### DIFF
--- a/sdk/include/psdk/batclass.h
+++ b/sdk/include/psdk/batclass.h
@@ -65,7 +65,7 @@ DEFINE_GUID(BATTERY_TAG_CHANGE_WMI_GUID,
 #define BATTERY_UNKNOWN_CAPACITY          0xFFFFFFFF
 
 /* BatteryEstimatedTime constant */
-#define BATTERY_UNKNOWN_TIME              0x80000000
+#define BATTERY_UNKNOWN_TIME              0xFFFFFFFF
 
 #define MAX_BATTERY_STRING_SIZE           128
 


### PR DESCRIPTION
## Purpose
Windows SDKs define this constant to **0xFFFFFFFF** but we define it to **0x80000000**. As a result, when our COMPBATT driver is being tested on Windows (namely XP, Vista and 7), `BATTERY_UNKNOWN_TIME` is not interpreted as UNKNOWN TIME but entirely something else.

This patch is needed for further development of #5719 to continue.

## Jira issues
[CORE-18969](https://jira.reactos.org/browse/CORE-18969)
[CORE-19452](https://jira.reactos.org/browse/CORE-19452)