### PR TITLE
[WIN32K:ENG] Fix CyberBoard BSOD by checking cStyles for NULL

### DIFF
--- a/win32ss/gdi/eng/lineto.c
+++ b/win32ss/gdi/eng/lineto.c
@@ -145,6 +145,7 @@ NWtoSE(SURFOBJ* OutputObj, CLIPOBJ* Clip,
                 y++;
                 if (y == lStyleMax)
                 {
+                    ASSERT(cStyles);
                     iStyle = (iStyle + 1) % cStyles;
                     lStyleMax = y + pulStyles[iStyle];
                 }
@@ -160,6 +161,7 @@ NWtoSE(SURFOBJ* OutputObj, CLIPOBJ* Clip,
                 x++;
                 if (x == lStyleMax)
                 {
+                    ASSERT(cStyles);
                     iStyle = (iStyle + 1) % cStyles;
                     lStyleMax = x + pulStyles[iStyle];
                 }
@@ -231,6 +233,7 @@ SWtoNE(SURFOBJ* OutputObj, CLIPOBJ* Clip,
                 y--;
                 if (y == lStyleMax)
                 {
+                    ASSERT(cStyles);
                     iStyle = (iStyle - 1) % cStyles;
                     lStyleMax = y - pulStyles[iStyle];
                 }
@@ -246,6 +249,7 @@ SWtoNE(SURFOBJ* OutputObj, CLIPOBJ* Clip,
                 x++;
                 if (x == lStyleMax)
                 {
+                    ASSERT(cStyles);
                     iStyle = (iStyle + 1) % cStyles;
                     lStyleMax = x + pulStyles[iStyle];
                 }
@@ -317,6 +321,7 @@ NEtoSW(SURFOBJ* OutputObj, CLIPOBJ* Clip,
                 y++;
                 if (y == lStyleMax)
                 {
+                    ASSERT(cStyles);
                     iStyle = (iStyle + 1) % cStyles;
                     lStyleMax = y + pulStyles[iStyle];
                 }
@@ -332,6 +337,7 @@ NEtoSW(SURFOBJ* OutputObj, CLIPOBJ* Clip,
                 x--;
                 if (x == lStyleMax)
                 {
+                    ASSERT(cStyles);
                     iStyle = (iStyle - 1) % cStyles;
                     lStyleMax = x - pulStyles[iStyle];
                 }
@@ -403,6 +409,7 @@ SEtoNW(SURFOBJ* OutputObj, CLIPOBJ* Clip,
                 y--;
                 if (y == lStyleMax)
                 {
+                    ASSERT(cStyles);
                     iStyle = (iStyle - 1) % cStyles;
                     lStyleMax = y - pulStyles[iStyle];
                 }
@@ -418,6 +425,7 @@ SEtoNW(SURFOBJ* OutputObj, CLIPOBJ* Clip,
                 x--;
                 if (x == lStyleMax)
                 {
+                    ASSERT(cStyles);
                     iStyle = (iStyle - 1) % cStyles;
                     lStyleMax = x - pulStyles[iStyle];
                 }


### PR DESCRIPTION
## Purpose

_Fix CyberBoard BSOD._

JIRA issue: [CORE-20209](https://jira.reactos.org/browse/CORE-20209)

## Proposed changes

_Test for non-NULL cStyles before using these values by adding ASSERT's._
_When setting "lStyleMax" replace " MAX_COORD" with "MAXLONG"._

After:
<img width="1042" height="856" alt="CyberBoard-OKpng" src="https://github.com/user-attachments/assets/1518b0c9-23da-407b-b140-3fa188877fc0" />

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=103239,103242
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=103240,103243

After commit 2:

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=103246,103250 LGTM
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=103247,103251 LGTM