### PR TITLE
[MMIXER] Fix improperly working volume control

### DIFF
--- a/sdk/lib/drivers/sound/mmixer/controls.c
+++ b/sdk/lib/drivers/sound/mmixer/controls.c
@@ -190,7 +190,7 @@ MMixerAddMixerControl(
 
             DPRINT("NodeIndex %u Range Min %d Max %d Steps %x UMin %x UMax %x\n", NodeIndex, Range->Bounds.SignedMinimum, Range->Bounds.SignedMaximum, Range->SteppingDelta, Range->Bounds.UnsignedMinimum, Range->Bounds.UnsignedMaximum);
 
-            MaxRange = Range->Bounds.UnsignedMaximum  - Range->Bounds.UnsignedMinimum;
+            MaxRange = Range->Bounds.SignedMaximum - Range->Bounds.SignedMinimum;
 
             if (MaxRange)
             {

--- a/sdk/lib/drivers/sound/mmixer/sup.c
+++ b/sdk/lib/drivers/sound/mmixer/sup.c
@@ -671,10 +671,9 @@ MMixerSetGetVolumeControlDetails(
     IN LPMIXERCONTROLDETAILS MixerControlDetails,
     LPMIXERLINE_EXT MixerLine)
 {
-    LPMIXERCONTROLDETAILS_UNSIGNED Input;
+    LPMIXERCONTROLDETAILS_SIGNED Input;
     LONG Value;
-    ULONG Index, Channel = 0;
-    ULONG dwValue;
+    ULONG Index, Channel;
     MIXER_STATUS Status;
     LPMIXERVOLUME_DATA VolumeData;
 
@@ -685,47 +684,41 @@ MMixerSetGetVolumeControlDetails(
     if (!VolumeData)
         return MM_STATUS_UNSUCCESSFUL;
 
-    /* get input */
-    Input = (LPMIXERCONTROLDETAILS_UNSIGNED)MixerControlDetails->paDetails;
+    /* Get input */
+    Input = (LPMIXERCONTROLDETAILS_SIGNED)MixerControlDetails->paDetails;
     if (!Input)
-        return MM_STATUS_UNSUCCESSFUL; /* to prevent dereferencing NULL */
+        return MM_STATUS_UNSUCCESSFUL; /* To prevent dereferencing NULL */
 
-    if (bSet)
+    /* Loop for each channel */
+    for (Channel = 0; Channel < MixerControlDetails->cChannels; Channel++)
     {
-        /* FIXME SEH */
-        Value = Input->dwValue;
-        Index = Value / VolumeData->InputSteppingDelta;
-
-        if (Index >= VolumeData->ValuesCount)
+        if (bSet)
         {
-            DPRINT1("Index %u out of bounds %u \n", Index, VolumeData->ValuesCount);
-            return MM_STATUS_INVALID_PARAMETER;
+            /* FIXME SEH */
+            Index = Input[Channel].lValue / VolumeData->InputSteppingDelta;
+
+            if (Index >= VolumeData->ValuesCount)
+            {
+                DPRINT1("Index %u out of bounds %u \n", Index, VolumeData->ValuesCount);
+                return MM_STATUS_INVALID_PARAMETER;
+            }
+
+            Value = VolumeData->Values[Index];
         }
 
-        Value = VolumeData->Values[Index];
+        /* Get/set control details */
+        Status = MMixerSetGetControlDetails(MixerContext, MixerControl->hDevice, NodeId, bSet, KSPROPERTY_AUDIO_VOLUMELEVEL, Channel, &Value);
+
+        if (!bSet)
+        {
+            /* FIXME SEH */
+            Input[Channel].lValue = MMixerGetVolumeControlIndex(VolumeData, Value);
+        }
     }
 
-    /* set control details */
     if (bSet)
     {
-        /* TODO */
-        Status = MMixerSetGetControlDetails(MixerContext, MixerControl->hDevice, NodeId, bSet, KSPROPERTY_AUDIO_VOLUMELEVEL, 0, &Value);
-        Status = MMixerSetGetControlDetails(MixerContext, MixerControl->hDevice, NodeId, bSet, KSPROPERTY_AUDIO_VOLUMELEVEL, 1, &Value);
-    }
-    else
-    {
-        Status = MMixerSetGetControlDetails(MixerContext, MixerControl->hDevice, NodeId, bSet, KSPROPERTY_AUDIO_VOLUMELEVEL, Channel, &Value);
-    }
-
-    if (!bSet)
-    {
-        dwValue = MMixerGetVolumeControlIndex(VolumeData, (LONG)Value);
-        /* FIXME SEH */
-        Input->dwValue = dwValue;
-    }
-    else
-    {
-        /* notify clients of a line change  MM_MIXM_CONTROL_CHANGE with MixerControl->dwControlID */
+        /* Notify clients of a line change  MM_MIXM_CONTROL_CHANGE with MixerControl->dwControlID */
         MMixerNotifyControlChange(MixerContext, MixerInfo, MM_MIXM_CONTROL_CHANGE, MixerControl->Control.dwControlID);
     }
     return Status;


### PR DESCRIPTION
## Purpose

Fix broken volume level changing and left/right speakers balance level changing.
Now the volume control works correctly and hence, the volume level can be properly changed from Sound Properties (mmsys.cpl) and Volume Mixer (sndvol32.exe) as well.
Note that the volume level settings changed by user are not saving after reboot yet. We need to save (write) and then load (read) them at next boot from `HKLM/System/CurrentControlSet/Control/DeviceClasses/KSCATEGORY_AUDIO/.../DeviceParameters/Mixer/.../*` keys inside wdmaud.sys, similarly to as it's done in Windows XP/2003. It can be tested (and is tested several times by me and is confirmed) by using MS wdmaud.sys in ReactOS. It writes the values in that key. So the actual volume values are stored there.
Another key, `HKCU/SOFTWARE/Microsoft/Windows/Applets/Volume Control/*`, is created and managed by sndvol32.exe instead, but it does not contain the actual values of volume Decibel levels.

JIRA issue: [CORE-20059](https://jira.reactos.org/browse/CORE-20059)

## Proposed changes

- Force using `MIXERCONTROLDETAILS_SIGNED` structure instead of `MIXERCONTROLDETAILS_UNSIGNED` from `MIXERCONTROLDETAILS.paDetails` member, which allows to use a negative Decibel values, those are more close to the absolute silence. This allows to start the counting of volume level from zero (silence) and then up to 100% (the maximum level of volume loudness).
- Get and set volume level value for all available output channels instead of only the 1st channel (available in `MIXERCONTROLDETAILS.cChannels` member), so other channels don't have a non-set volume values now. This allows to control the volume for all channels, so now it works correctly.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64:

## Result

As visible in the following video, volume control is now fixed and works correctly:

[ROS_system_volume_control.webm](https://github.com/user-attachments/assets/42bc2dc2-e810-432c-b6ad-0bea2ace202e)

Here's one more video too, which illustrates the left/right speakers balance is now working properly too (it is hearable here, unlike in previous video):

https://github.com/user-attachments/assets/096add77-14d9-46e9-8dcd-d3a189624f7a

:white_check_mark: Tested multiple times and confirmed by me: works perfectly in VirtualBox and VMware (also should on real hardware for non-HD audio controllers only). :smiley: 
But it does not work yet for (some) HD audio controllers yet (e. g., Realtek HD Audio), because of some other bugs related to that only (volume sliders are actually inactive, so the level cannot be changed at all. It's most likely because input and output devices are mismatched a bit: input (WaveIn) device is set as default, and, as we know, volume control is not available for WaveIn, so here's the actual source of problem). :slightly_frowning_face: 