### PR TITLE
[MSGINA][USERENV] Fix initialization of domain-login-related user profile information fields

### DIFF
--- a/dll/win32/userenv/profile.c
+++ b/dll/win32/userenv/profile.c
@@ -2007,7 +2007,7 @@ LoadUserProfileW(
     _Inout_ LPPROFILEINFOW lpProfileInfo)
 {
     WCHAR szUserHivePath[MAX_PATH];
-    DWORD dwLength = _countof(szUserHivePath);
+    DWORD dwLength;
     PTOKEN_USER UserSid = NULL;
     UNICODE_STRING SidString = { 0, 0, NULL };
     HANDLE hProfileMutex = NULL;
@@ -2055,6 +2055,14 @@ LoadUserProfileW(
     {
         DPRINT1("Loading profile %S\n", SidString.Buffer);
 
+        /*
+         * NOTE: lpProfilePath specifies the path to a *roaming* user profile,
+         * for example on a domain server, if any. It is then used to create
+         * a local image (copy) of the profile on the local computer.
+         *
+         * FIXME: We currently don't implement this in ReactOS; instead, we use
+         * it directly as *the* user's profile path, without doing any copy...
+         */
         if (lpProfileInfo->lpProfilePath)
         {
             /* Use the caller's specified roaming user profile path */
@@ -2062,17 +2070,18 @@ LoadUserProfileW(
         }
         else
         {
-            /* FIXME: check if MS Windows allows lpProfileInfo->lpProfilePath to be NULL */
+            /* Build a default user profile path */
+            dwLength = _countof(szUserHivePath);
             if (!GetProfilesDirectoryW(szUserHivePath, &dwLength))
             {
-                DPRINT1("GetProfilesDirectoryW() failed (error %ld)\n", GetLastError());
+                DPRINT1("GetProfilesDirectoryW() failed (Error %ld)\n", GetLastError());
                 goto cleanup;
             }
+            StringCbCatW(szUserHivePath, sizeof(szUserHivePath), L"\\");
+            StringCbCatW(szUserHivePath, sizeof(szUserHivePath), lpProfileInfo->lpUserName);
         }
 
         /* Create user hive name */
-        StringCbCatW(szUserHivePath, sizeof(szUserHivePath), L"\\");
-        StringCbCatW(szUserHivePath, sizeof(szUserHivePath), lpProfileInfo->lpUserName);
         StringCbCatW(szUserHivePath, sizeof(szUserHivePath), L"\\ntuser.dat");
         DPRINT("szUserHivePath: %S\n", szUserHivePath);
 


### PR DESCRIPTION
## Purpose

Some returned strings, pertaining to user login on domains (Active Directory...), were initialized by MSGINA with unrealistic values. This is fixed in this commit.

## Proposed changes

- ### `[MSGINA] CreateProfile(): Fix initialization of some `WLX_PROFILE_V2_0` members`

The following members of the returned `WLX_PROFILE_V2_0` structure: `pszProfile`, `pszPolicy`, `pszNetworkDefaultUserProfile`, and `pszServerName`, have a specific meaning and are used when logging to (NT4, Active Directory...) domains.
See the added code comments for details.

In particular, `pszProfile` specifies the path to a *roaming* user profile[^1] on a domain server, if any. It **DOES NOT** specify the local `"C:\Documents and Settings"` path (got via `GetProfilesDirectoryW()`).

Since we don't really support user login on domains, set these pointers to NULL.

----

Enabling UserEnv debug logging[^2] on Windows 2003, one can observe such following traces, for a `TestUser` roaming user profile:
```
USERENV(148.14c) 20:24:59:821 LoadUserProfile: Entering, hToken = <0x8bc>, lpProfileInfo = 0x6e5d8
USERENV(148.14c) 20:24:59:875 LoadUserProfile: lpProfileInfo->dwFlags = <0x0>
USERENV(148.14c) 20:24:59:912 LoadUserProfile: lpProfileInfo->lpUserName = <TestUser>
USERENV(148.14c) 20:24:59:966 LoadUserProfile: lpProfileInfo->lpProfilePath = <C:\Documents and Settings\TestUser_Roaming>
USERENV(148.14c) 20:25:00:021 LoadUserProfile: lpProfileInfo->lpDefaultPath = <\\PC-H\netlogon\Default User>
USERENV(148.14c) 20:25:00:075 LoadUserProfile: NULL server name
...
USERENV(148.14c) 20:25:06:177 CopyProfileDirectoryEx: Found hive file NTUSER.DAT
USERENV(148.14c) 20:25:06:395 ReconcileFile: C:\Documents and Settings\TestUser_Roaming\NTUSER.DAT ==> C:\Documents and Settings\TestUser\NTUSER.DAT  [OK]
...
```
The `lpProfilePath` specifies a roaming profile directory (`"TestUser_Roaming"`) for a user named named `TestUser`, and UserEnv proceeds to image the roaming profile into the directory (`"TestUser"`) in the local computer.

However, when the user has a local profile, the `lpProfilePath` is set to NULL in this case, and one observes instead:
```
USERENV(148.14c) 20:21:22:644 LoadUserProfile: NULL central profile path
```

[^1]: The following links explain this, also demonstrating UserEnv debug logging:
    - https://web.archive.org/web/20130319204738/http://blogs.technet.com/b/askds/archive/2008/11/11/understanding-how-to-read-a-userenv-log-part-2.aspx
    - https://web.archive.org/web/20150405040409/http://blogs.technet.com/b/ad/archive/2007/08/20/tracking-user-environment-creation.aspx

[^2]: For more details, see:
  https://www.betaarchive.com/wiki/index.php?title=Microsoft_KB_Archive/221833
  (archived from: http://support.microsoft.com/kb/221833)
  UserEnv debug logging is achieved by adding a `REG_DWORD` value named `UserEnvDebugLevel` in the following registry sub-key:
  `HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon`
  with a non-zero value.
  To view the output in a debugger (e.g. WinDbg when kernel-debugging Windows), set the value to `0x00020002`.


- ### `[USERENV] LoadUserProfileW(): Improve handling of lpProfileInfo->lpProfilePath`

  * As mentioned in the previous MSGINA commit, `lpProfilePath` specifies the path to a *roaming* user profile, for example on a domain server, if any. It is then used to create a local image (copy) of the profile on the local computer.

    HOWEVER (ReactOS HACK):
    We currently don't implement this in ReactOS; instead, we use it directly as *the* user's profile path, without doing any copy...

  * Yes, MS Windows allows `lpProfileInfo->lpProfilePath` to be NULL :)


## _Supplement: Dumping the output variables initialized by the `WlxLoggedOutSAS()` call on Windows:_
Based on our call implementation:
https://github.com/reactos/reactos/blob/96249c12d96f1fb29fd8a4da5f54197122160157/base/system/winlogon/sas.c#L1308-L1316
- Variables:
```
&Profile == 0x6f8d8		--> Profile == ??*(void**)(0x6f8d8) == 0x0116ff10
&MprNotifyInfo == 0x6f8b0
&UserToken == 0x6f8cc
&Options == 0x6f8c8
LogonSid == 0006f8d0 -> 000897c8
&LogonId == 0x7c5d0
SASAction == 0006f8d4 -> 00000001
Context == 0006f8c4 -> 00fa3fb0
```
- Values when login with user name == "Administrateur" (and computer name == "PC-H"):
```
0: kd> ??(msgina!_WLX_MPR_NOTIFY_INFO*)0x6f8b0
struct _WLX_MPR_NOTIFY_INFO * 0x0006f8b0
   +0x000 pszUserName      : 0x00fcf530  "Administrateur"
   +0x004 pszDomain        : 0x000cf8e8  "PC-H"
   +0x008 pszPassword      : 0x00faa9d0  ""
   +0x00c pszOldPassword   : (null) 

0: kd> ??*(msgina!_WLX_PROFILE_V2_0**)0x6f8d8
struct _WLX_PROFILE_V2_0 * 0x00fccf08
   +0x000 dwType           : 2
   +0x004 pszProfile       : (null) 
   +0x008 pszPolicy        : (null) 
   +0x00c pszNetworkDefaultUserProfile : (null) 
   +0x010 pszServerName    : (null) 
   +0x014 pszEnvironment   : 0x00fab7d8  "LOGONSERVER=\\PC-H"

0: kd> dW @@((*(msgina!_WLX_PROFILE_V2_0**)0x6f8d8)->pszEnvironment)
00fab7d8  004c 004f 0047 004f 004e 0053 0045 0052  L.O.G.O.N.S.E.R.
00fab7e8  0056 0045 0052 003d 005c 005c 0050 0043  V.E.R.=.\.\.P.C.
00fab7f8  002d 0048 0000 0055 0053 0045 0052 0044  -.H...U.S.E.R.D.
00fab808  004e 0053 0044 004f 004d 0041 0049 004e  N.S.D.O.M.A.I.N.
00fab818  003d 005c 004e 0054 0034 0000 0043 004c  =.\.N.T.4...C.L.
00fab828  0049 0045 004e 0054 004e 0041 004d 0045  I.E.N.T.N.A.M.E.
00fab838  003d 0000 0000 0000 0000 0000 0000 0000  =...............
00fab848  0000 0000 0000 0000 00c4 0010 016e 0108  ............n...
```
- Values when login with user name == "<domain_name>\Administrateur" using any random "domain_name" (and computer name == "PC-H"):
```
1: kd> ??(msgina!_WLX_MPR_NOTIFY_INFO*)0x6f8b0
struct _WLX_MPR_NOTIFY_INFO * 0x0006f8b0
   +0x000 pszUserName      : 0x00fa9308  "Administrateur"
   +0x004 pszDomain        : 0x00f9f738  "PC-H"
   +0x008 pszPassword      : 0x00fa07d0  ""
   +0x00c pszOldPassword   : (null) 

1: kd> ??*(msgina!_WLX_PROFILE_V2_0**)0x6f8d8
struct _WLX_PROFILE_V2_0 * 0x00f9f5f8
   +0x000 dwType           : 2
   +0x004 pszProfile       : (null) 
   +0x008 pszPolicy        : 0x00f9e638  "\\PC-H\netlogon\ntconfig.pol"
   +0x00c pszNetworkDefaultUserProfile : 0x00f9ea58  "\\PC-H\netlogon\Default User"
   +0x010 pszServerName    : 0x00085228  "\\PC-H"
   +0x014 pszEnvironment   : 0x00f9b030  "LOGONSERVER=\\PC-H"

1: kd> dW @@((*(msgina!_WLX_PROFILE_V2_0**)0x6f8d8)->pszEnvironment)
00f9b030  004c 004f 0047 004f 004e 0053 0045 0052  L.O.G.O.N.S.E.R.
00f9b040  0056 0045 0052 003d 005c 005c 0050 0043  V.E.R.=.\.\.P.C.
00f9b050  002d 0048 0000 0055 0053 0045 0052 0044  -.H...U.S.E.R.D.
00f9b060  004e 0053 0044 004f 004d 0041 0049 004e  N.S.D.O.M.A.I.N.
00f9b070  003d 005c 004e 0054 0034 0000 0043 004c  =.\.N.T.4...C.L.
00f9b080  0049 0045 004e 0054 004e 0041 004d 0045  I.E.N.T.N.A.M.E.
00f9b090  003d 0000 0000 0000 0000 0000 0000 0000  =...............
00f9b0a0  0000 0000 0000 0000 00c4 0010 018a 0108  ................
```

## TODO

- [ ] Fix the quoted commit hash in the log of the second commit, before merging!!
