### PR TITLE
[NTGDI] Fix 3d-text screensaver not moving in preview mode

### DIFF
--- a/win32ss/gdi/ntgdi/gdiobj.c
+++ b/win32ss/gdi/ntgdi/gdiobj.c
@@ -479,6 +479,12 @@ ENTRY_ReferenceEntryByHandle(HGDIOBJ hobj, FLONG fl)
 {
     ULONG ulIndex, cNewRefs, cOldRefs;
     PENTRY pentry;
+    PTHREADINFO pti = PsGetCurrentThreadWin32Thread();
+
+    /* Allow a window that is moving or resizing to have access to all of its child
+       windows dc's even if the dc belongs to another process i.e. 3D Screensaver  */
+    if (pti && pti->TIF_flags & TIF_MOVESIZETRACKING)
+        fl = GDIOBJFLAG_IGNOREPID;
 
     /* Get the handle index and check if its too big */
     ulIndex = GDI_HANDLE_GET_INDEX(hobj);


### PR DESCRIPTION
CORE-5601.
Patch from @I_Kill_Bugs. 

## Purpose

_Fix 3D-Text screensaver preview window unable to be moved in preview mode._

JIRA issue: [CORE-5601](https://jira.reactos.org/browse/CORE-5601)

## Proposed changes

_Allow a window that is moving or resizing to have access to all of its child_
_windows DC's even if the DC belongs to another process._

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: