### PR TITLE
[COMCTL32] Pager: Fix PGM_RECALCSIZE behaviour

### DIFF
--- a/dll/win32/comctl32/pager.c
+++ b/dll/win32/comctl32/pager.c
@@ -430,7 +430,7 @@ PAGER_RecalcSize(PAGER_INFO *infoPtr)
     if (!infoPtr->m_bProcessingReCalcSize)
     {
         infoPtr->m_bProcessingReCalcSize = TRUE;
-        /* NOTE: Posting a recalc message to ourselves, not actually a edit control message */
+        /* NOTE: Posting a recalc message to ourselves, not actually an edit control message */
         PostMessageW(infoPtr->hwndSelf, EM_FMTLINES, 0, 0);
     }
     return DefWindowProcW(infoPtr->hwndSelf, PGM_RECALCSIZE, 0, 0);

--- a/dll/win32/comctl32/pager.c
+++ b/dll/win32/comctl32/pager.c
@@ -430,6 +430,7 @@ PAGER_RecalcSize(PAGER_INFO *infoPtr)
     if (!infoPtr->m_bProcessingReCalcSize)
     {
         infoPtr->m_bProcessingReCalcSize = TRUE;
+        /* NOTE: Posting a recalc message to ourselves, not actually a edit control message */
         PostMessageW(infoPtr->hwndSelf, EM_FMTLINES, 0, 0);
     }
     return DefWindowProcW(infoPtr->hwndSelf, PGM_RECALCSIZE, 0, 0);
@@ -566,7 +567,11 @@ PAGER_Scroll(PAGER_INFO* infoPtr, INT dir)
 }
 
 static LRESULT
+#ifdef __REACTOS__
+PAGER_FmtLines(PAGER_INFO *infoPtr)
+#else
 PAGER_FmtLines(const PAGER_INFO *infoPtr)
+#endif
 {
 #ifdef __REACTOS__
     infoPtr->m_bProcessingReCalcSize = FALSE;

--- a/dll/win32/comctl32/pager.c
+++ b/dll/win32/comctl32/pager.c
@@ -433,7 +433,7 @@ PAGER_RecalcSize(PAGER_INFO *infoPtr)
         /* NOTE: Posting a recalc message to ourselves, not actually an edit control message */
         PostMessageW(infoPtr->hwndSelf, EM_FMTLINES, 0, 0);
     }
-    return DefWindowProcW(infoPtr->hwndSelf, PGM_RECALCSIZE, 0, 0);
+    return 0;
 #else
     if (infoPtr->hwndChild)
     {

--- a/dll/win32/comctl32/pager.c
+++ b/dll/win32/comctl32/pager.c
@@ -452,6 +452,7 @@ PAGER_RecalcSize(PAGER_INFO *infoPtr)
 #endif
 }
 
+
 static COLORREF
 PAGER_SetBkColor (PAGER_INFO* infoPtr, COLORREF clrBk)
 {


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-7017](https://jira.reactos.org/browse/CORE-7017)

## Proposed changes

- Add `m_bProcessingReCalcSize` to `PAGER_INFO` structure.
- Fix `EM_FMTLINES` and `PGM_RECALCSIZE` handling, by usiing `m_bProcessingReCalcSize`.

## Comparison

BEFORE:
![before2](https://github.com/user-attachments/assets/6c5320bf-2e3b-4ac7-9f35-9f82c35860c5)

AFTER:
![after2](https://github.com/user-attachments/assets/6a4196dd-6c0c-45e6-9acb-ab594f449615)

BEFORE:
![before3](https://github.com/user-attachments/assets/389aa7fd-9637-4a82-8993-e8c17621791e)

AFTER:
![after3](https://github.com/user-attachments/assets/80b715ec-aaed-4310-9f6b-f9a04f153f6b)

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=101390,101470 LGTM.
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=101391,101471 LGTM.