### PR TITLE
[IMM32][NTUSER] Strictly check Cicero IME

### DIFF
--- a/dll/win32/imm32/ctf.c
+++ b/dll/win32/imm32/ctf.c
@@ -929,7 +929,7 @@ HRESULT
 CtfImmTIMDestroyInputContext(
     _In_ HIMC hIMC)
 {
-    if (!IS_CICERO_MODE() || (GetWin32ClientInfo()->dwCompatFlags2 & 2))
+    if (!IS_CICERO_MODE() || IS_CICERO_COMPAT())
         return E_NOINTERFACE;
 
     return CtfImeDestroyInputContext(hIMC);

--- a/dll/win32/imm32/ctf.c
+++ b/dll/win32/imm32/ctf.c
@@ -929,7 +929,7 @@ HRESULT
 CtfImmTIMDestroyInputContext(
     _In_ HIMC hIMC)
 {
-    if (!IS_CICERO_MODE() || IS_CICERO_COMPAT())
+    if (!IS_CICERO_MODE() || IS_CICERO_COMPAT_DISABLED())
         return E_NOINTERFACE;
 
     return CtfImeDestroyInputContext(hIMC);

--- a/dll/win32/imm32/ime.c
+++ b/dll/win32/imm32/ime.c
@@ -756,12 +756,6 @@ UINT WINAPI ImmGetDescriptionA(HKL hKL, LPSTR lpszDescription, UINT uBufLen)
 
     TRACE("(%p,%p,%d)\n", hKL, lpszDescription, uBufLen);
 
-    if (!IS_IME_HKL(hKL))
-    {
-        TRACE("\n");
-        return 0;
-    }
-
     if (!ImmGetImeInfoEx(&info, ImeInfoExKeyboardLayout, &hKL))
     {
         ERR("\n");
@@ -786,12 +780,6 @@ UINT WINAPI ImmGetDescriptionW(HKL hKL, LPWSTR lpszDescription, UINT uBufLen)
 
     TRACE("(%p, %p, %d)\n", hKL, lpszDescription, uBufLen);
 
-    if (!IS_IME_HKL(hKL))
-    {
-        TRACE("\n");
-        return 0;
-    }
-
     if (!ImmGetImeInfoEx(&info, ImeInfoExKeyboardLayout, &hKL))
     {
         ERR("\n");
@@ -815,14 +803,6 @@ UINT WINAPI ImmGetIMEFileNameA( HKL hKL, LPSTR lpszFileName, UINT uBufLen)
     size_t cch;
 
     TRACE("(%p, %p, %u)\n", hKL, lpszFileName, uBufLen);
-
-    if (!IS_IME_HKL(hKL))
-    {
-        TRACE("\n");
-        if (uBufLen > 0)
-            lpszFileName[0] = 0;
-        return 0;
-    }
 
     if (!ImmGetImeInfoEx(&info, ImeInfoExKeyboardLayout, &hKL))
     {
@@ -856,14 +836,6 @@ UINT WINAPI ImmGetIMEFileNameW(HKL hKL, LPWSTR lpszFileName, UINT uBufLen)
 
     TRACE("(%p, %p, %u)\n", hKL, lpszFileName, uBufLen);
 
-    if (!IS_IME_HKL(hKL))
-    {
-        TRACE("\n");
-        if (uBufLen > 0)
-            lpszFileName[0] = 0;
-        return 0;
-    }
-
     if (!ImmGetImeInfoEx(&info, ImeInfoExKeyboardLayout, &hKL))
     {
         ERR("\n");
@@ -896,12 +868,6 @@ DWORD WINAPI ImmGetProperty(HKL hKL, DWORD fdwIndex)
     PIMEDPI pImeDpi = NULL;
 
     TRACE("(%p, %lu)\n", hKL, fdwIndex);
-
-    if (!IS_IME_HKL(hKL))
-    {
-        TRACE("\n");
-        return FALSE;
-    }
 
     if (!ImmGetImeInfoEx(&ImeInfoEx, ImeInfoExKeyboardLayout, &hKL))
     {

--- a/dll/win32/imm32/ime.c
+++ b/dll/win32/imm32/ime.c
@@ -194,7 +194,6 @@ BOOL APIENTRY Imm32InquireIme(PIMEDPI pImeDpi)
 #include <imetable.h>
 #undef DEFINE_IME_ENTRY
 
-// Win: LoadIME
 BOOL APIENTRY Imm32LoadIME(PIMEINFOEX pImeInfoEx, PIMEDPI pImeDpi)
 {
     WCHAR szPath[MAX_PATH];
@@ -229,6 +228,23 @@ BOOL APIENTRY Imm32LoadIME(PIMEINFOEX pImeInfoEx, PIMEDPI pImeDpi)
     } while (0);
 #include <imetable.h>
 #undef DEFINE_IME_ENTRY
+
+    /* Check for Cicero IMEs */
+    if (!IS_IME_HKL(pImeDpi->hKL) && IS_CICERO_MODE() && (GetWin32ClientInfo()->dwCompatFlags2 & 2))
+    {
+#define CHECK_IME_FN(name) do { \
+    if (!pImeDpi->name) { \
+        ERR("'%s' not found in Cicero IME module '%S'.\n", #name, szPath); \
+        goto Failed; \
+    } \
+} while(0)
+        CHECK_IME_FN(CtfImeInquireExW);
+        CHECK_IME_FN(CtfImeSelectEx);
+        CHECK_IME_FN(CtfImeEscapeEx);
+        CHECK_IME_FN(CtfImeGetGuidAtom);
+        CHECK_IME_FN(CtfImeIsGuidMapEnable);
+#undef CHECK_IME_FN
+    }
 
     if (Imm32InquireIme(pImeDpi))
     {

--- a/dll/win32/imm32/ime.c
+++ b/dll/win32/imm32/ime.c
@@ -230,7 +230,7 @@ BOOL APIENTRY Imm32LoadIME(PIMEINFOEX pImeInfoEx, PIMEDPI pImeDpi)
 #undef DEFINE_IME_ENTRY
 
     /* Check for Cicero IMEs */
-    if (!IS_IME_HKL(pImeDpi->hKL) && IS_CICERO_MODE() && IS_CICERO_COMPAT())
+    if (!IS_IME_HKL(pImeDpi->hKL) && IS_CICERO_MODE() && !IS_CICERO_COMPAT_DISABLED())
     {
 #define CHECK_IME_FN(name) do { \
     if (!pImeDpi->name) { \
@@ -626,8 +626,11 @@ ImmGetImeInfoEx(PIMEINFOEX pImeInfoEx, IMEINFOEXCLASS SearchType, PVOID pvSearch
         HKL hKL = *(HKL *)pvSearchKey;
         pImeInfoEx->hkl = hKL;
 
-        if (!IS_IME_HKL(hKL) && (!IS_CICERO_MODE() || IS_CICERO_COMPAT() || bTextServiceDisabled))
+        if (!IS_IME_HKL(hKL) &&
+            (!IS_CICERO_MODE() || IS_CICERO_COMPAT_DISABLED() || bTextServiceDisabled))
+        {
             return FALSE;
+        }
 
         return NtUserGetImeInfoEx(pImeInfoEx, SearchType);
     }

--- a/dll/win32/imm32/ime.c
+++ b/dll/win32/imm32/ime.c
@@ -629,6 +629,7 @@ ImmGetImeInfoEx(PIMEINFOEX pImeInfoEx, IMEINFOEXCLASS SearchType, PVOID pvSearch
         if (!IS_IME_HKL(hKL) &&
             (!IS_CICERO_MODE() || IS_CICERO_COMPAT_DISABLED() || bTextServiceDisabled))
         {
+            TRACE("IME is disabled\n");
             return FALSE;
         }
 
@@ -641,7 +642,8 @@ ImmGetImeInfoEx(PIMEINFOEX pImeInfoEx, IMEINFOEXCLASS SearchType, PVOID pvSearch
         return NtUserGetImeInfoEx(pImeInfoEx, SearchType);
     }
 
-    /* ImeInfoExImeWindow is ignored */
+    /* NOTE: ImeInfoExImeWindow is ignored */
+    ERR("SearchType: %d\n", SearchType);
     return FALSE;
 }
 

--- a/dll/win32/imm32/ime.c
+++ b/dll/win32/imm32/ime.c
@@ -6,7 +6,7 @@
  *              Copyright 2002, 2003, 2007 CodeWeavers, Aric Stewart
  *              Copyright 2017 James Tabor <james.tabor@reactos.org>
  *              Copyright 2018 Amine Khaldi <amine.khaldi@reactos.org>
- *              Copyright 2020-2022 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ *              Copyright 2020-2025 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  */
 
 #include "precomp.h"

--- a/dll/win32/imm32/ime.c
+++ b/dll/win32/imm32/ime.c
@@ -230,7 +230,7 @@ BOOL APIENTRY Imm32LoadIME(PIMEINFOEX pImeInfoEx, PIMEDPI pImeDpi)
 #undef DEFINE_IME_ENTRY
 
     /* Check for Cicero IMEs */
-    if (!IS_IME_HKL(pImeDpi->hKL) && IS_CICERO_MODE() && (GetWin32ClientInfo()->dwCompatFlags2 & 2))
+    if (!IS_IME_HKL(pImeDpi->hKL) && IS_CICERO_MODE() && IS_CICERO_COMPAT())
     {
 #define CHECK_IME_FN(name) do { \
     if (!pImeDpi->name) { \

--- a/win32ss/include/ntuser.h
+++ b/win32ss/include/ntuser.h
@@ -1207,12 +1207,13 @@ typedef struct tagCURSORDATA
 #define CURSORF_CURRENT      0x0200
 
 /* Flags for dwCompatFlags2 */
-#define COMPAT_FLAG_2_CICERO 2
+#define COMPAT_FLAG_2_CICERO_DISABLED 2
 
 #define IS_IMM_MODE() (gpsi && (gpsi->dwSRVIFlags & SRVINFO_IMM32))
 #define IS_CICERO_MODE() (gpsi && (gpsi->dwSRVIFlags & SRVINFO_CICERO_ENABLED))
 #define IS_16BIT_MODE() (GetWin32ClientInfo()->dwTIFlags & TIF_16BIT)
-#define IS_CICERO_COMPAT() (GetWin32ClientInfo()->dwCompatFlags2 & COMPAT_FLAG_2_CICERO)
+#define IS_CICERO_COMPAT_DISABLED() \
+    (GetWin32ClientInfo()->dwCompatFlags2 & COMPAT_FLAG_2_CICERO_DISABLED)
 
 typedef struct tagIMEUI
 {

--- a/win32ss/include/ntuser.h
+++ b/win32ss/include/ntuser.h
@@ -1206,9 +1206,13 @@ typedef struct tagCURSORDATA
 #define CURSORF_LINKED       0x0100
 #define CURSORF_CURRENT      0x0200
 
+/* Flags for dwCompatFlags2 */
+#define COMPAT_FLAG_2_CICERO 2
+
 #define IS_IMM_MODE() (gpsi && (gpsi->dwSRVIFlags & SRVINFO_IMM32))
 #define IS_CICERO_MODE() (gpsi && (gpsi->dwSRVIFlags & SRVINFO_CICERO_ENABLED))
 #define IS_16BIT_MODE() (GetWin32ClientInfo()->dwTIFlags & TIF_16BIT)
+#define IS_CICERO_COMPAT() (GetWin32ClientInfo()->dwCompatFlags2 & COMPAT_FLAG_2_CICERO)
 
 typedef struct tagIMEUI
 {

--- a/win32ss/user/ntuser/ime.c
+++ b/win32ss/user/ntuser/ime.c
@@ -946,7 +946,6 @@ Quit:
     return ret;
 }
 
-// Win: GetImeInfoEx
 BOOL FASTCALL
 UserGetImeInfoEx(
     _Inout_ PWINSTATION_OBJECT pWinSta,
@@ -1006,8 +1005,8 @@ UserGetImeInfoEx(
 BOOL
 NTAPI
 NtUserGetImeInfoEx(
-    PIMEINFOEX pImeInfoEx,
-    IMEINFOEXCLASS SearchType)
+    _Inout_ PIMEINFOEX pImeInfoEx,
+    _In_ IMEINFOEXCLASS SearchType)
 {
     IMEINFOEX ImeInfoEx;
     BOOL ret = FALSE;
@@ -1018,6 +1017,7 @@ NtUserGetImeInfoEx(
     if (!IS_IMM_MODE())
     {
         ERR("!IS_IMM_MODE()\n");
+        EngSetLastError(ERROR_CALL_NOT_IMPLEMENTED);
         goto Quit;
     }
 

--- a/win32ss/user/ntuser/ime.c
+++ b/win32ss/user/ntuser/ime.c
@@ -1824,6 +1824,12 @@ NtUserQueryInputContext(HIMC hIMC, DWORD dwType)
             if (ptiIMC->spDefaultImc)
                 ret = (DWORD_PTR)UserHMGetHandle(ptiIMC->spDefaultImc);
             break;
+
+        default:
+        {
+            FIXME("dwType: %ld\n", dwType);
+            break;
+        }
     }
 
 Quit:


### PR DESCRIPTION
## Purpose
This PR enhances Cicero IME support.
JIRA issue: [CORE-19268](https://jira.reactos.org/browse/CORE-19268)

## Proposed changes

- Add null checks for the functions of Cicero IMEs in `Imm32LoadIME` function.
- Add and use `IS_CICERO_COMPAT_DISABLED` macro in `win32ss/include/ntuser.h`.
- Fix `ImmGetImeInfoEx`, `Imm32LoadImeDpi`, `ImmGetDescriptionA`, `ImmGetDescriptionW`, `ImmGetIMEFileNameA`, `ImmGetIMEFileNameW`, and `ImmGetProperty` functions for Cicero IME support.
- Set last error in `NtUserGetImeInfoEx`.