### PR TITLE
[SHELL32][NTUSER] Implement the SEE_MASK_HOTKEY/ICON/HMONITOR flags

### DIFF
--- a/dll/win32/shell32/CShellLink.cpp
+++ b/dll/win32/shell32/CShellLink.cpp
@@ -2687,6 +2687,14 @@ HRESULT CShellLink::DoOpen(LPCMINVOKECOMMANDINFO lpici)
         else if (pszDirA && SHAnsiToUnicode(pszDirA, dir, _countof(dir)))
             sei.lpDirectory = dir;
     }
+
+    sei.dwHotKey = lpici->dwHotKey;
+    sei.fMask |= CmicFlagsToSeeFlags(lpici->fMask & CMIC_MASK_HOTKEY);
+    if ((!(sei.fMask & SEE_MASK_HOTKEY) || !sei.dwHotKey) && m_Header.wHotKey)
+    {
+        sei.dwHotKey = m_Header.wHotKey;
+        sei.fMask |= SEE_MASK_HOTKEY;
+    }
     return (ShellExecuteExW(&sei) ? S_OK : E_FAIL);
 }
 

--- a/dll/win32/shell32/CShellLink.cpp
+++ b/dll/win32/shell32/CShellLink.cpp
@@ -2690,7 +2690,7 @@ HRESULT CShellLink::DoOpen(LPCMINVOKECOMMANDINFO lpici)
 
     sei.dwHotKey = lpici->dwHotKey;
     sei.fMask |= CmicFlagsToSeeFlags(lpici->fMask & CMIC_MASK_HOTKEY);
-    if ((!(sei.fMask & SEE_MASK_HOTKEY) || !sei.dwHotKey) && m_Header.wHotKey)
+    if (m_Header.wHotKey)
     {
         sei.dwHotKey = m_Header.wHotKey;
         sei.fMask |= SEE_MASK_HOTKEY;

--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -517,21 +517,21 @@ static UINT_PTR SHELL_ExecuteW(const WCHAR *lpCmd, WCHAR *env, BOOL shWait,
 
     if (psei->fMask & SEE_MASK_HOTKEY)
     {
-        startup.hStdInput = LongToHandle(psei->dwHotKey);
+        startup.hStdInput = UlongToHandle(psei->dwHotKey);
         startup.dwFlags |= STARTF_USEHOTKEY;
     }
 
     if (psei->fMask & SEE_MASK_ICON) // hIcon has higher precedence than hMonitor
     {
-        startup.hStdOutput = (HANDLE)psei->hIcon;
+        startup.hStdOutput = psei->hIcon;
         startup.dwFlags |= STARTF_SHELLPRIVATE;
     }
     else if ((psei->fMask & SEE_MASK_HMONITOR) || psei->hwnd)
     {
         if (psei->fMask & SEE_MASK_HMONITOR)
-            startup.hStdOutput = (HANDLE)psei->hIcon;
+            startup.hStdOutput = psei->hMonitor;
         else if (psei->hwnd)
-            startup.hStdOutput = (HANDLE)MonitorFromWindow(psei->hwnd, MONITOR_DEFAULTTONEAREST);
+            startup.hStdOutput = MonitorFromWindow(psei->hwnd, MONITOR_DEFAULTTONEAREST);
         if (startup.hStdOutput)
             startup.dwFlags |= STARTF_SHELLPRIVATE;
     }

--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -27,6 +27,9 @@ WINE_DEFAULT_DEBUG_CHANNEL(exec);
 
 EXTERN_C BOOL PathIsExeW(LPCWSTR lpszPath);
 
+#ifndef STARTF_SHELLPRIVATE
+#define STARTF_SHELLPRIVATE 0x400 // From kernel32.h
+#endif
 #define SEE_MASK_CLASSALL (SEE_MASK_CLASSNAME | SEE_MASK_CLASSKEY)
 
 typedef UINT_PTR (*SHELL_ExecuteW32)(const WCHAR *lpCmd, WCHAR *env, BOOL shWait,
@@ -511,6 +514,27 @@ static UINT_PTR SHELL_ExecuteW(const WCHAR *lpCmd, WCHAR *env, BOOL shWait,
 
     if (psei->fMask & SEE_MASK_HASLINKNAME)
         startup.dwFlags |= STARTF_TITLEISLINKNAME;
+
+    if (psei->fMask & SEE_MASK_HOTKEY)
+    {
+        startup.hStdInput = LongToHandle(psei->dwHotKey);
+        startup.dwFlags |= STARTF_USEHOTKEY;
+    }
+
+    if (psei->fMask & SEE_MASK_ICON) // hIcon has higher precedence than hMonitor
+    {
+        startup.hStdOutput = (HANDLE)psei->hIcon;
+        startup.dwFlags |= STARTF_SHELLPRIVATE;
+    }
+    else if ((psei->fMask & SEE_MASK_HMONITOR) || psei->hwnd)
+    {
+        if (psei->fMask & SEE_MASK_HMONITOR)
+            startup.hStdOutput = (HANDLE)psei->hIcon;
+        else if (psei->hwnd)
+            startup.hStdOutput = (HANDLE)MonitorFromWindow(psei->hwnd, MONITOR_DEFAULTTONEAREST);
+        if (startup.hStdOutput)
+            startup.dwFlags |= STARTF_SHELLPRIVATE;
+    }
 
     if (CreateProcessW(NULL, (LPWSTR)lpCmd, NULL, NULL, FALSE, dwCreationFlags, env,
                        lpDirectory, &startup, &info))
@@ -1942,9 +1966,7 @@ static WCHAR *expand_environment( const WCHAR *str )
 static BOOL SHELL_execute(LPSHELLEXECUTEINFOW sei, SHELL_ExecuteW32 execfunc)
 {
     static const DWORD unsupportedFlags =
-        SEE_MASK_ICON         | SEE_MASK_HOTKEY |
-        SEE_MASK_CONNECTNETDRV | SEE_MASK_FLAG_DDEWAIT |
-        SEE_MASK_ASYNCOK      | SEE_MASK_HMONITOR;
+        SEE_MASK_CONNECTNETDRV | SEE_MASK_FLAG_DDEWAIT | SEE_MASK_ASYNCOK;
 
     DWORD len;
     UINT_PTR retval = SE_ERR_NOASSOC;

--- a/win32ss/user/ntuser/hotkey.c
+++ b/win32ss/user/ntuser/hotkey.c
@@ -89,7 +89,6 @@ IntGetModifiers(PBYTE pKeyState)
  *
  * Maps to/from MOD_/HOTKEYF_ (swaps the SHIFT and ALT bits)
  */
-
 static inline
 UCHAR
 IntSwapModHKF(UINT Input)

--- a/win32ss/user/ntuser/hotkey.h
+++ b/win32ss/user/ntuser/hotkey.h
@@ -14,7 +14,7 @@ typedef struct _HOT_KEY
 #define IDHK_F12       -5
 #define IDHK_SHIFTF12  -6
 #define IDHK_WINKEY    -7
-#define IDHK_REACTOS   -8
+#define IDHK_WNDKEY    -8 /* WM_SETHOTKEY */
 
 /* Window Snap Hot Keys */
 #define IDHK_SNAP_LEFT   -10

--- a/win32ss/user/ntuser/main.c
+++ b/win32ss/user/ntuser/main.c
@@ -469,7 +469,7 @@ InitThreadCallback(PETHREAD Thread)
     PTEB pTeb;
     PRTL_USER_PROCESS_PARAMETERS ProcessParams;
     PKL pDefKL;
-    ULONG fPrevW32PF_flags = 0;
+    BOOLEAN bFirstThread;
 
     Process = Thread->ThreadsProcess;
 
@@ -494,7 +494,7 @@ InitThreadCallback(PETHREAD Thread)
     pTeb->Win32ThreadInfo = ptiCurrent;
     ptiCurrent->pClientInfo = (PCLIENTINFO)pTeb->Win32ClientInfo;
     ptiCurrent->pcti = &ptiCurrent->cti;
-    fPrevW32PF_flags = ptiCurrent->ppi->W32PF_flags;
+    bFirstThread = !(ptiCurrent->ppi->W32PF_flags & W32PF_THREADCONNECTED);
 
     /* Mark the process as having threads */
     ptiCurrent->ppi->W32PF_flags |= W32PF_THREADCONNECTED;
@@ -588,14 +588,14 @@ InitThreadCallback(PETHREAD Thread)
           }
        }
 
-       if (!(fPrevW32PF_flags & W32PF_THREADCONNECTED))
+       if (bFirstThread)
        {
              /* Note: Only initialize once so it can be set back to 0 after being used */
              if (ProcessParams->WindowFlags & STARTF_USEHOTKEY)
                  ptiCurrent->ppi->dwHotkey = HandleToUlong(ProcessParams->StandardInput);
              /* TODO:
-             else if (Parameters->ShellInfo.Buffer)
-                 ..->dwHotkey = ParseShellInfo(Parameters->ShellInfo.Buffer, L"hotkey.");
+             else if (ProcessParams->ShellInfo.Buffer)
+                 ..->dwHotkey = ParseShellInfo(ProcessParams->ShellInfo.Buffer, L"hotkey.");
              */
 
              if (ProcessParams->WindowFlags & STARTF_SHELLPRIVATE)

--- a/win32ss/user/ntuser/main.c
+++ b/win32ss/user/ntuser/main.c
@@ -588,24 +588,24 @@ InitThreadCallback(PETHREAD Thread)
           }
        }
 
-       if (bFirstThread)
-       {
-             /* Note: Only initialize once so it can be set back to 0 after being used */
-             if (ProcessParams->WindowFlags & STARTF_USEHOTKEY)
-                 ptiCurrent->ppi->dwHotkey = HandleToUlong(ProcessParams->StandardInput);
-             /* TODO:
-             else if (ProcessParams->ShellInfo.Buffer)
-                 ..->dwHotkey = ParseShellInfo(ProcessParams->ShellInfo.Buffer, L"hotkey.");
-             */
+        if (bFirstThread)
+        {
+            /* Note: Only initialize once so it can be set back to 0 after being used */
+            if (ProcessParams->WindowFlags & STARTF_USEHOTKEY)
+                ptiCurrent->ppi->dwHotkey = HandleToUlong(ProcessParams->StandardInput);
+            /* TODO:
+            else if (ProcessParams->ShellInfo.Buffer)
+                ..->dwHotkey = ParseShellInfo(ProcessParams->ShellInfo.Buffer, L"hotkey.");
+            */
 
-             if (ProcessParams->WindowFlags & STARTF_SHELLPRIVATE)
-             {
-                 /* We need to validate this handle because it can also be a HICON */
-                 HMONITOR hMonitor = (HMONITOR)ProcessParams->StandardOutput;
-                 if (hMonitor && UserGetMonitorObject(hMonitor))
+            if (ProcessParams->WindowFlags & STARTF_SHELLPRIVATE)
+            {
+              /* We need to validate this handle because it can also be a HICON */
+                HMONITOR hMonitor = (HMONITOR)ProcessParams->StandardOutput;
+                if (hMonitor && UserGetMonitorObject(hMonitor))
                     ptiCurrent->ppi->hMonitor = hMonitor;
-             }
-       }
+            }
+        }
     }
 
     /*

--- a/win32ss/user/ntuser/main.c
+++ b/win32ss/user/ntuser/main.c
@@ -13,6 +13,13 @@
 #include <debug.h>
 #include <kdros.h>
 
+#ifndef STARTF_USEHOTKEY
+#define STARTF_USEHOTKEY    0x0200
+#endif
+#ifndef STARTF_SHELLPRIVATE
+#define STARTF_SHELLPRIVATE 0x0400
+#endif
+
 HANDLE hModuleWin;
 
 NTSTATUS ExitProcessCallback(PEPROCESS Process);
@@ -462,6 +469,7 @@ InitThreadCallback(PETHREAD Thread)
     PTEB pTeb;
     PRTL_USER_PROCESS_PARAMETERS ProcessParams;
     PKL pDefKL;
+    ULONG fPrevW32PF_flags = 0;
 
     Process = Thread->ThreadsProcess;
 
@@ -486,6 +494,7 @@ InitThreadCallback(PETHREAD Thread)
     pTeb->Win32ThreadInfo = ptiCurrent;
     ptiCurrent->pClientInfo = (PCLIENTINFO)pTeb->Win32ClientInfo;
     ptiCurrent->pcti = &ptiCurrent->cti;
+    fPrevW32PF_flags = ptiCurrent->ppi->W32PF_flags;
 
     /* Mark the process as having threads */
     ptiCurrent->ppi->W32PF_flags |= W32PF_THREADCONNECTED;
@@ -577,6 +586,25 @@ InitThreadCallback(PETHREAD Thread)
              ptiCurrent->ppi->usi.dwFlags     = ProcessParams->WindowFlags;
              ptiCurrent->ppi->usi.wShowWindow = (WORD)ProcessParams->ShowWindowFlags;
           }
+       }
+
+       if (!(fPrevW32PF_flags & W32PF_THREADCONNECTED))
+       {
+             /* Note: Only initialize once so it can be set back to 0 after being used */
+             if (ProcessParams->WindowFlags & STARTF_USEHOTKEY)
+                 ptiCurrent->ppi->dwHotkey = HandleToUlong(ProcessParams->StandardInput);
+             /* TODO:
+             else if (Parameters->ShellInfo.Buffer)
+                 ..->dwHotkey = ParseShellInfo(Parameters->ShellInfo.Buffer, L"hotkey.");
+             */
+
+             if (ProcessParams->WindowFlags & STARTF_SHELLPRIVATE)
+             {
+                 /* We need to validate this handle because it can also be a HICON */
+                 HMONITOR hMonitor = (HMONITOR)ProcessParams->StandardOutput;
+                 if (hMonitor && UserGetMonitorObject(hMonitor))
+                    ptiCurrent->ppi->hMonitor = hMonitor;
+             }
        }
     }
 

--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -2582,8 +2582,11 @@ co_UserCreateWindowEx(CREATESTRUCTW* Cs,
    /* Set the hotkey */
    if (!(Window->style & (WS_POPUP | WS_CHILD)) || (Window->ExStyle & WS_EX_APPWINDOW))
    {
-       co_IntSendMessage(UserHMGetHandle(Window), WM_SETHOTKEY, pti->ppi->dwHotkey, 0);
-       pti->ppi->dwHotkey = 0; /* Only the first suitable window gets the hotkey */
+       if (pti->ppi->dwHotkey)
+       {
+          co_IntSendMessage(UserHMGetHandle(Window), WM_SETHOTKEY, pti->ppi->dwHotkey, 0);
+          pti->ppi->dwHotkey = 0; /* Only the first suitable window gets the hotkey */
+       }
    }
 
    TRACE("co_UserCreateWindowEx(%wZ): Created window %p\n", ClassName, hWnd);

--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -1718,13 +1718,17 @@ IntFixWindowCoordinates(CREATESTRUCTW* Cs, PWND ParentWindow, DWORD* dwShowMode)
    /* default positioning for overlapped windows */
     if(!(Cs->style & (WS_POPUP | WS_CHILD)))
    {
-      PMONITOR pMonitor;
+      PMONITOR pMonitor = NULL;
       PRTL_USER_PROCESS_PARAMETERS ProcessParams;
+      PPROCESSINFO ppi = PsGetCurrentProcessWin32Process();
 
-      pMonitor = UserGetPrimaryMonitor();
+      if (ppi && ppi->hMonitor)
+         pMonitor = UserGetMonitorObject(ppi->hMonitor);
+      if (!pMonitor)
+         pMonitor = UserGetPrimaryMonitor();
 
       /* Check if we don't have a monitor attached yet */
-      if(pMonitor == NULL)
+      if (pMonitor == NULL)
       {
           Cs->x = Cs->y = 0;
           Cs->cx = 800;
@@ -2573,6 +2577,13 @@ co_UserCreateWindowEx(CREATESTRUCTW* Cs,
    {
        /* Count only console windows manually */
        co_IntUserManualGuiCheck(TRUE);
+   }
+
+   /* Set the hotkey */
+   if (!(Window->style & (WS_POPUP | WS_CHILD)) || (Window->ExStyle & WS_EX_APPWINDOW))
+   {
+       co_IntSendMessage(UserHMGetHandle(Window), WM_SETHOTKEY, pti->ppi->dwHotkey, 0);
+       pti->ppi->dwHotkey = 0; /* Only the first suitable window gets the hotkey */
    }
 
    TRACE("co_UserCreateWindowEx(%wZ): Created window %p\n", ClassName, hWnd);


### PR DESCRIPTION
Notes:
 - `SEE_MASK_ICON` only implements the shell32 part, nothing deeper. I was also unable to make it work on NT4/2000/XP (on cmd.exe).
 - `SEE_MASK_HMONITOR` works in theory but obviously not tested.
 - I verified that `SEE_MASK_HOTKEY` works the same on NT5 and ROS. It does not use the normal MOD flags but the flags from ComCtl32 (don't ask me why), this is also documented on MSDN. `SC_HOTKEY` is sent to the active window, presumably so it can be blocked by fullscreen things.
 - `psei->hIcon` is also correct for HMONITOR, they are in a union in newer SDKs.
 - `ParseShellInfo` is commened out because a similar function in kernel32 is not implemented either. Hopefully nobody is using this Windows 3 feature.
 - Because the  `RegisterHotKey` caller controls all 32-bits of the id and this `WM_SETHOTKEY` hotkey lives in the same list, I'm using a `NULL` `pti` to detect this so `IDHK_REACTOS` does not conflict. This should probably also be done with `IDHK_SNAP_*` etc.

`WM_SETHOTKEY` now also works correctly without using `SEE_MASK_HOTKEY`:
```
HWND hWnd = CreateWindowExA(WS_EX_APPWINDOW, "BUTTON", 0, WS_OVERLAPPEDWINDOW, 0, 0, 100, 100, NULL, NULL, NULL, NULL);
ShowWindow(hWnd, SW_SHOWNA);
SendMessage(hWnd, WM_SETHOTKEY, MAKEWORD(VK_F3, 3 /*Ctrl+Shift*/), 0);
for (MSG msg; IsWindow(hWnd) && GetMessage(&msg, 0, 0, NULL);) DispatchMessage(&msg);
```

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: