### PR TITLE
[CLIP] Add Czech (cs-CZ) and Slovak (sk-SK) translations

### DIFF
--- a/base/applications/cmdutils/clip/clip.rc
+++ b/base/applications/cmdutils/clip/clip.rc
@@ -12,6 +12,9 @@ LANGUAGE LANG_NEUTRAL, SUBLANG_NEUTRAL
 /* UTF-8 */
 #pragma code_page(65001)
 
+#ifdef LANGUAGE_CS_CZ
+    #include "lang/cs-CZ.rc"
+#endif
 #ifdef LANGUAGE_DE_DE
     #include "lang/de-DE.rc"
 #endif

--- a/base/applications/cmdutils/clip/clip.rc
+++ b/base/applications/cmdutils/clip/clip.rc
@@ -42,6 +42,9 @@ LANGUAGE LANG_NEUTRAL, SUBLANG_NEUTRAL
 #ifdef LANGUAGE_RU_RU
     #include "lang/ru-RU.rc"
 #endif
+#ifdef LANGUAGE_SK_SK
+    #include "lang/sk-SK.rc"
+#endif
 #ifdef LANGUAGE_TR_TR
     #include "lang/tr-TR.rc"
 #endif

--- a/base/applications/cmdutils/clip/lang/cs-CZ.rc
+++ b/base/applications/cmdutils/clip/lang/cs-CZ.rc
@@ -2,7 +2,7 @@
  * PROJECT:     ReactOS Clip Command
  * LICENSE:     See COPYING in the top level directory
  * PURPOSE:     Czech resource file
- * TRANSLATORS: Copyright 2025 Václav Zouzalík (Venca24) <vaclav.zouzalik@seznam.cz>
+ * TRANSLATOR:  Copyright 2025 Václav Zouzalík (Venca24) <vaclav.zouzalik@seznam.cz>
  */
 
 LANGUAGE LANG_CZECH, SUBLANG_DEFAULT

--- a/base/applications/cmdutils/clip/lang/cs-CZ.rc
+++ b/base/applications/cmdutils/clip/lang/cs-CZ.rc
@@ -1,0 +1,16 @@
+/*
+ * PROJECT:     ReactOS Clip Command
+ * LICENSE:     See COPYING in the top level directory
+ * PURPOSE:     Czech resource file
+ * TRANSLATORS: Copyright 2025 Václav Zouzalík (Venca24) <vaclav.zouzalik@seznam.cz>
+ */
+
+LANGUAGE LANG_CZECH, SUBLANG_DEFAULT
+
+STRINGTABLE
+BEGIN
+    IDS_USAGE "\nNapište ""CLIP /?"" pro informace o používání.\n"
+    IDS_HELP "\nPřesměrovává výstup programu v příkazové řádce do schránky.\n\n\
+CLIP [/?]\n\n\
+    /?  Zobrazí tuto nápovědu.\n"
+END

--- a/base/applications/cmdutils/clip/lang/sk-SK.rc
+++ b/base/applications/cmdutils/clip/lang/sk-SK.rc
@@ -2,7 +2,7 @@
  * PROJECT:     ReactOS Clip Command
  * LICENSE:     See COPYING in the top level directory
  * PURPOSE:     Slovak resource file
- * TRANSLATORS: Copyright 2025 Václav Zouzalík (Venca24) <vaclav.zouzalik@seznam.cz>
+ * TRANSLATOR:  Copyright 2025 Václav Zouzalík (Venca24) <vaclav.zouzalik@seznam.cz>
  */
 
 LANGUAGE LANG_SLOVAK, SUBLANG_DEFAULT

--- a/base/applications/cmdutils/clip/lang/sk-SK.rc
+++ b/base/applications/cmdutils/clip/lang/sk-SK.rc
@@ -1,0 +1,16 @@
+/*
+ * PROJECT:     ReactOS Clip Command
+ * LICENSE:     See COPYING in the top level directory
+ * PURPOSE:     Slovak resource file
+ * TRANSLATORS: Copyright 2025 Václav Zouzalík (Venca24) <vaclav.zouzalik@seznam.cz>
+ */
+
+LANGUAGE LANG_SLOVAK, SUBLANG_DEFAULT
+
+STRINGTABLE
+BEGIN
+    IDS_USAGE "\nNapíšte ""CLIP /?"" pre informácie o používaní.\n"
+    IDS_HELP "\nPresmerováva výstup programu v príkazovom riadku do schránky.\n\n\
+CLIP [/?]\n\n\
+    /?  Zobrazí túto nápovedu.\n"
+END


### PR DESCRIPTION
## Purpose

Adds the Czech and Slovak translations of ReactOS Clip Command.

JIRA issue: none