### PR TITLE
[SHELL32] SHELL_FindExecutable: Fix last regression from PR#7588

### DIFF
--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -796,12 +796,10 @@ static UINT SHELL_FindExecutable(LPCWSTR lpPath, LPCWSTR lpFile, LPCWSTR lpVerb,
         PathRemoveBlanksW(xlpFile);
 
         /* Clear any trailing periods */
-        for (SIZE_T i = wcslen(xlpFile); i > 0; i--)
+        SIZE_T i = wcslen(xlpFile);
+        while (i > 0 && xlpFile[i - 1] == '.')
         {
-            if (xlpFile[i - 1] == '.')
-                xlpFile[i - 1] = '\0';
-            else
-                break;
+            xlpFile[--i] = '\0';
         }
 
         lstrcpyW(lpResult, xlpFile);

--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -794,21 +794,22 @@ static UINT SHELL_FindExecutable(LPCWSTR lpPath, LPCWSTR lpFile, LPCWSTR lpVerb,
         TRACE("PathResolveW returned non-zero\n");
         lpFile = xlpFile;
         PathRemoveBlanksW(xlpFile);
+
+        /* Clear any trailing periods */
+        for (SIZE_T i = wcslen(xlpFile); i > 0; i--)
+        {
+            if (i > 0 && xlpFile[i - 1] == '.')
+                xlpFile[i - 1] = '\0';
+            else
+                break;
+        }
+
         lstrcpyW(lpResult, xlpFile);
         /* The file was found in lpPath or one of the directories in the system-wide search path */
     }
     else
     {
         xlpFile[0] = '\0';
-    }
-
-    /* Clear any trailing periods */
-    for (SIZE_T i = wcslen(xlpFile); i > 0; i--)
-    {
-        if (i > 0 && xlpFile[i - 1] == '.')
-            xlpFile[i - 1] = '\0';
-        else
-            break;
     }
 
     attribs = GetFileAttributesW(lpFile);

--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -798,7 +798,7 @@ static UINT SHELL_FindExecutable(LPCWSTR lpPath, LPCWSTR lpFile, LPCWSTR lpVerb,
         /* Clear any trailing periods */
         for (SIZE_T i = wcslen(xlpFile); i > 0; i--)
         {
-            if (i > 0 && xlpFile[i - 1] == '.')
+            if (xlpFile[i - 1] == '.')
                 xlpFile[i - 1] = '\0';
             else
                 break;

--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -806,7 +806,7 @@ static UINT SHELL_FindExecutable(LPCWSTR lpPath, LPCWSTR lpFile, LPCWSTR lpVerb,
     for (SIZE_T i = wcslen(xlpFile); i > 0; i--)
     {
         if (i > 0 && xlpFile[i - 1] == '.')
-            xlpFile[i - 1] = 0;
+            xlpFile[i - 1] = '\0';
         else
             break;
     }

--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -802,6 +802,15 @@ static UINT SHELL_FindExecutable(LPCWSTR lpPath, LPCWSTR lpFile, LPCWSTR lpVerb,
         xlpFile[0] = '\0';
     }
 
+  /* Clear any trailing periods */
+  for (INT i = wcslen(xlpFile); i >= 0; i--)
+  {
+      if (i > 0 && xlpFile[i - 1] == '.')
+          xlpFile[i - 1] = 0;
+      else
+          break;
+   }
+
     attribs = GetFileAttributesW(lpFile);
     if (attribs != INVALID_FILE_ATTRIBUTES && (attribs & FILE_ATTRIBUTE_DIRECTORY))
     {

--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -802,14 +802,14 @@ static UINT SHELL_FindExecutable(LPCWSTR lpPath, LPCWSTR lpFile, LPCWSTR lpVerb,
         xlpFile[0] = '\0';
     }
 
-  /* Clear any trailing periods */
-  for (SIZE_T i = wcslen(xlpFile);i > 0; i--)
-  {
-      if (i > 0 && xlpFile[i - 1] == '.')
-          xlpFile[i - 1] = 0;
-      else
-          break;
-   }
+    /* Clear any trailing periods */
+    for (SIZE_T i = wcslen(xlpFile); i > 0; i--)
+    {
+        if (i > 0 && xlpFile[i - 1] == '.')
+            xlpFile[i - 1] = 0;
+        else
+            break;
+    }
 
     attribs = GetFileAttributesW(lpFile);
     if (attribs != INVALID_FILE_ATTRIBUTES && (attribs & FILE_ATTRIBUTE_DIRECTORY))

--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -803,7 +803,7 @@ static UINT SHELL_FindExecutable(LPCWSTR lpPath, LPCWSTR lpFile, LPCWSTR lpVerb,
     }
 
   /* Clear any trailing periods */
-  for (INT i = wcslen(xlpFile); i >= 0; i--)
+  for (SIZE_T i = wcslen(xlpFile);i > 0; i--)
   {
       if (i > 0 && xlpFile[i - 1] == '.')
           xlpFile[i - 1] = 0;


### PR DESCRIPTION
## Purpose

_PR#7588 caused regressions in shell32:shlexec tests. This should fix the last one._

JIRA issue: [CORE-19964](https://jira.reactos.org/browse/CORE-19964)

## Proposed changes

_After the commit of PR's #7588 & #7633 there was still one regression in the shell32:shlexec regression test._
_The failure was in the processing of a path that contained a period (full stop) at the end._
_This adds processing to remove any trailing periods and fixes this last regression._

Testbot Results:
refs/pull/7643/merge on 0.4.16-dev-545-gb87c6b8

KVM:  https://reactos.org/testman/compare.php?ids=99904,99908,99912 LGTM
VBox: https://reactos.org/testman/compare.php?ids=99905,99909,99914 LGTM

shell32:shlexec is now back to 35 failures, which is the same as before the first PR commit
Plus, more total tests are now run at 1631 than were run before at 1622.

After Second Commit

KVM:  https://reactos.org/testman/compare.php?ids=99904,99908,99927 LGTM
VBox: https://reactos.org/testman/compare.php?ids=99905,99909,99928 LGTM

After 7th Commit

KVM:  https://reactos.org/testman/compare.php?ids=99904,99908,99967 LGTM
VBox: https://reactos.org/testman/compare.php?ids=99905,99909,99968 LGTM