### PR TITLE
[KERNEL32] RemoveDirectoryW: Fix the code for removing a mounted folder

### DIFF
--- a/dll/win32/kernel32/client/file/dir.c
+++ b/dll/win32/kernel32/client/file/dir.c
@@ -919,8 +919,8 @@ RemoveDirectoryW(IN LPCWSTR lpPathName)
         return FALSE;
     }
 
-    RtlCopyMemory(&PathName.Buffer, lpPathName, PathName.Length);
-    if (PathName.Buffer[PathName.Length / sizeof(WCHAR)] != L'\\')
+    RtlCopyMemory(PathName.Buffer, lpPathName, PathName.Length);
+    if (PathName.Buffer[(PathName.Length / sizeof(WCHAR)) - 1] != L'\\')
     {
         PathName.Buffer[PathName.Length / sizeof(WCHAR)] = L'\\';
         PathName.Buffer[(PathName.Length / sizeof(WCHAR)) + 1] = UNICODE_NULL;


### PR DESCRIPTION
Drop the idea of using Unicode String, which is not really needed here. Simply allocate buffer on a PWSTR variable so the path string can be manipulated as needed.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: