### PR TITLE
[WARNINGS] Fix MSVC warnings

### DIFF
--- a/dll/win32/browseui/basebarsite.cpp
+++ b/dll/win32/browseui/basebarsite.cpp
@@ -533,7 +533,7 @@ HRESULT STDMETHODCALLTYPE CBaseBarSite::EnumBands(UINT uBand, DWORD *pdwBandID)
 {
     REBARBANDINFO bandInfo;
 
-    if (uBand == -1ul)
+    if (uBand == UINT_MAX)
         return (HRESULT)SendMessage(RB_GETBANDCOUNT, 0, 0);
     if (pdwBandID == NULL)
         return E_INVALIDARG;

--- a/dll/win32/riched20/editor.c
+++ b/dll/win32/riched20/editor.c
@@ -4500,7 +4500,11 @@ static BOOL ME_IsCandidateAnURL(ME_TextEditor *editor, const ME_Cursor *start, i
 #define MAX_PREFIX_LEN 9
 #define X(str)  str, ARRAY_SIZE(str) - 1
   struct prefix_s {
+#ifdef __REACTOS__
+    const WCHAR text[MAX_PREFIX_LEN + 1];
+#else
     const WCHAR text[MAX_PREFIX_LEN];
+#endif
     int length;
   }prefixes[] = {
     {X(L"prospero:")},

--- a/dll/win32/winmm/CMakeLists.txt
+++ b/dll/win32/winmm/CMakeLists.txt
@@ -24,8 +24,9 @@ add_library(winmm MODULE
 
 if(MSVC)
     # Disable warning C4090: 'function': different 'const' qualifiers
+    # Disable warning C4146: unary minus operator applied to unsigned type, result still unsigned
     # Disable warning C4312: 'type cast': conversion from 'DWORD' to 'HTASK' of greater size
-    target_compile_options(winmm PRIVATE /wd4090 /wd4312)
+    target_compile_options(winmm PRIVATE /wd4090 /wd4146 /wd4312)
 endif()
 
 set_module_type(winmm win32dll)

--- a/sdk/cmake/msvc.cmake
+++ b/sdk/cmake/msvc.cmake
@@ -100,7 +100,7 @@ endif()
 
 # On x86 Debug builds, if it's not Clang-CL or msbuild, treat all warnings as errors
 if ((ARCH STREQUAL "i386") AND (CMAKE_BUILD_TYPE STREQUAL "Debug") AND (CMAKE_C_COMPILER_ID STREQUAL "MSVC") AND (NOT MSVC_IDE))
-    set(TREAT_ALL_WARNINGS_AS_ERRORS=TRUE)
+    set(TREAT_ALL_WARNINGS_AS_ERRORS TRUE)
 endif()
 
 # Define ALLOW_WARNINGS=TRUE on the cmake/configure command line to bypass errors


### PR DESCRIPTION
## Purpose

- Fix remaining warnings for MSVC x86
- Fix TREAT_ALL_WARNINGS_AS_ERRORS

## Testbot runs (Filled in by Devs)

- ✅ KVM x86: https://reactos.org/testman/compare.php?ids=101779,101781,101783,101788
- ✅ KVM x64: https://reactos.org/testman/compare.php?ids=101782,101784,101785,101789