### PR TITLE
[FREELDR] Fix UEFI boot after #7488 merge

### DIFF
--- a/boot/freeldr/freeldr/arch/uefi/uefildr.c
+++ b/boot/freeldr/freeldr/arch/uefi/uefildr.c
@@ -57,6 +57,19 @@ EfiEntry(
     /* Initialize I/O subsystem */
     FsInit();
 
+    /* Initialize the module list */
+    if (!PeLdrInitializeModuleList())
+    {
+        UiMessageBoxCritical("Unable to initialize module list.");
+        goto Quit;
+    }
+
+    if (!MachInitializeBootDevices())
+    {
+        UiMessageBoxCritical("Error when detecting hardware.");
+        goto Quit;
+    }
+
     /* 0x32000 is what UEFI defines, but we can go smaller if we want */
     BasicStack = (PVOID)((ULONG_PTR)0x32000 + (ULONG_PTR)MmAllocateMemoryWithType(0x32000, LoaderOsloaderStack));
     _changestack();


### PR DESCRIPTION
## Purpose

Make UEFI work again after #7488 merge

JIRA issue: [CORE-11954](https://jira.reactos.org/browse/CORE-11954)

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: