### PR TITLE
[SHELL32] Implement SHGetKnownFolderPath

### DIFF
--- a/dll/win32/shell32/shell32.spec
+++ b/dll/win32/shell32/shell32.spec
@@ -469,3 +469,4 @@
 757 stdcall -noname -version=0x600+ DisplayNameOfW(ptr ptr long ptr long)
 866 stdcall -noname -version=0x600+ SHExtCoCreateInstance(wstr ptr ptr ptr ptr)
 887 stub -noname -version=0x601+ SHExtCoCreateInstanceCheckCategory
+@ stdcall -version=0x600+ SHGetKnownFolderPath(ptr long ptr ptr)

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -3451,7 +3451,7 @@ HRESULT WINAPI SHGetKnownFolderPath(
 
     if (mapped_csidl == -1)
     {
-        ERR("Unknown known folder GUID requested\n");
+        ERR("Unknown known folder GUID requested: %s\n", debugstr_guid(&rfid));
         return E_INVALIDARG;
     }
 
@@ -3493,7 +3493,7 @@ HRESULT WINAPI SHGetKnownFolderPath(
              hr = HRESULT_FROM_WIN32(ERROR_PATH_NOT_FOUND);
              break;
         case CSIDL_Type_WindowsPath:
-            if (!GetWindowsDirectoryW(szPath, MAX_PATH))
+            if (!GetWindowsDirectoryW(szPath, _countof(szPath)))
             {
                 hr = HRESULT_FROM_WIN32(GetLastError());
             } 
@@ -3507,7 +3507,7 @@ HRESULT WINAPI SHGetKnownFolderPath(
             }
             break;
         case CSIDL_Type_SystemPath:
-            if (!GetSystemDirectoryW(szPath, MAX_PATH))
+            if (!GetSystemDirectoryW(szPath, _countof(szPath)))
             {
                 hr = HRESULT_FROM_WIN32(GetLastError());
             } 

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -3503,7 +3503,12 @@ HRESULT WINAPI SHGetKnownFolderPath(
             }
             if (SUCCEEDED(hr) && szDefaultPath && !IS_INTRESOURCE(szDefaultPath) && *szDefaultPath)
             {
-                PathAppendW(szPath, szDefaultPath);
+                hr = PathCchAppend(szPath, _countof(szPath), szDefaultPath);
+                if (FAILED(hr))
+                {
+                    ERR("PathCchAppend failed: 0x%08x\n", hr);
+                    return hr;
+                }
             }
             break;
         case CSIDL_Type_SystemPath:
@@ -3517,7 +3522,12 @@ HRESULT WINAPI SHGetKnownFolderPath(
             }
             if (SUCCEEDED(hr) && szDefaultPath && !IS_INTRESOURCE(szDefaultPath) && *szDefaultPath)
             {
-                PathAppendW(szPath, szDefaultPath);
+                hr = PathCchAppend(szPath, _countof(szPath), szDefaultPath);
+                if (FAILED(hr))
+                {
+                    ERR("PathCchAppend failed: 0x%08x\n", hr);
+                    return hr;
+                }
             }
             break;
         case CSIDL_Type_SystemX86Path:
@@ -3538,7 +3548,12 @@ HRESULT WINAPI SHGetKnownFolderPath(
             }
             if (SUCCEEDED(hr) && szDefaultPath && !IS_INTRESOURCE(szDefaultPath) && *szDefaultPath)
             {
-                PathAppendW(szPath, szDefaultPath);
+                hr = PathCchAppend(szPath, _countof(szPath), szDefaultPath);
+                if (FAILED(hr))
+                {
+                    ERR("PathCchAppend failed: 0x%08x\n", hr);
+                    return hr;
+                }
             }
             break;
         case CSIDL_Type_CurrVer:
@@ -3552,14 +3567,14 @@ HRESULT WINAPI SHGetKnownFolderPath(
             hr = _SHGetAllUsersProfilePath(internalFlags, (BYTE)mapped_csidl, szPath);
             break;
         default:
-            TRACE("SHGetKnownFolderPath: Unhandled CSIDL_Type %d\n", type);
+            ERR("SHGetKnownFolderPath: Unhandled CSIDL_Type %d\n", type);
             hr = E_NOTIMPL;
             break;
     }
 
     if (FAILED(hr))
     {
-        TRACE("Failed to get path, HRESULT=0x%08x\n", hr);
+        ERR("Failed to get path, HRESULT=0x%08x\n", hr);
         return hr;
     }
 
@@ -3569,7 +3584,7 @@ HRESULT WINAPI SHGetKnownFolderPath(
         hr = _SHExpandEnvironmentStrings(hToken, szPath, szExpandedPath, _countof(szExpandedPath));
         if (FAILED(hr))
         {
-             TRACE("Failed to expand environment strings, HRESULT=0x%08x\n", hr);
+             ERR("Failed to expand environment strings, HRESULT=0x%08x\n", hr);
              return hr;
         }
         StringCchCopyW(szPath, _countof(szPath), szExpandedPath);
@@ -3588,14 +3603,14 @@ HRESULT WINAPI SHGetKnownFolderPath(
                 if (ret != ERROR_SUCCESS && ret != ERROR_ALREADY_EXISTS)
                 {
                     hr = HRESULT_FROM_WIN32(ret);
-                    TRACE("Failed to create directory, HRESULT=0x%08x\n", hr);
+                    ERR("Failed to create directory, HRESULT=0x%08x\n", hr);
                     return hr;
                 }
             }
             else
             {
                  hr = HRESULT_FROM_WIN32(ERROR_PATH_NOT_FOUND);
-                 TRACE("Path not found and creation not requested\n");
+                 ERR("Path not found and creation not requested\n");
                  return hr;
             }
         }
@@ -3614,11 +3629,23 @@ HRESULT WINAPI SHGetKnownFolderPath(
             }
 
             StringCchCopyW(szDesktopIniPath, _countof(szDesktopIniPath), szPath);
-            PathAppendW(szDesktopIniPath, L"desktop.ini");
+            hr = PathCchAppend(szDesktopIniPath, _countof(szDesktopIniPath), L"desktop.ini");
 
-            StringCchPrintfW(szIconLocation, _countof(szIconLocation),
-                             L"%%SystemRoot%%\\system32\\shell32.dll,%d",
-                             nShell32IconIndex);
+            if (FAILED(hr))
+            {
+                ERR("PathCchAppend failed for desktop.ini: 0x%08x\n", hr);
+                return hr;
+            }
+
+            hr = StringCchPrintfW(szIconLocation, _countof(szIconLocation),
+                      L"%%SystemRoot%%\\system32\\shell32.dll,%d",
+                      nShell32IconIndex);
+
+            if (FAILED(hr))
+            {
+                ERR("StringCchPrintfW failed: 0x%08x\n", hr);
+                return hr;
+            }
 
             WritePrivateProfileStringW(L".ShellClassInfo", L"IconResource", szIconLocation, szDesktopIniPath);
 
@@ -3638,7 +3665,7 @@ HRESULT WINAPI SHGetKnownFolderPath(
     *ppszPath = (PWSTR)SHAlloc((pathLen + 1) * sizeof(WCHAR));
     if (!*ppszPath)
     {
-        TRACE("Failed to allocate memory for path\n");
+        ERR("Failed to allocate memory for path\n");
         hr = E_OUTOFMEMORY;
         return hr;
     }

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -3576,7 +3576,7 @@ HRESULT WINAPI SHGetKnownFolderPath(
     }
 
     BOOL bVerify = !(dwFlags & KF_FLAG_DONT_VERIFY);
-    BOOL bCreate = (dwFlags & (KF_FLAG_CREATE | KF_FLAG_INIT));
+    BOOL bCreate = !!(dwFlags & KF_FLAG_CREATE);
 
     if (bVerify)
     {

--- a/sdk/include/psdk/shlobj.h
+++ b/sdk/include/psdk/shlobj.h
@@ -197,6 +197,14 @@ SHGetFolderPathAndSubDirW(
   _In_opt_ LPCWSTR,
   _Out_writes_(MAX_PATH) LPWSTR);
 
+#if (_WIN32_WINNT >= _WIN32_WINNT_VISTA)
+HRESULT WINAPI SHGetKnownFolderPath(
+  _In_ REFKNOWNFOLDERID rfid,
+  _In_ DWORD dwFlags,
+  _In_opt_ HANDLE hToken,
+  _Outptr_ PWSTR *ppszPath);
+#endif
+
 #define SHGetFolderPathAndSubDir WINELIB_NAME_AW(SHGetFolderPathAndSubDir)
 
 HRESULT WINAPI


### PR DESCRIPTION
## Purpose

This implements the API call SHGetKnownFolderPath this is part 2 of reworking PR that was under https://github.com/reactos/reactos/pull/8013

JIRA issue: [CORE-20195](https://jira.reactos.org/browse/CORE-20195)

## Proposed changes

Implement the api call SHGetKnownFolderPath and update shlobj.h sdk header

## Notes (important)
Im not exactly sure how i would write the code to not be inside wine shellpath.c on original PR i was told to move it from there but problem is i call _SHGet... from wine shellpath...

It looks like wine already has test for SHGetKnownFolderPath so in this new PR i didnt include my own test if that is fine

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: