### PR TITLE
[GDI32_APITEST] Fix test on all versions of Windows at certain vertical resolutions

### DIFF
--- a/modules/rostests/apitests/gdi32/SetWindowExtEx.c
+++ b/modules/rostests/apitests/gdi32/SetWindowExtEx.c
@@ -178,9 +178,7 @@ void Test_SetWindowExtEx()
     /* Check the viewport now, should not be the same */
     GetViewportExtEx(hDC, &ViewportExt);
     ok_long(ViewportExt.cx,  GetDeviceCaps(GetDC(0), VERTRES));
-    /* The bit magic below (* 0x55555556LL >> 32) divides by 3, but avoids some
-     * off-by-one errors that can occur at some vertical resolutions. */
-    ok_long(ViewportExt.cy, -GetDeviceCaps(GetDC(0), VERTRES) * 0x55555556LL >> 32);
+    ok_long(ViewportExt.cy, -MulDiv(GetDeviceCaps(GetDC(0), VERTRES), 1, 3));
 
     /* again isotropic mode with 1:3 res */
     SetViewportExtEx(hDC, 6000, 3000, 0);

--- a/modules/rostests/apitests/gdi32/SetWindowExtEx.c
+++ b/modules/rostests/apitests/gdi32/SetWindowExtEx.c
@@ -178,7 +178,9 @@ void Test_SetWindowExtEx()
     /* Check the viewport now, should not be the same */
     GetViewportExtEx(hDC, &ViewportExt);
     ok_long(ViewportExt.cx,  GetDeviceCaps(GetDC(0), VERTRES));
-    ok_long(ViewportExt.cy, -GetDeviceCaps(GetDC(0), VERTRES) / 3);
+    /* The bit magic below (* 0x55555556LL >> 32) divides by 3, but avoids some
+     * off-by-one errors that can occur at some vertical resolutions. */
+    ok_long(ViewportExt.cy, -GetDeviceCaps(GetDC(0), VERTRES) * 0x55555556LL >> 32);
 
     /* again isotropic mode with 1:3 res */
     SetViewportExtEx(hDC, 6000, 3000, 0);


### PR DESCRIPTION
## Purpose

Fixes the gdi32:SetWindowExtEx test for unusual vertical resolutions.

I ran into this test failure often when running this test in VMware Workstation. When maximized, the vertical resolution of the guest VM is 920px, and unfortunately both GCC and MSVC builds will calculate this incorrectly without this fix. I did also test this change with several other vertical resolutions, and it worked on all resolutions while the older version only worked on most resolutions.

## Proposed changes

- Use multiplying and bit shifting to divide by 3 instead of relying on the compiler to figure out how to best divide by 3.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: