### PR TITLE
[CLEANMGR] Only allow one instance per drive

### DIFF
--- a/base/applications/cleanmgr/cleanmgr/CSelectDriveDlg.cpp
+++ b/base/applications/cleanmgr/cleanmgr/CSelectDriveDlg.cpp
@@ -25,6 +25,19 @@ public:
 
     LRESULT OnInitDialog(UINT, WPARAM, LPARAM, BOOL&)
     {
+        // Try to find an existing instance of this dialog
+        WCHAR buf[300];
+        GetWindowTextW(buf, _countof(buf));
+        for (HWND hNext = NULL, hFind; (hFind = ::FindWindowExW(NULL, hNext, NULL, buf)) != NULL; hNext = hFind)
+        {
+            if (hFind != *this && ::IsWindowVisible(hFind))
+            {
+                ::SetForegroundWindow(hFind);
+                EndDialog(IDCANCEL);
+                return FALSE;
+            }
+        }
+
         CWindow cbo = GetDlgItem(IDC_DRIVES);
         WCHAR VolumeNameBuffer[MAX_PATH + 1];
         CStringW Tmp;


### PR DESCRIPTION
Notes:
- It has to use `EnumWindows` to find the other instance window to activate because we don't know if it's in the ScanDrive stage or in PropertySheet.