### PR TITLE
[FORMAT] Usage(): Remove redundant LoadFMIFSEntryPoints() call

### DIFF
--- a/base/system/format/format.c
+++ b/base/system/format/format.c
@@ -323,14 +323,6 @@ static VOID Usage(LPWSTR ProgramName)
 
     K32LoadStringW(GetModuleHandle(NULL), STRING_HELP, szMsg, ARRAYSIZE(szMsg));
 
-#ifndef FMIFS_IMPORT_DLL
-    if (!LoadFMIFSEntryPoints())
-    {
-        ConPrintf(StdOut, szMsg, ProgramName, L"");
-        return;
-    }
-#endif
-
     szFormats[0] = 0;
     while (QueryAvailableFileSystemFormat(Index++, szFormatW, &dummy, &dummy, &latestVersion))
     {


### PR DESCRIPTION
## Purpose

wmain() already handles this.

Addendum to 9cea0fd (r24253).
JIRA issue: [CORE-20218](https://jira.reactos.org/browse/CORE-20218)

## Proposed changes

- Remove redundant LoadFMIFSEntryPoints() call