### PR TITLE
[NTOS:EX] Implement NtSetSystemInformation().SystemLoadGdiDriverInSystemSpaceInformation

### DIFF
--- a/ntoskrnl/ex/sysinfo.c
+++ b/ntoskrnl/ex/sysinfo.c
@@ -2363,9 +2363,8 @@ QSI_DEF(SystemSessionProcessesInformation)
 /* Class 54 - Load & map in system space */
 SSI_DEF(SystemLoadGdiDriverInSystemSpaceInformation)
 {
-    /* FIXME */
-    DPRINT1("NtSetSystemInformation - SystemLoadGdiDriverInSystemSpaceInformation not implemented\n");
-    return STATUS_NOT_IMPLEMENTED;
+    /* Similar to SystemLoadGdiDriverInformation */
+    return SSI_USE(SystemLoadGdiDriverInformation)(Buffer, Size);
 }
 
 /* Class 55 - NUMA processor information */

--- a/sdk/include/ndk/extypes.h
+++ b/sdk/include/ndk/extypes.h
@@ -1197,6 +1197,7 @@ typedef struct _SYSTEM_MEMORY_INFORMATION
 } SYSTEM_MEMORY_INFORMATION, *PSYSTEM_MEMORY_INFORMATION;
 
 // Class 26
+// See https://www.geoffchappell.com/studies/windows/km/ntoskrnl/api/ex/sysinfo/gdi_driver.htm.
 typedef struct _SYSTEM_GDI_DRIVER_INFORMATION
 {
     UNICODE_STRING DriverName;


### PR DESCRIPTION
## Purpose

Implement `SystemLoadGdiDriverInSystemSpaceInformation` case of `NtSetSystemInformation()` function.
According to https://www.geoffchappell.com/studies/windows/km/ntoskrnl/api/ex/sysinfo/gdi_driver.htm, it seem to do the similar thing to `SystemLoadGdiDriverInformation` (because these two cases have the same shared structure), so simply redirect `SystemLoadGdiDriverInSystemSpaceInformation` to `SystemLoadGdiDriverInformation` case, which we have already implemented.
This fixes VM starting failure for VirtualBox 3.1.0 - 4.0.24 and 4.3.0 - 4.3.12 versions, so this proves my changes actually work correctly.
Newer versions of VirtualBox still don't work because of another blocking bugs. 

JIRA issue: [CORE-20257](https://jira.reactos.org/browse/CORE-20257)

## Proposed changes

- Implement `SystemLoadGdiDriverInSystemSpaceInformation` case.
- Add a link to the documentation above the `SYSTEM_GDI_DRIVER_INFORMATION` structure definition in the appropriate psdk header.

## Result

VirtualBox 4.3.12 before:
![VirtualBox_ReactOS_27_06_2025_16_10_20](https://github.com/user-attachments/assets/dcb3d1d9-a2bd-4c28-b361-307d16e9d815)

and after:
![ReactOS_in_ReactOS_4](https://github.com/user-attachments/assets/a97179f1-d2c3-47d0-9699-72a17b901a54)

**NOTE: to properly load and save XML settings in VirtualBox 4.1.0 and newer versions, my another ole32 fix is still required. Will send a PR with that too. Without that, only older versions up to 4.0.24 are working, according to my tests.**

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: