### PR TITLE
[UNIATA] Fix memory corruption if SCSIOP_SERVICE_ACTION16 processed.

### DIFF
--- a/drivers/storage/ide/uniata/scsi.h
+++ b/drivers/storage/ide/uniata/scsi.h
@@ -1433,7 +1433,7 @@ typedef struct _READ_CAPACITY16_DATA {
     UCHAR Prot_EN:1;
     UCHAR RTO_EN:1;
     UCHAR Reserved:6;
-    UCHAR Reserved1[20];
+    UCHAR Reserved1[19];
 } READ_CAPACITY16_DATA, *PREAD_CAPACITY16_DATA;
 
 // CD ROM Read Table Of Contents (TOC) structures

--- a/drivers/storage/ide/uniata/scsi.h
+++ b/drivers/storage/ide/uniata/scsi.h
@@ -1433,7 +1433,13 @@ typedef struct _READ_CAPACITY16_DATA {
     UCHAR Prot_EN:1;
     UCHAR RTO_EN:1;
     UCHAR Reserved:6;
+#ifdef __REACTOS__
+    /* In ReactOS SDK sizeof(READ_CAPACITY16_DATA) == 32.
+     * Fixes CORE-19696 memory corruption on SCSIOP_SERVICE_ACTION16. */
     UCHAR Reserved1[19];
+#else
+    UCHAR Reserved1[20];
+#endif
 } READ_CAPACITY16_DATA, *PREAD_CAPACITY16_DATA;
 
 // CD ROM Read Table Of Contents (TOC) structures


### PR DESCRIPTION
Fix memory corruption if processed SCSIOP_SERVICE_ACTION16.
Reason: 
in uniata driver sizeof(READ_CAPACITY16_DATA) == 33
in reactos sdk sizeof(READ_CAPACITY16_DATA) == 32.

JIRA issue: [CORE-19696](https://jira.reactos.org/browse/CORE-19696)

After fix:
![изображение](https://github.com/user-attachments/assets/42310141-80ce-4284-bc14-0ffe3c0e70ba)

