### PR TITLE
[E1000] Implement OID_GEN_PHYSICAL_MEDIUM

### DIFF
--- a/drivers/network/dd/e1000/info.c
+++ b/drivers/network/dd/e1000/info.c
@@ -37,6 +37,7 @@ static NDIS_OID SupportedOidList[] =
     OID_802_3_PERMANENT_ADDRESS,
     OID_802_3_CURRENT_ADDRESS,
     OID_802_3_MAXIMUM_LIST_SIZE,
+    OID_GEN_PHYSICAL_MEDIUM,
 
     /* Statistics */
     OID_GEN_XMIT_OK,
@@ -236,6 +237,12 @@ MiniportQueryInformation(
         copyLength = sizeof(NDIS_PNP_CAPABILITIES);
 
         status = NICFillPowerManagementCapabilities(Adapter, &GenericInfo.PmCapabilities);
+        break;
+    }
+
+    case OID_GEN_PHYSICAL_MEDIUM:
+    {
+        GenericInfo.Ulong = NdisPhysicalMedium802_3;
         break;
     }
 


### PR DESCRIPTION
## Purpose

Implement OID_GEN_PHYSICAL_MEDIUM in e1000 driver to silence annoying debug spam on VBox.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86: https://reactos.org/testman/compare.php?ids=102104,102107
- [ ] KVM x64: https://reactos.org/testman/compare.php?ids=102088,102101