### PR TITLE
[IMM32] Fix ImmLocalAlloc usage

### DIFF
--- a/dll/win32/imm32/imemenu.c
+++ b/dll/win32/imm32/imemenu.c
@@ -562,7 +562,7 @@ ImmGetImeMenuItemsAW(
             if (lpImeMenuItems)
             {
                 cbTotal = ((dwSize / sizeof(IMEMENUITEMINFOA)) * sizeof(IMEMENUITEMINFOW));
-                pNewItems = ImmLocalAlloc(LPTR, cbTotal);
+                pNewItems = ImmLocalAlloc(0, cbTotal);
                 if (!pNewItems)
                 {
                     ERR("!pNewItems\n");
@@ -583,7 +583,7 @@ ImmGetImeMenuItemsAW(
             if (lpImeMenuItems)
             {
                 cbTotal = ((dwSize / sizeof(IMEMENUITEMINFOW)) * sizeof(IMEMENUITEMINFOA));
-                pNewItems = ImmLocalAlloc(LPTR, cbTotal);
+                pNewItems = ImmLocalAlloc(0, cbTotal);
                 if (!pNewItems)
                 {
                     ERR("!pNewItems\n");

--- a/dll/win32/imm32/precomp.h
+++ b/dll/win32/imm32/precomp.h
@@ -113,7 +113,7 @@ LPVOID FASTCALL ValidateHandle(HANDLE hObject, UINT uType);
 #define ValidateHwnd(hwnd) ValidateHandle((hwnd), TYPE_WINDOW)
 BOOL APIENTRY Imm32CheckImcProcess(PIMC pIMC);
 
-LPVOID APIENTRY ImmLocalAlloc(DWORD dwFlags, DWORD dwBytes);
+LPVOID ImmLocalAlloc(_In_ DWORD dwFlags, _In_ DWORD dwBytes);
 #define ImmLocalFree(lpData) HeapFree(ghImmHeap, 0, (lpData))
 
 LPWSTR APIENTRY Imm32WideFromAnsi(UINT uCodePage, LPCSTR pszA);

--- a/dll/win32/imm32/utils.c
+++ b/dll/win32/imm32/utils.c
@@ -411,8 +411,7 @@ BOOL APIENTRY Imm32CheckImcProcess(PIMC pIMC)
     return TRUE;
 }
 
-// Win: ImmLocalAlloc
-LPVOID APIENTRY ImmLocalAlloc(DWORD dwFlags, DWORD dwBytes)
+LPVOID ImmLocalAlloc(_In_ DWORD dwFlags, _In_ DWORD dwBytes)
 {
     if (!ghImmHeap)
     {


### PR DESCRIPTION
## Purpose

This PR fixes the `ImmLocalAlloc` usage by replacing the `LPTR` flag (designed for `LocalAlloc`) with `0`, which is appropriate for `ImmLocalAlloc` that uses `HeapAlloc` internally.

JIRA issue: [CORE-19268](https://jira.reactos.org/browse/CORE-19268)

## Proposed changes

- Replaces `LPTR` with `0` in two calls to `ImmLocalAlloc` within `imemenu.c` (No need to zero-fill).