### PR TITLE
[AMD64] msys2 shim

### DIFF
--- a/dll/appcompat/apphelp/hsdb.c
+++ b/dll/appcompat/apphelp/hsdb.c
@@ -25,7 +25,11 @@ typedef struct _ShimData
     DWORD dwMagic;
     SDBQUERYRESULT Query;
     WCHAR szLayer[MAX_LAYER_LENGTH];
-    DWORD dwRosProcessCompatVersion;  // ReactOS specific
+    // Start ReactOS specific
+    DWORD dwRosProcessCompatVersion;
+#ifdef _M_AMD64
+    PVOID RtlGetCurrentDirectory_U_RtlpMsysDecoy;
+#endif
 } ShimData;
 
 #define SHIMDATA_MAGIC  0xAC0DEDAB
@@ -35,7 +39,9 @@ C_ASSERT(SHIMDATA_MAGIC == REACTOS_SHIMDATA_MAGIC);
 C_ASSERT(sizeof(ShimData) == sizeof(ReactOS_ShimData));
 C_ASSERT(offsetof(ShimData, dwMagic) == offsetof(ReactOS_ShimData, dwMagic));
 C_ASSERT(offsetof(ShimData, dwRosProcessCompatVersion) == offsetof(ReactOS_ShimData, dwRosProcessCompatVersion));
-
+#ifdef _M_AMD64
+C_ASSERT(offsetof(ShimData, RtlGetCurrentDirectory_U_RtlpMsysDecoy) == offsetof(ReactOS_ShimData, RtlGetCurrentDirectory_U_RtlpMsysDecoy));
+#endif
 
 static BOOL WINAPI SdbpFileExists(LPCWSTR path)
 {

--- a/dll/appcompat/shims/genral/CMakeLists.txt
+++ b/dll/appcompat/shims/genral/CMakeLists.txt
@@ -11,6 +11,10 @@ list(APPEND SOURCE
     themes.c
     genral.spec)
 
+if(ARCH STREQUAL "amd64")
+    list(APPEND SOURCE msys2.c)
+endif()
+
 add_library(acgenral MODULE
     ${SOURCE}
     ${CMAKE_CURRENT_BINARY_DIR}/acgenral.def)

--- a/dll/appcompat/shims/genral/msys2.c
+++ b/dll/appcompat/shims/genral/msys2.c
@@ -1,0 +1,46 @@
+/*
+ * PROJECT:     ReactOS 'General' Shim library
+ * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
+ * PURPOSE:     Shim to apply the msys2 decoy
+ * COPYRIGHT:   Copyright 2025 Timo kreuzer <timo.kreuzer@reactos.org>
+ *              Copyright 2025 Mark Jansen <mark.jansen@reactos.org>
+ */
+
+#define WIN32_NO_STATUS
+#include <windef.h>
+#include <winbase.h>
+#include <rtlfuncs.h>
+#include <shimlib.h>
+#include <compat_undoc.h>
+
+static PVOID RtlGetCurrentDirectory_U_RtlpMsysDecoy;
+
+#define SHIM_NS         MsysDecoy
+#include <setup_shim.inl>
+
+
+BOOL WINAPI SHIM_OBJ_NAME(Notify)(DWORD fdwReason, PVOID ptr)
+{
+    if (fdwReason == SHIM_NOTIFY_ATTACH)
+    {
+        ReactOS_ShimData *pShimData = (ReactOS_ShimData *)NtCurrentPeb()->pShimData;
+        if (pShimData && pShimData->dwMagic == REACTOS_SHIMDATA_MAGIC)
+        {
+            /* Grab the private function from ntdll */
+            RtlGetCurrentDirectory_U_RtlpMsysDecoy = pShimData->RtlGetCurrentDirectory_U_RtlpMsysDecoy;
+            SHIM_MSG("RtlGetCurrentDirectory_U_RtlpMsysDecoy=%p\n", RtlGetCurrentDirectory_U_RtlpMsysDecoy);
+            return RtlGetCurrentDirectory_U_RtlpMsysDecoy != NULL;
+        }
+        SHIM_FAIL("Invalid pShimData @ %p\n", pShimData);
+        /* Returning false here will not register the hooks */
+        return FALSE;
+    }
+    return TRUE;
+}
+
+#define SHIM_NOTIFY_FN SHIM_OBJ_NAME(Notify)
+#define SHIM_NUM_HOOKS  1
+#define SHIM_SETUP_HOOKS \
+    SHIM_HOOK(0, "NTDLL.DLL", "RtlGetCurrentDirectory_U", RtlGetCurrentDirectory_U_RtlpMsysDecoy)
+
+#include <implement_shim.inl>

--- a/dll/appcompat/shims/shimlib/implement_shim.inl
+++ b/dll/appcompat/shims/shimlib/implement_shim.inl
@@ -40,13 +40,18 @@ PHOOKAPI WINAPI SHIM_OBJ_NAME(GetHookAPIs)(DWORD fdwReason, PCSTR pszCmdLine, PD
     SHIM_OBJ_NAME(g_pAPIHooks) = (PHOOKAPI)ShimLib_ShimMalloc(sizeof(HOOKAPI) * SHIM_NUM_HOOKS);
     if (SHIM_NUM_HOOKS)
         ZeroMemory(SHIM_OBJ_NAME(g_pAPIHooks), sizeof(HOOKAPI) * SHIM_NUM_HOOKS);
-    *pdwHookCount = SHIM_NUM_HOOKS;
 
 #ifdef SHIM_NOTIFY_FN
     if (!SHIM_NOTIFY_FN(fdwReason, NULL))
+    {
+        *pdwHookCount = 0;
+        /* Do not free the memory here */
+        SHIM_FAIL("%s failed during attach\n", SHIM_OBJ_NAME(Notify));
         return NULL;
+    }
 #endif
 
+    *pdwHookCount = SHIM_NUM_HOOKS;
 #if SHIM_NUM_HOOKS > 0
     SHIM_SETUP_HOOKS
 #endif

--- a/dll/ntdll/CMakeLists.txt
+++ b/dll/ntdll/CMakeLists.txt
@@ -40,7 +40,9 @@ list(APPEND SOURCE
 if(ARCH STREQUAL "i386")
     list(APPEND ASM_SOURCE dispatch/i386/dispatch.S)
 elseif(ARCH STREQUAL "amd64")
-    list(APPEND ASM_SOURCE dispatch/amd64/dispatch.S)
+    list(APPEND ASM_SOURCE
+        dispatch/amd64/dispatch.S
+        compat/amd64/msys2.S)
 elseif(ARCH STREQUAL "arm")
     list(APPEND ASM_SOURCE dispatch/arm/stubs_asm.s)
 else()

--- a/dll/ntdll/compat/amd64/msys2.S
+++ b/dll/ntdll/compat/amd64/msys2.S
@@ -1,0 +1,47 @@
+/*
+ * COPYRIGHT:       See COPYING in the top level directory
+ * PROJECT:         ReactOS kernel
+ * FILE:            dll/ntdll/compat/amd64/msys2.S
+ * PURPOSE:         Hack for msys-2
+ *
+ * PROGRAMMER:      Timo kreuzer (timo.kreuzer@reactos.org)
+ */
+
+/* INCLUDES ******************************************************************/
+
+#include <asm.inc>
+#include <ksamd64.inc>
+
+EXTERN RtlGetCurrentDirectory_U:PROC
+EXTERN FastPebLock:QWORD
+EXTERN RtlEnterCriticalSection:PROC
+EXTERN RtlpCurDirRef:QWORD
+
+.code
+
+// For the logic see https://github.com/git-for-windows/msys2-runtime/blob/bb4e8e05b4c68895887eba9c420e8a42e0e2801e/winsup/cygwin/path.cc#L4854C1-L4854C23
+
+MsysDecoy_UseRtlpCurDirRef:
+    // This path should never be executed!
+    int HEX(2c)
+
+    // msys-2 searches for this instruction squence to extract RtlpCurDirRef
+    lea rcx, FastPebLock[rip]
+    call RtlEnterCriticalSection
+    mov rbx, qword ptr RtlpCurDirRef[rip]
+    test rbx, rbx
+
+MsysDecoy_continue:
+    jmp RtlGetCurrentDirectory_U
+
+PUBLIC RtlGetCurrentDirectory_U_RtlpMsysDecoy
+RtlGetCurrentDirectory_U_RtlpMsysDecoy:
+
+    // Short jmp that hopefully does not contain a 0xe8
+    jmp short MsysDecoy_continue
+
+    // This emulates the call that msys is looking for
+    // and will never be executed
+    call MsysDecoy_UseRtlpCurDirRef
+
+END

--- a/media/sdb/sysmain.xml
+++ b/media/sdb/sysmain.xml
@@ -258,6 +258,15 @@
             <SHIM NAME="VMHorizonSetup">
                 <DLLFILE>aclayers.dll</DLLFILE>
             </SHIM>
+            <SHIM NAME="MsysDecoy" RUNTIME_PLATFORM="AMD64">
+                <DLLFILE>acgenral.dll</DLLFILE>
+                <DESCRIPTION>Shim RtlGetCurrentDirectory_U so msys2 can recognize it</DESCRIPTION>
+                <INCLUDE MODULE="msys-2.0.dll" />
+                <EXCLUDE MODULE="kernel32.dll" />
+                <EXCLUDE MODULE="msvcrt.dll" />
+                <EXCLUDE MODULE="ole32.dll" />
+                <EXCLUDE MODULE="oleaut32.dll" />
+            </SHIM>
 
             <!--<SHIM NAME="HideShimEnv">
                 <DLLFILE>aclayers.dll</DLLFILE>
@@ -462,6 +471,14 @@
                 <LINK_DATE>0x4a9b2979</LINK_DATE>
             </MATCHING_FILE>
             <SHIM_REF NAME="IgnoreFreeLibrary" COMMAND_LINE="libpng12.dll" />
+        </EXE>
+
+        <!-- X64 MSYS2 (CORE-20159) -->
+        <EXE NAME="*" APP_NAME="MSYS2 Applications" RUNTIME_PLATFORM="AMD64">
+            <MATCHING_FILE NAME="msys-2.0.dll">
+                <MODULE_TYPE>0x3</MODULE_TYPE>
+            </MATCHING_FILE>
+            <SHIM_REF NAME="MsysDecoy" />
         </EXE>
 
         <!-- ReactOS shim used to test the shim engine -->

--- a/sdk/include/reactos/compat_undoc.h
+++ b/sdk/include/reactos/compat_undoc.h
@@ -9,6 +9,10 @@ typedef struct _ReactOS_ShimData
     DWORD dwMagic;
     DWORD dwReserved2[242];
     DWORD dwRosProcessCompatVersion;
+
+#ifdef _M_AMD64
+    PVOID RtlGetCurrentDirectory_U_RtlpMsysDecoy;
+#endif
 } ReactOS_ShimData;
 
 


### PR DESCRIPTION
## Purpose

Add a shim for msys2 applications (x64)

JIRA issue: [CORE-20159](https://jira.reactos.org/browse/CORE-20159)

## Proposed changes

- Add very basic wildcard matching for shims
- Add support for including/excluding shims in the .sdb files based on architecture
- Add msys2 shim

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: