### PR TITLE
[SHDOCVW][EXPLORER][RSHELL][SDK] Populate WinList_* stubs

### DIFF
--- a/base/shell/explorer/precomp.h
+++ b/base/shell/explorer/precomp.h
@@ -42,6 +42,7 @@
 #include <shlwapi_undoc.h>
 #include <shlobj_undoc.h>
 #include <shlguid_undoc.h>
+#include <shdocvw_undoc.h>
 #include <undocshell.h>
 
 #include <ui/rosctrls.h>
@@ -119,7 +120,7 @@ VOID InitRSHELL(VOID);
 HRESULT WINAPI _CStartMenu_CreateInstance(REFIID riid, void **ppv);
 HANDLE WINAPI _SHCreateDesktop(IShellDesktopTray *ShellDesk);
 BOOL WINAPI _SHDesktopMessageLoop(HANDLE hDesktop);
-DWORD WINAPI _WinList_Init(void);
+BOOL WINAPI _WinList_Init(void);
 void WINAPI _ShellDDEInit(BOOL bInit);
 HRESULT WINAPI _CBandSiteMenu_CreateInstance(REFIID riid, void **ppv);
 HRESULT WINAPI _CBandSite_CreateInstance(LPUNKNOWN pUnkOuter, REFIID riid, void **ppv);

--- a/base/shell/explorer/rshell.cpp
+++ b/base/shell/explorer/rshell.cpp
@@ -105,9 +105,9 @@ BOOL WINAPI _SHDesktopMessageLoop(HANDLE hDesktop)
     return FALSE;
 }
 
-typedef DWORD(WINAPI* PWINLIST_INIT)(void);
+typedef BOOL (WINAPI *PWINLIST_INIT)(void);
 
-DWORD WINAPI _WinList_Init(void)
+BOOL WINAPI _WinList_Init(void)
 {
     HINSTANCE hFallback;
 
@@ -131,7 +131,7 @@ DWORD WINAPI _WinList_Init(void)
         }
     }
 
-    return 0;
+    return FALSE;
 }
 
 typedef void (WINAPI *PSHELLDDEINIT)(BOOL bInit);

--- a/base/shell/rshell/misc.cpp
+++ b/base/shell/rshell/misc.cpp
@@ -52,12 +52,6 @@ extern "C"
     HRESULT WINAPI RSHELL_CMergedFolder_CreateInstance(REFIID riid, LPVOID *ppv);
 }
 
-DWORD WINAPI WinList_Init(void)
-{
-    /* do something here (perhaps we may want to add our own implementation fo win8) */
-    return 0;
-}
-
 class CRShellModule : public CComModule
 {
 public:

--- a/dll/win32/shdocvw/CMakeLists.txt
+++ b/dll/win32/shdocvw/CMakeLists.txt
@@ -37,7 +37,8 @@ add_library(shdocvw_sublib OBJECT
     CNSCBand.cpp
     mrulist.cpp
     objects.cpp
-    utility.cpp)
+    utility.cpp
+    winlist.cpp)
 target_link_libraries(shdocvw_sublib PRIVATE atl_classes)
 target_compile_definitions(shdocvw_sublib PRIVATE $<TARGET_PROPERTY:shdocvw,COMPILE_DEFINITIONS>)
 target_compile_options(shdocvw_sublib PRIVATE $<TARGET_PROPERTY:shdocvw,COMPILE_OPTIONS>)

--- a/dll/win32/shdocvw/shdocvw.spec
+++ b/dll/win32/shdocvw/shdocvw.spec
@@ -8,7 +8,7 @@
 @ stdcall -private DllGetClassObject(ptr ptr ptr)
 @ stdcall -private DllGetVersion(ptr)
 110 stdcall -noname WinList_Init()
-111 stub -noname WinList_Terminate
+111 stdcall -noname WinList_Terminate()
 @ stdcall -private DllInstall(long wstr)
 @ stdcall -private DllRegisterServer()
 @ stub DllRegisterWindowClasses
@@ -74,11 +74,11 @@
 174 stub -noname SHIsGlobalOffline
 175 stub -noname DetectAndFixAssociations
 176 stub -noname EnsureWebViewRegSettings
-177 stub -noname WinList_NotifyNewLocation
-178 stub -noname WinList_FindFolderWindow
-179 stub -noname WinList_GetShellWindows
-180 stub -noname WinList_RegisterPending
-181 stub -noname WinList_Revoke
+177 stdcall -noname WinList_NotifyNewLocation(ptr long ptr)
+178 stdcall -noname WinList_FindFolderWindow(ptr long ptr ptr)
+179 stdcall -noname WinList_GetShellWindows(long)
+180 stdcall -noname WinList_RegisterPending(long ptr long ptr)
+181 stdcall -noname WinList_Revoke(long)
 182 stdcall SetQueryNetSessionCount(long)
 183 stub -noname SHMapNbspToSp
 184 stub SetShellOfflineState

--- a/dll/win32/shdocvw/shdocvw_main.c
+++ b/dll/win32/shdocvw/shdocvw_main.c
@@ -236,6 +236,7 @@ static BOOL SHDOCVW_LoadShell32(void)
      return ((SHDOCVW_hshell32 = LoadLibraryA("shell32.dll")) != NULL);
 }
 
+#ifndef __REACTOS__ /* See winlist.cpp */
 /***********************************************************************
  *		@ (SHDOCVW.110)
  *
@@ -247,6 +248,7 @@ DWORD WINAPI WinList_Init(void)
     FIXME("(), stub!\n");
     return 0x0deadfeed;
 }
+#endif /* ndef __REACTOS__ */
 
 /***********************************************************************
  *		@ (SHDOCVW.118)

--- a/dll/win32/shdocvw/winlist.cpp
+++ b/dll/win32/shdocvw/winlist.cpp
@@ -122,11 +122,14 @@ WinList_NotifyNewLocation(
     TRACE("(%p, %ld, %p)\n", pShellWindows, lCookie, pidl);
 
     if (!pidl)
+    {
+        ERR("!pidl\n");
         return E_UNEXPECTED;
+    }
 
     VARIANTARG varg;
     HRESULT hr = InitVariantFromIDList(&varg, pidl);
-    if (FAILED(hr))
+    if (FAILED_UNEXPECTEDLY(hr))
         return hr;
 
     hr = pShellWindows->OnNavigate(lCookie, &varg);
@@ -159,15 +162,21 @@ WinList_FindFolderWindow(
         *phwnd = 0;
 
     if (!pidl)
+    {
+        ERR("!pidl\n");
         return E_UNEXPECTED;
+    }
 
     IShellWindows *pShellWindows = WinList_GetShellWindows(ppvObj != NULL);
     if (!pShellWindows)
+    {
+        ERR("!pShellWindows\n");
         return E_UNEXPECTED;
+    }
 
     VARIANTARG varg;
     HRESULT hr = InitVariantFromIDList(&varg, pidl);
-    if (FAILED(hr))
+    if (FAILED_UNEXPECTEDLY(hr))
     {
         pShellWindows->Release();
         return hr;
@@ -205,15 +214,21 @@ WinList_RegisterPending(
     TRACE("(%ld, %p, %ld, %p)\n", dwThreadId, pidl, dwUnused, plCookie);
 
     if (!pidl)
+    {
+        ERR("!pidl\n");
         return E_UNEXPECTED;
+    }
 
     IShellWindows *pShellWindows = WinList_GetShellWindows(FALSE);
     if (!pShellWindows)
+    {
+        ERR("!pShellWindows\n");
         return E_UNEXPECTED;
+    }
 
     VARIANTARG varg;
     HRESULT hr = InitVariantFromIDList(&varg, pidl);
-    if (FAILED(hr))
+    if (FAILED_UNEXPECTEDLY(hr))
         return hr;
 
     hr = pShellWindows->RegisterPending(dwThreadId, &varg, &s_vaEmpty, SWC_BROWSER, plCookie);
@@ -236,7 +251,10 @@ WinList_Revoke(
 
     IShellWindows *pShellWindows = WinList_GetShellWindows(TRUE);
     if (!pShellWindows)
+    {
+        ERR("!pShellWindows\n");
         return E_FAIL;
+    }
 
     HRESULT hr = pShellWindows->Revoke(lCookie);
     pShellWindows->Release();

--- a/dll/win32/shdocvw/winlist.cpp
+++ b/dll/win32/shdocvw/winlist.cpp
@@ -1,7 +1,7 @@
 /*
  * PROJECT:     ReactOS shdocvw
  * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
- * PURPOSE:     WinList_* functions
+ * PURPOSE:     CLSID_ShellWindows and WinList_* functions
  * COPYRIGHT:   Copyright 2025 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  */
 
@@ -19,12 +19,15 @@ InitVariantFromBuffer(
     _In_ SIZE_T cb)
 {
     VariantInit(pvarg);
+
     LPSAFEARRAY pArray = SafeArrayCreateVector(VT_UI1, 0, cb);
     if (!pArray)
         return E_OUTOFMEMORY;
+
     CopyMemory(pArray->pvData, pv, cb);
     V_ARRAY(pvarg) = pArray;
     V_VT(pvarg) = VT_ARRAY | VT_UI1;
+
     return S_OK;
 }
 
@@ -43,8 +46,8 @@ VariantClearLazy(_Inout_ LPVARIANTARG pvarg)
     {
         case VT_EMPTY:
         case VT_I4:
-        case VT_BOOL:
         case VT_UI4:
+        case VT_BOOL:
             break;
         case VT_DISPATCH:
             if (V_DISPATCH(pvarg))

--- a/dll/win32/shdocvw/winlist.cpp
+++ b/dll/win32/shdocvw/winlist.cpp
@@ -149,7 +149,7 @@ WinList_FindFolderWindow(
     _In_ LPCITEMIDLIST pidl,
     _In_ DWORD dwUnused,
     _Out_ PLONG phwnd, // HWND but LONG type
-    _Out_ PVOID *ppvObj)
+    _Out_opt_ PVOID *ppvObj)
 {
     UNREFERENCED_PARAMETER(dwUnused);
 

--- a/dll/win32/shdocvw/winlist.cpp
+++ b/dll/win32/shdocvw/winlist.cpp
@@ -24,10 +24,9 @@ InitVariantFromBuffer(
     if (!pArray)
         return E_OUTOFMEMORY;
 
-    CopyMemory(pArray->pvData, pv, cb);
     V_ARRAY(pvarg) = pArray;
     V_VT(pvarg) = VT_ARRAY | VT_UI1;
-
+    CopyMemory(pArray->pvData, pv, cb);
     return S_OK;
 }
 

--- a/dll/win32/shdocvw/winlist.cpp
+++ b/dll/win32/shdocvw/winlist.cpp
@@ -45,17 +45,17 @@ VariantClearLazy(_Inout_ LPVARIANTARG pvarg)
     switch (V_VT(pvarg))
     {
         case VT_EMPTY:
+        case VT_BOOL:
         case VT_I4:
         case VT_UI4:
-        case VT_BOOL:
-            break;
-        case VT_DISPATCH:
-            if (V_DISPATCH(pvarg))
-                V_DISPATCH(pvarg)->Release();
             break;
         case VT_UNKNOWN:
             if (V_UNKNOWN(pvarg))
                 V_UNKNOWN(pvarg)->Release();
+            break;
+        case VT_DISPATCH:
+            if (V_DISPATCH(pvarg))
+                V_DISPATCH(pvarg)->Release();
             break;
         case VT_SAFEARRAY:
             SafeArrayDestroy(V_ARRAY(pvarg));
@@ -96,6 +96,7 @@ WinList_Terminate(VOID)
  *    WinList_GetShellWindows (SHDOCVW.179)
  *
  * NT 5.0 and higher.
+ * @see https://learn.microsoft.com/en-us/windows/win32/api/exdisp/nn-exdisp-ishellwindows
  */
 EXTERN_C
 IShellWindows* WINAPI
@@ -110,6 +111,7 @@ WinList_GetShellWindows(
  *    WinList_NotifyNewLocation (SHDOCVW.177)
  *
  * NT 5.0 and higher.
+ * @see https://learn.microsoft.com/en-us/windows/win32/api/exdisp/nf-exdisp-ishellwindows-onnavigate
  */
 EXTERN_C
 HRESULT WINAPI
@@ -137,6 +139,7 @@ WinList_NotifyNewLocation(
  *    WinList_FindFolderWindow (SHDOCVW.178)
  *
  * NT 5.0 and higher.
+ * @see https://learn.microsoft.com/en-us/windows/win32/api/exdisp/nf-exdisp-ishellwindows-findwindowsw
  */
 EXTERN_C
 HRESULT WINAPI
@@ -190,6 +193,7 @@ WinList_FindFolderWindow(
  *    WinList_RegisterPending (SHDOCVW.180)
  *
  * NT 5.0 and higher.
+ * @see https://learn.microsoft.com/en-us/windows/win32/api/exdisp/nf-exdisp-ishellwindows-registerpending
  */
 EXTERN_C
 HRESULT WINAPI
@@ -222,6 +226,7 @@ WinList_RegisterPending(
  *    WinList_Revoke (SHDOCVW.181)
  *
  * NT 5.0 and higher.
+ * @see https://learn.microsoft.com/en-us/windows/win32/api/exdisp/nf-exdisp-ishellwindows-revoke
  */
 EXTERN_C
 HRESULT WINAPI

--- a/dll/win32/shdocvw/winlist.cpp
+++ b/dll/win32/shdocvw/winlist.cpp
@@ -214,7 +214,7 @@ WinList_RegisterPending(
         return E_UNEXPECTED;
     }
 
-    IShellWindows *pShellWindows = WinList_GetShellWindows(FALSE);
+    CComPtr<IShellWindows> pShellWindows(WinList_GetShellWindows(FALSE));
     if (!pShellWindows)
     {
         ERR("!pShellWindows\n");

--- a/dll/win32/shdocvw/winlist.cpp
+++ b/dll/win32/shdocvw/winlist.cpp
@@ -1,0 +1,115 @@
+/*
+ * PROJECT:     ReactOS shdocvw
+ * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
+ * PURPOSE:     WinList_* functions
+ * COPYRIGHT:   Copyright 2025 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ */
+
+#include "objects.h"
+
+#include <wine/debug.h>
+WINE_DEFAULT_DEBUG_CHANNEL(shdocvw);
+
+/*************************************************************************
+ *    WinList_Init (SHDOCVW.110)
+ *
+ * Retired in NT 6.1.
+ */
+EXTERN_C
+BOOL WINAPI
+WinList_Init(VOID)
+{
+    FIXME("\n");
+    return FALSE;
+}
+
+/*************************************************************************
+ *    WinList_Terminate (SHDOCVW.111)
+ *
+ * NT 4.71 and higher. Retired in NT 6.1.
+ */
+EXTERN_C
+VOID WINAPI
+WinList_Terminate(VOID)
+{
+    FIXME("\n");
+}
+
+/*************************************************************************
+ *    WinList_GetShellWindows (SHDOCVW.179)
+ *
+ * NT 5.0 and higher.
+ */
+EXTERN_C
+IShellWindows* WINAPI
+WinList_GetShellWindows(
+    _In_ BOOL bCreate)
+{
+    FIXME("\n");
+    return NULL;
+}
+
+/*************************************************************************
+ *    WinList_NotifyNewLocation (SHDOCVW.177)
+ *
+ * NT 5.0 and higher.
+ */
+EXTERN_C
+HRESULT WINAPI
+WinList_NotifyNewLocation(
+    _In_ IShellWindows *pShellWindows,
+    _In_ LONG lCookie,
+    _In_ LPCITEMIDLIST pidl)
+{
+    FIXME("\n");
+    return E_NOTIMPL;
+}
+
+/*************************************************************************
+ *    WinList_FindFolderWindow (SHDOCVW.178)
+ *
+ * NT 5.0 and higher.
+ */
+EXTERN_C
+HRESULT WINAPI
+WinList_FindFolderWindow(
+    _In_ LPCITEMIDLIST pidl,
+    _In_ DWORD dwUnused,
+    _Out_ PINT pnClass,
+    _Out_ PVOID *ppvObj)
+{
+    UNREFERENCED_PARAMETER(dwUnused);
+    FIXME("\n");
+    return E_NOTIMPL;
+}
+
+/*************************************************************************
+ *    WinList_RegisterPending (SHDOCVW.180)
+ *
+ * NT 5.0 and higher.
+ */
+EXTERN_C
+HRESULT WINAPI
+WinList_RegisterPending(
+    _In_ DWORD dwThreadId,
+    _In_ LPCITEMIDLIST pidl,
+    _In_ DWORD dwUnused,
+    _Out_ PLONG plCookie)
+{
+    FIXME("\n");
+    return E_NOTIMPL;
+}
+
+/*************************************************************************
+ *    WinList_Revoke (SHDOCVW.181)
+ *
+ * NT 5.0 and higher.
+ */
+EXTERN_C
+HRESULT WINAPI
+WinList_Revoke(
+    _In_ LONG lCookie)
+{
+    FIXME("\n");
+    return E_NOTIMPL;
+}

--- a/dll/win32/shdocvw/winlist.cpp
+++ b/dll/win32/shdocvw/winlist.cpp
@@ -173,7 +173,7 @@ WinList_FindFolderWindow(
 
     IDispatch *pDispatch = NULL;
     INT options = ppvObj ? (SWFO_NEEDDISPATCH | SWFO_INCLUDEPENDING) : SWFO_INCLUDEPENDING;
-    hr = pShellWindows->FindWindowSW(&varg, &s_vaEmpty, 1, pnClass, options, &pDispatch);
+    hr = pShellWindows->FindWindowSW(&varg, &s_vaEmpty, SWC_BROWSER, pnClass, options, &pDispatch);
     if (pDispatch)
     {
         if (ppvObj)

--- a/dll/win32/shdocvw/winlist.cpp
+++ b/dll/win32/shdocvw/winlist.cpp
@@ -172,7 +172,7 @@ WinList_FindFolderWindow(
     }
 
     IDispatch *pDispatch = NULL;
-    INT options = ppvObj ? (SWFO_NEEDDISPATCH | SWFO_INCLUDEPENDING) : SWFO_INCLUDEPENDING;
+    const INT options = SWFO_INCLUDEPENDING | (ppvObj ? SWFO_NEEDDISPATCH : 0);
     hr = pShellWindows->FindWindowSW(&varg, &s_vaEmpty, SWC_BROWSER, pnClass, options, &pDispatch);
     if (pDispatch)
     {

--- a/dll/win32/shdocvw/winlist.cpp
+++ b/dll/win32/shdocvw/winlist.cpp
@@ -151,7 +151,7 @@ HRESULT WINAPI
 WinList_FindFolderWindow(
     _In_ LPCITEMIDLIST pidl,
     _In_ DWORD dwUnused,
-    _Out_ PLONG phwnd, // HWND but LONG type
+    _Out_opt_ PLONG phwnd, // Stores a window handle but LONG type
     _Out_opt_ PVOID *ppvObj)
 {
     UNREFERENCED_PARAMETER(dwUnused);

--- a/dll/win32/shdocvw/winlist.cpp
+++ b/dll/win32/shdocvw/winlist.cpp
@@ -152,14 +152,14 @@ WinList_FindFolderWindow(
     _In_ LPCITEMIDLIST pidl,
     _In_ DWORD dwUnused,
     _Out_opt_ PLONG phwnd, // Stores a window handle but LONG type
-    _Out_opt_ PVOID *ppvObj)
+    _Out_opt_ IWebBrowserApp **ppWebBrowserApp)
 {
     UNREFERENCED_PARAMETER(dwUnused);
 
-    TRACE("(%p, %ld, %p, %p)\n", pidl, dwUnused, phwnd, ppvObj);
+    TRACE("(%p, %ld, %p, %p)\n", pidl, dwUnused, phwnd, ppWebBrowserApp);
 
-    if (ppvObj)
-        *ppvObj = NULL;
+    if (ppWebBrowserApp)
+        *ppWebBrowserApp = NULL;
 
     if (phwnd)
         *phwnd = 0;
@@ -170,7 +170,7 @@ WinList_FindFolderWindow(
         return E_UNEXPECTED;
     }
 
-    CComPtr<IShellWindows> pShellWindows(WinList_GetShellWindows(ppvObj != NULL));
+    CComPtr<IShellWindows> pShellWindows(WinList_GetShellWindows(ppWebBrowserApp != NULL));
     if (!pShellWindows)
     {
         ERR("!pShellWindows\n");
@@ -183,10 +183,10 @@ WinList_FindFolderWindow(
         return hr;
 
     CComPtr<IDispatch> pDispatch;
-    const INT options = SWFO_INCLUDEPENDING | (ppvObj ? SWFO_NEEDDISPATCH : 0);
+    const INT options = SWFO_INCLUDEPENDING | (ppWebBrowserApp ? SWFO_NEEDDISPATCH : 0);
     hr = pShellWindows->FindWindowSW(&varg, &s_vaEmpty, SWC_BROWSER, phwnd, options, &pDispatch);
-    if (pDispatch && ppvObj)
-        hr = pDispatch->QueryInterface(IID_IWebBrowserApp, ppvObj);
+    if (pDispatch && ppWebBrowserApp)
+        hr = pDispatch->QueryInterface(IID_PPV_ARG(IWebBrowserApp, ppWebBrowserApp));
 
     VariantClearLazy(&varg);
     return hr;

--- a/dll/win32/shdocvw/winlist.cpp
+++ b/dll/win32/shdocvw/winlist.cpp
@@ -216,7 +216,7 @@ WinList_RegisterPending(
     if (FAILED(hr))
         return hr;
 
-    hr = pShellWindows->RegisterPending(dwThreadId, &varg, &s_vaEmpty, 1, plCookie);
+    hr = pShellWindows->RegisterPending(dwThreadId, &varg, &s_vaEmpty, SWC_BROWSER, plCookie);
     VariantClearLazy(&varg);
     return hr;
 }

--- a/dll/win32/shdocvw/winlist.cpp
+++ b/dll/win32/shdocvw/winlist.cpp
@@ -19,7 +19,7 @@ EXTERN_C
 BOOL WINAPI
 WinList_Init(VOID)
 {
-    FIXME("\n");
+    FIXME("()\n");
     return FALSE;
 }
 
@@ -32,7 +32,7 @@ EXTERN_C
 VOID WINAPI
 WinList_Terminate(VOID)
 {
-    FIXME("\n");
+    FIXME("()\n");
 }
 
 /*************************************************************************
@@ -45,7 +45,7 @@ IShellWindows* WINAPI
 WinList_GetShellWindows(
     _In_ BOOL bCreate)
 {
-    FIXME("\n");
+    FIXME("(%d)\n", bCreate);
     return NULL;
 }
 
@@ -61,7 +61,7 @@ WinList_NotifyNewLocation(
     _In_ LONG lCookie,
     _In_ LPCITEMIDLIST pidl)
 {
-    FIXME("\n");
+    FIXME("(%p, %ld, %p)\n", pShellWindows, lCookie, pidl);
     return E_NOTIMPL;
 }
 
@@ -79,7 +79,7 @@ WinList_FindFolderWindow(
     _Out_ PVOID *ppvObj)
 {
     UNREFERENCED_PARAMETER(dwUnused);
-    FIXME("\n");
+    FIXME("(%p, %ld, %p, %p)\n", pidl, dwUnused, pnClass, ppvObj);
     return E_NOTIMPL;
 }
 
@@ -96,7 +96,7 @@ WinList_RegisterPending(
     _In_ DWORD dwUnused,
     _Out_ PLONG plCookie)
 {
-    FIXME("\n");
+    FIXME("(0x%lX, %p, %ld, %p)\n", dwThreadId, pidl, dwUnused, plCookie);
     return E_NOTIMPL;
 }
 
@@ -110,6 +110,13 @@ HRESULT WINAPI
 WinList_Revoke(
     _In_ LONG lCookie)
 {
-    FIXME("\n");
-    return E_NOTIMPL;
+    TRACE("(%ld)\n", lCookie);
+
+    IShellWindows *pShellWindows = WinList_GetShellWindows(TRUE);
+    if (!pShellWindows)
+        return E_FAIL;
+
+    HRESULT hr = pShellWindows->Revoke(lCookie);
+    pShellWindows->Release();
+    return hr;
 }

--- a/dll/win32/shdocvw/winlist.cpp
+++ b/dll/win32/shdocvw/winlist.cpp
@@ -22,7 +22,10 @@ InitVariantFromBuffer(
 
     LPSAFEARRAY pArray = SafeArrayCreateVector(VT_UI1, 0, cb);
     if (!pArray)
+    {
+        ERR("!pArray\n");
         return E_OUTOFMEMORY;
+    }
 
     V_ARRAY(pvarg) = pArray;
     V_VT(pvarg) = VT_ARRAY | VT_UI1;

--- a/dll/win32/shdocvw/winlist.cpp
+++ b/dll/win32/shdocvw/winlist.cpp
@@ -143,18 +143,18 @@ HRESULT WINAPI
 WinList_FindFolderWindow(
     _In_ LPCITEMIDLIST pidl,
     _In_ DWORD dwUnused,
-    _Out_ PLONG pnClass,
+    _Out_ PLONG phwnd, // HWND but LONG type
     _Out_ PVOID *ppvObj)
 {
     UNREFERENCED_PARAMETER(dwUnused);
 
-    TRACE("(%p, %ld, %p, %p)\n", pidl, dwUnused, pnClass, ppvObj);
+    TRACE("(%p, %ld, %p, %p)\n", pidl, dwUnused, phwnd, ppvObj);
 
     if (ppvObj)
         *ppvObj = NULL;
 
-    if (pnClass)
-        *pnClass = 0;
+    if (phwnd)
+        *phwnd = 0;
 
     if (!pidl)
         return E_UNEXPECTED;
@@ -173,7 +173,7 @@ WinList_FindFolderWindow(
 
     IDispatch *pDispatch = NULL;
     const INT options = SWFO_INCLUDEPENDING | (ppvObj ? SWFO_NEEDDISPATCH : 0);
-    hr = pShellWindows->FindWindowSW(&varg, &s_vaEmpty, SWC_BROWSER, pnClass, options, &pDispatch);
+    hr = pShellWindows->FindWindowSW(&varg, &s_vaEmpty, SWC_BROWSER, phwnd, options, &pDispatch);
     if (pDispatch)
     {
         if (ppvObj)

--- a/dll/win32/shdocvw/winlist.cpp
+++ b/dll/win32/shdocvw/winlist.cpp
@@ -170,7 +170,7 @@ WinList_FindFolderWindow(
         return E_UNEXPECTED;
     }
 
-    IShellWindows *pShellWindows = WinList_GetShellWindows(ppvObj != NULL);
+    CComPtr<IShellWindows> pShellWindows(WinList_GetShellWindows(ppvObj != NULL));
     if (!pShellWindows)
     {
         ERR("!pShellWindows\n");
@@ -180,23 +180,15 @@ WinList_FindFolderWindow(
     VARIANTARG varg;
     HRESULT hr = InitVariantFromIDList(&varg, pidl);
     if (FAILED_UNEXPECTEDLY(hr))
-    {
-        pShellWindows->Release();
         return hr;
-    }
 
-    IDispatch *pDispatch = NULL;
+    CComPtr<IDispatch> pDispatch;
     const INT options = SWFO_INCLUDEPENDING | (ppvObj ? SWFO_NEEDDISPATCH : 0);
     hr = pShellWindows->FindWindowSW(&varg, &s_vaEmpty, SWC_BROWSER, phwnd, options, &pDispatch);
-    if (pDispatch)
-    {
-        if (ppvObj)
-            hr = pDispatch->QueryInterface(IID_IWebBrowserApp, ppvObj);
-        pDispatch->Release();
-    }
+    if (pDispatch && ppvObj)
+        hr = pDispatch->QueryInterface(IID_IWebBrowserApp, ppvObj);
 
     VariantClearLazy(&varg);
-    pShellWindows->Release();
     return hr;
 }
 
@@ -252,14 +244,12 @@ WinList_Revoke(
 {
     TRACE("(%ld)\n", lCookie);
 
-    IShellWindows *pShellWindows = WinList_GetShellWindows(TRUE);
+    CComPtr<IShellWindows> pShellWindows(WinList_GetShellWindows(TRUE));
     if (!pShellWindows)
     {
         ERR("!pShellWindows\n");
         return E_FAIL;
     }
 
-    HRESULT hr = pShellWindows->Revoke(lCookie);
-    pShellWindows->Release();
-    return hr;
+    return pShellWindows->Revoke(lCookie);
 }

--- a/dll/win32/shdocvw/winlist.cpp
+++ b/dll/win32/shdocvw/winlist.cpp
@@ -96,7 +96,7 @@ WinList_RegisterPending(
     _In_ DWORD dwUnused,
     _Out_ PLONG plCookie)
 {
-    FIXME("(0x%lX, %p, %ld, %p)\n", dwThreadId, pidl, dwUnused, plCookie);
+    FIXME("(%ld, %p, %ld, %p)\n", dwThreadId, pidl, dwUnused, plCookie);
     return E_NOTIMPL;
 }
 

--- a/sdk/include/reactos/shdocvw_undoc.h
+++ b/sdk/include/reactos/shdocvw_undoc.h
@@ -35,7 +35,7 @@ WinList_FindFolderWindow(
     _In_ LPCITEMIDLIST pidl,
     _In_ DWORD dwUnused,
     _Out_ PLONG phwnd,
-    _Out_ PVOID *ppvObj);
+    _Out_opt_ PVOID *ppvObj);
 
 HRESULT WINAPI
 WinList_RegisterPending(

--- a/sdk/include/reactos/shdocvw_undoc.h
+++ b/sdk/include/reactos/shdocvw_undoc.h
@@ -34,7 +34,7 @@ HRESULT WINAPI
 WinList_FindFolderWindow(
     _In_ LPCITEMIDLIST pidl,
     _In_ DWORD dwUnused,
-    _Out_ PLONG phwnd,
+    _Out_opt_ PLONG phwnd,
     _Out_opt_ PVOID *ppvObj);
 
 HRESULT WINAPI

--- a/sdk/include/reactos/shdocvw_undoc.h
+++ b/sdk/include/reactos/shdocvw_undoc.h
@@ -35,7 +35,7 @@ WinList_FindFolderWindow(
     _In_ LPCITEMIDLIST pidl,
     _In_ DWORD dwUnused,
     _Out_opt_ PLONG phwnd,
-    _Out_opt_ PVOID *ppvObj);
+    _Out_opt_ IWebBrowserApp **ppWebBrowserApp);
 
 HRESULT WINAPI
 WinList_RegisterPending(

--- a/sdk/include/reactos/shdocvw_undoc.h
+++ b/sdk/include/reactos/shdocvw_undoc.h
@@ -2,14 +2,16 @@
  * PROJECT:     ReactOS Headers
  * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
  * PURPOSE:     shdocvw.dll undocumented APIs
- * COPYRIGHT:   Copyright 2024 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ * COPYRIGHT:   Copyright 2024-2025 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  */
 
 #pragma once
 
+#include <exdisp.h> // For IShellWindows
+
 #ifdef __cplusplus
 extern "C" {
-#endif /* defined(__cplusplus) */
+#endif
 
 BOOL WINAPI
 IEILIsEqual(
@@ -17,6 +19,37 @@ IEILIsEqual(
     _In_ LPCITEMIDLIST pidl2,
     _In_ BOOL bUnknown);
 
+BOOL WINAPI WinList_Init(VOID);
+VOID WINAPI WinList_Terminate(VOID);
+
+IShellWindows* WINAPI
+WinList_GetShellWindows(
+    _In_ BOOL bCreate);
+
+HRESULT WINAPI
+WinList_NotifyNewLocation(
+    _In_ IShellWindows *pShellWindows,
+    _In_ LONG lCookie,
+    _In_ LPCITEMIDLIST pidl);
+
+HRESULT WINAPI
+WinList_FindFolderWindow(
+    _In_ LPCITEMIDLIST pidl,
+    _In_ DWORD dwUnused,
+    _Out_ PINT pnClass,
+    _Out_ PVOID *ppvObj);
+
+HRESULT WINAPI
+WinList_RegisterPending(
+    _In_ DWORD dwThreadId,
+    _In_ LPCITEMIDLIST pidl,
+    _In_ DWORD dwUnused,
+    _Out_ PLONG plCookie);
+
+HRESULT WINAPI
+WinList_Revoke(
+    _In_ LONG lCookie);
+
 #ifdef __cplusplus
 } /* extern "C" */
-#endif /* defined(__cplusplus) */
+#endif

--- a/sdk/include/reactos/shdocvw_undoc.h
+++ b/sdk/include/reactos/shdocvw_undoc.h
@@ -21,10 +21,8 @@ IEILIsEqual(
 
 BOOL WINAPI WinList_Init(VOID);
 VOID WINAPI WinList_Terminate(VOID);
-
-IShellWindows* WINAPI
-WinList_GetShellWindows(
-    _In_ BOOL bCreate);
+HRESULT WINAPI WinList_Revoke(_In_ LONG lCookie);
+IShellWindows* WINAPI WinList_GetShellWindows(_In_ BOOL bCreate);
 
 HRESULT WINAPI
 WinList_NotifyNewLocation(
@@ -45,10 +43,6 @@ WinList_RegisterPending(
     _In_ LPCITEMIDLIST pidl,
     _In_ DWORD dwUnused,
     _Out_ PLONG plCookie);
-
-HRESULT WINAPI
-WinList_Revoke(
-    _In_ LONG lCookie);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/sdk/include/reactos/shdocvw_undoc.h
+++ b/sdk/include/reactos/shdocvw_undoc.h
@@ -34,7 +34,7 @@ HRESULT WINAPI
 WinList_FindFolderWindow(
     _In_ LPCITEMIDLIST pidl,
     _In_ DWORD dwUnused,
-    _Out_ PLONG pnClass,
+    _Out_ PLONG phwnd,
     _Out_ PVOID *ppvObj);
 
 HRESULT WINAPI

--- a/sdk/include/reactos/shdocvw_undoc.h
+++ b/sdk/include/reactos/shdocvw_undoc.h
@@ -34,7 +34,7 @@ HRESULT WINAPI
 WinList_FindFolderWindow(
     _In_ LPCITEMIDLIST pidl,
     _In_ DWORD dwUnused,
-    _Out_ PINT pnClass,
+    _Out_ PLONG pnClass,
     _Out_ PVOID *ppvObj);
 
 HRESULT WINAPI

--- a/sdk/include/reactos/undocshell.h
+++ b/sdk/include/reactos/undocshell.h
@@ -928,7 +928,6 @@ BOOL WINAPI SHSettingsChanged(LPCVOID unused, LPCWSTR pszKey);
 #define TABDMC_LOADINPROC 2
 
 void WINAPI ShellDDEInit(BOOL bInit);
-DWORD WINAPI WinList_Init(void);
 
 IStream* WINAPI SHGetViewStream(LPCITEMIDLIST, DWORD, LPCTSTR, LPCTSTR, LPCTSTR);
 


### PR DESCRIPTION
## Purpose
Implementing missing features...
JIRA issue: [CORE-9368](https://jira.reactos.org/browse/CORE-9368)

## Proposed changes

- Modify `shdocvw.spec`.
- Add `dll/win32/shdocvw/winlist.cpp`.
- Add stubs of `WinList_*` functions.
- Add `WinList_*` function prototypes to `<shdocvw_undoc.h>`.
- Adapt `explorer` and `rshell` to new `WinList_Init` prototype.