### PR TITLE
[SDK][WINETESTS] Improve __ROS_LONG64__ hack

### DIFF
--- a/modules/rostests/apitests/advapi32/testlist.c
+++ b/modules/rostests/apitests/advapi32/testlist.c
@@ -1,4 +1,3 @@
-#define __ROS_LONG64__
 
 #define STANDALONE
 #include <apitest.h>

--- a/modules/rostests/apitests/advpack/testlist.c
+++ b/modules/rostests/apitests/advpack/testlist.c
@@ -5,7 +5,6 @@
  * COPYRIGHT:   Copyright 2023 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  */
 
-#define __ROS_LONG64__
 #define STANDALONE
 #include <apitest.h>
 

--- a/modules/rostests/apitests/browseui/testlist.c
+++ b/modules/rostests/apitests/browseui/testlist.c
@@ -1,4 +1,3 @@
-#define __ROS_LONG64__
 
 #define STANDALONE
 #include <apitest.h>

--- a/modules/rostests/apitests/com/testlist.c
+++ b/modules/rostests/apitests/com/testlist.c
@@ -1,4 +1,3 @@
-#define __ROS_LONG64__
 
 #define STANDALONE
 #include <apitest.h>

--- a/modules/rostests/apitests/crypt32/testlist.c
+++ b/modules/rostests/apitests/crypt32/testlist.c
@@ -1,4 +1,3 @@
-#define __ROS_LONG64__
 
 #define STANDALONE
 #include <apitest.h>

--- a/modules/rostests/apitests/dciman32/testlist.c
+++ b/modules/rostests/apitests/dciman32/testlist.c
@@ -1,4 +1,3 @@
-#define __ROS_LONG64__
 
 #define STANDALONE
 #include <apitest.h>

--- a/modules/rostests/apitests/fltlib/testlist.c
+++ b/modules/rostests/apitests/fltlib/testlist.c
@@ -1,4 +1,3 @@
-#define __ROS_LONG64__
 
 #define STANDALONE
 #include <apitest.h>

--- a/modules/rostests/apitests/gdi32/testlist.c
+++ b/modules/rostests/apitests/gdi32/testlist.c
@@ -1,4 +1,3 @@
-#define __ROS_LONG64__
 
 #define STANDALONE
 #include <apitest.h>

--- a/modules/rostests/apitests/iphlpapi/testlist.c
+++ b/modules/rostests/apitests/iphlpapi/testlist.c
@@ -1,4 +1,3 @@
-#define __ROS_LONG64__
 
 #define STANDALONE
 #include <apitest.h>

--- a/modules/rostests/apitests/kernel32/testlist.c
+++ b/modules/rostests/apitests/kernel32/testlist.c
@@ -1,4 +1,3 @@
-#define __ROS_LONG64__
 
 #define STANDALONE
 #include <apitest.h>

--- a/modules/rostests/apitests/localspl/testlist.c
+++ b/modules/rostests/apitests/localspl/testlist.c
@@ -5,8 +5,6 @@
  * COPYRIGHT:   Copyright 2015-2017 Colin Finck (colin@reactos.org)
  */
 
-#define __ROS_LONG64__
-
 #define STANDALONE
 #include <apitest.h>
 

--- a/modules/rostests/apitests/msvcrt/testlist.c
+++ b/modules/rostests/apitests/msvcrt/testlist.c
@@ -1,4 +1,3 @@
-#define __ROS_LONG64__
 
 #define STANDALONE
 #include <apitest.h>

--- a/modules/rostests/apitests/netapi32/testlist.c
+++ b/modules/rostests/apitests/netapi32/testlist.c
@@ -5,8 +5,6 @@
  * COPYRIGHT:   Copyright 2017 Colin Finck (colin@reactos.org)
  */
 
-#define __ROS_LONG64__
-
 #define STANDALONE
 #include <apitest.h>
 

--- a/modules/rostests/apitests/ntdll/testlist.c
+++ b/modules/rostests/apitests/ntdll/testlist.c
@@ -1,4 +1,3 @@
-#define __ROS_LONG64__
 
 #define STANDALONE
 #include <apitest.h>

--- a/modules/rostests/apitests/ole32/testlist.c
+++ b/modules/rostests/apitests/ole32/testlist.c
@@ -1,4 +1,3 @@
-#define __ROS_LONG64__
 
 #define STANDALONE
 #include <wine/test.h>

--- a/modules/rostests/apitests/opengl32/testlist.c
+++ b/modules/rostests/apitests/opengl32/testlist.c
@@ -1,4 +1,3 @@
-#define __ROS_LONG64__
 
 #define STANDALONE
 #include <wine/test.h>

--- a/modules/rostests/apitests/pefile/testlist.c
+++ b/modules/rostests/apitests/pefile/testlist.c
@@ -1,4 +1,3 @@
-#define __ROS_LONG64__
 
 #define STANDALONE
 #include <wine/test.h>

--- a/modules/rostests/apitests/powrprof/testlist.c
+++ b/modules/rostests/apitests/powrprof/testlist.c
@@ -1,4 +1,3 @@
-#define __ROS_LONG64__
 
 #define STANDALONE
 #include <apitest.h>

--- a/modules/rostests/apitests/psapi/testlist.c
+++ b/modules/rostests/apitests/psapi/testlist.c
@@ -1,4 +1,3 @@
-#define __ROS_LONG64__
 
 #define STANDALONE
 #include <wine/test.h>

--- a/modules/rostests/apitests/rtl/testlist.c
+++ b/modules/rostests/apitests/rtl/testlist.c
@@ -1,4 +1,4 @@
-#define __ROS_LONG64__
+
 #define wine_dbgstr_wn wine_dbgstr_wn_
 #define STANDALONE
 #include <apitest.h>

--- a/modules/rostests/apitests/sdk/testlist.c
+++ b/modules/rostests/apitests/sdk/testlist.c
@@ -1,4 +1,3 @@
-#define __ROS_LONG64__
 
 #define STANDALONE
 #include <apitest.h>

--- a/modules/rostests/apitests/setupapi/testlist.c
+++ b/modules/rostests/apitests/setupapi/testlist.c
@@ -1,4 +1,3 @@
-#define __ROS_LONG64__
 
 #define STANDALONE
 #include <apitest.h>

--- a/modules/rostests/apitests/shell32/testlist.c
+++ b/modules/rostests/apitests/shell32/testlist.c
@@ -1,4 +1,3 @@
-#define __ROS_LONG64__
 
 #define STANDALONE
 #include <wine/test.h>

--- a/modules/rostests/apitests/spoolss/testlist.c
+++ b/modules/rostests/apitests/spoolss/testlist.c
@@ -5,8 +5,6 @@
  * COPYRIGHT:   Copyright 2015-2018 Colin Finck (colin@reactos.org)
  */
 
-#define __ROS_LONG64__
-
 #define STANDALONE
 #include <apitest.h>
 

--- a/modules/rostests/apitests/umkm/testlist.c
+++ b/modules/rostests/apitests/umkm/testlist.c
@@ -1,4 +1,3 @@
-#define __ROS_LONG64__
 
 #define STANDALONE
 #include <apitest.h>

--- a/modules/rostests/apitests/user32/testlist.c
+++ b/modules/rostests/apitests/user32/testlist.c
@@ -1,4 +1,3 @@
-#define __ROS_LONG64__
 
 #define STANDALONE
 #include <apitest.h>

--- a/modules/rostests/apitests/userenv/testlist.c
+++ b/modules/rostests/apitests/userenv/testlist.c
@@ -1,4 +1,3 @@
-#define __ROS_LONG64__
 
 #define STANDALONE
 #include <apitest.h>

--- a/modules/rostests/apitests/uxtheme/testlist.c
+++ b/modules/rostests/apitests/uxtheme/testlist.c
@@ -1,4 +1,3 @@
-#define __ROS_LONG64__
 
 #define STANDALONE
 #include <apitest.h>

--- a/modules/rostests/apitests/win32nt/testlist.c
+++ b/modules/rostests/apitests/win32nt/testlist.c
@@ -1,4 +1,3 @@
-#define __ROS_LONG64__
 
 #define STANDALONE
 #include <apitest.h>

--- a/modules/rostests/apitests/winhttp/testlist.c
+++ b/modules/rostests/apitests/winhttp/testlist.c
@@ -1,4 +1,3 @@
-#define __ROS_LONG64__
 
 #define STANDALONE
 #include <apitest.h>

--- a/modules/rostests/apitests/wininet/testlist.c
+++ b/modules/rostests/apitests/wininet/testlist.c
@@ -1,4 +1,3 @@
-#define __ROS_LONG64__
 
 #define STANDALONE
 #include <apitest.h>

--- a/modules/rostests/apitests/winprint/testlist.c
+++ b/modules/rostests/apitests/winprint/testlist.c
@@ -14,8 +14,6 @@
  * they behave slightly different in terms of error codes due to the involved RPC and routing.
  */
 
-#define __ROS_LONG64__
-
 #define STANDALONE
 #include <apitest.h>
 

--- a/modules/rostests/apitests/winspool/testlist.c
+++ b/modules/rostests/apitests/winspool/testlist.c
@@ -5,8 +5,6 @@
  * COPYRIGHT:   Copyright 2015-2017 Colin Finck (colin@reactos.org)
  */
 
-#define __ROS_LONG64__
-
 #define STANDALONE
 #include <apitest.h>
 

--- a/modules/rostests/apitests/wlanapi/testlist.c
+++ b/modules/rostests/apitests/wlanapi/testlist.c
@@ -1,4 +1,3 @@
-#define __ROS_LONG64__
 
 #define STANDALONE
 #include <apitest.h>

--- a/modules/rostests/apitests/ws2_32/testlist.c
+++ b/modules/rostests/apitests/ws2_32/testlist.c
@@ -1,4 +1,3 @@
-#define __ROS_LONG64__
 
 #define STANDALONE
 #include <apitest.h>

--- a/modules/rostests/drivers/tcpip/testlist.c
+++ b/modules/rostests/drivers/tcpip/testlist.c
@@ -1,4 +1,3 @@
-#define __ROS_LONG64__
 
 #define STANDALONE
 #include <apitest.h>

--- a/modules/rostests/regtests/bugs/testlist.c
+++ b/modules/rostests/regtests/bugs/testlist.c
@@ -1,7 +1,6 @@
 /* Automatically generated file; DO NOT EDIT!! */
 
 #define WIN32_LEAN_AND_MEAN
-#define __ROS_LONG64__
 #include <windows.h>
 
 #define STANDALONE

--- a/modules/rostests/regtests/crt/testlist.c
+++ b/modules/rostests/regtests/crt/testlist.c
@@ -1,7 +1,6 @@
 /* Automatically generated file; DO NOT EDIT!! */
 
 #define WIN32_LEAN_AND_MEAN
-#define __ROS_LONG64__
 #include <windows.h>
 
 #define STANDALONE

--- a/modules/rostests/regtests/gdi/testlist.c
+++ b/modules/rostests/regtests/gdi/testlist.c
@@ -1,7 +1,6 @@
 /* Automatically generated file; DO NOT EDIT!! */
 
 #define WIN32_LEAN_AND_MEAN
-#define __ROS_LONG64__
 #include <windows.h>
 
 #define STANDALONE

--- a/modules/rostests/winetests/CMakeLists.txt
+++ b/modules/rostests/winetests/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D__ROS_LONG64__)
-
 if(MSVC)
     add_compile_options(
         /wd4090 # C4090: 'function': different 'const' qualifiers

--- a/modules/rostests/winetests/advpack/CMakeLists.txt
+++ b/modules/rostests/winetests/advpack/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 list(APPEND SOURCE
     advpack.c
     files.c

--- a/modules/rostests/winetests/amstream/CMakeLists.txt
+++ b/modules/rostests/winetests/amstream/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 add_executable(amstream_winetest amstream.c testlist.c)
 target_link_libraries(amstream_winetest uuid)
 set_module_type(amstream_winetest win32cui)

--- a/modules/rostests/winetests/atl/CMakeLists.txt
+++ b/modules/rostests/winetests/atl/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(-D_ATL_VER=_ATL_VER_30)
 
 list(APPEND SOURCE

--- a/modules/rostests/winetests/atl100/CMakeLists.txt
+++ b/modules/rostests/winetests/atl100/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(-DUSE_WINE_TODOS)
 add_definitions(-D_ATL_VER=_ATL_VER_100)
 list(APPEND SOURCE atl.c testlist.c)

--- a/modules/rostests/winetests/avifil32/CMakeLists.txt
+++ b/modules/rostests/winetests/avifil32/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 add_executable(avifil32_winetest api.c testlist.c)
 set_module_type(avifil32_winetest win32cui)
 add_importlibs(avifil32_winetest avifil32 ole32 msvcrt kernel32)

--- a/modules/rostests/winetests/bcrypt/CMakeLists.txt
+++ b/modules/rostests/winetests/bcrypt/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 remove_definitions(-D_WIN32_WINNT=0x502)
 add_executable(bcrypt_winetest bcrypt.c testlist.c)
 set_module_type(bcrypt_winetest win32cui)

--- a/modules/rostests/winetests/browseui/CMakeLists.txt
+++ b/modules/rostests/winetests/browseui/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 add_executable(browseui_winetest autocomplete.c progressdlg.c testlist.c)
 target_link_libraries(browseui_winetest uuid)
 set_module_type(browseui_winetest win32cui)

--- a/modules/rostests/winetests/cabinet/CMakeLists.txt
+++ b/modules/rostests/winetests/cabinet/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(-DUSE_WINE_TODOS)
 add_executable(cabinet_winetest extract.c fdi.c testlist.c)
 set_module_type(cabinet_winetest win32cui)

--- a/modules/rostests/winetests/cmd/CMakeLists.txt
+++ b/modules/rostests/winetests/cmd/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 add_executable(cmd_winetest batch.c testlist.c rsrc.rc)
 set_module_type(cmd_winetest win32cui)
 add_importlibs(cmd_winetest msvcrt kernel32)

--- a/modules/rostests/winetests/comcat/CMakeLists.txt
+++ b/modules/rostests/winetests/comcat/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 add_executable(comcat_winetest comcat.c testlist.c)
 target_link_libraries(comcat_winetest uuid)
 set_module_type(comcat_winetest win32cui)

--- a/modules/rostests/winetests/comctl32/CMakeLists.txt
+++ b/modules/rostests/winetests/comctl32/CMakeLists.txt
@@ -1,6 +1,7 @@
 
 remove_definitions(-D_WIN32_WINNT=0x502 -D_WIN32_IE=0x600)
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(-DUSE_WINE_TODOS -DWINETEST_USE_DBGSTR_LONGLONG)
 
 list(APPEND SOURCE

--- a/modules/rostests/winetests/comdlg32/CMakeLists.txt
+++ b/modules/rostests/winetests/comdlg32/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(-DUSE_WINE_TODOS)
 
 list(APPEND SOURCE

--- a/modules/rostests/winetests/credui/CMakeLists.txt
+++ b/modules/rostests/winetests/credui/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 add_executable(credui_winetest credui.c testlist.c)
 set_module_type(credui_winetest win32cui)
 add_importlibs(credui_winetest credui msvcrt kernel32)

--- a/modules/rostests/winetests/crypt32/CMakeLists.txt
+++ b/modules/rostests/winetests/crypt32/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(-DUSE_WINE_TODOS)
 
 list(APPEND SOURCE

--- a/modules/rostests/winetests/cryptnet/CMakeLists.txt
+++ b/modules/rostests/winetests/cryptnet/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 add_executable(cryptnet_winetest cryptnet.c testlist.c)
 set_module_type(cryptnet_winetest win32cui)
 add_importlibs(cryptnet_winetest cryptnet crypt32 msvcrt kernel32)

--- a/modules/rostests/winetests/cryptui/CMakeLists.txt
+++ b/modules/rostests/winetests/cryptui/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 add_executable(cryptui_winetest cryptui.c testlist.c)
 set_module_type(cryptui_winetest win32cui)
 add_importlibs(cryptui_winetest cryptui crypt32 user32 msvcrt kernel32)

--- a/modules/rostests/winetests/d3dcompiler_43/CMakeLists.txt
+++ b/modules/rostests/winetests/d3dcompiler_43/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(-DUSE_WINE_TODOS -DD3D_COMPILER_VERSION=43)
 
 add_executable(d3dcompiler_43_winetest

--- a/modules/rostests/winetests/d3drm/CMakeLists.txt
+++ b/modules/rostests/winetests/d3drm/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 add_definitions(-DUSE_WINE_TODOS)
 add_executable(d3drm_winetest d3drm.c vector.c testlist.c)
 target_link_libraries(d3drm_winetest uuid dxguid)

--- a/modules/rostests/winetests/d3dx9_36/CMakeLists.txt
+++ b/modules/rostests/winetests/d3dx9_36/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 add_executable(d3dx9_36_winetest
     asm.c
     core.c 

--- a/modules/rostests/winetests/dbghelp/CMakeLists.txt
+++ b/modules/rostests/winetests/dbghelp/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 add_executable(dbghelp_winetest dbghelp.c testlist.c)
 target_compile_definitions(dbghelp_winetest PRIVATE WINETEST_USE_DBGSTR_LONGLONG)
 set_module_type(dbghelp_winetest win32cui)

--- a/modules/rostests/winetests/devenum/CMakeLists.txt
+++ b/modules/rostests/winetests/devenum/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 add_executable(devenum_winetest devenum.c testlist.c)
 set_module_type(devenum_winetest win32cui)
 add_importlibs(devenum_winetest advapi32 dsound msvfw32 oleaut32 ole32 winmm msdmo msvcrt kernel32)

--- a/modules/rostests/winetests/dinput/CMakeLists.txt
+++ b/modules/rostests/winetests/dinput/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(-DUSE_WINE_TODOS)
 
 list(APPEND SOURCE

--- a/modules/rostests/winetests/dinput8/CMakeLists.txt
+++ b/modules/rostests/winetests/dinput8/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(-DUSE_WINE_TODOS )
 
 list(APPEND SOURCE

--- a/modules/rostests/winetests/dnsapi/CMakeLists.txt
+++ b/modules/rostests/winetests/dnsapi/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_executable(dnsapi_winetest name.c record.c testlist.c)
 set_module_type(dnsapi_winetest win32cui)
 add_importlibs(dnsapi_winetest dnsapi msvcrt kernel32)

--- a/modules/rostests/winetests/dplayx/CMakeLists.txt
+++ b/modules/rostests/winetests/dplayx/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 add_executable(dplayx_winetest dplayx.c testlist.c)
 set_module_type(dplayx_winetest win32cui)
 add_importlibs(dplayx_winetest dplayx ole32 oleaut32 version advapi32 msvcrt kernel32)

--- a/modules/rostests/winetests/dsound/CMakeLists.txt
+++ b/modules/rostests/winetests/dsound/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 list(APPEND SOURCE
     capture.c
     ds3d8.c

--- a/modules/rostests/winetests/dxdiagn/CMakeLists.txt
+++ b/modules/rostests/winetests/dxdiagn/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 list(APPEND SOURCE
     container.c
     provider.c

--- a/modules/rostests/winetests/faultrep/CMakeLists.txt
+++ b/modules/rostests/winetests/faultrep/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 add_executable(faultrep_winetest faultrep.c testlist.c)
 set_module_type(faultrep_winetest win32cui)
 add_importlibs(faultrep_winetest faultrep advapi32 msvcrt kernel32)

--- a/modules/rostests/winetests/fusion/CMakeLists.txt
+++ b/modules/rostests/winetests/fusion/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 list(APPEND SOURCE
     asmcache.c
     asmenum.c

--- a/modules/rostests/winetests/gdi32/CMakeLists.txt
+++ b/modules/rostests/winetests/gdi32/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 remove_definitions(-DWINVER=0x502 -D_WIN32_IE=0x600 -D_WIN32_WINNT=0x502)
 
 list(APPEND SOURCE

--- a/modules/rostests/winetests/gdiplus/CMakeLists.txt
+++ b/modules/rostests/winetests/gdiplus/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(-DUSE_WINE_TODOS)
 
 list(APPEND SOURCE

--- a/modules/rostests/winetests/hid/CMakeLists.txt
+++ b/modules/rostests/winetests/hid/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 add_executable(hid_winetest device.c testlist.c)
 set_module_type(hid_winetest win32cui)
 add_importlibs(hid_winetest hid setupapi msvcrt kernel32)

--- a/modules/rostests/winetests/hlink/CMakeLists.txt
+++ b/modules/rostests/winetests/hlink/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(-DUSE_WINE_TODOS)
 
 list(APPEND SOURCE

--- a/modules/rostests/winetests/hnetcfg/CMakeLists.txt
+++ b/modules/rostests/winetests/hnetcfg/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(-DUSE_WINE_TODOS)
 add_executable(hnetcfg_winetest policy.c testlist.c)
 target_link_libraries(hnetcfg_winetest uuid)

--- a/modules/rostests/winetests/imagehlp/CMakeLists.txt
+++ b/modules/rostests/winetests/imagehlp/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(-DUSE_WINE_TODOS)
 
 list(APPEND SOURCE

--- a/modules/rostests/winetests/imm32/CMakeLists.txt
+++ b/modules/rostests/winetests/imm32/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 add_executable(imm32_winetest imm32.c testlist.c)
 set_module_type(imm32_winetest win32cui)
 add_importlibs(imm32_winetest imm32 user32 msvcrt kernel32)

--- a/modules/rostests/winetests/inetcomm/CMakeLists.txt
+++ b/modules/rostests/winetests/inetcomm/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 add_definitions(
     -DUSE_WINE_TODOS
     -Dstrcasecmp=_stricmp

--- a/modules/rostests/winetests/inetmib1/CMakeLists.txt
+++ b/modules/rostests/winetests/inetmib1/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 add_executable(inetmib1_winetest main.c testlist.c)
 set_module_type(inetmib1_winetest win32cui)
 add_importlibs(inetmib1_winetest snmpapi msvcrt kernel32)

--- a/modules/rostests/winetests/iphlpapi/CMakeLists.txt
+++ b/modules/rostests/winetests/iphlpapi/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 add_executable(iphlpapi_winetest iphlpapi.c testlist.c)
 target_link_libraries(iphlpapi_winetest wine)
 set_module_type(iphlpapi_winetest win32cui)

--- a/modules/rostests/winetests/itss/CMakeLists.txt
+++ b/modules/rostests/winetests/itss/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 add_executable(itss_winetest protocol.c testlist.c rsrc.rc)
 set_module_type(itss_winetest win32cui)
 add_importlibs(itss_winetest ole32 msvcrt kernel32)

--- a/modules/rostests/winetests/jscript/CMakeLists.txt
+++ b/modules/rostests/winetests/jscript/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(-DUSE_WINE_TODOS)
 
 list(APPEND SOURCE

--- a/modules/rostests/winetests/kernel32/CMakeLists.txt
+++ b/modules/rostests/winetests/kernel32/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 include_directories(BEFORE ${REACTOS_SOURCE_DIR}/sdk/include/wine)
 remove_definitions(-DWINVER=0x502 -D_WIN32_IE=0x600 -D_WIN32_WINNT=0x502)
 add_definitions(-DWINVER=0x600 -D_WIN32_WINNT=0x601)

--- a/modules/rostests/winetests/localspl/CMakeLists.txt
+++ b/modules/rostests/winetests/localspl/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 include_directories(${REACTOS_SOURCE_DIR}/sdk/include/wine)
 add_executable(localspl_winetest localmon.c testlist.c)
 set_module_type(localspl_winetest win32cui)

--- a/modules/rostests/winetests/localui/CMakeLists.txt
+++ b/modules/rostests/winetests/localui/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 include_directories(${REACTOS_SOURCE_DIR}/sdk/include/wine)
 add_executable(localui_winetest localui.c testlist.c)
 set_module_type(localui_winetest win32cui)

--- a/modules/rostests/winetests/lz32/CMakeLists.txt
+++ b/modules/rostests/winetests/lz32/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 add_definitions(-DUSE_WINE_TODOS)
 add_executable(lz32_winetest lzexpand_main.c testlist.c)
 set_module_type(lz32_winetest win32cui)

--- a/modules/rostests/winetests/mapi32/CMakeLists.txt
+++ b/modules/rostests/winetests/mapi32/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 list(APPEND SOURCE
     imalloc.c
     prop.c

--- a/modules/rostests/winetests/mlang/CMakeLists.txt
+++ b/modules/rostests/winetests/mlang/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 add_definitions(-DUSE_WINE_TODOS)
 add_executable(mlang_winetest mlang.c testlist.c)
 set_module_type(mlang_winetest win32cui)

--- a/modules/rostests/winetests/mmdevapi/CMakeLists.txt
+++ b/modules/rostests/winetests/mmdevapi/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(-DWINETEST_USE_DBGSTR_LONGLONG)
 
 remove_definitions(-D_WIN32_WINNT=0x502)

--- a/modules/rostests/winetests/mpr/CMakeLists.txt
+++ b/modules/rostests/winetests/mpr/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 add_definitions(
     -DUSE_WINE_TODOS
     -D_WINE)

--- a/modules/rostests/winetests/msacm32/CMakeLists.txt
+++ b/modules/rostests/winetests/msacm32/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 add_executable(msacm32_winetest msacm.c testlist.c)
 set_module_type(msacm32_winetest win32cui)
 add_importlibs(msacm32_winetest msacm32 winmm msvcrt kernel32)

--- a/modules/rostests/winetests/mscms/CMakeLists.txt
+++ b/modules/rostests/winetests/mscms/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(-DUSE_WINE_TODOS)
 add_executable(mscms_winetest profile.c testlist.c)
 set_module_type(mscms_winetest win32cui)

--- a/modules/rostests/winetests/mscoree/CMakeLists.txt
+++ b/modules/rostests/winetests/mscoree/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(-DUSE_WINE_TODOS)
 
 add_executable(mscoree_winetest

--- a/modules/rostests/winetests/msctf/CMakeLists.txt
+++ b/modules/rostests/winetests/msctf/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 add_executable(msctf_winetest inputprocessor.c testlist.c msctf.rc)
 set_module_type(msctf_winetest win32cui)
 add_importlibs(msctf_winetest ole32 user32 advapi32 msvcrt kernel32)

--- a/modules/rostests/winetests/mshtml/CMakeLists.txt
+++ b/modules/rostests/winetests/mshtml/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(-DUSE_WINE_TODOS)
 add_idl_Headers(test_tlb_header test_tlb.idl)
 add_typelib(test_tlb.idl)

--- a/modules/rostests/winetests/msrle32/CMakeLists.txt
+++ b/modules/rostests/winetests/msrle32/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(-DUSE_WINE_TODOS)
 add_executable(msrle32_winetest msrle.c testlist.c)
 set_module_type(msrle32_winetest win32cui)

--- a/modules/rostests/winetests/mstask/CMakeLists.txt
+++ b/modules/rostests/winetests/mstask/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 list(APPEND SOURCE
     task.c
     task_scheduler.c

--- a/modules/rostests/winetests/msvcrtd/CMakeLists.txt
+++ b/modules/rostests/winetests/msvcrtd/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 add_executable(msvcrtd_winetest debug.c testlist.c)
 set_module_type(msvcrtd_winetest win32cui)
 add_importlibs(msvcrtd_winetest msvcrt kernel32)

--- a/modules/rostests/winetests/msvfw32/CMakeLists.txt
+++ b/modules/rostests/winetests/msvfw32/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(-DUSE_WINE_TODOS)
 add_executable(msvfw32_winetest drawdib.c mciwnd.c msvfw.c testlist.c msvfw32.rc)
 set_module_type(msvfw32_winetest win32cui)

--- a/modules/rostests/winetests/msxml3/CMakeLists.txt
+++ b/modules/rostests/winetests/msxml3/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(
     -DUSE_WINE_TODOS
     -DWINETEST_USE_DBGSTR_LONGLONG)

--- a/modules/rostests/winetests/netapi32/CMakeLists.txt
+++ b/modules/rostests/winetests/netapi32/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 list(APPEND SOURCE
     access.c
     apibuf.c

--- a/modules/rostests/winetests/netcfgx/CMakeLists.txt
+++ b/modules/rostests/winetests/netcfgx/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 add_executable(netcfgx_winetest netcfgx.c testlist.c)
 target_link_libraries(netcfgx_winetest uuid)
 set_module_type(netcfgx_winetest win32cui)

--- a/modules/rostests/winetests/ntdsapi/CMakeLists.txt
+++ b/modules/rostests/winetests/ntdsapi/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 add_executable(ntdsapi_winetest ntdsapi.c testlist.c)
 set_module_type(ntdsapi_winetest win32cui)
 add_importlibs(ntdsapi_winetest ntdsapi msvcrt kernel32)

--- a/modules/rostests/winetests/odbccp32/CMakeLists.txt
+++ b/modules/rostests/winetests/odbccp32/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 add_executable(odbccp32_winetest misc.c testlist.c odbccp32.rc)
 set_module_type(odbccp32_winetest win32cui)
 add_importlibs(odbccp32_winetest odbccp32 advapi32 msvcrt kernel32)

--- a/modules/rostests/winetests/ole32/CMakeLists.txt
+++ b/modules/rostests/winetests/ole32/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(-DUSE_WINE_TODOS)
 
 list(APPEND SOURCE

--- a/modules/rostests/winetests/oleacc/CMakeLists.txt
+++ b/modules/rostests/winetests/oleacc/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(-D__WINESRC__ -DWINETEST_USE_DBGSTR_LONGLONG)
 
 add_executable(oleacc_winetest main.c testlist.c)

--- a/modules/rostests/winetests/oleaut32/CMakeLists.txt
+++ b/modules/rostests/winetests/oleaut32/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(
     -D__WINESRC__
     -DUSE_WINE_TODOS

--- a/modules/rostests/winetests/oledlg/CMakeLists.txt
+++ b/modules/rostests/winetests/oledlg/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(-DUSE_WINE_TODOS)
 add_executable(oledlg_winetest main.c testlist.c)
 set_module_type(oledlg_winetest win32cui)

--- a/modules/rostests/winetests/opengl32/CMakeLists.txt
+++ b/modules/rostests/winetests/opengl32/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 add_executable(opengl32_winetest opengl.c testlist.c)
 set_module_type(opengl32_winetest win32cui)
 add_importlibs(opengl32_winetest opengl32 gdi32 user32 msvcrt kernel32)

--- a/modules/rostests/winetests/pdh/CMakeLists.txt
+++ b/modules/rostests/winetests/pdh/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(-DWINETEST_USE_DBGSTR_LONGLONG)
 add_executable(pdh_winetest pdh.c testlist.c)
 set_module_type(pdh_winetest win32cui)

--- a/modules/rostests/winetests/propsys/CMakeLists.txt
+++ b/modules/rostests/winetests/propsys/CMakeLists.txt
@@ -1,6 +1,5 @@
 
 add_definitions(-DUSE_WINE_TODOS -DWINETEST_USE_DBGSTR_LONGLONG)
-remove_definitions(-D__ROS_LONG64__)
 add_executable(propsys_winetest propsys.c testlist.c)
 set_module_type(propsys_winetest win32cui)
 add_importlibs(propsys_winetest propsys ole32 oleaut32 msvcrt kernel32)

--- a/modules/rostests/winetests/psapi/CMakeLists.txt
+++ b/modules/rostests/winetests/psapi/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 add_definitions(-D__WINESRC__)
 add_executable(psapi_winetest psapi_main.c testlist.c)
 set_module_type(psapi_winetest win32cui)

--- a/modules/rostests/winetests/qedit/CMakeLists.txt
+++ b/modules/rostests/winetests/qedit/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(-DUSE_WINE_TODOS)
 add_executable(qedit_winetest mediadet.c timeline.c testlist.c qedit.rc)
 set_module_type(qedit_winetest win32cui)

--- a/modules/rostests/winetests/qmgr/CMakeLists.txt
+++ b/modules/rostests/winetests/qmgr/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(-DWINETEST_USE_DBGSTR_LONGLONG)
 
 list(APPEND SOURCE

--- a/modules/rostests/winetests/quartz/CMakeLists.txt
+++ b/modules/rostests/winetests/quartz/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(-DWINETEST_USE_DBGSTR_LONGLONG)
 
 list(APPEND SOURCE

--- a/modules/rostests/winetests/rasapi32/CMakeLists.txt
+++ b/modules/rostests/winetests/rasapi32/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 add_executable(rasapi32_winetest rasapi.c testlist.c)
 set_module_type(rasapi32_winetest win32cui)
 add_importlibs(rasapi32_winetest msvcrt kernel32)

--- a/modules/rostests/winetests/reg/CMakeLists.txt
+++ b/modules/rostests/winetests/reg/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 add_executable(reg_winetest add.c copy.c delete.c export.c import.c query.c testlist.c)
 set_module_type(reg_winetest win32cui)
 add_importlibs(reg_winetest advapi32 msvcrt kernel32)

--- a/modules/rostests/winetests/regedit/CMakeLists.txt
+++ b/modules/rostests/winetests/regedit/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 add_executable(regedit_winetest regedit.c testlist.c)
 target_link_libraries(regedit_winetest wine)
 set_module_type(regedit_winetest win32cui)

--- a/modules/rostests/winetests/riched20/CMakeLists.txt
+++ b/modules/rostests/winetests/riched20/CMakeLists.txt
@@ -1,5 +1,4 @@
 
-remove_definitions(-D__ROS_LONG64__)
 add_definitions(-DUSE_WINE_TODOS)
 
 list(APPEND SOURCE

--- a/modules/rostests/winetests/riched32/CMakeLists.txt
+++ b/modules/rostests/winetests/riched32/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 add_executable(riched32_winetest editor.c testlist.c)
 set_module_type(riched32_winetest win32cui)
 add_importlibs(riched32_winetest ole32 user32 msvcrt kernel32)

--- a/modules/rostests/winetests/rsaenh/CMakeLists.txt
+++ b/modules/rostests/winetests/rsaenh/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(-DUSE_WINE_TODOS)
 add_executable(rsaenh_winetest rsaenh.c testlist.c)
 set_module_type(rsaenh_winetest win32cui)

--- a/modules/rostests/winetests/schannel/CMakeLists.txt
+++ b/modules/rostests/winetests/schannel/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 add_executable(schannel_winetest main.c testlist.c)
 set_module_type(schannel_winetest win32cui)
 add_importlibs(schannel_winetest msvcrt kernel32)

--- a/modules/rostests/winetests/scrrun/CMakeLists.txt
+++ b/modules/rostests/winetests/scrrun/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(-DUSE_WINE_TODOS)
 
 list(APPEND SOURCE

--- a/modules/rostests/winetests/secur32/CMakeLists.txt
+++ b/modules/rostests/winetests/secur32/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 list(APPEND SOURCE
     main.c
     negotiate.c

--- a/modules/rostests/winetests/serialui/CMakeLists.txt
+++ b/modules/rostests/winetests/serialui/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 add_executable(serialui_winetest confdlg.c testlist.c)
 set_module_type(serialui_winetest win32cui)
 add_importlibs(serialui_winetest msvcrt kernel32)

--- a/modules/rostests/winetests/services/CMakeLists.txt
+++ b/modules/rostests/winetests/services/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 add_executable(services_winetest service.c testlist.c)
 set_module_type(services_winetest win32cui)
 add_importlibs(services_winetest user32 advapi32 msvcrt kernel32)

--- a/modules/rostests/winetests/setupapi/CMakeLists.txt
+++ b/modules/rostests/winetests/setupapi/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(
     -D__WINESRC__
     -Dstrcasecmp=_stricmp

--- a/modules/rostests/winetests/shdocvw/CMakeLists.txt
+++ b/modules/rostests/winetests/shdocvw/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(-DUSE_WINE_TODOS)
 
 list(APPEND SOURCE

--- a/modules/rostests/winetests/shell32/CMakeLists.txt
+++ b/modules/rostests/winetests/shell32/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(
     -DWINETEST_USE_DBGSTR_LONGLONG
     -Dstrcasecmp=_stricmp

--- a/modules/rostests/winetests/shlwapi/CMakeLists.txt
+++ b/modules/rostests/winetests/shlwapi/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(
     -DUSE_WINE_TODOS
     -DWINETEST_USE_DBGSTR_LONGLONG)

--- a/modules/rostests/winetests/spoolss/CMakeLists.txt
+++ b/modules/rostests/winetests/spoolss/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(-DUSE_WINE_TODOS)
 add_executable(spoolss_winetest spoolss.c testlist.c)
 set_module_type(spoolss_winetest win32cui)

--- a/modules/rostests/winetests/sti/CMakeLists.txt
+++ b/modules/rostests/winetests/sti/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(-DUSE_WINE_TODOS)
 add_executable(sti_winetest sti.c testlist.c)
 set_module_type(sti_winetest win32cui)

--- a/modules/rostests/winetests/sxs/CMakeLists.txt
+++ b/modules/rostests/winetests/sxs/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(-DUSE_WINE_TODOS)
 add_idl_headers(sxs_winetest_idlheaders interfaces.idl)
 add_executable(sxs_winetest cache.c name.c sxs.c testlist.c resource.rc)

--- a/modules/rostests/winetests/twain_32/CMakeLists.txt
+++ b/modules/rostests/winetests/twain_32/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 add_executable(twain_32_winetest dsm.c testlist.c)
 set_module_type(twain_32_winetest win32cui)
 add_importlibs(twain_32_winetest user32 gdi32 msvcrt kernel32)

--- a/modules/rostests/winetests/urlmon/CMakeLists.txt
+++ b/modules/rostests/winetests/urlmon/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(-DUSE_WINE_TODOS)
 
 list(APPEND SOURCE

--- a/modules/rostests/winetests/user32/CMakeLists.txt
+++ b/modules/rostests/winetests/user32/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 remove_definitions(-DWINVER=0x502 -D_WIN32_WINNT=0x502)
 add_definitions(-DWINVER=0x602 -D_WIN32_WINNT=0x602)
 

--- a/modules/rostests/winetests/userenv/CMakeLists.txt
+++ b/modules/rostests/winetests/userenv/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 add_executable(userenv_winetest userenv.c testlist.c)
 set_module_type(userenv_winetest win32cui)
 target_link_libraries(userenv_winetest oldnames)

--- a/modules/rostests/winetests/usp10/CMakeLists.txt
+++ b/modules/rostests/winetests/usp10/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(-DUSE_WINE_TODOS)
 add_executable(usp10_winetest usp10.c testlist.c)
 set_module_type(usp10_winetest win32cui)

--- a/modules/rostests/winetests/uxtheme/CMakeLists.txt
+++ b/modules/rostests/winetests/uxtheme/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 add_executable(uxtheme_winetest system.c testlist.c)
 set_module_type(uxtheme_winetest win32cui)
 add_importlibs(uxtheme_winetest user32 gdi32 uxtheme msvcrt kernel32)

--- a/modules/rostests/winetests/vbscript/CMakeLists.txt
+++ b/modules/rostests/winetests/vbscript/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(-DUSE_WINE_TODOS)
 add_idl_headers(vbscript_wine_test_idlheader vbsregexp55.idl)
 

--- a/modules/rostests/winetests/version/CMakeLists.txt
+++ b/modules/rostests/winetests/version/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 list(APPEND SOURCE
     info.c
     install.c

--- a/modules/rostests/winetests/wbemdisp/CMakeLists.txt
+++ b/modules/rostests/winetests/wbemdisp/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(-DUSE_WINE_TODOS)
 add_executable(wbemdisp_winetest wbemdisp.c testlist.c)
 target_link_libraries(wbemdisp_winetest uuid)

--- a/modules/rostests/winetests/wbemprox/CMakeLists.txt
+++ b/modules/rostests/winetests/wbemprox/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(-DUSE_WINE_TODOS)
 
 list(APPEND SOURCE

--- a/modules/rostests/winetests/windowscodecs/CMakeLists.txt
+++ b/modules/rostests/winetests/windowscodecs/CMakeLists.txt
@@ -3,8 +3,6 @@ add_definitions(
     -DUSE_WINE_TODOS
     -DWINETEST_USE_DBGSTR_LONGLONG)
 
-remove_definitions(-D__ROS_LONG64__)
-
 list(APPEND SOURCE
     bitmap.c
     bmpformat.c

--- a/modules/rostests/winetests/windowscodecsext/CMakeLists.txt
+++ b/modules/rostests/winetests/windowscodecsext/CMakeLists.txt
@@ -1,5 +1,4 @@
 
-remove_definitions(-D__ROS_LONG64__)
 add_executable(windowscodecsext_winetest transform.c testlist.c)
 set_module_type(windowscodecsext_winetest win32cui)
 add_importlibs(windowscodecsext_winetest ole32 windowscodecsext msvcrt kernel32)

--- a/modules/rostests/winetests/winhttp/CMakeLists.txt
+++ b/modules/rostests/winetests/winhttp/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(-DUSE_WINE_TODOS)
 
 list(APPEND SOURCE

--- a/modules/rostests/winetests/wininet/CMakeLists.txt
+++ b/modules/rostests/winetests/wininet/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(-DUSE_WINE_TODOS)
 
 list(APPEND SOURCE

--- a/modules/rostests/winetests/wintrust/CMakeLists.txt
+++ b/modules/rostests/winetests/wintrust/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(-DUSE_WINE_TODOS)
 
 list(APPEND SOURCE

--- a/modules/rostests/winetests/wldap32/CMakeLists.txt
+++ b/modules/rostests/winetests/wldap32/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 add_executable(wldap32_winetest parse.c testlist.c)
 set_module_type(wldap32_winetest win32cui)
 add_importlibs(wldap32_winetest wldap32 msvcrt kernel32)

--- a/modules/rostests/winetests/wmiutils/CMakeLists.txt
+++ b/modules/rostests/winetests/wmiutils/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(
     -DUSE_WINE_TODOS
     -D__WINESRC__

--- a/modules/rostests/winetests/wmvcore/CMakeLists.txt
+++ b/modules/rostests/winetests/wmvcore/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(
     -DUSE_WINE_TODOS
     -D__WINESRC__)

--- a/modules/rostests/winetests/ws2_32/CMakeLists.txt
+++ b/modules/rostests/winetests/ws2_32/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 include_directories(BEFORE ${REACTOS_SOURCE_DIR}/sdk/include/wine)
 
 add_executable(ws2_32_winetest protocol.c sock.c testlist.c)

--- a/modules/rostests/winetests/wscript/CMakeLists.txt
+++ b/modules/rostests/winetests/wscript/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 add_definitions(-DUSE_WINE_TODOS)
 add_executable(wscript_winetest run.c testlist.c rsrc.rc)
 target_link_libraries(wscript_winetest uuid)

--- a/modules/rostests/winetests/wshom/CMakeLists.txt
+++ b/modules/rostests/winetests/wshom/CMakeLists.txt
@@ -1,3 +1,5 @@
+
+add_definitions(-D__ROS_LONG64__)
 add_definitions(-DUSE_WINE_TODOS)
 
 remove_definitions(-D_WIN32_WINNT=0x502)

--- a/modules/rostests/winetests/wtsapi32/CMakeLists.txt
+++ b/modules/rostests/winetests/wtsapi32/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(-DUSE_WINE_TODOS)
 add_executable(wtsapi32_winetest wtsapi.c testlist.c)
 set_module_type(wtsapi32_winetest win32cui)

--- a/modules/rostests/winetests/xcopy/CMakeLists.txt
+++ b/modules/rostests/winetests/xcopy/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_executable(xcopy_winetest xcopy.c testlist.c)
 set_module_type(xcopy_winetest win32cui)
 add_importlibs(xcopy_winetest msvcrt kernel32)

--- a/modules/rostests/winetests/xinput1_3/CMakeLists.txt
+++ b/modules/rostests/winetests/xinput1_3/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-D__ROS_LONG64__)
+
 add_executable(xinput1_3_winetest xinput.c testlist.c)
 set_module_type(xinput1_3_winetest win32cui)
 add_importlibs(xinput1_3_winetest user32 msvcrt kernel32)

--- a/modules/rostests/winetests/xmllite/CMakeLists.txt
+++ b/modules/rostests/winetests/xmllite/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_definitions(-D__ROS_LONG64__)
 add_definitions(-DUSE_WINE_TODOS)
 
 list(APPEND SOURCE

--- a/sdk/include/psdk/basetsd.h
+++ b/sdk/include/psdk/basetsd.h
@@ -6,12 +6,6 @@
 #include <msvctarget.h>
 #endif
 
-#if (defined(_LP64) || defined(__LP64__)) && !defined(_M_AMD64)
-#ifndef __ROS_LONG64__
-#define __ROS_LONG64__
-#endif
-#endif
-
 #ifdef __GNUC__
 #ifndef __int64
 #define __int64 long long

--- a/sdk/include/psdk/minwindef.h
+++ b/sdk/include/psdk/minwindef.h
@@ -27,13 +27,6 @@
 
 #include <specstrings.h>
 
-// FIXME: Ugly hack
-#if (defined(_LP64) || defined(__LP64__)) && !defined(_M_AMD64)
-#ifndef __ROS_LONG64__
-#define __ROS_LONG64__
-#endif
-#endif
-
 #ifndef NO_STRICT
 #ifndef STRICT
 #define STRICT 1

--- a/sdk/include/psdk/winsock.h
+++ b/sdk/include/psdk/winsock.h
@@ -15,12 +15,6 @@
 #include <windows.h>
 #endif
 
-#if (defined(_LP64) || defined(__LP64__)) && !defined(_M_AMD64)
-#ifndef __ROS_LONG64__
-#define __ROS_LONG64__
-#endif
-#endif
-
 #define _GNU_H_WINDOWS32_SOCKETS
 
 #ifdef __cplusplus

--- a/sdk/include/psdk/winsock2.h
+++ b/sdk/include/psdk/winsock2.h
@@ -39,12 +39,6 @@
 #endif
 #endif
 
-#if (defined(_LP64) || defined(__LP64__)) && !defined(_M_AMD64)
-#ifndef __ROS_LONG64__
-#define __ROS_LONG64__
-#endif
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/sdk/include/xdk/winnt.template.h
+++ b/sdk/include/xdk/winnt.template.h
@@ -28,12 +28,6 @@
 #error Compiler too old!
 #endif
 
-#if (defined(_LP64) || defined(__LP64__)) && !defined(_M_AMD64)
-#ifndef __ROS_LONG64__
-#define __ROS_LONG64__
-#endif
-#endif
-
 #include <ctype.h>
 //#include <winapifamily.h>
 #ifdef __GNUC__


### PR DESCRIPTION
## Purpose

Improve the __ROS_LONG64__ hack a bit.
Please don't ask to make the CMake changes nicer, they are supposed to go away!

## Proposed changes
- [SDK] Remove header definitions of __ROS_LONG64__
- [ROSTESTS] Remove definitions of __ROS_LONG64__ in testlist.c
- [WINETESTS] Move definition of __ROS_LONG64__ to individual tests

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: