### PR TITLE
[IMM32] NotifyIME: Improve debug trace

### DIFF
--- a/dll/win32/imm32/ime.c
+++ b/dll/win32/imm32/ime.c
@@ -595,7 +595,8 @@ BOOL WINAPI ImmNotifyIME(HIMC hIMC, DWORD dwAction, DWORD dwIndex, DWORD_PTR dwV
 
     TRACE("NotifyIME(%p, %ld, %ld, %p)\n", hIMC, dwAction, dwIndex, dwValue);
     ret = pImeDpi->NotifyIME(hIMC, dwAction, dwIndex, dwValue);
-    TRACE("NotifyIME = %d\n", ret);
+    if (!ret)
+        ERR("NotifyIME(%p, %ld, %ld, %p) failed\n", hIMC, dwAction, dwIndex, dwValue);
 
     ImmUnlockImeDpi(pImeDpi);
     return ret;

--- a/dll/win32/imm32/ime.c
+++ b/dll/win32/imm32/ime.c
@@ -593,6 +593,7 @@ BOOL WINAPI ImmNotifyIME(HIMC hIMC, DWORD dwAction, DWORD dwIndex, DWORD_PTR dwV
     if (IS_NULL_UNEXPECTEDLY(pImeDpi))
         return FALSE;
 
+    TRACE("NotifyIME(%p, %ld, %ld, %p)\n", hIMC, dwAction, dwIndex, dwValue);
     ret = pImeDpi->NotifyIME(hIMC, dwAction, dwIndex, dwValue);
     ImmUnlockImeDpi(pImeDpi);
     return ret;

--- a/dll/win32/imm32/ime.c
+++ b/dll/win32/imm32/ime.c
@@ -593,10 +593,10 @@ BOOL WINAPI ImmNotifyIME(HIMC hIMC, DWORD dwAction, DWORD dwIndex, DWORD_PTR dwV
     if (IS_NULL_UNEXPECTEDLY(pImeDpi))
         return FALSE;
 
-    TRACE("NotifyIME(%p, %ld, %ld, %p)\n", hIMC, dwAction, dwIndex, dwValue);
+    TRACE("NotifyIME(%p, %lu, %lu, %p)\n", hIMC, dwAction, dwIndex, dwValue);
     ret = pImeDpi->NotifyIME(hIMC, dwAction, dwIndex, dwValue);
     if (!ret)
-        ERR("NotifyIME(%p, %ld, %ld, %p) failed\n", hIMC, dwAction, dwIndex, dwValue);
+        WARN("NotifyIME(%p, %lu, %lu, %p) failed\n", hIMC, dwAction, dwIndex, dwValue);
 
     ImmUnlockImeDpi(pImeDpi);
     return ret;

--- a/dll/win32/imm32/ime.c
+++ b/dll/win32/imm32/ime.c
@@ -595,6 +595,8 @@ BOOL WINAPI ImmNotifyIME(HIMC hIMC, DWORD dwAction, DWORD dwIndex, DWORD_PTR dwV
 
     TRACE("NotifyIME(%p, %ld, %ld, %p)\n", hIMC, dwAction, dwIndex, dwValue);
     ret = pImeDpi->NotifyIME(hIMC, dwAction, dwIndex, dwValue);
+    TRACE("NotifyIME = %d\n", ret);
+
     ImmUnlockImeDpi(pImeDpi);
     return ret;
 }

--- a/dll/win32/imm32/precomp.h
+++ b/dll/win32/imm32/precomp.h
@@ -134,9 +134,15 @@ DWORD APIENTRY
 CandidateListAnsiToWide(const CANDIDATELIST *pAnsiCL, LPCANDIDATELIST pWideCL, DWORD dwBufLen,
                         UINT uCodePage);
 
-BOOL APIENTRY
-Imm32MakeIMENotify(HIMC hIMC, HWND hwnd, DWORD dwAction, DWORD dwIndex, DWORD_PTR dwValue,
-                   DWORD_PTR dwCommand, DWORD_PTR dwData);
+BOOL
+Imm32MakeIMENotify(
+    _In_ HIMC hIMC,
+    _In_ HWND hwnd,
+    _In_ DWORD dwAction,
+    _In_ DWORD dwIndex,
+    _Inout_opt_ DWORD_PTR dwValue,
+    _In_ DWORD dwCommand,
+    _Inout_opt_ DWORD_PTR dwData);
 
 DWORD APIENTRY Imm32BuildHimcList(DWORD dwThreadId, HIMC **pphList);
 

--- a/dll/win32/imm32/precomp.h
+++ b/dll/win32/imm32/precomp.h
@@ -46,11 +46,8 @@
 
 #include <wine/debug.h>
 
-/* #define UNEXPECTED() (ASSERT(FALSE), TRUE) */
-#define UNEXPECTED() TRUE
-
 #define ERR_PRINTF(fmt, ...) (__WINE_IS_DEBUG_ON(_ERR, __wine_dbch___default) ? \
-    (wine_dbg_printf(fmt, ##__VA_ARGS__), UNEXPECTED()) : UNEXPECTED())
+    (wine_dbg_printf("err:(%s:%d) " fmt, __RELFILE__, __LINE__, ##__VA_ARGS__), TRUE) : TRUE)
 
 /* Unexpected Condition Checkers */
 #if DBG

--- a/dll/win32/imm32/precomp.h
+++ b/dll/win32/imm32/precomp.h
@@ -138,7 +138,7 @@ CandidateListAnsiToWide(const CANDIDATELIST *pAnsiCL, LPCANDIDATELIST pWideCL, D
                         UINT uCodePage);
 
 BOOL APIENTRY
-Imm32MakeIMENotify(HIMC hIMC, HWND hwnd, DWORD dwAction, DWORD_PTR dwIndex, DWORD_PTR dwValue,
+Imm32MakeIMENotify(HIMC hIMC, HWND hwnd, DWORD dwAction, DWORD dwIndex, DWORD_PTR dwValue,
                    DWORD_PTR dwCommand, DWORD_PTR dwData);
 
 DWORD APIENTRY Imm32BuildHimcList(DWORD dwThreadId, HIMC **pphList);

--- a/dll/win32/imm32/utils.c
+++ b/dll/win32/imm32/utils.c
@@ -423,9 +423,15 @@ LPVOID APIENTRY ImmLocalAlloc(DWORD dwFlags, DWORD dwBytes)
     return HeapAlloc(ghImmHeap, dwFlags, dwBytes);
 }
 
-BOOL APIENTRY
-Imm32MakeIMENotify(HIMC hIMC, HWND hwnd, DWORD dwAction, DWORD dwIndex, DWORD_PTR dwValue,
-                   DWORD_PTR dwCommand, DWORD_PTR dwData)
+BOOL
+Imm32MakeIMENotify(
+    _In_ HIMC hIMC,
+    _In_ HWND hwnd,
+    _In_ DWORD dwAction,
+    _In_ DWORD dwIndex,
+    _Inout_opt_ DWORD_PTR dwValue,
+    _In_ DWORD dwCommand,
+    _Inout_opt_ DWORD_PTR dwData)
 {
     DWORD dwThreadId;
     HKL hKL;

--- a/dll/win32/imm32/utils.c
+++ b/dll/win32/imm32/utils.c
@@ -442,9 +442,9 @@ Imm32MakeIMENotify(HIMC hIMC, HWND hwnd, DWORD dwAction, DWORD dwIndex, DWORD_PT
             if (pImeDpi)
             {
                 /* do notify */
-                TRACE("NotifyIME(%p, %ld, %ld, %p)\n", hIMC, dwAction, dwIndex, dwValue);
+                TRACE("NotifyIME(%p, %lu, %lu, %p)\n", hIMC, dwAction, dwIndex, dwValue);
                 if (!pImeDpi->NotifyIME(hIMC, dwAction, dwIndex, dwValue))
-                    ERR("NotifyIME(%p, %ld, %ld, %p) failed\n", hIMC, dwAction, dwIndex, dwValue);
+                    WARN("NotifyIME(%p, %lu, %lu, %p) failed\n", hIMC, dwAction, dwIndex, dwValue);
 
                 ImmUnlockImeDpi(pImeDpi); /* unlock */
             }

--- a/dll/win32/imm32/utils.c
+++ b/dll/win32/imm32/utils.c
@@ -424,7 +424,7 @@ LPVOID APIENTRY ImmLocalAlloc(DWORD dwFlags, DWORD dwBytes)
 }
 
 BOOL APIENTRY
-Imm32MakeIMENotify(HIMC hIMC, HWND hwnd, DWORD dwAction, DWORD_PTR dwIndex, DWORD_PTR dwValue,
+Imm32MakeIMENotify(HIMC hIMC, HWND hwnd, DWORD dwAction, DWORD dwIndex, DWORD_PTR dwValue,
                    DWORD_PTR dwCommand, DWORD_PTR dwData)
 {
     DWORD dwThreadId;
@@ -442,7 +442,7 @@ Imm32MakeIMENotify(HIMC hIMC, HWND hwnd, DWORD dwAction, DWORD_PTR dwIndex, DWOR
             if (pImeDpi)
             {
                 /* do notify */
-                TRACE("NotifyIME(%p, %ld, %p, %p)\n", hIMC, dwAction, dwIndex, dwValue);
+                TRACE("NotifyIME(%p, %ld, %ld, %p)\n", hIMC, dwAction, dwIndex, dwValue);
                 pImeDpi->NotifyIME(hIMC, dwAction, dwIndex, dwValue);
 
                 ImmUnlockImeDpi(pImeDpi); /* unlock */

--- a/dll/win32/imm32/utils.c
+++ b/dll/win32/imm32/utils.c
@@ -423,7 +423,6 @@ LPVOID APIENTRY ImmLocalAlloc(DWORD dwFlags, DWORD dwBytes)
     return HeapAlloc(ghImmHeap, dwFlags, dwBytes);
 }
 
-// Win: MakeIMENotify
 BOOL APIENTRY
 Imm32MakeIMENotify(HIMC hIMC, HWND hwnd, DWORD dwAction, DWORD_PTR dwIndex, DWORD_PTR dwValue,
                    DWORD_PTR dwCommand, DWORD_PTR dwData)
@@ -443,11 +442,24 @@ Imm32MakeIMENotify(HIMC hIMC, HWND hwnd, DWORD dwAction, DWORD_PTR dwIndex, DWOR
             if (pImeDpi)
             {
                 /* do notify */
+                TRACE("NotifyIME(%p, %ld, %p, %p)\n", hIMC, dwAction, dwIndex, dwValue);
                 pImeDpi->NotifyIME(hIMC, dwAction, dwIndex, dwValue);
 
                 ImmUnlockImeDpi(pImeDpi); /* unlock */
             }
+            else
+            {
+                WARN("pImeDpi was NULL\n");
+            }
         }
+        else
+        {
+            WARN("dwThreadId was zero\n");
+        }
+    }
+    else
+    {
+        WARN("dwAction was zero\n");
     }
 
     if (hwnd && dwCommand)

--- a/dll/win32/imm32/utils.c
+++ b/dll/win32/imm32/utils.c
@@ -430,6 +430,7 @@ Imm32MakeIMENotify(HIMC hIMC, HWND hwnd, DWORD dwAction, DWORD dwIndex, DWORD_PT
     DWORD dwThreadId;
     HKL hKL;
     PIMEDPI pImeDpi;
+    BOOL ret;
 
     if (dwAction != 0)
     {
@@ -443,7 +444,8 @@ Imm32MakeIMENotify(HIMC hIMC, HWND hwnd, DWORD dwAction, DWORD dwIndex, DWORD_PT
             {
                 /* do notify */
                 TRACE("NotifyIME(%p, %ld, %ld, %p)\n", hIMC, dwAction, dwIndex, dwValue);
-                pImeDpi->NotifyIME(hIMC, dwAction, dwIndex, dwValue);
+                ret = pImeDpi->NotifyIME(hIMC, dwAction, dwIndex, dwValue);
+                TRACE("NotifyIME = %d\n", ret);
 
                 ImmUnlockImeDpi(pImeDpi); /* unlock */
             }

--- a/dll/win32/imm32/utils.c
+++ b/dll/win32/imm32/utils.c
@@ -430,7 +430,6 @@ Imm32MakeIMENotify(HIMC hIMC, HWND hwnd, DWORD dwAction, DWORD dwIndex, DWORD_PT
     DWORD dwThreadId;
     HKL hKL;
     PIMEDPI pImeDpi;
-    BOOL ret;
 
     if (dwAction != 0)
     {
@@ -444,8 +443,8 @@ Imm32MakeIMENotify(HIMC hIMC, HWND hwnd, DWORD dwAction, DWORD dwIndex, DWORD_PT
             {
                 /* do notify */
                 TRACE("NotifyIME(%p, %ld, %ld, %p)\n", hIMC, dwAction, dwIndex, dwValue);
-                ret = pImeDpi->NotifyIME(hIMC, dwAction, dwIndex, dwValue);
-                TRACE("NotifyIME = %d\n", ret);
+                if (!pImeDpi->NotifyIME(hIMC, dwAction, dwIndex, dwValue))
+                    ERR("NotifyIME(%p, %ld, %ld, %p) failed\n", hIMC, dwAction, dwIndex, dwValue);
 
                 ImmUnlockImeDpi(pImeDpi); /* unlock */
             }


### PR DESCRIPTION
## Purpose
Unleash our debugging power.
JIRA issue: [CORE-19455](https://jira.reactos.org/browse/CORE-19455)

## Proposed changes

- Add some traces for `NotifyIME` calls.
- Improve `Imm32MakeIMENotify` trace.
- Make some parameter types of `Imm32MakeIMENotify` function `DWORD`'s. 
- Fix and improve `ERR_PRINTF` macro.