### PR TITLE
[EXPLORER][SHELL32][SHELL32_APITEST][SDK] AppBar Part 2

### DIFF
--- a/base/shell/explorer/appbar.cpp
+++ b/base/shell/explorer/appbar.cpp
@@ -130,7 +130,7 @@ void CAppBarManager::OnAppBarQueryPos(_Inout_ PAPPBAR_COMMAND pData)
         return;
     }
 
-    PAPPBARDATA3264 pOutput = AppBar_LockOutput(pData);
+    PAPPBARDATAINTEROP pOutput = AppBar_LockOutput(pData);
     if (!pOutput)
     {
         ERR("!pOutput: %d\n", pData->dwProcessId);
@@ -187,7 +187,7 @@ void CAppBarManager::OnAppBarSetPos(_Inout_ PAPPBAR_COMMAND pData)
 
     OnAppBarQueryPos(pData);
 
-    PAPPBARDATA3264 pOutput = AppBar_LockOutput(pData);
+    PAPPBARDATAINTEROP pOutput = AppBar_LockOutput(pData);
     if (!pOutput)
         return;
 

--- a/base/shell/explorer/appbar.h
+++ b/base/shell/explorer/appbar.h
@@ -15,14 +15,14 @@ typedef struct tagAPPBAR
     RECT rc;
 } APPBAR, *PAPPBAR;
 
-static inline PAPPBARDATA3264
+static inline PAPPBARDATAINTEROP
 AppBar_LockOutput(_In_ PAPPBAR_COMMAND pData)
 {
-    return (PAPPBARDATA3264)SHLockShared(UlongToHandle(pData->hOutput32), pData->dwProcessId);
+    return (PAPPBARDATAINTEROP)SHLockShared(UlongToHandle(pData->hOutput32), pData->dwProcessId);
 }
 
 static inline VOID
-AppBar_UnLockOutput(_Out_ PAPPBARDATA3264 pOutput)
+AppBar_UnLockOutput(_Out_ PAPPBARDATAINTEROP pOutput)
 {
     SHUnlockShared(pOutput);
 }

--- a/base/shell/explorer/appbar.h
+++ b/base/shell/explorer/appbar.h
@@ -77,6 +77,7 @@ protected:
         _In_ const RECT *prcTray,
         _In_ HMONITOR hMonitor,
         _Out_ PRECT prcWorkArea);
+    void RecomputeAllWorkareas();
 
     void StuckAppChange(
         _In_opt_ HWND hwndTarget,
@@ -93,4 +94,11 @@ protected:
     virtual INT GetPosition() const = 0;
     virtual const RECT* GetTrayRect() = 0;
     virtual HWND GetDesktopWnd() const = 0;
+
+    static BOOL CALLBACK
+    MonitorEnumProc(
+        _In_ HMONITOR hMonitor,
+        _In_ HDC hDC,
+        _In_ LPRECT prc,
+        _Inout_ LPARAM lParam);
 };

--- a/base/shell/explorer/appbar.h
+++ b/base/shell/explorer/appbar.h
@@ -18,7 +18,7 @@ typedef struct tagAPPBAR
 static inline PAPPBARDATAINTEROP
 AppBar_LockOutput(_In_ PAPPBAR_COMMAND pData)
 {
-    return (PAPPBARDATAINTEROP)SHLockShared(UlongToHandle(pData->hOutput32), pData->dwProcessId);
+    return (PAPPBARDATAINTEROP)SHLockShared((HANDLE)pData->hOutput, pData->dwProcessId);
 }
 
 static inline VOID

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -2492,6 +2492,9 @@ ChangePos:
 
     LRESULT OnDisplayChange(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
     {
+        /* Refresh workareas */
+        RecomputeAllWorkareas();
+
         /* Load the saved tray window settings */
         RegLoadSettings();
 

--- a/dll/win32/shell32/appbar.c
+++ b/dll/win32/shell32/appbar.c
@@ -85,7 +85,7 @@ SHAppBarMessage(
     cmd.abd.rc = pData->rc;
     cmd.abd.lParam64 = pData->lParam;
     cmd.dwMessage = dwMessage;
-    cmd.hOutput32 = 0;
+    cmd.hOutput = (APPBAR_HANDLE)NULL;
     cmd.dwProcessId = GetCurrentProcessId();
 
     /* Make output data if necessary */
@@ -94,9 +94,8 @@ SHAppBarMessage(
         case ABM_QUERYPOS:
         case ABM_SETPOS:
         case ABM_GETTASKBARPOS:
-            cmd.hOutput32 = HandleToUlong(AppBar_CopyIn(&cmd.abd, sizeof(cmd.abd),
-                                          cmd.dwProcessId));
-            if (!cmd.hOutput32)
+            cmd.hOutput = (APPBAR_HANDLE)AppBar_CopyIn(&cmd.abd, sizeof(cmd.abd), cmd.dwProcessId);
+            if (!cmd.hOutput)
             {
                 ERR("AppBar_CopyIn: %d\n", dwMessage);
                 return FALSE;
@@ -111,10 +110,9 @@ SHAppBarMessage(
     UINT_PTR ret = SendMessageW(hTrayWnd, WM_COPYDATA, (WPARAM)pData->hWnd, (LPARAM)&copyData);
 
     /* Copy back output data */
-    if (cmd.hOutput32)
+    if (cmd.hOutput)
     {
-        HANDLE hOutput = UlongToHandle(cmd.hOutput32);
-        if (!AppBar_CopyOut(hOutput, &cmd.abd, sizeof(cmd.abd), cmd.dwProcessId))
+        if (!AppBar_CopyOut((HANDLE)cmd.hOutput, &cmd.abd, sizeof(cmd.abd), cmd.dwProcessId))
         {
             ERR("AppBar_CopyOut: %d\n", dwMessage);
             return FALSE;

--- a/dll/win32/shell32/appbar.c
+++ b/dll/win32/shell32/appbar.c
@@ -85,7 +85,7 @@ SHAppBarMessage(
     cmd.abd.rc = pData->rc;
     cmd.abd.lParam64 = pData->lParam;
     cmd.dwMessage = dwMessage;
-    cmd.hOutput = (APPBAR_HANDLE)NULL;
+    cmd.hOutput = (APPBAR_OUTPUT)NULL;
     cmd.dwProcessId = GetCurrentProcessId();
 
     /* Make output data if necessary */
@@ -94,7 +94,7 @@ SHAppBarMessage(
         case ABM_QUERYPOS:
         case ABM_SETPOS:
         case ABM_GETTASKBARPOS:
-            cmd.hOutput = (APPBAR_HANDLE)AppBar_CopyIn(&cmd.abd, sizeof(cmd.abd), cmd.dwProcessId);
+            cmd.hOutput = (APPBAR_OUTPUT)AppBar_CopyIn(&cmd.abd, sizeof(cmd.abd), cmd.dwProcessId);
             if (!cmd.hOutput)
             {
                 ERR("AppBar_CopyIn: %d\n", dwMessage);

--- a/modules/rostests/apitests/shell32/SHAppBarMessage.cpp
+++ b/modules/rostests/apitests/shell32/SHAppBarMessage.cpp
@@ -1138,7 +1138,7 @@ START_TEST(SHAppBarMessage)
     }
 
     SystemParametersInfo(SPI_GETWORKAREA, 0, &s_rcWorkArea, FALSE);
-    trace("s_rcWorkArea: %d, %d, %d, %d\n",
+    trace("s_rcWorkArea: %ld, %ld, %ld, %ld\n",
           s_rcWorkArea.left, s_rcWorkArea.top, s_rcWorkArea.right, s_rcWorkArea.bottom);
 
     HWND hwnd1 = Window::DoCreateMainWnd(hInstance, TEXT("Test1"), 80, 80,

--- a/modules/rostests/apitests/shell32/SHAppBarMessage.cpp
+++ b/modules/rostests/apitests/shell32/SHAppBarMessage.cpp
@@ -10,9 +10,6 @@
 #include <shlwapi.h>
 #include <stdio.h>
 
-#define NDEBUG
-#include <debug.h>
-
 /* Based on https://github.com/katahiromz/AppBarSample */
 
 //#define VERBOSE
@@ -469,9 +466,6 @@ protected:
             case ABE_RIGHT:
                 rc.left = rc.right - m_cxWidth;
                 break;
-            default:
-                ASSERT(FALSE);
-                break;
         }
 
         APPBARDATA abd = { sizeof(abd) };
@@ -688,7 +682,7 @@ protected:
         AppBar_Register(hwnd);
         AppBar_SetSide(hwnd, ABE_TOP);
 
-        DPRINT1("OnCreate(%p) done\n", hwnd);
+        trace("OnCreate(%p) done\n", hwnd);
         return TRUE;
     }
 
@@ -984,7 +978,7 @@ public:
         RECT rc1, rc2, rcWork;
         DWORD dwTID = GetWindowThreadProcessId(s_hwnd1, NULL);
 
-        DPRINT1("DoAction\n");
+        trace("DoAction\n");
         Sleep(INTERVAL);
 
         GetWindowRect(s_hwnd1, &rc1);
@@ -1136,7 +1130,7 @@ START_TEST(SHAppBarMessage)
         return;
     }
 
-    DPRINT1("SM_CMONITORS: %d\n", GetSystemMetrics(SM_CMONITORS));
+    trace("SM_CMONITORS: %d\n", GetSystemMetrics(SM_CMONITORS));
     if (GetSystemMetrics(SM_CMONITORS) != 1)
     {
         skip("Multi-monitor not supported yet\n");
@@ -1144,8 +1138,8 @@ START_TEST(SHAppBarMessage)
     }
 
     SystemParametersInfo(SPI_GETWORKAREA, 0, &s_rcWorkArea, FALSE);
-    DPRINT1("s_rcWorkArea: %d, %d, %d, %d\n",
-            s_rcWorkArea.left, s_rcWorkArea.top, s_rcWorkArea.right, s_rcWorkArea.bottom);
+    trace("s_rcWorkArea: %d, %d, %d, %d\n",
+          s_rcWorkArea.left, s_rcWorkArea.top, s_rcWorkArea.right, s_rcWorkArea.bottom);
 
     HWND hwnd1 = Window::DoCreateMainWnd(hInstance, TEXT("Test1"), 80, 80,
                                          WS_POPUP | WS_THICKFRAME | WS_CLIPCHILDREN);

--- a/sdk/include/reactos/undocshell.h
+++ b/sdk/include/reactos/undocshell.h
@@ -1227,20 +1227,22 @@ typedef struct SFVM_CUSTOMVIEWINFO_DATA
  * These structures can be sent from 32-bit shell32 to 64-bit Explorer.
  * See also: https://learn.microsoft.com/en-us/windows/win32/winprog64/interprocess-communication
  * > ... only the lower 32 bits are significant, so it is safe to truncate the handle
+ * See also: https://learn.microsoft.com/en-us/windows/win32/api/handleapi/nf-handleapi-duplicatehandle
+ * > DuplicateHandle can be used to duplicate a handle between a 32-bit process and a 64-bit process.
  */
 #include <pshpack8.h>
-typedef struct tagAPPBARDATA3264
+typedef struct tagAPPBARDATAINTEROP
 {
-    DWORD cbSize; /* == sizeof(APPBARDATA3264) */
+    DWORD cbSize; /* == sizeof(APPBARDATAINTEROP) */
     UINT32 hWnd32;
     UINT uCallbackMessage;
     UINT uEdge;
     RECT rc;
     LONGLONG lParam64;
-} APPBARDATA3264, *PAPPBARDATA3264;
+} APPBARDATAINTEROP, *PAPPBARDATAINTEROP;
 typedef struct tagAPPBAR_COMMAND
 {
-    APPBARDATA3264 abd;
+    APPBARDATAINTEROP abd;
     DWORD dwMessage;
     UINT32 hOutput32; /* For shlwapi!SHAllocShared */
     DWORD dwProcessId;

--- a/sdk/include/reactos/undocshell.h
+++ b/sdk/include/reactos/undocshell.h
@@ -1222,6 +1222,12 @@ typedef struct SFVM_CUSTOMVIEWINFO_DATA
 
 #include <poppack.h>
 
+#if defined(_WIN64) || defined(BUILD_WOW64_ENABLED)
+    typedef UINT_PTR APPBAR_HANDLE;
+#else
+    typedef HANDLE APPBAR_HANDLE;
+#endif
+
 /*
  * Private structures for internal AppBar messaging.
  * These structures can be sent from 32-bit shell32 to 64-bit Explorer.
@@ -1244,12 +1250,16 @@ typedef struct tagAPPBAR_COMMAND
 {
     APPBARDATAINTEROP abd;
     DWORD dwMessage;
-    UINT32 hOutput32; /* For shlwapi!SHAllocShared */
+    APPBAR_HANDLE hOutput; /* For shlwapi!SHAllocShared */
     DWORD dwProcessId;
 } APPBAR_COMMAND, *PAPPBAR_COMMAND;
 #include <poppack.h>
 
+#ifdef _WIN64
+C_ASSERT(sizeof(APPBAR_COMMAND) == 0x40);
+#else
 C_ASSERT(sizeof(APPBAR_COMMAND) == 0x38);
+#endif
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/sdk/include/reactos/undocshell.h
+++ b/sdk/include/reactos/undocshell.h
@@ -1223,7 +1223,7 @@ typedef struct SFVM_CUSTOMVIEWINFO_DATA
 #include <poppack.h>
 
 #if defined(_WIN64) || defined(BUILD_WOW6432)
-    typedef UINT_PTR APPBAR_OUTPUT;
+    typedef UINT64 APPBAR_OUTPUT;
 #else
     typedef HANDLE APPBAR_OUTPUT;
 #endif

--- a/sdk/include/reactos/undocshell.h
+++ b/sdk/include/reactos/undocshell.h
@@ -1222,7 +1222,7 @@ typedef struct SFVM_CUSTOMVIEWINFO_DATA
 
 #include <poppack.h>
 
-#if defined(_WIN64) || defined(BUILD_WOW64_ENABLED)
+#if defined(_WIN64) || defined(BUILD_WOW6432)
     typedef UINT_PTR APPBAR_OUTPUT;
 #else
     typedef HANDLE APPBAR_OUTPUT;

--- a/sdk/include/reactos/undocshell.h
+++ b/sdk/include/reactos/undocshell.h
@@ -1223,9 +1223,9 @@ typedef struct SFVM_CUSTOMVIEWINFO_DATA
 #include <poppack.h>
 
 #if defined(_WIN64) || defined(BUILD_WOW64_ENABLED)
-    typedef UINT_PTR APPBAR_HANDLE;
+    typedef UINT_PTR APPBAR_OUTPUT;
 #else
-    typedef HANDLE APPBAR_HANDLE;
+    typedef HANDLE APPBAR_OUTPUT;
 #endif
 
 /*
@@ -1250,7 +1250,7 @@ typedef struct tagAPPBAR_COMMAND
 {
     APPBARDATAINTEROP abd;
     DWORD dwMessage;
-    APPBAR_HANDLE hOutput; /* For shlwapi!SHAllocShared */
+    APPBAR_OUTPUT hOutput; /* For shlwapi!SHAllocShared */
     DWORD dwProcessId;
 } APPBAR_COMMAND, *PAPPBAR_COMMAND;
 #include <poppack.h>

--- a/sdk/include/reactos/undocshell.h
+++ b/sdk/include/reactos/undocshell.h
@@ -1255,7 +1255,7 @@ typedef struct tagAPPBAR_COMMAND
 } APPBAR_COMMAND, *PAPPBAR_COMMAND;
 #include <poppack.h>
 
-#ifdef _WIN64
+#if defined(_WIN64) || defined(BUILD_WOW6432)
 C_ASSERT(sizeof(APPBAR_COMMAND) == 0x40);
 #else
 C_ASSERT(sizeof(APPBAR_COMMAND) == 0x38);


### PR DESCRIPTION
## Purpose

Follow-up of #7778.
JIRA issue: [CORE-7237](https://jira.reactos.org/browse/CORE-7237)

## Proposed changes

- Rename `APPBARDATA3264` structure as `APPBARDATAINTEROP`.
- Fix structures for WoW64.
- Use `trace` instead of `DPRINT1`.
- Add `CAppBarManager::RecomputeAllWorkareas` function.
- Fix `WM_DISPLAYCHANGE` handling to re-compute the work areas.

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=101747,101866
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=101754,101868