### PR TITLE
[INDICDLL] Don't use user32 in DLL_PROCESS_ATTACH

### DIFF
--- a/base/applications/kbswitch/indicdll/indicdll.c
+++ b/base/applications/kbswitch/indicdll/indicdll.c
@@ -153,6 +153,11 @@ KbSwitchSetHooks(_In_ BOOL bDoHook)
             g_pShared->hShellHook &&
             g_pShared->hKeyboardHook)
         {
+            if (!g_pShared->hKbSwitchWnd || !IsWindow(g_pShared->hKbSwitchWnd))
+            {
+                g_pShared->hKbSwitchWnd = FindWindow(INDICATOR_CLASS, NULL);
+                TRACE("hKbSwitchWnd: %p\n", g_pShared->hKbSwitchWnd);
+            }
             LeaveProtectedSection();
             return TRUE;
         }
@@ -245,12 +250,6 @@ DllMain(IN HINSTANCE hinstDLL,
 
             if (!bAlreadyExists)
                 ZeroMemory(g_pShared, sizeof(*g_pShared));
-
-            if (!g_pShared->hKbSwitchWnd || !IsWindow(g_pShared->hKbSwitchWnd))
-            {
-                g_pShared->hKbSwitchWnd = FindWindow(INDICATOR_CLASS, NULL);
-                TRACE("hKbSwitchWnd: %p\n", g_pShared->hKbSwitchWnd);
-            }
 
             g_hMutex = CreateMutex(NULL, FALSE, TEXT("INDICDLL_PROTECTED"));
             if (!g_hMutex)

--- a/base/applications/kbswitch/indicdll/indicdll.c
+++ b/base/applications/kbswitch/indicdll/indicdll.c
@@ -153,11 +153,13 @@ KbSwitchSetHooks(_In_ BOOL bDoHook)
             g_pShared->hShellHook &&
             g_pShared->hKeyboardHook)
         {
+            // Find kbswitch window if necessary
             if (!g_pShared->hKbSwitchWnd || !IsWindow(g_pShared->hKbSwitchWnd))
             {
                 g_pShared->hKbSwitchWnd = FindWindow(INDICATOR_CLASS, NULL);
                 TRACE("hKbSwitchWnd: %p\n", g_pShared->hKbSwitchWnd);
             }
+
             LeaveProtectedSection();
             return TRUE;
         }


### PR DESCRIPTION
## Purpose
Related to #8145. We shouldn't use `user32` functions in `DllMain.DLL_PROCESS_ATTACH`. This bug affects Global Hook. See [`DllMain`](https://learn.microsoft.com/en-us/windows/win32/dlls/dllmain#remarks) and ["Dynamic-Link Library Best Practices"](https://learn.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-best-practices#general-best-practices) on MS Learn.

JIRA issue: [CORE-20242](https://jira.reactos.org/browse/CORE-20242)

## Proposed changes

- Don't use `user32!FindWindow` in `DllMain.DLL_PROCESS_ATTACH`, but in `KbSwitchSetHooks` function.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: