### PR TITLE
[EVENTVWR] Fix "Bytes" and "Word" buttons being enabled with empty entry

### DIFF
--- a/base/applications/mscutils/eventvwr/evtdetctl.c
+++ b/base/applications/mscutils/eventvwr/evtdetctl.c
@@ -807,6 +807,9 @@ EventDetailsCtrl(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
             InitDetailsDlgCtrl(hDlg, pData);
 
+            EnableWindow(GetDlgItem(hDlg, IDC_BYTESRADIO), FALSE);
+            EnableWindow(GetDlgItem(hDlg, IDC_WORDRADIO), FALSE);
+
             // OnSize(hDlg, pData, pData->cxOld, pData->cyOld);
             return (INT_PTR)TRUE;
         }


### PR DESCRIPTION
## Purpose

This fixes the radio buttons being enabled by default

JIRA issue: [CORE-20037](https://jira.reactos.org/browse/CORE-20037)

## Proposed changes

Same described above

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: