### PR TITLE
[SHELL32] Load shell icon size from registry

### DIFF
--- a/dll/win32/shell32/iconcache.cpp
+++ b/dll/win32/shell32/iconcache.cpp
@@ -44,7 +44,7 @@ CRITICAL_SECTION SHELL32_SicCS = { &critsect_debug, -1, 0, 0, 0, 0 };
 
 // Load metric value from registry
 static INT
-SHELL_GetMetricsValue(
+SIC_GetMetricsValue(
     _In_ PCWSTR pszValueName,
     _In_ INT nDefaultValue)
 {
@@ -59,22 +59,22 @@ SHELL_GetMetricsValue(
 }
 
 static VOID
-SHELL_GetBigIconSize(_Out_ PSIZE pSize)
+SIC_GetBigIconSize(_Out_ PSIZE pSize)
 {
     // NOTE: Shell icon size is always square
     INT nDefaultSize = GetSystemMetrics(SM_CXICON);
-    INT nIconSize = SHELL_GetMetricsValue(L"Shell Icon Size", nDefaultSize);
+    INT nIconSize = SIC_GetMetricsValue(L"Shell Icon Size", nDefaultSize);
     if (nIconSize <= 0)
         nIconSize = nDefaultSize;
     pSize->cx = pSize->cy = nIconSize;
 }
 
 static VOID
-SHELL_GetSmallIconSize(_Out_ PSIZE pSize)
+SIC_GetSmallIconSize(_Out_ PSIZE pSize)
 {
     // NOTE: Shell icon size is always square
     INT nDefaultSize = GetSystemMetrics(SM_CXICON) / 2;
-    INT nIconSize = SHELL_GetMetricsValue(L"Shell Small Icon Size", nDefaultSize);
+    INT nIconSize = SIC_GetMetricsValue(L"Shell Small Icon Size", nDefaultSize);
     if (nIconSize <= 0)
         nIconSize = nDefaultSize;
     pSize->cx = pSize->cy = nIconSize;
@@ -555,8 +555,8 @@ BOOL SIC_Initialize(void)
 
     ilMask |= ILC_MASK;
 
-    SHELL_GetSmallIconSize(&ShellSmallIconSize);
-    SHELL_GetBigIconSize(&ShellBigIconSize);
+    SIC_GetSmallIconSize(&ShellSmallIconSize);
+    SIC_GetBigIconSize(&ShellBigIconSize);
 
     ShellSmallIconList = ImageList_Create(ShellSmallIconSize.cx, ShellSmallIconSize.cy, ilMask,
                                           100, 100);

--- a/dll/win32/shell32/iconcache.cpp
+++ b/dll/win32/shell32/iconcache.cpp
@@ -86,7 +86,7 @@ SIC_GetIconBPP(VOID) // Bits Per Pixel
 {
     INT nDefaultBPP = SHGetCurColorRes();
     INT nIconBPP = SIC_GetMetricsValue(L"Shell Icon BPP", nDefaultBPP);
-    return (nIconBPP <= 0) ? nDefaultBPP : nIconBPP;
+    return (nIconBPP > 0) ? nIconBPP : nDefaultBPP;
 }
 
 /*****************************************************************************

--- a/dll/win32/shell32/iconcache.cpp
+++ b/dll/win32/shell32/iconcache.cpp
@@ -27,8 +27,8 @@ static HDPA        sic_hdpa = 0;
 
 static HIMAGELIST ShellSmallIconList;
 static HIMAGELIST ShellBigIconList;
-SIZE sic_SmallIconSize;
-SIZE sic_BigIconSize;
+SIZE ShellSmallIconSize;
+SIZE ShellBigIconSize;
 
 namespace
 {
@@ -418,9 +418,9 @@ static INT SIC_LoadIcon (LPCWSTR sSourceFile, INT dwSourceIndex, DWORD dwFlags)
     HICON hiconSmall=0;
     UINT ret;
 
-    PrivateExtractIconsW(sSourceFile, dwSourceIndex, sic_BigIconSize.cx, sic_BigIconSize.cy,
+    PrivateExtractIconsW(sSourceFile, dwSourceIndex, ShellBigIconSize.cx, ShellBigIconSize.cy,
                          &hiconLarge, NULL, 1, LR_COPYFROMRESOURCE);
-    PrivateExtractIconsW(sSourceFile, dwSourceIndex, sic_SmallIconSize.cx, sic_SmallIconSize.cy,
+    PrivateExtractIconsW(sSourceFile, dwSourceIndex, ShellSmallIconSize.cx, ShellSmallIconSize.cy,
                          &hiconSmall, NULL, 1, LR_COPYFROMRESOURCE);
 
     if ( !hiconLarge ||  !hiconSmall)
@@ -555,10 +555,10 @@ BOOL SIC_Initialize(void)
 
     ilMask |= ILC_MASK;
 
-    SHELL_GetSmallIconSize(&sic_SmallIconSize);
-    SHELL_GetBigIconSize(&sic_BigIconSize);
+    SHELL_GetSmallIconSize(&ShellSmallIconSize);
+    SHELL_GetBigIconSize(&ShellBigIconSize);
 
-    ShellSmallIconList = ImageList_Create(sic_SmallIconSize.cx, sic_SmallIconSize.cy, ilMask,
+    ShellSmallIconList = ImageList_Create(ShellSmallIconSize.cx, ShellSmallIconSize.cy, ilMask,
                                           100, 100);
     if (!ShellSmallIconList)
     {
@@ -566,7 +566,7 @@ BOOL SIC_Initialize(void)
         goto end;
     }
 
-    ShellBigIconList = ImageList_Create(sic_BigIconSize.cx, sic_BigIconSize.cy, ilMask, 100, 100);
+    ShellBigIconList = ImageList_Create(ShellBigIconSize.cx, ShellBigIconSize.cy, ilMask, 100, 100);
     if (!ShellBigIconList)
     {
         ERR("Failed to create the big icon list.\n");
@@ -575,7 +575,7 @@ BOOL SIC_Initialize(void)
 
     /* Load the document icon, which is used as the default if an icon isn't found. */
     hSm = (HICON)LoadImageW(shell32_hInstance, MAKEINTRESOURCEW(IDI_SHELL_DOCUMENT),
-                            IMAGE_ICON, sic_SmallIconSize.cx, sic_SmallIconSize.cy,
+                            IMAGE_ICON, ShellSmallIconSize.cx, ShellSmallIconSize.cy,
                             LR_SHARED | LR_DEFAULTCOLOR);
     if (!hSm)
     {
@@ -584,7 +584,7 @@ BOOL SIC_Initialize(void)
     }
 
     hLg = (HICON)LoadImageW(shell32_hInstance, MAKEINTRESOURCEW(IDI_SHELL_DOCUMENT),
-                            IMAGE_ICON, sic_BigIconSize.cx, sic_BigIconSize.cy,
+                            IMAGE_ICON, ShellBigIconSize.cx, ShellBigIconSize.cy,
                             LR_SHARED | LR_DEFAULTCOLOR);
     if (!hLg)
     {

--- a/dll/win32/shell32/iconcache.cpp
+++ b/dll/win32/shell32/iconcache.cpp
@@ -62,7 +62,10 @@ static VOID
 SHELL_GetBigIconSize(_Out_ PSIZE pSize)
 {
     // NOTE: Shell icon size is always square
-    INT nIconSize = SHELL_GetMetricsValue(L"Shell Icon Size", GetSystemMetrics(SM_CXICON));
+    INT nDefaultSize = GetSystemMetrics(SM_CXICON);
+    INT nIconSize = SHELL_GetMetricsValue(L"Shell Icon Size", nDefaultSize);
+    if (nIconSize <= 0)
+        nIconSize = nDefaultSize;
     pSize->cx = pSize->cy = nIconSize;
 }
 
@@ -70,8 +73,10 @@ static VOID
 SHELL_GetSmallIconSize(_Out_ PSIZE pSize)
 {
     // NOTE: Shell icon size is always square
-    INT nIconSize = SHELL_GetMetricsValue(L"Shell Small Icon Size",
-                                          GetSystemMetrics(SM_CXICON) / 2);
+    INT nDefaultSize = GetSystemMetrics(SM_CXICON) / 2;
+    INT nIconSize = SHELL_GetMetricsValue(L"Shell Small Icon Size", nDefaultSize);
+    if (nIconSize <= 0)
+        nIconSize = nDefaultSize;
     pSize->cx = pSize->cy = nIconSize;
 }
 

--- a/dll/win32/shell32/iconcache.cpp
+++ b/dll/win32/shell32/iconcache.cpp
@@ -3,7 +3,7 @@
  * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
  * PURPOSE:     Shell Icon Cache (SIC)
  * COPYRIGHT:   Copyright 1998, 1999 Juergen Schmied
- *              Copyright 2020-2023 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
+ *              Copyright 2025 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
  */
 
 #include "precomp.h"

--- a/dll/win32/shell32/iconcache.cpp
+++ b/dll/win32/shell32/iconcache.cpp
@@ -28,7 +28,7 @@ static HDPA        sic_hdpa = 0;
 static HIMAGELIST ShellSmallIconList;
 static HIMAGELIST ShellBigIconList;
 INT ShellSmallIconSize = 0;
-INT ShellBigIconSize = 0;
+INT ShellLargeIconSize = 0;
 INT ShellIconBPP = 0; // Bits Per Pixel
 
 namespace
@@ -60,7 +60,7 @@ SIC_GetMetricsValue(
 }
 
 static INT
-SIC_GetBigIconSize(VOID)
+SIC_GetLargeIconSize(VOID)
 {
     // NOTE: Shell icon size is always square
     INT nDefaultSize = GetSystemMetrics(SM_CXICON);
@@ -72,7 +72,7 @@ static INT
 SIC_GetSmallIconSize(VOID)
 {
     // NOTE: Shell icon size is always square
-    INT nDefaultSize = GetSystemMetrics(SM_CXICON) / 2;
+    INT nDefaultSize = GetSystemMetrics(SM_CXSMICON);
     INT nIconSize = SIC_GetMetricsValue(L"Shell Small Icon Size", nDefaultSize);
     return (nIconSize > 0) ? nIconSize : nDefaultSize;
 }
@@ -419,16 +419,15 @@ leave:
  */
 static INT SIC_LoadIcon (LPCWSTR sSourceFile, INT dwSourceIndex, DWORD dwFlags)
 {
-    HICON hiconLarge=0;
-    HICON hiconSmall=0;
+    HICON hiconLarge = NULL, hiconSmall = NULL;
     UINT ret;
 
-    PrivateExtractIconsW(sSourceFile, dwSourceIndex, ShellBigIconSize, ShellBigIconSize,
+    PrivateExtractIconsW(sSourceFile, dwSourceIndex, ShellLargeIconSize, ShellLargeIconSize,
                          &hiconLarge, NULL, 1, LR_COPYFROMRESOURCE);
     PrivateExtractIconsW(sSourceFile, dwSourceIndex, ShellSmallIconSize, ShellSmallIconSize,
                          &hiconSmall, NULL, 1, LR_COPYFROMRESOURCE);
 
-    if ( !hiconLarge ||  !hiconSmall)
+    if (!hiconLarge || !hiconSmall)
     {
         WARN("failure loading icon %i from %s (%p %p)\n", dwSourceIndex, debugstr_w(sSourceFile), hiconLarge, hiconSmall);
         if(hiconLarge) DestroyIcon(hiconLarge);
@@ -535,7 +534,7 @@ BOOL SIC_Initialize(void)
     }
 
     ShellSmallIconSize = SIC_GetSmallIconSize();
-    ShellBigIconSize = SIC_GetBigIconSize();
+    ShellLargeIconSize = SIC_GetLargeIconSize();
 
     bpp = ShellIconBPP = SIC_GetIconBPP(); // Bits Per Pixel
     if (bpp <= 4)
@@ -560,7 +559,7 @@ BOOL SIC_Initialize(void)
         goto end;
     }
 
-    ShellBigIconList = ImageList_Create(ShellBigIconSize, ShellBigIconSize, ilMask, 100, 100);
+    ShellBigIconList = ImageList_Create(ShellLargeIconSize, ShellLargeIconSize, ilMask, 100, 100);
     if (!ShellBigIconList)
     {
         ERR("Failed to create the big icon list.\n");
@@ -578,7 +577,7 @@ BOOL SIC_Initialize(void)
     }
 
     hLg = (HICON)LoadImageW(shell32_hInstance, MAKEINTRESOURCEW(IDI_SHELL_DOCUMENT),
-                            IMAGE_ICON, ShellBigIconSize, ShellBigIconSize,
+                            IMAGE_ICON, ShellLargeIconSize, ShellLargeIconSize,
                             LR_SHARED | LR_DEFAULTCOLOR);
     if (!hLg)
     {

--- a/dll/win32/shell32/wine/shell32_main.c
+++ b/dll/win32/shell32/wine/shell32_main.c
@@ -699,7 +699,7 @@ DWORD_PTR WINAPI SHGetFileInfoW(LPCWSTR path,DWORD dwFileAttributes,
                         UINT ret;
                         SIZE iconSize;
 
-                        // Get icon size
+                        /* Get icon size */
                         if (flags & SHGFI_SHELLICONSIZE)
                         {
                             if (flags & SHGFI_SMALLICON)

--- a/dll/win32/shell32/wine/shell32_main.c
+++ b/dll/win32/shell32/wine/shell32_main.c
@@ -705,7 +705,7 @@ DWORD_PTR WINAPI SHGetFileInfoW(LPCWSTR path,DWORD dwFileAttributes,
                             if (flags & SHGFI_SMALLICON)
                                 cxIcon = cyIcon = ShellSmallIconSize;
                             else
-                                cxIcon = cyIcon = ShellBigIconSize;
+                                cxIcon = cyIcon = ShellLargeIconSize;
                         }
                         else
                         {

--- a/dll/win32/shell32/wine/shell32_main.c
+++ b/dll/win32/shell32/wine/shell32_main.c
@@ -697,31 +697,31 @@ DWORD_PTR WINAPI SHGetFileInfoW(LPCWSTR path,DWORD dwFileAttributes,
                     else 
                     {
                         UINT ret;
-                        SIZE iconSize;
+                        INT cxIcon, cyIcon;
 
                         /* Get icon size */
                         if (flags & SHGFI_SHELLICONSIZE)
                         {
                             if (flags & SHGFI_SMALLICON)
-                                iconSize = ShellSmallIconSize;
+                                cxIcon = cyIcon = ShellSmallIconSize;
                             else
-                                iconSize = ShellBigIconSize;
+                                cxIcon = cyIcon = ShellBigIconSize;
                         }
                         else
                         {
                             if (flags & SHGFI_SMALLICON)
                             {
-                                iconSize.cx = GetSystemMetrics(SM_CXSMICON);
-                                iconSize.cy = GetSystemMetrics(SM_CYSMICON);
+                                cxIcon = GetSystemMetrics(SM_CXSMICON);
+                                cyIcon = GetSystemMetrics(SM_CYSMICON);
                             }
                             else
                             {
-                                iconSize.cx = GetSystemMetrics(SM_CXICON);
-                                iconSize.cy = GetSystemMetrics(SM_CYICON);
+                                cxIcon = GetSystemMetrics(SM_CXICON);
+                                cyIcon = GetSystemMetrics(SM_CYICON);
                             }
                         }
 
-                        ret = PrivateExtractIconsW(sTemp, icon_idx, iconSize.cx, iconSize.cy,
+                        ret = PrivateExtractIconsW(sTemp, icon_idx, cxIcon, cyIcon,
                                                    &psfi->hIcon, 0, 1, 0);
                         if (ret != 0 && ret != (UINT)-1)
                         {

--- a/dll/win32/shell32/wine/shell32_main.c
+++ b/dll/win32/shell32/wine/shell32_main.c
@@ -703,9 +703,9 @@ DWORD_PTR WINAPI SHGetFileInfoW(LPCWSTR path,DWORD dwFileAttributes,
                         if (flags & SHGFI_SHELLICONSIZE)
                         {
                             if (flags & SHGFI_SMALLICON)
-                                iconSize = sic_SmallIconSize;
+                                iconSize = ShellSmallIconSize;
                             else
-                                iconSize = sic_BigIconSize;
+                                iconSize = ShellBigIconSize;
                         }
                         else
                         {

--- a/dll/win32/shell32/wine/shell32_main.c
+++ b/dll/win32/shell32/wine/shell32_main.c
@@ -607,9 +607,6 @@ DWORD_PTR WINAPI SHGetFileInfoW(LPCWSTR path,DWORD dwFileAttributes,
     if (flags & SHGFI_SELECTED)
         FIXME("set icon to selected, stub\n");
 
-    if (flags & SHGFI_SHELLICONSIZE)
-        FIXME("set icon to shell size, stub\n");
-
     /* get the iconlocation */
     if (SUCCEEDED(hr) && (flags & SHGFI_ICONLOCATION ))
     {
@@ -700,16 +697,32 @@ DWORD_PTR WINAPI SHGetFileInfoW(LPCWSTR path,DWORD dwFileAttributes,
                     else 
                     {
                         UINT ret;
-                        if (flags & SHGFI_SMALLICON)
-                            ret = PrivateExtractIconsW( sTemp,icon_idx,
-                                GetSystemMetrics( SM_CXSMICON ),
-                                GetSystemMetrics( SM_CYSMICON ),
-                                &psfi->hIcon, 0, 1, 0);
+                        SIZE iconSize;
+
+                        // Get icon size
+                        if (flags & SHGFI_SHELLICONSIZE)
+                        {
+                            if (flags & SHGFI_SMALLICON)
+                                iconSize = sic_SmallIconSize;
+                            else
+                                iconSize = sic_BigIconSize;
+                        }
                         else
-                            ret = PrivateExtractIconsW( sTemp, icon_idx,
-                                GetSystemMetrics( SM_CXICON),
-                                GetSystemMetrics( SM_CYICON),
-                                &psfi->hIcon, 0, 1, 0);
+                        {
+                            if (flags & SHGFI_SMALLICON)
+                            {
+                                iconSize.cx = GetSystemMetrics(SM_CXSMICON);
+                                iconSize.cy = GetSystemMetrics(SM_CYSMICON);
+                            }
+                            else
+                            {
+                                iconSize.cx = GetSystemMetrics(SM_CXICON);
+                                iconSize.cy = GetSystemMetrics(SM_CYICON);
+                            }
+                        }
+
+                        ret = PrivateExtractIconsW(sTemp, icon_idx, iconSize.cx, iconSize.cy,
+                                                   &psfi->hIcon, 0, 1, 0);
                         if (ret != 0 && ret != (UINT)-1)
                         {
                             IconNotYetLoaded=FALSE;

--- a/dll/win32/shell32/wine/shell32_main.h
+++ b/dll/win32/shell32/wine/shell32_main.h
@@ -44,7 +44,7 @@ BOOL SIC_Initialize(void);
 void SIC_Destroy(void) DECLSPEC_HIDDEN;
 BOOL PidlToSicIndex (IShellFolder * sh, LPCITEMIDLIST pidl, BOOL bBigIcon, UINT uFlags, int * pIndex) DECLSPEC_HIDDEN;
 INT SIC_GetIconIndex (LPCWSTR sSourceFile, INT dwSourceIndex, DWORD dwFlags ) DECLSPEC_HIDDEN;
-extern INT ShellBigIconSize;
+extern INT ShellLargeIconSize;
 extern INT ShellSmallIconSize;
 extern INT ShellIconBPP;
 

--- a/dll/win32/shell32/wine/shell32_main.h
+++ b/dll/win32/shell32/wine/shell32_main.h
@@ -46,6 +46,7 @@ BOOL PidlToSicIndex (IShellFolder * sh, LPCITEMIDLIST pidl, BOOL bBigIcon, UINT 
 INT SIC_GetIconIndex (LPCWSTR sSourceFile, INT dwSourceIndex, DWORD dwFlags ) DECLSPEC_HIDDEN;
 extern SIZE ShellBigIconSize;
 extern SIZE ShellSmallIconSize;
+extern INT ShellIconBPP;
 
 /* Classes Root */
 HRESULT HCR_GetProgIdKeyOfExtension(PCWSTR szExtension, PHKEY phKey, BOOL AllowFallback);

--- a/dll/win32/shell32/wine/shell32_main.h
+++ b/dll/win32/shell32/wine/shell32_main.h
@@ -44,6 +44,8 @@ BOOL SIC_Initialize(void);
 void SIC_Destroy(void) DECLSPEC_HIDDEN;
 BOOL PidlToSicIndex (IShellFolder * sh, LPCITEMIDLIST pidl, BOOL bBigIcon, UINT uFlags, int * pIndex) DECLSPEC_HIDDEN;
 INT SIC_GetIconIndex (LPCWSTR sSourceFile, INT dwSourceIndex, DWORD dwFlags ) DECLSPEC_HIDDEN;
+extern SIZE sic_BigIconSize;
+extern SIZE sic_SmallIconSize;
 
 /* Classes Root */
 HRESULT HCR_GetProgIdKeyOfExtension(PCWSTR szExtension, PHKEY phKey, BOOL AllowFallback);

--- a/dll/win32/shell32/wine/shell32_main.h
+++ b/dll/win32/shell32/wine/shell32_main.h
@@ -44,8 +44,8 @@ BOOL SIC_Initialize(void);
 void SIC_Destroy(void) DECLSPEC_HIDDEN;
 BOOL PidlToSicIndex (IShellFolder * sh, LPCITEMIDLIST pidl, BOOL bBigIcon, UINT uFlags, int * pIndex) DECLSPEC_HIDDEN;
 INT SIC_GetIconIndex (LPCWSTR sSourceFile, INT dwSourceIndex, DWORD dwFlags ) DECLSPEC_HIDDEN;
-extern SIZE ShellBigIconSize;
-extern SIZE ShellSmallIconSize;
+extern INT ShellBigIconSize;
+extern INT ShellSmallIconSize;
 extern INT ShellIconBPP;
 
 /* Classes Root */

--- a/dll/win32/shell32/wine/shell32_main.h
+++ b/dll/win32/shell32/wine/shell32_main.h
@@ -44,8 +44,8 @@ BOOL SIC_Initialize(void);
 void SIC_Destroy(void) DECLSPEC_HIDDEN;
 BOOL PidlToSicIndex (IShellFolder * sh, LPCITEMIDLIST pidl, BOOL bBigIcon, UINT uFlags, int * pIndex) DECLSPEC_HIDDEN;
 INT SIC_GetIconIndex (LPCWSTR sSourceFile, INT dwSourceIndex, DWORD dwFlags ) DECLSPEC_HIDDEN;
-extern SIZE sic_BigIconSize;
-extern SIZE sic_SmallIconSize;
+extern SIZE ShellBigIconSize;
+extern SIZE ShellSmallIconSize;
 
 /* Classes Root */
 HRESULT HCR_GetProgIdKeyOfExtension(PCWSTR szExtension, PHKEY phKey, BOOL AllowFallback);


### PR DESCRIPTION
## Purpose

Improve usability. Re-trial of #7679 with different approach.
JIRA issue: [CORE-12905](https://jira.reactos.org/browse/CORE-12905)

## Proposed changes

- Add `ShellSmallIconSize`, `ShellLargeIconSize`, and `ShellIconBPP` global variables in `iconcache.cpp`.
- Add `SIC_GetMetricsValue`, `SIC_GetLargeIconSize`, `SIC_GetSmallIconSize`, and `SIC_GetIconBPP` helper functions in `iconcache.cpp`.
- Load shell icon size from registry key `"HKEY_CURRENT_USER\\Control Panel\\Desktop\\WindowMetrics"`.
- Load icon BPP (bits per pixel) from registry.
- Fix `SIC_Initialize` and `SIC_LoadIcon` functions for icon size.
- Fix `SHGetFileInfoW` function for `SHGFI_SHELLICONSIZE` flag.

## TODO

- [x] Do tests.

## Comparison
(With changing `"Shell Icon Size"` value and reboot)

BEFORE:
![before](https://github.com/user-attachments/assets/1b819c28-6dc9-446b-8276-35bbc729be9e)
No change in display.

AFTER:
![after](https://github.com/user-attachments/assets/3c4a4344-fae1-4db1-bc14-830e53579a7e)
The Desktop icons are shrinked.