### PR TITLE
[NDIS] Use the PCI standard bus interface for config access

### DIFF
--- a/drivers/network/ndis/CMakeLists.txt
+++ b/drivers/network/ndis/CMakeLists.txt
@@ -22,6 +22,7 @@ list(APPEND SOURCE
     ndis/config.c
     ndis/control.c
     ndis/efilter.c
+    ndis/guid.c
     ndis/hardware.c
     ndis/io.c
     ndis/main.c

--- a/drivers/network/ndis/include/miniport.h
+++ b/drivers/network/ndis/include/miniport.h
@@ -96,8 +96,8 @@ typedef struct _LOGICAL_ADAPTER
     HARDWARE_ADDRESS            Address;                /* Hardware address of adapter */
     ULONG                       AddressLength;          /* Length of hardware address */
     PMINIPORT_BUGCHECK_CONTEXT  BugcheckContext;        /* Adapter's shutdown handler */
-    PBUS_INTERFACE_STANDARD     BusInterface;
-    BOOLEAN                     BusInterfaceQueried;
+    BUS_INTERFACE_STANDARD     BusInterface;
+    BOOLEAN                    BusInterfaceQueried;
 } LOGICAL_ADAPTER, *PLOGICAL_ADAPTER;
 
 #define GET_LOGICAL_ADAPTER(Handle)((PLOGICAL_ADAPTER)Handle)

--- a/drivers/network/ndis/include/miniport.h
+++ b/drivers/network/ndis/include/miniport.h
@@ -96,6 +96,8 @@ typedef struct _LOGICAL_ADAPTER
     HARDWARE_ADDRESS            Address;                /* Hardware address of adapter */
     ULONG                       AddressLength;          /* Length of hardware address */
     PMINIPORT_BUGCHECK_CONTEXT  BugcheckContext;        /* Adapter's shutdown handler */
+    PBUS_INTERFACE_STANDARD     BusInterface;
+    BOOLEAN                     BusInterfaceQueried;
 } LOGICAL_ADAPTER, *PLOGICAL_ADAPTER;
 
 #define GET_LOGICAL_ADAPTER(Handle)((PLOGICAL_ADAPTER)Handle)

--- a/drivers/network/ndis/include/ndissys.h
+++ b/drivers/network/ndis/include/ndissys.h
@@ -54,6 +54,11 @@ NTAPI
 ExGetCurrentProcessorCpuUsage(
     PULONG CpuUsage);
 
+
+NTSTATUS
+NdisQueryPciBusInterface(
+    IN PLOGICAL_ADAPTER Adapter);
+
 /* portability fixes */
 #ifdef _M_AMD64
 #define KfReleaseSpinLock KeReleaseSpinLock

--- a/drivers/network/ndis/ndis/guid.c
+++ b/drivers/network/ndis/ndis/guid.c
@@ -1,0 +1,8 @@
+/* DO NOT USE THE PRECOMPILED HEADER FOR THIS FILE! */
+
+#include <ntdef.h>
+#include <initguid.h>
+#include <ioevent.h>
+#include <wdmguid.h>
+
+/* NO CODE HERE, THIS IS JUST REQUIRED FOR THE GUID DEFINITIONS */

--- a/drivers/network/ndis/ndis/hardware.c
+++ b/drivers/network/ndis/ndis/hardware.c
@@ -35,7 +35,7 @@ NdisQueryPciBusInterface(
       return STATUS_NOT_SUPPORTED;
     }
 
-    BusInterfacePtr = ExAllocatePoolWithTag(NonPagedPool, sizeof(BUS_INTERFACE_STANDARD), NDIS_TAG);
+    BusInterfacePtr = ExAllocatePoolWithTag(NonPagedPool, sizeof(*BusInterfacePtr), NDIS_TAG);
     if (BusInterfacePtr == NULL) {
       return STATUS_INSUFFICIENT_RESOURCES;
     }
@@ -58,7 +58,7 @@ NdisQueryPciBusInterface(
     IrpStack->MajorFunction = IRP_MJ_PNP;
     IrpStack->MinorFunction = IRP_MN_QUERY_INTERFACE;
     IrpStack->Parameters.QueryInterface.InterfaceType = &GUID_BUS_INTERFACE_STANDARD;
-    IrpStack->Parameters.QueryInterface.Size = sizeof(BUS_INTERFACE_STANDARD);
+    IrpStack->Parameters.QueryInterface.Size = sizeof(*BusInterfacePtr);
     IrpStack->Parameters.QueryInterface.Version = 1;
     IrpStack->Parameters.QueryInterface.Interface = (PINTERFACE)BusInterfacePtr;
     IrpStack->Parameters.QueryInterface.InterfaceSpecificData = NULL;
@@ -73,10 +73,8 @@ NdisQueryPciBusInterface(
 
     if (NT_SUCCESS(Status)) {
       Adapter->BusInterface = *BusInterfacePtr;
-      ExFreePoolWithTag(BusInterfacePtr, NDIS_TAG);
-    } else {
-      ExFreePoolWithTag(BusInterfacePtr, NDIS_TAG);
     }
+    ExFreePoolWithTag(BusInterfacePtr, NDIS_TAG);
 
     return Status;
 }
@@ -252,7 +250,6 @@ NdisReadPciSlotInformation(
     IN  ULONG       Length)
 {
   PLOGICAL_ADAPTER Adapter = NdisAdapterHandle;
-    /* NTSTATUS Status; */
 
   /* Slot number is ignored since W2K for all NDIS drivers. */
   if (Adapter->BusInterface.GetBusData != NULL) {
@@ -285,7 +282,6 @@ NdisWritePciSlotInformation(
     IN  ULONG       Length)
 {
   PLOGICAL_ADAPTER Adapter = NdisAdapterHandle;
-    /* NTSTATUS Status; */
 
   /* Slot number is ignored since W2K for all NDIS drivers. */
   if (Adapter->BusInterface.SetBusData != NULL) {

--- a/drivers/network/ndis/ndis/hardware.c
+++ b/drivers/network/ndis/ndis/hardware.c
@@ -35,7 +35,7 @@ NdisQueryPciBusInterface(
         return STATUS_NOT_SUPPORTED;
     }
 
-    BusInterface = ExAllocatePoolWithTag(NonPagedPool, sizeof(BUS_INTERFACE_STANDARD), NDIS_TAG);
+    BusInterface = ExAllocatePoolWithTag(NonPagedPool, sizeof(*BusInterface), NDIS_TAG);
     if (BusInterface == NULL) {
         return STATUS_INSUFFICIENT_RESOURCES;
     }
@@ -58,7 +58,7 @@ NdisQueryPciBusInterface(
     IrpStack->MajorFunction = IRP_MJ_PNP;
     IrpStack->MinorFunction = IRP_MN_QUERY_INTERFACE;
     IrpStack->Parameters.QueryInterface.InterfaceType = &GUID_BUS_INTERFACE_STANDARD;
-    IrpStack->Parameters.QueryInterface.Size = sizeof(BUS_INTERFACE_STANDARD);
+    IrpStack->Parameters.QueryInterface.Size = sizeof(*BusInterface);
     IrpStack->Parameters.QueryInterface.Version = 1;
     IrpStack->Parameters.QueryInterface.Interface = (PINTERFACE)BusInterface;
     IrpStack->Parameters.QueryInterface.InterfaceSpecificData = NULL;
@@ -293,13 +293,11 @@ NdisWritePciSlotInformation(
   Status = NdisQueryPciBusInterface(Adapter);
   if (NT_SUCCESS(Status) && Adapter->BusInterface != NULL) {
       ULONG Result;
-
       Result = Adapter->BusInterface->SetBusData(Adapter->BusInterface->Context,
                                                  PCI_WHICHSPACE_CONFIG,
                                                  Buffer,
                                                  Offset,
                                                  Length);
-
       NDIS_DbgPrint(MAX_TRACE, ("NdisWritePciSlotInformation: Using bus interface, wrote %u bytes\n", Result));
       return Result;
   }

--- a/drivers/network/ndis/ndis/hardware.c
+++ b/drivers/network/ndis/ndis/hardware.c
@@ -43,7 +43,7 @@ NdisQueryPciBusInterface(
     KeInitializeEvent(&Event, NotificationEvent, FALSE);
 
     Irp = IoBuildSynchronousFsdRequest(IRP_MJ_PNP,
-                                       Adapter->NdisMiniportBlock.PhysicalDeviceObject,
+                                       Adapter->NdisMiniportBlock.NextDeviceObject,
                                        NULL,
                                        0,
                                        NULL,
@@ -75,7 +75,6 @@ NdisQueryPciBusInterface(
         Adapter->BusInterface = BusInterface;
     } else {
         ExFreePoolWithTag(BusInterface, NDIS_TAG);
-        Adapter->BusInterface = NULL;
     }
 
     return Status;
@@ -268,7 +267,6 @@ NdisReadPciSlotInformation(
   }
 
   /* Fall back to HAL functions ONLY if bus interface is not available */
-  NDIS_DbgPrint(MAX_TRACE, ("NdisReadPciSlotInformation: Using HAL functions\n"));
   return HalGetBusDataByOffset(PCIConfiguration,
                                Adapter->NdisMiniportBlock.BusNumber, Adapter->NdisMiniportBlock.SlotNumber,
                                Buffer, Offset, Length);
@@ -303,7 +301,6 @@ NdisWritePciSlotInformation(
   }
 
   /* Fall back to HAL functions ONLY if bus interface is not available */
-  NDIS_DbgPrint(MAX_TRACE, ("NdisWritePciSlotInformation: Using HAL functions\n"));
   return HalSetBusDataByOffset(PCIConfiguration,
                                Adapter->NdisMiniportBlock.BusNumber, Adapter->NdisMiniportBlock.SlotNumber,
                                Buffer, Offset, Length);

--- a/drivers/network/ndis/ndis/hardware.c
+++ b/drivers/network/ndis/ndis/hardware.c
@@ -25,24 +25,22 @@ NdisQueryPciBusInterface(
     IO_STATUS_BLOCK IoStatusBlock;
     PIO_STACK_LOCATION IrpStack;
 
-    if (Adapter->BusInterfaceQueried) {
-      return (Adapter->BusInterface.GetBusData != NULL) ? STATUS_SUCCESS : STATUS_NOT_SUPPORTED;
-    }
+    if (Adapter->BusInterfaceQueried)
+        return (Adapter->BusInterface.GetBusData != NULL) ? STATUS_SUCCESS : STATUS_NOT_SUPPORTED;
 
     Adapter->BusInterfaceQueried = TRUE;
 
     KeInitializeEvent(&Event, NotificationEvent, FALSE);
 
     Irp = IoBuildSynchronousFsdRequest(IRP_MJ_PNP,
-                       Adapter->NdisMiniportBlock.NextDeviceObject,
-                       NULL,
-                       0,
-                       NULL,
-                       &Event,
-                       &IoStatusBlock);
-    if (Irp == NULL) {
-      return STATUS_INSUFFICIENT_RESOURCES;
-    }
+                                       Adapter->NdisMiniportBlock.NextDeviceObject,
+                                       NULL,
+                                       0,
+                                       NULL,
+                                       &Event,
+                                       &IoStatusBlock);
+    if (Irp == NULL)
+        return STATUS_INSUFFICIENT_RESOURCES;
 
     IrpStack = IoGetNextIrpStackLocation(Irp);
     IrpStack->MajorFunction = IRP_MJ_PNP;
@@ -56,15 +54,14 @@ NdisQueryPciBusInterface(
     Irp->IoStatus.Status = STATUS_NOT_SUPPORTED;
 
     Status = IoCallDriver(Adapter->NdisMiniportBlock.NextDeviceObject, Irp);
-    if (Status == STATUS_PENDING) {
-      KeWaitForSingleObject(&Event, Executive, KernelMode, FALSE, NULL);
-      Status = IoStatusBlock.Status;
+    if (Status == STATUS_PENDING)
+    {
+        KeWaitForSingleObject(&Event, Executive, KernelMode, FALSE, NULL);
+        Status = IoStatusBlock.Status;
     }
 
     if (!NT_SUCCESS(Status))
-    {
         RtlZeroMemory(&Adapter->BusInterface, sizeof(Adapter->BusInterface));
-    }
 
     return Status;
 }
@@ -242,7 +239,8 @@ NdisReadPciSlotInformation(
   PLOGICAL_ADAPTER Adapter = NdisAdapterHandle;
 
   /* Slot number is ignored since W2K for all NDIS drivers. */
-  if (Adapter->BusInterface.GetBusData != NULL) {
+  if (Adapter->BusInterface.GetBusData != NULL)
+  {
       ULONG Result;
       Result = Adapter->BusInterface.GetBusData(Adapter->BusInterface.Context,
                                                 PCI_WHICHSPACE_CONFIG,
@@ -274,7 +272,8 @@ NdisWritePciSlotInformation(
   PLOGICAL_ADAPTER Adapter = NdisAdapterHandle;
 
   /* Slot number is ignored since W2K for all NDIS drivers. */
-  if (Adapter->BusInterface.SetBusData != NULL) {
+  if (Adapter->BusInterface.SetBusData != NULL)
+  {
       ULONG Result;
       Result = Adapter->BusInterface.SetBusData(Adapter->BusInterface.Context,
                                                 PCI_WHICHSPACE_CONFIG,

--- a/drivers/network/ndis/ndis/miniport.c
+++ b/drivers/network/ndis/ndis/miniport.c
@@ -2553,7 +2553,6 @@ NdisIAddDevice(
   KeInitializeSpinLock(&Adapter->NdisMiniportBlock.Lock);
   InitializeListHead(&Adapter->ProtocolListHead);
 
-
   Status = IoRegisterDeviceInterface(PhysicalDeviceObject,
                                      &GUID_DEVINTERFACE_NET,
                                      NULL,

--- a/drivers/network/ndis/ndis/miniport.c
+++ b/drivers/network/ndis/ndis/miniport.c
@@ -2256,6 +2256,7 @@ NdisIPnPStopDevice(
 
         ExFreePoolWithTag(Adapter->BusInterface, NDIS_TAG);
         Adapter->BusInterface = NULL;
+        Adapter->BusInterfaceQueried = FALSE;
     }
 
   if (Adapter->NdisMiniportBlock.Resources)

--- a/drivers/network/ndis/ndis/miniport.c
+++ b/drivers/network/ndis/ndis/miniport.c
@@ -2249,6 +2249,15 @@ NdisIPnPStopDevice(
       Adapter->NdisMiniportBlock.AllocatedResourcesTranslated = NULL;
     }
 
+    if (Adapter->BusInterface)
+    {
+        if (Adapter->BusInterface->InterfaceDereference)
+            Adapter->BusInterface->InterfaceDereference(Adapter->BusInterface->Context);
+
+        ExFreePoolWithTag(Adapter->BusInterface, NDIS_TAG);
+        Adapter->BusInterface = NULL;
+    }
+
   if (Adapter->NdisMiniportBlock.Resources)
     {
       ExFreePool(Adapter->NdisMiniportBlock.Resources);
@@ -2541,6 +2550,9 @@ NdisIAddDevice(
   Adapter = (PLOGICAL_ADAPTER)DeviceObject->DeviceExtension;
   KeInitializeSpinLock(&Adapter->NdisMiniportBlock.Lock);
   InitializeListHead(&Adapter->ProtocolListHead);
+
+  Adapter->BusInterface = NULL;
+  Adapter->BusInterfaceQueried = FALSE;
 
   Status = IoRegisterDeviceInterface(PhysicalDeviceObject,
                                      &GUID_DEVINTERFACE_NET,


### PR DESCRIPTION
Main purpose of this is to prefer querying PCI.sys itself for PCI config access. 
Of course the old method will still be fall back on but this handles cases where the HAL methodology isn't usable.

## Testbot runs (Filled in by Devs)
 
- [x] KVM x86: https://reactos.org/testman/compare.php?ids=108680,108682,108684
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=108680,108682,108684