### PR TITLE
[EXPLORER] Use STDMETHODIMP and override

### DIFF
--- a/base/shell/explorer/startctxmnu.cpp
+++ b/base/shell/explorer/startctxmnu.cpp
@@ -189,7 +189,8 @@ public:
         return hRet;
     }
 
-    STDMETHODIMP InvokeCommand(LPCMINVOKECOMMANDINFO lpici) override
+    STDMETHODIMP
+    InvokeCommand(LPCMINVOKECOMMANDINFO lpici) override
     {
         UINT uiCmdId = PtrToUlong(lpici->lpVerb);
         if (!IsShellCmdId((UINT_PTR)lpici->lpVerb))

--- a/base/shell/explorer/startctxmnu.cpp
+++ b/base/shell/explorer/startctxmnu.cpp
@@ -145,12 +145,12 @@ public:
         return S_OK;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE
-        QueryContextMenu(HMENU hPopup,
-                         UINT indexMenu,
-                         UINT idCmdFirst,
-                         UINT idCmdLast,
-                         UINT uFlags)
+    STDMETHODIMP
+    QueryContextMenu(HMENU hPopup,
+                     UINT indexMenu,
+                     UINT idCmdFirst,
+                     UINT idCmdLast,
+                     UINT uFlags) override
     {
         LPITEMIDLIST pidlStart;
         CComPtr<IShellFolder> psfDesktop;
@@ -189,8 +189,7 @@ public:
         return hRet;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE
-        InvokeCommand(LPCMINVOKECOMMANDINFO lpici)
+    STDMETHODIMP InvokeCommand(LPCMINVOKECOMMANDINFO lpici) override
     {
         UINT uiCmdId = PtrToUlong(lpici->lpVerb);
         if (!IsShellCmdId((UINT_PTR)lpici->lpVerb))
@@ -219,12 +218,12 @@ public:
         return S_OK;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE
-        GetCommandString(UINT_PTR idCmd,
-                         UINT uType,
-                         UINT *pwReserved,
-                         LPSTR pszName,
-                         UINT cchMax)
+    STDMETHODIMP GetCommandString(
+        UINT_PTR idCmd,
+        UINT uType,
+        UINT *pwReserved,
+        LPSTR pszName,
+        UINT cchMax) override
     {
         if (!IsShellCmdId(idCmd) && m_Inner)
             return m_Inner->GetCommandString(idCmd, uType, pwReserved, pszName, cchMax);

--- a/base/shell/explorer/startctxmnu.cpp
+++ b/base/shell/explorer/startctxmnu.cpp
@@ -218,7 +218,8 @@ public:
         return S_OK;
     }
 
-    STDMETHODIMP GetCommandString(
+    STDMETHODIMP
+    GetCommandString(
         UINT_PTR idCmd,
         UINT uType,
         UINT *pwReserved,

--- a/base/shell/explorer/startmnusite.cpp
+++ b/base/shell/explorer/startmnusite.cpp
@@ -37,12 +37,12 @@ public:
 
     virtual ~CStartMenuSite() {}
 
-    /*******************************************************************/
+    // *** IServiceProvider methods ***
 
-    virtual HRESULT STDMETHODCALLTYPE QueryService(
+    STDMETHODIMP QueryService(
         IN REFGUID guidService,
         IN REFIID riid,
-        OUT PVOID *ppvObject)
+        OUT PVOID *ppvObject) override
     {
         if (IsEqualGUID(guidService, SID_SMenuPopup))
         {
@@ -52,10 +52,9 @@ public:
         return E_NOINTERFACE;
     }
 
-    /*******************************************************************/
+    // *** IOleWindow methods ***
 
-    virtual HRESULT STDMETHODCALLTYPE GetWindow(
-        OUT HWND *phwnd)
+    STDMETHODIMP GetWindow(OUT HWND *phwnd) override
     {
         TRACE("ITrayPriv::GetWindow\n");
 
@@ -66,16 +65,15 @@ public:
         return E_FAIL;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE ContextSensitiveHelp(
-        IN BOOL fEnterMode)
+    STDMETHODIMP ContextSensitiveHelp(IN BOOL fEnterMode) override
     {
         TRACE("ITrayPriv::ContextSensitiveHelp\n");
         return E_NOTIMPL;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE Execute(
+    STDMETHODIMP Execute(
         IN IShellFolder *pShellFolder,
-        IN LPCITEMIDLIST pidl)
+        IN LPCITEMIDLIST pidl) override
     {
         HRESULT ret = S_FALSE;
 
@@ -86,11 +84,11 @@ public:
         return ret;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE Unknown(
+    STDMETHODIMP Unknown(
         IN PVOID Unknown1,
         IN PVOID Unknown2,
         IN PVOID Unknown3,
-        IN PVOID Unknown4)
+        IN PVOID Unknown4) override
     {
         TRACE("ITrayPriv::Unknown(0x%p,0x%p,0x%p,0x%p)\n", Unknown1, Unknown2, Unknown3, Unknown4);
         return E_NOTIMPL;
@@ -112,8 +110,7 @@ public:
         return FALSE;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE AppendMenu(
-        OUT HMENU* phMenu)
+    STDMETHODIMP AppendMenu(OUT HMENU* phMenu) override
     {
         HMENU hMenu, hSettingsMenu;
         DWORD dwLogoff;
@@ -279,53 +276,55 @@ public:
 
     /*******************************************************************/
 
-    virtual HRESULT STDMETHODCALLTYPE QueryStatus(
+    STDMETHODIMP QueryStatus(
         IN const GUID *pguidCmdGroup  OPTIONAL,
         IN ULONG cCmds,
         IN OUT OLECMD *prgCmds,
-        IN OUT OLECMDTEXT *pCmdText  OPTIONAL)
+        IN OUT OLECMDTEXT *pCmdText  OPTIONAL) override
     {
         return E_NOTIMPL;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE Exec(
+    STDMETHODIMP Exec(
         IN const GUID *pguidCmdGroup  OPTIONAL,
         IN DWORD nCmdID,
         IN DWORD nCmdExecOpt,
         IN VARIANTARG *pvaIn  OPTIONAL,
-        IN VARIANTARG *pvaOut  OPTIONAL)
+        IN VARIANTARG *pvaOut  OPTIONAL) override
     {
         return E_NOTIMPL;
     }
 
     /*******************************************************************/
 
-    virtual HRESULT STDMETHODCALLTYPE SetClient(IUnknown *punkClient)
+    STDMETHODIMP SetClient(IUnknown *punkClient) override
     {
         return E_NOTIMPL;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE GetClient(IUnknown ** ppunkClient)
+    STDMETHODIMP GetClient(IUnknown ** ppunkClient) override
     {
         return E_NOTIMPL;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE OnPosRectChangeDB(RECT *prc)
+    STDMETHODIMP OnPosRectChangeDB(RECT *prc) override
     {
         return E_NOTIMPL;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE Popup(POINTL *ppt, RECTL *prcExclude, MP_POPUPFLAGS dwFlags)
+    // *** IMenuPopup methods ***
+
+    STDMETHODIMP Popup(POINTL *ppt, RECTL *prcExclude, MP_POPUPFLAGS dwFlags) override
     {
         return E_NOTIMPL;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE OnSelect(DWORD dwSelectType)
+    STDMETHODIMP OnSelect(DWORD dwSelectType) override
     {
         return E_NOTIMPL;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE SetSubMenu(IMenuPopup *pmp, BOOL fSet)
+    STDMETHODIMP SetSubMenu(IMenuPopup *pmp, BOOL fSet) override
     {
         if (!fSet)
         {

--- a/base/shell/explorer/startmnusite.cpp
+++ b/base/shell/explorer/startmnusite.cpp
@@ -39,7 +39,8 @@ public:
 
     // *** IServiceProvider methods ***
 
-    STDMETHODIMP QueryService(
+    STDMETHODIMP
+    QueryService(
         IN REFGUID guidService,
         IN REFIID riid,
         OUT PVOID *ppvObject) override
@@ -54,7 +55,8 @@ public:
 
     // *** IOleWindow methods ***
 
-    STDMETHODIMP GetWindow(OUT HWND *phwnd) override
+    STDMETHODIMP
+    GetWindow(OUT HWND *phwnd) override
     {
         TRACE("ITrayPriv::GetWindow\n");
 
@@ -65,13 +67,15 @@ public:
         return E_FAIL;
     }
 
-    STDMETHODIMP ContextSensitiveHelp(IN BOOL fEnterMode) override
+    STDMETHODIMP
+    ContextSensitiveHelp(IN BOOL fEnterMode) override
     {
         TRACE("ITrayPriv::ContextSensitiveHelp\n");
         return E_NOTIMPL;
     }
 
-    STDMETHODIMP Execute(
+    STDMETHODIMP
+    Execute(
         IN IShellFolder *pShellFolder,
         IN LPCITEMIDLIST pidl) override
     {
@@ -84,7 +88,8 @@ public:
         return ret;
     }
 
-    STDMETHODIMP Unknown(
+    STDMETHODIMP
+    Unknown(
         IN PVOID Unknown1,
         IN PVOID Unknown2,
         IN PVOID Unknown3,
@@ -110,7 +115,8 @@ public:
         return FALSE;
     }
 
-    STDMETHODIMP AppendMenu(OUT HMENU* phMenu) override
+    STDMETHODIMP
+    AppendMenu(OUT HMENU* phMenu) override
     {
         HMENU hMenu, hSettingsMenu;
         DWORD dwLogoff;
@@ -276,7 +282,8 @@ public:
 
     /*******************************************************************/
 
-    STDMETHODIMP QueryStatus(
+    STDMETHODIMP
+    QueryStatus(
         IN const GUID *pguidCmdGroup  OPTIONAL,
         IN ULONG cCmds,
         IN OUT OLECMD *prgCmds,
@@ -285,7 +292,8 @@ public:
         return E_NOTIMPL;
     }
 
-    STDMETHODIMP Exec(
+    STDMETHODIMP
+    Exec(
         IN const GUID *pguidCmdGroup  OPTIONAL,
         IN DWORD nCmdID,
         IN DWORD nCmdExecOpt,
@@ -297,34 +305,40 @@ public:
 
     /*******************************************************************/
 
-    STDMETHODIMP SetClient(IUnknown *punkClient) override
+    STDMETHODIMP
+    SetClient(IUnknown *punkClient) override
     {
         return E_NOTIMPL;
     }
 
-    STDMETHODIMP GetClient(IUnknown ** ppunkClient) override
+    STDMETHODIMP
+    GetClient(IUnknown ** ppunkClient) override
     {
         return E_NOTIMPL;
     }
 
-    STDMETHODIMP OnPosRectChangeDB(RECT *prc) override
+    STDMETHODIMP
+    OnPosRectChangeDB(RECT *prc) override
     {
         return E_NOTIMPL;
     }
 
     // *** IMenuPopup methods ***
 
-    STDMETHODIMP Popup(POINTL *ppt, RECTL *prcExclude, MP_POPUPFLAGS dwFlags) override
+    STDMETHODIMP
+    Popup(POINTL *ppt, RECTL *prcExclude, MP_POPUPFLAGS dwFlags) override
     {
         return E_NOTIMPL;
     }
 
-    STDMETHODIMP OnSelect(DWORD dwSelectType) override
+    STDMETHODIMP
+    OnSelect(DWORD dwSelectType) override
     {
         return E_NOTIMPL;
     }
 
-    STDMETHODIMP SetSubMenu(IMenuPopup *pmp, BOOL fSet) override
+    STDMETHODIMP
+    SetSubMenu(IMenuPopup *pmp, BOOL fSet) override
     {
         if (!fSet)
         {

--- a/base/shell/explorer/syspager.cpp
+++ b/base/shell/explorer/syspager.cpp
@@ -217,8 +217,9 @@ public:
     LRESULT OnGetMinimumSize(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
 
 public:
+    // *** IOleWindow methods ***
 
-    HRESULT WINAPI GetWindow(HWND* phwnd)
+    STDMETHODIMP GetWindow(HWND* phwnd) override
     {
         if (!phwnd)
             return E_INVALIDARG;
@@ -226,7 +227,7 @@ public:
         return S_OK;
     }
 
-    HRESULT WINAPI ContextSensitiveHelp(BOOL fEnterMode)
+    STDMETHODIMP ContextSensitiveHelp(BOOL fEnterMode) override
     {
         return E_NOTIMPL;
     }

--- a/base/shell/explorer/syspager.cpp
+++ b/base/shell/explorer/syspager.cpp
@@ -219,7 +219,8 @@ public:
 public:
     // *** IOleWindow methods ***
 
-    STDMETHODIMP GetWindow(HWND* phwnd) override
+    STDMETHODIMP
+    GetWindow(HWND* phwnd) override
     {
         if (!phwnd)
             return E_INVALIDARG;
@@ -227,7 +228,8 @@ public:
         return S_OK;
     }
 
-    STDMETHODIMP ContextSensitiveHelp(BOOL fEnterMode) override
+    STDMETHODIMP
+    ContextSensitiveHelp(BOOL fEnterMode) override
     {
         return E_NOTIMPL;
     }

--- a/base/shell/explorer/taskband.cpp
+++ b/base/shell/explorer/taskband.cpp
@@ -52,7 +52,7 @@ public:
 
     /*****************************************************************************/
 
-    virtual HRESULT STDMETHODCALLTYPE GetWindow(OUT HWND *phwnd)
+    STDMETHODIMP GetWindow(OUT HWND *phwnd) override
     {
         if (!m_hWnd)
             return E_FAIL;
@@ -62,40 +62,37 @@ public:
         return S_OK;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE ContextSensitiveHelp(
-        IN BOOL fEnterMode)
+    STDMETHODIMP ContextSensitiveHelp(IN BOOL fEnterMode) override
     {
         /* FIXME: Implement */
         return E_NOTIMPL;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE ShowDW(
-        IN BOOL bShow)
+    STDMETHODIMP ShowDW(IN BOOL bShow) override
     {
         /* We don't do anything... */
         return S_OK;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE CloseDW(
-        IN DWORD dwReserved)
+    STDMETHODIMP CloseDW(IN DWORD dwReserved) override
     {
         /* We don't do anything... */
         return S_OK;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE ResizeBorderDW(
+    STDMETHODIMP ResizeBorderDW(
         LPCRECT prcBorder,
         IUnknown *punkToolbarSite,
-        BOOL fReserved)
+        BOOL fReserved) override
     {
         /* No need to implement this method */
         return E_NOTIMPL;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE GetBandInfo(
+    STDMETHODIMP GetBandInfo(
         IN DWORD dwBandID,
         IN DWORD dwViewMode,
-        IN OUT DESKBANDINFO *pdbi)
+        IN OUT DESKBANDINFO *pdbi) override
     {
         TRACE("CTaskBand::GetBandInfo(0x%x,0x%x,0x%p) hWnd=0x%p\n", dwBandID, dwViewMode, pdbi, m_hWnd);
 
@@ -151,13 +148,24 @@ public:
 
     /*****************************************************************************/
     // *** IOleCommandTarget methods ***
-    virtual HRESULT STDMETHODCALLTYPE QueryStatus(const GUID *pguidCmdGroup, ULONG cCmds, OLECMD prgCmds [], OLECMDTEXT *pCmdText)
+
+    STDMETHODIMP
+    QueryStatus(
+        const GUID *pguidCmdGroup,
+        ULONG cCmds,
+        OLECMD prgCmds [],
+        OLECMDTEXT *pCmdText) override
     {
         UNIMPLEMENTED;
         return E_NOTIMPL;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE Exec(const GUID *pguidCmdGroup, DWORD nCmdID, DWORD nCmdexecopt, VARIANT *pvaIn, VARIANT *pvaOut)
+    STDMETHODIMP Exec(
+        const GUID *pguidCmdGroup,
+        DWORD nCmdID,
+        DWORD nCmdexecopt,
+        VARIANT *pvaIn,
+        VARIANT *pvaOut)
     {
         if (IsEqualIID(*pguidCmdGroup, IID_IBandSite))
         {
@@ -175,22 +183,19 @@ public:
 
     /*****************************************************************************/
 
-    virtual HRESULT STDMETHODCALLTYPE SetClient(
-        IN IUnknown *punkClient)
+    STDMETHODIMP SetClient(IN IUnknown *punkClient) override
     {
         TRACE("IDeskBar::SetClient(0x%p)\n", punkClient);
         return E_NOTIMPL;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE GetClient(
-        OUT IUnknown **ppunkClient)
+    STDMETHODIMP GetClient(OUT IUnknown **ppunkClient) override
     {
         TRACE("IDeskBar::GetClient(0x%p)\n", ppunkClient);
         return E_NOTIMPL;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE OnPosRectChangeDB(
-        IN RECT *prc)
+    STDMETHODIMP OnPosRectChangeDB(IN RECT *prc) override
     {
         TRACE("IDeskBar::OnPosRectChangeDB(0x%p=(%d,%d,%d,%d))\n", prc, prc->left, prc->top, prc->right, prc->bottom);
         if (prc->bottom - prc->top == 0)
@@ -201,8 +206,7 @@ public:
 
     /*****************************************************************************/
 
-    virtual HRESULT STDMETHODCALLTYPE GetClassID(
-        OUT CLSID *pClassID)
+    STDMETHODIMP GetClassID(OUT CLSID *pClassID) override
     {
         TRACE("CTaskBand::GetClassID(0x%p)\n", pClassID);
         /* We're going to return the (internal!) CLSID of the task band interface */
@@ -210,30 +214,28 @@ public:
         return S_OK;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE IsDirty()
+    STDMETHODIMP IsDirty() override
     {
         /* The object hasn't changed since the last save! */
         return S_FALSE;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE Load(
-        IN IStream *pStm)
+    STDMETHODIMP Load(IN IStream *pStm) override
     {
         TRACE("CTaskBand::Load called\n");
         /* Nothing to do */
         return S_OK;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE Save(
+    STDMETHODIMP Save(
         IN IStream *pStm,
-        IN BOOL fClearDirty)
+        IN BOOL fClearDirty) override
     {
         /* Nothing to do */
         return S_OK;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE GetSizeMax(
-        OUT ULARGE_INTEGER *pcbSize)
+    STDMETHODIMP GetSizeMax(OUT ULARGE_INTEGER *pcbSize) override
     {
         TRACE("CTaskBand::GetSizeMax called\n");
         /* We don't need any space for the task band */
@@ -243,7 +245,7 @@ public:
 
     /*****************************************************************************/
 
-    virtual HRESULT STDMETHODCALLTYPE SetSite(IUnknown *pUnkSite)
+    STDMETHODIMP SetSite(IUnknown *pUnkSite) override
     {
         HRESULT hRet;
         HWND hwndSite;
@@ -269,9 +271,9 @@ public:
         return S_OK;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE GetSite(
+    STDMETHODIMP GetSite(
         IN REFIID riid,
-        OUT VOID **ppvSite)
+        OUT VOID **ppvSite) override
     {
         TRACE("CTaskBand::GetSite(0x%p,0x%p)\n", riid, ppvSite);
 
@@ -286,37 +288,18 @@ public:
 
     /*****************************************************************************/
 
-    virtual HRESULT STDMETHODCALLTYPE ProcessMessage(
-        IN HWND hWnd,
-        IN UINT uMsg,
-        IN WPARAM wParam,
-        IN LPARAM lParam,
-        OUT LRESULT *plrResult)
-    {
-        TRACE("CTaskBand: IWinEventHandler::ProcessMessage(0x%p, 0x%x, 0x%p, 0x%p, 0x%p)\n", hWnd, uMsg, wParam, lParam, plrResult);
-        return E_NOTIMPL;
-    }
-
-    virtual HRESULT STDMETHODCALLTYPE ContainsWindow(
-        IN HWND hWnd)
-    {
-        if (hWnd == m_hWnd ||
-            IsChild(m_hWnd, hWnd))
-        {
-            TRACE("CTaskBand::ContainsWindow(0x%p) returns S_OK\n", hWnd);
-            return S_OK;
-        }
-
-        return S_FALSE;
-    }
-
-    virtual HRESULT STDMETHODCALLTYPE OnWinEvent(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT *theResult)
+    STDMETHODIMP OnWinEvent(
+        HWND hWnd,
+        UINT uMsg,
+        WPARAM wParam,
+        LPARAM lParam,
+        LRESULT *theResult) override
     {
         //UNIMPLEMENTED;
         return E_NOTIMPL;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE IsWindowOwner(HWND hWnd)
+    STDMETHODIMP IsWindowOwner(HWND hWnd) override
     {
         return (hWnd == m_hWnd) ? S_OK : S_FALSE;
     }

--- a/base/shell/explorer/taskband.cpp
+++ b/base/shell/explorer/taskband.cpp
@@ -52,7 +52,8 @@ public:
 
     /*****************************************************************************/
 
-    STDMETHODIMP GetWindow(OUT HWND *phwnd) override
+    STDMETHODIMP
+    GetWindow(OUT HWND *phwnd) override
     {
         if (!m_hWnd)
             return E_FAIL;
@@ -62,25 +63,29 @@ public:
         return S_OK;
     }
 
-    STDMETHODIMP ContextSensitiveHelp(IN BOOL fEnterMode) override
+    STDMETHODIMP
+    ContextSensitiveHelp(IN BOOL fEnterMode) override
     {
         /* FIXME: Implement */
         return E_NOTIMPL;
     }
 
-    STDMETHODIMP ShowDW(IN BOOL bShow) override
+    STDMETHODIMP
+    ShowDW(IN BOOL bShow) override
     {
         /* We don't do anything... */
         return S_OK;
     }
 
-    STDMETHODIMP CloseDW(IN DWORD dwReserved) override
+    STDMETHODIMP
+    CloseDW(IN DWORD dwReserved) override
     {
         /* We don't do anything... */
         return S_OK;
     }
 
-    STDMETHODIMP ResizeBorderDW(
+    STDMETHODIMP
+    ResizeBorderDW(
         LPCRECT prcBorder,
         IUnknown *punkToolbarSite,
         BOOL fReserved) override
@@ -89,7 +94,8 @@ public:
         return E_NOTIMPL;
     }
 
-    STDMETHODIMP GetBandInfo(
+    STDMETHODIMP
+    GetBandInfo(
         IN DWORD dwBandID,
         IN DWORD dwViewMode,
         IN OUT DESKBANDINFO *pdbi) override
@@ -160,12 +166,13 @@ public:
         return E_NOTIMPL;
     }
 
-    STDMETHODIMP Exec(
+    STDMETHODIMP
+    Exec(
         const GUID *pguidCmdGroup,
         DWORD nCmdID,
         DWORD nCmdexecopt,
         VARIANT *pvaIn,
-        VARIANT *pvaOut)
+        VARIANT *pvaOut) override
     {
         if (IsEqualIID(*pguidCmdGroup, IID_IBandSite))
         {
@@ -183,19 +190,22 @@ public:
 
     /*****************************************************************************/
 
-    STDMETHODIMP SetClient(IN IUnknown *punkClient) override
+    STDMETHODIMP
+    SetClient(IN IUnknown *punkClient) override
     {
         TRACE("IDeskBar::SetClient(0x%p)\n", punkClient);
         return E_NOTIMPL;
     }
 
-    STDMETHODIMP GetClient(OUT IUnknown **ppunkClient) override
+    STDMETHODIMP
+    GetClient(OUT IUnknown **ppunkClient) override
     {
         TRACE("IDeskBar::GetClient(0x%p)\n", ppunkClient);
         return E_NOTIMPL;
     }
 
-    STDMETHODIMP OnPosRectChangeDB(IN RECT *prc) override
+    STDMETHODIMP
+    OnPosRectChangeDB(IN RECT *prc) override
     {
         TRACE("IDeskBar::OnPosRectChangeDB(0x%p=(%d,%d,%d,%d))\n", prc, prc->left, prc->top, prc->right, prc->bottom);
         if (prc->bottom - prc->top == 0)
@@ -206,7 +216,8 @@ public:
 
     /*****************************************************************************/
 
-    STDMETHODIMP GetClassID(OUT CLSID *pClassID) override
+    STDMETHODIMP
+    GetClassID(OUT CLSID *pClassID) override
     {
         TRACE("CTaskBand::GetClassID(0x%p)\n", pClassID);
         /* We're going to return the (internal!) CLSID of the task band interface */
@@ -214,20 +225,23 @@ public:
         return S_OK;
     }
 
-    STDMETHODIMP IsDirty() override
+    STDMETHODIMP
+    IsDirty() override
     {
         /* The object hasn't changed since the last save! */
         return S_FALSE;
     }
 
-    STDMETHODIMP Load(IN IStream *pStm) override
+    STDMETHODIMP
+    Load(IN IStream *pStm) override
     {
         TRACE("CTaskBand::Load called\n");
         /* Nothing to do */
         return S_OK;
     }
 
-    STDMETHODIMP Save(
+    STDMETHODIMP
+    Save(
         IN IStream *pStm,
         IN BOOL fClearDirty) override
     {
@@ -235,7 +249,8 @@ public:
         return S_OK;
     }
 
-    STDMETHODIMP GetSizeMax(OUT ULARGE_INTEGER *pcbSize) override
+    STDMETHODIMP
+    GetSizeMax(OUT ULARGE_INTEGER *pcbSize) override
     {
         TRACE("CTaskBand::GetSizeMax called\n");
         /* We don't need any space for the task band */
@@ -245,7 +260,8 @@ public:
 
     /*****************************************************************************/
 
-    STDMETHODIMP SetSite(IUnknown *pUnkSite) override
+    STDMETHODIMP
+    SetSite(IUnknown *pUnkSite) override
     {
         HRESULT hRet;
         HWND hwndSite;
@@ -271,7 +287,8 @@ public:
         return S_OK;
     }
 
-    STDMETHODIMP GetSite(
+    STDMETHODIMP
+    GetSite(
         IN REFIID riid,
         OUT VOID **ppvSite) override
     {
@@ -288,7 +305,8 @@ public:
 
     /*****************************************************************************/
 
-    STDMETHODIMP OnWinEvent(
+    STDMETHODIMP
+    OnWinEvent(
         HWND hWnd,
         UINT uMsg,
         WPARAM wParam,
@@ -299,7 +317,8 @@ public:
         return E_NOTIMPL;
     }
 
-    STDMETHODIMP IsWindowOwner(HWND hWnd) override
+    STDMETHODIMP
+    IsWindowOwner(HWND hWnd) override
     {
         return (hWnd == m_hWnd) ? S_OK : S_FALSE;
     }

--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -1981,7 +1981,8 @@ public:
 
     // *** IOleWindow methods ***
 
-    STDMETHODIMP GetWindow(HWND* phwnd) override
+    STDMETHODIMP
+    GetWindow(HWND* phwnd) override
     {
         if (!phwnd)
             return E_INVALIDARG;
@@ -1989,7 +1990,8 @@ public:
         return S_OK;
     }
 
-    STDMETHODIMP ContextSensitiveHelp(BOOL fEnterMode) override
+    STDMETHODIMP
+    ContextSensitiveHelp(BOOL fEnterMode) override
     {
         return E_NOTIMPL;
     }

--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -1979,7 +1979,9 @@ public:
         return S_OK;
     }
 
-    HRESULT WINAPI GetWindow(HWND* phwnd)
+    // *** IOleWindow methods ***
+
+    STDMETHODIMP GetWindow(HWND* phwnd) override
     {
         if (!phwnd)
             return E_INVALIDARG;
@@ -1987,7 +1989,7 @@ public:
         return S_OK;
     }
 
-    HRESULT WINAPI ContextSensitiveHelp(BOOL fEnterMode)
+    STDMETHODIMP ContextSensitiveHelp(BOOL fEnterMode) override
     {
         return E_NOTIMPL;
     }

--- a/base/shell/explorer/tbsite.cpp
+++ b/base/shell/explorer/tbsite.cpp
@@ -56,12 +56,14 @@ class CTrayBandSite :
     };
 
 public:
-    STDMETHODIMP_(ULONG) AddRef() override
+    STDMETHODIMP_(ULONG)
+    AddRef() override
     {
         return InterlockedIncrement(&m_RefCount);
     }
 
-    STDMETHODIMP_(ULONG) Release() override
+    STDMETHODIMP_(ULONG)
+    Release() override
     {
         ULONG Ret = InterlockedDecrement(&m_RefCount);
 
@@ -71,7 +73,8 @@ public:
         return Ret;
     }
 
-    STDMETHODIMP QueryInterface(IN REFIID riid, OUT LPVOID *ppvObj) override
+    STDMETHODIMP
+    QueryInterface(IN REFIID riid, OUT LPVOID *ppvObj) override
     {
         if (ppvObj == NULL)
             return E_POINTER;
@@ -114,7 +117,8 @@ public:
 
     virtual ~CTrayBandSite() { }
 
-    STDMETHODIMP OnLoad(
+    STDMETHODIMP
+    OnLoad(
         IN OUT IStream *pStm,
         IN REFIID riid,
         OUT PVOID *pvObj) override
@@ -186,7 +190,8 @@ public:
         return hRet;
     }
 
-    STDMETHODIMP OnSave(
+    STDMETHODIMP
+    OnSave(
         IN OUT IUnknown *pUnk,
         IN OUT IStream *pStm) override
     {
@@ -198,12 +203,14 @@ public:
         return E_NOTIMPL;
     }
 
-    STDMETHODIMP IsTaskBand(IN IUnknown *punk) override
+    STDMETHODIMP
+    IsTaskBand(IN IUnknown *punk) override
     {
         return IsSameObject(m_BandSite, punk);
     }
 
-    STDMETHODIMP ProcessMessage(
+    STDMETHODIMP
+    ProcessMessage(
         IN HWND hWnd,
         IN UINT uMsg,
         IN WPARAM wParam,
@@ -276,7 +283,8 @@ public:
         return hRet;
     }
 
-    STDMETHODIMP AddContextMenus(
+    STDMETHODIMP
+    AddContextMenus(
         IN HMENU hmenu,
         IN UINT indexMenu,
         IN UINT idCmdFirst,
@@ -312,7 +320,8 @@ public:
         return S_OK;
     }
 
-    STDMETHODIMP Lock(IN BOOL bLock) override
+    STDMETHODIMP
+    Lock(IN BOOL bLock) override
     {
         BOOL bPrevLocked = Locked;
         BANDSITEINFO bsi;
@@ -341,7 +350,8 @@ public:
 
     /*******************************************************************/
 
-    STDMETHODIMP AddBand(IN IUnknown *punk) override
+    STDMETHODIMP
+    AddBand(IN IUnknown *punk) override
     {
         /* Send the DBID_DELAYINIT command to initialize the band to be added */
         /* FIXME: Should be delayed */
@@ -366,14 +376,16 @@ public:
         return S_OK;
     }
 
-    STDMETHODIMP EnumBands(
+    STDMETHODIMP
+    EnumBands(
         IN UINT uBand,
         OUT DWORD *pdwBandID) override
     {
         return m_BandSite->EnumBands(uBand, pdwBandID);
     }
 
-    STDMETHODIMP QueryBand(
+    STDMETHODIMP
+    QueryBand(
         IN DWORD dwBandID,
         OUT IDeskBand **ppstb,
         OUT DWORD *pdwState,
@@ -414,7 +426,8 @@ public:
         return hRet;
     }
 
-    STDMETHODIMP SetBandState(
+    STDMETHODIMP
+    SetBandState(
         IN DWORD dwBandID,
         IN DWORD dwMask,
         IN DWORD dwState) override
@@ -422,12 +435,14 @@ public:
         return m_BandSite->SetBandState(dwBandID, dwMask, dwState);
     }
 
-    STDMETHODIMP RemoveBand(IN DWORD dwBandID) override
+    STDMETHODIMP
+    RemoveBand(IN DWORD dwBandID) override
     {
         return m_BandSite->RemoveBand(dwBandID);
     }
 
-    STDMETHODIMP GetBandObject(
+    STDMETHODIMP
+    GetBandObject(
         IN DWORD dwBandID,
         IN REFIID riid,
         OUT VOID **ppv) override
@@ -435,12 +450,14 @@ public:
         return m_BandSite->GetBandObject(dwBandID, riid, ppv);
     }
 
-    STDMETHODIMP SetBandSiteInfo(IN const BANDSITEINFO *pbsinfo) override
+    STDMETHODIMP
+    SetBandSiteInfo(IN const BANDSITEINFO *pbsinfo) override
     {
         return m_BandSite->SetBandSiteInfo(pbsinfo);
     }
 
-    STDMETHODIMP GetBandSiteInfo(IN OUT BANDSITEINFO *pbsinfo) override
+    STDMETHODIMP
+    GetBandSiteInfo(IN OUT BANDSITEINFO *pbsinfo) override
     {
         return m_BandSite->GetBandSiteInfo(pbsinfo);
     }

--- a/base/shell/explorer/tbsite.cpp
+++ b/base/shell/explorer/tbsite.cpp
@@ -56,13 +56,12 @@ class CTrayBandSite :
     };
 
 public:
-
-    virtual ULONG STDMETHODCALLTYPE AddRef()
+    STDMETHODIMP_(ULONG) AddRef() override
     {
         return InterlockedIncrement(&m_RefCount);
     }
 
-    virtual ULONG STDMETHODCALLTYPE Release()
+    STDMETHODIMP_(ULONG) Release() override
     {
         ULONG Ret = InterlockedDecrement(&m_RefCount);
 
@@ -72,7 +71,7 @@ public:
         return Ret;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE QueryInterface(IN REFIID riid, OUT LPVOID *ppvObj)
+    STDMETHODIMP QueryInterface(IN REFIID riid, OUT LPVOID *ppvObj) override
     {
         if (ppvObj == NULL)
             return E_POINTER;
@@ -115,10 +114,10 @@ public:
 
     virtual ~CTrayBandSite() { }
 
-    virtual HRESULT STDMETHODCALLTYPE OnLoad(
+    STDMETHODIMP OnLoad(
         IN OUT IStream *pStm,
         IN REFIID riid,
-        OUT PVOID *pvObj)
+        OUT PVOID *pvObj) override
     {
         LARGE_INTEGER liPosZero;
         ULARGE_INTEGER liCurrent;
@@ -187,9 +186,9 @@ public:
         return hRet;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE OnSave(
+    STDMETHODIMP OnSave(
         IN OUT IUnknown *pUnk,
-        IN OUT IStream *pStm)
+        IN OUT IStream *pStm) override
     {
         /* NOTE: Callback routine called by the shell while saving the task band
                  stream. We use it to intercept the default behavior when the task
@@ -199,17 +198,17 @@ public:
         return E_NOTIMPL;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE IsTaskBand(IN IUnknown *punk)
+    STDMETHODIMP IsTaskBand(IN IUnknown *punk) override
     {
         return IsSameObject(m_BandSite, punk);
     }
 
-    virtual HRESULT STDMETHODCALLTYPE ProcessMessage(
+    STDMETHODIMP ProcessMessage(
         IN HWND hWnd,
         IN UINT uMsg,
         IN WPARAM wParam,
         IN LPARAM lParam,
-        OUT LRESULT *plResult)
+        OUT LRESULT *plResult) override
     {
         HRESULT hRet;
 
@@ -277,13 +276,13 @@ public:
         return hRet;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE AddContextMenus(
+    STDMETHODIMP AddContextMenus(
         IN HMENU hmenu,
         IN UINT indexMenu,
         IN UINT idCmdFirst,
         IN UINT idCmdLast,
         IN UINT uFlags,
-        OUT IContextMenu **ppcm)
+        OUT IContextMenu **ppcm) override
     {
         HRESULT hRet;
 
@@ -313,7 +312,7 @@ public:
         return S_OK;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE Lock(IN BOOL bLock)
+    STDMETHODIMP Lock(IN BOOL bLock) override
     {
         BOOL bPrevLocked = Locked;
         BANDSITEINFO bsi;
@@ -342,7 +341,7 @@ public:
 
     /*******************************************************************/
 
-    virtual HRESULT STDMETHODCALLTYPE AddBand(IN IUnknown *punk)
+    STDMETHODIMP AddBand(IN IUnknown *punk) override
     {
         /* Send the DBID_DELAYINIT command to initialize the band to be added */
         /* FIXME: Should be delayed */
@@ -367,19 +366,19 @@ public:
         return S_OK;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE EnumBands(
+    STDMETHODIMP EnumBands(
         IN UINT uBand,
-        OUT DWORD *pdwBandID)
+        OUT DWORD *pdwBandID) override
     {
         return m_BandSite->EnumBands(uBand, pdwBandID);
     }
 
-    virtual HRESULT STDMETHODCALLTYPE QueryBand(
+    STDMETHODIMP QueryBand(
         IN DWORD dwBandID,
         OUT IDeskBand **ppstb,
         OUT DWORD *pdwState,
         OUT LPWSTR pszName,
-        IN int cchName)
+        IN int cchName) override
     {
         HRESULT hRet;
         IDeskBand *pstb = NULL;
@@ -415,36 +414,33 @@ public:
         return hRet;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE SetBandState(
+    STDMETHODIMP SetBandState(
         IN DWORD dwBandID,
         IN DWORD dwMask,
-        IN DWORD dwState)
+        IN DWORD dwState) override
     {
         return m_BandSite->SetBandState(dwBandID, dwMask, dwState);
     }
 
-    virtual HRESULT STDMETHODCALLTYPE RemoveBand(
-        IN DWORD dwBandID)
+    STDMETHODIMP RemoveBand(IN DWORD dwBandID) override
     {
         return m_BandSite->RemoveBand(dwBandID);
     }
 
-    virtual HRESULT STDMETHODCALLTYPE GetBandObject(
+    STDMETHODIMP GetBandObject(
         IN DWORD dwBandID,
         IN REFIID riid,
-        OUT VOID **ppv)
+        OUT VOID **ppv) override
     {
         return m_BandSite->GetBandObject(dwBandID, riid, ppv);
     }
 
-    virtual HRESULT STDMETHODCALLTYPE SetBandSiteInfo(
-        IN const BANDSITEINFO *pbsinfo)
+    STDMETHODIMP SetBandSiteInfo(IN const BANDSITEINFO *pbsinfo) override
     {
         return m_BandSite->SetBandSiteInfo(pbsinfo);
     }
 
-    virtual HRESULT STDMETHODCALLTYPE GetBandSiteInfo(
-        IN OUT BANDSITEINFO *pbsinfo)
+    STDMETHODIMP GetBandSiteInfo(IN OUT BANDSITEINFO *pbsinfo) override
     {
         return m_BandSite->GetBandSiteInfo(pbsinfo);
     }

--- a/base/shell/explorer/trayclock.cpp
+++ b/base/shell/explorer/trayclock.cpp
@@ -106,7 +106,8 @@ private:
 public:
     // *** IOleWindow methods ***
 
-    STDMETHODIMP GetWindow(HWND* phwnd) override
+    STDMETHODIMP
+    GetWindow(HWND* phwnd) override
     {
         if (!phwnd)
             return E_INVALIDARG;
@@ -114,7 +115,8 @@ public:
         return S_OK;
     }
 
-    STDMETHODIMP ContextSensitiveHelp(BOOL fEnterMode) override
+    STDMETHODIMP
+    ContextSensitiveHelp(BOOL fEnterMode) override
     {
         return E_NOTIMPL;
     }

--- a/base/shell/explorer/trayclock.cpp
+++ b/base/shell/explorer/trayclock.cpp
@@ -104,8 +104,9 @@ private:
     VOID PaintLine(IN HDC hDC, IN OUT RECT *rcClient, IN UINT LineNumber, IN UINT szLinesIndex);
 
 public:
+    // *** IOleWindow methods ***
 
-    HRESULT WINAPI GetWindow(HWND* phwnd)
+    STDMETHODIMP GetWindow(HWND* phwnd) override
     {
         if (!phwnd)
             return E_INVALIDARG;
@@ -113,7 +114,7 @@ public:
         return S_OK;
     }
 
-    HRESULT WINAPI ContextSensitiveHelp(BOOL fEnterMode)
+    STDMETHODIMP ContextSensitiveHelp(BOOL fEnterMode) override
     {
         return E_NOTIMPL;
     }

--- a/base/shell/explorer/trayntfy.cpp
+++ b/base/shell/explorer/trayntfy.cpp
@@ -498,7 +498,8 @@ public:
 
     // *** IOleWindow methods ***
 
-    STDMETHODIMP GetWindow(HWND* phwnd) override
+    STDMETHODIMP
+    GetWindow(HWND* phwnd) override
     {
         if (!phwnd)
             return E_INVALIDARG;
@@ -506,7 +507,8 @@ public:
         return S_OK;
     }
 
-    STDMETHODIMP ContextSensitiveHelp(BOOL fEnterMode) override
+    STDMETHODIMP
+    ContextSensitiveHelp(BOOL fEnterMode) override
     {
         return E_NOTIMPL;
     }

--- a/base/shell/explorer/trayntfy.cpp
+++ b/base/shell/explorer/trayntfy.cpp
@@ -496,7 +496,9 @@ public:
         return GetParent().SendMessage(WM_NOTIFY, 0, (LPARAM)hdr);
     }
 
-    HRESULT WINAPI GetWindow(HWND* phwnd)
+    // *** IOleWindow methods ***
+
+    STDMETHODIMP GetWindow(HWND* phwnd) override
     {
         if (!phwnd)
             return E_INVALIDARG;
@@ -504,7 +506,7 @@ public:
         return S_OK;
     }
 
-    HRESULT WINAPI ContextSensitiveHelp(BOOL fEnterMode)
+    STDMETHODIMP ContextSensitiveHelp(BOOL fEnterMode) override
     {
         return E_NOTIMPL;
     }

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -3490,21 +3490,24 @@ HandleTrayContextMenu:
      *       with it (especially positioning of desktop icons)
      */
 
-    STDMETHODIMP_(ULONG) GetState() override
+    STDMETHODIMP_(ULONG)
+    GetState() override
     {
         /* FIXME: Return ABS_ flags? */
         TRACE("IShellDesktopTray::GetState() unimplemented!\n");
         return 0;
     }
 
-    STDMETHODIMP GetTrayWindow(OUT HWND *phWndTray) override
+    STDMETHODIMP
+    GetTrayWindow(OUT HWND *phWndTray) override
     {
         TRACE("IShellDesktopTray::GetTrayWindow(0x%p)\n", phWndTray);
         *phWndTray = m_hWnd;
         return S_OK;
     }
 
-    STDMETHODIMP RegisterDesktopWindow(IN HWND hWndDesktop) override
+    STDMETHODIMP
+    RegisterDesktopWindow(IN HWND hWndDesktop) override
     {
         TRACE("IShellDesktopTray::RegisterDesktopWindow(0x%p)\n", hWndDesktop);
 
@@ -3512,7 +3515,8 @@ HandleTrayContextMenu:
         return S_OK;
     }
 
-    STDMETHODIMP Unknown(IN DWORD dwUnknown1, IN DWORD dwUnknown2) override
+    STDMETHODIMP
+    Unknown(IN DWORD dwUnknown1, IN DWORD dwUnknown2) override
     {
         TRACE("IShellDesktopTray::Unknown(%u,%u) unimplemented!\n", dwUnknown1, dwUnknown2);
         return S_OK;
@@ -3526,7 +3530,8 @@ HandleTrayContextMenu:
 
     // *** IOleWindow methods ***
 
-    STDMETHODIMP GetWindow(HWND* phwnd) override
+    STDMETHODIMP
+    GetWindow(HWND* phwnd) override
     {
         if (!phwnd)
             return E_INVALIDARG;
@@ -3534,7 +3539,8 @@ HandleTrayContextMenu:
         return S_OK;
     }
 
-    STDMETHODIMP ContextSensitiveHelp(BOOL fEnterMode) override
+    STDMETHODIMP
+    ContextSensitiveHelp(BOOL fEnterMode) override
     {
         return E_NOTIMPL;
     }
@@ -3634,7 +3640,8 @@ public:
         return S_OK;
     }
 
-    STDMETHODIMP InvokeCommand(LPCMINVOKECOMMANDINFO lpici) override
+    STDMETHODIMP
+    InvokeCommand(LPCMINVOKECOMMANDINFO lpici) override
     {
         UINT uiCmdId = PtrToUlong(lpici->lpVerb);
         if (uiCmdId != 0)

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -3490,21 +3490,21 @@ HandleTrayContextMenu:
      *       with it (especially positioning of desktop icons)
      */
 
-    virtual ULONG STDMETHODCALLTYPE GetState()
+    STDMETHODIMP_(ULONG) GetState() override
     {
         /* FIXME: Return ABS_ flags? */
         TRACE("IShellDesktopTray::GetState() unimplemented!\n");
         return 0;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE GetTrayWindow(OUT HWND *phWndTray)
+    STDMETHODIMP GetTrayWindow(OUT HWND *phWndTray) override
     {
         TRACE("IShellDesktopTray::GetTrayWindow(0x%p)\n", phWndTray);
         *phWndTray = m_hWnd;
         return S_OK;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE RegisterDesktopWindow(IN HWND hWndDesktop)
+    STDMETHODIMP RegisterDesktopWindow(IN HWND hWndDesktop) override
     {
         TRACE("IShellDesktopTray::RegisterDesktopWindow(0x%p)\n", hWndDesktop);
 
@@ -3512,7 +3512,7 @@ HandleTrayContextMenu:
         return S_OK;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE Unknown(IN DWORD dwUnknown1, IN DWORD dwUnknown2)
+    STDMETHODIMP Unknown(IN DWORD dwUnknown1, IN DWORD dwUnknown2) override
     {
         TRACE("IShellDesktopTray::Unknown(%u,%u) unimplemented!\n", dwUnknown1, dwUnknown2);
         return S_OK;
@@ -3524,7 +3524,9 @@ HandleTrayContextMenu:
         return S_OK;
     }
 
-    HRESULT WINAPI GetWindow(HWND* phwnd)
+    // *** IOleWindow methods ***
+
+    STDMETHODIMP GetWindow(HWND* phwnd) override
     {
         if (!phwnd)
             return E_INVALIDARG;
@@ -3532,7 +3534,7 @@ HandleTrayContextMenu:
         return S_OK;
     }
 
-    HRESULT WINAPI ContextSensitiveHelp(BOOL fEnterMode)
+    STDMETHODIMP ContextSensitiveHelp(BOOL fEnterMode) override
     {
         return E_NOTIMPL;
     }
@@ -3572,12 +3574,12 @@ public:
         return S_OK;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE
-        QueryContextMenu(HMENU hPopup,
-                         UINT indexMenu,
-                         UINT idCmdFirst,
-                         UINT idCmdLast,
-                         UINT uFlags)
+    STDMETHODIMP
+    QueryContextMenu(HMENU hPopup,
+                     UINT indexMenu,
+                     UINT idCmdFirst,
+                     UINT idCmdLast,
+                     UINT uFlags) override
     {
         HMENU hMenuBase;
 
@@ -3632,8 +3634,7 @@ public:
         return S_OK;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE
-        InvokeCommand(LPCMINVOKECOMMANDINFO lpici)
+    STDMETHODIMP InvokeCommand(LPCMINVOKECOMMANDINFO lpici) override
     {
         UINT uiCmdId = PtrToUlong(lpici->lpVerb);
         if (uiCmdId != 0)
@@ -3662,12 +3663,13 @@ public:
         return S_OK;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE
-        GetCommandString(UINT_PTR idCmd,
+    STDMETHODIMP
+    GetCommandString(
+        UINT_PTR idCmd,
         UINT uType,
         UINT *pwReserved,
         LPSTR pszName,
-        UINT cchMax)
+        UINT cchMax) override
     {
         return E_NOTIMPL;
     }


### PR DESCRIPTION
## Purpose

Follow the standard way.
JIRA issue: [CORE-19469](https://jira.reactos.org/browse/CORE-19469)

## Proposed changes

- Use `STDMETHODIMP` and `override` keyword instead of `virtual HRESULT STDMETHODCALLTYPE`.
- Delete `CTaskBand::ProcessMessage` and `CTaskBand::ContainsWindow` methods. I think they are useless.