### PR TITLE
[UCRT] Fix GCC crashes

### DIFF
--- a/sdk/lib/ucrt/inc/corecrt_internal_simd.h
+++ b/sdk/lib/ucrt/inc/corecrt_internal_simd.h
@@ -19,22 +19,27 @@
 #if defined _CRT_SIMD_SUPPORT_AVAILABLE
 
 #if defined(__clang__)
-#define _UCRT_ENABLE_EXTENDED_ISA \
+#define _UCRT_ENABLE_SSE2 \
+    _Pragma("clang attribute push(__attribute__((target(\"sse2\"))), apply_to=function)")
+#define _UCRT_ENABLE_AVX2 \
     _Pragma("clang attribute push(__attribute__((target(\"sse2,avx,avx2\"))), apply_to=function)")
 #define _UCRT_RESTORE_DEFAULT_ISA \
     _Pragma("clang attribute pop")
 #elif defined(__GNUC__)
-#define _UCRT_ENABLE_EXTENDED_ISA \
+#define _UCRT_ENABLE_SSE2 \
+    _Pragma("GCC push_options") \
+    _Pragma("GCC target(\"sse2\")")
+#define _UCRT_ENABLE_AVX2 \
     _Pragma("GCC push_options") \
     _Pragma("GCC target(\"avx2\")")
 #define _UCRT_RESTORE_DEFAULT_ISA \
     _Pragma("GCC pop_options")
 #else
-#define _UCRT_ENABLE_EXTENDED_ISA
+#define _UCRT_ENABLE_SSE2
+#define _UCRT_ENABLE_AVX2
 #define _UCRT_RESTORE_DEFAULT_ISA
 #endif
 
-_UCRT_ENABLE_EXTENDED_ISA
 
     extern "C" int __isa_available;
 
@@ -70,6 +75,7 @@ _UCRT_ENABLE_EXTENDED_ISA
     };
 
 
+_UCRT_ENABLE_SSE2
 
     template <>
     struct __crt_simd_cleanup_guard<__crt_simd_isa::sse2>
@@ -120,7 +126,9 @@ _UCRT_ENABLE_EXTENDED_ISA
         }
     };
 
+_UCRT_RESTORE_DEFAULT_ISA
 
+_UCRT_ENABLE_AVX2
 
     template <>
     struct __crt_simd_cleanup_guard<__crt_simd_isa::avx2>

--- a/sdk/lib/ucrt/string/string.cmake
+++ b/sdk/lib/ucrt/string/string.cmake
@@ -57,6 +57,17 @@ list(APPEND UCRT_STRING_SOURCES
     string/wmemmove_s.cpp
 )
 
+# Special handling for GCC and Clang
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
+    list(APPEND UCRT_STRING_SOURCES
+        string/strnlen-avx2.cpp
+        string/strnlen-sse2.cpp
+    )
+
+    set_source_files_properties(string/strnlen-sse2.cpp PROPERTIES COMPILE_OPTIONS "-msse2")
+    set_source_files_properties(string/strnlen-avx2.cpp PROPERTIES COMPILE_OPTIONS "-mavx2")
+endif()
+
 if(${ARCH} STREQUAL "i386")
     list(APPEND UCRT_STRING_ASM_SOURCES
         string/i386/_memicmp.s

--- a/sdk/lib/ucrt/string/strnlen-avx2.cpp
+++ b/sdk/lib/ucrt/string/strnlen-avx2.cpp
@@ -1,0 +1,29 @@
+//
+// strnlen-avx2.cpp
+//
+//      Copyright (c) Timo Kreuzer
+//
+// Explicit template instantiations for AVX2 str(n)len code
+//
+
+#pragma GCC target("avx2")
+#define _UCRT_BUILD_AVX2
+#include "strnlen.cpp"
+
+template
+size_t __cdecl common_strnlen_simd<bounded, __crt_simd_isa::avx2, uint8_t>(
+    uint8_t const* const string,
+    size_t         const maximum_count
+    ) throw();
+
+template
+size_t __cdecl common_strnlen_simd<bounded, __crt_simd_isa::avx2, uint16_t>(
+    uint16_t const* const string,
+    size_t         const maximum_count
+    ) throw();
+
+template
+size_t __cdecl common_strnlen_simd<unbounded, __crt_simd_isa::avx2, uint16_t>(
+    uint16_t const* const string,
+    size_t         const maximum_count
+    ) throw();

--- a/sdk/lib/ucrt/string/strnlen-sse2.cpp
+++ b/sdk/lib/ucrt/string/strnlen-sse2.cpp
@@ -1,0 +1,29 @@
+//
+// strnlen-sse2.cpp
+//
+//      Copyright (c) Timo Kreuzer
+//
+// Explicit template instantiations for SSE2 str(n)len code
+//
+
+#pragma GCC target("sse2")
+#define _UCRT_BUILD_SSE2
+#include "strnlen.cpp"
+
+template
+size_t __cdecl common_strnlen_simd<bounded, __crt_simd_isa::sse2, uint8_t>(
+    uint8_t const* const string,
+    size_t         const maximum_count
+    ) throw();
+
+template
+size_t __cdecl common_strnlen_simd<bounded, __crt_simd_isa::sse2, uint16_t>(
+    uint16_t const* const string,
+    size_t         const maximum_count
+    ) throw();
+
+template
+size_t __cdecl common_strnlen_simd<unbounded, __crt_simd_isa::sse2, uint16_t>(
+    uint16_t const* const string,
+    size_t         const maximum_count
+    ) throw();


### PR DESCRIPTION
## Purpose

Fix 2 bugs that caused GCC builds of ucrtbase to crash.

## Proposed changes

- Fix __crt_fast_encode_pointer
- Fix GCC/Clang SIMD compilation

## Testbot runs (Filled in by Devs)

- ✅ KVM x86: https://reactos.org/testman/compare.php?ids=103104,103109,103138
- ✅ KVM x64: https://reactos.org/testman/compare.php?ids=103118,103126,103139