### PR TITLE
[EXPLORER] Taskbar: Set MINMAXINFO correctly

### DIFF
--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -3301,6 +3301,16 @@ HandleTrayContextMenu:
         return 0;
     }
 
+    // WM_GETMINMAXINFO
+    LRESULT OnGetMinMaxInfo(INT code, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
+    {
+        PMINMAXINFO pInfo = (PMINMAXINFO)lParam;
+        SIZE StartSize = m_StartButton.GetSize();
+        pInfo->ptMinTrackSize.x = StartSize.cx + 2 * GetSystemMetrics(SM_CXFRAME);
+        pInfo->ptMinTrackSize.y = StartSize.cy + 2 * GetSystemMetrics(SM_CYFRAME);
+        return 0;
+    }
+
     LRESULT OnRebarAutoSize(INT code, LPNMHDR nmhdr, BOOL& bHandled)
     {
 #if 0
@@ -3437,6 +3447,7 @@ HandleTrayContextMenu:
         MESSAGE_HANDLER(WM_INITMENUPOPUP, OnInitMenuPopup)
         MESSAGE_HANDLER(WM_ACTIVATE, OnActivate)
         MESSAGE_HANDLER(WM_SETFOCUS, OnSetFocus)
+        MESSAGE_HANDLER(WM_GETMINMAXINFO, OnGetMinMaxInfo)
         MESSAGE_HANDLER(TWM_SETTINGSCHANGED, OnTaskbarSettingsChanged)
         MESSAGE_HANDLER(TWM_OPENSTARTMENU, OnOpenStartMenu)
         MESSAGE_HANDLER(TWM_DOEXITWINDOWS, OnDoExitWindows)


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-20219](https://jira.reactos.org/browse/CORE-20219)

BEFORE:
![before](https://github.com/user-attachments/assets/595d01ef-b4fd-4419-aa35-e1f774fb7665)

AFTER:
![after](https://github.com/user-attachments/assets/b993c2be-a841-4cd4-b13b-7d664369dee5)

## Proposed changes

- Set `MINMAXINFO` data in `WM_GETMINMAXINFO` message handling.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: