### PR TITLE
[SETUPLIB] Fix system partition selection DPRINTs

### DIFF
--- a/base/setup/lib/utils/partlist.c
+++ b/base/setup/lib/utils/partlist.c
@@ -3438,7 +3438,8 @@ UseAlternativeDisk:
             DPRINT1("Use new first active system partition %lu in disk %lu, drive letter %C\n",
                     CandidatePartition->PartitionNumber,
                     CandidatePartition->DiskEntry->DiskNumber,
-                    !CandidatePartition->Volume->Info.DriveLetter ? L'-' : CandidatePartition->Volume->Info.DriveLetter);
+                    (!CandidatePartition->Volume || !CandidatePartition->Volume->Info.DriveLetter) ?
+                    L'-' : CandidatePartition->Volume->Info.DriveLetter);
 
             /* Return the candidate system partition */
             return CandidatePartition;
@@ -3478,7 +3479,8 @@ UseAlternativeDisk:
         DPRINT1("Use first active system partition %lu in disk %lu, drive letter %C\n",
                 CandidatePartition->PartitionNumber,
                 CandidatePartition->DiskEntry->DiskNumber,
-                !CandidatePartition->Volume->Info.DriveLetter ? L'-' : CandidatePartition->Volume->Info.DriveLetter);
+                (!CandidatePartition->Volume || !CandidatePartition->Volume->Info.DriveLetter) ?
+                L'-' : CandidatePartition->Volume->Info.DriveLetter);
 
         /* Return the candidate system partition */
         return CandidatePartition;
@@ -3516,7 +3518,8 @@ UseAlternativePartition:
     DPRINT1("Use alternative active system partition %lu in disk %lu, drive letter %C\n",
             CandidatePartition->PartitionNumber,
             CandidatePartition->DiskEntry->DiskNumber,
-            !CandidatePartition->Volume->Info.DriveLetter ? L'-' : CandidatePartition->Volume->Info.DriveLetter);
+            (!CandidatePartition->Volume || !CandidatePartition->Volume->Info.DriveLetter) ?
+            L'-' : CandidatePartition->Volume->Info.DriveLetter);
 
     /* Return the candidate system partition */
     return CandidatePartition;


### PR DESCRIPTION
Some partition entries (such as those added by the CreateInsertBlankRegion function) may not have their Volume member allocated. This fixes the USETUP crash when such partitions are handled.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: