### PR TITLE
[COMCTL32] [WINESYNC] Fix large height for ComboBox when CBS_NOINTEGRALHEIGHT is specified

### DIFF
--- a/dll/win32/comctl32/combo.c
+++ b/dll/win32/comctl32/combo.c
@@ -977,7 +977,7 @@ static void CBDropDown( LPHEADCOMBO lphc )
 
         if (lphc->dwStyle & CBS_NOINTEGRALHEIGHT)
         {
-            nDroppedHeight -= 1;
+            nDroppedHeight = min(nItems * nIHeight + COMBO_YBORDERSIZE(), nDroppedHeight - 1);
         }
         else
         {


### PR DESCRIPTION
## Purpose

This PR imports a fix from WINE project

JIRA issue: [CORE-19833](https://jira.reactos.org/browse/CORE-19833)

## Proposed changes

## TODO

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: