### PR TITLE
[BOOTDATA][NTUSER] Add DontLoadCTFIME and use it

### DIFF
--- a/boot/bootdata/hivesft.inf
+++ b/boot/bootdata/hivesft.inf
@@ -525,7 +525,8 @@ HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\IME Compatibility",,0x0000001
 
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\IMM","IME File",2,"msctfime.ime"
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\IMM","LoadIMM",0x00010003,0 ; "LoadIMM" means Cicero despite its name
-HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\IMM","LoadCTFIME",0x00010003,0
+HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\IMM","LoadCTFIME",0x00010003,0 ; Dummy setting, use DontLoadCTFIME
+HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\IMM","DontLoadCTFIME",0x00010003,1 ; Real setting
 
 ; DOS Device ports
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\Ports","COM1:",2,"9600,n,8,1"

--- a/boot/bootdata/hivesft.inf
+++ b/boot/bootdata/hivesft.inf
@@ -525,7 +525,7 @@ HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\IME Compatibility",,0x0000001
 
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\IMM","IME File",2,"msctfime.ime"
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\IMM","LoadIMM",0x00010003,0 ; "LoadIMM" means Cicero despite its name
-HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\IMM","DontLoadCTFIME",0x00010003,1
+HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\IMM","DontLoadCTFIME",0x00010003,1 ; Disable CTF IME
 
 ; DOS Device ports
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\Ports","COM1:",2,"9600,n,8,1"

--- a/boot/bootdata/hivesft.inf
+++ b/boot/bootdata/hivesft.inf
@@ -525,8 +525,7 @@ HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\IME Compatibility",,0x0000001
 
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\IMM","IME File",2,"msctfime.ime"
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\IMM","LoadIMM",0x00010003,0 ; "LoadIMM" means Cicero despite its name
-HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\IMM","LoadCTFIME",0x00010003,0 ; Dummy setting, use DontLoadCTFIME
-HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\IMM","DontLoadCTFIME",0x00010003,1 ; Real setting
+HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\IMM","DontLoadCTFIME",0x00010003,1
 
 ; DOS Device ports
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\Ports","COM1:",2,"9600,n,8,1"

--- a/win32ss/include/ntuser.h
+++ b/win32ss/include/ntuser.h
@@ -948,7 +948,7 @@ typedef LONG_PTR
 #define SRVINFO_DBCSENABLED 0x0002
 #define SRVINFO_IMM32       0x0004
 #define SRVINFO_APIHOOK     0x0010
-#define SRVINFO_CICERO_ENABLED 0x0020
+#define SRVINFO_CTFIME_ENABLED 0x0020
 #define SRVINFO_KBDPREF     0x0080
 
 #define NUM_SYSCOLORS 31
@@ -1210,7 +1210,7 @@ typedef struct tagCURSORDATA
 #define COMPAT_FLAG_2_CICERO_DISABLED 2
 
 #define IS_IMM_MODE() (gpsi && (gpsi->dwSRVIFlags & SRVINFO_IMM32))
-#define IS_CICERO_MODE() (gpsi && (gpsi->dwSRVIFlags & SRVINFO_CICERO_ENABLED))
+#define IS_CICERO_MODE() (gpsi && (gpsi->dwSRVIFlags & SRVINFO_CTFIME_ENABLED))
 #define IS_16BIT_MODE() (GetWin32ClientInfo()->dwTIFlags & TIF_16BIT)
 #define IS_CICERO_COMPAT_DISABLED() \
     (GetWin32ClientInfo()->dwCompatFlags2 & COMPAT_FLAG_2_CICERO_DISABLED)

--- a/win32ss/user/ntuser/metric.c
+++ b/win32ss/user/ntuser/metric.c
@@ -30,14 +30,11 @@ BOOL FASTCALL UserIsIMMEnabled(VOID)
 
 BOOL FASTCALL UserIsCiceroEnabled(VOID)
 {
-#if 1
-    return FALSE; /* FIXME: Cicero is not supported yet */
-#else
+    // "LoadCTFIME" is a dummy setting. Real setting is "DontLoadCTFIME".
     if (RegGetSectionDWORD(L"IMM", L"DontLoadCTFIME", FALSE))
         return FALSE;
 
     return UserIsIMMEnabled();
-#endif
 }
 
 BOOL

--- a/win32ss/user/ntuser/metric.c
+++ b/win32ss/user/ntuser/metric.c
@@ -198,7 +198,7 @@ InitMetrics(VOID)
         gpsi->dwSRVIFlags |= SRVINFO_IMM32; /* IME Support */
 
     if (UserIsCTFIMEEnabled())
-        gpsi->dwSRVIFlags |= SRVINFO_CICERO_ENABLED; /* Cicero support */
+        gpsi->dwSRVIFlags |= SRVINFO_CTFIME_ENABLED; /* CTF IME support */
 
     Setup = TRUE;
 

--- a/win32ss/user/ntuser/metric.c
+++ b/win32ss/user/ntuser/metric.c
@@ -28,7 +28,7 @@ BOOL FASTCALL UserIsIMMEnabled(VOID)
     return !!RegGetSectionDWORD(L"IMM", L"LoadIMM", FALSE);
 }
 
-BOOL FASTCALL UserIsCiceroEnabled(VOID)
+BOOL FASTCALL UserIsCTFIMEEnabled(VOID)
 {
     if (RegGetSectionDWORD(L"IMM", L"DontLoadCTFIME", FALSE))
         return FALSE;
@@ -197,7 +197,7 @@ InitMetrics(VOID)
     if (UserIsIMMEnabled())
         gpsi->dwSRVIFlags |= SRVINFO_IMM32; /* IME Support */
 
-    if (UserIsCiceroEnabled())
+    if (UserIsCTFIMEEnabled())
         gpsi->dwSRVIFlags |= SRVINFO_CICERO_ENABLED; /* Cicero support */
 
     Setup = TRUE;

--- a/win32ss/user/ntuser/metric.c
+++ b/win32ss/user/ntuser/metric.c
@@ -30,7 +30,6 @@ BOOL FASTCALL UserIsIMMEnabled(VOID)
 
 BOOL FASTCALL UserIsCiceroEnabled(VOID)
 {
-    // "LoadCTFIME" is a dummy setting. Real setting is "DontLoadCTFIME".
     if (RegGetSectionDWORD(L"IMM", L"DontLoadCTFIME", FALSE))
         return FALSE;
 

--- a/win32ss/user/ntuser/userfuncs.h
+++ b/win32ss/user/ntuser/userfuncs.h
@@ -85,7 +85,7 @@ BOOL NTAPI InitMetrics(VOID);
 LONG NTAPI UserGetSystemMetrics(ULONG Index);
 BOOL FASTCALL UserIsDBCSEnabled(VOID);
 BOOL FASTCALL UserIsIMMEnabled(VOID);
-BOOL FASTCALL UserIsCiceroEnabled(VOID);
+BOOL FASTCALL UserIsCTFIMEEnabled(VOID);
 
 /*************** KEYBOARD.C ***************/
 


### PR DESCRIPTION
## Purpose
Improve CTF IME customization. Use the proper names for CTF IME.
JIRA issue: [CORE-19268](https://jira.reactos.org/browse/CORE-19268)

## Proposed changes

- In the registry key `"HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\IMM"`, add `DontLoadCTFIME` value and set it to `1`.
- Delete `LoadCTFIME` value to avoid user confusing.
- Rename `UserIsCiceroEnabled` function as `UserIsCTFIMEEnabled`.
- Rename `SRVINFO_CICERO_ENABLED` flag as `SRVINFO_CTFIME_ENABLED`.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: