### PR TITLE
[CMAKE] Build host tools as Debug by default

### DIFF
--- a/sdk/cmake/host-tools.cmake
+++ b/sdk/cmake/host-tools.cmake
@@ -92,7 +92,7 @@ function(setup_host_tools)
     endif()
 
     if(NOT DEFINED HOST_BUILD_TYPE)
-        set(HOST_BUILD_TYPE Release)
+        set(HOST_BUILD_TYPE Debug)
     endif()
 
     ExternalProject_Add(host-tools


### PR DESCRIPTION
This is to fix kmtests on Test WHS. Seemingly something is broken with release builds of host tools, at least on GCC x86.

Jita ticket: https://jira.reactos.org/browse/CORE-19981

Tests:
✅ KVM x86: https://reactos.org/testman/compare.php?ids=100121,100127
