### PR TITLE
[KERNEL32] Fix use-after-free in GetStartupInfoA

### DIFF
--- a/dll/win32/kernel32/client/proc.c
+++ b/dll/win32/kernel32/client/proc.c
@@ -1397,8 +1397,7 @@ GetStartupInfoA(IN LPSTARTUPINFOA lpStartupInfo)
                             break;
                         }
 
-                        /* Someone beat us to it, use their data instead */
-                        StartupInfo = BaseAnsiStartupInfo;
+                        /* Someone beat us to it, we will use their data instead */
                         Status = STATUS_SUCCESS;
 
                         /* We're going to free our own stuff, but not raise */
@@ -1409,6 +1408,9 @@ GetStartupInfoA(IN LPSTARTUPINFOA lpStartupInfo)
                 RtlFreeAnsiString(&ShellString);
             }
             RtlFreeHeap(RtlGetProcessHeap(), 0, StartupInfo);
+
+            /* Get the cached information again: either still NULL or set by another thread */
+            StartupInfo = BaseAnsiStartupInfo;
         }
         else
         {
@@ -1417,7 +1419,7 @@ GetStartupInfoA(IN LPSTARTUPINFOA lpStartupInfo)
         }
 
         /* Raise an error unless we got here due to the race condition */
-        if (!NT_SUCCESS(Status)) RtlRaiseStatus(Status);
+        if (!StartupInfo) RtlRaiseStatus(Status);
     }
 
     /* Now copy from the cached ANSI version */


### PR DESCRIPTION
## Purpose

If multiple threads call GetStartupInfoA at roughly the same time, a thread that loses the race would free the global BaseAnsiStartupInfo instead of its own local data, resulting in a use-after-free.

## Proposed changes

- Set `StartupInfo` to point to the global `BaseAnsiStartupInfo` only after the local data has been freed.

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=103384,103389
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=103386,103388