### PR TITLE
[FREETYPE][NTGDI] Fix ftGdiGetTextMetricsW return for raster fonts

### DIFF
--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -5320,15 +5320,15 @@ ftGdiGetTextMetricsW(
             IntLockFreeType();
 
             Error = FT_Get_WinFNT_Header(Face, &Win);
-
             pOS2 = FT_Get_Sfnt_Table(Face, ft_sfnt_os2);
+            pHori = FT_Get_Sfnt_Table(Face, ft_sfnt_hhea);
+
             if (!pOS2 && Error)
             {
                 DPRINT1("Can't find OS/2 table - not TT font?\n");
                 Status = STATUS_INTERNAL_ERROR;
             }
 
-            pHori = FT_Get_Sfnt_Table(Face, ft_sfnt_hhea);
             if (!pHori && Error)
             {
                 DPRINT1("Can't find HHEA table - not TT font?\n");

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -3164,7 +3164,7 @@ IntGetOutlineTextMetrics(PFONTGDI FontGDI,
 
     Otm->otmSize = Cache->OutlineRequiredSize;
 
-    FillTM(&Otm->otmTextMetrics, FontGDI, pOS2, pHori, !Error ? &WinFNT : 0);
+    FillTM(&Otm->otmTextMetrics, FontGDI, pOS2, pHori, (Error ? NULL : &WinFNT));
 
     if (!pOS2)
         goto skip_os2;
@@ -5318,25 +5318,26 @@ ftGdiGetTextMetricsW(
             Status = STATUS_SUCCESS;
 
             IntLockFreeType();
+
+            Error = FT_Get_WinFNT_Header(Face, &Win);
+
             pOS2 = FT_Get_Sfnt_Table(Face, ft_sfnt_os2);
-            if (NULL == pOS2)
+            if (!pOS2 && Error)
             {
                 DPRINT1("Can't find OS/2 table - not TT font?\n");
                 Status = STATUS_INTERNAL_ERROR;
             }
 
             pHori = FT_Get_Sfnt_Table(Face, ft_sfnt_hhea);
-            if (NULL == pHori)
+            if (!pHori && Error)
             {
                 DPRINT1("Can't find HHEA table - not TT font?\n");
                 Status = STATUS_INTERNAL_ERROR;
             }
 
-            Error = FT_Get_WinFNT_Header(Face, &Win);
-
-            if (NT_SUCCESS(Status) || !Error)
+            if (NT_SUCCESS(Status))
             {
-                FillTM(&ptmwi->TextMetric, FontGDI, pOS2, pHori, !Error ? &Win : 0);
+                FillTM(&ptmwi->TextMetric, FontGDI, pOS2, pHori, (Error ? NULL : &Win));
 
                 /* FIXME: Fill Diff member */
             }


### PR DESCRIPTION
## Purpose
Try to get ready to support raster fonts.
JIRA issue: [CORE-17327](https://jira.reactos.org/browse/CORE-17327)

## Proposed changes

- Fix the return value of `ftGdiGetTextMetricsW` function for raster fonts.

## Comparison

BEFORE (with enabling raster fonts):
![before](https://github.com/user-attachments/assets/426467c3-56d8-40ba-871b-1b6354be9515)
No text displaying.

AFTER (with enabling raster fonts):
![after](https://github.com/user-attachments/assets/05ce6a6f-1251-4500-aad2-333f108add94)
At least, it displays text.