### PR TITLE
[BROWSEUI][SHELL32] Fixed FindFiles rename operation

### DIFF
--- a/dll/shellext/netshell/shfldr_netconnect.cpp
+++ b/dll/shellext/netshell/shfldr_netconnect.cpp
@@ -641,14 +641,6 @@ HRESULT WINAPI CNetConUiObject::InvokeCommand(LPCMINVOKECOMMANDINFO lpcmi)
     {
         CmdId = IDS_NET_PROPERTIES;
     }
-    else if ((UINT_PTR)lpcmi->lpVerb == FCIDM_SHVIEW_RENAME) // DefView accelerator
-    {
-        CmdId = IDS_NET_RENAME;
-    }
-    else if ((UINT_PTR)lpcmi->lpVerb == FCIDM_SHVIEW_PROPERTIES) // DefView accelerator
-    {
-        CmdId = IDS_NET_PROPERTIES;
-    }
     else if (!IS_INTRESOURCE(lpcmi->lpVerb) || LOWORD(lpcmi->lpVerb) > 7)
     {
         FIXME("Got invalid command\n");

--- a/dll/win32/browseui/shellfind/CFindFolder.cpp
+++ b/dll/win32/browseui/shellfind/CFindFolder.cpp
@@ -1145,15 +1145,18 @@ STDMETHODIMP CFindFolder::SetNameOf(HWND hwndOwner, PCUITEMID_CHILD pidl, LPCOLE
     if (!pPidlOut)
         return E_INVALIDARG; // Our pidls are special, the caller must get it from us and not from parsing
     *pPidlOut = NULL;
+
     HRESULT hr;
     CComPtr<IShellFolder> pFolder;
     PCUITEMID_CHILD pidlChild;
     if (FAILED_UNEXPECTEDLY(hr = GetFSFolderAndChild(pidl, &pFolder, &pidlChild)))
         return hr;
+
     PCWSTR pszDir = _ILGetPath(pidl);
     PWSTR pszFull = (PWSTR)SHAlloc((wcslen(pszDir) + MAX_PATH) * sizeof(*pszDir));
     if (!pszFull)
         return E_OUTOFMEMORY;
+
     PITEMID_CHILD pidlRawNew = NULL;
     hr = pFolder->SetNameOf(hwndOwner, pidlChild, lpName, dwFlags, &pidlRawNew);
     if (SUCCEEDED(hr) && pidlRawNew)
@@ -1162,7 +1165,8 @@ STDMETHODIMP CFindFolder::SetNameOf(HWND hwndOwner, PCUITEMID_CHILD pidl, LPCOLE
         hr = DisplayNameOfW(pFolder, pidlRawNew, SHGDN_FORPARSING | SHGDN_INFOLDER, szFileName, _countof(szFileName));
         ILFree(pidlRawNew);
         PathCombineW(pszFull, pszDir, szFileName);
-        hr = (SUCCEEDED(hr) && (*pPidlOut = _ILCreate(pszFull)) != NULL) ? S_OK : E_OUTOFMEMORY;
+        if (SUCCEEDED(hr))
+            hr = ((*pPidlOut = _ILCreate(pszFull)) != NULL) ? S_OK : E_OUTOFMEMORY;
     }
     SHFree(pszFull);
     return hr;

--- a/dll/win32/browseui/shellfind/CFindFolder.cpp
+++ b/dll/win32/browseui/shellfind/CFindFolder.cpp
@@ -10,6 +10,32 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(shellfind);
 
+#ifndef _SHELL32_
+
+static HRESULT WINAPI DisplayNameOfW(_In_ IShellFolder *psf, _In_ LPCITEMIDLIST pidl,
+                                     _In_ DWORD dwFlags, _Out_ LPWSTR pszBuf, _In_ UINT cchBuf)
+{
+    *pszBuf = UNICODE_NULL;
+    STRRET sr;
+    HRESULT hr = psf->GetDisplayNameOf(pidl, dwFlags, &sr);
+    return FAILED(hr) ? hr : StrRetToBufW(&sr, pidl, pszBuf, cchBuf);
+}
+
+static HRESULT
+GetCommandStringA(_In_ IContextMenu *pCM, _In_ UINT_PTR Id, _In_ UINT GCS,
+                  _Out_writes_(cchMax) LPSTR Buf, _In_ UINT cchMax)
+{
+    HRESULT hr = pCM->GetCommandString(Id, GCS & ~GCS_UNICODE, NULL, Buf, cchMax);
+    if (FAILED(hr))
+    {
+        WCHAR buf[MAX_PATH];
+        hr = pCM->GetCommandString(Id, GCS | GCS_UNICODE, NULL, (LPSTR)buf, _countof(buf));
+        if (SUCCEEDED(hr))
+            hr = SHUnicodeToAnsi(buf, Buf, cchMax) > 0 ? S_OK : E_FAIL;
+    }
+    return hr;
+}
+
 static HRESULT SHELL32_CoCreateInitSF(LPCITEMIDLIST pidlRoot, PERSIST_FOLDER_TARGET_INFO* ppfti,
                                 LPCITEMIDLIST pidlChild, const GUID* clsid, REFIID riid, LPVOID *ppvOut)
 {
@@ -36,6 +62,8 @@ static HRESULT SHELL32_CoCreateInitSF(LPCITEMIDLIST pidlRoot, PERSIST_FOLDER_TAR
 
     return pShellFolder->QueryInterface(riid, ppvOut);
 }
+
+#endif // _SHELL32_
 
 static void WINAPI _InsertMenuItemW(
         HMENU hMenu,
@@ -74,6 +102,28 @@ static void WINAPI _InsertMenuItemW(
     mii.wID = wID;
     mii.fType = fType;
     InsertMenuItemW(hMenu, indexMenu, fByPosition, &mii);
+}
+
+static HRESULT QueryActiveShellView(IUnknown *pUnkSite, REFGUID rService, IShellView **ppSV)
+{
+    CComPtr<IShellBrowser> pSB;
+    HRESULT hr = IUnknown_QueryService(pUnkSite, rService, IID_PPV_ARG(IShellBrowser, &pSB));
+    return SUCCEEDED(hr) ? pSB->QueryActiveShellView(ppSV) : hr;
+}
+
+static HRESULT BeginRenameOfShellViewSelection(IUnknown *pUnkSite)
+{
+    CComPtr<IShellView> pSV;
+    HRESULT hr = QueryActiveShellView(pUnkSite, SID_SShellBrowser, &pSV);
+    if (FAILED(hr))
+        return hr;
+    CComPtr<IFolderView2> pFV2;
+    if (SUCCEEDED(hr = pSV->QueryInterface(IID_PPV_ARG(IFolderView2, &pFV2))))
+        return pFV2->DoRename();
+    CComPtr<IShellView2> pSV2;
+    if (SUCCEEDED(hr = pSV->QueryInterface(IID_PPV_ARG(IShellView2, &pSV2))))
+        return pSV2->HandleRename(NULL);
+    return hr;
 }
 
 struct FolderViewColumns
@@ -894,22 +944,27 @@ STDMETHODIMP CFindFolder::GetAttributesOf(UINT cidl, PCUITEMID_CHILD_ARRAY apidl
         if (FAILED(hr = pFolder->GetAttributesOf(1, &pidlChild, rgfInOut)))
             break;
     }
-    *rgfInOut &= ~SFGAO_CANRENAME; // FIXME: Handle SetNameOf
     return hr;
 }
 
 class CFindFolderContextMenu :
         public IContextMenu,
+        public IObjectWithSite,
         public CComObjectRootEx<CComMultiThreadModelNoCS>
 {
     CComPtr<IContextMenu> m_pInner;
     CComPtr<IShellFolderView> m_shellFolderView;
+    IUnknown *m_pUnkSite = NULL;
+    UINT m_cidl;
     UINT m_MyFirstId = 0;
     static const UINT ADDITIONAL_MENU_ITEMS = 2;
 
-    //// *** IContextMenu methods ***
+    // *** IContextMenu ***
     STDMETHODIMP QueryContextMenu(HMENU hMenu, UINT indexMenu, UINT idCmdFirst, UINT idCmdLast, UINT uFlags)
     {
+        if (m_cidl > 1)
+            uFlags &= ~CMF_CANRENAME;
+
         m_MyFirstId = 0;
         if (idCmdLast - idCmdFirst > ADDITIONAL_MENU_ITEMS)
         {
@@ -927,12 +982,7 @@ class CFindFolderContextMenu :
 
     STDMETHODIMP InvokeCommand(LPCMINVOKECOMMANDINFO lpcmi)
     {
-        if (!IS_INTRESOURCE(lpcmi->lpVerb))
-        {
-            return m_pInner->InvokeCommand(lpcmi);
-        }
-
-        UINT idCmd = LOWORD(lpcmi->lpVerb);
+        WORD idCmd = IS_INTRESOURCE(lpcmi->lpVerb) ? LOWORD(lpcmi->lpVerb) : 0;
         if (m_MyFirstId && idCmd >= m_MyFirstId && idCmd < m_MyFirstId + ADDITIONAL_MENU_ITEMS)
         {
             PCUITEMID_CHILD *apidl;
@@ -945,12 +995,27 @@ class CFindFolderContextMenu :
             {
                 CComHeapPtr<ITEMIDLIST> folderPidl(ILCreateFromPathW(_ILGetPath(apidl[i])));
                 if (!folderPidl)
-                    return E_OUTOFMEMORY;
+                {
+                    hResult = E_OUTOFMEMORY;
+                    break;
+                }
                 LPCITEMIDLIST child = _ILGetFSPidl(apidl[i]);
                 SHOpenFolderAndSelectItems(folderPidl, 1, &child, 0);
             }
             LocalFree(apidl); // Yes, LocalFree
-            return S_OK;
+            return hResult;
+        }
+
+        // TODO: Use GetDfmCmd instead after moving all of this to shell32
+        CHAR szVerb[42];
+        PCSTR pszVerb = !idCmd ? lpcmi->lpVerb : NULL;
+        if (!pszVerb && SUCCEEDED(GetCommandStringA(m_pInner, LOWORD(lpcmi->lpVerb), GCS_VERBA, szVerb, _countof(szVerb))))
+            pszVerb = szVerb;
+
+        if (pszVerb && !lstrcmpiA(pszVerb, "rename"))
+        {
+            // Note: We can't invoke m_pInner (CDefaultContextMenu::DoRename) because the pidl is incorrect and SelectItem will fail.
+            return BeginRenameOfShellViewSelection(m_pUnkSite);
         }
 
         // FIXME: We can't block FCIDM_SHVIEW_REFRESH here, add items on SFVM_LISTREFRESHED instead
@@ -962,8 +1027,27 @@ class CFindFolderContextMenu :
         return m_pInner->GetCommandString(idCommand, uFlags, lpReserved, lpszName, uMaxNameLen);
     }
 
+    // *** IObjectWithSite ***
+    STDMETHODIMP SetSite(IUnknown *pUnkSite) override
+    {
+        IUnknown_Set(&m_pUnkSite, pUnkSite);
+        IUnknown_SetSite(m_pInner, pUnkSite);
+        return S_OK;
+    }
+
+    STDMETHODIMP GetSite(REFIID riid, void **ppvSite) override
+    {
+        *ppvSite = NULL;
+        return m_pUnkSite ? m_pUnkSite->QueryInterface(riid, ppvSite) : E_FAIL;
+    }
+
 public:
-    static HRESULT Create(IShellFolderView *pShellFolderView, IContextMenu *pInnerContextMenu, IContextMenu **pContextMenu)
+    ~CFindFolderContextMenu()
+    {
+        SetSite(NULL);
+    }
+
+    static HRESULT Create(IShellFolderView *pShellFolderView, UINT cidl, IContextMenu *pInnerContextMenu, IContextMenu **pContextMenu)
     {
         CComObject<CFindFolderContextMenu> *pObj;
         HRESULT hResult = CComObject<CFindFolderContextMenu>::CreateInstance(&pObj);
@@ -971,11 +1055,13 @@ public:
             return hResult;
         pObj->m_shellFolderView = pShellFolderView;
         pObj->m_pInner = pInnerContextMenu;
+        pObj->m_cidl = cidl;
         return pObj->QueryInterface(IID_PPV_ARG(IContextMenu, pContextMenu));
     }
 
     BEGIN_COM_MAP(CFindFolderContextMenu)
         COM_INTERFACE_ENTRY_IID(IID_IContextMenu, IContextMenu)
+        COM_INTERFACE_ENTRY_IID(IID_IObjectWithSite, IObjectWithSite)
     END_COM_MAP()
 };
 
@@ -1034,7 +1120,7 @@ STDMETHODIMP CFindFolder::GetUIObjectOf(HWND hwndOwner, UINT cidl, PCUITEMID_CHI
         hr = pShellFolder->GetUIObjectOf(hwndOwner, cidl, aFSPidl, riid, prgfInOut, (void**)&pContextMenu);
         if (FAILED_UNEXPECTEDLY(hr))
             return hr;
-        return CFindFolderContextMenu::Create(m_shellFolderView, pContextMenu, (IContextMenu **)ppvOut);
+        return CFindFolderContextMenu::Create(m_shellFolderView, cidl, pContextMenu, (IContextMenu **)ppvOut);
     }
 
     CComPtr<IShellFolder> pFolder;
@@ -1056,8 +1142,30 @@ STDMETHODIMP CFindFolder::GetDisplayNameOf(PCUITEMID_CHILD pidl, DWORD dwFlags, 
 STDMETHODIMP CFindFolder::SetNameOf(HWND hwndOwner, PCUITEMID_CHILD pidl, LPCOLESTR lpName, DWORD dwFlags,
                                     PITEMID_CHILD *pPidlOut)
 {
-    UNIMPLEMENTED;
-    return E_NOTIMPL;
+    if (!pPidlOut)
+        return E_INVALIDARG; // Our pidls are special, the caller must get it from us and not from parsing
+    *pPidlOut = NULL;
+    HRESULT hr;
+    CComPtr<IShellFolder> pFolder;
+    PCUITEMID_CHILD pidlChild;
+    if (FAILED_UNEXPECTEDLY(hr = GetFSFolderAndChild(pidl, &pFolder, &pidlChild)))
+        return hr;
+    PCWSTR pszDir = _ILGetPath(pidl);
+    PWSTR pszFull = (PWSTR)SHAlloc((wcslen(pszDir) + MAX_PATH) * sizeof(*pszDir));
+    if (!pszFull)
+        return E_OUTOFMEMORY;
+    PITEMID_CHILD pidlRawNew = NULL;
+    hr = pFolder->SetNameOf(hwndOwner, pidlChild, lpName, dwFlags, &pidlRawNew);
+    if (SUCCEEDED(hr) && pidlRawNew)
+    {
+        WCHAR szFileName[MAX_PATH];
+        hr = DisplayNameOfW(pFolder, pidlRawNew, SHGDN_FORPARSING | SHGDN_INFOLDER, szFileName, _countof(szFileName));
+        ILFree(pidlRawNew);
+        PathCombineW(pszFull, pszDir, szFileName);
+        hr = (SUCCEEDED(hr) && (*pPidlOut = _ILCreate(pszFull)) != NULL) ? S_OK : E_OUTOFMEMORY;
+    }
+    SHFree(pszFull);
+    return hr;
 }
 
 //// *** IShellFolderViewCB method ***

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -2160,7 +2160,7 @@ HRESULT CDefView::InvokeContextMenuCommand(CComPtr<IContextMenu>& pCM, LPCSTR lp
     {
         if (cmi.lpVerb != MAKEINTRESOURCEA(verbmap[i]))
             continue;
-        if (PCSTR pszverbA = MapFcidmCmdToVerb((SIZE_T)cmi.lpVerb))
+        if (PCSTR pszverbA = MapFcidmCmdToVerb((UINT_PTR)cmi.lpVerb))
         {
             // Map our internal commands to canonical verbs so non-shell32 menus can understand us
             SHAnsiToUnicode(pszverbA, szverbW, _countof(szverbW));

--- a/dll/win32/shell32/CDefaultContextMenu.cpp
+++ b/dll/win32/shell32/CDefaultContextMenu.cpp
@@ -180,6 +180,16 @@ static const struct _StaticInvokeCommandMap_
     { "moveto",          FCIDM_SHVIEW_MOVETO },
 };
 
+PCSTR MapFcidmCmdToVerb(_In_ SIZE_T CmdId)
+{
+    for (SIZE_T i = 0; i < _countof(g_StaticInvokeCmdMap); ++i)
+    {
+        if (g_StaticInvokeCmdMap[i].IntVerb == CmdId && CmdId)
+            return g_StaticInvokeCmdMap[i].szStringVerb;
+    }
+    return NULL;
+}
+
 UINT MapVerbToDfmCmd(_In_ LPCSTR verba)
 {
     for (UINT i = 0; i < _countof(g_StaticInvokeCmdMap); ++i)

--- a/dll/win32/shell32/CDefaultContextMenu.cpp
+++ b/dll/win32/shell32/CDefaultContextMenu.cpp
@@ -180,7 +180,7 @@ static const struct _StaticInvokeCommandMap_
     { "moveto",          FCIDM_SHVIEW_MOVETO },
 };
 
-PCSTR MapFcidmCmdToVerb(_In_ SIZE_T CmdId)
+PCSTR MapFcidmCmdToVerb(_In_ UINT_PTR CmdId)
 {
     for (SIZE_T i = 0; i < _countof(g_StaticInvokeCmdMap); ++i)
     {

--- a/dll/win32/shell32/precomp.h
+++ b/dll/win32/shell32/precomp.h
@@ -206,7 +206,7 @@ DCMA_InsertMenuItems(
 HRESULT
 SHELL32_DefaultContextMenuCallBack(IShellFolder *psf, IDataObject *pdo, UINT msg);
 PCSTR
-MapFcidmCmdToVerb(_In_ SIZE_T CmdId);
+MapFcidmCmdToVerb(_In_ UINT_PTR CmdId);
 UINT
 MapVerbToDfmCmd(_In_ LPCSTR verba);
 UINT

--- a/dll/win32/shell32/precomp.h
+++ b/dll/win32/shell32/precomp.h
@@ -205,6 +205,8 @@ DCMA_InsertMenuItems(
 
 HRESULT
 SHELL32_DefaultContextMenuCallBack(IShellFolder *psf, IDataObject *pdo, UINT msg);
+PCSTR
+MapFcidmCmdToVerb(_In_ SIZE_T CmdId);
 UINT
 MapVerbToDfmCmd(_In_ LPCSTR verba);
 UINT


### PR DESCRIPTION
DefView will now map its internal (FCIDM) commands (when sent from the toolbar and accelerators) to canonical verb strings so clients outside shell32 can detect the verb. This is critical for "rename" and handy for "properties".

JIRA issue: [CORE-18326](https://jira.reactos.org/browse/CORE-18326)

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: