### PR TITLE
[KMTESTS] KmtAreInterruptsEnabled(): Be explicit about architectures

### DIFF
--- a/modules/rostests/kmtests/include/kmt_test_kernel.h
+++ b/modules/rostests/kmtests/include/kmt_test_kernel.h
@@ -58,7 +58,13 @@ VOID KmtSetIrql(IN KIRQL NewIrql)
 
 BOOLEAN KmtAreInterruptsEnabled(VOID)
 {
-    return (__readeflags() & (1 << 9)) != 0;
+#if defined(_M_IX86) || defined(_M_AMD64)
+    return (__readeflags() & EFLAGS_INTERRUPT_MASK) != 0;
+#else
+#pragma message(__FILE__ ": warning : 'KmtAreInterruptsEnabled()' is UNIMPLEMENTED for this architecture")
+    // HACK: trivial stub. Used by ok_bool_true(KmtAreInterruptsEnabled(), ...).
+    return FALSE;
+#endif
 }
 
 typedef struct _POOL_HEADER


### PR DESCRIPTION
## Purpose

Let this function compile/run on other architectures, like ARM*.

JIRA issue: [ROSTESTS-363](https://jira.reactos.org/browse/ROSTESTS-363)

## Proposed changes

- Be explicit about architectures
- And improve code a bit.
