### PR TITLE
[KERNEL32_APITEST] Revert some manifest architecture changes

### DIFF
--- a/modules/rostests/apitests/kernel32/classtest.manifest
+++ b/modules/rostests/apitests/kernel32/classtest.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
-  <assemblyIdentity type="win32" name="ReactOS-TestLib" version="2.2.2.2" processorArchitecture="*" publicKeyToken="6595b64144ccf1df"/>
+  <assemblyIdentity type="win32" name="ReactOS-TestLib" version="2.2.2.2" processorArchitecture="x86" publicKeyToken="6595b64144ccf1df"/>
   <file name="testlib.dll">
     <windowClass>Button</windowClass>
     <windowClass>ButtonListBox</windowClass>

--- a/modules/rostests/apitests/kernel32/classtest2.manifest
+++ b/modules/rostests/apitests/kernel32/classtest2.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
-  <assemblyIdentity type="win32" name="ReactOS-TestLib" version="1.1.1.1" processorArchitecture="*" publicKeyToken="6595b64144ccf1df"/>
+  <assemblyIdentity type="win32" name="ReactOS-TestLib" version="1.1.1.1" processorArchitecture="x86" publicKeyToken="6595b64144ccf1df"/>
   <file name="testlib.dll">
     <windowClass>ButtonListBox</windowClass>
     <windowClass>ComboBoxEx32</windowClass>

--- a/modules/rostests/apitests/kernel32/dep1.manifest
+++ b/modules/rostests/apitests/kernel32/dep1.manifest
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
-  <assemblyIdentity type="win32" name="dep1" version="0.4.4.0" processorArchitecture="*" />
+  <assemblyIdentity type="win32" name="dep1" version="0.4.4.0" processorArchitecture="x86" />
   <file name="dep1.dll"/>
 </assembly>

--- a/modules/rostests/apitests/kernel32/deptest.manifest
+++ b/modules/rostests/apitests/kernel32/deptest.manifest
@@ -7,7 +7,7 @@
                   type="win32"
                   name="dep1"
                   version="0.4.4.0"
-                  processorArchitecture="*"
+                  processorArchitecture="x86"
                   />
           </dependentAssembly>
   </dependency>

--- a/modules/rostests/apitests/kernel32/redirptest/redir2dep.manifest
+++ b/modules/rostests/apitests/kernel32/redirptest/redir2dep.manifest
@@ -6,7 +6,7 @@
                   type="win32"
                   name="redirtest2"
                   version="0.2.2.2"
-                  processorArchitecture="*"
+                  processorArchitecture="x86"
                   />
           </dependentAssembly>
   </dependency>

--- a/modules/rostests/apitests/kernel32/redirptest/redirtest2.manifest
+++ b/modules/rostests/apitests/kernel32/redirptest/redirtest2.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
-  <assemblyIdentity type="win32" name="redirtest2" version="0.2.2.2" processorArchitecture="*" />
+  <assemblyIdentity type="win32" name="redirtest2" version="0.2.2.2" processorArchitecture="x86" />
   <file name="kernel32test_versioned.dll"/>
 </assembly>
  


### PR DESCRIPTION
## Purpose

Fixes crash of kernel32_apitest LoadLibraryExW and failures in kernel32_apitest  FindActCtxSectionStringW on Test WHS.

## Testbot runs (Filled in by Devs)

- WHS: https://reactos.org/testman/compare.php?ids=102018,102017,102019
- Windows 2003 x64: https://reactos.org/testman/compare.php?ids=102003,102020,102025
- KVM x86: https://reactos.org/testman/compare.php?ids=102000,102004,102028
- KVM x64: https://reactos.org/testman/compare.php?ids=102001,102006,102021,102027