### PR TITLE
[SDK:CMAKE] Remove unused BUILD_MP build option.

### DIFF
--- a/sdk/cmake/config.cmake
+++ b/sdk/cmake/config.cmake
@@ -92,8 +92,6 @@ else()
     set(_WINKD_ FALSE CACHE BOOL "Whether to compile with the KD protocol.")
 endif()
 
-option(BUILD_MP "Whether to build the multiprocessor versions of NTOSKRNL and HAL." ON)
-
 cmake_dependent_option(ISAPNP_ENABLE "Whether to enable the ISA PnP support." ON
                        "ARCH STREQUAL i386 AND NOT SARCH STREQUAL xbox" OFF)
 


### PR DESCRIPTION
## Purpose

It was introduced in commit 1f9c4940d (r38270), but this flag isn't used anymore in our source tree, and nowadays, we actively compile both UP and MP support.
