### PR TITLE
Try to fix regression

### DIFF
--- a/sdk/include/asm/asm.inc
+++ b/sdk/include/asm/asm.inc
@@ -319,7 +319,6 @@ ENDM
 .macro align x
     .align x
 .endm
-#define ALIGN align
 
 /* MASM compatible REPEAT, additional ENDR */
 #define REPEAT .rept
@@ -353,8 +352,8 @@ ENDM
 .endm
 
 /* MASM needs an END tag */
-#define END
-#define end
+.macro END
+.endm
 
 .macro .MODEL model
 .endm
@@ -362,7 +361,6 @@ ENDM
 .macro .code
     .text
 .endm
-#define CODESEG .code
 
 .macro .const
     .section .rdata


### PR DESCRIPTION
## Purpose

[ASM] Use macros instead of defines

Defines can cause problems, like previously with the end define, which caused a jump to label ".end" to be interpreted as a jump to ".", which is the current address, resulting in an infinite loop.
Remove obsolete CODESEG

Should fix tests