### PR TITLE
[NTUSER] IntLanguageToggle(): Guard against NULL pFocusQueue

### DIFF
--- a/win32ss/user/ntuser/keyboard.c
+++ b/win32ss/user/ntuser/keyboard.c
@@ -821,12 +821,17 @@ IntLanguageToggle(
     _In_ BOOL bSameLang,
     _In_ INT nKeyState)
 {
-    PWND pWnd = pFocusQueue->spwndFocus;
-    HWND hWnd;
-    WPARAM wParam = 0;
+    PWND pWnd;
     PTHREADINFO pti;
     PKL pkl;
+    WPARAM wParam = 0;
 
+    if (!pFocusQueue)
+    {
+        ERR("IntLanguageToggle(): NULL pFocusQueue\n");
+        return;
+    }
+    pWnd = pFocusQueue->spwndFocus;
     if (!pWnd)
         pWnd = pFocusQueue->spwndActive;
     if (!pWnd)
@@ -843,8 +848,7 @@ IntLanguageToggle(
     if (gSystemFS & pkl->dwFontSigs)
         wParam |= INPUTLANGCHANGE_SYSCHARSET;
 
-    hWnd = UserHMGetHandle(pWnd);
-    UserPostMessage(hWnd, WM_INPUTLANGCHANGEREQUEST, wParam, (LPARAM)pkl->hkl);
+    UserPostMessage(UserHMGetHandle(pWnd), WM_INPUTLANGCHANGEREQUEST, wParam, (LPARAM)pkl->hkl);
 }
 
 /* Check Language Toggle by [Left Alt]+Shift or Ctrl+Shift */


### PR DESCRIPTION
## Purpose

Guard against NULL pFocusQueue.
Addendum to commit 25b7447818 (PR #5839)

## How to reproduce

When being on the ReactOS explorer desktop, open the Start menu and select "Turn Off" (Shutdown).
In the Shutdown dialog, click on the "Cancel" button _**while pressing**_ on the keyboard the Ctrl-Alt-Shift keys combination, and also pressing/releasing each of these keys while maintaining the others very fast.