### PR TITLE
[KERNEL32] _dump_context(): Fix ARM case

### DIFF
--- a/dll/win32/kernel32/client/except.c
+++ b/dll/win32/kernel32/client/except.c
@@ -79,11 +79,11 @@ _dump_context(PCONTEXT pc)
     DbgPrint("R12: %I64x   R13: %I64x   R14: %I64x   R15: %I64x\n", pc->R12, pc->R13, pc->R14, pc->R15);
     DbgPrint("EFLAGS: %.8x\n", pc->EFlags);
 #elif defined(_M_ARM)
-    DbgPrint("PC:  %08lx   LR:  %08lx   SP:  %08lx\n", pc->Pc);
+    DbgPrint("PC:  %08lx   LR:  %08lx   SP:  %08lx\n", pc->Pc, pc->Lr, pc->Sp);
     DbgPrint("R0:  %08lx   R1:  %08lx   R2:  %08lx   R3:  %08lx\n", pc->R0, pc->R1, pc->R2, pc->R3);
     DbgPrint("R4:  %08lx   R5:  %08lx   R6:  %08lx   R7:  %08lx\n", pc->R4, pc->R5, pc->R6, pc->R7);
     DbgPrint("R8:  %08lx   R9:  %08lx   R10: %08lx   R11: %08lx\n", pc->R8, pc->R9, pc->R10, pc->R11);
-    DbgPrint("R12: %08lx   CPSR: %08lx  FPSCR: %08lx\n", pc->R12, pc->Cpsr, pc->R1, pc->Fpscr, pc->R3);
+    DbgPrint("R12: %08lx   CPSR: %08lx  FPSCR: %08lx\n", pc->R12, pc->Cpsr, pc->Fpscr);
 #else
     #error "Unknown architecture"
 #endif


### PR DESCRIPTION
## Purpose

Another small step in the right direction.

Addendum to 369786f (r67736).

## Proposed changes

- Match DbgPrint() parameters.