### PR TITLE
[NTOS:MM][NTOS:PS] Little fixes for NTDLL loading

### DIFF
--- a/ntoskrnl/include/internal/mm.h
+++ b/ntoskrnl/include/internal/mm.h
@@ -1652,9 +1652,7 @@ MmUnloadSystemImage(
 NTSTATUS
 NTAPI
 MmCheckSystemImage(
-    IN HANDLE ImageHandle,
-    IN BOOLEAN PurgeSection
-);
+    _In_ HANDLE ImageHandle);
 
 NTSTATUS
 NTAPI

--- a/ntoskrnl/mm/ARM3/sysldr.c
+++ b/ntoskrnl/mm/ARM3/sysldr.c
@@ -2742,8 +2742,8 @@ MmVerifyImageIsOkForMpUse(IN PVOID BaseAddress)
 
 NTSTATUS
 NTAPI
-MmCheckSystemImage(IN HANDLE ImageHandle,
-                   IN BOOLEAN PurgeSection)
+MmCheckSystemImage(
+    _In_ HANDLE ImageHandle)
 {
     NTSTATUS Status;
     HANDLE SectionHandle;
@@ -2837,12 +2837,15 @@ MmCheckSystemImage(IN HANDLE ImageHandle,
             goto Fail;
         }
 
-        /* Check that it's a valid SMP image if we have more then one CPU */
-        if (!MmVerifyImageIsOkForMpUse(ViewBase))
+#ifdef CONFIG_SMP
+        /* Check that it's a valid SMP image if we have more than one CPU */
+        if (KeNumberProcessors > 1 &&
+            (NtHeaders->FileHeader.Characteristics & IMAGE_FILE_UP_SYSTEM_ONLY))
         {
             /* Otherwise it's not the right image */
             Status = STATUS_IMAGE_MP_UP_MISMATCH;
         }
+#endif // CONFIG_SMP
     }
 
     /* Unmap the section, close the handle, and return status */
@@ -3171,7 +3174,7 @@ LoaderScan:
         }
 
         /* Validate it */
-        Status = MmCheckSystemImage(FileHandle, FALSE);
+        Status = MmCheckSystemImage(FileHandle);
         if ((Status == STATUS_IMAGE_CHECKSUM_MISMATCH) ||
             (Status == STATUS_IMAGE_MP_UP_MISMATCH) ||
             (Status == STATUS_INVALID_IMAGE_PROTECT))

--- a/ntoskrnl/mm/ARM3/sysldr.c
+++ b/ntoskrnl/mm/ARM3/sysldr.c
@@ -2839,8 +2839,7 @@ MmCheckSystemImage(
 
 #ifdef CONFIG_SMP
         /* Check that it's a valid SMP image if we have more than one CPU */
-        if (KeNumberProcessors > 1 &&
-            (NtHeaders->FileHeader.Characteristics & IMAGE_FILE_UP_SYSTEM_ONLY))
+        if (!MiVerifyImageIsOkForMpUse(NtHeaders))
         {
             /* Otherwise it's not the right image */
             Status = STATUS_IMAGE_MP_UP_MISMATCH;

--- a/ntoskrnl/ps/psmgr.c
+++ b/ntoskrnl/ps/psmgr.c
@@ -196,7 +196,7 @@ PsLocateSystemDll(VOID)
     /* Locate and open NTDLL to determine ImageBase and LdrStartup */
     InitializeObjectAttributes(&ObjectAttributes,
                                &PsNtDllPathName,
-                               0,
+                               OBJ_CASE_INSENSITIVE | OBJ_KERNEL_HANDLE,
                                NULL,
                                NULL);
     Status = ZwOpenFile(&FileHandle,
@@ -212,8 +212,8 @@ PsLocateSystemDll(VOID)
     }
 
     /* Check if the image is valid */
-    Status = MmCheckSystemImage(FileHandle, TRUE);
-    if (Status == STATUS_IMAGE_CHECKSUM_MISMATCH)
+    Status = MmCheckSystemImage(FileHandle);
+    if (Status == STATUS_IMAGE_CHECKSUM_MISMATCH || Status == STATUS_INVALID_IMAGE_PROTECT)
     {
         /* Raise a hard error */
         HardErrorParameters = (ULONG_PTR)&PsNtDllPathName;


### PR DESCRIPTION
- [NTOS:PS] `STATUS_INVALID_IMAGE_PROTECT` returned by `MmCheckSystemImage` should be a fatal error too.
- [NTOS:PS] Fix object attributes for opening Ntdll.
- [NTOS:MM] Remove `MmCheckSystemImage` unused parameter.
- [NTOS:MM] Inline `MmVerifyImageIsOkForMpUse` to `MmCheckSystemImage` and reduce a calling to `RtlImageNtHeader`.

From the closed PR #6963 