### PR TITLE
[KMTESTS] Kmtest fixes

### DIFF
--- a/modules/rostests/kmtests/ntos_ex/ExPools.c
+++ b/modules/rostests/kmtests/ntos_ex/ExPools.c
@@ -230,7 +230,7 @@ TestPoolQuota(VOID)
         if (Memory)
             ExFreePoolWithTag(Memory, 'tQmK');
     KmtEndSeh(STATUS_SUCCESS);
-#endif
+#endif // _WIN64
 }
 
 static

--- a/modules/rostests/kmtests/ntos_ex/ExPools.c
+++ b/modules/rostests/kmtests/ntos_ex/ExPools.c
@@ -12,7 +12,7 @@
 
 #define TAG_POOLTEST 'tstP'
 
-#define BASE_POOL_TYPE_MASK 1
+#define BASE_POOL_TYPE_MASK 3
 #define QUOTA_POOL_MASK 8
 
 static
@@ -141,7 +141,6 @@ VOID
 TestPoolQuota(VOID)
 {
     PEPROCESS Process = PsGetCurrentProcess();
-    PEPROCESS StoredProcess;
     PVOID Memory;
     LONG InitialRefCount;
     LONG RefCount;
@@ -163,16 +162,23 @@ TestPoolQuota(VOID)
         RefCount = GetRefCount(Process);
         ok_eq_long(RefCount, InitialRefCount + 1);
 
-        /* A pointer to the process is found right before the next pool header */
-        StoredProcess = ((PVOID *)((ULONG_PTR)Memory + 2 * sizeof(LIST_ENTRY)))[-1];
-        ok_eq_pointer(StoredProcess, Process);
+#ifdef _M_IX86
+        if (GetNTVersion() <= _WIN32_WINNT_WIN7)
+        {
+            /* For x86 NT 6.2 and older: a pointer to the process is found right before the next pool header */
+            PEPROCESS StoredProcess = ((PVOID *)((ULONG_PTR)Memory + 2 * sizeof(LIST_ENTRY)))[-1];
+            ok_eq_pointer(StoredProcess, Process);
+        }
+#endif
 
         /* Pool type should have QUOTA_POOL_MASK set */
         PoolType = KmtGetPoolType(Memory);
         ok(PoolType != 0, "PoolType is 0\n");
         PoolType--;
         ok(PoolType & QUOTA_POOL_MASK, "PoolType = %x\n", PoolType);
-        ok((PoolType & BASE_POOL_TYPE_MASK) == PagedPool, "PoolType = %x\n", PoolType);
+        ok((PoolType & BASE_POOL_TYPE_MASK) == PagedPool ||                // Win2k3
+           (PoolType & BASE_POOL_TYPE_MASK) == NonPagedPoolMustSucceed,    // Vista+ promotes the memory allocation
+           "PoolType = %x\n", PoolType);
 
         ExFreePoolWithTag(Memory, 'tQmK');
         RefCount = GetRefCount(Process);
@@ -196,6 +202,16 @@ TestPoolQuota(VOID)
         ok_eq_long(RefCount, InitialRefCount);
     }
 
+#ifdef _WIN64
+    KmtStartSeh()
+        Memory = ExAllocatePoolWithQuotaTag(PagedPool,
+                                            0x7FFFFFFF,
+                                            'tQmK');
+        ok(Memory != NULL, "Failed to get 2GB block: %p\n", Memory);
+        if (Memory)
+            ExFreePoolWithTag(Memory, 'tQmK');
+    KmtEndSeh(STATUS_SUCCESS);
+#else
     /* Function raises by default */
     KmtStartSeh()
         Memory = ExAllocatePoolWithQuotaTag(PagedPool,
@@ -214,6 +230,7 @@ TestPoolQuota(VOID)
         if (Memory)
             ExFreePoolWithTag(Memory, 'tQmK');
     KmtEndSeh(STATUS_SUCCESS);
+#endif
 }
 
 static

--- a/modules/rostests/kmtests/ntos_io/IoDeviceObject_drv.c
+++ b/modules/rostests/kmtests/ntos_io/IoDeviceObject_drv.c
@@ -350,11 +350,11 @@ TestDeviceCreated(
 
     /* Check the device object members */
     ok(DeviceObject->Type == 3, "Expected Type = 3, got %x\n", DeviceObject->Type);
-    #ifdef _M_IX86
+#ifdef _M_IX86
     ok(DeviceObject->Size == 0xb8, "Expected Size = 0xb8, got 0x%x\n", DeviceObject->Size);
-    #else
+#else
     ok(DeviceObject->Size == 0x150, "Expected Size = 0x150, got 0x%x\n", DeviceObject->Size);
-    #endif
+#endif
     ok(DeviceObject->ReferenceCount == 0, "Expected ReferenceCount = 0, got %lu\n",
         DeviceObject->ReferenceCount);
     ok(DeviceObject->DriverObject == ThisDriverObject,
@@ -404,11 +404,11 @@ TestDeviceDeletion(
 
     /* Check the device object members */
     ok(DeviceObject->Type == 3, "Expected Type = 3, got %d\n", DeviceObject->Type);
-    #ifdef _M_IX86
+#ifdef _M_IX86
     ok(DeviceObject->Size == 0xb8, "Expected Size = 0xb8, got 0x%x\n", DeviceObject->Size);
-    #else
+#else
     ok(DeviceObject->Size == 0x150, "Expected Size = 0x150, got 0x%x\n", DeviceObject->Size);
-    #endif
+#endif
     ok(DeviceObject->ReferenceCount == 0, "Expected ReferenceCount = 0, got %lu\n",
         DeviceObject->ReferenceCount);
     if (!Lower)

--- a/modules/rostests/kmtests/ntos_io/IoDeviceObject_drv.c
+++ b/modules/rostests/kmtests/ntos_io/IoDeviceObject_drv.c
@@ -181,9 +181,10 @@ TestDriverObject(
         ok_eq_pointer(DriverObject->DriverExtension->DriverObject, DriverObject);
         ok_eq_pointer(DriverObject->DriverExtension->AddDevice, NULL);
         ok_eq_ulong(DriverObject->DriverExtension->Count, 0UL);
+        /* Windows 7 doesn't capitalize "Services" like all other versions before and after it. */
         Equal = RtlEqualUnicodeString(RegistryPath,
                                       &RegPath,
-                                      FALSE);
+                                      (GetNTVersion() == _WIN32_WINNT_WIN7) ? TRUE : FALSE);
         ok(Equal, "RegistryPath is '%wZ'\n", RegistryPath);
         ok((ULONG_PTR)RegistryPath % PAGE_SIZE == 0, "RegistryPath %p not page-aligned\n", RegistryPath);
         ok_eq_pointer(RegistryPath->Buffer, (PWCHAR)(RegistryPath + 1));
@@ -193,7 +194,8 @@ TestDriverObject(
                                       FALSE);
         ok(Equal, "ServiceKeyName is '%wZ'\n", &DriverObject->DriverExtension->ServiceKeyName);
         ok_eq_tag(KmtGetPoolTag(DriverObject->DriverExtension->ServiceKeyName.Buffer), '  oI');
-        ok_eq_uint((KmtGetPoolType(DriverObject->DriverExtension->ServiceKeyName.Buffer) - 1) & BASE_POOL_TYPE_MASK, NonPagedPool);
+        if (GetNTVersion() <= _WIN32_WINNT_WS03) // Not guaranteed on Vista+
+            ok_eq_uint((KmtGetPoolType(DriverObject->DriverExtension->ServiceKeyName.Buffer) - 1) & BASE_POOL_TYPE_MASK, NonPagedPool);
         ok_eq_uint(DriverObject->DriverExtension->ServiceKeyName.MaximumLength, DriverObject->DriverExtension->ServiceKeyName.Length + sizeof(UNICODE_NULL));
         ok_eq_uint(DriverObject->DriverExtension->ServiceKeyName.Buffer[DriverObject->DriverExtension->ServiceKeyName.Length / sizeof(WCHAR)], UNICODE_NULL);
         Equal = RtlEqualUnicodeString(&DriverObject->DriverName,
@@ -348,7 +350,11 @@ TestDeviceCreated(
 
     /* Check the device object members */
     ok(DeviceObject->Type == 3, "Expected Type = 3, got %x\n", DeviceObject->Type);
-    ok(DeviceObject->Size == 0xb8, "Expected Size = 0xb8, got %x\n", DeviceObject->Size);
+    #ifdef _M_IX86
+    ok(DeviceObject->Size == 0xb8, "Expected Size = 0xb8, got 0x%x\n", DeviceObject->Size);
+    #else
+    ok(DeviceObject->Size == 0x150, "Expected Size = 0x150, got 0x%x\n", DeviceObject->Size);
+    #endif
     ok(DeviceObject->ReferenceCount == 0, "Expected ReferenceCount = 0, got %lu\n",
         DeviceObject->ReferenceCount);
     ok(DeviceObject->DriverObject == ThisDriverObject,
@@ -368,17 +374,19 @@ TestDeviceCreated(
             "Expected Flags DO_DEVICE_HAS_NAME | DO_DEVICE_INITIALIZING, got %lu\n", DeviceObject->Flags);
     }
     ok(DeviceObject->DeviceType == FILE_DEVICE_UNKNOWN,
-        "Expected DeviceType to match creation parameter FILE_DEVICE_UNKNWOWN, got %lu\n",
+       "Expected DeviceType to match creation parameter FILE_DEVICE_UNKNWOWN, got %lu\n",
         DeviceObject->DeviceType);
     ok(DeviceObject->ActiveThreadCount == 0, "Expected ActiveThreadCount = 0, got %lu\n", DeviceObject->ActiveThreadCount);
 
     /* Check the extended extension */
     extdev = (PEXTENDED_DEVOBJ_EXTENSION)DeviceObject->DeviceObjectExtension;
-    ok(extdev->ExtensionFlags == 0, "Expected Extended ExtensionFlags to be 0, got %lu\n", extdev->ExtensionFlags);
-    ok (extdev->Type == 13, "Expected Type of 13, got %d\n", extdev->Type);
-    ok (extdev->Size == 0, "Expected Size of 0, got %d\n", extdev->Size);
-    ok (extdev->DeviceObject == DeviceObject, "Expected DeviceOject to match newly created device %p, got %p\n",
-        DeviceObject, extdev->DeviceObject);
+    ok(extdev->ExtensionFlags == DOE_DEFAULT_SD_PRESENT || // Vista+
+       extdev->ExtensionFlags == 0,                        // WS03
+       "Expected Extended ExtensionFlags to be DOE_DEFAULT_SD_PRESENT or 0, got %lu\n", extdev->ExtensionFlags);
+    ok(extdev->Type == 13, "Expected Type of 13, got %d\n", extdev->Type);
+    ok(extdev->Size == 0, "Expected Size of 0, got %d\n", extdev->Size);
+    ok(extdev->DeviceObject == DeviceObject, "Expected DeviceOject to match newly created device %p, got %p\n",
+       DeviceObject, extdev->DeviceObject);
     ok(extdev->AttachedTo == NULL, "Expected AttachTo to be NULL, got %p\n", extdev->AttachedTo);
     ok(extdev->StartIoCount == 0, "Expected StartIoCount = 0, got %lu\n", extdev->StartIoCount);
     ok(extdev->StartIoKey == 0, "Expected StartIoKey = 0, got %lu\n", extdev->StartIoKey);
@@ -396,7 +404,11 @@ TestDeviceDeletion(
 
     /* Check the device object members */
     ok(DeviceObject->Type == 3, "Expected Type = 3, got %d\n", DeviceObject->Type);
-    ok(DeviceObject->Size == 0xb8, "Expected Size = 0xb8, got %d\n", DeviceObject->Size);
+    #ifdef _M_IX86
+    ok(DeviceObject->Size == 0xb8, "Expected Size = 0xb8, got 0x%x\n", DeviceObject->Size);
+    #else
+    ok(DeviceObject->Size == 0x150, "Expected Size = 0x150, got 0x%x\n", DeviceObject->Size);
+    #endif
     ok(DeviceObject->ReferenceCount == 0, "Expected ReferenceCount = 0, got %lu\n",
         DeviceObject->ReferenceCount);
     if (!Lower)
@@ -426,9 +438,9 @@ TestDeviceDeletion(
 
     /* Check the extended extension */
     extdev = (PEXTENDED_DEVOBJ_EXTENSION)DeviceObject->DeviceObjectExtension;
-    /* FIXME: Windows has the MSB set under some conditions, need to find out what this means */
-    ok((extdev->ExtensionFlags & 0x7fffffff) == DOE_UNLOAD_PENDING,
-        "Expected Extended ExtensionFlags to be DOE_UNLOAD_PENDING, got 0x%lx\n", extdev->ExtensionFlags);
+    ok((extdev->ExtensionFlags == (DOE_DEFAULT_SD_PRESENT | DOE_UNLOAD_PENDING) ||  // Vista+
+        extdev->ExtensionFlags & 0x7fffffff) == DOE_UNLOAD_PENDING,                 // WS03 FIXME: Windows has the MSB set under some conditions, need to find out what this means
+        "Unexpected Extended ExtensionFlags (0x%lx)\n", extdev->ExtensionFlags);
     ok (extdev->Type == 13, "Expected Type of 13, got %d\n", extdev->Type);
     ok (extdev->Size == 0, "Expected Size of 0, got %d\n", extdev->Size);
     ok (extdev->DeviceObject == DeviceObject, "Expected DeviceOject to match newly created device %p, got %p\n",

--- a/modules/rostests/kmtests/ntos_io/IoFilesystem.c
+++ b/modules/rostests/kmtests/ntos_io/IoFilesystem.c
@@ -116,7 +116,7 @@ TestAllInformation(VOID)
         return;
 
     /* Find filesystem for the system */
-    FsAttributeInfo = ExAllocatePoolWithTag(PagedPool, FSAttributeBufferSize, 'FSys');
+    FsAttributeInfo = ExAllocatePoolWithTag(PagedPool, FSAttributeBufferSize, 'sySF');
     if (FsAttributeInfo == NULL)
     {
         ok(FALSE, "Failed to allocate memory to query the filesystem!\n");
@@ -129,7 +129,6 @@ TestAllInformation(VOID)
                                           FsAttributeInfo,
                                           FSAttributeBufferSize,
                                           FileFsAttributeInformation);
-
     if (NT_SUCCESS(Status))
     {
         if (FsAttributeInfo->FileSystemNameLength >= 8 &&
@@ -138,7 +137,6 @@ TestAllInformation(VOID)
             g_Filesystem = NTFS;
             trace("Filesystem: NTFS\n");
         }
-
         else if (FsAttributeInfo->FileSystemNameLength >= 10 &&
                 RtlCompareMemory(FsAttributeInfo->FileSystemName, L"FAT32", 10) == 10)
         {
@@ -160,7 +158,7 @@ TestAllInformation(VOID)
         ok(FALSE, "Failed to query filesystem: %lx\n", Status);
     }
 
-    ExFreePoolWithTag(FsAttributeInfo, 'FSys');
+    ExFreePoolWithTag(FsAttributeInfo, 'sySF');
 
     /* NtQueryInformationFile doesn't do length checks for kernel callers in a free build */
     if (KmtIsCheckedBuild)
@@ -846,7 +844,7 @@ Cleanup:
 
 START_TEST(IoFilesystem)
 {
-    /* TestAllInformation() has to be first since we detect the filesystem there. */
+    /* TestAllInformation() has to be first since we detect the filesystem there */
     TestAllInformation();
     TestRelativeNames();
     TestSharedCacheMap();

--- a/modules/rostests/kmtests/ntos_io/IoFilesystem.c
+++ b/modules/rostests/kmtests/ntos_io/IoFilesystem.c
@@ -138,7 +138,7 @@ TestAllInformation(VOID)
             trace("Filesystem: NTFS\n");
         }
         else if (FsAttributeInfo->FileSystemNameLength >= 10 &&
-                RtlCompareMemory(FsAttributeInfo->FileSystemName, L"FAT32", 10) == 10)
+                 RtlCompareMemory(FsAttributeInfo->FileSystemName, L"FAT32", 10) == 10)
         {
             g_Filesystem = FAT32;
             trace("Filesystem: FAT32\n");

--- a/modules/rostests/kmtests/ntos_io/IoFilesystem.c
+++ b/modules/rostests/kmtests/ntos_io/IoFilesystem.c
@@ -7,7 +7,14 @@
 
 #include <kmt_test.h>
 
-/* FIXME: Test this stuff on non-FAT volumes */
+typedef enum
+{
+    NTFS,
+    FAT32,
+    Unknown
+} FSType;
+
+static FSType g_Filesystem;
 
 static
 NTSTATUS
@@ -84,6 +91,8 @@ TestAllInformation(VOID)
     ULONG NameLength;
     PWCHAR Name;
     UNICODE_STRING NamePart;
+    FILE_FS_ATTRIBUTE_INFORMATION* FsAttributeInfo;
+    ULONG FSAttributeBufferSize = sizeof(FILE_FS_ATTRIBUTE_INFORMATION) + 256;
 
     InitializeObjectAttributes(&ObjectAttributes,
                                &FileName,
@@ -105,6 +114,53 @@ TestAllInformation(VOID)
     ok_eq_hex(Status, STATUS_SUCCESS);
     if (skip(NT_SUCCESS(Status), "No file handle, %lx\n", Status))
         return;
+
+    /* Find filesystem for the system */
+    FsAttributeInfo = ExAllocatePoolWithTag(PagedPool, FSAttributeBufferSize, 'FSys');
+    if (FsAttributeInfo == NULL)
+    {
+        ok(FALSE, "Failed to allocate memory to query the filesystem!\n");
+        ZwClose(FileHandle);
+        return;
+    }
+
+    Status = ZwQueryVolumeInformationFile(FileHandle,
+                                          &IoStatus,
+                                          FsAttributeInfo,
+                                          FSAttributeBufferSize,
+                                          FileFsAttributeInformation);
+
+    if (NT_SUCCESS(Status))
+    {
+        if (FsAttributeInfo->FileSystemNameLength >= 8 &&
+            RtlCompareMemory(FsAttributeInfo->FileSystemName, L"NTFS", 8) == 8)
+        {
+            g_Filesystem = NTFS;
+            trace("Filesystem: NTFS\n");
+        }
+
+        else if (FsAttributeInfo->FileSystemNameLength >= 10 &&
+                RtlCompareMemory(FsAttributeInfo->FileSystemName, L"FAT32", 10) == 10)
+        {
+            g_Filesystem = FAT32;
+            trace("Filesystem: FAT32\n");
+        }
+        else
+        {
+            UNICODE_STRING FsName;
+            FsName.Length = FsAttributeInfo->FileSystemNameLength;
+            FsName.MaximumLength = FsAttributeInfo->FileSystemNameLength;
+            FsName.Buffer = FsAttributeInfo->FileSystemName;
+            g_Filesystem = Unknown;
+            trace("Unknown filesystem: %wZ\n", &FsName);
+        }
+    }
+    else
+    {
+        ok(FALSE, "Failed to query filesystem: %lx\n", Status);
+    }
+
+    ExFreePoolWithTag(FsAttributeInfo, 'FSys');
 
     /* NtQueryInformationFile doesn't do length checks for kernel callers in a free build */
     if (KmtIsCheckedBuild)
@@ -193,7 +249,10 @@ TestAllInformation(VOID)
     Length = FIELD_OFFSET(FILE_ALL_INFORMATION, NameInformation.FileName) + NameLength - 1;
     Status = QueryFileInfo(FileHandle, (PVOID*)&FileAllInfo, &Length, FileAllInformation);
     ok_eq_hex(Status, STATUS_BUFFER_OVERFLOW);
-    ok_eq_size(Length, FIELD_OFFSET(FILE_ALL_INFORMATION, NameInformation.FileName) + NameLength - 1);
+    if (g_Filesystem == FAT32)
+        ok_eq_size(Length, FIELD_OFFSET(FILE_ALL_INFORMATION, NameInformation.FileName) + NameLength - 1);
+    else if (g_Filesystem == NTFS)
+        ok_eq_size(Length, FIELD_OFFSET(FILE_ALL_INFORMATION, NameInformation.FileName) + NameLength - 2);
     if (FileAllInfo)
         KmtFreeGuarded(FileAllInfo);
 
@@ -226,7 +285,9 @@ TestAllInformation(VOID)
     Status = QueryFileInfo(FileHandle, (PVOID*)&FileEofInfo, &Length, FileEndOfFileInformation);
     // Checked build: STATUS_INVALID_INFO_CLASS, Free build: STATUS_INVALID_PARAMETER
     ok(Status == STATUS_INVALID_PARAMETER || Status == STATUS_INVALID_INFO_CLASS, "Wrong Status = %lx\n", Status);
-    ok_eq_size(Length, (SIZE_T)0x5555555555555555ULL);
+    ok(Length == 0 ||                            // Win10
+       Length == (SIZE_T)0x5555555555555555ULL,  // Win2k3-Win8.1
+       "Invalid length (0x%X)\n", Length);
     if (FileEofInfo)
         KmtFreeGuarded(FileEofInfo);
 
@@ -302,69 +363,74 @@ VOID
 TestRelativeNames(VOID)
 {
     NTSTATUS Status;
-    struct
+    typedef struct
     {
         PCWSTR ParentPathTemplate;
         PCWSTR RelativePathTemplate;
-        BOOLEAN IsDirectory;
-        NTSTATUS Status;
+        BOOLEAN IsDirectory_FAT32;
+        NTSTATUS Status_FAT32;
+        BOOLEAN IsDirectory_NTFS;
+        NTSTATUS Status_NTFS;
         BOOLEAN IsDrive;
-    } Tests[] =
+    } RelativeNameTest;
+
+    RelativeNameTest Tests[] =
     {
-        { NULL,                         L"C:\\",                            TRUE,   STATUS_SUCCESS, TRUE },
-        { NULL,                         L"C:\\\\",                          TRUE,   STATUS_SUCCESS, TRUE },
-        { NULL,                         L"C:\\\\\\",                        TRUE,   STATUS_OBJECT_NAME_INVALID, TRUE },
-        { NULL,                         L"C:\\ReactOS",                     TRUE,   STATUS_SUCCESS },
-        { NULL,                         L"C:\\ReactOS\\",                   TRUE,   STATUS_SUCCESS },
-        { NULL,                         L"C:\\ReactOS\\\\",                 TRUE,   STATUS_SUCCESS },
-        { NULL,                         L"C:\\ReactOS\\\\\\",               TRUE,   STATUS_OBJECT_NAME_INVALID },
-        { NULL,                         L"C:\\\\ReactOS",                   TRUE,   STATUS_SUCCESS },
-        { NULL,                         L"C:\\\\ReactOS\\",                 TRUE,   STATUS_SUCCESS },
-        { NULL,                         L"C:\\ReactOS\\explorer.exe",       FALSE,  STATUS_SUCCESS },
-        { NULL,                         L"C:\\ReactOS\\\\explorer.exe",     FALSE,  STATUS_OBJECT_NAME_INVALID },
-        { NULL,                         L"C:\\ReactOS\\explorer.exe\\",     FALSE,  STATUS_OBJECT_NAME_INVALID },
-        { NULL,                         L"C:\\ReactOS\\explorer.exe\\file", FALSE,  STATUS_OBJECT_PATH_NOT_FOUND },
-        { NULL,                         L"C:\\ReactOS\\explorer.exe\\\\",   FALSE,  STATUS_OBJECT_NAME_INVALID },
+        { NULL,                         L"C:\\",                            TRUE,   STATUS_SUCCESS,                 TRUE,   STATUS_SUCCESS, TRUE },
+        { NULL,                         L"C:\\\\",                          TRUE,   STATUS_SUCCESS,                 TRUE,   STATUS_SUCCESS, TRUE },
+        { NULL,                         L"C:\\\\\\",                        TRUE,   STATUS_OBJECT_NAME_INVALID,     TRUE,   STATUS_OBJECT_NAME_INVALID,TRUE },
+        { NULL,                         L"C:\\ReactOS",                     TRUE,   STATUS_SUCCESS,                 TRUE,   STATUS_SUCCESS},
+        { NULL,                         L"C:\\ReactOS\\",                   TRUE,   STATUS_SUCCESS,                 TRUE,   STATUS_SUCCESS, },
+        { NULL,                         L"C:\\ReactOS\\\\",                 TRUE,   STATUS_SUCCESS,                 TRUE,   STATUS_OBJECT_NAME_INVALID},
+        { NULL,                         L"C:\\ReactOS\\\\\\",               TRUE,   STATUS_OBJECT_NAME_INVALID,     TRUE,   STATUS_OBJECT_NAME_INVALID},
+        { NULL,                         L"C:\\\\ReactOS",                   TRUE,   STATUS_SUCCESS,                 TRUE,   STATUS_SUCCESS},
+        { NULL,                         L"C:\\\\ReactOS\\",                 TRUE,   STATUS_SUCCESS,                 TRUE,   STATUS_SUCCESS },
+        { NULL,                         L"C:\\ReactOS\\explorer.exe",       FALSE,  STATUS_SUCCESS,                 FALSE,  STATUS_SUCCESS},
+        { NULL,                         L"C:\\ReactOS\\\\explorer.exe",     FALSE,  STATUS_OBJECT_NAME_INVALID,     FALSE,  STATUS_OBJECT_NAME_INVALID },
+        { NULL,                         L"C:\\ReactOS\\explorer.exe\\",     FALSE,  STATUS_OBJECT_NAME_INVALID,     FALSE,  STATUS_OBJECT_NAME_INVALID },
+        { NULL,                         L"C:\\ReactOS\\explorer.exe\\file", FALSE,  STATUS_OBJECT_PATH_NOT_FOUND,   FALSE,  STATUS_OBJECT_PATH_NOT_FOUND },
+        { NULL,                         L"C:\\ReactOS\\explorer.exe\\\\",   FALSE,  STATUS_OBJECT_NAME_INVALID,     TRUE,  STATUS_OBJECT_NAME_INVALID },
         /* This will never return STATUS_NOT_A_DIRECTORY. IsDirectory=TRUE is a little hacky but achieves that without special handling */
-        { NULL,                         L"C:\\ReactOS\\explorer.exe\\\\\\", TRUE,   STATUS_OBJECT_NAME_INVALID },
-        { L"C:\\",                      L"",                                TRUE,   STATUS_SUCCESS },
-        { L"C:\\",                      L"\\",                              TRUE,   STATUS_OBJECT_NAME_INVALID },
-        { L"C:\\",                      L"ReactOS",                         TRUE,   STATUS_SUCCESS },
-        { L"C:\\",                      L"\\ReactOS",                       TRUE,   STATUS_OBJECT_NAME_INVALID },
-        { L"C:\\",                      L"ReactOS\\",                       TRUE,   STATUS_SUCCESS },
-        { L"C:\\",                      L"\\ReactOS\\",                     TRUE,   STATUS_OBJECT_NAME_INVALID },
-        { L"C:\\ReactOS",               L"",                                TRUE,   STATUS_SUCCESS },
-        { L"C:\\ReactOS",               L"explorer.exe",                    FALSE,  STATUS_SUCCESS },
-        { L"C:\\ReactOS\\explorer.exe", L"",                                FALSE,  STATUS_SUCCESS },
-        { L"C:\\ReactOS\\explorer.exe", L"file",                            FALSE,  STATUS_OBJECT_PATH_NOT_FOUND },
+        { NULL,                         L"C:\\ReactOS\\explorer.exe\\\\\\", TRUE,   STATUS_OBJECT_NAME_INVALID,     TRUE,   STATUS_OBJECT_NAME_INVALID },
+        { L"C:\\",                      L"",                                TRUE,   STATUS_SUCCESS,                 TRUE,   STATUS_SUCCESS },
+        { L"C:\\",                      L"\\",                              TRUE,   STATUS_OBJECT_NAME_INVALID,     TRUE,   STATUS_INVALID_PARAMETER },
+        { L"C:\\",                      L"ReactOS",                         TRUE,   STATUS_SUCCESS,                 TRUE,   STATUS_SUCCESS },
+        { L"C:\\",                      L"\\ReactOS",                       TRUE,   STATUS_OBJECT_NAME_INVALID,     TRUE,   STATUS_INVALID_PARAMETER },
+        { L"C:\\",                      L"ReactOS\\",                       TRUE,   STATUS_SUCCESS,                 TRUE,   STATUS_SUCCESS },
+        { L"C:\\",                      L"\\ReactOS\\",                     TRUE,   STATUS_OBJECT_NAME_INVALID,     TRUE,   STATUS_INVALID_PARAMETER },
+        { L"C:\\ReactOS",               L"",                                TRUE,   STATUS_SUCCESS,                 TRUE,   STATUS_SUCCESS },
+        { L"C:\\ReactOS",               L"explorer.exe",                    FALSE,  STATUS_SUCCESS,                 FALSE,  STATUS_SUCCESS },
+        { L"C:\\ReactOS\\explorer.exe", L"",                                FALSE,  STATUS_SUCCESS,                 FALSE,  STATUS_SUCCESS },
+        { L"C:\\ReactOS\\explorer.exe", L"file",                            FALSE,  STATUS_OBJECT_PATH_NOT_FOUND,   FALSE,  STATUS_OBJECT_PATH_NOT_FOUND },
         /* Let's try some nonexistent things */
-        { NULL,                         L"C:\\ReactOS\\IDoNotExist",        FALSE,  STATUS_OBJECT_NAME_NOT_FOUND },
-        { NULL,                         L"C:\\ReactOS\\IDoNotExist\\file",  FALSE,  STATUS_OBJECT_PATH_NOT_FOUND },
-        { NULL,                         L"C:\\ReactOS\\IDoNotExist\\file?", FALSE,  STATUS_OBJECT_PATH_NOT_FOUND },
-        { NULL,                         L"C:\\ReactOS\\IDoNotExist\\file\\\\",TRUE,STATUS_OBJECT_PATH_NOT_FOUND },
-        { NULL,                         L"C:\\ReactOS\\IDoNotExist\\file\\\\\\",TRUE,STATUS_OBJECT_PATH_NOT_FOUND },
-        { NULL,                         L"C:\\ReactOS\\AmIInvalid?",        FALSE,  STATUS_OBJECT_NAME_INVALID },
-        { NULL,                         L"C:\\ReactOS\\.",                  TRUE,   STATUS_OBJECT_NAME_NOT_FOUND },
-        { NULL,                         L"C:\\ReactOS\\..",                 TRUE,   STATUS_OBJECT_NAME_NOT_FOUND },
-        { NULL,                         L"C:\\ReactOS\\...",                TRUE,   STATUS_OBJECT_NAME_NOT_FOUND },
-        { NULL,                         L"C:\\ReactOS\\.\\system32",        TRUE,   STATUS_OBJECT_PATH_NOT_FOUND },
-        { NULL,                         L"C:\\ReactOS\\..\\ReactOS",        TRUE,   STATUS_OBJECT_PATH_NOT_FOUND },
-        { L"C:\\",                      L".",                               TRUE,   STATUS_OBJECT_NAME_NOT_FOUND },
-        { L"C:\\",                      L"..",                              TRUE,   STATUS_OBJECT_NAME_NOT_FOUND },
-        { L"C:\\",                      L"...",                             TRUE,   STATUS_OBJECT_NAME_NOT_FOUND },
-        { L"C:\\",                      L".\\ReactOS",                      TRUE,   STATUS_OBJECT_PATH_NOT_FOUND },
-        { L"C:\\",                      L"..\\ReactOS",                     TRUE,   STATUS_OBJECT_PATH_NOT_FOUND },
-        { L"C:\\ReactOS",               L".",                               TRUE,   STATUS_OBJECT_NAME_NOT_FOUND },
-        { L"C:\\ReactOS",               L"..",                              TRUE,   STATUS_OBJECT_NAME_NOT_FOUND },
-        { L"C:\\ReactOS",               L"...",                             TRUE,   STATUS_OBJECT_NAME_NOT_FOUND },
-        { L"C:\\ReactOS",               L".\\system32",                     TRUE,   STATUS_OBJECT_PATH_NOT_FOUND },
-        { L"C:\\ReactOS",               L"..\\ReactOS",                     TRUE,   STATUS_OBJECT_PATH_NOT_FOUND },
+        { NULL,                         L"C:\\ReactOS\\IDoNotExist",        FALSE,  STATUS_OBJECT_NAME_NOT_FOUND,   FALSE,  STATUS_OBJECT_NAME_NOT_FOUND },
+        { NULL,                         L"C:\\ReactOS\\IDoNotExist\\file",  FALSE,  STATUS_OBJECT_PATH_NOT_FOUND,   FALSE,  STATUS_OBJECT_PATH_NOT_FOUND  },
+        { NULL,                         L"C:\\ReactOS\\IDoNotExist\\file?", FALSE,  STATUS_OBJECT_PATH_NOT_FOUND,   FALSE,  STATUS_OBJECT_PATH_NOT_FOUND },
+        { NULL,                         L"C:\\ReactOS\\IDoNotExist\\file\\\\",TRUE, STATUS_OBJECT_PATH_NOT_FOUND,   TRUE,   STATUS_OBJECT_NAME_INVALID },
+        { NULL,                         L"C:\\ReactOS\\IDoNotExist\\file\\\\\\",TRUE,STATUS_OBJECT_PATH_NOT_FOUND,  TRUE,   STATUS_OBJECT_NAME_INVALID },
+        { NULL,                         L"C:\\ReactOS\\AmIInvalid?",        FALSE,  STATUS_OBJECT_NAME_INVALID,     FALSE,  STATUS_OBJECT_NAME_INVALID },
+        { NULL,                         L"C:\\ReactOS\\.",                  TRUE,   STATUS_OBJECT_NAME_NOT_FOUND,   TRUE,   STATUS_OBJECT_NAME_INVALID },
+        { NULL,                         L"C:\\ReactOS\\..",                 TRUE,   STATUS_OBJECT_NAME_NOT_FOUND,   TRUE,   STATUS_OBJECT_NAME_INVALID },
+        { NULL,                         L"C:\\ReactOS\\...",                TRUE,   STATUS_OBJECT_NAME_NOT_FOUND,   TRUE,   STATUS_OBJECT_NAME_NOT_FOUND },
+        { NULL,                         L"C:\\ReactOS\\.\\system32",        TRUE,   STATUS_OBJECT_PATH_NOT_FOUND,   TRUE,   STATUS_OBJECT_PATH_NOT_FOUND },
+        { NULL,                         L"C:\\ReactOS\\..\\ReactOS",        TRUE,   STATUS_OBJECT_PATH_NOT_FOUND,   TRUE,   STATUS_OBJECT_NAME_INVALID },
+        { L"C:\\",                      L".",                               TRUE,   STATUS_OBJECT_NAME_NOT_FOUND,   TRUE,   STATUS_OBJECT_NAME_INVALID },
+        { L"C:\\",                      L"..",                              TRUE,   STATUS_OBJECT_NAME_NOT_FOUND,   TRUE,   STATUS_OBJECT_NAME_INVALID },
+        { L"C:\\",                      L"...",                             TRUE,   STATUS_OBJECT_NAME_NOT_FOUND,   TRUE,   STATUS_OBJECT_NAME_NOT_FOUND },
+        { L"C:\\",                      L".\\ReactOS",                      TRUE,   STATUS_OBJECT_PATH_NOT_FOUND,   TRUE,   STATUS_OBJECT_PATH_NOT_FOUND },
+        { L"C:\\",                      L"..\\ReactOS",                     TRUE,   STATUS_OBJECT_PATH_NOT_FOUND,   TRUE,   STATUS_OBJECT_NAME_INVALID },
+        { L"C:\\ReactOS",               L".",                               TRUE,   STATUS_OBJECT_NAME_NOT_FOUND,   TRUE,   STATUS_OBJECT_NAME_INVALID },
+        { L"C:\\ReactOS",               L"..",                              TRUE,   STATUS_OBJECT_NAME_NOT_FOUND,   TRUE,   STATUS_OBJECT_NAME_INVALID },
+        { L"C:\\ReactOS",               L"...",                             TRUE,   STATUS_OBJECT_NAME_NOT_FOUND,   TRUE,   STATUS_OBJECT_NAME_NOT_FOUND },
+        { L"C:\\ReactOS",               L".\\system32",                     TRUE,   STATUS_OBJECT_PATH_NOT_FOUND,   TRUE,   STATUS_OBJECT_PATH_NOT_FOUND },
+        { L"C:\\ReactOS",               L"..\\ReactOS",                     TRUE,   STATUS_OBJECT_PATH_NOT_FOUND,   TRUE,   STATUS_OBJECT_NAME_INVALID },
         /* Volume open */
-        { NULL,                         L"C:",                              FALSE,  STATUS_SUCCESS, TRUE },
-        { L"C:",                        L"",                                FALSE,  STATUS_SUCCESS, TRUE },
-        { L"C:",                        L"\\",                              TRUE,   STATUS_OBJECT_PATH_NOT_FOUND },
-        { L"C:",                        L"file",                            TRUE,   STATUS_OBJECT_PATH_NOT_FOUND },
+        { NULL,                         L"C:",                              FALSE,  STATUS_SUCCESS,                 FALSE,  STATUS_SUCCESS, TRUE },
+        { L"C:",                        L"",                                FALSE,  STATUS_SUCCESS,                 FALSE,  STATUS_SUCCESS, TRUE },
+        { L"C:",                        L"\\",                              TRUE,   STATUS_OBJECT_PATH_NOT_FOUND,   TRUE,   STATUS_INVALID_PARAMETER },
+        { L"C:",                        L"file",                            TRUE,   STATUS_OBJECT_PATH_NOT_FOUND,   TRUE,   STATUS_INVALID_PARAMETER },
     };
+
     ULONG i;
     OBJECT_ATTRIBUTES ObjectAttributes;
     IO_STATUS_BLOCK IoStatus;
@@ -423,9 +489,28 @@ TestRelativeNames(VOID)
     if (skip(Buffer != NULL, "No buffer\n"))
         return;
 
+    if (g_Filesystem == Unknown)
+    {
+        trace("Unknown filesystem, running NTFS tests!\n");
+    }
+
     /* Finally run some tests! */
     for (i = 0; i < RTL_NUMBER_OF(Tests); i++)
     {
+        BOOLEAN isDirectory;
+        NTSTATUS expectedStatus;
+
+        if (g_Filesystem == FAT32)
+        {
+            isDirectory = Tests[i].IsDirectory_FAT32;
+            expectedStatus = Tests[i].Status_FAT32;
+        }
+        else /* Default to NTFS */
+        {
+            isDirectory = Tests[i].IsDirectory_NTFS;
+            expectedStatus = Tests[i].Status_NTFS;
+        }
+
         /* Open parent directory first */
         ParentHandle = NULL;
         if (Tests[i].ParentPathTemplate)
@@ -476,8 +561,8 @@ TestRelativeNames(VOID)
                             &IoStatus,
                             FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
                             0);
-        ok(Status == Tests[i].Status,
-           "[%lu] Status = %lx, expected %lx\n", i, Status, Tests[i].Status);
+        ok(Status == expectedStatus,
+           "[%lu] Status = %lx, expected %lx\n", i, Status, expectedStatus);
         if (NT_SUCCESS(Status))
             ObCloseHandle(FileHandle, KernelMode);
 
@@ -488,12 +573,20 @@ TestRelativeNames(VOID)
                             &IoStatus,
                             FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
                             FILE_DIRECTORY_FILE);
-        if (Tests[i].IsDirectory || (!TrailingBackslash && !NT_SUCCESS(Tests[i].Status)))
-            ok(Status == Tests[i].Status,
-               "[%lu] Status = %lx, expected %lx\n", i, Status, Tests[i].Status);
+        if (isDirectory || (!TrailingBackslash && !NT_SUCCESS(expectedStatus)))
+        {
+            ok(Status == expectedStatus,
+               "[%lu] Status = %lx, expected %lx\n", i, Status, expectedStatus);
+        }
         else
-            ok(Status == STATUS_NOT_A_DIRECTORY,
-               "[%lu] Status = %lx, expected STATUS_NOT_A_DIRECTORY\n", i, Status);
+        {
+            if (g_Filesystem == FAT32)
+                ok(Status == STATUS_NOT_A_DIRECTORY,
+                   "[%lu] Status = %lx, expected STATUS_NOT_A_DIRECTORY\n", i, Status);
+            else if (g_Filesystem == NTFS)
+                ok(Status == STATUS_NOT_A_DIRECTORY || Status == STATUS_INVALID_PARAMETER,
+                   "[%lu] Status = %lx, expected STATUS_NOT_A_DIRECTORY or STATUS_INVALID_PARAMETER\n", i, Status);
+        }
         if (NT_SUCCESS(Status))
             ObCloseHandle(FileHandle, KernelMode);
 
@@ -504,12 +597,12 @@ TestRelativeNames(VOID)
                             &IoStatus,
                             FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
                             FILE_NON_DIRECTORY_FILE);
-        if (Tests[i].IsDirectory && NT_SUCCESS(Tests[i].Status))
+        if (isDirectory && NT_SUCCESS(expectedStatus))
             ok(Status == STATUS_FILE_IS_A_DIRECTORY,
                "[%lu] Status = %lx, expected STATUS_FILE_IS_A_DIRECTORY\n", i, Status);
         else
-            ok(Status == Tests[i].Status,
-               "[%lu] Status = %lx, expected %lx\n", i, Status, Tests[i].Status);
+            ok(Status == expectedStatus,
+               "[%lu] Status = %lx, expected %lx\n", i, Status, expectedStatus);
         if (NT_SUCCESS(Status))
             ObCloseHandle(FileHandle, KernelMode);
 
@@ -520,12 +613,20 @@ TestRelativeNames(VOID)
                             &IoStatus,
                             FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
                             FILE_DIRECTORY_FILE | FILE_NON_DIRECTORY_FILE);
-        if (Tests[i].Status == STATUS_OBJECT_NAME_INVALID && Tests[i].IsDrive)
-            ok(Status == STATUS_OBJECT_NAME_INVALID,
-               "[%lu] Status = %lx, expected STATUS_OBJECT_NAME_INVALID\n", i, Status);
+        if (expectedStatus == STATUS_OBJECT_NAME_INVALID && Tests[i].IsDrive)
+        {
+            if (g_Filesystem == FAT32)
+                ok(Status == STATUS_OBJECT_NAME_INVALID,
+                   "[%lu] Status = %lx, expected STATUS_OBJECT_NAME_INVALID\n", i, Status);
+            else if (g_Filesystem == NTFS)
+                ok(Status == STATUS_INVALID_PARAMETER,
+                   "[%lu] Status = %lx, expected STATUS_INVALID_PARAMETER\n", i, Status);
+        }
         else
+        {
             ok(Status == STATUS_INVALID_PARAMETER,
                "[%lu] Status = %lx, expected STATUS_INVALID_PARAMETER\n", i, Status);
+        }
         if (NT_SUCCESS(Status))
             ObCloseHandle(FileHandle, KernelMode);
 
@@ -542,21 +643,21 @@ TestRelativeNames(VOID)
                               0,
                               NULL,
                               0);
-        if (Tests[i].Status == STATUS_OBJECT_NAME_NOT_FOUND)
+        if (expectedStatus == STATUS_OBJECT_NAME_NOT_FOUND)
             ok(Status == STATUS_SUCCESS,
                "[%lu] Status = %lx, expected STATUS_SUCCESS\n", i, Status);
-        else if (Tests[i].Status == STATUS_OBJECT_NAME_INVALID && Tests[i].IsDrive)
+        else if (expectedStatus == STATUS_OBJECT_NAME_INVALID && Tests[i].IsDrive)
             ok(Status == STATUS_OBJECT_NAME_INVALID,
                "[%lu] Status = %lx, expected STATUS_OBJECT_NAME_INVALID\n", i, Status);
         else if (Tests[i].IsDrive)
             ok(Status == STATUS_ACCESS_DENIED,
                "[%lu] Status = %lx, expected STATUS_ACCESS_DENIED\n", i, Status);
-        else if (Tests[i].Status == STATUS_SUCCESS)
-            ok(Status == STATUS_OBJECT_NAME_COLLISION,
-               "[%lu] Status = %lx, expected STATUS_OBJECT_NAME_COLLISION\n", i, Status);
+        else if (expectedStatus == STATUS_SUCCESS)
+            ok(Status == STATUS_OBJECT_NAME_COLLISION || Status == STATUS_ACCESS_DENIED,
+               "[%lu] Status = %lx, expected STATUS_OBJECT_NAME_COLLISION or STATUS_ACCESS_DENIED\n", i, Status);
         else
-            ok(Status == Tests[i].Status,
-               "[%lu] Status = %lx, expected %lx; %ls -- %ls\n", i, Status, Tests[i].Status, Tests[i].ParentPathTemplate, Tests[i].RelativePathTemplate);
+            ok(Status == expectedStatus,
+               "[%lu] Status = %lx, expected %lx; %ls -- %ls\n", i, Status, expectedStatus, Tests[i].ParentPathTemplate, Tests[i].RelativePathTemplate);
         if (NT_SUCCESS(Status))
         {
             if (IoStatus.Information == FILE_CREATED)
@@ -745,6 +846,7 @@ Cleanup:
 
 START_TEST(IoFilesystem)
 {
+    /* TestAllInformation() has to be first since we detect the filesystem there. */
     TestAllInformation();
     TestRelativeNames();
     TestSharedCacheMap();

--- a/sdk/include/ndk/iotypes.h
+++ b/sdk/include/ndk/iotypes.h
@@ -151,6 +151,7 @@ extern POBJECT_TYPE NTSYSAPI IoDriverObjectType;
 #define DOE_REMOVE_PENDING                      0x4
 #define DOE_REMOVE_PROCESSED                    0x8
 #define DOE_START_PENDING                       0x10
+#define DOE_DEFAULT_SD_PRESENT                  0x800
 
 //
 // Device Object StartIo Flags

--- a/sdk/include/xdk/setypes.h
+++ b/sdk/include/xdk/setypes.h
@@ -1275,26 +1275,11 @@ typedef struct _SE_EXPORTS {
   PSID SeUserModeDriversSid;
   PSID SeProcTrustWinTcbSid;
   PSID SeTrustedInstallerSid;
-
-  //
-  // New Privileges defined for Windows 10
-  //
-
   LUID SeDelegateSessionUserImpersonatePrivilege;
   PSID SeAppSiloSid;
   PSID SeAppSiloVolumeRootMinimalCapabilitySid;
   PSID SeAppSiloProfilesRootMinimalCapabilitySid;
-
-  //
-  // App Silo Prompt Access Capability SID
-  //
-
   PSID SeAppSiloPromptForAccessCapabilitySid;
-
-  //
-  // App Silo Access To Publisher Directory Capability SID
-  //
-
   PSID SeAppSiloAccessToPublisherDirectoryCapabilitySid;
 #endif
 } SE_EXPORTS, *PSE_EXPORTS;

--- a/sdk/include/xdk/setypes.h
+++ b/sdk/include/xdk/setypes.h
@@ -1270,12 +1270,20 @@ typedef struct _SE_EXPORTS {
   PSID SeHighMandatorySid;
   PSID SeSystemMandatorySid;
   PSID SeOwnerRightsSid;
-#if (_WIN32_WINNT >= _WIN32_WINNT_WIN8) || defined(__REACTOS__)   // The version guard is a guess.
+#if (NTDDI_VERSION >= NTDDI_WIN8) || defined(__REACTOS__)
   PSID SeAllAppPackagesSid;
   PSID SeUserModeDriversSid;
+#endif
+#if (NTDDI_VERSION >= NTDDI_WIN10_RS4)
   PSID SeProcTrustWinTcbSid;
+#endif
+#if (NTDDI_VERSION >= NTDDI_WIN8)
   PSID SeTrustedInstallerSid;
+#endif
+#if (NTDDI_VERSION >= NTDDI_WIN10_RS1)
   LUID SeDelegateSessionUserImpersonatePrivilege;
+#endif
+#if (NTDDI_VERSION >= NTDDI_WIN11) // The version guard is a guess.
   PSID SeAppSiloSid;
   PSID SeAppSiloVolumeRootMinimalCapabilitySid;
   PSID SeAppSiloProfilesRootMinimalCapabilitySid;

--- a/sdk/include/xdk/setypes.h
+++ b/sdk/include/xdk/setypes.h
@@ -1203,6 +1203,7 @@ typedef struct _TOKEN_ACCESS_INFORMATION {
 #define TOKEN_UIACCESS                  0x1000
 #define TOKEN_NOT_LOW                   0x2000
 
+/* See: https://microsoft.github.io/windows-docs-rs/doc/windows/Wdk/Storage/FileSystem/struct.SE_EXPORTS.html */
 typedef struct _SE_EXPORTS {
   LUID SeCreateTokenPrivilege;
   LUID SeAssignPrimaryTokenPrivilege;
@@ -1269,6 +1270,33 @@ typedef struct _SE_EXPORTS {
   PSID SeHighMandatorySid;
   PSID SeSystemMandatorySid;
   PSID SeOwnerRightsSid;
+#if (_WIN32_WINNT >= _WIN32_WINNT_WIN8) || defined(__REACTOS__)   // The version guard is a guess.
+  PSID SeAllAppPackagesSid;
+  PSID SeUserModeDriversSid;
+  PSID SeProcTrustWinTcbSid;
+  PSID SeTrustedInstallerSid;
+
+  //
+  // New Privileges defined for Windows 10
+  //
+
+  LUID SeDelegateSessionUserImpersonatePrivilege;
+  PSID SeAppSiloSid;
+  PSID SeAppSiloVolumeRootMinimalCapabilitySid;
+  PSID SeAppSiloProfilesRootMinimalCapabilitySid;
+
+  //
+  // App Silo Prompt Access Capability SID
+  //
+
+  PSID SeAppSiloPromptForAccessCapabilitySid;
+
+  //
+  // App Silo Access To Publisher Directory Capability SID
+  //
+
+  PSID SeAppSiloAccessToPublisherDirectoryCapabilitySid;
+#endif
 } SE_EXPORTS, *PSE_EXPORTS;
 
 typedef NTSTATUS


### PR DESCRIPTION
Same PR as #8286, all of the work was done by @cbialorucki except some cosmetic refactoring to [2950d94](https://github.com/maramadany/reactos/commit/2950d94bfd76b6a1f5e75765cb4a0bfa520990a3).

## Purpose

Fix failing kmtests on x64, NTFS, and Vista+ Windows systems.

Note: Between testing initially and developing these fixes, I switched my Windows 10 version from 22H2 to build 1607. This resulted in a lot of differences in the CmSecurity test. If we want to properly fix this test for Windows 10, as well as several others, we need to map build numbers from the KUSER_SHARED_DATA page to NTDDI versions and then check against the NTDDI version at runtime.
### Current test failures
| Test | 2003 (x86) | Vista (x86) | Vista (x64) | 7 (x86) | 7 (x64) | 8.1 (x86) | 8.1 (x64) | 10 (x86) | 10 (x64) |
| :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
| CmSecurity | 0 | 82 | 82 | 82 | 82 | 109 | 109 | 128 | 128 |
| ExPools | 0 | 1 | 4 | 1 | 4 | 2 | 4 | 2 | 2 |
| IoDeviceObject | 0 | 6 | 11 | 7 | 12 | 6 | 11 | 6 | 11 |
| IoFilesystem | 74 | 74 | 74 | 74 | 74 | 74 | 74 | 75 | 75 |
### New test failures
| Test | 2003 (x86) | Vista (x86) | Vista (x64) | 7 (x86) | 7 (x64) | 8.1 (x86) | 8.1 (x64) | 10 (x86) | 10 (x64) |
| :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
| CmSecurity | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 2 | 2 |
| ExPools | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
| IoDeviceObject | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
| IoFilesystem | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
## Proposed changes
- IoFilesystem: Add support for NTFS
- IoDeviceObject: Work around a Windows 7 bug, account for struct size changes on x64, accept Vista+ behavior
- ExPools: Accept pool being promoted to NonPaged on Vista+, accept 2GB allocation on x64, guard an undocumented behavior
- CmSecurity: Add tests for Vista-Win8.1

## Testbot runs (Filled in by Devs)
- [x]  WHS x86: https://reactos.org/testman/compare.php?ids=103654,103662
- [ ]  KVM x64: