### PR TITLE
[WORDPAD] Fix garbage in "Get Text" dialog.

### DIFF
--- a/base/applications/wordpad/wordpad.c
+++ b/base/applications/wordpad/wordpad.c
@@ -2294,6 +2294,7 @@ static LRESULT OnCommand( HWND hWnd, WPARAM wParam, LPARAM lParam)
         tr.chrg.cpMax = nLen;
         tr.lpstrText = data;
         SendMessageW(hwndEditor, EM_GETTEXTRANGE, 0, (LPARAM)&tr);
+        data[tr.chrg.cpMax - tr.chrg.cpMin] = L'\0';
         MessageBoxW(NULL, data, wszAppTitle, MB_OK);
         HeapFree( GetProcessHeap(), 0, data );
 

--- a/base/applications/wordpad/wordpad.c
+++ b/base/applications/wordpad/wordpad.c
@@ -2294,7 +2294,7 @@ static LRESULT OnCommand( HWND hWnd, WPARAM wParam, LPARAM lParam)
         tr.chrg.cpMax = nLen;
         tr.lpstrText = data;
         SendMessageW(hwndEditor, EM_GETTEXTRANGE, 0, (LPARAM)&tr);
-        data[tr.chrg.cpMax - tr.chrg.cpMin] = L'\0';
+        data[tr.chrg.cpMax - tr.chrg.cpMin] = UNICODE_NULL;
         MessageBoxW(NULL, data, wszAppTitle, MB_OK);
         HeapFree( GetProcessHeap(), 0, data );
 

--- a/base/applications/wordpad/wordpad.c
+++ b/base/applications/wordpad/wordpad.c
@@ -2294,7 +2294,9 @@ static LRESULT OnCommand( HWND hWnd, WPARAM wParam, LPARAM lParam)
         tr.chrg.cpMax = nLen;
         tr.lpstrText = data;
         SendMessageW(hwndEditor, EM_GETTEXTRANGE, 0, (LPARAM)&tr);
+        #ifdef __REACTOS__
         data[tr.chrg.cpMax - tr.chrg.cpMin] = UNICODE_NULL;
+        #endif
         MessageBoxW(NULL, data, wszAppTitle, MB_OK);
         HeapFree( GetProcessHeap(), 0, data );
 

--- a/base/applications/wordpad/wordpad.c
+++ b/base/applications/wordpad/wordpad.c
@@ -2294,9 +2294,9 @@ static LRESULT OnCommand( HWND hWnd, WPARAM wParam, LPARAM lParam)
         tr.chrg.cpMax = nLen;
         tr.lpstrText = data;
         SendMessageW(hwndEditor, EM_GETTEXTRANGE, 0, (LPARAM)&tr);
-        #ifdef __REACTOS__
+#ifdef __REACTOS__
         data[tr.chrg.cpMax - tr.chrg.cpMin] = UNICODE_NULL;
-        #endif
+#endif
         MessageBoxW(NULL, data, wszAppTitle, MB_OK);
         HeapFree( GetProcessHeap(), 0, data );
 


### PR DESCRIPTION
## Purpose

This fixes the garbage in the "Get Text" dialog which occurs if theres no text input and you  click "Get Text" under Extras

JIRA issue: [CORE-19868](https://jira.reactos.org/browse/CORE-19868)

## Proposed changes

Same described above

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: