### PR TITLE
[RAPPS] Add ExeInZip installer type to support running installers in zip files

### DIFF
--- a/base/applications/rapps/appdb.cpp
+++ b/base/applications/rapps/appdb.cpp
@@ -11,6 +11,7 @@
 #include "appdb.h"
 #include "configparser.h"
 #include "settings.h"
+#include "misc.h"
 
 
 static HKEY g_RootKeyEnum[3] = {HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE, HKEY_LOCAL_MACHINE};
@@ -32,6 +33,14 @@ ClearList(CAtlList<CAppInfo *> &list)
 CAppDB::CAppDB(const CStringW &path) : m_BasePath(path)
 {
     m_BasePath.Canonicalize();
+}
+
+CStringW
+CAppDB::GetDefaultPath()
+{
+    CStringW path;
+    GetStorageDirectory(path);
+    return path;
 }
 
 CAvailableApplicationInfo *

--- a/base/applications/rapps/appinfo.cpp
+++ b/base/applications/rapps/appinfo.cpp
@@ -380,10 +380,11 @@ CAvailableApplicationInfo::GetInstallerType() const
 {
     CStringW str;
     m_Parser->GetString(DB_INSTALLER, str);
-    if (str.CompareNoCase(DB_GENINSTSECTION) == 0)
+    if (str.CompareNoCase(DB_INSTALLER_GENERATE) == 0)
         return INSTALLER_GENERATE;
-    else
-        return INSTALLER_UNKNOWN;
+    if (str.CompareNoCase(DB_INSTALLER_EXEINZIP) == 0)
+        return INSTALLER_EXEINZIP;
+    return INSTALLER_UNKNOWN;
 }
 
 BOOL

--- a/base/applications/rapps/geninst.cpp
+++ b/base/applications/rapps/geninst.cpp
@@ -441,7 +441,7 @@ AddUninstallOperationsFromDB(LPCWSTR Name, WCHAR UnOp, CStringW PathPrefix = CSt
 static BOOL CALLBACK
 ExtractCallback(const EXTRACTCALLBACKINFO &, void *Context)
 {
-    InstallInfo &Info = *(InstallInfo *) Context;
+    InstallInfo &Info = *(InstallInfo *)Context;
     Info.Count += 1;
     return TRUE;
 }

--- a/base/applications/rapps/include/appdb.h
+++ b/base/applications/rapps/include/appdb.h
@@ -23,6 +23,9 @@ class CAppDB
   public:
     CAppDB(const CStringW &path);
 
+    static CStringW
+    GetDefaultPath();
+
     VOID
     GetApps(CAtlList<CAppInfo *> &List, AppsCategories Type) const;
     CAvailableApplicationInfo *

--- a/base/applications/rapps/include/appinfo.h
+++ b/base/applications/rapps/include/appinfo.h
@@ -83,6 +83,7 @@ enum InstallerType
 {
     INSTALLER_UNKNOWN,
     INSTALLER_GENERATE, // .zip file automatically converted to installer by rapps
+    INSTALLER_EXEINZIP,
 };
 
 #define DB_VERSION L"Version"
@@ -90,11 +91,16 @@ enum InstallerType
 #define DB_PUBLISHER L"Publisher"
 #define DB_REGNAME L"RegName"
 #define DB_INSTALLER L"Installer"
+#define DB_INSTALLER_GENERATE L"Generate"
+#define DB_INSTALLER_EXEINZIP L"ExeInZip"
 #define DB_SCOPE L"Scope" // User or Machine
 #define DB_SAVEAS L"SaveAs"
 
 #define DB_GENINSTSECTION L"Generate"
 #define GENERATE_ARPSUBKEY L"RApps" // Our uninstall data is stored here
+
+#define DB_EXEINZIPSECTION L"ExeInZip"
+#define DB_EXEINZIP_EXE L"Exe"
 
 class CAppRichEdit;
 class CConfigParser;
@@ -234,3 +240,5 @@ BOOL
 UninstallGenerated(CInstalledApplicationInfo &AppInfo, UninstallCommandFlags Flags);
 BOOL
 ExtractAndRunGeneratedInstaller(const CAvailableApplicationInfo &AppInfo, LPCWSTR Archive);
+HRESULT
+ExtractArchiveForExecution(PCWSTR pszArchive, const CStringW &PackageName, CStringW &TempDir, CStringW &App);

--- a/base/applications/rapps/include/misc.h
+++ b/base/applications/rapps/include/misc.h
@@ -16,6 +16,12 @@
 #define CurrentArchitecture L"ppc"
 #endif
 
+static inline HRESULT
+HResultFromWin32(UINT Error)
+{
+    return HRESULT_FROM_WIN32(Error);
+}
+
 static inline UINT
 ErrorFromHResult(HRESULT hr)
 {

--- a/base/applications/rapps/unattended.cpp
+++ b/base/applications/rapps/unattended.cpp
@@ -331,9 +331,7 @@ ParseCmdAndExecute(LPWSTR lpCmdLine, BOOL bIsFirstLaunch, int nCmdShow)
     if (!argv)
         return FALSE;
 
-    CStringW Directory;
-    GetStorageDirectory(Directory);
-    CAppDB db(Directory);
+    CAppDB db(CAppDB::GetDefaultPath());
 
     BOOL bAppwizMode = (argc > 1 && MatchCmdOption(argv[1], CMD_KEY_APPWIZ));
     if (!bAppwizMode)


### PR DESCRIPTION
This feature is to help streamline the installing experience. It will extract the downloaded .zip file to a subfolder in %temp% and execute the the installer. After the installer has completed, the temporary directory is deleted.

For a package like Hxd, simply adding `Installer = ExeInZip` to the main section is enough because Rapps will default to the first .exe it finds in the root of the extracted zip. For .zip files with a folder structure or multiple .exe files, the file to execute needs to be specified.

For the Royale theme (PR waiting), it would look something like this:

```
[Section]
Name = Royale
...
Installer = ExeInZip

[ExeInZip]
Exe = Royale Theme for Win XP (2)\Royale Theme for Win XP.exe
```


Notes:
 - WinGet calls this simply `zip` installer type but they have the concept of `NestedInstallerType ` which we don't.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: