### PR TITLE
[FREELDR] Fix Windows Vista boot

### DIFF
--- a/sdk/include/reactos/arc/arc.h
+++ b/sdk/include/reactos/arc/arc.h
@@ -640,9 +640,11 @@ typedef struct _LOADER_PARAMETER_EXTENSION
     LIST_ENTRY BootApplicationPersistentData;
     PVOID WmdTestResult;
     GUID BootIdentifier;
-#if (NTDDI_VERSION >= NTDDI_WIN7)
+#if (NTDDI_VERSION >= NTDDI_VISTASP1 || defined __REACTOS__)
     ULONG ResumePages;
     PVOID DumpHeader;
+#endif
+#if (NTDDI_VERSION >= NTDDI_WIN7)
     PVOID BgContext;
     PVOID NumaLocalityInfo;
     PVOID NumaGroupAssignment;
@@ -864,7 +866,7 @@ typedef struct _LOADER_PARAMETER_BLOCK
         PPC_LOADER_BLOCK PowerPC;
         ARM_LOADER_BLOCK Arm;
     } u;
-#if (NTDDI_VERSION >= NTDDI_LONGHORN)
+#if (NTDDI_VERSION >= NTDDI_LONGHORN || defined __REACTOS__)
     FIRMWARE_INFORMATION_LOADER_BLOCK FirmwareInformation;
 #endif
 } LOADER_PARAMETER_BLOCK, *PLOADER_PARAMETER_BLOCK;


### PR DESCRIPTION
## Purpose

Fix windows vista boot by avoiding 1MB low memory and fixing Loader structs.

JIRA issue: [CORE-XXXX](https://jira.reactos.org/browse/CORE-XXXX)

## Proposed changes

_Describe what you propose to change/add/fix with this pull request._

- Skip the low 1MB on allocations.

- Fix the Loader parameter structs to what windows vista expects.

## TODO

_Use a TODO when your pull request is Work in Progress._

- [ ] Maybe investigate this more

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: