### PR TITLE
[STOBJECT] Explicitly tell the user the battery is fully charged

### DIFF
--- a/dll/shellext/stobject/lang/cs-CZ.rc
+++ b/dll/shellext/stobject/lang/cs-CZ.rc
@@ -24,6 +24,7 @@ BEGIN
     IDS_PWR_AC "On AC power"
     IDS_PWR_HOURS_REMAINING "zbývá %1!u!:%2!02u! hodin (%3!u!%%)"
     IDS_PWR_MINUTES_REMAINING "zbývá %1!u! minut (%2!u!%%)"
+    IDS_PWR_FULLY_CHARGED "Fully charged"
 
     //Hotplug related strings
     IDS_HOTPLUG_REMOVE_1 "Bezpečně odebrat hardware"

--- a/dll/shellext/stobject/lang/de-DE.rc
+++ b/dll/shellext/stobject/lang/de-DE.rc
@@ -24,6 +24,7 @@ BEGIN
     IDS_PWR_AC "Mit Wechselstrom"
     IDS_PWR_HOURS_REMAINING "%1!u!:%2!02u! Stunden (%3!u!%%) verbleibend"
     IDS_PWR_MINUTES_REMAINING "%1!u! Min. (%2!u!%%) verbleibend"
+    IDS_PWR_FULLY_CHARGED "Fully charged"
 
     //Hotplug related strings
     IDS_HOTPLUG_REMOVE_1 "Hardware sicher entfernen"

--- a/dll/shellext/stobject/lang/en-US.rc
+++ b/dll/shellext/stobject/lang/en-US.rc
@@ -24,6 +24,7 @@ BEGIN
     IDS_PWR_AC "On AC power"
     IDS_PWR_HOURS_REMAINING "%1!u!:%2!02u! hours (%3!u!%%) remaining"
     IDS_PWR_MINUTES_REMAINING "%1!u! min (%2!u!%%) remaining"
+    IDS_PWR_FULLY_CHARGED "Fully charged"
 
     //Hotplug related strings
     IDS_HOTPLUG_REMOVE_1 "Safely Remove Hardware"

--- a/dll/shellext/stobject/lang/es-ES.rc
+++ b/dll/shellext/stobject/lang/es-ES.rc
@@ -25,6 +25,7 @@ BEGIN
     IDS_PWR_AC "En corriente alterna"
     IDS_PWR_HOURS_REMAINING "Quedan %1!u!:%2!02u! horas (%3!u!%%)"
     IDS_PWR_MINUTES_REMAINING "Quedan %1!u! minutos (%2!u!%%)"
+    IDS_PWR_FULLY_CHARGED "Fully charged"
 
     //Hotplug related strings
     IDS_HOTPLUG_REMOVE_1 "Desconectar de forma segura"

--- a/dll/shellext/stobject/lang/fr-FR.rc
+++ b/dll/shellext/stobject/lang/fr-FR.rc
@@ -24,6 +24,7 @@ BEGIN
     IDS_PWR_AC "Sur secteur"
     IDS_PWR_HOURS_REMAINING "%1!u!:%2!02u! heures (%3!u!%%) restantes"
     IDS_PWR_MINUTES_REMAINING "%1!u! mins (%2!u!%%) restantes"
+    IDS_PWR_FULLY_CHARGED "Fully charged"
 
     //Hotplug related strings
     IDS_HOTPLUG_REMOVE_1 "Retirer le périphérique en sécurité"

--- a/dll/shellext/stobject/lang/hi-IN.rc
+++ b/dll/shellext/stobject/lang/hi-IN.rc
@@ -31,6 +31,7 @@ BEGIN
     IDS_PWR_AC "On AC power"
     IDS_PWR_HOURS_REMAINING "%1!u!:%2!02u! घंटे (%3!u!%%) शेष"
     IDS_PWR_MINUTES_REMAINING "%1!u! मिनट (%2!u!%%) शेष"
+    IDS_PWR_FULLY_CHARGED "Fully charged"
 
     //Hotplug related strings
     IDS_HOTPLUG_REMOVE_1 "हार्डवेयर सुरक्षित रूप से निकालें"

--- a/dll/shellext/stobject/lang/it-IT.rc
+++ b/dll/shellext/stobject/lang/it-IT.rc
@@ -24,6 +24,7 @@ BEGIN
     IDS_PWR_AC                "Alimentazione da rete AC"
     IDS_PWR_HOURS_REMAINING   "%1!u!:%2!02u! ore (%3!u!%%) rimanenti"
     IDS_PWR_MINUTES_REMAINING "%1!u! minuti (%2!u!%%) rimanenti"
+    IDS_PWR_FULLY_CHARGED "Fully charged"
 
     //Hotplug related strings
     IDS_HOTPLUG_REMOVE_1  "Rimozione sicura dell'Hardware"

--- a/dll/shellext/stobject/lang/ja-JP.rc
+++ b/dll/shellext/stobject/lang/ja-JP.rc
@@ -24,6 +24,7 @@ BEGIN
     IDS_PWR_AC "交流電源"
     IDS_PWR_HOURS_REMAINING "残り %1!u!:%2!02u! 時間 (%3!u!%%)"
     IDS_PWR_MINUTES_REMAINING "残り %1!u! 分 (%2!u!%%)"
+    IDS_PWR_FULLY_CHARGED "Fully charged"
 
     //Hotplug related strings
     IDS_HOTPLUG_REMOVE_1 "安全なハードウェアの取り外し"

--- a/dll/shellext/stobject/lang/pl-PL.rc
+++ b/dll/shellext/stobject/lang/pl-PL.rc
@@ -24,6 +24,7 @@ BEGIN
     IDS_PWR_AC "Podłączony do zasilania"
     IDS_PWR_HOURS_REMAINING "Pozostało %1!u!:%2!02u! godzin (%3!u!%%)"
     IDS_PWR_MINUTES_REMAINING "Pozostało %1!u! minut (%2!u!%%)"
+    IDS_PWR_FULLY_CHARGED "Fully charged"
 
     //Hotplug related strings
     IDS_HOTPLUG_REMOVE_1 "Bezpieczne usuwanie sprzętu"

--- a/dll/shellext/stobject/lang/pt-PT.rc
+++ b/dll/shellext/stobject/lang/pt-PT.rc
@@ -24,6 +24,7 @@ BEGIN
     IDS_PWR_AC "Energia AC"
     IDS_PWR_HOURS_REMAINING "%1!u!:%2!02u! horas (%3!u!%%) remanescente"
     IDS_PWR_MINUTES_REMAINING "%1!u! min (%2!u!%%) remanescente"
+    IDS_PWR_FULLY_CHARGED "Fully charged"
 
     //Hotplug related strings
     IDS_HOTPLUG_REMOVE_1 "&Remover Hardware em segurança"

--- a/dll/shellext/stobject/lang/ro-RO.rc
+++ b/dll/shellext/stobject/lang/ro-RO.rc
@@ -32,6 +32,7 @@ BEGIN
     IDS_PWR_AC "Când există sursă CA"
     IDS_PWR_HOURS_REMAINING "%1!u!:%2!02u! ore (%3!u!%%) rămase"
     IDS_PWR_MINUTES_REMAINING "%1!u! minute (%2!u!%%) rămase"
+    IDS_PWR_FULLY_CHARGED "Fully charged"
 
     //Hotplug related strings
     IDS_HOTPLUG_REMOVE_1 "Eliminarea în siguranţă a unui dispozitiv hardware"

--- a/dll/shellext/stobject/lang/ru-RU.rc
+++ b/dll/shellext/stobject/lang/ru-RU.rc
@@ -32,6 +32,7 @@ BEGIN
     IDS_PWR_AC "От сети переменного тока"
     IDS_PWR_HOURS_REMAINING "%1!u!:%2!02u! часов (%3!u!%%) осталось"
     IDS_PWR_MINUTES_REMAINING "%1!u! минут (%2!u!%%) осталось"
+    IDS_PWR_FULLY_CHARGED "Fully charged"
 
     //Hotplug related strings
     IDS_HOTPLUG_REMOVE_1 "Безопасное извлечение устройства"

--- a/dll/shellext/stobject/lang/tr-TR.rc
+++ b/dll/shellext/stobject/lang/tr-TR.rc
@@ -26,6 +26,7 @@ BEGIN
     IDS_PWR_AC "Dalgalı akımda (AC)."
     IDS_PWR_HOURS_REMAINING "%1!u!.%2!02u! saat (%%%3!u!) kalan"
     IDS_PWR_MINUTES_REMAINING "%1!u! dakika (%%%2!u!) kalan"
+    IDS_PWR_FULLY_CHARGED "Fully charged"
 
     //Hotplug related strings
     IDS_HOTPLUG_REMOVE_1 "Donanımı Güvenli Kaldır"

--- a/dll/shellext/stobject/lang/zh-CN.rc
+++ b/dll/shellext/stobject/lang/zh-CN.rc
@@ -26,6 +26,7 @@ BEGIN
     IDS_PWR_AC "交流电源"
     IDS_PWR_HOURS_REMAINING "剩余 %1!u!:%2!02u!（%3!u!%%）"
     IDS_PWR_MINUTES_REMAINING "剩余 %1!u! 分钟（%2!u!%%）"
+    IDS_PWR_FULLY_CHARGED "Fully charged"
 
     //Hotplug related strings
     IDS_HOTPLUG_REMOVE_1 "安全地删除硬件"

--- a/dll/shellext/stobject/lang/zh-HK.rc
+++ b/dll/shellext/stobject/lang/zh-HK.rc
@@ -32,6 +32,7 @@ BEGIN
     IDS_PWR_AC "交流電源"
     IDS_PWR_HOURS_REMAINING "剩餘 %1!u!:%2!02u! 小時（%3!u!%%） "
     IDS_PWR_MINUTES_REMAINING "剩餘 %1!u! 分鐘（%2!u!%%） "
+    IDS_PWR_FULLY_CHARGED "Fully charged"
 
     //Hotplug related strings
     IDS_HOTPLUG_REMOVE_1 "安全地移除硬件"

--- a/dll/shellext/stobject/lang/zh-TW.rc
+++ b/dll/shellext/stobject/lang/zh-TW.rc
@@ -32,6 +32,7 @@ BEGIN
     IDS_PWR_AC "交流電源"
     IDS_PWR_HOURS_REMAINING "剩餘 %1!u!:%2!02u! 小時（%3!u!%%）"
     IDS_PWR_MINUTES_REMAINING "剩餘 %1!u! 分鐘（%2!u!%%）"
+    IDS_PWR_FULLY_CHARGED "Fully charged"
 
     //Hotplug related strings
     IDS_HOTPLUG_REMOVE_1 "安全地移除硬體"

--- a/dll/shellext/stobject/power.cpp
+++ b/dll/shellext/stobject/power.cpp
@@ -105,6 +105,13 @@ static HICON DynamicLoadIcon(HINSTANCE hinst)
         hBatIcon = LoadIcon(hinst, MAKEINTRESOURCE(bc_icons[index]));
         g_strTooltip.Format(IDS_PWR_CHARGING, PowerStatus.BatteryLifePercent);
     }
+    else if (PowerStatus.ACLineStatus == AC_LINE_ONLINE &&
+             PowerStatus.BatteryLifePercent == 100)
+    {
+        index = Quantize(PowerStatus.BatteryLifePercent);
+        hBatIcon = LoadIcon(hinst, MAKEINTRESOURCE(bc_icons[index]));
+        g_strTooltip.LoadStringW(IDS_PWR_FULLY_CHARGED);
+    }
     else if (((PowerStatus.BatteryFlag & BATTERY_FLAG_NO_BATTERY) == 0) &&
              ((PowerStatus.BatteryFlag & BATTERY_FLAG_CHARGING) == 0))
     {

--- a/dll/shellext/stobject/resource.h
+++ b/dll/shellext/stobject/resource.h
@@ -11,6 +11,7 @@
 #define IDS_PWR_AC                161
 #define IDS_PWR_HOURS_REMAINING   162
 #define IDS_PWR_MINUTES_REMAINING 163
+#define IDS_PWR_FULLY_CHARGED     164
 
 #define IDI_BATTERY               200
 #define IDI_EXTRACT               210


### PR DESCRIPTION
Short answer: our UI sucks bolas rojas.

Long answer: when the NT kernel informs the user-mode part of the system that the battery is no longer charging, the machine is directly powered up by the AC adapter. This is understood by determining the presence of **AC_LINE_ONLINE** status bit in `ACLineStatus` member field, which is a Windows API construct. In the NT world this is understood by checking the power state returned by the **BATTERY_STATUS** structure.

What's happening right now is that when the battery is fully charged, ROS UI simply displays "100% remaining" implying the battery is about to discharge, which is not the case. This is extremely confusing to the user. AND WORST PART IS THAT IT'S XP/2003 DESIGN, AND I HATE IT UGGGHHH. With this patch we're leaning towards Windows 10/11 way of informing the user the battery is fully charged. VIVA LA NT6!

This patch was written during CLT & Hackfest 2025 time.

## Jira Issues
[CORE-18969](https://jira.reactos.org/browse/CORE-18969)
[CORE-19452](https://jira.reactos.org/browse/CORE-19452)