### PR TITLE
[ROSTESTS][SHELL32] The shellexec(n) tests are broken on Windows

### DIFF
--- a/modules/rostests/apitests/shell32/testlist.c
+++ b/modules/rostests/apitests/shell32/testlist.c
@@ -97,10 +97,10 @@ const struct test winetest_testlist[] =
     { "SHDefExtractIcon", func_SHDefExtractIcon },
     { "SHEnumerateUnreadMailAccountsW", func_SHEnumerateUnreadMailAccountsW },
     { "She", func_She },
-    { "ShellExec_RunDLL", func_ShellExec_RunDLL },
-    { "ShellExecCmdLine", func_ShellExecCmdLine },
-    { "ShellExecuteEx", func_ShellExecuteEx },
-    { "ShellExecuteW", func_ShellExecuteW },
+    //{ "ShellExec_RunDLL", func_ShellExec_RunDLL }, Broke on Windows
+    //{ "ShellExecCmdLine", func_ShellExecCmdLine }, Broke on Windows
+    //{ "ShellExecuteEx", func_ShellExecuteEx }, Broke on Windows
+    //{ "ShellExecuteW", func_ShellExecuteW }, Broke on Windows
     { "ShellHook", func_ShellHook },
     { "ShellState", func_ShellState },
     { "SHGetAttributesFromDataObject", func_SHGetAttributesFromDataObject },


### PR DESCRIPTION
They leave a bunch of processes spawned forever preventing the system from shutting down