### PR TITLE
[NTGDI] Quiet debug log spam of GreGetObjectOwner if NULL input

### DIFF
--- a/win32ss/gdi/ntgdi/gdiobj.c
+++ b/win32ss/gdi/ntgdi/gdiobj.c
@@ -1193,6 +1193,12 @@ GreGetObjectOwner(HGDIOBJ hobj)
 {
     ULONG ulIndex, ulOwner;
 
+    if (hobj == NULL)
+    {
+        DPRINT("GreGetObjectOwner: invalid NULL handle\n");
+        return GDI_OBJ_HMGR_RESTRICTED;
+    }
+
     /* Get the handle index */
     ulIndex = GDI_HANDLE_GET_INDEX(hobj);
 


### PR DESCRIPTION
## Purpose

_When the input parameter is NULL for GreGetObjectOwner do not output any message to the debug log._
Co-authored-by: Timo Kreuzer <timo.kreuzer@reactos.org>

JIRA issue: [CORE-19962](https://jira.reactos.org/browse/CORE-19962)

## Proposed changes

_Check if input parameter is NULL and if so, then do a quick return of GDI_OBJ_HMGR_RESTRICTED._