### PR TITLE
[CMAKE] Introduce set_wine_module (Retry)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,9 @@ include(sdk/cmake/config.cmake)
 # Compiler flags handling
 include(sdk/cmake/compilerflags.cmake)
 
+# set_wine_module function
+include(sdk/cmake/set_wine_module.cmake)
+
 add_definitions(
     -D__REACTOS__
     # swprintf without count argument is used in most of the codebase

--- a/base/applications/cmdutils/cscript/CMakeLists.txt
+++ b/base/applications/cmdutils/cscript/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_definitions(-DCSCRIPT_BUILD -D__WINESRC__)
+add_definitions(-DCSCRIPT_BUILD)
 set(wscript_folder ${REACTOS_SOURCE_DIR}/base/applications/cmdutils/wscript)
 include_directories(${wscript_folder})
 
@@ -20,3 +20,4 @@ add_importlibs(cscript shell32 oleaut32 ole32 advapi32 user32 msvcrt kernel32 nt
 add_dependencies(cscript stdole2 cscript_idlheader)
 add_pch(cscript ${wscript_folder}/precomp.h SOURCE)
 add_cd_file(TARGET cscript DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(cscript) # CORE-5743: No ARRAY_SIZE macro

--- a/base/applications/cmdutils/reg/CMakeLists.txt
+++ b/base/applications/cmdutils/reg/CMakeLists.txt
@@ -2,9 +2,9 @@
 remove_definitions(-D_WIN32_WINNT=0x502)
 add_definitions(-D_WIN32_WINNT=0x600)
 
-add_definitions(-D__WINESRC__)
 add_executable(reg add.c copy.c delete.c export.c import.c query.c reg.c reg.rc)
 set_module_type(reg win32cui UNICODE)
 target_link_libraries(reg wine oldnames)
 add_importlibs(reg advapi32 advapi32_vista user32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET reg DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(reg) # CORE-5743: No ARRAY_SIZE macro

--- a/base/applications/cmdutils/taskkill/CMakeLists.txt
+++ b/base/applications/cmdutils/taskkill/CMakeLists.txt
@@ -1,7 +1,7 @@
 
-add_definitions(-D__WINESRC__)
 add_executable(taskkill taskkill.c taskkill.rc)
 target_link_libraries(taskkill wine)
 set_module_type(taskkill win32cui UNICODE)
 add_importlibs(taskkill psapi user32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET taskkill DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(taskkill) # CORE-5743: No ARRAY_SIZE macro

--- a/base/applications/cmdutils/wmic/CMakeLists.txt
+++ b/base/applications/cmdutils/wmic/CMakeLists.txt
@@ -1,7 +1,7 @@
 
-add_definitions(-D__WINESRC__)
 add_executable(wmic main.c wmic.rc)
 target_link_libraries(wmic wine)
 set_module_type(wmic win32cui UNICODE)
 add_importlibs(wmic oleaut32 ole32 user32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET wmic DESTINATION reactos/system32/wbem FOR all)
+set_wine_module_FIXME(wmic) # CORE-5743: No ARRAY_SIZE macro

--- a/base/applications/cmdutils/wscript/CMakeLists.txt
+++ b/base/applications/cmdutils/wscript/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-
 list(APPEND SOURCE
     arguments.c
     host.c
@@ -18,3 +16,4 @@ add_importlibs(wscript shell32 oleaut32 ole32 user32 advapi32 msvcrt kernel32 nt
 add_dependencies(wscript stdole2 wscript_idlheader)
 add_pch(wscript precomp.h SOURCE)
 add_cd_file(TARGET wscript DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(wscript) # CORE-5743: No ARRAY_SIZE macro

--- a/base/applications/cmdutils/xcopy/CMakeLists.txt
+++ b/base/applications/cmdutils/xcopy/CMakeLists.txt
@@ -1,7 +1,7 @@
 
-add_definitions(-D__WINESRC__)
 add_executable(xcopy xcopy.c xcopy.rc)
 target_link_libraries(xcopy wine)
 set_module_type(xcopy win32cui UNICODE)
 add_importlibs(xcopy shell32 user32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET xcopy DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(xcopy) # CORE-5743: No ARRAY_SIZE macro

--- a/base/applications/extrac32/CMakeLists.txt
+++ b/base/applications/extrac32/CMakeLists.txt
@@ -1,7 +1,7 @@
 
-add_definitions(-D__WINESRC__)
 add_executable(extrac32 extrac32.c)
 target_link_libraries(extrac32 wine)
 set_module_type(extrac32 win32gui UNICODE)
 add_importlibs(extrac32 shell32 setupapi shlwapi user32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET extrac32 DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(extrac32) # CORE-5743: No ARRAY_SIZE macro

--- a/base/applications/winhlp32/CMakeLists.txt
+++ b/base/applications/winhlp32/CMakeLists.txt
@@ -1,8 +1,5 @@
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
-
 add_definitions(
-    -D__WINESRC__
     -D__ROS_LONG64__
     -Dstrcasecmp=_stricmp
 )
@@ -31,3 +28,4 @@ target_link_libraries(winhlp32 wine oldnames)
 add_importlibs(winhlp32 user32 gdi32 shell32 comctl32 comdlg32 msvcrt kernel32 ntdll)
 add_pch(winhlp32 precomp.h "${PCH_SKIP_SOURCE}")
 add_cd_file(TARGET winhlp32 DESTINATION reactos FOR all)
+set_wine_module_FIXME(winhlp32) # CORE-5743: No ARRAY_SIZE macro

--- a/base/system/msiexec/CMakeLists.txt
+++ b/base/system/msiexec/CMakeLists.txt
@@ -1,7 +1,5 @@
 
-add_definitions(-D__WINESRC__)
 remove_definitions(-D_CRT_NON_CONFORMING_SWPRINTFS)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/wine)
 
 list(APPEND SOURCE
     msiexec.c
@@ -15,3 +13,4 @@ target_link_libraries(msiexec uuid wine)
 add_importlibs(msiexec user32 advapi32 ole32 comctl32 msi msvcrt kernel32 ntdll)
 add_pch(msiexec precomp.h SOURCE)
 add_cd_file(TARGET msiexec DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(msiexec) # CORE-5743: No ARRAY_SIZE macro

--- a/dll/cpl/appwiz/CMakeLists.txt
+++ b/dll/cpl/appwiz/CMakeLists.txt
@@ -2,8 +2,7 @@
 remove_definitions(-D_WIN32_WINNT=0x502)
 add_definitions(-D_WIN32_WINNT=0x600)
 
-add_definitions(-D__WINESRC__ -D_CRT_DECLARE_NONSTDC_NAMES=1)
-include_directories(BEFORE ${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
+add_definitions(-D_CRT_DECLARE_NONSTDC_NAMES=1)
 spec2def(appwiz.cpl appwiz.spec)
 
 list(APPEND SOURCE
@@ -27,3 +26,4 @@ add_delay_importlibs(appwiz msi)
 add_importlibs(appwiz urlmon ole32 comctl32 advapi32 shell32 shlwapi user32 msvcrt kernel32 ntdll)
 add_pch(appwiz appwiz.h SOURCE)
 add_cd_file(TARGET appwiz DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(appwiz) # CORE-5743: No CONST_VTABLE

--- a/dll/cpl/inetcpl/CMakeLists.txt
+++ b/dll/cpl/inetcpl/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(BEFORE ${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(inetcpl.cpl inetcpl.spec)
 
 list(APPEND SOURCE
@@ -26,3 +24,4 @@ add_delay_importlibs(inetcpl cryptui wininet ole32 urlmon shell32)
 add_importlibs(inetcpl advapi32 comctl32 user32 shlwapi msvcrt kernel32 ntdll)
 add_pch(inetcpl precomp.h SOURCE)
 add_cd_file(TARGET inetcpl DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(inetcpl) # CORE-5743: No ARRAY_SIZE macro

--- a/dll/directx/wine/d3d8/CMakeLists.txt
+++ b/dll/directx/wine/d3d8/CMakeLists.txt
@@ -1,10 +1,8 @@
 
 add_definitions(
-    -D__WINESRC__
     -D__ROS_LONG64__
     -DUSE_WIN32_OPENGL)
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(d3d8.dll d3d8.spec)
 
 list(APPEND SOURCE
@@ -33,3 +31,4 @@ target_link_libraries(d3d8 uuid wine)
 add_importlibs(d3d8 d3dwine msvcrt kernel32 ntdll)
 add_pch(d3d8 precomp.h "${PCH_SKIP_SOURCE}")
 add_cd_file(TARGET d3d8 DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(d3d8) # CORE-5743: No CONST_VTABLE

--- a/dll/directx/wine/d3d9/CMakeLists.txt
+++ b/dll/directx/wine/d3d9/CMakeLists.txt
@@ -1,9 +1,7 @@
 
 add_definitions(
-    -D__WINESRC__
     -DUSE_WIN32_OPENGL)
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(d3d9.dll d3d9.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -35,3 +33,4 @@ target_link_libraries(d3d9 wine)
 add_importlibs(d3d9 d3dwine user32 msvcrt kernel32 ntdll)
 add_pch(d3d9 precomp.h "${PCH_SKIP_SOURCE}")
 add_cd_file(TARGET d3d9 DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(d3d9) # CORE-5743: No ARRAY_SIZE and CONST_VTABLE

--- a/dll/directx/wine/d3drm/CMakeLists.txt
+++ b/dll/directx/wine/d3drm/CMakeLists.txt
@@ -1,6 +1,5 @@
 
-add_definitions(-D__WINESRC__ -D__ROS_LONG64__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
+add_definitions(-D__ROS_LONG64__)
 spec2def(d3drm.dll d3drm.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -28,6 +27,7 @@ target_link_libraries(d3drm dxguid uuid wine)
 add_importlibs(d3drm ddraw d3dxof msvcrt kernel32 ntdll)
 add_pch(d3drm precomp.h SOURCE)
 add_cd_file(TARGET d3drm DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(d3drm) # CORE-5743: No ARRAY_SIZE and CONST_VTABLE
 
 if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
     target_compile_options(d3drm PRIVATE -Wno-incompatible-function-pointer-types)

--- a/dll/directx/wine/d3dxof/CMakeLists.txt
+++ b/dll/directx/wine/d3dxof/CMakeLists.txt
@@ -1,6 +1,5 @@
 
-add_definitions(-D__WINESRC__ -D__ROS_LONG64__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
+add_definitions(-D__ROS_LONG64__)
 spec2def(d3dxof.dll d3dxof.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -22,3 +21,4 @@ target_link_libraries(d3dxof dxguid uuid wine)
 add_importlibs(d3dxof msvcrt kernel32 ntdll)
 add_pch(d3dxof precomp.h "${PCH_SKIP_SOURCE}")
 add_cd_file(TARGET d3dxof DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(d3dxof) # CORE-5743: No ARRAY_SIZE and CONST_VTABLE

--- a/dll/directx/wine/ddraw/CMakeLists.txt
+++ b/dll/directx/wine/ddraw/CMakeLists.txt
@@ -1,10 +1,7 @@
 
 add_definitions(
-    -D__WINESRC__
     -D__ROS_LONG64__
     -DUSE_WIN32_OPENGL)
-
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 
 spec2def(ddraw.dll ddraw.spec ADD_IMPORTLIB)
 
@@ -41,3 +38,4 @@ add_importlibs(ddraw advapi32 gdi32 user32 d3dwine msvcrt kernel32 ntdll)
 add_dependencies(ddraw wineheaders)
 add_pch(ddraw precomp.h SOURCE)
 add_cd_file(TARGET ddraw DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(ddraw) # CORE-5743: No ARRAY_SIZE and CONST_VTABLE

--- a/dll/directx/wine/devenum/CMakeLists.txt
+++ b/dll/directx/wine/devenum/CMakeLists.txt
@@ -2,8 +2,6 @@
 remove_definitions(-D_WIN32_WINNT=0x502 -DWINVER=0x502)
 add_definitions(-D_WIN32_WINNT=0x600 -DWINVER=0x600)
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(devenum.dll devenum.spec)
 
 list(APPEND SOURCE
@@ -26,3 +24,4 @@ add_importlibs(devenum advapi32 advapi32_vista ole32 oleaut32 winmm user32 avica
 add_dependencies(devenum wineheaders)
 add_pch(devenum precomp.h SOURCE)
 add_cd_file(TARGET devenum DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(devenum) # CORE-5743: No ARRAY_SIZE and CONST_VTABLE

--- a/dll/directx/wine/dinput/CMakeLists.txt
+++ b/dll/directx/wine/dinput/CMakeLists.txt
@@ -21,12 +21,14 @@ add_library(dinput MODULE
     dinput.rc
     version.rc
     ${CMAKE_CURRENT_BINARY_DIR}/dinput.def)
+set_wine_module_FIXME(dinput) # CORE-5743: No ARRAY_SIZE macro
 
 add_library(dinput_data_formats data_formats.c)
 add_dependencies(dinput_data_formats psdk)
+set_wine_module_FIXME(dinput_data_formats) # CORE-5743: No ARRAY_SIZE macro
+
 set_module_type(dinput win32dll)
 target_link_libraries(dinput dxguid uuid wine)
 add_importlibs(dinput comctl32 ole32 user32 advapi32 msvcrt kernel32 ntdll)
 add_pch(dinput precomp.h SOURCE)
 add_cd_file(TARGET dinput DESTINATION reactos/system32 FOR all)
-set_wine_module_FIXME(dinput) # CORE-5743: No ARRAY_SIZE macro

--- a/dll/directx/wine/dinput/CMakeLists.txt
+++ b/dll/directx/wine/dinput/CMakeLists.txt
@@ -1,6 +1,5 @@
 
-add_definitions(-D__WINESRC__ -DDIRECTINPUT_VERSION=0x0700)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
+add_definitions(-DDIRECTINPUT_VERSION=0x0700)
 spec2def(dinput.dll dinput.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -30,3 +29,4 @@ target_link_libraries(dinput dxguid uuid wine)
 add_importlibs(dinput comctl32 ole32 user32 advapi32 msvcrt kernel32 ntdll)
 add_pch(dinput precomp.h SOURCE)
 add_cd_file(TARGET dinput DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(dinput) # CORE-5743: No ARRAY_SIZE macro

--- a/dll/directx/wine/dinput8/CMakeLists.txt
+++ b/dll/directx/wine/dinput8/CMakeLists.txt
@@ -1,6 +1,5 @@
 
-add_definitions(-D__WINESRC__ -DDIRECTINPUT_VERSION=0x0800)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
+add_definitions(-DDIRECTINPUT_VERSION=0x0800)
 spec2def(dinput8.dll dinput8.spec ADD_IMPORTLIB)
 set(DINPUT_SOURCE_FOLDER ../dinput)
 
@@ -27,3 +26,4 @@ set_module_type(dinput8 win32dll)
 target_link_libraries(dinput8 dxguid uuid wine)
 add_importlibs(dinput8 comctl32 ole32 user32 advapi32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET dinput8 DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(dinput8) # CORE-5743: No ARRAY_SIZE and CONST_VTABLE

--- a/dll/directx/wine/dmusic/CMakeLists.txt
+++ b/dll/directx/wine/dmusic/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(dmusic.dll dmusic.spec)
 
 list(APPEND SOURCE
@@ -25,3 +23,4 @@ target_link_libraries(dmusic dxguid uuid wine)
 add_importlibs(dmusic ole32 advapi32 winmm dsound user32 msvcrt kernel32 ntdll)
 add_pch(dmusic precomp.h SOURCE)
 add_cd_file(TARGET dmusic DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(dmusic) # CORE-5743: No CONST_VTABLE

--- a/dll/directx/wine/dplayx/CMakeLists.txt
+++ b/dll/directx/wine/dplayx/CMakeLists.txt
@@ -1,9 +1,7 @@
 
 add_definitions(
-    -DCOM_NO_WINDOWS_H
-    -D__WINESRC__)
+    -DCOM_NO_WINDOWS_H)
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(dplayx.dll dplayx.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -28,3 +26,4 @@ target_link_libraries(dplayx dxguid uuid wine)
 add_importlibs(dplayx winmm ole32 user32 advapi32 msvcrt kernel32 ntdll)
 add_pch(dplayx precomp.h SOURCE)
 add_cd_file(TARGET dplayx DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(dplayx) # CORE-5743: No ARRAY_SIZE and CONST_VTABLE

--- a/dll/directx/wine/dpnhpast/CMakeLists.txt
+++ b/dll/directx/wine/dpnhpast/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(dpnhpast.dll dpnhpast.spec)
 
 list(APPEND SOURCE
@@ -13,3 +11,4 @@ set_module_type(dpnhpast win32dll)
 target_link_libraries(dpnhpast dxguid uuid wine)
 add_importlibs(dpnhpast msvcrt kernel32 ntdll)
 add_cd_file(TARGET dpnhpast DESTINATION reactos/system32 FOR all)
+set_wine_module(dpnhpast)

--- a/dll/directx/wine/dsound/CMakeLists.txt
+++ b/dll/directx/wine/dsound/CMakeLists.txt
@@ -1,10 +1,8 @@
 
 add_definitions(
     -D_WINE
-    -D_USE_MATH_DEFINES
-    -D__WINESRC__)
+    -D_USE_MATH_DEFINES)
 
-include_directories(BEFORE ${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(dsound.dll dsound.spec ADD_IMPORTLIB)
 
 add_library(dsound MODULE
@@ -26,3 +24,4 @@ set_module_type(dsound win32dll)
 target_link_libraries(dsound dxguid uuid wine)
 add_importlibs(dsound winmm advapi32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET dsound DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(dsound) # CORE-5743: No CONST_VTABLE

--- a/dll/directx/wine/dxdiagn/CMakeLists.txt
+++ b/dll/directx/wine/dxdiagn/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(dxdiagn.dll dxdiagn.spec)
 
 list(APPEND SOURCE
@@ -23,3 +21,4 @@ add_dependencies(dxdiagn wineheaders)
 add_importlibs(dxdiagn d3d9 ddraw version ole32 oleaut32 psapi user32 dsound msvcrt kernel32 ntdll)
 add_pch(dxdiagn precomp.h "${PCH_SKIP_SOURCE}")
 add_cd_file(TARGET dxdiagn DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(dxdiagn) # CORE-5743: No ARRAY_SIZE and CONST_VTABLE

--- a/dll/directx/wine/msdmo/CMakeLists.txt
+++ b/dll/directx/wine/msdmo/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(msdmo.dll msdmo.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -21,3 +19,4 @@ target_link_libraries(msdmo uuid wine mediaobj_guid)
 add_importlibs(msdmo user32 advapi32 ole32 msvcrt kernel32 ntdll)
 add_pch(msdmo precomp.h "${PCH_SKIP_SOURCE}")
 add_cd_file(TARGET msdmo DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(msdmo) # CORE-5743: No ARRAY_SIZE and CONST_VTABLE

--- a/dll/directx/wine/qcap/CMakeLists.txt
+++ b/dll/directx/wine/qcap/CMakeLists.txt
@@ -1,7 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(qcap.dll qcap.spec)
 
 list(APPEND SOURCE
@@ -26,3 +23,4 @@ target_link_libraries(qcap strmbase strmiids uuid wine)
 add_importlibs(qcap ole32 oleaut32 gdi32 advapi32 advapi32_vista msvcrt kernel32 ntdll)
 add_delay_importlibs(qcap msvfw32)
 add_cd_file(TARGET qcap DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(qcap) # CORE-5743: No CONST_VTABLE

--- a/dll/directx/wine/qedit/CMakeLists.txt
+++ b/dll/directx/wine/qedit/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(qedit.dll qedit.spec)
 
 list(APPEND SOURCE
@@ -20,3 +18,4 @@ target_link_libraries(qedit strmbase strmiids uuid wine)
 add_importlibs(qedit ole32 oleaut32 msvcrt kernel32 ntdll)
 add_pch(qedit precomp.h SOURCE)
 add_cd_file(TARGET qedit DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(qedit) # CORE-5743: No ARRAY_SIZE and CONST_VTABLE

--- a/dll/directx/wine/quartz/CMakeLists.txt
+++ b/dll/directx/wine/quartz/CMakeLists.txt
@@ -3,12 +3,10 @@ remove_definitions(-D_WIN32_WINNT=0x502)
 add_definitions(-D_WIN32_WINNT=0x600)
 
 add_definitions(
-    -D__WINESRC__
     -DENTRY_PREFIX=QUARTZ_
     -DWINE_REGISTER_DLL
     -DPROXY_DELEGATION)
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(quartz.dll quartz.spec)
 add_rpcproxy_files(quartz_strmif.idl)
 
@@ -61,3 +59,4 @@ add_importlibs(quartz dsound msacm32 msvfw32 ole32 oleaut32 rpcrt4 user32 gdi32 
 add_dependencies(quartz dxsdk quartz_idlheader stdole2)
 add_pch(quartz precomp.h "${PCH_SKIP_SOURCE}")
 add_cd_file(TARGET quartz DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(quartz) # CORE-5743: No CONST_VTABLE

--- a/dll/directx/wine/wined3d/CMakeLists.txt
+++ b/dll/directx/wine/wined3d/CMakeLists.txt
@@ -1,12 +1,9 @@
 
 add_definitions(
-    -D__WINESRC__
     -D_USE_MATH_DEFINES
     -DUSE_WIN32_OPENGL
     -D__ROS_LONG64__
     -Dcopysignf=_copysignf)
-
-include_directories(BEFORE ${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 
 # We name this d3dwine.dll, because the Virtualbox additions ship with a custom wined3d.dll
 # and it breaks everything if it is installed.
@@ -52,6 +49,7 @@ target_link_libraries(d3dwine wine)
 add_importlibs(d3dwine user32 opengl32 gdi32 gdi32_vista advapi32 msvcrt kernel32 ntdll)
 add_pch(d3dwine precomp.h SOURCE)
 add_cd_file(TARGET d3dwine DESTINATION reactos/system32 FOR all)
+set_wine_module(d3dwine)
 
 if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
     target_compile_options(d3dwine PRIVATE -Wno-format-overflow)

--- a/dll/win32/activeds/CMakeLists.txt
+++ b/dll/win32/activeds/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(activeds.dll activeds.spec)
 
 list(APPEND SOURCE
@@ -17,3 +15,4 @@ target_link_libraries(activeds wine)
 add_importlibs(activeds msvcrt kernel32 ntdll)
 add_pch(activeds precomp.h SOURCE)
 add_cd_file(TARGET activeds DESTINATION reactos/system32 FOR all)
+set_wine_module(activeds)

--- a/dll/win32/actxprxy/CMakeLists.txt
+++ b/dll/win32/actxprxy/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__WINESRC__)
+include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 add_definitions(-DWINE_REGISTER_DLL -DPROXY_DELEGATION)
 spec2def(actxprxy.dll actxprxy.spec)
 
@@ -43,4 +45,3 @@ target_link_libraries(actxprxy uuid wine ${PSEH_LIB})
 add_importlibs(actxprxy rpcrt4 ole32 oleaut32 msvcrt kernel32 ntdll)
 add_pch(actxprxy precomp.h SOURCE)
 add_cd_file(TARGET actxprxy DESTINATION reactos/system32 FOR all)
-set_wine_module(actxprxy)

--- a/dll/win32/actxprxy/CMakeLists.txt
+++ b/dll/win32/actxprxy/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 add_definitions(-DWINE_REGISTER_DLL -DPROXY_DELEGATION)
 spec2def(actxprxy.dll actxprxy.spec)
 
@@ -45,3 +43,4 @@ target_link_libraries(actxprxy uuid wine ${PSEH_LIB})
 add_importlibs(actxprxy rpcrt4 ole32 oleaut32 msvcrt kernel32 ntdll)
 add_pch(actxprxy precomp.h SOURCE)
 add_cd_file(TARGET actxprxy DESTINATION reactos/system32 FOR all)
+set_wine_module(actxprxy)

--- a/dll/win32/advpack/CMakeLists.txt
+++ b/dll/win32/advpack/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(BEFORE ${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(advpack.dll advpack.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -20,3 +18,4 @@ target_link_libraries(advpack wine)
 add_importlibs(advpack ole32 setupapi version advapi32 msvcrt kernel32 ntdll)
 add_pch(advpack precomp.h SOURCE)
 add_cd_file(TARGET advpack DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(advpack) # CORE-5743: No ARRAY_SIZE macro

--- a/dll/win32/atl/CMakeLists.txt
+++ b/dll/win32/atl/CMakeLists.txt
@@ -3,10 +3,8 @@ remove_definitions(-D_WIN32_WINNT=0x502)
 add_definitions(-D_WIN32_WINNT=0x600)
 
 add_definitions(
-    -D__WINESRC__
     -D_ATL_VER=_ATL_VER_30)
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(atl.dll atl.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -37,3 +35,4 @@ target_link_libraries(atl uuid wine)
 add_importlibs(atl oleaut32 ole32 user32 gdi32 advapi32 advapi32_vista shlwapi msvcrt kernel32 ntdll)
 add_pch(atl precomp.h SOURCE)
 add_cd_file(TARGET atl DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(atl) # CORE-5743: No ARRAY_SIZE macro

--- a/dll/win32/atl100/CMakeLists.txt
+++ b/dll/win32/atl100/CMakeLists.txt
@@ -3,10 +3,8 @@ remove_definitions(-D_WIN32_WINNT=0x502)
 add_definitions(-D_WIN32_WINNT=0x600)
 
 add_definitions(
-    -D__WINESRC__
     -D_ATL_VER=_ATL_VER_100)
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(atl100.dll atl100.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -25,3 +23,4 @@ target_link_libraries(atl100 uuid wine)
 add_importlibs(atl100 ole32 oleaut32 user32 gdi32 advapi32 advapi32_vista shlwapi msvcrt kernel32 ntdll)
 add_pch(atl100 precomp.h SOURCE)
 add_cd_file(TARGET atl100 DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(atl100) # CORE-5743: No ARRAY_SIZE macro

--- a/dll/win32/atl80/CMakeLists.txt
+++ b/dll/win32/atl80/CMakeLists.txt
@@ -3,7 +3,6 @@ remove_definitions(-D_WIN32_WINNT=0x502)
 add_definitions(-D_WIN32_WINNT=0x600)
 
 add_definitions(
-    -D__WINESRC__
     -D_ATL_VER=_ATL_VER_80)
 
 spec2def(atl80.dll atl80.spec ADD_IMPORTLIB)
@@ -25,3 +24,4 @@ target_link_libraries(atl80 uuid wine)
 add_importlibs(atl80 oleaut32 user32 ole32 gdi32 advapi32 advapi32_vista shlwapi msvcrt kernel32 ntdll)
 add_pch(atl80 precomp.h SOURCE)
 add_cd_file(TARGET atl80 DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(atl80) # CORE-5743: No ARRAY_SIZE macro

--- a/dll/win32/avifil32/CMakeLists.txt
+++ b/dll/win32/avifil32/CMakeLists.txt
@@ -2,8 +2,7 @@
 remove_definitions(-D_WIN32_WINNT=0x502)
 add_definitions(-D_WIN32_WINNT=0x600)
 
-add_definitions(-D__WINESRC__ -DENTRY_PREFIX=avifil32_)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
+add_definitions(-DENTRY_PREFIX=avifil32_)
 spec2def(avifil32.dll avifil32.spec ADD_IMPORTLIB)
 add_rpcproxy_files(avifil32.idl)
 
@@ -40,3 +39,4 @@ target_link_libraries(avifil32 wine ${PSEH_LIB})
 add_importlibs(avifil32 msacm32 msvfw32 winmm ole32 user32 advapi32 rpcrt4 msvcrt kernel32 ntdll)
 add_pch(avifil32 precomp.h "${PCH_SKIP_SOURCE}")
 add_cd_file(TARGET avifil32 DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(avifil32) # CORE-5743: No ARRAY_SIZE nor CONST_VTABLE

--- a/dll/win32/avrt/CMakeLists.txt
+++ b/dll/win32/avrt/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
-add_definitions(-D__WINESRC__)
 spec2def(avrt.dll avrt.spec)
 
 list(APPEND SOURCE
@@ -13,3 +11,4 @@ set_module_type(avrt win32dll)
 target_link_libraries(avrt wine)
 add_importlibs(avrt user32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET avrt DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(avrt) # CORE-5743: ???

--- a/dll/win32/bcrypt/CMakeLists.txt
+++ b/dll/win32/bcrypt/CMakeLists.txt
@@ -1,7 +1,5 @@
 
-add_definitions(-D__WINESRC__)
 include_directories(
-    ${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine
     ${REACTOS_SOURCE_DIR}/sdk/include/reactos/libs/mbedtls)
 spec2def(bcrypt.dll bcrypt.spec ADD_IMPORTLIB)
 
@@ -16,3 +14,4 @@ set_module_type(bcrypt win32dll)
 target_link_libraries(bcrypt wine)
 add_importlibs(bcrypt mbedtls advapi32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET bcrypt DESTINATION reactos/system32 FOR all)
+set_wine_module(bcrypt)

--- a/dll/win32/cabinet/CMakeLists.txt
+++ b/dll/win32/cabinet/CMakeLists.txt
@@ -1,10 +1,8 @@
 
 add_definitions(
-    -D__WINESRC__
     -DHAVE_ZLIB)
 
 include_directories(
-    ${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine
     ${REACTOS_SOURCE_DIR}/sdk/include/reactos/libs/zlib)
 
 spec2def(cabinet.dll cabinet.spec ADD_IMPORTLIB)
@@ -28,3 +26,4 @@ target_link_libraries(cabinet wine zlib)
 add_importlibs(cabinet msvcrt kernel32 ntdll)
 add_pch(cabinet precomp.h "${PCH_SKIP_SOURCE}")
 add_cd_file(TARGET cabinet DESTINATION reactos/system32 FOR all)
+set_wine_module(cabinet)

--- a/dll/win32/clusapi/CMakeLists.txt
+++ b/dll/win32/clusapi/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(clusapi.dll clusapi.spec)
 
 list(APPEND SOURCE
@@ -19,3 +17,4 @@ set_module_type(clusapi win32dll)
 target_link_libraries(clusapi wine)
 add_importlibs(clusapi msvcrt kernel32 ntdll)
 add_cd_file(TARGET clusapi DESTINATION reactos/system32 FOR all)
+set_wine_module(clusapi)

--- a/dll/win32/comcat/CMakeLists.txt
+++ b/dll/win32/comcat/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(comcat.dll comcat.spec)
 
 list(APPEND SOURCE
@@ -11,3 +9,4 @@ add_library(comcat MODULE ${SOURCE} version.rc)
 set_module_type(comcat win32dll)
 add_importlibs(comcat ole32 msvcrt kernel32)
 add_cd_file(TARGET comcat DESTINATION reactos/system32 FOR all)
+set_wine_module(comcat)

--- a/dll/win32/comctl32/CMakeLists.txt
+++ b/dll/win32/comctl32/CMakeLists.txt
@@ -1,6 +1,5 @@
 
 add_definitions(
-    -D__WINESRC__
     -D_WINE
     -D__ROS_LONG64__
     -D_COMCTL32_)
@@ -8,7 +7,6 @@ add_definitions(
 remove_definitions(-D_WIN32_WINNT=0x502 -DWINVER=0x502)
 add_definitions(-D_WIN32_WINNT=0x600 -DWINVER=0x600)
 
-include_directories(BEFORE ${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(comctl32.dll comctl32.spec ADD_IMPORTLIB)
 
 if(MSVC)
@@ -82,3 +80,4 @@ add_cd_file(TARGET comctl32 DESTINATION reactos/winsxs/${WINARCH}_microsoft.wind
 add_cd_file(TARGET comctl32 DESTINATION reactos/winsxs/${WINARCH}_microsoft.windows.common-controls_6595b64144ccf1df_6.0.2600.2982_none_deadbeef FOR all)
 add_cd_file(FILE ${CMAKE_CURRENT_SOURCE_DIR}/${WINARCH}_microsoft.windows.common-controls_6595b64144ccf1df_5.82.2600.2982_none_deadbeef.manifest DESTINATION reactos/winsxs/manifests FOR all)
 add_cd_file(FILE ${CMAKE_CURRENT_SOURCE_DIR}/${WINARCH}_microsoft.windows.common-controls_6595b64144ccf1df_6.0.2600.2982_none_deadbeef.manifest DESTINATION reactos/winsxs/manifests FOR all)
+set_wine_module_FIXME(comctl32) # CORE-5743: No ARRAY_SIZE macro

--- a/dll/win32/comdlg32/CMakeLists.txt
+++ b/dll/win32/comdlg32/CMakeLists.txt
@@ -1,10 +1,8 @@
 
 add_definitions(
-    -D__WINESRC__
     -D_WINE
     -D__ROS_LONG64__)
 
-include_directories(BEFORE ${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(comdlg32.dll comdlg32.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -32,3 +30,4 @@ add_delay_importlibs(comdlg32 ole32)
 add_importlibs(comdlg32 shell32 shlwapi comctl32 winspool user32 gdi32 advapi32 msvcrt kernel32 ntdll)
 add_pch(comdlg32 precomp.h SOURCE)
 add_cd_file(TARGET comdlg32 DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(comdlg32) # CORE-5743: No ARRAY_SIZE and CONST_VTABLE

--- a/dll/win32/compstui/CMakeLists.txt
+++ b/dll/win32/compstui/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(compstui.dll compstui.spec)
 
 list(APPEND SOURCE
@@ -12,3 +10,4 @@ set_module_type(compstui win32dll)
 target_link_libraries(compstui wine)
 add_importlibs(compstui msvcrt kernel32 ntdll)
 add_cd_file(TARGET compstui DESTINATION reactos/system32 FOR all)
+set_wine_module(compstui)

--- a/dll/win32/credui/CMakeLists.txt
+++ b/dll/win32/credui/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(credui.dll credui.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -13,3 +11,4 @@ set_module_type(credui win32dll)
 target_link_libraries(credui wine oldnames)
 add_importlibs(credui advapi32 user32 comctl32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET credui DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(credui) # CORE-5743: No ARRAY_SIZE macro

--- a/dll/win32/crypt32/CMakeLists.txt
+++ b/dll/win32/crypt32/CMakeLists.txt
@@ -3,14 +3,12 @@ remove_definitions(-D_WIN32_WINNT=0x502 -DWINVER=0x502)
 add_definitions(-D_WIN32_WINNT=0x600 -DWINVER=0x600)
 
 add_definitions(
-    -D__WINESRC__
     -D__ROS_LONG64__
     -D_WINE
     -D_CRYPT32_
     -Dstrncasecmp=_strnicmp
 )
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(crypt32.dll crypt32.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -60,3 +58,4 @@ add_delay_importlibs(crypt32 cryptnet)
 add_importlibs(crypt32 bcrypt user32 advapi32 advapi32_vista msvcrt kernel32 ntdll)
 add_pch(crypt32 precomp.h "${PCH_SKIP_SOURCE}")
 add_cd_file(TARGET crypt32 DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(crypt32) # CORE-5743: No ARRAY_SIZE macro

--- a/dll/win32/cryptdlg/CMakeLists.txt
+++ b/dll/win32/cryptdlg/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(cryptdlg.dll cryptdlg.spec)
 
 list(APPEND SOURCE
@@ -13,3 +11,4 @@ set_module_type(cryptdlg win32dll)
 target_link_libraries(cryptdlg wine)
 add_importlibs(cryptdlg advapi32 user32 crypt32 cryptui wintrust msvcrt kernel32 ntdll)
 add_cd_file(TARGET cryptdlg DESTINATION reactos/system32 FOR all)
+set_wine_module(cryptdlg)

--- a/dll/win32/cryptdll/CMakeLists.txt
+++ b/dll/win32/cryptdll/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(cryptdll.dll cryptdll.spec)
 
 list(APPEND SOURCE
@@ -13,3 +11,4 @@ set_module_type(cryptdll win32dll)
 target_link_libraries(cryptdll wine)
 add_importlibs(cryptdll advapi32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET cryptdll DESTINATION reactos/system32 FOR all)
+set_wine_module(cryptdll)

--- a/dll/win32/cryptnet/CMakeLists.txt
+++ b/dll/win32/cryptnet/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(cryptnet.dll cryptnet.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -14,3 +12,4 @@ target_link_libraries(cryptnet wine)
 add_delay_importlibs(cryptnet wininet)
 add_importlibs(cryptnet crypt32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET cryptnet DESTINATION reactos/system32 FOR all)
+set_wine_module(cryptnet)

--- a/dll/win32/cryptui/CMakeLists.txt
+++ b/dll/win32/cryptui/CMakeLists.txt
@@ -1,6 +1,5 @@
 
 add_definitions(
-    -D__WINESRC__
     -D_WINE
     -D__ROS_LONG64__)
 
@@ -18,3 +17,4 @@ target_link_libraries(cryptui uuid wine oldnames)
 add_delay_importlibs(cryptui urlmon wintrust)
 add_importlibs(cryptui user32 ole32 crypt32 gdi32 advapi32 comctl32 comdlg32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET cryptui DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(cryptui) # CORE-5743: No ARRAY_SIZE macro

--- a/dll/win32/dbgeng/CMakeLists.txt
+++ b/dll/win32/dbgeng/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(dbgeng.dll dbgeng.spec)
 
 list(APPEND SOURCE
@@ -14,3 +12,4 @@ target_link_libraries(dbgeng wine)
 add_importlibs(dbgeng psapi msvcrt ntdll)
 add_delay_importlibs(dbgeng version)
 add_cd_file(TARGET dbgeng DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(dbgeng) # CORE-5743: No ARRAY_SIZE and CONST_VTABLE

--- a/dll/win32/dbghelp/CMakeLists.txt
+++ b/dll/win32/dbghelp/CMakeLists.txt
@@ -26,7 +26,6 @@ if(NOT CMAKE_CROSSCOMPILING)
     target_link_libraries(dbghelphost PRIVATE host_includes)
 else()
     add_definitions(
-        -D__WINESRC__
         -D_WINE
         -DHAVE_ALLOCA_H
         -D_IMAGEHLP_SOURCE_)
@@ -75,6 +74,7 @@ else()
     add_importlibs(dbghelp psapi msvcrt kernel32 ntdll)
     add_pch(dbghelp precomp.h SOURCE)
     add_cd_file(TARGET dbghelp DESTINATION reactos/system32 FOR all)
+    set_wine_module_FIXME(dbghelp) # CORE-5743: No ARRAY_SIZE macro
 
     if(MSVC)
         # Disable warning C4146: unary minus operator applied to unsigned type, result still unsigned

--- a/dll/win32/dciman32/CMakeLists.txt
+++ b/dll/win32/dciman32/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(dciman32.dll dciman32.spec)
 
 list(APPEND SOURCE
@@ -13,3 +11,4 @@ set_module_type(dciman32 win32dll)
 target_link_libraries(dciman32 wine)
 add_importlibs(dciman32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET dciman32 DESTINATION reactos/system32 FOR all)
+set_wine_module(dciman32)

--- a/dll/win32/dwmapi/CMakeLists.txt
+++ b/dll/win32/dwmapi/CMakeLists.txt
@@ -1,4 +1,7 @@
 
+add_definitions(-D__WINESRC__)
+
+include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(dwmapi.dll dwmapi.spec)
 
 list(APPEND SOURCE
@@ -14,4 +17,3 @@ set_module_type(dwmapi win32dll UNICODE ENTRYPOINT 0)
 target_link_libraries(dwmapi uuid wine)
 add_importlibs(dwmapi user32 kernel32 ntdll)
 add_cd_file(TARGET dwmapi DESTINATION reactos/system32 FOR all)
-set_wine_module_FIXME(dwmapi) # CORE-5743: No ARRAY_SIZE macro

--- a/dll/win32/dwmapi/CMakeLists.txt
+++ b/dll/win32/dwmapi/CMakeLists.txt
@@ -1,7 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(dwmapi.dll dwmapi.spec)
 
 list(APPEND SOURCE
@@ -17,3 +14,4 @@ set_module_type(dwmapi win32dll UNICODE ENTRYPOINT 0)
 target_link_libraries(dwmapi uuid wine)
 add_importlibs(dwmapi user32 kernel32 ntdll)
 add_cd_file(TARGET dwmapi DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(dwmapi) # CORE-5743: No ARRAY_SIZE macro

--- a/dll/win32/faultrep/CMakeLists.txt
+++ b/dll/win32/faultrep/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(faultrep.dll faultrep.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -13,3 +11,4 @@ set_module_type(faultrep win32dll)
 target_link_libraries(faultrep wine)
 add_importlibs(faultrep advapi32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET faultrep DESTINATION reactos/system32 FOR all)
+set_wine_module(faultrep)

--- a/dll/win32/fontsub/CMakeLists.txt
+++ b/dll/win32/fontsub/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(fontsub.dll fontsub.spec)
 
 add_library(fontsub MODULE
@@ -12,3 +10,4 @@ set_module_type(fontsub win32dll)
 target_link_libraries(fontsub wine)
 add_importlibs(fontsub msvcrt kernel32 ntdll)
 add_cd_file(TARGET fontsub DESTINATION reactos/system32 FOR all)
+set_wine_module(fontsub)

--- a/dll/win32/fusion/CMakeLists.txt
+++ b/dll/win32/fusion/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(fusion.dll fusion.spec)
 
 list(APPEND COMMON_SOURCE
@@ -16,6 +14,7 @@ add_library(fusion_common STATIC ${COMMON_SOURCE})
 target_link_libraries(fusion_common oldnames)
 add_dependencies(fusion_common psdk)
 add_pch(fusion_common precomp.h COMMON_SOURCE)
+set_wine_module_FIXME(fusion_common) # CORE-5743: No ARRAY_SIZE and CONST_VTABLE
 
 add_library(fusion MODULE
     version.rc

--- a/dll/win32/gdiplus/CMakeLists.txt
+++ b/dll/win32/gdiplus/CMakeLists.txt
@@ -1,10 +1,8 @@
 
 add_definitions(
-    -D__WINESRC__
     -D__ROS_LONG64__
     -D_USE_MATH_DEFINES)
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(gdiplus.dll gdiplus.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -51,3 +49,4 @@ add_cd_file(FILE ${CMAKE_CURRENT_SOURCE_DIR}/${WINARCH}_microsoft.windows.gdiplu
 
 add_cd_file(TARGET gdiplus DESTINATION reactos/winsxs/${WINARCH}_microsoft.windows.gdiplus_6595b64144ccf1df_1.0.14393.0_none_deadbeef FOR all)
 add_cd_file(FILE ${CMAKE_CURRENT_SOURCE_DIR}/${WINARCH}_microsoft.windows.gdiplus_6595b64144ccf1df_1.0.14393.0_none_deadbeef.manifest DESTINATION reactos/winsxs/manifests FOR all)
+set_wine_module_FIXME(gdiplus) # CORE-5743: No ARRAY_SIZE macro

--- a/dll/win32/hhctrl.ocx/CMakeLists.txt
+++ b/dll/win32/hhctrl.ocx/CMakeLists.txt
@@ -2,8 +2,6 @@
 remove_definitions(-D_WIN32_WINNT=0x502)
 add_definitions(-D_WIN32_WINNT=0x600)
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(hhctrl.ocx hhctrl.ocx.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -38,3 +36,4 @@ add_importlibs(hhctrl advapi32 comctl32 shlwapi ole32 oleaut32 user32 gdi32 msvc
 add_dependencies(hhctrl stdole2 wineheaders)
 add_pch(hhctrl precomp.h "${PCH_SKIP_SOURCE}")
 add_cd_file(TARGET hhctrl DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(hhctrl) # CORE-5743: No ARRAY_SIZE and CONST_VTABLE

--- a/dll/win32/hlink/CMakeLists.txt
+++ b/dll/win32/hlink/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(hlink.dll hlink.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -24,3 +22,4 @@ add_delay_importlibs(hlink urlmon)
 add_importlibs(hlink shell32 ole32 advapi32 msvcrt kernel32 ntdll)
 add_pch(hlink precomp.h "${PCH_SKIP_SOURCE}")
 add_cd_file(TARGET hlink DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(hlink) # CORE-5743: No ARRAY_SIZE and CONST_VTABLE

--- a/dll/win32/hnetcfg/CMakeLists.txt
+++ b/dll/win32/hnetcfg/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(hnetcfg.dll hnetcfg.spec)
 
 list(APPEND SOURCE
@@ -32,3 +30,4 @@ target_link_libraries(hnetcfg wine uuid)
 add_importlibs(hnetcfg ole32 oleaut32 advapi32 mpr msvcrt kernel32 ntdll)
 add_pch(hnetcfg precomp.h SOURCE)
 add_cd_file(TARGET hnetcfg DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(hnetcfg) # CORE-5743: No ARRAY_SIZE and CONST_VTABLE

--- a/dll/win32/iccvid/CMakeLists.txt
+++ b/dll/win32/iccvid/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(iccvid.dll iccvid.spec)
 
 list(APPEND SOURCE
@@ -12,3 +10,4 @@ set_module_type(iccvid win32dll)
 target_link_libraries(iccvid wine)
 add_importlibs(iccvid user32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET iccvid DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(iccvid) # CORE-5743: No ARRAY_SIZE macro

--- a/dll/win32/ieframe/CMakeLists.txt
+++ b/dll/win32/ieframe/CMakeLists.txt
@@ -1,6 +1,5 @@
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
-add_definitions(-D__WINESRC__ -D__ROS_LONG64__)
+add_definitions(-D__ROS_LONG64__)
 spec2def(ieframe.dll ieframe.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -47,3 +46,4 @@ target_link_libraries(ieframe uuid wine)
 add_importlibs(ieframe urlmon shell32 comctl32 shlwapi oleaut32 ole32 user32 gdi32 advapi32 msvcrt kernel32 ntdll)
 add_pch(ieframe precomp.h SOURCE)
 add_cd_file(TARGET ieframe DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(ieframe) # CORE-5743: No CONST_VTABLE

--- a/dll/win32/imaadp32.acm/CMakeLists.txt
+++ b/dll/win32/imaadp32.acm/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(imaadp32.acm imaadp32.acm.spec)
 
 list(APPEND SOURCE
@@ -13,3 +11,4 @@ set_target_properties(imaadp32.acm PROPERTIES SUFFIX "")
 target_link_libraries(imaadp32.acm wine)
 add_importlibs(imaadp32.acm winmm user32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET imaadp32.acm DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(imaadp32.acm) # CORE-5743: No ARRAY_SIZE macro

--- a/dll/win32/inetcomm/CMakeLists.txt
+++ b/dll/win32/inetcomm/CMakeLists.txt
@@ -1,6 +1,5 @@
 
-add_definitions(-D__WINESRC__ -D__ROS_LONG64__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
+add_definitions(-D__ROS_LONG64__)
 spec2def(inetcomm.dll inetcomm.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -28,3 +27,4 @@ target_link_libraries(inetcomm uuid wine)
 add_importlibs(inetcomm ole32 oleaut32 ws2_32 user32 propsys urlmon msvcrt kernel32 ntdll)
 add_pch(inetcomm precomp.h "${PCH_SKIP_SOURCE}")
 add_cd_file(TARGET inetcomm DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(inetcomm) # CORE-5743: No ARRAY_SIZE and CONST_VTABLE

--- a/dll/win32/inetmib1/CMakeLists.txt
+++ b/dll/win32/inetmib1/CMakeLists.txt
@@ -1,6 +1,5 @@
 
-add_definitions(-D__WINESRC__ -D__ROS_LONG64__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
+add_definitions(-D__ROS_LONG64__)
 spec2def(inetmib1.dll inetmib1.spec)
 
 list(APPEND SOURCE
@@ -14,3 +13,4 @@ target_link_libraries(inetmib1 wine)
 add_delay_importlibs(inetmib1 iphlpapi)
 add_importlibs(inetmib1 snmpapi msvcrt kernel32 ntdll)
 add_cd_file(TARGET inetmib1 DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(inetmib1) # CORE-5743: No ARRAY_SIZE macro

--- a/dll/win32/initpki/CMakeLists.txt
+++ b/dll/win32/initpki/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(initpki.dll initpki.spec)
 
 list(APPEND SOURCE
@@ -13,3 +11,4 @@ set_module_type(initpki win32dll)
 target_link_libraries(initpki wine)
 add_importlibs(initpki msvcrt kernel32 ntdll)
 add_cd_file(TARGET initpki DESTINATION reactos/system32 FOR all)
+set_wine_module(initpki)

--- a/dll/win32/inseng/CMakeLists.txt
+++ b/dll/win32/inseng/CMakeLists.txt
@@ -3,11 +3,9 @@ remove_definitions(-D_WIN32_WINNT=0x502)
 add_definitions(-D_WIN32_WINNT=0x600)
 
 add_definitions(
-    -D__WINESRC__
     -Dstrcasecmp=_stricmp
     -Dstrncasecmp=_strnicmp
 )
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(inseng.dll inseng.spec)
 
 list(APPEND SOURCE
@@ -30,3 +28,4 @@ target_link_libraries(inseng uuid wine)
 add_importlibs(inseng ole32 urlmon kernel32_vista msvcrt kernel32 ntdll)
 add_pch(inseng precomp.h "${PCH_SKIP_SOURCE}")
 add_cd_file(TARGET inseng DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(inseng) # CORE-5743: No CONST_VTABLE

--- a/dll/win32/itircl/CMakeLists.txt
+++ b/dll/win32/itircl/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(itircl.dll itircl.spec)
 
 list(APPEND SOURCE
@@ -13,3 +11,4 @@ set_module_type(itircl win32dll)
 target_link_libraries(itircl wine)
 add_importlibs(itircl msvcrt kernel32 ntdll)
 add_cd_file(TARGET itircl DESTINATION reactos/system32 FOR all)
+set_wine_module(itircl)

--- a/dll/win32/itss/CMakeLists.txt
+++ b/dll/win32/itss/CMakeLists.txt
@@ -1,6 +1,5 @@
 
-add_definitions(-D__WINESRC__ -D__ROS_LONG64__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
+add_definitions(-D__ROS_LONG64__)
 spec2def(itss.dll itss.spec)
 
 list(APPEND SOURCE
@@ -27,3 +26,4 @@ add_importlibs(itss urlmon shlwapi ole32 msvcrt kernel32 ntdll)
 add_pch(itss precomp.h "${PCH_SKIP_SOURCE}")
 add_dependencies(itss wineheaders)
 add_cd_file(TARGET itss DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(itss) # CORE-5743: No ARRAY_SIZE and CONST_VTABLE

--- a/dll/win32/jsproxy/CMakeLists.txt
+++ b/dll/win32/jsproxy/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(jsproxy.dll jsproxy.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -13,3 +11,4 @@ set_module_type(jsproxy win32dll)
 target_link_libraries(jsproxy uuid wine)
 add_importlibs(jsproxy oleaut32 ole32 ws2_32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET jsproxy DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(jsproxy) # CORE-5743: No ARRAY_SIZE and CONST_VTABLE

--- a/dll/win32/loadperf/CMakeLists.txt
+++ b/dll/win32/loadperf/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(loadperf.dll loadperf.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -13,3 +11,4 @@ set_module_type(loadperf win32dll)
 target_link_libraries(loadperf wine)
 add_importlibs(loadperf msvcrt kernel32 ntdll)
 add_cd_file(TARGET loadperf DESTINATION reactos/system32 FOR all)
+set_wine_module(loadperf)

--- a/dll/win32/lz32/CMakeLists.txt
+++ b/dll/win32/lz32/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(lz32.dll lz32.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -13,3 +11,4 @@ target_link_libraries(lz32 wine)
 add_importlibs(lz32 kernel32 ntdll)
 add_dependencies(lz32 psdk)
 add_cd_file(TARGET lz32 DESTINATION reactos/system32 FOR all)
+set_wine_module(lz32)

--- a/dll/win32/mciavi32/CMakeLists.txt
+++ b/dll/win32/mciavi32/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(mciavi32.dll mciavi32.spec)
 
 list(APPEND SOURCE
@@ -20,3 +18,4 @@ target_link_libraries(mciavi32 wine)
 add_importlibs(mciavi32 msvfw32 winmm user32 gdi32 msvcrt kernel32 ntdll)
 add_pch(mciavi32 precomp.h SOURCE)
 add_cd_file(TARGET mciavi32 DESTINATION reactos/system32 FOR all)
+set_wine_module(mciavi32)

--- a/dll/win32/mciqtz32/CMakeLists.txt
+++ b/dll/win32/mciqtz32/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(mciqtz32.dll mciqtz32.spec)
 
 list(APPEND SOURCE
@@ -13,3 +11,4 @@ target_link_libraries(mciqtz32 wine strmiids)
 add_importlibs(mciqtz32 winmm ole32 user32 gdi32 msvcrt kernel32 ntdll)
 add_dependencies(mciqtz32 dxsdk)
 add_cd_file(TARGET mciqtz32 DESTINATION reactos/system32 FOR all)
+set_wine_module(mciqtz32)

--- a/dll/win32/mciseq/CMakeLists.txt
+++ b/dll/win32/mciseq/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(mciseq.dll mciseq.spec)
 
 list(APPEND SOURCE
@@ -12,6 +10,7 @@ set_module_type(mciseq win32dll)
 target_link_libraries(mciseq wine)
 add_importlibs(mciseq winmm user32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET mciseq DESTINATION reactos/system32 FOR all)
+set_wine_module(mciseq)
 
 if(MSVC)
     # Disable warning C4305: '=': truncation from 'UINT' to 'WORD'

--- a/dll/win32/mciwave/CMakeLists.txt
+++ b/dll/win32/mciwave/CMakeLists.txt
@@ -1,9 +1,7 @@
 
 add_definitions(
-    -D__WINESRC__
     -D_WINE)
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(mciwave.dll mciwave.spec)
 
 list(APPEND SOURCE
@@ -15,6 +13,7 @@ set_module_type(mciwave win32dll)
 target_link_libraries(mciwave wine)
 add_importlibs(mciwave user32 winmm msvcrt kernel32 ntdll)
 add_cd_file(TARGET mciwave DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(mciwave) # CORE-5743: No ARRAY_SIZE macro
 
 if(MSVC)
     # Disable warning C4305: '=': truncation from 'UINT' to 'WORD'

--- a/dll/win32/mgmtapi/CMakeLists.txt
+++ b/dll/win32/mgmtapi/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(mgmtapi.dll mgmtapi.spec)
 
 list(APPEND SOURCE
@@ -13,3 +11,4 @@ set_module_type(mgmtapi win32dll)
 target_link_libraries(mgmtapi wine)
 add_importlibs(mgmtapi msvcrt kernel32 ntdll)
 add_cd_file(TARGET mgmtapi DESTINATION reactos/system32 FOR all)
+set_wine_module(mgmtapi)

--- a/dll/win32/mlang/CMakeLists.txt
+++ b/dll/win32/mlang/CMakeLists.txt
@@ -1,9 +1,7 @@
 
 add_definitions(
-    -D__WINESRC__
     -DCOM_NO_WINDOWS_H)
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(mlang.dll mlang.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -17,3 +15,4 @@ target_link_libraries(mlang uuid wine oldnames)
 add_delay_importlibs(mlang oleaut32)
 add_importlibs(mlang gdi32 advapi32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET mlang DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(mlang) # CORE-5743: No ARRAY_SIZE and CONST_VTABLE

--- a/dll/win32/mmdevapi/CMakeLists.txt
+++ b/dll/win32/mmdevapi/CMakeLists.txt
@@ -2,8 +2,6 @@
 remove_definitions(-D_WIN32_WINNT=0x502)
 add_definitions(-D_WIN32_WINNT=0x600)
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(mmdevapi.dll mmdevapi.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -25,3 +23,4 @@ add_importlibs(mmdevapi ole32 oleaut32 user32 advapi32 msvcrt kernel32 ntdll)
 add_pch(mmdevapi precomp.h SOURCE)
 add_dependencies(mmdevapi dxsdk)
 add_cd_file(TARGET mmdevapi DESTINATION reactos/system32 FOR all)
+set_wine_module(mmdevapi)

--- a/dll/win32/mpr/CMakeLists.txt
+++ b/dll/win32/mpr/CMakeLists.txt
@@ -1,9 +1,7 @@
 
 add_definitions(
-    -D__WINESRC__
     -D_WINE)
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(mpr.dll mpr.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -26,3 +24,4 @@ target_link_libraries(mpr wine)
 add_importlibs(mpr advapi32 user32 msvcrt kernel32 ntdll)
 add_pch(mpr precomp.h SOURCE)
 add_cd_file(TARGET mpr DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(mpr) # CORE-5743: No ARRAY_SIZE macro

--- a/dll/win32/mprapi/CMakeLists.txt
+++ b/dll/win32/mprapi/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(mprapi.dll mprapi.spec)
 
 list(APPEND SOURCE
@@ -13,3 +11,4 @@ set_module_type(mprapi win32dll)
 target_link_libraries(mprapi wine)
 add_importlibs(mprapi msvcrt kernel32 ntdll)
 add_cd_file(TARGET mprapi DESTINATION reactos/system32 FOR all)
+set_wine_module(mprapi)

--- a/dll/win32/msacm32/CMakeLists.txt
+++ b/dll/win32/msacm32/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(msacm32.dll msacm32.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -24,3 +22,4 @@ target_link_libraries(msacm32 wine oldnames)
 add_importlibs(msacm32 advapi32 user32 winmm msvcrt kernel32 ntdll)
 add_pch(msacm32 precomp.h SOURCE)
 add_cd_file(TARGET msacm32 DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(msacm32) # CORE-5743: No ARRAY_SIZE macro

--- a/dll/win32/msadp32.acm/CMakeLists.txt
+++ b/dll/win32/msadp32.acm/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(msadp32.acm msadp32.acm.spec)
 
 list(APPEND SOURCE
@@ -13,3 +11,4 @@ set_target_properties(msadp32.acm PROPERTIES SUFFIX "")
 target_link_libraries(msadp32.acm wine)
 add_importlibs(msadp32.acm winmm user32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET msadp32.acm DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(msadp32.acm) # CORE-5743: No ARRAY_SIZE macro

--- a/dll/win32/mscat32/CMakeLists.txt
+++ b/dll/win32/mscat32/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(mscat32.dll mscat32.spec)
 
 list(APPEND SOURCE
@@ -12,3 +10,4 @@ set_module_type(mscat32 win32dll)
 target_link_libraries(mscat32 wine)
 add_importlibs(mscat32 wintrust msvcrt kernel32 ntdll)
 add_cd_file(TARGET mscat32 DESTINATION reactos/system32 FOR all)
+set_wine_module(mscat32)

--- a/dll/win32/mscms/CMakeLists.txt
+++ b/dll/win32/mscms/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(mscms.dll mscms.spec)
 
 list(APPEND SOURCE
@@ -18,3 +16,4 @@ set_module_type(mscms win32dll)
 target_link_libraries(mscms wine)
 add_importlibs(mscms advapi32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET mscms DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(mscms) # CORE-5743: No ARRAY_SIZE macro

--- a/dll/win32/mscoree/CMakeLists.txt
+++ b/dll/win32/mscoree/CMakeLists.txt
@@ -2,8 +2,6 @@
 remove_definitions(-D_WIN32_WINNT=0x502)
 add_definitions(-D_WIN32_WINNT=0x600)
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(mscoree.dll mscoree.spec)
 
 list(APPEND SOURCE
@@ -30,3 +28,4 @@ target_link_libraries(mscoree uuid wine)
 add_importlibs(mscoree dbghelp advapi32 shell32 ole32 shlwapi msvcrt kernel32 ntdll)
 add_pch(mscoree mscoree_private.h "${PCH_SKIP_SOURCE}")
 add_cd_file(TARGET mscoree DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(mscoree) # CORE-5743: No CONST_VTABLE

--- a/dll/win32/msctf/CMakeLists.txt
+++ b/dll/win32/msctf/CMakeLists.txt
@@ -2,8 +2,6 @@
 remove_definitions(-D_WIN32_WINNT=0x502)
 add_definitions(-D_WIN32_WINNT=0x600)
 
-add_definitions(-D__WINESRC__)
-include_directories(BEFORE ${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(msctf.dll msctf.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -36,3 +34,4 @@ add_importlibs(msctf user32 advapi32 advapi32_vista msvcrt kernel32 ntdll)
 add_delay_importlibs(msctf shell32 shlwapi ole32 oleaut32 imm32 gdi32)
 add_pch(msctf precomp.h SOURCE)
 add_cd_file(TARGET msctf DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(msctf) # CORE-5743: No CONST_VTABLE

--- a/dll/win32/msftedit/CMakeLists.txt
+++ b/dll/win32/msftedit/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(msftedit.dll msftedit.spec)
 
 list(APPEND SOURCE
@@ -14,3 +12,4 @@ set_module_type(msftedit win32dll)
 target_link_libraries(msftedit uuid wine)
 add_importlibs(msftedit riched20 msvcrt kernel32 ntdll)
 add_cd_file(TARGET msftedit DESTINATION reactos/system32 FOR all)
+set_wine_module(msftedit)

--- a/dll/win32/msg711.acm/CMakeLists.txt
+++ b/dll/win32/msg711.acm/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(msg711.acm msg711.acm.spec)
 
 list(APPEND SOURCE
@@ -13,3 +11,4 @@ set_target_properties(msg711.acm PROPERTIES SUFFIX "")
 target_link_libraries(msg711.acm wine)
 add_importlibs(msg711.acm winmm user32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET msg711.acm DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(msg711.acm) # CORE-5743: No ARRAY_SIZE macro

--- a/dll/win32/msgsm32.acm/CMakeLists.txt
+++ b/dll/win32/msgsm32.acm/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(msgsm32.acm msgsm32.acm.spec)
 
 list(APPEND SOURCE
@@ -13,3 +11,4 @@ set_target_properties(msgsm32.acm PROPERTIES SUFFIX "")
 target_link_libraries(msgsm32.acm wine)
 add_importlibs(msgsm32.acm winmm user32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET msgsm32.acm DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(msgsm32.acm) # CORE-5743: No ARRAY_SIZE macro

--- a/dll/win32/mshtml.tlb/CMakeLists.txt
+++ b/dll/win32/mshtml.tlb/CMakeLists.txt
@@ -1,7 +1,5 @@
 
 add_typelib(mshtml_tlb.idl)
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 add_library(mshtml.tlb MODULE rsrc.rc)
 
 list(APPEND mshtml_tlb_rc_deps
@@ -13,3 +11,4 @@ set_module_type(mshtml.tlb module)
 set_target_properties(mshtml.tlb PROPERTIES SUFFIX "")
 add_dependencies(mshtml.tlb stdole2)
 add_cd_file(TARGET mshtml.tlb DESTINATION reactos/system32 FOR all)
+set_wine_module(mshtml.tlb)

--- a/dll/win32/mshtml/CMakeLists.txt
+++ b/dll/win32/mshtml/CMakeLists.txt
@@ -3,14 +3,12 @@ remove_definitions(-D_WIN32_WINNT=0x502)
 add_definitions(-D_WIN32_WINNT=0x600)
 
 add_definitions(
-    -D__WINESRC__
     -D__ROS_LONG64__
     -DCOM_NO_WINDOWS_H
     -Dstrcasecmp=_stricmp
     -Dstrncasecmp=_strnicmp
 )
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 add_idl_headers(mshtml_nsiface_header nsiface.idl)
 spec2def(mshtml.dll mshtml.spec ADD_IMPORTLIB)
 
@@ -116,3 +114,4 @@ add_importlibs(mshtml urlmon shlwapi shell32 ole32 oleaut32 user32 gdi32 advapi3
 add_dependencies(mshtml mshtml_nsiface_header)
 add_pch(mshtml mshtml_private.h "${PCH_SKIP_SOURCE}")
 add_cd_file(TARGET mshtml DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(mshtml) # CORE-5743: No CONST_VTABLE

--- a/dll/win32/msimg32/CMakeLists.txt
+++ b/dll/win32/msimg32/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
-add_definitions(-D__WINESRC__)
 spec2def(msimg32.dll msimg32.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -12,3 +10,4 @@ set_module_type(msimg32 win32dll)
 target_link_libraries(msimg32 wine)
 add_importlibs(msimg32 gdi32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET msimg32 DESTINATION reactos/system32 FOR all)
+set_wine_module(msimg32)

--- a/dll/win32/msimtf/CMakeLists.txt
+++ b/dll/win32/msimtf/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(msimtf.dll msimtf.spec)
 
 list(APPEND SOURCE
@@ -19,3 +17,4 @@ target_link_libraries(msimtf uuid wine)
 add_importlibs(msimtf imm32 msvcrt kernel32 ntdll)
 add_pch(msimtf precomp.h SOURCE)
 add_cd_file(TARGET msimtf DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(msimtf) # CORE-5743: No CONST_VTABLE

--- a/dll/win32/msisip/CMakeLists.txt
+++ b/dll/win32/msisip/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(msisip.dll msisip.spec)
 
 list(APPEND SOURCE
@@ -13,3 +11,4 @@ set_module_type(msisip win32dll)
 target_link_libraries(msisip wine)
 add_importlibs(msisip crypt32 ole32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET msisip DESTINATION reactos/system32 FOR all)
+set_wine_module(msisip)

--- a/dll/win32/msisys.ocx/CMakeLists.txt
+++ b/dll/win32/msisys.ocx/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(msisys.ocx msisys.ocx.spec)
 
 list(APPEND SOURCE
@@ -12,3 +10,4 @@ set_module_type(msisys win32ocx)
 target_link_libraries(msisys wine)
 add_importlibs(msisys msvcrt kernel32 ntdll)
 add_cd_file(TARGET msisys DESTINATION reactos/system32 FOR all)
+set_wine_module(msisys)

--- a/dll/win32/msnet32/CMakeLists.txt
+++ b/dll/win32/msnet32/CMakeLists.txt
@@ -1,9 +1,8 @@
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
-add_definitions(-D__WINESRC__)
 spec2def(msnet32.dll msnet32.spec)
 add_library(msnet32 MODULE msnet_main.c ${CMAKE_CURRENT_BINARY_DIR}/msnet32.def)
 set_module_type(msnet32 win32dll)
 target_link_libraries(msnet32 wine)
 add_importlibs(msnet32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET msnet32 DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(msnet32) # CORE-5743

--- a/dll/win32/msrle32/CMakeLists.txt
+++ b/dll/win32/msrle32/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(msrle32.dll msrle32.spec)
 
 list(APPEND SOURCE
@@ -18,3 +16,4 @@ set_module_type(msrle32 win32dll)
 target_link_libraries(msrle32 wine)
 add_importlibs(msrle32 winmm user32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET msrle32 DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(msrle32) # CORE-5743: No ARRAY_SIZE macro

--- a/dll/win32/mssign32/CMakeLists.txt
+++ b/dll/win32/mssign32/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
-add_definitions(-D__WINESRC__)
 spec2def(mssign32.dll mssign32.spec)
 
 list(APPEND SOURCE
@@ -13,3 +11,4 @@ set_module_type(mssign32 win32dll)
 target_link_libraries(mssign32 wine)
 add_importlibs(mssign32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET mssign32 DESTINATION reactos/system32 FOR all)
+set_wine_module(mssign32)

--- a/dll/win32/mssip32/CMakeLists.txt
+++ b/dll/win32/mssip32/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
-add_definitions(-D__WINESRC__)
 spec2def(mssip32.dll mssip32.spec)
 
 list(APPEND SOURCE
@@ -13,3 +11,4 @@ set_module_type(mssip32 win32dll)
 target_link_libraries(mssip32 wine)
 add_importlibs(mssip32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET mssip32 DESTINATION reactos/system32 FOR all)
+set_wine_module(mssip32)

--- a/dll/win32/mstask/CMakeLists.txt
+++ b/dll/win32/mstask/CMakeLists.txt
@@ -1,7 +1,5 @@
 
-add_definitions(-D__WINESRC__)
 include_directories(BEFORE
-    ${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine
     ${REACTOS_BINARY_DIR}/dll/win32/netapi32)
 generate_idl_iids(mstask_local.idl)
 spec2def(mstask.dll mstask.spec)
@@ -28,3 +26,4 @@ add_importlibs(mstask ole32 msvcrt kernel32 ntdll)
 add_dependencies(mstask netapi32)
 add_pch(mstask precomp.h SOURCE)
 add_cd_file(TARGET mstask DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(mstask) # CORE-5743: No CONST_VTABLE

--- a/dll/win32/msvfw32/CMakeLists.txt
+++ b/dll/win32/msvfw32/CMakeLists.txt
@@ -1,7 +1,5 @@
 
-add_definitions(-D__WINESRC__)
 add_definitions(-D_WINE)
-include_directories(BEFORE ${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(msvfw32.dll msvfw32.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -21,3 +19,4 @@ target_link_libraries(msvfw32 wine)
 add_importlibs(msvfw32 winmm comctl32 user32 gdi32 advapi32 msvcrt kernel32 ntdll)
 add_pch(msvfw32 precomp.h SOURCE)
 add_cd_file(TARGET msvfw32 DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(msvfw32) # CORE-5743: No ARRAY_SIZE macro

--- a/dll/win32/msvidc32/CMakeLists.txt
+++ b/dll/win32/msvidc32/CMakeLists.txt
@@ -1,9 +1,7 @@
 
 add_definitions(
-    -D__WINESRC__
     -D_WINE)
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(msvidc32.dll msvidc32.spec)
 
 list(APPEND SOURCE
@@ -15,3 +13,4 @@ set_module_type(msvidc32 win32dll)
 target_link_libraries(msvidc32 wine)
 add_importlibs(msvidc32 user32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET msvidc32 DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(msvidc32) # CORE-5743: No ARRAY_SIZE macro

--- a/dll/win32/msxml/CMakeLists.txt
+++ b/dll/win32/msxml/CMakeLists.txt
@@ -3,10 +3,8 @@ remove_definitions(-D_WIN32_WINNT=0x502)
 add_definitions(-D_WIN32_WINNT=0x601)
 
 add_definitions(
-    -D__WINESRC__
     -D_WINE)
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(msxml.dll msxml.spec)
 add_typelib(msxml_tlb.idl)
 
@@ -21,3 +19,4 @@ target_link_libraries(msxml wine)
 add_importlibs(msxml msxml3 msvcrt kernel32)
 add_dependencies(msxml stdole2)
 add_cd_file(TARGET msxml DESTINATION reactos/system32 FOR all)
+set_wine_module(msxml)

--- a/dll/win32/msxml2/CMakeLists.txt
+++ b/dll/win32/msxml2/CMakeLists.txt
@@ -3,10 +3,8 @@ remove_definitions(-D_WIN32_WINNT=0x502)
 add_definitions(-D_WIN32_WINNT=0x601)
 
 add_definitions(
-    -D__WINESRC__
     -D_WINE)
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(msxml2.dll msxml2.spec)
 add_typelib(msxml2_tlb.idl)
 
@@ -21,3 +19,4 @@ target_link_libraries(msxml2 wine)
 add_importlibs(msxml2 msxml3 msvcrt kernel32)
 add_dependencies(msxml2 stdole2)
 add_cd_file(TARGET msxml2 DESTINATION reactos/system32 FOR all)
+set_wine_module(msxml2)

--- a/dll/win32/msxml3/CMakeLists.txt
+++ b/dll/win32/msxml3/CMakeLists.txt
@@ -1,13 +1,11 @@
 
 add_definitions(
-    -D__WINESRC__
     -D__ROS_LONG64__
     -D_WINE
     -DLIBXML_STATIC
     -DCOM_NO_WINDOWS_H)
 
 include_directories(
-    ${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine
     ${REACTOS_SOURCE_DIR}/sdk/lib/3rdparty/libwin-iconv)
 
 spec2def(msxml3.dll msxml3.spec ADD_IMPORTLIB NO_PRIVATE_WARNINGS)
@@ -89,3 +87,4 @@ add_importlibs(msxml3 urlmon ws2_32 shlwapi oleaut32 ole32 user32 msvcrt kernel3
 add_dependencies(msxml3 xmlparser_idlheader stdole2) # msxml3_v1.tlb needs stdole2.tlb
 add_pch(msxml3 precomp.h "${PCH_SKIP_SOURCE}")
 add_cd_file(TARGET msxml3 DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(msxml3) # CORE-5743: No ARRAY_SIZE and CONST_VTABLE

--- a/dll/win32/msxml4/CMakeLists.txt
+++ b/dll/win32/msxml4/CMakeLists.txt
@@ -3,11 +3,9 @@ remove_definitions(-D_WIN32_WINNT=0x502)
 add_definitions(-D_WIN32_WINNT=0x601)
 
 add_definitions(
-    -D__WINESRC__
     -D_WINE
     -DCOM_NO_WINDOWS_H)
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(msxml4.dll msxml4.spec)
 add_typelib(msxml4_tlb.idl)
 
@@ -22,3 +20,4 @@ target_link_libraries(msxml4 wine)
 add_importlibs(msxml4 msxml3 msvcrt kernel32)
 add_dependencies(msxml4 stdole2)
 add_cd_file(TARGET msxml4 DESTINATION reactos/system32 FOR all)
+set_wine_module(msxml4)

--- a/dll/win32/msxml6/CMakeLists.txt
+++ b/dll/win32/msxml6/CMakeLists.txt
@@ -3,11 +3,9 @@ remove_definitions(-D_WIN32_WINNT=0x502)
 add_definitions(-D_WIN32_WINNT=0x601)
 
 add_definitions(
-    -D__WINESRC__
     -D_WINE
     -DCOM_NO_WINDOWS_H)
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(msxml6.dll msxml6.spec)
 add_typelib(msxml6_tlb.idl)
 
@@ -22,3 +20,4 @@ target_link_libraries(msxml6 wine)
 add_importlibs(msxml6 msxml3 msvcrt kernel32)
 add_dependencies(msxml6 stdole2)
 add_cd_file(TARGET msxml6 DESTINATION reactos/system32 FOR all)
+set_wine_module(msxml6)

--- a/dll/win32/nddeapi/CMakeLists.txt
+++ b/dll/win32/nddeapi/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
-add_definitions(-D__WINESRC__)
 spec2def(nddeapi.dll nddeapi.spec)
 
 list(APPEND SOURCE
@@ -13,3 +11,4 @@ set_module_type(nddeapi win32dll)
 target_link_libraries(nddeapi wine)
 add_importlibs(nddeapi msvcrt kernel32 ntdll)
 add_cd_file(TARGET nddeapi DESTINATION reactos/system32 FOR all)
+set_wine_module(nddeapi)

--- a/dll/win32/npptools/CMakeLists.txt
+++ b/dll/win32/npptools/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(npptools.dll npptools.spec)
 
 add_library(npptools MODULE
@@ -11,3 +9,4 @@ add_library(npptools MODULE
 set_module_type(npptools win32dll)
 add_importlibs(npptools msvcrt kernel32 ntdll)
 add_cd_file(TARGET npptools DESTINATION reactos/system32 FOR all)
+set_wine_module(npptools)

--- a/dll/win32/ntdsapi/CMakeLists.txt
+++ b/dll/win32/ntdsapi/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
-add_definitions(-D__WINESRC__)
 spec2def(ntdsapi.dll ntdsapi.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -13,3 +11,4 @@ set_module_type(ntdsapi win32dll)
 target_link_libraries(ntdsapi wine)
 add_importlibs(ntdsapi user32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET ntdsapi DESTINATION reactos/system32 FOR all)
+set_wine_module(ntdsapi)

--- a/dll/win32/ntmarta/CMakeLists.txt
+++ b/dll/win32/ntmarta/CMakeLists.txt
@@ -1,5 +1,4 @@
 
-add_definitions(-D__WINESRC__)
 spec2def(ntmarta.dll ntmarta.spec)
 
 list(APPEND SOURCE

--- a/dll/win32/objsel/CMakeLists.txt
+++ b/dll/win32/objsel/CMakeLists.txt
@@ -2,8 +2,6 @@
 remove_definitions(-D_WIN32_WINNT=0x502)
 add_definitions(-D_WIN32_WINNT=0x600)
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(objsel.dll objsel.spec)
 
 list(APPEND SOURCE
@@ -21,3 +19,4 @@ target_link_libraries(objsel uuid wine)
 add_importlibs(objsel ole32 advapi32 msvcrt kernel32 ntdll)
 add_pch(objsel precomp.h SOURCE)
 add_cd_file(TARGET objsel DESTINATION reactos/system32 FOR all)
+set_wine_module(objsel)

--- a/dll/win32/odbc32/CMakeLists.txt
+++ b/dll/win32/odbc32/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(odbc32.dll odbc32.spec)
 
 list(APPEND SOURCE
@@ -13,3 +11,4 @@ set_module_type(odbc32 win32dll)
 target_link_libraries(odbc32 wine)
 add_importlibs(odbc32 advapi32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET odbc32 DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(odbc32) # CORE-5743: No ARRAY_SIZE macro

--- a/dll/win32/odbccp32/CMakeLists.txt
+++ b/dll/win32/odbccp32/CMakeLists.txt
@@ -2,8 +2,6 @@
 remove_definitions(-D_WIN32_WINNT=0x502)
 add_definitions(-D_WIN32_WINNT=0x600)
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(odbccp32.dll odbccp32.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -16,3 +14,4 @@ set_module_type(odbccp32 win32dll)
 target_link_libraries(odbccp32 uuid wine)
 add_importlibs(odbccp32 advapi32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET odbccp32 DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(odbccp32) # CORE-5743: No ARRAY_SIZE macro

--- a/dll/win32/ole32/CMakeLists.txt
+++ b/dll/win32/ole32/CMakeLists.txt
@@ -3,7 +3,6 @@ remove_definitions(-D_WIN32_WINNT=0x502)
 add_definitions(-D_WIN32_WINNT=0x600)
 
 add_definitions(
-    -D__WINESRC__
     -D_OLE32_
     -D__ROS_LONG64__
     -DCOM_NO_WINDOWS_H
@@ -11,7 +10,6 @@ add_definitions(
     -DPROXY_CLSID=CLSID_PSFactoryBuffer
     -DWINE_REGISTER_DLL)
 
-include_directories(BEFORE ${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(ole32.dll ole32.spec ADD_IMPORTLIB NO_PRIVATE_WARNINGS)
 generate_idl_iids(dcom.idl)
 add_idl_headers(ole32idl dcom.idl irot.idl)
@@ -94,3 +92,4 @@ add_importlibs(ole32 advapi32 user32 gdi32 rpcrt4 msvcrt kernel32 kernel32_vista
 add_dependencies(ole32 ole32idl)
 add_pch(ole32 precomp.h "${PCH_SKIP_SOURCE}")
 add_cd_file(TARGET ole32 DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(ole32) # CORE-5743: No ARRAY_SIZE and CONST_VTABLE

--- a/dll/win32/oleacc/CMakeLists.txt
+++ b/dll/win32/oleacc/CMakeLists.txt
@@ -1,11 +1,9 @@
 
 add_definitions(
-    -D__WINESRC__
     -DENTRY_PREFIX=OLEACC_
     -DPROXY_DELEGATION
     -DWINE_REGISTER_DLL)
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(oleacc.dll oleacc.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -43,3 +41,4 @@ target_link_libraries(oleacc uuid wine ${PSEH_LIB} oldnames)
 add_importlibs(oleacc oleaut32 ole32 user32 rpcrt4 msvcrt kernel32 ntdll)
 add_pch(oleacc precomp.h "${PCH_SKIP_SOURCE}")
 add_cd_file(TARGET oleacc DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(oleacc) # CORE-5743: No ARRAY_SIZE and CONST_VTABLE

--- a/dll/win32/oleaut32/CMakeLists.txt
+++ b/dll/win32/oleaut32/CMakeLists.txt
@@ -3,7 +3,6 @@ remove_definitions(-D_WIN32_WINNT=0x502)
 add_definitions(-D_WIN32_WINNT=0x600)
 
 add_definitions(
-    -D__WINESRC__
     -D__ROS_LONG64__
     -DCOM_NO_WINDOWS_H
     -D_OLEAUT32_
@@ -12,7 +11,6 @@ add_definitions(
     -DENTRY_PREFIX=OLEAUTPS_
     -DPROXY_CLSID=CLSID_PSFactoryBuffer)
 
-include_directories(BEFORE ${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(oleaut32.dll oleaut32.spec ADD_IMPORTLIB)
 add_rpcproxy_files(oleaut32_oaidl.idl oleaut32_ocidl.idl)
 
@@ -63,3 +61,4 @@ add_delay_importlibs(oleaut32 comctl32 urlmon windowscodecs)
 add_importlibs(oleaut32 ole32 rpcrt4 user32 gdi32 advapi32 kernel32_vista msvcrt kernel32 ntdll)
 add_pch(oleaut32 precomp.h "${PCH_SKIP_SOURCE}")
 add_cd_file(TARGET oleaut32 DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(oleaut32) # CORE-5743: No ARRAY_SIZE and CONST_VTABLE

--- a/dll/win32/olecli32/CMakeLists.txt
+++ b/dll/win32/olecli32/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
-add_definitions(-D__WINESRC__)
 spec2def(olecli32.dll olecli32.spec)
 
 list(APPEND SOURCE
@@ -13,3 +11,4 @@ set_module_type(olecli32 win32dll)
 target_link_libraries(olecli32 wine ${PSEH_LIB})
 add_importlibs(olecli32 ole32 gdi32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET olecli32 DESTINATION reactos/system32 FOR all)
+set_wine_module(olecli32)

--- a/dll/win32/oledlg/CMakeLists.txt
+++ b/dll/win32/oledlg/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(oledlg.dll oledlg.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -19,3 +17,4 @@ target_link_libraries(oledlg wine)
 add_importlibs(oledlg ole32 comdlg32 user32 advapi32 msvcrt kernel32 ntdll)
 add_pch(oledlg precomp.h SOURCE)
 add_cd_file(TARGET oledlg DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(oledlg) # CORE-5743: No ARRAY_SIZE macro

--- a/dll/win32/olepro32/CMakeLists.txt
+++ b/dll/win32/olepro32/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(olepro32.dll olepro32.spec)
 add_typelib(olepro.idl)
 
@@ -20,3 +18,4 @@ set_module_type(olepro32 win32dll)
 target_link_libraries(olepro32 wine)
 add_importlibs(olepro32 oleaut32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET olepro32 DESTINATION reactos/system32 FOR all)
+set_wine_module(olepro32)

--- a/dll/win32/olesvr32/CMakeLists.txt
+++ b/dll/win32/olesvr32/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
-add_definitions(-D__WINESRC__)
 spec2def(olesvr32.dll olesvr32.spec)
 
 list(APPEND SOURCE
@@ -13,3 +11,4 @@ set_module_type(olesvr32 win32dll)
 target_link_libraries(olesvr32 wine)
 add_importlibs(olesvr32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET olesvr32 DESTINATION reactos/system32 FOR all)
+set_wine_module(olesvr32)

--- a/dll/win32/olethk32/CMakeLists.txt
+++ b/dll/win32/olethk32/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
-add_definitions(-D__WINESRC__)
 spec2def(olethk32.dll olethk32.spec)
 
 list(APPEND SOURCE
@@ -14,3 +12,4 @@ set_module_type(olethk32 win32dll)
 target_link_libraries(olethk32 wine)
 add_importlibs(olethk32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET olethk32 DESTINATION reactos/system32 FOR all)
+set_wine_module(olethk32)

--- a/dll/win32/pdh/CMakeLists.txt
+++ b/dll/win32/pdh/CMakeLists.txt
@@ -2,8 +2,6 @@
 remove_definitions(-D_WIN32_WINNT=0x502)
 add_definitions(-D_WIN32_WINNT=0x600)
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(pdh.dll pdh.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -16,3 +14,4 @@ set_module_type(pdh win32dll)
 target_link_libraries(pdh wine)
 add_importlibs(pdh msvcrt kernel32_vista kernel32 ntdll)
 add_cd_file(TARGET pdh DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(pdh) # CORE-5743: No ARRAY_SIZE macro

--- a/dll/win32/pidgen/CMakeLists.txt
+++ b/dll/win32/pidgen/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
-add_definitions(-D__WINESRC__)
 spec2def(pidgen.dll pidgen.spec)
 
 list(APPEND SOURCE
@@ -14,3 +12,4 @@ set_module_type(pidgen win32dll)
 target_link_libraries(pidgen wine)
 add_importlibs(pidgen msvcrt kernel32 ntdll)
 add_cd_file(TARGET pidgen DESTINATION reactos/system32 FOR all)
+set_wine_module(pidgen)

--- a/dll/win32/propsys/CMakeLists.txt
+++ b/dll/win32/propsys/CMakeLists.txt
@@ -1,7 +1,6 @@
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 remove_definitions(-D_CRT_NON_CONFORMING_SWPRINTFS -D__ROS_LONG64__)
-add_definitions(-D__WINESRC__ -D_PROPSYS_)
+add_definitions(-D_PROPSYS_)
 spec2def(propsys.dll propsys.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -21,3 +20,4 @@ target_link_libraries(propsys uuid wine wine_dll_register)
 add_importlibs(propsys ole32 oleaut32 msvcrt kernel32 ntdll)
 add_pch(propsys precomp.h SOURCE)
 add_cd_file(TARGET propsys DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(propsys) # CORE-5743: No ARRAY_SIZE and CONST_VTABLE

--- a/dll/win32/pstorec/CMakeLists.txt
+++ b/dll/win32/pstorec/CMakeLists.txt
@@ -1,5 +1,4 @@
 
-add_definitions(-D__WINESRC__)
 spec2def(pstorec.dll pstorec.spec)
 
 list(APPEND SOURCE
@@ -15,3 +14,4 @@ target_link_libraries(pstorec uuid wine)
 add_importlibs(pstorec msvcrt kernel32 ntdll)
 add_dependencies(pstorec stdole2)
 add_cd_file(TARGET pstorec DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(pstorec) # CORE-5743: No CONST_VTABLE

--- a/dll/win32/qmgr/CMakeLists.txt
+++ b/dll/win32/qmgr/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 generate_idl_iids(qmgr_local.idl)
 spec2def(qmgr.dll qmgr.spec)
 
@@ -29,3 +27,4 @@ add_importlibs(qmgr winhttp ole32 advapi32 msvcrt kernel32 ntdll)
 add_pch(qmgr precomp.h SOURCE)
 add_cd_file(TARGET qmgr DESTINATION reactos/system32 FOR all)
 add_dependencies(qmgr qmgr_idlheader)
+set_wine_module_FIXME(qmgr) # CORE-5743: No ARRAY_SIZE and CONST_VTABLE

--- a/dll/win32/qmgrprxy/CMakeLists.txt
+++ b/dll/win32/qmgrprxy/CMakeLists.txt
@@ -1,9 +1,7 @@
 
 add_definitions(
-    -D__WINESRC__
     -DWINE_REGISTER_DLL)
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 generate_idl_iids(qmgrprxy.idl)
 spec2def(qmgrprxy.dll qmgrprxy.spec)
 add_rpcproxy_files(qmgrprxy.idl)
@@ -20,3 +18,4 @@ set_module_type(qmgrprxy win32dll)
 target_link_libraries(qmgrprxy ${PSEH_LIB} wine)
 add_importlibs(qmgrprxy rpcrt4 msvcrt kernel32 ntdll)
 add_cd_file(TARGET qmgrprxy DESTINATION reactos/system32 FOR all)
+set_wine_module(qmgrprxy)

--- a/dll/win32/query/CMakeLists.txt
+++ b/dll/win32/query/CMakeLists.txt
@@ -1,9 +1,7 @@
 
 add_definitions(
-    -D__WINESRC__
     -DCOM_NO_WINDOWS_H)
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(query.dll query.spec)
 
 list(APPEND SOURCE
@@ -16,3 +14,4 @@ set_module_type(query win32dll)
 target_link_libraries(query wine)
 add_importlibs(query msvcrt kernel32 ntdll)
 add_cd_file(TARGET query DESTINATION reactos/system32 FOR all)
+set_wine_module(query)

--- a/dll/win32/rasapi32/CMakeLists.txt
+++ b/dll/win32/rasapi32/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
-add_definitions(-D__WINESRC__)
 spec2def(rasapi32.dll rasapi32.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -13,3 +11,4 @@ set_module_type(rasapi32 win32dll)
 target_link_libraries(rasapi32 wine)
 add_importlibs(rasapi32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET rasapi32 DESTINATION reactos/system32 FOR all)
+set_wine_module(rasapi32)

--- a/dll/win32/regapi/CMakeLists.txt
+++ b/dll/win32/regapi/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(regapi.dll regapi.spec)
 
 list(APPEND SOURCE
@@ -13,3 +11,4 @@ set_module_type(regapi win32dll)
 target_link_libraries(regapi wine)
 add_importlibs(regapi advapi32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET regapi DESTINATION reactos/system32 FOR all)
+set_wine_module(regapi)

--- a/dll/win32/resutils/CMakeLists.txt
+++ b/dll/win32/resutils/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
-add_definitions(-D__WINESRC__)
 spec2def(resutils.dll resutils.spec)
 
 list(APPEND SOURCE
@@ -13,3 +11,4 @@ set_module_type(resutils win32dll)
 target_link_libraries(resutils wine)
 add_importlibs(resutils msvcrt kernel32 ntdll)
 add_cd_file(TARGET resutils DESTINATION reactos/system32 FOR all)
+set_wine_module(resutils)

--- a/dll/win32/riched20/CMakeLists.txt
+++ b/dll/win32/riched20/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 remove_definitions(-D_CRT_NON_CONFORMING_SWPRINTFS)
-add_definitions(-D__WINESRC__ -D__ROS_LONG64__)
+add_definitions(-D__ROS_LONG64__)
 include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(riched20.dll riched20.spec ADD_IMPORTLIB)
 
@@ -43,3 +43,4 @@ target_link_libraries(riched20 wine uuid)
 add_importlibs(riched20 ole32 oleaut32 usp10 imm32 user32 gdi32 msvcrt kernel32 ntdll)
 add_pch(riched20 precomp.h SOURCE)
 add_cd_file(TARGET riched20 DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(riched20) # CORE-5743: No ARRAY_SIZE and CONST_VTABLE

--- a/dll/win32/riched32/CMakeLists.txt
+++ b/dll/win32/riched32/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(riched32.dll riched32.spec)
 
 list(APPEND SOURCE
@@ -12,3 +10,4 @@ set_module_type(riched32 win32dll)
 target_link_libraries(riched32 wine)
 add_importlibs(riched32 riched20 user32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET riched32 DESTINATION reactos/system32 FOR all)
+set_wine_module(riched32)

--- a/dll/win32/rpcrt4/CMakeLists.txt
+++ b/dll/win32/rpcrt4/CMakeLists.txt
@@ -3,12 +3,10 @@ remove_definitions(-D_WIN32_WINNT=0x502)
 add_definitions(-D_WIN32_WINNT=0x600)
 
 add_definitions(
-    -D__WINESRC__
     -D_RPCRT4_
     -DCOM_NO_WINDOWS_H
     -DMSWMSG)
 
-include_directories(BEFORE ${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(rpcrt4.dll rpcrt4.spec ADD_IMPORTLIB)
 
 add_rpc_files(client epm.idl)
@@ -70,3 +68,4 @@ add_importlibs(rpcrt4 advapi32 advapi32_vista kernel32_vista ws2_32 msvcrt kerne
 add_dependencies(rpcrt4 ndr_types_header)
 add_pch(rpcrt4 precomp.h "${PCH_SKIP_SOURCE}")
 add_cd_file(TARGET rpcrt4 DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(rpcrt4) # CORE-5743: No ARRAY_SIZE and CONST_VTABLE

--- a/dll/win32/rsabase/CMakeLists.txt
+++ b/dll/win32/rsabase/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(rsabase.dll rsabase.spec)
 
 list(APPEND SOURCE
@@ -12,3 +10,4 @@ set_module_type(rsabase win32dll ENTRYPOINT 0 )
 target_link_libraries(rsabase wine)
 add_importlibs(rsabase rsaenh ntdll)
 add_cd_file(TARGET rsabase DESTINATION reactos/system32 FOR all)
+set_wine_module(rsabase)

--- a/dll/win32/rsaenh/CMakeLists.txt
+++ b/dll/win32/rsaenh/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(rsaenh.dll rsaenh.spec ADD_IMPORTLIB NO_PRIVATE_WARNINGS)
 
 list(APPEND SOURCE
@@ -27,3 +25,4 @@ target_link_libraries(rsaenh wine)
 add_importlibs(rsaenh msvcrt crypt32 advapi32 kernel32 ntdll)
 add_pch(rsaenh tomcrypt.h SOURCE)
 add_cd_file(TARGET rsaenh DESTINATION reactos/system32 FOR all)
+set_wine_module(rsaenh)

--- a/dll/win32/sccbase/CMakeLists.txt
+++ b/dll/win32/sccbase/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
-add_definitions(-D__WINESRC__)
 spec2def(sccbase.dll sccbase.spec)
 
 list(APPEND SOURCE
@@ -13,3 +11,4 @@ set_module_type(sccbase win32dll)
 target_link_libraries(sccbase wine)
 add_importlibs(sccbase msvcrt kernel32 ntdll)
 add_cd_file(TARGET sccbase DESTINATION reactos/system32 FOR all)
+set_wine_module(sccbase)

--- a/dll/win32/schannel/CMakeLists.txt
+++ b/dll/win32/schannel/CMakeLists.txt
@@ -1,10 +1,9 @@
 
 include_directories(
-    ${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine
     ${REACTOS_SOURCE_DIR}/sdk/include/reactos/libs/mbedtls)
 
 
-add_definitions(-D__WINESRC__ -D_WINE)
+add_definitions(-D_WINE)
 spec2def(schannel.dll schannel.spec)
 
 list(APPEND SOURCE
@@ -28,3 +27,4 @@ target_link_libraries(schannel wine)
 add_importlibs(schannel mbedtls crypt32 secur32 advapi32 msvcrt kernel32 ntdll)
 add_pch(schannel precomp.h SOURCE)
 add_cd_file(TARGET schannel DESTINATION reactos/system32 FOR all)
+set_wine_module(schannel)

--- a/dll/win32/scrrun/CMakeLists.txt
+++ b/dll/win32/scrrun/CMakeLists.txt
@@ -1,6 +1,5 @@
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
-add_definitions(-D__WINESRC__ -D__ROS_LONG64__)
+add_definitions(-D__ROS_LONG64__)
 spec2def(scrrun.dll scrrun.spec)
 add_idl_headers(scrrun_idlheader scrrun.idl)
 add_typelib(scrrun.idl)
@@ -33,3 +32,4 @@ target_link_libraries(scrrun uuid wine oldnames)
 add_importlibs(scrrun oleaut32 version advapi32 msvcrt kernel32 ntdll)
 add_pch(scrrun precomp.h "${PCH_SKIP_SOURCE}")
 add_cd_file(TARGET scrrun DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(scrrun) # CORE-5743: No ARRAY_SIZE and CONST_VTABLE

--- a/dll/win32/sensapi/CMakeLists.txt
+++ b/dll/win32/sensapi/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
-add_definitions(-D__WINESRC__)
 spec2def(sensapi.dll sensapi.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -12,3 +10,4 @@ set_module_type(sensapi win32dll)
 target_link_libraries(sensapi wine)
 add_importlibs(sensapi msvcrt kernel32 ntdll)
 add_cd_file(TARGET sensapi DESTINATION reactos/system32 FOR all)
+set_wine_module(sensapi)

--- a/dll/win32/shfolder/CMakeLists.txt
+++ b/dll/win32/shfolder/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
-add_definitions(-D__WINESRC__)
 spec2def(shfolder.dll shfolder.spec)
 
 list(APPEND SOURCE
@@ -13,3 +11,4 @@ target_link_libraries(shfolder wine)
 add_importlibs(shfolder shell32 kernel32 ntdll)
 add_dependencies(shfolder psdk)
 add_cd_file(TARGET shfolder DESTINATION reactos/system32 FOR all)
+set_wine_module(shfolder)

--- a/dll/win32/slbcsp/CMakeLists.txt
+++ b/dll/win32/slbcsp/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
-add_definitions(-D__WINESRC__)
 spec2def(slbcsp.dll slbcsp.spec)
 
 list(APPEND SOURCE
@@ -13,3 +11,4 @@ set_module_type(slbcsp win32dll)
 target_link_libraries(slbcsp wine)
 add_importlibs(slbcsp msvcrt kernel32 ntdll)
 add_cd_file(TARGET slbcsp DESTINATION reactos/system32 FOR all)
+set_wine_module(slbcsp)

--- a/dll/win32/snmpapi/CMakeLists.txt
+++ b/dll/win32/snmpapi/CMakeLists.txt
@@ -2,8 +2,6 @@
 remove_definitions(-D_WIN32_WINNT=0x502)
 add_definitions(-D_WIN32_WINNT=0x600)
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(snmpapi.dll snmpapi.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -16,3 +14,4 @@ set_module_type(snmpapi win32dll)
 target_link_libraries(snmpapi wine)
 add_importlibs(snmpapi msvcrt kernel32_vista kernel32 ntdll)
 add_cd_file(TARGET snmpapi DESTINATION reactos/system32 FOR all)
+set_wine_module(snmpapi)

--- a/dll/win32/softpub/CMakeLists.txt
+++ b/dll/win32/softpub/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(softpub.dll softpub.spec)
 
 add_library(softpub MODULE
@@ -11,3 +9,4 @@ set_module_type(softpub win32dll ENTRYPOINT 0 )
 target_link_libraries(softpub wine)
 add_importlibs(softpub wintrust)
 add_cd_file(TARGET softpub DESTINATION reactos/system32 FOR all)
+set_wine_module(softpub)

--- a/dll/win32/stdole2.tlb/CMakeLists.txt
+++ b/dll/win32/stdole2.tlb/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 add_typelib(std_ole_v2.idl)
 spec2def(stdole2.tlb stdole2.tlb.spec)
 
@@ -13,3 +11,4 @@ add_library(stdole2.tlb MODULE ${SOURCE})
 set_module_type(stdole2.tlb module)
 set_target_properties(stdole2.tlb PROPERTIES SUFFIX "")
 add_cd_file(TARGET stdole2.tlb DESTINATION reactos/system32 FOR all)
+set_wine_module(stdole2.tlb)

--- a/dll/win32/stdole32.tlb/CMakeLists.txt
+++ b/dll/win32/stdole32.tlb/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 add_typelib(std_ole_v1.idl)
 spec2def(stdole32.tlb stdole32.tlb.spec)
 
@@ -13,3 +11,4 @@ add_library(stdole32.tlb MODULE ${SOURCE})
 set_module_type(stdole32.tlb module)
 set_target_properties(stdole32.tlb PROPERTIES SUFFIX "")
 add_cd_file(TARGET stdole32.tlb DESTINATION reactos/system32 FOR all)
+set_wine_module(stdole32.tlb)

--- a/dll/win32/sti/CMakeLists.txt
+++ b/dll/win32/sti/CMakeLists.txt
@@ -1,11 +1,9 @@
 
 add_definitions(
-    -D__WINESRC__
     -DENTRY_PREFIX=STI_
     -DPROXY_DELEGATION
     -DWINE_REGISTER_DLL)
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(sti.dll sti.spec)
 add_rpcproxy_files(sti_wia.idl)
 
@@ -29,3 +27,4 @@ target_link_libraries(sti wine uuid ${PSEH_LIB})
 add_importlibs(sti ole32 oleaut32 rpcrt4 advapi32 msvcrt kernel32 ntdll)
 add_pch(sti precomp.h "${PCH_SKIP_SOURCE}")
 add_cd_file(TARGET sti DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(sti) # CORE-5743: No ARRAY_SIZE and CONST_VTABLE

--- a/dll/win32/sxs/CMakeLists.txt
+++ b/dll/win32/sxs/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
-add_definitions(-D__WINESRC__)
 spec2def(sxs.dll sxs.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -22,3 +20,4 @@ target_link_libraries(sxs wine)
 add_importlibs(sxs oleaut32 ole32 msvcrt kernel32 ntdll)
 add_pch(sxs precomp.h "${PCH_SKIP_SOURCE}")
 add_cd_file(TARGET sxs DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(sxs) # CORE-5743: No ARRAY_SIZE and CONST_VTABLE

--- a/dll/win32/tapi32/CMakeLists.txt
+++ b/dll/win32/tapi32/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
-add_definitions(-D__WINESRC__)
 spec2def(tapi32.dll tapi32.spec)
 
 list(APPEND SOURCE
@@ -20,3 +18,4 @@ target_link_libraries(tapi32 wine)
 add_importlibs(tapi32 advapi32 msvcrt kernel32 ntdll)
 add_pch(tapi32 precomp.h SOURCE)
 add_cd_file(TARGET tapi32 DESTINATION reactos/system32 FOR all)
+set_wine_module(tapi32)

--- a/dll/win32/traffic/CMakeLists.txt
+++ b/dll/win32/traffic/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
-add_definitions(-D__WINESRC__)
 spec2def(traffic.dll traffic.spec)
 
 list(APPEND SOURCE
@@ -13,3 +11,4 @@ set_module_type(traffic win32dll)
 target_link_libraries(traffic wine)
 add_importlibs(traffic msvcrt kernel32 ntdll)
 add_cd_file(TARGET traffic DESTINATION reactos/system32 FOR all)
+set_wine_module(traffic)

--- a/dll/win32/twain_32/CMakeLists.txt
+++ b/dll/win32/twain_32/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-include_directories(BEFORE ${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
-add_definitions(-D__WINESRC__)
 spec2def(twain_32.dll twain_32.spec)
 
 list(APPEND SOURCE
@@ -18,3 +16,4 @@ target_link_libraries(twain_32 wine)
 add_importlibs(twain_32 user32 msvcrt kernel32 ntdll)
 add_pch(twain_32 precomp.h SOURCE)
 add_cd_file(TARGET twain_32 DESTINATION reactos FOR all)
+set_wine_module(twain_32)

--- a/dll/win32/updspapi/CMakeLists.txt
+++ b/dll/win32/updspapi/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
-add_definitions(-D__WINESRC__)
 spec2def(updspapi.dll updspapi.spec)
 
 list(APPEND SOURCE
@@ -13,3 +11,4 @@ set_module_type(updspapi win32dll)
 target_link_libraries(updspapi wine)
 add_importlibs(updspapi setupapi msvcrt kernel32 ntdll)
 add_cd_file(TARGET updspapi DESTINATION reactos/system32 FOR all)
+set_wine_module(updspapi)

--- a/dll/win32/url/CMakeLists.txt
+++ b/dll/win32/url/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
-add_definitions(-D__WINESRC__)
 spec2def(url.dll url.spec)
 
 list(APPEND SOURCE
@@ -21,3 +19,4 @@ set_module_type(url win32dll)
 target_link_libraries(url wine)
 add_importlibs(url shell32 shlwapi msvcrt kernel32 ntdll)
 add_cd_file(TARGET url DESTINATION reactos/system32 FOR all)
+set_wine_module(url)

--- a/dll/win32/urlmon/CMakeLists.txt
+++ b/dll/win32/urlmon/CMakeLists.txt
@@ -1,13 +1,11 @@
 
 add_definitions(
-    -D__WINESRC__
     -D_URLMON_
     -DENTRY_PREFIX=URLMON_
     -DPROXY_DELEGATION
     -DWINE_REGISTER_DLL
     -DPROXY_CLSID_IS={0x79EAC9F1,0xBAF9,0x11CE,{0x8C,0x82,0x00,0xAA,0x00,0x4B,0xA9,0x0B}})
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(urlmon.dll urlmon.spec ADD_IMPORTLIB)
 add_rpcproxy_files(urlmon_urlmon.idl)
 
@@ -56,3 +54,4 @@ add_delay_importlibs(urlmon advpack)
 add_importlibs(urlmon rpcrt4 propsys ole32 oleaut32 shlwapi shell32 wininet user32 advapi32 kernel32_vista msvcrt kernel32 ntdll)
 add_pch(urlmon precomp.h "${PCH_SKIP_SOURCE}")
 add_cd_file(TARGET urlmon DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(urlmon) # CORE-5743: No ARRAY_SIZE macro

--- a/dll/win32/usp10/CMakeLists.txt
+++ b/dll/win32/usp10/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-include_directories(BEFORE ${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
-add_definitions(-D__WINESRC__)
 spec2def(usp10.dll usp10.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -28,3 +26,4 @@ target_link_libraries(usp10 wine)
 add_importlibs(usp10 advapi32 user32 gdi32 msvcrt kernel32 ntdll)
 add_pch(usp10 precomp.h SOURCE)
 add_cd_file(TARGET usp10 DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(usp10) # CORE-5743: No ARRAY_SIZE macro

--- a/dll/win32/vbscript/CMakeLists.txt
+++ b/dll/win32/vbscript/CMakeLists.txt
@@ -1,6 +1,5 @@
 
-add_definitions(-D__WINESRC__ -D__ROS_LONG64__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
+add_definitions(-D__ROS_LONG64__)
 spec2def(vbscript.dll vbscript.spec)
 
 list(APPEND SOURCE
@@ -50,3 +49,4 @@ add_importlibs(vbscript oleaut32 ole32 user32 msvcrt kernel32 ntdll)
 add_dependencies(vbscript vbscript_idlheader stdole2)
 add_pch(vbscript precomp.h "${PCH_SKIP_SOURCE}")
 add_cd_file(TARGET vbscript DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(vbscript) # CORE-5743: No ARRAY_SIZE and CONST_VTABLE

--- a/dll/win32/vssapi/CMakeLists.txt
+++ b/dll/win32/vssapi/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(BEFORE ${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(vssapi.dll vssapi.spec)
 
 list(APPEND SOURCE
@@ -17,3 +15,4 @@ set_module_type(vssapi win32dll)
 target_link_libraries(vssapi wine)
 add_importlibs(vssapi msvcrt kernel32 ntdll)
 add_cd_file(TARGET vssapi DESTINATION reactos/system32 FOR all)
+set_wine_module(vssapi)

--- a/dll/win32/wbemdisp/CMakeLists.txt
+++ b/dll/win32/wbemdisp/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(wbemdisp.dll wbemdisp.spec)
 
 list(APPEND SOURCE
@@ -32,3 +30,4 @@ add_dependencies(wbemdisp stdole2 wbemdisp_idlheader)
 add_importlibs(wbemdisp oleaut32 ole32 msvcrt kernel32 ntdll)
 add_pch(wbemdisp precomp.h "${PCH_SKIP_SOURCE}")
 add_cd_file(TARGET wbemdisp DESTINATION reactos/system32/wbem FOR all)
+set_wine_module_FIXME(wbemdisp) # CORE-5743: No ARRAY_SIZE and CONST_VTABLE

--- a/dll/win32/windowscodecs/CMakeLists.txt
+++ b/dll/win32/windowscodecs/CMakeLists.txt
@@ -1,6 +1,5 @@
 
 add_definitions(
-    -D__WINESRC__
     -DENTRY_PREFIX=WIC_
     -DPROXY_DELEGATION
     -DWINE_REGISTER_DLL)
@@ -10,7 +9,6 @@ remove_definitions(-D_CRT_NON_CONFORMING_SWPRINTFS)
 add_definitions(-D_WIN32_WINNT=0x600)
 
 include_directories(
-    BEFORE ${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine
     ${REACTOS_SOURCE_DIR}/sdk/include/reactos/libs/libjpeg
     ${REACTOS_SOURCE_DIR}/sdk/include/reactos/libs/zlib
     ${REACTOS_SOURCE_DIR}/sdk/include/reactos/libs/libpng
@@ -88,3 +86,4 @@ target_link_libraries(windowscodecs wine uuid ${PSEH_LIB} oldnames)
 add_importlibs(windowscodecs libjpeg libpng libtiff ole32 oleaut32 rpcrt4 shlwapi user32 gdi32 advapi32 advapi32_vista propsys msvcrt kernel32 ntdll)
 add_pch(windowscodecs precomp.h "${PCH_SKIP_SOURCE}")
 add_cd_file(TARGET windowscodecs DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(windowscodecs) # CORE-5743: No CONST_VTABLE

--- a/dll/win32/windowscodecsext/CMakeLists.txt
+++ b/dll/win32/windowscodecsext/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(windowscodecsext.dll windowscodecsext.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -12,3 +10,4 @@ set_module_type(windowscodecsext win32dll)
 target_link_libraries(windowscodecsext wine)
 add_importlibs(windowscodecsext ole32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET windowscodecsext DESTINATION reactos/system32 FOR all)
+set_wine_module(windowscodecsext)

--- a/dll/win32/winemp3.acm/CMakeLists.txt
+++ b/dll/win32/winemp3.acm/CMakeLists.txt
@@ -1,10 +1,8 @@
 
 add_definitions(
-    -D__WINESRC__
     -DWIN32)
 
 include_directories(
-    ${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine
     ${REACTOS_SOURCE_DIR}/sdk/include/reactos/libs/libmpg123)
 
 spec2def(winemp3.acm winemp3.acm.spec)
@@ -18,3 +16,4 @@ set_target_properties(winemp3.acm PROPERTIES SUFFIX "")
 target_link_libraries(winemp3.acm wine libmpg123 oldnames)
 add_importlibs(winemp3.acm shlwapi winmm user32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET winemp3.acm DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(winemp3.acm) # CORE-5743: No ARRAY_SIZE macro

--- a/dll/win32/winhttp/CMakeLists.txt
+++ b/dll/win32/winhttp/CMakeLists.txt
@@ -3,10 +3,8 @@ remove_definitions(-D_WIN32_WINNT=0x502)
 add_definitions(-D_WIN32_WINNT=0x600)
 
 add_definitions(
-    -D__WINESRC__
     -D_WINE)
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(winhttp.dll winhttp.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -34,3 +32,4 @@ add_importlibs(winhttp user32 advapi32 ws2_32 jsproxy kernel32_vista msvcrt kern
 add_dependencies(winhttp stdole2)
 add_pch(winhttp precomp.h SOURCE)
 add_cd_file(TARGET winhttp DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(winhttp) # CORE-5743: No ARRAY_SIZE macro

--- a/dll/win32/wininet/CMakeLists.txt
+++ b/dll/win32/wininet/CMakeLists.txt
@@ -7,7 +7,6 @@ add_definitions(
     -D_WIN32_WINNT=0x600)
 
 add_definitions(
-    -D__WINESRC__
     -D_WINE
     -D__ROS_LONG64__)
 
@@ -29,7 +28,6 @@ list(APPEND PCH_SKIP_SOURCE
     ${CMAKE_CURRENT_BINARY_DIR}/wininet_stubs.c)
 
 add_library(wininet_inflate OBJECT inflate.c)
-target_include_directories(wininet_inflate BEFORE PRIVATE ${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 add_dependencies(wininet_inflate psdk)
 
 add_library(wininet MODULE
@@ -51,3 +49,4 @@ add_delay_importlibs(wininet secur32 crypt32 cryptui iphlpapi dhcpcsvc)
 add_importlibs(wininet mpr shlwapi shell32 user32 advapi32 ws2_32 normaliz kernel32_vista msvcrt kernel32 ntdll)
 add_pch(wininet precomp.h "${PCH_SKIP_SOURCE}")
 add_cd_file(TARGET wininet DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(wininet) # CORE-5743: No ARRAY_SIZE macro

--- a/dll/win32/winscard/CMakeLists.txt
+++ b/dll/win32/winscard/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(BEFORE ${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(winscard.dll winscard.spec)
 
 list(APPEND SOURCE
@@ -19,3 +17,4 @@ target_link_libraries(winscard wine)
 add_importlibs(winscard msvcrt kernel32 ntdll)
 add_pch(winscard precomp.h SOURCE)
 add_cd_file(TARGET winscard DESTINATION reactos/system32 FOR all)
+set_wine_module(winscard)

--- a/dll/win32/wintrust/CMakeLists.txt
+++ b/dll/win32/wintrust/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(BEFORE ${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(wintrust.dll wintrust.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -30,3 +28,4 @@ add_delay_importlibs(wintrust cryptui)
 add_importlibs(wintrust imagehlp crypt32 user32 advapi32 msvcrt kernel32 ntdll)
 add_pch(wintrust precomp.h SOURCE)
 add_cd_file(TARGET wintrust DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(wintrust) # CORE-5743: No ARRAY_SIZE macro

--- a/dll/win32/wldap32/CMakeLists.txt
+++ b/dll/win32/wldap32/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(wldap32.dll wldap32.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -39,3 +37,4 @@ target_link_libraries(wldap32 wine)
 add_importlibs(wldap32 user32 msvcrt kernel32 ntdll)
 add_pch(wldap32 precomp.h "${PCH_SKIP_SOURCE}")
 add_cd_file(TARGET wldap32 DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(wldap32) # CORE-5743: No ARRAY_SIZE macro

--- a/dll/win32/wmiutils/CMakeLists.txt
+++ b/dll/win32/wmiutils/CMakeLists.txt
@@ -1,7 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(wmiutils.dll wmiutils.spec)
 
 list(APPEND SOURCE
@@ -15,3 +12,4 @@ set_module_type(wmiutils win32dll)
 target_link_libraries(wmiutils wine)
 add_importlibs(wmiutils oleaut32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET wmiutils DESTINATION reactos/system32/wbem FOR all)
+set_wine_module_FIXME(wmiutils) # CORE-5743: No CONST_VTABLE

--- a/dll/win32/wmvcore/CMakeLists.txt
+++ b/dll/win32/wmvcore/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(wmvcore.dll wmvcore.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -15,3 +13,4 @@ set_module_type(wmvcore win32dll)
 target_link_libraries(wmvcore wine)
 add_importlibs(wmvcore msvcrt kernel32 ntdll)
 add_cd_file(TARGET wmvcore DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(wmvcore) # CORE-5743: No CONST_VTABLE

--- a/dll/win32/wshom.ocx/CMakeLists.txt
+++ b/dll/win32/wshom.ocx/CMakeLists.txt
@@ -1,10 +1,7 @@
 
-add_definitions(-D__WINESRC__)
-
 remove_definitions(-D_WIN32_WINNT=0x502)
 add_definitions(-D_WIN32_WINNT=0x600)
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(wshom.ocx wshom.ocx.spec)
 add_idl_headers(wshom_idlheader wshom.idl)
 add_typelib(wshom.idl)
@@ -34,3 +31,4 @@ add_importlibs(wshom oleaut32 ole32 shell32 advapi32 advapi32_vista user32 msvcr
 add_dependencies(wshom stdole2 wshom_idlheader)
 add_pch(wshom precomp.h "${PCH_SKIP_SOURCE}")
 add_cd_file(TARGET wshom DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(wshom) # CORE-5743: No ARRAY_SIZE and CONST_VTABLE

--- a/dll/win32/wuapi/CMakeLists.txt
+++ b/dll/win32/wuapi/CMakeLists.txt
@@ -1,9 +1,7 @@
 
 add_definitions(
-    -D__WINESRC__
     -DCOM_NO_WINDOWS_H)
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(wuapi.dll wuapi.spec)
 
 list(APPEND SOURCE
@@ -30,3 +28,4 @@ add_importlibs(wuapi msvcrt kernel32 ntdll)
 add_dependencies(wuapi stdole2) # wuapi_tlb.tlb needs stdole2.tlb
 add_pch(wuapi precomp.h SOURCE)
 add_cd_file(TARGET wuapi DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(wuapi) # CORE-5743: No CONST_VTABLE

--- a/dll/win32/xinput1_1/CMakeLists.txt
+++ b/dll/win32/xinput1_1/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(xinput1_1.dll xinput1_1.spec)
 
 list(APPEND SOURCE
@@ -11,3 +9,4 @@ add_library(xinput1_1 MODULE ${SOURCE} version.rc)
 set_module_type(xinput1_1 win32dll)
 add_importlibs(xinput1_1 xinput1_3 msvcrt kernel32)
 add_cd_file(TARGET xinput1_1 DESTINATION reactos/system32 FOR all)
+set_wine_module(xinput1_1)

--- a/dll/win32/xinput1_2/CMakeLists.txt
+++ b/dll/win32/xinput1_2/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(xinput1_2.dll xinput1_2.spec)
 
 list(APPEND SOURCE
@@ -11,3 +9,4 @@ add_library(xinput1_2 MODULE ${SOURCE} version.rc)
 set_module_type(xinput1_2 win32dll)
 add_importlibs(xinput1_2 xinput1_3 msvcrt kernel32)
 add_cd_file(TARGET xinput1_2 DESTINATION reactos/system32 FOR all)
+set_wine_module(xinput1_2)

--- a/dll/win32/xinput1_3/CMakeLists.txt
+++ b/dll/win32/xinput1_3/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(xinput1_3.dll xinput1_3.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -12,3 +10,4 @@ set_module_type(xinput1_3 win32dll)
 target_link_libraries(xinput1_3 wine)
 add_importlibs(xinput1_3 msvcrt kernel32 ntdll)
 add_cd_file(TARGET xinput1_3 DESTINATION reactos/system32 FOR all)
+set_wine_module(xinput1_3)

--- a/dll/win32/xinput9_1_0/CMakeLists.txt
+++ b/dll/win32/xinput9_1_0/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(xinput9_1_0.dll xinput9_1_0.spec)
 
 list(APPEND SOURCE
@@ -11,3 +9,4 @@ add_library(xinput9_1_0 MODULE ${SOURCE} version.rc)
 set_module_type(xinput9_1_0 win32dll)
 add_importlibs(xinput9_1_0 msvcrt kernel32 xinput1_3)
 add_cd_file(TARGET xinput9_1_0 DESTINATION reactos/system32 FOR all)
+set_wine_module(xinput9_1_0)

--- a/dll/win32/xmllite/CMakeLists.txt
+++ b/dll/win32/xmllite/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(xmllite.dll xmllite.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -25,3 +23,4 @@ target_link_libraries(xmllite uuid wine oldnames)
 add_importlibs(xmllite msvcrt kernel32 ntdll)
 add_pch(xmllite precomp.h SOURCE)
 add_cd_file(TARGET xmllite DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(xmllite) # CORE-5743: No ARRAY_SIZE and CONST_VTABLE

--- a/dll/win32/xolehlp/CMakeLists.txt
+++ b/dll/win32/xolehlp/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(BEFORE ${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(xolehlp.dll xolehlp.spec)
 
 list(APPEND SOURCE
@@ -13,3 +11,4 @@ set_module_type(xolehlp win32dll)
 target_link_libraries(xolehlp adsiid uuid wine)
 add_importlibs(xolehlp msvcrt kernel32 ntdll)
 add_cd_file(TARGET xolehlp DESTINATION reactos/system32 FOR all)
+set_wine_module_FIXME(xolehlp) # CORE-5743: No ARRAY_SIZE and CONST_VTABLE

--- a/sdk/cmake/set_wine_module.cmake
+++ b/sdk/cmake/set_wine_module.cmake
@@ -1,0 +1,16 @@
+
+# FIXME: CORE-5743
+
+function(set_wine_module TARGET)
+    include_directories(BEFORE
+        ${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine
+        ${REACTOS_BINARY_DIR}/sdk/include/reactos/wine)
+endfunction()
+
+# FIXME: Replace this call with set_wine_module
+function(set_wine_module_FIXME TARGET)
+    include_directories(BEFORE
+        ${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine
+        ${REACTOS_BINARY_DIR}/sdk/include/reactos/wine)
+    target_compile_definitions(${TARGET} PRIVATE __WINESRC__)
+endfunction()

--- a/win32ss/printing/base/ntprint/CMakeLists.txt
+++ b/win32ss/printing/base/ntprint/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(ntprint.dll ntprint.spec)
 
 list(APPEND SOURCE
@@ -13,3 +11,4 @@ set_module_type(ntprint win32dll)
 target_link_libraries(ntprint wine)
 add_importlibs(ntprint winspool msvcrt kernel32 ntdll)
 add_cd_file(TARGET ntprint DESTINATION reactos/system32 FOR all)
+set_wine_module(ntprint)

--- a/win32ss/printing/base/printui/CMakeLists.txt
+++ b/win32ss/printing/base/printui/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(printui.dll printui.spec)
 
 list(APPEND SOURCE
@@ -13,3 +11,4 @@ set_module_type(printui win32dll)
 target_link_libraries(printui wine)
 add_importlibs(printui shell32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET printui DESTINATION reactos/system32 FOR all)
+set_wine_module(printui)

--- a/win32ss/printing/monitors/localmon/ui/CMakeLists.txt
+++ b/win32ss/printing/monitors/localmon/ui/CMakeLists.txt
@@ -10,4 +10,4 @@ set_module_type(localui win32dll)
 target_link_libraries(localui wine)
 add_importlibs(localui winspool user32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET localui DESTINATION reactos/system32 FOR all)
-set_wine_module(localui)
+set_wine_module_FIXME(localui) # CORE-5743: No ARRAY_SIZE macro

--- a/win32ss/printing/monitors/localmon/ui/CMakeLists.txt
+++ b/win32ss/printing/monitors/localmon/ui/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__WINESRC__)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(localui.dll localui.spec)
 
 list(APPEND SOURCE
@@ -12,3 +10,4 @@ set_module_type(localui win32dll)
 target_link_libraries(localui wine)
 add_importlibs(localui winspool user32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET localui DESTINATION reactos/system32 FOR all)
+set_wine_module(localui)


### PR DESCRIPTION
## Purpose
Re-trial of #7800. Deleting `__WINESRC__` hacks.
JIRA issue: [CORE-5743](https://jira.reactos.org/browse/CORE-5743)

## Proposed changes

- Add `sdk/cmake/set_wine_module.cmake`.
- Load `set_wine_module.cmake` at top-level `CMakeLists.txt`.
- Use `set_wine_module` cmake function and delete `__WINESRC__` as possible.
- Delete many `include_directories`.

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=101353,101363 LGTM.
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=101354,101364 LGTM.