### PR TITLE
[DWNL] improve user experience and fix progress output

### DIFF
--- a/base/applications/network/dwnl/dwnl.c
+++ b/base/applications/network/dwnl/dwnl.c
@@ -73,7 +73,7 @@ CBindStatusCallback_UpdateProgress(CBindStatusCallback *This)
         UINT Percentage;
 
         Percentage = (UINT)((This->Progress * 100) / This->Size);
-        if (Percentage > 99)
+        if (Percentage > 100) // If percentage is greater than 100%, do a failsafe
             Percentage = 99;
 
         LoadStringW(NULL, IDS_BYTES_DOWNLOADED_FULL, szMessage, ARRAYSIZE(szMessage));
@@ -246,6 +246,14 @@ CBindStatusCallback_OnProgress(IBindStatusCallback *iface,
             break;
 
         case BINDSTATUS_ENDDOWNLOADDATA:
+			/* since download is completed, update progress one last time to be at 100% */
+            if(This->Size) // To avoid division by zero: if file size is known
+            {
+
+                This->Progress = This->Size; // Ensure progress == total size
+                CBindStatusCallback_UpdateProgress(This); // Show 100% progress now
+            }
+
             ConResPrintf(StdOut, IDS_FILE_SAVED);
             break;
 
@@ -502,3 +510,4 @@ int wmain(int argc, WCHAR **argv)
 
     return iRet;
 }
+

--- a/base/applications/network/dwnl/dwnl.c
+++ b/base/applications/network/dwnl/dwnl.c
@@ -248,7 +248,6 @@ CBindStatusCallback_OnProgress(IBindStatusCallback *iface,
 
         case BINDSTATUS_ENDDOWNLOADDATA:
             /* Since download is completed, update progress one last time to be at 100% */
-			// Temporary comment to trigger GitHub pipeline
             This->Progress = This->Size; // Ensure progress == total size
             CBindStatusCallback_UpdateProgress(This); // Show 100% progress now
 

--- a/base/applications/network/dwnl/dwnl.c
+++ b/base/applications/network/dwnl/dwnl.c
@@ -73,8 +73,9 @@ CBindStatusCallback_UpdateProgress(CBindStatusCallback *This)
         UINT Percentage;
 
         Percentage = (UINT)((This->Progress * 100) / This->Size);
-    // If percentage is greater than 99% but sizes don't match, do a failsafe.
-    if ((Percentage > 99) && (This->Progress != This->Size))
+
+        // If percentage is greater than 99% but sizes don't match, do a failsafe.
+        if ((Percentage > 99) && (This->Progress != This->Size))
             Percentage = 99;
 
         LoadStringW(NULL, IDS_BYTES_DOWNLOADED_FULL, szMessage, ARRAYSIZE(szMessage));

--- a/base/applications/network/dwnl/dwnl.c
+++ b/base/applications/network/dwnl/dwnl.c
@@ -246,7 +246,7 @@ CBindStatusCallback_OnProgress(IBindStatusCallback *iface,
             break;
 
         case BINDSTATUS_ENDDOWNLOADDATA:
-			/* since download is completed, update progress one last time to be at 100% */
+            /* since download is completed, update progress one last time to be at 100% */
             if(This->Size) // To avoid division by zero: if file size is known
             {
 
@@ -510,4 +510,3 @@ int wmain(int argc, WCHAR **argv)
 
     return iRet;
 }
-

--- a/base/applications/network/dwnl/dwnl.c
+++ b/base/applications/network/dwnl/dwnl.c
@@ -248,11 +248,8 @@ CBindStatusCallback_OnProgress(IBindStatusCallback *iface,
 
         case BINDSTATUS_ENDDOWNLOADDATA:
             /* Since download is completed, update progress one last time to be at 100% */
-            if (This->Size) // To avoid division by zero: if file size is known
-            {
-                This->Progress = This->Size; // Ensure progress == total size
-                CBindStatusCallback_UpdateProgress(This); // Show 100% progress now
-            }
+            This->Progress = This->Size; // Ensure progress == total size
+            CBindStatusCallback_UpdateProgress(This); // Show 100% progress now
 
             ConResPrintf(StdOut, IDS_FILE_SAVED);
             break;

--- a/base/applications/network/dwnl/dwnl.c
+++ b/base/applications/network/dwnl/dwnl.c
@@ -248,6 +248,7 @@ CBindStatusCallback_OnProgress(IBindStatusCallback *iface,
 
         case BINDSTATUS_ENDDOWNLOADDATA:
             /* Since download is completed, update progress one last time to be at 100% */
+			// Temporary comment to trigger GitHub pipeline
             This->Progress = This->Size; // Ensure progress == total size
             CBindStatusCallback_UpdateProgress(This); // Show 100% progress now
 

--- a/base/applications/network/dwnl/dwnl.c
+++ b/base/applications/network/dwnl/dwnl.c
@@ -73,7 +73,7 @@ CBindStatusCallback_UpdateProgress(CBindStatusCallback *This)
         UINT Percentage;
 
         Percentage = (UINT)((This->Progress * 100) / This->Size);
-        if (Percentage > 100) // If percentage is greater than 100%, do a failsafe
+        if ((Percentage > 99) && (This->Progress != This->Size)) // If percentage is greater than 99% but sizes don't match, do a failsafe
             Percentage = 99;
 
         LoadStringW(NULL, IDS_BYTES_DOWNLOADED_FULL, szMessage, ARRAYSIZE(szMessage));

--- a/base/applications/network/dwnl/dwnl.c
+++ b/base/applications/network/dwnl/dwnl.c
@@ -73,7 +73,8 @@ CBindStatusCallback_UpdateProgress(CBindStatusCallback *This)
         UINT Percentage;
 
         Percentage = (UINT)((This->Progress * 100) / This->Size);
-        if ((Percentage > 99) && (This->Progress != This->Size)) // If percentage is greater than 99% but sizes don't match, do a failsafe
+    // If percentage is greater than 99% but sizes don't match, do a failsafe.
+    if ((Percentage > 99) && (This->Progress != This->Size))
             Percentage = 99;
 
         LoadStringW(NULL, IDS_BYTES_DOWNLOADED_FULL, szMessage, ARRAYSIZE(szMessage));

--- a/base/applications/network/dwnl/dwnl.c
+++ b/base/applications/network/dwnl/dwnl.c
@@ -73,7 +73,6 @@ CBindStatusCallback_UpdateProgress(CBindStatusCallback *This)
         UINT Percentage;
 
         Percentage = (UINT)((This->Progress * 100) / This->Size);
-
         // If percentage is greater than 99% but sizes don't match, do a failsafe.
         if ((Percentage > 99) && (This->Progress != This->Size))
             Percentage = 99;

--- a/base/applications/network/dwnl/dwnl.c
+++ b/base/applications/network/dwnl/dwnl.c
@@ -247,7 +247,7 @@ CBindStatusCallback_OnProgress(IBindStatusCallback *iface,
             break;
 
         case BINDSTATUS_ENDDOWNLOADDATA:
-            /* since download is completed, update progress one last time to be at 100% */
+            /* Since download is completed, update progress one last time to be at 100% */
             if(This->Size) // To avoid division by zero: if file size is known
             {
 

--- a/base/applications/network/dwnl/dwnl.c
+++ b/base/applications/network/dwnl/dwnl.c
@@ -248,9 +248,8 @@ CBindStatusCallback_OnProgress(IBindStatusCallback *iface,
 
         case BINDSTATUS_ENDDOWNLOADDATA:
             /* Since download is completed, update progress one last time to be at 100% */
-            if(This->Size) // To avoid division by zero: if file size is known
+            if (This->Size) // To avoid division by zero: if file size is known
             {
-
                 This->Progress = This->Size; // Ensure progress == total size
                 CBindStatusCallback_UpdateProgress(This); // Show 100% progress now
             }


### PR DESCRIPTION
## Purpose

Currently, this is the behavior of `dwnl.exe`, on large files,

```
C:\dwnl>dwnl https://github.com/win32ss/supermium/releases/download/v132-r2/supe
rmium_132_32_setup.exe DL1.exe
--2025-04-17 16:33:24-- https://github.com/win32ss/supermium/releases/download/v
132-r2/supermium_132_32_setup.exe
        => DL1.exe
Connecting to 4.237.22.38... done.
Sending request... Connecting to 185.199.108.133... done.
Sending request... done.
Length: 106478533 [application/x-msdownload]

99% (106471168 byte(s) downloaded)
File saved.
```

Notice that the progression stops at **99%** AND **Length: 106478533** does **NOT** match **106471168 byte(s) downloaded**

This Push Request aims to fix this experience

## Proposed changes

The following changes were made

* CBindStatusCallback_UpdateProgress - Rework the failsafe check to enable percentage to be at 100%
* CBindStatusCallback_UpdateProgress - More thorough failsafe check, to avoid displaying 100% (or even 101%) where the actual and expected file sizes don't match
* `case BINDSTATUS_ENDDOWNLOADDATA` - Do update the progress one last time to be at 100%, on download success

### New behavior

The result is now:

```
C:\dwnl>dwnl-100 https://github.com/win32ss/supermium/releases/download/v132-r2/
supermium_132_32_setup.exe DL2.exe
--2025-04-17 16:34:14-- https://github.com/win32ss/supermium/releases/download/v
132-r2/supermium_132_32_setup.exe
        => DL2.exe
Connecting to 4.237.22.38... done.
Sending request... Connecting to 185.199.108.133... done.
Sending request... done.
Length: 106478533 [application/x-msdownload]

100% (106478533 byte(s) downloaded)
File saved.
```

By the way, just for reference, both old `dwnl.exe` and updated `dwnl.exe` produce the same files, so downloading logic is not changed (according to hashmyfiles):
```
==================================================
Filename          : DL1.exe
MD5               : 6bc6783323e698144315ada93af20581
SHA1              : b9138fef8a730d9ac888a1868c9147aefd7fb7c9
CRC32             : 41678877
SHA-256           : a02092240dbf277faf974a9aa8948328bff5fc1d46de37bb82377741b9078e24
SHA-512           : fe40c8cacb05ef9b8573c043102d6ec276af5627601707d8f935c4976e5a2cde253d7e45fb40c9a6d7d7e1580231751b028e3085d987fef141875441e98135f7
SHA-384           : 511224cefd366aa4386cdbc97f0c53d73688b006e3638cdec5e66cad00a443bb4cf58d59356c08c35ac5306584798dd4
Full Path         : C:\dwnl\DL1.exe
Modified Time     : 4/17/2025 4:34:00 PM
Created Time      : 4/17/2025 4:33:59 PM
Entry Modified Time: 
File Size         : 106,478,533
File Version      : 23.01
Product Version   : 23.01
Identical         : 1
Extension         : exe
File Attributes   : A
Hash Start Time   : 4/17/2025 4:52:54 PM
Hash End Time     : 4/17/2025 4:53:01 PM
Hashing Duration  : 00:00:07.152
==================================================

==================================================
Filename          : DL2.exe
MD5               : 6bc6783323e698144315ada93af20581
SHA1              : b9138fef8a730d9ac888a1868c9147aefd7fb7c9
CRC32             : 41678877
SHA-256           : a02092240dbf277faf974a9aa8948328bff5fc1d46de37bb82377741b9078e24
SHA-512           : fe40c8cacb05ef9b8573c043102d6ec276af5627601707d8f935c4976e5a2cde253d7e45fb40c9a6d7d7e1580231751b028e3085d987fef141875441e98135f7
SHA-384           : 511224cefd366aa4386cdbc97f0c53d73688b006e3638cdec5e66cad00a443bb4cf58d59356c08c35ac5306584798dd4
Full Path         : C:\dwnl\DL2.exe
Modified Time     : 4/17/2025 4:34:48 PM
Created Time      : 4/17/2025 4:34:46 PM
Entry Modified Time: 
File Size         : 106,478,533
File Version      : 23.01
Product Version   : 23.01
Identical         : 1
Extension         : exe
File Attributes   : A
Hash Start Time   : 4/17/2025 4:53:01 PM
Hash End Time     : 4/17/2025 4:53:09 PM
Hashing Duration  : 00:00:07.887
==================================================
```

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: