### PR TITLE
[BOOTSECT][FREELDR] Fix wrong comment of conditional jump on `ext.S` and `extldr.S`

### DIFF
--- a/boot/freeldr/bootsect/ext.S
+++ b/boot/freeldr/bootsect/ext.S
@@ -608,7 +608,7 @@ SearchFile:
     mov di, offset ExtLdrFileName                                       // Load target filename address
     mov cx, offset ExtLdrFileNameEnd - ExtLdrFileName                   // Length of filename to compare
     cmp byte ptr ds:[si + EXT_DIRECTORY_ENTRY_NAME_LENGTH_OFFSET], cl   // Compare if both names have the same length
-    jnz .Skip                                                           // Skip this entry if yes
+    jnz .Skip                                                           // Skip this entry if not
     add si, EXT_DIRECTORY_ENTRY_NAME_OFFSET                             // Move to filename in entry
     repe cmpsb                                                          // Compare filenames
     pop si                                                              // Restore SI

--- a/boot/freeldr/bootsect/extldr.S
+++ b/boot/freeldr/bootsect/extldr.S
@@ -54,7 +54,7 @@ ExtLdrEntryPoint:
     mov di, offset FreeLdrFileName                                      // Load target filename address
     mov cx, offset FreeLdrFileNameEnd - FreeLdrFileName                 // Length of filename to compare
     cmp byte ptr ds:[si + EXT_DIRECTORY_ENTRY_NAME_LENGTH_OFFSET], cl   // Compare if both names have the same length
-    jnz .FSkip2                                                         // Skip this entry if yes
+    jnz .FSkip2                                                         // Skip this entry if not
     add si, EXT_DIRECTORY_ENTRY_NAME_OFFSET                             // Move to filename in entry
     repe cmpsb                                                          // Compare filenames
     pop si                                                              // Restore SI


### PR DESCRIPTION
I'm sorry if i didn't noticed that before