### PR TITLE
[REGEDIT] Add missing status text for "new" elements

### DIFF
--- a/base/applications/regedit/lang/bg-BG.rc
+++ b/base/applications/regedit/lang/bg-BG.rc
@@ -435,6 +435,8 @@ BEGIN
     ID_EDIT_NEW_STRINGVALUE "Добавя нова низова стойност"
     ID_EDIT_NEW_BINARYVALUE "Добавя нова двоична стойност"
     ID_EDIT_NEW_DWORDVALUE "Добавя нова стойност за двойна дума"
+    ID_EDIT_NEW_MULTISTRINGVALUE "Adds a new multi string value"
+    ID_EDIT_NEW_EXPANDABLESTRINGVALUE "Adds a new expandable string value"
     ID_REGISTRY_IMPORTREGISTRYFILE "Внася се словесен файл в регистъра"
     ID_REGISTRY_EXPORTREGISTRYFILE "Изнася се целия регистър или части от него в словесен файл"
     ID_REGISTRY_LOADHIVE "Зарежда се роеви файл в регистъра"

--- a/base/applications/regedit/lang/cs-CZ.rc
+++ b/base/applications/regedit/lang/cs-CZ.rc
@@ -432,6 +432,8 @@ BEGIN
     ID_EDIT_NEW_STRINGVALUE "Přidá novou položku ve formě řetězce"
     ID_EDIT_NEW_BINARYVALUE "Přidá novou položku s binární hodnotou"
     ID_EDIT_NEW_DWORDVALUE "Přidá novou DWORD položku"
+    ID_EDIT_NEW_MULTISTRINGVALUE "Adds a new multi string value"
+    ID_EDIT_NEW_EXPANDABLESTRINGVALUE "Adds a new expandable string value"
     ID_REGISTRY_IMPORTREGISTRYFILE "Importuje textový soubor do registru"
     ID_REGISTRY_EXPORTREGISTRYFILE "Exportuje všechny části registru do textového souboru"
     ID_REGISTRY_LOADHIVE "Načte soubor podregistru"

--- a/base/applications/regedit/lang/de-DE.rc
+++ b/base/applications/regedit/lang/de-DE.rc
@@ -432,6 +432,8 @@ BEGIN
     ID_EDIT_NEW_STRINGVALUE "Fügt eine neue Zeichenkette hinzu"
     ID_EDIT_NEW_BINARYVALUE "Fügt einen neuen Binärwärt hinzu"
     ID_EDIT_NEW_DWORDVALUE "Fügt einen neuen DWORD-Wert hinzu"
+    ID_EDIT_NEW_MULTISTRINGVALUE "Fügt eine neue Mehrfachzeichenkette hinzu"
+    ID_EDIT_NEW_EXPANDABLESTRINGVALUE "Fügt eine neue erweiterbare Zeichenkette hinzu"
     ID_REGISTRY_IMPORTREGISTRYFILE "Importiert eine Textddatei in die Registry"
     ID_REGISTRY_EXPORTREGISTRYFILE "Exportiert Teile oder die ganze Registry in eine Textdatei"
     ID_REGISTRY_LOADHIVE "Lädt einen Hive in die Registry"

--- a/base/applications/regedit/lang/el-GR.rc
+++ b/base/applications/regedit/lang/el-GR.rc
@@ -432,6 +432,8 @@ BEGIN
     ID_EDIT_NEW_STRINGVALUE "Προσθέτει μια νέα αλφαριθμητική τιμή"
     ID_EDIT_NEW_BINARYVALUE "Προσθέτει μια νέα δυαδική τιμή"
     ID_EDIT_NEW_DWORDVALUE "Προσθέτιε μαι νέα double word τιμή"
+    ID_EDIT_NEW_MULTISTRINGVALUE "Adds a new multi string value"
+    ID_EDIT_NEW_EXPANDABLESTRINGVALUE "Adds a new expandable string value"
     ID_REGISTRY_IMPORTREGISTRYFILE "Εισάγει ένα αρχείο κειμένου στη registry"
     ID_REGISTRY_EXPORTREGISTRYFILE "Εξάγωη όλη ή ένα κομμάτι της registry σε ένα αρχείο κειμένου"
     ID_REGISTRY_LOADHIVE "Loads a hive file into the registry"

--- a/base/applications/regedit/lang/en-US.rc
+++ b/base/applications/regedit/lang/en-US.rc
@@ -432,6 +432,8 @@ BEGIN
     ID_EDIT_NEW_STRINGVALUE "Adds a new string value"
     ID_EDIT_NEW_BINARYVALUE "Adds a new binary value"
     ID_EDIT_NEW_DWORDVALUE "Adds a new double word value"
+    ID_EDIT_NEW_MULTISTRINGVALUE "Adds a new multi string value"
+    ID_EDIT_NEW_EXPANDABLESTRINGVALUE "Adds a new expandable string value"
     ID_REGISTRY_IMPORTREGISTRYFILE "Imports a text file into the registry"
     ID_REGISTRY_EXPORTREGISTRYFILE "Exports all or part of the registry to a text file"
     ID_REGISTRY_LOADHIVE "Loads a hive file into the registry"

--- a/base/applications/regedit/lang/es-ES.rc
+++ b/base/applications/regedit/lang/es-ES.rc
@@ -435,6 +435,8 @@ BEGIN
     ID_EDIT_NEW_STRINGVALUE "Añade un nuevo valor de cadena"
     ID_EDIT_NEW_BINARYVALUE "Añade un nuevo valor binario"
     ID_EDIT_NEW_DWORDVALUE "Añade un nuevo valor de doble palabra"
+    ID_EDIT_NEW_MULTISTRINGVALUE "Adds a new multi string value"
+    ID_EDIT_NEW_EXPANDABLESTRINGVALUE "Adds a new expandable string value"
     ID_REGISTRY_IMPORTREGISTRYFILE "Importa un archivo de texto al Registro"
     ID_REGISTRY_EXPORTREGISTRYFILE "Exporta todo o parte del Registro a un archivo de texto"
     ID_REGISTRY_LOADHIVE "Carga un subárbol en el Registro"

--- a/base/applications/regedit/lang/fr-FR.rc
+++ b/base/applications/regedit/lang/fr-FR.rc
@@ -432,6 +432,8 @@ BEGIN
     ID_EDIT_NEW_STRINGVALUE "Ajoute une nouvelle valeur chaîne"
     ID_EDIT_NEW_BINARYVALUE "Ajoute une nouvelle valeur binaire"
     ID_EDIT_NEW_DWORDVALUE "Ajoute une nouvelle valeur mot double"
+    ID_EDIT_NEW_MULTISTRINGVALUE "Adds a new multi string value"
+    ID_EDIT_NEW_EXPANDABLESTRINGVALUE "Adds a new expandable string value"
     ID_REGISTRY_IMPORTREGISTRYFILE "Importe un fichier texte dans les registres"
     ID_REGISTRY_EXPORTREGISTRYFILE "Exporte tout ou une partie des registres dans un fichier texte"
     ID_REGISTRY_LOADHIVE "Charge un fichier ruche dans le Registre"

--- a/base/applications/regedit/lang/he-IL.rc
+++ b/base/applications/regedit/lang/he-IL.rc
@@ -432,6 +432,8 @@ BEGIN
     ID_EDIT_NEW_STRINGVALUE "Adds a new string value"
     ID_EDIT_NEW_BINARYVALUE "Adds a new binary value"
     ID_EDIT_NEW_DWORDVALUE "Adds a new double word value"
+    ID_EDIT_NEW_MULTISTRINGVALUE "Adds a new multi string value"
+    ID_EDIT_NEW_EXPANDABLESTRINGVALUE "Adds a new expandable string value"
     ID_REGISTRY_IMPORTREGISTRYFILE "Imports a text file into the registry"
     ID_REGISTRY_EXPORTREGISTRYFILE "Exports all or part of the registry to a text file"
     ID_REGISTRY_LOADHIVE "Loads a hive file into the registry"

--- a/base/applications/regedit/lang/hu-HU.rc
+++ b/base/applications/regedit/lang/hu-HU.rc
@@ -432,6 +432,8 @@ BEGIN
     ID_EDIT_NEW_STRINGVALUE "Adds a new string value"
     ID_EDIT_NEW_BINARYVALUE "Adds a new binary value"
     ID_EDIT_NEW_DWORDVALUE "Adds a new double word value"
+    ID_EDIT_NEW_MULTISTRINGVALUE "Adds a new multi string value"
+    ID_EDIT_NEW_EXPANDABLESTRINGVALUE "Adds a new expandable string value"
     ID_REGISTRY_IMPORTREGISTRYFILE "Imports a text file into the registry"
     ID_REGISTRY_EXPORTREGISTRYFILE "Exports all or part of the registry to a text file"
     ID_REGISTRY_LOADHIVE "Loads a hive file into the registry"

--- a/base/applications/regedit/lang/id-ID.rc
+++ b/base/applications/regedit/lang/id-ID.rc
@@ -432,6 +432,8 @@ BEGIN
     ID_EDIT_NEW_STRINGVALUE "Menambah nilai string baru"
     ID_EDIT_NEW_BINARYVALUE "Menambah nilai biner baru"
     ID_EDIT_NEW_DWORDVALUE "Menambah nilai double word baru"
+    ID_EDIT_NEW_MULTISTRINGVALUE "Adds a new multi string value"
+    ID_EDIT_NEW_EXPANDABLESTRINGVALUE "Adds a new expandable string value"
     ID_REGISTRY_IMPORTREGISTRYFILE "Mengimpor file teks ke dalam registri"
     ID_REGISTRY_EXPORTREGISTRYFILE "Mengekspor semua atau sebagian registri ke file teks"
     ID_REGISTRY_LOADHIVE "Memuat berkas hive ke dalam registri"

--- a/base/applications/regedit/lang/it-IT.rc
+++ b/base/applications/regedit/lang/it-IT.rc
@@ -440,6 +440,8 @@ BEGIN
     ID_EDIT_NEW_STRINGVALUE "Aggiunge un nuovo valore stringa"
     ID_EDIT_NEW_BINARYVALUE "Aggiunge un nuovo valore binario"
     ID_EDIT_NEW_DWORDVALUE "Aggiunge un nuovo valore DWORD"
+    ID_EDIT_NEW_MULTISTRINGVALUE "Adds a new multi string value"
+    ID_EDIT_NEW_EXPANDABLESTRINGVALUE "Adds a new expandable string value"
     ID_REGISTRY_IMPORTREGISTRYFILE "Importa un file di testo nel Registro"
     ID_REGISTRY_EXPORTREGISTRYFILE "Esporta tutto o parte del Registro in un file di testo"
     ID_REGISTRY_LOADHIVE "Carica un file hive nel Registro di sistema"

--- a/base/applications/regedit/lang/ja-JP.rc
+++ b/base/applications/regedit/lang/ja-JP.rc
@@ -432,6 +432,8 @@ BEGIN
     ID_EDIT_NEW_STRINGVALUE "新しい文字列値を追加します"
     ID_EDIT_NEW_BINARYVALUE "新しいバイナリ値を追加します"
     ID_EDIT_NEW_DWORDVALUE "新しい DWORD 値を追加します"
+    ID_EDIT_NEW_MULTISTRINGVALUE "Adds a new multi string value"
+    ID_EDIT_NEW_EXPANDABLESTRINGVALUE "Adds a new expandable string value"
     ID_REGISTRY_IMPORTREGISTRYFILE "テキスト ファイルをレジストリにインポートします"
     ID_REGISTRY_EXPORTREGISTRYFILE "レジストリの一部または全体をテキスト ファイルにエクスポートします"
     ID_REGISTRY_LOADHIVE "ハイブ ファイルをレジストリに読み込みます"

--- a/base/applications/regedit/lang/ko-KR.rc
+++ b/base/applications/regedit/lang/ko-KR.rc
@@ -434,6 +434,8 @@ BEGIN
     ID_EDIT_NEW_STRINGVALUE "새 문자열 값을 추가합니다"
     ID_EDIT_NEW_BINARYVALUE "새 바이너리 값을 추가합니다"
     ID_EDIT_NEW_DWORDVALUE "새 DWORD값을 추가합니다"
+    ID_EDIT_NEW_MULTISTRINGVALUE "Adds a new multi string value"
+    ID_EDIT_NEW_EXPANDABLESTRINGVALUE "Adds a new expandable string value"
     ID_REGISTRY_IMPORTREGISTRYFILE "텍스트 파일을 레지스트리로 불러 옵니다"
     ID_REGISTRY_EXPORTREGISTRYFILE "텍스트 파일로 레지스트리의 전체나 일부를 내보냅니다"
     ID_REGISTRY_LOADHIVE "Loads a hive file into the registry"

--- a/base/applications/regedit/lang/nl-NL.rc
+++ b/base/applications/regedit/lang/nl-NL.rc
@@ -432,6 +432,8 @@ BEGIN
     ID_EDIT_NEW_STRINGVALUE "Een nieuwe tekenreekswaarde toevoegen"
     ID_EDIT_NEW_BINARYVALUE "Een nieuwe binaire waarde toevoegen"
     ID_EDIT_NEW_DWORDVALUE "Een nieuwe DWORD-waarde toevoegen"
+    ID_EDIT_NEW_MULTISTRINGVALUE "Adds a new multi string value"
+    ID_EDIT_NEW_EXPANDABLESTRINGVALUE "Adds a new expandable string value"
     ID_REGISTRY_IMPORTREGISTRYFILE "Een tekstbestand in het register importeren"
     ID_REGISTRY_EXPORTREGISTRYFILE "Het register of een gedeelte ervan naar een tekstbestand exporteren"
     ID_REGISTRY_LOADHIVE "Loads a hive file into the registry"

--- a/base/applications/regedit/lang/no-NO.rc
+++ b/base/applications/regedit/lang/no-NO.rc
@@ -432,6 +432,8 @@ BEGIN
     ID_EDIT_NEW_STRINGVALUE "Legger til en ny strengverdi"
     ID_EDIT_NEW_BINARYVALUE "Legger til en ny binær verdi"
     ID_EDIT_NEW_DWORDVALUE "Legger til en ny DWORD-verdi"
+    ID_EDIT_NEW_MULTISTRINGVALUE "Adds a new multi string value"
+    ID_EDIT_NEW_EXPANDABLESTRINGVALUE "Adds a new expandable string value"
     ID_REGISTRY_IMPORTREGISTRYFILE "Importerer en tekstfil inn i Registret"
     ID_REGISTRY_EXPORTREGISTRYFILE "Eksporterer hele eller deler av Registret til en tekstfil"
     ID_REGISTRY_LOADHIVE "Loads a hive file into the registry"

--- a/base/applications/regedit/lang/pl-PL.rc
+++ b/base/applications/regedit/lang/pl-PL.rc
@@ -440,6 +440,8 @@ BEGIN
     ID_EDIT_NEW_STRINGVALUE "Dodaje nową wartość ciągu"
     ID_EDIT_NEW_BINARYVALUE "Dodaje nową wartość binarną"
     ID_EDIT_NEW_DWORDVALUE "Dodaje nową wartość DWORD"
+    ID_EDIT_NEW_MULTISTRINGVALUE "Adds a new multi string value"
+    ID_EDIT_NEW_EXPANDABLESTRINGVALUE "Adds a new expandable string value"
     ID_REGISTRY_IMPORTREGISTRYFILE "Importuje plik do rejestru"
     ID_REGISTRY_EXPORTREGISTRYFILE "Eksportuje całość lub część rejestru do pliku"
     ID_REGISTRY_LOADHIVE "Ładuje plik Drzewa do rejestru"

--- a/base/applications/regedit/lang/pt-BR.rc
+++ b/base/applications/regedit/lang/pt-BR.rc
@@ -432,6 +432,8 @@ BEGIN
     ID_EDIT_NEW_STRINGVALUE "Adiciona novo valor string"
     ID_EDIT_NEW_BINARYVALUE "Adiciona novo valor binário"
     ID_EDIT_NEW_DWORDVALUE "Adiciona novo valor DWORD"
+    ID_EDIT_NEW_MULTISTRINGVALUE "Adds a new multi string value"
+    ID_EDIT_NEW_EXPANDABLESTRINGVALUE "Adds a new expandable string value"
     ID_REGISTRY_IMPORTREGISTRYFILE "Importa um arquivo de texto para o registro"
     ID_REGISTRY_EXPORTREGISTRYFILE "Exporta todo ou parte do Registro para um arquivo texto"
     ID_REGISTRY_LOADHIVE "Loads a hive file into the registry"

--- a/base/applications/regedit/lang/pt-PT.rc
+++ b/base/applications/regedit/lang/pt-PT.rc
@@ -442,6 +442,8 @@ BEGIN
     ID_EDIT_NEW_STRINGVALUE "Adiciona um novo valor texto"
     ID_EDIT_NEW_BINARYVALUE "Adiciona um novo valor binário"
     ID_EDIT_NEW_DWORDVALUE "Adiciona um novo valor DWORD"
+    ID_EDIT_NEW_MULTISTRINGVALUE "Adds a new multi string value"
+    ID_EDIT_NEW_EXPANDABLESTRINGVALUE "Adds a new expandable string value"
     ID_REGISTRY_IMPORTREGISTRYFILE "Importa um ficheiro de texto para o registo"
     ID_REGISTRY_EXPORTREGISTRYFILE "Exporta todo ou parte do registo para um ficheiro de texto"
     ID_REGISTRY_LOADHIVE "Carrega um ficheiro de secção no registo"

--- a/base/applications/regedit/lang/ro-RO.rc
+++ b/base/applications/regedit/lang/ro-RO.rc
@@ -442,6 +442,8 @@ BEGIN
     ID_EDIT_NEW_STRINGVALUE "Adaugă o nouă valoare șir"
     ID_EDIT_NEW_BINARYVALUE "Adaugă o nouă valoare de 1 bit"
     ID_EDIT_NEW_DWORDVALUE "Adaugă o nouă valoare de 32 de biți"
+    ID_EDIT_NEW_MULTISTRINGVALUE "Adds a new multi string value"
+    ID_EDIT_NEW_EXPANDABLESTRINGVALUE "Adds a new expandable string value"
     ID_REGISTRY_IMPORTREGISTRYFILE "Importă registru dintr-un fișier"
     ID_REGISTRY_EXPORTREGISTRYFILE "Exportă registrul total sau parțial într-un fișier"
     ID_REGISTRY_LOADHIVE "Încarcă un fișier binar în registru"

--- a/base/applications/regedit/lang/ru-RU.rc
+++ b/base/applications/regedit/lang/ru-RU.rc
@@ -445,6 +445,8 @@ BEGIN
     ID_EDIT_NEW_STRINGVALUE "Добавляет новое строковое значение"
     ID_EDIT_NEW_BINARYVALUE "Добавляет новое бинарное значение"
     ID_EDIT_NEW_DWORDVALUE "Добавляет новое DWORD-значение"
+    ID_EDIT_NEW_MULTISTRINGVALUE "Adds a new multi string value"
+    ID_EDIT_NEW_EXPANDABLESTRINGVALUE "Adds a new expandable string value"
     ID_REGISTRY_IMPORTREGISTRYFILE "Импортирует текстовой файл в реестр"
     ID_REGISTRY_EXPORTREGISTRYFILE "Экспортирует весь реестр или его часть в текстовой файл"
     ID_REGISTRY_LOADHIVE "Загрузить файл куста реестра в реестр"

--- a/base/applications/regedit/lang/sk-SK.rc
+++ b/base/applications/regedit/lang/sk-SK.rc
@@ -435,6 +435,8 @@ BEGIN
     ID_EDIT_NEW_STRINGVALUE "Pridá novú reťazcovú hodnotu"
     ID_EDIT_NEW_BINARYVALUE "Pridá novú binárnu hodnotu"
     ID_EDIT_NEW_DWORDVALUE "Pridá novú double word hodnotu"
+    ID_EDIT_NEW_MULTISTRINGVALUE "Adds a new multi string value"
+    ID_EDIT_NEW_EXPANDABLESTRINGVALUE "Adds a new expandable string value"
     ID_REGISTRY_IMPORTREGISTRYFILE "Imports a text file into the registry"
     ID_REGISTRY_EXPORTREGISTRYFILE "Exports all or part of the registry to a text file"
     ID_REGISTRY_LOADHIVE "Loads a hive file into the registry"

--- a/base/applications/regedit/lang/sl-SI.rc
+++ b/base/applications/regedit/lang/sl-SI.rc
@@ -432,6 +432,8 @@ BEGIN
     ID_EDIT_NEW_STRINGVALUE "Doda nov niz"
     ID_EDIT_NEW_BINARYVALUE "Doda novo binarno vrednost"
     ID_EDIT_NEW_DWORDVALUE "Doda novo DWORD vrednost"
+    ID_EDIT_NEW_MULTISTRINGVALUE "Adds a new multi string value"
+    ID_EDIT_NEW_EXPANDABLESTRINGVALUE "Adds a new expandable string value"
     ID_REGISTRY_IMPORTREGISTRYFILE "V register uvozi datoteko z besedilom"
     ID_REGISTRY_EXPORTREGISTRYFILE "Registrsko datoteko ali njen del izvozi v besedilno datoteko"
     ID_REGISTRY_LOADHIVE "Loads a hive file into the registry"

--- a/base/applications/regedit/lang/sq-AL.rc
+++ b/base/applications/regedit/lang/sq-AL.rc
@@ -435,6 +435,8 @@ BEGIN
     ID_EDIT_NEW_STRINGVALUE "Shton një vlerë të re string"
     ID_EDIT_NEW_BINARYVALUE "Shton një vlerë të re binar"
     ID_EDIT_NEW_DWORDVALUE "ADDS një vlerë të re të dyfishtë fjalën"
+    ID_EDIT_NEW_MULTISTRINGVALUE "Adds a new multi string value"
+    ID_EDIT_NEW_EXPANDABLESTRINGVALUE "Adds a new expandable string value"
     ID_REGISTRY_IMPORTREGISTRYFILE "Importon një file teksti në regjistër"
     ID_REGISTRY_EXPORTREGISTRYFILE "Eksportet gjitha ose pjesë e regjistrit në një skedar teksti"
     ID_REGISTRY_LOADHIVE "Ngarkon një dokument në regjistër"

--- a/base/applications/regedit/lang/sv-SE.rc
+++ b/base/applications/regedit/lang/sv-SE.rc
@@ -432,6 +432,8 @@ BEGIN
     ID_EDIT_NEW_STRINGVALUE "Lägger till ett nytt strängvärde"
     ID_EDIT_NEW_BINARYVALUE "Lägger till ett nytt binärt värde"
     ID_EDIT_NEW_DWORDVALUE "Lägger till ett nytt dubbelordsvärde"
+    ID_EDIT_NEW_MULTISTRINGVALUE "Adds a new multi string value"
+    ID_EDIT_NEW_EXPANDABLESTRINGVALUE "Adds a new expandable string value"
     ID_REGISTRY_IMPORTREGISTRYFILE "Importerar en textfil till registret"
     ID_REGISTRY_EXPORTREGISTRYFILE "Exporterar hela eller en del av registret till en textfil"
     ID_REGISTRY_LOADHIVE "Läser in registerdatafil till registret"

--- a/base/applications/regedit/lang/th-TH.rc
+++ b/base/applications/regedit/lang/th-TH.rc
@@ -434,6 +434,8 @@ BEGIN
     ID_EDIT_NEW_STRINGVALUE "Adds a new string value"
     ID_EDIT_NEW_BINARYVALUE "Adds a new binary value"
     ID_EDIT_NEW_DWORDVALUE "Adds a new double word value"
+    ID_EDIT_NEW_MULTISTRINGVALUE "Adds a new multi string value"
+    ID_EDIT_NEW_EXPANDABLESTRINGVALUE "Adds a new expandable string value"
     ID_REGISTRY_IMPORTREGISTRYFILE "Imports a text file into the registry"
     ID_REGISTRY_EXPORTREGISTRYFILE "Exports all or part of the registry to a text file"
     ID_REGISTRY_LOADHIVE "Loads a hive file into the registry"

--- a/base/applications/regedit/lang/tr-TR.rc
+++ b/base/applications/regedit/lang/tr-TR.rc
@@ -434,6 +434,8 @@ BEGIN
     ID_EDIT_NEW_STRINGVALUE "Yeni bir dizi değeri ekler"
     ID_EDIT_NEW_BINARYVALUE "Yeni bir ikili değer ekler"
     ID_EDIT_NEW_DWORDVALUE "Yeni bir DWORD değeri ekler"
+    ID_EDIT_NEW_MULTISTRINGVALUE "Adds a new multi string value"
+    ID_EDIT_NEW_EXPANDABLESTRINGVALUE "Adds a new expandable string value"
     ID_REGISTRY_IMPORTREGISTRYFILE "Bir metin dosyasını Kayıt Defteri'ne alır"
     ID_REGISTRY_EXPORTREGISTRYFILE "Kayıt Defteri'nin tümünü ya da bir bölümünü bir metin dosyasına verir"
     ID_REGISTRY_LOADHIVE "Kayıt Defteri'ne bir yığın dosyasını yükler"

--- a/base/applications/regedit/lang/uk-UA.rc
+++ b/base/applications/regedit/lang/uk-UA.rc
@@ -434,6 +434,8 @@ BEGIN
     ID_EDIT_NEW_STRINGVALUE "Додає нове рядкове значення"
     ID_EDIT_NEW_BINARYVALUE "Додає нове двійкове значення"
     ID_EDIT_NEW_DWORDVALUE "Додає нове DWORD-значення"
+    ID_EDIT_NEW_MULTISTRINGVALUE "Adds a new multi string value"
+    ID_EDIT_NEW_EXPANDABLESTRINGVALUE "Adds a new expandable string value"
     ID_REGISTRY_IMPORTREGISTRYFILE "Імпортує текстовий файл до реєстру"
     ID_REGISTRY_EXPORTREGISTRYFILE "Експортує весь реєстр або його частину в текстовий файл"
     ID_REGISTRY_LOADHIVE "Loads a hive file into the registry"

--- a/base/applications/regedit/lang/zh-CN.rc
+++ b/base/applications/regedit/lang/zh-CN.rc
@@ -442,6 +442,8 @@ BEGIN
     ID_EDIT_NEW_STRINGVALUE "添加新字符串值"
     ID_EDIT_NEW_BINARYVALUE "添加新二进制值"
     ID_EDIT_NEW_DWORDVALUE "添加新 DWORD 值"
+    ID_EDIT_NEW_MULTISTRINGVALUE "Adds a new multi string value"
+    ID_EDIT_NEW_EXPANDABLESTRINGVALUE "Adds a new expandable string value"
     ID_REGISTRY_IMPORTREGISTRYFILE "将文本文件导入到注册表中"
     ID_REGISTRY_EXPORTREGISTRYFILE "将注册表全部或部分导出到文件中"
     ID_REGISTRY_LOADHIVE "加載配置单元到注册表中"

--- a/base/applications/regedit/lang/zh-HK.rc
+++ b/base/applications/regedit/lang/zh-HK.rc
@@ -452,6 +452,8 @@ BEGIN
     ID_EDIT_NEW_STRINGVALUE "新增新的字串值"
     ID_EDIT_NEW_BINARYVALUE "新增新二進制值"
     ID_EDIT_NEW_DWORDVALUE "新增新 DWORD 值"
+    ID_EDIT_NEW_MULTISTRINGVALUE "Adds a new multi string value"
+    ID_EDIT_NEW_EXPANDABLESTRINGVALUE "Adds a new expandable string value"
     ID_REGISTRY_IMPORTREGISTRYFILE "將檔案匯入到登錄中"
     ID_REGISTRY_EXPORTREGISTRYFILE "將登錄全部或部分匯出到檔案中"
     ID_REGISTRY_LOADHIVE "載入 Hive 控制檔到登錄中"

--- a/base/applications/regedit/lang/zh-TW.rc
+++ b/base/applications/regedit/lang/zh-TW.rc
@@ -441,6 +441,8 @@ BEGIN
     ID_EDIT_NEW_STRINGVALUE "新增新的字元串值"
     ID_EDIT_NEW_BINARYVALUE "新增新的二進制值"
     ID_EDIT_NEW_DWORDVALUE "新增新的 DWORD 值"
+    ID_EDIT_NEW_MULTISTRINGVALUE "Adds a new multi string value"
+    ID_EDIT_NEW_EXPANDABLESTRINGVALUE "Adds a new expandable string value"
     ID_REGISTRY_IMPORTREGISTRYFILE "將檔案匯入到登錄中"
     ID_REGISTRY_EXPORTREGISTRYFILE "將登錄全部或部分匯出到檔案中"
     ID_REGISTRY_LOADHIVE "載入 Hive 控制檔到登錄中"


### PR DESCRIPTION
## Purpose

Add missing status text to the "Multi-String Value" and "Expandable String Value" in the "new" menu of the registry editor for the english and german languages.

JIRA issue: [CORE-19886](https://jira.reactos.org/browse/CORE-19886)

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: