### PR TITLE
[APPWIZ] Don't set the .lnk filename as the shortcut comment

### DIFF
--- a/dll/cpl/appwiz/createlink.c
+++ b/dll/cpl/appwiz/createlink.c
@@ -489,6 +489,9 @@ FinishDlgProc(HWND hwndDlg,
                     PathRemoveExtensionW(pContext->szLinkName);
                     PathAddExtensionW(pContext->szLinkName, L".lnk");
 
+                    /* Don't set a comment */
+                    pContext->szDescription[0] = UNICODE_NULL;
+
                     if (!CreateShortcut(pContext))
                     {
                         WCHAR szMessage[128];


### PR DESCRIPTION
Windows does not set the comment when creating a new shortcut in the wizard and neither should we because we have no useful information to put there.