### PR TITLE
[COMCTL32] Fix StatusBar left border frame missing

### DIFF
--- a/dll/win32/comctl32/commctrl.c
+++ b/dll/win32/comctl32/commctrl.c
@@ -686,7 +686,11 @@ void WINAPI DrawStatusTextW (HDC hdc, LPCRECT lprc, LPCWSTR text, UINT style)
         border = 0;
 
     oldbkcolor = SetBkColor (hdc, comctl32_color.clrBtnFace);
+#ifdef __REACTOS__
+    DrawEdge (hdc, &r, border, BF_RECT|BF_ADJUST);
+#else
     DrawEdge (hdc, &r, border, BF_MIDDLE|BF_RECT|BF_ADJUST);
+#endif
 
     /* now draw text */
     if (text) {

--- a/dll/win32/comctl32/commctrl.c
+++ b/dll/win32/comctl32/commctrl.c
@@ -686,7 +686,7 @@ void WINAPI DrawStatusTextW (HDC hdc, LPCRECT lprc, LPCWSTR text, UINT style)
         border = 0;
 
     oldbkcolor = SetBkColor (hdc, comctl32_color.clrBtnFace);
-#ifdef __REACTOS__
+#ifdef __REACTOS__ // HACK for CORE-19854.
     DrawEdge (hdc, &r, border, BF_RECT|BF_ADJUST);
 #else
     DrawEdge (hdc, &r, border, BF_MIDDLE|BF_RECT|BF_ADJUST);


### PR DESCRIPTION
## Purpose

_Fix regression of missing left border of some text as shown in Explorer._

JIRA issue: [CORE-19854](https://jira.reactos.org/browse/CORE-19854)

## Proposed changes

_Remove flag BF_MIDDLE from DrawEdge function._

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64:

Before: 

![commctl-bad](https://github.com/user-attachments/assets/3cd7a19b-1fb9-4a85-8805-c3942ab9894e)

After:

![commctl-OK](https://github.com/user-attachments/assets/851282e8-261a-4479-87f8-133d14b3eab2)
