### PR TITLE
[NTOS] Fix MSVC warnings

### DIFF
--- a/ntoskrnl/io/iomgr/deviface.c
+++ b/ntoskrnl/io/iomgr/deviface.c
@@ -824,13 +824,13 @@ IoGetDeviceInterfaceAlias(
     DeviceString.MaximumLength = DeviceString.Length;
     DeviceString.Buffer = Buffer;
 
-    /* 
+    /*
      * Separate symbolic link into 4 parts:
      * 1) prefix string (\??\ for kernel mode or \\?\ for user mode),
      * 2) munged path string (like ##?#ACPI#PNP0501#1#{GUID}),
      * 3) GUID string (the current GUID),
      * 4) reference string (goes after GUID, starts with '\').
-     * 
+     *
      * We need only reference string.
      */
     Status = IopSeparateSymbolicLink(SymbolicLinkName,
@@ -1905,7 +1905,7 @@ IoSetDeviceInterfaceState(IN PUNICODE_STRING SymbolicLinkName,
     }
 
     ASSERT(GuidString.Buffer >= LinkNameNoPrefix.Buffer + 1);
-    DeviceInstance.Length = (GuidString.Buffer - LinkNameNoPrefix.Buffer - 1) * sizeof(WCHAR);
+    DeviceInstance.Length = (USHORT)((GuidString.Buffer - LinkNameNoPrefix.Buffer - 1) * sizeof(WCHAR));
     if (DeviceInstance.Length == 0)
     {
         DPRINT1("No device instance in link name '%wZ'\n", SymbolicLinkName);

--- a/ntoskrnl/io/iomgr/driver.c
+++ b/ntoskrnl/io/iomgr/driver.c
@@ -5,7 +5,7 @@
  * PURPOSE:         Driver Object Management
  * PROGRAMMERS:     Alex Ionescu (alex.ionescu@reactos.org)
  *                  Filip Navara (navaraf@reactos.org)
- *                  Hervé Poussineau (hpoussin@reactos.org)
+ *                  HervÃ© Poussineau (hpoussin@reactos.org)
  */
 
 /* INCLUDES *******************************************************************/
@@ -136,13 +136,19 @@ IopGetDriverNames(
     if (NT_SUCCESS(status))
     {
         /* We've got the ObjectName, use it as the driver name */
-        if (kvInfo->Type != REG_SZ || kvInfo->DataLength == 0)
+        if ((kvInfo->Type != REG_SZ) ||
+            (kvInfo->DataLength < sizeof(UNICODE_NULL)) ||
+            (kvInfo->DataLength > UNICODE_STRING_MAX_BYTES) ||
+            ((kvInfo->DataLength % sizeof(WCHAR)) != 0))
         {
+            DPRINT1("ObjectName invalid (Type = %lu, DataLength = %lu)\n",
+                    kvInfo->Type,
+                    kvInfo->DataLength);
             ExFreePool(kvInfo);
             return STATUS_ILL_FORMED_SERVICE_ENTRY;
         }
 
-        driverName.Length = kvInfo->DataLength - sizeof(UNICODE_NULL);
+        driverName.Length = (USHORT)(kvInfo->DataLength - sizeof(UNICODE_NULL));
         driverName.MaximumLength = kvInfo->DataLength;
         driverName.Buffer = ExAllocatePoolWithTag(NonPagedPool, driverName.MaximumLength, TAG_IO);
         if (!driverName.Buffer)
@@ -963,13 +969,19 @@ IopInitializeBuiltinDriver(IN PLDR_DATA_TABLE_ENTRY BootLdrEntry)
             {
                 continue;
             }
-            if (kvInfo->Type != REG_SZ || kvInfo->DataLength == 0)
+            if ((kvInfo->Type != REG_SZ) ||
+                (kvInfo->DataLength < sizeof(UNICODE_NULL)) ||
+                (kvInfo->DataLength > UNICODE_STRING_MAX_BYTES) ||
+                ((kvInfo->DataLength % sizeof(WCHAR)) != 0))
             {
+                DPRINT1("ObjectName invalid (Type = %lu, DataLength = %lu)\n",
+                        kvInfo->Type,
+                        kvInfo->DataLength);
                 ExFreePool(kvInfo);
                 continue;
             }
 
-            instancePath.Length = kvInfo->DataLength - sizeof(UNICODE_NULL);
+            instancePath.Length = (USHORT)(kvInfo->DataLength - sizeof(UNICODE_NULL));
             instancePath.MaximumLength = kvInfo->DataLength;
             instancePath.Buffer = ExAllocatePoolWithTag(NonPagedPool,
                                                         instancePath.MaximumLength,
@@ -1948,13 +1960,19 @@ IopLoadDriver(
     Status = IopGetRegistryValue(ServiceHandle, L"ImagePath", &kvInfo);
     if (NT_SUCCESS(Status))
     {
-        if ((kvInfo->Type != REG_EXPAND_SZ && kvInfo->Type != REG_SZ) || kvInfo->DataLength == 0)
+        if ((kvInfo->Type != REG_EXPAND_SZ && kvInfo->Type != REG_SZ) ||
+            (kvInfo->DataLength < sizeof(UNICODE_NULL)) ||
+            (kvInfo->DataLength > UNICODE_STRING_MAX_BYTES) ||
+            ((kvInfo->DataLength % sizeof(WCHAR)) != 0))
         {
+            DPRINT1("ObjectName invalid (Type = %lu, DataLength = %lu)\n",
+                    kvInfo->Type,
+                    kvInfo->DataLength);
             ExFreePool(kvInfo);
             return STATUS_ILL_FORMED_SERVICE_ENTRY;
         }
 
-        ImagePath.Length = kvInfo->DataLength - sizeof(UNICODE_NULL);
+        ImagePath.Length = (USHORT)(kvInfo->DataLength - sizeof(UNICODE_NULL));
         ImagePath.MaximumLength = kvInfo->DataLength;
         ImagePath.Buffer = ExAllocatePoolWithTag(PagedPool, ImagePath.MaximumLength, TAG_RTLREGISTRY);
         if (!ImagePath.Buffer)

--- a/ntoskrnl/ob/oblink.c
+++ b/ntoskrnl/ob/oblink.c
@@ -442,7 +442,7 @@ ObpParseSymbolicLink(IN PVOID ParsedObject,
     POBJECT_SYMBOLIC_LINK SymlinkObject = (POBJECT_SYMBOLIC_LINK)ParsedObject;
     PUNICODE_STRING TargetPath;
     PWSTR NewTargetPath;
-    ULONG LengthUsed, MaximumLength, TempLength;
+    SIZE_T LengthUsed, MaximumLength, TempLength;
     NTSTATUS Status;
     PAGED_CODE();
 


### PR DESCRIPTION
## Purpose

Fix MSVC warnings. Be strict about string length to prevent overflows.

## Testbot runs (Filled in by Devs)

- ❔ KVM x86: https://reactos.org/testman/compare.php?ids=101470,101477,101483,101502
- ❔ KVM x64: https://reactos.org/testman/compare.php?ids=101478,101479,101484,101503
Possible regression in urlmon:protocol. Needs investigation

Retest:
- ✅ KVM x86: https://reactos.org/testman/compare.php?ids=101558,101560,101562,101564
- ✅ KVM x64: https://reactos.org/testman/compare.php?ids=101561,101563,101565,101566
