### PR TITLE
[NTGDI] Fix 2 bugs in IntGdiWidenPath

### DIFF
--- a/win32ss/gdi/ntgdi/path.c
+++ b/win32ss/gdi/ntgdi/path.c
@@ -1789,7 +1789,7 @@ PPATH FASTCALL
 IntGdiWidenPath(PPATH pPath, UINT penWidth, UINT penStyle, FLOAT eMiterLimit)
 {
     INT i, j, numStrokes, numOldStrokes, penWidthIn, penWidthOut;
-    PPATH flat_path, pNewPath, *pStrokes = NULL, *pOldStrokes, pUpPath, pDownPath;
+    PPATH flat_path, pNewPath = NULL, *pStrokes = NULL, *pOldStrokes, pUpPath, pDownPath;
     BYTE *type;
     DWORD joint, endcap;
     KFLOATING_SAVE fpsave;
@@ -1819,11 +1819,7 @@ IntGdiWidenPath(PPATH pPath, UINT penWidth, UINT penStyle, FLOAT eMiterLimit)
             ERR("Expected PT_MOVETO %s, got path flag %c\n",
                     i == 0 ? "as first point" : "after PT_CLOSEFIGURE",
                     flat_path->pFlags[i]);
-            if (pStrokes)
-                ExFreePoolWithTag(pStrokes, TAG_PATH);
-            PATH_UnlockPath(flat_path);
-            PATH_Delete(flat_path->BaseObject.hHmgr);
-            return NULL;
+            goto Exit;
         }
         switch(flat_path->pFlags[i])
         {
@@ -1844,18 +1840,14 @@ IntGdiWidenPath(PPATH pPath, UINT penWidth, UINT penStyle, FLOAT eMiterLimit)
                     if (!pStrokes)
                     {
                        ExFreePoolWithTag(pOldStrokes, TAG_PATH);
-                       PATH_UnlockPath(flat_path);
-                       PATH_Delete(flat_path->BaseObject.hHmgr);
-                       return NULL;
+                       goto Exit;
                     }
                     RtlCopyMemory(pStrokes, pOldStrokes, numOldStrokes * sizeof(PPATH));
                     ExFreePoolWithTag(pOldStrokes, TAG_PATH); // Free old pointer.
                 }
                 if (!pStrokes)
                 {
-                   PATH_UnlockPath(flat_path);
-                   PATH_Delete(flat_path->BaseObject.hHmgr);
-                   return NULL;
+                   goto Exit;
                 }
                 pStrokes[numStrokes - 1] = ExAllocatePoolWithTag(PagedPool, sizeof(PATH), TAG_PATH);
                 if (!pStrokes[numStrokes - 1])
@@ -1876,15 +1868,16 @@ IntGdiWidenPath(PPATH pPath, UINT penWidth, UINT penStyle, FLOAT eMiterLimit)
                 break;
             default:
                 ERR("Got path flag %c\n", flat_path->pFlags[i]);
-                if (pStrokes)
-                    ExFreePoolWithTag(pStrokes, TAG_PATH);
-                PATH_UnlockPath(flat_path);
-                PATH_Delete(flat_path->BaseObject.hHmgr);
-                return NULL;
+                goto Exit;
         }
     }
 
     pNewPath = PATH_CreatePath( flat_path->numEntriesUsed );
+    if (pNewPath == NULL)
+    {
+        ERR("PATH_CreatePath\n");
+        goto Exit;
+    }
 
     KeSaveFloatingPointState(&fpsave);
 
@@ -2106,14 +2099,17 @@ IntGdiWidenPath(PPATH pPath, UINT penWidth, UINT penStyle, FLOAT eMiterLimit)
         PATH_DestroyGdiPath(pDownPath);
         ExFreePoolWithTag(pDownPath, TAG_PATH);
     }
-    if (pStrokes) ExFreePoolWithTag(pStrokes, TAG_PATH);
 
-    PATH_UnlockPath(flat_path);
-    PATH_Delete(flat_path->BaseObject.hHmgr);
     pNewPath->state = PATH_Closed;
     PATH_UnlockPath(pNewPath);
 
     KeRestoreFloatingPointState(&fpsave);
+
+Exit:
+    if (pStrokes) ExFreePoolWithTag(pStrokes, TAG_PATH);
+    HPATH hpathToDelete = flat_path->BaseObject.hHmgr;
+    PATH_UnlockPath(flat_path);
+    PATH_Delete(hpathToDelete);
 
     return pNewPath;
 }

--- a/win32ss/gdi/ntgdi/path.c
+++ b/win32ss/gdi/ntgdi/path.c
@@ -1792,6 +1792,7 @@ IntGdiWidenPath(PPATH pPath, UINT penWidth, UINT penStyle, FLOAT eMiterLimit)
     PPATH flat_path, pNewPath, *pStrokes = NULL, *pOldStrokes, pUpPath, pDownPath;
     BYTE *type;
     DWORD joint, endcap;
+    KFLOATING_SAVE fpsave;
 
     endcap = (PS_ENDCAP_MASK & penStyle);
     joint = (PS_JOIN_MASK & penStyle);
@@ -1884,6 +1885,8 @@ IntGdiWidenPath(PPATH pPath, UINT penWidth, UINT penStyle, FLOAT eMiterLimit)
     }
 
     pNewPath = PATH_CreatePath( flat_path->numEntriesUsed );
+
+    KeSaveFloatingPointState(&fpsave);
 
     for (i = 0; i < numStrokes; i++)
     {
@@ -2109,6 +2112,9 @@ IntGdiWidenPath(PPATH pPath, UINT penWidth, UINT penStyle, FLOAT eMiterLimit)
     PATH_Delete(flat_path->BaseObject.hHmgr);
     pNewPath->state = PATH_Closed;
     PATH_UnlockPath(pNewPath);
+
+    KeRestoreFloatingPointState(&fpsave);
+
     return pNewPath;
 }
 


### PR DESCRIPTION
## Purpose

Fixes 2 bugs in IntGdiWidenPath that cause crashes:
- Save and restore floating point state to avoid both inheriting a bad exception state, that can cause a bugcheck on a divide-by-zero-error.
- Add failure check for PATH_CreatePath and use a common "goto Exit" path

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: