### PR TITLE
[GDI32] Fix MSVC warning. Simplify code.

### DIFF
--- a/win32ss/gdi/gdi32/objects/bitmap.c
+++ b/win32ss/gdi/gdi32/objects/bitmap.c
@@ -1019,8 +1019,7 @@ SetDIBitsToDevice(
 
     if (pConvertedInfo->bmiHeader.biHeight < 0)
     {
-        if (pConvertedInfo->bmiHeader.biHeight < -MaxSourceHeight || 
-            (YDest >= 0 && src_y < -ScanLines))
+        if (pConvertedInfo->bmiHeader.biHeight < -MaxSourceHeight || YDest >= 0)
         {
             LinesCopied = ScanLines + src_y;
         }


### PR DESCRIPTION
## Purpose

_This is a very small revert of #5227 to simplify the code and eliminate an MSVC warning._
_The MSVC warning was spotted by Timo Kreuzer when working on his PR #7894._
_After my investigation, I found that this part of the code was no longer necessary._

JIRA issues:
[CORE-12377](https://jira.reactos.org/browse/CORE-12377)
[CORE-18084](https://jira.reactos.org/browse/CORE-18084)
[CORE-13889](https://jira.reactos.org/browse/CORE-13889)

## Proposed changes

_This should be done in coordination with PR #7894._

## Testbot runs (Filled in by Devs)

- [X] KVM x86: https://reactos.org/testman/compare.php?ids=101595,101596,101599 LGTM
- [X] KVM x64: https://reactos.org/testman/compare.php?ids=101592,101601 LGTM