### PR TITLE
[NPFS] Fix dereference of uninitialized variable

### DIFF
--- a/drivers/filesystems/npfs/fileobsup.c
+++ b/drivers/filesystems/npfs/fileobsup.c
@@ -36,6 +36,8 @@ NpDecodeFileObject(IN PFILE_OBJECT FileObject,
         switch (Node->NodeType)
         {
             case NPFS_NTC_VCB:
+                *Ccb = NULL;
+                if (PrimaryContext) *PrimaryContext = Node;
                 return NPFS_NTC_VCB;
 
             case NPFS_NTC_ROOT_DCB:

--- a/drivers/filesystems/npfs/fsctrl.c
+++ b/drivers/filesystems/npfs/fsctrl.c
@@ -363,7 +363,7 @@ NpPeek(IN PDEVICE_OBJECT DeviceObject,
         return STATUS_PIPE_DISCONNECTED;
     }
 
-    if ((Type != NPFS_NTC_CCB) &&
+    if ((Type != NPFS_NTC_CCB) ||
         (OutputLength < FIELD_OFFSET(FILE_PIPE_PEEK_BUFFER, Data)))
     {
         return STATUS_INVALID_PARAMETER;


### PR DESCRIPTION
## Purpose

Fix dereference of uninitialized variable. Happens with updated ntdll_winetest.

## Proposed changes

- Avoid uninitialized return variables
- Fix a parameter check

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: