### PR TITLE
[SETUPAPI] Fix wrong registry key opened by SetupDiCreateDeviceInterfaceRegKeyW()

### DIFF
--- a/dll/win32/setupapi/devinst.c
+++ b/dll/win32/setupapi/devinst.c
@@ -2618,9 +2618,9 @@ HKEY WINAPI SetupDiCreateDeviceInterfaceRegKeyW(
         HINF InfHandle,
         PCWSTR InfSectionName)
 {
-    HKEY hKey, hDevKey;
-    LPWSTR SymbolicLink;
-    DWORD Length, Index;
+    HKEY hKey, hDevKey, hRefKey, hDevParamKey;
+    LPWSTR SymbolicLink, ReferenceString;
+    DWORD Length, RefLength, Index;
     LONG rc;
     WCHAR bracedGuidString[39];
     struct DeviceInterface *DevItf;
@@ -2681,9 +2681,17 @@ HKEY WINAPI SetupDiCreateDeviceInterfaceRegKeyW(
 
     wcscpy(SymbolicLink, DevItf->SymbolicLink);
 
+    /* Enumerate all characters in symbolic link */
     Index = 0;
     while(SymbolicLink[Index])
     {
+        /* Check for a start position of reference string */
+        if (SymbolicLink[Index] == L'}' && SymbolicLink[Index + 1] == L'\\')
+        {
+            /* Found it */
+            break;
+        }
+        /* Replace all '\' backslashes by '#' pounds in symbolic link */
         if (SymbolicLink[Index] == L'\\')
         {
             SymbolicLink[Index] = L'#';
@@ -2691,11 +2699,47 @@ HKEY WINAPI SetupDiCreateDeviceInterfaceRegKeyW(
         Index++;
     }
 
-    rc = RegCreateKeyExW(hKey, SymbolicLink, 0, NULL, 0, samDesired, NULL, &hDevKey, NULL);
+    /* Create reference string */
+    RefLength = (Length / sizeof(WCHAR) - Index) * sizeof(WCHAR);
+    ReferenceString = HeapAlloc(GetProcessHeap(), 0, RefLength);
+    if (!ReferenceString)
+    {
+        HeapFree(GetProcessHeap(), 0, SymbolicLink);
+        SetLastError(ERROR_NOT_ENOUGH_MEMORY);
+        return INVALID_HANDLE_VALUE;
+    }
 
-    RegCloseKey(hKey);
+    wcscpy(ReferenceString, L"#");
+    wcscat(ReferenceString, &SymbolicLink[Index + 2]); /* Skip first '\' backslash */
+
+    /* Null-terminate symbolic link at the beginning of the reference part,
+     * as we don't need a ref part in key name. */
+    SymbolicLink[Index + 1] = '\0';
+
+    /* Open device instance key */
+    rc = RegOpenKeyExW(hKey, SymbolicLink, 0, samDesired, &hDevKey);
     HeapFree(GetProcessHeap(), 0, SymbolicLink);
+    RegCloseKey(hKey);
+    if (rc != ERROR_SUCCESS)
+    {
+        HeapFree(GetProcessHeap(), 0, ReferenceString);
+        SetLastError(rc);
+        return INVALID_HANDLE_VALUE;
+    }
 
+    /* Open reference key */
+    rc = RegOpenKeyExW(hDevKey, ReferenceString, 0, samDesired, &hRefKey);
+    HeapFree(GetProcessHeap(), 0, ReferenceString);
+    RegCloseKey(hDevKey);
+    if (rc != ERROR_SUCCESS)
+    {
+        SetLastError(rc);
+        return INVALID_HANDLE_VALUE;
+    }
+
+    /* Create/open "Device Parameters" subkey */
+    rc = RegCreateKeyExW(hRefKey, L"Device Parameters", 0, NULL, 0, samDesired, NULL, &hDevParamKey, NULL);
+    RegCloseKey(hRefKey);
     if (rc == ERROR_SUCCESS)
     {
         if (InfHandle && InfSectionName)
@@ -2704,7 +2748,7 @@ HKEY WINAPI SetupDiCreateDeviceInterfaceRegKeyW(
                                             InfHandle,
                                             InfSectionName,
                                             SPINST_INIFILES | SPINST_REGISTRY | SPINST_INI2REG | SPINST_FILES | SPINST_BITREG | SPINST_REGSVR | SPINST_UNREGSVR | SPINST_PROFILEITEMS | SPINST_COPYINF,
-                                            hDevKey,
+                                            hDevParamKey,
                                             NULL,
                                             0,
                                             set->SelectedDevice->InstallParams.InstallMsgHandler,
@@ -2712,14 +2756,14 @@ HKEY WINAPI SetupDiCreateDeviceInterfaceRegKeyW(
                                             INVALID_HANDLE_VALUE,
                                             NULL))
             {
-                RegCloseKey(hDevKey);
+                RegCloseKey(hDevParamKey);
                 return INVALID_HANDLE_VALUE;
             }
         }
     }
 
     SetLastError(rc);
-    return hDevKey;
+    return hDevParamKey;
 }
 
 /***********************************************************************

--- a/dll/win32/setupapi/interface.c
+++ b/dll/win32/setupapi/interface.c
@@ -336,7 +336,7 @@ InstallOneInterface(
     IN HDEVINFO DeviceInfoSet,
     IN struct DeviceInfo *devInfo)
 {
-    HKEY hKey, hRefKey;
+    HKEY hKey;
     LPWSTR Path;
     SP_DEVICE_INTERFACE_DATA DeviceInterfaceData;
     struct DeviceInterface *DevItf = NULL;
@@ -374,37 +374,7 @@ InstallOneInterface(
         return FALSE;
     }
 
-    if (ReferenceString)
-    {
-        Path = HeapAlloc(GetProcessHeap(), 0, (wcslen(ReferenceString) + 2) * sizeof(WCHAR));
-        if (!Path)
-        {
-            RegCloseKey(hKey);
-            return FALSE;
-        }
-
-        wcscpy(Path, L"#");
-        wcscat(Path, ReferenceString);
-
-        if (RegCreateKeyExW(hKey, Path, 0, NULL, 0, KEY_ALL_ACCESS, NULL, &hRefKey, NULL) != ERROR_SUCCESS)
-        {
-            ERR("failed to create key %s %lx\n", debugstr_w(Path), GetLastError());
-            HeapFree(GetProcessHeap(), 0, Path);
-            return FALSE;
-        }
-
-        RegCloseKey(hKey);
-        hKey = hRefKey;
-        HeapFree(GetProcessHeap(), 0, Path);
-    }
-
-    if (RegCreateKeyExW(hKey, L"Device Parameters", 0, NULL, 0, KEY_ALL_ACCESS, NULL, &hRefKey, NULL) != ERROR_SUCCESS)
-    {
-        RegCloseKey(hKey);
-        return FALSE;
-    }
-
-    return SetupInstallFromInfSectionW(NULL, /* FIXME */ hInf, InterfaceSection, SPINST_REGISTRY, hRefKey, NULL, 0, NULL, NULL, NULL, NULL);
+    return SetupInstallFromInfSectionW(NULL, /* FIXME */ hInf, InterfaceSection, SPINST_REGISTRY, hKey, NULL, 0, NULL, NULL, NULL, NULL);
 }
 
 /***********************************************************************


### PR DESCRIPTION
## Purpose

The function should create/open "Device Parameters" subkey of a device reference key (and return a handle to it), instead of device instance subkey.
This fixes audio devices enumeration failure of winmm.dll from Windows 2000 SP4 (and unneeded creation of wrong registry keys) when using ReactOS with audio stack replacement from Windows XP/2003. 

JIRA issue: [CORE-19986](https://jira.reactos.org/browse/CORE-19986)

## Proposed changes

- Fix `SetupDiCreateDeviceInterfaceRegKeyW()` to open (and return a handle to) the correct registry key.
- Fix its usage in internal `InstallOneInterface()` helper, which is called by `SetupDiInstallDeviceInterfaces()`.

## TODO

- [ ] There is one more usage of this function in our streamci: https://git.reactos.org/?p=reactos.git;a=blob;f=dll/win32/streamci/streamci.c;hb=2b2bdabe7221f9b35f135b013e44bce4bfd16c66#l168. **Does it need to be updated too?**
- [ ] Is a handle to a "Device Parameters" subkey instead of device instance subkey suitable as  5th parameter for `SetupInstallFromInfSectionW()`? It is now passed there both in `SetupDiCreateDeviceInterfaceRegKeyW()` and in `InstallOneInterface()` helper.

## Result

As visible on the following screenshots, incorrect registry keys are no longer created, as MS winmm now receives a handle to the correct registry key to write a "SetupPreferredAudioDevicesCount" value and it does not try to write that in the wrong place. Hence, audio devices enumeration is fixed.

Before:
![before](https://github.com/user-attachments/assets/0f6dd13e-bf51-4639-b02e-5c63b27e0f24)

After:
![after](https://github.com/user-attachments/assets/999a00a0-f493-4124-b16c-1ff0978f998f)

Windows XP SP3 (for comparison):
![XP](https://github.com/user-attachments/assets/efa87c5e-e99f-4680-8580-97d2d13a5905)