### PR TITLE
[RAPPS] Hide packages not compatible with the current NT version

### DIFF
--- a/base/applications/rapps/appinfo.cpp
+++ b/base/applications/rapps/appinfo.cpp
@@ -299,16 +299,24 @@ bool
 CAvailableApplicationInfo::IsCompatible() const
 {
     CStringW szBuffer;
-    if (m_Parser->GetString(DB_OSBUILD, szBuffer))
+    if (m_Parser->GetString(DB_NTVER, szBuffer))
     {
-        PWSTR start = szBuffer.GetBuffer();
-        PWSTR p;
-        UINT minb = wcstoul(start, &p, 0);
+        LPWSTR start = szBuffer.GetString();
+        LPWSTR p;
+        ULONG MinNTVer = wcstoul(start, &p, 0);
         if (p > start)
         {
-            UINT osb = GetOsBuildNumber();
-            UINT maxb = (*p == '-') ? wcstoul(++p, NULL, 0) : (*p == '+' ? UINT_MAX : 0);
-            return maxb && osb >= minb && osb <= maxb;
+            ULONG NTVersion = GetNTVersion();
+            // Treat as range if we have '-', otherwise treat it as XXX+
+            ULONG MaxNTVer = (*p == '-') ? wcstoul(++p, NULL, 0) : UINT_MAX;
+            // Handle the XXX- case (That version or lower)
+            if (MaxNTVer == 0)
+            {
+                MaxNTVer = MinNTVer;
+                MinNTVer = 0;
+            }
+
+            return NTVersion >= MinNTVer && NTVersion <= MaxNTVer;
         }
     }
     return true;

--- a/base/applications/rapps/include/appinfo.h
+++ b/base/applications/rapps/include/appinfo.h
@@ -98,7 +98,7 @@ enum InstallerType
 #define DB_SCOPE L"Scope" // User or Machine
 #define DB_SAVEAS L"SaveAs"
 #define DB_SILENTARGS L"SilentParameters"
-#define DB_OSBUILD L"OsBuild" // "Min-Max" || "Min+"
+#define DB_NTVER L"NTVersion" // "Max-" || "Min-Max" || "Min" || "Min+"
 
 #define DB_GENINSTSECTION L"Generate"
 #define GENERATE_ARPSUBKEY L"RApps" // Our uninstall data is stored here

--- a/base/applications/rapps/include/misc.h
+++ b/base/applications/rapps/include/misc.h
@@ -85,8 +85,8 @@ ExtractFilesFromCab(LPCWSTR FullCabPath, const CStringW &szOutputDir,
 
 BOOL
 IsSystem64Bit();
-UINT
-GetOsBuildNumber();
+ULONG
+GetNTVersion();
 
 INT
 GetSystemColorDepth();

--- a/base/applications/rapps/misc.cpp
+++ b/base/applications/rapps/misc.cpp
@@ -391,18 +391,14 @@ IsSystem64Bit()
 #endif
 }
 
-UINT
-GetOsBuildNumber()
+ULONG
+GetNTVersion()
 {
-    static UINT build = 0;
-    if (!build)
-    {
-        OSVERSIONINFOW ovi;
-        ovi.dwOSVersionInfoSize = sizeof(ovi);
-        GetVersionExW(&ovi);
-        build = ovi.dwBuildNumber;
-    }
-    return build;
+    RTL_OSVERSIONINFOW osvi = {0};
+    osvi.dwOSVersionInfoSize = sizeof(osvi);
+    RtlGetVersion(&osvi);
+
+    return (osvi.dwMajorVersion << 8) | (osvi.dwMinorVersion);
 }
 
 INT
@@ -590,7 +586,7 @@ GetProgramFilesPath(CStringW &Path, BOOL PerUser, HWND hwnd)
     {
         hr = GetSpecialPath(CSIDL_LOCAL_APPDATA, Path, hwnd);
         // Use the correct path on NT6 (on NT5 the path becomes a bit long)
-        if (SUCCEEDED(hr) && GetOsBuildNumber() >= 6000)
+        if (SUCCEEDED(hr) && LOBYTE(GetVersion()) >= 6)
         {
             Path = BuildPath(Path, L"Programs"); // Should not be localized
         }


### PR DESCRIPTION
There will come a time when the nightly and normal release don't target the same Windows version and since we only have one RAPPS DB, we need a way to not break the normal release. The ship has already sailed for <= 0.4.15 but we can at least try to make things better for 0.4.16. I don't know exactly how we will solve this in the future (I'm thinking some meta info in the main package entry that lets us select the most recent supported version of the app) but if we end up with a DB where we have `someapp.txt` and `someapp.Vista.txt`, we need a way to hide the incompatible package downlevel.

Notes:
 - Nothing needs/should be done to the packages in the database at this time, this is only an escape mechanism that may be used later.
 - The format of the new value is `Max-`, `Min-Max`, `Min` or `Min+`. I chose this over two entries (Min & Max) to reduce the number of database reads since this happens on startup and on refresh in the UI and is an operation we unfortunately perform on the UI thread.
 - This needs to happen before the next planned release in spring 2026.

Example:

```ini
[Section]
Name = Example app
UrlDownload = http://example.com/setup.exe
NTVersion = 0x600+
```


## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: