### PR TITLE
[COMCTL32] Include size of state imagelist for column 0 LVSCW_AUTOSIZE

### DIFF
--- a/dll/win32/comctl32/listview.c
+++ b/dll/win32/comctl32/listview.c
@@ -8556,8 +8556,13 @@ static BOOL LISTVIEW_SetColumnWidth(LISTVIEW_INFO *infoPtr, INT nColumn, INT cx)
 	if (infoPtr->himlSmall && (nColumn == 0 || (LISTVIEW_GetColumnInfo(infoPtr, nColumn)->fmt & LVCFMT_IMAGE)))
 	    max_cx += infoPtr->iconSize.cx;
 	max_cx += TRAILING_LABEL_PADDING;
+#ifdef __REACTOS__
+        if (nColumn == 0 && infoPtr->himlState)
+            max_cx += infoPtr->iconStateSize.cx;
+#else
         if (nColumn == 0 && (infoPtr->dwLvExStyle & LVS_EX_CHECKBOXES))
             max_cx += GetSystemMetrics(SM_CXSMICON);
+#endif
     }
 
     /* autosize based on listview items width */


### PR DESCRIPTION
JIRA issue: [CORE-20080](https://jira.reactos.org/browse/CORE-20080) and partial [CORE-15423](https://jira.reactos.org/browse/CORE-15423)

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: