### PR TITLE
[KERNEL32] GetStartupInfoA(): Check other thread result at the latest

### DIFF
--- a/dll/win32/kernel32/client/procansi.c
+++ b/dll/win32/kernel32/client/procansi.c
@@ -287,8 +287,6 @@ GetStartupInfoA(IN LPSTARTUPINFOA lpStartupInfo)
                         }
 
                         /* Someone beat us to it, we will use their data instead */
-                        Status = STATUS_SUCCESS;
-
                         /* We're going to free our own stuff, but not raise */
                         RtlFreeAnsiString(&TitleString);
                     }
@@ -297,9 +295,6 @@ GetStartupInfoA(IN LPSTARTUPINFOA lpStartupInfo)
                 RtlFreeAnsiString(&ShellString);
             }
             RtlFreeHeap(RtlGetProcessHeap(), 0, StartupInfo);
-
-            /* Get the cached information again: either still NULL or set by another thread */
-            StartupInfo = BaseAnsiStartupInfo;
         }
         else
         {
@@ -307,8 +302,12 @@ GetStartupInfoA(IN LPSTARTUPINFOA lpStartupInfo)
             Status = STATUS_NO_MEMORY;
         }
 
-        /* Raise an error unless we got here due to the race condition */
-        if (!StartupInfo) RtlRaiseStatus(Status);
+        /* Raise an error if there is no cached information */
+        if (!BaseAnsiStartupInfo)
+            RtlRaiseStatus(Status);
+
+        /* Get the cached information again: set by another thread */
+        StartupInfo = BaseAnsiStartupInfo;
     }
 
     /* Now copy from the cached ANSI version */


### PR DESCRIPTION
## Purpose

Give a bit more time to succeed.

Follow-up to 4f61d2ea04 (0.4.16-dev-1610).

## Proposed changes

- Remove a remnant assignment.
- Check the interesting variable itself and as late as possible.

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=107435,107445
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=107436,107446