### PR TITLE
[CMAKE] clang*: Re-enable -Werror=unknown-warning-option

### DIFF
--- a/dll/win32/ucrtbase/CMakeLists.txt
+++ b/dll/win32/ucrtbase/CMakeLists.txt
@@ -22,11 +22,9 @@ add_library(ucrtbase SHARED
     ucrtbase.def
 )
 
-if(NOT MSVC)
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
     target_compile_options(ucrtbase PRIVATE -Wno-builtin-declaration-mismatch)
-endif()
-
-if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
+elseif(CMAKE_C_COMPILER_ID STREQUAL "Clang")
     # Silence warnings in ucrtbase_stubs.c
     target_compile_options(ucrtbase PRIVATE -Wno-incompatible-library-redeclaration)
 endif()

--- a/drivers/wdm/audio/drivers/CMIDriver/CMakeLists.txt
+++ b/drivers/wdm/audio/drivers/CMIDriver/CMakeLists.txt
@@ -31,7 +31,10 @@ if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
 endif()
 
 if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
-    target_compile_options(cmipci PRIVATE -Wno-enum-constexpr-conversion)
+    if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL "16" AND
+       CMAKE_C_COMPILER_VERSION VERSION_LESS "20.1")
+        target_compile_options(cmipci PRIVATE -Wno-enum-constexpr-conversion)
+    endif()
 endif()
 
 add_pch(cmipci precomp.h "${PCH_SKIP_SOURCE}")

--- a/sdk/cmake/gcc.cmake
+++ b/sdk/cmake/gcc.cmake
@@ -184,9 +184,10 @@ add_compile_options(
     -Wno-deprecated
     -Wno-unused-result # FIXME To be removed when CORE-17637 is resolved
     -Wno-format
-    -Wno-maybe-uninitialized
-    -Wno-nonnull-compare
 )
+if(NOT CMAKE_C_COMPILER_ID STREQUAL "Clang")
+    add_compile_options(-Wno-maybe-uninitialized)
+endif()
 
 if(ARCH STREQUAL "arm")
     add_compile_options(-Wno-attributes)
@@ -194,13 +195,14 @@ endif()
 
 if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
     add_compile_options(
+        -Wno-nonnull-compare
         -Wno-unknown-pragmas
     )
 elseif(CMAKE_C_COMPILER_ID STREQUAL "Clang")
-    add_compile_options("$<$<COMPILE_LANGUAGE:C>:-Wno-microsoft>")
     add_compile_options(
+        $<$<COMPILE_LANGUAGE:C>:-Wno-microsoft>
         -Wno-pragma-pack
-        -Wno-unknown-warning-option
+        $<$<COMPILE_LANGUAGE:C,CXX>:-Werror=unknown-warning-option>
     )
 endif()
 

--- a/sdk/cmake/msvc.cmake
+++ b/sdk/cmake/msvc.cmake
@@ -158,9 +158,9 @@ endif()
 add_compile_options(/w14115)
 
 if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
-    add_compile_options("$<$<COMPILE_LANGUAGE:C,CXX>:-nostdinc>")
     add_compile_options(
-        -Wno-unknown-warning-option
+        $<$<COMPILE_LANGUAGE:C,CXX>:-Werror=unknown-warning-option>
+        $<$<COMPILE_LANGUAGE:C,CXX>:-nostdinc>
         -Wno-multichar
         -Wno-char-subscripts
         -Wno-microsoft-enum-forward-reference

--- a/sdk/lib/3rdparty/zlib/CMakeLists.txt
+++ b/sdk/lib/3rdparty/zlib/CMakeLists.txt
@@ -31,7 +31,7 @@ list(APPEND MINIZIP_SOURCE
     contrib/minizip/zip.c
     contrib/minizip/zip.h)
 
-if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
+if(CMAKE_C_COMPILER_ID STREQUAL "Clang" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL "15")
     add_compile_options(-Wno-deprecated-non-prototype)
 endif()
 

--- a/sdk/lib/ucrt/CMakeLists.txt
+++ b/sdk/lib/ucrt/CMakeLists.txt
@@ -37,10 +37,8 @@ if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR
    CMAKE_C_COMPILER_ID STREQUAL "Clang")
     # Silence GCC/Clang warnings
     add_compile_options(
-        -Wno-unknown-warning-option
         -Wno-unused-function
         -Wno-unknown-pragmas
-        -Wno-builtin-declaration-mismatch
         -Wno-parentheses
         -Wno-unused-variable
         -Wno-sign-compare
@@ -63,6 +61,9 @@ if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR
         -Wno-ignored-attributes
         -Wno-uninitialized
     )
+    if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+        add_compile_options(-Wno-builtin-declaration-mismatch)
+    endif()
     add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-reorder>)
 endif()
 

--- a/sdk/lib/vcruntime/CMakeLists.txt
+++ b/sdk/lib/vcruntime/CMakeLists.txt
@@ -14,10 +14,10 @@ endif()
 # Silence GCC/Clang warnings
 if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR
    CMAKE_C_COMPILER_ID STREQUAL "Clang")
-    add_compile_options(
-        -Wno-builtin-declaration-mismatch
-        -Wno-unused-function
-    )
+    add_compile_options(-Wno-unused-function)
+    if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+        add_compile_options(-Wno-builtin-declaration-mismatch)
+    endif()
 endif()
 
 add_compile_definitions(


### PR DESCRIPTION
## Purpose

Fix regressions and new cases since it was disabled.
Clarify current state, allow further work on other options.

JIRA issue: [CORE-20226](https://jira.reactos.org/browse/CORE-20226)

## Proposed changes

- Fix affected occurrences.
- Re-enable -Werror=unknown-warning-option.