### PR TITLE
[EXPLORER] Implement ClearRecentDocsOnExit setting

### DIFF
--- a/base/shell/explorer/precomp.h
+++ b/base/shell/explorer/precomp.h
@@ -353,6 +353,8 @@ UpdateStartMenu(IN OUT IMenuPopup *pMenuPopup,
  */
 VOID
 ShowCustomizeClassic(HINSTANCE, HWND);
+VOID
+ClearRecentAndMru();
 
 /*
 * startmnusite.cpp

--- a/base/shell/explorer/startmnucust.cpp
+++ b/base/shell/explorer/startmnucust.cpp
@@ -72,7 +72,7 @@ static BOOL HandleMruData(BOOL Delete)
     {
         WCHAR szKey[200];
         PCWSTR pszKey = g_MruKeys[i];
-        if (*pszKey != 'S')
+        if (*pszKey != 'S') // Keys not starting with S[oftware] are assumed to be relative to "SMWCV"
         {
             wsprintfW(szKey, L"%s\\%s", L"Software\\Microsoft\\Windows\\CurrentVersion", pszKey);
             pszKey = szKey;

--- a/base/shell/explorer/startmnucust.cpp
+++ b/base/shell/explorer/startmnucust.cpp
@@ -58,10 +58,53 @@ static BOOL RecentHasShortcut(HWND hwnd)
     return TRUE;
 }
 
-static VOID OnClearRecentItems(HWND hwnd)
+static const PCWSTR g_MruKeys[] = 
+{
+    L"Software\\Microsoft\\Internet Explorer\\TypedURLs",
+    L"Explorer\\RunMRU",
+    L"Explorer\\Comdlg32\\OpenSaveMRU",
+    L"Explorer\\Comdlg32\\LastVisitedMRU",
+};
+
+static BOOL HandleMruData(BOOL Delete)
+{
+    for (UINT i = 0; i < _countof(g_MruKeys); ++i)
+    {
+        WCHAR szKey[200];
+        PCWSTR pszKey = g_MruKeys[i];
+        if (*pszKey != 'S')
+        {
+            wsprintfW(szKey, L"%s\\%s", L"Software\\Microsoft\\Windows\\CurrentVersion", pszKey);
+            pszKey = szKey;
+        }
+
+        HKEY hKey;
+        if (Delete)
+        {
+            SHDeleteKeyW(HKEY_CURRENT_USER, pszKey);
+        }
+        else if (RegOpenKeyExW(HKEY_CURRENT_USER, pszKey, 0, KEY_WRITE, &hKey) == ERROR_SUCCESS)
+        {
+            RegCloseKey(hKey);
+            return TRUE;
+        }
+    }
+    return FALSE;
+}
+
+VOID ClearRecentAndMru()
 {
     SHAddToRecentDocs(SHARD_PIDL, NULL);
-    EnableWindow(GetDlgItem(hwnd, IDC_CLASSICSTART_CLEAR), RecentHasShortcut(hwnd));
+    HandleMruData(TRUE);
+}
+
+static VOID InitializeClearButton(HWND hwnd)
+{
+    HWND hWndClear = GetDlgItem(hwnd, IDC_CLASSICSTART_CLEAR);
+    BOOL bHasData = RecentHasShortcut(hwnd) || HandleMruData(FALSE);
+    if (!bHasData && hWndClear == GetFocus())
+        SendMessage(hwnd, WM_NEXTDLGCTL, 0, FALSE);
+    EnableWindow(hWndClear, bHasData);
 }
 
 struct CUSTOM_ENTRY;
@@ -175,7 +218,7 @@ static VOID AddCustomItem(HWND hTreeView, const CUSTOM_ENTRY *entry)
 
 static void CustomizeClassic_OnInitDialog(HWND hwnd)
 {
-    EnableWindow(GetDlgItem(hwnd, IDC_CLASSICSTART_CLEAR), RecentHasShortcut(hwnd));
+    InitializeClearButton(hwnd);
 
     HWND hTreeView = GetDlgItem(hwnd, IDC_CLASSICSTART_SETTINGS);
 
@@ -240,7 +283,8 @@ INT_PTR CALLBACK CustomizeClassicProc(HWND hwnd, UINT Message, WPARAM wParam, LP
                     OnAdvancedStartMenuItems();
                     break;
                 case IDC_CLASSICSTART_CLEAR:
-                    OnClearRecentItems(hwnd);
+                    ClearRecentAndMru();
+                    InitializeClearButton(hwnd);
                     break;
                 case IDOK:
                     if (CustomizeClassic_OnOK(hwnd))

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -470,6 +470,9 @@ public:
             return;
 
         SendMessage(m_DesktopWnd, WM_PROGMAN_SAVESTATE, 0, 0);
+
+        if (SHRestricted(REST_CLEARRECENTDOCSONEXIT))
+            ClearRecentAndMru();
     }
 
     LRESULT DoExitWindows()


### PR DESCRIPTION

![TweakUI](https://github.com/user-attachments/assets/8cc451db-3c5d-498b-9046-222509da5b88)

Note that the normal clear button is also supposed to clear the registry and it also says so in the UI text:

![ROS Explorer](https://github.com/user-attachments/assets/fd11661e-5e5a-4978-9a5a-a23e74cf2f85)


## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: