### PR TITLE
[NTOS:OB] Allow ObpCaseInsensitive to be configured via registry.

### DIFF
--- a/ntoskrnl/config/cmdata.c
+++ b/ntoskrnl/config/cmdata.c
@@ -543,6 +543,13 @@ DATA_SEG("INITDATA") CM_SYSTEM_CONTROL_VECTOR CmControlVector[] =
         NULL
     },
     {
+        L"Session Manager\\Kernel",
+        L"ObCaseInsensitive",
+        &ObpCaseInsensitive,
+        NULL,
+        NULL
+    },
+    {
         L"Session Manager\\I/O System",
         L"CountOperations",
         &DummyData,

--- a/ntoskrnl/include/internal/ob.h
+++ b/ntoskrnl/include/internal/ob.h
@@ -648,6 +648,7 @@ extern ALIGNEDNAME ObpDosDevicesShortNameRoot;
 extern UNICODE_STRING ObpDosDevicesShortName;
 extern WCHAR ObpUnsecureGlobalNamesBuffer[128];
 extern ULONG ObpUnsecureGlobalNamesLength;
+extern ULONG ObpCaseInsensitive;
 extern ULONG ObpObjectSecurityMode;
 extern ULONG ObpProtectionMode;
 extern ULONG ObpLUIDDeviceMapsDisabled;

--- a/ntoskrnl/include/internal/ob.h
+++ b/ntoskrnl/include/internal/ob.h
@@ -205,7 +205,7 @@ ObpLookupEntryDirectory(
     IN POBJECT_DIRECTORY Directory,
     IN PUNICODE_STRING Name,
     IN ULONG Attributes,
-    IN UCHAR SearchShadow,
+    IN BOOLEAN SearchShadow,
     IN POBP_LOOKUP_CONTEXT Context
 );
 

--- a/ntoskrnl/ob/obdir.c
+++ b/ntoskrnl/ob/obdir.c
@@ -158,7 +158,7 @@ NTAPI
 ObpLookupEntryDirectory(IN POBJECT_DIRECTORY Directory,
                         IN PUNICODE_STRING Name,
                         IN ULONG Attributes,
-                        IN UCHAR SearchShadow,
+                        IN BOOLEAN SearchShadow,
                         IN POBP_LOOKUP_CONTEXT Context)
 {
     BOOLEAN CaseInsensitive = FALSE;

--- a/ntoskrnl/ob/obname.c
+++ b/ntoskrnl/ob/obname.c
@@ -15,7 +15,7 @@
 #define NDEBUG
 #include <debug.h>
 
-BOOLEAN ObpCaseInsensitive = TRUE;
+ULONG ObpCaseInsensitive = TRUE;
 POBJECT_DIRECTORY ObpRootDirectoryObject;
 POBJECT_DIRECTORY ObpTypeDirectoryObject;
 


### PR DESCRIPTION
## Purpose

This feature corresponds to the system policy:
"System objects: Require case insensitivity for non-Windows subsystems"
https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/jj852277(v=ws.11)
https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-10/security/threat-protection/security-policy-settings/system-objects-require-case-insensitivity-for-non-windows-subsystems

It is also used in conjunction with NTFS to get system-wide filesystem case-sensitivity:
https://www.betaarchive.com/wiki/index.php/Microsoft_KB_Archive/929110

This is controlled with a REG_DWORD value named `ObCaseInsensitive`
inside the registry key
`HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Kernel` .

Object case (in)sensitivity check is done in the ObpLookupObjectName() helper.
The `ObpCaseInsensitive` variable is used to retrieve the data,
hence it needs to be a ULONG.
