### PR TITLE
[SETUPLDR] Add support for architecture-specific "SourceDisksNames" section

### DIFF
--- a/base/setup/lib/spapisup/spapisup.h
+++ b/base/setup/lib/spapisup/spapisup.h
@@ -13,15 +13,17 @@
 #define _SETUPAPI_
 #endif
 
-/* Architecture names to be used for architecture-specific INF sections */
-#ifdef _M_IX86
+/* Architecture name suffixes for architecture-specific INF sections */
+#if defined(_M_IX86)
 #define INF_ARCH L"x86"
 #elif defined(_M_AMD64)
 #define INF_ARCH L"amd64"
-#elif defined(_M_IA64)
-#define INF_ARCH L"ia64"
 #elif defined(_M_ARM)
 #define INF_ARCH L"arm"
+#elif defined(_M_ARM64)
+#define INF_ARCH L"arm64"
+#elif defined(_M_IA64)
+#define INF_ARCH L"ia64"
 #elif defined(_M_PPC)
 #define INF_ARCH L"ppc"
 #endif


### PR DESCRIPTION
## Purpose / Proposed changes

Add support for architecture-specific "SourceDisksNames" section.
Will be used for installing specific drivers on x64 (e.g. the ACPI driver, see PR #8238).

Add also the ARM64 define in the SETUPLIB spapisup.h header.
