### PR TITLE
[SHELL32] Handle sort order in RegItems

### DIFF
--- a/dll/win32/shell32/folders/CDesktopFolder.cpp
+++ b/dll/win32/shell32/folders/CDesktopFolder.cpp
@@ -29,9 +29,9 @@ extern BOOL SHELL32_IsShellFolderNamespaceItemHidden(LPCWSTR SubKey, REFCLSID Cl
 
 static const REQUIREDREGITEM g_RequiredItems[] =
 {
-    { CLSID_MyComputer, "sysdm.cpl", 0x50 },
-    { CLSID_NetworkPlaces, "ncpa.cpl", 0x58 },
-    { CLSID_Internet, "inetcpl.cpl", 0x68 },
+    { CLSID_MyComputer, "sysdm.cpl", REGITEMORDER_MYCOMPUTER },
+    { CLSID_NetworkPlaces, "ncpa.cpl", REGITEMORDER_NETHOOD },
+    { CLSID_Internet, "inetcpl.cpl", REGITEMORDER_INTERNET },
 };
 static const REGFOLDERINFO g_RegFolderInfo =
 {

--- a/dll/win32/shell32/folders/CDrivesFolder.cpp
+++ b/dll/win32/shell32/folders/CDrivesFolder.cpp
@@ -57,7 +57,7 @@ static int iDriveTypeIds[7] = { IDS_DRIVE_FIXED,       /* DRIVE_UNKNOWN */
 
 static const REQUIREDREGITEM g_RequiredItems[] =
 {
-    { CLSID_ControlPanel, 0, 0x50 },
+    { CLSID_ControlPanel, 0, REGITEMORDER_MYCOMPUTER_CONTROLS },
 };
 static const REGFOLDERINFO g_RegFolderInfo =
 {

--- a/dll/win32/shell32/wine/pidl.c
+++ b/dll/win32/shell32/wine/pidl.c
@@ -1763,19 +1763,19 @@ LPITEMIDLIST _ILCreateDesktop(void)
 LPITEMIDLIST _ILCreateMyComputer(void)
 {
     TRACE("()\n");
-    return _ILCreateGuid(PT_DESKTOP_REGITEM, &CLSID_MyComputer);
+    return _ILCreateGuid(PT_DESKTOP_REGITEM, &CLSID_MyComputer, REGITEMORDER_MYCOMPUTER);
 }
 
 LPITEMIDLIST _ILCreateMyDocuments(void)
 {
     TRACE("()\n");
-    return _ILCreateGuid(PT_DESKTOP_REGITEM, &CLSID_MyDocuments);
+    return _ILCreateGuid(PT_DESKTOP_REGITEM, &CLSID_MyDocuments, REGITEMORDER_MYDOCS_DEFAULT);
 }
 
 LPITEMIDLIST _ILCreateIExplore(void)
 {
     TRACE("()\n");
-    return _ILCreateGuid(PT_DESKTOP_REGITEM, &CLSID_Internet);
+    return _ILCreateGuid(PT_DESKTOP_REGITEM, &CLSID_Internet, REGITEMORDER_INTERNET);
 }
 
 LPITEMIDLIST _ILCreateControlPanel(void)
@@ -1785,7 +1785,7 @@ LPITEMIDLIST _ILCreateControlPanel(void)
     TRACE("()\n");
     if (parent)
     {
-        LPITEMIDLIST cpl = _ILCreateGuid(PT_COMPUTER_REGITEM, &CLSID_ControlPanel);
+        LPITEMIDLIST cpl = _ILCreateGuid(PT_COMPUTER_REGITEM, &CLSID_ControlPanel, REGITEMORDER_MYCOMPUTER_CONTROLS);
         if (cpl)
         {
             ret = ILCombine(parent, cpl);
@@ -1826,22 +1826,22 @@ LPITEMIDLIST _ILCreatePrinters(void)
 LPITEMIDLIST _ILCreateNetwork(void)
 {
     TRACE("()\n");
-    return _ILCreateGuid(PT_DESKTOP_REGITEM, &CLSID_NetworkPlaces);
+    return _ILCreateGuid(PT_DESKTOP_REGITEM, &CLSID_NetworkPlaces, REGITEMORDER_NETHOOD);
 }
 
 LPITEMIDLIST _ILCreateBitBucket(void)
 {
     TRACE("()\n");
-    return _ILCreateGuid(PT_DESKTOP_REGITEM, &CLSID_RecycleBin);
+    return _ILCreateGuid(PT_DESKTOP_REGITEM, &CLSID_RecycleBin, REGITEMORDER_RECYCLEBIN);
 }
 
 LPITEMIDLIST _ILCreateAdminTools(void)
 {
     TRACE("()\n");
-    return _ILCreateGuid(PT_GUID, &CLSID_AdminFolderShortcut); //FIXME
+    return _ILCreateGuid(PT_GUID, &CLSID_AdminFolderShortcut, REGITEMORDER_DEFAULT); //FIXME
 }
 
-LPITEMIDLIST _ILCreateGuid(PIDLTYPE type, REFIID guid)
+LPITEMIDLIST _ILCreateGuid(PIDLTYPE type, REFIID guid, BYTE SortOrder)
 {
     LPITEMIDLIST pidlOut;
 
@@ -1851,7 +1851,7 @@ LPITEMIDLIST _ILCreateGuid(PIDLTYPE type, REFIID guid)
         if (pidlOut)
         {
             LPPIDLDATA pData = _ILGetDataPointer(pidlOut);
-
+            pidlOut->mkid.abID[1] = SortOrder;
             pData->u.guid.guid = *guid;
             TRACE("-- create GUID-pidl %s\n",
                   debugstr_guid(&(pData->u.guid.guid)));

--- a/dll/win32/shell32/wine/pidl.h
+++ b/dll/win32/shell32/wine/pidl.h
@@ -119,7 +119,27 @@ extern "C" {
 #define PT_INTERNET_URL         0x61
 #define PT_CONTROLS_OLDREGITEM  0x70
 #define PT_CONTROLS_NEWREGITEM  0x71
+
+#define REGITEMLOCATION_CONTROLS CSIDL_DRIVES
+#define REGITEMLOCATION_PRINTERS CSIDL_CONTROLS
+
+#define REGITEMORDER_DEFAULT                 0x80
+#define REGITEMORDER_LIBRARIES               0x42
+#define REGITEMORDER_USERSFILEFOLDER         0x44
+#define REGITEMORDER_MYCOMPUTER              0x50
+#define REGITEMORDER_MYDOCS_BEFOREMYCOMPUTER 0x48 // Tweak UI "Desktop => First Icon" only
+#define REGITEMORDER_MYDOCS_AFTERMYCOMPUTER  0x54 // accepts these two values.
+#define REGITEMORDER_MYDOCS_DEFAULT          0x48
+#define REGITEMORDER_NETHOOD                 0x58
+#if REGITEMLOCATION_CONTROLS == CSIDL_DESKTOP
+#define REGITEMORDER_RECYCLEBIN              0x78
+#else
+#define REGITEMORDER_RECYCLEBIN              0x60
 #endif
+#define REGITEMORDER_INTERNET                0x68
+#define REGITEMORDER_DESKTOP_CONTROLS        0x70 // NT6
+#define REGITEMORDER_MYCOMPUTER_CONTROLS     0x1E // NT5
+#endif // __REACTOS__
 
 static inline BYTE _ILGetType(LPCITEMIDLIST pidl)
 {
@@ -269,7 +289,7 @@ UINT _ILGetDepth(LPCITEMIDLIST pidl);
 /* Creates a PIDL with guid format and type type, which must be one of PT_GUID,
  * PT_SHELLEXT, or PT_YAGUID.
  */
-LPITEMIDLIST	_ILCreateGuid(PIDLTYPE type, REFIID guid) DECLSPEC_HIDDEN;
+LPITEMIDLIST	_ILCreateGuid(PIDLTYPE type, REFIID guid, BYTE SortOrder);
 
 #ifndef __REACTOS__
 /* Like _ILCreateGuid, but using the string szGUID. */


### PR DESCRIPTION
This makes the TweakUI "First icon on desktop" setting work correctly.

![TweakUI](https://github.com/user-attachments/assets/3510ec8b-8056-45b9-bf28-0c0adecad256)

Notes:
- This will change the desktop regitem icon order for all languages. Sorting My Documents before My Computer has always been set like this in the registry but ROS never respected it before now. Windows also defaults to sorting My Documents first.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: