### PR TITLE
[FREELDR] Fix menu display on VMWare

### DIFF
--- a/boot/freeldr/freeldr/bootmgr.c
+++ b/boot/freeldr/freeldr/bootmgr.c
@@ -427,8 +427,8 @@ VOID RunLoader(VOID)
 
     for (;;)
     {
-        /* Redraw the backdrop */
-        UiDrawBackdrop();
+        /* Redraw the backdrop, but don't overwrite boot options */
+        UiDrawBackdrop(UiGetScreenHeight() - 2);
 
         /* Show the operating system list menu */
         if (!UiDisplayMenu("Please select the operating system to start:",

--- a/boot/freeldr/freeldr/include/ui.h
+++ b/boot/freeldr/freeldr/include/ui.h
@@ -53,7 +53,7 @@ extern const PCSTR UiMonthNames[12];
 
 BOOLEAN    UiInitialize(BOOLEAN ShowUi);                                // Initialize User-Interface
 VOID    UiUnInitialize(PCSTR BootText);                        // Un-initialize User-Interface
-VOID    UiDrawBackdrop(VOID);                                    // Fills the entire screen with a backdrop
+VOID    UiDrawBackdrop(ULONG DrawHeight);                      // Fills the entire screen with a backdrop
 VOID    UiFillArea(ULONG Left, ULONG Top, ULONG Right, ULONG Bottom, CHAR FillChar, UCHAR Attr /* Color Attributes */);    // Fills the area specified with FillChar and Attr
 VOID    UiDrawShadow(ULONG Left, ULONG Top, ULONG Right, ULONG Bottom);    // Draws a shadow on the bottom and right sides of the area specified
 VOID    UiDrawBox(ULONG Left, ULONG Top, ULONG Right, ULONG Bottom, UCHAR VertStyle, UCHAR HorzStyle, BOOLEAN Fill, BOOLEAN Shadow, UCHAR Attr);    // Draws a box around the area specified
@@ -202,7 +202,7 @@ BOOLEAN    UiEditBox(PCSTR MessageText, PCHAR EditTextBuffer, ULONG Length);
 UCHAR    UiTextToColor(PCSTR ColorText);                        // Converts the text color into it's equivalent color value
 UCHAR    UiTextToFillStyle(PCSTR FillStyleText);                // Converts the text fill into it's equivalent fill value
 
-VOID    UiFadeInBackdrop(VOID);                                    // Draws the backdrop and fades the screen in
+VOID    UiFadeInBackdrop(ULONG DrawHeight);                     // Draws the backdrop and fades the screen in
 VOID    UiFadeOut(VOID);                                        // Fades the screen out
 
 /* Menu Functions ************************************************************/
@@ -254,7 +254,7 @@ typedef struct tagUIVTBL
     BOOLEAN (*Initialize)(VOID);
     VOID (*UnInitialize)(VOID);
 
-    VOID (*DrawBackdrop)(VOID);
+    VOID (*DrawBackdrop)(ULONG DrawHeight);
     VOID (*FillArea)(ULONG Left, ULONG Top, ULONG Right, ULONG Bottom, CHAR FillChar, UCHAR Attr);
     VOID (*DrawShadow)(ULONG Left, ULONG Top, ULONG Right, ULONG Bottom);
     VOID (*DrawBox)(ULONG Left, ULONG Top, ULONG Right, ULONG Bottom, UCHAR VertStyle, UCHAR HorzStyle, BOOLEAN Fill, BOOLEAN Shadow, UCHAR Attr);
@@ -285,7 +285,7 @@ typedef struct tagUIVTBL
     BOOLEAN (*EditBox)(PCSTR MessageText, PCHAR EditTextBuffer, ULONG Length);
     UCHAR (*TextToColor)(PCSTR ColorText);
     UCHAR (*TextToFillStyle)(PCSTR FillStyleText);
-    VOID (*FadeInBackdrop)(VOID);
+    VOID (*FadeInBackdrop)(ULONG DrawHeight);
     VOID (*FadeOut)(VOID);
 
     BOOLEAN (*DisplayMenu)(

--- a/boot/freeldr/freeldr/include/ui/minitui.h
+++ b/boot/freeldr/freeldr/include/ui/minitui.h
@@ -10,7 +10,7 @@
 
 /* Textual User Interface Functions ******************************************/
 
-VOID MiniTuiDrawBackdrop(VOID);
+VOID MiniTuiDrawBackdrop(ULONG DrawHeight);
 VOID MiniTuiDrawStatusText(PCSTR StatusText);
 
 VOID

--- a/boot/freeldr/freeldr/include/ui/noui.h
+++ b/boot/freeldr/freeldr/include/ui/noui.h
@@ -13,7 +13,7 @@
 BOOLEAN NoUiInitialize(VOID);
 VOID NoUiUnInitialize(VOID);
 
-VOID NoUiDrawBackdrop(VOID);
+VOID NoUiDrawBackdrop(ULONG DrawHeight);
 VOID NoUiFillArea(ULONG Left, ULONG Top, ULONG Right, ULONG Bottom, CHAR FillChar, UCHAR Attr);
 VOID NoUiDrawShadow(ULONG Left, ULONG Top, ULONG Right, ULONG Bottom);
 VOID NoUiDrawBox(ULONG Left, ULONG Top, ULONG Right, ULONG Bottom, UCHAR VertStyle, UCHAR HorzStyle, BOOLEAN Fill, BOOLEAN Shadow, UCHAR Attr);
@@ -84,7 +84,7 @@ NoUiDrawProgressBar(
 BOOLEAN NoUiEditBox(PCSTR MessageText, PCHAR EditTextBuffer, ULONG Length);
 UCHAR NoUiTextToColor(PCSTR ColorText);
 UCHAR NoUiTextToFillStyle(PCSTR FillStyleText);
-VOID NoUiFadeInBackdrop(VOID);
+VOID NoUiFadeInBackdrop(ULONG DrawHeight);
 VOID NoUiFadeOut(VOID);
 
 /* Menu Functions ************************************************************/

--- a/boot/freeldr/freeldr/include/ui/tui.h
+++ b/boot/freeldr/freeldr/include/ui/tui.h
@@ -37,7 +37,7 @@ TuiTruncateStringEllipsis(
 BOOLEAN    TuiInitialize(VOID);                                    // Initialize User-Interface
 VOID    TuiUnInitialize(VOID);                                    // Un-initialize User-Interface
 
-VOID    TuiDrawBackdrop(VOID);                                    // Fills the entire screen with a backdrop
+VOID    TuiDrawBackdrop(ULONG DrawHeight);                        // Fills the entire screen with a backdrop
 VOID    TuiFillArea(ULONG Left, ULONG Top, ULONG Right, ULONG Bottom, CHAR FillChar, UCHAR Attr /* Color Attributes */);    // Fills the area specified with FillChar and Attr
 VOID    TuiDrawShadow(ULONG Left, ULONG Top, ULONG Right, ULONG Bottom);    // Draws a shadow on the bottom and right sides of the area specified
 
@@ -127,7 +127,7 @@ BOOLEAN    TuiEditBox(PCSTR MessageText, PCHAR EditTextBuffer, ULONG Length);
 UCHAR    TuiTextToColor(PCSTR ColorText);                        // Converts the text color into it's equivalent color value
 UCHAR    TuiTextToFillStyle(PCSTR FillStyleText);                // Converts the text fill into it's equivalent fill value
 
-VOID    TuiFadeInBackdrop(VOID);                                // Draws the backdrop and fades the screen in
+VOID    TuiFadeInBackdrop(ULONG DrawHeight);                     // Draws the backdrop and fades the screen in
 VOID    TuiFadeOut(VOID);                                        // Fades the screen out
 
 /* Menu Functions ************************************************************/

--- a/boot/freeldr/freeldr/linuxboot.c
+++ b/boot/freeldr/freeldr/linuxboot.c
@@ -114,7 +114,7 @@ LoadAndBootLinux(
     else
         strcpy(LinuxBootDescription, "Loading Linux...");
 
-    UiDrawBackdrop();
+    UiDrawBackdrop(UiGetScreenHeight());
     UiDrawStatusText(LinuxBootDescription);
     UiDrawProgressBarCenter(LinuxBootDescription);
 

--- a/boot/freeldr/freeldr/ntldr/setupldr.c
+++ b/boot/freeldr/freeldr/ntldr/setupldr.c
@@ -531,7 +531,7 @@ LoadReactOSSetup(
     }
 
     /* Let the user know we started loading */
-    UiDrawBackdrop();
+    UiDrawBackdrop(UiGetScreenHeight());
     UiDrawStatusText("Setup is loading...");
     UiDrawProgressBarCenter("Loading ReactOS Setup...");
 

--- a/boot/freeldr/freeldr/ntldr/winldr.c
+++ b/boot/freeldr/freeldr/ntldr/winldr.c
@@ -1030,7 +1030,7 @@ LoadAndBootWindows(
     }
 
     /* Let the user know we started loading */
-    UiDrawBackdrop();
+    UiDrawBackdrop(UiGetScreenHeight());
     UiDrawStatusText("Loading...");
     UiDrawProgressBarCenter("Loading NT...");
 

--- a/boot/freeldr/freeldr/options.c
+++ b/boot/freeldr/freeldr/options.c
@@ -108,7 +108,7 @@ VOID DoOptionsMenu(IN OperatingSystemItem* OperatingSystem)
     }
 
     /* Clear the backdrop */
-    UiDrawBackdrop();
+    UiDrawBackdrop(UiGetScreenHeight());
 
     switch (SelectedMenuItem)
     {

--- a/boot/freeldr/freeldr/ui/directui.c
+++ b/boot/freeldr/freeldr/ui/directui.c
@@ -35,7 +35,7 @@ UiInitialize(IN BOOLEAN ShowUi)
     MachVideoGetDisplaySize(&UiScreenWidth, &UiScreenHeight, &Depth);
 
     /* Clear the screen */
-    UiDrawBackdrop();
+    UiDrawBackdrop(UiGetScreenHeight());
     return TRUE;
 }
 
@@ -47,7 +47,7 @@ UiUnInitialize(IN PCSTR BootText)
 }
 
 VOID
-UiDrawBackdrop(VOID)
+UiDrawBackdrop(ULONG DrawHeight)
 {
     /* Clear the screen */
     MachVideoClearScreen(ATTR(COLOR_WHITE, COLOR_BLACK));

--- a/boot/freeldr/freeldr/ui/minitui.c
+++ b/boot/freeldr/freeldr/ui/minitui.c
@@ -53,10 +53,10 @@ BOOLEAN MiniTuiInitialize(VOID)
     return TRUE;
 }
 
-VOID MiniTuiDrawBackdrop(VOID)
+VOID MiniTuiDrawBackdrop(ULONG DrawHeight)
 {
     /* Fill in a black background */
-    TuiFillArea(0, 0, UiScreenWidth - 1, UiScreenHeight - 3,
+    TuiFillArea(0, 0, UiScreenWidth - 1, DrawHeight - 1,
                 UiBackdropFillStyle,
                 ATTR(UiBackdropFgColor, UiBackdropBgColor));
 
@@ -186,7 +186,7 @@ MiniTuiDrawMenu(
     ULONG i;
 
     /* Draw the backdrop */
-    UiDrawBackdrop();
+    UiDrawBackdrop(UiGetScreenHeight());
 
     /* No GUI status bar text, just minimal text. Show the menu header. */
     if (MenuInfo->MenuHeader)

--- a/boot/freeldr/freeldr/ui/noui.c
+++ b/boot/freeldr/freeldr/ui/noui.c
@@ -17,7 +17,7 @@ VOID NoUiUnInitialize(VOID)
 {
 }
 
-VOID NoUiDrawBackdrop(VOID)
+VOID NoUiDrawBackdrop(ULONG DrawHeight)
 {
 }
 
@@ -145,7 +145,7 @@ UCHAR NoUiTextToFillStyle(PCSTR FillStyleText)
     return 0;
 }
 
-VOID NoUiFadeInBackdrop(VOID)
+VOID NoUiFadeInBackdrop(ULONG DrawHeight)
 {
 }
 

--- a/boot/freeldr/freeldr/ui/tui.c
+++ b/boot/freeldr/freeldr/ui/tui.c
@@ -269,13 +269,13 @@ VOID TuiUnInitialize(VOID)
     MachVideoHideShowTextCursor(TRUE);
 }
 
-VOID TuiDrawBackdrop(VOID)
+VOID TuiDrawBackdrop(ULONG DrawHeight)
 {
     /* Fill in the background (excluding title box & status bar) */
     TuiFillArea(0,
                 TUI_TITLE_BOX_CHAR_HEIGHT,
                 UiScreenWidth - 1,
-                UiScreenHeight - 3,
+                DrawHeight - 2,
                 UiBackdropFillStyle,
                 ATTR(UiBackdropFgColor, UiBackdropBgColor));
 
@@ -979,7 +979,7 @@ UCHAR TuiTextToFillStyle(PCSTR FillStyleText)
     return LIGHT_FILL;
 }
 
-VOID TuiFadeInBackdrop(VOID)
+VOID TuiFadeInBackdrop(ULONG DrawHeight)
 {
     PPALETTE_ENTRY TuiFadePalette = NULL;
 
@@ -996,7 +996,7 @@ VOID TuiFadeInBackdrop(VOID)
     }
 
     // Draw the backdrop and title box
-    TuiDrawBackdrop();
+    TuiDrawBackdrop(UiGetScreenHeight());
 
     if (UiUseSpecialEffects && ! MachVideoIsPaletteFixed() && TuiFadePalette != NULL)
     {

--- a/boot/freeldr/freeldr/ui/tuimenu.c
+++ b/boot/freeldr/freeldr/ui/tuimenu.c
@@ -202,7 +202,7 @@ TuiDrawMenu(
 
     // FIXME: Theme-specific
     /* Draw the backdrop */
-    UiDrawBackdrop();
+    UiDrawBackdrop(UiGetScreenHeight());
 
     /* Draw the menu box */
     TuiDrawMenuBox(MenuInfo);

--- a/boot/freeldr/freeldr/ui/ui.c
+++ b/boot/freeldr/freeldr/ui/ui.c
@@ -215,7 +215,7 @@ BOOLEAN UiInitialize(BOOLEAN ShowUi)
     }
 
     /* Draw the backdrop and fade it in if special effects are enabled */
-    UiFadeInBackdrop();
+    UiFadeInBackdrop(UiGetScreenHeight());
 
     TRACE("UiInitialize() returning TRUE.\n");
     return TRUE;
@@ -223,16 +223,16 @@ BOOLEAN UiInitialize(BOOLEAN ShowUi)
 
 VOID UiUnInitialize(PCSTR BootText)
 {
-    UiDrawBackdrop();
+    UiDrawBackdrop(UiGetScreenHeight());
     UiDrawStatusText(BootText);
     UiInfoBox(BootText);
 
     UiVtbl.UnInitialize();
 }
 
-VOID UiDrawBackdrop(VOID)
+VOID UiDrawBackdrop(ULONG DrawHeight)
 {
-    UiVtbl.DrawBackdrop();
+    UiVtbl.DrawBackdrop(DrawHeight);
 }
 
 VOID UiFillArea(ULONG Left, ULONG Top, ULONG Right, ULONG Bottom, CHAR FillChar, UCHAR Attr /* Color Attributes */)
@@ -620,9 +620,9 @@ UiDisplayMenu(
                               KeyPressFilter, Context);
 }
 
-VOID UiFadeInBackdrop(VOID)
+VOID UiFadeInBackdrop(ULONG DrawHeight)
 {
-    UiVtbl.FadeInBackdrop();
+    UiVtbl.FadeInBackdrop(DrawHeight);
 }
 
 VOID UiFadeOut(VOID)


### PR DESCRIPTION
When drawing the menu, the boot options should not be overwritten, but when clearing the screen, everything needs to be drawn, otherwise there will be uninitialized characters at the bottom.
