### PR TITLE
[REGEDIT] Block tree label edit if the delete accelerator has been pressed

### DIFF
--- a/base/applications/regedit/treeview.c
+++ b/base/applications/regedit/treeview.c
@@ -669,6 +669,7 @@ BOOL TreeWndNotifyProc(HWND hWnd, WPARAM wParam, LPARAM lParam, BOOL *Result)
         {
             LPNMTVDISPINFO ptvdi = (LPNMTVDISPINFO)lParam;
             HWND hWndFocus = GetFocus();
+
             /* cancel label edit for rootkeys */
             if (!TreeView_GetParent(g_pChildWnd->hTreeWnd, ptvdi->item.hItem) ||
                 !TreeView_GetParent(g_pChildWnd->hTreeWnd, TreeView_GetParent(g_pChildWnd->hTreeWnd, ptvdi->item.hItem)))

--- a/base/applications/regedit/treeview.c
+++ b/base/applications/regedit/treeview.c
@@ -668,6 +668,7 @@ BOOL TreeWndNotifyProc(HWND hWnd, WPARAM wParam, LPARAM lParam, BOOL *Result)
         case TVN_BEGINLABELEDIT:
         {
             LPNMTVDISPINFO ptvdi = (LPNMTVDISPINFO)lParam;
+            HWND hWndFocus = GetFocus();
             /* cancel label edit for rootkeys */
             if (!TreeView_GetParent(g_pChildWnd->hTreeWnd, ptvdi->item.hItem) ||
                 !TreeView_GetParent(g_pChildWnd->hTreeWnd, TreeView_GetParent(g_pChildWnd->hTreeWnd, ptvdi->item.hItem)))
@@ -677,6 +678,12 @@ BOOL TreeWndNotifyProc(HWND hWnd, WPARAM wParam, LPARAM lParam, BOOL *Result)
             else
             {
                 *Result = FALSE;
+            }
+
+            /* cancel label edit if VK_DELETE accelerator opened a MessageBox */
+            if (hWndFocus != g_pChildWnd->hTreeWnd && hWndFocus != TreeView_GetEditControl(g_pChildWnd->hTreeWnd))
+            {
+                *Result = TRUE;
             }
             return TRUE;
         }


### PR DESCRIPTION
If we delete a key while the label edit control is visible, the GUI gets messed up and can only be fixed by pressing Esc when the correct control has focus.

![screenshot](https://github.com/user-attachments/assets/098cbbb2-8acc-44cf-af1f-834de41bf4b8)
