### PR TITLE
[WINESYNC][COMCTL32] Move caret to the end on "select all"

### DIFF
--- a/dll/win32/comctl32/edit.c
+++ b/dll/win32/comctl32/edit.c
@@ -3469,6 +3469,7 @@ static LRESULT EDIT_WM_KeyDown(EDITSTATE *es, INT key)
                 {
                     if (!notify_parent(es, EN_UPDATE)) break;
                     notify_parent(es, EN_CHANGE);
+					EDIT_EM_ScrollCaret(es);
                 }
             }
             break;

--- a/dll/win32/comctl32/edit.c
+++ b/dll/win32/comctl32/edit.c
@@ -3469,7 +3469,9 @@ static LRESULT EDIT_WM_KeyDown(EDITSTATE *es, INT key)
                 {
                     if (!notify_parent(es, EN_UPDATE)) break;
                     notify_parent(es, EN_CHANGE);
+#ifdef __REACTOS__
 					EDIT_EM_ScrollCaret(es);
+#endif
                 }
             }
             break;


### PR DESCRIPTION
## Purpose

This PR imports an one-line fix from WINE project

Commit: [e71087cd@gitlab.winehq.org:wine/wine](https://gitlab.winehq.org/wine/wine/-/commit/e71087cd39fdc546846f1f74f2e701596bcfd18d)

JIRA issue: [CORE-19903](https://jira.reactos.org/browse/CORE-19903)

## Proposed changes

## TODO

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: