### PR TITLE
[KBSWITCH] Handle IME Menu default items

### DIFF
--- a/base/applications/kbswitch/indicdll/indicdll.c
+++ b/base/applications/kbswitch/indicdll/indicdll.c
@@ -43,7 +43,6 @@ WinHookProc(INT code, WPARAM wParam, LPARAM lParam)
         case HCBT_ACTIVATE:
         case HCBT_SETFOCUS:
         {
-            OutputDebugStringA("HCBT_ACTIVATE / HCBT_SETFOCUS\n");
             HWND hwndFocus = (HWND)wParam;
             if (hwndFocus && hwndFocus != g_pShared->hKbSwitchWnd)
                 PostMessageToMainWnd(WM_WINDOW_ACTIVATE, (WPARAM)hwndFocus, 0);
@@ -64,13 +63,11 @@ ShellHookProc(INT code, WPARAM wParam, LPARAM lParam)
     {
         case HSHELL_WINDOWACTIVATED:
         {
-            OutputDebugStringA("HSHELL_WINDOWACTIVATED\n");
             PostMessageToMainWnd(WM_WINDOW_ACTIVATE, wParam, 0);
             break;
         }
         case HSHELL_LANGUAGE:
         {
-            OutputDebugStringA("HSHELL_LANGUAGE\n");
             PostMessageToMainWnd(WM_LANG_CHANGED, wParam, lParam);
             break;
         }

--- a/base/applications/kbswitch/lang/bg-BG.rc
+++ b/base/applications/kbswitch/lang/bg-BG.rc
@@ -9,3 +9,13 @@ BEGIN
         MENUITEM "Из&ход", ID_EXIT
     END
 END
+
+STRINGTABLE
+BEGIN
+    IDS_IME_ON "Input System (IME) - ON"
+    IDS_IME_OFF "Input System (IME) - OFF"
+    IDS_SOFTKBD_ON "Soft Keyboard - ON"
+    IDS_SOFTKBD_OFF "Soft Keyboard - OFF"
+    IDS_SHOWTOOLBAR "Show Toolbar"
+    IDS_INPUTSYSTEM "Input System (IME) configuration..."
+END

--- a/base/applications/kbswitch/lang/cs-CZ.rc
+++ b/base/applications/kbswitch/lang/cs-CZ.rc
@@ -14,3 +14,13 @@ BEGIN
         MENUITEM "&Ukončit", ID_EXIT
     END
 END
+
+STRINGTABLE
+BEGIN
+    IDS_IME_ON "Input System (IME) - ON"
+    IDS_IME_OFF "Input System (IME) - OFF"
+    IDS_SOFTKBD_ON "Soft Keyboard - ON"
+    IDS_SOFTKBD_OFF "Soft Keyboard - OFF"
+    IDS_SHOWTOOLBAR "Show Toolbar"
+    IDS_INPUTSYSTEM "Input System (IME) configuration..."
+END

--- a/base/applications/kbswitch/lang/de-DE.rc
+++ b/base/applications/kbswitch/lang/de-DE.rc
@@ -9,3 +9,13 @@ BEGIN
         MENUITEM "&Beenden", ID_EXIT
     END
 END
+
+STRINGTABLE
+BEGIN
+    IDS_IME_ON "Input System (IME) - ON"
+    IDS_IME_OFF "Input System (IME) - OFF"
+    IDS_SOFTKBD_ON "Soft Keyboard - ON"
+    IDS_SOFTKBD_OFF "Soft Keyboard - OFF"
+    IDS_SHOWTOOLBAR "Show Toolbar"
+    IDS_INPUTSYSTEM "Input System (IME) configuration..."
+END

--- a/base/applications/kbswitch/lang/en-US.rc
+++ b/base/applications/kbswitch/lang/en-US.rc
@@ -9,3 +9,13 @@ BEGIN
         MENUITEM "E&xit", ID_EXIT
     END
 END
+
+STRINGTABLE
+BEGIN
+    IDS_IME_ON "Input System (IME) - ON"
+    IDS_IME_OFF "Input System (IME) - OFF"
+    IDS_SOFTKBD_ON "Soft Keyboard - ON"
+    IDS_SOFTKBD_OFF "Soft Keyboard - OFF"
+    IDS_SHOWTOOLBAR "Show Toolbar"
+    IDS_INPUTSYSTEM "Input System (IME) configuration..."
+END

--- a/base/applications/kbswitch/lang/es-ES.rc
+++ b/base/applications/kbswitch/lang/es-ES.rc
@@ -9,3 +9,13 @@ BEGIN
         MENUITEM "&Salir", ID_EXIT
     END
 END
+
+STRINGTABLE
+BEGIN
+    IDS_IME_ON "Input System (IME) - ON"
+    IDS_IME_OFF "Input System (IME) - OFF"
+    IDS_SOFTKBD_ON "Soft Keyboard - ON"
+    IDS_SOFTKBD_OFF "Soft Keyboard - OFF"
+    IDS_SHOWTOOLBAR "Show Toolbar"
+    IDS_INPUTSYSTEM "Input System (IME) configuration..."
+END

--- a/base/applications/kbswitch/lang/et-EE.rc
+++ b/base/applications/kbswitch/lang/et-EE.rc
@@ -9,3 +9,13 @@ BEGIN
         MENUITEM "V&älju", ID_EXIT
     END
 END
+
+STRINGTABLE
+BEGIN
+    IDS_IME_ON "Input System (IME) - ON"
+    IDS_IME_OFF "Input System (IME) - OFF"
+    IDS_SOFTKBD_ON "Soft Keyboard - ON"
+    IDS_SOFTKBD_OFF "Soft Keyboard - OFF"
+    IDS_SHOWTOOLBAR "Show Toolbar"
+    IDS_INPUTSYSTEM "Input System (IME) configuration..."
+END

--- a/base/applications/kbswitch/lang/fr-FR.rc
+++ b/base/applications/kbswitch/lang/fr-FR.rc
@@ -9,3 +9,13 @@ BEGIN
         MENUITEM "Quitt&er", ID_EXIT
     END
 END
+
+STRINGTABLE
+BEGIN
+    IDS_IME_ON "Input System (IME) - ON"
+    IDS_IME_OFF "Input System (IME) - OFF"
+    IDS_SOFTKBD_ON "Soft Keyboard - ON"
+    IDS_SOFTKBD_OFF "Soft Keyboard - OFF"
+    IDS_SHOWTOOLBAR "Show Toolbar"
+    IDS_INPUTSYSTEM "Input System (IME) configuration..."
+END

--- a/base/applications/kbswitch/lang/he-IL.rc
+++ b/base/applications/kbswitch/lang/he-IL.rc
@@ -9,3 +9,13 @@ BEGIN
         MENUITEM "&יציאה", ID_EXIT
     END
 END
+
+STRINGTABLE
+BEGIN
+    IDS_IME_ON "Input System (IME) - ON"
+    IDS_IME_OFF "Input System (IME) - OFF"
+    IDS_SOFTKBD_ON "Soft Keyboard - ON"
+    IDS_SOFTKBD_OFF "Soft Keyboard - OFF"
+    IDS_SHOWTOOLBAR "Show Toolbar"
+    IDS_INPUTSYSTEM "Input System (IME) configuration..."
+END

--- a/base/applications/kbswitch/lang/it-IT.rc
+++ b/base/applications/kbswitch/lang/it-IT.rc
@@ -9,3 +9,13 @@ BEGIN
         MENUITEM "&Esci", ID_EXIT
     END
 END
+
+STRINGTABLE
+BEGIN
+    IDS_IME_ON "Input System (IME) - ON"
+    IDS_IME_OFF "Input System (IME) - OFF"
+    IDS_SOFTKBD_ON "Soft Keyboard - ON"
+    IDS_SOFTKBD_OFF "Soft Keyboard - OFF"
+    IDS_SHOWTOOLBAR "Show Toolbar"
+    IDS_INPUTSYSTEM "Input System (IME) configuration..."
+END

--- a/base/applications/kbswitch/lang/ja-JP.rc
+++ b/base/applications/kbswitch/lang/ja-JP.rc
@@ -9,3 +9,13 @@ BEGIN
         MENUITEM "終了(&E)", ID_EXIT
     END
 END
+
+STRINGTABLE
+BEGIN
+    IDS_IME_ON "入力システム (IME) - オン"
+    IDS_IME_OFF "入力システム (IME) - オフ"
+    IDS_SOFTKBD_ON "ソフト キーボード - オン"
+    IDS_SOFTKBD_OFF "ソフト キーボード - オフ"
+    IDS_SHOWTOOLBAR "ツールバーを表示する"
+    IDS_INPUTSYSTEM "入力システム (IME) の設定..."
+END

--- a/base/applications/kbswitch/lang/lt-LT.rc
+++ b/base/applications/kbswitch/lang/lt-LT.rc
@@ -11,3 +11,13 @@ BEGIN
         MENUITEM "&Baigti", ID_EXIT
     END
 END
+
+STRINGTABLE
+BEGIN
+    IDS_IME_ON "Input System (IME) - ON"
+    IDS_IME_OFF "Input System (IME) - OFF"
+    IDS_SOFTKBD_ON "Soft Keyboard - ON"
+    IDS_SOFTKBD_OFF "Soft Keyboard - OFF"
+    IDS_SHOWTOOLBAR "Show Toolbar"
+    IDS_INPUTSYSTEM "Input System (IME) configuration..."
+END

--- a/base/applications/kbswitch/lang/no-NO.rc
+++ b/base/applications/kbswitch/lang/no-NO.rc
@@ -9,3 +9,13 @@ BEGIN
         MENUITEM "&Avslutt", ID_EXIT
     END
 END
+
+STRINGTABLE
+BEGIN
+    IDS_IME_ON "Input System (IME) - ON"
+    IDS_IME_OFF "Input System (IME) - OFF"
+    IDS_SOFTKBD_ON "Soft Keyboard - ON"
+    IDS_SOFTKBD_OFF "Soft Keyboard - OFF"
+    IDS_SHOWTOOLBAR "Show Toolbar"
+    IDS_INPUTSYSTEM "Input System (IME) configuration..."
+END

--- a/base/applications/kbswitch/lang/pl-PL.rc
+++ b/base/applications/kbswitch/lang/pl-PL.rc
@@ -17,3 +17,13 @@ BEGIN
         MENUITEM "&Wyjście", ID_EXIT
     END
 END
+
+STRINGTABLE
+BEGIN
+    IDS_IME_ON "Input System (IME) - ON"
+    IDS_IME_OFF "Input System (IME) - OFF"
+    IDS_SOFTKBD_ON "Soft Keyboard - ON"
+    IDS_SOFTKBD_OFF "Soft Keyboard - OFF"
+    IDS_SHOWTOOLBAR "Show Toolbar"
+    IDS_INPUTSYSTEM "Input System (IME) configuration..."
+END

--- a/base/applications/kbswitch/lang/pt-BR.rc
+++ b/base/applications/kbswitch/lang/pt-BR.rc
@@ -11,3 +11,13 @@ BEGIN
         MENUITEM "&Sair", ID_EXIT
     END
 END
+
+STRINGTABLE
+BEGIN
+    IDS_IME_ON "Input System (IME) - ON"
+    IDS_IME_OFF "Input System (IME) - OFF"
+    IDS_SOFTKBD_ON "Soft Keyboard - ON"
+    IDS_SOFTKBD_OFF "Soft Keyboard - OFF"
+    IDS_SHOWTOOLBAR "Show Toolbar"
+    IDS_INPUTSYSTEM "Input System (IME) configuration..."
+END

--- a/base/applications/kbswitch/lang/pt-PT.rc
+++ b/base/applications/kbswitch/lang/pt-PT.rc
@@ -16,3 +16,13 @@ BEGIN
         MENUITEM "&Sair", ID_EXIT
     END
 END
+
+STRINGTABLE
+BEGIN
+    IDS_IME_ON "Input System (IME) - ON"
+    IDS_IME_OFF "Input System (IME) - OFF"
+    IDS_SOFTKBD_ON "Soft Keyboard - ON"
+    IDS_SOFTKBD_OFF "Soft Keyboard - OFF"
+    IDS_SHOWTOOLBAR "Show Toolbar"
+    IDS_INPUTSYSTEM "Input System (IME) configuration..."
+END

--- a/base/applications/kbswitch/lang/ro-RO.rc
+++ b/base/applications/kbswitch/lang/ro-RO.rc
@@ -16,3 +16,13 @@ BEGIN
         MENUITEM "I&eșire", ID_EXIT
     END
 END
+
+STRINGTABLE
+BEGIN
+    IDS_IME_ON "Input System (IME) - ON"
+    IDS_IME_OFF "Input System (IME) - OFF"
+    IDS_SOFTKBD_ON "Soft Keyboard - ON"
+    IDS_SOFTKBD_OFF "Soft Keyboard - OFF"
+    IDS_SHOWTOOLBAR "Show Toolbar"
+    IDS_INPUTSYSTEM "Input System (IME) configuration..."
+END

--- a/base/applications/kbswitch/lang/ru-RU.rc
+++ b/base/applications/kbswitch/lang/ru-RU.rc
@@ -9,3 +9,13 @@ BEGIN
         MENUITEM "&Выход", ID_EXIT
     END
 END
+
+STRINGTABLE
+BEGIN
+    IDS_IME_ON "Input System (IME) - ON"
+    IDS_IME_OFF "Input System (IME) - OFF"
+    IDS_SOFTKBD_ON "Soft Keyboard - ON"
+    IDS_SOFTKBD_OFF "Soft Keyboard - OFF"
+    IDS_SHOWTOOLBAR "Show Toolbar"
+    IDS_INPUTSYSTEM "Input System (IME) configuration..."
+END

--- a/base/applications/kbswitch/lang/sk-SK.rc
+++ b/base/applications/kbswitch/lang/sk-SK.rc
@@ -13,3 +13,13 @@ BEGIN
         MENUITEM "&Zavrieť", ID_EXIT
     END
 END
+
+STRINGTABLE
+BEGIN
+    IDS_IME_ON "Input System (IME) - ON"
+    IDS_IME_OFF "Input System (IME) - OFF"
+    IDS_SOFTKBD_ON "Soft Keyboard - ON"
+    IDS_SOFTKBD_OFF "Soft Keyboard - OFF"
+    IDS_SHOWTOOLBAR "Show Toolbar"
+    IDS_INPUTSYSTEM "Input System (IME) configuration..."
+END

--- a/base/applications/kbswitch/lang/sq-AL.rc
+++ b/base/applications/kbswitch/lang/sq-AL.rc
@@ -13,3 +13,13 @@ BEGIN
         MENUITEM "&Dil", ID_EXIT
     END
 END
+
+STRINGTABLE
+BEGIN
+    IDS_IME_ON "Input System (IME) - ON"
+    IDS_IME_OFF "Input System (IME) - OFF"
+    IDS_SOFTKBD_ON "Soft Keyboard - ON"
+    IDS_SOFTKBD_OFF "Soft Keyboard - OFF"
+    IDS_SHOWTOOLBAR "Show Toolbar"
+    IDS_INPUTSYSTEM "Input System (IME) configuration..."
+END

--- a/base/applications/kbswitch/lang/sv-SE.rc
+++ b/base/applications/kbswitch/lang/sv-SE.rc
@@ -11,3 +11,13 @@ BEGIN
         MENUITEM "&Avsluta", ID_EXIT
     END
 END
+
+STRINGTABLE
+BEGIN
+    IDS_IME_ON "Input System (IME) - ON"
+    IDS_IME_OFF "Input System (IME) - OFF"
+    IDS_SOFTKBD_ON "Soft Keyboard - ON"
+    IDS_SOFTKBD_OFF "Soft Keyboard - OFF"
+    IDS_SHOWTOOLBAR "Show Toolbar"
+    IDS_INPUTSYSTEM "Input System (IME) configuration..."
+END

--- a/base/applications/kbswitch/lang/tr-TR.rc
+++ b/base/applications/kbswitch/lang/tr-TR.rc
@@ -11,3 +11,13 @@ BEGIN
         MENUITEM "&Çıkış", ID_EXIT
     END
 END
+
+STRINGTABLE
+BEGIN
+    IDS_IME_ON "Input System (IME) - ON"
+    IDS_IME_OFF "Input System (IME) - OFF"
+    IDS_SOFTKBD_ON "Soft Keyboard - ON"
+    IDS_SOFTKBD_OFF "Soft Keyboard - OFF"
+    IDS_SHOWTOOLBAR "Show Toolbar"
+    IDS_INPUTSYSTEM "Input System (IME) configuration..."
+END

--- a/base/applications/kbswitch/lang/uk-UA.rc
+++ b/base/applications/kbswitch/lang/uk-UA.rc
@@ -17,3 +17,13 @@ BEGIN
         MENUITEM "В&ихід", ID_EXIT
     END
 END
+
+STRINGTABLE
+BEGIN
+    IDS_IME_ON "Input System (IME) - ON"
+    IDS_IME_OFF "Input System (IME) - OFF"
+    IDS_SOFTKBD_ON "Soft Keyboard - ON"
+    IDS_SOFTKBD_OFF "Soft Keyboard - OFF"
+    IDS_SHOWTOOLBAR "Show Toolbar"
+    IDS_INPUTSYSTEM "Input System (IME) configuration..."
+END

--- a/base/applications/kbswitch/lang/zh-CN.rc
+++ b/base/applications/kbswitch/lang/zh-CN.rc
@@ -17,3 +17,13 @@ BEGIN
         MENUITEM "退出(&E)", ID_EXIT
     END
 END
+
+STRINGTABLE
+BEGIN
+    IDS_IME_ON "Input System (IME) - ON"
+    IDS_IME_OFF "Input System (IME) - OFF"
+    IDS_SOFTKBD_ON "Soft Keyboard - ON"
+    IDS_SOFTKBD_OFF "Soft Keyboard - OFF"
+    IDS_SHOWTOOLBAR "Show Toolbar"
+    IDS_INPUTSYSTEM "Input System (IME) configuration..."
+END

--- a/base/applications/kbswitch/lang/zh-HK.rc
+++ b/base/applications/kbswitch/lang/zh-HK.rc
@@ -17,3 +17,13 @@ BEGIN
         MENUITEM "結束(&E)", ID_EXIT
     END
 END
+
+STRINGTABLE
+BEGIN
+    IDS_IME_ON "Input System (IME) - ON"
+    IDS_IME_OFF "Input System (IME) - OFF"
+    IDS_SOFTKBD_ON "Soft Keyboard - ON"
+    IDS_SOFTKBD_OFF "Soft Keyboard - OFF"
+    IDS_SHOWTOOLBAR "Show Toolbar"
+    IDS_INPUTSYSTEM "Input System (IME) configuration..."
+END

--- a/base/applications/kbswitch/lang/zh-TW.rc
+++ b/base/applications/kbswitch/lang/zh-TW.rc
@@ -17,3 +17,13 @@ BEGIN
         MENUITEM "結束(&E)", ID_EXIT
     END
 END
+
+STRINGTABLE
+BEGIN
+    IDS_IME_ON "Input System (IME) - ON"
+    IDS_IME_OFF "Input System (IME) - OFF"
+    IDS_SOFTKBD_ON "Soft Keyboard - ON"
+    IDS_SOFTKBD_OFF "Soft Keyboard - OFF"
+    IDS_SHOWTOOLBAR "Show Toolbar"
+    IDS_INPUTSYSTEM "Input System (IME) configuration..."
+END

--- a/base/applications/kbswitch/resource.h
+++ b/base/applications/kbswitch/resource.h
@@ -6,7 +6,19 @@
 /* Menus */
 #define IDR_POPUP 100
 
+/* Strings */
+#define IDS_IME_ON 300
+#define IDS_IME_OFF 301
+#define IDS_SOFTKBD_ON 302
+#define IDS_SOFTKBD_OFF 303
+#define IDS_SHOWTOOLBAR 304
+#define IDS_INPUTSYSTEM 305
+
 /* Menu items */
-#define ID_EXIT        100
+#define ID_EXIT 100
 #define ID_PREFERENCES 101
-#define ID_LANG_BASE   1000
+#define ID_INPUTSYSTEM 252
+#define ID_IMEONOFF 500
+#define ID_SOFTKBDONOFF 501
+#define ID_SHOWTOOLBAR 502
+#define ID_LANG_BASE 1000


### PR DESCRIPTION
## Purpose

Finishing IME menu work. The IME menu of the system pen icon has to append the default items if `DMI_LEFT` and `RDMI_RIGHT` are not specified.
JIRA issue: [CORE-20142](https://jira.reactos.org/browse/CORE-20142)

## Proposed changes

- Add `IsRegImeToolbarShown` and `ShowImeToolbar` helper functions.
- Add more code into `KbSwitch_OnPenIconMsg` function to handle IME menu default items.
- Add many resource strings.

## Screenshots

AFTER:
![after](https://github.com/user-attachments/assets/124e9cef-be0d-4463-9a3c-ae33c64c1cf9)

![after2](https://github.com/user-attachments/assets/732c1773-b80d-4ddc-9165-fe041d5e52e9)

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: