### PR TITLE
[MSCTF_WINETEST] Disable it

### DIFF
--- a/modules/rostests/winetests/CMakeLists.txt
+++ b/modules/rostests/winetests/CMakeLists.txt
@@ -69,7 +69,7 @@ add_subdirectory(mpr)
 add_subdirectory(msacm32)
 add_subdirectory(mscms)
 add_subdirectory(mscoree)
-add_subdirectory(msctf)
+#add_subdirectory(msctf) # msctf_winetest is not trustworthy
 add_subdirectory(mshtml)
 add_subdirectory(msi)
 add_subdirectory(msrle32)

--- a/modules/rostests/winetests/CMakeLists.txt
+++ b/modules/rostests/winetests/CMakeLists.txt
@@ -69,7 +69,7 @@ add_subdirectory(mpr)
 add_subdirectory(msacm32)
 add_subdirectory(mscms)
 add_subdirectory(mscoree)
-#add_subdirectory(msctf) # msctf_winetest is not trustworthy
+#add_subdirectory(msctf) # msctf_winetest is not reliable at all; See CORE-20235
 add_subdirectory(mshtml)
 add_subdirectory(msi)
 add_subdirectory(msrle32)


### PR DESCRIPTION
## Purpose

`msctf_winetest` is not reliable at all. To begin `msctf.dll` development, we have to disable these tests.
JIRA issue: [CORE-19361](https://jira.reactos.org/browse/CORE-19361) [CORE-20235](https://jira.reactos.org/browse/CORE-20235)

## Proposed changes

- Modify `modules/rostests/winetests/CMakeLists.txt` to disable `msctf_winetest`.

## Screenshots

WinXP x86:
![msctf-WinXP](https://github.com/user-attachments/assets/64850f38-5deb-4dc6-a407-954bd299a04c)

Win10 x64:
![msctf-Win10](https://github.com/user-attachments/assets/be40023b-0f85-4ccd-b068-d0ea2cb52883)

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: