### PR TITLE
[WINLOGON] Diverse fixes - Part 2 (WLX_SAS_ACTION_TASKLIST)

### DIFF
--- a/dll/win32/msgina/gui.c
+++ b/dll/win32/msgina/gui.c
@@ -1062,13 +1062,10 @@ GUILoggedOnSAS(
 
     if (dwSasType != WLX_SAS_TYPE_CTRL_ALT_DEL)
     {
-        /* Nothing to do for WLX_SAS_TYPE_TIMEOUT ; the dialog will
+        /* Nothing to do for WLX_SAS_TYPE_TIMEOUT; the dialog will
          * close itself thanks to the use of WlxDialogBoxParam */
         return WLX_SAS_ACTION_NONE;
     }
-
-    pgContext->pWlxFuncs->WlxSwitchDesktopToWinlogon(
-        pgContext->hWlx);
 
     result = pgContext->pWlxFuncs->WlxDialogBoxParam(
         pgContext->hWlx,
@@ -1082,12 +1079,6 @@ GUILoggedOnSAS(
         result > WLX_SAS_ACTION_SWITCH_CONSOLE)
     {
         result = WLX_SAS_ACTION_NONE;
-    }
-
-    if (result == WLX_SAS_ACTION_NONE)
-    {
-        pgContext->pWlxFuncs->WlxSwitchDesktopToUser(
-            pgContext->hWlx);
     }
 
     return result;


### PR DESCRIPTION
# `[WINLOGON] Improve WLX_SAS_ACTION_TASKLIST handling in logged-on/logged-on SAS states`

## Purpose

JIRA issue: [CORE-13478](https://jira.reactos.org/browse/CORE-13478)
Addendum to commit 46dcab7ab.

The `WLX_SAS_ACTION_TASKLIST` action can be invoked in three scenarii to open the Task-Manager:

1. from the logged-on state (`LogonState == STATE_LOGGED_ON`), when the user presses Ctrl-Shift-Esc while being on its own desktop (usual case);

2. from the Logged-On SAS dialog (`LogonState == STATE_LOGGED_ON_SAS`), when the user presses the "Task-Manager" button: here Winlogon should switch back to the user's desktop, restoring `STATE_LOGGED_ON` and start the TaskMgr;

3. or when the user presses Ctrl-Shift-Esc **while being on the Logged-On SAS dialog**: in this case, the Task-Manager is started on the currently-hidden user's desktop (and so, will be hidden), but the SAS dialog stays open. The user will see the opened TaskMgr once (s)he closes the SAS dialog and Winlogon switches back to the user's desktop.

## Proposed changes

In order to support these scenarii, the `WLX_SAS_ACTION_TASKLIST` action handling is reworked:

- `SASWindowProc(WM_HOTKEY, IDHK_CTRL_SHIFT_ESC)` always invokes the `DoGenericAction(WLX_SAS_ACTION_TASKLIST)`: this allows centralizing inside `DoGenericAction()` the condition checks for starting TaskMgr.

- `DoGenericAction(WLX_SAS_ACTION_TASKLIST)` just starts the Task-Manager only if the Winlogon's `LogonState` is either `STATE_LOGGED_ON` or `STATE_LOGGED_ON_SAS`. It doesn't attempt there to switch desktops nor change the `LogonState` value, in order to support scenarii 2 and 3.

- The switch from/to Winlogon/user's desktops when going to the `LogonState: STATE_LOGGED_ON -> STATE_LOGGED_ON_SAS` change is done in `DispatchSAS()`, just before invoking the GINA's `WlxLoggedOnSAS()` (see below for more details) and just after it returns, only in the necessary cases.


# `[MSGINA] The WlxLoggedOnSAS() dialog shouldn't switch the desktops itself.`

## Purpose

This behaviour can be observed on Windows with Winlogon debugging + tracing enabled. It is Winlogon instead that does the desktop switch itself, as for all the other SAS dialogs, in addition to changing its internal `LogonState`.

Fix for commit 7aecedf79 (r58785).
