### PR TITLE
[SHELL32][SHELL32_APITEST][SDK] SHIsBadInterfacePtr

### DIFF
--- a/dll/win32/shell32/stubs.cpp
+++ b/dll/win32/shell32/stubs.cpp
@@ -569,17 +569,6 @@ DDECreatePostNotify(LPVOID lpUnknown)
 /*
  * Unimplemented
  */
-EXTERN_C BOOL
-WINAPI
-SHIsBadInterfacePtr(LPVOID pv, UINT ucb)
-{
-    FIXME("SHIsBadInterfacePtr() stub\n");
-    return FALSE;
-}
-
-/*
- * Unimplemented
- */
 EXTERN_C VOID
 WINAPI
 AppCompat_RunDLLW(HWND hwnd, HINSTANCE hInstance, LPWSTR pszCmdLine, int nCmdShow)

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -1809,20 +1809,6 @@ SHELL_CreateShell32DefaultExtractIcon(int IconIndex, REFIID riid, LPVOID *ppvOut
     return initIcon->QueryInterface(riid, ppvOut);
 }
 
-// FIXME: Kill me
-struct CUnknownVtbl
-{
-    HRESULT (STDMETHODCALLTYPE *QueryInterface)(REFIID riid, LPVOID *ppvObj);
-    ULONG (STDMETHODCALLTYPE *AddRef)();
-    ULONG (STDMETHODCALLTYPE *Release)();
-};
-
-// FIXME: Kill me
-struct CUnknown
-{
-    CUnknownVtbl *lpVtbl;
-};
-
 /*************************************************************************
  *  SHIsBadInterfacePtr [SHELL32.84]
  */
@@ -1832,6 +1818,13 @@ SHIsBadInterfacePtr(
     _In_ LPCVOID pv,
     _In_ UINT_PTR ucb)
 {
+    struct CUnknownVtbl
+    {
+        HRESULT (STDMETHODCALLTYPE *QueryInterface)(REFIID riid, LPVOID *ppvObj);
+        ULONG (STDMETHODCALLTYPE *AddRef)();
+        ULONG (STDMETHODCALLTYPE *Release)();
+    };
+    struct CUnknown { CUnknownVtbl *lpVtbl; };
     const CUnknown *punk = reinterpret_cast<const CUnknown *>(pv);
     return !punk || IsBadReadPtr(punk, sizeof(punk->lpVtbl)) ||
            IsBadReadPtr(punk->lpVtbl, ucb) ||

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -1809,6 +1809,35 @@ SHELL_CreateShell32DefaultExtractIcon(int IconIndex, REFIID riid, LPVOID *ppvOut
     return initIcon->QueryInterface(riid, ppvOut);
 }
 
+// FIXME: Kill me
+struct CUnknownVtbl
+{
+    HRESULT (STDMETHODCALLTYPE *QueryInterface)(REFIID riid, LPVOID *ppvObj);
+    ULONG (STDMETHODCALLTYPE *AddRef)();
+    ULONG (STDMETHODCALLTYPE *Release)();
+};
+
+// FIXME: Kill me
+struct CUnknown
+{
+    CUnknownVtbl *lpVtbl;
+};
+
+/*************************************************************************
+ *  SHIsBadInterfacePtr [SHELL32.84]
+ */
+EXTERN_C
+BOOL WINAPI
+SHIsBadInterfacePtr(
+    _In_ LPCVOID pv,
+    _In_ UINT_PTR ucb)
+{
+    const CUnknown *punk = reinterpret_cast<const CUnknown *>(pv);
+    return !punk || IsBadReadPtr(punk, sizeof(punk->lpVtbl)) ||
+           IsBadReadPtr(punk->lpVtbl, ucb) ||
+           IsBadCodePtr((FARPROC)punk->lpVtbl->Release);
+}
+
 /*************************************************************************
  *  SHGetUserDisplayName [SHELL32.241]
  *

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -1811,6 +1811,8 @@ SHELL_CreateShell32DefaultExtractIcon(int IconIndex, REFIID riid, LPVOID *ppvOut
 
 /*************************************************************************
  *  SHIsBadInterfacePtr [SHELL32.84]
+ *
+ * Retired in 6.0 from Windows Vista and higher.
  */
 EXTERN_C
 BOOL WINAPI

--- a/modules/rostests/apitests/shell32/CMakeLists.txt
+++ b/modules/rostests/apitests/shell32/CMakeLists.txt
@@ -32,6 +32,7 @@ list(APPEND SOURCE
     SHCreateFileDataObject.cpp
     SHCreateFileExtractIconW.cpp
     SHGetUnreadMailCountW.cpp
+    SHIsBadInterfacePtr.cpp
     SHParseDisplayName.cpp
     SHRestricted.cpp
     SHShouldShowWizards.cpp

--- a/modules/rostests/apitests/shell32/SHIsBadInterfacePtr.cpp
+++ b/modules/rostests/apitests/shell32/SHIsBadInterfacePtr.cpp
@@ -10,35 +10,20 @@
 
 typedef BOOL (WINAPI *FN_SHIsBadInterfacePtr)(LPCVOID, UINT_PTR);
 
-// FIXME: Kill me
-struct CUnknownVtbl
-{
-    HRESULT (STDMETHODCALLTYPE *QueryInterface)(REFIID riid, LPVOID *ppvObj);
-    ULONG (STDMETHODCALLTYPE *AddRef)();
-    ULONG (STDMETHODCALLTYPE *Release)();
-};
-
-// FIXME: Kill me
-struct CUnknown
-{
-    CUnknownVtbl *lpVtbl;
-};
-
-static HRESULT STDMETHODCALLTYPE dummy_QueryInterface(REFIID riid, LPVOID *ppvObj)
-{
-    return S_OK;
-}
-static ULONG STDMETHODCALLTYPE dummy_AddRef()
-{
-    return S_OK;
-}
-static ULONG STDMETHODCALLTYPE dummy_Release()
-{
-    return S_OK;
-}
+static HRESULT STDMETHODCALLTYPE dummy_QueryInterface(REFIID riid, LPVOID *ppvObj) { return S_OK; }
+static ULONG STDMETHODCALLTYPE dummy_AddRef() { return S_OK; }
+static ULONG STDMETHODCALLTYPE dummy_Release() { return S_OK; }
 
 START_TEST(SHIsBadInterfacePtr)
 {
+    struct CUnknownVtbl
+    {
+        HRESULT (STDMETHODCALLTYPE *QueryInterface)(REFIID riid, LPVOID *ppvObj);
+        ULONG (STDMETHODCALLTYPE *AddRef)();
+        ULONG (STDMETHODCALLTYPE *Release)();
+    };
+    struct CUnknown { CUnknownVtbl *lpVtbl; };
+
     BOOL ret;
     FN_SHIsBadInterfacePtr SHIsBadInterfacePtr =
         (FN_SHIsBadInterfacePtr)GetProcAddress(GetModuleHandleW(L"shell32"), MAKEINTRESOURCEA(84));

--- a/modules/rostests/apitests/shell32/SHIsBadInterfacePtr.cpp
+++ b/modules/rostests/apitests/shell32/SHIsBadInterfacePtr.cpp
@@ -1,0 +1,68 @@
+/*
+ * PROJECT:     ReactOS API tests
+ * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
+ * PURPOSE:     Test for SHIsBadInterfacePtr
+ * COPYRIGHT:   Copyright 2025 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
+ */
+
+#include "shelltest.h"
+#include <undocshell.h>
+
+typedef BOOL (WINAPI *FN_SHIsBadInterfacePtr)(LPCVOID, UINT_PTR);
+
+// FIXME: Kill me
+struct CUnknownVtbl
+{
+    HRESULT (STDMETHODCALLTYPE *QueryInterface)(REFIID riid, LPVOID *ppvObj);
+    ULONG (STDMETHODCALLTYPE *AddRef)();
+    ULONG (STDMETHODCALLTYPE *Release)();
+};
+
+// FIXME: Kill me
+struct CUnknown
+{
+    CUnknownVtbl *lpVtbl;
+};
+
+static HRESULT STDMETHODCALLTYPE dummy_QueryInterface(REFIID riid, LPVOID *ppvObj)
+{
+    return S_OK;
+}
+static ULONG STDMETHODCALLTYPE dummy_AddRef()
+{
+    return S_OK;
+}
+static ULONG STDMETHODCALLTYPE dummy_Release()
+{
+    return S_OK;
+}
+
+START_TEST(SHIsBadInterfacePtr)
+{
+    BOOL ret;
+    FN_SHIsBadInterfacePtr SHIsBadInterfacePtr =
+        (FN_SHIsBadInterfacePtr)GetProcAddress(GetModuleHandleW(L"shell32"), MAKEINTRESOURCEA(84));
+
+    if (!SHIsBadInterfacePtr)
+    {
+        skip("There is no SHIsBadInterfacePtr\n");
+        return;
+    }
+
+    ret = SHIsBadInterfacePtr(NULL, 1);
+    ok_int(ret, TRUE);
+
+    CUnknown unk1 = { NULL };
+    ret = SHIsBadInterfacePtr(&unk1, 1);
+    ok_int(ret, TRUE);
+
+    CUnknownVtbl vtbl1 = { dummy_QueryInterface, dummy_AddRef, NULL };
+    CUnknown unk2 = { &vtbl1 };
+    ret = SHIsBadInterfacePtr(&unk2, 1);
+    ok_int(ret, TRUE);
+
+    CUnknownVtbl vtbl2 = { dummy_QueryInterface, dummy_AddRef, dummy_Release };
+    CUnknown unk3 = { &vtbl2 };
+    ret = SHIsBadInterfacePtr(&unk3, 1);
+    ok_int(ret, FALSE);
+}

--- a/modules/rostests/apitests/shell32/testlist.c
+++ b/modules/rostests/apitests/shell32/testlist.c
@@ -46,6 +46,7 @@ extern void func_SHGetAttributesFromDataObject(void);
 extern void func_SHGetFileInfo(void);
 extern void func_SHGetUnreadMailCountW(void);
 extern void func_SHGetUserDisplayName(void);
+extern void func_SHIsBadInterfacePtr(void);
 extern void func_SHLimitInputEdit(void);
 extern void func_SHParseDisplayName(void);
 extern void func_SHShouldShowWizards(void);
@@ -99,6 +100,7 @@ const struct test winetest_testlist[] =
     { "SHGetFileInfo", func_SHGetFileInfo },
     { "SHGetUnreadMailCountW", func_SHGetUnreadMailCountW },
     { "SHGetUserDisplayName", func_SHGetUserDisplayName },
+    { "SHIsBadInterfacePtr", func_SHIsBadInterfacePtr },
     { "SHLimitInputEdit", func_SHLimitInputEdit },
     { "SHParseDisplayName", func_SHParseDisplayName },
     { "SHShouldShowWizards", func_SHShouldShowWizards },

--- a/sdk/include/reactos/undocshell.h
+++ b/sdk/include/reactos/undocshell.h
@@ -954,6 +954,11 @@ LONG WINAPI SHRegQueryValueExW(
     #define SHRegQueryValueEx SHRegQueryValueExA
 #endif
 
+BOOL WINAPI
+SHIsBadInterfacePtr(
+    _In_ LPCVOID pv,
+    _In_ UINT_PTR ucb);
+
 HRESULT WINAPI
 CopyStreamUI(
     _In_ IStream *pSrc,


### PR DESCRIPTION
## Purpose

Implementing missing features...
JIRA issue: [CORE-19278](https://jira.reactos.org/browse/CORE-19278)

## Proposed changes

- Move function definition from `stubs.cpp` to `utils.cpp`.
- Implement `SHIsBadInterfacePtr` function in `utils.cpp`.
- Add prototype to `<undocshell.h>`.

## TODO

- [x] Do tests.