### PR TITLE
[IMM32] Don't use IS_NULL_UNEXPECTEDLY

### DIFF
--- a/dll/win32/imm32/candidate.c
+++ b/dll/win32/imm32/candidate.c
@@ -438,7 +438,6 @@ BOOL WINAPI ImmSetCandidateWindow(HIMC hIMC, LPCANDIDATEFORM lpCandidate)
 
     if (IS_CROSS_THREAD_HIMC(hIMC))
         return FALSE;
-    }
 
     pIC = ImmLockIMC(hIMC);
     if (!pIC)

--- a/dll/win32/imm32/candidate.c
+++ b/dll/win32/imm32/candidate.c
@@ -161,20 +161,25 @@ ImmGetCandidateListAW(HIMC hIMC, DWORD dwIndex, LPCANDIDATELIST lpCandList, DWOR
     LPCANDIDATELIST pCL;
 
     pClientImc = ImmLockClientImc(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pClientImc))
+    if (!pClientImc)
+    {
+        ERR("!pClientImc\n");
         return 0;
+    }
 
     uCodePage = pClientImc->uCodePage;
     pIC = ImmLockIMC(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pIC))
+    if (!pIC)
     {
+        ERR("!pIC\n");
         ImmUnlockClientImc(pClientImc);
         return 0;
     }
 
     pCI = ImmLockIMCC(pIC->hCandInfo);
-    if (IS_NULL_UNEXPECTEDLY(pCI))
+    if (!pCI)
     {
+        ERR("!pCI\n");
         ImmUnlockIMC(hIMC);
         ImmUnlockClientImc(pClientImc);
         return 0;
@@ -254,18 +259,25 @@ ImmGetCandidateListCountAW(HIMC hIMC, LPDWORD lpdwListCount, BOOL bAnsi)
     const CANDIDATELIST *pCL;
     const DWORD *pdwOffsets;
 
-    if (IS_NULL_UNEXPECTEDLY(lpdwListCount))
+    if (!lpdwListCount)
+    {
+        ERR("!lpdwListCount\n");
         return 0;
+    }
 
     *lpdwListCount = 0;
 
     pClientImc = ImmLockClientImc(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pClientImc))
+    if (!pClientImc)
+    {
+        ERR("!pClientImc\n");
         return 0;
+    }
 
     pIC = ImmLockIMC(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pIC))
+    if (!pIC)
     {
+        ERR("!pIC\n");
         ImmUnlockClientImc(pClientImc);
         return 0;
     }
@@ -273,8 +285,9 @@ ImmGetCandidateListCountAW(HIMC hIMC, LPDWORD lpdwListCount, BOOL bAnsi)
     uCodePage = pClientImc->uCodePage;
 
     pCI = ImmLockIMCC(pIC->hCandInfo);
-    if (IS_NULL_UNEXPECTEDLY(pCI))
+    if (!pCI)
     {
+        ERR("!pCI\n");
         ImmUnlockIMC(hIMC);
         ImmUnlockClientImc(pClientImc);
         return 0;
@@ -389,8 +402,11 @@ ImmGetCandidateWindow(HIMC hIMC, DWORD dwIndex, LPCANDIDATEFORM lpCandidate)
     }
 
     pIC = ImmLockIMC(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pIC))
+    if (!pIC)
+    {
+        ERR("!pIC\n");
         return FALSE;
+    }
 
     pCF = &pIC->cfCandForm[dwIndex];
     if (pCF->dwIndex != IMM_INVALID_CANDFORM)
@@ -420,12 +436,18 @@ BOOL WINAPI ImmSetCandidateWindow(HIMC hIMC, LPCANDIDATEFORM lpCandidate)
         return FALSE;
     }
 
-    if (IS_CROSS_THREAD_HIMC(hIMC))
+    if (!hIMC)
+    {
+        ERR("!hIMC\n");
         return FALSE;
+    }
 
     pIC = ImmLockIMC(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pIC))
+    if (!pIC)
+    {
+        ERR("!pIC\n");
         return FALSE;
+    }
 
     hWnd = pIC->hWnd;
     pIC->cfCandForm[lpCandidate->dwIndex] = *lpCandidate;

--- a/dll/win32/imm32/candidate.c
+++ b/dll/win32/imm32/candidate.c
@@ -438,7 +438,6 @@ BOOL WINAPI ImmSetCandidateWindow(HIMC hIMC, LPCANDIDATEFORM lpCandidate)
 
     if (IS_CROSS_THREAD_HIMC(hIMC))
     {
-        ERR("!hIMC\n");
         return FALSE;
     }
 

--- a/dll/win32/imm32/candidate.c
+++ b/dll/win32/imm32/candidate.c
@@ -436,7 +436,7 @@ BOOL WINAPI ImmSetCandidateWindow(HIMC hIMC, LPCANDIDATEFORM lpCandidate)
         return FALSE;
     }
 
-    if (!hIMC)
+    if (IS_CROSS_THREAD_HIMC(hIMC))
     {
         ERR("!hIMC\n");
         return FALSE;

--- a/dll/win32/imm32/candidate.c
+++ b/dll/win32/imm32/candidate.c
@@ -437,7 +437,6 @@ BOOL WINAPI ImmSetCandidateWindow(HIMC hIMC, LPCANDIDATEFORM lpCandidate)
     }
 
     if (IS_CROSS_THREAD_HIMC(hIMC))
-    {
         return FALSE;
     }
 

--- a/dll/win32/imm32/compstr.c
+++ b/dll/win32/imm32/compstr.c
@@ -23,12 +23,16 @@ Imm32OpenICAndCS(HIMC hIMC, LPINPUTCONTEXT *ppIC, LPCOMPOSITIONSTRING *ppCS)
     *ppCS = NULL;
 
     pIC = ImmLockIMC(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pIC))
+    if (!pIC)
+    {
+        ERR("!pIC\n");
         return FALSE;
+    }
 
     pCS = ImmLockIMCC(pIC->hCompStr);
-    if (IS_NULL_UNEXPECTEDLY(pCS))
+    if (!pCS)
     {
+        ERR("!pCS\n");
         ImmUnlockIMC(hIMC);
         return FALSE;
     }
@@ -539,8 +543,11 @@ ImmSetCompositionStringAW(HIMC hIMC, DWORD dwIndex, LPVOID pComp, DWORD dwCompLe
 
     hKL = GetKeyboardLayout(dwThreadId);
     pImeDpi = ImmLockImeDpi(hKL);
-    if (IS_NULL_UNEXPECTEDLY(pImeDpi))
+    if (!pImeDpi)
+    {
+        ERR("!pImeDpi\n");
         return FALSE;
+    }
 
     uCodePage = pImeDpi->uCodePage;
     bAnsiClient = !ImeDpi_IsUnicode(pImeDpi);
@@ -590,8 +597,11 @@ ImmSetCompositionStringAW(HIMC hIMC, DWORD dwIndex, LPVOID pComp, DWORD dwCompLe
                 {
                     cbCompNew = Imm32CompStrWideToAnsi(pComp, dwCompLen, NULL, 0, uCodePage);
                     pCompNew = ImmLocalAlloc(0, cbCompNew);
-                    if (IS_NULL_UNEXPECTEDLY(pCompNew))
+                    if (!pCompNew)
+                    {
+                        ERR("!pCompNew\n");
                         goto Quit;
+                    }
 
                     Imm32CompStrWideToAnsi(pComp, dwCompLen, pCompNew, cbCompNew, uCodePage);
                 }
@@ -599,8 +609,11 @@ ImmSetCompositionStringAW(HIMC hIMC, DWORD dwIndex, LPVOID pComp, DWORD dwCompLe
                 {
                     cbCompNew = Imm32CompStrAnsiToWide(pComp, dwCompLen, NULL, 0, uCodePage);
                     pCompNew = ImmLocalAlloc(0, cbCompNew);
-                    if (IS_NULL_UNEXPECTEDLY(pCompNew))
+                    if (!pCompNew)
+                    {
+                        ERR("!pCompNew\n");
                         goto Quit;
+                    }
 
                     Imm32CompStrAnsiToWide(pComp, dwCompLen, pCompNew, cbCompNew, uCodePage);
                 }
@@ -612,8 +625,11 @@ ImmSetCompositionStringAW(HIMC hIMC, DWORD dwIndex, LPVOID pComp, DWORD dwCompLe
                 {
                     cbReadNew = Imm32CompStrWideToAnsi(pRead, dwReadLen, NULL, 0, uCodePage);
                     pReadNew = ImmLocalAlloc(0, cbReadNew);
-                    if (IS_NULL_UNEXPECTEDLY(pReadNew))
+                    if (!pReadNew)
+                    {
+                        ERR("!pReadNew\n");
                         goto Quit;
+                    }
 
                     Imm32CompStrWideToAnsi(pRead, dwReadLen, pReadNew, cbReadNew, uCodePage);
                 }
@@ -621,8 +637,11 @@ ImmSetCompositionStringAW(HIMC hIMC, DWORD dwIndex, LPVOID pComp, DWORD dwCompLe
                 {
                     cbReadNew = Imm32CompStrAnsiToWide(pRead, dwReadLen, NULL, 0, uCodePage);
                     pReadNew = ImmLocalAlloc(0, cbReadNew);
-                    if (IS_NULL_UNEXPECTEDLY(pReadNew))
+                    if (!pReadNew)
+                    {
+                        ERR("!pReadNew\n");
                         goto Quit;
+                    }
 
                     Imm32CompStrAnsiToWide(pRead, dwReadLen, pReadNew, cbReadNew, uCodePage);
                 }
@@ -639,8 +658,11 @@ ImmSetCompositionStringAW(HIMC hIMC, DWORD dwIndex, LPVOID pComp, DWORD dwCompLe
                                                         CS_SizeW(pCS, CompStr),
                                                         NULL, 0, uCodePage);
                     pCompNew = ImmLocalAlloc(0, cbCompNew);
-                    if (IS_NULL_UNEXPECTEDLY(pCompNew))
+                    if (!pCompNew)
+                    {
+                        ERR("!pCompNew\n");
                         goto Quit;
+                    }
 
                     Imm32CompAttrWideToAnsi(pComp, dwCompLen,
                                             CS_StrW(pCS, CompStr), CS_SizeW(pCS, CompStr),
@@ -653,8 +675,11 @@ ImmSetCompositionStringAW(HIMC hIMC, DWORD dwIndex, LPVOID pComp, DWORD dwCompLe
                                                         CS_SizeA(pCS, CompStr),
                                                         NULL, 0, uCodePage);
                     pCompNew = ImmLocalAlloc(0, cbCompNew);
-                    if (IS_NULL_UNEXPECTEDLY(pCompNew))
+                    if (!pCompNew)
+                    {
+                        ERR("!pCompNew\n");
                         goto Quit;
+                    }
 
                     Imm32CompAttrAnsiToWide(pComp, dwCompLen,
                                             CS_StrA(pCS, CompStr), CS_SizeA(pCS, CompStr),
@@ -671,8 +696,11 @@ ImmSetCompositionStringAW(HIMC hIMC, DWORD dwIndex, LPVOID pComp, DWORD dwCompLe
                                                         CS_SizeW(pCS, CompReadStr),
                                                         NULL, 0, uCodePage);
                     pReadNew = ImmLocalAlloc(0, cbReadNew);
-                    if (IS_NULL_UNEXPECTEDLY(pReadNew))
+                    if (!pReadNew)
+                    {
+                        ERR("!pReadNew\n");
                         goto Quit;
+                    }
 
                     Imm32CompAttrWideToAnsi(pRead, dwReadLen,
                                             CS_StrW(pCS, CompReadStr), CS_SizeW(pCS, CompReadStr),
@@ -685,8 +713,11 @@ ImmSetCompositionStringAW(HIMC hIMC, DWORD dwIndex, LPVOID pComp, DWORD dwCompLe
                                                         CS_SizeA(pCS, CompReadStr),
                                                         NULL, 0, uCodePage);
                     pReadNew = ImmLocalAlloc(0, cbReadNew);
-                    if (IS_NULL_UNEXPECTEDLY(pReadNew))
+                    if (!pReadNew)
+                    {
+                        ERR("!pReadNew\n");
                         goto Quit;
+                    }
 
                     Imm32CompAttrAnsiToWide(pRead, dwReadLen,
                                             CS_StrA(pCS, CompReadStr), CS_SizeA(pCS, CompReadStr),
@@ -703,8 +734,11 @@ ImmSetCompositionStringAW(HIMC hIMC, DWORD dwIndex, LPVOID pComp, DWORD dwCompLe
                     cbCompNew = Imm32CompClauseWideToAnsi(pComp, dwCompLen, CS_StrW(pCS, CompStr),
                                                           NULL, 0, uCodePage);
                     pCompNew = ImmLocalAlloc(0, cbCompNew);
-                    if (IS_NULL_UNEXPECTEDLY(pCompNew))
+                    if (!pCompNew)
+                    {
+                        ERR("!pCompNew\n");
                         goto Quit;
+                    }
 
                     Imm32CompClauseWideToAnsi(pComp, dwCompLen, CS_StrW(pCS, CompStr),
                                               pCompNew, cbCompNew, uCodePage);
@@ -714,8 +748,11 @@ ImmSetCompositionStringAW(HIMC hIMC, DWORD dwIndex, LPVOID pComp, DWORD dwCompLe
                     cbCompNew = Imm32CompClauseAnsiToWide(pComp, dwCompLen, CS_StrA(pCS, CompStr),
                                                           NULL, 0, uCodePage);
                     pCompNew = ImmLocalAlloc(0, cbCompNew);
-                    if (IS_NULL_UNEXPECTEDLY(pCompNew))
+                    if (!pCompNew)
+                    {
+                        ERR("!pCompNew\n");
                         goto Quit;
+                    }
 
                     Imm32CompClauseAnsiToWide(pComp, dwCompLen, CS_StrA(pCS, CompStr),
                                               pCompNew, cbCompNew, uCodePage);
@@ -729,8 +766,11 @@ ImmSetCompositionStringAW(HIMC hIMC, DWORD dwIndex, LPVOID pComp, DWORD dwCompLe
                     cbReadNew = Imm32CompClauseWideToAnsi(pRead, dwReadLen, CS_StrW(pCS, CompReadStr),
                                                           NULL, 0, uCodePage);
                     pReadNew = ImmLocalAlloc(0, cbReadNew);
-                    if (IS_NULL_UNEXPECTEDLY(pReadNew))
+                    if (!pReadNew)
+                    {
+                        ERR("!pReadNew\n");
                         goto Quit;
+                    }
 
                     Imm32CompClauseWideToAnsi(pRead, dwReadLen,
                                               CS_StrW(pCS, CompReadStr),
@@ -741,8 +781,11 @@ ImmSetCompositionStringAW(HIMC hIMC, DWORD dwIndex, LPVOID pComp, DWORD dwCompLe
                     cbReadNew = Imm32CompClauseAnsiToWide(pRead, dwReadLen, CS_StrA(pCS, CompReadStr),
                                                           NULL, 0, uCodePage);
                     pReadNew = ImmLocalAlloc(0, cbReadNew);
-                    if (IS_NULL_UNEXPECTEDLY(pReadNew))
+                    if (!pReadNew)
+                    {
+                        ERR("!pReadNew\n");
                         goto Quit;
+                    }
 
                     Imm32CompClauseAnsiToWide(pRead, dwReadLen, CS_StrA(pCS, CompReadStr),
                                               pReadNew, cbReadNew, uCodePage);
@@ -758,8 +801,11 @@ ImmSetCompositionStringAW(HIMC hIMC, DWORD dwIndex, LPVOID pComp, DWORD dwCompLe
                 {
                     cbCompNew = Imm32ReconvertAnsiFromWide(NULL, pComp, uCodePage);
                     pCompNew = ImmLocalAlloc(0, cbCompNew);
-                    if (IS_NULL_UNEXPECTEDLY(pCompNew))
+                    if (!pCompNew)
+                    {
+                        ERR("!pCompNew\n");
                         goto Quit;
+                    }
 
                     pRS = pCompNew;
                     pRS->dwSize = cbCompNew;
@@ -770,8 +816,11 @@ ImmSetCompositionStringAW(HIMC hIMC, DWORD dwIndex, LPVOID pComp, DWORD dwCompLe
                 {
                     cbCompNew = Imm32ReconvertWideFromAnsi(NULL, pComp, uCodePage);
                     pCompNew = ImmLocalAlloc(0, cbCompNew);
-                    if (IS_NULL_UNEXPECTEDLY(pCompNew))
+                    if (!pCompNew)
+                    {
+                        ERR("!pCompNew\n");
                         goto Quit;
+                    }
 
                     pRS = pCompNew;
                     pRS->dwSize = cbCompNew;
@@ -786,8 +835,11 @@ ImmSetCompositionStringAW(HIMC hIMC, DWORD dwIndex, LPVOID pComp, DWORD dwCompLe
                 {
                     cbReadNew = Imm32ReconvertAnsiFromWide(NULL, pRead, uCodePage);
                     pReadNew = ImmLocalAlloc(0, cbReadNew);
-                    if (IS_NULL_UNEXPECTEDLY(pReadNew))
+                    if (!pReadNew)
+                    {
+                        ERR("!pReadNew\n");
                         goto Quit;
+                    }
 
                     pRS = pReadNew;
                     pRS->dwSize = cbReadNew;
@@ -798,8 +850,11 @@ ImmSetCompositionStringAW(HIMC hIMC, DWORD dwIndex, LPVOID pComp, DWORD dwCompLe
                 {
                     cbReadNew = Imm32ReconvertWideFromAnsi(NULL, pRead, uCodePage);
                     pReadNew = ImmLocalAlloc(0, cbReadNew);
-                    if (IS_NULL_UNEXPECTEDLY(pReadNew))
+                    if (!pReadNew)
+                    {
+                        ERR("!pReadNew\n");
                         goto Quit;
+                    }
 
                     pRS = pReadNew;
                     pRS->dwSize = cbReadNew;
@@ -864,24 +919,34 @@ LONG WINAPI ImmGetCompositionStringA(HIMC hIMC, DWORD dwIndex, LPVOID lpBuf, DWO
 
     TRACE("(%p, %lu, %p, %lu)\n", hIMC, dwIndex, lpBuf, dwBufLen);
 
-    if (dwBufLen && IS_NULL_UNEXPECTEDLY(lpBuf))
+    if (dwBufLen && !lpBuf)
+    {
+        ERR("dwBufLen && !lpBuf\n");
         return 0;
+    }
 
     pClientImc = ImmLockClientImc(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pClientImc))
+    if (!pClientImc)
+    {
+        ERR("!pClientImc\n");
         return 0;
+    }
 
     bAnsiClient = !(pClientImc->dwFlags & CLIENTIMC_WIDE);
     uCodePage = pClientImc->uCodePage;
     ImmUnlockClientImc(pClientImc);
 
     pIC = ImmLockIMC(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pIC))
+    if (!pIC)
+    {
+        ERR("!pIC\n");
         return 0;
+    }
 
     pCS = ImmLockIMCC(pIC->hCompStr);
-    if (IS_NULL_UNEXPECTEDLY(pCS))
+    if (!pCS)
     {
+        ERR("!pCS\n");
         ImmUnlockIMC(hIMC);
         return 0;
     }
@@ -907,24 +972,34 @@ LONG WINAPI ImmGetCompositionStringW(HIMC hIMC, DWORD dwIndex, LPVOID lpBuf, DWO
 
     TRACE("(%p, %lu, %p, %lu)\n", hIMC, dwIndex, lpBuf, dwBufLen);
 
-    if (dwBufLen && IS_NULL_UNEXPECTEDLY(lpBuf))
+    if (dwBufLen && !lpBuf)
+    {
+        ERR("dwBufLen && !lpBuf\n");
         return 0;
+    }
 
     pClientImc = ImmLockClientImc(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pClientImc))
+    if (!pClientImc)
+    {
+        ERR("!pClientImc\n");
         return 0;
+    }
 
     bAnsiClient = !(pClientImc->dwFlags & CLIENTIMC_WIDE);
     uCodePage = pClientImc->uCodePage;
     ImmUnlockClientImc(pClientImc);
 
     pIC = ImmLockIMC(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pIC))
+    if (!pIC)
+    {
+        ERR("!pIC\n");
         return 0;
+    }
 
     pCS = ImmLockIMCC(pIC->hCompStr);
-    if (IS_NULL_UNEXPECTEDLY(pCS))
+    if (!pCS)
     {
+        ERR("!pCS\n");
         ImmUnlockIMC(hIMC);
         return 0;
     }

--- a/dll/win32/imm32/ctf.c
+++ b/dll/win32/imm32/ctf.c
@@ -305,8 +305,11 @@ Imm32AllocateTLS(VOID)
         return pData;
 
     pData = (IMMTLSDATA*)ImmLocalAlloc(HEAP_ZERO_MEMORY, sizeof(IMMTLSDATA));
-    if (IS_NULL_UNEXPECTEDLY(pData))
+    if (!pData)
+    {
+        ERR("!pData\n");
         return NULL;
+    }
 
     if (IS_ZERO_UNEXPECTEDLY(TlsSetValue(g_dwTLSIndex, pData)))
     {
@@ -593,8 +596,11 @@ CtfImmCoInitialize(VOID)
 
     pSpy = Imm32AllocIMMISPY();
     pData->pSpy = (IInitializeSpy*)pSpy;
-    if (IS_NULL_UNEXPECTEDLY(pSpy))
+    if (!pSpy)
+    {
+        ERR("!pSpy\n");
         return S_OK; /* Cannot allocate a spy */
+    }
 
     if (FAILED_UNEXPECTEDLY(Imm32CoRegisterInitializeSpy(pData->pSpy, &pData->uliCookie)))
     {
@@ -1242,8 +1248,11 @@ CtfImmSetLangBand(
     if (hWnd && gpsi)
         pWnd = ValidateHwndNoErr(hWnd);
 
-    if (IS_NULL_UNEXPECTEDLY(pWnd))
+    if (!pWnd)
+    {
+        ERR("!pWnd\n");
         return 0;
+    }
 
     if (pWnd->state2 & WNDS2_WMCREATEMSGPROCESSED)
     {
@@ -1253,8 +1262,11 @@ CtfImmSetLangBand(
     }
 
     pSetBand = ImmLocalAlloc(0, sizeof(IMM_DELAY_SET_LANG_BAND));
-    if (IS_NULL_UNEXPECTEDLY(pSetBand))
+    if (!pSetBand)
+    {
+        ERR("!pSetBand\n");
         return 0;
+    }
 
     pSetBand->hWnd = hWnd;
     pSetBand->fSet = fSet;
@@ -1292,20 +1304,27 @@ CtfImmGenerateMessage(
     }
 
     pClientImc = ImmLockClientImc(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pClientImc))
+    if (!pClientImc)
+    {
+        ERR("!pClientImc\n");
         return FALSE;
+    }
 
     bUnicode = !!(pClientImc->dwFlags & CLIENTIMC_WIDE);
     ImmUnlockClientImc(pClientImc);
 
     pIC = (LPINPUTCONTEXT)ImmLockIMC(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pIC))
+    if (!pIC)
+    {
+        ERR("!pIC\n");
         return FALSE;
+    }
 
     dwNumMsgBuf = pIC->dwNumMsgBuf;
     pOldTransMsg = (LPTRANSMSG)ImmLockIMCC(pIC->hMsgBuf);
-    if (IS_NULL_UNEXPECTEDLY(pOldTransMsg))
+    if (!pOldTransMsg)
     {
+        ERR("!pOldTransMsg\n");
         pIC->dwNumMsgBuf = 0;
         ImmUnlockIMC(hIMC);
         return TRUE;
@@ -1313,8 +1332,9 @@ CtfImmGenerateMessage(
 
     cbTransMsg = sizeof(TRANSMSG) * dwNumMsgBuf;
     pNewTransMsg = (PTRANSMSG)ImmLocalAlloc(0, cbTransMsg);
-    if (IS_NULL_UNEXPECTEDLY(pNewTransMsg))
+    if (!pNewTransMsg)
     {
+        ERR("!pNewTransMsg\n");
         ImmUnlockIMCC(pIC->hMsgBuf);
         pIC->dwNumMsgBuf = 0;
         ImmUnlockIMC(hIMC);
@@ -1451,8 +1471,11 @@ CtfImmIsGuidMapEnable(
         return ret;
 
     pImeDpi = Imm32FindOrLoadImeDpi(hKL);
-    if (IS_NULL_UNEXPECTEDLY(pImeDpi))
+    if (!pImeDpi)
+    {
+        ERR("!pImeDpi\n");
         return ret;
+    }
 
     ret = pImeDpi->CtfImeIsGuidMapEnable(hIMC);
 
@@ -1487,8 +1510,11 @@ CtfImmGetGuidAtom(
         return S_OK;
 
     pImeDpi = Imm32FindOrLoadImeDpi(hKL);
-    if (IS_NULL_UNEXPECTEDLY(pImeDpi))
+    if (!pImeDpi)
+    {
+        ERR("!pImeDpi\n");
         return hr;
+    }
 
     hr = pImeDpi->CtfImeGetGuidAtom(hIMC, dwUnknown, pdwGuidAtom);
 

--- a/dll/win32/imm32/guideline.c
+++ b/dll/win32/imm32/guideline.c
@@ -22,21 +22,26 @@ ImmGetGuideLineAW(HIMC hIMC, DWORD dwIndex, LPVOID lpBuf, DWORD dwBufLen, BOOL b
     UINT uCodePage;
 
     pClientImc = ImmLockClientImc(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pClientImc))
+    if (!pClientImc)
+    {
+        ERR("!pClientImc\n");
         return 0;
+    }
 
     uCodePage = pClientImc->uCodePage;
 
     pIC = ImmLockIMC(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pIC))
+    if (!pIC)
     {
+        ERR("!pIC\n");
         ImmUnlockClientImc(pClientImc);
         return 0;
     }
 
     pGuideLine = ImmLockIMCC(pIC->hGuideLine);
-    if (IS_NULL_UNEXPECTEDLY(pGuideLine))
+    if (!pGuideLine)
     {
+        ERR("!pGuideLine\n");
         ImmUnlockIMC(hIMC);
         ImmUnlockClientImc(pClientImc);
         return 0;

--- a/dll/win32/imm32/ime.c
+++ b/dll/win32/imm32/ime.c
@@ -291,8 +291,11 @@ PIMEDPI APIENTRY Imm32LoadImeDpi(HKL hKL, BOOL bLock)
     }
 
     pImeDpiNew = ImmLocalAlloc(HEAP_ZERO_MEMORY, sizeof(IMEDPI));
-    if (IS_NULL_UNEXPECTEDLY(pImeDpiNew))
+    if (!pImeDpiNew)
+    {
+        ERR("!pImeDpiNew\n");
         return NULL;
+    }
 
     pImeDpiNew->hKL = hKL;
 
@@ -426,12 +429,18 @@ HKL WINAPI ImmInstallIMEA(LPCSTR lpszIMEFileName, LPCSTR lpszLayoutText)
     TRACE("(%s, %s)\n", lpszIMEFileName, lpszLayoutText);
 
     pszFileNameW = Imm32WideFromAnsi(CP_ACP, lpszIMEFileName);
-    if (IS_NULL_UNEXPECTEDLY(pszFileNameW))
+    if (!pszFileNameW)
+    {
+        ERR("!pszFileNameW\n");
         goto Quit;
+    }
 
     pszLayoutTextW = Imm32WideFromAnsi(CP_ACP, lpszLayoutText);
-    if (IS_NULL_UNEXPECTEDLY(pszLayoutTextW))
+    if (!pszLayoutTextW)
+    {
+        ERR("!pszLayoutTextW\n");
         goto Quit;
+    }
 
     hKL = ImmInstallIMEW(pszFileNameW, pszLayoutTextW);
 
@@ -458,8 +467,11 @@ HKL WINAPI ImmInstallIMEW(LPCWSTR lpszIMEFileName, LPCWSTR lpszLayoutText)
 
     GetFullPathNameW(lpszIMEFileName, _countof(szImeFileName), szImeFileName, &pchFilePart);
     CharUpperW(szImeFileName);
-    if (IS_NULL_UNEXPECTEDLY(pchFilePart))
+    if (!pchFilePart)
+    {
+        ERR("!pchFilePart\n");
         return NULL;
+    }
 
     /* Load the IME version info */
     InfoEx.hkl = hNewKL = NULL;
@@ -476,8 +488,11 @@ HKL WINAPI ImmInstallIMEW(LPCWSTR lpszIMEFileName, LPCWSTR lpszLayoutText)
     if (cLayouts)
     {
         pLayouts = ImmLocalAlloc(0, cLayouts * sizeof(REG_IME));
-        if (IS_NULL_UNEXPECTEDLY(pLayouts))
+        if (!pLayouts)
+        {
+            ERR("!pLayouts\n");
             return NULL;
+        }
 
         if (!Imm32GetImeLayout(pLayouts, cLayouts))
         {
@@ -590,8 +605,11 @@ BOOL WINAPI ImmNotifyIME(HIMC hIMC, DWORD dwAction, DWORD dwIndex, DWORD_PTR dwV
 
     hKL = GetKeyboardLayout(0);
     pImeDpi = ImmLockImeDpi(hKL);
-    if (IS_NULL_UNEXPECTEDLY(pImeDpi))
+    if (!pImeDpi)
+    {
+        ERR("!pImeDpi\n");
         return FALSE;
+    }
 
     ret = pImeDpi->NotifyIME(hIMC, dwAction, dwIndex, dwValue);
     ImmUnlockImeDpi(pImeDpi);
@@ -918,8 +936,11 @@ DWORD WINAPI ImmGetProperty(HKL hKL, DWORD fdwIndex)
     if (ImeInfoEx.fLoadFlag != 2)
     {
         pImeDpi = Imm32FindOrLoadImeDpi(hKL);
-        if (IS_NULL_UNEXPECTEDLY(pImeDpi))
+        if (!pImeDpi)
+        {
+            ERR("!pImeDpi\n");
             return FALSE;
+        }
 
         pImeInfo = &pImeDpi->ImeInfo;
     }
@@ -958,8 +979,11 @@ LRESULT WINAPI ImmEscapeA(HKL hKL, HIMC hIMC, UINT uSubFunc, LPVOID lpData)
     TRACE("(%p, %p, %u, %p)\n", hKL, hIMC, uSubFunc, lpData);
 
     pImeDpi = Imm32FindOrLoadImeDpi(hKL);
-    if (IS_NULL_UNEXPECTEDLY(pImeDpi))
+    if (!pImeDpi)
+    {
+        ERR("!pImeDpi\n");
         return 0;
+    }
 
     if (!ImeDpi_IsUnicode(pImeDpi) || !lpData) /* No conversion needed */
     {
@@ -1047,8 +1071,11 @@ LRESULT WINAPI ImmEscapeW(HKL hKL, HIMC hIMC, UINT uSubFunc, LPVOID lpData)
     TRACE("(%p, %p, %u, %p)\n", hKL, hIMC, uSubFunc, lpData);
 
     pImeDpi = Imm32FindOrLoadImeDpi(hKL);
-    if (IS_NULL_UNEXPECTEDLY(pImeDpi))
+    if (!pImeDpi)
+    {
+        ERR("!pImeDpi\n");
         return 0;
+    }
 
     if (ImeDpi_IsUnicode(pImeDpi) || !lpData) /* No conversion needed */
     {
@@ -1120,12 +1147,18 @@ BOOL WINAPI ImmGetOpenStatus(HIMC hIMC)
 
     TRACE("(%p)\n", hIMC);
 
-    if (IS_NULL_UNEXPECTEDLY(hIMC))
+    if (!hIMC)
+    {
+        ERR("!hIMC\n");
         return FALSE;
+    }
 
     pIC = ImmLockIMC(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pIC))
+    if (!pIC)
+    {
+        ERR("!pIC\n");
         return FALSE;
+    }
 
     ret = pIC->fOpen;
     ImmUnlockIMC(hIMC);
@@ -1149,8 +1182,11 @@ BOOL WINAPI ImmSetOpenStatus(HIMC hIMC, BOOL fOpen)
         return FALSE;
 
     pIC = ImmLockIMC(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pIC))
+    if (!pIC)
+    {
+        ERR("!pIC\n");
         return FALSE;
+    }
 
     if (pIC->fOpen != fOpen)
     {
@@ -1187,8 +1223,11 @@ BOOL WINAPI ImmGetStatusWindowPos(HIMC hIMC, LPPOINT lpptPos)
     TRACE("(%p, %p)\n", hIMC, lpptPos);
 
     pIC = ImmLockIMC(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pIC))
+    if (!pIC)
+    {
+        ERR("!pIC\n");
         return FALSE;
+    }
 
     ret = !!(pIC->fdwInit & INIT_STATUSWNDPOS);
     if (ret)
@@ -1212,8 +1251,11 @@ BOOL WINAPI ImmSetStatusWindowPos(HIMC hIMC, LPPOINT lpptPos)
         return FALSE;
 
     pIC = ImmLockIMC(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pIC))
+    if (!pIC)
+    {
+        ERR("!pIC\n");
         return FALSE;
+    }
 
     hWnd = pIC->hWnd;
     pIC->ptStatusWndPos = *lpptPos;
@@ -1237,8 +1279,11 @@ BOOL WINAPI ImmGetCompositionWindow(HIMC hIMC, LPCOMPOSITIONFORM lpCompForm)
     TRACE("(%p, %p)\n", hIMC, lpCompForm);
 
     pIC = ImmLockIMC(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pIC))
+    if (!pIC)
+    {
+        ERR("!pIC\n");
         return FALSE;
+    }
 
     if (pIC->fdwInit & INIT_COMPFORM)
     {
@@ -1262,8 +1307,11 @@ BOOL WINAPI ImmSetCompositionWindow(HIMC hIMC, LPCOMPOSITIONFORM lpCompForm)
         return FALSE;
 
     pIC = (LPINPUTCONTEXTDX)ImmLockIMC(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pIC))
+    if (!pIC)
+    {
+        ERR("!pIC\n");
         return FALSE;
+    }
 
     pIC->cfCompForm = *lpCompForm;
     pIC->fdwInit |= INIT_COMPFORM;
@@ -1294,15 +1342,21 @@ BOOL WINAPI ImmGetCompositionFontA(HIMC hIMC, LPLOGFONTA lplf)
     TRACE("(%p, %p)\n", hIMC, lplf);
 
     pClientImc = ImmLockClientImc(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pClientImc))
+    if (!pClientImc)
+    {
+        ERR("!pClientImc\n");
         return FALSE;
+    }
 
     bWide = (pClientImc->dwFlags & CLIENTIMC_WIDE);
     ImmUnlockClientImc(pClientImc);
 
     pIC = ImmLockIMC(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pIC))
+    if (!pIC)
+    {
+        ERR("!pIC\n");
         return FALSE;
+    }
 
     if (pIC->fdwInit & INIT_LOGFONT)
     {
@@ -1331,15 +1385,21 @@ BOOL WINAPI ImmGetCompositionFontW(HIMC hIMC, LPLOGFONTW lplf)
     TRACE("(%p, %p)\n", hIMC, lplf);
 
     pClientImc = ImmLockClientImc(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pClientImc))
+    if (!pClientImc)
+    {
+        ERR("!pClientImc\n");
         return FALSE;
+    }
 
     bWide = (pClientImc->dwFlags & CLIENTIMC_WIDE);
     ImmUnlockClientImc(pClientImc);
 
     pIC = ImmLockIMC(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pIC))
+    if (!pIC)
+    {
+        ERR("!pIC\n");
         return FALSE;
+    }
 
     if (pIC->fdwInit & INIT_LOGFONT)
     {
@@ -1373,8 +1433,11 @@ BOOL WINAPI ImmSetCompositionFontA(HIMC hIMC, LPLOGFONTA lplf)
         return FALSE;
 
     pClientImc = ImmLockClientImc(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pClientImc))
+    if (!pClientImc)
+    {
+        ERR("!pClientImc\n");
         return FALSE;
+    }
 
     bWide = (pClientImc->dwFlags & CLIENTIMC_WIDE);
     ImmUnlockClientImc(pClientImc);
@@ -1386,8 +1449,11 @@ BOOL WINAPI ImmSetCompositionFontA(HIMC hIMC, LPLOGFONTA lplf)
     }
 
     pIC = (LPINPUTCONTEXTDX)ImmLockIMC(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pIC))
+    if (!pIC)
+    {
+        ERR("!pIC\n");
         return FALSE;
+    }
 
     if (GetWin32ClientInfo()->dwExpWinVer < _WIN32_WINNT_NT4) /* old version (3.x)? */
     {
@@ -1429,8 +1495,11 @@ BOOL WINAPI ImmSetCompositionFontW(HIMC hIMC, LPLOGFONTW lplf)
         return FALSE;
 
     pClientImc = ImmLockClientImc(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pClientImc))
+    if (!pClientImc)
+    {
+        ERR("!pClientImc\n");
         return FALSE;
+    }
 
     bWide = (pClientImc->dwFlags & CLIENTIMC_WIDE);
     ImmUnlockClientImc(pClientImc);
@@ -1442,8 +1511,11 @@ BOOL WINAPI ImmSetCompositionFontW(HIMC hIMC, LPLOGFONTW lplf)
     }
 
     pIC = (LPINPUTCONTEXTDX)ImmLockIMC(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pIC))
+    if (!pIC)
+    {
+        ERR("!pIC\n");
         return FALSE;
+    }
 
     if (GetWin32ClientInfo()->dwExpWinVer < _WIN32_WINNT_NT4) /* old version (3.x)? */
     {
@@ -1483,8 +1555,11 @@ ImmGetConversionListA(HKL hKL, HIMC hIMC, LPCSTR pSrc, LPCANDIDATELIST lpDst,
     TRACE("(%p, %p, %s, %p, %lu, 0x%lX)\n", hKL, hIMC, pSrc, lpDst, dwBufLen, uFlag);
 
     pImeDpi = Imm32FindOrLoadImeDpi(hKL);
-    if (IS_NULL_UNEXPECTEDLY(pImeDpi))
+    if (!pImeDpi)
+    {
+        ERR("!pImeDpi\n");
         return 0;
+    }
 
     if (!ImeDpi_IsUnicode(pImeDpi)) /* No conversion needed */
     {
@@ -1496,8 +1571,11 @@ ImmGetConversionListA(HKL hKL, HIMC hIMC, LPCSTR pSrc, LPCANDIDATELIST lpDst,
     if (pSrc)
     {
         pszSrcW = Imm32WideFromAnsi(pImeDpi->uCodePage, pSrc);
-        if (IS_NULL_UNEXPECTEDLY(pszSrcW))
+        if (!pszSrcW)
+        {
+            ERR("!pszSrcW\n");
             goto Quit;
+        }
     }
 
     cb = pImeDpi->ImeConversionList(hIMC, pszSrcW, NULL, 0, uFlag);
@@ -1505,8 +1583,11 @@ ImmGetConversionListA(HKL hKL, HIMC hIMC, LPCSTR pSrc, LPCANDIDATELIST lpDst,
         goto Quit;
 
     pCL = ImmLocalAlloc(0, cb);
-    if (IS_NULL_UNEXPECTEDLY(pCL))
+    if (!pCL)
+    {
+        ERR("!pCL\n");
         goto Quit;
+    }
 
     cb = pImeDpi->ImeConversionList(hIMC, pszSrcW, pCL, cb, uFlag);
     if (IS_ZERO_UNEXPECTEDLY(cb))
@@ -1538,8 +1619,11 @@ ImmGetConversionListW(HKL hKL, HIMC hIMC, LPCWSTR pSrc, LPCANDIDATELIST lpDst,
     TRACE("(%p, %p, %S, %p, %lu, 0x%lX)\n", hKL, hIMC, pSrc, lpDst, dwBufLen, uFlag);
 
     pImeDpi = Imm32FindOrLoadImeDpi(hKL);
-    if (IS_NULL_UNEXPECTEDLY(pImeDpi))
+    if (!pImeDpi)
+    {
+        ERR("!pImeDpi\n");
         return 0;
+    }
 
     if (ImeDpi_IsUnicode(pImeDpi)) /* No conversion needed */
     {
@@ -1551,8 +1635,11 @@ ImmGetConversionListW(HKL hKL, HIMC hIMC, LPCWSTR pSrc, LPCANDIDATELIST lpDst,
     if (pSrc)
     {
         pszSrcA = Imm32AnsiFromWide(pImeDpi->uCodePage, pSrc);
-        if (IS_NULL_UNEXPECTEDLY(pszSrcA))
+        if (!pszSrcA)
+        {
+            ERR("!pszSrcA\n");
             goto Quit;
+        }
     }
 
     cb = pImeDpi->ImeConversionList(hIMC, pszSrcA, NULL, 0, uFlag);
@@ -1560,8 +1647,11 @@ ImmGetConversionListW(HKL hKL, HIMC hIMC, LPCWSTR pSrc, LPCANDIDATELIST lpDst,
         goto Quit;
 
     pCL = ImmLocalAlloc(0, cb);
-    if (IS_NULL_UNEXPECTEDLY(pCL))
+    if (!pCL)
+    {
+        ERR("!pCL\n");
         goto Quit;
+    }
 
     cb = pImeDpi->ImeConversionList(hIMC, pszSrcA, pCL, cb, uFlag);
     if (IS_ZERO_UNEXPECTEDLY(cb))
@@ -1587,8 +1677,11 @@ BOOL WINAPI ImmGetConversionStatus(HIMC hIMC, LPDWORD lpfdwConversion, LPDWORD l
     TRACE("(%p %p %p)\n", hIMC, lpfdwConversion, lpfdwSentence);
 
     pIC = ImmLockIMC(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pIC))
+    if (!pIC)
+    {
+        ERR("!pIC\n");
         return FALSE;
+    }
 
     if (lpfdwConversion)
     {
@@ -1627,8 +1720,11 @@ BOOL WINAPI ImmSetConversionStatus(HIMC hIMC, DWORD fdwConversion, DWORD fdwSent
         return FALSE;
 
     pIC = ImmLockIMC(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pIC))
+    if (!pIC)
+    {
+        ERR("!pIC\n");
         return FALSE;
+    }
 
     if (pIC->fdwConversion != fdwConversion)
     {
@@ -1677,12 +1773,21 @@ BOOL WINAPI ImmConfigureIMEA(HKL hKL, HWND hWnd, DWORD dwMode, LPVOID lpData)
 
     TRACE("(%p, %p, 0x%lX, %p)\n", hKL, hWnd, dwMode, lpData);
 
-    if (IS_NULL_UNEXPECTEDLY(ValidateHwnd(hWnd)) || IS_CROSS_PROCESS_HWND(hWnd))
+    if (!ValidateHwnd(hWnd))
+    {
+        ERR("!ValidateHwnd(hWnd)\n");
+        return FALSE;
+    }
+
+    if (IS_CROSS_PROCESS_HWND(hWnd))
         return FALSE;
 
     pImeDpi = Imm32FindOrLoadImeDpi(hKL);
-    if (IS_NULL_UNEXPECTEDLY(pImeDpi))
+    if (!pImeDpi)
+    {
+        ERR("!pImeDpi\n");
         return FALSE;
+    }
 
     RtlZeroMemory(&RegWordW, sizeof(RegWordW));
 
@@ -1694,15 +1799,21 @@ BOOL WINAPI ImmConfigureIMEA(HKL hKL, HWND hWnd, DWORD dwMode, LPVOID lpData)
     if (pRegWordA->lpReading)
     {
         RegWordW.lpReading = Imm32WideFromAnsi(pImeDpi->uCodePage, pRegWordA->lpReading);
-        if (IS_NULL_UNEXPECTEDLY(RegWordW.lpReading))
+        if (!RegWordW.lpReading)
+        {
+            ERR("!RegWordW.lpReading\n");
             goto Quit;
+        }
     }
 
     if (pRegWordA->lpWord)
     {
         RegWordW.lpWord = Imm32WideFromAnsi(pImeDpi->uCodePage, pRegWordA->lpWord);
-        if (IS_NULL_UNEXPECTEDLY(RegWordW.lpWord))
+        if (!RegWordW.lpWord)
+        {
+            ERR("!RegWordW.lpWord\n");
             goto Quit;
+        }
     }
 
     lpData = &RegWordW;
@@ -1732,12 +1843,21 @@ BOOL WINAPI ImmConfigureIMEW(HKL hKL, HWND hWnd, DWORD dwMode, LPVOID lpData)
 
     TRACE("(%p, %p, 0x%lX, %p)\n", hKL, hWnd, dwMode, lpData);
 
-    if (IS_NULL_UNEXPECTEDLY(ValidateHwnd(hWnd)) || IS_CROSS_PROCESS_HWND(hWnd))
+    if (!ValidateHwnd(hWnd))
+    {
+        ERR("!ValidateHwnd(hWnd)\n");
+        return FALSE;
+    }
+
+    if (IS_CROSS_PROCESS_HWND(hWnd))
         return FALSE;
 
     pImeDpi = Imm32FindOrLoadImeDpi(hKL);
-    if (IS_NULL_UNEXPECTEDLY(pImeDpi))
+    if (!pImeDpi)
+    {
+        ERR("!pImeDpi\n");
         return FALSE;
+    }
 
     RtlZeroMemory(&RegWordA, sizeof(RegWordA));
 
@@ -1749,15 +1869,21 @@ BOOL WINAPI ImmConfigureIMEW(HKL hKL, HWND hWnd, DWORD dwMode, LPVOID lpData)
     if (pRegWordW->lpReading)
     {
         RegWordA.lpReading = Imm32AnsiFromWide(pImeDpi->uCodePage, pRegWordW->lpReading);
-        if (IS_NULL_UNEXPECTEDLY(RegWordA.lpReading))
+        if (!RegWordA.lpReading)
+        {
+            ERR("!RegWordA.lpReading\n");
             goto Quit;
+        }
     }
 
     if (pRegWordW->lpWord)
     {
         RegWordA.lpWord = Imm32AnsiFromWide(pImeDpi->uCodePage, pRegWordW->lpWord);
-        if (IS_NULL_UNEXPECTEDLY(RegWordA.lpWord))
+        if (!RegWordA.lpWord)
+        {
+            ERR("!RegWordA.lpWord\n");
             goto Quit;
+        }
     }
 
     lpData = &RegWordA;
@@ -1794,12 +1920,18 @@ BOOL WINAPI ImmWINNLSEnableIME(HWND hWnd, BOOL enable)
     }
 
     hIMC = (HIMC)NtUserGetThreadState(THREADSTATE_DEFAULTINPUTCONTEXT);
-    if (IS_NULL_UNEXPECTEDLY(hIMC))
+    if (!hIMC)
+    {
+        ERR("!hIMC\n");
         return FALSE;
+    }
 
     pClientImc = ImmLockClientImc(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pClientImc))
+    if (!pClientImc)
+    {
+        ERR("!pClientImc\n");
         return FALSE;
+    }
 
     ret = !(pClientImc->dwFlags & CLIENTIMC_DISABLEIME);
     if (!!enable == ret)

--- a/dll/win32/imm32/keymsg.c
+++ b/dll/win32/imm32/keymsg.c
@@ -70,8 +70,11 @@ BOOL APIENTRY Imm32CImeNonImeToggle(HIMC hIMC, HKL hKL, HWND hWnd, LANGID LangID
     LPINPUTCONTEXT pIC;
     BOOL fOpen;
 
-    if (IS_NULL_UNEXPECTEDLY(hWnd))
+    if (!hWnd)
+    {
+        ERR("!hWnd\n");
         return FALSE;
+    }
 
     if (LOWORD(hKL) != LangID || !ImmIsIME(hKL))
     {
@@ -80,8 +83,11 @@ BOOL APIENTRY Imm32CImeNonImeToggle(HIMC hIMC, HKL hKL, HWND hWnd, LANGID LangID
     }
 
     pIC = ImmLockIMC(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pIC))
+    if (!pIC)
+    {
+        ERR("!pIC\n");
         return TRUE;
+    }
 
     fOpen = pIC->fOpen;
     ImmUnlockIMC(hIMC);
@@ -106,8 +112,11 @@ BOOL APIENTRY Imm32CShapeToggle(HIMC hIMC, HKL hKL, HWND hWnd)
         return FALSE;
 
     pIC = ImmLockIMC(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pIC))
+    if (!pIC)
+    {
+        ERR("!pIC\n");
         return TRUE;
+    }
 
     fOpen = pIC->fOpen;
     if (fOpen)
@@ -137,8 +146,11 @@ BOOL APIENTRY Imm32CSymbolToggle(HIMC hIMC, HKL hKL, HWND hWnd)
         return FALSE;
 
     pIC = ImmLockIMC(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pIC))
+    if (!pIC)
+    {
+        ERR("!pIC\n");
         return TRUE;
+    }
 
     fOpen = pIC->fOpen;
     if (fOpen)
@@ -191,8 +203,11 @@ BOOL APIENTRY Imm32KShapeToggle(HIMC hIMC)
     DWORD dwConversion, dwSentence;
 
     pIC = ImmLockIMC(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pIC))
+    if (!pIC)
+    {
+        ERR("!pIC\n");
         return FALSE;
+    }
 
     dwConversion = (pIC->fdwConversion ^ IME_CMODE_FULLSHAPE);
     dwSentence = pIC->fdwSentence;
@@ -214,8 +229,11 @@ BOOL APIENTRY Imm32KHanjaConvert(HIMC hIMC)
     DWORD dwConversion, dwSentence;
 
     pIC = ImmLockIMC(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pIC))
+    if (!pIC)
+    {
+        ERR("!pIC\n");
         return FALSE;
+    }
 
     dwConversion = (pIC->fdwConversion ^ IME_CMODE_HANJACONVERT);
     dwSentence = pIC->fdwSentence;
@@ -233,8 +251,11 @@ BOOL APIENTRY Imm32KEnglish(HIMC hIMC)
     BOOL fOpen;
 
     pIC = ImmLockIMC(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pIC))
+    if (!pIC)
+    {
+        ERR("!pIC\n");
         return FALSE;
+    }
 
     dwConversion = (pIC->fdwConversion ^ IME_CMODE_NATIVE);
     dwSentence = pIC->fdwSentence;
@@ -297,8 +318,11 @@ BOOL APIENTRY Imm32ProcessHotKey(HWND hWnd, HIMC hIMC, HKL hKL, DWORD dwHotKeyID
         return FALSE;
 
     pImeDpi = ImmLockImeDpi(hKL);
-    if (IS_NULL_UNEXPECTEDLY(pImeDpi))
+    if (!pImeDpi)
+    {
+        ERR("!pImeDpi\n");
         return FALSE;
+    }
 
     ret = (BOOL)pImeDpi->ImeEscape(hIMC, IME_ESC_PRIVATE_HOTKEY, &dwHotKeyID);
     ImmUnlockImeDpi(pImeDpi);
@@ -319,8 +343,11 @@ ImmIsUIMessageAW(HWND hWndIME, UINT msg, WPARAM wParam, LPARAM lParam, BOOL bAns
             return FALSE;
     }
 
-    if (IS_NULL_UNEXPECTEDLY(hWndIME))
+    if (!hWndIME)
+    {
+        ERR("!hWndIME\n");
         return TRUE;
+    }
 
     if (bAnsi)
         SendMessageA(hWndIME, msg, wParam, lParam);
@@ -341,8 +368,11 @@ Imm32SendNotificationProc(
     UNREFERENCED_PARAMETER(lParam);
 
     pIC = (LPINPUTCONTEXTDX)ImmLockIMC(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pIC))
+    if (!pIC)
+    {
+        ERR("!pIC\n");
         return TRUE;
+    }
 
     hWnd = pIC->hWnd;
     if (!IsWindow(hWnd))
@@ -427,8 +457,11 @@ Imm32ProcessRequest(HIMC hIMC, PWND pWnd, DWORD dwCommand, LPVOID pData, BOOL bA
             break;
 
         default:
-            if (IS_NULL_UNEXPECTEDLY(pData))
+            if (!pData)
+            {
+                ERR("!pData\n");
                 return 0;
+            }
             break;
     }
 
@@ -451,8 +484,11 @@ Imm32ProcessRequest(HIMC hIMC, PWND pWnd, DWORD dwCommand, LPVOID pData, BOOL bA
             else
                 pTempData = ImmLocalAlloc(0, sizeof(LOGFONTW));
 
-            if (IS_NULL_UNEXPECTEDLY(pTempData))
+            if (!pTempData)
+            {
+                ERR("!pTempData\n");
                 return 0;
+            }
             break;
 
         case IMR_RECONVERTSTRING: case IMR_CONFIRMRECONVERTSTRING: case IMR_DOCUMENTFEED:
@@ -465,8 +501,11 @@ Imm32ProcessRequest(HIMC hIMC, PWND pWnd, DWORD dwCommand, LPVOID pData, BOOL bA
                 ret = Imm32ReconvertWideFromAnsi(NULL, pData, uCodePage);
 
             pTempData = ImmLocalAlloc(0, ret + sizeof(WCHAR));
-            if (IS_NULL_UNEXPECTEDLY(pTempData))
+            if (!pTempData)
+            {
+                ERR("!pTempData\n");
                 return 0;
+            }
 
             pRS = pTempData;
             pRS->dwSize = ret;
@@ -495,8 +534,11 @@ Imm32ProcessRequest(HIMC hIMC, PWND pWnd, DWORD dwCommand, LPVOID pData, BOOL bA
                     return 0;
 
                 pCS = ImmLocalAlloc(0, (cchCompStr + 1) * sizeof(CHAR));
-                if (IS_NULL_UNEXPECTEDLY(pCS))
+                if (!pCS)
+                {
+                    ERR("!pCS\n");
                     return 0;
+                }
 
                 ImmGetCompositionStringA(hIMC, GCS_COMPSTR, pCS, cchCompStr);
                 pICP->dwCharPos = IchWideFromAnsi(pICP->dwCharPos, pCS, uCodePage);
@@ -508,8 +550,11 @@ Imm32ProcessRequest(HIMC hIMC, PWND pWnd, DWORD dwCommand, LPVOID pData, BOOL bA
                     return 0;
 
                 pCS = ImmLocalAlloc(0, (cchCompStr + 1) * sizeof(WCHAR));
-                if (IS_NULL_UNEXPECTEDLY(pCS))
+                if (!pCS)
+                {
+                    ERR("!pCS\n");
                     return 0;
+                }
 
                 ImmGetCompositionStringW(hIMC, GCS_COMPSTR, pCS, cchCompStr);
                 pICP->dwCharPos = IchAnsiFromWide(pICP->dwCharPos, pCS, uCodePage);
@@ -586,12 +631,21 @@ LRESULT APIENTRY ImmRequestMessageAW(HIMC hIMC, WPARAM wParam, LPARAM lParam, BO
     HWND hWnd;
     PWND pWnd = NULL;
 
-    if (IS_NULL_UNEXPECTEDLY(hIMC) || IS_CROSS_THREAD_HIMC(hIMC))
+    if (!hIMC)
+    {
+        ERR("!hIMC\n");
+        return FALSE;
+    }
+
+    if (IS_CROSS_THREAD_HIMC(hIMC))
         return FALSE;
 
     pIC = ImmLockIMC(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pIC))
+    if (!pIC)
+    {
+        ERR("!pIC\n");
         return FALSE;
+    }
 
     hWnd = pIC->hWnd;
     if (hWnd)
@@ -678,8 +732,11 @@ UINT WINAPI ImmGetVirtualKey(HWND hWnd)
 
     hIMC = ImmGetContext(hWnd);
     pIC = (LPINPUTCONTEXTDX)ImmLockIMC(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pIC))
+    if (!pIC)
+    {
+        ERR("!pIC\n");
         return ret;
+    }
 
     if (pIC->bNeedsTrans)
         ret = pIC->nVKey;
@@ -699,8 +756,11 @@ DWORD WINAPI ImmGetAppCompatFlags(HIMC hIMC)
     TRACE("(%p)\n", hIMC);
 
     pClientIMC = ImmLockClientImc(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pClientIMC))
+    if (!pClientIMC)
+    {
+        ERR("!pClientIMC\n");
         return 0;
+    }
 
     dwFlags = pClientIMC->dwCompatFlags;
     ImmUnlockClientImc(pClientIMC);
@@ -853,15 +913,21 @@ BOOL WINAPI ImmGenerateMessage(HIMC hIMC)
         return FALSE;
 
     pClientImc = ImmLockClientImc(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pClientImc))
+    if (!pClientImc)
+    {
+        ERR("!pClientImc\n");
         return FALSE;
+    }
 
     bAnsi = !(pClientImc->dwFlags & CLIENTIMC_WIDE);
     ImmUnlockClientImc(pClientImc);
 
     pIC = ImmLockIMC(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pIC))
+    if (!pIC)
+    {
+        ERR("!pIC\n");
         return FALSE;
+    }
 
     dwCount = pIC->dwNumMsgBuf;
     if (dwCount == 0)
@@ -869,13 +935,19 @@ BOOL WINAPI ImmGenerateMessage(HIMC hIMC)
 
     hMsgBuf = pIC->hMsgBuf;
     pMsgs = ImmLockIMCC(hMsgBuf);
-    if (IS_NULL_UNEXPECTEDLY(pMsgs))
+    if (!pMsgs)
+    {
+        ERR("!pMsgs\n");
         goto Quit;
+    }
 
     cbTrans = dwCount * sizeof(TRANSMSG);
     pTrans = ImmLocalAlloc(0, cbTrans);
-    if (IS_NULL_UNEXPECTEDLY(pTrans))
+    if (!pTrans)
+    {
+        ERR("!pTrans\n");
         goto Quit;
+    }
 
     RtlCopyMemory(pTrans, pMsgs, cbTrans);
 
@@ -923,8 +995,11 @@ ImmPostMessages(HWND hwnd, HIMC hIMC, DWORD dwCount, LPTRANSMSG lpTransMsg)
     BOOL bAnsi;
 
     pClientImc = ImmLockClientImc(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pClientImc))
+    if (!pClientImc)
+    {
+        ERR("!pClientImc\n");
         return;
+    }
 
     bAnsi = !(pClientImc->dwFlags & CLIENTIMC_WIDE);
     ImmUnlockClientImc(pClientImc);
@@ -1004,8 +1079,9 @@ BOOL WINAPI ImmTranslateMessage(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lKeyD
 
     hIMC = ImmGetContext(hwnd);
     pIC = (LPINPUTCONTEXTDX)ImmLockIMC(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pIC))
+    if (!pIC)
     {
+        ERR("!pIC\n");
         ImmReleaseContext(hwnd, hIMC);
         return FALSE;
     }
@@ -1032,8 +1108,11 @@ BOOL WINAPI ImmTranslateMessage(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lKeyD
     dwThreadId = GetWindowThreadProcessId(hwnd, NULL);
     hKL = GetKeyboardLayout(dwThreadId);
     pImeDpi = ImmLockImeDpi(hKL);
-    if (IS_NULL_UNEXPECTEDLY(pImeDpi))
+    if (!pImeDpi)
+    {
+        ERR("!pImeDpi\n");
         goto Quit;
+    }
 
     if (!GetKeyboardState(abKeyState)) /* get keyboard ON/OFF status */
     {
@@ -1074,8 +1153,11 @@ BOOL WINAPI ImmTranslateMessage(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lKeyD
     /* allocate a list */
     cbList = offsetof(TRANSMSGLIST, TransMsg) + MSG_COUNT * sizeof(TRANSMSG);
     pList = ImmLocalAlloc(0, cbList);
-    if (IS_NULL_UNEXPECTEDLY(pList))
+    if (!pList)
+    {
+        ERR("!pList\n");
         goto Quit;
+    }
 
     /* use IME conversion engine and convert the list */
     pList->uMsgCount = MSG_COUNT;
@@ -1092,8 +1174,11 @@ BOOL WINAPI ImmTranslateMessage(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lKeyD
     else
     {
         pTransMsg = ImmLockIMCC(pIC->hMsgBuf);
-        if (IS_NULL_UNEXPECTEDLY(pTransMsg))
+        if (!pTransMsg)
+        {
+            ERR("!pTransMsg\n");
             goto Quit;
+        }
         ImmPostMessages(hwnd, hIMC, kret, pTransMsg);
         ImmUnlockIMCC(pIC->hMsgBuf);
     }
@@ -1162,22 +1247,34 @@ ImmCallImeConsoleIME(
 
     if (hWnd && gpsi)
         pWnd = ValidateHwndNoErr(hWnd);
-    if (IS_NULL_UNEXPECTEDLY(pWnd))
+    if (!pWnd)
+    {
+        ERR("!pWnd\n");
         return 0;
+    }
 
     hIMC = ImmGetContext(hWnd);
-    if (IS_NULL_UNEXPECTEDLY(hIMC))
+    if (!hIMC)
+    {
+        ERR("!hIMC\n");
         return 0;
+    }
 
     uVK = *puVK = (wParam & 0xFF);
 
     pIMC = ValidateHandleNoErr(hIMC, TYPE_INPUTCONTEXT);
-    if (IS_NULL_UNEXPECTEDLY(pIMC))
+    if (!pIMC)
+    {
+        ERR("!pIMC\n");
         return 0;
+    }
 
     pImeDpi = ImmLockImeDpi(hKL);
-    if (IS_NULL_UNEXPECTEDLY(pImeDpi))
+    if (!pImeDpi)
+    {
+        ERR("!pImeDpi\n");
         return 0;
+    }
 
     if ((lParam & MAKELPARAM(0, KF_UP)) && (pImeDpi->ImeInfo.fdwProperty & IME_PROP_IGNORE_UPKEYS))
         goto Quit;

--- a/dll/win32/imm32/precomp.h
+++ b/dll/win32/imm32/precomp.h
@@ -53,8 +53,6 @@
 #if DBG
     #define FAILED_UNEXPECTEDLY(hr) \
         (FAILED(hr) ? (ERR("FAILED(0x%08X)\n", hr), UNEXPECTED()) : FALSE)
-    #define IS_NULL_UNEXPECTEDLY(p) \
-        (!(p) ? (ERR("%s was NULL\n", #p), UNEXPECTED()) : FALSE)
     #define IS_ZERO_UNEXPECTEDLY(p) \
         (!(p) ? (ERR("%s was zero\n", #p), UNEXPECTED()) : FALSE)
     #define IS_TRUE_UNEXPECTEDLY(x) \
@@ -63,7 +61,6 @@
         ((x) != ERROR_SUCCESS ? (ERR("%s was %d\n", #x, (int)(x)), UNEXPECTED()) : FALSE)
 #else
     #define FAILED_UNEXPECTEDLY(hr) FAILED(hr)
-    #define IS_NULL_UNEXPECTEDLY(p) (!(p))
     #define IS_ZERO_UNEXPECTEDLY(p) (!(p))
     #define IS_TRUE_UNEXPECTEDLY(x) (x)
     #define IS_ERROR_UNEXPECTEDLY(x) ((x) != ERROR_SUCCESS)

--- a/dll/win32/imm32/regword.c
+++ b/dll/win32/imm32/regword.c
@@ -38,15 +38,21 @@ Imm32EnumWordProcA2W(LPCSTR pszReadingA, DWORD dwStyle, LPCSTR pszRegisterA, LPV
     if (pszReadingA)
     {
         pszReadingW = Imm32WideFromAnsi(lpEnumData->uCodePage, pszReadingA);
-        if (IS_NULL_UNEXPECTEDLY(pszReadingW))
+        if (!pszReadingW)
+        {
+            ERR("!pszReadingW\n");
             goto Quit;
+        }
     }
 
     if (pszRegisterA)
     {
         pszRegisterW = Imm32WideFromAnsi(lpEnumData->uCodePage, pszRegisterA);
-        if (IS_NULL_UNEXPECTEDLY(pszRegisterW))
+        if (!pszRegisterW)
+        {
+            ERR("!pszRegisterW\n");
             goto Quit;
+        }
     }
 
     ret = lpEnumData->lpfnEnumProc(pszReadingW, dwStyle, pszRegisterW, lpEnumData->lpData);
@@ -68,15 +74,21 @@ Imm32EnumWordProcW2A(LPCWSTR pszReadingW, DWORD dwStyle, LPCWSTR pszRegisterW, L
     if (pszReadingW)
     {
         pszReadingA = Imm32AnsiFromWide(lpEnumData->uCodePage, pszReadingW);
-        if (IS_NULL_UNEXPECTEDLY(pszReadingW))
+        if (!pszReadingW)
+        {
+            ERR("!pszReadingW\n");
             goto Quit;
+        }
     }
 
     if (pszRegisterW)
     {
         pszRegisterA = Imm32AnsiFromWide(lpEnumData->uCodePage, pszRegisterW);
-        if (IS_NULL_UNEXPECTEDLY(pszRegisterA))
+        if (!pszRegisterA)
+        {
+            ERR("!pszRegisterA\n");
             goto Quit;
+        }
     }
 
     ret = lpEnumData->lpfnEnumProc(pszReadingA, dwStyle, pszRegisterA, lpEnumData->lpData);
@@ -105,8 +117,11 @@ ImmEnumRegisterWordA(HKL hKL, REGISTERWORDENUMPROCA lpfnEnumProc,
           dwStyle, lpszRegister, lpData);
 
     pImeDpi = Imm32FindOrLoadImeDpi(hKL);
-    if (IS_NULL_UNEXPECTEDLY(pImeDpi))
+    if (!pImeDpi)
+    {
+        ERR("!pImeDpi\n");
         return 0;
+    }
 
     if (!ImeDpi_IsUnicode(pImeDpi)) /* No conversion needed */
     {
@@ -119,15 +134,21 @@ ImmEnumRegisterWordA(HKL hKL, REGISTERWORDENUMPROCA lpfnEnumProc,
     if (lpszReading)
     {
         pszReadingW = Imm32WideFromAnsi(pImeDpi->uCodePage, lpszReading);
-        if (IS_NULL_UNEXPECTEDLY(pszReadingW))
+        if (!pszReadingW)
+        {
+            ERR("!pszReadingW");
             goto Quit;
+        }
     }
 
     if (lpszRegister)
     {
         pszRegisterW = Imm32WideFromAnsi(pImeDpi->uCodePage, lpszRegister);
-        if (IS_NULL_UNEXPECTEDLY(pszRegisterW))
+        if (!pszRegisterW)
+        {
+            ERR("!pszRegisterW\n");
             goto Quit;
+        }
     }
 
     EnumDataW2A.lpfnEnumProc = lpfnEnumProc;
@@ -162,8 +183,11 @@ ImmEnumRegisterWordW(HKL hKL, REGISTERWORDENUMPROCW lpfnEnumProc,
           dwStyle, lpszRegister, lpData);
 
     pImeDpi = Imm32FindOrLoadImeDpi(hKL);
-    if (IS_NULL_UNEXPECTEDLY(pImeDpi))
+    if (!pImeDpi)
+    {
+        ERR("!pImeDpi\n");
         return 0;
+    }
 
     if (ImeDpi_IsUnicode(pImeDpi)) /* No conversion needed */
     {
@@ -176,15 +200,21 @@ ImmEnumRegisterWordW(HKL hKL, REGISTERWORDENUMPROCW lpfnEnumProc,
     if (lpszReading)
     {
         pszReadingA = Imm32AnsiFromWide(pImeDpi->uCodePage, lpszReading);
-        if (IS_NULL_UNEXPECTEDLY(pszReadingA))
+        if (!pszReadingA)
+        {
+            ERR("!pszReadingA\n");
             goto Quit;
+        }
     }
 
     if (lpszRegister)
     {
         pszRegisterA = Imm32AnsiFromWide(pImeDpi->uCodePage, lpszRegister);
-        if (IS_NULL_UNEXPECTEDLY(pszRegisterA))
+        if (!pszRegisterA)
+        {
+            ERR("!pszRegisterA\n");
             goto Quit;
+        }
     }
 
     EnumDataA2W.lpfnEnumProc = lpfnEnumProc;
@@ -218,8 +248,11 @@ UINT WINAPI ImmGetRegisterWordStyleA(HKL hKL, UINT nItem, LPSTYLEBUFA lpStyleBuf
     TRACE("(%p, %u, %p)\n", hKL, nItem, lpStyleBuf);
 
     pImeDpi = Imm32FindOrLoadImeDpi(hKL);
-    if (IS_NULL_UNEXPECTEDLY(pImeDpi))
+    if (!pImeDpi)
+    {
+        ERR("!pImeDpi\n");
         return 0;
+    }
 
     if (!ImeDpi_IsUnicode(pImeDpi)) /* No conversion needed */
     {
@@ -230,8 +263,11 @@ UINT WINAPI ImmGetRegisterWordStyleA(HKL hKL, UINT nItem, LPSTYLEBUFA lpStyleBuf
     if (nItem > 0)
     {
         pNewStylesW = ImmLocalAlloc(0, nItem * sizeof(STYLEBUFW));
-        if (IS_NULL_UNEXPECTEDLY(pNewStylesW))
+        if (!pNewStylesW)
+        {
+            ERR("!pNewStylesW\n");
             goto Quit;
+        }
     }
 
     ret = pImeDpi->ImeGetRegisterWordStyle(nItem, pNewStylesW);
@@ -277,8 +313,11 @@ UINT WINAPI ImmGetRegisterWordStyleW(HKL hKL, UINT nItem, LPSTYLEBUFW lpStyleBuf
     TRACE("(%p, %u, %p)\n", hKL, nItem, lpStyleBuf);
 
     pImeDpi = Imm32FindOrLoadImeDpi(hKL);
-    if (IS_NULL_UNEXPECTEDLY(pImeDpi))
+    if (!pImeDpi)
+    {
+        ERR("!pImeDpi\n");
         return 0;
+    }
 
     if (ImeDpi_IsUnicode(pImeDpi)) /* No conversion needed */
     {
@@ -289,8 +328,11 @@ UINT WINAPI ImmGetRegisterWordStyleW(HKL hKL, UINT nItem, LPSTYLEBUFW lpStyleBuf
     if (nItem > 0)
     {
         pNewStylesA = ImmLocalAlloc(0, nItem * sizeof(STYLEBUFA));
-        if (IS_NULL_UNEXPECTEDLY(pNewStylesA))
+        if (!pNewStylesA)
+        {
+            ERR("!pNewStylesA\n");
             goto Quit;
+        }
     }
 
     ret = pImeDpi->ImeGetRegisterWordStyle(nItem, pNewStylesA);
@@ -333,8 +375,11 @@ ImmRegisterWordA(HKL hKL, LPCSTR lpszReading, DWORD dwStyle, LPCSTR lpszRegister
     TRACE("(%p, %s, 0x%lX, %s)\n", hKL, lpszReading, dwStyle, lpszRegister);
 
     pImeDpi = Imm32FindOrLoadImeDpi(hKL);
-    if (IS_NULL_UNEXPECTEDLY(pImeDpi))
+    if (!pImeDpi)
+    {
+        ERR("!pImeDpi\n");
         return FALSE;
+    }
 
     if (!ImeDpi_IsUnicode(pImeDpi)) /* No conversion needed */
     {
@@ -346,15 +391,21 @@ ImmRegisterWordA(HKL hKL, LPCSTR lpszReading, DWORD dwStyle, LPCSTR lpszRegister
     if (lpszReading)
     {
         pszReadingW = Imm32WideFromAnsi(pImeDpi->uCodePage, lpszReading);
-        if (IS_NULL_UNEXPECTEDLY(pszReadingW))
+        if (!pszReadingW)
+        {
+            ERR("!pszReadingW\n");
             goto Quit;
+        }
     }
 
     if (lpszRegister)
     {
         pszRegisterW = Imm32WideFromAnsi(pImeDpi->uCodePage, lpszRegister);
-        if (IS_NULL_UNEXPECTEDLY(pszRegisterW))
+        if (!pszRegisterW)
+        {
+            ERR("!pszRegisterW\n");
             goto Quit;
+        }
     }
 
     ret = pImeDpi->ImeRegisterWord(pszReadingW, dwStyle, pszRegisterW);
@@ -380,8 +431,11 @@ ImmRegisterWordW(HKL hKL, LPCWSTR lpszReading, DWORD dwStyle, LPCWSTR lpszRegist
     TRACE("(%p, %S, 0x%lX, %S)\n", hKL, lpszReading, dwStyle, lpszRegister);
 
     pImeDpi = Imm32FindOrLoadImeDpi(hKL);
-    if (IS_NULL_UNEXPECTEDLY(pImeDpi))
+    if (!pImeDpi)
+    {
+        ERR("!pImeDpi\n");
         return FALSE;
+    }
 
     if (ImeDpi_IsUnicode(pImeDpi)) /* No conversion needed */
     {
@@ -393,15 +447,21 @@ ImmRegisterWordW(HKL hKL, LPCWSTR lpszReading, DWORD dwStyle, LPCWSTR lpszRegist
     if (lpszReading)
     {
         pszReadingA = Imm32AnsiFromWide(pImeDpi->uCodePage, lpszReading);
-        if (IS_NULL_UNEXPECTEDLY(pszReadingA))
+        if (!pszReadingA)
+        {
+            ERR("!pszReadingA\n");
             goto Quit;
+        }
     }
 
     if (lpszRegister)
     {
         pszRegisterA = Imm32AnsiFromWide(pImeDpi->uCodePage, lpszRegister);
-        if (IS_NULL_UNEXPECTEDLY(pszRegisterA))
+        if (!pszRegisterA)
+        {
+            ERR("!pszRegisterA\n");
             goto Quit;
+        }
     }
 
     ret = pImeDpi->ImeRegisterWord(pszReadingA, dwStyle, pszRegisterA);
@@ -427,8 +487,11 @@ ImmUnregisterWordA(HKL hKL, LPCSTR lpszReading, DWORD dwStyle, LPCSTR lpszUnregi
     TRACE("(%p, %s, 0x%lX, %s)\n", hKL, lpszReading, dwStyle, lpszUnregister);
 
     pImeDpi = Imm32FindOrLoadImeDpi(hKL);
-    if (IS_NULL_UNEXPECTEDLY(pImeDpi))
+    if (!pImeDpi)
+    {
+        ERR("!pImeDpi\n");
         return FALSE;
+    }
 
     if (!ImeDpi_IsUnicode(pImeDpi)) /* No conversion needed */
     {
@@ -440,15 +503,21 @@ ImmUnregisterWordA(HKL hKL, LPCSTR lpszReading, DWORD dwStyle, LPCSTR lpszUnregi
     if (lpszReading)
     {
         pszReadingW = Imm32WideFromAnsi(pImeDpi->uCodePage, lpszReading);
-        if (IS_NULL_UNEXPECTEDLY(pszReadingW))
+        if (!pszReadingW)
+        {
+            ERR("!pszReadingW\n");
             goto Quit;
+        }
     }
 
     if (lpszUnregister)
     {
         pszUnregisterW = Imm32WideFromAnsi(pImeDpi->uCodePage, lpszUnregister);
-        if (IS_NULL_UNEXPECTEDLY(pszUnregisterW))
+        if (!pszUnregisterW)
+        {
+            ERR("!pszUnregisterW\n");
             goto Quit;
+        }
     }
 
     ret = pImeDpi->ImeUnregisterWord(pszReadingW, dwStyle, pszUnregisterW);
@@ -474,8 +543,11 @@ ImmUnregisterWordW(HKL hKL, LPCWSTR lpszReading, DWORD dwStyle, LPCWSTR lpszUnre
     TRACE("(%p, %S, 0x%lX, %S)\n", hKL, lpszReading, dwStyle, lpszUnregister);
 
     pImeDpi = Imm32FindOrLoadImeDpi(hKL);
-    if (IS_NULL_UNEXPECTEDLY(pImeDpi))
+    if (!pImeDpi)
+    {
+        ERR("!pImeDpi\n");
         return FALSE;
+    }
 
     if (ImeDpi_IsUnicode(pImeDpi)) /* No conversion needed */
     {
@@ -487,15 +559,21 @@ ImmUnregisterWordW(HKL hKL, LPCWSTR lpszReading, DWORD dwStyle, LPCWSTR lpszUnre
     if (lpszReading)
     {
         pszReadingA = Imm32AnsiFromWide(pImeDpi->uCodePage, lpszReading);
-        if (IS_NULL_UNEXPECTEDLY(pszReadingA))
+        if (!pszReadingA)
+        {
+            ERR("!pszReadingA\n");
             goto Quit;
+        }
     }
 
     if (lpszUnregister)
     {
         pszUnregisterA = Imm32AnsiFromWide(pImeDpi->uCodePage, lpszUnregister);
-        if (IS_NULL_UNEXPECTEDLY(pszUnregisterA))
+        if (!pszUnregisterA)
+        {
+            ERR("!pszUnregisterA\n");
             goto Quit;
+        }
     }
 
     ret = pImeDpi->ImeUnregisterWord(pszReadingA, dwStyle, pszUnregisterA);

--- a/dll/win32/imm32/softkbd.c
+++ b/dll/win32/imm32/softkbd.c
@@ -2124,8 +2124,11 @@ ImmCreateSoftKeyboard(
     /* Check IME */
     hKL = GetKeyboardLayout(0);
     pImeDpi = ImmLockImeDpi(hKL);
-    if (IS_NULL_UNEXPECTEDLY(pImeDpi))
+    if (!pImeDpi)
+    {
+        ERR("!pImeDpi\n");
         return NULL; /* No IME */
+    }
 
     UICaps = pImeDpi->ImeInfo.fdwUICaps;
     ImmUnlockImeDpi(pImeDpi);

--- a/dll/win32/imm32/utils.c
+++ b/dll/win32/imm32/utils.c
@@ -217,8 +217,12 @@ BOOL WINAPI Imm32IsImcAnsi(HIMC hIMC)
 {
     BOOL ret;
     PCLIENTIMC pClientImc = ImmLockClientImc(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pClientImc))
+    if (!pClientImc)
+    {
+        ERR("!pClientImc\n");
         return -1;
+    }
+
     ret = !(pClientImc->dwFlags & CLIENTIMC_WIDE);
     ImmUnlockClientImc(pClientImc);
     return ret;
@@ -228,8 +232,12 @@ LPWSTR APIENTRY Imm32WideFromAnsi(UINT uCodePage, LPCSTR pszA)
 {
     INT cch = lstrlenA(pszA);
     LPWSTR pszW = ImmLocalAlloc(0, (cch + 1) * sizeof(WCHAR));
-    if (IS_NULL_UNEXPECTEDLY(pszW))
+    if (!pszW)
+    {
+        ERR("!pszW\n");
         return NULL;
+    }
+
     cch = MultiByteToWideChar(uCodePage, MB_PRECOMPOSED, pszA, cch, pszW, cch + 1);
     pszW[cch] = 0;
     return pszW;
@@ -240,8 +248,12 @@ LPSTR APIENTRY Imm32AnsiFromWide(UINT uCodePage, LPCWSTR pszW)
     INT cchW = lstrlenW(pszW);
     INT cchA = (cchW + 1) * sizeof(WCHAR);
     LPSTR pszA = ImmLocalAlloc(0, cchA);
-    if (IS_NULL_UNEXPECTEDLY(pszA))
+    if (!pszA)
+    {
+        ERR("!pszA\n");
         return NULL;
+    }
+
     cchA = WideCharToMultiByte(uCodePage, 0, pszW, cchW, pszA, cchA, NULL, NULL);
     pszA[cchA] = 0;
     return pszA;
@@ -393,8 +405,11 @@ BOOL APIENTRY Imm32CheckImcProcess(PIMC pIMC)
     HIMC hIMC;
     DWORD_PTR dwPID1, dwPID2;
 
-    if (IS_NULL_UNEXPECTEDLY(pIMC))
+    if (!pIMC)
+    {
+        ERR("!pIMC\n");
         return FALSE;
+    }
 
     if (pIMC->head.pti == Imm32CurrentPti())
         return TRUE;
@@ -417,8 +432,11 @@ LPVOID APIENTRY ImmLocalAlloc(DWORD dwFlags, DWORD dwBytes)
     if (!ghImmHeap)
     {
         ghImmHeap = RtlGetProcessHeap();
-        if (IS_NULL_UNEXPECTEDLY(ghImmHeap))
+        if (!ghImmHeap)
+        {
+            ERR("!ghImmHeap\n");
             return NULL;
+        }
     }
     return HeapAlloc(ghImmHeap, dwFlags, dwBytes);
 }
@@ -466,8 +484,11 @@ DWORD APIENTRY Imm32BuildHimcList(DWORD dwThreadId, HIMC **pphList)
     HIMC *phNewList;
 
     phNewList = ImmLocalAlloc(0, dwCount * sizeof(HIMC));
-    if (IS_NULL_UNEXPECTEDLY(phNewList))
+    if (!phNewList)
+    {
+        ERR("!phNewList\n");
         return 0;
+    }
 
     Status = NtUserBuildHimcList(dwThreadId, dwCount, phNewList, &dwCount);
     while (Status == STATUS_BUFFER_TOO_SMALL)
@@ -477,8 +498,11 @@ DWORD APIENTRY Imm32BuildHimcList(DWORD dwThreadId, HIMC **pphList)
             return 0;
 
         phNewList = ImmLocalAlloc(0, dwCount * sizeof(HIMC));
-        if (IS_NULL_UNEXPECTEDLY(phNewList))
+        if (phNewList)
+        {
+            ERR("!phNewList\n");
             return 0;
+        }
 
         Status = NtUserBuildHimcList(dwThreadId, dwCount, phNewList, &dwCount);
     }
@@ -545,8 +569,11 @@ BOOL APIENTRY
 Imm32LoadImeStateSentence(LPINPUTCONTEXTDX pIC, PIME_STATE pState, HKL hKL)
 {
     PIME_SUBSTATE pSubState = Imm32FetchImeSubState(pState, hKL);
-    if (IS_NULL_UNEXPECTEDLY(pSubState))
+    if (!pSubState)
+    {
+        ERR("!pSubState\n");
         return FALSE;
+    }
 
     pIC->fdwSentence |= pSubState->dwValue;
     return TRUE;
@@ -557,8 +584,11 @@ BOOL APIENTRY
 Imm32SaveImeStateSentence(LPINPUTCONTEXTDX pIC, PIME_STATE pState, HKL hKL)
 {
     PIME_SUBSTATE pSubState = Imm32FetchImeSubState(pState, hKL);
-    if (IS_NULL_UNEXPECTEDLY(pSubState))
+    if (!pSubState)
+    {
+        ERR("!pSubState\n");
         return FALSE;
+    }
 
     pSubState->dwValue = (pIC->fdwSentence & 0xffff0000);
     return TRUE;
@@ -805,8 +835,11 @@ BOOL APIENTRY Imm32LoadImeVerInfo(PIMEINFOEX pImeInfoEx)
     if (!hinstVersion)
     {
         hinstVersion = LoadLibraryW(szPath);
-        if (IS_NULL_UNEXPECTEDLY(hinstVersion))
+        if (!hinstVersion)
+        {
+            ERR("!hinstVersion\n");
             return FALSE;
+        }
 
         bLoaded = TRUE;
     }
@@ -828,8 +861,11 @@ BOOL APIENTRY Imm32LoadImeVerInfo(PIMEINFOEX pImeInfoEx)
         goto Quit;
 
     pVerInfo = ImmLocalAlloc(0, cbVerInfo);
-    if (IS_NULL_UNEXPECTEDLY(pVerInfo))
+    if (!pVerInfo)
+    {
+        ERR("!pVerInfo\n");
         goto Quit;
+    }
 
     /* Load the version info of the IME module */
     if (s_fnGetFileVersionInfoW(szPath, dwHandle, cbVerInfo, pVerInfo) &&
@@ -1084,8 +1120,11 @@ BOOL APIENTRY Imm32CopyImeFile(LPWSTR pszOldFile, LPCWSTR pszNewFile)
     if (!hinstLZ32)
     {
         hinstLZ32 = LoadLibraryW(szLZ32Path);
-        if (IS_NULL_UNEXPECTEDLY(hinstLZ32))
+        if (!hinstLZ32)
+        {
+            ERR("!hinstLZ32\n");
             return FALSE;
+        }
         bLoaded = TRUE;
     }
 
@@ -1199,8 +1238,11 @@ DWORD WINAPI ImmGetIMCLockCount(HIMC hIMC)
     PCLIENTIMC pClientImc;
 
     pClientImc = ImmLockClientImc(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pClientImc))
+    if (!pClientImc)
+    {
+        ERR("!pClientImc\n");
         return 0;
+    }
 
     ret = 0;
     hInputContext = pClientImc->hInputContext;

--- a/dll/win32/imm32/utils.c
+++ b/dll/win32/imm32/utils.c
@@ -498,7 +498,7 @@ DWORD APIENTRY Imm32BuildHimcList(DWORD dwThreadId, HIMC **pphList)
             return 0;
 
         phNewList = ImmLocalAlloc(0, dwCount * sizeof(HIMC));
-        if (phNewList)
+        if (!phNewList)
         {
             ERR("!phNewList\n");
             return 0;

--- a/dll/win32/imm32/win3.c
+++ b/dll/win32/imm32/win3.c
@@ -52,8 +52,11 @@ WINNLSTranslateMessageJ(DWORD dwCount, LPTRANSMSG pTrans, LPINPUTCONTEXTDX pIC,
     // clone the message list
     cbTempList = (dwCount + 1) * sizeof(TRANSMSG);
     pTempList = ImmLocalAlloc(HEAP_ZERO_MEMORY, cbTempList);
-    if (IS_NULL_UNEXPECTEDLY(pTempList))
+    if (!pTempList)
+    {
+        ERR("!pTempList\n");
         return 0;
+    }
     RtlCopyMemory(pTempList, pTrans, dwCount * sizeof(TRANSMSG));
 
     if (pIC->dwUIFlags & 0x2)
@@ -188,12 +191,16 @@ WINNLSTranslateMessage(DWORD dwCount, LPTRANSMSG pEntries, HIMC hIMC, BOOL bAnsi
     LPCOMPOSITIONSTRING pCS;
 
     pIC = (LPINPUTCONTEXTDX)ImmLockIMC(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pIC))
+    if (!pIC)
+    {
+        ERR("!pIC\n");
         return 0;
+    }
 
     pCS = ImmLockIMCC(pIC->hCompStr);
-    if (IS_NULL_UNEXPECTEDLY(pCS))
+    if (!pCS)
     {
+        ERR("!pCS\n");
         ImmUnlockIMC(hIMC);
         return 0;
     }


### PR DESCRIPTION
## Purpose
`IS_NULL_UNEXPECTEDLY` macro is not compatible to Wine. Don't use it.
JIRA issue: [CORE-19268](https://jira.reactos.org/browse/CORE-19268)

## Proposed changes

- Delete `IS_NULL_UNEXPECTEDLY` macro definition and usages.
