### PR TITLE
[SYSDM][BROWSEUI][SHELL32][SDK] Added Advanced Performance Options property sheets

### DIFF
--- a/boot/bootdata/hivedef.inf
+++ b/boot/bootdata/hivedef.inf
@@ -2154,6 +2154,29 @@ HKCU,"AppEvents\EventLabels\WindowsLogoff","DispFileName",0x00000000,"@mmsys.cpl
 HKCU,"AppEvents\EventLabels\WindowsLogon","",0x00000000,"%EVENT_LABEL_27%"
 HKCU,"AppEvents\EventLabels\WindowsLogon","DispFileName",0x00000000,"@mmsys.cpl,-5853"
 
+; Sysdm.cpl Visual Effects
+HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects\ListviewShadow,ValueName,,ListviewShadow
+HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects\ListviewShadow,RegPath,,Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced
+HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects\ListviewShadow,Text,,"@shell32.dll,-30541"
+HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects\ListviewShadow,Type,,checkbox
+HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects\ListviewShadow,DefaultValue,0x00010001,1
+HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects\ListviewShadow,CheckedValue,0x00010001,1
+HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects\ListviewShadow,UncheckedValue,0x00010001,0
+HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects\DragFullWindows,SPIActionSet,0x00010001,37
+HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects\DragFullWindows,SPIActionGet,0x00010001,38
+HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects\DragFullWindows,Text,,"@shell32.dll,-30533"
+HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects\DragFullWindows,Type,,checkbox
+HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects\DragFullWindows,DefaultValue,0x00010001,1
+HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects\DragFullWindows,CheckedValue,0x00010001,1
+HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects\DragFullWindows,UncheckedValue,0x00010001,0
+HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects\FontSmoothing,SPIActionSet,0x00010001,75
+HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects\FontSmoothing,SPIActionGet,0x00010001,74
+HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects\FontSmoothing,Text,,"@shell32.dll,-30535"
+HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects\FontSmoothing,Type,,checkbox
+HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects\FontSmoothing,DefaultValue,0x00010001,1
+HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects\FontSmoothing,CheckedValue,0x00010001,1
+HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects\FontSmoothing,UncheckedValue,0x00010001,0
+
 ;-------------------------------- STRINGS -------------------------------
 
 [Strings]

--- a/dll/cpl/desk/theme.c
+++ b/dll/cpl/desk/theme.c
@@ -204,7 +204,7 @@ LoadCurrentScheme(OUT COLOR_SCHEME *scheme)
                                 0);
     if (!ret) return FALSE;
 
-    /* Show shadows under menus */
+    /* Show shadows under windows */
     ret = SystemParametersInfoW(SPI_GETDROPSHADOW,
                                 0,
                                 &scheme->Effects.bDropShadow,
@@ -402,7 +402,7 @@ ApplyScheme(IN COLOR_SCHEME *scheme, IN PTHEME_SELECTION pSelectedTheme)
     /* Use large icons */
     //SYS_CONFIG(SPI_GETDRAGFULLWINDOWS,   (PVOID) g->SchemeAdv.Effects.bMenuFade);
 
-    /* Show shadows under menus */
+    /* Show shadows under windows */
     SYS_CONFIG(SPI_SETDROPSHADOW,                0, IntToPtr(scheme->Effects.bDropShadow));
 
     /* Show window contents while dragging */

--- a/dll/cpl/sysdm/CMakeLists.txt
+++ b/dll/cpl/sysdm/CMakeLists.txt
@@ -11,6 +11,7 @@ list(APPEND SOURCE
     hardprof.c
     hardware.c
     licence.c
+    performance.c
     smbios.c
     startrec.c
     sysdm.c
@@ -27,7 +28,7 @@ add_library(sysdm MODULE
     ${CMAKE_CURRENT_BINARY_DIR}/sysdm.def)
 
 set_module_type(sysdm cpl UNICODE)
-target_link_libraries(sysdm udmihelp)
+target_link_libraries(sysdm udmihelp uuid)
 add_importlibs(sysdm advapi32 setupapi user32 gdi32 comctl32 comdlg32 msimg32 shell32 shlwapi ole32 powrprof msvcrt kernel32 ntdll)
 add_pch(sysdm precomp.h SOURCE)
 add_cd_file(TARGET sysdm DESTINATION reactos/system32 FOR all)

--- a/dll/cpl/sysdm/advanced.c
+++ b/dll/cpl/sysdm/advanced.c
@@ -133,10 +133,7 @@ AdvancedPageProc(HWND hwndDlg,
             switch (LOWORD(wParam))
             {
                 case IDC_PERFOR:
-                    DialogBox(hApplet,
-                              MAKEINTRESOURCE(IDD_VIRTMEM),
-                              hwndDlg,
-                              VirtMemDlgProc);
+                    ShowPerformanceOptions(hwndDlg);
                     break;
 
                 case IDC_USERPROFILE:

--- a/dll/cpl/sysdm/lang/bg-BG.rc
+++ b/dll/cpl/sysdm/lang/bg-BG.rc
@@ -323,10 +323,34 @@ BEGIN
     DEFPUSHBUTTON "Добре", IDOK, 106, 140, 54, 15
 END
 
+IDD_VISUALEFFECTS DIALOGEX 6, 18, 227, 204
+CAPTION "Visual Effects"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   LTEXT "Select the settings you want to use for the appearance and performance of ReactOS on this computer.", IDC_STATIC, 7, 6, 208, 18
+   CONTROL "", IDC_TREE, "SysTreeView32", TVS_LINESATROOT | TVS_DISABLEDRAGDROP | WS_CHILD | WS_VISIBLE | WS_BORDER | WS_TABSTOP, 7, 32, 213, 168
+END
+
+IDD_ADVANCEDPERF DIALOGEX 6, 18, 227, 128
+CAPTION "Advanced"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   GROUPBOX "CPU scheduling", IDC_STATIC, 7, 8, 213, 46
+   LTEXT "Adjust for best performance of:", IDC_STATIC, 14, 23, 199, 8
+   AUTORADIOBUTTON "&Programs", IDC_CPUCLIENT, 14, 36, 75, 12
+   AUTORADIOBUTTON "Background &services", IDC_CPUSERVER, 96, 36, 85, 12
+   GROUPBOX "Virtual memory", IDC_STATIC, 7, 60, 213, 57
+   LTEXT "A paging file is an area on the hard disk that ReactOS uses as if it were RAM.", IDC_STATIC, 14, 74, 199, 16
+   PUSHBUTTON "&Change...", IDC_CHANGESWAP, 163, 97, 50, 14
+END
+
 STRINGTABLE
 BEGIN
     IDS_CPLSYSTEMNAME "Система"
     IDS_CPLSYSTEMDESCRIPTION "Можете да видите сведения за компютъра ви и за различни настройки"
+    IDS_PERFORMANCEOPTIONS "Performance Options"
     IDS_MEGABYTE "МБ"
     IDS_GIGABYTE "ГБ"
     IDS_TERABYTE "ТБ"

--- a/dll/cpl/sysdm/lang/cs-CZ.rc
+++ b/dll/cpl/sysdm/lang/cs-CZ.rc
@@ -328,10 +328,34 @@ BEGIN
     DEFPUSHBUTTON "OK", IDOK, 106, 140, 54, 15
 END
 
+IDD_VISUALEFFECTS DIALOGEX 6, 18, 227, 204
+CAPTION "Visual Effects"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   LTEXT "Select the settings you want to use for the appearance and performance of ReactOS on this computer.", IDC_STATIC, 7, 6, 208, 18
+   CONTROL "", IDC_TREE, "SysTreeView32", TVS_LINESATROOT | TVS_DISABLEDRAGDROP | WS_CHILD | WS_VISIBLE | WS_BORDER | WS_TABSTOP, 7, 32, 213, 168
+END
+
+IDD_ADVANCEDPERF DIALOGEX 6, 18, 227, 128
+CAPTION "Advanced"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   GROUPBOX "CPU scheduling", IDC_STATIC, 7, 8, 213, 46
+   LTEXT "Adjust for best performance of:", IDC_STATIC, 14, 23, 199, 8
+   AUTORADIOBUTTON "&Programs", IDC_CPUCLIENT, 14, 36, 75, 12
+   AUTORADIOBUTTON "Background &services", IDC_CPUSERVER, 96, 36, 85, 12
+   GROUPBOX "Virtual memory", IDC_STATIC, 7, 60, 213, 57
+   LTEXT "A paging file is an area on the hard disk that ReactOS uses as if it were RAM.", IDC_STATIC, 14, 74, 199, 16
+   PUSHBUTTON "&Change...", IDC_CHANGESWAP, 163, 97, 50, 14
+END
+
 STRINGTABLE
 BEGIN
     IDS_CPLSYSTEMNAME "Systém"
     IDS_CPLSYSTEMDESCRIPTION "Zde lze zobrazit informace o tomto počítači a změnit různá systémová a hardwarová nastavení."
+    IDS_PERFORMANCEOPTIONS "Performance Options"
     IDS_MEGABYTE "MB RAM"
     IDS_GIGABYTE "GB RAM"
     IDS_TERABYTE "TB RAM"

--- a/dll/cpl/sysdm/lang/da-DK.rc
+++ b/dll/cpl/sysdm/lang/da-DK.rc
@@ -323,10 +323,34 @@ BEGIN
     DEFPUSHBUTTON "OK", IDOK, 106, 140, 54, 15
 END
 
+IDD_VISUALEFFECTS DIALOGEX 6, 18, 227, 204
+CAPTION "Visual Effects"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   LTEXT "Select the settings you want to use for the appearance and performance of ReactOS on this computer.", IDC_STATIC, 7, 6, 208, 18
+   CONTROL "", IDC_TREE, "SysTreeView32", TVS_LINESATROOT | TVS_DISABLEDRAGDROP | WS_CHILD | WS_VISIBLE | WS_BORDER | WS_TABSTOP, 7, 32, 213, 168
+END
+
+IDD_ADVANCEDPERF DIALOGEX 6, 18, 227, 128
+CAPTION "Advanced"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   GROUPBOX "CPU scheduling", IDC_STATIC, 7, 8, 213, 46
+   LTEXT "Adjust for best performance of:", IDC_STATIC, 14, 23, 199, 8
+   AUTORADIOBUTTON "&Programs", IDC_CPUCLIENT, 14, 36, 75, 12
+   AUTORADIOBUTTON "Background &services", IDC_CPUSERVER, 96, 36, 85, 12
+   GROUPBOX "Virtual memory", IDC_STATIC, 7, 60, 213, 57
+   LTEXT "A paging file is an area on the hard disk that ReactOS uses as if it were RAM.", IDC_STATIC, 14, 74, 199, 16
+   PUSHBUTTON "&Change...", IDC_CHANGESWAP, 163, 97, 50, 14
+END
+
 STRINGTABLE
 BEGIN
     IDS_CPLSYSTEMNAME "System Indstillinger"
     IDS_CPLSYSTEMDESCRIPTION "Se mere information omkring din computer, og skift diverse system og hardware indstillinger."
+    IDS_PERFORMANCEOPTIONS "Performance Options"
     IDS_MEGABYTE "MB of RAM"
     IDS_GIGABYTE "GB of RAM"
     IDS_TERABYTE "TB of RAM"

--- a/dll/cpl/sysdm/lang/de-DE.rc
+++ b/dll/cpl/sysdm/lang/de-DE.rc
@@ -332,10 +332,34 @@ BEGIN
     DEFPUSHBUTTON "OK", IDOK, 106, 140, 54, 15
 END
 
+IDD_VISUALEFFECTS DIALOGEX 6, 18, 227, 204
+CAPTION "Visual Effects"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   LTEXT "Select the settings you want to use for the appearance and performance of ReactOS on this computer.", IDC_STATIC, 7, 6, 208, 18
+   CONTROL "", IDC_TREE, "SysTreeView32", TVS_LINESATROOT | TVS_DISABLEDRAGDROP | WS_CHILD | WS_VISIBLE | WS_BORDER | WS_TABSTOP, 7, 32, 213, 168
+END
+
+IDD_ADVANCEDPERF DIALOGEX 6, 18, 227, 128
+CAPTION "Advanced"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   GROUPBOX "CPU scheduling", IDC_STATIC, 7, 8, 213, 46
+   LTEXT "Adjust for best performance of:", IDC_STATIC, 14, 23, 199, 8
+   AUTORADIOBUTTON "&Programs", IDC_CPUCLIENT, 14, 36, 75, 12
+   AUTORADIOBUTTON "Background &services", IDC_CPUSERVER, 96, 36, 85, 12
+   GROUPBOX "Virtual memory", IDC_STATIC, 7, 60, 213, 57
+   LTEXT "A paging file is an area on the hard disk that ReactOS uses as if it were RAM.", IDC_STATIC, 14, 74, 199, 16
+   PUSHBUTTON "&Change...", IDC_CHANGESWAP, 163, 97, 50, 14
+END
+
 STRINGTABLE
 BEGIN
     IDS_CPLSYSTEMNAME "System"
     IDS_CPLSYSTEMDESCRIPTION "Zeigt Informationen über Ihren Computer an und ändert verschiedene Computer- und Hardware-Einstellungen"
+    IDS_PERFORMANCEOPTIONS "Performance Options"
     IDS_MEGABYTE "MB RAM"
     IDS_GIGABYTE "GB RAM"
     IDS_TERABYTE "TB RAM"

--- a/dll/cpl/sysdm/lang/el-GR.rc
+++ b/dll/cpl/sysdm/lang/el-GR.rc
@@ -323,10 +323,34 @@ BEGIN
     DEFPUSHBUTTON "OK", IDOK, 106, 140, 54, 15
 END
 
+IDD_VISUALEFFECTS DIALOGEX 6, 18, 227, 204
+CAPTION "Visual Effects"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   LTEXT "Select the settings you want to use for the appearance and performance of ReactOS on this computer.", IDC_STATIC, 7, 6, 208, 18
+   CONTROL "", IDC_TREE, "SysTreeView32", TVS_LINESATROOT | TVS_DISABLEDRAGDROP | WS_CHILD | WS_VISIBLE | WS_BORDER | WS_TABSTOP, 7, 32, 213, 168
+END
+
+IDD_ADVANCEDPERF DIALOGEX 6, 18, 227, 128
+CAPTION "Advanced"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   GROUPBOX "CPU scheduling", IDC_STATIC, 7, 8, 213, 46
+   LTEXT "Adjust for best performance of:", IDC_STATIC, 14, 23, 199, 8
+   AUTORADIOBUTTON "&Programs", IDC_CPUCLIENT, 14, 36, 75, 12
+   AUTORADIOBUTTON "Background &services", IDC_CPUSERVER, 96, 36, 85, 12
+   GROUPBOX "Virtual memory", IDC_STATIC, 7, 60, 213, 57
+   LTEXT "A paging file is an area on the hard disk that ReactOS uses as if it were RAM.", IDC_STATIC, 14, 74, 199, 16
+   PUSHBUTTON "&Change...", IDC_CHANGESWAP, 163, 97, 50, 14
+END
+
 STRINGTABLE
 BEGIN
     IDS_CPLSYSTEMNAME "Σύστημα"
     IDS_CPLSYSTEMDESCRIPTION "Δείτε πληροφορίες για το σύστημα του υπολογιστή σας και αλλάξτε ρυθμίσεις υλικού, επιδόσεων και αυτόματης ενημέρωσης."
+    IDS_PERFORMANCEOPTIONS "Performance Options"
     IDS_MEGABYTE "MB μνήμης RAM"
     IDS_GIGABYTE "GB μνήμης RAM"
     IDS_TERABYTE "TB μνήμης RAM"

--- a/dll/cpl/sysdm/lang/en-US.rc
+++ b/dll/cpl/sysdm/lang/en-US.rc
@@ -323,10 +323,34 @@ BEGIN
     DEFPUSHBUTTON "OK", IDOK, 106, 140, 54, 15
 END
 
+IDD_VISUALEFFECTS DIALOGEX 6, 18, 227, 204
+CAPTION "Visual Effects"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   LTEXT "Select the settings you want to use for the appearance and performance of ReactOS on this computer.", IDC_STATIC, 7, 6, 208, 18
+   CONTROL "", IDC_TREE, "SysTreeView32", TVS_LINESATROOT | TVS_DISABLEDRAGDROP | WS_CHILD | WS_VISIBLE | WS_BORDER | WS_TABSTOP, 7, 32, 213, 168
+END
+
+IDD_ADVANCEDPERF DIALOGEX 6, 18, 227, 128
+CAPTION "Advanced"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   GROUPBOX "CPU scheduling", IDC_STATIC, 7, 8, 213, 46
+   LTEXT "Adjust for best performance of:", IDC_STATIC, 14, 23, 199, 8
+   AUTORADIOBUTTON "&Programs", IDC_CPUCLIENT, 14, 36, 75, 12
+   AUTORADIOBUTTON "Background &services", IDC_CPUSERVER, 96, 36, 85, 12
+   GROUPBOX "Virtual memory", IDC_STATIC, 7, 60, 213, 57
+   LTEXT "A paging file is an area on the hard disk that ReactOS uses as if it were RAM.", IDC_STATIC, 14, 74, 199, 16
+   PUSHBUTTON "&Change...", IDC_CHANGESWAP, 163, 97, 50, 14
+END
+
 STRINGTABLE
 BEGIN
     IDS_CPLSYSTEMNAME "System"
     IDS_CPLSYSTEMDESCRIPTION "See information about your computer and change various system and hardware settings."
+    IDS_PERFORMANCEOPTIONS "Performance Options"
     IDS_MEGABYTE "MB of RAM"
     IDS_GIGABYTE "GB of RAM"
     IDS_TERABYTE "TB of RAM"

--- a/dll/cpl/sysdm/lang/es-ES.rc
+++ b/dll/cpl/sysdm/lang/es-ES.rc
@@ -325,10 +325,34 @@ BEGIN
     DEFPUSHBUTTON "Aceptar", IDOK, 106, 140, 54, 15
 END
 
+IDD_VISUALEFFECTS DIALOGEX 6, 18, 227, 204
+CAPTION "Visual Effects"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   LTEXT "Select the settings you want to use for the appearance and performance of ReactOS on this computer.", IDC_STATIC, 7, 6, 208, 18
+   CONTROL "", IDC_TREE, "SysTreeView32", TVS_LINESATROOT | TVS_DISABLEDRAGDROP | WS_CHILD | WS_VISIBLE | WS_BORDER | WS_TABSTOP, 7, 32, 213, 168
+END
+
+IDD_ADVANCEDPERF DIALOGEX 6, 18, 227, 128
+CAPTION "Advanced"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   GROUPBOX "CPU scheduling", IDC_STATIC, 7, 8, 213, 46
+   LTEXT "Adjust for best performance of:", IDC_STATIC, 14, 23, 199, 8
+   AUTORADIOBUTTON "&Programs", IDC_CPUCLIENT, 14, 36, 75, 12
+   AUTORADIOBUTTON "Background &services", IDC_CPUSERVER, 96, 36, 85, 12
+   GROUPBOX "Virtual memory", IDC_STATIC, 7, 60, 213, 57
+   LTEXT "A paging file is an area on the hard disk that ReactOS uses as if it were RAM.", IDC_STATIC, 14, 74, 199, 16
+   PUSHBUTTON "&Change...", IDC_CHANGESWAP, 163, 97, 50, 14
+END
+
 STRINGTABLE
 BEGIN
     IDS_CPLSYSTEMNAME "Sistema"
     IDS_CPLSYSTEMDESCRIPTION "Muestra información sobre el sistema de su equipo y cambia la configuración del hardware, rendimiento y actualizaciones automáticas."
+    IDS_PERFORMANCEOPTIONS "Performance Options"
     IDS_MEGABYTE "MB de RAM"
     IDS_GIGABYTE "GB de RAM"
     IDS_TERABYTE "TB de RAM"

--- a/dll/cpl/sysdm/lang/fr-FR.rc
+++ b/dll/cpl/sysdm/lang/fr-FR.rc
@@ -323,10 +323,34 @@ BEGIN
     DEFPUSHBUTTON "OK", IDOK, 106, 140, 54, 15
 END
 
+IDD_VISUALEFFECTS DIALOGEX 6, 18, 227, 204
+CAPTION "Visual Effects"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   LTEXT "Select the settings you want to use for the appearance and performance of ReactOS on this computer.", IDC_STATIC, 7, 6, 208, 18
+   CONTROL "", IDC_TREE, "SysTreeView32", TVS_LINESATROOT | TVS_DISABLEDRAGDROP | WS_CHILD | WS_VISIBLE | WS_BORDER | WS_TABSTOP, 7, 32, 213, 168
+END
+
+IDD_ADVANCEDPERF DIALOGEX 6, 18, 227, 128
+CAPTION "Advanced"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   GROUPBOX "CPU scheduling", IDC_STATIC, 7, 8, 213, 46
+   LTEXT "Adjust for best performance of:", IDC_STATIC, 14, 23, 199, 8
+   AUTORADIOBUTTON "&Programs", IDC_CPUCLIENT, 14, 36, 75, 12
+   AUTORADIOBUTTON "Background &services", IDC_CPUSERVER, 96, 36, 85, 12
+   GROUPBOX "Virtual memory", IDC_STATIC, 7, 60, 213, 57
+   LTEXT "A paging file is an area on the hard disk that ReactOS uses as if it were RAM.", IDC_STATIC, 14, 74, 199, 16
+   PUSHBUTTON "&Change...", IDC_CHANGESWAP, 163, 97, 50, 14
+END
+
 STRINGTABLE
 BEGIN
     IDS_CPLSYSTEMNAME "Système"
     IDS_CPLSYSTEMDESCRIPTION "Affiche des informations à propos de l'ordinateur et change des réglages systèmes et matériels."
+    IDS_PERFORMANCEOPTIONS "Performance Options"
     IDS_MEGABYTE "Mo de RAM"
     IDS_GIGABYTE "Go de RAM"
     IDS_TERABYTE "To de RAM"

--- a/dll/cpl/sysdm/lang/he-IL.rc
+++ b/dll/cpl/sysdm/lang/he-IL.rc
@@ -325,10 +325,34 @@ BEGIN
     DEFPUSHBUTTON "אישור", IDOK, 106, 140, 54, 15
 END
 
+IDD_VISUALEFFECTS DIALOGEX 6, 18, 227, 204
+CAPTION "Visual Effects"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   LTEXT "Select the settings you want to use for the appearance and performance of ReactOS on this computer.", IDC_STATIC, 7, 6, 208, 18
+   CONTROL "", IDC_TREE, "SysTreeView32", TVS_LINESATROOT | TVS_DISABLEDRAGDROP | WS_CHILD | WS_VISIBLE | WS_BORDER | WS_TABSTOP, 7, 32, 213, 168
+END
+
+IDD_ADVANCEDPERF DIALOGEX 6, 18, 227, 128
+CAPTION "Advanced"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   GROUPBOX "CPU scheduling", IDC_STATIC, 7, 8, 213, 46
+   LTEXT "Adjust for best performance of:", IDC_STATIC, 14, 23, 199, 8
+   AUTORADIOBUTTON "&Programs", IDC_CPUCLIENT, 14, 36, 75, 12
+   AUTORADIOBUTTON "Background &services", IDC_CPUSERVER, 96, 36, 85, 12
+   GROUPBOX "Virtual memory", IDC_STATIC, 7, 60, 213, 57
+   LTEXT "A paging file is an area on the hard disk that ReactOS uses as if it were RAM.", IDC_STATIC, 14, 74, 199, 16
+   PUSHBUTTON "&Change...", IDC_CHANGESWAP, 163, 97, 50, 14
+END
+
 STRINGTABLE
 BEGIN
     IDS_CPLSYSTEMNAME "מערכת"
     IDS_CPLSYSTEMDESCRIPTION "See information about your computer and change various system and hardware settings."
+    IDS_PERFORMANCEOPTIONS "Performance Options"
     IDS_MEGABYTE "MB זיכרון פיזי"
     IDS_GIGABYTE "GB זיכרון פיזי"
     IDS_TERABYTE "TB זיכרון פיזי"

--- a/dll/cpl/sysdm/lang/hu-HU.rc
+++ b/dll/cpl/sysdm/lang/hu-HU.rc
@@ -325,10 +325,34 @@ BEGIN
     DEFPUSHBUTTON "OK", IDOK, 106, 140, 54, 15
 END
 
+IDD_VISUALEFFECTS DIALOGEX 6, 18, 227, 204
+CAPTION "Visual Effects"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   LTEXT "Select the settings you want to use for the appearance and performance of ReactOS on this computer.", IDC_STATIC, 7, 6, 208, 18
+   CONTROL "", IDC_TREE, "SysTreeView32", TVS_LINESATROOT | TVS_DISABLEDRAGDROP | WS_CHILD | WS_VISIBLE | WS_BORDER | WS_TABSTOP, 7, 32, 213, 168
+END
+
+IDD_ADVANCEDPERF DIALOGEX 6, 18, 227, 128
+CAPTION "Advanced"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   GROUPBOX "CPU scheduling", IDC_STATIC, 7, 8, 213, 46
+   LTEXT "Adjust for best performance of:", IDC_STATIC, 14, 23, 199, 8
+   AUTORADIOBUTTON "&Programs", IDC_CPUCLIENT, 14, 36, 75, 12
+   AUTORADIOBUTTON "Background &services", IDC_CPUSERVER, 96, 36, 85, 12
+   GROUPBOX "Virtual memory", IDC_STATIC, 7, 60, 213, 57
+   LTEXT "A paging file is an area on the hard disk that ReactOS uses as if it were RAM.", IDC_STATIC, 14, 74, 199, 16
+   PUSHBUTTON "&Change...", IDC_CHANGESWAP, 163, 97, 50, 14
+END
+
 STRINGTABLE
 BEGIN
     IDS_CPLSYSTEMNAME "Rendszer"
     IDS_CPLSYSTEMDESCRIPTION "A számítógéppel kapcsolatos információk megjelenítése, különböző rendszer és hardver beállítások módosítása."
+    IDS_PERFORMANCEOPTIONS "Performance Options"
     IDS_MEGABYTE "MB RAM"
     IDS_GIGABYTE "GB RAM"
     IDS_TERABYTE "TB RAM"

--- a/dll/cpl/sysdm/lang/id-ID.rc
+++ b/dll/cpl/sysdm/lang/id-ID.rc
@@ -323,10 +323,34 @@ BEGIN
     DEFPUSHBUTTON "OK", IDOK, 106, 140, 54, 15
 END
 
+IDD_VISUALEFFECTS DIALOGEX 6, 18, 227, 204
+CAPTION "Visual Effects"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   LTEXT "Select the settings you want to use for the appearance and performance of ReactOS on this computer.", IDC_STATIC, 7, 6, 208, 18
+   CONTROL "", IDC_TREE, "SysTreeView32", TVS_LINESATROOT | TVS_DISABLEDRAGDROP | WS_CHILD | WS_VISIBLE | WS_BORDER | WS_TABSTOP, 7, 32, 213, 168
+END
+
+IDD_ADVANCEDPERF DIALOGEX 6, 18, 227, 128
+CAPTION "Advanced"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   GROUPBOX "CPU scheduling", IDC_STATIC, 7, 8, 213, 46
+   LTEXT "Adjust for best performance of:", IDC_STATIC, 14, 23, 199, 8
+   AUTORADIOBUTTON "&Programs", IDC_CPUCLIENT, 14, 36, 75, 12
+   AUTORADIOBUTTON "Background &services", IDC_CPUSERVER, 96, 36, 85, 12
+   GROUPBOX "Virtual memory", IDC_STATIC, 7, 60, 213, 57
+   LTEXT "A paging file is an area on the hard disk that ReactOS uses as if it were RAM.", IDC_STATIC, 14, 74, 199, 16
+   PUSHBUTTON "&Change...", IDC_CHANGESWAP, 163, 97, 50, 14
+END
+
 STRINGTABLE
 BEGIN
     IDS_CPLSYSTEMNAME "Sistem"
     IDS_CPLSYSTEMDESCRIPTION "Lihat informasi tentang komputer anda dan ubah berbagai setelan sistem dan perangkat keras."
+    IDS_PERFORMANCEOPTIONS "Performance Options"
     IDS_MEGABYTE "MB RAM"
     IDS_GIGABYTE "GB RAM"
     IDS_TERABYTE "TB RAM"

--- a/dll/cpl/sysdm/lang/it-IT.rc
+++ b/dll/cpl/sysdm/lang/it-IT.rc
@@ -323,10 +323,34 @@ BEGIN
     DEFPUSHBUTTON "OK", IDOK, 106, 140, 54, 15
 END
 
+IDD_VISUALEFFECTS DIALOGEX 6, 18, 227, 204
+CAPTION "Visual Effects"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   LTEXT "Select the settings you want to use for the appearance and performance of ReactOS on this computer.", IDC_STATIC, 7, 6, 208, 18
+   CONTROL "", IDC_TREE, "SysTreeView32", TVS_LINESATROOT | TVS_DISABLEDRAGDROP | WS_CHILD | WS_VISIBLE | WS_BORDER | WS_TABSTOP, 7, 32, 213, 168
+END
+
+IDD_ADVANCEDPERF DIALOGEX 6, 18, 227, 128
+CAPTION "Advanced"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   GROUPBOX "CPU scheduling", IDC_STATIC, 7, 8, 213, 46
+   LTEXT "Adjust for best performance of:", IDC_STATIC, 14, 23, 199, 8
+   AUTORADIOBUTTON "&Programs", IDC_CPUCLIENT, 14, 36, 75, 12
+   AUTORADIOBUTTON "Background &services", IDC_CPUSERVER, 96, 36, 85, 12
+   GROUPBOX "Virtual memory", IDC_STATIC, 7, 60, 213, 57
+   LTEXT "A paging file is an area on the hard disk that ReactOS uses as if it were RAM.", IDC_STATIC, 14, 74, 199, 16
+   PUSHBUTTON "&Change...", IDC_CHANGESWAP, 163, 97, 50, 14
+END
+
 STRINGTABLE
 BEGIN
     IDS_CPLSYSTEMNAME "Sistema"
     IDS_CPLSYSTEMDESCRIPTION "Visualizza informazioni sul vostro computer e modifica varie impostazioni di sistema."
+    IDS_PERFORMANCEOPTIONS "Performance Options"
     IDS_MEGABYTE "MB di RAM"
     IDS_GIGABYTE "GB di RAM"
     IDS_TERABYTE "TB di RAM"

--- a/dll/cpl/sysdm/lang/ja-JP.rc
+++ b/dll/cpl/sysdm/lang/ja-JP.rc
@@ -323,10 +323,34 @@ BEGIN
     DEFPUSHBUTTON "OK", IDOK, 106, 140, 54, 15
 END
 
+IDD_VISUALEFFECTS DIALOGEX 6, 18, 227, 204
+CAPTION "Visual Effects"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   LTEXT "Select the settings you want to use for the appearance and performance of ReactOS on this computer.", IDC_STATIC, 7, 6, 208, 18
+   CONTROL "", IDC_TREE, "SysTreeView32", TVS_LINESATROOT | TVS_DISABLEDRAGDROP | WS_CHILD | WS_VISIBLE | WS_BORDER | WS_TABSTOP, 7, 32, 213, 168
+END
+
+IDD_ADVANCEDPERF DIALOGEX 6, 18, 227, 128
+CAPTION "Advanced"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   GROUPBOX "CPU scheduling", IDC_STATIC, 7, 8, 213, 46
+   LTEXT "Adjust for best performance of:", IDC_STATIC, 14, 23, 199, 8
+   AUTORADIOBUTTON "&Programs", IDC_CPUCLIENT, 14, 36, 75, 12
+   AUTORADIOBUTTON "Background &services", IDC_CPUSERVER, 96, 36, 85, 12
+   GROUPBOX "Virtual memory", IDC_STATIC, 7, 60, 213, 57
+   LTEXT "A paging file is an area on the hard disk that ReactOS uses as if it were RAM.", IDC_STATIC, 14, 74, 199, 16
+   PUSHBUTTON "&Change...", IDC_CHANGESWAP, 163, 97, 50, 14
+END
+
 STRINGTABLE
 BEGIN
     IDS_CPLSYSTEMNAME "システム"
     IDS_CPLSYSTEMDESCRIPTION "コンピュータのさまざまなシステムおよびハードウェアの設定を変更するには情報をご覧ください。"
+    IDS_PERFORMANCEOPTIONS "Performance Options"
     IDS_MEGABYTE "MB RAM"
     IDS_GIGABYTE "GB RAM"
     IDS_TERABYTE "TB RAM"

--- a/dll/cpl/sysdm/lang/nl-NL.rc
+++ b/dll/cpl/sysdm/lang/nl-NL.rc
@@ -323,10 +323,34 @@ BEGIN
     DEFPUSHBUTTON "OK", IDOK, 106, 140, 54, 15
 END
 
+IDD_VISUALEFFECTS DIALOGEX 6, 18, 227, 204
+CAPTION "Visual Effects"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   LTEXT "Select the settings you want to use for the appearance and performance of ReactOS on this computer.", IDC_STATIC, 7, 6, 208, 18
+   CONTROL "", IDC_TREE, "SysTreeView32", TVS_LINESATROOT | TVS_DISABLEDRAGDROP | WS_CHILD | WS_VISIBLE | WS_BORDER | WS_TABSTOP, 7, 32, 213, 168
+END
+
+IDD_ADVANCEDPERF DIALOGEX 6, 18, 227, 128
+CAPTION "Advanced"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   GROUPBOX "CPU scheduling", IDC_STATIC, 7, 8, 213, 46
+   LTEXT "Adjust for best performance of:", IDC_STATIC, 14, 23, 199, 8
+   AUTORADIOBUTTON "&Programs", IDC_CPUCLIENT, 14, 36, 75, 12
+   AUTORADIOBUTTON "Background &services", IDC_CPUSERVER, 96, 36, 85, 12
+   GROUPBOX "Virtual memory", IDC_STATIC, 7, 60, 213, 57
+   LTEXT "A paging file is an area on the hard disk that ReactOS uses as if it were RAM.", IDC_STATIC, 14, 74, 199, 16
+   PUSHBUTTON "&Change...", IDC_CHANGESWAP, 163, 97, 50, 14
+END
+
 STRINGTABLE
 BEGIN
     IDS_CPLSYSTEMNAME "Systeem"
     IDS_CPLSYSTEMDESCRIPTION "Systeeminformatie weergeven en omgevingsinstellingen wijzigen."
+    IDS_PERFORMANCEOPTIONS "Performance Options"
     IDS_MEGABYTE "MB of RAM"
     IDS_GIGABYTE "GB of RAM"
     IDS_TERABYTE "TB of RAM"

--- a/dll/cpl/sysdm/lang/no-NO.rc
+++ b/dll/cpl/sysdm/lang/no-NO.rc
@@ -323,10 +323,34 @@ BEGIN
     DEFPUSHBUTTON "OK", IDOK, 106, 140, 54, 15
 END
 
+IDD_VISUALEFFECTS DIALOGEX 6, 18, 227, 204
+CAPTION "Visual Effects"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   LTEXT "Select the settings you want to use for the appearance and performance of ReactOS on this computer.", IDC_STATIC, 7, 6, 208, 18
+   CONTROL "", IDC_TREE, "SysTreeView32", TVS_LINESATROOT | TVS_DISABLEDRAGDROP | WS_CHILD | WS_VISIBLE | WS_BORDER | WS_TABSTOP, 7, 32, 213, 168
+END
+
+IDD_ADVANCEDPERF DIALOGEX 6, 18, 227, 128
+CAPTION "Advanced"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   GROUPBOX "CPU scheduling", IDC_STATIC, 7, 8, 213, 46
+   LTEXT "Adjust for best performance of:", IDC_STATIC, 14, 23, 199, 8
+   AUTORADIOBUTTON "&Programs", IDC_CPUCLIENT, 14, 36, 75, 12
+   AUTORADIOBUTTON "Background &services", IDC_CPUSERVER, 96, 36, 85, 12
+   GROUPBOX "Virtual memory", IDC_STATIC, 7, 60, 213, 57
+   LTEXT "A paging file is an area on the hard disk that ReactOS uses as if it were RAM.", IDC_STATIC, 14, 74, 199, 16
+   PUSHBUTTON "&Change...", IDC_CHANGESWAP, 163, 97, 50, 14
+END
+
 STRINGTABLE
 BEGIN
     IDS_CPLSYSTEMNAME "System"
     IDS_CPLSYSTEMDESCRIPTION "Se informasjon om din datamaskin og endre forskjellig system og maskinvare innstilling."
+    IDS_PERFORMANCEOPTIONS "Performance Options"
     IDS_MEGABYTE "MB Systemminne"
     IDS_GIGABYTE "GB Systemminne"
     IDS_TERABYTE "TB Systemminne"

--- a/dll/cpl/sysdm/lang/pl-PL.rc
+++ b/dll/cpl/sysdm/lang/pl-PL.rc
@@ -332,10 +332,34 @@ BEGIN
     DEFPUSHBUTTON "OK", IDOK, 106, 140, 54, 15
 END
 
+IDD_VISUALEFFECTS DIALOGEX 6, 18, 227, 204
+CAPTION "Visual Effects"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   LTEXT "Select the settings you want to use for the appearance and performance of ReactOS on this computer.", IDC_STATIC, 7, 6, 208, 18
+   CONTROL "", IDC_TREE, "SysTreeView32", TVS_LINESATROOT | TVS_DISABLEDRAGDROP | WS_CHILD | WS_VISIBLE | WS_BORDER | WS_TABSTOP, 7, 32, 213, 168
+END
+
+IDD_ADVANCEDPERF DIALOGEX 6, 18, 227, 128
+CAPTION "Advanced"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   GROUPBOX "CPU scheduling", IDC_STATIC, 7, 8, 213, 46
+   LTEXT "Adjust for best performance of:", IDC_STATIC, 14, 23, 199, 8
+   AUTORADIOBUTTON "&Programs", IDC_CPUCLIENT, 14, 36, 75, 12
+   AUTORADIOBUTTON "Background &services", IDC_CPUSERVER, 96, 36, 85, 12
+   GROUPBOX "Virtual memory", IDC_STATIC, 7, 60, 213, 57
+   LTEXT "A paging file is an area on the hard disk that ReactOS uses as if it were RAM.", IDC_STATIC, 14, 74, 199, 16
+   PUSHBUTTON "&Change...", IDC_CHANGESWAP, 163, 97, 50, 14
+END
+
 STRINGTABLE
 BEGIN
     IDS_CPLSYSTEMNAME "System"
     IDS_CPLSYSTEMDESCRIPTION "Wyświetl informacje o Twoim systemie komputerowym, zmień ustawienia dotyczące sprzętu i wydajności"
+    IDS_PERFORMANCEOPTIONS "Performance Options"
     IDS_MEGABYTE "MB RAM"
     IDS_GIGABYTE "GB RAM"
     IDS_TERABYTE "TB RAM"

--- a/dll/cpl/sysdm/lang/pt-PT.rc
+++ b/dll/cpl/sysdm/lang/pt-PT.rc
@@ -330,10 +330,34 @@ BEGIN
     DEFPUSHBUTTON "OK", IDOK, 106, 140, 54, 15
 END
 
+IDD_VISUALEFFECTS DIALOGEX 6, 18, 227, 204
+CAPTION "Visual Effects"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   LTEXT "Select the settings you want to use for the appearance and performance of ReactOS on this computer.", IDC_STATIC, 7, 6, 208, 18
+   CONTROL "", IDC_TREE, "SysTreeView32", TVS_LINESATROOT | TVS_DISABLEDRAGDROP | WS_CHILD | WS_VISIBLE | WS_BORDER | WS_TABSTOP, 7, 32, 213, 168
+END
+
+IDD_ADVANCEDPERF DIALOGEX 6, 18, 227, 128
+CAPTION "Advanced"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   GROUPBOX "CPU scheduling", IDC_STATIC, 7, 8, 213, 46
+   LTEXT "Adjust for best performance of:", IDC_STATIC, 14, 23, 199, 8
+   AUTORADIOBUTTON "&Programs", IDC_CPUCLIENT, 14, 36, 75, 12
+   AUTORADIOBUTTON "Background &services", IDC_CPUSERVER, 96, 36, 85, 12
+   GROUPBOX "Virtual memory", IDC_STATIC, 7, 60, 213, 57
+   LTEXT "A paging file is an area on the hard disk that ReactOS uses as if it were RAM.", IDC_STATIC, 14, 74, 199, 16
+   PUSHBUTTON "&Change...", IDC_CHANGESWAP, 163, 97, 50, 14
+END
+
 STRINGTABLE
 BEGIN
     IDS_CPLSYSTEMNAME "Sistema"
     IDS_CPLSYSTEMDESCRIPTION "Veja informações sobre o computador e altere várias definições do sistema e hardware."
+    IDS_PERFORMANCEOPTIONS "Performance Options"
     IDS_MEGABYTE "MB de RAM"
     IDS_GIGABYTE "GB de RAM"
     IDS_TERABYTE "TB de RAM"

--- a/dll/cpl/sysdm/lang/ro-RO.rc
+++ b/dll/cpl/sysdm/lang/ro-RO.rc
@@ -332,10 +332,34 @@ BEGIN
     DEFPUSHBUTTON "OK", IDOK, 106, 140, 54, 15
 END
 
+IDD_VISUALEFFECTS DIALOGEX 6, 18, 227, 204
+CAPTION "Visual Effects"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   LTEXT "Select the settings you want to use for the appearance and performance of ReactOS on this computer.", IDC_STATIC, 7, 6, 208, 18
+   CONTROL "", IDC_TREE, "SysTreeView32", TVS_LINESATROOT | TVS_DISABLEDRAGDROP | WS_CHILD | WS_VISIBLE | WS_BORDER | WS_TABSTOP, 7, 32, 213, 168
+END
+
+IDD_ADVANCEDPERF DIALOGEX 6, 18, 227, 128
+CAPTION "Advanced"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   GROUPBOX "CPU scheduling", IDC_STATIC, 7, 8, 213, 46
+   LTEXT "Adjust for best performance of:", IDC_STATIC, 14, 23, 199, 8
+   AUTORADIOBUTTON "&Programs", IDC_CPUCLIENT, 14, 36, 75, 12
+   AUTORADIOBUTTON "Background &services", IDC_CPUSERVER, 96, 36, 85, 12
+   GROUPBOX "Virtual memory", IDC_STATIC, 7, 60, 213, 57
+   LTEXT "A paging file is an area on the hard disk that ReactOS uses as if it were RAM.", IDC_STATIC, 14, 74, 199, 16
+   PUSHBUTTON "&Change...", IDC_CHANGESWAP, 163, 97, 50, 14
+END
+
 STRINGTABLE
 BEGIN
     IDS_CPLSYSTEMNAME "Sistem"
     IDS_CPLSYSTEMDESCRIPTION "Se vizualizează informaţii despre computerul personal şi se modifică setările pentru echipamentele hardware, pentru performanţă şi pentru actualizările automate."
+    IDS_PERFORMANCEOPTIONS "Performance Options"
     IDS_MEGABYTE "MO de RAM"
     IDS_GIGABYTE "GO de RAM"
     IDS_TERABYTE "TO de RAM"

--- a/dll/cpl/sysdm/lang/ru-RU.rc
+++ b/dll/cpl/sysdm/lang/ru-RU.rc
@@ -323,10 +323,34 @@ BEGIN
     DEFPUSHBUTTON "ОК", IDOK, 106, 140, 54, 15
 END
 
+IDD_VISUALEFFECTS DIALOGEX 6, 18, 227, 204
+CAPTION "Visual Effects"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   LTEXT "Select the settings you want to use for the appearance and performance of ReactOS on this computer.", IDC_STATIC, 7, 6, 208, 18
+   CONTROL "", IDC_TREE, "SysTreeView32", TVS_LINESATROOT | TVS_DISABLEDRAGDROP | WS_CHILD | WS_VISIBLE | WS_BORDER | WS_TABSTOP, 7, 32, 213, 168
+END
+
+IDD_ADVANCEDPERF DIALOGEX 6, 18, 227, 128
+CAPTION "Advanced"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   GROUPBOX "CPU scheduling", IDC_STATIC, 7, 8, 213, 46
+   LTEXT "Adjust for best performance of:", IDC_STATIC, 14, 23, 199, 8
+   AUTORADIOBUTTON "&Programs", IDC_CPUCLIENT, 14, 36, 75, 12
+   AUTORADIOBUTTON "Background &services", IDC_CPUSERVER, 96, 36, 85, 12
+   GROUPBOX "Virtual memory", IDC_STATIC, 7, 60, 213, 57
+   LTEXT "A paging file is an area on the hard disk that ReactOS uses as if it were RAM.", IDC_STATIC, 14, 74, 199, 16
+   PUSHBUTTON "&Change...", IDC_CHANGESWAP, 163, 97, 50, 14
+END
+
 STRINGTABLE
 BEGIN
     IDS_CPLSYSTEMNAME "Система"
     IDS_CPLSYSTEMDESCRIPTION "Просмотр информации о вашем компьютере и изменение различных системных и аппаратных параметров."
+    IDS_PERFORMANCEOPTIONS "Performance Options"
     IDS_MEGABYTE "Мб ОЗУ"
     IDS_GIGABYTE "Гб ОЗУ"
     IDS_TERABYTE "Тб ОЗУ"

--- a/dll/cpl/sysdm/lang/sk-SK.rc
+++ b/dll/cpl/sysdm/lang/sk-SK.rc
@@ -331,10 +331,34 @@ BEGIN
     DEFPUSHBUTTON "OK", IDOK, 106, 140, 54, 15
 END
 
+IDD_VISUALEFFECTS DIALOGEX 6, 18, 227, 204
+CAPTION "Visual Effects"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   LTEXT "Select the settings you want to use for the appearance and performance of ReactOS on this computer.", IDC_STATIC, 7, 6, 208, 18
+   CONTROL "", IDC_TREE, "SysTreeView32", TVS_LINESATROOT | TVS_DISABLEDRAGDROP | WS_CHILD | WS_VISIBLE | WS_BORDER | WS_TABSTOP, 7, 32, 213, 168
+END
+
+IDD_ADVANCEDPERF DIALOGEX 6, 18, 227, 128
+CAPTION "Advanced"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   GROUPBOX "CPU scheduling", IDC_STATIC, 7, 8, 213, 46
+   LTEXT "Adjust for best performance of:", IDC_STATIC, 14, 23, 199, 8
+   AUTORADIOBUTTON "&Programs", IDC_CPUCLIENT, 14, 36, 75, 12
+   AUTORADIOBUTTON "Background &services", IDC_CPUSERVER, 96, 36, 85, 12
+   GROUPBOX "Virtual memory", IDC_STATIC, 7, 60, 213, 57
+   LTEXT "A paging file is an area on the hard disk that ReactOS uses as if it were RAM.", IDC_STATIC, 14, 74, 199, 16
+   PUSHBUTTON "&Change...", IDC_CHANGESWAP, 163, 97, 50, 14
+END
+
 STRINGTABLE
 BEGIN
     IDS_CPLSYSTEMNAME "Systém"
     IDS_CPLSYSTEMDESCRIPTION "Zobrazí informácie o počítači, zmenách rôznych systémových a hardvérových nastavení."
+    IDS_PERFORMANCEOPTIONS "Performance Options"
     IDS_MEGABYTE "MB pamäte RAM"
     IDS_GIGABYTE "GB pamäte RAM"
     IDS_TERABYTE "TB pamäte RAM"

--- a/dll/cpl/sysdm/lang/sq-AL.rc
+++ b/dll/cpl/sysdm/lang/sq-AL.rc
@@ -323,10 +323,34 @@ BEGIN
     DEFPUSHBUTTON "OK", IDOK, 106, 140, 54, 15
 END
 
+IDD_VISUALEFFECTS DIALOGEX 6, 18, 227, 204
+CAPTION "Visual Effects"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   LTEXT "Select the settings you want to use for the appearance and performance of ReactOS on this computer.", IDC_STATIC, 7, 6, 208, 18
+   CONTROL "", IDC_TREE, "SysTreeView32", TVS_LINESATROOT | TVS_DISABLEDRAGDROP | WS_CHILD | WS_VISIBLE | WS_BORDER | WS_TABSTOP, 7, 32, 213, 168
+END
+
+IDD_ADVANCEDPERF DIALOGEX 6, 18, 227, 128
+CAPTION "Advanced"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   GROUPBOX "CPU scheduling", IDC_STATIC, 7, 8, 213, 46
+   LTEXT "Adjust for best performance of:", IDC_STATIC, 14, 23, 199, 8
+   AUTORADIOBUTTON "&Programs", IDC_CPUCLIENT, 14, 36, 75, 12
+   AUTORADIOBUTTON "Background &services", IDC_CPUSERVER, 96, 36, 85, 12
+   GROUPBOX "Virtual memory", IDC_STATIC, 7, 60, 213, 57
+   LTEXT "A paging file is an area on the hard disk that ReactOS uses as if it were RAM.", IDC_STATIC, 14, 74, 199, 16
+   PUSHBUTTON "&Change...", IDC_CHANGESWAP, 163, 97, 50, 14
+END
+
 STRINGTABLE
 BEGIN
     IDS_CPLSYSTEMNAME "Sistemi"
     IDS_CPLSYSTEMDESCRIPTION "Shih informacionin në lidhje me kompjuterin tuaj dhe ndrysho sistemin dhe konfigurimin e pjesëve elektronike të ndryshme."
+    IDS_PERFORMANCEOPTIONS "Performance Options"
     IDS_MEGABYTE "MB e RAM"
     IDS_GIGABYTE "GB e RAM"
     IDS_TERABYTE "TB e RAM"

--- a/dll/cpl/sysdm/lang/sv-SE.rc
+++ b/dll/cpl/sysdm/lang/sv-SE.rc
@@ -325,10 +325,34 @@ BEGIN
     DEFPUSHBUTTON "OK", IDOK, 106, 140, 54, 15
 END
 
+IDD_VISUALEFFECTS DIALOGEX 6, 18, 227, 204
+CAPTION "Visual Effects"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   LTEXT "Select the settings you want to use for the appearance and performance of ReactOS on this computer.", IDC_STATIC, 7, 6, 208, 18
+   CONTROL "", IDC_TREE, "SysTreeView32", TVS_LINESATROOT | TVS_DISABLEDRAGDROP | WS_CHILD | WS_VISIBLE | WS_BORDER | WS_TABSTOP, 7, 32, 213, 168
+END
+
+IDD_ADVANCEDPERF DIALOGEX 6, 18, 227, 128
+CAPTION "Advanced"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   GROUPBOX "CPU scheduling", IDC_STATIC, 7, 8, 213, 46
+   LTEXT "Adjust for best performance of:", IDC_STATIC, 14, 23, 199, 8
+   AUTORADIOBUTTON "&Programs", IDC_CPUCLIENT, 14, 36, 75, 12
+   AUTORADIOBUTTON "Background &services", IDC_CPUSERVER, 96, 36, 85, 12
+   GROUPBOX "Virtual memory", IDC_STATIC, 7, 60, 213, 57
+   LTEXT "A paging file is an area on the hard disk that ReactOS uses as if it were RAM.", IDC_STATIC, 14, 74, 199, 16
+   PUSHBUTTON "&Change...", IDC_CHANGESWAP, 163, 97, 50, 14
+END
+
 STRINGTABLE
 BEGIN
     IDS_CPLSYSTEMNAME "System"
     IDS_CPLSYSTEMDESCRIPTION "Se information om din dator och ändra olika system- och hårdvaruinställningar."
+    IDS_PERFORMANCEOPTIONS "Performance Options"
     IDS_MEGABYTE "MB RAM"
     IDS_GIGABYTE "GB RAM"
     IDS_TERABYTE "TB RAM"

--- a/dll/cpl/sysdm/lang/tr-TR.rc
+++ b/dll/cpl/sysdm/lang/tr-TR.rc
@@ -325,10 +325,34 @@ BEGIN
     DEFPUSHBUTTON "Tamam", IDOK, 106, 140, 54, 15
 END
 
+IDD_VISUALEFFECTS DIALOGEX 6, 18, 227, 204
+CAPTION "Visual Effects"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   LTEXT "Select the settings you want to use for the appearance and performance of ReactOS on this computer.", IDC_STATIC, 7, 6, 208, 18
+   CONTROL "", IDC_TREE, "SysTreeView32", TVS_LINESATROOT | TVS_DISABLEDRAGDROP | WS_CHILD | WS_VISIBLE | WS_BORDER | WS_TABSTOP, 7, 32, 213, 168
+END
+
+IDD_ADVANCEDPERF DIALOGEX 6, 18, 227, 128
+CAPTION "Advanced"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   GROUPBOX "CPU scheduling", IDC_STATIC, 7, 8, 213, 46
+   LTEXT "Adjust for best performance of:", IDC_STATIC, 14, 23, 199, 8
+   AUTORADIOBUTTON "&Programs", IDC_CPUCLIENT, 14, 36, 75, 12
+   AUTORADIOBUTTON "Background &services", IDC_CPUSERVER, 96, 36, 85, 12
+   GROUPBOX "Virtual memory", IDC_STATIC, 7, 60, 213, 57
+   LTEXT "A paging file is an area on the hard disk that ReactOS uses as if it were RAM.", IDC_STATIC, 14, 74, 199, 16
+   PUSHBUTTON "&Change...", IDC_CHANGESWAP, 163, 97, 50, 14
+END
+
 STRINGTABLE
 BEGIN
     IDS_CPLSYSTEMNAME "Sistem"
     IDS_CPLSYSTEMDESCRIPTION "Bilgisayar hakkında bilgi görüntüler ve türlü sistem ve donanım ayarlarını değiştirir."
+    IDS_PERFORMANCEOPTIONS "Performance Options"
     IDS_MEGABYTE "MB Bellek"
     IDS_GIGABYTE "GB Bellek"
     IDS_TERABYTE "TB Bellek"

--- a/dll/cpl/sysdm/lang/uk-UA.rc
+++ b/dll/cpl/sysdm/lang/uk-UA.rc
@@ -331,10 +331,34 @@ BEGIN
     DEFPUSHBUTTON "OK", IDOK, 106, 140, 54, 15
 END
 
+IDD_VISUALEFFECTS DIALOGEX 6, 18, 227, 204
+CAPTION "Visual Effects"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   LTEXT "Select the settings you want to use for the appearance and performance of ReactOS on this computer.", IDC_STATIC, 7, 6, 208, 18
+   CONTROL "", IDC_TREE, "SysTreeView32", TVS_LINESATROOT | TVS_DISABLEDRAGDROP | WS_CHILD | WS_VISIBLE | WS_BORDER | WS_TABSTOP, 7, 32, 213, 168
+END
+
+IDD_ADVANCEDPERF DIALOGEX 6, 18, 227, 128
+CAPTION "Advanced"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   GROUPBOX "CPU scheduling", IDC_STATIC, 7, 8, 213, 46
+   LTEXT "Adjust for best performance of:", IDC_STATIC, 14, 23, 199, 8
+   AUTORADIOBUTTON "&Programs", IDC_CPUCLIENT, 14, 36, 75, 12
+   AUTORADIOBUTTON "Background &services", IDC_CPUSERVER, 96, 36, 85, 12
+   GROUPBOX "Virtual memory", IDC_STATIC, 7, 60, 213, 57
+   LTEXT "A paging file is an area on the hard disk that ReactOS uses as if it were RAM.", IDC_STATIC, 14, 74, 199, 16
+   PUSHBUTTON "&Change...", IDC_CHANGESWAP, 163, 97, 50, 14
+END
+
 STRINGTABLE
 BEGIN
     IDS_CPLSYSTEMNAME "Система"
     IDS_CPLSYSTEMDESCRIPTION "Перегляд відомостей про систему комп'ютера та зміна параметрів обладнання, швидкодії, автоматичних оновлень."
+    IDS_PERFORMANCEOPTIONS "Performance Options"
     IDS_MEGABYTE "Мб ОЗП"
     IDS_GIGABYTE "Гб ОЗП"
     IDS_TERABYTE "Тб ОЗП"

--- a/dll/cpl/sysdm/lang/zh-CN.rc
+++ b/dll/cpl/sysdm/lang/zh-CN.rc
@@ -332,10 +332,34 @@ BEGIN
     DEFPUSHBUTTON "确定", IDOK, 106, 140, 54, 15
 END
 
+IDD_VISUALEFFECTS DIALOGEX 6, 18, 227, 204
+CAPTION "Visual Effects"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   LTEXT "Select the settings you want to use for the appearance and performance of ReactOS on this computer.", IDC_STATIC, 7, 6, 208, 18
+   CONTROL "", IDC_TREE, "SysTreeView32", TVS_LINESATROOT | TVS_DISABLEDRAGDROP | WS_CHILD | WS_VISIBLE | WS_BORDER | WS_TABSTOP, 7, 32, 213, 168
+END
+
+IDD_ADVANCEDPERF DIALOGEX 6, 18, 227, 128
+CAPTION "Advanced"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   GROUPBOX "CPU scheduling", IDC_STATIC, 7, 8, 213, 46
+   LTEXT "Adjust for best performance of:", IDC_STATIC, 14, 23, 199, 8
+   AUTORADIOBUTTON "&Programs", IDC_CPUCLIENT, 14, 36, 75, 12
+   AUTORADIOBUTTON "Background &services", IDC_CPUSERVER, 96, 36, 85, 12
+   GROUPBOX "Virtual memory", IDC_STATIC, 7, 60, 213, 57
+   LTEXT "A paging file is an area on the hard disk that ReactOS uses as if it were RAM.", IDC_STATIC, 14, 74, 199, 16
+   PUSHBUTTON "&Change...", IDC_CHANGESWAP, 163, 97, 50, 14
+END
+
 STRINGTABLE
 BEGIN
     IDS_CPLSYSTEMNAME "系统"
     IDS_CPLSYSTEMDESCRIPTION "查看您的计算机系统的信息并更改各种系统及硬件设置"
+    IDS_PERFORMANCEOPTIONS "Performance Options"
     IDS_MEGABYTE "MB 内存"
     IDS_GIGABYTE "GB 内存"
     IDS_TERABYTE "TB 内存"

--- a/dll/cpl/sysdm/lang/zh-HK.rc
+++ b/dll/cpl/sysdm/lang/zh-HK.rc
@@ -331,10 +331,34 @@ BEGIN
     DEFPUSHBUTTON "確定", IDOK, 106, 140, 54, 15
 END
 
+IDD_VISUALEFFECTS DIALOGEX 6, 18, 227, 204
+CAPTION "Visual Effects"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   LTEXT "Select the settings you want to use for the appearance and performance of ReactOS on this computer.", IDC_STATIC, 7, 6, 208, 18
+   CONTROL "", IDC_TREE, "SysTreeView32", TVS_LINESATROOT | TVS_DISABLEDRAGDROP | WS_CHILD | WS_VISIBLE | WS_BORDER | WS_TABSTOP, 7, 32, 213, 168
+END
+
+IDD_ADVANCEDPERF DIALOGEX 6, 18, 227, 128
+CAPTION "Advanced"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   GROUPBOX "CPU scheduling", IDC_STATIC, 7, 8, 213, 46
+   LTEXT "Adjust for best performance of:", IDC_STATIC, 14, 23, 199, 8
+   AUTORADIOBUTTON "&Programs", IDC_CPUCLIENT, 14, 36, 75, 12
+   AUTORADIOBUTTON "Background &services", IDC_CPUSERVER, 96, 36, 85, 12
+   GROUPBOX "Virtual memory", IDC_STATIC, 7, 60, 213, 57
+   LTEXT "A paging file is an area on the hard disk that ReactOS uses as if it were RAM.", IDC_STATIC, 14, 74, 199, 16
+   PUSHBUTTON "&Change...", IDC_CHANGESWAP, 163, 97, 50, 14
+END
+
 STRINGTABLE
 BEGIN
     IDS_CPLSYSTEMNAME "系統"
     IDS_CPLSYSTEMDESCRIPTION "查看您的電腦系統的訊息並更改各種系統及硬件設定"
+    IDS_PERFORMANCEOPTIONS "Performance Options"
     IDS_MEGABYTE "MB 記憶體"
     IDS_GIGABYTE "GB 記憶體"
     IDS_TERABYTE "TB 記憶體"

--- a/dll/cpl/sysdm/lang/zh-TW.rc
+++ b/dll/cpl/sysdm/lang/zh-TW.rc
@@ -332,10 +332,34 @@ BEGIN
     DEFPUSHBUTTON "確定", IDOK, 106, 140, 54, 15
 END
 
+IDD_VISUALEFFECTS DIALOGEX 6, 18, 227, 204
+CAPTION "Visual Effects"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   LTEXT "Select the settings you want to use for the appearance and performance of ReactOS on this computer.", IDC_STATIC, 7, 6, 208, 18
+   CONTROL "", IDC_TREE, "SysTreeView32", TVS_LINESATROOT | TVS_DISABLEDRAGDROP | WS_CHILD | WS_VISIBLE | WS_BORDER | WS_TABSTOP, 7, 32, 213, 168
+END
+
+IDD_ADVANCEDPERF DIALOGEX 6, 18, 227, 128
+CAPTION "Advanced"
+FONT 8, "MS Shell Dlg"
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+BEGIN
+   GROUPBOX "CPU scheduling", IDC_STATIC, 7, 8, 213, 46
+   LTEXT "Adjust for best performance of:", IDC_STATIC, 14, 23, 199, 8
+   AUTORADIOBUTTON "&Programs", IDC_CPUCLIENT, 14, 36, 75, 12
+   AUTORADIOBUTTON "Background &services", IDC_CPUSERVER, 96, 36, 85, 12
+   GROUPBOX "Virtual memory", IDC_STATIC, 7, 60, 213, 57
+   LTEXT "A paging file is an area on the hard disk that ReactOS uses as if it were RAM.", IDC_STATIC, 14, 74, 199, 16
+   PUSHBUTTON "&Change...", IDC_CHANGESWAP, 163, 97, 50, 14
+END
+
 STRINGTABLE
 BEGIN
     IDS_CPLSYSTEMNAME "系統"
     IDS_CPLSYSTEMDESCRIPTION "查看您的電腦系統的資訊並更改各種系統及硬體設定"
+    IDS_PERFORMANCEOPTIONS "Performance Options"
     IDS_MEGABYTE "MB 記憶體"
     IDS_GIGABYTE "GB 記憶體"
     IDS_TERABYTE "TB 記憶體"

--- a/dll/cpl/sysdm/performance.c
+++ b/dll/cpl/sysdm/performance.c
@@ -1,0 +1,156 @@
+/*
+ * PROJECT:     ReactOS System Control Panel Applet
+ * LICENSE:     LGPL-2.1+ (https://spdx.org/licenses/LGPL-2.1+)
+ * FILE:        dll/cpl/sysdm/performance.c
+ * PURPOSE:     Performance settings property sheets
+ * COPYRIGHT:   Copyright 2024 Whindmar Saksit <whindsaks@proton.me>
+ *
+ */
+
+#define COBJMACROS
+#include "precomp.h"
+#include <shlguid_undoc.h> // CLSID_CRegTreeOptions
+#include <shlobj_undoc.h> // IRegTreeOptions
+
+static VOID
+RegTreeOpt_OnDestroy(IRegTreeOptions *pRTO)
+{
+    if (pRTO)
+    {
+        IRegTreeOptions_WalkTree(pRTO, WALK_TREE_DESTROY);
+        IRegTreeOptions_Release(pRTO);
+    }
+}
+
+static BOOL
+RegTreeOpt_ToggleCheckItem(IRegTreeOptions *pRTO, HTREEITEM hItem)
+{
+    return pRTO && SUCCEEDED(IRegTreeOptions_ToggleItem(pRTO, hItem));
+}
+
+static BOOL
+RegTreeOpt_OnTreeViewClick(IRegTreeOptions *pRTO, HWND hWndTree)
+{
+    TV_HITTESTINFO HitTest;
+    DWORD dwPos = GetMessagePos();
+    HitTest.pt.x = GET_X_LPARAM(dwPos);
+    HitTest.pt.y = GET_Y_LPARAM(dwPos);
+    ScreenToClient(hWndTree, &HitTest.pt);
+    HTREEITEM hItem = TreeView_HitTest(hWndTree, &HitTest);
+    return RegTreeOpt_ToggleCheckItem(pRTO, hItem);
+}
+
+static BOOL
+RegTreeOpt_OnTreeViewKeyDown(IRegTreeOptions *pRTO, HWND hWndTree, TV_KEYDOWN *pKey)
+{
+    if (pKey->wVKey == VK_SPACE)
+        return RegTreeOpt_ToggleCheckItem(pRTO, TreeView_GetSelection(hWndTree));
+    else if (pKey->wVKey == VK_F5 && pRTO)
+        IRegTreeOptions_WalkTree(pRTO, WALK_TREE_REFRESH);
+    return FALSE;
+}
+
+static INT_PTR CALLBACK
+VisualEffectsDlgProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
+{
+    IRegTreeOptions *pRTO = (IRegTreeOptions*)GetWindowLongPtr(hDlg, DWLP_USER);
+    HWND hWndTree = GetDlgItem(hDlg, IDC_TREE);
+
+    switch (uMsg)
+    {
+        case WM_INITDIALOG:
+        {
+            IRegTreeOptions *pRTO = NULL;
+            if (SUCCEEDED(CoCreateInstance(&CLSID_CRegTreeOptions, NULL, CLSCTX_INPROC_SERVER,
+                                           &IID_IRegTreeOptions, (void**)&pRTO)))
+            {
+                LPCSTR pszPath = "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\VisualEffects";
+                SetWindowLongPtr(hDlg, DWLP_USER, (LPARAM)pRTO);
+                IRegTreeOptions_InitTree(pRTO, hWndTree, HKEY_LOCAL_MACHINE, pszPath, NULL);
+            }
+            return TRUE;
+        }
+
+        case WM_DESTROY:
+            RegTreeOpt_OnDestroy(pRTO);
+            SetWindowLongPtr(hDlg, DWLP_USER, (LPARAM)NULL);
+            break;
+
+        case WM_NOTIFY:
+            switch (((LPNMHDR)lParam)->code)
+            {
+                case NM_CLICK:
+                    if (RegTreeOpt_OnTreeViewClick(pRTO, hWndTree))
+                        PropSheet_Changed(GetParent(hDlg), hDlg);
+                    break;
+
+                case TVN_KEYDOWN:
+                    if (RegTreeOpt_OnTreeViewKeyDown(pRTO, hWndTree, (TV_KEYDOWN*)lParam))
+                        PropSheet_Changed(GetParent(hDlg), hDlg);
+                    break;
+
+                case PSN_APPLY:
+                {
+                    if (pRTO)
+                        IRegTreeOptions_WalkTree(pRTO, WALK_TREE_SAVE);
+
+                    SHSendMessageBroadcastW(WM_SETTINGCHANGE, 0, 0); // For the ListviewShadow setting
+                    return TRUE;
+                }
+            }
+            break;
+    }
+    return FALSE;
+}
+
+static INT_PTR CALLBACK
+AdvancedDlgProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
+{
+    switch (uMsg)
+    {
+        case WM_INITDIALOG:
+            // TODO: Not implemented yet
+            EnableWindow(GetDlgItem(hDlg, IDC_CPUCLIENT), FALSE);
+            EnableWindow(GetDlgItem(hDlg, IDC_CPUSERVER), FALSE);
+            return TRUE;
+
+        case WM_COMMAND:
+            switch (LOWORD(wParam))
+            {
+                case IDC_CHANGESWAP:
+                    DialogBox(hApplet, MAKEINTRESOURCE(IDD_VIRTMEM), hDlg, VirtMemDlgProc);
+                    break;
+            }
+            break;
+    }
+    return FALSE;
+}
+
+VOID
+ShowPerformanceOptions(HWND hDlg)
+{
+    HRESULT hrInit = CoInitialize(NULL); // For IRegTreeOptions
+    PROPSHEETHEADERW psh = { sizeof(psh), PSH_PROPSHEETPAGE | PSH_NOCONTEXTHELP };
+    PROPSHEETPAGEW pages[2] = { 0 };
+
+    pages[0].dwSize = sizeof(*pages);
+    pages[0].hInstance = hApplet;
+    pages[0].pszTemplate = MAKEINTRESOURCEW(IDD_VISUALEFFECTS);
+    pages[0].pfnDlgProc = VisualEffectsDlgProc;
+
+    pages[1].dwSize = sizeof(*pages);
+    pages[1].hInstance = hApplet;
+    pages[1].pszTemplate = MAKEINTRESOURCEW(IDD_ADVANCEDPERF);
+    pages[1].pfnDlgProc = AdvancedDlgProc;
+
+    psh.hwndParent = hDlg;
+    psh.hInstance = hApplet;
+    psh.pszCaption = MAKEINTRESOURCEW(IDS_PERFORMANCEOPTIONS);
+    psh.nPages = _countof(pages);
+    psh.ppsp = pages;
+
+    PropertySheetW(&psh);
+
+    if (SUCCEEDED(hrInit))
+        CoUninitialize();
+}

--- a/dll/cpl/sysdm/precomp.h
+++ b/dll/cpl/sysdm/precomp.h
@@ -43,6 +43,7 @@ void ShowLastWin32Error(HWND hWndOwner);
 INT_PTR CALLBACK GeneralPageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
 INT_PTR CALLBACK HardwarePageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
 INT_PTR CALLBACK AdvancedPageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
+VOID ShowPerformanceOptions(HWND hDlg);
 
 /* Dialogs */
 INT_PTR CALLBACK HardProfDlgProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam);

--- a/dll/cpl/sysdm/resource.h
+++ b/dll/cpl/sysdm/resource.h
@@ -14,6 +14,8 @@
 #define IDB_ROSBMP 55
 #define IDB_ROSMASK 56
 
+#define IDS_PERFORMANCEOPTIONS 35
+
 #define IDS_CPLSYSTEMNAME        60
 #define IDS_CPLSYSTEMDESCRIPTION 61
 
@@ -151,6 +153,16 @@
 #define IDC_BUTTON_MOVE_UP       710
 #define IDC_BUTTON_MOVE_DOWN     711
 #define IDC_BUTTON_EDIT_TEXT     712
+
+/* Visual Effects */
+#define IDD_VISUALEFFECTS 112
+#define IDC_TREE 100
+
+/* Advanced Performance */
+#define IDD_ADVANCEDPERF 115
+#define IDC_CPUCLIENT    100
+#define IDC_CPUSERVER    101
+#define IDC_CHANGESWAP   102
 
 /* Virtual memory */
 #define IDD_VIRTMEM      900

--- a/dll/cpl/sysdm/sysdm.c
+++ b/dll/cpl/sysdm/sysdm.c
@@ -164,6 +164,12 @@ SystemApplet(HWND hwnd, UINT uMsg, LPARAM wParam, LPARAM lParam)
         nPage = _wtoi((PWSTR)lParam);
     }
 
+    if (nPage == -1)
+    {
+        ShowPerformanceOptions(hwnd);
+        return TRUE;
+    }
+
     ZeroMemory(&psh, sizeof(PROPSHEETHEADER));
     psh.dwSize = sizeof(PROPSHEETHEADER);
     psh.dwFlags =  PSH_PROPTITLE | PSH_USEICONID | PSH_USECALLBACK;

--- a/dll/win32/browseui/regtreeoptions.cpp
+++ b/dll/win32/browseui/regtreeoptions.cpp
@@ -21,6 +21,7 @@ enum {
     STATE_RADIOOFF = TYPE_RADIO * STATEIMAGESPERTYPE,
     STATE_RADIOON,
     STATE_GROUP    = TYPE_GROUP * STATEIMAGESPERTYPE,
+    REG_GET_DIRECT = -1,
 };
 
 C_ASSERT((STATE_CHECKON & 1) && (STATE_RADIOON & 1) && STATE_RADIOON < STATE_GROUP);
@@ -162,7 +163,7 @@ static HRESULT GetDefaultValue(HKEY hKey, DWORD &Type, LPVOID Data, DWORD &Size)
     return HRESULT_FROM_WIN32(Err);
 }
 
-static HRESULT GetSetState(HKEY hKey, DWORD &Type, LPBYTE Data, DWORD &Size, BOOL Set)
+HRESULT CRegTreeOptions::GetSetState(HKEY hKey, DWORD &Type, LPBYTE Data, DWORD &Size, BOOL Set)
 {
     HRESULT hr;
     UINT SysParam = GetRegDWORD(hKey, Set ? L"SPIActionSet" : L"SPIActionGet", DWORD(0));
@@ -174,24 +175,24 @@ static HRESULT GetSetState(HKEY hKey, DWORD &Type, LPBYTE Data, DWORD &Size, BOO
         return S_OK;
     }
 
-#if 0 // TODO
     // learn.microsoft.com/en-us/windows/win32/api/shobjidl_core/nn-shobjidl_core-iregtreeitem
+    WCHAR szTemp[42];
     CLSID clsid;
-    if (SUCCEEDED(GetRegString(hKey, "CLSID", Temp, _countof(Temp))) && ..(Temp, &clsid))
+    if (SUCCEEDED(GetRegString(hKey, L"CLSID", szTemp, _countof(szTemp))) &&
+        SUCCEEDED(CLSIDFromStringWrap(szTemp, &clsid)))
     {
         IRegTreeItem *pRTI;
-        if (SUCCEEDED(hr = IUnknown_QueryService(m_pUnkSite, clsid, IID_PPV_ARG(IRegTreeItem, &pti))) ||
+        if (SUCCEEDED(hr = IUnknown_QueryService(m_pUnkSite, clsid, IID_PPV_ARG(IRegTreeItem, &pRTI))) ||
             SUCCEEDED(hr = SHCoCreateInstance(NULL, &clsid, NULL, IID_PPV_ARG(IRegTreeItem, &pRTI))))
         {
             BOOL *boolptr = (BOOL*)Data;
             Size = sizeof(BOOL);
-            Type = REG_DWORD;
+            Type = REG_GET_DIRECT;
             hr = Set ? pRTI->SetCheckState(*boolptr) : pRTI->GetCheckState(boolptr);
             pRTI->Release();
         }
         return hr;
     }
-#endif
 
     DWORD Mask = ~DWORD(0), Offset = 0;
     BOOL HasMask = GetRegDWORD(hKey, L"Mask", &Mask) == ERROR_SUCCESS;
@@ -286,7 +287,7 @@ static HRESULT GetSetState(HKEY hKey, DWORD &Type, LPBYTE Data, DWORD &Size, BOO
     return hr;
 }
 
-static HRESULT GetCheckState(HKEY hKey, BOOL UseDefault = FALSE)
+HRESULT CRegTreeOptions::GetCheckState(HKEY hKey, BOOL UseDefault)
 {
     BYTE CurrData[MAXVALUEDATA], CheckData[MAXVALUEDATA];
     DWORD CurrType, CheckType, CurrSize, CheckSize, Err, Checked;
@@ -317,7 +318,11 @@ static HRESULT GetCheckState(HKEY hKey, BOOL UseDefault = FALSE)
 
     CurrType = NormalizeRegType(CurrType);
     CheckType = NormalizeRegType(CheckType);
-    if (CurrType != CheckType)
+    if (CurrType == REG_GET_DIRECT)
+    {
+        Checked = *(BOOL*)CurrData;
+    }
+    else if (CurrType != CheckType)
     {
         return HRESULT_FROM_WIN32(ERROR_BAD_FORMAT);
     }
@@ -339,7 +344,7 @@ static HRESULT GetCheckState(HKEY hKey, BOOL UseDefault = FALSE)
     return Checked ? S_OK : S_FALSE;
 }
 
-static HRESULT SaveCheckState(HKEY hKey, BOOL Checked)
+HRESULT CRegTreeOptions::SaveCheckState(HKEY hKey, BOOL Checked)
 {
     BYTE Data[MAXVALUEDATA];
     DWORD Type = REG_DWORD, Size = sizeof(Data);
@@ -351,7 +356,7 @@ static HRESULT SaveCheckState(HKEY hKey, BOOL Checked)
     return Err ? HRESULT_FROM_WIN32(Err) : GetSetState(hKey, Type, Data, Size, TRUE);
 }
 
-static void WalkTree(WALK_TREE_CMD Command, HWND hTree, HTREEITEM hTI)
+void CRegTreeOptions::WalkTree(WALK_TREE_CMD Command, HWND hTree, HTREEITEM hTI)
 {
     for (HTREEITEM hChildTI = TreeView_GetChild(hTree, hTI); hChildTI;)
     {
@@ -517,7 +522,7 @@ HRESULT STDMETHODCALLTYPE CRegTreeOptions::WalkTree(WALK_TREE_CMD Command)
 {
     for (HTREEITEM hTI = TreeView_GetRoot(m_hTree); hTI;)
     {
-        ::WalkTree(Command, m_hTree, hTI);
+        WalkTree(Command, m_hTree, hTI);
         hTI = TreeView_GetNextSibling(m_hTree, hTI);
     }
     return S_OK;

--- a/dll/win32/browseui/regtreeoptions.h
+++ b/dll/win32/browseui/regtreeoptions.h
@@ -22,6 +22,10 @@ public:
     ~CRegTreeOptions();
 
     void AddItemsFromRegistry(HKEY hKey, HTREEITEM hParent, HTREEITEM hInsertAfter);
+    HRESULT GetSetState(HKEY hKey, DWORD &Type, LPBYTE Data, DWORD &Size, BOOL Set);
+    HRESULT GetCheckState(HKEY hKey, BOOL UseDefault = FALSE);
+    HRESULT SaveCheckState(HKEY hKey, BOOL Checked);
+    void WalkTree(WALK_TREE_CMD Command, HWND hTree, HTREEITEM hTI);
 
     // *** IRegTreeOptions methods ***
     STDMETHOD(InitTree)(HWND hTV, HKEY hKey, LPCSTR SubKey, char const *pUnknown) override;

--- a/dll/win32/shell32/lang/bg-BG.rc
+++ b/dll/win32/shell32/lang/bg-BG.rc
@@ -1040,6 +1040,10 @@ BEGIN
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
     IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
+    IDS_VISEFFECT_DRAGFULL "Show window contents while dragging"
+    IDS_VISEFFECT_FONTSMOOTHING "Smooth edges of screen fonts"
+    IDS_VISEFFECT_LISTVIEWSHADOW "Use drop shadows for icon labels on the desktop"
+
     IDS_NEWEXT_ADVANCED_LEFT "<< Ad&vanced"
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"
     IDS_NEWEXT_NEW "<New>"

--- a/dll/win32/shell32/lang/cs-CZ.rc
+++ b/dll/win32/shell32/lang/cs-CZ.rc
@@ -1048,6 +1048,10 @@ BEGIN
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
     IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
+    IDS_VISEFFECT_DRAGFULL "Show window contents while dragging"
+    IDS_VISEFFECT_FONTSMOOTHING "Smooth edges of screen fonts"
+    IDS_VISEFFECT_LISTVIEWSHADOW "Use drop shadows for icon labels on the desktop"
+
     IDS_NEWEXT_ADVANCED_LEFT "<< Ad&vanced"
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"
     IDS_NEWEXT_NEW "<New>"

--- a/dll/win32/shell32/lang/de-DE.rc
+++ b/dll/win32/shell32/lang/de-DE.rc
@@ -1041,6 +1041,10 @@ BEGIN
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
     IDS_ADVANCED_SMALL_START_MENU "Kleine Symbole im Startmenü anzeigen"
 
+    IDS_VISEFFECT_DRAGFULL "Show window contents while dragging"
+    IDS_VISEFFECT_FONTSMOOTHING "Smooth edges of screen fonts"
+    IDS_VISEFFECT_LISTVIEWSHADOW "Use drop shadows for icon labels on the desktop"
+
     IDS_NEWEXT_ADVANCED_LEFT "<< Er&weitert"
     IDS_NEWEXT_ADVANCED_RIGHT "&Erweitert >>"
     IDS_NEWEXT_NEW "<Neu>"

--- a/dll/win32/shell32/lang/el-GR.rc
+++ b/dll/win32/shell32/lang/el-GR.rc
@@ -1040,6 +1040,10 @@ BEGIN
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
     IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
+    IDS_VISEFFECT_DRAGFULL "Show window contents while dragging"
+    IDS_VISEFFECT_FONTSMOOTHING "Smooth edges of screen fonts"
+    IDS_VISEFFECT_LISTVIEWSHADOW "Use drop shadows for icon labels on the desktop"
+
     IDS_NEWEXT_ADVANCED_LEFT "<< Ad&vanced"
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"
     IDS_NEWEXT_NEW "<New>"

--- a/dll/win32/shell32/lang/en-GB.rc
+++ b/dll/win32/shell32/lang/en-GB.rc
@@ -1040,6 +1040,10 @@ BEGIN
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
     IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
+    IDS_VISEFFECT_DRAGFULL "Show window contents while dragging"
+    IDS_VISEFFECT_FONTSMOOTHING "Smooth edges of screen fonts"
+    IDS_VISEFFECT_LISTVIEWSHADOW "Use drop shadows for icon labels on the desktop"
+
     IDS_NEWEXT_ADVANCED_LEFT "<< Ad&vanced"
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"
     IDS_NEWEXT_NEW "<New>"

--- a/dll/win32/shell32/lang/en-US.rc
+++ b/dll/win32/shell32/lang/en-US.rc
@@ -1040,6 +1040,10 @@ BEGIN
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
     IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
+    IDS_VISEFFECT_DRAGFULL "Show window contents while dragging"
+    IDS_VISEFFECT_FONTSMOOTHING "Smooth edges of screen fonts"
+    IDS_VISEFFECT_LISTVIEWSHADOW "Use drop shadows for icon labels on the desktop"
+
     IDS_NEWEXT_ADVANCED_LEFT "<< Ad&vanced"
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"
     IDS_NEWEXT_NEW "<New>"

--- a/dll/win32/shell32/lang/es-ES.rc
+++ b/dll/win32/shell32/lang/es-ES.rc
@@ -1049,6 +1049,10 @@ BEGIN
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
     IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
+    IDS_VISEFFECT_DRAGFULL "Show window contents while dragging"
+    IDS_VISEFFECT_FONTSMOOTHING "Smooth edges of screen fonts"
+    IDS_VISEFFECT_LISTVIEWSHADOW "Use drop shadows for icon labels on the desktop"
+
     IDS_NEWEXT_ADVANCED_LEFT "<< A&vanzado"
     IDS_NEWEXT_ADVANCED_RIGHT "A&vanzado >>"
     IDS_NEWEXT_NEW "<Nuevo>"

--- a/dll/win32/shell32/lang/et-EE.rc
+++ b/dll/win32/shell32/lang/et-EE.rc
@@ -1047,6 +1047,10 @@ BEGIN
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
     IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
+    IDS_VISEFFECT_DRAGFULL "Show window contents while dragging"
+    IDS_VISEFFECT_FONTSMOOTHING "Smooth edges of screen fonts"
+    IDS_VISEFFECT_LISTVIEWSHADOW "Use drop shadows for icon labels on the desktop"
+
     IDS_NEWEXT_ADVANCED_LEFT "<< Tä&psemalt"
     IDS_NEWEXT_ADVANCED_RIGHT "Tä&psemalt >>"
     IDS_NEWEXT_NEW "<Uus>"

--- a/dll/win32/shell32/lang/eu-ES.rc
+++ b/dll/win32/shell32/lang/eu-ES.rc
@@ -1045,6 +1045,10 @@ BEGIN
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
     IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
+    IDS_VISEFFECT_DRAGFULL "Show window contents while dragging"
+    IDS_VISEFFECT_FONTSMOOTHING "Smooth edges of screen fonts"
+    IDS_VISEFFECT_LISTVIEWSHADOW "Use drop shadows for icon labels on the desktop"
+
     IDS_NEWEXT_ADVANCED_LEFT "<< &Aurreratua"
     IDS_NEWEXT_ADVANCED_RIGHT "&Aurreratua >>"
     IDS_NEWEXT_NEW "<Berri>"

--- a/dll/win32/shell32/lang/fi-FI.rc
+++ b/dll/win32/shell32/lang/fi-FI.rc
@@ -1040,6 +1040,10 @@ BEGIN
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
     IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
+    IDS_VISEFFECT_DRAGFULL "Show window contents while dragging"
+    IDS_VISEFFECT_FONTSMOOTHING "Smooth edges of screen fonts"
+    IDS_VISEFFECT_LISTVIEWSHADOW "Use drop shadows for icon labels on the desktop"
+
     IDS_NEWEXT_ADVANCED_LEFT "<< Ad&vanced"
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"
     IDS_NEWEXT_NEW "<New>"

--- a/dll/win32/shell32/lang/fr-FR.rc
+++ b/dll/win32/shell32/lang/fr-FR.rc
@@ -1040,6 +1040,10 @@ BEGIN
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
     IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
+    IDS_VISEFFECT_DRAGFULL "Show window contents while dragging"
+    IDS_VISEFFECT_FONTSMOOTHING "Smooth edges of screen fonts"
+    IDS_VISEFFECT_LISTVIEWSHADOW "Use drop shadows for icon labels on the desktop"
+
     IDS_NEWEXT_ADVANCED_LEFT "<< A&vancé"
     IDS_NEWEXT_ADVANCED_RIGHT "A&vancé >>"
     IDS_NEWEXT_NEW "<Nouveau>"

--- a/dll/win32/shell32/lang/he-IL.rc
+++ b/dll/win32/shell32/lang/he-IL.rc
@@ -1048,6 +1048,10 @@ BEGIN
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
     IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
+    IDS_VISEFFECT_DRAGFULL "Show window contents while dragging"
+    IDS_VISEFFECT_FONTSMOOTHING "Smooth edges of screen fonts"
+    IDS_VISEFFECT_LISTVIEWSHADOW "Use drop shadows for icon labels on the desktop"
+
     IDS_NEWEXT_ADVANCED_LEFT "<< &מתקדם"
     IDS_NEWEXT_ADVANCED_RIGHT "&מתקדם >>"
     IDS_NEWEXT_NEW "<חדש>"

--- a/dll/win32/shell32/lang/hi-IN.rc
+++ b/dll/win32/shell32/lang/hi-IN.rc
@@ -1042,6 +1042,10 @@ BEGIN
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
     IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
+    IDS_VISEFFECT_DRAGFULL "Show window contents while dragging"
+    IDS_VISEFFECT_FONTSMOOTHING "Smooth edges of screen fonts"
+    IDS_VISEFFECT_LISTVIEWSHADOW "Use drop shadows for icon labels on the desktop"
+
     IDS_NEWEXT_ADVANCED_LEFT "<< &उन्नत"
     IDS_NEWEXT_ADVANCED_RIGHT "&उन्नत >>"
     IDS_NEWEXT_NEW "<नया>"

--- a/dll/win32/shell32/lang/hu-HU.rc
+++ b/dll/win32/shell32/lang/hu-HU.rc
@@ -1039,6 +1039,10 @@ BEGIN
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
     IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
+    IDS_VISEFFECT_DRAGFULL "Show window contents while dragging"
+    IDS_VISEFFECT_FONTSMOOTHING "Smooth edges of screen fonts"
+    IDS_VISEFFECT_LISTVIEWSHADOW "Use drop shadows for icon labels on the desktop"
+
     IDS_NEWEXT_ADVANCED_LEFT "<< &Haladó"
     IDS_NEWEXT_ADVANCED_RIGHT "&Haladó >>"
     IDS_NEWEXT_NEW "<Új>"

--- a/dll/win32/shell32/lang/id-ID.rc
+++ b/dll/win32/shell32/lang/id-ID.rc
@@ -1037,6 +1037,10 @@ BEGIN
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Tampilkan Alat Administratif"
     IDS_ADVANCED_SMALL_START_MENU "Tampilkan Ikon Kecil dalam Menu mulai"
 
+    IDS_VISEFFECT_DRAGFULL "Show window contents while dragging"
+    IDS_VISEFFECT_FONTSMOOTHING "Smooth edges of screen fonts"
+    IDS_VISEFFECT_LISTVIEWSHADOW "Use drop shadows for icon labels on the desktop"
+
     IDS_NEWEXT_ADVANCED_LEFT "<< Tin&gkat lanjut"
     IDS_NEWEXT_ADVANCED_RIGHT "Tin&gkat lanjut >>"
     IDS_NEWEXT_NEW "<Baru>"

--- a/dll/win32/shell32/lang/it-IT.rc
+++ b/dll/win32/shell32/lang/it-IT.rc
@@ -1040,6 +1040,10 @@ BEGIN
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
     IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
+    IDS_VISEFFECT_DRAGFULL "Show window contents while dragging"
+    IDS_VISEFFECT_FONTSMOOTHING "Smooth edges of screen fonts"
+    IDS_VISEFFECT_LISTVIEWSHADOW "Use drop shadows for icon labels on the desktop"
+
     IDS_NEWEXT_ADVANCED_LEFT "<< Ad&vanced"
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"
     IDS_NEWEXT_NEW "<New>"

--- a/dll/win32/shell32/lang/ja-JP.rc
+++ b/dll/win32/shell32/lang/ja-JP.rc
@@ -1037,6 +1037,10 @@ BEGIN
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "「管理者ツール」を表示"
     IDS_ADVANCED_SMALL_START_MENU "小さいアイコンでスタートメニューを表示"
 
+    IDS_VISEFFECT_DRAGFULL "Show window contents while dragging"
+    IDS_VISEFFECT_FONTSMOOTHING "Smooth edges of screen fonts"
+    IDS_VISEFFECT_LISTVIEWSHADOW "Use drop shadows for icon labels on the desktop"
+
     IDS_NEWEXT_ADVANCED_LEFT "<< 高度な設定(&V)"
     IDS_NEWEXT_ADVANCED_RIGHT "高度な設定(&V) >>"
     IDS_NEWEXT_NEW "<新規>"

--- a/dll/win32/shell32/lang/ko-KR.rc
+++ b/dll/win32/shell32/lang/ko-KR.rc
@@ -1047,6 +1047,10 @@ BEGIN
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
     IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
+    IDS_VISEFFECT_DRAGFULL "Show window contents while dragging"
+    IDS_VISEFFECT_FONTSMOOTHING "Smooth edges of screen fonts"
+    IDS_VISEFFECT_LISTVIEWSHADOW "Use drop shadows for icon labels on the desktop"
+
     IDS_NEWEXT_ADVANCED_LEFT "<< Ad&vanced"
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"
     IDS_NEWEXT_NEW "<New>"

--- a/dll/win32/shell32/lang/nl-NL.rc
+++ b/dll/win32/shell32/lang/nl-NL.rc
@@ -1040,6 +1040,10 @@ BEGIN
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
     IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
+    IDS_VISEFFECT_DRAGFULL "Show window contents while dragging"
+    IDS_VISEFFECT_FONTSMOOTHING "Smooth edges of screen fonts"
+    IDS_VISEFFECT_LISTVIEWSHADOW "Use drop shadows for icon labels on the desktop"
+
     IDS_NEWEXT_ADVANCED_LEFT "<< Ad&vanced"
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"
     IDS_NEWEXT_NEW "<New>"

--- a/dll/win32/shell32/lang/no-NO.rc
+++ b/dll/win32/shell32/lang/no-NO.rc
@@ -1040,6 +1040,10 @@ BEGIN
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
     IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
+    IDS_VISEFFECT_DRAGFULL "Show window contents while dragging"
+    IDS_VISEFFECT_FONTSMOOTHING "Smooth edges of screen fonts"
+    IDS_VISEFFECT_LISTVIEWSHADOW "Use drop shadows for icon labels on the desktop"
+
     IDS_NEWEXT_ADVANCED_LEFT "<< Ad&vanced"
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"
     IDS_NEWEXT_NEW "<New>"

--- a/dll/win32/shell32/lang/pl-PL.rc
+++ b/dll/win32/shell32/lang/pl-PL.rc
@@ -1049,6 +1049,10 @@ BEGIN
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Wyświetl polecenie Narzędzia administracyjne"
     IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
+    IDS_VISEFFECT_DRAGFULL "Show window contents while dragging"
+    IDS_VISEFFECT_FONTSMOOTHING "Smooth edges of screen fonts"
+    IDS_VISEFFECT_LISTVIEWSHADOW "Use drop shadows for icon labels on the desktop"
+
     IDS_NEWEXT_ADVANCED_LEFT "<< &Zaawansowane"
     IDS_NEWEXT_ADVANCED_RIGHT "&Zaawansowane >>"
     IDS_NEWEXT_NEW "<Nowy>"

--- a/dll/win32/shell32/lang/pt-BR.rc
+++ b/dll/win32/shell32/lang/pt-BR.rc
@@ -1040,6 +1040,10 @@ BEGIN
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
     IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
+    IDS_VISEFFECT_DRAGFULL "Show window contents while dragging"
+    IDS_VISEFFECT_FONTSMOOTHING "Smooth edges of screen fonts"
+    IDS_VISEFFECT_LISTVIEWSHADOW "Use drop shadows for icon labels on the desktop"
+
     IDS_NEWEXT_ADVANCED_LEFT "<< Ad&vanced"
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"
     IDS_NEWEXT_NEW "<New>"

--- a/dll/win32/shell32/lang/pt-PT.rc
+++ b/dll/win32/shell32/lang/pt-PT.rc
@@ -1049,6 +1049,10 @@ BEGIN
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Mostrar 'Ferramentas administrativas'"
     IDS_ADVANCED_SMALL_START_MENU "Mostrar ícones pequenos no menu 'Iniciar'"
 
+    IDS_VISEFFECT_DRAGFULL "Show window contents while dragging"
+    IDS_VISEFFECT_FONTSMOOTHING "Smooth edges of screen fonts"
+    IDS_VISEFFECT_LISTVIEWSHADOW "Use drop shadows for icon labels on the desktop"
+
     IDS_NEWEXT_ADVANCED_LEFT "<< A&vançado"
     IDS_NEWEXT_ADVANCED_RIGHT "Avança&do >>"
     IDS_NEWEXT_NEW "<Novo>"

--- a/dll/win32/shell32/lang/ro-RO.rc
+++ b/dll/win32/shell32/lang/ro-RO.rc
@@ -1048,6 +1048,10 @@ BEGIN
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Se afişează Instrumente de administrare"
     IDS_ADVANCED_SMALL_START_MENU "Se afişează Pictograme mici în Meniul Start"
 
+    IDS_VISEFFECT_DRAGFULL "Show window contents while dragging"
+    IDS_VISEFFECT_FONTSMOOTHING "Smooth edges of screen fonts"
+    IDS_VISEFFECT_LISTVIEWSHADOW "Use drop shadows for icon labels on the desktop"
+
     IDS_NEWEXT_ADVANCED_LEFT "<< &Complex"
     IDS_NEWEXT_ADVANCED_RIGHT "&Complex >>"
     IDS_NEWEXT_NEW "<Nou>"

--- a/dll/win32/shell32/lang/ru-RU.rc
+++ b/dll/win32/shell32/lang/ru-RU.rc
@@ -1049,6 +1049,10 @@ BEGIN
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Отображать меню ""Администрирование"""
     IDS_ADVANCED_SMALL_START_MENU "Мелкие значки в главном меню"
 
+    IDS_VISEFFECT_DRAGFULL "Show window contents while dragging"
+    IDS_VISEFFECT_FONTSMOOTHING "Smooth edges of screen fonts"
+    IDS_VISEFFECT_LISTVIEWSHADOW "Use drop shadows for icon labels on the desktop"
+
     IDS_NEWEXT_ADVANCED_LEFT "<< До&полнительно"
     IDS_NEWEXT_ADVANCED_RIGHT "До&полнительно >>"
     IDS_NEWEXT_NEW "<Новый>"

--- a/dll/win32/shell32/lang/sk-SK.rc
+++ b/dll/win32/shell32/lang/sk-SK.rc
@@ -1040,6 +1040,10 @@ BEGIN
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
     IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
+    IDS_VISEFFECT_DRAGFULL "Show window contents while dragging"
+    IDS_VISEFFECT_FONTSMOOTHING "Smooth edges of screen fonts"
+    IDS_VISEFFECT_LISTVIEWSHADOW "Use drop shadows for icon labels on the desktop"
+
     IDS_NEWEXT_ADVANCED_LEFT "<< Ad&vanced"
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"
     IDS_NEWEXT_NEW "<New>"

--- a/dll/win32/shell32/lang/sl-SI.rc
+++ b/dll/win32/shell32/lang/sl-SI.rc
@@ -1040,6 +1040,10 @@ BEGIN
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
     IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
+    IDS_VISEFFECT_DRAGFULL "Show window contents while dragging"
+    IDS_VISEFFECT_FONTSMOOTHING "Smooth edges of screen fonts"
+    IDS_VISEFFECT_LISTVIEWSHADOW "Use drop shadows for icon labels on the desktop"
+
     IDS_NEWEXT_ADVANCED_LEFT "<< Ad&vanced"
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"
     IDS_NEWEXT_NEW "<New>"

--- a/dll/win32/shell32/lang/sq-AL.rc
+++ b/dll/win32/shell32/lang/sq-AL.rc
@@ -1047,6 +1047,10 @@ BEGIN
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
     IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
+    IDS_VISEFFECT_DRAGFULL "Show window contents while dragging"
+    IDS_VISEFFECT_FONTSMOOTHING "Smooth edges of screen fonts"
+    IDS_VISEFFECT_LISTVIEWSHADOW "Use drop shadows for icon labels on the desktop"
+
     IDS_NEWEXT_ADVANCED_LEFT "<< Ad&vanced"
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"
     IDS_NEWEXT_NEW "<New>"

--- a/dll/win32/shell32/lang/sv-SE.rc
+++ b/dll/win32/shell32/lang/sv-SE.rc
@@ -1040,6 +1040,10 @@ BEGIN
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
     IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
+    IDS_VISEFFECT_DRAGFULL "Show window contents while dragging"
+    IDS_VISEFFECT_FONTSMOOTHING "Smooth edges of screen fonts"
+    IDS_VISEFFECT_LISTVIEWSHADOW "Use drop shadows for icon labels on the desktop"
+
     IDS_NEWEXT_ADVANCED_LEFT "<< Ad&vanced"
     IDS_NEWEXT_ADVANCED_RIGHT "Ad&vanced >>"
     IDS_NEWEXT_NEW "<New>"

--- a/dll/win32/shell32/lang/tr-TR.rc
+++ b/dll/win32/shell32/lang/tr-TR.rc
@@ -1049,6 +1049,10 @@ BEGIN
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
     IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
+    IDS_VISEFFECT_DRAGFULL "Show window contents while dragging"
+    IDS_VISEFFECT_FONTSMOOTHING "Smooth edges of screen fonts"
+    IDS_VISEFFECT_LISTVIEWSHADOW "Use drop shadows for icon labels on the desktop"
+
     IDS_NEWEXT_ADVANCED_LEFT "<< G&elişmiş"
     IDS_NEWEXT_ADVANCED_RIGHT "Ge&lişmiş >>"
     IDS_NEWEXT_NEW "<Yeni>"

--- a/dll/win32/shell32/lang/uk-UA.rc
+++ b/dll/win32/shell32/lang/uk-UA.rc
@@ -1040,6 +1040,10 @@ BEGIN
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
     IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
+    IDS_VISEFFECT_DRAGFULL "Show window contents while dragging"
+    IDS_VISEFFECT_FONTSMOOTHING "Smooth edges of screen fonts"
+    IDS_VISEFFECT_LISTVIEWSHADOW "Use drop shadows for icon labels on the desktop"
+
     IDS_NEWEXT_ADVANCED_LEFT "<< &Додатково"
     IDS_NEWEXT_ADVANCED_RIGHT "&Додатково >>"
     IDS_NEWEXT_NEW "<Новий>"

--- a/dll/win32/shell32/lang/zh-CN.rc
+++ b/dll/win32/shell32/lang/zh-CN.rc
@@ -1050,6 +1050,10 @@ BEGIN
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "显示管理工具"
     IDS_ADVANCED_SMALL_START_MENU "在“开始”菜单中显示小图标"
 
+    IDS_VISEFFECT_DRAGFULL "Show window contents while dragging"
+    IDS_VISEFFECT_FONTSMOOTHING "Smooth edges of screen fonts"
+    IDS_VISEFFECT_LISTVIEWSHADOW "Use drop shadows for icon labels on the desktop"
+
     IDS_NEWEXT_ADVANCED_LEFT "<< 高级(&V)"
     IDS_NEWEXT_ADVANCED_RIGHT "高级(&V) >>"
     IDS_NEWEXT_NEW "<新建>"

--- a/dll/win32/shell32/lang/zh-HK.rc
+++ b/dll/win32/shell32/lang/zh-HK.rc
@@ -1048,6 +1048,10 @@ BEGIN
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
     IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
+    IDS_VISEFFECT_DRAGFULL "Show window contents while dragging"
+    IDS_VISEFFECT_FONTSMOOTHING "Smooth edges of screen fonts"
+    IDS_VISEFFECT_LISTVIEWSHADOW "Use drop shadows for icon labels on the desktop"
+
     IDS_NEWEXT_ADVANCED_LEFT "<< 進階(&V)"
     IDS_NEWEXT_ADVANCED_RIGHT "進階(&V) >>"
     IDS_NEWEXT_NEW "<新增>"

--- a/dll/win32/shell32/lang/zh-TW.rc
+++ b/dll/win32/shell32/lang/zh-TW.rc
@@ -1049,6 +1049,10 @@ BEGIN
     IDS_ADVANCED_DISPLAY_ADMINTOOLS "Display Administrative Tools"
     IDS_ADVANCED_SMALL_START_MENU "Show Small Icons in Start menu"
 
+    IDS_VISEFFECT_DRAGFULL "Show window contents while dragging"
+    IDS_VISEFFECT_FONTSMOOTHING "Smooth edges of screen fonts"
+    IDS_VISEFFECT_LISTVIEWSHADOW "Use drop shadows for icon labels on the desktop"
+
     IDS_NEWEXT_ADVANCED_LEFT "<< 進階(&V)"
     IDS_NEWEXT_ADVANCED_RIGHT "進階(&V) >>"
     IDS_NEWEXT_NEW "<新增>"

--- a/dll/win32/shell32/shresdef.h
+++ b/dll/win32/shell32/shresdef.h
@@ -361,20 +361,23 @@
 
 #define IDS_REMOVE_EXT                              30522
 
+#define IDS_VISEFFECT_DRAGFULL                      30533
+#define IDS_VISEFFECT_FONTSMOOTHING                 30535
+#define IDS_VISEFFECT_LISTVIEWSHADOW                30541
+
 #define IDS_NO_ICONS                                30529
 #define IDS_FILE_NOT_FOUND                          30530 // FIXME: "Animations in taskbar"
 #define IDS_LINK_INVALID                            30531
 #define IDS_COPYTOMENU                              30532
-#define IDS_COPYTOTITLE                             30533
+#define IDS_COPYTOTITLE                             60005
 #define IDS_COPYITEMS                               30534
-#define IDS_COPYBUTTON                              30535
+#define IDS_COPYBUTTON                              60007
 #define IDS_MOVETOMENU                              30536
 #define IDS_MOVETOTITLE                             30537
 #define IDS_MOVEITEMS                               30538
 #define IDS_MOVEBUTTON                              30539 // FIXME: "Slide open combo boxes"
 
 #define IDS_SYSTEMFOLDER                            30540 // FIXME: "Show translucent selection rectangle"
-#define IDS_DESKTOPLABELDROPSHADOW                  30541
 #define IDS_FOLDERTYPEBACKGROUNDIMAGE               30543
 
 #define IDS_LOG_OFF_DESC                            35000

--- a/sdk/include/psdk/shobjidl.idl
+++ b/sdk/include/psdk/shobjidl.idl
@@ -2442,6 +2442,19 @@ interface IObjectWithSelection : IUnknown
     HRESULT GetSelection([in] REFIID riid, [out, iid_is(riid)] void **ppv);
 };
 
+/*****************************************************************************
+ * IRegTreeItem interface
+ */
+[
+    uuid(A9521922-0812-4d44-9EC3-7FD38C726F3D),
+    pointer_default(unique)
+]
+interface IRegTreeItem : IUnknown
+{
+    HRESULT GetCheckState([out] BOOL *pbCheck);
+    HRESULT SetCheckState([in] BOOL bCheck);
+};
+
 
 /*****************************************************************************
  * IOpenControlPanel interface (Vista+)

--- a/sdk/include/reactos/shlobj_undoc.h
+++ b/sdk/include/reactos/shlobj_undoc.h
@@ -139,8 +139,10 @@ DECLARE_INTERFACE_(IBanneredBar, IUnknown)//, "596A9A94-013E-11d1-8D34-00A0C90F2
  */
 struct DEFFOLDERSETTINGS
 {
+#ifdef __cplusplus
     enum { SIZE_NT4 = 8, SIZE_IE4 = 36, SIZE_XP = 40 };
     enum { VER_98 = 0, VER_2000 = 3, VER_XP = 4 }; // Win98SE with IE5 writes 0, not 3 as the version
+#endif
     UINT Statusbar : 1; // "StatusBarOther" is the new location for this
     UINT Toolbar : 1; // Not used when Explorer uses ReBar
     FOLDERSETTINGS FolderSettings;

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -86,6 +86,7 @@ BOOL WINAPI SHAboutInfoW(LPWSTR lpszDest, DWORD dwDestLen);
 #define SHAboutInfo SHAboutInfoA
 #endif
 
+HRESULT WINAPI CLSIDFromStringWrap(_In_ LPCWSTR idstr, _Out_ CLSID *id);
 HMODULE WINAPI SHPinDllOfCLSID(REFIID refiid);
 HRESULT WINAPI IUnknown_QueryStatus(IUnknown *lpUnknown, REFGUID pguidCmdGroup, ULONG cCmds, OLECMD *prgCmds, OLECMDTEXT* pCmdText);
 HRESULT WINAPI IUnknown_Exec(IUnknown* lpUnknown, REFGUID pguidCmdGroup, DWORD nCmdID, DWORD nCmdexecopt, VARIANT* pvaIn, VARIANT* pvaOut);


### PR DESCRIPTION
Notes:

 - I have verified that the CRegTreeOptions implementation now handles COM entries correctly but I decided to leave out the COM code in Sysdm.cpl for our ROS-specific Window Snap option. The entries using COM on Windows in this dialog are DWMEnabled?, Themes, ThumbnailsOrIcon and WebView.
 - NT5 has the VisualEffects registration in shell32 but not in modern Windows so I decided to not put it in shell32. The strings are still in shell32 for some reason.
 - The string IDs in shell32 are the same in WinXP and Win10, we were already using them incorrectly for something else so I had to reassign those.
- The 2nd property sheet page implements nothing but is required so the page file dialog button ends up in the right place.
- I did not implement the radio buttons to select different configurations. I'm not sure if the logic is simply to check/uncheck everything nor how they interact with the "DefaultByAlphaTest" etc. values that we don't handle.

![Props](https://github.com/user-attachments/assets/9c88de9c-f26a-44b0-98ea-a2d6e55c8478)


## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: