### PR TITLE
[PSAPI][KERNEL32] Convert the PSAPI exports to a static library

### DIFF
--- a/dll/win32/kernel32/CMakeLists.txt
+++ b/dll/win32/kernel32/CMakeLists.txt
@@ -130,7 +130,7 @@ set_module_type(kernel32 win32dll ENTRYPOINT DllMain 12)
 set_subsystem(kernel32 console)
 ################# END  HACK #################
 
-target_link_libraries(kernel32 kernel32_vista_static kernel32_shared wine chkstk ${PSEH_LIB})
+target_link_libraries(kernel32 psapi_static kernel32_vista_static kernel32_shared wine chkstk ${PSEH_LIB})
 add_importlibs(kernel32 ntdll)
 add_pch(kernel32 k32.h SOURCE)
 add_dependencies(kernel32 psdk errcodes asm)

--- a/dll/win32/kernel32/kernel32.spec
+++ b/dll/win32/kernel32/kernel32.spec
@@ -760,6 +760,33 @@
 @ stdcall IsValidLocale(long long)
 @ stdcall -version=0x501-0x502 IsValidUILanguage(long)
 @ stdcall IsWow64Process(ptr ptr)
+@ stdcall -version=0x601+ K32EmptyWorkingSet(long) EmptyWorkingSet
+@ stdcall -version=0x601+ K32EnumDeviceDrivers(ptr long ptr) EnumDeviceDrivers
+@ stdcall -version=0x601+ K32EnumPageFilesA(ptr ptr) EnumPageFilesA
+@ stdcall -version=0x601+ K32EnumPageFilesW(ptr ptr) EnumPageFilesW
+@ stdcall -version=0x601+ K32EnumProcessModules(long ptr long ptr) EnumProcessModules
+@ stdcall -stub -version=0x601+ K32EnumProcessModulesEx(long ptr long ptr long); EnumProcessModulesEx
+@ stdcall -version=0x601+ K32EnumProcesses(ptr long ptr) EnumProcesses
+@ stdcall -version=0x601+ K32GetDeviceDriverBaseNameA(ptr ptr long) GetDeviceDriverBaseNameA
+@ stdcall -version=0x601+ K32GetDeviceDriverBaseNameW(ptr ptr long) GetDeviceDriverBaseNameW
+@ stdcall -version=0x601+ K32GetDeviceDriverFileNameA(ptr ptr long) GetDeviceDriverFileNameA
+@ stdcall -version=0x601+ K32GetDeviceDriverFileNameW(ptr ptr long) GetDeviceDriverFileNameW
+@ stdcall -version=0x601+ K32GetMappedFileNameA(long ptr ptr long) GetMappedFileNameA
+@ stdcall -version=0x601+ K32GetMappedFileNameW(long ptr ptr long) GetMappedFileNameW
+@ stdcall -version=0x601+ K32GetModuleBaseNameA(long long ptr long) GetModuleBaseNameA
+@ stdcall -version=0x601+ K32GetModuleBaseNameW(long long ptr long) GetModuleBaseNameW
+@ stdcall -version=0x601+ K32GetModuleFileNameExA(long long ptr long) GetModuleFileNameExA
+@ stdcall -version=0x601+ K32GetModuleFileNameExW(long long ptr long) GetModuleFileNameExW
+@ stdcall -version=0x601+ K32GetModuleInformation(long long ptr long) GetModuleInformation
+@ stdcall -version=0x601+ K32GetPerformanceInfo(ptr long) GetPerformanceInfo
+@ stdcall -version=0x601+ K32GetProcessImageFileNameA(long ptr long) GetProcessImageFileNameA
+@ stdcall -version=0x601+ K32GetProcessImageFileNameW(long ptr long) GetProcessImageFileNameW
+@ stdcall -version=0x601+ K32GetProcessMemoryInfo(long ptr long) GetProcessMemoryInfo
+@ stdcall -version=0x601+ K32GetWsChanges(long ptr long) GetWsChanges
+@ stdcall -stub -version=0x601+ K32GetWsChangesEx(long ptr ptr); GetWsChangesEx
+@ stdcall -version=0x601+ K32InitializeProcessForWsWatch(long) InitializeProcessForWsWatch
+@ stdcall -version=0x601+ K32QueryWorkingSet(long ptr long) QueryWorkingSet
+@ stdcall -version=0x601+ K32QueryWorkingSetEx(long ptr long) QueryWorkingSetEx
 @ stdcall -version=0x600+ LCIDToLocaleName(long wstr long long)
 @ stdcall LCMapStringA(long long str long ptr long)
 @ stdcall -version=0x600+ LCMapStringEx(long long wstr long ptr long ptr ptr long)

--- a/dll/win32/psapi/CMakeLists.txt
+++ b/dll/win32/psapi/CMakeLists.txt
@@ -1,13 +1,17 @@
 
 spec2def(psapi.dll psapi.spec ADD_IMPORTLIB)
 
+list(APPEND PSAPI_STATIC_SOURCE psapi.c)
+add_library(psapi_static ${PSAPI_STATIC_SOURCE})
+add_dependencies(psapi_static psdk)
+
 list(APPEND SOURCE
-    psapi.c
+    main.c
     psapi.rc
     ${CMAKE_CURRENT_BINARY_DIR}/psapi.def)
 
 add_library(psapi MODULE ${SOURCE})
 set_module_type(psapi win32dll ENTRYPOINT DllMain 12)
-target_link_libraries(psapi ${PSEH_LIB})
+target_link_libraries(psapi psapi_static ${PSEH_LIB})
 add_importlibs(psapi kernel32 ntdll)
 add_cd_file(TARGET psapi DESTINATION reactos/system32 FOR all)

--- a/dll/win32/psapi/main.c
+++ b/dll/win32/psapi/main.c
@@ -1,0 +1,74 @@
+/*
+ * PROJECT:     ReactOS Process Status Helper Library
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     PSAPI Win2k3 style entrypoint
+ * COPYRIGHT:   Copyright 2013 Pierre Schweitzer <pierre@reactos.org>
+ */
+
+#include <stdarg.h>
+
+#define WIN32_NO_STATUS
+#include <windef.h>
+#include <winbase.h>
+#define NTOS_MODE_USER
+#include <ndk/psfuncs.h>
+#include <ndk/rtlfuncs.h>
+
+#include <psapi.h>
+
+#define NDEBUG
+#include <debug.h>
+
+static
+VOID
+NTAPI
+PsParseCommandLine(VOID)
+{
+    UNIMPLEMENTED;
+}
+
+static
+VOID
+NTAPI
+PsInitializeAndStartProfile(VOID)
+{
+    UNIMPLEMENTED;
+}
+
+static
+VOID
+NTAPI
+PsStopAndAnalyzeProfile(VOID)
+{
+    UNIMPLEMENTED;
+}
+
+/*
+ * @implemented
+ */
+BOOLEAN
+WINAPI
+DllMain(HINSTANCE hDllHandle,
+        DWORD nReason,
+        LPVOID Reserved)
+{
+    switch(nReason)
+    {
+        case DLL_PROCESS_ATTACH:
+            DisableThreadLibraryCalls(hDllHandle);
+            if (NtCurrentPeb()->ProcessParameters->Flags & RTL_USER_PROCESS_PARAMETERS_PROFILE_USER)
+            {
+                PsParseCommandLine();
+                PsInitializeAndStartProfile();
+            }
+            break;
+
+        case DLL_PROCESS_DETACH:
+            if (NtCurrentPeb()->ProcessParameters->Flags & RTL_USER_PROCESS_PARAMETERS_PROFILE_USER)
+            {
+                PsStopAndAnalyzeProfile();
+            }
+            break;
+    }
+    return TRUE;
+}

--- a/dll/win32/psapi/psapi.c
+++ b/dll/win32/psapi/psapi.c
@@ -245,67 +245,6 @@ CallBackConvertToAscii(LPVOID pContext,
 }
 
 /*
- * @unimplemented
- */
-static VOID NTAPI
-PsParseCommandLine(VOID)
-{
-    UNIMPLEMENTED;
-}
-
-/*
- * @unimplemented
- */
-static VOID NTAPI
-PsInitializeAndStartProfile(VOID)
-{
-    UNIMPLEMENTED;
-}
-
-/*
- * @unimplemented
- */
-static VOID NTAPI
-PsStopAndAnalyzeProfile(VOID)
-{
-    UNIMPLEMENTED;
-}
-
-/* PUBLIC *********************************************************************/
-
-/*
- * @implemented
- */
-BOOLEAN
-WINAPI
-DllMain(HINSTANCE hDllHandle,
-        DWORD nReason,
-        LPVOID Reserved)
-{
-    switch(nReason)
-    {
-        case DLL_PROCESS_ATTACH:
-            DisableThreadLibraryCalls(hDllHandle);
-            if (NtCurrentPeb()->ProcessParameters->Flags & RTL_USER_PROCESS_PARAMETERS_PROFILE_USER)
-            {
-                PsParseCommandLine();
-                PsInitializeAndStartProfile();
-            }
-            break;
-
-        case DLL_PROCESS_DETACH:
-            if (NtCurrentPeb()->ProcessParameters->Flags & RTL_USER_PROCESS_PARAMETERS_PROFILE_USER)
-            {
-                PsStopAndAnalyzeProfile();
-            }
-            break;
-    }
-
-    return TRUE;
-}
-
-
-/*
  * @implemented
  */
 BOOL


### PR DESCRIPTION
This behavior is straight out of win7 where this logic was moved to KernelBase and friends. Required for thousands of apps. But also just preps for the KernelBase sync from Wine-10


- [x] KVM x86: https://reactos.org/testman/compare.php?ids=100758,100766
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=100759,100765