### PR TITLE
[MSGINA] Don't depend on powrprof.dll; fix shutdown from fancy dialog

### DIFF
--- a/dll/win32/msgina/CMakeLists.txt
+++ b/dll/win32/msgina/CMakeLists.txt
@@ -23,6 +23,6 @@ add_library(msgina MODULE
 set_module_type(msgina win32dll UNICODE)
 target_link_libraries(msgina wine uuid ${PSEH_LIB} cpprt atl_classes)
 add_delay_importlibs(msgina secur32)
-add_importlibs(msgina advapi32 user32 gdi32 powrprof userenv msvcrt kernel32 ntdll)
+add_importlibs(msgina advapi32 user32 gdi32 userenv msvcrt kernel32 ntdll)
 add_pch(msgina msgina.h "${PCH_SKIP_SOURCE}")
 add_cd_file(TARGET msgina DESTINATION reactos/system32 FOR all)


### PR DESCRIPTION
## Purpose & Proposed changes

JIRA issue: [CORE-19104](https://jira.reactos.org/browse/CORE-19104)

- Use `NtPowerInformation()` and the `IS_PWR_*` macros instead.

- Fancy shutdown dialog:

  * Enable or disable the hibernate/sleep buttons depending on the previously-determined available shutdown options.

  * Don't invoke `ExitWindowsEx()` or `SetSuspendState()` directly within Msgina, but return a suitable `WLX_SAS_ACTION_SHUTDOWN_*` value, like what's done by the classic dialog. The power action proper is then performed by the caller of the shutdown dialog: either Shell32 or Winlogon.
