### PR TITLE
[NTUSER] Solve 'Double Popup Menu' problem

### DIFF
--- a/win32ss/include/ntuser.h
+++ b/win32ss/include/ntuser.h
@@ -436,6 +436,8 @@ typedef struct tagMENU
     LIST_ENTRY ListEntry;
     HWND hWnd; /* Window containing the menu, use POPUPMENU */
     BOOL TimeToHide;
+    BOOL fInsideMenuLoop; /* Valid only on top menu */
+    BOOL fInEndMenu; /* Valid only on top menu */
 } MENU, *PMENU;
 
 typedef struct tagPOPUPMENU

--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -4395,29 +4395,6 @@ static INT FASTCALL MENU_TrackMenu(PMENU pmenu, UINT wFlags, INT x, INT y,
     return executedMenuId;
 }
 
-static VOID FASTCALL
-MENU_TerminateOldMenuTracking(VOID)
-{
-    PWND pOldWnd = MENU_IsMenuActive();
-    if (!pOldWnd)
-        return;
-
-    HWND hwndOld = UserHMGetHandle(pOldWnd);
-    MENU_EndMenu(pOldWnd);
-
-    /*
-     * Wait for closing hwndOld.
-     * FIXME: We shouldn't wait for closing, that will be a slow-down.
-     *        However there are some global variables for tracking
-     */
-    MSG msg;
-    while (IntIsWindow(hwndOld) &&
-           co_IntGetPeekMessage(&msg, hwndOld, 0, 0, PM_REMOVE, TRUE))
-    {
-        IntDispatchMessage(&msg);
-    }
-}
-
 /***********************************************************************
  *           MenuInitTracking
  */
@@ -4435,12 +4412,12 @@ static BOOL FASTCALL MENU_InitTracking(PWND pWnd, PMENU Menu, BOOL bPopup, UINT 
      * but there are some bugs left that need to be fixed in this case.
      */
     if (!bPopup)
-    {
         Menu->hWnd = UserHMGetHandle(pWnd);
-    }
 
     /* We have to finish old menu tracking before starting new tracking */
-    MENU_TerminateOldMenuTracking();
+    PWND pOldWnd = MENU_IsMenuActive();
+    if (pOldWnd)
+        MENU_EndMenu(pOldWnd);
 
     top_popup = Menu->hWnd;
     top_popup_hmenu = UserHMGetHandle(Menu);

--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -4398,25 +4398,26 @@ static INT FASTCALL MENU_TrackMenu(PMENU pmenu, UINT wFlags, INT x, INT y,
     return executedMenuId;
 }
 
-static VOID FASTCALL MENU_TerminateOldMenuTracking(VOID)
+static VOID FASTCALL
+MENU_TerminateOldMenuTracking(VOID)
 {
     PWND pOldWnd = MENU_IsMenuActive();
-    if (pOldWnd)
-    {
-        HWND hwndOld = UserHMGetHandle(pOldWnd);
-        MENU_EndMenu(pOldWnd);
+    if (!pOldWnd)
+        return;
 
-        /*
-         * Wait for closing hwndOld.
-         * FIXME: We shouldn't wait for closing, that will be a slow-down.
-         *        However there are some global variables for tracking
-         */
-        MSG msg;
-        while (IntIsWindow(hwndOld) &&
-               co_IntGetPeekMessage(&msg, hwndOld, 0, 0, PM_REMOVE, TRUE))
-        {
-            IntDispatchMessage(&msg);
-        }
+    HWND hwndOld = UserHMGetHandle(pOldWnd);
+    MENU_EndMenu(pOldWnd);
+
+    /*
+     * Wait for closing hwndOld.
+     * FIXME: We shouldn't wait for closing, that will be a slow-down.
+     *        However there are some global variables for tracking
+     */
+    MSG msg;
+    while (IntIsWindow(hwndOld) &&
+           co_IntGetPeekMessage(&msg, hwndOld, 0, 0, PM_REMOVE, TRUE))
+    {
+        IntDispatchMessage(&msg);
     }
 }
 

--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -4398,7 +4398,7 @@ static INT FASTCALL MENU_TrackMenu(PMENU pmenu, UINT wFlags, INT x, INT y,
     return executedMenuId;
 }
 
-static VOID MENU_TerminateOldMenuTracking(VOID)
+static VOID FASTCALL MENU_TerminateOldMenuTracking(VOID)
 {
     PWND pOldWnd = MENU_IsMenuActive();
     if (pOldWnd)

--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -4608,6 +4608,7 @@ BOOL WINAPI IntTrackPopupMenuEx( PMENU menu, UINT wFlags, int x, int y,
             UserHMGetHandle(menu), wFlags, x, y, UserHMGetHandle(pWnd), lpTpm); //,
             //lpTpm ? wine_dbgstr_rect( &lpTpm->rcExclude) : "-" );
 
+    /* Defaulting to TPM_RIGHTBUTTON will make behaviour better */
     if (!(wFlags & (TPM_LEFTBUTTON | TPM_RIGHTBUTTON)))
         wFlags |= TPM_RIGHTBUTTON;
 

--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -4406,6 +4406,11 @@ static VOID MENU_TerminateOldMenuTracking(VOID)
         HWND hwndOld = UserHMGetHandle(pOldWnd);
         MENU_EndMenu(pOldWnd);
 
+        /*
+         * Wait for closing hwndOld.
+         * FIXME: We shouldn't wait for closing, that will be a slow-down.
+         *        However there are some global variables for tracking
+         */
         MSG msg;
         while (IntIsWindow(hwndOld) &&
                co_IntGetPeekMessage(&msg, hwndOld, 0, 0, PM_REMOVE, TRUE))


### PR DESCRIPTION
## Purpose

Because the users dislike wrong UI behavior.

JIRA issue: [CORE-5065](https://jira.reactos.org/browse/CORE-5065)
JIRA issue: [CORE-10829](https://jira.reactos.org/browse/CORE-10829)
JIRA issue: [CORE-11756](https://jira.reactos.org/browse/CORE-11756)

## Proposed changes
- Make two global variables (`fInsideMenuLoop` and `fInEndMenu`) member variables of `MENU` structure.
- Terminate old menu tracking at the beginning of `MENU_InitTracking` by using `MENU_EndMenu`.
- Add `TPM_RIGHTBUTTON` flag if neither `TPM_LEFTBUTTON` nor `TPM_RIGHTBUTTON` is specified.

## TODO

- [x] Normal popup menu
- [x] System menu
- [ ] Menu Bar
- [ ] Fixing "Double Popup menu" problem
- [x] Esc key
- [x] Arrow keys
- [x] Enter key
- [x] Alt key
- [x] Left click
- [ ] Right click
- [x] Left Double click
- [ ] Right Double click
- [ ] Focus and activation

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=102219,102233
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=102220,102234