### PR TITLE
[NTOS:MM] Fix broken ASSERT

### DIFF
--- a/ntoskrnl/mm/freelist.c
+++ b/ntoskrnl/mm/freelist.c
@@ -318,7 +318,7 @@ MiAllocatePagesForMdl(IN PHYSICAL_ADDRESS LowAddress,
                 // Get the PFN entry for this page
                 //
                 Pfn1 = MiGetPfnEntry(Page);
-                ASSERT(Pfn1);
+                if (!Pfn1) continue;
 
                 //
                 // Make sure it's free and if this is our first pass, zeroed


### PR DESCRIPTION
## Purpose

Fixes crash when the caller passes HighAddress below MmHighestPhysicalAddress.
Observed with nvidia miniport driver.

JIRA issue: [CORE-20008](https://jira.reactos.org/browse/CORE-20008)
 [CORE-19348](https://jira.reactos.org/browse/CORE-19348)

## Tests

- ✅ KVM x86: https://reactos.org/testman/compare.php?ids=100749,100751,100753,100757
- ✅ KVM x64: https://reactos.org/testman/compare.php?ids=100750,100752,100754,100756
