### PR TITLE
[RTL] Implement `RtlRemoteCall` on x64 and x86

### DIFF
--- a/modules/rostests/apitests/ntdll/CMakeLists.txt
+++ b/modules/rostests/apitests/ntdll/CMakeLists.txt
@@ -150,10 +150,16 @@ if(ARCH STREQUAL "i386")
         ../crt/i386/setjmp_helper.s
         i386/NtContinue.S
     )
+    list(APPEND SOURCE
+        RtlRemoteCall.c
+    )
 elseif(ARCH STREQUAL "amd64")
     add_asm_files(ntdll_apitest_asm
         ../crt/amd64/setjmp_helper.s
         amd64/NtContinue.S
+    )
+    list(APPEND SOURCE
+        RtlRemoteCall.c
     )
 endif()
 

--- a/modules/rostests/apitests/ntdll/RtlRemoteCall.c
+++ b/modules/rostests/apitests/ntdll/RtlRemoteCall.c
@@ -1,0 +1,284 @@
+/*
+ * PROJECT:     ReactOS API tests
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     Test for x64 and x86 RtlRemoteCall
+ * COPYRIGHT:   Copyright 2025 Ratin Gao <ratin@knsoft.org>
+ */
+
+#include "precomp.h"
+
+#define RTL_REMOTECALL_MAX_ARG_COUNT 4
+
+/* High 16 bits should be zero */
+#define TEST_VALUE_CALLSITE ((PVOID)(ULONG_PTR)0x00001C1C1C1C1C1CULL)
+
+#define PRESET_VALUE_A ((ULONG_PTR)0xEAEAEAEAEAEAEAEAULL)
+#define PRESET_VALUE_B ((ULONG_PTR)0xEBEBEBEBEBEBEBEBULL)
+#define PRESET_VALUE_C ((ULONG_PTR)0xECECECECECECECECULL)
+#define PRESET_VALUE_D ((ULONG_PTR)0xEDEDEDEDEDEDEDEDULL)
+#define PRESET_VALUE_E ((ULONG_PTR)0xEFEFEFEFEFEFEFEFULL)
+#define PRESET_VALUE_F ((ULONG_PTR)0xFEFEFEFEFEFEFEFEULL)
+#define PRESET_VALUE_G ((ULONG_PTR)0xFDFDFDFDFDFDFDFDULL)
+#define PRESET_VALUE_08 ((ULONG_PTR)0x0808080808080808ULL)
+#define PRESET_VALUE_09 ((ULONG_PTR)0x0909090909090909ULL)
+#define PRESET_VALUE_10 ((ULONG_PTR)0x1010101010101010ULL)
+#define PRESET_VALUE_11 ((ULONG_PTR)0x1111111111111111ULL)
+#define PRESET_VALUE_12 ((ULONG_PTR)0x1212121212121212ULL)
+#define PRESET_VALUE_13 ((ULONG_PTR)0x1313131313131313ULL)
+#define PRESET_VALUE_14 ((ULONG_PTR)0x1414141414141414ULL)
+#define PRESET_VALUE_15 ((ULONG_PTR)0x1515151515151515ULL)
+
+static ULONG_PTR g_Params[RTL_REMOTECALL_MAX_ARG_COUNT + 1] = {
+    (ULONG_PTR)0xAAAAAAAAAAAAAAAAULL,
+    (ULONG_PTR)0xBBBBBBBBBBBBBBBBULL,
+    (ULONG_PTR)0xCCCCCCCCCCCCCCCCULL,
+    (ULONG_PTR)0xDDDDDDDDDDDDDDDDULL,
+    (ULONG_PTR)0xEEEEEEEEEEEEEEEEULL
+};
+
+static
+void
+RemoteCall(
+    _In_ HANDLE ProcessHandle,
+    _In_ HANDLE ThreadHandle,
+    _In_ ULONG ArgumentCount,
+    _In_reads_(ArgumentCount) PULONG_PTR Arguments,
+    _In_ BOOLEAN PassContext)
+{
+    NTSTATUS Status;
+    CONTEXT Context, *PassedContextPtr, PassedContext;
+    ULONG_PTR OldPc, OldSp, ArgSize, Params[RTL_REMOTECALL_MAX_ARG_COUNT + 1], *ParamsPtr;
+
+    /* Preset some values into the context */
+    Context.ContextFlags = CONTEXT_FULL;
+    Status = NtGetContextThread(ThreadHandle, &Context);
+    if (!NT_SUCCESS(Status))
+    {
+        goto _Skip;
+    }
+#if defined(_M_X64)
+    OldPc = Context.Rip;
+    OldSp = Context.Rsp; 
+    Context.Rax = PRESET_VALUE_A;
+    Context.Rbx = PRESET_VALUE_B;
+    Context.Rcx = PRESET_VALUE_C;
+    Context.Rdx = PRESET_VALUE_D;
+    Context.Rsi = PRESET_VALUE_E;
+    Context.Rdi = PRESET_VALUE_F;
+    Context.Rbp = PRESET_VALUE_G;
+    Context.R8  = PRESET_VALUE_08;
+    Context.R9  = PRESET_VALUE_09;
+    Context.R10 = PRESET_VALUE_10;
+    Context.R11 = PRESET_VALUE_11;
+    Context.R12 = PRESET_VALUE_12;
+    Context.R13 = PRESET_VALUE_13;
+    Context.R14 = PRESET_VALUE_14;
+    Context.R15 = PRESET_VALUE_15;
+#elif defined(_M_IX86)
+    OldPc = Context.Eip;
+    OldSp = Context.Esp; 
+    Context.Eax = PRESET_VALUE_A;
+    Context.Ebx = PRESET_VALUE_B;
+    Context.Ecx = PRESET_VALUE_C;
+    Context.Edx = PRESET_VALUE_D;
+    Context.Esi = PRESET_VALUE_E;
+    Context.Edi = PRESET_VALUE_F;
+    Context.Ebp = PRESET_VALUE_G;
+#endif
+    Status = NtSetContextThread(ThreadHandle, &Context);
+    if (!NT_SUCCESS(Status))
+    {
+        goto _Skip;
+    }
+
+    /* Call RtlRemoteCall and get context */
+    Status = RtlRemoteCall(ProcessHandle,
+                           ThreadHandle,
+                           TEST_VALUE_CALLSITE,
+                           ArgumentCount,
+                           Arguments,
+                           PassContext,
+                           TRUE);
+    if (ArgumentCount > RTL_REMOTECALL_MAX_ARG_COUNT)
+    {
+        ok(Status == STATUS_INVALID_PARAMETER, "RtlRemoteCall returned wrong status 0x%08lX\n", Status);
+    }
+    else
+    {
+        ok(Status == STATUS_SUCCESS, "RtlRemoteCall failed with 0x%08lX\n", Status);
+    }
+    if (!NT_SUCCESS(Status))
+    {
+        return;
+    }
+    Status = NtGetContextThread(ThreadHandle, &Context);
+    if (!NT_SUCCESS(Status))
+    {
+        goto _Skip;
+    }
+
+    /* Check preset values untouched */
+#if defined(_M_X64)
+    ok_size_t(Context.Rax, STATUS_ALERTED);
+    ok_size_t(Context.Rbx, PRESET_VALUE_B);
+    ok_size_t(Context.Rcx, PRESET_VALUE_C);
+    ok_size_t(Context.Rdx, PRESET_VALUE_D);
+    ok_size_t(Context.Rsi, PRESET_VALUE_E);
+    ok_size_t(Context.Rdi, PRESET_VALUE_F);
+    ok_size_t(Context.Rbp, PRESET_VALUE_G);
+    ok_size_t(Context.R8 , PRESET_VALUE_08);
+    ok_size_t(Context.R9 , PRESET_VALUE_09);
+    ok_size_t(Context.R10, PRESET_VALUE_10);
+#elif defined(_M_IX86)
+    ok_size_t(Context.Eax, PRESET_VALUE_A);
+    ok_size_t(Context.Ebx, PRESET_VALUE_B);
+    ok_size_t(Context.Ecx, PRESET_VALUE_C);
+    ok_size_t(Context.Edx, PRESET_VALUE_D);
+    ok_size_t(Context.Esi, PRESET_VALUE_E);
+    ok_size_t(Context.Edi, PRESET_VALUE_F);
+    ok_size_t(Context.Ebp, PRESET_VALUE_G);
+#endif
+
+    /* Check new stack pointer, program counter, and input parameters */
+    ArgSize = ArgumentCount * sizeof(*Arguments);
+#if defined(_M_X64)
+    ok_size_t(Context.Rsp, OldSp - sizeof(CONTEXT));
+    ok_size_t(Context.Rip, (ULONG_PTR)TEST_VALUE_CALLSITE);
+    Params[0] = Context.R11;
+    Params[1] = Context.R12;
+    Params[2] = Context.R13;
+    Params[3] = Context.R14;
+    Params[4] = Context.R15;
+    if (PassContext)
+    {
+        ok_size_t(Context.R11, Context.Rsp);
+        ParamsPtr = &Params[1];
+    }
+    else
+    {
+        ParamsPtr = &Params[0];
+        ok_size_t(Context.R15, PRESET_VALUE_15);
+    }
+#elif defined(_M_IX86)
+    ULONG_PTR NewSp = OldSp - ArgSize;
+    if (PassContext)
+    {
+        NewSp -= sizeof(PCONTEXT) + sizeof(CONTEXT);
+    }
+    ok_size_t(Context.Esp, NewSp);
+    ok_size_t(Context.Eip, (ULONG_PTR)TEST_VALUE_CALLSITE);
+    Status = NtReadVirtualMemory(ProcessHandle, (PVOID)Context.Esp, Params, sizeof(Params), NULL);
+    if (!NT_SUCCESS(Status))
+    {
+        goto _Skip;
+    }
+    ParamsPtr = &Params[PassContext ? 1 : 0];
+#else
+    ParamsPtr = NULL;
+#endif
+    if (ParamsPtr != NULL)
+    {
+        ok(memcmp(ParamsPtr, Arguments, ArgSize) == 0, "Passed parameters are incorrect\n");
+    }
+
+    /* Check passed context, which was written to stack */
+#if defined(_M_X64)
+    PassedContextPtr = (PCONTEXT)Context.Rsp;
+#elif defined(_M_IX86)
+    PassedContextPtr = PassContext ? (PCONTEXT)(Context.Esp + ArgSize + sizeof(PCONTEXT)) : NULL;
+#else
+    PassedContextPtr = NULL;
+#endif
+    if (PassedContextPtr != NULL)
+    {
+        /* If PassContext, the first parameter passed is the pointer to the context passed */
+        if (PassContext)
+        {
+            ok_size_t((ULONG_PTR)PassedContextPtr, Params[0]);
+        }
+        Status = NtReadVirtualMemory(ProcessHandle,
+                                     PassedContextPtr,
+                                     &PassedContext,
+                                     sizeof(PassedContext),
+                                     NULL);
+        if (!NT_SUCCESS(Status))
+        {
+            goto _Skip;
+        }
+#if defined(_M_X64)
+        ok_eq_ulong(PassedContext.ContextFlags, CONTEXT_FULL);
+        ok_size_t(PassedContext.Rax, STATUS_ALERTED);
+        ok_size_t(PassedContext.Rbx, PRESET_VALUE_B);
+        ok_size_t(PassedContext.Rcx, PRESET_VALUE_C);
+        ok_size_t(PassedContext.Rdx, PRESET_VALUE_D);
+        ok_size_t(PassedContext.Rsi, PRESET_VALUE_E);
+        ok_size_t(PassedContext.Rdi, PRESET_VALUE_F);
+        ok_size_t(PassedContext.Rbp, PRESET_VALUE_G);
+        ok_size_t(PassedContext.R8 , PRESET_VALUE_08);
+        ok_size_t(PassedContext.R9 , PRESET_VALUE_09);
+        ok_size_t(PassedContext.R10, PRESET_VALUE_10);
+        ok_size_t(PassedContext.R11, PRESET_VALUE_11);
+        ok_size_t(PassedContext.R12, PRESET_VALUE_12);
+        ok_size_t(PassedContext.R13, PRESET_VALUE_13);
+        ok_size_t(PassedContext.R14, PRESET_VALUE_14);
+        ok_size_t(PassedContext.R15, PRESET_VALUE_15);
+        ok_size_t(PassedContext.Rip, OldPc);
+        ok_size_t(PassedContext.Rsp, OldSp);
+#elif defined(_M_IX86)
+        ok_eq_ulong(PassedContext.ContextFlags, CONTEXT_FULL);
+        ok_size_t(PassedContext.Eax, PRESET_VALUE_A);
+        ok_size_t(PassedContext.Ebx, PRESET_VALUE_B);
+        ok_size_t(PassedContext.Ecx, PRESET_VALUE_C);
+        ok_size_t(PassedContext.Edx, PRESET_VALUE_D);
+        ok_size_t(PassedContext.Esi, PRESET_VALUE_E);
+        ok_size_t(PassedContext.Edi, PRESET_VALUE_F);
+        ok_size_t(PassedContext.Ebp, PRESET_VALUE_G);
+        ok_size_t(PassedContext.Eip, OldPc);
+        ok_size_t(PassedContext.Esp, OldSp);
+#endif
+    }
+
+    return;
+
+_Skip:
+    skip("API failed with 0x%08lX, test skipped", Status);
+}
+
+START_TEST(RtlRemoteCall)
+{
+    STARTUPINFOW si = { sizeof(si) };
+    PROCESS_INFORMATION pi;
+
+    /*
+     * Create a process in a suspended state to test,
+     * set DEBUG_PROCESS flag to make sure the process will be terminated if this test went wrong.
+     */
+    if (!CreateProcessW(NtCurrentPeb()->ProcessParameters->ImagePathName.Buffer,
+                        NULL,
+                        NULL,
+                        NULL,
+                        FALSE,
+                        CREATE_SUSPENDED | DEBUG_PROCESS,
+                        NULL,
+                        NULL,
+                        &si,
+                        &pi))
+    {
+        skip("CreateProcessW failed with 0x%08lX, test cannot continue\n", GetLastError());
+        return;
+    }
+
+    /* PassContext is set */
+    RemoteCall(pi.hProcess, pi.hThread, RTL_REMOTECALL_MAX_ARG_COUNT, g_Params, TRUE);
+
+    /* PassContext is not set */
+    RemoteCall(pi.hProcess, pi.hThread, RTL_REMOTECALL_MAX_ARG_COUNT, g_Params, FALSE);
+
+    /* The maximum number of parameters is 4 */
+    RemoteCall(pi.hProcess, pi.hThread, RTL_REMOTECALL_MAX_ARG_COUNT + 1, g_Params, TRUE);
+
+    /* Cleanup */
+    TerminateProcess(pi.hProcess, 0);
+    CloseHandle(pi.hThread);
+    CloseHandle(pi.hProcess);
+}

--- a/modules/rostests/apitests/ntdll/testlist.c
+++ b/modules/rostests/apitests/ntdll/testlist.c
@@ -118,6 +118,7 @@ extern void func_RtlpApplyLengthFunction(void);
 extern void func_RtlpEnsureBufferSize(void);
 extern void func_RtlQueryTimeZoneInformation(void);
 extern void func_RtlReAllocateHeap(void);
+extern void func_RtlRemoteCall(void);
 extern void func_RtlRemovePrivileges(void);
 extern void func_RtlUnhandledExceptionFilter(void);
 extern void func_RtlUnicodeStringToAnsiString(void);
@@ -267,6 +268,9 @@ const struct test winetest_testlist[] =
 #endif
 #ifdef _M_AMD64
     { "RtlCaptureContext",              func_RtlCaptureContext },
+#endif
+#if defined(_M_X64) || defined(_M_IX86)
+    { "RtlRemoteCall",                  func_RtlRemoteCall },
 #endif
 
     { 0, 0 }

--- a/sdk/include/ndk/rtlfuncs.h
+++ b/sdk/include/ndk/rtlfuncs.h
@@ -2845,14 +2845,13 @@ NTSYSAPI
 NTSTATUS
 NTAPI
 RtlRemoteCall(
-    _In_ HANDLE Process,
-    _In_ HANDLE Thread,
+    _In_ HANDLE ProcessHandle,
+    _In_ HANDLE ThreadHandle,
     _In_ PVOID CallSite,
     _In_ ULONG ArgumentCount,
-    _In_ PULONG Arguments,
+    _In_reads_(ArgumentCount) PULONG_PTR Arguments,
     _In_ BOOLEAN PassContext,
-    _In_ BOOLEAN AlreadySuspended
-);
+    _In_ BOOLEAN AlreadySuspended);
 
 NTSYSAPI
 NTSTATUS

--- a/sdk/lib/rtl/thread.c
+++ b/sdk/lib/rtl/thread.c
@@ -337,16 +337,188 @@ _NtCurrentTeb(VOID)
     return NtCurrentTeb();
 }
 
+#if defined(_M_X64) || defined(_M_IX86)
+#define RTL_REMOTECALL_MAX_ARG_COUNT 4
+#endif
+
+/**
+ * @brief
+ * Hijacks a remote thread to run at a specified location.
+ *
+ * @param[in] ProcessHandle
+ * A handle to the target process.
+ * Must have PROCESS_VM_WRITE privilege if writing context or arguments to the stack of target thread.
+ *
+ * @param[in] ThreadHandle
+ * A handle to the target thread. Must have THREAD_GET_CONTEXT and THREAD_SET_CONTEXT privileges.
+ * THREAD_SUSPEND_RESUME privilege is required if AlreadySuspended is not set.
+ *
+ * @param[in] CallSite
+ * New location to run.
+ *
+ * @param[in] ArgumentCount
+ * Specifies the number of entries in the Arguments array.
+ * The maximum value is RTL_REMOTECALL_MAX_ARG_COUNT.
+ *
+ * @param[in] Arguments
+ * A pointer to an array of arguments to pass.
+ *
+ * @param[in] PassContext
+ * Passes an additional argument before Arguments, which is a pointer to a CONTEXT structure
+ * captured before hijacking.
+ * x64: The CONTEXT will be always written to target thread's stack regardless of PassContext.
+ *
+ * @param[in] AlreadySuspended
+ * Indicates the target thread is already suspended. If AlreadySuspended is not set,
+ * RtlRemoteCall will suspend and resume the target thread.
+ * x64: RAX will be set to STATUS_ALERTED if AlreadySuspended is set.
+ *
+ * @remarks
+ * x64: Arguments will be written to R11-R15.
+ * x86: Arguments will be written to the stack in order.
+ * This function's behavior depends on platform, see the implementation and apitest for more details.
+ */
+
 NTSTATUS
 NTAPI
-RtlRemoteCall(IN HANDLE Process,
-              IN HANDLE Thread,
-              IN PVOID CallSite,
-              IN ULONG ArgumentCount,
-              IN PULONG Arguments,
-              IN BOOLEAN PassContext,
-              IN BOOLEAN AlreadySuspended)
+RtlRemoteCall(
+    _In_ HANDLE ProcessHandle,
+    _In_ HANDLE ThreadHandle,
+    _In_ PVOID CallSite,
+    _In_ ULONG ArgumentCount,
+    _In_reads_(ArgumentCount) PULONG_PTR Arguments,
+    _In_ BOOLEAN PassContext,
+    _In_ BOOLEAN AlreadySuspended)
 {
+    /* Implemented on x64 and x86 currently */
+#if !defined(_M_X64) && !defined(_M_IX86)
     UNIMPLEMENTED;
     return STATUS_NOT_IMPLEMENTED;
+#else
+
+    NTSTATUS Status;
+    CONTEXT Context;
+    ULONG ArgumentSize;
+    ULONG_PTR NewStack, *ArgPtr;
+
+    if (ArgumentCount > RTL_REMOTECALL_MAX_ARG_COUNT)
+    {
+        return STATUS_INVALID_PARAMETER;
+    }
+
+    /* Suspend target thread if it is not suspended yet */
+    if (!AlreadySuspended)
+    {
+        Status = NtSuspendThread(ThreadHandle, NULL);
+        if (!NT_SUCCESS(Status))
+        {
+            return Status;
+        }
+    }
+
+    /* Get target thread context */
+    Context.ContextFlags = CONTEXT_FULL;
+    Status = NtGetContextThread(ThreadHandle, &Context);
+    if (!NT_SUCCESS(Status))
+    {
+        goto _Exit;
+    }
+
+    /* x64 specific: Set RAX to STATUS_ALERTED if target thread is already suspended */
+#ifdef _M_X64
+    if (AlreadySuspended)
+    {
+        Context.Rax = STATUS_ALERTED;
+    }
+#endif
+
+    /*
+     * Write context to the stack.
+     * x64 specific: ignore PassContext parameter, always write context to the stack.
+     */
+#ifdef _M_X64
+    NewStack = Context.Rsp - sizeof(Context);
+#else
+    NewStack = Context.Esp;
+    if (PassContext)
+    {
+        NewStack -= sizeof(Context);
+#endif
+        Status = NtWriteVirtualMemory(ProcessHandle,
+                                      (PVOID)NewStack,
+                                      &Context,
+                                      sizeof(Context),
+                                      NULL);
+        if (!NT_SUCCESS(Status))
+        {
+            goto _Exit;
+        }
+#ifdef _M_X64
+        Context.Rsp = NewStack;
+#else
+        Context.Esp = NewStack;
+    }
+#endif
+
+    /*
+     * Write parameters to target thread stack or context, and set new context.
+     * If PassContext is set, the first parameter is a pointer to the context we just written.
+     * x86 specific: write all parameters to the stack.
+     * x64 specific: write parameters to R11-R15 registers.
+     */
+    ArgumentSize = ArgumentCount * sizeof(*Arguments);
+#ifdef _M_X64
+    ArgPtr = &Context.R11;
+    if (PassContext)
+    {
+        *ArgPtr++ = NewStack;
+    }
+    if (ArgumentCount)
+    {
+        RtlCopyMemory(ArgPtr, Arguments, ArgumentSize);
+    }
+    Context.Rip = (ULONG_PTR)CallSite;
+#else
+    ULONG_PTR Args[RTL_REMOTECALL_MAX_ARG_COUNT + 1];
+
+    if (PassContext)
+    {
+        Args[0] = NewStack;
+        if (Arguments)
+        {
+            RtlCopyMemory(&Args[1], Arguments, ArgumentSize);
+        }
+        ArgumentSize += sizeof(*Arguments);
+        ArgPtr = Args;
+    }
+    else
+    {
+        ArgPtr = Arguments;
+    }
+    if (ArgumentSize)
+    {
+        NewStack -= ArgumentSize;
+        Status = NtWriteVirtualMemory(ProcessHandle,
+                                      (PVOID)NewStack,
+                                      ArgPtr,
+                                      ArgumentSize,
+                                      NULL);
+        if (!NT_SUCCESS(Status))
+        {
+            goto _Exit;
+        }
+        Context.Esp = NewStack;
+    }
+    Context.Eip = (ULONG_PTR)CallSite;
+#endif
+    Status = NtSetContextThread(ThreadHandle, &Context);
+
+_Exit:
+    if (!AlreadySuspended)
+    {
+        NtResumeThread(ThreadHandle, NULL);
+    }
+    return Status;
+
+#endif
 }


### PR DESCRIPTION
## Purpose

Implement `RtlRemoteCall` on x64 and x86.

This PR is for re-opening #8146 , after a rework of API test (applied suggestions, use C instead of assembly and test on a remote process).

JIRA issue: None.

## Proposed changes

- Implement `RtlRemoteCall` on x64 and x86.
- Add apitest.

## Apitest snapshots

On Win11 (x86 and x64 build):
<img width="1197" height="396" alt="ScreenShot_2025-12-27_071500_861" src="https://github.com/user-attachments/assets/9a261627-2f01-4688-87ec-48477993ec72" />
<img width="1200" height="387" alt="ScreenShot_2025-12-27_071527_710" src="https://github.com/user-attachments/assets/2feeb3bf-355a-472f-8221-81483a3dbf0b" />

On ReactOS x86:
<img width="798" height="600" alt="ScreenShot_2025-12-27_073056_972" src="https://github.com/user-attachments/assets/cdfde3e7-5dd4-4bdc-ab81-39422b254faf" />

On ReactOS x64:
<img width="798" height="600" alt="ScreenShot_2025-12-27_075335_319" src="https://github.com/user-attachments/assets/29e21cf6-8139-41be-8df1-91a31973d296" />

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: