### PR TITLE
[MAGNIFY][SHELLEXT] Improve Notify Icon menu position

### DIFF
--- a/base/applications/magnify/magnifier.c
+++ b/base/applications/magnify/magnifier.c
@@ -465,18 +465,34 @@ void Draw(HDC aDc)
     ReleaseDC(hDesktopWindow, desktopHdc);
 }
 
-void HandleNotifyIconMessage(HWND hWnd, WPARAM wParam, LPARAM lParam)
+static VOID
+HandleRightContextMenu(HWND hWnd)
 {
     POINT pt;
+    GetCursorPos(&pt);
 
+    SetForegroundWindow(hWnd);
+
+    TPMPARAMS params = { sizeof(params) };
+    HWND hTrayWnd = FindWindowW(L"Shell_TrayWnd", NULL);
+    HWND hNotifyWnd = FindWindowExW(hTrayWnd, NULL, L"TrayNotifyWnd", NULL);
+    GetWindowRect(hNotifyWnd, &params.rcExclude);
+
+    UINT uFlags = TPM_VERTICAL | TPM_RIGHTALIGN | TPM_RIGHTBUTTON;
+    TrackPopupMenuEx(notifyMenu, uFlags, pt.x, pt.y, hWnd, &params);
+
+    PostMessage(hWnd, WM_NULL, 0, 0);
+}
+
+void HandleNotifyIconMessage(HWND hWnd, WPARAM wParam, LPARAM lParam)
+{
     switch(lParam)
     {
         case WM_LBUTTONUP:
             PostMessage(hMainWnd, WM_COMMAND, IDM_OPTIONS, 0);
             break;
         case WM_RBUTTONUP:
-            GetCursorPos(&pt);
-            TrackPopupMenu(notifyMenu, 0, pt.x, pt.y, 0, hWnd, NULL);
+            HandleRightContextMenu(hWnd);
             break;
     }
 }

--- a/dll/shellext/netshell/lanstatusui.cpp
+++ b/dll/shellext/netshell/lanstatusui.cpp
@@ -924,10 +924,15 @@ VOID ShowNetworkIconContextMenu(
         }
     }
 
-    TrackPopupMenuEx(hMenu, TPM_LEFTALIGN | TPM_BOTTOMALIGN | TPM_RIGHTBUTTON, pt.x, pt.y, hwndOwner, NULL);
+    TPMPARAMS params = { sizeof(params) };
+    HWND hTrayWnd = FindWindowW(L"Shell_TrayWnd", NULL);
+    HWND hNotifyWnd = FindWindowEx(hTrayWnd, NULL, L"TrayNotifyWnd", NULL);
+    GetWindowRect(hNotifyWnd, &params.rcExclude);
+
+    UINT uFlags = TPM_VERTICAL | TPM_RIGHTALIGN | TPM_RIGHTBUTTON;
+    TrackPopupMenuEx(hMenu, uFlags, pt.x, pt.y, hwndOwner, &params);
 
     PostMessage(hwndOwner, WM_NULL, 0, 0);
-
     DestroyMenu(hMenu);
 }
 

--- a/dll/shellext/stobject/hotplug.cpp
+++ b/dll/shellext/stobject/hotplug.cpp
@@ -175,14 +175,17 @@ static void _ShowContextMenu(CSysTray * pSysTray)
     }
 
     SetForegroundWindow(pSysTray->GetHWnd());
-    DWORD flags = TPM_RETURNCMD | TPM_NONOTIFY | TPM_RIGHTALIGN | TPM_BOTTOMALIGN;
+
+    TPMPARAMS params = { sizeof(params) };
+    HWND hTrayWnd = FindWindowW(L"Shell_TrayWnd", NULL);
+    HWND hNotifyWnd = FindWindowExW(hTrayWnd, NULL, L"TrayNotifyWnd", NULL);
+    GetWindowRect(hNotifyWnd, &params.rcExclude);
+
+    DWORD flags = TPM_VERTICAL | TPM_RIGHTALIGN | TPM_RETURNCMD | TPM_RIGHTBUTTON | TPM_NONOTIFY;
     POINT pt;
     GetCursorPos(&pt);
 
-    DWORD id = TrackPopupMenuEx(hPopup, flags,
-        pt.x, pt.y,
-        pSysTray->GetHWnd(), NULL);
-
+    DWORD id = TrackPopupMenuEx(hPopup, flags, pt.x, pt.y, pSysTray->GetHWnd(), &params);
     if (id > 0)
     {
         id--; // since array indices starts from zero.
@@ -218,18 +221,19 @@ static void _ShowContextMenuR(CSysTray * pSysTray)
     SetMenuDefaultItem(hPopup, IDS_HOTPLUG_REMOVE_2, FALSE);
 
     SetForegroundWindow(pSysTray->GetHWnd());
-    DWORD flags = TPM_RETURNCMD | TPM_NONOTIFY | TPM_RIGHTALIGN | TPM_BOTTOMALIGN;
+
+    TPMPARAMS params = { sizeof(params) };
+    HWND hTrayWnd = FindWindowW(L"Shell_TrayWnd", NULL);
+    HWND hNotifyWnd = FindWindowExW(hTrayWnd, NULL, L"TrayNotifyWnd", NULL);
+    GetWindowRect(hNotifyWnd, &params.rcExclude);
+
+    DWORD flags = TPM_VERTICAL | TPM_RIGHTALIGN | TPM_RETURNCMD | TPM_RIGHTBUTTON | TPM_NONOTIFY;
     POINT pt;
     GetCursorPos(&pt);
 
-    DWORD id = TrackPopupMenuEx(hPopup, flags,
-        pt.x, pt.y,
-        pSysTray->GetHWnd(), NULL);
-
+    DWORD id = TrackPopupMenuEx(hPopup, flags, pt.x, pt.y, pSysTray->GetHWnd(), &params);
     if (id == IDS_HOTPLUG_REMOVE_2)
-    {
         _RunHotplug(pSysTray);
-    }
 
     DestroyMenu(hPopup);
 }

--- a/dll/shellext/stobject/power.cpp
+++ b/dll/shellext/stobject/power.cpp
@@ -182,14 +182,17 @@ static void _ShowContextMenu(CSysTray * pSysTray)
     SetMenuDefaultItem(hPopup, IDS_PWR_PROPERTIES, FALSE);
 
     SetForegroundWindow(pSysTray->GetHWnd());
-    DWORD flags = TPM_RETURNCMD | TPM_NONOTIFY | TPM_RIGHTALIGN | TPM_BOTTOMALIGN;
+
+    TPMPARAMS params = { sizeof(params) };
+    HWND hTrayWnd = FindWindowW(L"Shell_TrayWnd", NULL);
+    HWND hNotifyWnd = FindWindowExW(hTrayWnd, NULL, L"TrayNotifyWnd", NULL);
+    GetWindowRect(hNotifyWnd, &params.rcExclude);
+
     POINT pt;
     GetCursorPos(&pt);
 
-    DWORD id = TrackPopupMenuEx(hPopup, flags,
-        pt.x, pt.y,
-        pSysTray->GetHWnd(), NULL);
-
+    DWORD flags = TPM_VERTICAL | TPM_RIGHTALIGN | TPM_RETURNCMD | TPM_RIGHTBUTTON | TPM_NONOTIFY;
+    UINT id = TrackPopupMenuEx(hPopup, flags, pt.x, pt.y, pSysTray->GetHWnd(), &params);
     switch (id)
     {
         case IDS_PWR_PROPERTIES:

--- a/dll/shellext/stobject/volume.cpp
+++ b/dll/shellext/stobject/volume.cpp
@@ -235,14 +235,17 @@ static void _ShowContextMenu(CSysTray * pSysTray)
     AppendMenuW(hPopup, MF_STRING, IDS_VOL_ADJUST, strAdjust);
     SetMenuDefaultItem(hPopup, IDS_VOL_OPEN, FALSE);
 
-    DWORD flags = TPM_RETURNCMD | TPM_NONOTIFY | TPM_RIGHTALIGN | TPM_BOTTOMALIGN;
+    TPMPARAMS params = { sizeof(params) };
+    HWND hTrayWnd = FindWindowW(L"Shell_TrayWnd", NULL);
+    HWND hNotifyWnd = FindWindowExW(hTrayWnd, NULL, L"TrayNotifyWnd", NULL);
+    GetWindowRect(hNotifyWnd, &params.rcExclude);
+
+    DWORD flags = TPM_VERTICAL | TPM_RIGHTALIGN | TPM_RETURNCMD | TPM_RIGHTBUTTON | TPM_NONOTIFY;
     POINT pt;
     SetForegroundWindow(pSysTray->GetHWnd());
     GetCursorPos(&pt);
 
-    DWORD id = TrackPopupMenuEx(hPopup, flags,
-        pt.x, pt.y,
-        pSysTray->GetHWnd(), NULL);
+    DWORD id = TrackPopupMenuEx(hPopup, flags, pt.x, pt.y, pSysTray->GetHWnd(), &params);
 
     DestroyMenu(hPopup);
 


### PR DESCRIPTION
## Purpose

Aligning the popup menu from the taskbar notification area icon.
JIRA issue: [CORE-10829](https://jira.reactos.org/browse/CORE-10829)

BEFORE:
![before](https://github.com/user-attachments/assets/4ac8f919-2f7c-4d91-8958-a5e5f56aba3d)

AFTER:
![after](https://github.com/user-attachments/assets/0d01f480-cad1-4515-9bb4-71b2c0c8da31)

## Proposed changes

- Get the Notify Window by `FindWindow[Ex]`.
- Use `TrackPopupMenuEx` with `TPMPARAMS`, excluding the rectangle of the Notify Window.
- Add `TPM_VERTICAL` flag.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: