### PR TITLE
[USER32] Fix use of uninitialized variable

### DIFF
--- a/win32ss/user/user32/windows/cursoricon.c
+++ b/win32ss/user/user32/windows/cursoricon.c
@@ -1622,7 +1622,7 @@ CURSORICON_LoadFromFileW(
     DWORD filesize = 0, BmpIconSize;
     PBYTE bits, pbBmpIcon = NULL;
     HANDLE hCurIcon = NULL;
-    CURSORDATA cursorData;
+    CURSORDATA cursorData = { 0 };
 
     TRACE("loading %s\n", debugstr_w( lpszName ));
 
@@ -1646,7 +1646,6 @@ CURSORICON_LoadFromFileW(
     if(!cxDesired) cxDesired = entry->bWidth;
     if(!cyDesired) cyDesired = entry->bHeight;
     /* A bit of preparation */
-    ZeroMemory(&cursorData, sizeof(cursorData));
     if(!bIcon)
     {
         cursorData.xHotspot = entry->xHotspot;


### PR DESCRIPTION
## Purpose

Fix use of uninitialized variable

## Testbot runs (Filled in by Devs)

- KVM x86: https://reactos.org/testman/compare.php?ids=101440,101443,101446,101449
- KVM x64: https://reactos.org/testman/compare.php?ids=101441,101444,101447,101450