### PR TITLE
[SHELL32] Respect StrCmpLogicalW policy in shell folders

### DIFF
--- a/dll/win32/shell32/dialogs/general.cpp
+++ b/dll/win32/shell32/dialogs/general.cpp
@@ -72,6 +72,7 @@ IntSetShellStateSettings(BOOL bDoubleClick, BOOL bUseCommonTasks)
     shellstate.fWebView = !!bUseCommonTasks;
     SHGetSetSettings(&shellstate, SSF_DOUBLECLICKINWEBVIEW | SSF_WEBVIEW, TRUE);
 
+    // FIXME: This is not correct, it does nothing. SHGetSetSettings will broadcast it.
     SHSettingsChanged(0, L"ShellState");
     return TRUE;
 }
@@ -107,7 +108,7 @@ static BOOL IntSetUnderlineState(BOOL bIconUnderline)
     if (Status != ERROR_SUCCESS)
         return FALSE;
 
-    SHSettingsChanged(0, L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\IconUnderline");
+    SHSendMessageBroadcastW(WM_SETTINGCHANGE, 0, (LPARAM)L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\IconUnderline");
     return TRUE;
 }
 

--- a/dll/win32/shell32/dialogs/view.cpp
+++ b/dll/win32/shell32/dialogs/view.cpp
@@ -942,8 +942,11 @@ ViewDlg_Apply(HWND hwndDlg)
     // update user's settings
     SHGetSetSettings(&ShellState, dwMask, TRUE);
 
+    // invalidate cached restrictions
+    SHSettingsChanged(0, 0);
+
     // notify all
-    SendMessage(HWND_BROADCAST, WM_WININICHANGE, 0, 0);
+    SHSendMessageBroadcastW(WM_WININICHANGE, 0, 0);
 
     PostCabinetMessage(WM_COMMAND, FCIDM_DESKBROWSER_REFRESH, 0);
 }

--- a/dll/win32/shell32/folders/CControlPanelFolder.cpp
+++ b/dll/win32/shell32/folders/CControlPanelFolder.cpp
@@ -345,10 +345,10 @@ HRESULT WINAPI CControlPanelFolder::CompareIDs(LPARAM lParam, PCUIDLIST_RELATIVE
     switch(LOWORD(lParam))
     {
         case CONTROLPANEL_COL_NAME:
-            result = _wcsicmp(pData1->szName + pData1->offsDispName, pData2->szName + pData2->offsDispName);
+            result = SHELL_StrCmpLogical(pData1->szName + pData1->offsDispName, pData2->szName + pData2->offsDispName);
             break;
         case CONTROLPANEL_COL_COMMENT:
-            result = _wcsicmp(pData1->szName + pData1->offsComment, pData2->szName + pData2->offsComment);
+            result = SHELL_StrCmpLogical(pData1->szName + pData1->offsComment, pData2->szName + pData2->offsComment);
             break;
         default:
             ERR("Got wrong lParam!\n");

--- a/dll/win32/shell32/folders/CFSFolder.cpp
+++ b/dll/win32/shell32/folders/CFSFolder.cpp
@@ -1127,7 +1127,7 @@ HRESULT WINAPI CFSFolder::CompareIDs(LPARAM lParam,
     switch (LOWORD(lParam))
     {
         case SHFSF_COL_NAME:
-            result = _wcsicmp(pszName1, pszName2);
+            result = CompareUiStrings(pszName1, pszName2, lParam);
             break;
         case SHFSF_COL_SIZE:
             if (pData1->u.file.dwFileSize > pData2->u.file.dwFileSize)
@@ -1141,7 +1141,7 @@ HRESULT WINAPI CFSFolder::CompareIDs(LPARAM lParam,
             // FIXME: Compare the type strings from SHGetFileInfo
             pExtension1 = PathFindExtensionW(pszName1);
             pExtension2 = PathFindExtensionW(pszName2);
-            result = _wcsicmp(pExtension1, pExtension2);
+            result = CompareUiStrings(pExtension1, pExtension2, lParam);
             break;
         case SHFSF_COL_MDATE:
             result = pData1->u.file.uFileDate - pData2->u.file.uFileDate;

--- a/dll/win32/shell32/folders/CFSFolder.h
+++ b/dll/win32/shell32/folders/CFSFolder.h
@@ -133,9 +133,11 @@ class CFSFolder :
         static HRESULT FormatDateTime(const FILETIME &ft, LPWSTR Buf, UINT cchBuf);
         static HRESULT FormatSize(UINT64 size, LPWSTR Buf, UINT cchBuf);
         static HRESULT CompareSortFoldersFirst(LPCITEMIDLIST pidl1, LPCITEMIDLIST pidl2);
-        static inline int CompareUiStrings(LPCWSTR a, LPCWSTR b)
+        static inline int CompareUiStrings(LPCWSTR a, LPCWSTR b, LPARAM lParam = 0)
         {
-            return StrCmpLogicalW(a, b);
+            if (lParam & SHCIDS_CANONICALONLY)
+                return _wcsicmp(a, b);
+            return SHELL_StrCmpLogical(a, b);
         }
 };
 

--- a/dll/win32/shell32/folders/CRecycleBin.cpp
+++ b/dll/win32/shell32/folders/CRecycleBin.cpp
@@ -762,7 +762,7 @@ HRESULT WINAPI CRecycleBin::CompareIDs(LPARAM lParam, PCUIDLIST_RELATIVE pidl1, 
                     return CompareCanonical(*pData1, *pData2);
                 pName1 = GetItemOriginalFileName(*pData1);
                 pName2 = GetItemOriginalFileName(*pData2);
-                result = CFSFolder::CompareUiStrings(pName1, pName2);
+                result = CFSFolder::CompareUiStrings(pName1, pName2, lParam);
             }
             else
             {
@@ -782,7 +782,7 @@ HRESULT WINAPI CRecycleBin::CompareIDs(LPARAM lParam, PCUIDLIST_RELATIVE pidl1, 
             {
                 if (SUCCEEDED(hr = GetItemOriginalFolder(*pData2, const_cast<LPWSTR&>(pName2))))
                 {
-                    result = CFSFolder::CompareUiStrings(pName1, pName2);
+                    result = CFSFolder::CompareUiStrings(pName1, pName2, lParam);
                     SHFree(const_cast<LPWSTR>(pName2));
                 }
                 SHFree(const_cast<LPWSTR>(pName1));
@@ -797,7 +797,7 @@ HRESULT WINAPI CRecycleBin::CompareIDs(LPARAM lParam, PCUIDLIST_RELATIVE pidl1, 
         case COLUMN_TYPE:
             GetItemTypeName(pidl1, *pData1, shfi1);
             GetItemTypeName(pidl2, *pData2, shfi2);
-            result = CFSFolder::CompareUiStrings(shfi1.szTypeName, shfi2.szTypeName);
+            result = CFSFolder::CompareUiStrings(shfi1.szTypeName, shfi2.szTypeName, lParam);
             break;
         case COLUMN_MTIME:
             _ILGetFileDateTime(pidl1, &ft1);

--- a/dll/win32/shell32/shelldesktop/CDesktopBrowser.cpp
+++ b/dll/win32/shell32/shelldesktop/CDesktopBrowser.cpp
@@ -431,6 +431,7 @@ LRESULT CDesktopBrowser::OnSettingChange(UINT uMsg, WPARAM wParam, LPARAM lParam
         LPVOID lpEnvironment;
         RegenerateUserEnvironment(&lpEnvironment, TRUE);
     }
+    SHSettingsChanged((LPCVOID)wParam, (PCWSTR)lParam); // Refresh policy restrictions
 
     if (m_hWndShellView)
     {

--- a/dll/win32/shell32/shelldesktop/CDesktopBrowser.cpp
+++ b/dll/win32/shell32/shelldesktop/CDesktopBrowser.cpp
@@ -431,7 +431,7 @@ LRESULT CDesktopBrowser::OnSettingChange(UINT uMsg, WPARAM wParam, LPARAM lParam
         LPVOID lpEnvironment;
         RegenerateUserEnvironment(&lpEnvironment, TRUE);
     }
-    SHSettingsChanged((LPCVOID)wParam, (PCWSTR)lParam); // Refresh policy restrictions
+    SHSettingsChanged((LPCVOID)wParam, (PCWSTR)lParam); // Invalidate cached restrictions
 
     if (m_hWndShellView)
     {

--- a/dll/win32/shell32/shlfolder.cpp
+++ b/dll/win32/shell32/shlfolder.cpp
@@ -307,7 +307,7 @@ HRESULT SHELL32_CompareDetails(IShellFolder2* isf, LPARAM lParam, LPCITEMIDLIST 
     if (FAILED(hres))
         return MAKE_COMPARE_HRESULT(1);
 
-    int ret = _wcsicmp(wszItem1, wszItem2);
+    int ret = CFSFolder::CompareUiStrings(wszItem1, wszItem2, lParam);
     if (ret == 0)
         return SHELL32_CompareChildren(isf, lParam, pidl1, pidl2);
 

--- a/dll/win32/shell32/wine/shell32_main.h
+++ b/dll/win32/shell32/wine/shell32_main.h
@@ -35,6 +35,7 @@ extern "C" {
 */
 extern HMODULE	huser32 DECLSPEC_HIDDEN;
 extern HINSTANCE shell32_hInstance DECLSPEC_HIDDEN;
+extern int (WINAPI* SHELL_StrCmpLogical)(PCWSTR s1, PCWSTR s2);
 
 BOOL WINAPI Shell_GetImageLists(HIMAGELIST * lpBigList, HIMAGELIST * lpSmallList);
 


### PR DESCRIPTION
This setting is controlled by Group Policy and/or Tweak UI.

![TweakUI](https://github.com/user-attachments/assets/8d798c0f-72a3-4b88-b7ff-e163ca3b5835)


## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: