### PR TITLE
[COMCTL32] ListView must update header font if it deletes the old font

### DIFF
--- a/dll/win32/comctl32/listview.c
+++ b/dll/win32/comctl32/listview.c
@@ -12013,6 +12013,7 @@ LISTVIEW_WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
         wParam == SPI_SETNONCLIENTMETRICS ||
         (!wParam && !lParam))
     {
+      HFONT hOldDefaultFont = infoPtr->hDefaultFont;
       BOOL bDefaultOrNullFont = (infoPtr->hDefaultFont == infoPtr->hFont || !infoPtr->hFont);
       LOGFONTW logFont;
       SystemParametersInfoW(SPI_GETICONTITLELOGFONT, 0, &logFont, 0);
@@ -12025,7 +12026,12 @@ LISTVIEW_WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
       infoPtr->hDefaultFont = CreateFontIndirectW(&logFont);
 
       if (bDefaultOrNullFont)
+      {
         infoPtr->hFont = infoPtr->hDefaultFont;
+        // Check if we just deleted the font the header is using
+        if (infoPtr->hwndHeader && hOldDefaultFont == GetWindowFont(infoPtr->hwndHeader))
+            SendMessageW(infoPtr->hwndHeader, WM_SETFONT, (WPARAM)infoPtr->hFont, TRUE);
+      }
 
       LISTVIEW_SaveTextMetrics(infoPtr);
       LISTVIEW_UpdateItemSize(infoPtr);


### PR DESCRIPTION
A bug fix for PR #7783 (by @katahiromz).

Regression spotted by @HBelusca: Click OK in Folder Options when the View tab is active. This causes a WM_SETTINGCHANGE broadcast and the Listview in an open Explorer window (in report view) deletes its font and the header ends up painting with a deleted font.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: