### PR TITLE
[SERVMAN] Services Properties 'Dependencies' tab missing text

### DIFF
--- a/base/applications/mscutils/servman/lang/bg-BG.rc
+++ b/base/applications/mscutils/servman/lang/bg-BG.rc
@@ -157,6 +157,7 @@ BEGIN
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "Някои услуги зависят от други услуги, водачи (driver) и зареждат други групи. Ако някоя системна съставка е спряна или не работи правилно, зависимите от нея услуги може да бъдат засегнати.", IDC_STATIC, 8, 7, 238, 26
     LTEXT "Тази услуга зависи от следните съставки", IDC_STATIC, 8, 57, 236, 9
+    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/bg-BG.rc
+++ b/base/applications/mscutils/servman/lang/bg-BG.rc
@@ -156,8 +156,8 @@ BEGIN
             WS_VISIBLE | WS_TABSTOP | TVS_HASBUTTONS | TVS_HASLINES |
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "Някои услуги зависят от други услуги, водачи (driver) и зареждат други групи. Ако някоя системна съставка е спряна или не работи правилно, зависимите от нея услуги може да бъдат засегнати.", IDC_STATIC, 8, 7, 238, 26
-    LTEXT "Тази услуга зависи от следните съставки", IDC_STATIC, 8, 57, 236, 9
-    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
+    LTEXT "Тази услуга зависи от следните съставки:", IDC_STATIC, 8, 57, 236, 9
+    LTEXT "The following components depend on this service:", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/cs-CZ.rc
+++ b/base/applications/mscutils/servman/lang/cs-CZ.rc
@@ -157,6 +157,7 @@ BEGIN
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "Některé služby závisí na jiných službách, systémových ovladačích nebo načítají jiné skupiny služeb. Zastavené nebo nesprávně fungující součásti systému mohou ovlivnit závislé služby.", IDC_STATIC, 8, 7, 238, 26
     LTEXT "Tato služba závisí na následujících součástech:", IDC_STATIC, 8, 57, 236, 9
+    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/cs-CZ.rc
+++ b/base/applications/mscutils/servman/lang/cs-CZ.rc
@@ -157,7 +157,7 @@ BEGIN
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "Některé služby závisí na jiných službách, systémových ovladačích nebo načítají jiné skupiny služeb. Zastavené nebo nesprávně fungující součásti systému mohou ovlivnit závislé služby.", IDC_STATIC, 8, 7, 238, 26
     LTEXT "Tato služba závisí na následujících součástech:", IDC_STATIC, 8, 57, 236, 9
-    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
+    LTEXT "The following components depend on this service:", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/de-DE.rc
+++ b/base/applications/mscutils/servman/lang/de-DE.rc
@@ -156,8 +156,8 @@ BEGIN
             WS_VISIBLE | WS_TABSTOP | TVS_HASBUTTONS | TVS_HASLINES |
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "Einige Dienste sind von anderen Diensten, Systemtreibern und Ladegruppen abhängig. Falls eine Systemkomponente anhält oder nicht einwandfrei ausgeführt wird, kann dies Auswirkungen auf abhängige Dienste haben.", IDC_STATIC, 8, 7, 238, 38
-    LTEXT "Dieser Dienst ist von folgenden Systemkomponenten abhängig", IDC_STATIC, 8, 57, 236, 9
-    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
+    LTEXT "Dieser Dienst ist von folgenden Systemkomponenten abhängig:", IDC_STATIC, 8, 57, 236, 9
+    LTEXT "Die folgenden Komponenten sind von diesem Dienst abhängig:", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/de-DE.rc
+++ b/base/applications/mscutils/servman/lang/de-DE.rc
@@ -157,6 +157,7 @@ BEGIN
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "Einige Dienste sind von anderen Diensten, Systemtreibern und Ladegruppen abhängig. Falls eine Systemkomponente anhält oder nicht einwandfrei ausgeführt wird, kann dies Auswirkungen auf abhängige Dienste haben.", IDC_STATIC, 8, 7, 238, 38
     LTEXT "Dieser Dienst ist von folgenden Systemkomponenten abhängig", IDC_STATIC, 8, 57, 236, 9
+    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/el-GR.rc
+++ b/base/applications/mscutils/servman/lang/el-GR.rc
@@ -156,8 +156,8 @@ BEGIN
             WS_VISIBLE | WS_TABSTOP | TVS_HASBUTTONS | TVS_HASLINES |
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "Some services depend on other services, system drivers and load order groups. If a system component is stopped or it is not running properly, dependant services can be affected.", IDC_STATIC, 8, 7, 238, 26
-    LTEXT "This service depends on the following components", IDC_STATIC, 8, 57, 236, 9
-    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
+    LTEXT "This service depends on the following components:", IDC_STATIC, 8, 57, 236, 9
+    LTEXT "The following components depend on this service:", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/el-GR.rc
+++ b/base/applications/mscutils/servman/lang/el-GR.rc
@@ -157,6 +157,7 @@ BEGIN
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "Some services depend on other services, system drivers and load order groups. If a system component is stopped or it is not running properly, dependant services can be affected.", IDC_STATIC, 8, 7, 238, 26
     LTEXT "This service depends on the following components", IDC_STATIC, 8, 57, 236, 9
+    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/en-US.rc
+++ b/base/applications/mscutils/servman/lang/en-US.rc
@@ -157,6 +157,7 @@ BEGIN
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "Some services depend on other services, system drivers and load order groups. If a system component is stopped or it is not running properly, dependant services can be affected.", IDC_STATIC, 8, 7, 238, 26
     LTEXT "This service depends on the following components", IDC_STATIC, 8, 57, 236, 9
+    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/en-US.rc
+++ b/base/applications/mscutils/servman/lang/en-US.rc
@@ -156,8 +156,8 @@ BEGIN
             WS_VISIBLE | WS_TABSTOP | TVS_HASBUTTONS | TVS_HASLINES |
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "Some services depend on other services, system drivers and load order groups. If a system component is stopped or it is not running properly, dependant services can be affected.", IDC_STATIC, 8, 7, 238, 26
-    LTEXT "This service depends on the following components", IDC_STATIC, 8, 57, 236, 9
-    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
+    LTEXT "&This service depends on the following components:", IDC_STATIC, 8, 57, 236, 9
+    LTEXT "The &following components depend on this service:", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/es-ES.rc
+++ b/base/applications/mscutils/servman/lang/es-ES.rc
@@ -160,6 +160,7 @@ BEGIN
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "Algunos servicios dependen de otros servicios, controladores del sistema y grupos de orden de carga. Si se detiene un componente del sistema o no funciona correctamente, es posible que otros servicios que dependan de éstos resulten afectados.", IDC_STATIC, 8, 7, 238, 26
     LTEXT "Éste servicio depende de los siguientes componentes", IDC_STATIC, 8, 57, 236, 9
+    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/es-ES.rc
+++ b/base/applications/mscutils/servman/lang/es-ES.rc
@@ -159,8 +159,8 @@ BEGIN
             WS_VISIBLE | WS_TABSTOP | TVS_HASBUTTONS | TVS_HASLINES |
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "Algunos servicios dependen de otros servicios, controladores del sistema y grupos de orden de carga. Si se detiene un componente del sistema o no funciona correctamente, es posible que otros servicios que dependan de éstos resulten afectados.", IDC_STATIC, 8, 7, 238, 26
-    LTEXT "Éste servicio depende de los siguientes componentes", IDC_STATIC, 8, 57, 236, 9
-    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
+    LTEXT "Éste servicio depende de los siguientes componentes:", IDC_STATIC, 8, 57, 236, 9
+    LTEXT "The following components depend on this service:", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/fr-FR.rc
+++ b/base/applications/mscutils/servman/lang/fr-FR.rc
@@ -156,8 +156,8 @@ BEGIN
             WS_VISIBLE | WS_TABSTOP | TVS_HASBUTTONS | TVS_HASLINES |
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "Certains services dépendent d'autres services, pilotes système et groupes d'ordre de chargement. Si un composant système est arrêté ou ne fonctionne pas correctement, les services dépendants peuvent être affectés.", IDC_STATIC, 8, 7, 238, 36
-    LTEXT "Ce service dépend des composants système suivants", IDC_STATIC, 8, 57, 236, 9
-    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
+    LTEXT "&Ce service dépend des composants système suivants:", IDC_STATIC, 8, 57, 236, 9
+    LTEXT "Les c&omposants système suivants dépendent de ce service:", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/fr-FR.rc
+++ b/base/applications/mscutils/servman/lang/fr-FR.rc
@@ -157,6 +157,7 @@ BEGIN
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "Certains services dépendent d'autres services, pilotes système et groupes d'ordre de chargement. Si un composant système est arrêté ou ne fonctionne pas correctement, les services dépendants peuvent être affectés.", IDC_STATIC, 8, 7, 238, 36
     LTEXT "Ce service dépend des composants système suivants", IDC_STATIC, 8, 57, 236, 9
+    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/he-IL.rc
+++ b/base/applications/mscutils/servman/lang/he-IL.rc
@@ -157,6 +157,7 @@ BEGIN
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "שירותים מסוימים תלויים בשירותים אחרים, במנהלים של התקנים של המערכת ובקבוצות סדר טעינה. אם רכיב מערכת הופסק או שאינו פועל כראוי, ייתכן ששירותים התלויים בו יושפעו.", IDC_STATIC, 8, 7, 238, 26
     LTEXT "שירות זה תלוי ברכיבי המערכת הבאים", IDC_STATIC, 8, 57, 236, 9
+    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/he-IL.rc
+++ b/base/applications/mscutils/servman/lang/he-IL.rc
@@ -156,8 +156,8 @@ BEGIN
             WS_VISIBLE | WS_TABSTOP | TVS_HASBUTTONS | TVS_HASLINES |
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "שירותים מסוימים תלויים בשירותים אחרים, במנהלים של התקנים של המערכת ובקבוצות סדר טעינה. אם רכיב מערכת הופסק או שאינו פועל כראוי, ייתכן ששירותים התלויים בו יושפעו.", IDC_STATIC, 8, 7, 238, 26
-    LTEXT "שירות זה תלוי ברכיבי המערכת הבאים", IDC_STATIC, 8, 57, 236, 9
-    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
+    LTEXT "שירות זה תלוי ברכיבי המערכת הבאים:", IDC_STATIC, 8, 57, 236, 9
+    LTEXT "The following components depend on this service:", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/id-ID.rc
+++ b/base/applications/mscutils/servman/lang/id-ID.rc
@@ -156,8 +156,8 @@ BEGIN
             WS_VISIBLE | WS_TABSTOP | TVS_HASBUTTONS | TVS_HASLINES |
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "Beberapa layanan bergantung pada layanan lainnya, driver sistem dan grup urutan pengambilan. Jika komponen sistem dihentikan atau tidak berjalan dengan benar, layanan yang bergantung akan dipengaruhi.", IDC_STATIC, 8, 7, 238, 26
-    LTEXT "Layanan ini tergantung pada komponen berikut", IDC_STATIC, 8, 57, 236, 9
-    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
+    LTEXT "Layanan ini tergantung pada komponen berikut:", IDC_STATIC, 8, 57, 236, 9
+    LTEXT "The following components depend on this service:", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/id-ID.rc
+++ b/base/applications/mscutils/servman/lang/id-ID.rc
@@ -157,6 +157,7 @@ BEGIN
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "Beberapa layanan bergantung pada layanan lainnya, driver sistem dan grup urutan pengambilan. Jika komponen sistem dihentikan atau tidak berjalan dengan benar, layanan yang bergantung akan dipengaruhi.", IDC_STATIC, 8, 7, 238, 26
     LTEXT "Layanan ini tergantung pada komponen berikut", IDC_STATIC, 8, 57, 236, 9
+    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/it-IT.rc
+++ b/base/applications/mscutils/servman/lang/it-IT.rc
@@ -156,8 +156,8 @@ BEGIN
             WS_VISIBLE | WS_TABSTOP | TVS_HASBUTTONS | TVS_HASLINES |
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "Alcuni servizi dipendono da altri servizi, driver di sistema e gruppi di ordine di caricamento. Se un componente di sistema viene fermato o non sta funzionando regolarmente, i servizi dipendenti possono venire influenzati.", IDC_STATIC, 8, 7, 238, 26
-    LTEXT "Questo servizio dipende dai seguenti componenti", IDC_STATIC, 8, 57, 236, 9
-    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
+    LTEXT "Questo servizio dipende dai seguenti componenti:", IDC_STATIC, 8, 57, 236, 9
+    LTEXT "The following components depend on this service:", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/it-IT.rc
+++ b/base/applications/mscutils/servman/lang/it-IT.rc
@@ -157,6 +157,7 @@ BEGIN
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "Alcuni servizi dipendono da altri servizi, driver di sistema e gruppi di ordine di caricamento. Se un componente di sistema viene fermato o non sta funzionando regolarmente, i servizi dipendenti possono venire influenzati.", IDC_STATIC, 8, 7, 238, 26
     LTEXT "Questo servizio dipende dai seguenti componenti", IDC_STATIC, 8, 57, 236, 9
+    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/ja-JP.rc
+++ b/base/applications/mscutils/servman/lang/ja-JP.rc
@@ -156,8 +156,8 @@ BEGIN
             WS_VISIBLE | WS_TABSTOP | TVS_HASBUTTONS | TVS_HASLINES |
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "他のサービス、システム ドライバ、読み込み順グループなどに依存しているサービスがあります。システム コンポーネントが停止するか、または正常に実行されない場合、依存するサービスが影響されている場合があります。", IDC_STATIC, 8, 7, 238, 26
-    LTEXT "このサービスが依存するコンポーネント", IDC_STATIC, 8, 57, 236, 9
-    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
+    LTEXT "このサービスが依存するコンポーネント:", IDC_STATIC, 8, 57, 236, 9
+    LTEXT "The following components depend on this service:", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/ja-JP.rc
+++ b/base/applications/mscutils/servman/lang/ja-JP.rc
@@ -157,6 +157,7 @@ BEGIN
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "他のサービス、システム ドライバ、読み込み順グループなどに依存しているサービスがあります。システム コンポーネントが停止するか、または正常に実行されない場合、依存するサービスが影響されている場合があります。", IDC_STATIC, 8, 7, 238, 26
     LTEXT "このサービスが依存するコンポーネント", IDC_STATIC, 8, 57, 236, 9
+    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/ko-KR.rc
+++ b/base/applications/mscutils/servman/lang/ko-KR.rc
@@ -159,7 +159,7 @@ BEGIN
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "일부 서비스는 다른 서비스나 시스템 드라이버, 그룹 등에 종속되어 있습니다. 만약 시스템 컴포넌트가 정지되었거나 제대로 동작하지 않는다면, 종속된 서비스에 영향을 끼칠 수 있습니다.", IDC_STATIC, 8, 7, 238, 26
     LTEXT "이 서비스는 다음 컴포넌트에 종속되어 있습니다.", IDC_STATIC, 8, 57, 236, 9
-    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
+    LTEXT "The following components depend on this service:", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/ko-KR.rc
+++ b/base/applications/mscutils/servman/lang/ko-KR.rc
@@ -159,6 +159,7 @@ BEGIN
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "일부 서비스는 다른 서비스나 시스템 드라이버, 그룹 등에 종속되어 있습니다. 만약 시스템 컴포넌트가 정지되었거나 제대로 동작하지 않는다면, 종속된 서비스에 영향을 끼칠 수 있습니다.", IDC_STATIC, 8, 7, 238, 26
     LTEXT "이 서비스는 다음 컴포넌트에 종속되어 있습니다.", IDC_STATIC, 8, 57, 236, 9
+    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/no-NO.rc
+++ b/base/applications/mscutils/servman/lang/no-NO.rc
@@ -157,6 +157,7 @@ BEGIN
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "Noen tjenester depend på andre tjenester, system drivere og laster system grupper. Hvis system komponenten er stoppet eller ikke kjøre riktig, dependant services can be affected.", IDC_STATIC, 8, 7, 238, 26
     LTEXT "Denne tjenesten depends på følgende komponenter", IDC_STATIC, 8, 57, 236, 9
+    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/no-NO.rc
+++ b/base/applications/mscutils/servman/lang/no-NO.rc
@@ -156,8 +156,8 @@ BEGIN
             WS_VISIBLE | WS_TABSTOP | TVS_HASBUTTONS | TVS_HASLINES |
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "Noen tjenester depend på andre tjenester, system drivere og laster system grupper. Hvis system komponenten er stoppet eller ikke kjøre riktig, dependant services can be affected.", IDC_STATIC, 8, 7, 238, 26
-    LTEXT "Denne tjenesten depends på følgende komponenter", IDC_STATIC, 8, 57, 236, 9
-    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
+    LTEXT "Denne tjenesten depends på følgende komponenter:", IDC_STATIC, 8, 57, 236, 9
+    LTEXT "The following components depend on this service:", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/pl-PL.rc
+++ b/base/applications/mscutils/servman/lang/pl-PL.rc
@@ -166,8 +166,8 @@ BEGIN
             WS_VISIBLE | WS_TABSTOP | TVS_HASBUTTONS | TVS_HASLINES |
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "Niektóre usługi są zależne od innych usług, sterowników systemowych i grup kolejności ładowania. Jeżeli składnik systemu jest zatrzymany lub nie działa prawidłowo, zależne od niego usługi nie uruchomią się.", IDC_STATIC, 8, 7, 238, 26
-    LTEXT "Ta usługa jest zależna od następujących składników systemu", IDC_STATIC, 8, 57, 236, 9
-    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
+    LTEXT "Ta usługa jest zależna od następujących składników systemu:", IDC_STATIC, 8, 57, 236, 9
+    LTEXT "The following components depend on this service:", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/pl-PL.rc
+++ b/base/applications/mscutils/servman/lang/pl-PL.rc
@@ -167,6 +167,7 @@ BEGIN
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "Niektóre usługi są zależne od innych usług, sterowników systemowych i grup kolejności ładowania. Jeżeli składnik systemu jest zatrzymany lub nie działa prawidłowo, zależne od niego usługi nie uruchomią się.", IDC_STATIC, 8, 7, 238, 26
     LTEXT "Ta usługa jest zależna od następujących składników systemu", IDC_STATIC, 8, 57, 236, 9
+    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/pt-PT.rc
+++ b/base/applications/mscutils/servman/lang/pt-PT.rc
@@ -157,6 +157,7 @@ BEGIN
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "Alguns serviços dependem de outros serviços, controladores de sistema e grupos de ordenamento de carregamento. Se um componente do sistema for parado ou não estiver a ser executado correctamente, os serviços dependentes podem ser afectados.", IDC_STATIC, 8, 7, 238, 34
     LTEXT "Este serviço depende dos seguintes componentes do sistema:", IDC_STATIC, 8, 57, 236, 9
+    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
     LTEXT "Os seguintes componentes do sistema dependem deste serviço:", IDC_DEPEND_SERVICE, 8, 138, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/pt-PT.rc
+++ b/base/applications/mscutils/servman/lang/pt-PT.rc
@@ -157,7 +157,7 @@ BEGIN
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "Alguns serviços dependem de outros serviços, controladores de sistema e grupos de ordenamento de carregamento. Se um componente do sistema for parado ou não estiver a ser executado correctamente, os serviços dependentes podem ser afectados.", IDC_STATIC, 8, 7, 238, 34
     LTEXT "Este serviço depende dos seguintes componentes do sistema:", IDC_STATIC, 8, 57, 236, 9
-    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
+    LTEXT "The following components depend on this service:", IDC_STATIC, 8, 140, 236, 9
     LTEXT "Os seguintes componentes do sistema dependem deste serviço:", IDC_DEPEND_SERVICE, 8, 138, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/ro-RO.rc
+++ b/base/applications/mscutils/servman/lang/ro-RO.rc
@@ -166,6 +166,7 @@ BEGIN
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "Unele servicii depind de alte servicii sau de module de sistem și de ordinea încărcării în grup. Dacă o componentă de sistem este oprită sau nu rulează corespunzător, serviciile dependente pot fi și ele afectate.", IDC_STATIC, 8, 7, 238, 26
     LTEXT "Acest serviciu depinde de următoarele componente", IDC_STATIC, 8, 57, 236, 9
+    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/ro-RO.rc
+++ b/base/applications/mscutils/servman/lang/ro-RO.rc
@@ -165,8 +165,8 @@ BEGIN
             WS_VISIBLE | WS_TABSTOP | TVS_HASBUTTONS | TVS_HASLINES |
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "Unele servicii depind de alte servicii sau de module de sistem și de ordinea încărcării în grup. Dacă o componentă de sistem este oprită sau nu rulează corespunzător, serviciile dependente pot fi și ele afectate.", IDC_STATIC, 8, 7, 238, 26
-    LTEXT "Acest serviciu depinde de următoarele componente", IDC_STATIC, 8, 57, 236, 9
-    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
+    LTEXT "Acest serviciu depinde de următoarele componente:", IDC_STATIC, 8, 57, 236, 9
+    LTEXT "Următoarele componente depind de acest serviciu:", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/ru-RU.rc
+++ b/base/applications/mscutils/servman/lang/ru-RU.rc
@@ -157,7 +157,7 @@ BEGIN
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "Некоторые службы зависят от других. Если служба остановлена или неправильно работает, это отражается на зависимых от нее службах.", IDC_STATIC, 8, 7, 238, 26
     LTEXT "Эта служба зависит от следующих компонентов:", IDC_STATIC, 8, 59, 236, 9
-    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
+    LTEXT "Следующие компоненты зависят от этой службы:", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/ru-RU.rc
+++ b/base/applications/mscutils/servman/lang/ru-RU.rc
@@ -157,6 +157,7 @@ BEGIN
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "Некоторые службы зависят от других. Если служба остановлена или неправильно работает, это отражается на зависимых от нее службах.", IDC_STATIC, 8, 7, 238, 26
     LTEXT "Эта служба зависит от следующих компонентов:", IDC_STATIC, 8, 59, 236, 9
+    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/sk-SK.rc
+++ b/base/applications/mscutils/servman/lang/sk-SK.rc
@@ -161,8 +161,8 @@ BEGIN
             WS_VISIBLE | WS_TABSTOP | TVS_HASBUTTONS | TVS_HASLINES |
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "Some services depend on other services, system drivers and load order groups. If a system component is stopped or it is not running properly, dependant services can be affected.", IDC_STATIC, 8, 7, 238, 26
-    LTEXT "This service depends on the following components", IDC_STATIC, 8, 57, 236, 9
-    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
+    LTEXT "This service depends on the following components:", IDC_STATIC, 8, 57, 236, 9
+    LTEXT "The following components depend on this service:", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/sk-SK.rc
+++ b/base/applications/mscutils/servman/lang/sk-SK.rc
@@ -162,6 +162,7 @@ BEGIN
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "Some services depend on other services, system drivers and load order groups. If a system component is stopped or it is not running properly, dependant services can be affected.", IDC_STATIC, 8, 7, 238, 26
     LTEXT "This service depends on the following components", IDC_STATIC, 8, 57, 236, 9
+    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/sq-AL.rc
+++ b/base/applications/mscutils/servman/lang/sq-AL.rc
@@ -161,8 +161,8 @@ BEGIN
             WS_VISIBLE | WS_TABSTOP | TVS_HASBUTTONS | TVS_HASLINES |
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "Disa shërbime varen nga shërbimet e tjera, driverat e sistemit dhe ngarkimet grupet te renditura. Nëse një komponent sistem është i ndalur ose ajo nuk është në drejtimin e duhur, shërbimet e varur mund të preken.", IDC_STATIC, 8, 7, 238, 26
-    LTEXT "Ky shërbim varet nga komponentet në vijim", IDC_STATIC, 8, 57, 236, 9
-    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
+    LTEXT "Ky shërbim varet nga komponentet në vijim:", IDC_STATIC, 8, 57, 236, 9
+    LTEXT "The following components depend on this service:", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/sq-AL.rc
+++ b/base/applications/mscutils/servman/lang/sq-AL.rc
@@ -162,6 +162,7 @@ BEGIN
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "Disa shërbime varen nga shërbimet e tjera, driverat e sistemit dhe ngarkimet grupet te renditura. Nëse një komponent sistem është i ndalur ose ajo nuk është në drejtimin e duhur, shërbimet e varur mund të preken.", IDC_STATIC, 8, 7, 238, 26
     LTEXT "Ky shërbim varet nga komponentet në vijim", IDC_STATIC, 8, 57, 236, 9
+    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/sv-SE.rc
+++ b/base/applications/mscutils/servman/lang/sv-SE.rc
@@ -164,6 +164,7 @@ BEGIN
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "Några tjänster är beroende av andra tjänster, systemdrivrutiner och laddsystemsgrupper. Om systemkomponenten är stoppad eller inte kör korrekt, kan tjänster som är beroende av den bli påverkade.", IDC_STATIC, 8, 7, 238, 26
     LTEXT "Denna tjänsten är beroende av följande komponenter", IDC_STATIC, 8, 57, 236, 9
+    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/sv-SE.rc
+++ b/base/applications/mscutils/servman/lang/sv-SE.rc
@@ -163,8 +163,8 @@ BEGIN
             WS_VISIBLE | WS_TABSTOP | TVS_HASBUTTONS | TVS_HASLINES |
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "Några tjänster är beroende av andra tjänster, systemdrivrutiner och laddsystemsgrupper. Om systemkomponenten är stoppad eller inte kör korrekt, kan tjänster som är beroende av den bli påverkade.", IDC_STATIC, 8, 7, 238, 26
-    LTEXT "Denna tjänsten är beroende av följande komponenter", IDC_STATIC, 8, 57, 236, 9
-    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
+    LTEXT "Denna tjänsten är beroende av följande komponenter:", IDC_STATIC, 8, 57, 236, 9
+    LTEXT "The following components depend on this service:", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/th-TH.rc
+++ b/base/applications/mscutils/servman/lang/th-TH.rc
@@ -165,6 +165,7 @@ BEGIN
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "การให้บริการบางอย่างขึ้นกับบริการอื่นๆด้วย, ตัวขับเคลื่อนของระบบ และการดึงข้อมูลตามลำดับกลุ่ม ถ้าส่วนประกอบต่างๆของระบบหยุดทำงานลง หรือไม่ทำงานตามสมควร การให้บริการแบบไม่กำหนดเองจะมีผลทันที", IDC_STATIC, 8, 7, 238, 26
     LTEXT "การให้บริการนี้ขึ้นอยู่กับส่วนประกอบอื่นๆที่ตามมาด้วย", IDC_STATIC, 8, 57, 236, 9
+    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/th-TH.rc
+++ b/base/applications/mscutils/servman/lang/th-TH.rc
@@ -164,8 +164,8 @@ BEGIN
             WS_VISIBLE | WS_TABSTOP | TVS_HASBUTTONS | TVS_HASLINES |
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "การให้บริการบางอย่างขึ้นกับบริการอื่นๆด้วย, ตัวขับเคลื่อนของระบบ และการดึงข้อมูลตามลำดับกลุ่ม ถ้าส่วนประกอบต่างๆของระบบหยุดทำงานลง หรือไม่ทำงานตามสมควร การให้บริการแบบไม่กำหนดเองจะมีผลทันที", IDC_STATIC, 8, 7, 238, 26
-    LTEXT "การให้บริการนี้ขึ้นอยู่กับส่วนประกอบอื่นๆที่ตามมาด้วย", IDC_STATIC, 8, 57, 236, 9
-    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
+    LTEXT "การให้บริการนี้ขึ้นอยู่กับส่วนประกอบอื่นๆที่ตามมาด้วย:", IDC_STATIC, 8, 57, 236, 9
+    LTEXT "The following components depend on this service:", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/tr-TR.rc
+++ b/base/applications/mscutils/servman/lang/tr-TR.rc
@@ -159,7 +159,7 @@ BEGIN
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "Birtakım hizmetler, başka hizmetlere, sistem sürücülerine ve yükleme sırası bileşenlerine bağımlıdır. Eğer bir sistem bileşeni, durdurulmuşsa ya da düzgün çalışmıyorsa bağımlı hizmetler etkilenebilir.", IDC_STATIC, 8, 7, 238, 26
     LTEXT "Bu hizmet aşağıdaki bileşenlere bağımlıdır:", IDC_STATIC, 8, 57, 236, 9
-    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
+    LTEXT "The following components depend on this service:", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/tr-TR.rc
+++ b/base/applications/mscutils/servman/lang/tr-TR.rc
@@ -159,6 +159,7 @@ BEGIN
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "Birtakım hizmetler, başka hizmetlere, sistem sürücülerine ve yükleme sırası bileşenlerine bağımlıdır. Eğer bir sistem bileşeni, durdurulmuşsa ya da düzgün çalışmıyorsa bağımlı hizmetler etkilenebilir.", IDC_STATIC, 8, 7, 238, 26
     LTEXT "Bu hizmet aşağıdaki bileşenlere bağımlıdır:", IDC_STATIC, 8, 57, 236, 9
+    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/uk-UA.rc
+++ b/base/applications/mscutils/servman/lang/uk-UA.rc
@@ -165,6 +165,7 @@ BEGIN
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "Деякі служби залежать від інших служб, системних драйверів або списку завантаження груп служб. Якщо служба зупинена або неправильно працює, це впливає на залежні від неї служби.", IDC_STATIC, 8, 7, 238, 26
     LTEXT "Ця служба залежить від наступних компонентів", IDC_STATIC, 8, 57, 236, 9
+    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/uk-UA.rc
+++ b/base/applications/mscutils/servman/lang/uk-UA.rc
@@ -164,8 +164,8 @@ BEGIN
             WS_VISIBLE | WS_TABSTOP | TVS_HASBUTTONS | TVS_HASLINES |
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "Деякі служби залежать від інших служб, системних драйверів або списку завантаження груп служб. Якщо служба зупинена або неправильно працює, це впливає на залежні від неї служби.", IDC_STATIC, 8, 7, 238, 26
-    LTEXT "Ця служба залежить від наступних компонентів", IDC_STATIC, 8, 57, 236, 9
-    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
+    LTEXT "Ця служба залежить від наступних компонентів:", IDC_STATIC, 8, 57, 236, 9
+    LTEXT "The following components depend on this service:", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/zh-CN.rc
+++ b/base/applications/mscutils/servman/lang/zh-CN.rc
@@ -159,6 +159,7 @@ BEGIN
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "一些服务依赖于其他服务，系统驱动程序和加载顺序组。如果一个系统组件被停止或者没有正确运行，依赖它的服务也会被影响。", IDC_STATIC, 8, 7, 238, 26
     LTEXT "这个服务依赖于以下的组件", IDC_STATIC, 8, 57, 236, 9
+    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/zh-CN.rc
+++ b/base/applications/mscutils/servman/lang/zh-CN.rc
@@ -158,8 +158,8 @@ BEGIN
             WS_VISIBLE | WS_TABSTOP | TVS_HASBUTTONS | TVS_HASLINES |
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "一些服务依赖于其他服务，系统驱动程序和加载顺序组。如果一个系统组件被停止或者没有正确运行，依赖它的服务也会被影响。", IDC_STATIC, 8, 7, 238, 26
-    LTEXT "这个服务依赖于以下的组件", IDC_STATIC, 8, 57, 236, 9
-    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
+    LTEXT "这个服务依赖于以下的组件:", IDC_STATIC, 8, 57, 236, 9
+    LTEXT "The following components depend on this service:", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/zh-HK.rc
+++ b/base/applications/mscutils/servman/lang/zh-HK.rc
@@ -165,6 +165,7 @@ BEGIN
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "一些服務依賴於其他服務，系統驅動程式和載入順序組。如果一個系統元件被停止或者沒有正確執行，依賴它的服務也會受到影響。", IDC_STATIC, 8, 7, 238, 26
     LTEXT "這個服務依賴於以下的元件：", IDC_STATIC, 8, 57, 236, 9
+    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/zh-HK.rc
+++ b/base/applications/mscutils/servman/lang/zh-HK.rc
@@ -165,7 +165,7 @@ BEGIN
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "一些服務依賴於其他服務，系統驅動程式和載入順序組。如果一個系統元件被停止或者沒有正確執行，依賴它的服務也會受到影響。", IDC_STATIC, 8, 7, 238, 26
     LTEXT "這個服務依賴於以下的元件：", IDC_STATIC, 8, 57, 236, 9
-    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
+    LTEXT "The following components depend on this service:", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/zh-TW.rc
+++ b/base/applications/mscutils/servman/lang/zh-TW.rc
@@ -165,6 +165,7 @@ BEGIN
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "一些服務依賴於其他服務，系統驅動程式和載入順序組。如果一個系統元件被停止或者沒有正確運行，被其依賴的服務也會被影響。", IDC_STATIC, 8, 7, 238, 26
     LTEXT "這個服務依賴於以下的元件：", IDC_STATIC, 8, 57, 236, 9
+    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 

--- a/base/applications/mscutils/servman/lang/zh-TW.rc
+++ b/base/applications/mscutils/servman/lang/zh-TW.rc
@@ -165,7 +165,7 @@ BEGIN
             TVS_LINESATROOT | TVS_DISABLEDRAGDROP, 8, 151, 236, 68
     LTEXT "一些服務依賴於其他服務，系統驅動程式和載入順序組。如果一個系統元件被停止或者沒有正確運行，被其依賴的服務也會被影響。", IDC_STATIC, 8, 7, 238, 26
     LTEXT "這個服務依賴於以下的元件：", IDC_STATIC, 8, 57, 236, 9
-    LTEXT "The following components depend on this service", IDC_STATIC, 8, 140, 236, 9
+    LTEXT "The following components depend on this service:", IDC_STATIC, 8, 140, 236, 9
     LTEXT "", IDC_DEPEND_SERVICE, 8, 38, 236, 13
 END
 


### PR DESCRIPTION
## Purpose

_Add missing text above lower listbox._

JIRA issue: [CORE-20115](https://jira.reactos.org/browse/CORE-20115)

## Proposed changes

_Add static text for all languages for description of lower listbox._

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64:

Before:

![servman-lang-bad](https://github.com/user-attachments/assets/1097d18a-9666-4eea-b827-295f73b78a08)

After:

![servman-lang-ok](https://github.com/user-attachments/assets/614b15e3-2b82-4951-bf93-2d6a7f8faa09)
