### PR TITLE
[SHELL32][SHDOCVW] Only forward menu messages to the correct shell extension

### DIFF
--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -141,15 +141,15 @@ struct MenuCleanup
     }
     ~MenuCleanup()
     {
-        if (m_hMenu)
-        {
-            DestroyMenu(m_hMenu);
-            m_hMenu = NULL;
-        }
         if (m_pCM)
         {
             IUnknown_SetSite(m_pCM, NULL);
             m_pCM.Release();
+        }
+        if (m_hMenu)
+        {
+            DestroyMenu(m_hMenu);
+            m_hMenu = NULL;
         }
     }
 };
@@ -497,7 +497,7 @@ public:
     LRESULT OnNotify(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
     LRESULT OnChangeNotify(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
     LRESULT OnUpdateStatusbar(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
-    LRESULT OnCustomItem(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
+    LRESULT OnMenuMessage(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
     LRESULT OnSettingChange(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
     LRESULT OnInitMenuPopup(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
     LRESULT OnChangeCBChain(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
@@ -548,8 +548,8 @@ public:
     MESSAGE_HANDLER(SHV_CHANGE_NOTIFY, OnChangeNotify)
     MESSAGE_HANDLER(SHV_UPDATESTATUSBAR, OnUpdateStatusbar)
     MESSAGE_HANDLER(WM_CONTEXTMENU, OnContextMenu)
-    MESSAGE_HANDLER(WM_DRAWITEM, OnCustomItem)
-    MESSAGE_HANDLER(WM_MEASUREITEM, OnCustomItem)
+    MESSAGE_HANDLER(WM_DRAWITEM, OnMenuMessage)
+    MESSAGE_HANDLER(WM_MEASUREITEM, OnMenuMessage)
     MESSAGE_HANDLER(WM_SHOWWINDOW, OnShowWindow)
     MESSAGE_HANDLER(WM_GETDLGCODE, OnGetDlgCode)
     MESSAGE_HANDLER(WM_DESTROY, OnDestroy)
@@ -3009,10 +3009,7 @@ LRESULT CDefView::OnChangeNotify(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &
     return TRUE;
 }
 
-HRESULT SHGetMenuIdFromMenuMsg(UINT uMsg, LPARAM lParam, UINT *CmdId);
-HRESULT SHSetMenuIdInMenuMsg(UINT uMsg, LPARAM lParam, UINT CmdId);
-
-LRESULT CDefView::OnCustomItem(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled)
+LRESULT CDefView::OnMenuMessage(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled)
 {
     if (!m_pCM)
     {
@@ -3020,19 +3017,9 @@ LRESULT CDefView::OnCustomItem(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bH
         ERR("no context menu\n");
         return FALSE;
     }
-
-    // lParam of WM_DRAWITEM WM_MEASUREITEM contains a menu id and
-    // this also needs to be changed to a menu identifier offset
-    UINT CmdID;
-    HRESULT hres = SHGetMenuIdFromMenuMsg(uMsg, lParam, &CmdID);
-    if (SUCCEEDED(hres))
-        SHSetMenuIdInMenuMsg(uMsg, lParam, CmdID - CONTEXT_MENU_BASE_ID);
-
-    /* Forward the message to the IContextMenu2 */
-    LRESULT result;
-    hres = SHForwardContextMenuMsg(m_pCM, uMsg, wParam, lParam, &result, TRUE);
-
-    return (SUCCEEDED(hres));
+    LRESULT result = 0;
+    HRESULT hres = SHForwardContextMenuMsg(m_pCM, uMsg, wParam, lParam, &result, TRUE);
+    return SUCCEEDED(hres);
 }
 
 LRESULT CDefView::OnSettingChange(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled)
@@ -3052,7 +3039,7 @@ LRESULT CDefView::OnInitMenuPopup(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL 
     UINT  menuItemId;
 
     if (m_pCM)
-        OnCustomItem(uMsg, wParam, lParam, bHandled);
+        OnMenuMessage(uMsg, wParam, lParam, bHandled);
 
     HMENU hViewMenu = GetSubmenuByID(m_hMenu, FCIDM_MENU_VIEW);
 

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -3036,8 +3036,10 @@ LRESULT CDefView::OnInitMenuPopup(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL 
 {
     HMENU hmenu = (HMENU) wParam;
     int nPos = LOWORD(lParam);
-    UINT  menuItemId;
+    UINT menuItemId;
 
+    if (m_isEditing)
+        ListView_CancelEditLabel(m_ListView);
     if (m_pCM)
         OnMenuMessage(uMsg, wParam, lParam, bHandled);
 

--- a/dll/win32/shell32/CDefaultContextMenu.cpp
+++ b/dll/win32/shell32/CDefaultContextMenu.cpp
@@ -157,6 +157,7 @@ class CDefaultContextMenu :
         UINT m_cKeys;
         PIDLIST_ABSOLUTE m_pidlFolder;
         DWORD m_bGroupPolicyActive;
+        UINT m_iIdQCMFirst;
         CAtlList<DynamicShellEntry> m_DynamicEntries;
         UINT m_iIdSHEFirst; /* first used id */
         UINT m_iIdSHELast; /* last used id */
@@ -244,6 +245,7 @@ CDefaultContextMenu::CDefaultContextMenu() :
     m_cKeys(NULL),
     m_pidlFolder(NULL),
     m_bGroupPolicyActive(0),
+    m_iIdQCMFirst(0),
     m_iIdSHEFirst(0),
     m_iIdSHELast(0),
     m_iIdSCMFirst(0),
@@ -840,6 +842,7 @@ CDefaultContextMenu::QueryContextMenu(
     UINT idCmdLast,
     UINT uFlags)
 {
+    m_iIdQCMFirst = idCmdFirst;
     HRESULT hr;
     UINT idCmdNext = idCmdFirst;
     UINT cIds = 0;
@@ -1536,7 +1539,6 @@ CDefaultContextMenu::InvokeCommand(
         else
             return E_INVALIDARG;
     }
-
     CmdId = LOWORD(LocalInvokeInfo.lpVerb);
 
     if (!m_DynamicEntries.IsEmpty() && CmdId >= m_iIdSHEFirst && CmdId < m_iIdSHELast)
@@ -1726,8 +1728,7 @@ CDefaultContextMenu::HandleMenuMsg(
     WPARAM wParam,
     LPARAM lParam)
 {
-    /* FIXME: Should we implement this as well? */
-    return S_OK;
+    return HandleMenuMsg2(uMsg, wParam, lParam, NULL);
 }
 
 HRESULT SHGetMenuIdFromMenuMsg(UINT uMsg, LPARAM lParam, UINT *CmdId)
@@ -1744,25 +1745,6 @@ HRESULT SHGetMenuIdFromMenuMsg(UINT uMsg, LPARAM lParam, UINT *CmdId)
         *CmdId = pMeasureStruct->itemID;
         return S_OK;
     }
-
-    return E_FAIL;
-}
-
-HRESULT SHSetMenuIdInMenuMsg(UINT uMsg, LPARAM lParam, UINT CmdId)
-{
-    if (uMsg == WM_DRAWITEM)
-    {
-        DRAWITEMSTRUCT* pDrawStruct = reinterpret_cast<DRAWITEMSTRUCT*>(lParam);
-        pDrawStruct->itemID = CmdId;
-        return S_OK;
-    }
-    else if (uMsg == WM_MEASUREITEM)
-    {
-        MEASUREITEMSTRUCT* pMeasureStruct = reinterpret_cast<MEASUREITEMSTRUCT*>(lParam);
-        pMeasureStruct->itemID = CmdId;
-        return S_OK;
-    }
-
     return E_FAIL;
 }
 
@@ -1774,34 +1756,31 @@ CDefaultContextMenu::HandleMenuMsg2(
     LPARAM lParam,
     LRESULT *plResult)
 {
-    if (uMsg == WM_INITMENUPOPUP)
-    {
-        POSITION it = m_DynamicEntries.GetHeadPosition();
-        while (it != NULL)
-        {
-            DynamicShellEntry& info = m_DynamicEntries.GetNext(it);
-            SHForwardContextMenuMsg(info.pCM, uMsg, wParam, lParam, plResult, TRUE);
-        }
-        return S_OK;
-    }
+    if (!SHELL_IsContextMenuMsg(uMsg))
+        return E_FAIL;
 
     UINT CmdId;
-    HRESULT hr = SHGetMenuIdFromMenuMsg(uMsg, lParam, &CmdId);
-    if (FAILED(hr))
-        return S_FALSE;
-
-    if (CmdId < m_iIdSHEFirst || CmdId >= m_iIdSHELast)
-        return S_FALSE;
-
-    CmdId -= m_iIdSHEFirst;
-    PDynamicShellEntry pEntry = GetDynamicEntry(CmdId);
-    if (pEntry)
+    if (uMsg == WM_INITMENUPOPUP)
     {
-        SHSetMenuIdInMenuMsg(uMsg, lParam, CmdId - pEntry->iIdCmdFirst);
-        SHForwardContextMenuMsg(pEntry->pCM, uMsg, wParam, lParam, plResult, TRUE);
+        CmdId = GetMenuItemID((HMENU)wParam, 0);
+        if (CmdId == ~0ul)
+            return E_FAIL;
     }
+    else
+    {
+        HRESULT hr = SHGetMenuIdFromMenuMsg(uMsg, lParam, &CmdId);
+        if (FAILED(hr))
+            return S_FALSE;
+    }
+    CmdId -= m_iIdQCMFirst; // Convert from Win32 id to our base
 
-   return S_OK;
+    if (CmdId >= m_iIdSHEFirst && CmdId < m_iIdSHELast)
+    {
+        if (PDynamicShellEntry pEntry = GetDynamicEntry(CmdId - m_iIdSHEFirst))
+            return SHForwardContextMenuMsg(pEntry->pCM, uMsg, wParam, lParam, plResult, TRUE);
+    }
+    // TODO: m_pmcb
+    return E_FAIL;
 }
 
 HRESULT

--- a/dll/win32/shell32/CDefaultContextMenu.cpp
+++ b/dll/win32/shell32/CDefaultContextMenu.cpp
@@ -157,7 +157,7 @@ class CDefaultContextMenu :
         UINT m_cKeys;
         PIDLIST_ABSOLUTE m_pidlFolder;
         DWORD m_bGroupPolicyActive;
-        UINT m_iIdQCMFirst;
+        UINT m_iIdQCMFirst; /* The first id passed to us in QueryContextMenu */
         CAtlList<DynamicShellEntry> m_DynamicEntries;
         UINT m_iIdSHEFirst; /* first used id */
         UINT m_iIdSHELast; /* last used id */
@@ -842,9 +842,8 @@ CDefaultContextMenu::QueryContextMenu(
     UINT idCmdLast,
     UINT uFlags)
 {
-    m_iIdQCMFirst = idCmdFirst;
     HRESULT hr;
-    UINT idCmdNext = idCmdFirst;
+    UINT idCmdNext = m_iIdQCMFirst = idCmdFirst;
     UINT cIds = 0;
 
     TRACE("BuildShellItemContextMenu entered\n");
@@ -1779,7 +1778,7 @@ CDefaultContextMenu::HandleMenuMsg2(
         if (PDynamicShellEntry pEntry = GetDynamicEntry(CmdId - m_iIdSHEFirst))
             return SHForwardContextMenuMsg(pEntry->pCM, uMsg, wParam, lParam, plResult, TRUE);
     }
-    // TODO: m_pmcb
+    // TODO: _DoCallback(DFM_WM_*, ...)
     return E_FAIL;
 }
 

--- a/dll/win32/shell32/CNewMenu.cpp
+++ b/dll/win32/shell32/CNewMenu.cpp
@@ -704,7 +704,7 @@ HRESULT
 WINAPI
 CNewMenu::HandleMenuMsg(UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-    return S_OK;
+    return HandleMenuMsg2(uMsg, wParam, lParam, NULL);
 }
 
 HRESULT
@@ -734,19 +734,19 @@ CNewMenu::HandleMenuMsg2(UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT *plRes
             if (!lpdis || lpdis->CtlType != ODT_MENU)
                 break;
 
-            DWORD id = LOWORD(lpdis->itemID);
+            DWORD id = lpdis->itemID;
             HICON hIcon = NULL;
-            if (m_idCmdFirst + id == m_idCmdFolder)
+            if (id == m_idCmdFolder)
             {
                 hIcon = m_hIconFolder;
             }
-            else if (m_idCmdFirst + id == m_idCmdLink)
+            else if (id == m_idCmdLink)
             {
                 hIcon = m_hIconLink;
             }
             else
             {
-                SHELLNEW_ITEM *pItem = FindItemFromIdOffset(id);
+                SHELLNEW_ITEM *pItem = FindItemFromIdOffset(id - m_idCmdFirst);
                 if (pItem)
                     hIcon = pItem->hIcon;
             }

--- a/dll/win32/shell32/brfolder.cpp
+++ b/dll/win32/shell32/brfolder.cpp
@@ -1337,7 +1337,7 @@ BrFolderDlgProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
     if (!info)
         return 0;
 
-    if (info->pContextMenu)
+    if (info->pContextMenu && SHELL_IsContextMenuMsg(uMsg))
     {
         LRESULT result;
         if (SHForwardContextMenuMsg(info->pContextMenu, uMsg, wParam,

--- a/dll/win32/shlwapi/rosordinal.c
+++ b/dll/win32/shlwapi/rosordinal.c
@@ -15,6 +15,9 @@ HRESULT WINAPI SHForwardContextMenuMsg(IUnknown* pUnk, UINT uMsg, WPARAM wParam,
     IContextMenu3* pcmenu3;
     IContextMenu2* pcmenu2;
 
+    if (!pUnk)
+        return E_FAIL;
+
     /* First try to use the IContextMenu3 interface */
     hr = IUnknown_QueryInterface(pUnk, &IID_IContextMenu3, (void**)&pcmenu3);
     if (SUCCEEDED(hr))
@@ -35,7 +38,9 @@ HRESULT WINAPI SHForwardContextMenuMsg(IUnknown* pUnk, UINT uMsg, WPARAM wParam,
 
     hr = IContextMenu2_HandleMenuMsg(pcmenu2, uMsg, wParam, lParam);
     IContextMenu2_Release(pcmenu2);
-    return hr;
+    if (pResult)
+        *pResult = 0;
+    return hr == S_OK ? S_FALSE : hr;
 }
 
 /* http://undoc.airesoft.co.uk/shlwapi.dll/SHAreIconsEqual.php */

--- a/sdk/include/reactos/shellutils.h
+++ b/sdk/include/reactos/shellutils.h
@@ -635,6 +635,12 @@ typedef CCoInitBase<OleInitialize, OleUninitialize> COleInit;
 #define SEE_CMIC_COMMON_FLAGS      (SEE_CMIC_COMMON_BASICFLAGS | SEE_MASK_HOTKEY | SEE_MASK_ICON | \
                                     SEE_MASK_HASLINKNAME | SEE_MASK_HASTITLE)
 
+static inline BOOL SHELL_IsContextMenuMsg(UINT uMsg)
+{
+    return uMsg == WM_MEASUREITEM || uMsg == WM_DRAWITEM ||
+           uMsg == WM_INITMENUPOPUP || uMsg == WM_MENUSELECT || uMsg == WM_MENUCHAR;
+}
+
 static inline BOOL ILIsSingle(LPCITEMIDLIST pidl)
 {
     return pidl == ILFindLastID(pidl);


### PR DESCRIPTION
* Folder Marker 1.4 fails if it gets a `WM_INITPOPUPMENU` it does not expect.
* Owner-draw messages must be forwarded by the window hosting `IContextMenu`.

JIRA issue: [CORE-17811](https://jira.reactos.org/browse/CORE-17811)

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: