### PR TITLE
[BROWSEUI][SDK] Implement IAddressEditBox::SetCurrentDir

### DIFF
--- a/dll/win32/browseui/addresseditbox.cpp
+++ b/dll/win32/browseui/addresseditbox.cpp
@@ -90,8 +90,9 @@ HRESULT STDMETHODCALLTYPE CAddressEditBox::Init(HWND comboboxEx, HWND editContro
     return hResult;
 }
 
-HRESULT STDMETHODCALLTYPE CAddressEditBox::SetCurrentDir(long paramC)
+HRESULT STDMETHODCALLTYPE CAddressEditBox::SetCurrentDir(PCWSTR pszPath)
 {
+    pidlLastParsed = ILCreateFromPathW(pszPath);
     return E_NOTIMPL;
 }
 
@@ -200,8 +201,8 @@ HRESULT STDMETHODCALLTYPE CAddressEditBox::ParseNow(long paramC)
     ULONG attributes;
     HRESULT hr;
     HWND topLevelWindow;
-    PIDLIST_ABSOLUTE pidlCurrent= NULL;
-    PIDLIST_RELATIVE pidlRelative = NULL;
+    CComHeapPtr<ITEMIDLIST_ABSOLUTE> pidlCurrent;
+    CComHeapPtr<ITEMIDLIST_RELATIVE> pidlRelative;
     CComPtr<IShellFolder> psfCurrent;
 
     CComPtr<IBrowserService> pbs;
@@ -245,7 +246,6 @@ HRESULT STDMETHODCALLTYPE CAddressEditBox::ParseNow(long paramC)
     if (SUCCEEDED(hr))
     {
         pidlLastParsed = ILCombine(pidlCurrent, pidlRelative);
-        ILFree(pidlRelative);
         goto cleanup;
     }
 
@@ -254,8 +254,6 @@ parseabsolute:
     hr = psfDesktop->ParseDisplayName(topLevelWindow, NULL, address, &eaten, &pidlLastParsed, &attributes);
 
 cleanup:
-    if (pidlCurrent)
-        ILFree(pidlCurrent);
     return hr;
 }
 

--- a/dll/win32/browseui/addresseditbox.cpp
+++ b/dll/win32/browseui/addresseditbox.cpp
@@ -92,6 +92,8 @@ HRESULT STDMETHODCALLTYPE CAddressEditBox::Init(HWND comboboxEx, HWND editContro
 
 HRESULT STDMETHODCALLTYPE CAddressEditBox::SetCurrentDir(PCWSTR pszPath)
 {
+    if (pidlLastParsed)
+        ILFree(pidlLastParsed);
     pidlLastParsed = ILCreateFromPathW(pszPath);
     return E_NOTIMPL;
 }

--- a/dll/win32/browseui/addresseditbox.cpp
+++ b/dll/win32/browseui/addresseditbox.cpp
@@ -1,27 +1,10 @@
 /*
- * ReactOS Explorer
- *
- * Copyright 2009 Andrew Hill <ash77 at domain reactos.org>
- * Copyright 2023 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * PROJECT:     ReactOS Explorer
+ * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
+ * PURPOSE:     The combo box of the address band
+ * COPYRIGHT:   Copyright 2009 Andrew Hill <ash77 at domain reactos.org>
+ *              Copyright 2023-2025 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  */
-
-/*
-This class handles the combo box of the address band.
-*/
 
 #include "precomp.h"
 
@@ -371,12 +354,13 @@ HRESULT STDMETHODCALLTYPE CAddressEditBox::OnWinEvent(
             if (HIWORD(wParam) == CBN_SELCHANGE)
             {
                 HWND hwndCombo = (HWND)lParam;
-                UINT iItem = (UINT)SendMessageW(hwndCombo, CB_GETCURSEL, 0, 0);
+                INT iItem = (INT)SendMessageW(hwndCombo, CB_GETCURSEL, 0, 0);
                 PIDLIST_ABSOLUTE pidl =
                     (PIDLIST_ABSOLUTE)SendMessageW(hwndCombo, CB_GETITEMDATA, iItem, 0);
                 m_pidlLastParsed.Free();
                 if (pidl)
                     m_pidlLastParsed.Attach(ILClone(pidl));
+
                 Execute(0);
             }
             break;

--- a/dll/win32/browseui/addresseditbox.cpp
+++ b/dll/win32/browseui/addresseditbox.cpp
@@ -351,12 +351,11 @@ HRESULT STDMETHODCALLTYPE CAddressEditBox::OnWinEvent(
     {
         case WM_COMMAND:
         {
-            if (HIWORD(wParam) == CBN_SELCHANGE)
+            if (HIWORD(wParam) == CBN_SELCHANGE && fCombobox == (HWND)lParam)
             {
-                HWND hwndCombo = (HWND)lParam;
-                INT iItem = (INT)SendMessageW(hwndCombo, CB_GETCURSEL, 0, 0);
+                INT iItem = (INT)fCombobox.SendMessage(CB_GETCURSEL);
                 PIDLIST_ABSOLUTE pidl =
-                    (PIDLIST_ABSOLUTE)SendMessageW(hwndCombo, CB_GETITEMDATA, iItem, 0);
+                    (PIDLIST_ABSOLUTE)fCombobox.SendMessage(CB_GETITEMDATA, iItem);
                 m_pidlLastParsed.Free();
                 if (pidl)
                     m_pidlLastParsed.Attach(ILClone(pidl));

--- a/dll/win32/browseui/addresseditbox.h
+++ b/dll/win32/browseui/addresseditbox.h
@@ -62,7 +62,7 @@ public:
 
     // *** IAddressEditBox methods ***
     STDMETHOD(Init)(HWND comboboxEx, HWND editControl, long param14, IUnknown *param18) override;
-    STDMETHOD(SetCurrentDir)(long paramC) override;
+    STDMETHOD(SetCurrentDir)(PCWSTR pszPath) override;
     STDMETHOD(ParseNow)(long paramC) override;
     STDMETHOD(Execute)(long paramC) override;
     STDMETHOD(Save)(long paramC) override;

--- a/dll/win32/browseui/addresseditbox.h
+++ b/dll/win32/browseui/addresseditbox.h
@@ -37,7 +37,7 @@ private:
     CContainedWindow                        fEditWindow;
     DWORD                                   fAdviseCookie;
     CComPtr<IUnknown>                       fSite;
-    LPITEMIDLIST                            pidlLastParsed;
+    CComHeapPtr<ITEMIDLIST_ABSOLUTE>        m_pidlLastParsed;
     HWND                                    hComboBoxEx;
 public:
     CAddressEditBox();

--- a/dll/win32/browseui/addresseditbox.h
+++ b/dll/win32/browseui/addresseditbox.h
@@ -1,21 +1,9 @@
 /*
- * ReactOS Explorer
- *
- * Copyright 2009 Andrew Hill <ash77 at domain reactos.org>
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * PROJECT:     ReactOS Explorer
+ * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
+ * PURPOSE:     The combo box of the address band
+ * COPYRIGHT:   Copyright 2009 Andrew Hill <ash77 at domain reactos.org>
+ *              Copyright 2023-2025 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  */
 
 #pragma once

--- a/sdk/include/reactos/shlobj_undoc.h
+++ b/sdk/include/reactos/shlobj_undoc.h
@@ -354,7 +354,7 @@ DECLARE_INTERFACE_(IAddressEditBox, IUnknown)
 	STDMETHOD_(ULONG,Release)(THIS) PURE;
 	 /*** IAddressEditBox ***/
 	STDMETHOD(Init)(THIS_ HWND comboboxEx, HWND editControl, long param14, IUnknown *param18) PURE;
-	STDMETHOD(SetCurrentDir)(THIS_ long paramC) PURE;
+	STDMETHOD(SetCurrentDir)(THIS_ PCWSTR pszPath) PURE;
 	STDMETHOD(ParseNow)(THIS_ long paramC) PURE;
 	STDMETHOD(Execute)(THIS_ long paramC) PURE;
 	STDMETHOD(Save)(THIS_ long paramC) PURE;


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-19704](https://jira.reactos.org/browse/CORE-19704)

## Proposed changes

- Rename and retype `pidlLastParsed` as `CComHeapPtr<ITEMIDLIST_ABSOLUTE> m_pidlLastParsed`.
- Implement `CAddressEditBox::SetCurrentDir` method.
- Simplify `CAddressEditBox::ParseNow` method.
- Modify `IAddressEditBox` interface.