### PR TITLE
[MSWSOCK] Fix integer overflow

### DIFF
--- a/dll/win32/mswsock/mswhelper.c
+++ b/dll/win32/mswsock/mswhelper.c
@@ -104,7 +104,7 @@ BOOL
 mswBufferAppendLst(_Inout_ PMSW_BUFFER mswBuf,
                    _In_ void **lst,
                    _In_ DWORD itemByteLength,
-                   _In_opt_ int ptrofs)
+                   _In_opt_ LONG_PTR ptrofs)
 {
     DWORD lstItemCount;
     DWORD lstByteSize;
@@ -159,7 +159,7 @@ mswBufferAppendLst(_Inout_ PMSW_BUFFER mswBuf,
 BOOL
 mswBufferAppendStrLstA(_Inout_ PMSW_BUFFER mswBuf,
                        _In_ void **lst,
-                       _In_opt_ int ptrofs)
+                       _In_opt_ LONG_PTR ptrofs)
 {
     DWORD lstItemLen[MAX_ARRAY_SIZE];
     DWORD lstItemCount;

--- a/dll/win32/mswsock/mswhelper.h
+++ b/dll/win32/mswsock/mswhelper.h
@@ -57,13 +57,13 @@ mswBufferAppendLst(
   _Inout_ PMSW_BUFFER mswBuf,
   _In_ void **lst,
   _In_ DWORD itemByteLength,
-  _In_opt_ int deltaofs);
+  _In_opt_ LONG_PTR ptrofs);
 
 BOOL
 mswBufferAppendStrLstA(
   _Inout_ PMSW_BUFFER mswBuf,
   _In_ void **lst,
-  _In_opt_ int ptrofs);
+  _In_opt_ LONG_PTR ptrofs);
 
 BOOL
 mswBufferAppendBlob_Hostent(


### PR DESCRIPTION
## Purpose

Fix integer overflow in mswsock which could result in a crash in ws2_32.dll when using x64 builds. This occurs when using https://github.com/ReactOS-Longhorn-Initiative/reactos fork and running Unity games.

JIRA issue: None

## Proposed changes


- Use LONG_PTR instead of integer to store pointer to start of list

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: