### PR TITLE
[NDK][ROSLOAD][ROSTESTS][SDK][WINE] Fix and use standard 'ReactOS' casing

### DIFF
--- a/base/setup/reactos/lang/et-EE.rc
+++ b/base/setup/reactos/lang/et-EE.rc
@@ -158,7 +158,7 @@ STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYS
 CAPTION "ReactOS'i paigalduse lõpetamine"
 FONT 8, "MS Shell Dlg"
 BEGIN
-    LTEXT "Reactos'i paigaldusviisardi lõpetamine", IDC_FINISHTITLE, 115, 8, 195, 24
+    LTEXT "ReactOS'i paigaldusviisardi lõpetamine", IDC_FINISHTITLE, 115, 8, 195, 24
     LTEXT "ReactOS'i paigaldamise esimene järk on edukalt lõpetatud.", IDC_STATIC, 115, 50, 195, 17
     LTEXT "Vajuta Lõpeta, et arvuti taaskäivitada.", IDC_STATIC, 115, 80, 195, 17
     CONTROL "", IDC_RESTART_PROGRESS, "msctls_progress32", PBS_SMOOTH | WS_CHILD | WS_VISIBLE | WS_BORDER, 115, 110, 195, 8

--- a/base/setup/reactos/lang/vi-VN.rc
+++ b/base/setup/reactos/lang/vi-VN.rc
@@ -155,7 +155,7 @@ END
 
 IDD_RESTARTPAGE DIALOGEX 0, 0, 317, 193
 STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
-CAPTION "Đang hoàn tất cài đặt Reactos"
+CAPTION "Đang hoàn tất cài đặt ReactOS"
 FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "Completing the ReactOS Setup Wizard", IDC_FINISHTITLE, 115, 8, 195, 24

--- a/base/setup/usetup/lang/hu-HU.h
+++ b/base/setup/usetup/lang/hu-HU.h
@@ -15,7 +15,7 @@ static MUI_ENTRY huHUSetupInitPageEntries[] =
     {
         0,
         20,
-        "K\202rem v\240rjon am\241g a Reactos telep\241t\213 inicializ\240lja mag\240t",
+        "K\202rem v\240rjon am\241g a ReactOS telep\241t\213 inicializ\240lja mag\240t",
         TEXT_STYLE_NORMAL | TEXT_ALIGN_CENTER,
         TEXT_ID_STATIC
     },

--- a/boot/environ/app/rosload/rosload.c
+++ b/boot/environ/app/rosload/rosload.c
@@ -1103,7 +1103,7 @@ OslMain (
     LibraryParameters.MinimumAllocationCount = 1024;
     LibraryParameters.MinimumHeapSize = 2 * 1024 * 1024;
     LibraryParameters.HeapAllocationAttributes = BlMemoryKernelRange;
-    LibraryParameters.FontBaseDirectory = L"\\Reactos\\Boot\\Fonts";
+    LibraryParameters.FontBaseDirectory = L"\\ReactOS\\Boot\\Fonts";
     LibraryParameters.DescriptorCount = 512;
 
     /* Initialize the boot library */

--- a/dll/directx/wine/readme.txt
+++ b/dll/directx/wine/readme.txt
@@ -1,5 +1,5 @@
 This is Wine DirectX support.
-It works in Reactos and Windows.
+It works in ReactOS and Windows.
 When ReactOS own ReactX are in-place
 this file will be removed from our SVN
 for now they stay as temporary solutions.

--- a/modules/rostests/tests/hivetest/hivetest.c
+++ b/modules/rostests/tests/hivetest/hivetest.c
@@ -628,8 +628,8 @@ void test5(void)
   NTSTATUS Status;
 
   dprintf("NtOpenKey : \n");
-  dprintf("  \\Registry\\Machine\\Software\\reactos : ");
-  RtlRosInitUnicodeStringFromLiteral(&KeyName,L"\\Registry\\Machine\\Software\\reactos");
+  dprintf("  \\Registry\\Machine\\Software\\ReactOS : ");
+  RtlRosInitUnicodeStringFromLiteral(&KeyName,L"\\Registry\\Machine\\Software\\ReactOS");
   InitializeObjectAttributes(&ObjectAttributes, &KeyName, OBJ_CASE_INSENSITIVE
 				, NULL, NULL);
   Status=NtOpenKey( &hKey, KEY_ALL_ACCESS, &ObjectAttributes);
@@ -653,8 +653,8 @@ void test6(void)
   ULONG Length,i;
 
   dprintf("Create target key\n");
-  dprintf("  Key: \\Registry\\Machine\\SOFTWARE\\Reactos\n");
-  RtlRosInitUnicodeStringFromLiteral(&KeyName, L"\\Registry\\Machine\\SOFTWARE\\Reactos");
+  dprintf("  Key: \\Registry\\Machine\\SOFTWARE\\ReactOS\n");
+  RtlRosInitUnicodeStringFromLiteral(&KeyName, L"\\Registry\\Machine\\SOFTWARE\\ReactOS");
   InitializeObjectAttributes(&ObjectAttributes, &KeyName, OBJ_CASE_INSENSITIVE
 				, NULL, NULL);
   Status = NtCreateKey(&hKey, KEY_ALL_ACCESS , &ObjectAttributes
@@ -695,9 +695,9 @@ void test6(void)
     return;
 
   dprintf("Create link value\n");
-  dprintf("  Value: SymbolicLinkValue = '\\Registry\\Machine\\SOFTWARE\\Reactos'\n");
+  dprintf("  Value: SymbolicLinkValue = '\\Registry\\Machine\\SOFTWARE\\ReactOS'\n");
   RtlRosInitUnicodeStringFromLiteral(&ValueName, L"SymbolicLinkValue");
-  Status=NtSetValueKey(hKey,&ValueName,0,REG_LINK,(PVOID)L"\\Registry\\Machine\\SOFTWARE\\Reactos",68);
+  Status=NtSetValueKey(hKey,&ValueName,0,REG_LINK,(PVOID)L"\\Registry\\Machine\\SOFTWARE\\ReactOS",68);
   dprintf("  NtSetValueKey() called (Status %lx)\n",Status);
   if (!NT_SUCCESS(Status))
     {

--- a/modules/rostests/tests/regtest/regtest.c
+++ b/modules/rostests/tests/regtest/regtest.c
@@ -591,8 +591,8 @@ void test5(void)
   NTSTATUS Status;
 
   dprintf("NtOpenKey : \n");
-  dprintf("  \\Registry\\Machine\\Software\\reactos : ");
-  RtlRosInitUnicodeStringFromLiteral(&KeyName,L"\\Registry\\Machine\\Software\\reactos");
+  dprintf("  \\Registry\\Machine\\Software\\ReactOS : ");
+  RtlRosInitUnicodeStringFromLiteral(&KeyName,L"\\Registry\\Machine\\Software\\ReactOS");
   InitializeObjectAttributes(&ObjectAttributes, &KeyName, OBJ_CASE_INSENSITIVE
 				, NULL, NULL);
   Status=NtOpenKey( &hKey, KEY_ALL_ACCESS, &ObjectAttributes);
@@ -616,8 +616,8 @@ void test6(void)
   ULONG Length,i;
 
   dprintf("Create target key\n");
-  dprintf("  Key: \\Registry\\Machine\\SOFTWARE\\Reactos\n");
-  RtlRosInitUnicodeStringFromLiteral(&KeyName, L"\\Registry\\Machine\\SOFTWARE\\Reactos");
+  dprintf("  Key: \\Registry\\Machine\\SOFTWARE\\ReactOS\n");
+  RtlRosInitUnicodeStringFromLiteral(&KeyName, L"\\Registry\\Machine\\SOFTWARE\\ReactOS");
   InitializeObjectAttributes(&ObjectAttributes, &KeyName, OBJ_CASE_INSENSITIVE
 				, NULL, NULL);
   Status = NtCreateKey(&hKey, KEY_ALL_ACCESS , &ObjectAttributes
@@ -658,9 +658,9 @@ void test6(void)
     return;
 
   dprintf("Create link value\n");
-  dprintf("  Value: SymbolicLinkValue = '\\Registry\\Machine\\SOFTWARE\\Reactos'\n");
+  dprintf("  Value: SymbolicLinkValue = '\\Registry\\Machine\\SOFTWARE\\ReactOS'\n");
   RtlRosInitUnicodeStringFromLiteral(&ValueName, L"SymbolicLinkValue");
-  Status=NtSetValueKey(hKey,&ValueName,0,REG_LINK,(PVOID)L"\\Registry\\Machine\\SOFTWARE\\Reactos",68);
+  Status=NtSetValueKey(hKey,&ValueName,0,REG_LINK,(PVOID)L"\\Registry\\Machine\\SOFTWARE\\ReactOS",68);
   dprintf("  NtSetValueKey() called (Status %lx)\n",Status);
   if (!NT_SUCCESS(Status))
     {

--- a/sdk/include/ndk/rtlfuncs.h
+++ b/sdk/include/ndk/rtlfuncs.h
@@ -5165,7 +5165,7 @@ RtlIsValidLocaleName(
 // Flags for RtlLocaleNameToLcid / RtlLcidToLocaleName / RtlIsValidLocaleName
 #define RTL_LOCALE_ALLOW_NEUTRAL_NAMES 0x00000002 // Return locales like "en" or "de"
 
-#endif /* Win vista or Reactos Ntdll build */
+#endif /* Win Vista or ReactOS Ntdll build */
 
 #if (_WIN32_WINNT >= _WIN32_WINNT_WIN7) || (defined(__REACTOS__) && defined(_NTDLLBUILD_))
 
@@ -5179,7 +5179,7 @@ BOOLEAN
 NTAPI
 RtlTryAcquireSRWLockExclusive(PRTL_SRWLOCK SRWLock);
 
-#endif /* Win7 or Reactos Ntdll build */
+#endif /* Win7 or ReactOS Ntdll build */
 
 #endif // NTOS_MODE_USER
 


### PR DESCRIPTION
## Purpose

Fix and use standard 'ReactOS' casing , instead of "Reactos" or variations thereof, in localization files, comments, and registry keys.