### PR TITLE
[SDK] Improve definition of (RTL_)CRITICAL_SECTION_DEBUG

### DIFF
--- a/dll/win32/kernel32/wine/profile.c
+++ b/dll/win32/kernel32/wine/profile.c
@@ -103,7 +103,7 @@ static RTL_CRITICAL_SECTION_DEBUG critsect_debug =
 {
     0, 0, &PROFILE_CritSect,
     { &critsect_debug.ProcessLocksList, &critsect_debug.ProcessLocksList },
-      0, 0, 0
+      0, 0, { 0 }
 };
 static RTL_CRITICAL_SECTION PROFILE_CritSect = { &critsect_debug, -1, 0, 0, 0, 0 };
 

--- a/dll/win32/kernel32/winnls/string/lcformat.c
+++ b/dll/win32/kernel32/winnls/string/lcformat.c
@@ -126,11 +126,7 @@ static CRITICAL_SECTION_DEBUG NLS_FormatsCS_debug =
     0, 0, &NLS_FormatsCS,
     { &NLS_FormatsCS_debug.ProcessLocksList,
       &NLS_FormatsCS_debug.ProcessLocksList },
-#ifdef __REACTOS__
-      0, 0, 0
-#else
       0, 0, { (DWORD_PTR)(__FILE__ ": NLS_Formats") }
-#endif
 };
 static CRITICAL_SECTION NLS_FormatsCS = { &NLS_FormatsCS_debug, -1, 0, 0, 0, 0 };
 

--- a/sdk/include/ndk/rtltypes.h
+++ b/sdk/include/ndk/rtltypes.h
@@ -1423,8 +1423,24 @@ typedef struct _RTL_CRITICAL_SECTION_DEBUG
     LIST_ENTRY ProcessLocksList;
     ULONG EntryCount;
     ULONG ContentionCount;
-    ULONG Spare[2];
+    union
+    {
+        ULONG_PTR WineDebugString;
+        ULONG_PTR Spare[1];
+        struct
+        {
+            ULONG Flags;
+            USHORT CreatorBackTraceIndexHigh;
+            USHORT SpareWORD;
+        };
+    };
 } RTL_CRITICAL_SECTION_DEBUG, *PRTL_CRITICAL_SECTION_DEBUG, RTL_RESOURCE_DEBUG, *PRTL_RESOURCE_DEBUG;
+
+#ifdef _WIN64
+C_ASSERT(sizeof(RTL_CRITICAL_SECTION_DEBUG) == 0x30);
+#else
+C_ASSERT(sizeof(RTL_CRITICAL_SECTION_DEBUG) == 0x20);
+#endif
 
 typedef struct _RTL_CRITICAL_SECTION
 {

--- a/sdk/include/psdk/winbase.h
+++ b/sdk/include/psdk/winbase.h
@@ -908,11 +908,17 @@ typedef struct _CRITICAL_SECTION_DEBUG {
 	LIST_ENTRY ProcessLocksList;
 	DWORD EntryCount;
 	DWORD ContentionCount;
-//#ifdef __WINESRC__ //not all wine code is marked so
-	DWORD_PTR Spare[8/sizeof(DWORD_PTR)];/* in Wine they store a string here */
-//#else
-	//WORD SpareWORD;
-//#endif
+    union
+    {
+        DWORD_PTR WineDebugString;
+        DWORD_PTR Spare[1];
+        struct
+        {
+            DWORD Flags;
+            WORD CreatorBackTraceIndexHigh;
+            WORD SpareWORD;
+        };
+    };
 } CRITICAL_SECTION_DEBUG,*PCRITICAL_SECTION_DEBUG,*LPCRITICAL_SECTION_DEBUG;
 
 typedef struct _CRITICAL_SECTION {

--- a/sdk/include/xdk/winnt_old.h
+++ b/sdk/include/xdk/winnt_old.h
@@ -2791,9 +2791,17 @@ typedef struct _RTL_CRITICAL_SECTION_DEBUG {
   LIST_ENTRY ProcessLocksList;
   DWORD EntryCount;
   DWORD ContentionCount;
-  DWORD Flags;
-  WORD CreatorBackTraceIndexHigh;
-  WORD SpareWORD;
+  union
+  {
+    DWORD_PTR WineDebugString;
+    DWORD_PTR Spare[1];
+    struct
+    {
+      DWORD Flags;
+      WORD CreatorBackTraceIndexHigh;
+      WORD SpareWORD;
+    };
+  };
 } RTL_CRITICAL_SECTION_DEBUG, *PRTL_CRITICAL_SECTION_DEBUG, RTL_RESOURCE_DEBUG, *PRTL_RESOURCE_DEBUG;
 
 #include "pshpack8.h"


### PR DESCRIPTION
## Purpose

Improved definition that is compatible with wine hacks.

## Testbot runs (Filled in by Devs)

- ✅ KVM x86: https://reactos.org/testman/compare.php?ids=101167,101169,101171,101183
- ✅ KVM x64: https://reactos.org/testman/compare.php?ids=101172,101173,101174,101184