### PR TITLE
[NTOS:SE] SeValidSecurityDescriptor: Use relative security descriptor header size for length calculation

### DIFF
--- a/ntoskrnl/se/sd.c
+++ b/ntoskrnl/se/sd.c
@@ -1035,7 +1035,7 @@ SeValidSecurityDescriptor(
 
     if (Length < SECURITY_DESCRIPTOR_MIN_LENGTH)
     {
-        DPRINT1("Invalid Security Descriptor revision\n");
+        DPRINT1("Invalid Security Descriptor length\n");
         return FALSE;
     }
 
@@ -1051,7 +1051,7 @@ SeValidSecurityDescriptor(
         return FALSE;
     }
 
-    SdLength = sizeof(SECURITY_DESCRIPTOR);
+    SdLength = sizeof(*SecurityDescriptor);
 
     /* Check Owner SID */
     if (!SecurityDescriptor->Owner)


### PR DESCRIPTION
Fixes Win2k3 ntfs.sys on x64

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: