### PR TITLE
[NTUSER] IntTrackPopupMenuEx: Check TPMPARAMS.cbSize

### DIFF
--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -4580,6 +4580,13 @@ BOOL WINAPI IntTrackPopupMenuEx( PMENU menu, UINT wFlags, int x, int y,
     BOOL ret = FALSE;
     PTHREADINFO pti = PsGetCurrentThreadWin32Thread();
 
+    if (lpTpm && lpTpm->cbSize != sizeof(*lpTpm))
+    {
+        ERR("cbSize was %u\n", lpTpm->cbSize);
+        EngSetLastError(ERROR_INVALID_PARAMETER);
+        return FALSE;
+    }
+
     if (pti != pWnd->head.pti)
     {
        ERR("Must be the same pti!\n");


### PR DESCRIPTION
## Purpose
Validate structure size.
JIRA issue: [CORE-3247](https://jira.reactos.org/browse/CORE-3247)

## Proposed changes

- In `IntTrackPopupMenuEx` function, if `lpTpm` was non-NULL, then validate `lpTpm->cbSize`.
- If validation failed set `ERROR_INVALID_PARAMETER`.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: