### PR TITLE
[PSDK][KS] IKsProcessingObject_fnProcessingObjectWork(): Fix mutex copypastas

### DIFF
--- a/drivers/ksfilter/ks/filter.c
+++ b/drivers/ksfilter/ks/filter.c
@@ -140,12 +140,12 @@ IKsProcessingObject_fnProcessingObjectWork(
     if (KeGetCurrentIrql() == PASSIVE_LEVEL)
     {
         /* acquire processing mutex */
-        KeWaitForSingleObject(&This->ControlMutex, Executive, KernelMode, FALSE, NULL);
+        KeWaitForSingleObject(&This->ProcessingMutex, Executive, KernelMode, FALSE, NULL);
     }
     else
     {
         /* dispatch level processing */
-        if (KeReadStateMutex(&This->ControlMutex) == 0)
+        if (KeReadStateMutex(&This->ProcessingMutex) == 0)
         {
             /* some thread was faster */
             DPRINT1("processing object too slow\n");
@@ -154,7 +154,7 @@ IKsProcessingObject_fnProcessingObjectWork(
 
         /* acquire processing mutex */
         TimeOut.QuadPart = 0LL;
-        Status = KeWaitForSingleObject(&This->ControlMutex, Executive, KernelMode, FALSE, &TimeOut);
+        Status = KeWaitForSingleObject(&This->ProcessingMutex, Executive, KernelMode, FALSE, &TimeOut);
 
         if (Status == STATUS_TIMEOUT)
         {

--- a/sdk/include/psdk/ks.h
+++ b/sdk/include/psdk/ks.h
@@ -5050,6 +5050,13 @@ KsFilterFactoryGetDevice(
     return KsGetDevice((PVOID)FilterFactory);
 }
 
+_IRQL_requires_max_(PASSIVE_LEVEL)
+KSDDKAPI
+VOID
+NTAPI
+KsFilterReleaseProcessingMutex(
+  _In_ PKSFILTER Filter);
+
 /* etc. */
 #endif /* avstream */
 


### PR DESCRIPTION
## Purpose

Fix mutex mismatch.

JIRA issue: [CORE-19511](https://jira.reactos.org/browse/CORE-19511)

## Proposed changes

- ks.h: Add KsFilterReleaseProcessingMutex() declaration
- IKsProcessingObject_fnProcessingObjectWork(): Fix mutex copypastas
Addendum to c6b26fa452 (r50531).