### PR TITLE
[SHELL32] SEE_MASK_IDLIST should not assume the PIDL is always a FS path

### DIFF
--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -2077,6 +2077,7 @@ static BOOL SHELL_execute(LPSHELLEXECUTEINFOW sei, SHELL_ExecuteW32 execfunc)
         (sei_tmp.fMask & SEE_MASK_INVOKEIDLIST) != SEE_MASK_INVOKEIDLIST)
     {
         LPCITEMIDLIST pidl = (LPCITEMIDLIST)sei_tmp.lpIDList;
+
         CComPtr<IShellExecuteHookW> pSEH;
         HRESULT hr = SHBindToParent(pidl, IID_PPV_ARG(IShellExecuteHookW, &pSEH), NULL);
         if (SUCCEEDED(hr))
@@ -2085,6 +2086,7 @@ static BOOL SHELL_execute(LPSHELLEXECUTEINFOW sei, SHELL_ExecuteW32 execfunc)
             if (hr == S_OK)
                 return TRUE;
         }
+
         hr = SHGetNameAndFlagsW(pidl, SHGDN_FORPARSING, wszApplicationName, dwApplicationNameLen, NULL);
         if (FAILED(hr))
         {


### PR DESCRIPTION
This fixes the execution of `shell:::{645FF040-5081-101B-9F08-00AA002F954E}` in the Run dialog.

The desktop folder parses this string to the PIDL equivalent of `::{645FF040-5081-101B-9F08-00AA002F954E}` (a RegItem PIDL) and `CDefaultContextMenu::InvokePidl` will call back into `ShellExecute`. This PR allows `ShellExecute` to get back the string `::{645FF040-5081-101B-9F08-00AA002F954E}` from the PIDL and `explorer.exe ::{645FF040-5081-101B-9F08-00AA002F954E}` will end up doing the right thing.

JIRA issue: [CORE-16898](https://jira.reactos.org/browse/CORE-16898) (the shell:::{} part).