### PR TITLE
[SHELL32] Fix: Deselect highlighted item in shell menus on close

### DIFF
--- a/dll/win32/shell32/shellmenu/CMenuBand.cpp
+++ b/dll/win32/shell32/shellmenu/CMenuBand.cpp
@@ -588,6 +588,8 @@ HRESULT STDMETHODCALLTYPE CMenuBand::OnSelect(DWORD dwSelectType)
     case MPOS_CANCELLEVEL:
         if (m_subMenuChild)
             m_subMenuChild->OnSelect(dwSelectType);
+        // Deselect the currently selected item
+        _ChangeHotItem(NULL, -1, 0);
         break;
     }
     return S_FALSE;


### PR DESCRIPTION
## Purpose

This PR fixes "[definitely not EXPLORER] a subtle keyboard focus glitch in the startmenu" by deselecting the currently selected item in CMenuBand.

JIRA issue: [CORE-18855](https://jira.reactos.org/browse/CORE-18855)

## Proposed changes

Add a call to `_ChangeHotItem(NULL, -1, 0)` in `CMenuBand::OnSelect(MPOS_CANCELLEVEL)` which causes to deselect currently selected item the moment the menu bands (including start menu) are closing.
Start Menu is not destroyed when it's closed so its allocated resources can be re-used next time user wants to open it, so to keep this behavior and still not having an item selected every time you open the start menu, you have to deselect the currently selected item.
