### PR TITLE
[NTUSER] Handle window update region larger than the current window in clip region

### DIFF
--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -2037,7 +2037,17 @@ co_WinPosSetWindowPos(
       }
       else if(VisAfter)
       {
-         REGION_bOffsetRgn(VisAfter, -Window->rcWindow.left, -Window->rcWindow.top);
+          /* Clip existing update region to new window size */
+          if (Window->hrgnUpdate != NULL)
+          {
+              PREGION RgnUpdate = REGION_LockRgn(Window->hrgnUpdate);
+              if (RgnUpdate)
+              {
+                  RgnType = IntGdiCombineRgn(RgnUpdate, RgnUpdate, VisAfter, RGN_AND);
+                  REGION_UnlockRgn(RgnUpdate);
+              }
+          }
+          REGION_bOffsetRgn(VisAfter, -Window->rcWindow.left, -Window->rcWindow.top);
       }
 
       /*


### PR DESCRIPTION
Patch by I_Kill_Bugs for CORE-18799, CORE-18206, and CORE-19371.
I have changed the original logic to be better recommendation from I_Kill_Bugs.

## Purpose

_Adjust update region size if it is larger than current window to smaller size._

JIRA issue: [CORE-18206](https://jira.reactos.org/browse/CORE-18206)
[CORE-18799](https://jira.reactos.org/browse/CORE-18799)
[CORE-19371](https://jira.reactos.org/browse/CORE-19371)

## Proposed changes

_If Window->hrgnUpdate is not NULL, combine with VisAfter using RGN_AND before invalidating._
_Add explanatory message stating the reason for the changes._