### PR TITLE
[NTOS] Make KeFeatureBits 64 bits and detect more features

### DIFF
--- a/ntoskrnl/ex/sysinfo.c
+++ b/ntoskrnl/ex/sysinfo.c
@@ -664,7 +664,13 @@ QSI_DEF(SystemProcessorInformation)
 #else
     Spi->MaximumProcessors = 0;
 #endif
-    Spi->ProcessorFeatureBits = KeFeatureBits;
+
+    /* According to Geoff Chappell, on Win 8.1 x64 / Win 10 x86, where this
+       field is extended to 64 bits, it continues to produce only the low 32
+       bits. For the full value, use SYSTEM_PROCESSOR_FEATURES_INFORMATION.
+       See https://www.geoffchappell.com/studies/windows/km/ntoskrnl/api/ex/sysinfo/processor.htm
+     */
+    Spi->ProcessorFeatureBits = (ULONG)KeFeatureBits;
 
     DPRINT("Arch %u Level %u Rev 0x%x\n", Spi->ProcessorArchitecture,
         Spi->ProcessorLevel, Spi->ProcessorRevision);

--- a/ntoskrnl/include/internal/i386/ke.h
+++ b/ntoskrnl/include/internal/i386/ke.h
@@ -22,6 +22,14 @@ extern "C"
 #define KD_BREAKPOINT_SIZE        sizeof(UCHAR)
 #define KD_BREAKPOINT_VALUE       0xCC
 
+/* CPUID 1 - ECX flags */
+#define X86_FEATURE_SSE3        0x00000001
+#define X86_FEATURE_SSSE3       0x00000200
+#define X86_FEATURE_SSE4_1      0x00080000
+#define X86_FEATURE_SSE4_2      0x00100000
+#define X86_FEATURE_XSAVE       0x04000000
+#define X86_FEATURE_RDRAND      0x40000000
+
 /* CPUID 1 - EDX flags */
 #define X86_FEATURE_FPU         0x00000001 /* x87 FPU is present */
 #define X86_FEATURE_VME         0x00000002 /* Virtual 8086 Extensions are present */

--- a/ntoskrnl/include/internal/i386/ke.h
+++ b/ntoskrnl/include/internal/i386/ke.h
@@ -462,7 +462,7 @@ NTAPI
 KiSetProcessorType(VOID);
 
 CODE_SEG("INIT")
-ULONG
+ULONG64
 NTAPI
 KiGetFeatureBits(VOID);
 

--- a/ntoskrnl/include/internal/ke.h
+++ b/ntoskrnl/include/internal/ke.h
@@ -103,7 +103,7 @@ extern BOOLEAN ExCmosClockIsSane;
 extern USHORT KeProcessorArchitecture;
 extern USHORT KeProcessorLevel;
 extern USHORT KeProcessorRevision;
-extern ULONG KeFeatureBits;
+extern ULONG64 KeFeatureBits;
 extern KNODE KiNode0;
 extern PKNODE KeNodeBlock[1];
 extern UCHAR KeNumberNodes;

--- a/ntoskrnl/ke/amd64/cpu.c
+++ b/ntoskrnl/ke/amd64/cpu.c
@@ -206,6 +206,7 @@ KiGetFeatureBits(VOID)
     if (VersionInfo.Ecx.Bits.SSSE3) FeatureBits |= KF_SSSE3;
     if (VersionInfo.Ecx.Bits.CMPXCHG16B) FeatureBits |= KF_CMPXCHG16B;
     if (VersionInfo.Ecx.Bits.SSE4_1) FeatureBits |= KF_SSE4_1;
+    if (VersionInfo.Ecx.Bits.SSE4_2) FeatureBits |= KF_SSE4_2;
     if (VersionInfo.Ecx.Bits.XSAVE) FeatureBits |= KF_XSTATE;
     if (VersionInfo.Ecx.Bits.RDRAND) FeatureBits |= KF_RDRAND;
 

--- a/ntoskrnl/ke/amd64/krnlinit.c
+++ b/ntoskrnl/ke/amd64/krnlinit.c
@@ -233,7 +233,7 @@ KiInitializeKernel(IN PKPROCESS InitProcess,
     ULONG i;
 
     /* Set boot-level flags */
-    KeFeatureBits = Prcb->FeatureBits;
+    KeFeatureBits = Prcb->FeatureBits | (ULONG64)Prcb->FeatureBitsHigh << 32;
 
     /* Initialize 8/16 bit SList support */
     RtlpUse16ByteSLists = (KeFeatureBits & KF_CMPXCHG16B) ? TRUE : FALSE;

--- a/ntoskrnl/ke/i386/cpu.c
+++ b/ntoskrnl/ke/i386/cpu.c
@@ -209,13 +209,13 @@ KiSetProcessorType(VOID)
 }
 
 CODE_SEG("INIT")
-ULONG
+ULONG64
 NTAPI
 KiGetFeatureBits(VOID)
 {
     PKPRCB Prcb = KeGetCurrentPrcb();
     ULONG Vendor;
-    ULONG FeatureBits = KF_WORKING_PTE;
+    ULONG64 FeatureBits = KF_WORKING_PTE;
     CPU_INFO CpuInfo, DummyCpuInfo;
     UCHAR Ccr1;
     BOOLEAN ExtendedCPUID = TRUE;

--- a/ntoskrnl/ke/i386/cpu.c
+++ b/ntoskrnl/ke/i386/cpu.c
@@ -361,6 +361,14 @@ KiGetFeatureBits(VOID)
             break;
     }
 
+    /* Get some features from ECX */
+    if (CpuInfo.Ecx & X86_FEATURE_SSE3) FeatureBits |= KF_SSE3;
+    if (CpuInfo.Ecx & X86_FEATURE_SSSE3) FeatureBits |= KF_SSSE3;
+    if (CpuInfo.Ecx & X86_FEATURE_SSE4_1) FeatureBits |= KF_SSE4_1;
+    if (CpuInfo.Ecx & X86_FEATURE_SSE4_2) FeatureBits |= KF_SSE4_2;
+    if (CpuInfo.Ecx & X86_FEATURE_XSAVE) FeatureBits |= KF_XSTATE;
+    if (CpuInfo.Ecx & X86_FEATURE_RDRAND) FeatureBits |= KF_RDRAND;
+
     /* Set the current features */
     CpuFeatures = CpuInfo.Edx;
 

--- a/ntoskrnl/ke/i386/kiinit.c
+++ b/ntoskrnl/ke/i386/kiinit.c
@@ -572,6 +572,17 @@ KiInitializeKernel(IN PKPROCESS InitProcess,
         (KeFeatureBits & KF_3DNOW) ? TRUE: FALSE;
     SharedUserData->ProcessorFeatures[PF_RDTSC_INSTRUCTION_AVAILABLE] =
         (KeFeatureBits & KF_RDTSC) ? TRUE: FALSE;
+    SharedUserData->ProcessorFeatures[PF_RDRAND_INSTRUCTION_AVAILABLE] =
+        (KeFeatureBits & KF_RDRAND) ? TRUE : FALSE;
+    // Note: On x86 we lack support for saving/restoring SSE state
+    SharedUserData->ProcessorFeatures[PF_SSE3_INSTRUCTIONS_AVAILABLE] =
+        (KeFeatureBits & KF_SSE3) ? TRUE : FALSE;
+    SharedUserData->ProcessorFeatures[PF_SSSE3_INSTRUCTIONS_AVAILABLE] =
+        (KeFeatureBits & KF_SSSE3) ? TRUE : FALSE;
+    SharedUserData->ProcessorFeatures[PF_SSE4_1_INSTRUCTIONS_AVAILABLE] =
+        (KeFeatureBits & KF_SSE4_1) ? TRUE : FALSE;
+    SharedUserData->ProcessorFeatures[PF_SSE4_2_INSTRUCTIONS_AVAILABLE] =
+        (KeFeatureBits & KF_SSE4_2) ? TRUE : FALSE;
 
     /* Set up the thread-related fields in the PRCB */
     Prcb->CurrentThread = InitThread;

--- a/ntoskrnl/ke/i386/kiinit.c
+++ b/ntoskrnl/ke/i386/kiinit.c
@@ -384,7 +384,7 @@ KiVerifyCpuFeatures(PKPRCB Prcb)
         KeBugCheckEx(UNSUPPORTED_PROCESSOR, 0x386, 0, 0, 0);
 
     // 3. Finally, obtain CPU features.
-    ULONG FeatureBits = KiGetFeatureBits();
+    ULONG64 FeatureBits = KiGetFeatureBits();
 
     // 4. Verify it supports everything we need.
     if (!(FeatureBits & KF_RDTSC))
@@ -423,7 +423,8 @@ KiVerifyCpuFeatures(PKPRCB Prcb)
     }
 
     // 5. Save feature bits.
-    Prcb->FeatureBits = FeatureBits;
+    Prcb->FeatureBits = (ULONG)FeatureBits;
+    Prcb->FeatureBitsHigh = FeatureBits >> 32;
 }
 
 CODE_SEG("INIT")
@@ -445,7 +446,7 @@ KiInitializeKernel(IN PKPROCESS InitProcess,
 
     /* Set boot-level flags */
     if (Number == 0)
-        KeFeatureBits = Prcb->FeatureBits;
+        KeFeatureBits = Prcb->FeatureBits | (ULONG64)Prcb->FeatureBitsHigh << 32;
 
     /* Set the default NX policy (opt-in) */
     SharedUserData->NXSupportPolicy = NX_SUPPORT_POLICY_OPTIN;

--- a/ntoskrnl/ke/krnlinit.c
+++ b/ntoskrnl/ke/krnlinit.c
@@ -19,7 +19,7 @@
 USHORT KeProcessorArchitecture;
 USHORT KeProcessorLevel;
 USHORT KeProcessorRevision;
-ULONG KeFeatureBits;
+ULONG64 KeFeatureBits;
 
 /* System call count */
 ULONG KiServiceLimit = NUMBER_OF_SYSCALLS;

--- a/sdk/include/ndk/amd64/ketypes.h
+++ b/sdk/include/ndk/amd64/ketypes.h
@@ -939,7 +939,10 @@ typedef struct _KPRCB
     ULONG CacheCount;
 #endif
 #ifdef __REACTOS__
+#if  (NTDDI_VERSION < NTDDI_WINBLUE)
+    // On Win 8.1+ the FeatureBits field is extended to 64 bits
     ULONG FeatureBitsHigh;
+#endif
 #endif
 } KPRCB, *PKPRCB;
 

--- a/sdk/include/ndk/extypes.h
+++ b/sdk/include/ndk/extypes.h
@@ -761,7 +761,11 @@ typedef struct _SYSTEM_PROCESSOR_INFORMATION
 #else
     USHORT MaximumProcessors;
 #endif
+#if (NTDDI_VERSION >= NTDDI_WIN10) || ((NTDDI_VERSION >= NTDDI_WINBLUE) && defined(_WIN64))
+    ULONG64 ProcessorFeatureBits;
+#else
     ULONG ProcessorFeatureBits;
+#endif
 } SYSTEM_PROCESSOR_INFORMATION, *PSYSTEM_PROCESSOR_INFORMATION;
 
 // Class 2

--- a/sdk/include/ndk/i386/ketypes.h
+++ b/sdk/include/ndk/i386/ketypes.h
@@ -781,6 +781,12 @@ typedef struct _KPRCB
     ULONG PackageProcessorSet;
     ULONG CoreProcessorSet;
 #endif
+#ifdef __REACTOS__
+#if  (NTDDI_VERSION < NTDDI_WIN10)
+    // On Win 10+ the FeatureBits field is extended to 64 bits
+    ULONG FeatureBitsHigh;
+#endif
+#endif
 } KPRCB, *PKPRCB;
 
 //


### PR DESCRIPTION
## Purpose

- Make KeFeatureBits 64 bits
- Detect more features

## Test
- ✅ KVM x86: https://reactos.org/testman/compare.php?ids=100025,100028,100029,100035
