### PR TITLE
[SHELL32] Move SheRemoveQuotesA/W to shlfileop.cpp

### DIFF
--- a/dll/win32/shell32/shlfileop.cpp
+++ b/dll/win32/shell32/shlfileop.cpp
@@ -2107,6 +2107,54 @@ void WINAPI SHFreeNameMappings(HANDLE hNameMapping)
 }
 
 /*************************************************************************
+ *                SheRemoveQuotesA (SHELL32.@)
+ */
+EXTERN_C LPSTR
+WINAPI
+SheRemoveQuotesA(LPSTR psz)
+{
+    PCHAR pch;
+
+    if (*psz == '"')
+    {
+        for (pch = psz + 1; *pch && *pch != '"'; ++pch)
+        {
+            *(pch - 1) = *pch;
+        }
+
+        if (*pch == '"')
+            *(pch - 1) = ANSI_NULL;
+    }
+
+    return psz;
+}
+
+/*************************************************************************
+ *                SheRemoveQuotesW (SHELL32.@)
+ *
+ * ExtractAssociatedIconExW uses this function.
+ */
+EXTERN_C LPWSTR
+WINAPI
+SheRemoveQuotesW(LPWSTR psz)
+{
+    PWCHAR pch;
+
+    if (*psz == L'"')
+    {
+        for (pch = psz + 1; *pch && *pch != L'"'; ++pch)
+        {
+            *(pch - 1) = *pch;
+        }
+
+        if (*pch == L'"')
+            *(pch - 1) = UNICODE_NULL;
+    }
+
+    return psz;
+}
+
+/*************************************************************************
  * SheGetDirA [SHELL32.@]
  *
  * drive = 0: returns the current directory path

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -763,54 +763,6 @@ SHCreatePropertyBag(_In_ REFIID riid, _Out_ void **ppvObj)
 }
 
 /*************************************************************************
- *                SheRemoveQuotesA (SHELL32.@)
- */
-EXTERN_C LPSTR
-WINAPI
-SheRemoveQuotesA(LPSTR psz)
-{
-    PCHAR pch;
-
-    if (*psz == '"')
-    {
-        for (pch = psz + 1; *pch && *pch != '"'; ++pch)
-        {
-            *(pch - 1) = *pch;
-        }
-
-        if (*pch == '"')
-            *(pch - 1) = ANSI_NULL;
-    }
-
-    return psz;
-}
-
-/*************************************************************************
- *                SheRemoveQuotesW (SHELL32.@)
- *
- * ExtractAssociatedIconExW uses this function.
- */
-EXTERN_C LPWSTR
-WINAPI
-SheRemoveQuotesW(LPWSTR psz)
-{
-    PWCHAR pch;
-
-    if (*psz == L'"')
-    {
-        for (pch = psz + 1; *pch && *pch != L'"'; ++pch)
-        {
-            *(pch - 1) = *pch;
-        }
-
-        if (*pch == L'"')
-            *(pch - 1) = UNICODE_NULL;
-    }
-
-    return psz;
-}
-
-/*************************************************************************
  *  SHFindComputer [SHELL32.91]
  *
  * Invokes the shell search in My Computer. Used in SHFindFiles.


### PR DESCRIPTION
## Purpose

Improve consistency of code management.
JIRA issue: [CORE-19278](https://jira.reactos.org/browse/CORE-19278)

## Proposed changes

- Move `SheRemoveQuotesA` and `SheRemoveQuotesW` functions from `utils.cpp` into `shlfileop.cpp`.