### PR TITLE
[USER32] Read the CoolSwitch settings from the registry

### DIFF
--- a/win32ss/user/user32/controls/appswitch.c
+++ b/win32ss/user/user32/controls/appswitch.c
@@ -63,27 +63,70 @@ int nShift = 0;
 
 BOOL Esc = FALSE;
 
+enum { DefSwitchRows = 3, DefSwitchColumns = 7 };
 BOOL CoolSwitch = TRUE;
-int CoolSwitchRows = 3;
-int CoolSwitchColumns = 7;
+int CoolSwitchRows = DefSwitchRows;
+int CoolSwitchColumns = DefSwitchColumns;
+BOOL SettingsLoaded = FALSE;
 
 // window style
 const DWORD Style = WS_POPUP | WS_BORDER | WS_DISABLED;
 const DWORD ExStyle = WS_EX_TOPMOST | WS_EX_DLGMODALFRAME | WS_EX_TOOLWINDOW;
 
-BOOL LoadCoolSwitchSettings(void)
+static int GetRegInt(HKEY hKey, PCWSTR Name, int DefVal)
 {
-   CoolSwitch = TRUE;
-   CoolSwitchRows = 3;
-   CoolSwitchColumns = 7;
+   WCHAR buf[100];
+   DWORD cb = sizeof(buf), type;
+   DWORD err = RegQueryValueExW(hKey, Name, 0, &type, (BYTE*)buf, &cb);
+   if (err == ERROR_SUCCESS && cb <= sizeof(buf) - sizeof(*buf))
+   {
+      buf[cb / sizeof(*buf)] = UNICODE_NULL;
+      if (type == REG_SZ || type == REG_EXPAND_SZ)
+      {
+         WCHAR *pszEnd;
+         long Value = wcstol(buf, &pszEnd, 10);
+         return pszEnd > buf ? Value : DefVal;
+      }
+      if ((type == REG_DWORD || type == REG_BINARY) && cb == sizeof(DWORD))
+      {
+         return *(DWORD*)buf;
+      }
+   }
+   return DefVal;
+}
 
-   // FIXME: load the settings from registry
+static void LoadCoolSwitchSettings(void)
+{
+   HKEY hKey;
+
+   if (!SettingsLoaded
+#if DBG
+       && !(GetKeyState(VK_SCROLL) & 1) // If Scroll-Lock is on, always read the settings
+#endif
+       )
+   {
+      return;
+   }
+
+   SettingsLoaded = TRUE;
+   // TODO: Should read from win.ini instead when IniFileMapping is fixed
+   if (!RegOpenKeyExW(HKEY_CURRENT_USER, L"Control Panel\\Desktop", 0, KEY_READ, &hKey))
+   {
+      CoolSwitch = GetRegInt(hKey, L"CoolSwitch", TRUE);
+      CoolSwitchRows = GetRegInt(hKey, L"CoolSwitchRows", DefSwitchRows);
+      CoolSwitchColumns = GetRegInt(hKey, L"CoolSwitchColumns", DefSwitchColumns);
+      RegCloseKey(hKey);
+   }
+
+   if (CoolSwitchRows * CoolSwitchColumns < 1 * 3)
+   {
+      CoolSwitchRows = DefSwitchRows;
+      CoolSwitchColumns = DefSwitchColumns;
+   }
 
    TRACE("CoolSwitch: %d\n", CoolSwitch);
    TRACE("CoolSwitchRows: %d\n", CoolSwitchRows);
    TRACE("CoolSwitchColumns: %d\n", CoolSwitchColumns);
-
-   return TRUE;
 }
 
 void ResizeAndCenter(HWND hwnd, int width, int height)

--- a/win32ss/user/user32/controls/appswitch.c
+++ b/win32ss/user/user32/controls/appswitch.c
@@ -75,7 +75,7 @@ const DWORD ExStyle = WS_EX_TOPMOST | WS_EX_DLGMODALFRAME | WS_EX_TOOLWINDOW;
 
 static int GetRegInt(HKEY hKey, PCWSTR Name, int DefVal)
 {
-   WCHAR buf[100];
+   WCHAR buf[sizeof("-2147483648")];
    DWORD cb = sizeof(buf), type;
    DWORD err = RegQueryValueExW(hKey, Name, 0, &type, (BYTE*)buf, &cb);
    if (err == ERROR_SUCCESS && cb <= sizeof(buf) - sizeof(*buf))

--- a/win32ss/user/user32/controls/appswitch.c
+++ b/win32ss/user/user32/controls/appswitch.c
@@ -75,58 +75,58 @@ const DWORD ExStyle = WS_EX_TOPMOST | WS_EX_DLGMODALFRAME | WS_EX_TOOLWINDOW;
 
 static int GetRegInt(HKEY hKey, PCWSTR Name, int DefVal)
 {
-   WCHAR buf[sizeof("-2147483648")];
-   DWORD cb = sizeof(buf), type;
-   DWORD err = RegQueryValueExW(hKey, Name, 0, &type, (BYTE*)buf, &cb);
-   if (err == ERROR_SUCCESS && cb <= sizeof(buf) - sizeof(*buf))
-   {
-      buf[cb / sizeof(*buf)] = UNICODE_NULL;
-      if (type == REG_SZ || type == REG_EXPAND_SZ)
-      {
-         WCHAR *pszEnd;
-         long Value = wcstol(buf, &pszEnd, 10);
-         return pszEnd > buf ? Value : DefVal;
-      }
-      if ((type == REG_DWORD || type == REG_BINARY) && cb == sizeof(DWORD))
-      {
-         return *(DWORD*)buf;
-      }
-   }
-   return DefVal;
+    WCHAR buf[sizeof("-2147483648")];
+    DWORD cb = sizeof(buf), type;
+    DWORD err = RegQueryValueExW(hKey, Name, NULL, &type, (BYTE*)buf, &cb);
+    if (err == ERROR_SUCCESS && cb <= sizeof(buf) - sizeof(*buf))
+    {
+        buf[cb / sizeof(*buf)] = UNICODE_NULL;
+        if (type == REG_SZ || type == REG_EXPAND_SZ)
+        {
+            WCHAR *pszEnd;
+            long Value = wcstol(buf, &pszEnd, 10);
+            return pszEnd > buf ? Value : DefVal;
+        }
+        if ((type == REG_DWORD || type == REG_BINARY) && cb == sizeof(DWORD))
+        {
+            return *(DWORD*)buf;
+        }
+    }
+    return DefVal;
 }
 
 static void LoadCoolSwitchSettings(void)
 {
-   HKEY hKey;
+    HKEY hKey;
 
-   if (SettingsLoaded
+    if (SettingsLoaded
 #if DBG
-       && !(GetKeyState(VK_SCROLL) & 1) // If Scroll-Lock is on, always read the settings
+        && !(GetKeyState(VK_SCROLL) & 1) // If Scroll-Lock is on, always read the settings
 #endif
-       )
-   {
-      return;
-   }
+        )
+    {
+        return;
+    }
 
-   SettingsLoaded = TRUE;
-   // TODO: Should read from win.ini instead when IniFileMapping is fixed
-   if (!RegOpenKeyExW(HKEY_CURRENT_USER, L"Control Panel\\Desktop", 0, KEY_READ, &hKey))
-   {
-      CoolSwitch = GetRegInt(hKey, L"CoolSwitch", TRUE);
-      CoolSwitchRows = GetRegInt(hKey, L"CoolSwitchRows", DefSwitchRows);
-      CoolSwitchColumns = GetRegInt(hKey, L"CoolSwitchColumns", DefSwitchColumns);
-      RegCloseKey(hKey);
-   }
+    SettingsLoaded = TRUE;
+    // TODO: Should read from win.ini instead when IniFileMapping is implemented
+    if (!RegOpenKeyExW(HKEY_CURRENT_USER, L"Control Panel\\Desktop", 0, KEY_READ, &hKey))
+    {
+        CoolSwitch = GetRegInt(hKey, L"CoolSwitch", TRUE);
+        CoolSwitchRows = GetRegInt(hKey, L"CoolSwitchRows", DefSwitchRows);
+        CoolSwitchColumns = GetRegInt(hKey, L"CoolSwitchColumns", DefSwitchColumns);
+        RegCloseKey(hKey);
+    }
 
-   if (CoolSwitchRows * CoolSwitchColumns < 3)
-   {
-      CoolSwitchRows = DefSwitchRows;
-      CoolSwitchColumns = DefSwitchColumns;
-   }
+    if (CoolSwitchRows * CoolSwitchColumns < 3)
+    {
+        CoolSwitchRows = DefSwitchRows;
+        CoolSwitchColumns = DefSwitchColumns;
+    }
 
-   TRACE("CoolSwitch: %d\n", CoolSwitch);
-   TRACE("CoolSwitchRows: %d\n", CoolSwitchRows);
-   TRACE("CoolSwitchColumns: %d\n", CoolSwitchColumns);
+    TRACE("CoolSwitch: %d\n", CoolSwitch);
+    TRACE("CoolSwitchRows: %d\n", CoolSwitchRows);
+    TRACE("CoolSwitchColumns: %d\n", CoolSwitchColumns);
 }
 
 void ResizeAndCenter(HWND hwnd, int width, int height)

--- a/win32ss/user/user32/controls/appswitch.c
+++ b/win32ss/user/user32/controls/appswitch.c
@@ -99,7 +99,7 @@ static void LoadCoolSwitchSettings(void)
 {
    HKEY hKey;
 
-   if (!SettingsLoaded
+   if (SettingsLoaded
 #if DBG
        && !(GetKeyState(VK_SCROLL) & 1) // If Scroll-Lock is on, always read the settings
 #endif
@@ -118,7 +118,7 @@ static void LoadCoolSwitchSettings(void)
       RegCloseKey(hKey);
    }
 
-   if (CoolSwitchRows * CoolSwitchColumns < 1 * 3)
+   if (CoolSwitchRows * CoolSwitchColumns < 3)
    {
       CoolSwitchRows = DefSwitchRows;
       CoolSwitchColumns = DefSwitchColumns;


### PR DESCRIPTION
![TweakUI](https://github.com/user-attachments/assets/1ae4a7ff-afcc-4bca-8b61-32a362b58044)

Notes:
- I don't know if Windows has a way to reload this without rebooting but the overhead of reading them again in debug mode is negligible for those people that keep Scroll-Lock on all the time.
- I don't think `CoolSwitch == FALSE` is correctly implemented in ROS, it should probably still switch the windows while staying hidden? Someone else will have to deal with that in another PR...

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: