### PR TITLE
[MSGINA][WINLOGON] Dialogs usability fixes + fix the dialogs SetFocus() calls

### DIFF
--- a/base/system/winlogon/lang/bg-BG.rc
+++ b/base/system/winlogon/lang/bg-BG.rc
@@ -17,7 +17,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "БДС (DLL) за потребителско влизане %s не се зареди.", IDC_GINALOADFAILED, 39, 16, 156, 24
     LTEXT "Свържете се със системният си управник, за да смени БДС (DLL) или да възстанови първоначалната такава.", IDC_GINALOADFAILEDCONTACT, 39, 53, 151, 25
-    DEFPUSHBUTTON "Пре&запуск", 1, 80, 91, 68, 14
+    DEFPUSHBUTTON "Пре&запуск", IDOK, 80, 91, 68, 14
 END
 
 IDD_SYSSHUTDOWN DIALOGEX 50, 50, 180, 140
@@ -26,10 +26,10 @@ CAPTION "System Shutdown"
 FONT 8, "MS Shell Dlg"
 BEGIN
     ICON IDI_WARNING, IDC_SYSSHUTDOWNICON, 6, 7, 18, 20
-    LTEXT "A system shutdown has been initiated. Please save all your work and terminate your session. All unsaved work will be lost when the system shuts down.", -1, 38, 7, 135, 40
-    LTEXT "The system shuts down in:", -1, 38, 50, 90, 8
+    LTEXT "A system shutdown has been initiated. Please save all your work and terminate your session. All unsaved work will be lost when the system shuts down.", IDC_STATIC, 38, 7, 135, 40
+    LTEXT "The system shuts down in:", IDC_STATIC, 38, 50, 90, 8
     LTEXT "00:00:00", IDC_SYSSHUTDOWNTIMELEFT, 132, 50, 41, 8
-    LTEXT "Message:", -1, 38, 65, 135, 8
+    LTEXT "Message:", IDC_STATIC, 38, 65, 135, 8
     EDITTEXT IDC_SYSSHUTDOWNMESSAGE, 34, 75, 139, 58, ES_LEFT | ES_MULTILINE | ES_AUTOVSCROLL | ES_READONLY | NOT WS_BORDER | NOT WS_TABSTOP, WS_EX_STATICEDGE
 END
 

--- a/base/system/winlogon/lang/cs-CZ.rc
+++ b/base/system/winlogon/lang/cs-CZ.rc
@@ -26,7 +26,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "Dynamická knihovna %s selhala při nahrávání.", IDC_GINALOADFAILED, 39, 16, 156, 24
     LTEXT "Kontaktujte správce počítače pro nahrazení dynamickě knihovny nebo obnovte původní dynamickou knihovnu.", IDC_GINALOADFAILEDCONTACT, 39, 53, 151, 25
-    DEFPUSHBUTTON "&Restart", 1, 80, 91, 68, 14
+    DEFPUSHBUTTON "&Restartovat", IDOK, 80, 91, 68, 14
 END
 
 IDD_SYSSHUTDOWN DIALOGEX 50, 50, 180, 140
@@ -35,10 +35,10 @@ CAPTION "Vypínání systému"
 FONT 8, "MS Shell Dlg"
 BEGIN
     ICON IDI_WARNING, IDC_SYSSHUTDOWNICON, 6, 7, 18, 20
-    LTEXT "Byl zahájen proces vypínání systému. Uložte prosím svoji práci a ukončete sezení. Veškerá neuložená data budou po vypnutí systému ztracena.", -1, 38, 7, 135, 40
-    LTEXT "Systém se vypne za:", -1, 38, 50, 90, 8
+    LTEXT "Byl zahájen proces vypínání systému. Uložte prosím svoji práci a ukončete sezení. Veškerá neuložená data budou po vypnutí systému ztracena.", IDC_STATIC, 38, 7, 135, 40
+    LTEXT "Systém se vypne za:", IDC_STATIC, 38, 50, 90, 8
     LTEXT "00:00:00", IDC_SYSSHUTDOWNTIMELEFT, 132, 50, 41, 8
-    LTEXT "Zpráva:", -1, 38, 65, 135, 8
+    LTEXT "Zpráva:", IDC_STATIC, 38, 65, 135, 8
     EDITTEXT IDC_SYSSHUTDOWNMESSAGE, 34, 75, 139, 58, ES_LEFT | ES_MULTILINE | ES_AUTOVSCROLL | ES_READONLY | NOT WS_BORDER | NOT WS_TABSTOP, WS_EX_STATICEDGE
 END
 

--- a/base/system/winlogon/lang/de-DE.rc
+++ b/base/system/winlogon/lang/de-DE.rc
@@ -19,7 +19,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "Die DLL %s konnte nicht geladen werden.", IDC_GINALOADFAILED, 39, 16, 156, 24
     LTEXT "Kontaktieren Sie Ihren Systemadministrator, um die Datei zu ersetzen, oder stellen Sie die Originaldatei wieder her.", IDC_GINALOADFAILEDCONTACT, 39, 53, 151, 25
-    DEFPUSHBUTTON "Neusta&rt", 1, 80, 91, 68, 14
+    DEFPUSHBUTTON "Neusta&rt", IDOK, 80, 91, 68, 14
 END
 
 IDD_SYSSHUTDOWN DIALOGEX 50, 50, 180, 140
@@ -28,10 +28,10 @@ CAPTION "System Shutdown"
 FONT 8, "MS Shell Dlg"
 BEGIN
     ICON IDI_WARNING, IDC_SYSSHUTDOWNICON, 6, 7, 18, 20
-    LTEXT "Das System wird heruntergefahren. Speichern Sie alle Daten und melden Sie sich ab. Alle nicht gespeicherten Änderungen gehen verloren.", -1, 38, 7, 135, 40
-    LTEXT "Zeit bis zum Herunterfahren:", -1, 38, 50, 93, 8
+    LTEXT "Das System wird heruntergefahren. Speichern Sie alle Daten und melden Sie sich ab. Alle nicht gespeicherten Änderungen gehen verloren.", IDC_STATIC, 38, 7, 135, 40
+    LTEXT "Zeit bis zum Herunterfahren:", IDC_STATIC, 38, 50, 93, 8
     LTEXT "00:00:00", IDC_SYSSHUTDOWNTIMELEFT, 132, 50, 41, 8
-    LTEXT "Meldung:", -1, 38, 65, 135, 8
+    LTEXT "Meldung:", IDC_STATIC, 38, 65, 135, 8
     EDITTEXT IDC_SYSSHUTDOWNMESSAGE, 34, 75, 139, 58, ES_LEFT | ES_MULTILINE | ES_AUTOVSCROLL | ES_READONLY | NOT WS_BORDER | NOT WS_TABSTOP, WS_EX_STATICEDGE
 END
 

--- a/base/system/winlogon/lang/el-GR.rc
+++ b/base/system/winlogon/lang/el-GR.rc
@@ -17,7 +17,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "Η Logon  Διεπαφή Χρήστη DLL %s απέτυχε να φορτωθεί.", IDC_GINALOADFAILED, 39, 16, 156, 24
     LTEXT "Επικοινωνείστε με τον διαχειριστή του συστήματός σας για να αντικαταστήσει το DLL, ή να επαναφέρει το αρχικό DLL.", IDC_GINALOADFAILEDCONTACT, 39, 53, 151, 25
-    DEFPUSHBUTTON "&Restart", 1, 80, 91, 68, 14
+    DEFPUSHBUTTON "&Επανεκκίνηση", IDOK, 80, 91, 68, 14
 END
 
 IDD_SYSSHUTDOWN DIALOGEX 50, 50, 180, 140
@@ -26,10 +26,10 @@ CAPTION "System Shutdown"
 FONT 8, "MS Shell Dlg"
 BEGIN
     ICON IDI_WARNING, IDC_SYSSHUTDOWNICON, 6, 7, 18, 20
-    LTEXT "A system shutdown has been initiated. Please save all your work and terminate your session. All unsaved work will be lost when the system shuts down.", -1, 38, 7, 135, 40
-    LTEXT "The system shuts down in:", -1, 38, 50, 90, 8
+    LTEXT "A system shutdown has been initiated. Please save all your work and terminate your session. All unsaved work will be lost when the system shuts down.", IDC_STATIC, 38, 7, 135, 40
+    LTEXT "The system shuts down in:", IDC_STATIC, 38, 50, 90, 8
     LTEXT "00:00:00", IDC_SYSSHUTDOWNTIMELEFT, 132, 50, 41, 8
-    LTEXT "Message:", -1, 38, 65, 135, 8
+    LTEXT "Message:", IDC_STATIC, 38, 65, 135, 8
     EDITTEXT IDC_SYSSHUTDOWNMESSAGE, 34, 75, 139, 58, ES_LEFT | ES_MULTILINE | ES_AUTOVSCROLL | ES_READONLY | NOT WS_BORDER | NOT WS_TABSTOP, WS_EX_STATICEDGE
 END
 

--- a/base/system/winlogon/lang/en-US.rc
+++ b/base/system/winlogon/lang/en-US.rc
@@ -17,7 +17,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "The Logon User Interface DLL %s failed to load.", IDC_GINALOADFAILED, 39, 16, 156, 24
     LTEXT "Contact your system administrator to replace the DLL, or restore the original DLL.", IDC_GINALOADFAILEDCONTACT, 39, 53, 151, 25
-    DEFPUSHBUTTON "&Restart", 1, 80, 91, 68, 14
+    DEFPUSHBUTTON "&Restart", IDOK, 80, 91, 68, 14
 END
 
 IDD_SYSSHUTDOWN DIALOGEX 50, 50, 180, 140
@@ -26,10 +26,10 @@ CAPTION "System Shutdown"
 FONT 8, "MS Shell Dlg"
 BEGIN
     ICON IDI_WARNING, IDC_SYSSHUTDOWNICON, 6, 7, 18, 20
-    LTEXT "A system shutdown has been initiated. Please save all your work and terminate your session. All unsaved work will be lost when the system shuts down.", -1, 38, 7, 135, 40
-    LTEXT "The system shuts down in:", -1, 38, 50, 90, 8
+    LTEXT "A system shutdown has been initiated. Please save all your work and terminate your session. All unsaved work will be lost when the system shuts down.", IDC_STATIC, 38, 7, 135, 40
+    LTEXT "The system shuts down in:", IDC_STATIC, 38, 50, 90, 8
     LTEXT "00:00:00", IDC_SYSSHUTDOWNTIMELEFT, 132, 50, 41, 8
-    LTEXT "Message:", -1, 38, 65, 135, 8
+    LTEXT "Message:", IDC_STATIC, 38, 65, 135, 8
     EDITTEXT IDC_SYSSHUTDOWNMESSAGE, 34, 75, 139, 58, ES_LEFT | ES_MULTILINE | ES_AUTOVSCROLL | ES_READONLY | NOT WS_BORDER | NOT WS_TABSTOP, WS_EX_STATICEDGE
 END
 

--- a/base/system/winlogon/lang/es-ES.rc
+++ b/base/system/winlogon/lang/es-ES.rc
@@ -19,7 +19,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "La DLL %s de la interfaz de inicio de sesión dio un error al cargar.", IDC_GINALOADFAILED, 39, 16, 156, 24
     LTEXT "Contacte con el administrador de su sistema para sustituir la librería DLL, o reinstale la DLL original.", IDC_GINALOADFAILEDCONTACT, 39, 53, 151, 25
-    DEFPUSHBUTTON "&Reiniciar", 1, 80, 91, 68, 14
+    DEFPUSHBUTTON "&Reiniciar", IDOK, 80, 91, 68, 14
 END
 
 IDD_SYSSHUTDOWN DIALOGEX 50, 50, 180, 140
@@ -28,10 +28,10 @@ CAPTION "Apagar el Sistema"
 FONT 8, "MS Shell Dlg"
 BEGIN
     ICON IDI_WARNING, IDC_SYSSHUTDOWNICON, 6, 7, 18, 20
-    LTEXT "Se ha iniciado el apagado del sistema. Por favor, guarda todo tu trabajo y cierra la sesión. Se perderá todo el trabajo no guardado.", -1, 38, 7, 135, 40
-    LTEXT "El sistema se apagará en:", -1, 38, 50, 90, 8
+    LTEXT "Se ha iniciado el apagado del sistema. Por favor, guarda todo tu trabajo y cierra la sesión. Se perderá todo el trabajo no guardado.", IDC_STATIC, 38, 7, 135, 40
+    LTEXT "El sistema se apagará en:", IDC_STATIC, 38, 50, 90, 8
     LTEXT "00:00:00", IDC_SYSSHUTDOWNTIMELEFT, 132, 50, 41, 8
-    LTEXT "Mensaje:", -1, 38, 65, 135, 8
+    LTEXT "Mensaje:", IDC_STATIC, 38, 65, 135, 8
     EDITTEXT IDC_SYSSHUTDOWNMESSAGE, 34, 75, 139, 58, ES_LEFT | ES_MULTILINE | ES_AUTOVSCROLL | ES_READONLY | NOT WS_BORDER | NOT WS_TABSTOP, WS_EX_STATICEDGE
 END
 

--- a/base/system/winlogon/lang/eu-ES.rc
+++ b/base/system/winlogon/lang/eu-ES.rc
@@ -24,7 +24,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "La DLL %s del interfaz de Logon dió un error al cargar.", IDC_GINALOADFAILED, 39, 16, 156, 24
     LTEXT "Contacte con el administrador de su sistema para sustituir la DLL, ó reinstale la DLL original.", IDC_GINALOADFAILEDCONTACT, 39, 53, 151, 25
-    DEFPUSHBUTTON "&Berrabiarazi", 1, 80, 91, 68, 14
+    DEFPUSHBUTTON "&Berrabiarazi", IDOK, 80, 91, 68, 14
 END
 
 IDD_SYSSHUTDOWN DIALOGEX 50, 50, 180, 140
@@ -33,10 +33,10 @@ CAPTION "Itzali Sistema"
 FONT 8, "MS Shell Dlg"
 BEGIN
     ICON IDI_WARNING, IDC_SYSSHUTDOWNICON, 6, 7, 18, 20
-    LTEXT "Se ha iniciado el apagado del sistema. Por favor, guarda todo tu trabajo y cierra la sesión. Se perderá todo el trabajo no guardado.", -1, 38, 7, 135, 40
-    LTEXT "El sistema se apagará en:", -1, 38, 50, 90, 8
+    LTEXT "Se ha iniciado el apagado del sistema. Por favor, guarda todo tu trabajo y cierra la sesión. Se perderá todo el trabajo no guardado.", IDC_STATIC, 38, 7, 135, 40
+    LTEXT "El sistema se apagará en:", IDC_STATIC, 38, 50, 90, 8
     LTEXT "00:00:00", IDC_SYSSHUTDOWNTIMELEFT, 132, 50, 41, 8
-    LTEXT "Mensaje:", -1, 38, 65, 135, 8
+    LTEXT "Mensaje:", IDC_STATIC, 38, 65, 135, 8
     EDITTEXT IDC_SYSSHUTDOWNMESSAGE, 34, 75, 139, 58, ES_LEFT | ES_MULTILINE | ES_AUTOVSCROLL | ES_READONLY | NOT WS_BORDER | NOT WS_TABSTOP, WS_EX_STATICEDGE
 END
 

--- a/base/system/winlogon/lang/fr-FR.rc
+++ b/base/system/winlogon/lang/fr-FR.rc
@@ -19,7 +19,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "Le chargement du DLL %s de l'interface utilisateur a échoué.", IDC_GINALOADFAILED, 39, 16, 156, 24
     LTEXT "Contactez votre administrateur système pour remplacer la DLL, ou restaurez la DLL originale.", IDC_GINALOADFAILEDCONTACT, 39, 53, 151, 25
-    DEFPUSHBUTTON "&Redémarrer", 1, 80, 91, 68, 14
+    DEFPUSHBUTTON "&Redémarrer", IDOK, 80, 91, 68, 14
 END
 
 IDD_SYSSHUTDOWN DIALOGEX 50, 50, 180, 140
@@ -28,10 +28,10 @@ CAPTION "Arrêt du système"
 FONT 8, "MS Shell Dlg"
 BEGIN
     ICON IDI_WARNING, IDC_SYSSHUTDOWNICON, 6, 7, 18, 20
-    LTEXT "Un arrêt du système a été initié. Veuillez enregistrer tous les travaux en cours et quitter votre session. Toutes les modifications non enregistrées seront perdues.", -1, 38, 7, 135, 40
-    LTEXT "Le système s'arrête dans :", -1, 38, 50, 90, 8
+    LTEXT "Un arrêt du système a été initié. Veuillez enregistrer tous les travaux en cours et quitter votre session. Toutes les modifications non enregistrées seront perdues.", IDC_STATIC, 38, 7, 135, 40
+    LTEXT "Le système s'arrête dans :", IDC_STATIC, 38, 50, 90, 8
     LTEXT "00:00:00", IDC_SYSSHUTDOWNTIMELEFT, 132, 50, 41, 8
-    LTEXT "Message :", -1, 38, 65, 135, 8
+    LTEXT "Message :", IDC_STATIC, 38, 65, 135, 8
     EDITTEXT IDC_SYSSHUTDOWNMESSAGE, 34, 75, 139, 58, ES_LEFT | ES_MULTILINE | ES_AUTOVSCROLL | ES_READONLY | NOT WS_BORDER | NOT WS_TABSTOP, WS_EX_STATICEDGE
 END
 

--- a/base/system/winlogon/lang/he-IL.rc
+++ b/base/system/winlogon/lang/he-IL.rc
@@ -19,7 +19,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "ספריית הקישור הדינאמי %s של ממשק ההתחברות נכשלה להטען.", IDC_GINALOADFAILED, 39, 16, 156, 24
     LTEXT "פנה אל מנהל המערכת שלך כדי להחליף את הDLL, או תשחזר את הDLL המקורי.", IDC_GINALOADFAILEDCONTACT, 39, 53, 151, 25
-    DEFPUSHBUTTON "הפעל מחדש", 1, 80, 91, 68, 14
+    DEFPUSHBUTTON "הפעל מחדש", IDOK, 80, 91, 68, 14
 END
 
 IDD_SYSSHUTDOWN DIALOGEX 50, 50, 180, 140
@@ -28,10 +28,10 @@ CAPTION "System Shutdown"
 FONT 8, "MS Shell Dlg"
 BEGIN
     ICON IDI_WARNING, IDC_SYSSHUTDOWNICON, 6, 7, 18, 20
-    LTEXT "A system shutdown has been initiated. Please save all your work and terminate your session. All unsaved work will be lost when the system shuts down.", -1, 38, 7, 135, 40
-    LTEXT "The system shuts down in:", -1, 38, 50, 90, 8
+    LTEXT "A system shutdown has been initiated. Please save all your work and terminate your session. All unsaved work will be lost when the system shuts down.", IDC_STATIC, 38, 7, 135, 40
+    LTEXT "The system shuts down in:", IDC_STATIC, 38, 50, 90, 8
     LTEXT "00:00:00", IDC_SYSSHUTDOWNTIMELEFT, 132, 50, 41, 8
-    LTEXT "Message:", -1, 38, 65, 135, 8
+    LTEXT "Message:", IDC_STATIC, 38, 65, 135, 8
     EDITTEXT IDC_SYSSHUTDOWNMESSAGE, 34, 75, 139, 58, ES_LEFT | ES_MULTILINE | ES_AUTOVSCROLL | ES_READONLY | NOT WS_BORDER | NOT WS_TABSTOP, WS_EX_STATICEDGE
 END
 

--- a/base/system/winlogon/lang/hu-HU.rc
+++ b/base/system/winlogon/lang/hu-HU.rc
@@ -19,7 +19,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "A Felhasználó beléptetését kezelő DLL (%s) nem tudott betöltődni.", IDC_GINALOADFAILED, 39, 16, 156, 24
     LTEXT "Értesítse a rendszergazdát, hogy javítsa ki a DLL állományt.", IDC_GINALOADFAILEDCONTACT, 39, 53, 151, 25
-    DEFPUSHBUTTON "&Újraindítás", 1, 80, 91, 68, 14
+    DEFPUSHBUTTON "&Újraindítás", IDOK, 80, 91, 68, 14
 END
 
 IDD_SYSSHUTDOWN DIALOGEX 50, 50, 180, 140
@@ -28,10 +28,10 @@ CAPTION "A rendszer leállítása"
 FONT 8, "MS Shell Dlg"
 BEGIN
     ICON IDI_WARNING, IDC_SYSSHUTDOWNICON, 6, 7, 18, 20
-    LTEXT "A rendszer leállítását kezdeményezték. Kérjük mentse el az összes folyamatban lévő munkáját és jelentkezzen ki a munkamenetből. Minden nem mentett módosítás elvész.", -1, 38, 7, 135, 40
-    LTEXT "A rendszer ennyi idő múlva leáll:", -1, 38, 50, 90, 8
+    LTEXT "A rendszer leállítását kezdeményezték. Kérjük mentse el az összes folyamatban lévő munkáját és jelentkezzen ki a munkamenetből. Minden nem mentett módosítás elvész.", IDC_STATIC, 38, 7, 135, 40
+    LTEXT "A rendszer ennyi idő múlva leáll:", IDC_STATIC, 38, 50, 90, 8
     LTEXT "00:00:00", IDC_SYSSHUTDOWNTIMELEFT, 132, 50, 41, 8
-    LTEXT "Üzenet:", -1, 38, 65, 135, 8
+    LTEXT "Üzenet:", IDC_STATIC, 38, 65, 135, 8
     EDITTEXT IDC_SYSSHUTDOWNMESSAGE, 34, 75, 139, 58, ES_LEFT | ES_MULTILINE | ES_AUTOVSCROLL | ES_READONLY | NOT WS_BORDER | NOT WS_TABSTOP, WS_EX_STATICEDGE
 END
 

--- a/base/system/winlogon/lang/id-ID.rc
+++ b/base/system/winlogon/lang/id-ID.rc
@@ -19,7 +19,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "DLL Antarmuka Masuk Pengguna %s gagal diambil.", IDC_GINALOADFAILED, 39, 16, 156, 24
     LTEXT "Hubungi administrator sistem anda untuk mengganti DLL, atau mengembalikan DLL aslinya.", IDC_GINALOADFAILEDCONTACT, 39, 53, 151, 25
-    DEFPUSHBUTTON "&Mulai Lagi", 1, 80, 91, 68, 14
+    DEFPUSHBUTTON "&Mulai Ulang", IDOK, 80, 91, 68, 14
 END
 
 IDD_SYSSHUTDOWN DIALOGEX 50, 50, 180, 140
@@ -28,10 +28,10 @@ CAPTION "Menonaktifkan Sistem"
 FONT 8, "MS Shell Dlg"
 BEGIN
     ICON IDI_WARNING, IDC_SYSSHUTDOWNICON, 6, 7, 18, 20
-    LTEXT "Menonaktifkan sistem telah dimulai. Mohon simpan semua pekerjaan dan menghentikan sesi. Semua pekerjaan yang belum tersimpan akan hilang ketika sistem dinonaktifkan.", -1, 38, 7, 135, 40
-    LTEXT "Menonaktifkan sistem dalam waktu:", -1, 38, 50, 90, 8
+    LTEXT "Menonaktifkan sistem telah dimulai. Mohon simpan semua pekerjaan dan menghentikan sesi. Semua pekerjaan yang belum tersimpan akan hilang ketika sistem dinonaktifkan.", IDC_STATIC, 38, 7, 135, 40
+    LTEXT "Menonaktifkan sistem dalam waktu:", IDC_STATIC, 38, 50, 90, 8
     LTEXT "00:00:00", IDC_SYSSHUTDOWNTIMELEFT, 132, 50, 41, 8
-    LTEXT "Pesan:", -1, 38, 65, 135, 8
+    LTEXT "Pesan:", IDC_STATIC, 38, 65, 135, 8
     EDITTEXT IDC_SYSSHUTDOWNMESSAGE, 34, 75, 139, 58, ES_LEFT | ES_MULTILINE | ES_AUTOVSCROLL | ES_READONLY | NOT WS_BORDER | NOT WS_TABSTOP, WS_EX_STATICEDGE
 END
 

--- a/base/system/winlogon/lang/it-IT.rc
+++ b/base/system/winlogon/lang/it-IT.rc
@@ -17,7 +17,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "La DLL  %s per il Logon dell utente non si e' caricata.", IDC_GINALOADFAILED, 39, 16, 156, 24
     LTEXT "Contattare l'amministratore del sistema per sostituire la DLL o per ripristinare quella originale.", IDC_GINALOADFAILEDCONTACT, 39, 53, 151, 25
-    DEFPUSHBUTTON "&Riavvio", 1, 80, 91, 68, 14
+    DEFPUSHBUTTON "&Riavvio", IDOK, 80, 91, 68, 14
 END
 
 IDD_SYSSHUTDOWN DIALOGEX 50, 50, 180, 140
@@ -26,10 +26,10 @@ CAPTION "System Shutdown"
 FONT 8, "MS Shell Dlg"
 BEGIN
     ICON IDI_WARNING, IDC_SYSSHUTDOWNICON, 6, 7, 18, 20
-    LTEXT "È stato inizializzato uno spegnimento di sistema. Per favore salvare il lavoro e terminare la sessione. Tutto il lavoro non salvato andrà perso quando il sistema sarà spento.", -1, 38, 7, 135, 40
-    LTEXT "Il sistema si spegnerà:", -1, 38, 50, 90, 8
+    LTEXT "È stato inizializzato uno spegnimento di sistema. Per favore salvare il lavoro e terminare la sessione. Tutto il lavoro non salvato andrà perso quando il sistema sarà spento.", IDC_STATIC, 38, 7, 135, 40
+    LTEXT "Il sistema si spegnerà:", IDC_STATIC, 38, 50, 90, 8
     LTEXT "00:00:00", IDC_SYSSHUTDOWNTIMELEFT, 132, 50, 41, 8
-    LTEXT "Message:", -1, 38, 65, 135, 8
+    LTEXT "Message:", IDC_STATIC, 38, 65, 135, 8
     EDITTEXT IDC_SYSSHUTDOWNMESSAGE, 34, 75, 139, 58, ES_LEFT | ES_MULTILINE | ES_AUTOVSCROLL | ES_READONLY | NOT WS_BORDER | NOT WS_TABSTOP, WS_EX_STATICEDGE
 END
 

--- a/base/system/winlogon/lang/ja-JP.rc
+++ b/base/system/winlogon/lang/ja-JP.rc
@@ -17,7 +17,7 @@ FONT 9, "MS UI Gothic"
 BEGIN
     LTEXT "ログオン ユーザー インターフェイス DLL %s の読み込みに失敗しました。", IDC_GINALOADFAILED, 39, 16, 156, 24
     LTEXT "システムの管理者に連絡をとり、DLL を置き換えてもらうか、オリジナルの DLL を復旧してもらってください。", IDC_GINALOADFAILEDCONTACT, 39, 53, 151, 25
-    DEFPUSHBUTTON "再起動(&R)", 1, 80, 91, 68, 14
+    DEFPUSHBUTTON "再起動(&R)", IDOK, 80, 91, 68, 14
 END
 
 IDD_SYSSHUTDOWN DIALOGEX 50, 50, 180, 140
@@ -26,10 +26,10 @@ CAPTION "システムのシャットダウン"
 FONT 9, "MS UI Gothic"
 BEGIN
     ICON IDI_WARNING, IDC_SYSSHUTDOWNICON, 6, 7, 18, 20
-    LTEXT "システムのシャットダウンが開始されました。あなたの作業をすべて保存し、セッションを終了して下さい。シャットダウン時に保存していない作業は失われます。", -1, 38, 7, 135, 40
-    LTEXT "シャットダウンまで:", -1, 38, 50, 90, 8
+    LTEXT "システムのシャットダウンが開始されました。あなたの作業をすべて保存し、セッションを終了して下さい。シャットダウン時に保存していない作業は失われます。", IDC_STATIC, 38, 7, 135, 40
+    LTEXT "シャットダウンまで:", IDC_STATIC, 38, 50, 90, 8
     LTEXT "00:00:00", IDC_SYSSHUTDOWNTIMELEFT, 132, 50, 41, 8
-    LTEXT "メッセージ:", -1, 38, 65, 135, 8
+    LTEXT "メッセージ:", IDC_STATIC, 38, 65, 135, 8
     EDITTEXT IDC_SYSSHUTDOWNMESSAGE, 34, 75, 139, 58, ES_LEFT | ES_MULTILINE | ES_AUTOVSCROLL | ES_READONLY | NOT WS_BORDER | NOT WS_TABSTOP, WS_EX_STATICEDGE
 END
 

--- a/base/system/winlogon/lang/lt-LT.rc
+++ b/base/system/winlogon/lang/lt-LT.rc
@@ -19,7 +19,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "Nepavyko įkelti prisijungimo prie vartotojo aplinkos DLL %s.", IDC_GINALOADFAILED, 39, 16, 156, 24
     LTEXT "Susisiekite su sistemos administratoriumi, kuris pakeistų arba atstatytų originalią DLL.", IDC_GINALOADFAILEDCONTACT, 39, 53, 151, 25
-    DEFPUSHBUTTON "&Perkrauti", 1, 80, 91, 68, 14
+    DEFPUSHBUTTON "&Perkrauti", IDOK, 80, 91, 68, 14
 END
 
 IDD_SYSSHUTDOWN DIALOGEX 50, 50, 180, 140
@@ -28,10 +28,10 @@ CAPTION "System Shutdown"
 FONT 8, "MS Shell Dlg"
 BEGIN
     ICON IDI_WARNING, IDC_SYSSHUTDOWNICON, 6, 7, 18, 20
-    LTEXT "A system shutdown has been initiated. Please save all your work and terminate your session. All unsaved work will be lost when the system shuts down.", -1, 38, 7, 135, 40
-    LTEXT "The system shuts down in:", -1, 38, 50, 90, 8
+    LTEXT "A system shutdown has been initiated. Please save all your work and terminate your session. All unsaved work will be lost when the system shuts down.", IDC_STATIC, 38, 7, 135, 40
+    LTEXT "The system shuts down in:", IDC_STATIC, 38, 50, 90, 8
     LTEXT "00:00:00", IDC_SYSSHUTDOWNTIMELEFT, 132, 50, 41, 8
-    LTEXT "Message:", -1, 38, 65, 135, 8
+    LTEXT "Message:", IDC_STATIC, 38, 65, 135, 8
     EDITTEXT IDC_SYSSHUTDOWNMESSAGE, 34, 75, 139, 58, ES_LEFT | ES_MULTILINE | ES_AUTOVSCROLL | ES_READONLY | NOT WS_BORDER | NOT WS_TABSTOP, WS_EX_STATICEDGE
 END
 

--- a/base/system/winlogon/lang/ms-MY.rc
+++ b/base/system/winlogon/lang/ms-MY.rc
@@ -19,7 +19,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "Antara muka pengguna log masuk DLL %s gagal untuk dimuatkan.", IDC_GINALOADFAILED, 39, 16, 156, 24
     LTEXT "Hubungi pentadbir sistem anda untuk menukar DLL, atau mengambil semula DLL yang asal.", IDC_GINALOADFAILEDCONTACT, 39, 53, 151, 25
-    DEFPUSHBUTTON "Mula semula(&R)", 1, 80, 91, 68, 14
+    DEFPUSHBUTTON "Mula semula(&R)", IDOK, 80, 91, 68, 14
 END
 
 IDD_SYSSHUTDOWN DIALOGEX 50, 50, 180, 140
@@ -28,10 +28,10 @@ CAPTION "System Shutdown"
 FONT 8, "MS Shell Dlg"
 BEGIN
     ICON IDI_WARNING, IDC_SYSSHUTDOWNICON, 6, 7, 18, 20
-    LTEXT "A system shutdown has been initiated. Please save all your work and terminate your session. All unsaved work will be lost when the system shuts down.", -1, 38, 7, 135, 40
-    LTEXT "The system shuts down in:", -1, 38, 50, 90, 8
+    LTEXT "A system shutdown has been initiated. Please save all your work and terminate your session. All unsaved work will be lost when the system shuts down.", IDC_STATIC, 38, 7, 135, 40
+    LTEXT "The system shuts down in:", IDC_STATIC, 38, 50, 90, 8
     LTEXT "00:00:00", IDC_SYSSHUTDOWNTIMELEFT, 132, 50, 41, 8
-    LTEXT "Message:", -1, 38, 65, 135, 8
+    LTEXT "Message:", IDC_STATIC, 38, 65, 135, 8
     EDITTEXT IDC_SYSSHUTDOWNMESSAGE, 34, 75, 139, 58, ES_LEFT | ES_MULTILINE | ES_AUTOVSCROLL | ES_READONLY | NOT WS_BORDER | NOT WS_TABSTOP, WS_EX_STATICEDGE
 END
 

--- a/base/system/winlogon/lang/nl-NL.rc
+++ b/base/system/winlogon/lang/nl-NL.rc
@@ -17,7 +17,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "De gebruikers interface logon DLL %s kon niet worden geladen.", IDC_GINALOADFAILED, 39, 16, 156, 24
     LTEXT "Neem contact op met de systeemadministrator om de DLL te vervangen, of plaats de oude DLL.", IDC_GINALOADFAILEDCONTACT, 39, 53, 151, 25
-    DEFPUSHBUTTON "&Restart", 1, 80, 91, 68, 14
+    DEFPUSHBUTTON "&Herstart", IDOK, 80, 91, 68, 14
 END
 
 IDD_SYSSHUTDOWN DIALOGEX 50, 50, 180, 140
@@ -26,10 +26,10 @@ CAPTION "System Shutdown"
 FONT 8, "MS Shell Dlg"
 BEGIN
     ICON IDI_WARNING, IDC_SYSSHUTDOWNICON, 6, 7, 18, 20
-    LTEXT "A system shutdown has been initiated. Please save all your work and terminate your session. All unsaved work will be lost when the system shuts down.", -1, 38, 7, 135, 40
-    LTEXT "The system shuts down in:", -1, 38, 50, 90, 8
+    LTEXT "A system shutdown has been initiated. Please save all your work and terminate your session. All unsaved work will be lost when the system shuts down.", IDC_STATIC, 38, 7, 135, 40
+    LTEXT "The system shuts down in:", IDC_STATIC, 38, 50, 90, 8
     LTEXT "00:00:00", IDC_SYSSHUTDOWNTIMELEFT, 132, 50, 41, 8
-    LTEXT "Message:", -1, 38, 65, 135, 8
+    LTEXT "Message:", IDC_STATIC, 38, 65, 135, 8
     EDITTEXT IDC_SYSSHUTDOWNMESSAGE, 34, 75, 139, 58, ES_LEFT | ES_MULTILINE | ES_AUTOVSCROLL | ES_READONLY | NOT WS_BORDER | NOT WS_TABSTOP, WS_EX_STATICEDGE
 END
 

--- a/base/system/winlogon/lang/no-NO.rc
+++ b/base/system/winlogon/lang/no-NO.rc
@@ -17,7 +17,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "Logg på bruker Interface DLL %s mislykkes å laste.", IDC_GINALOADFAILED, 39, 16, 156, 24
     LTEXT "Kontakt din system administrator for å erstatte DLL, eller få tilbake orginale DLL.", IDC_GINALOADFAILEDCONTACT, 39, 53, 151, 25
-    DEFPUSHBUTTON "&Restart", 1, 80, 91, 68, 14
+    DEFPUSHBUTTON "&Restart", IDOK, 80, 91, 68, 14
 END
 
 IDD_SYSSHUTDOWN DIALOGEX 50, 50, 180, 140
@@ -26,10 +26,10 @@ CAPTION "System Shutdown"
 FONT 8, "MS Shell Dlg"
 BEGIN
     ICON IDI_WARNING, IDC_SYSSHUTDOWNICON, 6, 7, 18, 20
-    LTEXT "A system shutdown has been initiated. Please save all your work and terminate your session. All unsaved work will be lost when the system shuts down.", -1, 38, 7, 135, 40
-    LTEXT "The system shuts down in:", -1, 38, 50, 90, 8
+    LTEXT "A system shutdown has been initiated. Please save all your work and terminate your session. All unsaved work will be lost when the system shuts down.", IDC_STATIC, 38, 7, 135, 40
+    LTEXT "The system shuts down in:", IDC_STATIC, 38, 50, 90, 8
     LTEXT "00:00:00", IDC_SYSSHUTDOWNTIMELEFT, 132, 50, 41, 8
-    LTEXT "Message:", -1, 38, 65, 135, 8
+    LTEXT "Message:", IDC_STATIC, 38, 65, 135, 8
     EDITTEXT IDC_SYSSHUTDOWNMESSAGE, 34, 75, 139, 58, ES_LEFT | ES_MULTILINE | ES_AUTOVSCROLL | ES_READONLY | NOT WS_BORDER | NOT WS_TABSTOP, WS_EX_STATICEDGE
 END
 

--- a/base/system/winlogon/lang/pl-PL.rc
+++ b/base/system/winlogon/lang/pl-PL.rc
@@ -25,7 +25,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "Nie można załadować biblioteki DLL interfejsu logowania użytkownika %s.", IDC_GINALOADFAILED, 39, 16, 156, 24
     LTEXT "Skontaktuj się z administratorem systemu, aby zamienić bibliotekę DLL lub odtworzyć jej oryginalną wersję.", IDC_GINALOADFAILEDCONTACT, 39, 53, 151, 25
-    DEFPUSHBUTTON "&Uruchom ponownie", 1, 80, 91, 71, 14
+    DEFPUSHBUTTON "&Uruchom ponownie", IDOK, 80, 91, 71, 14
 END
 
 IDD_SYSSHUTDOWN DIALOGEX 50, 50, 184, 140
@@ -34,10 +34,10 @@ CAPTION "Zamykanie systemu"
 FONT 8, "MS Shell Dlg"
 BEGIN
     ICON IDI_WARNING, IDC_SYSSHUTDOWNICON, 6, 7, 18, 20
-    LTEXT "Trwa zamykanie systemu. Zapisz wszystkie rozpoczęte prace i wyloguj się. Wszystkie niezapisane zmiany zostaną utracone po zamknięciu systemu.", -1, 33, 7, 147, 42
-    LTEXT "Czas do zamknięcia:", -1, 33, 50, 90, 8
+    LTEXT "Trwa zamykanie systemu. Zapisz wszystkie rozpoczęte prace i wyloguj się. Wszystkie niezapisane zmiany zostaną utracone po zamknięciu systemu.", IDC_STATIC, 33, 7, 147, 42
+    LTEXT "Czas do zamknięcia:", IDC_STATIC, 33, 50, 90, 8
     LTEXT "00:00:00", IDC_SYSSHUTDOWNTIMELEFT, 132, 50, 41, 8
-    LTEXT "Wiadomość:", -1, 33, 65, 135, 8
+    LTEXT "Wiadomość:", IDC_STATIC, 33, 65, 135, 8
     EDITTEXT IDC_SYSSHUTDOWNMESSAGE, 30, 75, 146, 58, ES_LEFT | ES_MULTILINE | ES_AUTOVSCROLL | ES_READONLY | NOT WS_BORDER | NOT WS_TABSTOP, WS_EX_STATICEDGE
 END
 

--- a/base/system/winlogon/lang/pt-BR.rc
+++ b/base/system/winlogon/lang/pt-BR.rc
@@ -9,7 +9,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "O seu computador pode ser desligado com segurança.", IDC_SHUTDOWNCOMPUTER, 31, 6, 132, 18
     ICON IDI_WINLOGON, IDC_SHTDOWNICON, 6, 7, 18, 20
-    DEFPUSHBUTTON "&Restart", IDC_BTNSHTDOWNCOMPUTER, 62, 32, 40, 14
+    DEFPUSHBUTTON "&Reiniciar", IDC_BTNSHTDOWNCOMPUTER, 62, 32, 40, 14
 END
 
 IDD_GINALOADFAILED DIALOGEX 58, 83, 231, 119
@@ -19,7 +19,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "A DLL de Logon de Interface de Usuário %s falhou ao carregar.", IDC_GINALOADFAILED, 39, 16, 156, 24
     LTEXT "Contate o administrador do seu sistema para substituir a DLL, ou recuperar a DLL original.", IDC_GINALOADFAILEDCONTACT, 39, 53, 151, 25
-    DEFPUSHBUTTON "&Reiniciar", 1, 80, 91, 68, 14
+    DEFPUSHBUTTON "&Reiniciar", IDOK, 80, 91, 68, 14
 END
 
 IDD_SYSSHUTDOWN DIALOGEX 50, 50, 180, 140
@@ -28,10 +28,10 @@ CAPTION "System Shutdown"
 FONT 8, "MS Shell Dlg"
 BEGIN
     ICON IDI_WARNING, IDC_SYSSHUTDOWNICON, 6, 7, 18, 20
-    LTEXT "A system shutdown has been initiated. Please save all your work and terminate your session. All unsaved work will be lost when the system shuts down.", -1, 38, 7, 135, 40
-    LTEXT "The system shuts down in:", -1, 38, 50, 90, 8
+    LTEXT "A system shutdown has been initiated. Please save all your work and terminate your session. All unsaved work will be lost when the system shuts down.", IDC_STATIC, 38, 7, 135, 40
+    LTEXT "The system shuts down in:", IDC_STATIC, 38, 50, 90, 8
     LTEXT "00:00:00", IDC_SYSSHUTDOWNTIMELEFT, 132, 50, 41, 8
-    LTEXT "Message:", -1, 38, 65, 135, 8
+    LTEXT "Message:", IDC_STATIC, 38, 65, 135, 8
     EDITTEXT IDC_SYSSHUTDOWNMESSAGE, 34, 75, 139, 58, ES_LEFT | ES_MULTILINE | ES_AUTOVSCROLL | ES_READONLY | NOT WS_BORDER | NOT WS_TABSTOP, WS_EX_STATICEDGE
 END
 

--- a/base/system/winlogon/lang/pt-PT.rc
+++ b/base/system/winlogon/lang/pt-PT.rc
@@ -19,7 +19,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "A Interface do utilizador da DLL de início de sessão %s falhou ao carregar.", IDC_GINALOADFAILED, 39, 16, 156, 24
     LTEXT "Contacte o administrador do seu sistema para substituir a DLL, ou recuperar a DLL original.", IDC_GINALOADFAILEDCONTACT, 39, 53, 151, 25
-    DEFPUSHBUTTON "&Reiniciar", 1, 80, 91, 68, 14
+    DEFPUSHBUTTON "&Reiniciar", IDOK, 80, 91, 68, 14
 END
 
 IDD_SYSSHUTDOWN DIALOGEX 50, 50, 180, 140
@@ -28,10 +28,10 @@ CAPTION "Encerrar o sistema"
 FONT 8, "MS Shell Dlg"
 BEGIN
     ICON IDI_WARNING, IDC_SYSSHUTDOWNICON, 6, 7, 18, 20
-    LTEXT "O sistema iniciou o encerramento. Por favor guarde o seu trabalho e termine a sessão. Todos os dados não guardados serão perdidos quando o sistema encerrar.", -1, 38, 7, 135, 40
-    LTEXT "O sistema encerrará em:", -1, 38, 50, 90, 8
+    LTEXT "O sistema iniciou o encerramento. Por favor guarde o seu trabalho e termine a sessão. Todos os dados não guardados serão perdidos quando o sistema encerrar.", IDC_STATIC, 38, 7, 135, 40
+    LTEXT "O sistema encerrará em:", IDC_STATIC, 38, 50, 90, 8
     LTEXT "00:00:00", IDC_SYSSHUTDOWNTIMELEFT, 132, 50, 41, 8
-    LTEXT "Mensagem:", -1, 38, 65, 135, 8
+    LTEXT "Mensagem:", IDC_STATIC, 38, 65, 135, 8
     EDITTEXT IDC_SYSSHUTDOWNMESSAGE, 34, 75, 139, 58, ES_LEFT | ES_MULTILINE | ES_AUTOVSCROLL | ES_READONLY | NOT WS_BORDER | NOT WS_TABSTOP, WS_EX_STATICEDGE
 END
 

--- a/base/system/winlogon/lang/ro-RO.rc
+++ b/base/system/winlogon/lang/ro-RO.rc
@@ -17,7 +17,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "Computerul se poate închide în siguranţă.", IDC_SHUTDOWNCOMPUTER, 31, 6, 132, 18
     ICON IDI_WINLOGON, IDC_SHTDOWNICON, 6, 7, 18, 20
-    DEFPUSHBUTTON  "&Repornire", IDC_BTNSHTDOWNCOMPUTER, 62, 32, 40, 14
+    DEFPUSHBUTTON "&Repornire", IDC_BTNSHTDOWNCOMPUTER, 62, 32, 40, 14
 END
 
 IDD_GINALOADFAILED DIALOGEX 58, 83, 231, 119
@@ -27,7 +27,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "Încărcarea DLL-ului %s, de interfaţă utilizator pentru Log on, nu a reuşit ", IDC_GINALOADFAILED, 39, 16, 156, 24
     LTEXT "Contactaţi administratorul de sistem pentru a înlocui biblioteca DLL sau restauraţi biblioteca DLL originală.", IDC_GINALOADFAILEDCONTACT, 39, 53, 151, 25
-    DEFPUSHBUTTON "&Repornire", 1, 80, 91, 68, 14
+    DEFPUSHBUTTON "&Repornire", IDOK, 80, 91, 68, 14
 END
 
 IDD_SYSSHUTDOWN DIALOGEX 50, 50, 180, 140
@@ -36,10 +36,10 @@ CAPTION "Închidere sistem"
 FONT 8, "MS Shell Dlg"
 BEGIN
     ICON IDI_WARNING, IDC_SYSSHUTDOWNICON, 6, 7, 18, 20
-    LTEXT "Acest sistem se închide. Salvaţi lucrările curente şi faceţi Log off. Modificările care nu se salvează se vor pierde.", -1, 38, 7, 135, 40
-    LTEXT "Timp până la închidere:", -1, 38, 50, 90, 8
+    LTEXT "Acest sistem se închide. Salvaţi lucrările curente şi faceţi Log off. Modificările care nu se salvează se vor pierde.", IDC_STATIC, 38, 7, 135, 40
+    LTEXT "Timp până la închidere:", IDC_STATIC, 38, 50, 90, 8
     LTEXT "00:00:00", IDC_SYSSHUTDOWNTIMELEFT, 132, 50, 41, 8
-    LTEXT "Mesaj:", -1, 38, 65, 135, 8
+    LTEXT "Mesaj:", IDC_STATIC, 38, 65, 135, 8
     EDITTEXT IDC_SYSSHUTDOWNMESSAGE, 34, 75, 139, 58, ES_LEFT | ES_MULTILINE | ES_AUTOVSCROLL | ES_READONLY | NOT WS_BORDER | NOT WS_TABSTOP, WS_EX_STATICEDGE
 END
 

--- a/base/system/winlogon/lang/ru-RU.rc
+++ b/base/system/winlogon/lang/ru-RU.rc
@@ -17,7 +17,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "Невозможно загрузить DLL-библиотеку %s.", IDC_GINALOADFAILED, 39, 16, 156, 24
     LTEXT "Свяжитесь с системным администратором, чтобы заменить или восстановить оригинальный файл DLL.", IDC_GINALOADFAILEDCONTACT, 39, 53, 151, 25
-    DEFPUSHBUTTON "&Перезагрузка", 1, 80, 91, 68, 14
+    DEFPUSHBUTTON "&Перезагрузка", IDOK, 80, 91, 68, 14
 END
 
 IDD_SYSSHUTDOWN DIALOGEX 50, 50, 180, 140
@@ -26,10 +26,10 @@ CAPTION "Завершение работы системы"
 FONT 8, "MS Shell Dlg"
 BEGIN
     ICON IDI_WARNING, IDC_SYSSHUTDOWNICON, 6, 7, 18, 20
-    LTEXT "Система завершает работу. Сохраните все данные и выйдите из системы. Все несохранённые данные будут утеряны, как только система завершит работу.", -1, 38, 7, 135, 40
-    LTEXT "Время до отключения:", -1, 38, 50, 90, 8
+    LTEXT "Система завершает работу. Сохраните все данные и выйдите из системы. Все несохранённые данные будут утеряны, как только система завершит работу.", IDC_STATIC, 38, 7, 135, 40
+    LTEXT "Время до отключения:", IDC_STATIC, 38, 50, 90, 8
     LTEXT "00:00:00", IDC_SYSSHUTDOWNTIMELEFT, 132, 50, 41, 8
-    LTEXT "Сообщение:", -1, 38, 65, 135, 8
+    LTEXT "Сообщение:", IDC_STATIC, 38, 65, 135, 8
     EDITTEXT IDC_SYSSHUTDOWNMESSAGE, 34, 75, 139, 58, ES_LEFT | ES_MULTILINE | ES_AUTOVSCROLL | ES_READONLY | NOT WS_BORDER | NOT WS_TABSTOP, WS_EX_STATICEDGE
 END
 

--- a/base/system/winlogon/lang/sk-SK.rc
+++ b/base/system/winlogon/lang/sk-SK.rc
@@ -25,7 +25,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "DLL knižnicu %s prihlasovacieho používateľského rozhrania sa nepodarilo načítať.", IDC_GINALOADFAILED, 39, 16, 156, 24
     LTEXT "Obráťte sa na správcu systému, aby DLL knižnicu nahradil alebo obnovil pôvodnú.", IDC_GINALOADFAILEDCONTACT, 39, 53, 151, 25
-    DEFPUSHBUTTON "&Reštartovať", 1, 80, 91, 68, 14
+    DEFPUSHBUTTON "&Reštartovať", IDOK, 80, 91, 68, 14
 END
 
 IDD_SYSSHUTDOWN DIALOGEX 50, 50, 180, 140
@@ -34,10 +34,10 @@ CAPTION "Vypínanie systému"
 FONT 8, "MS Shell Dlg"
 BEGIN
     ICON IDI_WARNING, IDC_SYSSHUTDOWNICON, 6, 7, 18, 20
-    LTEXT "Bol začatý proces vypínania systému. Uložte prosím svoju prácu a ukončite reláciu. Všetky neuložené dáta budú po vypnutí systému stratené.", -1, 38, 7, 135, 40
-    LTEXT "Systém sa vypne za:", -1, 38, 50, 90, 8
+    LTEXT "Bol začatý proces vypínania systému. Uložte prosím svoju prácu a ukončite reláciu. Všetky neuložené dáta budú po vypnutí systému stratené.", IDC_STATIC, 38, 7, 135, 40
+    LTEXT "Systém sa vypne za:", IDC_STATIC, 38, 50, 90, 8
     LTEXT "00:00:00", IDC_SYSSHUTDOWNTIMELEFT, 132, 50, 41, 8
-    LTEXT "Správa:", -1, 38, 65, 135, 8
+    LTEXT "Správa:", IDC_STATIC, 38, 65, 135, 8
     EDITTEXT IDC_SYSSHUTDOWNMESSAGE, 34, 75, 139, 58, ES_LEFT | ES_MULTILINE | ES_AUTOVSCROLL | ES_READONLY | NOT WS_BORDER | NOT WS_TABSTOP, WS_EX_STATICEDGE
 END
 

--- a/base/system/winlogon/lang/sq-AL.rc
+++ b/base/system/winlogon/lang/sq-AL.rc
@@ -21,7 +21,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "Hyrja e Nderfaqes se perdoruesit DLL %s deshtoj ne ngarkim.", IDC_GINALOADFAILED, 39, 16, 156, 24
     LTEXT "Kontaktoni administratorin e sistemit per te zevendesuar DLL, ose te ktheje origjinalin e DLL.", IDC_GINALOADFAILEDCONTACT, 39, 53, 151, 25
-    DEFPUSHBUTTON "&Rifillo", 1, 80, 91, 68, 14
+    DEFPUSHBUTTON "&Rifillo", IDOK, 80, 91, 68, 14
 END
 
 IDD_SYSSHUTDOWN DIALOGEX 50, 50, 180, 140
@@ -30,10 +30,10 @@ CAPTION "System Shutdown"
 FONT 8, "MS Shell Dlg"
 BEGIN
     ICON IDI_WARNING, IDC_SYSSHUTDOWNICON, 6, 7, 18, 20
-    LTEXT "A system shutdown has been initiated. Please save all your work and terminate your session. All unsaved work will be lost when the system shuts down.", -1, 38, 7, 135, 40
-    LTEXT "The system shuts down in:", -1, 38, 50, 90, 8
+    LTEXT "A system shutdown has been initiated. Please save all your work and terminate your session. All unsaved work will be lost when the system shuts down.", IDC_STATIC, 38, 7, 135, 40
+    LTEXT "The system shuts down in:", IDC_STATIC, 38, 50, 90, 8
     LTEXT "00:00:00", IDC_SYSSHUTDOWNTIMELEFT, 132, 50, 41, 8
-    LTEXT "Message:", -1, 38, 65, 135, 8
+    LTEXT "Message:", IDC_STATIC, 38, 65, 135, 8
     EDITTEXT IDC_SYSSHUTDOWNMESSAGE, 34, 75, 139, 58, ES_LEFT | ES_MULTILINE | ES_AUTOVSCROLL | ES_READONLY | NOT WS_BORDER | NOT WS_TABSTOP, WS_EX_STATICEDGE
 END
 

--- a/base/system/winlogon/lang/sv-SE.rc
+++ b/base/system/winlogon/lang/sv-SE.rc
@@ -19,7 +19,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "DLL-filen %s kunde inte laddas.", IDC_GINALOADFAILED, 39, 16, 156, 24
     LTEXT "Kontakta din systemadministratör för att ersätta eller återställa DLL-filen.", IDC_GINALOADFAILEDCONTACT, 39, 53, 151, 25
-    DEFPUSHBUTTON "&Starta om", 1, 80, 91, 68, 14
+    DEFPUSHBUTTON "&Starta om", IDOK, 80, 91, 68, 14
 END
 
 IDD_SYSSHUTDOWN DIALOGEX 50, 50, 180, 140
@@ -28,10 +28,10 @@ CAPTION "System Shutdown"
 FONT 8, "MS Shell Dlg"
 BEGIN
     ICON IDI_WARNING, IDC_SYSSHUTDOWNICON, 6, 7, 18, 20
-    LTEXT "A system shutdown has been initiated. Please save all your work and terminate your session. All unsaved work will be lost when the system shuts down.", -1, 38, 7, 135, 40
-    LTEXT "The system shuts down in:", -1, 38, 50, 90, 8
+    LTEXT "A system shutdown has been initiated. Please save all your work and terminate your session. All unsaved work will be lost when the system shuts down.", IDC_STATIC, 38, 7, 135, 40
+    LTEXT "The system shuts down in:", IDC_STATIC, 38, 50, 90, 8
     LTEXT "00:00:00", IDC_SYSSHUTDOWNTIMELEFT, 132, 50, 41, 8
-    LTEXT "Message:", -1, 38, 65, 135, 8
+    LTEXT "Message:", IDC_STATIC, 38, 65, 135, 8
     EDITTEXT IDC_SYSSHUTDOWNMESSAGE, 34, 75, 139, 58, ES_LEFT | ES_MULTILINE | ES_AUTOVSCROLL | ES_READONLY | NOT WS_BORDER | NOT WS_TABSTOP, WS_EX_STATICEDGE
 END
 

--- a/base/system/winlogon/lang/tr-TR.rc
+++ b/base/system/winlogon/lang/tr-TR.rc
@@ -19,7 +19,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "Oturum Açma Kullanıcı Arayüzü %s DLL'si yüklemede başarısız oldu.", IDC_GINALOADFAILED, 39, 16, 156, 24
     LTEXT "DLL'yi yenisiyle değiştirmek ya da özgün DLL'yi onarmak için sistem yöneticinize başvurunuz.", IDC_GINALOADFAILEDCONTACT, 39, 53, 151, 25
-    DEFPUSHBUTTON "&Yeniden Başlat", 1, 80, 91, 68, 14
+    DEFPUSHBUTTON "&Yeniden Başlat", IDOK, 80, 91, 68, 14
 END
 
 IDD_SYSSHUTDOWN DIALOGEX 50, 50, 180, 140
@@ -28,10 +28,10 @@ CAPTION "Sistemi Kapatma"
 FONT 8, "MS Shell Dlg"
 BEGIN
     ICON IDI_WARNING, IDC_SYSSHUTDOWNICON, 6, 7, 18, 20
-    LTEXT "Bir sistem kapatma başlatıldı. Lütfen bütün işlerinizi kaydediniz ve oturumunuzu sonlandırınız. Bütün kaydedilmemiş işler, sistem kapatılırken kaybedilir.", -1, 38, 7, 135, 40
-    LTEXT "Sistem kapatılıyor:", -1, 38, 50, 90, 8
+    LTEXT "Bir sistem kapatma başlatıldı. Lütfen bütün işlerinizi kaydediniz ve oturumunuzu sonlandırınız. Bütün kaydedilmemiş işler, sistem kapatılırken kaybedilir.", IDC_STATIC, 38, 7, 135, 40
+    LTEXT "Sistem kapatılıyor:", IDC_STATIC, 38, 50, 90, 8
     LTEXT "00:00:00", IDC_SYSSHUTDOWNTIMELEFT, 132, 50, 41, 8
-    LTEXT "İleti:", -1, 38, 65, 135, 8
+    LTEXT "İleti:", IDC_STATIC, 38, 65, 135, 8
     EDITTEXT IDC_SYSSHUTDOWNMESSAGE, 34, 75, 139, 58, ES_LEFT | ES_MULTILINE | ES_AUTOVSCROLL | ES_READONLY | NOT WS_BORDER | NOT WS_TABSTOP, WS_EX_STATICEDGE
 END
 

--- a/base/system/winlogon/lang/uk-UA.rc
+++ b/base/system/winlogon/lang/uk-UA.rc
@@ -17,7 +17,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "Не вдалося завантажити бібліотеку інтерфейсу входу користувача %s.", IDC_GINALOADFAILED, 39, 16, 156, 24
     LTEXT "Зверніться до системного адміністратора щоб замінити наявну, або відновіть початкову бібліотеку.", IDC_GINALOADFAILEDCONTACT, 39, 53, 151, 25
-    DEFPUSHBUTTON "&Перезавантаження", 1, 80, 91, 68, 14
+    DEFPUSHBUTTON "&Перезавантаження", IDOK, 80, 91, 68, 14
 END
 
 IDD_SYSSHUTDOWN DIALOGEX 50, 50, 180, 140
@@ -26,10 +26,10 @@ CAPTION "System Shutdown"
 FONT 8, "MS Shell Dlg"
 BEGIN
     ICON IDI_WARNING, IDC_SYSSHUTDOWNICON, 6, 7, 18, 20
-    LTEXT "A system shutdown has been initiated. Please save all your work and terminate your session. All unsaved work will be lost when the system shuts down.", -1, 38, 7, 135, 40
-    LTEXT "The system shuts down in:", -1, 38, 50, 90, 8
+    LTEXT "A system shutdown has been initiated. Please save all your work and terminate your session. All unsaved work will be lost when the system shuts down.", IDC_STATIC, 38, 7, 135, 40
+    LTEXT "The system shuts down in:", IDC_STATIC, 38, 50, 90, 8
     LTEXT "00:00:00", IDC_SYSSHUTDOWNTIMELEFT, 132, 50, 41, 8
-    LTEXT "Message:", -1, 38, 65, 135, 8
+    LTEXT "Message:", IDC_STATIC, 38, 65, 135, 8
     EDITTEXT IDC_SYSSHUTDOWNMESSAGE, 34, 75, 139, 58, ES_LEFT | ES_MULTILINE | ES_AUTOVSCROLL | ES_READONLY | NOT WS_BORDER | NOT WS_TABSTOP, WS_EX_STATICEDGE
 END
 

--- a/base/system/winlogon/lang/zh-CN.rc
+++ b/base/system/winlogon/lang/zh-CN.rc
@@ -27,7 +27,7 @@ FONT 9, "宋体"
 BEGIN
     LTEXT "加载登录用户界面的 DLL 文件 %s 启动失败。", IDC_GINALOADFAILED, 39, 16, 156, 24
     LTEXT "请与系统管理员联系，以替换 DLL 文件，或还原初始的 DLL。", IDC_GINALOADFAILEDCONTACT, 39, 53, 151, 25
-    DEFPUSHBUTTON "重新启动(&R)", 1, 80, 91, 68, 14
+    DEFPUSHBUTTON "重新启动(&R)", IDOK, 80, 91, 68, 14
 END
 
 IDD_SYSSHUTDOWN DIALOGEX 50, 50, 180, 140
@@ -36,10 +36,10 @@ CAPTION "关机"
 FONT 9, "宋体"
 BEGIN
     ICON IDI_WARNING, IDC_SYSSHUTDOWNICON, 6, 7, 18, 20
-    LTEXT "已计划系统关闭。请保存所有工作并终止会话。系统关闭时，所有未保存的工作都将丢失。", -1, 38, 7, 135, 40
-    LTEXT "系统将在以下时间内关机：", -1, 38, 50, 90, 8
+    LTEXT "已计划系统关闭。请保存所有工作并终止会话。系统关闭时，所有未保存的工作都将丢失。", IDC_STATIC, 38, 7, 135, 40
+    LTEXT "系统将在以下时间内关机：", IDC_STATIC, 38, 50, 90, 8
     LTEXT "00:00:00", IDC_SYSSHUTDOWNTIMELEFT, 132, 50, 41, 8
-    LTEXT "附加信息：", -1, 38, 65, 135, 8
+    LTEXT "附加信息：", IDC_STATIC, 38, 65, 135, 8
     EDITTEXT IDC_SYSSHUTDOWNMESSAGE, 34, 75, 139, 58, ES_LEFT | ES_MULTILINE | ES_AUTOVSCROLL | ES_READONLY | NOT WS_BORDER | NOT WS_TABSTOP, WS_EX_STATICEDGE
 END
 

--- a/base/system/winlogon/lang/zh-HK.rc
+++ b/base/system/winlogon/lang/zh-HK.rc
@@ -25,7 +25,7 @@ FONT 9, "新細明體"
 BEGIN
     LTEXT "載入登入使用者介面的 DLL 檔案 %s 載入失敗。", IDC_GINALOADFAILED, 39, 16, 156, 24
     LTEXT "請與系統管理員聯繫，以更換 DLL 檔案，或還原初始的 DLL。", IDC_GINALOADFAILEDCONTACT, 39, 53, 151, 25
-    DEFPUSHBUTTON "重新開機(&R)", 1, 80, 91, 68, 14
+    DEFPUSHBUTTON "重新開機(&R)", IDOK, 80, 91, 68, 14
 END
 
 IDD_SYSSHUTDOWN DIALOGEX 50, 50, 180, 140
@@ -34,10 +34,10 @@ CAPTION "系統關閉"
 FONT 9, "新細明體"
 BEGIN
     ICON IDI_WARNING, IDC_SYSSHUTDOWNICON, 6, 7, 18, 20
-    LTEXT "系統關機程序已啟動。請儲存所有工作並登出。所有未儲存的工作都會在關機時遺失。", -1, 38, 7, 135, 40
-    LTEXT "關機前剩餘時間︰", -1, 38, 50, 90, 8
+    LTEXT "系統關機程序已啟動。請儲存所有工作並登出。所有未儲存的工作都會在關機時遺失。", IDC_STATIC, 38, 7, 135, 40
+    LTEXT "關機前剩餘時間︰", IDC_STATIC, 38, 50, 90, 8
     LTEXT "00:00:00", IDC_SYSSHUTDOWNTIMELEFT, 132, 50, 41, 8
-    LTEXT "附加訊息：", -1, 38, 65, 135, 8
+    LTEXT "附加訊息：", IDC_STATIC, 38, 65, 135, 8
     EDITTEXT IDC_SYSSHUTDOWNMESSAGE, 34, 75, 139, 58, ES_LEFT | ES_MULTILINE | ES_AUTOVSCROLL | ES_READONLY | NOT WS_BORDER | NOT WS_TABSTOP, WS_EX_STATICEDGE
 END
 

--- a/base/system/winlogon/lang/zh-TW.rc
+++ b/base/system/winlogon/lang/zh-TW.rc
@@ -25,7 +25,7 @@ FONT 9, "新細明體"
 BEGIN
     LTEXT "載入登入使用者介面的 DLL 檔案 %s 載入失敗。", IDC_GINALOADFAILED, 39, 16, 156, 24
     LTEXT "請與系統管理員聯繫，以更換 DLL 檔案，或還原初始的 DLL。", IDC_GINALOADFAILEDCONTACT, 39, 53, 151, 25
-    DEFPUSHBUTTON "重新開機(&R)", 1, 80, 91, 68, 14
+    DEFPUSHBUTTON "重新開機(&R)", IDOK, 80, 91, 68, 14
 END
 
 IDD_SYSSHUTDOWN DIALOGEX 50, 50, 180, 140
@@ -34,10 +34,10 @@ CAPTION "系統關閉"
 FONT 9, "新細明體"
 BEGIN
     ICON IDI_WARNING, IDC_SYSSHUTDOWNICON, 6, 7, 18, 20
-    LTEXT "系統關機程序已啟動。請儲存所有工作並登出。所有未儲存的工作都會在關機時遺失。", -1, 38, 7, 135, 40
-    LTEXT "關機前剩餘時間︰", -1, 38, 50, 90, 8
+    LTEXT "系統關機程序已啟動。請儲存所有工作並登出。所有未儲存的工作都會在關機時遺失。", IDC_STATIC, 38, 7, 135, 40
+    LTEXT "關機前剩餘時間︰", IDC_STATIC, 38, 50, 90, 8
     LTEXT "00:00:00", IDC_SYSSHUTDOWNTIMELEFT, 132, 50, 41, 8
-    LTEXT "附加訊息：", -1, 38, 65, 135, 8
+    LTEXT "附加訊息：", IDC_STATIC, 38, 65, 135, 8
     EDITTEXT IDC_SYSSHUTDOWNMESSAGE, 34, 75, 139, 58, ES_LEFT | ES_MULTILINE | ES_AUTOVSCROLL | ES_READONLY | NOT WS_BORDER | NOT WS_TABSTOP, WS_EX_STATICEDGE
 END
 

--- a/base/system/winlogon/resource.h
+++ b/base/system/winlogon/resource.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#define IDC_STATIC  (-1)
+
 /* Icons */
 #define IDI_WINLOGON 4
 

--- a/base/system/winlogon/sas.c
+++ b/base/system/winlogon/sas.c
@@ -1122,8 +1122,8 @@ ShutdownComputerWindowProc(
         }
         case WM_INITDIALOG:
         {
-            RemoveMenu(GetSystemMenu(hwndDlg, FALSE), SC_CLOSE, MF_BYCOMMAND);
-            SetFocus(GetDlgItem(hwndDlg, IDC_BTNSHTDOWNCOMPUTER));
+            /* Remove the Close menu item */
+            DeleteMenu(GetSystemMenu(hwndDlg, FALSE), SC_CLOSE, MF_BYCOMMAND);
             return TRUE;
         }
     }

--- a/base/system/winlogon/winlogon.c
+++ b/base/system/winlogon/winlogon.c
@@ -431,8 +431,6 @@ GinaLoadFailedWindowProc(
                 wsprintfW(text, templateText, (LPWSTR)lParam);
                 SetDlgItemTextW(hwndDlg, IDC_GINALOADFAILED, text);
             }
-
-            SetFocus(GetDlgItem(hwndDlg, IDOK));
             return TRUE;
         }
 

--- a/dll/win32/msgina/gui.c
+++ b/dll/win32/msgina/gui.c
@@ -780,7 +780,7 @@ ChangePasswordDialogProc(
             SendDlgItemMessageW(hwndDlg, IDC_CHANGEPWD_DOMAIN, CB_ADDSTRING, 0, (LPARAM)pgContext->DomainName);
             SendDlgItemMessageW(hwndDlg, IDC_CHANGEPWD_DOMAIN, CB_SETCURSEL, 0, 0);
             SetFocus(GetDlgItem(hwndDlg, IDC_CHANGEPWD_OLDPWD));
-            return TRUE;
+            return FALSE; // Default focus is changed.
         }
 
         case WM_COMMAND:
@@ -795,7 +795,7 @@ ChangePasswordDialogProc(
                     {
                         SetDlgItemTextW(hwndDlg, IDC_CHANGEPWD_NEWPWD1, NULL);
                         SetDlgItemTextW(hwndDlg, IDC_CHANGEPWD_NEWPWD2, NULL);
-                        SetFocus(GetDlgItem(hwndDlg, IDC_CHANGEPWD_OLDPWD));
+                        SendMessageW(hwndDlg, WM_NEXTDLGCTL, (WPARAM)GetDlgItem(hwndDlg, IDC_CHANGEPWD_OLDPWD), TRUE);
                     }
                     return TRUE;
 
@@ -1320,7 +1320,9 @@ LogonDialogProc(
 
             if (pDlgData->pgContext->bAutoAdminLogon ||
                 !pDlgData->pgContext->bDontDisplayLastUserName)
+            {
                 SetDlgItemTextW(hwndDlg, IDC_LOGON_USERNAME, pDlgData->pgContext->UserName);
+            }
 
             if (pDlgData->pgContext->bAutoAdminLogon)
                 SetDlgItemTextW(hwndDlg, IDC_LOGON_PASSWORD, pDlgData->pgContext->Password);
@@ -1338,7 +1340,7 @@ LogonDialogProc(
             if (pDlgData->pgContext->bAutoAdminLogon)
                 PostMessage(GetDlgItem(hwndDlg, IDOK), BM_CLICK, 0, 0);
 
-            return TRUE;
+            return FALSE; // Default focus is changed.
         }
 
         case WM_PAINT:
@@ -1589,18 +1591,18 @@ UnlockDialogProc(
             if (pDlgData == NULL)
                 return FALSE;
 
+            DlgData_LoadBitmaps(pDlgData);
+
             SetWelcomeText(hwndDlg);
 
             SetLockMessage(hwndDlg, IDC_UNLOCK_MESSAGE, pDlgData->pgContext);
-
             SetDlgItemTextW(hwndDlg, IDC_UNLOCK_USERNAME, pDlgData->pgContext->UserName);
-            SetFocus(GetDlgItem(hwndDlg, IDC_UNLOCK_PASSWORD));
 
             if (pDlgData->pgContext->bDisableCAD)
                 EnableWindow(GetDlgItem(hwndDlg, IDCANCEL), FALSE);
 
-            DlgData_LoadBitmaps(pDlgData);
-            return TRUE;
+            SetFocus(GetDlgItem(hwndDlg, IDC_UNLOCK_PASSWORD));
+            return FALSE; // Default focus is changed.
         }
 
         case WM_PAINT:

--- a/dll/win32/msgina/gui.c
+++ b/dll/win32/msgina/gui.c
@@ -793,6 +793,7 @@ ChangePasswordDialogProc(
                     }
                     else
                     {
+                        SetDlgItemTextW(hwndDlg, IDC_CHANGEPWD_OLDPWD, NULL);
                         SetDlgItemTextW(hwndDlg, IDC_CHANGEPWD_NEWPWD1, NULL);
                         SetDlgItemTextW(hwndDlg, IDC_CHANGEPWD_NEWPWD2, NULL);
                         SendMessageW(hwndDlg, WM_NEXTDLGCTL, (WPARAM)GetDlgItem(hwndDlg, IDC_CHANGEPWD_OLDPWD), TRUE);
@@ -1364,7 +1365,14 @@ LogonDialogProc(
             {
                 case IDOK:
                     if (DoLogon(hwndDlg, pDlgData->pgContext))
+                    {
                         EndDialog(hwndDlg, WLX_SAS_ACTION_LOGON);
+                    }
+                    else
+                    {
+                        SetDlgItemTextW(hwndDlg, IDC_LOGON_PASSWORD, NULL);
+                        SendMessageW(hwndDlg, WM_NEXTDLGCTL, (WPARAM)GetDlgItem(hwndDlg, IDC_LOGON_PASSWORD), TRUE);
+                    }
                     return TRUE;
 
                 case IDCANCEL:
@@ -1625,7 +1633,14 @@ UnlockDialogProc(
             {
                 case IDOK:
                     if (DoUnlock(hwndDlg, pDlgData->pgContext, &result))
+                    {
                         EndDialog(hwndDlg, result);
+                    }
+                    else
+                    {
+                        SetDlgItemTextW(hwndDlg, IDC_UNLOCK_PASSWORD, NULL);
+                        SendMessageW(hwndDlg, WM_NEXTDLGCTL, (WPARAM)GetDlgItem(hwndDlg, IDC_UNLOCK_PASSWORD), TRUE);
+                    }
                     return TRUE;
 
                 case IDCANCEL:


### PR DESCRIPTION
## Purpose

Many Winlogon and MSGina dialogs were invoking `SetFocus()`, mostly in their `WM_INITDIALOG` handler, but in few cases also elsewhere, in an erroneous manner:
- If in `WM_INITDIALOG`, the handler returned `TRUE` nevertheless, thus ignoring any focus set by the caller;
- If in another handler, the focus would generate an inconsistent behaviour with the dialog push-buttons, as mentioned in https://devblogs.microsoft.com/oldnewthing/20040802-00/?p=38283 (and reminded to me in https://github.com/reactos/reactos/pull/8334#discussion_r2274589628 )

Take also the opportunity (2nd commit) to fix some dialog controls IDs, adjust few translations, and usability fixes in the dialogs requesting login (with password fields).

## Proposed changes

- ### `[MSGINA] Fix default focus to dialog controls`

- ### `[WINLOGON] *.rc: Fix dialog controls IDs; adjust few translations`

  - "1" == `IDOK`; "-1" == `IDC_STATIC`
  - Use the same translation for "Restart" between the two "GINA failed to load" and "Shutdown Computer" dialogs.

- ### `[WINLOGON] Let the dialog manager manage the default focus`

  - The single default button in the "Shutdown Computer" and "GINA failed to load" dialogs will be automatically focused by the dialog manager, so there is no need to invoke `SetFocus()` in their `WM_INITDIALOG` handler -- which also erroneously returned `TRUE`, thus ignoring any focus set by the caller :D

  - Use `DeleteMenu()` instead of `RemoveMenu()` so that it'll free any memory resources.

- ### `[MSGINA] Erase passwords & set focus back to the password field, in failure cases`

  Do this in the "Logon", "Unlock Computer", and "Change Password" dialogs.
