### PR TITLE
[SHELL32] Implement IShellFolder2::GetDetailsEx

### DIFF
--- a/dll/win32/shell32/folders/CControlPanelFolder.cpp
+++ b/dll/win32/shell32/folders/CControlPanelFolder.cpp
@@ -84,6 +84,14 @@ HRESULT WINAPI CControlPanelEnum::Initialize(DWORD dwFlags, IEnumIDList* pRegEnu
     return S_OK;
 }
 
+static const CLSID* IsRegItem(LPCITEMIDLIST pidl)
+{
+    BYTE type = _ILGetType(pidl);
+    if (type == PT_CONTROLS_OLDREGITEM || type == PT_CONTROLS_NEWREGITEM)
+        return (CLSID*)(&pidl->mkid.abID[pidl->mkid.cb - sizeof(CLSID)]);
+    return NULL;
+}
+
 static LPITEMIDLIST _ILCreateCPanelApplet(LPCWSTR pszName, LPCWSTR pszDisplayName, LPCWSTR pszComment, int iIconIdx)
 {
     PIDLCPanelStruct *pCP;
@@ -565,8 +573,9 @@ HRESULT WINAPI CControlPanelFolder::GetDefaultColumnState(UINT iColumn, DWORD *p
 
 HRESULT WINAPI CControlPanelFolder::GetDetailsEx(PCUITEMID_CHILD pidl, const SHCOLUMNID *pscid, VARIANT *pv)
 {
-    FIXME("(%p)\n", this);
-    return E_NOTIMPL;
+    if (IsRegItem(pidl))
+        return m_regFolder->GetDetailsEx(pidl, pscid, pv);
+    return SHELL32_GetDetailsOfPKeyAsVariant(this, pidl, pscid, pv, FALSE);
 }
 
 HRESULT WINAPI CControlPanelFolder::GetDetailsOf(PCUITEMID_CHILD pidl, UINT iColumn, SHELLDETAILS *psd)
@@ -605,8 +614,12 @@ HRESULT WINAPI CControlPanelFolder::GetDetailsOf(PCUITEMID_CHILD pidl, UINT iCol
 
 HRESULT WINAPI CControlPanelFolder::MapColumnToSCID(UINT column, SHCOLUMNID *pscid)
 {
-    FIXME("(%p)\n", this);
-    return E_NOTIMPL;
+    switch (column)
+    {
+        case CONTROLPANEL_COL_NAME: return MakeSCID(*pscid, FMTID_Storage, PID_STG_NAME);
+        case CONTROLPANEL_COL_COMMENT: return MakeSCID(*pscid, FMTID_SummaryInformation, PIDSI_COMMENTS);
+    }
+    return E_INVALIDARG;
 }
 
 /************************************************************************

--- a/dll/win32/shell32/folders/CControlPanelFolder.cpp
+++ b/dll/win32/shell32/folders/CControlPanelFolder.cpp
@@ -88,7 +88,7 @@ static const CLSID* IsRegItem(LPCITEMIDLIST pidl)
 {
     BYTE type = _ILGetType(pidl);
     if (type == PT_CONTROLS_OLDREGITEM || type == PT_CONTROLS_NEWREGITEM)
-        return (CLSID*)(&pidl->mkid.abID[pidl->mkid.cb - sizeof(CLSID)]);
+        return (CLSID*)((BYTE*)pidl + (pidl->mkid.cb - sizeof(CLSID)));
     return NULL;
 }
 
@@ -575,7 +575,7 @@ HRESULT WINAPI CControlPanelFolder::GetDetailsEx(PCUITEMID_CHILD pidl, const SHC
 {
     if (IsRegItem(pidl))
         return m_regFolder->GetDetailsEx(pidl, pscid, pv);
-    return SHELL32_GetDetailsOfPKeyAsVariant(this, pidl, pscid, pv, FALSE);
+    return SH32_GetDetailsOfPKeyAsVariant(this, pidl, pscid, pv, FALSE);
 }
 
 HRESULT WINAPI CControlPanelFolder::GetDetailsOf(PCUITEMID_CHILD pidl, UINT iColumn, SHELLDETAILS *psd)

--- a/dll/win32/shell32/folders/CDesktopFolder.cpp
+++ b/dll/win32/shell32/folders/CDesktopFolder.cpp
@@ -955,14 +955,14 @@ HRESULT WINAPI CDesktopFolder::GetDefaultColumnState(UINT iColumn, SHCOLSTATEF *
     return hr;
 }
 
-HRESULT WINAPI CDesktopFolder::GetDetailsEx(
-    PCUITEMID_CHILD pidl,
-    const SHCOLUMNID *pscid,
-    VARIANT *pv)
+HRESULT WINAPI CDesktopFolder::GetDetailsEx(PCUITEMID_CHILD pidl,
+                                            const SHCOLUMNID *pscid, VARIANT *pv)
 {
-    FIXME ("(%p)\n", this);
-
-    return E_NOTIMPL;
+    HRESULT hr;
+    CComPtr<IShellFolder2> psf;
+    if (FAILED_UNEXPECTEDLY(hr = _GetSFFromPidl(pidl, &psf)))
+        return hr;
+    return psf->GetDetailsEx(pidl, pscid, pv);
 }
 
 /*************************************************************************
@@ -1002,8 +1002,14 @@ HRESULT WINAPI CDesktopFolder::GetDetailsOf(
 
 HRESULT WINAPI CDesktopFolder::MapColumnToSCID(UINT column, SHCOLUMNID *pscid)
 {
-    FIXME ("(%p)\n", this);
-    return E_NOTIMPL;
+    // Note: All these folders use the same SHFSF_COL mapping (m_regFolder only handles a subset).
+    if (m_DesktopFSFolder)
+        return m_DesktopFSFolder->MapColumnToSCID(column, pscid);
+    if (m_SharedDesktopFSFolder)
+        return m_SharedDesktopFSFolder->MapColumnToSCID(column, pscid);
+    if (m_regFolder)
+        return m_regFolder->MapColumnToSCID(column, pscid);
+    return E_FAIL;
 }
 
 HRESULT WINAPI CDesktopFolder::GetClassID(CLSID *lpClassId)

--- a/dll/win32/shell32/folders/CDrivesFolder.cpp
+++ b/dll/win32/shell32/folders/CDrivesFolder.cpp
@@ -26,8 +26,8 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(shell);
 
-BOOL IsDriveFloppyA(LPCSTR pszDriveRoot);
-BOOL IsDriveFloppyW(LPCWSTR pszDriveRoot);
+extern BOOL IsDriveFloppyA(LPCSTR pszDriveRoot);
+extern BOOL IsDriveFloppyW(LPCWSTR pszDriveRoot);
 
 /*
 CDrivesFolder should create a CRegFolder to represent the virtual items that exist only in

--- a/dll/win32/shell32/folders/CDrivesFolder.cpp
+++ b/dll/win32/shell32/folders/CDrivesFolder.cpp
@@ -1185,7 +1185,7 @@ HRESULT WINAPI CDrivesFolder::GetDetailsEx(PCUITEMID_CHILD pidl, const SHCOLUMNI
     }
     if (pCLSID)
         return m_regFolder->GetDetailsEx(pidl, pscid, pv);
-    return SHELL32_GetDetailsOfPKeyAsVariant(this, pidl, pscid, pv, FALSE);
+    return SH32_GetDetailsOfPKeyAsVariant(this, pidl, pscid, pv, FALSE);
 }
 
 HRESULT WINAPI CDrivesFolder::GetDetailsOf(PCUITEMID_CHILD pidl, UINT iColumn, SHELLDETAILS *psd)
@@ -1208,13 +1208,14 @@ HRESULT WINAPI CDrivesFolder::GetDetailsOf(PCUITEMID_CHILD pidl, UINT iColumn, S
         switch (MyComputerSFHeader[iColumn].colnameid)
         {
             case IDS_SHV_COLUMN_NAME:
+                return m_regFolder->GetDetailsOf(pidl, SHFSF_COL_NAME, psd);
             case IDS_SHV_COLUMN_TYPE:
-                return m_regFolder->GetDetailsOf(pidl, iColumn, psd);
+                return m_regFolder->GetDetailsOf(pidl, SHFSF_COL_TYPE, psd);
             case IDS_SHV_COLUMN_DISK_CAPACITY:
             case IDS_SHV_COLUMN_DISK_AVAILABLE:
-                return SHSetStrRet(&psd->str, ""); /* blank col */
+                return SHSetStrRetEmpty(&psd->str);
             case IDS_SHV_COLUMN_COMMENTS:
-                return m_regFolder->GetDetailsOf(pidl, 2, psd); /* 2 = comments */
+                return m_regFolder->GetDetailsOf(pidl, SHFSF_COL_COMMENT, psd);
             DEFAULT_UNREACHABLE;
         }
     }

--- a/dll/win32/shell32/folders/CFSFolder.cpp
+++ b/dll/win32/shell32/folders/CFSFolder.cpp
@@ -176,7 +176,7 @@ HRESULT GetCLSIDForFileType(PCUIDLIST_RELATIVE pidl, LPCWSTR KeyName, CLSID* pcl
     return GetCLSIDForFileTypeFromExtension(pExtension, KeyName, pclsid);
 }
 
-HRESULT GetItemCLSID(PCUIDLIST_RELATIVE pidl, CLSID* pclsid)
+HRESULT GetItemCLSID(PCUIDLIST_RELATIVE pidl, CLSID *pclsid)
 {
     WCHAR buf[256];
     LPCWSTR pExt = ExtensionFromPidlEx(pidl, buf, _countof(buf), TRUE);
@@ -185,6 +185,7 @@ HRESULT GetItemCLSID(PCUIDLIST_RELATIVE pidl, CLSID* pclsid)
     HRESULT hr = E_FAIL;
     if (!ItemIsFolder(pidl))
         hr = GetCLSIDForFileTypeFromExtension(pExt, L"CLSID", pclsid);
+    // TODO: Should we handle folders with desktop.ini here?
     if (hr != S_OK && pExt[0] == '.' && pExt[1] == '{')
         hr = CLSIDFromString(pExt + 1, pclsid);
     return hr;
@@ -1711,7 +1712,7 @@ HRESULT WINAPI CFSFolder::GetDetailsEx(PCUITEMID_CHILD pidl, const SHCOLUMNID *p
                 break;
         }
     }
-    return SHELL32_GetDetailsOfPKeyAsVariant(this, pidl, pscid, pv, TRUE);
+    return SH32_GetDetailsOfPKeyAsVariant(this, pidl, pscid, pv, TRUE);
 }
 
 HRESULT WINAPI CFSFolder::GetDetailsOf(PCUITEMID_CHILD pidl,

--- a/dll/win32/shell32/folders/CFSFolder.cpp
+++ b/dll/win32/shell32/folders/CFSFolder.cpp
@@ -1696,7 +1696,7 @@ HRESULT WINAPI CFSFolder::GetDetailsEx(PCUITEMID_CHILD pidl, const SHCOLUMNID *p
         switch (pscid->pid)
         {
             case PID_STG_NAME: // Handled directly here for faster performance
-                return SHELL_GetDetailsOfStringAsVariant(this, pidl, SHFSF_COL_NAME, pv);
+                return SHELL_GetDetailsOfAsStringVariant(this, pidl, SHFSF_COL_NAME, pv);
             case PID_STG_SIZE:
                 V_VT(pv) = VT_UI4;
                 V_UI4(pv) = _ILGetFileSize(pidl, NULL, 0);

--- a/dll/win32/shell32/folders/CFSFolder.cpp
+++ b/dll/win32/shell32/folders/CFSFolder.cpp
@@ -88,7 +88,7 @@ static HKEY OpenKeyFromFileType(LPCWSTR pExtension, LPCWSTR KeyName)
     return hkey;
 }
 
-static LPCWSTR ExtensionFromPidlEx(PCUIDLIST_RELATIVE pidl, LPWSTR Buf, UINT cchMax, BOOL AllowFolder)
+static LPCWSTR ExtensionFromPidl(PCUIDLIST_RELATIVE pidl, LPWSTR Buf, UINT cchMax, BOOL AllowFolder = FALSE)
 {
     if (!AllowFolder && !_ILIsValue(pidl))
     {
@@ -104,11 +104,6 @@ static LPCWSTR ExtensionFromPidlEx(PCUIDLIST_RELATIVE pidl, LPWSTR Buf, UINT cch
         return NULL;
     }
     return pExtension;
-}
-
-static LPCWSTR ExtensionFromPidl(PCUIDLIST_RELATIVE pidl, LPWSTR Buf, UINT cchMax)
-{
-    return ExtensionFromPidlEx(pidl, Buf, cchMax, FALSE);
 }
 
 static HRESULT GetCLSIDForFileTypeFromExtension(LPCWSTR pExtension, LPCWSTR KeyName, CLSID* pclsid)
@@ -179,7 +174,7 @@ HRESULT GetCLSIDForFileType(PCUIDLIST_RELATIVE pidl, LPCWSTR KeyName, CLSID* pcl
 HRESULT GetItemCLSID(PCUIDLIST_RELATIVE pidl, CLSID *pclsid)
 {
     WCHAR buf[256];
-    LPCWSTR pExt = ExtensionFromPidlEx(pidl, buf, _countof(buf), TRUE);
+    LPCWSTR pExt = ExtensionFromPidl(pidl, buf, _countof(buf), TRUE);
     if (!pExt)
         return E_FAIL;
     HRESULT hr = E_FAIL;
@@ -1778,7 +1773,7 @@ HRESULT WINAPI CFSFolder::GetDetailsOf(PCUITEMID_CHILD pidl,
     return hr;
 }
 
-HRESULT WINAPI CFSFolder::MapColumnToSCID (UINT column, SHCOLUMNID *pscid)
+HRESULT WINAPI CFSFolder::MapColumnToSCID(UINT column, SHCOLUMNID *pscid)
 {
     switch (column)
     {

--- a/dll/win32/shell32/folders/CRegFolder.cpp
+++ b/dll/win32/shell32/folders/CRegFolder.cpp
@@ -818,7 +818,18 @@ HRESULT WINAPI CRegFolder::GetDefaultColumnState(UINT iColumn, DWORD *pcsFlags)
 
 HRESULT WINAPI CRegFolder::GetDetailsEx(PCUITEMID_CHILD pidl, const SHCOLUMNID *pscid, VARIANT *pv)
 {
-    return E_NOTIMPL;
+    const CLSID *pCLSID = IsRegItem(pidl);
+    if (!pCLSID)
+        return E_INVALIDARG;
+    if (pscid->fmtid == FMTID_ShellDetails)
+    {
+        switch (pscid->pid)
+        {
+            case PID_DESCRIPTIONID:
+                return SHELL_CreateSHDESCRIPTIONID(pv, SHDID_ROOT_REGITEM, pCLSID);
+        }
+    }
+    return SHELL32_GetDetailsOfPKeyAsVariant(this, pidl, pscid, pv, TRUE);
 }
 
 HRESULT WINAPI CRegFolder::GetDetailsOf(PCUITEMID_CHILD pidl, UINT iColumn, SHELLDETAILS *psd)
@@ -867,7 +878,13 @@ HRESULT WINAPI CRegFolder::GetDetailsOf(PCUITEMID_CHILD pidl, UINT iColumn, SHEL
 
 HRESULT WINAPI CRegFolder::MapColumnToSCID(UINT column, SHCOLUMNID *pscid)
 {
-    return E_NOTIMPL;
+    switch (column)
+    {
+        case COL_NAME: return MakeSCID(*pscid, FMTID_Storage, PID_STG_NAME);
+        case COL_TYPE: return MakeSCID(*pscid, FMTID_Storage, PID_STG_STORAGETYPE);
+        case COL_INFOTIP: return MakeSCID(*pscid, FMTID_SummaryInformation, PIDSI_COMMENTS);
+    }
+    return E_INVALIDARG;
 }
 
 static HRESULT CALLBACK RegFolderContextMenuCallback(IShellFolder *psf, HWND hwnd, IDataObject *pdtobj,

--- a/dll/win32/shell32/folders/CRegFolder.cpp
+++ b/dll/win32/shell32/folders/CRegFolder.cpp
@@ -868,7 +868,7 @@ HRESULT WINAPI CRegFolder::GetDetailsOf(PCUITEMID_CHILD pidl, UINT iColumn, SHEL
             RegCloseKey(hKey);
             return S_OK;
         default:
-            /* Return an empty string when we area asked for a column we don't support.
+            /* Return an empty string when we are asked for a column we don't support.
                Only  the regfolder is supposed to do this as it supports less columns compared to other folder
                and its contents are supposed to be presented alongside items that support more columns. */
             return SHSetStrRetEmpty(&psd->str);

--- a/dll/win32/shell32/folders/CRegFolder.cpp
+++ b/dll/win32/shell32/folders/CRegFolder.cpp
@@ -869,7 +869,7 @@ HRESULT WINAPI CRegFolder::GetDetailsOf(PCUITEMID_CHILD pidl, UINT iColumn, SHEL
             return S_OK;
         default:
             /* Return an empty string when we are asked for a column we don't support.
-               Only  the regfolder is supposed to do this as it supports less columns compared to other folder
+               Only the regfolder is supposed to do this as it supports fewer columns compared to other folders
                and its contents are supposed to be presented alongside items that support more columns. */
             return SHSetStrRetEmpty(&psd->str);
     }

--- a/dll/win32/shell32/folders/CRegFolder.cpp
+++ b/dll/win32/shell32/folders/CRegFolder.cpp
@@ -829,7 +829,7 @@ HRESULT WINAPI CRegFolder::GetDetailsEx(PCUITEMID_CHILD pidl, const SHCOLUMNID *
                 return SHELL_CreateSHDESCRIPTIONID(pv, SHDID_ROOT_REGITEM, pCLSID);
         }
     }
-    return SHELL32_GetDetailsOfPKeyAsVariant(this, pidl, pscid, pv, TRUE);
+    return SH32_GetDetailsOfPKeyAsVariant(this, pidl, pscid, pv, TRUE);
 }
 
 HRESULT WINAPI CRegFolder::GetDetailsOf(PCUITEMID_CHILD pidl, UINT iColumn, SHELLDETAILS *psd)
@@ -860,7 +860,7 @@ HRESULT WINAPI CRegFolder::GetDetailsOf(PCUITEMID_CHILD pidl, UINT iColumn, SHEL
         case COL_INFOTIP:
             HKEY hKey;
             if (!HCR_RegOpenClassIDKey(*clsid, &hKey))
-                return SHSetStrRet(&psd->str, "");
+                return SHSetStrRetEmpty(&psd->str);
 
             psd->str.cStr[0] = 0x00;
             psd->str.uType = STRRET_CSTR;
@@ -871,7 +871,7 @@ HRESULT WINAPI CRegFolder::GetDetailsOf(PCUITEMID_CHILD pidl, UINT iColumn, SHEL
             /* Return an empty string when we area asked for a column we don't support.
                Only  the regfolder is supposed to do this as it supports less columns compared to other folder
                and its contents are supposed to be presented alongside items that support more columns. */
-            return SHSetStrRet(&psd->str, "");
+            return SHSetStrRetEmpty(&psd->str);
     }
     return E_FAIL;
 }

--- a/dll/win32/shell32/shfldr.h
+++ b/dll/win32/shell32/shfldr.h
@@ -110,7 +110,7 @@ SHELL_GetDetailsOfStringAsVariant(IShellFolder2 *pSF, PCUITEMID_CHILD pidl, UINT
 HRESULT
 SHELL_GetDetailsOfColumnAsVariant(IShellFolder2 *pSF, PCUITEMID_CHILD pidl, UINT Column, VARTYPE vt, VARIANT *pVar);
 HRESULT
-SHELL32_GetDetailsOfPKeyAsVariant(IShellFolder2 *pSF, PCUITEMID_CHILD pidl, const SHCOLUMNID *pscid, VARIANT *pVar, BOOL Direct);
+SH32_GetDetailsOfPKeyAsVariant(IShellFolder2 *pSF, PCUITEMID_CHILD pidl, const SHCOLUMNID *pscid, VARIANT *pVar, BOOL Direct);
 
 HRESULT
 SHELL_CreateAbsolutePidl(IShellFolder *pSF, PCUIDLIST_RELATIVE pidlChild, PIDLIST_ABSOLUTE *ppPidl);

--- a/dll/win32/shell32/shfldr.h
+++ b/dll/win32/shell32/shfldr.h
@@ -23,6 +23,7 @@
 
 #ifndef _SHFLDR_H_
 #define _SHFLDR_H_
+#include <ntquery.h> // For PID_STG_*
 
 #define CHARS_IN_GUID 39
 
@@ -93,6 +94,23 @@ SHELL_GetDefaultFolderEnumSHCONTF();
 
 BOOL
 SHELL_IncludeItemInFolderEnum(IShellFolder *pSF, PCUITEMID_CHILD pidl, SFGAOF Query, SHCONTF Flags);
+
+static inline HRESULT
+MakeSCID(SHCOLUMNID &scid, REFCLSID fmtid, UINT pid)
+{
+    scid.fmtid = fmtid;
+    scid.pid = pid;
+    return S_OK;
+}
+
+HRESULT
+SHELL_MapSCIDToColumn(IShellFolder2 *pSF, const SHCOLUMNID *pscid);
+HRESULT
+SHELL_GetDetailsOfStringAsVariant(IShellFolder2 *pSF, PCUITEMID_CHILD pidl, UINT Column, VARIANT *pVar);
+HRESULT
+SHELL_GetDetailsOfColumnAsVariant(IShellFolder2 *pSF, PCUITEMID_CHILD pidl, UINT Column, VARTYPE vt, VARIANT *pVar);
+HRESULT
+SHELL32_GetDetailsOfPKeyAsVariant(IShellFolder2 *pSF, PCUITEMID_CHILD pidl, const SHCOLUMNID *pscid, VARIANT *pVar, BOOL Direct);
 
 HRESULT
 SHELL_CreateAbsolutePidl(IShellFolder *pSF, PCUIDLIST_RELATIVE pidlChild, PIDLIST_ABSOLUTE *ppPidl);

--- a/dll/win32/shell32/shfldr.h
+++ b/dll/win32/shell32/shfldr.h
@@ -110,7 +110,7 @@ SHELL_GetDetailsOfAsStringVariant(IShellFolder2 *pSF, PCUITEMID_CHILD pidl, UINT
 HRESULT
 SHELL_GetDetailsOfColumnAsVariant(IShellFolder2 *pSF, PCUITEMID_CHILD pidl, UINT Column, VARTYPE vt, VARIANT *pVar);
 HRESULT
-SH32_GetDetailsOfPKeyAsVariant(IShellFolder2 *pSF, PCUITEMID_CHILD pidl, const SHCOLUMNID *pscid, VARIANT *pVar, BOOL Direct);
+SH32_GetDetailsOfPKeyAsVariant(IShellFolder2 *pSF, PCUITEMID_CHILD pidl, const SHCOLUMNID *pscid, VARIANT *pVar, BOOL UseFsColMap);
 
 HRESULT
 SHELL_CreateAbsolutePidl(IShellFolder *pSF, PCUIDLIST_RELATIVE pidlChild, PIDLIST_ABSOLUTE *ppPidl);

--- a/dll/win32/shell32/shfldr.h
+++ b/dll/win32/shell32/shfldr.h
@@ -106,7 +106,7 @@ MakeSCID(SHCOLUMNID &scid, REFCLSID fmtid, UINT pid)
 HRESULT
 SHELL_MapSCIDToColumn(IShellFolder2 *pSF, const SHCOLUMNID *pscid);
 HRESULT
-SHELL_GetDetailsOfStringAsVariant(IShellFolder2 *pSF, PCUITEMID_CHILD pidl, UINT Column, VARIANT *pVar);
+SHELL_GetDetailsOfAsStringVariant(IShellFolder2 *pSF, PCUITEMID_CHILD pidl, UINT Column, VARIANT *pVar);
 HRESULT
 SHELL_GetDetailsOfColumnAsVariant(IShellFolder2 *pSF, PCUITEMID_CHILD pidl, UINT Column, VARTYPE vt, VARIANT *pVar);
 HRESULT

--- a/dll/win32/shell32/shlfolder.cpp
+++ b/dll/win32/shell32/shlfolder.cpp
@@ -96,7 +96,7 @@ SHELL_GetDetailsOfStringAsVariant(IShellFolder2 *pSF, PCUITEMID_CHILD pidl, UINT
 {
     V_VT(pVar) = VT_EMPTY;
     SHELLDETAILS sd;
-    sd.str.uType = STRRET_OFFSET;
+    sd.str.uType = STRRET_CSTR;
     HRESULT hr = pSF->GetDetailsOf(pidl, Column, &sd);
     if (FAILED(hr))
         return hr;
@@ -130,7 +130,7 @@ SHELL_GetDetailsOfColumnAsVariant(IShellFolder2 *pSF, PCUITEMID_CHILD pidl, UINT
 }
 
 HRESULT
-SHELL32_GetDetailsOfPKeyAsVariant(IShellFolder2 *pSF, PCUITEMID_CHILD pidl, const SHCOLUMNID *pscid, VARIANT *pVar, BOOL Direct)
+SH32_GetDetailsOfPKeyAsVariant(IShellFolder2 *pSF, PCUITEMID_CHILD pidl, const SHCOLUMNID *pscid, VARIANT *pVar, BOOL Direct)
 {
     VARTYPE vt = VT_EMPTY;
     HRESULT hr = Direct ? MapSCIDToShell32FsColumn(pscid, vt) : SHELL_MapSCIDToColumn(pSF, pscid);

--- a/dll/win32/shell32/shlfolder.cpp
+++ b/dll/win32/shell32/shlfolder.cpp
@@ -92,7 +92,7 @@ SHELL_MapSCIDToColumn(IShellFolder2 *pSF, const SHCOLUMNID *pscid)
 }
 
 HRESULT
-SHELL_GetDetailsOfStringAsVariant(IShellFolder2 *pSF, PCUITEMID_CHILD pidl, UINT Column, VARIANT *pVar)
+SHELL_GetDetailsOfAsStringVariant(IShellFolder2 *pSF, PCUITEMID_CHILD pidl, UINT Column, VARIANT *pVar)
 {
     V_VT(pVar) = VT_EMPTY;
     SHELLDETAILS sd;
@@ -109,7 +109,7 @@ SHELL_GetDetailsOfStringAsVariant(IShellFolder2 *pSF, PCUITEMID_CHILD pidl, UINT
 HRESULT
 SHELL_GetDetailsOfColumnAsVariant(IShellFolder2 *pSF, PCUITEMID_CHILD pidl, UINT Column, VARTYPE vt, VARIANT *pVar)
 {
-    HRESULT hr = SHELL_GetDetailsOfStringAsVariant(pSF, pidl, Column, pVar);
+    HRESULT hr = SHELL_GetDetailsOfAsStringVariant(pSF, pidl, Column, pVar);
     if (FAILED(hr))
         return hr;
     if (vt == VT_EMPTY)

--- a/dll/win32/shell32/shlfolder.cpp
+++ b/dll/win32/shell32/shlfolder.cpp
@@ -61,11 +61,11 @@ MapSCIDToShell32FsColumn(const SHCOLUMNID *pscid, VARTYPE &vt)
     {
         switch (pscid->pid)
         {
-            case PID_STG_NAME:        return (vt = VT_BSTR, SHFSF_COL_NAME);
-            case PID_STG_SIZE:        return (vt = VT_UI8, SHFSF_COL_SIZE);
-            case PID_STG_STORAGETYPE: return (vt = VT_BSTR, SHFSF_COL_TYPE);
-            case PID_STG_ATTRIBUTES:  return (vt = VT_BSTR, SHFSF_COL_FATTS);
-            case PID_STG_WRITETIME:   return (vt = VT_DATE, SHFSF_COL_MDATE);
+            case PID_STG_NAME:        vt = VT_BSTR; return SHFSF_COL_NAME;
+            case PID_STG_SIZE:        vt = VT_UI8; return SHFSF_COL_SIZE;
+            case PID_STG_STORAGETYPE: vt = VT_BSTR; return SHFSF_COL_TYPE;
+            case PID_STG_ATTRIBUTES:  vt = VT_BSTR; return SHFSF_COL_FATTS;
+            case PID_STG_WRITETIME:   vt = VT_DATE; return SHFSF_COL_MDATE;
         }
     }
     if (pscid->fmtid == FMTID_SummaryInformation && pscid->pid == PIDSI_COMMENTS)
@@ -130,10 +130,12 @@ SHELL_GetDetailsOfColumnAsVariant(IShellFolder2 *pSF, PCUITEMID_CHILD pidl, UINT
 }
 
 HRESULT
-SH32_GetDetailsOfPKeyAsVariant(IShellFolder2 *pSF, PCUITEMID_CHILD pidl, const SHCOLUMNID *pscid, VARIANT *pVar, BOOL Direct)
+SH32_GetDetailsOfPKeyAsVariant(IShellFolder2 *pSF, PCUITEMID_CHILD pidl, const SHCOLUMNID *pscid, VARIANT *pVar, BOOL UseFsColMap)
 {
+    // CFSFolder and CRegFolder uses the SHFSF_COL columns and can use the faster and better version,
+    // everyone else must ask the folder to map the SCID to a column.
     VARTYPE vt = VT_EMPTY;
-    HRESULT hr = Direct ? MapSCIDToShell32FsColumn(pscid, vt) : SHELL_MapSCIDToColumn(pSF, pscid);
+    HRESULT hr = UseFsColMap ? MapSCIDToShell32FsColumn(pscid, vt) : SHELL_MapSCIDToColumn(pSF, pscid);
     return SUCCEEDED(hr) ? SHELL_GetDetailsOfColumnAsVariant(pSF, pidl, hr, vt, pVar) : hr;
 }
 

--- a/dll/win32/shell32/wine/pidl.c
+++ b/dll/win32/shell32/wine/pidl.c
@@ -1254,6 +1254,33 @@ LPITEMIDLIST WINAPI SHSimpleIDListFromPathAW(LPCVOID lpszPath)
     return SHSimpleIDListFromPathA (lpszPath);
 }
 
+static HRESULT GetShellFolder2ItemDetailsExToBuffer(IShellFolder2 *psf2, LPCITEMIDLIST pidl,
+                                                    const SHCOLUMNID *pscid, void*buf, UINT cb)
+{
+    VARIANT var;
+    V_VT(&var) = VT_EMPTY;
+    HRESULT hr = IShellFolder2_GetDetailsEx(psf2, pidl, pscid, &var);
+    if (SUCCEEDED(hr))
+    {
+        hr = SHELL_VariantToBuffer(&var, buf, cb);
+        VariantClear(&var);
+    }
+    return hr;
+}
+
+static HRESULT GetShellFolder1ItemDetailsExToBuffer(LPSHELLFOLDER psf, LPCITEMIDLIST pidl,
+                                                    const SHCOLUMNID *pscid, void*buf, UINT cb)
+{
+    IShellFolder2 *psf2;
+    HRESULT hr = IShellFolder_QueryInterface(psf, &IID_IShellFolder2, (void**)&psf2);
+    if (SUCCEEDED(hr))
+    {
+        hr = GetShellFolder2ItemDetailsExToBuffer(psf2, pidl, pscid, buf, cb);
+        IShellFolder2_Release(psf2);
+    }
+    return hr;
+}
+
 /*************************************************************************
  * SHGetDataFromIDListA [SHELL32.247]
  *
@@ -1303,8 +1330,10 @@ HRESULT WINAPI SHGetDataFromIDListA(LPSHELLFOLDER psf, LPCITEMIDLIST pidl,
             pfd->cAlternateFileName[0] = '\0';
         return S_OK;
 
-    case SHGDFIL_NETRESOURCE:
     case SHGDFIL_DESCRIPTIONID:
+        return SHGetDataFromIDListW(psf, pidl, nFormat, dest, len);
+
+    case SHGDFIL_NETRESOURCE:
         FIXME_(shell)("SHGDFIL %i stub\n", nFormat);
         break;
 
@@ -1334,7 +1363,7 @@ HRESULT WINAPI SHGetDataFromIDListW(LPSHELLFOLDER psf, LPCITEMIDLIST pidl,
 
     switch (nFormat)
     {
-    case SHGDFIL_FINDDATA:
+    case SHGDFIL_FINDDATA: /* FIXME: Ask the folder for PID_FINDDATA */
         pfd = dest;
 
         if (_ILIsDrive(pidl))
@@ -1362,8 +1391,14 @@ HRESULT WINAPI SHGetDataFromIDListW(LPSHELLFOLDER psf, LPCITEMIDLIST pidl,
             pfd->cAlternateFileName[13] = 0;
         return S_OK;
 
-    case SHGDFIL_NETRESOURCE:
     case SHGDFIL_DESCRIPTIONID:
+        {
+            /* TODO: Use PKEY_DescriptionID when the propsys headers are ready */
+            SHCOLUMNID scid = { FMTID_ShellDetails, PID_DESCRIPTIONID };
+            return GetShellFolder1ItemDetailsExToBuffer(psf, pidl, &scid, dest, len);
+        }
+
+    case SHGDFIL_NETRESOURCE:
         FIXME_(shell)("SHGDFIL %i stub\n", nFormat);
         break;
 

--- a/dll/win32/shell32/wine/pidl.c
+++ b/dll/win32/shell32/wine/pidl.c
@@ -1392,11 +1392,11 @@ HRESULT WINAPI SHGetDataFromIDListW(LPSHELLFOLDER psf, LPCITEMIDLIST pidl,
         return S_OK;
 
     case SHGDFIL_DESCRIPTIONID:
-        {
-            /* TODO: Use PKEY_DescriptionID when the propsys headers are ready */
-            SHCOLUMNID scid = { FMTID_ShellDetails, PID_DESCRIPTIONID };
-            return GetShellFolder1ItemDetailsExToBuffer(psf, pidl, &scid, dest, len);
-        }
+    {
+        /* TODO: Use PKEY_DescriptionID when the propsys headers are ready */
+        SHCOLUMNID scid = { FMTID_ShellDetails, PID_DESCRIPTIONID };
+        return GetShellFolder1ItemDetailsExToBuffer(psf, pidl, &scid, dest, len);
+    }
 
     case SHGDFIL_NETRESOURCE:
         FIXME_(shell)("SHGDFIL %i stub\n", nFormat);

--- a/dll/win32/shell32/wine/shell32_main.h
+++ b/dll/win32/shell32/wine/shell32_main.h
@@ -215,6 +215,73 @@ LPWSTR SH_FormatFileSizeWithBytes(PULARGE_INTEGER lpQwSize, LPWSTR pszBuf, UINT 
 HRESULT WINAPI DoRegisterServer(void);
 HRESULT WINAPI DoUnregisterServer(void);
 
+/* Property system */
+static inline HRESULT
+SHELL_CreateVariantBufferEx(VARIANT *pVar, UINT cb, VARTYPE vt)
+{
+    SAFEARRAY *pSA = SafeArrayCreateVector(vt, 0, cb);
+    if (pSA)
+    {
+        V_VT(pVar) = VT_ARRAY | vt;
+        V_ARRAY(pVar) = pSA;
+        return S_OK;
+    }
+    return E_OUTOFMEMORY;
+}
+
+static inline HRESULT
+SHELL_CreateVariantBuffer(VARIANT *pVar, UINT cb)
+{
+    return SHELL_CreateVariantBufferEx(pVar, cb, VT_UI1);
+}
+
+static inline HRESULT
+SHELL_InitVariantFromBuffer(VARIANT *pVar, const void *pData, UINT cb)
+{
+    HRESULT hr = SHELL_CreateVariantBuffer(pVar, cb);
+    if (SUCCEEDED(hr))
+        CopyMemory(V_ARRAY(pVar)->pvData, pData, cb);
+    return hr;
+}
+
+static inline void*
+SHELL_GetSafeArrayDataPtr(const SAFEARRAY *pSA, SIZE_T *pcb)
+{
+    if (pSA->cDims != 1)
+        return NULL;
+    LONG lob, upb;
+    SafeArrayGetLBound((SAFEARRAY*)pSA, 1, &lob);
+    SafeArrayGetUBound((SAFEARRAY*)pSA, 1, &upb);
+    *pcb = ((SIZE_T)upb - (SIZE_T)lob) + 1;
+    return pSA->pvData;
+}
+
+static inline HRESULT
+SHELL_VariantToBuffer(VARIANT *pVar, void *pData, SIZE_T cb)
+{
+    if (V_VT(pVar) != (VT_ARRAY | VT_UI1))
+        return E_INVALIDARG;
+    SIZE_T cbArr;
+    void *pArrData = SHELL_GetSafeArrayDataPtr(V_ARRAY(pVar), &cbArr);
+    if (!pArrData || cbArr < cb)
+        return E_FAIL;
+    CopyMemory(pData, pArrData, cb);
+    return (cbArr > cb) ? S_FALSE : S_OK;
+}
+
+static inline HRESULT
+SHELL_CreateSHDESCRIPTIONID(VARIANT *pVar, DWORD Id, const CLSID *pCLSID)
+{
+    HRESULT hr = SHELL_CreateVariantBuffer(pVar, sizeof(SHDESCRIPTIONID));
+    if (SUCCEEDED(hr))
+    {
+        SHDESCRIPTIONID *pDID = (SHDESCRIPTIONID*)V_ARRAY(pVar)->pvData;
+        pDID->dwDescriptionId = Id;
+        pDID->clsid = *pCLSID;
+    }
+    return hr;
+}
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/dll/win32/shell32/wine/shell32_main.h
+++ b/dll/win32/shell32/wine/shell32_main.h
@@ -252,7 +252,7 @@ SHELL_GetSafeArrayDataPtr(const SAFEARRAY *pSA, SIZE_T *pcb)
     LONG lob, upb;
     SafeArrayGetLBound((SAFEARRAY*)pSA, 1, &lob);
     SafeArrayGetUBound((SAFEARRAY*)pSA, 1, &upb);
-    *pcb = ((SIZE_T)upb - (SIZE_T)lob) + 1;
+    *pcb = (SIZE_T)(upb - lob) + 1;
     return pSA->pvData;
 }
 

--- a/sdk/include/reactos/shellutils.h
+++ b/sdk/include/reactos/shellutils.h
@@ -474,6 +474,13 @@ template<class B, class R> static HRESULT SHILCombine(B base, PCUIDLIST_RELATIVE
 static inline bool StrIsNullOrEmpty(LPCSTR str) { return !str || !*str; }
 static inline bool StrIsNullOrEmpty(LPCWSTR str) { return !str || !*str; }
 
+HRESULT inline SHSetStrRetEmpty(LPSTRRET pStrRet)
+{
+    pStrRet->uType = STRRET_CSTR;
+    pStrRet->cStr[0] = '\0';
+    return S_OK;
+}
+
 HRESULT inline SHSetStrRet(LPSTRRET pStrRet, LPCSTR pstrValue)
 {
     pStrRet->uType = STRRET_CSTR;


### PR DESCRIPTION
Notes:
 - Handling `PKEY_DescriptionID`/`SHGDFIL_DESCRIPTIONID` fixes the Desktop icons page in Tweak UI v2.
 - Lays the foundation for fixing the official way to [detect the Recycle Bin](https://devblogs.microsoft.com/oldnewthing/20080918-00/?p=20843).
 - Pre-emptive comment about the "switch case return" on one line style; keep in mind that Windows XP supports more than 50 columns here, modern Windows even more!
 - The Init/FromBuffer functions are modeled after functions with the same names in propsys.dll but we can't use that directly here since it's Vista+. Once propsys is working properly, shell32 can switch to those functions when targeting NT6+.


## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: