### PR TITLE
[NTGDI][GDI32] AddFontResource: Support multiple files

### DIFF
--- a/win32ss/gdi/eng/stubs.c
+++ b/win32ss/gdi/eng/stubs.c
@@ -1184,23 +1184,6 @@ NtGdiGetStringBitmapW(
  */
 BOOL
 APIENTRY
-NtGdiRemoveFontResourceW(
-    IN WCHAR *pwszFiles,
-    IN ULONG cwc,
-    IN ULONG cFiles,
-    IN ULONG fl,
-    IN DWORD dwPidTid,
-    IN OPTIONAL DESIGNVECTOR *pdv)
-{
-    UNIMPLEMENTED;
-    return FALSE;
-}
-
-/*
- * @unimplemented
- */
-BOOL
-APIENTRY
 NtGdiPolyTextOutW(
     IN HDC hdc,
     IN POLYTEXTW *pptw,

--- a/win32ss/gdi/gdi32/include/gdi32p.h
+++ b/win32ss/gdi/gdi32/include/gdi32p.h
@@ -208,18 +208,33 @@ typedef DWORD (WINAPI *QUERYREMOTEFONTS) (DWORD,DWORD,DWORD);
 
 extern CLOSEPRINTER fpClosePrinter;
 extern OPENPRINTERW fpOpenPrinterW;
+extern HANDLE hProcessHeap;
 
 /* FUNCTIONS *****************************************************************/
 
-PVOID FASTCALL HEAP_alloc(SIZE_T len);
-VOID FASTCALL HEAP_free(LPVOID memory);
-NTSTATUS HEAP_strdupA2W(OUT LPWSTR* ppszW, IN LPCSTR lpszA);
+static inline PVOID FASTCALL
+HEAP_alloc(SIZE_T len)
+{
+    /* make sure hProcessHeap gets initialized by GdiProcessSetup before we get here */
+    ASSERT(hProcessHeap);
+    return RtlAllocateHeap(hProcessHeap, 0, len);
+}
+
+static inline VOID FASTCALL
+HEAP_free(LPVOID memory)
+{
+    /* make sure hProcessHeap gets initialized by GdiProcessSetup before we get here */
+    ASSERT(hProcessHeap);
+    RtlFreeHeap(hProcessHeap, 0, memory);
+}
+
+NTSTATUS FASTCALL HEAP_strdupA2W(OUT LPWSTR* ppszW, IN LPCSTR lpszA);
 
 /* Buffered Ansi-to-Wide conversion */
 LPWSTR FASTCALL HEAP_strdupA2W_buf(IN LPCSTR lpszA, OUT LPWSTR pszBuff, IN SIZE_T cchBuff);
 
 /* Free memory allocated by HEAP_strdupA2W_buf */
-inline VOID FASTCALL
+static inline VOID FASTCALL
 HEAP_strdupA2W_buf_free(LPWSTR pszW, LPWSTR pszBuff)
 {
     if (pszW && pszW != pszBuff)

--- a/win32ss/gdi/gdi32/include/gdi32p.h
+++ b/win32ss/gdi/gdi32/include/gdi32p.h
@@ -229,7 +229,7 @@ HEAP_free(LPVOID memory)
 NTSTATUS FASTCALL
 HEAP_strdupA2W(OUT LPWSTR* ppszW, IN LPCSTR lpszA);
 
-/* Buffered Ansi-to-Wide conversion */
+/* Buffered string conversion (quicker) */
 PWSTR FASTCALL
 HEAP_strdupA2W_buf(IN PCSTR lpszA, OUT PWSTR pszBuff, IN SIZE_T cchBuff);
 

--- a/win32ss/gdi/gdi32/include/gdi32p.h
+++ b/win32ss/gdi/gdi32/include/gdi32p.h
@@ -228,10 +228,12 @@ HEAP_free(LPVOID memory)
     RtlFreeHeap(hProcessHeap, 0, memory);
 }
 
-NTSTATUS FASTCALL HEAP_strdupA2W(OUT LPWSTR* ppszW, IN LPCSTR lpszA);
+NTSTATUS FASTCALL
+HEAP_strdupA2W(OUT LPWSTR* ppszW, IN LPCSTR lpszA);
 
 /* Buffered Ansi-to-Wide conversion */
-LPWSTR FASTCALL HEAP_strdupA2W_buf(IN LPCSTR lpszA, OUT LPWSTR pszBuff, IN SIZE_T cchBuff);
+LPWSTR FASTCALL
+HEAP_strdupA2W_buf(IN LPCSTR lpszA, OUT LPWSTR pszBuff, IN SIZE_T cchBuff);
 
 /* Free memory allocated by HEAP_strdupA2W_buf */
 static inline VOID FASTCALL

--- a/win32ss/gdi/gdi32/include/gdi32p.h
+++ b/win32ss/gdi/gdi32/include/gdi32p.h
@@ -211,17 +211,20 @@ extern OPENPRINTERW fpOpenPrinterW;
 
 /* FUNCTIONS *****************************************************************/
 
-PVOID
-HEAP_alloc(DWORD len);
+PVOID FASTCALL HEAP_alloc(SIZE_T len);
+VOID FASTCALL HEAP_free(LPVOID memory);
+NTSTATUS HEAP_strdupA2W(OUT LPWSTR* ppszW, IN LPCSTR lpszA);
 
-NTSTATUS
-HEAP_strdupA2W(
-    LPWSTR* ppszW,
-    LPCSTR lpszA
-);
+/* Buffered Ansi-to-Wide conversion */
+LPWSTR FASTCALL HEAP_strdupA2W_buf(IN LPCSTR lpszA, OUT LPWSTR pszBuff, IN SIZE_T cchBuff);
 
-VOID
-HEAP_free(LPVOID memory);
+/* Free memory allocated by HEAP_strdupA2W_buf */
+inline VOID FASTCALL
+HEAP_strdupA2W_buf_free(LPWSTR pszW, LPWSTR pszBuff)
+{
+    if (pszW && pszW != pszBuff)
+        HEAP_free(pszW);
+}
 
 VOID
 FASTCALL

--- a/win32ss/gdi/gdi32/include/gdi32p.h
+++ b/win32ss/gdi/gdi32/include/gdi32p.h
@@ -234,7 +234,10 @@ HEAP_strdupA2W(_Outptr_ PWSTR* ppszW, _In_ PCSTR lpszA);
 
 /* Buffered string conversion (quicker) */
 PWSTR FASTCALL
-HEAP_strdupA2W_buf(_In_ PCSTR lpszA, _Out_ PWSTR pszStaticBuff, _In_ SIZE_T cchStaticBuff);
+HEAP_strdupA2W_buf(
+    _In_ PCSTR lpszA,
+    _In_ PWSTR pszStaticBuff,
+    _In_ SIZE_T cchStaticBuff);
 
 /* Free memory allocated by HEAP_strdupA2W_buf */
 static inline VOID FASTCALL

--- a/win32ss/gdi/gdi32/include/gdi32p.h
+++ b/win32ss/gdi/gdi32/include/gdi32p.h
@@ -215,16 +215,14 @@ extern HANDLE hProcessHeap;
 static inline PVOID FASTCALL
 HEAP_alloc(SIZE_T len)
 {
-    /* make sure hProcessHeap gets initialized by GdiProcessSetup before we get here */
-    ASSERT(hProcessHeap);
+    ASSERT(hProcessHeap); /* Make sure hProcessHeap gets initialized */
     return RtlAllocateHeap(hProcessHeap, 0, len);
 }
 
 static inline VOID FASTCALL
 HEAP_free(LPVOID memory)
 {
-    /* make sure hProcessHeap gets initialized by GdiProcessSetup before we get here */
-    ASSERT(hProcessHeap);
+    ASSERT(hProcessHeap); /* Make sure hProcessHeap gets initialized */
     RtlFreeHeap(hProcessHeap, 0, memory);
 }
 

--- a/win32ss/gdi/gdi32/include/gdi32p.h
+++ b/win32ss/gdi/gdi32/include/gdi32p.h
@@ -232,8 +232,8 @@ NTSTATUS FASTCALL
 HEAP_strdupA2W(OUT LPWSTR* ppszW, IN LPCSTR lpszA);
 
 /* Buffered Ansi-to-Wide conversion */
-LPWSTR FASTCALL
-HEAP_strdupA2W_buf(IN LPCSTR lpszA, OUT LPWSTR pszBuff, IN SIZE_T cchBuff);
+PWSTR FASTCALL
+HEAP_strdupA2W_buf(IN PCSTR lpszA, OUT PWSTR pszBuff, IN SIZE_T cchBuff);
 
 /* Free memory allocated by HEAP_strdupA2W_buf */
 static inline VOID FASTCALL

--- a/win32ss/gdi/gdi32/include/gdi32p.h
+++ b/win32ss/gdi/gdi32/include/gdi32p.h
@@ -212,33 +212,38 @@ extern HANDLE hProcessHeap;
 
 /* FUNCTIONS *****************************************************************/
 
-static inline PVOID FASTCALL
-HEAP_alloc(SIZE_T len)
+static inline
+_Ret_maybenull_
+__drv_allocatesMem(Mem)
+PVOID FASTCALL
+HEAP_alloc(_In_ SIZE_T len)
 {
-    ASSERT(hProcessHeap); /* Make sure hProcessHeap gets initialized */
+    ASSERT(hProcessHeap);
     return RtlAllocateHeap(hProcessHeap, 0, len);
 }
 
 static inline VOID FASTCALL
-HEAP_free(LPVOID memory)
+HEAP_free(_In_ __drv_freesMem(Mem) PVOID memory)
 {
-    ASSERT(hProcessHeap); /* Make sure hProcessHeap gets initialized */
+    ASSERT(hProcessHeap);
     RtlFreeHeap(hProcessHeap, 0, memory);
 }
 
 NTSTATUS FASTCALL
-HEAP_strdupA2W(OUT LPWSTR* ppszW, IN LPCSTR lpszA);
+HEAP_strdupA2W(_Outptr_ PWSTR* ppszW, _In_ PCSTR lpszA);
 
 /* Buffered string conversion (quicker) */
 PWSTR FASTCALL
-HEAP_strdupA2W_buf(IN PCSTR lpszA, OUT PWSTR pszBuff, IN SIZE_T cchBuff);
+HEAP_strdupA2W_buf(_In_ PCSTR lpszA, _Out_ PWSTR pszStaticBuff, _In_ SIZE_T cchStaticBuff);
 
 /* Free memory allocated by HEAP_strdupA2W_buf */
 static inline VOID FASTCALL
-HEAP_strdupA2W_buf_free(LPWSTR pszW, LPWSTR pszBuff)
+HEAP_strdupA2W_buf_free(
+    _In_opt_ PWSTR pszDynamicBuff,
+    _In_ PWSTR pszStaticBuff)
 {
-    if (pszW && pszW != pszBuff)
-        HEAP_free(pszW);
+    if (pszDynamicBuff && pszDynamicBuff != pszStaticBuff)
+        HEAP_free(pszDynamicBuff);
 }
 
 VOID

--- a/win32ss/gdi/gdi32/misc/heap.c
+++ b/win32ss/gdi/gdi32/misc/heap.c
@@ -30,9 +30,8 @@
 // global variables in a dll are process-global
 HANDLE hProcessHeap = NULL;
 
-
-PVOID
-HEAP_alloc ( DWORD len )
+PVOID FASTCALL
+HEAP_alloc(SIZE_T len)
 {
     /* make sure hProcessHeap gets initialized by GdiProcessSetup before we get here */
     assert(hProcessHeap);
@@ -58,12 +57,31 @@ HEAP_strdupA2W ( LPWSTR* ppszW, LPCSTR lpszA )
     return Status;
 }
 
-
-VOID
-HEAP_free ( LPVOID memory )
+VOID FASTCALL
+HEAP_free(LPVOID memory)
 {
     /* make sure hProcessHeap gets initialized by GdiProcessSetup before we get here */
     assert(hProcessHeap);
 
     RtlFreeHeap ( hProcessHeap, 0, memory );
+}
+
+LPWSTR FASTCALL
+HEAP_strdupA2W_buf(IN LPCSTR lpszA, OUT LPWSTR pszBuff, IN SIZE_T cchBuff)
+{
+    if (!lpszA)
+        return NULL;
+
+    LPWSTR pszW;
+    SIZE_T size = strlen(lpszA) + 1;
+    if (size < cchBuff)
+        pszW = pszBuff;
+    else
+        pszW = HEAP_alloc(size * sizeof(WCHAR));
+
+    if (!pszW)
+        return NULL;
+
+    RtlMultiByteToUnicodeN(pszW, size * sizeof(WCHAR), NULL, lpszA, size);
+    return pszW;
 }

--- a/win32ss/gdi/gdi32/misc/heap.c
+++ b/win32ss/gdi/gdi32/misc/heap.c
@@ -49,19 +49,14 @@ HEAP_strdupA2W ( LPWSTR* ppszW, LPCSTR lpszA )
     return Status;
 }
 
-LPWSTR FASTCALL
-HEAP_strdupA2W_buf(IN LPCSTR lpszA, OUT LPWSTR pszBuff, IN SIZE_T cchBuff)
+PWSTR FASTCALL
+HEAP_strdupA2W_buf(IN PCSTR lpszA, OUT PWSTR pszBuff, IN SIZE_T cchBuff)
 {
     if (!lpszA)
         return NULL;
 
-    LPWSTR pszW;
     SIZE_T size = strlen(lpszA) + 1;
-    if (size < cchBuff)
-        pszW = pszBuff;
-    else
-        pszW = HEAP_alloc(size * sizeof(WCHAR));
-
+    PWSTR pszW = (size < cchBuff) ? pszBuff : HEAP_alloc(size * sizeof(WCHAR));
     if (!pszW)
         return NULL;
 

--- a/win32ss/gdi/gdi32/misc/heap.c
+++ b/win32ss/gdi/gdi32/misc/heap.c
@@ -30,15 +30,7 @@
 // global variables in a dll are process-global
 HANDLE hProcessHeap = NULL;
 
-PVOID FASTCALL
-HEAP_alloc(SIZE_T len)
-{
-    /* make sure hProcessHeap gets initialized by GdiProcessSetup before we get here */
-    assert(hProcessHeap);
-    return RtlAllocateHeap ( hProcessHeap, 0, len );
-}
-
-NTSTATUS
+NTSTATUS FASTCALL
 HEAP_strdupA2W ( LPWSTR* ppszW, LPCSTR lpszA )
 {
     ULONG len;
@@ -53,17 +45,8 @@ HEAP_strdupA2W ( LPWSTR* ppszW, LPCSTR lpszA )
     if ( !*ppszW )
         return STATUS_NO_MEMORY;
     Status = RtlMultiByteToUnicodeN ( *ppszW, len*sizeof(WCHAR), NULL, (PCHAR)lpszA, len );
-    (*ppszW)[len] = L'\0';
+    (*ppszW)[len] = UNICODE_NULL;
     return Status;
-}
-
-VOID FASTCALL
-HEAP_free(LPVOID memory)
-{
-    /* make sure hProcessHeap gets initialized by GdiProcessSetup before we get here */
-    assert(hProcessHeap);
-
-    RtlFreeHeap ( hProcessHeap, 0, memory );
 }
 
 LPWSTR FASTCALL

--- a/win32ss/gdi/gdi32/misc/heap.c
+++ b/win32ss/gdi/gdi32/misc/heap.c
@@ -31,7 +31,7 @@
 HANDLE hProcessHeap = NULL;
 
 NTSTATUS FASTCALL
-HEAP_strdupA2W ( LPWSTR* ppszW, LPCSTR lpszA )
+HEAP_strdupA2W(_Outptr_ PWSTR* ppszW, _In_ PCSTR lpszA)
 {
     ULONG len;
     NTSTATUS Status;
@@ -50,13 +50,16 @@ HEAP_strdupA2W ( LPWSTR* ppszW, LPCSTR lpszA )
 }
 
 PWSTR FASTCALL
-HEAP_strdupA2W_buf(IN PCSTR lpszA, OUT PWSTR pszBuff, IN SIZE_T cchBuff)
+HEAP_strdupA2W_buf(
+    _In_ PCSTR lpszA,
+    _Out_ PWSTR pszStaticBuff,
+    _In_ SIZE_T cchStaticBuff)
 {
     if (!lpszA)
         return NULL;
 
     SIZE_T size = strlen(lpszA) + 1;
-    PWSTR pszW = (size < cchBuff) ? pszBuff : HEAP_alloc(size * sizeof(WCHAR));
+    PWSTR pszW = (size < cchStaticBuff) ? pszStaticBuff : HEAP_alloc(size * sizeof(WCHAR));
     if (!pszW)
         return NULL;
 

--- a/win32ss/gdi/gdi32/misc/heap.c
+++ b/win32ss/gdi/gdi32/misc/heap.c
@@ -52,7 +52,7 @@ HEAP_strdupA2W(_Outptr_ PWSTR* ppszW, _In_ PCSTR lpszA)
 PWSTR FASTCALL
 HEAP_strdupA2W_buf(
     _In_ PCSTR lpszA,
-    _Out_ PWSTR pszStaticBuff,
+    _In_ PWSTR pszStaticBuff,
     _In_ SIZE_T cchStaticBuff)
 {
     if (!lpszA)

--- a/win32ss/gdi/gdi32/objects/font.c
+++ b/win32ss/gdi/gdi32/objects/font.c
@@ -1994,7 +1994,7 @@ IntConvertFontPaths(
         UINT_PTR spanLen = pch1 - pch1Prev;
         if (spanLen < _countof(L".ttf") || spanLen >= MAX_PATH)
         {
-            dwError = ERROR_INVALID_PARAMETER;
+            dwError = ERROR_INVALID_FUNCTION;
             break;
         }
 
@@ -2013,7 +2013,7 @@ IntConvertFontPaths(
         SIZE_T cch = wcslen(szFullPath);
         if (cch < _countof(L".ttf"))
         {
-            dwError = ERROR_INVALID_PARAMETER;
+            dwError = ERROR_INVALID_FUNCTION;
             break;
         }
         PCWSTR pchDotExt = &szFullPath[cch - 4];
@@ -2028,7 +2028,7 @@ IntConvertFontPaths(
                 _wcsnicmp(pchDotExt, L".fot", 4) != 0 &&
                 _wcsnicmp(pchDotExt, L".pfm", 4) != 0)
             {
-                dwError = ERROR_INVALID_PARAMETER;
+                dwError = ERROR_INVALID_FUNCTION;
                 break;
             }
         }
@@ -2037,7 +2037,7 @@ IntConvertFontPaths(
             if (_wcsnicmp(pchDotExt, L".pfb", 4) != 0 &&
                 _wcsnicmp(pchDotExt, L".mmm", 4) != 0)
             {
-                dwError = ERROR_INVALID_PARAMETER;
+                dwError = ERROR_INVALID_FUNCTION;
                 break;
             }
         }
@@ -2055,7 +2055,7 @@ IntConvertFontPaths(
             StringCchCatW(pszBuff, cchBuff, L"|") != S_OK)
         {
             RtlFreeUnicodeString(&NtAbsPath);
-            dwError = ERROR_BUFFER_OVERFLOW;
+            dwError = ERROR_INVALID_FUNCTION;
             break;
         }
 
@@ -2071,7 +2071,7 @@ IntConvertFontPaths(
     {
         HEAP_free(pszBuff);
         *pcwc = *pcFiles = 0;
-        if (dwError == ERROR_FILE_NOT_FOUND)
+        if (dwError != ERROR_INVALID_FUNCTION)
             SetLastError(dwError);
         return NULL;
     }

--- a/win32ss/gdi/gdi32/objects/font.c
+++ b/win32ss/gdi/gdi32/objects/font.c
@@ -2050,7 +2050,7 @@ IntConvertFontPaths(
             break;
         }
 
-        // Append a path to pszBuff
+        // Append a path and '|' to pszBuff
         if (StringCchCatW(pszBuff, cchBuff, NtAbsPath.Buffer) != S_OK ||
             StringCchCatW(pszBuff, cchBuff, L"|") != S_OK)
         {
@@ -2103,20 +2103,18 @@ CreateScalableFontResourceA(
     return FALSE;
 }
 
-/*
- * @implemented
- */
-int
+/* @implemented */
+INT
 WINAPI
-AddFontResourceExW ( LPCWSTR lpszFilename, DWORD fl, PVOID pvReserved )
+AddFontResourceExW(LPCWSTR lpszFilename, DWORD fl, PVOID pvReserved)
 {
     if (fl & ~(FR_PRIVATE | FR_NOT_ENUM))
     {
-        SetLastError( ERROR_INVALID_PARAMETER );
+        SetLastError(ERROR_INVALID_PARAMETER);
         return 0;
     }
 
-    return GdiAddFontResourceW(lpszFilename, fl,0);
+    return GdiAddFontResourceW(lpszFilename, fl, NULL);
 }
 
 /* @implemented */
@@ -2157,51 +2155,39 @@ AddFontResourceExA(LPCSTR lpszFilename, DWORD fl, PVOID pvReserved)
     return ret;
 }
 
-/*
- * @implemented
- */
-int
+/* @implemented */
+INT
 WINAPI
-AddFontResourceA ( LPCSTR lpszFilename )
+AddFontResourceA(LPCSTR lpszFilename)
 {
     return AddFontResourceExA(lpszFilename, 0, NULL);
 }
 
-/*
- * @implemented
- */
-int
+/* @implemented */
+INT
 WINAPI
-AddFontResourceW ( LPCWSTR lpszFilename )
+AddFontResourceW(LPCWSTR lpszFilename)
 {
-    return GdiAddFontResourceW ( lpszFilename, 0, 0 );
+    return GdiAddFontResourceW(lpszFilename, 0, NULL);
 }
 
-
-/*
- * @implemented
- */
+/* @implemented */
 BOOL
 WINAPI
 RemoveFontResourceW(LPCWSTR lpFileName)
 {
-    return RemoveFontResourceExW(lpFileName,0,0);
+    return RemoveFontResourceExW(lpFileName, 0, NULL);
 }
 
-
-/*
- * @implemented
- */
+/* @implemented */
 BOOL
 WINAPI
 RemoveFontResourceA(LPCSTR lpFileName)
 {
-    return RemoveFontResourceExA(lpFileName,0,0);
+    return RemoveFontResourceExA(lpFileName, 0, NULL);
 }
 
-/*
- * @implemented
- */
+/* @implemented */
 BOOL
 WINAPI
 RemoveFontResourceExA(LPCSTR lpFileName,
@@ -2241,9 +2227,7 @@ RemoveFontResourceExA(LPCSTR lpFileName,
     return result;
 }
 
-/*
- * @implemented
- */
+/* @implemented */
 BOOL
 WINAPI
 RemoveFontResourceExW(LPCWSTR lpFileName,

--- a/win32ss/gdi/gdi32/objects/font.c
+++ b/win32ss/gdi/gdi32/objects/font.c
@@ -2011,33 +2011,23 @@ IntConvertFontPaths(
             break;
         }
 
-        // Check filename extension
-        SIZE_T cch = wcslen(szFullPath);
-        if (cch < _countof(L".ttf"))
-        {
-            dwError = ERROR_INVALID_FUNCTION;
-            break;
-        }
-        PCWSTR pchDotExt = &szFullPath[cch - 4];
         if (bFirst)
         {
             bFirst = FALSE;
-            if (_wcsnicmp(pchDotExt, L".ttf", 4) != 0 &&
-                _wcsnicmp(pchDotExt, L".ttc", 4) != 0 &&
-                _wcsnicmp(pchDotExt, L".otf", 4) != 0 &&
-                _wcsnicmp(pchDotExt, L".fon", 4) != 0 &&
-                _wcsnicmp(pchDotExt, L".fnt", 4) != 0 &&
-                _wcsnicmp(pchDotExt, L".fot", 4) != 0 &&
-                _wcsnicmp(pchDotExt, L".pfm", 4) != 0)
+        }
+        else
+        {
+            SIZE_T cch = wcslen(szFullPath);
+            if (cch < _countof(L".pfb"))
             {
                 dwError = ERROR_INVALID_FUNCTION;
                 break;
             }
-        }
-        else
-        {
-            if (_wcsnicmp(pchDotExt, L".pfb", 4) != 0 &&
-                _wcsnicmp(pchDotExt, L".mmm", 4) != 0)
+
+            // Check filename extension
+            PCWSTR pchDotExt = &szFullPath[cch - 4];
+            if (_wcsicmp(pchDotExt, L".pfb") != 0 &&
+                _wcsicmp(pchDotExt, L".mmm") != 0)
             {
                 dwError = ERROR_INVALID_FUNCTION;
                 break;

--- a/win32ss/gdi/gdi32/objects/font.c
+++ b/win32ss/gdi/gdi32/objects/font.c
@@ -2098,7 +2098,10 @@ CreateScalableFontResourceA(
 /* @implemented */
 INT
 WINAPI
-AddFontResourceExW(LPCWSTR lpszFilename, DWORD fl, PVOID pvReserved)
+AddFontResourceExW(
+    _In_ LPCWSTR lpszFilename,
+    _In_ DWORD fl,
+    _In_opt_ PVOID pvReserved)
 {
     if (fl & ~(FR_PRIVATE | FR_NOT_ENUM))
     {
@@ -2112,7 +2115,10 @@ AddFontResourceExW(LPCWSTR lpszFilename, DWORD fl, PVOID pvReserved)
 /* @implemented */
 INT
 WINAPI
-AddFontResourceExA(LPCSTR lpszFilename, DWORD fl, PVOID pvReserved)
+AddFontResourceExA(
+    _In_ LPCSTR lpszFilename,
+    _In_ DWORD fl,
+    _In_opt_ PVOID pvReserved)
 {
     if (fl & ~(FR_PRIVATE | FR_NOT_ENUM))
     {
@@ -2150,7 +2156,7 @@ AddFontResourceExA(LPCSTR lpszFilename, DWORD fl, PVOID pvReserved)
 /* @implemented */
 INT
 WINAPI
-AddFontResourceA(LPCSTR lpszFilename)
+AddFontResourceA(_In_ LPCSTR lpszFilename)
 {
     return AddFontResourceExA(lpszFilename, 0, NULL);
 }
@@ -2158,7 +2164,7 @@ AddFontResourceA(LPCSTR lpszFilename)
 /* @implemented */
 INT
 WINAPI
-AddFontResourceW(LPCWSTR lpszFilename)
+AddFontResourceW(_In_ LPCWSTR lpszFilename)
 {
     return GdiAddFontResourceW(lpszFilename, 0, NULL);
 }
@@ -2166,7 +2172,7 @@ AddFontResourceW(LPCWSTR lpszFilename)
 /* @implemented */
 BOOL
 WINAPI
-RemoveFontResourceW(LPCWSTR lpFileName)
+RemoveFontResourceW(_In_ LPCWSTR lpFileName)
 {
     return RemoveFontResourceExW(lpFileName, 0, NULL);
 }
@@ -2174,7 +2180,7 @@ RemoveFontResourceW(LPCWSTR lpFileName)
 /* @implemented */
 BOOL
 WINAPI
-RemoveFontResourceA(LPCSTR lpFileName)
+RemoveFontResourceA(_In_ LPCSTR lpFileName)
 {
     return RemoveFontResourceExA(lpFileName, 0, NULL);
 }
@@ -2182,9 +2188,10 @@ RemoveFontResourceA(LPCSTR lpFileName)
 /* @implemented */
 BOOL
 WINAPI
-RemoveFontResourceExA(LPCSTR lpFileName,
-                      DWORD fl,
-                      PVOID pdv)
+RemoveFontResourceExA(
+    _In_ LPCSTR lpFileName,
+    _In_ DWORD fl,
+    _In_opt_ PVOID pdv)
 {
     if (fl & ~(FR_PRIVATE | FR_NOT_ENUM))
     {
@@ -2222,9 +2229,10 @@ RemoveFontResourceExA(LPCSTR lpFileName,
 /* @implemented */
 BOOL
 WINAPI
-RemoveFontResourceExW(LPCWSTR lpFileName,
-                      DWORD fl,
-                      PVOID pdv)
+RemoveFontResourceExW(
+    _In_ LPCWSTR lpFileName,
+    _In_ DWORD fl,
+    _In_opt_ PVOID pdv)
 {
     DPRINT("RemoveFontResourceExW\n");
 

--- a/win32ss/gdi/gdi32/objects/font.c
+++ b/win32ss/gdi/gdi32/objects/font.c
@@ -1,10 +1,12 @@
 /*
- * COPYRIGHT:       See COPYING in the top level directory
- * PROJECT:         ReactOS system libraries
- * FILE:            win32ss/gdi/gdi32/objects/font.c
- * PURPOSE:
- * PROGRAMMER:
- *
+ * PROJECT:     ReactOS GDI32
+ * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
+ * PURPOSE:     Font manipulation API
+ * COPYRIGHT:   Copyright 2019 James Tabor
+ *              Copyright 2019 Pierre Schweitzer (heis_spiter@hotmail.com)
+ *              Copyright 2019-2021 Hermes Belusca-Maito (hermes.belusca-maito@reactos.org)
+ *              Copyright 2018 Baruch Rutman (peterooch@gmail.com)
+ *              Copyright 2025 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
  */
 
 #include <precomp.h>
@@ -2544,9 +2546,7 @@ NewEnumFontFamiliesExW(
     return ret;
 }
 
-/*
- * @implemented
- */
+/* @implemented */
 INT
 WINAPI
 GdiAddFontResourceW(
@@ -2800,4 +2800,3 @@ cGetTTFFromFOT(DWORD x1 ,DWORD x2 ,DWORD x3, DWORD x4, DWORD x5, DWORD x6, DWORD
     SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
     return 0;
 }
-

--- a/win32ss/gdi/ntgdi/font.c
+++ b/win32ss/gdi/ntgdi/font.c
@@ -444,12 +444,12 @@ RealizeFontInit(HFONT hFont)
 INT
 APIENTRY
 NtGdiAddFontResourceW(
-    IN WCHAR *pwcFiles,
-    IN ULONG cwc,
-    IN ULONG cFiles,
-    IN FLONG fl,
-    IN DWORD dwPidTid,
-    IN OPTIONAL DESIGNVECTOR *pdv)
+    _In_reads_(cwc) WCHAR *pwcFiles,
+    _In_ ULONG cwc,
+    _In_ ULONG cFiles,
+    _In_ FLONG fl,
+    _In_ DWORD dwPidTid,
+    _In_opt_ DESIGNVECTOR *pdv)
 {
     UNICODE_STRING SafeFileName;
     INT Ret;

--- a/win32ss/gdi/ntgdi/font.c
+++ b/win32ss/gdi/ntgdi/font.c
@@ -464,7 +464,7 @@ NtGdiAddFontResourceW(
         return 0;
 
     SafeFileName.Length = (USHORT)((cwc - 1) * sizeof(WCHAR));
-    SafeFileName.MaximumLength = SafeFileName.Length + 2 * sizeof(UNICODE_NULL); // Security issue
+    SafeFileName.MaximumLength = SafeFileName.Length + sizeof(UNICODE_NULL);
     SafeFileName.Buffer = ExAllocatePoolWithTag(PagedPool,
                                                 SafeFileName.MaximumLength,
                                                 TAG_STRING);
@@ -485,9 +485,7 @@ NtGdiAddFontResourceW(
     }
     _SEH2_END;
 
-    // Security issue: Avoid buffer overrun by double '\0'
     SafeFileName.Buffer[SafeFileName.Length / sizeof(WCHAR)] = UNICODE_NULL;
-    SafeFileName.Buffer[SafeFileName.Length / sizeof(WCHAR) + 1] = UNICODE_NULL;
 
     Ret = IntGdiAddFontResourceEx(&SafeFileName, fl, 0, cFiles, cwc);
 
@@ -518,7 +516,7 @@ NtGdiRemoveFontResourceW(
         return FALSE;
 
     SafeFileName.Length = (USHORT)((cwc - 1) * sizeof(WCHAR));
-    SafeFileName.MaximumLength = SafeFileName.Length + 2 * sizeof(UNICODE_NULL); // Security issue
+    SafeFileName.MaximumLength = SafeFileName.Length + sizeof(UNICODE_NULL);
     SafeFileName.Buffer = ExAllocatePoolWithTag(PagedPool,
                                                 SafeFileName.MaximumLength,
                                                 TAG_STRING);
@@ -539,9 +537,7 @@ NtGdiRemoveFontResourceW(
     }
     _SEH2_END;
 
-    // Security issue: Avoid buffer overrun by double '\0'
     SafeFileName.Buffer[SafeFileName.Length / sizeof(WCHAR)] = UNICODE_NULL;
-    SafeFileName.Buffer[SafeFileName.Length / sizeof(WCHAR) + 1] = UNICODE_NULL;
 
     Ret = IntGdiRemoveFontResource(&SafeFileName, fl, cFiles, cwc);
 

--- a/win32ss/gdi/ntgdi/font.c
+++ b/win32ss/gdi/ntgdi/font.c
@@ -496,12 +496,12 @@ NtGdiAddFontResourceW(
 BOOL
 APIENTRY
 NtGdiRemoveFontResourceW(
-    IN WCHAR *pwszFiles,
-    IN ULONG cwc,
-    IN ULONG cFiles,
-    IN ULONG fl,
-    IN DWORD dwPidTid,
-    IN OPTIONAL DESIGNVECTOR *pdv)
+    _In_reads_(cwc) WCHAR *pwszFiles,
+    _In_ ULONG cwc,
+    _In_ ULONG cFiles,
+    _In_ ULONG fl,
+    _In_ DWORD dwPidTid,
+    _In_opt_ DESIGNVECTOR *pdv)
 {
     UNICODE_STRING SafeFileName;
     BOOL Ret;

--- a/win32ss/gdi/ntgdi/font.c
+++ b/win32ss/gdi/ntgdi/font.c
@@ -441,8 +441,8 @@ RealizeFontInit(HFONT hFont)
 static BOOL
 IntCheckFontPathNames(
     _In_reads_(cwc) WCHAR *pwcFiles,
-    _In_ ULONG cwc,
-    _In_ ULONG cFiles)
+    _In_ ULONG cFiles,
+    _In_ ULONG cwc)
 {
     ULONG ich, cRealFiles;
 
@@ -494,7 +494,7 @@ NtGdiAddFontResourceW(
     {
         ProbeForRead(pwcFiles, cwc * sizeof(WCHAR), sizeof(WCHAR));
 
-        if (!IntCheckFontPathNames(pwcFiles, cwc, cFiles))
+        if (!IntCheckFontPathNames(pwcFiles, cFiles, cwc))
             return 0;
  
         RtlCopyMemory(SafeFileName.Buffer, pwcFiles, SafeFileName.Length);
@@ -548,7 +548,7 @@ NtGdiRemoveFontResourceW(
     {
         ProbeForRead(pwszFiles, cwc * sizeof(WCHAR), sizeof(WCHAR));
 
-        if (!IntCheckFontPathNames(pwszFiles, cwc, cFiles))
+        if (!IntCheckFontPathNames(pwszFiles, cFiles, cwc))
             return FALSE;
 
         RtlCopyMemory(SafeFileName.Buffer, pwszFiles, SafeFileName.Length);

--- a/win32ss/gdi/ntgdi/font.c
+++ b/win32ss/gdi/ntgdi/font.c
@@ -453,6 +453,7 @@ NtGdiAddFontResourceW(
 {
     UNICODE_STRING SafeFileName;
     INT Ret;
+    ULONG ich, cRealFiles;
 
     DBG_UNREFERENCED_PARAMETER(dwPidTid);
     DBG_UNREFERENCED_PARAMETER(pdv);
@@ -476,6 +477,19 @@ NtGdiAddFontResourceW(
         ProbeForRead(pwcFiles, cwc * sizeof(WCHAR), sizeof(WCHAR));
         if (pwcFiles[cwc - 1] != UNICODE_NULL)
             return 0;
+
+        for (ich = cRealFiles = 0; ich < cwc; ++ich)
+        {
+            if (!pwcFiles[ich])
+                ++cRealFiles;
+        }
+
+        if (cRealFiles < cFiles)
+        {
+            DPRINT1("%d < %d\n", cRealFiles, cFiles);
+            return 0;
+        }
+
         RtlCopyMemory(SafeFileName.Buffer, pwcFiles, SafeFileName.Length);
     }
     _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -1233,7 +1233,9 @@ IntUnicodeStringToBuffer(LPWSTR pszBuffer, SIZE_T cbBuffer, const UNICODE_STRING
 }
 
 static NTSTATUS
-DuplicateUnicodeString(const UNICODE_STRING *Source, PUNICODE_STRING Destination)
+DuplicateUnicodeString(
+    _In_ PCUNICODE_STRING Source,
+    _Out_ PUNICODE_STRING Destination)
 {
     NTSTATUS Status = STATUS_NO_MEMORY;
     UNICODE_STRING Tmp;
@@ -2090,9 +2092,9 @@ NameFromCharSet(BYTE CharSet)
 /* Adds the font resource from the specified file to the system */
 static INT FASTCALL
 IntGdiAddFontResourceSingle(
-    IN const UNICODE_STRING *FileName,
-    IN DWORD Characteristics,
-    IN DWORD dwFlags)
+    _In_ PCUNICODE_STRING FileName,
+    _In_ DWORD Characteristics,
+    _In_ DWORD dwFlags)
 {
     NTSTATUS Status;
     HANDLE FileHandle;
@@ -2290,11 +2292,11 @@ IntGdiAddFontResourceSingle(
 
 INT FASTCALL
 IntGdiAddFontResourceEx(
-    IN const UNICODE_STRING *FileName,
-    IN DWORD Characteristics,
-    IN DWORD dwFlags,
-    IN DWORD cFiles,
-    IN DWORD cwc)
+    _In_ PCUNICODE_STRING FileName,
+    _In_ DWORD Characteristics,
+    _In_ DWORD dwFlags,
+    _In_ DWORD cFiles,
+    _In_ DWORD cwc)
 {
     PWSTR pchFile = FileName->Buffer;
     SIZE_T cchFile;
@@ -2304,10 +2306,6 @@ IntGdiAddFontResourceEx(
     {
         _SEH2_TRY
         {
-            // Security issue: FileName should be terminated by double '\0'
-            if (!*pchFile)
-                return FALSE;
-
             cchFile = wcslen(pchFile);
         }
         _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
@@ -2338,18 +2336,18 @@ IntGdiAddFontResourceEx(
 
 static BOOL FASTCALL
 IntGdiRemoveFontResourceSingle(
-    IN const UNICODE_STRING *FileName,
-    IN DWORD dwFlags)
+    _In_ PCUNICODE_STRING FileName,
+    _In_ DWORD dwFlags)
 {
     return FALSE; // FIXME
 }
 
 BOOL FASTCALL
 IntGdiRemoveFontResource(
-    IN const UNICODE_STRING *FileName,
-    IN DWORD dwFlags,
-    IN DWORD cFiles,
-    IN DWORD cwc)
+    _In_ PCUNICODE_STRING FileName,
+    _In_ DWORD dwFlags,
+    _In_ DWORD cFiles,
+    _In_ DWORD cwc)
 {
     PWSTR pchFile = FileName->Buffer;
     SIZE_T cchFile;
@@ -2358,10 +2356,6 @@ IntGdiRemoveFontResource(
     {
         _SEH2_TRY
         {
-            // Security issue: FileName should be terminated by double '\0'
-            if (!*pchFile)
-                return FALSE;
-
             cchFile = wcslen(pchFile);
         }
         _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -4223,7 +4223,6 @@ IntRequestFontSize(PDC dc, PFONTGDI FontGDI, LONG lfWidth, LONG lfHeight)
         if (error)
         {
             DPRINT1("%s: Failed to request font size.\n", face->family_name);
-            ASSERT(FALSE);
             return error;
         }
 

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -1666,11 +1666,8 @@ IntLoadSystemFonts(VOID)
                     {
                         RtlCopyUnicodeString(&FileName, &Directory);
                         RtlAppendUnicodeStringToString(&FileName, &TempString);
-                        if (!IntGdiAddFontResourceEx(&FileName, 0, AFRX_WRITE_REGISTRY, 1,
-                                                     FileName.MaximumLength / sizeof(WCHAR)))
-                        {
+                        if (!IntGdiAddFontResourceEx(&FileName, 1, 0, AFRX_WRITE_REGISTRY))
                             DPRINT1("ERR: Failed to load %wZ\n", &FileName);
-                        }
                     }
 
                     if (DirInfo->NextEntryOffset == 0)
@@ -2293,10 +2290,9 @@ IntGdiAddFontResourceSingle(
 INT FASTCALL
 IntGdiAddFontResourceEx(
     _In_ PCUNICODE_STRING FileName,
-    _In_ DWORD Characteristics,
-    _In_ DWORD dwFlags,
     _In_ DWORD cFiles,
-    _In_ DWORD cwc)
+    _In_ DWORD Characteristics,
+    _In_ DWORD dwFlags)
 {
     PWSTR pchFile = FileName->Buffer;
     SIZE_T cchFile;
@@ -2313,10 +2309,6 @@ IntGdiAddFontResourceEx(
             _SEH2_YIELD(return FALSE);
         }
         _SEH2_END;
-
-        // Security issue: Prohibit buffer overrun
-        if (pchFile + (cchFile + 1) > FileName->Buffer + cwc)
-            return FALSE;
 
         UNICODE_STRING ustrPathName;
         ustrPathName.Length = (USHORT)(cchFile * sizeof(WCHAR));
@@ -2345,9 +2337,8 @@ IntGdiRemoveFontResourceSingle(
 BOOL FASTCALL
 IntGdiRemoveFontResource(
     _In_ PCUNICODE_STRING FileName,
-    _In_ DWORD dwFlags,
     _In_ DWORD cFiles,
-    _In_ DWORD cwc)
+    _In_ DWORD dwFlags)
 {
     PWSTR pchFile = FileName->Buffer;
     SIZE_T cchFile;
@@ -2363,10 +2354,6 @@ IntGdiRemoveFontResource(
             _SEH2_YIELD(return FALSE);
         }
         _SEH2_END;
-
-        // Security issue: Prohibit buffer overrun
-        if (pchFile + (cchFile + 1) > FileName->Buffer + cwc)
-            return FALSE;
 
         UNICODE_STRING ustrPathName;
         ustrPathName.Length = (USHORT)(cchFile * sizeof(WCHAR));
@@ -2526,8 +2513,7 @@ IntLoadFontsInRegistry(VOID)
         if (NT_SUCCESS(Status))
         {
             RtlCreateUnicodeString(&FileNameW, szPath);
-            nFontCount += IntGdiAddFontResourceEx(&FileNameW, 0, dwFlags, 1,
-                                                  FileNameW.MaximumLength / sizeof(WCHAR));
+            nFontCount += IntGdiAddFontResourceEx(&FileNameW, 1, 0, dwFlags);
             RtlFreeUnicodeString(&FileNameW);
         }
 

--- a/win32ss/gdi/ntgdi/text.h
+++ b/win32ss/gdi/ntgdi/text.h
@@ -118,9 +118,9 @@ ULONG FASTCALL FontGetObject(PTEXTOBJ TextObj, ULONG Count, PVOID Buffer);
 VOID FASTCALL IntLoadSystemFonts(VOID);
 BOOL FASTCALL IntLoadFontsInRegistry(VOID);
 VOID FASTCALL IntGdiCleanupPrivateFontsForProcess(VOID);
-INT FASTCALL IntGdiAddFontResourceEx(const UNICODE_STRING *FileName, DWORD Characteristics,
+INT FASTCALL IntGdiAddFontResourceEx(PCUNICODE_STRING FileName, DWORD Characteristics,
                                      DWORD dwFlags, DWORD cFiles, DWORD cwc);
-BOOL FASTCALL IntGdiRemoveFontResource(const UNICODE_STRING *FileName, DWORD dwFlags,
+BOOL FASTCALL IntGdiRemoveFontResource(PCUNICODE_STRING FileName, DWORD dwFlags,
                                        DWORD cFiles, DWORD cwc);
 HANDLE FASTCALL IntGdiAddFontMemResource(PVOID Buffer, DWORD dwSize, PDWORD pNumAdded);
 BOOL FASTCALL IntGdiRemoveFontMemResource(HANDLE hMMFont);

--- a/win32ss/gdi/ntgdi/text.h
+++ b/win32ss/gdi/ntgdi/text.h
@@ -120,15 +120,13 @@ BOOL FASTCALL IntLoadFontsInRegistry(VOID);
 VOID FASTCALL IntGdiCleanupPrivateFontsForProcess(VOID);
 INT FASTCALL IntGdiAddFontResourceEx(
     _In_ PCUNICODE_STRING FileName,
-    _In_ DWORD Characteristics,
-    _In_ DWORD dwFlags,
     _In_ DWORD cFiles,
-    _In_ DWORD cwc);
+    _In_ DWORD Characteristics,
+    _In_ DWORD dwFlags);
 BOOL FASTCALL IntGdiRemoveFontResource(
     _In_ PCUNICODE_STRING FileName,
-    _In_ DWORD dwFlags,
     _In_ DWORD cFiles,
-    _In_ DWORD cwc);
+    _In_ DWORD dwFlags);
 HANDLE FASTCALL IntGdiAddFontMemResource(PVOID Buffer, DWORD dwSize, PDWORD pNumAdded);
 BOOL FASTCALL IntGdiRemoveFontMemResource(HANDLE hMMFont);
 ULONG FASTCALL ftGdiGetGlyphOutline(PDC,WCHAR,UINT,LPGLYPHMETRICS,ULONG,PVOID,LPMAT2,BOOL);

--- a/win32ss/gdi/ntgdi/text.h
+++ b/win32ss/gdi/ntgdi/text.h
@@ -118,10 +118,17 @@ ULONG FASTCALL FontGetObject(PTEXTOBJ TextObj, ULONG Count, PVOID Buffer);
 VOID FASTCALL IntLoadSystemFonts(VOID);
 BOOL FASTCALL IntLoadFontsInRegistry(VOID);
 VOID FASTCALL IntGdiCleanupPrivateFontsForProcess(VOID);
-INT FASTCALL IntGdiAddFontResourceEx(PCUNICODE_STRING FileName, DWORD Characteristics,
-                                     DWORD dwFlags, DWORD cFiles, DWORD cwc);
-BOOL FASTCALL IntGdiRemoveFontResource(PCUNICODE_STRING FileName, DWORD dwFlags,
-                                       DWORD cFiles, DWORD cwc);
+INT FASTCALL IntGdiAddFontResourceEx(
+    _In_ PCUNICODE_STRING FileName,
+    _In_ DWORD Characteristics,
+    _In_ DWORD dwFlags,
+    _In_ DWORD cFiles,
+    _In_ DWORD cwc);
+BOOL FASTCALL IntGdiRemoveFontResource(
+    _In_ PCUNICODE_STRING FileName,
+    _In_ DWORD dwFlags,
+    _In_ DWORD cFiles,
+    _In_ DWORD cwc);
 HANDLE FASTCALL IntGdiAddFontMemResource(PVOID Buffer, DWORD dwSize, PDWORD pNumAdded);
 BOOL FASTCALL IntGdiRemoveFontMemResource(HANDLE hMMFont);
 ULONG FASTCALL ftGdiGetGlyphOutline(PDC,WCHAR,UINT,LPGLYPHMETRICS,ULONG,PVOID,LPMAT2,BOOL);

--- a/win32ss/gdi/ntgdi/text.h
+++ b/win32ss/gdi/ntgdi/text.h
@@ -118,9 +118,10 @@ ULONG FASTCALL FontGetObject(PTEXTOBJ TextObj, ULONG Count, PVOID Buffer);
 VOID FASTCALL IntLoadSystemFonts(VOID);
 BOOL FASTCALL IntLoadFontsInRegistry(VOID);
 VOID FASTCALL IntGdiCleanupPrivateFontsForProcess(VOID);
-INT FASTCALL IntGdiAddFontResource(PUNICODE_STRING FileName, DWORD Characteristics);
-INT FASTCALL IntGdiAddFontResourceEx(PUNICODE_STRING FileName, DWORD Characteristics,
-                                     DWORD dwFlags);
+INT FASTCALL IntGdiAddFontResourceEx(const UNICODE_STRING *FileName, DWORD Characteristics,
+                                     DWORD dwFlags, DWORD cFiles, DWORD cwc);
+BOOL FASTCALL IntGdiRemoveFontResource(const UNICODE_STRING *FileName, DWORD dwFlags,
+                                       DWORD cFiles, DWORD cwc);
 HANDLE FASTCALL IntGdiAddFontMemResource(PVOID Buffer, DWORD dwSize, PDWORD pNumAdded);
 BOOL FASTCALL IntGdiRemoveFontMemResource(HANDLE hMMFont);
 ULONG FASTCALL ftGdiGetGlyphOutline(PDC,WCHAR,UINT,LPGLYPHMETRICS,ULONG,PVOID,LPMAT2,BOOL);


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-17684](https://jira.reactos.org/browse/CORE-17684)

## Proposed changes

- Add `HEAP_strdupA2W_buf` and `HEAP_strdupA2W_buf_free` helper functions for quick string conversion.
- Optimize `HEAP_...` functions.
- Add `IntConvertFontPaths` helper function.
- Support multiple files in `AddFontResource` function.
- Add `cFiles` parameter to some internal font addition/removal functions.
- Half-implement `NtGdiRemoveFontResourceW` and `RemoveFontResourceExW` functions.

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=101236,101283 LGTM.
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=101237,101284 LGTM.