### PR TITLE
[INTL] "sLanguage" relates to LOCALE_SABBREVLANGNAME actually, not LO…

### DIFF
--- a/dll/cpl/intl/generalp.c
+++ b/dll/cpl/intl/generalp.c
@@ -786,7 +786,7 @@ SetNewLocale(
                   MAX_MISCCOUNTRY);
 
     GetLocaleInfo(lcid,
-                  LOCALE_SLANGUAGE | LOCALE_NOUSEROVERRIDE,
+                  LOCALE_SABBREVLANGNAME | LOCALE_NOUSEROVERRIDE,
                   pGlobalData->szMiscLanguage,
                   MAX_MISCLANGUAGE);
 

--- a/dll/cpl/intl/intl.h
+++ b/dll/cpl/intl/intl.h
@@ -46,7 +46,7 @@
 #define MAX_YEAR_EDIT           4
 
 #define MAX_MISCCOUNTRY        80
-#define MAX_MISCLANGUAGE       80
+#define MAX_MISCLANGUAGE        4
 
 #define MAX_GROUPINGFORMATS     3
 


### PR DESCRIPTION
…CALE_SLANGUAGE

## Purpose

Fix mismatch.

Similar to ba507ba (0.4.7-dev-635).
JIRA issue: [CORE-15848](https://jira.reactos.org/browse/CORE-15848)

## Proposed changes

- Use `LOCALE_SABBREVLANGNAME`