### PR TITLE
[RICHED20] Fix RTC MSVC Failure in function ME_GetTextW.

### DIFF
--- a/dll/win32/riched20/editor.c
+++ b/dll/win32/riched20/editor.c
@@ -4357,7 +4357,11 @@ int ME_GetTextW(ME_TextEditor *editor, WCHAR *buffer, int buflen,
     str = get_text( run, 0 );
   }
   /* append '\r' to the last paragraph. */
+#ifdef __REACTOS__
   if (run == para_end_run( para_prev( editor_end_para( editor ) ) ) && bEOP && buflen)
+#else
+  if (run == para_end_run( para_prev( editor_end_para( editor ) ) ) && bEOP)
+#endif
   {
     *buffer = '\r';
     buffer ++;

--- a/dll/win32/riched20/editor.c
+++ b/dll/win32/riched20/editor.c
@@ -4357,7 +4357,7 @@ int ME_GetTextW(ME_TextEditor *editor, WCHAR *buffer, int buflen,
     str = get_text( run, 0 );
   }
   /* append '\r' to the last paragraph. */
-  if (run == para_end_run( para_prev( editor_end_para( editor ) ) ) && bEOP)
+  if (run == para_end_run( para_prev( editor_end_para( editor ) ) ) && bEOP && buflen)
   {
     *buffer = '\r';
     buffer ++;


### PR DESCRIPTION
## Purpose

_Import Wine commit: https://gitlab.winehq.org/wine/wine/-/commit/5cbe3a6cb186cffed20e3fea5f88abd0880d3914._
_Thanks to @tkreuzer for pointing me to the correctly failing function._

JIRA issue: [CORE-20082](https://jira.reactos.org/browse/CORE-20082)

## Proposed changes

_Condition adding '\r' and incrementing buffer on 'buflen' not being zero._

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: