### PR TITLE
[BROWSEUI][SHELL32] Fix FindFolder icons

### DIFF
--- a/dll/win32/browseui/shellfind/CFindFolder.cpp
+++ b/dll/win32/browseui/shellfind/CFindFolder.cpp
@@ -200,7 +200,7 @@ void CFindFolder::FreePidlArray(HDPA hDpa)
 
 HDPA CFindFolder::CreateAbsolutePidlArray(UINT cidl, PCUITEMID_CHILD_ARRAY apidl)
 {
-    HDPA hDpa = = DPA_Create(0);
+    HDPA hDpa = DPA_Create(0);
     if (hDpa)
     {
         for (UINT i = 0; i < cidl; ++i)
@@ -1007,7 +1007,9 @@ STDMETHODIMP CFindFolder::GetUIObjectOf(HWND hwndOwner, UINT cidl, PCUITEMID_CHI
         aFSPidl = aFSPidlAlloc;
     }
     for (UINT i = 0; i < cidl; i++)
+    {
         aFSPidl[i] = _ILGetFSPidl(apidl[i]);
+    }
 
     if (riid == IID_IContextMenu)
     {
@@ -1138,3 +1140,4 @@ STDMETHODIMP CFindFolder::GetClassID(CLSID *pClassId)
     *pClassId = CLSID_FindFolder;
     return S_OK;
 }
+  

--- a/dll/win32/browseui/shellfind/CFindFolder.cpp
+++ b/dll/win32/browseui/shellfind/CFindFolder.cpp
@@ -107,7 +107,7 @@ static LPITEMIDLIST _ILCreate(LPCWSTR lpszPath)
     }
     LPITEMIDLIST lpLastFSPidl = ILFindLastID(lpFSPidl);
 
-    SIZE_T cbPath = ((PathFindFileNameW(lpszPath) - lpszPath) + 1) * sizeof(WCHAR);
+    SIZE_T cbPath = (PathFindFileNameW(lpszPath) - lpszPath + 1) * sizeof(WCHAR);
     SIZE_T cbData = sizeof(WORD) + cbPath + lpLastFSPidl->mkid.cb;
     if (cbData > 0xffff)
         return NULL;
@@ -200,8 +200,8 @@ void CFindFolder::FreePidlArray(HDPA hDpa)
 
 HDPA CFindFolder::CreateAbsolutePidlArray(UINT cidl, PCUITEMID_CHILD_ARRAY apidl)
 {
-    HDPA hDpa;
-    if ((hDpa = DPA_Create(0)) != NULL)
+    HDPA hDpa = = DPA_Create(0);
+    if (hDpa)
     {
         for (UINT i = 0; i < cidl; ++i)
         {
@@ -853,7 +853,7 @@ STDMETHODIMP CFindFolder::CompareIDs(LPARAM lParam, PCUIDLIST_RELATIVE pidl1, PC
         wColumn -= _countof(g_ColumnDefs) - 1;
         break;
     }
-    // FIXME:
+    // FIXME: DefView does not like the way we sort
     return m_pisfInner->CompareIDs(HIWORD(lParam) | wColumn, _ILGetFSPidl(pidl1), _ILGetFSPidl(pidl2));
 }
 

--- a/dll/win32/browseui/shellfind/CFindFolder.cpp
+++ b/dll/win32/browseui/shellfind/CFindFolder.cpp
@@ -1140,4 +1140,3 @@ STDMETHODIMP CFindFolder::GetClassID(CLSID *pClassId)
     *pClassId = CLSID_FindFolder;
     return S_OK;
 }
-  

--- a/dll/win32/browseui/shellfind/CFindFolder.cpp
+++ b/dll/win32/browseui/shellfind/CFindFolder.cpp
@@ -84,7 +84,7 @@ struct FolderViewColumns
     int cxChar;
 };
 
-static FolderViewColumns g_ColumnDefs[] =
+static const FolderViewColumns g_ColumnDefs[] =
 {
     {IDS_COL_NAME,      SHCOLSTATE_TYPE_STR | SHCOLSTATE_ONBYDEFAULT, LVCFMT_LEFT, 30},
     {IDS_COL_LOCATION,  SHCOLSTATE_TYPE_STR | SHCOLSTATE_ONBYDEFAULT, LVCFMT_LEFT, 30},
@@ -92,6 +92,7 @@ static FolderViewColumns g_ColumnDefs[] =
 };
 
 CFindFolder::CFindFolder() :
+    m_pidl(NULL),
     m_hStopEvent(NULL)
 {
 }
@@ -106,26 +107,32 @@ static LPITEMIDLIST _ILCreate(LPCWSTR lpszPath)
     }
     LPITEMIDLIST lpLastFSPidl = ILFindLastID(lpFSPidl);
 
-    int pathLen = (PathFindFileNameW(lpszPath) - lpszPath) * sizeof(WCHAR);
-    int cbData = sizeof(WORD) + pathLen + lpLastFSPidl->mkid.cb;
+    SIZE_T cbPath = ((PathFindFileNameW(lpszPath) - lpszPath) + 1) * sizeof(WCHAR);
+    SIZE_T cbData = sizeof(WORD) + cbPath + lpLastFSPidl->mkid.cb;
+    if (cbData > 0xffff)
+        return NULL;
     LPITEMIDLIST pidl = (LPITEMIDLIST) SHAlloc(cbData + sizeof(WORD));
     if (!pidl)
         return NULL;
 
     LPBYTE p = (LPBYTE) pidl;
-    *((WORD *) p) = cbData;
-    p += sizeof(WORD);
+    p += sizeof(WORD); // mkid.cb
 
-    memcpy(p, lpszPath, pathLen);
-    p += pathLen - sizeof(WCHAR);
-    *((WCHAR *) p) = '\0';
-    p += sizeof(WCHAR);
+    PWSTR path = (PWSTR)p;
+    memcpy(p, lpszPath, cbPath);
+    p += cbPath;
+    ((PWSTR)p)[-1] = UNICODE_NULL; // "C:\" not "C:" (required by ILCreateFromPathW and matches Windows)
+    if (!PathIsRootW(path))
+    {
+        p -= sizeof(WCHAR);
+        ((PWSTR)p)[-1] = UNICODE_NULL; // "C:\folder"
+    }
 
     memcpy(p, lpLastFSPidl, lpLastFSPidl->mkid.cb);
     p += lpLastFSPidl->mkid.cb;
 
-    *((WORD *) p) = 0;
-
+    pidl->mkid.cb = p - (LPBYTE)pidl;
+    *((WORD *) p) = 0; // Terminator
     return pidl;
 }
 
@@ -142,6 +149,74 @@ static LPCITEMIDLIST _ILGetFSPidl(LPCITEMIDLIST pidl)
         return pidl;
     return (LPCITEMIDLIST) ((LPBYTE) pidl->mkid.abID
                             + ((wcslen((LPCWSTR) pidl->mkid.abID) + 1) * sizeof(WCHAR)));
+}
+
+static PIDLIST_ABSOLUTE _ILCreateAbsolute(LPCITEMIDLIST pidlChild)
+{
+    PIDLIST_ABSOLUTE pidl = NULL;
+    if (PIDLIST_ABSOLUTE pidlFolder = SHSimpleIDListFromPath(_ILGetPath(pidl))) // FIXME: SHELL32_CreateSimpleIDListFromPath(, DIRECTORY)
+    {
+        pidl = ILCombine(pidlFolder, _ILGetFSPidl(pidl));
+        ILFree(pidlFolder);
+    }
+    return pidl;
+}
+
+HRESULT CFindFolder::GetFSFolderAndChild(LPCITEMIDLIST pidl, IShellFolder **ppSF, PCUITEMID_CHILD *ppidlLast)
+{
+    ATLASSERT(m_pSfDesktop);
+    PCWSTR path = _ILGetPath(pidl);
+    if (!path || !path[0])
+        return E_INVALIDARG;
+    PIDLIST_ABSOLUTE pidlFolder = ILCreateFromPathW(path); //FIXME: SHELL32_CreateSimpleIDListFromPath(, DIRECTORY);
+    if (!pidlFolder)
+        return E_FAIL;
+    HRESULT hr = m_pSfDesktop->BindToObject(pidlFolder, NULL, IID_PPV_ARG(IShellFolder, ppSF));
+    ILFree(pidlFolder);
+    if (ppidlLast)
+        *ppidlLast = _ILGetFSPidl(pidl);
+    return hr;
+}
+
+HRESULT CFindFolder::GetFSFolder2AndChild(LPCITEMIDLIST pidl, IShellFolder2 **ppSF, PCUITEMID_CHILD *ppidlLast)
+{
+    CComPtr<IShellFolder> pSF1;
+    HRESULT hr = GetFSFolderAndChild(pidl, &pSF1, ppidlLast);
+    if (SUCCEEDED(hr))
+        hr = pSF1->QueryInterface(IID_PPV_ARG(IShellFolder2, ppSF));
+    return hr;
+}
+
+static int CALLBACK ILFreeHelper(void *pItem, void *pCaller)
+{
+    ILFree((LPITEMIDLIST)pItem);
+    return TRUE;
+}
+
+void CFindFolder::FreePidlArray(HDPA hDpa)
+{
+    DPA_DestroyCallback(hDpa, ILFreeHelper, NULL);
+}
+
+HDPA CFindFolder::CreateAbsolutePidlArray(UINT cidl, PCUITEMID_CHILD_ARRAY apidl)
+{
+    HDPA hDpa;
+    if ((hDpa = DPA_Create(0)) != NULL)
+    {
+        for (UINT i = 0; i < cidl; ++i)
+        {
+            PIDLIST_ABSOLUTE pidl = _ILCreateAbsolute(apidl[i]);
+            if (pidl)
+            {
+                if (DPA_InsertPtr(hDpa, i, pidl) >= 0)
+                    continue;
+                ILFree(pidl);
+            }
+            FreePidlArray(hDpa);
+            return NULL;
+        }
+    }
+    return hDpa;
 }
 
 struct _SearchData
@@ -666,9 +741,9 @@ STDMETHODIMP CFindFolder::EnumSearches(IEnumExtraSearch **ppenum)
 STDMETHODIMP CFindFolder::GetDefaultColumn(DWORD, ULONG *pSort, ULONG *pDisplay)
 {
     if (pSort)
-        *pSort = 0;
+        *pSort = COL_NAME_INDEX;
     if (pDisplay)
-        *pDisplay = 0;
+        *pDisplay = COL_NAME_INDEX;
     return S_OK;
 }
 
@@ -684,17 +759,28 @@ STDMETHODIMP CFindFolder::GetDefaultColumnState(UINT iColumn, DWORD *pcsFlags)
 
 STDMETHODIMP CFindFolder::GetDetailsEx(PCUITEMID_CHILD pidl, const SHCOLUMNID *pscid, VARIANT *pv)
 {
-    return m_pisfInner->GetDetailsEx(pidl, pscid, pv);
+    // FIXME: Handle COL_LOCATION_INDEX and COL_RELEVANCE_INDEX
+    CComPtr<IShellFolder2> pFolder;
+    PCUITEMID_CHILD pChild;
+    if (SUCCEEDED(GetFSFolder2AndChild(pidl, &pFolder, &pChild)))
+        return pFolder->GetDetailsEx(pChild, pscid, pv);
+    return E_FAIL;
 }
 
 STDMETHODIMP CFindFolder::GetDetailsOf(PCUITEMID_CHILD pidl, UINT iColumn, SHELLDETAILS *pDetails)
 {
     if (iColumn >= _countof(g_ColumnDefs))
-        return m_pisfInner->GetDetailsOf(_ILGetFSPidl(pidl), iColumn - _countof(g_ColumnDefs) + 1, pDetails);
+    {
+        UINT FSColumn = iColumn - _countof(g_ColumnDefs) + 1; 
+        LPCITEMIDLIST pidlFS = _ILGetFSPidl(pidl);
+        CComPtr<IShellFolder2> pFolder;
+        if (SUCCEEDED(GetFSFolder2AndChild(pidl, &pFolder)))
+            return pFolder->GetDetailsOf(pidlFS, FSColumn, pDetails);
+        return E_FAIL;
+    }
 
     pDetails->cxChar = g_ColumnDefs[iColumn].cxChar;
     pDetails->fmt = g_ColumnDefs[iColumn].fmt;
-
     if (!pidl)
         return SHSetStrRet(&pDetails->str, _AtlBaseModule.GetResourceInstance(), g_ColumnDefs[iColumn].iResource);
 
@@ -709,7 +795,8 @@ STDMETHODIMP CFindFolder::GetDetailsOf(PCUITEMID_CHILD pidl, UINT iColumn, SHELL
         return SHSetStrRet(&pDetails->str, "");
     }
 
-    return GetDisplayNameOf(pidl, SHGDN_NORMAL, &pDetails->str);
+    ATLASSERT(iColumn == COL_NAME_INDEX);
+    return GetDisplayNameOf(pidl, SHGDN_NORMAL | SHGDN_INFOLDER, &pDetails->str);
 }
 
 STDMETHODIMP CFindFolder::MapColumnToSCID(UINT iColumn, SHCOLUMNID *pscid)
@@ -734,8 +821,12 @@ STDMETHODIMP CFindFolder::EnumObjects(HWND hwndOwner, DWORD dwFlags, LPENUMIDLIS
 
 STDMETHODIMP CFindFolder::BindToObject(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut)
 {
-    UNIMPLEMENTED;
-    return E_NOTIMPL;
+    HRESULT hr;
+    CComPtr<IShellFolder> pInnerFolder;
+    PCUITEMID_CHILD pidlChild;
+    if (SUCCEEDED(hr = GetFSFolderAndChild(pidl, &pInnerFolder, &pidlChild)))
+        hr = pInnerFolder->BindToObject(pidlChild, pbcReserved, riid, ppvOut);
+    return hr;
 }
 
 STDMETHODIMP CFindFolder::BindToStorage(PCUIDLIST_RELATIVE pidl, LPBC pbcReserved, REFIID riid, LPVOID *ppvOut)
@@ -759,6 +850,7 @@ STDMETHODIMP CFindFolder::CompareIDs(LPARAM lParam, PCUIDLIST_RELATIVE pidl1, PC
         wColumn -= _countof(g_ColumnDefs) - 1;
         break;
     }
+    // FIXME:
     return m_pisfInner->CompareIDs(HIWORD(lParam) | wColumn, _ILGetFSPidl(pidl1), _ILGetFSPidl(pidl2));
 }
 
@@ -783,14 +875,24 @@ STDMETHODIMP CFindFolder::CreateViewObject(HWND hwndOwner, REFIID riid, LPVOID *
 
 STDMETHODIMP CFindFolder::GetAttributesOf(UINT cidl, PCUITEMID_CHILD_ARRAY apidl, DWORD *rgfInOut)
 {
-    CComHeapPtr<PCITEMID_CHILD> aFSPidl;
-    aFSPidl.Allocate(cidl);
-    for (UINT i = 0; i < cidl; i++)
+    if (!cidl)
     {
-        aFSPidl[i] = _ILGetFSPidl(apidl[i]);
+        *rgfInOut &= SFGAO_BROWSABLE; // TODO: SFGAO_CANRENAME?
+        return S_OK;
     }
 
-    return m_pisfInner->GetAttributesOf(cidl, aFSPidl, rgfInOut);
+    HRESULT hr = E_INVALIDARG;
+    for (UINT i = 0; i < cidl; ++i)
+    {
+        CComPtr<IShellFolder> pFolder;
+        PCUITEMID_CHILD pidlChild;
+        if (FAILED(hr = GetFSFolderAndChild(apidl[i], &pFolder, &pidlChild)))
+            break;
+        if (FAILED(hr = pFolder->GetAttributesOf(1, &pidlChild, rgfInOut)))
+            break;
+    }
+    *rgfInOut &= ~SFGAO_CANRENAME; // FIXME: Handle SetNameOf
+    return hr;
 }
 
 class CFindFolderContextMenu :
@@ -805,7 +907,7 @@ class CFindFolderContextMenu :
     //// *** IContextMenu methods ***
     STDMETHODIMP QueryContextMenu(HMENU hMenu, UINT indexMenu, UINT idCmdFirst, UINT idCmdLast, UINT uFlags)
     {
-        m_firstCmdId = indexMenu;
+        m_firstCmdId = idCmdFirst;
         _InsertMenuItemW(hMenu, indexMenu++, TRUE, idCmdFirst++, MFT_STRING, MAKEINTRESOURCEW(IDS_SEARCH_OPEN_FOLDER), MFS_ENABLED);
         _InsertMenuItemW(hMenu, indexMenu++, TRUE, idCmdFirst++, MFT_SEPARATOR, NULL, 0);
         return m_pInner->QueryContextMenu(hMenu, indexMenu, idCmdFirst, idCmdLast, uFlags);
@@ -838,9 +940,11 @@ class CFindFolderContextMenu :
             return S_OK;
         }
 
+        // FIXME: We can't block FCIDM_SHVIEW_REFRESH here, add items on SFVM_LISTREFRESHED instead
         CMINVOKECOMMANDINFOEX actualCmdInfo;
         memcpy(&actualCmdInfo, lpcmi, lpcmi->cbSize);
-        actualCmdInfo.lpVerb -= ADDITIONAL_MENU_ITEMS;
+        if (LOWORD(lpcmi->lpVerb) < FCIDM_SHVIEW_ARRANGE) // HACKFIX for DefView using direct FCIDM_SHVIEW ids
+            actualCmdInfo.lpVerb -= ADDITIONAL_MENU_ITEMS;
         return m_pInner->InvokeCommand((CMINVOKECOMMANDINFO *)&actualCmdInfo);
     }
 
@@ -866,47 +970,76 @@ public:
     END_COM_MAP()
 };
 
+int CALLBACK CFindFolder::SortItemsForDataObject(void *p1, void *p2, LPARAM lparam)
+{
+    // For Delete/Move operations, a subfolder/file needs to come before the parent folder
+    return ::ILGetSize((LPCITEMIDLIST)p1) - ::ILGetSize((LPCITEMIDLIST)p2);
+}
+
 STDMETHODIMP CFindFolder::GetUIObjectOf(HWND hwndOwner, UINT cidl, PCUITEMID_CHILD_ARRAY apidl, REFIID riid,
                                         UINT *prgfInOut, LPVOID *ppvOut)
 {
+    HRESULT hr;
     if (cidl <= 0)
-    {
-        return m_pisfInner->GetUIObjectOf(hwndOwner, cidl, apidl, riid, prgfInOut, ppvOut);
-    }
+        return E_INVALIDARG;
 
-    CComHeapPtr<PCITEMID_CHILD> aFSPidl;
-    aFSPidl.Allocate(cidl);
-    for (UINT i = 0; i < cidl; i++)
+    CComHeapPtr<PCITEMID_CHILD> aFSPidlAlloc;
+    PCITEMID_CHILD pidlSingleBuffer, *aFSPidl = &pidlSingleBuffer; // Optimize for single item callers
+    if (cidl != 1)
     {
-        aFSPidl[i] = _ILGetFSPidl(apidl[i]);
+        if (riid == IID_IDataObject)
+        {
+            if (HDPA hDpa = CreateAbsolutePidlArray(cidl, apidl))
+            {
+                DPA_Sort(hDpa, SortItemsForDataObject, NULL);
+                ITEMIDLIST pidlRoot = {};
+                hr = SHCreateFileDataObject(&pidlRoot, cidl, (PCUITEMID_CHILD_ARRAY)DPA_GetPtrPtr(hDpa),
+                                            NULL, (IDataObject**)ppvOut);
+                FreePidlArray(hDpa);
+                return hr;
+            }
+        }
+
+        aFSPidlAlloc.Allocate(cidl);
+        aFSPidl = aFSPidlAlloc;
     }
+    for (UINT i = 0; i < cidl; i++)
+        aFSPidl[i] = _ILGetFSPidl(apidl[i]);
 
     if (riid == IID_IContextMenu)
     {
+        // FIXME: Use CDefFolderMenu_Create2(..., AddFSClassKeysToArray())
         CComHeapPtr<ITEMIDLIST> folderPidl(ILCreateFromPathW(_ILGetPath(apidl[0])));
         if (!folderPidl)
             return E_OUTOFMEMORY;
         CComPtr<IShellFolder> pDesktopFolder;
-        HRESULT hResult = SHGetDesktopFolder(&pDesktopFolder);
-        if (FAILED_UNEXPECTEDLY(hResult))
-            return hResult;
+        if (FAILED_UNEXPECTEDLY(hr = SHGetDesktopFolder(&pDesktopFolder)))
+            return hr;
         CComPtr<IShellFolder> pShellFolder;
-        hResult = pDesktopFolder->BindToObject(folderPidl, NULL, IID_PPV_ARG(IShellFolder, &pShellFolder));
-        if (FAILED_UNEXPECTEDLY(hResult))
-            return hResult;
+        hr = pDesktopFolder->BindToObject(folderPidl, NULL, IID_PPV_ARG(IShellFolder, &pShellFolder));
+        if (FAILED_UNEXPECTEDLY(hr))
+            return hr;
         CComPtr<IContextMenu> pContextMenu;
-        hResult = pShellFolder->GetUIObjectOf(hwndOwner, cidl, aFSPidl, riid, prgfInOut, (LPVOID *)&pContextMenu);
-        if (FAILED_UNEXPECTEDLY(hResult))
-            return hResult;
+        hr = pShellFolder->GetUIObjectOf(hwndOwner, cidl, aFSPidl, riid, prgfInOut, (void**)&pContextMenu);
+        if (FAILED_UNEXPECTEDLY(hr))
+            return hr;
         return CFindFolderContextMenu::Create(m_shellFolderView, pContextMenu, (IContextMenu **)ppvOut);
     }
 
-    return m_pisfInner->GetUIObjectOf(hwndOwner, cidl, aFSPidl, riid, prgfInOut, ppvOut);
+    CComPtr<IShellFolder> pFolder;
+    if (SUCCEEDED(hr = GetFSFolderAndChild(apidl[0], &pFolder)))
+        return pFolder->GetUIObjectOf(hwndOwner, cidl, aFSPidl, riid, prgfInOut, ppvOut);
+    return hr;
 }
 
 STDMETHODIMP CFindFolder::GetDisplayNameOf(PCUITEMID_CHILD pidl, DWORD dwFlags, LPSTRRET pName)
 {
-    return m_pisfInner->GetDisplayNameOf(_ILGetFSPidl(pidl), dwFlags, pName);
+    HRESULT hr;
+    CComPtr<IShellFolder> pFolder;
+    PCUITEMID_CHILD pidlChild;
+    if (SUCCEEDED(hr = GetFSFolderAndChild(pidl, &pFolder, &pidlChild)))
+        return pFolder->GetDisplayNameOf(pidlChild, dwFlags, pName);
+    return hr;
 }
 
 STDMETHODIMP CFindFolder::SetNameOf(HWND hwndOwner, PCUITEMID_CHILD pidl, LPCOLESTR lpName, DWORD dwFlags,
@@ -933,11 +1066,7 @@ STDMETHODIMP CFindFolder::MessageSFVCB(UINT uMsg, WPARAM wParam, LPARAM lParam)
             SubclassWindow((HWND) wParam);
 
             // Get shell browser for updating status bar text
-            CComPtr<IServiceProvider> pServiceProvider;
-            HRESULT hr = m_shellFolderView->QueryInterface(IID_PPV_ARG(IServiceProvider, &pServiceProvider));
-            if (FAILED_UNEXPECTEDLY(hr))
-                return hr;
-            hr = pServiceProvider->QueryService(SID_SShellBrowser, IID_PPV_ARG(IShellBrowser, &m_shellBrowser));
+            HRESULT hr = IUnknown_QueryService(m_shellFolderView, SID_SShellBrowser, IID_PPV_ARG(IShellBrowser, &m_shellBrowser));
             if (FAILED_UNEXPECTEDLY(hr))
                 return hr;
 
@@ -946,9 +1075,9 @@ STDMETHODIMP CFindFolder::MessageSFVCB(UINT uMsg, WPARAM wParam, LPARAM lParam)
             hr = m_shellBrowser->QueryInterface(IID_PPV_ARG(IWebBrowser2, &pWebBrowser2));
             if (FAILED_UNEXPECTEDLY(hr))
                 return hr;
-            WCHAR pwszGuid[MAX_PATH];
-            StringFromGUID2(CLSID_FileSearchBand, pwszGuid, _countof(pwszGuid));
-            CComVariant searchBar(pwszGuid);
+            WCHAR wszGuid[39];
+            StringFromGUID2(CLSID_FileSearchBand, wszGuid, _countof(wszGuid));
+            CComVariant searchBar(wszGuid);
             return pWebBrowser2->ShowBrowserBar(&searchBar, NULL, NULL);
         }
         case SFVM_WINDOWCLOSING:
@@ -973,6 +1102,7 @@ STDMETHODIMP CFindFolder::MessageSFVCB(UINT uMsg, WPARAM wParam, LPARAM lParam)
             }
             return hr;
         }
+        // TODO: SFVM_GETCOLUMNSTREAM
     }
     return E_NOTIMPL;
 }
@@ -980,21 +1110,20 @@ STDMETHODIMP CFindFolder::MessageSFVCB(UINT uMsg, WPARAM wParam, LPARAM lParam)
 //// *** IPersistFolder2 methods ***
 STDMETHODIMP CFindFolder::GetCurFolder(PIDLIST_ABSOLUTE *pidl)
 {
-    *pidl = ILClone(m_pidl);
-    return S_OK;
+    return SHILClone(m_pidl, pidl);
 }
 
 // *** IPersistFolder methods ***
 STDMETHODIMP CFindFolder::Initialize(PCIDLIST_ABSOLUTE pidl)
 {
-    m_pidl = ILClone(pidl);
-    if (!m_pidl)
-        return E_OUTOFMEMORY;
-
-    return SHELL32_CoCreateInitSF(m_pidl,
-                                  NULL,
-                                  NULL,
-                                  &CLSID_ShellFSFolder,
+    if (m_pidl)
+        return E_UNEXPECTED;
+    HRESULT hr;
+    if (FAILED(hr = SHGetDesktopFolder((IShellFolder**)&m_pSfDesktop)))
+        return hr;
+    if (FAILED(hr = SHILClone(pidl, &m_pidl)))
+        return hr;
+    return SHELL32_CoCreateInitSF(m_pidl, NULL, NULL, &CLSID_ShellFSFolder,
                                   IID_PPV_ARG(IShellFolder2, &m_pisfInner));
 }
 

--- a/dll/win32/browseui/shellfind/CFindFolder.h
+++ b/dll/win32/browseui/shellfind/CFindFolder.h
@@ -64,11 +64,16 @@ class CFindFolder :
 
 private:
     LPITEMIDLIST m_pidl;
-    CComPtr<IShellFolder2> m_pisfInner;
+    CComPtr<IShellFolder2> m_pisfInner, m_pSfDesktop;
     CComPtr<IShellFolderView> m_shellFolderView;
     CComPtr<IShellBrowser> m_shellBrowser;
     HANDLE m_hStopEvent;
 
+    HRESULT GetFSFolderAndChild(LPCITEMIDLIST pidl, IShellFolder **ppSF, PCUITEMID_CHILD *ppidlLast = NULL);
+    HRESULT GetFSFolder2AndChild(LPCITEMIDLIST pidl, IShellFolder2 **ppSF, PCUITEMID_CHILD *ppidlLast = NULL);
+    void FreePidlArray(HDPA hDpa);
+    HDPA CreateAbsolutePidlArray(UINT cidl, PCUITEMID_CHILD_ARRAY apidl);
+    static int CALLBACK SortItemsForDataObject(void *p1, void *p2, LPARAM lparam);
     void NotifyConnections(DISPID id);
     static DWORD WINAPI SearchThreadProc(LPVOID lpParameter);
 

--- a/dll/win32/shell32/CShellLink.cpp
+++ b/dll/win32/shell32/CShellLink.cpp
@@ -1790,6 +1790,7 @@ HRESULT STDMETHODCALLTYPE CShellLink::GetIconLocation(UINT uFlags, PWSTR pszIcon
     }
     else
     {
+        // TODO: If GetIconLocation succeeded, why are we setting GIL_NOTFILENAME? And are we not PERINSTANCE?
         *pwFlags = GIL_NOTFILENAME | GIL_PERCLASS;
     }
 
@@ -2575,13 +2576,12 @@ HRESULT STDMETHODCALLTYPE CShellLink::QueryContextMenu(HMENU hMenu, UINT indexMe
     if (!InsertMenuItemW(hMenu, indexMenu++, TRUE, &mii))
         return E_FAIL;
 
-    UNREFERENCED_PARAMETER(indexMenu);
-
     return MAKE_HRESULT(SEVERITY_SUCCESS, 0, id);
 }
 
 HRESULT CShellLink::DoOpenFileLocation()
 {
+    // TODO: SHOpenFolderAndSelectItems
     WCHAR szParams[MAX_PATH + 64];
     StringCbPrintfW(szParams, sizeof(szParams), L"/select,%s", m_sPath);
 


### PR DESCRIPTION
- Shortcut icons require the correct IShellFolder because it needs the full path (`CFSFolder::_CreateShellExtInstance` calls `PathCombineW` with its own path).
- Items in a drive root needs the final backslash to be a valid path (also matches Windows parent path display).

[CORE-18692](https://jira.reactos.org/browse/CORE-18692)

Notes:
- The whole CFindFolder implementation needs to move to shell32 to completely fix multi-selection context menus when the items are in different parent folders.