### PR TITLE
[USER32][COMCTL32] Edit: Optimize EDIT_SetCaretPos for speed

### DIFF
--- a/dll/win32/comctl32/edit.c
+++ b/dll/win32/comctl32/edit.c
@@ -5179,35 +5179,43 @@ static LRESULT CALLBACK EDIT_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPAR
     /* IME messages to make the edit control IME aware */
     case WM_IME_SETCONTEXT:
 #ifdef __REACTOS__
-        /* Korean doesn't want composition window */
-        if (PRIMARYLANGID(LOWORD(GetKeyboardLayout(0))) == LANG_KOREAN)
-            lParam &= ~ISC_SHOWUICOMPOSITIONWINDOW;
-
-        if (wParam)
         {
-            HIMC hIMC = ImmGetContext(hwnd);
-            LPINPUTCONTEXTDX pIC = (LPINPUTCONTEXTDX)ImmLockIMC(hIMC);
-            if (pIC)
-            {
-                pIC->dwUIFlags &= ~0x40000;
-                ImmUnlockIMC(hIMC);
-            }
-            if (FALSE) /* FIXME: Condition */
-                ImmNotifyIME(hIMC, NI_COMPOSITIONSTR, CPS_CANCEL, 0);
-            ImmReleaseContext(hwnd, hIMC);
-        }
+            HKL hKL = GetKeyboardLayout(0);
 
-        result = DefWindowProcW(hwnd, msg, wParam, lParam);
+            /* Korean doesn't want composition window */
+            if (PRIMARYLANGID(LOWORD(hKL)) == LANG_KOREAN)
+                lParam &= ~ISC_SHOWUICOMPOSITIONWINDOW;
+
+            if (wParam)
+            {
+                HIMC hIMC = ImmGetContext(hwnd);
+                LPINPUTCONTEXTDX pIC = (LPINPUTCONTEXTDX)ImmLockIMC(hIMC);
+                if (pIC)
+                {
+                    pIC->dwUIFlags &= ~0x40000;
+                    ImmUnlockIMC(hIMC);
+                }
+                if (FALSE) /* FIXME: Condition */
+                    ImmNotifyIME(hIMC, NI_COMPOSITIONSTR, CPS_CANCEL, 0);
+                ImmReleaseContext(hwnd, hIMC);
+            }
+
+            result = DefWindowProcW(hwnd, msg, wParam, lParam);
+        }
 #endif
         break;
 
     case WM_IME_STARTCOMPOSITION:
 #ifdef __REACTOS__
-        /* Korean doesn't want composition window */
-        if (PRIMARYLANGID(LOWORD(GetKeyboardLayout(0))) == LANG_KOREAN)
-            return TRUE;
+        {
+            HKL hKL = GetKeyboardLayout(0);
 
-        result = DefWindowProcW(hwnd, msg, wParam, lParam);
+            /* Korean doesn't want composition window */
+            if (PRIMARYLANGID(LOWORD(hKL)) == LANG_KOREAN)
+                return TRUE;
+
+            result = DefWindowProcW(hwnd, msg, wParam, lParam);
+        }
 #else
         es->composition_start = es->selection_end;
         es->composition_len = 0;

--- a/dll/win32/comctl32/edit.c
+++ b/dll/win32/comctl32/edit.c
@@ -1762,10 +1762,8 @@ static void EDIT_SetCaretPos(EDITSTATE *es, INT pos,
 
     SetCaretPos(pt.x, pt.y);
 
-    if (!ImmIsIME(hKL))
-        return;
-
-    EDIT_ImmSetCompositionWindow(es, pt);
+    if (IS_IME_HKL(hKL))
+        EDIT_ImmSetCompositionWindow(es, pt);
 #else
 	TRACE("%d - %dx%d\n", pos, (short)LOWORD(res), (short)HIWORD(res));
 	SetCaretPos((short)LOWORD(res), (short)HIWORD(res));
@@ -3884,7 +3882,7 @@ static void EDIT_WM_SetFont(EDITSTATE *es, HFONT font, BOOL redraw)
 		ShowCaret(es->hwndSelf);
 	}
 #ifdef __REACTOS__
-    if (ImmIsIME(GetKeyboardLayout(0)))
+    if (IS_IME_HKL(GetKeyboardLayout(0)))
     {
         LOGFONTW lf;
         HIMC hIMC = ImmGetContext(es->hwndSelf);
@@ -5181,7 +5179,8 @@ static LRESULT CALLBACK EDIT_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPAR
     /* IME messages to make the edit control IME aware */
     case WM_IME_SETCONTEXT:
 #ifdef __REACTOS__
-        if (FALSE) /* FIXME: Condition */
+        /* Korean doesn't want composition window */
+        if (PRIMARYLANGID(LOWORD(GetKeyboardLayout(0))) == LANG_KOREAN)
             lParam &= ~ISC_SHOWUICOMPOSITIONWINDOW;
 
         if (wParam)
@@ -5204,8 +5203,10 @@ static LRESULT CALLBACK EDIT_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPAR
 
     case WM_IME_STARTCOMPOSITION:
 #ifdef __REACTOS__
-        if (FALSE) /* FIXME: Condition */
+        /* Korean doesn't want composition window */
+        if (PRIMARYLANGID(LOWORD(GetKeyboardLayout(0))) == LANG_KOREAN)
             return TRUE;
+
         result = DefWindowProcW(hwnd, msg, wParam, lParam);
 #else
         es->composition_start = es->selection_end;

--- a/win32ss/user/user32/controls/edit.c
+++ b/win32ss/user/user32/controls/edit.c
@@ -1914,10 +1914,8 @@ static void EDIT_SetCaretPos(EDITSTATE *es, INT pos,
 
     SetCaretPos(pt.x, pt.y);
 
-    if (!ImmIsIME(hKL))
-        return;
-
-    EDIT_ImmSetCompositionWindow(es, pt);
+    if (IS_IME_HKL(hKL))
+        EDIT_ImmSetCompositionWindow(es, pt);
 #else
 	TRACE("%d - %dx%d\n", pos, (short)LOWORD(res), (short)HIWORD(res));
 	SetCaretPos((short)LOWORD(res), (short)HIWORD(res));
@@ -4038,7 +4036,7 @@ static void EDIT_WM_SetFont(EDITSTATE *es, HFONT font, BOOL redraw)
 		ShowCaret(es->hwndSelf);
 	}
 #ifdef __REACTOS__
-    if (ImmIsIME(GetKeyboardLayout(0)))
+    if (IS_IME_HKL(GetKeyboardLayout(0)))
     {
         LOGFONTW lf;
         HIMC hIMC = ImmGetContext(es->hwndSelf);
@@ -5387,7 +5385,8 @@ LRESULT WINAPI EditWndProc_common( HWND hwnd, UINT msg, WPARAM wParam, LPARAM lP
 	/* IME messages to make the edit control IME aware */
 	case WM_IME_SETCONTEXT:
 #ifdef __REACTOS__
-        if (FALSE) /* FIXME: Condition */
+        /* Korean doesn't want composition window */
+        if (PRIMARYLANGID(LOWORD(GetKeyboardLayout(0))) == LANG_KOREAN)
             lParam &= ~ISC_SHOWUICOMPOSITIONWINDOW;
 
         if (wParam)
@@ -5410,8 +5409,10 @@ LRESULT WINAPI EditWndProc_common( HWND hwnd, UINT msg, WPARAM wParam, LPARAM lP
 
 	case WM_IME_STARTCOMPOSITION:
 #ifdef __REACTOS__
-        if (FALSE) /* FIXME: Condition */
+        /* Korean doesn't want composition window */
+        if (PRIMARYLANGID(LOWORD(GetKeyboardLayout(0))) == LANG_KOREAN)
             return TRUE;
+
         result = DefWindowProcT(hwnd, msg, wParam, lParam, unicode);
 #else
 		es->composition_start = es->selection_end;

--- a/win32ss/user/user32/controls/edit.c
+++ b/win32ss/user/user32/controls/edit.c
@@ -5385,35 +5385,43 @@ LRESULT WINAPI EditWndProc_common( HWND hwnd, UINT msg, WPARAM wParam, LPARAM lP
 	/* IME messages to make the edit control IME aware */
 	case WM_IME_SETCONTEXT:
 #ifdef __REACTOS__
-        /* Korean doesn't want composition window */
-        if (PRIMARYLANGID(LOWORD(GetKeyboardLayout(0))) == LANG_KOREAN)
-            lParam &= ~ISC_SHOWUICOMPOSITIONWINDOW;
-
-        if (wParam)
         {
-            HIMC hIMC = ImmGetContext(hwnd);
-            LPINPUTCONTEXTDX pIC = (LPINPUTCONTEXTDX)ImmLockIMC(hIMC);
-            if (pIC)
-            {
-                pIC->dwUIFlags &= ~0x40000;
-                ImmUnlockIMC(hIMC);
-            }
-            if (GetWin32ClientInfo()->CI_flags & CI_WOW)
-                ImmNotifyIME(hIMC, NI_COMPOSITIONSTR, CPS_CANCEL, 0);
-            ImmReleaseContext(hwnd, hIMC);
-        }
+            HKL hKL = GetKeyboardLayout(0);
 
-        result = DefWindowProcT(hwnd, WM_IME_SETCONTEXT, wParam, lParam, unicode);
+            /* Korean doesn't want composition window */
+            if (PRIMARYLANGID(LOWORD(hKL)) == LANG_KOREAN)
+                lParam &= ~ISC_SHOWUICOMPOSITIONWINDOW;
+
+            if (wParam)
+            {
+                HIMC hIMC = ImmGetContext(hwnd);
+                LPINPUTCONTEXTDX pIC = (LPINPUTCONTEXTDX)ImmLockIMC(hIMC);
+                if (pIC)
+                {
+                    pIC->dwUIFlags &= ~0x40000;
+                    ImmUnlockIMC(hIMC);
+                }
+                if (GetWin32ClientInfo()->CI_flags & CI_WOW)
+                    ImmNotifyIME(hIMC, NI_COMPOSITIONSTR, CPS_CANCEL, 0);
+                ImmReleaseContext(hwnd, hIMC);
+            }
+
+            result = DefWindowProcT(hwnd, WM_IME_SETCONTEXT, wParam, lParam, unicode);
+        }
 #endif
 		break;
 
 	case WM_IME_STARTCOMPOSITION:
 #ifdef __REACTOS__
-        /* Korean doesn't want composition window */
-        if (PRIMARYLANGID(LOWORD(GetKeyboardLayout(0))) == LANG_KOREAN)
-            return TRUE;
+        {
+            HKL hKL = GetKeyboardLayout(0);
 
-        result = DefWindowProcT(hwnd, msg, wParam, lParam, unicode);
+            /* Korean doesn't want composition window */
+            if (PRIMARYLANGID(LOWORD(hKL)) == LANG_KOREAN)
+                return TRUE;
+
+            result = DefWindowProcT(hwnd, msg, wParam, lParam, unicode);
+        }
 #else
 		es->composition_start = es->selection_end;
 		es->composition_len = 0;


### PR DESCRIPTION
## Purpose
The caret move on IME was slow until this PR.
JIRA issue: [CORE-19268](https://jira.reactos.org/browse/CORE-19268)

## Proposed changes

- Don't use `ImmIsIME` but use `IS_IME_HKL(hKL)` in `EDIT_SetCaretPos` function. This change improves the caret speed.
- Prohibit display of composition window for Korean in the handling of `WM_IME_SETCONTEXT` and `WM_IME_STARTCOMPOSITION`, because Korean doesn't want it.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: