### PR TITLE
[FREETYPE][NTGDI] Use num_faces instead of ttc_header.count

### DIFF
--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -1986,17 +1986,10 @@ IntGdiLoadFontsFromMemory(PGDI_LOAD_FONT pLoadFont,
 
     if (FontIndex == -1)
     {
-        if (FT_IS_SFNT(Face))
+        FT_Long iFace, num_faces = Face->num_faces;
+        for (iFace = 1; iFace < num_faces; ++iFace)
         {
-            TT_Face TrueType = (TT_Face)Face;
-            if (TrueType->ttc_header.count > 1)
-            {
-                FT_Long i;
-                for (i = 1; i < TrueType->ttc_header.count; ++i)
-                {
-                    FaceCount += IntGdiLoadFontsFromMemory(pLoadFont, NULL, i, -1);
-                }
-            }
+            FaceCount += IntGdiLoadFontsFromMemory(pLoadFont, NULL, iFace, -1);
         }
         FontIndex = 0;
     }


### PR DESCRIPTION
## Purpose

Supporting raster fonts. Using `num_faces` is the generic way.
JIRA issue: [CORE-16165](https://jira.reactos.org/browse/CORE-16165)

## Proposed changes

- Use `FT_FaceRec.num_faces` instead of `TT_Face.ttc_header.count` in counting the font faces in `IntGdiLoadFontsFromMemory` function.

## TODO

- [x] Do tests.