### PR TITLE
[PSDK] Avoid CO_E_NOTINITIALIZED macro redefinition warning

### DIFF
--- a/sdk/include/psdk/ddraw.h
+++ b/sdk/include/psdk/ddraw.h
@@ -8,7 +8,9 @@
 #else
 #define IUnknown void
 #if !defined(NT_BUILD_ENVIRONMENT) && !defined(WINNT)
+    #ifndef CO_E_NOTINITIALIZED /* Avoid conflict warning with _HRESULT_TYPEDEF_(0x800401F0L) in winerror.h */
         #define CO_E_NOTINITIALIZED 0x800401F0L
+    #endif
 #endif
 #endif
 

--- a/sdk/include/psdk/ddraw.h
+++ b/sdk/include/psdk/ddraw.h
@@ -8,9 +8,9 @@
 #else
 #define IUnknown void
 #if !defined(NT_BUILD_ENVIRONMENT) && !defined(WINNT)
-    #ifndef CO_E_NOTINITIALIZED /* Avoid conflict warning with _HRESULT_TYPEDEF_(0x800401F0L) in winerror.h */
-        #define CO_E_NOTINITIALIZED 0x800401F0L
-    #endif
+  #ifndef CO_E_NOTINITIALIZED /* Avoid conflict warning with _HRESULT_TYPEDEF_(0x800401F0L) in winerror.h */
+  #define CO_E_NOTINITIALIZED 0x800401F0L
+  #endif
 #endif
 #endif
 


### PR DESCRIPTION
This warning appears quite a few times in the build log.

```
D:\a\reactos\reactos\src\sdk\include\psdk\ddraw.h(11): warning C4005: 'CO_E_NOTINITIALIZED': macro redefinition
D:\a\reactos\reactos\src\sdk\include\psdk\winerror.h(2803): note: see previous definition of 'CO_E_NOTINITIALIZED'
```

This fix is also a part of my larger [warning fix PR](https://github.com/reactos/reactos/pull/7031/) but it does not seem that like will ever get accepted so I cherry-picked this one since it bothers me when searching for "error" in the log.