### PR TITLE
[SDK:DELAYIMP] Fix handling of the hookable symbols for GCC

### DIFF
--- a/modules/rostests/apitests/dbghelp/pdb.c
+++ b/modules/rostests/apitests/dbghelp/pdb.c
@@ -15,8 +15,6 @@
 
 #include "wine/test.h"
 
-extern PfnDliHook __pfnDliFailureHook2;
-
 #define ok_ulonglong(expression, result) \
     do { \
         ULONG64 _value = (expression); \
@@ -218,6 +216,10 @@ FARPROC WINAPI DliFailHook(unsigned dliNotify, PDelayLoadInfo pdli)
     /* This is not the function you are looking for, continue default behavior (throw exception) */
     return NULL;
 }
+
+/* Register the failure hook using the magic name '__pfnDliFailureHook2'. */
+PfnDliHook __pfnDliFailureHook2 = DliFailHook;
+
 
 /* Maybe our dbghelp.dll is too old? */
 static BOOL supports_pdb(HANDLE hProc, DWORD64 BaseAddress)
@@ -580,9 +582,6 @@ START_TEST(pdb)
     }
 
     init_dbghelp_version();
-
-    /* Register the failure hook using the magic name '__pfnDliFailureHook2'. */
-    __pfnDliFailureHook2 = DliFailHook;
 
     if (init_sym(FALSE))
     {

--- a/modules/rostests/apitests/sdk/delayimp.cpp
+++ b/modules/rostests/apitests/sdk/delayimp.cpp
@@ -366,13 +366,12 @@ LONG ExceptionFilter(IN PEXCEPTION_POINTERS ExceptionInfo, ULONG ExceptionCode)
 }
 
 /* We register one hook the 'default' way and one manually,
-so that we can check that both fallback and registration work*/
-extern "C"
+ * so that we can check that both fallback and registration work */
+ExternC
 {
-    extern PfnDliHook __pfnDliNotifyHook2;
-    //PfnDliHook __pfnDliFailureHook2 = DliFailHook;
+    PfnDliHook __pfnDliNotifyHook2 = DliHook;
+    PfnDliHook __pfnDliFailureHook2; // = DliFailHook;
 }
-
 
 bool g_UsePointers = false;
 
@@ -401,8 +400,7 @@ unsigned g_imagehlp[] = { dliStartProcessing, dliNotePreLoadLibrary, dliFailLoad
 //#define DELAYLOAD_SUPPORTS_UNLOADING
 START_TEST(delayimp)
 {
-    __pfnDliNotifyHook2 = DliHook;
-    /* Verify that both scenario's work */
+    /* Verify that both scenarii work */
     ok(__pfnDliNotifyHook2 == DliHook, "Expected __pfnDliNotifyHook2 to be DliHook(%p), but was: %p\n",
         DliHook, __pfnDliNotifyHook2);
     ok(__pfnDliFailureHook2 == NULL, "Expected __pfnDliFailureHook2 to be NULL, but was: %p\n",

--- a/sdk/lib/delayimp/delayimp.c
+++ b/sdk/lib/delayimp/delayimp.c
@@ -15,13 +15,16 @@
 
 /**** Linker magic: provide a default (NULL) pointer, but allow the user to override it ****/
 
-/* The actual items we use */
-PfnDliHook __pfnDliNotifyHook2;
-PfnDliHook __pfnDliFailureHook2;
+#if defined(__GNUC__)
 
-#if !defined(__GNUC__)
+/* The fallback (weak) symbols we may use */
+__attribute__((weak)) PfnDliHook __pfnDliNotifyHook2  = NULL;
+__attribute__((weak)) PfnDliHook __pfnDliFailureHook2 = NULL;
+
+#else // !__GNUC__
+
 /* The fallback symbols */
-PfnDliHook __pfnDliNotifyHook2Default = NULL;
+PfnDliHook __pfnDliNotifyHook2Default  = NULL;
 PfnDliHook __pfnDliFailureHook2Default = NULL;
 
 /* Tell the linker to use the fallback symbols */
@@ -32,7 +35,8 @@ PfnDliHook __pfnDliFailureHook2Default = NULL;
 #pragma comment(linker, "/alternatename:__pfnDliNotifyHook2=__pfnDliNotifyHook2Default")
 #pragma comment(linker, "/alternatename:__pfnDliFailureHook2=__pfnDliFailureHook2Default")
 #endif
-#endif
+
+#endif // __GNUC__
 
 
 /**** Helper functions to convert from RVA to address ****/


### PR DESCRIPTION
## Purpose

Addendum to commit 91d86a9a91 (r71190) and e5904542d6 (PR #377)

JIRA issue: [CORE-10935](https://jira.reactos.org/browse/CORE-10935)

Mark `__pfnDliNotifyHook2` and `__pfnDliFailureHook2` as weak symbols that
default to NULL (equivalent to what is done for MSVC).
Otherwise, without doing this, overriding these symbols for using custom
delay-loading hooks in a program, would result in linking errors, for
example:
```
  ld.exe: sdk/lib/delayimp/cmakefiles/delayimp.dir/delayimp.c.obj:delayimp.c:
  (.bss+0x4): multiple definition of `__pfnDliNotifyHook2';
  base/setup/reactos/CMakeFiles/reactos.dir/reactos.c.obj:reactos.c:(.data+0x4): first defined here
```
We don't use `__declspec(selectany)` because it appears it would be
needed for the overriding declaration as well, and this would make the
usage non-compatible with the official MSVC delayimp library.

References:
https://stackoverflow.com/q/2290587
https://ofekshilon.com/2014/02/10/linker-weak-symbols/

## Proposed changes

Mark `__pfnDliNotifyHook2` and `__pfnDliFailureHook2` with `__attribute__((weak))` to fix the problem described above.

## TODO

- [ ] Verify that the changes build correctly with Clang(-cl and non-cl)
- [ ] Verify that the tests run OK.
