### PR TITLE
icmpapi.h and other PIO_APC_ROUTINE type fixes

### DIFF
--- a/drivers/filesystems/udfs/Include/nt_native.h
+++ b/drivers/filesystems/udfs/Include/nt_native.h
@@ -874,6 +874,9 @@ typedef struct _IO_STATUS_BLOCK {
 
 typedef
 VOID
+#ifdef __REACTOS__
+NTAPI
+#endif
 (*PIO_APC_ROUTINE) (
     IN PVOID ApcContext,
     IN PIO_STATUS_BLOCK IoStatusBlock,

--- a/modules/rostests/tests/apc/apc.c
+++ b/modules/rostests/tests/apc/apc.c
@@ -72,7 +72,7 @@ int main(int argc, char* argv[])
    printf("Reading file\n");
    Status = ZwReadFile(FileHandle,
 			NULL,
-			(PIO_APC_ROUTINE)ApcRoutine,
+			ApcRoutine,
 			(PVOID) 0xdeadbeef,
 			&IoStatus,
 			Buffer,

--- a/sdk/include/ndk/iotypes.h
+++ b/sdk/include/ndk/iotypes.h
@@ -1174,6 +1174,8 @@ typedef VOID
     _In_ PIO_STATUS_BLOCK IoStatusBlock,
     _In_ ULONG Reserved);
 
+#define PIO_APC_ROUTINE_DEFINED
+
 //
 // Mailslot IOCTL Codes
 //

--- a/sdk/include/psdk/icmpapi.h
+++ b/sdk/include/psdk/icmpapi.h
@@ -18,8 +18,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#ifndef __WINE_ICMPAPI_H
-#define __WINE_ICMPAPI_H
+#ifndef _ICMP_INCLUDED_
+#define _ICMP_INCLUDED_
+
+#pragma once
 
 #ifdef __cplusplus
 extern "C" {
@@ -29,9 +31,11 @@ HANDLE WINAPI  IcmpCreateFile(
     VOID
     );
 
+#if (NTDDI_VERSION >= NTDDI_WINXP)
 HANDLE WINAPI  Icmp6CreateFile(
     VOID
     );
+#endif
 
 BOOL WINAPI  IcmpCloseHandle(
     HANDLE  IcmpHandle
@@ -53,7 +57,11 @@ WINAPI
 IcmpSendEcho2(
     HANDLE                   IcmpHandle,
     HANDLE                   Event,
+#ifdef PIO_APC_ROUTINE_DEFINED
+    PIO_APC_ROUTINE          ApcRoutine,
+#else
     FARPROC                  ApcRoutine,
+#endif
     PVOID                    ApcContext,
     IPAddr                   DestinationAddress,
     LPVOID                   RequestData,
@@ -64,12 +72,40 @@ IcmpSendEcho2(
     DWORD                    Timeout
     );
 
+#if (NTDDI_VERSION >= NTDDI_VISTASP1)
+DWORD
+WINAPI
+IcmpSendEcho2Ex(
+    HANDLE                   IcmpHandle,
+    HANDLE                   Event,
+#ifdef PIO_APC_ROUTINE_DEFINED
+    PIO_APC_ROUTINE          ApcRoutine,
+#else
+    FARPROC                  ApcRoutine,
+#endif
+    PVOID                    ApcContext,
+    IPAddr                   SourceAddress,
+    IPAddr                   DestinationAddress,
+    LPVOID                   RequestData,
+    WORD                     RequestSize,
+    PIP_OPTION_INFORMATION   RequestOptions,
+    LPVOID                   ReplyBuffer,
+    DWORD                    ReplySize,
+    DWORD                    Timeout
+    );
+#endif
+
+#if (NTDDI_VERSION >= NTDDI_WINXP)
 DWORD
 WINAPI
 Icmp6SendEcho2(
     HANDLE                   IcmpHandle,
     HANDLE                   Event,
+#ifdef PIO_APC_ROUTINE_DEFINED
+    PIO_APC_ROUTINE          ApcRoutine,
+#else
     FARPROC                  ApcRoutine,
+#endif
     PVOID                    ApcContext,
     struct sockaddr_in6     *SourceAddress,
     struct sockaddr_in6     *DestinationAddress,
@@ -80,6 +116,7 @@ Icmp6SendEcho2(
     DWORD                    ReplySize,
     DWORD                    Timeout
     );
+#endif
 
 DWORD
 WINAPI
@@ -88,16 +125,17 @@ IcmpParseReplies(
     DWORD                    ReplySize
     );
 
+#if (NTDDI_VERSION >= NTDDI_WINXP)
 DWORD
 WINAPI
 Icmp6ParseReplies(
     LPVOID                   ReplyBuffer,
     DWORD                    ReplySize
     );
+#endif
 
 #ifdef __cplusplus
 }
 #endif
 
-
-#endif /* __WINE_ICMPAPI_H */
+#endif /* _ICMP_INCLUDED_ */

--- a/sdk/include/psdk/winternl.h
+++ b/sdk/include/psdk/winternl.h
@@ -296,6 +296,8 @@ VOID
     _In_ PIO_STATUS_BLOCK IoStatusBlock,
     _In_ ULONG Reserved);
 
+#define PIO_APC_ROUTINE_DEFINED
+
 __kernel_entry
 NTSYSCALLAPI
 NTSTATUS


### PR DESCRIPTION
## Purpose

- Add missing definitions in icmpapi.h
- Fix `PIO_APC_ROUTINE` type related usages.

## Proposed changes

- ### `[PSDK][NDK] winternl.h, iotypes.h: define PIO_APC_ROUTINE_DEFINED`

  Define `PIO_APC_ROUTINE_DEFINED` after the `PIO_APC_ROUTINE` callback type definition. Used by icmpapi.h `Icmp*SendEcho2*()` routines.

- ### `[PSDK] Add missing definitions in icmpapi.h`

  - Rename `__WINE_ICMPAPI_H` to the official `_ICMP_INCLUDED_`;

  - Use `NTDDI_VERSION` versioning for some funtions;

  - Use `PIO_APC_ROUTINE_DEFINED` for the `ApcRoutine` parameter of the `Icmp*SendEcho2*()` functions, allowing to use the proper `PIO_APC_ROUTINE` type instead of `FARPROC`;

  - Add missing Vista SP1+ `IcmpSendEcho2Ex()` function.

- ### `[ROSTESTS:TESTS] Don't need the PIO_APC_ROUTINE cast`

- ### `[UDFS] Add missing NTAPI for PIO_APC_ROUTINE`
