### PR TITLE
[FREELDR] Fix x64 boot on VirtualBox

### DIFF
--- a/boot/freeldr/freeldr/arch/i386/hwacpi.c
+++ b/boot/freeldr/freeldr/arch/i386/hwacpi.c
@@ -69,6 +69,14 @@ FindAcpiTable(VOID)
     return OutputPointer;
 }
 
+SIZE_T
+FindAcpiTableSize(VOID)
+{
+    /* Calculate a size large enough for this variable by getting the bytes of every descriptor. */
+    return (PcBiosMapCount * sizeof(BIOS_MEMORY_MAP)) +
+           sizeof(ACPI_BIOS_DATA) - sizeof(BIOS_MEMORY_MAP);
+}
+
 VOID
 DetectAcpiBios(PCONFIGURATION_COMPONENT_DATA SystemKey, ULONG *BusNumber)
 {
@@ -87,8 +95,7 @@ DetectAcpiBios(PCONFIGURATION_COMPONENT_DATA SystemKey, ULONG *BusNumber)
         AcpiPresent = TRUE;
 
         /* Calculate the table size */
-        TableSize = PcBiosMapCount * sizeof(BIOS_MEMORY_MAP) +
-            sizeof(ACPI_BIOS_DATA) - sizeof(BIOS_MEMORY_MAP);
+        TableSize = FindAcpiTableSize();
 
         /* Set 'Configuration Data' value */
         PartialResourceList =

--- a/boot/freeldr/freeldr/arch/uefi/uefihw.c
+++ b/boot/freeldr/freeldr/arch/uefi/uefihw.c
@@ -65,6 +65,13 @@ FindAcpiTable(VOID)
     return OutputPointer;
 }
 
+SIZE_T
+FindAcpiTableSize(VOID)
+{
+    //TODO:
+    return 0;
+}
+
 VOID
 DetectAcpiBios(PCONFIGURATION_COMPONENT_DATA SystemKey, ULONG *BusNumber)
 {

--- a/boot/freeldr/freeldr/freeldr.spec
+++ b/boot/freeldr/freeldr/freeldr.spec
@@ -109,6 +109,7 @@
 @ cdecl GetBootMgrInfo()
 @ cdecl IsAcpiPresent()
 @ cdecl FindAcpiTable()
+@ cdecl FindAcpiTableSize()
 @ cdecl LoadSettings()
 @ cdecl MachHwDetect()
 @ cdecl MachPrepareForReactOS()

--- a/boot/freeldr/freeldr/include/arch/pc/hardware.h
+++ b/boot/freeldr/freeldr/include/arch/pc/hardware.h
@@ -85,6 +85,7 @@ DetectBiosDisks(PCONFIGURATION_COMPONENT_DATA SystemKey,
 
 /* hwacpi.c */
 PVOID FindAcpiTable(VOID);
+SIZE_T FindAcpiTableSize(VOID);
 VOID DetectAcpiBios(PCONFIGURATION_COMPONENT_DATA SystemKey, ULONG *BusNumber);
 
 /* hwapm.c */

--- a/boot/freeldr/freeldr/ntldr/arch/amd64/winldr.c
+++ b/boot/freeldr/freeldr/ntldr/arch/amd64/winldr.c
@@ -204,7 +204,29 @@ MempSetupPaging(IN PFN_NUMBER StartPage,
 VOID
 MempUnmapPage(PFN_NUMBER Page)
 {
-   // TRACE(">>> MempUnmapPage\n");
+    PHARDWARE_PTE PpeBase, PdeBase, PteBase;
+    ULONG Index;
+
+    PpeBase = MempGetOrCreatePageDir(PxeBase, VAtoPXI(PaToVa((PVOID)(ULONG_PTR)(Page * PAGE_SIZE))));
+    PdeBase = MempGetOrCreatePageDir(PpeBase, VAtoPPI(PaToVa((PVOID)(ULONG_PTR)(Page * PAGE_SIZE))));
+    PteBase = MempGetOrCreatePageDir(PdeBase, VAtoPDI(PaToVa((PVOID)(ULONG_PTR)(Page * PAGE_SIZE))));
+
+    if (!PteBase)
+    {
+        ERR("!!!No Dir %p, %p, %p, %p\n", PxeBase, PpeBase, PdeBase, PteBase);
+        return;
+    }
+
+    Index = VAtoPTI(PaToVa((PVOID)(ULONG_PTR)(Page * PAGE_SIZE)));
+    if (!PteBase[Index].Valid)
+    {
+        ERR("!!!Already unmapped %ld\n", Index);
+        return;
+    }
+
+    PteBase[Index].Valid = 0;
+    PteBase[Index].Write = 0;
+    PteBase[Index].PageFrameNumber = 0;
 }
 
 static

--- a/boot/freeldr/freeldr/ntldr/winldr.c
+++ b/boot/freeldr/freeldr/ntldr/winldr.c
@@ -246,13 +246,6 @@ WinLdrInitializePhase1(PLOADER_PARAMETER_BLOCK LoaderBlock,
     /* FIXME! HACK value for docking profile */
     Extension->Profile.Status = 2;
 
-    PDESCRIPTION_HEADER AcpiTable = FindAcpiTable();
-    if (AcpiTable)
-    {
-        Extension->AcpiTable = AcpiTable;
-        Extension->AcpiTableSize = AcpiTable->Length;
-    }
-
     if (VersionToBoot >= _WIN32_WINNT_VISTA)
     {
         Extension->BootViaWinload = 1;


### PR DESCRIPTION
- (maybe?) Implement MempUnmapPage on x64
- Make a temporary mapping of the ACPITables and remove it before jumping to the kernel so we can copy it into a clone.
- Generalize FindAcpiTableSize

The reason why this is needed is because Virtualbox when the RAM is set to 1.3GB~ or above will throw the ACPI Tables above the line freeloader can access. We don't want to extend what freeloader maps and sees so this is the solution:
Allow the Kernel page tables to do the mapping for us (Which we can easily ummap from!)
## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=101171,101179
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=101174,101180