### PR TITLE
[NTGDI:FREETYPE] Fix Fonts broken by opening VLC About (Retry of PR #4579)

### DIFF
--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -2921,7 +2921,7 @@ FillTM(TEXTMETRICW *TM, PFONTGDI FontGDI,
     TM->tmMaxCharWidth = (FT_MulFix(Face->max_advance_width, XScale) + 32) >> 6;
 
     if (FontGDI->OriginalWeight != FW_DONTCARE &&
-        FontGDI->OriginalWeight != FW_NORMAL)
+        FontGDI->OriginalWeight > FontGDI->RequestWeight)
     {
         TM->tmWeight = FontGDI->OriginalWeight;
     }

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -1816,7 +1816,7 @@ IntGdiLoadFontsFromMemory(PGDI_LOAD_FONT pLoadFont,
     FontGDI->CharSet = ANSI_CHARSET;
     FontGDI->OriginalItalic = FALSE;
     FontGDI->RequestItalic = FALSE;
-    FontGDI->OriginalWeight = FALSE;
+    FontGDI->OriginalWeight = FW_DONTCARE;
     FontGDI->RequestWeight = FW_NORMAL;
 
     IntLockFreeType();


### PR DESCRIPTION
## Purpose

_Return the original weight from the font instead of the requested weight under certain conditions._

JIRA issue: [CORE-17011](https://jira.reactos.org/browse/CORE-17011)

## Proposed changes

_Check is FontGDI->OriginalWeight > FontGDI->RequestWeight and if so, then return original weight._

## Testbot runs (Filled in by Devs)

- [X] KVM x86: https://reactos.org/testman/compare.php?ids=101599,101600,101605,101607 LGTM
- [ ] KVM x64:

Before:

![VLC-Fonts-Bad](https://github.com/user-attachments/assets/a5b1087e-d935-4a6a-9fd0-beeb0c0e7760)

After:

![VLC-Fonts-OK](https://github.com/user-attachments/assets/70619c56-504d-4e4a-a815-27f09ff7c4f5)
