### PR TITLE
[BROWSEUI] Fix CompareIDs lParam passed to inner folder

### DIFF
--- a/dll/win32/browseui/shellfind/CFindFolder.cpp
+++ b/dll/win32/browseui/shellfind/CFindFolder.cpp
@@ -845,7 +845,7 @@ STDMETHODIMP CFindFolder::GetDetailsOf(PCUITEMID_CHILD pidl, UINT iColumn, SHELL
     if (iColumn == COL_RELEVANCE_INDEX)
     {
         // TODO: Fill once the relevance is calculated
-        return SHSetStrRet(&pDetails->str, "");
+        return SHSetStrRetEmpty(&pDetails->str);
     }
 
     ATLASSERT(iColumn == COL_NAME_INDEX);
@@ -903,8 +903,7 @@ STDMETHODIMP CFindFolder::CompareIDs(LPARAM lParam, PCUIDLIST_RELATIVE pidl1, PC
         wColumn -= _countof(g_ColumnDefs) - 1;
         break;
     }
-    // FIXME: DefView does not like the way we sort
-    return m_pisfInner->CompareIDs(HIWORD(lParam) | wColumn, _ILGetFSPidl(pidl1), _ILGetFSPidl(pidl2));
+    return m_pisfInner->CompareIDs(MAKELONG(wColumn, HIWORD(lParam)), _ILGetFSPidl(pidl1), _ILGetFSPidl(pidl2));
 }
 
 STDMETHODIMP CFindFolder::CreateViewObject(HWND hwndOwner, REFIID riid, LPVOID *ppvOut)

--- a/dll/win32/browseui/shellfind/CSearchBar.cpp
+++ b/dll/win32/browseui/shellfind/CSearchBar.cpp
@@ -885,7 +885,8 @@ void CSearchBar::TrySetFocus(UINT Source)
     {
         BOOL IsOnButton = GetDlgItem(IDC_SEARCH_BUTTON) == hWndFocus;
         BOOL IsOnSelfPane = hWndFocus == m_hWnd;
-        if (!hWndFocus || IsOnSelfPane || IsOnButton || !IsWindowChildOf(hWndFocus, m_hWnd))
-            SendMessageW(WM_NEXTDLGCTL, (WPARAM)GetDlgItem(IDC_SEARCH_FILENAME), TRUE);
+        BOOL IsInPaneChild = hWndFocus && IsWindowChildOf(hWndFocus, m_hWnd);
+        if ((cItems == 0 && !IsInPaneChild) || IsOnSelfPane || IsOnButton)
+            SendMessage(WM_NEXTDLGCTL, (WPARAM)GetDlgItem(IDC_SEARCH_FILENAME), TRUE);
     }
 }

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -1365,13 +1365,14 @@ int CDefView::LV_FindItemByPidl(PCUITEMID_CHILD pidl)
         }
         else
         {
-            for (i = 0; i < cItems; i++)
+#if DBG
+            for (i = 0; pidl && i < cItems; i++)
             {
-                //FIXME: ILIsEqual needs absolute pidls!
                 currentpidl = _PidlByItem(i);
-                if (ILIsEqual(pidl, currentpidl))
-                    return i;
+                if (currentpidl && currentpidl->mkid.cb == pidl->mkid.cb && !memcmp(currentpidl, pidl, pidl->mkid.cb))
+                    DbgPrint("Matched item #%d, broken CompareIDs?\n", i);
             }
+#endif
             break;
         }
     }


### PR DESCRIPTION
`CFindFolder` is incorrectly forwarding `SHCIDS_CANONICALONLY` to its inner `CFSFolder` causing `CFSFolder::CompareIDs` to fail.

Notes:
- Also fixes focus stealing during rename if the search completes during a rename.

JIRA issue: [CORE-20250](https://jira.reactos.org/browse/CORE-20250)

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: