### PR TITLE
[NTDLL] Improve x64 KiUserExceptionDispatcher

### DIFF
--- a/dll/ntdll/dispatch/amd64/dispatch.S
+++ b/dll/ntdll/dispatch/amd64/dispatch.S
@@ -17,6 +17,11 @@ EXTERN LdrpInit:PROC
 EXTERN ZwCallbackReturn:PROC
 EXTERN RtlRaiseStatus:PROC
 
+.data
+
+Wow64PrepareForException:
+    .quad 0
+
 .code
 
 PUBLIC LdrInitializeThunk
@@ -195,7 +200,21 @@ PUBLIC KiUserExceptionDispatcher
     /* Clear direction flag */
     cld
 
+    /* Check the WOW64 callback */
+    mov rax, qword ptr Wow64PrepareForException[rip]
+    test rax, rax
+    jz .NoWow64
+
+    /* Prepare for WOW64 exception dispatching */
+    lea rcx, [rsp + CONTEXT_FRAME_LENGTH] /* ExceptionRecord */
+    lea rdx, [rsp] /* ContextRecord */
+    call rax
+
+.NoWow64:
+
     /* Dispatch the exception */
+    lea rcx, [rsp + CONTEXT_FRAME_LENGTH] /* ExceptionRecord */
+    lea rdx, [rsp] /* ContextRecord */
     call RtlDispatchException
 
     /* Check for success */


### PR DESCRIPTION
## Purpose

Add Wow64PrepareForException handler, which is well documented as a hook for KiUserExceptionDispatcher (see e.g. https://github.com/brew02/KiUserExceptionDispatcherHook) and used by ntdll_winetest. This also reloads rcx and rdx for the call to RtlDispatchException from the stack instead of relying on the registers to be set up by the kernel, which again is a feature used by ntdll_winetest, which calls this function from a hook with zeroed registers.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: https://reactos.org/testman/compare.php?ids=103794,103796,103791