### PR TITLE
[COMCTL32_APITEST] Rename a test

### DIFF
--- a/modules/rostests/apitests/comctl32/imagelist.c
+++ b/modules/rostests/apitests/comctl32/imagelist.c
@@ -144,7 +144,7 @@ static void Test_Flags(void)
     }
 }
 
-START_TEST(imagelist)
+START_TEST(ImageListApi)
 {
     InitCommonControls();
     Test_SystemIL();

--- a/modules/rostests/apitests/comctl32/testlist.c
+++ b/modules/rostests/apitests/comctl32/testlist.c
@@ -2,14 +2,14 @@
 #include <apitest.h>
 
 extern void func_button(void);
-extern void func_imagelist(void);
+extern void func_ImageListApi(void);
 extern void func_propsheet(void);
 extern void func_toolbar(void);
 
 const struct test winetest_testlist[] =
 {
     { "buttonv6", func_button },
-    { "imagelist", func_imagelist },
+    { "ImageListApi", func_ImageListApi },
     { "propsheetv6", func_propsheet },
     { "toolbarv6", func_toolbar },
     { 0, 0 }


### PR DESCRIPTION
The test name was conflicting with an existing winetest, which breaks testman.

When adding new tests or modifying existing ones, please always run them on buildbot before merging!