### PR TITLE
[WINLOGON][WLNTFYTESTS] The "Enabled" registry value doesn't exist for notifications

### DIFF
--- a/base/system/winlogon/notify.c
+++ b/base/system/winlogon/notify.c
@@ -207,14 +207,6 @@ AddNotificationDll(
 
     dwSize = sizeof(BOOL);
     RegQueryValueExW(hDllKey,
-                     L"Enabled",
-                     NULL,
-                     &dwType,
-                     (PBYTE)&NotificationDll->bEnabled,
-                     &dwSize);
-
-    dwSize = sizeof(BOOL);
-    RegQueryValueExW(hDllKey,
                      L"Impersonate",
                      NULL,
                      &dwType,

--- a/dll/win32/wlnotify/scard.c
+++ b/dll/win32/wlnotify/scard.c
@@ -2,7 +2,7 @@
  * PROJECT:     ReactOS system libraries
  * LICENSE:     GPL - See COPYING in the top level directory
  * FILE:        dll/win32/wlnotify/scard.c
- * PURPOSE:     SCard logon notifications
+ * PURPOSE:     SmartCard Certificate Propagation logon notifications
  * PROGRAMMER:  Eric Kohl <eric.kohl@reactos.org>
  */
 
@@ -42,6 +42,11 @@ SCardStartCertProp(
     TRACE("hToken: %p\n", pInfo->hToken);
     TRACE("hDesktop: %p\n", pInfo->hDesktop);
     TRACE("pStatusCallback: %p\n", pInfo->pStatusCallback);
+    /*
+     * TODO: Check whether certificate propagation is enabled or disabled,
+     * by reading the "Enabled" REG_DWORD value in the registry key:
+     * HKLM,"Software\Microsoft\Windows NT\CurrentVersion\Winlogon\Notify\ScCertProp"
+     */
 }
 
 

--- a/modules/rostests/win32/winlogon/wlntfytests/wlntfytests.c
+++ b/modules/rostests/win32/winlogon/wlntfytests/wlntfytests.c
@@ -1394,10 +1394,6 @@ HRESULT WINAPI DllRegisterServer(VOID)
 
     // TODO: Purpose TBD.
     // dwValue = 1;
-    // RegSetValueExW(hNotifyKey, L"Enabled", 0, REG_DWORD, (PBYTE)&dwValue, sizeof(dwValue));
-
-    // TODO: Purpose TBD.
-    // dwValue = 1;
     // RegSetValueExW(hNotifyKey, L"Safe", 0, REG_DWORD, (PBYTE)&dwValue, sizeof(dwValue));
 
     for (i = 0; i < _countof(NotifyEvents); ++i)


### PR DESCRIPTION
## Purpose

Analysis of strings in Win2000 and WinXP/2003 winlogon.exe, show that the "Enabled" registry value doesn't exist for notifications.

This value is actually only used by the ScCertProp (Smart Card Certificate Propagation) notifications, in wlnotify.dll, to enable or disable certificate progagation.[^1]

Note that whatever the "Enabled" registry value is, the notification DLL is still loaded within winlogon.exe.

We however keep the `bEnabled` internal flag, so as to be able to disable at runtime notifications that could not be delay-loaded, or that behave erratically, etc.

[WLNOTIFY] Add a comment about the "Enabled" value in scard.c!SCardStartCertProp()

[^1]: For more information, see:
https://www.microfocus.com/documentation/securelogin/9.0/administration_guide/blm54qb.html?view=print
https://www.betaarchive.com/wiki/index.php?title=Microsoft_KB_Archive/925884
