### PR TITLE
[LWIP] CMakeLists.txt: Add a 'not part of the build' comment

### DIFF
--- a/drivers/network/tcpip/lwip/CMakeLists.txt
+++ b/drivers/network/tcpip/lwip/CMakeLists.txt
@@ -1,3 +1,5 @@
+# This "example" CMakeLists.txt is not part of the build.
+
 cmake_minimum_required(VERSION 3.10)
 
 set (CMAKE_CONFIGURATION_TYPES "Debug;Release")


### PR DESCRIPTION
## Purpose

Make it obvious that we don't really care what this file is doing, especially using different settings than root CMakeLists.txt.

Addendum to d6eebaa47a (0.4.16-dev-237).

## Proposed changes

- CMakeLists.txt: Add a 'not part of the build' comment