### PR TITLE
[APITEST] Add GetNTVersion() macro for version detection on Windows 8.x+

### DIFF
--- a/modules/rostests/apitests/include/apitest.h
+++ b/modules/rostests/apitests/include/apitest.h
@@ -12,6 +12,10 @@
 #define InvalidPointer ((PVOID)0x5555555555555555ULL)
 // #define InvalidPointer ((PVOID)0x0123456789ABCDEFULL)
 
+// Magic pointers come from KUSER_SHARED_DATA; needed to get true NT version on Windows 8.x+
+#define KUSER_SHARED_DATA_UMPTR 0x7FFE0000
+#define GetNTVersion() (((*(ULONG*)(KUSER_SHARED_DATA_UMPTR + 0x026C)) << 8) | (*(ULONG*)(KUSER_SHARED_DATA_UMPTR + 0x0270)))
+
 #include <pseh/pseh2.h>
 
 #define StartSeh()                                  \


### PR DESCRIPTION
## Purpose

Add a macro to `apitest.h` to get the version NT we are currently running on. This is needed to get the correct NT version on Windows after Windows 8.x.

For example, with this macro you can easily check if you're running on Windows 10 or newer with `if (GetNTVersion() >= _WIN32_WINNT_WIN10)`.  

## Proposed changes
- Grab the NT Major and Minor versions from `KUSER_SHARED_DATA`.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: