### PR TITLE
[SHDOCVW][SHELL32] Rename RegItem to empty name must reset the name to the default

### DIFF
--- a/dll/win32/shdocvw/CExplorerBand.cpp
+++ b/dll/win32/shdocvw/CExplorerBand.cpp
@@ -235,7 +235,7 @@ CExplorerBand::_NavigateToPIDL(
     HTREEITEM hParent = NULL, tmp;
     while (TRUE)
     {
-        CItemData *pItemData = GetItemData(hItem);
+        CItemData *pItemData = _GetItemData(hItem);
         if (!pItemData)
         {
             ERR("Something has gone wrong, no data associated to node\n");

--- a/dll/win32/shdocvw/CFavBand.cpp
+++ b/dll/win32/shdocvw/CFavBand.cpp
@@ -146,7 +146,7 @@ STDMETHODIMP CFavBand::OnSelectionChanged(_In_ PCIDLIST_ABSOLUTE pidl)
     if (attrs & SFGAO_FOLDER)
     {
         HTREEITEM hItem = TreeView_GetSelection(m_hwndTreeView);
-        CItemData *pItemData = GetItemData(hItem);
+        CItemData *pItemData = _GetItemData(hItem);
         if (pItemData && !pItemData->expanded)
         {
             _InsertSubitems(hItem, pItemData->absolutePidl);

--- a/dll/win32/shdocvw/CNSCBand.cpp
+++ b/dll/win32/shdocvw/CNSCBand.cpp
@@ -886,8 +886,8 @@ LRESULT CNSCBand::OnEndLabelEdit(_In_ LPNMTVDISPINFO dispInfo)
         CComHeapPtr<ITEMIDLIST> pidlNewAbs(ILCombine(pidlParent, pidlNew));
         if (RenamedCurrent)
         {
-            // Get the new name and icon of item from the folder. RegItems can be renamed to
-            // their default name by the folder (which is not the string in NMTVDISPINFO).
+            // Get the new item name from the folder because RegItems can be renamed to their
+            // default name by the folder (which is not the string we have in NMTVDISPINFO).
             WCHAR wszDisplayName[MAX_PATH];
             if (SUCCEEDED(_GetNameOfItem(pParent, pidlNew, wszDisplayName)))
             {
@@ -1324,7 +1324,7 @@ STDMETHODIMP CNSCBand::TranslateAcceleratorIO(LPMSG lpMsg)
         }
         else
         {
-            MessageBeep(0);
+            MessageBeep(0xFFFFFFFF);
         }
     }
 

--- a/dll/win32/shdocvw/CNSCBand.cpp
+++ b/dll/win32/shdocvw/CNSCBand.cpp
@@ -818,7 +818,7 @@ LRESULT CNSCBand::OnBeginLabelEdit(_In_ LPNMTVDISPINFO dispInfo)
     return TRUE;
 }
 
-HRESULT CNSCBand::_UpdateBrowser(LPCITEMIDLIST pidlGoto, BOOL EatSelfNavigation)
+HRESULT CNSCBand::_UpdateBrowser(LPCITEMIDLIST pidlGoto, BOOL IgnoreSelfNavigation)
 {
     CComPtr<IShellBrowser> pBrowserService;
     HRESULT hr = IUnknown_QueryService(m_pSite, SID_STopLevelBrowser,
@@ -828,7 +828,7 @@ HRESULT CNSCBand::_UpdateBrowser(LPCITEMIDLIST pidlGoto, BOOL EatSelfNavigation)
 
     if (_IsCurrentLocation(pidlGoto) == S_OK) // Don't add duplicates to the travel log
     {
-        if (EatSelfNavigation)
+        if (IgnoreSelfNavigation)
             return S_FALSE;
 
         CComPtr<IShellView> psv;

--- a/dll/win32/shdocvw/CNSCBand.cpp
+++ b/dll/win32/shdocvw/CNSCBand.cpp
@@ -99,7 +99,7 @@ VOID CNSCBand::OnFinalMessage(HWND)
 
 // *** helper methods ***
 
-CNSCBand::CItemData* CNSCBand::GetItemData(_In_ HTREEITEM hItem)
+CNSCBand::CItemData* CNSCBand::_GetItemData(_In_ HTREEITEM hItem)
 {
     if (hItem == TVI_ROOT)
         return NULL;
@@ -109,6 +109,39 @@ CNSCBand::CItemData* CNSCBand::GetItemData(_In_ HTREEITEM hItem)
         return NULL;
 
     return reinterpret_cast<CItemData*>(tvItem.lParam);
+}
+
+CNSCBand::CItemData* CNSCBand::_GetItemData(_In_ UINT ItemSpec)
+{
+    HTREEITEM hItem = m_hwndTreeView.GetNextItem(NULL, ItemSpec);
+    return hItem ? _GetItemData(hItem) : NULL;
+}
+
+SFGAOF CNSCBand::_GetAttributesOfItem(_In_ CItemData *pData, _In_ SFGAOF Query)
+{
+    if (!pData)
+        return 0;
+    CComPtr<IShellFolder> pFolder;
+    LPCITEMIDLIST pidlChild;
+    HRESULT hr = SHBindToParent(pData->absolutePidl, IID_PPV_ARG(IShellFolder, &pFolder), &pidlChild);
+    if (FAILED_UNEXPECTEDLY(hr))
+        return 0;
+    SFGAOF Attributes = Query;
+    if (FAILED_UNEXPECTEDLY(hr = pFolder->GetAttributesOf(1, &pidlChild, &Attributes)))
+        return 0;
+    return Attributes & Query;
+}
+
+HRESULT CNSCBand::_GetNameOfItem(IShellFolder *pSF, PCUITEMID_CHILD pidl, PWSTR Name)
+{
+    STRRET strret;
+    HRESULT hr = pSF->GetDisplayNameOf(pidl, SHGDN_INFOLDER, &strret);
+    if (FAILED_UNEXPECTEDLY(hr))
+        return hr;
+    hr = StrRetToBufW(&strret, pidl, Name, MAX_PATH);
+    if (FAILED_UNEXPECTEDLY(hr))
+        return hr;
+    return hr;
 }
 
 static HRESULT
@@ -260,7 +293,7 @@ CNSCBand::_IsTreeItemInEnum(
     _In_ HTREEITEM hItem,
     _In_ IEnumIDList *pEnum)
 {
-    CItemData* pItemData = GetItemData(hItem);
+    CItemData* pItemData = _GetItemData(hItem);
     if (!pItemData)
         return FALSE;
 
@@ -286,7 +319,7 @@ CNSCBand::_TreeItemHasThisChild(
     for (hItem = TreeView_GetChild(m_hwndTreeView, hItem); hItem;
          hItem = TreeView_GetNextSibling(m_hwndTreeView, hItem))
     {
-        CItemData* pItemData = GetItemData(hItem);
+        CItemData* pItemData = _GetItemData(hItem);
         if (ILIsEqual(pItemData->relativePidl, pidlChild))
             return TRUE;
     }
@@ -316,7 +349,7 @@ CNSCBand::_GetItemEnum(
     }
     else
     {
-        CItemData* pItemData = GetItemData(hItem);
+        CItemData* pItemData = _GetItemData(hItem);
         if (!pItemData && hItem == TVI_ROOT && !_WantsRootItem())
             hr = psfDesktop->BindToObject(m_pidlRoot, NULL, IID_PPV_ARG(IShellFolder, ppFolder));
         else
@@ -358,7 +391,7 @@ void CNSCBand::_RefreshRecurse(_In_ HTREEITEM hTarget)
     pEnum = NULL;
     hrEnum = _GetItemEnum(pEnum, hTarget);
 
-    CItemData* pItemData = ((hTarget == TVI_ROOT) ? NULL : GetItemData(hTarget));
+    CItemData* pItemData = ((hTarget == TVI_ROOT) ? NULL : _GetItemData(hTarget));
 
     // Insert new items and update items
     if (SUCCEEDED(hrEnum))
@@ -461,19 +494,12 @@ CNSCBand::_InsertItem(
     if (FAILED_UNEXPECTEDLY(hr))
         return NULL;
 
-    /* Get the name of the node */
     WCHAR wszDisplayName[MAX_PATH];
-    STRRET strret;
-    hr = psfParent->GetDisplayNameOf(pEltRelative, SHGDN_INFOLDER, &strret);
-    if (FAILED_UNEXPECTEDLY(hr))
+    if (FAILED_UNEXPECTEDLY(hr = _GetNameOfItem(psfParent, pEltRelative, wszDisplayName)))
         return NULL;
 
-    hr = StrRetToBufW(&strret, pEltRelative, wszDisplayName, MAX_PATH);
-    if (FAILED_UNEXPECTEDLY(hr))
-        return NULL;
-
-    /* Get the icon of the node */
-    INT iIcon = SHMapPIDLToSystemImageListIndex(psfParent, pEltRelative, NULL);
+    INT iSelIcon = -1;
+    INT iIcon = SHMapPIDLToSystemImageListIndex(psfParent, pEltRelative, &iSelIcon);
 
     CItemData* pChildInfo = new CItemData;
     if (!pChildInfo)
@@ -489,7 +515,8 @@ CNSCBand::_InsertItem(
     tvInsert.item.mask = TVIF_PARAM | TVIF_TEXT | TVIF_IMAGE | TVIF_SELECTEDIMAGE | TVIF_CHILDREN;
     tvInsert.item.cchTextMax = MAX_PATH;
     tvInsert.item.pszText = wszDisplayName;
-    tvInsert.item.iImage = tvInsert.item.iSelectedImage = iIcon;
+    tvInsert.item.iImage = iIcon;
+    tvInsert.item.iSelectedImage = iSelIcon >= 0 ? iSelIcon : iIcon;
     tvInsert.item.lParam = (LPARAM)pChildInfo;
 
     if (!(attrs & SFGAO_STREAM) && (attrs & SFGAO_HASSUBFOLDER))
@@ -684,7 +711,7 @@ BOOL CNSCBand::OnTreeItemExpanding(_In_ LPNMTREEVIEW pnmtv)
     if (pnmtv->action == TVE_EXPAND)
     {
         // Grab our directory PIDL
-        pItemData = GetItemData(pnmtv->itemNew.hItem);
+        pItemData = _GetItemData(pnmtv->itemNew.hItem);
         // We have it, let's try
         if (pItemData && !pItemData->expanded)
         {
@@ -713,7 +740,7 @@ BOOL CNSCBand::OnTreeItemDeleted(_In_ LPNMTREEVIEW pnmtv)
         TreeView_SelectItem(m_hwndTreeView, hParent);
 
     /* Destroy memory associated to our node */
-    CItemData* pItemData = GetItemData(hItem);
+    CItemData* pItemData = _GetItemData(hItem);
     if (!pItemData)
         return FALSE;
 
@@ -727,14 +754,14 @@ void CNSCBand::_OnSelectionChanged(_In_ LPNMTREEVIEW pnmtv)
     HTREEITEM hItem = pnmtv->itemNew.hItem;
     if (!hItem)
         return;
-    CItemData* pItemData = GetItemData(hItem);
+    CItemData* pItemData = _GetItemData(hItem);
     if (pItemData)
         OnSelectionChanged(pItemData->absolutePidl);
 }
 
 void CNSCBand::OnTreeItemDragging(_In_ LPNMTREEVIEW pnmtv, _In_ BOOL isRightClick)
 {
-    CItemData* pItemData = GetItemData(pnmtv->itemNew.hItem);
+    CItemData* pItemData = _GetItemData(pnmtv->itemNew.hItem);
     if (!pItemData)
         return;
 
@@ -772,7 +799,7 @@ LRESULT CNSCBand::OnBeginLabelEdit(_In_ LPNMTVDISPINFO dispInfo)
     LPCITEMIDLIST pChild;
     HRESULT hr;
 
-    CItemData *info = GetItemData(dispInfo->item.hItem);
+    CItemData *info = _GetItemData(dispInfo->item.hItem);
     if (!info)
         return FALSE;
 
@@ -791,7 +818,7 @@ LRESULT CNSCBand::OnBeginLabelEdit(_In_ LPNMTVDISPINFO dispInfo)
     return TRUE;
 }
 
-HRESULT CNSCBand::_UpdateBrowser(LPCITEMIDLIST pidlGoto)
+HRESULT CNSCBand::_UpdateBrowser(LPCITEMIDLIST pidlGoto, BOOL EatSelfNavigation)
 {
     CComPtr<IShellBrowser> pBrowserService;
     HRESULT hr = IUnknown_QueryService(m_pSite, SID_STopLevelBrowser,
@@ -799,6 +826,17 @@ HRESULT CNSCBand::_UpdateBrowser(LPCITEMIDLIST pidlGoto)
     if (FAILED_UNEXPECTEDLY(hr))
         return hr;
 
+    if (_IsCurrentLocation(pidlGoto) == S_OK) // Don't add duplicates to the travel log
+    {
+        if (EatSelfNavigation)
+            return S_FALSE;
+
+        CComPtr<IShellView> psv;
+        if (SUCCEEDED(hr = pBrowserService->QueryActiveShellView(&psv)))
+            hr = psv->Refresh();
+        if (SUCCEEDED(hr))
+            return hr;
+    }
     hr = pBrowserService->BrowseObject(pidlGoto, SBSP_SAMEBROWSER | SBSP_ABSOLUTE);
     if (FAILED_UNEXPECTEDLY(hr))
         return hr;
@@ -808,8 +846,9 @@ HRESULT CNSCBand::_UpdateBrowser(LPCITEMIDLIST pidlGoto)
 
 LRESULT CNSCBand::OnEndLabelEdit(_In_ LPNMTVDISPINFO dispInfo)
 {
-    CItemData *info = GetItemData(dispInfo->item.hItem);
+    CItemData *info = _GetItemData(dispInfo->item.hItem);
     HRESULT hr;
+    BOOL AllowTreeSetNewName = TRUE;
 
     m_isEditing = FALSE;
     if (m_oldSelected)
@@ -847,7 +886,19 @@ LRESULT CNSCBand::OnEndLabelEdit(_In_ LPNMTVDISPINFO dispInfo)
         CComHeapPtr<ITEMIDLIST> pidlNewAbs(ILCombine(pidlParent, pidlNew));
         if (RenamedCurrent)
         {
-            _UpdateBrowser(pidlNewAbs);
+            // Get the new name and icon of item from the folder. RegItems can be renamed to
+            // their default name by the folder (which is not the string in NMTVDISPINFO).
+            WCHAR wszDisplayName[MAX_PATH];
+            if (SUCCEEDED(_GetNameOfItem(pParent, pidlNew, wszDisplayName)))
+            {
+                TVITEMW tvi;
+                tvi.mask = TVIF_TEXT;
+                tvi.hItem = dispInfo->item.hItem;
+                tvi.pszText = wszDisplayName;
+                AllowTreeSetNewName = !m_hwndTreeView.SetItem(&tvi);
+            }
+
+            _UpdateBrowser(pidlNewAbs, TRUE);
         }
         else
         {
@@ -855,7 +906,7 @@ LRESULT CNSCBand::OnEndLabelEdit(_In_ LPNMTVDISPINFO dispInfo)
             SHChangeNotify(SHCNE_RENAMEFOLDER, SHCNF_IDLIST, info->absolutePidl, pidlNewAbs);
         }
 
-        return TRUE;
+        return AllowTreeSetNewName;
     }
 
     return FALSE;
@@ -961,7 +1012,7 @@ LRESULT CNSCBand::OnContextMenu(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &b
         ClientToScreen(&pt);
     }
 
-    CItemData *info = GetItemData(hItem);
+    CItemData *info = _GetItemData(hItem);
     if (!info)
     {
         ERR("No node data, something has gone wrong\n");
@@ -1246,14 +1297,45 @@ STDMETHODIMP CNSCBand::HasFocusIO()
 
 STDMETHODIMP CNSCBand::TranslateAcceleratorIO(LPMSG lpMsg)
 {
+    if (lpMsg->message == WM_KEYDOWN && lpMsg->wParam == VK_F2 && !m_isEditing)
+    {
+        if (HTREEITEM hItem = m_hwndTreeView.GetNextItem(NULL, TVGN_CARET))
+        {
+            if (_GetAttributesOfItem(_GetItemData(hItem), SFGAO_CANRENAME))
+            {
+                m_hwndTreeView.SetFocus();
+                m_hwndTreeView.EditLabel(hItem);
+                return S_OK;
+            }
+        }
+    }
+
+    if (lpMsg->message == WM_SYSKEYDOWN && lpMsg->wParam == VK_RETURN && !m_isEditing)
+    {
+        CItemData *pItem = _GetItemData(TVGN_CARET);
+        if (pItem && _GetAttributesOfItem(pItem, SFGAO_HASPROPSHEET))
+        {
+            SHELLEXECUTEINFOW sei = { sizeof(sei), SEE_MASK_INVOKEIDLIST, m_hwndTreeView };
+            sei.lpVerb = L"properties";
+            sei.lpIDList = pItem->absolutePidl;
+            sei.nShow = SW_SHOW;
+            ShellExecuteExW(&sei);
+            return S_OK;
+        }
+        else
+        {
+            MessageBeep(0);
+        }
+    }
+
     if (lpMsg->hwnd == m_hWnd ||
         (m_isEditing && IsChild(lpMsg->hwnd)))
     {
+        // TODO: Why is it doing this for m_hWnd for all messages?!
         TranslateMessage(lpMsg);
         DispatchMessage(lpMsg);
         return S_OK;
     }
-
     return S_FALSE;
 }
 
@@ -1413,7 +1495,7 @@ STDMETHODIMP CNSCBand::DragOver(DWORD glfKeyState, POINTL pt, DWORD *pdwEffect)
 
     if (info.hItem != m_childTargetNode)
     {
-        CItemData *pItemData = GetItemData(info.hItem);
+        CItemData *pItemData = _GetItemData(info.hItem);
         if (!pItemData)
             return E_FAIL;
 

--- a/dll/win32/shdocvw/CNSCBand.h
+++ b/dll/win32/shdocvw/CNSCBand.h
@@ -41,7 +41,10 @@ public:
         CComHeapPtr<ITEMIDLIST> relativePidl;
         BOOL expanded = FALSE;
     };
-    CItemData* GetItemData(_In_ HTREEITEM hItem);
+    CItemData* _GetItemData(_In_ HTREEITEM hItem);
+    CItemData* _GetItemData(_In_ UINT ItemSpec = TVGN_CARET);
+    SFGAOF _GetAttributesOfItem(_In_ CItemData *pData, _In_ SFGAOF Query);
+    HRESULT _GetNameOfItem(IShellFolder *pSF, PCUITEMID_CHILD pidl, PWSTR Name);
 
     // *** IOleWindow methods ***
     STDMETHODIMP GetWindow(HWND *lphwnd) override;
@@ -189,7 +192,7 @@ protected:
         _In_ LPCITEMIDLIST pEltRelative,
         _In_ BOOL bSort);
     BOOL _InsertSubitems(HTREEITEM hItem, LPCITEMIDLIST entry);
-    HRESULT _UpdateBrowser(LPCITEMIDLIST pidlGoto);
+    HRESULT _UpdateBrowser(LPCITEMIDLIST pidlGoto, BOOL EatSelfNavigation = FALSE);
     HRESULT _GetCurrentLocation(_Out_ PIDLIST_ABSOLUTE *ppidl);
     HRESULT _IsCurrentLocation(_In_ PCIDLIST_ABSOLUTE pidl);
     void _Refresh();

--- a/dll/win32/shdocvw/CNSCBand.h
+++ b/dll/win32/shdocvw/CNSCBand.h
@@ -192,7 +192,7 @@ protected:
         _In_ LPCITEMIDLIST pEltRelative,
         _In_ BOOL bSort);
     BOOL _InsertSubitems(HTREEITEM hItem, LPCITEMIDLIST entry);
-    HRESULT _UpdateBrowser(LPCITEMIDLIST pidlGoto, BOOL EatSelfNavigation = FALSE);
+    HRESULT _UpdateBrowser(LPCITEMIDLIST pidlGoto, BOOL IgnoreSelfNavigation = FALSE);
     HRESULT _GetCurrentLocation(_Out_ PIDLIST_ABSOLUTE *ppidl);
     HRESULT _IsCurrentLocation(_In_ PCIDLIST_ABSOLUTE pidl);
     void _Refresh();

--- a/dll/win32/shell32/folders/CDesktopFolder.h
+++ b/dll/win32/shell32/folders/CDesktopFolder.h
@@ -125,7 +125,7 @@ class CDesktopFolder :
             }
             if (ppwszInvalidChars)
             {
-                SHStrDupW(INVALID_FILETITLE_CHARACTERSW, ppwszInvalidChars);
+                return SHStrDupW(INVALID_FILETITLE_CHARACTERSW, ppwszInvalidChars);
             }
             return S_OK;
         }

--- a/dll/win32/shell32/shell32.spec
+++ b/dll/win32/shell32/shell32.spec
@@ -305,9 +305,9 @@
 305 stdcall SHGetFolderPathAndSubDirA(long long long long str ptr)
 306 stdcall SHGetFolderPathAndSubDirW(long long long long wstr ptr)
 307 stdcall SHGetFolderPathW(long long long long ptr)
-@ stdcall -version=0x600+ SHGetIDListFromObject(ptr ptr)
 308 stdcall SHGetIconOverlayIndexA(str long)
 309 stdcall SHGetIconOverlayIndexW(wstr long)
+@ stdcall -version=0x600+ SHGetIDListFromObject(ptr ptr)
 310 stdcall SHGetInstanceExplorer(long)
 311 stdcall SHGetMalloc(ptr)
 312 stdcall SHGetNewLinkInfo(str str ptr long long) SHGetNewLinkInfoA

--- a/dll/win32/shell32/shell32.spec
+++ b/dll/win32/shell32/shell32.spec
@@ -293,6 +293,7 @@
 293 stdcall SHFreeNameMappings(ptr)
 294 stdcall SHGetDataFromIDListA(ptr ptr long ptr long)
 295 stdcall SHGetDataFromIDListW(ptr ptr long ptr long)
+@ stdcall -version=0x600+ SHGetIDListFromObject(ptr ptr)
 296 stdcall SHGetDesktopFolder(ptr)
 297 stdcall SHGetDiskFreeSpaceA(str ptr ptr ptr) kernel32.GetDiskFreeSpaceExA
 298 stdcall SHGetDiskFreeSpaceExA(str ptr ptr ptr) kernel32.GetDiskFreeSpaceExA

--- a/dll/win32/shell32/shell32.spec
+++ b/dll/win32/shell32/shell32.spec
@@ -293,7 +293,6 @@
 293 stdcall SHFreeNameMappings(ptr)
 294 stdcall SHGetDataFromIDListA(ptr ptr long ptr long)
 295 stdcall SHGetDataFromIDListW(ptr ptr long ptr long)
-@ stdcall -version=0x600+ SHGetIDListFromObject(ptr ptr)
 296 stdcall SHGetDesktopFolder(ptr)
 297 stdcall SHGetDiskFreeSpaceA(str ptr ptr ptr) kernel32.GetDiskFreeSpaceExA
 298 stdcall SHGetDiskFreeSpaceExA(str ptr ptr ptr) kernel32.GetDiskFreeSpaceExA
@@ -306,6 +305,7 @@
 305 stdcall SHGetFolderPathAndSubDirA(long long long long str ptr)
 306 stdcall SHGetFolderPathAndSubDirW(long long long long wstr ptr)
 307 stdcall SHGetFolderPathW(long long long long ptr)
+@ stdcall -version=0x600+ SHGetIDListFromObject(ptr ptr)
 308 stdcall SHGetIconOverlayIndexA(str long)
 309 stdcall SHGetIconOverlayIndexW(wstr long)
 310 stdcall SHGetInstanceExplorer(long)

--- a/dll/win32/shell32/shfldr.h
+++ b/dll/win32/shell32/shfldr.h
@@ -159,7 +159,7 @@ BOOL SHELL_FS_HideExtension(LPCWSTR pwszPath);
 
 static inline BOOL IsIllegalFsFileName(PCWSTR Name)
 {
-    return StrIsNullOrEmpty(Name) || StrCSpnIW(Name, INVALID_FILETITLE_CHARACTERSW) < lstrlenW(Name);
+    return StrIsNullOrEmpty(Name) || StrPBrkW(Name, INVALID_FILETITLE_CHARACTERSW);
 }
 
 void CloseRegKeyArray(HKEY* array, UINT cKeys);

--- a/dll/win32/shell32/shfldr.h
+++ b/dll/win32/shell32/shfldr.h
@@ -95,6 +95,9 @@ BOOL
 SHELL_IncludeItemInFolderEnum(IShellFolder *pSF, PCUITEMID_CHILD pidl, SFGAOF Query, SHCONTF Flags);
 
 HRESULT
+SHELL_CreateAbsolutePidl(IShellFolder *pSF, PCUIDLIST_RELATIVE pidlChild, PIDLIST_ABSOLUTE *ppPidl);
+
+HRESULT
 Shell_NextElement(
     _Inout_ LPWSTR *ppch,
     _Out_ LPWSTR pszOut,
@@ -153,6 +156,11 @@ static __inline int SHELL32_GUIDToStringW (REFGUID guid, LPWSTR str)
 
 void SHELL_FS_ProcessDisplayFilename(LPWSTR szPath, DWORD dwFlags);
 BOOL SHELL_FS_HideExtension(LPCWSTR pwszPath);
+
+static inline BOOL IsIllegalFsFileName(PCWSTR Name)
+{
+    return StrIsNullOrEmpty(Name) || StrCSpnIW(Name, INVALID_FILETITLE_CHARACTERSW) < lstrlenW(Name);
+}
 
 void CloseRegKeyArray(HKEY* array, UINT cKeys);
 LSTATUS AddClassKeyToArray(const WCHAR* szClass, HKEY* array, UINT* cKeys);

--- a/dll/win32/shell32/shlfolder.cpp
+++ b/dll/win32/shell32/shlfolder.cpp
@@ -54,6 +54,18 @@ BOOL SHELL_IncludeItemInFolderEnum(IShellFolder *pSF, PCUITEMID_CHILD pidl, SFGA
     return TRUE;
 }
 
+HRESULT SHELL_CreateAbsolutePidl(IShellFolder *pSF, PCUIDLIST_RELATIVE pidlChild, PIDLIST_ABSOLUTE *ppPidl)
+{
+    PIDLIST_ABSOLUTE pidlFolder;
+    HRESULT hr = SHGetIDListFromObject(pSF, &pidlFolder);
+    if (SUCCEEDED(hr))
+    {
+        hr = SHILCombine(pidlFolder, pidlChild, ppPidl);
+        ILFree(pidlFolder);
+    }
+    return hr;
+}
+
 HRESULT
 Shell_NextElement(
     _Inout_ LPWSTR *ppch,

--- a/dll/win32/shell32/wine/pidl.c
+++ b/dll/win32/shell32/wine/pidl.c
@@ -1623,7 +1623,14 @@ HRESULT WINAPI SHGetNameFromIDList(PCIDLIST_ABSOLUTE pidl, SIGDN sigdnName, PWST
     return ret;
 }
 
-#ifndef __REACTOS__
+/*************************************************************************
+ * SHGetItemFromDataObject          [SHELL32.@]
+ */
+HRESULT WINAPI SHGetItemFromDataObject(IDataObject *pdtobj, DATAOBJ_GET_ITEM_FLAGS dwFlags,
+                                       REFIID riid, void **ppv)
+{
+    return E_NOTIMPL; // FIXME
+}
 
 /*************************************************************************
  * SHGetIDListFromObject             [SHELL32.@]
@@ -1700,8 +1707,6 @@ HRESULT WINAPI SHGetIDListFromObject(IUnknown *punk, PIDLIST_ABSOLUTE *ppidl)
 
     return ret;
 }
-
-#endif /* !__REACTOS__ */
 
 /**************************************************************************
  *


### PR DESCRIPTION
The rename to empty trick now works in the tree view. It does not work in DefView yet because of a bug in the ListView control.

JIRA issue: [CORE-18839](https://jira.reactos.org/browse/CORE-18839)

Notes:
- Regarding the use of `IsIllegalFsFileName` in `CRegFolder::SetNameOf`. RegItems are technically able to have any name but allowing strange things might cause problems during parsing in CDesktopFolder (I did not test) and Windows itself limits the characters it allows. 
![Win RegItem rename](https://github.com/user-attachments/assets/96d6a749-54b6-442c-a9f7-c82150ac3c4b)
