### PR TITLE
[SDK][CRT] Improve setjmp/longjmp and add testcase

### DIFF
--- a/modules/rostests/apitests/crt/crtdll_crt_apitest.cmake
+++ b/modules/rostests/apitests/crt/crtdll_crt_apitest.cmake
@@ -260,7 +260,7 @@ list(APPEND SOURCE_CRTDLL
 #    _scalb.c
 #    _searchenv.c
 #    _seterrormode.c
-#    _setjmp.c
+    setjmp.c
 #    _setmode.c
 #    _setsystime.c
 #    _sleep.c
@@ -544,7 +544,7 @@ if(ARCH STREQUAL "i386")
 elseif(ARCH STREQUAL "amd64")
     list(APPEND SOURCE_CRTDLL
     #    __C_specific_handler
-    #    _setjmp.c
+        setjmp.c
     #    _setjmpex.c
     #    _local_unwind.c
     #    longjmp.c

--- a/modules/rostests/apitests/crt/crtdll_crt_apitest.cmake
+++ b/modules/rostests/apitests/crt/crtdll_crt_apitest.cmake
@@ -260,7 +260,6 @@ list(APPEND SOURCE_CRTDLL
 #    _scalb.c
 #    _searchenv.c
 #    _seterrormode.c
-    setjmp.c
 #    _setmode.c
 #    _setsystime.c
 #    _sleep.c
@@ -448,6 +447,7 @@ list(APPEND SOURCE_CRTDLL
 #    rewind.c
 #    scanf.c
 #    setbuf.c
+    setjmp.c
 #    setlocale.c
 #    setvbuf.c
 #    signal.c
@@ -544,7 +544,6 @@ if(ARCH STREQUAL "i386")
 elseif(ARCH STREQUAL "amd64")
     list(APPEND SOURCE_CRTDLL
     #    __C_specific_handler
-        setjmp.c
     #    _setjmpex.c
     #    _local_unwind.c
     #    longjmp.c

--- a/modules/rostests/apitests/crt/crtdll_crt_apitest.cmake
+++ b/modules/rostests/apitests/crt/crtdll_crt_apitest.cmake
@@ -549,6 +549,10 @@ elseif(ARCH STREQUAL "amd64")
     #    _local_unwind.c
     #    longjmp.c
     )
+elseif(ARCH STREQUAL "arm")
+    list(APPEND SOURCE_CRTDLL
+        setjmp.c
+    )
 endif()
 
 

--- a/modules/rostests/apitests/crt/crtdll_crt_apitest.cmake
+++ b/modules/rostests/apitests/crt/crtdll_crt_apitest.cmake
@@ -447,7 +447,6 @@ list(APPEND SOURCE_CRTDLL
 #    rewind.c
 #    scanf.c
 #    setbuf.c
-    setjmp.c
 #    setlocale.c
 #    setvbuf.c
 #    signal.c
@@ -540,10 +539,12 @@ if(ARCH STREQUAL "i386")
     #    _aullrem.c
     #    _aullshr.c
     #    _chkstk.c
+        setjmp.c
     )
 elseif(ARCH STREQUAL "amd64")
     list(APPEND SOURCE_CRTDLL
     #    __C_specific_handler
+        setjmp.c
     #    _setjmpex.c
     #    _local_unwind.c
     #    longjmp.c

--- a/modules/rostests/apitests/crt/msvcrt_crt_apitest.cmake
+++ b/modules/rostests/apitests/crt/msvcrt_crt_apitest.cmake
@@ -1352,7 +1352,6 @@ if(ARCH STREQUAL "i386")
 elseif(ARCH STREQUAL "amd64")
     list(APPEND SOURCE_MSVCRT
     #    __C_specific_handler
-        setjmp.c
     #    _setjmpex.c
     #    _local_unwind.c
     #    longjmp.c

--- a/modules/rostests/apitests/crt/msvcrt_crt_apitest.cmake
+++ b/modules/rostests/apitests/crt/msvcrt_crt_apitest.cmake
@@ -1145,7 +1145,6 @@ list(APPEND SOURCE_MSVCRT
 #    scanf.c
 #    scanf_s.c
 #    setbuf.c
-    setjmp.c
 #    setlocale.c
 #    setvbuf.c
 #    signal.c
@@ -1264,6 +1263,7 @@ list(APPEND SOURCE_MSVCRT
 if(ARCH STREQUAL "i386")
     list(APPEND SOURCE_MSVCRT
         __getmainargs.c ##FIXME: Moved here because it doesn't work on x64
+        setjmp.c
     #    _CIacos.c
     #    _CIasin.c
     #    _CIatan.c
@@ -1363,6 +1363,7 @@ elseif(ARCH STREQUAL "amd64")
     #    fmodf.c
     #    logf.c
     #    powf.c
+        setjmp.c
     #    sinf.c
     #    sqrtf.c
     )

--- a/modules/rostests/apitests/crt/msvcrt_crt_apitest.cmake
+++ b/modules/rostests/apitests/crt/msvcrt_crt_apitest.cmake
@@ -1352,6 +1352,7 @@ if(ARCH STREQUAL "i386")
 elseif(ARCH STREQUAL "amd64")
     list(APPEND SOURCE_MSVCRT
     #    __C_specific_handler
+        setjmp.c
     #    _setjmpex.c
     #    _local_unwind.c
     #    longjmp.c
@@ -1363,7 +1364,6 @@ elseif(ARCH STREQUAL "amd64")
     #    fmodf.c
     #    logf.c
     #    powf.c
-        setjmp.c
     #    sinf.c
     #    sqrtf.c
     )

--- a/modules/rostests/apitests/crt/msvcrt_crt_apitest.cmake
+++ b/modules/rostests/apitests/crt/msvcrt_crt_apitest.cmake
@@ -1369,6 +1369,7 @@ elseif(ARCH STREQUAL "amd64")
     )
 elseif(ARCH STREQUAL "arm")
     list(APPEND SOURCE_MSVCRT
+        setjmp.c
         __rt_div.c
         __fto64.c
         __64tof.c

--- a/modules/rostests/apitests/crt/msvcrt_crt_apitest.cmake
+++ b/modules/rostests/apitests/crt/msvcrt_crt_apitest.cmake
@@ -1145,7 +1145,7 @@ list(APPEND SOURCE_MSVCRT
 #    scanf.c
 #    scanf_s.c
 #    setbuf.c
-#    _setjmp.c
+    setjmp.c
 #    setlocale.c
 #    setvbuf.c
 #    signal.c
@@ -1352,7 +1352,7 @@ if(ARCH STREQUAL "i386")
 elseif(ARCH STREQUAL "amd64")
     list(APPEND SOURCE_MSVCRT
     #    __C_specific_handler
-    #    _setjmp.c
+        setjmp.c
     #    _setjmpex.c
     #    _local_unwind.c
     #    longjmp.c

--- a/modules/rostests/apitests/crt/ntdll_crt_apitest.cmake
+++ b/modules/rostests/apitests/crt/ntdll_crt_apitest.cmake
@@ -80,6 +80,7 @@ list(APPEND SOURCE_NTDLL
 #    memset.c
 #    pow.c
 #    qsort.c
+    setjmp.c
 #    sin.c
     sprintf.c
 #    sqrt.c
@@ -146,7 +147,6 @@ if(ARCH STREQUAL "i386")
 elseif(ARCH STREQUAL "amd64")
     list(APPEND SOURCE_NTDLL
     #    __C_specific_handler
-        setjmp.c
     #    _setjmpex.c
     #    _local_unwind.c
     #    longjmp.c

--- a/modules/rostests/apitests/crt/ntdll_crt_apitest.cmake
+++ b/modules/rostests/apitests/crt/ntdll_crt_apitest.cmake
@@ -152,6 +152,10 @@ elseif(ARCH STREQUAL "amd64")
     #    _local_unwind.c
     #    longjmp.c
     )
+elseif(ARCH STREQUAL "arm")
+    list(APPEND SOURCE_NTDLL
+        setjmp.c
+    )
 endif()
 
 add_executable(ntdll_crt_apitest testlist.c ${SOURCE_NTDLL})

--- a/modules/rostests/apitests/crt/ntdll_crt_apitest.cmake
+++ b/modules/rostests/apitests/crt/ntdll_crt_apitest.cmake
@@ -146,7 +146,7 @@ if(ARCH STREQUAL "i386")
 elseif(ARCH STREQUAL "amd64")
     list(APPEND SOURCE_NTDLL
     #    __C_specific_handler
-    #    _setjmp.c
+        setjmp.c
     #    _setjmpex.c
     #    _local_unwind.c
     #    longjmp.c

--- a/modules/rostests/apitests/crt/ntdll_crt_apitest.cmake
+++ b/modules/rostests/apitests/crt/ntdll_crt_apitest.cmake
@@ -80,7 +80,6 @@ list(APPEND SOURCE_NTDLL
 #    memset.c
 #    pow.c
 #    qsort.c
-    setjmp.c
 #    sin.c
     sprintf.c
 #    sqrt.c
@@ -129,6 +128,7 @@ list(APPEND SOURCE_NTDLL
 
 if(ARCH STREQUAL "i386")
     list(APPEND SOURCE_NTDLL
+        setjmp.c
     #    _CIpow.c
     #    _ftol.c
     #    _alldiv.c
@@ -147,6 +147,7 @@ if(ARCH STREQUAL "i386")
 elseif(ARCH STREQUAL "amd64")
     list(APPEND SOURCE_NTDLL
     #    __C_specific_handler
+        setjmp.c
     #    _setjmpex.c
     #    _local_unwind.c
     #    longjmp.c

--- a/modules/rostests/apitests/crt/setjmp.c
+++ b/modules/rostests/apitests/crt/setjmp.c
@@ -47,7 +47,10 @@ static void Test_setjmp_2(void)
     volatile int z = 4;
     if (setjmp(g_jmp_buf) == 0)
     {
+        ok_int(TRUE, TRUE);
         Test_longjmp();
+        ok_int(TRUE, FALSE);
+        ok_int(TRUE, FALSE);
         ok_int(TRUE, FALSE);
     }
     else
@@ -55,7 +58,6 @@ static void Test_setjmp_2(void)
         ok_int(x, 2);
         ok_int(y, 3);
         ok_int(z, 4);
-        ok_int(TRUE, TRUE);
     }
 }
 

--- a/modules/rostests/apitests/crt/setjmp.c
+++ b/modules/rostests/apitests/crt/setjmp.c
@@ -7,7 +7,7 @@
 
 #include <apitest.h>
 #include <setjmp.h>
-#
+
 static jmp_buf g_jmp_buf;
 
 static void Test_longjmp(void)

--- a/modules/rostests/apitests/crt/setjmp.c
+++ b/modules/rostests/apitests/crt/setjmp.c
@@ -1,7 +1,7 @@
 /*
  * PROJECT:     ReactOS CRT
  * LICENSE:     MIT (https://spdx.org/licenses/MIT)
- * PURPOSE:     Tests for setjmp/longjmp
+ * PURPOSE:     Tests for setjmp and longjmp
  * COPYRIGHT:   Copyright 2025 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  *              Copyright 2025 Serge Gautherie <reactos-git_serge_171003@gautherie.fr>
  */

--- a/modules/rostests/apitests/crt/setjmp.c
+++ b/modules/rostests/apitests/crt/setjmp.c
@@ -2,7 +2,8 @@
  * PROJECT:     ReactOS CRT
  * LICENSE:     MIT (https://spdx.org/licenses/MIT)
  * PURPOSE:     Tests for setjmp/longjmp
- * COPYRIGHT:   Copyright 2025 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
+ * COPYRIGHT:   Copyright 2025 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ *              Copyright 2025 Serge Gautherie <reactos-git_serge_171003@gautherie.fr>
  */
 
 #include <apitest.h>

--- a/modules/rostests/apitests/crt/setjmp.c
+++ b/modules/rostests/apitests/crt/setjmp.c
@@ -1,0 +1,67 @@
+/*
+ * PROJECT:     ReactOS CRT
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     Tests for setjmp/longjmp
+ * COPYRIGHT:   Copyright 2025 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
+ */
+
+#include <apitest.h>
+#include <setjmp.h>
+#
+static jmp_buf g_jmp_buf;
+
+static void Test_longjmp(void)
+{
+    longjmp(g_jmp_buf, 1);
+}
+
+static void Test_setjmp_0(void)
+{
+    if (setjmp(g_jmp_buf) == 0)
+    {
+        ok_int(TRUE, TRUE);
+    }
+    else
+    {
+        ok_int(TRUE, FALSE);
+    }
+}
+
+static void Test_setjmp_1(void)
+{
+    if (setjmp(g_jmp_buf) == 0)
+    {
+        Test_longjmp();
+        ok_int(TRUE, FALSE);
+    }
+    else
+    {
+        ok_int(TRUE, TRUE);
+    }
+}
+
+static void Test_setjmp_2(void)
+{
+    volatile int x = 2;
+    volatile int y = 3;
+    volatile int z = 4;
+    if (setjmp(g_jmp_buf) == 0)
+    {
+        Test_longjmp();
+        ok_int(TRUE, FALSE);
+    }
+    else
+    {
+        ok_int(x, 2);
+        ok_int(y, 3);
+        ok_int(z, 4);
+        ok_int(TRUE, TRUE);
+    }
+}
+
+START_TEST(setjmp)
+{
+    Test_setjmp_0();
+    Test_setjmp_1();
+    Test_setjmp_2();
+}

--- a/modules/rostests/apitests/crt/setjmp.c
+++ b/modules/rostests/apitests/crt/setjmp.c
@@ -105,7 +105,7 @@ static void TEST_setjmp_3(void)
 
 static void TEST_setjmp_4(void)
 {
-    volatile int x = 101, y = 102, z = 103;
+    volatile int x = 0xFEEDF00D;
     volatile int value;
 
     memset(&g_jmp_buf, 0xCC, sizeof(g_jmp_buf));
@@ -115,23 +115,16 @@ static void TEST_setjmp_4(void)
     {
         ok_int(TRUE, TRUE);
 
-        z = 999;
         TEST_longjmp(0);
 
-        ok_int(TRUE, FALSE);
-        ok_int(TRUE, FALSE);
         ok_int(TRUE, FALSE);
     }
     else if (value == 1)
     {
-        ok_int(x, 101);
-        ok_int(y, 102);
-        ok_int(z, 999);
+        ok_int(x, 0xFEEDF00D);
     }
     else
     {
-        ok_int(TRUE, FALSE);
-        ok_int(TRUE, FALSE);
         ok_int(TRUE, FALSE);
     }
 }

--- a/modules/rostests/apitests/crt/setjmp.c
+++ b/modules/rostests/apitests/crt/setjmp.c
@@ -63,10 +63,10 @@ static void TEST_setjmp_2(void)
     }
 }
 
-static void TEST_longjmp(void)
+static void TEST_longjmp(int value)
 {
     ok_int(TRUE, TRUE);
-    longjmp(g_jmp_buf, 0xBEEFCAFE);
+    longjmp(g_jmp_buf, value);
     ok_int(TRUE, FALSE);
 }
 
@@ -83,7 +83,7 @@ static void TEST_setjmp_3(void)
         ok_int(TRUE, TRUE);
 
         z = 9999;
-        TEST_longjmp();
+        TEST_longjmp(0xBEEFCAFE);
 
         ok_int(TRUE, FALSE);
         ok_int(TRUE, FALSE);
@@ -103,9 +103,43 @@ static void TEST_setjmp_3(void)
     }
 }
 
+static void TEST_setjmp_4(void)
+{
+    volatile int x = 101, y = 102, z = 103;
+    volatile int value;
+
+    memset(&g_jmp_buf, 0, sizeof(g_jmp_buf));
+    value = setjmp(g_jmp_buf);
+
+    if (value == 0)
+    {
+        ok_int(TRUE, TRUE);
+
+        z = 999;
+        TEST_longjmp(0);
+
+        ok_int(TRUE, FALSE);
+        ok_int(TRUE, FALSE);
+        ok_int(TRUE, FALSE);
+    }
+    else if (value == 1)
+    {
+        ok_int(x, 101);
+        ok_int(y, 102);
+        ok_int(z, 999);
+    }
+    else
+    {
+        ok_int(TRUE, FALSE);
+        ok_int(TRUE, FALSE);
+        ok_int(TRUE, FALSE);
+    }
+}
+
 START_TEST(setjmp)
 {
     TEST_setjmp_1();
     TEST_setjmp_2();
     TEST_setjmp_3();
+    TEST_setjmp_4();
 }

--- a/modules/rostests/apitests/crt/setjmp.c
+++ b/modules/rostests/apitests/crt/setjmp.c
@@ -21,8 +21,8 @@ static void TEST_setjmp_1(void)
     {
         ok_int(TRUE, TRUE);
         ok_int(x, 2);
-        ok_int(x, 3);
-        ok_int(x, 4);
+        ok_int(y, 3);
+        ok_int(z, 4);
     }
     else
     {
@@ -63,7 +63,7 @@ static void TEST_setjmp_2(void)
     }
 }
 
-static void TEST_longjmp(int value)
+static void TEST_longjmp(void)
 {
     ok_int(TRUE, TRUE);
     longjmp(g_jmp_buf, 0xBEEFCAFE);

--- a/modules/rostests/apitests/crt/setjmp.c
+++ b/modules/rostests/apitests/crt/setjmp.c
@@ -15,7 +15,7 @@ static void TEST_setjmp_1(void)
 {
     volatile int x = 2, y = 3, z = 4;
 
-    memset(&g_jmp_buf, 0, sizeof(g_jmp_buf));
+    memset(&g_jmp_buf, 0xCC, sizeof(g_jmp_buf));
 
     if (setjmp(g_jmp_buf) == 0)
     {
@@ -38,7 +38,7 @@ static void TEST_setjmp_2(void)
     volatile int x = 1001, y = 1002, z = 1003;
     volatile int value;
 
-    memset(&g_jmp_buf, 0, sizeof(g_jmp_buf));
+    memset(&g_jmp_buf, 0xCC, sizeof(g_jmp_buf));
     value = setjmp(g_jmp_buf);
 
     if (value == 0)
@@ -75,7 +75,7 @@ static void TEST_setjmp_3(void)
     volatile int x = 1001, y = 1002, z = 1003;
     volatile int value;
 
-    memset(&g_jmp_buf, 0, sizeof(g_jmp_buf));
+    memset(&g_jmp_buf, 0xCC, sizeof(g_jmp_buf));
     value = setjmp(g_jmp_buf);
 
     if (value == 0)
@@ -108,7 +108,7 @@ static void TEST_setjmp_4(void)
     volatile int x = 101, y = 102, z = 103;
     volatile int value;
 
-    memset(&g_jmp_buf, 0, sizeof(g_jmp_buf));
+    memset(&g_jmp_buf, 0xCC, sizeof(g_jmp_buf));
     value = setjmp(g_jmp_buf);
 
     if (value == 0)

--- a/modules/rostests/apitests/crt/static_crt_apitest.cmake
+++ b/modules/rostests/apitests/crt/static_crt_apitest.cmake
@@ -14,6 +14,7 @@ list(APPEND SOURCE_STATIC
     mbstowcs.c
     mbtowc.c
     rand_s.c
+    setjmp.c
     sprintf.c
     strcpy.c
     strlen.c

--- a/modules/rostests/apitests/crt/static_crt_apitest.cmake
+++ b/modules/rostests/apitests/crt/static_crt_apitest.cmake
@@ -35,6 +35,7 @@ elseif(ARCH STREQUAL "amd64")
     )
 elseif(ARCH STREQUAL "arm")
     list(APPEND SOURCE_STATIC
+        setjmp.c
         __rt_div.c
         __fto64.c
         __64tof.c

--- a/modules/rostests/apitests/crt/static_crt_apitest.cmake
+++ b/modules/rostests/apitests/crt/static_crt_apitest.cmake
@@ -14,7 +14,6 @@ list(APPEND SOURCE_STATIC
     mbstowcs.c
     mbtowc.c
     rand_s.c
-    setjmp.c
     sprintf.c
     strcpy.c
     strlen.c
@@ -27,10 +26,12 @@ list(APPEND SOURCE_STATIC
 if(ARCH STREQUAL "i386")
     list(APPEND SOURCE_STATIC
         # To be filled
+        setjmp.c
     )
 elseif(ARCH STREQUAL "amd64")
     list(APPEND SOURCE_STATIC
         # To be filled
+        setjmp.c
     )
 elseif(ARCH STREQUAL "arm")
     list(APPEND SOURCE_STATIC

--- a/modules/rostests/apitests/crt/testlist.c
+++ b/modules/rostests/apitests/crt/testlist.c
@@ -57,7 +57,9 @@ const struct test winetest_testlist[] =
     { "_vsnwprintf", func__vsnwprintf },
     { "mbstowcs", func_mbstowcs },
     { "mbtowc", func_mbtowc },
+#if defined(_M_IX86) || defined(_M_AMD64)
     { "setjmp", func_setjmp },
+#endif
     { "_snprintf", func__snprintf },
     { "_snwprintf", func__snwprintf },
     { "sprintf", func_sprintf },

--- a/modules/rostests/apitests/crt/testlist.c
+++ b/modules/rostests/apitests/crt/testlist.c
@@ -57,7 +57,7 @@ const struct test winetest_testlist[] =
     { "_vsnwprintf", func__vsnwprintf },
     { "mbstowcs", func_mbstowcs },
     { "mbtowc", func_mbtowc },
-#if defined(_M_IX86) || defined(_M_AMD64)
+#if defined(_M_IX86) || defined(_M_AMD64) || defined(_M_ARM)
     { "setjmp", func_setjmp },
 #endif
     { "_snprintf", func__snprintf },

--- a/modules/rostests/apitests/crt/testlist.c
+++ b/modules/rostests/apitests/crt/testlist.c
@@ -32,6 +32,7 @@ extern void func__vsnprintf(void);
 extern void func__vsnwprintf(void);
 extern void func_mbstowcs(void);
 extern void func_mbtowc(void);
+extern void func_setjmp(void);
 extern void func_rand_s(void);
 extern void func_sprintf(void);
 extern void func_strcpy(void);
@@ -56,6 +57,7 @@ const struct test winetest_testlist[] =
     { "_vsnwprintf", func__vsnwprintf },
     { "mbstowcs", func_mbstowcs },
     { "mbtowc", func_mbtowc },
+    { "setjmp", func_setjmp },
     { "_snprintf", func__snprintf },
     { "_snwprintf", func__snwprintf },
     { "sprintf", func_sprintf },

--- a/sdk/lib/crt/setjmp/amd64/setjmp.s
+++ b/sdk/lib/crt/setjmp/amd64/setjmp.s
@@ -169,7 +169,7 @@ FUNC longjmp
     jz LABEL3                                   /* If val is 0, jump to LABEL3 */
     jmp qword ptr [rcx + JUMP_BUFFER_Rip]       /* Jump to the stored return address (rip) */
 LABEL3:
-    mov rax, 1                                  /* If val was 0, return 1 */
+    mov rax, 1                                  /* If val was 0, return 1 on second (longjmp) return */
     jmp qword ptr [rcx + JUMP_BUFFER_Rip]       /* Jump to the stored return address (rip) */
 ENDFUNC
 

--- a/sdk/lib/crt/setjmp/amd64/setjmp.s
+++ b/sdk/lib/crt/setjmp/amd64/setjmp.s
@@ -2,8 +2,9 @@
  * PROJECT:     ReactOS system libraries
  * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
  * PURPOSE:     Implementation of setjmp/longjmp
- * COPYRIGHT:   Copyright (c) Timo Kreuzer (timo.kreuzer@reactos.org)
- *              Copyright (c) 2025 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
+ * COPYRIGHT:   Copyright Timo Kreuzer (timo.kreuzer@reactos.org)
+ *              Copyright 2025 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
+ *              Copyright 2025 Serge Gautherie <reactos-git_serge_171003@gautherie.fr>
  */
 
 /* INCLUDES ******************************************************************/

--- a/sdk/lib/crt/setjmp/amd64/setjmp.s
+++ b/sdk/lib/crt/setjmp/amd64/setjmp.s
@@ -158,8 +158,8 @@ FUNC longjmp
     mov [rsp + 8], rax
 
     mov rax, rdx                                /* Move rdx into rax (return value) */
-    test rax, rax                               /* Check if rdx is 0 */
-    jnz LJJMP2                                  /* If rdx is non-zero, jump to LJJMP2 */
+    test rax, rax                               /* Check if rax is 0 */
+    jnz LJJMP2                                  /* If rax is non-zero, jump to LJJMP2 */
     inc rax                                     /* Increment rax */
 LJJMP2:
     ret

--- a/sdk/lib/crt/setjmp/amd64/setjmp.s
+++ b/sdk/lib/crt/setjmp/amd64/setjmp.s
@@ -162,9 +162,9 @@ FUNC longjmp
     movdqu xmm15, [rcx + JUMP_BUFFER_Xmm15]     /* Restore xmm15 */
     mov rax, rdx                                /* Move val into rax (return value) */
     test rax, rax                               /* Check if val is 0 */
-    jnz LJRET                                   /* If val is non-zero, jump to LJRET */
+    jnz LJJMP                                   /* If val is non-zero, jump to LJJMP */
     inc eax                                     /* Increment rax */
-LJRET:
+LJJMP:
     jmp qword ptr [rcx + JUMP_BUFFER_Rip]       /* Jump to the stored return address (rip) */
 ENDFUNC
 

--- a/sdk/lib/crt/setjmp/amd64/setjmp.s
+++ b/sdk/lib/crt/setjmp/amd64/setjmp.s
@@ -49,31 +49,35 @@ FUNC _setjmp
 
     .endprolog
 
-    mov [rcx + JUMP_BUFFER_Rbx], rbx            /* Store rbx */
-    mov [rcx + JUMP_BUFFER_Rsp], rsp            /* Store rsp */
-    mov [rcx + JUMP_BUFFER_Rbp], rbp            /* Store rbp */
-    mov [rcx + JUMP_BUFFER_Rsi], rsi            /* Store rsi (non-volatile on windows) */
-    mov [rcx + JUMP_BUFFER_Rdi], rdi            /* Store rdi (non-volatile on windows) */
-    mov [rcx + JUMP_BUFFER_R12], r12            /* Store r12 */
-    mov [rcx + JUMP_BUFFER_R13], r13            /* Store r13 */
-    mov [rcx + JUMP_BUFFER_R14], r14            /* Store r14 */
-    mov [rcx + JUMP_BUFFER_R15], r15            /* Store r15 */
+    mov [rcx + JUMP_BUFFER_Rbx], rbx            /* Save rbx */
+    mov [rcx + JUMP_BUFFER_Rsp], rsp            /* Save rsp */
+    mov [rcx + JUMP_BUFFER_Rbp], rbp            /* Save rbp */
+    mov [rcx + JUMP_BUFFER_Rsi], rsi            /* Save rsi */
+    mov [rcx + JUMP_BUFFER_Rdi], rdi            /* Save rdi */
+    mov [rcx + JUMP_BUFFER_R12], r12            /* Save r12 */
+    mov [rcx + JUMP_BUFFER_R13], r13            /* Save r13 */
+    mov [rcx + JUMP_BUFFER_R14], r14            /* Save r14 */
+    mov [rcx + JUMP_BUFFER_R15], r15            /* Save r15 */
 
-    mov rax, [rsp + 8]                          /* Get the return address */
-    mov [rcx + JUMP_BUFFER_Rip], rax            /* Store rip (return address) */
+    mov [rcx + JUMP_BUFFER_Xmm6], xmm6          /* Save xmm6 */
+    mov [rcx + JUMP_BUFFER_Xmm7], xmm7          /* Save xmm7 */
+    mov [rcx + JUMP_BUFFER_Xmm8], xmm8          /* Save xmm8 */
+    mov [rcx + JUMP_BUFFER_Xmm9], xmm9          /* Save xmm9 */
+    mov [rcx + JUMP_BUFFER_Xmm10], xmm10        /* Save xmm10 */
+    mov [rcx + JUMP_BUFFER_Xmm11], xmm11        /* Save xmm11 */
+    mov [rcx + JUMP_BUFFER_Xmm12], xmm12        /* Save xmm12 */
+    mov [rcx + JUMP_BUFFER_Xmm13], xmm13        /* Save xmm13 */
+    mov [rcx + JUMP_BUFFER_Xmm14], xmm14        /* Save xmm14 */
+    mov [rcx + JUMP_BUFFER_Xmm15], xmm15        /* Save xmm15 */
 
-    movdqu [rcx + JUMP_BUFFER_Xmm6], xmm6       /* Store xmm6 */
-    movdqu [rcx + JUMP_BUFFER_Xmm7], xmm7       /* Store xmm7 */
-    movdqu [rcx + JUMP_BUFFER_Xmm8], xmm8       /* Store xmm8 */
-    movdqu [rcx + JUMP_BUFFER_Xmm9], xmm9       /* Store xmm9 */
-    movdqu [rcx + JUMP_BUFFER_Xmm10], xmm10     /* Store xmm10 */
-    movdqu [rcx + JUMP_BUFFER_Xmm11], xmm11     /* Store xmm11 */
-    movdqu [rcx + JUMP_BUFFER_Xmm12], xmm12     /* Store xmm12 */
-    movdqu [rcx + JUMP_BUFFER_Xmm13], xmm13     /* Store xmm13 */
-    movdqu [rcx + JUMP_BUFFER_Xmm14], xmm14     /* Store xmm14 */
-    movdqu [rcx + JUMP_BUFFER_Xmm15], xmm15     /* Store xmm15 */
+    lea rax, [rsp + 8]                          /* Get frame */
+    mov [rcx + JUMP_BUFFER_Frame], rax          /* Save frame */
 
-    xor rax, rax                                /* Return 0 on first (_setjmp) return */
+    mov rax, SJ_RET                             /* Get address */
+    mov [rcx + JUMP_BUFFER_Rip], rax            /* Save as RIP */
+
+    xor rax, rax                                /* Return 0 (first time) */
+SJ_RET:
     ret
 ENDFUNC
 
@@ -90,31 +94,33 @@ FUNC _setjmpex
 
     .endprolog
 
-    mov [rcx + JUMP_BUFFER_Rbx], rbx            /* Store rbx */
-    mov [rcx + JUMP_BUFFER_Rsp], rsp            /* Store rsp */
-    mov [rcx + JUMP_BUFFER_Rbp], rbp            /* Store rbp */
-    mov [rcx + JUMP_BUFFER_Rsi], rsi            /* Store rsi (non-volatile on windows) */
-    mov [rcx + JUMP_BUFFER_Rdi], rdi            /* Store rdi (non-volatile on windows) */
-    mov [rcx + JUMP_BUFFER_R12], r12            /* Store r12 */
-    mov [rcx + JUMP_BUFFER_R13], r13            /* Store r13 */
-    mov [rcx + JUMP_BUFFER_R14], r14            /* Store r14 */
-    mov [rcx + JUMP_BUFFER_R15], r15            /* Store r15 */
+    mov [rcx + JUMP_BUFFER_Rbx], rbx            /* Save rbx */
+    mov [rcx + JUMP_BUFFER_Rsp], rsp            /* Save rsp */
+    mov [rcx + JUMP_BUFFER_Rbp], rbp            /* Save rbp */
+    mov [rcx + JUMP_BUFFER_Rsi], rsi            /* Save rsi */
+    mov [rcx + JUMP_BUFFER_Rdi], rdi            /* Save rdi */
+    mov [rcx + JUMP_BUFFER_R12], r12            /* Save r12 */
+    mov [rcx + JUMP_BUFFER_R13], r13            /* Save r13 */
+    mov [rcx + JUMP_BUFFER_R14], r14            /* Save r14 */
+    mov [rcx + JUMP_BUFFER_R15], r15            /* Save r15 */
 
-    mov rax, [rsp + 8]                          /* Get the return address */
-    mov [rcx + JUMP_BUFFER_Rip], rax            /* Store rip (return address) */
+    mov [rcx + JUMP_BUFFER_Xmm6], xmm6          /* Save xmm6 */
+    mov [rcx + JUMP_BUFFER_Xmm7], xmm7          /* Save xmm7 */
+    mov [rcx + JUMP_BUFFER_Xmm8], xmm8          /* Save xmm8 */
+    mov [rcx + JUMP_BUFFER_Xmm9], xmm9          /* Save xmm9 */
+    mov [rcx + JUMP_BUFFER_Xmm10], xmm10        /* Save xmm10 */
+    mov [rcx + JUMP_BUFFER_Xmm11], xmm11        /* Save xmm11 */
+    mov [rcx + JUMP_BUFFER_Xmm12], xmm12        /* Save xmm12 */
+    mov [rcx + JUMP_BUFFER_Xmm13], xmm13        /* Save xmm13 */
+    mov [rcx + JUMP_BUFFER_Xmm14], xmm14        /* Save xmm14 */
+    mov [rcx + JUMP_BUFFER_Xmm15], xmm15        /* Save xmm15 */
 
-    movdqu [rcx + JUMP_BUFFER_Xmm6], xmm6       /* Store xmm6 */
-    movdqu [rcx + JUMP_BUFFER_Xmm7], xmm7       /* Store xmm7 */
-    movdqu [rcx + JUMP_BUFFER_Xmm8], xmm8       /* Store xmm8 */
-    movdqu [rcx + JUMP_BUFFER_Xmm9], xmm9       /* Store xmm9 */
-    movdqu [rcx + JUMP_BUFFER_Xmm10], xmm10     /* Store xmm10 */
-    movdqu [rcx + JUMP_BUFFER_Xmm11], xmm11     /* Store xmm11 */
-    movdqu [rcx + JUMP_BUFFER_Xmm12], xmm12     /* Store xmm12 */
-    movdqu [rcx + JUMP_BUFFER_Xmm13], xmm13     /* Store xmm13 */
-    movdqu [rcx + JUMP_BUFFER_Xmm14], xmm14     /* Store xmm14 */
-    movdqu [rcx + JUMP_BUFFER_Xmm15], xmm15     /* Store xmm15 */
+    mov [rcx + JUMP_BUFFER_Frame], rdx          /* Save frame */
 
-    xor rax, rax                                /* Return 0 on first (_setjmpex) return */
+    mov rax, SJX_RET                            /* Get address */
+    mov [rcx + JUMP_BUFFER_Rip], rax            /* Save as RIP */
+    xor rax, rax                                /* Return 0 (first time) */
+SJX_RET:
     ret
 ENDFUNC
 
@@ -142,27 +148,29 @@ FUNC longjmp
     mov r14, [rcx + JUMP_BUFFER_R14]            /* Restore r14 */
     mov r15, [rcx + JUMP_BUFFER_R15]            /* Restore r15 */
 
-    movdqu xmm6, [rcx + JUMP_BUFFER_Xmm6]       /* Restore xmm6 */
-    movdqu xmm7, [rcx + JUMP_BUFFER_Xmm7]       /* Restore xmm7 */
-    movdqu xmm8, [rcx + JUMP_BUFFER_Xmm8]       /* Restore xmm8 */
-    movdqu xmm9, [rcx + JUMP_BUFFER_Xmm9]       /* Restore xmm9 */
-    movdqu xmm10, [rcx + JUMP_BUFFER_Xmm10]     /* Restore xmm10 */
-    movdqu xmm11, [rcx + JUMP_BUFFER_Xmm11]     /* Restore xmm11 */
-    movdqu xmm12, [rcx + JUMP_BUFFER_Xmm12]     /* Restore xmm12 */
-    movdqu xmm13, [rcx + JUMP_BUFFER_Xmm13]     /* Restore xmm13 */
-    movdqu xmm14, [rcx + JUMP_BUFFER_Xmm14]     /* Restore xmm14 */
-    movdqu xmm15, [rcx + JUMP_BUFFER_Xmm15]     /* Restore xmm15 */
+    mov xmm6, [rcx + JUMP_BUFFER_Xmm6]          /* Restore xmm6 */
+    mov xmm7, [rcx + JUMP_BUFFER_Xmm7]          /* Restore xmm7 */
+    mov xmm8, [rcx + JUMP_BUFFER_Xmm8]          /* Restore xmm8 */
+    mov xmm9, [rcx + JUMP_BUFFER_Xmm9]          /* Restore xmm9 */
+    mov xmm10, [rcx + JUMP_BUFFER_Xmm10]        /* Restore xmm10 */
+    mov xmm11, [rcx + JUMP_BUFFER_Xmm11]        /* Restore xmm11 */
+    mov xmm12, [rcx + JUMP_BUFFER_Xmm12]        /* Restore xmm12 */
+    mov xmm13, [rcx + JUMP_BUFFER_Xmm13]        /* Restore xmm13 */
+    mov xmm14, [rcx + JUMP_BUFFER_Xmm14]        /* Restore xmm14 */
+    mov xmm15, [rcx + JUMP_BUFFER_Xmm15]        /* Restore xmm15 */
 
-    /* Store return address */
-    mov rax, [rcx + JUMP_BUFFER_Rip]
-    mov [rsp + 8], rax
+    mov rax, [rcx + JUMP_BUFFER_Frame]          /* Get frame */
+    mov rsp, rax                                /* Restore frame */
 
-    mov rax, rdx                                /* Move rdx into rax (return value) */
-    test rax, rax                               /* Check if rax is 0 */
-    jnz LJJMP2                                  /* If rax is non-zero, jump to LJJMP2 */
-    inc rax                                     /* Increment rax */
-LJJMP2:
-    ret
+    mov rdx, [rcx + JUMP_BUFFER_Rip]            /* Get target RIP */
+    mov rax, rdx                                /* 2nd argument */
+
+    /* Return 2nd argument, or 1 if it was zero */
+    test rax, rax
+    jnz LJ_JMP
+    inc rax
+LJ_JMP:
+    jmp rdx
 ENDFUNC
 
 END

--- a/sdk/lib/crt/setjmp/amd64/setjmp.s
+++ b/sdk/lib/crt/setjmp/amd64/setjmp.s
@@ -79,7 +79,7 @@ FUNC _setjmp
     movdqu [rcx + JUMP_BUFFER_Xmm15], xmm15     /* Store xmm15 */
     mov rsp, rbp                                /* Restore original rsp */
     pop rbp                                     /* Restore original rbp */
-    xor eax, eax                                /* Return 0 */
+    xor eax, eax                                /* Return 0 on first (_setjmp) return */
 LABEL1:
     ret
 ENDFUNC

--- a/sdk/lib/crt/setjmp/amd64/setjmp.s
+++ b/sdk/lib/crt/setjmp/amd64/setjmp.s
@@ -50,9 +50,6 @@ FUNC _setjmp
 
     .endprolog
 
-    push rbp                                    /* Save rbp */
-    mov rbp, rsp                                /* rbp = rsp */
-    and rsp, -16                                /* Align rsp to 16-byte boundary */
     mov [rcx + JUMP_BUFFER_Rbx], rbx            /* Store rbx */
     mov [rcx + JUMP_BUFFER_Rsp], rsp            /* Store rsp */
     mov [rcx + JUMP_BUFFER_Rbp], rbp            /* Store rbp */
@@ -62,10 +59,13 @@ FUNC _setjmp
     mov [rcx + JUMP_BUFFER_R13], r13            /* Store r13 */
     mov [rcx + JUMP_BUFFER_R14], r14            /* Store r14 */
     mov [rcx + JUMP_BUFFER_R15], r15            /* Store r15 */
+
     lea rax, [rip + SJRET]                      /* Get the return address (see SJRET below) */
     mov [rcx + JUMP_BUFFER_Rip], rax            /* Store rip (return address) */
+
     mov rax, [rsp + 8]                          /* Get frame pointer */
     mov [rcx + JUMP_BUFFER_Frame], rax          /* Store frame pointer */
+
     movdqu [rcx + JUMP_BUFFER_Xmm6], xmm6       /* Store xmm6 */
     movdqu [rcx + JUMP_BUFFER_Xmm7], xmm7       /* Store xmm7 */
     movdqu [rcx + JUMP_BUFFER_Xmm8], xmm8       /* Store xmm8 */
@@ -76,8 +76,7 @@ FUNC _setjmp
     movdqu [rcx + JUMP_BUFFER_Xmm13], xmm13     /* Store xmm13 */
     movdqu [rcx + JUMP_BUFFER_Xmm14], xmm14     /* Store xmm14 */
     movdqu [rcx + JUMP_BUFFER_Xmm15], xmm15     /* Store xmm15 */
-    mov rsp, rbp                                /* Restore original rsp */
-    pop rbp                                     /* Restore original rbp */
+
     xor eax, eax                                /* Return 0 on first (_setjmp) return */
 SJRET:
     ret
@@ -96,9 +95,6 @@ FUNC _setjmpex
 
     .endprolog
 
-    push rbp                                    /* Save rbp */
-    mov rbp, rsp                                /* rbp = rsp */
-    and rsp, -16                                /* Align rsp to 16-byte boundary */
     mov [rcx + JUMP_BUFFER_Rbx], rbx            /* Store rbx */
     mov [rcx + JUMP_BUFFER_Rsp], rsp            /* Store rsp */
     mov [rcx + JUMP_BUFFER_Rbp], rbp            /* Store rbp */
@@ -108,9 +104,12 @@ FUNC _setjmpex
     mov [rcx + JUMP_BUFFER_R13], r13            /* Store r13 */
     mov [rcx + JUMP_BUFFER_R14], r14            /* Store r14 */
     mov [rcx + JUMP_BUFFER_R15], r15            /* Store r15 */
+
     lea rax, [rip + SJXRET]                     /* Get the return address (see SJXRET below) */
     mov [rcx + JUMP_BUFFER_Rip], rax            /* Store rip (return address) */
+
     mov [rcx + JUMP_BUFFER_Frame], rdx          /* Store frame */
+
     movdqu [rcx + JUMP_BUFFER_Xmm6], xmm6       /* Store xmm6 */
     movdqu [rcx + JUMP_BUFFER_Xmm7], xmm7       /* Store xmm7 */
     movdqu [rcx + JUMP_BUFFER_Xmm8], xmm8       /* Store xmm8 */
@@ -121,9 +120,9 @@ FUNC _setjmpex
     movdqu [rcx + JUMP_BUFFER_Xmm13], xmm13     /* Store xmm13 */
     movdqu [rcx + JUMP_BUFFER_Xmm14], xmm14     /* Store xmm14 */
     movdqu [rcx + JUMP_BUFFER_Xmm15], xmm15     /* Store xmm15 */
-    mov rsp, rbp                                /* Restore original rsp */
-    pop rbp                                     /* Restore original rbp */
+
     xor eax, eax                                /* Return 0 on first (_setjmpex) return */
+
 SJXRET:
     ret
 ENDFUNC
@@ -151,8 +150,10 @@ FUNC longjmp
     mov r13, [rcx + JUMP_BUFFER_R13]            /* Restore r13 */
     mov r14, [rcx + JUMP_BUFFER_R14]            /* Restore r14 */
     mov r15, [rcx + JUMP_BUFFER_R15]            /* Restore r15 */
+
     mov rax, [rcx + JUMP_BUFFER_Frame]          /* Get frame pointer */
     mov [rsp + 8], rax                          /* Restore frame pointer */
+
     movdqu xmm6, [rcx + JUMP_BUFFER_Xmm6]       /* Restore xmm6 */
     movdqu xmm7, [rcx + JUMP_BUFFER_Xmm7]       /* Restore xmm7 */
     movdqu xmm8, [rcx + JUMP_BUFFER_Xmm8]       /* Restore xmm8 */
@@ -163,10 +164,14 @@ FUNC longjmp
     movdqu xmm13, [rcx + JUMP_BUFFER_Xmm13]     /* Restore xmm13 */
     movdqu xmm14, [rcx + JUMP_BUFFER_Xmm14]     /* Restore xmm14 */
     movdqu xmm15, [rcx + JUMP_BUFFER_Xmm15]     /* Restore xmm15 */
+
     mov rax, rdx                                /* Move val into rax (return value) */
+
     test rax, rax                               /* Check if val is 0 */
     jnz LJJMP                                   /* If val is non-zero, jump to LJJMP */
+
     inc rax                                     /* Increment rax */
+
 LJJMP:
     jmp qword ptr [rcx + JUMP_BUFFER_Rip]       /* Jump to the stored return address (rip) */
 ENDFUNC

--- a/sdk/lib/crt/setjmp/amd64/setjmp.s
+++ b/sdk/lib/crt/setjmp/amd64/setjmp.s
@@ -65,7 +65,7 @@ FUNC _setjmp
     mov [rcx + JUMP_BUFFER_R15], r15            /* Store r15 */
     lea rax, [rip + LABEL1]                     /* Get the return address (LABEL1) */
     mov [rcx + JUMP_BUFFER_Rip], rax            /* Store rip (return address) */
-    mov rax, [rsp + 8]
+    mov rax, [rsp + 8]                          /* Get frame pointer */
     mov [rcx + JUMP_BUFFER_Frame], rax          /* Store frame pointer */
     movdqu [rcx + JUMP_BUFFER_Xmm6], xmm6       /* Store xmm6 */
     movdqu [rcx + JUMP_BUFFER_Xmm7], xmm7       /* Store xmm7 */
@@ -152,7 +152,7 @@ FUNC longjmp
     mov r13, [rcx + JUMP_BUFFER_R13]            /* Restore r13 */
     mov r14, [rcx + JUMP_BUFFER_R14]            /* Restore r14 */
     mov r15, [rcx + JUMP_BUFFER_R15]            /* Restore r15 */
-    mov rax, [rcx + JUMP_BUFFER_Frame]          /* Restore frame pointer */
+    mov rax, [rcx + JUMP_BUFFER_Frame]          /* Get frame pointer */
     mov [rsp + 8], rax                          /* Restore frame pointer */
     movdqu xmm6, [rcx + JUMP_BUFFER_Xmm6]       /* Restore xmm6 */
     movdqu xmm7, [rcx + JUMP_BUFFER_Xmm7]       /* Restore xmm7 */

--- a/sdk/lib/crt/setjmp/amd64/setjmp.s
+++ b/sdk/lib/crt/setjmp/amd64/setjmp.s
@@ -61,7 +61,7 @@ FUNC _setjmp
 
     mov [rcx + JUMP_BUFFER_Frame], rbp          /* Store frame pointer (rbp) */
 
-    lea rax, [esp + 8]                          /* Get the return address */
+    mov rax, [esp + 8]                          /* Get the return address */
     mov [rcx + JUMP_BUFFER_Rip], rax            /* Store rip (return address) */
 
     movdqu [rcx + JUMP_BUFFER_Xmm6], xmm6       /* Store xmm6 */
@@ -103,7 +103,7 @@ FUNC _setjmpex
     mov [rcx + JUMP_BUFFER_R15], r15            /* Store r15 */
     mov [rcx + JUMP_BUFFER_Frame], rdx          /* Store frame pointer from 2nd argument */
 
-    lea rax, [esp + 8]                          /* Get the return address */
+    mov rax, [esp + 8]                          /* Get the return address */
     mov [rcx + JUMP_BUFFER_Rip], rax            /* Store rip (return address) */
 
     movdqu [rcx + JUMP_BUFFER_Xmm6], xmm6       /* Store xmm6 */
@@ -145,8 +145,9 @@ FUNC longjmp
     mov r14, [rcx + JUMP_BUFFER_R14]            /* Restore r14 */
     mov r15, [rcx + JUMP_BUFFER_R15]            /* Restore r15 */
 
-    mov rax, [rcx + JUMP_BUFFER_Frame]          /* Get frame pointer */
-    test rax, rax                               /* Restore frame pointer (rbp) if non-zero */
+    /* Restore frame pointer (rbp) if non-zero */
+    mov rax, [rcx + JUMP_BUFFER_Frame]
+    test rax, rax
     jz LJJMP1
     mov rbp, rax
 LJJMP1:
@@ -162,8 +163,9 @@ LJJMP1:
     movdqu xmm14, [rcx + JUMP_BUFFER_Xmm14]     /* Restore xmm14 */
     movdqu xmm15, [rcx + JUMP_BUFFER_Xmm15]     /* Restore xmm15 */
 
-    mov rax, [rcx + JUMP_BUFFER_Rip]             /* Get return address */
-    mov [esp + 8], rax                           /* Store return address */
+    /* Store return address */
+    mov rax, [rcx + JUMP_BUFFER_Rip]
+    mov [esp + 8], rax
 
     mov rax, rdx                                /* Move val into rax (return value) */
     test rax, rax                               /* Check if val is 0 */

--- a/sdk/lib/crt/setjmp/amd64/setjmp.s
+++ b/sdk/lib/crt/setjmp/amd64/setjmp.s
@@ -59,7 +59,7 @@ FUNC _setjmp
     mov [rcx + JUMP_BUFFER_R13], r13            /* Store r13 */
     mov [rcx + JUMP_BUFFER_R14], r14            /* Store r14 */
     mov [rcx + JUMP_BUFFER_R15], r15            /* Store r15 */
-    lea rax, [rip + JKRET]                      /* Get the return address (see JKRET below) */
+    lea rax, [rip + SJRET]                      /* Get the return address (see SJRET below) */
     mov [rcx + JUMP_BUFFER_Rip], rax            /* Store rip (return address) */
     mov rax, [rsp + 8]                          /* Get frame pointer */
     mov [rcx + JUMP_BUFFER_Frame], rax          /* Store frame pointer */
@@ -76,7 +76,7 @@ FUNC _setjmp
     mov rsp, rbp                                /* Restore original rsp */
     pop rbp                                     /* Restore original rbp */
     xor eax, eax                                /* Return 0 on first (_setjmp) return */
-JKRET:
+SJRET:
     ret
 ENDFUNC
 
@@ -105,7 +105,7 @@ FUNC _setjmpex
     mov [rcx + JUMP_BUFFER_R13], r13            /* Store r13 */
     mov [rcx + JUMP_BUFFER_R14], r14            /* Store r14 */
     mov [rcx + JUMP_BUFFER_R15], r15            /* Store r15 */
-    lea rax, [rip + JKXRET]                     /* Get the return address (see JKXRET below) */
+    lea rax, [rip + SJXRET]                     /* Get the return address (see SJXRET below) */
     mov [rcx + JUMP_BUFFER_Rip], rax            /* Store rip (return address) */
     mov [rcx + JUMP_BUFFER_Frame], rdx          /* Store frame */
     movdqu [rcx + JUMP_BUFFER_Xmm6], xmm6       /* Store xmm6 */
@@ -121,7 +121,7 @@ FUNC _setjmpex
     mov rsp, rbp                                /* Restore original rsp */
     pop rbp                                     /* Restore original rbp */
     xor eax, eax                                /* Return 0 on first (_setjmpex) return */
-JKXRET:
+SJXRET:
     ret
 ENDFUNC
 

--- a/sdk/lib/crt/setjmp/amd64/setjmp.s
+++ b/sdk/lib/crt/setjmp/amd64/setjmp.s
@@ -163,7 +163,7 @@ FUNC longjmp
     mov rax, rdx                                /* Move val into rax (return value) */
     test rax, rax                               /* Check if val is 0 */
     jnz LJJMP                                   /* If val is non-zero, jump to LJJMP */
-    inc eax                                     /* Increment rax */
+    inc rax                                     /* Increment rax */
 LJJMP:
     jmp qword ptr [rcx + JUMP_BUFFER_Rip]       /* Jump to the stored return address (rip) */
 ENDFUNC

--- a/sdk/lib/crt/setjmp/amd64/setjmp.s
+++ b/sdk/lib/crt/setjmp/amd64/setjmp.s
@@ -63,7 +63,7 @@ FUNC _setjmp
     mov [rcx + JUMP_BUFFER_R13], r13            /* Store r13 */
     mov [rcx + JUMP_BUFFER_R14], r14            /* Store r14 */
     mov [rcx + JUMP_BUFFER_R15], r15            /* Store r15 */
-    lea rax, [rip + LABEL1]                     /* Get the return address (LABEL1 below) */
+    lea rax, [rip + JKRET]                      /* Get the return address (see JKRET below) */
     mov [rcx + JUMP_BUFFER_Rip], rax            /* Store rip (return address) */
     mov rax, [rsp + 8]                          /* Get frame pointer */
     mov [rcx + JUMP_BUFFER_Frame], rax          /* Store frame pointer */
@@ -80,7 +80,7 @@ FUNC _setjmp
     mov rsp, rbp                                /* Restore original rsp */
     pop rbp                                     /* Restore original rbp */
     xor eax, eax                                /* Return 0 on first (_setjmp) return */
-LABEL1:
+JKRET:
     ret
 ENDFUNC
 
@@ -109,7 +109,7 @@ FUNC _setjmpex
     mov [rcx + JUMP_BUFFER_R13], r13            /* Store r13 */
     mov [rcx + JUMP_BUFFER_R14], r14            /* Store r14 */
     mov [rcx + JUMP_BUFFER_R15], r15            /* Store r15 */
-    lea rax, [rip + LABEL2]                     /* Get the return address (LABEL2 below) */
+    lea rax, [rip + JKXRET]                     /* Get the return address (see JKXRET below) */
     mov [rcx + JUMP_BUFFER_Rip], rax            /* Store rip (return address) */
     mov [rcx + JUMP_BUFFER_Frame], rdx          /* Store frame */
     movdqu [rcx + JUMP_BUFFER_Xmm6], xmm6       /* Store xmm6 */
@@ -125,7 +125,7 @@ FUNC _setjmpex
     mov rsp, rbp                                /* Restore original rsp */
     pop rbp                                     /* Restore original rbp */
     xor eax, eax                                /* Return 0 on first (_setjmpex) return */
-LABEL2:
+JKXRET:
     ret
 ENDFUNC
 
@@ -166,9 +166,9 @@ FUNC longjmp
     movdqu xmm15, [rcx + JUMP_BUFFER_Xmm15]     /* Restore xmm15 */
     mov rax, rdx                                /* Move val into rax (return value) */
     test rax, rax                               /* Check if val is 0 */
-    jz LABEL3                                   /* If val is 0, jump to LABEL3 */
+    jz LJRET                                    /* If val is 0, jump to LJRET */
     jmp qword ptr [rcx + JUMP_BUFFER_Rip]       /* Jump to the stored return address (rip) */
-LABEL3:
+LJRET:
     mov rax, 1                                  /* If val was 0, return 1 on second (longjmp) return */
     jmp qword ptr [rcx + JUMP_BUFFER_Rip]       /* Jump to the stored return address (rip) */
 ENDFUNC

--- a/sdk/lib/crt/setjmp/amd64/setjmp.s
+++ b/sdk/lib/crt/setjmp/amd64/setjmp.s
@@ -1,7 +1,7 @@
 /*
  * PROJECT:     ReactOS system libraries
  * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
- * PURPOSE:     Implementation of amd64 setjmp/longjmp
+ * PURPOSE:     Implementation of amd64 _setjmp / longjmp
  * COPYRIGHT:   Copyright Timo Kreuzer (timo.kreuzer@reactos.org)
  *              Copyright 2025 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
  *              Copyright 2025 Serge Gautherie <reactos-git_serge_171003@gautherie.fr>

--- a/sdk/lib/crt/setjmp/amd64/setjmp.s
+++ b/sdk/lib/crt/setjmp/amd64/setjmp.s
@@ -72,7 +72,7 @@ FUNC _setjmp
 
     mov [rcx + JUMP_BUFFER_Frame], rbp          /* Save frame */
 
-    mov rax, [rsp]                              /* Get address */
+    mov rax, [rsp]                              /* Get return address */
     mov [rcx + JUMP_BUFFER_Rip], rax            /* Save as RIP */
 
     xor rax, rax                                /* Return 0 (first time) */
@@ -113,16 +113,17 @@ FUNC _setjmpex
     movdqu [rcx + JUMP_BUFFER_Xmm14], xmm14     /* Save xmm14 */
     movdqu [rcx + JUMP_BUFFER_Xmm15], xmm15     /* Save xmm15 */
 
-    mov [rcx + JUMP_BUFFER_Frame], rdx          /* Save frame */
+    mov [rcx + JUMP_BUFFER_Frame], rdx          /* Save frame from 2nd argument */
 
-    mov rax, [rsp]                              /* Get address */
+    mov rax, [rsp]                              /* Get return address */
     mov [rcx + JUMP_BUFFER_Rip], rax            /* Save as RIP */
 
     xor rax, rax                                /* Return 0 (first time) */
-SJX_RET:
     ret
 ENDFUNC
 
+EXTERN RtlLookupFunctionEntry:PROC
+EXTERN RtlVirtualUnwind:PROC
 
 /*!
  * void longjmp(jmp_buf env, int value);
@@ -136,6 +137,11 @@ PUBLIC longjmp
 FUNC longjmp
 
     .endprolog
+
+    /*
+     * FIXME: Unwinding (Windows x64)
+     * NOTE: Use RtlLookupFunctionEntry, RtlVirtualUnwind
+     */
 
     mov rbx, [rcx + JUMP_BUFFER_Rbx]            /* Restore rbx */
     mov rsp, [rcx + JUMP_BUFFER_Rsp]            /* Restore rsp */

--- a/sdk/lib/crt/setjmp/amd64/setjmp.s
+++ b/sdk/lib/crt/setjmp/amd64/setjmp.s
@@ -59,16 +59,16 @@ FUNC _setjmp
     mov [rcx + JUMP_BUFFER_R14], r14            /* Save r14 */
     mov [rcx + JUMP_BUFFER_R15], r15            /* Save r15 */
 
-    mov [rcx + JUMP_BUFFER_Xmm6], xmm6          /* Save xmm6 */
-    mov [rcx + JUMP_BUFFER_Xmm7], xmm7          /* Save xmm7 */
-    mov [rcx + JUMP_BUFFER_Xmm8], xmm8          /* Save xmm8 */
-    mov [rcx + JUMP_BUFFER_Xmm9], xmm9          /* Save xmm9 */
-    mov [rcx + JUMP_BUFFER_Xmm10], xmm10        /* Save xmm10 */
-    mov [rcx + JUMP_BUFFER_Xmm11], xmm11        /* Save xmm11 */
-    mov [rcx + JUMP_BUFFER_Xmm12], xmm12        /* Save xmm12 */
-    mov [rcx + JUMP_BUFFER_Xmm13], xmm13        /* Save xmm13 */
-    mov [rcx + JUMP_BUFFER_Xmm14], xmm14        /* Save xmm14 */
-    mov [rcx + JUMP_BUFFER_Xmm15], xmm15        /* Save xmm15 */
+    movdqu [rcx + JUMP_BUFFER_Xmm6], xmm6       /* Save xmm6 */
+    movdqu [rcx + JUMP_BUFFER_Xmm7], xmm7       /* Save xmm7 */
+    movdqu [rcx + JUMP_BUFFER_Xmm8], xmm8       /* Save xmm8 */
+    movdqu [rcx + JUMP_BUFFER_Xmm9], xmm9       /* Save xmm9 */
+    movdqu [rcx + JUMP_BUFFER_Xmm10], xmm10     /* Save xmm10 */
+    movdqu [rcx + JUMP_BUFFER_Xmm11], xmm11     /* Save xmm11 */
+    movdqu [rcx + JUMP_BUFFER_Xmm12], xmm12     /* Save xmm12 */
+    movdqu [rcx + JUMP_BUFFER_Xmm13], xmm13     /* Save xmm13 */
+    movdqu [rcx + JUMP_BUFFER_Xmm14], xmm14     /* Save xmm14 */
+    movdqu [rcx + JUMP_BUFFER_Xmm15], xmm15     /* Save xmm15 */
 
     lea rax, [rsp + 8]                          /* Get frame */
     mov [rcx + JUMP_BUFFER_Frame], rax          /* Save frame */
@@ -104,16 +104,16 @@ FUNC _setjmpex
     mov [rcx + JUMP_BUFFER_R14], r14            /* Save r14 */
     mov [rcx + JUMP_BUFFER_R15], r15            /* Save r15 */
 
-    mov [rcx + JUMP_BUFFER_Xmm6], xmm6          /* Save xmm6 */
-    mov [rcx + JUMP_BUFFER_Xmm7], xmm7          /* Save xmm7 */
-    mov [rcx + JUMP_BUFFER_Xmm8], xmm8          /* Save xmm8 */
-    mov [rcx + JUMP_BUFFER_Xmm9], xmm9          /* Save xmm9 */
-    mov [rcx + JUMP_BUFFER_Xmm10], xmm10        /* Save xmm10 */
-    mov [rcx + JUMP_BUFFER_Xmm11], xmm11        /* Save xmm11 */
-    mov [rcx + JUMP_BUFFER_Xmm12], xmm12        /* Save xmm12 */
-    mov [rcx + JUMP_BUFFER_Xmm13], xmm13        /* Save xmm13 */
-    mov [rcx + JUMP_BUFFER_Xmm14], xmm14        /* Save xmm14 */
-    mov [rcx + JUMP_BUFFER_Xmm15], xmm15        /* Save xmm15 */
+    movdqu [rcx + JUMP_BUFFER_Xmm6], xmm6       /* Save xmm6 */
+    movdqu [rcx + JUMP_BUFFER_Xmm7], xmm7       /* Save xmm7 */
+    movdqu [rcx + JUMP_BUFFER_Xmm8], xmm8       /* Save xmm8 */
+    movdqu [rcx + JUMP_BUFFER_Xmm9], xmm9       /* Save xmm9 */
+    movdqu [rcx + JUMP_BUFFER_Xmm10], xmm10     /* Save xmm10 */
+    movdqu [rcx + JUMP_BUFFER_Xmm11], xmm11     /* Save xmm11 */
+    movdqu [rcx + JUMP_BUFFER_Xmm12], xmm12     /* Save xmm12 */
+    movdqu [rcx + JUMP_BUFFER_Xmm13], xmm13     /* Save xmm13 */
+    movdqu [rcx + JUMP_BUFFER_Xmm14], xmm14     /* Save xmm14 */
+    movdqu [rcx + JUMP_BUFFER_Xmm15], xmm15     /* Save xmm15 */
 
     mov [rcx + JUMP_BUFFER_Frame], rdx          /* Save frame */
 
@@ -148,16 +148,16 @@ FUNC longjmp
     mov r14, [rcx + JUMP_BUFFER_R14]            /* Restore r14 */
     mov r15, [rcx + JUMP_BUFFER_R15]            /* Restore r15 */
 
-    mov xmm6, [rcx + JUMP_BUFFER_Xmm6]          /* Restore xmm6 */
-    mov xmm7, [rcx + JUMP_BUFFER_Xmm7]          /* Restore xmm7 */
-    mov xmm8, [rcx + JUMP_BUFFER_Xmm8]          /* Restore xmm8 */
-    mov xmm9, [rcx + JUMP_BUFFER_Xmm9]          /* Restore xmm9 */
-    mov xmm10, [rcx + JUMP_BUFFER_Xmm10]        /* Restore xmm10 */
-    mov xmm11, [rcx + JUMP_BUFFER_Xmm11]        /* Restore xmm11 */
-    mov xmm12, [rcx + JUMP_BUFFER_Xmm12]        /* Restore xmm12 */
-    mov xmm13, [rcx + JUMP_BUFFER_Xmm13]        /* Restore xmm13 */
-    mov xmm14, [rcx + JUMP_BUFFER_Xmm14]        /* Restore xmm14 */
-    mov xmm15, [rcx + JUMP_BUFFER_Xmm15]        /* Restore xmm15 */
+    movdqu xmm6, [rcx + JUMP_BUFFER_Xmm6]       /* Restore xmm6 */
+    movdqu xmm7, [rcx + JUMP_BUFFER_Xmm7]       /* Restore xmm7 */
+    movdqu xmm8, [rcx + JUMP_BUFFER_Xmm8]       /* Restore xmm8 */
+    movdqu xmm9, [rcx + JUMP_BUFFER_Xmm9]       /* Restore xmm9 */
+    movdqu xmm10, [rcx + JUMP_BUFFER_Xmm10]     /* Restore xmm10 */
+    movdqu xmm11, [rcx + JUMP_BUFFER_Xmm11]     /* Restore xmm11 */
+    movdqu xmm12, [rcx + JUMP_BUFFER_Xmm12]     /* Restore xmm12 */
+    movdqu xmm13, [rcx + JUMP_BUFFER_Xmm13]     /* Restore xmm13 */
+    movdqu xmm14, [rcx + JUMP_BUFFER_Xmm14]     /* Restore xmm14 */
+    movdqu xmm15, [rcx + JUMP_BUFFER_Xmm15]     /* Restore xmm15 */
 
     mov rax, [rcx + JUMP_BUFFER_Frame]          /* Get frame */
     mov rsp, rax                                /* Restore frame */

--- a/sdk/lib/crt/setjmp/amd64/setjmp.s
+++ b/sdk/lib/crt/setjmp/amd64/setjmp.s
@@ -166,11 +166,9 @@ FUNC longjmp
     movdqu xmm15, [rcx + JUMP_BUFFER_Xmm15]     /* Restore xmm15 */
     mov rax, rdx                                /* Move val into rax (return value) */
     test rax, rax                               /* Check if val is 0 */
-    jz LJRET                                    /* If val is 0, jump to LJRET */
-    jmp qword ptr [rcx + JUMP_BUFFER_Rip]       /* Jump to the stored return address (rip) */
+    jnz LJRET                                   /* If val is non-zero, jump to LJRET */
+    inc eax                                     /* Increment rax */
 LJRET:
-    xor rax, rax
-    inc rax                                     /* If val was 0, return 1 on second (longjmp) return */
     jmp qword ptr [rcx + JUMP_BUFFER_Rip]       /* Jump to the stored return address (rip) */
 ENDFUNC
 

--- a/sdk/lib/crt/setjmp/amd64/setjmp.s
+++ b/sdk/lib/crt/setjmp/amd64/setjmp.s
@@ -32,7 +32,6 @@
 #define JUMP_BUFFER_Xmm14 224 /* 0xe0 */
 #define JUMP_BUFFER_Xmm15 240 /* 0xf0 */
 
-
 /* FUNCTIONS ******************************************************************/
 .code64
 

--- a/sdk/lib/crt/setjmp/amd64/setjmp.s
+++ b/sdk/lib/crt/setjmp/amd64/setjmp.s
@@ -70,14 +70,12 @@ FUNC _setjmp
     movdqu [rcx + JUMP_BUFFER_Xmm14], xmm14     /* Save xmm14 */
     movdqu [rcx + JUMP_BUFFER_Xmm15], xmm15     /* Save xmm15 */
 
-    lea rax, [rsp + 8]                          /* Get frame */
-    mov [rcx + JUMP_BUFFER_Frame], rax          /* Save frame */
+    mov [rcx + JUMP_BUFFER_Frame], rbp          /* Save frame */
 
-    mov rax, SJ_RET                             /* Get address */
+    mov rax, [rsp]                              /* Get address */
     mov [rcx + JUMP_BUFFER_Rip], rax            /* Save as RIP */
 
     xor rax, rax                                /* Return 0 (first time) */
-SJ_RET:
     ret
 ENDFUNC
 
@@ -117,8 +115,9 @@ FUNC _setjmpex
 
     mov [rcx + JUMP_BUFFER_Frame], rdx          /* Save frame */
 
-    mov rax, SJX_RET                            /* Get address */
+    mov rax, [rsp]                              /* Get address */
     mov [rcx + JUMP_BUFFER_Rip], rax            /* Save as RIP */
+
     xor rax, rax                                /* Return 0 (first time) */
 SJX_RET:
     ret
@@ -159,18 +158,17 @@ FUNC longjmp
     movdqu xmm14, [rcx + JUMP_BUFFER_Xmm14]     /* Restore xmm14 */
     movdqu xmm15, [rcx + JUMP_BUFFER_Xmm15]     /* Restore xmm15 */
 
-    mov rax, [rcx + JUMP_BUFFER_Frame]          /* Get frame */
-    mov rsp, rax                                /* Restore frame */
+    mov rax, [rcx + JUMP_BUFFER_Rip]            /* Get rip */
+    mov [rsp], rax                              /* Store return address */
 
-    mov rdx, [rcx + JUMP_BUFFER_Rip]            /* Get target RIP */
-    mov rax, rdx                                /* 2nd argument */
+    mov rax, rdx                                /* Get 2nd argument */
 
     /* Return 2nd argument, or 1 if it was zero */
     test rax, rax
     jnz LJ_JMP
     inc rax
 LJ_JMP:
-    jmp rdx
+    ret
 ENDFUNC
 
 END

--- a/sdk/lib/crt/setjmp/amd64/setjmp.s
+++ b/sdk/lib/crt/setjmp/amd64/setjmp.s
@@ -59,9 +59,7 @@ FUNC _setjmp
     mov [rcx + JUMP_BUFFER_R14], r14            /* Store r14 */
     mov [rcx + JUMP_BUFFER_R15], r15            /* Store r15 */
 
-    mov [rcx + JUMP_BUFFER_Frame], rbp          /* Store frame pointer (rbp) */
-
-    mov rax, [esp + 8]                          /* Get the return address */
+    mov rax, [rsp + 8]                          /* Get the return address */
     mov [rcx + JUMP_BUFFER_Rip], rax            /* Store rip (return address) */
 
     movdqu [rcx + JUMP_BUFFER_Xmm6], xmm6       /* Store xmm6 */
@@ -101,9 +99,8 @@ FUNC _setjmpex
     mov [rcx + JUMP_BUFFER_R13], r13            /* Store r13 */
     mov [rcx + JUMP_BUFFER_R14], r14            /* Store r14 */
     mov [rcx + JUMP_BUFFER_R15], r15            /* Store r15 */
-    mov [rcx + JUMP_BUFFER_Frame], rdx          /* Store frame pointer from 2nd argument */
 
-    mov rax, [esp + 8]                          /* Get the return address */
+    mov rax, [rsp + 8]                          /* Get the return address */
     mov [rcx + JUMP_BUFFER_Rip], rax            /* Store rip (return address) */
 
     movdqu [rcx + JUMP_BUFFER_Xmm6], xmm6       /* Store xmm6 */
@@ -145,13 +142,6 @@ FUNC longjmp
     mov r14, [rcx + JUMP_BUFFER_R14]            /* Restore r14 */
     mov r15, [rcx + JUMP_BUFFER_R15]            /* Restore r15 */
 
-    /* Restore frame pointer (rbp) if non-zero */
-    mov rax, [rcx + JUMP_BUFFER_Frame]
-    test rax, rax
-    jz LJJMP1
-    mov rbp, rax
-LJJMP1:
-
     movdqu xmm6, [rcx + JUMP_BUFFER_Xmm6]       /* Restore xmm6 */
     movdqu xmm7, [rcx + JUMP_BUFFER_Xmm7]       /* Restore xmm7 */
     movdqu xmm8, [rcx + JUMP_BUFFER_Xmm8]       /* Restore xmm8 */
@@ -167,9 +157,9 @@ LJJMP1:
     mov rax, [rcx + JUMP_BUFFER_Rip]
     mov [esp + 8], rax
 
-    mov rax, rdx                                /* Move val into rax (return value) */
-    test rax, rax                               /* Check if val is 0 */
-    jnz LJJMP2                                  /* If val is non-zero, jump to LJJMP2 */
+    mov rax, rdx                                /* Move rdx into rax (return value) */
+    test rax, rax                               /* Check if rdx is 0 */
+    jnz LJJMP2                                  /* If rdx is non-zero, jump to LJJMP2 */
     inc rax                                     /* Increment rax */
 LJJMP2:
     ret

--- a/sdk/lib/crt/setjmp/amd64/setjmp.s
+++ b/sdk/lib/crt/setjmp/amd64/setjmp.s
@@ -101,8 +101,7 @@ FUNC _setjmpex
     mov [rcx + JUMP_BUFFER_R13], r13            /* Store r13 */
     mov [rcx + JUMP_BUFFER_R14], r14            /* Store r14 */
     mov [rcx + JUMP_BUFFER_R15], r15            /* Store r15 */
-
-    mov [rcx + JUMP_BUFFER_Frame], rdx          /* Store frame pointer from argument */
+    mov [rcx + JUMP_BUFFER_Frame], rdx          /* Store frame pointer from 2nd argument */
 
     lea rax, [esp + 8]                          /* Get the return address */
     mov [rcx + JUMP_BUFFER_Rip], rax            /* Store rip (return address) */

--- a/sdk/lib/crt/setjmp/amd64/setjmp.s
+++ b/sdk/lib/crt/setjmp/amd64/setjmp.s
@@ -155,7 +155,7 @@ FUNC longjmp
 
     /* Store return address */
     mov rax, [rcx + JUMP_BUFFER_Rip]
-    mov [esp + 8], rax
+    mov [rsp + 8], rax
 
     mov rax, rdx                                /* Move rdx into rax (return value) */
     test rax, rax                               /* Check if rdx is 0 */

--- a/sdk/lib/crt/setjmp/amd64/setjmp.s
+++ b/sdk/lib/crt/setjmp/amd64/setjmp.s
@@ -6,6 +6,8 @@
  *              Copyright (c) 2025 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
  */
 
+/* INCLUDES ******************************************************************/
+
 #include <asm.inc>
 #include <ksamd64.inc>
 

--- a/sdk/lib/crt/setjmp/amd64/setjmp.s
+++ b/sdk/lib/crt/setjmp/amd64/setjmp.s
@@ -124,7 +124,7 @@ FUNC _setjmpex
     movdqu [rcx + JUMP_BUFFER_Xmm15], xmm15     /* Store xmm15 */
     mov rsp, rbp                                /* Restore original rsp */
     pop rbp                                     /* Restore original rbp */
-    xor eax, eax                                /* Return 0 */
+    xor eax, eax                                /* Return 0 on first (_setjmpex) return */
 LABEL2:
     ret
 ENDFUNC

--- a/sdk/lib/crt/setjmp/amd64/setjmp.s
+++ b/sdk/lib/crt/setjmp/amd64/setjmp.s
@@ -4,7 +4,6 @@
  * PURPOSE:     Implementation of amd64 _setjmp / longjmp
  * COPYRIGHT:   Copyright Timo Kreuzer (timo.kreuzer@reactos.org)
  *              Copyright 2025 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
- *              Copyright 2025 Serge Gautherie <reactos-git_serge_171003@gautherie.fr>
  */
 
 /* INCLUDES ******************************************************************/

--- a/sdk/lib/crt/setjmp/amd64/setjmp.s
+++ b/sdk/lib/crt/setjmp/amd64/setjmp.s
@@ -55,15 +55,15 @@ FUNC _setjmp
     mov rbp, rsp                                /* rbp = rsp */
     and rsp, -16                                /* Align rsp to 16-byte boundary */
     mov [rcx + JUMP_BUFFER_Rbx], rbx            /* Store rbx */
-    mov [rcx + JUMP_BUFFER_Rsp], rsp            /* Store rsp (aligned) */
-    mov [rcx + JUMP_BUFFER_Rbp], rbp            /* Store rbp (aligned) */
+    mov [rcx + JUMP_BUFFER_Rsp], rsp            /* Store rsp */
+    mov [rcx + JUMP_BUFFER_Rbp], rbp            /* Store rbp */
     mov [rcx + JUMP_BUFFER_Rsi], rsi            /* Store rsi (non-volatile on windows) */
     mov [rcx + JUMP_BUFFER_Rdi], rdi            /* Store rdi (non-volatile on windows) */
     mov [rcx + JUMP_BUFFER_R12], r12            /* Store r12 */
     mov [rcx + JUMP_BUFFER_R13], r13            /* Store r13 */
     mov [rcx + JUMP_BUFFER_R14], r14            /* Store r14 */
     mov [rcx + JUMP_BUFFER_R15], r15            /* Store r15 */
-    lea rax, [rip + LABEL1]                     /* Get the return address (LABEL1) */
+    lea rax, [rip + LABEL1]                     /* Get the return address (LABEL1 below) */
     mov [rcx + JUMP_BUFFER_Rip], rax            /* Store rip (return address) */
     mov rax, [rsp + 8]                          /* Get frame pointer */
     mov [rcx + JUMP_BUFFER_Frame], rax          /* Store frame pointer */
@@ -109,7 +109,7 @@ FUNC _setjmpex
     mov [rcx + JUMP_BUFFER_R13], r13            /* Store r13 */
     mov [rcx + JUMP_BUFFER_R14], r14            /* Store r14 */
     mov [rcx + JUMP_BUFFER_R15], r15            /* Store r15 */
-    lea rax, [rip + LABEL2]                     /* Get the return address (LABEL2) */
+    lea rax, [rip + LABEL2]                     /* Get the return address (LABEL2 below) */
     mov [rcx + JUMP_BUFFER_Rip], rax            /* Store rip (return address) */
     mov [rcx + JUMP_BUFFER_Frame], rdx          /* Store frame */
     movdqu [rcx + JUMP_BUFFER_Xmm6], xmm6       /* Store xmm6 */

--- a/sdk/lib/crt/setjmp/amd64/setjmp.s
+++ b/sdk/lib/crt/setjmp/amd64/setjmp.s
@@ -1,7 +1,7 @@
 /*
  * PROJECT:     ReactOS system libraries
  * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
- * PURPOSE:     Implementation of setjmp/longjmp
+ * PURPOSE:     Implementation of amd64 setjmp/longjmp
  * COPYRIGHT:   Copyright Timo Kreuzer (timo.kreuzer@reactos.org)
  *              Copyright 2025 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
  *              Copyright 2025 Serge Gautherie <reactos-git_serge_171003@gautherie.fr>

--- a/sdk/lib/crt/setjmp/amd64/setjmp.s
+++ b/sdk/lib/crt/setjmp/amd64/setjmp.s
@@ -4,6 +4,7 @@
  * PURPOSE:           Implementation of _setjmp/longjmp
  * FILE:              lib/sdk/crt/setjmp/amd64/setjmp.s
  * PROGRAMMER:        Timo Kreuzer (timo.kreuzer@reactos.org)
+ *                    Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
  */
 
 /* INCLUDES ******************************************************************/
@@ -50,33 +51,8 @@ FUNC _setjmp
 
     .endprolog
 
-    /* Load rsp as it was before the call into rax */
-    lea rax, [rsp + 8]
-    /* Load return address into r8 */
-    mov r8, [rsp]
-    mov qword ptr [rcx + JUMP_BUFFER_Frame], 0
-    mov [rcx + JUMP_BUFFER_Rbx], rbx
-    mov [rcx + JUMP_BUFFER_Rbp], rbp
-    mov [rcx + JUMP_BUFFER_Rsi], rsi
-    mov [rcx + JUMP_BUFFER_Rdi], rdi
-    mov [rcx + JUMP_BUFFER_R12], r12
-    mov [rcx + JUMP_BUFFER_R13], r13
-    mov [rcx + JUMP_BUFFER_R14], r14
-    mov [rcx + JUMP_BUFFER_R15], r15
-    mov [rcx + JUMP_BUFFER_Rsp], rax
-    mov [rcx + JUMP_BUFFER_Rip], r8
-    movdqa [rcx + JUMP_BUFFER_Xmm6], xmm6
-    movdqa [rcx + JUMP_BUFFER_Xmm7], xmm7
-    movdqa [rcx + JUMP_BUFFER_Xmm8], xmm8
-    movdqa [rcx + JUMP_BUFFER_Xmm9], xmm9
-    movdqa [rcx + JUMP_BUFFER_Xmm10], xmm10
-    movdqa [rcx + JUMP_BUFFER_Xmm11], xmm11
-    movdqa [rcx + JUMP_BUFFER_Xmm12], xmm12
-    movdqa [rcx + JUMP_BUFFER_Xmm13], xmm13
-    movdqa [rcx + JUMP_BUFFER_Xmm14], xmm14
-    movdqa [rcx + JUMP_BUFFER_Xmm15], xmm15
-    xor rax, rax
-    ret
+    xor rdx, rdx
+    jmp _setjmpex
 ENDFUNC
 
 /*!
@@ -92,32 +68,35 @@ FUNC _setjmpex
 
     .endprolog
 
-    /* Load rsp as it was before the call into rax */
-    lea rax, [rsp + 8]
-    /* Load return address into r8 */
-    mov r8, [rsp]
-    mov [rcx + JUMP_BUFFER_Frame], rdx
-    mov [rcx + JUMP_BUFFER_Rbx], rbx
-    mov [rcx + JUMP_BUFFER_Rbp], rbp
-    mov [rcx + JUMP_BUFFER_Rsi], rsi
-    mov [rcx + JUMP_BUFFER_Rdi], rdi
-    mov [rcx + JUMP_BUFFER_R12], r12
-    mov [rcx + JUMP_BUFFER_R13], r13
-    mov [rcx + JUMP_BUFFER_R14], r14
-    mov [rcx + JUMP_BUFFER_R15], r15
-    mov [rcx + JUMP_BUFFER_Rsp], rax
-    mov [rcx + JUMP_BUFFER_Rip], r8
-    movdqa [rcx + JUMP_BUFFER_Xmm6], xmm6
-    movdqa [rcx + JUMP_BUFFER_Xmm7], xmm7
-    movdqa [rcx + JUMP_BUFFER_Xmm8], xmm8
-    movdqa [rcx + JUMP_BUFFER_Xmm9], xmm9
-    movdqa [rcx + JUMP_BUFFER_Xmm10], xmm10
-    movdqa [rcx + JUMP_BUFFER_Xmm11], xmm11
-    movdqa [rcx + JUMP_BUFFER_Xmm12], xmm12
-    movdqa [rcx + JUMP_BUFFER_Xmm13], xmm13
-    movdqa [rcx + JUMP_BUFFER_Xmm14], xmm14
-    movdqa [rcx + JUMP_BUFFER_Xmm15], xmm15
-    xor rax, rax
+    push rbp                                    /* Save rbp */
+    mov rbp, rsp                                /* rbp = rsp */
+    and rsp, -16                                /* Align rsp to 16-byte boundary */
+    mov [rcx + JUMP_BUFFER_Rbx], rbx            /* Store rbx */
+    mov [rcx + JUMP_BUFFER_Rsp], rsp            /* Store rsp */
+    mov [rcx + JUMP_BUFFER_Rbp], rbp            /* Store rbp */
+    mov [rcx + JUMP_BUFFER_Rsi], rsi            /* Store rsi (non-volatile on windows) */
+    mov [rcx + JUMP_BUFFER_Rdi], rdi            /* Store rdi (non-volatile on windows) */
+    mov [rcx + JUMP_BUFFER_R12], r12            /* Store r12 */
+    mov [rcx + JUMP_BUFFER_R13], r13            /* Store r13 */
+    mov [rcx + JUMP_BUFFER_R14], r14            /* Store r14 */
+    mov [rcx + JUMP_BUFFER_R15], r15            /* Store r15 */
+    lea rax, [rip + LABEL2]                     /* Get the return address (LABEL2) */
+    mov [rcx + JUMP_BUFFER_Rip], rax            /* Store rip (return address) */
+    mov [rcx + JUMP_BUFFER_Frame], rdx          /* Store frame */
+    movdqu [rcx + JUMP_BUFFER_Xmm6], xmm6       /* Store xmm6 */
+    movdqu [rcx + JUMP_BUFFER_Xmm7], xmm7       /* Store xmm7 */
+    movdqu [rcx + JUMP_BUFFER_Xmm8], xmm8       /* Store xmm8 */
+    movdqu [rcx + JUMP_BUFFER_Xmm9], xmm9       /* Store xmm9 */
+    movdqu [rcx + JUMP_BUFFER_Xmm10], xmm10     /* Store xmm10 */
+    movdqu [rcx + JUMP_BUFFER_Xmm11], xmm11     /* Store xmm11 */
+    movdqu [rcx + JUMP_BUFFER_Xmm12], xmm12     /* Store xmm12 */
+    movdqu [rcx + JUMP_BUFFER_Xmm13], xmm13     /* Store xmm13 */
+    movdqu [rcx + JUMP_BUFFER_Xmm14], xmm14     /* Store xmm14 */
+    movdqu [rcx + JUMP_BUFFER_Xmm15], xmm15     /* Store xmm15 */
+    mov rsp, rbp                                /* Restore original rsp */
+    pop rbp                                     /* Restore original rbp */
+    xor eax, eax                                /* Return 0 */
+LABEL2:
     ret
 ENDFUNC
 
@@ -135,35 +114,34 @@ FUNC longjmp
 
     .endprolog
 
-    // FIXME: handle frame
-
-    mov rbx, [rcx + JUMP_BUFFER_Rbx]
-    mov rbp, [rcx + JUMP_BUFFER_Rbp]
-    mov rsi, [rcx + JUMP_BUFFER_Rsi]
-    mov rdi, [rcx + JUMP_BUFFER_Rdi]
-    mov r12, [rcx + JUMP_BUFFER_R12]
-    mov r13, [rcx + JUMP_BUFFER_R13]
-    mov r14, [rcx + JUMP_BUFFER_R14]
-    mov r15, [rcx + JUMP_BUFFER_R15]
-    mov rsp, [rcx + JUMP_BUFFER_Rsp]
-    mov r8, [rcx + JUMP_BUFFER_Rip]
-    movdqa xmm6, [rcx + JUMP_BUFFER_Xmm6]
-    movdqa xmm7, [rcx + JUMP_BUFFER_Xmm7]
-    movdqa xmm8, [rcx + JUMP_BUFFER_Xmm8]
-    movdqa xmm9, [rcx + JUMP_BUFFER_Xmm9]
-    movdqa xmm10, [rcx + JUMP_BUFFER_Xmm10]
-    movdqa xmm11, [rcx + JUMP_BUFFER_Xmm11]
-    movdqa xmm12, [rcx + JUMP_BUFFER_Xmm12]
-    movdqa xmm13, [rcx + JUMP_BUFFER_Xmm13]
-    movdqa xmm14, [rcx + JUMP_BUFFER_Xmm14]
-    movdqa xmm15, [rcx + JUMP_BUFFER_Xmm15]
-
-    /* return param2 or 1 if it was 0 */
-    mov rax, rdx
-    test rax, rax
-    jnz l2
-    inc rax
-l2: jmp r8
+    mov rbx, [rcx + JUMP_BUFFER_Rbx]            /* Restore rbx */
+    mov rsp, [rcx + JUMP_BUFFER_Rsp]            /* Restore rsp */
+    mov rbp, [rcx + JUMP_BUFFER_Rbp]            /* Restore rbp */
+    mov rsi, [rcx + JUMP_BUFFER_Rsi]            /* Restore rsi */
+    mov rdi, [rcx + JUMP_BUFFER_Rdi]            /* Restore rdi */
+    mov r12, [rcx + JUMP_BUFFER_R12]            /* Restore r12 */
+    mov r13, [rcx + JUMP_BUFFER_R13]            /* Restore r13 */
+    mov r14, [rcx + JUMP_BUFFER_R14]            /* Restore r14 */
+    mov r15, [rcx + JUMP_BUFFER_R15]            /* Restore r15 */
+    mov rax, [rcx + JUMP_BUFFER_Frame]          /* Restore frame pointer */
+    mov [rsp + 8], rax                          /* Restore frame pointer */
+    movdqu xmm6, [rcx + JUMP_BUFFER_Xmm6]       /* Restore xmm6 */
+    movdqu xmm7, [rcx + JUMP_BUFFER_Xmm7]       /* Restore xmm7 */
+    movdqu xmm8, [rcx + JUMP_BUFFER_Xmm8]       /* Restore xmm8 */
+    movdqu xmm9, [rcx + JUMP_BUFFER_Xmm9]       /* Restore xmm9 */
+    movdqu xmm10, [rcx + JUMP_BUFFER_Xmm10]     /* Restore xmm10 */
+    movdqu xmm11, [rcx + JUMP_BUFFER_Xmm11]     /* Restore xmm11 */
+    movdqu xmm12, [rcx + JUMP_BUFFER_Xmm12]     /* Restore xmm12 */
+    movdqu xmm13, [rcx + JUMP_BUFFER_Xmm13]     /* Restore xmm13 */
+    movdqu xmm14, [rcx + JUMP_BUFFER_Xmm14]     /* Restore xmm14 */
+    movdqu xmm15, [rcx + JUMP_BUFFER_Xmm15]     /* Restore xmm15 */
+    mov rax, rdx                                /* Move val into rax (return value) */
+    test rax, rax                               /* Check if val is 0 */
+    jz LABEL3                                   /* If val is 0, jump to LABEL3 */
+    jmp qword ptr [rcx + JUMP_BUFFER_Rip]       /* Jump to the stored return address (rip) */
+LABEL3:
+    mov rax, 1                                  /* If val was 0, return 1 */
+    jmp qword ptr [rcx + JUMP_BUFFER_Rip]       /* Jump to the stored return address (rip) */
 ENDFUNC
 
 END

--- a/sdk/lib/crt/setjmp/amd64/setjmp.s
+++ b/sdk/lib/crt/setjmp/amd64/setjmp.s
@@ -169,7 +169,8 @@ FUNC longjmp
     jz LJRET                                    /* If val is 0, jump to LJRET */
     jmp qword ptr [rcx + JUMP_BUFFER_Rip]       /* Jump to the stored return address (rip) */
 LJRET:
-    mov rax, 1                                  /* If val was 0, return 1 on second (longjmp) return */
+    xor rax, rax
+    inc rax                                     /* If val was 0, return 1 on second (longjmp) return */
     jmp qword ptr [rcx + JUMP_BUFFER_Rip]       /* Jump to the stored return address (rip) */
 ENDFUNC
 

--- a/sdk/lib/crt/setjmp/amd64/setjmp.s
+++ b/sdk/lib/crt/setjmp/amd64/setjmp.s
@@ -59,7 +59,7 @@ FUNC _setjmp
     mov [rcx + JUMP_BUFFER_R14], r14            /* Store r14 */
     mov [rcx + JUMP_BUFFER_R15], r15            /* Store r15 */
 
-    mov [rcx + JUMP_BUFFER_Frame], ebp          /* Store frame pointer (ebp) */
+    mov [rcx + JUMP_BUFFER_Frame], rbp          /* Store frame pointer (rbp) */
 
     lea rax, [esp + 8]                          /* Get the return address */
     mov [rcx + JUMP_BUFFER_Rip], rax            /* Store rip (return address) */
@@ -102,7 +102,7 @@ FUNC _setjmpex
     mov [rcx + JUMP_BUFFER_R14], r14            /* Store r14 */
     mov [rcx + JUMP_BUFFER_R15], r15            /* Store r15 */
 
-    mov [rcx + JUMP_BUFFER_Frame], rdx          /* Store frame pointer (rdx) */
+    mov [rcx + JUMP_BUFFER_Frame], rdx          /* Store frame pointer from argument */
 
     lea rax, [esp + 8]                          /* Get the return address */
     mov [rcx + JUMP_BUFFER_Rip], rax            /* Store rip (return address) */
@@ -146,7 +146,11 @@ FUNC longjmp
     mov r14, [rcx + JUMP_BUFFER_R14]            /* Restore r14 */
     mov r15, [rcx + JUMP_BUFFER_R15]            /* Restore r15 */
 
-    mov ebp, [rcx + JUMP_BUFFER_Frame]          /* Get frame pointer (ebp) */
+    mov rax, [rcx + JUMP_BUFFER_Frame]          /* Get frame pointer */
+    test rax, rax                               /* Restore frame pointer (rbp) if non-zero */
+    jz LJJMP1
+    mov rbp, rax
+LJJMP1:
 
     movdqu xmm6, [rcx + JUMP_BUFFER_Xmm6]       /* Restore xmm6 */
     movdqu xmm7, [rcx + JUMP_BUFFER_Xmm7]       /* Restore xmm7 */
@@ -164,11 +168,9 @@ FUNC longjmp
 
     mov rax, rdx                                /* Move val into rax (return value) */
     test rax, rax                               /* Check if val is 0 */
-    jnz LJJMP                                   /* If val is non-zero, jump to LJJMP */
-
+    jnz LJJMP2                                  /* If val is non-zero, jump to LJJMP2 */
     inc rax                                     /* Increment rax */
-
-LJJMP:
+LJJMP2:
     ret
 ENDFUNC
 

--- a/sdk/lib/crt/setjmp/amd64/setjmp.s
+++ b/sdk/lib/crt/setjmp/amd64/setjmp.s
@@ -1,13 +1,10 @@
 /*
- * COPYRIGHT:         See COPYING in the top level directory
- * PROJECT:           ReactOS system libraries
- * PURPOSE:           Implementation of _setjmp/longjmp
- * FILE:              lib/sdk/crt/setjmp/amd64/setjmp.s
- * PROGRAMMER:        Timo Kreuzer (timo.kreuzer@reactos.org)
- *                    Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
+ * PROJECT:     ReactOS system libraries
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Implementation of setjmp/longjmp
+ * COPYRIGHT:   Copyright (c) Timo Kreuzer (timo.kreuzer@reactos.org)
+ *              Copyright (c) 2025 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
  */
-
-/* INCLUDES ******************************************************************/
 
 #include <asm.inc>
 #include <ksamd64.inc>

--- a/sdk/lib/crt/setjmp/amd64/setjmp.s
+++ b/sdk/lib/crt/setjmp/amd64/setjmp.s
@@ -51,8 +51,37 @@ FUNC _setjmp
 
     .endprolog
 
-    xor rdx, rdx
-    jmp _setjmpex
+    push rbp                                    /* Save rbp */
+    mov rbp, rsp                                /* rbp = rsp */
+    and rsp, -16                                /* Align rsp to 16-byte boundary */
+    mov [rcx + JUMP_BUFFER_Rbx], rbx            /* Store rbx */
+    mov [rcx + JUMP_BUFFER_Rsp], rsp            /* Store rsp (aligned) */
+    mov [rcx + JUMP_BUFFER_Rbp], rbp            /* Store rbp (aligned) */
+    mov [rcx + JUMP_BUFFER_Rsi], rsi            /* Store rsi (non-volatile on windows) */
+    mov [rcx + JUMP_BUFFER_Rdi], rdi            /* Store rdi (non-volatile on windows) */
+    mov [rcx + JUMP_BUFFER_R12], r12            /* Store r12 */
+    mov [rcx + JUMP_BUFFER_R13], r13            /* Store r13 */
+    mov [rcx + JUMP_BUFFER_R14], r14            /* Store r14 */
+    mov [rcx + JUMP_BUFFER_R15], r15            /* Store r15 */
+    lea rax, [rip + LABEL1]                     /* Get the return address (LABEL1) */
+    mov [rcx + JUMP_BUFFER_Rip], rax            /* Store rip (return address) */
+    mov rax, [rsp + 8]
+    mov [rcx + JUMP_BUFFER_Frame], rax          /* Store frame pointer */
+    movdqu [rcx + JUMP_BUFFER_Xmm6], xmm6       /* Store xmm6 */
+    movdqu [rcx + JUMP_BUFFER_Xmm7], xmm7       /* Store xmm7 */
+    movdqu [rcx + JUMP_BUFFER_Xmm8], xmm8       /* Store xmm8 */
+    movdqu [rcx + JUMP_BUFFER_Xmm9], xmm9       /* Store xmm9 */
+    movdqu [rcx + JUMP_BUFFER_Xmm10], xmm10     /* Store xmm10 */
+    movdqu [rcx + JUMP_BUFFER_Xmm11], xmm11     /* Store xmm11 */
+    movdqu [rcx + JUMP_BUFFER_Xmm12], xmm12     /* Store xmm12 */
+    movdqu [rcx + JUMP_BUFFER_Xmm13], xmm13     /* Store xmm13 */
+    movdqu [rcx + JUMP_BUFFER_Xmm14], xmm14     /* Store xmm14 */
+    movdqu [rcx + JUMP_BUFFER_Xmm15], xmm15     /* Store xmm15 */
+    mov rsp, rbp                                /* Restore original rsp */
+    pop rbp                                     /* Restore original rbp */
+    xor eax, eax                                /* Return 0 */
+LABEL1:
+    ret
 ENDFUNC
 
 /*!

--- a/sdk/lib/crt/setjmp/arm/setjmp.s
+++ b/sdk/lib/crt/setjmp/arm/setjmp.s
@@ -55,8 +55,11 @@
     vld1.64 {d6}, [r0]!
     vld1.64 {d7}, [r0]!
 
-    /* Return 1 */
-    mov r0, #1
+    /* Check if r1 is zero */
+    cmp r1, #0
+    /* if r1 is zero, then set r0 to 1, else r0 = r1 */
+    moveq r0, #1
+    movne r0, r1
     bx lr
     LEAF_END longjmp
 

--- a/sdk/lib/crt/setjmp/arm/setjmp.s
+++ b/sdk/lib/crt/setjmp/arm/setjmp.s
@@ -55,9 +55,8 @@
     vld1.64 {d6}, [r0]!
     vld1.64 {d7}, [r0]!
 
-    /* Check if r1 is zero */
+    /* Return r1, or 1 if it is 0. */
     cmp r1, #0
-    /* if r1 is zero, then set r0 to 1, else r0 = r1 */
     moveq r0, #1
     movne r0, r1
     bx lr

--- a/sdk/lib/crt/setjmp/arm/setjmp.s
+++ b/sdk/lib/crt/setjmp/arm/setjmp.s
@@ -41,6 +41,9 @@
 
     LEAF_ENTRY longjmp
 
+    /* Save 2nd argument */
+    mov r2, r1
+
     ldmia r0!, {r1,r4-r11}
     ldmia r0!, {r1,lr,fp}
     mov sp, r1
@@ -55,10 +58,10 @@
     vld1.64 {d6}, [r0]!
     vld1.64 {d7}, [r0]!
 
-    /* Return r1, or 1 if it is 0. */
-    cmp r1, #0
+    /* Return 2nd argument, or 1 if it is 0. */
+    cmp r2, #0
     moveq r0, #1
-    movne r0, r1
+    movne r0, r2
     bx lr
     LEAF_END longjmp
 

--- a/sdk/lib/crt/setjmp/i386/setjmp.s
+++ b/sdk/lib/crt/setjmp/i386/setjmp.s
@@ -107,6 +107,10 @@ _longjmp:
     mov edi, [ecx + JB_DI*4]
     mov esi, [ecx + JB_SI*4]
     mov esp, [ecx + JB_SP*4]
+    test eax, eax
+    jnz LJJMP
+    inc eax
+LJJMP:
     /* Jump to saved PC.  */
     jmp edx
 

--- a/sdk/lib/crt/setjmp/i386/setjmp.s
+++ b/sdk/lib/crt/setjmp/i386/setjmp.s
@@ -107,6 +107,7 @@ _longjmp:
     mov edi, [ecx + JB_DI*4]
     mov esi, [ecx + JB_SI*4]
     mov esp, [ecx + JB_SP*4]
+    /* If return value is 0, return 1 instead. */
     test eax, eax
     jnz LJJMP
     inc eax


### PR DESCRIPTION
## Purpose

`setjmp` and `longjmp` are important functions. New freetype (#7786) uses these functions. Some `setjmp` / `longjmp` were incomplete.
JIRA issue: [CORE-19265](https://jira.reactos.org/browse/CORE-19265)

## Proposed changes

- Add `setjmp` testcase to CRT tests.
- Modify `sdk/lib/crt/setjmp/amd64/setjmp.s`
- Fix x86 and arm `longjmp`.
- Amd64 unwinding is not supported yet.

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=101250,101253 LGTM.
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=101251,101263 LGTM.