### PR TITLE
[FREELDR] Make the NTFS filename comparison conforming to the NTLDR/BOOTMGR

### DIFF
--- a/boot/freeldr/freeldr/lib/fs/ntfs.c
+++ b/boot/freeldr/freeldr/lib/fs/ntfs.c
@@ -525,19 +525,15 @@ static BOOLEAN NtfsCompareFileName(PCHAR FileName, PNTFS_INDEX_ENTRY IndexEntry)
     if (strlen(FileName) != EntryFileNameLength)
         return FALSE;
 
-    /* Do case-sensitive compares for Posix file names. */
-    if (IndexEntry->FileName.FileNameType == NTFS_FILE_NAME_POSIX)
-    {
-        for (i = 0; i < EntryFileNameLength; i++)
-            if (EntryFileName[i] != FileName[i])
-                return FALSE;
-    }
-    else
-    {
-        for (i = 0; i < EntryFileNameLength; i++)
-            if (tolower(EntryFileName[i]) != tolower(FileName[i]))
-                return FALSE;
-    }
+    /* Always do case-insensitive compares for file names.
+     * Why is this necessary?
+     * Because when modifying an Windows ntfs partition formatted with Windows itself
+     * on Linux the ntldr/bootmgr will boot normally ignoring the case of the path
+     * so let's do the same.
+     */
+    for (i = 0; i < EntryFileNameLength; i++)
+        if (tolower(EntryFileName[i]) != tolower(FileName[i]))
+            return FALSE;
 
     return TRUE;
 }

--- a/boot/freeldr/freeldr/lib/fs/ntfs.c
+++ b/boot/freeldr/freeldr/lib/fs/ntfs.c
@@ -525,15 +525,17 @@ static BOOLEAN NtfsCompareFileName(PCHAR FileName, PNTFS_INDEX_ENTRY IndexEntry)
     if (strlen(FileName) != EntryFileNameLength)
         return FALSE;
 
-    /* Always do case-insensitive compares for file names.
-     * Why is this necessary?
-     * Because when modifying an Windows ntfs partition formatted with Windows itself
-     * on Linux the ntldr/bootmgr will boot normally ignoring the case of the path
-     * so let's do the same.
+    /*
+     * Always perform case-insensitive comparison for file names.
+     * This is necessary, because when modifying e.g. on Linux a Windows NTFS
+     * partition formatted with Windows itself, the NTLDR/BOOTMGR will boot
+     * normally ignoring the case of the paths.
      */
     for (i = 0; i < EntryFileNameLength; i++)
+    {
         if (tolower(EntryFileName[i]) != tolower(FileName[i]))
             return FALSE;
+    }
 
     return TRUE;
 }


### PR DESCRIPTION
## Purpose

So when you create a NTFS partition with windows and modify with linux the ntldr/bootmgr will compare the file names ignoring the case of the file while freeldr does not and the same hack is on btrfs file name comparison.
This PR is necessary because the case of the file names on registry are not consistent!!!!

JIRA issue: [CORE-XXXX](https://jira.reactos.org/browse/CORE-XXXX)

## How to reproduce
- Try to install windows with ntfs and install freeldr on it
- Try to modify windows partition on linux like creating/copying some new files
- Try to boot with freeldr (it will fail if the hive file path case is different than the actual file path)
- Try to boot with ntldr/bootmgr (it will work finally reaching the desktop)

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: