### PR TITLE
[IMM32] Don't use IS_ERROR_UNEXPECTEDLY

### DIFF
--- a/dll/win32/imm32/imm.c
+++ b/dll/win32/imm32/imm.c
@@ -88,8 +88,11 @@ BOOL WINAPI ImmLoadLayout(HKL hKL, PIMEINFOEX pImeInfoEx)
 
     /* Open the key */
     error = RegOpenKeyExW(HKEY_LOCAL_MACHINE, pszSubKey, 0, KEY_READ, &hKey);
-    if (IS_ERROR_UNEXPECTEDLY(error))
+    if (error)
+    {
+        ERR("error: %ld\n", error);
         return FALSE;
+    }
 
     /* Load "IME File" value */
     cbData = sizeof(pImeInfoEx->wszImeFile);

--- a/dll/win32/imm32/precomp.h
+++ b/dll/win32/imm32/precomp.h
@@ -59,14 +59,11 @@
         (!(p) ? (ERR("%s was zero\n", #p), UNEXPECTED()) : FALSE)
     #define IS_TRUE_UNEXPECTEDLY(x) \
         ((x) ? (ERR("%s was %d\n", #x, (int)(x)), UNEXPECTED()) : FALSE)
-    #define IS_ERROR_UNEXPECTEDLY(x) \
-        ((x) != ERROR_SUCCESS ? (ERR("%s was %d\n", #x, (int)(x)), UNEXPECTED()) : FALSE)
 #else
     #define FAILED_UNEXPECTEDLY(hr) FAILED(hr)
     #define IS_NULL_UNEXPECTEDLY(p) (!(p))
     #define IS_ZERO_UNEXPECTEDLY(p) (!(p))
     #define IS_TRUE_UNEXPECTEDLY(x) (x)
-    #define IS_ERROR_UNEXPECTEDLY(x) ((x) != ERROR_SUCCESS)
 #endif
 
 #define IS_CROSS_THREAD_HIMC(hIMC)   IS_TRUE_UNEXPECTEDLY(Imm32IsCrossThreadAccess(hIMC))

--- a/dll/win32/imm32/utils.c
+++ b/dll/win32/imm32/utils.c
@@ -906,8 +906,11 @@ UINT APIENTRY Imm32GetImeLayout(PREG_IME pLayouts, UINT cLayouts)
 
     /* Open the registry keyboard layouts */
     lError = RegOpenKeyW(HKEY_LOCAL_MACHINE, REGKEY_KEYBOARD_LAYOUTS, &hkeyLayouts);
-    if (IS_ERROR_UNEXPECTEDLY(lError))
+    if (lError)
+    {
+        ERR("error: %ld\n", lError);
         return 0;
+    }
 
     for (iKey = nCount = 0; ; ++iKey)
     {
@@ -929,8 +932,11 @@ UINT APIENTRY Imm32GetImeLayout(PREG_IME pLayouts, UINT cLayouts)
             break;
 
         lError = RegOpenKeyW(hkeyLayouts, szImeKey, &hkeyIME); /* Open the IME key */
-        if (IS_ERROR_UNEXPECTEDLY(lError))
+        if (lError)
+        {
+            ERR("error: %ld\n", lError);
             continue;
+        }
 
         /* Load the "Ime File" value */
         szImeFileName[0] = 0;
@@ -981,28 +987,40 @@ BOOL APIENTRY Imm32WriteImeLayout(HKL hKL, LPCWSTR pchFilePart, LPCWSTR pszLayou
 
     /* Open the registry keyboard layouts */
     lError = RegOpenKeyW(HKEY_LOCAL_MACHINE, REGKEY_KEYBOARD_LAYOUTS, &hkeyLayouts);
-    if (IS_ERROR_UNEXPECTEDLY(lError))
+    if (lError)
+    {
+        ERR("error: %ld\n", lError);
         return FALSE;
+    }
 
     /* Get the IME key from hKL */
     StringCchPrintf(szImeKey, _countof(szImeKey), L"%08X", HandleToUlong(hKL));
 
     /* Create a registry IME key */
     lError = RegCreateKeyW(hkeyLayouts, szImeKey, &hkeyIME);
-    if (IS_ERROR_UNEXPECTEDLY(lError))
+    if (lError)
+    {
+        ERR("error: %ld\n", lError);
         goto Failure;
+    }
 
     /* Write "Ime File" */
     cbData = (wcslen(pchFilePart) + 1) * sizeof(WCHAR);
     lError = RegSetValueExW(hkeyIME, L"Ime File", 0, REG_SZ, (LPBYTE)pchFilePart, cbData);
-    if (IS_ERROR_UNEXPECTEDLY(lError))
+    if (lError)
+    {
+        ERR("error: %ld\n", lError);
         goto Failure;
+    }
 
     /* Write "Layout Text" */
     cbData = (wcslen(pszLayoutText) + 1) * sizeof(WCHAR);
     lError = RegSetValueExW(hkeyIME, L"Layout Text", 0, REG_SZ, (LPBYTE)pszLayoutText, cbData);
-    if (IS_ERROR_UNEXPECTEDLY(lError))
+    if (lError)
+    {
+        ERR("error: %ld\n", lError);
         goto Failure;
+    }
 
     /* Choose "Layout File" from hKL */
     LangID = LOWORD(hKL);
@@ -1016,8 +1034,11 @@ BOOL APIENTRY Imm32WriteImeLayout(HKL hKL, LPCWSTR pchFilePart, LPCWSTR pszLayou
     /* Write "Layout File" */
     cbData = (wcslen(pszLayoutFile) + 1) * sizeof(WCHAR);
     lError = RegSetValueExW(hkeyIME, L"Layout File", 0, REG_SZ, (LPBYTE)pszLayoutFile, cbData);
-    if (IS_ERROR_UNEXPECTEDLY(lError))
+    if (lError)
+    {
+        ERR("error: %ld\n", lError);
         goto Failure;
+    }
 
     RegCloseKey(hkeyIME);
     RegCloseKey(hkeyLayouts);


### PR DESCRIPTION
## Purpose

`IS_ERROR_UNEXPECTEDLY` macro is not compatible to Wine. Don't use it.
JIRA issue: [CORE-19268](https://jira.reactos.org/browse/CORE-19268)

## Proposed changes

- Delete `IS_ERROR_UNEXPECTEDLY` macro definition and usages.