### PR TITLE
[SHELL32] CMenuBand must set ShowWindow value for InvokeCommand

### DIFF
--- a/dll/win32/shell32/shellmenu/CMenuBand.cpp
+++ b/dll/win32/shell32/shellmenu/CMenuBand.cpp
@@ -865,6 +865,7 @@ HRESULT CMenuBand::_TrackContextMenu(IContextMenu * contextMenu, INT x, INT y)
             cmi.fMask |= CMIC_MASK_SHIFT_DOWN;
         if (GetKeyState(VK_CONTROL) < 0)
             cmi.fMask |= CMIC_MASK_CONTROL_DOWN;
+        cmi.nShow = SW_SHOW;
         hr = contextMenu->InvokeCommand(&cmi);
         TRACE("InvokeCommand returned hr=%08x\n", hr);
     }

--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -1461,7 +1461,7 @@ static HRESULT shellex_run_context_menu_default(IShellExtInit *obj,
 
     memset(&ici, 0, sizeof ici);
     ici.cbSize = sizeof ici;
-    ici.fMask = CMIC_MASK_UNICODE | (sei->fMask & (SEE_MASK_NO_CONSOLE | SEE_MASK_NOASYNC | SEE_MASK_ASYNCOK | SEE_MASK_FLAG_NO_UI));
+    ici.fMask = (sei->fMask & SEE_CMIC_COMMON_BASICFLAGS) | CMIC_MASK_UNICODE;
     ici.nShow = sei->nShow;
     ici.lpVerb = MAKEINTRESOURCEA(def);
     ici.hwnd = sei->hwnd;
@@ -1794,7 +1794,7 @@ SHELL_InvokePidl(
 
     // Invoke a command
     CMINVOKECOMMANDINFO ici = { sizeof(ici) };
-    ici.fMask = (sei->fMask & (SEE_MASK_NO_CONSOLE | SEE_MASK_ASYNCOK | SEE_MASK_FLAG_NO_UI));
+    ici.fMask = (sei->fMask & SEE_CMIC_COMMON_BASICFLAGS) & ~CMIC_MASK_UNICODE; // FIXME: Unicode?
     ici.nShow = sei->nShow;
     ici.hwnd = sei->hwnd;
     char szVerb[VERBKEY_CCHMAX];


### PR DESCRIPTION
Some verbs in the right-click menu of start menu entries starts processes with their window hidden because the show command is incorrectly set to SW_HIDE (0).