### PR TITLE
[SHELL32][SHELL32_APITEST][SDK] Implement SHGetUserDisplayName

### DIFF
--- a/dll/win32/shell32/CMakeLists.txt
+++ b/dll/win32/shell32/CMakeLists.txt
@@ -120,7 +120,7 @@ set_source_files_properties(shell32.rc PROPERTIES OBJECT_DEPENDS ${CMAKE_CURRENT
 
 set_module_type(shell32 win32dll UNICODE)
 target_link_libraries(shell32 shellmenu shelldesktop wine uuid recyclebin cpprt atl_classes oldnames)
-add_delay_importlibs(shell32 powrprof shdocvw devmgr winspool.drv winmm mpr uxtheme ole32 oleaut32 userenv browseui version fmifs)
+add_delay_importlibs(shell32 powrprof shdocvw devmgr winspool.drv winmm mpr uxtheme ole32 oleaut32 userenv browseui version fmifs netapi32 secur32)
 add_importlibs(shell32 advapi32 gdi32 user32 comctl32 comdlg32 shlwapi msvcrt kernel32 ntdll)
 add_dependencies(shell32 stdole2) # shell32_shldisp.tlb needs stdole2.tlb
 add_pch(shell32 precomp.h "${PCH_SKIP_SOURCE}")

--- a/dll/win32/shell32/stubs.cpp
+++ b/dll/win32/shell32/stubs.cpp
@@ -925,18 +925,6 @@ PathIsSlowW(
  */
 EXTERN_C DWORD
 WINAPI
-SHGetUserDisplayName(LPWSTR lpName, PULONG puSize)
-{
-    FIXME("SHGetUserDisplayName() stub\n");
-    wcscpy(lpName, L"UserName");
-    return ERROR_SUCCESS;
-}
-
-/*
- * Unimplemented
- */
-EXTERN_C DWORD
-WINAPI
 SHGetProcessDword(DWORD dwUnknown1, DWORD dwUnknown2)
 {
     /* Unimplemented in WinXP SP3 */

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -1559,7 +1559,7 @@ SHGetUserDisplayName(
     {
         // Try to get the user name by using Network API
         PUSER_INFO_2 UserInfo;
-        DWORD NetError = NetUserGetInfo(NULL, UserName, 2, (LPBYTE *)&UserInfo);
+        DWORD NetError = NetUserGetInfo(NULL, UserName, 2, (PBYTE*)&UserInfo);
         if (NetError)
         {
             hr = HRESULT_FROM_WIN32(NetError);

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -1558,7 +1558,7 @@ SHGetUserDisplayName(
     if (error == ERROR_NONE_MAPPED)
     {
         // Try to get the user name by using Network API
-        USER_INFO_2 *UserInfo;
+        PUSER_INFO_2 UserInfo;
         DWORD NetError = NetUserGetInfo(NULL, UserName, 2, (LPBYTE *)&UserInfo);
         if (NetError)
         {

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -1536,13 +1536,13 @@ SHELL_CreateShell32DefaultExtractIcon(int IconIndex, REFIID riid, LPVOID *ppvOut
 EXTERN_C
 HRESULT WINAPI
 SHGetUserDisplayName(
-    _In_z_ LPWSTR lpName,
+    _Out_writes_to_(*puSize, *puSize) PWSTR pName,
     _Inout_ PULONG puSize)
 {
-    if (!lpName || !puSize)
+    if (!pName || !puSize)
         return E_INVALIDARG;
 
-    if (GetUserNameExW(NameDisplay, lpName, puSize))
+    if (GetUserNameExW(NameDisplay, pName, puSize))
         return S_OK;
 
     LONG error = GetLastError(); // for ERROR_NONE_MAPPED
@@ -1568,7 +1568,7 @@ SHGetUserDisplayName(
         {
             if (UserInfo->usri2_full_name)
             {
-                hr = StringCchCopyW(lpName, *puSize, UserInfo->usri2_full_name);
+                hr = StringCchCopyW(pName, *puSize, UserInfo->usri2_full_name);
                 if (SUCCEEDED(hr))
                 {
                     // Including the terminating null character
@@ -1582,7 +1582,7 @@ SHGetUserDisplayName(
 
     if (FAILED(hr))
     {
-        hr = StringCchCopyW(lpName, *puSize, UserName);
+        hr = StringCchCopyW(pName, *puSize, UserName);
         if (SUCCEEDED(hr))
             *puSize = cchUserName;
     }

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -1571,7 +1571,7 @@ SHGetUserDisplayName(
                 hr = StringCchCopyW(pName, *puSize, UserInfo->usri2_full_name);
                 if (SUCCEEDED(hr))
                 {
-                    // Including the terminating null character
+                    // Include the NUL-terminator
                     *puSize = lstrlenW(UserInfo->usri2_full_name) + 1;
                 }
             }

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -1576,7 +1576,7 @@ SHGetUserDisplayName(
                 }
             }
 
-            NetApiBufferFree(UserInfo); // Clean up
+            NetApiBufferFree(UserInfo);
         }
     }
 

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -1546,13 +1546,12 @@ SHGetUserDisplayName(
         return S_OK;
 
     LONG error = GetLastError(); // for ERROR_NONE_MAPPED
+    HRESULT hr = HRESULT_FROM_WIN32(error);
 
     WCHAR UserName[MAX_PATH];
     DWORD cchUserName = _countof(UserName);
     if (!GetUserNameW(UserName, &cchUserName))
         return HRESULT_FROM_WIN32(GetLastError());
-
-    HRESULT hr = HRESULT_FROM_WIN32(error);
 
     // Was the user name not available in the specified format (NameDisplay)?
     if (error == ERROR_NONE_MAPPED)

--- a/modules/rostests/apitests/shell32/CMakeLists.txt
+++ b/modules/rostests/apitests/shell32/CMakeLists.txt
@@ -41,6 +41,7 @@ list(APPEND SOURCE
     ShellInfo.cpp
     ShellState.cpp
     SHGetAttributesFromDataObject.cpp
+    SHGetUserDisplayName.cpp
     SHLimitInputEdit.cpp
     menu.cpp
     shelltest.cpp)

--- a/modules/rostests/apitests/shell32/SHGetUserDisplayName.cpp
+++ b/modules/rostests/apitests/shell32/SHGetUserDisplayName.cpp
@@ -7,11 +7,12 @@
 
 #include "shelltest.h"
 #include <undocshell.h>
+#include <secext.h>
 
 START_TEST(SHGetUserDisplayName)
 {
     HRESULT hr;
-    WCHAR szBuf[MAX_PATH], szName[MAX_PATH];
+    WCHAR szBuf[MAX_PATH];
     ULONG cchBuf;
 
     hr = SHGetUserDisplayName(NULL, NULL);
@@ -27,9 +28,4 @@ START_TEST(SHGetUserDisplayName)
     cchBuf = _countof(szBuf);
     hr = SHGetUserDisplayName(szBuf, &cchBuf);
     ok_hex(hr, S_OK);
-
-    cchBuf = _countof(szName);
-    GetUserNameW(szName, &cchBuf);
-
-    ok_wstr(szBuf, szName);
 }

--- a/modules/rostests/apitests/shell32/SHGetUserDisplayName.cpp
+++ b/modules/rostests/apitests/shell32/SHGetUserDisplayName.cpp
@@ -7,7 +7,6 @@
 
 #include "shelltest.h"
 #include <undocshell.h>
-#include <secext.h>
 
 START_TEST(SHGetUserDisplayName)
 {

--- a/modules/rostests/apitests/shell32/SHGetUserDisplayName.cpp
+++ b/modules/rostests/apitests/shell32/SHGetUserDisplayName.cpp
@@ -1,0 +1,35 @@
+/*
+ * PROJECT:     ReactOS API tests
+ * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
+ * PURPOSE:     Test for SHGetUserDisplayName
+ * COPYRIGHT:   Copyright 2025 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
+ */
+
+#include "shelltest.h"
+#include <undocshell.h>
+
+START_TEST(SHGetUserDisplayName)
+{
+    HRESULT hr;
+    WCHAR szBuf[MAX_PATH], szName[MAX_PATH];
+    ULONG cchBuf;
+
+    hr = SHGetUserDisplayName(NULL, NULL);
+    ok_hex(hr, E_INVALIDARG);
+
+    hr = SHGetUserDisplayName(szBuf, NULL);
+    ok_hex(hr, E_INVALIDARG);
+
+    cchBuf = _countof(szBuf);
+    hr = SHGetUserDisplayName(NULL, &cchBuf);
+    ok_hex(hr, E_INVALIDARG);
+
+    cchBuf = _countof(szBuf);
+    hr = SHGetUserDisplayName(szBuf, &cchBuf);
+    ok_hex(hr, S_OK);
+
+    cchBuf = _countof(szName);
+    GetUserNameW(szName, &cchBuf);
+
+    ok_wstr(szBuf, szName);
+}

--- a/modules/rostests/apitests/shell32/testlist.c
+++ b/modules/rostests/apitests/shell32/testlist.c
@@ -42,6 +42,7 @@ extern void func_ShellHook(void);
 extern void func_ShellState(void);
 extern void func_SHGetAttributesFromDataObject(void);
 extern void func_SHGetFileInfo(void);
+extern void func_SHGetUserDisplayName(void);
 extern void func_SHLimitInputEdit(void);
 extern void func_SHParseDisplayName(void);
 extern void func_SHSimpleIDListFromPath(void);
@@ -88,6 +89,7 @@ const struct test winetest_testlist[] =
     { "ShellState", func_ShellState },
     { "SHGetAttributesFromDataObject", func_SHGetAttributesFromDataObject },
     { "SHGetFileInfo", func_SHGetFileInfo },
+    { "SHGetUserDisplayName", func_SHGetUserDisplayName },
     { "SHLimitInputEdit", func_SHLimitInputEdit },
     { "SHParseDisplayName", func_SHParseDisplayName },
     { "SHSimpleIDListFromPath", func_SHSimpleIDListFromPath },

--- a/sdk/include/psdk/secext.h
+++ b/sdk/include/psdk/secext.h
@@ -34,10 +34,6 @@ BOOLEAN WINAPI TranslateNameW(LPCWSTR,EXTENDED_NAME_FORMAT,EXTENDED_NAME_FORMAT,
 #define TranslateName TranslateNameA
 #endif
 
-#ifdef __cplusplus
-} // extern "C"
-#endif
-
 #endif /* ! RC_INVOKED */
 #endif /* _WIN32_WINNT >= 0x0500 */
 #endif /* ! _SECEXT_H */

--- a/sdk/include/psdk/secext.h
+++ b/sdk/include/psdk/secext.h
@@ -3,6 +3,11 @@
 
 #ifndef RC_INVOKED
 #if (_WIN32_WINNT >= 0x0500)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef enum
 {
   NameUnknown = 0,
@@ -34,6 +39,9 @@ BOOLEAN WINAPI TranslateNameW(LPCWSTR,EXTENDED_NAME_FORMAT,EXTENDED_NAME_FORMAT,
 #define TranslateName TranslateNameA
 #endif
 
+#ifdef __cplusplus
+} // extern "C"
+#endif
 
 #endif /* ! RC_INVOKED */
 #endif /* _WIN32_WINNT >= 0x0500 */

--- a/sdk/include/psdk/secext.h
+++ b/sdk/include/psdk/secext.h
@@ -36,4 +36,9 @@ BOOLEAN WINAPI TranslateNameW(LPCWSTR,EXTENDED_NAME_FORMAT,EXTENDED_NAME_FORMAT,
 
 #endif /* ! RC_INVOKED */
 #endif /* _WIN32_WINNT >= 0x0500 */
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
 #endif /* ! _SECEXT_H */

--- a/sdk/include/psdk/secext.h
+++ b/sdk/include/psdk/secext.h
@@ -1,8 +1,13 @@
 #ifndef _SECEXT_H
 #define _SECEXT_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifndef RC_INVOKED
 #if (_WIN32_WINNT >= 0x0500)
+
 typedef enum
 {
   NameUnknown = 0,

--- a/sdk/include/psdk/secext.h
+++ b/sdk/include/psdk/secext.h
@@ -3,11 +3,6 @@
 
 #ifndef RC_INVOKED
 #if (_WIN32_WINNT >= 0x0500)
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 typedef enum
 {
   NameUnknown = 0,

--- a/sdk/include/reactos/undocshell.h
+++ b/sdk/include/reactos/undocshell.h
@@ -211,6 +211,11 @@ DWORD WINAPI SHNetConnectionDialog(
 
 BOOL WINAPI SHIsTempDisplayMode(VOID);
 
+HRESULT WINAPI
+SHGetUserDisplayName(
+    _In_z_ LPWSTR lpName,
+    _Inout_ PULONG puSize);
+
 /****************************************************************************
  * Cabinet Window Messages
  */

--- a/sdk/include/reactos/undocshell.h
+++ b/sdk/include/reactos/undocshell.h
@@ -213,7 +213,7 @@ BOOL WINAPI SHIsTempDisplayMode(VOID);
 
 HRESULT WINAPI
 SHGetUserDisplayName(
-    _In_z_ LPWSTR lpName,
+    _Out_writes_to_(*puSize, *puSize) PWSTR pName,
     _Inout_ PULONG puSize);
 
 /****************************************************************************


### PR DESCRIPTION
## Purpose
Implemementing missing features...
JIRA issue: [CORE-19278](https://jira.reactos.org/browse/CORE-19278)

## Proposed changes

- Add `netapi32` and `secur32` delay importing.
- Move function definition from `stubs.cpp` into `utils.cpp`.
- Include some security headers in `utils.cpp`.
- Adapt `<secext.h>` to C++.
- Add prototype to `<undocshell.h>`.

## TODO

- [x] Do tests.