### PR TITLE
[CONSRV] Pasting CJK text

### DIFF
--- a/win32ss/user/winsrv/consrv/coninput.c
+++ b/win32ss/user/winsrv/consrv/coninput.c
@@ -220,7 +220,7 @@ ConioProcessInputEvent(PCONSRV_CONSOLE Console,
             if (Console->LineBuffer && !Console->LineComplete)
             {
                 /* Line input is in progress; end it */
-                Console->LinePos = Console->LineSize = 0;
+                Console->LineColumn = Console->LinePos = Console->LineSize = 0;
                 Console->LineComplete = TRUE;
             }
             return STATUS_SUCCESS; // STATUS_CONTROL_C_EXIT;

--- a/win32ss/user/winsrv/consrv/console.c
+++ b/win32ss/user/winsrv/consrv/console.c
@@ -745,7 +745,7 @@ ConSrvInitConsole(OUT PHANDLE NewConsoleHandle,
     /* Initialize the Input Line Discipline */
     // InitLineInput(Console);
     Console->LineBuffer = NULL;
-    Console->LinePos = Console->LineMaxSize = Console->LineSize = 0;
+    Console->LineColumn = Console->LinePos = Console->LineMaxSize = Console->LineSize = 0;
     Console->LineComplete = Console->LineUpPressed = FALSE;
     // LineWakeupMask
     Console->LineInsertToggle =

--- a/win32ss/user/winsrv/consrv/frontends/gui/guiterm.c
+++ b/win32ss/user/winsrv/consrv/frontends/gui/guiterm.c
@@ -685,13 +685,9 @@ GuiWriteStream(IN OUT PFRONTEND This,
         if (GuiData->Console->IsCJK)
         {
             if (CursorStartX > 0)
-            {
                 InvalidateCell(GuiData, CursorStartX - 1, CursorStartY);
-            }
             if (CursorStartX + 1 < Buff->ViewSize.X)
-            {
                 InvalidateCell(GuiData, CursorStartX + 1, CursorStartY);
-            }
         }
     }
 
@@ -707,9 +703,7 @@ GuiWriteStream(IN OUT PFRONTEND This,
             if (CursorEndX > 0)
                 InvalidateCell(GuiData, CursorEndX - 1, CursorEndY);
             if (CursorEndX + 1 < Buff->ViewSize.X)
-            {
                 InvalidateCell(GuiData, CursorEndX + 1, CursorEndY);
-            }
         }
     }
 

--- a/win32ss/user/winsrv/consrv/frontends/gui/guiterm.c
+++ b/win32ss/user/winsrv/consrv/frontends/gui/guiterm.c
@@ -705,7 +705,10 @@ GuiWriteStream(IN OUT PFRONTEND This,
         if (GuiData->Console->IsCJK)
         {
             InvalidateCell(GuiData, CursorEndX - 1, CursorEndY);
-            InvalidateCell(GuiData, CursorEndX + 1, CursorEndY);
+            if (CursorEndX + 1 < Buff->ViewSize.X)
+            {
+                InvalidateCell(GuiData, CursorEndX + 1, CursorEndY);
+            }
         }
     }
 

--- a/win32ss/user/winsrv/consrv/frontends/gui/guiterm.c
+++ b/win32ss/user/winsrv/consrv/frontends/gui/guiterm.c
@@ -682,6 +682,8 @@ GuiWriteStream(IN OUT PFRONTEND This,
             || CursorStartY < Region->Top || Region->Bottom < CursorStartY)
     {
         InvalidateCell(GuiData, CursorStartX, CursorStartY);
+        InvalidateCell(GuiData, CursorStartX - 1, CursorStartY);
+        InvalidateCell(GuiData, CursorStartX + 1, CursorStartY);
     }
 
     CursorEndX = Buff->CursorPosition.X;
@@ -691,6 +693,8 @@ GuiWriteStream(IN OUT PFRONTEND This,
             && (CursorEndX != CursorStartX || CursorEndY != CursorStartY))
     {
         InvalidateCell(GuiData, CursorEndX, CursorEndY);
+        InvalidateCell(GuiData, CursorEndX - 1, CursorEndY);
+        InvalidateCell(GuiData, CursorEndX + 1, CursorEndY);
     }
 
     // HACK!!

--- a/win32ss/user/winsrv/consrv/frontends/gui/guiterm.c
+++ b/win32ss/user/winsrv/consrv/frontends/gui/guiterm.c
@@ -684,7 +684,10 @@ GuiWriteStream(IN OUT PFRONTEND This,
         InvalidateCell(GuiData, CursorStartX, CursorStartY);
         if (GuiData->Console->IsCJK)
         {
-            InvalidateCell(GuiData, CursorStartX - 1, CursorStartY);
+            if (CursorStartX > 0)
+            {
+                InvalidateCell(GuiData, CursorStartX - 1, CursorStartY);
+            }
             InvalidateCell(GuiData, CursorStartX + 1, CursorStartY);
         }
     }

--- a/win32ss/user/winsrv/consrv/frontends/gui/guiterm.c
+++ b/win32ss/user/winsrv/consrv/frontends/gui/guiterm.c
@@ -704,7 +704,8 @@ GuiWriteStream(IN OUT PFRONTEND This,
         InvalidateCell(GuiData, CursorEndX, CursorEndY);
         if (GuiData->Console->IsCJK)
         {
-            InvalidateCell(GuiData, CursorEndX - 1, CursorEndY);
+            if (CursorEndX > 0)
+                InvalidateCell(GuiData, CursorEndX - 1, CursorEndY);
             if (CursorEndX + 1 < Buff->ViewSize.X)
             {
                 InvalidateCell(GuiData, CursorEndX + 1, CursorEndY);

--- a/win32ss/user/winsrv/consrv/frontends/gui/guiterm.c
+++ b/win32ss/user/winsrv/consrv/frontends/gui/guiterm.c
@@ -682,8 +682,11 @@ GuiWriteStream(IN OUT PFRONTEND This,
             || CursorStartY < Region->Top || Region->Bottom < CursorStartY)
     {
         InvalidateCell(GuiData, CursorStartX, CursorStartY);
-        InvalidateCell(GuiData, CursorStartX - 1, CursorStartY);
-        InvalidateCell(GuiData, CursorStartX + 1, CursorStartY);
+        if (GuiData->Console->IsCJK)
+        {
+            InvalidateCell(GuiData, CursorStartX - 1, CursorStartY);
+            InvalidateCell(GuiData, CursorStartX + 1, CursorStartY);
+        }
     }
 
     CursorEndX = Buff->CursorPosition.X;
@@ -693,8 +696,11 @@ GuiWriteStream(IN OUT PFRONTEND This,
             && (CursorEndX != CursorStartX || CursorEndY != CursorStartY))
     {
         InvalidateCell(GuiData, CursorEndX, CursorEndY);
-        InvalidateCell(GuiData, CursorEndX - 1, CursorEndY);
-        InvalidateCell(GuiData, CursorEndX + 1, CursorEndY);
+        if (GuiData->Console->IsCJK)
+        {
+            InvalidateCell(GuiData, CursorEndX - 1, CursorEndY);
+            InvalidateCell(GuiData, CursorEndX + 1, CursorEndY);
+        }
     }
 
     // HACK!!

--- a/win32ss/user/winsrv/consrv/frontends/gui/guiterm.c
+++ b/win32ss/user/winsrv/consrv/frontends/gui/guiterm.c
@@ -688,7 +688,10 @@ GuiWriteStream(IN OUT PFRONTEND This,
             {
                 InvalidateCell(GuiData, CursorStartX - 1, CursorStartY);
             }
-            InvalidateCell(GuiData, CursorStartX + 1, CursorStartY);
+            if (CursorStartX + 1 < Buff->ViewSize.X)
+            {
+                InvalidateCell(GuiData, CursorStartX + 1, CursorStartY);
+            }
         }
     }
 

--- a/win32ss/user/winsrv/consrv/frontends/gui/text.c
+++ b/win32ss/user/winsrv/consrv/frontends/gui/text.c
@@ -3,7 +3,7 @@
  * PROJECT:         ReactOS Console Server DLL
  * FILE:            win32ss/user/winsrv/consrv/frontends/gui/text.c
  * PURPOSE:         GUI Terminal Front-End - Support for text-mode screen-buffers
- * PROGRAMMERS:     Gé van Geldorp
+ * PROGRAMMERS:     GÃ© van Geldorp
  *                  Johannes Anderwald
  *                  Jeffrey Morlan
  *                  Hermes Belusca-Maito (hermes.belusca@sfr.fr)
@@ -278,8 +278,6 @@ PasteText(
         }
         else
         {
-            /* Pressing some control keys */
-
             /* Pressing the character key, with the control keys maintained pressed */
             er.Event.KeyEvent.wVirtualKeyCode = LOBYTE(VkKey);
             er.Event.KeyEvent.wVirtualScanCode = MapVirtualKeyW(LOBYTE(VkKey), MAPVK_VK_TO_VSC);

--- a/win32ss/user/winsrv/consrv/frontends/gui/text.c
+++ b/win32ss/user/winsrv/consrv/frontends/gui/text.c
@@ -272,15 +272,21 @@ PasteText(
              * convert the character to OEM / multibyte and use MapVirtualKey()
              * on each byte (simulating an Alt-0xxx OEM keyboard press).
              */
+            er.Event.KeyEvent.wVirtualKeyCode = VK_PACKET;
+            er.Event.KeyEvent.wVirtualScanCode = CurChar;
+            er.Event.KeyEvent.uChar.UnicodeChar = CurChar;
+        }
+        else
+        {
+            /* Pressing some control keys */
+
+            /* Pressing the character key, with the control keys maintained pressed */
+            er.Event.KeyEvent.wVirtualKeyCode = LOBYTE(VkKey);
+            er.Event.KeyEvent.wVirtualScanCode = MapVirtualKeyW(LOBYTE(VkKey), MAPVK_VK_TO_VSC);
+            er.Event.KeyEvent.uChar.UnicodeChar = CurChar;
         }
 
-        /* Pressing some control keys */
-
-        /* Pressing the character key, with the control keys maintained pressed */
         er.Event.KeyEvent.bKeyDown = TRUE;
-        er.Event.KeyEvent.wVirtualKeyCode = LOBYTE(VkKey);
-        er.Event.KeyEvent.wVirtualScanCode = MapVirtualKeyW(LOBYTE(VkKey), MAPVK_VK_TO_VSC);
-        er.Event.KeyEvent.uChar.UnicodeChar = CurChar;
         er.Event.KeyEvent.dwControlKeyState = 0;
         if (HIBYTE(VkKey) & 1)
             er.Event.KeyEvent.dwControlKeyState |= SHIFT_PRESSED;

--- a/win32ss/user/winsrv/consrv/frontends/terminal.c
+++ b/win32ss/user/winsrv/consrv/frontends/terminal.c
@@ -340,7 +340,8 @@ ConSrvTermReadStream(IN OUT PTERMINAL This,
             Console->LineBuffer = ConsoleAllocHeap(0, Console->LineMaxSize * sizeof(WCHAR));
             if (Console->LineBuffer == NULL) return STATUS_NO_MEMORY;
 
-            Console->LineColumn = Console->LinePos = Console->LineSize = ReadControl->nInitialChars;
+            Console->LinePos = Console->LineSize = ReadControl->nInitialChars;
+            Console->LineColumn = GetTextWidth(Console->LineBuffer, ReadControl->nInitialChars, Console->LineSize);
             Console->LineComplete = Console->LineUpPressed = FALSE;
             Console->LineInsertToggle = Console->InsertMode;
             Console->LineWakeupMask = ReadControl->dwCtrlWakeupMask;

--- a/win32ss/user/winsrv/consrv/frontends/terminal.c
+++ b/win32ss/user/winsrv/consrv/frontends/terminal.c
@@ -340,7 +340,7 @@ ConSrvTermReadStream(IN OUT PTERMINAL This,
             Console->LineBuffer = ConsoleAllocHeap(0, Console->LineMaxSize * sizeof(WCHAR));
             if (Console->LineBuffer == NULL) return STATUS_NO_MEMORY;
 
-            Console->LinePos = Console->LineSize = ReadControl->nInitialChars;
+            Console->LineColumn = Console->LinePos = Console->LineSize = ReadControl->nInitialChars;
             Console->LineComplete = Console->LineUpPressed = FALSE;
             Console->LineInsertToggle = Console->InsertMode;
             Console->LineWakeupMask = ReadControl->dwCtrlWakeupMask;
@@ -354,7 +354,7 @@ ConSrvTermReadStream(IN OUT PTERMINAL This,
             if (Console->LineSize >= Console->LineMaxSize)
             {
                 Console->LineComplete = TRUE;
-                Console->LinePos = 0;
+                Console->LineColumn = Console->LinePos = 0;
             }
         }
 
@@ -411,7 +411,7 @@ ConSrvTermReadStream(IN OUT PTERMINAL This,
                 /* The entire line has been read */
                 ConsoleFreeHeap(Console->LineBuffer);
                 Console->LineBuffer = NULL;
-                Console->LinePos = Console->LineMaxSize = Console->LineSize = 0;
+                Console->LineColumn = Console->LinePos = Console->LineMaxSize = Console->LineSize = 0;
                 // Console->LineComplete = Console->LineUpPressed = FALSE;
                 Console->LineComplete = FALSE;
             }

--- a/win32ss/user/winsrv/consrv/include/conio_winsrv.h
+++ b/win32ss/user/winsrv/consrv/include/conio_winsrv.h
@@ -153,6 +153,7 @@ typedef struct _CONSRV_CONSOLE
     ULONG   LineMaxSize;                    /* Maximum size of line in characters (including CR+LF) */
     ULONG   LineSize;                       /* Current size of line */
     ULONG   LinePos;                        /* Current position within line */
+    ULONG   LineColumn;
     BOOLEAN LineComplete;                   /* User pressed enter, ready to send back to client */
     BOOLEAN LineUpPressed;
     BOOLEAN LineInsertToggle;               /* Replace character over cursor instead of inserting */

--- a/win32ss/user/winsrv/consrv/lineinput.c
+++ b/win32ss/user/winsrv/consrv/lineinput.c
@@ -42,9 +42,8 @@ GetTextWidth(PCWSTR Text, UINT TextLength, UINT TextMax)
     for (ich = 0; ich < TextLength && ich < TextMax; ++ich)
     {
         if (IS_FULL_WIDTH(Text[ich]))
-            width += 2;
-        else
             ++width;
+        ++width;
     }
 
     return width;

--- a/win32ss/user/winsrv/consrv/lineinput.c
+++ b/win32ss/user/winsrv/consrv/lineinput.c
@@ -34,8 +34,8 @@ ConvertInputUnicodeToAnsi(PCONSRV_CONSOLE Console,
 
 /* PRIVATE FUNCTIONS **********************************************************/
 
-static UINT
-GetTextWidth(PCWSTR Text, UINT TextLength, UINT TextMax)
+UINT
+GetTextWidth(_In_ PCWSTR Text, _In_ UINT TextLength, _In_ UINT TextMax)
 {
     UINT ich, width = 0;
 

--- a/win32ss/user/winsrv/consrv/lineinput.h
+++ b/win32ss/user/winsrv/consrv/lineinput.h
@@ -12,3 +12,5 @@ VOID
 LineInputKeyDown(PCONSRV_CONSOLE Console,
                  PUNICODE_STRING ExeName,
                  KEY_EVENT_RECORD *KeyEvent);
+
+UINT GetTextWidth(_In_ PCWSTR Text, _In_ UINT TextLength, _In_ UINT TextMax);


### PR DESCRIPTION
## Purpose
This PR fixes a display issue when pasting CJK (Chinese, Japanese, Korean) text in console by properly handling the width differences between single-byte and double-byte characters.

JIRA issue: [CORE-12451](https://jira.reactos.org/browse/CORE-12451)

## Proposed changes

- Adds `LineColumn` member to `CONSRV_CONSOLE` structure.
- Adds `GetTextWidth` helper function.
- Fixes `LineInputSetPos` and `LineInputEdit` functions for CJK characters.
- Implements proper screen invalidation for CJK character rendering.

## TODO

- [ ] VK_LEFT
- [ ] Line edit history garbage

## Screenshots and movie
(ReactOS JPN Package from Rapps required)
BEFORE:
![before](https://github.com/user-attachments/assets/90712d8a-dd0c-46fb-a8d4-f8ad0cab08b2)
Full-width characters had truncated as halves.

AFTER:
![after](https://github.com/user-attachments/assets/50dde9e7-f300-4bcc-9fad-a159e9704ce4)
Full-width characters displayed correctly.

Movie (AFTER):
https://github.com/user-attachments/assets/838b65d0-d73e-4809-966e-4aa0fa7c8693

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: