### PR TITLE
[FREETYPE][NTGDI] Simplify IntGdiLoadFontsFromMemory

### DIFF
--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -1727,15 +1727,12 @@ IntGdiLoadFontsFromMemory(PGDI_LOAD_FONT pLoadFont,
     FT_Face             Face;
     ANSI_STRING         AnsiString;
     FT_WinFNT_HeaderRec WinFNT;
-    INT                 FaceCount = 0, CharSetCount = 0;
-    PUNICODE_STRING     pFileName       = pLoadFont->pFileName;
+    INT                 BitIndex, FaceCount = 0, CharSetCount = 0;
+    PUNICODE_STRING     pFileName = pLoadFont->pFileName, pValueName = &pLoadFont->RegValueName;
     DWORD               Characteristics = pLoadFont->Characteristics;
-    PUNICODE_STRING     pValueName = &pLoadFont->RegValueName;
     TT_OS2 *            pOS2;
-    INT                 BitIndex;
-    FT_UShort           os2_version;
+    FT_UShort           os2_version, os2_usWeightClass;
     FT_ULong            os2_ulCodePageRange1;
-    FT_UShort           os2_usWeightClass;
 
     ASSERT(SharedFace != NULL);
     ASSERT(FontIndex != -1);
@@ -2027,7 +2024,7 @@ IntGdiLoadFontByIndexFromMemory(PGDI_LOAD_FONT pLoadFont, FT_Long FontIndex)
         else
             DPRINT1("Error reading font (error code: %d)\n", Error);
         IntUnLockFreeType();
-        return 0;   /* Failure */
+        return 0; /* Failure */
     }
 
     pLoadFont->IsTrueType = FT_IS_SFNT(Face);
@@ -2039,7 +2036,8 @@ IntGdiLoadFontByIndexFromMemory(PGDI_LOAD_FONT pLoadFont, FT_Long FontIndex)
     if (!SharedFace)
     {
         DPRINT1("SharedFace_Create failed\n");
-        return 0;
+        EngSetLastError(ERROR_NOT_ENOUGH_MEMORY);
+        return 0; /* Failure */
     }
 
     if (FontIndex == -1)

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -2032,10 +2032,10 @@ IntGdiLoadFontByIndexFromMemory(PGDI_LOAD_FONT pLoadFont, FT_Long FontIndex)
 
     pLoadFont->IsTrueType = FT_IS_SFNT(Face);
     num_faces = Face->num_faces;
+    SharedFace = SharedFace_Create(Face, pLoadFont->Memory);
 
     IntUnLockFreeType();
 
-    SharedFace = SharedFace_Create(Face, pLoadFont->Memory);
     if (!SharedFace)
     {
         DPRINT1("SharedFace_Create failed\n");

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -1727,12 +1727,15 @@ IntGdiLoadFontsFromMemory(PGDI_LOAD_FONT pLoadFont,
     FT_Face             Face;
     ANSI_STRING         AnsiString;
     FT_WinFNT_HeaderRec WinFNT;
-    INT                 BitIndex, FaceCount = 0, CharSetCount = 0;
-    PUNICODE_STRING     pFileName = pLoadFont->pFileName, pValueName = &pLoadFont->RegValueName;
+    INT                 FaceCount = 0, CharSetCount = 0;
+    PUNICODE_STRING     pFileName       = pLoadFont->pFileName;
     DWORD               Characteristics = pLoadFont->Characteristics;
+    PUNICODE_STRING     pValueName = &pLoadFont->RegValueName;
     TT_OS2 *            pOS2;
-    FT_UShort           os2_version, os2_usWeightClass;
+    INT                 BitIndex;
+    FT_UShort           os2_version;
     FT_ULong            os2_ulCodePageRange1;
+    FT_UShort           os2_usWeightClass;
 
     ASSERT(SharedFace != NULL);
     ASSERT(FontIndex != -1);


### PR DESCRIPTION
## Purpose

Simplify code logic and reduce management cost.
JIRA issue: [CORE-19973](https://jira.reactos.org/browse/CORE-19973)

## Proposed changes

- Add `IntGdiLoadFontByIndexFromMemory` helper function.
- Simplify `IntGdiLoadFontsFromMemory` function.

## TODO

- [x] Do tests.