### PR TITLE
[VCRUNTIME] Fix a bug in x64 __security_init_cookie

### DIFF
--- a/sdk/lib/vcruntime/__security_init_cookie.c
+++ b/sdk/lib/vcruntime/__security_init_cookie.c
@@ -70,15 +70,16 @@ void __security_init_cookie(void)
     randomValue += GetCurrentProcessId();
     randomValue = _rotlptr(randomValue, GetCurrentProcessId() >> 2);
 
-    if (randomValue == DEFAULT_SECURITY_COOKIE)
-    {
-        randomValue++;
-    }
-
 #ifdef _WIN64
     /* Zero out highest 16 bits */
     randomValue &= 0x0000FFFFFFFFFFFFull;
 #endif
+
+    /* Avoid the default security cookie */
+    if (randomValue == DEFAULT_SECURITY_COOKIE)
+    {
+        randomValue++;
+    }
 
     __security_cookie = randomValue;
     __security_cookie_complement = ~randomValue;


### PR DESCRIPTION
## Purpose

Fix a bug in x64 __security_init_cookie

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64:
