### PR TITLE
[ROSAUTOTEST] Allow rosautotest to be in the same directory as its files and show its duration at the end.

### DIFF
--- a/modules/rostests/rosautotest/CWineTest.cpp
+++ b/modules/rostests/rosautotest/CWineTest.cpp
@@ -64,11 +64,27 @@ CWineTest::GetNextFile()
     WIN32_FIND_DATAW fd;
 
     /* Did we already begin searching for files? */
-    if(m_hFind)
+    if (m_hFind)
     {
         /* Then get the next file (if any) */
-        if(FindNextFileW(m_hFind, &fd))
-            FoundFile = true;
+        if (FindNextFileW(m_hFind, &fd))
+        {
+            // printf("cFileName is '%S'.\n", fd.cFileName);
+            /* if it was NOT rosautotest.exe then proceed as normal */
+            if (wcsicmp(fd.cFileName, TestName) != 0)
+            {
+                FoundFile = true;
+            }
+            else
+            {
+                /* It was rosautotest.exe so get the next file (if any) */
+                if (FindNextFileW(m_hFind, &fd))
+                {
+                    FoundFile = true;
+                }
+                // printf("cFileName is '%S'.\n", fd.cFileName);
+            }
+        }
     }
     else
     {
@@ -91,8 +107,25 @@ CWineTest::GetNextFile()
         /* Search for the first file and check whether we got one */
         m_hFind = FindFirstFileW(FindPath.c_str(), &fd);
 
-        if(m_hFind != INVALID_HANDLE_VALUE)
-            FoundFile = true;
+        /* If we returned a good handle */
+        if (m_hFind != INVALID_HANDLE_VALUE)
+        {
+            // printf("cFileName is '%S'.\n", fd.cFileName);
+            /* if it was NOT rosautotest.exe then proceed as normal */
+            if (wcsicmp(fd.cFileName, TestName) != 0)
+            {
+                FoundFile = true;
+            }
+            else
+            {
+                /* It was rosautotest.exe so get the next file (if any) */
+                if (FindNextFileW(m_hFind, &fd))
+                {
+                    FoundFile = true;
+                }
+                // printf("cFileName is '%S'.\n", fd.cFileName);
+            }
+        }
     }
 
     if(FoundFile)

--- a/modules/rostests/rosautotest/CWineTest.cpp
+++ b/modules/rostests/rosautotest/CWineTest.cpp
@@ -111,7 +111,7 @@ CWineTest::GetNextFile()
         if (m_hFind != INVALID_HANDLE_VALUE)
         {
             // printf("cFileName is '%S'.\n", fd.cFileName);
-            /* if it was NOT rosautotest.exe then proceed as normal */
+            /* If it was NOT rosautotest.exe then proceed as normal */
             if (wcsicmp(fd.cFileName, TestName) != 0)
             {
                 FoundFile = true;

--- a/modules/rostests/rosautotest/CWineTest.cpp
+++ b/modules/rostests/rosautotest/CWineTest.cpp
@@ -71,7 +71,7 @@ CWineTest::GetNextFile()
         {
             // printf("cFileName is '%S'.\n", fd.cFileName);
             /* If it was NOT rosautotest.exe then proceed as normal */
-            if (wcsicmp(fd.cFileName, TestName) != 0)
+            if (_wcsicmp(fd.cFileName, TestName) != 0)
             {
                 FoundFile = true;
             }

--- a/modules/rostests/rosautotest/CWineTest.cpp
+++ b/modules/rostests/rosautotest/CWineTest.cpp
@@ -112,7 +112,7 @@ CWineTest::GetNextFile()
         {
             // printf("cFileName is '%S'.\n", fd.cFileName);
             /* If it was NOT rosautotest.exe then proceed as normal */
-            if (wcsicmp(fd.cFileName, TestName) != 0)
+            if (_wcsicmp(fd.cFileName, TestName) != 0)
             {
                 FoundFile = true;
             }

--- a/modules/rostests/rosautotest/CWineTest.cpp
+++ b/modules/rostests/rosautotest/CWineTest.cpp
@@ -70,7 +70,7 @@ CWineTest::GetNextFile()
         if (FindNextFileW(m_hFind, &fd))
         {
             // printf("cFileName is '%S'.\n", fd.cFileName);
-            /* if it was NOT rosautotest.exe then proceed as normal */
+            /* If it was NOT rosautotest.exe then proceed as normal */
             if (wcsicmp(fd.cFileName, TestName) != 0)
             {
                 FoundFile = true;

--- a/modules/rostests/rosautotest/main.cpp
+++ b/modules/rostests/rosautotest/main.cpp
@@ -9,6 +9,8 @@
 #include <cstdio>
 #include <ndk/setypes.h>
 #include <ndk/exfuncs.h>
+#include <strsafe.h>
+WCHAR TestName[MAX_PATH];
 
 CConfiguration Configuration;
 
@@ -87,6 +89,12 @@ extern "C" int
 wmain(int argc, wchar_t* argv[])
 {
     int ReturnValue = 1;
+    DWORD TestStartTime, TestEndTime;
+
+    GetModuleFileNameW(NULL, TestName, _countof(TestName));
+    WCHAR* Name = wcsrchr(TestName, '\\');
+    Name++;
+    StringCchCopyW(TestName, _countof(TestName), Name);
 
     SetNtGlobalFlags();
 
@@ -99,6 +107,7 @@ wmain(int argc, wchar_t* argv[])
         Configuration.GetSystemInformation();
         Configuration.GetConfigurationFromFile();
 
+        TestStartTime = GetTickCount();
         ss << endl
            << endl
            << "[ROSAUTOTEST] System uptime " << setprecision(2) << fixed;
@@ -138,6 +147,23 @@ wmain(int argc, wchar_t* argv[])
             }
             WineTest.Run();
         }
+
+        /* Clear the stringstream */
+        ss.str("");
+        ss.clear();
+
+        /* Show the beginning time again */
+        ss << "[ROSAUTOTEST] System uptime at start was " << setprecision(2) << fixed;
+        ss << ((float)TestStartTime / 1000) << " seconds" << endl;
+
+        /* Show the time now so that we can see how long the tests took */
+        TestEndTime = GetTickCount();
+        ss << endl
+           << "[ROSAUTOTEST] System uptime at end was " << setprecision(2) << fixed;
+        ss << ((float)TestEndTime / 1000) << " seconds" << endl;
+        ss << "[ROSAUTOTEST] Duration was " << (((float)TestEndTime / 1000) - ((float)TestStartTime / 1000)) / 60;
+        ss << " minutes" << endl;
+        StringOut(ss.str());
 
         /* For sysreg2 */
         DbgPrint("SYSREG_CHECKPOINT:THIRDBOOT_COMPLETE\n");

--- a/modules/rostests/rosautotest/main.cpp
+++ b/modules/rostests/rosautotest/main.cpp
@@ -95,8 +95,7 @@ wmain(int argc, wchar_t* argv[])
 //    printf("Full TestName is '%S'\n", TestName);
     WCHAR* Name = wcsrchr(TestName, '\\');
     if (Name)
-        Name++;
-    memmove(TestName, Name, _countof(TestName) * sizeof(WCHAR));
+        memmove(TestName, Name + 1, _countof(TestName) * sizeof(WCHAR));
 //    printf("Short TestName is '%S'.\n", TestName);
 
     SetNtGlobalFlags();

--- a/modules/rostests/rosautotest/main.cpp
+++ b/modules/rostests/rosautotest/main.cpp
@@ -9,7 +9,7 @@
 #include <cstdio>
 #include <ndk/setypes.h>
 #include <ndk/exfuncs.h>
-#include <strsafe.h>
+
 WCHAR TestName[MAX_PATH];
 
 CConfiguration Configuration;
@@ -92,9 +92,12 @@ wmain(int argc, wchar_t* argv[])
     DWORD TestStartTime, TestEndTime;
 
     GetModuleFileNameW(NULL, TestName, _countof(TestName));
+//    printf("Full TestName is '%S'\n", TestName);
     WCHAR* Name = wcsrchr(TestName, '\\');
-    Name++;
-    StringCchCopyW(TestName, _countof(TestName), Name);
+    if (Name)
+        Name++;
+    memmove(TestName, Name, _countof(TestName) * sizeof(WCHAR));
+//    printf("Short TestName is '%S'.\n", TestName);
 
     SetNtGlobalFlags();
 
@@ -161,7 +164,7 @@ wmain(int argc, wchar_t* argv[])
         ss << endl
            << "[ROSAUTOTEST] System uptime at end was " << setprecision(2) << fixed;
         ss << ((float)TestEndTime / 1000) << " seconds" << endl;
-        ss << "[ROSAUTOTEST] Duration was " << (((float)TestEndTime / 1000) - ((float)TestStartTime / 1000)) / 60;
+        ss << "[ROSAUTOTEST] Duration was " << (((float)TestEndTime - (float)TestStartTime) / 1000) / 60;
         ss << " minutes" << endl;
         StringOut(ss.str());
 

--- a/modules/rostests/rosautotest/main.cpp
+++ b/modules/rostests/rosautotest/main.cpp
@@ -95,7 +95,7 @@ wmain(int argc, wchar_t* argv[])
 //    printf("Full TestName is '%S'\n", TestName);
     WCHAR* Name = wcsrchr(TestName, '\\');
     if (Name)
-        memmove(TestName, Name + 1, _countof(TestName) * sizeof(WCHAR));
+        memmove(TestName, Name + 1, (wcslen(Name + 1) + 1) * sizeof(WCHAR));
 //    printf("Short TestName is '%S'.\n", TestName);
 
     SetNtGlobalFlags();

--- a/modules/rostests/rosautotest/precomp.h
+++ b/modules/rostests/rosautotest/precomp.h
@@ -80,4 +80,6 @@ string StringOut(const string& String, bool forcePrint = true);
 string UnicodeToAscii(PCWSTR UnicodeString);
 string UnicodeToAscii(const wstring& UnicodeString);
 
+extern WCHAR TestName[MAX_PATH];
+
 #endif /* _ROSAUTOTEST_H_ */


### PR DESCRIPTION
## rosautotest improvements

Typical results:
[ROSAUTOTEST] System uptime at start was 412412.86 seconds

[ROSAUTOTEST] System uptime at end was 412412.88 seconds
[ROSAUTOTEST] Duration was 0.00 minutes

The main reason that I created this was to allow me to be able to copy a single folder named "bin" into a downloaded ISO install of ReactOS. These have no ReactOS tests included with them. I wanted to be able to get the Regression Test results to use as a base and I originally had to merge my external "bin" folder with the new install and then copy over the rosautotest.exe file into the C:\ReactOS\system32 subdirectory. I wanted to be able to simplify this action, so the idea to make rosautotest.exe exclude itself from trying to run itself as a test was born. Also, these tests take a long time and scroll by hundreds of lines and I wanted to be able to see at the end of the tests just how long that they had taken. I created this PR so that others could benefit from my efforts.

Retry of PR #3433
KVM Testbot: https://build.reactos.org/#/builders/6/builds/37880
KVM: https://reactos.org/testman/compare.php?ids=101131,101136 LGTM
KVM_x64: https://reactos.org/testman/compare.php?ids=101174,101187