### PR TITLE
[APPCOMPAT] Add RendererFull3D flag

### DIFF
--- a/dll/appcompat/apphelp/shimeng.c
+++ b/dll/appcompat/apphelp/shimeng.c
@@ -1219,12 +1219,12 @@ VOID SeiInit(LPCWSTR ProcessImage, HSDB hsdb, SDBQUERYRESULT* pQuery, BOOLEAN Pr
     SeiBuildShimRefArray(hsdb, pQuery, &ShimRefArray, &ShimFlags);
     if (ShimFlags.AppCompatFlags.QuadPart)
     {
-        SeiDbgPrint(SEI_MSG, NULL, "Using KERNEL apphack flags 0x%I64x\n", ShimFlags.AppCompatFlags.QuadPart);
+        SeiDbgPrint(SEI_MSG, NULL, "Using KERNEL apphack flags 0x%llx\n", ShimFlags.AppCompatFlags.QuadPart);
         Peb->AppCompatFlags.QuadPart |= ShimFlags.AppCompatFlags.QuadPart;
     }
     if (ShimFlags.AppCompatFlagsUser.QuadPart)
     {
-        SeiDbgPrint(SEI_MSG, NULL, "Using USER apphack flags 0x%I64x\n", ShimFlags.AppCompatFlagsUser.QuadPart);
+        SeiDbgPrint(SEI_MSG, NULL, "Using USER apphack flags 0x%llx\n", ShimFlags.AppCompatFlagsUser.QuadPart);
         Peb->AppCompatFlagsUser.QuadPart |= ShimFlags.AppCompatFlagsUser.QuadPart;
     }
     if (ShimFlags.ProcessParameters_Flags)

--- a/dll/appcompat/apphelp/shimeng.h
+++ b/dll/appcompat/apphelp/shimeng.h
@@ -76,8 +76,8 @@ typedef struct _HOOKMODULEINFO
 
 typedef struct _FLAGINFO
 {
-    ULARGE_INTEGER AppCompatFlags;
-    ULARGE_INTEGER AppCompatFlagsUser;
+    ULARGE_INTEGER AppCompatFlags;     // APPCOMPAT_FLAGS
+    ULARGE_INTEGER AppCompatFlagsUser; // APPCOMPAT_USERFLAGS
     ULONG ProcessParameters_Flags;
 } FLAGINFO, *PFLAGINFO;
 

--- a/media/sdb/sysmain.xml
+++ b/media/sdb/sysmain.xml
@@ -271,6 +271,10 @@
                 <FLAG_MASK_KERNEL>8</FLAG_MASK_KERNEL>
             </FLAG>
 
+            <FLAG NAME="RendererFull3D">
+                <!-- ReactOS specific (CORE-20322) -->
+                <FLAG_MASK_KERNEL>0x8000000000000000</FLAG_MASK_KERNEL>
+            </FLAG>
         </LIBRARY>
 
         <!-- Backwards compatibility layers, incomplete! -->
@@ -441,6 +445,9 @@
         </LAYER>
         <LAYER NAME="GetDiskFreeSpace2GB">
             <FLAG_REF NAME="GetDiskFreeSpace2GB" />
+        </LAYER>
+        <LAYER NAME="RendererFull3D">
+            <FLAG_REF NAME="RendererFull3D" />
         </LAYER>
 
         <!-- Applications -->

--- a/sdk/include/ndk/peb_teb.h
+++ b/sdk/include/ndk/peb_teb.h
@@ -155,8 +155,8 @@ typedef struct STRUCT(_PEB)
     ULONG TlsExpansionBitmapBits[32];
     ULONG SessionId;
 #if (NTDDI_VERSION >= NTDDI_WINXP)
-    ULARGE_INTEGER AppCompatFlags;
-    ULARGE_INTEGER AppCompatFlagsUser;
+    ULARGE_INTEGER AppCompatFlags;     // APPCOMPAT_FLAGS
+    ULARGE_INTEGER AppCompatFlagsUser; // APPCOMPAT_USERFLAGS
     PTR(PVOID) pShimData;
     PTR(PVOID) AppCompatInfo;
     STRUCT(UNICODE_STRING) CSDVersion;

--- a/sdk/include/ndk/pstypes.h
+++ b/sdk/include/ndk/pstypes.h
@@ -752,7 +752,7 @@ typedef struct _Wx86ThreadState
 #endif
 
 //
-// PEB.AppCompatFlags
+// PEB.AppCompatFlags.LowPart
 // Tag FLAG_MASK_KERNEL
 //
 typedef enum _APPCOMPAT_FLAGS
@@ -773,8 +773,30 @@ typedef enum _APPCOMPAT_FLAGS
     DisableNDRIIDConsistencyCheck = 0x20000,
     UserDisableForwarderPatch = 0x40000,
     DisableNewWMPAINTDispatchInOLE = 0x100000,
+    AddRestrictedSidInCoInitializeSecurity = 0x200000,
+    AllocDebugInfoForCritSections = 0x400000,
+    EnableLegacyLoadTypeLibForRelativePaths = 0x800000,
+    AllowMaximizedWindowGamma = 0x1000000,
+    CloudFilesHydrationDisallowed = 0x2000000,
+    CloudFilesFullHydrationOnOpen = 0x4000000,
+    CloudFilesFullHydration = 0x8000000,
+    DisableParallelLoader = 0x10000000,
+    DisguisePlaceholders = 0x20000000,
+    CloudFilesHydrationInForeground = 0x40000000,
     DoNotAddToCache = 0x80000000,
 } APPCOMPAT_FLAGS;
+
+//
+// PEB.AppCompatFlags.HighPart
+// Tag FLAG_MASK_KERNEL
+//
+typedef enum _APPCOMPAT_FLAGS_HIGHPART
+{
+    PosixDeleteDisabled = 0x1,
+
+    // ReactOS-specific
+    RendererFull3D = 0x80000000,    // CORE-20322
+} APPCOMPAT_FLAGS_HIGHPART;
 
 
 //
@@ -814,11 +836,6 @@ typedef enum _APPCOMPAT_USERFLAGS
     ForceLegacyResizeCM = 0x20000000,
     HardwareAudioMixer = 0x40000000,
     DisableSWCursorOnMoveSize = 0x80000000,
-#if 0
-    DisableWindowArrangement = 0x100000000,
-    ReorderWaveForCommunications = 0x200000000,
-    NoGdiHwAcceleration = 0x400000000,
-#endif
 } APPCOMPAT_USERFLAGS;
 
 //
@@ -830,6 +847,34 @@ typedef enum _APPCOMPAT_USERFLAGS_HIGHPART
     DisableWindowArrangement = 0x1,
     ReorderWaveForCommunications = 0x2,
     NoGdiHwAcceleration = 0x4,
+    NoTimerCoalescing = 0x8,
+    PrinterIsolationAware = 0x10,
+    UseWARPRendering = 0x20,
+    MirrorDriverDrawCursor = 0x40,
+    InstallShieldInstaller = 0x80,
+    Disable8And16BitModes = 0x100,
+    Disable8And16BitD3D = 0x200,
+    PromotePointer = 0x400,
+    PreventMouseInPointer = 0x800,
+    _8And16BitAggregateBlts = 0x1000,
+    _8And16BitGDIRedraw = 0x2000,
+    _8And16BitCopyOnFlip = 0x4000,
+    _8And16BitNoIncRefCount = 0x8000,
+    _8And16BitDXMaxWinMode = 0x10000,
+    EarlyMouseDelegation = 0x20000,
+    _8And16BitTimedPriSync = 0x40000,
+    UseIntegratedGraphics = 0x80000,
+    UseLegacyMouseWheelRouting = 0x100000,
+    PerProcessSystemDPIForceOn = 0x200000,
+    PerProcessSystemDPIForceOff = 0x400000,
+    DPIUnaware = 0x800000,
+    NoVirtWndRects = 0x1000000,
+    CFDNoRedirectInitialFolder = 0x2000000,
+    NoDTToDITMouseBatch = 0x4000000,
+    GdiDPIScaling = 0x8000000,
+    QueueMouseMoveOnReleaseCapture = 0x10000000,
+    DisableFocusTracking = 0x20000000,
+    GdiDPIScalingForceDisable = 0x40000000,
 } APPCOMPAT_USERFLAGS_HIGHPART;
 
 //

--- a/sdk/tools/xml2sdb/xml2sdb.cpp
+++ b/sdk/tools/xml2sdb/xml2sdb.cpp
@@ -88,7 +88,7 @@ std::string ReadStringNode(XMLHandle dbNode, const char* nodeName)
     return ToString(dbNode.FirstChildElement(nodeName));
 }
 
-DWORD ReadQWordNode(XMLHandle dbNode, const char* nodeName)
+QWORD ReadQWordNode(XMLHandle dbNode, const char* nodeName)
 {
     std::string value = ReadStringNode(dbNode, nodeName);
     int base = 10;
@@ -97,7 +97,7 @@ DWORD ReadQWordNode(XMLHandle dbNode, const char* nodeName)
         base = 16;
         value = value.substr(2);
     }
-    return static_cast<QWORD>(strtoul(value.c_str(), NULL, base));
+    return static_cast<QWORD>(strtoull(value.c_str(), NULL, base));
 }
 
 DWORD ReadDWordNode(XMLHandle dbNode, const char* nodeName)


### PR DESCRIPTION
This flag will be used for DDraw experiments.

Use the flag like this:
```c
    if (NtCurrentPeb()->AppCompatFlags.HighPart & RendererFull3D)
    {
        MessageBoxW(
            NULL,
            L"Disk Cleanup cannot run under AppCompat with the 'Force 3D rendering for all applications' setting "
            L"enabled.",
            L"Disk Cleanup", MB_OK | MB_ICONERROR);
    }

```

JIRA issue: [CORE-20322](https://jira.reactos.org/browse/CORE-20322)
