### PR TITLE
[SHELL32] CFolderOptions Reset can call DefView directly if there is no browser

### DIFF
--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -4208,13 +4208,13 @@ HRESULT WINAPI CDefView::Exec(const GUID *pguidCmdGroup, DWORD nCmdID, DWORD nCm
                 SHDeleteKey(HKEY_CURRENT_USER, L"Software\\Microsoft\\Windows\\ShellNoRoam\\Bags");
                 if (SUCCEEDED(GetDefaultViewStream(STGM_WRITE, &pStream)))
                     SaveViewState(pStream);
-                break;
+                return S_OK;
             case DVCMDID_RESET_DEFAULTFOLDER_SETTINGS:
-                wsprintfW(SubKey, L"%s\\%s", REGSTR_PATH_EXPLORER, L"Streams\\Default");
+                PathCombineW(SubKey, REGSTR_PATH_EXPLORER, L"Streams\\Default");
                 SHDeleteKey(HKEY_CURRENT_USER, SubKey);
                 SHDeleteKey(HKEY_CURRENT_USER, L"Software\\Microsoft\\Windows\\ShellNoRoam\\Bags");
                 m_FolderSettings.fFlags |= FWF_NOBROWSERVIEWSTATE; // Don't let this folder save itself
-                break;
+                return S_OK;
         }
     }
 

--- a/dll/win32/shell32/CFolderOptions.cpp
+++ b/dll/win32/shell32/CFolderOptions.cpp
@@ -117,7 +117,7 @@ static HRESULT ResetGlobalFolderSettings()
 {
     IGlobalFolderSettings *pgfs;
     HRESULT hr = CoCreateInstance(CLSID_GlobalFolderSettings, NULL, CLSCTX_INPROC_SERVER,
-                                  IID_IGlobalFolderSettings, (void **)&pgfs);
+                                  IID_PPV_ARG(IGlobalFolderSettings, &pgfs));
     if (SUCCEEDED(hr))
     {
         hr = pgfs->Set(NULL, 0, 0);

--- a/dll/win32/shell32/CFolderOptions.cpp
+++ b/dll/win32/shell32/CFolderOptions.cpp
@@ -113,6 +113,45 @@ HRESULT STDMETHODCALLTYPE CFolderOptions::GetSite(REFIID riid, void **ppvSite)
 /*************************************************************************
  * FolderOptions helper methods
  */
+static HRESULT ResetGlobalFolderSettings()
+{
+    IGlobalFolderSettings *pgfs;
+    HRESULT hr = CoCreateInstance(CLSID_GlobalFolderSettings, NULL, CLSCTX_INPROC_SERVER,
+                                  IID_IGlobalFolderSettings, (void **)&pgfs);
+    if (SUCCEEDED(hr))
+    {
+        hr = pgfs->Set(NULL, 0, 0);
+        pgfs->Release();
+    }
+    return hr;
+}
+
+static inline HRESULT ExecResetDefViewFolderSettings(IUnknown *pUnk)
+{
+    return IUnknown_Exec(pUnk, CGID_DefView, DVCMDID_RESET_DEFAULTFOLDER_SETTINGS,
+                         OLECMDEXECOPT_DODEFAULT, NULL, NULL);
+}
+
+static HRESULT ResetDefViewFolderSettings()
+{
+    CComPtr<IShellFolder> pSF;
+    HRESULT hr = SHGetDesktopFolder(&pSF);
+    if (SUCCEEDED(hr))
+    {
+        CComPtr<IShellView> pSV;
+        SFV_CREATE create = { sizeof(SFV_CREATE), pSF };
+        if (SUCCEEDED(hr = SHCreateShellFolderView(&create, &pSV)))
+            hr = ExecResetDefViewFolderSettings(pSV);
+    }
+    return hr;
+}
+
+HRESULT CFolderOptions::ResetGlobalAndDefViewFolderSettings()
+{
+    ResetDefViewFolderSettings();
+    return ResetGlobalFolderSettings();
+}
+
 HRESULT CFolderOptions::HandleDefFolderSettings(int Action)
 {
     IBrowserService2 *bs2;
@@ -126,25 +165,19 @@ HRESULT CFolderOptions::HandleDefFolderSettings(int Action)
         else if (Action == DFSA_RESET)
         {
             // There does not seem to be a method in IBrowserService2 for this
-            IUnknown_Exec(bs2, CGID_DefView, DVCMDID_RESET_DEFAULTFOLDER_SETTINGS, OLECMDEXECOPT_DODEFAULT, NULL, NULL);
+            ExecResetDefViewFolderSettings(bs2);
         }
         else
         {
-            // FFSA_QUERY: hr is already correct
+            // DFSA_QUERY: hr is already correct
         }
         bs2->Release();
     }
 
     if (Action == DFSA_RESET)
     {
-        IGlobalFolderSettings *pgfs;
-        HRESULT hr = CoCreateInstance(CLSID_GlobalFolderSettings, NULL, CLSCTX_INPROC_SERVER,
-                                      IID_IGlobalFolderSettings, (void **)&pgfs);
-        if (SUCCEEDED(hr))
-        {
-            hr = pgfs->Set(NULL, 0, 0);
-            pgfs->Release();
-        }
+        // In case the browser is hosting a 3rd-party view, we force a DefView reset
+        hr = ResetGlobalAndDefViewFolderSettings();
     }
 
     return hr;

--- a/dll/win32/shell32/CFolderOptions.h
+++ b/dll/win32/shell32/CFolderOptions.h
@@ -66,6 +66,8 @@ class CFolderOptions :
             return HandleDefFolderSettings(ResetToDefault ? DFSA_RESET : DFSA_APPLY);
         }
 
+        static HRESULT ResetGlobalAndDefViewFolderSettings();
+
         DECLARE_REGISTRY_RESOURCEID(IDR_FOLDEROPTIONS)
         DECLARE_NOT_AGGREGATABLE(CFolderOptions)
 

--- a/dll/win32/shell32/dialogs/view.cpp
+++ b/dll/win32/shell32/dialogs/view.cpp
@@ -975,9 +975,12 @@ FolderOptionsViewDlg(
                 case IDC_VIEW_RESET_ALL:
                 {
                     HRESULT hr = HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
+                    bool ResetToDefault = LOWORD(wParam) == IDC_VIEW_RESET_ALL;
                     CFolderOptions *pFO = (CFolderOptions*)GetWindowLongPtr(hwndDlg, GWL_USERDATA);
                     if (pFO)
-                        hr = pFO->ApplyDefFolderSettings(LOWORD(wParam) == IDC_VIEW_RESET_ALL);
+                        hr = pFO->ApplyDefFolderSettings(ResetToDefault); // Use IBrowserService2
+                    if (ResetToDefault && hr == HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED))
+                        hr = CFolderOptions::ResetGlobalAndDefViewFolderSettings(); // No browser
                     if (FAILED(hr))
                         SHELL_ErrorBox(hwndDlg, hr);
                     break;


### PR DESCRIPTION
JIRA issue: [CORE-20029](https://jira.reactos.org/browse/CORE-20029)

The "Reset all folders" flow is now:
- If we have an IShellBrowser with a IBrowserService2 service, use that (browseui or 3rd-party browser).
  - This should (browseui will) reset the browser settings and forward the command to the view (DefView or 3rd-party).
  - Forward the command to DefView (in case the browser is hosting a 3rd-party view).
  - Reset IGlobalFolderSettings.
- If there is no browser, we reset the global settings and forward the command to DefView.

