### PR TITLE
[BOOTDATA] Disable logoff/password-change/workstation-lock in the LiveCD

### DIFF
--- a/boot/bootdata/livecd.inf
+++ b/boot/bootdata/livecd.inf
@@ -41,6 +41,14 @@ HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\ComDlg32",,0x00000012
 HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\ComDlg32\LastVisitedMRU",,0x00000012
 HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\ComDlg32\OpenSaveMRU",,0x00000012
 
+; Policies overrides
+HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon","DisableLockWorkstation",0x00010001,1
+HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System","DisableLockWorkstation",0x00010001,1
+HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System","DisableChangePassword",0x00010001,1
+HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer","NoDisconnect",0x00010001,1
+HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer","NoLogoff",0x00010001,1
+HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer","StartMenuLogoff",0x00010001,1
+
 ; User Profile environment variables
 HKLM,"SYSTEM\CurrentControlSet\Control\Session Manager\Environment","USERPROFILE",0x00020000,"%SystemDrive%\Profiles\Default User"
 HKLM,"SYSTEM\CurrentControlSet\Control\Session Manager\Environment","ALLUSERSPROFILE",0x00020000,"%SystemDrive%\Profiles\All Users"


### PR DESCRIPTION
## Purpose & Proposed changes

- Disable "Log Off" from the Start Menu and the C-A-D Security dialog;

- Disable the "Lock Workstation" and "Change Password" buttons in the Security dialog.

These are only "UI"-usability features to prevent the user from logging off when running the LiveCD. (Logging off from the SYSTEM account, and changing its password, don't make much sense.)

- Requires PR #8372 for this to work.

JIRA issue: [CORE-11397](https://jira.reactos.org/browse/CORE-11397)

## How it looks like

- No "Log off" item in the Start menu and amongst the Shutdown dialog choices:
  <img width="666" height="353" alt="shutdown_dialog_choices" src="https://github.com/user-attachments/assets/75ff3141-e45e-409a-a997-45957bb1453a" />

- The LiveCD doesn't react to the Ctrl-Alt-Del (partially on purpose), so it doesn't show the Security dialog.
  Here is the Security dialog when run from a regular ReactOS installation, after applying the same policy settings:
  <img width="797" height="568" alt="security_dialog" src="https://github.com/user-attachments/assets/2c66e871-c481-4d86-91cc-4660b839fab7" />
