### PR TITLE
[COMCTL32] ListView LVIS_CUT image does not depend on focus

### DIFF
--- a/dll/win32/comctl32/listview.c
+++ b/dll/win32/comctl32/listview.c
@@ -2270,11 +2270,7 @@ static void LISTVIEW_InvalidateSelectedItems(const LISTVIEW_INFO *infoPtr)
     iterator_frameditems(&i, infoPtr, &infoPtr->rcList); 
     while(iterator_next(&i))
     {
-#ifdef __REACTOS__
-	if (LISTVIEW_GetItemState(infoPtr, i.nItem, LVIS_SELECTED | LVIS_CUT))
-#else
 	if (LISTVIEW_GetItemState(infoPtr, i.nItem, LVIS_SELECTED))
-#endif
 	    LISTVIEW_InvalidateItem(infoPtr, i.nItem);
     }
     iterator_destroy(&i);
@@ -4782,10 +4778,17 @@ static void LISTVIEW_DrawItemPart(LISTVIEW_INFO *infoPtr, LVITEMW *item, const N
 
         TRACE("iImage=%d\n", item->iImage);
 
+#ifdef __REACTOS__
+        if (item->state & (LVIS_CUT | (infoPtr->bFocus ? LVIS_SELECTED : 0)))
+            style = ILD_SELECTED;
+        else
+            style = ILD_NORMAL;
+#else
         if (item->state & (LVIS_SELECTED | LVIS_CUT) && infoPtr->bFocus)
             style = ILD_SELECTED;
         else
             style = ILD_NORMAL;
+#endif
 
         ImageList_DrawEx(himl, item->iImage, nmlvcd->nmcd.hdc, rcIcon.left, rcIcon.top,
                          rcIcon.right - rcIcon.left, rcIcon.bottom - rcIcon.top, infoPtr->clrBk,

--- a/dll/win32/comctl32/listview.c
+++ b/dll/win32/comctl32/listview.c
@@ -4780,15 +4780,12 @@ static void LISTVIEW_DrawItemPart(LISTVIEW_INFO *infoPtr, LVITEMW *item, const N
 
 #ifdef __REACTOS__
         if (item->state & (LVIS_CUT | (infoPtr->bFocus ? LVIS_SELECTED : 0)))
-            style = ILD_SELECTED;
-        else
-            style = ILD_NORMAL;
 #else
         if (item->state & (LVIS_SELECTED | LVIS_CUT) && infoPtr->bFocus)
+#endif
             style = ILD_SELECTED;
         else
             style = ILD_NORMAL;
-#endif
 
         ImageList_DrawEx(himl, item->iImage, nmlvcd->nmcd.hdc, rcIcon.left, rcIcon.top,
                          rcIcon.right - rcIcon.left, rcIcon.bottom - rcIcon.top, infoPtr->clrBk,


### PR DESCRIPTION
This is mostly for DefView (a files hidden attribute does not depend on window focus) but the fix belongs in ListView.

Undoes flicker caused by PR #4218. Does not cause regression for [CORE-16722](https://jira.reactos.org/browse/CORE-16722) as far as I can tell.

![OldVsNew](https://github.com/user-attachments/assets/22ac4815-4477-4ec4-b3c2-e90b28a7a52e)

<details><summary>Code example</summary>
<pre><code>InitCommonControls();
SHFILEINFOA shfi;
INT_PTR shil = SHGetFileInfoA("x", FILE_ATTRIBUTE_DIRECTORY, &shfi, sizeof(shfi), SHGFI_USEFILEATTRIBUTES | SHGFI_SYSICONINDEX | SHGFI_SHELLICONSIZE | SHGFI_SMALLICON);
HWND hList = CreateWindowEx(WS_EX_APPWINDOW, WC_LISTVIEW, 0, WS_VISIBLE | WS_OVERLAPPEDWINDOW | LVS_SMALLICON | LVS_ALIGNLEFT | LVS_NOLABELWRAP | LVS_SHOWSELALWAYS, 0, 0, 150, 150, 0, 0, 0, 0);
ListView_SetImageList(hList, (HIMAGELIST)shil, LVSIL_SMALL);
UINT states[] = { LVIS_SELECTED | LVIS_FOCUSED, LVIS_SELECTED, LVIS_SELECTED | LVIS_CUT, LVIS_CUT, 0 };
for (UINT i = 0; i < ARRAYSIZE(states); ++i)
{
    LVITEM lvi = { LVIF_TEXT | LVIF_IMAGE, 42 };
    TCHAR buf[42];
    wsprintf(lvi.pszText = buf, TEXT("%.4X"), states[i]);
    lvi.iImage = shfi.iIcon;
    lvi.iItem = ListView_InsertItem(hList, &lvi);
    ListView_SetItemState(hList, lvi.iItem, states[i], states[i]);
}
SetForegroundWindow(GetShellWindow()); // Set focus somewhere else
for (MSG msg; GetMessage(&msg, 0, 0, 0);)
{
    if (msg.message == WM_NCLBUTTONDOWN && msg.hwnd == hList) ExitProcess(0);
    TranslateMessage(&msg);
    DispatchMessage(&msg);
}
</code></pre>
</details> 


