### PR TITLE
[EXPLORER] Fix Taskbar context menu Z-order bug

### DIFF
--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -1957,20 +1957,18 @@ public:
         Data.pTray = m_Tray;
         ::EnumDisplayMonitors(NULL, NULL, FullScreenEnumProc, (LPARAM)&Data);
 
-        // Make the taskbar bottom or top
-        UINT uFlags = SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_NOOWNERZORDER;
-        HWND hwndTray = m_Tray->GetHWND();
-        ::SetWindowPos(hwndTray, (hwndRude ? HWND_BOTTOM : HWND_TOP), 0, 0, 0, 0, uFlags);
-
         if (hwndRude)
         {
+            // Make the taskbar bottom
+            UINT uFlags = SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_NOOWNERZORDER;
+            HWND hwndTray = m_Tray->GetHWND();
+            ::SetWindowPos(hwndTray, HWND_BOTTOM, 0, 0, 0, 0, uFlags);
+
+            // Switch to the rude app if necessary
             DWORD exstyle = (DWORD)::GetWindowLongPtrW(hwndRude, GWL_EXSTYLE);
             if (!(exstyle & WS_EX_TOPMOST) && !SHELL_IsRudeWindowActive(hwndRude))
                 ::SwitchToThisWindow(hwndRude, TRUE);
         }
-
-        // FIXME: NIN_BALLOONHIDE
-        // FIXME: NIN_POPUPCLOSE
     }
 
     HWND FindRudeApp(_In_opt_ HWND hwndFirstCheck)
@@ -2001,6 +1999,8 @@ public:
     // HSHELL_WINDOWACTIVATED, HSHELL_RUDEAPPACTIVATED
     void OnWindowActivated(_In_ HWND hwndTarget)
     {
+        if (!FindTaskItem(hwndTarget))
+            return;
         // Re-start rude app validation
         KillTimer(TIMER_ID_VALIDATE_RUDE_APP);
         SetTimer(TIMER_ID_VALIDATE_RUDE_APP, VALIDATE_RUDE_INTERVAL, NULL);
@@ -2010,6 +2010,8 @@ public:
     // HSHELL_WINDOWDESTROYED
     void OnWindowDestroyed(_In_ HWND hwndTarget)
     {
+        if (!FindTaskItem(hwndTarget))
+            return;
         HWND hwndRude = FindRudeApp(hwndTarget);
         HandleFullScreenApp(hwndRude);
     }


### PR DESCRIPTION
## Purpose
Taskbar task button context menu was wrongly overlapped by Taskbar. #8105 introduced this bug.
JIRA issue: [CORE-20260](https://jira.reactos.org/browse/CORE-20260)

## Proposed changes

- Don't bring the taskbar to top on no rude app.
- Check the target window by `FindTaskItem` in `OnWindowActivated` and `OnWindowDestroyed`.
## Comparison

BEFORE:
![before](https://github.com/user-attachments/assets/556d98b7-1f5a-48f0-8a1e-4617639885df)
AFTER:
![after](https://github.com/user-attachments/assets/390c56ad-cacf-4901-9e22-767fe13510b6)

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=102757,102814
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=102758,102816