### PR TITLE
[NTGDI][NTUSER] Initial support of NtGdiRemoveFontResourceW

### DIFF
--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -2366,7 +2366,7 @@ IntDeleteRegFontEntry(_In_ LPCWSTR pszFileName, _In_ DWORD dwFlags)
         if (!NT_SUCCESS(Status) || _wcsicmp(szValue, pFileName) != 0)
             continue;
 
-        Status = RegDeleteValueW(hKey, szValue);
+        Status = RegDeleteValueW(hKey, szName);
         if (!NT_SUCCESS(Status))
             ret = FALSE;
     }

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -2428,6 +2428,7 @@ IntGdiRemoveFontResourceSingle(
 
     /* Delete font entries that matches PathName */
     IntLockFreeType();
+Retry:
     for (CurrentEntry = g_FontListHead.Flink;
          CurrentEntry != &g_FontListHead;
          CurrentEntry = NextEntry)
@@ -2442,6 +2443,7 @@ IntGdiRemoveFontResourceSingle(
             if (dwFlags & AFRX_WRITE_REGISTRY)
                 IntDeleteRegFontEntry(pszFileTitle, dwFlags);
             ret = TRUE;
+            goto Retry;
         }
     }
     IntUnLockFreeType();

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -2327,7 +2327,7 @@ IntGdiAddFontResourceEx(
     return ret;
 }
 
-/* Borrrowed from shlwapi */
+/* Borrowed from shlwapi */
 static LPWSTR
 PathFindFileNameW(PCWSTR lpszPath)
 {

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -2366,10 +2366,6 @@ IntDeleteRegFontEntry(_In_ PCWSTR pszFileName, _In_ DWORD dwFlags)
         if (!NT_SUCCESS(Status))
             break;
 
-        /* Avoid buffer overrun */
-        szName[RTL_NUMBER_OF(szName) - 1] = UNICODE_NULL;
-        szValue[RTL_NUMBER_OF(szValue) - 1] = UNICODE_NULL;
-
         if (_wcsicmp(szValue, pszFileName) != 0) /* Skip if the filename was not equal */
             continue;
 

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -2357,7 +2357,7 @@ IntDeleteRegFontEntry(_In_ PCWSTR pszFileName, _In_ DWORD dwFlags)
     if (!NT_SUCCESS(Status))
         return;
 
-    for (dwIndex = 0; NT_SUCCESS(Status); ++dwIndex)
+    for (dwIndex = 0;;)
     {
         NameLength = RTL_NUMBER_OF(szName);
         ValueSize = sizeof(szValue);
@@ -2366,12 +2366,15 @@ IntDeleteRegFontEntry(_In_ PCWSTR pszFileName, _In_ DWORD dwFlags)
             break;
 
         if (dwType != REG_SZ || _wcsicmp(szValue, pszFileName) != 0)
+        {
+            ++dwIndex;
             continue;
+        }
 
         /* Delete the found value */
         Status = RegDeleteValueW(hKey, szName);
-        if (NT_SUCCESS(Status))
-            --dwIndex;
+        if (!NT_SUCCESS(Status))
+            ++dwIndex;
     }
 
     ZwClose(hKey);

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -2428,7 +2428,7 @@ IntGdiRemoveFontResourceSingle(
     }
     IntUnLockFreeType();
 
-    RtlFreeUnicodeString(&PathName);
+    ExFreePoolWithTag(pszBuffer, TAG_USTR);
     return ret;
 }
 

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -2344,9 +2344,9 @@ PathFindFileNameW(_In_ PCWSTR pszPath)
     return (PWSTR)lastSlash;
 }
 
-/* Delete registry font entry */
+/* Delete registry font entries */
 static VOID
-IntDeleteRegFontEntry(_In_ PCWSTR pszFileName, _In_ DWORD dwFlags)
+IntDeleteRegFontEntries(_In_ PCWSTR pszFileName, _In_ DWORD dwFlags)
 {
     NTSTATUS Status;
     HKEY hKey;
@@ -2374,7 +2374,7 @@ IntDeleteRegFontEntry(_In_ PCWSTR pszFileName, _In_ DWORD dwFlags)
         /* Delete the found value */
         Status = RegDeleteValueW(hKey, szName);
         if (!NT_SUCCESS(Status))
-            ++dwIndex;
+            break;
     }
 
     ZwClose(hKey);
@@ -2439,7 +2439,7 @@ IntGdiRemoveFontResourceSingle(
             RemoveEntryList(&FontEntry->ListEntry);
             CleanupFontEntry(FontEntry);
             if (dwFlags & AFRX_WRITE_REGISTRY)
-                IntDeleteRegFontEntry(pszFileTitle, dwFlags);
+                IntDeleteRegFontEntries(pszFileTitle, dwFlags);
             ret = TRUE;
         }
     }

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -2341,7 +2341,7 @@ PathFindFileNameW(PCWSTR lpszPath)
         }
         lpszPath++;
     }
-    return (LPWSTR)lastSlash;
+    return (PWSTR)lastSlash;
 }
 
 /* Delete registry font entry */

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -2348,7 +2348,7 @@ PathFindFileNameW(PCWSTR lpszPath)
 static BOOL
 IntDeleteRegFontEntry(_In_ PCWSTR pszFileName, _In_ DWORD dwFlags)
 {
-    NTSTATUS Status;
+    NTSTATUS Status = STATUS_SUCCESS;
     HKEY hKey;
     WCHAR szName[MAX_PATH], szValue[MAX_PATH];
     ULONG dwIndex, NameLength, ValueSize;

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -2329,17 +2329,17 @@ IntGdiAddFontResourceEx(
 
 /* Borrowed from shlwapi */
 static PWSTR
-PathFindFileNameW(PCWSTR lpszPath)
+PathFindFileNameW(_In_ PCWSTR pszPath)
 {
-    PCWSTR lastSlash = lpszPath;
-    while (*lpszPath)
+    PCWSTR lastSlash = pszPath;
+    while (*pszPath)
     {
-        if ((*lpszPath == L'\\' || *lpszPath == L'/' || *lpszPath == L':') &&
-            lpszPath[1] && lpszPath[1] != '\\' && lpszPath[1] != L'/')
+        if ((*pszPath == L'\\' || *pszPath == L'/' || *pszPath == L':') &&
+            pszPath[1] && pszPath[1] != '\\' && pszPath[1] != L'/')
         {
-            lastSlash = lpszPath + 1;
+            lastSlash = pszPath + 1;
         }
-        lpszPath++;
+        pszPath++;
     }
     return (PWSTR)lastSlash;
 }

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -2345,7 +2345,7 @@ PathFindFileNameW(PCWSTR lpszPath)
 }
 
 /* Delete registry font entry */
-static BOOL
+static VOID
 IntDeleteRegFontEntry(_In_ PCWSTR pszFileName, _In_ DWORD dwFlags)
 {
     NTSTATUS Status = STATUS_SUCCESS;
@@ -2356,9 +2356,8 @@ IntDeleteRegFontEntry(_In_ PCWSTR pszFileName, _In_ DWORD dwFlags)
 
     Status = RegOpenKey(g_FontRegPath.Buffer, &hKey);
     if (!NT_SUCCESS(Status))
-        return FALSE;
+        return;
 
-Retry:
     for (dwIndex = 0; NT_SUCCESS(Status); ++dwIndex)
     {
         NameLength = RTL_NUMBER_OF(szName);
@@ -2377,13 +2376,10 @@ Retry:
         /* Delete the found value */
         Status = RegDeleteValueW(hKey, szName);
         if (NT_SUCCESS(Status))
-            goto Retry;
-
-        ret = FALSE;
+            --dwIndex;
     }
 
     ZwClose(hKey);
-    return ret;
 }
 
 static BOOL FASTCALL

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -2428,7 +2428,8 @@ IntGdiRemoveFontResourceSingle(
     }
     IntUnLockFreeType();
 
-    ExFreePoolWithTag(pszBuffer, TAG_USTR);
+    if (pszBuffer)
+        ExFreePoolWithTag(pszBuffer, TAG_USTR);
     return ret;
 }
 

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -2328,14 +2328,14 @@ IntGdiAddFontResourceEx(
 }
 
 /* Borrowed from shlwapi */
-static LPWSTR
+static PWSTR
 PathFindFileNameW(PCWSTR lpszPath)
 {
     PCWSTR lastSlash = lpszPath;
-    while (lpszPath && *lpszPath)
+    while (*lpszPath)
     {
-        if ((*lpszPath == '\\' || *lpszPath == '/' || *lpszPath == ':') &&
-            lpszPath[1] && lpszPath[1] != '\\' && lpszPath[1] != '/')
+        if ((*lpszPath == L'\\' || *lpszPath == L'/' || *lpszPath == L':') &&
+            lpszPath[1] && lpszPath[1] != '\\' && lpszPath[1] != L'/')
         {
             lastSlash = lpszPath + 1;
         }
@@ -2439,6 +2439,7 @@ Retry:
         FontGDI = FontEntry->Font;
         if (FontGDI->Filename && _wcsicmp(FontGDI->Filename, pszFileTitle) == 0)
         {
+            RemoveEntryList(&FontEntry->ListEntry);
             CleanupFontEntry(FontEntry);
             if (dwFlags & AFRX_WRITE_REGISTRY)
                 IntDeleteRegFontEntry(pszFileTitle, dwFlags);

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -2428,8 +2428,7 @@ IntGdiRemoveFontResourceSingle(
     }
     IntUnLockFreeType();
 
-    if (pszBuffer)
-        ExFreePoolWithTag(pszBuffer, TAG_USTR);
+    RtlFreeUnicodeString(&PathName);
     return ret;
 }
 

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -2348,7 +2348,7 @@ PathFindFileNameW(PCWSTR lpszPath)
 static VOID
 IntDeleteRegFontEntry(_In_ PCWSTR pszFileName, _In_ DWORD dwFlags)
 {
-    NTSTATUS Status = STATUS_SUCCESS;
+    NTSTATUS Status;
     HKEY hKey;
     WCHAR szName[MAX_PATH], szValue[MAX_PATH];
     ULONG dwIndex, NameLength, ValueSize;

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -2351,8 +2351,7 @@ IntDeleteRegFontEntry(_In_ PCWSTR pszFileName, _In_ DWORD dwFlags)
     NTSTATUS Status;
     HKEY hKey;
     WCHAR szName[MAX_PATH], szValue[MAX_PATH];
-    ULONG dwIndex, NameLength, ValueSize;
-    BOOL ret = TRUE;
+    ULONG dwIndex, NameLength, ValueSize, dwType;
 
     Status = RegOpenKey(g_FontRegPath.Buffer, &hKey);
     if (!NT_SUCCESS(Status))
@@ -2362,11 +2361,11 @@ IntDeleteRegFontEntry(_In_ PCWSTR pszFileName, _In_ DWORD dwFlags)
     {
         NameLength = RTL_NUMBER_OF(szName);
         ValueSize = sizeof(szValue);
-        Status = RegEnumValueW(hKey, dwIndex, szName, &NameLength, NULL, szValue, &ValueSize);
+        Status = RegEnumValueW(hKey, dwIndex, szName, &NameLength, &dwType, szValue, &ValueSize);
         if (!NT_SUCCESS(Status))
             break;
 
-        if (_wcsicmp(szValue, pszFileName) != 0) /* Skip if the filename was not equal */
+        if (dwType != REG_SZ || _wcsicmp(szValue, pszFileName) != 0)
             continue;
 
         /* Delete the found value */

--- a/win32ss/gdi/ntgdi/misc.h
+++ b/win32ss/gdi/ntgdi/misc.h
@@ -60,6 +60,19 @@ DWORD
 NTAPI
 RegGetSectionDWORD(LPCWSTR pszSection, PCWSTR pszValue, DWORD dwDefault);
 
+NTSTATUS NTAPI
+RegDeleteValueW(_In_ HKEY hKey, _In_ LPCWSTR pszValueName);
+
+NTSTATUS NTAPI
+RegEnumValueW(
+    _In_ HKEY hKey,
+    _In_ ULONG Index,
+    _Out_opt_ LPWSTR Name,
+    _Out_opt_ PULONG NameLength,
+    _Out_opt_ PULONG Type,
+    _Out_opt_ PVOID Data,
+    _Out_opt_ PULONG DataLength);
+
 VOID
 FASTCALL
 SetLastNtError(_In_ NTSTATUS Status);

--- a/win32ss/user/ntuser/misc/registry.c
+++ b/win32ss/user/ntuser/misc/registry.c
@@ -380,3 +380,119 @@ RegWriteUserSetting(
     return NT_SUCCESS(Status);
 }
 
+static inline BOOL
+IsStringType(ULONG Type)
+{
+    return (Type == REG_SZ) || (Type == REG_EXPAND_SZ) || (Type == REG_MULTI_SZ);
+}
+
+NTSTATUS
+NTAPI
+RegEnumValueW(
+    _In_ HKEY hKey,
+    _In_ ULONG Index,
+    _Out_opt_ LPWSTR Name,
+    _Out_opt_ PULONG NameLength,
+    _Out_opt_ PULONG Type,
+    _Out_opt_ PVOID Data,
+    _Out_opt_ PULONG DataLength)
+{
+    PKEY_VALUE_FULL_INFORMATION ValueInfo = NULL;
+    ULONG BufferLength = 0;
+    ULONG ReturnedLength;
+    NTSTATUS Status;
+
+    /* Calculate the required buffer length */
+    BufferLength = FIELD_OFFSET(KEY_VALUE_FULL_INFORMATION, Name);
+    BufferLength += (MAX_PATH + 1) * sizeof(WCHAR);
+    if (Data != NULL)
+        BufferLength += *DataLength;
+
+    /* Allocate the value buffer */
+    ValueInfo = ExAllocatePoolWithTag(PagedPool, BufferLength, TAG_TEMP);
+    if (ValueInfo == NULL)
+        return STATUS_NO_MEMORY;
+
+    /* Enumerate the value*/
+    Status = ZwEnumerateValueKey(hKey,
+                                 Index,
+                                 KeyValueFullInformation,
+                                 ValueInfo,
+                                 BufferLength,
+                                 &ReturnedLength);
+    if (NT_SUCCESS(Status))
+    {
+        if (Name)
+        {
+            /* Check if the name fits */
+            if (ValueInfo->NameLength < (*NameLength * sizeof(WCHAR)))
+            {
+                /* Copy it */
+                RtlMoveMemory(Name, ValueInfo->Name, ValueInfo->NameLength);
+
+                /* Terminate the string */
+                Name[ValueInfo->NameLength / sizeof(WCHAR)] = UNICODE_NULL;
+            }
+            else
+            {
+                /* Otherwise, we ran out of buffer space */
+                Status = STATUS_BUFFER_OVERFLOW;
+                goto done;
+            }
+        }
+
+        if (Data)
+        {
+            /* Check if the data fits */
+            if (ValueInfo->DataLength <= *DataLength)
+            {
+                /* Copy it */
+                RtlMoveMemory(Data,
+                              (PVOID)((ULONG_PTR)ValueInfo + ValueInfo->DataOffset),
+                              ValueInfo->DataLength);
+
+                /* if the type is REG_SZ and data is not 0-terminated
+                 * and there is enough space in the buffer NT appends a \0 */
+                if (IsStringType(ValueInfo->Type) &&
+                    ValueInfo->DataLength <= *DataLength - sizeof(WCHAR))
+                {
+                    WCHAR *ptr = (WCHAR *)((ULONG_PTR)Data + ValueInfo->DataLength);
+                    if ((ptr > (WCHAR *)Data) && ptr[-1])
+                        *ptr = UNICODE_NULL;
+                }
+            }
+            else
+            {
+                Status = STATUS_BUFFER_OVERFLOW;
+                goto done;
+            }
+        }
+    }
+
+done:
+    if ((NT_SUCCESS(Status)) || (Status == STATUS_BUFFER_OVERFLOW))
+    {
+        if (Type)
+            *Type = ValueInfo->Type;
+
+        if (NameLength)
+            *NameLength = ValueInfo->NameLength;
+
+        if (DataLength)
+            *DataLength = ValueInfo->DataLength;
+    }
+
+    /* Free the buffer and return status */
+    if (ValueInfo)
+        ExFreePoolWithTag(ValueInfo, TAG_TEMP);
+
+    return Status;
+}
+
+NTSTATUS NTAPI
+RegDeleteValueW(_In_ HKEY hKey, _In_ LPCWSTR pszValueName)
+{
+    UNICODE_STRING ustrName;
+    RtlInitUnicodeString(&ustrName, pszValueName);
+    return ZwDeleteValueKey(hKey, &ustrName);
+}

--- a/win32ss/user/ntuser/misc/registry.c
+++ b/win32ss/user/ntuser/misc/registry.c
@@ -425,7 +425,7 @@ RegEnumValueW(
         if (Name)
         {
             /* Check if the name fits */
-            if (ValueInfo->NameLength < (*NameLength * sizeof(WCHAR)))
+            if ((ValueInfo->NameLength + sizeof(WCHAR)) <= (*NameLength * sizeof(WCHAR)))
             {
                 /* Copy it */
                 RtlMoveMemory(Name, ValueInfo->Name, ValueInfo->NameLength);


### PR DESCRIPTION
## Purpose
Enable the users to delete fonts.
JIRA issue: [CORE-17684](https://jira.reactos.org/browse/CORE-17684)

## Proposed changes

- Add `IntDeleteRegFontEntry` helper function.
- Add `RegDeleteValueW` and `RegEnumValueW` helper functions in `win32ss/user/ntuser/misc/registry.c`.
- Add some code to `IntGdiRemoveFontResourceSingle` function.

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=101881,101913
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=101882,101914