### PR TITLE
[SDK] shellutils.h: Fix IID_PPV_ARG macro

### DIFF
--- a/sdk/include/reactos/shellutils.h
+++ b/sdk/include/reactos/shellutils.h
@@ -62,7 +62,7 @@ Win32DbgPrint(const char *filename, int line, const char *lpFormat, ...)
     Win32DbgPrint(__FILE__, __LINE__, fmt, ##__VA_ARGS__)
 
 #ifdef __cplusplus
-#   define IID_PPV_ARG(Itype, ppType) IID_##Itype, reinterpret_cast<void**>((reinterpret_cast<Itype**>(ppType)))
+#   define IID_PPV_ARG(Itype, ppType) IID_##Itype, reinterpret_cast<void**>(ppType)
 #   define IID_NULL_PPV_ARG(Itype, ppType) IID_##Itype, NULL, reinterpret_cast<void**>((reinterpret_cast<Itype**>(ppType)))
 #else
 #   define IID_PPV_ARG(Itype, ppType) &IID_##Itype, (void**)(ppType)

--- a/sdk/include/reactos/shellutils.h
+++ b/sdk/include/reactos/shellutils.h
@@ -19,6 +19,8 @@
 #ifndef __ROS_SHELL_UTILS_H
 #define __ROS_SHELL_UTILS_H
 
+#pragma once
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* defined(__cplusplus) */

--- a/sdk/include/reactos/shellutils.h
+++ b/sdk/include/reactos/shellutils.h
@@ -60,8 +60,8 @@ Win32DbgPrint(const char *filename, int line, const char *lpFormat, ...)
     Win32DbgPrint(__FILE__, __LINE__, fmt, ##__VA_ARGS__)
 
 #ifdef __cplusplus
-#   define IID_PPV_ARG(Itype, ppType) IID_##Itype, reinterpret_cast<void**>((static_cast<Itype**>(ppType)))
-#   define IID_NULL_PPV_ARG(Itype, ppType) IID_##Itype, NULL, reinterpret_cast<void**>((static_cast<Itype**>(ppType)))
+#   define IID_PPV_ARG(Itype, ppType) IID_##Itype, reinterpret_cast<void**>((reinterpret_cast<Itype**>(ppType)))
+#   define IID_NULL_PPV_ARG(Itype, ppType) IID_##Itype, NULL, reinterpret_cast<void**>((reinterpret_cast<Itype**>(ppType)))
 #else
 #   define IID_PPV_ARG(Itype, ppType) &IID_##Itype, (void**)(ppType)
 #   define IID_NULL_PPV_ARG(Itype, ppType) &IID_##Itype, NULL, (void**)(ppType)

--- a/sdk/include/reactos/shellutils.h
+++ b/sdk/include/reactos/shellutils.h
@@ -63,7 +63,7 @@ Win32DbgPrint(const char *filename, int line, const char *lpFormat, ...)
 
 #ifdef __cplusplus
 #   define IID_PPV_ARG(Itype, ppType) IID_##Itype, reinterpret_cast<void**>(ppType)
-#   define IID_NULL_PPV_ARG(Itype, ppType) IID_##Itype, NULL, reinterpret_cast<void**>((reinterpret_cast<Itype**>(ppType)))
+#   define IID_NULL_PPV_ARG(Itype, ppType) IID_##Itype, NULL, reinterpret_cast<void**>(ppType)
 #else
 #   define IID_PPV_ARG(Itype, ppType) &IID_##Itype, (void**)(ppType)
 #   define IID_NULL_PPV_ARG(Itype, ppType) &IID_##Itype, NULL, (void**)(ppType)


### PR DESCRIPTION
## Purpose
Type casting in `IID_PPV_ARG` macro failed in some situations.
JIRA issue: N/A

## Proposed changes

- Fix and simplify `IID_PPV_ARG` and `IID_NULL_PPV_ARG` macros.
- Add `#pragma once`.