### PR TITLE
[BROWSEUI] Fix 'bad window handle' on CShellBrowser::RepositionBars

### DIFF
--- a/dll/win32/browseui/shellbrowser.cpp
+++ b/dll/win32/browseui/shellbrowser.cpp
@@ -1617,6 +1617,10 @@ void CShellBrowser::RepositionBars()
             }
         }
     }
+
+    if (!fCurrentShellViewWindow)
+        return;
+
     ::SetWindowPos(fCurrentShellViewWindow, NULL, clientRect.left, clientRect.top,
                         clientRect.right - clientRect.left,
                         clientRect.bottom - clientRect.top, SWP_NOOWNERZORDER | SWP_NOZORDER);


### PR DESCRIPTION
## Purpose
Silence `"NtUserSetWindowPos bad window handle!"` error at `win32k!NtUserSetWindowPos` function when Desktop has started up.
JIRA issue: [CORE-19663](https://jira.reactos.org/browse/CORE-19663)

## Proposed changes

- Add null check of window handle before `SetWindowPos` call in `CShellBrowser::RepositionBars` method.
