### PR TITLE
[MAGNIFIER] Gray out help

### DIFF
--- a/base/applications/magnify/magnifier.c
+++ b/base/applications/magnify/magnifier.c
@@ -897,6 +897,8 @@ INT_PTR CALLBACK OptionsProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lPar
             if (bShowMagnifier)
                 SendDlgItemMessage(hDlg,IDC_SHOWMAGNIFIERCHECK,BM_SETCHECK, wParam, 0);
 
+            EnableWindow(GetDlgItem(hDlg, IDC_BUTTON_HELP), FALSE);
+
             return (INT_PTR)TRUE;
         }
 


### PR DESCRIPTION
## Purpose

This grays out the help button in magnifier, as currently there is no help, this is to prevent users being confused untill a proper help will be implemented

JIRA issue: [CORE-20067](https://jira.reactos.org/browse/CORE-20067)

note: this is my first ever pullrequest and i will try to do more meaningfull changes in the future to help reactos, if theres anything wrong please tell me

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: