### PR TITLE
[NTOS:KE] Implement KeI386VirtualIntExtensions code paths for INT and IRET

### DIFF
--- a/ntoskrnl/ke/i386/v86vdm.c
+++ b/ntoskrnl/ke/i386/v86vdm.c
@@ -191,13 +191,21 @@ KiVdmOpcodeINTnn(IN PKTRAP_FRAME TrapFrame,
     V86EFlags &= (EFLAGS_ALIGN_CHECK | EFLAGS_INTERRUPT_MASK);
 
     /* Check for VME support */
-    ASSERT(KeI386VirtualIntExtensions == FALSE);
+    if (KeI386VirtualIntExtensions)
+    {
+        /* Set IF based on VIF */
+        V86EFlags &= ~EFLAGS_INTERRUPT_MASK;
+        if (TrapEFlags & EFLAGS_VIF)
+        {
+            V86EFlags |= EFLAGS_INTERRUPT_MASK;
+        }
+    }
 
     /* Mask in the relevant V86 EFlags into the trap flags */
     V86EFlags |= (TrapEFlags & ~EFLAGS_INTERRUPT_MASK);
 
     /* And mask out the VIF, nested task and TF flag from the trap flags */
-    TrapFrame->EFlags = TrapEFlags &~ (EFLAGS_VIF | EFLAGS_NESTED_TASK | EFLAGS_TF);
+    TrapFrame->EFlags = TrapEFlags & ~(EFLAGS_VIF | EFLAGS_NESTED_TASK | EFLAGS_TF);
 
     /* Add the IOPL flag to the local trap flags */
     V86EFlags |= EFLAGS_IOPL;
@@ -299,11 +307,17 @@ KiVdmOpcodeIRET(IN PKTRAP_FRAME TrapFrame,
     }
 
     /* Mask out EFlags */
-    EFlags &= ~(EFLAGS_IOPL + EFLAGS_VIF + EFLAGS_NESTED_TASK + EFLAGS_VIP);
+    EFlags &= ~(EFLAGS_VIP | EFLAGS_VIF | EFLAGS_NESTED_TASK | EFLAGS_IOPL);
     V86EFlags = EFlags;
 
     /* Check for VME support */
-    ASSERT(KeI386VirtualIntExtensions == FALSE);
+    if (KeI386VirtualIntExtensions)
+    {
+        if (EFlags & EFLAGS_INTERRUPT_MASK)
+        {
+            EFlags |= EFLAGS_VIF;
+        }
+    }
 
     /* Add V86 and Interrupt flag */
     EFlags |= EFLAGS_V86_MASK | EFLAGS_INTERRUPT_MASK;


### PR DESCRIPTION
In order for 0.4.15 to continue its release process we should probably get this in. 
Continued from PR #6070

JIRA issue: [CORE-19049](https://jira.reactos.org/browse/CORE-19049)

- [x] KVM x86: https://reactos.org/testman//compare.php?ids=100758,100768
- [x] KVM x64: https://reactos.org/testman//compare.php?ids=100759,100767
