### PR TITLE
[NTDLL] Fix Vista+ stubs (Add Parameters)

### DIFF
--- a/dll/ntdll/def/ntdll.spec
+++ b/dll/ntdll/def/ntdll.spec
@@ -64,44 +64,46 @@
 @ stdcall -version=0x502 EtwControlTraceA(double str ptr long)
 @ stdcall -version=0x502 EtwControlTraceW(double wstr ptr long)
 @ stdcall -stub EtwCreateTraceInstanceId(ptr ptr)
-@ stub -version=0x600+ EtwDeliverDataBlock
+@ stdcall -stub -version=0x600+ EtwDeliverDataBlock(long)
 @ stdcall -version=0x502 EtwEnableTrace(long long long ptr double)
-@ stub -version=0x600+ EtwEnumerateProcessRegGuids
+@ stdcall -stub -version=0x600+ EtwEnumerateProcessRegGuids(ptr long ptr)
 @ stdcall -stub -version=0x502 EtwEnumerateTraceGuids(ptr long ptr)
-@ stub -version=0x600+ EtwEventActivityIdControl
-@ stub -version=0x600+ EtwEventEnabled
-@ stub -version=0x600+ EtwEventProviderEnabled
-@ stub -version=0x600+ EtwEventRegister
-@ stub -version=0x600+ EtwEventUnregister
-@ stub -version=0x600+ EtwEventWrite
-@ stub -version=0x600+ EtwEventWriteEndScenario
-@ stub -version=0x600+ EtwEventWriteFull
-@ stub -version=0x600+ EtwEventWriteStartScenario
-@ stub -version=0x600+ EtwEventWriteString
-@ stub -version=0x600+ EtwEventWriteTransfer
+@ stdcall -stub -version=0x600+ EtwEventActivityIdControl(long ptr)
+@ stdcall -stub -version=0x600+ EtwEventEnabled(int64 ptr)
+@ stdcall -stub -version=0x600+ EtwEventProviderEnabled(long long long)
+@ stdcall -stub -version=0x600+ EtwEventRegister(ptr ptr ptr ptr) 
+@ stdcall -stub -version=0x600+ EtwEventSetInformation(int64 long ptr long)
+@ stdcall -stub -version=0x600+ EtwEventUnregister(int64)
+@ stdcall -stub -version=0x600+ EtwEventWrite(int64 ptr long ptr)
+@ stdcall -stub -version=0x600+ EtwEventWriteEndScenario(long ptr long long)
+@ stdcall -stub -version=0x600+ EtwEventWriteFull(long long long long long long long)
+@ stdcall -stub -version=0x600+ EtwEventWriteStartScenario(long ptr long long)
+@ stdcall -stub -version=0x600+ EtwEventWriteString(long long long long)
+@ stdcall -stub -version=0x600+ EtwEventWriteTransfer(long ptr ptr ptr long long)
 @ stdcall -version=0x502 EtwFlushTraceA(double str ptr)
 @ stdcall -version=0x502 EtwFlushTraceW(double wstr ptr)
 @ stdcall EtwGetTraceEnableFlags(double)
 @ stdcall EtwGetTraceEnableLevel(double)
 @ stdcall EtwGetTraceLoggerHandle(ptr)
-@ stub -version=0x600+ EtwLogTraceEvent
-@ stub -version=0x600+ EtwNotificationRegister
+@ stdcall -stub -version=0x600+ EtwLogTraceEvent(long long)
+@ stdcall -stub -version=0x600+ EtwNotificationRegister(ptr long long long ptr)
 @ stdcall -stub -version=0x502 EtwNotificationRegistrationA(ptr long ptr long long)
 @ stdcall -stub -version=0x502 EtwNotificationRegistrationW(ptr long ptr long long)
-@ stub -version=0x600+ EtwNotificationUnregister
-@ stub -version=0x600+ EtwProcessPrivateLoggerRequest
+@ stdcall -stub -version=0x600+ EtwNotificationUnregister(long ptr)
+@ stdcall -stub -version=0x600+ EtwProcessPrivateLoggerRequest(ptr)
 @ stdcall -version=0x502 EtwQueryAllTracesA(ptr long ptr)
 @ stdcall -version=0x502 EtwQueryAllTracesW(ptr long ptr)
 @ stdcall -version=0x502 EtwQueryTraceA(double str ptr)
 @ stdcall -version=0x502 EtwQueryTraceW(double wstr ptr)
 @ stdcall -stub -version=0x502 EtwReceiveNotificationsA(long long long long)
 @ stdcall -stub -version=0x502 EtwReceiveNotificationsW(long long long long)
-@ stub -version=0x600+ EtwRegisterSecurityProvider
+@ stdcall -stub -version=0x600+ EtwRegister(ptr ptr ptr ptr)
+@ stdcall -stub -version=0x600+ EtwRegisterSecurityProvider()
 @ stdcall EtwRegisterTraceGuidsA(ptr ptr ptr long ptr str str ptr)
 @ stdcall EtwRegisterTraceGuidsW(ptr ptr ptr long ptr wstr wstr ptr)
-@ stub -version=0x600+ EtwReplyNotification
-@ stub -version=0x600+ EtwSendNotification
-@ stub -version=0x600+ EtwSetMark
+@ stdcall -stub -version=0x600+ EtwReplyNotification(long)
+@ stdcall -stub -version=0x600+ EtwSendNotification(long long ptr long long)
+@ stdcall -stub -version=0x600+ EtwSetMark(long long long)
 @ stdcall -version=0x502 EtwStartTraceA(ptr str ptr)
 @ stdcall -version=0x502 EtwStartTraceW(ptr wstr ptr)
 @ stdcall -version=0x502 EtwStopTraceA(double str ptr)
@@ -110,14 +112,16 @@
 @ stdcall -stub EtwTraceEventInstance(double ptr ptr ptr)
 @ varargs EtwTraceMessage(int64 long ptr long)
 @ stdcall -stub EtwTraceMessageVa(int64 long ptr long ptr)
+@ stdcall -stub -version=0x600+ EtwUnregister(int64)
 @ stdcall EtwUnregisterTraceGuids(double)
 @ stdcall -version=0x502 EtwUpdateTraceA(double str ptr)
 @ stdcall -version=0x502 EtwUpdateTraceW(double wstr ptr)
-@ stub -version=0x600+ EtwWriteUMSecurityEvent
-@ stub -version=0x600+ EtwpCreateEtwThread
-@ stub -version=0x600+ EtwpGetCpuSpeed
+@ stdcall -stub -version=0x600+ EtwWrite(int64 ptr ptr long ptr)
+@ stdcall -stub -version=0x600+ EtwWriteUMSecurityEvent(ptr long long long)
+@ stdcall -stub -version=0x600+ EtwpCreateEtwThread(long long)
+@ stdcall -stub -version=0x600+ EtwpGetCpuSpeed(ptr)
 @ stdcall -stub -version=0x502 EtwpGetTraceBuffer(long long long long)
-@ stub -version=0x600+ EtwpNotificationThread
+@ stdcall -stub -version=0x600+ EtwpNotificationThread() ; doesn't exist in win11
 @ stdcall -stub -version=0x502 EtwpSetHWConfigFunction(ptr long)
 @ stdcall -arch=x86_64 ExpInterlockedPopEntrySListEnd()
 @ stub -version=0x600+ -arch=x86_64 ExpInterlockedPopEntrySListEnd8
@@ -150,7 +154,7 @@
 @ stdcall LdrFlushAlternateResourceModules()
 @ stdcall LdrGetDllHandle(wstr ptr ptr ptr)
 @ stdcall LdrGetDllHandleEx(long wstr ptr ptr ptr)
-@ stub -version=0x600+ LdrGetFailureData
+@ stdcall -stub -version=0x600+ LdrGetFailureData()
 @ stdcall -stub -version=0x600+ LdrGetFileNameFromLoadAsDataTable(ptr ptr)
 @ stdcall -stub -version=0x600+ -arch=x86_64 LdrGetKnownDllSectionHandle(wstr long ptr)
 @ stdcall LdrGetProcedureAddress(ptr ptr long ptr)
@@ -159,11 +163,11 @@
 @ stdcall LdrInitShimEngineDynamic(ptr)
 @ stdcall LdrInitializeThunk(long long long long)
 @ stdcall LdrLoadAlternateResourceModule(ptr ptr)
-@ stub -version=0x600+ LdrLoadAlternateResourceModuleEx
+@ stdcall -stub -version=0x600+ LdrLoadAlternateResourceModuleEx(long long ptr ptr long)
 @ stdcall LdrLoadDll(wstr long ptr ptr)
 @ stdcall LdrLockLoaderLock(long ptr ptr)
 @ stdcall LdrOpenImageFileOptionsKey(ptr long ptr) ; 5.2 SP1 and higher
-@ stub -version=0x600+ -arch=x86_64 LdrProcessInitializationComplete
+@ stdcall -stub -version=0x600+ -arch=x86_64 LdrProcessInitializationComplete()
 @ stdcall LdrProcessRelocationBlock(ptr long ptr long)
 @ stdcall LdrQueryImageFileExecutionOptions(ptr str long ptr long ptr)
 @ stdcall LdrQueryImageFileExecutionOptionsEx(ptr ptr long ptr long ptr long)
@@ -172,25 +176,25 @@
 @ stdcall LdrQueryProcessModuleInformation(ptr long ptr)
 @ stdcall -stub -version=0x600+ LdrRegisterDllNotification(long ptr ptr ptr)
 @ stdcall -stub -version=0x600+ LdrRemoveLoadAsDataTable(ptr ptr ptr long)
-@ stub -version=0x600+ LdrResFindResource
-@ stub -version=0x600+ LdrResFindResourceDirectory
-@ stub -version=0x600+ LdrResRelease
-@ stub -version=0x600+ LdrResSearchResource
+@ stdcall -stub -version=0x600+ LdrResFindResource(ptr long long long long long long long long)
+@ stdcall -stub -version=0x600+ LdrResFindResourceDirectory(ptr long long long long long long)
+@ stdcall -stub -version=0x600+ LdrResRelease(ptr ptr long long)
+@ stdcall -stub -version=0x600+ LdrResSearchResource(wstr wstr long long long ptr long long)
 @ stdcall LdrSetAppCompatDllRedirectionCallback(long ptr ptr)
 @ stdcall LdrSetDllManifestProber(ptr)
-@ stub -version=0x600+ LdrSetMUICacheType
+@ stdcall -stub -version=0x600+ LdrSetMUICacheType(long)
 @ stdcall LdrShutdownProcess()
 @ stdcall LdrShutdownThread()
 @ stdcall LdrUnloadAlternateResourceModule(ptr)
-@ stub -version=0x600+ LdrUnloadAlternateResourceModuleEx
+@ stdcall -stub -version=0x600+ LdrUnloadAlternateResourceModuleEx(long long)
 @ stdcall LdrUnloadDll(ptr)
 @ stdcall LdrUnlockLoaderLock(long ptr)
 @ stdcall -stub -version=0x600+ LdrUnregisterDllNotification(ptr)
 @ stdcall LdrVerifyImageMatchesChecksum(ptr long long long)
 @ stdcall -stub -version=0x600+ LdrVerifyImageMatchesChecksumEx(ptr ptr)
-@ stub -version=0x600+ LdrpResGetMappingSize
-@ stub -version=0x600+ LdrpResGetRCConfig
-@ stub -version=0x600+ LdrpResGetResourceDirectory
+@ stdcall -stub -version=0x600+ LdrpResGetMappingSize(long ptr long long)
+@ stdcall -stub -version=0x600+ LdrpResGetRCConfig(long long ptr long long) ; doesn't exist on win11
+@ stdcall -stub -version=0x600+ LdrpResGetResourceDirectory(long long long ptr ptr)
 @ stdcall -version=0x600+ MD4Final(ptr)
 @ stdcall -version=0x600+ MD4Init(ptr)
 @ stdcall -version=0x600+ MD4Update(ptr ptr long)
@@ -208,7 +212,7 @@
 @ stdcall NtAccessCheckByTypeResultList(ptr ptr ptr long ptr long ptr ptr long ptr ptr)
 @ stdcall NtAccessCheckByTypeResultListAndAuditAlarm(ptr ptr ptr ptr ptr ptr long long long ptr long ptr long ptr ptr ptr)
 @ stdcall NtAccessCheckByTypeResultListAndAuditAlarmByHandle(ptr ptr ptr ptr ptr ptr ptr long long long ptr long ptr long ptr ptr ptr)
-@ stub -version=0x600+ NtAcquireCMFViewOwnership
+@ stdcall -stub -version=0x600+ NtAcquireCMFViewOwnership(ptr ptr long) ; doesn't exist on Win11
 @ stdcall NtAddAtom(ptr long ptr)
 @ stdcall NtAddBootEntry(ptr long)
 @ stdcall NtAddDriverEntry(ptr long) ; 5.2 and higher
@@ -220,42 +224,42 @@
 @ stdcall NtAllocateUserPhysicalPages(ptr ptr ptr)
 @ stdcall NtAllocateUuids(ptr ptr ptr ptr)
 @ stdcall NtAllocateVirtualMemory(long ptr ptr ptr long long)
-@ stub -version=0x600+ NtAlpcAcceptConnectPort
-@ stub -version=0x600+ NtAlpcCancelMessage
-@ stub -version=0x600+ NtAlpcConnectPort
-@ stub -version=0x600+ NtAlpcCreatePort
-@ stub -version=0x600+ NtAlpcCreatePortSection
-@ stub -version=0x600+ NtAlpcCreateResourceReserve
-@ stub -version=0x600+ NtAlpcCreateSectionView
-@ stub -version=0x600+ NtAlpcCreateSecurityContext
-@ stub -version=0x600+ NtAlpcDeletePortSection
-@ stub -version=0x600+ NtAlpcDeleteResourceReserve
-@ stub -version=0x600+ NtAlpcDeleteSectionView
-@ stub -version=0x600+ NtAlpcDeleteSecurityContext
-@ stub -version=0x600+ NtAlpcDisconnectPort
-@ stub -version=0x600+ NtAlpcImpersonateClientOfPort
+@ stdcall -stub -version=0x600+ NtAlpcAcceptConnectPort(long long long long long long long long long)
+@ stdcall -stub -version=0x600+ NtAlpcCancelMessage(long long long)
+@ stdcall -stub -version=0x600+ NtAlpcConnectPort(long long long long long long long long long long long)
+@ stdcall -stub -version=0x600+ NtAlpcCreatePort(long long long) 
+@ stdcall -stub -version=0x600+ NtAlpcCreatePortSection(long long long long ptr ptr)
+@ stdcall -stub -version=0x600+ NtAlpcCreateResourceReserve(long long long ptr)
+@ stdcall -stub -version=0x600+ NtAlpcCreateSectionView(long long long)
+@ stdcall -stub -version=0x600+ NtAlpcCreateSecurityContext(long long ptr)
+@ stdcall -stub -version=0x600+ NtAlpcDeletePortSection(long long long long ptr ptr)
+@ stdcall -stub -version=0x600+ NtAlpcDeleteResourceReserve(long long long ptr)
+@ stdcall -stub -version=0x600+ NtAlpcDeleteSectionView(long long long ptr)
+@ stdcall -stub -version=0x600+ NtAlpcDeleteSecurityContext(long long long)
+@ stdcall -stub -version=0x600+ NtAlpcDisconnectPort(long long)
+@ stdcall -stub -version=0x600+ NtAlpcImpersonateClientOfPort(long long long)
 @ stub -version=0x600+ NtAlpcOpenSenderProcess
 @ stub -version=0x600+ NtAlpcOpenSenderThread
-@ stub -version=0x600+ NtAlpcQueryInformation
-@ stub -version=0x600+ NtAlpcQueryInformationMessage
-@ stub -version=0x600+ NtAlpcRevokeSecurityContext
-@ stub -version=0x600+ NtAlpcSendWaitReceivePort
-@ stub -version=0x600+ NtAlpcSetInformation
+@ stdcall -stub -version=0x600+ NtAlpcQueryInformation(long long long long long)
+@ stdcall -stub -version=0x600+ NtAlpcQueryInformationMessage(long long long long long long)
+@ stdcall -stub -version=0x600+ NtAlpcRevokeSecurityContext(long long long)
+@ stdcall -stub -version=0x600+ NtAlpcSendWaitReceivePort(long long long long long long long long)
+@ stdcall -stub -version=0x600+ NtAlpcSetInformation(long long long long)
 @ stdcall NtApphelpCacheControl(long ptr)
 @ stdcall NtAreMappedFilesTheSame(ptr ptr)
 @ stdcall NtAssignProcessToJobObject(long long)
 @ stdcall NtCallbackReturn(ptr long long)
 @ stdcall NtCancelDeviceWakeupRequest(ptr)
 @ stdcall NtCancelIoFile(long ptr)
-@ stub -version=0x600+ NtCancelIoFileEx
-@ stub -version=0x600+ NtCancelSynchronousIoFile
+@ stdcall -stub -version=0x600+ NtCancelIoFileEx(long ptr ptr)
+@ stdcall -stub -version=0x600+ NtCancelSynchronousIoFile(long ptr ptr)
 @ stdcall NtCancelTimer(long ptr)
 @ stdcall NtClearEvent(long)
 @ stdcall NtClose(long)
 @ stdcall NtCloseObjectAuditAlarm(ptr ptr long)
-@ stub -version=0x600+ NtCommitComplete
-@ stub -version=0x600+ NtCommitEnlistment
-@ stub -version=0x600+ NtCommitTransaction
+@ stdcall -stub -version=0x600+ NtCommitComplete(ptr ptr)
+@ stdcall -stub -version=0x600+ NtCommitEnlistment(ptr ptr)
+@ stdcall -stub -version=0x600+ NtCommitTransaction(ptr long)
 @ stdcall NtCompactKeys(long ptr)
 @ stdcall NtCompareTokens(ptr ptr ptr)
 @ stdcall NtCompleteConnectPort(ptr)
@@ -264,7 +268,7 @@
 @ stdcall NtContinue(ptr long)
 @ stdcall NtCreateDebugObject(ptr long ptr long)
 @ stdcall NtCreateDirectoryObject(long long long)
-@ stub -version=0x600+ NtCreateEnlistment
+@ stdcall -stub -version=0x600+ NtCreateEnlistment(ptr long ptr ptr ptr long long ptr)
 @ stdcall NtCreateEvent(long long long long long)
 @ stdcall NtCreateEventPair(ptr long ptr)
 @ stdcall NtCreateFile(ptr long ptr ptr long long long ptr long long ptr)
@@ -272,18 +276,18 @@
 @ stdcall NtCreateJobObject(ptr long ptr)
 @ stdcall NtCreateJobSet(long ptr long)
 @ stdcall NtCreateKey(ptr long ptr long ptr long long)
-@ stub -version=0x600+ NtCreateKeyTransacted
+@ stdcall -stub -version=0x600+ NtCreateKeyTransacted(ptr long ptr long ptr long long ptr)
 @ stdcall NtCreateKeyedEvent(ptr long ptr long)
 @ stdcall NtCreateMailslotFile(long long long long long long long long)
 @ stdcall NtCreateMutant(ptr long ptr long)
 @ stdcall NtCreateNamedPipeFile(ptr long ptr ptr long long long long long long long long long ptr)
 @ stdcall NtCreatePagingFile(ptr ptr ptr long)
 @ stdcall NtCreatePort(ptr ptr long long ptr)
-@ stub -version=0x600+ NtCreatePrivateNamespace
+@ stdcall -stub -version=0x600+ NtCreatePrivateNamespace(ptr long ptr ptr)
 @ stdcall NtCreateProcess(ptr long ptr ptr long ptr ptr ptr)
 @ stdcall NtCreateProcessEx(ptr long ptr ptr long ptr ptr ptr long)
 @ stdcall NtCreateProfile(ptr ptr ptr long long ptr long long long) ; CHECKME
-@ stub -version=0x600+ NtCreateResourceManager
+@ stdcall -stub -version=0x600+ NtCreateResourceManager(ptr long ptr ptr ptr long wstr)
 @ stdcall NtCreateSection(ptr long ptr ptr long long ptr)
 @ stdcall NtCreateSemaphore(ptr long ptr long long)
 @ stdcall NtCreateSymbolicLinkObject(ptr long ptr ptr)
@@ -291,11 +295,11 @@
 @ stub -version=0x600+ NtCreateThreadEx
 @ stdcall NtCreateTimer(ptr long ptr long)
 @ stdcall NtCreateToken(ptr long ptr long ptr ptr ptr ptr ptr ptr ptr ptr ptr)
-@ stub -version=0x600+ NtCreateTransaction
-@ stub -version=0x600+ NtCreateTransactionManager
-@ stub -version=0x600+ NtCreateUserProcess
+@ stdcall -stub -version=0x600+ NtCreateTransaction(ptr long ptr ptr ptr long long long ptr wstr)
+@ stdcall -stub -version=0x600+ NtCreateTransactionManager(ptr long ptr wstr long long)
+@ stdcall -stub -version=0x600+ NtCreateUserProcess(ptr ptr long long ptr ptr long long ptr long long)
 @ stdcall NtCreateWaitablePort(ptr ptr long long long)
-@ stub -version=0x600+ NtCreateWorkerFactory
+@ stdcall -stub -version=0x600+ NtCreateWorkerFactory(ptr long long long long long long long long long)
 @ stdcall -arch=win32 NtCurrentTeb() _NtCurrentTeb
 @ stdcall NtDebugActiveProcess(ptr ptr)
 @ stdcall NtDebugContinue(ptr ptr long)
@@ -306,7 +310,7 @@
 @ stdcall NtDeleteFile(ptr)
 @ stdcall NtDeleteKey(long)
 @ stdcall NtDeleteObjectAuditAlarm(ptr ptr long)
-@ stub -version=0x600+ NtDeletePrivateNamespace
+@ stdcall -stub -version=0x600+ NtDeletePrivateNamespace(long)
 @ stdcall NtDeleteValueKey(long ptr)
 @ stdcall NtDeviceIoControlFile(long long long long long long long long long long)
 @ stdcall NtDisplayString(ptr)
@@ -322,37 +326,37 @@
 @ stdcall NtFilterToken(ptr long ptr ptr ptr ptr)
 @ stdcall NtFindAtom(ptr long ptr)
 @ stdcall NtFlushBuffersFile(long ptr)
-@ stub -version=0x600+ NtFlushInstallUILanguage
+@ stdcall -stub -version=0x600+ NtFlushInstallUILanguage(long long)
 @ stdcall NtFlushInstructionCache(long ptr long)
 @ stdcall NtFlushKey(long)
-@ stub -version=0x600+ NtFlushProcessWriteBuffers
+@ stdcall -stub -version=0x600+ NtFlushProcessWriteBuffers()
 @ stdcall NtFlushVirtualMemory(long ptr ptr long)
 @ stdcall NtFlushWriteBuffer()
 @ stdcall NtFreeUserPhysicalPages(ptr ptr ptr)
 @ stdcall NtFreeVirtualMemory(long ptr ptr long)
-@ stub -version=0x600+ NtFreezeRegistry
-@ stub -version=0x600+ NtFreezeTransactions
+@ stdcall -stub -version=0x600+ NtFreezeRegistry(long)
+@ stdcall -stub -version=0x600+ NtFreezeTransactions(ptr ptr)
 @ stdcall NtFsControlFile(long long long long long long long long long long)
 @ stdcall NtGetContextThread(long ptr)
 @ stdcall NtGetCurrentProcessorNumber() ; 5.2 and higher
 @ stdcall NtGetDevicePowerState(ptr ptr)
-@ stub -version=0x600+ NtGetMUIRegistryInfo
-@ stub -version=0x600+ NtGetNextProcess
-@ stub -version=0x600+ NtGetNextThread
-@ stub -version=0x600+ NtGetNlsSectionPtr
-@ stub -version=0x600+ NtGetNotificationResourceManager
+@ stdcall -stub -version=0x600+ NtGetMUIRegistryInfo(long ptr ptr)
+@ stdcall -stub -version=0x600+ NtGetNextProcess(long long long long ptr)
+@ stdcall -stub -version=0x600+ NtGetNextThread(ptr ptr long long long ptr)
+@ stdcall -stub -version=0x600+ NtGetNlsSectionPtr(long long long ptr ptr)
+@ stdcall -stub -version=0x600+ NtGetNotificationResourceManager(ptr ptr long ptr ptr long long)
 @ stdcall NtGetPlugPlayEvent(long long ptr long)
 @ stdcall NtGetTickCount() RtlGetTickCount
 @ stdcall NtGetWriteWatch(long long ptr long ptr ptr ptr)
 @ stdcall NtImpersonateAnonymousToken(ptr)
 @ stdcall NtImpersonateClientOfPort(ptr ptr)
 @ stdcall NtImpersonateThread(ptr ptr ptr)
-@ stub -version=0x600+ NtInitializeNlsFiles
+@ stdcall -stub -version=0x600+ NtInitializeNlsFiles(ptr ptr)
 @ stdcall NtInitializeRegistry(long)
 @ stdcall NtInitiatePowerAction (long long long long)
 @ stdcall NtIsProcessInJob(long long)
 @ stdcall NtIsSystemResumeAutomatic()
-@ stub -version=0x600+ NtIsUILanguageComitted
+@ stdcall -stub -version=0x600+ NtIsUILanguageComitted()
 @ stdcall NtListenPort(ptr ptr)
 @ stdcall NtLoadDriver(ptr)
 @ stdcall NtLoadKey2(ptr ptr long)
@@ -364,7 +368,7 @@
 @ stdcall NtLockVirtualMemory(long ptr ptr long)
 @ stdcall NtMakePermanentObject(ptr)
 @ stdcall NtMakeTemporaryObject(long)
-@ stub -version=0x600+ NtMapCMFModule
+@ stdcall -stub -version=0x600+ NtMapCMFModule(long long ptr ptr ptr ptr)
 @ stdcall NtMapUserPhysicalPages(ptr ptr ptr)
 @ stdcall NtMapUserPhysicalPagesScatter(ptr ptr ptr)
 @ stdcall NtMapViewOfSection(long long ptr long long ptr ptr long long long)
@@ -374,43 +378,43 @@
 @ stdcall NtNotifyChangeKey(long long ptr ptr ptr long long ptr long long)
 @ stdcall NtNotifyChangeMultipleKeys(ptr long ptr ptr ptr ptr ptr long long ptr long long)
 @ stdcall NtOpenDirectoryObject(long long long)
-@ stub -version=0x600+ NtOpenEnlistment
+@ stdcall -stub -version=0x600+ NtOpenEnlistment(ptr long ptr ptr ptr)
 @ stdcall NtOpenEvent(long long long)
 @ stdcall NtOpenEventPair(ptr long ptr)
 @ stdcall NtOpenFile(ptr long ptr ptr long long)
 @ stdcall NtOpenIoCompletion(ptr long ptr)
 @ stdcall NtOpenJobObject(ptr long ptr)
 @ stdcall NtOpenKey(ptr long ptr)
-@ stub -version=0x600+ NtOpenKeyTransacted
+@ stdcall -stub -version=0x600+ NtOpenKeyTransacted(ptr long ptr ptr)
 @ stdcall NtOpenKeyedEvent(ptr long ptr)
 @ stdcall NtOpenMutant(ptr long ptr)
 @ stdcall NtOpenObjectAuditAlarm(ptr ptr ptr ptr ptr ptr long long ptr long long ptr)
-@ stub -version=0x600+ NtOpenPrivateNamespace
+@ stdcall -stub -version=0x600+ NtOpenPrivateNamespace(ptr long ptr ptr)
 @ stdcall NtOpenProcess(ptr long ptr ptr)
 @ stdcall NtOpenProcessToken(long long ptr)
 @ stdcall NtOpenProcessTokenEx(long long long ptr)
-@ stub -version=0x600+ NtOpenResourceManager
+@ stdcall -stub -version=0x600+ NtOpenResourceManager(ptr long ptr ptr ptr)
 @ stdcall NtOpenSection(ptr long ptr)
 @ stdcall NtOpenSemaphore(long long ptr)
-@ stub -version=0x600+ NtOpenSession
+@ stdcall -stub -version=0x600+ NtOpenSession(ptr long ptr)
 @ stdcall NtOpenSymbolicLinkObject (ptr long ptr)
 @ stdcall NtOpenThread(ptr long ptr ptr)
 @ stdcall NtOpenThreadToken(long long long ptr)
 @ stdcall NtOpenThreadTokenEx(long long long long ptr)
 @ stdcall NtOpenTimer(ptr long ptr)
-@ stub -version=0x600+ NtOpenTransaction
-@ stub -version=0x600+ NtOpenTransactionManager
+@ stdcall -stub -version=0x600+ NtOpenTransaction(ptr long ptr ptr ptr)
+@ stdcall -stub -version=0x600+ NtOpenTransactionManager(ptr long ptr ptr ptr long)
 @ stdcall NtPlugPlayControl(ptr ptr long)
 @ stdcall NtPowerInformation(long ptr long ptr long)
-@ stub -version=0x600+ NtPrePrepareComplete
-@ stub -version=0x600+ NtPrePrepareEnlistment
-@ stub -version=0x600+ NtPrepareComplete
-@ stub -version=0x600+ NtPrepareEnlistment
+@ stdcall -stub -version=0x600+ NtPrePrepareComplete(ptr ptr)
+@ stdcall -stub -version=0x600+ NtPrePrepareEnlistment(ptr ptr)
+@ stdcall -stub -version=0x600+ NtPrepareComplete(ptr ptr)
+@ stdcall -stub -version=0x600+ NtPrepareEnlistment(ptr ptr)
 @ stdcall NtPrivilegeCheck(ptr ptr ptr)
 @ stdcall NtPrivilegeObjectAuditAlarm(ptr ptr ptr long ptr long)
 @ stdcall NtPrivilegedServiceAuditAlarm(ptr ptr ptr ptr long)
-@ stub -version=0x600+ NtPropagationComplete
-@ stub -version=0x600+ NtPropagationFailed
+@ stdcall -stub -version=0x600+ NtPropagationComplete(ptr long long ptr)
+@ stdcall -stub -version=0x600+ NtPropagationFailed(ptr long long)
 @ stdcall NtProtectVirtualMemory(long ptr ptr long ptr)
 @ stdcall NtPulseEvent(long ptr)
 @ stdcall NtQueryAttributesFile(ptr ptr)
@@ -426,22 +430,22 @@
 @ stdcall NtQueryEvent(long long ptr long ptr)
 @ stdcall NtQueryFullAttributesFile(ptr ptr)
 @ stdcall NtQueryInformationAtom(long long ptr long ptr)
-@ stub -version=0x600+ NtQueryInformationEnlistment
+@ stdcall -stub -version=0x600+ NtQueryInformationEnlistment(ptr long ptr long ptr)
 @ stdcall NtQueryInformationFile(ptr ptr ptr long long)
 @ stdcall NtQueryInformationJobObject(ptr long ptr long ptr)
 @ stdcall NtQueryInformationPort(ptr long ptr long ptr)
 @ stdcall NtQueryInformationProcess(ptr long ptr long ptr)
-@ stub -version=0x600+ NtQueryInformationResourceManager
+@ stdcall -stub -version=0x600+ NtQueryInformationResourceManager(ptr long ptr long ptr)
 @ stdcall NtQueryInformationThread(ptr long ptr long ptr)
 @ stdcall NtQueryInformationToken(ptr long ptr long ptr)
-@ stub -version=0x600+ NtQueryInformationTransaction
-@ stub -version=0x600+ NtQueryInformationTransactionManager
-@ stub -version=0x600+ NtQueryInformationWorkerFactory
+@ stdcall -stub -version=0x600+ NtQueryInformationTransaction(ptr long ptr ptr ptr)
+@ stdcall -stub -version=0x600+ NtQueryInformationTransactionManager(ptr long ptr long ptr)
+@ stdcall -stub -version=0x600+ NtQueryInformationWorkerFactory(ptr long ptr long ptr)
 @ stdcall NtQueryInstallUILanguage(ptr)
 @ stdcall NtQueryIntervalProfile(long ptr)
 @ stdcall NtQueryIoCompletion(long long ptr long ptr)
 @ stdcall NtQueryKey (long long ptr long ptr)
-@ stub -version=0x600+ NtQueryLicenseValue
+@ stdcall -stub -version=0x600+ NtQueryLicenseValue(wstr ptr ptr long ptr)
 @ stdcall NtQueryMultipleValueKey(long ptr long ptr long ptr)
 @ stdcall NtQueryMutant(long long ptr long ptr)
 @ stdcall NtQueryObject(long long long long long)
@@ -468,26 +472,26 @@
 @ stdcall NtRaiseHardError(long long long ptr long ptr)
 @ stdcall NtReadFile(long long ptr ptr ptr ptr long ptr ptr)
 @ stdcall NtReadFileScatter(long long ptr ptr ptr ptr long ptr ptr)
-@ stub -version=0x600+ NtReadOnlyEnlistment
+@ stdcall -stub -version=0x600+ NtReadOnlyEnlistment(ptr ptr)
 @ stdcall NtReadRequestData(ptr ptr long ptr long ptr)
 @ stdcall NtReadVirtualMemory(long ptr ptr long ptr)
-@ stub -version=0x600+ NtRecoverEnlistment
-@ stub -version=0x600+ NtRecoverResourceManager
-@ stub -version=0x600+ NtRecoverTransactionManager
-@ stub -version=0x600+ NtRegisterProtocolAddressInformation
+@ stdcall -stub -version=0x600+ NtRecoverEnlistment(ptr ptr)
+@ stdcall -stub -version=0x600+ NtRecoverResourceManager(ptr)
+@ stdcall -stub -version=0x600+ NtRecoverTransactionManager(ptr)
+@ stdcall -stub -version=0x600+ NtRegisterProtocolAddressInformation(ptr ptr long ptr long)
 @ stdcall NtRegisterThreadTerminatePort(ptr)
-@ stub -version=0x600+ NtReleaseCMFViewOwnership
+@ stdcall -stub -version=0x600+ NtReleaseCMFViewOwnership()
 @ stdcall NtReleaseKeyedEvent(ptr ptr long ptr)
 @ stdcall NtReleaseMutant(long ptr)
 @ stdcall NtReleaseSemaphore(long long ptr)
-@ stub -version=0x600+ NtReleaseWorkerFactoryWorker
+@ stdcall -stub -version=0x600+ NtReleaseWorkerFactoryWorker(ptr)
 @ stdcall NtRemoveIoCompletion(ptr ptr ptr ptr ptr)
-@ stub -version=0x600+ NtRemoveIoCompletionEx
+@ stdcall -stub -version=0x600+ NtRemoveIoCompletionEx(ptr ptr long ptr ptr long)
 @ stdcall NtRemoveProcessDebug(ptr ptr)
 @ stdcall NtRenameKey(ptr ptr)
-@ stub -version=0x600+ NtRenameTransactionManager
+@ stdcall -stub -version=0x600+ NtRenameTransactionManager(ptr ptr)
 @ stdcall NtReplaceKey(ptr long ptr)
-@ stub -version=0x600+ NtReplacePartitionUnit
+@ stdcall -stub -version=0x600+ NtReplacePartitionUnit(wstr wstr long)
 @ stdcall NtReplyPort(ptr ptr)
 @ stdcall NtReplyWaitReceivePort(ptr ptr ptr ptr)
 @ stdcall NtReplyWaitReceivePortEx(ptr ptr ptr ptr ptr)
@@ -501,10 +505,10 @@
 @ stdcall NtRestoreKey(long long long)
 @ stdcall NtResumeProcess(ptr)
 @ stdcall NtResumeThread(long long)
-@ stub -version=0x600+ NtRollbackComplete
-@ stub -version=0x600+ NtRollbackEnlistment
-@ stub -version=0x600+ NtRollbackTransaction
-@ stub -version=0x600+ NtRollforwardTransactionManager
+@ stdcall -stub -version=0x600+ NtRollbackComplete(ptr ptr)
+@ stdcall -stub -version=0x600+ NtRollbackEnlistment(ptr long ptr long)
+@ stdcall -stub -version=0x600+ NtRollbackTransaction(ptr long)
+@ stdcall -stub -version=0x600+ NtRollforwardTransactionManager(ptr ptr)
 @ stdcall NtSaveKey(long long)
 @ stdcall NtSaveKeyEx(ptr ptr long)
 @ stdcall NtSaveMergedKeys(ptr ptr ptr)
@@ -523,18 +527,18 @@
 @ stdcall NtSetHighEventPair(ptr)
 @ stdcall NtSetHighWaitLowEventPair(ptr)
 @ stdcall NtSetInformationDebugObject(ptr long ptr long ptr)
-@ stub -version=0x600+ NtSetInformationEnlistment
+@ stdcall -stub -version=0x600+ NtSetInformationEnlistment(ptr long ptr long)
 @ stdcall NtSetInformationFile(ptr ptr ptr long long)
 @ stdcall NtSetInformationJobObject(ptr long ptr long)
 @ stdcall NtSetInformationKey(ptr long ptr long)
 @ stdcall NtSetInformationObject(ptr long ptr long)
 @ stdcall NtSetInformationProcess(ptr long ptr long)
-@ stub -version=0x600+ NtSetInformationResourceManager
+@ stdcall -stub -version=0x600+ NtSetInformationResourceManager(ptr long ptr long)
 @ stdcall NtSetInformationThread(ptr long ptr long)
 @ stdcall NtSetInformationToken(ptr long ptr long)
-@ stub -version=0x600+ NtSetInformationTransaction
-@ stub -version=0x600+ NtSetInformationTransactionManager
-@ stub -version=0x600+ NtSetInformationWorkerFactory
+@ stdcall -stub -version=0x600+ NtSetInformationTransaction(ptr long ptr long)
+@ stdcall -stub -version=0x600+ NtSetInformationTransactionManager(ptr long ptr long)
+@ stdcall -stub -version=0x600+ NtSetInformationWorkerFactory(ptr long ptr long)
 @ stdcall NtSetIntervalProfile(long long)
 @ stdcall NtSetIoCompletion(ptr long ptr long long)
 @ stdcall NtSetLdtEntries(long int64 long int64)
@@ -554,9 +558,9 @@
 @ stdcall NtSetValueKey(long long long long long long)
 @ stdcall NtSetVolumeInformationFile(long ptr ptr long long)
 @ stdcall NtShutdownSystem(long)
-@ stub -version=0x600+ NtShutdownWorkerFactory
+@ stdcall -stub -version=0x600+ NtShutdownWorkerFactory(ptr ptr)
 @ stdcall NtSignalAndWaitForSingleObject(long long long ptr)
-@ stub -version=0x600+ NtSinglePhaseReject
+@ stdcall -stub -version=0x600+ NtSinglePhaseReject(ptr ptr)
 @ stdcall NtStartProfile(ptr)
 @ stdcall NtStopProfile(ptr)
 @ stdcall NtSuspendProcess(ptr)
@@ -566,9 +570,9 @@
 @ stdcall NtTerminateProcess(ptr long)
 @ stdcall NtTerminateThread(ptr long)
 @ stdcall NtTestAlert()
-@ stub -version=0x600+ NtThawRegistry
-@ stub -version=0x600+ NtThawTransactions
-@ stub -version=0x600+ NtTraceControl
+@ stdcall -stub -version=0x600+ NtThawRegistry()
+@ stdcall -stub -version=0x600+ NtThawTransactions()
+@ stdcall -stub -version=0x600+ NtTraceControl(long ptr long ptr long long)
 @ stdcall NtTraceEvent(long long long ptr)
 @ stdcall NtTranslateFilePath(ptr long ptr long)
 @ stdcall NtUnloadDriver(ptr)
@@ -587,16 +591,16 @@
 @ stub -version=0x600+ NtWaitForWorkViaWorkerFactory
 @ stdcall NtWaitHighEventPair(ptr)
 @ stdcall NtWaitLowEventPair(ptr)
-@ stub -version=0x600+ NtWorkerFactoryWorkerReady
+@ stdcall -stub -version=0x600+ NtWorkerFactoryWorkerReady(long)
 @ stdcall NtWriteFile(long long ptr ptr ptr ptr long ptr ptr)
 @ stdcall NtWriteFileGather(long long ptr ptr ptr ptr long ptr ptr)
 @ stdcall NtWriteRequestData(ptr ptr long ptr long ptr)
 @ stdcall NtWriteVirtualMemory(long ptr ptr long ptr)
 @ stdcall NtYieldExecution()
-@ stub -version=0x600+ NtdllDefWindowProc_A
-@ stub -version=0x600+ NtdllDefWindowProc_W
-@ stub -version=0x600+ NtdllDialogWndProc_A
-@ stub -version=0x600+ NtdllDialogWndProc_W
+@ stdcall -stub -version=0x600+ NtdllDefWindowProc_A(long long long long)
+@ stdcall -stub -version=0x600+ NtdllDefWindowProc_W(long long long long)
+@ stdcall -stub -version=0x600+ NtdllDialogWndProc_A(long long long long)
+@ stdcall -stub -version=0x600+ NtdllDialogWndProc_W(long long long long)
 @ stdcall PfxFindPrefix(ptr ptr)
 @ stdcall PfxInitialize(ptr)
 @ stdcall PfxInsertPrefix(ptr ptr ptr)
@@ -627,10 +631,10 @@
 @ stdcall RtlAddAuditAccessObjectAce(ptr long long long ptr ptr ptr long long)
 @ stdcall -stub RtlAddCompoundAce(ptr long long long ptr ptr)
 @ stdcall -arch=x86_64 RtlAddFunctionTable(ptr long long)
-@ stub -version=0x600+ RtlAddMandatoryAce
+@ stdcall -stub -version=0x600+ RtlAddMandatoryAce(ptr long long long long ptr) ; not present in Win11
 @ stdcall RtlAddRefActivationContext(ptr)
 @ stdcall RtlAddRefMemoryStream(ptr)
-@ stub -version=0x600+ RtlAddSIDToBoundaryDescriptor
+@ stdcall -stub -version=0x600+ RtlAddSIDToBoundaryDescriptor(ptr ptr) ; not present in Win11
 @ stdcall RtlAddVectoredContinueHandler(long ptr)
 @ stdcall RtlAddVectoredExceptionHandler(long ptr)
 @ stdcall -stub RtlAddressInSectionTable(ptr ptr long)
@@ -639,8 +643,8 @@
 @ stdcall RtlAllocateAndInitializeSid(ptr long long long long long long long long long ptr)
 @ stdcall RtlAllocateHandle(ptr ptr)
 @ stdcall RtlAllocateHeap(ptr long ptr)
-@ stub -version=0x600+ RtlAllocateMemoryBlockLookaside
-@ stub -version=0x600+ RtlAllocateMemoryZone
+@ stdcall -stub -version=0x600+ RtlAllocateMemoryBlockLookaside(ptr long ptr) ; not present in Win11
+@ stdcall -stub -version=0x600+ RtlAllocateMemoryZone(long long ptr) ; not present in Win11
 @ stdcall RtlAnsiCharToUnicodeChar(ptr)
 @ stdcall RtlAnsiStringToUnicodeSize(ptr) RtlxAnsiStringToUnicodeSize
 @ stdcall RtlAnsiStringToUnicodeString(ptr ptr long)
@@ -657,8 +661,8 @@
 @ stdcall RtlAreBitsClear(ptr long long)
 @ stdcall RtlAreBitsSet(ptr long long)
 @ stdcall RtlAssert(ptr ptr long ptr)
-@ stub -version=0x600+ RtlBarrier
-@ stub -version=0x600+ RtlBarrierForDelete
+@ stdcall -stub -version=0x600+ RtlBarrier(ptr long)
+@ stdcall -stub -version=0x600+ RtlBarrierForDelete(long long)
 @ stdcall RtlCancelTimer(ptr ptr)
 @ stdcall -register RtlCaptureContext(ptr)
 @ stdcall RtlCaptureStackBackTrace(long long ptr ptr)
@@ -667,23 +671,23 @@
 @ stdcall RtlCheckForOrphanedCriticalSections(ptr)
 @ stdcall -stub -version=0x502 RtlCheckProcessParameters(ptr ptr ptr ptr)
 @ stdcall RtlCheckRegistryKey(long ptr)
-@ stub -version=0x600+ RtlCleanUpTEBLangLists
+@ stdcall -stub -version=0x600+ RtlCleanUpTEBLangLists()
 @ stdcall RtlClearAllBits(ptr)
 @ stdcall RtlClearBits(ptr long long)
 @ stdcall RtlCloneMemoryStream(ptr ptr)
-@ stub -version=0x600+ RtlCloneUserProcess
-@ stub -version=0x600+ RtlCmDecodeMemIoResource
-@ stub -version=0x600+ RtlCmEncodeMemIoResource
-@ stub -version=0x600+ RtlCommitDebugInfo
+@ stdcall -stub -version=0x600+ RtlCloneUserProcess(long long long long long)
+@ stdcall -stub -version=0x600+ RtlCmDecodeMemIoResource(ptr ptr)
+@ stdcall -stub -version=0x600+ RtlCmEncodeMemIoResource(ptr long long long)
+@ stdcall -stub -version=0x600+ RtlCommitDebugInfo(ptr long)
 @ stdcall RtlCommitMemoryStream(ptr long)
 @ stdcall RtlCompactHeap(long long)
-@ stub -version=0x600+ RtlCompareAltitudes
+@ stdcall -stub -version=0x600+ RtlCompareAltitudes(wstr wstr)
 @ stdcall RtlCompareMemory(ptr ptr long)
 @ stdcall RtlCompareMemoryUlong(ptr long long)
 @ stdcall RtlCompareString(ptr ptr long)
 @ stdcall RtlCompareUnicodeString (ptr ptr long)
 @ stdcall -version=0x600+ RtlCompareUnicodeStrings(wstr long wstr long long)
-@ stub -version=0x600+ -arch=x86_64 RtlCompleteProcessCloning
+@ stdcall -stub -version=0x600+ -arch=x86_64 RtlCompleteProcessCloning(long)
 @ stdcall RtlCompressBuffer(long ptr long ptr long long ptr ptr)
 @ stdcall RtlComputeCrc32(long ptr long)
 @ stdcall RtlComputeImportTableHash(ptr ptr long)
@@ -691,7 +695,7 @@
 @ stdcall -stub -version=0x600+ RtlConnectToSm(ptr ptr long ptr)
 @ stdcall RtlConsoleMultiByteToUnicodeN(ptr long ptr ptr long ptr)
 @ stdcall RtlConvertExclusiveToShared(ptr)
-@ stub -version=0x600+ RtlConvertLCIDToString
+@ stdcall -stub -version=0x600+ RtlConvertLCIDToString(long long long ptr long)
 @ stdcall -arch=win32 -ret64 RtlConvertLongToLargeInteger(long)
 @ stdcall RtlConvertSharedToExclusive(ptr)
 @ stdcall RtlConvertSidToUnicodeString(ptr ptr long)
@@ -702,7 +706,7 @@
 @ stdcall RtlCopyLuidAndAttributesArray(long ptr ptr)
 @ stdcall RtlCopyMappedMemory(ptr ptr long)
 @ cdecl -version=0x600+ -arch=x86_64 RtlCopyMemory(ptr ptr long) memmove
-@ stub -version=0x600+ -arch=x86_64 RtlCopyMemoryNonTemporal
+@ stdcall -stub -version=0x600+ -arch=x86_64 RtlCopyMemoryNonTemporal(ptr ptr long)
 @ stdcall RtlCopyMemoryStreamTo(ptr ptr int64 ptr ptr)
 @ stdcall RtlCopyOutOfProcessMemoryStreamTo(ptr ptr int64 ptr ptr) RtlCopyMemoryStreamTo
 @ stdcall RtlCopySecurityDescriptor(ptr ptr)
@@ -715,14 +719,14 @@
 @ stdcall RtlCreateAndSetSD(ptr long ptr ptr ptr)
 @ stdcall RtlCreateAtomTable(long ptr)
 @ stdcall RtlCreateBootStatusDataFile()
-@ stub -version=0x600+ RtlCreateBoundaryDescriptor
+@ stdcall -stub -version=0x600+ RtlCreateBoundaryDescriptor(ptr long)
 @ stdcall RtlCreateEnvironment(long ptr)
-@ stub -version=0x600+ RtlCreateEnvironmentEx
+@ stdcall -stub -version=0x600+ RtlCreateEnvironmentEx(ptr ptr long)
 @ stdcall RtlCreateHeap(long ptr long long ptr ptr)
-@ stub -version=0x600+ RtlCreateMemoryBlockLookaside
-@ stub -version=0x600+ RtlCreateMemoryZone
+@ stdcall -stub -version=0x600+ RtlCreateMemoryBlockLookaside(ptr long long long long)
+@ stdcall -stub -version=0x600+ RtlCreateMemoryZone(ptr long long)
 @ stdcall RtlCreateProcessParameters(ptr ptr ptr ptr ptr ptr ptr ptr ptr ptr)
-@ stub -version=0x600+ RtlCreateProcessParametersEx
+@ stdcall -stub -version=0x600+ RtlCreateProcessParametersEx(ptr wstr ptr wstr wstr ptr wstr wstr ptr ptr long)
 @ stdcall RtlCreateQueryDebugBuffer(long long)
 @ stdcall RtlCreateRegistryKey(long wstr)
 @ stdcall RtlCreateSecurityDescriptor(ptr long)
@@ -735,12 +739,12 @@
 @ stdcall RtlCreateUnicodeStringFromAsciiz(ptr str)
 @ stdcall RtlCreateUserProcess(ptr long ptr ptr ptr ptr long ptr ptr ptr)
 @ stdcall RtlCreateUserSecurityObject(ptr long ptr ptr long ptr ptr)
-@ stub -version=0x600+ RtlCreateUserStack
+@ stdcall -stub -version=0x600+ RtlCreateUserStack(long long long long long ptr)
 @ stdcall RtlCreateUserThread(long ptr long ptr long long ptr ptr ptr ptr)
-@ stub -version=0x600+ RtlCultureNameToLCID
+@ stdcall -stub -version=0x600+ RtlCultureNameToLCID(ptr ptr)
 @ stdcall RtlCustomCPToUnicodeN(ptr wstr long ptr str long)
 @ stdcall RtlCutoverTimeToSystemTime(ptr ptr ptr long)
-@ stub -version=0x600+ RtlDeCommitDebugInfo
+@ stdcall -stub -version=0x600+ RtlDeCommitDebugInfo(long long long) ; doesn't exist in win11
 @ stdcall RtlDeNormalizeProcessParams(ptr)
 @ stdcall RtlDeactivateActivationContext(long long)
 @ stdcall -arch=x86_64,arm RtlDeactivateActivationContextUnsafeFast(ptr)
@@ -753,8 +757,8 @@
 @ stdcall RtlDelete(ptr)
 @ stdcall RtlDeleteAce(ptr long)
 @ stdcall RtlDeleteAtomFromAtomTable(ptr long)
-@ stub -version=0x600+ RtlDeleteBarrier
-@ stub -version=0x600+ RtlDeleteBoundaryDescriptor
+@ stdcall -stub -version=0x600+ RtlDeleteBarrier(long)
+@ stdcall -stub -version=0x600+ RtlDeleteBoundaryDescriptor(ptr)
 @ stdcall RtlDeleteCriticalSection(ptr)
 @ stdcall RtlDeleteElementGenericTable(ptr ptr)
 @ stdcall RtlDeleteElementGenericTableAvl(ptr ptr)
@@ -766,15 +770,15 @@
 @ stdcall RtlDeleteTimer(ptr ptr ptr)
 @ stdcall RtlDeleteTimerQueue(ptr)
 @ stdcall RtlDeleteTimerQueueEx(ptr ptr)
-@ stub -version=0x600+ RtlDeregisterSecureMemoryCacheCallback
+@ stdcall -stub -version=0x600+ RtlDeregisterSecureMemoryCacheCallback(ptr)
 @ stdcall RtlDeregisterWait(ptr)
 @ stdcall RtlDeregisterWaitEx(ptr ptr)
 @ stdcall RtlDestroyAtomTable(ptr)
 @ stdcall RtlDestroyEnvironment(ptr)
 @ stdcall RtlDestroyHandleTable(ptr)
 @ stdcall RtlDestroyHeap(long)
-@ stub -version=0x600+ RtlDestroyMemoryBlockLookaside
-@ stub -version=0x600+ RtlDestroyMemoryZone
+@ stdcall -stub -version=0x600+ RtlDestroyMemoryBlockLookaside(long)
+@ stdcall -stub -version=0x600+ RtlDestroyMemoryZone(long)
 @ stdcall RtlDestroyProcessParameters(ptr)
 @ stdcall RtlDestroyQueryDebugBuffer(ptr)
 @ stdcall RtlDetermineDosPathNameType_U(wstr)
@@ -814,27 +818,27 @@
 @ stdcall RtlEqualString(ptr ptr long)
 @ stdcall RtlEqualUnicodeString(ptr ptr long)
 @ stdcall RtlEraseUnicodeString(ptr)
-@ stub -version=0x600+ RtlExitUserProcess
+@ stdcall -stub -version=0x600+ RtlExitUserProcess(long)
 @ stdcall RtlExitUserThread(long)
-@ stub -version=0x600+ RtlExpandEnvironmentStrings
+@ stdcall -stub -version=0x600+ RtlExpandEnvironmentStrings(long ptr long ptr long ptr)
 @ stdcall RtlExpandEnvironmentStrings_U(ptr ptr ptr ptr)
 @ stdcall -version=0x502 RtlExtendHeap(ptr long ptr ptr)
-@ stub -version=0x600+ RtlExtendMemoryBlockLookaside
-@ stub -version=0x600+ RtlExtendMemoryZone
+@ stdcall -stub -version=0x600+ RtlExtendMemoryBlockLookaside(long)
+@ stdcall -stub -version=0x600+ RtlExtendMemoryZone(long long)
 @ stdcall -arch=win32 -ret64 RtlExtendedIntegerMultiply(double long)
 @ stdcall -arch=win32 -ret64 RtlExtendedLargeIntegerDivide(double long ptr)
 @ stdcall -arch=win32 -ret64 RtlExtendedMagicDivide(double double long)
 @ stdcall RtlFillMemory(ptr long long)
 @ stdcall -arch=i386,arm RtlFillMemoryUlong(ptr long long)
 @ stdcall RtlFinalReleaseOutOfProcessMemoryStream(ptr)
-@ stub -version=0x600+ RtlFindAceByType
+@ stdcall -stub -version=0x600+ RtlFindAceByType(long long ptr)
 @ stdcall RtlFindActivationContextSectionGuid(long ptr long ptr ptr)
 @ stdcall RtlFindActivationContextSectionString(long ptr long ptr ptr)
 @ stdcall RtlFindCharInUnicodeString(long ptr ptr ptr)
 @ stdcall RtlFindClearBits(ptr long long)
 @ stdcall RtlFindClearBitsAndSet(ptr long long)
 @ stdcall RtlFindClearRuns(ptr ptr long long)
-@ stub -version=0x600+ RtlFindClosestEncodableLength
+@ stdcall -stub -version=0x600+ RtlFindClosestEncodableLength(long ptr)
 @ stdcall RtlFindLastBackwardRunClear(ptr long ptr)
 @ stdcall RtlFindLeastSignificantBit(double)
 @ stdcall RtlFindLongestRunClear(ptr long)
@@ -845,8 +849,8 @@
 @ stdcall RtlFindSetBitsAndClear(ptr long long)
 @ stdcall RtlFirstEntrySList(ptr)
 @ stdcall RtlFirstFreeAce(ptr ptr)
-@ stub -version=0x600+ RtlFlsAlloc
-@ stub -version=0x600+ RtlFlsFree
+@ stdcall -stub -version=0x600+ RtlFlsAlloc(long long long long)
+@ stdcall -stub -version=0x600+ RtlFlsFree(long)
 @ stdcall RtlFlushSecureMemoryCache(ptr ptr)
 @ stdcall RtlFormatCurrentUserKeyPath(ptr)
 @ stdcall RtlFormatMessage(ptr long long long long ptr ptr long ptr)
@@ -855,12 +859,12 @@
 @ stdcall RtlFreeAnsiString(long)
 @ stdcall RtlFreeHandle(ptr ptr)
 @ stdcall RtlFreeHeap(long long long)
-@ stub -version=0x600+ RtlFreeMemoryBlockLookaside
+@ stdcall -stub -version=0x600+ RtlFreeMemoryBlockLookaside(long long)
 @ stdcall RtlFreeOemString(ptr)
 @ stdcall RtlFreeSid(long)
 @ stdcall RtlFreeThreadActivationContextStack()
 @ stdcall RtlFreeUnicodeString(ptr)
-@ stub -version=0x600+ RtlFreeUserStack
+@ stdcall -stub -version=0x600+ RtlFreeUserStack(long)
 @ stdcall -version=0x502 RtlFreeUserThreadStack(ptr ptr)
 @ stdcall RtlGUIDFromString(ptr ptr)
 @ stdcall RtlGenerate8dot3Name(ptr ptr long ptr)
@@ -873,11 +877,11 @@
 @ stdcall RtlGetCurrentDirectory_U(long ptr)
 @ stdcall RtlGetCurrentPeb()
 @ stdcall RtlGetCurrentProcessorNumber() ; 5.2 SP1 and higher
-@ stub -version=0x600+ RtlGetCurrentTransaction
+@ stdcall -stub -version=0x600+ RtlGetCurrentTransaction()
 @ stdcall RtlGetDaclSecurityDescriptor(ptr ptr ptr ptr)
 @ stdcall RtlGetElementGenericTable(ptr long)
 @ stdcall RtlGetElementGenericTableAvl(ptr long)
-@ stub -version=0x600+ RtlGetFileMUIPath
+@ stdcall -stub -version=0x600+ RtlGetFileMUIPath(long long ptr ptr long long ptr)
 @ stdcall RtlGetFrame()
 @ stdcall RtlGetFullPathName_U(wstr long ptr ptr)
 @ stdcall RtlGetFullPathName_UstrEx(ptr ptr ptr ptr ptr ptr ptr ptr)
@@ -895,38 +899,38 @@
 @ stdcall RtlGetNtProductType(ptr)
 @ stdcall RtlGetNtVersionNumbers(ptr ptr ptr)
 @ stdcall RtlGetOwnerSecurityDescriptor(ptr ptr ptr)
-@ stub -version=0x600+ RtlGetParentLocaleName
+@ stdcall -stub -version=0x600+ RtlGetParentLocaleName(wstr long long long)
 @ stdcall RtlGetProcessHeaps(long ptr)
 @ stub -version=0x600+ RtlGetProductInfo
 @ stdcall RtlGetSaclSecurityDescriptor(ptr ptr ptr ptr)
 @ stdcall RtlGetSecurityDescriptorRMControl(ptr ptr)
 @ stdcall RtlGetSetBootStatusData(ptr long long ptr long long)
-@ stub -version=0x600+ RtlGetSystemPreferredUILanguages
+@ stdcall -stub -version=0x600+ RtlGetSystemPreferredUILanguages(long ptr ptr ptr ptr)
 @ stdcall RtlGetThreadErrorMode()
-@ stub -version=0x600+ RtlGetThreadLangIdByIndex
-@ stub -version=0x600+ RtlGetThreadPreferredUILanguages
-@ stub -version=0x600+ RtlGetUILanguageInfo
+@ stdcall -stub -version=0x600+ RtlGetThreadLangIdByIndex(long long ptr ptr)
+@ stdcall -stub -version=0x600+ RtlGetThreadPreferredUILanguages(long long ptr ptr)
+@ stdcall -stub -version=0x600+ RtlGetUILanguageInfo(long ptr long ptr ptr)
 @ stdcall RtlGetUnloadEventTrace()
-@ stub -version=0x600+ RtlGetUnloadEventTraceEx
+@ stdcall -stub -version=0x600+ RtlGetUnloadEventTraceEx(ptr ptr ptr)
 @ stdcall RtlGetUserInfoHeap(ptr long ptr ptr ptr)
-@ stub -version=0x600+ RtlGetUserPreferredUILanguages
+@ stdcall -stub -version=0x600+ RtlGetUserPreferredUILanguages(long ptr ptr ptr ptr)
 @ stdcall RtlGetVersion(ptr)
 @ stdcall RtlHashUnicodeString(ptr long long ptr)
-@ stub -version=0x600+ RtlHeapTrkInitialize
+@ stdcall -stub -version=0x600+ RtlHeapTrkInitialize(ptr)
 @ stdcall RtlIdentifierAuthoritySid(ptr)
-@ stub -version=0x600+ RtlIdnToAscii
-@ stub -version=0x600+ RtlIdnToNameprepUnicode
-@ stub -version=0x600+ RtlIdnToUnicode
+@ stdcall -stub -version=0x600+ RtlIdnToAscii(long long long long long)
+@ stdcall -stub -version=0x600+ RtlIdnToNameprepUnicode(long long long long long)
+@ stdcall -stub -version=0x600+ RtlIdnToUnicode(long long long long long)
 @ stdcall RtlImageDirectoryEntryToData(ptr long long ptr)
 @ stdcall RtlImageNtHeader(long)
 @ stdcall RtlImageNtHeaderEx(long ptr double ptr)
 @ stdcall RtlImageRvaToSection(ptr long long)
 @ stdcall RtlImageRvaToVa(ptr long long ptr)
 @ stdcall RtlImpersonateSelf(long)
-@ stub -version=0x600+ RtlImpersonateSelfEx
+@ stdcall -stub -version=0x600+ RtlImpersonateSelfEx(long long ptr)
 @ stdcall RtlInitAnsiString(ptr str)
 @ stdcall RtlInitAnsiStringEx(ptr str)
-@ stub -version=0x600+ RtlInitBarrier
+@ stdcall -stub -version=0x600+ RtlInitBarrier(long long)
 @ stdcall RtlInitCodePageTable(ptr ptr)
 @ stdcall RtlInitMemoryStream(ptr)
 @ stdcall RtlInitNlsTables(ptr ptr ptr ptr)
@@ -941,11 +945,11 @@
 @ stdcall RtlInitializeCriticalSection(ptr)
 @ stdcall RtlInitializeCriticalSectionAndSpinCount(ptr long)
 @ stdcall -version=0x600+ RtlInitializeCriticalSectionEx(ptr long long)
-@ stub -version=0x600+ -arch=i386 RtlInitializeExceptionChain
+@ stdcall -stub -version=0x600+ -arch=i386 RtlInitializeExceptionChain(ptr)
 @ stdcall RtlInitializeGenericTable(ptr ptr ptr ptr ptr)
 @ stdcall RtlInitializeGenericTableAvl(ptr ptr ptr ptr ptr)
 @ stdcall RtlInitializeHandleTable(long long ptr)
-@ stub -version=0x600+ RtlInitializeNtUserPfn
+@ stdcall -stub -version=0x600+ RtlInitializeNtUserPfn(wstr long ptr long wstr ptr)
 @ stdcall RtlInitializeRXact(ptr long ptr)
 @ stdcall RtlInitializeResource(ptr)
 @ stdcall RtlInitializeSListHead(ptr)
@@ -964,8 +968,8 @@
 @ stdcall RtlInterlockedPopEntrySList(ptr)
 @ stdcall RtlInterlockedPushEntrySList(ptr ptr)
 @ stdcall -arch=x86_64 RtlInterlockedPushListSList(ptr ptr ptr long)
-@ stub -version=0x600+ RtlIoDecodeMemIoResource
-@ stub -version=0x600+ RtlIoEncodeMemIoResource
+@ stdcall -stub -version=0x600+ RtlIoDecodeMemIoResource(ptr ptr ptr ptr)
+@ stdcall -stub -version=0x600+ RtlIoEncodeMemIoResource(ptr long long long long long)
 @ stdcall RtlIpv4AddressToStringA(ptr ptr)
 @ stdcall RtlIpv4AddressToStringExA(ptr long ptr ptr)
 @ stdcall RtlIpv4AddressToStringExW(ptr long ptr ptr)
@@ -985,18 +989,18 @@
 @ stdcall RtlIsActivationContextActive(ptr)
 @ stdcall RtlIsCriticalSectionLocked(ptr)
 @ stdcall RtlIsCriticalSectionLockedByThread(ptr)
-@ stub -version=0x600+ RtlIsCurrentThreadAttachExempt
+@ stdcall -stub -version=0x600+ RtlIsCurrentThreadAttachExempt()
 @ stdcall RtlIsDosDeviceName_U(wstr)
 @ stdcall RtlIsGenericTableEmpty(ptr)
 @ stdcall RtlIsGenericTableEmptyAvl(ptr)
 @ stdcall RtlIsNameLegalDOS8Dot3(ptr ptr ptr)
-@ stub -version=0x600+ RtlIsNormalizedString
+@ stdcall -stub -version=0x600+ RtlIsNormalizedString(long ptr long ptr)
 @ stdcall RtlIsTextUnicode(ptr long ptr)
 @ stdcall RtlIsThreadWithinLoaderCallout()
 @ stdcall RtlIsValidHandle(ptr ptr)
 @ stdcall RtlIsValidIndexHandle(ptr long ptr)
-@ stub -version=0x600+ RtlIsValidLocaleName
-@ stub -version=0x600+ RtlLCIDToCultureName
+@ stdcall -stub -version=0x600+ RtlIsValidLocaleName(ptr long)
+@ stdcall -stub -version=0x600+ RtlLCIDToCultureName(long long)
 @ stdcall -arch=win32 -ret64 RtlLargeIntegerAdd(double double)
 @ stdcall -arch=win32 -ret64 RtlLargeIntegerArithmeticShift(double long)
 @ stdcall -arch=win32 -ret64 RtlLargeIntegerDivide(double double ptr)
@@ -1005,20 +1009,20 @@
 @ stdcall -arch=win32 -ret64 RtlLargeIntegerShiftRight(double long)
 @ stdcall -arch=win32 -ret64 RtlLargeIntegerSubtract(double double)
 @ stdcall RtlLargeIntegerToChar(ptr long long ptr)
-@ stub -version=0x600+ RtlLcidToLocaleName
+@ stdcall -stub -version=0x600+ RtlLcidToLocaleName(long long long long)
 @ stdcall RtlLeaveCriticalSection(ptr)
 @ stdcall RtlLengthRequiredSid(long)
 @ stdcall RtlLengthSecurityDescriptor(ptr)
 @ stdcall RtlLengthSid(ptr)
 @ stdcall RtlLocalTimeToSystemTime(ptr ptr)
-@ stub -version=0x600+ RtlLocaleNameToLcid
+@ stdcall -stub -version=0x600+ RtlLocaleNameToLcid(wstr ptr long)
 @ stdcall RtlLockBootStatusData(ptr)
-@ stub -version=0x600+ RtlLockCurrentThread
+@ stdcall -stub -version=0x600+ RtlLockCurrentThread()
 @ stdcall RtlLockHeap(long)
-@ stub -version=0x600+ RtlLockMemoryBlockLookaside
+@ stdcall -stub -version=0x600+ RtlLockMemoryBlockLookaside(long)
 @ stdcall RtlLockMemoryStreamRegion(ptr int64 int64 long)
-@ stub -version=0x600+ RtlLockMemoryZone
-@ stub -version=0x600+ RtlLockModuleSection
+@ stdcall -stub -version=0x600+ RtlLockMemoryZone(long)
+@ stdcall -stub -version=0x600+ RtlLockModuleSection(long)
 @ stdcall -stub RtlLogStackBackTrace()
 @ stdcall RtlLookupAtomInAtomTable(ptr wstr ptr)
 @ stdcall RtlLookupElementGenericTable(ptr ptr)
@@ -1042,7 +1046,7 @@
 @ stdcall RtlNewSecurityObjectEx(ptr ptr ptr ptr long long ptr ptr)
 @ stdcall RtlNewSecurityObjectWithMultipleInheritance(ptr ptr ptr ptr long long long ptr ptr)
 @ stdcall RtlNormalizeProcessParams(ptr)
-@ stub -version=0x600+ RtlNormalizeString
+@ stdcall -stub -version=0x600+ RtlNormalizeString(long long long long ptr)
 @ stdcall RtlNtPathNameToDosPathName(long ptr ptr ptr) ; CHECKME (last arg)
 @ stdcall RtlNtStatusToDosError(long)
 @ stdcall RtlNtStatusToDosErrorNoTeb(long)
@@ -1051,35 +1055,35 @@
 @ stdcall RtlNumberGenericTableElementsAvl(ptr)
 @ stdcall RtlNumberOfClearBits(ptr)
 @ stdcall RtlNumberOfSetBits(ptr)
-@ stub -version=0x600+ RtlNumberOfSetBitsUlongPtr
+@ stdcall -stub -version=0x600+ RtlNumberOfSetBitsUlongPtr(long)
 @ stdcall RtlOemStringToUnicodeSize(ptr) RtlxOemStringToUnicodeSize
 @ stdcall RtlOemStringToUnicodeString(ptr ptr long)
 @ stdcall RtlOemToUnicodeN(ptr long ptr ptr long)
 @ stdcall RtlOpenCurrentUser(long ptr)
-@ stub -version=0x600+ RtlOwnerAcesPresent
+@ stdcall -stub -version=0x600+ RtlOwnerAcesPresent(long)
 @ stdcall RtlPcToFileHeader(ptr ptr)
 @ stdcall RtlPinAtomInAtomTable(ptr long)
 @ stdcall RtlPopFrame(ptr)
 @ stdcall RtlPrefixString(ptr ptr long)
 @ stdcall RtlPrefixUnicodeString(ptr ptr long)
-@ stub -version=0x600+ -arch=x86_64 RtlPrepareForProcessCloning
-@ stub -version=0x600+ RtlProcessFlsData
+@ stdcall -stub -version=0x600+ -arch=x86_64 RtlPrepareForProcessCloning()
+@ stdcall -stub -version=0x600+ RtlProcessFlsData(long long)
 @ stdcall RtlProtectHeap(ptr long)
 @ stdcall RtlPushFrame(ptr)
 @ stdcall -version=0x600+ RtlQueryActivationContextApplicationSettings(long ptr wstr wstr ptr ptr ptr)
 @ stdcall RtlQueryAtomInAtomTable(ptr long ptr ptr ptr ptr)
-@ stub -version=0x600+ RtlQueryCriticalSectionOwner
+@ stdcall -stub -version=0x600+ RtlQueryCriticalSectionOwner(ptr)
 @ stdcall RtlQueryDepthSList(ptr)
-@ stub -version=0x600+ RtlQueryDynamicTimeZoneInformation
-@ stub -version=0x600+ RtlQueryElevationFlags
-@ stub -version=0x600+ RtlQueryEnvironmentVariable
+@ stdcall -stub -version=0x600+ RtlQueryDynamicTimeZoneInformation(ptr)
+@ stdcall -stub -version=0x600+ RtlQueryElevationFlags(ptr)
+@ stdcall -stub -version=0x600+ RtlQueryEnvironmentVariable(ptr ptr long ptr long ptr)
 @ stdcall RtlQueryEnvironmentVariable_U(ptr ptr ptr)
 @ stdcall RtlQueryHeapInformation(long long ptr long ptr)
 @ stdcall RtlQueryInformationAcl(ptr ptr long long)
 @ stdcall RtlQueryInformationActivationContext(long long ptr long ptr long ptr)
 @ stdcall RtlQueryInformationActiveActivationContext(long ptr long ptr)
 @ stdcall RtlQueryInterfaceMemoryStream(ptr ptr ptr)
-@ stub -version=0x600+ RtlQueryModuleInformation
+@ stdcall -stub -version=0x600+ RtlQueryModuleInformation(ptr long ptr)
 @ stdcall -stub RtlQueryProcessBackTraceInformation(ptr)
 @ stdcall RtlQueryProcessDebugInformation(long long ptr)
 @ stdcall RtlQueryProcessHeapInformation(ptr)
@@ -1114,13 +1118,13 @@
 @ stdcall -version=0x600+ RtlRemovePrivileges(ptr ptr long)
 @ stdcall RtlRemoveVectoredContinueHandler(ptr)
 @ stdcall RtlRemoveVectoredExceptionHandler(ptr)
-@ stub -version=0x600+ RtlReportException
-@ stub -version=0x600+ RtlResetMemoryBlockLookaside
-@ stub -version=0x600+ RtlResetMemoryZone
+@ stdcall -stub -version=0x600+ RtlReportException(long long long)
+@ stdcall -stub -version=0x600+ RtlResetMemoryBlockLookaside(long)
+@ stdcall -stub -version=0x600+ RtlResetMemoryZone(long)
 @ stdcall RtlResetRtlTranslations(ptr)
 @ stdcall -arch=x86_64 RtlRestoreContext(ptr ptr)
 @ stdcall RtlRestoreLastWin32Error(long) RtlSetLastWin32Error
-@ stub -version=0x600+ RtlRetrieveNtUserPfn
+@ stdcall -stub -version=0x600+ RtlRetrieveNtUserPfn(ptr ptr ptr)
 @ stdcall RtlRevertMemoryStream(ptr)
 @ stdcall RtlRunDecodeUnicodeString(long ptr)
 @ stdcall RtlRunEncodeUnicodeString(long ptr)
@@ -1141,11 +1145,11 @@
 @ stdcall RtlSetCriticalSectionSpinCount(ptr long)
 @ stdcall RtlSetCurrentDirectory_U(ptr)
 @ stdcall RtlSetCurrentEnvironment(wstr ptr)
-@ stub -version=0x600+ RtlSetCurrentTransaction
+@ stdcall -stub -version=0x600+ RtlSetCurrentTransaction(ptr)
 @ stdcall RtlSetDaclSecurityDescriptor(ptr long ptr long)
-@ stub -version=0x600+ RtlSetDynamicTimeZoneInformation
+@ stdcall -stub -version=0x600+ RtlSetDynamicTimeZoneInformation(long)
 @ stdcall RtlSetEnvironmentStrings(wstr long)
-@ stub -version=0x600+ RtlSetEnvironmentVar
+@ stdcall -stub -version=0x600+ RtlSetEnvironmentVar(ptr ptr long ptr long)
 @ stdcall RtlSetEnvironmentVariable(ptr ptr ptr)
 @ stdcall RtlSetGroupSecurityDescriptor(ptr ptr long)
 @ stdcall RtlSetHeapInformation(ptr long ptr ptr)
@@ -1155,7 +1159,7 @@
 @ stdcall RtlSetLastWin32ErrorAndNtStatusFromNtStatus(long)
 @ stdcall RtlSetMemoryStreamSize(ptr int64)
 @ stdcall RtlSetOwnerSecurityDescriptor(ptr ptr long)
-@ stub -version=0x600+ RtlSetProcessDebugInformation
+@ stdcall -stub -version=0x600+ RtlSetProcessDebugInformation(ptr long ptr)
 @ cdecl RtlSetProcessIsCritical(long ptr long)
 @ stdcall RtlSetSaclSecurityDescriptor(ptr long ptr long)
 @ stdcall RtlSetSecurityDescriptorRMControl(ptr ptr)
@@ -1164,18 +1168,18 @@
 @ stdcall RtlSetThreadErrorMode(long ptr)
 @ cdecl RtlSetThreadIsCritical(long ptr long)
 @ stdcall RtlSetThreadPoolStartFunc(ptr ptr)
-@ stub -version=0x600+ RtlSetThreadPreferredUILanguages
+@ stdcall -stub -version=0x600+ RtlSetThreadPreferredUILanguages(long ptr ptr)
 @ stdcall RtlSetTimeZoneInformation(ptr)
 @ stdcall RtlSetTimer(ptr ptr ptr ptr long long long)
 @ stdcall RtlSetUnhandledExceptionFilter(ptr)
 @ stdcall -stub -version=0x502 RtlSetUnicodeCallouts(ptr)
 @ stdcall RtlSetUserFlagsHeap(ptr long ptr long long)
 @ stdcall RtlSetUserValueHeap(ptr long ptr ptr)
-@ stub -version=0x600+ RtlSidDominates
-@ stub -version=0x600+ RtlSidEqualLevel
-@ stub -version=0x600+ RtlSidHashInitialize
-@ stub -version=0x600+ RtlSidHashLookup
-@ stub -version=0x600+ RtlSidIsHigherLevel
+@ stdcall -stub -version=0x600+ RtlSidDominates(long long ptr)
+@ stdcall -stub -version=0x600+ RtlSidEqualLevel(long long ptr)
+@ stdcall -stub -version=0x600+ RtlSidHashInitialize(ptr long ptr)
+@ stdcall -stub -version=0x600+ RtlSidHashLookup(long ptr)
+@ stdcall -stub -version=0x600+ RtlSidIsHigherLevel(long long ptr)
 @ stdcall RtlSizeHeap(long long ptr)
 @ stdcall -version=0x600+ RtlSleepConditionVariableCS(ptr ptr ptr)
 @ stdcall -version=0x600+ RtlSleepConditionVariableSRW(ptr ptr ptr long)
@@ -1202,7 +1206,9 @@
 @ stdcall RtlTraceDatabaseLock(ptr)
 @ stdcall RtlTraceDatabaseUnlock(ptr)
 @ stdcall RtlTraceDatabaseValidate(ptr)
-@ stub -version=0x600+ RtlTryAcquirePebLock
+@ stdcall -stub -version=0x600+ RtlTryAcquirePebLock()
+@ stdcall -version=0x601 RtlTryAcquireSRWLockExclusive(ptr)
+@ stdcall -version=0x601 RtlTryAcquireSRWLockShared(ptr)
 @ stdcall RtlTryEnterCriticalSection(ptr)
 @ stdcall RtlUnhandledExceptionFilter2(ptr long)
 @ stdcall RtlUnhandledExceptionFilter(ptr)
@@ -1218,12 +1224,12 @@
 @ stdcall RtlUnicodeToOemN(ptr long ptr ptr long)
 @ stdcall RtlUniform(ptr)
 @ stdcall RtlUnlockBootStatusData(ptr)
-@ stub -version=0x600+ RtlUnlockCurrentThread
+@ stdcall -stub -version=0x600+ RtlUnlockCurrentThread()
 @ stdcall RtlUnlockHeap(long)
-@ stub -version=0x600+ RtlUnlockMemoryBlockLookaside
+@ stdcall -stub -version=0x600+ RtlUnlockMemoryBlockLookaside(long)
 @ stdcall RtlUnlockMemoryStreamRegion(ptr int64 int64 long)
-@ stub -version=0x600+ RtlUnlockMemoryZone
-@ stub -version=0x600+ RtlUnlockModuleSection
+@ stdcall -stub -version=0x600+ RtlUnlockMemoryZone(long)
+@ stdcall -stub -version=0x600+ RtlUnlockModuleSection(long)
 @ stdcall -register RtlUnwind(ptr ptr ptr ptr)
 @ stdcall -arch=x86_64 RtlUnwindEx(long long ptr long ptr)
 @ stdcall RtlUpcaseUnicodeChar(long)
@@ -1234,13 +1240,13 @@
 @ stdcall RtlUpcaseUnicodeToCustomCPN(ptr ptr long ptr wstr long)
 @ stdcall RtlUpcaseUnicodeToMultiByteN(ptr long ptr ptr long)
 @ stdcall RtlUpcaseUnicodeToOemN(ptr long ptr ptr long)
-@ stub -version=0x600+ RtlUpdateClonedCriticalSection
-@ stub -version=0x600+ RtlUpdateClonedSRWLock
+@ stdcall -stub -version=0x600+ RtlUpdateClonedCriticalSection(long)
+@ stdcall -stub -version=0x600+ RtlUpdateClonedSRWLock(ptr long)
 @ stdcall RtlUpdateTimer(ptr ptr long long)
 @ stdcall RtlUpperChar(long)
 @ stdcall RtlUpperString(ptr ptr)
 @ stdcall -version=0x502 RtlUsageHeap(ptr long ptr)
-@ stub -version=0x600+ RtlUserThreadStart
+@ stdcall -stub -version=0x600+ RtlUserThreadStart(long long)
 @ stdcall RtlValidAcl(ptr)
 @ stdcall RtlValidRelativeSecurityDescriptor(ptr long long)
 @ stdcall RtlValidSecurityDescriptor(ptr)
@@ -1254,38 +1260,38 @@
 @ stdcall -version=0x600+ RtlWakeConditionVariable(ptr)
 @ stdcall RtlWalkFrameChain(ptr long long)
 @ stdcall RtlWalkHeap(long ptr)
-@ stub -version=0x600+ RtlWerpReportException
-@ stub -version=0x600+ RtlWow64CallFunction64
+@ stdcall -stub -version=0x600+ RtlWerpReportException(long long ptr long long ptr)
+@ stdcall -stub -version=0x600+ RtlWow64CallFunction64()
 @ stdcall RtlWow64EnableFsRedirection(long)
 @ stdcall RtlWow64EnableFsRedirectionEx(long ptr)
-@ stub -version=0x600+ -arch=x86_64 RtlWow64GetThreadContext
-@ stub -version=0x600+ -arch=x86_64 RtlWow64LogMessageInEventLogger
-@ stub -version=0x600+ -arch=x86_64 RtlWow64SetThreadContext
-@ stub -version=0x600+ -arch=x86_64 RtlWow64SuspendThread
+@ stdcall -stub -version=0x600+ -arch=x86_64 RtlWow64GetThreadContext(ptr ptr)
+@ stdcall -stub -version=0x600+ -arch=x86_64 RtlWow64LogMessageInEventLogger(long long long)
+@ stdcall -stub -version=0x600+ -arch=x86_64 RtlWow64SetThreadContext(long long)
+@ stdcall -stub -version=0x600+ -arch=x86_64 RtlWow64SuspendThread(long long)
 @ stdcall RtlWriteMemoryStream(ptr ptr long ptr)
 @ stdcall RtlWriteRegistryValue(long ptr ptr long ptr long)
 @ stdcall RtlZeroHeap(ptr long)
 @ stdcall RtlZeroMemory(ptr long)
 @ stdcall RtlZombifyActivationContext(ptr)
 @ stdcall RtlpApplyLengthFunction(long long ptr ptr)
-@ stub -version=0x600+ RtlpCheckDynamicTimeZoneInformation
-@ stub -version=0x600+ RtlpCleanupRegistryKeys
-@ stub -version=0x600+ RtlpConvertCultureNamesToLCIDs
-@ stub -version=0x600+ RtlpConvertLCIDsToCultureNames
-@ stub -version=0x600+ RtlpCreateProcessRegistryInfo
+@ stdcall -stub -version=0x600+ RtlpCheckDynamicTimeZoneInformation(ptr long)
+@ stdcall -stub -version=0x600+ RtlpCleanupRegistryKeys()
+@ stdcall -stub -version=0x600+ RtlpConvertCultureNamesToLCIDs(wstr ptr)
+@ stdcall -stub -version=0x600+ RtlpConvertLCIDsToCultureNames(wstr ptr)
+@ stdcall -stub -version=0x600+ RtlpCreateProcessRegistryInfo(ptr)
 @ stdcall RtlpEnsureBufferSize(long ptr long)
-@ stub -version=0x600+ RtlpGetLCIDFromLangInfoNode
-@ stub -version=0x600+ RtlpGetNameFromLangInfoNode
-@ stub -version=0x600+ RtlpGetSystemDefaultUILanguage
-@ stub -version=0x600+ RtlpGetUserOrMachineUILanguage4NLS
-@ stub -version=0x600+ RtlpInitializeLangRegistryInfo
-@ stub -version=0x600+ RtlpIsQualifiedLanguage
-@ stub -version=0x600+ RtlpLoadMachineUIByPolicy
-@ stub -version=0x600+ RtlpLoadUserUIByPolicy
-@ stub -version=0x600+ RtlpMuiFreeLangRegistryInfo
-@ stub -version=0x600+ RtlpMuiRegCreateRegistryInfo
-@ stub -version=0x600+ RtlpMuiRegFreeRegistryInfo
-@ stub -version=0x600+ RtlpMuiRegLoadRegistryInfo
+@ stdcall -stub -version=0x600+ RtlpGetLCIDFromLangInfoNode(long long ptr)
+@ stdcall -stub -version=0x600+ RtlpGetNameFromLangInfoNode(long long long)
+@ stdcall -stub -version=0x600+ RtlpGetSystemDefaultUILanguage(ptr long)
+@ stdcall -stub -version=0x600+ RtlpGetUserOrMachineUILanguage4NLS(long long ptr)
+@ stdcall -stub -version=0x600+ RtlpInitializeLangRegistryInfo(ptr)
+@ stdcall -stub -version=0x600+ RtlpIsQualifiedLanguage(long ptr long)
+@ stdcall -stub -version=0x600+ RtlpLoadMachineUIByPolicy(ptr long ptr)
+@ stdcall -stub -version=0x600+ RtlpLoadUserUIByPolicy(ptr long ptr)
+@ stdcall -stub -version=0x600+ RtlpMuiFreeLangRegistryInfo(long)
+@ stdcall -stub -version=0x600+ RtlpMuiRegCreateRegistryInfo()
+@ stdcall -stub -version=0x600+ RtlpMuiRegFreeRegistryInfo(long long)
+@ stdcall -stub -version=0x600+ RtlpMuiRegLoadRegistryInfo(long long)
 @ stdcall RtlpNotOwnerCriticalSection(ptr)
 @ stdcall RtlpNtCreateKey(ptr long ptr long ptr ptr)
 @ stdcall RtlpNtEnumerateSubKey(ptr ptr long long)
@@ -1293,24 +1299,24 @@
 @ stdcall RtlpNtOpenKey(ptr long ptr long)
 @ stdcall RtlpNtQueryValueKey(ptr ptr ptr ptr long)
 @ stdcall RtlpNtSetValueKey(ptr long ptr long)
-@ stub -version=0x600+ RtlpQueryDefaultUILanguage
-@ stub -version=0x600+ -arch=x86_64 RtlpQueryProcessDebugInformationFromWow64
-@ stub -version=0x600+ RtlpRefreshCachedUILanguage
-@ stub -version=0x600+ RtlpSetInstallLanguage
-@ stub -version=0x600+ RtlpSetPreferredUILanguages
-@ stub -version=0x600+ RtlpSetUserPreferredUILanguages
+@ stdcall -stub -version=0x600+ RtlpQueryDefaultUILanguage(ptr long)
+@ stdcall -stub -version=0x600+ -arch=x86_64 RtlpQueryProcessDebugInformationFromWow64(long ptr)
+@ stdcall -stub -version=0x600+ RtlpRefreshCachedUILanguage(wstr long)
+@ stdcall -stub -version=0x600+ RtlpSetInstallLanguage(long ptr)
+@ stdcall -stub -version=0x600+ RtlpSetPreferredUILanguages(long ptr ptr) ; x64 only?
+@ stdcall -stub -arch=i386 -version=0x600+ RtlpSetUserPreferredUILanguages(long ptr ptr) ; seems to be i386 only
 @ stdcall RtlpUnWaitCriticalSection(ptr)
-@ stub -version=0x600+ RtlpVerifyAndCommitUILanguageSettings
+@ stdcall -stub -version=0x600+ RtlpVerifyAndCommitUILanguageSettings(long)
 @ stdcall RtlpWaitForCriticalSection(ptr)
 @ stdcall RtlxAnsiStringToUnicodeSize(ptr)
 @ stdcall RtlxOemStringToUnicodeSize(ptr)
 @ stdcall RtlxUnicodeStringToAnsiSize(ptr)
 @ stdcall RtlxUnicodeStringToOemSize(ptr)
-@ stub -version=0x600+ ShipAssert
-@ stub -version=0x600+ ShipAssertGetBufferInfo
-@ stub -version=0x600+ ShipAssertMsgA
-@ stub -version=0x600+ ShipAssertMsgW
-@ stub -version=0x600+ TpAllocAlpcCompletion
+@ stdcall -stub -version=0x600+ ShipAssert(long long)
+@ stdcall -stub -version=0x600+ ShipAssertGetBufferInfo(ptr ptr)
+@ stdcall -stub -version=0x600+ ShipAssertMsgA(long long)
+@ stdcall -stub -version=0x600+ ShipAssertMsgW(long long)
+@ stdcall -stub -version=0x600+ TpAllocAlpcCompletion(ptr ptr ptr ptr ptr)
 @ stdcall -version=0x600+ TpAllocCleanupGroup(ptr)
 @ stdcall -version=0x600+ TpAllocIoCompletion(ptr ptr ptr ptr ptr)
 @ stdcall -version=0x600+ TpAllocPool(ptr ptr)
@@ -1324,15 +1330,15 @@
 @ stdcall -version=0x600+ TpCallbackSetEventOnCompletion(ptr ptr)
 @ stdcall -version=0x600+ TpCallbackUnloadDllOnCompletion(ptr ptr)
 @ stdcall -version=0x600+ TpCancelAsyncIoOperation(ptr)
-@ stub -version=0x600+ TpCaptureCaller
-@ stub -version=0x600+ TpCheckTerminateWorker
-@ stub -version=0x600+ TpDbgDumpHeapUsage
-@ stub -version=0x600+ TpDbgSetLogRoutine
+@ stdcall -stub -version=0x600+ TpCaptureCaller(long)
+@ stdcall -stub -version=0x600+ TpCheckTerminateWorker(ptr)
+@ stdcall -stub -version=0x600+ TpDbgDumpHeapUsage(long ptr long)
+@ stdcall -stub -version=0x600+ TpDbgSetLogRoutine()
 @ stdcall -version=0x600+ TpDisassociateCallback(ptr)
 @ stdcall -version=0x600+ TpIsTimerSet(ptr)
 @ stdcall -version=0x600+ TpPostWork(ptr)
 @ stdcall -version=0x600+ TpQueryPoolStackInformation(ptr ptr)
-@ stub -version=0x600+ TpReleaseAlpcCompletion
+@ stdcall -stub -version=0x600+ TpReleaseAlpcCompletion(ptr)
 @ stdcall -version=0x600+ TpReleaseCleanupGroup(ptr)
 @ stdcall -version=0x600+ TpReleaseCleanupGroupMembers(ptr long ptr)
 @ stdcall -version=0x600+ TpReleaseIoCompletion(ptr)
@@ -1347,22 +1353,22 @@
 @ stdcall -version=0x600+ TpSetWait(ptr long ptr)
 @ stdcall -version=0x600+ TpSimpleTryPost(ptr ptr ptr)
 @ stdcall -version=0x600+ TpStartAsyncIoOperation(ptr)
-@ stub -version=0x600+ TpWaitForAlpcCompletion
+@ stdcall -stub -version=0x600+ TpWaitForAlpcCompletion(ptr)
 @ stdcall -version=0x600+ TpWaitForIoCompletion(ptr long)
 @ stdcall -version=0x600+ TpWaitForTimer(ptr long)
 @ stdcall -version=0x600+ TpWaitForWait(ptr long)
 @ stdcall -version=0x600+ TpWaitForWork(ptr long)
 @ stdcall -ret64 VerSetConditionMask(double long long)
-@ stub -version=0x600+ WerCheckEventEscalation
-@ stub -version=0x600+ WerReportSQMEvent
-@ stub -version=0x600+ WerReportWatsonEvent
-@ stub -version=0x600+ WinSqmAddToStream
-@ stub -version=0x600+ WinSqmEndSession
-@ stub -version=0x600+ WinSqmEventEnabled
-@ stub -version=0x600+ WinSqmEventWrite
-@ stub -version=0x600+ WinSqmIsOptedIn
-@ stub -version=0x600+ WinSqmSetString
-@ stub -version=0x600+ WinSqmStartSession
+@ stdcall -stub -version=0x600+ WerCheckEventEscalation(long ptr) ; doesn't exist in win11
+@ stdcall -stub -version=0x600+ WerReportSQMEvent(long long long)
+@ stdcall -stub -version=0x600+ WerReportWatsonEvent(long long long long) ; doesn't exist in win11
+@ stdcall -stub -version=0x600+ WinSqmAddToStream(ptr long long long) ; stub on Win11?
+@ stdcall -stub -version=0x600+ WinSqmEndSession(ptr) ; stub on Win11?
+@ stdcall -stub -version=0x600+ WinSqmEventEnabled(long ptr) ; stub on Win11?
+@ stdcall -stub -version=0x600+ WinSqmEventWrite(long long long) ; stub on Win11?
+@ stdcall -stub -version=0x600+ WinSqmIsOptedIn() ; stub on Win11?
+@ stdcall -stub -version=0x600+ WinSqmSetString(ptr long ptr) ; stub on Win11?
+@ stdcall -stub -version=0x600+ WinSqmStartSession(ptr) ; stub on Win11?
 @ stdcall ZwAcceptConnectPort(ptr long ptr long long ptr)
 @ stdcall ZwAccessCheck(ptr long long ptr ptr ptr ptr ptr)
 @ stdcall ZwAccessCheckAndAuditAlarm(ptr long ptr ptr ptr long ptr long ptr ptr ptr)
@@ -1410,15 +1416,15 @@
 @ stdcall ZwCallbackReturn(ptr long long)
 @ stdcall ZwCancelDeviceWakeupRequest(ptr)
 @ stdcall ZwCancelIoFile(long ptr)
-@ stub -version=0x600+ ZwCancelIoFileEx
-@ stub -version=0x600+ ZwCancelSynchronousIoFile
+@ stdcall -stub -version=0x600+ ZwCancelIoFileEx(ptr ptr ptr)
+@ stdcall -stub -version=0x600+ ZwCancelSynchronousIoFile(ptr ptr ptr)
 @ stdcall ZwCancelTimer(long ptr)
 @ stdcall ZwClearEvent(long)
 @ stdcall ZwClose(long)
 @ stdcall ZwCloseObjectAuditAlarm(ptr ptr long)
-@ stub -version=0x600+ ZwCommitComplete
-@ stub -version=0x600+ ZwCommitEnlistment
-@ stub -version=0x600+ ZwCommitTransaction
+@ stdcall -stub -version=0x600+ ZwCommitComplete(ptr ptr)
+@ stdcall -stub -version=0x600+ ZwCommitEnlistment(ptr ptr)
+@ stdcall -stub -version=0x600+ ZwCommitTransaction(ptr long)
 @ stdcall ZwCompactKeys(long ptr)
 @ stdcall ZwCompareTokens(ptr ptr ptr)
 @ stdcall ZwCompleteConnectPort(ptr)
@@ -1427,7 +1433,7 @@
 @ stdcall ZwContinue(ptr long)
 @ stdcall ZwCreateDebugObject(ptr long ptr long)
 @ stdcall ZwCreateDirectoryObject(long long long)
-@ stub -version=0x600+ ZwCreateEnlistment
+@ stdcall -stub -version=0x600+ ZwCreateEnlistment(ptr long ptr ptr ptr long long ptr)
 @ stdcall ZwCreateEvent(long long long long long)
 @ stdcall ZwCreateEventPair(ptr long ptr)
 @ stdcall ZwCreateFile(ptr long ptr ptr long long long ptr long long ptr)
@@ -1435,7 +1441,7 @@
 @ stdcall ZwCreateJobObject(ptr long ptr)
 @ stdcall ZwCreateJobSet(long ptr long)
 @ stdcall ZwCreateKey(ptr long ptr long ptr long long)
-@ stub -version=0x600+ ZwCreateKeyTransacted
+@ stdcall -stub -version=0x600+ ZwCreateKeyTransacted(ptr long ptr long ptr long ptr ptr)
 @ stdcall ZwCreateKeyedEvent(ptr long ptr long)
 @ stdcall ZwCreateMailslotFile(long long long long long long long long)
 @ stdcall ZwCreateMutant(ptr long ptr long)
@@ -1445,19 +1451,19 @@
 @ stdcall ZwCreateProcess(ptr long ptr ptr long ptr ptr ptr)
 @ stdcall ZwCreateProcessEx(ptr long ptr ptr long ptr ptr ptr long)
 @ stdcall ZwCreateProfile(ptr ptr ptr long long ptr long long long) ; CHECKME
-@ stub -version=0x600+ ZwCreateResourceManager
+@ stdcall -stub -version=0x600+ ZwCreateResourceManager(ptr long ptr ptr ptr long wstr)
 @ stdcall ZwCreateSection(ptr long ptr ptr long long long)
 @ stdcall ZwCreateSemaphore(ptr long ptr long long)
 @ stdcall ZwCreateSymbolicLinkObject(ptr long ptr ptr)
 @ stdcall ZwCreateThread(ptr long ptr ptr ptr ptr ptr long)
-@ stub -version=0x600+ ZwCreateThreadEx
+@ stdcall -stub -version=0x600+ ZwCreateThreadEx(ptr long ptr ptr ptr ptr long long long long ptr)
 @ stdcall ZwCreateTimer(ptr long ptr long)
 @ stdcall ZwCreateToken(ptr long ptr long ptr ptr ptr ptr ptr ptr ptr ptr ptr)
-@ stub -version=0x600+ ZwCreateTransaction
-@ stub -version=0x600+ ZwCreateTransactionManager
-@ stub -version=0x600+ ZwCreateUserProcess
+@ stdcall -stub -version=0x600+ ZwCreateTransaction(ptr long ptr ptr ptr long long long ptr wstr)
+@ stdcall -stub -version=0x600+ ZwCreateTransactionManager(ptr long ptr ptr long long)
+@ stdcall -stub -version=0x600+ ZwCreateUserProcess(ptr ptr long long ptr ptr long long ptr ptr ptr)
 @ stdcall ZwCreateWaitablePort(ptr ptr long long long)
-@ stub -version=0x600+ ZwCreateWorkerFactory
+@ stdcall -stub -version=0x600+ ZwCreateWorkerFactory(ptr long ptr ptr ptr ptr ptr long long long)
 @ stdcall ZwDebugActiveProcess(ptr ptr)
 @ stdcall ZwDebugContinue(ptr ptr long)
 @ stdcall ZwDelayExecution(long ptr)
@@ -1467,7 +1473,7 @@
 @ stdcall ZwDeleteFile(ptr)
 @ stdcall ZwDeleteKey(long)
 @ stdcall ZwDeleteObjectAuditAlarm(ptr ptr long)
-@ stub -version=0x600+ ZwDeletePrivateNamespace
+@ stdcall -stub -version=0x600+ ZwDeletePrivateNamespace(ptr)
 @ stdcall ZwDeleteValueKey(long ptr)
 @ stdcall ZwDeviceIoControlFile(long long long long long long long long long long)
 @ stdcall ZwDisplayString(ptr)
@@ -1477,42 +1483,42 @@
 @ stdcall ZwEnumerateDriverEntries(ptr ptr)
 @ stdcall ZwEnumerateKey(long long long ptr long ptr)
 @ stdcall ZwEnumerateSystemEnvironmentValuesEx(long ptr long)
-@ stub -version=0x600+ ZwEnumerateTransactionObject
+@ stdcall -stub -version=0x600+ ZwEnumerateTransactionObject(ptr long ptr long ptr)
 @ stdcall ZwEnumerateValueKey(long long long ptr long ptr)
 @ stdcall ZwExtendSection(ptr ptr)
 @ stdcall ZwFilterToken(ptr long ptr ptr ptr ptr)
 @ stdcall ZwFindAtom(ptr long ptr)
 @ stdcall ZwFlushBuffersFile(long ptr)
-@ stub -version=0x600+ ZwFlushInstallUILanguage
+@ stdcall -stub -version=0x600+ ZwFlushInstallUILanguage(long long)
 @ stdcall ZwFlushInstructionCache(long ptr long)
 @ stdcall ZwFlushKey(long)
-@ stub -version=0x600+ ZwFlushProcessWriteBuffers
+@ stdcall -stub -version=0x600+ ZwFlushProcessWriteBuffers()
 @ stdcall ZwFlushVirtualMemory(long ptr ptr long)
 @ stdcall ZwFlushWriteBuffer()
 @ stdcall ZwFreeUserPhysicalPages(ptr ptr ptr)
 @ stdcall ZwFreeVirtualMemory(long ptr ptr long)
-@ stub -version=0x600+ ZwFreezeRegistry
-@ stub -version=0x600+ ZwFreezeTransactions
+@ stdcall -stub -version=0x600+ ZwFreezeRegistry(long)
+@ stdcall -stub -version=0x600+ ZwFreezeTransactions(ptr ptr)
 @ stdcall ZwFsControlFile(long long long long long long long long long long)
 @ stdcall ZwGetContextThread(long ptr)
 @ stdcall ZwGetCurrentProcessorNumber()
 @ stdcall ZwGetDevicePowerState(ptr ptr)
-@ stub -version=0x600+ ZwGetMUIRegistryInfo
-@ stub -version=0x600+ ZwGetNextProcess
-@ stub -version=0x600+ ZwGetNextThread
-@ stub -version=0x600+ ZwGetNlsSectionPtr
-@ stub -version=0x600+ ZwGetNotificationResourceManager
+@ stdcall -stub -version=0x600+ ZwGetMUIRegistryInfo(long ptr ptr)
+@ stdcall -stub -version=0x600+ ZwGetNextProcess(ptr long long long ptr)
+@ stdcall -stub -version=0x600+ ZwGetNextThread(ptr ptr long long long ptr)
+@ stdcall -stub -version=0x600+ ZwGetNlsSectionPtr(long long ptr ptr ptr)
+@ stdcall -stub -version=0x600+ ZwGetNotificationResourceManager(ptr ptr long ptr ptr long ptr)
 @ stdcall ZwGetPlugPlayEvent(long long ptr long)
 @ stdcall ZwGetWriteWatch(long long ptr long ptr ptr ptr)
 @ stdcall ZwImpersonateAnonymousToken(ptr)
 @ stdcall ZwImpersonateClientOfPort(ptr ptr)
 @ stdcall ZwImpersonateThread(ptr ptr ptr)
-@ stub -version=0x600+ ZwInitializeNlsFiles
+@ stdcall -stub -version=0x600+ ZwInitializeNlsFiles(ptr ptr ptr ptr)
 @ stdcall ZwInitializeRegistry(long)
 @ stdcall ZwInitiatePowerAction(long long long long)
 @ stdcall ZwIsProcessInJob(long long)
 @ stdcall ZwIsSystemResumeAutomatic()
-@ stub -version=0x600+ ZwIsUILanguageComitted
+@ stdcall -stub -version=0x600+ ZwIsUILanguageComitted()
 @ stdcall ZwListenPort(ptr ptr)
 @ stdcall ZwLoadDriver(ptr)
 @ stdcall ZwLoadKey2(ptr ptr long)
@@ -1524,7 +1530,7 @@
 @ stdcall ZwLockVirtualMemory(long ptr ptr long)
 @ stdcall ZwMakePermanentObject(ptr)
 @ stdcall ZwMakeTemporaryObject(long)
-@ stub -version=0x600+ ZwMapCMFModule
+@ stdcall -stub -version=0x600+ ZwMapCMFModule(long long ptr ptr ptr)
 @ stdcall ZwMapUserPhysicalPages(ptr ptr ptr)
 @ stdcall ZwMapUserPhysicalPagesScatter(ptr ptr ptr)
 @ stdcall ZwMapViewOfSection(long long ptr long long ptr ptr long long long)
@@ -1534,43 +1540,43 @@
 @ stdcall ZwNotifyChangeKey(long long ptr ptr ptr long long ptr long long)
 @ stdcall ZwNotifyChangeMultipleKeys(ptr long ptr ptr ptr ptr ptr long long ptr long long)
 @ stdcall ZwOpenDirectoryObject(long long long)
-@ stub -version=0x600+ ZwOpenEnlistment
+@ stdcall -stub -version=0x600+ ZwOpenEnlistment(ptr long ptr ptr ptr)
 @ stdcall ZwOpenEvent(long long long)
 @ stdcall ZwOpenEventPair(ptr long ptr)
 @ stdcall ZwOpenFile(ptr long ptr ptr long long)
 @ stdcall ZwOpenIoCompletion(ptr long ptr)
 @ stdcall ZwOpenJobObject(ptr long ptr)
 @ stdcall ZwOpenKey(ptr long ptr)
-@ stub -version=0x600+ ZwOpenKeyTransacted
+@ stdcall -stub -version=0x600+ ZwOpenKeyTransacted(ptr long ptr ptr)
 @ stdcall ZwOpenKeyedEvent(ptr long ptr)
 @ stdcall ZwOpenMutant(ptr long ptr)
 @ stdcall ZwOpenObjectAuditAlarm(ptr ptr ptr ptr ptr ptr long long ptr long long ptr)
-@ stub -version=0x600+ ZwOpenPrivateNamespace
+@ stdcall -stub -version=0x600+ ZwOpenPrivateNamespace(ptr long ptr ptr)
 @ stdcall ZwOpenProcess(ptr long ptr ptr)
 @ stdcall ZwOpenProcessToken(long long ptr)
 @ stdcall ZwOpenProcessTokenEx(long long long ptr)
-@ stub -version=0x600+ ZwOpenResourceManager
+@ stdcall -stub -version=0x600+ ZwOpenResourceManager(ptr long ptr ptr ptr)
 @ stdcall ZwOpenSection(ptr long ptr)
 @ stdcall ZwOpenSemaphore(long long ptr)
-@ stub -version=0x600+ ZwOpenSession
+@ stdcall -stub -version=0x600+ ZwOpenSession(ptr long ptr)
 @ stdcall ZwOpenSymbolicLinkObject (ptr long ptr)
 @ stdcall ZwOpenThread(ptr long ptr ptr)
 @ stdcall ZwOpenThreadToken(long long long ptr)
 @ stdcall ZwOpenThreadTokenEx(long long long long ptr)
 @ stdcall ZwOpenTimer(ptr long ptr)
-@ stub -version=0x600+ ZwOpenTransaction
-@ stub -version=0x600+ ZwOpenTransactionManager
+@ stdcall -stub -version=0x600+ ZwOpenTransaction(ptr long ptr ptr ptr)
+@ stdcall -stub -version=0x600+ ZwOpenTransactionManager(ptr long ptr wstr ptr long)
 @ stdcall ZwPlugPlayControl(ptr ptr long)
 @ stdcall ZwPowerInformation(long ptr long ptr long)
-@ stub -version=0x600+ ZwPrePrepareComplete
-@ stub -version=0x600+ ZwPrePrepareEnlistment
-@ stub -version=0x600+ ZwPrepareComplete
-@ stub -version=0x600+ ZwPrepareEnlistment
+@ stdcall -stub -version=0x600+ ZwPrePrepareComplete(ptr ptr)
+@ stdcall -stub -version=0x600+ ZwPrePrepareEnlistment(ptr ptr)
+@ stdcall -stub -version=0x600+ ZwPrepareComplete(ptr ptr)
+@ stdcall -stub -version=0x600+ ZwPrepareEnlistment(ptr ptr)
 @ stdcall ZwPrivilegeCheck(ptr ptr ptr)
 @ stdcall ZwPrivilegeObjectAuditAlarm(ptr ptr ptr long ptr long)
 @ stdcall ZwPrivilegedServiceAuditAlarm(ptr ptr ptr ptr long)
-@ stub -version=0x600+ ZwPropagationComplete
-@ stub -version=0x600+ ZwPropagationFailed
+@ stdcall -stub -version=0x600+ ZwPropagationComplete(ptr long long ptr)
+@ stdcall -stub -version=0x600+ ZwPropagationFailed(ptr long long)
 @ stdcall ZwProtectVirtualMemory(long ptr ptr long ptr)
 @ stdcall ZwPulseEvent(long ptr)
 @ stdcall ZwQueryAttributesFile(ptr ptr)
@@ -1586,22 +1592,22 @@
 @ stdcall ZwQueryEvent(long long ptr long ptr)
 @ stdcall ZwQueryFullAttributesFile(ptr ptr)
 @ stdcall ZwQueryInformationAtom(long long ptr long ptr)
-@ stub -version=0x600+ ZwQueryInformationEnlistment
+@ stdcall -stub -version=0x600+ ZwQueryInformationEnlistment(ptr long ptr long ptr)
 @ stdcall ZwQueryInformationFile(long ptr ptr long long)
 @ stdcall ZwQueryInformationJobObject(long long ptr long ptr)
 @ stdcall ZwQueryInformationPort(ptr long ptr long ptr)
 @ stdcall ZwQueryInformationProcess(long long ptr long ptr)
-@ stub -version=0x600+ ZwQueryInformationResourceManager
+@ stdcall -stub -version=0x600+ ZwQueryInformationResourceManager(ptr long ptr long ptr)
 @ stdcall ZwQueryInformationThread(long long ptr long ptr)
 @ stdcall ZwQueryInformationToken(long long ptr long ptr)
-@ stub -version=0x600+ ZwQueryInformationTransaction
-@ stub -version=0x600+ ZwQueryInformationTransactionManager
-@ stub -version=0x600+ ZwQueryInformationWorkerFactory
+@ stdcall -stub -version=0x600+ ZwQueryInformationTransaction(ptr long ptr long ptr)
+@ stdcall -stub -version=0x600+ ZwQueryInformationTransactionManager(ptr)
+@ stdcall -stub -version=0x600+ ZwQueryInformationWorkerFactory(ptr long ptr long ptr)
 @ stdcall ZwQueryInstallUILanguage(ptr)
 @ stdcall ZwQueryIntervalProfile(long ptr)
 @ stdcall ZwQueryIoCompletion(long long ptr long ptr)
 @ stdcall ZwQueryKey(long long ptr long ptr)
-@ stub -version=0x600+ ZwQueryLicenseValue
+@ stdcall -stub -version=0x600+ ZwQueryLicenseValue(ptr ptr ptr long ptr)
 @ stdcall ZwQueryMultipleValueKey(long ptr long ptr long ptr)
 @ stdcall ZwQueryMutant(long long ptr long ptr)
 @ stdcall ZwQueryObject(long long long long long)
@@ -1628,26 +1634,26 @@
 @ stdcall ZwRaiseHardError(long long long ptr long ptr)
 @ stdcall ZwReadFile(long long ptr ptr ptr ptr long ptr ptr)
 @ stdcall ZwReadFileScatter(long long ptr ptr ptr ptr long ptr ptr)
-@ stub -version=0x600+ ZwReadOnlyEnlistment
+@ stdcall -stub -version=0x600+ ZwReadOnlyEnlistment(ptr ptr)
 @ stdcall ZwReadRequestData(ptr ptr long ptr long ptr)
 @ stdcall ZwReadVirtualMemory(long ptr ptr long ptr)
-@ stub -version=0x600+ ZwRecoverEnlistment
-@ stub -version=0x600+ ZwRecoverResourceManager
-@ stub -version=0x600+ ZwRecoverTransactionManager
-@ stub -version=0x600+ ZwRegisterProtocolAddressInformation
+@ stdcall -stub -version=0x600+ ZwRecoverEnlistment(ptr ptr)
+@ stdcall -stub -version=0x600+ ZwRecoverResourceManager(ptr)
+@ stdcall -stub -version=0x600+ ZwRecoverTransactionManager(ptr)
+@ stdcall -stub -version=0x600+ ZwRegisterProtocolAddressInformation(ptr ptr long ptr long)
 @ stdcall ZwRegisterThreadTerminatePort(ptr)
-@ stub -version=0x600+ ZwReleaseCMFViewOwnership
+@ stdcall -stub -version=0x600+ ZwReleaseCMFViewOwnership()
 @ stdcall ZwReleaseKeyedEvent(ptr ptr long ptr)
 @ stdcall ZwReleaseMutant(long ptr)
 @ stdcall ZwReleaseSemaphore(long long ptr)
-@ stub -version=0x600+ ZwReleaseWorkerFactoryWorker
+@ stdcall -stub -version=0x600+ ZwReleaseWorkerFactoryWorker(ptr)
 @ stdcall ZwRemoveIoCompletion(ptr ptr ptr ptr ptr)
-@ stub -version=0x600+ ZwRemoveIoCompletionEx
+@ stdcall -stub -version=0x600+ ZwRemoveIoCompletionEx(ptr ptr long ptr ptr long)
 @ stdcall ZwRemoveProcessDebug(ptr ptr)
 @ stdcall ZwRenameKey(ptr ptr)
-@ stub -version=0x600+ ZwRenameTransactionManager
+@ stdcall -stub -version=0x600+ ZwRenameTransactionManager(wstr ptr)
 @ stdcall ZwReplaceKey(ptr long ptr)
-@ stub -version=0x600+ ZwReplacePartitionUnit
+@ stdcall -stub -version=0x600+ ZwReplacePartitionUnit(wstr wstr long)
 @ stdcall ZwReplyPort(ptr ptr)
 @ stdcall ZwReplyWaitReceivePort(ptr ptr ptr ptr)
 @ stdcall ZwReplyWaitReceivePortEx(ptr ptr ptr ptr ptr)
@@ -1661,10 +1667,10 @@
 @ stdcall ZwRestoreKey(long long long)
 @ stdcall ZwResumeProcess(ptr)
 @ stdcall ZwResumeThread(long long)
-@ stub -version=0x600+ ZwRollbackComplete
-@ stub -version=0x600+ ZwRollbackEnlistment
-@ stub -version=0x600+ ZwRollbackTransaction
-@ stub -version=0x600+ ZwRollforwardTransactionManager
+@ stdcall -stub -version=0x600+ ZwRollbackComplete(ptr ptr)
+@ stdcall -stub -version=0x600+ ZwRollbackEnlistment(ptr ptr)
+@ stdcall -stub -version=0x600+ ZwRollbackTransaction(ptr long)
+@ stdcall -stub -version=0x600+ ZwRollforwardTransactionManager(ptr ptr)
 @ stdcall ZwSaveKey(long long)
 @ stdcall ZwSaveKeyEx(ptr ptr long)
 @ stdcall ZwSaveMergedKeys(ptr ptr ptr)
@@ -1683,18 +1689,18 @@
 @ stdcall ZwSetHighEventPair(ptr)
 @ stdcall ZwSetHighWaitLowEventPair(ptr)
 @ stdcall ZwSetInformationDebugObject(ptr long ptr long ptr)
-@ stub -version=0x600+ ZwSetInformationEnlistment
+@ stdcall -stub -version=0x600+ ZwSetInformationEnlistment(ptr long ptr long)
 @ stdcall ZwSetInformationFile(long long long long long)
 @ stdcall ZwSetInformationJobObject(long long ptr long)
 @ stdcall ZwSetInformationKey(long long ptr long)
 @ stdcall ZwSetInformationObject(long long ptr long)
 @ stdcall ZwSetInformationProcess(long long long long)
-@ stub -version=0x600+ ZwSetInformationResourceManager
+@ stdcall -stub -version=0x600+ ZwSetInformationResourceManager(ptr long ptr long)
 @ stdcall ZwSetInformationThread(long long ptr long)
 @ stdcall ZwSetInformationToken(long long ptr long)
-@ stub -version=0x600+ ZwSetInformationTransaction
-@ stub -version=0x600+ ZwSetInformationTransactionManager
-@ stub -version=0x600+ ZwSetInformationWorkerFactory
+@ stdcall -stub -version=0x600+ ZwSetInformationTransaction(ptr long ptr long)
+@ stdcall -stub -version=0x600+ ZwSetInformationTransactionManager(ptr long ptr long)
+@ stdcall -stub -version=0x600+ ZwSetInformationWorkerFactory(ptr long ptr long)
 @ stdcall ZwSetIntervalProfile(long long)
 @ stdcall ZwSetIoCompletion(ptr long ptr long long)
 @ stdcall ZwSetLdtEntries(long int64 long int64)
@@ -1714,9 +1720,9 @@
 @ stdcall ZwSetValueKey(long long long long long long)
 @ stdcall ZwSetVolumeInformationFile(long ptr ptr long long)
 @ stdcall ZwShutdownSystem(long)
-@ stub -version=0x600+ ZwShutdownWorkerFactory
+@ stdcall -stub -version=0x600+ ZwShutdownWorkerFactory(ptr ptr)
 @ stdcall ZwSignalAndWaitForSingleObject(long long long ptr)
-@ stub -version=0x600+ ZwSinglePhaseReject
+@ stdcall -stub -version=0x600+ ZwSinglePhaseReject(ptr ptr)
 @ stdcall ZwStartProfile(ptr)
 @ stdcall ZwStopProfile(ptr)
 @ stdcall ZwSuspendProcess(ptr)
@@ -1726,9 +1732,9 @@
 @ stdcall ZwTerminateProcess(ptr long)
 @ stdcall ZwTerminateThread(ptr long)
 @ stdcall ZwTestAlert()
-@ stub -version=0x600+ ZwThawRegistry
-@ stub -version=0x600+ ZwThawTransactions
-@ stub -version=0x600+ ZwTraceControl
+@ stdcall -stub -version=0x600+ ZwThawRegistry()
+@ stdcall -stub -version=0x600+ ZwThawTransactions()
+@ stdcall -stub -version=0x600+ ZwTraceControl(long ptr long ptr long long)
 @ stdcall ZwTraceEvent(long long long ptr)
 @ stdcall ZwTranslateFilePath(ptr long ptr long)
 @ stdcall ZwUnloadDriver(ptr)
@@ -1744,10 +1750,10 @@
 @ stdcall ZwWaitForMultipleObjects32(long ptr long long ptr)
 @ stdcall ZwWaitForMultipleObjects(long ptr long long ptr)
 @ stdcall ZwWaitForSingleObject(long long long)
-@ stub -version=0x600+ ZwWaitForWorkViaWorkerFactory
+@ stdcall -stub -version=0x600+ ZwWaitForWorkViaWorkerFactory(ptr ptr long ptr ptr)
 @ stdcall ZwWaitHighEventPair(ptr)
 @ stdcall ZwWaitLowEventPair(ptr)
-@ stub -version=0x600+ ZwWorkerFactoryWorkerReady
+@ stdcall -stub -version=0x600+ ZwWorkerFactoryWorkerReady(ptr)
 @ stdcall ZwWriteFile(long long ptr ptr ptr ptr long ptr ptr)
 @ stdcall ZwWriteFileGather(long long ptr ptr ptr ptr long ptr ptr)
 @ stdcall ZwWriteRequestData(ptr ptr long ptr long ptr)
@@ -1814,7 +1820,7 @@
 @ cdecl _vscwprintf(wstr ptr)
 @ cdecl _vsnprintf(ptr long str ptr)
 @ cdecl _vsnwprintf(ptr long wstr ptr)
-@ stub -version=0x600+ _vswprintf
+@ cdecl -stub -version=0x600+ _vswprintf(ptr wstr ptr)
 @ cdecl _wcsicmp(wstr wstr)
 @ cdecl _wcslwr(wstr)
 @ cdecl _wcsnicmp(wstr wstr long)


### PR DESCRIPTION
Mostly based on Windows 11 22H2 and Vista SP2 and WINE-10.0

This is a revised version of a commit made by @archeYR when we were trying to get browsers and a few apps to work back
in july of 2023.

I've modified it based on some stuff from WINE-10.0. 

(No logic changes so ill just run it on one and one)
- [x] KVM x86: https://reactos.org/testman/compare.php?ids=100758,100760
