### PR TITLE
[EVENTVWR] Localize and check item count

### DIFF
--- a/base/applications/mscutils/eventvwr/eventvwr.c
+++ b/base/applications/mscutils/eventvwr/eventvwr.c
@@ -1998,10 +1998,11 @@ EnumEventsThread(IN LPVOID lpParameter)
     SYSTEMTIME time;
     LVITEMW lviEventItem;
 
+    EnableEventDetailsButtons(hwndEventDetails, FALSE);
+
     /* Save the current event log filter globally */
     EventLogFilter_AddRef(EventLogFilter);
     ActiveFilter = EventLogFilter;
-
 
     /** HACK!! **/
     EventLog = EventLogFilter->EventLogs[0];

--- a/base/applications/mscutils/eventvwr/eventvwr.c
+++ b/base/applications/mscutils/eventvwr/eventvwr.c
@@ -1978,6 +1978,7 @@ EnumEventsThread(IN LPVOID lpParameter)
     BOOL bResult = TRUE; /* Read succeeded */
     HANDLE hProcessHeap = GetProcessHeap();
     PSID pLastSid = NULL;
+    INT nItems;
 
     UINT uStep = 0, uStepAt = 0, uPos = 0;
 
@@ -2263,6 +2264,8 @@ Quit:
     /* All events loaded */
 
 Cleanup:
+    nItems = ListView_GetItemCount(hwndListView);
+    EnableEventDetailsButtons(hwndEventDetails, (nItems > 0));
 
     ShowWindow(hwndStatusProgress, SW_HIDE);
     SendMessageW(hwndListView, LVM_PROGRESS, 0, FALSE);

--- a/base/applications/mscutils/eventvwr/evtdetctl.c
+++ b/base/applications/mscutils/eventvwr/evtdetctl.c
@@ -792,6 +792,11 @@ EventDetailsCtrl(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
                 pData->EventLogFilter = DetailInfo->EventLogFilter;
                 pData->iEventItem     = DetailInfo->iEventItem;
             }
+            else
+            {
+                pData->iEventItem = -1;
+            }
+
             pData->bDisplayWords  = FALSE;
             pData->hMonospaceFont = CreateMonospaceFont();
 

--- a/base/applications/mscutils/eventvwr/evtdetctl.c
+++ b/base/applications/mscutils/eventvwr/evtdetctl.c
@@ -839,6 +839,14 @@ EventDetailsCtrl(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
                 {
                     BOOL bPrev = (LOWORD(wParam) == IDC_PREVIOUS);
                     INT iItem, iSel;
+                    WCHAR szText[200];
+
+                    if (ListView_GetItemCount(hwndListView) <= 0)
+                    {
+                        LoadStringW(hInst, IDS_NOMOREITEMS, szText, _countof(szText));
+                        MessageBoxW(hDlg, szText, szTitle, MB_ICONWARNING);
+                        break;
+                    }
 
                     /* Select the previous/next item from our current one */
                     iItem = ListView_GetNextItem(hwndListView,
@@ -846,17 +854,11 @@ EventDetailsCtrl(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
                                                  bPrev ? LVNI_ABOVE : LVNI_BELOW);
                     if (iItem == -1)
                     {
-                        // TODO: Localization.
-                        if (MessageBoxW(hDlg,
-                                        bPrev
-                                            ? L"You have reached the beginning of the event log. Do you want to continue from the end?"
-                                            : L"You have reached the end of the event log. Do you want to continue from the beginning?",
-                                        szTitle,
-                                        MB_YESNO | MB_ICONQUESTION)
-                            == IDNO)
-                        {
+                        LoadStringW(hInst,
+                                    (bPrev ? IDS_CONTFROMEND : IDS_CONTFROMBEGINNING),
+                                    szText, _countof(szText));
+                        if (MessageBoxW(hDlg, szText, szTitle, MB_YESNO | MB_ICONQUESTION) == IDNO)
                             break;
-                        }
 
                         /* Determine from where to restart */
                         if (bPrev)

--- a/base/applications/mscutils/eventvwr/evtdetctl.c
+++ b/base/applications/mscutils/eventvwr/evtdetctl.c
@@ -844,7 +844,7 @@ EventDetailsCtrl(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
                     if (nItems <= 0)
                     {
                         LoadStringW(hInst, IDS_NOMOREITEMS, szText, _countof(szText));
-                        MessageBoxW(hDlg, szText, szTitle, MB_ICONWARNING);
+                        MessageBoxW(hDlg, szText, szTitle, MB_ICONINFORMATION);
                         break;
                     }
 

--- a/base/applications/mscutils/eventvwr/evtdetctl.c
+++ b/base/applications/mscutils/eventvwr/evtdetctl.c
@@ -841,9 +841,9 @@ EventDetailsCtrl(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
                     INT iItem, iSel, nItems = ListView_GetItemCount(hwndListView);
                     WCHAR szText[200];
 
-                    if (nItems <= 0)
+                    if (nItems <= 0) /* No items? */
                     {
-                        LoadStringW(hInst, IDS_NOMOREITEMS, szText, _countof(szText));
+                        LoadStringW(hInst, IDS_NOITEMS, szText, _countof(szText));
                         MessageBoxW(hDlg, szText, szTitle, MB_ICONINFORMATION);
                         break;
                     }

--- a/base/applications/mscutils/eventvwr/evtdetctl.c
+++ b/base/applications/mscutils/eventvwr/evtdetctl.c
@@ -842,11 +842,7 @@ EventDetailsCtrl(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
                     WCHAR szText[200];
 
                     if (nItems <= 0) /* No items? */
-                    {
-                        LoadStringW(hInst, IDS_NOITEMS, szText, _countof(szText));
-                        MessageBoxW(hDlg, szText, szTitle, MB_ICONINFORMATION);
                         break;
-                    }
 
                     /* Select the previous/next item from our current one */
                     iItem = ListView_GetNextItem(hwndListView, -1, LVNI_ALL | LVNI_SELECTED);
@@ -957,4 +953,12 @@ CreateEventDetailsCtrl(HINSTANCE hInstance,
     return CreateDialogParamW(hInstance,
                               MAKEINTRESOURCEW(IDD_EVENTDETAILS_CTRL),
                               hParentWnd, EventDetailsCtrl, lParam);
+}
+
+VOID
+EnableEventDetailsButtons(HWND hWnd, BOOL bEnable)
+{
+    EnableDlgItem(hWnd, IDC_PREVIOUS, bEnable);
+    EnableDlgItem(hWnd, IDC_NEXT, bEnable);
+    EnableDlgItem(hWnd, IDC_COPY, bEnable);
 }

--- a/base/applications/mscutils/eventvwr/evtdetctl.c
+++ b/base/applications/mscutils/eventvwr/evtdetctl.c
@@ -838,10 +838,10 @@ EventDetailsCtrl(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
                 case IDC_NEXT:
                 {
                     BOOL bPrev = (LOWORD(wParam) == IDC_PREVIOUS);
-                    INT iItem, iSel;
+                    INT iItem, iSel, nItems = ListView_GetItemCount(hwndListView);
                     WCHAR szText[200];
 
-                    if (ListView_GetItemCount(hwndListView) <= 0)
+                    if (nItems <= 0)
                     {
                         LoadStringW(hInst, IDS_NOMOREITEMS, szText, _countof(szText));
                         MessageBoxW(hDlg, szText, szTitle, MB_ICONWARNING);
@@ -849,10 +849,10 @@ EventDetailsCtrl(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
                     }
 
                     /* Select the previous/next item from our current one */
-                    iItem = ListView_GetNextItem(hwndListView,
-                                                 pData->iEventItem,
-                                                 bPrev ? LVNI_ABOVE : LVNI_BELOW);
-                    if (iItem == -1)
+                    iItem = ListView_GetNextItem(hwndListView, -1, LVNI_ALL | LVNI_SELECTED);
+                    iItem = ListView_GetNextItem(hwndListView, iItem,
+                                                 (bPrev ? LVNI_ABOVE : LVNI_BELOW));
+                    if (iItem < 0 || iItem >= nItems)
                     {
                         LoadStringW(hInst,
                                     (bPrev ? IDS_CONTFROMEND : IDS_CONTFROMBEGINNING),
@@ -861,10 +861,7 @@ EventDetailsCtrl(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
                             break;
 
                         /* Determine from where to restart */
-                        if (bPrev)
-                            iItem = ListView_GetItemCount(hwndListView) - 1;
-                        else
-                            iItem = 0;
+                        iItem = (bPrev ? (nItems - 1) : 0);
                     }
 
                     /*

--- a/base/applications/mscutils/eventvwr/evtdetctl.h
+++ b/base/applications/mscutils/eventvwr/evtdetctl.h
@@ -7,8 +7,7 @@
  *              Copyright 2016-2022 Hermès Bélusca-Maïto <hermes.belusca-maito@reactos.org>
  */
 
-#ifndef _EVTDETCTL_H_
-#define _EVTDETCTL_H_
+#pragma once
 
 /* Optional structure passed by pointer
  * as LPARAM to CreateEventDetailsCtrl() */
@@ -26,4 +25,4 @@ CreateEventDetailsCtrl(HINSTANCE hInstance,
                        HWND hParentWnd,
                        LPARAM lParam);
 
-#endif /* _EVTDETCTL_H_ */
+VOID EnableEventDetailsButtons(HWND hWnd, BOOL bEnable);

--- a/base/applications/mscutils/eventvwr/lang/bg-BG.rc
+++ b/base/applications/mscutils/eventvwr/lang/bg-BG.rc
@@ -169,7 +169,7 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "Не е намерено описанието на събитие ( %lu ) в източник ( %s ). Възможно е местият компютър да няма нужните сведения в регистъра или DLL файловет, нужни за показване на съобщения от отдалечен компютър.\n\nThe following information is part of the event:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOITEMS "No items"
+    IDS_NOITEMS "No items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/bg-BG.rc
+++ b/base/applications/mscutils/eventvwr/lang/bg-BG.rc
@@ -167,6 +167,9 @@ BEGIN
     IDS_CLEAREVENTS_MSG "Do you want to save this event log before clearing it?"
     IDS_RESTOREDEFAULTS "Do you want to restore all settings for this log to their default values?"
     IDS_EVENTSTRINGIDNOTFOUND "Не е намерено описанието на събитие ( %lu ) в източник ( %s ). Възможно е местият компютър да няма нужните сведения в регистъра или DLL файловет, нужни за показване на съобщения от отдалечен компютър.\n\nThe following information is part of the event:\n\n"
+    IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
+    IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
+    IDS_NOMOREITEMS "No more items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/bg-BG.rc
+++ b/base/applications/mscutils/eventvwr/lang/bg-BG.rc
@@ -169,7 +169,6 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "Не е намерено описанието на събитие ( %lu ) в източник ( %s ). Възможно е местият компютър да няма нужните сведения в регистъра или DLL файловет, нужни за показване на съобщения от отдалечен компютър.\n\nThe following information is part of the event:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOITEMS "No items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/bg-BG.rc
+++ b/base/applications/mscutils/eventvwr/lang/bg-BG.rc
@@ -169,7 +169,7 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "Не е намерено описанието на събитие ( %lu ) в източник ( %s ). Възможно е местият компютър да няма нужните сведения в регистъра или DLL файловет, нужни за показване на съобщения от отдалечен компютър.\n\nThe following information is part of the event:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOMOREITEMS "No more items."
+    IDS_NOITEMS "No items"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/cs-CZ.rc
+++ b/base/applications/mscutils/eventvwr/lang/cs-CZ.rc
@@ -169,7 +169,7 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "Popis ID události ( %lu ) zdroj ( %s ) nebyl nalezen. Místní počítač neobsahuje potřebné informace v registru nebo chybí DLL soubory pro zobrazení zpráv ze vzdáleného počítače.\n\nThe following information is part of the event:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOITEMS "No items"
+    IDS_NOITEMS "No items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/cs-CZ.rc
+++ b/base/applications/mscutils/eventvwr/lang/cs-CZ.rc
@@ -169,7 +169,6 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "Popis ID události ( %lu ) zdroj ( %s ) nebyl nalezen. Místní počítač neobsahuje potřebné informace v registru nebo chybí DLL soubory pro zobrazení zpráv ze vzdáleného počítače.\n\nThe following information is part of the event:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOITEMS "No items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/cs-CZ.rc
+++ b/base/applications/mscutils/eventvwr/lang/cs-CZ.rc
@@ -169,7 +169,7 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "Popis ID události ( %lu ) zdroj ( %s ) nebyl nalezen. Místní počítač neobsahuje potřebné informace v registru nebo chybí DLL soubory pro zobrazení zpráv ze vzdáleného počítače.\n\nThe following information is part of the event:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOMOREITEMS "No more items."
+    IDS_NOITEMS "No items"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/cs-CZ.rc
+++ b/base/applications/mscutils/eventvwr/lang/cs-CZ.rc
@@ -167,6 +167,9 @@ BEGIN
     IDS_CLEAREVENTS_MSG "Chcete tento protokol před odstraněním uložit?"
     IDS_RESTOREDEFAULTS "Do you want to restore all settings for this log to their default values?"
     IDS_EVENTSTRINGIDNOTFOUND "Popis ID události ( %lu ) zdroj ( %s ) nebyl nalezen. Místní počítač neobsahuje potřebné informace v registru nebo chybí DLL soubory pro zobrazení zpráv ze vzdáleného počítače.\n\nThe following information is part of the event:\n\n"
+    IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
+    IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
+    IDS_NOMOREITEMS "No more items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/de-DE.rc
+++ b/base/applications/mscutils/eventvwr/lang/de-DE.rc
@@ -170,7 +170,7 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "Die Bezeichnung für die Ereignis-ID ( %lu ) in der Quelle ( %s ) kann nicht gefunden werden. Es könnte sein, dass der lokale Computer die notwendigen Registry Einträge oder Nachrichten DLLs, um Nachrichten entfernter Computer anzuzeigen, nicht besitzt.\n\nDas Ereignis enthält folgende Informationen:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOITEMS "No items"
+    IDS_NOITEMS "No items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/de-DE.rc
+++ b/base/applications/mscutils/eventvwr/lang/de-DE.rc
@@ -168,6 +168,9 @@ BEGIN
     IDS_CLEAREVENTS_MSG "Möchten Sie dieses Protokoll vor dem Löschen speichern?"
     IDS_RESTOREDEFAULTS "Möchten Sie alle Einstellungen für dieses Protokoll wieder auf die Standardwerte zurücksetzen?"
     IDS_EVENTSTRINGIDNOTFOUND "Die Bezeichnung für die Ereignis-ID ( %lu ) in der Quelle ( %s ) kann nicht gefunden werden. Es könnte sein, dass der lokale Computer die notwendigen Registry Einträge oder Nachrichten DLLs, um Nachrichten entfernter Computer anzuzeigen, nicht besitzt.\n\nDas Ereignis enthält folgende Informationen:\n\n"
+    IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
+    IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
+    IDS_NOMOREITEMS "No more items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/de-DE.rc
+++ b/base/applications/mscutils/eventvwr/lang/de-DE.rc
@@ -170,7 +170,6 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "Die Bezeichnung für die Ereignis-ID ( %lu ) in der Quelle ( %s ) kann nicht gefunden werden. Es könnte sein, dass der lokale Computer die notwendigen Registry Einträge oder Nachrichten DLLs, um Nachrichten entfernter Computer anzuzeigen, nicht besitzt.\n\nDas Ereignis enthält folgende Informationen:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOITEMS "No items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/de-DE.rc
+++ b/base/applications/mscutils/eventvwr/lang/de-DE.rc
@@ -170,7 +170,7 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "Die Bezeichnung für die Ereignis-ID ( %lu ) in der Quelle ( %s ) kann nicht gefunden werden. Es könnte sein, dass der lokale Computer die notwendigen Registry Einträge oder Nachrichten DLLs, um Nachrichten entfernter Computer anzuzeigen, nicht besitzt.\n\nDas Ereignis enthält folgende Informationen:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOMOREITEMS "No more items."
+    IDS_NOITEMS "No items"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/el-GR.rc
+++ b/base/applications/mscutils/eventvwr/lang/el-GR.rc
@@ -169,7 +169,6 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "The description for Event ID ( %lu ) in Source ( %s ) cannot be found. The local computer may not have the necessary registry information or message DLL files to display messages from a remote computer.\n\nThe following information is part of the event:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOITEMS "No items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/el-GR.rc
+++ b/base/applications/mscutils/eventvwr/lang/el-GR.rc
@@ -169,7 +169,7 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "The description for Event ID ( %lu ) in Source ( %s ) cannot be found. The local computer may not have the necessary registry information or message DLL files to display messages from a remote computer.\n\nThe following information is part of the event:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOMOREITEMS "No more items."
+    IDS_NOITEMS "No items"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/el-GR.rc
+++ b/base/applications/mscutils/eventvwr/lang/el-GR.rc
@@ -169,7 +169,7 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "The description for Event ID ( %lu ) in Source ( %s ) cannot be found. The local computer may not have the necessary registry information or message DLL files to display messages from a remote computer.\n\nThe following information is part of the event:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOITEMS "No items"
+    IDS_NOITEMS "No items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/el-GR.rc
+++ b/base/applications/mscutils/eventvwr/lang/el-GR.rc
@@ -167,6 +167,9 @@ BEGIN
     IDS_CLEAREVENTS_MSG "Do you want to save this event log before clearing it?"
     IDS_RESTOREDEFAULTS "Do you want to restore all settings for this log to their default values?"
     IDS_EVENTSTRINGIDNOTFOUND "The description for Event ID ( %lu ) in Source ( %s ) cannot be found. The local computer may not have the necessary registry information or message DLL files to display messages from a remote computer.\n\nThe following information is part of the event:\n\n"
+    IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
+    IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
+    IDS_NOMOREITEMS "No more items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/en-US.rc
+++ b/base/applications/mscutils/eventvwr/lang/en-US.rc
@@ -171,7 +171,7 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "The description for Event ID ( %lu ) in Source ( %s ) cannot be found. The local computer may not have the necessary registry information or message DLL files to display messages from a remote computer.\n\nThe following information is part of the event:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOMOREITEMS "No more items."
+    IDS_NOITEMS "No items"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/en-US.rc
+++ b/base/applications/mscutils/eventvwr/lang/en-US.rc
@@ -169,6 +169,9 @@ BEGIN
     IDS_CLEAREVENTS_MSG "Do you want to save this event log before clearing it?"
     IDS_RESTOREDEFAULTS "Do you want to restore all settings for this log to their default values?"
     IDS_EVENTSTRINGIDNOTFOUND "The description for Event ID ( %lu ) in Source ( %s ) cannot be found. The local computer may not have the necessary registry information or message DLL files to display messages from a remote computer.\n\nThe following information is part of the event:\n\n"
+    IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
+    IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
+    IDS_NOMOREITEMS "No more items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/en-US.rc
+++ b/base/applications/mscutils/eventvwr/lang/en-US.rc
@@ -171,7 +171,7 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "The description for Event ID ( %lu ) in Source ( %s ) cannot be found. The local computer may not have the necessary registry information or message DLL files to display messages from a remote computer.\n\nThe following information is part of the event:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOITEMS "No items"
+    IDS_NOITEMS "No items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/en-US.rc
+++ b/base/applications/mscutils/eventvwr/lang/en-US.rc
@@ -171,7 +171,6 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "The description for Event ID ( %lu ) in Source ( %s ) cannot be found. The local computer may not have the necessary registry information or message DLL files to display messages from a remote computer.\n\nThe following information is part of the event:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOITEMS "No items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/es-ES.rc
+++ b/base/applications/mscutils/eventvwr/lang/es-ES.rc
@@ -172,7 +172,6 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "No se pudo recuperar la descripción para el evento con ID ( %lu ) y origen ( %s ). El equipo local puede no tener la información necesaria en el registro o las DLLs necesarias para mostrar los mensajes de un equipo remoto.\n\nLa siguiente información es parte del evento:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOITEMS "No items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/es-ES.rc
+++ b/base/applications/mscutils/eventvwr/lang/es-ES.rc
@@ -170,6 +170,9 @@ BEGIN
     IDS_CLEAREVENTS_MSG "¿Desea guardar este registro de eventos antes de borrarlo?"
     IDS_RESTOREDEFAULTS "Do you want to restore all settings for this log to their default values?"
     IDS_EVENTSTRINGIDNOTFOUND "No se pudo recuperar la descripción para el evento con ID ( %lu ) y origen ( %s ). El equipo local puede no tener la información necesaria en el registro o las DLLs necesarias para mostrar los mensajes de un equipo remoto.\n\nLa siguiente información es parte del evento:\n\n"
+    IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
+    IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
+    IDS_NOMOREITEMS "No more items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/es-ES.rc
+++ b/base/applications/mscutils/eventvwr/lang/es-ES.rc
@@ -172,7 +172,7 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "No se pudo recuperar la descripción para el evento con ID ( %lu ) y origen ( %s ). El equipo local puede no tener la información necesaria en el registro o las DLLs necesarias para mostrar los mensajes de un equipo remoto.\n\nLa siguiente información es parte del evento:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOMOREITEMS "No more items."
+    IDS_NOITEMS "No items"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/es-ES.rc
+++ b/base/applications/mscutils/eventvwr/lang/es-ES.rc
@@ -172,7 +172,7 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "No se pudo recuperar la descripción para el evento con ID ( %lu ) y origen ( %s ). El equipo local puede no tener la información necesaria en el registro o las DLLs necesarias para mostrar los mensajes de un equipo remoto.\n\nLa siguiente información es parte del evento:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOITEMS "No items"
+    IDS_NOITEMS "No items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/fr-FR.rc
+++ b/base/applications/mscutils/eventvwr/lang/fr-FR.rc
@@ -170,7 +170,7 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "La description pour l'événement d'ID ( %lu ) dans la source ( %s ) ne peut être trouvée. L'ordinateur local pourrait ne pas avoir les informations registres nécessaires ou les fichiers DLL de message pour afficher les messages depuis un ordinateur distant.\n\nLes informations suivantes font partie de l'événement :\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOMOREITEMS "No more items."
+    IDS_NOITEMS "No items"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/fr-FR.rc
+++ b/base/applications/mscutils/eventvwr/lang/fr-FR.rc
@@ -168,6 +168,9 @@ BEGIN
     IDS_CLEAREVENTS_MSG "Voulez-vous enregistrer ce journal d'événements avant de l'effacer ?"
     IDS_RESTOREDEFAULTS "Voulez-vous vraiment réinitialiser tous les paramètres pour ce journal aux valeurs par défaut ?"
     IDS_EVENTSTRINGIDNOTFOUND "La description pour l'événement d'ID ( %lu ) dans la source ( %s ) ne peut être trouvée. L'ordinateur local pourrait ne pas avoir les informations registres nécessaires ou les fichiers DLL de message pour afficher les messages depuis un ordinateur distant.\n\nLes informations suivantes font partie de l'événement :\n\n"
+    IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
+    IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
+    IDS_NOMOREITEMS "No more items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/fr-FR.rc
+++ b/base/applications/mscutils/eventvwr/lang/fr-FR.rc
@@ -170,7 +170,7 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "La description pour l'événement d'ID ( %lu ) dans la source ( %s ) ne peut être trouvée. L'ordinateur local pourrait ne pas avoir les informations registres nécessaires ou les fichiers DLL de message pour afficher les messages depuis un ordinateur distant.\n\nLes informations suivantes font partie de l'événement :\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOITEMS "No items"
+    IDS_NOITEMS "No items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/fr-FR.rc
+++ b/base/applications/mscutils/eventvwr/lang/fr-FR.rc
@@ -170,7 +170,6 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "La description pour l'événement d'ID ( %lu ) dans la source ( %s ) ne peut être trouvée. L'ordinateur local pourrait ne pas avoir les informations registres nécessaires ou les fichiers DLL de message pour afficher les messages depuis un ordinateur distant.\n\nLes informations suivantes font partie de l'événement :\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOITEMS "No items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/he-IL.rc
+++ b/base/applications/mscutils/eventvwr/lang/he-IL.rc
@@ -169,7 +169,6 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "The description for Event ID ( %lu ) in Source ( %s ) cannot be found. The local computer may not have the necessary registry information or message DLL files to display messages from a remote computer.\n\nThe following information is part of the event:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOITEMS "No items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/he-IL.rc
+++ b/base/applications/mscutils/eventvwr/lang/he-IL.rc
@@ -169,7 +169,7 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "The description for Event ID ( %lu ) in Source ( %s ) cannot be found. The local computer may not have the necessary registry information or message DLL files to display messages from a remote computer.\n\nThe following information is part of the event:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOMOREITEMS "No more items."
+    IDS_NOITEMS "No items"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/he-IL.rc
+++ b/base/applications/mscutils/eventvwr/lang/he-IL.rc
@@ -169,7 +169,7 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "The description for Event ID ( %lu ) in Source ( %s ) cannot be found. The local computer may not have the necessary registry information or message DLL files to display messages from a remote computer.\n\nThe following information is part of the event:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOITEMS "No items"
+    IDS_NOITEMS "No items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/he-IL.rc
+++ b/base/applications/mscutils/eventvwr/lang/he-IL.rc
@@ -167,6 +167,9 @@ BEGIN
     IDS_CLEAREVENTS_MSG "Do you want to save this event log before clearing it?"
     IDS_RESTOREDEFAULTS "Do you want to restore all settings for this log to their default values?"
     IDS_EVENTSTRINGIDNOTFOUND "The description for Event ID ( %lu ) in Source ( %s ) cannot be found. The local computer may not have the necessary registry information or message DLL files to display messages from a remote computer.\n\nThe following information is part of the event:\n\n"
+    IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
+    IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
+    IDS_NOMOREITEMS "No more items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/it-IT.rc
+++ b/base/applications/mscutils/eventvwr/lang/it-IT.rc
@@ -170,7 +170,6 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "La descrizione per l'ID evento ( %lu ) proveniente da ( %s ) non può essere trovata. Il computer locale potrebbe non avere le informazioni sul registry necessarie o i file DLL con i messaggi necessari per la visualizzazione da un computer remoto.\n\nThe following information is part of the event:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOITEMS "No items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/it-IT.rc
+++ b/base/applications/mscutils/eventvwr/lang/it-IT.rc
@@ -170,7 +170,7 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "La descrizione per l'ID evento ( %lu ) proveniente da ( %s ) non può essere trovata. Il computer locale potrebbe non avere le informazioni sul registry necessarie o i file DLL con i messaggi necessari per la visualizzazione da un computer remoto.\n\nThe following information is part of the event:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOITEMS "No items"
+    IDS_NOITEMS "No items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/it-IT.rc
+++ b/base/applications/mscutils/eventvwr/lang/it-IT.rc
@@ -170,7 +170,7 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "La descrizione per l'ID evento ( %lu ) proveniente da ( %s ) non può essere trovata. Il computer locale potrebbe non avere le informazioni sul registry necessarie o i file DLL con i messaggi necessari per la visualizzazione da un computer remoto.\n\nThe following information is part of the event:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOMOREITEMS "No more items."
+    IDS_NOITEMS "No items"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/it-IT.rc
+++ b/base/applications/mscutils/eventvwr/lang/it-IT.rc
@@ -168,6 +168,9 @@ BEGIN
     IDS_CLEAREVENTS_MSG "Do you want to save this event log before clearing it?"
     IDS_RESTOREDEFAULTS "Do you want to restore all settings for this log to their default values?"
     IDS_EVENTSTRINGIDNOTFOUND "La descrizione per l'ID evento ( %lu ) proveniente da ( %s ) non può essere trovata. Il computer locale potrebbe non avere le informazioni sul registry necessarie o i file DLL con i messaggi necessari per la visualizzazione da un computer remoto.\n\nThe following information is part of the event:\n\n"
+    IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
+    IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
+    IDS_NOMOREITEMS "No more items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/ja-JP.rc
+++ b/base/applications/mscutils/eventvwr/lang/ja-JP.rc
@@ -168,9 +168,9 @@ BEGIN
     IDS_CLEAREVENTS_MSG "このイベントをクリアする前に保存したいですか？"
     IDS_RESTOREDEFAULTS "すべての設定をデフォルトに戻しますか？"
     IDS_EVENTSTRINGIDNOTFOUND "イベント ID (%lu) (ソース %s 内) に関する説明が見つかりませんでした。 リモート コンピュータからメッセージを表示するために必要なレジストリ情報またはメッセージ DLL ファイルがローカル コンピュータにない可能性があります。\n\n次の情報はイベントの一部です:\n\n"
-    IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
-    IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOMOREITEMS "No more items."
+    IDS_CONTFROMBEGINNING "イベント ログの最後に到達しました。最初から続けますか？"
+    IDS_CONTFROMEND "イベント ログの先頭に到達しました。最後から続けますか？"
+    IDS_NOITEMS "項目がありません。"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/ja-JP.rc
+++ b/base/applications/mscutils/eventvwr/lang/ja-JP.rc
@@ -170,7 +170,6 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "イベント ID (%lu) (ソース %s 内) に関する説明が見つかりませんでした。 リモート コンピュータからメッセージを表示するために必要なレジストリ情報またはメッセージ DLL ファイルがローカル コンピュータにない可能性があります。\n\n次の情報はイベントの一部です:\n\n"
     IDS_CONTFROMBEGINNING "イベント ログの最後に到達しました。最初から続けますか？"
     IDS_CONTFROMEND "イベント ログの先頭に到達しました。最後から続けますか？"
-    IDS_NOITEMS "項目がありません。"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/ja-JP.rc
+++ b/base/applications/mscutils/eventvwr/lang/ja-JP.rc
@@ -168,6 +168,9 @@ BEGIN
     IDS_CLEAREVENTS_MSG "このイベントをクリアする前に保存したいですか？"
     IDS_RESTOREDEFAULTS "すべての設定をデフォルトに戻しますか？"
     IDS_EVENTSTRINGIDNOTFOUND "イベント ID (%lu) (ソース %s 内) に関する説明が見つかりませんでした。 リモート コンピュータからメッセージを表示するために必要なレジストリ情報またはメッセージ DLL ファイルがローカル コンピュータにない可能性があります。\n\n次の情報はイベントの一部です:\n\n"
+    IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
+    IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
+    IDS_NOMOREITEMS "No more items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/ko-KR.rc
+++ b/base/applications/mscutils/eventvwr/lang/ko-KR.rc
@@ -169,7 +169,6 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "( %s ) 의 이벤트ID ( %lu ) 에 대한 설명을 찾을 수 없습니다. 로컬 컴퓨터가 원격 컴퓨터의 메세지를 표시하는데 필요한 레지스트리나 DLL 파일을 가지지 않고 있을수 있습니다.\n\nThe following information is part of the event:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOITEMS "No items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/ko-KR.rc
+++ b/base/applications/mscutils/eventvwr/lang/ko-KR.rc
@@ -167,6 +167,9 @@ BEGIN
     IDS_CLEAREVENTS_MSG "Do you want to save this event log before clearing it?"
     IDS_RESTOREDEFAULTS "Do you want to restore all settings for this log to their default values?"
     IDS_EVENTSTRINGIDNOTFOUND "( %s ) 의 이벤트ID ( %lu ) 에 대한 설명을 찾을 수 없습니다. 로컬 컴퓨터가 원격 컴퓨터의 메세지를 표시하는데 필요한 레지스트리나 DLL 파일을 가지지 않고 있을수 있습니다.\n\nThe following information is part of the event:\n\n"
+    IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
+    IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
+    IDS_NOMOREITEMS "No more items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/ko-KR.rc
+++ b/base/applications/mscutils/eventvwr/lang/ko-KR.rc
@@ -169,7 +169,7 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "( %s ) 의 이벤트ID ( %lu ) 에 대한 설명을 찾을 수 없습니다. 로컬 컴퓨터가 원격 컴퓨터의 메세지를 표시하는데 필요한 레지스트리나 DLL 파일을 가지지 않고 있을수 있습니다.\n\nThe following information is part of the event:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOMOREITEMS "No more items."
+    IDS_NOITEMS "No items"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/ko-KR.rc
+++ b/base/applications/mscutils/eventvwr/lang/ko-KR.rc
@@ -169,7 +169,7 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "( %s ) 의 이벤트ID ( %lu ) 에 대한 설명을 찾을 수 없습니다. 로컬 컴퓨터가 원격 컴퓨터의 메세지를 표시하는데 필요한 레지스트리나 DLL 파일을 가지지 않고 있을수 있습니다.\n\nThe following information is part of the event:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOITEMS "No items"
+    IDS_NOITEMS "No items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/no-NO.rc
+++ b/base/applications/mscutils/eventvwr/lang/no-NO.rc
@@ -169,7 +169,7 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "Beskrivelsen for Hendelse ID ( %lu ) i kilden ( %s ) kan ikke bli finnet. Lokale datamaskinen har ikke nødvendige register informasjon eller melding DLL filer for å vise melding fra en fjern datamaskin.\n\nThe following information is part of the event:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOITEMS "No items"
+    IDS_NOITEMS "No items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/no-NO.rc
+++ b/base/applications/mscutils/eventvwr/lang/no-NO.rc
@@ -167,6 +167,9 @@ BEGIN
     IDS_CLEAREVENTS_MSG "Do you want to save this event log before clearing it?"
     IDS_RESTOREDEFAULTS "Do you want to restore all settings for this log to their default values?"
     IDS_EVENTSTRINGIDNOTFOUND "Beskrivelsen for Hendelse ID ( %lu ) i kilden ( %s ) kan ikke bli finnet. Lokale datamaskinen har ikke nødvendige register informasjon eller melding DLL filer for å vise melding fra en fjern datamaskin.\n\nThe following information is part of the event:\n\n"
+    IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
+    IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
+    IDS_NOMOREITEMS "No more items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/no-NO.rc
+++ b/base/applications/mscutils/eventvwr/lang/no-NO.rc
@@ -169,7 +169,6 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "Beskrivelsen for Hendelse ID ( %lu ) i kilden ( %s ) kan ikke bli finnet. Lokale datamaskinen har ikke nødvendige register informasjon eller melding DLL filer for å vise melding fra en fjern datamaskin.\n\nThe following information is part of the event:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOITEMS "No items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/no-NO.rc
+++ b/base/applications/mscutils/eventvwr/lang/no-NO.rc
@@ -169,7 +169,7 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "Beskrivelsen for Hendelse ID ( %lu ) i kilden ( %s ) kan ikke bli finnet. Lokale datamaskinen har ikke nødvendige register informasjon eller melding DLL filer for å vise melding fra en fjern datamaskin.\n\nThe following information is part of the event:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOMOREITEMS "No more items."
+    IDS_NOITEMS "No items"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/pl-PL.rc
+++ b/base/applications/mscutils/eventvwr/lang/pl-PL.rc
@@ -172,7 +172,7 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "Opis zdarzenia dla danego numeru ID ( %lu ) nie został odnaleziony w źródle ( %s ). Ten komputer może nie miec wystarczających informacji w rejestrze, albo bibliotek DLL, aby wyświetlić wiadomości z komputera zdalnego.\n\nThe following information is part of the event:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOMOREITEMS "No more items."
+    IDS_NOITEMS "No items"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/pl-PL.rc
+++ b/base/applications/mscutils/eventvwr/lang/pl-PL.rc
@@ -170,6 +170,9 @@ BEGIN
     IDS_CLEAREVENTS_MSG "Czy chcesz zapisać dziennik zdarzeń przed czyszczeniem?"
     IDS_RESTOREDEFAULTS "Czy chcesz przywrócić wszystkie ustawienia tego dziennika do wartości domyślnych?"
     IDS_EVENTSTRINGIDNOTFOUND "Opis zdarzenia dla danego numeru ID ( %lu ) nie został odnaleziony w źródle ( %s ). Ten komputer może nie miec wystarczających informacji w rejestrze, albo bibliotek DLL, aby wyświetlić wiadomości z komputera zdalnego.\n\nThe following information is part of the event:\n\n"
+    IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
+    IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
+    IDS_NOMOREITEMS "No more items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/pl-PL.rc
+++ b/base/applications/mscutils/eventvwr/lang/pl-PL.rc
@@ -172,7 +172,7 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "Opis zdarzenia dla danego numeru ID ( %lu ) nie został odnaleziony w źródle ( %s ). Ten komputer może nie miec wystarczających informacji w rejestrze, albo bibliotek DLL, aby wyświetlić wiadomości z komputera zdalnego.\n\nThe following information is part of the event:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOITEMS "No items"
+    IDS_NOITEMS "No items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/pl-PL.rc
+++ b/base/applications/mscutils/eventvwr/lang/pl-PL.rc
@@ -172,7 +172,6 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "Opis zdarzenia dla danego numeru ID ( %lu ) nie został odnaleziony w źródle ( %s ). Ten komputer może nie miec wystarczających informacji w rejestrze, albo bibliotek DLL, aby wyświetlić wiadomości z komputera zdalnego.\n\nThe following information is part of the event:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOITEMS "No items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/pt-BR.rc
+++ b/base/applications/mscutils/eventvwr/lang/pt-BR.rc
@@ -167,6 +167,9 @@ BEGIN
     IDS_CLEAREVENTS_MSG "Do you want to save this event log before clearing it?"
     IDS_RESTOREDEFAULTS "Do you want to restore all settings for this log to their default values?"
     IDS_EVENTSTRINGIDNOTFOUND "A descrição para Event ID ( %lu ) em Fonte ( %s ) não foi encontrado. O computador local talvez não possua a informação de registro necessária ou mensagem de arquivos DLL para exibir mensagens de um computador remoto.\n\nThe following information is part of the event:\n\n"
+    IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
+    IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
+    IDS_NOMOREITEMS "No more items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/pt-BR.rc
+++ b/base/applications/mscutils/eventvwr/lang/pt-BR.rc
@@ -169,7 +169,6 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "A descrição para Event ID ( %lu ) em Fonte ( %s ) não foi encontrado. O computador local talvez não possua a informação de registro necessária ou mensagem de arquivos DLL para exibir mensagens de um computador remoto.\n\nThe following information is part of the event:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOITEMS "No items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/pt-BR.rc
+++ b/base/applications/mscutils/eventvwr/lang/pt-BR.rc
@@ -169,7 +169,7 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "A descrição para Event ID ( %lu ) em Fonte ( %s ) não foi encontrado. O computador local talvez não possua a informação de registro necessária ou mensagem de arquivos DLL para exibir mensagens de um computador remoto.\n\nThe following information is part of the event:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOITEMS "No items"
+    IDS_NOITEMS "No items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/pt-BR.rc
+++ b/base/applications/mscutils/eventvwr/lang/pt-BR.rc
@@ -169,7 +169,7 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "A descrição para Event ID ( %lu ) em Fonte ( %s ) não foi encontrado. O computador local talvez não possua a informação de registro necessária ou mensagem de arquivos DLL para exibir mensagens de um computador remoto.\n\nThe following information is part of the event:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOMOREITEMS "No more items."
+    IDS_NOITEMS "No items"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/pt-PT.rc
+++ b/base/applications/mscutils/eventvwr/lang/pt-PT.rc
@@ -169,7 +169,7 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "A descrição do ID de Evento ( %lu ) na Origem ( %s ) não foi encontrado. O computador local talvez não possua a informação de registo necessária ou os ficheiros DLL necessárias para apresentar mensagens de um computador remoto.\n\nA informação seguinte é parte do evento:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOMOREITEMS "No more items."
+    IDS_NOITEMS "No items"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/pt-PT.rc
+++ b/base/applications/mscutils/eventvwr/lang/pt-PT.rc
@@ -169,7 +169,6 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "A descrição do ID de Evento ( %lu ) na Origem ( %s ) não foi encontrado. O computador local talvez não possua a informação de registo necessária ou os ficheiros DLL necessárias para apresentar mensagens de um computador remoto.\n\nA informação seguinte é parte do evento:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOITEMS "No items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/pt-PT.rc
+++ b/base/applications/mscutils/eventvwr/lang/pt-PT.rc
@@ -167,6 +167,9 @@ BEGIN
     IDS_CLEAREVENTS_MSG "Deseja guardar este registo de eventos antes de limpar?"
     IDS_RESTOREDEFAULTS "Tem a certeza de que pretende repor todas definições deste registo para os valores predefinidos?"
     IDS_EVENTSTRINGIDNOTFOUND "A descrição do ID de Evento ( %lu ) na Origem ( %s ) não foi encontrado. O computador local talvez não possua a informação de registo necessária ou os ficheiros DLL necessárias para apresentar mensagens de um computador remoto.\n\nA informação seguinte é parte do evento:\n\n"
+    IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
+    IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
+    IDS_NOMOREITEMS "No more items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/pt-PT.rc
+++ b/base/applications/mscutils/eventvwr/lang/pt-PT.rc
@@ -169,7 +169,7 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "A descrição do ID de Evento ( %lu ) na Origem ( %s ) não foi encontrado. O computador local talvez não possua a informação de registo necessária ou os ficheiros DLL necessárias para apresentar mensagens de um computador remoto.\n\nA informação seguinte é parte do evento:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOITEMS "No items"
+    IDS_NOITEMS "No items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/ro-RO.rc
+++ b/base/applications/mscutils/eventvwr/lang/ro-RO.rc
@@ -171,7 +171,6 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "Imposibil de găsit descrierea evenimentului cu ID-ul ( %lu ) în sursa ( %s ). Este posibil ca computerul local să nu aibă informațiile de registru necesare sau fișierele DLL de mesaje pentru a afișa mesaje de la un computer la distanță.\n\nUrmătoarele informații fac parte din eveniment:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOITEMS "No items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/ro-RO.rc
+++ b/base/applications/mscutils/eventvwr/lang/ro-RO.rc
@@ -169,6 +169,9 @@ BEGIN
     IDS_CLEAREVENTS_MSG "Doriți să salvați acest jurnal de evenimente înainte de a-l închide?"
     IDS_RESTOREDEFAULTS "Doriți să restabiliți toate setările pentru acest jurnal la valorile lor implicite?"
     IDS_EVENTSTRINGIDNOTFOUND "Imposibil de găsit descrierea evenimentului cu ID-ul ( %lu ) în sursa ( %s ). Este posibil ca computerul local să nu aibă informațiile de registru necesare sau fișierele DLL de mesaje pentru a afișa mesaje de la un computer la distanță.\n\nUrmătoarele informații fac parte din eveniment:\n\n"
+    IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
+    IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
+    IDS_NOMOREITEMS "No more items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/ro-RO.rc
+++ b/base/applications/mscutils/eventvwr/lang/ro-RO.rc
@@ -171,7 +171,7 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "Imposibil de găsit descrierea evenimentului cu ID-ul ( %lu ) în sursa ( %s ). Este posibil ca computerul local să nu aibă informațiile de registru necesare sau fișierele DLL de mesaje pentru a afișa mesaje de la un computer la distanță.\n\nUrmătoarele informații fac parte din eveniment:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOMOREITEMS "No more items."
+    IDS_NOITEMS "No items"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/ro-RO.rc
+++ b/base/applications/mscutils/eventvwr/lang/ro-RO.rc
@@ -171,7 +171,7 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "Imposibil de găsit descrierea evenimentului cu ID-ul ( %lu ) în sursa ( %s ). Este posibil ca computerul local să nu aibă informațiile de registru necesare sau fișierele DLL de mesaje pentru a afișa mesaje de la un computer la distanță.\n\nUrmătoarele informații fac parte din eveniment:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOITEMS "No items"
+    IDS_NOITEMS "No items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/ru-RU.rc
+++ b/base/applications/mscutils/eventvwr/lang/ru-RU.rc
@@ -171,6 +171,9 @@ BEGIN
     IDS_CLEAREVENTS_MSG "Вы хотите сохранить журнал событий перед очисткой?"
     IDS_RESTOREDEFAULTS "Do you want to restore all settings for this log to their default values?"
     IDS_EVENTSTRINGIDNOTFOUND "Не найдено описание для события с кодом ( %lu ) в источнике ( %s ). Возможно, на локальном компьютере нет нужных данных в реестре или файлов DLL сообщений для отображения сообщений удаленного компьютера.\n\nСледующая информация часть события:\n\n"
+    IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
+    IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
+    IDS_NOMOREITEMS "No more items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/ru-RU.rc
+++ b/base/applications/mscutils/eventvwr/lang/ru-RU.rc
@@ -173,7 +173,6 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "Не найдено описание для события с кодом ( %lu ) в источнике ( %s ). Возможно, на локальном компьютере нет нужных данных в реестре или файлов DLL сообщений для отображения сообщений удаленного компьютера.\n\nСледующая информация часть события:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOITEMS "No items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/ru-RU.rc
+++ b/base/applications/mscutils/eventvwr/lang/ru-RU.rc
@@ -173,7 +173,7 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "Не найдено описание для события с кодом ( %lu ) в источнике ( %s ). Возможно, на локальном компьютере нет нужных данных в реестре или файлов DLL сообщений для отображения сообщений удаленного компьютера.\n\nСледующая информация часть события:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOMOREITEMS "No more items."
+    IDS_NOITEMS "No items"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/ru-RU.rc
+++ b/base/applications/mscutils/eventvwr/lang/ru-RU.rc
@@ -173,7 +173,7 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "Не найдено описание для события с кодом ( %lu ) в источнике ( %s ). Возможно, на локальном компьютере нет нужных данных в реестре или файлов DLL сообщений для отображения сообщений удаленного компьютера.\n\nСледующая информация часть события:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOITEMS "No items"
+    IDS_NOITEMS "No items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/sk-SK.rc
+++ b/base/applications/mscutils/eventvwr/lang/sk-SK.rc
@@ -169,7 +169,6 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "Popis pre udalosť ID ( %lu ) zo zdroja ( %s ) nebol nájdený. The local computer may not have the necessary registry information or message DLL files to display messages from a remote computer.\n\nThe following information is part of the event:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOITEMS "No items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/sk-SK.rc
+++ b/base/applications/mscutils/eventvwr/lang/sk-SK.rc
@@ -169,7 +169,7 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "Popis pre udalosť ID ( %lu ) zo zdroja ( %s ) nebol nájdený. The local computer may not have the necessary registry information or message DLL files to display messages from a remote computer.\n\nThe following information is part of the event:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOMOREITEMS "No more items."
+    IDS_NOITEMS "No items"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/sk-SK.rc
+++ b/base/applications/mscutils/eventvwr/lang/sk-SK.rc
@@ -169,7 +169,7 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "Popis pre udalosť ID ( %lu ) zo zdroja ( %s ) nebol nájdený. The local computer may not have the necessary registry information or message DLL files to display messages from a remote computer.\n\nThe following information is part of the event:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOITEMS "No items"
+    IDS_NOITEMS "No items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/sk-SK.rc
+++ b/base/applications/mscutils/eventvwr/lang/sk-SK.rc
@@ -167,6 +167,9 @@ BEGIN
     IDS_CLEAREVENTS_MSG "Do you want to save this event log before clearing it?"
     IDS_RESTOREDEFAULTS "Do you want to restore all settings for this log to their default values?"
     IDS_EVENTSTRINGIDNOTFOUND "Popis pre udalosť ID ( %lu ) zo zdroja ( %s ) nebol nájdený. The local computer may not have the necessary registry information or message DLL files to display messages from a remote computer.\n\nThe following information is part of the event:\n\n"
+    IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
+    IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
+    IDS_NOMOREITEMS "No more items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/sq-AL.rc
+++ b/base/applications/mscutils/eventvwr/lang/sq-AL.rc
@@ -169,7 +169,7 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "Përshkrimi për ngjarjet ID ( %lu ) në burim ( %s ) nuk gjindet. Kompjuter vendas mund të mos ketë informacionin e regjistrit te nevojshem ose mesazhin për dokumentat DLL për të shfaqur nga një kompjuter në distancë.\n\nThe following information is part of the event:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOMOREITEMS "No more items."
+    IDS_NOITEMS "No items"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/sq-AL.rc
+++ b/base/applications/mscutils/eventvwr/lang/sq-AL.rc
@@ -169,7 +169,6 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "Përshkrimi për ngjarjet ID ( %lu ) në burim ( %s ) nuk gjindet. Kompjuter vendas mund të mos ketë informacionin e regjistrit te nevojshem ose mesazhin për dokumentat DLL për të shfaqur nga një kompjuter në distancë.\n\nThe following information is part of the event:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOITEMS "No items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/sq-AL.rc
+++ b/base/applications/mscutils/eventvwr/lang/sq-AL.rc
@@ -167,6 +167,9 @@ BEGIN
     IDS_CLEAREVENTS_MSG "Do you want to save this event log before clearing it?"
     IDS_RESTOREDEFAULTS "Do you want to restore all settings for this log to their default values?"
     IDS_EVENTSTRINGIDNOTFOUND "Përshkrimi për ngjarjet ID ( %lu ) në burim ( %s ) nuk gjindet. Kompjuter vendas mund të mos ketë informacionin e regjistrit te nevojshem ose mesazhin për dokumentat DLL për të shfaqur nga një kompjuter në distancë.\n\nThe following information is part of the event:\n\n"
+    IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
+    IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
+    IDS_NOMOREITEMS "No more items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/sq-AL.rc
+++ b/base/applications/mscutils/eventvwr/lang/sq-AL.rc
@@ -169,7 +169,7 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "Përshkrimi për ngjarjet ID ( %lu ) në burim ( %s ) nuk gjindet. Kompjuter vendas mund të mos ketë informacionin e regjistrit te nevojshem ose mesazhin për dokumentat DLL për të shfaqur nga një kompjuter në distancë.\n\nThe following information is part of the event:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOITEMS "No items"
+    IDS_NOITEMS "No items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/sv-SE.rc
+++ b/base/applications/mscutils/eventvwr/lang/sv-SE.rc
@@ -169,7 +169,6 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "Beskrivning av Händelse ID ( %lu ) i källan ( %s ) kan inte hittas. Lokal dator har inte nödvendig registerinformation eller meddelander DLL filer for å vise meddelander från en fjärr dator.\n\nThe following information is part of the event:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOITEMS "No items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/sv-SE.rc
+++ b/base/applications/mscutils/eventvwr/lang/sv-SE.rc
@@ -169,7 +169,7 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "Beskrivning av Händelse ID ( %lu ) i källan ( %s ) kan inte hittas. Lokal dator har inte nödvendig registerinformation eller meddelander DLL filer for å vise meddelander från en fjärr dator.\n\nThe following information is part of the event:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOMOREITEMS "No more items."
+    IDS_NOITEMS "No items"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/sv-SE.rc
+++ b/base/applications/mscutils/eventvwr/lang/sv-SE.rc
@@ -167,6 +167,9 @@ BEGIN
     IDS_CLEAREVENTS_MSG "Do you want to save this event log before clearing it?"
     IDS_RESTOREDEFAULTS "Do you want to restore all settings for this log to their default values?"
     IDS_EVENTSTRINGIDNOTFOUND "Beskrivning av Händelse ID ( %lu ) i källan ( %s ) kan inte hittas. Lokal dator har inte nödvendig registerinformation eller meddelander DLL filer for å vise meddelander från en fjärr dator.\n\nThe following information is part of the event:\n\n"
+    IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
+    IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
+    IDS_NOMOREITEMS "No more items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/sv-SE.rc
+++ b/base/applications/mscutils/eventvwr/lang/sv-SE.rc
@@ -169,7 +169,7 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "Beskrivning av Händelse ID ( %lu ) i källan ( %s ) kan inte hittas. Lokal dator har inte nödvendig registerinformation eller meddelander DLL filer for å vise meddelander från en fjärr dator.\n\nThe following information is part of the event:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOITEMS "No items"
+    IDS_NOITEMS "No items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/tr-TR.rc
+++ b/base/applications/mscutils/eventvwr/lang/tr-TR.rc
@@ -168,6 +168,9 @@ BEGIN
     IDS_CLEAREVENTS_MSG "Silmeden önce bu olay kaydını kaydetmek ister misiniz?"
     IDS_RESTOREDEFAULTS "Bu günlük için tüm ayarları varsayılan değerlerine geri yüklemek istiyor musunuz?"
     IDS_EVENTSTRINGIDNOTFOUND "( %s ) kaynağındaki ( %lu ) olay kimliği için açıklama bulunamıyor. Yerel bilgisayarda, uzak bilgisayardan iletileri görüntülemesi için gerekli Kayıt Defteri bilgisi veya ileti DLL dosyaları olmayabilir.\n\nAşağıdaki bilgi olayın parçasıdır:\n\n"
+    IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
+    IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
+    IDS_NOMOREITEMS "No more items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/tr-TR.rc
+++ b/base/applications/mscutils/eventvwr/lang/tr-TR.rc
@@ -170,7 +170,7 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "( %s ) kaynağındaki ( %lu ) olay kimliği için açıklama bulunamıyor. Yerel bilgisayarda, uzak bilgisayardan iletileri görüntülemesi için gerekli Kayıt Defteri bilgisi veya ileti DLL dosyaları olmayabilir.\n\nAşağıdaki bilgi olayın parçasıdır:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOITEMS "No items"
+    IDS_NOITEMS "No items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/tr-TR.rc
+++ b/base/applications/mscutils/eventvwr/lang/tr-TR.rc
@@ -170,7 +170,7 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "( %s ) kaynağındaki ( %lu ) olay kimliği için açıklama bulunamıyor. Yerel bilgisayarda, uzak bilgisayardan iletileri görüntülemesi için gerekli Kayıt Defteri bilgisi veya ileti DLL dosyaları olmayabilir.\n\nAşağıdaki bilgi olayın parçasıdır:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOMOREITEMS "No more items."
+    IDS_NOITEMS "No items"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/tr-TR.rc
+++ b/base/applications/mscutils/eventvwr/lang/tr-TR.rc
@@ -170,7 +170,6 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "( %s ) kaynağındaki ( %lu ) olay kimliği için açıklama bulunamıyor. Yerel bilgisayarda, uzak bilgisayardan iletileri görüntülemesi için gerekli Kayıt Defteri bilgisi veya ileti DLL dosyaları olmayabilir.\n\nAşağıdaki bilgi olayın parçasıdır:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOITEMS "No items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/uk-UA.rc
+++ b/base/applications/mscutils/eventvwr/lang/uk-UA.rc
@@ -171,7 +171,6 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "Опис для Ідентифікатора події ( %lu ) за джерелом ( %s ) не знайдено. Локальний комп'ютер може не мати необхідної інформації в реєстрі чи DLL файлів повідомлень для відображення повідомлень, що надходять від віддаленого комп'ютера.\n\nThe following information is part of the event:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOITEMS "No items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/uk-UA.rc
+++ b/base/applications/mscutils/eventvwr/lang/uk-UA.rc
@@ -171,7 +171,7 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "Опис для Ідентифікатора події ( %lu ) за джерелом ( %s ) не знайдено. Локальний комп'ютер може не мати необхідної інформації в реєстрі чи DLL файлів повідомлень для відображення повідомлень, що надходять від віддаленого комп'ютера.\n\nThe following information is part of the event:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOMOREITEMS "No more items."
+    IDS_NOITEMS "No items"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/uk-UA.rc
+++ b/base/applications/mscutils/eventvwr/lang/uk-UA.rc
@@ -171,7 +171,7 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "Опис для Ідентифікатора події ( %lu ) за джерелом ( %s ) не знайдено. Локальний комп'ютер може не мати необхідної інформації в реєстрі чи DLL файлів повідомлень для відображення повідомлень, що надходять від віддаленого комп'ютера.\n\nThe following information is part of the event:\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOITEMS "No items"
+    IDS_NOITEMS "No items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/uk-UA.rc
+++ b/base/applications/mscutils/eventvwr/lang/uk-UA.rc
@@ -169,6 +169,9 @@ BEGIN
     IDS_CLEAREVENTS_MSG "Do you want to save this event log before clearing it?"
     IDS_RESTOREDEFAULTS "Do you want to restore all settings for this log to their default values?"
     IDS_EVENTSTRINGIDNOTFOUND "Опис для Ідентифікатора події ( %lu ) за джерелом ( %s ) не знайдено. Локальний комп'ютер може не мати необхідної інформації в реєстрі чи DLL файлів повідомлень для відображення повідомлень, що надходять від віддаленого комп'ютера.\n\nThe following information is part of the event:\n\n"
+    IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
+    IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
+    IDS_NOMOREITEMS "No more items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/zh-CN.rc
+++ b/base/applications/mscutils/eventvwr/lang/zh-CN.rc
@@ -171,7 +171,7 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "无法找到来源（%s）中的事件 ID（%lu）的描述。本地计算机可能没有显示来自远程计算机的消息所必需的注册表信息或消息 DLL 文件。\n\n下面的信息是事件的一部分：\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOMOREITEMS "No more items."
+    IDS_NOITEMS "No items"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/zh-CN.rc
+++ b/base/applications/mscutils/eventvwr/lang/zh-CN.rc
@@ -171,7 +171,7 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "无法找到来源（%s）中的事件 ID（%lu）的描述。本地计算机可能没有显示来自远程计算机的消息所必需的注册表信息或消息 DLL 文件。\n\n下面的信息是事件的一部分：\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOITEMS "No items"
+    IDS_NOITEMS "No items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/zh-CN.rc
+++ b/base/applications/mscutils/eventvwr/lang/zh-CN.rc
@@ -171,7 +171,6 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "无法找到来源（%s）中的事件 ID（%lu）的描述。本地计算机可能没有显示来自远程计算机的消息所必需的注册表信息或消息 DLL 文件。\n\n下面的信息是事件的一部分：\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOITEMS "No items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/zh-CN.rc
+++ b/base/applications/mscutils/eventvwr/lang/zh-CN.rc
@@ -169,6 +169,9 @@ BEGIN
     IDS_CLEAREVENTS_MSG "你想要在清除之前保存此事件日志吗？"
     IDS_RESTOREDEFAULTS "你想要将这个日志的所有设置恢复为默认值吗？"
     IDS_EVENTSTRINGIDNOTFOUND "无法找到来源（%s）中的事件 ID（%lu）的描述。本地计算机可能没有显示来自远程计算机的消息所必需的注册表信息或消息 DLL 文件。\n\n下面的信息是事件的一部分：\n\n"
+    IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
+    IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
+    IDS_NOMOREITEMS "No more items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/zh-HK.rc
+++ b/base/applications/mscutils/eventvwr/lang/zh-HK.rc
@@ -170,7 +170,6 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "找不到來源（%s）中的事件 ID（%lu）的描述。本地電腦可能沒有顯示來自遠端電腦訊息所需的註冊表資訊或訊息 DLL 檔。\n\n下列資訊是部分事件：\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOITEMS "No items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/zh-HK.rc
+++ b/base/applications/mscutils/eventvwr/lang/zh-HK.rc
@@ -168,6 +168,9 @@ BEGIN
     IDS_CLEAREVENTS_MSG "您想在清除之前儲存這個事件記錄嗎？"
     IDS_RESTOREDEFAULTS "您要將這個記錄的所有設定還原至預設值嗎？"
     IDS_EVENTSTRINGIDNOTFOUND "找不到來源（%s）中的事件 ID（%lu）的描述。本地電腦可能沒有顯示來自遠端電腦訊息所需的註冊表資訊或訊息 DLL 檔。\n\n下列資訊是部分事件：\n\n"
+    IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
+    IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
+    IDS_NOMOREITEMS "No more items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/zh-HK.rc
+++ b/base/applications/mscutils/eventvwr/lang/zh-HK.rc
@@ -170,7 +170,7 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "找不到來源（%s）中的事件 ID（%lu）的描述。本地電腦可能沒有顯示來自遠端電腦訊息所需的註冊表資訊或訊息 DLL 檔。\n\n下列資訊是部分事件：\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOITEMS "No items"
+    IDS_NOITEMS "No items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/zh-HK.rc
+++ b/base/applications/mscutils/eventvwr/lang/zh-HK.rc
@@ -170,7 +170,7 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "找不到來源（%s）中的事件 ID（%lu）的描述。本地電腦可能沒有顯示來自遠端電腦訊息所需的註冊表資訊或訊息 DLL 檔。\n\n下列資訊是部分事件：\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOMOREITEMS "No more items."
+    IDS_NOITEMS "No items"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/zh-TW.rc
+++ b/base/applications/mscutils/eventvwr/lang/zh-TW.rc
@@ -170,7 +170,7 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "找不到來源（%s）中的事件 ID（%lu）的描述。本地電腦可能沒有顯示來自遠端電腦消息所必需的註冊表資訊或消息 DLL 檔。\n\n下列資訊是部分事件︰\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOMOREITEMS "No more items."
+    IDS_NOITEMS "No items"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/zh-TW.rc
+++ b/base/applications/mscutils/eventvwr/lang/zh-TW.rc
@@ -170,7 +170,6 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "找不到來源（%s）中的事件 ID（%lu）的描述。本地電腦可能沒有顯示來自遠端電腦消息所必需的註冊表資訊或消息 DLL 檔。\n\n下列資訊是部分事件︰\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOITEMS "No items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/zh-TW.rc
+++ b/base/applications/mscutils/eventvwr/lang/zh-TW.rc
@@ -170,7 +170,7 @@ BEGIN
     IDS_EVENTSTRINGIDNOTFOUND "找不到來源（%s）中的事件 ID（%lu）的描述。本地電腦可能沒有顯示來自遠端電腦消息所必需的註冊表資訊或消息 DLL 檔。\n\n下列資訊是部分事件︰\n\n"
     IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
     IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
-    IDS_NOITEMS "No items"
+    IDS_NOITEMS "No items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/lang/zh-TW.rc
+++ b/base/applications/mscutils/eventvwr/lang/zh-TW.rc
@@ -168,6 +168,9 @@ BEGIN
     IDS_CLEAREVENTS_MSG "您要在清除之前儲存此事件記錄嗎？"
     IDS_RESTOREDEFAULTS "您要這個記錄的所有設定還原至預設值嗎？"
     IDS_EVENTSTRINGIDNOTFOUND "找不到來源（%s）中的事件 ID（%lu）的描述。本地電腦可能沒有顯示來自遠端電腦消息所必需的註冊表資訊或消息 DLL 檔。\n\n下列資訊是部分事件︰\n\n"
+    IDS_CONTFROMBEGINNING "You have reached the end of the event log. Do you want to continue from the beginning?"
+    IDS_CONTFROMEND "You have reached the beginning of the event log. Do you want to continue from the end?"
+    IDS_NOMOREITEMS "No more items."
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/eventvwr/resource.h
+++ b/base/applications/mscutils/eventvwr/resource.h
@@ -107,7 +107,7 @@
 #define IDS_RESTOREDEFAULTS             112
 #define IDS_CONTFROMBEGINNING           113
 #define IDS_CONTFROMEND                 114
-#define IDS_NOMOREITEMS                 115
+#define IDS_NOITEMS                 115
 
 #define IDS_USAGE                       120
 #define IDS_EVENTLOGFILE                121

--- a/base/applications/mscutils/eventvwr/resource.h
+++ b/base/applications/mscutils/eventvwr/resource.h
@@ -105,6 +105,9 @@
 #define IDS_CLEAREVENTS_MSG             110
 #define IDS_EVENTSTRINGIDNOTFOUND       111
 #define IDS_RESTOREDEFAULTS             112
+#define IDS_CONTFROMBEGINNING           113
+#define IDS_CONTFROMEND                 114
+#define IDS_NOMOREITEMS                 115
 
 #define IDS_USAGE                       120
 #define IDS_EVENTLOGFILE                121

--- a/base/applications/mscutils/eventvwr/resource.h
+++ b/base/applications/mscutils/eventvwr/resource.h
@@ -107,7 +107,6 @@
 #define IDS_RESTOREDEFAULTS             112
 #define IDS_CONTFROMBEGINNING           113
 #define IDS_CONTFROMEND                 114
-#define IDS_NOITEMS                 115
 
 #define IDS_USAGE                       120
 #define IDS_EVENTLOGFILE                121


### PR DESCRIPTION
## Purpose

Don’t display garbage to the users.
JIRA issue: [CORE-19786](https://jira.reactos.org/browse/CORE-19786)

## Proposed changes

- Localize message text by using newly added `IDS_CONTFROMBEGINNING` and `IDS_CONTFROMEND` resource strings.
- Check item count before showing next/previous item.
- Add `EnableEventDetailsButtons` function.

## Comparison

BEFORE:
![before](https://github.com/user-attachments/assets/b288b338-7b15-481b-a50b-13eca32cb5c0)
Garbage is displayed.

AFTER:
![after](https://github.com/user-attachments/assets/f887379e-cf82-4cef-bafd-f6b02a56a2aa)
Buttons are disabled.