### PR TITLE
[KMTESTS] ExHardError and RtlCaptureContextKM fixes

### DIFF
--- a/modules/rostests/apitests/rtl/amd64/RtlCaptureContext.c
+++ b/modules/rostests/apitests/rtl/amd64/RtlCaptureContext.c
@@ -154,10 +154,20 @@ START_TEST(RtlCaptureContext)
     ok_eq_hex64(CapturedContext.Legacy[7].Low, OriginalContext.Legacy[7].Low);
     ok_eq_hex64(CapturedContext.Legacy[7].High, OriginalContext.Legacy[7].High & 0xFF);
 #else
-    ok_eq_hex(CapturedContext.FltSave.ControlWord, 0xcccc);
-    ok_eq_hex(CapturedContext.FltSave.StatusWord, 0xcccc);
-    ok_eq_hex(CapturedContext.FltSave.TagWord, 0xcc);
-    ok_eq_hex(CapturedContext.FltSave.Reserved1, 0xcc);
+    if (GetNTVersion() >= _WIN32_WINNT_WIN8)
+    {
+        ok_eq_hex(CapturedContext.FltSave.ControlWord, 0x27f);
+        ok_eq_hex(CapturedContext.FltSave.StatusWord, 0x00);
+        ok_eq_hex(CapturedContext.FltSave.TagWord, 0x00);
+        ok_eq_hex(CapturedContext.FltSave.Reserved1, 0x00);
+    }
+    else
+    {
+        ok_eq_hex(CapturedContext.FltSave.ControlWord, 0xcccc);
+        ok_eq_hex(CapturedContext.FltSave.StatusWord, 0xcccc);
+        ok_eq_hex(CapturedContext.FltSave.TagWord, 0xcc);
+        ok_eq_hex(CapturedContext.FltSave.Reserved1, 0xcc);
+    }
     ok_eq_hex(CapturedContext.FltSave.MxCsr_Mask, 0xcccccccc);
     ok_eq_hex(CapturedContext.FltSave.ErrorOpcode, 0xcccc);
     ok_eq_hex(CapturedContext.FltSave.ErrorOffset, 0xcccccccc);
@@ -168,7 +178,10 @@ START_TEST(RtlCaptureContext)
     ok_eq_hex(CapturedContext.FltSave.Reserved3, 0xcccc);
 
     /* We get the value from OriginalContext.MxCsr, since we set that later in the wrapper */
-    ok_eq_hex(CapturedContext.FltSave.MxCsr, 0xcccccccc);
+    if (GetNTVersion() >= _WIN32_WINNT_WIN8)
+        ok_eq_hex(CapturedContext.FltSave.MxCsr, 0xffff);
+    else
+        ok_eq_hex(CapturedContext.FltSave.MxCsr, 0xcccccccc);
 
     /* Legacy floating point registers are truncated to 10 bytes */
     ok_eq_hex64(CapturedContext.Legacy[0].Low, 0xcccccccccccccccc);

--- a/modules/rostests/kmtests/ntos_ex/ExHardError.c
+++ b/modules/rostests/kmtests/ntos_ex/ExHardError.c
@@ -94,7 +94,27 @@ TestHardError(
     CheckHardError(0x40000003,                  0, OptionOk,                STATUS_SUCCESS,            ResponseNotHandled,     6, 1, 2, 3, 4, 5, 6);           // TODO: interactive on ROS
     }
 
-    CheckHardError(0x40000004,                  0, OptionShutdownSystem,    STATUS_PRIVILEGE_NOT_HELD, ResponseNotHandled,     0, 0);
+    // The return value is a random large value on Windows Server 2003
+    if (GetNTVersion() > _WIN32_WINNT_WS03)
+    {
+#if _WIN64
+        if (GetNTVersion() == _WIN32_WINNT_VISTA)
+        {
+            CheckHardError(0x40000004,                  0, OptionShutdownSystem,    STATUS_PRIVILEGE_NOT_HELD, 64,     0, 0);
+        }
+        else
+        {
+            CheckHardError(0x40000004,                  0, OptionShutdownSystem,    STATUS_PRIVILEGE_NOT_HELD, ResponseReturnToCaller,     0, 0);
+        }
+#else
+        // Return value is also a random large value on 32-bit 8+
+        if (GetNTVersion() < _WIN32_WINNT_WIN8)
+        {
+            CheckHardError(0x40000004,                  0, OptionShutdownSystem,    STATUS_PRIVILEGE_NOT_HELD, ResponseReturnToCaller,     0, 0);
+        }
+#endif
+    }
+
     if (InteractivePart1)
     {
     // TODO: these 2 are interactive on ROS
@@ -116,12 +136,12 @@ TestHardError(
     CheckHardError(0x40000013,                  0, OptionYesNoCancel,       STATUS_SUCCESS,            ResponseNo,             0, 0);                          // outputs a box :|
     CheckHardError(0x40000013,                  0, OptionYesNoCancel,       STATUS_SUCCESS,            ResponseCancel,         0, 0);                          // outputs a box :|
     }
-    CheckHardError(0x40000009,                  0, 9,                       STATUS_SUCCESS,            ResponseNotHandled,     0, 0);
-    CheckHardError(0x4000000a,                  0, 10,                      STATUS_SUCCESS,            ResponseNotHandled,     0, 0);
-    CheckHardError(0x4000000b,                  0, 11,                      STATUS_SUCCESS,            ResponseNotHandled,     0, 0);
-    CheckHardError(0x4000000c,                  0, 12,                      STATUS_SUCCESS,            ResponseNotHandled,     0, 0);
-    CheckHardError(0x4000000d,                  0, MAXULONG / 2 + 1,        STATUS_SUCCESS,            ResponseNotHandled,     0, 0);
-    CheckHardError(0x4000000d,                  0, MAXULONG,                STATUS_SUCCESS,            ResponseNotHandled,     0, 0);
+    CheckHardError(0x40000009,                  0, 9,                       STATUS_SUCCESS,            ResponseReturnToCaller,     0, 0);
+    CheckHardError(0x4000000a,                  0, 10,                      STATUS_SUCCESS,            ResponseReturnToCaller,     0, 0);
+    CheckHardError(0x4000000b,                  0, 11,                      STATUS_SUCCESS,            ResponseReturnToCaller,     0, 0);
+    CheckHardError(0x4000000c,                  0, 12,                      STATUS_SUCCESS,            ResponseReturnToCaller,     0, 0);
+    CheckHardError(0x4000000d,                  0, MAXULONG / 2 + 1,        STATUS_SUCCESS,            ResponseReturnToCaller,     0, 0);
+    CheckHardError(0x4000000d,                  0, MAXULONG,                STATUS_SUCCESS,            ResponseReturnToCaller,     0, 0);
 
     if (InteractivePart2)
     {


### PR DESCRIPTION
## Purpose

Fixes failing tests on Windows.

## Proposed changes

- Adjust expected values (often according to NT version).

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: