### PR TITLE
[EXPLORER][COMCTL32][SHELL32] Enable SPI_SETICONTITLELOGFONT

### DIFF
--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -2454,6 +2454,9 @@ ChangePos:
             CheckTrayWndPosition();
         }
 
+        if (m_DesktopWnd)
+            ::SendMessageW(m_DesktopWnd, uMsg, wParam, lParam);
+
         if (m_StartMenuPopup && lstrcmpiW((LPCWSTR)lParam, L"TraySettings") == 0)
         {
             HideStartMenu();

--- a/dll/cpl/desk/theme.c
+++ b/dll/cpl/desk/theme.c
@@ -373,12 +373,6 @@ ApplyScheme(IN COLOR_SCHEME *scheme, IN PTHEME_SELECTION pSelectedTheme)
                           &scheme->icMetrics,
                           SPIF_UPDATEINIFILE | SPIF_SENDCHANGE);
 
-    /* Apply icon title font */
-    SystemParametersInfoW(SPI_SETICONTITLELOGFONT,
-                          sizeof(scheme->icMetrics.lfFont),
-                          &scheme->icMetrics.lfFont,
-                          SPIF_UPDATEINIFILE | SPIF_SENDCHANGE);
-
     /* Effects, save only when needed: */
     /* FIXME: XP seems to use grayed checkboxes to reflect differences between menu and tooltips settings
      * Just keep them in sync for now.

--- a/dll/cpl/desk/theme.c
+++ b/dll/cpl/desk/theme.c
@@ -373,6 +373,12 @@ ApplyScheme(IN COLOR_SCHEME *scheme, IN PTHEME_SELECTION pSelectedTheme)
                           &scheme->icMetrics,
                           SPIF_UPDATEINIFILE | SPIF_SENDCHANGE);
 
+    /* Apply icon title font */
+    SystemParametersInfoW(SPI_SETICONTITLELOGFONT,
+                          sizeof(scheme->icMetrics.lfFont),
+                          &scheme->icMetrics.lfFont,
+                          SPIF_UPDATEINIFILE | SPIF_SENDCHANGE);
+
     /* Effects, save only when needed: */
     /* FIXME: XP seems to use grayed checkboxes to reflect differences between menu and tooltips settings
      * Just keep them in sync for now.

--- a/dll/win32/comctl32/listview.c
+++ b/dll/win32/comctl32/listview.c
@@ -12002,8 +12002,8 @@ LISTVIEW_WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
       return DefWindowProcW(hwnd, uMsg, wParam, lParam);
 
 #ifdef __REACTOS__
-  case WM_WININICHANGE: /* Same as WM_SETTINGCHANGE */
-    if (!wParam || wParam == SPI_SETICONTITLELOGFONT)
+  case WM_SETTINGCHANGE: /* Same as WM_WININICHANGE */
+    if (wParam == SPI_SETICONTITLELOGFONT)
     {
       BOOL bWasSameFont = (infoPtr->hDefaultFont == infoPtr->hFont);
       LOGFONTW logFont;
@@ -12017,6 +12017,8 @@ LISTVIEW_WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
         infoPtr->hFont = infoPtr->hDefaultFont;
 
       LISTVIEW_SaveTextMetrics(infoPtr);
+      LISTVIEW_UpdateItemSize(infoPtr);
+      LISTVIEW_UpdateScroll(infoPtr);
       LISTVIEW_InvalidateRect(infoPtr, NULL);
       return 0;
     }

--- a/dll/win32/comctl32/listview.c
+++ b/dll/win32/comctl32/listview.c
@@ -12012,6 +12012,9 @@ LISTVIEW_WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
       LOGFONTW logFont;
       SystemParametersInfoW(SPI_GETICONTITLELOGFONT, 0, &logFont, 0);
 
+      if (infoPtr->autoSpacing)
+        LISTVIEW_SetIconSpacing(infoPtr, -1, -1);
+
       if (infoPtr->hDefaultFont)
         DeleteObject(infoPtr->hDefaultFont);
       infoPtr->hDefaultFont = CreateFontIndirectW(&logFont);

--- a/dll/win32/comctl32/listview.c
+++ b/dll/win32/comctl32/listview.c
@@ -12001,7 +12001,27 @@ LISTVIEW_WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
       }
       return DefWindowProcW(hwnd, uMsg, wParam, lParam);
 
+#ifdef __REACTOS__
+  case WM_WININICHANGE: /* Same as WM_SETTINGCHANGE */
+    if (!wParam || wParam == SPI_SETICONTITLELOGFONT)
+    {
+      BOOL bWasSameFont = (infoPtr->hDefaultFont == infoPtr->hFont);
+      LOGFONTW logFont;
+      SystemParametersInfoW(SPI_GETICONTITLELOGFONT, 0, &logFont, 0);
+
+      DeleteObject(infoPtr->hDefaultFont);
+      infoPtr->hDefaultFont = CreateFontIndirectW(&logFont);
+
+      if (bWasSameFont || !infoPtr->hFont)
+        infoPtr->hFont = infoPtr->hDefaultFont;
+
+      LISTVIEW_SaveTextMetrics(infoPtr);
+      LISTVIEW_InvalidateRect(infoPtr, NULL);
+      return 0;
+    }
+#else
 /*	case WM_WININICHANGE: */
+#endif
 
   default:
     if ((uMsg >= WM_USER) && (uMsg < WM_APP) && !COMCTL32_IsReflectedMessage(uMsg))

--- a/dll/win32/comctl32/listview.c
+++ b/dll/win32/comctl32/listview.c
@@ -12009,7 +12009,8 @@ LISTVIEW_WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
       LOGFONTW logFont;
       SystemParametersInfoW(SPI_GETICONTITLELOGFONT, 0, &logFont, 0);
 
-      DeleteObject(infoPtr->hDefaultFont);
+      if (infoPtr->hDefaultFont)
+        DeleteObject(infoPtr->hDefaultFont);
       infoPtr->hDefaultFont = CreateFontIndirectW(&logFont);
 
       if (bWasSameFont || !infoPtr->hFont)

--- a/dll/win32/comctl32/listview.c
+++ b/dll/win32/comctl32/listview.c
@@ -12003,44 +12003,28 @@ LISTVIEW_WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
 #ifdef __REACTOS__
   case WM_SETTINGCHANGE: /* Same as WM_WININICHANGE */
+    if (wParam == SPI_SETICONMETRICS ||
+        wParam == SPI_SETICONTITLELOGFONT ||
+        wParam == SPI_SETNONCLIENTMETRICS ||
+        (!wParam && !lParam))
     {
-      BOOL bSetFont = FALSE;
+      BOOL bDefaultOrNullFont = (infoPtr->hDefaultFont == infoPtr->hFont || !infoPtr->hFont);
       LOGFONTW logFont;
+      SystemParametersInfoW(SPI_GETICONTITLELOGFONT, 0, &logFont, 0);
 
-      if (wParam == SPI_SETICONMETRICS || (!wParam && !lParam))
-      {
-        ICONMETRICS metrics;
-        SystemParametersInfoW(SPI_GETICONMETRICS, 0, &metrics, 0);
-        LISTVIEW_SetIconSpacing(infoPtr, metrics.iHorzSpacing, metrics.iVertSpacing);
-        logFont = metrics.lfFont;
-        bSetFont = TRUE;
-      }
+      if (infoPtr->hDefaultFont)
+        DeleteObject(infoPtr->hDefaultFont);
+      infoPtr->hDefaultFont = CreateFontIndirectW(&logFont);
 
-      if (wParam == SPI_SETICONTITLELOGFONT || (!wParam && lParam))
-      {
-        SystemParametersInfoW(SPI_GETICONTITLELOGFONT, 0, &logFont, 0);
-        bSetFont = TRUE;
-      }
+      if (bDefaultOrNullFont)
+        infoPtr->hFont = infoPtr->hDefaultFont;
 
-      if (bSetFont)
-      {
-        BOOL bDefaultOrNullFont = (infoPtr->hDefaultFont == infoPtr->hFont || !infoPtr->hFont);
-
-        if (infoPtr->hDefaultFont)
-          DeleteObject(infoPtr->hDefaultFont);
-        infoPtr->hDefaultFont = CreateFontIndirectW(&logFont);
-
-        if (bDefaultOrNullFont)
-          infoPtr->hFont = infoPtr->hDefaultFont;
-
-        LISTVIEW_SaveTextMetrics(infoPtr);
-        LISTVIEW_UpdateItemSize(infoPtr);
-        LISTVIEW_UpdateScroll(infoPtr);
-        LISTVIEW_InvalidateRect(infoPtr, NULL);
-      }
-
-      return 0;
+      LISTVIEW_SaveTextMetrics(infoPtr);
+      LISTVIEW_UpdateItemSize(infoPtr);
+      LISTVIEW_UpdateScroll(infoPtr);
+      LISTVIEW_InvalidateRect(infoPtr, NULL);
     }
+    return 0;
 #else
 /*	case WM_WININICHANGE: */
 #endif

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -3008,9 +3008,7 @@ LRESULT CDefView::OnSettingChange(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL 
     if (wParam == SPI_SETDESKWALLPAPER || wParam == 0)
         UpdateListColors();
 
-    if (wParam == SPI_SETICONTITLELOGFONT || !wParam)
-        m_ListView.SendMessage(uMsg, wParam, lParam);
-
+    m_ListView.SendMessage(uMsg, wParam, lParam);
     return S_OK;
 }
 

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -3008,6 +3008,9 @@ LRESULT CDefView::OnSettingChange(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL 
     if (wParam == SPI_SETDESKWALLPAPER || wParam == 0)
         UpdateListColors();
 
+    if (wParam == SPI_SETICONTITLELOGFONT || !wParam)
+        m_ListView.SendMessage(uMsg, wParam, lParam);
+
     return S_OK;
 }
 


### PR DESCRIPTION
## Purpose
Enable desktop icon title font setting.
JIRA issue: [CORE-13601](https://jira.reactos.org/browse/CORE-13601)

## Proposed changes

- Forward `WM_SETTINGCHANGE` message up to ListView.
- ListView accepts `WM_SETTINGCHANGE` message.
- Enable icon spacing.

## Comparison

BEFORE:
![before](https://github.com/user-attachments/assets/75d4c1cc-52e3-4915-bd75-bc0dc41d3ebe)
Desktop icon title font was not changed. Icon spacing not working.

AFTER (1):
![after1](https://github.com/user-attachments/assets/260bb027-f15c-4092-821d-c5f70a6b7bfe)
Desktop icon title font is changed.

AFTER (2):
![after3](https://github.com/user-attachments/assets/3ae63e8f-abc5-4dbe-8d2c-b978d802d31b)
Icon spacing is working.