### PR TITLE
[TCPIP] Return MIB_IF_TYPE_ETHERNET for WLAN adapter types when compiling ReactOS as NT 5.2

### DIFF
--- a/drivers/network/tcpip/tcpip/iinfo.c
+++ b/drivers/network/tcpip/tcpip/iinfo.c
@@ -72,7 +72,12 @@ TDI_STATUS InfoTdiQueryGetInterfaceMIB(TDIEntityID ID,
                     case NdisPhysicalMediumUnspecified:
 #endif
                     case NdisPhysicalMediumWirelessLan:
+                        /* Win2003: MIB_IF_TYPE_ETHERNET; Vista+: IF_TYPE_IEEE80211 */
+#if (_WIN32_WINNT >= _WIN32_WINNT_VISTA)
                         OutData->if_type = IF_TYPE_IEEE80211;
+#else
+                        OutData->if_type = MIB_IF_TYPE_ETHERNET;
+#endif
                         break;
 #if 0
                     case NdisPhysicalMediumCableModem:
@@ -83,9 +88,12 @@ TDI_STATUS InfoTdiQueryGetInterfaceMIB(TDIEntityID ID,
                     case NdisPhysicalMedium1394:
                     case NdisPhysicalMediumWirelessWan:
 #endif
+#if (_WIN32_WINNT >= _WIN32_WINNT_VISTA)
+                    /* NDIS 6.0+ (Vista+) */
                     case NdisPhysicalMediumNative802_11:
                         OutData->if_type = IF_TYPE_IEEE80211;
                         break;
+#endif
 #if 0
                     case NdisPhysicalMediumBluetooth:
                     case NdisPhysicalMediumInfiniband:


### PR DESCRIPTION
## Purpose

Split Windows Server 2003 and Windows Vista behaviour in two different cases and make them used separately: when ReactOS target version is NT 5.2, use the 1st case, otherwise use the 2nd one instead.
Also, handle `NdisPhysicalMediumNative802_11` case only for NT 6.0 and newer, since it's actually supported starting from NDIS 6.0 only, according to MSDN:
https://learn.microsoft.com/en-us/windows-hardware/drivers/network/oid-gen-physical-medium
, while for NDIS 5.1 and newer it's:
https://learn.microsoft.com/en-us/previous-versions/windows/hardware/network/ff560255(v=vs.85).
This fixes:
1. A critical regression with not accessible networking in ReactOS when NT5-compatible Ethernet/Wi-Fi drivers are used (both in VM and on real hardware) caused by commit 3842b59f75e0793188fc94fb2c670930a04d7fbe by @EricKohl.
2. Failure to open Network Properties and Network Status from the Network tray icon.

MSDN tells us this is done so for Windows XP and Server 2003 as well, and `IF_TYPE_IEEE80211` is returned only in Windows Vista and newer, so the following Microsoft documentation is actually correct in this case:
https://learn.microsoft.com/en-us/windows/win32/api/iptypes/ns-iptypes-ip_adapter_info
(see the information about `IP_ADAPTER_INFO.Type` member below)
**Please note that the behaviour of Vista+ case (e. g., when compiling ReactOS targeted as NT 6.0 and newer) remains unchanged after this fix (networking still may not work), so it still requires the proper support of 3rd-party NT6+ compatible network miniport drivers (by handling this case via the Vista/NDIS6-style way) for NT6 target!
For those who doesn't agree with this and prefer to always use NT6 behaviour instead:
This is a quick fix, which is purposed to fix the blocker regression that prevents the further development and testing, as soon as possible.
If you know/have/can provide any better solution for this, which same allows those network drivers to work correctly, it would be welcome and can supersede this PR as well.
But until that, this fix can probably only be considered as a valid (temporary) solution.
P. S.: IMHO this looks logically more correct to fix the problem by another way, like Vista+ does (since NT6 behaviour remains unchanged after this fix), but only for Vista and newer versions (e. g., when compiling ReactOS as NT 6.0 or newer).**

JIRA issue: [CORE-20244](https://jira.reactos.org/browse/CORE-20244)

## Result

As the following photo shows, after applying the patch, networking works again on my test Asus-F5R Notebook at least (both LAN and WLAN):
![20250731_170740](https://github.com/user-attachments/assets/0f664f15-5218-470e-b732-47f159572731)
Atheros L2 Fast Ethernet 10/100 Base-T Controller is tested there, but inbuilt Azureware GE-780 (Atheros AR5001) Wireless Network Adapter is also confirmed to be working on this hardware as well.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: