### PR TITLE
[SHELL32][SHELL32_APITESTS] SHDefExtractIcon zero icon size as sysmetric

### DIFF
--- a/dll/win32/shell32/iconcache.cpp
+++ b/dll/win32/shell32/iconcache.cpp
@@ -1019,6 +1019,9 @@ HRESULT WINAPI SHDefExtractIconW(LPCWSTR pszIconFile, int iIndex, UINT uFlags,
     HICON hIcons[2];
     WARN("%s %d 0x%08x %p %p %d, semi-stub\n", debugstr_w(pszIconFile), iIndex, uFlags, phiconLarge, phiconSmall, nIconSize);
 
+    if (!nIconSize)
+        nIconSize = MAKELONG(GetSystemMetrics(SM_CXICON), GetSystemMetrics(SM_CXSMICON));
+
     ret = PrivateExtractIconsW(pszIconFile, iIndex, nIconSize, nIconSize, hIcons, NULL, 2, LR_DEFAULTCOLOR);
     /* FIXME: deal with uFlags parameter which contains GIL_ flags */
     if (ret == 0xFFFFFFFF)

--- a/modules/rostests/apitests/shell32/ExtractIconEx.cpp
+++ b/modules/rostests/apitests/shell32/ExtractIconEx.cpp
@@ -9,6 +9,29 @@
 #include "shelltest.h"
 #include <stdio.h>
 
+EXTERN_C BOOL WINAPI SHAreIconsEqual(HICON hIcon1, HICON hIcon2);
+
+static void SafeDestroyIcon(HICON hIco)
+{
+    if (hIco)
+        DestroyIcon(hIco);
+}
+
+static UINT GetIcoSize(HICON hIco)
+{
+    ICONINFO info;
+    if (GetIconInfo(hIco, &info))
+    {
+        BITMAP bm;
+        if (!GetObject(info.hbmColor ? info.hbmColor : info.hbmMask, sizeof(bm), &bm))
+            bm.bmWidth = 0;
+        DeleteObject(info.hbmMask);
+        DeleteObject(info.hbmColor);
+        return bm.bmWidth ;
+    }
+    return 0;
+}
+
 typedef struct
 {
     PCWSTR pszFilePath;
@@ -121,4 +144,67 @@ START_TEST(ExtractIconEx)
 
     DeleteFileA(FileName[0]);
     DeleteFileA(FileName[1]);
+}
+
+static HRESULT SHDEI(LPCWSTR pszIconFile, int Index = 0, UINT GIL = 0, UINT Size = 0)
+{
+    HICON hIco = NULL;
+    HRESULT hr = SHDefExtractIcon(pszIconFile, Index, GIL, &hIco, NULL, Size);
+    if (hr == S_OK)
+    {
+        hr = GetIcoSize(hIco);
+        SafeDestroyIcon(hIco);
+    }
+    return hr;
+}
+
+START_TEST(SHDefExtractIcon)
+{
+    HRESULT hr;
+    int SysBigIconSize = GetSystemMetrics(SM_CXICON);
+
+    // Modern Windows requires the system image list to be initialized for GIL_SIMULATEDOC to work!
+    SHFILEINFOW shfi;
+    SHGetFileInfoW(L"x", 0, &shfi, sizeof(shfi), SHGFI_SYSICONINDEX | SHGFI_USEFILEATTRIBUTES);
+
+    WCHAR path[MAX_PATH];
+    GetSystemDirectoryW(path, _countof(path));
+    PathAppendW(path, L"user32.dll");
+    int index = 1;
+
+    ok(SHDEI(path, index, 0, 0) == SysBigIconSize, "Zero size is GetSystemMetrics\n");
+    ok(SHDEI(path, index, 0, SysBigIconSize * 2) == SysBigIconSize * 2, "Resize\n");
+
+    HICON hIcoLarge, hIcoSmall;
+    if (SHDefExtractIcon(path, index, 0, &hIcoLarge, &hIcoSmall, 0) != S_OK)
+        hIcoLarge = hIcoSmall = NULL;
+    ok(hIcoLarge && hIcoSmall && !SHAreIconsEqual(hIcoLarge, hIcoSmall), "Large+Small\n");
+    SafeDestroyIcon(hIcoLarge);
+    SafeDestroyIcon(hIcoSmall);
+
+    static const int sizes[] = { 0, SysBigIconSize * 2 };
+    for (UINT i = 0; i < _countof(sizes); ++i)
+    {
+        HICON hIcoNormal, hIcoSimDoc;
+        if (FAILED(hr = SHDefExtractIcon(path, index, 0, &hIcoNormal, NULL, sizes[i])))
+            hIcoNormal = NULL;
+        if (FAILED(hr = SHDefExtractIcon(path, index, GIL_SIMULATEDOC, &hIcoSimDoc, NULL, sizes[i])))
+            hIcoSimDoc = NULL;
+        ok(hIcoNormal && hIcoSimDoc && !SHAreIconsEqual(hIcoNormal, hIcoSimDoc), "GIL_SIMULATEDOC\n");
+        SafeDestroyIcon(hIcoNormal);
+        SafeDestroyIcon(hIcoSimDoc);
+    }
+
+    GetTempPathW(_countof(path), path);
+    GetTempFileNameW(path, L"TST", 0, path);
+    ok(SHDEI(path) == S_FALSE, "Empty file contains no icons\n");
+    HANDLE hFile = CreateFileW(path, GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_DELETE, NULL, OPEN_EXISTING, 0, NULL);
+    if (hFile != INVALID_HANDLE_VALUE)
+    {
+        DWORD io;
+        WriteFile(hFile, "!", 1, &io, NULL);
+        CloseHandle(hFile);
+        ok(SHDEI(path) == S_FALSE, "File contains no icons\n");
+    }
+    DeleteFile(path);
 }

--- a/modules/rostests/apitests/shell32/testlist.c
+++ b/modules/rostests/apitests/shell32/testlist.c
@@ -34,6 +34,7 @@ extern void func_SHChangeNotify(void);
 extern void func_SHCreateDataObject(void);
 extern void func_SHCreateFileDataObject(void);
 extern void func_SHCreateFileExtractIconW(void);
+extern void func_SHDefExtractIcon(void);
 extern void func_SHEnumerateUnreadMailAccountsW(void);
 extern void func_She(void);
 extern void func_ShellExec_RunDLL(void);
@@ -89,6 +90,7 @@ const struct test winetest_testlist[] =
     { "SHCreateDataObject", func_SHCreateDataObject },
     { "SHCreateFileDataObject", func_SHCreateFileDataObject },
     { "SHCreateFileExtractIconW", func_SHCreateFileExtractIconW },
+    { "SHDefExtractIcon", func_SHDefExtractIcon },
     { "SHEnumerateUnreadMailAccountsW", func_SHEnumerateUnreadMailAccountsW },
     { "She", func_She },
     { "ShellExec_RunDLL", func_ShellExec_RunDLL },


### PR DESCRIPTION
The documentation says "Pass 0 to specify default large and small sizes".

Notes:
- The new `GIL_SIMULATEDOC` test fails on ROS because that feature is not implemented yet.