### PR TITLE
[SHLWAPI] Import Wine fixes for PathUndecorate and PathRemoveBlanks

### DIFF
--- a/dll/win32/shlwapi/path.c
+++ b/dll/win32/shlwapi/path.c
@@ -4061,31 +4061,23 @@ LPCWSTR WINAPI PathFindSuffixArrayW(LPCWSTR lpszSuffix, LPCWSTR *lppszArray, int
  * NOTES
  *  A decorations form is "path[n].ext" where "n" is an optional decimal number.
  */
-VOID WINAPI PathUndecorateA(LPSTR lpszPath)
+void WINAPI PathUndecorateA(LPSTR pszPath)
 {
-  TRACE("(%s)\n",debugstr_a(lpszPath));
+  char *ext, *skip;
 
-  if (lpszPath)
-  {
-    LPSTR lpszExt = PathFindExtensionA(lpszPath);
-    if (lpszExt > lpszPath && lpszExt[-1] == ']')
-    {
-      LPSTR lpszSkip = lpszExt - 2;
-      if (*lpszSkip == '[')
-        lpszSkip++;  /* [] (no number) */
-      else
-        while (lpszSkip > lpszPath && isdigit(lpszSkip[-1]))
-          lpszSkip--;
-      if (lpszSkip > lpszPath && lpszSkip[-1] == '[' && lpszSkip[-2] != '\\')
-      {
-        /* remove the [n] */
-        lpszSkip--;
-        while (*lpszExt)
-          *lpszSkip++ = *lpszExt++;
-        *lpszSkip = '\0';
-      }
-    }
-  }
+  TRACE("(%s)\n", debugstr_a(pszPath));
+
+  if (!pszPath) return;
+
+  ext = PathFindExtensionA(pszPath);
+  if (ext == pszPath || ext[-1] != ']') return;
+
+  skip = ext - 2;
+  while (skip > pszPath && '0' <= *skip && *skip <= '9')
+      skip--;
+
+  if (skip > pszPath && *skip == '[' && skip[-1] != '\\')
+      memmove(skip, ext, strlen(ext) + 1);
 }
 
 /*************************************************************************
@@ -4093,31 +4085,23 @@ VOID WINAPI PathUndecorateA(LPSTR lpszPath)
  *
  * See PathUndecorateA.
  */
-VOID WINAPI PathUndecorateW(LPWSTR lpszPath)
+void WINAPI PathUndecorateW(LPWSTR pszPath)
 {
-  TRACE("(%s)\n",debugstr_w(lpszPath));
+  WCHAR *ext, *skip;
 
-  if (lpszPath)
-  {
-    LPWSTR lpszExt = PathFindExtensionW(lpszPath);
-    if (lpszExt > lpszPath && lpszExt[-1] == ']')
-    {
-      LPWSTR lpszSkip = lpszExt - 2;
-      if (*lpszSkip == '[')
-        lpszSkip++; /* [] (no number) */
-      else
-        while (lpszSkip > lpszPath && isdigitW(lpszSkip[-1]))
-          lpszSkip--;
-      if (lpszSkip > lpszPath && lpszSkip[-1] == '[' && lpszSkip[-2] != '\\')
-      {
-        /* remove the [n] */
-        lpszSkip--;
-        while (*lpszExt)
-          *lpszSkip++ = *lpszExt++;
-        *lpszSkip = '\0';
-      }
-    }
-  }
+  TRACE("(%s)\n", debugstr_w(pszPath));
+
+  if (!pszPath) return;
+
+  ext = PathFindExtensionW(pszPath);
+  if (ext == pszPath || ext[-1] != ']') return;
+
+  skip = ext - 2;
+  while (skip > pszPath && '0' <= *skip && *skip <= '9')
+      skip--;
+
+  if (skip > pszPath && *skip == '[' && skip[-1] != '\\')
+      memmove(skip, ext, (wcslen(ext) + 1) * sizeof(WCHAR));
 }
 
 /*************************************************************************

--- a/dll/win32/shlwapi/path.c
+++ b/dll/win32/shlwapi/path.c
@@ -891,25 +891,28 @@ LPWSTR WINAPI PathRemoveBackslashW( LPWSTR lpszPath )
  * RETURNS
  *  Nothing.
  */
-VOID WINAPI PathRemoveBlanksA(LPSTR lpszPath)
+void WINAPI PathRemoveBlanksA(LPSTR pszPath)
 {
-  TRACE("(%s)\n", debugstr_a(lpszPath));
+    LPSTR start, first;
 
-  if(lpszPath && *lpszPath)
-  {
-    LPSTR start = lpszPath;
+    TRACE("(%s)\n", debugstr_a(pszPath));
 
-    while (*lpszPath == ' ')
-      lpszPath = CharNextA(lpszPath);
+    if (!pszPath || !*pszPath)
+        return;
 
-    while(*lpszPath)
-      *start++ = *lpszPath++;
+    start = first = pszPath;
 
-    if (start != lpszPath)
-      while (start[-1] == ' ')
-        start--;
+    while (*pszPath == ' ')
+        pszPath = CharNextA(pszPath);
+
+    while (*pszPath)
+        *start++ = *pszPath++;
+
+    if (start != first)
+        while (start[-1] == ' ')
+            start--;
+
     *start = '\0';
-  }
 }
 
 /*************************************************************************
@@ -917,25 +920,28 @@ VOID WINAPI PathRemoveBlanksA(LPSTR lpszPath)
  *
  * See PathRemoveBlanksA.
  */
-VOID WINAPI PathRemoveBlanksW(LPWSTR lpszPath)
+void WINAPI PathRemoveBlanksW(LPWSTR pszPath)
 {
-  TRACE("(%s)\n", debugstr_w(lpszPath));
+    LPWSTR start, first;
 
-  if(lpszPath && *lpszPath)
-  {
-    LPWSTR start = lpszPath;
+    TRACE("(%s)\n", debugstr_w(pszPath));
 
-    while (*lpszPath == ' ')
-      lpszPath++;
+    if (!pszPath || !*pszPath)
+        return;
 
-    while(*lpszPath)
-      *start++ = *lpszPath++;
+    start = first = pszPath;
 
-    if (start != lpszPath)
-      while (start[-1] == ' ')
-        start--;
+    while (*pszPath == ' ')
+        pszPath++;
+
+    while (*pszPath)
+        *start++ = *pszPath++;
+
+    if (start != first)
+        while (start[-1] == ' ')
+            start--;
+
     *start = '\0';
-  }
 }
 
 /*************************************************************************

--- a/modules/rostests/winetests/shlwapi/path.c
+++ b/modules/rostests/winetests/shlwapi/path.c
@@ -1712,6 +1712,50 @@ static void test_PathUndecorate(void)
     PathUndecorateW(NULL);
 }
 
+static void test_PathRemoveBlanks(void)
+{
+    struct remove_blanks_test {
+        const char* input;
+        const char* expected;
+    };
+    struct remove_blanks_test tests[] = {
+        {"", ""},
+        {" ", ""},
+        {"test", "test"},
+        {" test", "test"},
+        {"  test", "test"},
+        {"test ", "test"},
+        {"test  ", "test"},
+        {" test  ", "test"},
+        {"  test ", "test"}};
+    char pathA[MAX_PATH];
+    WCHAR pathW[MAX_PATH];
+    int i, ret;
+    const UINT CP_ASCII = 20127;
+
+    PathRemoveBlanksW(NULL);
+    PathRemoveBlanksA(NULL);
+
+    for (i=0; i < ARRAY_SIZE(tests); i++)
+    {
+        strcpy(pathA, tests[i].input);
+        PathRemoveBlanksA(pathA);
+        ok(strcmp(pathA, tests[i].expected) == 0, "input string '%s', expected '%s', got '%s'\n",
+            tests[i].input, tests[i].expected, pathA);
+
+        ret = MultiByteToWideChar(CP_ASCII, MB_ERR_INVALID_CHARS, tests[i].input, -1, pathW, MAX_PATH);
+        ok(ret != 0, "MultiByteToWideChar failed for '%s'\n", tests[i].input);
+
+        PathRemoveBlanksW(pathW);
+
+        ret = WideCharToMultiByte(CP_ASCII, 0, pathW, -1, pathA, MAX_PATH, NULL, NULL);
+        ok(ret != 0, "WideCharToMultiByte failed for %s from test string '%s'\n", wine_dbgstr_w(pathW), tests[i].input);
+
+        ok(strcmp(pathA, tests[i].expected) == 0, "input string '%s', expected '%s', got '%s'\n",
+            tests[i].input, tests[i].expected, pathA);
+    }
+}
+
 START_TEST(path)
 {
     HMODULE hShlwapi = GetModuleHandleA("shlwapi.dll");
@@ -1759,4 +1803,5 @@ START_TEST(path)
     test_PathIsRelativeW();
     test_PathStripPathA();
     test_PathUndecorate();
+    test_PathRemoveBlanks();
 }

--- a/modules/rostests/winetests/shlwapi/path.c
+++ b/modules/rostests/winetests/shlwapi/path.c
@@ -1672,6 +1672,46 @@ static void test_PathStripPathA(void)
     PathStripPathA((char*)const_path);
 }
 
+static void test_PathUndecorate(void)
+{
+    static const struct {
+        const WCHAR *path;
+        const WCHAR *expect;
+    } tests[] = {
+        { L"c:\\test\\a[123]",          L"c:\\test\\a" },
+        { L"c:\\test\\a[123].txt",      L"c:\\test\\a.txt" },
+        { L"c:\\test\\a.txt[123]",      L"c:\\test\\a.txt[123]" },
+        { L"c:\\test\\a[123a].txt",     L"c:\\test\\a[123a].txt" },
+        { L"c:\\test\\a[a123].txt",     L"c:\\test\\a[a123].txt" },
+        { L"c:\\test\\a[12\x0660].txt", L"c:\\test\\a[12\x0660].txt" },
+        { L"c:\\test\\a[12]file",       L"c:\\test\\a[12]file" },
+        { L"c:\\test[123]\\a",          L"c:\\test[123]\\a" },
+        { L"c:\\test\\[123]",           L"c:\\test\\[123]" },
+        { L"a[123]",                    L"a" },
+        { L"a[]",                       L"a" },
+        { L"[123]",                     L"[123]" }
+    };
+    char bufa[MAX_PATH], expect[MAX_PATH];
+    WCHAR buf[MAX_PATH];
+    unsigned i;
+
+    for (i = 0; i < ARRAY_SIZE(tests); i++)
+    {
+        wcscpy(buf, tests[i].path);
+        PathUndecorateW(buf);
+        ok(!wcscmp(buf, tests[i].expect), "PathUndecorateW returned %s, expected %s\n",
+           wine_dbgstr_w(buf), wine_dbgstr_w(tests[i].expect));
+
+        WideCharToMultiByte(CP_ACP, WC_NO_BEST_FIT_CHARS, tests[i].path, -1, bufa, ARRAY_SIZE(bufa), "?", NULL);
+        WideCharToMultiByte(CP_ACP, WC_NO_BEST_FIT_CHARS, tests[i].expect, -1, expect, ARRAY_SIZE(expect), "?", NULL);
+        PathUndecorateA(bufa);
+        ok(!strcmp(bufa, expect), "PathUndecorateA returned %s, expected %s\n", bufa, expect);
+    }
+
+    PathUndecorateA(NULL);
+    PathUndecorateW(NULL);
+}
+
 START_TEST(path)
 {
     HMODULE hShlwapi = GetModuleHandleA("shlwapi.dll");
@@ -1718,4 +1758,5 @@ START_TEST(path)
     test_PathIsRelativeA();
     test_PathIsRelativeW();
     test_PathStripPathA();
+    test_PathUndecorate();
 }


### PR DESCRIPTION
## Purpose

Import fixes for PathUndecorate and PathRemoveBlanks from Wine.
Needed for PR #7633.

## Proposed changes

- ### `[SHLWAPI][WINESYNC] Import PathUndecorate wine fix + adaptation for ReactOS.`
  ```
  shlwapi: Fix PathUndecorate[AW] implementation.

  Signed-off-by: Jacek Caban <jacek@codeweavers.com>
  Signed-off-by: Alexandre Julliard <julliard@winehq.org>

  wine commit id f3c1d663a4a4a99b5c07000cb0ad9cc55d1e1c88 by Jacek Caban <jacek@codeweavers.com>
  ```

- ### `[SHLWAPI][WINESYNC] Import PathRemoveBlanks wine fix + adaptation for ReactOS.`
  ```
  kernelbase: Always remove trailing spaces in PathRemoveBlanks.

  Signed-off-by: Esme Povirk <esme@codeweavers.com>
  Signed-off-by: Alexandre Julliard <julliard@winehq.org>

  wine commit id 404cd8a92bd99332a7ef8ec96edbf5aeea8cab76 by Esme Povirk <esme@codeweavers.com>
  ```

## Test results

- Test VBox: ✅ https://reactos.org/testman/compare.php?ids=99828,99832
- Test KVM: ✅ https://reactos.org/testman/compare.php?ids=99827,99833
- Test KVM_x64: ✅ https://reactos.org/testman/compare.php?ids=99831,99836