### PR TITLE
[CONSRV] Don't set LineComplete on Ctrl+C or Ctrl+Break

### DIFF
--- a/win32ss/user/winsrv/consrv/coninput.c
+++ b/win32ss/user/winsrv/consrv/coninput.c
@@ -221,7 +221,6 @@ ConioProcessInputEvent(PCONSRV_CONSOLE Console,
             {
                 /* Line input is in progress; end it */
                 Console->LinePos = Console->LineSize = 0;
-                Console->LineComplete = FALSE;
             }
             return STATUS_SUCCESS; // STATUS_CONTROL_C_EXIT;
         }

--- a/win32ss/user/winsrv/consrv/coninput.c
+++ b/win32ss/user/winsrv/consrv/coninput.c
@@ -221,7 +221,7 @@ ConioProcessInputEvent(PCONSRV_CONSOLE Console,
             {
                 /* Line input is in progress; end it */
                 Console->LinePos = Console->LineSize = 0;
-                Console->LineComplete = TRUE;
+                Console->LineComplete = FALSE;
             }
             return STATUS_SUCCESS; // STATUS_CONTROL_C_EXIT;
         }


### PR DESCRIPTION
## Purpose
Avoid unexpected infinite loop of `ftp.exe`.
JIRA issue: [CORE-19513](https://jira.reactos.org/browse/CORE-19513)

## Proposed changes

- Don't set `LineComplete` on `Ctrl+C` or `Ctrl+Break` in `ConioProcessInputEvent` function.

## Comparison

BEFORE:
![before](https://github.com/user-attachments/assets/80582ae8-4fe7-4667-bc94-4ca360a1c87c)

AFTER:
![after](https://github.com/user-attachments/assets/b9d06e19-ebfe-494f-8989-c4226c3b6fe0)

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: