### PR TITLE
[SHELL32_APITEST] Comment out OpenAs_RunDLL test

### DIFF
--- a/modules/rostests/apitests/shell32/testlist.c
+++ b/modules/rostests/apitests/shell32/testlist.c
@@ -81,7 +81,7 @@ const struct test winetest_testlist[] =
     { "Int64ToString", func_Int64ToString },
     { "IShellFolderViewCB", func_IShellFolderViewCB },
     { "menu", func_menu },
-    { "OpenAs_RunDLL", func_OpenAs_RunDLL },
+    //{ "OpenAs_RunDLL", func_OpenAs_RunDLL }, // Test hangs on Win 2003
     { "PathIsEqualOrSubFolder", func_PathIsEqualOrSubFolder },
     { "PathIsTemporary", func_PathIsTemporary },
     { "PathMakeUniqueName", func_PathMakeUniqueName },


### PR DESCRIPTION
## Purpose

This test hangs on Windows 2003 and breaks testing on Windows 2003 x64.

JIRA issue: [CORE-14762](https://jira.reactos.org/browse/CORE-14762)

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=101941,101948,102003,102011
