### PR TITLE
[RICHED20] Fix thiscall functions with MSVC builds

### DIFF
--- a/dll/win32/riched20/CMakeLists.txt
+++ b/dll/win32/riched20/CMakeLists.txt
@@ -36,6 +36,11 @@ add_library(riched20 MODULE
     version.rc
     ${CMAKE_CURRENT_BINARY_DIR}/riched20.def)
 
+if(MSVC AND ARCH STREQUAL "i386")
+    # MSVC doesn't support __thiscall in C code
+    target_compile_definitions(riched20 PRIVATE __ASM_USE_THISCALL_WRAPPER)
+endif()
+
 add_typelib(riched_tom.idl)
 add_dependencies(riched20 stdole2)
 set_module_type(riched20 win32dll)

--- a/dll/win32/riched20/riched20.h
+++ b/dll/win32/riched20/riched20.h
@@ -1,0 +1,185 @@
+/*
+ * RichEdit - functions and interfaces around CreateTextServices for txtsrv.c
+ *
+ * Copyright 2005, 2006, Maarten Lankhorst
+ *
+ * RichEdit - ITextHost implementation for windowed richedit controls for txthost.c
+ *
+ * Copyright 2009 by Dylan Smith
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+
+/* Forward definitions from txtsrv.c to make MSVC compile in ReactOS. */
+
+DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_TxSendMessage( ITextServices *iface, UINT msg, WPARAM wparam,
+                                                            LPARAM lparam, LRESULT *result );
+
+DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_TxDraw( ITextServices *iface, DWORD aspect, LONG index, void *aspect_info,
+                                                     DVTARGETDEVICE *td, HDC draw, HDC target,
+                                                     const RECTL *bounds, const RECTL *mf_bounds, RECT *update,
+                                                     BOOL (CALLBACK *continue_fn)(DWORD), DWORD continue_param,
+                                                     LONG view_id );
+
+DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_TxGetHScroll( ITextServices *iface, LONG *min_pos, LONG *max_pos, LONG *pos,
+                                                           LONG *page, BOOL *enabled );
+
+DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_TxGetVScroll( ITextServices *iface, LONG *min_pos, LONG *max_pos, LONG *pos,
+                                                           LONG *page, BOOL *enabled );
+
+DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_OnTxSetCursor( ITextServices *iface, DWORD aspect, LONG index,
+                                                            void *aspect_info, DVTARGETDEVICE *td, HDC draw,
+                                                            HDC target, const RECT *client, INT x, INT y );
+
+DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_TxQueryHitPoint(ITextServices *iface, DWORD dwDrawAspect, LONG lindex,
+                                                             void *pvAspect, DVTARGETDEVICE *ptd, HDC hdcDraw,
+                                                             HDC hicTargetDev, LPCRECT lprcClient, INT x, INT y,
+                                                             DWORD *pHitResult);
+
+DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_OnTxInPlaceActivate( ITextServices *iface, const RECT *client );
+
+DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_OnTxInPlaceDeactivate(ITextServices *iface);
+
+DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_OnTxUIActivate(ITextServices *iface);
+
+DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_OnTxUIDeactivate(ITextServices *iface);
+
+DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_TxGetText( ITextServices *iface, BSTR *text );
+
+DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_TxSetText( ITextServices *iface, const WCHAR *text );
+
+DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_TxGetCurTargetX(ITextServices *iface, LONG *x);
+
+DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_TxGetBaseLinePos(ITextServices *iface, LONG *x);
+
+DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_TxGetNaturalSize( ITextServices *iface, DWORD aspect, HDC draw,
+                                                               HDC target, DVTARGETDEVICE *td, DWORD mode,
+                                                               const SIZEL *extent, LONG *width, LONG *height );
+
+DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_TxGetDropTarget(ITextServices *iface, IDropTarget **ppDropTarget);
+
+DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_OnTxPropertyBitsChange( ITextServices *iface, DWORD mask, DWORD bits );
+
+DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_TxGetCachedSize(ITextServices *iface, DWORD *pdwWidth, DWORD *pdwHeight);
+
+
+/* Forward definitions from txthost.c to make MSVC compile in ReactOS. */
+
+
+DECLSPEC_HIDDEN HDC __thiscall ITextHostImpl_TxGetDC( ITextHost2 *iface );
+
+DECLSPEC_HIDDEN INT __thiscall ITextHostImpl_TxReleaseDC( ITextHost2 *iface, HDC hdc );
+
+DECLSPEC_HIDDEN BOOL __thiscall ITextHostImpl_TxShowScrollBar( ITextHost2 *iface, INT bar, BOOL show );
+
+DECLSPEC_HIDDEN BOOL __thiscall ITextHostImpl_TxEnableScrollBar( ITextHost2 *iface, INT bar, INT arrows );
+
+DECLSPEC_HIDDEN BOOL __thiscall ITextHostImpl_TxSetScrollRange( ITextHost2 *iface, INT bar, LONG min_pos, INT max_pos, BOOL redraw );
+
+DECLSPEC_HIDDEN BOOL __thiscall ITextHostImpl_TxSetScrollPos( ITextHost2 *iface, INT bar, INT pos, BOOL redraw );
+
+DECLSPEC_HIDDEN void __thiscall ITextHostImpl_TxInvalidateRect( ITextHost2 *iface, const RECT *rect, BOOL mode );
+
+DECLSPEC_HIDDEN void __thiscall ITextHostImpl_TxViewChange( ITextHost2 *iface, BOOL update );
+
+DECLSPEC_HIDDEN BOOL __thiscall ITextHostImpl_TxCreateCaret( ITextHost2 *iface, HBITMAP bitmap, INT width, INT height );
+
+DECLSPEC_HIDDEN BOOL __thiscall ITextHostImpl_TxShowCaret( ITextHost2 *iface, BOOL show );
+
+DECLSPEC_HIDDEN BOOL __thiscall ITextHostImpl_TxSetCaretPos( ITextHost2 *iface, INT x, INT y );
+
+DECLSPEC_HIDDEN BOOL __thiscall ITextHostImpl_TxSetTimer( ITextHost2 *iface, UINT id, UINT timeout );
+
+DECLSPEC_HIDDEN void __thiscall ITextHostImpl_TxKillTimer( ITextHost2 *iface, UINT id );
+
+DECLSPEC_HIDDEN void __thiscall ITextHostImpl_TxScrollWindowEx( ITextHost2 *iface, INT dx, INT dy, const RECT *scroll,
+                                                                const RECT *clip, HRGN update_rgn, RECT *update_rect,
+                                                                UINT flags );
+
+DECLSPEC_HIDDEN void __thiscall ITextHostImpl_TxSetCapture( ITextHost2 *iface, BOOL capture );
+
+DECLSPEC_HIDDEN void __thiscall ITextHostImpl_TxSetFocus( ITextHost2 *iface );
+
+DECLSPEC_HIDDEN void __thiscall ITextHostImpl_TxSetCursor( ITextHost2 *iface, HCURSOR cursor, BOOL text );
+
+DECLSPEC_HIDDEN BOOL __thiscall ITextHostImpl_TxScreenToClient( ITextHost2 *iface, POINT *pt );
+
+DECLSPEC_HIDDEN BOOL __thiscall ITextHostImpl_TxClientToScreen( ITextHost2 *iface, POINT *pt );
+
+DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxActivate( ITextHost2 *iface, LONG *old_state );
+
+DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxDeactivate( ITextHost2 *iface, LONG new_state );
+
+DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetClientRect( ITextHost2 *iface, RECT *rect );
+
+DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetViewInset( ITextHost2 *iface, RECT *rect );
+
+DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetCharFormat( ITextHost2 *iface, const CHARFORMATW **ppCF );
+
+DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetParaFormat( ITextHost2 *iface, const PARAFORMAT **fmt );
+
+DECLSPEC_HIDDEN COLORREF __thiscall ITextHostImpl_TxGetSysColor( ITextHost2 *iface, int index );
+
+DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetBackStyle( ITextHost2 *iface, TXTBACKSTYLE *style );
+
+DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetMaxLength( ITextHost2 *iface, DWORD *length );
+
+DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetScrollBars( ITextHost2 *iface, DWORD *scrollbars );
+
+DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetPasswordChar( ITextHost2 *iface, WCHAR *c );
+
+DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetAcceleratorPos( ITextHost2 *iface, LONG *pos );
+
+DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetExtent( ITextHost2 *iface, SIZEL *extent );
+
+DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_OnTxCharFormatChange( ITextHost2 *iface, const CHARFORMATW *pcf );
+
+DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_OnTxParaFormatChange( ITextHost2 *iface, const PARAFORMAT *ppf );
+
+DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetPropertyBits( ITextHost2 *iface, DWORD mask, DWORD *bits );
+
+DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxNotify( ITextHost2 *iface, DWORD iNotify, void *pv );
+
+DECLSPEC_HIDDEN HIMC __thiscall ITextHostImpl_TxImmGetContext( ITextHost2 *iface );
+
+DECLSPEC_HIDDEN void __thiscall ITextHostImpl_TxImmReleaseContext( ITextHost2 *iface, HIMC context );
+
+DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetSelectionBarWidth( ITextHost2 *iface, LONG *width );
+
+DECLSPEC_HIDDEN BOOL __thiscall ITextHostImpl_TxIsDoubleClickPending( ITextHost2 *iface );
+
+DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetWindow( ITextHost2 *iface, HWND *hwnd );
+
+DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxSetForegroundWindow( ITextHost2 *iface );
+
+DECLSPEC_HIDDEN HPALETTE __thiscall ITextHostImpl_TxGetPalette( ITextHost2 *iface );
+
+DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetEastAsianFlags( ITextHost2 *iface, LONG *flags );
+
+DECLSPEC_HIDDEN HCURSOR __thiscall ITextHostImpl_TxSetCursor2( ITextHost2 *iface, HCURSOR cursor, BOOL text );
+
+DECLSPEC_HIDDEN void __thiscall ITextHostImpl_TxFreeTextServicesNotification( ITextHost2 *iface );
+
+DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetEditStyle( ITextHost2 *iface, DWORD item, DWORD *data );
+
+DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetWindowStyles( ITextHost2 *iface, DWORD *style, DWORD *ex_style );
+
+DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxShowDropCaret( ITextHost2 *iface, BOOL show, HDC hdc, const RECT *rect );
+
+DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxDestroyCaret( ITextHost2 *iface );
+
+DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetHorzExtent( ITextHost2 *iface, LONG *horz_extent );
+

--- a/dll/win32/riched20/txthost.c
+++ b/dll/win32/riched20/txthost.c
@@ -29,6 +29,7 @@
 #include "editstr.h"
 #include "rtf.h"
 #include "undocuser.h"
+#include "riched20.h"
 
 WINE_DEFAULT_DEBUG_CHANNEL(richedit);
 
@@ -168,56 +169,36 @@ static ULONG WINAPI ITextHostImpl_Release( ITextHost2 *iface )
     return ref;
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN HDC __stdcall ITextHostImpl_TxGetDC( ITextHost2 *iface )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxGetDC,4)
 DECLSPEC_HIDDEN HDC __thiscall ITextHostImpl_TxGetDC( ITextHost2 *iface )
-#endif
 {
     struct host *host = impl_from_ITextHost( iface );
     return GetDC( host->window );
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN INT __stdcall ITextHostImpl_TxReleaseDC( ITextHost2 *iface, HDC hdc )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxReleaseDC,8)
 DECLSPEC_HIDDEN INT __thiscall ITextHostImpl_TxReleaseDC( ITextHost2 *iface, HDC hdc )
-#endif
 {
     struct host *host = impl_from_ITextHost( iface );
     return ReleaseDC( host->window, hdc );
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN BOOL __stdcall ITextHostImpl_TxShowScrollBar( ITextHost2 *iface, INT bar, BOOL show )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxShowScrollBar,12)
 DECLSPEC_HIDDEN BOOL __thiscall ITextHostImpl_TxShowScrollBar( ITextHost2 *iface, INT bar, BOOL show )
-#endif
 {
     struct host *host = impl_from_ITextHost( iface );
     return ShowScrollBar( host->window, bar, show );
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN BOOL __stdcall ITextHostImpl_TxEnableScrollBar( ITextHost2 *iface, INT bar, INT arrows )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxEnableScrollBar,12)
 DECLSPEC_HIDDEN BOOL __thiscall ITextHostImpl_TxEnableScrollBar( ITextHost2 *iface, INT bar, INT arrows )
-#endif
 {
     struct host *host = impl_from_ITextHost( iface );
     return EnableScrollBar( host->window, bar, arrows );
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN BOOL __stdcall ITextHostImpl_TxSetScrollRange( ITextHost2 *iface, INT bar, LONG min_pos, INT max_pos, BOOL redraw )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxSetScrollRange,20)
 DECLSPEC_HIDDEN BOOL __thiscall ITextHostImpl_TxSetScrollRange( ITextHost2 *iface, INT bar, LONG min_pos, INT max_pos, BOOL redraw )
-#endif
 {
     struct host *host = impl_from_ITextHost( iface );
     SCROLLINFO info = { .cbSize = sizeof(info), .fMask = SIF_PAGE | SIF_RANGE };
@@ -241,12 +222,8 @@ DECLSPEC_HIDDEN BOOL __thiscall ITextHostImpl_TxSetScrollRange( ITextHost2 *ifac
     return SetScrollInfo( host->window, bar, &info, redraw );
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN BOOL __stdcall ITextHostImpl_TxSetScrollPos( ITextHost2 *iface, INT bar, INT pos, BOOL redraw )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxSetScrollPos,16)
 DECLSPEC_HIDDEN BOOL __thiscall ITextHostImpl_TxSetScrollPos( ITextHost2 *iface, INT bar, INT pos, BOOL redraw )
-#endif
 {
     struct host *host = impl_from_ITextHost( iface );
     DWORD style = GetWindowLongW( host->window, GWL_STYLE );
@@ -270,89 +247,57 @@ DECLSPEC_HIDDEN BOOL __thiscall ITextHostImpl_TxSetScrollPos( ITextHost2 *iface,
     return SetScrollPos( host->window, bar, pos, redraw ) != 0;
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN void __stdcall ITextHostImpl_TxInvalidateRect( ITextHost2 *iface, const RECT *rect, BOOL mode )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxInvalidateRect,12)
 DECLSPEC_HIDDEN void __thiscall ITextHostImpl_TxInvalidateRect( ITextHost2 *iface, const RECT *rect, BOOL mode )
-#endif
 {
     struct host *host = impl_from_ITextHost( iface );
     InvalidateRect( host->window, rect, mode );
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN void __stdcall ITextHostImpl_TxViewChange( ITextHost2 *iface, BOOL update )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxViewChange,8)
 DECLSPEC_HIDDEN void __thiscall ITextHostImpl_TxViewChange( ITextHost2 *iface, BOOL update )
-#endif
 {
     struct host *host = impl_from_ITextHost( iface );
     if (update) UpdateWindow( host->window );
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN BOOL __stdcall ITextHostImpl_TxCreateCaret( ITextHost2 *iface, HBITMAP bitmap, INT width, INT height )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxCreateCaret,16)
 DECLSPEC_HIDDEN BOOL __thiscall ITextHostImpl_TxCreateCaret( ITextHost2 *iface, HBITMAP bitmap, INT width, INT height )
-#endif
 {
     struct host *host = impl_from_ITextHost( iface );
     return CreateCaret( host->window, bitmap, width, height );
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN BOOL __stdcall ITextHostImpl_TxShowCaret( ITextHost2 *iface, BOOL show )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxShowCaret,8)
 DECLSPEC_HIDDEN BOOL __thiscall ITextHostImpl_TxShowCaret( ITextHost2 *iface, BOOL show )
-#endif
 {
     struct host *host = impl_from_ITextHost( iface );
     if (show) return ShowCaret( host->window );
     else return HideCaret( host->window );
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN BOOL __stdcall ITextHostImpl_TxSetCaretPos( ITextHost2 *iface, INT x, INT y )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxSetCaretPos,12)
 DECLSPEC_HIDDEN BOOL __thiscall ITextHostImpl_TxSetCaretPos( ITextHost2 *iface, INT x, INT y )
-#endif
 {
     return SetCaretPos(x, y);
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN BOOL __stdcall ITextHostImpl_TxSetTimer( ITextHost2 *iface, UINT id, UINT timeout )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxSetTimer,12)
 DECLSPEC_HIDDEN BOOL __thiscall ITextHostImpl_TxSetTimer( ITextHost2 *iface, UINT id, UINT timeout )
-#endif
 {
     struct host *host = impl_from_ITextHost( iface );
     return SetTimer( host->window, id, timeout, NULL ) != 0;
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN void __stdcall ITextHostImpl_TxKillTimer( ITextHost2 *iface, UINT id )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxKillTimer,8)
 DECLSPEC_HIDDEN void __thiscall ITextHostImpl_TxKillTimer( ITextHost2 *iface, UINT id )
-#endif
 {
     struct host *host = impl_from_ITextHost( iface );
     KillTimer( host->window, id );
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN void __stdcall ITextHostImpl_TxScrollWindowEx( ITextHost2 *iface, INT dx, INT dy, const RECT *scroll,
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxScrollWindowEx,32)
 DECLSPEC_HIDDEN void __thiscall ITextHostImpl_TxScrollWindowEx( ITextHost2 *iface, INT dx, INT dy, const RECT *scroll,
-#endif
                                                                 const RECT *clip, HRGN update_rgn, RECT *update_rect,
                                                                 UINT flags )
 {
@@ -360,90 +305,58 @@ DECLSPEC_HIDDEN void __thiscall ITextHostImpl_TxScrollWindowEx( ITextHost2 *ifac
     ScrollWindowEx( host->window, dx, dy, scroll, clip, update_rgn, update_rect, flags );
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN void __stdcall ITextHostImpl_TxSetCapture( ITextHost2 *iface, BOOL capture )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxSetCapture,8)
 DECLSPEC_HIDDEN void __thiscall ITextHostImpl_TxSetCapture( ITextHost2 *iface, BOOL capture )
-#endif
 {
     struct host *host = impl_from_ITextHost( iface );
     if (capture) SetCapture( host->window );
     else ReleaseCapture();
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN void __stdcall ITextHostImpl_TxSetFocus( ITextHost2 *iface )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxSetFocus,4)
 DECLSPEC_HIDDEN void __thiscall ITextHostImpl_TxSetFocus( ITextHost2 *iface )
-#endif
 {
     struct host *host = impl_from_ITextHost( iface );
     SetFocus( host->window );
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN void __stdcall ITextHostImpl_TxSetCursor( ITextHost2 *iface, HCURSOR cursor, BOOL text )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxSetCursor,12)
 DECLSPEC_HIDDEN void __thiscall ITextHostImpl_TxSetCursor( ITextHost2 *iface, HCURSOR cursor, BOOL text )
-#endif
 {
     SetCursor( cursor );
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN BOOL __stdcall ITextHostImpl_TxScreenToClient( ITextHost2 *iface, POINT *pt )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxScreenToClient,8)
 DECLSPEC_HIDDEN BOOL __thiscall ITextHostImpl_TxScreenToClient( ITextHost2 *iface, POINT *pt )
-#endif
 {
     struct host *host = impl_from_ITextHost( iface );
     return ScreenToClient( host->window, pt );
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN BOOL __stdcall ITextHostImpl_TxClientToScreen( ITextHost2 *iface, POINT *pt )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxClientToScreen,8)
 DECLSPEC_HIDDEN BOOL __thiscall ITextHostImpl_TxClientToScreen( ITextHost2 *iface, POINT *pt )
-#endif
 {
     struct host *host = impl_from_ITextHost( iface );
     return ClientToScreen( host->window, pt );
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN HRESULT __stdcall ITextHostImpl_TxActivate( ITextHost2 *iface, LONG *old_state )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxActivate,8)
 DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxActivate( ITextHost2 *iface, LONG *old_state )
-#endif
 {
     struct host *host = impl_from_ITextHost( iface );
     *old_state = HandleToLong( SetActiveWindow( host->window ) );
     return *old_state ? S_OK : E_FAIL;
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN HRESULT __stdcall ITextHostImpl_TxDeactivate( ITextHost2 *iface, LONG new_state )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxDeactivate,8)
 DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxDeactivate( ITextHost2 *iface, LONG new_state )
-#endif
 {
     HWND ret = SetActiveWindow( LongToHandle( new_state ) );
     return ret ? S_OK : E_FAIL;
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN HRESULT __stdcall ITextHostImpl_TxGetClientRect( ITextHost2 *iface, RECT *rect )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxGetClientRect,8)
 DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetClientRect( ITextHost2 *iface, RECT *rect )
-#endif
 {
     struct host *host = impl_from_ITextHost( iface );
 
@@ -458,45 +371,29 @@ DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetClientRect( ITextHost2 *if
     return S_OK;
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN HRESULT __stdcall ITextHostImpl_TxGetViewInset( ITextHost2 *iface, RECT *rect )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxGetViewInset,8)
 DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetViewInset( ITextHost2 *iface, RECT *rect )
-#endif
 {
     SetRectEmpty( rect );
     return S_OK;
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN HRESULT __stdcall ITextHostImpl_TxGetCharFormat( ITextHost2 *iface, const CHARFORMATW **ppCF )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxGetCharFormat,8)
 DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetCharFormat( ITextHost2 *iface, const CHARFORMATW **ppCF )
-#endif
 {
     return E_NOTIMPL;
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN HRESULT __stdcall ITextHostImpl_TxGetParaFormat( ITextHost2 *iface, const PARAFORMAT **fmt )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxGetParaFormat,8)
 DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetParaFormat( ITextHost2 *iface, const PARAFORMAT **fmt )
-#endif
 {
     struct host *host = impl_from_ITextHost( iface );
     *fmt = (const PARAFORMAT *)&host->para_fmt;
     return S_OK;
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN COLORREF __stdcall ITextHostImpl_TxGetSysColor( ITextHost2 *iface, int index )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxGetSysColor,8)
 DECLSPEC_HIDDEN COLORREF __thiscall ITextHostImpl_TxGetSysColor( ITextHost2 *iface, int index )
-#endif
 {
     struct host *host = impl_from_ITextHost( iface );
 
@@ -504,34 +401,22 @@ DECLSPEC_HIDDEN COLORREF __thiscall ITextHostImpl_TxGetSysColor( ITextHost2 *ifa
     return GetSysColor( index );
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN HRESULT __stdcall ITextHostImpl_TxGetBackStyle( ITextHost2 *iface, TXTBACKSTYLE *style )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxGetBackStyle,8)
 DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetBackStyle( ITextHost2 *iface, TXTBACKSTYLE *style )
-#endif
 {
     *style = TXTBACK_OPAQUE;
     return S_OK;
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN HRESULT __stdcall ITextHostImpl_TxGetMaxLength( ITextHost2 *iface, DWORD *length )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxGetMaxLength,8)
 DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetMaxLength( ITextHost2 *iface, DWORD *length )
-#endif
 {
     *length = INFINITE;
     return S_OK;
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN HRESULT __stdcall ITextHostImpl_TxGetScrollBars( ITextHost2 *iface, DWORD *scrollbars )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxGetScrollBars,8)
 DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetScrollBars( ITextHost2 *iface, DWORD *scrollbars )
-#endif
 {
     struct host *host = impl_from_ITextHost( iface );
 
@@ -539,12 +424,8 @@ DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetScrollBars( ITextHost2 *if
     return S_OK;
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN HRESULT __stdcall ITextHostImpl_TxGetPasswordChar( ITextHost2 *iface, WCHAR *c )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxGetPasswordChar,8)
 DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetPasswordChar( ITextHost2 *iface, WCHAR *c )
-#endif
 {
     struct host *host = impl_from_ITextHost( iface );
 
@@ -552,53 +433,33 @@ DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetPasswordChar( ITextHost2 *
     return *c ? S_OK : S_FALSE;
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN HRESULT __stdcall ITextHostImpl_TxGetAcceleratorPos( ITextHost2 *iface, LONG *pos )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxGetAcceleratorPos,8)
 DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetAcceleratorPos( ITextHost2 *iface, LONG *pos )
-#endif
 {
     *pos = -1;
     return S_OK;
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN HRESULT __stdcall ITextHostImpl_TxGetExtent( ITextHost2 *iface, SIZEL *extent )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxGetExtent,8)
 DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetExtent( ITextHost2 *iface, SIZEL *extent )
-#endif
 {
     return E_NOTIMPL;
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN HRESULT __stdcall ITextHostImpl_OnTxCharFormatChange( ITextHost2 *iface, const CHARFORMATW *pcf )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_OnTxCharFormatChange,8)
 DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_OnTxCharFormatChange( ITextHost2 *iface, const CHARFORMATW *pcf )
-#endif
 {
     return S_OK;
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN HRESULT __stdcall ITextHostImpl_OnTxParaFormatChange( ITextHost2 *iface, const PARAFORMAT *ppf )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_OnTxParaFormatChange,8)
 DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_OnTxParaFormatChange( ITextHost2 *iface, const PARAFORMAT *ppf )
-#endif
 {
     return S_OK;
 }
 
-#ifdef _MSC_VER
-HRESULT __stdcall ITextHostImpl_TxGetPropertyBits(ITextHost2 *iface, DWORD mask, DWORD *bits )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxGetPropertyBits,12)
 DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetPropertyBits( ITextHost2 *iface, DWORD mask, DWORD *bits )
-#endif
 {
     struct host *host = impl_from_ITextHost( iface );
 
@@ -606,12 +467,8 @@ DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetPropertyBits( ITextHost2 *
     return S_OK;
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN HRESULT __stdcall ITextHostImpl_TxNotify( ITextHost2 *iface, DWORD iNotify, void *pv )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxNotify,12)
 DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxNotify( ITextHost2 *iface, DWORD iNotify, void *pv )
-#endif
 {
     struct host *host = impl_from_ITextHost( iface );
     UINT id;
@@ -667,34 +524,22 @@ DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxNotify( ITextHost2 *iface, DW
     return S_OK;
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN HIMC __stdcall ITextHostImpl_TxImmGetContext( ITextHost2 *iface )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxImmGetContext,4)
 DECLSPEC_HIDDEN HIMC __thiscall ITextHostImpl_TxImmGetContext( ITextHost2 *iface )
-#endif
 {
     struct host *host = impl_from_ITextHost( iface );
     return ImmGetContext( host->window );
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN void __stdcall ITextHostImpl_TxImmReleaseContext( ITextHost2 *iface, HIMC context )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxImmReleaseContext,8)
 DECLSPEC_HIDDEN void __thiscall ITextHostImpl_TxImmReleaseContext( ITextHost2 *iface, HIMC context )
-#endif
 {
     struct host *host = impl_from_ITextHost( iface );
     ImmReleaseContext( host->window, context );
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN HRESULT __stdcall ITextHostImpl_TxGetSelectionBarWidth( ITextHost2 *iface, LONG *width )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxGetSelectionBarWidth,8)
 DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetSelectionBarWidth( ITextHost2 *iface, LONG *width )
-#endif
 {
     struct host *host = impl_from_ITextHost( iface );
 
@@ -702,124 +547,76 @@ DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetSelectionBarWidth( ITextHo
     return S_OK;
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN BOOL __stdcall ITextHostImpl_TxIsDoubleClickPending( ITextHost2 *iface )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxIsDoubleClickPending,4)
 DECLSPEC_HIDDEN BOOL __thiscall ITextHostImpl_TxIsDoubleClickPending( ITextHost2 *iface )
-#endif
 {
     return FALSE;
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN HRESULT __stdcall ITextHostImpl_TxGetWindow( ITextHost2 *iface, HWND *hwnd )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxGetWindow,8)
 DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetWindow( ITextHost2 *iface, HWND *hwnd )
-#endif
 {
     struct host *host = impl_from_ITextHost( iface );
     *hwnd = host->window;
     return S_OK;
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN HRESULT __stdcall ITextHostImpl_TxSetForegroundWindow( ITextHost2 *iface )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxSetForegroundWindow,4)
 DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxSetForegroundWindow( ITextHost2 *iface )
-#endif
 {
     return E_NOTIMPL;
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN HPALETTE __stdcall ITextHostImpl_TxGetPalette( ITextHost2 *iface )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxGetPalette,4)
 DECLSPEC_HIDDEN HPALETTE __thiscall ITextHostImpl_TxGetPalette( ITextHost2 *iface )
-#endif
 {
     return NULL;
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN HRESULT __stdcall ITextHostImpl_TxGetEastAsianFlags( ITextHost2 *iface, LONG *flags )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxGetEastAsianFlags,8)
 DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetEastAsianFlags( ITextHost2 *iface, LONG *flags )
-#endif
 {
     return E_NOTIMPL;
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN HCURSOR __stdcall ITextHostImpl_TxSetCursor2( ITextHost2 *iface, HCURSOR cursor, BOOL text )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxSetCursor2,12)
 DECLSPEC_HIDDEN HCURSOR __thiscall ITextHostImpl_TxSetCursor2( ITextHost2 *iface, HCURSOR cursor, BOOL text )
-#endif
 {
     return NULL;
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN void __stdcall ITextHostImpl_TxFreeTextServicesNotification( ITextHost2 *iface )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxFreeTextServicesNotification,4)
 DECLSPEC_HIDDEN void __thiscall ITextHostImpl_TxFreeTextServicesNotification( ITextHost2 *iface )
-#endif
 {
     return;
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN HRESULT __stdcall ITextHostImpl_TxGetEditStyle( ITextHost2 *iface, DWORD item, DWORD *data )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxGetEditStyle,12)
 DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetEditStyle( ITextHost2 *iface, DWORD item, DWORD *data )
-#endif
 {
     return E_NOTIMPL;
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN HRESULT __stdcall ITextHostImpl_TxGetWindowStyles( ITextHost2 *iface, DWORD *style, DWORD *ex_style )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxGetWindowStyles,12)
 DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetWindowStyles( ITextHost2 *iface, DWORD *style, DWORD *ex_style )
-#endif
 {
     return E_NOTIMPL;
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN HRESULT __stdcall ITextHostImpl_TxShowDropCaret( ITextHost2 *iface, BOOL show, HDC hdc, const RECT *rect )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxShowDropCaret,16)
 DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxShowDropCaret( ITextHost2 *iface, BOOL show, HDC hdc, const RECT *rect )
-#endif
 {
     return E_NOTIMPL;
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN HRESULT __stdcall ITextHostImpl_TxDestroyCaret( ITextHost2 *iface )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxDestroyCaret,4)
 DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxDestroyCaret( ITextHost2 *iface )
-#endif
 {
     return E_NOTIMPL;
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN HRESULT __stdcall ITextHostImpl_TxGetHorzExtent( ITextHost2 *iface, LONG *horz_extent )
-#else
 DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxGetHorzExtent,8)
 DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetHorzExtent( ITextHost2 *iface, LONG *horz_extent )
-#endif
 {
     return E_NOTIMPL;
 }
@@ -968,47 +765,6 @@ static const ITextHost2Vtbl textHostVtbl =
     ITextHostImpl_QueryInterface,
     ITextHostImpl_AddRef,
     ITextHostImpl_Release,
-#ifdef _MSC_VER
-    ITextHostImpl_TxGetDC,
-    ITextHostImpl_TxReleaseDC,
-    ITextHostImpl_TxShowScrollBar,
-    ITextHostImpl_TxEnableScrollBar,
-    ITextHostImpl_TxSetScrollRange,
-    ITextHostImpl_TxSetScrollPos,
-    ITextHostImpl_TxInvalidateRect,
-    ITextHostImpl_TxViewChange,
-    ITextHostImpl_TxCreateCaret,
-    ITextHostImpl_TxShowCaret,
-    ITextHostImpl_TxSetCaretPos,
-    ITextHostImpl_TxSetTimer,
-    ITextHostImpl_TxKillTimer,
-    ITextHostImpl_TxScrollWindowEx,
-    ITextHostImpl_TxSetCapture,
-    ITextHostImpl_TxSetFocus,
-    ITextHostImpl_TxSetCursor,
-    ITextHostImpl_TxScreenToClient,
-    ITextHostImpl_TxClientToScreen,
-    ITextHostImpl_TxActivate,
-    ITextHostImpl_TxDeactivate,
-    ITextHostImpl_TxGetClientRect,
-    ITextHostImpl_TxGetViewInset,
-    ITextHostImpl_TxGetCharFormat,
-    ITextHostImpl_TxGetParaFormat,
-    ITextHostImpl_TxGetSysColor,
-    ITextHostImpl_TxGetBackStyle,
-    ITextHostImpl_TxGetMaxLength,
-    ITextHostImpl_TxGetScrollBars,
-    ITextHostImpl_TxGetPasswordChar,
-    ITextHostImpl_TxGetAcceleratorPos,
-    ITextHostImpl_TxGetExtent,
-    ITextHostImpl_OnTxCharFormatChange,
-    ITextHostImpl_OnTxParaFormatChange,
-    ITextHostImpl_TxGetPropertyBits,
-    ITextHostImpl_TxNotify,
-    ITextHostImpl_TxImmGetContext,
-    ITextHostImpl_TxImmReleaseContext,
-    ITextHostImpl_TxGetSelectionBarWidth,
-#else
     THISCALL(ITextHostImpl_TxGetDC),
     THISCALL(ITextHostImpl_TxReleaseDC),
     THISCALL(ITextHostImpl_TxShowScrollBar),
@@ -1048,23 +804,7 @@ static const ITextHost2Vtbl textHostVtbl =
     THISCALL(ITextHostImpl_TxImmGetContext),
     THISCALL(ITextHostImpl_TxImmReleaseContext),
     THISCALL(ITextHostImpl_TxGetSelectionBarWidth),
-#endif
-
 /* ITextHost2 */
-#ifdef _MSC_VER
-    ITextHostImpl_TxIsDoubleClickPending,
-    ITextHostImpl_TxGetWindow,
-    ITextHostImpl_TxSetForegroundWindow,
-    ITextHostImpl_TxGetPalette,
-    ITextHostImpl_TxGetEastAsianFlags,
-    ITextHostImpl_TxSetCursor2,
-    ITextHostImpl_TxFreeTextServicesNotification,
-    ITextHostImpl_TxGetEditStyle,
-    ITextHostImpl_TxGetWindowStyles,
-    ITextHostImpl_TxShowDropCaret,
-    ITextHostImpl_TxDestroyCaret,
-    ITextHostImpl_TxGetHorzExtent
-#else
     THISCALL(ITextHostImpl_TxIsDoubleClickPending),
     THISCALL(ITextHostImpl_TxGetWindow),
     THISCALL(ITextHostImpl_TxSetForegroundWindow),
@@ -1077,7 +817,6 @@ static const ITextHost2Vtbl textHostVtbl =
     THISCALL(ITextHostImpl_TxShowDropCaret),
     THISCALL(ITextHostImpl_TxDestroyCaret),
     THISCALL(ITextHostImpl_TxGetHorzExtent)
-#endif
 };
 
 static const char * const edit_messages[] =

--- a/dll/win32/riched20/txtsrv.c
+++ b/dll/win32/riched20/txtsrv.c
@@ -29,6 +29,7 @@
 #include "textserv.h"
 #include "wine/debug.h"
 #include "editstr.h"
+#include "riched20.h"
 
 WINE_DEFAULT_DEBUG_CHANNEL(richedit);
 
@@ -116,12 +117,8 @@ static ULONG WINAPI fnTextSrv_Release(ITextServices *iface)
     return IUnknown_Release( services->outer_unk );
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN HRESULT __stdcall fnTextSrv_TxSendMessage( ITextServices *iface, UINT msg, WPARAM wparam,
-#else
 DEFINE_THISCALL_WRAPPER(fnTextSrv_TxSendMessage,20)
 DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_TxSendMessage( ITextServices *iface, UINT msg, WPARAM wparam,
-#endif
                                                             LPARAM lparam, LRESULT *result )
 {
     struct text_services *services = impl_from_ITextServices( iface );
@@ -153,12 +150,8 @@ static HRESULT update_client_rect( struct text_services *services, const RECT *c
     return S_OK;
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN HRESULT __stdcall fnTextSrv_TxDraw( ITextServices *iface, DWORD aspect, LONG index, void *aspect_info,
-#else
 DEFINE_THISCALL_WRAPPER(fnTextSrv_TxDraw,52)
 DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_TxDraw( ITextServices *iface, DWORD aspect, LONG index, void *aspect_info,
-#endif
                                                      DVTARGETDEVICE *td, HDC draw, HDC target,
                                                      const RECTL *bounds, const RECTL *mf_bounds, RECT *update,
                                                      BOOL (CALLBACK *continue_fn)(DWORD), DWORD continue_param,
@@ -199,12 +192,8 @@ DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_TxDraw( ITextServices *iface, DWORD
     return S_OK;
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN HRESULT __stdcall fnTextSrv_TxGetHScroll( ITextServices *iface, LONG *min_pos, LONG *max_pos, LONG *pos,
-#else
 DEFINE_THISCALL_WRAPPER(fnTextSrv_TxGetHScroll,24)
 DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_TxGetHScroll( ITextServices *iface, LONG *min_pos, LONG *max_pos, LONG *pos,
-#endif
                                                            LONG *page, BOOL *enabled )
 {
     struct text_services *services = impl_from_ITextServices( iface );
@@ -217,12 +206,8 @@ DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_TxGetHScroll( ITextServices *iface,
     return S_OK;
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN HRESULT __stdcall fnTextSrv_TxGetVScroll( ITextServices *iface, LONG *min_pos, LONG *max_pos, LONG *pos,
-#else
 DEFINE_THISCALL_WRAPPER(fnTextSrv_TxGetVScroll,24)
 DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_TxGetVScroll( ITextServices *iface, LONG *min_pos, LONG *max_pos, LONG *pos,
-#endif
                                                            LONG *page, BOOL *enabled )
 {
     struct text_services *services = impl_from_ITextServices( iface );
@@ -235,12 +220,8 @@ DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_TxGetVScroll( ITextServices *iface,
     return S_OK;
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN HRESULT __stdcall fnTextSrv_OnTxSetCursor( ITextServices *iface, DWORD aspect, LONG index,
-#else
 DEFINE_THISCALL_WRAPPER(fnTextSrv_OnTxSetCursor,40)
 DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_OnTxSetCursor( ITextServices *iface, DWORD aspect, LONG index,
-#endif
                                                             void *aspect_info, DVTARGETDEVICE *td, HDC draw,
                                                             HDC target, const RECT *client, INT x, INT y )
 {
@@ -257,12 +238,8 @@ DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_OnTxSetCursor( ITextServices *iface
     return S_OK;
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN HRESULT __stdcall fnTextSrv_TxQueryHitPoint(ITextServices *iface, DWORD dwDrawAspect, LONG lindex,
-#else
 DEFINE_THISCALL_WRAPPER(fnTextSrv_TxQueryHitPoint,44)
 DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_TxQueryHitPoint(ITextServices *iface, DWORD dwDrawAspect, LONG lindex,
-#endif
                                                              void *pvAspect, DVTARGETDEVICE *ptd, HDC hdcDraw,
                                                              HDC hicTargetDev, LPCRECT lprcClient, INT x, INT y,
                                                              DWORD *pHitResult)
@@ -273,12 +250,8 @@ DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_TxQueryHitPoint(ITextServices *ifac
     return E_NOTIMPL;
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN HRESULT __stdcall fnTextSrv_OnTxInPlaceActivate( ITextServices *iface, const RECT *client )
-#else
 DEFINE_THISCALL_WRAPPER(fnTextSrv_OnTxInPlaceActivate,8)
 DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_OnTxInPlaceActivate( ITextServices *iface, const RECT *client )
-#endif
 {
     struct text_services *services = impl_from_ITextServices( iface );
     HRESULT hr;
@@ -297,12 +270,8 @@ DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_OnTxInPlaceActivate( ITextServices 
     return S_OK;
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN HRESULT __stdcall fnTextSrv_OnTxInPlaceDeactivate(ITextServices *iface)
-#else
 DEFINE_THISCALL_WRAPPER(fnTextSrv_OnTxInPlaceDeactivate,4)
 DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_OnTxInPlaceDeactivate(ITextServices *iface)
-#endif
 {
     struct text_services *services = impl_from_ITextServices( iface );
 
@@ -311,12 +280,8 @@ DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_OnTxInPlaceDeactivate(ITextServices
     return S_OK;
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN HRESULT __stdcall fnTextSrv_OnTxUIActivate(ITextServices *iface)
-#else
 DEFINE_THISCALL_WRAPPER(fnTextSrv_OnTxUIActivate,4)
 DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_OnTxUIActivate(ITextServices *iface)
-#endif
 {
     struct text_services *services = impl_from_ITextServices( iface );
 
@@ -324,12 +289,8 @@ DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_OnTxUIActivate(ITextServices *iface
     return E_NOTIMPL;
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN HRESULT __stdcall fnTextSrv_OnTxUIDeactivate(ITextServices *iface)
-#else
 DEFINE_THISCALL_WRAPPER(fnTextSrv_OnTxUIDeactivate,4)
 DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_OnTxUIDeactivate(ITextServices *iface)
-#endif
 {
     struct text_services *services = impl_from_ITextServices( iface );
 
@@ -337,12 +298,8 @@ DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_OnTxUIDeactivate(ITextServices *ifa
     return E_NOTIMPL;
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN HRESULT __stdcall fnTextSrv_TxGetText( ITextServices *iface, BSTR *text )
-#else
 DEFINE_THISCALL_WRAPPER(fnTextSrv_TxGetText,8)
 DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_TxGetText( ITextServices *iface, BSTR *text )
-#endif
 {
     struct text_services *services = impl_from_ITextServices( iface );
     int length;
@@ -364,12 +321,8 @@ DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_TxGetText( ITextServices *iface, BS
     return S_OK;
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN HRESULT __stdcall fnTextSrv_TxSetText( ITextServices *iface, const WCHAR *text )
-#else
 DEFINE_THISCALL_WRAPPER(fnTextSrv_TxSetText,8)
 DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_TxSetText( ITextServices *iface, const WCHAR *text )
-#endif
 {
     struct text_services *services = impl_from_ITextServices( iface );
     ME_Cursor cursor;
@@ -386,12 +339,8 @@ DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_TxSetText( ITextServices *iface, co
     return S_OK;
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN HRESULT __stdcall fnTextSrv_TxGetCurTargetX(ITextServices *iface, LONG *x)
-#else
 DEFINE_THISCALL_WRAPPER(fnTextSrv_TxGetCurTargetX,8)
 DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_TxGetCurTargetX(ITextServices *iface, LONG *x)
-#endif
 {
     struct text_services *services = impl_from_ITextServices( iface );
 
@@ -399,12 +348,8 @@ DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_TxGetCurTargetX(ITextServices *ifac
     return E_NOTIMPL;
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN HRESULT __stdcall fnTextSrv_TxGetBaseLinePos(ITextServices *iface, LONG *x)
-#else
 DEFINE_THISCALL_WRAPPER(fnTextSrv_TxGetBaseLinePos,8)
 DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_TxGetBaseLinePos(ITextServices *iface, LONG *x)
-#endif
 {
     struct text_services *services = impl_from_ITextServices( iface );
 
@@ -412,12 +357,8 @@ DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_TxGetBaseLinePos(ITextServices *ifa
     return E_NOTIMPL;
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN HRESULT __stdcall fnTextSrv_TxGetNaturalSize( ITextServices *iface, DWORD aspect, HDC draw,
-#else
 DEFINE_THISCALL_WRAPPER(fnTextSrv_TxGetNaturalSize,36)
 DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_TxGetNaturalSize( ITextServices *iface, DWORD aspect, HDC draw,
-#endif
                                                                HDC target, DVTARGETDEVICE *td, DWORD mode,
                                                                const SIZEL *extent, LONG *width, LONG *height )
 {
@@ -456,12 +397,8 @@ DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_TxGetNaturalSize( ITextServices *if
     return S_OK;
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN HRESULT __stdcall fnTextSrv_TxGetDropTarget(ITextServices *iface, IDropTarget **ppDropTarget)
-#else
 DEFINE_THISCALL_WRAPPER(fnTextSrv_TxGetDropTarget,8)
 DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_TxGetDropTarget(ITextServices *iface, IDropTarget **ppDropTarget)
-#endif
 {
     struct text_services *services = impl_from_ITextServices( iface );
 
@@ -469,12 +406,8 @@ DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_TxGetDropTarget(ITextServices *ifac
     return E_NOTIMPL;
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN HRESULT __stdcall fnTextSrv_OnTxPropertyBitsChange( ITextServices *iface, DWORD mask, DWORD bits )
-#else
 DEFINE_THISCALL_WRAPPER(fnTextSrv_OnTxPropertyBitsChange,12)
 DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_OnTxPropertyBitsChange( ITextServices *iface, DWORD mask, DWORD bits )
-#endif
 {
     struct text_services *services = impl_from_ITextServices( iface );
     DWORD scrollbars;
@@ -537,12 +470,8 @@ DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_OnTxPropertyBitsChange( ITextServic
     return S_OK;
 }
 
-#ifdef _MSC_VER
-DECLSPEC_HIDDEN HRESULT __stdcall fnTextSrv_TxGetCachedSize(ITextServices *iface, DWORD *pdwWidth, DWORD *pdwHeight)
-#else
 DEFINE_THISCALL_WRAPPER(fnTextSrv_TxGetCachedSize,12)
 DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_TxGetCachedSize(ITextServices *iface, DWORD *pdwWidth, DWORD *pdwHeight)
-#endif
 {
     struct text_services *services = impl_from_ITextServices( iface );
 
@@ -553,7 +482,6 @@ DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_TxGetCachedSize(ITextServices *ifac
 #ifdef __ASM_USE_THISCALL_WRAPPER
 
 #define STDCALL(func) (void *) __stdcall_ ## func
-
 #ifdef _MSC_VER
 #define DEFINE_STDCALL_WRAPPER(num,func) \
     __declspec(naked) HRESULT __stdcall_##func(void) \
@@ -599,26 +527,6 @@ const ITextServicesVtbl text_services_stdcall_vtbl =
     NULL,
     NULL,
     NULL,
-#ifdef _MSC_VER
-    ITextServices_TxSendMessage,
-    ITextServices_TxDraw,
-    ITextServices_TxGetHScroll,
-    ITextServices_TxGetVScroll,
-    ITextServices_OnTxSetCursor,
-    ITextServices_TxQueryHitPoint,
-    ITextServices_OnTxInPlaceActivate,
-    ITextServices_OnTxInPlaceDeactivate,
-    ITextServices_OnTxUIActivate,
-    ITextServices_OnTxUIDeactivate,
-    ITextServices_TxGetText,
-    ITextServices_TxSetText,
-    ITextServices_TxGetCurTargetX,
-    ITextServices_TxGetBaseLinePos,
-    ITextServices_TxGetNaturalSize,
-    ITextServices_TxGetDropTarget,
-    ITextServices_OnTxPropertyBitsChange,
-    ITextServices_TxGetCachedSize,
-#else /* _MSC_VER */
     STDCALL(ITextServices_TxSendMessage),
     STDCALL(ITextServices_TxDraw),
     STDCALL(ITextServices_TxGetHScroll),
@@ -637,7 +545,6 @@ const ITextServicesVtbl text_services_stdcall_vtbl =
     STDCALL(ITextServices_TxGetDropTarget),
     STDCALL(ITextServices_OnTxPropertyBitsChange),
     STDCALL(ITextServices_TxGetCachedSize),
-#endif
 };
 
 #endif /* __ASM_USE_THISCALL_WRAPPER */
@@ -647,26 +554,6 @@ static const ITextServicesVtbl textservices_vtbl =
     fnTextSrv_QueryInterface,
     fnTextSrv_AddRef,
     fnTextSrv_Release,
-#ifdef _MSC_VER
-    fnTextSrv_TxSendMessage,
-    fnTextSrv_TxDraw,
-    fnTextSrv_TxGetHScroll,
-    fnTextSrv_TxGetVScroll,
-    fnTextSrv_OnTxSetCursor,
-    fnTextSrv_TxQueryHitPoint,
-    fnTextSrv_OnTxInPlaceActivate,
-    fnTextSrv_OnTxInPlaceDeactivate,
-    fnTextSrv_OnTxUIActivate,
-    fnTextSrv_OnTxUIDeactivate,
-    fnTextSrv_TxGetText,
-    fnTextSrv_TxSetText,
-    fnTextSrv_TxGetCurTargetX,
-    fnTextSrv_TxGetBaseLinePos,
-    fnTextSrv_TxGetNaturalSize,
-    fnTextSrv_TxGetDropTarget,
-    fnTextSrv_OnTxPropertyBitsChange,
-    fnTextSrv_TxGetCachedSize
-#else /* _MSC_VER */
     THISCALL(fnTextSrv_TxSendMessage),
     THISCALL(fnTextSrv_TxDraw),
     THISCALL(fnTextSrv_TxGetHScroll),
@@ -685,7 +572,6 @@ static const ITextServicesVtbl textservices_vtbl =
     THISCALL(fnTextSrv_TxGetDropTarget),
     THISCALL(fnTextSrv_OnTxPropertyBitsChange),
     THISCALL(fnTextSrv_TxGetCachedSize)
-#endif
 };
 
 HRESULT create_text_services( IUnknown *outer, ITextHost *text_host, IUnknown **unk, BOOL emulate_10 )


### PR DESCRIPTION
## Purpose

Properly fix thiscall functions by enabling thiscall wrappers on MSVC builds.
This reverts commit 74599f6 ("[RICHED20] Fix MSVC Wordpad failure after riched20 Wine Sync to 6.10 (#7789)")

Jira Issue: https://jira.reactos.org/browse/CORE-20079
See also https://jira.reactos.org/browse/CORE-20006
See also https://jira.reactos.org/browse/CORE-20079

## Testbot runs (Filled in by Devs)

- KVM x86: https://reactos.org/testman/compare.php?ids=101394,101397,101400,101404
- KVM x64: https://reactos.org/testman/compare.php?ids=101395,101398,101401,101406