### PR TITLE
[NTOS:KE] Make KeQueryActiveProcessors portable and non-paged

### DIFF
--- a/ntoskrnl/ke/amd64/cpu.c
+++ b/ntoskrnl/ke/amd64/cpu.c
@@ -667,16 +667,6 @@ KeFlushEntireTb(IN BOOLEAN Invalid,
 
 }
 
-KAFFINITY
-NTAPI
-KeQueryActiveProcessors(VOID)
-{
-    PAGED_CODE();
-
-    /* Simply return the number of active processors */
-    return KeActiveProcessors;
-}
-
 NTSTATUS
 NTAPI
 KxSaveFloatingPointState(OUT PKFLOATING_SAVE FloatingState)

--- a/ntoskrnl/ke/arm/cpu.c
+++ b/ntoskrnl/ke/arm/cpu.c
@@ -156,21 +156,6 @@ KeSetDmaIoCoherency(IN ULONG Coherency)
 /*
  * @implemented
  */
-KAFFINITY
-NTAPI
-KeQueryActiveProcessors(VOID)
-{
-    PAGED_CODE();
-
-    //
-    // Simply return the number of active processors
-    //
-    return KeActiveProcessors;
-}
-
-/*
- * @implemented
- */
 VOID
 __cdecl
 KeSaveStateForHibernate(IN PKPROCESSOR_STATE State)

--- a/ntoskrnl/ke/i386/cpu.c
+++ b/ntoskrnl/ke/i386/cpu.c
@@ -1652,19 +1652,6 @@ KeSetDmaIoCoherency(IN ULONG Coherency)
 /*
  * @implemented
  */
-KAFFINITY
-NTAPI
-KeQueryActiveProcessors(VOID)
-{
-    PAGED_CODE();
-
-    /* Simply return the number of active processors */
-    return KeActiveProcessors;
-}
-
-/*
- * @implemented
- */
 VOID
 __cdecl
 KeSaveStateForHibernate(IN PKPROCESSOR_STATE State)

--- a/ntoskrnl/ke/krnlinit.c
+++ b/ntoskrnl/ke/krnlinit.c
@@ -20,7 +20,6 @@ USHORT KeProcessorArchitecture;
 USHORT KeProcessorLevel;
 USHORT KeProcessorRevision;
 ULONG KeFeatureBits;
-KAFFINITY KeActiveProcessors = 1;
 
 /* System call count */
 ULONG KiServiceLimit = NUMBER_OF_SYSCALLS;
@@ -30,9 +29,6 @@ PLOADER_PARAMETER_BLOCK KeLoaderBlock;
 
 /* PRCB Array */
 PKPRCB KiProcessorBlock[MAXIMUM_PROCESSORS];
-
-/* Number of processors */
-CCHAR KeNumberProcessors = 0;
 
 /* NUMA Node Support */
 KNODE KiNode0;

--- a/ntoskrnl/ke/processor.c
+++ b/ntoskrnl/ke/processor.c
@@ -1,0 +1,26 @@
+/*
+ * PROJECT:     ReactOS Kernel
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     Portable processor related routines
+ * COPYRIGHT:   Copyright 2025 Timo Kreuzer <timo.kreuzer@reactos.org>
+ */
+
+/* INCLUDES ******************************************************************/
+
+#include <ntoskrnl.h>
+#define NDEBUG
+#include <debug.h>
+
+/* GLOBALS *******************************************************************/
+
+CCHAR KeNumberProcessors = 0;
+KAFFINITY KeActiveProcessors = 0;
+
+/* FUNCTIONS *****************************************************************/
+
+KAFFINITY
+NTAPI
+KeQueryActiveProcessors(VOID)
+{
+    return KeActiveProcessors;
+}

--- a/ntoskrnl/ntos.cmake
+++ b/ntoskrnl/ntos.cmake
@@ -186,6 +186,7 @@ list(APPEND SOURCE
     ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/ipi.c
     ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/krnlinit.c
     ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/mutex.c
+    ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/processor.c
     ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/procobj.c
     ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/profobj.c
     ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/queue.c


### PR DESCRIPTION
In Windows Vista and later, this routine can be called at any IRQL.
