### PR TITLE
[SHELL32] Don't set a desktop.ini folder icon on WinDir and System32

### DIFF
--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -1519,21 +1519,21 @@ static const CSIDL_DATA CSIDL_Data[] =
         CSIDL_Type_CurrVer,
         L"ProgramFilesX86",
         L"Program Files (x86)",
-        -IDI_SHELL_PROGRAMS_FOLDER
+        0
     },
     { /* 0x2b - CSIDL_PROGRAM_FILES_COMMON */
         &FOLDERID_ProgramFilesCommon,
         CSIDL_Type_CurrVer,
         L"ProgramFilesCommon",
         MAKEINTRESOURCEW(IDS_PROGRAM_FILES_COMMON),
-        -IDI_SHELL_PROGRAMS_FOLDER
+        0
     },
     { /* 0x2c - CSIDL_PROGRAM_FILES_COMMONX86 */
         &FOLDERID_ProgramFilesCommonX86,
         CSIDL_Type_CurrVer,
         L"ProgramFilesCommonX86",
         L"Program Files (x86)\\Common Files",
-        -IDI_SHELL_PROGRAMS_FOLDER
+        0
     },
     { /* 0x2d - CSIDL_COMMON_TEMPLATES */
         &FOLDERID_CommonTemplates,

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -1229,11 +1229,7 @@ static const CSIDL_DATA CSIDL_Data[] =
         CSIDL_Type_User,
         L"Desktop",
         MAKEINTRESOURCEW(IDS_DESKTOPDIRECTORY),
-#ifdef __REACTOS__
         0
-#else
-        -IDI_SHELL_DESKTOP
-#endif
     },
     { /* 0x01 - CSIDL_INTERNET */
         &FOLDERID_InternetFolder,
@@ -1246,11 +1242,7 @@ static const CSIDL_DATA CSIDL_Data[] =
         CSIDL_Type_User,
         L"Programs",
         MAKEINTRESOURCEW(IDS_PROGRAMS),
-#ifdef __REACTOS__
         0
-#else
-        -IDI_SHELL_PROGRAMS_FOLDER
-#endif
     },
     { /* 0x03 - CSIDL_CONTROLS (.CPL files) */
         &FOLDERID_ControlPanelFolder,
@@ -1352,11 +1344,7 @@ static const CSIDL_DATA CSIDL_Data[] =
         CSIDL_Type_User,
         L"Desktop",
         MAKEINTRESOURCEW(IDS_DESKTOPDIRECTORY),
-#ifdef __REACTOS__
         0
-#else
-        -IDI_SHELL_DESKTOP
-#endif
     },
     { /* 0x11 - CSIDL_DRIVES */
         &FOLDERID_ComputerFolder,
@@ -1404,11 +1392,7 @@ static const CSIDL_DATA CSIDL_Data[] =
         CSIDL_Type_AllUsers,
         L"Common Programs",
         MAKEINTRESOURCEW(IDS_PROGRAMS),
-#ifdef __REACTOS__
         0
-#else
-        -IDI_SHELL_PROGRAMS_FOLDER
-#endif
     },
     { /* 0x18 - CSIDL_COMMON_STARTUP */
         &FOLDERID_CommonStartup,
@@ -1421,11 +1405,7 @@ static const CSIDL_DATA CSIDL_Data[] =
         CSIDL_Type_AllUsers,
         L"Common Desktop",
         MAKEINTRESOURCEW(IDS_DESKTOPDIRECTORY),
-#ifdef __REACTOS__
         0
-#else
-        -IDI_SHELL_DESKTOP
-#endif
     },
     { /* 0x1a - CSIDL_APPDATA */
         &FOLDERID_RoamingAppData,
@@ -1494,25 +1474,21 @@ static const CSIDL_DATA CSIDL_Data[] =
         CSIDL_Type_WindowsPath,
         L"Windows",
         NULL,
-        -IDI_SHELL_SYSTEM_GEAR
+        0
     },
     { /* 0x25 - CSIDL_SYSTEM */
         &FOLDERID_System,
         CSIDL_Type_SystemPath,
         L"System",
         NULL,
-        -IDI_SHELL_SYSTEM_GEAR
+        0
     },
     { /* 0x26 - CSIDL_PROGRAM_FILES */
         &FOLDERID_ProgramFiles,
         CSIDL_Type_CurrVer,
         L"ProgramFiles",
         MAKEINTRESOURCEW(IDS_PROGRAM_FILES),
-#ifdef __REACTOS__
         0
-#else
-        -IDI_SHELL_PROGRAMS_FOLDER
-#endif
     },
     { /* 0x27 - CSIDL_MYPICTURES */
         &FOLDERID_Pictures,


### PR DESCRIPTION
JIRA issue: [CORE-19037](https://jira.reactos.org/browse/CORE-19037)

The member for storing the icon was removed in wine [332b90c0064563a9e4f67fb2d9b26a940e5e745c](https://gitlab.winehq.org/wine/wine/-/commit/332b90c0064563a9e4f67fb2d9b26a940e5e745c) so I'm removing the `__REACTOS__` checks (and we are not wine syncing shell32 anyway).

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: