### PR TITLE
[CMAKE] msvc.cmake: Add /wd4819 for Far East Asian

### DIFF
--- a/sdk/cmake/msvc.cmake
+++ b/sdk/cmake/msvc.cmake
@@ -40,6 +40,9 @@ if(CMAKE_C_COMPILER_ID STREQUAL "MSVC")
     add_compile_options(/X /Zl)
 endif()
 
+# Erase warning C4819 for Far-East users: The file contains characters that cannot be displayed in the current code page
+add_compile_options(/wd4819)
+
 # Disable buffer security checks by default.
 add_compile_options(/GS-)
 

--- a/sdk/cmake/msvc.cmake
+++ b/sdk/cmake/msvc.cmake
@@ -40,7 +40,7 @@ if(CMAKE_C_COMPILER_ID STREQUAL "MSVC")
     add_compile_options(/X /Zl)
 endif()
 
-# Erase warning C4819 for Far-East users: The file contains characters that cannot be displayed in the current code page
+# Erase warning C4819 for Far East Asian: The file contains characters that cannot be displayed in the current code page
 add_compile_options(/wd4819)
 
 # Disable buffer security checks by default.


### PR DESCRIPTION
## Purpose
"Far East Asian" Visual Studio had generated a lot of `"warning C4819: File contains characters that cannot be displayed in the current code page..."`.

JIRA issue: N/A

![error](https://github.com/user-attachments/assets/783df0d0-8fe7-42f9-99f6-2c22c07fd268)

![success](https://github.com/user-attachments/assets/79e8a719-7cc7-4ab8-b485-81d21827449f)

```txt
error C2220: 次の警告はエラーとして処理されます
warning C4819: ファイルは、現在のコード ページ (932) で表示できない文字を含んでいます。データの損失を防ぐために、ファイルを Unicode 形式で保存してください。
```

## Proposed changes

- Insert `add_compile_options(/wd4819)` into `sdk/cmake/msvc.cmake`.

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=102846,102853
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=102848,102854