### PR TITLE
[NTUSER] NtUserSetLogonNotifyWindow(): Lock-protect access to global data

### DIFF
--- a/win32ss/user/ntuser/winsta.c
+++ b/win32ss/user/ntuser/winsta.c
@@ -1963,19 +1963,25 @@ NtUserBuildNameList(
 BOOL APIENTRY
 NtUserSetLogonNotifyWindow(HWND hWnd)
 {
-    if (gpidLogon != PsGetCurrentProcessId())
-    {
-        return FALSE;
-    }
+    BOOL Ret = FALSE;
+
+    UserEnterExclusive();
 
     if (!IntIsWindow(hWnd))
+        goto Leave;
+
+    if (gpidLogon != PsGetCurrentProcessId())
     {
-        return FALSE;
+        EngSetLastError(ERROR_ACCESS_DENIED);
+        goto Leave;
     }
 
     hwndSAS = hWnd;
+    Ret = TRUE;
 
-    return TRUE;
+Leave:
+    UserLeave();
+    return Ret;
 }
 
 BOOL


### PR DESCRIPTION
## Purpose / Proposed changes

Lock-protect access to global data, like with all the other win32k NtUser* functions:
acquire on entry and release on exit the global lock, since the function is reading/writing to global variables.

Also, set the last-error to `ERROR_ACCESS_DENIED` if the caller isn't the registered logon process.
