### PR TITLE
[NTDLL_APITEST] Fix test for RtlAllocateHeap

### DIFF
--- a/modules/rostests/apitests/ntdll/RtlAllocateHeap.c
+++ b/modules/rostests/apitests/ntdll/RtlAllocateHeap.c
@@ -9,58 +9,67 @@
 
 #include <pseh/pseh2.h>
 
-PVOID Buffers[0x100];
-
 START_TEST(RtlAllocateHeap)
 {
+    PVOID Buffers[0x100];
     USHORT i;
     HANDLE hHeap;
-    BOOLEAN Aligned = TRUE;
+    BOOLEAN Not8BytesAligned = FALSE;
+    BOOLEAN Not16BytesAligned = FALSE;
     RTL_HEAP_PARAMETERS Parameters = {0};
 
-    for (i = 0; i < 0x100; ++i)
+    for (i = 0; i < ARRAYSIZE(Buffers); ++i)
     {
+        /* RtlAllocateHeap() totally ignores HEAP_CREATE_ALIGN_16 (it's only for RtlCreateHeap() */
         Buffers[i] = RtlAllocateHeap(RtlGetProcessHeap(), HEAP_CREATE_ALIGN_16, (i % 16 ) + 1);
         ASSERT(Buffers[i] != NULL);
-        if (!((ULONG_PTR)Buffers[i] & 0xF))
-        {
-            Aligned = FALSE;
-        }
+
+        if (Buffers[i] != ALIGN_DOWN_POINTER_BY(Buffers[i], 8))
+            Not8BytesAligned = TRUE;
+
+        if (Buffers[i] != ALIGN_DOWN_POINTER_BY(Buffers[i], 16))
+            Not16BytesAligned = TRUE;
     }
 
-    for (i = 0; i < 0x100; ++i)
+    for (i = 0; i < ARRAYSIZE(Buffers); ++i)
     {
         RtlFreeHeap(RtlGetProcessHeap(), 0, Buffers[i]);
     }
 
-    ok(Aligned == FALSE, "No unaligned address returned\n");
+    ok(Not8BytesAligned == FALSE, "Found address that was not 8 byte aligned\n");
+#ifdef _WIN64
+    ok(Not16BytesAligned == FALSE, "Found address that was not 16 byte aligned\n");
+#endif
 
-    Aligned = TRUE;
+    Not16BytesAligned = FALSE;
     Parameters.Length = sizeof(Parameters);
     hHeap = RtlCreateHeap(HEAP_CREATE_ALIGN_16, NULL, 0, 0, NULL, &Parameters);
+    ok(hHeap != NULL, "Failed to create heap!\n");
     if (hHeap == NULL)
     {
+        skip("Failed to create heap!\n");
         return;
     }
 
-    for (i = 0; i < 0x100; ++i)
+    for (i = 0; i < ARRAYSIZE(Buffers); ++i)
     {
         Buffers[i] = RtlAllocateHeap(hHeap, 0, (i % 16 ) + 1);
         ASSERT(Buffers[i] != NULL);
-        if (!((ULONG_PTR)Buffers[i] & 0xF))
-        {
-            Aligned = FALSE;
-        }
+
+        if (Buffers[i] != ALIGN_DOWN_POINTER_BY(Buffers[i], 16))
+            Not16BytesAligned = TRUE;
     }
 
-    for (i = 0; i < 0x100; ++i)
+    for (i = 0; i < ARRAYSIZE(Buffers); ++i)
     {
         RtlFreeHeap(hHeap, 0, Buffers[i]);
     }
 
     RtlDestroyHeap(hHeap);
 
-    ok(Aligned == TRUE, "Unaligned address returned\n");
+    /* Windows 2003 always returns unaligned addresses */
+    ok(Not16BytesAligned == FALSE || broken(GetNTVersion() < _WIN32_WINNT_VISTA),
+       "Found address that was not 16 byte aligned\n");
 
     _SEH2_TRY
     {


### PR DESCRIPTION
## Purpose

Fix test for RtlAllocateHeap

## Testbot runs (Filled in by Devs)

- [x] WHS x86: https://reactos.org/testman/compare.php?ids=109195,109274
- [x] Vista x64: https://reactos.org/testman/compare.php?ids=109270,109273
