### PR TITLE
[SDK][USER32] Implement WM_IME_SYSTEM.IMS_SOFTKBDONOFF

### DIFF
--- a/sdk/include/ddk/immdev.h
+++ b/sdk/include/ddk/immdev.h
@@ -103,6 +103,7 @@ typedef struct tagGUIDELINE {
 #define IMS_CONFIGURE           0x0D
 #define IMS_SETOPENSTATUS       0x0F
 #define IMS_FREELAYOUT          0x11
+#define IMS_SOFTKBDONOFF        0x13
 #define IMS_GETCONVSTATUS       0x14
 #define IMS_IMEHELP             0x15
 #define IMS_IMEACTIVATE         0x17

--- a/win32ss/user/user32/misc/imm.c
+++ b/win32ss/user/user32/misc/imm.c
@@ -637,7 +637,6 @@ ImeWnd_SwitchSoftKbdProc(_In_ HIMC hIMC, _In_ LPARAM lParam)
 }
 
 /* Handles WM_IME_SYSTEM message of the default IME window. */
-/* Win: ImeSystemHandler */
 static LRESULT ImeWnd_OnImeSystem(PIMEUI pimeui, WPARAM wParam, LPARAM lParam)
 {
     LRESULT ret = 0;

--- a/win32ss/user/user32/misc/imm.c
+++ b/win32ss/user/user32/misc/imm.c
@@ -618,6 +618,24 @@ User32DoImeHelp(PIMEUI pimeui, WPARAM wParam, LPARAM lParam)
     return ret;
 }
 
+static BOOL CALLBACK
+ImeWnd_SwitchSoftKbdProc(_In_ HIMC hIMC, _In_ LPARAM lParam)
+{
+    DWORD dwConversion, dwSentence, dwNewConversion;
+
+    IMM_FN(ImmGetConversionStatus)(hIMC, &dwConversion, &dwSentence);
+
+    if (lParam)
+        dwNewConversion = dwConversion | IME_CMODE_SOFTKBD;
+    else
+        dwNewConversion = dwConversion & ~IME_CMODE_SOFTKBD;
+
+    if (dwNewConversion != dwConversion)
+        IMM_FN(ImmSetConversionStatus)(hIMC, dwNewConversion, dwSentence);
+
+    return TRUE;
+}
+
 /* Handles WM_IME_SYSTEM message of the default IME window. */
 /* Win: ImeSystemHandler */
 static LRESULT ImeWnd_OnImeSystem(PIMEUI pimeui, WPARAM wParam, LPARAM lParam)
@@ -720,8 +738,8 @@ static LRESULT ImeWnd_OnImeSystem(PIMEUI pimeui, WPARAM wParam, LPARAM lParam)
             ret = IMM_FN(ImmFreeLayout)((HKL)lParam);
             break;
 
-        case 0x13:
-            FIXME("\n");
+        case IMS_SOFTKBDONOFF:
+            IMM_FN(ImmEnumInputContext)(0, ImeWnd_SwitchSoftKbdProc, lParam);
             break;
 
         case IMS_GETCONVSTATUS:


### PR DESCRIPTION
## Purpose

Supporting soft keyboard will improve IME usability.
JIRA issue: [CORE-19268](https://jira.reactos.org/browse/CORE-19268)

## Proposed changes

- Define `IMS_SOFTKBDONOFF` constant as `0x13` in `<immdev.h>`.
- Implement `WM_IME_SYSTEM.IMS_SOFTKBDONOFF` message handling in `ImeWnd_OnImeSystem`.