### PR TITLE
[WIN32SS:NTUSER] Minor code cleanup in hotkey code

### DIFF
--- a/win32ss/user/ntuser/hotkey.h
+++ b/win32ss/user/ntuser/hotkey.h
@@ -27,7 +27,7 @@ VOID FASTCALL UnregisterThreadHotKeys(PTHREADINFO pti);
 BOOL NTAPI co_UserProcessHotKeys(WORD wVk, BOOL bIsDown);
 UINT FASTCALL DefWndGetHotKey(PWND pWnd);
 INT FASTCALL DefWndSetHotKey(PWND pWnd, WPARAM wParam);
-VOID FASTCALL StartDebugHotKeys(VOID);
+VOID FASTCALL SetDebugHotKeys(VOID);
 BOOL FASTCALL UserRegisterHotKey(PWND pWnd,int id,UINT fsModifiers,UINT vk);
 BOOL FASTCALL UserUnregisterHotKey(PWND pWnd, int id);
 

--- a/win32ss/user/ntuser/input.c
+++ b/win32ss/user/ntuser/input.c
@@ -204,7 +204,7 @@ RawInputThreadMain(VOID)
                 UserRegisterHotKey(PWND_BOTTOM, IDHK_SNAP_UP, MOD_WIN, VK_UP);
                 UserRegisterHotKey(PWND_BOTTOM, IDHK_SNAP_DOWN, MOD_WIN, VK_DOWN);
                 // Register the debug hotkeys.
-                StartDebugHotKeys();
+                SetDebugHotKeys();
                 UserLeave();
             }
         }

--- a/win32ss/user/ntuser/message.c
+++ b/win32ss/user/ntuser/message.c
@@ -2187,18 +2187,14 @@ IntUninitMessagePumpHook(VOID)
 }
 
 BOOL FASTCALL
-IntCallMsgFilter( LPMSG lpmsg, INT code)
+IntCallMsgFilter(LPMSG lpmsg, INT code)
 {
-    BOOL Ret = FALSE;
+    BOOL Ret;
 
-    if ( co_HOOK_CallHooks( WH_SYSMSGFILTER, code, 0, (LPARAM)lpmsg))
-    {
-        Ret = TRUE;
-    }
-    else
-    {
-        Ret = co_HOOK_CallHooks( WH_MSGFILTER, code, 0, (LPARAM)lpmsg);
-    }
+    Ret = co_HOOK_CallHooks(WH_SYSMSGFILTER, code, 0, (LPARAM)lpmsg);
+    if (!Ret)
+        Ret = co_HOOK_CallHooks(WH_MSGFILTER, code, 0, (LPARAM)lpmsg);
+
     return Ret;
 }
 
@@ -2447,16 +2443,7 @@ NtUserCallMsgFilter( LPMSG lpmsg, INT code)
     _SEH2_END;
 
     UserEnterExclusive();
-
-    if ( co_HOOK_CallHooks( WH_SYSMSGFILTER, code, 0, (LPARAM)&Msg))
-    {
-        Ret = TRUE;
-    }
-    else
-    {
-        Ret = co_HOOK_CallHooks( WH_MSGFILTER, code, 0, (LPARAM)&Msg);
-    }
-
+    Ret = IntCallMsgFilter(&Msg, code);
     UserLeave();
 
     _SEH2_TRY


### PR DESCRIPTION
## Purpose & Proposed changes

- Remove duplicated code in NtUserRegisterHotKey() and in NtUserUnregisterHotKey() by directly calling UserRegisterHotKey() and UserUnregisterHotKey() after the usual user-validation steps.

- In UserRegisterHotKey(), ignore hotkeys with virtual key VK_PACKET since this is not a real keyboard input, but is instead used in conjunction with unicode characters to simulate keystrokes for non-keyboard input methods.

- s/StartDebugHotKeys/SetDebugHotKeys/

- Remove duplicate code between NtUserCallMsgFilter() and IntCallMsgFilter().

## Testbot runs (Filled in by Devs)

- [ ] KVM x86: fix the testbots infrastructure,and only then you'll have the results! :P
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=102340,102346