### PR TITLE
[SETUPAPI] Do not fail enumeration on invalid device interface keys

### DIFF
--- a/dll/win32/setupapi/interface.c
+++ b/dll/win32/setupapi/interface.c
@@ -213,7 +213,10 @@ SETUP_CreateInterfaceList(
             /* Read SymbolicLink value */
             rc = RegQueryValueExW(hReferenceKey, SymbolicLink, NULL, &dwRegType, NULL, &dwLength);
             if (rc != ERROR_SUCCESS )
-                goto cleanup;
+            {
+                RegCloseKey(hReferenceKey);
+                continue;
+            }
             if (dwRegType != REG_SZ)
             {
                 rc = ERROR_GEN_FAILURE;

--- a/dll/win32/setupapi/interface.c
+++ b/dll/win32/setupapi/interface.c
@@ -212,7 +212,7 @@ SETUP_CreateInterfaceList(
 
             /* Read SymbolicLink value */
             rc = RegQueryValueExW(hReferenceKey, SymbolicLink, NULL, &dwRegType, NULL, &dwLength);
-            if (rc != ERROR_SUCCESS )
+            if (rc != ERROR_SUCCESS)
             {
                 RegCloseKey(hReferenceKey);
                 continue;

--- a/dll/win32/setupapi/interface.c
+++ b/dll/win32/setupapi/interface.c
@@ -214,6 +214,7 @@ SETUP_CreateInterfaceList(
             rc = RegQueryValueExW(hReferenceKey, SymbolicLink, NULL, &dwRegType, NULL, &dwLength);
             if (rc != ERROR_SUCCESS)
             {
+                /* Skip device interface with invalid reference value (i.e. interface not actually available for this device) */
                 RegCloseKey(hReferenceKey);
                 continue;
             }


### PR DESCRIPTION
## setupapi improvement
- Don't stop enumeration on invalid device interface key
- Necessary for drivers, which install multiple device interfaces and all interfaces might not be available for this device.

