### PR TITLE
[EXPLORER] Support Unicode on Start Button InvokeCommand

### DIFF
--- a/base/shell/explorer/startctxmnu.cpp
+++ b/base/shell/explorer/startctxmnu.cpp
@@ -196,13 +196,12 @@ public:
         if (!IsShellCmdId(uiCmdId))
         {
             CMINVOKECOMMANDINFOEX cmici = { sizeof(cmici) };
-            CHAR szDirA[MAX_PATH];
-            WCHAR szDirW[MAX_PATH], szVerbW[MAX_PATH];
 
             /* Setup and invoke the shell command */
             cmici.hwnd = m_Owner;
             cmici.nShow = SW_NORMAL;
             cmici.fMask = CMIC_MASK_UNICODE;
+            WCHAR szVerbW[MAX_PATH];
             if (IS_INTRESOURCE(lpici->lpVerb))
             {
                 cmici.lpVerb = MAKEINTRESOURCEA(uiCmdId - INNERIDOFFSET);
@@ -215,11 +214,13 @@ public:
                 cmici.lpVerbW = szVerbW;
             }
 
+            CHAR szDirA[MAX_PATH];
+            WCHAR szDirW[MAX_PATH];
             if (SHGetPathFromIDListW(m_FolderPidl, szDirW))
             {
-                cmici.lpDirectoryW = szDirW;
                 SHUnicodeToAnsi(szDirW, szDirA, _countof(szDirA));
                 cmici.lpDirectory = szDirA;
+                cmici.lpDirectoryW = szDirW;
             }
 
             return m_Inner->InvokeCommand((CMINVOKECOMMANDINFO *)&cmici);

--- a/base/shell/explorer/startctxmnu.cpp
+++ b/base/shell/explorer/startctxmnu.cpp
@@ -223,7 +223,7 @@ public:
                 cmici.lpDirectoryW = szDirW;
             }
 
-            return m_Inner->InvokeCommand((CMINVOKECOMMANDINFO *)&cmici);
+            return m_Inner->InvokeCommand((LPCMINVOKECOMMANDINFO)&cmici);
         }
         m_TrayWnd->ExecContextMenuCmd(uiCmdId);
         return S_OK;

--- a/base/shell/explorer/startctxmnu.cpp
+++ b/base/shell/explorer/startctxmnu.cpp
@@ -196,7 +196,8 @@ public:
         if (!IsShellCmdId(uiCmdId))
         {
             CMINVOKECOMMANDINFOEX cmici = { sizeof(cmici) };
-            WCHAR szDir[MAX_PATH], szVerb[MAX_PATH];
+            CHAR szDirA[MAX_PATH];
+            WCHAR szDirW[MAX_PATH], szVerbW[MAX_PATH];
 
             /* Setup and invoke the shell command */
             cmici.hwnd = m_Owner;
@@ -204,16 +205,22 @@ public:
             cmici.fMask = CMIC_MASK_UNICODE;
             if (IS_INTRESOURCE(lpici->lpVerb))
             {
+                cmici.lpVerb = MAKEINTRESOURCEA(uiCmdId - INNERIDOFFSET);
                 cmici.lpVerbW = MAKEINTRESOURCEW(uiCmdId - INNERIDOFFSET);
             }
             else
             {
-                SHAnsiToUnicode(lpici->lpVerb, szVerb, _countof(szVerb));
-                cmici.lpVerbW = szVerb;
+                cmici.lpVerb = lpici->lpVerb;
+                SHAnsiToUnicode(lpici->lpVerb, szVerbW, _countof(szVerbW));
+                cmici.lpVerbW = szVerbW;
             }
 
-            if (SHGetPathFromIDListW(m_FolderPidl, szDir))
-                cmici.lpDirectoryW = szDir;
+            if (SHGetPathFromIDListW(m_FolderPidl, szDirW))
+            {
+                cmici.lpDirectoryW = szDirW;
+                SHUnicodeToAnsi(szDirW, szDirA, _countof(szDirA));
+                cmici.lpDirectory = szDirA;
+            }
 
             return m_Inner->InvokeCommand((CMINVOKECOMMANDINFO *)&cmici);
         }


### PR DESCRIPTION
## Purpose
Support Unicode on Start Button context menu for international text support.
JIRA issue: N/A

## Proposed changes

- Support Unicode in `CStartMenuBtnCtxMenu::InvokeCommand` method by using `CMINVOKECOMMANDINFOEX` structure.

## TODO

- [x] Do tests.