### PR TITLE
[UXTHEME][UXTHEME_APITEST][SDK] GetThemeParseErrorInfo

### DIFF
--- a/dll/win32/uxtheme/CMakeLists.txt
+++ b/dll/win32/uxtheme/CMakeLists.txt
@@ -6,6 +6,7 @@ spec2def(uxtheme.dll uxtheme.spec ADD_IMPORTLIB)
 list(APPEND SOURCE
     buffer.c
     draw.c
+    errinfo.c
     main.c
     metric.c
     msstyles.c

--- a/dll/win32/uxtheme/errinfo.c
+++ b/dll/win32/uxtheme/errinfo.c
@@ -10,7 +10,15 @@
 #include <strsafe.h>
 
 HRESULT
-UXTHEME_MakeErrorLast(VOID)
+UXTHEME_MakeError32(_In_ LONG error)
+{
+    if (error < 0)
+        return (HRESULT)error;
+    return HRESULT_FROM_WIN32(error);
+}
+
+HRESULT
+UXTHEME_MakeLastError(VOID)
 {
     return UXTHEME_MakeError32(GetLastError());
 }
@@ -96,7 +104,7 @@ UXTHEME_FormatParseMessage(
     ret = UXTHEME_FormatLocalMsg(hUxTheme, nID, pszDest, cchDest, szDrive, pErrInfo);
     FreeLibrary(hUxTheme);
 
-    return ret ? S_OK : UXTHEME_MakeErrorLast();
+    return ret ? S_OK : UXTHEME_MakeLastError();
 }
 
 // Parser should use this function on failure

--- a/dll/win32/uxtheme/errinfo.c
+++ b/dll/win32/uxtheme/errinfo.c
@@ -169,6 +169,6 @@ HRESULT WINAPI
 GetThemeParseErrorInfo(_Inout_ PPARSE_ERROR_INFO pInfo)
 {
     if (IsBadWritePtr(pInfo, sizeof(*pInfo)))
-        return UXTHEME_MakeError32(E_POINTER);
+        return E_POINTER;
     return UXTHEME_GetThemeParseErrorInfo(pInfo);
 }

--- a/dll/win32/uxtheme/errinfo.c
+++ b/dll/win32/uxtheme/errinfo.c
@@ -113,32 +113,6 @@ UXTHEME_FormatParseMessage(
     return ret ? S_OK : UXTHEME_MakeErrorLast();
 }
 
-HRESULT
-UXTHEME_GetThemeParseErrorInfo(_Inout_ PPARSE_ERROR_INFO pInfo)
-{
-    PTMERRINFO pErrInfo;
-    HRESULT hr;
-
-    if (pInfo->cbSize != sizeof(*pInfo))
-        return E_INVALIDARG;
-
-    pErrInfo = UXTHEME_GetParseErrorInfo(TRUE);
-    if (!pErrInfo)
-        return E_OUTOFMEMORY;
-
-    hr = UXTHEME_FormatParseMessage(pErrInfo, pInfo->ErrInfo.szPath0,
-                                    _countof(pInfo->ErrInfo.szPath0) +
-                                    _countof(pInfo->ErrInfo.szPath1));
-    if (FAILED(hr))
-        return hr;
-
-    pInfo->ErrInfo.nID = pErrInfo->nID;
-    pInfo->ErrInfo.dwError = pErrInfo->dwError;
-    StringCchCopyW(pInfo->ErrInfo.szPath2, _countof(pInfo->ErrInfo.szPath2), pErrInfo->szPath2);
-    StringCchCopyW(pInfo->ErrInfo.szPath3, _countof(pInfo->ErrInfo.szPath3), pErrInfo->szPath3);
-    return hr;
-}
-
 // Parser should use this function on failure
 HRESULT
 UXTHEME_MakeParseError(
@@ -168,7 +142,28 @@ UXTHEME_MakeParseError(
 HRESULT WINAPI
 GetThemeParseErrorInfo(_Inout_ PPARSE_ERROR_INFO pInfo)
 {
-    if (IsBadWritePtr(pInfo, sizeof(*pInfo)))
+    PTMERRINFO pErrInfo;
+    HRESULT hr;
+
+    if (!pInfo)
         return E_POINTER;
-    return UXTHEME_GetThemeParseErrorInfo(pInfo);
+
+    if (pInfo->cbSize != sizeof(*pInfo))
+        return E_INVALIDARG;
+
+    pErrInfo = UXTHEME_GetParseErrorInfo(TRUE);
+    if (!pErrInfo)
+        return E_OUTOFMEMORY;
+
+    hr = UXTHEME_FormatParseMessage(pErrInfo, pInfo->ErrInfo.szPath0,
+                                    _countof(pInfo->ErrInfo.szPath0) +
+                                    _countof(pInfo->ErrInfo.szPath1));
+    if (FAILED(hr))
+        return hr;
+
+    pInfo->ErrInfo.nID = pErrInfo->nID;
+    pInfo->ErrInfo.dwError = pErrInfo->dwError;
+    StringCchCopyW(pInfo->ErrInfo.szPath2, _countof(pInfo->ErrInfo.szPath2), pErrInfo->szPath2);
+    StringCchCopyW(pInfo->ErrInfo.szPath3, _countof(pInfo->ErrInfo.szPath3), pErrInfo->szPath3);
+    return hr;
 }

--- a/dll/win32/uxtheme/errinfo.c
+++ b/dll/win32/uxtheme/errinfo.c
@@ -56,22 +56,22 @@ UXTHEME_FormatLocalMsg(
     _In_ LPCWSTR pszDrive,
     _In_ PTMERRINFO pErrInfo)
 {
-    WCHAR szText[MAX_PATH];
+    WCHAR szFormat[MAX_PATH];
     LPWSTR pch;
 
-    if (!LoadStringW(hInstance, uID, szText, _countof(szText)))
+    if (!LoadStringW(hInstance, uID, szFormat, _countof(szFormat)))
         return FALSE;
 
-    for (pch = szText; *pch; ++pch)
+    for (pch = szFormat; *pch; ++pch)
     {
         if (*pch == L'%' && (*++pch == L'1' || *pch == L'2'))
             *pch = 's';
     }
 
-    if (!szText[0])
+    if (!szFormat[0])
         return FALSE;
 
-    StringCchPrintfW(pszDest, cchDest, szText, pErrInfo->szPath0, pErrInfo->szPath1);
+    StringCchPrintfW(pszDest, cchDest, szFormat, pErrInfo->szPath0, pErrInfo->szPath1);
     return TRUE;
 }
 

--- a/dll/win32/uxtheme/errinfo.c
+++ b/dll/win32/uxtheme/errinfo.c
@@ -119,7 +119,7 @@ UXTHEME_GetThemeParseErrorInfo(_Inout_ PPARSE_ERROR_INFO pInfo)
     PTMERRINFO pErrInfo;
     HRESULT hr;
 
-    if (pInfo->cbSize != sizeof(PARSE_ERROR_INFO))
+    if (pInfo->cbSize != sizeof(*pInfo))
         return UXTHEME_MakeError32(E_INVALIDARG);
 
     pErrInfo = UXTHEME_GetParseErrorInfo(TRUE);

--- a/dll/win32/uxtheme/errinfo.c
+++ b/dll/win32/uxtheme/errinfo.c
@@ -20,7 +20,7 @@ UXTHEME_GetParseErrorInfo(_In_ BOOL bCreate)
 {
     PTMERRINFO pErrInfo;
 
-    if (gdwErrorInfoTlsIndex == -1)
+    if (gdwErrorInfoTlsIndex == TLS_OUT_OF_INDEXES)
         return NULL;
 
     pErrInfo = TlsGetValue(gdwErrorInfoTlsIndex);

--- a/dll/win32/uxtheme/errinfo.c
+++ b/dll/win32/uxtheme/errinfo.c
@@ -69,7 +69,7 @@ UXTHEME_FormatLocalMsg(
             continue;
 
         ++pch;
-        if (*pch == L'1' || *pch == L'2'))
+        if (*pch == L'1' || *pch == L'2')
             *pch = L's';
     }
 

--- a/dll/win32/uxtheme/errinfo.c
+++ b/dll/win32/uxtheme/errinfo.c
@@ -98,11 +98,11 @@ UXTHEME_FormatParseMessage(
 
     _wsplitpath(szFullPath, szDrive, szDir, szFileName, szExt);
     if (lstrcmpiW(szFileName, L"packthem") == 0)
-        return S_OK;
-
-    hMod = GetModuleHandleW(NULL);
-    if (UXTHEME_FormatLocalMsg(hMod, nID, pszDest, cchDest, szDrive, pErrInfo))
-        return S_OK;
+    {
+        hMod = GetModuleHandleW(NULL);
+        if (UXTHEME_FormatLocalMsg(hMod, nID, pszDest, cchDest, szDrive, pErrInfo))
+            return S_OK;
+    }
 
     hUxTheme = LoadLibraryW(L"uxtheme.dll");
     if (!hUxTheme)

--- a/dll/win32/uxtheme/errinfo.c
+++ b/dll/win32/uxtheme/errinfo.c
@@ -137,6 +137,7 @@ UXTHEME_GetThemeParseErrorInfo(_Inout_ PPARSE_ERROR_INFO pInfo)
     return hr;
 }
 
+// Parser should use this function on failure
 HRESULT
 UXTHEME_MakeParseError(
     _In_ UINT nID,

--- a/dll/win32/uxtheme/errinfo.c
+++ b/dll/win32/uxtheme/errinfo.c
@@ -57,27 +57,13 @@ UXTHEME_FormatLocalMsg(
     _In_ PTMERRINFO pErrInfo)
 {
     WCHAR szFormat[MAX_PATH];
-    LPWSTR pch;
+    LPCWSTR args[2] = { pErrInfo->szPath0, pErrInfo->szPath1 };
 
-    if (!LoadStringW(hInstance, uID, szFormat, _countof(szFormat)))
+    if (!LoadStringW(hInstance, uID, szFormat, _countof(szFormat)) || !szFormat[0])
         return FALSE;
 
-    // Convert "%1" and "%2" to "%s"
-    for (pch = szFormat; *pch; ++pch)
-    {
-        if (*pch != L'%')
-            continue;
-
-        ++pch;
-        if (*pch == L'1' || *pch == L'2')
-            *pch = L's';
-    }
-
-    if (!szFormat[0])
-        return FALSE;
-
-    StringCchPrintfW(pszDest, cchDest, szFormat, pErrInfo->szPath0, pErrInfo->szPath1);
-    return TRUE;
+    return FormatMessageW(FORMAT_MESSAGE_FROM_STRING | FORMAT_MESSAGE_ARGUMENT_ARRAY,
+                          szFormat, 0, 0, pszDest, cchDest, (va_list *)args) != 0;
 }
 
 static HRESULT

--- a/dll/win32/uxtheme/errinfo.c
+++ b/dll/win32/uxtheme/errinfo.c
@@ -29,7 +29,7 @@ UXTHEME_GetParseErrorInfo(_In_ BOOL bCreate)
 
     if (bCreate)
     {
-        pErrInfo = LocalAlloc(LPTR, sizeof(TMERRINFO));
+        pErrInfo = LocalAlloc(LPTR, sizeof(*pErrInfo));
         TlsSetValue(gdwErrorInfoTlsIndex, pErrInfo);
     }
 

--- a/dll/win32/uxtheme/errinfo.c
+++ b/dll/win32/uxtheme/errinfo.c
@@ -120,7 +120,7 @@ UXTHEME_GetThemeParseErrorInfo(_Inout_ PPARSE_ERROR_INFO pInfo)
     HRESULT hr;
 
     if (pInfo->cbSize != sizeof(*pInfo))
-        return UXTHEME_MakeError32(E_INVALIDARG);
+        return E_INVALIDARG;
 
     pErrInfo = UXTHEME_GetParseErrorInfo(TRUE);
     if (!pErrInfo)

--- a/dll/win32/uxtheme/errinfo.c
+++ b/dll/win32/uxtheme/errinfo.c
@@ -18,22 +18,22 @@ UXTHEME_MakeErrorLast(VOID)
 PTMERRINFO
 UXTHEME_GetParseErrorInfo(_In_ BOOL bCreate)
 {
-    PTMERRINFO ptr;
+    PTMERRINFO pErrInfo;
 
     if (gdwErrorInfoTlsIndex == -1)
         return NULL;
 
-    ptr = TlsGetValue(gdwErrorInfoTlsIndex);
-    if (ptr)
-        return ptr;
+    pErrInfo = TlsGetValue(gdwErrorInfoTlsIndex);
+    if (pErrInfo)
+        return pErrInfo;
 
     if (bCreate)
     {
-        ptr = LocalAlloc(LPTR, sizeof(TMERRINFO));
-        TlsSetValue(gdwErrorInfoTlsIndex, ptr);
+        pErrInfo = LocalAlloc(LPTR, sizeof(TMERRINFO));
+        TlsSetValue(gdwErrorInfoTlsIndex, pErrInfo);
     }
 
-    return ptr;
+    return pErrInfo;
 }
 
 VOID
@@ -62,10 +62,15 @@ UXTHEME_FormatLocalMsg(
     if (!LoadStringW(hInstance, uID, szFormat, _countof(szFormat)))
         return FALSE;
 
+    // Convert "%1" and "%2" to "%s"
     for (pch = szFormat; *pch; ++pch)
     {
-        if (*pch == L'%' && (*++pch == L'1' || *pch == L'2'))
-            *pch = 's';
+        if (*pch != L'%')
+            continue;
+
+        ++pch;
+        if (*pch == L'1' || *pch == L'2'))
+            *pch = L's';
     }
 
     if (!szFormat[0])
@@ -92,7 +97,6 @@ UXTHEME_FormatParseMessage(
         return S_OK;
 
     _wsplitpath(szFullPath, szDrive, szDir, szFileName, szExt);
-
     if (lstrcmpiW(szFileName, L"packthem") == 0)
         return S_OK;
 

--- a/dll/win32/uxtheme/errinfo.c
+++ b/dll/win32/uxtheme/errinfo.c
@@ -126,7 +126,9 @@ UXTHEME_GetThemeParseErrorInfo(_Inout_ PPARSE_ERROR_INFO pInfo)
     if (!pErrInfo)
         return UXTHEME_MakeError32(E_OUTOFMEMORY);
 
-    hr = UXTHEME_FormatParseMessage(pErrInfo, pInfo->ErrInfo.szPath0, _countof(pInfo->ErrInfo.szPath0));
+    hr = UXTHEME_FormatParseMessage(pErrInfo, pInfo->ErrInfo.szPath0,
+                                    _countof(pInfo->ErrInfo.szPath0) +
+                                    _countof(pInfo->ErrInfo.szPath1));
     if (FAILED(hr))
         return hr;
 

--- a/dll/win32/uxtheme/errinfo.c
+++ b/dll/win32/uxtheme/errinfo.c
@@ -124,7 +124,7 @@ UXTHEME_GetThemeParseErrorInfo(_Inout_ PPARSE_ERROR_INFO pInfo)
 
     pErrInfo = UXTHEME_GetParseErrorInfo(TRUE);
     if (!pErrInfo)
-        return UXTHEME_MakeError32(E_OUTOFMEMORY);
+        return E_OUTOFMEMORY;
 
     hr = UXTHEME_FormatParseMessage(pErrInfo, pInfo->ErrInfo.szPath0,
                                     _countof(pInfo->ErrInfo.szPath0) +

--- a/dll/win32/uxtheme/errinfo.c
+++ b/dll/win32/uxtheme/errinfo.c
@@ -115,13 +115,13 @@ UXTHEME_MakeParseError(
     _In_ LPCWSTR pszPath1,
     _In_ LPCWSTR pszPath2,
     _In_ LPCWSTR pszPath3,
-    _In_ DWORD dwError)
+    _In_ INT nLineNo)
 {
     PTMERRINFO pErrInfo = UXTHEME_GetParseErrorInfo(TRUE);
     if (pErrInfo)
     {
         pErrInfo->nID = nID;
-        pErrInfo->dwError = dwError;
+        pErrInfo->nLineNo = nLineNo;
         StringCchCopyW(pErrInfo->szPath0, _countof(pErrInfo->szPath0), pszPath0);
         StringCchCopyW(pErrInfo->szPath1, _countof(pErrInfo->szPath1), pszPath1);
         StringCchCopyW(pErrInfo->szPath2, _countof(pErrInfo->szPath2), pszPath2);
@@ -156,7 +156,7 @@ GetThemeParseErrorInfo(_Inout_ PPARSE_ERROR_INFO pInfo)
         return hr;
 
     pInfo->ErrInfo.nID = pErrInfo->nID;
-    pInfo->ErrInfo.dwError = pErrInfo->dwError;
+    pInfo->ErrInfo.nLineNo = pErrInfo->nLineNo;
     StringCchCopyW(pInfo->ErrInfo.szPath2, _countof(pInfo->ErrInfo.szPath2), pErrInfo->szPath2);
     StringCchCopyW(pInfo->ErrInfo.szPath3, _countof(pInfo->ErrInfo.szPath3), pErrInfo->szPath3);
     return hr;

--- a/dll/win32/uxtheme/main.c
+++ b/dll/win32/uxtheme/main.c
@@ -22,7 +22,6 @@
 
 /***********************************************************************/
 
-/* For the moment, do nothing here. */
 BOOL WINAPI DllMain(HINSTANCE hInstDLL, DWORD fdwReason, LPVOID lpv)
 {
     TRACE("%p 0x%x %p: stub\n", hInstDLL, fdwReason, lpv);
@@ -32,6 +31,7 @@ BOOL WINAPI DllMain(HINSTANCE hInstDLL, DWORD fdwReason, LPVOID lpv)
             UXTHEME_InitSystem(hInstDLL);
             break;
         case DLL_PROCESS_DETACH:
+            UXTHEME_UnInitSystem(hInstDLL);
             break;
     }
     return TRUE;

--- a/dll/win32/uxtheme/main.c
+++ b/dll/win32/uxtheme/main.c
@@ -33,6 +33,11 @@ BOOL WINAPI DllMain(HINSTANCE hInstDLL, DWORD fdwReason, LPVOID lpv)
         case DLL_PROCESS_DETACH:
             UXTHEME_UnInitSystem(hInstDLL);
             break;
+        case DLL_THREAD_ATTACH:
+            break;
+        case DLL_THREAD_DETACH:
+            UXTHEME_DeleteParseErrorInfo();
+            break;
     }
     return TRUE;
 }

--- a/dll/win32/uxtheme/system.c
+++ b/dll/win32/uxtheme/system.c
@@ -24,6 +24,8 @@
 #include <winreg.h>
 #include <uxundoc.h>
 
+DWORD gdwErrorInfoTlsIndex = -1;
+
 /***********************************************************************
  * Defines and global variables
  */
@@ -588,6 +590,19 @@ void UXTHEME_InitSystem(HINSTANCE hInst)
 
     RtlInitializeHandleTable(0xFFF, sizeof(UXTHEME_HANDLE), &g_UxThemeHandleTable);
     g_cHandles = 0;
+
+    gdwErrorInfoTlsIndex = TlsAlloc();
+}
+
+/***********************************************************************
+ *      UXTHEME_UnInitSystem
+ */
+void UXTHEME_UnInitSystem(HINSTANCE hInst)
+{
+    UXTHEME_DeleteParseErrorInfo();
+
+    TlsFree(gdwErrorInfoTlsIndex);
+    gdwErrorInfoTlsIndex = -1;
 }
 
 /***********************************************************************

--- a/dll/win32/uxtheme/system.c
+++ b/dll/win32/uxtheme/system.c
@@ -24,7 +24,7 @@
 #include <winreg.h>
 #include <uxundoc.h>
 
-DWORD gdwErrorInfoTlsIndex = -1;
+DWORD gdwErrorInfoTlsIndex = TLS_OUT_OF_INDEXES;
 
 /***********************************************************************
  * Defines and global variables
@@ -602,7 +602,7 @@ void UXTHEME_UnInitSystem(HINSTANCE hInst)
     UXTHEME_DeleteParseErrorInfo();
 
     TlsFree(gdwErrorInfoTlsIndex);
-    gdwErrorInfoTlsIndex = -1;
+    gdwErrorInfoTlsIndex = TLS_OUT_OF_INDEXES;
 }
 
 /***********************************************************************

--- a/dll/win32/uxtheme/uxtheme.spec
+++ b/dll/win32/uxtheme/uxtheme.spec
@@ -45,7 +45,7 @@
 45 stdcall -noname ClassicSystemParametersInfoW(long long ptr long)
 46 stdcall -noname ClassicAdjustWindowRectEx(ptr long long long)
 47 stdcall DrawThemeBackgroundEx(ptr ptr long long ptr ptr)
-48 stub -noname GetThemeParseErrorInfo
+48 stdcall -noname GetThemeParseErrorInfo(ptr)
 49 stdcall GetThemeAppProperties()
 50 stdcall GetThemeBackgroundContentRect(ptr ptr long long ptr ptr)
 51 stdcall GetThemeBackgroundExtent(ptr ptr long long ptr ptr)

--- a/dll/win32/uxtheme/uxthemep.h
+++ b/dll/win32/uxtheme/uxthemep.h
@@ -300,6 +300,6 @@ UXTHEME_MakeParseError(
     _In_ LPCWSTR pszPath1,
     _In_ LPCWSTR pszPath2,
     _In_ LPCWSTR pszPath3,
-    _In_ DWORD dwError);
+    _In_ INT nLineNo);
 
 #endif /* _UXTHEME_PCH_ */

--- a/dll/win32/uxtheme/uxthemep.h
+++ b/dll/win32/uxtheme/uxthemep.h
@@ -289,17 +289,31 @@ BOOL CALLBACK UXTHEME_broadcast_theme_changed (HWND hWnd, LPARAM enable);
 
 extern DWORD gdwErrorInfoTlsIndex;
 
-HRESULT UXTHEME_MakeError32(_In_ LONG error);
-HRESULT UXTHEME_MakeLastError(VOID);
 VOID UXTHEME_DeleteParseErrorInfo(VOID);
+
+static inline
+HRESULT
+UXTHEME_MakeError(_In_ LONG error)
+{
+    if (error < 0)
+        return (HRESULT)error;
+    return HRESULT_FROM_WIN32(error);
+}
+
+static inline
+HRESULT
+UXTHEME_MakeLastError(VOID)
+{
+    return UXTHEME_MakeError(GetLastError());
+}
 
 HRESULT
 UXTHEME_MakeParseError(
     _In_ UINT nID,
-    _In_ LPCWSTR pszPath0,
-    _In_ LPCWSTR pszPath1,
-    _In_ LPCWSTR pszPath2,
-    _In_ LPCWSTR pszPath3,
+    _In_ LPCWSTR pszParam1,
+    _In_ LPCWSTR pszParam2,
+    _In_ LPCWSTR pszFile,
+    _In_ LPCWSTR pszLine,
     _In_ INT nLineNo);
 
 #endif /* _UXTHEME_PCH_ */

--- a/dll/win32/uxtheme/uxthemep.h
+++ b/dll/win32/uxtheme/uxthemep.h
@@ -90,6 +90,16 @@ typedef struct _THEME_FILE {
     PTHEME_IMAGE images;
 } THEME_FILE, *PTHEME_FILE;
 
+typedef struct tagTMERRINFO
+{
+    UINT nID;
+    WCHAR szParam1[MAX_PATH];
+    WCHAR szParam2[MAX_PATH];
+    WCHAR szFile[MAX_PATH];
+    WCHAR szLine[MAX_PATH];
+    INT nLineNo;
+} TMERRINFO, *PTMERRINFO;
+
 typedef struct _UXINI_FILE *PUXINI_FILE;
 
 typedef struct _UXTHEME_HANDLE

--- a/dll/win32/uxtheme/uxthemep.h
+++ b/dll/win32/uxtheme/uxthemep.h
@@ -289,15 +289,8 @@ BOOL CALLBACK UXTHEME_broadcast_theme_changed (HWND hWnd, LPARAM enable);
 
 extern DWORD gdwErrorInfoTlsIndex;
 
-static inline HRESULT
-UXTHEME_MakeError32(_In_ LONG error)
-{
-    if (error < 0)
-        return (HRESULT)error;
-    return HRESULT_FROM_WIN32(error);
-}
-
-HRESULT UXTHEME_MakeErrorLast(VOID);
+HRESULT UXTHEME_MakeError32(_In_ LONG error);
+HRESULT UXTHEME_MakeLastError(VOID);
 VOID UXTHEME_DeleteParseErrorInfo(VOID);
 
 HRESULT

--- a/dll/win32/uxtheme/uxthemep.h
+++ b/dll/win32/uxtheme/uxthemep.h
@@ -276,6 +276,7 @@ extern ATOM atWndContext;
 extern BOOL g_bThemeHooksActive;
 
 void UXTHEME_InitSystem(HINSTANCE hInst);
+void UXTHEME_UnInitSystem(HINSTANCE hInst);
 void UXTHEME_LoadTheme(BOOL bLoad);
 BOOL CALLBACK UXTHEME_broadcast_theme_changed (HWND hWnd, LPARAM enable);
 
@@ -285,5 +286,27 @@ BOOL CALLBACK UXTHEME_broadcast_theme_changed (HWND hWnd, LPARAM enable);
 #define ALPHABLEND_BINARY           1
 /* Full alpha blending */
 #define ALPHABLEND_FULL             2
+
+extern DWORD gdwErrorInfoTlsIndex;
+
+static inline HRESULT
+UXTHEME_MakeError32(_In_ LONG error)
+{
+    if (error < 0)
+        return (HRESULT)error;
+    return HRESULT_FROM_WIN32(error);
+}
+
+HRESULT UXTHEME_MakeErrorLast(VOID);
+VOID UXTHEME_DeleteParseErrorInfo(VOID);
+
+HRESULT
+UXTHEME_MakeParseError(
+    _In_ UINT nID,
+    _In_ LPCWSTR pszPath0,
+    _In_ LPCWSTR pszPath1,
+    _In_ LPCWSTR pszPath2,
+    _In_ LPCWSTR pszPath3,
+    _In_ DWORD dwError);
 
 #endif /* _UXTHEME_PCH_ */

--- a/modules/rostests/apitests/uxtheme/CMakeLists.txt
+++ b/modules/rostests/apitests/uxtheme/CMakeLists.txt
@@ -2,6 +2,7 @@
 list(APPEND SOURCE
     CloseThemeData.c
     DrawThemeParentBackground.c
+    GetThemeParseErrorInfo.c
     SetWindowTheme.c
     SetThemeAppProperties.c
     ../include/msgtrace.c

--- a/modules/rostests/apitests/uxtheme/GetThemeParseErrorInfo.c
+++ b/modules/rostests/apitests/uxtheme/GetThemeParseErrorInfo.c
@@ -1,5 +1,5 @@
 /*
- * PROJECT:     ReactOS api tests
+ * PROJECT:     ReactOS API tests
  * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
  * PURPOSE:     Tests for GetThemeParseErrorInfo
  * COPYRIGHT:   Copyright 2025 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>

--- a/modules/rostests/apitests/uxtheme/GetThemeParseErrorInfo.c
+++ b/modules/rostests/apitests/uxtheme/GetThemeParseErrorInfo.c
@@ -81,7 +81,8 @@ START_TEST(GetThemeParseErrorInfo)
     ok_hex(hr, S_OK);
     ok_int(Info.ErrInfo.nID, 160);
 
-    ok(Info.ErrInfo.szPath0[0] != L'@', "Info.ErrInfo.szPath0 was empty\n");
+    ok(Info.ErrInfo.szPath0[0] != UNICODE_NULL, "Info.ErrInfo.szPath0 was empty\n");
+    ok(Info.ErrInfo.szPath0[0] != L'@', "Info.ErrInfo.szPath0 had no change\n");
     trace("Info.ErrInfo.szPath0: %S\n", Info.ErrInfo.szPath0); // "Must be Primitive, enum, or type: Invalid"
 
     ok_int(Info.ErrInfo.szPath1[0], L'@');

--- a/modules/rostests/apitests/uxtheme/GetThemeParseErrorInfo.c
+++ b/modules/rostests/apitests/uxtheme/GetThemeParseErrorInfo.c
@@ -73,14 +73,18 @@ START_TEST(GetThemeParseErrorInfo)
 
     ZeroMemory(&Info, sizeof(Info));
     Info.cbSize = sizeof(Info);
+    Info.ErrInfo.szPath0[0] = L'@';
+    Info.ErrInfo.szPath1[0] = L'@';
+    Info.ErrInfo.szPath2[0] = L'@';
+    Info.ErrInfo.szPath3[0] = L'@';
     hr = GetThemeParseErrorInfo(&Info);
     ok_hex(hr, S_OK);
     ok_int(Info.ErrInfo.nID, 160);
 
-    ok(Info.ErrInfo.szPath0[0] != 0, "Info.ErrInfo.szPath0 was empty\n");
+    ok(Info.ErrInfo.szPath0[0] != L'@', "Info.ErrInfo.szPath0 was empty\n");
     trace("Info.ErrInfo.szPath0: %S\n", Info.ErrInfo.szPath0); // "Must be Primitive, enum, or type: Invalid"
 
-    ok_int(Info.ErrInfo.szPath1[0], 0);
+    ok_int(Info.ErrInfo.szPath1[0], L'@');
     ok_wstr(Info.ErrInfo.szPath2, L"invalid.ini");
     ok_wstr(Info.ErrInfo.szPath3, L"Invalid=Invalid");
     ok_int(Info.ErrInfo.nLineNo, 2);

--- a/modules/rostests/apitests/uxtheme/GetThemeParseErrorInfo.c
+++ b/modules/rostests/apitests/uxtheme/GetThemeParseErrorInfo.c
@@ -73,20 +73,20 @@ START_TEST(GetThemeParseErrorInfo)
 
     ZeroMemory(&Info, sizeof(Info));
     Info.cbSize = sizeof(Info);
-    Info.ErrInfo.szPath0[0] = L'@';
-    Info.ErrInfo.szPath1[0] = L'@';
-    Info.ErrInfo.szPath2[0] = L'@';
-    Info.ErrInfo.szPath3[0] = L'@';
+    Info.szDescription[0] = L'@';
+    Info.szDescription[MAX_PATH] = L'@';
+    Info.szFile[0] = L'@';
+    Info.szLine[0] = L'@';
     hr = GetThemeParseErrorInfo(&Info);
     ok_hex(hr, S_OK);
-    ok_int(Info.ErrInfo.nID, 160);
+    ok_int(Info.nID, 160);
 
-    ok(Info.ErrInfo.szPath0[0] != UNICODE_NULL, "Info.ErrInfo.szPath0 was empty\n");
-    ok(Info.ErrInfo.szPath0[0] != L'@', "Info.ErrInfo.szPath0 had no change\n");
-    trace("Info.ErrInfo.szPath0: %S\n", Info.ErrInfo.szPath0); // "Must be Primitive, enum, or type: InvalidValueName"
+    ok(Info.szDescription[0] != UNICODE_NULL, "Info.szDescription was empty\n");
+    ok(Info.szDescription[0] != L'@', "Info.szDescription had no change\n");
+    trace("szDescription: %S\n", Info.szDescription); // "Must be Primitive, enum, or type: InvalidValueName"
 
-    ok_int(Info.ErrInfo.szPath1[0], L'@');
-    ok_wstr(Info.ErrInfo.szPath2, L"invalid.ini");
-    ok_wstr(Info.ErrInfo.szPath3, L"InvalidValueName=InvalidValue");
-    ok_int(Info.ErrInfo.nLineNo, 2);
+    ok_int(Info.szDescription[MAX_PATH], L'@');
+    ok_wstr(Info.szFile, L"invalid.ini");
+    ok_wstr(Info.szLine, L"InvalidValueName=InvalidValue");
+    ok_int(Info.nLineNo, 2);
 }

--- a/modules/rostests/apitests/uxtheme/GetThemeParseErrorInfo.c
+++ b/modules/rostests/apitests/uxtheme/GetThemeParseErrorInfo.c
@@ -83,7 +83,7 @@ START_TEST(GetThemeParseErrorInfo)
 
     ok(Info.szDescription[0] != UNICODE_NULL, "Info.szDescription was empty\n");
     ok(Info.szDescription[0] != L'@', "Info.szDescription had no change\n");
-    trace("szDescription: %S\n", Info.szDescription); // "Must be Primitive, enum, or type: InvalidValueName"
+    trace("szDescription: %s\n", wine_dbgstr_w(Info.szDescription)); // "Must be Primitive, enum, or type: InvalidValueName"
 
     ok_int(Info.szDescription[MAX_PATH], L'@');
     ok_wstr(Info.szFile, L"invalid.ini");

--- a/modules/rostests/apitests/uxtheme/GetThemeParseErrorInfo.c
+++ b/modules/rostests/apitests/uxtheme/GetThemeParseErrorInfo.c
@@ -1,0 +1,29 @@
+/*
+ * PROJECT:     ReactOS api tests
+ * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
+ * PURPOSE:     Tests for GetThemeParseErrorInfo
+ * COPYRIGHT:   Copyright 2025 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ */
+
+#include <apitest.h>
+#include <stdlib.h>
+#include <windows.h>
+#include <uxtheme.h>
+#include <uxundoc.h>
+
+START_TEST(GetThemeParseErrorInfo)
+{
+    HRESULT hr;
+    PARSE_ERROR_INFO Info;
+
+    hr = GetThemeParseErrorInfo(NULL);
+    ok_hex(hr, E_POINTER);
+
+    ZeroMemory(&Info, sizeof(Info));
+    hr = GetThemeParseErrorInfo(&Info);
+    ok_hex(hr, E_INVALIDARG);
+
+    Info.cbSize = sizeof(Info);
+    hr = GetThemeParseErrorInfo(&Info);
+    ok_hex(hr, HRESULT_FROM_WIN32(ERROR_RESOURCE_NAME_NOT_FOUND));
+}

--- a/modules/rostests/apitests/uxtheme/GetThemeParseErrorInfo.c
+++ b/modules/rostests/apitests/uxtheme/GetThemeParseErrorInfo.c
@@ -69,7 +69,7 @@ START_TEST(GetThemeParseErrorInfo)
     hr = ParseThemeIniFile(L"invalid.ini", szPath, ParseThemeIniFileProc, NULL);
     ok_hex(hr, HRESULT_FROM_WIN32(ERROR_UNKNOWN_PROPERTY));
 
-    DeleteFileW(L"invalid.ini");
+    _wremove(L"invalid.ini");
 
     ZeroMemory(&Info, sizeof(Info));
     Info.cbSize = sizeof(Info);

--- a/modules/rostests/apitests/uxtheme/GetThemeParseErrorInfo.c
+++ b/modules/rostests/apitests/uxtheme/GetThemeParseErrorInfo.c
@@ -62,8 +62,8 @@ START_TEST(GetThemeParseErrorInfo)
     }
 
     FILE *fout = _wfopen(L"invalid.ini", L"wb");
-    fprintf(fout, "[Invalid]\n");
-    fprintf(fout, "Invalid=Invalid\n");
+    fprintf(fout, "[InvalidKey]\n");
+    fprintf(fout, "InvalidValueName=InvalidValue\n");
     fclose(fout);
 
     hr = ParseThemeIniFile(L"invalid.ini", szPath, ParseThemeIniFileProc, NULL);
@@ -83,10 +83,10 @@ START_TEST(GetThemeParseErrorInfo)
 
     ok(Info.ErrInfo.szPath0[0] != UNICODE_NULL, "Info.ErrInfo.szPath0 was empty\n");
     ok(Info.ErrInfo.szPath0[0] != L'@', "Info.ErrInfo.szPath0 had no change\n");
-    trace("Info.ErrInfo.szPath0: %S\n", Info.ErrInfo.szPath0); // "Must be Primitive, enum, or type: Invalid"
+    trace("Info.ErrInfo.szPath0: %S\n", Info.ErrInfo.szPath0); // "Must be Primitive, enum, or type: InvalidValueName"
 
     ok_int(Info.ErrInfo.szPath1[0], L'@');
     ok_wstr(Info.ErrInfo.szPath2, L"invalid.ini");
-    ok_wstr(Info.ErrInfo.szPath3, L"Invalid=Invalid");
+    ok_wstr(Info.ErrInfo.szPath3, L"InvalidValueName=InvalidValue");
     ok_int(Info.ErrInfo.nLineNo, 2);
 }

--- a/modules/rostests/apitests/uxtheme/GetThemeParseErrorInfo.c
+++ b/modules/rostests/apitests/uxtheme/GetThemeParseErrorInfo.c
@@ -7,14 +7,39 @@
 
 #include <apitest.h>
 #include <stdlib.h>
+#include <stdio.h>
 #include <windows.h>
 #include <uxtheme.h>
 #include <uxundoc.h>
+
+typedef HRESULT (WINAPI *FN_GetThemeParseErrorInfo)(PPARSE_ERROR_INFO);
+typedef HRESULT (WINAPI *FN_ParseThemeIniFile)(LPCWSTR, LPWSTR, PARSETHEMEINIFILEPROC, LPVOID);
+
+static BOOL CALLBACK
+ParseThemeIniFileProc(
+    DWORD dwType,
+    LPWSTR pszParam1,
+    LPWSTR pszParam2,
+    LPWSTR pszParam3,
+    DWORD dwParam,
+    LPVOID lpData)
+{
+    return TRUE;
+}
 
 START_TEST(GetThemeParseErrorInfo)
 {
     HRESULT hr;
     PARSE_ERROR_INFO Info;
+    WCHAR szPath[MAX_PATH];
+
+    FN_GetThemeParseErrorInfo GetThemeParseErrorInfo =
+        (FN_GetThemeParseErrorInfo)GetProcAddress(GetModuleHandleW(L"uxtheme.dll"), MAKEINTRESOURCEA(48));
+    if (!GetThemeParseErrorInfo)
+    {
+        skip("No GetThemeParseErrorInfo found\n");
+        return;
+    }
 
     hr = GetThemeParseErrorInfo(NULL);
     ok_hex(hr, E_POINTER);
@@ -27,4 +52,36 @@ START_TEST(GetThemeParseErrorInfo)
     Info.cbSize = sizeof(Info);
     hr = GetThemeParseErrorInfo(&Info);
     ok_hex(hr, HRESULT_FROM_WIN32(ERROR_RESOURCE_NAME_NOT_FOUND));
+
+    FN_ParseThemeIniFile ParseThemeIniFile =
+        (FN_ParseThemeIniFile)GetProcAddress(GetModuleHandleW(L"uxtheme.dll"), MAKEINTRESOURCEA(11));
+    if (!ParseThemeIniFile)
+    {
+        skip("No ParseThemeIniFile found\n");
+        return;
+    }
+
+    FILE *fout = _wfopen(L"invalid.ini", L"wb");
+    fprintf(fout, "[Invalid]\n");
+    fprintf(fout, "Invalid=Invalid\n");
+    fclose(fout);
+
+    hr = ParseThemeIniFile(L"invalid.ini", szPath, ParseThemeIniFileProc, NULL);
+    ok_hex(hr, HRESULT_FROM_WIN32(ERROR_UNKNOWN_PROPERTY));
+
+    DeleteFileW(L"invalid.ini");
+
+    ZeroMemory(&Info, sizeof(Info));
+    Info.cbSize = sizeof(Info);
+    hr = GetThemeParseErrorInfo(&Info);
+    ok_hex(hr, S_OK);
+    ok_int(Info.ErrInfo.nID, 160);
+
+    ok(Info.ErrInfo.szPath0[0] != 0, "Info.ErrInfo.szPath0 was empty\n");
+    trace("Info.ErrInfo.szPath0: %S\n", Info.ErrInfo.szPath0); // "Must be Primitive, enum, or type: Invalid"
+
+    ok_int(Info.ErrInfo.szPath1[0], 0);
+    ok_wstr(Info.ErrInfo.szPath2, L"invalid.ini");
+    ok_wstr(Info.ErrInfo.szPath3, L"Invalid=Invalid");
+    ok_int(Info.ErrInfo.nLineNo, 2);
 }

--- a/modules/rostests/apitests/uxtheme/GetThemeParseErrorInfo.c
+++ b/modules/rostests/apitests/uxtheme/GetThemeParseErrorInfo.c
@@ -23,6 +23,7 @@ START_TEST(GetThemeParseErrorInfo)
     hr = GetThemeParseErrorInfo(&Info);
     ok_hex(hr, E_INVALIDARG);
 
+    ZeroMemory(&Info, sizeof(Info));
     Info.cbSize = sizeof(Info);
     hr = GetThemeParseErrorInfo(&Info);
     ok_hex(hr, HRESULT_FROM_WIN32(ERROR_RESOURCE_NAME_NOT_FOUND));

--- a/modules/rostests/apitests/uxtheme/testlist.c
+++ b/modules/rostests/apitests/uxtheme/testlist.c
@@ -5,6 +5,7 @@
 
 extern void func_CloseThemeData(void);
 extern void func_DrawThemeParentBackground(void);
+extern void func_GetThemeParseErrorInfo(void);
 extern void func_SetThemeAppProperties(void);
 extern void func_SetWindowTheme(void);
 
@@ -12,6 +13,7 @@ const struct test winetest_testlist[] =
 {
     { "CloseThemeData", func_CloseThemeData },
     { "DrawThemeParentBackground", func_DrawThemeParentBackground },
+    { "GetThemeParseErrorInfo", func_GetThemeParseErrorInfo },
     { "SetWindowTheme", func_SetWindowTheme },
     { "SetThemeAppProperties", func_SetThemeAppProperties },
     { 0, 0 }

--- a/sdk/include/reactos/uxundoc.h
+++ b/sdk/include/reactos/uxundoc.h
@@ -9,17 +9,21 @@ typedef HANDLE HTHEMEFILE;
 typedef struct tagTMERRINFO
 {
     UINT nID;
-    WCHAR szPath0[MAX_PATH];
-    WCHAR szPath1[MAX_PATH];
-    WCHAR szPath2[MAX_PATH];
-    WCHAR szPath3[MAX_PATH];
+    WCHAR szParam1[MAX_PATH];
+    WCHAR szParam2[MAX_PATH];
+    WCHAR szFile[MAX_PATH];
+    WCHAR szLine[MAX_PATH];
     INT nLineNo;
 } TMERRINFO, *PTMERRINFO;
 
 typedef struct tagPARSE_ERROR_INFO
 {
     DWORD cbSize;
-    TMERRINFO ErrInfo;
+    UINT nID;
+    WCHAR szDescription[2 * MAX_PATH];
+    WCHAR szFile[MAX_PATH];
+    WCHAR szLine[MAX_PATH];
+    INT nLineNo;
 } PARSE_ERROR_INFO, *PPARSE_ERROR_INFO;
 
 HRESULT WINAPI GetThemeParseErrorInfo(_Inout_ PPARSE_ERROR_INFO pInfo);

--- a/sdk/include/reactos/uxundoc.h
+++ b/sdk/include/reactos/uxundoc.h
@@ -6,16 +6,6 @@ extern "C" {
 
 typedef HANDLE HTHEMEFILE;
 
-typedef struct tagTMERRINFO
-{
-    UINT nID;
-    WCHAR szParam1[MAX_PATH];
-    WCHAR szParam2[MAX_PATH];
-    WCHAR szFile[MAX_PATH];
-    WCHAR szLine[MAX_PATH];
-    INT nLineNo;
-} TMERRINFO, *PTMERRINFO;
-
 typedef struct tagPARSE_ERROR_INFO
 {
     DWORD cbSize;

--- a/sdk/include/reactos/uxundoc.h
+++ b/sdk/include/reactos/uxundoc.h
@@ -13,7 +13,7 @@ typedef struct tagTMERRINFO
     WCHAR szPath1[MAX_PATH];
     WCHAR szPath2[MAX_PATH];
     WCHAR szPath3[MAX_PATH];
-    DWORD dwError;
+    INT nLineNo;
 } TMERRINFO, *PTMERRINFO;
 
 typedef struct tagPARSE_ERROR_INFO

--- a/sdk/include/reactos/uxundoc.h
+++ b/sdk/include/reactos/uxundoc.h
@@ -1,6 +1,28 @@
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef HANDLE HTHEMEFILE;
+
+typedef struct tagTMERRINFO
+{
+    UINT nID;
+    WCHAR szPath0[MAX_PATH];
+    WCHAR szPath1[MAX_PATH];
+    WCHAR szPath2[MAX_PATH];
+    WCHAR szPath3[MAX_PATH];
+    DWORD dwError;
+} TMERRINFO, *PTMERRINFO;
+
+typedef struct tagPARSE_ERROR_INFO
+{
+    DWORD cbSize;
+    TMERRINFO ErrInfo;
+} PARSE_ERROR_INFO, *PPARSE_ERROR_INFO;
+
+HRESULT WINAPI GetThemeParseErrorInfo(_Inout_ PPARSE_ERROR_INFO pInfo);
 
 /**********************************************************************
  *              ENUMTHEMEPROC
@@ -118,3 +140,6 @@ BOOL WINAPI ThemeHooksInstall(VOID);
 
 BOOL WINAPI ThemeHooksRemove(VOID);
 
+#ifdef __cplusplus
+} // extern "C"
+#endif


### PR DESCRIPTION
## Purpose
Implementing missing features...
JIRA issue: [CORE-12805](https://jira.reactos.org/browse/CORE-12805)

## Proposed changes

- Add `dll/win32/uxtheme/errinfo.c`.
- Implement `GetThemeParseErrorInfo` function in `errinfo.c`.
- Modify `uxtheme.spec`.
- Add `GetThemeParseErrorInfo` prototype to `<uxundoc.h>`.
- Adapt `<uxundoc.h>` to C++.
- Add global variable `gdwErrorInfoTlsIndex`.
- Add `UXTHEME_UnInitSystem` function.

## TODO

- [x] Do tests.