### PR TITLE
[BOOT] Make ACPI always copy on amd64

### DIFF
--- a/boot/bootdata/txtsetup.sif
+++ b/boot/bootdata/txtsetup.sif
@@ -87,7 +87,6 @@ FreeSysPartDiskSpace=450
 ; "MouseDrivers.Load" sections.
 ;
 [SourceDisksFiles]
-acpi.sys     = 1,,,,,,,4,1,,,1,4
 nmidebug.sys = 1,,,,,,x,4,,,,1,4
 sacdrv.sys   = 1,,,,,,x,4,,,,1,4
 uniata.sys   = 1,,,,,,x,4,,,,1,4
@@ -138,8 +137,10 @@ mountmgr.sys = 1,,,,,,x,4,,,,1,4
 partmgr.sys  = 1,,,,,,x,4,,,,1,4
 
 [SourceDisksFiles.x86]
+acpi.sys     = 1,,,,,,,4,1,,,1,4
 
 [SourceDisksFiles.amd64]
+acpi.sys     = 1,,,,,,x,4,,,,1,4
 
 ;
 ; The [SystemPartitionFiles] section lists all the files


### PR DESCRIPTION
This just makes it so ACPI.sys is always loaded and copied by the bootcd no matter what on amd64. 
On x86 it can depend on whether we're using an ACPI hal but is set up to never boot with ACPI on the bootcd.
The only reason bootcd boots on x64 is because UNIATA is technically not PNP compliant and is rude.

JIRA issues: [CORE-14922](https://jira.reactos.org/browse/CORE-14922), [CORE-17256](https://jira.reactos.org/browse/CORE-17256)

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=103039,103051
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=103040,103053