### PR TITLE
[BLANKSCR] Add and update Czech (cs-CZ) and Slovak (sk-SK) translations

### DIFF
--- a/modules/rosapps/applications/screensavers/blankscr/lang/cs-CZ.rc
+++ b/modules/rosapps/applications/screensavers/blankscr/lang/cs-CZ.rc
@@ -1,0 +1,14 @@
+/*
+ * PROJECT:     ReactOS Blank ScreenSaver
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Czech resource file
+ * TRANSLATOR:  Copyright 2025 Václav Zouzalík (Venca24) <vaclav.zouzalik@seznam.cz>
+ */
+
+LANGUAGE LANG_CZECH, SUBLANG_DEFAULT
+
+STRINGTABLE
+BEGIN
+    IDS_DESCRIPTION "Prázdná obrazovka"
+    IDS_TEXT        "Žádná nastavení nejsou potřeba."
+END

--- a/modules/rosapps/applications/screensavers/blankscr/lang/sk-SK.rc
+++ b/modules/rosapps/applications/screensavers/blankscr/lang/sk-SK.rc
@@ -1,11 +1,15 @@
-/* TRANSLATOR:  Kario (kario@szm.sk)
- * DATE OF TR:  22-09-2007
+/*
+ * PROJECT:     ReactOS Blank ScreenSaver
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Slovak resource file
+ * TRANSLATORS: Copyright 2007 Mário Kačmár <kario@szm.sk>
+ *              Copyright 2025 Václav Zouzalík (Venca24) <vaclav.zouzalik@seznam.cz>
  */
 
 LANGUAGE LANG_SLOVAK, SUBLANG_DEFAULT
 
 STRINGTABLE
 BEGIN
-    IDS_DESCRIPTION "Blank"
+    IDS_DESCRIPTION "Prázdna obrazovka"
     IDS_TEXT        "Nie sú potrebné žiadne nastavenia."
 END

--- a/modules/rosapps/applications/screensavers/blankscr/scrnsave.rc
+++ b/modules/rosapps/applications/screensavers/blankscr/scrnsave.rc
@@ -20,6 +20,9 @@ IDI_ICON ICON "res/icon_blankscr.ico"
 #ifdef LANGUAGE_BG_BG
     #include "lang/bg-BG.rc"
 #endif
+#ifdef LANGUAGE_CS_CZ
+    #include "lang/cs-CZ.rc"
+#endif
 #ifdef LANGUAGE_DE_DE
     #include "lang/de-DE.rc"
 #endif


### PR DESCRIPTION
## Purpose

Adds the Czech and updates the Slovak translation of ReactOS Blank ScreenSaver.

JIRA issue: none