### PR TITLE
[NTOS] Fix x64 definition of MMPFN

### DIFF
--- a/ntoskrnl/include/internal/mm.h
+++ b/ntoskrnl/include/internal/mm.h
@@ -376,6 +376,12 @@ typedef struct _MMPFNENTRY
     USHORT ParityError:1;
 } MMPFNENTRY;
 
+#ifdef _WIN64
+#define MI_PTE_FRAME_BITS 57
+#else
+#define MI_PTE_FRAME_BITS 25
+#endif
+
 // Mm internal
 typedef struct _MMPFN
 {
@@ -409,6 +415,9 @@ typedef struct _MMPFN
             USHORT ShortFlags;
         } e2;
     } u3;
+#ifdef _WIN64
+    ULONG UsedPageTableEntries;
+#endif
     union
     {
         MMPTE OriginalPte;
@@ -422,7 +431,7 @@ typedef struct _MMPFN
         ULONG_PTR EntireFrame;
         struct
         {
-            ULONG_PTR PteFrame:25;
+            ULONG_PTR PteFrame : MI_PTE_FRAME_BITS;
             ULONG_PTR InPageError:1;
             ULONG_PTR VerifierAllocation:1;
             ULONG_PTR AweAllocation:1;

--- a/ntoskrnl/mm/ARM3/miarm.h
+++ b/ntoskrnl/mm/ARM3/miarm.h
@@ -220,24 +220,14 @@ extern const ULONG MmProtectToValue[32];
 //
 #define MI_INITIAL_SESSION_IDS  64
 
-#if defined(_M_IX86) || defined(_M_ARM)
-//
-// PFN List Sentinel
-//
-#define LIST_HEAD 0xFFFFFFFF
+#define LIST_HEAD ULONG_PTR_MAX
 
 //
 // Because GCC cannot automatically downcast 0xFFFFFFFF to lesser-width bits,
 // we need a manual definition suited to the number of bits in the PteFrame.
 // This is used as a LIST_HEAD for the colored list
 //
-#define COLORED_LIST_HEAD ((1 << 25) - 1) // 0x1FFFFFF
-#elif defined(_M_AMD64)
-#define LIST_HEAD 0xFFFFFFFFFFFFFFFFLL
-#define COLORED_LIST_HEAD ((1ULL << 57) - 1) // 0x1FFFFFFFFFFFFFFLL
-#else
-#error Define these please!
-#endif
+#define COLORED_LIST_HEAD (((ULONG_PTR)1 << MI_PTE_FRAME_BITS) - 1)
 
 //
 // Returns the color of a page


### PR DESCRIPTION
## Purpose

Adjust the definition of COLORED_LIST_HEAD to always match the new MI_PTE_FRAME_BITS define.

## Testbot runs (Filled in by Devs)

- ✅ KVM x86: https://reactos.org/testman/compare.php?ids=101658,101660,101663,101681
- ✅ KVM x64: https://reactos.org/testman/compare.php?ids=101806,101808,101809,101812
