### PR TITLE
[NTUSER][COMCTL32] Fix garbage displayed at bottom of listbox

### DIFF
--- a/dll/win32/comctl32/listbox.c
+++ b/dll/win32/comctl32/listbox.c
@@ -1129,7 +1129,9 @@ static LRESULT LISTBOX_Paint( LB_DESCR *descr, HDC hdc )
         /* keep the focus rect, to paint the focus item after */
         if (i == descr->focus_item)
             focusRect = rect;
-
+#ifdef __REACTOS__
+        rect.bottom = min(rect.bottom, descr->height);
+#endif
         LISTBOX_PaintItem( descr, hdc, &rect, i, ODA_DRAWENTIRE, TRUE );
         rect.top = rect.bottom;
 

--- a/win32ss/user/user32/controls/listbox.c
+++ b/win32ss/user/user32/controls/listbox.c
@@ -1076,7 +1076,9 @@ static LRESULT LISTBOX_Paint( LB_DESCR *descr, HDC hdc )
         /* keep the focus rect, to paint the focus item after */
         if (i == descr->focus_item)
             focusRect = rect;
-    
+#ifdef __REACTOS__
+        rect.bottom = min(rect.bottom, descr->height);
+#endif
         LISTBOX_PaintItem( descr, hdc, &rect, i, ODA_DRAWENTIRE, TRUE );
         rect.top = rect.bottom;
 


### PR DESCRIPTION
## Purpose

_Fix 2nd stage setup Acknowledgements listbox and other comctl32 lisboxes._

JIRA issue: [CORE-20062](https://jira.reactos.org/browse/CORE-20062)

## Proposed changes

_@I_Kill_Bugs fix._
_Change rect.bottom calculation in LISTBOX_Paint function in user32 and comctl32._

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=103433,103436 LGTM
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=103434,103437 LGTM

Before:
<img width="818" height="688" alt="ReactOS_Listbox_Before" src="https://github.com/user-attachments/assets/9b29f362-7f0f-4ee0-a2fd-7aa17e39c616" />

After:
<img width="818" height="688" alt="ReactOS_Listbox_After" src="https://github.com/user-attachments/assets/5608526e-c0d2-4ed8-b536-a58a7a9b0b8a" />

Comparison with W2K3SP2:
<img width="938" height="857" alt="W2K3SP2_Listbox1" src="https://github.com/user-attachments/assets/507c6b7d-764c-4fa4-9225-bb8e4ce3de6f" />

## Initial Display Improvements

Before (shows full Line 16):
<img width="1042" height="856" alt="ReactOS_Listbox_Init_Before" src="https://github.com/user-attachments/assets/12f6723b-a768-4bdd-b2a4-c18a86aeb8d9" />

After (shows truncated Line 16):
<img width="1042" height="856" alt="ReactOS_Listbox_Init_After" src="https://github.com/user-attachments/assets/f447ad81-0729-4ba2-9c0c-55e70931fe36" />

W2K3SP2 (shows truncated Line 16):
<img width="938" height="857" alt="W2K3SP2_Listbox_Init" src="https://github.com/user-attachments/assets/5595b910-ae09-422d-83b9-220ff5bb6fd4" />

Before (focus on Line 16):
<img width="1042" height="856" alt="ReactOS_Listbox_Init_Before_Focus16" src="https://github.com/user-attachments/assets/25da7450-c9f9-4831-9579-9532d7c0412b" />

After (focus on Line 16):
<img width="1042" height="856" alt="ReactOS_Listbox_Init_After_Focus16" src="https://github.com/user-attachments/assets/751c8de8-5983-482a-b716-de18888f82f7" />

W2K3SP2 (focus on Line 16):
<img width="938" height="857" alt="W2K3SP2_Listbox_Init_Focus16" src="https://github.com/user-attachments/assets/326a11c5-860c-4922-830b-0aa46b38659d" />