### PR TITLE
[NTDLL_APITEST] Add a test for NtQuerySection

### DIFF
--- a/modules/rostests/apitests/ntdll/CMakeLists.txt
+++ b/modules/rostests/apitests/ntdll/CMakeLists.txt
@@ -47,6 +47,7 @@ list(APPEND SOURCE
     NtQueryKey.c
     NtQueryObject.c
     NtQueryOpenSubKeys.c
+    NtQuerySection.c
     NtQuerySystemEnvironmentValue.c
     NtQuerySystemInformation.c
     NtQueryValueKey.c

--- a/modules/rostests/apitests/ntdll/NtQuerySection.c
+++ b/modules/rostests/apitests/ntdll/NtQuerySection.c
@@ -1,0 +1,122 @@
+/*
+ * PROJECT:     ReactOS API Tests
+ * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
+ * PURPOSE:     Test for NtQuerySection
+ * COPYRIGHT:   Copyright 2025 Timo Kreuzer <timo.kreuzer@reactos.org>
+ */
+
+#include "precomp.h"
+
+START_TEST(NtQuerySection)
+{
+    NTSTATUS Status;
+    HANDLE hSection;
+    LARGE_INTEGER MaximumSize;
+    SECTION_BASIC_INFORMATION SectionInfo;
+    SIZE_T ReturnLength;
+
+    // Create a section with SEC_COMMIT
+    MaximumSize.QuadPart = 0x20000;
+    Status = NtCreateSection(&hSection,
+                             SECTION_ALL_ACCESS,
+                             NULL, // ObjectAttributes,
+                             &MaximumSize,
+                             PAGE_EXECUTE_READWRITE,
+                             SEC_COMMIT,
+                             NULL);
+    ok_ntstatus(Status, STATUS_SUCCESS);
+    ok(hSection != NULL, "hSection is NULL\n");
+
+    // Call NtQuerySection with SectionBasicInformation and a NULL handle
+    Status = NtQuerySection(NULL,
+                            SectionBasicInformation,
+                            &SectionInfo,
+                            sizeof(SectionInfo),
+                            &ReturnLength);
+    ok_ntstatus(Status, STATUS_INVALID_HANDLE);
+
+    // Call NtQuerySection with SectionBasicInformation and a NULL buffer
+    Status = NtQuerySection(hSection,
+                            SectionBasicInformation,
+                            NULL,
+                            sizeof(SectionInfo),
+                            &ReturnLength);
+    ok_ntstatus(Status, STATUS_ACCESS_VIOLATION);
+
+    // Call NtQuerySection with SectionBasicInformation and a too small buffer
+    Status = NtQuerySection(hSection,
+                            SectionBasicInformation,
+                            &SectionInfo,
+                            sizeof(SectionInfo) - 1,
+                            &ReturnLength);
+    ok_ntstatus(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    // Call NtQuerySection with SectionBasicInformation
+    Status = NtQuerySection(hSection,
+                            SectionBasicInformation,
+                            &SectionInfo,
+                            sizeof(SectionInfo),
+                            &ReturnLength);
+    ok_ntstatus(Status, STATUS_SUCCESS);
+    ok(ReturnLength == sizeof(SectionInfo), "ReturnLength is %lu, expected %u\n", ReturnLength, sizeof(SectionInfo));
+    ok(SectionInfo.BaseAddress == NULL, "BaseAddress is %p, expected NULL\n", SectionInfo.BaseAddress);
+    ok(SectionInfo.Attributes == SEC_COMMIT, "Attributes is %lx, expected %x\n", SectionInfo.Attributes, SEC_COMMIT);
+    ok(SectionInfo.Size.QuadPart == 0x20000, "Size is %I64x, expected %I64x\n", SectionInfo.Size.QuadPart, 0x20000ull);
+
+    // Close the section handle
+    NtClose(hSection);
+
+    // Create a section with SEC_RESERVE
+    MaximumSize.QuadPart = 0x20000;
+    Status = NtCreateSection(&hSection,
+                             SECTION_ALL_ACCESS,
+                             NULL, // ObjectAttributes,
+                             &MaximumSize,
+                             PAGE_EXECUTE_READWRITE,
+                             SEC_RESERVE,
+                             NULL);
+    ok_ntstatus(Status, STATUS_SUCCESS);
+    ok(hSection != NULL, "hSection is NULL\n");
+
+    // Call NtQuerySection with SectionBasicInformation
+    Status = NtQuerySection(hSection,
+                            SectionBasicInformation,
+                            &SectionInfo,
+                            sizeof(SectionInfo),
+                            &ReturnLength);
+    ok_ntstatus(Status, STATUS_SUCCESS);
+    ok(ReturnLength == sizeof(SectionInfo), "ReturnLength is %lu, expected %u\n", ReturnLength, sizeof(SectionInfo));
+    ok(SectionInfo.BaseAddress == NULL, "BaseAddress is %p, expected NULL\n", SectionInfo.BaseAddress);
+    ok(SectionInfo.Attributes == SEC_RESERVE, "Attributes is %lx, expected %x\n", SectionInfo.Attributes, SEC_RESERVE);
+    ok(SectionInfo.Size.QuadPart == 0x20000, "Size is %I64x, expected %I64x\n", SectionInfo.Size.QuadPart, 0x20000ull);
+
+    // Close the section handle
+    NtClose(hSection);
+
+    // Create a section with SEC_BASED
+    MaximumSize.QuadPart = 0x20000;
+    Status = NtCreateSection(&hSection,
+                             SECTION_ALL_ACCESS,
+                             NULL, // ObjectAttributes,
+                             &MaximumSize,
+                             PAGE_EXECUTE_READWRITE,
+                             SEC_BASED | SEC_COMMIT,
+                             NULL);
+    ok_ntstatus(Status, STATUS_SUCCESS);
+    ok(hSection != NULL, "hSection is NULL\n");
+
+    // Call NtQuerySection with SectionBasicInformation
+    Status = NtQuerySection(hSection,
+                            SectionBasicInformation,
+                            &SectionInfo,
+                            sizeof(SectionInfo),
+                            &ReturnLength);
+    ok_ntstatus(Status, STATUS_SUCCESS);
+    ok(ReturnLength == sizeof(SectionInfo), "ReturnLength is %lu, expected %u\n", ReturnLength, sizeof(SectionInfo));
+    ok(SectionInfo.BaseAddress != NULL, "BaseAddress is NULL\n");
+    ok(SectionInfo.Attributes == (SEC_BASED | SEC_COMMIT), "Attributes is %lx, expected %x\n", SectionInfo.Attributes, SEC_BASED | SEC_COMMIT);
+    ok(SectionInfo.Size.QuadPart == 0x20000, "Size is %I64x, expected %I64x\n", SectionInfo.Size.QuadPart, 0x20000ull);
+
+    // Close the section handle
+    NtClose(hSection);
+}

--- a/modules/rostests/apitests/ntdll/RtlUnicodeToOemN.c
+++ b/modules/rostests/apitests/ntdll/RtlUnicodeToOemN.c
@@ -110,7 +110,7 @@ static const struct
 
 START_TEST(RtlUnicodeToOemN)
 {
-    ULONG Length;
+    SIZE_T Length;
     LPSTR StrOem;
     ULONG ResultSize;
     NTSTATUS Status;
@@ -216,7 +216,7 @@ START_TEST(RtlUnicodeToOemN)
                                       Length,
                                       &ResultSize,
                                       TestData[i].Test[j].StrW,
-                                      wcslen(TestData[i].Test[j].StrW) * sizeof(WCHAR));
+                                      (ULONG)wcslen(TestData[i].Test[j].StrW) * sizeof(WCHAR));
 
             ok_ntstatus(Status, TestData[i].Test[j].Status);
             ok_long(ResultSize, TestData[i].Test[j].ReturnedSize);

--- a/modules/rostests/apitests/ntdll/testlist.c
+++ b/modules/rostests/apitests/ntdll/testlist.c
@@ -41,6 +41,7 @@ extern void func_NtQueryInformationToken(void);
 extern void func_NtQueryKey(void);
 extern void func_NtQueryObject(void);
 extern void func_NtQueryOpenSubKeys(void);
+extern void func_NtQuerySection(void);
 extern void func_NtQuerySystemEnvironmentValue(void);
 extern void func_NtQuerySystemInformation(void);
 extern void func_NtQueryValueKey(void);
@@ -149,6 +150,7 @@ const struct test winetest_testlist[] =
     { "NtQueryKey",                     func_NtQueryKey },
     { "NtQueryObject",                  func_NtQueryObject },
     { "NtQueryOpenSubKeys",             func_NtQueryOpenSubKeys },
+    { "NtQuerySection",                 func_NtQuerySection },
     { "NtQuerySystemEnvironmentValue",  func_NtQuerySystemEnvironmentValue },
     { "NtQuerySystemInformation",       func_NtQuerySystemInformation },
     { "NtQueryValueKey",                func_NtQueryValueKey },


### PR DESCRIPTION
## Purpose

Add a test for NtQuerySection

## Testbot runs (Filled in by Devs)

- ✅ Win 2003 x86: https://build.reactos.org/#/builders/11/builds/7826/steps/1/logs/stdio: "NtQuerySection: 24 tests executed (0 marked as todo, 0 failures), 0 skipped."
- ✅ Win 2003 x64: https://reactos.org/testman/compare.php?ids=101568
- KVM x86: https://reactos.org/testman/compare.php?ids=101569
- KVM x64: https://reactos.org/testman/compare.php?ids=101571
