### PR TITLE
[VIDEOPRT][WIN32K] Fix crash/lockup after VMware Tools' VGA driver is installed

### DIFF
--- a/win32ss/drivers/videoprt/dispatch.c
+++ b/win32ss/drivers/videoprt/dispatch.c
@@ -1055,6 +1055,16 @@ IntVideoPortForwardIrpAndWait(PDEVICE_OBJECT DeviceObject, PIRP Irp)
     PVIDEO_PORT_DEVICE_EXTENSION DeviceExtension =
         (PVIDEO_PORT_DEVICE_EXTENSION)DeviceObject->DeviceExtension;
 
+    /* Check if we have a lower device to forward to */
+    if (DeviceExtension->NextDeviceObject == NULL)
+    {
+        /* No lower device, complete the request with success */
+        Irp->IoStatus.Status = STATUS_SUCCESS;
+        Irp->IoStatus.Information = 0;
+        IoCompleteRequest(Irp, IO_NO_INCREMENT);
+        return STATUS_SUCCESS;
+    }
+
     KeInitializeEvent(&Event, NotificationEvent, FALSE);
     IoCopyCurrentIrpStackLocationToNext(Irp);
     IoSetCompletionRoutine(Irp,
@@ -1109,8 +1119,19 @@ IntVideoPortDispatchFdoPnp(
         case IRP_MN_QUERY_DEVICE_RELATIONS:
             if (IrpSp->Parameters.QueryDeviceRelations.Type != BusRelations)
             {
-                IoSkipCurrentIrpStackLocation(Irp);
-                Status = IoCallDriver(DeviceExtension->NextDeviceObject, Irp);
+                if (DeviceExtension->NextDeviceObject != NULL)
+                {
+                    IoSkipCurrentIrpStackLocation(Irp);
+                    Status = IoCallDriver(DeviceExtension->NextDeviceObject, Irp);
+                }
+                else
+                {
+                    /* No lower device to forward to, complete the request */
+                    Irp->IoStatus.Status = STATUS_SUCCESS;
+                    Irp->IoStatus.Information = 0;
+                    IoCompleteRequest(Irp, IO_NO_INCREMENT);
+                    Status = STATUS_SUCCESS;
+                }
             }
             else
             {
@@ -1197,9 +1218,21 @@ IntVideoPortDispatchPower(
 
     if (DeviceExtension->Common.Fdo)
     {
-        PoStartNextPowerIrp(Irp);
-        IoSkipCurrentIrpStackLocation(Irp);
-        return PoCallDriver(DeviceExtension->NextDeviceObject, Irp);
+        if (DeviceExtension->NextDeviceObject != NULL)
+        {
+            PoStartNextPowerIrp(Irp);
+            IoSkipCurrentIrpStackLocation(Irp);
+            return PoCallDriver(DeviceExtension->NextDeviceObject, Irp);
+        }
+        else
+        {
+            /* No lower device to forward to, complete the request */
+            Irp->IoStatus.Status = STATUS_SUCCESS;
+            Irp->IoStatus.Information = 0;
+            PoStartNextPowerIrp(Irp);
+            IoCompleteRequest(Irp, IO_NO_INCREMENT);
+            return STATUS_SUCCESS;
+        }
     }
     else
     {
@@ -1228,8 +1261,19 @@ IntVideoPortDispatchSystemControl(
 
     if (DeviceExtension->Common.Fdo)
     {
-        IoSkipCurrentIrpStackLocation(Irp);
-        return IoCallDriver(DeviceExtension->NextDeviceObject, Irp);
+        if (DeviceExtension->NextDeviceObject != NULL)
+        {
+            IoSkipCurrentIrpStackLocation(Irp);
+            return IoCallDriver(DeviceExtension->NextDeviceObject, Irp);
+        }
+        else
+        {
+            /* No lower device to forward to, complete the request */
+            Irp->IoStatus.Status = STATUS_SUCCESS;
+            Irp->IoStatus.Information = 0;
+            IoCompleteRequest(Irp, IO_NO_INCREMENT);
+            return STATUS_SUCCESS;
+        }
     }
     else
     {

--- a/win32ss/drivers/videoprt/videoprt.c
+++ b/win32ss/drivers/videoprt/videoprt.c
@@ -1616,6 +1616,12 @@ VideoPortCheckForDeviceExistence(
 
     DeviceExtension = VIDEO_PORT_GET_DEVICE_EXTENSION(HwDeviceExtension);
 
+    if (DeviceExtension->NextDeviceObject == NULL)
+    {
+        WARN_(VIDEOPRT, "DeviceExtension->NextDeviceObject is NULL!\n");
+        return FALSE;
+    }
+
     PciDevicePresentInterface.Size = sizeof(PCI_DEVICE_PRESENT_INTERFACE);
     PciDevicePresentInterface.Version = 1;
     IoStack.Parameters.QueryInterface.Size = PciDevicePresentInterface.Size;


### PR DESCRIPTION
## Purpose

When installing the VMware Tools VGA driver, it works until you reboot, at which point the VM fails to boot.
My goal with this PR is to fix this issue in a safe and proper manner. I'm not super experienced with C so any feedback is welcome.

This patch mostly works out of the box, you have to change two settings in the Display section of the VM settings:
1. Disable 3D Acceleration (Retail XP/2003 has this problem too)
2. If your host machine has multiple monitors (being ran on Workstation Pro or Fusion), you need to change it from "Use Host Setting for monitors" to "Specify monitor settings" and change it to 1 monitor. I'm not sure why but otherwise it causes the VM to think it has the # of monitors equal to your host, but because Workstation/Fusion only actually provide one display it screws things up. This can probably be fixed in code, my solution was going to be to add a condition where if the driver is VMware's it assumes one monitor no matter what the driver says.

## Proposed changes
- Fixes a few null pointer dereferences and other similar errors in both WIN32K.SYS and VIDEOPRT.SYS when the VMware Tools VGA driver is installed
- There are still 2 issues (one can most likely be fixed in code, see TODO section below)

## TODO

- [ ] Fix 3D Acceleration (not sure this can be done)
- [ ] Fix multiple monitors

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: