### PR TITLE
[WINLOGON][WLNTFYTESTS] Implement loading notification DLLs in safe-boot mode

### DIFF
--- a/modules/rostests/win32/winlogon/wlntfytests/wlntfytests.c
+++ b/modules/rostests/win32/winlogon/wlntfytests/wlntfytests.c
@@ -1386,15 +1386,12 @@ HRESULT WINAPI DllRegisterServer(VOID)
     dwValue = 0;
     RegSetValueExW(hNotifyKey, L"Impersonate", 0, REG_DWORD, (PBYTE)&dwValue, sizeof(dwValue));
 
-    // dwValue = 1;
-    // RegSetValueExW(hNotifyKey, L"SafeMode", 0, REG_DWORD, (PBYTE)&dwValue, sizeof(dwValue));
+    /* Can be invoked also in SafeMode */
+    dwValue = 1;
+    RegSetValueExW(hNotifyKey, L"SafeMode", 0, REG_DWORD, (PBYTE)&dwValue, sizeof(dwValue));
 
     // dwValue = 600;
     // RegSetValueExW(hNotifyKey, L"MaxWait", 0, REG_DWORD, (PBYTE)&dwValue, sizeof(dwValue));
-
-    // TODO: Purpose TBD.
-    // dwValue = 1;
-    // RegSetValueExW(hNotifyKey, L"Safe", 0, REG_DWORD, (PBYTE)&dwValue, sizeof(dwValue));
 
     for (i = 0; i < _countof(NotifyEvents); ++i)
     {


### PR DESCRIPTION
## Purpose

Historical note:
Investigation shows that this functionality, introduced between builds 1902 and 1906 of Windows NT 5.0 (future 2000) Beta 3, has always been "nop-ed" and has remained this way till Windows Server 2003. The value read from the "SafeMode" registry value is unconditionally overridden afterwards, causing the notification DLLs to always be loaded.

In ReactOS, this functionality is restored, and only the notifications tagged as such are loaded in SafeMode.

Furthermore:
Analysis of strings in Win2000 and WinXP/2003 winlogon.exe, show that the "Safe" registry value doesn't exist for notifications; instead, it is named "SafeMode".
The "Safe" value appears only for the SensLogn (SENS Winlogon Event) handler registry entry. My hypothesis is that the value name is a typo for the "SafeMode" value. It has been introduced in the `\Winlogon\Notify\SensLogn` registry entry for SensLogn around Windows NT 5.0 build 1946.
