### PR TITLE
[SDK] Fix product verison for user mode DLLs

### DIFF
--- a/sdk/include/reactos/wine/wine_common_ver.rc
+++ b/sdk/include/reactos/wine/wine_common_ver.rc
@@ -51,4 +51,6 @@
 
 #define REACTOS_VERSION_DLL
 
+#define REACTOS_PRODUCTVERSION REACTOS_FILEVERSION
+
 #include <reactos/version.rc>


### PR DESCRIPTION
## Purpose
Specify the correct comctl version to fix tooltips in SIV software.

BEFORE
![tip](https://github.com/user-attachments/assets/c52fd3d0-2ed5-450c-b57f-53045e0b4724)
![22](https://github.com/user-attachments/assets/9b2ab007-4e9a-4aeb-ac5d-85d9b410b291)

AFTER
![tip2](https://github.com/user-attachments/assets/93402f55-a8ee-42f0-979e-8342c0857b5f)
![33](https://github.com/user-attachments/assets/07741083-5bf6-46ac-b62b-87ee6693c64c)

JIRA issue: none

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: