### PR TITLE
[NTOS] Fix PEB affinity [NTDLL] Silence LdrpValidateImageForMp

### DIFF
--- a/dll/ntdll/ldr/ldrinit.c
+++ b/dll/ntdll/ldr/ldrinit.c
@@ -1538,7 +1538,9 @@ VOID
 NTAPI
 LdrpValidateImageForMp(IN PLDR_DATA_TABLE_ENTRY LdrDataTableEntry)
 {
-    UNIMPLEMENTED;
+    DPRINT("LdrpValidateImageForMp is unimplemented\n");
+    // TODO:
+    // Scan the LockPrefixTable in the load config directory
 }
 
 BOOLEAN

--- a/ntoskrnl/mm/ARM3/procsup.c
+++ b/ntoskrnl/mm/ARM3/procsup.c
@@ -20,6 +20,7 @@
 ULONG MmProcessColorSeed = 0x12345678;
 ULONG MmMaximumDeadKernelStacks = 5;
 SLIST_HEADER MmDeadStackSListHead;
+ULONG MmRotatingUniprocessorNumber = 0;
 
 /* PRIVATE FUNCTIONS **********************************************************/
 
@@ -526,7 +527,6 @@ MmCreatePeb(IN PEPROCESS Process,
     PIMAGE_LOAD_CONFIG_DIRECTORY ImageConfigData;
     NTSTATUS Status;
     USHORT Characteristics;
-    KAFFINITY ProcessAffinityMask = 0;
     SectionOffset.QuadPart = (ULONGLONG)0;
     *BasePeb = NULL;
 
@@ -606,6 +606,7 @@ MmCreatePeb(IN PEPROCESS Process,
         // Heap and Debug Data
         //
         Peb->NumberOfProcessors = KeNumberProcessors;
+        Peb->ImageProcessAffinityMask = KeActiveProcessors;
         Peb->BeingDebugged = (BOOLEAN)(Process->DebugPort != NULL);
         Peb->NtGlobalFlag = NtGlobalFlag;
         Peb->HeapSegmentReserve = MmHeapSegmentReserve;
@@ -712,7 +713,7 @@ MmCreatePeb(IN PEPROCESS Process,
             if ((ImageConfigData) && (ImageConfigData->ProcessAffinityMask))
             {
                 /* Take the value from the image configuration directory */
-                ProcessAffinityMask = ImageConfigData->ProcessAffinityMask;
+                Peb->ImageProcessAffinityMask = ImageConfigData->ProcessAffinityMask;
             }
 
             //
@@ -720,17 +721,12 @@ MmCreatePeb(IN PEPROCESS Process,
             if (Characteristics & IMAGE_FILE_UP_SYSTEM_ONLY)
             {
                 //
-                // Force it to use CPU 0
+                // Set single processor rotating affinity.
+                // See https://www.microsoftpressstore.com/articles/article.aspx?p=2233328&seqNum=3
                 //
-                /* FIXME: this should use the MmRotatingUniprocessorNumber */
-                Peb->ImageProcessAffinityMask = 0;
-            }
-            else
-            {
-                //
-                // Whatever was configured
-                //
-                Peb->ImageProcessAffinityMask = ProcessAffinityMask;
+                Peb->ImageProcessAffinityMask = AFFINITY_MASK(MmRotatingUniprocessorNumber);
+                ASSERT(Peb->ImageProcessAffinityMask & KeActiveProcessors);
+                MmRotatingUniprocessorNumber = (MmRotatingUniprocessorNumber + 1) % KeNumberProcessors;
             }
         }
         _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)


### PR DESCRIPTION
## Purpose

[NTOS:MM] Fix process affinity in MmCreatePeb
[NTDLL] Demote UNIMPLEMENTED to DPRINT in LdrpValidateImageForMp to silence spam on SMP builds

## Test
- ✅ KVM x86: https://reactos.org/testman/compare.php?ids=99946,99949,99953
