### PR TITLE
[SHELL32][SHELL32_APITEST][SDK] Support SheGetPathOffsetW

### DIFF
--- a/dll/win32/shell32/stubs.cpp
+++ b/dll/win32/shell32/stubs.cpp
@@ -262,17 +262,6 @@ SheSetCurDrive(INT iIndex)
 /*
  * Unimplemented
  */
-EXTERN_C INT
-WINAPI
-SheGetPathOffsetW(LPWSTR lpPath)
-{
-    FIXME("SheGetPathOffsetW() stub\n");
-    return 0;
-}
-
-/*
- * Unimplemented
- */
 EXTERN_C BOOL
 WINAPI
 SheGetDirExW(LPWSTR lpDrive,

--- a/dll/win32/shell32/utils.cpp
+++ b/dll/win32/shell32/utils.cpp
@@ -1835,6 +1835,33 @@ SHIsBadInterfacePtr(
 }
 
 /*************************************************************************
+ *  SheGetPathOffsetW [SHELL32.349]
+ */
+EXTERN_C INT WINAPI
+SheGetPathOffsetW(_In_ PCWSTR pszPath)
+{
+    if (!pszPath || !*pszPath)
+        return -1;
+
+    // Drive path?
+    if (pszPath[1] == L':' &&
+        (!pszPath[2] || pszPath[2] == L'\\' || pszPath[2] == L'/'))
+    {
+        return 2; // The length of "C:", "D:", etc.
+    }
+
+    if (!PathIsUNCW(pszPath)) // Not a UNC path?
+        return -1;
+
+    // "\\\\SERVER\\SharedFolder..."
+    SIZE_T ich = 2 + wcscspn(&pszPath[2], L"\\/");
+    if (!pszPath[ich])
+        return -1;
+    ich = (ich + 1) + wcscspn(&pszPath[ich + 1], L"\\/");
+    return (INT)ich;
+}
+
+/*************************************************************************
  *  SHGetUserDisplayName [SHELL32.241]
  *
  * @see https://undoc.airesoft.co.uk/shell32.dll/SHGetUserDisplayName.php

--- a/modules/rostests/apitests/shell32/CMakeLists.txt
+++ b/modules/rostests/apitests/shell32/CMakeLists.txt
@@ -41,6 +41,7 @@ list(APPEND SOURCE
     SHShouldShowWizards.cpp
     SHEnumerateUnreadMailAccountsW.cpp
     She.cpp
+    SheGetPathOffset.cpp
     ShellExec_RunDLL.cpp
     ShellExecCmdLine.cpp
     ShellExecuteEx.cpp

--- a/modules/rostests/apitests/shell32/SheGetPathOffset.cpp
+++ b/modules/rostests/apitests/shell32/SheGetPathOffset.cpp
@@ -1,0 +1,99 @@
+/*
+ * PROJECT:     ReactOS api tests
+ * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
+ * PURPOSE:     Tests for SheGetPathOffsetW
+ * COPYRIGHT:   Copyright 2025 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ */
+
+#include <shelltest.h>
+#include <undocshell.h>
+#include <versionhelpers.h>
+
+typedef INT (WINAPI *FN_SheGetPathOffsetW)(PCWSTR);
+
+static FN_SheGetPathOffsetW s_pSheGetPathOffsetW = NULL;
+
+static void
+Test_SheGetPathOffsetW(void)
+{
+    INT ret;
+
+    ret = s_pSheGetPathOffsetW(NULL);
+    ok_int(ret, -1);
+
+    ret = s_pSheGetPathOffsetW(L"");
+    ok_int(ret, -1);
+
+    ret = s_pSheGetPathOffsetW(L"C");
+    ok_int(ret, -1);
+
+    ret = s_pSheGetPathOffsetW(L"C:");
+    ok_int(ret, 2);
+    ret = s_pSheGetPathOffsetW(L"C:\\");
+    ok_int(ret, 2);
+    ret = s_pSheGetPathOffsetW(L"C:/");
+    ok_int(ret, 2);
+
+    ret = s_pSheGetPathOffsetW(L"C:Windows");
+    ok_int(ret, -1);
+    ret = s_pSheGetPathOffsetW(L"C:\\Windows");
+    ok_int(ret, 2);
+    ret = s_pSheGetPathOffsetW(L"C:/Windows");
+    ok_int(ret, 2);
+
+    ret = s_pSheGetPathOffsetW(L"\\\\SHARED");
+    ok_int(ret, -1);
+
+    ret = s_pSheGetPathOffsetW(L"\\\\SHARED\\TEST");
+    ok_int(ret, 13);
+    ret = s_pSheGetPathOffsetW(L"\\\\SHARED/TEST");
+    ok_int(ret, 13);
+
+    ret = s_pSheGetPathOffsetW(L"//SHARED\\TEST");
+    ok_int(ret, -1);
+    ret = s_pSheGetPathOffsetW(L"//SHARED/TEST/");
+    ok_int(ret, -1);
+    ret = s_pSheGetPathOffsetW(L"//SHARED/TEST/TEST");
+    ok_int(ret, -1);
+    ret = s_pSheGetPathOffsetW(L"\\\\SHARED\\TEST\\");
+    ok_int(ret, 13);
+    ret = s_pSheGetPathOffsetW(L"\\\\SHARED\\TEST/");
+    ok_int(ret, 13);
+    ret = s_pSheGetPathOffsetW(L"\\\\SHARED\\TEST\\TEST");
+    ok_int(ret, 13);
+    ret = s_pSheGetPathOffsetW(L"\\\\SHARED\\TEST/TEST");
+    ok_int(ret, 13);
+    ret = s_pSheGetPathOffsetW(L"\\\\SHARED/TEST/TEST");
+    ok_int(ret, 13);
+    ret = s_pSheGetPathOffsetW(L"\\\\SHARED/TEST\\TEST");
+    ok_int(ret, 13); 
+}
+
+START_TEST(SheGetPathOffset)
+{
+    if (IsWindowsVistaOrGreater())
+    {
+        skip("Vista+\n");
+        return;
+    }
+    if (!IsWindowsVersionOrGreater(5, 2, 0))
+    {
+        skip("XP\n");
+        return;
+    }
+
+    HINSTANCE hShell32 = GetModuleHandleW(L"shell32.dll");
+
+    s_pSheGetPathOffsetW = (FN_SheGetPathOffsetW)GetProcAddress(hShell32, MAKEINTRESOURCEA(349));
+    if (!s_pSheGetPathOffsetW)
+    {
+        s_pSheGetPathOffsetW = (FN_SheGetPathOffsetW)GetProcAddress(hShell32, "SheGetPathOffsetW");
+        if (!s_pSheGetPathOffsetW)
+        {
+            skip("SheGetPathOffsetW not found\n");
+            return;
+        }
+    }
+
+    Test_SheGetPathOffsetW();
+}

--- a/modules/rostests/apitests/shell32/testlist.c
+++ b/modules/rostests/apitests/shell32/testlist.c
@@ -39,6 +39,7 @@ extern void func_SHCreateFileExtractIconW(void);
 extern void func_SHDefExtractIcon(void);
 extern void func_SHEnumerateUnreadMailAccountsW(void);
 extern void func_She(void);
+extern void func_SheGetPathOffset(void);
 extern void func_ShellExec_RunDLL(void);
 extern void func_ShellExecCmdLine(void);
 extern void func_ShellExecuteEx(void);
@@ -97,6 +98,7 @@ const struct test winetest_testlist[] =
     { "SHDefExtractIcon", func_SHDefExtractIcon },
     { "SHEnumerateUnreadMailAccountsW", func_SHEnumerateUnreadMailAccountsW },
     { "She", func_She },
+    { "SheGetPathOffset", func_SheGetPathOffset },
     { "ShellExec_RunDLL", func_ShellExec_RunDLL },
     { "ShellExecCmdLine", func_ShellExecCmdLine },
     { "ShellExecuteEx", func_ShellExecuteEx },

--- a/sdk/include/reactos/undocshell.h
+++ b/sdk/include/reactos/undocshell.h
@@ -531,6 +531,8 @@ BOOL WINAPI PathIsEqualOrSubFolder(_In_ LPCWSTR pszFile1OrCSIDL, _In_ LPCWSTR ps
 BOOL WINAPI PathIsTemporaryA(_In_ LPCSTR Str);
 BOOL WINAPI PathIsTemporaryW(_In_ LPCWSTR Str);
 
+INT WINAPI SheGetPathOffsetW(_In_ PCWSTR pszPath);
+
 /****************************************************************************
  * Shell File Operations error codes - SHFileOperationA/W
  */


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-19278](https://jira.reactos.org/browse/CORE-19278)

## Proposed changes

- Implement `SheGetPathOffsetW` function.
- Add `SheGetPathOffsetW` prototype to `<undocshell.h>`.
- Add `SheGetPathOffset` testcase to `shell32_apitest`.

## Comparison

WinXP:
![WinXP](https://github.com/user-attachments/assets/16111c57-18e2-42c9-9508-dd1bac2d1e50)
Skipped.

Win2k3:
![Win2k3](https://github.com/user-attachments/assets/57446848-be19-439a-b26d-36885c454827)
Successful.

Win10 x64:
![Win10](https://github.com/user-attachments/assets/20bfadbf-fda4-488a-b6b3-1e0c5a40965f)
Skipped.

ReactOS (AFTER):
![after](https://github.com/user-attachments/assets/4015aa5d-19a0-46c2-803b-97416ed80ae4)
Successful.