### PR TITLE
[CONFIGURE] Display the platform/operating system on which the build configuration takes place

### DIFF
--- a/configure.cmd
+++ b/configure.cmd
@@ -70,7 +70,7 @@ if defined ROS_ARCH (
 
 REM Checkpoint
 if not defined ARCH (
-    echo Unknown build architecture
+    echo Unknown build architecture.
     goto quit
 )
 
@@ -157,6 +157,10 @@ if "!CMAKE_GENERATOR!" == "Ninja" (
     echo This script defaults to Ninja. Type "configure help" for alternative options.
 )
 
+REM Display information
+echo Configuring a new ReactOS build on:
+(for /f "delims=" %%x in ('ver') do @echo %%x) & echo.
+
 REM Create directories
 set REACTOS_OUTPUT_PATH=output-%BUILD_ENVIRONMENT%-%ARCH%
 
@@ -188,10 +192,9 @@ if "%VS_SOLUTION%" == "1" (
     goto quit
 )
 
-echo Preparing reactos...
 
 if EXIST CMakeCache.txt (
-    del CMakeCache.txt /q
+    del /q CMakeCache.txt
 )
 
 if "%BUILD_ENVIRONMENT%" == "MinGW" (

--- a/configure.sh
+++ b/configure.sh
@@ -40,13 +40,15 @@ while [ $# -gt 0 ]; do
 	shift
 done
 
+echo "Configuring a new ReactOS build on:"
+echo $(uname -srvpio); echo
+
 if [ "$REACTOS_SOURCE_DIR" = "$PWD" ]; then
 	echo "Creating directories in $REACTOS_OUTPUT_PATH"
 	mkdir -p "$REACTOS_OUTPUT_PATH"
 	cd "$REACTOS_OUTPUT_PATH"
 fi
 
-echo "Preparing reactos..."
 rm -f CMakeCache.txt host-tools/CMakeCache.txt
 
 cmake -G "$CMAKE_GENERATOR" -DENABLE_CCACHE:BOOL=0 -DCMAKE_TOOLCHAIN_FILE:FILEPATH=toolchain-gcc.cmake -DARCH:STRING=$ARCH $EXTRA_ARGS $ROS_CMAKEOPTS "$REACTOS_SOURCE_DIR"


### PR DESCRIPTION
## Purpose

Display the platform/operating system on which the build configuration takes place.
This information may be useful in some scenarii. For example, see:
https://chat.reactos.org/reactos/pl/wee3sy6ye7g4txynn14s1mo77e

## Proposed changes

- On Windows, use the `ver` command, embedded in a parsing `for` command to strip the extra leading newline emitted.
  Example output:
  ```
  Detected Visual Studio Environment VS16-i386

  Configuring a new ReactOS build on:
  Microsoft Windows [version 6.1.7601]

  Preparing reactos...
  ```

- On Unix, use `uname -srvpio`
  Example output:
  ```
  Configuring a new ReactOS build on:
  CYGWIN_NT-6.1-7601-WOW64 3.3.6-341.i686 2022-09-05 11:11 UTC unknown unknown Cygwin

  Preparing reactos...
  ```
