### PR TITLE
[SHELL32] Multiple drives property sheet support

### DIFF
--- a/dll/win32/shell32/dialogs/drvdefext.cpp
+++ b/dll/win32/shell32/dialogs/drvdefext.cpp
@@ -689,11 +689,39 @@ CDrvDefExt::~CDrvDefExt()
 
 }
 
+struct CDrop
+{
+    HRESULT hr;
+    STGMEDIUM stgm;
+    HDROP hDrop;
+
+    explicit CDrop(IDataObject *pDO)
+    {
+        FORMATETC format = { CF_HDROP, NULL, DVASPECT_CONTENT, -1, TYMED_HGLOBAL };
+        hDrop = SUCCEEDED(hr = pDO->GetData(&format, &stgm)) ? (HDROP)stgm.hGlobal : NULL;
+    }
+
+    ~CDrop()
+    {
+        if (hDrop)
+            ReleaseStgMedium(&stgm);
+    }
+
+    UINT GetCount()
+    {
+        return DragQueryFileW(hDrop, -1, NULL, 0);
+    }
+};
+
+static inline bool
+IsValidDrivePath(PCWSTR Path)
+{
+    return GetDriveTypeW(Path) > DRIVE_NO_ROOT_DIR;
+}
+
 HRESULT WINAPI
 CDrvDefExt::Initialize(PCIDLIST_ABSOLUTE pidlFolder, IDataObject *pDataObj, HKEY hkeyProgID)
 {
-    FORMATETC format;
-    STGMEDIUM stgm;
     HRESULT hr;
 
     TRACE("%p %p %p %p\n", this, pidlFolder, pDataObj, hkeyProgID);
@@ -701,24 +729,20 @@ CDrvDefExt::Initialize(PCIDLIST_ABSOLUTE pidlFolder, IDataObject *pDataObj, HKEY
     if (!pDataObj)
         return E_FAIL;
 
-    format.cfFormat = CF_HDROP;
-    format.ptd = NULL;
-    format.dwAspect = DVASPECT_CONTENT;
-    format.lindex = -1;
-    format.tymed = TYMED_HGLOBAL;
 
-    hr = pDataObj->GetData(&format, &stgm);
-    if (FAILED(hr))
+    CDrop drop(pDataObj);
+    if (FAILED_UNEXPECTEDLY(hr = drop.hr))
         return hr;
 
-    if (!DragQueryFileW((HDROP)stgm.hGlobal, 0, m_wszDrive, _countof(m_wszDrive)))
+    if (!DragQueryFileW(drop.hDrop, 0, m_wszDrive, _countof(m_wszDrive)))
     {
         ERR("DragQueryFileW failed\n");
-        ReleaseStgMedium(&stgm);
         return E_FAIL;
     }
 
-    ReleaseStgMedium(&stgm);
+    if (drop.GetCount() > 1)
+        m_Multiple = pDataObj;
+
     TRACE("Drive properties %ls\n", m_wszDrive);
 
     return S_OK;
@@ -745,37 +769,75 @@ CDrvDefExt::GetCommandString(UINT_PTR idCmd, UINT uType, UINT *pwReserved, LPSTR
     return E_NOTIMPL;
 }
 
-HRESULT WINAPI
-CDrvDefExt::AddPages(LPFNADDPROPSHEETPAGE pfnAddPage, LPARAM lParam)
+HRESULT
+CDrvDefExt::AddMainPage(LPFNADDPROPSHEETPAGE pfnAddPage, LPARAM lParam)
 {
-    HPROPSHEETPAGE hPage;
+    WCHAR szTitle[MAX_PATH], *pszTitle = NULL;
+    if (m_Multiple)
+    {
+        CComHeapPtr<ITEMIDLIST_ABSOLUTE> pidl(SHSimpleIDListFromPathW(m_wszDrive));
+        if (SUCCEEDED(SHGetNameAndFlagsW(pidl, SHGDN_INFOLDER, szTitle, _countof(szTitle), NULL)))
+            pszTitle = szTitle;
+    }
 
+    HPROPSHEETPAGE hPage;
     hPage = SH_CreatePropertySheetPageEx(IDD_DRIVE_PROPERTIES, GeneralPageProc, (LPARAM)this,
-                                         NULL, &PropSheetPageLifetimeCallback<CDrvDefExt>);
+                                         pszTitle, &PropSheetPageLifetimeCallback<CDrvDefExt>);
     HRESULT hr = AddPropSheetPage(hPage, pfnAddPage, lParam);
     if (FAILED_UNEXPECTEDLY(hr))
         return hr;
     else
         AddRef(); // For PropSheetPageLifetimeCallback
+    return hr;
+}
 
-    if (GetDriveTypeW(m_wszDrive) == DRIVE_FIXED)
+HRESULT WINAPI
+CDrvDefExt::AddPages(LPFNADDPROPSHEETPAGE pfnAddPage, LPARAM lParam)
+{
+    HRESULT hr = AddMainPage(pfnAddPage, lParam);
+    if (FAILED_UNEXPECTEDLY(hr))
+        return hr;
+
+    if (m_Multiple)
     {
-        hPage = SH_CreatePropertySheetPage(IDD_DRIVE_TOOLS,
-                                           ExtraPageProc,
-                                           (LPARAM)this,
-                                           NULL);
-        if (hPage)
-            pfnAddPage(hPage, lParam);
+        CDrop drop(m_Multiple);
+        UINT count = SUCCEEDED(drop.hr) ? drop.GetCount() : 0;
+        for (UINT i = 0; ++i < count;) // Skipping the first drive since it already has a page
+        {
+            CComPtr<CDrvDefExt> SheetExt;
+            if (FAILED_UNEXPECTEDLY(hr = ShellObjectCreator(SheetExt)))
+                continue;
+            if (!DragQueryFileW(drop.hDrop, i, SheetExt->m_wszDrive, _countof(SheetExt->m_wszDrive)))
+                continue;
+            if (!IsValidDrivePath(SheetExt->m_wszDrive))
+                continue;
+
+            SheetExt->m_Multiple = m_Multiple;
+            SheetExt->AddMainPage(pfnAddPage, lParam);
+        }
     }
-
-    if (GetDriveTypeW(m_wszDrive) != DRIVE_REMOTE)
+    else
     {
-        hPage = SH_CreatePropertySheetPage(IDD_DRIVE_HARDWARE,
-                                           HardwarePageProc,
-                                           (LPARAM)this,
-                                           NULL);
-        if (hPage)
-            pfnAddPage(hPage, lParam);
+        HPROPSHEETPAGE hPage;
+        if (GetDriveTypeW(m_wszDrive) == DRIVE_FIXED)
+        {
+            hPage = SH_CreatePropertySheetPage(IDD_DRIVE_TOOLS,
+                                               ExtraPageProc,
+                                               (LPARAM)this,
+                                               NULL);
+            if (hPage)
+                pfnAddPage(hPage, lParam);
+        }
+
+        if (GetDriveTypeW(m_wszDrive) != DRIVE_REMOTE)
+        {
+            hPage = SH_CreatePropertySheetPage(IDD_DRIVE_HARDWARE,
+                                               HardwarePageProc,
+                                               (LPARAM)this,
+                                               NULL);
+            if (hPage)
+                pfnAddPage(hPage, lParam);
+        }
     }
 
     return S_OK;

--- a/dll/win32/shell32/dialogs/drvdefext.h
+++ b/dll/win32/shell32/dialogs/drvdefext.h
@@ -46,7 +46,6 @@ public:
 	CDrvDefExt();
 	~CDrvDefExt();
 
-
 	// IShellExtInit
 	STDMETHOD(Initialize)(PCIDLIST_ABSOLUTE pidlFolder, IDataObject *pDataObj, HKEY hkeyProgID) override;
 

--- a/dll/win32/shell32/dialogs/drvdefext.h
+++ b/dll/win32/shell32/dialogs/drvdefext.h
@@ -38,10 +38,13 @@ private:
 
     WCHAR m_wszDrive[MAX_PATH];
     UINT m_FreeSpacePerc;
+    CComPtr<IDataObject> m_Multiple;
 
 public:
 	CDrvDefExt();
 	~CDrvDefExt();
+
+	HRESULT AddMainPage(LPFNADDPROPSHEETPAGE pfnAddPage, LPARAM lParam);
 
 	// IShellExtInit
 	STDMETHOD(Initialize)(PCIDLIST_ABSOLUTE pidlFolder, IDataObject *pDataObj, HKEY hkeyProgID) override;

--- a/dll/win32/shell32/dialogs/drvdefext.h
+++ b/dll/win32/shell32/dialogs/drvdefext.h
@@ -40,11 +40,12 @@ private:
     UINT m_FreeSpacePerc;
     CComPtr<IDataObject> m_Multiple;
 
+    HRESULT AddMainPage(LPFNADDPROPSHEETPAGE pfnAddPage, LPARAM lParam);
+
 public:
 	CDrvDefExt();
 	~CDrvDefExt();
 
-	HRESULT AddMainPage(LPFNADDPROPSHEETPAGE pfnAddPage, LPARAM lParam);
 
 	// IShellExtInit
 	STDMETHOD(Initialize)(PCIDLIST_ABSOLUTE pidlFolder, IDataObject *pDataObj, HKEY hkeyProgID) override;

--- a/dll/win32/shell32/precomp.h
+++ b/dll/win32/shell32/precomp.h
@@ -172,6 +172,8 @@ SHELL32_ShowPropertiesDialog(IDataObject *pdtobj);
 HRESULT
 SHELL32_ShowFilesystemItemPropertiesDialogAsync(IDataObject *pDO);
 HRESULT
+SHELL32_ShowFilesystemItemsPropertiesDialogAsync(HWND hOwner, IDataObject *pDO);
+HRESULT
 SHELL32_ShowShellExtensionProperties(const CLSID *pClsid, IDataObject *pDO);
 HRESULT
 SHELL_ShowItemIDListProperties(LPCITEMIDLIST pidl);
@@ -296,6 +298,7 @@ BOOL PathIsDosDevice(_In_ LPCWSTR pszName);
 HRESULT SHELL32_GetDllFromRundll32CommandLine(LPCWSTR pszCmd, LPWSTR pszOut, SIZE_T cchMax);
 HRESULT SHILAppend(_Inout_ LPITEMIDLIST pidl, _Inout_ LPITEMIDLIST *ppidl);
 
+HRESULT DataObject_GetHIDACount(IDataObject *pdo);
 PIDLIST_ABSOLUTE SHELL_CIDA_ILCloneFull(_In_ const CIDA *pCIDA, _In_ UINT Index);
 PIDLIST_ABSOLUTE SHELL_DataObject_ILCloneFullItem(_In_ IDataObject *pDO, _In_ UINT Index);
 HRESULT SHELL_CloneDataObject(_In_ IDataObject *pDO, _Out_ IDataObject **ppDO);

--- a/dll/win32/shell32/shlfolder.cpp
+++ b/dll/win32/shell32/shlfolder.cpp
@@ -509,16 +509,7 @@ SHELL32_ShowPropertiesDialog(IDataObject *pdtobj)
 {
     if (!pdtobj)
         return E_INVALIDARG;
-
-    CDataObjectHIDA cida(pdtobj);
-    if (FAILED_UNEXPECTEDLY(cida.hr()))
-        return cida.hr();
-    if (cida->cidl > 1)
-    {
-        ERR("SHMultiFileProperties is not yet implemented\n");
-        return E_FAIL;
-    }
-    return SHELL32_ShowFilesystemItemPropertiesDialogAsync(pdtobj);
+    return SHELL32_ShowFilesystemItemsPropertiesDialogAsync(NULL, pdtobj);
 }
 
 HRESULT

--- a/dll/win32/shell32/stubs.cpp
+++ b/dll/win32/shell32/stubs.cpp
@@ -84,15 +84,6 @@ SHParseDarwinIDFromCacheW(LPCWSTR lpUnknown1, LPWSTR lpUnknown2)
     return E_FAIL;
 }
 
-static HRESULT DataObject_GetHIDACount(IDataObject *pdo)
-{
-    if (!pdo)
-        return E_INVALIDARG;
-    CDataObjectHIDA cida(pdo);
-    HRESULT hr = cida.hr();
-    return SUCCEEDED(hr) ? cida->cidl : hr;
-}
-
 /*
  * Unimplemented
  */

--- a/dll/win32/shell32/utils.h
+++ b/dll/win32/shell32/utils.h
@@ -149,4 +149,4 @@ struct CCidaChildArrayHelper
     HRESULT m_hr;
     PCUIDLIST_RELATIVE_ARRAY m_array;
 };
-#endif
+#endif // __cplusplus


### PR DESCRIPTION
- Adds support for multiple drives in a single property sheet
- Fixes crash in SHELL_CloneDataObject when the HIDA contains multiple PIDLs [CORE-20025](https://jira.reactos.org/browse/CORE-20025)

![Props](https://github.com/user-attachments/assets/1ef2057d-e1af-4813-989a-e2d9b7f4e291)
