### PR TITLE
[SHELL32][SHELL32_APITEST][SDK] SHGetComputerDisplayNameW

### DIFF
--- a/dll/win32/shell32/shell32.spec
+++ b/dll/win32/shell32/shell32.spec
@@ -460,7 +460,7 @@
 749 stdcall -noname -version=0x501-0x502 SHGetShellStyleHInstance()
 750 stdcall -noname SHGetAttributesFromDataObject(ptr long ptr ptr)
 751 stub -noname SHSimulateDropOnClsid
-752 stdcall -noname SHGetComputerDisplayNameW(long long long long)
+752 stdcall -noname SHGetComputerDisplayNameW(wstr long ptr long)
 753 stdcall -noname CheckStagingArea()
 754 stub -noname SHLimitInputEditWithFlags
 755 stdcall -noname PathIsEqualOrSubFolder(wstr wstr)

--- a/dll/win32/shell32/stubs.cpp
+++ b/dll/win32/shell32/stubs.cpp
@@ -820,10 +820,3 @@ DWORD WINAPI CheckStagingArea(VOID)
     /* Called by native explorer */
     return 0;
 }
-
-EXTERN_C
-DWORD WINAPI SHGetComputerDisplayNameW(DWORD param1, DWORD param2, DWORD param3, DWORD param4)
-{
-    FIXME("SHGetComputerDisplayNameW() stub\n");
-    return E_FAIL;
-}

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -1913,9 +1913,9 @@ SHELL_SkipServerSlashes(
 // Get server computer name from cache
 static HRESULT
 SHELL_GetCachedComputerDescription(
-    _In_ PCWSTR pszServerName,
     _Out_ PWSTR pszDesc,
-    _In_ DWORD cchDescMax)
+    _In_ DWORD cchDescMax,
+    _In_ PCWSTR pszServerName)
 {
     cchDescMax *= sizeof(WCHAR);
     DWORD error = SHGetValueW(HKEY_CURRENT_USER, COMPUTER_DESCRIPTIONS_KEY,
@@ -1940,9 +1940,9 @@ SHELL_CacheComputerDescription(
 // Get real server computer name
 static HRESULT
 SHELL_GetComputerDescription(
-    _In_ PWSTR pszServerName,
     _Out_ PWSTR pszDesc,
-    _In_ INT cchDescMax)
+    _In_ INT cchDescMax,
+    _In_ PWSTR pszServerName)
 {
     PSERVER_INFO_101 bufptr;
     NET_API_STATUS error = NetServerGetInfo(pszServerName, 101, (PBYTE*)&bufptr);
@@ -1963,10 +1963,10 @@ SHELL_GetComputerDescription(
 // Build display machine name
 HRESULT
 SHELL_BuildDisplayMachineName(
-    _In_ PCWSTR pszServerName,
-    _In_ PCWSTR pszDescription,
     _Out_ PWSTR pszName,
-    _In_ DWORD cchNameMax)
+    _In_ DWORD cchNameMax,
+    _In_ PCWSTR pszServerName,
+    _In_ PCWSTR pszDescription)
 {
     if (!pszDescription || !*pszDescription)
         return E_FAIL;
@@ -2004,11 +2004,11 @@ SHGetComputerDisplayNameW(
     // Get computer description from cache if necessary
     HRESULT hr = E_FAIL;
     if (!(dwFlags & SHGCDN_NOCACHE))
-        hr = SHELL_GetCachedComputerDescription(pszServerName, szDesc, _countof(szDesc));
+        hr = SHELL_GetCachedComputerDescription(szDesc, _countof(szDesc), pszServerName);
 
     if (FAILED(hr)) // No cache?
     {
-        hr = SHELL_GetComputerDescription(pszServerName, szDesc, _countof(szDesc)); // Real get
+        hr = SHELL_GetComputerDescription(szDesc, _countof(szDesc), pszServerName); // Real get
         if (FAILED(hr))
             szDesc[0] = UNICODE_NULL;
 
@@ -2033,5 +2033,5 @@ SHGetComputerDisplayNameW(
     }
 
     // Build a string like "Description (SERVERNAME)"
-    return SHELL_BuildDisplayMachineName(pszServerName, szDesc, pszName, cchNameMax);
+    return SHELL_BuildDisplayMachineName(pszName, cchNameMax, pszServerName, szDesc);
 }

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -1928,9 +1928,9 @@ SHELL_CacheComputerDescription(
     if (!pszDesc)
         return;
 
-    DWORD cbDesc = (wcslen(pszDesc) + 1) * sizeof(WCHAR);
+    SIZE_T cbDesc = (wcslen(pszDesc) + 1) * sizeof(WCHAR);
     SHSetValueW(HKEY_CURRENT_USER, COMPUTER_DESCRIPTIONS_KEY,
-                SHELL_SkipServerSlashes(pszServerName), REG_SZ, pszDesc, cbDesc);
+                SHELL_SkipServerSlashes(pszServerName), REG_SZ, pszDesc, DWORD(cbDesc));
 }
 
 static HRESULT

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -1993,7 +1993,7 @@ SHGetComputerDisplayNameW(
     // If no server name is specified, retrieve the local computer name
     if (!pszServerName)
     {
-        // Get local computer name
+        // Use computer name as server name
         DWORD cchCompName = _countof(szCompName);
         if (!GetComputerNameW(szCompName, &cchCompName))
             return E_FAIL;

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -1963,7 +1963,7 @@ SHELL_GetComputerDescription(
 // Build computer display name
 HRESULT
 SHELL_BuildDisplayMachineName(
-    _Out_ PWSTR pszName,
+    _Out_writes_z_(cchNameMax) PWSTR pszName,
     _In_ DWORD cchNameMax,
     _In_ PCWSTR pszServerName,
     _In_ PCWSTR pszDescription)

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -1942,7 +1942,7 @@ SHELL_GetComputerDescription(
     PSERVER_INFO_101 bufptr;
     NET_API_STATUS error = NetServerGetInfo(pszServerName, 101, (PBYTE*)&bufptr);
     HRESULT hr = (error > 0) ? HRESULT_FROM_WIN32(error) : error;
-    if (FAILED(hr))
+    if (FAILED_UNEXPECTEDLY(hr))
         return hr;
 
     PCWSTR comment = bufptr->sv101_comment;

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -2006,9 +2006,10 @@ SHGetComputerDisplayNameW(
     if (!(dwFlags & SHGCDN_NOCACHE))
         hr = SHELL_GetCachedComputerDescription(szDesc, _countof(szDesc), pszServerName);
 
-    if (FAILED(hr)) // No cache?
+    // Actually retrieve the computer description if it is not in the cache
+    if (FAILED(hr))
     {
-        hr = SHELL_GetComputerDescription(szDesc, _countof(szDesc), pszServerName); // Real get
+        hr = SHELL_GetComputerDescription(szDesc, _countof(szDesc), pszServerName);
         if (FAILED(hr))
             szDesc[0] = UNICODE_NULL;
 

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -1983,9 +1983,9 @@ SHELL_BuildDisplayMachineName(
 EXTERN_C
 HRESULT WINAPI
 SHGetComputerDisplayNameW(
-    _In_opt_ LPWSTR pszServerName,
+    _In_opt_ PWSTR pszServerName,
     _In_ DWORD dwFlags,
-    _Out_writes_z_(cchNameMax) LPWSTR pszName,
+    _Out_writes_z_(cchNameMax) PWSTR pszName,
     _In_ DWORD cchNameMax)
 {
     WCHAR szDesc[256], szCompName[MAX_COMPUTERNAME_LENGTH + 1];

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -2013,8 +2013,9 @@ SHGetComputerDisplayNameW(
         if (FAILED(hr))
             szDesc[0] = UNICODE_NULL;
 
+        // Cache the description if necessary
         if (!(dwFlags & SHGCDN_NOCACHE))
-            SHELL_CacheComputerDescription(pszServerName, szDesc); // Do cache
+            SHELL_CacheComputerDescription(pszServerName, szDesc);
 
         // If getting the computer description failed, store the server name only
         if (FAILED(hr))

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -1997,6 +1997,7 @@ SHGetComputerDisplayNameW(
         DWORD cchCompName = _countof(szCompName);
         if (!GetComputerNameW(szCompName, &cchCompName))
             return E_FAIL;
+        pszServerName = szCompName;
 
         dwFlags |= SHGCDN_NOCACHE; // Don't cache
         pszServerName = szCompName; // Use computer name as server name

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -1895,7 +1895,7 @@ SHGetUserDisplayName(
     return hr;
 }
 
-// Skip leading server backslashes
+// Skip leading backslashes
 PWSTR
 SHELL_SkipServerSlashes(
     _In_ PCWSTR pszPath)
@@ -1906,11 +1906,11 @@ SHELL_SkipServerSlashes(
     return const_cast<PWSTR>(pch);
 }
 
-// The registry key for server computer names cache
+// The registry key for server computer descriptions cache
 #define COMPUTER_DESCRIPTIONS_KEY \
     L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\ComputerDescriptions"
 
-// Get server computer name from cache
+// Get server computer description from cache
 static HRESULT
 SHELL_GetCachedComputerDescription(
     _Out_ PWSTR pszDesc,
@@ -1923,7 +1923,7 @@ SHELL_GetCachedComputerDescription(
     return HRESULT_FROM_WIN32(error);
 }
 
-// Do cache a server computer name
+// Do cache a server computer description
 VOID
 SHELL_CacheComputerDescription(
     _In_ PCWSTR pszServerName,
@@ -1937,7 +1937,7 @@ SHELL_CacheComputerDescription(
                 SHELL_SkipServerSlashes(pszServerName), REG_SZ, pszDesc, (DWORD)cbDesc);
 }
 
-// Get real server computer name
+// Get real server computer description
 static HRESULT
 SHELL_GetComputerDescription(
     _Out_ PWSTR pszDesc,
@@ -1960,9 +1960,9 @@ SHELL_GetComputerDescription(
     return hr;
 }
 
-// Build display machine name
+// Build computer display name
 HRESULT
-SHELL_BuildDisplayMachineName(
+SHELL_BuildComputerDisplayName(
     _Out_ PWSTR pszName,
     _In_ DWORD cchNameMax,
     _In_ PCWSTR pszServerName,
@@ -2033,5 +2033,5 @@ SHGetComputerDisplayNameW(
     }
 
     // Build a string like "Description (SERVERNAME)"
-    return SHELL_BuildDisplayMachineName(pszName, cchNameMax, pszServerName, szDesc);
+    return SHELL_BuildComputerDisplayName(pszName, cchNameMax, pszServerName, szDesc);
 }

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -2018,16 +2018,16 @@ SHGetComputerDisplayNameW(
         // Cache the description if necessary
         if (!(dwFlags & SHGCDN_NOCACHE))
             SHELL_CacheComputerDescription(pszServerName, szDesc);
+    }
 
-        // If getting the computer description failed, store the server name only
-        if (FAILED(hr))
-        {
-            if (dwFlags & SHGCDN_NOSERVERNAME)
-                return hr; // Bail out if no server name is requested
+    // If getting the computer description failed, store the server name only
+    if (FAILED(hr) || !szDesc[0])
+    {
+        if (dwFlags & SHGCDN_NOSERVERNAME)
+            return hr; // Bail out if no server name is requested
 
-            StringCchCopyW(pszName, cchNameMax, SHELL_SkipServerSlashes(pszServerName));
-            return S_OK;
-        }
+        StringCchCopyW(pszName, cchNameMax, SHELL_SkipServerSlashes(pszServerName));
+        return S_OK;
     }
 
     // If no server name is requested, store the description only

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -2000,7 +2000,6 @@ SHGetComputerDisplayNameW(
         pszServerName = szCompName;
 
         dwFlags |= SHGCDN_NOCACHE; // Don't cache
-        pszServerName = szCompName; // Use computer name as server name
     }
 
     // Get computer description from cache if necessary

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -2028,9 +2028,10 @@ SHGetComputerDisplayNameW(
         }
     }
 
-    if (dwFlags & SHGCDN_NOSERVERNAME) // No server name?
+    // If no server name is requested, store the description only
+    if (dwFlags & SHGCDN_NOSERVERNAME)
     {
-        StringCchCopyW(pszName, cchNameMax, szDesc); // Store description only
+        StringCchCopyW(pszName, cchNameMax, szDesc);
         return S_OK;
     }
 

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -1940,7 +1940,7 @@ SHELL_CacheComputerDescription(
 // Get real server computer description
 static HRESULT
 SHELL_GetComputerDescription(
-    _Out_ PWSTR pszDesc,
+    _Out_writes_z_(cchDescMax) PWSTR pszDesc,
     _In_ SIZE_T cchDescMax,
     _In_ PWSTR pszServerName)
 {

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -1913,7 +1913,7 @@ SHELL_SkipServerSlashes(
 // Get server computer description from cache
 static HRESULT
 SHELL_GetCachedComputerDescription(
-    _Out_ PWSTR pszDesc,
+    _Out_writes_z_(cchDescMax) PWSTR pszDesc,
     _In_ DWORD cchDescMax,
     _In_ PCWSTR pszServerName)
 {

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -1896,14 +1896,14 @@ SHGetUserDisplayName(
 }
 
 // Skip leading backslashes
-PWSTR
+static PCWSTR
 SHELL_SkipServerSlashes(
     _In_ PCWSTR pszPath)
 {
     PCWSTR pch;
     for (pch = pszPath; *pch == L'\\'; ++pch)
         ;
-    return const_cast<PWSTR>(pch);
+    return pch;
 }
 
 // The registry key for server computer descriptions cache
@@ -1924,7 +1924,7 @@ SHELL_GetCachedComputerDescription(
 }
 
 // Do cache a server computer description
-VOID
+static VOID
 SHELL_CacheComputerDescription(
     _In_ PCWSTR pszServerName,
     _In_ PCWSTR pszDesc)
@@ -1961,7 +1961,7 @@ SHELL_GetComputerDescription(
 }
 
 // Build computer display name
-HRESULT
+static HRESULT
 SHELL_BuildDisplayMachineName(
     _Out_writes_z_(cchNameMax) PWSTR pszName,
     _In_ DWORD cchNameMax,

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -2015,12 +2015,12 @@ SHGetComputerDisplayNameW(
         if (!(dwFlags & SHGCDN_NOCACHE))
             SHELL_CacheComputerDescription(pszServerName, szDesc); // Do cache
 
-        if (FAILED(hr)) // Real get failed?
+        // If getting the computer description failed, store the server name only
+        if (FAILED(hr))
         {
-            if (dwFlags & SHGCDN_NOSERVERNAME) // No server name?
-                return hr;
+            if (dwFlags & SHGCDN_NOSERVERNAME)
+                return hr; // Bail out if no server name is requested
 
-            // Store server name only
             StringCchCopyW(pszName, cchNameMax, SHELL_SkipServerSlashes(pszServerName));
             return S_OK;
         }

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -1999,7 +1999,8 @@ SHGetComputerDisplayNameW(
             return E_FAIL;
         pszServerName = szCompName;
 
-        dwFlags |= SHGCDN_NOCACHE; // Don't cache
+        // Don't use the cache for the local machine
+        dwFlags |= SHGCDN_NOCACHE;
     }
 
     // Get computer description from cache if necessary

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -1936,7 +1936,7 @@ SHELL_CacheComputerDescription(
 
 static HRESULT
 SHELL_GetComputerDescription(
-    _Inout_ PWSTR pszServerName,
+    _In_ PWSTR pszServerName,
     _Out_ PWSTR pszDesc,
     _In_ INT cchDescMax)
 {
@@ -1979,13 +1979,11 @@ SHELL_BuildDisplayMachineName(
 
 /*************************************************************************
  *  SHGetComputerDisplayNameW [SHELL32.752]
- *
- * Imported by logonui.exe.
  */
 EXTERN_C
 HRESULT WINAPI
 SHGetComputerDisplayNameW(
-    _Inout_opt_ LPWSTR pszServerName,
+    _In_opt_ LPWSTR pszServerName,
     _In_ DWORD dwFlags,
     _Out_ LPWSTR pszName,
     _In_ DWORD cchNameMax)

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -1985,7 +1985,7 @@ HRESULT WINAPI
 SHGetComputerDisplayNameW(
     _In_opt_ LPWSTR pszServerName,
     _In_ DWORD dwFlags,
-    _Out_ LPWSTR pszName,
+    _Out_writes_z_(cchNameMax) LPWSTR pszName,
     _In_ DWORD cchNameMax)
 {
     WCHAR szDesc[256], szCompName[MAX_COMPUTERNAME_LENGTH + 1];

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -1962,7 +1962,7 @@ SHELL_GetComputerDescription(
 
 // Build computer display name
 HRESULT
-SHELL_BuildComputerDisplayName(
+SHELL_BuildDisplayMachineName(
     _Out_ PWSTR pszName,
     _In_ DWORD cchNameMax,
     _In_ PCWSTR pszServerName,
@@ -2033,5 +2033,5 @@ SHGetComputerDisplayNameW(
     }
 
     // Build a string like "Description (SERVERNAME)"
-    return SHELL_BuildComputerDisplayName(pszName, cchNameMax, pszServerName, szDesc);
+    return SHELL_BuildDisplayMachineName(pszName, cchNameMax, pszServerName, szDesc);
 }

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -1941,7 +1941,7 @@ SHELL_CacheComputerDescription(
 static HRESULT
 SHELL_GetComputerDescription(
     _Out_ PWSTR pszDesc,
-    _In_ INT cchDescMax,
+    _In_ SIZE_T cchDescMax,
     _In_ PWSTR pszServerName)
 {
     PSERVER_INFO_101 bufptr;

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -1930,7 +1930,7 @@ SHELL_CacheComputerDescription(
 
     SIZE_T cbDesc = (wcslen(pszDesc) + 1) * sizeof(WCHAR);
     SHSetValueW(HKEY_CURRENT_USER, COMPUTER_DESCRIPTIONS_KEY,
-                SHELL_SkipServerSlashes(pszServerName), REG_SZ, pszDesc, DWORD(cbDesc));
+                SHELL_SkipServerSlashes(pszServerName), REG_SZ, pszDesc, (DWORD)cbDesc);
 }
 
 static HRESULT

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -1905,6 +1905,9 @@ SHELL_SkipServerSlashes(
     return const_cast<PWSTR>(pch);
 }
 
+#define COMPUTER_DESCRIPTIONS_KEY \
+    L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\ComputerDescriptions"
+
 static HRESULT
 SHELL_GetCachedComputerDescription(
     _In_ PCWSTR pszServerName,
@@ -1912,10 +1915,8 @@ SHELL_GetCachedComputerDescription(
     _In_ DWORD cchDescMax)
 {
     cchDescMax *= sizeof(WCHAR);
-    LSTATUS error = SHGetValueW(HKEY_CURRENT_USER,
-                                L"Software\\Microsoft\\Windows\\CurrentVersion\\"
-                                L"Explorer\\ComputerDescriptions",
-                                SHELL_SkipServerSlashes(pszServerName), NULL, pszDesc, &cchDescMax);
+    DWORD error = SHGetValueW(HKEY_CURRENT_USER, COMPUTER_DESCRIPTIONS_KEY,
+                              SHELL_SkipServerSlashes(pszServerName), NULL, pszDesc, &cchDescMax);
     return HRESULT_FROM_WIN32(error);
 }
 
@@ -1927,9 +1928,8 @@ SHELL_CacheComputerDescription(
     if (!pszDesc)
         return;
 
-    DWORD cbDesc = (lstrlenW(pszDesc) + 1) * sizeof(WCHAR);
-    SHSetValueW(HKEY_CURRENT_USER,
-                L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\ComputerDescriptions",
+    DWORD cbDesc = (wcslen(pszDesc) + 1) * sizeof(WCHAR);
+    SHSetValueW(HKEY_CURRENT_USER, COMPUTER_DESCRIPTIONS_KEY,
                 SHELL_SkipServerSlashes(pszServerName), REG_SZ, pszDesc, cbDesc);
 }
 

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -1990,7 +1990,8 @@ SHGetComputerDisplayNameW(
 {
     WCHAR szDesc[256], szCompName[MAX_COMPUTERNAME_LENGTH + 1];
 
-    if (!pszServerName) // Server name not specified?
+    // If no server name is specified, retrieve the local computer name
+    if (!pszServerName)
     {
         // Get local computer name
         DWORD cchCompName = _countof(szCompName);

--- a/dll/win32/shell32/utils.h
+++ b/dll/win32/shell32/utils.h
@@ -53,7 +53,6 @@ typedef struct {
 
 HRESULT
 SHELL_MapContextMenuVerbToCmdId(LPCMINVOKECOMMANDINFO pICI, const CMVERBMAP *pMap);
-
 HRESULT
 SHELL_GetCommandStringImpl(SIZE_T CmdId, UINT uFlags, LPSTR Buf, UINT cchBuf, const CMVERBMAP *pMap);
 

--- a/dll/win32/shell32/utils.h
+++ b/dll/win32/shell32/utils.h
@@ -53,8 +53,25 @@ typedef struct {
 
 HRESULT
 SHELL_MapContextMenuVerbToCmdId(LPCMINVOKECOMMANDINFO pICI, const CMVERBMAP *pMap);
+
 HRESULT
 SHELL_GetCommandStringImpl(SIZE_T CmdId, UINT uFlags, LPSTR Buf, UINT cchBuf, const CMVERBMAP *pMap);
+
+PWSTR
+SHELL_SkipServerSlashes(
+    _In_ PCWSTR pszPath);
+
+VOID
+SHELL_CacheComputerDescription(
+    _In_ PCWSTR pszServerName,
+    _In_ PCWSTR pszDesc);
+
+HRESULT
+SHELL_BuildDisplayMachineName(
+    _Out_ PWSTR pszName,
+    _In_ DWORD cchNameMax,
+    _In_ PCWSTR pszServerName,
+    _In_ PCWSTR pszDescription);
 
 // SHExtractIconsW is a forward, use this function instead inside shell32
 inline HICON

--- a/dll/win32/shell32/utils.h
+++ b/dll/win32/shell32/utils.h
@@ -57,22 +57,6 @@ SHELL_MapContextMenuVerbToCmdId(LPCMINVOKECOMMANDINFO pICI, const CMVERBMAP *pMa
 HRESULT
 SHELL_GetCommandStringImpl(SIZE_T CmdId, UINT uFlags, LPSTR Buf, UINT cchBuf, const CMVERBMAP *pMap);
 
-PWSTR
-SHELL_SkipServerSlashes(
-    _In_ PCWSTR pszPath);
-
-VOID
-SHELL_CacheComputerDescription(
-    _In_ PCWSTR pszServerName,
-    _In_ PCWSTR pszDesc);
-
-HRESULT
-SHELL_BuildDisplayMachineName(
-    _Out_ PWSTR pszName,
-    _In_ DWORD cchNameMax,
-    _In_ PCWSTR pszServerName,
-    _In_ PCWSTR pszDescription);
-
 // SHExtractIconsW is a forward, use this function instead inside shell32
 inline HICON
 SHELL32_SHExtractIcon(LPCWSTR File, int Index, int cx, int cy)

--- a/modules/rostests/apitests/shell32/CMakeLists.txt
+++ b/modules/rostests/apitests/shell32/CMakeLists.txt
@@ -31,6 +31,7 @@ list(APPEND SOURCE
     SHCreateDataObject.cpp
     SHCreateFileDataObject.cpp
     SHCreateFileExtractIconW.cpp
+    SHGetComputerDisplayNameW.cpp
     SHGetUnreadMailCountW.cpp
     SHIsBadInterfacePtr.cpp
     SHParseDisplayName.cpp

--- a/modules/rostests/apitests/shell32/SHGetComputerDisplayNameW.cpp
+++ b/modules/rostests/apitests/shell32/SHGetComputerDisplayNameW.cpp
@@ -52,7 +52,6 @@ SHELL_GetCachedComputerDescription(
     _In_ PCWSTR pszServerName)
 {
     cchDescMax *= sizeof(WCHAR);
-
     LSTATUS error = SHGetValueW(HKEY_CURRENT_USER, COMPUTER_DESCRIPTIONS_KEY,
                                 SHELL_SkipServerSlashes(pszServerName), NULL, pszDesc, &cchDescMax);
     return HRESULT_FROM_WIN32(error);

--- a/modules/rostests/apitests/shell32/SHGetComputerDisplayNameW.cpp
+++ b/modules/rostests/apitests/shell32/SHGetComputerDisplayNameW.cpp
@@ -131,7 +131,7 @@ START_TEST(SHGetComputerDisplayNameW)
 {
     if (IsWindowsVistaOrGreater())
     {
-        skip("Vista+\n");
+        skip("Vista+\n"); // Tests on Vista+ will cause exception
         return;
     }
 

--- a/modules/rostests/apitests/shell32/SHGetComputerDisplayNameW.cpp
+++ b/modules/rostests/apitests/shell32/SHGetComputerDisplayNameW.cpp
@@ -47,9 +47,9 @@ SHELL_CacheComputerDescription(
 
 static HRESULT
 SHELL_GetCachedComputerDescription(
-    _In_ PCWSTR pszServerName,
     _Out_ PWSTR pszDesc,
-    _In_ DWORD cchDescMax)
+    _In_ DWORD cchDescMax,
+    _In_ PCWSTR pszServerName)
 {
     cchDescMax *= sizeof(WCHAR);
 
@@ -60,10 +60,10 @@ SHELL_GetCachedComputerDescription(
 
 static HRESULT
 SHELL_BuildDisplayMachineName(
-    _In_ PCWSTR pszServerName,
-    _In_ PCWSTR pszDescription,
     _Out_ PWSTR pszName,
-    _In_ DWORD cchNameMax)
+    _In_ DWORD cchNameMax,
+    _In_ PCWSTR pszServerName,
+    _In_ PCWSTR pszDescription)
 {
     if (!pszDescription || !*pszDescription)
         return E_FAIL;
@@ -92,7 +92,7 @@ TEST_SHGetComputerDisplayNameW(VOID)
 
     SHELL_CacheComputerDescription(szServerName, L"DummyDescription");
 
-    HRESULT hr = SHELL_GetCachedComputerDescription(szServerName, szDesc, _countof(szDesc));
+    HRESULT hr = SHELL_GetCachedComputerDescription(szDesc, _countof(szDesc), szServerName);
     if (FAILED(hr))
         szDesc[0] = UNICODE_NULL;
     trace("%s\n", wine_dbgstr_w(szDesc));
@@ -109,7 +109,7 @@ TEST_SHGetComputerDisplayNameW(VOID)
     trace("%s\n", wine_dbgstr_w(szServerName));
     ok_wstr(szServerName, L"DummyServerName");
 
-    hr = SHELL_BuildDisplayMachineName(szServerName, szDesc, szName, _countof(szName));
+    hr = SHELL_BuildDisplayMachineName(szName, _countof(szName), szServerName, szDesc);
     ok_hex(hr, S_OK);
 
     trace("%s\n", wine_dbgstr_w(szDisplayName));

--- a/modules/rostests/apitests/shell32/SHGetComputerDisplayNameW.cpp
+++ b/modules/rostests/apitests/shell32/SHGetComputerDisplayNameW.cpp
@@ -11,7 +11,7 @@
 #include <strsafe.h>
 #include <versionhelpers.h>
 
-typedef HRESULT (WINAPI *FN_SHGetComputerDisplayNameW)(LPWSTR, DWORD, LPWSTR, DWORD);
+typedef HRESULT (WINAPI *FN_SHGetComputerDisplayNameW)(PWSTR, DWORD, PWSTR, DWORD);
 typedef NET_API_STATUS (WINAPI *FN_NetServerGetInfo)(LPWSTR, DWORD, PBYTE*);
 typedef NET_API_STATUS (WINAPI *FN_NetApiBufferFree)(PVOID);
 

--- a/modules/rostests/apitests/shell32/SHGetComputerDisplayNameW.cpp
+++ b/modules/rostests/apitests/shell32/SHGetComputerDisplayNameW.cpp
@@ -19,6 +19,9 @@ static FN_SHGetComputerDisplayNameW s_pSHGetComputerDisplayNameW = NULL;
 static FN_NetServerGetInfo s_pNetServerGetInfo = NULL;
 static FN_NetApiBufferFree s_pNetApiBufferFree = NULL;
 
+#define COMPUTER_DESCRIPTIONS_KEY \
+    L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\ComputerDescriptions"
+
 static PWSTR
 SHELL_SkipServerSlashes(
     _In_ PCWSTR pszPath)
@@ -38,10 +41,8 @@ SHELL_CacheComputerDescription(
         return;
 
     DWORD cbDesc = (lstrlenW(pszDesc) + 1) * sizeof(WCHAR);
-    SHSetValueW(
-        HKEY_CURRENT_USER,
-        L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\ComputerDescriptions",
-        SHELL_SkipServerSlashes(pszServerName), REG_SZ, pszDesc, cbDesc);
+    SHSetValueW(HKEY_CURRENT_USER, COMPUTER_DESCRIPTIONS_KEY,
+                SHELL_SkipServerSlashes(pszServerName), REG_SZ, pszDesc, cbDesc);
 }
 
 static HRESULT
@@ -52,9 +53,7 @@ SHELL_GetCachedComputerDescription(
 {
     cchDescMax *= sizeof(WCHAR);
 
-    LSTATUS error = SHGetValueW(HKEY_CURRENT_USER,
-                                L"Software\\Microsoft\\Windows\\CurrentVersion\\"
-                                L"Explorer\\ComputerDescriptions",
+    LSTATUS error = SHGetValueW(HKEY_CURRENT_USER, COMPUTER_DESCRIPTIONS_KEY,
                                 SHELL_SkipServerSlashes(pszServerName), NULL, pszDesc, &cchDescMax);
     return HRESULT_FROM_WIN32(error);
 }
@@ -119,9 +118,7 @@ TEST_SHGetComputerDisplayNameW(VOID)
 
     // Delete registry value
     HKEY hKey;
-    LSTATUS error = RegOpenKeyExW(HKEY_CURRENT_USER,
-                                  L"Software\\Microsoft\\Windows\\CurrentVersion\\"
-                                  L"Explorer\\ComputerDescriptions", 0, KEY_WRITE, &hKey);
+    LSTATUS error = RegOpenKeyExW(HKEY_CURRENT_USER, COMPUTER_DESCRIPTIONS_KEY, 0, KEY_WRITE, &hKey);
     if (error == ERROR_SUCCESS)
     {
         RegDeleteValueW(hKey, L"DummyServerName");

--- a/modules/rostests/apitests/shell32/SHGetComputerDisplayNameW.cpp
+++ b/modules/rostests/apitests/shell32/SHGetComputerDisplayNameW.cpp
@@ -22,14 +22,14 @@ static FN_NetApiBufferFree s_pNetApiBufferFree = NULL;
 #define COMPUTER_DESCRIPTIONS_KEY \
     L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\ComputerDescriptions"
 
-static PWSTR
+static PCWSTR
 SHELL_SkipServerSlashes(
     _In_ PCWSTR pszPath)
 {
     PCWSTR pch;
     for (pch = pszPath; *pch == L'\\'; ++pch)
         ;
-    return const_cast<PWSTR>(pch);
+    return pch;
 }
 
 static VOID

--- a/modules/rostests/apitests/shell32/SHGetComputerDisplayNameW.cpp
+++ b/modules/rostests/apitests/shell32/SHGetComputerDisplayNameW.cpp
@@ -143,17 +143,10 @@ START_TEST(SHGetComputerDisplayNameW)
     }
 
     s_pNetServerGetInfo = (FN_NetServerGetInfo)GetProcAddress(hNetApi32, "NetServerGetInfo");
-    if (!s_pNetServerGetInfo)
-    {
-        skip("NetServerGetInfo not found\n");
-        FreeLibrary(hNetApi32);
-        return;
-    }
-
     s_pNetApiBufferFree = (FN_NetApiBufferFree)GetProcAddress(hNetApi32, "NetApiBufferFree");
-    if (!s_pNetApiBufferFree)
+    if (!s_pNetServerGetInfo || !s_pNetApiBufferFree)
     {
-        skip("NetApiBufferFree not found\n");
+        skip("NetServerGetInfo or NetApiBufferFree not found\n");
         FreeLibrary(hNetApi32);
         return;
     }

--- a/modules/rostests/apitests/shell32/SHGetComputerDisplayNameW.cpp
+++ b/modules/rostests/apitests/shell32/SHGetComputerDisplayNameW.cpp
@@ -40,9 +40,9 @@ SHELL_CacheComputerDescription(
     if (!pszDesc)
         return;
 
-    DWORD cbDesc = (lstrlenW(pszDesc) + 1) * sizeof(WCHAR);
+    SIZE_T cbDesc = (wcslen(pszDesc) + 1) * sizeof(WCHAR);
     SHSetValueW(HKEY_CURRENT_USER, COMPUTER_DESCRIPTIONS_KEY,
-                SHELL_SkipServerSlashes(pszServerName), REG_SZ, pszDesc, cbDesc);
+                SHELL_SkipServerSlashes(pszServerName), REG_SZ, pszDesc, (DWORD)cbDesc);
 }
 
 static HRESULT
@@ -52,8 +52,8 @@ SHELL_GetCachedComputerDescription(
     _In_ PCWSTR pszServerName)
 {
     cchDescMax *= sizeof(WCHAR);
-    LSTATUS error = SHGetValueW(HKEY_CURRENT_USER, COMPUTER_DESCRIPTIONS_KEY,
-                                SHELL_SkipServerSlashes(pszServerName), NULL, pszDesc, &cchDescMax);
+    DWORD error = SHGetValueW(HKEY_CURRENT_USER, COMPUTER_DESCRIPTIONS_KEY,
+                              SHELL_SkipServerSlashes(pszServerName), NULL, pszDesc, &cchDescMax);
     return HRESULT_FROM_WIN32(error);
 }
 

--- a/modules/rostests/apitests/shell32/SHGetComputerDisplayNameW.cpp
+++ b/modules/rostests/apitests/shell32/SHGetComputerDisplayNameW.cpp
@@ -67,15 +67,10 @@ SHELL_BuildDisplayMachineName(
     if (!pszDescription || !*pszDescription)
         return E_FAIL;
 
-    PCWSTR pszFormat = SHRestricted(REST_ALLOWCOMMENTTOGGLE) ? L"%1 (%2)" : L"%2 (%1)";
-    PCWSTR args[] = { SHELL_SkipServerSlashes(pszServerName), pszDescription };
-    if (!FormatMessageW(FORMAT_MESSAGE_ARGUMENT_ARRAY | FORMAT_MESSAGE_FROM_STRING,
-                        pszFormat, 0, 0, pszName, cchNameMax, (va_list *)args))
-    {
-        return E_FAIL;
-    }
-
-    return S_OK;
+    PCWSTR pszFormat = (SHRestricted(REST_ALLOWCOMMENTTOGGLE) ? L"%2 (%1)" : L"%1 (%2)");
+    PCWSTR args[] = { pszDescription , SHELL_SkipServerSlashes(pszServerName) };
+    return (FormatMessageW(FORMAT_MESSAGE_ARGUMENT_ARRAY | FORMAT_MESSAGE_FROM_STRING,
+                           pszFormat, 0, 0, pszName, cchNameMax, (va_list *)args) ? S_OK : E_FAIL);
 }
 
 static VOID
@@ -129,7 +124,7 @@ START_TEST(SHGetComputerDisplayNameW)
 {
     if (IsWindowsVistaOrGreater())
     {
-        skip("Vista+\n"); // Tests on Vista+ will cause exception
+        skip("Tests on Vista+ will cause exception\n");
         return;
     }
 

--- a/modules/rostests/apitests/shell32/SHGetComputerDisplayNameW.cpp
+++ b/modules/rostests/apitests/shell32/SHGetComputerDisplayNameW.cpp
@@ -47,7 +47,7 @@ SHELL_CacheComputerDescription(
 
 static HRESULT
 SHELL_GetCachedComputerDescription(
-    _Out_ PWSTR pszDesc,
+    _Out_writes_z_(cchDescMax) PWSTR pszDesc,
     _In_ DWORD cchDescMax,
     _In_ PCWSTR pszServerName)
 {

--- a/modules/rostests/apitests/shell32/SHGetComputerDisplayNameW.cpp
+++ b/modules/rostests/apitests/shell32/SHGetComputerDisplayNameW.cpp
@@ -106,13 +106,13 @@ TEST_SHGetComputerDisplayNameW(VOID)
     hr = SHGetComputerDisplayNameW(szServerName, 0, szDisplayName, _countof(szDisplayName));
     ok_hex(hr, S_OK);
     trace("%s\n", wine_dbgstr_w(szServerName));
-    trace("%s\n", wine_dbgstr_w(szDisplayName));
     ok_wstr(szServerName, L"DummyServerName");
 
     hr = SHELL_BuildDisplayMachineName(szServerName, szDesc, szName, _countof(szName));
     ok_hex(hr, S_OK);
 
     trace("%s\n", wine_dbgstr_w(szDisplayName));
+    trace("%s\n", wine_dbgstr_w(szName));
     ok_wstr(szDisplayName, szName);
 
     // Delete registry value

--- a/modules/rostests/apitests/shell32/SHGetComputerDisplayNameW.cpp
+++ b/modules/rostests/apitests/shell32/SHGetComputerDisplayNameW.cpp
@@ -82,17 +82,16 @@ static VOID
 TEST_SHGetComputerDisplayNameW(VOID)
 {
     WCHAR szCompName[MAX_COMPUTERNAME_LENGTH + 1], szDesc[256], szDisplayName[MAX_PATH];
-    WCHAR szDummyServer[] = L"DummyServerName";
-    WCHAR szName[MAX_PATH];
+    WCHAR szName[MAX_PATH], szServerName[] = L"DummyServerName";
 
     DWORD cchCompName = _countof(szCompName);
     BOOL ret = GetComputerNameW(szCompName, &cchCompName);
     ok_int(ret, TRUE);
     trace("%s\n", wine_dbgstr_w(szCompName));
 
-    SHELL_CacheComputerDescription(szDummyServer, L"DummyDescription");
+    SHELL_CacheComputerDescription(szServerName, L"DummyDescription");
 
-    HRESULT hr = SHELL_GetCachedComputerDescription(szDummyServer, szDesc, _countof(szDesc));
+    HRESULT hr = SHELL_GetCachedComputerDescription(szServerName, szDesc, _countof(szDesc));
     if (FAILED(hr))
         szDesc[0] = UNICODE_NULL;
     trace("%s\n", wine_dbgstr_w(szDesc));
@@ -104,17 +103,17 @@ TEST_SHGetComputerDisplayNameW(VOID)
     ok_wstr(szDisplayName, szCompName);
 
     StringCchCopyW(szDisplayName, _countof(szDisplayName), L"@");
-    hr = SHGetComputerDisplayNameW(szDummyServer, 0, szDisplayName, _countof(szDisplayName));
+    hr = SHGetComputerDisplayNameW(szServerName, 0, szDisplayName, _countof(szDisplayName));
     ok_hex(hr, S_OK);
-    trace("%s\n", wine_dbgstr_w(szDummyServer));
+    trace("%s\n", wine_dbgstr_w(szServerName));
     trace("%s\n", wine_dbgstr_w(szDisplayName));
-    ok_wstr(szDummyServer, L"DummyServerName");
+    ok_wstr(szServerName, L"DummyServerName");
 
-    hr = SHELL_BuildDisplayMachineName(szDummyServer, szDesc, szName, _countof(szName));
+    hr = SHELL_BuildDisplayMachineName(szServerName, szDesc, szName, _countof(szName));
     ok_hex(hr, S_OK);
 
     trace("%s\n", wine_dbgstr_w(szDisplayName));
-    ok_wstr(szName, szDisplayName);
+    ok_wstr(szDisplayName, szName);
 
     // Delete registry value
     HKEY hKey;

--- a/modules/rostests/apitests/shell32/SHGetComputerDisplayNameW.cpp
+++ b/modules/rostests/apitests/shell32/SHGetComputerDisplayNameW.cpp
@@ -59,7 +59,7 @@ SHELL_GetCachedComputerDescription(
 
 static HRESULT
 SHELL_BuildDisplayMachineName(
-    _Out_ PWSTR pszName,
+    _Out_writes_z_(cchNameMax) PWSTR pszName,
     _In_ DWORD cchNameMax,
     _In_ PCWSTR pszServerName,
     _In_ PCWSTR pszDescription)

--- a/modules/rostests/apitests/shell32/SHGetComputerDisplayNameW.cpp
+++ b/modules/rostests/apitests/shell32/SHGetComputerDisplayNameW.cpp
@@ -1,0 +1,165 @@
+/*
+ * PROJECT:     ReactOS API Tests
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Tests for SHGetComputerDisplayNameW
+ * COPYRIGHT:   Copyright 2025 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ */
+
+#include "shelltest.h"
+#include <lmserver.h>
+#include <undocshell.h>
+#include <strsafe.h>
+#include <versionhelpers.h>
+
+typedef NET_API_STATUS (WINAPI *FN_NetServerGetInfo)(LPWSTR, DWORD, PBYTE*);
+typedef NET_API_STATUS (WINAPI *FN_NetApiBufferFree)(PVOID);
+
+static FN_NetServerGetInfo s_pNetServerGetInfo = NULL;
+static FN_NetApiBufferFree s_pNetApiBufferFree = NULL;
+
+static PWSTR
+SHELL_SkipServerSlashes(
+    _In_ PCWSTR pszPath)
+{
+    PCWSTR pch;
+    for (pch = pszPath; *pch == L'\\'; ++pch)
+        ;
+    return const_cast<PWSTR>(pch);
+}
+
+static VOID
+SHELL_CacheComputerDescription(
+    _In_ PCWSTR pszServerName,
+    _In_ PCWSTR pszDesc)
+{
+    if (!pszDesc)
+        return;
+
+    DWORD cbDesc = (lstrlenW(pszDesc) + 1) * sizeof(WCHAR);
+    SHSetValueW(
+        HKEY_CURRENT_USER,
+        L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\ComputerDescriptions",
+        SHELL_SkipServerSlashes(pszServerName), REG_SZ, pszDesc, cbDesc);
+}
+
+static HRESULT
+SHELL_GetCachedComputerDescription(
+    _In_ PCWSTR pszServerName,
+    _Out_ PWSTR pszDesc,
+    _In_ DWORD cchDescMax)
+{
+    cchDescMax *= sizeof(WCHAR);
+
+    LSTATUS error = SHGetValueW(HKEY_CURRENT_USER,
+                                L"Software\\Microsoft\\Windows\\CurrentVersion\\"
+                                L"Explorer\\ComputerDescriptions",
+                                SHELL_SkipServerSlashes(pszServerName), NULL, pszDesc, &cchDescMax);
+    return HRESULT_FROM_WIN32(error);
+}
+
+static HRESULT
+SHELL_BuildDisplayMachineName(
+    _In_ PCWSTR pszServerName,
+    _In_ PCWSTR pszDescription,
+    _Out_ PWSTR pszName,
+    _In_ DWORD cchNameMax)
+{
+    if (!pszDescription || !*pszDescription)
+        return E_FAIL;
+
+    PCWSTR pszFormat = SHRestricted(REST_ALLOWCOMMENTTOGGLE) ? L"%1 (%2)" : L"%2 (%1)";
+    PCWSTR args[] = { SHELL_SkipServerSlashes(pszServerName), pszDescription };
+    if (!FormatMessageW(FORMAT_MESSAGE_ARGUMENT_ARRAY | FORMAT_MESSAGE_FROM_STRING,
+                        pszFormat, 0, 0, pszName, cchNameMax, (va_list *)args))
+    {
+        return E_FAIL;
+    }
+
+    return S_OK;
+}
+
+static VOID
+TEST_SHGetComputerDisplayNameW(VOID)
+{
+    WCHAR szCompName[MAX_COMPUTERNAME_LENGTH + 1], szDesc[256], szDisplayName[MAX_PATH];
+    WCHAR szDummyServer[] = L"DummyServerName";
+    WCHAR szName[MAX_PATH];
+
+    DWORD cchCompName = _countof(szCompName);
+    BOOL ret = GetComputerNameW(szCompName, &cchCompName);
+    ok_int(ret, TRUE);
+    trace("%s\n", wine_dbgstr_w(szCompName));
+
+    SHELL_CacheComputerDescription(szDummyServer, L"DummyDescription");
+
+    HRESULT hr = SHELL_GetCachedComputerDescription(szDummyServer, szDesc, _countof(szDesc));
+    if (FAILED(hr))
+        szDesc[0] = UNICODE_NULL;
+    trace("%s\n", wine_dbgstr_w(szDesc));
+
+    StringCchCopyW(szDisplayName, _countof(szDisplayName), L"@");
+    hr = SHGetComputerDisplayNameW(NULL, SHGCDN_NOCACHE, szDisplayName, _countof(szDisplayName));
+    ok_hex(hr, S_OK);
+    trace("%s\n", wine_dbgstr_w(szDisplayName));
+    ok_wstr(szDisplayName, szCompName);
+
+    StringCchCopyW(szDisplayName, _countof(szDisplayName), L"@");
+    hr = SHGetComputerDisplayNameW(szDummyServer, 0, szDisplayName, _countof(szDisplayName));
+    ok_hex(hr, S_OK);
+    trace("%s\n", wine_dbgstr_w(szDummyServer));
+    trace("%s\n", wine_dbgstr_w(szDisplayName));
+    ok_wstr(szDummyServer, L"DummyServerName");
+
+    hr = SHELL_BuildDisplayMachineName(szDummyServer, szDesc, szName, _countof(szName));
+    ok_hex(hr, S_OK);
+
+    trace("%s\n", wine_dbgstr_w(szDisplayName));
+    ok_wstr(szName, szDisplayName);
+
+    // Delete registry value
+    HKEY hKey;
+    LSTATUS error = RegOpenKeyExW(HKEY_CURRENT_USER,
+                                  L"Software\\Microsoft\\Windows\\CurrentVersion\\"
+                                  L"Explorer\\ComputerDescriptions", 0, KEY_WRITE, &hKey);
+    if (error == ERROR_SUCCESS)
+    {
+        RegDeleteValueW(hKey, L"DummyServerName");
+        RegCloseKey(hKey);
+    }
+}
+
+START_TEST(SHGetComputerDisplayNameW)
+{
+    if (IsWindowsVistaOrGreater())
+    {
+        skip("Vista+\n");
+        return;
+    }
+
+    HINSTANCE hNetApi32 = LoadLibraryW(L"netapi32.dll");
+    if (!hNetApi32)
+    {
+        skip("netapi32.dll not found\n");
+        return;
+    }
+
+    s_pNetServerGetInfo = (FN_NetServerGetInfo)GetProcAddress(hNetApi32, "NetServerGetInfo");
+    if (!s_pNetServerGetInfo)
+    {
+        skip("NetServerGetInfo not found\n");
+        FreeLibrary(hNetApi32);
+        return;
+    }
+
+    s_pNetApiBufferFree = (FN_NetApiBufferFree)GetProcAddress(hNetApi32, "NetApiBufferFree");
+    if (!s_pNetApiBufferFree)
+    {
+        skip("NetApiBufferFree not found\n");
+        FreeLibrary(hNetApi32);
+        return;
+    }
+
+    TEST_SHGetComputerDisplayNameW();
+
+    FreeLibrary(hNetApi32);
+}

--- a/modules/rostests/apitests/shell32/testlist.c
+++ b/modules/rostests/apitests/shell32/testlist.c
@@ -43,6 +43,7 @@ extern void func_ShellExecuteW(void);
 extern void func_ShellHook(void);
 extern void func_ShellState(void);
 extern void func_SHGetAttributesFromDataObject(void);
+extern void func_SHGetComputerDisplayNameW(void);
 extern void func_SHGetFileInfo(void);
 extern void func_SHGetUnreadMailCountW(void);
 extern void func_SHGetUserDisplayName(void);
@@ -97,6 +98,7 @@ const struct test winetest_testlist[] =
     { "ShellHook", func_ShellHook },
     { "ShellState", func_ShellState },
     { "SHGetAttributesFromDataObject", func_SHGetAttributesFromDataObject },
+    { "SHGetComputerDisplayNameW", func_SHGetComputerDisplayNameW },
     { "SHGetFileInfo", func_SHGetFileInfo },
     { "SHGetUnreadMailCountW", func_SHGetUnreadMailCountW },
     { "SHGetUserDisplayName", func_SHGetUserDisplayName },

--- a/sdk/include/reactos/undocshell.h
+++ b/sdk/include/reactos/undocshell.h
@@ -974,7 +974,7 @@ HRESULT WINAPI
 SHGetComputerDisplayNameW(
     _In_opt_ LPWSTR pszServerName,
     _In_ DWORD dwFlags,
-    _Out_ LPWSTR pszName,
+    _Out_writes_z_(cchNameMax) LPWSTR pszName,
     _In_ DWORD cchNameMax);
 
 /*****************************************************************************

--- a/sdk/include/reactos/undocshell.h
+++ b/sdk/include/reactos/undocshell.h
@@ -966,6 +966,17 @@ CopyStreamUI(
     _Inout_opt_ IProgressDialog *pProgress,
     _In_opt_ DWORDLONG dwlSize);
 
+// Flags for SHGetComputerDisplayNameW
+#define SHGCDN_NOCACHE 0x1
+#define SHGCDN_NOSERVERNAME 0x10000
+
+HRESULT WINAPI
+SHGetComputerDisplayNameW(
+    _Inout_opt_ LPWSTR pszServerName,
+    _In_ DWORD dwFlags,
+    _Out_ LPWSTR pszName,
+    _In_ DWORD cchNameMax);
+
 /*****************************************************************************
  * INVALID_FILETITLE_CHARACTERS
  */

--- a/sdk/include/reactos/undocshell.h
+++ b/sdk/include/reactos/undocshell.h
@@ -972,7 +972,7 @@ CopyStreamUI(
 
 HRESULT WINAPI
 SHGetComputerDisplayNameW(
-    _Inout_opt_ LPWSTR pszServerName,
+    _In_opt_ LPWSTR pszServerName,
     _In_ DWORD dwFlags,
     _Out_ LPWSTR pszName,
     _In_ DWORD cchNameMax);


### PR DESCRIPTION
## Purpose

Implementing missing features...
JIRA issue: [CORE-19278](https://jira.reactos.org/browse/CORE-19278)

## Proposed changes

- Modify `shell32.spec`.
- Move function definition from `stubs.cpp` to `utils.cpp`.
- Implement `SHGetComputerDisplayNameW` function.
- Add prototype to `<undocshell.h>`.

## TODO

- [x] Do tests.