### PR TITLE
[PING] Update SendBuffer fill method

### DIFF
--- a/base/applications/network/ping/ping.c
+++ b/base/applications/network/ping/ping.c
@@ -427,7 +427,7 @@ Ping(void)
 
     if (RequestSize != 0)
     {
-        SendBuffer = (PUCHAR)malloc(RequestSize);
+        SendBuffer = malloc(RequestSize);
         if (SendBuffer == NULL)
         {
             ConResPrintf(StdErr, IDS_NO_RESOURCES);

--- a/base/applications/network/ping/ping.c
+++ b/base/applications/network/ping/ping.c
@@ -25,7 +25,6 @@
  * FILE:        base/applications/network/ping/ping.c
  * PURPOSE:     Network test utility
  * PROGRAMMERS: Tim Crawford <crawfxrd@gmail.com>
-                Curtis Wilson <LiquidFox1776@gmail.com>
  */
 
 #include <stdlib.h>

--- a/base/applications/network/ping/ping.c
+++ b/base/applications/network/ping/ping.c
@@ -488,7 +488,7 @@ Ping(void)
                                SendBuffer, (USHORT)RequestSize, &IpOptions,
                                ReplyBuffer, ReplySize, Timeout);
     }
-
+    // TODO: Compare ReplyBuffer data to SendBuffer.
     free(SendBuffer);
 
     if (Status == 0)

--- a/base/applications/network/ping/ping.c
+++ b/base/applications/network/ping/ping.c
@@ -437,7 +437,7 @@ Ping(void)
          * until SendBuffer is full. */
         for(int i = 0; i  < RequestSize; i++)
         {
-            ((PUCHAR)SendBuffer)[i] = (UCHAR)(ALPHABET_START + (i % ALPHABET_LENGTH));
+            ((PUCHAR)SendBuffer)[i] = (UCHAR)('a' + (i % ('w'-'a'+1)));
         }
     }
 

--- a/base/applications/network/ping/ping.c
+++ b/base/applications/network/ping/ping.c
@@ -486,7 +486,8 @@ Ping(void)
                                SendBuffer, (USHORT)RequestSize, &IpOptions,
                                ReplyBuffer, ReplySize, Timeout);
     }
-    // TODO: Compare ReplyBuffer data to SendBuffer.
+
+    /* TODO: Compare ReplyBuffer data to SendBuffer. */
     free(SendBuffer);
 
     if (Status == 0)

--- a/base/applications/network/ping/ping.c
+++ b/base/applications/network/ping/ping.c
@@ -435,7 +435,7 @@ Ping(void)
         /* Windows ping utility fills the optional data field with
          * ASCII characters from 'a' to 'w', wrapping back around
          * until SendBuffer is full. */
-        for(int i = 0; i  < RequestSize; i++)
+        for (ULONG i = 0; i < RequestSize; i++)
         {
             ((PUCHAR)SendBuffer)[i] = (UCHAR)('a' + (i % ('w'-'a'+1)));
         }

--- a/base/applications/network/ping/ping.c
+++ b/base/applications/network/ping/ping.c
@@ -47,6 +47,8 @@
 #define NDEBUG
 #include <debug.h>
 
+#define ALPHABET_START 97
+#define ALPHABET_LENGTH 23
 #define SIZEOF_ICMP_ERROR 8
 #define SIZEOF_IO_STATUS_BLOCK 8
 #define DEFAULT_TIMEOUT 1000
@@ -438,7 +440,7 @@ Ping(void)
         // until SendBuffer is full
         for(int i = 0; i  < RequestSize; i++)
         {
-            ((PUCHAR)SendBuffer)[i] = (UCHAR)('a' + (i % ('w' - 'a')));
+            ((PUCHAR)SendBuffer)[i] = (UCHAR)(ALPHABET_START + (i % ALPHABET_LENGTH));
         }
     }
 

--- a/base/applications/network/ping/ping.c
+++ b/base/applications/network/ping/ping.c
@@ -46,8 +46,6 @@
 #define NDEBUG
 #include <debug.h>
 
-#define ALPHABET_START 97
-#define ALPHABET_LENGTH 23
 #define SIZEOF_ICMP_ERROR 8
 #define SIZEOF_IO_STATUS_BLOCK 8
 #define DEFAULT_TIMEOUT 1000

--- a/base/applications/network/ping/ping.c
+++ b/base/applications/network/ping/ping.c
@@ -436,9 +436,7 @@ Ping(void)
          * ASCII characters from 'a' to 'w', wrapping back around
          * until SendBuffer is full. */
         for (ULONG i = 0; i < RequestSize; i++)
-        {
             ((PUCHAR)SendBuffer)[i] = (UCHAR)('a' + (i % ('w' - 'a' + 1)));
-        }
     }
 
     if (Family == AF_INET6)

--- a/base/applications/network/ping/ping.c
+++ b/base/applications/network/ping/ping.c
@@ -437,7 +437,7 @@ Ping(void)
          * until SendBuffer is full. */
         for (ULONG i = 0; i < RequestSize; i++)
         {
-            ((PUCHAR)SendBuffer)[i] = (UCHAR)('a' + (i % ('w'-'a'+1)));
+            ((PUCHAR)SendBuffer)[i] = (UCHAR)('a' + (i % ('w' - 'a' + 1)));
         }
     }
 

--- a/base/applications/network/ping/ping.c
+++ b/base/applications/network/ping/ping.c
@@ -420,7 +420,7 @@ void
 Ping(void)
 {
     PVOID ReplyBuffer;
-    PUCHAR SendBuffer = NULL;
+    PVOID SendBuffer = NULL;
     DWORD ReplySize = 0;
     DWORD Status;
 
@@ -438,7 +438,7 @@ Ping(void)
         // until SendBuffer is full
         for(int i = 0; i  < RequestSize; i++)
         {
-            SendBuffer[i] = (UCHAR)(97 + (i % 23));
+            ((PUCHAR)SendBuffer)[i] = (UCHAR)('a' + (i % ('w' - 'a')));
         }
     }
 
@@ -479,14 +479,14 @@ Ping(void)
         Status = Icmp6SendEcho2(hIcmpFile, NULL, NULL, NULL,
                                 &Source,
                                 (struct sockaddr_in6 *)Target->ai_addr,
-                                (PVOID)SendBuffer, (USHORT)RequestSize, &IpOptions,
+                                SendBuffer, (USHORT)RequestSize, &IpOptions,
                                 ReplyBuffer, ReplySize, Timeout);
     }
     else
     {
         Status = IcmpSendEcho2(hIcmpFile, NULL, NULL, NULL,
                                ((PSOCKADDR_IN)Target->ai_addr)->sin_addr.s_addr,
-                               (PVOID)SendBuffer, (USHORT)RequestSize, &IpOptions,
+                               SendBuffer, (USHORT)RequestSize, &IpOptions,
                                ReplyBuffer, ReplySize, Timeout);
     }
 

--- a/base/applications/network/ping/ping.c
+++ b/base/applications/network/ping/ping.c
@@ -434,9 +434,9 @@ Ping(void)
             exit(1);
         }
 
-        // Windows ping utility fills the optional data field
-        // with ASCII characters from 'a' to 'w' wrapping back around
-        // until SendBuffer is full
+        /* Windows ping utility fills the optional data field with
+         * ASCII characters from 'a' to 'w', wrapping back around
+         * until SendBuffer is full. */
         for(int i = 0; i  < RequestSize; i++)
         {
             ((PUCHAR)SendBuffer)[i] = (UCHAR)(ALPHABET_START + (i % ALPHABET_LENGTH));


### PR DESCRIPTION
## Purpose

The ping utility found in various versions of Windows fills the optional data field in the ICMP echo request structure with ASCII characters from 'a' to 'w' wrapping back around until SendBuffer is full.  The purpose of this patch is to implement that behavior. Right now the optional data is filled by using the ZeroMemory functon on the SendBuffer variable.

## Proposed changes

Change SendBuffer to PUCHAR. Add a loop that populates SendBuffer in the function static void Ping(void) as described above.