### PR TITLE
[BROWSEUI] Fix backspace button behavior in win32 shell browser

### DIFF
--- a/dll/win32/browseui/shellbrowser.cpp
+++ b/dll/win32/browseui/shellbrowser.cpp
@@ -3145,7 +3145,6 @@ HRESULT STDMETHODCALLTYPE CShellBrowser::GoBack()
         return hResult;
 
     hResult = travelLog->GetTravelEntry(static_cast<IDropTarget *>(this), TLOG_BACK, &unusedEntry);
-
     if (SUCCEEDED(hResult))
     {
         unusedEntry.Release();

--- a/dll/win32/browseui/shellbrowser.cpp
+++ b/dll/win32/browseui/shellbrowser.cpp
@@ -3886,7 +3886,7 @@ LRESULT CShellBrowser::OnGoHome(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL &
 
 LRESULT CShellBrowser::OnBackspace(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL &bHandled)
 {
-    HRESULT hResult = GoBackOrForward();
+    HRESULT hResult = LOBYTE(GetVersion()) >= 6 ? GoBackOrForward() : NavigateToParent();
     if (FAILED(hResult))
         TRACE("GoBackOrForward failed with hResult=%08lx\n", hResult);
     return 0;

--- a/dll/win32/browseui/shellbrowser.cpp
+++ b/dll/win32/browseui/shellbrowser.cpp
@@ -3151,7 +3151,7 @@ HRESULT STDMETHODCALLTYPE CShellBrowser::GoBack()
         return travelLog->Travel(static_cast<IDropTarget *>(this), TLOG_BACK);
     }
 
-    return E_ABORT;
+    return hResult;
 }
 
 HRESULT STDMETHODCALLTYPE CShellBrowser::GoForward()
@@ -3171,7 +3171,7 @@ HRESULT STDMETHODCALLTYPE CShellBrowser::GoForward()
         return travelLog->Travel(static_cast<IDropTarget *>(this), TLOG_FORE);
     }
 
-    return E_ABORT;
+    return hResult;
 }
 
 HRESULT STDMETHODCALLTYPE CShellBrowser::GoHome()

--- a/dll/win32/browseui/shellbrowser.cpp
+++ b/dll/win32/browseui/shellbrowser.cpp
@@ -3888,7 +3888,7 @@ LRESULT CShellBrowser::OnBackspace(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOO
 {
     HRESULT hResult = LOBYTE(GetVersion()) >= 6 ? GoBackOrForward() : NavigateToParent();
     if (FAILED(hResult))
-        TRACE("GoBackOrForward failed with hResult=%08lx\n", hResult);
+        TRACE("Backspace navigation failed with hResult=%08lx\n", hResult);
     return 0;
 }
 

--- a/dll/win32/browseui/shellbrowser.cpp
+++ b/dll/win32/browseui/shellbrowser.cpp
@@ -3136,9 +3136,9 @@ HRESULT STDMETHODCALLTYPE CShellBrowser::v_CheckZoneCrossing(LPCITEMIDLIST pidl)
 
 HRESULT STDMETHODCALLTYPE CShellBrowser::GoBack()
 {
-    CComPtr<ITravelLog>                     travelLog;
-    CComPtr<ITravelEntry>                   unusedEntry;
-    HRESULT                                 hResult;
+    CComPtr<ITravelLog> travelLog;
+    CComPtr<ITravelEntry> unusedEntry;
+    HRESULT hResult;
 
     hResult = GetTravelLog(&travelLog);
     if (FAILED_UNEXPECTEDLY(hResult))
@@ -3156,9 +3156,9 @@ HRESULT STDMETHODCALLTYPE CShellBrowser::GoBack()
 
 HRESULT STDMETHODCALLTYPE CShellBrowser::GoForward()
 {
-    CComPtr<ITravelLog>                     travelLog;
-    CComPtr<ITravelEntry>                   unusedEntry;
-    HRESULT                                 hResult;
+    CComPtr<ITravelLog> travelLog;
+    CComPtr<ITravelEntry> unusedEntry;
+    HRESULT hResult;
 
     hResult = GetTravelLog(&travelLog);
     if (FAILED_UNEXPECTEDLY(hResult))

--- a/dll/win32/browseui/shellbrowser.cpp
+++ b/dll/win32/browseui/shellbrowser.cpp
@@ -3166,7 +3166,6 @@ HRESULT STDMETHODCALLTYPE CShellBrowser::GoForward()
         return hResult;
 
     hResult = travelLog->GetTravelEntry(static_cast<IDropTarget *>(this), TLOG_FORE, &unusedEntry);
-
     if (SUCCEEDED(hResult))
     {
         unusedEntry.Release();


### PR DESCRIPTION
## Purpose

Update backspace button functionality to align with standard Windows behavior in the win32 shell browser.


## Proposed changes

- Solved FIXME in `CShellBrowser::OnBackspace`
- Added `CShellBrowser::GoBackOrForward()` helper function
