### PR TITLE
[HAL][NTDLL_APITEST] Fix hang of ntdll:NtStartProfile test

### DIFF
--- a/hal/halx86/apic/halinit.c
+++ b/hal/halx86/apic/halinit.c
@@ -58,6 +58,14 @@ HalpInitPhase0(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
                                CLOCK2_LEVEL,
                                HalpClockInterrupt,
                                Latched);
+
+    /* Enable profile interrupt handler */
+    HalpEnableInterruptHandler(IDT_DEVICE,
+                               0,
+                               APIC_PROFILE_VECTOR,
+                               PROFILE_LEVEL,
+                               HalpProfileInterrupt,
+                               Latched);
 }
 
 VOID

--- a/modules/rostests/apitests/ntdll/NtCreateProfile.c
+++ b/modules/rostests/apitests/ntdll/NtCreateProfile.c
@@ -154,7 +154,7 @@ TestParameterValidation(void)
                                  0x80000000,
                                  ProfileTime,
                                  1);
-        ok_hex(Status, STATUS_ACCESS_VIOLATION);
+        ok_hex(Status, (sizeof(PVOID) == 8) ? STATUS_BUFFER_TOO_SMALL : STATUS_ACCESS_VIOLATION);
 
         Status = NtCreateProfile(NULL,
                                  NULL,
@@ -165,7 +165,7 @@ TestParameterValidation(void)
                                  0x80000000,
                                  ProfileTime,
                                  1);
-        ok_hex(Status, STATUS_ACCESS_VIOLATION);
+        ok_hex(Status, (sizeof(PVOID) == 8) ? STATUS_BUFFER_TOO_SMALL : STATUS_ACCESS_VIOLATION);
 
         Status = NtCreateProfile(NULL,
                                  NULL,
@@ -176,7 +176,9 @@ TestParameterValidation(void)
                                  0x80000000,
                                  ProfileTime,
                                  1);
-        ok_hex(Status, IsWow64 ? STATUS_ACCESS_VIOLATION : STATUS_BUFFER_OVERFLOW);
+        ok_hex(Status, (sizeof(PVOID) == 8) ? STATUS_BUFFER_TOO_SMALL :
+                       IsWow64 ? STATUS_ACCESS_VIOLATION : 
+                       STATUS_BUFFER_OVERFLOW);
 
         Status = NtCreateProfile(NULL,
                                  NULL,
@@ -187,7 +189,9 @@ TestParameterValidation(void)
                                  0x80000000,
                                  ProfileTime,
                                  1);
-        ok_hex(Status, IsWow64 ? STATUS_ACCESS_VIOLATION : STATUS_BUFFER_OVERFLOW);
+        ok_hex(Status, (sizeof(PVOID) == 8) ? STATUS_BUFFER_TOO_SMALL :
+                       IsWow64 ? STATUS_ACCESS_VIOLATION : 
+                       STATUS_BUFFER_OVERFLOW);
     }
 
     /* Handle is probed first and requires no alignment, buffer requires ULONG alignment */
@@ -281,34 +285,34 @@ TestBufferSizeValidation(void)
         { __LINE__,          8,  3, sizeof(ULONG),      STATUS_ACCESS_VIOLATION },
         { __LINE__,          9,  3, sizeof(ULONG),      STATUS_BUFFER_TOO_SMALL, STATUS_ACCESS_VIOLATION },
         { __LINE__,         10,  3, sizeof(ULONG),      STATUS_BUFFER_TOO_SMALL },
-                                                        
+
         { __LINE__,         16,  4, sizeof(ULONG),      STATUS_ACCESS_VIOLATION },
         { __LINE__,         17,  4, sizeof(ULONG),      STATUS_BUFFER_TOO_SMALL, STATUS_ACCESS_VIOLATION },
         { __LINE__,         18,  4, sizeof(ULONG),      STATUS_BUFFER_TOO_SMALL, STATUS_ACCESS_VIOLATION },
         { __LINE__,         19,  4, sizeof(ULONG),      STATUS_BUFFER_TOO_SMALL, STATUS_ACCESS_VIOLATION },
         { __LINE__,         20,  4, sizeof(ULONG),      STATUS_BUFFER_TOO_SMALL },
-                                                        
+
         { __LINE__,         32,  5, sizeof(ULONG),      STATUS_ACCESS_VIOLATION },
         { __LINE__,         33,  5, sizeof(ULONG),      STATUS_BUFFER_TOO_SMALL, STATUS_ACCESS_VIOLATION },
         { __LINE__,         39,  5, sizeof(ULONG),      STATUS_BUFFER_TOO_SMALL, STATUS_ACCESS_VIOLATION },
         { __LINE__,         40,  5, sizeof(ULONG),      STATUS_BUFFER_TOO_SMALL },
-                                                        
+
         { __LINE__,        256,  8, sizeof(ULONG),      STATUS_ACCESS_VIOLATION },
         { __LINE__,        257,  8, sizeof(ULONG),      STATUS_BUFFER_TOO_SMALL, STATUS_ACCESS_VIOLATION },
         { __LINE__,        319,  8, sizeof(ULONG),      STATUS_BUFFER_TOO_SMALL, STATUS_ACCESS_VIOLATION },
         { __LINE__,        320,  8, sizeof(ULONG),      STATUS_BUFFER_TOO_SMALL },
-                                                        
+
         { __LINE__,        256,  8, sizeof(ULONG),      STATUS_ACCESS_VIOLATION },
         { __LINE__,        257,  8, sizeof(ULONG),      STATUS_BUFFER_TOO_SMALL, STATUS_ACCESS_VIOLATION },
         { __LINE__,        319,  8, sizeof(ULONG),      STATUS_BUFFER_TOO_SMALL, STATUS_ACCESS_VIOLATION },
         { __LINE__,        320,  8, sizeof(ULONG),      STATUS_BUFFER_TOO_SMALL },
-                                                        
+
         { __LINE__, 0x80000000, 31, sizeof(ULONG),      STATUS_ACCESS_VIOLATION },
         { __LINE__, 0x80000001, 31, sizeof(ULONG),      STATUS_BUFFER_TOO_SMALL, STATUS_ACCESS_VIOLATION },
         { __LINE__, 0xBFFFFFFF, 31, sizeof(ULONG),      STATUS_BUFFER_TOO_SMALL, STATUS_ACCESS_VIOLATION },
         { __LINE__, 0xA0000000, 31, sizeof(ULONG),      STATUS_BUFFER_TOO_SMALL },
-                                                                   
-        /* Nothing checks against the max MDL size */              
+
+        /* Nothing checks against the max MDL size */
         { __LINE__,          3,  2, MAX_MDL_BUFFER_SIZE,           STATUS_ACCESS_VIOLATION },
         { __LINE__,          3,  2, MAX_MDL_BUFFER_SIZE + 1,       STATUS_ACCESS_VIOLATION },
         { __LINE__,          3,  2, (MAX_MDL_BUFFER_SIZE + 1) * 2, STATUS_ACCESS_VIOLATION },


### PR DESCRIPTION
## Purpose

Fix hang and reboot on x64 on NtStartProfile test

## Proposed changes

- [HAL/APIC] Set the profiling interrupt handler
- [NTDLL_APITEST] Fix NtCreateProfile tests for x64

## Testbot runs (Filled in by Devs)

- [ ] KVM x86: https://reactos.org/testman/compare.php?ids=101186,101194,101196,101200
- [ ] KVM x64: https://reactos.org/testman/compare.php?ids=101188,101195,101197,101201
- [ ] Test WHS: https://reactos.org/testman/compare.php?ids=101165,101207
- [ ] Test Win2003_x64: tbd