### PR TITLE
[SHELL32] fix: focus glitch when hovering separators with submenu open

### DIFF
--- a/dll/win32/shell32/shellmenu/CMenuFocusManager.cpp
+++ b/dll/win32/shell32/shellmenu/CMenuFocusManager.cpp
@@ -355,10 +355,10 @@ LRESULT CMenuFocusManager::ProcessMouseMove(MSG* msg)
         }
         else if (iHitTestResult == -1)
         {
-            // TB_HITTEST would return -1 in 2 states,
-            // 1. the mouse is outside the toolbar
-            // 2. the mouse is over the first item, and that item is a separator
-            // Confirm the second scenario by checking first item's rect
+            // TB_HITTEST would return -1 in two cases:
+            // 1. the mouse is outside the toolbar;
+            // 2. the mouse is over the first item, and that item is a separator.
+            // Confirm the second scenario by checking first item's rect.
             RECT rc;
             SendMessageW(child, TB_GETITEMRECT, 1, (LPARAM)&rc);
             if (PtInRect(&rc, pt))

--- a/dll/win32/shell32/shellmenu/CMenuFocusManager.cpp
+++ b/dll/win32/shell32/shellmenu/CMenuFocusManager.cpp
@@ -348,6 +348,12 @@ LRESULT CMenuFocusManager::ProcessMouseMove(MSG* msg)
         iHitTestResult = SendMessageW(child, TB_HITTEST, 0, (LPARAM) &pt);
         isTracking = entry->mb->_IsTracking();
 
+        // Separators have a negative ID
+        if (iHitTestResult < -1)
+        {
+            iHitTestResult = -iHitTestResult;
+        }
+
         if (SendMessage(child, WM_USER_ISTRACKEDITEM, iHitTestResult, 0) == S_FALSE)
         {
             // The current tracked item has changed, notify the toolbar

--- a/dll/win32/shell32/shellmenu/CMenuFocusManager.cpp
+++ b/dll/win32/shell32/shellmenu/CMenuFocusManager.cpp
@@ -352,7 +352,7 @@ LRESULT CMenuFocusManager::ProcessMouseMove(MSG* msg)
 
         if (iHitTestResult < -1)
         {
-            // TB_HITTEST would would return negative numbers for separators
+            // TB_HITTEST would return negative numbers for separators
             iHitTestResult = -iHitTestResult;
         }
         else if (iHitTestResult == -1)

--- a/dll/win32/shell32/shellmenu/CMenuFocusManager.cpp
+++ b/dll/win32/shell32/shellmenu/CMenuFocusManager.cpp
@@ -324,7 +324,7 @@ LRESULT CMenuFocusManager::ProcessMouseMove(MSG* msg)
 
     POINT pt = msg->pt;
 
-    RECT itemRc = { 0 };
+    RECT rcItem;
 
     // Don't do anything if another window is capturing the mouse.
     HWND cCapture = ::GetCapture();

--- a/dll/win32/shell32/shellmenu/CMenuFocusManager.cpp
+++ b/dll/win32/shell32/shellmenu/CMenuFocusManager.cpp
@@ -361,11 +361,8 @@ LRESULT CMenuFocusManager::ProcessMouseMove(MSG* msg)
             // Confirm the second scenario by checking first item's rect
             RECT rc;
             SendMessageW(child, TB_GETITEMRECT, 1, (LPARAM)&rc);
-
             if (PtInRect(&rc, pt))
-            {
                 iHitTestResult = 1;
-            }
         }
 
         if (SendMessage(child, WM_USER_ISTRACKEDITEM, iHitTestResult, 0) == S_FALSE)

--- a/dll/win32/shell32/shellmenu/CMenuFocusManager.cpp
+++ b/dll/win32/shell32/shellmenu/CMenuFocusManager.cpp
@@ -362,13 +362,11 @@ LRESULT CMenuFocusManager::ProcessMouseMove(MSG* msg)
             // TB_HITTEST would return -1 in 2 states,
             // 1. the mouse is outside the toolbar
             // 2. the mouse is over the first item, and that item is a separator
-            
             // Confirm the second scenario by checking first item's rect
-            SendMessageW(child, TB_GETITEMRECT, 1, (LPARAM)&itemRc);
+            SendMessageW(child, TB_GETITEMRECT, 1, (LPARAM)&rcItem);
 
-            if (PtInRect(&itemRc, pt))
+            if (PtInRect(&rcItem, pt))
             {
-                // The first menu item is actually a separator and the mouse is hovering it right now
                 iHitTestResult = 1;
             }
         }

--- a/dll/win32/shell32/shellmenu/CMenuFocusManager.cpp
+++ b/dll/win32/shell32/shellmenu/CMenuFocusManager.cpp
@@ -357,8 +357,6 @@ LRESULT CMenuFocusManager::ProcessMouseMove(MSG* msg)
         }
         else if (iHitTestResult == -1)
         {
-            ERR("TB_HITTEST returned -1\n");
-
             // TB_HITTEST would return -1 in 2 states,
             // 1. the mouse is outside the toolbar
             // 2. the mouse is over the first item, and that item is a separator

--- a/dll/win32/shell32/shellmenu/CMenuFocusManager.cpp
+++ b/dll/win32/shell32/shellmenu/CMenuFocusManager.cpp
@@ -324,8 +324,6 @@ LRESULT CMenuFocusManager::ProcessMouseMove(MSG* msg)
 
     POINT pt = msg->pt;
 
-    RECT rcItem;
-
     // Don't do anything if another window is capturing the mouse.
     HWND cCapture = ::GetCapture();
     if (cCapture && cCapture != m_captureHwnd && m_current->type != TrackedMenuEntry)
@@ -361,9 +359,10 @@ LRESULT CMenuFocusManager::ProcessMouseMove(MSG* msg)
             // 1. the mouse is outside the toolbar
             // 2. the mouse is over the first item, and that item is a separator
             // Confirm the second scenario by checking first item's rect
-            SendMessageW(child, TB_GETITEMRECT, 1, (LPARAM)&rcItem);
+            RECT rc;
+            SendMessageW(child, TB_GETITEMRECT, 1, (LPARAM)&rc);
 
-            if (PtInRect(&rcItem, pt))
+            if (PtInRect(&rc, pt))
             {
                 iHitTestResult = 1;
             }


### PR DESCRIPTION
## Purpose

This PR fixes a mouse focus glitch, happens when you move the mouse over separators in shell menus.

JIRA issue: [CORE-20124](https://jira.reactos.org/browse/CORE-20124)

## Proposed changes
Since `TB_HITTEST` returns negative numbers for ID for separator menu items ([documentation](https://learn.microsoft.com/en-us/windows/win32/controls/tb-hittest)), shell menu assumes mouse moved outside of the menu popup, highlighting the menu item for currently open submenu.
To fix this behavior, we can detect separators in `CMenuFocusManager::ProcessMouseMove` and "invert" the ID returned by `TB_HITTEST` to make it a positive number again, so the shell menu wouldn't glitch.

## TODO

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: