### PR TITLE
[UNIATA] UniataChipDetect(): Workaround AHCI detection

### DIFF
--- a/drivers/storage/ide/uniata/id_init.cpp
+++ b/drivers/storage/ide/uniata/id_init.cpp
@@ -658,11 +658,18 @@ for_ugly_chips:
             }
             break;
         default:
+#ifdef __REACTOS__
+            /* I assume:
+             * - RangeStart == 0LL, "always". (CORE-13346)
+             * - It will be updated by UniataAhciDetect() a few lines below...
+             */
+#else
             if(!ScsiPortConvertPhysicalAddressToUlong((*ConfigInfo->AccessRanges)[5].RangeStart)) {
                 KdPrint2((PRINT_PREFIX "No BAR5, try BM\n"));
                 ChipFlags &= ~UNIATA_AHCI;
                 deviceExtension->HwFlags &= ~UNIATA_AHCI;
             }
+#endif
             break;
         }
     }


### PR DESCRIPTION
## Purpose

Fix AHCI support regression.

Reverts a part of 1afae58 (r69699).
JIRA issue: [CORE-13346](https://jira.reactos.org/browse/CORE-13346)

## Proposed changes

- Disable a "new" code block, which is broken.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: