### PR TITLE
[COMCTL32] Fix shift-selecting files not working as expected in small/large icons views

### DIFF
--- a/dll/win32/comctl32/listview.c
+++ b/dll/win32/comctl32/listview.c
@@ -3729,44 +3729,44 @@ static void LISTVIEW_SetGroupSelection(LISTVIEW_INFO *infoPtr, INT nItem)
     if ((infoPtr->uView == LV_VIEW_LIST) || (infoPtr->uView == LV_VIEW_DETAILS))
     {
 #endif
-    if (infoPtr->nSelectionMark == -1)
-    {
-        infoPtr->nSelectionMark = nItem;
-        ranges_additem(selection, nItem);
-    }
-    else
-    {
-        RANGE sel;
-        
-        sel.lower = min(infoPtr->nSelectionMark, nItem);
-        sel.upper = max(infoPtr->nSelectionMark, nItem) + 1;
-        ranges_add(selection, sel);
-    }
+	if (infoPtr->nSelectionMark == -1)
+	{
+	    infoPtr->nSelectionMark = nItem;
+	    ranges_additem(selection, nItem);
+	}
+	else
+	{
+	    RANGE sel;
+	    
+	    sel.lower = min(infoPtr->nSelectionMark, nItem);
+	    sel.upper = max(infoPtr->nSelectionMark, nItem) + 1;
+	    ranges_add(selection, sel);
+	}
 #ifndef __REACTOS__
     }
     else
     {
-    RECT rcItem, rcSel, rcSelMark;
-    POINT ptItem;
-    
-    rcItem.left = LVIR_BOUNDS;
-    if (!LISTVIEW_GetItemRect(infoPtr, nItem, &rcItem)) {
-        ranges_destroy (selection);
-        return;
-    }
-    rcSelMark.left = LVIR_BOUNDS;
-    if (!LISTVIEW_GetItemRect(infoPtr, infoPtr->nSelectionMark, &rcSelMark)) {
-        ranges_destroy (selection);
-        return;
-    }
-    UnionRect(&rcSel, &rcItem, &rcSelMark);
-    iterator_frameditems(&i, infoPtr, &rcSel);
-    while(iterator_next(&i))
-    {
-        LISTVIEW_GetItemPosition(infoPtr, i.nItem, &ptItem);
-        if (PtInRect(&rcSel, ptItem)) ranges_additem(selection, i.nItem);
-    }
-    iterator_destroy(&i);
+	RECT rcItem, rcSel, rcSelMark;
+	POINT ptItem;
+	
+	rcItem.left = LVIR_BOUNDS;
+	if (!LISTVIEW_GetItemRect(infoPtr, nItem, &rcItem)) {
+	     ranges_destroy (selection);
+	     return;
+	}
+	rcSelMark.left = LVIR_BOUNDS;
+	if (!LISTVIEW_GetItemRect(infoPtr, infoPtr->nSelectionMark, &rcSelMark)) {
+	     ranges_destroy (selection);
+	     return;
+	}
+	UnionRect(&rcSel, &rcItem, &rcSelMark);
+	iterator_frameditems(&i, infoPtr, &rcSel);
+	while(iterator_next(&i))
+	{
+	    LISTVIEW_GetItemPosition(infoPtr, i.nItem, &ptItem);
+	    if (PtInRect(&rcSel, ptItem)) ranges_additem(selection, i.nItem);
+	}
+	iterator_destroy(&i);
     }
 #endif
 

--- a/dll/win32/comctl32/listview.c
+++ b/dll/win32/comctl32/listview.c
@@ -3725,8 +3725,6 @@ static void LISTVIEW_SetGroupSelection(LISTVIEW_INFO *infoPtr, INT nItem)
     item.state = LVIS_SELECTED; 
     item.stateMask = LVIS_SELECTED;
 
-    if ((infoPtr->uView == LV_VIEW_LIST) || (infoPtr->uView == LV_VIEW_DETAILS))
-    {
 	if (infoPtr->nSelectionMark == -1)
 	{
 	    infoPtr->nSelectionMark = nItem;
@@ -3740,32 +3738,7 @@ static void LISTVIEW_SetGroupSelection(LISTVIEW_INFO *infoPtr, INT nItem)
 	    sel.upper = max(infoPtr->nSelectionMark, nItem) + 1;
 	    ranges_add(selection, sel);
 	}
-    }
-    else
-    {
-	RECT rcItem, rcSel, rcSelMark;
-	POINT ptItem;
 	
-	rcItem.left = LVIR_BOUNDS;
-	if (!LISTVIEW_GetItemRect(infoPtr, nItem, &rcItem)) {
-	     ranges_destroy (selection);
-	     return;
-	}
-	rcSelMark.left = LVIR_BOUNDS;
-	if (!LISTVIEW_GetItemRect(infoPtr, infoPtr->nSelectionMark, &rcSelMark)) {
-	     ranges_destroy (selection);
-	     return;
-	}
-	UnionRect(&rcSel, &rcItem, &rcSelMark);
-	iterator_frameditems(&i, infoPtr, &rcSel);
-	while(iterator_next(&i))
-	{
-	    LISTVIEW_GetItemPosition(infoPtr, i.nItem, &ptItem);
-	    if (PtInRect(&rcSel, ptItem)) ranges_additem(selection, i.nItem);
-	}
-	iterator_destroy(&i);
-    }
-
     /* disable per item notifications on LVS_OWNERDATA style
        FIXME: single LVN_ODSTATECHANGED should be used */
     old_mask = infoPtr->notify_mask & NOTIFY_MASK_ITEM_CHANGE;

--- a/dll/win32/comctl32/listview.c
+++ b/dll/win32/comctl32/listview.c
@@ -3725,20 +3725,51 @@ static void LISTVIEW_SetGroupSelection(LISTVIEW_INFO *infoPtr, INT nItem)
     item.state = LVIS_SELECTED; 
     item.stateMask = LVIS_SELECTED;
 
-	if (infoPtr->nSelectionMark == -1)
-	{
-	    infoPtr->nSelectionMark = nItem;
-	    ranges_additem(selection, nItem);
-	}
-	else
-	{
-	    RANGE sel;
-	    
-	    sel.lower = min(infoPtr->nSelectionMark, nItem);
-	    sel.upper = max(infoPtr->nSelectionMark, nItem) + 1;
-	    ranges_add(selection, sel);
-	}
-	
+#ifndef __REACTOS__
+    if ((infoPtr->uView == LV_VIEW_LIST) || (infoPtr->uView == LV_VIEW_DETAILS))
+    {
+#endif
+    if (infoPtr->nSelectionMark == -1)
+    {
+        infoPtr->nSelectionMark = nItem;
+        ranges_additem(selection, nItem);
+    }
+    else
+    {
+        RANGE sel;
+        
+        sel.lower = min(infoPtr->nSelectionMark, nItem);
+        sel.upper = max(infoPtr->nSelectionMark, nItem) + 1;
+        ranges_add(selection, sel);
+    }
+#ifndef __REACTOS__
+    }
+    else
+    {
+    RECT rcItem, rcSel, rcSelMark;
+    POINT ptItem;
+    
+    rcItem.left = LVIR_BOUNDS;
+    if (!LISTVIEW_GetItemRect(infoPtr, nItem, &rcItem)) {
+        ranges_destroy (selection);
+        return;
+    }
+    rcSelMark.left = LVIR_BOUNDS;
+    if (!LISTVIEW_GetItemRect(infoPtr, infoPtr->nSelectionMark, &rcSelMark)) {
+        ranges_destroy (selection);
+        return;
+    }
+    UnionRect(&rcSel, &rcItem, &rcSelMark);
+    iterator_frameditems(&i, infoPtr, &rcSel);
+    while(iterator_next(&i))
+    {
+        LISTVIEW_GetItemPosition(infoPtr, i.nItem, &ptItem);
+        if (PtInRect(&rcSel, ptItem)) ranges_additem(selection, i.nItem);
+    }
+    iterator_destroy(&i);
+    }
+#endif
+
     /* disable per item notifications on LVS_OWNERDATA style
        FIXME: single LVN_ODSTATECHANGED should be used */
     old_mask = infoPtr->notify_mask & NOTIFY_MASK_ITEM_CHANGE;


### PR DESCRIPTION
## Purpose

Fixes the behavior when selecting multiple files in a folder with the Shift key, while using either the Large Icons or Small Icons view, so that it is consistent with how it works on Windows.

JIRA issue: [CORE-10386](https://jira.reactos.org/browse/CORE-10386)

## Proposed changes

- Disable the specialized code for these views in LISTVIEW_SetGroupSelection, using the same code as for the list and details views, which also works fine for them.

## Result
Before:
![Captura de ecrã 2025-02-22 155409](https://github.com/user-attachments/assets/69747b71-0379-4bfa-b87a-5242f977c1ce)
After:
![Captura de ecrã 2025-02-22 155206](https://github.com/user-attachments/assets/b26ed36d-9fde-4f41-ac8e-46c8f9b30be1)
