### PR TITLE
[RAPPS] Must apply settings changes when a new download folder is created

### DIFF
--- a/base/applications/rapps/geninst.cpp
+++ b/base/applications/rapps/geninst.cpp
@@ -173,14 +173,10 @@ struct InstallInfo : CommonInfo
     }
 };
 
-static UINT
+static inline UINT
 ErrorBox(UINT Error = GetLastError())
 {
-    if (!Error)
-        Error = ERROR_INTERNAL_ERROR;
-    ErrorBox(g_pInfo->GetGuiOwner(), Error);
-    g_pInfo->Error = Error;
-    return Error;
+    return g_pInfo->Error = ErrorBox(g_pInfo->GetGuiOwner(), Error);
 }
 
 static LPCWSTR

--- a/base/applications/rapps/geninst.cpp
+++ b/base/applications/rapps/geninst.cpp
@@ -178,10 +178,7 @@ ErrorBox(UINT Error = GetLastError())
 {
     if (!Error)
         Error = ERROR_INTERNAL_ERROR;
-    WCHAR buf[400];
-    UINT fmf = FORMAT_MESSAGE_IGNORE_INSERTS | FORMAT_MESSAGE_FROM_SYSTEM;
-    FormatMessageW(fmf, NULL, Error, 0, buf, _countof(buf), NULL);
-    MessageBoxW(g_pInfo->GetGuiOwner(), buf, 0, MB_OK | MB_ICONSTOP);
+    ErrorBox(g_pInfo->GetGuiOwner(), Error);
     g_pInfo->Error = Error;
     return Error;
 }

--- a/base/applications/rapps/include/misc.h
+++ b/base/applications/rapps/include/misc.h
@@ -26,6 +26,9 @@ ErrorFromHResult(HRESULT hr)
         return hr >= 0 ? ERROR_SUCCESS : hr;
 }
 
+UINT
+ErrorBox(HWND hOwner, UINT Error = GetLastError());
+
 VOID
 CopyTextToClipboard(LPCWSTR lpszText);
 VOID

--- a/base/applications/rapps/misc.cpp
+++ b/base/applications/rapps/misc.cpp
@@ -16,7 +16,7 @@ UINT
 ErrorBox(HWND hOwner, UINT Error)
 {
     if (!Error)
-        Error = ERROR_INTERNAL_ERROR;
+        Error = ERROR_INTERNAL_ERROR; // Note: geninst.cpp depends on this
     WCHAR buf[400];
     UINT fmf = FORMAT_MESSAGE_IGNORE_INSERTS | FORMAT_MESSAGE_FROM_SYSTEM;
     FormatMessageW(fmf, NULL, Error, 0, buf, _countof(buf), NULL);

--- a/base/applications/rapps/misc.cpp
+++ b/base/applications/rapps/misc.cpp
@@ -12,6 +12,18 @@
 
 static HANDLE hLog = NULL;
 
+UINT
+ErrorBox(HWND hOwner, UINT Error)
+{
+    if (!Error)
+        Error = ERROR_INTERNAL_ERROR;
+    WCHAR buf[400];
+    UINT fmf = FORMAT_MESSAGE_IGNORE_INSERTS | FORMAT_MESSAGE_FROM_SYSTEM;
+    FormatMessageW(fmf, NULL, Error, 0, buf, _countof(buf), NULL);
+    MessageBoxW(hOwner, buf, 0, MB_OK | MB_ICONSTOP);
+    return Error;
+}
+
 VOID
 CopyTextToClipboard(LPCWSTR lpszText)
 {


### PR DESCRIPTION
If the download directory does not exist (Run RAPPS and go to settings without ever downloading anything), creating the directory exits the dialog prematurely without applying the settings.
