### PR TITLE
[CRT_APITEST] Fix test failures on Win 2003 x64

### DIFF
--- a/modules/rostests/apitests/crt/setjmp.c
+++ b/modules/rostests/apitests/crt/setjmp.c
@@ -57,8 +57,13 @@ static void TEST_setjmp_normal(void)
 #endif /* ndef __clang__ */
         case 3:
             ok_int(value, 333);
-            ok_int(finally_called, TRUE);
-            ok_int(abnormal, TRUE);
+#ifdef _M_AMD64 // This is broken on Windows 2003 x64
+            if (_winver >= _WIN32_WINNT_VISTA)
+#endif
+            {
+                ok_int(finally_called, TRUE);
+                ok_int(abnormal, TRUE);
+            }
             stage = 4;
 #ifdef __clang__ /* avoiding clang build hung up */
             skip("avoiding clang build crash\n");


### PR DESCRIPTION
## Purpose

fix failures: https://reactos.org/testman/compare.php?ids=101896

## Testbot runs (Filled in by Devs)

- [x] Test WHS: https://reactos.org/testman/compare.php?ids=102029,102036
- [ ] Test Windows 2003 x64: