### PR TITLE
[COMPILER_APITEST] Fix todo_gcc macro to work on Windows

### DIFF
--- a/modules/rostests/apitests/compiler/floatconv.c
+++ b/modules/rostests/apitests/compiler/floatconv.c
@@ -39,7 +39,7 @@
 #endif
 
 #ifdef __GNUC__
-#define todo_gcc todo_ros
+#define todo_gcc todo_if(TRUE)
 #else
 #define todo_gcc
 #endif


### PR DESCRIPTION
## Purpose

Fix compiler apitest to pass on Windows regardless if it was compiled with GCC or MSVC.

## Proposed changes

- Always mark a todo_gcc test as todo regardless of platform when compiled using GCC. The macro used before, `todo_ros`, only marks the test as todo if the platform is ReactOS and executes them otherwise.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: