### PR TITLE
[ROSAUTOTEST][SDK] ROS detection for apitests

### DIFF
--- a/modules/rostests/rosautotest/CConfiguration.cpp
+++ b/modules/rostests/rosautotest/CConfiguration.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "precomp.h"
+#include <versionhelpers.h>
 
 #define CONFIGURATION_FILENAMEA   "rosautotest.ini"
 #define CONFIGURATION_FILENAMEW   L"rosautotest.ini"
@@ -32,6 +33,9 @@ CConfiguration::CConfiguration()
         FATAL("GetWindowsDirectoryW failed\n");
 
     m_IsReactOS = !_wcsnicmp(&WindowsDirectory[3], L"reactos", 7);
+#ifdef __REACTOS__
+    m_IsReactOS = m_IsReactOS || IsReactOS();
+#endif
 
     if(GetEnvironmentVariableW(L"WINETEST_INTERACTIVE", Interactive, _countof(Interactive)))
         m_IsInteractive = _wtoi(Interactive);

--- a/sdk/include/psdk/versionhelpers.h
+++ b/sdk/include/psdk/versionhelpers.h
@@ -148,9 +148,6 @@ IsActiveSessionCountLimited()
 VERSIONHELPERAPI
 IsReactOS()
 {
-    // FIXME: Find a better method!
-    WCHAR szWinDir[MAX_PATH];
-    GetWindowsDirectoryW(szWinDir, _countof(szWinDir));
-    return (wcsstr(szWinDir, L"ReactOS") != NULL);
+    return *(UINT*)0x7ffe0ffc == 0x8eac705;
 }
 #endif // __REACTOS__


### PR DESCRIPTION
Uses the recently added magic value instead of checking the name of the "Windows" directory.