### PR TITLE
[RTL/x64][COMPILER_APITEST] Implement support for collided unwinds

### DIFF
--- a/modules/rostests/apitests/compiler/ms_seh.c
+++ b/modules/rostests/apitests/compiler/ms_seh.c
@@ -79,6 +79,10 @@ int seh0058();
     } \
     _SEH2_END
 
+#if defined(_MSC_VER) && !defined(_USE_NATIVE_SEH)
+#define _USE_NATIVE_SEH
+#endif
+
 START_TEST(ms_seh)
 {
     run_test(seh0001);

--- a/sdk/lib/rtl/CMakeLists.txt
+++ b/sdk/lib/rtl/CMakeLists.txt
@@ -108,7 +108,8 @@ elseif(ARCH STREQUAL "amd64")
     list(APPEND ASM_SOURCE
         amd64/debug_asm.S
         amd64/except_asm.S
-        amd64/slist.S)
+        amd64/slist.S
+        amd64/unwind-asm.s)
     list(APPEND SOURCE
         bitmap64.c
         byteswap.c

--- a/sdk/lib/rtl/amd64/unwind-asm.s
+++ b/sdk/lib/rtl/amd64/unwind-asm.s
@@ -1,0 +1,61 @@
+/*
+ * PROJECT:     ReactOS runtime library
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     Unwinding related x64 asm functions
+ * COPYRIGHT:   Copyright 2025 Timo Kreuzer <timo.kreuzer@reactos.org>
+ */
+
+#include <asm.inc>
+#include <ksamd64.inc>
+
+.code64
+
+EXTERN RtlpExecuteHandlerForUnwindHandler:PROC
+
+//
+// EXCEPTION_DISPOSITION
+// RtlpExecuteHandlerForUnwind(
+//    _Inout_ PEXCEPTION_RECORD* ExceptionRecord,
+//    _In_ PVOID EstablisherFrame,
+//    _Inout_ PCONTEXT ContextRecord,
+//    _In_ PDISPATCHER_CONTEXT DispatcherContext);
+//
+PUBLIC RtlpExecuteHandlerForUnwind
+#ifdef _USE_ML
+RtlpExecuteHandlerForUnwind PROC FRAME:RtlpExecuteHandlerForUnwindHandler
+#else
+.PROC RtlpExecuteHandlerForUnwind
+.seh_handler RtlpExecuteHandlerForUnwindHandler, @unwind, @except
+.seh_handlerdata
+.long 0 // Count
+.seh_code
+#endif
+
+    /* Save ExceptionRecord->ExceptionFlags in the home space */
+    mov eax, [rcx + ErExceptionFlags]
+    mov [rsp + P1Home], eax
+
+    /* Save DispatcherContext in the home space */
+    mov [rsp + P4Home], r9
+
+    sub rsp, 40
+    .ALLOCSTACK 40
+    .ENDPROLOG
+
+    /* Call the language handler */
+    call qword ptr [r9 + DcLanguageHandler]
+
+    /* This nop prevents RtlVirtualUnwind from unwinding the epilog,
+       which would lead to ignoring the handler */
+    nop
+
+    add rsp, 40
+    ret
+
+#ifdef _USE_ML
+RtlpExecuteHandlerForUnwind ENDP
+#else
+.ENDP
+#endif
+
+END

--- a/sdk/lib/rtl/rtlp.h
+++ b/sdk/lib/rtl/rtlp.h
@@ -184,7 +184,6 @@ RtlpExecuteHandlerForException(PEXCEPTION_RECORD ExceptionRecord,
                                PCONTEXT Context,
                                PVOID DispatcherContext,
                                PEXCEPTION_ROUTINE ExceptionHandler);
-#endif
 
 EXCEPTION_DISPOSITION
 NTAPI
@@ -193,6 +192,16 @@ RtlpExecuteHandlerForUnwind(PEXCEPTION_RECORD ExceptionRecord,
                             PCONTEXT Context,
                             PVOID DispatcherContext,
                             PEXCEPTION_ROUTINE ExceptionHandler);
+#else
+EXCEPTION_DISPOSITION
+NTAPI
+RtlpExecuteHandlerForUnwind(
+    _Inout_ struct _EXCEPTION_RECORD *ExceptionRecord,
+    _In_ PVOID EstablisherFrame,
+    _Inout_ struct _CONTEXT *ContextRecord,
+    _In_ PVOID DispatcherContext);
+
+#endif
 
 VOID
 NTAPI


### PR DESCRIPTION
## Purpose

This PR implements support for collided unwinds to RtlUnwindInternal. This fixes crashes in SEH tests.

## Proposed changes

- Implement RtlpExecuteHandlerForUnwind in asm
- Implement RtlpExecuteHandlerForUnwindHandler
- Use the correct context in DISPATCHER_CONTEXT when unwinding
- Handle collided unwinds

## Testbot runs (Filled in by Devs)

- ✅ KVM x86: https://reactos.org/testman/compare.php?ids=103089,103096,103098
- ✅ KVM x64: https://reactos.org/testman/compare.php?ids=103090,103097,103099