### PR TITLE
[SHLWAPI_APITEST] Fix heap assertion and test failures

### DIFF
--- a/modules/rostests/apitests/shlwapi/IsQSForward.cpp
+++ b/modules/rostests/apitests/shlwapi/IsQSForward.cpp
@@ -13,8 +13,6 @@
 #include <pseh/pseh2.h>
 #include <versionhelpers.h>
 
-static BOOL g_bVista = FALSE;
-
 static HRESULT
 IsQSForwardMockup(_In_opt_ const GUID *pguidCmdGroup, _In_ ULONG cCmds, _In_ OLECMD *prgCmds)
 {
@@ -63,7 +61,7 @@ IsQSForwardMockup(_In_opt_ const GUID *pguidCmdGroup, _In_ ULONG cCmds, _In_ OLE
     {
         if (!IsEqualGUID(CGID_Explorer, *pguidCmdGroup))
         {
-            if (g_bVista)
+            if (IsWindows8OrGreater())
                 return OLECMDERR_E_UNKNOWNGROUP;
             else
                 return OLECMDERR_E_NOTSUPPORTED;
@@ -363,8 +361,6 @@ static VOID TEST_MayExecForwardMockup(VOID)
 
 START_TEST(IsQSForward)
 {
-    g_bVista = IsWindowsVistaOrGreater();
-
     TEST_IsQSForward();
     TEST_MayQSForwardMockup();
     TEST_MayExecForwardMockup();

--- a/modules/rostests/apitests/shlwapi/IsQSForward.cpp
+++ b/modules/rostests/apitests/shlwapi/IsQSForward.cpp
@@ -13,6 +13,8 @@
 #include <pseh/pseh2.h>
 #include <versionhelpers.h>
 
+static const BOOL g_bWin8 = IsWindows8OrGreater();
+
 static HRESULT
 IsQSForwardMockup(_In_opt_ const GUID *pguidCmdGroup, _In_ ULONG cCmds, _In_ OLECMD *prgCmds)
 {
@@ -61,7 +63,7 @@ IsQSForwardMockup(_In_opt_ const GUID *pguidCmdGroup, _In_ ULONG cCmds, _In_ OLE
     {
         if (!IsEqualGUID(CGID_Explorer, *pguidCmdGroup))
         {
-            if (IsWindows8OrGreater())
+            if (g_bWin8)
                 return OLECMDERR_E_UNKNOWNGROUP;
             else
                 return OLECMDERR_E_NOTSUPPORTED;

--- a/modules/rostests/apitests/shlwapi/PathIsUNC.c
+++ b/modules/rostests/apitests/shlwapi/PathIsUNC.c
@@ -40,7 +40,7 @@ START_TEST(isuncpath)
     DO_TEST(FALSE, L"path1");
     DO_TEST(FALSE, L"c:\\path1");
 
-    if ((GetVersion() & 0xFF) >= 0x06)
+    if (GetNTVersion() >= _WIN32_WINNT_VISTA)
         DO_TEST(FALSE, L"\\\\?\\c:\\path1");
     else
         DO_TEST(TRUE, L"\\\\?\\c:\\path1");
@@ -55,7 +55,7 @@ START_TEST(isuncpath)
     DO_TEST(FALSE, (wchar_t*)NULL);
     DO_TEST(FALSE, L" ");
 
-    if ((GetVersion() & 0xFF) >= 0x06)
+    if (GetNTVersion() >= _WIN32_WINNT_VISTA)
         DO_TEST(FALSE, L"\\\\?\\");
     else
         DO_TEST(TRUE, L"\\\\?\\");

--- a/modules/rostests/apitests/shlwapi/PathIsUNC.c
+++ b/modules/rostests/apitests/shlwapi/PathIsUNC.c
@@ -40,8 +40,10 @@ START_TEST(isuncpath)
     DO_TEST(FALSE, L"path1");
     DO_TEST(FALSE, L"c:\\path1");
 
-    /* MSDN says FALSE but the test shows TRUE on Windows 2003, but returns FALSE on Windows 7 */
-    DO_TEST(TRUE, L"\\\\?\\c:\\path1");
+    if ((GetVersion() & 0xFF) >= 0x06)
+        DO_TEST(FALSE, L"\\\\?\\c:\\path1");
+    else
+        DO_TEST(TRUE, L"\\\\?\\c:\\path1");
 
     DO_TEST(TRUE, L"\\\\path1\\");
     DO_TEST(FALSE, L"//");
@@ -53,6 +55,8 @@ START_TEST(isuncpath)
     DO_TEST(FALSE, (wchar_t*)NULL);
     DO_TEST(FALSE, L" ");
 
-    /* The test shows TRUE on Windows 2003, but returns FALSE on Windows 7 */
-    DO_TEST(TRUE, L"\\\\?\\");
+    if ((GetVersion() & 0xFF) >= 0x06)
+        DO_TEST(FALSE, L"\\\\?\\");
+    else
+        DO_TEST(TRUE, L"\\\\?\\");
 }

--- a/modules/rostests/apitests/shlwapi/PathIsUNCServer.c
+++ b/modules/rostests/apitests/shlwapi/PathIsUNCServer.c
@@ -39,6 +39,8 @@ START_TEST(isuncpathserver)
     DO_TEST(FALSE, L"");
     DO_TEST(FALSE, L" ");
 
-    /* The test shows TRUE on Windows 2003, but returns FALSE on Windows 7 */
-    DO_TEST(TRUE, L"\\\\?");
+    if ((GetVersion() & 0xFF) >= 0x06)
+        DO_TEST(FALSE, L"\\\\?");
+    else
+        DO_TEST(TRUE, L"\\\\?");
 }

--- a/modules/rostests/apitests/shlwapi/PathIsUNCServer.c
+++ b/modules/rostests/apitests/shlwapi/PathIsUNCServer.c
@@ -39,7 +39,7 @@ START_TEST(isuncpathserver)
     DO_TEST(FALSE, L"");
     DO_TEST(FALSE, L" ");
 
-    if ((GetVersion() & 0xFF) >= 0x06)
+    if (GetNTVersion() >= _WIN32_WINNT_VISTA)
         DO_TEST(FALSE, L"\\\\?");
     else
         DO_TEST(TRUE, L"\\\\?");

--- a/modules/rostests/apitests/shlwapi/SHPropertyBag.cpp
+++ b/modules/rostests/apitests/shlwapi/SHPropertyBag.cpp
@@ -95,6 +95,13 @@ public:
                 if (lstrcmpiW(pszPropName, L"RECTL2.top") == 0)
                     return E_FAIL;
 
+                if (lstrcmpiW(pszPropName, L"Str1") == 0)
+                {
+                    V_VT(pvari) = VT_BSTR;
+                    V_BSTR(pvari) = SysAllocString(L"TestString");
+                    return S_OK;
+                }
+
                 if (lstrcmpiW(pszPropName, L"GUID1") == 0)
                 {
                     V_VT(pvari) = (VT_UI1 | VT_ARRAY);


### PR DESCRIPTION
## Purpose

Fix test failures and a heap assertion on Vista+.

### Current test failures
| Test            | 2003 (x86) | Vista (x86) | Vista (x64) | 7 (x86) | 7 (x64) | 8.1 (x86) | 8.1 (x64) | 10 (x86) | 10 (x64) |
| --------------- | ---------- | ----------- | ----------- | ------- | ------- | --------- | --------- | -------- | -------- |
| IsQSForward     | 0          | 47          | 47          | 47      | 47      | 0         | 0         | 0        | 0        |
| PathIsUNC       | 0          | 2           | 2           | 2       | 2       | 2         | 2         | 2        | 2        |
| PathIsUNCServer | 0          | 1           | 1           | 1       | 1       | 1         | 1         | 1        | 1        |

### New test failures
| Test            | 2003 (x86) | Vista (x86) | Vista (x64) | 7 (x86) | 7 (x64) | 8.1 (x86) | 8.1 (x64) | 10 (x86) | 10 (x64) |
| --------------- | ---------- | ----------- | ----------- | ------- | ------- | --------- | --------- | -------- | -------- |
| IsQSForward     | 0          | 0           | 0           | 0       | 0       | 0         | 0         | 0        | 0        |
| PathIsUNC       | 0          | 0           | 0           | 0       | 0       | 0         | 0         | 0        | 0        |
| PathIsUNCServer | 0          | 0           | 0           | 0       | 0       | 0         | 0         | 0        | 0        |

## Proposed changes
- Properly initialize a string in `SHPropertyBag` test. This prevents a heap assertion failure on Vista+ when freed and connected to a debugger.
- Adjust a value against Windows 8+ instead of Vista as originally assumed in the `IsQSForward` test.
- Use `GetVersion()` to check if we are running on NT6+ and test appropriately in the `PathIsUNC` and `PathIsUNCServer` tests.

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=102908,102910
  No visible changes (the `shlwapi:SHPropertyBag` test was apparently succeeding with its 239 tests).
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=102909,102912
  Here, the `shlwapi:SHPropertyBag` test was previously crashing, but it now successfully passes.
  However, the `shell32:SHChangeNotify` gets 4 more errors. I don't know whether this is related to anything, or whether this is just a fluke.
