### PR TITLE
[COMCTL32] ImageList_LoadImageW with CLR_NONE should not use a mask

### DIFF
--- a/dll/win32/comctl32/imagelist.c
+++ b/dll/win32/comctl32/imagelist.c
@@ -2263,7 +2263,20 @@ ImageList_LoadImageW (HINSTANCE hi, LPCWSTR lpbmp, INT cx, INT cGrow,
             DeleteObject (handle);
             return NULL;
         }
+#ifdef __REACTOS__
+        if (clrMask == CLR_NONE)
+            nImageCount = ImageList_Add(himl, handle, NULL);
+        else
+            nImageCount = ImageList_AddMasked(himl, handle, clrMask);
+        
+        if (nImageCount < 0)
+        {
+            ImageList_Destroy(himl);
+            himl = NULL;
+        }
+#else
         ImageList_AddMasked (himl, handle, clrMask);
+#endif
     }
     else if ((uType == IMAGE_ICON) || (uType == IMAGE_CURSOR)) {
         ICONINFO ii;


### PR DESCRIPTION
![TweakUI](https://github.com/user-attachments/assets/b59b7c75-8156-459c-b084-5187bd85770a)

[CORE-16146](https://jira.reactos.org/browse/CORE-16146)

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: