### PR TITLE
[MSGINA][LSASRV] Support LSA secret DefaultPassword in autologon

### DIFF
--- a/dll/win32/lsasrv/lsarpc.c
+++ b/dll/win32/lsasrv/lsarpc.c
@@ -3620,6 +3620,8 @@ LsarRetrievePrivateData(
     PRPC_UNICODE_STRING KeyName,
     PLSAPR_CR_CIPHER_VALUE *EncryptedData)
 {
+    /* TODO: This should just call LsarOpenSecret(SECRET_QUERY_VALUE)+LsarQuerySecret? */
+
     PLSA_DB_OBJECT PolicyObject = NULL;
     PLSA_DB_OBJECT SecretObject = NULL;
     PLSAPR_CR_CIPHER_VALUE EncCurrentValue = NULL;
@@ -3633,7 +3635,7 @@ LsarRetrievePrivateData(
     /* Validate the SecretHandle */
     Status = LsapValidateDbObject(PolicyHandle,
                                   LsaDbPolicyObject,
-                                  POLICY_CREATE_SECRET,
+                                  POLICY_GET_PRIVATE_INFORMATION,
                                   &PolicyObject);
     if (!NT_SUCCESS(Status))
     {


### PR DESCRIPTION
Tweak UI and [Sysinternals Autologon](https://learn.microsoft.com/en-us/sysinternals/downloads/autologon) stores the autologon password as a LSA secret.

Notes:
- The problem in lsasrv was probably a copy/paste bug from `LsarStorePrivateData` to `LsarRetrievePrivateData`. I changed it to the access constant documented on MSDN.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: