### PR TITLE
[UCRT] Fix MSVC compiling on VS 2017 after Timo's UCRT commits

### DIFF
--- a/sdk/lib/ucrt/math/_dclass.c
+++ b/sdk/lib/ucrt/math/_dclass.c
@@ -11,7 +11,7 @@
 #include <math.h>
 #include <stdint.h>
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && (_MSC_VER >= 1920)
 #pragma function(_dclass)
 #endif
 

--- a/sdk/lib/ucrt/math/_dclass.c
+++ b/sdk/lib/ucrt/math/_dclass.c
@@ -11,7 +11,7 @@
 #include <math.h>
 #include <stdint.h>
 
-#if defined(_MSC_VER) && (_MSC_VER >= 1920)
+#if defined(_MSC_VER) && (_MSC_VER >= 1922)
 #pragma function(_dclass)
 #endif
 

--- a/sdk/lib/ucrt/math/_dtest.c
+++ b/sdk/lib/ucrt/math/_dtest.c
@@ -10,7 +10,7 @@
 
 #include <math.h>
 
-#if defined(_MSC_VER) && (_MSC_VER >= 1920)
+#if defined(_MSC_VER) && (_MSC_VER >= 1922)
 #pragma function(_dtest)
 #endif
 

--- a/sdk/lib/ucrt/math/_dtest.c
+++ b/sdk/lib/ucrt/math/_dtest.c
@@ -10,7 +10,7 @@
 
 #include <math.h>
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && (_MSC_VER >= 1920)
 #pragma function(_dtest)
 #endif
 

--- a/sdk/lib/ucrt/math/_fdclass.c
+++ b/sdk/lib/ucrt/math/_fdclass.c
@@ -11,7 +11,7 @@
 #include <math.h>
 #include <stdint.h>
 
-#if defined(_MSC_VER) && (_MSC_VER >= 1920)
+#if defined(_MSC_VER) && (_MSC_VER >= 1922)
 #pragma function(_fdclass)
 #endif
 

--- a/sdk/lib/ucrt/math/_fdclass.c
+++ b/sdk/lib/ucrt/math/_fdclass.c
@@ -11,7 +11,7 @@
 #include <math.h>
 #include <stdint.h>
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && (_MSC_VER >= 1920)
 #pragma function(_fdclass)
 #endif
 

--- a/sdk/lib/ucrt/math/_fdtest.c
+++ b/sdk/lib/ucrt/math/_fdtest.c
@@ -10,7 +10,7 @@
 
 #include <math.h>
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && (_MSC_VER >= 1920)
 #pragma function(_fdtest)
 #endif
 

--- a/sdk/lib/ucrt/math/_fdtest.c
+++ b/sdk/lib/ucrt/math/_fdtest.c
@@ -10,7 +10,7 @@
 
 #include <math.h>
 
-#if defined(_MSC_VER) && (_MSC_VER >= 1920)
+#if defined(_MSC_VER) && (_MSC_VER >= 1922)
 #pragma function(_fdtest)
 #endif
 

--- a/sdk/lib/ucrt/stdlib/div.cpp
+++ b/sdk/lib/ucrt/stdlib/div.cpp
@@ -9,7 +9,7 @@
 #include <stdlib.h>
 
 
-#ifdef  _MSC_VER
+#if defined(_MSC_VER) && (_MSC_VER >= 1920)
 #pragma function(div)
 #endif
 extern "C" div_t __cdecl div(int const numerator, int const denominator)

--- a/sdk/lib/ucrt/stdlib/div.cpp
+++ b/sdk/lib/ucrt/stdlib/div.cpp
@@ -9,7 +9,7 @@
 #include <stdlib.h>
 
 
-#if defined(_MSC_VER) && (_MSC_VER >= 1920)
+#if defined(_MSC_VER) && (_MSC_VER >= 1922)
 #pragma function(div)
 #endif
 extern "C" div_t __cdecl div(int const numerator, int const denominator)

--- a/sdk/lib/ucrt/stdlib/ldiv.cpp
+++ b/sdk/lib/ucrt/stdlib/ldiv.cpp
@@ -9,7 +9,7 @@
 #include <stdlib.h>
 
 
-#if defined(_MSC_VER) && (_MSC_VER >= 1920)
+#if defined(_MSC_VER) && (_MSC_VER >= 1922)
 #pragma function(ldiv)
 #endif
 extern "C" ldiv_t __cdecl ldiv(long const numerator, long const denominator)

--- a/sdk/lib/ucrt/stdlib/ldiv.cpp
+++ b/sdk/lib/ucrt/stdlib/ldiv.cpp
@@ -9,7 +9,7 @@
 #include <stdlib.h>
 
 
-#ifdef  _MSC_VER
+#if defined(_MSC_VER) && (_MSC_VER >= 1920)
 #pragma function(ldiv)
 #endif
 extern "C" ldiv_t __cdecl ldiv(long const numerator, long const denominator)

--- a/sdk/lib/ucrt/stdlib/lldiv.cpp
+++ b/sdk/lib/ucrt/stdlib/lldiv.cpp
@@ -9,7 +9,7 @@
 #include <stdlib.h>
 
 
-#if defined(_MSC_VER) && (_MSC_VER >= 1920)
+#if defined(_MSC_VER) && (_MSC_VER >= 1922)
 #pragma function(lldiv)
 #endif
 extern "C" lldiv_t __cdecl lldiv(long long const numerator, long long const denominator)

--- a/sdk/lib/ucrt/stdlib/lldiv.cpp
+++ b/sdk/lib/ucrt/stdlib/lldiv.cpp
@@ -9,7 +9,7 @@
 #include <stdlib.h>
 
 
-#ifdef  _MSC_VER
+#if defined(_MSC_VER) && (_MSC_VER >= 1920)
 #pragma function(lldiv)
 #endif
 extern "C" lldiv_t __cdecl lldiv(long long const numerator, long long const denominator)


### PR DESCRIPTION
CORE-19996

## Purpose

_Fix MSVC compiling on VS 2017 after recent UCRT commits._

JIRA issue: [CORE-19996](https://jira.reactos.org/browse/CORE-19996)

## Proposed changes

_Change condition of using '#pragma function..' to only use this on VS 2019 or later._

Based on Serge's comment and Timo's suggestion I tested this on https://godbolt.org/ .
It indicates that the test should use 1922 instead of 1920, so I am changing the PR now to reflect this.