### PR TITLE
[BROWSEUI] Quick Launch: Refresh buttons on change notify

### DIFF
--- a/dll/win32/browseui/shellbars/CISFBand.cpp
+++ b/dll/win32/browseui/shellbars/CISFBand.cpp
@@ -73,6 +73,15 @@ HRESULT CISFBand::CreateSimpleToolbar(HWND hWndParent)
     return hr;
 }
 
+void CISFBand::RefreshToolbar()
+{
+    DeleteToolbarButtons();
+    AddToolbarButtons();
+
+    if (m_Site)
+        IUnknown_Exec(m_Site, IID_IDeskBand, DBID_BANDINFOCHANGED, 0, NULL, NULL);
+}
+
 HRESULT CISFBand::AddToolbarButtons()
 {
     CComPtr<IEnumIDList> pEnum;
@@ -113,15 +122,6 @@ void CISFBand::DeleteToolbarButtons()
         CoTaskMemFree((LPITEMIDLIST)tb.dwData);
         SendMessage(TB_DELETEBUTTON, 0, 0);
     }
-}
-
-void CISFBand::RefreshToolbar()
-{
-    DeleteToolbarButtons();
-    AddToolbarButtons();
-
-    if (m_Site)
-        IUnknown_Exec(m_Site, IID_IDeskBand, DBID_BANDINFOCHANGED, 0, NULL, NULL);
 }
 
 LRESULT CISFBand::OnTimer(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled)

--- a/dll/win32/browseui/shellbars/CISFBand.cpp
+++ b/dll/win32/browseui/shellbars/CISFBand.cpp
@@ -158,7 +158,7 @@ void CISFBand::RegisterChangeNotify(BOOL bRegister)
                                                  SHCNE_ALLEVENTS, WM_ISFBAND_CHANGE_NOTIFY,
                                                  1, &entry);
     }
-    else
+    else // De-register?
     {
         if (m_uChangeNotify)
         {

--- a/dll/win32/browseui/shellbars/CISFBand.cpp
+++ b/dll/win32/browseui/shellbars/CISFBand.cpp
@@ -190,11 +190,14 @@ LRESULT CISFBand::OnChangeNotify(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &
 // WM_DESTROY
 LRESULT CISFBand::OnDestroy(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled)
 {
-    KillTimer(TIMERID_DELAYED_REFRESH);
     RegisterChangeNotify(FALSE);
-    UnsubclassWindow();
-    ShowWindow(SW_HIDE);
-    DeleteToolbarButtons();
+    if (m_hWnd)
+    {
+        KillTimer(TIMERID_DELAYED_REFRESH);
+        ShowWindow(SW_HIDE);
+        DeleteToolbarButtons();
+        UnsubclassWindow();
+    }
     bHandled = FALSE;
     return 0;
 }

--- a/dll/win32/browseui/shellbars/CISFBand.cpp
+++ b/dll/win32/browseui/shellbars/CISFBand.cpp
@@ -40,7 +40,6 @@ CISFBand::CISFBand() :
 
 CISFBand::~CISFBand()
 {
-    CloseDW(0);
 }
 
 HRESULT CISFBand::CreateSimpleToolbar(HWND hWndParent)
@@ -142,6 +141,10 @@ LRESULT CISFBand::OnDestroy(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHand
 {
     KillTimer(TIMERID_REFRESH);
     UnregisterChangeNotify();
+    ShowWindow(SW_HIDE);
+    DeleteToolbarButtons();
+    UnsubclassWindow();
+    bHandled = FALSE;
     return 0;
 }
 
@@ -237,13 +240,7 @@ void CISFBand::UnregisterChangeNotify()
     {
         if (m_hWnd)
         {
-            ShowWindow(SW_HIDE);
-
-            DeleteToolbarButtons();
-
             DestroyWindow();
-
-            m_hWnd = NULL;
             return S_OK;
         }
 

--- a/dll/win32/browseui/shellbars/CISFBand.cpp
+++ b/dll/win32/browseui/shellbars/CISFBand.cpp
@@ -31,7 +31,7 @@ TODO:
 // *** CISFBand ***
 
 CISFBand::CISFBand()
-    : m_BandID(0),
+    : m_BandID(0)
     , m_pidl(NULL)
     , m_uChangeNotify(0)
     , m_bShowText(TRUE)

--- a/dll/win32/browseui/shellbars/CISFBand.cpp
+++ b/dll/win32/browseui/shellbars/CISFBand.cpp
@@ -56,15 +56,14 @@ HRESULT CISFBand::CreateSimpleToolbar(HWND hWndParent)
 
     ShowHideText(m_bShowText);
     SetImageListIconSize(m_bSmallIcon);
-    AddToolbarButtons();
 
-    return S_OK;
+    return AddToolbarButtons();
 }
 
-void CISFBand::RefreshToolbar()
+HRESULT CISFBand::RefreshToolbar()
 {
     DeleteToolbarButtons();
-    AddToolbarButtons();
+    return AddToolbarButtons();
 }
 
 HRESULT CISFBand::AddToolbarButtons()

--- a/dll/win32/browseui/shellbars/CISFBand.cpp
+++ b/dll/win32/browseui/shellbars/CISFBand.cpp
@@ -1,4 +1,4 @@
-/*/*
+/*
  * PROJECT:     ReactOS shell extensions
  * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
  * PURPOSE:     Quick Launch Toolbar (Taskbar Shell Extension)

--- a/dll/win32/browseui/shellbars/CISFBand.cpp
+++ b/dll/win32/browseui/shellbars/CISFBand.cpp
@@ -56,7 +56,7 @@ HRESULT CISFBand::CreateSimpleToolbar(HWND hWndParent)
 
     ShowHideText(m_bShowText);
     SetImageListIconSize(m_bSmallIcon);
-    RefreshToolbar();
+    AddToolbarButtons();
 
     return S_OK;
 }
@@ -65,7 +65,6 @@ void CISFBand::RefreshToolbar()
 {
     DeleteToolbarButtons();
     AddToolbarButtons();
-    BandInfoChanged();
 }
 
 HRESULT CISFBand::AddToolbarButtons()
@@ -94,7 +93,7 @@ HRESULT CISFBand::AddToolbarButtons()
     }
 
     SendMessage(TB_AUTOSIZE, 0, 0);
-    return S_OK;
+    return BandInfoChanged();
 }
 
 void CISFBand::DeleteToolbarButtons()

--- a/dll/win32/browseui/shellbars/CISFBand.cpp
+++ b/dll/win32/browseui/shellbars/CISFBand.cpp
@@ -48,8 +48,7 @@ HRESULT CISFBand::CreateSimpleToolbar(HWND hWndParent)
 {
     // Create the toolbar.
     DWORD style = WS_CHILD | TBSTYLE_FLAT | TBSTYLE_LIST | CCS_NORESIZE | CCS_NODIVIDER;
-    HWND hwndToolbar = ::CreateWindowEx(0, TOOLBARCLASSNAME, NULL, style,
-                                        CW_USEDEFAULT, CW_USEDEFAULT, 0, 0,
+    HWND hwndToolbar = ::CreateWindowEx(0, TOOLBARCLASSNAME, NULL, style, 0, 0, 0, 0,
                                         hWndParent, NULL, 0, NULL);
     if (!hwndToolbar)
         return E_FAIL;

--- a/dll/win32/browseui/shellbars/CISFBand.cpp
+++ b/dll/win32/browseui/shellbars/CISFBand.cpp
@@ -163,6 +163,9 @@ HRESULT CISFBand::ShowHideText(_In_ BOOL bShow)
     return S_OK;
 }
 
+//****************************************************************************
+// Message handlers
+
 LRESULT CISFBand::OnTimer(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled)
 {
     if (wParam == TIMERID_DELAYED_REFRESH)

--- a/dll/win32/browseui/shellbars/CISFBand.cpp
+++ b/dll/win32/browseui/shellbars/CISFBand.cpp
@@ -60,14 +60,14 @@ HRESULT CISFBand::CreateSimpleToolbar(HWND hWndParent)
         SendMessage(TB_SETEXTENDEDSTYLE, 0, TBSTYLE_EX_MIXEDBUTTONS);
 
     // Set the image list.
-    HIMAGELIST* piml;
-    HRESULT hr = SHGetImageList(SHIL_SMALL, IID_IImageList, (void**)&piml);
+    CComPtr<IImageList> piml;
+    HRESULT hr = SHGetImageList(SHIL_SMALL, IID_PPV_ARG(IImageList, &piml));
     if (FAILED_UNEXPECTEDLY(hr))
     {
         DestroyWindow();
         return hr;
     }
-    SendMessage(TB_SETIMAGELIST, 0, (LPARAM)piml);
+    SendMessage(TB_SETIMAGELIST, 0, (LPARAM)(HIMAGELIST)piml.Detach());
 
     RefreshToolbar();
     return hr;

--- a/dll/win32/browseui/shellbars/CISFBand.cpp
+++ b/dll/win32/browseui/shellbars/CISFBand.cpp
@@ -53,6 +53,7 @@ HRESULT CISFBand::CreateSimpleToolbar(HWND hWndParent)
         return E_FAIL;
 
     SubclassWindow(hwndToolbar);
+    ATLASSERT(m_hWnd);
 
     ShowHideText(m_bShowText);
     SetImageListIconSize(m_bSmallIcon);
@@ -112,6 +113,8 @@ BOOL CISFBand::RegisterChangeNotify(_In_ BOOL bRegister)
 {
     if (bRegister)
     {
+        if (!m_pidl)
+            return FALSE;
 #define SHCNE_WATCH (SHCNE_RENAMEITEM | SHCNE_CREATE | SHCNE_DELETE | SHCNE_MKDIR | \
                      SHCNE_RMDIR | SHCNE_UPDATEDIR | SHCNE_UPDATEITEM | SHCNE_UPDATEIMAGE | \
                      SHCNE_RENAMEFOLDER | SHCNE_ASSOCCHANGED)
@@ -574,6 +577,8 @@ LRESULT CISFBand::OnDestroy(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHand
             }
 
             m_pidl.Attach(ILClone(pidl));
+            if (!m_pidl)
+                ERR("Out of memory\n");
         }
 
         if (psf != NULL)
@@ -587,6 +592,7 @@ LRESULT CISFBand::OnDestroy(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHand
             if (FAILED_UNEXPECTEDLY(hr))
                 return hr;
 
+            ATLASSERT(m_pidl);
             m_pISF = psf;
         }
 

--- a/dll/win32/browseui/shellbars/CISFBand.cpp
+++ b/dll/win32/browseui/shellbars/CISFBand.cpp
@@ -175,7 +175,7 @@ LRESULT CISFBand::OnTimer(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandle
 
 LRESULT CISFBand::OnChangeNotify(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled)
 {
-    // This code reduces the redrawing cost
+    // This code reduces the redrawing cost by coalescing multiple change events
     KillTimer(TIMERID_DELAYED_REFRESH);
     SetTimer(TIMERID_DELAYED_REFRESH, TIMER_REFRESH_DELAY);
     return 0;

--- a/dll/win32/browseui/shellbars/CISFBand.cpp
+++ b/dll/win32/browseui/shellbars/CISFBand.cpp
@@ -104,6 +104,9 @@ HRESULT CISFBand::AddToolbarButtons()
 
 void CISFBand::DeleteToolbarButtons()
 {
+    // Assumption: Deleting a button causes the remaining buttons to shift,
+    // so the next button always appears at index 0. This ensures the loop
+    // progresses and avoids infinite loops.
     TBBUTTON tb;
     while (SendMessage(TB_GETBUTTON, 0, (LPARAM)&tb))
     {

--- a/dll/win32/browseui/shellbars/CISFBand.cpp
+++ b/dll/win32/browseui/shellbars/CISFBand.cpp
@@ -24,7 +24,7 @@ TODO:
     ** Implement responding to theme change
 */
 
-#define TIMERID_REFRESH 0xBEEFCAFE
+#define TIMERID_DELAYED_REFRESH 0xBEEFCAFE
 #define TIMER_REFRESH_DELAY 500
 
 //*****************************************************************************************
@@ -123,7 +123,7 @@ void CISFBand::RefreshToolbar()
 
 LRESULT CISFBand::OnTimer(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled)
 {
-    if (wParam != TIMERID_REFRESH)
+    if (wParam != TIMERID_DELAYED_REFRESH)
         return 0;
 
     KillTimer(wParam);
@@ -133,14 +133,14 @@ LRESULT CISFBand::OnTimer(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandle
 
 LRESULT CISFBand::OnChangeNotify(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled)
 {
-    KillTimer(TIMERID_REFRESH);
-    SetTimer(TIMERID_REFRESH, TIMER_REFRESH_DELAY);
+    KillTimer(TIMERID_DELAYED_REFRESH);
+    SetTimer(TIMERID_DELAYED_REFRESH, TIMER_REFRESH_DELAY);
     return 0;
 }
 
 LRESULT CISFBand::OnDestroy(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled)
 {
-    KillTimer(TIMERID_REFRESH);
+    KillTimer(TIMERID_DELAYED_REFRESH);
     RegisterChangeNotify(FALSE);
     ShowWindow(SW_HIDE);
     DeleteToolbarButtons();

--- a/dll/win32/browseui/shellbars/CISFBand.cpp
+++ b/dll/win32/browseui/shellbars/CISFBand.cpp
@@ -194,13 +194,10 @@ LRESULT CISFBand::OnChangeNotify(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &
 LRESULT CISFBand::OnDestroy(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled)
 {
     RegisterChangeNotify(FALSE);
-    if (m_hWnd)
-    {
-        KillTimer(TIMERID_DELAYED_REFRESH);
-        ShowWindow(SW_HIDE);
-        DeleteToolbarButtons();
-        UnsubclassWindow();
-    }
+    KillTimer(TIMERID_DELAYED_REFRESH);
+    ShowWindow(SW_HIDE);
+    DeleteToolbarButtons();
+    UnsubclassWindow();
     bHandled = FALSE;
     return 0;
 }

--- a/dll/win32/browseui/shellbars/CISFBand.cpp
+++ b/dll/win32/browseui/shellbars/CISFBand.cpp
@@ -182,9 +182,9 @@ LRESULT CISFBand::OnDestroy(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHand
 {
     KillTimer(TIMERID_DELAYED_REFRESH);
     RegisterChangeNotify(FALSE);
+    UnsubclassWindow();
     ShowWindow(SW_HIDE);
     DeleteToolbarButtons();
-    UnsubclassWindow();
     bHandled = FALSE;
     return 0;
 }

--- a/dll/win32/browseui/shellbars/CISFBand.cpp
+++ b/dll/win32/browseui/shellbars/CISFBand.cpp
@@ -114,9 +114,12 @@ void CISFBand::RegisterChangeNotify(_In_ BOOL bRegister)
 {
     if (bRegister)
     {
+#define SHCNE_WATCH (SHCNE_RENAMEITEM | SHCNE_CREATE | SHCNE_DELETE | SHCNE_MKDIR | \
+                     SHCNE_RMDIR | SHCNE_UPDATEDIR | SHCNE_UPDATEITEM | SHCNE_UPDATEIMAGE | \
+                     SHCNE_RENAMEFOLDER | SHCNE_ASSOCCHANGED)
         SHChangeNotifyEntry entry = { m_pidl, FALSE };
         m_uChangeNotify = SHChangeNotifyRegister(m_hWnd, SHCNRF_ShellLevel | SHCNRF_NewDelivery,
-                                                 SHCNE_ALLEVENTS, WM_ISFBAND_CHANGE_NOTIFY,
+                                                 SHCNE_WATCH, WM_ISFBAND_CHANGE_NOTIFY,
                                                  1, &entry);
     }
     else // De-register?

--- a/dll/win32/browseui/shellbars/CISFBand.cpp
+++ b/dll/win32/browseui/shellbars/CISFBand.cpp
@@ -108,7 +108,7 @@ void CISFBand::DeleteToolbarButtons()
     }
 }
 
-void CISFBand::RegisterChangeNotify(_In_ BOOL bRegister)
+BOOL CISFBand::RegisterChangeNotify(_In_ BOOL bRegister)
 {
     if (bRegister)
     {
@@ -119,6 +119,7 @@ void CISFBand::RegisterChangeNotify(_In_ BOOL bRegister)
         m_uChangeNotify = SHChangeNotifyRegister(m_hWnd, SHCNRF_ShellLevel | SHCNRF_NewDelivery,
                                                  SHCNE_WATCH, WM_ISFBAND_CHANGE_NOTIFY,
                                                  1, &entry);
+        return m_uChangeNotify != 0;
     }
     else // De-register?
     {
@@ -126,7 +127,9 @@ void CISFBand::RegisterChangeNotify(_In_ BOOL bRegister)
         {
             SHChangeNotifyDeregister(m_uChangeNotify);
             m_uChangeNotify = 0;
+            return TRUE;
         }
+        return FALSE;
     }
 }
 

--- a/dll/win32/browseui/shellbars/CISFBand.cpp
+++ b/dll/win32/browseui/shellbars/CISFBand.cpp
@@ -133,6 +133,7 @@ LRESULT CISFBand::OnTimer(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandle
 
 LRESULT CISFBand::OnChangeNotify(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled)
 {
+    // This code reduces the redrawing cost
     KillTimer(TIMERID_DELAYED_REFRESH);
     SetTimer(TIMERID_DELAYED_REFRESH, TIMER_REFRESH_DELAY);
     return 0;

--- a/dll/win32/browseui/shellbars/CISFBand.cpp
+++ b/dll/win32/browseui/shellbars/CISFBand.cpp
@@ -166,6 +166,7 @@ HRESULT CISFBand::ShowHideText(_In_ BOOL bShow)
 //****************************************************************************
 // Message handlers
 
+// WM_TIMER
 LRESULT CISFBand::OnTimer(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled)
 {
     if (wParam == TIMERID_DELAYED_REFRESH)
@@ -176,6 +177,7 @@ LRESULT CISFBand::OnTimer(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandle
     return 0;
 }
 
+// WM_ISFBAND_CHANGE_NOTIFY
 LRESULT CISFBand::OnChangeNotify(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled)
 {
     // This code reduces the redrawing cost by coalescing multiple change events
@@ -184,6 +186,7 @@ LRESULT CISFBand::OnChangeNotify(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &
     return 0;
 }
 
+// WM_DESTROY
 LRESULT CISFBand::OnDestroy(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled)
 {
     KillTimer(TIMERID_DELAYED_REFRESH);

--- a/dll/win32/browseui/shellbars/CISFBand.cpp
+++ b/dll/win32/browseui/shellbars/CISFBand.cpp
@@ -22,6 +22,7 @@ TODO:
 */
 
 #define TIMERID_REFRESH 0xBEEF
+#define TIMER_REFRESH_DELAY 500
 
 //*****************************************************************************************
 // *** CISFBand ***
@@ -141,7 +142,7 @@ LRESULT CISFBand::OnTimer(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandle
 LRESULT CISFBand::OnChangeNotify(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled)
 {
     KillTimer(TIMERID_REFRESH);
-    SetTimer(TIMERID_REFRESH, 500);
+    SetTimer(TIMERID_REFRESH, TIMER_REFRESH_DELAY);
     return 0;
 }
 

--- a/dll/win32/browseui/shellbars/CISFBand.cpp
+++ b/dll/win32/browseui/shellbars/CISFBand.cpp
@@ -80,7 +80,7 @@ HRESULT CISFBand::AddToolbarButtons()
         return hr;
 
     LPITEMIDLIST pidl;
-    for (INT i = 0; pEnum->Next(1, &pidl, NULL) != S_FALSE; ++i)
+    for (INT i = 0; pEnum->Next(1, &pidl, NULL) == S_OK; ++i)
     {
         STRRET strret;
         hr = m_pISF->GetDisplayNameOf(pidl, SHGDN_NORMAL, &strret);

--- a/dll/win32/browseui/shellbars/CISFBand.h
+++ b/dll/win32/browseui/shellbars/CISFBand.h
@@ -39,6 +39,7 @@ class CISFBand :
     void RegisterChangeNotify();
     void UnregisterChangeNotify();
     HRESULT AddButtons();
+    void DeleteButtons();
     void RefreshToolbar();
 
 public:

--- a/dll/win32/browseui/shellbars/CISFBand.h
+++ b/dll/win32/browseui/shellbars/CISFBand.h
@@ -34,16 +34,17 @@ class CISFBand :
 
     // Menu
     BOOL m_textFlag;
-    BOOL m_iconFlag;
+    BOOL m_bSmallIcon;
     BOOL m_QLaunch;
 
     void RegisterChangeNotify(BOOL bRegister);
     HRESULT AddToolbarButtons();
     void DeleteToolbarButtons();
     void RefreshToolbar();
+    HRESULT SetIconSize(BOOL bSmall);
+    HRESULT BandInfoChanged();
 
 public:
-
     CISFBand();
     virtual ~CISFBand();
 

--- a/dll/win32/browseui/shellbars/CISFBand.h
+++ b/dll/win32/browseui/shellbars/CISFBand.h
@@ -33,7 +33,7 @@ class CISFBand :
     UINT m_uChangeNotify;
 
     // Menu
-    BOOL m_textFlag;
+    BOOL m_bShowText;
     BOOL m_bSmallIcon;
     BOOL m_QLaunch;
 
@@ -43,6 +43,7 @@ class CISFBand :
     void RefreshToolbar();
     HRESULT SetIconSize(BOOL bSmall);
     HRESULT BandInfoChanged();
+    HRESULT ShowHideText(BOOL bShow);
 
 public:
     CISFBand();

--- a/dll/win32/browseui/shellbars/CISFBand.h
+++ b/dll/win32/browseui/shellbars/CISFBand.h
@@ -37,7 +37,7 @@ class CISFBand :
     BOOL m_bSmallIcon;
     BOOL m_QLaunch;
 
-    void RegisterChangeNotify(_In_ BOOL bRegister);
+    BOOL RegisterChangeNotify(_In_ BOOL bRegister);
     HRESULT AddToolbarButtons();
     void DeleteToolbarButtons();
     HRESULT RefreshToolbar();

--- a/dll/win32/browseui/shellbars/CISFBand.h
+++ b/dll/win32/browseui/shellbars/CISFBand.h
@@ -1,9 +1,10 @@
 /*
  * PROJECT:     ReactOS shell extensions
- * LICENSE:     GPL - See COPYING in the top level directory
- * FILE:        dll/shellext/qcklnch/CISFBand.h
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
  * PURPOSE:     Quick Launch Toolbar (Taskbar Shell Extension)
- * PROGRAMMERS: Shriraj Sawant a.k.a SR13 <sr.official@hotmail.com>
+ * COPYRIGHT:   Copyright 2017 Shriraj Sawant a.k.a SR13 <sr.official@hotmail.com>
+ *              Copyright 2017-2018 Giannis Adamopoulos
+ *              Copyright 2023-2025 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  */
 
 #pragma once
@@ -38,8 +39,8 @@ class CISFBand :
 
     void RegisterChangeNotify();
     void UnregisterChangeNotify();
-    HRESULT AddButtons();
-    void DeleteButtons();
+    HRESULT AddToolbarButtons();
+    void DeleteToolbarButtons();
     void RefreshToolbar();
 
 public:

--- a/dll/win32/browseui/shellbars/CISFBand.h
+++ b/dll/win32/browseui/shellbars/CISFBand.h
@@ -29,7 +29,7 @@ class CISFBand :
 
     // Toolbar
     CComPtr<IShellFolder> m_pISF;
-    PIDLIST_ABSOLUTE m_pidl;
+    CComHeapPtr<ITEMIDLIST_ABSOLUTE> m_pidl;
     UINT m_uChangeNotify;
 
     // Menu
@@ -37,13 +37,13 @@ class CISFBand :
     BOOL m_bSmallIcon;
     BOOL m_QLaunch;
 
-    void RegisterChangeNotify(BOOL bRegister);
+    void RegisterChangeNotify(_In_ BOOL bRegister);
     HRESULT AddToolbarButtons();
     void DeleteToolbarButtons();
     void RefreshToolbar();
-    HRESULT SetIconSize(BOOL bSmall);
+    HRESULT SetImageListIconSize(_In_ BOOL bSmall);
     HRESULT BandInfoChanged();
-    HRESULT ShowHideText(BOOL bShow);
+    HRESULT ShowHideText(_In_ BOOL bShow);
 
 public:
     CISFBand();

--- a/dll/win32/browseui/shellbars/CISFBand.h
+++ b/dll/win32/browseui/shellbars/CISFBand.h
@@ -37,8 +37,7 @@ class CISFBand :
     BOOL m_iconFlag;
     BOOL m_QLaunch;
 
-    void RegisterChangeNotify();
-    void UnregisterChangeNotify();
+    void RegisterChangeNotify(BOOL bRegister);
     HRESULT AddToolbarButtons();
     void DeleteToolbarButtons();
     void RefreshToolbar();
@@ -183,6 +182,10 @@ public:
         UINT uFlags
     ) override;
 
+    LRESULT OnChangeNotify(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
+    LRESULT OnTimer(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
+    LRESULT OnDestroy(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
+
 //*****************************************************************************************************
 
     DECLARE_REGISTRY_RESOURCEID(IDR_ISFBAND)
@@ -201,10 +204,6 @@ public:
         COM_INTERFACE_ENTRY_IID(IID_IShellFolderBand, IShellFolderBand)
         COM_INTERFACE_ENTRY_IID(IID_IContextMenu, IContextMenu)
     END_COM_MAP()
-
-    LRESULT OnChangeNotify(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
-    LRESULT OnTimer(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
-    LRESULT OnDestroy(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
 
     BEGIN_MSG_MAP(CISFBand)
         MESSAGE_HANDLER(WM_ISFBAND_CHANGE_NOTIFY, OnChangeNotify)

--- a/dll/win32/browseui/shellbars/CISFBand.h
+++ b/dll/win32/browseui/shellbars/CISFBand.h
@@ -40,7 +40,7 @@ class CISFBand :
     void RegisterChangeNotify(_In_ BOOL bRegister);
     HRESULT AddToolbarButtons();
     void DeleteToolbarButtons();
-    void RefreshToolbar();
+    HRESULT RefreshToolbar();
     HRESULT SetImageListIconSize(_In_ BOOL bSmall);
     HRESULT BandInfoChanged();
     HRESULT ShowHideText(_In_ BOOL bShow);

--- a/dll/win32/browseui/shellbars/CISFBand.h
+++ b/dll/win32/browseui/shellbars/CISFBand.h
@@ -8,8 +8,10 @@
 
 #pragma once
 
+#define WM_ISFBAND_CHANGE_NOTIFY (WM_USER + 100)
+
 class CISFBand :
-    public CWindow,
+    public CWindowImpl<CISFBand, CWindow>,
     public CComCoClass<CBandSiteMenu, &CLSID_ISFBand>,
     public CComObjectRootEx<CComMultiThreadModelNoCS>,
     public IObjectWithSite,
@@ -27,11 +29,17 @@ class CISFBand :
     // Toolbar
     CComPtr<IShellFolder> m_pISF;
     PIDLIST_ABSOLUTE m_pidl;
+    UINT m_uChangeNotify;
 
     // Menu
     BOOL m_textFlag;
     BOOL m_iconFlag;
     BOOL m_QLaunch;
+
+    void RegisterChangeNotify();
+    void UnregisterChangeNotify();
+    HRESULT AddButtons();
+    void RefreshToolbar();
 
 public:
 
@@ -191,6 +199,16 @@ public:
         COM_INTERFACE_ENTRY_IID(IID_IShellFolderBand, IShellFolderBand)
         COM_INTERFACE_ENTRY_IID(IID_IContextMenu, IContextMenu)
     END_COM_MAP()
+
+    LRESULT OnChangeNotify(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
+    LRESULT OnTimer(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
+    LRESULT OnDestroy(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
+
+    BEGIN_MSG_MAP(CISFBand)
+        MESSAGE_HANDLER(WM_ISFBAND_CHANGE_NOTIFY, OnChangeNotify)
+        MESSAGE_HANDLER(WM_TIMER, OnTimer)
+        MESSAGE_HANDLER(WM_DESTROY, OnDestroy)
+    END_MSG_MAP()
 };
 
 extern "C" HRESULT WINAPI RSHELL_CISFBand_CreateInstance(REFIID riid, void** ppv);


### PR DESCRIPTION
## Purpose
Respond change notification on Quick Launch.
JIRA issue: [CORE-18475](https://jira.reactos.org/browse/CORE-18475)

## Proposed changes

- Subclass `CISFBand` to handle messages.
- Register change notification.
- Refresh buttons on change notification.
- Use timer to improve UI/UX and reduce cost.

## Comparison

BEFORE:
![before](https://github.com/user-attachments/assets/9e7133a3-5336-42af-bd34-5ea64ed8ee32)

AFTER:
![after](https://github.com/user-attachments/assets/93341741-cf86-415a-bc2c-66d791fccced)