### PR TITLE
[NTGDI] Fix SAI Paint Tool Initial Graphics Display

### DIFF
--- a/win32ss/gdi/ntgdi/dibobj.c
+++ b/win32ss/gdi/ntgdi/dibobj.c
@@ -585,7 +585,7 @@ NtGdiSetDIBitsToDeviceInternal(
 
     SourceSize.cx = bmi->bmiHeader.biWidth;
     SourceSize.cy = ScanLines;
-    if (YDest >= 0 && YSrc >= 0)
+    if (YDest >= 0 && YSrc > 0)
     {
         ScanLines += YSrc;
     }

--- a/win32ss/gdi/ntgdi/dibobj.c
+++ b/win32ss/gdi/ntgdi/dibobj.c
@@ -532,7 +532,10 @@ NtGdiSetDIBitsToDeviceInternal(
     {
         ScanLines = min(abs(Height), ScanLines);
         if (YSrc > 0)
+        {
             ScanLines += YSrc;
+            YSrc = 0;
+        }
     }
     else
     {
@@ -582,7 +585,7 @@ NtGdiSetDIBitsToDeviceInternal(
 
     SourceSize.cx = bmi->bmiHeader.biWidth;
     SourceSize.cy = ScanLines;
-    if (YDest >= 0 && YSrc > 0)
+    if (YDest >= 0 && YSrc >= 0)
     {
         ScanLines += YSrc;
     }

--- a/win32ss/gdi/ntgdi/dibobj.c
+++ b/win32ss/gdi/ntgdi/dibobj.c
@@ -519,7 +519,7 @@ NtGdiSetDIBitsToDeviceInternal(
     _SEH2_END;
 
     DPRINT("StartScan %d ScanLines %d Bits %p bmi %p ColorUse %d\n"
-           "    Height %d Width %d SizeImage %d\n"
+           "    Height %d Width %d biSizeImage %d\n"
            "    biHeight %d biWidth %d biBitCount %d\n"
            "    XSrc %d YSrc %d XDest %d YDest %d\n",
            StartScan, ScanLines, Bits, bmi, ColorUse,

--- a/win32ss/gdi/ntgdi/dibobj.c
+++ b/win32ss/gdi/ntgdi/dibobj.c
@@ -521,7 +521,7 @@ NtGdiSetDIBitsToDeviceInternal(
     DPRINT("StartScan %d ScanLines %d Bits %p bmi %p ColorUse %d\n"
            "    Height %d Width %d SizeImage %d\n"
            "    biHeight %d biWidth %d biBitCount %d\n"
-           "    XSrc %d YSrc %d xDext %d yDest %d\n",
+           "    XSrc %d YSrc %d XDest %d YDest %d\n",
            StartScan, ScanLines, Bits, bmi, ColorUse,
            Height, Width, bmi->bmiHeader.biSizeImage,
            bmi->bmiHeader.biHeight, bmi->bmiHeader.biWidth,
@@ -585,10 +585,6 @@ NtGdiSetDIBitsToDeviceInternal(
 
     SourceSize.cx = bmi->bmiHeader.biWidth;
     SourceSize.cy = ScanLines;
-    if (YDest >= 0 && YSrc > 0)
-    {
-        ScanLines += YSrc;
-    }
 
     //DIBWidth = WIDTH_BYTES_ALIGN32(SourceSize.cx, bmi->bmiHeader.biBitCount);
 


### PR DESCRIPTION
CORE-15002
Credit for this goes to Simone Lombardo

## Purpose

Show actual bitmaps instead of black boxes on graphics of SAI Paint Tool.

JIRA issue: [CORE-15002](https://jira.reactos.org/browse/CORE-15002)

## Proposed changes

In function NtGdiSetDIBitsToDeviceInternal check if `YDest >= 0` and `YSrc > 0`.
If the above is true, then set `YSrc = 0`.
This fixes the initial graphics display for the SAI paint tool program.

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=103616,103619
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=103617,103620

(See `gdi32:bitmap` test.)

Before:
<img width="1042" height="856" alt="SAI_Paint_Tool_Large_Before" src="https://github.com/user-attachments/assets/6f0345dd-bda3-4966-99a7-b4d05002f2c1" />

After:
<img width="1042" height="856" alt="SAI_Paint_Tool_Large_After" src="https://github.com/user-attachments/assets/6feb404f-b671-489f-8cd6-2bec5c752a0b" />

_Note: Since this affects code involving PR #5227, I also tested VB6, Word 2000, Excel 2000, and Hoyle Cards._