### PR TITLE
[FREELDR] Show a notice message when booting in debug mode

### DIFF
--- a/boot/freeldr/freeldr/ntldr/winldr.c
+++ b/boot/freeldr/freeldr/ntldr/winldr.c
@@ -1251,6 +1251,29 @@ LoadAndBootWindowsCommon(
     /* "Stop all motors", change videomode */
     MachPrepareForReactOS();
 
+    /* Show the "debug mode" notice if needed */
+    BOOLEAN DebugMode = !NtLdrGetOption(BootOptions, "NODEBUG") && /* NODEBUG is absent, priority over DEBUG option */
+                        !NtLdrGetOption(BootOptions, "CRASHDEBUG") && /* CRASHDEBUG is abset, no wait during the boot */
+                        !!NtLdrGetOption(BootOptions, "DEBUG"); /* DEBUG is present */
+    if (DebugMode)
+    {
+        /* It is booting in debug mode */
+        TuiPrintf("Booting in debug mode\n");
+
+        /* Check whether there is a DEBUGPORT option */
+        PCSTR DebugPort;
+        ULONG DebugPortLength;
+        DebugPort = NtLdrGetOptionEx(BootOptions, "DEBUGPORT=", &DebugPortLength);
+        if (DebugPort && (DebugPortLength > 10))
+        {
+            /* Show the debug port */
+            DebugPort += 10;
+            DebugPortLength -= 10;
+            TuiPrintf("You would need a debugger attached to the %.*s port to continue.\n", DebugPortLength, DebugPort);
+        }
+        TuiPrintf("For more information, visit https://reactos.org/wiki/Debugging.\n");
+    }
+
     /* Debugging... */
     //DumpMemoryAllocMap();
 

--- a/boot/freeldr/freeldr/ntldr/winldr.c
+++ b/boot/freeldr/freeldr/ntldr/winldr.c
@@ -1257,21 +1257,25 @@ LoadAndBootWindowsCommon(
         !NtLdrGetOption(BootOptions, "NODEBUG") &&
         NtLdrGetOption(BootOptions, "DEBUG"))
     {
-        /* It is booting in debug mode */
-        TuiPrintf("Booting in debug mode\n");
-
         /* Check whether there is a DEBUGPORT option */
         PCSTR DebugPort;
-        ULONG DebugPortLength;
+        ULONG DebugPortLength = 0;
         DebugPort = NtLdrGetOptionEx(BootOptions, "DEBUGPORT=", &DebugPortLength);
-        if (DebugPort && (DebugPortLength > 10))
+        if (DebugPort != NULL && DebugPortLength > 10)
         {
-            /* Show the debug port */
-            DebugPort += 10;
-            DebugPortLength -= 10;
-            TuiPrintf("You would need a debugger attached to the %.*s port to continue.\n", DebugPortLength, DebugPort);
+            /* Move to the debug port name */
+            DebugPort += 10; DebugPortLength -= 10;
         }
-        TuiPrintf("For more information, visit https://reactos.org/wiki/Debugging.\n");
+        else
+        {
+            /* Default to COM */
+            DebugPort = "COM"; DebugPortLength = 3;
+        }
+
+        /* It is booting in debug mode, show the banner */
+        TuiPrintf("You need to connect a debugger on port %.*s\n"
+                  "For more information, visit https://reactos.org/wiki/Debugging.\n",
+                  DebugPortLength, DebugPort);
     }
 
     /* Debugging... */

--- a/boot/freeldr/freeldr/ntldr/winldr.c
+++ b/boot/freeldr/freeldr/ntldr/winldr.c
@@ -1255,7 +1255,7 @@ LoadAndBootWindowsCommon(
     /* Match KdInitSystem() conditions */
     if (!NtLdrGetOption(BootOptions, "CRASHDEBUG") &&
         !NtLdrGetOption(BootOptions, "NODEBUG") &&
-        NtLdrGetOption(BootOptions, "DEBUG"))
+        !!NtLdrGetOption(BootOptions, "DEBUG"))
     {
         /* Check whether there is a DEBUGPORT option */
         PCSTR DebugPort;

--- a/boot/freeldr/freeldr/ntldr/winldr.c
+++ b/boot/freeldr/freeldr/ntldr/winldr.c
@@ -1252,10 +1252,10 @@ LoadAndBootWindowsCommon(
     MachPrepareForReactOS();
 
     /* Show the "debug mode" notice if needed */
-    BOOLEAN DebugMode = !NtLdrGetOption(BootOptions, "NODEBUG") && /* NODEBUG is absent, priority over DEBUG option */
-                        !NtLdrGetOption(BootOptions, "CRASHDEBUG") && /* CRASHDEBUG is abset, no wait during the boot */
-                        !!NtLdrGetOption(BootOptions, "DEBUG"); /* DEBUG is present */
-    if (DebugMode)
+    /* Match KdInitSystem() conditions */
+    if (!NtLdrGetOption(BootOptions, "CRASHDEBUG") &&
+        !NtLdrGetOption(BootOptions, "NODEBUG") &&
+        NtLdrGetOption(BootOptions, "DEBUG"))
     {
         /* It is booting in debug mode */
         TuiPrintf("Booting in debug mode\n");


### PR DESCRIPTION
## Purpose

This PR makes FreeLoader print a notice message before it passes the control to the kernel, if boot option `/DEBUG` is provided.

I'm doing this because people (like me😅) can forget that they're booting in debug mode and they need to attach a debugger for boot process to continue. 

JIRA issue: None

Screenshot:

https://github.com/user-attachments/assets/67f6cc16-2276-475a-a8b5-63f29fe881d2

## Proposed changes

* Check for absence of `NODEBUG` and `CRASHDEBUG` options and presence of `DEBUG` option
* Use `TuiPrintf` to print the notice message if the check passed
* I tried to use `#if KDBG` to exclude the code from compilation if KDBG support is not enabled, but seems like KDBG is not defined in Free Loader even when it's enabled in the kernel. I tried to use the CMake code included in NTOSKRNL's CMakeLists but still it didn't work.
