### PR TITLE
[RAPPS] Set working directory for zip generated shortcuts

### DIFF
--- a/base/applications/rapps/geninst.cpp
+++ b/base/applications/rapps/geninst.cpp
@@ -309,6 +309,9 @@ CreateShortcut(const CStringW &Target)
     {
         if (SUCCEEDED(hr = link->SetPath(Target)))
         {
+            SplitFileAndDirectory(Target, &tmp);
+            link->SetWorkingDirectory(tmp);
+
             if (SUCCEEDED(GetCustomIconPath(Info, tmp)))
             {
                 LPWSTR p = tmp.GetBuffer();


### PR DESCRIPTION
Some applications are broken and assume the working directory is the same as the .exe directory (xrick etc).
