### PR TITLE
[NETAPI32] Revert to Wine module

### DIFF
--- a/dll/win32/netapi32/CMakeLists.txt
+++ b/dll/win32/netapi32/CMakeLists.txt
@@ -51,7 +51,7 @@ add_library(netapi32 MODULE
     ${CMAKE_CURRENT_BINARY_DIR}/netapi32.def)
 
 set_module_type(netapi32 win32dll)
-target_link_libraries(netapi32 wine2ros ${PSEH_LIB})
+target_link_libraries(netapi32 wine ${PSEH_LIB})
 add_delay_importlibs(netapi32 samlib secur32)
 add_importlibs(netapi32 iphlpapi ws2_32 advapi32 rpcrt4 msvcrt kernel32 ntdll)
 add_pch(netapi32 netapi32.h "${PCH_SKIP_SOURCE}")

--- a/dll/win32/netapi32/netapi32.h
+++ b/dll/win32/netapi32/netapi32.h
@@ -1,9 +1,7 @@
 #ifndef __WINE_NETAPI32_H__
 #define __WINE_NETAPI32_H__
 
-#ifndef __REACTOS__
 #include <wine/config.h>
-#endif
 
 #include <limits.h>
 #include <stdarg.h>
@@ -21,12 +19,8 @@
 #include <nb30.h>
 #include <iphlpapi.h>
 
-#ifdef __REACTOS__
-#include <wine2ros.h>
-#else
 #include <wine/debug.h>
 #include <wine/unicode.h>
-#endif
 
 #define NTOS_MODE_USER
 #include <ndk/rtlfuncs.h>


### PR DESCRIPTION
## Purpose

Partially revert #7912.
JIRA issue: [CORE-5743](https://jira.reactos.org/browse/CORE-5743)

## Proposed changes

- Use `wine` instead of `wine2ros`.