### PR TITLE
[MMIXER] Don't stop audio devices enumeration when one or more of them failed to initialize

### DIFF
--- a/sdk/lib/drivers/sound/mmixer/mixer.c
+++ b/sdk/lib/drivers/sound/mmixer/mixer.c
@@ -817,11 +817,8 @@ MMixerInitialize(
      /* store mixer list */
      MixerContext->MixerContext = (PVOID)MixerList;
 
-    /* start enumerating all available devices */
-    Count = 0;
-    DeviceIndex = 0;
-
-    do
+    /* enumerate all available devices */
+    for (DeviceIndex = 0; ; DeviceIndex++)
     {
         /* enumerate a device */
         Status = EnumFunction(EnumContext, DeviceIndex, &DeviceName, &hMixer, &hKey);
@@ -834,29 +831,27 @@ MMixerInitialize(
                 /* enumeration has finished */
                 break;
             }
-            else
-            {
-                DPRINT1("Failed to enumerate device %lu\n", DeviceIndex);
 
-                /* TODO cleanup */
-                return Status;
-            }
+            DPRINT1("EnumFunction() failed for device %lu, Status %x\n", DeviceIndex, Status);
+
+            /* ignore error and continue */
         }
         else
         {
             /* create a mixer data entry */
             Status = MMixerCreateMixerData(MixerContext, MixerList, DeviceIndex, DeviceName, hMixer, hKey);
             if (Status != MM_STATUS_SUCCESS)
-                break;
-        }
+                DPRINT1("MMixerCreateMixerData() failed for device %lu, Status %x\n",
+                        DeviceIndex, Status);
 
-        /* increment device index */
-        DeviceIndex++;
-    }while(TRUE);
+            /* ignore error and continue */
+        }
+    }
 
     /* now all filters have been pre-opened
      * lets enumerate the filters
      */
+    Count = 0;
     Entry = MixerList->MixerData.Flink;
     while(Entry != &MixerList->MixerData)
     {


### PR DESCRIPTION
## Purpose

Skip unsuccessfully initialized devices and continue enumeration until all of devices are enumerated.
Patch by @janderwald.
Should work better in pair with #7741.
This fixes 0 audio devices detected for some audio controllers, and hence allows to properly detect all available devices and play the sound for HD audio controllers (e. g., Realtek) with MMixer routines enabled.
Tested personally with Realtek HD Audio driver version R2.74 for Windows XP/Server 2003 in pair with hdaudbus.sys from Widnows Vista SP2. It works now with MMixer APIs enabled. :smiley: 

JIRA issue: [CORE-17285](https://jira.reactos.org/browse/CORE-17285)

## Proposed changes

- Skip invalid devices and continue enumeration till the end.
- Improve debug print by displaying the value of returned status in case some of devices failed to initialize.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: