### PR TITLE
[USER32] .spec: Fix GetDpiForMonitorInternal() param type

### DIFF
--- a/win32ss/user/user32/user32.spec
+++ b/win32ss/user/user32/user32.spec
@@ -293,7 +293,7 @@
 @ stdcall GetDlgItemTextA(long long ptr long)
 @ stdcall GetDlgItemTextW(long long ptr long)
 @ stdcall GetDoubleClickTime() NtUserGetDoubleClickTime
-@ stdcall -version=0x601+ GetDpiForMonitorInternal(long long ptr ptr)
+@ stdcall -version=0x601+ GetDpiForMonitorInternal(ptr long ptr ptr)
 @ stdcall -version=0xA00+ GetDpiForSystem()
 @ stdcall -version=0xA00+ GetDpiForWindow(ptr)
 @ stdcall GetFocus()


### PR DESCRIPTION
## Purpose

Use ptr for handles.

```c
 113 GetDpiForMonitorInternal(
 114     _In_  HMONITOR monitor,
 115     _In_  UINT type,
 116     _Out_ UINT *x,
 117     _Out_ UINT *y)
```

## Proposed changes

- .spec: Fix GetDpiForMonitorInternal() param type