### PR TITLE
[RTL/x64] Fix a bug in RtlpUnwindInternal

### DIFF
--- a/sdk/lib/rtl/amd64/unwind.c
+++ b/sdk/lib/rtl/amd64/unwind.c
@@ -649,6 +649,18 @@ Exit:
     return NULL;
 }
 
+static __inline
+BOOL
+RtlpIsStackPointerValid(
+    _In_ ULONG64 StackPointer,
+    _In_ ULONG64 LowLimit,
+    _In_ ULONG64 HighLimit)
+{
+    return (StackPointer >= LowLimit) &&
+           (StackPointer < HighLimit) &&
+           ((StackPointer & 7) == 0);
+}
+
 /*!
     \remark The implementation is based on the description in this blog: http://www.nynaeve.net/?p=106
 
@@ -699,6 +711,11 @@ RtlpUnwindInternal(
     /* Start looping */
     while (TRUE)
     {
+        if (!RtlpIsStackPointerValid(UnwindContext.Rsp, StackLow, StackHigh))
+        {
+            return FALSE;
+        }
+
         /* Lookup the FunctionEntry for the current RIP */
         FunctionEntry = RtlLookupFunctionEntry(UnwindContext.Rip, &ImageBase, NULL);
         if (FunctionEntry == NULL)


### PR DESCRIPTION
Check if the stack pointer is out of bounds, before trying to unwind a frame. This will not fix any crashes, but it prevents simple crashes from going into a recursive exception.
