### PR TITLE
[COMCTL32] ReactOS second stage listbox selection fix

### DIFF
--- a/dll/win32/comctl32/listbox.c
+++ b/dll/win32/comctl32/listbox.c
@@ -204,10 +204,6 @@ static void set_item_height( LB_DESCR *descr, UINT index, UINT height )
 
 static BOOL is_item_selected( const LB_DESCR *descr, UINT index )
 {
-#ifdef __REACTOS__
-    if (descr->style & LBS_NOSEL)
-        return FALSE;
-#endif
     if (!(descr->style & (LBS_MULTIPLESEL | LBS_EXTENDEDSEL)))
         return index == descr->selected_item;
     if (descr->style & LBS_NODATA)
@@ -615,6 +611,9 @@ static void LISTBOX_PaintItem( LB_DESCR *descr, HDC hdc, const RECT *rect,
     if (index < descr->nb_items)
     {
         item_str = get_item_string(descr, index);
+#ifdef __REACTOS__
+        if (!(descr->style & LBS_NOSEL))
+#endif
         selected = is_item_selected(descr, index);
     }
 

--- a/dll/win32/comctl32/listbox.c
+++ b/dll/win32/comctl32/listbox.c
@@ -204,6 +204,10 @@ static void set_item_height( LB_DESCR *descr, UINT index, UINT height )
 
 static BOOL is_item_selected( const LB_DESCR *descr, UINT index )
 {
+#ifdef __REACTOS__
+    if (descr->style & LBS_NOSEL)
+        return FALSE;
+#endif
     if (!(descr->style & (LBS_MULTIPLESEL | LBS_EXTENDEDSEL)))
         return index == descr->selected_item;
     if (descr->style & LBS_NODATA)


### PR DESCRIPTION
@I_Kill_Bugs patch

## Purpose

_Fix ReactOS second stage listbox selection highlight failure._

JIRA issue: [CORE-19814](https://jira.reactos.org/browse/CORE-19814)

## Proposed changes

_Check for LBS_NOSEL flag for 'descr->style' in 'LISTBOX_PaintItem' and if FALSE, only then set 'selected'._