### PR TITLE
[NTOS:KD:KDBG] Fix KdMax value without debugger 

### DIFF
--- a/ntoskrnl/kd/kd.h
+++ b/ntoskrnl/kd/kd.h
@@ -83,10 +83,10 @@ KdpDebugLogInit(
 #define DEFAULT_DEBUG_BAUD_RATE 115200 /* 115200 Baud */
 
 /* KD Native Modes */
-#define KdScreen    0
-#define KdSerial    1
-#define KdFile      2
-#define KdKdbg      3
+// #define KdScreen    0
+// #define KdSerial    1
+// #define KdFile      2
+// #define KdKdbg      3
 #define KdMax       4
 
 /* KD Private Debug Modes */

--- a/ntoskrnl/kd/kd.h
+++ b/ntoskrnl/kd/kd.h
@@ -86,8 +86,12 @@ KdpDebugLogInit(
 // #define KdScreen    0
 // #define KdSerial    1
 // #define KdFile      2
+#ifndef KDBG
+#define KdMax       3
+#else
 // #define KdKdbg      3
 #define KdMax       4
+#endif
 
 /* KD Private Debug Modes */
 typedef struct _KDP_DEBUG_MODE


### PR DESCRIPTION
## Purpose

Avoid `NULL` in `InitRoutines[KdMax]`.

JIRA issue: [CORE-20107](https://jira.reactos.org/browse/CORE-20107)

## Proposed changes

- Comment defines related to KdMax out
- Fix KdMax value without debugger