### PR TITLE
[SHELL32] Display cut items as ghosted

### DIFF
--- a/dll/shellext/netshell/shfldr_netconnect.cpp
+++ b/dll/shellext/netshell/shfldr_netconnect.cpp
@@ -661,7 +661,7 @@ HRESULT WINAPI CNetConUiObject::InvokeCommand(LPCMINVOKECOMMANDINFO lpcmi)
         {
             HRESULT hr;
             CComPtr<IShellView> psv;
-            hr = IUnknown_QueryService(m_pUnknown, SID_IFolderView, IID_PPV_ARG(IShellView, &psv));
+            hr = IUnknown_QueryService(m_pUnknown, SID_SFolderView, IID_PPV_ARG(IShellView, &psv));
             if (SUCCEEDED(hr))
             {
                 SVSIF selFlags = SVSI_DESELECTOTHERS | SVSI_EDIT | SVSI_ENSUREVISIBLE | SVSI_FOCUSED | SVSI_SELECT;

--- a/dll/win32/shell32/CDefViewBckgrndMenu.cpp
+++ b/dll/win32/shell32/CDefViewBckgrndMenu.cpp
@@ -70,7 +70,7 @@ BOOL CDefViewBckgrndMenu::_bIsDesktopBrowserMenu()
 
     /* Get a pointer to the shell browser */
     CComPtr<IShellView> psv;
-    HRESULT hr = IUnknown_QueryService(m_site, SID_IFolderView, IID_PPV_ARG(IShellView, &psv));
+    HRESULT hr = IUnknown_QueryService(m_site, SID_SFolderView, IID_PPV_ARG(IShellView, &psv));
     if (FAILED_UNEXPECTEDLY(hr))
         return FALSE;
 
@@ -265,7 +265,7 @@ CDefViewBckgrndMenu::InvokeCommand(LPCMINVOKECOMMANDINFO lpcmi)
 
         /* Get a pointer to the shell browser */
         CComPtr<IShellView> psv;
-        HRESULT hr = IUnknown_QueryService(m_site, SID_IFolderView, IID_PPV_ARG(IShellView, &psv));
+        HRESULT hr = IUnknown_QueryService(m_site, SID_SFolderView, IID_PPV_ARG(IShellView, &psv));
         if (FAILED_UNEXPECTEDLY(hr))
             return hr;
 

--- a/dll/win32/shell32/CDefaultContextMenu.cpp
+++ b/dll/win32/shell32/CDefaultContextMenu.cpp
@@ -1031,10 +1031,16 @@ HRESULT CDefaultContextMenu::DoCopyOrCut(LPCMINVOKECOMMANDINFOEX lpcmi, BOOL bCo
     GlobalUnlock(medium.hGlobal);
     m_pDataObj->SetData(&formatetc, &medium, TRUE);
 
+    CComPtr<IShellFolderView> psfv;
+    if (SUCCEEDED(IUnknown_QueryService(m_site, SID_SFolderView, IID_PPV_ARG(IShellFolderView, &psfv))))
+        psfv->SetPoints(m_pDataObj);
+
     HRESULT hr = OleSetClipboard(m_pDataObj);
     if (FAILED_UNEXPECTEDLY(hr))
         return hr;
 
+    if (psfv)
+        psfv->SetClipboard(!bCopy);
     return S_OK;
 }
 
@@ -1161,7 +1167,7 @@ CDefaultContextMenu::DoCreateNewFolder(
         return S_OK;
 
     /* Get a pointer to the shell view */
-    hr = IUnknown_QueryService(m_site, SID_IFolderView, IID_PPV_ARG(IShellView, &psv));
+    hr = IUnknown_QueryService(m_site, SID_SFolderView, IID_PPV_ARG(IShellView, &psv));
     if (FAILED_UNEXPECTEDLY(hr))
         return S_OK;
 

--- a/dll/win32/shell32/CNewMenu.cpp
+++ b/dll/win32/shell32/CNewMenu.cpp
@@ -430,7 +430,7 @@ HRESULT CNewMenu::SelectNewItem(LONG wEventId, UINT uFlags, LPWSTR pszName, BOOL
         return S_OK;
 
     /* Get a pointer to the shell view */
-    hr = IUnknown_QueryService(m_pSite, SID_IFolderView, IID_PPV_ARG(IShellView, &lpSV));
+    hr = IUnknown_QueryService(m_pSite, SID_SFolderView, IID_PPV_ARG(IShellView, &lpSV));
     if (FAILED_UNEXPECTEDLY(hr))
         return S_OK;
 

--- a/dll/win32/shell32/droptargets/CFSDropTarget.cpp
+++ b/dll/win32/shell32/droptargets/CFSDropTarget.cpp
@@ -468,7 +468,7 @@ HRESULT WINAPI CFSDropTarget::Drop(IDataObject *pDataObject,
     if (*pdwEffect == DROPEFFECT_MOVE && m_site)
     {
         CComPtr<IShellFolderView> psfv;
-        HRESULT hr = IUnknown_QueryService(m_site, SID_IFolderView, IID_PPV_ARG(IShellFolderView, &psfv));
+        HRESULT hr = IUnknown_QueryService(m_site, SID_SFolderView, IID_PPV_ARG(IShellFolderView, &psfv));
         if (SUCCEEDED(hr) && psfv->IsDropOnSource(this) == S_OK)
         {
             _RepositionItems(psfv, pDataObject, pt);

--- a/dll/win32/shell32/folders/CRecycleBin.cpp
+++ b/dll/win32/shell32/folders/CRecycleBin.cpp
@@ -505,7 +505,7 @@ fail:
     return mem;
 }
 
-typedef struct
+typedef struct _FILEOPDATA
 {
     PCUITEMID_CHILD_ARRAY apidl;
     UINT cidl, index;

--- a/dll/win32/shell32/precomp.h
+++ b/dll/win32/shell32/precomp.h
@@ -322,7 +322,7 @@ InvokeIExecuteCommandWithDataObject(
     _In_opt_ LPCMINVOKECOMMANDINFOEX pICI,
     _In_opt_ IUnknown *pSite);
 
-typedef enum {
+typedef enum _FILEOPCALLBACKEVENT {
     FOCE_STARTOPERATIONS,
     FOCE_FINISHOPERATIONS,
     FOCE_PREMOVEITEM,

--- a/dll/win32/shell32/shelldesktop/CDirectoryWatcher.cpp
+++ b/dll/win32/shell32/shelldesktop/CDirectoryWatcher.cpp
@@ -299,7 +299,8 @@ GetFilterFromEvents(DWORD fEvents)
     return (FILE_NOTIFY_CHANGE_FILE_NAME |
             FILE_NOTIFY_CHANGE_DIR_NAME |
             FILE_NOTIFY_CHANGE_CREATION |
-            FILE_NOTIFY_CHANGE_SIZE);
+            FILE_NOTIFY_CHANGE_SIZE |
+            FILE_NOTIFY_CHANGE_ATTRIBUTES);
 }
 
 // Restart a watch by using ReadDirectoryChangesW function

--- a/dll/win32/shell32/utils.h
+++ b/dll/win32/shell32/utils.h
@@ -93,9 +93,7 @@ SHELL_CreateFallbackExtractIconForNoAssocFile(REFIID riid, LPVOID *ppvOut)
 
 struct ClipboardViewerChain
 {
-    HWND m_hWndNext;
-
-    ClipboardViewerChain() : m_hWndNext(HWND_BOTTOM) {}
+    HWND m_hWndNext = HWND_BOTTOM;
 
     void Unhook(HWND hWnd)
     {

--- a/sdk/include/psdk/shobjidl.idl
+++ b/sdk/include/psdk/shobjidl.idl
@@ -898,6 +898,7 @@ interface IFolderView : IUnknown
         [in] DWORD flags
     );
 }
+cpp_quote("#define SID_SFolderView IID_IFolderView")
 
 [v1_enum] enum tagSORTDIRECTION
 {

--- a/sdk/include/reactos/shlguid_undoc.h
+++ b/sdk/include/reactos/shlguid_undoc.h
@@ -211,7 +211,6 @@ DEFINE_GUID(IID_IPinnedList,               0xBBD20037, 0xBC0E, 0x42F1, 0x91, 0x3
 
 #define SID_STravelLogCursor IID_ITravelLogStg
 #define SID_IBandSite IID_IBandSite
-#define SID_IFolderView IID_IFolderView
 #define SID_IShellBrowser IID_IShellBrowser
 
 #endif // __SHLGUID_UNDOC_H


### PR DESCRIPTION
- When Ctrl+X is pressed on a selected item, it will appear ghosted until another clipboard action takes place.
- Generate `SHCNE_UPDATE*` notifications when file attributes change.
- When an items hidden attribute is changed (filesystem notification), we must update the ghosted state.

[CORE-9465](https://jira.reactos.org/browse/CORE-9465)