### PR TITLE
[IMM32] ImeGetImeMenuItems is optional

### DIFF
--- a/dll/win32/imm32/imemenu.c
+++ b/dll/win32/imm32/imemenu.c
@@ -541,7 +541,7 @@ ImmGetImeMenuItemsAW(
     /* ImeGetImeMenuItems is optional */
     if (!pImeDpi->ImeGetImeMenuItems)
     {
-        WARN("ImeGetImeMenuItems is not available. This is optional.\n");
+        WARN("ImeGetImeMenuItems is not available (optional).\n");
         ImmUnlockImeDpi(pImeDpi);
         ImmUnlockIMC(hIMC);
         return 0;

--- a/dll/win32/imm32/imemenu.c
+++ b/dll/win32/imm32/imemenu.c
@@ -538,6 +538,15 @@ ImmGetImeMenuItemsAW(
         return 0;
     }
 
+    /* ImeGetImeMenuItems is optional */
+    if (!pImeDpi->ImeGetImeMenuItems)
+    {
+        ERR("!pImeDpi->ImeGetImeMenuItems\n");
+        ImmUnlockImeDpi(pImeDpi);
+        ImmUnlockIMC(hIMC);
+        return 0;
+    }
+
     /* Is the IME ANSI? */
     BOOL bImcIsAnsi = Imm32IsImcAnsi(hIMC);
 

--- a/dll/win32/imm32/imemenu.c
+++ b/dll/win32/imm32/imemenu.c
@@ -541,7 +541,7 @@ ImmGetImeMenuItemsAW(
     /* ImeGetImeMenuItems is optional */
     if (!pImeDpi->ImeGetImeMenuItems)
     {
-        ERR("!pImeDpi->ImeGetImeMenuItems\n");
+        WARN("ImeGetImeMenuItems is not available. This is optional.\n");
         ImmUnlockImeDpi(pImeDpi);
         ImmUnlockIMC(hIMC);
         return 0;


### PR DESCRIPTION
## Purpose
Supporting old IMEs.
JIRA issue: [CORE-19268](https://jira.reactos.org/browse/CORE-19268)

## Proposed changes

- Do null check of `ImeGetImeMenuItems` function of IME side, in `ImmGetImeMenuItemsAW` function.