### PR TITLE
[NTUSER][USER32] Support GetWindow.GW_ENABLEDPOPUP

### DIFF
--- a/win32ss/include/ntuser.h
+++ b/win32ss/include/ntuser.h
@@ -1670,7 +1670,7 @@ enum SimpleCallRoutines
     TWOPARAM_ROUTINE_WOWCLEANUP
 };
 
-DWORD
+DWORD_PTR
 NTAPI
 NtUserCallHwnd(
     HWND hWnd,

--- a/win32ss/user/ntuser/defwnd.c
+++ b/win32ss/user/ntuser/defwnd.c
@@ -526,7 +526,7 @@ DWP_GetEnabledPopup(PWND pWnd)
                      pwndNode2 = pwndNode2->spwndOwner)
                 {
                     if (pwndNode2 == pWnd)
-                        return pwndNode1; /* Found */
+                        return pwndNode1;
                 }
             }
         }

--- a/win32ss/user/ntuser/defwnd.c
+++ b/win32ss/user/ntuser/defwnd.c
@@ -516,8 +516,12 @@ DWP_GetEnabledPopup(PWND pWnd)
 
         /*
          * 1. We want to detect the window that owns the same input target of pWnd.
-         *    The message queue will identify the input target.
-         * 2. 16-bit app has no message queue.
+         * 2. For non-16-bit apps, we need to check the two threads' input queues to
+         *    see whether they are the same, while for 16-bit apps it's sufficient to
+         *    only check the thread info pointers themselves (ptiNode and pti).
+         * See also:
+         *    https://devblogs.microsoft.com/oldnewthing/20060221-09/?p=32203
+         *    https://github.com/reactos/reactos/pull/7700#discussion_r1939435931
          */
         ptiNode = pwndNode1->head.pti;
         if ((!(pti->TIF_flags & TIF_16BIT) && ptiNode->MessageQueue == pti->MessageQueue) ||

--- a/win32ss/user/ntuser/defwnd.c
+++ b/win32ss/user/ntuser/defwnd.c
@@ -505,11 +505,12 @@ DWP_GetEnabledPopup(PWND pWnd)
 
     for (pwndNode1 = pWnd->spwndNext; pwndNode1 != pWnd; )
     {
-        if (!pwndNode1)
+        if (!pwndNode1) /* NULL detected? */
         {
             if (bFoundNullNode)
                 return NULL;
             bFoundNullNode = TRUE;
+            /* Retry with parent's first child (once only) */
             pwndNode1 = pWnd->spwndParent->spwndChild;
             continue;
         }

--- a/win32ss/user/ntuser/defwnd.c
+++ b/win32ss/user/ntuser/defwnd.c
@@ -515,7 +515,8 @@ DWP_GetEnabledPopup(PWND pWnd)
         }
 
         ptiNode = pwndNode1->head.pti;
-        if (ptiNode->MessageQueue == pti->MessageQueue) /* Same message queue? */
+        if ((!(pti->TIF_flags & TIF_16BIT) && ptiNode->MessageQueue == pti->MessageQueue) ||
+            ((pti->TIF_flags & TIF_16BIT) && ptiNode == pti))
         {
             style = pwndNode1->style;
             if ((style & WS_VISIBLE) && !(style & WS_DISABLED)) /* Visible and enabled? */

--- a/win32ss/user/ntuser/defwnd.c
+++ b/win32ss/user/ntuser/defwnd.c
@@ -514,6 +514,11 @@ DWP_GetEnabledPopup(PWND pWnd)
             continue;
         }
 
+        /*
+         * 1. We want to detect the window that owns the same input target of pWnd.
+         *    The message queue will identify the input target.
+         * 2. 16-bit app has no message queue.
+         */
         ptiNode = pwndNode1->head.pti;
         if ((!(pti->TIF_flags & TIF_16BIT) && ptiNode->MessageQueue == pti->MessageQueue) ||
             ((pti->TIF_flags & TIF_16BIT) && ptiNode == pti))

--- a/win32ss/user/ntuser/defwnd.c
+++ b/win32ss/user/ntuser/defwnd.c
@@ -498,9 +498,8 @@ DefWndGetIcon(PWND pWnd, WPARAM wParam, LPARAM lParam)
 PWND FASTCALL
 DWP_GetEnabledPopup(PWND pWnd)
 {
-    PWND pwndNode1, pwndNode2;
+    PWND pwndNode1;
     PTHREADINFO pti = pWnd->head.pti, ptiNode;
-    DWORD style;
     BOOL bFoundNullNode = FALSE;
 
     for (pwndNode1 = pWnd->spwndNext; pwndNode1 != pWnd; )
@@ -519,10 +518,11 @@ DWP_GetEnabledPopup(PWND pWnd)
         if ((!(pti->TIF_flags & TIF_16BIT) && ptiNode->MessageQueue == pti->MessageQueue) ||
             ((pti->TIF_flags & TIF_16BIT) && ptiNode == pti))
         {
-            style = pwndNode1->style;
+            DWORD style = pwndNode1->style;
             if ((style & WS_VISIBLE) && !(style & WS_DISABLED)) /* Visible and enabled? */
             {
                 /* Does pwndNode1 have a pWnd as an ancestor? */
+                PWND pwndNode2;
                 for (pwndNode2 = pwndNode1->spwndOwner; pwndNode2;
                      pwndNode2 = pwndNode2->spwndOwner)
                 {

--- a/win32ss/user/ntuser/simplecall.c
+++ b/win32ss/user/ntuser/simplecall.c
@@ -706,7 +706,7 @@ NtUserCallHwndOpt(
     return hWnd;
 }
 
-DWORD
+DWORD_PTR
 APIENTRY
 NtUserCallHwnd(
     HWND hWnd,
@@ -754,6 +754,17 @@ NtUserCallHwnd(
             }
             UserLeave();
             return FALSE;
+        }
+
+        case HWND_ROUTINE_DWP_GETENABLEDPOPUP:
+        {
+            PWND pWnd;
+            UserEnterExclusive();
+            pWnd = UserGetWindowObject(hWnd);
+            if (pWnd)
+                pWnd = DWP_GetEnabledPopup(pWnd);
+            UserLeave();
+            return (DWORD_PTR)pWnd;
         }
     }
 

--- a/win32ss/user/ntuser/simplecall.c
+++ b/win32ss/user/ntuser/simplecall.c
@@ -759,7 +759,7 @@ NtUserCallHwnd(
         case HWND_ROUTINE_DWP_GETENABLEDPOPUP:
         {
             PWND pWnd;
-            UserEnterExclusive();
+            UserEnterShared();
             pWnd = UserGetWindowObject(hWnd);
             if (pWnd)
                 pWnd = DWP_GetEnabledPopup(pWnd);

--- a/win32ss/user/ntuser/userfuncs.h
+++ b/win32ss/user/ntuser/userfuncs.h
@@ -161,6 +161,7 @@ LRESULT NC_HandleNCRButtonDown( PWND wnd, WPARAM wParam, LPARAM lParam );
 HBRUSH FASTCALL DefWndControlColor(HDC hDC,UINT ctlType);
 BOOL UserDrawSysMenuButton(PWND pWnd, HDC hDC, LPRECT Rect, BOOL Down);
 BOOL UserPaintCaption(PWND pWnd, INT Flags);
+PWND FASTCALL DWP_GetEnabledPopup(PWND pWnd);
 
 /************** LAYERED **************/
 

--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -427,10 +427,6 @@ IntGetWindow(HWND hWnd,
                     FoundWnd = FoundWnd->spwndNext;
                 break;
 
-            case GW_ENABLEDPOPUP:
-                FoundWnd = DWP_GetEnabledPopup(Wnd);
-                break;
-
             default:
                 EngSetLastError(ERROR_INVALID_GW_COMMAND);
                 break;

--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -427,8 +427,12 @@ IntGetWindow(HWND hWnd,
                     FoundWnd = FoundWnd->spwndNext;
                 break;
 
+            case GW_ENABLEDPOPUP:
+                FoundWnd = DWP_GetEnabledPopup(Wnd);
+                break;
+
             default:
-                Wnd = NULL;
+                EngSetLastError(ERROR_INVALID_GW_COMMAND);
                 break;
     }
 

--- a/win32ss/user/user32/include/ntwrapper.h
+++ b/win32ss/user/user32/include/ntwrapper.h
@@ -725,22 +725,22 @@ EXTINLINE VOID NtUserxNotifyWinEvent(HWND hWnd, PVOID ne)
 
 EXTINLINE DWORD NtUserxGetWindowContextHelpId(HWND hwnd)
 {
-    return NtUserCallHwnd(hwnd, HWND_ROUTINE_GETWNDCONTEXTHLPID);
+    return (DWORD)NtUserCallHwnd(hwnd, HWND_ROUTINE_GETWNDCONTEXTHLPID);
 }
 
 EXTINLINE BOOL NtUserxDeregisterShellHookWindow(HWND hWnd)
 {
-    return NtUserCallHwnd(hWnd, HWND_ROUTINE_DEREGISTERSHELLHOOKWINDOW);
+    return (BOOL)NtUserCallHwnd(hWnd, HWND_ROUTINE_DEREGISTERSHELLHOOKWINDOW);
 }
 
 EXTINLINE BOOL NtUserxRegisterShellHookWindow(HWND hWnd)
 {
-    return NtUserCallHwnd(hWnd, HWND_ROUTINE_REGISTERSHELLHOOKWINDOW);
+    return (BOOL)NtUserCallHwnd(hWnd, HWND_ROUTINE_REGISTERSHELLHOOKWINDOW);
 }
 
 EXTINLINE BOOL NtUserxSetMessageBox(HWND hWnd)
 {
-    return NtUserCallHwnd(hWnd, HWND_ROUTINE_SETMSGBOX);
+    return (BOOL)NtUserCallHwnd(hWnd, HWND_ROUTINE_SETMSGBOX);
 }
 
 EXTINLINE VOID NtUserxClearWindowState(PWND pWnd, UINT Flag)

--- a/win32ss/user/user32/windows/window.c
+++ b/win32ss/user/user32/windows/window.c
@@ -1150,8 +1150,10 @@ GetWindow(HWND hWnd,
             }
 
             default:
-                Wnd = NULL;
+            {
+                UserSetLastError(ERROR_INVALID_GW_COMMAND);
                 break;
+            }
         }
 
         if (FoundWnd != NULL)

--- a/win32ss/user/user32/windows/window.c
+++ b/win32ss/user/user32/windows/window.c
@@ -1141,6 +1141,14 @@ GetWindow(HWND hWnd,
                     FoundWnd = DesktopPtrToUser(FoundWnd->spwndNext);
                 break;
 
+            case GW_ENABLEDPOPUP:
+            {
+                PWND pwndPopup = (PWND)NtUserCallHwnd(hWnd, HWND_ROUTINE_DWP_GETENABLEDPOPUP);
+                if (pwndPopup)
+                    FoundWnd = DesktopPtrToUser(pwndPopup);
+                break;
+            }
+
             default:
                 Wnd = NULL;
                 break;


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-6920](https://jira.reactos.org/browse/CORE-6920)

## Proposed changes

- Make the return value of `NtUserCallHwnd` a `DWORD_PTR`.
- Add `DWP_GetEnabledPopup` helper function in `win32ss/user/ntuser/defwnd.c`.
- Add code to `NtUserCallHwnd` for `HWND_ROUTINE_DWP_GETENABLEDPOPUP`.
- Add code to `GetWindow` for `GW_ENABLEDPOPUP`.
- Set last error in `GetWindow` and `IntGetWindow`.

## TODO

- [x] Do tests.

## Comparison

WinXP:
![WinXP](https://github.com/user-attachments/assets/5ed27310-6aff-4484-9c36-cdeb5cddecb0)
Successful.

Win2k3:
![Win2k3](https://github.com/user-attachments/assets/719e23c7-1a09-441c-8879-4c5137421198)
Successful.

Win10:
![Win10](https://github.com/user-attachments/assets/d3027cf1-61bb-490a-93a3-2959390a0c20)
Successful.

ReactOS (BEFORE):
![before](https://github.com/user-attachments/assets/b6a4c1ff-6b9c-49a5-bbdb-59524a9e2ba6)
8 failures.

ReactOS (AFTER):
![after](https://github.com/user-attachments/assets/6540959a-fe78-4859-a956-92317b973c53)
2 failures. Maybe Z-order problem?