### PR TITLE
[PSEH] Guard SEH2 macros for Clang on Linux x64 builders

### DIFF
--- a/sdk/lib/pseh/include/pseh/pseh2.h
+++ b/sdk/lib/pseh/include/pseh/pseh2.h
@@ -88,11 +88,13 @@ _Pragma("GCC diagnostic pop")
 #define _SEH2_LEAVE goto __seh2_scope_end__;
 #define _SEH2_VOLATILE volatile
 
+#ifndef __try // Conflict with GCC's x64 Linux STL, affects Clang on Linux x64 compilation as well
 #define __try _SEH2_TRY
 #define __except _SEH2_EXCEPT
 #define __finally _SEH2_FINALLY
 #define __endtry _SEH2_END
 #define __leave _SEH2_LEAVE
+#endif
 #define _exception_code() 0
 #define _exception_info() ((void*)0)
 


### PR DESCRIPTION
## Purpose

Probably **hack**fixing a corner case detected via broken entities of wlanwiz due to its usage of STLport. This was already done to PSEH3 prior to me.
Corner case examples: [broken](https://github.com/SigmaTel71/reactos/actions/runs/15911239148) and ["fixed"](https://github.com/SigmaTel71/reactos/actions/runs/15945705635)

JIRA issue: [CORE-6622](https://jira.reactos.org/browse/CORE-6622)

## Proposed changes

- Guard SEH2 family macros behind `#ifndef`

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=102937,102939
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=102938,102940