### PR TITLE
[CMAKE] Try to fix MSVC add_linker_script

### DIFF
--- a/sdk/cmake/msvc.cmake
+++ b/sdk/cmake/msvc.cmake
@@ -578,10 +578,10 @@ function(add_linker_script _target _linker_script_file)
         # Generate at compile-time a linker response file and append it
         # to the linker command-line.
         add_custom_command(
-            OUTPUT ${_generated_file}
-            # TARGET ${_target} PRE_LINK # PRE_BUILD
+            # OUTPUT ${_generated_file}
+            TARGET ${_target} PRE_LINK # PRE_BUILD
             COMMAND ${CMAKE_C_COMPILER} /nologo ${_no_std_includes_flag} /D__LINKER__ /EP /c "${_file_full_path}" > "${_generated_file}"
-            DEPENDS ${_file_full_path}
+            # DEPENDS ${_file_full_path}
             VERBATIM)
         set_source_files_properties(${_generated_file} PROPERTIES GENERATED TRUE)
         # add_custom_target("${_target}_${_file_name}" ALL DEPENDS ${_generated_file})

--- a/sdk/cmake/msvc.cmake
+++ b/sdk/cmake/msvc.cmake
@@ -578,8 +578,8 @@ function(add_linker_script _target _linker_script_file)
         # Generate at compile-time a linker response file and append it
         # to the linker command-line.
         add_custom_command(
-            # OUTPUT ${_generated_file}
-            TARGET ${_target} PRE_LINK # PRE_BUILD
+            OUTPUT ${_generated_file}
+            # TARGET ${_target} PRE_LINK # PRE_BUILD
             COMMAND ${CMAKE_C_COMPILER} /nologo ${_no_std_includes_flag} /D__LINKER__ /EP /c "${_file_full_path}" > "${_generated_file}"
             DEPENDS ${_file_full_path}
             VERBATIM)
@@ -587,7 +587,7 @@ function(add_linker_script _target _linker_script_file)
         # add_custom_target("${_target}_${_file_name}" ALL DEPENDS ${_generated_file})
         # add_dependencies(${_target} "${_target}_${_file_name}")
         target_link_options(${_target} PRIVATE "@${_generated_file}")
-        set_property(TARGET ${_target} APPEND PROPERTY LINK_DEPENDS ${_file_full_path})
+        set_property(TARGET ${_target} APPEND PROPERTY LINK_DEPENDS ${_generated_file})
     endif()
 endfunction()
 


### PR DESCRIPTION
Newer CMake versions complain: "The following keywords are not supported when using add_custom_command(TARGET): DEPENDS."
