### PR TITLE
[TCPIP] Always depend on TCP/IP implementation for unspecified port

### DIFF
--- a/drivers/network/tcpip/tcpip/fileobjs.c
+++ b/drivers/network/tcpip/tcpip/fileobjs.c
@@ -486,22 +486,9 @@ NTSTATUS FileOpenAddress(
           /* Sanity check */
           ASSERT(Address->Address[0].Address[0].sin_port == AddrFile->Port);
       }
-      else if (!AddrIsUnspecified(&AddrFile->Address))
-      {
-          /* The client is trying to bind to a local address so allocate a port now too */
-          AllocatedPort = TCPAllocatePort(0);
-
-          /* Check for bind success */
-          if (AllocatedPort == (UINT)-1)
-          {
-              ExFreePoolWithTag(AddrFile, ADDR_FILE_TAG);
-              return STATUS_ADDRESS_ALREADY_EXISTS;
-          }
-          AddrFile->Port = AllocatedPort;
-      }
       else
       {
-          /* The client wants an unspecified port with an unspecified address so we wait to see what the TCP library gives us */
+          /* The client wants an unspecified port so we wait to see what the TCP library gives us */
           AddrFile->Port = 0;
       }
 


### PR DESCRIPTION
## Purpose

In bind(2) when specifying 0 as port the TCP/IP (or also UDP/IP) driver is supposed to assign a free port number in the range 0xc000-0xffff. In the ReactOS TCP/IP driver there are two implementations of this mechanism: one in the "TCP/IP library" and one in the lwip TCP/IP stack.

The TCP/IP library can reassign local ports to connection oriented sockets as soon as the address file (TDI) of a former connection oriented socket is closed. The problem that arises with such a port reuse is that the TCP/IP stack keeps the socket for a time period specified in the TCP/IP RFC (the state is called FINWAIT if I remember correctly). So if the same port is assigned twice we will get an status 0xc000020a (STATUS_ADDRESS_ALREADY_EXISTS) from the lwip implementation, thereby making new connections to the same remote IP/port pair with a newly created socket impossible.

## Proposed changes

The solution I came up with (and which solves the can't connect any more issue) is to simply not use the TCPAllocatePort() mechanism when the port is 0 (unspecified) which lets the lwip implementation choose a free port (honoring sockets in FINWAIT state).

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: