### PR TITLE
[NTGDI][GDI32] SAI Paint Tool Regression Fix

### DIFF
--- a/win32ss/gdi/gdi32/objects/bitmap.c
+++ b/win32ss/gdi/gdi32/objects/bitmap.c
@@ -982,6 +982,17 @@ SetDIBitsToDevice(
         }
     }
 
+    if (YDest >= 0)
+    {
+        ScanLines = min(abs(Height), ScanLines);
+        if (YSrc > 0)
+        {
+            ScanLines += YSrc;
+            if (Height + YDest + 1 < ScanLines)
+                YSrc = 0;
+        }
+    }
+
     /*
      if ( !pDc_Attr || // DC is Public
      ColorUse == DIB_PAL_COLORS ||

--- a/win32ss/gdi/ntgdi/dibobj.c
+++ b/win32ss/gdi/ntgdi/dibobj.c
@@ -528,16 +528,7 @@ NtGdiSetDIBitsToDeviceInternal(
            bmi->bmiHeader.biBitCount,
            XSrc, YSrc, XDest, YDest);
 
-    if (YDest >= 0)
-    {
-        ScanLines = min(abs(Height), ScanLines);
-        if (YSrc > 0)
-        {
-            ScanLines += YSrc;
-            YSrc = 0;
-        }
-    }
-    else
+    if (YDest < 0)
     {
         ScanLines = min(ScanLines, abs(bmi->bmiHeader.biHeight) - StartScan);
     }


### PR DESCRIPTION
CORE-20336

## Purpose

_Fix regressions caused by PR #8348._

JIRA issue: [CORE-20336](https://jira.reactos.org/browse/CORE-20336)

## Proposed changes

_Move some code in win32ss/gdi/ntgdi/dibobj.c into win32ss/gdi/gdi32/objects/bitmap.c._
_Condition "YSrc = 0;" on "if (Height + YDest + 1 < ScanLines)" which fixes some gdi32:bitmap regressions._

## Testbot runs (Filled in by Devs)

- [X] KVM x86: https://reactos.org/testman/compare.php?ids=103795,103801 LGTM
- [X] KVM x64: https://reactos.org/testman/compare.php?ids=103796,103803 LGTM

With my minimized gdi32:winetest Before PR:
<img width="818" height="688" alt="pr8383_before" src="https://github.com/user-attachments/assets/6490da37-84fb-4cbd-a7cf-ec4597caba9e" />

With my minimized gdi32:winetest After PR:
<img width="818" height="688" alt="pr8383_after" src="https://github.com/user-attachments/assets/cec24149-5302-41e2-9421-d1555ccfd35d" />
