### PR TITLE
[SHDOCVW_APITEST] Add WinList testcase

### DIFF
--- a/modules/rostests/apitests/shdocvw/CMakeLists.txt
+++ b/modules/rostests/apitests/shdocvw/CMakeLists.txt
@@ -1,6 +1,7 @@
 
 list(APPEND SOURCE
     MRUList.cpp
+    WinList.cpp
     testlist.c)
 
 add_executable(shdocvw_apitest ${SOURCE})

--- a/modules/rostests/apitests/shdocvw/WinList.cpp
+++ b/modules/rostests/apitests/shdocvw/WinList.cpp
@@ -41,7 +41,7 @@ TEST_WinList_GetShellWindows(VOID)
     {
         LONG nCount = -1;
         HRESULT hr = pShellWindows1->get_Count(&nCount);
-        ok_long(hr, S_OK);
+        ok_hex(hr, S_OK);
         ok(nCount >= 0, "nCount was %ld\n", nCount);
 
         pShellWindows1->Release();
@@ -74,7 +74,7 @@ TEST_CLSID_ShellWindows(VOID)
     {
         LONG nCount = -1;
         HRESULT hr = pShellWindows->get_Count(&nCount);
-        ok_long(hr, S_OK);
+        ok_hex(hr, S_OK);
         ok(nCount >= 0, "nCount was %ld\n", nCount);
 
         pShellWindows->Release();

--- a/modules/rostests/apitests/shdocvw/WinList.cpp
+++ b/modules/rostests/apitests/shdocvw/WinList.cpp
@@ -1,7 +1,7 @@
 /*
  * PROJECT:     ReactOS api tests
  * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
- * PURPOSE:     Tests for shdocvw!WinList_*
+ * PURPOSE:     Tests for shdocvw!WinList_* functions
  * COPYRIGHT:   Copyright 2025 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  */
 

--- a/modules/rostests/apitests/shdocvw/WinList.cpp
+++ b/modules/rostests/apitests/shdocvw/WinList.cpp
@@ -92,26 +92,36 @@ TEST_SHDOCVW_WinList(VOID)
 static VOID
 TEST_CLSID_ShellWindows(VOID)
 {
-    IShellWindows *pShellWindows = NULL;
+    IShellWindows *pShellWindows1 = NULL;
     CoCreateInstance(CLSID_ShellWindows, NULL, CLSCTX_INPROC_SERVER | CLSCTX_LOCAL_SERVER,
-                     IID_IShellWindows, (LPVOID *)&pShellWindows);
-    ok(pShellWindows != NULL, "pShellWindows was null\n");
+                     IID_IShellWindows, (LPVOID *)&pShellWindows1);
+    ok(pShellWindows1 != NULL, "pShellWindows1 was null\n");
 
-    if (pShellWindows)
+    IShellWindows *pShellWindows2 = NULL;
+    CoCreateInstance(CLSID_ShellWindows, NULL, CLSCTX_INPROC_SERVER | CLSCTX_LOCAL_SERVER,
+                     IID_IShellWindows, (LPVOID *)&pShellWindows2);
+    ok(pShellWindows2 != NULL, "pShellWindows2 was null\n");
+
+    ok_ptr(pShellWindows1, pShellWindows2);
+
+    if (pShellWindows1)
     {
         LONG nCount = -1;
-        HRESULT hr = pShellWindows->get_Count(&nCount);
+        HRESULT hr = pShellWindows1->get_Count(&nCount);
         ok_hex(hr, S_OK);
         ok(nCount >= 0, "nCount was %ld\n", nCount);
         trace("%ld\n", nCount);
 
-        pShellWindows->Release();
+        pShellWindows1->Release();
     }
     else
     {
         ok_int(TRUE, FALSE);
         ok_int(TRUE, FALSE);
     }
+
+    if (pShellWindows1 != pShellWindows2 && pShellWindows2)
+        pShellWindows2->Release();
 }
 
 START_TEST(WinList)

--- a/modules/rostests/apitests/shdocvw/WinList.cpp
+++ b/modules/rostests/apitests/shdocvw/WinList.cpp
@@ -64,6 +64,26 @@ TEST_WinList_GetShellWindows(VOID)
 }
 
 static VOID
+TEST_WinList_Mix(VOID)
+{
+    IShellWindows *pShellWindows1 = g_pWinList_GetShellWindows(FALSE);
+    trace("%p\n", pShellWindows1);
+    ok(pShellWindows1 != NULL, "pShellWindows1 was null\n");
+
+    IShellWindows *pShellWindows2 = NULL;
+    CoCreateInstance(CLSID_ShellWindows, NULL, CLSCTX_INPROC_SERVER | CLSCTX_LOCAL_SERVER,
+                     IID_IShellWindows, (LPVOID *)&pShellWindows2);
+    ok(pShellWindows2 != NULL, "pShellWindows2 was null\n");
+
+    ok_ptr(pShellWindows1, pShellWindows2);
+
+    if (pShellWindows1)
+        pShellWindows1->Release();
+    if (pShellWindows1 != pShellWindows2 && pShellWindows2)
+        pShellWindows2->Release();
+}
+
+static VOID
 TEST_SHDOCVW_WinList(VOID)
 {
     HINSTANCE hSHDOCVW = LoadLibraryW(L"shdocvw.dll");
@@ -84,6 +104,7 @@ TEST_SHDOCVW_WinList(VOID)
     else
     {
         TEST_WinList_GetShellWindows();
+        TEST_WinList_Mix();
     }
 
     FreeLibrary(hSHDOCVW);

--- a/modules/rostests/apitests/shdocvw/WinList.cpp
+++ b/modules/rostests/apitests/shdocvw/WinList.cpp
@@ -63,30 +63,6 @@ TEST_WinList_GetShellWindows(VOID)
 }
 
 static VOID
-TEST_CLSID_ShellWindows(VOID)
-{
-    IShellWindows *pShellWindows = NULL;
-    CoCreateInstance(CLSID_ShellWindows, NULL, CLSCTX_INPROC_SERVER | CLSCTX_LOCAL_SERVER,
-                     IID_IShellWindows, (LPVOID *)&pShellWindows);
-    ok(pShellWindows != NULL, "pShellWindows was null\n");
-
-    if (pShellWindows)
-    {
-        LONG nCount = -1;
-        HRESULT hr = pShellWindows->get_Count(&nCount);
-        ok_hex(hr, S_OK);
-        ok(nCount >= 0, "nCount was %ld\n", nCount);
-
-        pShellWindows->Release();
-    }
-    else
-    {
-        ok_int(TRUE, FALSE);
-        ok_int(TRUE, FALSE);
-    }
-}
-
-static VOID
 TEST_SHDOCVW_WinList(VOID)
 {
     HINSTANCE hSHDOCVW = LoadLibraryW(L"shdocvw.dll");
@@ -110,6 +86,30 @@ TEST_SHDOCVW_WinList(VOID)
     }
 
     FreeLibrary(hSHDOCVW);
+}
+
+static VOID
+TEST_CLSID_ShellWindows(VOID)
+{
+    IShellWindows *pShellWindows = NULL;
+    CoCreateInstance(CLSID_ShellWindows, NULL, CLSCTX_INPROC_SERVER | CLSCTX_LOCAL_SERVER,
+                     IID_IShellWindows, (LPVOID *)&pShellWindows);
+    ok(pShellWindows != NULL, "pShellWindows was null\n");
+
+    if (pShellWindows)
+    {
+        LONG nCount = -1;
+        HRESULT hr = pShellWindows->get_Count(&nCount);
+        ok_hex(hr, S_OK);
+        ok(nCount >= 0, "nCount was %ld\n", nCount);
+
+        pShellWindows->Release();
+    }
+    else
+    {
+        ok_int(TRUE, FALSE);
+        ok_int(TRUE, FALSE);
+    }
 }
 
 START_TEST(WinList)

--- a/modules/rostests/apitests/shdocvw/WinList.cpp
+++ b/modules/rostests/apitests/shdocvw/WinList.cpp
@@ -86,31 +86,37 @@ TEST_CLSID_ShellWindows(VOID)
     }
 }
 
-START_TEST(WinList)
+static VOID
+TEST_SHDOCVW_WinList(VOID)
 {
-    HRESULT hrCoInit = CoInitialize(NULL);
-
     HINSTANCE hSHDOCVW = LoadLibraryW(L"shdocvw.dll");
     if (!hSHDOCVW)
     {
         skip("shdocvw.dll not loaded\n");
+        return;
+    }
+
+    g_pWinList_Init = (FN_WinList_Init)GetProcAddress(hSHDOCVW, MAKEINTRESOURCEA(110));
+    g_pWinList_Terminate = (FN_WinList_Terminate)GetProcAddress(hSHDOCVW, MAKEINTRESOURCEA(111));
+    g_pWinList_GetShellWindows = (FN_WinList_GetShellWindows)GetProcAddress(hSHDOCVW, MAKEINTRESOURCEA(179));
+    if (!g_pWinList_Init || !g_pWinList_Terminate || !g_pWinList_GetShellWindows)
+    {
+        skip("Some WinList_* functions not found: %p %p %p\n",
+             g_pWinList_Init, g_pWinList_Terminate, g_pWinList_GetShellWindows);
     }
     else
     {
-        g_pWinList_Init = (FN_WinList_Init)GetProcAddress(hSHDOCVW, MAKEINTRESOURCEA(110));
-        g_pWinList_Terminate = (FN_WinList_Terminate)GetProcAddress(hSHDOCVW, MAKEINTRESOURCEA(111));
-        g_pWinList_GetShellWindows = (FN_WinList_GetShellWindows)GetProcAddress(hSHDOCVW, MAKEINTRESOURCEA(179));
-        if (!g_pWinList_Init || !g_pWinList_Terminate || !g_pWinList_GetShellWindows)
-        {
-            skip("Some WinList_* functions not found: %p %p %p\n",
-                 g_pWinList_Init, g_pWinList_Terminate, g_pWinList_GetShellWindows);
-        }
-        else
-        {
-            TEST_WinList_GetShellWindows();
-        }
+        TEST_WinList_GetShellWindows();
     }
 
+    FreeLibrary(hSHDOCVW);
+}
+
+START_TEST(WinList)
+{
+    HRESULT hrCoInit = CoInitialize(NULL);
+
+    TEST_SHDOCVW_WinList();
     TEST_CLSID_ShellWindows();
 
     if (SUCCEEDED(hrCoInit))

--- a/modules/rostests/apitests/shdocvw/WinList.cpp
+++ b/modules/rostests/apitests/shdocvw/WinList.cpp
@@ -1,0 +1,79 @@
+/*
+ * PROJECT:     ReactOS api tests
+ * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
+ * PURPOSE:     Tests for shdocvw!WinList_*
+ * COPYRIGHT:   Copyright 2025 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ */
+
+#include <apitest.h>
+#include <shlwapi.h>
+#include <shlobj.h>
+#include <shlobj_undoc.h>
+#include <shlguid_undoc.h>
+#include <shlwapi_undoc.h>
+#include <versionhelpers.h>
+
+typedef BOOL (WINAPI *FN_WinList_Init)(VOID);
+typedef VOID (WINAPI *FN_WinList_Terminate)(VOID);
+typedef IShellWindows* (WINAPI *FN_WinList_GetShellWindows)(BOOL);
+
+static FN_WinList_Init g_pWinList_Init = NULL;
+static FN_WinList_Terminate g_pWinList_Terminate = NULL;
+static FN_WinList_GetShellWindows g_pWinList_GetShellWindows = NULL;
+
+static VOID
+TEST_WinList(VOID)
+{
+    BOOL bInited = g_pWinList_Init && g_pWinList_Init();
+    ok_int(bInited, FALSE); // WinList_Init should fail because this process is not explorer.exe
+
+    IShellWindows *pShellWindows = g_pWinList_GetShellWindows(FALSE);
+    ok(pShellWindows != NULL, "pShellWindows was null\n");
+
+    if (pShellWindows)
+    {
+        LONG nCount = -1;
+        HRESULT hr = pShellWindows->get_Count(&nCount);
+        ok_long(hr, S_OK);
+        ok(nCount >= 0, "nCount was %ld\n", nCount);
+
+        pShellWindows->Release();
+    }
+    else
+    {
+        ok_int(TRUE, FALSE);
+        ok_int(TRUE, FALSE);
+    }
+
+    if (bInited && g_pWinList_Terminate)
+        g_pWinList_Terminate();
+}
+
+START_TEST(WinList)
+{
+    HRESULT hrCoInit = CoInitialize(NULL);
+
+    HINSTANCE hSHDOCVW = LoadLibraryW(L"shdocvw.dll");
+    if (!hSHDOCVW)
+    {
+        skip("shdocvw.dll not loaded\n");
+    }
+    else
+    {
+        g_pWinList_Init = (FN_WinList_Init)GetProcAddress(hSHDOCVW, MAKEINTRESOURCEA(110));
+        g_pWinList_Terminate = (FN_WinList_Terminate)GetProcAddress(hSHDOCVW, MAKEINTRESOURCEA(111));
+        g_pWinList_GetShellWindows = (FN_WinList_GetShellWindows)GetProcAddress(hSHDOCVW, MAKEINTRESOURCEA(179));
+        if (!g_pWinList_Init || !g_pWinList_Terminate || !g_pWinList_GetShellWindows)
+        {
+            skip("Some WinList_* functions not found: %p %p %p\n",
+                 g_pWinList_Init, g_pWinList_Terminate, g_pWinList_GetShellWindows);
+        }
+        else
+        {
+            TEST_WinList();
+        }
+    }
+
+    if (SUCCEEDED(hrCoInit))
+        CoUninitialize();
+}

--- a/modules/rostests/apitests/shdocvw/WinList.cpp
+++ b/modules/rostests/apitests/shdocvw/WinList.cpp
@@ -22,28 +22,46 @@ static FN_WinList_Terminate g_pWinList_Terminate = NULL;
 static FN_WinList_GetShellWindows g_pWinList_GetShellWindows = NULL;
 
 static VOID
-TEST_WinList(VOID)
+TEST_WinList_GetShellWindows(VOID)
 {
     BOOL bInited = g_pWinList_Init && g_pWinList_Init();
     ok_int(bInited, FALSE); // WinList_Init should fail because this process is not explorer.exe
 
-    IShellWindows *pShellWindows = g_pWinList_GetShellWindows(FALSE);
-    ok(pShellWindows != NULL, "pShellWindows was null\n");
+    IShellWindows *pShellWindows1 = g_pWinList_GetShellWindows(FALSE);
+    trace("%p\n", pShellWindows1);
+    ok(pShellWindows1 != NULL, "pShellWindows1 was null\n");
 
-    if (pShellWindows)
+    IShellWindows *pShellWindows2 = g_pWinList_GetShellWindows(FALSE);
+    trace("%p\n", pShellWindows2);
+    ok(pShellWindows2 != NULL, "pShellWindows2 was null\n");
+
+    IShellWindows *pShellWindows3 = g_pWinList_GetShellWindows(TRUE);
+    trace("%p\n", pShellWindows3);
+    ok(pShellWindows3 != NULL, "pShellWindows3 was null\n");
+
+    ok_ptr(pShellWindows1, pShellWindows2);
+    ok_ptr(pShellWindows2, pShellWindows3);
+
+    if (pShellWindows1)
     {
         LONG nCount = -1;
-        HRESULT hr = pShellWindows->get_Count(&nCount);
+        HRESULT hr = pShellWindows1->get_Count(&nCount);
         ok_long(hr, S_OK);
         ok(nCount >= 0, "nCount was %ld\n", nCount);
 
-        pShellWindows->Release();
+        pShellWindows1->Release();
     }
     else
     {
         ok_int(TRUE, FALSE);
         ok_int(TRUE, FALSE);
     }
+
+    if (pShellWindows1 != pShellWindows2 && pShellWindows2)
+        pShellWindows2->Release();
+
+    if (pShellWindows1 != pShellWindows2 && pShellWindows2 != pShellWindows3 && pShellWindows3)
+        pShellWindows3->Release();
 
     if (bInited && g_pWinList_Terminate)
         g_pWinList_Terminate();
@@ -70,7 +88,7 @@ START_TEST(WinList)
         }
         else
         {
-            TEST_WinList();
+            TEST_WinList_GetShellWindows();
         }
     }
 

--- a/modules/rostests/apitests/shdocvw/WinList.cpp
+++ b/modules/rostests/apitests/shdocvw/WinList.cpp
@@ -43,6 +43,7 @@ TEST_WinList_GetShellWindows(VOID)
         HRESULT hr = pShellWindows1->get_Count(&nCount);
         ok_hex(hr, S_OK);
         ok(nCount >= 0, "nCount was %ld\n", nCount);
+        trace("%ld\n", nCount);
 
         pShellWindows1->Release();
     }
@@ -102,6 +103,7 @@ TEST_CLSID_ShellWindows(VOID)
         HRESULT hr = pShellWindows->get_Count(&nCount);
         ok_hex(hr, S_OK);
         ok(nCount >= 0, "nCount was %ld\n", nCount);
+        trace("%ld\n", nCount);
 
         pShellWindows->Release();
     }

--- a/modules/rostests/apitests/shdocvw/WinList.cpp
+++ b/modules/rostests/apitests/shdocvw/WinList.cpp
@@ -62,6 +62,30 @@ TEST_WinList_GetShellWindows(VOID)
         g_pWinList_Terminate();
 }
 
+static VOID
+TEST_CLSID_ShellWindows(VOID)
+{
+    IShellWindows *pShellWindows = NULL;
+    CoCreateInstance(CLSID_ShellWindows, NULL, CLSCTX_INPROC_SERVER | CLSCTX_LOCAL_SERVER,
+                     IID_IShellWindows, (LPVOID *)&pShellWindows);
+    ok(pShellWindows != NULL, "pShellWindows was null\n");
+
+    if (pShellWindows)
+    {
+        LONG nCount = -1;
+        HRESULT hr = pShellWindows->get_Count(&nCount);
+        ok_long(hr, S_OK);
+        ok(nCount >= 0, "nCount was %ld\n", nCount);
+
+        pShellWindows->Release();
+    }
+    else
+    {
+        ok_int(TRUE, FALSE);
+        ok_int(TRUE, FALSE);
+    }
+}
+
 START_TEST(WinList)
 {
     HRESULT hrCoInit = CoInitialize(NULL);
@@ -86,6 +110,8 @@ START_TEST(WinList)
             TEST_WinList_GetShellWindows();
         }
     }
+
+    TEST_CLSID_ShellWindows();
 
     if (SUCCEEDED(hrCoInit))
         CoUninitialize();

--- a/modules/rostests/apitests/shdocvw/WinList.cpp
+++ b/modules/rostests/apitests/shdocvw/WinList.cpp
@@ -53,10 +53,10 @@ TEST_WinList_GetShellWindows(VOID)
         ok_int(TRUE, FALSE);
     }
 
-    if (pShellWindows1 != pShellWindows2 && pShellWindows2)
+    if (pShellWindows2)
         pShellWindows2->Release();
 
-    if (pShellWindows1 != pShellWindows2 && pShellWindows2 != pShellWindows3 && pShellWindows3)
+    if (pShellWindows3)
         pShellWindows3->Release();
 
     if (bInited && g_pWinList_Terminate)
@@ -79,7 +79,7 @@ TEST_WinList_Mix(VOID)
 
     if (pShellWindows1)
         pShellWindows1->Release();
-    if (pShellWindows1 != pShellWindows2 && pShellWindows2)
+    if (pShellWindows2)
         pShellWindows2->Release();
 }
 
@@ -141,7 +141,7 @@ TEST_CLSID_ShellWindows(VOID)
         ok_int(TRUE, FALSE);
     }
 
-    if (pShellWindows1 != pShellWindows2 && pShellWindows2)
+    if (pShellWindows2)
         pShellWindows2->Release();
 }
 

--- a/modules/rostests/apitests/shdocvw/WinList.cpp
+++ b/modules/rostests/apitests/shdocvw/WinList.cpp
@@ -55,7 +55,7 @@ TEST_WinList_GetShellWindows(VOID)
     if (pShellWindows1 != pShellWindows2 && pShellWindows2)
         pShellWindows2->Release();
 
-    if (pShellWindows2 != pShellWindows3 && pShellWindows3)
+    if (pShellWindows1 != pShellWindows2 && pShellWindows2 != pShellWindows3 && pShellWindows3)
         pShellWindows3->Release();
 
     if (bInited && g_pWinList_Terminate)

--- a/modules/rostests/apitests/shdocvw/WinList.cpp
+++ b/modules/rostests/apitests/shdocvw/WinList.cpp
@@ -6,12 +6,7 @@
  */
 
 #include <apitest.h>
-#include <shlwapi.h>
 #include <shlobj.h>
-#include <shlobj_undoc.h>
-#include <shlguid_undoc.h>
-#include <shlwapi_undoc.h>
-#include <versionhelpers.h>
 
 typedef BOOL (WINAPI *FN_WinList_Init)(VOID);
 typedef VOID (WINAPI *FN_WinList_Terminate)(VOID);
@@ -60,7 +55,7 @@ TEST_WinList_GetShellWindows(VOID)
     if (pShellWindows1 != pShellWindows2 && pShellWindows2)
         pShellWindows2->Release();
 
-    if (pShellWindows1 != pShellWindows2 && pShellWindows2 != pShellWindows3 && pShellWindows3)
+    if (pShellWindows2 != pShellWindows3 && pShellWindows3)
         pShellWindows3->Release();
 
     if (bInited && g_pWinList_Terminate)

--- a/modules/rostests/apitests/shdocvw/testlist.c
+++ b/modules/rostests/apitests/shdocvw/testlist.c
@@ -2,9 +2,11 @@
 #include <apitest.h>
 
 extern void func_MRUList(void);
+extern void func_WinList(void);
 
 const struct test winetest_testlist[] =
 {
     { "MRUList", func_MRUList },
+    { "WinList", func_WinList },
     { 0, 0 }
 };


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-9368](https://jira.reactos.org/browse/CORE-9368)

## Proposed changes

- Add `WinList` testcase for `CLSID_ShellWindows` class and `shdocvw!WinList_*` functions.

## TODO

- [x] Do tests.

## Comparison

WinXP:
![WinXP](https://github.com/user-attachments/assets/35d7a54c-9d63-4dbf-84d0-92ffd6ee13fb)
Successful.

Win2k3:
![Win2k3](https://github.com/user-attachments/assets/6d04db99-cbbf-41f9-991f-0fa2c4efa14a)
Successful.

Win10:
![Win10](https://github.com/user-attachments/assets/6c697faf-dedd-4333-a5a4-b6e7b6732f4d)
Partially skipped.