### PR TITLE
[NET] Fix 'net use' command random fails

### DIFF
--- a/base/applications/network/net/cmdUse.c
+++ b/base/applications/network/net/cmdUse.c
@@ -228,6 +228,7 @@ cmdUse(
         lpNet.dwType = RESOURCETYPE_DISK;
         lpNet.lpLocalName = (argv[2][0] != L'*') ? argv[2] : NULL;
         lpNet.lpRemoteName = argv[3];
+        lpNet.lpComment = L"";
         lpNet.lpProvider = NULL;
 
         Status = WNetUseConnection(NULL, &lpNet, NULL, NULL, CONNECT_REDIRECT | (Persist ? CONNECT_UPDATE_PROFILE : 0), Access, &Size, &OutFlags);

--- a/base/applications/network/net/cmdUse.c
+++ b/base/applications/network/net/cmdUse.c
@@ -171,7 +171,7 @@ cmdUse(
     else
     {
         BOOL Persist = FALSE;
-        NETRESOURCE lpNet;
+        NETRESOURCE lpNet = { 0 };
         WCHAR Access[256];
         DWORD OutFlags = 0, Size = ARRAYSIZE(Access);
 


### PR DESCRIPTION
CORE-20287

## Purpose

_Fix random failures of 'net use' when mounting an NFS share._

JIRA issue: [CORE-20287](https://jira.reactos.org/browse/CORE-20287)

## Proposed changes

_Initialize variable lpNet.lpComment that was previously uninitialized._

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=103322,103325 LGTM
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=103323,103326 LGTM