### PR TITLE
[SHELL32] Follow-up of #7805: Improve PathMakeUniqueName

### DIFF
--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -793,11 +793,11 @@ static BOOL PathMakeUniqueNameW(
     }
 
     LPWSTR pchTitle = pszDest + cchTitle;
-    INT ich;
-    for (ich = 1; ich < maxCount; ++ich)
+    INT count;
+    for (count = 1; count < maxCount; ++count)
     {
         WCHAR tempName[MAX_PATH];
-        if (StringCchPrintfW(tempName, _countof(tempName), formatString, ich) != S_OK ||
+        if (StringCchPrintfW(tempName, _countof(tempName), formatString, count) != S_OK ||
             StringCchCatW(tempName, _countof(tempName), pchDotExt) != S_OK)
         {
             return FALSE;

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -671,7 +671,7 @@ static BOOL PathMakeUniqueNameW(
     _Out_ PWSTR pszUniqueName,
     _In_ UINT cchMax,
     _In_ PCWSTR pszTemplate,
-    _In_opt_ PCWSTR pszLongPlate,
+    _In_opt_ PCWSTR pszLongPlate, /* Long template */
     _In_opt_ PCWSTR pszDir)
 {
     TRACE("%p %u %s %s %s\n",
@@ -730,7 +730,7 @@ static BOOL PathMakeUniqueNameW(
             cchTitle = MSDOS_8DOT3_FILENAME_TITLE_LEN - 1;
 
         INT extLength = lstrlenW(pchDotExt);
-        while (extLength + cchTitle + dirLength + 1 > (cchMax - 1) && cchTitle > 1)
+        while ((dirLength + cchTitle + extLength + 1 > (cchMax - 1)) && cchTitle > 1)
             --cchTitle;
 
         if (cchTitle <= 0)
@@ -778,7 +778,7 @@ static BOOL PathMakeUniqueNameW(
             formatString = L" (%d)";
         }
 
-        INT remainingChars = cchMax - cchTitle - dirLength - lstrlenW(formatString) + 2;
+        INT remainingChars = cchMax - (dirLength + cchTitle + (lstrlenW(formatString) - 2));
         if (remainingChars <= 0)
             maxCount = 1;
         else if (remainingChars == 1)

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -699,7 +699,7 @@ static BOOL PathMakeUniqueNameW(
 
     PCWSTR pszTitle = pszLongPlate ? pszLongPlate : pszTemplate;
     PCWSTR pchDotExt = NULL;
-    LPCWSTR formatString = L"%d";
+    PCWSTR formatString = L"%d";
 
     if (   !pszTitle
         || !IsLFNDriveW(pszDir)

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -683,7 +683,7 @@ static BOOL PathMakeUniqueNameW(
 
     pszUniqueName[0] = UNICODE_NULL;
 
-    LPWSTR pszDest = pszUniqueName;
+    PWSTR pszDest = pszUniqueName;
     UINT dirLength = 0;
     if (pszDir)
     {
@@ -792,7 +792,7 @@ static BOOL PathMakeUniqueNameW(
     if (StringCchCopyNW(pszDest, cchMax - dirLength, pszTitle, cchTitle) != S_OK)
         return FALSE;
 
-    LPWSTR pchTitle = pszDest + cchTitle;
+    PWSTR pchTitle = pszDest + cchTitle;
     INT count;
     for (count = 1; count < maxCount; ++count)
     {

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -740,8 +740,7 @@ static BOOL PathMakeUniqueNameW(
         else
             maxCount = 100;
 
-        if (StringCchCopyNW(pszDest, cchMax - dirLength, pszTemplate, cchTitle) != S_OK)
-            return FALSE;
+        pszTitle = pszTemplate;
     }
     else
     {
@@ -788,10 +787,10 @@ static BOOL PathMakeUniqueNameW(
             maxCount = 100;
         else
             maxCount = 1000;
-
-        if (StringCchCopyNW(pszDest, cchMax - dirLength, pszTitle, cchTitle) != S_OK)
-            return FALSE;
     }
+
+    if (StringCchCopyNW(pszDest, cchMax - dirLength, pszTitle, cchTitle) != S_OK)
+        return FALSE;
 
     LPWSTR pchTitle = pszDest + cchTitle;
     INT count;

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -713,7 +713,6 @@ static BOOL PathMakeUniqueNameW(
         if (!pszTemplate)
             return FALSE;
 
-        PCWSTR pszSrc = pszTemplate;
         pchDotExt = PathFindExtensionW(pszTemplate);
         INT extLength = lstrlenW(pchDotExt);
 
@@ -740,7 +739,7 @@ static BOOL PathMakeUniqueNameW(
         else
             maxCount = 1;
 
-        if (StringCchCopyNW(pszDest, cchMax - dirLength, pszSrc, cchTitle) != S_OK)
+        if (StringCchCopyNW(pszDest, cchMax - dirLength, pszTemplate, cchTitle) != S_OK)
             return FALSE;
     }
     else

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -698,9 +698,8 @@ static BOOL PathMakeUniqueNameW(
     }
 
     PCWSTR pszTitle = pszLongPlate ? pszLongPlate : pszTemplate;
-    PCWSTR pchDotExt = NULL;
-    PCWSTR formatString = L"%d";
-    INT maxCount, cchTitle = 0;
+    PCWSTR pchDotExt, formatString = L"%d";
+    INT maxCount, cchTitle;
 
     if (   !pszTitle
         || !IsLFNDriveW(pszDir)
@@ -730,7 +729,7 @@ static BOOL PathMakeUniqueNameW(
             cchTitle = MSDOS_8DOT3_FILENAME_TITLE_LEN - 1;
 
         INT extLength = lstrlenW(pchDotExt);
-        while ((dirLength + cchTitle + extLength + 1 > (cchMax - 1)) && cchTitle > 1)
+        while (cchTitle > 1 && (dirLength + cchTitle + extLength + 1 > (cchMax - 1)))
             --cchTitle;
 
         if (cchTitle <= 0)

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -700,8 +700,7 @@ static BOOL PathMakeUniqueNameW(
     PCWSTR pszTitle = pszLongPlate ? pszLongPlate : pszTemplate;
     PCWSTR pchDotExt = NULL;
     PCWSTR formatString = L"%d";
-    INT maxCount;
-    INT cchTitle = 0;
+    INT maxCount, cchTitle = 0;
 
     if (   !pszTitle
         || !IsLFNDriveW(pszDir)
@@ -714,7 +713,6 @@ static BOOL PathMakeUniqueNameW(
             return FALSE;
 
         pchDotExt = PathFindExtensionW(pszTemplate);
-        INT extLength = lstrlenW(pchDotExt);
 
         cchTitle = pchDotExt - pszTemplate;
         if (cchTitle > 1)
@@ -731,13 +729,16 @@ static BOOL PathMakeUniqueNameW(
         if (cchTitle > MSDOS_8DOT3_FILENAME_TITLE_LEN - 1)
             cchTitle = MSDOS_8DOT3_FILENAME_TITLE_LEN - 1;
 
+        INT extLength = lstrlenW(pchDotExt);
         while (extLength + cchTitle + dirLength + 1 > (cchMax - 1) && cchTitle > 1)
             --cchTitle;
 
-        if (cchTitle >= 1)
-            maxCount = (cchTitle != 1) ? 100 : 10;
-        else
+        if (cchTitle <= 0)
             maxCount = 1;
+        else if (cchTitle == 1)
+            maxCount = 10;
+        else
+            maxCount = 100;
 
         if (StringCchCopyNW(pszDest, cchMax - dirLength, pszTemplate, cchTitle) != S_OK)
             return FALSE;
@@ -779,14 +780,14 @@ static BOOL PathMakeUniqueNameW(
         }
 
         INT remainingChars = cchMax - cchTitle - dirLength - lstrlenW(formatString) + 2;
-        if (remainingChars == 1)
+        if (remainingChars <= 0)
+            maxCount = 1;
+        else if (remainingChars == 1)
             maxCount = 10;
         else if (remainingChars == 2)
             maxCount = 100;
-        else if (remainingChars > 0)
-            maxCount = 1000;
         else
-            maxCount = 1;
+            maxCount = 1000;
 
         if (StringCchCopyNW(pszDest, cchMax - dirLength, pszTitle, cchTitle) != S_OK)
             return FALSE;

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -698,6 +698,8 @@ static BOOL PathMakeUniqueNameW(
     }
 
     PCWSTR pszTitle = pszLongPlate ? pszLongPlate : pszTemplate;
+    PCWSTR pchDotExt = NULL;
+    LPCWSTR formatString = L"%d";
 
     if (   !pszTitle
         || !IsLFNDriveW(pszDir)
@@ -710,12 +712,8 @@ static BOOL PathMakeUniqueNameW(
             return FALSE;
 
         PCWSTR pszSrc = pszTemplate;
-        PCWSTR pchDotExt = PathFindExtensionW(pszTemplate);
+        pchDotExt = PathFindExtensionW(pszTemplate);
         INT extLength = lstrlenW(pchDotExt);
-
-        WCHAR formatString[MAX_PATH];
-        if (StringCchCopyW(formatString, _countof(formatString), L"%d") != S_OK)
-            return FALSE;
 
         INT cchTitle = pchDotExt - pszTemplate;
         if (cchTitle > 1)
@@ -728,8 +726,9 @@ static BOOL PathMakeUniqueNameW(
             }
         }
 
-        if (cchTitle > 7)
-            cchTitle = 7;
+#define MSDOS_8DOT3_FILENAME_TITLE_LEN 8
+        if (cchTitle > MSDOS_8DOT3_FILENAME_TITLE_LEN - 1)
+            cchTitle = MSDOS_8DOT3_FILENAME_TITLE_LEN - 1;
 
         while (extLength + cchTitle + dirLength + 1 > (cchMax - 1) && cchTitle > 1)
             --cchTitle;
@@ -764,9 +763,7 @@ static BOOL PathMakeUniqueNameW(
     else
     {
         PCWSTR openParen = StrChrW(pszTitle, L'(');
-        PCWSTR pchDotExt = NULL;
         INT cchTitle = 0;
-        WCHAR formatString[MAX_PATH];
 
         if (openParen)
         {
@@ -786,23 +783,19 @@ static BOOL PathMakeUniqueNameW(
             {
                 pchDotExt = openParen + 1;
                 cchTitle = pchDotExt - pszTitle;
-                if (StringCchCopyW(formatString, _countof(formatString), L"%d") != S_OK)
-                    return FALSE;
             }
             else
             {
                 pchDotExt = PathFindExtensionW(pszTitle);
                 cchTitle = pchDotExt - pszTitle;
-                if (StringCchCopyW(formatString, _countof(formatString), L" (%d)") != S_OK)
-                    return FALSE;
+                formatString = L" (%d)";
             }
         }
         else
         {
             pchDotExt = PathFindExtensionW(pszTitle);
             cchTitle = pchDotExt - pszTitle;
-            if (StringCchCopyW(formatString, _countof(formatString), L" (%d)") != S_OK)
-                return FALSE;
+            formatString = L" (%d)";
         }
 
         INT maxCount = 1;


### PR DESCRIPTION
## Purpose

Follow-up of #7805.
JIRA issue: [CORE-19278](https://jira.reactos.org/browse/CORE-19278)

## Proposed changes

- Simplify `formatString` handling.
- Move `pchDotExt` declaration.
- Define `MSDOS_8DOT3_FILENAME_TITLE_LEN` macro and use it.
- Commonize some code.