### PR TITLE
[SHELL32] SHELL_ArgifyW(): don't use SearchPathW() for receiving a path to a file

### DIFF
--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -197,11 +197,9 @@ static void ParseTildeEffect(PWSTR &res, LPCWSTR &args, DWORD &len, DWORD &used,
 
 static BOOL SHELL_ArgifyW(WCHAR* out, DWORD len, const WCHAR* fmt, const WCHAR* lpFile, LPITEMIDLIST pidl, LPCWSTR args, DWORD* out_len, const WCHAR* lpDir)
 {
-    WCHAR   xlpFile[1024];
     BOOL    done = FALSE;
     BOOL    found_p1 = FALSE;
     PWSTR   res = out;
-    PCWSTR  cmd;
     DWORD   used = 0;
     bool    tildeEffect = false;
 
@@ -279,20 +277,14 @@ static BOOL SHELL_ArgifyW(WCHAR* out, DWORD len, const WCHAR* fmt, const WCHAR* 
                 break;
 
                 case '1':
-                    if (!done || (*fmt == '1'))
+                    if ((!done || (*fmt == '1')) && lpFile)
                     {
-                        /*FIXME Is the call to SearchPathW() really needed? We already have separated out the parameter string in args. */
-                        if (SearchPathW(lpDir, lpFile, L".exe", ARRAY_SIZE(xlpFile), xlpFile, NULL))
-                            cmd = xlpFile;
-                        else
-                            cmd = lpFile;
-
-                        SIZE_T cmdlen = wcslen(cmd);
-                        used += cmdlen;
+                        SIZE_T filelen = wcslen(lpFile);
+                        used += filelen;
                         if (used < len)
                         {
-                            wcscpy(res, cmd);
-                            res += cmdlen;
+                            wcscpy(res, lpFile);
+                            res += filelen;
                         }
                     }
                     found_p1 = TRUE;


### PR DESCRIPTION
## Purpose

Get rid from bogus `SearchPathW`() call, which is marked as most likely not needed in the comment above (by Wine). Simply get a length of the file name and use the file name directly instead, with checking for its validity too. Similarly as it's done for other cases. That call seems actually not needed because it is already done using `SearchPathW`() in another parts of the code in this file, before calling `SHELL_ArgifyW`(). Fixes another heap corruption when trying to login via OAuth method in SpotifyXP 2.0.3 Beta (nightly build).

JIRA issue: [CORE-19953](https://jira.reactos.org/browse/CORE-19953)

## Proposed changes

- Use `lpFile` explicitly instead of passing it to `SearchPathW`() and using returned data from it.
- Check for a valdity of input 'lpFile' parameter (`!= NULL`).
- Get rid from no longer needed variables.

## Result

The following screenshot proves SpotifyXP 2.0.3 Beta now logins via OAuth method correclty and allows to listen Spoitfy music properly. The previous PR did not fix the bug fully, as I discovered it later.
![SpotifyXP](https://github.com/user-attachments/assets/d1a466e2-c3c7-43a7-9fac-f058be5bf0dc)