### PR TITLE
[SYSSETUP] Apply theming specified in unattend files very early on when booting the LiveCD or a new install

### DIFF
--- a/boot/bootdata/bootcd/unattend.inf
+++ b/boot/bootdata/bootcd/unattend.inf
@@ -59,16 +59,12 @@ LocaleID = 409
 ; 1: ReactOS Workstation
 ProductOption = 0
 
-; enable this section to automatically launch programs
+; Enable this section to automatically launch programs
 ; after 3rd boot
-;
 ; [GuiRunOnce]
 ; %SystemRoot%\system32\cmd.exe
-; Enable the next line (+ the GuiRunOnce section) to enable the lautus theme
-; "rundll32.exe shell32.dll,Control_RunDLL desk.cpl desk,@Appearance /Action:ActivateMSTheme /file:%SYSTEMROOT%\Resources\themes\lautus\lautus.msstyles"
 
-
-; enable this section to change resolution / bpp
+; Enable this section to change resolution / bpp
 ; setting a value to 0 or skipping it will leave it unchanged
 ; [Display]
 ; BitsPerPel = 32
@@ -79,4 +75,9 @@ ProductOption = 0
 ; enable this section to add environment variables
 ;[Env]
 ;WINETEST_PLATFORM=reactos
+
+; Enable this section to enable the default ReactOS theme
+; [Shell]
+; DefaultThemesOff = no
+; CustomDefaultThemeFile = "%WINDIR%\Resources\Themes\Lautus\lautus.msstyles"
 


### PR DESCRIPTION
## Purpose

Apply theming specified in unattend files very early on when booting the LiveCD or a new install.
_For testing:_ Add a "demo" for testing purposes (won't be included in the final PR).

https://github.com/user-attachments/assets/21983104-47d0-4f55-a216-2c1915f53257

### _Side note:_

On Windows, neither `shell32.dll!Control_RunDLL` nor `desk.cpl` attempt to expand any environment strings in the _**parameters**_ given to the CPL file (anything that follows "desk.cpl" in the `rundll32.exe shell32.dll,Control_RunDLL desk.cpl,,2 /Action:OpenTheme /file:"%SYSTEMROOT%\Resources\themes\Luna.theme"` , for example). The desk.cpl then shows an error. This means that it's the _caller_ who has to expand the path before sending it as a parameter via `Control_RunDLL` to desk.cpl.
![image](https://github.com/user-attachments/assets/5701cd3a-bc26-4c2b-8727-20999097ae33)

## Proposed changes

Use a `[Shell]` section with `DefaultThemesOff` and `CustomDefaultThemeFile`
values, specifying respectively whether to use the classic theme or a
custom one, and the complete path to the custom .theme (or .msstyles) file.

These values are compatible with those documented in the
"MS Windows Preinstallation Reference" help file
of the Windows installation CD (DEPLOY.CAB\ref.chm)
