### PR TITLE
[NTOS:KE/x64] Implement stack based context capture

### DIFF
--- a/ntoskrnl/include/internal/amd64/ke.h
+++ b/ntoskrnl/include/internal/amd64/ke.h
@@ -474,6 +474,11 @@ KiGetUserModeStackAddress(void)
 }
 
 VOID
+KiGetTrapContext(
+    _In_ PKTRAP_FRAME TrapFrame,
+    _Out_ PCONTEXT Context);
+
+VOID
 KiSetTrapContext(
     _Out_ PKTRAP_FRAME TrapFrame,
     _In_ PCONTEXT Context,

--- a/ntoskrnl/ke/amd64/context.c
+++ b/ntoskrnl/ke/amd64/context.c
@@ -293,6 +293,28 @@ KeTrapFrameToContext(IN PKTRAP_FRAME TrapFrame,
 }
 
 VOID
+RtlGetUnwindContext(
+    _Out_ PCONTEXT Context,
+    _In_ DWORD64 TargetFrame);
+
+VOID
+KiGetTrapContextInternal(
+    _In_ PKTRAP_FRAME TrapFrame,
+    _Out_ PCONTEXT Context)
+{
+    ULONG64 TargetFrame;
+
+    /* Get the volatile register context from the trap frame */
+    KeTrapFrameToContext(TrapFrame, NULL, Context);
+
+    /* The target frame is MAX_SYSCALL_PARAM_SIZE bytes before the trap frame */
+    TargetFrame = (ULONG64)TrapFrame - MAX_SYSCALL_PARAM_SIZE;
+
+    /* Get the nonvolatiles on the stack */
+    RtlGetUnwindContext(Context, TargetFrame);
+}
+
+VOID
 RtlSetUnwindContext(
     _In_ PCONTEXT Context,
     _In_ DWORD64 TargetFrame);

--- a/ntoskrnl/ke/amd64/trap.S
+++ b/ntoskrnl/ke/amd64/trap.S
@@ -1137,6 +1137,29 @@ KiConvertToGuiThreadFailed:
 
 ENDFUNC
 
+EXTERN KiGetTrapContextInternal:PROC
+
+/*
+ * VOID
+ * KiGetTrapContext(
+ *     _Out_ PKTRAP_FRAME TrapFrame,
+ *     _In_ PCONTEXT Context);
+ */
+PUBLIC KiGetTrapContext
+.PROC KiGetTrapContext
+
+    /* Generate a KEXCEPTION_FRAME on the stack */
+    GENERATE_EXCEPTION_FRAME
+
+    call KiGetTrapContextInternal
+
+    /* Restore the registers from the KEXCEPTION_FRAME */
+    RESTORE_EXCEPTION_STATE
+
+    /* Return */
+    ret
+
+.ENDP
 
 EXTERN KiSetTrapContextInternal:PROC
 

--- a/ntoskrnl/ps/amd64/psctx.c
+++ b/ntoskrnl/ps/amd64/psctx.c
@@ -58,10 +58,8 @@ PspGetOrSetContextKernelRoutine(
     }
     else
     {
-        /* Convert the trap frame to a context */
-        KeTrapFrameToContext(TrapFrame,
-                             NULL,
-                             &GetSetContext->Context);
+        /* Get the nonvolatiles from the stack */
+        KiGetTrapContext(TrapFrame, &GetSetContext->Context);
     }
 
     /* Notify the Native API that we are done */

--- a/sdk/lib/rtl/amd64/unwind.c
+++ b/sdk/lib/rtl/amd64/unwind.c
@@ -1141,25 +1141,35 @@ RtlSetUnwindContext(
     _In_ DWORD64 TargetFrame)
 {
     KNONVOLATILE_CONTEXT_POINTERS ContextPointers;
+    ULONG ContextFlags = Context->ContextFlags & ~CONTEXT_AMD64;
 
     /* Capture pointers to the non-volatiles up to the target frame */
     RtlpCaptureNonVolatileContextPointers(&ContextPointers, TargetFrame);
 
     /* Copy the nonvolatiles to the captured locations */
-    *ContextPointers.R12 = Context->R12;
-    *ContextPointers.R13 = Context->R13;
-    *ContextPointers.R14 = Context->R14;
-    *ContextPointers.R15 = Context->R15;
-    *ContextPointers.Xmm6 = Context->Xmm6;
-    *ContextPointers.Xmm7 = Context->Xmm7;
-    *ContextPointers.Xmm8 = Context->Xmm8;
-    *ContextPointers.Xmm9 = Context->Xmm9;
-    *ContextPointers.Xmm10 = Context->Xmm10;
-    *ContextPointers.Xmm11 = Context->Xmm11;
-    *ContextPointers.Xmm12 = Context->Xmm12;
-    *ContextPointers.Xmm13 = Context->Xmm13;
-    *ContextPointers.Xmm14 = Context->Xmm14;
-    *ContextPointers.Xmm15 = Context->Xmm15;
+    if (ContextFlags & CONTEXT_INTEGER)
+    {
+        *ContextPointers.Rbx = Context->Rbx;
+        *ContextPointers.Rsi = Context->Rsi;
+        *ContextPointers.Rdi = Context->Rdi;
+        *ContextPointers.R12 = Context->R12;
+        *ContextPointers.R13 = Context->R13;
+        *ContextPointers.R14 = Context->R14;
+        *ContextPointers.R15 = Context->R15;
+    }
+    if (ContextFlags & CONTEXT_FLOATING_POINT)
+    {
+        *ContextPointers.Xmm6 = Context->Xmm6;
+        *ContextPointers.Xmm7 = Context->Xmm7;
+        *ContextPointers.Xmm8 = Context->Xmm8;
+        *ContextPointers.Xmm9 = Context->Xmm9;
+        *ContextPointers.Xmm10 = Context->Xmm10;
+        *ContextPointers.Xmm11 = Context->Xmm11;
+        *ContextPointers.Xmm12 = Context->Xmm12;
+        *ContextPointers.Xmm13 = Context->Xmm13;
+        *ContextPointers.Xmm14 = Context->Xmm14;
+        *ContextPointers.Xmm15 = Context->Xmm15;
+    }
 }
 
 VOID

--- a/sdk/lib/rtl/amd64/unwind.c
+++ b/sdk/lib/rtl/amd64/unwind.c
@@ -1136,6 +1136,43 @@ RtlpCaptureNonVolatileContextPointers(
 }
 
 VOID
+RtlGetUnwindContext(
+    _Out_ PCONTEXT Context,
+    _In_ DWORD64 TargetFrame)
+{
+    KNONVOLATILE_CONTEXT_POINTERS ContextPointers;
+    ULONG ContextFlags = Context->ContextFlags & ~CONTEXT_AMD64;
+
+    /* Capture pointers to the non-volatiles up to the target frame */
+    RtlpCaptureNonVolatileContextPointers(&ContextPointers, TargetFrame);
+
+    /* Copy the nonvolatiles from the captured locations */
+    if (ContextFlags & CONTEXT_INTEGER)
+    {
+        Context->Rbx = *ContextPointers.Rbx;
+        Context->Rsi = *ContextPointers.Rsi;
+        Context->Rdi = *ContextPointers.Rdi;
+        Context->R12 = *ContextPointers.R12;
+        Context->R13 = *ContextPointers.R13;
+        Context->R14 = *ContextPointers.R14;
+        Context->R15 = *ContextPointers.R15;
+    }
+    if (ContextFlags & CONTEXT_FLOATING_POINT)
+    {
+        Context->Xmm6 = *ContextPointers.Xmm6;
+        Context->Xmm7 = *ContextPointers.Xmm7;
+        Context->Xmm8 = *ContextPointers.Xmm8;
+        Context->Xmm9 = *ContextPointers.Xmm9;
+        Context->Xmm10 = *ContextPointers.Xmm10;
+        Context->Xmm11 = *ContextPointers.Xmm11;
+        Context->Xmm12 = *ContextPointers.Xmm12;
+        Context->Xmm13 = *ContextPointers.Xmm13;
+        Context->Xmm14 = *ContextPointers.Xmm14;
+        Context->Xmm15 = *ContextPointers.Xmm15;
+    }
+}
+
+VOID
 RtlSetUnwindContext(
     _In_ PCONTEXT Context,
     _In_ DWORD64 TargetFrame)


### PR DESCRIPTION
## Purpose

Implement stack based context capture. This is used in PspGetOrSetContextKernelRoutine to get the non-volatile registers, which are not present in the trap frame. The same mechanism was already implemented for setting the registers.

## Testbot runs (Filled in by Devs)

- ✅ KVM x86: https://reactos.org/testman/compare.php?ids=102964,102973,102975
- ✅ KVM x64: https://reactos.org/testman/compare.php?ids=102965,102974,102976