### PR TITLE
[NEWDEV] Fix `HardwareId` match logic in `UpdateDriverForPlugAndPlayDevicesW`

### DIFF
--- a/dll/win32/newdev/newdev.c
+++ b/dll/win32/newdev/newdev.c
@@ -1,7 +1,7 @@
 /*
  * New device installer (newdev.dll)
  *
- * Copyright 2005-2006 Hervé Poussineau (hpoussin@reactos.org)
+ * Copyright 2005-2006 HervÃ© Poussineau (hpoussin@reactos.org)
  *           2005 Christoph von Wittich (Christoph@ActiveVB.de)
  *           2009 Colin Finck (colin@reactos.org)
  *
@@ -50,6 +50,7 @@ UpdateDriverForPlugAndPlayDevicesW(
     LPWSTR Buffer = NULL;
     DWORD BufferSize;
     LPCWSTR CurrentHardwareId; /* Pointer into Buffer */
+    DWORD Property;
     BOOL FoundHardwareId, FoundAtLeastOneDevice = FALSE;
     BOOL ret = FALSE;
 
@@ -86,51 +87,58 @@ UpdateDriverForPlugAndPlayDevicesW(
             break;
         }
 
-        /* Get Hardware ID */
-        HeapFree(GetProcessHeap(), 0, Buffer);
-        Buffer = NULL;
-        BufferSize = 0;
-        while (!SetupDiGetDeviceRegistryPropertyW(
-            DevInstData.hDevInfo,
-            &DevInstData.devInfoData,
-            SPDRP_HARDWAREID,
-            NULL,
-            (PBYTE)Buffer,
-            BufferSize,
-            &BufferSize))
-        {
-            if (GetLastError() == ERROR_FILE_NOT_FOUND)
-            {
-                Buffer = NULL;
-                break;
-            }
-            else if (GetLastError() != ERROR_INSUFFICIENT_BUFFER)
-            {
-                TRACE("SetupDiGetDeviceRegistryPropertyW() failed with error 0x%x\n", GetLastError());
-                goto cleanup;
-            }
-            /* This error was expected */
-            HeapFree(GetProcessHeap(), 0, Buffer);
-            Buffer = HeapAlloc(GetProcessHeap(), 0, BufferSize);
-            if (!Buffer)
-            {
-                TRACE("HeapAlloc() failed\n", GetLastError());
-                SetLastError(ERROR_NOT_ENOUGH_MEMORY);
-                goto cleanup;
-            }
-        }
-        if (Buffer == NULL)
-            continue;
-
-        /* Check if we match the given hardware ID */
+        /* Match Hardware ID */
         FoundHardwareId = FALSE;
-        for (CurrentHardwareId = Buffer; *CurrentHardwareId != UNICODE_NULL; CurrentHardwareId += wcslen(CurrentHardwareId) + 1)
+        Property = SPDRP_HARDWAREID;
+        while(TRUE)
         {
-            if (wcscmp(CurrentHardwareId, HardwareId) == 0)
+            /* Get IDs data */
+            Buffer = NULL;
+            BufferSize = 0;
+            while (!SetupDiGetDeviceRegistryPropertyW(DevInstData.hDevInfo,
+                                                      &DevInstData.devInfoData,
+                                                      Property,
+                                                      NULL,
+                                                      (PBYTE)Buffer,
+                                                      BufferSize,
+                                                      &BufferSize))
             {
-                FoundHardwareId = TRUE;
+                if (GetLastError() == ERROR_FILE_NOT_FOUND)
+                {
+                    break;
+                }
+                else if (GetLastError() != ERROR_INSUFFICIENT_BUFFER)
+                {
+                    TRACE("SetupDiGetDeviceRegistryPropertyW() failed with error 0x%x\n", GetLastError());
+                    goto cleanup;
+                }
+                /* This error was expected */
+                HeapFree(GetProcessHeap(), 0, Buffer);
+                Buffer = HeapAlloc(GetProcessHeap(), 0, BufferSize);
+                if (!Buffer)
+                {
+                    TRACE("HeapAlloc() failed\n", GetLastError());
+                    SetLastError(ERROR_NOT_ENOUGH_MEMORY);
+                    goto cleanup;
+                }
+            }
+            if (Buffer)
+            {
+                /* Check if we match the given hardware ID */
+                for (CurrentHardwareId = Buffer; *CurrentHardwareId != UNICODE_NULL; CurrentHardwareId += wcslen(CurrentHardwareId) + 1)
+                {
+                    if (_wcsicmp(CurrentHardwareId, HardwareId) == 0)
+                    {
+                        FoundHardwareId = TRUE;
+                        break;
+                    }
+                }
+            }
+            if (FoundHardwareId || Property == SPDRP_COMPATIBLEIDS)
+            {
                 break;
             }
+            Property = SPDRP_COMPATIBLEIDS;
         }
         if (!FoundHardwareId)
             continue;

--- a/dll/win32/newdev/newdev.c
+++ b/dll/win32/newdev/newdev.c
@@ -90,7 +90,7 @@ UpdateDriverForPlugAndPlayDevicesW(
         /* Match Hardware ID */
         FoundHardwareId = FALSE;
         Property = SPDRP_HARDWAREID;
-        while(TRUE)
+        while (TRUE)
         {
             /* Get IDs data */
             Buffer = NULL;


### PR DESCRIPTION
## Purpose

Match Hardware ID correctly. This fix is required to install the latest (7.1.6) Virtual Box Guest Additions drivers.

JIRA issue: None.

## Proposed changes

- Add [Compatible IDs](https://learn.microsoft.com/en-us/windows-hardware/drivers/install/compatible-ids) match, call `SetupDiGetDeviceRegistryPropertyW` twice, once for `SPDRP_HARDWAREID` and once for `SPDRP_COMPATIBLEIDS`.
- Use case-insensitive comparison (`wcscmp` -> `_wcsicmp`)
- Convert code file to UTF-8 encoding (for the character `é` in file head)

## Details

After #7746 , #7769 , #7770 , the installer installs driver VBoxGuest incorrectly, because `UpdateDriverForPlugAndPlayDevicesW` failed with `ERROR_NO_SUCH_DEVINST`. In fact, the device is present, the installer and this function work fine in Win2K3.

According to:
[Microsoft Learning - Compatible ID](https://learn.microsoft.com/en-us/windows-hardware/drivers/install/compatible-ids):
> A compatible ID is a vendor-defined identification string that Windows uses to match a device to a [driver package](https://learn.microsoft.com/en-us/windows-hardware/drivers/install/driver-packages).

[Microsoft Learning - Device identification strings](https://learn.microsoft.com/en-us/windows-hardware/drivers/install/device-identification-strings):
> Windows tries to find a match for one of the hardware IDs or compatible IDs.

Our current implementation match device with [Hardware ID](https://learn.microsoft.com/en-us/windows-hardware/drivers/install/hardware-ids) only, [Compatible IDs](https://learn.microsoft.com/en-us/windows-hardware/drivers/install/compatible-ids) match should be added.

The corresponding ID returned by `SetupDiGetDeviceRegistryPropertyW` is upper-case in both of ReactOS and Win2K3, but the installer inputs `HardwareId` has lower-case letters, we should do a case-insensitive match here.

After PRs mentioned above and this, the installer works and installed all components correctly:
![image](https://github.com/user-attachments/assets/8f345207-7ed0-45e0-94a3-659887585a53)
(Display driver and share folder driver work fine ^_^)
