### PR TITLE
[FREELDR] Hack AMD64 to boot with higher amounts of RAM

### DIFF
--- a/boot/freeldr/freeldr/include/mm.h
+++ b/boot/freeldr/freeldr/include/mm.h
@@ -68,7 +68,9 @@ typedef struct _FREELDR_MEMORY_DESCRIPTOR
 #define MM_PAGE_SIZE    4096
 #define MM_PAGE_MASK    0xFFF
 #define MM_PAGE_SHIFT    12
-#define MM_MAX_PAGE        0xFFFFFFFFF /* 36 bits for the PFN */
+//HACK: ReactOS AMD64 can't handle the full memory range yet CORE-20265
+//#define MM_MAX_PAGE        0xFFFFFFFFF /* 36 bits for the PFN */
+#define MM_MAX_PAGE        0x1FFFFF
 #define MM_MAX_PAGE_LOADER 0x3FFFF /* on x64 freeldr only maps 1 GB */
 
 #define MM_SIZE_TO_PAGES(a)  \


### PR DESCRIPTION
Hack reactos amd64 so we can boot on systems with higher ram amounts tested up to 128gb

@tkreuzer  mentioned a real fix will come eventually but for now i'll apply this hack

JIRA report: [CORE-20265](https://jira.reactos.org/browse/CORE-20265)

## Testbot runs (Filled in by Devs)

- [ ] KVM x86: N/A (This is a AMD64 only PR)
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=102862,102866