### PR TITLE
[BATTC][COMPBATT] Move the IOCTL_BATTERY_QUERY_STATUS wait hack to BATTC

### DIFF
--- a/drivers/acpi/cmbatt/cmbpnp.c
+++ b/drivers/acpi/cmbatt/cmbpnp.c
@@ -680,6 +680,11 @@ CmBattAddBattery(IN PDRIVER_OBJECT DriverObject,
     FdoExtension->InterruptTime = KeQueryInterruptTime();
     FdoExtension->TripPointSet = CmBattSetTripPoint(FdoExtension, 0) !=
                                  STATUS_OBJECT_NAME_NOT_FOUND;
+    if (!FdoExtension->TripPointSet)
+    {
+        DbgPrint("**** Battery ID 0x%x (PDO: 0x%p, FDO: 0x%p) doesn't support _BTP method\n",
+                 FdoExtension->DeviceId, DeviceObject, FdoDeviceObject);
+    }
 
     /* Setup the battery miniport information structure */
     RtlZeroMemory(&MiniportInfo, sizeof(MiniportInfo));

--- a/drivers/acpi/cmbatt/cmexec.c
+++ b/drivers/acpi/cmbatt/cmexec.c
@@ -11,7 +11,6 @@
 #include "cmbatt.h"
 
 #include <acpiioct.h>
-#include <debug.h>
 
 typedef struct _ACPI_PACKAGE_FIELD
 {
@@ -385,7 +384,7 @@ CmBattSetTripPoint(IN PCMBATT_DEVICE_EXTENSION DeviceExtension,
     PAGED_CODE();
     if (CmBattDebug & 0x440)
         DbgPrint("CmBattSetTripPoint: _BTP Alarm Value %x Device %x Tid %x\n",
-                 AlarmValue, DeviceExtension->DeviceId, KeGetCurrentThread);
+                 AlarmValue, DeviceExtension->DeviceId, KeGetCurrentThread());
 
     /* Request the _BTP method */
     *(PULONG)InputBuffer.MethodName = 'PTB_';

--- a/drivers/battery/battc/battc.c
+++ b/drivers/battery/battc/battc.c
@@ -292,8 +292,13 @@ BatteryClassIoctl(PVOID ClassData,
                                                                  &BattNotify);
                 if (!NT_SUCCESS(Status))
                 {
-                    DPRINT1("SetStatusNotify failed (0x%x)\n", Status);
-                    break;
+                    DPRINT("SetStatusNotify failed (0x%x)\n", Status);
+                    // HACK: Continue anyway; the non-zero timeout will limit polling rate.
+                    // FIXME: Hardcoded (wait for 5 seconds) because ACPI notifications don't work...
+                    BattWait.Timeout = 5000;
+                    // FIXME 2: All these IOCTLs handled in BatteryClassIoctl() should actually
+                    // be queued and be serviced by a worker thread that also handles the slow
+                    // battery polling, in case the battery doesn't support status notifications.
                 }
 
                 ExAcquireFastMutex(&BattClass->Mutex);

--- a/drivers/battery/compbatt/compbatt.c
+++ b/drivers/battery/compbatt/compbatt.c
@@ -80,7 +80,7 @@ CompBattSystemControl(
  * location which contains the data of the individual battery.
  *
  * @param[in] Context
- * An aribtrary pointer that points to context data, this paramater
+ * An arbitrary pointer that points to context data, this parameter
  * is unused.
  *
  * @return
@@ -355,7 +355,7 @@ CompBattMonitorIrpCompleteWorker(
 
     /* Setup the necessary data to read battery status */
     BatteryData->WaitStatus.BatteryTag = BatteryData->Tag;
-    BatteryData->WaitStatus.Timeout = 3000;  // FIXME: Hardcoded (wait for 3 seconds) because we do not have ACPI notifications implemented yet...
+    BatteryData->WaitStatus.Timeout = -1;
 
     RtlCopyMemory(&BatteryData->WorkerBuffer.WorkerWaitStatus,
                   &BatteryData->WaitStatus,


### PR DESCRIPTION
## Purpose & Proposed changes

JIRA issue: [CORE-20343](https://jira.reactos.org/browse/CORE-20343)

The 3-second timeout FIXME (instead of waiting indefinitely), made in the COMPBATT worker thread for the IOCTL_BATTERY_QUERY_STATUS case, was done because _*our*_ BATTC handler expects the batteries to always support the BTP (Battery Trip Point) feature for signaling a change of battery status, but in the cases where it isn't supported, any waits it tried for the battery to notify about a status change would never happen.

Furthermore, following commit 3a6e0d4b65, the SetStatusNotify() call (_which always fails if the battery doesn't support the BTP feature_) would now always exit the IOCTL_BATTERY_QUERY_STATUS handling without any waiting nor battery polling [^1], and this would cause the COMPBATT worker thread to busy-poll again forever.

The timeout FIXME is now moved to BATTC, instead of COMPBATT, since the actual fixes should be in BATTC. In particular, it should queue all the query IOCTLs and then serve them, either using the StatusNotify (BTP) functionality if the battery supports it, or if not, do a very-slow battery polling.

I've also increased the timeout a little bit more (5 seconds and not 3).

[^1]: Per the ACPI specification, it is expected that the operating system
  performs battery polling if the battery doesn't support BTP, see:
  https://uefi.org/htmlspecs/ACPI_Spec_6_4_html/10_Power_Source_and_Power_Meter_Devices/Power_Source_and_Power_Meter_Devices.html#btp-battery-trip-point

## Testing

I have tested this under the following configuration: VirtualBox 5.0.20 r106931 on Dell Studio 1747 laptop with battery plugged in and being charged.
Since the crux of the problem is that the battery ReactOS sees doesn't report the `_BTP` feature present, the problem can be reproduced more simply by changing this line of code:
https://github.com/reactos/reactos/blob/20d7fd78aeacb10cce8c3b779b36f609c6aee332/drivers/acpi/cmbatt/cmbpnp.c#L681-L682
to:
```c
    FdoExtension->TripPointSet = FALSE;
```

Then, you should observe the following in the debug log, during 2nd stage setup or later:
```

(ntoskrnl\kd64\kdinit.c:94) -----------------------------------------------------
(ntoskrnl\kd64\kdinit.c:95) ReactOS 0.4.16-x86-dev (Build 20250913-0.4.16-dev-1726-g20d7fd7) (Commit 20d7fd78aeacb10cce8c3b779b36f609c6aee332)
(ntoskrnl\kd64\kdinit.c:96) 1 System Processor [512 MB Memory]
(ntoskrnl\kd64\kdinit.c:100) Command Line: DEBUG DEBUGPORT=VBOX SOS
(ntoskrnl\kd64\kdinit.c:103) ARC Paths: multi(0)disk(0)rdisk(0)partition(2) \ multi(0)disk(0)rdisk(0)partition(2) \ReactOS\
(ntoskrnl\ke\i386\cpu.c:454) Supported CPU features: KF_V86_VIS KF_RDTSC KF_CR4 KF_CMOV KF_GLOBAL_PAGE KF_LARGE_PAGE KF_MTRR KF_CMPXCHG8B KF_MMX KF_WORKING_PTE KF_PAT KF_FXSR KF_FAST_SYSCALL KF_XMMI KF_XMMI64 KF_NX_BIT X86_FEATURE_PAE X86_FEATURE_APIC
(ntoskrnl\ke\i386\cpu.c:750) Prefetch Cache: 64 bytes	L2 Cache: 262144 bytes	L2 Cache Line: 64 bytes	L2 Cache Associativity: 8
(hal\halx86\acpi\halacpi.c:782) ACPI Timer at: 4008h (EXT: 256)
(hal\halx86\acpi\halacpi.c:928) ACPI v3.0-4.0_A detected. Tables: [XSDT] [FACP]

...

(base\services\umpnpmgr\install.c:118) Installing: ACPI\ACPI0003\0
fixme:(dll\win32\setupapi\driver.c:1004) ExcludeFromSelect list ignored
fixme:(dll\win32\setupapi\driver.c:1004) ExcludeFromSelect list ignored
...
fixme:(dll\win32\setupapi\driver.c:1004) ExcludeFromSelect list ignored
fixme:(dll\win32\setupapi\driver.c:1004) ExcludeFromSelect list ignored
(ntoskrnl\mm\ARM3\sysldr.c:170) Loading: \SystemRoot\System32\drivers\compbatt.sys at F7CD2000 with b pages
(ntoskrnl\mm\ARM3\sysldr.c:170) Loading: \SystemRoot\System32\drivers\battc.sys at F7CCA000 with 8 pages
(ntoskrnl\io\pnpmgr\pnproot.c:1373) IRP_MJ_PNP / Unknown minor function 0x1
(ntoskrnl\io\pnpmgr\devaction.c:1901) Removal vetoed by Root\COMPOSITE_BATTERY\0000
(ntoskrnl\io\pnpmgr\devaction.c:2022) Removal vetoed by failing the query remove request
(ntoskrnl\io\pnpmgr\pnproot.c:1373) IRP_MJ_PNP / Unknown minor function 0x3
(base\services\umpnpmgr\event.c:103) Removal pending: Root\COMPOSITE_BATTERY\0000
(base\services\umpnpmgr\event.c:99) Removal vetoed: Root\COMPOSITE_BATTERY\0000
(ntoskrnl\mm\ARM3\sysldr.c:170) Loading: \SystemRoot\System32\drivers\cmbatt.sys at F7CBB000 with f pages
(ntoskrnl\mm\ARM3\sysldr.c:170) Loading: \SystemRoot\System32\drivers\wmilib.sys at F7CB3000 with 8 pages
WARNING:  AcpiInterfaceNotificationsRegister at drivers\bus\acpi\interface.c:80 is UNIMPLEMENTED!
(base\services\umpnpmgr\install.c:118) Installing: ACPI\FixedButton\2&ccb86d17&0
(ntoskrnl\io\pnpmgr\devaction.c:2610) NOTE: attempt to start an already started/uninitialized device ACPI\FixedButton\2&ccb86d17&0
(base\services\umpnpmgr\install.c:118) Installing: ACPI\GenuineIntel_-_x86_Family_6_Model_30\_0
(ntoskrnl\io\pnpmgr\devaction.c:2610) NOTE: attempt to start an already started/uninitialized device ACPI\GenuineIntel_-_x86_Family_6_Model_30\_0
err:(dll\win32\newdev\newdev.c:1022) DevInstallW failed with error 31
(base\services\umpnpmgr\install.c:245) InstallDevice failed for DeviceInstance 'ACPI\GenuineIntel_-_x86_Family_6_Model_30\_0'
(base\services\umpnpmgr\install.c:118) Installing: ACPI\PNP0000\2&ccb86d17&0
(base\services\umpnpmgr\install.c:118) Installing: ACPI\PNP0100\2&ccb86d17&0
(base\services\umpnpmgr\install.c:118) Installing: ACPI\PNP0200\2&ccb86d17&0
(base\services\umpnpmgr\install.c:118) Installing: ACPI\PNP0303\2&ccb86d17&0
(ntoskrnl\io\pnpmgr\devaction.c:2610) NOTE: attempt to start an already started/uninitialized device ACPI\PNP0303\2&ccb86d17&0
(base\services\umpnpmgr\install.c:118) Installing: ACPI\PNP0501\1
fixme:(dll\win32\msports\classinst.c:41) GetBootResourceList()
err:(dll\win32\msports\classinst.c:118) RegQueryValueExW() failed (Error 0)
(ntoskrnl\mm\ARM3\sysldr.c:170) Loading: \SystemRoot\System32\drivers\serial.sys at F7CA5000 with e pages
(ntoskrnl\io\pnpmgr\pnpres.c:648) Resource conflict: IRQ (0x4 0x4 vs. 0x4 0x4)
(ntoskrnl\io\pnpmgr\pnpres.c:648) Resource conflict: IRQ (0x4 0x4 vs. 0x4 0x4)
(base\services\umpnpmgr\install.c:118) Installing: ACPI\PNP0501\2
fixme:(dll\win32\msports\classinst.c:41) GetBootResourceList()
err:(dll\win32\msports\classinst.c:118) RegQueryValueExW() failed (Error 0)
(ntoskrnl\io\pnpmgr\pnpres.c:648) Resource conflict: IRQ (0x3 0x3 vs. 0x3 0x3)
(ntoskrnl\io\pnpmgr\pnpres.c:648) Resource conflict: IRQ (0x3 0x3 vs. 0x3 0x3)
(base\services\umpnpmgr\install.c:118) Installing: ACPI\PNP0A03\0
(ntoskrnl\io\pnpmgr\devaction.c:2610) NOTE: attempt to start an already started/uninitialized device ACPI\PNP0A03\0
(base\services\umpnpmgr\install.c:118) Installing: ACPI\PNP0C0A\0
WARNING:  AcpiInterfaceNotificationsRegister at drivers\bus\acpi\interface.c:80 is UNIMPLEMENTED!
(drivers\battery\battc\battc.c:295) SetStatusNotify failed (0xc0000034)
(drivers\battery\battc\battc.c:295) SetStatusNotify failed (0xc0000034)
...
(drivers\battery\battc\battc.c:295) SetStatusNotify failed (0xc0000034)
(drivers\battery\battc\battc.c:295) SetStatusNotify failed (0xc0000034)

Breakpoint 17 hit
>  295:                     DPRINT1("SetStatusNotify failed (0x%x)\n", Status);
battc!BatteryClassIoctl+0x28d:
f7ccb4ed ba01000000      mov     edx,1
kd> kp
ChildEBP RetAddr  
f85dac64 f7cbc91d battc!BatteryClassIoctl(void * ClassData = 0xb11de388, struct _IRP * Irp = 0xb12559e0)+0x28d [D:\rossrc\reactos\drivers\battery\battc\battc.c @ 295]
f85dac94 8048a5c7 cmbatt!CmBattIoctl(struct _DEVICE_OBJECT * DeviceObject = 0xb1130020, struct _IRP * Irp = 0xb12559e0)+0x13d [D:\rossrc\reactos\drivers\acpi\cmbatt\cmbatt.c @ 647]
f85dacc0 f7cd4529 nt!IofCallDriver(struct _DEVICE_OBJECT * DeviceObject = 0xb1130020, struct _IRP * Irp = 0xb12559e0)+0xc7 [D:\rossrc\reactos\ntoskrnl\io\iomgr\irp.c @ 1286]
f85dad10 8044c93a compbatt!CompBattMonitorIrpCompleteWorker(struct _COMPBATT_BATTERY_DATA * BatteryData = 0xb115a1a0)+0x499 [D:\rossrc\reactos\drivers\battery\compbatt\compbatt.c @ 385]
f85dad88 805416f6 nt!ExpWorkerThreadEntryPoint(void * Context = 0x80000001)+0x1ca [D:\rossrc\reactos\ntoskrnl\ex\work.c @ 158]
f85dadbc 8056d883 nt!PspSystemThreadStartup(<function> * StartRoutine = 0x8044c770, void * StartContext = 0x80000001)+0x76 [D:\rossrc\reactos\ntoskrnl\ps\thread.c @ 156]
f85daddc 8054167f nt!KiThreadStartup(void)+0x63 [D:\rossrc\reactos\ntoskrnl\ke\i386\thrdini.c @ 78]
f85dade0 8044c76f nt!PspCreateThread+0xf0f
f85dade4 80000001 nt!ExpWorkerThreadBalanceManager+0x29f
WARNING: Frame IP not in any known module. Following frames may be wrong.
f85dade8 cccccc00 0x80000001
f85dadec 00000000 0xcccccc00
```
