### PR TITLE
[CMAKE][NOTEPAD][SDK] Add Notepad Help

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,6 +230,11 @@ Enable this if the module uses typeid or dynamic_cast. You will probably need to
         option(PCH "Whether to use precompiled headers" ON)
     endif()
 
+    option(ENABLE_HELPOFHTML "Enable HelpOfHtml (HOH)" ON)
+    if(ENABLE_HELPOFHTML)
+      add_definitions(-DENABLE_HELPOFHTML)
+    endif()
+
     # Version Options
     add_definitions(-DWINVER=0x502
                     -D_WIN32_IE=0x600

--- a/base/applications/notepad/CMakeLists.txt
+++ b/base/applications/notepad/CMakeLists.txt
@@ -3,6 +3,10 @@ if(DBG)
     add_definitions(-D_DEBUG=1)
 endif()
 
+if(ENABLE_HELPOFHTML)
+    include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos)
+endif()
+
 list(APPEND SOURCE
     dialog.c
     main.c
@@ -18,3 +22,7 @@ add_importlibs(notepad user32 gdi32 comctl32 comdlg32 advapi32 shell32 msvcrt ke
 add_pch(notepad notepad.h SOURCE)
 add_cd_file(TARGET notepad DESTINATION reactos FOR all)
 add_cd_file(TARGET notepad DESTINATION reactos/system32 FOR all)
+if(ENABLE_HELPOFHTML)
+    add_cd_file(FILE ${CMAKE_CURRENT_SOURCE_DIR}/help/notepad_en.txt DESTINATION reactos/Help FOR bootcd)
+    add_cd_file(FILE ${CMAKE_CURRENT_SOURCE_DIR}/help/notepad_en.html DESTINATION reactos/Help FOR bootcd)
+endif()

--- a/base/applications/notepad/dialog.c
+++ b/base/applications/notepad/dialog.c
@@ -5,10 +5,13 @@
  * COPYRIGHT:  Copyright 1998,99 Marcel Baur <mbaur@g26.ethz.ch>
  *             Copyright 2002 Sylvain Petreolle <spetreolle@yahoo.fr>
  *             Copyright 2002 Andriy Palamarchuk
- *             Copyright 2023 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ *             Copyright 2025 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  */
 
 #include "notepad.h"
+#ifdef ENABLE_HELPOFHTML
+    #include "helpofhtml.h"
+#endif
 
 #include <assert.h>
 #include <commctrl.h>
@@ -16,7 +19,6 @@
 
 LRESULT CALLBACK EDIT_WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
 
-static const TCHAR helpfile[] = _T("notepad.hlp");
 static const TCHAR empty_str[] = _T("");
 static const TCHAR szDefaultExt[] = _T("txt");
 static const TCHAR txt_files[] = _T("*.txt");
@@ -953,7 +955,11 @@ VOID DIALOG_ViewStatusBar(VOID)
 
 VOID DIALOG_HelpContents(VOID)
 {
-    WinHelp(Globals.hMainWnd, helpfile, HELP_INDEX, 0);
+#ifdef ENABLE_HELPOFHTML
+    HelpOfHtml(Globals.hMainWnd, _T("notepad"), HELP_INDEX, 0);
+#else
+    WinHelp(Globals.hMainWnd, _T("notepad.hlp"), HELP_INDEX, 0);
+#endif
 }
 
 VOID DIALOG_HelpAboutNotepad(VOID)

--- a/base/applications/notepad/help/notepad_en.html
+++ b/base/applications/notepad/help/notepad_en.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Notepad Help</title>
+  <link rel="shortcut icon" id="favicon" />
+  <style>
+    body {
+      color: #000000;
+      background-color: #ddddff;
+    }
+    h1 {
+      font-size: 125%;
+    }
+    h2 {
+      font-size: 110%;
+    }
+    h3 {
+      font-size: 100%;
+    }
+    p {
+      font-size: 90%;
+    }
+    small {
+      font-size: 80%;
+    }
+    #notepad_icon {
+      vertical-align: middle;
+    }
+    #roslogo {
+      vertical-align: middle;
+    }
+  </style>
+</head>
+<body>
+
+<header>
+  <h1><img id="notepad_icon" alt="" /> Notepad Help</h1>
+
+  <hr />
+</header>
+
+<section>
+  <h2>What's Notepad?</h1>
+
+  <p>
+  Notepad, part of ReactOS, is a basic text editor for plain text (<code>.txt</code>) files. Ideal for quick note-taking or coding, it's lightweight and lacks advanced formatting like bold or italics.
+  </p>
+</section>
+
+<footer>
+  <hr />
+  <small><img id="roslogo" alt="[ReactOS Logo]" /> &copy; 2025 ReactOS Development Team</small>
+</footer>
+
+<script>
+  <!-- Embedding image data. Use this: https://dopiaza.org/goodies/data-uri-generator/ -->
+  var notepad_icon = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAFCElEQVRYw+2XXWwUVRTHf3d3Zne2326L2BBFA0IroHypQfrS0jb4gR9ABHkyEB+aaCRqNH3WBHgwaRMLGE3EoJAgiSGa0pa2GhMJVbAFoTZQWqGtbWFrS7vdnd2dudcH2OmW7rYFw5Oeh82ZO3fu+d///5xz98J/3USqF9WVuopGbTweNwB367+9KyamA+BKfNi/f7+q2Vujamo+UeGwxRsVZYTDFv/Gr66uUlXVVWrfvn0qGQAt8WH+ww+Rm5sLKJovKjIyDVA3v7tbf+njS0EpAoEAMwLIyMjg2rUBAkMBhBAEx0yEuMmg46sZfBLmIzhz5jT5+flkZ+VMnwM1NTVq+crlBAKDDA8PE+o/TOj6z/jy1gKKcOAkRu4aAMyhk3j9a1BKERk+hSfn6Zu6j7SgZz2FAqzRX3BnPomV/jz3z5lDXt5ceq72UFFRIZIyoGka/vv8rFqxCqUkSm3FEe2Wo9RUGSfGlPOrlIKEqUII+vp66e3pTS2BEILsrGw0TZshUOqxVHOEEGRkZOJ2u6fPAV3XkVJSX18/be3OFmDcysvL8Xg8SedoiQvEd19eXn5HgWZiInHtlACklOi6jlKKhoaGaXd0p0yUlpaiaRqjQz3sKM9UUrlwC/i84YaYJIGmaUgpKS0tvatAqZi40nmW2kO7uNx+mheKN1K6agstzV8ixHHlAHC5XAghUEpx4sSJGQOVlZXNOKezvYXaQ7sZuPoHZeu38fq7n5LZ9jvG0W8p6ujjoCYnJIgniVLKYWA6beN+suAdbT9Re3g3fw92U7R6MVuffRU72Ees5yq9ZgSt7hhfL4qiu8QEgLS0NAfA3VCulOLCmWaOH97F+I0BilYX8MSGzcTGehntbsKKhrhy+RtaWhvoWjgOwsWBhrGJHDAMA6UUUkoaGxtnXWKg6O/6jYu/HsWtwhSvWcqSx54hMvwno92NRCNh2ntMLg3A9ZGDeDLyONAcFFOqwDAMpJQopVi3bt2sdn321HG+++ojdBVi/dplLF74CObIZUY6G4iYEc5dCdM5KIhYHko3vYU7awEbXnwleSv2+XwO/U1NTTMG7zpXT1frMTY9V8SCh+dhDl1ipKuOYDjG2a4wF/slyp3OgpUvsW3H+/jS0mlra0vdB7xerwOguLh4Wgl+/P4z+i7U8uYHlfjz5jLQ+CEjYyat3Sbdgwr/3PlsrniHwhXFzmkqpcQwjOQA9uzZo+I9QEpJU1NTSsW7ztXTc76O7dtfQ1MRei6d54fWMbr6I2TPmc+S4pfx5z9K/7Civ7kZgJKSEqcbVlVVqZ07d07OgXgXjOdASUnJpJ1bloVpmtQd+ZgLJ49gGD721nyBEIL0LD/+/GWsL9/CAw8uwuv14vF4MAwDn8/nrGvbNpqmYVnWVAai0ajTq+M5kGi2bTMc+AufkUnJxvfI9M9D9+UgcROLxXC73Xi9XkKhkAM63tallM5mdF0nGo1OBWCapoNUSpkyB6SUWJZFLBbDsiyHsXgX1TQNXddxuVy4XC5nvfi3mqZhmuZUAOFwGI/Hg23bSbtd4n8GTdPQtElHiBNkurE4A0kBxBlI7ILJyjBZoNmelLZto+s64+PjUwGMjY2Rk5ODy+Wa+SJxq6ySAb39XTJQwWBwKoBgMEhHRwft7e337gYkBIWFhYRCoakAIpEItm1TUFBwT69hpmkmrwKAysrKO9J4Nna7pG63G9u2+d8S7R+4BzmhNdcIOwAAAABJRU5ErkJggg==";
+  var roslogo = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAALm0lEQVRYw+2Xe3DTV3bHv7+X3g9LMrb8wrZsAZawMfIDY9mAEzAEAusuu2Fbks3QITUlngSmbaZNOt3ObLO7ZZnuLkubLMlCmGRmh+wOa5JA4gfYxi/wA+z4jR+SZUu2ZFm2ZMt6/R79o4E6pJm2f/Wfnr/uvTPnns+ce8655wD/x0J8y3lqXFxcfkpKShrHcQTLsgs8z49OTU0N/E8uNRgMuSRJbqFpegNFUYLT6ZxZXl5+CMD53wKIxeJnTp8+/ecHDx4kLBbLhFgsDo+NjWl6enoyent7RX19fe3BYPD60NDQ5Ho9s9mcJZVKv2uxWMoKCgoihYWF9s2bNy9FIhHJgwcPsj/77DO8++6770cikaZvBRCLxZXV1dX/fPz4cWp4eHjeZrPFRkdH5+x2e5/JZLp/8eJFdmRkZE9tbW1FW1vb8Orq6r+xLMtpNJqTVqvVUlVV1ZyTk9NcU1NDDw8P78jIyMg3mUxJ6enpjMlk0n/00UfcpUuX3ohEIg3fAKBp2lpaWvqP165dk6hUqr8iCMJNkqREEISNIyMjBQ0NDUV3794dCDPMr7eVPLd51b98rHtwxEXTosWibebIvt3Frb/+8VsyhUJRY7Va9fv27evKycnpJQjCwfN8OBaL6dfW1s4fO3Ys3NHR8SOWZTsAgH4M8NJLL32fIAhWr9c3EQTRtc4xYwAaTr55Lt+vyzuz5PN96WhsTWY5DhRFQiwm0d4/igfj06zaaO3KzzfdKt+W+/cWy1bfU687zXFc86ZNmwozMzNfuHr1agcAkACgVCp15eXl6W63u8fr9ZJPx8V3X//pz5MMm7vyc00vx6lkyQLPIhJaRWg1gEg4BDYWxVpwjV7wLZe2dA/80+Xbba2/+v0XpU/f4/V6CY/H011eXp6hUqm0TwCkUilNURSlVCrH+vr6Eh8rmHa/rH/25D90P3+48q8rdxcwxqwM6DRq0CQBgePARqOAwIOhKYhFNEQMjUgkgnGbw2Sb8TR/3D5wej3Aw4cP9SqVaoymaZLjOPoJgMfjcU9PT5MvvvjiVHt7e7LP59uYWlKpZbSKO0nJSYX+QAhTM17Mzc0BIEBRFBgRA6lUAqlEDJIkIBaJkZWeguyMVIgYBmNTDmZiynGxcdD+KgC4XK70jo6OpOPHj0/Z7XYyGAx6ngAAQH9/v+PQoUPxLS0tows+X4U2IetDpUqV43a7ca+rG413WvHgYT9mnU6EI1GQFA1QNMLRGBQyGQxpemQkJ2KzIQ2p+ngwNA2bw0nMujy//KRzsIzn+T0tLS0je/fuTejv73c8tks9XvA8H7dt27bi+vr6Gw8ezf6YlarLotEIEY5EsLKyAu/CAgIBP0KhEHie/yqHCJAkCZbnEWU5JOs3ICFei0AgiHiNCmqVEpwAMiFBV9746fW40eHhD4xGY+WVK1e6FhcXB77mgVgs1nDz5s2tH338sXfWPqHXqmSEAACCAIHnwdAElDIJ4jUqJOjU0MYpoZDLIRKLIYAAy3JYWQlCo1Yhy7AReeZNyDJsBACE1taMLS3NxK1btzw3b940x2Kxxm94YGlpKRiLxdL9nOyF+eWVEikioGRqSEQ0NEoZ4tUKJGpVSNCooFUroVLIIZdJIRKJQItESEtKxK6dRUhPS4ZWp4VcqYRA0ABB4VFPG0QKlSdJq6bfeeedmaGhobon9Wd9lPr9/g9GB7pbCnbuxmBbHbbkZiJG0FBKxVBIGEjFItAUCY7jsBYKwx8MwRdYQyAUhVQixuy8F1FSAn2iFioZgzSZCAh68WBuBiV7j1h/8/7l8Orq6on1Nr8GMDY25tqw0WgzRlazcwqtmBnswbOHqiCRSiBhaEjEItAkAfYxwEoQ/tU1hGM8BIqGSCwBJwBKCY0sjRSIhfH7uk/wXNX34JqZoceGB9tHR0fn1tuk1m927dq1XZG17URgdnxDUYkVJAEsOm2wWsug06ih06igUSuhVMghl0ohlUogk8mgViuhi9dBr09Eul4Dg04OJUPiw6tXkZeXB0N2Nj68/D4SktOW1QrpgsPhsH0DwGQyaVM3pv8E2sx0pVKhCXtncKjqKJwOG4J+HwoLCqBSyKGQSSGTSiCRSiCTSv/DuFaDhHgt0jaokKaWQc5QuHHjBliWxXe+cwTv/eYSBIkKpbv3/GHROX2EIIg6j8cT/hrAli1bavbuP7DkWmG1yalpGcKaH0QsiBdeOIbWpjsAxyJny2aIGQYMw0DE0KAZGjRFAQK+SkUBMQD3Wu9ieHQUf/bDl1FbewOjthls2JiFSJT9kXW7mRoYGNjmcDj+8y8oLCxMy8/P352o01wTxVY9NEFgu/UZTIxPYOTLh6h59TR6urvQ2d4OmqYgYiiIGBoimgZJADzPIRKJIhAM4m5zC241NiNvz0HU3W5Bc/t9aFIMIEmS7Wn4Y2JVVdXv8vLy9hQXF6c+AWAY5tiRI0fuXL16NZFhg1qGIgGCRNUPXsTt23cwPj6O1157DS0tzWhuagJJEKAoEiKGhkQkAk1ToCkCgz330NRQh5Qt+Rjue4Cbn34CXboRLM+BYeguo8FQcfTo0aTDhw83URR17AnA1q1bd5WUlNRLJJIfFuVtaWZIbikai0Esk+NkdTVqa2sxOTmJM2fOoLOzEzdu3ADPC+B5AdEYC57l0NHUiM72NmRvL0Fw2YvutmYkbcoFSdFgaAocG/3tiRMnbhEE8bLVaq0zm827AYDMycnZUVRUtFxdXS3Oy8vTjY8MNUjIaHM4FMKSfxUylQZ/efo0amtrMTg4iDNnz8Jut+ODK5cRjUYhQED73WZM2uwoeuYgwit+DD7shda4HSKxFBRFgiGJyZ+crb6cm5v7aXFxcfypU6dEhYWFyyaTqZgkCMJktVof2Wy2Pfv377/b2dk5xQd89YitLni8i5j3rUCi1ODUqzWob2jA7cZGvPIX1ZDK5Ljwy1/A7fYgKdMIa+VhBNyzeDQ0gARTEZRKJSRiGmIRzQukcOpxsO/bt6/VZrPtKS0tHQdgIhUKhc5gMPiNRuN2i8Vyv7e31ztts/WS4cBnQb8v7HDNY3bRD56R4uSpVzE0OobfXr6Mst0VsOzYiSvvX4LLYQfH8wizHAorKpGoloPkIuB5XgBBvHX+jdee1P78/Pz7WVlZ241G47JSqdSRwWAw6PV6E4xGYzzHcU4AqK+vH3fabZ+wK4v1S15PaMrhhNPjg0DR2H/oCIKhMC5e+BWkciX2PPc8urvuofXzPyJRrwcJHgTPIhaL8cFQ5K3zb9T87KnGyGk0GuO9Xm9CIBBYo6LRqMpsNj+fkJAgz8zMvH7u3LmA3+8PBwIBX1JC/LJKLiE4kMkCz0k7mm8TDXWfo2CnFTKlGp9e/wNisRhSsjfDvxJEd2szKC6GOK1mTadRnTn3Rs0vnm7Lzp49qwwEAt+fnJxUXrt27RbxVQn+6dtvv/2nO3bs+DnHcV8A4F0u1wa32108NDS078uBAePE5FRg09Z8XVF5RUZo2Ut3d90Ho9RgamwEFM/CkLNVCPHkrG2w918DbqekoqJiR2Vl5dTOnTu7BEEYJklyEQBJUdSBe/fu/c2bb775u7a2tr973JbrMjIyfvb6668/m5iYOLW0tBSdnp4O9/b2jns8nj6LxTJ34MCBork597P3e7pVk4/G76abct26tCxiwbMQXJiecC45pxItFsuRo0ePOg8cOPDF9evXJ8+fP2/WarUFFovFmJmZKVGr1SK32224cOFCo81m+1sAvvWDiS47O/vsK6+8snX//v2zGRkZToIgxP39/fqOjo60tra2ufHx8c/n5uaaAoGA79vGMqPR+Cdms/lQWVlZUklJyUxubu68IAgRu92eUldXl/ree+8NTkxM/AsA3385mkkkkrLk5OSspKSkuPn5+WAkEpkhCGJgZmbG9b8ZOlNTU1MA5IrF4lS9Xi+fm5tbdrlcE+FwuB3/L+vk3wFhFhCdjY9q3wAAAABJRU5ErkJggg==";
+  document.getElementById("notepad_icon").src = notepad_icon;
+  document.getElementById("favicon").href = notepad_icon;
+  document.getElementById("roslogo").src = roslogo;
+</script>
+</body></html>

--- a/base/applications/notepad/help/notepad_en.txt
+++ b/base/applications/notepad/help/notepad_en.txt
@@ -1,0 +1,8 @@
+﻿# Notepad Help
+
+## What's Notepad?
+
+Notepad, part of ReactOS, is a basic text editor for plain text (.txt) files. Ideal for quick note-taking or coding, it's lightweight and lacks advanced formatting like bold or italics.
+
+---
+© 2025 ReactOS Development Team

--- a/base/applications/notepad/main.c
+++ b/base/applications/notepad/main.c
@@ -344,8 +344,10 @@ NOTEPAD_WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 
         DIALOG_FileNew(); /* Initialize file info */
 
+#ifndef ENABLE_HELPOFHTML
         // For now, the "Help" dialog is disabled due to the lack of HTML Help support
         EnableMenuItem(Globals.hMenu, CMD_HELP_CONTENTS, MF_BYCOMMAND | MF_GRAYED);
+#endif
         break;
 
     case WM_COMMAND:

--- a/sdk/include/reactos/helpofhtml.h
+++ b/sdk/include/reactos/helpofhtml.h
@@ -1,0 +1,157 @@
+/*
+ * PROJECT:     ReactOS HelpOfHtml (HOH)
+ * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
+ * PURPOSE:     ReactOS-specific help system
+ * COPYRIGHT:   Copyright (c) 2025 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
+ */
+
+#pragma once
+
+#ifdef ENABLE_HELPOFHTML
+    #include <winreg.h>
+    #include <string.h>
+    #include <tchar.h>
+    #include <shellapi.h>
+    #include <strsafe.h>
+
+    // Does registry key exist?
+    static inline BOOL
+    HOH_IsRegKeyAvailable(LPCWSTR lpSubKey)
+    {
+        HKEY hKey;
+        if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, lpSubKey, 0, KEY_READ, &hKey) == ERROR_SUCCESS)
+        {
+            RegCloseKey(hKey);
+            return TRUE;
+        }
+        return FALSE;
+    }
+
+    static inline BOOL
+    HOH_IsFirefoxAvailable(void)
+    {
+        return HOH_IsRegKeyAvailable(L"SOFTWARE\\Mozilla\\Mozilla Firefox") ||
+               HOH_IsRegKeyAvailable(L"SOFTWARE\\Wow6432Node\\Mozilla\\Mozilla Firefox");
+    }
+
+    static inline BOOL
+    HOH_IsChromeAvailable(void)
+    {
+        return HOH_IsRegKeyAvailable(L"SOFTWARE\\Google\\Chrome") ||
+               HOH_IsRegKeyAvailable(L"SOFTWARE\\Wow6432Node\\Google\\Chrome");
+    }
+
+    static inline BOOL
+    HOH_IsWineGeckoAvailable(void)
+    {
+        return HOH_IsRegKeyAvailable(L"SOFTWARE\\Wine\\MSHTML");
+    }
+
+    typedef struct tagHOH_SUFFIX_AND_LANG
+    {
+        LPCTSTR suffix;
+        LANGID wLangId;
+    } HOH_SUFFIX_AND_LANG, *PHOH_SUFFIX_AND_LANG;
+
+    // Add language suffix
+    static inline void
+    HOH_AddLangSuffix(LPTSTR pszPath, SIZE_T cchPathMax, LANGID wLangId)
+    {
+        static const HOH_SUFFIX_AND_LANG pairs[] =
+        {
+            // FIXME: Add more languages
+            { TEXT("_de"), MAKELANGID(LANG_GERMAN,   SUBLANG_NEUTRAL) },
+            { TEXT("_en"), MAKELANGID(LANG_ENGLISH,  SUBLANG_ENGLISH_US) },
+            { TEXT("_fr"), MAKELANGID(LANG_FRENCH,   SUBLANG_NEUTRAL) },
+            { TEXT("_it"), MAKELANGID(LANG_ITALIAN,  SUBLANG_NEUTRAL) },
+            { TEXT("_ja"), MAKELANGID(LANG_JAPANESE, SUBLANG_DEFAULT) },
+            { TEXT("_zh"), MAKELANGID(LANG_CHINESE,  SUBLANG_CHINESE_SIMPLIFIED) },
+        };
+        const size_t count = _countof(pairs);
+
+        // 1st try: Best match
+        size_t iPair;
+        for (iPair = 0; iPair < count; ++iPair)
+        {
+            if (pairs[iPair].wLangId == wLangId)
+            {
+                StringCchCat(pszPath, cchPathMax, pairs[iPair].suffix);
+                return;
+            }
+        }
+
+        // 2nd try: PRIMARYLANGID match
+        for (iPair = 0; iPair < count; ++iPair)
+        {
+            if (PRIMARYLANGID(pairs[iPair].wLangId) == PRIMARYLANGID(wLangId))
+            {
+                StringCchCat(pszPath, cchPathMax, pairs[iPair].suffix);
+                return;
+            }
+        }
+
+        // 3rd try: default is English
+        StringCchCat(pszPath, cchPathMax, TEXT("_en"));
+    }
+
+    static inline BOOL
+    HelpOfHtml(
+        HWND hWndMain,
+        LPCTSTR lpszHelp,
+        UINT uCommand,
+        DWORD_PTR dwData)
+    {
+        UNREFERENCED_PARAMETER(uCommand);
+        UNREFERENCED_PARAMETER(dwData);
+
+        // Build help file pathname
+        TCHAR szPath[MAX_PATH];
+        GetWindowsDirectory(szPath, _countof(szPath));
+        StringCchCat(szPath, _countof(szPath), _T("\\Help\\"));
+        StringCchCat(szPath, _countof(szPath), lpszHelp);
+
+        // Delete .extension
+        LPTSTR pch = _tcsrchr(szPath, _T('\\'));
+        if (pch)
+            pch = _tcsrchr(pch, _T('.'));
+        if (pch)
+            *pch = 0;
+        else
+            pch = szPath + _tcslen(szPath);
+
+        LANGID wLangId = GetUserDefaultLangID();
+        HOH_AddLangSuffix(szPath, _countof(szPath), wLangId);
+
+        INT iTry;
+        for (iTry = 0; iTry < 2; ++iTry)
+        {
+            // Add .html if the browser is available; otherwise .txt
+            if (HOH_IsFirefoxAvailable() ||
+                HOH_IsChromeAvailable() ||
+                HOH_IsWineGeckoAvailable())
+            {
+                StringCchCat(szPath, _countof(szPath), _T(".html"));
+            }
+            else
+            {
+                StringCchCat(szPath, _countof(szPath), _T(".txt"));
+            }
+
+            if (GetFileAttributes(szPath) != INVALID_FILE_ATTRIBUTES)
+                break; // File found
+
+            // English is default
+            *pch = 0;
+            StringCchCat(szPath, _countof(szPath), L"_en");
+        }
+
+        // Open the file
+        SHELLEXECUTEINFO sei = { sizeof(sei) };
+        sei.hwnd = hWndMain;
+        sei.lpFile = szPath;
+        sei.nShow = SW_SHOWNORMAL;
+        return ShellExecuteEx(&sei);
+    }
+#else
+    #define HelpOfHtml(hWndMain, lpszHelp, uCommand, dwData) /* empty */
+#endif


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-7285](https://jira.reactos.org/browse/CORE-7285)

## Proposed changes

- Add `ENABLE_HELPOFHTML` cmake option.
- Modify `base/applications/notepad/CMakeLists.txt`.
- Add `sdk/include/reactos/helpofhtml.h`.
- Add help documents to `notepad`.

## Screenshots

![after](https://github.com/user-attachments/assets/f6b07e15-e226-4cc9-a590-e5073e7162f0)