### PR TITLE
[WINLOGON] Diverse fixes - Part 1

### DIFF
--- a/base/system/winlogon/sas.c
+++ b/base/system/winlogon/sas.c
@@ -1049,7 +1049,10 @@ HandleShutdown(
             DialogBox(hAppInstance, MAKEINTRESOURCE(IDD_SHUTDOWNCOMPUTER),
                       GetDesktopWindow(), ShutdownComputerWindowProc);
         }
-        NtShutdownSystem(ShutdownNoReboot);
+        if (wlxAction == WLX_SAS_ACTION_SHUTDOWN_POWER_OFF)
+            NtShutdownSystem(ShutdownPowerOff);
+        else // if (wlxAction == WLX_SAS_ACTION_SHUTDOWN)
+            NtShutdownSystem(ShutdownNoReboot);
     }
     RtlAdjustPrivilege(SE_SHUTDOWN_PRIVILEGE, Old, FALSE, &Old);
     return STATUS_SUCCESS;

--- a/base/system/winlogon/wlx.c
+++ b/base/system/winlogon/wlx.c
@@ -411,10 +411,14 @@ WlxSwitchDesktopToUser(
     HANDLE hWlx)
 {
     PWLSESSION Session = (PWLSESSION)hWlx;
+    BOOL bRet;
 
     TRACE("WlxSwitchDesktopToUser()\n");
 
-    return (int)SwitchDesktop(Session->ApplicationDesktop);
+    bRet = SwitchDesktop(Session->ApplicationDesktop);
+    if (bRet)
+        SetThreadDesktop(Session->ApplicationDesktop);
+    return (int)bRet;
 }
 
 /*
@@ -426,10 +430,14 @@ WlxSwitchDesktopToWinlogon(
     HANDLE hWlx)
 {
     PWLSESSION Session = (PWLSESSION)hWlx;
+    BOOL bRet;
 
     TRACE("WlxSwitchDesktopToWinlogon()\n");
 
-    return (int)SwitchDesktop(Session->WinlogonDesktop);
+    bRet = SwitchDesktop(Session->WinlogonDesktop);
+    if (bRet)
+        SetThreadDesktop(Session->WinlogonDesktop);
+    return (int)bRet;
 }
 
 /*

--- a/base/system/winlogon/wlx.c
+++ b/base/system/winlogon/wlx.c
@@ -104,7 +104,7 @@ CloseAllDialogWindows(VOID)
                                     DIALOG_LIST_ENTRY,
                                     Entry);
 
-        PostMessage(Current->hWnd, WLX_WM_SAS, 0, 0);
+        PostMessage(Current->hWnd, WLX_WM_SAS, WLX_SAS_TYPE_TIMEOUT, 0);
 
         ListEntry = ListEntry->Flink;
     }
@@ -141,8 +141,25 @@ DefaultWlxWindowProc(
 
     if (uMsg == WLX_WM_SAS)
     {
-        EndDialog(hwndDlg, WLX_DLG_SAS);
-        return 0;
+        /* Determine which result to return */
+        switch (wParam)
+        {
+            case WLX_SAS_TYPE_CTRL_ALT_DEL:
+            default:
+                ret = WLX_DLG_SAS;
+                break;
+            case WLX_SAS_TYPE_TIMEOUT:
+                ret = WLX_DLG_INPUT_TIMEOUT;
+                break;
+            case WLX_SAS_TYPE_SCRNSVR_TIMEOUT:
+                ret = WLX_DLG_SCREEN_SAVER_TIMEOUT;
+                break;
+            case WLX_SAS_TYPE_USER_LOGOFF:
+                ret = WLX_DLG_USER_LOGOFF;
+                break;
+        }
+        EndDialog(hwndDlg, ret);
+        return TRUE;
     }
 
     ret = ListEntry->DlgProc(hwndDlg, uMsg, wParam, lParam);


### PR DESCRIPTION
## Purpose

Some simple fixes for Winlogon.

## Proposed changes

- ### `[WINLOGON] DefaultWlxWindowProc(WLX_WM_SAS): return an adequate WLX_DLG_* value`
  For more details, see:
  https://learn.microsoft.com/en-us/windows/win32/api/winwlx/nc-winwlx-pwlx_dialog_box_indirect_param#return-value

- ### `[WINLOGON] WlxSwitchDesktopToUser/Winlogon(): ensure the calling thread is assigned the specified desktop`
  Invoke SetThreadDesktop() after a successful SwitchDesktop() call.

- ### `[WINLOGON] Invoke NtShutdownSystem() with an adequate shutdown action`
  Specify a shutdown action value corresponding to the `WLX_SAS_ACTION_SHUTDOWN_*` ones.