### PR TITLE
[EXPLORER] Add fullscreen handling

### DIFF
--- a/base/shell/explorer/precomp.h
+++ b/base/shell/explorer/precomp.h
@@ -133,7 +133,7 @@ HRESULT WINAPI _CBandSite_CreateInstance(LPUNKNOWN pUnkOuter, REFIID riid, void 
 #define TWM_OPENSTARTMENU (WM_USER + 260)
 #define TWM_SETTINGSCHANGED (WM_USER + 300)
 #define TWM_SETZORDER (WM_USER + 338)
-#define TWM_PULSE (WM_USER + 400) // wParam: type of pulse. lParam: target window
+#define TWM_NOTIFYFULLSCREENAPP (WM_USER + 999) /* ReactOS-specific */
 
 extern const GUID IID_IShellDesktopTray;
 

--- a/base/shell/explorer/precomp.h
+++ b/base/shell/explorer/precomp.h
@@ -173,7 +173,7 @@ DECLARE_INTERFACE_(ITrayWindow, IUnknown)
 #define ITrayWindow_ExecContextMenuCmd(p,a) (p)->lpVtbl->ExecContextMenuCmd(p,a)
 #define ITrayWindow_Lock(p,a)               (p)->lpVtbl->Lock(p,a)
 #define ITrayWindow_IsTaskWnd(p,a)          (p)->lpVtbl->IsTaskWnd(p,a)
-#define ITrayWindow_NotifyFullScreenToAppBars(p,a,b) (p)->lpVtbl->(p,a,b)
+#define ITrayWindow_NotifyFullScreenToAppBars(p,a,b) (p)->lpVtbl->NotifyFullScreenToAppBars(p,a,b)
 #endif
 
 HRESULT CreateTrayWindow(ITrayWindow ** ppTray);

--- a/base/shell/explorer/precomp.h
+++ b/base/shell/explorer/precomp.h
@@ -133,7 +133,7 @@ HRESULT WINAPI _CBandSite_CreateInstance(LPUNKNOWN pUnkOuter, REFIID riid, void 
 #define TWM_OPENSTARTMENU (WM_USER + 260)
 #define TWM_SETTINGSCHANGED (WM_USER + 300)
 #define TWM_SETZORDER (WM_USER + 338)
-#define TWM_NOTIFYFULLSCREENAPP (WM_USER + 777) /* ReactOS-specific */
+#define TWM_NotifyFullScreenToAppBars (WM_USER + 777) /* ReactOS-specific */
 
 extern const GUID IID_IShellDesktopTray;
 
@@ -154,6 +154,7 @@ DECLARE_INTERFACE_(ITrayWindow, IUnknown)
     STDMETHOD_(BOOL, ExecContextMenuCmd) (THIS_ UINT uiCmd) PURE;
     STDMETHOD_(BOOL, Lock) (THIS_ BOOL bLock) PURE;
     STDMETHOD_(BOOL, IsTaskWnd) (THIS_ HWND hWnd) PURE;
+    STDMETHOD_(HRESULT, NotifyFullScreenToAppBars)(THIS_ HMONITOR hMonitor, BOOL bFullOpening) PURE;
 };
 #undef INTERFACE
 
@@ -172,6 +173,7 @@ DECLARE_INTERFACE_(ITrayWindow, IUnknown)
 #define ITrayWindow_ExecContextMenuCmd(p,a) (p)->lpVtbl->ExecContextMenuCmd(p,a)
 #define ITrayWindow_Lock(p,a)               (p)->lpVtbl->Lock(p,a)
 #define ITrayWindow_IsTaskWnd(p,a)          (p)->lpVtbl->IsTaskWnd(p,a)
+#define ITrayWindow_NotifyFullScreenToAppBars(p,a,b) (p)->lpVtbl->(p,a,b)
 #endif
 
 HRESULT CreateTrayWindow(ITrayWindow ** ppTray);

--- a/base/shell/explorer/precomp.h
+++ b/base/shell/explorer/precomp.h
@@ -133,7 +133,7 @@ HRESULT WINAPI _CBandSite_CreateInstance(LPUNKNOWN pUnkOuter, REFIID riid, void 
 #define TWM_OPENSTARTMENU (WM_USER + 260)
 #define TWM_SETTINGSCHANGED (WM_USER + 300)
 #define TWM_SETZORDER (WM_USER + 338)
-#define TWM_NOTIFYFULLSCREENAPP (WM_USER + 999) /* ReactOS-specific */
+#define TWM_NOTIFYFULLSCREENAPP (WM_USER + 777) /* ReactOS-specific */
 
 extern const GUID IID_IShellDesktopTray;
 

--- a/base/shell/explorer/precomp.h
+++ b/base/shell/explorer/precomp.h
@@ -134,8 +134,6 @@ HRESULT WINAPI _CBandSite_CreateInstance(LPUNKNOWN pUnkOuter, REFIID riid, void 
 #define TWM_SETTINGSCHANGED (WM_USER + 300)
 #define TWM_SETZORDER (WM_USER + 338)
 #define TWM_PULSE (WM_USER + 400) // wParam: type of pulse. lParam: target window
-#define PULSE_ACTIVATE 0
-#define PULSE_DESTROYED 1
 
 extern const GUID IID_IShellDesktopTray;
 

--- a/base/shell/explorer/precomp.h
+++ b/base/shell/explorer/precomp.h
@@ -133,7 +133,6 @@ HRESULT WINAPI _CBandSite_CreateInstance(LPUNKNOWN pUnkOuter, REFIID riid, void 
 #define TWM_OPENSTARTMENU (WM_USER + 260)
 #define TWM_SETTINGSCHANGED (WM_USER + 300)
 #define TWM_SETZORDER (WM_USER + 338)
-#define TWM_NotifyFullScreenToAppBars (WM_USER + 777) /* ReactOS-specific */
 
 extern const GUID IID_IShellDesktopTray;
 

--- a/base/shell/explorer/precomp.h
+++ b/base/shell/explorer/precomp.h
@@ -133,7 +133,9 @@ HRESULT WINAPI _CBandSite_CreateInstance(LPUNKNOWN pUnkOuter, REFIID riid, void 
 #define TWM_OPENSTARTMENU (WM_USER + 260)
 #define TWM_SETTINGSCHANGED (WM_USER + 300)
 #define TWM_SETZORDER (WM_USER + 338)
-#define TWM_PULSE (WM_USER + 400)
+#define TWM_PULSE (WM_USER + 400) // wParam: type of pulse. lParam: target window
+#define PULSE_ACTIVATE 0
+#define PULSE_DESTROYED 1
 
 extern const GUID IID_IShellDesktopTray;
 

--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -2198,7 +2198,7 @@ public:
         case TIMER_ID_VALIDATE_RUDE_APP_2:
         case TIMER_ID_VALIDATE_RUDE_APP_3:
         case TIMER_ID_VALIDATE_RUDE_APP_4:
-            // Activation of rude app might take some time after HSHELL_...ACTIVATED.
+            // Real activation of rude app might take some time after HSHELL_...ACTIVATED.
             // Wait up to 5 seconds with validating the rude app at each second.
             {
                 HWND hwndRude = FindRudeApp(NULL);

--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -59,12 +59,12 @@ SHELL_GetMonitorRect(
         {
             if (bWorkAreaOnly)
             {
-                SystemParametersInfoW(SPI_GETWORKAREA, 0, prcDest, 0);
+                ::SystemParametersInfoW(SPI_GETWORKAREA, 0, prcDest, 0);
             }
             else
             {
-                SetRect(prcDest, 0, 0,
-                        GetSystemMetrics(SM_CXSCREEN), GetSystemMetrics(SM_CYSCREEN));
+                ::SetRect(prcDest, 0, 0,
+                          GetSystemMetrics(SM_CXSCREEN), GetSystemMetrics(SM_CYSCREEN));
             }
         }
         return FALSE;
@@ -119,7 +119,7 @@ SHELL_IsRudeWindow(_In_opt_ HMONITOR hMonitor, _In_ HWND hWnd, _In_ BOOL bDontCh
     }
     else
     {
-        GetWindowRect(hWnd, &rcWnd);
+        ::GetWindowRect(hWnd, &rcWnd);
     }
 
     RECT rcUnion;
@@ -1923,7 +1923,7 @@ public:
     {
         PRUDEAPPDATA pData = (PRUDEAPPDATA)lParam;
 
-        HMONITOR hMon = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
+        HMONITOR hMon = ::MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
         if (!hMon ||
             (pData->hTargetMonitor && pData->hTargetMonitor != hMon) ||
             !SHELL_IsRudeWindow(hMon, hwnd, (hwnd == pData->hwndFirstCheck)))
@@ -1987,7 +1987,7 @@ public:
         {
             DWORD exstyle = (DWORD)::GetWindowLongPtrW(hwndRude, GWL_EXSTYLE);
             if (!(exstyle & WS_EX_TOPMOST) && !SHELL_IsRudeWindowActive(hwndRude))
-                SwitchToThisWindow(hwndRude, TRUE);
+                ::SwitchToThisWindow(hwndRude, TRUE);
         }
 
         // FIXME: NIN_BALLOONHIDE

--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -2183,9 +2183,12 @@ public:
             {
                 HWND hwndRude = FindRudeApp(NULL);
                 HandleFullScreenApp(hwndRude);
-                DWORD exstyle = (DWORD)::GetWindowLongPtrW(hwndRude, GWL_EXSTYLE);
-                if (hwndRude && !(exstyle & WS_EX_TOPMOST) && !SHELL_IsRudeWindowActive(hwndRude))
-                    SwitchToThisWindow(hwndRude, TRUE);
+                if (hwndRude)
+                {
+                    DWORD exstyle = (DWORD)::GetWindowLongPtrW(hwndRude, GWL_EXSTYLE);
+                    if (!(exstyle & WS_EX_TOPMOST) && !SHELL_IsRudeWindowActive(hwndRude))
+                        SwitchToThisWindow(hwndRude, TRUE);
+                }
                 KillTimer(wParam);
                 if (!hwndRude && wParam < TIMER_ID_VALIDATE_RUDE_APP_4)
                     SetTimer(wParam + 1, 1000, NULL); // Next timer

--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -2183,6 +2183,8 @@ public:
         case TIMER_ID_VALIDATE_RUDE_APP_2:
         case TIMER_ID_VALIDATE_RUDE_APP_3:
         case TIMER_ID_VALIDATE_RUDE_APP_4:
+            // Activation of rude app might take some time after HSHELL_...ACTIVATED.
+            // Wait up to 5 seconds, and validate the rude app at each second.
             {
                 HWND hwndRude = FindRudeApp(NULL);
                 HandleFullScreenApp(hwndRude);

--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -1923,6 +1923,7 @@ public:
         return FALSE; // Finish
     }
 
+    // Internal structure for FullScreenEnumProc
     typedef struct tagFULLSCREENDATA
     {
         const RECT *pRect;

--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -1958,10 +1958,8 @@ public:
             bFullOpening = ::EqualRect(&rc, &rcMon);
         }
 
-        // We have to communicate with tray somehow, in order to notify ABN_FULLSCREENAPP.
-        // I decided to use newly-defined TWM_NOTIFYFULLSCREENAPP message (ReactOS-specific).
-        HWND hwndTray = pData->pTray->GetHWND();
-        ::PostMessageW(hwndTray, TWM_NOTIFYFULLSCREENAPP, (WPARAM)hMonitor, bFullOpening);
+        // Notify ABN_FULLSCREENAPP to appbars
+        pData->pTray->NotifyFullScreenToAppBars(hMonitor, bFullOpening);
         return TRUE;
     }
 

--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -35,11 +35,15 @@
 // Fullscreen windows (a.k.a. rude apps) checker
 
 // Timer IDs for validating rude apps
-#define TIMER_ID_VALIDATE_RUDE_APP_0 5
-#define TIMER_ID_VALIDATE_RUDE_APP_1 6
-#define TIMER_ID_VALIDATE_RUDE_APP_2 7
-#define TIMER_ID_VALIDATE_RUDE_APP_3 8
-#define TIMER_ID_VALIDATE_RUDE_APP_4 9
+enum
+{
+    TIMER_ID_VALIDATE_RUDE_APP_0 = 5,
+    TIMER_ID_VALIDATE_RUDE_APP_1,
+    TIMER_ID_VALIDATE_RUDE_APP_2,
+    TIMER_ID_VALIDATE_RUDE_APP_3,
+    TIMER_ID_VALIDATE_RUDE_APP_4,
+};
+
 #define VALIDATE_RUDE_INTERVAL 1000
 
 static BOOL
@@ -1559,6 +1563,12 @@ public:
     {
         m_IsDestroying = TRUE;
 
+        KillTimer(TIMER_ID_VALIDATE_RUDE_APP_0);
+        KillTimer(TIMER_ID_VALIDATE_RUDE_APP_1);
+        KillTimer(TIMER_ID_VALIDATE_RUDE_APP_2);
+        KillTimer(TIMER_ID_VALIDATE_RUDE_APP_3);
+        KillTimer(TIMER_ID_VALIDATE_RUDE_APP_4);
+
         /* Unregister the shell hook */
         RegisterShellHook(m_hWnd, FALSE);
 
@@ -1974,6 +1984,13 @@ public:
         else
             ::SetWindowPos(hwndTray, HWND_TOP, 0, 0, 0, 0, uFlags);
 
+        if (hwndRude)
+        {
+            DWORD exstyle = (DWORD)::GetWindowLongPtrW(hwndRude, GWL_EXSTYLE);
+            if (!(exstyle & WS_EX_TOPMOST) && !SHELL_IsRudeWindowActive(hwndRude))
+                SwitchToThisWindow(hwndRude, TRUE);
+        }
+
         // FIXME: NIN_BALLOONHIDE
         // FIXME: NIN_POPUPCLOSE
     }
@@ -2015,12 +2032,6 @@ public:
     {
         HWND hwndRude = FindRudeApp(hwndTarget);
         HandleFullScreenApp(hwndRude);
-        if (hwndRude)
-        {
-            DWORD exstyle = (DWORD)::GetWindowLongPtrW(hwndRude, GWL_EXSTYLE);
-            if (!(exstyle & WS_EX_TOPMOST) && !SHELL_IsRudeWindowActive(hwndRude))
-                SwitchToThisWindow(hwndRude, TRUE); // Not rude!
-        }
     }
 
     LRESULT OnEraseBackground(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
@@ -2193,12 +2204,6 @@ public:
             {
                 HWND hwndRude = FindRudeApp(NULL);
                 HandleFullScreenApp(hwndRude);
-                if (hwndRude)
-                {
-                    DWORD exstyle = (DWORD)::GetWindowLongPtrW(hwndRude, GWL_EXSTYLE);
-                    if (!(exstyle & WS_EX_TOPMOST) && !SHELL_IsRudeWindowActive(hwndRude))
-                        SwitchToThisWindow(hwndRude, TRUE);
-                }
                 KillTimer(wParam);
                 if (!hwndRude && wParam < TIMER_ID_VALIDATE_RUDE_APP_4)
                     SetTimer(wParam + 1, VALIDATE_RUDE_INTERVAL, NULL); // Next timer

--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -2181,10 +2181,10 @@ public:
                 HWND hwndRude = FindRudeApp(NULL);
                 HandleFullScreenApp(hwndRude);
 
-                // Retry with next timer id if any when no rude detected
+                // Check counter and retry when no rude app detected
                 KillTimer(wParam);
                 ++m_nRudeAppValidationCounter;
-                if (!hwndRude && m_nRudeAppValidationCounter < VALIDATE_RUDE_MAX_COUNT)
+                if (m_nRudeAppValidationCounter < VALIDATE_RUDE_MAX_COUNT && !hwndRude)
                     SetTimer(wParam, VALIDATE_RUDE_INTERVAL, NULL);
                 break;
             }

--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -1946,9 +1946,10 @@ public:
             bFullOpening = ::EqualRect(&rc, &rcMon);
         }
 
-        // We have to communicate with tray somehow.
-        // I decided to use newly-defined TWM_NOTIFYFULLSCREENAPP message.
-        ::PostMessageW(pData->pTray->GetHWND(), TWM_NOTIFYFULLSCREENAPP, (WPARAM)hMonitor, bFullOpening);
+        // We have to communicate with tray somehow, in order to notify ABN_FULLSCREENAPP.
+        // I decided to use newly-defined TWM_NOTIFYFULLSCREENAPP message (ReactOS-specific).
+        HWND hwndTray = pData->pTray->GetHWND();
+        ::PostMessageW(hwndTray, TWM_NOTIFYFULLSCREENAPP, (WPARAM)hMonitor, bFullOpening);
         return TRUE;
     }
 

--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -1674,7 +1674,6 @@ public:
         TaskItem = FindTaskItemByIndex((INT) wIndex);
         if (TaskItem != NULL)
         {
-            SendPulseToTray(0, TaskItem->hWnd);
             HandleTaskItemClick(TaskItem);
             return TRUE;
         }

--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -1933,7 +1933,7 @@ public:
 
     // Notify ABN_FULLSCREENAPP for each monitor
     static BOOL CALLBACK
-    FullScreenEnumProc(HMONITOR hMonitor, HDC hDC, LPRECT prc, LPARAM lParam)
+    FullScreenEnumProc(_In_ HMONITOR hMonitor, _In_opt_ HDC hDC, _In_ LPRECT prc, _In_ LPARAM lParam)
     {
         PFULLSCREENDATA pData = (PFULLSCREENDATA)lParam;
 
@@ -1953,7 +1953,7 @@ public:
         return TRUE;
     }
 
-    void HandleFullScreenApp(HWND hwndRude)
+    void HandleFullScreenApp(_In_opt_ HWND hwndRude)
     {
         // Notify ABN_FULLSCREENAPP for every monitor
         RECT rc;

--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -105,9 +105,8 @@ SHELL_IsRudeWindow(_In_opt_ HMONITOR hMonitor, _In_ HWND hWnd, _In_ BOOL bDontCh
 
     DWORD style = ::GetWindowLongPtrW(hWnd, GWL_STYLE);
 
-#define CHECK_STYLE (WS_THICKFRAME | WS_DLGFRAME | WS_BORDER)
-
     RECT rcWnd;
+    enum { CHECK_STYLE = WS_THICKFRAME | WS_DLGFRAME | WS_BORDER };
     if ((style & CHECK_STYLE) == CHECK_STYLE)
     {
         ::GetClientRect(hWnd, &rcWnd); // Ignore frame

--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -1559,15 +1559,17 @@ public:
         return TRUE;
     }
 
+    void KillValidateRudeTimers()
+    {
+        for (INT id = TIMER_ID_VALIDATE_RUDE_APP_0; id <= TIMER_ID_VALIDATE_RUDE_APP_4; ++id)
+            KillTimer(id);
+    }
+
     LRESULT OnDestroy(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
     {
         m_IsDestroying = TRUE;
 
-        KillTimer(TIMER_ID_VALIDATE_RUDE_APP_0);
-        KillTimer(TIMER_ID_VALIDATE_RUDE_APP_1);
-        KillTimer(TIMER_ID_VALIDATE_RUDE_APP_2);
-        KillTimer(TIMER_ID_VALIDATE_RUDE_APP_3);
-        KillTimer(TIMER_ID_VALIDATE_RUDE_APP_4);
+        KillValidateRudeTimers();
 
         /* Unregister the shell hook */
         RegisterShellHook(m_hWnd, FALSE);
@@ -2010,7 +2012,7 @@ public:
     LRESULT OnWindowPosChanged(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
     {
         // Re-start rude app validation
-        KillTimer(TIMER_ID_VALIDATE_RUDE_APP_0);
+        KillValidateRudeTimers();
         SetTimer(TIMER_ID_VALIDATE_RUDE_APP_0, VALIDATE_RUDE_INTERVAL, NULL);
         bHandled = FALSE;
         return 0;
@@ -2020,7 +2022,7 @@ public:
     void OnWindowActivated(_In_ HWND hwndTarget)
     {
         // Re-start rude app validation
-        KillTimer(TIMER_ID_VALIDATE_RUDE_APP_0);
+        KillValidateRudeTimers();
         SetTimer(TIMER_ID_VALIDATE_RUDE_APP_0, VALIDATE_RUDE_INTERVAL, NULL);
     }
 

--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -1994,6 +1994,7 @@ public:
     {
         // Start rude app validation
         SetTimer(TIMER_ID_VALIDATE_RUDE_APP_0, VALIDATE_RUDE_INTERVAL, NULL);
+        bHandled = FALSE;
         return 0;
     }
 

--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -1965,7 +1965,7 @@ public:
         Data.pTray = m_Tray;
         ::EnumDisplayMonitors(NULL, NULL, FullScreenEnumProc, (LPARAM)&Data);
 
-        // Bring up / sink taskbar
+        // Make the taskbar bottom or top
         UINT uFlags = SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_NOREPOSITION;
         HWND hwndTray = m_Tray->GetHWND();
         if (hwndRude)

--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -1944,7 +1944,7 @@ public:
             bFullOpening = ::EqualRect(&rc, &rcMon);
         }
 
-        ::PostMessage(pData->pTray->GetHWND(), TWM_NOTIFYFULLSCREENAPP, (WPARAM)hMonitor, bFullOpening);
+        ::PostMessageW(pData->pTray->GetHWND(), TWM_NOTIFYFULLSCREENAPP, (WPARAM)hMonitor, bFullOpening);
         return TRUE;
     }
 

--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -2188,7 +2188,7 @@ public:
         case TIMER_ID_VALIDATE_RUDE_APP_3:
         case TIMER_ID_VALIDATE_RUDE_APP_4:
             // Activation of rude app might take some time after HSHELL_...ACTIVATED.
-            // Wait up to 5 seconds, and validate the rude app at each second.
+            // Wait up to 5 seconds with validating the rude app at each second.
             {
                 HWND hwndRude = FindRudeApp(NULL);
                 HandleFullScreenApp(hwndRude);

--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -2181,7 +2181,6 @@ public:
                 HWND hwndRude = FindRudeApp(NULL);
                 HandleFullScreenApp(hwndRude);
 
-                // Check counter and retry when no rude app detected
                 KillTimer(wParam);
                 ++m_nRudeAppValidationCounter;
                 if (m_nRudeAppValidationCounter < VALIDATE_RUDE_MAX_COUNT && !hwndRude)

--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -40,6 +40,7 @@
 #define TIMER_ID_VALIDATE_RUDE_APP_2 7
 #define TIMER_ID_VALIDATE_RUDE_APP_3 8
 #define TIMER_ID_VALIDATE_RUDE_APP_4 9
+#define VALIDATE_RUDE_INTERVAL 1000
 
 static BOOL
 SHELL_GetMonitorRect(
@@ -1991,7 +1992,7 @@ public:
     LRESULT OnWindowPosChanged(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
     {
         // Start rude app validation
-        SetTimer(TIMER_ID_VALIDATE_RUDE_APP_0, 1000, NULL);
+        SetTimer(TIMER_ID_VALIDATE_RUDE_APP_0, VALIDATE_RUDE_INTERVAL, NULL);
         return 0;
     }
 
@@ -1999,7 +2000,7 @@ public:
     void OnWindowActivated(_In_ HWND hwndTarget)
     {
         // Start rude app validation
-        SetTimer(TIMER_ID_VALIDATE_RUDE_APP_0, 1000, NULL);
+        SetTimer(TIMER_ID_VALIDATE_RUDE_APP_0, VALIDATE_RUDE_INTERVAL, NULL);
     }
 
     // HSHELL_WINDOWDESTROYED
@@ -2191,7 +2192,7 @@ public:
                 }
                 KillTimer(wParam);
                 if (!hwndRude && wParam < TIMER_ID_VALIDATE_RUDE_APP_4)
-                    SetTimer(wParam + 1, 1000, NULL); // Next timer
+                    SetTimer(wParam + 1, VALIDATE_RUDE_INTERVAL, NULL); // Next timer
                 break;
             }
         }

--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -74,15 +74,12 @@ SHELL_GetMonitorRect(
 static BOOL
 SHELL_IsParentOwnerOrSelf(_In_ HWND hwndTarget, _In_ HWND hWnd)
 {
-    for (;;)
+    for (; hWnd; hWnd = ::GetParent(hWnd))
     {
-        if (!hWnd)
-            return FALSE;
         if (hWnd == hwndTarget)
-            break;
-        hWnd = ::GetParent(hWnd);
+            return TRUE;
     }
-    return TRUE;
+    return FALSE;
 }
 
 static BOOL

--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -55,18 +55,14 @@ SHELL_GetMonitorRect(
     MONITORINFO mi = { sizeof(mi) };
     if (!hMonitor || !::GetMonitorInfoW(hMonitor, &mi))
     {
-        if (prcDest)
-        {
-            if (bWorkAreaOnly)
-            {
-                ::SystemParametersInfoW(SPI_GETWORKAREA, 0, prcDest, 0);
-            }
-            else
-            {
-                ::SetRect(prcDest, 0, 0,
-                          GetSystemMetrics(SM_CXSCREEN), GetSystemMetrics(SM_CYSCREEN));
-            }
-        }
+        if (!prcDest)
+            return FALSE;
+
+        if (bWorkAreaOnly)
+            ::SystemParametersInfoW(SPI_GETWORKAREA, 0, prcDest, 0);
+        else
+            ::SetRect(prcDest, 0, 0, GetSystemMetrics(SM_CXSCREEN), GetSystemMetrics(SM_CYSCREEN));
+
         return FALSE;
     }
 

--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -1977,7 +1977,7 @@ public:
         ::EnumDisplayMonitors(NULL, NULL, FullScreenEnumProc, (LPARAM)&Data);
 
         // Make the taskbar bottom or top
-        UINT uFlags = SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_NOREPOSITION;
+        UINT uFlags = SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_NOOWNERZORDER;
         HWND hwndTray = m_Tray->GetHWND();
         ::SetWindowPos(hwndTray, (hwndRude ? HWND_BOTTOM : HWND_TOP), 0, 0, 0, 0, uFlags);
 

--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -1979,10 +1979,7 @@ public:
         // Make the taskbar bottom or top
         UINT uFlags = SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_NOREPOSITION;
         HWND hwndTray = m_Tray->GetHWND();
-        if (hwndRude)
-            ::SetWindowPos(hwndTray, HWND_BOTTOM, 0, 0, 0, 0, uFlags);
-        else
-            ::SetWindowPos(hwndTray, HWND_TOP, 0, 0, 0, 0, uFlags);
+        ::SetWindowPos(hwndTray, (hwndRude ? HWND_BOTTOM : HWND_TOP), 0, 0, 0, 0, uFlags);
 
         if (hwndRude)
         {

--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -2170,14 +2170,14 @@ public:
         switch (wParam)
         {
 #if DUMP_TASKS != 0
-        case 1:
-            DumpTasks();
-            break;
+            case 1:
+                DumpTasks();
+                break;
 #endif
-        case TIMER_ID_VALIDATE_RUDE_APP:
-            // Real activation of rude app might take some time after HSHELL_...ACTIVATED.
-            // Wait up to 5 seconds with validating the rude app at each second.
+            case TIMER_ID_VALIDATE_RUDE_APP:
             {
+                // Real activation of rude app might take some time after HSHELL_...ACTIVATED.
+                // Wait up to 5 seconds with validating the rude app at each second.
                 HWND hwndRude = FindRudeApp(NULL);
                 HandleFullScreenApp(hwndRude);
 
@@ -2186,6 +2186,11 @@ public:
                 ++m_nRudeAppValidationCounter;
                 if (m_nRudeAppValidationCounter < VALIDATE_RUDE_MAX_COUNT && !hwndRude)
                     SetTimer(wParam, VALIDATE_RUDE_INTERVAL, NULL);
+                break;
+            }
+            default:
+            {
+                WARN("Unknown timer ID: %p\n", wParam);
                 break;
             }
         }

--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -1946,6 +1946,8 @@ public:
             bFullOpening = ::EqualRect(&rc, &rcMon);
         }
 
+        // We have to communicate with tray somehow.
+        // I decided to use newly-defined TWM_NOTIFYFULLSCREENAPP message.
         ::PostMessageW(pData->pTray->GetHWND(), TWM_NOTIFYFULLSCREENAPP, (WPARAM)hMonitor, bFullOpening);
         return TRUE;
     }
@@ -1992,7 +1994,8 @@ public:
     // WM_WINDOWPOSCHANGED
     LRESULT OnWindowPosChanged(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
     {
-        // Start rude app validation
+        // Re-start rude app validation
+        KillTimer(TIMER_ID_VALIDATE_RUDE_APP_0);
         SetTimer(TIMER_ID_VALIDATE_RUDE_APP_0, VALIDATE_RUDE_INTERVAL, NULL);
         bHandled = FALSE;
         return 0;
@@ -2001,7 +2004,8 @@ public:
     // HSHELL_WINDOWACTIVATED, HSHELL_RUDEAPPACTIVATED
     void OnWindowActivated(_In_ HWND hwndTarget)
     {
-        // Start rude app validation
+        // Re-start rude app validation
+        KillTimer(TIMER_ID_VALIDATE_RUDE_APP_0);
         SetTimer(TIMER_ID_VALIDATE_RUDE_APP_0, VALIDATE_RUDE_INTERVAL, NULL);
     }
 

--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -2200,6 +2200,7 @@ public:
         case TIMER_ID_VALIDATE_RUDE_APP_4:
             // Real activation of rude app might take some time after HSHELL_...ACTIVATED.
             // Wait up to 5 seconds with validating the rude app at each second.
+            // This is the same behavior as Windows Explorer.
             {
                 HWND hwndRude = FindRudeApp(NULL);
                 HandleFullScreenApp(hwndRude);

--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -1472,10 +1472,10 @@ public:
         return TRUE;
     }
 
-    VOID SendPulseToTray(BOOL bDelete, HWND hwndActive)
+    VOID SendPulseToTray(UINT uType, HWND hwndActive)
     {
         HWND hwndTray = m_Tray->GetHWND();
-        ::SendMessage(hwndTray, TWM_PULSE, bDelete, (LPARAM)hwndActive);
+        ::PostMessage(hwndTray, TWM_PULSE, uType, (LPARAM)hwndActive);
     }
 
     static BOOL InvokeRegistryAppKeyCommand(UINT uAppCmd)
@@ -1554,19 +1554,19 @@ public:
             break;
 
         case HSHELL_WINDOWCREATED:
-            SendPulseToTray(FALSE, (HWND)lParam);
+            SendPulseToTray((UINT)wParam, (HWND)lParam);
             AddTask((HWND) lParam);
             break;
 
         case HSHELL_WINDOWDESTROYED:
             /* The window still exists! Delay destroying it a bit */
-            SendPulseToTray(TRUE, (HWND)lParam);
+            SendPulseToTray((UINT)wParam, (HWND)lParam);
             DeleteTask((HWND)lParam);
             break;
 
         case HSHELL_RUDEAPPACTIVATED:
         case HSHELL_WINDOWACTIVATED:
-            SendPulseToTray(FALSE, (HWND)lParam);
+            SendPulseToTray((UINT)wParam, (HWND)lParam);
             ActivateTask((HWND)lParam);
             break;
 
@@ -1674,7 +1674,7 @@ public:
         TaskItem = FindTaskItemByIndex((INT) wIndex);
         if (TaskItem != NULL)
         {
-            SendPulseToTray(FALSE, TaskItem->hWnd);
+            SendPulseToTray(0, TaskItem->hWnd);
             HandleTaskItemClick(TaskItem);
             return TRUE;
         }

--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -2202,9 +2202,11 @@ public:
             {
                 HWND hwndRude = FindRudeApp(NULL);
                 HandleFullScreenApp(hwndRude);
+
+                // Retry with next timer id if any when no rude detected
                 KillTimer(wParam);
                 if (!hwndRude && wParam < TIMER_ID_VALIDATE_RUDE_APP_4)
-                    SetTimer(wParam + 1, VALIDATE_RUDE_INTERVAL, NULL); // Next timer
+                    SetTimer(wParam + 1, VALIDATE_RUDE_INTERVAL, NULL);
                 break;
             }
         }

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -3318,25 +3318,30 @@ HandleTrayContextMenu:
 
     LRESULT OnTimer(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
     {
-        if (wParam == TIMER_ID_MOUSETRACK)
+        switch (wParam)
         {
-            ProcessMouseTracking();
-        }
-        else if (wParam == TIMER_ID_AUTOHIDE)
-        {
-            ProcessAutoHide();
-        }
-        else if (TIMER_ID_DETECT_RUDE_APP_0 <= wParam && wParam <= TIMER_ID_DETECT_RUDE_APP_4)
-        {
-            // Wait 5 seconds for rude app detection
-            HWND hwndRude = FindRudeApp(NULL);
-            HandleFullScreenApp(hwndRude);
-            DWORD exstyle = (DWORD)::GetWindowLongPtrW(hwndRude, GWL_EXSTYLE);
-            if (hwndRude && !(exstyle & WS_EX_TOPMOST) && !SHELL_IsRudeWindowActive(hwndRude))
-                SwitchToThisWindow(hwndRude, TRUE);
-            KillTimer(wParam);
-            if (!hwndRude && wParam < TIMER_ID_DETECT_RUDE_APP_4)
-                SetTimer(wParam + 1, 1000, NULL);
+            case TIMER_ID_MOUSETRACK:
+                ProcessMouseTracking();
+                break;
+            case TIMER_ID_AUTOHIDE:
+                ProcessAutoHide();
+                break;
+            case TIMER_ID_DETECT_RUDE_APP_0:
+            case TIMER_ID_DETECT_RUDE_APP_1:
+            case TIMER_ID_DETECT_RUDE_APP_2:
+            case TIMER_ID_DETECT_RUDE_APP_3:
+            case TIMER_ID_DETECT_RUDE_APP_4:
+            {
+                HWND hwndRude = FindRudeApp(NULL);
+                HandleFullScreenApp(hwndRude);
+                DWORD exstyle = (DWORD)::GetWindowLongPtrW(hwndRude, GWL_EXSTYLE);
+                if (hwndRude && !(exstyle & WS_EX_TOPMOST) && !SHELL_IsRudeWindowActive(hwndRude))
+                    SwitchToThisWindow(hwndRude, TRUE);
+                KillTimer(wParam);
+                if (!hwndRude && wParam < TIMER_ID_DETECT_RUDE_APP_4)
+                    SetTimer(wParam + 1, 1000, NULL);
+                break;
+            }
         }
         return 0;
     }

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -17,12 +17,12 @@ HRESULT TrayWindowCtxMenuCreator(ITrayWindow * TrayWnd, IN HWND hWndOwner, ICont
 #define TIMER_ID_AUTOHIDE 1
 #define TIMER_ID_MOUSETRACK 2
 
-// Timer IDs for rude apps detection
-#define TIMER_ID_DETECT_RUDE_APP_0 5
-#define TIMER_ID_DETECT_RUDE_APP_1 6
-#define TIMER_ID_DETECT_RUDE_APP_2 7
-#define TIMER_ID_DETECT_RUDE_APP_3 8
-#define TIMER_ID_DETECT_RUDE_APP_4 9
+// Timer IDs for validating rude apps
+#define TIMER_ID_VALIDATE_RUDE_APP_0 5
+#define TIMER_ID_VALIDATE_RUDE_APP_1 6
+#define TIMER_ID_VALIDATE_RUDE_APP_2 7
+#define TIMER_ID_VALIDATE_RUDE_APP_3 8
+#define TIMER_ID_VALIDATE_RUDE_APP_4 9
 
 #define MOUSETRACK_INTERVAL 100
 #define AUTOHIDE_DELAY_HIDE 2000
@@ -3166,8 +3166,8 @@ HandleTrayContextMenu:
     // HSHELL_WINDOWACTIVATED, HSHELL_RUDEAPPACTIVATED
     void OnWindowActivated(_In_ HWND hwndTarget)
     {
-        // Start rude apps detection
-        SetTimer(TIMER_ID_DETECT_RUDE_APP_0, 1000, NULL);
+        // Start rude app validation
+        SetTimer(TIMER_ID_VALIDATE_RUDE_APP_0, 1000, NULL);
     }
 
     // HSHELL_WINDOWDESTROYED
@@ -3186,8 +3186,8 @@ HandleTrayContextMenu:
     // WM_WINDOWPOSCHANGED
     LRESULT OnWindowPosChanged(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
     {
-        // Start rude apps detection
-        SetTimer(TIMER_ID_DETECT_RUDE_APP_0, 1000, NULL);
+        // Start rude app validation
+        SetTimer(TIMER_ID_VALIDATE_RUDE_APP_0, 1000, NULL);
         return 0;
     }
 
@@ -3336,11 +3336,11 @@ HandleTrayContextMenu:
             case TIMER_ID_AUTOHIDE:
                 ProcessAutoHide();
                 break;
-            case TIMER_ID_DETECT_RUDE_APP_0:
-            case TIMER_ID_DETECT_RUDE_APP_1:
-            case TIMER_ID_DETECT_RUDE_APP_2:
-            case TIMER_ID_DETECT_RUDE_APP_3:
-            case TIMER_ID_DETECT_RUDE_APP_4:
+            case TIMER_ID_VALIDATE_RUDE_APP_0:
+            case TIMER_ID_VALIDATE_RUDE_APP_1:
+            case TIMER_ID_VALIDATE_RUDE_APP_2:
+            case TIMER_ID_VALIDATE_RUDE_APP_3:
+            case TIMER_ID_VALIDATE_RUDE_APP_4:
             {
                 HWND hwndRude = FindRudeApp(NULL);
                 HandleFullScreenApp(hwndRude);
@@ -3348,7 +3348,7 @@ HandleTrayContextMenu:
                 if (hwndRude && !(exstyle & WS_EX_TOPMOST) && !SHELL_IsRudeWindowActive(hwndRude))
                     SwitchToThisWindow(hwndRude, TRUE);
                 KillTimer(wParam);
-                if (!hwndRude && wParam < TIMER_ID_DETECT_RUDE_APP_4)
+                if (!hwndRude && wParam < TIMER_ID_VALIDATE_RUDE_APP_4)
                     SetTimer(wParam + 1, 1000, NULL); // Next timer
                 break;
             }

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -3339,7 +3339,7 @@ HandleTrayContextMenu:
                     SwitchToThisWindow(hwndRude, TRUE);
                 KillTimer(wParam);
                 if (!hwndRude && wParam < TIMER_ID_DETECT_RUDE_APP_4)
-                    SetTimer(wParam + 1, 1000, NULL);
+                    SetTimer(wParam + 1, 1000, NULL); // Next timer
                 break;
             }
         }

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -3189,7 +3189,7 @@ HandleTrayContextMenu:
                 OnWindowDestroyed(hwndTarget);
                 break;
             default:
-                WARN("%p\n", wParam);
+                WARN("%u\n", (UINT)wParam);
                 break;
         }
         return 0;

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -178,7 +178,7 @@ struct MINWNDPOS
 CSimpleArray<MINWNDPOS>  g_MinimizedAll;
 
 //************************************************************************
-// Fullscreen windows (a.k.a rude apps) checker
+// Fullscreen windows (a.k.a. rude apps) checker
 
 static BOOL
 SHELL_GetMonitorRect(HMONITOR hMonitor, PRECT prcDest, BOOL bWorkAreaOnly)

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -3038,7 +3038,10 @@ HandleTrayContextMenu:
                               SWP_NOOWNERZORDER | SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE);
     }
 
-    // TWM_NOTIFYFULLSCREENAPP
+    // TWM_NOTIFYFULLSCREENAPP (ReactOS-specific)
+    // @param wParam The target monitor.
+    // @param lParam A BOOL flag that indicates whether the rude app is shown or not.
+    // @return Zero.
     LRESULT OnNotifyFullScreenApp(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
     {
         HMONITOR hMonitor = (HMONITOR)wParam;
@@ -3166,7 +3169,7 @@ HandleTrayContextMenu:
                 ProcessAutoHide();
                 break;
             default:
-                WARN("wParam: %p\n", (void *)wParam);
+                WARN("Invalid timer ID: %u\n", (UINT)wParam);
                 break;
         }
         return 0;

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -3161,6 +3161,7 @@ HandleTrayContextMenu:
                 break;
             default:
                 WARN("Invalid timer ID: %u\n", (UINT)wParam);
+                bHandled = FALSE;
                 break;
         }
         return 0;

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -16,7 +16,6 @@ HRESULT TrayWindowCtxMenuCreator(ITrayWindow * TrayWnd, IN HWND hWndOwner, ICont
 
 #define TIMER_ID_AUTOHIDE 1
 #define TIMER_ID_MOUSETRACK 2
-
 #define MOUSETRACK_INTERVAL 100
 #define AUTOHIDE_DELAY_HIDE 2000
 #define AUTOHIDE_DELAY_SHOW 50
@@ -170,8 +169,11 @@ struct MINWNDPOS
 };
 CSimpleArray<MINWNDPOS>  g_MinimizedAll;
 
-//************************************************************************
-// CStartButton
+/*
+ * ITrayWindow
+ */
+
+const GUID IID_IShellDesktopTray = { 0x213e2df9, 0x9a14, 0x4328, { 0x99, 0xb1, 0x69, 0x61, 0xf9, 0x14, 0x3c, 0xe9 } };
 
 class CStartButton
     : public CWindowImpl<CStartButton>
@@ -299,11 +301,6 @@ public:
         MESSAGE_HANDLER(WM_LBUTTONDOWN, OnLButtonDown)
     END_MSG_MAP()
 };
-
-//************************************************************************
-// CTrayWindow
-
-const GUID IID_IShellDesktopTray = { 0x213e2df9, 0x9a14, 0x4328, { 0x99, 0xb1, 0x69, 0x61, 0xf9, 0x14, 0x3c, 0xe9 } };
 
 class CTrayWindow :
     public CComCoClass<CTrayWindow>,
@@ -3586,9 +3583,6 @@ protected:
         SetWindowPos(hwndInsertAfter, 0, 0, 0, 0, SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE);
     }
 };
-
-//************************************************************************
-// CTrayWindowCtxMenu
 
 class CTrayWindowCtxMenu :
     public CComCoClass<CTrayWindowCtxMenu>,

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -3181,8 +3181,6 @@ HandleTrayContextMenu:
         HWND hwndTarget = (HWND)lParam;
         switch (wParam)
         {
-            case 0:
-                break;
             case HSHELL_RUDEAPPACTIVATED:
             case HSHELL_WINDOWACTIVATED:
                 OnWindowActivated(hwndTarget);

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -190,7 +190,17 @@ SHELL_GetMonitorRect(
     if (!hMonitor || !::GetMonitorInfoW(hMonitor, &mi))
     {
         if (prcDest)
-            SetRect(prcDest, 0, 0, GetSystemMetrics(SM_CXSCREEN), GetSystemMetrics(SM_CYSCREEN));
+        {
+            if (bWorkAreaOnly)
+            {
+                SystemParametersInfoW(SPI_GETWORKAREA, 0, prcDest, 0);
+            }
+            else
+            {
+                SetRect(prcDest, 0, 0,
+                        GetSystemMetrics(SM_CXSCREEN), GetSystemMetrics(SM_CYSCREEN));
+            }
+        }
         return FALSE;
     }
 

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -3165,6 +3165,9 @@ HandleTrayContextMenu:
             case TIMER_ID_AUTOHIDE:
                 ProcessAutoHide();
                 break;
+            default:
+                WARN("wParam: %p\n", (void *)wParam);
+                break;
         }
         return 0;
     }

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -3035,16 +3035,10 @@ HandleTrayContextMenu:
                               SWP_NOOWNERZORDER | SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE);
     }
 
-    // TWM_NOTIFYFULLSCREENAPP (ReactOS-specific)
-    // @param wParam The target monitor.
-    // @param lParam A BOOL flag that indicates whether the rude app is shown or not.
-    // @return Zero.
-    LRESULT OnNotifyFullScreenApp(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
+    STDMETHODIMP NotifyFullScreenToAppBars(HMONITOR hMonitor, BOOL bFullOpening) override
     {
-        HMONITOR hMonitor = (HMONITOR)wParam;
-        BOOL bFullOpening = (BOOL)lParam;
         OnAppBarNotifyAll(hMonitor, NULL, ABN_FULLSCREENAPP, bFullOpening);
-        return 0;
+        return S_OK;
     }
 
     LRESULT OnHotkey(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
@@ -3416,7 +3410,6 @@ HandleTrayContextMenu:
         MESSAGE_HANDLER(TWM_DOEXITWINDOWS, OnDoExitWindows)
         MESSAGE_HANDLER(TWM_GETTASKSWITCH, OnGetTaskSwitch)
         MESSAGE_HANDLER(TWM_SETZORDER, OnSetZOrder)
-        MESSAGE_HANDLER(TWM_NOTIFYFULLSCREENAPP, OnNotifyFullScreenApp)
     ALT_MSG_MAP(1)
     END_MSG_MAP()
 


### PR DESCRIPTION
## Purpose
Adds support for handling fullscreen applications (a.k.a. “rude apps”) so the taskbar can hide or show appropriately.

JIRA issue: [CORE-11242](https://jira.reactos.org/browse/CORE-11242)

## Proposed changes

Adds support for detecting “rude” fullscreen applications and hiding or showing the taskbar accordingly.

- Removes legacy pulse/timer logic in the tray window and adds a fullscreen notification workflow.
- Implements fullscreen detection across monitors in the task switcher, using a sequence of validation timers.
- Defines a new `ITrayWindow::NotifyFullScreenToAppBars` interface method to broadcast fullscreen state to appbars.

## Screenshots

BEFORE:
![before](https://github.com/user-attachments/assets/48a93222-5975-4082-a7c8-5fddd41ca026)

AFTER:
![after](https://github.com/user-attachments/assets/41bd65ad-b580-49c5-a8ad-aab7e4e0a09c)
## TODO

- [x] Test `Win+D`
- [x] Test `Win+M`
- [x] Test task switching
- [x] Window activation
- [x] Cursor position and visibility
- [x] Top-most windows
- [x] Test rude apps
    - [x] [CORE-15681](https://jira.reactos.org/browse/CORE-15681) by oleg-dubinskiy.
    - [x] [CORE-16056](https://jira.reactos.org/browse/CORE-16056) by katahiromz.
    - [x] [CORE-16063](https://jira.reactos.org/browse/CORE-16063) by katahiromz.
    - [ ] [CORE-16104](https://jira.reactos.org/browse/CORE-16104) It won't start up. FAILED.
    - [ ] [CORE-16129](https://jira.reactos.org/browse/CORE-16129) Opera is not responding. FAILED.
    - [x] [CORE-16131](https://jira.reactos.org/browse/CORE-16131) by katahiromz.
    - [x] [CORE-16132](https://jira.reactos.org/browse/CORE-16132) by katahiromz.
    - [x] [CORE-16192](https://jira.reactos.org/browse/CORE-16192) by katahiromz.
    - [x] [CORE-16196](https://jira.reactos.org/browse/CORE-16196) by katahiromz.
    - [x] [CORE-16249](https://jira.reactos.org/browse/CORE-16249) by katahiromz.
    - [x] [CORE-16290](https://jira.reactos.org/browse/CORE-16290) by katahiromz.
    - [x] [CORE-16313](https://jira.reactos.org/browse/CORE-16313) by katahiromz.
    - [x] [CORE-16320](https://jira.reactos.org/browse/CORE-16320) by katahiromz.
    - [x] [CORE-16322](https://jira.reactos.org/browse/CORE-16322) by katahiromz.
    - [x] [CORE-16347](https://jira.reactos.org/browse/CORE-16347) by katahiromz.
    - [x] [CORE-16584](https://jira.reactos.org/browse/CORE-16584) by katahiromz.
    - [x] [CORE-19795](https://jira.reactos.org/browse/CORE-19795) by katahiromz.
    - [ ] [CORE-16443](https://jira.reactos.org/browse/CORE-16443) I don't have PowerPoint.
    - [x] [CORE-9862](https://jira.reactos.org/browse/CORE-9862) by katahiromz.
    - [x] [CORE-16230](https://jira.reactos.org/browse/CORE-16230) by katahiromz.
    - [x] [CORE-10738](https://jira.reactos.org/browse/CORE-10738) by katahiromz.
    - [x] [CORE-12263](https://jira.reactos.org/browse/CORE-12263) by katahiromz.

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=102446,102457
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=102447,102459