### PR TITLE
[IMM32] Revert to Wine module

### DIFF
--- a/dll/win32/imm32/CMakeLists.txt
+++ b/dll/win32/imm32/CMakeLists.txt
@@ -28,6 +28,6 @@ add_rc_deps(imm32.rc ${imm32_rc_deps})
 
 add_library(imm32 MODULE ${SOURCE} imm32.rc)
 set_module_type(imm32 win32dll UNICODE ENTRYPOINT ImmDllInitialize 12)
-target_link_libraries(imm32 wine2ros win32ksys uuid)
+target_link_libraries(imm32 wine win32ksys uuid)
 add_importlibs(imm32 advapi32 user32 gdi32 kernel32 ntdll)
 add_cd_file(TARGET imm32 DESTINATION reactos/system32 FOR all)

--- a/dll/win32/imm32/precomp.h
+++ b/dll/win32/imm32/precomp.h
@@ -44,23 +44,23 @@
 
 #include <strsafe.h>
 
-#include <wine2ros.h>
+#include <wine/debug.h>
 
-/* #define UNEXPECTED() (ASSERT(FALSE), TRUE) */
-#define UNEXPECTED() TRUE
+#define ERR_PRINTF(fmt, ...) \
+    (__WINE_IS_DEBUG_ON(_ERR, __wine_dbch___default) ? (wine_dbg_printf(fmt, ##__VA_ARGS__), TRUE) : TRUE)
 
 /* Unexpected Condition Checkers */
 #if DBG
     #define FAILED_UNEXPECTEDLY(hr) \
-        (FAILED(hr) ? (ERR("FAILED(0x%08X)\n", hr), UNEXPECTED()) : FALSE)
+        (FAILED(hr) ? ERR_PRINTF("FAILED(0x%08X)\n", hr) : FALSE)
     #define IS_NULL_UNEXPECTEDLY(p) \
-        (!(p) ? (ERR("%s was NULL\n", #p), UNEXPECTED()) : FALSE)
+        (!(p) ? ERR_PRINTF("%s was NULL\n", #p) : FALSE)
     #define IS_ZERO_UNEXPECTEDLY(p) \
-        (!(p) ? (ERR("%s was zero\n", #p), UNEXPECTED()) : FALSE)
+        (!(p) ? ERR_PRINTF("%s was zero\n", #p) : FALSE)
     #define IS_TRUE_UNEXPECTEDLY(x) \
-        ((x) ? (ERR("%s was %d\n", #x, (int)(x)), UNEXPECTED()) : FALSE)
+        ((x) ? ERR_PRINTF("%s was %d\n", #x, (int)(x)) : FALSE)
     #define IS_ERROR_UNEXPECTEDLY(x) \
-        ((x) != ERROR_SUCCESS ? (ERR("%s was %d\n", #x, (int)(x)), UNEXPECTED()) : FALSE)
+        ((x) != ERROR_SUCCESS ? ERR_PRINTF("%s was %d\n", #x, (int)(x)) : FALSE)
 #else
     #define FAILED_UNEXPECTEDLY(hr) FAILED(hr)
     #define IS_NULL_UNEXPECTEDLY(p) (!(p))

--- a/dll/win32/imm32/precomp.h
+++ b/dll/win32/imm32/precomp.h
@@ -46,8 +46,11 @@
 
 #include <wine/debug.h>
 
-#define ERR_PRINTF(fmt, ...) \
-    (__WINE_IS_DEBUG_ON(_ERR, __wine_dbch___default) ? (wine_dbg_printf(fmt, ##__VA_ARGS__), TRUE) : TRUE)
+/* #define UNEXPECTED() (ASSERT(FALSE), TRUE) */
+#define UNEXPECTED() TRUE
+
+#define ERR_PRINTF(fmt, ...) (__WINE_IS_DEBUG_ON(_ERR, __wine_dbch___default) ? \
+    (wine_dbg_printf(fmt, ##__VA_ARGS__), UNEXPECTED()) : UNEXPECTED())
 
 /* Unexpected Condition Checkers */
 #if DBG
@@ -58,7 +61,7 @@
     #define IS_ZERO_UNEXPECTEDLY(p) \
         (!(p) ? ERR_PRINTF("%s was zero\n", #p) : FALSE)
     #define IS_TRUE_UNEXPECTEDLY(x) \
-        ((x) ? ERR_PRINTF("%s was %d\n", #x, (int)(x)) : FALSE)
+        ((x) ? ERR_PRINTF("%s was non-zero\n", #x) : FALSE)
     #define IS_ERROR_UNEXPECTEDLY(x) \
         ((x) != ERROR_SUCCESS ? ERR_PRINTF("%s was %d\n", #x, (int)(x)) : FALSE)
 #else


### PR DESCRIPTION
## Purpose
Partially revert #7912.
JIRA issue: [CORE-5743](https://jira.reactos.org/browse/CORE-5743)

## Proposed changes

- Use `wine` instead of `wine2ros`.
- Improve Unexpected Condition Checkers.