### PR TITLE
[FREETYPE][FTFD][NTGDI] Split FT_Bitmap_Convert hack

### DIFF
--- a/sdk/lib/3rdparty/freetype/freetype.def
+++ b/sdk/lib/3rdparty/freetype/freetype.def
@@ -23,7 +23,6 @@ EXPORTS
   FT_Attach_File
   FT_Attach_Stream
   FT_Bitmap_Convert
-  FT_Bitmap_Convert_ReactOS_Hack
   FT_Bitmap_Copy
   FT_Bitmap_Done
   FT_Bitmap_Embolden

--- a/sdk/lib/3rdparty/freetype/freetype.def
+++ b/sdk/lib/3rdparty/freetype/freetype.def
@@ -23,6 +23,7 @@ EXPORTS
   FT_Attach_File
   FT_Attach_Stream
   FT_Bitmap_Convert
+  FT_Bitmap_Convert_ReactOS_Hack
   FT_Bitmap_Copy
   FT_Bitmap_Done
   FT_Bitmap_Embolden

--- a/sdk/lib/3rdparty/freetype/include/freetype/ftbitmap.h
+++ b/sdk/lib/3rdparty/freetype/include/freetype/ftbitmap.h
@@ -199,8 +199,8 @@ FT_BEGIN_HEADER
   /*    alignment :: The pitch of the bitmap is a multiple of this         */
   /*                 parameter.  Common values are 1, 2, or 4.             */
   /*                                                                       */
-  /*    hack      :: If true, the bitmap will be ReactOS compatible.       */
-  /*                 If false, the bitmap will be same as                  */
+  /*    hack      :: If TRUE, the bitmap will be ReactOS compatible.       */
+  /*                 If FALSE, the bitmap will be same as                  */
   /*                 FT_Bitmap_Convert returns.                            */
   /*                                                                       */
   /* <Output>                                                              */

--- a/sdk/lib/3rdparty/freetype/include/freetype/ftbitmap.h
+++ b/sdk/lib/3rdparty/freetype/include/freetype/ftbitmap.h
@@ -189,7 +189,7 @@ FT_BEGIN_HEADER
   /*                                                                       */
   /* <Description>                                                         */
   /*    Mainly same as @FT_Bitmap_Convert, but the bitmap will be          */
-  /*    ReactOS compatible.                                                */
+  /*    ReactOS compatible when hack parameter is true.                    */
   /*                                                                       */
   /* <Input>                                                               */
   /*    library   :: A handle to a library object.                         */
@@ -198,6 +198,10 @@ FT_BEGIN_HEADER
   /*                                                                       */
   /*    alignment :: The pitch of the bitmap is a multiple of this         */
   /*                 parameter.  Common values are 1, 2, or 4.             */
+  /*                                                                       */
+  /*    hack      :: If true, the bitmap will be ReactOS compatible.       */
+  /*                 If false, the bitmap will be same as                  */
+  /*                 FT_Bitmap_Convert returns.                            */
   /*                                                                       */
   /* <Output>                                                              */
   /*    target    :: The target bitmap.                                    */
@@ -209,7 +213,8 @@ FT_BEGIN_HEADER
   FT_Bitmap_Convert_ReactOS_Hack( FT_Library        library,
                                   const FT_Bitmap  *source,
                                   FT_Bitmap        *target,
-                                  FT_Int            alignment );
+                                  FT_Int            alignment,
+                                  FT_Bool           hack);
 #endif
 
   /*************************************************************************/

--- a/sdk/lib/3rdparty/freetype/include/freetype/ftbitmap.h
+++ b/sdk/lib/3rdparty/freetype/include/freetype/ftbitmap.h
@@ -181,6 +181,36 @@ FT_BEGIN_HEADER
                      FT_Bitmap        *target,
                      FT_Int            alignment );
 
+#ifdef __REACTOS__
+  /*************************************************************************/
+  /*                                                                       */
+  /* <Function>                                                            */
+  /*    FT_Bitmap_Convert_ReactOS_Hack                                     */
+  /*                                                                       */
+  /* <Description>                                                         */
+  /*    Mainly same as @FT_Bitmap_Convert, but the bitmap will be          */
+  /*    ReactOS compatible.                                                */
+  /*                                                                       */
+  /* <Input>                                                               */
+  /*    library   :: A handle to a library object.                         */
+  /*                                                                       */
+  /*    source    :: The source bitmap.                                    */
+  /*                                                                       */
+  /*    alignment :: The pitch of the bitmap is a multiple of this         */
+  /*                 parameter.  Common values are 1, 2, or 4.             */
+  /*                                                                       */
+  /* <Output>                                                              */
+  /*    target    :: The target bitmap.                                    */
+  /*                                                                       */
+  /* <Return>                                                              */
+  /*    FreeType error code.  0~means success.                             */
+  /*                                                                       */
+  FT_EXPORT( FT_Error )
+  FT_Bitmap_Convert_ReactOS_Hack( FT_Library        library,
+                                  const FT_Bitmap  *source,
+                                  FT_Bitmap        *target,
+                                  FT_Int            alignment );
+#endif
 
   /*************************************************************************/
   /*                                                                       */

--- a/sdk/lib/3rdparty/freetype/src/base/ftbitmap.c
+++ b/sdk/lib/3rdparty/freetype/src/base/ftbitmap.c
@@ -811,7 +811,7 @@
     return error;
   }
 
-#ifndef __REACTOS__
+#ifdef __REACTOS__
   /* documentation is in ftbitmap.h */
 
   FT_EXPORT_DEF( FT_Error )
@@ -820,7 +820,7 @@
                      FT_Bitmap        *target,
                      FT_Int            alignment )
   {
-    return FT_Bitmap_Convert_ReactOS_Hack(library, source, target, alignment, 0);
+    return FT_Bitmap_Convert_ReactOS_Hack(library, source, target, alignment, FALSE);
   }
 #endif
 

--- a/sdk/lib/3rdparty/freetype/src/base/ftbitmap.c
+++ b/sdk/lib/3rdparty/freetype/src/base/ftbitmap.c
@@ -498,13 +498,22 @@
   }
 
 
-#ifdef __REACTOS__
   /* documentation is in ftbitmap.h */
+
+#ifdef __REACTOS__
   FT_EXPORT_DEF( FT_Error )
   FT_Bitmap_Convert_ReactOS_Hack( FT_Library        library,
                                   const FT_Bitmap  *source,
                                   FT_Bitmap        *target,
-                                  FT_Int            alignment )
+                                  FT_Int            alignment,
+                                  FT_Bool           hack )
+#else
+  FT_EXPORT_DEF( FT_Error )
+  FT_Bitmap_Convert( FT_Library        library,
+                     const FT_Bitmap  *source,
+                     FT_Bitmap        *target,
+                     FT_Int            alignment )
+#endif
   {
     FT_Error   error = FT_Err_Ok;
     FT_Memory  memory;
@@ -602,15 +611,20 @@
             FT_Int  val = ss[0]; /* avoid a byte->int cast on each line */
 
 #ifdef __REACTOS__
-            tt[0] = (FT_Byte)( ( val & 0x80 ) ? 0xff : 0);
-            tt[1] = (FT_Byte)( ( val & 0x40 ) ? 0xff : 0);
-            tt[2] = (FT_Byte)( ( val & 0x20 ) ? 0xff : 0);
-            tt[3] = (FT_Byte)( ( val & 0x10 ) ? 0xff : 0);
-            tt[4] = (FT_Byte)( ( val & 0x08 ) ? 0xff : 0);
-            tt[5] = (FT_Byte)( ( val & 0x04 ) ? 0xff : 0);
-            tt[6] = (FT_Byte)( ( val & 0x02 ) ? 0xff : 0);
-            tt[7] = (FT_Byte)( ( val & 0x01 ) ? 0xff : 0);
-#else
+            if (hack)
+            {
+                tt[0] = (FT_Byte)( ( val & 0x80 ) ? 0xff : 0);
+                tt[1] = (FT_Byte)( ( val & 0x40 ) ? 0xff : 0);
+                tt[2] = (FT_Byte)( ( val & 0x20 ) ? 0xff : 0);
+                tt[3] = (FT_Byte)( ( val & 0x10 ) ? 0xff : 0);
+                tt[4] = (FT_Byte)( ( val & 0x08 ) ? 0xff : 0);
+                tt[5] = (FT_Byte)( ( val & 0x04 ) ? 0xff : 0);
+                tt[6] = (FT_Byte)( ( val & 0x02 ) ? 0xff : 0);
+                tt[7] = (FT_Byte)( ( val & 0x01 ) ? 0xff : 0);
+            }
+            else
+            {
+#endif
             tt[0] = (FT_Byte)( ( val & 0x80 ) >> 7 );
             tt[1] = (FT_Byte)( ( val & 0x40 ) >> 6 );
             tt[2] = (FT_Byte)( ( val & 0x20 ) >> 5 );
@@ -619,6 +633,8 @@
             tt[5] = (FT_Byte)( ( val & 0x04 ) >> 2 );
             tt[6] = (FT_Byte)( ( val & 0x02 ) >> 1 );
             tt[7] = (FT_Byte)(   val & 0x01 );
+#ifdef __REACTOS__
+            }
 #endif
 
             tt += 8;
@@ -635,10 +651,11 @@
             for ( ; j > 0; j-- )
             {
 #ifdef __REACTOS__
-              tt[0] = (FT_Byte)( ( val & 0x80 ) ? 0xff : 0);
-#else
-              tt[0] = (FT_Byte)( ( val & 0x80 ) >> 7);
+              if (hack)
+                tt[0] = (FT_Byte)( ( val & 0x80 ) ? 0xff : 0);
+              else
 #endif
+              tt[0] = (FT_Byte)( ( val & 0x80 ) >> 7);
               val <<= 1;
               tt   += 1;
             }
@@ -793,8 +810,8 @@
 
     return error;
   }
-#endif
 
+#ifndef __REACTOS__
   /* documentation is in ftbitmap.h */
 
   FT_EXPORT_DEF( FT_Error )
@@ -803,278 +820,9 @@
                      FT_Bitmap        *target,
                      FT_Int            alignment )
   {
-    FT_Error   error = FT_Err_Ok;
-    FT_Memory  memory;
-
-    FT_Byte*  s;
-    FT_Byte*  t;
-
-
-    if ( !library )
-      return FT_THROW( Invalid_Library_Handle );
-
-    if ( !source || !target )
-      return FT_THROW( Invalid_Argument );
-
-    memory = library->memory;
-
-    switch ( source->pixel_mode )
-    {
-    case FT_PIXEL_MODE_MONO:
-    case FT_PIXEL_MODE_GRAY:
-    case FT_PIXEL_MODE_GRAY2:
-    case FT_PIXEL_MODE_GRAY4:
-    case FT_PIXEL_MODE_LCD:
-    case FT_PIXEL_MODE_LCD_V:
-    case FT_PIXEL_MODE_BGRA:
-      {
-        FT_Int    pad, old_target_pitch, target_pitch;
-        FT_ULong  old_size;
-
-
-        old_target_pitch = target->pitch;
-        if ( old_target_pitch < 0 )
-          old_target_pitch = -old_target_pitch;
-
-        old_size = target->rows * (FT_UInt)old_target_pitch;
-
-        target->pixel_mode = FT_PIXEL_MODE_GRAY;
-        target->rows       = source->rows;
-        target->width      = source->width;
-
-        pad = 0;
-        if ( alignment > 0 )
-        {
-          pad = (FT_Int)source->width % alignment;
-          if ( pad != 0 )
-            pad = alignment - pad;
-        }
-
-        target_pitch = (FT_Int)source->width + pad;
-
-        if ( target_pitch > 0                                               &&
-             (FT_ULong)target->rows > FT_ULONG_MAX / (FT_ULong)target_pitch )
-          return FT_THROW( Invalid_Argument );
-
-        if ( FT_QREALLOC( target->buffer,
-                          old_size, target->rows * (FT_UInt)target_pitch ) )
-          return error;
-
-        target->pitch = target->pitch < 0 ? -target_pitch : target_pitch;
-      }
-      break;
-
-    default:
-      error = FT_THROW( Invalid_Argument );
-    }
-
-    s = source->buffer;
-    t = target->buffer;
-
-    /* take care of bitmap flow */
-    if ( source->pitch < 0 )
-      s -= source->pitch * (FT_Int)( source->rows - 1 );
-    if ( target->pitch < 0 )
-      t -= target->pitch * (FT_Int)( target->rows - 1 );
-
-    switch ( source->pixel_mode )
-    {
-    case FT_PIXEL_MODE_MONO:
-      {
-        FT_UInt  i;
-
-
-        target->num_grays = 2;
-
-        for ( i = source->rows; i > 0; i-- )
-        {
-          FT_Byte*  ss = s;
-          FT_Byte*  tt = t;
-          FT_UInt   j;
-
-
-          /* get the full bytes */
-          for ( j = source->width >> 3; j > 0; j-- )
-          {
-            FT_Int  val = ss[0]; /* avoid a byte->int cast on each line */
-
-            tt[0] = (FT_Byte)( ( val & 0x80 ) >> 7 );
-            tt[1] = (FT_Byte)( ( val & 0x40 ) >> 6 );
-            tt[2] = (FT_Byte)( ( val & 0x20 ) >> 5 );
-            tt[3] = (FT_Byte)( ( val & 0x10 ) >> 4 );
-            tt[4] = (FT_Byte)( ( val & 0x08 ) >> 3 );
-            tt[5] = (FT_Byte)( ( val & 0x04 ) >> 2 );
-            tt[6] = (FT_Byte)( ( val & 0x02 ) >> 1 );
-            tt[7] = (FT_Byte)(   val & 0x01 );
-
-            tt += 8;
-            ss += 1;
-          }
-
-          /* get remaining pixels (if any) */
-          j = source->width & 7;
-          if ( j > 0 )
-          {
-            FT_Int  val = *ss;
-
-
-            for ( ; j > 0; j-- )
-            {
-              tt[0] = (FT_Byte)( ( val & 0x80 ) ? 0xff : 0);
-              val <<= 1;
-              tt   += 1;
-            }
-          }
-
-          s += source->pitch;
-          t += target->pitch;
-        }
-      }
-      break;
-
-
-    case FT_PIXEL_MODE_GRAY:
-    case FT_PIXEL_MODE_LCD:
-    case FT_PIXEL_MODE_LCD_V:
-      {
-        FT_UInt  width = source->width;
-        FT_UInt  i;
-
-
-        target->num_grays = 256;
-
-        for ( i = source->rows; i > 0; i-- )
-        {
-          FT_ARRAY_COPY( t, s, width );
-
-          s += source->pitch;
-          t += target->pitch;
-        }
-      }
-      break;
-
-
-    case FT_PIXEL_MODE_GRAY2:
-      {
-        FT_UInt  i;
-
-
-        target->num_grays = 4;
-
-        for ( i = source->rows; i > 0; i-- )
-        {
-          FT_Byte*  ss = s;
-          FT_Byte*  tt = t;
-          FT_UInt   j;
-
-
-          /* get the full bytes */
-          for ( j = source->width >> 2; j > 0; j-- )
-          {
-            FT_Int  val = ss[0];
-
-
-            tt[0] = (FT_Byte)( ( val & 0xC0 ) >> 6 );
-            tt[1] = (FT_Byte)( ( val & 0x30 ) >> 4 );
-            tt[2] = (FT_Byte)( ( val & 0x0C ) >> 2 );
-            tt[3] = (FT_Byte)( ( val & 0x03 ) );
-
-            ss += 1;
-            tt += 4;
-          }
-
-          j = source->width & 3;
-          if ( j > 0 )
-          {
-            FT_Int  val = ss[0];
-
-
-            for ( ; j > 0; j-- )
-            {
-              tt[0]  = (FT_Byte)( ( val & 0xC0 ) >> 6 );
-              val  <<= 2;
-              tt    += 1;
-            }
-          }
-
-          s += source->pitch;
-          t += target->pitch;
-        }
-      }
-      break;
-
-
-    case FT_PIXEL_MODE_GRAY4:
-      {
-        FT_UInt  i;
-
-
-        target->num_grays = 16;
-
-        for ( i = source->rows; i > 0; i-- )
-        {
-          FT_Byte*  ss = s;
-          FT_Byte*  tt = t;
-          FT_UInt   j;
-
-
-          /* get the full bytes */
-          for ( j = source->width >> 1; j > 0; j-- )
-          {
-            FT_Int  val = ss[0];
-
-
-            tt[0] = (FT_Byte)( ( val & 0xF0 ) >> 4 );
-            tt[1] = (FT_Byte)( ( val & 0x0F ) );
-
-            ss += 1;
-            tt += 2;
-          }
-
-          if ( source->width & 1 )
-            tt[0] = (FT_Byte)( ( ss[0] & 0xF0 ) >> 4 );
-
-          s += source->pitch;
-          t += target->pitch;
-        }
-      }
-      break;
-
-
-    case FT_PIXEL_MODE_BGRA:
-      {
-        FT_UInt  i;
-
-
-        target->num_grays = 256;
-
-        for ( i = source->rows; i > 0; i-- )
-        {
-          FT_Byte*  ss = s;
-          FT_Byte*  tt = t;
-          FT_UInt   j;
-
-
-          for ( j = source->width; j > 0; j-- )
-          {
-            tt[0] = ft_gray_for_premultiplied_srgb_bgra( ss );
-
-            ss += 4;
-            tt += 1;
-          }
-
-          s += source->pitch;
-          t += target->pitch;
-        }
-      }
-      break;
-
-    default:
-      ;
-    }
-
-    return error;
+    return FT_Bitmap_Convert_ReactOS_Hack(library, source, target, alignment, 0);
   }
+#endif
 
   /* documentation is in ftbitmap.h */
 

--- a/sdk/lib/3rdparty/freetype/src/base/ftbitmap.c
+++ b/sdk/lib/3rdparty/freetype/src/base/ftbitmap.c
@@ -498,290 +498,6 @@
   }
 
 
-  /* documentation is in ftbitmap.h */
-
-#ifdef __REACTOS__
-  /* See also FT_Bitmap_Convert_ReactOS_Hack below */
-#endif
-  FT_EXPORT_DEF( FT_Error )
-  FT_Bitmap_Convert( FT_Library        library,
-                     const FT_Bitmap  *source,
-                     FT_Bitmap        *target,
-                     FT_Int            alignment )
-  {
-    FT_Error   error = FT_Err_Ok;
-    FT_Memory  memory;
-
-    FT_Byte*  s;
-    FT_Byte*  t;
-
-
-    if ( !library )
-      return FT_THROW( Invalid_Library_Handle );
-
-    if ( !source || !target )
-      return FT_THROW( Invalid_Argument );
-
-    memory = library->memory;
-
-    switch ( source->pixel_mode )
-    {
-    case FT_PIXEL_MODE_MONO:
-    case FT_PIXEL_MODE_GRAY:
-    case FT_PIXEL_MODE_GRAY2:
-    case FT_PIXEL_MODE_GRAY4:
-    case FT_PIXEL_MODE_LCD:
-    case FT_PIXEL_MODE_LCD_V:
-    case FT_PIXEL_MODE_BGRA:
-      {
-        FT_Int    pad, old_target_pitch, target_pitch;
-        FT_ULong  old_size;
-
-
-        old_target_pitch = target->pitch;
-        if ( old_target_pitch < 0 )
-          old_target_pitch = -old_target_pitch;
-
-        old_size = target->rows * (FT_UInt)old_target_pitch;
-
-        target->pixel_mode = FT_PIXEL_MODE_GRAY;
-        target->rows       = source->rows;
-        target->width      = source->width;
-
-        pad = 0;
-        if ( alignment > 0 )
-        {
-          pad = (FT_Int)source->width % alignment;
-          if ( pad != 0 )
-            pad = alignment - pad;
-        }
-
-        target_pitch = (FT_Int)source->width + pad;
-
-        if ( target_pitch > 0                                               &&
-             (FT_ULong)target->rows > FT_ULONG_MAX / (FT_ULong)target_pitch )
-          return FT_THROW( Invalid_Argument );
-
-        if ( FT_QREALLOC( target->buffer,
-                          old_size, target->rows * (FT_UInt)target_pitch ) )
-          return error;
-
-        target->pitch = target->pitch < 0 ? -target_pitch : target_pitch;
-      }
-      break;
-
-    default:
-      error = FT_THROW( Invalid_Argument );
-    }
-
-    s = source->buffer;
-    t = target->buffer;
-
-    /* take care of bitmap flow */
-    if ( source->pitch < 0 )
-      s -= source->pitch * (FT_Int)( source->rows - 1 );
-    if ( target->pitch < 0 )
-      t -= target->pitch * (FT_Int)( target->rows - 1 );
-
-    switch ( source->pixel_mode )
-    {
-    case FT_PIXEL_MODE_MONO:
-      {
-        FT_UInt  i;
-
-
-        target->num_grays = 2;
-
-        for ( i = source->rows; i > 0; i-- )
-        {
-          FT_Byte*  ss = s;
-          FT_Byte*  tt = t;
-          FT_UInt   j;
-
-
-          /* get the full bytes */
-          for ( j = source->width >> 3; j > 0; j-- )
-          {
-            FT_Int  val = ss[0]; /* avoid a byte->int cast on each line */
-
-            tt[0] = (FT_Byte)( ( val & 0x80 ) >> 7 );
-            tt[1] = (FT_Byte)( ( val & 0x40 ) >> 6 );
-            tt[2] = (FT_Byte)( ( val & 0x20 ) >> 5 );
-            tt[3] = (FT_Byte)( ( val & 0x10 ) >> 4 );
-            tt[4] = (FT_Byte)( ( val & 0x08 ) >> 3 );
-            tt[5] = (FT_Byte)( ( val & 0x04 ) >> 2 );
-            tt[6] = (FT_Byte)( ( val & 0x02 ) >> 1 );
-            tt[7] = (FT_Byte)(   val & 0x01 );
-
-            tt += 8;
-            ss += 1;
-          }
-
-          /* get remaining pixels (if any) */
-          j = source->width & 7;
-          if ( j > 0 )
-          {
-            FT_Int  val = *ss;
-
-
-            for ( ; j > 0; j-- )
-            {
-              tt[0] = (FT_Byte)( ( val & 0x80 ) ? 0xff : 0);
-              val <<= 1;
-              tt   += 1;
-            }
-          }
-
-          s += source->pitch;
-          t += target->pitch;
-        }
-      }
-      break;
-
-
-    case FT_PIXEL_MODE_GRAY:
-    case FT_PIXEL_MODE_LCD:
-    case FT_PIXEL_MODE_LCD_V:
-      {
-        FT_UInt  width = source->width;
-        FT_UInt  i;
-
-
-        target->num_grays = 256;
-
-        for ( i = source->rows; i > 0; i-- )
-        {
-          FT_ARRAY_COPY( t, s, width );
-
-          s += source->pitch;
-          t += target->pitch;
-        }
-      }
-      break;
-
-
-    case FT_PIXEL_MODE_GRAY2:
-      {
-        FT_UInt  i;
-
-
-        target->num_grays = 4;
-
-        for ( i = source->rows; i > 0; i-- )
-        {
-          FT_Byte*  ss = s;
-          FT_Byte*  tt = t;
-          FT_UInt   j;
-
-
-          /* get the full bytes */
-          for ( j = source->width >> 2; j > 0; j-- )
-          {
-            FT_Int  val = ss[0];
-
-
-            tt[0] = (FT_Byte)( ( val & 0xC0 ) >> 6 );
-            tt[1] = (FT_Byte)( ( val & 0x30 ) >> 4 );
-            tt[2] = (FT_Byte)( ( val & 0x0C ) >> 2 );
-            tt[3] = (FT_Byte)( ( val & 0x03 ) );
-
-            ss += 1;
-            tt += 4;
-          }
-
-          j = source->width & 3;
-          if ( j > 0 )
-          {
-            FT_Int  val = ss[0];
-
-
-            for ( ; j > 0; j-- )
-            {
-              tt[0]  = (FT_Byte)( ( val & 0xC0 ) >> 6 );
-              val  <<= 2;
-              tt    += 1;
-            }
-          }
-
-          s += source->pitch;
-          t += target->pitch;
-        }
-      }
-      break;
-
-
-    case FT_PIXEL_MODE_GRAY4:
-      {
-        FT_UInt  i;
-
-
-        target->num_grays = 16;
-
-        for ( i = source->rows; i > 0; i-- )
-        {
-          FT_Byte*  ss = s;
-          FT_Byte*  tt = t;
-          FT_UInt   j;
-
-
-          /* get the full bytes */
-          for ( j = source->width >> 1; j > 0; j-- )
-          {
-            FT_Int  val = ss[0];
-
-
-            tt[0] = (FT_Byte)( ( val & 0xF0 ) >> 4 );
-            tt[1] = (FT_Byte)( ( val & 0x0F ) );
-
-            ss += 1;
-            tt += 2;
-          }
-
-          if ( source->width & 1 )
-            tt[0] = (FT_Byte)( ( ss[0] & 0xF0 ) >> 4 );
-
-          s += source->pitch;
-          t += target->pitch;
-        }
-      }
-      break;
-
-
-    case FT_PIXEL_MODE_BGRA:
-      {
-        FT_UInt  i;
-
-
-        target->num_grays = 256;
-
-        for ( i = source->rows; i > 0; i-- )
-        {
-          FT_Byte*  ss = s;
-          FT_Byte*  tt = t;
-          FT_UInt   j;
-
-
-          for ( j = source->width; j > 0; j-- )
-          {
-            tt[0] = ft_gray_for_premultiplied_srgb_bgra( ss );
-
-            ss += 4;
-            tt += 1;
-          }
-
-          s += source->pitch;
-          t += target->pitch;
-        }
-      }
-      break;
-
-    default:
-      ;
-    }
-
-    return error;
-  }
-
 #ifdef __REACTOS__
   /* documentation is in ftbitmap.h */
   FT_EXPORT_DEF( FT_Error )
@@ -1078,6 +794,287 @@
     return error;
   }
 #endif
+
+  /* documentation is in ftbitmap.h */
+
+  FT_EXPORT_DEF( FT_Error )
+  FT_Bitmap_Convert( FT_Library        library,
+                     const FT_Bitmap  *source,
+                     FT_Bitmap        *target,
+                     FT_Int            alignment )
+  {
+    FT_Error   error = FT_Err_Ok;
+    FT_Memory  memory;
+
+    FT_Byte*  s;
+    FT_Byte*  t;
+
+
+    if ( !library )
+      return FT_THROW( Invalid_Library_Handle );
+
+    if ( !source || !target )
+      return FT_THROW( Invalid_Argument );
+
+    memory = library->memory;
+
+    switch ( source->pixel_mode )
+    {
+    case FT_PIXEL_MODE_MONO:
+    case FT_PIXEL_MODE_GRAY:
+    case FT_PIXEL_MODE_GRAY2:
+    case FT_PIXEL_MODE_GRAY4:
+    case FT_PIXEL_MODE_LCD:
+    case FT_PIXEL_MODE_LCD_V:
+    case FT_PIXEL_MODE_BGRA:
+      {
+        FT_Int    pad, old_target_pitch, target_pitch;
+        FT_ULong  old_size;
+
+
+        old_target_pitch = target->pitch;
+        if ( old_target_pitch < 0 )
+          old_target_pitch = -old_target_pitch;
+
+        old_size = target->rows * (FT_UInt)old_target_pitch;
+
+        target->pixel_mode = FT_PIXEL_MODE_GRAY;
+        target->rows       = source->rows;
+        target->width      = source->width;
+
+        pad = 0;
+        if ( alignment > 0 )
+        {
+          pad = (FT_Int)source->width % alignment;
+          if ( pad != 0 )
+            pad = alignment - pad;
+        }
+
+        target_pitch = (FT_Int)source->width + pad;
+
+        if ( target_pitch > 0                                               &&
+             (FT_ULong)target->rows > FT_ULONG_MAX / (FT_ULong)target_pitch )
+          return FT_THROW( Invalid_Argument );
+
+        if ( FT_QREALLOC( target->buffer,
+                          old_size, target->rows * (FT_UInt)target_pitch ) )
+          return error;
+
+        target->pitch = target->pitch < 0 ? -target_pitch : target_pitch;
+      }
+      break;
+
+    default:
+      error = FT_THROW( Invalid_Argument );
+    }
+
+    s = source->buffer;
+    t = target->buffer;
+
+    /* take care of bitmap flow */
+    if ( source->pitch < 0 )
+      s -= source->pitch * (FT_Int)( source->rows - 1 );
+    if ( target->pitch < 0 )
+      t -= target->pitch * (FT_Int)( target->rows - 1 );
+
+    switch ( source->pixel_mode )
+    {
+    case FT_PIXEL_MODE_MONO:
+      {
+        FT_UInt  i;
+
+
+        target->num_grays = 2;
+
+        for ( i = source->rows; i > 0; i-- )
+        {
+          FT_Byte*  ss = s;
+          FT_Byte*  tt = t;
+          FT_UInt   j;
+
+
+          /* get the full bytes */
+          for ( j = source->width >> 3; j > 0; j-- )
+          {
+            FT_Int  val = ss[0]; /* avoid a byte->int cast on each line */
+
+            tt[0] = (FT_Byte)( ( val & 0x80 ) >> 7 );
+            tt[1] = (FT_Byte)( ( val & 0x40 ) >> 6 );
+            tt[2] = (FT_Byte)( ( val & 0x20 ) >> 5 );
+            tt[3] = (FT_Byte)( ( val & 0x10 ) >> 4 );
+            tt[4] = (FT_Byte)( ( val & 0x08 ) >> 3 );
+            tt[5] = (FT_Byte)( ( val & 0x04 ) >> 2 );
+            tt[6] = (FT_Byte)( ( val & 0x02 ) >> 1 );
+            tt[7] = (FT_Byte)(   val & 0x01 );
+
+            tt += 8;
+            ss += 1;
+          }
+
+          /* get remaining pixels (if any) */
+          j = source->width & 7;
+          if ( j > 0 )
+          {
+            FT_Int  val = *ss;
+
+
+            for ( ; j > 0; j-- )
+            {
+              tt[0] = (FT_Byte)( ( val & 0x80 ) ? 0xff : 0);
+              val <<= 1;
+              tt   += 1;
+            }
+          }
+
+          s += source->pitch;
+          t += target->pitch;
+        }
+      }
+      break;
+
+
+    case FT_PIXEL_MODE_GRAY:
+    case FT_PIXEL_MODE_LCD:
+    case FT_PIXEL_MODE_LCD_V:
+      {
+        FT_UInt  width = source->width;
+        FT_UInt  i;
+
+
+        target->num_grays = 256;
+
+        for ( i = source->rows; i > 0; i-- )
+        {
+          FT_ARRAY_COPY( t, s, width );
+
+          s += source->pitch;
+          t += target->pitch;
+        }
+      }
+      break;
+
+
+    case FT_PIXEL_MODE_GRAY2:
+      {
+        FT_UInt  i;
+
+
+        target->num_grays = 4;
+
+        for ( i = source->rows; i > 0; i-- )
+        {
+          FT_Byte*  ss = s;
+          FT_Byte*  tt = t;
+          FT_UInt   j;
+
+
+          /* get the full bytes */
+          for ( j = source->width >> 2; j > 0; j-- )
+          {
+            FT_Int  val = ss[0];
+
+
+            tt[0] = (FT_Byte)( ( val & 0xC0 ) >> 6 );
+            tt[1] = (FT_Byte)( ( val & 0x30 ) >> 4 );
+            tt[2] = (FT_Byte)( ( val & 0x0C ) >> 2 );
+            tt[3] = (FT_Byte)( ( val & 0x03 ) );
+
+            ss += 1;
+            tt += 4;
+          }
+
+          j = source->width & 3;
+          if ( j > 0 )
+          {
+            FT_Int  val = ss[0];
+
+
+            for ( ; j > 0; j-- )
+            {
+              tt[0]  = (FT_Byte)( ( val & 0xC0 ) >> 6 );
+              val  <<= 2;
+              tt    += 1;
+            }
+          }
+
+          s += source->pitch;
+          t += target->pitch;
+        }
+      }
+      break;
+
+
+    case FT_PIXEL_MODE_GRAY4:
+      {
+        FT_UInt  i;
+
+
+        target->num_grays = 16;
+
+        for ( i = source->rows; i > 0; i-- )
+        {
+          FT_Byte*  ss = s;
+          FT_Byte*  tt = t;
+          FT_UInt   j;
+
+
+          /* get the full bytes */
+          for ( j = source->width >> 1; j > 0; j-- )
+          {
+            FT_Int  val = ss[0];
+
+
+            tt[0] = (FT_Byte)( ( val & 0xF0 ) >> 4 );
+            tt[1] = (FT_Byte)( ( val & 0x0F ) );
+
+            ss += 1;
+            tt += 2;
+          }
+
+          if ( source->width & 1 )
+            tt[0] = (FT_Byte)( ( ss[0] & 0xF0 ) >> 4 );
+
+          s += source->pitch;
+          t += target->pitch;
+        }
+      }
+      break;
+
+
+    case FT_PIXEL_MODE_BGRA:
+      {
+        FT_UInt  i;
+
+
+        target->num_grays = 256;
+
+        for ( i = source->rows; i > 0; i-- )
+        {
+          FT_Byte*  ss = s;
+          FT_Byte*  tt = t;
+          FT_UInt   j;
+
+
+          for ( j = source->width; j > 0; j-- )
+          {
+            tt[0] = ft_gray_for_premultiplied_srgb_bgra( ss );
+
+            ss += 4;
+            tt += 1;
+          }
+
+          s += source->pitch;
+          t += target->pitch;
+        }
+      }
+      break;
+
+    default:
+      ;
+    }
+
+    return error;
+  }
 
   /* documentation is in ftbitmap.h */
 

--- a/sdk/lib/3rdparty/freetype/src/base/ftbitmap.c
+++ b/sdk/lib/3rdparty/freetype/src/base/ftbitmap.c
@@ -500,11 +500,295 @@
 
   /* documentation is in ftbitmap.h */
 
+#ifdef __REACTOS__
+  /* See also FT_Bitmap_Convert_ReactOS_Hack below */
+#endif
   FT_EXPORT_DEF( FT_Error )
   FT_Bitmap_Convert( FT_Library        library,
                      const FT_Bitmap  *source,
                      FT_Bitmap        *target,
                      FT_Int            alignment )
+  {
+    FT_Error   error = FT_Err_Ok;
+    FT_Memory  memory;
+
+    FT_Byte*  s;
+    FT_Byte*  t;
+
+
+    if ( !library )
+      return FT_THROW( Invalid_Library_Handle );
+
+    if ( !source || !target )
+      return FT_THROW( Invalid_Argument );
+
+    memory = library->memory;
+
+    switch ( source->pixel_mode )
+    {
+    case FT_PIXEL_MODE_MONO:
+    case FT_PIXEL_MODE_GRAY:
+    case FT_PIXEL_MODE_GRAY2:
+    case FT_PIXEL_MODE_GRAY4:
+    case FT_PIXEL_MODE_LCD:
+    case FT_PIXEL_MODE_LCD_V:
+    case FT_PIXEL_MODE_BGRA:
+      {
+        FT_Int    pad, old_target_pitch, target_pitch;
+        FT_ULong  old_size;
+
+
+        old_target_pitch = target->pitch;
+        if ( old_target_pitch < 0 )
+          old_target_pitch = -old_target_pitch;
+
+        old_size = target->rows * (FT_UInt)old_target_pitch;
+
+        target->pixel_mode = FT_PIXEL_MODE_GRAY;
+        target->rows       = source->rows;
+        target->width      = source->width;
+
+        pad = 0;
+        if ( alignment > 0 )
+        {
+          pad = (FT_Int)source->width % alignment;
+          if ( pad != 0 )
+            pad = alignment - pad;
+        }
+
+        target_pitch = (FT_Int)source->width + pad;
+
+        if ( target_pitch > 0                                               &&
+             (FT_ULong)target->rows > FT_ULONG_MAX / (FT_ULong)target_pitch )
+          return FT_THROW( Invalid_Argument );
+
+        if ( FT_QREALLOC( target->buffer,
+                          old_size, target->rows * (FT_UInt)target_pitch ) )
+          return error;
+
+        target->pitch = target->pitch < 0 ? -target_pitch : target_pitch;
+      }
+      break;
+
+    default:
+      error = FT_THROW( Invalid_Argument );
+    }
+
+    s = source->buffer;
+    t = target->buffer;
+
+    /* take care of bitmap flow */
+    if ( source->pitch < 0 )
+      s -= source->pitch * (FT_Int)( source->rows - 1 );
+    if ( target->pitch < 0 )
+      t -= target->pitch * (FT_Int)( target->rows - 1 );
+
+    switch ( source->pixel_mode )
+    {
+    case FT_PIXEL_MODE_MONO:
+      {
+        FT_UInt  i;
+
+
+        target->num_grays = 2;
+
+        for ( i = source->rows; i > 0; i-- )
+        {
+          FT_Byte*  ss = s;
+          FT_Byte*  tt = t;
+          FT_UInt   j;
+
+
+          /* get the full bytes */
+          for ( j = source->width >> 3; j > 0; j-- )
+          {
+            FT_Int  val = ss[0]; /* avoid a byte->int cast on each line */
+
+            tt[0] = (FT_Byte)( ( val & 0x80 ) >> 7 );
+            tt[1] = (FT_Byte)( ( val & 0x40 ) >> 6 );
+            tt[2] = (FT_Byte)( ( val & 0x20 ) >> 5 );
+            tt[3] = (FT_Byte)( ( val & 0x10 ) >> 4 );
+            tt[4] = (FT_Byte)( ( val & 0x08 ) >> 3 );
+            tt[5] = (FT_Byte)( ( val & 0x04 ) >> 2 );
+            tt[6] = (FT_Byte)( ( val & 0x02 ) >> 1 );
+            tt[7] = (FT_Byte)(   val & 0x01 );
+
+            tt += 8;
+            ss += 1;
+          }
+
+          /* get remaining pixels (if any) */
+          j = source->width & 7;
+          if ( j > 0 )
+          {
+            FT_Int  val = *ss;
+
+
+            for ( ; j > 0; j-- )
+            {
+              tt[0] = (FT_Byte)( ( val & 0x80 ) ? 0xff : 0);
+              val <<= 1;
+              tt   += 1;
+            }
+          }
+
+          s += source->pitch;
+          t += target->pitch;
+        }
+      }
+      break;
+
+
+    case FT_PIXEL_MODE_GRAY:
+    case FT_PIXEL_MODE_LCD:
+    case FT_PIXEL_MODE_LCD_V:
+      {
+        FT_UInt  width = source->width;
+        FT_UInt  i;
+
+
+        target->num_grays = 256;
+
+        for ( i = source->rows; i > 0; i-- )
+        {
+          FT_ARRAY_COPY( t, s, width );
+
+          s += source->pitch;
+          t += target->pitch;
+        }
+      }
+      break;
+
+
+    case FT_PIXEL_MODE_GRAY2:
+      {
+        FT_UInt  i;
+
+
+        target->num_grays = 4;
+
+        for ( i = source->rows; i > 0; i-- )
+        {
+          FT_Byte*  ss = s;
+          FT_Byte*  tt = t;
+          FT_UInt   j;
+
+
+          /* get the full bytes */
+          for ( j = source->width >> 2; j > 0; j-- )
+          {
+            FT_Int  val = ss[0];
+
+
+            tt[0] = (FT_Byte)( ( val & 0xC0 ) >> 6 );
+            tt[1] = (FT_Byte)( ( val & 0x30 ) >> 4 );
+            tt[2] = (FT_Byte)( ( val & 0x0C ) >> 2 );
+            tt[3] = (FT_Byte)( ( val & 0x03 ) );
+
+            ss += 1;
+            tt += 4;
+          }
+
+          j = source->width & 3;
+          if ( j > 0 )
+          {
+            FT_Int  val = ss[0];
+
+
+            for ( ; j > 0; j-- )
+            {
+              tt[0]  = (FT_Byte)( ( val & 0xC0 ) >> 6 );
+              val  <<= 2;
+              tt    += 1;
+            }
+          }
+
+          s += source->pitch;
+          t += target->pitch;
+        }
+      }
+      break;
+
+
+    case FT_PIXEL_MODE_GRAY4:
+      {
+        FT_UInt  i;
+
+
+        target->num_grays = 16;
+
+        for ( i = source->rows; i > 0; i-- )
+        {
+          FT_Byte*  ss = s;
+          FT_Byte*  tt = t;
+          FT_UInt   j;
+
+
+          /* get the full bytes */
+          for ( j = source->width >> 1; j > 0; j-- )
+          {
+            FT_Int  val = ss[0];
+
+
+            tt[0] = (FT_Byte)( ( val & 0xF0 ) >> 4 );
+            tt[1] = (FT_Byte)( ( val & 0x0F ) );
+
+            ss += 1;
+            tt += 2;
+          }
+
+          if ( source->width & 1 )
+            tt[0] = (FT_Byte)( ( ss[0] & 0xF0 ) >> 4 );
+
+          s += source->pitch;
+          t += target->pitch;
+        }
+      }
+      break;
+
+
+    case FT_PIXEL_MODE_BGRA:
+      {
+        FT_UInt  i;
+
+
+        target->num_grays = 256;
+
+        for ( i = source->rows; i > 0; i-- )
+        {
+          FT_Byte*  ss = s;
+          FT_Byte*  tt = t;
+          FT_UInt   j;
+
+
+          for ( j = source->width; j > 0; j-- )
+          {
+            tt[0] = ft_gray_for_premultiplied_srgb_bgra( ss );
+
+            ss += 4;
+            tt += 1;
+          }
+
+          s += source->pitch;
+          t += target->pitch;
+        }
+      }
+      break;
+
+    default:
+      ;
+    }
+
+    return error;
+  }
+
+#ifdef __REACTOS__
+  /* documentation is in ftbitmap.h */
+  FT_EXPORT_DEF( FT_Error )
+  FT_Bitmap_Convert_ReactOS_Hack( FT_Library        library,
+                                  const FT_Bitmap  *source,
+                                  FT_Bitmap        *target,
+                                  FT_Int            alignment )
   {
     FT_Error   error = FT_Err_Ok;
     FT_Memory  memory;
@@ -793,7 +1077,7 @@
 
     return error;
   }
-
+#endif
 
   /* documentation is in ftbitmap.h */
 

--- a/win32ss/drivers/font/ftfd/ftfd.spec
+++ b/win32ss/drivers/font/ftfd/ftfd.spec
@@ -6,6 +6,7 @@
   @ cdecl FT_Attach_File ()
   @ cdecl FT_Attach_Stream ()
   @ cdecl FT_Bitmap_Convert ()
+  @ cdecl FT_Bitmap_Convert_ReactOS_Hack ()
   @ cdecl FT_Bitmap_Copy ()
   @ cdecl FT_Bitmap_Done ()
   @ cdecl FT_Bitmap_Embolden ()

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -3852,7 +3852,8 @@ IntGetBitmapGlyphWithCache(
 
     BitmapGlyph = (FT_BitmapGlyph)GlyphCopy;
     FT_Bitmap_New(&AlignedBitmap);
-    if (FT_Bitmap_Convert_ReactOS_Hack(GlyphSlot->library, &BitmapGlyph->bitmap, &AlignedBitmap, 4))
+    if (FT_Bitmap_Convert_ReactOS_Hack(GlyphSlot->library, &BitmapGlyph->bitmap,
+                                       &AlignedBitmap, 4, 1))
     {
         DPRINT1("Conversion failed\n");
         ExFreePoolWithTag(NewEntry, TAG_FONT);

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -3853,7 +3853,7 @@ IntGetBitmapGlyphWithCache(
     BitmapGlyph = (FT_BitmapGlyph)GlyphCopy;
     FT_Bitmap_New(&AlignedBitmap);
     if (FT_Bitmap_Convert_ReactOS_Hack(GlyphSlot->library, &BitmapGlyph->bitmap,
-                                       &AlignedBitmap, 4, 1))
+                                       &AlignedBitmap, 4, TRUE))
     {
         DPRINT1("Conversion failed\n");
         ExFreePoolWithTag(NewEntry, TAG_FONT);

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -3852,7 +3852,7 @@ IntGetBitmapGlyphWithCache(
 
     BitmapGlyph = (FT_BitmapGlyph)GlyphCopy;
     FT_Bitmap_New(&AlignedBitmap);
-    if(FT_Bitmap_Convert(GlyphSlot->library, &BitmapGlyph->bitmap, &AlignedBitmap, 4))
+    if (FT_Bitmap_Convert_ReactOS_Hack(GlyphSlot->library, &BitmapGlyph->bitmap, &AlignedBitmap, 4))
     {
         DPRINT1("Conversion failed\n");
         ExFreePoolWithTag(NewEntry, TAG_FONT);


### PR DESCRIPTION
## Purpose
Currently, our `FT_Bitmap_Convert` function has a hack to make the bitmap image compatible to ReactOS.
I think the hack on `FT_Bitmap_Convert` should be separated from our font engine.
JIRA issue: [CORE-16047](https://jira.reactos.org/browse/CORE-16047)

## Proposed changes

- Add `FT_Bitmap_Convert_ReactOS_Hack` function, that is based on `FT_Bitmap_Convert`, and split the hack of `FT_Bitmap_Convert`.
- Use `FT_Bitmap_Convert_ReactOS_Hack` in `IntGetBitmapGlyphWithCache` function instead of `FT_Bitmap_Convert`.
- Modify `ftfd.spec` to add `FT_Bitmap_Convert_ReactOS_Hack`.

## TODO

- [x] Do tests.