### PR TITLE
[WIN32KNT_APITEST][NTUSER] Fix NtUserCreateAcceleratorTable memory corruption

### DIFF
--- a/modules/rostests/apitests/win32nt/CMakeLists.txt
+++ b/modules/rostests/apitests/win32nt/CMakeLists.txt
@@ -48,6 +48,7 @@ list(APPEND SOURCE
 #    ntuser/NtUserCallNoParam.c
 #    ntuser/NtUserCallOneParam.c
     ntuser/NtUserCountClipboardFormats.c
+    ntuser/NtUserCreateAcceleratorTable.c
     ntuser/NtUserCreateWindowEx.c
 #    ntuser/NtUserEnumDisplayMonitors.c
     ntuser/NtUserEnumDisplaySettings.c

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserCreateAcceleratorTable.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserCreateAcceleratorTable.c
@@ -1,0 +1,32 @@
+/*
+ * PROJECT:     ReactOS api tests
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Test for NtUserCreateAcceleratorTable
+ * COPYRIGHT:   Copyright 2025 Max Korostil (mrmks04@yandex.ru)
+ */
+
+#include "../win32nt.h"
+
+
+START_TEST(NtUserCreateAcceleratorTable)
+{
+    HACCEL hAccel;
+    ACCEL Entries[5];
+    ULONG EntriesCount = 0x80000005;
+
+    hAccel = NtUserCreateAcceleratorTable(Entries, EntriesCount);
+    ok_hdl(hAccel, NULL);
+
+    hAccel = NtUserCreateAcceleratorTable(NULL, EntriesCount);
+    ok_hdl(hAccel, NULL);
+
+    hAccel = NtUserCreateAcceleratorTable(Entries, 0);
+    ok_hdl(hAccel, NULL);
+
+    EntriesCount = ARRAYSIZE(Entries);
+    hAccel = NtUserCreateAcceleratorTable((LPACCEL)(ULONG_PTR)0xC0FEC0FE, EntriesCount);
+    ok_hdl(hAccel, NULL);
+
+    hAccel = NtUserCreateAcceleratorTable(Entries, EntriesCount);
+    ok(hAccel != NULL, "hAccel is NULL\n");
+}

--- a/modules/rostests/apitests/win32nt/testlist.c
+++ b/modules/rostests/apitests/win32nt/testlist.c
@@ -48,6 +48,7 @@ extern void func_NtGdiTransformPoints(void);
 //extern void func_NtUserCallNoParam(void);
 //extern void func_NtUserCallOneParam(void);
 extern void func_NtUserCountClipboardFormats(void);
+extern void func_NtUserCreateAcceleratorTable(void);
 extern void func_NtUserCreateWindowEx(void);
 //extern void func_NtUserEnumDisplayMonitors(void);
 extern void func_NtUserEnumDisplaySettings(void);
@@ -117,6 +118,7 @@ const struct test winetest_testlist[] =
     //{ "NtUserCallNoParam", func_NtUserCallNoParam },
     //{ "NtUserCallOneParam", func_NtUserCallOneParam },
     { "NtUserCountClipboardFormats", func_NtUserCountClipboardFormats },
+    { "NtUserCreateAcceleratorTable", func_NtUserCreateAcceleratorTable },
     { "NtUserCreateWindowEx", func_NtUserCreateWindowEx },
     //{ "NtUserEnumDisplayMonitors", func_NtUserEnumDisplayMonitors },
     { "NtUserEnumDisplaySettings", func_NtUserEnumDisplaySettings },

--- a/win32ss/user/ntuser/accelerator.c
+++ b/win32ss/user/ntuser/accelerator.c
@@ -237,7 +237,8 @@ NtUserCreateAcceleratorTable(
           Entries, EntriesCount);
     UserEnterExclusive();
 
-    if (!Entries || EntriesCount <= 0)
+    if (!Entries || !EntriesCount ||
+        EntriesCount > (MAXULONG_PTR / sizeof(ACCEL)))
     {
         SetLastNtError(STATUS_INVALID_PARAMETER);
         goto Exit; // Return NULL


### PR DESCRIPTION
Fix NtUserCreateAcceleratorTable memory corruption.
Сaused by overflow in calculating required memory.


JIRA issue: [CORE-18122](https://jira.reactos.org/browse/CORE-18122)

