### PR TITLE
[SHELL32] [KERNEL32] Implement Some API Calls for Steam

### DIFF
--- a/dll/win32/shell32/shell32.spec
+++ b/dll/win32/shell32/shell32.spec
@@ -467,3 +467,4 @@
 755 stdcall -noname PathIsEqualOrSubFolder(wstr wstr)
 756 stub -noname DeleteFileThumbnail
 757 stdcall -version=0x600+ DisplayNameOfW(ptr ptr long ptr long)
+758 stdcall -version=0x600+ SHGetKnownFolderPath(ptr long ptr ptr)

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -3396,3 +3396,243 @@ HRESULT WINAPI SHGetSpecialFolderLocation(
     hr = SHGetFolderLocation(hwndOwner, nFolder, NULL, 0, ppidl);
     return hr;
 }
+
+#ifdef __REACTOS__
+/*************************************************************************
+ * SHGetKnownFolderPath [SHELL32.758] (Vista+)
+ *
+ * Retrieves the path of a known folder identified by its ID.
+ *
+ * PARAMS
+ *   rfid       [I] A KNOWNFOLDERID GUID that identifies the folder.
+ *   dwFlags    [I] Flags to specify retrieval options.
+ *   hToken     [I] An access token that represents a specific user.
+ *                  Can be NULL (current user), -1 (default user profile),
+ *                  or a valid token handle.
+ *   ppszPath   [O] Pointer to a buffer allocated with SHAlloc that contains
+ *                  the path string. Caller is responsible for freeing.
+ *
+ * RETURNS
+ *   S_OK: Success. *ppszPath contains the path.
+ *   S_FALSE: Folder exists but has no path (virtual folder without KF_FLAG_NO_ALIAS).
+ *   E_INVALIDARG: rfid is not a valid KNOWNFOLDERID or ppszPath is NULL.
+ *   Other HRESULT error codes on failure (e.g., out of memory, path not found).
+ */
+HRESULT WINAPI SHGetKnownFolderPath(
+    REFKNOWNFOLDERID rfid,
+    DWORD dwFlags,
+    HANDLE hToken,
+    PWSTR *ppszPath)
+{
+    UINT i;
+    HRESULT hr = E_INVALIDARG;
+    WCHAR szPath[MAX_PATH];
+    INT mapped_csidl = -1;
+
+    if (!ppszPath)
+        return E_INVALIDARG;
+
+    *ppszPath = NULL;
+
+    if ((dwFlags & KF_FLAG_DEFAULT_PATH) && (hToken == NULL))
+        hToken = (HANDLE)-1;
+
+    for (i = 0; i < ARRAY_SIZE(CSIDL_Data); ++i)
+    {
+        if (IsEqualGUID(rfid, CSIDL_Data[i].id))
+        {
+            mapped_csidl = i;
+            hr = S_OK;
+            break;
+        }
+    }
+
+    if (mapped_csidl == -1)
+    {
+        return E_INVALIDARG;
+    }
+
+    CSIDL_Type type = CSIDL_Data[mapped_csidl].type;
+    LPCWSTR szDefaultPath = CSIDL_Data[mapped_csidl].szDefaultPath;
+    int nShell32IconIndex = CSIDL_Data[mapped_csidl].nShell32IconIndex;
+
+
+    switch (mapped_csidl)
+    {
+        case CSIDL_INTERNET:
+        case CSIDL_CONTROLS:
+        case CSIDL_PRINTERS:
+        case CSIDL_BITBUCKET:
+        case CSIDL_DRIVES:
+        case CSIDL_NETWORK:
+        case CSIDL_CONNECTIONS:
+            if (!(dwFlags & KF_FLAG_NO_ALIAS))
+            {
+                return S_FALSE;
+            }
+            break;
+        default:
+             break;
+    }
+
+
+    szPath[0] = UNICODE_NULL;
+
+    DWORD internalFlags = 0;
+    if (dwFlags & KF_FLAG_DEFAULT_PATH)
+        internalFlags |= SHGFP_TYPE_DEFAULT;
+
+    switch (type)
+    {
+        case CSIDL_Type_Disallowed:
+            hr = E_INVALIDARG;
+            break;
+        case CSIDL_Type_NonExistent:
+             hr = HRESULT_FROM_WIN32(ERROR_PATH_NOT_FOUND);
+             break;
+        case CSIDL_Type_WindowsPath:
+            if (!GetWindowsDirectoryW(szPath, MAX_PATH))
+            {
+                hr = HRESULT_FROM_WIN32(GetLastError());
+            } else {
+                hr = S_OK;
+            }
+            if (SUCCEEDED(hr) && szDefaultPath && !IS_INTRESOURCE(szDefaultPath) && *szDefaultPath)
+            {
+                PathAppendW(szPath, szDefaultPath);
+            }
+            break;
+        case CSIDL_Type_SystemPath:
+            if (!GetSystemDirectoryW(szPath, MAX_PATH))
+            {
+                hr = HRESULT_FROM_WIN32(GetLastError());
+            } else {
+                hr = S_OK;
+            }
+            if (SUCCEEDED(hr) && szDefaultPath && !IS_INTRESOURCE(szDefaultPath) && *szDefaultPath)
+            {
+                PathAppendW(szPath, szDefaultPath);
+            }
+            break;
+        case CSIDL_Type_SystemX86Path:
+            if (!GetSystemWow64DirectoryW(szPath, MAX_PATH))
+            {
+                if (!GetSystemDirectoryW(szPath, MAX_PATH))
+                {
+                    hr = HRESULT_FROM_WIN32(GetLastError());
+                } else {
+                    hr = S_OK;
+                }
+            } else {
+                hr = S_OK;
+            }
+             if (SUCCEEDED(hr) && szDefaultPath && !IS_INTRESOURCE(szDefaultPath) && *szDefaultPath)
+            {
+                PathAppendW(szPath, szDefaultPath);
+            }
+            break;
+        case CSIDL_Type_CurrVer:
+            hr = _SHGetCurrentVersionPath(internalFlags, (BYTE)mapped_csidl, szPath);
+            break;
+        case CSIDL_Type_User:
+        case CSIDL_Type_InMyDocuments:
+            hr = _SHGetUserProfilePath(hToken, internalFlags, (BYTE)mapped_csidl, szPath);
+            break;
+        case CSIDL_Type_AllUsers:
+            hr = _SHGetAllUsersProfilePath(internalFlags, (BYTE)mapped_csidl, szPath);
+            break;
+        default:
+            hr = E_NOTIMPL;
+            break;
+    }
+
+    if (FAILED(hr))
+    {
+        goto end;
+    }
+
+    if (!(dwFlags & KF_FLAG_DONT_UNEXPAND) && szPath[0] == '%')
+    {
+        WCHAR szExpandedPath[MAX_PATH];
+        hr = _SHExpandEnvironmentStrings(hToken, szPath, szExpandedPath, _countof(szExpandedPath));
+        if (FAILED(hr))
+        {
+             goto end;
+        }
+        StringCchCopyW(szPath, _countof(szPath), szExpandedPath);
+    }
+
+    BOOL bVerify = !(dwFlags & KF_FLAG_DONT_VERIFY);
+    BOOL bCreate = (dwFlags & (KF_FLAG_CREATE | KF_FLAG_INIT));
+
+    if (bVerify)
+    {
+        if (!PathFileExistsW(szPath))
+        {
+            if (bCreate)
+            {
+                int ret = SHCreateDirectoryExW(NULL, szPath, NULL);
+                if (ret != ERROR_SUCCESS && ret != ERROR_ALREADY_EXISTS)
+                {
+                    hr = HRESULT_FROM_WIN32(ret);
+                    goto end;
+                }
+            }
+            else
+            {
+                 hr = HRESULT_FROM_WIN32(ERROR_PATH_NOT_FOUND);
+                 goto end;
+            }
+        }
+
+        if ((dwFlags & KF_FLAG_INIT) && nShell32IconIndex)
+        {
+            WCHAR szIconLocation[MAX_PATH];
+            WCHAR szDesktopIniPath[MAX_PATH];
+            DWORD dwAttributes;
+
+            dwAttributes = GetFileAttributesW(szPath);
+            if (dwAttributes != INVALID_FILE_ATTRIBUTES)
+            {
+                 dwAttributes |= FILE_ATTRIBUTE_READONLY;
+                 SetFileAttributesW(szPath, dwAttributes);
+            }
+
+
+            StringCchCopyW(szDesktopIniPath, _countof(szDesktopIniPath), szPath);
+            PathAppendW(szDesktopIniPath, L"desktop.ini");
+
+            StringCchPrintfW(szIconLocation, _countof(szIconLocation),
+                             L"%%SystemRoot%%\\system32\\shell32.dll,%d",
+                             nShell32IconIndex);
+
+            WritePrivateProfileStringW(L".ShellClassInfo", L"IconResource", szIconLocation, szDesktopIniPath);
+
+            WritePrivateProfileStringW(NULL, NULL, NULL, szDesktopIniPath);
+
+            dwAttributes = GetFileAttributesW(szDesktopIniPath);
+             if (dwAttributes != INVALID_FILE_ATTRIBUTES)
+            {
+                dwAttributes |= FILE_ATTRIBUTE_SYSTEM | FILE_ATTRIBUTE_HIDDEN;
+                SetFileAttributesW(szDesktopIniPath, dwAttributes);
+            }
+        }
+    }
+
+    SIZE_T pathLen = lstrlenW(szPath);
+    *ppszPath = (PWSTR)SHAlloc((pathLen + 1) * sizeof(WCHAR));
+
+    if (!*ppszPath)
+    {
+        hr = E_OUTOFMEMORY;
+        goto end;
+    }
+
+    StringCchCopyW(*ppszPath, pathLen + 1, szPath);
+
+    hr = S_OK;
+
+end:
+    return hr;
+}
+#endif

--- a/modules/rostests/apitests/shell32/CMakeLists.txt
+++ b/modules/rostests/apitests/shell32/CMakeLists.txt
@@ -54,7 +54,8 @@ list(APPEND SOURCE
     SHSetUnreadMailCountW.cpp
     StrRStr.cpp
     menu.cpp
-    shelltest.cpp)
+    shelltest.cpp
+    SHGetKnownFolderPath.cpp)
 
 list(APPEND PCH_SKIP_SOURCE
     testlist.c)

--- a/modules/rostests/apitests/shell32/SHGetKnownFolderPath.cpp
+++ b/modules/rostests/apitests/shell32/SHGetKnownFolderPath.cpp
@@ -1,0 +1,85 @@
+/*
+ * PROJECT:     ReactOS API tests
+ * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
+ * PURPOSE:     Test for SHGetKnownFolderPath
+ * COPYRIGHT:   Copyright 2025 Petru Răzvan (petrurazvan@proton.me)
+ */
+#include "shelltest.h"
+
+typedef HRESULT (WINAPI *PSHGETKNOWNFOLDERPATH)(REFKNOWNFOLDERID, DWORD, HANDLE, PWSTR *);
+
+static PSHGETKNOWNFOLDERPATH pSHGetKnownFolderPath = NULL;
+
+START_TEST(SHGetKnownFolderPath)
+{
+    HRESULT hr;
+    HINSTANCE hShell32;
+    PWSTR path = NULL;
+    HRESULT result;
+
+    hShell32 = LoadLibraryW(L"shell32.dll");
+    if (!hShell32)
+    {
+        skip("Failed to load shell32.dll\n");
+        return;
+    }
+
+    pSHGetKnownFolderPath = (PSHGETKNOWNFOLDERPATH)GetProcAddress(hShell32, "SHGetKnownFolderPath");
+
+    if (!pSHGetKnownFolderPath)
+    {
+        trace("SHGetKnownFolderPath not exported. Likely running on an OS older than Vista.\n");
+    }
+
+    hr = CoInitializeEx(NULL, COINIT_APARTMENTTHREADED);
+    if (FAILED(hr))
+    {
+        skip("Failed to initialize COM library. Error Code: 0x%08lX\n", hr);
+        pSHGetKnownFolderPath = NULL;
+    }
+
+    if (pSHGetKnownFolderPath)
+    {
+        result = pSHGetKnownFolderPath(FOLDERID_Desktop, 0, NULL, &path);
+        if (SUCCEEDED(result))
+        {
+            ok(path != NULL, "Desktop: Expected success (hr=0x%lx), got path %ls\n", result, path);
+        }
+        else if (result == S_FALSE)
+        {
+             ok(path == NULL, "Desktop: Expected S_FALSE, got hr=0x%lx, path %p\n", result, path);
+        }
+        else
+        {
+            ok(0, "Desktop: Expected success, got Error Code: 0x%08lX\n", result);
+            ok(path == NULL, "Desktop: Expected path to be NULL on failure\n");
+        }
+        if (path) SHFree(path);
+        path = NULL;
+
+        result = pSHGetKnownFolderPath(FOLDERID_Documents, 0, NULL, &path);
+        if (SUCCEEDED(result))
+        {
+            ok(path != NULL, "Documents: Expected success (hr=0x%lx), got path %ls\n", result, path);
+        }
+        else if (result == S_FALSE)
+        {
+             ok(path == NULL, "Documents: Expected S_FALSE, got hr=0x%lx, path %p\n", result, path);
+        }
+         else
+        {
+            ok(0, "Documents: Expected success, got Error Code: 0x0%08lX\n", result);
+            ok(path == NULL, "Documents: Expected path to be NULL on failure\n");
+        }
+        if (path) SHFree(path);
+        path = NULL;
+    }
+
+
+    if (SUCCEEDED(hr))
+    {
+        CoUninitialize();
+    }
+
+    FreeLibrary(hShell32);
+}

--- a/modules/rostests/apitests/shell32/testlist.c
+++ b/modules/rostests/apitests/shell32/testlist.c
@@ -58,6 +58,7 @@ extern void func_SHSimpleIDListFromPath(void);
 extern void func_SHRestricted(void);
 extern void func_SHSetUnreadMailCountW(void);
 extern void func_StrRStr(void);
+extern void func_SHGetKnownFolderPath(void);
 
 const struct test winetest_testlist[] =
 {
@@ -116,6 +117,7 @@ const struct test winetest_testlist[] =
     { "SHRestricted", func_SHRestricted },
     { "SHSetUnreadMailCountW", func_SHSetUnreadMailCountW },
     { "StrRStr", func_StrRStr },
+    { "SHGetKnownFolderPath", func_SHGetKnownFolderPath },
 
     { 0, 0 }
 };

--- a/sdk/include/psdk/shlobj.h
+++ b/sdk/include/psdk/shlobj.h
@@ -197,6 +197,14 @@ SHGetFolderPathAndSubDirW(
   _In_opt_ LPCWSTR,
   _Out_writes_(MAX_PATH) LPWSTR);
 
+#if (_WIN32_WINNT >= 0x0600)
+HRESULT WINAPI SHGetKnownFolderPath(
+  REFKNOWNFOLDERID rfid,
+  DWORD dwFlags,
+  HANDLE hToken,
+  PWSTR *ppszPath);
+#endif
+
 #define SHGetFolderPathAndSubDir WINELIB_NAME_AW(SHGetFolderPathAndSubDir)
 
 HRESULT WINAPI


### PR DESCRIPTION
## Purpose

This is pullrequest to get steam to work

JIRA issue: [CORE-20195](https://jira.reactos.org/browse/CORE-20195)

## Proposed changes

Implement the API calls TryAcquireSRWLockExclusive and SHGetKnownFolderPath

## TODO

- [x] Implement SHGetKnownFolderPath
- [ ]  TryAcquireSRWLockExclusive

## Notes
Im confused related to TryAcquireSRWLockExclusive, im not sure if its same as AcquireSRWLockExclusive or something ekse

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: