### PR TITLE
[GIT] .sh script files should (or must...) always use LF (Unix) line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -30,6 +30,9 @@
 *.TXT text
 *.y text
 
+# Files with these extensions must always have LF (Unix) line endings.
+*.sh text eol=lf
+
 # Files with these extensions end up in the built ReactOS system, so they
 # need to have CRLF line endings.
 *.bat text eol=crlf


### PR DESCRIPTION
## Purpose

Ensure that .sh script files should (or must...) always use LF (Unix) line endings.
This is what's expected by e.g. Cygwin (ba)sh on Windows. I don't know whether there exists ports of the GNU utils (and shell) that would _NOT_ support LF-only files, though...