### PR TITLE
[WKSSVC] Stubplement support for level 1101 in NetrWkstaUserGetInfo

### DIFF
--- a/base/services/wkssvc/rpcserver.c
+++ b/base/services/wkssvc/rpcserver.c
@@ -845,6 +845,7 @@ NetrWkstaUserGetInfo(
 
         default:
             ERR("\n");
+            dwResult = ERROR_INVALID_LEVEL;
             break;
     }
 

--- a/base/services/wkssvc/rpcserver.c
+++ b/base/services/wkssvc/rpcserver.c
@@ -757,7 +757,8 @@ NetrWkstaUserGetInfo(
             ZeroMemory(pUserInfo, sizeof(WKSTA_USER_INFO_0));
 
             /* User Name */
-            pUserInfo->UserInfo0.wkui0_username = midl_user_allocate(UserInfoResponseBuffer->UserName.Length + sizeof(WCHAR));
+            pUserInfo->UserInfo0.wkui0_username =
+                midl_user_allocate(UserInfoResponseBuffer->UserName.Length + sizeof(WCHAR));
             if (pUserInfo->UserInfo0.wkui0_username == NULL)
             {
                 ERR("\n");
@@ -765,8 +766,11 @@ NetrWkstaUserGetInfo(
                 break;
             }
 
-            ZeroMemory(pUserInfo->UserInfo0.wkui0_username, UserInfoResponseBuffer->UserName.Length + sizeof(WCHAR));
-            CopyMemory(pUserInfo->UserInfo0.wkui0_username, UserInfoResponseBuffer->UserName.Buffer, UserInfoResponseBuffer->UserName.Length);
+            ZeroMemory(pUserInfo->UserInfo0.wkui0_username,
+                       UserInfoResponseBuffer->UserName.Length + sizeof(WCHAR));
+            CopyMemory(pUserInfo->UserInfo0.wkui0_username,
+                       UserInfoResponseBuffer->UserName.Buffer,
+                       UserInfoResponseBuffer->UserName.Length);
 
             *UserInfo = pUserInfo;
             break;
@@ -783,7 +787,8 @@ NetrWkstaUserGetInfo(
             ZeroMemory(pUserInfo, sizeof(WKSTA_USER_INFO_1));
 
             /* User Name */
-            pUserInfo->UserInfo1.wkui1_username = midl_user_allocate(UserInfoResponseBuffer->UserName.Length + sizeof(WCHAR));
+            pUserInfo->UserInfo1.wkui1_username =
+                midl_user_allocate(UserInfoResponseBuffer->UserName.Length + sizeof(WCHAR));
             if (pUserInfo->UserInfo1.wkui1_username == NULL)
             {
                 ERR("\n");
@@ -791,11 +796,15 @@ NetrWkstaUserGetInfo(
                 break;
             }
 
-            ZeroMemory(pUserInfo->UserInfo1.wkui1_username, UserInfoResponseBuffer->UserName.Length + sizeof(WCHAR));
-            CopyMemory(pUserInfo->UserInfo1.wkui1_username, UserInfoResponseBuffer->UserName.Buffer, UserInfoResponseBuffer->UserName.Length);
+            ZeroMemory(pUserInfo->UserInfo1.wkui1_username,
+                       UserInfoResponseBuffer->UserName.Length + sizeof(WCHAR));
+            CopyMemory(pUserInfo->UserInfo1.wkui1_username,
+                       UserInfoResponseBuffer->UserName.Buffer,
+                       UserInfoResponseBuffer->UserName.Length);
 
             /* Logon Domain Name */
-            pUserInfo->UserInfo1.wkui1_logon_domain = midl_user_allocate(UserInfoResponseBuffer->LogonDomainName.Length + sizeof(WCHAR));
+            pUserInfo->UserInfo1.wkui1_logon_domain =
+                midl_user_allocate(UserInfoResponseBuffer->LogonDomainName.Length + sizeof(WCHAR));
             if (pUserInfo->UserInfo1.wkui1_logon_domain == NULL)
             {
                 ERR("\n");
@@ -803,13 +812,17 @@ NetrWkstaUserGetInfo(
                 break;
             }
 
-            ZeroMemory(pUserInfo->UserInfo1.wkui1_logon_domain, UserInfoResponseBuffer->LogonDomainName.Length + sizeof(WCHAR));
-            CopyMemory(pUserInfo->UserInfo1.wkui1_logon_domain, UserInfoResponseBuffer->LogonDomainName.Buffer, UserInfoResponseBuffer->LogonDomainName.Length);
+            ZeroMemory(pUserInfo->UserInfo1.wkui1_logon_domain,
+                       UserInfoResponseBuffer->LogonDomainName.Length + sizeof(WCHAR));
+            CopyMemory(pUserInfo->UserInfo1.wkui1_logon_domain,
+                       UserInfoResponseBuffer->LogonDomainName.Buffer,
+                       UserInfoResponseBuffer->LogonDomainName.Length);
 
             /* FIXME: wkui1_oth_domains */
 
             /* Logon Server */
-            pUserInfo->UserInfo1.wkui1_logon_server = midl_user_allocate(UserInfoResponseBuffer->LogonServer.Length + sizeof(WCHAR));
+            pUserInfo->UserInfo1.wkui1_logon_server =
+                midl_user_allocate(UserInfoResponseBuffer->LogonServer.Length + sizeof(WCHAR));
             if (pUserInfo->UserInfo1.wkui1_logon_server == NULL)
             {
                 ERR("\n");
@@ -817,8 +830,11 @@ NetrWkstaUserGetInfo(
                 break;
             }
 
-            ZeroMemory(pUserInfo->UserInfo1.wkui1_logon_server, UserInfoResponseBuffer->LogonServer.Length + sizeof(WCHAR));
-            CopyMemory(pUserInfo->UserInfo1.wkui1_logon_server, UserInfoResponseBuffer->LogonServer.Buffer, UserInfoResponseBuffer->LogonServer.Length);
+            ZeroMemory(pUserInfo->UserInfo1.wkui1_logon_server,
+                       UserInfoResponseBuffer->LogonServer.Length + sizeof(WCHAR));
+            CopyMemory(pUserInfo->UserInfo1.wkui1_logon_server,
+                       UserInfoResponseBuffer->LogonServer.Buffer,
+                       UserInfoResponseBuffer->LogonServer.Length);
 
             *UserInfo = pUserInfo;
             break;

--- a/base/services/wkssvc/rpcserver.c
+++ b/base/services/wkssvc/rpcserver.c
@@ -847,7 +847,19 @@ NetrWkstaUserGetInfo(
             break;
 
         case 1101:
+            pUserInfo = midl_user_allocate(sizeof(WKSTA_USER_INFO_1101));
+            if (pUserInfo == NULL)
+            {
+                ERR("Failed to allocate WKSTA_USER_INFO_1101\n");
+                dwResult = ERROR_NOT_ENOUGH_MEMORY;
+                break;
+            }
+
+            ZeroMemory(pUserInfo, sizeof(WKSTA_USER_INFO_1101));
+
             /* FIXME: wkui1101_oth_domains */
+
+            *UserInfo = pUserInfo;
             break;
 
         default:

--- a/base/services/wkssvc/rpcserver.c
+++ b/base/services/wkssvc/rpcserver.c
@@ -762,6 +762,7 @@ NetrWkstaUserGetInfo(
             if (pUserInfo->UserInfo0.wkui0_username == NULL)
             {
                 ERR("\n");
+                midl_user_free(pUserInfo);
                 dwResult = ERROR_NOT_ENOUGH_MEMORY;
                 break;
             }
@@ -792,6 +793,7 @@ NetrWkstaUserGetInfo(
             if (pUserInfo->UserInfo1.wkui1_username == NULL)
             {
                 ERR("\n");
+                midl_user_free(pUserInfo);
                 dwResult = ERROR_NOT_ENOUGH_MEMORY;
                 break;
             }
@@ -808,6 +810,8 @@ NetrWkstaUserGetInfo(
             if (pUserInfo->UserInfo1.wkui1_logon_domain == NULL)
             {
                 ERR("\n");
+                midl_user_free(pUserInfo->UserInfo1.wkui1_username);
+                midl_user_free(pUserInfo);
                 dwResult = ERROR_NOT_ENOUGH_MEMORY;
                 break;
             }
@@ -826,6 +830,9 @@ NetrWkstaUserGetInfo(
             if (pUserInfo->UserInfo1.wkui1_logon_server == NULL)
             {
                 ERR("\n");
+                midl_user_free(pUserInfo->UserInfo1.wkui1_username);
+                midl_user_free(pUserInfo->UserInfo1.wkui1_logon_domain);
+                midl_user_free(pUserInfo);
                 dwResult = ERROR_NOT_ENOUGH_MEMORY;
                 break;
             }


### PR DESCRIPTION
## Purpose

Add minimal functionality for for level 1101 in NetrWkstaUserGetInfo to prevent netapi32_winetest:wksta from crashing (introduced in 45b008d).
Also plug some memory leaks, fix an error return and improve formatting.

## Tests
- ✅ KVM x86: https://reactos.org/testman/compare.php?ids=99585,99589,99592,99596
