### PR TITLE
[SHELL32] Don't pass menu band hwnd to InvokeCommand

### DIFF
--- a/dll/win32/shell32/shellmenu/CMenuBand.cpp
+++ b/dll/win32/shell32/shellmenu/CMenuBand.cpp
@@ -861,7 +861,8 @@ HRESULT CMenuBand::_TrackContextMenu(IContextMenu * contextMenu, INT x, INT y)
         _MenuItemSelect(MPOS_FULLCANCEL);
 
         TRACE("Before InvokeCommand\n");
-        CMINVOKECOMMANDINFO cmi = { sizeof(cmi), 0, hwnd };
+        // Note: Not passing hwnd to InvokeCommand because it can be a BaseBar window that is about to die
+        CMINVOKECOMMANDINFO cmi = { sizeof(cmi), 0, NULL };
         cmi.lpVerb = MAKEINTRESOURCEA(uCommand - idCmdFirst);
         if (GetKeyState(VK_SHIFT) < 0)
             cmi.fMask |= CMIC_MASK_SHIFT_DOWN;


### PR DESCRIPTION
The menu band window is about to go away, don't pass it to InvokeCommand because it's invalid as an owner window for any dialogs the callee might display.

To reproduce the bug:

1. Create a .txt or .bmp file in My Documents
2. Change the Start Menu settings to expand My Documents
3. Open Start Menu=>Documents=>My Documents and right-click the file and invoke "Open With".
4. `SHOpenWithDialog` dies immediately because the owner window has now been destroyed.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: