### PR TITLE
[XDK] Add missing PCI subclass type definition

### DIFF
--- a/sdk/include/xdk/iotypes.h
+++ b/sdk/include/xdk/iotypes.h
@@ -4130,6 +4130,7 @@ typedef struct _PCI_EXPRESS_SRIOV_CAPABILITY {
 #define PCI_SUBCLASS_MSC_FLOPPY_CTLR        0x02
 #define PCI_SUBCLASS_MSC_IPI_CTLR           0x03
 #define PCI_SUBCLASS_MSC_RAID_CTLR          0x04
+#define PCI_SUBCLASS_MSC_AHCI_CTLR          0x06
 #define PCI_SUBCLASS_MSC_OTHER              0x80
 
 /* PCI device subclasses for class 2 (network controllers)*/


### PR DESCRIPTION
## Purpose

This is split out of https://github.com/reactos/reactos/pull/6577

JIRA issue: [CORE-17256](https://jira.reactos.org/browse/CORE-17256)

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: