### PR TITLE
[SHELL32_APITEST] Add PathProcessCommand testcase

### DIFF
--- a/modules/rostests/apitests/shell32/CMakeLists.txt
+++ b/modules/rostests/apitests/shell32/CMakeLists.txt
@@ -25,6 +25,7 @@ list(APPEND SOURCE
     PathIsEqualOrSubFolder.cpp
     PathIsTemporary.cpp
     PathMakeUniqueName.cpp
+    PathProcessCommand.cpp
     PathResolve.cpp
     RealShellExecuteEx.cpp
     SHAppBarMessage.cpp

--- a/modules/rostests/apitests/shell32/PathProcessCommand.cpp
+++ b/modules/rostests/apitests/shell32/PathProcessCommand.cpp
@@ -104,8 +104,10 @@ START_TEST(PathProcessCommand)
     s_PathProcessCommand = (FN_PathProcessCommand)
         GetProcAddress(GetModuleHandleW(L"shell32"), "PathProcessCommand");
     if (!s_PathProcessCommand)
+    {
         s_PathProcessCommand = (FN_PathProcessCommand)
             GetProcAddress(GetModuleHandleW(L"shell32"), MAKEINTRESOURCEA(653));
+    }
     if (!s_PathProcessCommand)
     {
         skip("PathProcessCommand not found\n");

--- a/modules/rostests/apitests/shell32/PathProcessCommand.cpp
+++ b/modules/rostests/apitests/shell32/PathProcessCommand.cpp
@@ -23,6 +23,7 @@ Test_PathProcessCommand(void)
     FILE *fout;
     WCHAR szCurDir[MAX_PATH];
     WCHAR szFull1[MAX_PATH], szFull2[MAX_PATH], szFull3[MAX_PATH], szFull4[MAX_PATH];
+    WCHAR szFull5[MAX_PATH];
 
     fout = _wfopen(L"_Test.exe", L"wb");
     fclose(fout);
@@ -35,11 +36,15 @@ Test_PathProcessCommand(void)
     lstrcpynW(szFull1, szCurDir, _countof(szFull1));
     lstrcpynW(szFull2, szCurDir, _countof(szFull2));
     lstrcpynW(szFull4, szCurDir, _countof(szFull4));
+    lstrcpynW(szFull5, szCurDir, _countof(szFull5));
 
     lstrcatW(szFull1, L"\\_Test.exe");
     lstrcatW(szFull2, L"\\test with spaces.exe");
     wsprintfW(szFull3, L"\"%s\"", szFull2);
     lstrcatW(szFull4, L"\\_Test.exe arg1 arg2");
+    lstrcatW(szFull5, L"\\_TestDir.exe");
+
+    CreateDirectoryW(L"_TestDir.exe", NULL);
 
     // Test case 1: Basic functionality (no flags)
     lstrcpynW(buffer, L"<>", _countof(buffer));
@@ -93,6 +98,19 @@ Test_PathProcessCommand(void)
     ok_int(result, lstrlenW(szFull1) + 1);
     ok_wstri(buffer, szFull1);
 
+    // Test case 9: No directories
+    lstrcpynW(buffer, L"<>", _countof(buffer));
+    result = s_PathProcessCommand(L"_TestDir.exe", buffer, _countof(buffer), PPCF_NODIRECTORIES);
+    ok_int(result, -1);
+    ok_wstri(buffer, L"<>");
+
+    // Test case 10: With directories
+    lstrcpynW(buffer, L"<>", _countof(buffer));
+    result = s_PathProcessCommand(L"_TestDir.exe", buffer, _countof(buffer), 0);
+    ok_int(result, lstrlenW(szFull5) + 1);
+    ok_wstri(buffer, szFull5);
+
+    RemoveDirectoryW(L"_TestDir.exe");
     DeleteFileW(L"_Test.exe");
     DeleteFileW(L"test with spaces.exe");
 }

--- a/modules/rostests/apitests/shell32/PathProcessCommand.cpp
+++ b/modules/rostests/apitests/shell32/PathProcessCommand.cpp
@@ -1,0 +1,124 @@
+/*
+ * PROJECT:     ReactOS API tests
+ * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
+ * PURPOSE:     Tests for PathProcessCommand
+ * COPYRIGHT:   Copyright 2025 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
+ */
+
+#include "shelltest.h"
+#include <stdio.h>
+
+#define ok_wstri(x, y) \
+    ok(_wcsicmp(x, y) == 0, "Wrong string. Expected '%S', got '%S'\n", y, x)
+
+typedef LONG (WINAPI *FN_PathProcessCommand)(LPCWSTR, LPWSTR, INT, DWORD);
+
+static FN_PathProcessCommand s_PathProcessCommand = NULL;
+
+static void
+Test_PathProcessCommand(void)
+{
+    WCHAR buffer[MAX_PATH], szCalcExe[MAX_PATH];
+    LONG result;
+    FILE *fout;
+    WCHAR szCurDir[MAX_PATH];
+    WCHAR szFull1[MAX_PATH], szFull2[MAX_PATH], szFull3[MAX_PATH], szFull4[MAX_PATH];
+
+    fout = _wfopen(L"_Test.exe", L"wb");
+    fclose(fout);
+    fout = _wfopen(L"test with spaces.exe", L"wb");
+    fclose(fout);
+
+    GetFullPathNameW(L".", _countof(szCurDir), szCurDir, NULL);
+    GetShortPathNameW(szCurDir, szCurDir, _countof(szCurDir));
+
+    lstrcpynW(szFull1, szCurDir, _countof(szFull1));
+    lstrcpynW(szFull2, szCurDir, _countof(szFull2));
+    lstrcpynW(szFull4, szCurDir, _countof(szFull4));
+
+    lstrcatW(szFull1, L"\\_Test.exe");
+    lstrcatW(szFull2, L"\\test with spaces.exe");
+    wsprintfW(szFull3, L"\"%s\"", szFull2);
+    lstrcatW(szFull4, L"\\_Test.exe arg1 arg2");
+
+    // Test case 1: Basic functionality (no flags)
+    lstrcpynW(buffer, L"<>", _countof(buffer));
+    result = s_PathProcessCommand(L"_Test", buffer, _countof(buffer), 0);
+    ok_int(result, lstrlenW(szFull1) + 1);
+    ok_wstri(buffer, szFull1);
+
+    // Test case 2: Quoted path
+    lstrcpynW(buffer, L"<>", _countof(buffer));
+    result = s_PathProcessCommand(L"\"test with spaces\"", buffer, _countof(buffer), 0);
+    ok_int(result, lstrlenW(szFull2) + 1);
+    ok_wstri(buffer, szFull2);
+
+    // Test case 3: Add quotes flag
+    lstrcpynW(buffer, L"<>", _countof(buffer));
+    result = s_PathProcessCommand(L"test with spaces", buffer, _countof(buffer), PPCF_ADDQUOTES);
+    ok_int(result, lstrlenW(szFull3) + 1);
+    ok_wstri(buffer, szFull3);
+
+    // Test case 4: Add arguments flag
+    lstrcpynW(buffer, L"<>", _countof(buffer));
+    result = s_PathProcessCommand(L"_Test arg1 arg2", buffer, _countof(buffer), PPCF_ADDARGUMENTS);
+    ok_int(result, lstrlenW(szFull4) + 1);
+    ok_wstri(buffer, szFull4);
+
+    // calc.exe
+    GetSystemDirectoryW(szCalcExe, _countof(szCalcExe));
+    PathAppendW(szCalcExe, L"calc.exe");
+
+    // Test case 5: Longest possible flag
+    lstrcpynW(buffer, L"<>", _countof(buffer));
+    result = s_PathProcessCommand(szCalcExe, buffer, _countof(buffer), PPCF_LONGESTPOSSIBLE);
+    ok_int(result, lstrlenW(szCalcExe) + 1);
+    ok_wstri(buffer, szCalcExe);
+
+    // Test case 6: Buffer too small
+    lstrcpynW(buffer, L"<>", _countof(buffer));
+    result = s_PathProcessCommand(L"_Test.exe", buffer, 5, 0);
+    ok_int(result, -1);
+    ok_wstri(buffer, L"<>");
+
+    // Test case 7: Null input path
+    lstrcpynW(buffer, L"<>", _countof(buffer));
+    result = s_PathProcessCommand(NULL, buffer, _countof(buffer), 0);
+    ok_int(result, -1);
+    ok_wstri(buffer, L"<>");
+
+    // Test case 8: Relative path resolution
+    lstrcpynW(buffer, L"<>", _countof(buffer));
+    result = s_PathProcessCommand(L"_Test.exe", buffer, _countof(buffer), PPCF_FORCEQUALIFY);
+    ok_int(result, lstrlenW(szFull1) + 1);
+    ok_wstri(buffer, szFull1);
+
+    DeleteFileW(L"_Test.exe");
+    DeleteFileW(L"test with spaces.exe");
+}
+
+START_TEST(PathProcessCommand)
+{
+    WCHAR szCurDir[MAX_PATH], szTempDir[MAX_PATH];
+
+    s_PathProcessCommand = (FN_PathProcessCommand)
+        GetProcAddress(GetModuleHandleW(L"shell32"), "PathProcessCommand");
+    if (!s_PathProcessCommand)
+        s_PathProcessCommand = (FN_PathProcessCommand)
+            GetProcAddress(GetModuleHandleW(L"shell32"), MAKEINTRESOURCEA(653));
+    if (!s_PathProcessCommand)
+    {
+        skip("PathProcessCommand not found\n");
+        return;
+    }
+
+    GetCurrentDirectoryW(_countof(szCurDir), szCurDir);
+    GetEnvironmentVariableW(L"TEMP", szTempDir, _countof(szTempDir));
+    SetCurrentDirectoryW(szTempDir);
+
+    SetEnvironmentVariableW(L"PATH", szTempDir);
+
+    Test_PathProcessCommand();
+
+    SetCurrentDirectoryW(szCurDir);
+}

--- a/modules/rostests/apitests/shell32/testlist.c
+++ b/modules/rostests/apitests/shell32/testlist.c
@@ -27,6 +27,7 @@ extern void func_OpenAs_RunDLL(void);
 extern void func_PathIsEqualOrSubFolder(void);
 extern void func_PathIsTemporary(void);
 extern void func_PathMakeUniqueName(void);
+extern void func_PathProcessCommand(void);
 extern void func_PathResolve(void);
 extern void func_PIDL(void);
 extern void func_RealShellExecuteEx(void);
@@ -84,6 +85,7 @@ const struct test winetest_testlist[] =
     { "PathIsEqualOrSubFolder", func_PathIsEqualOrSubFolder },
     { "PathIsTemporary", func_PathIsTemporary },
     { "PathMakeUniqueName", func_PathMakeUniqueName },
+    { "PathProcessCommand", func_PathProcessCommand },
     { "PathResolve", func_PathResolve },
     { "PIDL", func_PIDL },
     { "RealShellExecuteEx", func_RealShellExecuteEx },


### PR DESCRIPTION
## Purpose
Implementing `shell32!PathProcessCommand` function.
JIRA issue: [CORE-17659](https://jira.reactos.org/browse/CORE-17659)

## Comparison

WinXP:
![WinXP](https://github.com/user-attachments/assets/6e8338b9-a2ed-4cc0-b925-dfd301d2c9bf)
Successful.

Win2k3:
![Win2k3](https://github.com/user-attachments/assets/247e1678-0afb-4cc3-b7a2-94f0e846ef80)
Successful.

Win10 x64:
![Win10](https://github.com/user-attachments/assets/b9031b9b-37a8-4f22-949b-3457d9055c71)
Skipped.

ReactOS:
![before](https://github.com/user-attachments/assets/88210d22-2b4c-44f9-874c-dead5f81fa88)
`PathProcessCommand` is not implemented yet.