### PR TITLE
[KMTESTS:HAL] Add a test for string I/O intrinsic functions

### DIFF
--- a/modules/rostests/kmtests/CMakeLists.txt
+++ b/modules/rostests/kmtests/CMakeLists.txt
@@ -44,6 +44,7 @@ list(APPEND KMTEST_DRV_SOURCE
     kmtest_drv/kmtest_drv.c
     kmtest_drv/structs.c
     kmtest_drv/testlist.c
+    kmtest_drv/vm_detect.c
 
     example/Example.c
     example/KernelType.c
@@ -118,6 +119,13 @@ list(APPEND KMTEST_DRV_SOURCE
     ${COMMON_SOURCE}
 
     kmtest_drv/kmtest_drv.rc)
+
+if(ARCH STREQUAL "i386" OR ARCH STREQUAL "amd64")
+    add_asm_files(KMTEST_DRV_ASM
+        kmtest_drv/vm_detect.S)
+    list(APPEND KMTEST_DRV_SOURCE
+        ${KMTEST_DRV_ASM})
+endif()
 
 add_library(kmtest_drv MODULE ${KMTEST_DRV_SOURCE})
 set_module_type(kmtest_drv kernelmodedriver)

--- a/modules/rostests/kmtests/CMakeLists.txt
+++ b/modules/rostests/kmtests/CMakeLists.txt
@@ -124,7 +124,8 @@ if(ARCH STREQUAL "i386" OR ARCH STREQUAL "amd64")
     add_asm_files(KMTEST_DRV_ASM
         kmtest_drv/vm_detect.S)
     list(APPEND KMTEST_DRV_SOURCE
-        ${KMTEST_DRV_ASM})
+        ${KMTEST_DRV_ASM}
+        hal/HalPortIo.c)
 endif()
 
 add_library(kmtest_drv MODULE ${KMTEST_DRV_SOURCE})

--- a/modules/rostests/kmtests/hal/HalPortIo.c
+++ b/modules/rostests/kmtests/hal/HalPortIo.c
@@ -1,0 +1,145 @@
+/*
+ * PROJECT:     ReactOS Kernel-Mode Tests
+ * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
+ * PURPOSE:     Tests for string I/O intrinsic functions
+ * COPYRIGHT:   Copyright 2025 Dmitry Borisov <di.sean@protonmail.com>
+ */
+
+/* INCLUDES *******************************************************************/
+
+#include <kmt_test.h>
+
+#define NDEBUG
+#include <debug.h>
+
+/* GLOBALS ********************************************************************/
+
+/* Compile with the highest optimization level to trigger a bug (See CORE-20078) */
+#ifdef _MSC_VER
+#pragma optimize("gst", on)
+#pragma auto_inline(on)
+#else
+#pragma GCC optimize("O3")
+#endif
+
+/* Used to isolate the effects of intrinsics from each other */
+typedef struct _TEST_CONTEXT
+{
+    PVOID OldBuffer;
+    UCHAR Pad[78];
+    USHORT Port;
+    ULONG Size;
+    PVOID Buffer;
+} TEST_CONTEXT, *PTEST_CONTEXT;
+
+/* TEST FUNCTIONS *************************************************************/
+
+static
+/*
+ * Isolate the effects of intrinsics from each other
+ * and hide the TEST_CONTEXT initialization from the optimizer.
+ */
+DECLSPEC_NOINLINE
+VOID
+TestWriteStringUshort(
+    _In_ PTEST_CONTEXT Context)
+{
+    __outwordstring(Context->Port, Context->Buffer, Context->Size / sizeof(USHORT));
+
+    /*
+     * The 'rep outsw' instruction increments or decrements the address in ESI by Size * 2.
+     * Test for CORE-20078: the ESI value should be preserved across calls.
+     */
+    ok_eq_pointer(Context->Buffer, Context->OldBuffer);
+}
+
+static
+DECLSPEC_NOINLINE
+VOID
+TestWriteStringUlong(
+    _In_ PTEST_CONTEXT Context)
+{
+    __outdwordstring(Context->Port, Context->Buffer, Context->Size / sizeof(ULONG));
+
+    ok_eq_pointer(Context->Buffer, Context->OldBuffer);
+}
+
+static
+DECLSPEC_NOINLINE
+VOID
+TestWriteStringUchar(
+    _In_ PTEST_CONTEXT Context)
+{
+    __inbytestring(Context->Port, Context->Buffer, Context->Size);
+
+    ok_eq_pointer(Context->Buffer, Context->OldBuffer);
+}
+
+static
+DECLSPEC_NOINLINE
+VOID
+TestReadStringUshort(
+    _In_ PTEST_CONTEXT Context)
+{
+    __inwordstring(Context->Port, Context->Buffer, Context->Size / sizeof(USHORT));
+
+    ok_eq_pointer(Context->Buffer, Context->OldBuffer);
+}
+
+static
+DECLSPEC_NOINLINE
+VOID
+TestReadStringUlong(
+    _In_ PTEST_CONTEXT Context)
+{
+    __outdwordstring(Context->Port, Context->Buffer, Context->Size / sizeof(ULONG));
+
+    ok_eq_pointer(Context->Buffer, Context->OldBuffer);
+}
+
+static
+DECLSPEC_NOINLINE
+VOID
+TestReadStringUchar(
+    _In_ PTEST_CONTEXT Context)
+{
+    __inbytestring(Context->Port, Context->Buffer, Context->Size);
+
+    ok_eq_pointer(Context->Buffer, Context->OldBuffer);
+}
+
+static
+VOID
+TestStringIo(VOID)
+{
+    TEST_CONTEXT Context;
+    UCHAR Buffer[20];
+
+    /* End of the x86 I/O range */
+    Context.Port = 0xFFFF - sizeof(ULONG);
+
+    Context.Buffer = Buffer;
+    Context.OldBuffer = Buffer;
+    Context.Size = sizeof(Buffer);
+
+    TestReadStringUchar(&Context);
+    TestReadStringUshort(&Context);
+    TestReadStringUlong(&Context);
+
+    /*
+     * Check whether the driver is running inside a virtual machine
+     * as it's not safe to write to I/O ports
+     * without having the port resources assigned.
+     */
+    if (!skip(KmtIsVirtualMachine, "Please run those tests in a supported virtual machine\n"))
+    {
+        TestWriteStringUchar(&Context);
+        TestWriteStringUshort(&Context);
+        TestWriteStringUlong(&Context);
+    }
+}
+
+START_TEST(HalPortIo)
+{
+    TestStringIo();
+}

--- a/modules/rostests/kmtests/include/kmt_test.h
+++ b/modules/rostests/kmtests/include/kmt_test.h
@@ -156,6 +156,7 @@ typedef struct
 
 extern BOOLEAN KmtIsCheckedBuild;
 extern BOOLEAN KmtIsMultiProcessorBuild;
+extern BOOLEAN KmtIsVirtualMachine;
 extern PCSTR KmtMajorFunctionNames[];
 extern PDRIVER_OBJECT KmtDriverObject;
 

--- a/modules/rostests/kmtests/include/kmt_test_kernel.h
+++ b/modules/rostests/kmtests/include/kmt_test_kernel.h
@@ -14,6 +14,7 @@
 
 BOOLEAN KmtIsCheckedBuild;
 BOOLEAN KmtIsMultiProcessorBuild;
+BOOLEAN KmtIsVirtualMachine;
 PCSTR KmtMajorFunctionNames[] =
 {
     "Create",

--- a/modules/rostests/kmtests/kmtest_drv/kmtest_drv.c
+++ b/modules/rostests/kmtests/kmtest_drv/kmtest_drv.c
@@ -36,6 +36,10 @@ typedef struct _KMT_USER_WORK_LIST
     KEVENT NewWorkEvent;
 } KMT_USER_WORK_LIST, *PKMT_USER_WORK_LIST;
 
+extern
+BOOLEAN
+KmtDetectVirtualMachine(VOID);
+
 /* Prototypes */
 DRIVER_INITIALIZE DriverEntry;
 static DRIVER_UNLOAD DriverUnload;
@@ -88,6 +92,7 @@ DriverEntry(
     Prcb = KeGetCurrentPrcb();
     KmtIsCheckedBuild = (Prcb->BuildType & PRCB_BUILD_DEBUG) != 0;
     KmtIsMultiProcessorBuild = (Prcb->BuildType & PRCB_BUILD_UNIPROCESSOR) == 0;
+    KmtIsVirtualMachine = KmtDetectVirtualMachine();
     KmtDriverObject = DriverObject;
 
     RtlInitUnicodeString(&DeviceName, KMTEST_DEVICE_DRIVER_PATH);

--- a/modules/rostests/kmtests/kmtest_drv/testlist.c
+++ b/modules/rostests/kmtests/kmtest_drv/testlist.c
@@ -26,6 +26,9 @@ KMT_TESTFUNC Test_FsRtlLegal;
 KMT_TESTFUNC Test_FsRtlMcb;
 KMT_TESTFUNC Test_FsRtlRemoveDotsFromPath;
 KMT_TESTFUNC Test_FsRtlTunnel;
+#if defined(_M_IX86) || defined(_M_AMD64)
+KMT_TESTFUNC Test_HalPortIo;
+#endif
 KMT_TESTFUNC Test_HalSystemInfo;
 KMT_TESTFUNC Test_IoCreateFile;
 KMT_TESTFUNC Test_IoDeviceInterface;
@@ -110,6 +113,9 @@ const KMT_TEST TestList[] =
     { "FsRtlMcb",                           Test_FsRtlMcb },
     { "FsRtlRemoveDotsFromPath",            Test_FsRtlRemoveDotsFromPath },
     { "FsRtlTunnel",                        Test_FsRtlTunnel },
+#if defined(_M_IX86) || defined(_M_AMD64)
+    { "HalPortIo",                          Test_HalPortIo },
+#endif
     { "HalSystemInfo",                      Test_HalSystemInfo },
     { "IoCreateFile",                       Test_IoCreateFile },
     { "IoDeviceInterface",                  Test_IoDeviceInterface },

--- a/modules/rostests/kmtests/kmtest_drv/vm_detect.S
+++ b/modules/rostests/kmtests/kmtest_drv/vm_detect.S
@@ -1,0 +1,53 @@
+/*
+ * PROJECT:     ReactOS Kernel-Mode Tests
+ * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
+ * PURPOSE:     ASM helper functions for VM detection
+ * COPYRIGHT:   Copyright 2025 Dmitry Borisov <di.sean@protonmail.com>
+ */
+
+#include <asm.inc>
+
+#define VMWARE_SIGNATURE    HEX(564D5868) // 'VMXh'
+#define VMWARE_PORT         HEX(5658) // 'VX'
+
+.code
+
+/*
+ * BOOLEAN
+ * VmIsVMware(VOID);
+ */
+#ifdef _M_IX86
+PUBLIC _VmIsVMware
+_VmIsVMware:
+    push ebx
+    push ecx
+    push edx
+#else
+PUBLIC VmIsVMware
+VmIsVMware:
+    push rbx
+    push rcx
+    push rdx
+#endif
+
+    mov eax, VMWARE_SIGNATURE
+    mov ebx, 0
+    mov ecx, 10
+    mov edx, VMWARE_PORT
+    in eax, dx
+    cmp ebx, VMWARE_SIGNATURE
+    sete al
+
+#ifdef _M_IX86
+    pop edx
+    pop ecx
+    pop ebx
+#else
+    pop rdx
+    pop rcx
+    pop rbx
+#endif
+
+    ret
+
+END

--- a/modules/rostests/kmtests/kmtest_drv/vm_detect.c
+++ b/modules/rostests/kmtests/kmtest_drv/vm_detect.c
@@ -1,0 +1,61 @@
+/*
+ * PROJECT:     ReactOS Kernel-Mode Tests
+ * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
+ * PURPOSE:     VM detection code
+ * COPYRIGHT:   Copyright 2025 Dmitry Borisov <di.sean@protonmail.com>
+ */
+
+/* INCLUDES *******************************************************************/
+
+#include <kmt_test.h>
+
+/* FUNCTIONS ******************************************************************/
+
+#if defined(_M_IX86) || defined(_M_AMD64)
+extern BOOLEAN VmIsVMware(VOID);
+
+static
+BOOLEAN
+VmIsHypervisorPresent(VOID)
+{
+    INT CpuInfo[4];
+
+    __cpuid(CpuInfo, 1);
+
+    return !!(CpuInfo[2] & 0x80000000);
+}
+
+static
+BOOLEAN
+VmIsVbox(VOID)
+{
+    ULONG PciId, BytesRead;
+    PCI_SLOT_NUMBER Slot;
+
+    Slot.u.AsULONG = 0;
+    Slot.u.bits.DeviceNumber = 4;
+    Slot.u.bits.FunctionNumber = 0;
+
+    BytesRead = HalGetBusDataByOffset(PCIConfiguration,
+                                      0,
+                                      Slot.u.AsULONG,
+                                      &PciId,
+                                      FIELD_OFFSET(PCI_COMMON_HEADER, VendorID),
+                                      sizeof(PciId));
+    return (BytesRead == sizeof(PciId)) && (PciId == 0xCAFE80EE);
+}
+#endif // defined(_M_IX86) || defined(_M_AMD64)
+
+/*
+ * NOTE: We make no attempt to support every software in existence.
+ * Only VMs used by Testman are checked.
+ */
+BOOLEAN
+KmtDetectVirtualMachine(VOID)
+{
+#if defined(_M_IX86) || defined(_M_AMD64)
+    return VmIsHypervisorPresent() || VmIsVbox() || VmIsVMware();
+#else
+    return FALSE;
+#endif
+}


### PR DESCRIPTION

## Purpose

JIRA issue: [CORE-20078](https://jira.reactos.org/browse/CORE-20078)

## TODO

- [x] Test VMware detection

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: