### PR TITLE
[USER32] PrivateExtractIcons must return 0 for empty files

### DIFF
--- a/win32ss/user/user32/misc/exticon.c
+++ b/win32ss/user/user32/misc/exticon.c
@@ -347,6 +347,14 @@ static UINT ICO_ExtractIconExW(
 	hFile = CreateFileW(szExePath, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, 0, 0);
 	if (hFile == INVALID_HANDLE_VALUE) return ret;
 	fsizel = GetFileSize(hFile,&fsizeh);
+#ifdef __REACTOS__
+    if (!(fsizel | fsizeh))
+    {
+        /* Cannot map zero sized file */
+        CloseHandle(hFile);
+        return 0; /* No icons */
+    }
+#endif
 
 	/* Map the file */
 	fmapping = CreateFileMappingW(hFile, NULL, PAGE_READONLY | SEC_COMMIT, 0, 0, NULL);

--- a/win32ss/user/user32/misc/exticon.c
+++ b/win32ss/user/user32/misc/exticon.c
@@ -350,7 +350,7 @@ static UINT ICO_ExtractIconExW(
 #ifdef __REACTOS__
     if (!(fsizel | fsizeh))
     {
-        /* Cannot map zero sized file */
+        /* Cannot map empty file */
         CloseHandle(hFile);
         return 0; /* No icons */
     }


### PR DESCRIPTION
This bug breaks the documented `S_FALSE` return value for `SHDefExtractIconW` when the icon is not found.