### PR TITLE
[NTOS:CC] Improve cache flush synchronization

### DIFF
--- a/ntoskrnl/include/internal/cc.h
+++ b/ntoskrnl/include/internal/cc.h
@@ -193,7 +193,7 @@ typedef struct _ROS_SHARED_CACHE_MAP
     LIST_ENTRY CacheMapVacbListHead;
     BOOLEAN PinAccess;
     KSPIN_LOCK CacheMapLock;
-    KGUARDED_MUTEX FlushCacheLock;
+    KEVENT FlushDoneEvent;
 #if DBG
     BOOLEAN Trace; /* enable extra trace output for this cache map and it's VACBs */
 #endif
@@ -202,7 +202,7 @@ typedef struct _ROS_SHARED_CACHE_MAP
 #define READAHEAD_DISABLED 0x1
 #define WRITEBEHIND_DISABLED 0x2
 #define SHARED_CACHE_MAP_IN_CREATION 0x4
-#define SHARED_CACHE_MAP_IN_LAZYWRITE 0x8
+#define SHARED_CACHE_MAP_IN_FLUSH 0x8
 
 typedef struct _ROS_VACB
 {


### PR DESCRIPTION
## Purpose
An attempt to fix performance regression from PR [#7054](https://github.com/reactos/reactos/pull/7054) .

JIRA issue: [CORE-19664](https://jira.reactos.org/browse/CORE-19664) and (maybe) [CORE-19787](https://jira.reactos.org/browse/CORE-19787)

## Proposed changes
- Use flag check to prevent race condition between `CcFlushCache` and lazy writer.
- Use flush done event notification instead of locking `CcFlushCache` with a mutex.

## TODO
- [ ] Test if this PR don't reintroduce [CORE-19664](https://jira.reactos.org/browse/CORE-19664) and reliable.
- [ ] Test if this PR also fix [CORE-19787](https://jira.reactos.org/browse/CORE-19787) . This is optional (I don't have the Office 2010 setup).