### PR TITLE
[RICHED20] RichEditWndProc_common(): Add check for host->text_srv

### DIFF
--- a/dll/win32/riched20/txthost.c
+++ b/dll/win32/riched20/txthost.c
@@ -1284,10 +1284,7 @@ static LRESULT RichEditWndProc_common( HWND hwnd, UINT msg, WPARAM wparam,
             /* fall through */
         default:
 #ifdef __REACTOS__
-            if(host->text_srv)
-                hr = ITextServices_TxSendMessage( host->text_srv, msg, wparam, lparam, &res );
-            else
-                hr = S_FALSE;
+            hr = (host->text_srv ? ITextServices_TxSendMessage( host->text_srv, msg, wparam, lparam, &res ) : S_FALSE);
 #else
             hr = ITextServices_TxSendMessage( host->text_srv, msg, wparam, lparam, &res );
 #endif

--- a/dll/win32/riched20/txthost.c
+++ b/dll/win32/riched20/txthost.c
@@ -1283,7 +1283,14 @@ static LRESULT RichEditWndProc_common( HWND hwnd, UINT msg, WPARAM wparam,
             if (host->dialog_mode && !host->emulate_10 && handle_dialog_enter( host )) break;
             /* fall through */
         default:
+#ifdef __REACTOS__
+            if(host->text_srv)
+                hr = ITextServices_TxSendMessage( host->text_srv, msg, wparam, lparam, &res );
+            else
+                hr = S_FALSE;
+#else
             hr = ITextServices_TxSendMessage( host->text_srv, msg, wparam, lparam, &res );
+#endif
         }
         break;
 


### PR DESCRIPTION
## Purpose

_Fix crash of DevCpp caused by host->text_srv being NULL._

JIRA issue: [CORE-19991](https://jira.reactos.org/browse/CORE-19991)

## Proposed changes

_Test for host->txt_srv in RichEditWndProc_common being NULL and if so, just return S_FALSE._