### PR TITLE
[NTOS:EX] Check boot-time drivers for MP support

### DIFF
--- a/ntoskrnl/ex/init.c
+++ b/ntoskrnl/ex/init.c
@@ -863,6 +863,16 @@ ExpLoadBootSymbols(
                                 LdrEntry->DllBase,
                                 (ULONG_PTR)PsGetCurrentProcessId());
         }
+
+#ifdef CONFIG_SMP
+        /* Check that the image is safe to use if we have more than one CPU */
+        if (!MmVerifyImageIsOkForMpUse(LdrEntry->DllBase))
+        {
+            KeBugCheckEx(UP_DRIVER_ON_MP_SYSTEM,
+                         (ULONG_PTR)LdrEntry->DllBase,
+                         0, 0, 0);
+        }
+#endif // CONFIG_SMP
     }
 }
 

--- a/ntoskrnl/include/internal/mm.h
+++ b/ntoskrnl/include/internal/mm.h
@@ -1649,6 +1649,13 @@ MmUnloadSystemImage(
     IN PVOID ImageHandle
 );
 
+#ifdef CONFIG_SMP
+BOOLEAN
+NTAPI
+MmVerifyImageIsOkForMpUse(
+    _In_ PVOID BaseAddress);
+#endif // CONFIG_SMP
+
 NTSTATUS
 NTAPI
 MmCheckSystemImage(

--- a/sdk/include/reactos/mc/bugcodes.mc
+++ b/sdk/include/reactos/mc/bugcodes.mc
@@ -1179,6 +1179,14 @@ Language=English
 WIN32K_INIT_OR_RIT_FAILURE
 .
 
+MessageId=0x92
+Severity=Success
+Facility=System
+SymbolicName=UP_DRIVER_ON_MP_SYSTEM
+Language=English
+UP_DRIVER_ON_MP_SYSTEM
+.
+
 MessageId=0x93
 Severity=Success
 Facility=System


### PR DESCRIPTION
## Purpose

Check whether the boot-time drivers are safe to use on MP systems.

## Proposed changes

Invoke the MmVerifyImageIsOkForMpUse() helper. If the boot-time driver
only supports a monoprocessor system, bugcheck with UP_DRIVER_ON_MP_SYSTEM.

https://learn.microsoft.com/en-us/windows-hardware/drivers/debugger/bug-check-0x92--up-driver-on-mp-system

Note that we don't do this check very soon at boot time (e.g. in
MiReloadBootLoadedDrivers or MiInitializeLoadedModuleList), but only
after loading the drivers' debug symbols (if any).
The reason is simply to ease debugging in case we bugcheck: this allows
having the debugger set up with the symbols for this driver.

For automatic and manual driver loading, MmVerifyImageIsOkForMpUse()
is invoked by MmCheckSystemImage() but in this case, there is graceful
failure and no bugcheck.
