### PR TITLE
[NDIS] NDIS_TAG: Fix definition and usages

### DIFF
--- a/drivers/network/ndis/include/ndissys.h
+++ b/drivers/network/ndis/include/ndissys.h
@@ -26,7 +26,7 @@
 /* the version of NDIS we claim to be */
 #define NDIS_VERSION 0x00050001
 
-#define NDIS_TAG  0x4e4d4953
+#define NDIS_TAG 'SIDN' // "NDIS"
 
 #define MIN(value1, value2) \
     ((value1 < value2)? value1 : value2)

--- a/drivers/network/ndis/ndis/protocol.c
+++ b/drivers/network/ndis/ndis/protocol.c
@@ -925,7 +925,7 @@ ndisBindMiniportsToProtocol(OUT PNDIS_STATUS Status, IN PPROTOCOL_BINDING Protoc
     ULONG ResultLength;
     PLIST_ENTRY CurrentEntry = NULL;
 
-    RegistryPathStr = ExAllocatePoolWithTag(PagedPool, sizeof(SERVICES_KEY) + ProtocolCharacteristics->Name.Length + sizeof(LINKAGE_KEY), NDIS_TAG + __LINE__);
+    RegistryPathStr = ExAllocatePoolWithTag(PagedPool, sizeof(SERVICES_KEY) + ProtocolCharacteristics->Name.Length + sizeof(LINKAGE_KEY), NDIS_TAG);
     if(!RegistryPathStr)
     {
         NDIS_DbgPrint(MIN_TRACE, ("Insufficient resources.\n"));
@@ -944,7 +944,7 @@ ndisBindMiniportsToProtocol(OUT PNDIS_STATUS Status, IN PPROTOCOL_BINDING Protoc
     InitializeObjectAttributes(&ObjectAttributes, &RegistryPath, OBJ_CASE_INSENSITIVE | OBJ_KERNEL_HANDLE, NULL, NULL);
     NtStatus = ZwOpenKey(&DriverKeyHandle, KEY_READ, &ObjectAttributes);
 
-    ExFreePool(RegistryPathStr);
+    ExFreePoolWithTag(RegistryPathStr, NDIS_TAG);
 
     if(NT_SUCCESS(NtStatus))
     {
@@ -960,7 +960,7 @@ ndisBindMiniportsToProtocol(OUT PNDIS_STATUS Status, IN PPROTOCOL_BINDING Protoc
         }
         else
         {
-            KeyInformation = ExAllocatePoolWithTag(PagedPool, sizeof(KEY_VALUE_PARTIAL_INFORMATION) + ResultLength, NDIS_TAG + __LINE__);
+            KeyInformation = ExAllocatePoolWithTag(PagedPool, sizeof(KEY_VALUE_PARTIAL_INFORMATION) + ResultLength, NDIS_TAG);
             if(!KeyInformation)
             {
                 NDIS_DbgPrint(MIN_TRACE, ("Insufficient resources.\n"));
@@ -977,7 +977,7 @@ ndisBindMiniportsToProtocol(OUT PNDIS_STATUS Status, IN PPROTOCOL_BINDING Protoc
                 if(!NT_SUCCESS(NtStatus))
                 {
                     NDIS_DbgPrint(MIN_TRACE, ("Unable to query the Bind value\n"));
-                    ExFreePool(KeyInformation);
+                    ExFreePoolWithTag(KeyInformation, NDIS_TAG);
                     KeyInformation = NULL;
                 }
             }
@@ -987,7 +987,6 @@ ndisBindMiniportsToProtocol(OUT PNDIS_STATUS Status, IN PPROTOCOL_BINDING Protoc
     if (!NT_SUCCESS(NtStatus))
     {
         NDIS_DbgPrint(MID_TRACE, ("Performing global bind for protocol '%wZ'\n", &ProtocolCharacteristics->Name));
-        KeyInformation = NULL;
 
         CurrentEntry = AdapterListHead.Flink;
     }
@@ -1103,7 +1102,7 @@ ndisBindMiniportsToProtocol(OUT PNDIS_STATUS Status, IN PPROTOCOL_BINDING Protoc
 
     if (KeyInformation)
     {
-        ExFreePool(KeyInformation);
+        ExFreePoolWithTag(KeyInformation, NDIS_TAG);
     }
 }
 


### PR DESCRIPTION
## Purpose

Do not use random tags.

Addendum to e8861acfb2 (r12196) and 5658b2154c (r53045).
JIRA issue: [CORE-18791](https://jira.reactos.org/browse/CORE-18791)

## Proposed changes

- Let it be "NDIS", instead of variations of "SIMN".
- Use matching ExFreePoolWithTag().
- Remove a redundant 'KeyInformation = NULL;'.

## TODO

I fixed the existing cases only.
A follow-up would be to use the tag everywhere in this module.