### PR TITLE
[TASKMGR] Distinguish WOW64 processes with a " *32" in the image name

### DIFF
--- a/base/applications/taskmgr/perfdata.c
+++ b/base/applications/taskmgr/perfdata.c
@@ -390,7 +390,8 @@ ReadProcOwner:
                     pPerfData[Idx].GDIObjectCount = GetGuiResources(hProcess, GR_GDIOBJECTS);
                 }
 
-                if (IsWow64Process(hProcess, &bIsWow64) && bIsWow64) {
+                if (IsWow64Process(hProcess, &bIsWow64) && bIsWow64)
+                {
                     wcscat(pPerfData[Idx].ImageName, L" *32");
                 }
 

--- a/base/applications/taskmgr/perfdata.c
+++ b/base/applications/taskmgr/perfdata.c
@@ -176,6 +176,7 @@ void PerfDataRefresh(void)
     PSID                                       ProcessUser;
     ULONG                                      Buffer[64]; /* must be 4 bytes aligned! */
     ULONG                                      cwcUserName;
+    BOOL                                       bIsWow64;
 
     /* Get new system time */
     status = NtQuerySystemInformation(SystemTimeOfDayInformation, &SysTimeInfo, sizeof(SysTimeInfo), NULL);
@@ -313,7 +314,7 @@ void PerfDataRefresh(void)
                 }
             }
         }
-
+        
         if (pSPI->ImageName.Buffer) {
             /* Don't assume a UNICODE_STRING Buffer is zero terminated: */
             int len = pSPI->ImageName.Length / 2;
@@ -387,6 +388,10 @@ ReadProcOwner:
 
                     pPerfData[Idx].USERObjectCount = GetGuiResources(hProcess, GR_USEROBJECTS);
                     pPerfData[Idx].GDIObjectCount = GetGuiResources(hProcess, GR_GDIOBJECTS);
+                }
+
+                if (IsWow64Process(hProcess, &bIsWow64) && bIsWow64) {
+                    wcscat(pPerfData[Idx].ImageName, L" *32");
                 }
 
                 GetProcessIoCounters(hProcess, &pPerfData[Idx].IOCounters);

--- a/base/applications/taskmgr/perfdata.c
+++ b/base/applications/taskmgr/perfdata.c
@@ -314,7 +314,7 @@ void PerfDataRefresh(void)
                 }
             }
         }
-        
+
         if (pSPI->ImageName.Buffer) {
             /* Don't assume a UNICODE_STRING Buffer is zero terminated: */
             int len = pSPI->ImageName.Length / 2;

--- a/base/applications/taskmgr/perfdata.h
+++ b/base/applications/taskmgr/perfdata.h
@@ -12,7 +12,7 @@
 
 typedef struct _PERFDATA
 {
-	WCHAR				ImageName[MAX_PATH + 4];
+	WCHAR				ImageName[MAX_PATH + _countof(L" *32") - 1];
 	HANDLE				ProcessId;
 	WCHAR				UserName[MAX_PATH];
 	ULONG				SessionId;

--- a/base/applications/taskmgr/perfdata.h
+++ b/base/applications/taskmgr/perfdata.h
@@ -12,7 +12,7 @@
 
 typedef struct _PERFDATA
 {
-	WCHAR				ImageName[MAX_PATH];
+	WCHAR				ImageName[MAX_PATH + 4];
 	HANDLE				ProcessId;
 	WCHAR				UserName[MAX_PATH];
 	ULONG				SessionId;


### PR DESCRIPTION
## Purpose

In Windows' taskmgr, 32-bit processes are marked with a ` *32` appended to their image name. Even though ReactOS doesn't have a WOW64 yet, this feature could be easily implemented for the future.

![ReactOS taskmgr running on Windows 10](https://github.com/user-attachments/assets/4fb69d8c-d8c5-489f-b083-ce9a42d0fd23)
ReactOS taskmgr running on Windows 10

## Proposed changes

- For every process in `pPerfData`, use the open handle, to check if the process is a WOW64 process - if so, change the displayed name 