### PR TITLE
[SETUPAPI] Stub implement `SetupQueryInfVersionInformation`

### DIFF
--- a/dll/win32/setupapi/query.c
+++ b/dll/win32/setupapi/query.c
@@ -693,3 +693,21 @@ BOOL WINAPI SetupQueryInfOriginalFileInformationW(
 
     return TRUE;
 }
+
+BOOL WINAPI SetupQueryInfVersionInformationA(SP_INF_INFORMATION *info, UINT index, const char *key, char *buff,
+    DWORD size, DWORD *req_size)
+{
+    FIXME("info %p, index %d, key %s, buff %p, size %ld, req_size %p stub!\n", info, index, debugstr_a(key), buff,
+        size, req_size);
+    SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
+    return FALSE;
+}
+
+BOOL WINAPI SetupQueryInfVersionInformationW(SP_INF_INFORMATION *info, UINT index, const WCHAR *key, WCHAR *buff,
+    DWORD size, DWORD *req_size)
+{
+    FIXME("info %p, index %d, key %s, buff %p, size %ld, req_size %p stub!\n", info, index, debugstr_w(key), buff,
+        size, req_size);
+    SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
+    return FALSE;
+}

--- a/dll/win32/setupapi/setupapi.spec
+++ b/dll/win32/setupapi/setupapi.spec
@@ -475,8 +475,8 @@
 @ stdcall SetupQueryInfFileInformationW(ptr long wstr long ptr)
 @ stdcall SetupQueryInfOriginalFileInformationA(ptr long ptr ptr)
 @ stdcall SetupQueryInfOriginalFileInformationW(ptr long ptr ptr)
-@ stub SetupQueryInfVersionInformationA
-@ stub SetupQueryInfVersionInformationW
+@ stdcall SetupQueryInfVersionInformationA(ptr long str ptr long ptr)
+@ stdcall SetupQueryInfVersionInformationW(ptr long wstr ptr long ptr)
 @ stub SetupQuerySourceListA
 @ stub SetupQuerySourceListW
 @ stdcall SetupQuerySpaceRequiredOnDriveA(long str ptr ptr long)


### PR DESCRIPTION
## Purpose

Sync `SetupQueryInfVersionInformation` stubs to Wine.

JIRA issue: None.

## Proposed changes

- Stub implement `SetupQueryInfVersionInformation`

---

The new synced stubs set `ERROR_CALL_NOT_IMPLEMENTED` as last error and return, rather than raise exception `EXCEPTION_WINE_STUB (0x80000100)`, then the Virtual Box Guest Addition 7.1.6 setup progress can move on.

Before this PR (PR #7746 goes first), setup raises 0x80000100:
![image](https://github.com/user-attachments/assets/6bb6e630-ed25-481d-84ec-e46520fbed17)

After this PR, setup still gets stuck because of another problem (relates to `SetupInstallServicesFromInfSectionExW`), I'll fix that in a separate PR (#7770).
