### PR TITLE
[WINESYNC][COMCTL32] Fix: deleting system font object when destroying syslink

### DIFF
--- a/dll/win32/comctl32/syslink.c
+++ b/dll/win32/comctl32/syslink.c
@@ -1719,6 +1719,9 @@ static LRESULT WINAPI SysLinkWindowProc(HWND hwnd, UINT message,
     case WM_DESTROY:
         TRACE("SysLink Ctrl destruction, hwnd=%p\n", hwnd);
         SYSLINK_ClearDoc(infoPtr);
+#ifndef __REACTOS__ 
+        if(infoPtr->Font != 0) DeleteObject(infoPtr->Font); 
+#endif
         if(infoPtr->LinkFont != 0) DeleteObject(infoPtr->LinkFont);
         SetWindowLongPtrW(hwnd, 0, 0);
         Free (infoPtr);

--- a/dll/win32/comctl32/syslink.c
+++ b/dll/win32/comctl32/syslink.c
@@ -1719,8 +1719,8 @@ static LRESULT WINAPI SysLinkWindowProc(HWND hwnd, UINT message,
     case WM_DESTROY:
         TRACE("SysLink Ctrl destruction, hwnd=%p\n", hwnd);
         SYSLINK_ClearDoc(infoPtr);
-#ifndef __REACTOS__ 
-        if(infoPtr->Font != 0) DeleteObject(infoPtr->Font); 
+#ifndef __REACTOS__
+        if(infoPtr->Font != 0) DeleteObject(infoPtr->Font);
 #endif
         if(infoPtr->LinkFont != 0) DeleteObject(infoPtr->LinkFont);
         SetWindowLongPtrW(hwnd, 0, 0);

--- a/dll/win32/comctl32/syslink.c
+++ b/dll/win32/comctl32/syslink.c
@@ -1719,7 +1719,6 @@ static LRESULT WINAPI SysLinkWindowProc(HWND hwnd, UINT message,
     case WM_DESTROY:
         TRACE("SysLink Ctrl destruction, hwnd=%p\n", hwnd);
         SYSLINK_ClearDoc(infoPtr);
-        if(infoPtr->Font != 0) DeleteObject(infoPtr->Font);
         if(infoPtr->LinkFont != 0) DeleteObject(infoPtr->LinkFont);
         SetWindowLongPtrW(hwnd, 0, 0);
         Free (infoPtr);


### PR DESCRIPTION
## Purpose

This PR imports a fix from WINE project

Commit: [4805986](https://github.com/wine-mirror/wine/commit/480598680ceb86661bd269b7a64bd90e38a40f98) on wine-mirror/wine

JIRA issue: [CORE-20127](https://jira.reactos.org/browse/CORE-20127)

## Proposed changes

The font object `infoPtr->Font` is not owned by the `syslink` control, therefore freeing it would make the whole system use a different font. The fix provided by wine removes the code that deletes this font object but I think we need a check in `DeleteObject` routine to prevent a random app from deleting objects used by the system.

## TODO

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: