### PR TITLE
[SHELL32_APITEST] Fixed SimpleIDListFromPath and SHGetFileInfo tests on NT5

### DIFF
--- a/modules/rostests/apitests/shell32/ItemIDList.cpp
+++ b/modules/rostests/apitests/shell32/ItemIDList.cpp
@@ -160,7 +160,7 @@ START_TEST(SHSimpleIDListFromPath)
     }
 
     LPITEMIDLIST pidl;
-    ok_int((pidl = SHSimpleIDListFromPath(L"c:")) != NULL, TRUE);
+    ok_int((pidl = SHSimpleIDListFromPath(L"c:")) != NULL, LOBYTE(GetVersion()) >= 6);
     ILFree(pidl);
     ok_int((pidl = SHSimpleIDListFromPath(L"c:\\")) != NULL, TRUE);
     ILFree(pidl);

--- a/modules/rostests/apitests/shell32/ShellInfo.cpp
+++ b/modules/rostests/apitests/shell32/ShellInfo.cpp
@@ -61,7 +61,7 @@ START_TEST(SHGetFileInfo)
     my_ok_all_flags(info.dwAttributes, SFGAO_FILESYSTEM | SFGAO_STREAM);
 
     info.dwAttributes = ~SFGAO_VALIDATE;
-    ok_int(SHGFI(L"c:", info, flags | SHGFI_ATTR_SPECIFIED), TRUE); // ROS fails this, a parsing bug in CDrivesFolder?
+    ok_int(SHGFI(L"c:", info, flags | SHGFI_ATTR_SPECIFIED), LOBYTE(GetVersion()) >= 6);
     my_ok_all_flags(info.dwAttributes, SFGAO_FILESYSTEM | SFGAO_FILESYSANCESTOR);
 
     info.dwAttributes = ~SFGAO_VALIDATE;


### PR DESCRIPTION
## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: