### PR TITLE
[NTUSER] Fix improper desktop wallpaper painting

### DIFF
--- a/win32ss/user/ntuser/desktop.c
+++ b/win32ss/user/ntuser/desktop.c
@@ -1848,6 +1848,281 @@ IntFreeDesktopHeap(IN OUT PDESKTOP Desktop)
 #endif
 }
 
+static VOID
+IntCalcWallpaperCoordinates(
+    _Out_ PSIZE pszSrc,
+    _Out_ PSIZE pszDst,
+    _Out_ PSIZE pszDesk,
+    _Out_ PPOINT pptSrc,
+    _Out_ PPOINT pptDst)
+{
+    int x, y;
+    POINT ptSrc, ptDst;
+    SIZE szDesk, szSrc, szDst;
+    int scaledWidth, scaledHeight;
+    int wallpaperX, wallpaperY, wallpaperWidth, wallpaperHeight;
+    PWND WndDesktop = UserGetDesktopWindow();
+
+    szDesk.cx = WndDesktop->rcWindow.right - WndDesktop->rcWindow.left;
+    szDesk.cy = WndDesktop->rcWindow.bottom - WndDesktop->rcWindow.top;
+
+    if (gspv.WallpaperMode == wmFit ||
+        gspv.WallpaperMode == wmFill)
+    {
+        int scaleNum, scaleDen;
+
+        /* Precision improvement over ((sz.cx / gspv.cxWallpaper) > (sz.cy / gspv.cyWallpaper)) */
+        if ((szDesk.cx * gspv.cyWallpaper) > (szDesk.cy * gspv.cxWallpaper))
+        {
+            if (gspv.WallpaperMode == wmFit)
+            {
+                scaleNum = szDesk.cy;
+                scaleDen = gspv.cyWallpaper;
+            }
+            else
+            {
+                scaleNum = szDesk.cx;
+                scaleDen = gspv.cxWallpaper;
+            }
+        }
+        else
+        {
+            if (gspv.WallpaperMode == wmFit)
+            {
+                scaleNum = szDesk.cx;
+                scaleDen = gspv.cxWallpaper;
+            }
+            else
+            {
+                scaleNum = szDesk.cy;
+                scaleDen = gspv.cyWallpaper;
+            }
+        }
+
+        scaledWidth = EngMulDiv(gspv.cxWallpaper, scaleNum, scaleDen);
+        scaledHeight = EngMulDiv(gspv.cyWallpaper, scaleNum, scaleDen);
+    }
+
+    if (gspv.WallpaperMode == wmStretch ||
+        gspv.WallpaperMode == wmTile ||
+        gspv.WallpaperMode == wmFill)
+    {
+        x = 0;
+        y = 0;
+    }
+    else if (gspv.WallpaperMode == wmFit)
+    {
+        x = (szDesk.cx - scaledWidth) / 2;
+        y = (szDesk.cy - scaledHeight) / 2;
+    }
+    else
+    {
+        /* Find the upper left corner, can be negative if the bitmap is bigger than the screen */
+        x = (szDesk.cx / 2) - (gspv.cxWallpaper / 2);
+        y = (szDesk.cy / 2) - (gspv.cyWallpaper / 2);
+    }
+
+    if (gspv.WallpaperMode == wmTile)
+    {
+        szSrc.cx = 0; // not used
+        szSrc.cy = 0; // not used
+        szDst.cx = gspv.cxWallpaper;
+        szDst.cy = gspv.cyWallpaper;
+        ptSrc.x = 0;
+        ptSrc.y = 0;
+    }
+    else if (gspv.WallpaperMode == wmStretch)
+    {
+        szSrc.cx = gspv.cxWallpaper;
+        szSrc.cy = gspv.cyWallpaper;
+        szDst.cx = szDesk.cx;
+        szDst.cy = szDesk.cy;
+        ptSrc.x = 0;
+        ptSrc.y = 0;
+    }
+    else if (gspv.WallpaperMode == wmFit)
+    {
+        szSrc.cx = gspv.cxWallpaper;
+        szSrc.cy = gspv.cyWallpaper;
+        szDst.cx = scaledWidth;
+        szDst.cy = scaledHeight;
+        ptSrc.x = 0;
+        ptSrc.y = 0;
+    }
+    else if (gspv.WallpaperMode == wmFill)
+    {
+        wallpaperX = (((scaledWidth - szDesk.cx) * gspv.cxWallpaper) / (2 * scaledWidth));
+        wallpaperY = (((scaledHeight - szDesk.cy) * gspv.cyWallpaper) / (2 * scaledHeight));
+
+        wallpaperWidth = (szDesk.cx * gspv.cxWallpaper) / scaledWidth;
+        wallpaperHeight = (szDesk.cy * gspv.cyWallpaper) / scaledHeight;
+
+        szSrc.cx = wallpaperWidth;
+        szSrc.cy = wallpaperHeight;
+        szDst.cx = szDesk.cx;
+        szDst.cy = szDesk.cy;
+        ptSrc.x = wallpaperX;
+        ptSrc.y = wallpaperY;
+    }
+    else if (gspv.WallpaperMode == wmCenter)
+    {
+        szSrc.cx = 0; // not used
+        szSrc.cy = 0; // not used
+        szDst.cx = gspv.cxWallpaper;
+        szDst.cy = gspv.cyWallpaper;
+        ptSrc.x = 0;
+        ptSrc.y = 0;
+    }
+    ptDst.x = x;
+    ptDst.y = y;
+
+    *pszSrc = szSrc;
+    *pszDst = szDst;
+    *pszDesk = szDesk;
+    *pptSrc = ptSrc;
+    *pptDst = ptDst;
+}
+
+HBITMAP
+IntStretchWallpaper(_In_ HBITMAP hBitmap)
+{
+    if (hBitmap)
+    {
+        HDC hWallpaperDC;
+        HBITMAP hNewBitmap;
+        POINT ptSrc, ptDst;
+        SIZE szDesk, szSrc, szDst;
+
+        IntCalcWallpaperCoordinates(&szSrc, &szDst, &szDesk, &ptSrc, &ptDst);
+
+        hWallpaperDC = NtGdiCreateCompatibleDC(ScreenDeviceContext);
+        if (hWallpaperDC)
+        {
+            hNewBitmap = NtGdiCreateCompatibleBitmap(ScreenDeviceContext, szDesk.cx, szDesk.cy);
+            if (hNewBitmap)
+            {
+                HBITMAP hOldBitmap1, hOldBitmap2;
+
+                hOldBitmap1 = NtGdiSelectBitmap(hSystemBM, hNewBitmap);
+                hOldBitmap2 = NtGdiSelectBitmap(hWallpaperDC, hBitmap);
+
+                /*
+                 * Stretch the bitmap to the required coordinates
+                 * on the system memory DC first,
+                 * and then simply blit the result to an ouput hDC
+                 * to show the bitmap on the desktop.
+                 * Fixes improper wallpaper painting.
+                 */
+                NtGdiStretchBlt(hSystemBM,
+                                ptDst.x,
+                                ptDst.y,
+                                szDst.cx,
+                                szDst.cy,
+                                hWallpaperDC,
+                                ptSrc.x,
+                                ptSrc.y,
+                                szSrc.cx,
+                                szSrc.cy,
+                                SRCCOPY,
+                                0);
+
+                NtGdiSelectBitmap(hSystemBM, hOldBitmap1);
+                NtGdiSelectBitmap(hWallpaperDC, hOldBitmap2);
+                NtGdiDeleteObjectApp(hWallpaperDC);
+                NtGdiDeleteObjectApp(hBitmap);
+                GreSetBitmapOwner(hNewBitmap, GDI_OBJ_HMGR_PUBLIC);
+                return hNewBitmap;
+            }
+            NtGdiDeleteObjectApp(hWallpaperDC);
+        }
+    }
+    return NULL;
+}
+
+static BOOL
+IntPaintWallpaper(HDC hDC, PWND pwndDesktop)
+{
+    HBRUSH DesktopBrush, PreviousBrush;
+    HBITMAP hOldBitmap;
+    POINT ptSrc, ptDst;
+    SIZE szDesk, szSrc, szDst;
+    RECT Rect;
+
+    if (GdiGetClipBox(hDC, &Rect) == ERROR)
+        return FALSE;
+
+    DesktopBrush = (HBRUSH)pwndDesktop->pcls->hbrBackground;
+
+    IntCalcWallpaperCoordinates(&szSrc, &szDst, &szDesk, &ptSrc, &ptDst);
+
+    /* Fill in the area that the bitmap is not going to cover */
+    if (ptDst.x > 0 || ptDst.y > 0)
+    {
+        /* FIXME: Clip out the bitmap
+           can be replaced with "NtGdiPatBlt(hDC, x, y, gspv.cxWallpaper, gspv.cyWallpaper, PATCOPY | DSTINVERT);"
+           once we support DSTINVERT */
+        PreviousBrush = NtGdiSelectBrush(hDC, DesktopBrush);
+        NtGdiPatBlt(hDC, Rect.left, Rect.top, Rect.right, Rect.bottom, PATCOPY);
+        NtGdiSelectBrush(hDC, PreviousBrush);
+    }
+
+    hOldBitmap = NtGdiSelectBitmap(hSystemBM, gspv.hbmWallpaper);
+
+    if (gspv.WallpaperMode == wmStretch ||
+        gspv.WallpaperMode == wmFit ||
+        gspv.WallpaperMode == wmFill)
+    {
+        NtGdiBitBlt(hDC,
+                    ptDst.x,
+                    ptDst.y,
+                    szDst.cx,
+                    szDst.cy,
+                    hSystemBM,
+                    ptDst.x,
+                    ptDst.y,
+                    SRCCOPY,
+                    CLR_INVALID,
+                    0);
+    }
+    else if (gspv.WallpaperMode == wmTile)
+    {
+        /* Paint the bitmap across the screen then down */
+        for (int y = 0; y < Rect.bottom; y += gspv.cyWallpaper)
+        {
+            for (int x = 0; x < Rect.right; x += gspv.cxWallpaper)
+            {
+                NtGdiBitBlt(hDC,
+                            x,
+                            y,
+                            szDst.cx,
+                            szDst.cy,
+                            hSystemBM,
+                            ptSrc.x,
+                            ptSrc.y,
+                            SRCCOPY,
+                            CLR_INVALID,
+                            0);
+            }
+        }
+    }
+    else /* wmCenter */
+    {
+        NtGdiBitBlt(hDC,
+                    ptDst.x,
+                    ptDst.y,
+                    szDst.cx,
+                    szDst.cy,
+                    hSystemBM,
+                    ptSrc.x,
+                    ptSrc.y,
+                    SRCCOPY,
+                    CLR_INVALID,
+                    0);
+    }
+    NtGdiSelectBitmap(hSystemBM, hOldBitmap);
+    return TRUE;
+}
+
 BOOL FASTCALL
 IntPaintDesktop(HDC hDC)
 {
@@ -1881,191 +2156,8 @@ IntPaintDesktop(HDC hDC)
          */
         if (gspv.hbmWallpaper != NULL)
         {
-            SIZE sz;
-            int x, y;
-            int scaledWidth, scaledHeight;
-            int wallpaperX, wallpaperY, wallpaperWidth, wallpaperHeight;
-            HDC hWallpaperDC;
-
-            sz.cx = WndDesktop->rcWindow.right - WndDesktop->rcWindow.left;
-            sz.cy = WndDesktop->rcWindow.bottom - WndDesktop->rcWindow.top;
-
-            if (gspv.WallpaperMode == wmFit ||
-                gspv.WallpaperMode == wmFill)
-            {
-                int scaleNum, scaleDen;
-
-                // Precision improvement over ((sz.cx / gspv.cxWallpaper) > (sz.cy / gspv.cyWallpaper))
-                if ((sz.cx * gspv.cyWallpaper) > (sz.cy * gspv.cxWallpaper))
-                {
-                    if (gspv.WallpaperMode == wmFit)
-                    {
-                        scaleNum = sz.cy;
-                        scaleDen = gspv.cyWallpaper;
-                    }
-                    else
-                    {
-                        scaleNum = sz.cx;
-                        scaleDen = gspv.cxWallpaper;
-                    }
-                }
-                else
-                {
-                    if (gspv.WallpaperMode == wmFit)
-                    {
-                        scaleNum = sz.cx;
-                        scaleDen = gspv.cxWallpaper;
-                    }
-                    else
-                    {
-                        scaleNum = sz.cy;
-                        scaleDen = gspv.cyWallpaper;
-                    }
-                }
-
-                scaledWidth = EngMulDiv(gspv.cxWallpaper, scaleNum, scaleDen);
-                scaledHeight = EngMulDiv(gspv.cyWallpaper, scaleNum, scaleDen);
-
-                if (gspv.WallpaperMode == wmFill)
-                {
-                    wallpaperX = (((scaledWidth - sz.cx) * gspv.cxWallpaper) / (2 * scaledWidth));
-                    wallpaperY = (((scaledHeight - sz.cy) * gspv.cyWallpaper) / (2 * scaledHeight));
-
-                    wallpaperWidth = (sz.cx * gspv.cxWallpaper) / scaledWidth;
-                    wallpaperHeight = (sz.cy * gspv.cyWallpaper) / scaledHeight;
-                }
-            }
-
-            if (gspv.WallpaperMode == wmStretch ||
-                gspv.WallpaperMode == wmTile ||
-                gspv.WallpaperMode == wmFill)
-            {
-                x = 0;
-                y = 0;
-            }
-            else if (gspv.WallpaperMode == wmFit)
-            {
-                x = (sz.cx - scaledWidth) / 2;
-                y = (sz.cy - scaledHeight) / 2;
-            }
-            else
-            {
-                /* Find the upper left corner, can be negative if the bitmap is bigger than the screen */
-                x = (sz.cx / 2) - (gspv.cxWallpaper / 2);
-                y = (sz.cy / 2) - (gspv.cyWallpaper / 2);
-            }
-
-            hWallpaperDC = NtGdiCreateCompatibleDC(hDC);
-            if (hWallpaperDC != NULL)
-            {
-                HBITMAP hOldBitmap;
-
-                /* Fill in the area that the bitmap is not going to cover */
-                if (x > 0 || y > 0)
-                {
-                    /* FIXME: Clip out the bitmap
-                       can be replaced with "NtGdiPatBlt(hDC, x, y, gspv.cxWallpaper, gspv.cyWallpaper, PATCOPY | DSTINVERT);"
-                       once we support DSTINVERT */
-                    PreviousBrush = NtGdiSelectBrush(hDC, DesktopBrush);
-                    NtGdiPatBlt(hDC, Rect.left, Rect.top, Rect.right, Rect.bottom, PATCOPY);
-                    NtGdiSelectBrush(hDC, PreviousBrush);
-                }
-
-                /* Do not fill the background after it is painted no matter the size of the picture */
-                doPatBlt = FALSE;
-
-                hOldBitmap = NtGdiSelectBitmap(hWallpaperDC, gspv.hbmWallpaper);
-
-                if (gspv.WallpaperMode == wmStretch)
-                {
-                    if (Rect.right && Rect.bottom)
-                        NtGdiStretchBlt(hDC,
-                                        x,
-                                        y,
-                                        sz.cx,
-                                        sz.cy,
-                                        hWallpaperDC,
-                                        0,
-                                        0,
-                                        gspv.cxWallpaper,
-                                        gspv.cyWallpaper,
-                                        SRCCOPY,
-                                        CLR_INVALID);
-                }
-                else if (gspv.WallpaperMode == wmTile)
-                {
-                    /* Paint the bitmap across the screen then down */
-                    for (y = 0; y < Rect.bottom; y += gspv.cyWallpaper)
-                    {
-                        for (x = 0; x < Rect.right; x += gspv.cxWallpaper)
-                        {
-                            NtGdiBitBlt(hDC,
-                                        x,
-                                        y,
-                                        gspv.cxWallpaper,
-                                        gspv.cyWallpaper,
-                                        hWallpaperDC,
-                                        0,
-                                        0,
-                                        SRCCOPY,
-                                        CLR_INVALID,
-                                        0);
-                        }
-                    }
-                }
-                else if (gspv.WallpaperMode == wmFit)
-                {
-                    if (Rect.right && Rect.bottom)
-                    {
-                        NtGdiStretchBlt(hDC,
-                                        x,
-                                        y,
-                                        scaledWidth,
-                                        scaledHeight,
-                                        hWallpaperDC,
-                                        0,
-                                        0,
-                                        gspv.cxWallpaper,
-                                        gspv.cyWallpaper,
-                                        SRCCOPY,
-                                        CLR_INVALID);
-                    }
-                }
-                else if (gspv.WallpaperMode == wmFill)
-                {
-                    if (Rect.right && Rect.bottom)
-                    {
-                        NtGdiStretchBlt(hDC,
-                                        x,
-                                        y,
-                                        sz.cx,
-                                        sz.cy,
-                                        hWallpaperDC,
-                                        wallpaperX,
-                                        wallpaperY,
-                                        wallpaperWidth,
-                                        wallpaperHeight,
-                                        SRCCOPY,
-                                        CLR_INVALID);
-                    }
-                }
-                else
-                {
-                    NtGdiBitBlt(hDC,
-                                x,
-                                y,
-                                gspv.cxWallpaper,
-                                gspv.cyWallpaper,
-                                hWallpaperDC,
-                                0,
-                                0,
-                                SRCCOPY,
-                                CLR_INVALID,
-                                0);
-                }
-                NtGdiSelectBitmap(hWallpaperDC, hOldBitmap);
-                NtGdiDeleteObjectApp(hWallpaperDC);
-            }
+            /* Do not fill the background after it is painted no matter the size of the picture */
+            doPatBlt = !IntPaintWallpaper(hDC, WndDesktop);
         }
     }
     else

--- a/win32ss/user/ntuser/desktop.c
+++ b/win32ss/user/ntuser/desktop.c
@@ -1853,6 +1853,279 @@ IntFreeDesktopHeap(IN OUT PDESKTOP Desktop)
 #endif
 }
 
+static VOID
+IntCalcWallpaperCoordinates(
+    _In_ PWND pwndDesktop,
+    _Out_ PSIZE pszDesk,
+    _Out_ PSIZE pszSrc,
+    _Out_ PSIZE pszDst,
+    _Out_ PPOINT pptSrc,
+    _Out_ PPOINT pptDst)
+{
+    int x, y;
+    POINT ptSrc, ptDst;
+    SIZE szDesk, szSrc, szDst;
+    int scaledWidth, scaledHeight;
+
+    szDesk.cx = pwndDesktop->rcWindow.right - pwndDesktop->rcWindow.left;
+    szDesk.cy = pwndDesktop->rcWindow.bottom - pwndDesktop->rcWindow.top;
+
+    if (gspv.WallpaperMode == wmFit ||
+        gspv.WallpaperMode == wmFill)
+    {
+        int scaleNum, scaleDen;
+
+        /* Precision improvement over ((sz.cx / gspv.cxWallpaper) > (sz.cy / gspv.cyWallpaper)) */
+        if ((szDesk.cx * gspv.cyWallpaper) > (szDesk.cy * gspv.cxWallpaper))
+        {
+            if (gspv.WallpaperMode == wmFit)
+            {
+                scaleNum = szDesk.cy;
+                scaleDen = gspv.cyWallpaper;
+            }
+            else
+            {
+                scaleNum = szDesk.cx;
+                scaleDen = gspv.cxWallpaper;
+            }
+        }
+        else
+        {
+            if (gspv.WallpaperMode == wmFit)
+            {
+                scaleNum = szDesk.cx;
+                scaleDen = gspv.cxWallpaper;
+            }
+            else
+            {
+                scaleNum = szDesk.cy;
+                scaleDen = gspv.cyWallpaper;
+            }
+        }
+
+        scaledWidth = EngMulDiv(gspv.cxWallpaper, scaleNum, scaleDen);
+        scaledHeight = EngMulDiv(gspv.cyWallpaper, scaleNum, scaleDen);
+    }
+
+    if (gspv.WallpaperMode == wmStretch ||
+        gspv.WallpaperMode == wmTile ||
+        gspv.WallpaperMode == wmFill)
+    {
+        x = 0;
+        y = 0;
+    }
+    else if (gspv.WallpaperMode == wmFit)
+    {
+        x = (szDesk.cx - scaledWidth) / 2;
+        y = (szDesk.cy - scaledHeight) / 2;
+    }
+    else
+    {
+        /* Find the upper left corner, can be negative if the bitmap is bigger than the screen */
+        x = (szDesk.cx / 2) - (gspv.cxWallpaper / 2);
+        y = (szDesk.cy / 2) - (gspv.cyWallpaper / 2);
+    }
+
+    if (gspv.WallpaperMode == wmTile)
+    {
+        szSrc.cx = 0; // not used
+        szSrc.cy = 0; // not used
+        szDst.cx = gspv.cxWallpaper;
+        szDst.cy = gspv.cyWallpaper;
+        ptSrc.x = 0;
+        ptSrc.y = 0;
+    }
+    else if (gspv.WallpaperMode == wmStretch)
+    {
+        szSrc.cx = gspv.cxWallpaper;
+        szSrc.cy = gspv.cyWallpaper;
+        szDst.cx = szDesk.cx;
+        szDst.cy = szDesk.cy;
+        ptSrc.x = 0;
+        ptSrc.y = 0;
+    }
+    else if (gspv.WallpaperMode == wmFit)
+    {
+        szSrc.cx = gspv.cxWallpaper;
+        szSrc.cy = gspv.cyWallpaper;
+        szDst.cx = scaledWidth;
+        szDst.cy = scaledHeight;
+        ptSrc.x = 0;
+        ptSrc.y = 0;
+    }
+    else if (gspv.WallpaperMode == wmFill)
+    {
+        int wallpaperX = (((scaledWidth - szDesk.cx) * gspv.cxWallpaper) / (2 * scaledWidth));
+        int wallpaperY = (((scaledHeight - szDesk.cy) * gspv.cyWallpaper) / (2 * scaledHeight));
+
+        szSrc.cx = EngMulDiv(gspv.cxWallpaper, szDesk.cx, scaledWidth);
+        szSrc.cy = EngMulDiv(gspv.cyWallpaper, szDesk.cy, scaledHeight);
+        szDst.cx = szDesk.cx;
+        szDst.cy = szDesk.cy;
+        ptSrc.x = wallpaperX;
+        ptSrc.y = wallpaperY;
+    }
+    else if (gspv.WallpaperMode == wmCenter)
+    {
+        szSrc.cx = 0; // not used
+        szSrc.cy = 0; // not used
+        szDst.cx = gspv.cxWallpaper;
+        szDst.cy = gspv.cyWallpaper;
+        ptSrc.x = 0;
+        ptSrc.y = 0;
+    }
+    ptDst.x = x;
+    ptDst.y = y;
+
+    *pszDesk = szDesk;
+    *pszSrc = szSrc;
+    *pszDst = szDst;
+    *pptSrc = ptSrc;
+    *pptDst = ptDst;
+}
+
+HBITMAP
+IntStretchWallpaper(
+    _In_ PWND pwndDesktop,
+    _In_ HBITMAP hBitmap)
+{
+    HDC hWallpaperDC;
+    HBITMAP hNewBitmap;
+    POINT ptSrc, ptDst;
+    SIZE szDesk, szSrc, szDst;
+
+    if (!hBitmap)
+        return NULL;
+
+    IntCalcWallpaperCoordinates(pwndDesktop, &szDesk, &szSrc, &szDst, &ptSrc, &ptDst);
+
+    hWallpaperDC = NtGdiCreateCompatibleDC(ScreenDeviceContext);
+    if (hWallpaperDC)
+    {
+        hNewBitmap = NtGdiCreateCompatibleBitmap(ScreenDeviceContext, szDesk.cx, szDesk.cy);
+        if (hNewBitmap)
+        {
+            HBITMAP hOldBitmap1, hOldBitmap2;
+
+            hOldBitmap1 = NtGdiSelectBitmap(hSystemBM, hNewBitmap);
+            hOldBitmap2 = NtGdiSelectBitmap(hWallpaperDC, hBitmap);
+
+            /*
+             * Stretch the bitmap to the required coordinates
+             * on the system memory DC first,
+             * and then simply blit the result to an ouput hDC
+             * to show the bitmap on the desktop.
+             * Fixes improper wallpaper painting.
+             */
+            NtGdiStretchBlt(hSystemBM,
+                            ptDst.x,
+                            ptDst.y,
+                            szDst.cx,
+                            szDst.cy,
+                            hWallpaperDC,
+                            ptSrc.x,
+                            ptSrc.y,
+                            szSrc.cx,
+                            szSrc.cy,
+                            SRCCOPY,
+                            0);
+
+            NtGdiSelectBitmap(hSystemBM, hOldBitmap1);
+            NtGdiSelectBitmap(hWallpaperDC, hOldBitmap2);
+            NtGdiDeleteObjectApp(hWallpaperDC);
+            NtGdiDeleteObjectApp(hBitmap);
+            GreSetBitmapOwner(hNewBitmap, GDI_OBJ_HMGR_PUBLIC);
+            return hNewBitmap;
+        }
+        NtGdiDeleteObjectApp(hWallpaperDC);
+    }
+    return NULL;
+}
+
+static BOOL
+IntPaintWallpaper(HDC hDC, PWND pwndDesktop)
+{
+    HBRUSH DesktopBrush, PreviousBrush;
+    HBITMAP hOldBitmap;
+    POINT ptSrc, ptDst;
+    SIZE szDesk, szSrc, szDst;
+    RECT Rect;
+
+    if (GdiGetClipBox(hDC, &Rect) == ERROR)
+        return FALSE;
+
+    DesktopBrush = (HBRUSH)pwndDesktop->pcls->hbrBackground;
+
+    IntCalcWallpaperCoordinates(pwndDesktop, &szDesk, &szSrc, &szDst, &ptSrc, &ptDst);
+
+    /* Fill in the area that the bitmap is not going to cover */
+    if (ptDst.x > 0 || ptDst.y > 0)
+    {
+        /* FIXME: Clip out the bitmap
+           can be replaced with "NtGdiPatBlt(hDC, x, y, gspv.cxWallpaper, gspv.cyWallpaper, PATCOPY | DSTINVERT);"
+           once we support DSTINVERT */
+        PreviousBrush = NtGdiSelectBrush(hDC, DesktopBrush);
+        NtGdiPatBlt(hDC, Rect.left, Rect.top, Rect.right, Rect.bottom, PATCOPY);
+        NtGdiSelectBrush(hDC, PreviousBrush);
+    }
+
+    hOldBitmap = NtGdiSelectBitmap(hSystemBM, gspv.hbmWallpaper);
+
+    if (gspv.WallpaperMode == wmStretch ||
+        gspv.WallpaperMode == wmFit ||
+        gspv.WallpaperMode == wmFill)
+    {
+        NtGdiBitBlt(hDC,
+                    ptDst.x,
+                    ptDst.y,
+                    szDst.cx,
+                    szDst.cy,
+                    hSystemBM,
+                    ptDst.x,
+                    ptDst.y,
+                    SRCCOPY,
+                    CLR_INVALID,
+                    0);
+    }
+    else if (gspv.WallpaperMode == wmTile)
+    {
+        /* Paint the bitmap across the screen then down */
+        for (int y = 0; y < Rect.bottom; y += gspv.cyWallpaper)
+        {
+            for (int x = 0; x < Rect.right; x += gspv.cxWallpaper)
+            {
+                NtGdiBitBlt(hDC,
+                            x,
+                            y,
+                            szDst.cx,
+                            szDst.cy,
+                            hSystemBM,
+                            ptSrc.x,
+                            ptSrc.y,
+                            SRCCOPY,
+                            CLR_INVALID,
+                            0);
+            }
+        }
+    }
+    else /* wmCenter */
+    {
+        NtGdiBitBlt(hDC,
+                    ptDst.x,
+                    ptDst.y,
+                    szDst.cx,
+                    szDst.cy,
+                    hSystemBM,
+                    ptSrc.x,
+                    ptSrc.y,
+                    SRCCOPY,
+                    CLR_INVALID,
+                    0);
+    }
+    NtGdiSelectBitmap(hSystemBM, hOldBitmap);
+    return TRUE;
+}
+
 BOOL FASTCALL
 IntPaintDesktop(HDC hDC)
 {
@@ -1886,191 +2159,8 @@ IntPaintDesktop(HDC hDC)
          */
         if (gspv.hbmWallpaper != NULL)
         {
-            SIZE sz;
-            int x, y;
-            int scaledWidth, scaledHeight;
-            int wallpaperX, wallpaperY, wallpaperWidth, wallpaperHeight;
-            HDC hWallpaperDC;
-
-            sz.cx = WndDesktop->rcWindow.right - WndDesktop->rcWindow.left;
-            sz.cy = WndDesktop->rcWindow.bottom - WndDesktop->rcWindow.top;
-
-            if (gspv.WallpaperMode == wmFit ||
-                gspv.WallpaperMode == wmFill)
-            {
-                int scaleNum, scaleDen;
-
-                // Precision improvement over ((sz.cx / gspv.cxWallpaper) > (sz.cy / gspv.cyWallpaper))
-                if ((sz.cx * gspv.cyWallpaper) > (sz.cy * gspv.cxWallpaper))
-                {
-                    if (gspv.WallpaperMode == wmFit)
-                    {
-                        scaleNum = sz.cy;
-                        scaleDen = gspv.cyWallpaper;
-                    }
-                    else
-                    {
-                        scaleNum = sz.cx;
-                        scaleDen = gspv.cxWallpaper;
-                    }
-                }
-                else
-                {
-                    if (gspv.WallpaperMode == wmFit)
-                    {
-                        scaleNum = sz.cx;
-                        scaleDen = gspv.cxWallpaper;
-                    }
-                    else
-                    {
-                        scaleNum = sz.cy;
-                        scaleDen = gspv.cyWallpaper;
-                    }
-                }
-
-                scaledWidth = EngMulDiv(gspv.cxWallpaper, scaleNum, scaleDen);
-                scaledHeight = EngMulDiv(gspv.cyWallpaper, scaleNum, scaleDen);
-
-                if (gspv.WallpaperMode == wmFill)
-                {
-                    wallpaperX = (((scaledWidth - sz.cx) * gspv.cxWallpaper) / (2 * scaledWidth));
-                    wallpaperY = (((scaledHeight - sz.cy) * gspv.cyWallpaper) / (2 * scaledHeight));
-
-                    wallpaperWidth = (sz.cx * gspv.cxWallpaper) / scaledWidth;
-                    wallpaperHeight = (sz.cy * gspv.cyWallpaper) / scaledHeight;
-                }
-            }
-
-            if (gspv.WallpaperMode == wmStretch ||
-                gspv.WallpaperMode == wmTile ||
-                gspv.WallpaperMode == wmFill)
-            {
-                x = 0;
-                y = 0;
-            }
-            else if (gspv.WallpaperMode == wmFit)
-            {
-                x = (sz.cx - scaledWidth) / 2;
-                y = (sz.cy - scaledHeight) / 2;
-            }
-            else
-            {
-                /* Find the upper left corner, can be negative if the bitmap is bigger than the screen */
-                x = (sz.cx / 2) - (gspv.cxWallpaper / 2);
-                y = (sz.cy / 2) - (gspv.cyWallpaper / 2);
-            }
-
-            hWallpaperDC = NtGdiCreateCompatibleDC(hDC);
-            if (hWallpaperDC != NULL)
-            {
-                HBITMAP hOldBitmap;
-
-                /* Fill in the area that the bitmap is not going to cover */
-                if (x > 0 || y > 0)
-                {
-                    /* FIXME: Clip out the bitmap
-                       can be replaced with "NtGdiPatBlt(hDC, x, y, gspv.cxWallpaper, gspv.cyWallpaper, PATCOPY | DSTINVERT);"
-                       once we support DSTINVERT */
-                    PreviousBrush = NtGdiSelectBrush(hDC, DesktopBrush);
-                    NtGdiPatBlt(hDC, Rect.left, Rect.top, Rect.right, Rect.bottom, PATCOPY);
-                    NtGdiSelectBrush(hDC, PreviousBrush);
-                }
-
-                /* Do not fill the background after it is painted no matter the size of the picture */
-                doPatBlt = FALSE;
-
-                hOldBitmap = NtGdiSelectBitmap(hWallpaperDC, gspv.hbmWallpaper);
-
-                if (gspv.WallpaperMode == wmStretch)
-                {
-                    if (Rect.right && Rect.bottom)
-                        NtGdiStretchBlt(hDC,
-                                        x,
-                                        y,
-                                        sz.cx,
-                                        sz.cy,
-                                        hWallpaperDC,
-                                        0,
-                                        0,
-                                        gspv.cxWallpaper,
-                                        gspv.cyWallpaper,
-                                        SRCCOPY,
-                                        CLR_INVALID);
-                }
-                else if (gspv.WallpaperMode == wmTile)
-                {
-                    /* Paint the bitmap across the screen then down */
-                    for (y = 0; y < Rect.bottom; y += gspv.cyWallpaper)
-                    {
-                        for (x = 0; x < Rect.right; x += gspv.cxWallpaper)
-                        {
-                            NtGdiBitBlt(hDC,
-                                        x,
-                                        y,
-                                        gspv.cxWallpaper,
-                                        gspv.cyWallpaper,
-                                        hWallpaperDC,
-                                        0,
-                                        0,
-                                        SRCCOPY,
-                                        CLR_INVALID,
-                                        0);
-                        }
-                    }
-                }
-                else if (gspv.WallpaperMode == wmFit)
-                {
-                    if (Rect.right && Rect.bottom)
-                    {
-                        NtGdiStretchBlt(hDC,
-                                        x,
-                                        y,
-                                        scaledWidth,
-                                        scaledHeight,
-                                        hWallpaperDC,
-                                        0,
-                                        0,
-                                        gspv.cxWallpaper,
-                                        gspv.cyWallpaper,
-                                        SRCCOPY,
-                                        CLR_INVALID);
-                    }
-                }
-                else if (gspv.WallpaperMode == wmFill)
-                {
-                    if (Rect.right && Rect.bottom)
-                    {
-                        NtGdiStretchBlt(hDC,
-                                        x,
-                                        y,
-                                        sz.cx,
-                                        sz.cy,
-                                        hWallpaperDC,
-                                        wallpaperX,
-                                        wallpaperY,
-                                        wallpaperWidth,
-                                        wallpaperHeight,
-                                        SRCCOPY,
-                                        CLR_INVALID);
-                    }
-                }
-                else
-                {
-                    NtGdiBitBlt(hDC,
-                                x,
-                                y,
-                                gspv.cxWallpaper,
-                                gspv.cyWallpaper,
-                                hWallpaperDC,
-                                0,
-                                0,
-                                SRCCOPY,
-                                CLR_INVALID,
-                                0);
-                }
-                NtGdiSelectBitmap(hWallpaperDC, hOldBitmap);
-                NtGdiDeleteObjectApp(hWallpaperDC);
-            }
+            /* Do not fill the background after it is painted no matter the size of the picture */
+            doPatBlt = !IntPaintWallpaper(hDC, WndDesktop);
         }
     }
     else

--- a/win32ss/user/ntuser/sysparams.c
+++ b/win32ss/user/ntuser/sysparams.c
@@ -643,6 +643,9 @@ SpiGetUserPref(DWORD dwMask, PVOID pvParam, FLONG fl)
     return SpiGetInt(pvParam, &iValue, fl);
 }
 
+HBITMAP
+IntStretchWallpaper(_In_ HBITMAP hBitmap);
+
 static
 UINT_PTR
 SpiSetWallpaper(PVOID pvParam, FLONG fl)
@@ -775,7 +778,16 @@ SpiSetWallpaper(PVOID pvParam, FLONG fl)
     }
 
     /* Set the new wallpaper */
-    gspv.hbmWallpaper = hbmp;
+    if (gspv.WallpaperMode == wmStretch ||
+        gspv.WallpaperMode == wmFit ||
+        gspv.WallpaperMode == wmFill)
+    {
+        gspv.hbmWallpaper = IntStretchWallpaper(hbmp);
+    }
+    else
+    {
+        gspv.hbmWallpaper = hbmp;
+    }
 
     NtUserRedrawWindow(UserGetShellWindow(), NULL, NULL, RDW_INVALIDATE | RDW_ERASE);
 

--- a/win32ss/user/ntuser/sysparams.c
+++ b/win32ss/user/ntuser/sysparams.c
@@ -643,6 +643,11 @@ SpiGetUserPref(DWORD dwMask, PVOID pvParam, FLONG fl)
     return SpiGetInt(pvParam, &iValue, fl);
 }
 
+HBITMAP
+IntStretchWallpaper(
+    _In_ PWND pwndDesktop,
+    _In_ HBITMAP hBitmap);
+
 static
 UINT_PTR
 SpiSetWallpaper(PVOID pvParam, FLONG fl)
@@ -762,7 +767,7 @@ SpiSetWallpaper(PVOID pvParam, FLONG fl)
         /* Remove wallpaper */
         gspv.cxWallpaper = 0;
         gspv.cyWallpaper = 0;
-        hbmp = 0;
+        hbmp = NULL;
     }
 
     /* Take care of the old wallpaper, if any */
@@ -775,7 +780,16 @@ SpiSetWallpaper(PVOID pvParam, FLONG fl)
     }
 
     /* Set the new wallpaper */
-    gspv.hbmWallpaper = hbmp;
+    if (gspv.WallpaperMode == wmStretch ||
+        gspv.WallpaperMode == wmFit ||
+        gspv.WallpaperMode == wmFill)
+    {
+        gspv.hbmWallpaper = IntStretchWallpaper(UserGetDesktopWindow(), hbmp);
+    }
+    else
+    {
+        gspv.hbmWallpaper = hbmp;
+    }
 
     NtUserRedrawWindow(UserGetShellWindow(), NULL, NULL, RDW_INVALIDATE | RDW_ERASE);
 


### PR DESCRIPTION
## Purpose

Fix desktop wallpaper painting behaviour for "Stretch", "Fit" and "Fill" displaying modes.
"Tile" and "Center" modes remain unaffected, since they already have no any painting issues.

JIRA issues: [CORE-13891](https://jira.reactos.org/browse/CORE-13891), [CORE-15820](https://jira.reactos.org/browse/CORE-15820), [CORE-15826](https://jira.reactos.org/browse/CORE-15826)

## Proposed changes

- Create a new compatible bitmap to make user-defined wallpaper fit to the screen size.
- Stretch user-defined wallpaper to this bitmap each time when wallpaper is set in Display Properties, to match the required screen coordinates. Don't do it on each desktop redrawing.
- Use the system memory DC for stretching the wallpaper image and store it there first, instead of blit it to the destination (output) DC directly.
- Use the same system memory DC for "Tile" and "Center" wallpaper modes too, to avoid unneeded allocating and freeing a new memory DC internally. Get rid from internally managed DC and use a global system memory DC to manage all wallpaper modes instead.
- Move wallpaper coordinates calculation code into a separate function, because it's now used more than one time, both when blit to system memory DC on wallpaper changing and when actually repainting desktop.
- Move wallpaper repainting code from `IntPaintDesktop()` into a separate function too, and call it from there.
- Pass the previously calculated input and output coordinates (left, top, width and height) for an each displaying mode appropriately: "Tile", "Center", "Stretch", "Fit" and "Fill".
- Then, simply blit a result to the output DC on each desktop repaint, to view the wallpaper contents on the desktop.

## Result

How it looks
before:

[Wallpaper_bug_before:(.webm](https://github.com/user-attachments/assets/12001a2f-cce5-478a-a911-389923a63d45)

and after:

[Wallpaper_bug_fixed_new!:D.webm](https://github.com/user-attachments/assets/d126a37a-b74b-44a3-b40a-5abae6e0e3d9)

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: