### PR TITLE
[FREETYPE] Fix WordPad ruler rendering

### DIFF
--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -4095,7 +4095,7 @@ IntRequestFontSize(PDC dc, PFONTGDI FontGDI, LONG lfWidth, LONG lfHeight)
     TT_OS2 *pOS2;
     TT_HoriHeader *pHori;
     FT_WinFNT_HeaderRec WinFNT;
-    LONG Ascent, Descent, Sum, EmHeight, Width64;
+    LONG Ascent, Descent, Sum, EmHeight;
 
     lfWidth = abs(lfWidth);
     if (lfHeight == 0)
@@ -4205,24 +4205,21 @@ IntRequestFontSize(PDC dc, PFONTGDI FontGDI, LONG lfWidth, LONG lfHeight)
 #if 1
     /* I think this is wrong implementation but its test result is better. */
     if (lfWidth != 0)
-        Width64 = FT_MulDiv(lfWidth, face->units_per_EM, pOS2->xAvgCharWidth) << 6;
-    else
-        Width64 = 0;
+        req.width = FT_MulDiv(lfWidth, face->units_per_EM, pOS2->xAvgCharWidth) << 6;
 #else
     /* I think this is correct implementation but it is mismatching to the
        other metric functions. The test result is bad. */
     if (lfWidth != 0)
-        Width64 = (FT_MulDiv(lfWidth, 96 * 5, 72 * 3) << 6); /* ??? FIXME */
-    else
-        Width64 = 0;
+        req.width = (FT_MulDiv(lfWidth, 96 * 5, 72 * 3) << 6); /* ??? FIXME */
 #endif
+    else
+        req.width = 0;
 
-    /* We do not handle small widths well, so just use zero for these. See CORE-19870. */
+    /* HACK: We do not handle small widths well, so just use zero for these. See CORE-19870. */
     if (lfWidth < 10)
-        Width64 = 0;
+        req.width = 0;
 
     req.type           = FT_SIZE_REQUEST_TYPE_NOMINAL;
-    req.width          = Width64;
     req.height         = (EmHeight << 6);
     req.horiResolution = 0;
     req.vertResolution = 0;

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -4217,6 +4217,10 @@ IntRequestFontSize(PDC dc, PFONTGDI FontGDI, LONG lfWidth, LONG lfHeight)
         Width64 = 0;
 #endif
 
+    /* We do not handle small widths well, so just use zero for these. See CORE-19870. */
+    if (lfWidth < 10)
+        Width64 = 0;
+
     req.type           = FT_SIZE_REQUEST_TYPE_NOMINAL;
     req.width          = Width64;
     req.height         = (EmHeight << 6);


### PR DESCRIPTION
## Purpose
Based on @Doug-Lyons's `wordpad-ruler-fix-05.patch`.
JIRA issue: [CORE-19870](https://jira.reactos.org/browse/CORE-19870)

## Proposed changes

- In `IntRequestFontSize` function, if `lfWidth < 10`, then `req.width = 0;`.

## TODO

- [x] Do big tests.

## Screenshots

BEFORE:
![before](https://github.com/user-attachments/assets/4e989710-6e8c-4404-add1-baec0cfa041b)

AFTER:
![after](https://github.com/user-attachments/assets/703c8964-5b1a-4f5e-9a1d-acdd17bf1a22)