### PR TITLE
[GITHUB] build-msvc-arm: Limit arm to windows-2022

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,11 +145,19 @@ jobs:
   build-msvc-arm:
     strategy:
       matrix:
-        toolset: ['14','14.2'] # VS 2022, 2019
+        os: [windows-2022, windows-latest]
+        toolset: ['14', '14.29'] # VS 2022 (ongoing), 2019 (last)
         arch: [arm, arm64]
         config: [Debug, Release]
+        exclude:
+          # arm64: windows-latest is enough/fine.
+          - os: windows-2022
+            arch: arm64
+          # arm (sdk): only available on windows-2022.
+          - os: windows-latest
+            arch: arm
       fail-fast: false
-    runs-on: windows-latest
+    runs-on: ${{matrix.os}}
     steps:
     - name: Install ninja
       run: choco install -y ninja


### PR DESCRIPTION
## Purpose

Needed SDK support is not available on windows-2025.

Also, tweak toolset line.

JIRA issue: [CORE-20325](https://jira.reactos.org/browse/CORE-20325)

## Proposed changes

- Limit arm to windows-2022