### PR TITLE
[GDI32][NTGDI][SDK] ExtTextOut: Fix some type problems

### DIFF
--- a/sdk/include/psdk/ntgdi.h
+++ b/sdk/include/psdk/ntgdi.h
@@ -2500,10 +2500,10 @@ NtGdiExtTextOutW(
     _In_ INT x,
     _In_ INT y,
     _In_ UINT flOpts,
-    _In_opt_ LPRECT prcl,
-    _In_reads_opt_(cwc) LPWSTR pwsz,
-    _In_range_(0, 0xffff) INT cwc,
-    _In_reads_opt_(_Inexpressible_(cwc)) LPINT pdx,
+    _In_opt_ LPCRECT prcl,
+    _In_reads_opt_(cwc) LPCWSTR pwsz,
+    _In_range_(0, 0xffff) UINT cwc,
+    _In_reads_opt_(_Inexpressible_(cwc)) const INT *pdx,
     _In_ DWORD dwCodePage);
 
 __kernel_entry

--- a/win32ss/gdi/gdi32/objects/text.c
+++ b/win32ss/gdi/gdi32/objects/text.c
@@ -647,10 +647,10 @@ ExtTextOutW(
                             x,
                             y,
                             fuOptions,
-                            (LPRECT)lprc,
-                            (LPWSTR)lpString,
+                            lprc,
+                            lpString,
                             cwc,
-                            (LPINT)lpDx,
+                            lpDx,
                             0);
 }
 

--- a/win32ss/gdi/gdi32/objects/text.c
+++ b/win32ss/gdi/gdi32/objects/text.c
@@ -70,7 +70,7 @@ TextOutW(
     _In_reads_(cchString) LPCWSTR lpString,
     _In_ INT cchString)
 {
-    return ExtTextOutW(hdc, nXStart, nYStart, 0, NULL, (LPWSTR)lpString, cchString, NULL);
+    return ExtTextOutW(hdc, nXStart, nYStart, 0, NULL, lpString, cchString, NULL);
 }
 
 

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -7360,10 +7360,10 @@ NtGdiExtTextOutW(
     IN INT XStart,
     IN INT YStart,
     IN UINT fuOptions,
-    IN OPTIONAL LPRECT UnsafeRect,
-    IN LPWSTR UnsafeString,
-    IN INT Count,
-    IN OPTIONAL LPINT UnsafeDx,
+    IN OPTIONAL LPCRECT UnsafeRect,
+    IN LPCWSTR UnsafeString,
+    IN UINT Count,
+    IN OPTIONAL const INT *UnsafeDx,
     IN DWORD dwCodePage)
 {
     BOOL Result = FALSE;


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-19898](https://jira.reactos.org/browse/CORE-19898)

## Proposed changes

- Modify `NtGdiExtTextOutW` prototype.
- Add `const` to some paramters.
- Make `Count` parameter unsigned.
- Delete needless type casts.

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=101311,101314 LGTM.
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=101312,101317 LGTM.