### PR TITLE
[WINESYNC][COMCTL32] Fix Exception in PROPSHEET_DoCommand

### DIFF
--- a/dll/win32/comctl32/propsheet.c
+++ b/dll/win32/comctl32/propsheet.c
@@ -3255,7 +3255,9 @@ static BOOL PROPSHEET_DoCommand(HWND hwnd, WORD wID)
 		{
                     PropSheetInfo* psInfo = GetPropW(hwnd, PropSheetInfoStr);
 
+#ifdef __REACTOS__
                     if (psInfo == NULL) break;
+#endif
 
                     /* don't overwrite ID_PSRESTARTWINDOWS or ID_PSREBOOTSYSTEM */
                     if (psInfo->result == 0)


### PR DESCRIPTION
## Purpose

This fixes the exception in PROPSHEET_DoCommand by importing the patch from Wine https://gitlab.winehq.org/wine/wine/-/commit/affd5177bba907a015d1c6fc8ac9970731125268

JIRA issue: [CORE-20036](https://jira.reactos.org/browse/CORE-20036)

## Proposed changes

Import the fix proposed in the jira issue into the code

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: