### PR TITLE
[WINLOGON] GetNotificationHandler(): Fix ANSI_NULL handling

### DIFF
--- a/base/system/winlogon/notify.c
+++ b/base/system/winlogon/notify.c
@@ -67,7 +67,7 @@ GetNotificationHandler(
     DWORD dwType, dwSize;
     CHAR szFuncBuffer[128];
 
-    dwSize = sizeof(szFuncBuffer);
+    dwSize = sizeof(szFuncBuffer) - 1;
     lError = RegQueryValueExA(hDllKey,
                               pNotification,
                               NULL,
@@ -81,7 +81,7 @@ GetNotificationHandler(
     }
 
     /* NUL-terminate */
-    szFuncBuffer[dwSize / sizeof(CHAR) - 1] = ANSI_NULL;
+    szFuncBuffer[dwSize] = ANSI_NULL;
 
     return (PWLX_NOTIFY_HANDLER)GetProcAddress(hModule, szFuncBuffer);
 }


### PR DESCRIPTION
## Purpose

Fix ANSI_NULL handling

Addendum to 2cf3f14c50 (0.4.16-dev-1598).
JIRA issue: [CORE-9598](https://jira.reactos.org/browse/CORE-9598)

## Proposed changes

- Reserve last char.