### PR TITLE
[NOTEPAD] Don't get handle before ReadText

### DIFF
--- a/base/applications/notepad/dialog.c
+++ b/base/applications/notepad/dialog.c
@@ -360,7 +360,7 @@ VOID DoOpenFile(LPCTSTR szFileName)
     }
 
     /* To make loading file quicker, we use the internal handle of EDIT control */
-    hLocal = (HLOCAL)SendMessageW(Globals.hEdit, EM_GETHANDLE, 0, 0);
+    hLocal = LocalAlloc(LHND, sizeof(UNICODE_NULL));
     if (!ReadText(hFile, &hLocal, &Globals.encFile, &Globals.iEoln))
     {
         ShowLastError();


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-18944](https://jira.reactos.org/browse/CORE-18944)

## Proposed changes

- Don't send `EM_GETHANDLE` message before `ReadText` call.