### PR TITLE
[IMM32][SDK] Support ImmIMPQueryIMEA/W and ImmIMPSetIMEA/W

### DIFF
--- a/sdk/include/reactos/imm32_undoc.h
+++ b/sdk/include/reactos/imm32_undoc.h
@@ -233,6 +233,10 @@ LRESULT WINAPI ImmPutImeMenuItemsIntoMappedFile(_In_ HIMC hIMC);
 
 BOOL WINAPI ImmIMPGetIMEA(_In_opt_ HWND hWnd, _Out_ LPIMEPROA pImePro);
 BOOL WINAPI ImmIMPGetIMEW(_In_opt_ HWND hWnd, _Out_ LPIMEPROW pImePro);
+BOOL WINAPI ImmIMPQueryIMEA(_Inout_ LPIMEPROA pImePro);
+BOOL WINAPI ImmIMPQueryIMEW(_Inout_ LPIMEPROW pImePro);
+BOOL WINAPI ImmIMPSetIMEA(_In_opt_ HWND hWnd, _Inout_ LPIMEPROA pImePro);
+BOOL WINAPI ImmIMPSetIMEW(_In_opt_ HWND hWnd, _Inout_ LPIMEPROW pImePro);
 
 HRESULT WINAPI CtfAImmActivate(_Out_opt_ HINSTANCE *phinstCtfIme);
 HRESULT WINAPI CtfAImmDeactivate(_In_ BOOL bDestroy);
@@ -260,8 +264,12 @@ CtfImmDispatchDefImeMessage(
 
 #ifdef UNICODE
     #define ImmIMPGetIME ImmIMPGetIMEW
+    #define ImmIMPQueryIME ImmIMPQueryIMEW
+    #define ImmIMPSetIME ImmIMPSetIMEW
 #else
     #define ImmIMPGetIME ImmIMPGetIMEA
+    #define ImmIMPQueryIME ImmIMPQueryIMEA
+    #define ImmIMPSetIME ImmIMPSetIMEA
 #endif
 
 #ifdef __cplusplus

--- a/win32ss/user/imm32/imepro.c
+++ b/win32ss/user/imm32/imepro.c
@@ -122,6 +122,7 @@ ImmIMPQueryIMEA(_Inout_ LPIMEPROA pImePro)
     IMEPROW ProW;
     if (pImePro->szName[0])
     {
+        /* pImePro->szName is BYTE[], so we need type cast */
         if (!MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, (PSTR)pImePro->szName, -1,
                                  ProW.szName, _countof(ProW.szName)))
         {
@@ -226,6 +227,7 @@ ImmIMPSetIMEA(
 
     if (pImePro->szName[0])
     {
+        /* pImePro->szName is BYTE[], so we need type cast */
         if (!MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, (PSTR)pImePro->szName, -1,
                                  ProW.szName, _countof(ProW.szName)))
         {

--- a/win32ss/user/imm32/imepro.c
+++ b/win32ss/user/imm32/imepro.c
@@ -122,10 +122,10 @@ ImmIMPQueryIMEA(_Inout_ LPIMEPROA pImePro)
     IMEPROW ProW;
     if (pImePro->szName[0])
     {
-        if (!MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, pImePro->szName, -1,
+        if (!MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, (PSTR)pImePro->szName, -1,
                                  ProW.szName, _countof(ProW.szName)))
         {
-            ERR("szName: %s\n", debugstr_w(pImePro->szName));
+            ERR("szName: %s\n", debugstr_a((PSTR)pImePro->szName));
             return FALSE;
         }
         ProW.szName[_countof(ProW.szName) - 1] = UNICODE_NULL; /* Avoid buffer overrun */
@@ -226,10 +226,10 @@ ImmIMPSetIMEA(
 
     if (pImePro->szName[0])
     {
-        if (!MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, pImePro->szName, -1,
+        if (!MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, (PSTR)pImePro->szName, -1,
                                  ProW.szName, _countof(ProW.szName)))
         {
-            ERR("szName: %s\n", debugstr_w(pImePro->szName));
+            ERR("szName: %s\n", debugstr_a((PSTR)pImePro->szName));
             return FALSE;
         }
         ProW.szName[_countof(ProW.szName) - 1] = UNICODE_NULL; /* Avoid buffer overrun */

--- a/win32ss/user/imm32/imepro.c
+++ b/win32ss/user/imm32/imepro.c
@@ -19,6 +19,9 @@ Imm32ConvertImeProWideToAnsi(
     _In_ const IMEPROW *pProW,
     _Out_ PIMEPROA pProA)
 {
+    ASSERT(pProW);
+    ASSERT(pProA);
+
     pProA->hWnd = pProW->hWnd;
     pProA->InstDate = pProW->InstDate;
     pProA->wVersion = pProW->wVersion;
@@ -39,6 +42,8 @@ Imm32IMPGetIME(
     _In_ HKL hKL,
     _Out_ PIMEPROW pProW)
 {
+    ASSERT(pProW);
+
     IMEINFOEX ImeInfoEx;
     if (!ImmGetImeInfoEx(&ImeInfoEx, ImeInfoExKeyboardLayout, &hKL))
         return FALSE;
@@ -68,6 +73,8 @@ ImmIMPGetIMEA(
 
     TRACE("(%p, %p)\n", hWnd, pImePro);
 
+    ASSERT(pImePro);
+
     if (!Imm32IsSystemJapaneseOrKorean())
     {
         SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
@@ -95,6 +102,8 @@ ImmIMPGetIMEW(
 
     TRACE("(%p, %p)\n", hWnd, pImePro);
 
+    ASSERT(pImePro);
+
     if (!Imm32IsSystemJapaneseOrKorean())
     {
         SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
@@ -112,6 +121,8 @@ BOOL WINAPI
 ImmIMPQueryIMEA(_Inout_ LPIMEPROA pImePro)
 {
     TRACE("(%p)\n", pImePro);
+
+    ASSERT(pImePro);
 
     if (!Imm32IsSystemJapaneseOrKorean())
     {
@@ -150,6 +161,8 @@ BOOL WINAPI
 ImmIMPQueryIMEW(_Inout_ LPIMEPROW pImePro)
 {
     TRACE("(%p)\n", pImePro);
+
+    ASSERT(pImePro);
 
     if (!Imm32IsSystemJapaneseOrKorean())
     {
@@ -218,6 +231,8 @@ ImmIMPSetIMEA(
 {
     TRACE("(%p, %p)\n", hWnd, pImePro);
 
+    ASSERT(pImePro);
+
     IMEPROW ProW;
     if (!Imm32IsSystemJapaneseOrKorean())
     {
@@ -255,6 +270,8 @@ ImmIMPSetIMEW(
     UNREFERENCED_PARAMETER(hWnd);
 
     TRACE("(%p, %p)\n", hWnd, pImePro);
+
+    ASSERT(pImePro);
 
     if (!Imm32IsSystemJapaneseOrKorean())
     {

--- a/win32ss/user/imm32/imepro.c
+++ b/win32ss/user/imm32/imepro.c
@@ -15,7 +15,9 @@ WINE_DEFAULT_DEBUG_CHANNEL(imm);
  */
 
 static VOID
-Imm32ConvertImeProWideToAnsi(_In_ const IMEPROW *pProW, _Out_ PIMEPROA pProA)
+Imm32ConvertImeProWideToAnsi(
+    _In_ const IMEPROW *pProW,
+    _Out_ PIMEPROA pProA)
 {
     pProA->hWnd = pProW->hWnd;
     pProA->InstDate = pProW->InstDate;
@@ -33,7 +35,9 @@ Imm32ConvertImeProWideToAnsi(_In_ const IMEPROW *pProW, _Out_ PIMEPROA pProA)
 }
 
 static BOOL
-Imm32IMPGetIME(_In_ HKL hKL, _Out_ PIMEPROW pProW)
+Imm32IMPGetIME(
+    _In_ HKL hKL,
+    _Out_ PIMEPROW pProW)
 {
     IMEINFOEX ImeInfoEx;
     if (!ImmGetImeInfoEx(&ImeInfoEx, ImeInfoExKeyboardLayout, &hKL))
@@ -56,7 +60,9 @@ Imm32IMPGetIME(_In_ HKL hKL, _Out_ PIMEPROW pProW)
  *		ImmIMPGetIMEA(IMM32.@)
  */
 BOOL WINAPI
-ImmIMPGetIMEA(_In_opt_ HWND hWnd, _Out_ LPIMEPROA pImePro)
+ImmIMPGetIMEA(
+    _In_opt_ HWND hWnd,
+    _Out_ LPIMEPROA pImePro)
 {
     UNREFERENCED_PARAMETER(hWnd);
 
@@ -81,7 +87,9 @@ ImmIMPGetIMEA(_In_opt_ HWND hWnd, _Out_ LPIMEPROA pImePro)
  *		ImmIMPGetIMEW(IMM32.@)
  */
 BOOL WINAPI
-ImmIMPGetIMEW(_In_opt_ HWND hWnd, _Out_ LPIMEPROW pImePro)
+ImmIMPGetIMEW(
+    _In_opt_ HWND hWnd,
+    _Out_ LPIMEPROW pImePro)
 {
     UNREFERENCED_PARAMETER(hWnd);
 
@@ -100,39 +108,212 @@ ImmIMPGetIMEW(_In_opt_ HWND hWnd, _Out_ LPIMEPROW pImePro)
 /***********************************************************************
  *		ImmIMPQueryIMEA(IMM32.@)
  */
-BOOL WINAPI ImmIMPQueryIMEA(LPIMEPROA pImePro)
+BOOL WINAPI
+ImmIMPQueryIMEA(_Inout_ LPIMEPROA pImePro)
 {
-    FIXME("(%p)\n", pImePro);
-    SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
-    return FALSE;
+    TRACE("(%p)\n", pImePro);
+
+    if (!Imm32IsSystemJapaneseOrKorean())
+    {
+        SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
+        return FALSE;
+    }
+
+    IMEPROW ProW;
+    if (pImePro->szName[0])
+    {
+        if (!MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, pImePro->szName, -1,
+                                 ProW.szName, _countof(ProW.szName)))
+        {
+            ERR("szName: %s\n", debugstr_w(pImePro->szName));
+            return FALSE;
+        }
+        ProW.szName[_countof(ProW.szName) - 1] = UNICODE_NULL; /* Avoid buffer overrun */
+    }
+    else
+    {
+        ProW.szName[0] = 0;
+    }
+
+    if (!ImmIMPQueryIMEW(&ProW))
+        return FALSE;
+
+    Imm32ConvertImeProWideToAnsi(&ProW, pImePro);
+    return TRUE;
 }
 
 /***********************************************************************
  *		ImmIMPQueryIMEW(IMM32.@)
  */
-BOOL WINAPI ImmIMPQueryIMEW(LPIMEPROW pImePro)
+BOOL WINAPI
+ImmIMPQueryIMEW(_Inout_ LPIMEPROW pImePro)
 {
-    FIXME("(%p)\n", pImePro);
-    SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
-    return FALSE;
+    TRACE("(%p)\n", pImePro);
+
+    if (!Imm32IsSystemJapaneseOrKorean())
+    {
+        SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
+        return FALSE;
+    }
+
+    INT nLayouts = GetKeyboardLayoutList(0, NULL);
+    if (nLayouts <= 0)
+    {
+        ERR("nLayouts: %d\n", nLayouts);
+        return FALSE;
+    }
+
+    HKL *phKLs = ImmLocalAlloc(0, nLayouts * sizeof(HKL));
+    if (!phKLs)
+    {
+        ERR("Out of memory\n");
+        return FALSE;
+    }
+
+    if (GetKeyboardLayoutList(nLayouts, phKLs) != nLayouts)
+    {
+        ERR("KL count mismatch\n");
+        ImmLocalFree(phKLs);
+        return FALSE;
+    }
+
+    BOOL result = FALSE;
+    if (pImePro->szName[0])
+    {
+        IMEINFOEX ImeInfoEx;
+        if (ImmGetImeInfoEx(&ImeInfoEx, ImeInfoExImeFileName, pImePro->szName))
+        {
+            for (INT iKL = 0; iKL < nLayouts; ++iKL)
+            {
+                if (phKLs[iKL] == ImeInfoEx.hkl)
+                {
+                    result = Imm32IMPGetIME(phKLs[iKL], pImePro);
+                    break;
+                }
+            }
+        }
+    }
+    else
+    {
+        for (INT iKL = 0; iKL < nLayouts; ++iKL)
+        {
+            result = Imm32IMPGetIME(phKLs[iKL], pImePro);
+            if (result)
+                break;
+        }
+    }
+
+    ImmLocalFree(phKLs);
+    return result;
 }
 
 /***********************************************************************
  *		ImmIMPSetIMEA(IMM32.@)
  */
-BOOL WINAPI ImmIMPSetIMEA(HWND hWnd, LPIMEPROA pImePro)
+BOOL WINAPI
+ImmIMPSetIMEA(
+    _In_opt_ HWND hWnd,
+    _Inout_ LPIMEPROA pImePro)
 {
-    FIXME("(%p, %p)\n", hWnd, pImePro);
-    SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
-    return FALSE;
+    TRACE("(%p, %p)\n", hWnd, pImePro);
+
+    IMEPROW ProW;
+    if (!Imm32IsSystemJapaneseOrKorean())
+    {
+        SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
+        return FALSE;
+    }
+
+    if (pImePro->szName[0])
+    {
+        if (!MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, pImePro->szName, -1,
+                                 ProW.szName, _countof(ProW.szName)))
+        {
+            ERR("szName: %s\n", debugstr_w(pImePro->szName));
+            return FALSE;
+        }
+        ProW.szName[_countof(ProW.szName) - 1] = UNICODE_NULL; /* Avoid buffer overrun */
+    }
+    else
+    {
+        ProW.szName[0] = UNICODE_NULL;
+    }
+
+    return ImmIMPSetIMEW(hWnd, &ProW);
 }
 
 /***********************************************************************
  *		ImmIMPSetIMEW(IMM32.@)
  */
-BOOL WINAPI ImmIMPSetIMEW(HWND hWnd, LPIMEPROW pImePro)
+BOOL WINAPI
+ImmIMPSetIMEW(
+    _In_opt_ HWND hWnd,
+    _Inout_ LPIMEPROW pImePro)
 {
-    FIXME("(%p, %p)\n", hWnd, pImePro);
-    SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
+    UNREFERENCED_PARAMETER(hWnd);
+
+    TRACE("(%p, %p)\n", hWnd, pImePro);
+
+    if (!Imm32IsSystemJapaneseOrKorean())
+    {
+        SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
+        return FALSE;
+    }
+
+    HKL hTargetKL = NULL;
+    if (pImePro->szName[0])
+    {
+        IMEINFOEX ImeInfoEx;
+        if (!ImmGetImeInfoEx(&ImeInfoEx, ImeInfoExImeFileName, pImePro->szName))
+            return FALSE;
+
+        hTargetKL = ImeInfoEx.hkl;
+    }
+    else
+    {
+        INT nLayouts = GetKeyboardLayoutList(0, NULL);
+        if (nLayouts <= 0)
+        {
+            ERR("nLayouts: %d\n", nLayouts);
+            return FALSE;
+        }
+
+        HKL *phKLs = ImmLocalAlloc(0, nLayouts * sizeof(HKL));
+        if (!phKLs)
+        {
+            ERR("Out of memory\n");
+            return FALSE;
+        }
+
+        if (GetKeyboardLayoutList(nLayouts, phKLs) == nLayouts)
+        {
+            for (INT iKL = 0; iKL < nLayouts; ++iKL)
+            {
+                if (!ImmIsIME(phKLs[iKL]))
+                {
+                    hTargetKL = phKLs[iKL];
+                    break;
+                }
+            }
+        }
+        else
+        {
+            ERR("KL count mismatch\n");
+        }
+
+        ImmLocalFree(phKLs);
+    }
+
+    if (hTargetKL && GetKeyboardLayout(0) != hTargetKL)
+    {
+        HWND hwndFocus = GetFocus();
+        if (hwndFocus)
+        {
+            PostMessageW(hwndFocus, WM_INPUTLANGCHANGEREQUEST, INPUTLANGCHANGE_SYSCHARSET,
+                         (LPARAM)hTargetKL);
+            return TRUE;
+        }
+    }
+
     return FALSE;
 }

--- a/win32ss/user/imm32/imepro.c
+++ b/win32ss/user/imm32/imepro.c
@@ -133,7 +133,7 @@ ImmIMPQueryIMEA(_Inout_ LPIMEPROA pImePro)
     }
     else
     {
-        ProW.szName[0] = 0;
+        ProW.szName[0] = UNICODE_NULL;
     }
 
     if (!ImmIMPQueryIMEW(&ProW))


### PR DESCRIPTION
## Purpose
Implementing missing features... These functions are given for IME program handling.
JIRA issue: [CORE-19268](https://jira.reactos.org/browse/CORE-19268)

## Proposed changes

- Implement `ImmIMPQueryIMEA` and `ImmIMPQueryIMEW` functions.
- Implement `ImmIMPSetIMEA` and `ImmIMPSetIMEW` functions.
- Add prototypes to `<imm32_undoc.h>`.