### PR TITLE
[DESK] Don't include .ico files in the list of wallpapers

### DIFF
--- a/dll/cpl/desk/background.c
+++ b/dll/cpl/desk/background.c
@@ -155,6 +155,9 @@ GdipGetSupportedFileExtensions(VOID)
 
     for (i = 0; i < num; ++i)
     {
+        if (!lstrcmpiW(codecInfo[i].FilenameExtension, L"*.ico"))
+            continue;
+
         StringCbCatW(lpBuffer, size, codecInfo[i].FilenameExtension);
         if (i < (num - 1))
         {


### PR DESCRIPTION
Icons rarely makes good wallpapers and GDI+ does not pick the best image automatically. Implementing the same workaround shimgvw uses is overkill.

JIRA issue: [CORE-20003](https://jira.reactos.org/browse/CORE-20003)
