### PR TITLE
[NDK][NTOS][NTDLL][KERNEL32] Fix read/write of KSYSTEM_TIME

### DIFF
--- a/dll/ntdll/rtl/libsupp.c
+++ b/dll/ntdll/rtl/libsupp.c
@@ -1221,22 +1221,9 @@ ULONG
 NTAPI
 RtlGetTickCount(VOID)
 {
-    ULARGE_INTEGER TickCount;
+    LARGE_INTEGER TickCount;
 
-#ifdef _WIN64
-    TickCount.QuadPart = *((volatile ULONG64*)&SharedUserData->TickCount);
-#else
-    while (TRUE)
-    {
-        TickCount.HighPart = (ULONG)SharedUserData->TickCount.High1Time;
-        TickCount.LowPart = SharedUserData->TickCount.LowPart;
-
-        if (TickCount.HighPart == (ULONG)SharedUserData->TickCount.High2Time)
-            break;
-
-        YieldProcessor();
-    }
-#endif
+    TickCount = KiReadSystemTime(&SharedUserData->TickCount);
 
     return (ULONG)((UInt32x32To64(TickCount.LowPart,
                                   SharedUserData->TickCountMultiplier) >> 24) +

--- a/dll/ntdll/rtl/libsupp.c
+++ b/dll/ntdll/rtl/libsupp.c
@@ -1225,10 +1225,8 @@ RtlGetTickCount(VOID)
 
     TickCount = KiReadSystemTime(&SharedUserData->TickCount);
 
-    return (ULONG)((UInt32x32To64(TickCount.LowPart,
-                                  SharedUserData->TickCountMultiplier) >> 24) +
-                    UInt32x32To64((TickCount.HighPart << 8) & 0xFFFFFFFF,
-                                  SharedUserData->TickCountMultiplier));
+    /* Convert to milliseconds */
+    return KiTickCountToMs(TickCount);
 }
 
 /* EOF */

--- a/dll/win32/kernel32/client/time.c
+++ b/dll/win32/kernel32/client/time.c
@@ -426,11 +426,8 @@ GetTickCount(VOID)
 
     TickCount = KiReadSystemTime(&SharedUserData->TickCount);
 
-    return (ULONG)((UInt32x32To64(TickCount.LowPart,
-                                  SharedUserData->TickCountMultiplier) >> 24) +
-                    UInt32x32To64((TickCount.HighPart << 8) & 0xFFFFFFFF,
-                                  SharedUserData->TickCountMultiplier));
-
+    /* Convert to milliseconds */
+    return (DWORD)KiTickCountToMs(TickCount);
 }
 
 /*

--- a/dll/win32/kernel32/kernel32_vista/GetTickCount64.c
+++ b/dll/win32/kernel32/kernel32_vista/GetTickCount64.c
@@ -8,18 +8,11 @@ ULONGLONG
 WINAPI
 GetTickCount64(VOID)
 {
-    ULARGE_INTEGER TickCount;
+    LARGE_INTEGER TickCount;
 
-    while (TRUE)
-    {
-        TickCount.HighPart = (ULONG)SharedUserData->TickCount.High1Time;
-        TickCount.LowPart = SharedUserData->TickCount.LowPart;
+    TickCount = KiReadSystemTime(&SharedUserData->TickCount);
 
-        if (TickCount.HighPart == (ULONG)SharedUserData->TickCount.High2Time) break;
-
-        YieldProcessor();
-     }
-
-     return (UInt32x32To64(TickCount.LowPart, SharedUserData->TickCountMultiplier) >> 24) +
-            (UInt32x32To64(TickCount.HighPart, SharedUserData->TickCountMultiplier) << 8);
+    ULONG TickCountMultiplier = SharedUserData->TickCountMultiplier;
+    return (UInt32x32To64(TickCount.LowPart, TickCountMultiplier) >> 24) +
+           (UInt32x32To64(TickCount.HighPart, TickCountMultiplier) << 8);
 }

--- a/dll/win32/kernel32/kernel32_vista/GetTickCount64.c
+++ b/dll/win32/kernel32/kernel32_vista/GetTickCount64.c
@@ -12,7 +12,6 @@ GetTickCount64(VOID)
 
     TickCount = KiReadSystemTime(&SharedUserData->TickCount);
 
-    ULONG TickCountMultiplier = SharedUserData->TickCountMultiplier;
-    return (UInt32x32To64(TickCount.LowPart, TickCountMultiplier) >> 24) +
-           (UInt32x32To64(TickCount.HighPart, TickCountMultiplier) << 8);
+    /* Convert to milliseconds */
+    return KiTickCountToMs(TickCount);
 }

--- a/ntoskrnl/ex/init.c
+++ b/ntoskrnl/ex/init.c
@@ -1550,9 +1550,7 @@ Phase1InitializationDiscard(IN PVOID Context)
                                                     10000000);
 
             /* Set the boot time-zone bias */
-            SharedUserData->TimeZoneBias.High2Time = ExpTimeZoneBias.HighPart;
-            SharedUserData->TimeZoneBias.LowPart = ExpTimeZoneBias.LowPart;
-            SharedUserData->TimeZoneBias.High1Time = ExpTimeZoneBias.HighPart;
+            KiWriteSystemTime(&SharedUserData->TimeZoneBias, ExpTimeZoneBias);
 
             /* Convert the boot time to local time, and set it */
             UniversalBootTime.QuadPart = SystemBootTime.QuadPart +

--- a/ntoskrnl/ex/time.c
+++ b/ntoskrnl/ex/time.c
@@ -336,9 +336,7 @@ ExRefreshTimeZoneInformation(IN PLARGE_INTEGER CurrentBootTime)
     ExpTimeZoneBias = NewTimeZoneBias;
 
     /* Change SharedUserData->TimeZoneBias for user-mode applications */
-    SharedUserData->TimeZoneBias.High2Time = ExpTimeZoneBias.u.HighPart;
-    SharedUserData->TimeZoneBias.LowPart = ExpTimeZoneBias.u.LowPart;
-    SharedUserData->TimeZoneBias.High1Time = ExpTimeZoneBias.u.HighPart;
+    KiWriteSystemTime(&SharedUserData->TimeZoneBias, ExpTimeZoneBias);
     SharedUserData->TimeZoneId = ExpTimeZoneId;
 
     /* Convert boot time from local time to UTC */
@@ -349,9 +347,7 @@ ExRefreshTimeZoneInformation(IN PLARGE_INTEGER CurrentBootTime)
 
     /* Change it for user-mode applications */
     CurrentTime.QuadPart += ExpTimeZoneBias.QuadPart;
-    SharedUserData->SystemTime.High2Time = CurrentTime.u.HighPart;
-    SharedUserData->SystemTime.LowPart = CurrentTime.u.LowPart;
-    SharedUserData->SystemTime.High1Time = CurrentTime.u.HighPart;
+    KiWriteSystemTime(&SharedUserData->SystemTime, CurrentTime);
 
     /* Return success */
     return TRUE;
@@ -424,9 +420,7 @@ ExpSetTimeZoneInformation(PRTL_TIME_ZONE_INFORMATION TimeZoneInformation)
                   sizeof(RTL_TIME_ZONE_INFORMATION));
 
     /* Set the new time zone information */
-    SharedUserData->TimeZoneBias.High1Time = ExpTimeZoneBias.u.HighPart;
-    SharedUserData->TimeZoneBias.High2Time = ExpTimeZoneBias.u.HighPart;
-    SharedUserData->TimeZoneBias.LowPart = ExpTimeZoneBias.u.LowPart;
+    KiWriteSystemTime(&SharedUserData->TimeZoneBias, ExpTimeZoneBias);
     SharedUserData->TimeZoneId = ExpTimeZoneId;
 
     DPRINT("New time zone bias: %I64d minutes\n",

--- a/ntoskrnl/ke/clock.c
+++ b/ntoskrnl/ke/clock.c
@@ -55,9 +55,7 @@ KeSetSystemTime(IN PLARGE_INTEGER NewTime,
     KeQuerySystemTime(OldTime);
 
     /* Set the new system time (ordering of these operations is critical) */
-    SharedUserData->SystemTime.High2Time = NewTime->HighPart;
-    SharedUserData->SystemTime.LowPart = NewTime->LowPart;
-    SharedUserData->SystemTime.High1Time = NewTime->HighPart;
+    KiWriteSystemTime(&SharedUserData->SystemTime, *NewTime);
 
     /* Check if this was for the HAL and set the RTC time */
     if (HalTime) ExCmosClockIsSane = HalSetRealTimeClock(&TimeFields);
@@ -162,17 +160,9 @@ KeQueryTimeIncrement(VOID)
 #undef KeQueryTickCount
 VOID
 NTAPI
-KeQueryTickCount(IN PLARGE_INTEGER TickCount)
+KeQueryTickCount(_Out_ PLARGE_INTEGER TickCount)
 {
-    /* Loop until we get a perfect match */
-    for (;;)
-    {
-        /* Read the tick count value */
-        TickCount->HighPart = KeTickCount.High1Time;
-        TickCount->LowPart = KeTickCount.LowPart;
-        if (TickCount->HighPart == KeTickCount.High2Time) break;
-        YieldProcessor();
-    }
+    *TickCount = KiReadSystemTime(&KeTickCount);
 }
 
 #ifndef _M_AMD64

--- a/sdk/include/ndk/kefuncs.h
+++ b/sdk/include/ndk/kefuncs.h
@@ -396,6 +396,59 @@ KeRaiseUserException(
 
 #endif
 
+#ifndef NONAMELESSUNION
+
+FORCEINLINE
+LARGE_INTEGER
+KiReadSystemTime(
+    _In_ volatile const KSYSTEM_TIME *SystemTime)
+{
+    LARGE_INTEGER Time;
+
+#ifdef _WIN64
+    /* Do a single atomic read */
+    Time.QuadPart = *(volatile LONG64*)SystemTime;
+#else
+    /* Read in a loop until we get a match */
+    for (;;)
+    {
+        Time.HighPart = SystemTime->High1Time;
+        Time.LowPart = SystemTime->LowPart;
+        if (Time.HighPart == SystemTime->High2Time)
+            break;
+        YieldProcessor();
+    }
+#endif
+    return Time;
+}
+
+#ifndef NTOS_MODE_USER
+
+FORCEINLINE
+VOID
+KiWriteSystemTime(
+    _Out_ volatile KSYSTEM_TIME *SystemTime,
+    _In_ LARGE_INTEGER NewTime)
+{
+    /* Update High2Time first to indicate an update in progress */
+    SystemTime->High2Time = NewTime.HighPart;
+
+#ifdef _WIN64
+    /* Do a single 'atomic' write. This isn't actually guaranteed to be atomic,
+       if the address isn't 64 bit aligned. But as long as the entire 64 bits
+       are within a single cache line, we should be good (on x64 at least,
+       when it comes to ARM64, all bets are off) This is also what Windows does. */
+    *(LONG64*)SystemTime = NewTime.QuadPart;
+#else
+    /* Update low part, then high part to allow readers detect partial updates. */
+    SystemTime->LowPart = NewTime.LowPart;
+    SystemTime->High1Time = NewTime.HighPart;
+#endif
+}
+
+#endif // !NTOS_MODE_USER
+#endif // !NONAMELESSUNION
+
 //
 // Native Calls
 //

--- a/sdk/include/ndk/kefuncs.h
+++ b/sdk/include/ndk/kefuncs.h
@@ -447,6 +447,22 @@ KiWriteSystemTime(
 }
 
 #endif // !NTOS_MODE_USER
+
+FORCEINLINE
+ULONG64
+KiTickCountToMs(_In_ LARGE_INTEGER TickCount)
+{
+#ifdef _WIN64
+    /* Native math is optimal on 64 bit */
+    return (TickCount.QuadPart * SharedUserData->TickCountMultiplier) >> 24;
+#else
+    /* This is optimal on 32 bit (overflows after ~20,000 years) */
+    ULONG Multiplier = SharedUserData->TickCountMultiplier;
+    return (UInt32x32To64(TickCount.LowPart, Multiplier) >> 24) +
+            UInt32x32To64(TickCount.HighPart << 8, Multiplier);
+#endif
+}
+
 #endif // !NONAMELESSUNION
 
 //

--- a/sdk/include/ndk/ketypes.h
+++ b/sdk/include/ndk/ketypes.h
@@ -126,11 +126,6 @@ Author:
 #define THREAD_ALERT_INCREMENT          2
 
 //
-// Physical memory offset of KUSER_SHARED_DATA
-//
-#define KI_USER_SHARED_DATA_PHYSICAL    0x41000
-
-//
 // Quantum values and decrements
 //
 #define MAX_QUANTUM                     0x7F
@@ -163,6 +158,11 @@ typedef struct _FIBER                                    /* Field offsets:    */
     struct _ACTIVATION_CONTEXT_STACK *ActivationContextStackPointer;
 #endif
 } FIBER, *PFIBER;
+
+//
+// KUSER_SHARED_DATA location in User Mode
+//
+#define USER_SHARED_DATA                0x7FFE0000
 
 #ifndef NTOS_MODE_USER
 //

--- a/sdk/include/ndk/pstypes.h
+++ b/sdk/include/ndk/pstypes.h
@@ -46,11 +46,6 @@ extern POBJECT_TYPE NTSYSAPI PsJobType;
 #endif // !NTOS_MODE_USER
 
 //
-// KUSER_SHARED_DATA location in User Mode
-//
-#define USER_SHARED_DATA                        (0x7FFE0000)
-
-//
 // Global Flags
 //
 #define FLG_STOP_ON_EXCEPTION                   0x00000001

--- a/sdk/include/xdk/arm64/ke.h
+++ b/sdk/include/xdk/arm64/ke.h
@@ -13,6 +13,7 @@ $if (_WDMDDK_)
 #define PROFILE_LEVEL           15
 #define HIGH_LEVEL              15
 
+#define KI_USER_SHARED_DATA     0xFFFFF78000000000ULL
 #define SharedUserData          ((KUSER_SHARED_DATA * const)KI_USER_SHARED_DATA)
 
 #define PAGE_SIZE               0x1000

--- a/win32ss/gdi/eng/engmisc.c
+++ b/win32ss/gdi/eng/engmisc.c
@@ -287,16 +287,13 @@ ULONGLONG
 APIENTRY
 EngGetTickCount(VOID)
 {
-    ULONG Multiplier;
     LARGE_INTEGER TickCount;
 
-    /* Get the multiplier and current tick count */
+    /* Get the current tick count */
     KeQueryTickCount(&TickCount);
-    Multiplier = SharedUserData->TickCountMultiplier;
 
-    /* Convert to milliseconds and return */
-    return (Int64ShrlMod32(UInt32x32To64(Multiplier, TickCount.LowPart), 24) +
-            (Multiplier * (TickCount.HighPart << 8)));
+    /* Convert to milliseconds */
+    return KiTickCountToMs(TickCount);
 }
 
 /* EOF */


### PR DESCRIPTION
## Purpose

Fix KiWriteSystemTime and move it to NDK. The previous implementation of KiWriteSystemTime was broken and updated the fields in the wrong order. Before that it was right for SystemTime and wrong for InterruptTime. ExpSetTimeZoneInformation had it wrong for the TimeZoneBias.
Add KiReadSystemTime to read KSYSTEM_TIME values correctly, instead of doing it manually (and partly wrongly) all over the place.

## Testbot runs (Filled in by Devs)

- ✅ KVM x86: https://reactos.org/testman/compare.php?ids=104214,104217,104227,104230
- ✅ KVM x64: https://reactos.org/testman/compare.php?ids=104207,104216,104226,104229

New run (2026-04-23):
- [x] KVM x86: https://reactos.org/testman/compare.php?ids=106969,106970,106974
  riched32:editor and rpcrt4:cstub did run without regressions, but the debug output was messed up.
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=106962,106963,106975
  user32 tests are not regressions, but fixes from a previous merge that wasn't built, so the comparison is to an older version.