### PR TITLE
[KBSWITCH] Refactor on layout numbers

### DIFF
--- a/base/applications/kbswitch/kbswitch.c
+++ b/base/applications/kbswitch/kbswitch.c
@@ -495,7 +495,7 @@ ActivateLayout(HWND hwnd, INT iKL, HWND hwndTarget OPTIONAL, BOOL bNoActivate)
     TCHAR szKLID[CCH_LAYOUT_ID + 1], szLangName[MAX_PATH];
     LANGID LangID;
 
-    if (iKL < 0 || iKL >= _countof(g_ahKLs)) /* Invalid */
+    if (iKL < 0 || iKL >= g_cKLs) /* Invalid */
         return;
 
     GetKLIDFromLayoutNum(iKL, szKLID, _countof(szKLID));

--- a/base/applications/kbswitch/kbswitch.c
+++ b/base/applications/kbswitch/kbswitch.c
@@ -730,8 +730,7 @@ KbSwitch_OnNotifyIconMsg(HWND hwnd, UINT uMouseMsg)
     {
         /* Rebuild the left popup menu on every click to take care of keyboard layout changes */
         HMENU hPopupMenu = BuildLeftPopupMenu();
-        /* CORE-5065: Should we use TPM_RIGHTBUTTON instead of TPM_LEFTBUTTON here? */
-        nID = TrackPopupMenuEx(hPopupMenu, TPM_LEFTALIGN | TPM_RETURNCMD | TPM_RIGHTBUTTON,
+        nID = TrackPopupMenuEx(hPopupMenu, TPM_LEFTALIGN | TPM_RETURNCMD | TPM_LEFTBUTTON,
                                pt.x, pt.y, hwnd, NULL);
         DestroyMenu(hPopupMenu);
     }

--- a/base/applications/kbswitch/kbswitch.c
+++ b/base/applications/kbswitch/kbswitch.c
@@ -40,8 +40,8 @@ HINSTANCE g_hInst = NULL;
 HMODULE   g_hHookDLL = NULL;
 HICON     g_hTrayIcon = NULL;
 HWND      g_hwndLastActive = NULL;
-INT       g_iKL = 0;
-INT       g_cKLs = 0;
+UINT      g_iKL = 0;
+UINT      g_cKLs = 0;
 HKL       g_ahKLs[64];
 UINT      g_uTaskbarRestartMsg = 0;
 UINT      g_uShellHookMessage = 0;
@@ -166,7 +166,7 @@ static HKL GetActiveKL(VOID)
 
 static VOID UpdateLayoutList(HKL hKL OPTIONAL)
 {
-    INT iKL;
+    UINT iKL;
 
     if (!hKL)
         hKL = GetActiveKL();
@@ -184,13 +184,13 @@ static VOID UpdateLayoutList(HKL hKL OPTIONAL)
     }
 }
 
-static HKL GetHKLFromLayoutNum(INT iKL)
+static HKL GetHKLFromLayoutNum(UINT iKL)
 {
-    return (0 <= iKL && iKL < g_cKLs) ? g_ahKLs[iKL] : GetActiveKL();
+    return (iKL < g_cKLs) ? g_ahKLs[iKL] : GetActiveKL();
 }
 
 static VOID
-GetKLIDFromLayoutNum(INT iKL, LPTSTR szKLID, SIZE_T KLIDLength)
+GetKLIDFromLayoutNum(UINT iKL, LPTSTR szKLID, SIZE_T KLIDLength)
 {
     GetKLIDFromHKL(GetHKLFromLayoutNum(iKL), szKLID, KLIDLength);
 }
@@ -207,7 +207,7 @@ GetSystemLibraryPath(LPTSTR szPath, SIZE_T cchPath, LPCTSTR FileName)
 }
 
 static BOOL
-GetLayoutName(INT iKL, LPTSTR szName, SIZE_T NameLength)
+GetLayoutName(UINT iKL, LPTSTR szName, SIZE_T NameLength)
 {
     HKEY hKey;
     HRESULT hr;
@@ -488,13 +488,13 @@ EnumWindowsProc(HWND hwnd, LPARAM lParam)
 }
 
 static VOID
-ActivateLayout(HWND hwnd, INT iKL, HWND hwndTarget OPTIONAL, BOOL bNoActivate)
+ActivateLayout(HWND hwnd, UINT iKL, HWND hwndTarget OPTIONAL, BOOL bNoActivate)
 {
     HKL hKl;
     TCHAR szKLID[CCH_LAYOUT_ID + 1], szLangName[MAX_PATH];
     LANGID LangID;
 
-    if (iKL < 0 || iKL >= g_cKLs) /* Invalid */
+    if (iKL >= g_cKLs) /* Invalid */
         return;
 
     GetKLIDFromLayoutNum(iKL, szKLID, _countof(szKLID));
@@ -532,7 +532,7 @@ BuildLeftPopupMenu(VOID)
     TCHAR szName[MAX_PATH], szKLID[CCH_LAYOUT_ID + 1], szImeFile[80];
     HICON hIcon;
     MENUITEMINFO mii = { sizeof(mii) };
-    INT iKL;
+    UINT iKL;
 
     for (iKL = 0; iKL < g_cKLs; ++iKL)
     {
@@ -605,7 +605,7 @@ DeleteHooks(VOID)
 
 static UINT GetLayoutNum(HKL hKL)
 {
-    INT iKL;
+    UINT iKL;
 
     for (iKL = 0; iKL < g_cKLs; ++iKL)
     {

--- a/base/applications/kbswitch/kbswitch.c
+++ b/base/applications/kbswitch/kbswitch.c
@@ -715,7 +715,7 @@ KbSwitch_OnTimer(HWND hwnd, UINT_PTR nTimerID)
 static void
 KbSwitch_OnNotifyIconMsg(HWND hwnd, UINT uMouseMsg)
 {
-    if (uMouseMsg != WM_LBUTTONDOWN && uMouseMsg != WM_RBUTTONDOWN)
+    if (uMouseMsg != WM_LBUTTONUP && uMouseMsg != WM_RBUTTONUP && uMouseMsg != WM_CONTEXTMENU)
         return;
 
     UpdateLayoutList(NULL);
@@ -726,18 +726,21 @@ KbSwitch_OnNotifyIconMsg(HWND hwnd, UINT uMouseMsg)
     SetForegroundWindow(hwnd);
 
     INT nID;
-    if (uMouseMsg == WM_LBUTTONDOWN)
+    if (uMouseMsg == WM_LBUTTONUP)
     {
         /* Rebuild the left popup menu on every click to take care of keyboard layout changes */
         HMENU hPopupMenu = BuildLeftPopupMenu();
-        nID = TrackPopupMenuEx(hPopupMenu, TPM_RETURNCMD | TPM_LEFTBUTTON, pt.x, pt.y, hwnd, NULL);
+        /* CORE-5065: Should we use TPM_RIGHTBUTTON instead of TPM_LEFTBUTTON here? */
+        nID = TrackPopupMenuEx(hPopupMenu, TPM_LEFTALIGN | TPM_RETURNCMD | TPM_RIGHTBUTTON,
+                               pt.x, pt.y, hwnd, NULL);
         DestroyMenu(hPopupMenu);
     }
-    else /* WM_RBUTTONDOWN */
+    else /* WM_RBUTTONUP or WM_CONTEXTMENU */
     {
         HMENU hPopupMenu = LoadMenu(g_hInst, MAKEINTRESOURCE(IDR_POPUP));
         HMENU hSubMenu = GetSubMenu(hPopupMenu, 0);
-        nID = TrackPopupMenuEx(hSubMenu, TPM_RETURNCMD | TPM_RIGHTBUTTON, pt.x, pt.y, hwnd, NULL);
+        nID = TrackPopupMenuEx(hSubMenu, TPM_LEFTALIGN | TPM_RETURNCMD | TPM_RIGHTBUTTON,
+                               pt.x, pt.y, hwnd, NULL);
         DestroyMenu(hPopupMenu);
     }
 

--- a/base/applications/kbswitch/kbswitch.c
+++ b/base/applications/kbswitch/kbswitch.c
@@ -43,7 +43,6 @@ HWND      g_hwndLastActive = NULL;
 INT       g_iKL = 0;
 INT       g_cKLs = 0;
 HKL       g_ahKLs[64];
-HMENU     g_hPopupMenu = NULL;
 UINT      g_uTaskbarRestartMsg = 0;
 UINT      g_uShellHookMessage = 0;
 
@@ -695,8 +694,6 @@ KbSwitch_OnDestroy(HWND hwnd)
 {
     KillTimer(hwnd, TIMER_ID_LANG_CHANGED_DELAYED);
     DeleteHooks();
-    if (g_hPopupMenu)
-        DestroyMenu(g_hPopupMenu);
     DeleteTrayIcon(hwnd);
     PostQuitMessage(0);
 }
@@ -732,17 +729,16 @@ KbSwitch_OnNotifyIconMsg(HWND hwnd, UINT uMouseMsg)
     if (uMouseMsg == WM_LBUTTONDOWN)
     {
         /* Rebuild the left popup menu on every click to take care of keyboard layout changes */
-        HMENU hLeftPopupMenu = BuildLeftPopupMenu();
-        nID = TrackPopupMenu(hLeftPopupMenu, TPM_RETURNCMD | TPM_LEFTBUTTON, pt.x, pt.y, 0, hwnd, NULL);
-        DestroyMenu(hLeftPopupMenu);
+        HMENU hPopupMenu = BuildLeftPopupMenu();
+        nID = TrackPopupMenuEx(hPopupMenu, TPM_RETURNCMD | TPM_LEFTBUTTON, pt.x, pt.y, hwnd, NULL);
+        DestroyMenu(hPopupMenu);
     }
     else /* WM_RBUTTONDOWN */
     {
-        if (!g_hPopupMenu)
-            g_hPopupMenu = LoadMenu(g_hInst, MAKEINTRESOURCE(IDR_POPUP));
-
-        HMENU hSubMenu = GetSubMenu(g_hPopupMenu, 0);
-        nID = TrackPopupMenu(hSubMenu, TPM_RETURNCMD | TPM_RIGHTBUTTON, pt.x, pt.y, 0, hwnd, NULL);
+        HMENU hPopupMenu = LoadMenu(g_hInst, MAKEINTRESOURCE(IDR_POPUP));
+        HMENU hSubMenu = GetSubMenu(hPopupMenu, 0);
+        nID = TrackPopupMenuEx(hSubMenu, TPM_RETURNCMD | TPM_RIGHTBUTTON, pt.x, pt.y, hwnd, NULL);
+        DestroyMenu(hPopupMenu);
     }
 
     PostMessage(hwnd, WM_NULL, 0, 0);

--- a/base/applications/kbswitch/resource.h
+++ b/base/applications/kbswitch/resource.h
@@ -9,4 +9,4 @@
 /* Menu items */
 #define ID_EXIT        101
 #define ID_PREFERENCES 102
-#define ID_LANG_BASE   10000
+#define ID_LANG_BASE   1000

--- a/base/applications/kbswitch/resource.h
+++ b/base/applications/kbswitch/resource.h
@@ -7,5 +7,6 @@
 #define IDR_POPUP 12000
 
 /* Menu items */
-#define ID_EXIT        10001
-#define ID_PREFERENCES 10002
+#define ID_EXIT        101
+#define ID_PREFERENCES 102
+#define ID_LANG_BASE   10000

--- a/base/applications/kbswitch/resource.h
+++ b/base/applications/kbswitch/resource.h
@@ -4,9 +4,9 @@
 #define IDI_MAIN 100
 
 /* Menus */
-#define IDR_POPUP 12000
+#define IDR_POPUP 100
 
 /* Menu items */
-#define ID_EXIT        101
-#define ID_PREFERENCES 102
+#define ID_EXIT        100
+#define ID_PREFERENCES 101
 #define ID_LANG_BASE   1000


### PR DESCRIPTION
## Purpose
We believe the power of simplicity.
JIRA issue: [CORE-20142](https://jira.reactos.org/browse/CORE-20142)

## Proposed changes

- Rename `g_nCurrentLayoutNum` as `g_iKL` for simplicity.
- Make `g_iKL` zero-based indexing.
- Add `ID_LANG_BASE` id for language menu items and adjust `ID_EXIT`/`ID_PREFERENCES` values.
- Fix `KbSwitch_OnNotifyIconMsg` function.