### PR TITLE
[IMM32] Use ANSI_NULL and UNICODE_NULL

### DIFF
--- a/win32ss/user/imm32/compstr.c
+++ b/win32ss/user/imm32/compstr.c
@@ -44,7 +44,7 @@ Imm32CompStrAnsiToWide(LPCSTR psz, DWORD cb, LPWSTR lpBuf, DWORD dwBufLen, UINT 
     DWORD ret = MultiByteToWideChar(uCodePage, MB_PRECOMPOSED, psz, cb / sizeof(CHAR),
                                     lpBuf, dwBufLen / sizeof(WCHAR));
     if (lpBuf && (ret + 1) * sizeof(WCHAR) <= dwBufLen)
-        lpBuf[ret] = 0;
+        lpBuf[ret] = UNICODE_NULL;
     return ret * sizeof(WCHAR);
 }
 
@@ -54,7 +54,7 @@ Imm32CompStrWideToAnsi(LPCWSTR psz, DWORD cb, LPSTR lpBuf, DWORD dwBufLen, UINT 
     DWORD ret = WideCharToMultiByte(uCodePage, 0, psz, cb / sizeof(WCHAR),
                                     lpBuf, dwBufLen / sizeof(CHAR), NULL, NULL);
     if (lpBuf && (ret + 1) * sizeof(CHAR) <= dwBufLen)
-        lpBuf[ret] = 0;
+        lpBuf[ret] = ANSI_NULL;
     return ret * sizeof(CHAR);
 }
 

--- a/win32ss/user/imm32/ime.c
+++ b/win32ss/user/imm32/ime.c
@@ -657,7 +657,7 @@ ImmGetDescriptionA(
     cch = WideCharToMultiByte(CP_ACP, 0, info.wszImeDescription, (INT)cch,
                               lpszDescription, uBufLen, NULL, NULL);
     if (uBufLen)
-        lpszDescription[cch] = 0;
+        lpszDescription[cch] = ANSI_NULL;
     return (UINT)cch;
 }
 
@@ -707,7 +707,7 @@ ImmGetIMEFileNameA(
     {
         ERR("\n");
         if (uBufLen > 0)
-            lpszFileName[0] = 0;
+            lpszFileName[0] = ANSI_NULL;
         return 0;
     }
 
@@ -721,7 +721,7 @@ ImmGetIMEFileNameA(
     if (cch > uBufLen - 1)
         cch = uBufLen - 1;
 
-    lpszFileName[cch] = 0;
+    lpszFileName[cch] = ANSI_NULL;
     return (UINT)cch;
 }
 
@@ -743,7 +743,7 @@ ImmGetIMEFileNameW(
     {
         ERR("\n");
         if (uBufLen > 0)
-            lpszFileName[0] = 0;
+            lpszFileName[0] = UNICODE_NULL;
         return 0;
     }
 
@@ -756,7 +756,7 @@ ImmGetIMEFileNameW(
     if (cch > uBufLen - 1)
         cch = uBufLen - 1;
 
-    lpszFileName[cch] = 0;
+    lpszFileName[cch] = UNICODE_NULL;
     return (UINT)cch;
 }
 
@@ -884,7 +884,7 @@ ImmEscapeA(
                 szW[_countof(szW) - 1] = UNICODE_NULL; /* Avoid buffer overrun */
                 WideCharToMultiByte(pImeDpi->uCodePage, 0, szW, -1,
                                     lpData, MAX_IMM_FILENAME, NULL, NULL);
-                ((LPSTR)lpData)[MAX_IMM_FILENAME - 1] = 0;
+                ((LPSTR)lpData)[MAX_IMM_FILENAME - 1] = ANSI_NULL; // Avoid buffer overrun
             }
             break;
 
@@ -964,7 +964,7 @@ ImmEscapeW(
             ret = ImeDpi_Escape(pImeDpi, hIMC, uSubFunc, szA, hKL);
             if (ret)
             {
-                szA[_countof(szA) - 1] = 0;
+                szA[_countof(szA) - 1] = ANSI_NULL; // Avoid buffer overrun
                 MultiByteToWideChar(pImeDpi->uCodePage, MB_PRECOMPOSED,
                                     szA, -1, lpData, MAX_IMM_FILENAME);
                 ((LPWSTR)lpData)[MAX_IMM_FILENAME - 1] = UNICODE_NULL; /* Avoid buffer overrun */
@@ -975,7 +975,7 @@ ImmEscapeW(
         case IME_ESC_HANJA_MODE:
             WideCharToMultiByte(pImeDpi->uCodePage, 0,
                                 lpData, -1, szA, _countof(szA), NULL, NULL);
-            szA[_countof(szA) - 1] = 0;
+            szA[_countof(szA) - 1] = ANSI_NULL; // Avoid buffer overrun
             ret = ImeDpi_Escape(pImeDpi, hIMC, uSubFunc, szA, hKL);
             break;
 

--- a/win32ss/user/imm32/imemenu.c
+++ b/win32ss/user/imm32/imemenu.c
@@ -68,7 +68,7 @@ Imm32ImeMenuAnsiToWide(
     pItemW->dwItemData = pItemA->dwItemData;
     ret = MultiByteToWideChar(uCodePage, 0, pItemA->szString, -1,
                               pItemW->szString, _countof(pItemW->szString));
-    pItemW->szString[_countof(pItemW->szString) - 1] = UNICODE_NULL;
+    pItemW->szString[_countof(pItemW->szString) - 1] = UNICODE_NULL; // Avoid buffer overrun
     return !!ret;
 }
 
@@ -90,7 +90,7 @@ Imm32ImeMenuWideToAnsi(
     pItemA->hbmpItem = pItemW->hbmpItem;
     ret = WideCharToMultiByte(uCodePage, 0, pItemW->szString, -1,
                               pItemA->szString, _countof(pItemA->szString), NULL, NULL);
-    pItemA->szString[_countof(pItemA->szString) - 1] = ANSI_NULL;
+    pItemA->szString[_countof(pItemA->szString) - 1] = ANSI_NULL; // Avoid buffer overrun
     return !!ret;
 }
 

--- a/win32ss/user/imm32/regword.c
+++ b/win32ss/user/imm32/regword.c
@@ -263,7 +263,7 @@ ImmGetRegisterWordStyleA(
                                        NULL, NULL);
             if (cchA > _countof(pDestA->szDescription) - 1)
                 cchA = _countof(pDestA->szDescription) - 1;
-            pDestA->szDescription[cchA] = 0;
+            pDestA->szDescription[cchA] = ANSI_NULL;
         }
     }
 
@@ -325,7 +325,7 @@ ImmGetRegisterWordStyleW(
                                        pDestW->szDescription, _countof(pDestW->szDescription));
             if (cchW > _countof(pDestW->szDescription) - 1)
                 cchW = _countof(pDestW->szDescription) - 1;
-            pDestW->szDescription[cchW] = 0;
+            pDestW->szDescription[cchW] = UNICODE_NULL;
         }
     }
 

--- a/win32ss/user/imm32/utils.c
+++ b/win32ss/user/imm32/utils.c
@@ -100,7 +100,7 @@ LPWSTR Imm32WideFromAnsi(UINT uCodePage, LPCSTR pszA)
     if (IS_NULL_UNEXPECTEDLY(pszW))
         return NULL;
     cch = MultiByteToWideChar(uCodePage, MB_PRECOMPOSED, pszA, cch, pszW, cch + 1);
-    pszW[cch] = 0;
+    pszW[cch] = UNICODE_NULL;
     return pszW;
 }
 
@@ -112,7 +112,7 @@ LPSTR Imm32AnsiFromWide(UINT uCodePage, LPCWSTR pszW)
     if (IS_NULL_UNEXPECTEDLY(pszA))
         return NULL;
     cchA = WideCharToMultiByte(uCodePage, 0, pszW, cchW, pszA, cchA, NULL, NULL);
-    pszA[cchA] = 0;
+    pszA[cchA] = ANSI_NULL;
     return pszA;
 }
 
@@ -170,7 +170,7 @@ VOID LogFontAnsiToWide(const LOGFONTA *plfA, LPLOGFONTW plfW)
                               plfW->lfFaceName, _countof(plfW->lfFaceName));
     if (cch > _countof(plfW->lfFaceName) - 1)
         cch = _countof(plfW->lfFaceName) - 1;
-    plfW->lfFaceName[cch] = 0;
+    plfW->lfFaceName[cch] = UNICODE_NULL;
 }
 
 VOID LogFontWideToAnsi(const LOGFONTW *plfW, LPLOGFONTA plfA)
@@ -182,7 +182,7 @@ VOID LogFontWideToAnsi(const LOGFONTW *plfW, LPLOGFONTA plfA)
                               plfA->lfFaceName, _countof(plfA->lfFaceName), NULL, NULL);
     if (cch > _countof(plfA->lfFaceName) - 1)
         cch = _countof(plfA->lfFaceName) - 1;
-    plfA->lfFaceName[cch] = 0;
+    plfA->lfFaceName[cch] = ANSI_NULL;
 }
 
 static PVOID FASTCALL DesktopPtrToUser(PVOID ptr)
@@ -504,7 +504,7 @@ Imm32ReconvertWideFromAnsi(LPRECONVERTSTRING pDest, const RECONVERTSTRING *pSrc,
     pchDest = (LPWSTR)((LPBYTE)pDest + pDest->dwStrOffset);
     cchDest = MultiByteToWideChar(uCodePage, MB_PRECOMPOSED, pchSrc, pSrc->dwStrLen,
                                   pchDest, cchDest);
-    pchDest[cchDest] = 0;
+    pchDest[cchDest] = UNICODE_NULL;
 
     TRACE("cbDest: 0x%X\n", cbDest);
     return cbDest;
@@ -569,7 +569,7 @@ Imm32ReconvertAnsiFromWide(LPRECONVERTSTRING pDest, const RECONVERTSTRING *pSrc,
     pchDest = (LPSTR)pDest + pDest->dwStrOffset;
     cchDest = WideCharToMultiByte(uCodePage, 0, pchSrc, pSrc->dwStrLen,
                                   pchDest, cchDest, NULL, NULL);
-    pchDest[cchDest] = 0;
+    pchDest[cchDest] = ANSI_NULL;
 
     TRACE("cchDest: 0x%X\n", cchDest);
     return cbDest;


### PR DESCRIPTION
## Purpose
Coding style fix.
JIRA issue: [CORE-19268](https://jira.reactos.org/browse/CORE-19268)

## Proposed changes

- Use `ANSI_NULL` for `'\0'`.
- Use `UNICODE_NULL` for `L'\0'`.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: