### PR TITLE
[TCPIP] Fix synchronization on SMP

### DIFF
--- a/drivers/network/tcpip/include/lwip/arch/sys_arch.h
+++ b/drivers/network/tcpip/include/lwip/arch/sys_arch.h
@@ -11,7 +11,7 @@ typedef struct _sys_mbox_t
 {
     KSPIN_LOCK Lock;
     LIST_ENTRY ListHead;
-    KEVENT Event;
+    KSEMAPHORE Semaphore;
     int Valid;
 } sys_mbox_t;
 

--- a/drivers/network/tcpip/include/lwip/arch/sys_arch.h
+++ b/drivers/network/tcpip/include/lwip/arch/sys_arch.h
@@ -15,7 +15,7 @@ typedef struct _sys_mbox_t
     int Valid;
 } sys_mbox_t;
 
-typedef KIRQL sys_prot_t;
+typedef u32_t sys_prot_t;
 
 typedef u32_t sys_thread_t;
 


### PR DESCRIPTION
## Purpose

Fixes 2 synchronization issues on SMP builds.

## Proposed changes
- Use ERESOURCE for global synchronization on SMP builds instead of only raising IRQL
- Use KSEMAPHORE instead of NotificationEvent for "mbox" list notification

## Testbot runs (Filled in by Devs)

- ✅ KVM x86: https://reactos.org/testman/compare.php?ids=103070,103080,103082
- ✅ KVM x64: https://reactos.org/testman/compare.php?ids=103320,103323,103331