### PR TITLE
[KERNEL32] Implement GetFinalPathNameByHandleW

### DIFF
--- a/dll/win32/kernel32/kernel32_vista/CMakeLists.txt
+++ b/dll/win32/kernel32/kernel32_vista/CMakeLists.txt
@@ -11,6 +11,7 @@ list(APPEND SOURCE
     EnumSystemLocalesEx.c
     GetLocaleInfoEx.c
     GetFileInformationByHandleEx.c
+    GetFinalPathNameByHandle.c
     GetTickCount64.c
     GetUserDefaultLocaleName.c
     InitOnce.c

--- a/dll/win32/kernel32/kernel32_vista/GetFinalPathNameByHandle.c
+++ b/dll/win32/kernel32/kernel32_vista/GetFinalPathNameByHandle.c
@@ -1,0 +1,306 @@
+/*
+ * PROJECT:     ReactOS Win32 Base API
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     Implementation of GetFinalPathNameByHandleW
+ * COPYRIGHT:   Copyright 2025 Timo Kreuzer <timo.kreuzer@reactos.org>
+ */
+
+#include "k32_vista.h"
+#include <winnls.h>
+#include <mountmgr.h>
+
+#define NDEBUG
+#include <debug.h>
+
+// Note: The wine implementation is broken and cannot be used.
+
+static
+NTSTATUS
+QueryDosVolumeNameForNtDeviceName(
+    _In_ PCUNICODE_STRING DeviceName,
+    _Inout_ PUNICODE_STRING DosVolumeName)
+{
+    static const UNICODE_STRING MupDevice = RTL_CONSTANT_STRING(L"\\Device\\Mup");
+    static const UNICODE_STRING LanManDevice = RTL_CONSTANT_STRING(L"\\Device\\LanmanRedirector");
+    static const UNICODE_STRING MountMgrDevice = RTL_CONSTANT_STRING(L"\\Device\\MountPointManager");
+    static OBJECT_ATTRIBUTES ObjectAttributes = RTL_CONSTANT_OBJECT_ATTRIBUTES(&MountMgrDevice, OBJ_CASE_INSENSITIVE);
+    IO_STATUS_BLOCK IoStatusBlock;
+    HANDLE MountMgrHandle;
+    WCHAR Buffer[MAX_PATH];
+    PMOUNTMGR_TARGET_NAME TargetName = (PMOUNTMGR_TARGET_NAME)Buffer;
+    PMOUNTMGR_VOLUME_PATHS VolumePaths = (PMOUNTMGR_VOLUME_PATHS)Buffer;
+    NTSTATUS Status;
+
+    /* Validate parameters */
+    if ((DeviceName == NULL) || (DeviceName->Buffer == NULL) || (DeviceName->Length == 0) ||
+        (DosVolumeName == NULL) || (DosVolumeName->Buffer == NULL) || (DosVolumeName->MaximumLength == 0))
+    {
+        ASSERT(FALSE);
+        return STATUS_INVALID_PARAMETER;
+    }
+
+    /* Reset the output name */
+    DosVolumeName->Length = 0;
+
+    /* Check for network shares */
+    if (RtlEqualUnicodeString(DeviceName, &MupDevice, TRUE) ||
+        RtlEqualUnicodeString(DeviceName, &LanManDevice, TRUE))
+    {
+        /* For Mup or LanmanRedirector we use the UNC path format */
+        return RtlAppendUnicodeToString(DosVolumeName, L"\\\\?\\UNC\\");
+    }
+
+    /* Open a handle to the mount manager */
+    Status = NtCreateFile(&MountMgrHandle,
+                          STANDARD_RIGHTS_READ,
+                          &ObjectAttributes,
+                          &IoStatusBlock,
+                          NULL,
+                          FILE_ATTRIBUTE_NORMAL,
+                          FILE_SHARE_READ | FILE_SHARE_WRITE,
+                          FILE_OPEN_IF,
+                          0,
+                          NULL,
+                          0);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("NtCreateFile failed: %lx\n", Status);
+        return Status;
+    }
+
+    /* Use the MountMgr to query the volume name */
+    TargetName->DeviceNameLength = DeviceName->Length;
+    RtlCopyMemory(TargetName->DeviceName, DeviceName->Buffer, DeviceName->Length);
+    Status = NtDeviceIoControlFile(MountMgrHandle,
+                                   NULL,
+                                   NULL,
+                                   NULL,
+                                   &IoStatusBlock,
+                                   IOCTL_MOUNTMGR_QUERY_DOS_VOLUME_PATH,
+                                   Buffer,
+                                   sizeof(Buffer),
+                                   Buffer,
+                                   sizeof(Buffer));
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("NtDeviceIoControlFile failed: %lx\n", Status);
+        goto Exit;
+    }
+
+    if ((IoStatusBlock.Information < sizeof(*VolumePaths)) ||
+        (IoStatusBlock.Information < (VolumePaths->MultiSzLength + sizeof(ULONG))))
+    {
+        DPRINT1("Invalid information returned: %lu\n", IoStatusBlock.Information);
+        ASSERT(FALSE);
+        Status = STATUS_UNSUCCESSFUL;
+        goto Exit;
+    }
+
+    /* Construct the full volume path name from the first returned DOS volume */
+    if (!NT_SUCCESS(RtlAppendUnicodeToString(DosVolumeName, L"\\\\?\\")) ||
+        !NT_SUCCESS(RtlAppendUnicodeToString(DosVolumeName, VolumePaths->MultiSz) ||
+        !NT_SUCCESS(RtlAppendUnicodeToString(DosVolumeName, L"\\"))))
+    {
+        DPRINT1("RtlAppendUnicodeToString failed: %lx\n", Status);
+        goto Exit;
+    }
+
+    /* This is based on Windows behavior */
+    SetLastError(ERROR_SUCCESS);
+
+Exit:
+    NtClose(MountMgrHandle);
+
+    return Status;
+}
+
+DWORD
+WINAPI
+GetFinalPathNameByHandleW(
+    _In_ HANDLE hFile,
+    _Out_writes_(cchFilePath) LPWSTR lpszFilePath,
+    _In_ DWORD cchFilePath,
+    _In_ DWORD dwFlags)
+{
+    struct
+    {
+        union
+        {
+            OBJECT_NAME_INFORMATION Object;
+            FILE_NAME_INFORMATION File;
+        };
+        WCHAR String[MAX_PATH];
+    } NameInfoBuffer;
+    PFILE_NAME_INFORMATION FileNameInfo = &NameInfoBuffer.File;
+    PUNICODE_STRING ObjectName = &NameInfoBuffer.Object.Name;
+    WCHAR VolumeBuffer[sizeof("\\Device\\Volume{01234567-89ab-cdef-0123-456789abcdef}")];
+    IO_STATUS_BLOCK IoStatusBlock;
+    PWSTR PathSplit;
+    UNICODE_STRING DeviceName, RelativePath, VolumeName;
+    SIZE_T VolumeLength;
+    ULONG VolumeType;
+    NTSTATUS Status;
+    ULONG FinalLength;
+    BOOL Success;
+
+    /* Extract the requested volume type */
+    VolumeType = dwFlags & (VOLUME_NAME_GUID | VOLUME_NAME_NONE | VOLUME_NAME_NT);
+
+    /* Check if more than one volume type flag is set */
+    if (VolumeType & (VolumeType- 1))
+    {
+        DPRINT1("Invalid flags passed: %lx\n", dwFlags);
+        SetLastError(ERROR_INVALID_PARAMETER);
+        return 0;
+    }
+
+    /* Query the file name. This returns the relative path without volume.
+       This also validates that the handle refers to a file. */
+    Status = NtQueryInformationFile(hFile,
+                                    &IoStatusBlock,
+                                    &NameInfoBuffer,
+                                    sizeof(NameInfoBuffer),
+                                    FileNameInformation);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("NtQueryInformationFile failed: %lx\n", Status);
+        BaseSetLastNTError(Status);
+        return 0;
+    }
+
+    /* If no volume was requested, return the relative path */
+    if (VolumeType == VOLUME_NAME_NONE)
+    {
+        FinalLength = FileNameInfo->FileNameLength / sizeof(WCHAR);
+        if (cchFilePath < FinalLength + 1)
+        {
+            SetLastError(ERROR_NOT_ENOUGH_MEMORY);
+            return FinalLength + 1;
+        }
+
+        /* Copy the name to the caller's buffer */
+        RtlCopyMemory(lpszFilePath, FileNameInfo->FileName, FileNameInfo->FileNameLength);
+        lpszFilePath[FinalLength] = UNICODE_NULL;
+
+        /* Return the length of the name */
+        return FinalLength;
+    }
+
+    /* Query the NT object name */
+    Status = NtQueryObject(hFile,
+                           ObjectNameInformation,
+                           &NameInfoBuffer,
+                           sizeof(NameInfoBuffer) - sizeof(WCHAR),
+                           NULL);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("NtQueryObject failed: %lx\n", Status);
+        BaseSetLastNTError(Status);
+        return 0;
+    }
+
+    /* If the NT path was requested, we return the name as it is */
+    if (VolumeType == VOLUME_NAME_NT)
+    {
+        /* Calculate the final length and validate the buffer size */
+        FinalLength = ObjectName->Length / sizeof(WCHAR);
+        if (cchFilePath < FinalLength + 1)
+        {
+            SetLastError(ERROR_NOT_ENOUGH_MEMORY);
+            return FinalLength + 1;
+        }
+
+        /* Copy the name to the caller's buffer */
+        RtlCopyMemory(lpszFilePath, ObjectName->Buffer, ObjectName->Length);
+        lpszFilePath[ObjectName->Length / sizeof(WCHAR)] = UNICODE_NULL;
+
+        /* Return the length of the name */
+        return FinalLength;
+    }
+
+    /* For everything else we need to split the path */
+    PathSplit = wcschr(&ObjectName->Buffer[sizeof("\\Device\\") - 1], L'\\');
+    if (PathSplit == NULL)
+    {
+        DPRINT1("Invalid object name: %wZ\n", ObjectName);
+        SetLastError(ERROR_INVALID_HANDLE);
+        return 0;
+    }
+
+    DeviceName.Buffer = ObjectName->Buffer;
+    DeviceName.Length = (USHORT)(PathSplit - ObjectName->Buffer) * sizeof(WCHAR);
+    DeviceName.MaximumLength = DeviceName.Length;
+
+    RelativePath.Buffer = PathSplit + 1;
+    RelativePath.Length = ObjectName->Length - DeviceName.Length - sizeof(WCHAR);
+    RelativePath.MaximumLength = RelativePath.Length;
+
+    /* Query the DOS volume name */
+    RtlInitEmptyUnicodeString(&VolumeName, VolumeBuffer, sizeof(VolumeBuffer));
+    Status = QueryDosVolumeNameForNtDeviceName(&DeviceName, &VolumeName);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("QueryDosVolumeNameForNtDeviceName failed: %lx\n", Status);
+        BaseSetLastNTError(Status);
+        return 0;
+    }
+
+    if (VolumeType == VOLUME_NAME_DOS)
+    {
+        /* Calculate the final length and validate the buffer size */
+        FinalLength = ((VolumeName.Length + RelativePath.Length) / sizeof(WCHAR));
+        if (cchFilePath < FinalLength + 1)
+        {
+            SetLastError(ERROR_NOT_ENOUGH_MEMORY);
+            return FinalLength + 1;
+        }
+
+        /* Construct the final name */
+        RtlCopyMemory(lpszFilePath, VolumeName.Buffer, VolumeName.Length);
+        RtlCopyMemory(lpszFilePath + (VolumeName.Length / sizeof(WCHAR)),
+                      RelativePath.Buffer,
+                      RelativePath.Length);
+        lpszFilePath[FinalLength] = UNICODE_NULL;
+
+        /* Return the length of the name */
+        return FinalLength;
+    }
+    else if (VolumeType == VOLUME_NAME_GUID)
+    {
+        /* Query the GUID volume name */
+        Success = GetVolumeNameForVolumeMountPointW(VolumeBuffer,
+                                                    VolumeBuffer,
+                                                    ARRAYSIZE(VolumeBuffer));
+        if (!Success)
+        {
+            DPRINT1("GetVolumeNameForVolumeMountPointW failed: %d\n", GetLastError());
+            SetLastError(ERROR_PATH_NOT_FOUND);
+            return 0;
+        }
+
+        /* Calculate the final length and validate the buffer size */
+        VolumeLength = wcslen(VolumeBuffer);
+        FinalLength = VolumeLength + (RelativePath.Length / sizeof(WCHAR));
+        if (cchFilePath < FinalLength + 1)
+        {
+            SetLastError(ERROR_NOT_ENOUGH_MEMORY);
+            return FinalLength + 1;
+        }
+
+        /* Construct the final name */
+        RtlCopyMemory(lpszFilePath, VolumeBuffer, VolumeLength * sizeof(WCHAR));
+        RtlCopyMemory(lpszFilePath + VolumeLength,
+                      RelativePath.Buffer,
+                      RelativePath.Length);
+        lpszFilePath[FinalLength] = UNICODE_NULL;
+
+        /* This is based on Windows behavior */
+        SetLastError(ERROR_SUCCESS);
+
+        return FinalLength;
+    }
+
+    DPRINT1("Invalid flags passed: %lx\n", dwFlags);
+    SetLastError(ERROR_INVALID_PARAMETER);
+    return 0;
+}

--- a/dll/win32/kernel32/kernel32_vista/vista.c
+++ b/dll/win32/kernel32/kernel32_vista/vista.c
@@ -446,28 +446,6 @@ CreateSymbolicLinkA(IN LPCSTR lpSymlinkFileName,
 
 
 /*
- * @unimplemented
- */
-DWORD
-WINAPI
-GetFinalPathNameByHandleW(IN HANDLE hFile,
-                          OUT LPWSTR lpszFilePath,
-                          IN DWORD cchFilePath,
-                          IN DWORD dwFlags)
-{
-    if (dwFlags & ~(VOLUME_NAME_DOS | VOLUME_NAME_GUID | VOLUME_NAME_NT |
-                    VOLUME_NAME_NONE | FILE_NAME_NORMALIZED | FILE_NAME_OPENED))
-    {
-        SetLastError(ERROR_INVALID_PARAMETER);
-        return 0;
-    }
-
-    UNIMPLEMENTED;
-    return 0;
-}
-
-
-/*
  * @implemented
  */
 DWORD
@@ -533,7 +511,6 @@ GetFinalPathNameByHandleA(IN HANDLE hFile,
 
     return Ret;
 }
-
 
 /*
  * @unimplemented

--- a/modules/rostests/apitests/kernel32/CMakeLists.txt
+++ b/modules/rostests/apitests/kernel32/CMakeLists.txt
@@ -17,6 +17,7 @@ list(APPEND SOURCE
     GetCPInfo.c
     GetCurrentDirectory.c
     GetDriveType.c
+    GetFinalPathNameByHandle.c
     GetLocaleInfo.c
     GetModuleFileName.c
     GetVolumeInformation.c
@@ -54,7 +55,7 @@ add_executable(kernel32_apitest
 target_link_libraries(kernel32_apitest wine ${PSEH_LIB})
 set_module_type(kernel32_apitest win32cui)
 add_delay_importlibs(kernel32_apitest advapi32 shlwapi)
-add_importlibs(kernel32_apitest msvcrt kernel32 ntdll)
+add_importlibs(kernel32_apitest netapi32 msvcrt kernel32 ntdll)
 add_dependencies(kernel32_apitest FormatMessage)
 add_pch(kernel32_apitest precomp.h "${PCH_SKIP_SOURCE}")
 add_rostests_file(TARGET kernel32_apitest)

--- a/modules/rostests/apitests/kernel32/GetFinalPathNameByHandle.c
+++ b/modules/rostests/apitests/kernel32/GetFinalPathNameByHandle.c
@@ -1,0 +1,464 @@
+/*
+ * PROJECT:     ReactOS api tests
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     Tests for GetFinalPathNameByHandleW
+ * COPYRIGHT:   Copyright 2025 Timo Kreuzer <timo.kreuzer@reactos.org>
+ */
+
+#include "precomp.h"
+#include <lm.h>
+#include <ndk/obfuncs.h>
+#include <ndk/iofuncs.h>
+
+typedef
+DWORD
+WINAPI
+FN_GetFinalPathNameByHandleW(
+    _In_ HANDLE hFile,
+    _Out_writes_(cchFilePath) LPWSTR lpszFilePath,
+    _In_ DWORD cchFilePath,
+    _In_ DWORD dwFlags);
+FN_GetFinalPathNameByHandleW* pGetFinalPathNameByHandleW = NULL;
+
+#define VOLUME_NAME_DOS 0x0
+#define VOLUME_NAME_GUID 0x1
+#define VOLUME_NAME_NT 0x2
+#define VOLUME_NAME_NONE 0x4
+#define FILE_NAME_NORMALIZED 0x0
+#define FILE_NAME_OPENED 0x8
+
+static void Test_File(void)
+{
+    WCHAR FilePath[MAX_PATH];
+    WCHAR Buffer[MAX_PATH];
+    WCHAR VolumeBuffer[4];
+    PWSTR VolumeRelativePath;
+    WCHAR ExpectedString[MAX_PATH];
+    DWORD Result;
+    SIZE_T ExpectedStringLength;
+    HANDLE hFile;
+    BOOL Success;
+
+    /* Get the full path name of the current executable */
+    Result = GetModuleFileNameW(NULL, FilePath, ARRAYSIZE(FilePath));
+    ok(Result != 0, "GetModuleFileNameW failed: %ld\n", GetLastError());
+    if (Result == 0)
+    {
+        skip("GetModuleFileNameW failed\n");
+        return;
+    }
+
+    /* Open the executable file */
+    hFile = CreateFileW(FilePath,
+                        GENERIC_READ,
+                        FILE_SHARE_READ | FILE_SHARE_WRITE,
+                        NULL,
+                        OPEN_EXISTING,
+                        FILE_ATTRIBUTE_NORMAL,
+                        NULL);
+    ok(hFile != INVALID_HANDLE_VALUE, "File '%S': Opening failed\n", FilePath);
+    if (hFile == INVALID_HANDLE_VALUE)
+    {
+        skip("File '%S': Opening failed\n", FilePath);
+        return;
+    }
+
+    /* Expected string for VOLUME_NAME_DOS:
+       L"\\\\?\\C:\\ReactOS\\bin\\kernel32_apitest.exe" */
+    wcscpy(ExpectedString, L"\\\\?\\");
+    wcscat(ExpectedString, FilePath);
+    ExpectedStringLength = wcslen(ExpectedString);
+
+    SetLastError(0xdeadbeef);
+    StartSeh()
+        Result = pGetFinalPathNameByHandleW(hFile, NULL, ARRAYSIZE(Buffer), VOLUME_NAME_DOS);
+    EndSeh(STATUS_ACCESS_VIOLATION)
+
+    SetLastError(0xdeadbeef);
+    memset(Buffer, 0xCC, sizeof(Buffer));
+    Result = pGetFinalPathNameByHandleW(hFile, Buffer, 0, VOLUME_NAME_DOS);
+    ok_eq_ulong(Result, ExpectedStringLength + 1);
+    ok_eq_wchar(Buffer[0], 0xCCCC);
+    ok_err(ERROR_NOT_ENOUGH_MEMORY);
+
+    SetLastError(0xdeadbeef);
+    memset(Buffer, 0xCC, sizeof(Buffer));
+    Result = pGetFinalPathNameByHandleW(hFile, Buffer, 9, VOLUME_NAME_DOS);
+    ok_eq_ulong(Result, ExpectedStringLength + 1);
+    ok_eq_wchar(Buffer[0], 0xCCCC);
+    ok_err(ERROR_NOT_ENOUGH_MEMORY);
+
+    SetLastError(0xdeadbeef);
+    memset(Buffer, 0xCC, sizeof(Buffer));
+    Result = pGetFinalPathNameByHandleW(hFile, NULL, 0, VOLUME_NAME_DOS);
+    ok_eq_ulong(Result, ExpectedStringLength + 1);
+    ok_err(ERROR_NOT_ENOUGH_MEMORY);
+
+    SetLastError(0xdeadbeef);
+    memset(Buffer, 0xCC, sizeof(Buffer));
+    Result = pGetFinalPathNameByHandleW(hFile, Buffer, ARRAYSIZE(Buffer), 0x1000);
+    ok_eq_ulong(Result, ExpectedStringLength);
+    ok_eq_wstr(Buffer, ExpectedString);
+    ok_err(0);
+
+    SetLastError(0xdeadbeef);
+    memset(Buffer, 0xCC, sizeof(Buffer));
+    Result = pGetFinalPathNameByHandleW(hFile, Buffer, ARRAYSIZE(Buffer), 7);
+    ok_eq_ulong(Result, 0ul);
+    ok_eq_wchar(Buffer[0], 0xCCCC);
+    ok_err(ERROR_INVALID_PARAMETER);
+
+    SetLastError(0xdeadbeef);
+    memset(Buffer, 0xCC, sizeof(Buffer));
+    Result = pGetFinalPathNameByHandleW(hFile, Buffer, ARRAYSIZE(Buffer), VOLUME_NAME_DOS);
+    ok_eq_ulong(Result, ExpectedStringLength);
+    ok_eq_wstr(Buffer, ExpectedString);
+    ok_err(0);
+
+    SetLastError(0xdeadbeef);
+    memset(Buffer, 0xCC, sizeof(Buffer));
+    Result = pGetFinalPathNameByHandleW(hFile, Buffer, ARRAYSIZE(Buffer), VOLUME_NAME_DOS | FILE_NAME_OPENED);
+    ok_eq_ulong(Result, ExpectedStringLength);
+    ok_eq_wstr(Buffer, ExpectedString);
+    ok_err(0);
+
+    /* Query the GUID based volume name */
+    memcpy(VolumeBuffer, FilePath, 3 * sizeof(WCHAR));
+    VolumeBuffer[3] = UNICODE_NULL;
+    Success = GetVolumeNameForVolumeMountPointW(VolumeBuffer,
+                                                ExpectedString,
+                                                ARRAYSIZE(ExpectedString));
+    if (!Success)
+    {
+        skip("GetVolumeNameForVolumeMountPointW failed: %ld\n", GetLastError());
+        return;
+    }
+
+    /* Expected string for VOLUME_NAME_GUID:
+       L"\\\\?\\Volume{cd4317d4-A62f-53d7-b36c-73f935c37280}\\ReactOS\\bin\\kernel32_apitest.exe" */
+    VolumeRelativePath = &FilePath[wcslen(L"C:\\")];
+    wcscat(ExpectedString, VolumeRelativePath);
+    ExpectedStringLength = wcslen(ExpectedString);
+
+    SetLastError(0xdeadbeef);
+    memset(Buffer, 0xCC, sizeof(Buffer));
+    Result = pGetFinalPathNameByHandleW(hFile, Buffer, ARRAYSIZE(Buffer), VOLUME_NAME_GUID);
+    ok_eq_ulong(Result, ExpectedStringLength);
+    ok_eq_wstr(Buffer, ExpectedString);
+    ok_err(0);
+
+    SetLastError(0xdeadbeef);
+    memset(Buffer, 0xCC, sizeof(Buffer));
+    Result = pGetFinalPathNameByHandleW(hFile, Buffer, ARRAYSIZE(Buffer), VOLUME_NAME_GUID | FILE_NAME_OPENED);
+    ok_eq_ulong(Result, ExpectedStringLength);
+    ok_eq_wstr(Buffer, ExpectedString);
+    ok_err(0);
+
+    /* Expected string for VOLUME_NAME_NT (2):
+       L"\\Device\\HarddiskVolume1\\ReactOS\\bin\\kernel32_apitest.exe" */
+    ExpectedStringLength = wcslen(L"\\Device\\HarddiskVolume*\\") +
+                           wcslen(VolumeRelativePath);
+
+    SetLastError(0xdeadbeef);
+    memset(Buffer, 0xCC, sizeof(Buffer));
+    Result = pGetFinalPathNameByHandleW(hFile, Buffer, ARRAYSIZE(Buffer), VOLUME_NAME_NT);
+    ok_eq_ulong(Result, ExpectedStringLength);
+    ok_int(wcsncmp(Buffer, L"\\Device\\HarddiskVolume", 22), 0);
+    ok_int(wcscmp(Buffer + 24, VolumeRelativePath), 0);
+    ok_err(0xdeadbeef);
+
+    SetLastError(0xdeadbeef);
+    memset(Buffer, 0xCC, sizeof(Buffer));
+    Result = pGetFinalPathNameByHandleW(hFile, Buffer, ARRAYSIZE(Buffer), VOLUME_NAME_NT | FILE_NAME_OPENED);
+    ok_eq_ulong(Result, ExpectedStringLength);
+    ok_int(wcsncmp(Buffer, L"\\Device\\HarddiskVolume", 22), 0);
+    ok_int(wcscmp(Buffer + 24, VolumeRelativePath), 0);
+    ok_err(0xdeadbeef);
+
+    /* Expected string for VOLUME_NAME_NONE:
+       L"\\ReactOS\\bin\\kernel32_apitest.exe" */
+    ExpectedStringLength = wcslen(VolumeRelativePath - 1);
+
+    SetLastError(0xdeadbeef);
+    memset(Buffer, 0xCC, sizeof(Buffer));
+    Result = pGetFinalPathNameByHandleW(hFile, Buffer, ARRAYSIZE(Buffer), VOLUME_NAME_NONE);
+    ok_eq_ulong(Result, ExpectedStringLength);
+    ok_eq_wstr(Buffer, VolumeRelativePath - 1);
+    ok_err(0xdeadbeef);
+
+    SetLastError(0xdeadbeef);
+    memset(Buffer, 0xCC, sizeof(Buffer));
+    Result = pGetFinalPathNameByHandleW(hFile, Buffer, ARRAYSIZE(Buffer), VOLUME_NAME_NONE | FILE_NAME_OPENED);
+    ok_eq_ulong(Result, ExpectedStringLength);
+    ok_eq_wstr(Buffer, VolumeRelativePath - 1);
+    ok_err(0xdeadbeef);
+
+    SetLastError(0xdeadbeef);
+    memset(Buffer, 0xCC, sizeof(Buffer));
+    Result = pGetFinalPathNameByHandleW(hFile, Buffer, 1, VOLUME_NAME_NONE | FILE_NAME_OPENED);
+    ok_eq_ulong(Result, ExpectedStringLength + 1);
+    ok_eq_wchar(Buffer[0], 0xCCCC);
+    ok_err(ERROR_NOT_ENOUGH_MEMORY);
+
+    CloseHandle(hFile);
+}
+
+static void Test_NetworkShare(void)
+{
+    WCHAR PathBuffer[MAX_PATH];
+    WCHAR RemotePathBuffer[MAX_PATH];
+    WCHAR Buffer[MAX_PATH];
+    WCHAR ExpectedString[MAX_PATH];
+    PWSTR FileName;
+    DWORD Result;
+    SIZE_T ExpectedStringLength;
+    DWORD dwError = 0;
+    HANDLE hFile;
+    NET_API_STATUS Status;
+
+    /* Get the full path name of the current executable */
+    Result = GetModuleFileNameW(NULL, PathBuffer, ARRAYSIZE(PathBuffer));
+    ok(Result != 0, "GetModuleFileNameW failed: %ld\n", GetLastError());
+    if (Result == 0)
+    {
+        skip("GetModuleFileNameW failed: %ld\n", GetLastError());
+        return;
+    }
+
+    /* Reduce to the containing folder */
+    FileName = wcsrchr(PathBuffer, L'\\');
+    *FileName = L'\0';
+    FileName++;
+
+    // Define the share parameters
+    static WCHAR ShareName[] = L"TestShare"; // Name of the share
+
+    NetShareDel(L"", ShareName, 0);
+
+    // Set up the SHARE_INFO_2 structure
+    SHARE_INFO_2 shareInfo = { 0 };
+    shareInfo.shi2_netname = ShareName;
+    shareInfo.shi2_type = STYPE_DISKTREE; // Disk directory share
+    shareInfo.shi2_remark = L"";
+    shareInfo.shi2_permissions = ACCESS_ALL; // Full access (adjust as needed)
+    shareInfo.shi2_max_uses = -1; // Unlimited connections
+    shareInfo.shi2_current_uses = 0; // 0 for new share
+    shareInfo.shi2_path = PathBuffer;
+    shareInfo.shi2_passwd = NULL; // No password
+
+    // Call NetShareAdd to create the share
+    Status = NetShareAdd(L"", // Empty string for local machine
+                         2,             // Level 2 for SHARE_INFO_2
+                         (LPBYTE)&shareInfo, // Share info structure
+                         &dwError);       // Error code if applicable
+    if (Status != NERR_Success)
+    {
+        skip("Failed to create share. Error code: %ld\n", Status);
+        if (Status == ERROR_ACCESS_DENIED)
+        {
+            wprintf(L"Error: Access denied. Ensure you have administrative privileges.\n");
+        }
+
+        return;
+    }
+
+    swprintf(RemotePathBuffer, L"\\\\localhost\\%s\\%s", ShareName, FileName);
+    hFile = CreateFileW(RemotePathBuffer,
+                        GENERIC_READ,
+                        FILE_SHARE_READ | FILE_SHARE_WRITE,
+                        NULL,
+                        OPEN_EXISTING,
+                        FILE_ATTRIBUTE_NORMAL,
+                        NULL);
+    ok(hFile != INVALID_HANDLE_VALUE, "Failed to open file '%S'. Error: %ld\n",
+       RemotePathBuffer, GetLastError());
+    if (hFile == INVALID_HANDLE_VALUE)
+    {
+        skip("Failed to open file '%S'. Error: %ld\n", RemotePathBuffer, GetLastError());
+        /* Clean up by deleting the share */
+        NetShareDel(L"", ShareName, 0);
+        return;
+    }
+
+    /* Expected string for VOLUME_NAME_DOS:
+       L"\\\\?\\UNC\\localhost\\TestShare\\kernel32_apitest.exe" */
+    swprintf(ExpectedString, L"\\\\?\\UNC\\localhost\\%s\\%s", ShareName, FileName);
+    ExpectedStringLength = wcslen(ExpectedString);
+    SetLastError(0xdeadbeef);
+    memset(Buffer, 0xCC, sizeof(Buffer));
+    Result = pGetFinalPathNameByHandleW(hFile, Buffer, ARRAYSIZE(Buffer), VOLUME_NAME_DOS);
+    ok_eq_ulong(Result, ExpectedStringLength);
+    ok_eq_wstr(Buffer, ExpectedString);
+    ok_err(0xdeadbeef);
+
+    SetLastError(0xdeadbeef);
+    memset(Buffer, 0xCC, sizeof(Buffer));
+    Result = pGetFinalPathNameByHandleW(hFile, Buffer, ARRAYSIZE(Buffer), VOLUME_NAME_DOS | FILE_NAME_OPENED);
+    ok_eq_ulong(Result, ExpectedStringLength);
+    ok_eq_wstr(Buffer, ExpectedString);
+    ok_err(0xdeadbeef);
+
+    // VOLUME_NAME_GUID doesn't work for network shares
+    SetLastError(0xdeadbeef);
+    memset(Buffer, 0xCC, sizeof(Buffer));
+    Result = pGetFinalPathNameByHandleW(hFile, Buffer, ARRAYSIZE(Buffer), VOLUME_NAME_GUID);
+    ok_eq_ulong(Result, 0ul);
+    ok_eq_wchar(Buffer[0], 0xCCCC);
+    ok_err(ERROR_PATH_NOT_FOUND);
+
+    SetLastError(0xdeadbeef);
+    memset(Buffer, 0xCC, sizeof(Buffer));
+    Result = pGetFinalPathNameByHandleW(hFile, Buffer, ARRAYSIZE(Buffer), VOLUME_NAME_GUID | FILE_NAME_OPENED);
+    ok_eq_ulong(Result, 0ul);
+    ok_eq_wchar(Buffer[0], 0xCCCC);
+    ok_err(ERROR_PATH_NOT_FOUND);
+
+    /* Expected string for VOLUME_NAME_NT (2):
+       L"\\Device\\Mup\\localhost\\TestShare\\kernel32_apitest.exe" */
+    swprintf(ExpectedString, L"\\Device\\Mup\\localhost\\%s\\%s", ShareName, FileName);
+    ExpectedStringLength = wcslen(ExpectedString);
+    SetLastError(0xdeadbeef);
+    memset(Buffer, 0xCC, sizeof(Buffer));
+    Result = pGetFinalPathNameByHandleW(hFile, Buffer, ARRAYSIZE(Buffer), VOLUME_NAME_NT);
+    ok_eq_ulong(Result, ExpectedStringLength);
+    ok_eq_wstr(Buffer, ExpectedString);
+    ok_err(0xdeadbeef);
+
+    SetLastError(0xdeadbeef);
+    memset(Buffer, 0xCC, sizeof(Buffer));
+    Result = pGetFinalPathNameByHandleW(hFile, Buffer, ARRAYSIZE(Buffer), VOLUME_NAME_NT | FILE_NAME_OPENED);
+    ok_eq_ulong(Result, ExpectedStringLength);
+    ok_eq_wstr(Buffer, ExpectedString);
+    ok_err(0xdeadbeef);
+
+    /* Expected string for VOLUME_NAME_NONE:
+       L"\\localhost\\TestShare\\kernel32_apitest.exe" */
+    swprintf(ExpectedString, L"\\localhost\\%s\\%s", ShareName,  FileName);
+    ExpectedStringLength = wcslen(ExpectedString);
+    SetLastError(0xdeadbeef);
+    memset(Buffer, 0xCC, sizeof(Buffer));
+    Result = pGetFinalPathNameByHandleW(hFile, Buffer, ARRAYSIZE(Buffer), VOLUME_NAME_NONE);
+    ok_eq_ulong(Result, ExpectedStringLength);
+    ok_eq_wstr(Buffer, ExpectedString);
+    ok_err(0xdeadbeef);
+
+    SetLastError(0xdeadbeef);
+    memset(Buffer, 0xCC, sizeof(Buffer));
+    Result = pGetFinalPathNameByHandleW(hFile, Buffer, ARRAYSIZE(Buffer), VOLUME_NAME_NONE | FILE_NAME_OPENED);
+    ok_eq_ulong(Result, ExpectedStringLength);
+    ok_eq_wstr(Buffer, ExpectedString);
+    ok_err(0xdeadbeef);
+
+    /* Clean up */
+    CloseHandle(hFile);
+    Status = NetShareDel(L"", ShareName, 0);
+    ok_ntstatus(Status, NERR_Success);
+}
+
+static void Test_Other(void)
+{
+    WCHAR Buffer[MAX_PATH];
+    DWORD Result;
+    HANDLE Handle;
+    UNICODE_STRING DeviceName;
+    OBJECT_ATTRIBUTES ObjectAttributes;
+    IO_STATUS_BLOCK IoStatusBlock;
+    NTSTATUS Status;
+
+    /* Test NULL handle */
+    SetLastError(0xdeadbeef);
+    Result = pGetFinalPathNameByHandleW(NULL, Buffer, ARRAYSIZE(Buffer), VOLUME_NAME_DOS);
+    ok_eq_ulong(Result, 0ul);
+    ok_err(ERROR_INVALID_HANDLE);
+
+    /* Test NULL handle and NULL buffer */
+    SetLastError(0xdeadbeef);
+    Result = pGetFinalPathNameByHandleW(NULL, NULL, ARRAYSIZE(Buffer), VOLUME_NAME_DOS);
+    ok_eq_ulong(Result, 0ul);
+    ok_err(ERROR_INVALID_HANDLE);
+
+    /* Test NULL handle and invalid volume type */
+    SetLastError(0xdeadbeef);
+    Result = pGetFinalPathNameByHandleW(NULL, Buffer, ARRAYSIZE(Buffer), VOLUME_NAME_NT | VOLUME_NAME_GUID);
+    ok_eq_ulong(Result, 0ul);
+    ok_err(ERROR_INVALID_PARAMETER);
+
+    /* Test INVALID_HANDLE_VALUE */
+    SetLastError(0xdeadbeef);
+    memset(Buffer, 0xCC, sizeof(Buffer));
+    Result = pGetFinalPathNameByHandleW(INVALID_HANDLE_VALUE, Buffer, ARRAYSIZE(Buffer), VOLUME_NAME_DOS);
+    ok_eq_ulong(Result, 0ul);
+    ok_eq_wchar(Buffer[0], 0xCCCC);
+    ok_err(ERROR_INVALID_HANDLE);
+
+    /* Test NtCurrentProcess */
+    SetLastError(0xdeadbeef);
+    memset(Buffer, 0xCC, sizeof(Buffer));
+    Result = pGetFinalPathNameByHandleW(NtCurrentProcess(), Buffer, ARRAYSIZE(Buffer), VOLUME_NAME_NT);
+    ok_eq_ulong(Result, 0ul);
+    ok_eq_wchar(Buffer[0], 0xCCCC);
+    ok_err(ERROR_INVALID_HANDLE);
+
+    /* Open a handle to the Beep device */
+    RtlInitUnicodeString(&DeviceName, L"\\Device\\Beep");
+    InitializeObjectAttributes(&ObjectAttributes, &DeviceName, OBJ_CASE_INSENSITIVE, NULL, NULL);
+    Status = NtOpenFile(&Handle, FILE_READ_ATTRIBUTES, &ObjectAttributes, &IoStatusBlock, FILE_SHARE_READ | FILE_SHARE_WRITE, 0);
+    ok_ntstatus(Status, STATUS_SUCCESS);
+    if (!NT_SUCCESS(Status))
+    {
+        skip("Opening Beep device failed\n");
+    }
+    else
+    {
+        SetLastError(0xdeadbeef);
+        memset(Buffer, 0xCC, sizeof(Buffer));
+        Result = pGetFinalPathNameByHandleW(Handle, Buffer, ARRAYSIZE(Buffer), VOLUME_NAME_NT);
+        ok_eq_ulong(Result, 0ul);
+        ok_eq_wchar(Buffer[0], 0xCCCC);
+        ok_err(ERROR_INVALID_FUNCTION);
+        NtClose(Handle);
+    }
+
+    /* Open a handle to the Null device */
+    RtlInitUnicodeString(&DeviceName, L"\\Device\\Null");
+    InitializeObjectAttributes(&ObjectAttributes, &DeviceName, OBJ_CASE_INSENSITIVE, NULL, NULL);
+    Status = NtOpenFile(&Handle, FILE_READ_ATTRIBUTES, &ObjectAttributes, &IoStatusBlock, FILE_SHARE_READ | FILE_SHARE_WRITE, 0);
+    ok_ntstatus(Status, STATUS_SUCCESS);
+    if (!NT_SUCCESS(Status))
+    {
+        skip("Opening Null device failed\n");
+    }
+    else
+    {
+        SetLastError(0xdeadbeef);
+        memset(Buffer, 0xCC, sizeof(Buffer));
+        Result = pGetFinalPathNameByHandleW(Handle, Buffer, ARRAYSIZE(Buffer), VOLUME_NAME_NT);
+        ok_eq_ulong(Result, 0ul);
+        ok_eq_wchar(Buffer[0], 0xCCCC);
+        ok_err(ERROR_INVALID_PARAMETER);
+        NtClose(Handle);
+    }
+}
+
+
+START_TEST(GetFinalPathNameByHandle)
+{
+    HMODULE hmodKernel32 = GetModuleHandleW(L"kernel32.dll");
+    pGetFinalPathNameByHandleW = (FN_GetFinalPathNameByHandleW*)
+        GetProcAddress(hmodKernel32, "GetFinalPathNameByHandleW");
+    if (pGetFinalPathNameByHandleW == NULL)
+    {
+        hmodKernel32 = GetModuleHandleW(L"kernel32_vista.dll");
+        pGetFinalPathNameByHandleW = (FN_GetFinalPathNameByHandleW*)
+            GetProcAddress(hmodKernel32, "GetFinalPathNameByHandleW");
+        if (pGetFinalPathNameByHandleW == NULL)
+        {
+            skip("GetFinalPathNameByHandleW not available\n");
+            return;
+        }
+    }
+
+    Test_File();
+    Test_NetworkShare();
+    Test_Other();
+}

--- a/modules/rostests/apitests/kernel32/testlist.c
+++ b/modules/rostests/apitests/kernel32/testlist.c
@@ -17,6 +17,7 @@ extern void func_GetComputerNameEx(void);
 extern void func_GetCPInfo(void);
 extern void func_GetCurrentDirectory(void);
 extern void func_GetDriveType(void);
+extern void func_GetFinalPathNameByHandle(void);
 extern void func_GetLocaleInfo(void);
 extern void func_GetModuleFileName(void);
 extern void func_GetVolumeInformation(void);
@@ -58,6 +59,7 @@ const struct test winetest_testlist[] =
     { "GetCPInfo",                   func_GetCPInfo },
     { "GetCurrentDirectory",         func_GetCurrentDirectory },
     { "GetDriveType",                func_GetDriveType },
+    { "GetFinalPathNameByHandle",    func_GetFinalPathNameByHandle },
     { "GetLocaleInfo",               func_GetLocaleInfo },
     { "GetModuleFileName",           func_GetModuleFileName },
     { "GetVolumeInformation",        func_GetVolumeInformation },

--- a/sdk/include/psdk/lmshare.h
+++ b/sdk/include/psdk/lmshare.h
@@ -33,96 +33,159 @@ extern "C" {
 #define PERM_FILE_READ 1
 #define PERM_FILE_WRITE 2
 #define PERM_FILE_CREATE 4
-typedef struct _FILE_INFO_2 { DWORD fi2_id;} FILE_INFO_2,*PFILE_INFO_2,*LPFILE_INFO_2;
-typedef struct _FILE_INFO_3 {
+
+typedef struct _FILE_INFO_2
+{
+    DWORD fi2_id;
+} FILE_INFO_2, *PFILE_INFO_2, *LPFILE_INFO_2;
+
+typedef struct _FILE_INFO_3
+{
 	DWORD fi3_id;
 	DWORD fi3_permissions;
 	DWORD fi3_num_locks;
-	LPTSTR fi3_pathname;
-	LPTSTR fi3_username;
-} FILE_INFO_3,*PFILE_INFO_3,*LPFILE_INFO_3;
-typedef struct _SHARE_INFO_0 { LPTSTR shi0_netname; } SHARE_INFO_0,*PSHARE_INFO_0,*LPSHARE_INFO_0;
-typedef struct _SHARE_INFO_1 {
-	LPTSTR shi1_netname;
+	LMSTR fi3_pathname;
+	LMSTR fi3_username;
+} FILE_INFO_3, *PFILE_INFO_3, *LPFILE_INFO_3;
+
+typedef struct _SHARE_INFO_0
+{
+    LMSTR shi0_netname;
+} SHARE_INFO_0, *PSHARE_INFO_0, *LPSHARE_INFO_0;
+
+typedef struct _SHARE_INFO_1
+{
+	LMSTR shi1_netname;
 	DWORD shi1_type;
-	LPTSTR shi1_remark;
-} SHARE_INFO_1,*PSHARE_INFO_1,*LPSHARE_INFO_1;
-typedef struct _SHARE_INFO_2 {
-	LPTSTR shi2_netname;
+	LMSTR shi1_remark;
+} SHARE_INFO_1, *PSHARE_INFO_1, *LPSHARE_INFO_1;
+
+typedef struct _SHARE_INFO_2
+{
+	LMSTR shi2_netname;
 	DWORD shi2_type;
-	LPTSTR shi2_remark;
+	LMSTR shi2_remark;
 	DWORD shi2_permissions;
 	DWORD shi2_max_uses;
 	DWORD shi2_current_uses;
-	LPTSTR shi2_path;
-	LPTSTR shi2_passwd;
-} SHARE_INFO_2,*PSHARE_INFO_2,*LPSHARE_INFO_2;
-typedef struct _SHARE_INFO_502 {
-	LPTSTR shi502_netname;
+	LMSTR shi2_path;
+	LMSTR shi2_passwd;
+} SHARE_INFO_2, *PSHARE_INFO_2, *LPSHARE_INFO_2;
+
+typedef struct _SHARE_INFO_501
+{
+    LMSTR shi501_netname;
+    DWORD shi501_type;
+    LMSTR shi501_remark;
+    DWORD shi501_flags;
+} SHARE_INFO_501, *PSHARE_INFO_501, *LPSHARE_INFO_501;
+
+typedef struct _SHARE_INFO_502
+{
+	LMSTR shi502_netname;
 	DWORD shi502_type;
-	LPTSTR shi502_remark;
+	LMSTR shi502_remark;
 	DWORD shi502_permissions;
 	DWORD shi502_max_uses;
 	DWORD shi502_current_uses;
-	LPTSTR shi502_path;
-	LPTSTR shi502_passwd;
+	LMSTR shi502_path;
+	LMSTR shi502_passwd;
 	DWORD shi502_reserved;
 	PSECURITY_DESCRIPTOR shi502_security_descriptor;
-} SHARE_INFO_502,*PSHARE_INFO_502,*LPSHARE_INFO_502;
-typedef struct _SHARE_INFO_1004 {
+} SHARE_INFO_502, *PSHARE_INFO_502, *LPSHARE_INFO_502;
+
+typedef struct _SHARE_INFO_503
+{
+    LMSTR shi503_netname;
+    DWORD shi503_type;
+    LMSTR shi503_remark;
+    DWORD shi503_permissions;
+    DWORD shi503_max_uses;
+    DWORD shi503_current_uses;
+    LMSTR shi503_path;
+    LMSTR shi503_passwd;
+    LMSTR shi503_servername;
+    DWORD shi503_reserved;
+    PSECURITY_DESCRIPTOR  shi503_security_descriptor;
+} SHARE_INFO_503, *PSHARE_INFO_503, *LPSHARE_INFO_503;
+
+typedef struct _SHARE_INFO_1004
+{
 	LPTSTR shi1004_remark;
-} SHARE_INFO_1004,*PSHARE_INFO_1004,*LPSHARE_INFO_1004;
-typedef struct _SHARE_INFO_1006 {
+} SHARE_INFO_1004, *PSHARE_INFO_1004, *LPSHARE_INFO_1004;
+
+typedef struct _SHARE_INFO_1006
+{
 	DWORD shi1006_max_uses;
-} SHARE_INFO_1006,*PSHARE_INFO_1006,*LPSHARE_INFO_1006;
-typedef struct _SHARE_INFO_1501 {
+} SHARE_INFO_1006, *PSHARE_INFO_1006, *LPSHARE_INFO_1006;
+
+typedef struct _SHARE_INFO_1501
+{
 	DWORD shi1501_reserved;
 	PSECURITY_DESCRIPTOR shi1501_security_descriptor;
-} SHARE_INFO_1501,*PSHARE_INFO_1501,*LPSHARE_INFO_1501;
-typedef struct _SESSION_INFO_0 { LPWSTR sesi0_cname; } SESSION_INFO_0,*PSESSION_INFO_0,*LPSESSION_INFO_0;
-typedef struct _SESSION_INFO_1 {
-	LPTSTR sesi1_cname;
-	LPTSTR sesi1_username;
+} SHARE_INFO_1501, *PSHARE_INFO_1501, *LPSHARE_INFO_1501;
+
+typedef struct _SESSION_INFO_0
+{
+    LMSTR sesi0_cname;
+} SESSION_INFO_0, *PSESSION_INFO_0, *LPSESSION_INFO_0;
+
+typedef struct _SESSION_INFO_1
+{
+	LMSTR sesi1_cname;
+	LMSTR sesi1_username;
 	DWORD sesi1_num_opens;
 	DWORD sesi1_time;
 	DWORD sesi1_idle_time;
 	DWORD sesi1_user_flags;
-} SESSION_INFO_1,*PSESSION_INFO_1,*LPSESSION_INFO_1;
-typedef struct _SESSION_INFO_2 {
-	LPTSTR sesi2_cname;
-	LPTSTR sesi2_username;
+} SESSION_INFO_1, *PSESSION_INFO_1, *LPSESSION_INFO_1;
+
+typedef struct _SESSION_INFO_2
+{
+	LMSTR sesi2_cname;
+	LMSTR sesi2_username;
 	DWORD sesi2_num_opens;
 	DWORD sesi2_time;
 	DWORD sesi2_idle_time;
 	DWORD sesi2_user_flags;
-	LPWSTR sesi2_cltype_name;
-} SESSION_INFO_2,*PSESSION_INFO_2,*LPSESSION_INFO_2;
-typedef struct _SESSION_INFO_10 {
-	LPWSTR sesi10_cname;
-	LPWSTR sesi10_username;
+	LMSTR sesi2_cltype_name;
+} SESSION_INFO_2, *PSESSION_INFO_2, *LPSESSION_INFO_2;
+
+typedef struct _SESSION_INFO_10
+{
+	LMSTR sesi10_cname;
+	LMSTR sesi10_username;
 	DWORD sesi10_time;
 	DWORD sesi10_idle_time;
-} SESSION_INFO_10,*PSESSION_INFO_10,*LPSESSION_INFO_10;
-typedef struct _SESSION_INFO_502 {
-	LPWSTR sesi502_cname;
-	LPWSTR sesi502_username;
+} SESSION_INFO_10, *PSESSION_INFO_10, *LPSESSION_INFO_10;
+
+typedef struct _SESSION_INFO_502
+{
+	LMSTR sesi502_cname;
+	LMSTR sesi502_username;
 	DWORD sesi502_num_opens;
 	DWORD sesi502_time;
 	DWORD sesi502_idle_time;
 	DWORD sesi502_user_flags;
-	LPWSTR sesi502_cltype_name;
-	LPWSTR sesi502_transport;
-} SESSION_INFO_502,*PSESSION_INFO_502,*LPSESSION_INFO_502;
-typedef struct _CONNECTION_INFO_0 { DWORD coni0_id; } CONNECTION_INFO_0,*PCONNECTION_INFO_0,*LPCONNECTION_INFO_0;
-typedef struct _CONNECTION_INFO_1 {
+	LMSTR sesi502_cltype_name;
+	LMSTR sesi502_transport;
+} SESSION_INFO_502, *PSESSION_INFO_502, *LPSESSION_INFO_502;
+
+typedef struct _CONNECTION_INFO_0
+{
+    DWORD coni0_id;
+} CONNECTION_INFO_0, *PCONNECTION_INFO_0, *LPCONNECTION_INFO_0;
+
+typedef struct _CONNECTION_INFO_1
+{
 	DWORD coni1_id;
 	DWORD coni1_type;
 	DWORD coni1_num_opens;
 	DWORD coni1_num_users;
 	DWORD coni1_time;
-	LPWSTR coni1_username;
-	LPWSTR coni1_netname;
-} CONNECTION_INFO_1,*PCONNECTION_INFO_1,*LPCONNECTION_INFO_1;
+	LMSTR coni1_username;
+	LMSTR coni1_netname;
+} CONNECTION_INFO_1, *PCONNECTION_INFO_1, *LPCONNECTION_INFO_1;
 
 NET_API_STATUS WINAPI NetShareAdd(LMSTR,DWORD,LPBYTE,LPDWORD);
 NET_API_STATUS WINAPI NetShareCheck(LMSTR,LMSTR,LPDWORD);


### PR DESCRIPTION
## Purpose

This PR implements GetFinalPathNameByHandleW. The wine version is broken and doesn't work, because it relies on a broken behavior of NtQueryObject.

## Proposed changes

- [PSDK] Fix up lmshare.h
- [NTDLL_APITEST] Add another test for NtQueryObject (This shows that wine's code doesn't work)
- [KERNEL32_APITEST] Add tests for GetFinalPathNameByHandleW
- [KERNEL32_VISTA] Implement GetFinalPathNameByHandleW

## Testbot runs (Filled in by Devs)

- ✅ KVM x86: https://reactos.org/testman/compare.php?ids=102622,102628,102631
- ✅ KVM x64: https://reactos.org/testman/compare.php?ids=102626,102629,102632