### PR TITLE
[SHELL32] Remove FIXME for CORE-19477

### DIFF
--- a/dll/win32/shell32/shellmenu/CStartMenu.cpp
+++ b/dll/win32/shell32/shellmenu/CStartMenu.cpp
@@ -371,9 +371,6 @@ private:
 
         TRACE("csidl: 0x%X\n", csidl);
 
-        if (csidl == CSIDL_CONTROLS || csidl == CSIDL_NETWORK || csidl == CSIDL_PRINTERS)
-            FIXME("This CSIDL %d wrongly opens My Computer. CORE-19477\n", csidl);
-
         CComHeapPtr<ITEMIDLIST> pidl;
         SHGetSpecialFolderLocation(NULL, csidl, &pidl);
 


### PR DESCRIPTION
## Purpose

This PR removes a debug message for an issue ([CORE-19477](https://jira.reactos.org/browse/CORE-19477)) already fixed previously

JIRA issue: [CORE-20151](https://jira.reactos.org/browse/CORE-20151)

## Proposed changes

## TODO

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: