### PR TITLE
[EVENTLOG][FMIFS][KERNEL32][APITESTS] Fix leaks after calling `RtlDosPathNameToNtPathName_U`

### DIFF
--- a/base/services/eventlog/eventlog.c
+++ b/base/services/eventlog/eventlog.c
@@ -422,6 +422,7 @@ LoadLogFile(HKEY hKey, PWSTR LogName)
 
     HeapFree(GetProcessHeap(), 0, Expanded);
     HeapFree(GetProcessHeap(), 0, Buf);
+    RtlFreeHeap(RtlGetProcessHeap(), 0, FileName.Buffer);
     return pLogf;
 }
 

--- a/dll/win32/fmifs/query.c
+++ b/dll/win32/fmifs/query.c
@@ -4,7 +4,7 @@
  * FILE:            reactos/dll/win32/fmifs/query.c
  * PURPOSE:         Query volume information
  *
- * PROGRAMMERS:     Hervé Poussineau (hpoussin@reactos.org)
+ * PROGRAMMERS:     HervÃ© Poussineau (hpoussin@reactos.org)
  */
 
 #include "precomp.h"
@@ -134,6 +134,10 @@ QueryDeviceInformation(
                         &Iosb,
                         FILE_SHARE_READ | FILE_SHARE_WRITE,
                         FILE_SYNCHRONOUS_IO_NONALERT);
+    if (DeviceName.Buffer != DiskDevice)
+    {
+        RtlFreeHeap(RtlGetProcessHeap(), 0, DeviceName.Buffer);
+    }
     if (!NT_SUCCESS(Status))
         return FALSE;
 

--- a/dll/win32/kernel32/client/file/fileinfo.c
+++ b/dll/win32/kernel32/client/file/fileinfo.c
@@ -669,6 +669,7 @@ GetFileAttributesW(LPCWSTR lpFileName)
                                NULL, NULL);
     /* Simply query attributes */
     Status = NtQueryAttributesFile(&ObjectAttributes, &FileInformation);
+    RtlFreeHeap(RtlGetProcessHeap(), 0, FileName.Buffer);
     if (!NT_SUCCESS(Status))
     {
         /* It failed? Is it a DOS device? */

--- a/dll/win32/kernel32/client/utils.c
+++ b/dll/win32/kernel32/client/utils.c
@@ -687,7 +687,7 @@ NTSTATUS
 WINAPI
 BasepMapFile(IN LPCWSTR lpApplicationName,
              OUT PHANDLE hSection,
-             IN PUNICODE_STRING ApplicationName)
+             OUT PUNICODE_STRING ApplicationName)
 {
     RTL_RELATIVE_NAME_U RelativeName;
     OBJECT_ATTRIBUTES ObjectAttributes;
@@ -732,6 +732,7 @@ BasepMapFile(IN LPCWSTR lpApplicationName,
                         &IoStatusBlock,
                         FILE_SHARE_DELETE | FILE_SHARE_READ,
                         FILE_SYNCHRONOUS_IO_NONALERT | FILE_NON_DIRECTORY_FILE);
+    RtlReleaseRelativeName(&RelativeName);
     if (!NT_SUCCESS(Status))
     {
         DPRINT1("Failed to open file\n");

--- a/dll/win32/kernel32/include/kernel32.h
+++ b/dll/win32/kernel32/include/kernel32.h
@@ -305,7 +305,7 @@ NTSTATUS
 WINAPI
 BasepMapFile(IN LPCWSTR lpApplicationName,
              OUT PHANDLE hSection,
-             IN PUNICODE_STRING ApplicationName);
+             OUT PUNICODE_STRING ApplicationName);
 
 PCODEPAGE_ENTRY FASTCALL
 IntGetCodePageEntry(UINT CodePage);

--- a/modules/rostests/apitests/ntdll/NtApphelpCacheControl.c
+++ b/modules/rostests/apitests/ntdll/NtApphelpCacheControl.c
@@ -117,6 +117,10 @@ static void RunApphelpCacheControlTests(SC_HANDLE service_handle)
     if (!InitEnv(&ntPath))
     {
         skip("NtApphelpCacheControl expects a different structure layout\n");
+        if (Result)
+        {
+            RtlFreeHeap(RtlGetProcessHeap(), 0, ntPath.Buffer);
+        }
         return;
     }
     /* At this point we have made sure that our binary is not present in the cache,

--- a/modules/rostests/apitests/ntdll/NtMapViewOfSection.c
+++ b/modules/rostests/apitests/ntdll/NtMapViewOfSection.c
@@ -769,8 +769,10 @@ Test_ImageSection(void)
     if (!NT_SUCCESS(Status))
     {
         skip("Failed to open file %s\n", wine_dbgstr_wn(FileName.Buffer, FileName.Length / sizeof(WCHAR)));
+        RtlFreeHeap(RtlGetProcessHeap(), 0, FileName.Buffer);
         return;
     }
+    RtlFreeHeap(RtlGetProcessHeap(), 0, FileName.Buffer);
 
     /* Create a data section with write access */
     Status = NtCreateSection(&DataSectionHandle,
@@ -1029,6 +1031,7 @@ Test_ImageSection2(void)
                         &IoStatusBlock,
                         FILE_SHARE_READ,
                         FILE_SYNCHRONOUS_IO_NONALERT);
+    RtlFreeHeap(RtlGetProcessHeap(), 0, FileName.Buffer);
     ok_ntstatus(Status, STATUS_SUCCESS);
     printf("Opened file with handle %p\n", FileHandle);
 

--- a/modules/rostests/apitests/ntdll/RtlDosPathNameToNtPathName_U.c
+++ b/modules/rostests/apitests/ntdll/RtlDosPathNameToNtPathName_U.c
@@ -133,7 +133,7 @@ static void test2(LPCWSTR pwsz, LPCWSTR pwszExpected, LPCWSTR pwszExpectedPartNa
 	      memcmp(NtName.Buffer, L"\\??\\", 8) == 0;
 	check_result(bOK, "NtName does not start with \"\\??\\\"");
 	if (!bOK) {
-		return;
+        goto Quit;
 	}
 
 	if (pwszExpected) {
@@ -148,7 +148,7 @@ static void test2(LPCWSTR pwsz, LPCWSTR pwszExpected, LPCWSTR pwszExpectedPartNa
 			printf("input:  : %2Iu chars \"%S\"\n", wcslen(pwsz), pwsz);
 			printf("Expected: %2Iu chars \"%S\"\n", lenExp, pwszExpected);
 			printf("Actual  : %2Iu chars \"%S\"\n", lenAct, lenAct ? pwszActual : L"(null)");
-			return;
+            goto Quit;
 		}
 	} else
 	if (NtName.Length)
@@ -170,7 +170,7 @@ static void test2(LPCWSTR pwsz, LPCWSTR pwszExpected, LPCWSTR pwszExpectedPartNa
 			printf("input:  : %2Iu chars \"%S\"\n", wcslen(pwsz), pwsz);
 			printf("Expected: %2Iu chars \"%S\"\n", lenExp, pwszExpectedPartName);
 			printf("Actual  : %2Iu chars \"%S\"\n", lenAct, lenAct ? PartName : L"(null)");
-			return;
+            goto Quit;
 		}
 	} else
 	if (PartName)
@@ -179,6 +179,10 @@ static void test2(LPCWSTR pwsz, LPCWSTR pwszExpected, LPCWSTR pwszExpectedPartNa
 		printf("input:  : %2Iu chars \"%S\"\n", wcslen(pwsz), pwsz);
 		printf("Actual  : %2Iu chars %S\n", wcslen(PartName), PartName);
 	}
+
+Quit:
+    RtlFreeHeap(RtlGetProcessHeap(), 0, NtName.Buffer);
+    RtlReleaseRelativeName(&RelativeName);
 }
 
 // NULL Expected means result is expected to be NULL too.

--- a/modules/rostests/apitests/win32u/ntgdi/NtGdiGetFontResourceInfoInternalW.c
+++ b/modules/rostests/apitests/win32u/ntgdi/NtGdiGetFontResourceInfoInternalW.c
@@ -30,6 +30,7 @@ START_TEST(NtGdiGetFontResourceInfoInternalW)
         &dwBufSize,
         &logfont,
         2);
+    RtlFreeHeap(RtlGetProcessHeap(), 0, NtFileName.Buffer);
 
     ok(bRet != FALSE, "bRet was FALSE.\n");
 

--- a/win32ss/user/ntuser/sysparams.c
+++ b/win32ss/user/ntuser/sysparams.c
@@ -696,7 +696,7 @@ SpiSetWallpaper(PVOID pvParam, FLONG fl)
         ustr.Length = 0;
         if (!W32kDosPathNameToNtPathName(gspv.awcWallpaper, &ustr))
         {
-            ERR("RtlDosPathNameToNtPathName_U failed\n");
+            ERR("W32kDosPathNameToNtPathName failed\n");
             return 0;
         }
 


### PR DESCRIPTION
## Purpose

Fix leaks.

```C
NTSYSAPI
BOOLEAN
NTAPI
RtlDosPathNameToNtPathName_U(
    _In_opt_z_ PCWSTR DosName,
    _Out_ PUNICODE_STRING NtName,
    _Out_opt_ PCWSTR *PartName,
    _Out_opt_ PRTL_RELATIVE_NAME_U RelativeName);
```
- `NtName` should be freed by `RtlFreeHeap(RtlGetProcessHeap(), 0, NtName.Buffer)` or `RtlFreeUnicodeString(&NtName)`, the former is used more often and I also recommend it.
- `RelativeName` should be freed by `RtlReleaseRelativeName(RelativeName)`.

I once fixed this for `FindFirstFileExW` in [#5592](https://github.com/reactos/reactos/pull/5592), but I found these leaks elsewhere, so I grepped all `RtlDosPathNameToNtPathName_U` occurrences, review and fix leak if exists in this PR.

JIRA issue: None

## Proposed changes

- Fix leaks
- `dll/win32/fmifs/query.c` is converted to utf-8.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: