### PR TITLE
[SHELL32] Respect the REST_NODRIVES restriction

### DIFF
--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -2923,8 +2923,8 @@ LRESULT CDefView::OnChangeNotify(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &
         ERR("hLock == NULL\n");
         return FALSE;
     }
-
-    TRACE("(%p)(%p,%p,%p)\n", this, Pidls[0], Pidls[1], lParam);
+    lEvent &= ~SHCNE_INTERRUPT;
+    TRACE("(%p)(%p,%p,%p) %#x\n", this, Pidls[0], Pidls[1], lParam, (UINT)lEvent);
 
     if (_DoFolderViewCB(SFVM_FSNOTIFY, (WPARAM)Pidls, lEvent) == S_FALSE)
     {
@@ -2934,7 +2934,6 @@ LRESULT CDefView::OnChangeNotify(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &
 
     // Translate child IDLs.
     // SHSimpleIDListFromPathW creates fake PIDLs (lacking some attributes)
-    lEvent &= ~SHCNE_INTERRUPT;
     HRESULT hr;
     PITEMID_CHILD child0 = NULL, child1 = NULL;
     CComHeapPtr<ITEMIDLIST_RELATIVE> pidl0Temp, pidl1Temp;

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -2924,7 +2924,7 @@ LRESULT CDefView::OnChangeNotify(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &
         return FALSE;
     }
     lEvent &= ~SHCNE_INTERRUPT;
-    TRACE("(%p)(%p,%p,%p) %#x\n", this, Pidls[0], Pidls[1], lParam, (UINT)lEvent);
+    TRACE("(%p)(%p,%p,%p) %#x\n", this, Pidls[0], Pidls[1], lParam, lEvent);
 
     if (_DoFolderViewCB(SFVM_FSNOTIFY, (WPARAM)Pidls, lEvent) == S_FALSE)
     {

--- a/dll/win32/shell32/folders/CDrivesFolder.cpp
+++ b/dll/win32/shell32/folders/CDrivesFolder.cpp
@@ -563,15 +563,12 @@ class CDrivesFolderEnum :
             if (dwFlags & SHCONTF_FOLDERS)
             {
                 WCHAR wszDriveName[] = {'A', ':', '\\', '\0'};
-                DWORD dwDrivemap = GetLogicalDrives();
-                DWORD dwRestricted = SHRestricted(REST_NODRIVES);
-                while (wszDriveName[0] <= 'Z')
+                DWORD dwDrivemap = GetLogicalDrives() & ~SHRestricted(REST_NODRIVES);
+                for (; wszDriveName[0] <= 'Z'; wszDriveName[0]++)
                 {
-                    if ((dwDrivemap & 1) && !(dwRestricted & 1))
+                    if (dwDrivemap & 1)
                         AddToEnumList(_ILCreateDrive(wszDriveName));
-                    wszDriveName[0]++;
-                    dwDrivemap = dwDrivemap >> 1;
-                    dwRestricted = dwRestricted >> 1;
+                    dwDrivemap >>= 1;
                 }
             }
 

--- a/dll/win32/shell32/folders/CDrivesFolder.cpp
+++ b/dll/win32/shell32/folders/CDrivesFolder.cpp
@@ -567,7 +567,7 @@ class CDrivesFolderEnum :
                 DWORD dwRestricted = SHRestricted(REST_NODRIVES);
                 while (wszDriveName[0] <= 'Z')
                 {
-                    if((dwDrivemap & 1) && !(dwRestricted & 1))
+                    if ((dwDrivemap & 1) && !(dwRestricted & 1))
                         AddToEnumList(_ILCreateDrive(wszDriveName));
                     wszDriveName[0]++;
                     dwDrivemap = dwDrivemap >> 1;

--- a/dll/win32/shell32/folders/CDrivesFolder.h
+++ b/dll/win32/shell32/folders/CDrivesFolder.h
@@ -79,7 +79,7 @@ class CDrivesFolder :
         STDMETHOD(CallBack)(IShellFolder *psf, HWND hwndOwner, IDataObject *pdtobj, UINT uMsg, WPARAM wParam, LPARAM lParam) override;
 
         // IShellFolderViewCB
-        STDMETHODIMP MessageSFVCB(UINT uMsg, WPARAM wParam, LPARAM lParam) override { return E_NOTIMPL; }
+        STDMETHODIMP MessageSFVCB(UINT uMsg, WPARAM wParam, LPARAM lParam) override;
 
         // IFolderFilter
         STDMETHOD(ShouldShow)(IShellFolder *psf, PCIDLIST_ABSOLUTE pidlFolder, PCUITEMID_CHILD pidlItem) override;


### PR DESCRIPTION
This is the "My Computer => Drives" setting in TweakUI. Hiding a drive only hides it from the listing in Explorer, you can still access it by typing its address in the address bar. Hiding a slow floppy drive is useful to speed up Explorer.

![TweakUI](https://github.com/user-attachments/assets/74852414-c053-4aaa-b8cf-65d0c30d5859)

Notes:
- The icons will be fixed in another PR (part of a icon fix branch).
- The StrCmpLogical PR #7900 will make refresh to see the changes work when WM_SETTINGCHANGE is broadcast.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: