### PR TITLE
[CHKDSK][FORMAT] Clarify LoadFMIFSEntryPoints() behavior

### DIFF
--- a/base/system/chkdsk/chkdsk.c
+++ b/base/system/chkdsk/chkdsk.c
@@ -320,22 +320,22 @@ ChkdskCallback(
 //
 // LoadFMIFSEntryPoints
 //
-// Loads FMIFS.DLL and locates the entry point(s) we are going to use
+// Loads FMIFS.DLL and locates the entry point(s) we are going to use.
+//
+// Failure means the library or 1+ function is not loaded/assigned.
 //
 //----------------------------------------------------------------------
-static BOOLEAN
+static BOOL
 LoadFMIFSEntryPoints(VOID)
 {
+    // Let program termination free the library.
     HMODULE hFmifs = LoadLibraryW(L"fmifs.dll");
-    if (hFmifs == NULL)
+    if (!hFmifs)
         return FALSE;
 
     Chkdsk = (PCHKDSK)GetProcAddress(hFmifs, "Chkdsk");
     if (!Chkdsk)
-    {
-        FreeLibrary(hFmifs);
         return FALSE;
-    }
 
     return TRUE;
 }

--- a/base/system/format/format.c
+++ b/base/system/format/format.c
@@ -270,35 +270,29 @@ FormatExCallback(
 //
 // LoadFMIFSEntryPoints
 //
-// Loads FMIFS.DLL and locates the entry point(s) we are going to use
+// Loads FMIFS.DLL and locates the entry point(s) we are going to use.
+//
+// Failure means the library or 1+ function is not loaded/assigned.
 //
 //----------------------------------------------------------------------
-static BOOLEAN LoadFMIFSEntryPoints(VOID)
+static BOOL LoadFMIFSEntryPoints(VOID)
 {
-    HMODULE hFmifs = LoadLibraryW( L"fmifs.dll");
-    if (hFmifs == NULL)
+    // Let program termination free the library.
+    HMODULE hFmifs = LoadLibraryW(L"fmifs.dll");
+    if (!hFmifs)
         return FALSE;
 
     FormatEx = (PFORMATEX)GetProcAddress(hFmifs, "FormatEx");
     if (!FormatEx)
-    {
-        FreeLibrary(hFmifs);
         return FALSE;
-    }
 
     EnableVolumeCompression = (PENABLEVOLUMECOMPRESSION)GetProcAddress(hFmifs, "EnableVolumeCompression");
     if (!EnableVolumeCompression)
-    {
-        FreeLibrary(hFmifs);
         return FALSE;
-    }
 
     QueryAvailableFileSystemFormat = (PQUERYAVAILABLEFILESYSTEMFORMAT)GetProcAddress(hFmifs, "QueryAvailableFileSystemFormat");
     if (!QueryAvailableFileSystemFormat)
-    {
-        FreeLibrary(hFmifs);
         return FALSE;
-    }
 
     return TRUE;
 }


### PR DESCRIPTION
## Purpose

Especially, freeing the library without NULLifying the function pointers was inconsistent.

## Proposed changes

- Remove inconsistent FreeLibrary() calls.
- Tweak code.
- Improve documentation.