### PR TITLE
[NTDLL_WINETEST][NTOS:PS] Fix a few NtQueryInformationProcess(Process*) handling cases

### DIFF
--- a/modules/rostests/winetests/ntdll/info.c
+++ b/modules/rostests/winetests/ntdll/info.c
@@ -1582,12 +1582,20 @@ static void test_query_process_debug_object_handle(int argc, char **argv)
     debug_object = (HANDLE)0xdeadbeef;
     status = pNtQueryInformationProcess(pi.hProcess, ProcessDebugObjectHandle,
             &debug_object, sizeof(debug_object), NULL);
+#ifndef __REACTOS__
     todo_wine
+#endif
     ok(status == STATUS_SUCCESS,
        "Expected NtQueryInformationProcess to return STATUS_SUCCESS, got 0x%08x\n", status);
+#ifndef __REACTOS__
     todo_wine
+#endif
     ok(debug_object != NULL,
        "Expected debug object handle to be non-NULL, got %p\n", debug_object);
+#ifdef __REACTOS__
+    status = NtClose( debug_object );
+    ok( !status, "NtClose failed %x\n", status );
+#endif
 
     for (;;)
     {

--- a/ntoskrnl/ps/query.c
+++ b/ntoskrnl/ps/query.c
@@ -1088,7 +1088,8 @@ NtQueryInformationProcess(
 
             if (ProcessHandle != NtCurrentProcess())
             {
-                return STATUS_INVALID_PARAMETER;
+                Status = STATUS_INVALID_PARAMETER;
+                break;
             }
 
             /* Get the options */

--- a/ntoskrnl/ps/query.c
+++ b/ntoskrnl/ps/query.c
@@ -1133,18 +1133,22 @@ NtQueryInformationProcess(
             Status = STATUS_INVALID_INFO_CLASS;
     }
 
-    /* Protect write with SEH */
-    _SEH2_TRY
+    /* Check if caller wants the return length and if there is one */
+    if (ReturnLength != NULL && Length != 0)
     {
-        /* Check if caller wanted return length */
-        if ((ReturnLength) && (Length)) *ReturnLength = Length;
+        /* Protect write with SEH */
+        _SEH2_TRY
+        {
+            *ReturnLength = Length;
+        }
+        _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+        {
+            /* Get exception code.
+             * Note: This overwrites any previous failure status. */
+            Status = _SEH2_GetExceptionCode();
+        }
+        _SEH2_END;
     }
-    _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
-    {
-        /* Get exception code */
-        Status = _SEH2_GetExceptionCode();
-    }
-    _SEH2_END;
 
     return Status;
 }


### PR DESCRIPTION
## Purpose

Correctly handle failures. Plus a couple optimizations.

## Proposed changes

- test_query_process_debug_object_handle(): 1 WINESYNC
Cherry-pick WineTest part of
https://gitlab.winehq.org/wine/wine/-/commit/52d733b5c4876276d7a2dfc8d9a9bb72a853dfd0
- Fix NtQueryInformationProcess(ProcessDebugObjectHandle)
Addendum to 1e172203a (r55734).
-- Close DebugPort, on failure.
- Optimize NtQueryInformationProcess(ProcessWow64Information)
on 32-bit.
Addendum to 1e172203a (r55734).
- Fix NtQueryInformationProcess(ProcessExecuteFlags)
s/return/break/ on a failure case.
Addendum to 1e172203a (r55734).
- NtQueryInformationProcess(): Optimize *ReturnLength assignment
Addendum to 2278c29 (r23175).

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=102496,102509
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=102497,102510

In all these, one additional test in `ntdll:info` is run, and the number of failures didn't change.