### PR TITLE
[MSGINA] OnInitSecurityDlg(): Remove unnecessary code

### DIFF
--- a/dll/win32/msgina/gui.c
+++ b/dll/win32/msgina/gui.c
@@ -842,9 +842,6 @@ OnInitSecurityDlg(HWND hwnd,
     wsprintfW(Buffer4, Buffer1, Buffer2, Buffer3);
 
     SetDlgItemTextW(hwnd, IDC_SECURITY_LOGONDATE, Buffer4);
-
-    if (pgContext->bAutoAdminLogon)
-        EnableWindow(GetDlgItem(hwnd, IDC_SECURITY_LOGOFF), FALSE);
 }
 
 


### PR DESCRIPTION
## Purpose

The Security dialog can be displayed only when a user is logged. When this is so, the `pgContext->bAutoAdminLogon` has already been reset to `FALSE`, see `gui.c!DoLogon()`. Thus there is really no reason to disable the "Log Off" button in that case.

Addendum to commit c633b79451 (r61622)
