### PR TITLE
[COMPILER_APITEST] Remove UB float conversions

### DIFF
--- a/modules/rostests/apitests/compiler/floatconv.c
+++ b/modules/rostests/apitests/compiler/floatconv.c
@@ -7,36 +7,10 @@
 
 #include <apitest.h>
 
-/* Note: There are 2 behaviors for float to unsigned integer conversion:
- * 1. The old behavior, which exists only on x86 and CL versions up to somewhere
- *    between 19.40.33811 and 19.41.33923:
- *     - If a negative float is cast to an unsigned integer, the result is ULONG_MAX
- *       for uint32 and ULLONG_MAX for uint64.
- *     - If a float is cast to an unsigned long and the value is larger than ULONG_MAX,
- *       the result is ULONG_MAX.
- * 2. The new behavior (all x64 and x86 versions after the ones mentioned above):
- *     - If a negative float is cast to an unsigned integer, the result is the same as
-         first casting to the signed type, then casting to the unsigned type.
- *     - If a float is cast to an unsigned integer and the value is too large for the type,
- *       the result is 0 for uint32 and 0x8000000000000000 for uint64.
- * In the old version, the float to unsigned conversion was inlined and used _ftoul2 and
- * a comparison against 0x43e0000000000000 (9223372036854775808.0) to check for overflow.
- * In the new version, the float to unsigned conversion is done by a call to _ftoul2_legacy,
- * which checks for overflow by comparing against 0x5f800000 (18446744073709551616.0) and
- * then forwards the call to either _ftol2 or _ftoul2.
+/* Real floating-integer conversions: The fractional part is discarded (truncated towards zero).
+ * If the resulting value can be represented by the target type, that value is used.
+ * Otherwise, the behavior is undefined.
  */
-
-#if defined(_M_IX86) && defined(__VS_PROJECT__) && (_MSC_FULL_VER < 194133923)
-#define OLD_BEHAVIOR
-#endif
-
-#ifdef OLD_BEHAVIOR
-#define ULONG_OVERFLOW ULONG_MAX
-#define ULONGLONG_OVERFLOW ULLONG_MAX
-#else
-#define ULONG_OVERFLOW 0ul
-#define ULONGLONG_OVERFLOW 0x8000000000000000ull
-#endif
 
 __declspec(noinline)
 long cast_float_to_long(float f)
@@ -99,11 +73,6 @@ void Test_float(void)
     ok_eq_long(cast_float_to_long(2147483500.0f), 2147483520l);
     ok_eq_long(cast_float_to_long(2147483583.999f), 2147483520l);
     ok_eq_long(cast_float_to_long(-2147483583.999f), -2147483520l);
-    ok_eq_long(cast_float_to_long(2147483584.0f), LONG_MIN); // -2147483648
-    ok_eq_long(cast_float_to_long(2147483648.0f), LONG_MIN); // -2147483648
-    ok_eq_long(cast_float_to_long(-2147483648.0f), LONG_MIN); // -2147483648
-    ok_eq_long(cast_float_to_long(10000000000.0f), LONG_MIN);
-    ok_eq_long(cast_float_to_long(-10000000000.0f), LONG_MIN);
 
     // float to unsigned long cast (positive values)
     ok_eq_ulong(cast_float_to_ulong(0.0f), 0ul);
@@ -112,21 +81,10 @@ void Test_float(void)
     ok_eq_ulong(cast_float_to_ulong(0.999999f), 0ul);
     ok_eq_ulong(cast_float_to_ulong(2147483648.0f), 2147483648ul); // 0x80000000
     ok_eq_ulong(cast_float_to_ulong(4294967150.0f), 4294967040ul); // 0xFFFFFF00
-    ok_eq_ulong(cast_float_to_ulong(4294967294.0f), ULONG_OVERFLOW);
 
     // float to unsigned long cast (negative values)
     ok_eq_ulong(cast_float_to_ulong(-0.0f), 0ul);
     ok_eq_ulong(cast_float_to_ulong(-0.5f), 0ul);
-    ok_eq_ulong(cast_float_to_ulong(-1.0f), ULONG_MAX);
-#ifdef OLD_BEHAVIOR
-    ok_eq_ulong(cast_float_to_ulong(-10.0f), ULONG_MAX);
-    ok_eq_ulong(cast_float_to_ulong(-1147483648.0f), ULONG_MAX);
-    ok_eq_ulong(cast_float_to_ulong(-2147483648.0f), ULONG_MAX);
-#else
-    ok_eq_ulong(cast_float_to_ulong(-10.0f), (unsigned long)-10);
-    ok_eq_ulong(cast_float_to_ulong(-1147483648.0f), (unsigned long)-1147483648ll);
-    ok_eq_ulong(cast_float_to_ulong(-2147483648.0f), (unsigned long)-2147483648ll);
-#endif
 
     // float to long long cast
     ok_eq_longlong(cast_float_to_longlong(0.0f), 0ll);
@@ -137,11 +95,7 @@ void Test_float(void)
     ok_eq_longlong(cast_float_to_longlong(0.999999f), 0ll);
     ok_eq_longlong(cast_float_to_longlong(-0.999999f), 0ll);
     ok_eq_longlong(cast_float_to_longlong(9223371761976868863.9999f), 9223371487098961920ll);
-    ok_eq_longlong(cast_float_to_longlong(9223371761976868864.0f), LLONG_MIN);
     ok_eq_longlong(cast_float_to_longlong(-9223371761976868863.9999f), -9223371487098961920ll);
-    ok_eq_longlong(cast_float_to_longlong(-9223371761976868864.0f), LLONG_MIN);
-    ok_eq_longlong(cast_float_to_longlong(100000000000000000000.0f), LLONG_MIN);
-    ok_eq_longlong(cast_float_to_longlong(-100000000000000000000.0f), LLONG_MIN);
 
     // float to unsigned long long cast (positive values)
     ok_eq_ulonglong(cast_float_to_ulonglong(0.0f), 0ull);
@@ -151,31 +105,10 @@ void Test_float(void)
     ok_eq_ulonglong(cast_float_to_ulonglong(9223371487098961920.0f), 9223371487098961920ull); // 0x7FFFFF8000000000
     ok_eq_ulonglong(cast_float_to_ulonglong(9223372036854775808.0f), 9223372036854775808ull); // 0x8000000000000000
     ok_eq_ulonglong(cast_float_to_ulonglong(18446743523953737727.9f), 18446742974197923840ull); // 0xFFFFFF0000000000
-#ifndef __GNUC__ // GCC inlines the conversion, we cannot fix this
-    ok_eq_ulonglong(cast_float_to_ulonglong(18446743523953737728.0f), ULONGLONG_OVERFLOW); // 0x8000000000000000 / 0xFFFFFFFFFFFFFFFF
-    ok_eq_ulonglong(cast_float_to_ulonglong(20000000000000000000.0f), ULONGLONG_OVERFLOW); // 0x8000000000000000 / 0xFFFFFFFFFFFFFFFF
-#endif
 
     // float to unsigned long long cast (negative values)
     ok_eq_ulonglong(cast_float_to_ulonglong(-0.0f), 0ull);
     ok_eq_ulonglong(cast_float_to_ulonglong(-0.5f), 0ull);
-    ok_eq_ulonglong(cast_float_to_ulonglong(-1.0f), 18446744073709551615ull);
-#ifdef OLD_BEHAVIOR
-    ok_eq_ulonglong(cast_float_to_ulonglong(-10.0f), ULLONG_MAX);
-    ok_eq_ulonglong(cast_float_to_ulonglong(-1147483648.0f), ULLONG_MAX);
-    ok_eq_ulonglong(cast_float_to_ulonglong(-2147483648.0f), ULLONG_MAX);
-    ok_eq_ulonglong(cast_float_to_ulonglong(-9223371761976868863.9f), ULLONG_MAX);
-    ok_eq_ulonglong(cast_float_to_ulonglong(-9223371761976868864.0f), ULLONG_MAX);
-    ok_eq_ulonglong(cast_float_to_ulonglong(-9223372036854775808.0f), ULLONG_MAX);
-#else
-    ok_eq_ulonglong(cast_float_to_ulonglong(-10.0f), (unsigned long long)-10);
-    ok_eq_ulonglong(cast_float_to_ulonglong(-1147483648.0f), (unsigned long long)-1147483648ll);
-    ok_eq_ulonglong(cast_float_to_ulonglong(-2147483648.0f), (unsigned long long)-2147483648ll);
-    ok_eq_ulonglong(cast_float_to_ulonglong(-9223371761976868863.9f), (unsigned long long)-9223371487098961920);
-    ok_eq_ulonglong(cast_float_to_ulonglong(-9223371761976868864.0f), (unsigned long long)(-9223372036854775807ll - 1)); // 0x8000000000000000 / ULONGLONG_OVERFLOW
-    ok_eq_ulonglong(cast_float_to_ulonglong(-9223372036854775808.0f), (unsigned long long)(-9223372036854775807ll - 1)); // 0x8000000000000000 / ULONGLONG_OVERFLOW
-#endif
-    ok_eq_ulonglong(cast_float_to_ulonglong(-100000000000000000000.0f), ULONGLONG_OVERFLOW);
 }
 
 void Test_double(void)
@@ -190,10 +123,6 @@ void Test_double(void)
     ok_eq_long(cast_double_to_long(-0.999999999), 0l);
     ok_eq_long(cast_double_to_long(2147483647.99999), 2147483647l);
     ok_eq_long(cast_double_to_long(-2147483647.99999), -2147483647l);
-    ok_eq_long(cast_double_to_long(2147483648.0), LONG_MIN); // -2147483648
-    ok_eq_long(cast_double_to_long(-2147483648.0), LONG_MIN); // -2147483648
-    ok_eq_long(cast_double_to_long(10000000000.0), LONG_MIN);
-    ok_eq_long(cast_double_to_long(-10000000000.0), LONG_MIN);
 
     // double to unsigned long cast (positive values)
     ok_eq_ulong(cast_double_to_ulong(0.0), 0ul);
@@ -202,21 +131,10 @@ void Test_double(void)
     ok_eq_ulong(cast_double_to_ulong(0.999999999), 0ul);
     ok_eq_ulong(cast_double_to_ulong(2147483648.0), 2147483648ul); // 0x80000000
     ok_eq_ulong(cast_double_to_ulong(4294967295.0), 4294967295ul); // 0xFFFFFFFF
-    ok_eq_ulong(cast_double_to_ulong(4294967296.0), ULONG_OVERFLOW);
 
     // double to unsigned long cast (negative values)
     ok_eq_ulong(cast_double_to_ulong(-0.0), 0ul);
     ok_eq_ulong(cast_double_to_ulong(-0.5), 0ul);
-    ok_eq_ulong(cast_double_to_ulong(-1.0), ULONG_MAX);
-#ifdef OLD_BEHAVIOR
-    ok_eq_ulong(cast_double_to_ulong(-10.0), ULONG_MAX);
-    ok_eq_ulong(cast_double_to_ulong(-1147483648.0), ULONG_MAX);
-    ok_eq_ulong(cast_double_to_ulong(-2147483648.0), ULONG_MAX);
-#else
-    ok_eq_ulong(cast_double_to_ulong(-10.0), (unsigned long)-10);
-    ok_eq_ulong(cast_double_to_ulong(-1147483648.0), (unsigned long)-1147483648ll);
-    ok_eq_ulong(cast_double_to_ulong(-2147483648.0), (unsigned long)-2147483648ll);
-#endif
 
     // double to long long cast
     ok_eq_longlong(cast_double_to_longlong(0.0), 0ll);
@@ -227,11 +145,7 @@ void Test_double(void)
     ok_eq_longlong(cast_double_to_longlong(0.999999), 0ll);
     ok_eq_longlong(cast_double_to_longlong(-0.999999), 0ll);
     ok_eq_longlong(cast_double_to_longlong(9223372036854775295.9), 9223372036854774784ll);
-    ok_eq_longlong(cast_double_to_longlong(9223372036854775296.0), LLONG_MIN);
     ok_eq_longlong(cast_double_to_longlong(-9223372036854775295.9), -9223372036854774784ll);
-    ok_eq_longlong(cast_double_to_longlong(-9223372036854775296.0), LLONG_MIN);
-    ok_eq_longlong(cast_double_to_longlong(100000000000000000000.0), LLONG_MIN);
-    ok_eq_longlong(cast_double_to_longlong(-100000000000000000000.0), LLONG_MIN);
 
     // double to unsigned long long cast (positive values)
     ok_eq_ulonglong(cast_double_to_ulonglong(0.0), 0ull);
@@ -241,31 +155,10 @@ void Test_double(void)
     ok_eq_ulonglong(cast_double_to_ulonglong(9223372036854774784.0), 9223372036854774784ull); // 0x7FFFFFFFFFFFFC00
     ok_eq_ulonglong(cast_double_to_ulonglong(9223372036854775808.0), 9223372036854775808ull); // 0x8000000000000000
     ok_eq_ulonglong(cast_double_to_ulonglong(18446744073709550591.9), 18446744073709549568ull); // 0xFFFFFFFFFFFFF800
-#ifndef __GNUC__ // GCC inlines the conversion, we cannot fix this
-    ok_eq_ulonglong(cast_double_to_ulonglong(18446744073709550592.0), ULONGLONG_OVERFLOW); // 0x8000000000000000 / 0xFFFFFFFFFFFFFFFF
-    ok_eq_ulonglong(cast_double_to_ulonglong(18446744073709551616.0), ULONGLONG_OVERFLOW); // 0x8000000000000000 / 0xFFFFFFFFFFFFFFFF
-    ok_eq_ulonglong(cast_double_to_ulonglong(20000000000000000000.0), ULONGLONG_OVERFLOW); // 0x8000000000000000 / 0xFFFFFFFFFFFFFFFF
-#endif
 
     // float to unsigned long long cast (negative values)
     ok_eq_ulonglong(cast_double_to_ulonglong(-0.0), 0ull);
     ok_eq_ulonglong(cast_double_to_ulonglong(-0.5), 0ull);
-    ok_eq_ulonglong(cast_double_to_ulonglong(-1.0), 18446744073709551615ull);
-#ifdef OLD_BEHAVIOR
-    ok_eq_ulonglong(cast_double_to_ulonglong(-10.0), ULLONG_MAX);
-    ok_eq_ulonglong(cast_double_to_ulonglong(-1147483648.0), ULLONG_MAX);
-    ok_eq_ulonglong(cast_double_to_ulonglong(-2147483648.0), ULLONG_MAX);
-    ok_eq_ulonglong(cast_double_to_ulonglong(-9223371761976868863.9), ULLONG_MAX);
-    ok_eq_ulonglong(cast_double_to_ulonglong(-9223371761976868864.0), ULLONG_MAX);
-    ok_eq_ulonglong(cast_double_to_ulonglong(-9223372036854775808.0), ULLONG_MAX);
-#else
-    ok_eq_ulonglong(cast_double_to_ulonglong(-10.0), (unsigned long long)-10);
-    ok_eq_ulonglong(cast_double_to_ulonglong(-1147483648.0), (unsigned long long)-1147483648ll);
-    ok_eq_ulonglong(cast_double_to_ulonglong(-2147483648.0), (unsigned long long)-2147483648ll);
-    ok_eq_ulonglong(cast_double_to_ulonglong(-9223372036854775000.0), (unsigned long long)-9223372036854774784ll);
-    ok_eq_ulonglong(cast_double_to_ulonglong(-9223372036854775808.0), (unsigned long long)(-9223372036854775807ll - 1));
-#endif
-    ok_eq_ulonglong(cast_double_to_ulonglong(-100000000000000000000.0), ULONGLONG_OVERFLOW);
 }
 
 START_TEST(floatconv)


### PR DESCRIPTION
## Purpose

Remove UB float conversions to prevent tests failing.

It doesn't make any sense to test UB cases as compilers can do anything without violating the standard. Programmers shouldn't rely on the consistency of these conversions.
