### PR TITLE
[RAPPS] Don't display Freeware license string if the type is also Freeware

### DIFF
--- a/base/applications/rapps/appinfo.cpp
+++ b/base/applications/rapps/appinfo.cpp
@@ -163,16 +163,16 @@ CAvailableApplicationInfo::LicenseString()
     LicenseType licenseType;
 
     if (IsKnownLicenseType(IntBuffer))
-    {
         licenseType = static_cast<LicenseType>(IntBuffer);
-    }
     else
-    {
         licenseType = LICENSE_NONE;
+
+    if (licenseType == LICENSE_NONE || licenseType == LICENSE_FREEWARE)
+    {
         if (szLicenseString.CompareNoCase(L"Freeware") == 0)
         {
             licenseType = LICENSE_FREEWARE;
-            szLicenseString = L"";
+            szLicenseString = L""; // Don't display as "Freeware (Freeware)"
         }
     }
 


### PR DESCRIPTION
```
License=Freeware
LicenseType=2
```
should not display as "Freeware (Freeware)".
