### PR TITLE
[NTOS] Implement support for global pages

### DIFF
--- a/ntoskrnl/include/config.h
+++ b/ntoskrnl/include/config.h
@@ -1,4 +1,4 @@
 #pragma once
 
 // Enable global page support.
-// #define _GLOBAL_PAGES_ARE_AWESOME_
+#define _GLOBAL_PAGES_ARE_AWESOME_

--- a/ntoskrnl/include/internal/amd64/ke.h
+++ b/ntoskrnl/include/internal/amd64/ke.h
@@ -256,25 +256,6 @@ KeRestoreInterrupts(BOOLEAN WereEnabled)
     if (WereEnabled) _enable();
 }
 
-//
-// Invalidates the TLB entry for a specified address
-//
-FORCEINLINE
-VOID
-KeInvalidateTlbEntry(IN PVOID Address)
-{
-    /* Invalidate the TLB entry for this address */
-    __invlpg(Address);
-}
-
-FORCEINLINE
-VOID
-KeFlushProcessTb(VOID)
-{
-    /* Flush the TLB by resetting CR3 */
-    __writecr3(__readcr3());
-}
-
 FORCEINLINE
 VOID
 KeSweepICache(IN PVOID BaseAddress,

--- a/ntoskrnl/include/internal/arch/ke.h
+++ b/ntoskrnl/include/internal/arch/ke.h
@@ -21,6 +21,7 @@
 
 #ifdef _M_IX86
 #include <internal/i386/ke.h>
+#include <internal/x86x64/ke.h>
 #elif defined(_M_PPC)
 #include <internal/powerpc/ke.h>
 #elif defined(_M_MIPS)
@@ -29,6 +30,7 @@
 #include <internal/arm/ke.h>
 #elif defined(_M_AMD64)
 #include <internal/amd64/ke.h>
+#include <internal/x86x64/ke.h>
 #else
 #error "Unknown processor"
 #endif

--- a/ntoskrnl/include/internal/arm/ke.h
+++ b/ntoskrnl/include/internal/arm/ke.h
@@ -98,12 +98,16 @@ KeRestoreInterrupts(BOOLEAN WereEnabled)
     if (WereEnabled) _enable();
 }
 
+static const ULONG KxFlushIndividualProcessPagesMaximum = 1024; // Based on Linux tlb_single_page_flush_ceiling
+static const ULONG KxFlushIndividualGlobalPagesMaximum = 1024; // Just a guess
+
 //
 // Invalidates the TLB entry for a specified address
 //
 FORCEINLINE
 VOID
-KeInvalidateTlbEntry(IN PVOID Address)
+KxFlushSingleCurrentTb(
+    _In_ PVOID Address)
 {
     /* Invalidate the TLB entry for this address */
     KeArmInvalidateTlbEntry(Address);
@@ -111,7 +115,29 @@ KeInvalidateTlbEntry(IN PVOID Address)
 
 FORCEINLINE
 VOID
-KeFlushProcessTb(VOID)
+KxFlushRangeCurrentTb(
+    _In_ PVOID Address,
+    _In_ ULONG NumberOfPages)
+{
+    /* Invalidate the TLB entry for each page */
+    for (ULONG i = 0; i < NumberOfPages; i++)
+    {
+        KeArmInvalidateTlbEntry((PVOID)((ULONG_PTR)Address + (i * PAGE_SIZE)));
+    }
+}
+
+FORCEINLINE
+VOID
+KxFlushProcessCurrentTb(
+    VOID)
+{
+    KeArmFlushTlb();
+}
+
+FORCEINLINE
+VOID
+KxFlushEntireCurrentTb(
+    VOID)
 {
     KeArmFlushTlb();
 }

--- a/ntoskrnl/include/internal/i386/ke.h
+++ b/ntoskrnl/include/internal/i386/ke.h
@@ -350,25 +350,6 @@ KeQueryInterruptHandler(IN ULONG Vector)
                     (Pcr->IDT[Entry].Offset & 0xFFFF));
 }
 
-//
-// Invalidates the TLB entry for a specified address
-//
-FORCEINLINE
-VOID
-KeInvalidateTlbEntry(IN PVOID Address)
-{
-    /* Invalidate the TLB entry for this address */
-    __invlpg(Address);
-}
-
-FORCEINLINE
-VOID
-KeFlushProcessTb(VOID)
-{
-    /* Flush the TLB by resetting CR3 */
-    __writecr3(__readcr3());
-}
-
 FORCEINLINE
 VOID
 KeSweepICache(IN PVOID BaseAddress,

--- a/ntoskrnl/include/internal/ke.h
+++ b/ntoskrnl/include/internal/ke.h
@@ -378,6 +378,15 @@ KiIpiSignalPacketDoneAndStall(
     IN volatile PULONG ReverseStall
 );
 
+VOID
+NTAPI
+KiIpiSendRequest(
+    _In_ KAFFINITY TargetSet,
+    _In_ PKIPI_WORKER WorkerRoutine,
+    _In_ PVOID Parameter1,
+    _In_ PVOID Parameter2,
+    _In_ PVOID Parameter3);
+
 /* next file ***************************************************************/
 
 UCHAR

--- a/ntoskrnl/include/internal/ke.h
+++ b/ntoskrnl/include/internal/ke.h
@@ -828,7 +828,26 @@ KiHandleNmi(VOID);
 
 VOID
 NTAPI
-KeFlushCurrentTb(VOID);
+KeFlushSingleTb(
+    _In_ PVOID Address,
+    _In_ BOOLEAN AllProcessors);
+
+VOID
+NTAPI
+KeFlushRangeTb(
+    _In_ PVOID Address,
+    _In_ ULONG NumberOfPages,
+    _In_ BOOLEAN Global);
+
+VOID
+NTAPI
+KeFlushProcessTb(VOID);
+
+VOID
+NTAPI
+KeFlushEntireTb(
+    _In_ BOOLEAN Invalid,
+    _In_ BOOLEAN AllProcessors);
 
 BOOLEAN
 NTAPI

--- a/ntoskrnl/include/internal/ke_x.h
+++ b/ntoskrnl/include/internal/ke_x.h
@@ -11,6 +11,14 @@ extern "C"
 {
 #endif
 
+FORCEINLINE
+PKPROCESS
+KeGetCurrentProcess(VOID)
+{
+    /* Get the current process */
+    return KeGetCurrentThread()->ApcState.Process;
+}
+
 #ifndef _M_ARM
 FORCEINLINE
 KPROCESSOR_MODE

--- a/ntoskrnl/include/internal/x86x64/ke.h
+++ b/ntoskrnl/include/internal/x86x64/ke.h
@@ -1,0 +1,90 @@
+/*
+ * PROJECT:     ReactOS Kernel
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     Architecture specific support routines shared between x86 and x64
+ * COPYRIGHT:   Copyright 2025 Timo Kreuzer <timo.kreuzer@reactos.org>
+ */
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern ULONG64 KeFeatureBits;
+
+static const ULONG KxFlushIndividualProcessPagesMaximum = 33; // Based on Linux tlb_single_page_flush_ceiling
+static const ULONG KxFlushIndividualGlobalPagesMaximum = 100; // Just a guess
+
+/*!
+ * \brief Flushes the current processor's TLB for a single page.
+ * \note This function flushes global pages.
+ */
+FORCEINLINE
+VOID
+KxFlushSingleCurrentTb(
+    _In_ PVOID Address)
+{
+    /* Invalidate the TLB entry for this address */
+    __invlpg(Address);
+}
+
+/*!
+* \brief Flushes the current processor's TLB for a range of pages.
+* \param Address The starting address of the range to flush.
+* \param NumberOfPages The number of pages to flush.
+* \note This function flushes global pages. It does not optimize for large ranges.
+*/
+FORCEINLINE
+VOID
+KxFlushRangeCurrentTb(
+    _In_ PVOID Address,
+    _In_ ULONG NumberOfPages)
+{
+    /* Invalidate the TLB entry for each page */
+    for (ULONG i = 0; i < NumberOfPages; i++)
+    {
+        __invlpg((PVOID)((ULONG_PTR)Address + (i * PAGE_SIZE)));
+    }
+}
+
+/*!
+ * \brief Flushes the current processor's TLB, excluding global pages.
+ */
+FORCEINLINE
+VOID
+KxFlushProcessCurrentTb(
+    VOID)
+{
+    /* Flush the TLB excluding global pages */
+    __writecr3(__readcr3());
+}
+
+/*!
+ * \brief Flushes the current processor's entire TLB, including global pages.
+ */
+FORCEINLINE
+VOID
+KxFlushEntireCurrentTb(
+    VOID)
+{
+#ifdef _GLOBAL_PAGES_ARE_AWESOME_
+    /* Check if global pages are enabled in CR4 */
+    if (KeFeatureBits & KF_GLOBAL_PAGE)
+    {
+        /* Disable and restore PGE. This will flush the entire TLB */
+        ULONG64 oldCr4 = __readcr4();
+        __writecr4(oldCr4 & ~CR4_PGE);
+        __writecr4(oldCr4);
+    }
+    else
+#endif
+    {
+        /* We don't use global pages, reset CR3 instead */
+        __writecr3(__readcr3());
+    }
+}
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/ntoskrnl/ke/amd64/cpu.c
+++ b/ntoskrnl/ke/amd64/cpu.c
@@ -525,14 +525,6 @@ KiGetCacheInformation(VOID)
 
 VOID
 NTAPI
-KeFlushCurrentTb(VOID)
-{
-    /* Flush the TLB by resetting CR3 */
-    __writecr3(__readcr3());
-}
-
-VOID
-NTAPI
 KiRestoreProcessorControlState(PKPROCESSOR_STATE ProcessorState)
 {
     /* Restore the CR registers */
@@ -647,26 +639,6 @@ KiRestoreProcessorState(
 
     /* Restore control registers */
     KiRestoreProcessorControlState(&Prcb->ProcessorState);
-}
-
-VOID
-NTAPI
-KeFlushEntireTb(IN BOOLEAN Invalid,
-                IN BOOLEAN AllProcessors)
-{
-    KIRQL OldIrql;
-
-    // FIXME: halfplemented
-    /* Raise the IRQL for the TB Flush */
-    OldIrql = KeRaiseIrqlToSynchLevel();
-
-    /* Flush the TB for the Current CPU, and update the flush stamp */
-    KeFlushCurrentTb();
-
-    /* Update the flush stamp and return to original IRQL */
-    InterlockedExchangeAdd(&KiTbFlushTimeStamp, 1);
-    KeLowerIrql(OldIrql);
-
 }
 
 NTSTATUS

--- a/ntoskrnl/ke/amd64/freeze.c
+++ b/ntoskrnl/ke/amd64/freeze.c
@@ -88,6 +88,9 @@ KiProcessorFreezeHandler(
     /* Restore the processor state */
     KiRestoreProcessorState(TrapFrame, ExceptionFrame);
 
+    /* Flush the TLB on this processor */
+    KxFlushEntireCurrentTb();
+
     /* We are running again now */
     CurrentPrcb->IpiFrozen = IPI_FROZEN_STATE_RUNNING;
 

--- a/ntoskrnl/ke/amd64/ipi.c
+++ b/ntoskrnl/ke/amd64/ipi.c
@@ -14,6 +14,34 @@
 /* FUNCTIONS *****************************************************************/
 
 VOID
+NTAPI
+KiIpiSendRequest(
+    _In_ KAFFINITY TargetSet,
+    _In_ PKIPI_WORKER WorkerRoutine,
+    _In_ PVOID Parameter1,
+    _In_ PVOID Parameter2,
+    _In_ PVOID Parameter3)
+{
+    KIRQL OldIrql;
+
+    if (KeNumberProcessors > 1)
+    {
+        ASSERT(FALSE);
+    }
+
+    KeRaiseIrql(IPI_LEVEL, &OldIrql);
+
+    if (TargetSet & KeGetCurrentPrcb()->SetMember)
+    {
+        WorkerRoutine(NULL, Parameter1, Parameter2, Parameter3);
+    }
+    else
+        __debugbreak();
+
+    KeLowerIrql(OldIrql);
+}
+
+VOID
 FASTCALL
 KiIpiSend(
     _In_ KAFFINITY TargetSet,

--- a/ntoskrnl/ke/amd64/kiinit.c
+++ b/ntoskrnl/ke/amd64/kiinit.c
@@ -551,6 +551,9 @@ KiSystemStartup(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
     /* Set processor as active */
     KeActiveProcessors |= 1ULL << Cpu;
 
+    /* We are running the initial system process now */
+    InterlockedOr64(&KiInitialProcess.Pcb.ActiveProcessors, 1ULL << Cpu);
+
     /* Release lock */
     InterlockedAnd64((PLONG64)&KiFreezeExecutionLock, 0);
 

--- a/ntoskrnl/ke/amd64/stubs.c
+++ b/ntoskrnl/ke/amd64/stubs.c
@@ -170,7 +170,9 @@ KiSwapProcess(IN PKPROCESS NewProcess,
 #ifdef CONFIG_SMP
     /* Update active processor mask */
     InterlockedXor64((PLONG64)&NewProcess->ActiveProcessors, Pcr->Prcb.SetMember);
+    NT_ASSERT((NewProcess->ActiveProcessors & Pcr->Prcb.SetMember) != 0);
     InterlockedXor64((PLONG64)&OldProcess->ActiveProcessors, Pcr->Prcb.SetMember);
+    NT_ASSERT((OldProcess->ActiveProcessors & Pcr->Prcb.SetMember) == 0);
 #endif
 
     /* Update CR3 */

--- a/ntoskrnl/ke/amd64/thrdini.c
+++ b/ntoskrnl/ke/amd64/thrdini.c
@@ -161,11 +161,7 @@ KiSwapContextResume(
     NewProcess = NewThread->ApcState.Process;
     if (OldProcess != NewProcess)
     {
-        /* Switch address space and flush TLB */
-        __writecr3(NewProcess->DirectoryTableBase[0]);
-
-        /* Set new TSS fields */
-        //Pcr->TssBase->IoMapBase = NewProcess->IopmOffset;
+        KiSwapProcess(NewProcess, OldProcess);
     }
 
     /* Set TEB pointer and GS base */

--- a/ntoskrnl/ke/freeze.c
+++ b/ntoskrnl/ke/freeze.c
@@ -73,7 +73,7 @@ KeThawExecution(IN BOOLEAN Enable)
     KiFreezeFlag = 0;
 
     /* Cleanup CPU caches */
-    KeFlushCurrentTb();
+    KxFlushEntireCurrentTb();
 
     /* Restore the old IRQL */
 #ifndef CONFIG_SMP

--- a/ntoskrnl/ke/ipi.c
+++ b/ntoskrnl/ke/ipi.c
@@ -273,4 +273,16 @@ KeIpiGenericCall(IN PKIPI_BROADCAST_WORKER Function,
     return Status;
 }
 
+VOID
+NTAPI
+KiIpiSendRequest(
+    _In_ KAFFINITY TargetSet,
+    _In_ PKIPI_WORKER WorkerRoutine,
+    _In_ PVOID Parameter1,
+    _In_ PVOID Parameter2,
+    _In_ PVOID Parameter3)
+{
+    ASSERTMSG("Not yet implemented\n", FALSE);
+}
+
 #endif // !_M_AMD64

--- a/ntoskrnl/ke/tlbflush.c
+++ b/ntoskrnl/ke/tlbflush.c
@@ -1,0 +1,163 @@
+/*
+ * PROJECT:     ReactOS Kernel
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     Support routines for flushing the TLB
+ * COPYRIGHT:   Copyright 2025 Timo Kreuzer <timo.kreuzer@reactos.org>
+ */
+
+/* INCLUDES *******************************************************************/
+
+#include <ntoskrnl.h>
+
+/* FUNCTIONS ******************************************************************/
+
+#ifdef CONFIG_SMP
+static
+VOID
+NTAPI
+KiFlushSingleTbIpiWorker(
+    _In_ PKIPI_CONTEXT PacketContext,
+    _In_ PVOID Parameter1,
+    _In_ PVOID Parameter2,
+    _In_ PVOID Parameter3)
+{
+    KxFlushSingleCurrentTb(Parameter1);
+}
+#endif
+
+VOID
+NTAPI
+KeFlushSingleTb(
+    _In_ PVOID Address,
+    _In_ BOOLEAN AllProcessors)
+{
+#ifdef CONFIG_SMP
+    KAFFINITY TargetSet = AllProcessors ?
+        KeActiveProcessors : KeGetCurrentProcess()->ActiveProcessors;
+    KiIpiSendRequest(TargetSet,
+                     KiFlushSingleTbIpiWorker,
+                     Address,
+                     NULL,
+                     NULL);
+#else
+    KxFlushSingleCurrentTb(Address);
+#endif
+}
+
+#ifdef CONFIG_SMP
+static
+VOID
+NTAPI
+KiFlushRangeTbIpiWorker(
+    _In_ PKIPI_CONTEXT PacketContext,
+    _In_ PVOID Parameter1,
+    _In_ PVOID Parameter2,
+    _In_ PVOID Parameter3)
+{
+    KxFlushRangeCurrentTb(Parameter1, PtrToUlong(Parameter2));
+}
+#endif
+
+VOID
+NTAPI
+KeFlushRangeTb(
+    _In_ PVOID Address,
+    _In_ ULONG NumberOfPages,
+    _In_ BOOLEAN Global)
+{
+    /* If Global is true it means all TLB entries on all processors,
+       otherwise local TLB entries on the process's active processors. */
+    if (Global)
+    {
+        if (NumberOfPages > KxFlushIndividualGlobalPagesMaximum)
+        {
+            /* Flush the entire TLB instead */
+            KeFlushEntireTb(TRUE, TRUE);
+            return;
+        }
+    }
+    else
+    {
+        if (NumberOfPages > KxFlushIndividualProcessPagesMaximum)
+        {
+            /* Flush the entire TLB instead */
+            KeFlushProcessTb();
+            return;
+        }
+    }
+
+#ifdef CONFIG_SMP
+    KAFFINITY TargetSet = Global ?
+        KeActiveProcessors : KeGetCurrentProcess()->ActiveProcessors;
+    KiIpiSendRequest(TargetSet,
+                     KiFlushRangeTbIpiWorker,
+                     Address,
+                     ULongToPtr(NumberOfPages),
+                     NULL);
+#else
+    KxFlushRangeCurrentTb(Address, NumberOfPages);
+#endif
+}
+
+#ifdef CONFIG_SMP
+static
+VOID
+NTAPI
+KiFlushProcessTbIpiWorker(
+    _In_ PKIPI_CONTEXT PacketContext,
+    _In_ PVOID Parameter1,
+    _In_ PVOID Parameter2,
+    _In_ PVOID Parameter3)
+{
+    KxFlushProcessCurrentTb();
+}
+#endif
+
+VOID
+NTAPI
+KeFlushProcessTb(VOID)
+{
+#ifdef CONFIG_SMP
+    KiIpiSendRequest(KeGetCurrentProcess()->ActiveProcessors,
+                     KiFlushProcessTbIpiWorker,
+                     NULL,
+                     NULL,
+                     NULL);
+#else
+    KxFlushProcessCurrentTb();
+#endif
+}
+
+#ifdef CONFIG_SMP
+static
+VOID
+NTAPI
+KiFlushEntireTbIpiWorker(
+    _In_ PKIPI_CONTEXT PacketContext,
+    _In_ PVOID Parameter1,
+    _In_ PVOID Parameter2,
+    _In_ PVOID Parameter3)
+{
+    /* Flush the current TB */
+    KxFlushEntireCurrentTb();
+}
+#endif
+
+VOID
+NTAPI
+KeFlushEntireTb(
+    _In_ BOOLEAN Invalid,
+    _In_ BOOLEAN AllProcessors)
+{
+#ifdef CONFIG_SMP
+    KAFFINITY TargetSet = AllProcessors ?
+        KeActiveProcessors : KeGetCurrentProcess()->ActiveProcessors;
+    KiIpiSendRequest(TargetSet,
+                     KiFlushEntireTbIpiWorker,
+                     NULL,
+                     NULL,
+                     NULL);
+#else
+    KxFlushEntireCurrentTb();
+#endif
+}

--- a/ntoskrnl/mm/ARM3/hypermap.c
+++ b/ntoskrnl/mm/ARM3/hypermap.c
@@ -20,6 +20,7 @@
 PMMPTE MmFirstReservedMappingPte, MmLastReservedMappingPte;
 PMMPTE MiFirstReservedZeroingPte;
 MMPTE HyperTemplatePte;
+extern PKTHREAD MiZeroPageThread;
 
 /* PRIVATE FUNCTIONS **********************************************************/
 
@@ -118,6 +119,7 @@ MiMapPagesInZeroSpace(IN PMMPFN Pfn1,
     //
     // Sanity checks
     //
+    ASSERT(KeGetCurrentThread() == MiZeroPageThread);
     ASSERT(KeGetCurrentIrql() == PASSIVE_LEVEL);
     ASSERT(NumberOfPages != 0);
     ASSERT(NumberOfPages <= MI_ZERO_PTES);
@@ -192,6 +194,7 @@ MiUnmapPagesInZeroSpace(IN PVOID VirtualAddress,
     //
     // Sanity checks
     //
+    ASSERT(KeGetCurrentThread() == MiZeroPageThread);
     ASSERT(KeGetCurrentIrql() == PASSIVE_LEVEL);
     ASSERT (NumberOfPages != 0);
     ASSERT(NumberOfPages <= MI_ZERO_PTES);

--- a/ntoskrnl/mm/ARM3/hypermap.c
+++ b/ntoskrnl/mm/ARM3/hypermap.c
@@ -140,7 +140,7 @@ MiMapPagesInZeroSpace(IN PMMPFN Pfn1,
         //
         Offset = MI_ZERO_PTES;
         PointerPte->u.Hard.PageFrameNumber = Offset;
-        KeFlushProcessTb();
+        KeFlushRangeTb(MiPteToAddress(PointerPte + 1), MI_ZERO_PTES, TRUE);
     }
 
     //
@@ -205,7 +205,8 @@ MiUnmapPagesInZeroSpace(IN PVOID VirtualAddress,
     PointerPte = MiAddressToPte(VirtualAddress);
 
     //
-    // Blow away the mapped zero PTEs
+    // Blow away the mapped zero PTEs.
+    // Note: TLB flush happens in MiMapPagesInZeroSpace, when a new range is started
     //
     RtlZeroMemory(PointerPte, NumberOfPages * sizeof(MMPTE));
 }

--- a/ntoskrnl/mm/ARM3/i386/init.c
+++ b/ntoskrnl/mm/ARM3/i386/init.c
@@ -501,7 +501,7 @@ MiInitMachineDependent(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
     PsGetCurrentProcess()->Pcb.DirectoryTableBase[1] = PageFrameIndex << PAGE_SHIFT;
 
     /* Flush the TLB */
-    KeFlushCurrentTb();
+    KxFlushEntireCurrentTb();
 
     /* Release the lock */
     MiReleasePfnLock(OldIrql);

--- a/ntoskrnl/mm/ARM3/i386/init.c
+++ b/ntoskrnl/mm/ARM3/i386/init.c
@@ -250,22 +250,6 @@ MiInitMachineDependent(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
     PMMPFN Pfn1;
     ULONG Flags;
 
-#if defined(_GLOBAL_PAGES_ARE_AWESOME_)
-
-    /* Check for global bit */
-    if (KeFeatureBits & KF_GLOBAL_PAGE)
-    {
-        /* Set it on the template PTE and PDE */
-        ValidKernelPte.u.Hard.Global = TRUE;
-        ValidKernelPde.u.Hard.Global = TRUE;
-    }
-
-#endif
-
-    /* Now templates are ready */
-    TempPte = ValidKernelPte;
-    TempPde = ValidKernelPde;
-
     //
     // Set CR3 for the system process
     //
@@ -362,6 +346,14 @@ MiInitMachineDependent(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
     ASSERT(PageFrameIndex != 0);
     DPRINT("PFN DB PA PFN begins at: %lx\n", PageFrameIndex);
     DPRINT("NP PA PFN begins at: %lx\n", PageFrameIndex + MxPfnAllocation);
+
+#ifdef _GLOBAL_PAGES_ARE_AWESOME_
+    MiInitializeGlobalPages();
+#endif
+
+    /* Now templates are ready */
+    TempPte = ValidKernelPte;
+    TempPde = ValidKernelPde;
 
     /* Convert nonpaged pool size from bytes to pages */
     MmMaximumNonPagedPoolInPages = MmMaximumNonPagedPoolInBytes >> PAGE_SHIFT;

--- a/ntoskrnl/mm/ARM3/mmdbg.c
+++ b/ntoskrnl/mm/ARM3/mmdbg.c
@@ -90,7 +90,7 @@ MiDbgTranslatePhysicalAddress(IN ULONG64 PhysicalAddress,
     }
 
     /* Map the PTE and invalidate its TLB entry */
-    *MmDebugPte = TempPte;
+    MI_WRITE_VALID_PTE(MmDebugPte, TempPte);
     KxFlushSingleCurrentTb(MappingBaseAddress);
 
     /* Calculate and return the virtual offset into our mapping page */

--- a/ntoskrnl/mm/ARM3/mmdbg.c
+++ b/ntoskrnl/mm/ARM3/mmdbg.c
@@ -91,7 +91,7 @@ MiDbgTranslatePhysicalAddress(IN ULONG64 PhysicalAddress,
 
     /* Map the PTE and invalidate its TLB entry */
     *MmDebugPte = TempPte;
-    KeInvalidateTlbEntry(MappingBaseAddress);
+    KxFlushSingleCurrentTb(MappingBaseAddress);
 
     /* Calculate and return the virtual offset into our mapping page */
     return (PVOID)((ULONG_PTR)MappingBaseAddress +
@@ -110,7 +110,7 @@ MiDbgUnTranslatePhysicalAddress(VOID)
 
     /* Clear the mapping PTE and invalidate its TLB entry */
     MmDebugPte->u.Long = 0;
-    KeInvalidateTlbEntry(MappingBaseAddress);
+    KxFlushSingleCurrentTb(MappingBaseAddress);
 }
 
 

--- a/ntoskrnl/mm/ARM3/mminit.c
+++ b/ntoskrnl/mm/ARM3/mminit.c
@@ -597,6 +597,119 @@ MiInitializeColorTables(VOID)
     }
 }
 
+#ifdef _GLOBAL_PAGES_ARE_AWESOME_
+
+CODE_SEG("INIT")
+static
+VOID
+MiInitGlobalPagesForPtes(_Inout_ PMMPTE StartingPte, _Inout_ PMMPTE EndingPte)
+{
+    PMMPTE PointerPte;
+
+    /* Loop the PTEs */
+    for (PointerPte = StartingPte; PointerPte <= EndingPte; PointerPte++)
+    {
+        if (!PointerPte->u.Hard.Valid) continue;
+
+        /* Set the global bit */
+        PointerPte->u.Hard.Global = MiIsGlobalPte(PointerPte);
+    }
+}
+
+CODE_SEG("INIT")
+static
+VOID
+MiInitGlobalPagesForPdes(_Inout_ PMMPDE StartingPde, _Inout_ PMMPDE EndingPde)
+{
+    PMMPDE PointerPde;
+    PMMPTE StartingPte;
+
+    /* Loop the PDEs */
+    for (PointerPde = StartingPde; PointerPde <= EndingPde; PointerPde++)
+    {
+        if (!PointerPde->u.Hard.Valid) continue;
+
+        /* Loop all PTEs for this PDE */
+        StartingPte = (PMMPTE)MiPteToAddress(PointerPde);
+        MiInitGlobalPagesForPtes(StartingPte, StartingPte + PTE_PER_PAGE - 1);
+    }
+}
+
+#if (_MI_PAGING_LEVELS >= 3)
+CODE_SEG("INIT")
+static
+VOID
+MiInitGlobalPagesForPpes(_Inout_ PMMPPE StartingPpe, _Inout_ PMMPPE EndingPpe)
+{
+    PMMPPE PointerPpe;
+    PMMPDE StartingPde;
+
+    /* Loop the PPEs */
+    for (PointerPpe = StartingPpe; PointerPpe <= EndingPpe; PointerPpe++)
+    {
+        if (!PointerPpe->u.Hard.Valid) continue;
+
+        StartingPde = (PMMPDE)MiPteToAddress(PointerPpe);
+        MiInitGlobalPagesForPdes(StartingPde, StartingPde + PDE_PER_PAGE - 1);
+    }
+}
+#endif
+
+#if (_MI_PAGING_LEVELS >= 4)
+CODE_SEG("INIT")
+static
+VOID
+MiInitGlobalPagesForPxes(_Inout_ PMMPXE StartingPxe, _Inout_ PMMPXE EndingPxe)
+{
+    PMMPXE PointerPxe;
+    PMMPPE StartingPpe;
+
+    /* Loop the PXEs */
+    for (PointerPxe = StartingPxe; PointerPxe <= EndingPxe; PointerPxe++)
+    {
+        if (!PointerPxe->u.Hard.Valid) continue;
+
+        StartingPpe = (PMMPPE)MiPteToAddress(PointerPxe);
+        MiInitGlobalPagesForPpes(StartingPpe, StartingPpe + PPE_PER_PAGE - 1);
+    }
+}
+#endif // (_MI_PAGING_LEVELS >= 4)
+
+CODE_SEG("INIT")
+VOID
+MiInitializeGlobalPages(VOID)
+{
+    /* Make sure everything is set up */
+    ASSERT(MmSystemRangeStart != NULL);
+    ASSERT(MmHyperSpaceEnd != NULL);
+    ASSERT(MmSessionBase != NULL);
+    ASSERT(MiSessionSpaceEnd != NULL);
+
+    /* Check for global bit */
+    if (KeFeatureBits & KF_GLOBAL_PAGE)
+    {
+        /* Set it on the template PTE and PDE */
+        ValidKernelPte.u.Hard.Global = TRUE;
+        //ValidKernelPde.u.Hard.Global = TRUE; // FIXME: disabled for now
+    }
+
+#if (_MI_PAGING_LEVELS >= 4)
+    MiInitGlobalPagesForPxes(MiAddressToPxe((PVOID)MI_REAL_SYSTEM_RANGE_START),
+                             MiAddressToPxe(MI_HIGHEST_SYSTEM_ADDRESS));
+#elif (_MI_PAGING_LEVELS >= 3)
+    MiInitGlobalPagesForPpes(MiAddressToPpe(MmSystemRangeStart),
+                             MiAddressToPpe(MI_HIGHEST_SYSTEM_ADDRESS));
+#else
+    MiInitGlobalPagesForPdes(MiAddressToPde(MmSystemRangeStart),
+                             MiAddressToPde(MI_HIGHEST_SYSTEM_ADDRESS));
+#endif
+
+    /* Flush the entire TLB on this processor */
+    KxFlushEntireCurrentTb();
+}
+
+#endif // (_GLOBAL_PAGES_ARE_AWESOME_)
+
 #ifndef _M_AMD64
 CODE_SEG("INIT")
 BOOLEAN

--- a/ntoskrnl/mm/ARM3/mminit.c
+++ b/ntoskrnl/mm/ARM3/mminit.c
@@ -1182,7 +1182,7 @@ MmFreeLoaderBlock(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
     /* Release the PFN lock and flush the TLB */
     DPRINT("Loader pages freed: %lx\n", LoaderPages);
     MiReleasePfnLock(OldIrql);
-    KeFlushCurrentTb();
+    KeFlushEntireTb(TRUE, TRUE);
 
     /* Free our run structure */
     ExFreePoolWithTag(Buffer, 'lMmM');

--- a/ntoskrnl/mm/ARM3/section.c
+++ b/ntoskrnl/mm/ARM3/section.c
@@ -1890,7 +1890,7 @@ MiFlushTbAndCapture(IN PMMVAD FoundVad,
     // Flush the TLB
     //
     ASSERT(PreviousPte.u.Hard.Valid == 1);
-    KeFlushCurrentTb();
+    KeFlushEntireTb(TRUE, TRUE);
     ASSERT(PreviousPte.u.Hard.Valid == 1);
 
     //
@@ -2004,7 +2004,7 @@ MiRemoveMappedPtes(IN PVOID BaseAddress,
     }
 
     /* Flush the TLB */
-    KeFlushCurrentTb();
+    KeFlushEntireTb(TRUE, TRUE);
 
     /* Acquire the PFN lock */
     OldIrql = MiAcquirePfnLock();

--- a/ntoskrnl/mm/ARM3/sysldr.c
+++ b/ntoskrnl/mm/ARM3/sysldr.c
@@ -2353,7 +2353,7 @@ MmChangeKernelResourceSectionProtection(IN ULONG_PTR ProtectionMask)
     }
 
     /* Only flush the current processor's TLB */
-    KeFlushCurrentTb();
+    KxFlushEntireCurrentTb();
     return TRUE;
 }
 
@@ -2913,7 +2913,7 @@ LdrpInitSecurityCookie(PLDR_DATA_TABLE_ENTRY LdrEntry)
 
     if (!Cookie)
         return NULL;
-    
+
     /* Check if it's a default one */
     if ((*Cookie == DEFAULT_SECURITY_COOKIE) ||
         (*Cookie == 0))
@@ -2938,7 +2938,7 @@ LdrpInitSecurityCookie(PLDR_DATA_TABLE_ENTRY LdrEntry)
         }
 
         /* Set the new cookie value */
-        *Cookie = NewCookie; 
+        *Cookie = NewCookie;
     }
 
     return Cookie;

--- a/ntoskrnl/mm/ARM3/syspte.c
+++ b/ntoskrnl/mm/ARM3/syspte.c
@@ -233,7 +233,7 @@ MiReserveAlignedSystemPtes(IN ULONG NumberOfPtes,
     //
     // Flush the TLB
     //
-    KeFlushProcessTb();
+    KeFlushEntireTb(TRUE, TRUE);
 
     //
     // Return the reserved PTEs
@@ -280,6 +280,11 @@ MiReleaseSystemPtes(IN PMMPTE StartingPte,
     // Zero PTEs
     //
     RtlZeroMemory(StartingPte, NumberOfPtes * sizeof(MMPTE));
+
+    //
+    // Flush the TLB
+    //
+    KeFlushRangeTb(StartingPte, NumberOfPtes, TRUE);
 
     //
     // Acquire the System PTE lock

--- a/ntoskrnl/mm/ARM3/virtual.c
+++ b/ntoskrnl/mm/ARM3/virtual.c
@@ -522,7 +522,7 @@ MiDeletePte(IN PMMPTE PointerPte,
     }
 
     /* Flush the TLB */
-    KeFlushCurrentTb();
+    KeFlushEntireTb(TRUE, TRUE);
 }
 
 VOID
@@ -2421,11 +2421,11 @@ MiProtectVirtualMemory(IN PEPROCESS Process,
                     MiDecrementShareCount(Pfn1, PFN_FROM_PTE(&PteContents));
                     // FIXME: remove the page from the WS
                     MI_WRITE_INVALID_PTE(PointerPte, PteContents);
-#ifdef CONFIG_SMP
-                    // FIXME: Should invalidate entry in every CPU TLB
-                    ASSERT(KeNumberProcessors == 1);
+
+#ifndef CONFIG_SMP
+                    /* Invalidate the TLB entry. On SMP we flush the process TLB below */
+                    KxFlushSingleCurrentTb(MiPteToAddress(PointerPte));
 #endif
-                    KeInvalidateTlbEntry(MiPteToAddress(PointerPte));
 
                     /* We are done for this PTE */
                     MiReleasePfnLock(OldIrql);
@@ -2456,6 +2456,12 @@ MiProtectVirtualMemory(IN PEPROCESS Process,
             /* Move to the next PTE */
             PointerPte++;
         }
+
+#ifdef CONFIG_SMP
+        KeFlushRangeTb((PVOID)StartingAddress,
+                       (EndingAddress + 1 - StartingAddress) / PAGE_SIZE,
+                       FALSE);
+#endif
 
         /* Unlock the working set */
         MiUnlockProcessWorkingSetUnsafe(Process, Thread);
@@ -2618,7 +2624,7 @@ MiProcessValidPteList(IN PMMPTE *ValidPteList,
     // All the PTEs have been dereferenced and made invalid, flush the TLB now
     // and then release the PFN lock
     //
-    KeFlushCurrentTb();
+    KeFlushEntireTb(TRUE, TRUE);
     MiReleasePfnLock(OldIrql);
 }
 

--- a/ntoskrnl/mm/ARM3/wslist.cpp
+++ b/ntoskrnl/mm/ARM3/wslist.cpp
@@ -94,7 +94,8 @@ static void FreeWsleIndex(PMMWSL WsList, ULONG Index)
 
             PointerPte->u.Long = 0;
 
-            KeInvalidateTlbEntry(Wsle + LastInitializedWsle - 1);
+            /* Flush the TLB entry */
+            KeFlushSingleTb(Wsle + LastInitializedWsle - 1, FALSE);
             LastInitializedWsle -= PAGE_SIZE / sizeof(MMWSLE);
         }
         return;
@@ -245,7 +246,7 @@ TrimWsList(PMMWSL WsList)
         {
             Entry.u1.e1.Age = 0;
             PointerPte->u.Hard.Accessed = 0;
-            KeInvalidateTlbEntry(Entry.u1.VirtualAddress);
+            KeFlushSingleTb(Entry.u1.VirtualAddress, FALSE);
             continue;
         }
 
@@ -293,7 +294,7 @@ TrimWsList(PMMWSL WsList)
 
             /* Make this a transition PTE */
             MI_MAKE_TRANSITION_PTE(PointerPte, Page, Protection);
-            KeInvalidateTlbEntry(MiAddressToPte(PointerPte));
+            KeFlushSingleTb(MiAddressToPte(PointerPte), FALSE);
 
             /* Drop the share count. This will take care of putting it in the standby or modified list. */
             MiDecrementShareCount(Pfn, Page);

--- a/ntoskrnl/mm/ARM3/zeropage.c
+++ b/ntoskrnl/mm/ARM3/zeropage.c
@@ -18,6 +18,7 @@
 /* GLOBALS ********************************************************************/
 
 KEVENT MmZeroingPageEvent;
+PKTHREAD MiZeroPageThread;
 
 /* PRIVATE FUNCTIONS **********************************************************/
 
@@ -38,6 +39,9 @@ MmZeroPageThread(VOID)
     PKTHREAD Thread = KeGetCurrentThread();
     PVOID StartAddress, EndAddress;
     PVOID WaitObjects[2];
+
+    ASSERT(MiZeroPageThread == NULL);
+    MiZeroPageThread = Thread;
 
     /* Get the discardable sections to free them */
     MiFindInitializationCode(&StartAddress, &EndAddress);

--- a/ntoskrnl/mm/amd64/init.c
+++ b/ntoskrnl/mm/amd64/init.c
@@ -224,8 +224,8 @@ MiInitializePageTable(VOID)
         PointerPxe->u.Long = 0;
     }
 
-    /* Flush the TLB */
-    KeFlushCurrentTb();
+    /* Flush the TLB on this processor */
+    KxFlushEntireCurrentTb();
 
     /* Set up a template PTE */
     TmplPte.u.Long = 0;

--- a/ntoskrnl/mm/amd64/init.c
+++ b/ntoskrnl/mm/amd64/init.c
@@ -176,6 +176,10 @@ MiMapPTEs(
     PMMPTE PointerPte;
     MMPTE TmplPte = ValidKernelPte;
 
+#ifdef _GLOBAL_PAGES_ARE_AWESOME_
+    TmplPte.u.Hard.Global = MiIsGlobalPte(MiAddressToPte(StartAddress));
+#endif
+
     /* Loop the PTEs */
     for (PointerPte = MiAddressToPte(StartAddress);
          PointerPte <= MiAddressToPte(EndAddress);
@@ -707,6 +711,9 @@ MiInitMachineDependent(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
     MmPfnDatabase = (PVOID)MI_PFN_DATABASE;
     MmWorkingSetList = (PVOID)MI_WORKING_SET_LIST;
 
+#ifdef _GLOBAL_PAGES_ARE_AWESOME_
+    MiInitializeGlobalPages();
+#endif
 
 //    PrototypePte.u.Proto.Valid = 1
 //    PrototypePte.u.ReadOnly

--- a/ntoskrnl/mm/amd64/procsup.c
+++ b/ntoskrnl/mm/amd64/procsup.c
@@ -85,7 +85,7 @@ MiArchCreateProcessAddressSpace(
     ASSERT(MiAddressToPxi(MmHyperSpaceEnd) >= TableIndex);
 
     /* Setup a PTE for the page directory mappings */
-    TempPte = ValidKernelPte;
+    TempPte = ValidKernelPteLocal;
 
     /* Update the self mapping of the PML4 */
     TableIndex = MiAddressToPxi((PVOID)PXE_SELFMAP);

--- a/ntoskrnl/mm/i386/page.c
+++ b/ntoskrnl/mm/i386/page.c
@@ -293,7 +293,8 @@ MmDeleteVirtualMappingEx(
         PointerPte = MiAddressToPte(Address);
         OldPte.u.Long = InterlockedExchangePte(PointerPte, 0);
 
-        KeInvalidateTlbEntry(Address);
+        /* Flush the TLB entry for this process */
+        KeFlushSingleTb(Address, FALSE);
 
         if (OldPte.u.Long != 0)
         {
@@ -880,7 +881,7 @@ MmSetPageProtect(PEPROCESS Process, PVOID Address, ULONG flProtect)
     }
 
     if (OldPte.u.Long != TempPte.u.Long)
-        KeInvalidateTlbEntry(Address);
+        KeFlushSingleTb(Address, FALSE);
 
     MiUnlockProcessWorkingSetUnsafe(Process, PsGetCurrentThread());
 }
@@ -914,7 +915,7 @@ MmSetDirtyBit(PEPROCESS Process, PVOID Address, BOOLEAN Bit)
     PointerPte->u.Hard.Dirty = !!Bit;
 
     if (!Bit)
-        KeInvalidateTlbEntry(Address);
+        KeFlushSingleTb(Address, FALSE);
 
     MiUnlockProcessWorkingSetUnsafe(Process, PsGetCurrentThread());
 }

--- a/ntoskrnl/mm/mminit.c
+++ b/ntoskrnl/mm/mminit.c
@@ -206,9 +206,8 @@ NTAPI
 MmInitSystem(IN ULONG Phase,
              IN PLOADER_PARAMETER_BLOCK LoaderBlock)
 {
-    extern MMPTE ValidKernelPte;
     PMMPTE PointerPte;
-    MMPTE TempPte = ValidKernelPte;
+    MMPTE TempPte;
     PFN_NUMBER PageFrameNumber;
     PLIST_ENTRY ListEntry;
     PLDR_DATA_TABLE_ENTRY DataTableEntry;

--- a/ntoskrnl/ntos.cmake
+++ b/ntoskrnl/ntos.cmake
@@ -196,6 +196,7 @@ list(APPEND SOURCE
     ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/thrdschd.c
     ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/time.c
     ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/timerobj.c
+    ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/tlbflush.c
     ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/wait.c
     ${REACTOS_SOURCE_DIR}/ntoskrnl/lpc/close.c
     ${REACTOS_SOURCE_DIR}/ntoskrnl/lpc/complete.c

--- a/sdk/include/ndk/kefuncs.h
+++ b/sdk/include/ndk/kefuncs.h
@@ -146,12 +146,6 @@ KeSetAffinityThread(
     _In_ KAFFINITY Affinity
 );
 
-PKPROCESS
-NTAPI
-KeGetCurrentProcess(
-    VOID
-);
-
 BOOLEAN
 NTAPI
 KeAddSystemServiceTable(


### PR DESCRIPTION
## Purpose

This PR implements support for global pages (kernel pages that are not flushed out of the TLB on a process switch).

## Proposed changes

- [NDK][NTOS] Implement inline KeGetCurrentProcess
- [NTOS:KE/x64] Make sure that KPROCESS::ActiveProcessors is set correctly
- [NTOS:KE] Implement KiIpiSendRequest stub (later used for SMP TLB shootdown)
- [NTOS::KE] Rewrite TLB flushing (to support SMP and global pages)
- [NTOS:MM] Implement support for global pages

## TODO (not addressed in this PR)
- Make PDEs global
- Optimize global VA state lookup with a bitmap

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=101663,101673,101688,101685
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=101675,101689,101695,101686