### PR TITLE
[SYSSETUP] WriteUserLocale(): Fix Locale[] length and value

### DIFF
--- a/dll/win32/syssetup/wizard.c
+++ b/dll/win32/syssetup/wizard.c
@@ -1455,11 +1455,11 @@ WriteUserLocale(VOID)
 {
     HKEY hKey;
     LCID lcid;
-    WCHAR Locale[12];
+    WCHAR Locale[9] = L"0000";
 
     lcid = GetSystemDefaultLCID();
 
-    if (GetLocaleInfoW(MAKELCID(lcid, SORT_DEFAULT), LOCALE_ILANGUAGE, Locale, ARRAYSIZE(Locale)) != 0)
+    if (GetLocaleInfoW(MAKELCID(lcid, SORT_DEFAULT), LOCALE_ILANGUAGE, &Locale[4], _countof(Locale) - 4) != 0)
     {
         if (RegCreateKeyExW(HKEY_CURRENT_USER, L"Control Panel\\International",
                             0, NULL, REG_OPTION_NON_VOLATILE,


### PR DESCRIPTION
## Purpose

'Locale' format is "0000nnnn".

JIRA issue: [CORE-15848](https://jira.reactos.org/browse/CORE-15848)

## Proposed changes

- WriteUserLocale(): Fix Locale[] length and value