### PR TITLE
[IMM32] Make IMM32 non-Wine module

### DIFF
--- a/dll/win32/imm32/CMakeLists.txt
+++ b/dll/win32/imm32/CMakeLists.txt
@@ -22,29 +22,11 @@ list(APPEND SOURCE
     ${CMAKE_CURRENT_BINARY_DIR}/imm32_stubs.c
     ${CMAKE_CURRENT_BINARY_DIR}/imm32.def)
 
-list(APPEND imm32_rc_deps
-    ${CMAKE_CURRENT_SOURCE_DIR}/res/1033_Bitmap_100.bmp
-    ${CMAKE_CURRENT_SOURCE_DIR}/res/1033_Bitmap_101.bmp
-    ${CMAKE_CURRENT_SOURCE_DIR}/res/1033_Bitmap_102.bmp
-    ${CMAKE_CURRENT_SOURCE_DIR}/res/1033_Bitmap_103.bmp
-    ${CMAKE_CURRENT_SOURCE_DIR}/res/1033_Bitmap_104.bmp
-    ${CMAKE_CURRENT_SOURCE_DIR}/res/1033_Bitmap_105.bmp
-    ${CMAKE_CURRENT_SOURCE_DIR}/res/1033_Bitmap_106.bmp
-    ${CMAKE_CURRENT_SOURCE_DIR}/res/1033_Bitmap_107.bmp
-    ${CMAKE_CURRENT_SOURCE_DIR}/res/1033_Bitmap_108.bmp
-    ${CMAKE_CURRENT_SOURCE_DIR}/res/2052_Bitmap_201.bmp
-    ${CMAKE_CURRENT_SOURCE_DIR}/res/2052_Bitmap_202.bmp
-    ${CMAKE_CURRENT_SOURCE_DIR}/res/2052_Bitmap_203.bmp
-    ${CMAKE_CURRENT_SOURCE_DIR}/res/2052_Bitmap_204.bmp
-    ${CMAKE_CURRENT_SOURCE_DIR}/res/2052_Bitmap_205.bmp
-    ${CMAKE_CURRENT_SOURCE_DIR}/res/2052_Bitmap_206.bmp
-    ${CMAKE_CURRENT_SOURCE_DIR}/res/2052_Bitmap_207.bmp
-    ${CMAKE_CURRENT_SOURCE_DIR}/res/2052_Bitmap_208.bmp
-    ${CMAKE_CURRENT_SOURCE_DIR}/res/2052_Bitmap_209.bmp)
+file(GLOB imm32_rc_deps ${CMAKE_CURRENT_SOURCE_DIR}/res/*.*)
+add_rc_deps(imm32.rc ${imm32_rc_deps})
 
 add_library(imm32 MODULE ${SOURCE} imm32.rc)
 set_module_type(imm32 win32dll UNICODE ENTRYPOINT ImmDllInitialize 12)
-set_source_files_properties(imm32.rc PROPERTIES OBJECT_DEPENDS "${imm32_rc_deps}")
 target_link_libraries(imm32 wine win32ksys uuid)
 add_importlibs(imm32 advapi32 user32 gdi32 kernel32 ntdll)
 add_cd_file(TARGET imm32 DESTINATION reactos/system32 FOR all)

--- a/dll/win32/imm32/ctf.c
+++ b/dll/win32/imm32/ctf.c
@@ -308,7 +308,7 @@ Imm32AllocateTLS(VOID)
     if (IS_NULL_UNEXPECTEDLY(pData))
         return NULL;
 
-    if (IS_FALSE_UNEXPECTEDLY(TlsSetValue(g_dwTLSIndex, pData)))
+    if (IS_ZERO_UNEXPECTEDLY(TlsSetValue(g_dwTLSIndex, pData)))
     {
         ImmLocalFree(pData);
         return NULL;

--- a/dll/win32/imm32/debug.h
+++ b/dll/win32/imm32/debug.h
@@ -1,0 +1,91 @@
+/*
+ * PROJECT:     ReactOS IMM32
+ * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
+ * PURPOSE:     Debugging IMM32
+ * COPYRIGHT:   Copyright 2025 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ */
+
+#pragma once
+
+typedef enum tagDEBUGCHANNEL
+{
+    DbgChimm = 0,
+} DEBUGCHANNEL;
+
+#if DBG
+    #ifndef __RELFILE__
+        #define __RELFILE__ __FILE__
+    #endif
+
+    #define ERR_LEVEL   0x1
+    #define TRACE_LEVEL 0x8
+
+    #define WINE_DEFAULT_DEBUG_CHANNEL(x) static int DbgDefaultChannel = DbgCh##x;
+    #define DBG_IS_CHANNEL_ENABLED(ch) Imm32IsDebugChannelEnabled(ch)
+
+    #define DBG_PRINT(ch, level, tag, fmt, ...) (void)( \
+        (((level) == ERR_LEVEL) || DBG_IS_CHANNEL_ENABLED(ch)) ? \
+        (DbgPrint("(%s:%d) %s" fmt, __RELFILE__, __LINE__, (tag), ##__VA_ARGS__), FALSE) : TRUE \
+    )
+
+    #define ERR(fmt, ...)   DBG_PRINT(DbgDefaultChannel, ERR_LEVEL,   "err: ",   fmt, ##__VA_ARGS__)
+    #define WARN(fmt, ...)  DBG_PRINT(DbgDefaultChannel, ERR_LEVEL,   "warn: ",  fmt, ##__VA_ARGS__)
+    #define FIXME(fmt, ...) DBG_PRINT(DbgDefaultChannel, ERR_LEVEL,   "fixme: ", fmt, ##__VA_ARGS__)
+    #define TRACE(fmt, ...) DBG_PRINT(DbgDefaultChannel, TRACE_LEVEL, "",        fmt, ##__VA_ARGS__)
+#else
+    #define WINE_DEFAULT_DEBUG_CHANNEL(x)
+    #define DBG_IS_CHANNEL_ENABLED(ch,level)
+    #define DBG_PRINT(ch,level)
+    #define ERR(fmt, ...)
+    #define WARN(fmt, ...)
+    #define FIXME(fmt, ...)
+    #define TRACE(fmt, ...)
+#endif
+
+#if DBG
+static inline BOOL
+Imm32IsDebugChannelEnabled(DEBUGCHANNEL channel)
+{
+    CHAR szValue[MAX_PATH], *pch0, *pch;
+
+    if (!GetEnvironmentVariableA("DEBUGCHANNEL", szValue, _countof(szValue)))
+        return FALSE;
+
+    for (pch0 = szValue;; pch0 = pch + 1)
+    {
+        pch = strchr(pch0, ',');
+        if (pch)
+            *pch = ANSI_NULL;
+        if (channel == DbgChimm && _stricmp(pch0, "imm") == 0)
+            return TRUE;
+        if (!pch)
+            return FALSE;
+    }
+}
+#endif
+
+/* #define UNEXPECTED() (ASSERT(FALSE), TRUE) */
+#define UNEXPECTED() TRUE
+
+/* Unexpected Condition Checkers */
+#if DBG
+    #define FAILED_UNEXPECTEDLY(hr) \
+        (FAILED(hr) ? (ERR("FAILED(0x%08X)\n", hr), UNEXPECTED()) : FALSE)
+    #define IS_NULL_UNEXPECTEDLY(p) \
+        (!(p) ? (ERR("%s was NULL\n", #p), UNEXPECTED()) : FALSE)
+    #define IS_ZERO_UNEXPECTEDLY(p) \
+        (!(p) ? (ERR("%s was zero\n", #p), UNEXPECTED()) : FALSE)
+    #define IS_TRUE_UNEXPECTEDLY(x) \
+        ((x) ? (ERR("%s was %d\n", #x, (int)(x)), UNEXPECTED()) : FALSE)
+    #define IS_ERROR_UNEXPECTEDLY(x) \
+        ((x) != ERROR_SUCCESS ? (ERR("%s was %d\n", #x, (int)(x)), UNEXPECTED()) : FALSE)
+#else
+    #define FAILED_UNEXPECTEDLY(hr) FAILED(hr)
+    #define IS_NULL_UNEXPECTEDLY(p) (!(p))
+    #define IS_ZERO_UNEXPECTEDLY(p) (!(p))
+    #define IS_TRUE_UNEXPECTEDLY(x) (x)
+    #define IS_ERROR_UNEXPECTEDLY(x) ((x) != ERROR_SUCCESS)
+#endif
+
+#define IS_CROSS_THREAD_HIMC(hIMC)   IS_TRUE_UNEXPECTEDLY(Imm32IsCrossThreadAccess(hIMC))
+#define IS_CROSS_PROCESS_HWND(hWnd)  IS_TRUE_UNEXPECTEDLY(Imm32IsCrossProcessAccess(hWnd))

--- a/dll/win32/imm32/ime.c
+++ b/dll/win32/imm32/ime.c
@@ -208,7 +208,7 @@ BOOL APIENTRY Imm32LoadIME(PIMEINFOEX pImeInfoEx, PIMEDPI pImeDpi)
     pImeDpi->hInst = hIME = LoadLibraryW(szPath);
     if (hIME == NULL)
     {
-        ERR("LoadLibraryW(%s) failed\n", debugstr_w(szPath));
+        ERR("LoadLibraryW(%S) failed\n", szPath);
         return FALSE;
     }
 
@@ -223,7 +223,7 @@ BOOL APIENTRY Imm32LoadIME(PIMEINFOEX pImeInfoEx, PIMEDPI pImeDpi)
         fn = GetProcAddress(hIME, #name); \
         if (fn) pImeDpi->name = (FN_##name)fn; \
         else if (!(optional)) { \
-            ERR("'%s' not found in IME module '%s'.\n", #name, debugstr_w(szPath)); \
+            ERR("'%s' not found in IME module '%S'.\n", #name, szPath); \
             goto Failed; \
         } \
     } while (0);
@@ -750,7 +750,7 @@ HKL WINAPI ImmInstallIMEA(LPCSTR lpszIMEFileName, LPCSTR lpszLayoutText)
     HKL hKL = NULL;
     LPWSTR pszFileNameW = NULL, pszLayoutTextW = NULL;
 
-    TRACE("(%s, %s)\n", debugstr_a(lpszIMEFileName), debugstr_a(lpszLayoutText));
+    TRACE("(%s, %s)\n", lpszIMEFileName, lpszLayoutText);
 
     pszFileNameW = Imm32WideFromAnsi(CP_ACP, lpszIMEFileName);
     if (IS_NULL_UNEXPECTEDLY(pszFileNameW))
@@ -781,7 +781,7 @@ HKL WINAPI ImmInstallIMEW(LPCWSTR lpszIMEFileName, LPCWSTR lpszLayoutText)
     WORD wLangID;
     PREG_IME pLayouts = NULL;
 
-    TRACE("(%s, %s)\n", debugstr_w(lpszIMEFileName), debugstr_w(lpszLayoutText));
+    TRACE("(%S, %S)\n", lpszIMEFileName, lpszLayoutText);
 
     GetFullPathNameW(lpszIMEFileName, _countof(szImeFileName), szImeFileName, &pchFilePart);
     CharUpperW(szImeFileName);
@@ -1807,8 +1807,7 @@ ImmGetConversionListA(HKL hKL, HIMC hIMC, LPCSTR pSrc, LPCANDIDATELIST lpDst,
     LPCANDIDATELIST pCL = NULL;
     PIMEDPI pImeDpi;
 
-    TRACE("(%p, %p, %s, %p, %lu, 0x%lX)\n", hKL, hIMC, debugstr_a(pSrc),
-          lpDst, dwBufLen, uFlag);
+    TRACE("(%p, %p, %s, %p, %lu, 0x%lX)\n", hKL, hIMC, pSrc, lpDst, dwBufLen, uFlag);
 
     pImeDpi = Imm32FindOrLoadImeDpi(hKL);
     if (IS_NULL_UNEXPECTEDLY(pImeDpi))
@@ -1863,8 +1862,7 @@ ImmGetConversionListW(HKL hKL, HIMC hIMC, LPCWSTR pSrc, LPCANDIDATELIST lpDst,
     LPCANDIDATELIST pCL = NULL;
     LPSTR pszSrcA = NULL;
 
-    TRACE("(%p, %p, %s, %p, %lu, 0x%lX)\n", hKL, hIMC, debugstr_w(pSrc),
-          lpDst, dwBufLen, uFlag);
+    TRACE("(%p, %p, %S, %p, %lu, 0x%lX)\n", hKL, hIMC, pSrc, lpDst, dwBufLen, uFlag);
 
     pImeDpi = Imm32FindOrLoadImeDpi(hKL);
     if (IS_NULL_UNEXPECTEDLY(pImeDpi))

--- a/dll/win32/imm32/precomp.h
+++ b/dll/win32/imm32/precomp.h
@@ -44,8 +44,7 @@
 
 #include <strsafe.h>
 
-#include <wine/debug.h>
-#include <wine/list.h>
+#include "debug.h"
 
 #define IMM_INIT_MAGIC          0x19650412
 #define IMM_INVALID_CANDFORM    ULONG_MAX
@@ -100,53 +99,6 @@ BOOL APIENTRY Imm32IsCrossThreadAccess(HIMC hIMC);
 BOOL APIENTRY Imm32IsCrossProcessAccess(HWND hWnd);
 BOOL WINAPI Imm32IsImcAnsi(HIMC hIMC);
 
-#if 0
-    #define UNEXPECTED() ASSERT(FALSE)
-#else
-    #define UNEXPECTED() 0
-#endif
-
-/*
- * Unexpected Condition Checkers
- * --- Examine the condition, and then generate trace log if necessary.
- */
-#ifdef NDEBUG /* on Release */
-#define FAILED_UNEXPECTEDLY(hr) (FAILED(hr))
-#define IS_NULL_UNEXPECTEDLY(p) (!(p))
-#define IS_ZERO_UNEXPECTEDLY(p) (!(p))
-#define IS_TRUE_UNEXPECTEDLY(x) (x)
-#define IS_FALSE_UNEXPECTEDLY(x) (!(x))
-#define IS_ERROR_UNEXPECTEDLY(x) (!(x))
-#else /* on Debug */
-#define FAILED_UNEXPECTEDLY(hr) \
-    (FAILED(hr) ? (ros_dbg_log(__WINE_DBCL_ERR, __wine_dbch___default, \
-                   __FILE__, __FUNCTION__, __LINE__, "FAILED(%s)\n", #hr), UNEXPECTED(), TRUE) \
-                : FALSE)
-#define IS_NULL_UNEXPECTEDLY(p) \
-    (!(p) ? (ros_dbg_log(__WINE_DBCL_ERR, __wine_dbch___default, \
-                         __FILE__, __FUNCTION__, __LINE__, "%s was NULL\n", #p), UNEXPECTED(), TRUE) \
-          : FALSE)
-#define IS_ZERO_UNEXPECTEDLY(p) \
-    (!(p) ? (ros_dbg_log(__WINE_DBCL_ERR, __wine_dbch___default, \
-                         __FILE__, __FUNCTION__, __LINE__, "%s was zero\n", #p), UNEXPECTED(), TRUE) \
-          : FALSE)
-#define IS_TRUE_UNEXPECTEDLY(x) \
-    ((x) ? (ros_dbg_log(__WINE_DBCL_ERR, __wine_dbch___default, \
-                        __FILE__, __FUNCTION__, __LINE__, "%s was non-zero\n", #x), UNEXPECTED(), TRUE) \
-         : FALSE)
-#define IS_FALSE_UNEXPECTEDLY(x) \
-    ((!(x)) ? (ros_dbg_log(__WINE_DBCL_ERR, __wine_dbch___default, \
-                           __FILE__, __FUNCTION__, __LINE__, "%s was FALSE\n", #x), UNEXPECTED(), TRUE) \
-            : FALSE)
-#define IS_ERROR_UNEXPECTEDLY(x) \
-    ((x) != ERROR_SUCCESS ? (ros_dbg_log(__WINE_DBCL_ERR, __wine_dbch___default, \
-                                          __FILE__, __FUNCTION__, __LINE__, \
-                                          "%s was 0x%X\n", #x, (x)), TRUE) \
-                          : FALSE)
-#endif
-
-#define IS_CROSS_THREAD_HIMC(hIMC)     IS_TRUE_UNEXPECTEDLY(Imm32IsCrossThreadAccess(hIMC))
-#define IS_CROSS_PROCESS_HWND(hWnd)    IS_TRUE_UNEXPECTEDLY(Imm32IsCrossProcessAccess(hWnd))
 #define ImeDpi_IsUnicode(pImeDpi)      ((pImeDpi)->ImeInfo.fdwProperty & IME_PROP_UNICODE)
 
 DWORD APIENTRY

--- a/dll/win32/imm32/regword.c
+++ b/dll/win32/imm32/regword.c
@@ -101,8 +101,8 @@ ImmEnumRegisterWordA(HKL hKL, REGISTERWORDENUMPROCA lpfnEnumProc,
     ENUM_WORD_W2A EnumDataW2A;
     PIMEDPI pImeDpi;
 
-    TRACE("(%p, %p, %s, 0x%lX, %s, %p)\n", hKL, lpfnEnumProc, debugstr_a(lpszReading),
-          dwStyle, debugstr_a(lpszRegister), lpData);
+    TRACE("(%p, %p, %s, 0x%lX, %s, %p)\n", hKL, lpfnEnumProc, lpszReading,
+          dwStyle, lpszRegister, lpData);
 
     pImeDpi = Imm32FindOrLoadImeDpi(hKL);
     if (IS_NULL_UNEXPECTEDLY(pImeDpi))
@@ -158,8 +158,8 @@ ImmEnumRegisterWordW(HKL hKL, REGISTERWORDENUMPROCW lpfnEnumProc,
     ENUM_WORD_A2W EnumDataA2W;
     PIMEDPI pImeDpi;
 
-    TRACE("(%p, %p, %s, 0x%lX, %s, %p)\n", hKL, lpfnEnumProc, debugstr_w(lpszReading),
-          dwStyle, debugstr_w(lpszRegister), lpData);
+    TRACE("(%p, %p, %S, 0x%lX, %S, %p)\n", hKL, lpfnEnumProc, lpszReading,
+          dwStyle, lpszRegister, lpData);
 
     pImeDpi = Imm32FindOrLoadImeDpi(hKL);
     if (IS_NULL_UNEXPECTEDLY(pImeDpi))
@@ -330,8 +330,7 @@ ImmRegisterWordA(HKL hKL, LPCSTR lpszReading, DWORD dwStyle, LPCSTR lpszRegister
     PIMEDPI pImeDpi;
     LPWSTR pszReadingW = NULL, pszRegisterW = NULL;
 
-    TRACE("(%p, %s, 0x%lX, %s)\n", hKL, debugstr_a(lpszReading), dwStyle,
-          debugstr_a(lpszRegister));
+    TRACE("(%p, %s, 0x%lX, %s)\n", hKL, lpszReading, dwStyle, lpszRegister);
 
     pImeDpi = Imm32FindOrLoadImeDpi(hKL);
     if (IS_NULL_UNEXPECTEDLY(pImeDpi))
@@ -378,8 +377,7 @@ ImmRegisterWordW(HKL hKL, LPCWSTR lpszReading, DWORD dwStyle, LPCWSTR lpszRegist
     PIMEDPI pImeDpi;
     LPSTR pszReadingA = NULL, pszRegisterA = NULL;
 
-    TRACE("(%p, %s, 0x%lX, %s)\n", hKL, debugstr_w(lpszReading), dwStyle,
-          debugstr_w(lpszRegister));
+    TRACE("(%p, %S, 0x%lX, %S)\n", hKL, lpszReading, dwStyle, lpszRegister);
 
     pImeDpi = Imm32FindOrLoadImeDpi(hKL);
     if (IS_NULL_UNEXPECTEDLY(pImeDpi))
@@ -426,8 +424,7 @@ ImmUnregisterWordA(HKL hKL, LPCSTR lpszReading, DWORD dwStyle, LPCSTR lpszUnregi
     PIMEDPI pImeDpi;
     LPWSTR pszReadingW = NULL, pszUnregisterW = NULL;
 
-    TRACE("(%p, %s, 0x%lX, %s)\n", hKL, debugstr_a(lpszReading), dwStyle,
-          debugstr_a(lpszUnregister));
+    TRACE("(%p, %s, 0x%lX, %s)\n", hKL, lpszReading, dwStyle, lpszUnregister);
 
     pImeDpi = Imm32FindOrLoadImeDpi(hKL);
     if (IS_NULL_UNEXPECTEDLY(pImeDpi))
@@ -474,8 +471,7 @@ ImmUnregisterWordW(HKL hKL, LPCWSTR lpszReading, DWORD dwStyle, LPCWSTR lpszUnre
     PIMEDPI pImeDpi;
     LPSTR pszReadingA = NULL, pszUnregisterA = NULL;
 
-    TRACE("(%p, %s, 0x%lX, %s)\n", hKL, debugstr_w(lpszReading), dwStyle,
-          debugstr_w(lpszUnregister));
+    TRACE("(%p, %S, 0x%lX, %S)\n", hKL, lpszReading, dwStyle, lpszUnregister);
 
     pImeDpi = Imm32FindOrLoadImeDpi(hKL);
     if (IS_NULL_UNEXPECTEDLY(pImeDpi))

--- a/dll/win32/imm32/softkbd.c
+++ b/dll/win32/imm32/softkbd.c
@@ -169,7 +169,7 @@ T1_GetTextMetric(_Out_ LPTEXTMETRICW ptm)
     HFONT hFont;
     HGDIOBJ hFontOld;
     HDC hDC;
-#ifndef NDEBUG
+#if DBG
     WCHAR szFace[LF_FACESIZE];
 #endif
 
@@ -190,9 +190,9 @@ T1_GetTextMetric(_Out_ LPTEXTMETRICW ptm)
     hDC = GetDC(NULL);
     hFontOld = SelectObject(hDC, hFont);
 
-#ifndef NDEBUG
+#if DBG
     GetTextFaceW(hDC, _countof(szFace), szFace);
-    TRACE("szFace: %s\n", debugstr_w(szFace));
+    TRACE("szFace: %S\n", szFace);
 #endif
 
     GetTextMetricsW(hDC, ptm);

--- a/media/doc/WINESYNC.txt
+++ b/media/doc/WINESYNC.txt
@@ -80,7 +80,6 @@ dll/win32/iccvid              # Synced to WineStaging-4.0
 dll/win32/ieframe             # Synced to WineStaging-4.18
 dll/win32/imaadp32.acm        # Synced to WineStaging-4.0
 dll/win32/imagehlp            # Synced to WineStaging-4.18
-dll/win32/imm32               # Forked at WineStaging-4.18
 dll/win32/inetcomm            # Synced to WineStaging-4.18
 dll/win32/inetmib1            # Synced to WineStaging-4.18
 dll/win32/initpki             # Synced to WineStaging-4.18


### PR DESCRIPTION
## Purpose

Related to #7870. `IMM32` uses NDK. So, we have to remove Wine dependency.
JIRA issue: [CORE-5743](https://jira.reactos.org/browse/CORE-5743)

## Proposed changes

- Add `dll/win32/imm32/debug.h`.
- Remove Wine dependency.
- Don't use `debugstr_a` and `debugstr_w` macros.
- Update the documentation (`media/doc/WINESYNC.txt`) to reflect the removal of the Wine dependency.

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=101390,101486
- [ ] KVM x64: https://reactos.org/testman/compare.php?ids=101391