### PR TITLE
[NTUSER] Load SM_CXICON etc. settings from registry

### DIFF
--- a/win32ss/user/ntuser/metric.c
+++ b/win32ss/user/ntuser/metric.c
@@ -5,6 +5,7 @@
  * FILE:             win32ss/user/ntuser/metric.c
  * PROGRAMER:        Casper S. Hornstrup (chorns@users.sourceforge.net)
  *                   Timo Kreuzer (timo.kreuzer@reactos.org)
+ *                   Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
  */
 
 #include <win32k.h>
@@ -130,10 +131,10 @@ InitMetrics(VOID)
     piSysMet[SM_CXHTHUMB] = gspv.ncm.iScrollHeight;     // 16;
     piSysMet[SM_CYVSCROLL] = gspv.ncm.iScrollHeight;    // 16
     piSysMet[SM_CXHSCROLL] = gspv.ncm.iScrollHeight;    // 16;
-    piSysMet[SM_CXICON] = 32;
-    piSysMet[SM_CYICON] = 32;
-    piSysMet[SM_CXSMICON] = 16;
-    piSysMet[SM_CYSMICON] = 16;
+    piSysMet[SM_CXICON] = gspv.nIconSize; // 32
+    piSysMet[SM_CYICON] = gspv.nIconSize; // 32
+    piSysMet[SM_CXSMICON] = gspv.nSmallIconSize; // 16
+    piSysMet[SM_CYSMICON] = gspv.nSmallIconSize; // 16
     piSysMet[SM_CXICONSPACING] = gspv.im.iHorzSpacing;  // 64;
     piSysMet[SM_CYICONSPACING] = gspv.im.iVertSpacing;  // 64;
     piSysMet[SM_CXCURSOR] = 32;

--- a/win32ss/user/ntuser/sysparams.c
+++ b/win32ss/user/ntuser/sysparams.c
@@ -4,6 +4,7 @@
  * PURPOSE:          System parameters functions
  * FILE:             win32ss/user/ntuser/sysparams.c
  * PROGRAMER:        Timo Kreuzer (timo.kreuzer@reactos.org)
+ *                   Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
  */
 
 // TODO:
@@ -205,6 +206,11 @@ SpiFixupValues(VOID)
 //                               gspv.tmMenuFont.tmExternalLeading);
     if (gspv.iDblClickTime == 0) gspv.iDblClickTime = 500;
 
+    if (gspv.nIconSize <= 0)
+        gspv.nIconSize = 32;
+    if (gspv.nSmallIconSize <= 0)
+        gspv.nSmallIconSize = 16;
+
     // FIXME: Hack!!!
     gspv.tmMenuFont.tmHeight = 11;
     gspv.tmMenuFont.tmExternalLeading = 2;
@@ -295,6 +301,10 @@ SpiUpdatePerUserSystemParameters(VOID)
     gspv.im.iVertSpacing = SpiLoadMetric(VAL_ICONVSPC, 64);
     gspv.im.iTitleWrap = SpiLoadMetric(VAL_ITWRAP, 1);
     SpiLoadFont(&gspv.im.lfFont, L"IconFont", &lf1);
+
+    /* Load icon size */
+    gspv.nIconSize = SpiLoadInt(KEY_METRIC, L"Shell Icon Size", 32);
+    gspv.nSmallIconSize = SpiLoadInt(KEY_METRIC, L"Shell Small Icon Size", 16);
 
     /* Load desktop settings */
     gspv.bDragFullWindows = SpiLoadInt(KEY_DESKTOP, VAL_DRAG, 0);

--- a/win32ss/user/ntuser/sysparams.h
+++ b/win32ss/user/ntuser/sysparams.h
@@ -157,6 +157,9 @@ typedef struct _SPIVALUES
     DWORD dwForegroundFlashCount;
     DWORD dwCaretWidth;
 
+    INT nIconSize;
+    INT nSmallIconSize;
+
 //    SPI_LANGDRIVER
 //    SPI_SETDESKPATTERN
 //    SPI_SETPENWINDOWS


### PR DESCRIPTION
## Purpose

Improve usability.
JIRA issue: [CORE-12905](https://jira.reactos.org/browse/CORE-12905)

## Proposed changes

- Add `nIconSize` and `nSmallIconSize` values to `SPIVALUES` structure.
- Load `"Shell Icon Size"` and `"Shell Small Icon Size"` values from registry.
- Enable changing of `SM_CXICON`, `SM_CYICON`, `SM_CXSMICON`, and `SM_CYSMICON` settings.

## TODO

- [x] Do tests.

## Comparison

BEFORE:
![before](https://github.com/user-attachments/assets/080eeae4-dc5b-423c-912c-e10231ff5d71)

AFTER:
![after](https://github.com/user-attachments/assets/2efcc31f-ca16-450a-b21b-121a8d81ca13)