### PR TITLE
[RAPPS] Ask user if they want to run the zip app they just installed

### DIFF
--- a/base/applications/rapps/geninst.cpp
+++ b/base/applications/rapps/geninst.cpp
@@ -271,15 +271,15 @@ GetLocalizedSMFolderName(LPCWSTR WinVal, LPCWSTR RosInf, LPCWSTR RosVal, CString
     return ReadIniValue(path, L"Strings", RosVal, Output) > 0;
 }
 
-static BOOL
-CreateShortcut(const CStringW &Target)
+static CStringW
+CreateMainShortcut(const CStringW &Target)
 {
     InstallInfo &Info = *static_cast<InstallInfo *>(g_pInfo);
     UINT csidl = Info.PerUser ? CSIDL_PROGRAMS : CSIDL_COMMON_PROGRAMS;
     CStringW rel = Info.ShortcutFile, path, dir, tmp;
 
     if (FAILED(GetSpecialPath(csidl, path, Info.GetGuiOwner())))
-        return TRUE; // Pretend everything is OK
+        return L""; // Pretend everything is OK
 
     int cat;
     if (Info.Parser.GetInt(DB_CATEGORY, cat) && cat == ENUM_CAT_GAMES)
@@ -300,7 +300,7 @@ CreateShortcut(const CStringW &Target)
     if ((Info.Error = ErrorFromHResult(hr)) != 0)
     {
         ErrorBox(Info.Error);
-        return FALSE;
+        return L"";
     }
 
     CComPtr<IShellLinkW> link;
@@ -337,7 +337,7 @@ CreateShortcut(const CStringW &Target)
     {
         ErrorBox(ErrorFromHResult(hr));
     }
-    return !Info.Error;
+    return Info.Error ? L"" : path;
 }
 
 static BOOL
@@ -563,7 +563,20 @@ ExtractAndInstallThread(LPVOID Parameter)
 
         if (!Info.Error && Info.ShortcutFile)
         {
-            CreateShortcut(Info.MainApp);
+            tmp = CreateMainShortcut(Info.MainApp);
+            if (!tmp.IsEmpty() && !Info.Silent)
+            {
+                CStringW message, format;
+                format.LoadString(IDS_INSTGEN_CONFIRMINSTRUNAPP);
+                message.Format(format, const_cast<PCWSTR>(AppName));
+                if (MessageBoxW(Info.GetGuiOwner(), message, AppName, MB_YESNO | MB_ICONQUESTION) == IDYES)
+                {
+                    SHELLEXECUTEINFOW sei = { sizeof(sei), SEE_MASK_NOASYNC, Info.GetGuiOwner() };
+                    sei.lpFile = tmp;
+                    sei.nShow = SW_SHOW;
+                    ShellExecuteExW(&sei);
+                }
+            }
         }
     }
 
@@ -609,7 +622,7 @@ UIDlgProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
                 ErrorBox();
                 SendMessageW(hDlg, IM_END, 0, 0);
             }
-            break;
+            return TRUE;
         }
         case WM_CLOSE:
             return TRUE;

--- a/base/applications/rapps/include/resource.h
+++ b/base/applications/rapps/include/resource.h
@@ -235,6 +235,7 @@
 
 /* Generated installer */
 #define IDS_INSTGEN_CONFIRMUNINST               1000
+#define IDS_INSTGEN_CONFIRMINSTRUNAPP           1001
 
 /* Accelerators */
 #define HOTKEYS                  715

--- a/base/applications/rapps/lang/bg-BG.rc
+++ b/base/applications/rapps/lang/bg-BG.rc
@@ -265,4 +265,5 @@ END
 STRINGTABLE
 BEGIN
     IDS_INSTGEN_CONFIRMUNINST "Are you sure you want to uninstall %s?"
+    IDS_INSTGEN_CONFIRMINSTRUNAPP "Installation complete, run %s now?"
 END

--- a/base/applications/rapps/lang/cs-CZ.rc
+++ b/base/applications/rapps/lang/cs-CZ.rc
@@ -266,4 +266,5 @@ END
 STRINGTABLE
 BEGIN
     IDS_INSTGEN_CONFIRMUNINST "Opravdu chcete odinstalovat %s?"
+    IDS_INSTGEN_CONFIRMINSTRUNAPP "Installation complete, run %s now?"
 END

--- a/base/applications/rapps/lang/de-DE.rc
+++ b/base/applications/rapps/lang/de-DE.rc
@@ -268,4 +268,5 @@ END
 STRINGTABLE
 BEGIN
     IDS_INSTGEN_CONFIRMUNINST "Are you sure you want to uninstall %s?"
+    IDS_INSTGEN_CONFIRMINSTRUNAPP "Installation complete, run %s now?"
 END

--- a/base/applications/rapps/lang/en-US.rc
+++ b/base/applications/rapps/lang/en-US.rc
@@ -268,4 +268,5 @@ END
 STRINGTABLE
 BEGIN
     IDS_INSTGEN_CONFIRMUNINST "Are you sure you want to uninstall %s?"
+    IDS_INSTGEN_CONFIRMINSTRUNAPP "Installation complete, run %s now?"
 END

--- a/base/applications/rapps/lang/es-ES.rc
+++ b/base/applications/rapps/lang/es-ES.rc
@@ -267,4 +267,5 @@ END
 STRINGTABLE
 BEGIN
     IDS_INSTGEN_CONFIRMUNINST "Are you sure you want to uninstall %s?"
+    IDS_INSTGEN_CONFIRMINSTRUNAPP "Installation complete, run %s now?"
 END

--- a/base/applications/rapps/lang/et-EE.rc
+++ b/base/applications/rapps/lang/et-EE.rc
@@ -265,4 +265,5 @@ END
 STRINGTABLE
 BEGIN
     IDS_INSTGEN_CONFIRMUNINST "Are you sure you want to uninstall %s?"
+    IDS_INSTGEN_CONFIRMINSTRUNAPP "Installation complete, run %s now?"
 END

--- a/base/applications/rapps/lang/fr-FR.rc
+++ b/base/applications/rapps/lang/fr-FR.rc
@@ -268,4 +268,5 @@ END
 STRINGTABLE
 BEGIN
     IDS_INSTGEN_CONFIRMUNINST "Êtes-vous sûr de vouloir désinstaller %s ?"
+    IDS_INSTGEN_CONFIRMINSTRUNAPP "Installation complete, run %s now?"
 END

--- a/base/applications/rapps/lang/he-IL.rc
+++ b/base/applications/rapps/lang/he-IL.rc
@@ -270,4 +270,5 @@ END
 STRINGTABLE
 BEGIN
     IDS_INSTGEN_CONFIRMUNINST "Are you sure you want to uninstall %s?"
+    IDS_INSTGEN_CONFIRMINSTRUNAPP "Installation complete, run %s now?"
 END

--- a/base/applications/rapps/lang/hu-HU.rc
+++ b/base/applications/rapps/lang/hu-HU.rc
@@ -265,4 +265,5 @@ END
 STRINGTABLE
 BEGIN
     IDS_INSTGEN_CONFIRMUNINST "Are you sure you want to uninstall %s?"
+    IDS_INSTGEN_CONFIRMINSTRUNAPP "Installation complete, run %s now?"
 END

--- a/base/applications/rapps/lang/id-ID.rc
+++ b/base/applications/rapps/lang/id-ID.rc
@@ -265,4 +265,5 @@ END
 STRINGTABLE
 BEGIN
     IDS_INSTGEN_CONFIRMUNINST "Are you sure you want to uninstall %s?"
+    IDS_INSTGEN_CONFIRMINSTRUNAPP "Installation complete, run %s now?"
 END

--- a/base/applications/rapps/lang/it-IT.rc
+++ b/base/applications/rapps/lang/it-IT.rc
@@ -267,4 +267,5 @@ END
 STRINGTABLE
 BEGIN
     IDS_INSTGEN_CONFIRMUNINST "Are you sure you want to uninstall %s?"
+    IDS_INSTGEN_CONFIRMINSTRUNAPP "Installation complete, run %s now?"
 END

--- a/base/applications/rapps/lang/ja-JP.rc
+++ b/base/applications/rapps/lang/ja-JP.rc
@@ -267,4 +267,5 @@ END
 STRINGTABLE
 BEGIN
     IDS_INSTGEN_CONFIRMUNINST "Are you sure you want to uninstall %s?"
+    IDS_INSTGEN_CONFIRMINSTRUNAPP "Installation complete, run %s now?"
 END

--- a/base/applications/rapps/lang/no-NO.rc
+++ b/base/applications/rapps/lang/no-NO.rc
@@ -265,4 +265,5 @@ END
 STRINGTABLE
 BEGIN
     IDS_INSTGEN_CONFIRMUNINST "Are you sure you want to uninstall %s?"
+    IDS_INSTGEN_CONFIRMINSTRUNAPP "Installation complete, run %s now?"
 END

--- a/base/applications/rapps/lang/pl-PL.rc
+++ b/base/applications/rapps/lang/pl-PL.rc
@@ -267,4 +267,5 @@ END
 STRINGTABLE
 BEGIN
     IDS_INSTGEN_CONFIRMUNINST "Are you sure you want to uninstall %s?"
+    IDS_INSTGEN_CONFIRMINSTRUNAPP "Installation complete, run %s now?"
 END

--- a/base/applications/rapps/lang/pt-BR.rc
+++ b/base/applications/rapps/lang/pt-BR.rc
@@ -265,4 +265,5 @@ END
 STRINGTABLE
 BEGIN
     IDS_INSTGEN_CONFIRMUNINST "Are you sure you want to uninstall %s?"
+    IDS_INSTGEN_CONFIRMINSTRUNAPP "Installation complete, run %s now?"
 END

--- a/base/applications/rapps/lang/pt-PT.rc
+++ b/base/applications/rapps/lang/pt-PT.rc
@@ -265,4 +265,5 @@ END
 STRINGTABLE
 BEGIN
     IDS_INSTGEN_CONFIRMUNINST "Are you sure you want to uninstall %s?"
+    IDS_INSTGEN_CONFIRMINSTRUNAPP "Installation complete, run %s now?"
 END

--- a/base/applications/rapps/lang/ro-RO.rc
+++ b/base/applications/rapps/lang/ro-RO.rc
@@ -267,4 +267,5 @@ END
 STRINGTABLE
 BEGIN
     IDS_INSTGEN_CONFIRMUNINST "Sigur doriți să dezinstalați %s?"
+    IDS_INSTGEN_CONFIRMINSTRUNAPP "Installation complete, run %s now?"
 END

--- a/base/applications/rapps/lang/ru-RU.rc
+++ b/base/applications/rapps/lang/ru-RU.rc
@@ -270,4 +270,5 @@ END
 STRINGTABLE
 BEGIN
     IDS_INSTGEN_CONFIRMUNINST "Are you sure you want to uninstall %s?"
+    IDS_INSTGEN_CONFIRMINSTRUNAPP "Installation complete, run %s now?"
 END

--- a/base/applications/rapps/lang/sk-SK.rc
+++ b/base/applications/rapps/lang/sk-SK.rc
@@ -266,4 +266,5 @@ END
 STRINGTABLE
 BEGIN
     IDS_INSTGEN_CONFIRMUNINST "Ste si istí, že chcete odinštalovať %s?"
+    IDS_INSTGEN_CONFIRMINSTRUNAPP "Installation complete, run %s now?"
 END

--- a/base/applications/rapps/lang/sq-AL.rc
+++ b/base/applications/rapps/lang/sq-AL.rc
@@ -265,4 +265,5 @@ END
 STRINGTABLE
 BEGIN
     IDS_INSTGEN_CONFIRMUNINST "Are you sure you want to uninstall %s?"
+    IDS_INSTGEN_CONFIRMINSTRUNAPP "Installation complete, run %s now?"
 END

--- a/base/applications/rapps/lang/sv-SE.rc
+++ b/base/applications/rapps/lang/sv-SE.rc
@@ -265,4 +265,5 @@ END
 STRINGTABLE
 BEGIN
     IDS_INSTGEN_CONFIRMUNINST "Are you sure you want to uninstall %s?"
+    IDS_INSTGEN_CONFIRMINSTRUNAPP "Installation complete, run %s now?"
 END

--- a/base/applications/rapps/lang/tr-TR.rc
+++ b/base/applications/rapps/lang/tr-TR.rc
@@ -267,4 +267,5 @@ END
 STRINGTABLE
 BEGIN
     IDS_INSTGEN_CONFIRMUNINST "Kaldırmak istediğinizden emin misiniz %s?"
+    IDS_INSTGEN_CONFIRMINSTRUNAPP "Installation complete, run %s now?"
 END

--- a/base/applications/rapps/lang/uk-UA.rc
+++ b/base/applications/rapps/lang/uk-UA.rc
@@ -268,4 +268,5 @@ END
 STRINGTABLE
 BEGIN
     IDS_INSTGEN_CONFIRMUNINST "Are you sure you want to uninstall %s?"
+    IDS_INSTGEN_CONFIRMINSTRUNAPP "Installation complete, run %s now?"
 END

--- a/base/applications/rapps/lang/zh-CN.rc
+++ b/base/applications/rapps/lang/zh-CN.rc
@@ -269,4 +269,5 @@ END
 STRINGTABLE
 BEGIN
     IDS_INSTGEN_CONFIRMUNINST "Are you sure you want to uninstall %s?"
+    IDS_INSTGEN_CONFIRMINSTRUNAPP "Installation complete, run %s now?"
 END

--- a/base/applications/rapps/lang/zh-HK.rc
+++ b/base/applications/rapps/lang/zh-HK.rc
@@ -266,4 +266,5 @@ END
 STRINGTABLE
 BEGIN
     IDS_INSTGEN_CONFIRMUNINST "Are you sure you want to uninstall %s?"
+    IDS_INSTGEN_CONFIRMINSTRUNAPP "Installation complete, run %s now?"
 END

--- a/base/applications/rapps/lang/zh-TW.rc
+++ b/base/applications/rapps/lang/zh-TW.rc
@@ -266,4 +266,5 @@ END
 STRINGTABLE
 BEGIN
     IDS_INSTGEN_CONFIRMUNINST "Are you sure you want to uninstall %s?"
+    IDS_INSTGEN_CONFIRMINSTRUNAPP "Installation complete, run %s now?"
 END


### PR DESCRIPTION
After the zip has been installed, ask the user if they want to run the extracted application.

It is pretty common for installers to allow the user to launch the new program, saves them a trip to the Start Menu.

Notes:
 - The previous `return TRUE` in `CreateShortcut` on special folder failure is now technically a function failure but nobody was checking the old return value. This failure path still does not call `ErrorBox` because if we can't create/open the start menu folder, the shell/registry is hosed.