### PR TITLE
[DESK][SHELL32] Remove desk.cpl hacks for argument parsing

### DIFF
--- a/dll/cpl/desk/desk.c
+++ b/dll/cpl/desk/desk.c
@@ -174,23 +174,14 @@ DisplayApplet(HWND hwnd, UINT uMsg, LPARAM wParam, LPARAM lParam)
 
         nPage = _wtoi((PWSTR)lParam);
 
-#if 0
         argv = CommandLineToArgvW((LPCWSTR)lParam, &argc);
-#else
-        argv = CommandLineToArgvW(GetCommandLineW(), &argc);
-#endif
 
         if (argv && argc)
         {
             for (i = 0; i<argc; i++)
             {
-#if 0
                 if (argv[i][0] == L'@')
                     pwszSelectedTab = &argv[i][1];
-#else
-                if (wcsncmp(argv[i], L"desk,@", 6) == 0)
-                    pwszSelectedTab = &argv[i][6];
-#endif
                 else if (wcsncmp(argv[i], L"/Action:", 8) == 0)
                     pwszAction = &argv[i][8];
                 else if (wcsncmp(argv[i], L"/file:", 6) == 0)

--- a/dll/win32/shell32/wine/control.c
+++ b/dll/win32/shell32/wine/control.c
@@ -1050,7 +1050,7 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
     /* If an unquoted comma was found, there are at least two parts of the string:
      * - the CPL path
      * - either a dialog box number preceeded by @, or a dialog box name.
-     * If there was a second unqoted comma, there is another part of the string:
+     * If there was a second unquoted comma, there is another part of the string:
      * - the rest of the parameters. */
     else
     {

--- a/dll/win32/shell32/wine/control.c
+++ b/dll/win32/shell32/wine/control.c
@@ -1016,8 +1016,11 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
                 else if (!pchSecondComma) 
                     pchSecondComma = &wszCmd[i];
                 break;
-            case L' ': 
-                pchLastUnquotedSpace = &wszCmd[i];
+            case L' ':
+                if (!pchFirstComma)
+                    pchFirstComma = &wszCmd[i];
+                else
+                    pchLastUnquotedSpace = &wszCmd[i];
                 break;
         }
     }
@@ -1104,7 +1107,8 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
             }
         }
 
-        if (sp >= applet->count && (wszDialogBoxName[0] == L'\0' || wszDialogBoxName[0] == L'@'))
+        if (sp >= applet->count && (wszDialogBoxName[0] == L'\0' || wszDialogBoxName[0] == L'@' ||
+                                    extraPmts[0] != '\0'))
         {
             sp = 0;
         }

--- a/dll/win32/shell32/wine/control.c
+++ b/dll/win32/shell32/wine/control.c
@@ -1108,7 +1108,7 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
         }
 
         if (applet->count == 1 ||
-            (sp >= applet->count && (wszDialogBoxName[0] == L'\0' || wszDialogBoxName[0] == L'@')))
+            (sp >= applet->count && (wszDialogBoxName[0] == UNICODE_NULL || wszDialogBoxName[0] == L'@')))
         {
             sp = 0;
         }

--- a/dll/win32/shell32/wine/control.c
+++ b/dll/win32/shell32/wine/control.c
@@ -1107,8 +1107,8 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
             }
         }
 
-        if (sp >= applet->count && (wszDialogBoxName[0] == L'\0' || wszDialogBoxName[0] == L'@' ||
-                                    extraPmts[0] != '\0'))
+        if (applet->count == 1 ||
+            (sp >= applet->count && (wszDialogBoxName[0] == L'\0' || wszDialogBoxName[0] == L'@')))
         {
             sp = 0;
         }


### PR DESCRIPTION
## Purpose

Remove argument parsing hacks from desk.cpl that were originally introduced to make it work with the previous broken implementation of `Control_RunDLLW`. 

JIRA issue: [CORE-20076](https://jira.reactos.org/browse/CORE-20076)

## Proposed changes

- Remove argument parsing hacks from desk.cpl
- Fix some issues with space separated string parsing in `Control_RunDLL`
- Windows seems to allow invalid dialogbox names if ~~extra arguments are passed~~ there is only one dialogbox; this might need some new cases in rostests

## TODO

- [ ] Add some rostests for this (maybe)
- ~~Revert #6930 (maybe)~~

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: