### PR TITLE
[CMBATT] Minor improvements to estimated battery time code

### DIFF
--- a/drivers/bus/acpi/cmbatt/cmbatt.h
+++ b/drivers/bus/acpi/cmbatt/cmbatt.h
@@ -42,6 +42,18 @@
 #define CMBATT_PNP_ENTRY_EXIT   0x200
 #define CMBATT_ACPI_ASSERT      0x400
 
+//
+// Constant used to determine if the battery was discharging
+// for over 15 seconds since last time the AC adapter got unplugged.
+//
+#define CMBATT_DISCHARGE_TIME   150000000
+
+//
+// Bogus constant used to determine if the remaining battery capacity
+// overflows which is returned by the hardware.
+//
+#define CMBATT_CAPACITY_BOGUS   0x100000
+
 typedef enum _CMBATT_EXTENSION_TYPE
 {
     CmBattAcAdapter,


### PR DESCRIPTION
## Purpose
There are a few issues with the estimated battery time code. First, in `CmBattGetBatteryStatus` we are checking if the battery was discharging for the first time, but we are checking that against **ACPI_BATT_STAT_DISCHARG**. This bit flag is returned by **_BST** ACPI control method in `BstState`, therefore checking the presence of such bit flag against `DeviceExtension->State` is wrong from the start.

The correct approach should be, cache the previous power state of an individual CM battery before resetting it, and check right away if the battery used to discharge before. If not, update the discharge time. Furthermore, in `CmBattQueryInformation` we should be checking if the battery has been discharging for over 15 seconds but the current code does something different.. Fix that.

This patch is needed for the development of the Power Manager (#5719) to continue.

## Proposed Changes
- Declare **CMBATT_DISCHARGE_TIME** and **CMBATT_CAPACITY_BOGUS** constructs
- Determine if the battery was already discharging and if not, update the time when it's being discharged
- Fix the condition where it checks if the battery has been discharging for quite some time
- Default the time to **BATTERY_UNKNOWN_TIME** if querying the estimated battery time request fails or if the battery has just started discharging not over 15 seconds

## Jira issues
[CORE-18969](https://jira.reactos.org/browse/CORE-18969)
[CORE-19452](https://jira.reactos.org/browse/CORE-19452)