### PR TITLE
[MSCONFIG] Disable actions that are not implemented

### DIFF
--- a/base/applications/msconfig/freeldrpage.c
+++ b/base/applications/msconfig/freeldrpage.c
@@ -140,6 +140,7 @@ FreeLdrPageWndProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
         hFreeLdrDialog = hDlg;
         SetWindowPos(hDlg, NULL, 10, 32, 0, 0, SWP_NOACTIVATE | SWP_NOOWNERZORDER | SWP_NOSIZE | SWP_NOZORDER);
         InitializeFreeLDRDialog(hDlg);
+        DisableAllExcept(hDlg, IDC_LIST_BOX); // FIXME: Implement saving
         return TRUE;
     case WM_COMMAND:
         switch(HIWORD(wParam))

--- a/base/applications/msconfig/msconfig.c
+++ b/base/applications/msconfig/msconfig.c
@@ -80,6 +80,14 @@ BOOL EnableDialogTheme(HWND hwnd)
         return FALSE;
     }
 }
+
+VOID DisableAllExcept(HWND hTabDlg, UINT idExcept)
+{
+    HWND hSkip = GetDlgItem(hTabDlg, idExcept);
+    for (HWND hWnd = NULL; (hWnd = FindWindowExW(hTabDlg, hWnd, NULL, NULL)) != NULL;)
+        EnableWindow(hWnd, hWnd == hSkip);
+}
+
 BOOL OnCreate(HWND hWnd)
 {
     TCHAR   szTemp[256];
@@ -135,6 +143,10 @@ BOOL OnCreate(HWND hWnd)
 
     MsConfig_OnTabWndSelChange();
 
+    // FIXME: We don't support applying anything
+    EnableWindow(GetDlgItem(hWnd, IDOK), FALSE);
+    EnableWindow(GetDlgItem(hWnd, IDC_BTN_APPLY), FALSE);
+    EnableWindow(GetDlgItem(hWnd, IDC_BTN_HELP), FALSE);
     return TRUE;
 }
 

--- a/base/applications/msconfig/msconfig.h
+++ b/base/applications/msconfig/msconfig.h
@@ -1,3 +1,5 @@
 #pragma once
 
 extern HINSTANCE hInst;
+
+VOID DisableAllExcept(HWND hTabDlg, UINT idExcept);

--- a/base/applications/msconfig/srvpage.c
+++ b/base/applications/msconfig/srvpage.c
@@ -67,7 +67,26 @@ ServicesPageWndProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
         (void)ListView_InsertColumn(hServicesListCtrl, 3, &column);
 
         GetServices();
+        DisableAllExcept(hDlg, IDC_SERVICES_LIST); // FIXME: Implement saving
         return TRUE;
+
+    case WM_NOTIFY:
+        if (wParam == IDC_SERVICES_LIST)
+        {
+            NMLISTVIEW *pnmlv = (NMLISTVIEW*)lParam;
+            UINT toggled = (pnmlv->uOldState ^ pnmlv->uNewState) & LVIS_STATEIMAGEMASK;
+            if (pnmlv->hdr.code == LVN_ITEMCHANGING && (pnmlv->uChanged & LVIF_STATE) && toggled)
+            {
+                // Only allow checkbox changes during WM_INITDIALOG
+                if (!IsWindowEnabled(GetDlgItem(hDlg, IDC_BTN_SERVICES_ACTIVATE)))
+                {
+                    MessageBeep(-1);
+                    SetWindowLongPtr(hDlg, DWLP_MSGRESULT, TRUE);
+                    return TRUE;
+                }
+            }
+        }
+        break;
     }
 
     return 0;

--- a/base/applications/msconfig/startuppage.c
+++ b/base/applications/msconfig/startuppage.c
@@ -65,8 +65,26 @@ StartupPageWndProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
 
         //FIXME: What about HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\Userinit
         //FIXME: Common Startup (startmenu)
-
+        DisableAllExcept(hDlg, IDC_STARTUP_LIST); // FIXME: Implement saving
         return TRUE;
+
+    case WM_NOTIFY:
+        if (wParam == IDC_STARTUP_LIST)
+        {
+            NMLISTVIEW *pnmlv = (NMLISTVIEW*)lParam;
+            UINT toggled = (pnmlv->uOldState ^ pnmlv->uNewState) & LVIS_STATEIMAGEMASK;
+            if (pnmlv->hdr.code == LVN_ITEMCHANGING && (pnmlv->uChanged & LVIF_STATE) && toggled)
+            {
+                // Only allow checkbox changes during WM_INITDIALOG
+                if (!IsWindowEnabled(GetDlgItem(hDlg, IDC_BTN_STARTUP_ACTIVATE)))
+                {
+                    MessageBeep(-1);
+                    SetWindowLongPtr(hDlg, DWLP_MSGRESULT, TRUE);
+                    return TRUE;
+                }
+            }
+        }
+        break;
     }
 
     return 0;

--- a/base/applications/msconfig/systempage.c
+++ b/base/applications/msconfig/systempage.c
@@ -94,6 +94,7 @@ SystemPageWndProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
             hSystemDialog = hDlg;
             SetWindowPos(hDlg, NULL, 10, 32, 0, 0, SWP_NOACTIVATE | SWP_NOOWNERZORDER | SWP_NOSIZE | SWP_NOZORDER);
             InitializeSystemDialog(hDlg);
+            DisableAllExcept(hDlg, IDC_SYSTEM_TREE); // FIXME: Implement saving
             return TRUE;
         }
     }


### PR DESCRIPTION
Noting is more infuriating than OK/Apply buttons that do nothing silently. This disables all buttons that do nothing.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: