### PR TITLE
[MSHTML_WINETEST] Fix crashes

### DIFF
--- a/dll/win32/urlmon/CMakeLists.txt
+++ b/dll/win32/urlmon/CMakeLists.txt
@@ -4,7 +4,8 @@ add_definitions(
     -D_URLMON_
     -DENTRY_PREFIX=URLMON_
     -DPROXY_DELEGATION
-    -DWINE_REGISTER_DLL)
+    -DWINE_REGISTER_DLL
+    -DPROXY_CLSID_IS={0x79EAC9F1,0xBAF9,0x11CE,{0x8C,0x82,0x00,0xAA,0x00,0x4B,0xA9,0x0B}})
 
 include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(urlmon.dll urlmon.spec ADD_IMPORTLIB)

--- a/modules/rostests/winetests/mshtml/activex.c
+++ b/modules/rostests/winetests/mshtml/activex.c
@@ -2434,6 +2434,7 @@ static void test_flash_ax(void)
         skip("Skipping test_ui_activate(). ROSTESTS-114.\n");
         skip("Skipping test_container(notif_doc). ROSTESTS-114.\n");
         skip("Skipping test_object_elem(notif_doc). ROSTESTS-114.\n");
+        return;
     }
 
     IOleClientSite_AddRef(client_site);


### PR DESCRIPTION
## Purpose

Fix crash of mshtml_winetest activex and htmldoc

## Tests
✅ KVM x86: https://reactos.org/testman/compare.php?ids=99938,99946,99949,99955
- mshtml:activex: crash fixed
- mshtml:htmldoc: crash fixed
- urlmon:misc: crash fixed
- urlmon:sec_mgr: 1 test fixed

