### PR TITLE
[WIN32K] Fix gdi/dib horizontal line draw functions

### DIFF
--- a/win32ss/gdi/dib/dib16bpp.c
+++ b/win32ss/gdi/dib/dib16bpp.c
@@ -43,6 +43,9 @@ DIB_16BPP_HLine(SURFOBJ *SurfObj, LONG x1, LONG x2, LONG y, ULONG c)
   /* This is about 10% faster than the generic C code below */
   LONG Count = x2 - x1;
 
+  if (x1 >= x2)
+    return;
+
   __asm__ __volatile__ (
     "  cld\n"
     "  mov  %0, %%eax\n"

--- a/win32ss/gdi/dib/dib8bpp.c
+++ b/win32ss/gdi/dib/dib8bpp.c
@@ -36,6 +36,8 @@ DIB_8BPP_GetPixel(SURFOBJ *SurfObj, LONG x, LONG y)
 VOID
 DIB_8BPP_HLine(SURFOBJ *SurfObj, LONG x1, LONG x2, LONG y, ULONG c)
 {
+  if (x1 >= x2)
+    return;
   memset((PBYTE)SurfObj->pvScan0 + y * SurfObj->lDelta + x1, (BYTE) c, x2 - x1);
 }
 

--- a/win32ss/gdi/dib/i386/dib24bpp_hline.s
+++ b/win32ss/gdi/dib/i386/dib24bpp_hline.s
@@ -19,12 +19,13 @@ PUBLIC _DIB_24BPP_HLine
                          sub     esp, 24
                          mov     ebx, [esp+40]
                          mov     edi, [esp+52]
-                         mov     ecx, [esp+44]
+                         mov     ecx, [esp+44]      // ecx =  LONG x1
                          mov     eax, [ebx+36]
                          mov     esi, [ebx+32]
-                         mov     edx, [esp+48]
+                         mov     edx, [esp+48]      // edx =  LONG x2
                          imul    eax, edi
-                         sub     edx, ecx
+                         sub     edx, ecx           // cx  = (x2 - x1) ;
+                         jc      short .exit_here   // cx must not be negative
                          mov     [esp], edx
                          add     eax, esi
                          lea     eax, [eax+ecx*2]
@@ -37,6 +38,7 @@ PUBLIC _DIB_24BPP_HLine
                          mov     [esp], eax
                          inc     eax
                          jnz     small_fill
+               .exit_here:
                          add     esp, 24
                          pop     ebx
                          pop     esi

--- a/win32ss/gdi/dib/i386/dib32bpp_hline.s
+++ b/win32ss/gdi/dib/i386/dib32bpp_hline.s
@@ -24,6 +24,7 @@ _DIB_32BPP_HLine:
                   imul    eax, edi
                   mov     edi, [ecx+32]
                   sub     ebx, edx            // cx  = (x2 - x1) ;
+                  jc      short .exit_here    // cx must not be negative
                   add     eax, edi
                   lea     edx, [eax+edx*4]
                   mov     [esp], edx
@@ -47,7 +48,7 @@ _save_rest:
                   rep stosd                  // The actual fill
                   shr     eax, 16
                   stosw
-
+.exit_here:
                   mov     ebx, [esp+4]
                   mov     edi, [esp+8]
                   add     esp, 12


### PR DESCRIPTION
## Purpose

_Fix crashes in horizontal line draw functions._

JIRA issue: [CORE-19634](https://jira.reactos.org/browse/CORE-19634)

## Proposed changes

_Make sure that value for x2 is always greater than x1 and if not then exit/return from function._

## Testbot runs (Filled in by Devs)

- [X] KVM x86: https://reactos.org/testman/compare.php?ids=103070,103072 LGTM
- [ ] KVM x64: