### PR TITLE
[NTOS:MM] Implement MmGetVirtualForPhysical

### DIFF
--- a/modules/rostests/kmtests/ntos_mm/MmSection.c
+++ b/modules/rostests/kmtests/ntos_mm/MmSection.c
@@ -568,6 +568,25 @@ TestPhysicalMemorySection(VOID)
     RtlFillMemory(MyPage + 2 * PAGE_SIZE / 4, PAGE_SIZE / 4, 0xab);
     RtlFillMemory(MyPage + 3 * PAGE_SIZE / 4, PAGE_SIZE / 4, 0xef);
 
+    /* Get the virtual address for the physical, compare, and check that modifications are reflected */
+    Mapping = MmGetVirtualForPhysical(MyPagePhysical);
+    ok(Mapping != NULL, "MmGetVirtualForPhysical failed expected mapping got NULL\n");
+    EqualBytes = RtlCompareMemory(Mapping, MyPage, PAGE_SIZE);
+    ok_eq_size(EqualBytes, PAGE_SIZE);
+
+    MappingBytes = Mapping;
+    ok(MappingBytes[5] == 0x23, "Mapping[5] = 0x%x\n", MappingBytes[5]);
+    ok(MyPage[5] == 0x23, "MyPage[5] = 0x%x\n", MyPage[5]);
+
+    MyPage[5] = 0x44;
+    ok(MappingBytes[5] == 0x44, "Mapping[5] = 0x%x\n", MappingBytes[5]);
+    ok(MyPage[5] == 0x44, "MyPage[5] = 0x%x\n", MyPage[5]);
+
+    MappingBytes[5] = 0x88;
+    ok(MappingBytes[5] == 0x88, "Mapping[5] = 0x%x\n", MappingBytes[5]);
+    ok(MyPage[5] == 0x88, "MyPage[5] = 0x%x\n", MyPage[5]);
+
+
     ZeroPageContents = ExAllocatePoolWithTag(PagedPool, PAGE_SIZE, 'ZPmK');
     if (skip(ZeroPageContents != NULL, "Out of memory\n"))
     {

--- a/ntoskrnl/mm/ARM3/virtual.c
+++ b/ntoskrnl/mm/ARM3/virtual.c
@@ -2735,15 +2735,23 @@ MiDecommitPages(IN PVOID StartingAddress,
 
 /* PUBLIC FUNCTIONS ***********************************************************/
 
-/*
- * @unimplemented
- */
 PVOID
 NTAPI
 MmGetVirtualForPhysical(IN PHYSICAL_ADDRESS PhysicalAddress)
 {
-    UNIMPLEMENTED;
-    return 0;
+    PFN_NUMBER Pfn;
+    PMMPFN Pfn1;
+    ULONG_PTR VirtualAddress;
+
+    Pfn = PhysicalAddress.QuadPart >> PAGE_SHIFT;
+    Pfn1 = MiGetPfnEntry(Pfn);
+    if (Pfn1 == NULL)
+        return NULL;
+
+    VirtualAddress = (ULONG_PTR)MiPteToAddress(Pfn1->PteAddress);
+    VirtualAddress += BYTE_OFFSET(PhysicalAddress.QuadPart);
+
+    return (PVOID)VirtualAddress;
 }
 
 /*


### PR DESCRIPTION
## Purpose

This PR implements the `MmGetVirtualForPhysical` function.

## Proposed changes

- Implement the `MmGetVirtualForPhysical`. The associated PFN with the physical address is retrieved. From the PFN the PteAddress is used to get the virtual address corresponding to the page. This is similar to how Windows 11 does it.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: