### PR TITLE
[HAL] Misc fixes

### DIFF
--- a/hal/halx86/apic/apic.c
+++ b/hal/halx86/apic/apic.c
@@ -503,7 +503,7 @@ ApicInitializeIOApic(VOID)
     ReDirReg.Vector = APIC_CLOCK_VECTOR;
     ReDirReg.MessageType = APIC_MT_Fixed;
     ReDirReg.DestinationMode = APIC_DM_Physical;
-    ReDirReg.TriggerMode = APIC_TGM_Edge;
+    ReDirReg.TriggerMode = APIC_TGM_Level;
     ReDirReg.Mask = 1;
     ReDirReg.Destination = ApicRead(APIC_ID);
     ApicWriteIORedirectionEntry(APIC_CLOCK_INDEX, ReDirReg);

--- a/hal/halx86/apic/apic.c
+++ b/hal/halx86/apic/apic.c
@@ -675,7 +675,6 @@ HalEnableSystemInterrupt(
     IN KINTERRUPT_MODE InterruptMode)
 {
     IOAPIC_REDIRECTION_REGISTER ReDirReg;
-    PKPRCB Prcb = KeGetCurrentPrcb();
     UCHAR Index;
     ASSERT(Irql <= HIGH_LEVEL);
     ASSERT((IrqlToTpr(Irql) & 0xF0) == (Vector & 0xF0));
@@ -693,26 +692,21 @@ HalEnableSystemInterrupt(
     /* Read the redirection entry */
     ReDirReg = ApicReadIORedirectionEntry(Index);
 
-    /* Check if the interrupt was unused */
-    if (ReDirReg.Vector != Vector)
+    /* Check if the interrupt is already enabled */
+    if (ReDirReg.Mask == FALSE)
     {
-        ReDirReg.Vector = Vector;
-        ReDirReg.MessageType = APIC_MT_LowestPriority;
-        ReDirReg.DestinationMode = APIC_DM_Logical;
-        ReDirReg.Destination = 0;
+        /* If the vector matches, there is nothing more to do,
+           otherwise something is wrong. */
+        return (ReDirReg.Vector == Vector);
     }
 
-    /* Check if the destination is logical */
-    if (ReDirReg.DestinationMode == APIC_DM_Logical)
-    {
-        /* Set the bit for this cpu */
-        ReDirReg.Destination |= ApicLogicalId(Prcb->Number);
-    }
-
-    /* Set the trigger mode */
-    ReDirReg.TriggerMode = 1 - InterruptMode;
-
-    /* Now unmask it */
+    /* Set up the redirection entry */
+    ReDirReg.Vector = Vector;
+    ReDirReg.MessageType = APIC_MT_Fixed;
+    ReDirReg.DestinationMode = APIC_DM_Physical;
+    ReDirReg.Destination = KeGetCurrentPrcb()->InitialApicId;
+    ReDirReg.TriggerMode = (InterruptMode == LevelSensitive) ?
+        APIC_TGM_Level : APIC_TGM_Edge;
     ReDirReg.Mask = FALSE;
 
     /* Write back the entry */

--- a/hal/halx86/apic/apic.c
+++ b/hal/halx86/apic/apic.c
@@ -385,7 +385,7 @@ HalpAllocateSystemInterrupt(
     ReDirReg.TriggerMode = APIC_TGM_Edge;
     ReDirReg.Mask = 1;
     ReDirReg.Reserved = 0;
-    ReDirReg.Destination = 0;
+    ReDirReg.Destination = ApicRead(APIC_ID) >> 24;
 
     /* Initialize entry */
     ApicWriteIORedirectionEntry(Irq, ReDirReg);
@@ -484,7 +484,7 @@ ApicInitializeIOApic(VOID)
     ReDirReg.TriggerMode = APIC_TGM_Edge;
     ReDirReg.Mask = 1;
     ReDirReg.Reserved = 0;
-    ReDirReg.Destination = 0;
+    ReDirReg.Destination = ApicRead(APIC_ID) >> 24;
 
     /* Loop all table entries */
     for (Index = 0; Index < APIC_MAX_IRQ; Index++)
@@ -505,7 +505,7 @@ ApicInitializeIOApic(VOID)
     ReDirReg.DestinationMode = APIC_DM_Physical;
     ReDirReg.TriggerMode = APIC_TGM_Level;
     ReDirReg.Mask = 1;
-    ReDirReg.Destination = ApicRead(APIC_ID);
+    ReDirReg.Destination = ApicRead(APIC_ID) >> 24;
     ApicWriteIORedirectionEntry(APIC_CLOCK_INDEX, ReDirReg);
 }
 
@@ -704,7 +704,7 @@ HalEnableSystemInterrupt(
     ReDirReg.Vector = Vector;
     ReDirReg.MessageType = APIC_MT_Fixed;
     ReDirReg.DestinationMode = APIC_DM_Physical;
-    ReDirReg.Destination = KeGetCurrentPrcb()->InitialApicId;
+    ReDirReg.Destination = ApicRead(APIC_ID) >> 24;
     ReDirReg.TriggerMode = (InterruptMode == LevelSensitive) ?
         APIC_TGM_Level : APIC_TGM_Edge;
     ReDirReg.Mask = FALSE;

--- a/hal/halx86/apic/apic.c
+++ b/hal/halx86/apic/apic.c
@@ -152,7 +152,7 @@ ApicRequestSelfInterrupt(IN UCHAR Vector, UCHAR TriggerMode)
     ULONG IrrBit = 1UL << VectorLow;
 
     /* Setup the command register */
-    Icr.Long0 = 0;
+    Icr.LongLong = 0;
     Icr.Vector = Vector;
     Icr.MessageType = APIC_MT_Fixed;
     Icr.TriggerMode = TriggerMode;
@@ -168,7 +168,8 @@ ApicRequestSelfInterrupt(IN UCHAR Vector, UCHAR TriggerMode)
         IcrStatus.Long0 = ApicRead(APIC_ICR0);
     } while (IcrStatus.DeliveryStatus);
 
-    /* Write the low dword to send the interrupt */
+    /* Write high dword first, then low dword to send the interrupt */
+    ApicWrite(APIC_ICR1, Icr.Long1);
     ApicWrite(APIC_ICR0, Icr.Long0);
 
     /* Wait until we see the interrupt request.
@@ -176,7 +177,7 @@ ApicRequestSelfInterrupt(IN UCHAR Vector, UCHAR TriggerMode)
      */
     while (!(ApicRead(Irr) & IrrBit))
     {
-        NOTHING;
+        YieldProcessor();
     }
 
     /* Finally, restore the original interrupt state */

--- a/hal/halx86/apic/apicp.h
+++ b/hal/halx86/apic/apicp.h
@@ -32,6 +32,7 @@
     #define IrqlToSoftVector(Irql) ((Irql << 4)|0xf)
     #define TprToIrql(Tpr) ((KIRQL)(Tpr >> 4))
     #define CLOCK2_LEVEL CLOCK_LEVEL
+    #define APIC_PROFILE_LEVEL PROFILE_LEVEL
 #else
     #define LOCAL_APIC_BASE  0xFFFE0000
     #define IOAPIC_BASE 0xFFFE1000
@@ -54,6 +55,7 @@
     #define IrqlToTpr(Irql) (HalpIRQLtoTPR[Irql])
     #define IrqlToSoftVector(Irql) IrqlToTpr(Irql)
     #define TprToIrql(Tpr)  (HalVectorToIRQL[Tpr >> 4])
+    #define APIC_PROFILE_LEVEL HIGH_LEVEL
 #endif
 
 #define APIC_MAX_IRQ 24

--- a/hal/halx86/apic/apictimer.c
+++ b/hal/halx86/apic/apictimer.c
@@ -36,11 +36,11 @@ ApicSetTimerInterval(ULONG MicroSeconds)
     /* Set the count interval */
     ApicWrite(APIC_TICR, (ULONG)TimerInterval);
 
-    /* Set to periodic */
+    /* Set to periodic / masked */
     LvtEntry.Long = 0;
     LvtEntry.TimerMode = 1;
     LvtEntry.Vector = APIC_PROFILE_VECTOR;
-    LvtEntry.Mask = 0;
+    LvtEntry.Mask = 1;
     ApicWrite(APIC_TMRLVTR, LvtEntry.Long);
 
 }

--- a/hal/halx86/apic/halinit.c
+++ b/hal/halx86/apic/halinit.c
@@ -63,7 +63,7 @@ HalpInitPhase0(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
     HalpEnableInterruptHandler(IDT_DEVICE,
                                0,
                                APIC_PROFILE_VECTOR,
-                               PROFILE_LEVEL,
+                               APIC_PROFILE_LEVEL,
                                HalpProfileInterrupt,
                                Latched);
 }

--- a/hal/halx86/generic/cmos.c
+++ b/hal/halx86/generic/cmos.c
@@ -24,8 +24,8 @@ UCHAR
 NTAPI
 HalpReadCmos(IN UCHAR Reg)
 {
-    /* Select the register */
-    WRITE_PORT_UCHAR(CMOS_CONTROL_PORT, Reg);
+    /* Select the register (0x80 to disable NMIs) */
+    WRITE_PORT_UCHAR(CMOS_CONTROL_PORT, 0x80 | Reg);
 
     /* Query the value */
     return READ_PORT_UCHAR(CMOS_DATA_PORT);
@@ -37,8 +37,8 @@ NTAPI
 HalpWriteCmos(IN UCHAR Reg,
               IN UCHAR Value)
 {
-    /* Select the register */
-    WRITE_PORT_UCHAR(CMOS_CONTROL_PORT, Reg);
+    /* Select the register (0x80 to disable NMIs) */
+    WRITE_PORT_UCHAR(CMOS_CONTROL_PORT, 0x80 | Reg);
 
     /* Write the value */
     WRITE_PORT_UCHAR(CMOS_DATA_PORT, Value);


### PR DESCRIPTION
## Purpose

Fix a number of issues, mostly APIC related.

## Proposed changes

* [HALX86] Set the NMI disable flag when accessing CMOS registers
* [HALX86/APIC] Mask profiling interrupt on init
* [HALX86/APIC] Fix interrupt delivery on bare metal
* [HALX86/APIC] Set timer interrupt to level triggered
* [HALX86/APIC] Use physical addressing in HalEnableSystemInterrupt
* [HALX86/APIC] Read APIC Id from APIC instead of using initial Id
* [HALX86/APIC] Change IRQL for x86 profile interrupt to HIGH_LEVEL

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=101595,101596,101605,101609
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=101592,101597,101606,101610