### PR TITLE
[UXTHEME] Implement SetSystemVisualStyle

### DIFF
--- a/dll/cpl/desk/theme.c
+++ b/dll/cpl/desk/theme.c
@@ -438,6 +438,19 @@ ApplyScheme(IN COLOR_SCHEME *scheme, IN PTHEME_SELECTION pSelectedTheme)
                     StyleName,
                     (lstrlenW(StyleName) + 1) * sizeof(WCHAR));
     }
+    
+    if (pSelectedTheme->ThemeActive)
+    {
+        SHSetValueW(HKEY_CURRENT_USER, L"Control Panel\\Appearance", L"Current", REG_SZ, NULL, 0);
+        SHSetValueW(HKEY_CURRENT_USER, L"Control Panel\\Appearance", L"NewCurrent", REG_SZ, NULL, 0);
+    }
+    else if (pSelectedTheme->Color)
+    {
+        PCWSTR ClassicSchemeName = pSelectedTheme->Color->DisplayName;
+        DWORD cb = (lstrlenW(ClassicSchemeName) + 1) * sizeof(WCHAR);
+        SHSetValueW(HKEY_CURRENT_USER, L"Control Panel\\Appearance", L"Current", REG_SZ, ClassicSchemeName, cb); // 95+
+        SHSetValueW(HKEY_CURRENT_USER, L"Control Panel\\Appearance", L"NewCurrent", REG_SZ, ClassicSchemeName, cb); // XP+
+    }
 }
 
 static THEME*

--- a/dll/win32/uxtheme/system.c
+++ b/dll/win32/uxtheme/system.c
@@ -545,12 +545,21 @@ static HRESULT UXTHEME_ApplyTheme(PTHEME_FILE tf)
 		(lstrlenW(tf->pszSelectedSize)+1)*sizeof(WCHAR));
             RegSetValueExW(hKey, szDllName, 0, REG_SZ, (const BYTE*)tf->szThemeFile, 
 		(lstrlenW(tf->szThemeFile)+1)*sizeof(WCHAR));
+#ifdef __REACTOS__
+        {
+            WCHAR buf[100];
+            UINT cch = wsprintfW(buf, L"%u", GetUserDefaultUILanguage());
+            RegSetValueExW(hKey, L"LastUserLangID", 0, REG_SZ, (const BYTE*)buf, ++cch * sizeof(WCHAR));
+        }
+#endif
         }
         else {
             RegDeleteValueW(hKey, szColorName);
             RegDeleteValueW(hKey, szSizeName);
             RegDeleteValueW(hKey, szDllName);
-
+#ifdef __REACTOS__
+            RegDeleteValueW(hKey, L"LastUserLangID");
+#endif
         }
         RegCloseKey(hKey);
     }
@@ -1153,31 +1162,64 @@ HRESULT WINAPI CloseThemeFile(HTHEMEFILE hThemeFile)
  *
  * PARAMS
  *     hThemeFile           Handle to theme file
- *     unknown              See notes
+ *     Flags                Unknown flag bits
  *     hWnd                 Window requesting the theme change
  *
  * RETURNS
  *     Success: S_OK
  *     Failure: HRESULT error-code
- *
- * NOTES
- * I'm not sure what the second parameter is (the datatype is likely wrong), other then this:
- * Under XP if I pass
- * char b[] = "";
- *   the theme is applied with the screen redrawing really badly (flickers)
- * char b[] = "\0"; where \0 can be one or more of any character, makes no difference
- *   the theme is applied smoothly (screen does not flicker)
- * char *b = "\0" or NULL; where \0 can be zero or more of any character, makes no difference
- *   the function fails returning invalid parameter... very strange
  */
+#ifdef __REACTOS__
+HRESULT WINAPI ApplyTheme(HTHEMEFILE hThemeFile, UINT Flags, HWND hWnd)
+{
+    HRESULT hr;
+    TRACE("(%p,%#x,%p)\n", hThemeFile, Flags, hWnd);
+#else
 HRESULT WINAPI ApplyTheme(HTHEMEFILE hThemeFile, char *unknown, HWND hWnd)
 {
     HRESULT hr;
     TRACE("(%p,%s,%p)\n", hThemeFile, unknown, hWnd);
+#endif
     hr = UXTHEME_ApplyTheme(hThemeFile);
     UXTHEME_broadcast_theme_changed (NULL, (g_ActiveThemeFile != NULL));
     return hr;
 }
+
+#ifdef __REACTOS__
+/**********************************************************************
+ *      SetSystemVisualStyle                              (UXTHEME.65)
+*/
+HRESULT WINAPI SetSystemVisualStyle(PCWSTR pszStyleFile, PCWSTR pszColor, PCWSTR pszSize, UINT Flags)
+{
+    HTHEMEFILE hThemeFile = NULL;
+    HRESULT hr;
+
+    if (pszStyleFile)
+    {
+        WCHAR szColor[256], szSize[256];
+        if (!pszColor || !*pszColor)
+        {
+            GetThemeDefaults(pszStyleFile, szColor, 256, NULL, 0);
+            pszColor = szColor;
+        }
+        if (!pszSize || !*pszSize)
+        {
+            GetThemeDefaults(pszStyleFile, NULL, 0, szSize, 256);
+            pszSize = szSize;
+        }
+
+        hr = OpenThemeFile(pszStyleFile, pszColor, pszSize, &hThemeFile, 0);
+        if (FAILED(hr))
+            return hr;
+    }
+    hr = ApplyTheme(hThemeFile, Flags, NULL);
+
+    if (hThemeFile)
+        CloseThemeFile(hThemeFile);
+
+    return hr;
+}
+#endif // __REACTOS__
 
 /**********************************************************************
  *      GetThemeDefaults                                   (UXTHEME.7)
@@ -1211,8 +1253,15 @@ HRESULT WINAPI GetThemeDefaults(LPCWSTR pszThemeFileName, LPWSTR pszColorName,
     hr = MSSTYLES_OpenThemeFile(pszThemeFileName, NULL, NULL, &pt);
     if(FAILED(hr)) return hr;
 
+#ifdef __REACTOS__
+    if (pszColorName)
+        lstrcpynW(pszColorName, pt->pszSelectedColor, dwColorNameLen);
+    if (pszSizeName)
+        lstrcpynW(pszSizeName, pt->pszSelectedSize, dwSizeNameLen);
+#else
     lstrcpynW(pszColorName, pt->pszSelectedColor, dwColorNameLen);
     lstrcpynW(pszSizeName, pt->pszSelectedSize, dwSizeNameLen);
+#endif
 
     MSSTYLES_CloseThemeFile(pt);
     return S_OK;

--- a/dll/win32/uxtheme/uxtheme.spec
+++ b/dll/win32/uxtheme/uxtheme.spec
@@ -62,7 +62,7 @@
 62 stub -noname ServerClearStockObjects
 63 stub -noname MarkSelection
 #64 ProcessLoadTheme_RunDLLW
-#65 SetSystemVisualStyle
+65 stdcall -noname SetSystemVisualStyle(wstr wstr wstr long)
 #66 ServiceClearStockObjects
 67 stdcall GetThemeIntList(ptr long long long ptr)
 68 stdcall GetThemeMargins(ptr ptr long long long ptr ptr)

--- a/sdk/include/reactos/uxundoc.h
+++ b/sdk/include/reactos/uxundoc.h
@@ -81,9 +81,17 @@ HRESULT WINAPI OpenThemeFile(LPCWSTR pszThemeFileName,
 
 HRESULT WINAPI CloseThemeFile(HTHEMEFILE hThemeFile);
 
+#define UXTAPPLYFLAG_LOADSYSTEMMETRICS  0x01 //stackoverflow.com/a/1036903
+#define UXTAPPLYFLAG_APPLYSYSTEMMETRICS 0x20 //stackoverflow.com/a/1036903
+
 HRESULT WINAPI ApplyTheme(HTHEMEFILE hThemeFile,
-                          char *unknown,
+                          UINT Flags,
                           HWND hWnd);
+
+HRESULT WINAPI SetSystemVisualStyle(PCWSTR pszStyleFile,
+                                    PCWSTR pszColor,
+                                    PCWSTR pszSize,
+                                    UINT Flags);
 
 HRESULT WINAPI GetThemeDefaults(LPCWSTR pszThemeFileName,
                                 LPWSTR pszColorName,


### PR DESCRIPTION
Notes:
- The registry values are not used by ROS but at least they match what Windows does now (Current/NewCurrent was set by ROS setup and then never updated again).

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: