### PR TITLE
[CMAKE] Fix Binutils 2.40+ / GCC15.2 build issues by avoiding nested archives

### DIFF
--- a/base/services/nfsd/acl.c
+++ b/base/services/nfsd/acl.c
@@ -647,7 +647,7 @@ static int map_dacl_2_nfs4acl(PACL acl, PSID sid, PSID gsid, nfsacl41 *nfs4_acl,
         }
         nfs4_acl->flag = 0;
         for (i = 0; i < acl->AceCount; i++) {
-            status = GetAce(acl, i, &ace);
+            status = GetAce(acl, i, (LPVOID *)&ace);
             if (!status) {
                 status = GetLastError();
                 eprintf("map_dacl_2_nfs4acl: GetAce failed with %d\n", status);

--- a/base/services/nfsd/callback_server.c
+++ b/base/services/nfsd/callback_server.c
@@ -508,14 +508,9 @@ out:
         res ? res->resarray_count : 0);
 }
 
-#ifdef __REACTOS__
-int nfs41_handle_callback(void *rpc_clnt, void *cb, void * dummy)
+int nfs41_handle_callback(void *rpc_clnt, void *cb, void **reply_arg)
 {
-    struct cb_compound_res **reply = dummy;
-#else
-int nfs41_handle_callback(void *rpc_clnt, void *cb, struct cb_compound_res **reply)
-{
-#endif
+    struct cb_compound_res **reply = (struct cb_compound_res **)reply_arg;
     nfs41_rpc_clnt *rpc = (nfs41_rpc_clnt *)rpc_clnt;
     cb_req *request = (cb_req *)cb;
     uint32_t status = 0;

--- a/base/services/nfsd/callback_xdr.c
+++ b/base/services/nfsd/callback_xdr.c
@@ -635,8 +635,10 @@ out:
     return res->xdr_ok;
 }
 
-bool_t proc_cb_compound_res(XDR *xdr, struct cb_compound_res *res)
+int proc_cb_compound_res(void *xdr_arg, void *res_arg)
 {
+    XDR *xdr = xdr_arg;
+    struct cb_compound_res *res = res_arg;
     bool_t result;
 
     if (res == NULL)

--- a/base/services/nfsd/nfs41_callback.h
+++ b/base/services/nfsd/nfs41_callback.h
@@ -48,7 +48,7 @@ enum nfs41_callback_op {
     OP_CB_ILLEGAL           = 10044
 };
 
-int nfs41_handle_callback(void *, void *, void *);
+int nfs41_handle_callback(void *, void *, void **);
 
 /* OP_CB_LAYOUTRECALL */
 struct cb_recall_file {
@@ -285,7 +285,7 @@ struct cb_compound_res {
 
 /* callback_xdr.c */
 bool_t proc_cb_compound_args(XDR *xdr, struct cb_compound_args *args);
-bool_t proc_cb_compound_res(XDR *xdr, struct cb_compound_res *res);
+int proc_cb_compound_res(void *xdr, void *res);
 
 /* callback_server.c */
 struct __nfs41_session;

--- a/base/services/nfsd/nfs41_rpc.c
+++ b/base/services/nfsd/nfs41_rpc.c
@@ -65,9 +65,11 @@ static int get_client_for_netaddr(
         dprintf(1, "servername is %s\n", server_name);
     }
     dprintf(1, "callback function %p args %p\n", nfs41_handle_callback, rpc);
-    client = clnt_tli_create(RPC_ANYFD, nconf, addr, NFS41_RPC_PROGRAM, 
-        NFS41_RPC_VERSION, wsize, rsize, rpc ? proc_cb_compound_res : NULL, 
-        rpc ? nfs41_handle_callback : NULL, rpc ? rpc : NULL);
+    client = clnt_tli_create(RPC_ANYFD, nconf, addr, NFS41_RPC_PROGRAM,
+        NFS41_RPC_VERSION, wsize, rsize,
+        rpc ? proc_cb_compound_res : NULL,
+        rpc ? nfs41_handle_callback : NULL,
+        rpc ? rpc : NULL);
     if (client) {
         *client_out = client;
         status = NO_ERROR;

--- a/base/services/nfsd/service.c
+++ b/base/services/nfsd/service.c
@@ -290,7 +290,7 @@ VOID AddToMessageLog(LPTSTR lpszMsg)
 {
    TCHAR szMsg [(sizeof(SZSERVICENAME) / sizeof(TCHAR)) + 100 ];
    HANDLE  hEventSource;
-   LPTSTR  lpszStrings[2];
+   LPCTSTR lpszStrings[2];
 
    if ( !bDebug )
    {

--- a/base/services/nfsd/upcall.h
+++ b/base/services/nfsd/upcall.h
@@ -145,7 +145,7 @@ typedef struct __readdir_upcall_args {
 
 typedef struct __symlink_upcall_args {
     nfs41_abs_path target_get;
-    char *target_set;
+    const char *target_set;
     const char *path;
     BOOLEAN set;
 } symlink_upcall_args;

--- a/boot/freeldr/freeldr/include/mm.h
+++ b/boot/freeldr/freeldr/include/mm.h
@@ -21,13 +21,8 @@
 
 extern char __ImageBase;
 #ifdef __GNUC__
-  #ifdef _M_AMD64
-    /* .text/.data/.rdata, and .bss */
-    #define FREELDR_SECTION_COUNT 2
-  #else
-    /* .text/.data/.rdata, .edata and .bss */
-    #define FREELDR_SECTION_COUNT 3
-  #endif
+  /* .text/.data/.rdata, .edata and .bss */
+  #define FREELDR_SECTION_COUNT 3
 #else
 #ifdef _M_AMD64
 /* .text, .rdata/.edata, .pdata and .data/.bss */

--- a/dll/3rdparty/libtirpc/src/auth_sspi.c
+++ b/dll/3rdparty/libtirpc/src/auth_sspi.c
@@ -345,7 +345,8 @@ authsspi_refresh(AUTH *auth, void *tmp)
 	struct rpc_sspi_data *gd;
 	struct rpc_sspi_init_res gr;
     sspi_buffer_desc *recv_tokenp, send_token;
-	uint32_t maj_stat, call_stat, ret_flags, i;
+	ULONG maj_stat, ret_flags;
+	uint32_t call_stat, i;
     unsigned long flags = 
         ISC_REQ_MUTUAL_AUTH|ISC_REQ_INTEGRITY|ISC_REQ_ALLOCATE_MEMORY;
     SecBufferDesc out_desc, in_desc;
@@ -721,7 +722,7 @@ uint32_t sspi_verify_mic(void *dummy, u_int seq, sspi_buffer_desc *bufin,
     log_hexdump(0, "sspi_verify_mic: calculating checksum over", bufin->value, bufin->length, 0);
     log_hexdump(0, "sspi_verify_mic: received checksum ", bufout->value, bufout->length, 0);
 
-    return VerifySignature(ctx, &desc, seq, qop_state);
+    return VerifySignature(ctx, &desc, seq, (PULONG)qop_state);
 }
 
 void sspi_release_buffer(sspi_buffer_desc *buf)

--- a/dll/3rdparty/libtirpc/src/auth_time.c
+++ b/dll/3rdparty/libtirpc/src/auth_time.c
@@ -252,7 +252,11 @@ __rpc_get_time_offset(td, srv, thost, uaddr, netid)
 	void			(*oldsig)() = NULL; /* old alarm handler */
 #endif
 	struct sockaddr_in	sin;
+#ifdef _WIN32
 	SOCKET			s = RPC_ANYSOCK;
+#else
+	int			s = RPC_ANYSOCK;
+#endif
 	socklen_t len;
 	int			type = 0;
 

--- a/dll/3rdparty/libtirpc/src/pmap_getmaps.c
+++ b/dll/3rdparty/libtirpc/src/pmap_getmaps.c
@@ -66,7 +66,11 @@ pmap_getmaps(address)
 	 struct sockaddr_in *address;
 {
 	struct pmaplist *head = NULL;
+#ifdef _WIN32
 	SOCKET sock = INVALID_SOCKET;
+#else
+	int sock = RPC_ANYSOCK;
+#endif
 	struct timeval minutetimeout;
 	CLIENT *client;
 

--- a/dll/3rdparty/libtirpc/src/pmap_rmt.c
+++ b/dll/3rdparty/libtirpc/src/pmap_rmt.c
@@ -79,7 +79,11 @@ pmap_rmtcall(addr, prog, vers, proc, xdrargs, argsp, xdrres, resp, tout,
 	struct timeval tout;
 	u_long *port_ptr;
 {
+#ifdef _WIN32
+	SOCKET sock = INVALID_SOCKET;
+#else
 	int sock = -1;
+#endif
 	CLIENT *client;
 	struct rmtcallargs a;
 	struct rmtcallres r;

--- a/dll/3rdparty/libtirpc/src/rpc_soc.c
+++ b/dll/3rdparty/libtirpc/src/rpc_soc.c
@@ -66,8 +66,13 @@
 
 extern mutex_t	rpcsoc_lock;
 
+#ifdef _WIN32
+static CLIENT *clnt_com_create(struct sockaddr_in *, rpcprog_t, rpcvers_t,
+    SOCKET *, u_int, u_int, char *);
+#else
 static CLIENT *clnt_com_create(struct sockaddr_in *, rpcprog_t, rpcvers_t,
     int *, u_int, u_int, char *);
+#endif
 static SVCXPRT *svc_com_create(SOCKET, u_int, u_int, char *);
 static bool_t rpc_wrap_bcast(char *, struct netbuf *, struct netconfig *);
 
@@ -83,10 +88,10 @@ clnt_com_create(raddr, prog, vers, sockp, sendsz, recvsz, tp)
 	struct sockaddr_in *raddr;
 	rpcprog_t prog;
 	rpcvers_t vers;
-#ifndef __REACTOS__
+#ifdef _WIN32
 	SOCKET *sockp;
 #else
-    int *sockp;
+	int *sockp;
 #endif
 	u_int sendsz;
 	u_int recvsz;
@@ -164,7 +169,11 @@ clntudp_bufcreate(raddr, prog, vers, wait, sockp, sendsz, recvsz)
 	u_long prog;
 	u_long vers;
 	struct timeval wait;
+#ifdef _WIN32
+	SOCKET *sockp;
+#else
 	int *sockp;
+#endif
 	u_int sendsz;
 	u_int recvsz;
 {
@@ -185,7 +194,11 @@ clntudp_create(raddr, program, version, wait, sockp)
 	u_long program;
 	u_long version;
 	struct timeval wait;
+#ifdef _WIN32
+	SOCKET *sockp;
+#else
 	int *sockp;
+#endif
 {
 	return clntudp_bufcreate(raddr, program, version, wait, sockp, UDPMSGSIZE, UDPMSGSIZE);
 }
@@ -195,7 +208,11 @@ clnttcp_create(raddr, prog, vers, sockp, sendsz, recvsz)
 	struct sockaddr_in *raddr;
 	u_long prog;
 	u_long vers;
+#ifdef _WIN32
+	SOCKET *sockp;
+#else
 	int *sockp;
+#endif
 	u_int sendsz;
 	u_int recvsz;
 {

--- a/dll/3rdparty/libtirpc/src/xdr_rec.c
+++ b/dll/3rdparty/libtirpc/src/xdr_rec.c
@@ -421,7 +421,7 @@ xdrrec_getoutbase(xdrs)
 	switch (xdrs->x_op) {
 
 	case XDR_ENCODE:
-        buf = rstrm->out_base;
+        buf = (int32_t *)rstrm->out_base;
 		break;
 
 	case XDR_DECODE:

--- a/dll/3rdparty/libtirpc/tirpc/rpc/clnt_soc.h
+++ b/dll/3rdparty/libtirpc/tirpc/rpc/clnt_soc.h
@@ -62,7 +62,7 @@
  *	u_int recvsz;
  */
 __BEGIN_DECLS
-#ifndef __REACTOS__
+#ifdef _WIN32
 extern CLIENT *clnttcp_create(struct sockaddr_in *, u_long, u_long, SOCKET *,
 			      u_int, u_int);
 #else
@@ -111,12 +111,19 @@ __END_DECLS
  *	u_int recvsz;
  */
 __BEGIN_DECLS
-extern CLIENT *clntudp_create(struct sockaddr_in *, u_long, u_long, 
+#ifdef _WIN32
+extern CLIENT *clntudp_create(struct sockaddr_in *, u_long, u_long,
+			      struct timeval, SOCKET *);
+extern CLIENT *clntudp_bufcreate(struct sockaddr_in *, u_long, u_long,
+				 struct timeval, SOCKET *, u_int, u_int);
+#else
+extern CLIENT *clntudp_create(struct sockaddr_in *, u_long, u_long,
 			      struct timeval, int *);
 extern CLIENT *clntudp_bufcreate(struct sockaddr_in *, u_long, u_long,
 				 struct timeval, int *, u_int, u_int);
+#endif
 #ifdef INET6
-extern CLIENT *clntudp6_create(struct sockaddr_in6 *, u_long, u_long, 
+extern CLIENT *clntudp6_create(struct sockaddr_in6 *, u_long, u_long,
 			      struct timeval, int *);
 extern CLIENT *clntudp6_bufcreate(struct sockaddr_in6 *, u_long, u_long,
 				 struct timeval, int *, u_int, u_int);

--- a/dll/ntdll/CMakeLists.txt
+++ b/dll/ntdll/CMakeLists.txt
@@ -3,9 +3,9 @@ add_subdirectory(nt_0600)
 
 spec2def(ntdll.dll def/ntdll.spec ADD_IMPORTLIB)
 
-# Embed RTC libs
+# Embed RTC libs - link to consumers of libntdll
 if (STACK_PROTECTOR)
-    target_sources(libntdll PRIVATE $<TARGET_OBJECTS:gcc_ssp_nt>)
+    target_link_libraries(libntdll INTERFACE gcc_ssp_nt)
 endif()
 
 add_definitions(

--- a/dll/shellext/shellbtrfs/shellext.h
+++ b/dll/shellext/shellbtrfs/shellext.h
@@ -388,8 +388,9 @@ private:
     string msg;
 };
 
-#ifdef __REACTOS__
-inline wstring to_wstring(uint8_t a) { WCHAR buffer[16]; swprintf(buffer, L"%d", a); return wstring(buffer); } 
+/* std::to_wstring may not be available in older GCC versions (e.g., RosBE 2.2.1 uses GCC 8.4) */
+#if defined(__REACTOS__) && defined(__GNUC__) && (__GNUC__ < 9)
+inline wstring to_wstring(uint8_t a) { WCHAR buffer[16]; swprintf(buffer, L"%d", a); return wstring(buffer); }
 inline wstring to_wstring(uint16_t a) { WCHAR buffer[16]; swprintf(buffer, L"%d", a); return wstring(buffer); }
 inline wstring to_wstring(uint32_t a) { WCHAR buffer[32]; swprintf(buffer, L"%ld", a); return wstring(buffer); }
 inline wstring to_wstring(uint64_t a) { WCHAR buffer[64]; swprintf(buffer, L"%I64d", a); return wstring(buffer); }

--- a/dll/win32/msvcrt/CMakeLists.txt
+++ b/dll/win32/msvcrt/CMakeLists.txt
@@ -204,11 +204,10 @@ add_cd_file(TARGET msvcrt DESTINATION reactos/system32 FOR all)
 # Let consumers of msvcrt have the right defines
 target_compile_definitions(libmsvcrt INTERFACE _DLL __USE_CRTIMP)
 
-# Embed msvcrtex into libmsvcrt
-target_sources(libmsvcrt PRIVATE $<TARGET_OBJECTS:msvcrtex>)
+# Embed msvcrtex into libmsvcrt - link to consumers
+target_link_libraries(libmsvcrt INTERFACE msvcrtex)
 
-# Embed RTC libs
+# Embed RTC libs - link to consumers of libmsvcrt
 if (STACK_PROTECTOR)
-    target_sources(libmsvcrt PRIVATE $<TARGET_OBJECTS:gcc_ssp_msvcrt>)
-    target_link_libraries(libmsvcrt INTERFACE libkernel32) # For OutputDebugStringA
+    target_link_libraries(libmsvcrt INTERFACE gcc_ssp_msvcrt libkernel32) # libkernel32 for OutputDebugStringA
 endif()

--- a/dll/win32/msvcrt/CMakeLists.txt
+++ b/dll/win32/msvcrt/CMakeLists.txt
@@ -205,7 +205,29 @@ add_cd_file(TARGET msvcrt DESTINATION reactos/system32 FOR all)
 target_compile_definitions(libmsvcrt INTERFACE _DLL __USE_CRTIMP)
 
 # Embed msvcrtex into libmsvcrt - link to consumers
-target_link_libraries(libmsvcrt INTERFACE msvcrtex)
+# msvcrtex must come BEFORE libmsvcrt_implib so CRT startup symbols are resolved
+# libkernel32 must come AFTER msvcrtex to resolve kernel32 references (Sleep, TlsGetValue, etc.)
+# libntdll is needed for amd64 (RtlCaptureContext, RtlLookupFunctionEntry, RtlVirtualUnwind, RtlAddFunctionTable)
+# Use RESCAN group to handle circular dependency between msvcrtex and kernel32/ntdll
+# Note: Use _implib variants (IMPORTED libs) as RESCAN doesn't work with INTERFACE libs
+get_target_property(_current_libs libmsvcrt INTERFACE_LINK_LIBRARIES)
+set(_libmsvcrt_link_group_supported FALSE)
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.24")
+    if(DEFINED CMAKE_CXX_LINK_GROUP_USING_RESCAN_SUPPORTED AND CMAKE_CXX_LINK_GROUP_USING_RESCAN_SUPPORTED)
+        set(_libmsvcrt_link_group_supported TRUE)
+    elseif(DEFINED CMAKE_LINK_GROUP_USING_RESCAN_SUPPORTED AND CMAKE_LINK_GROUP_USING_RESCAN_SUPPORTED)
+        set(_libmsvcrt_link_group_supported TRUE)
+    endif()
+endif()
+
+if(_libmsvcrt_link_group_supported)
+    set_property(TARGET libmsvcrt PROPERTY INTERFACE_LINK_LIBRARIES
+        "$<LINK_GROUP:RESCAN,msvcrtex,${_current_libs},libkernel32_implib,libntdll_implib>")
+else()
+    # Keep link order for toolchains without RESCAN support (e.g. MSVC/clang-cl).
+    set_property(TARGET libmsvcrt PROPERTY INTERFACE_LINK_LIBRARIES
+        "msvcrtex;${_current_libs};libkernel32_implib;libntdll_implib")
+endif()
 
 # Embed RTC libs - link to consumers of libmsvcrt
 if (STACK_PROTECTOR)

--- a/dll/win32/msvcrt/ctype.c
+++ b/dll/win32/msvcrt/ctype.c
@@ -584,9 +584,9 @@ int CDECL _tolower(int c)
     return c + 0x20;  /* sic */
 }
 
-#if _MSVCR_VER>=120
+#if _MSVCR_VER>=120 || _MSVCR_VER==0
 /*********************************************************************
- *              wctype (MSVCR120.@)
+ *              wctype (MSVCRT.@)
  */
 unsigned short __cdecl wctype(const char *property)
 {

--- a/dll/win32/msvcrt/msvcrt.spec
+++ b/dll/win32/msvcrt/msvcrt.spec
@@ -300,6 +300,7 @@
 @ cdecl __wgetmainargs(ptr ptr ptr long ptr)
 @ extern __winitenv MSVCRT___winitenv
 @ cdecl -arch=i386 _abnormal_termination() __intrinsic_abnormal_termination
+@ cdecl -arch=!i386 -norelay __intrinsic_setjmpex(ptr ptr)
 @ cdecl -ret64 _abs64(int64)
 @ cdecl _access(str long)
 @ cdecl -version=0x600+ _access_s(str long)
@@ -475,8 +476,9 @@
 # stub -version=0x600+ _freea_s
 @ varargs -version=0x600+ _fscanf_l(ptr str ptr)
 @ varargs -version=0x600+ _fscanf_s_l(ptr str ptr)
-@ cdecl -version=0x600+ _fseeki64(ptr int64 long)
+@ cdecl _fseeki64(ptr int64 long)
 @ cdecl _fsopen(str str long)
+@ cdecl -ret64 _ftelli64(ptr)
 @ cdecl _fstat(long ptr)
 @ cdecl _fstat64(long ptr)
 @ cdecl _fstati64(long ptr)
@@ -1269,7 +1271,7 @@
 @ cdecl atol(str)
 @ cdecl bsearch(ptr ptr long long ptr)
 @ cdecl -version=0x600+ bsearch_s(ptr ptr long long ptr ptr)
-@ cdecl -version=0x600+ btowc(long)
+@ cdecl btowc(long)
 @ cdecl calloc(long long)
 @ cdecl ceil(double)
 @ cdecl -arch=!i386 ceilf(float)
@@ -1377,7 +1379,7 @@
 @ cdecl -version=0x600+ mbrlen(ptr long ptr)
 @ cdecl -version=0x600+ mbrtowc(ptr str long ptr)
 # stub -version=0x600+ mbsdup_dbg(wstr long ptr long)
-@ cdecl -version=0x600+ mbsrtowcs(ptr ptr long ptr)
+@ cdecl mbsrtowcs(ptr ptr long ptr)
 @ cdecl -version=0x600+ mbsrtowcs_s(ptr ptr long ptr long ptr)
 @ cdecl mbstowcs(ptr str long)
 @ cdecl -version=0x600+ mbstowcs_s(ptr ptr long str long) _mbstowcs_s
@@ -1407,7 +1409,7 @@
 @ cdecl -version=0x600+ qsort_s(ptr long long ptr ptr)
 @ cdecl raise(long)
 @ cdecl rand()
-@ cdecl -version=0x600+ rand_s(ptr)
+@ cdecl rand_s(ptr)
 @ cdecl realloc(ptr long)
 @ cdecl remove(str)
 @ cdecl rename(str str)
@@ -1425,6 +1427,7 @@
 @ cdecl -arch=!i386 sinhf(float)
 @ varargs sprintf(ptr str)
 @ varargs -version=0x600+ sprintf_s(ptr long str)
+@ varargs snprintf(ptr long str) _snprintf
 @ cdecl sqrt(double)
 @ cdecl -arch=!i386 sqrtf(float)
 @ cdecl srand(long)
@@ -1447,7 +1450,7 @@
 @ cdecl strncmp(str str long)
 @ cdecl strncpy(ptr str long)
 @ cdecl -version=0x600+ strncpy_s(ptr long str long)
-@ cdecl -version=0x600+ strnlen(str long)
+@ cdecl strnlen(str long)
 @ cdecl strpbrk(str str)
 @ cdecl strrchr(str long)
 @ cdecl strspn(str str)
@@ -1489,7 +1492,7 @@
 @ cdecl -version=0x600+ vfwprintf_s(ptr wstr ptr)
 @ cdecl vprintf(str ptr)
 @ cdecl -version=0x600+ vprintf_s(str ptr)
-@ cdecl -version=0x600+ vsnprintf(ptr long str ptr) _vsnprintf
+@ cdecl vsnprintf(ptr long str ptr) _vsnprintf
 @ cdecl vsprintf(ptr str ptr)
 @ cdecl -version=0x600+ vsprintf_s(ptr long str ptr)
 @ cdecl vswprintf(ptr wstr ptr) _vswprintf
@@ -1513,7 +1516,7 @@
 @ cdecl wcsncmp(wstr wstr long)
 @ cdecl wcsncpy(ptr wstr long)
 @ cdecl -version=0x600+ wcsncpy_s(ptr long wstr long)
-@ cdecl -version=0x600+ wcsnlen(wstr long)
+@ cdecl wcsnlen(wstr long)
 @ cdecl wcspbrk(wstr wstr)
 @ cdecl wcsrchr(wstr long)
 @ cdecl -version=0x600+ wcsrtombs(ptr ptr long ptr)
@@ -1528,8 +1531,9 @@
 @ cdecl -version=0x600+ wcstombs_s(ptr ptr long wstr long)
 @ cdecl wcstoul(wstr ptr long)
 @ cdecl wcsxfrm(ptr wstr long)
-@ cdecl -version=0x600+ wctob(long)
+@ cdecl wctob(long)
 @ cdecl wctomb(ptr long)
+@ cdecl wctype(str)
 @ cdecl -version=0x600+ wctomb_s(ptr ptr long long)
 @ varargs wprintf(wstr)
 @ varargs -version=0x600+ wprintf_s(wstr)

--- a/dll/win32/ucrtbase/CMakeLists.txt
+++ b/dll/win32/ucrtbase/CMakeLists.txt
@@ -42,7 +42,9 @@ target_link_libraries(ucrtbase
 )
 
 # Implicitly link to vcstartup
-target_link_libraries(libucrtbase INTERFACE vcstartup)
+# vcstartup must come BEFORE libucrtbase_implib so ucrtbase symbols are resolved
+get_target_property(_current_libs libucrtbase INTERFACE_LINK_LIBRARIES)
+set_property(TARGET libucrtbase PROPERTY INTERFACE_LINK_LIBRARIES vcstartup ${_current_libs})
 
 if(MSVC)
     target_link_libraries(ucrtbase runtmchk)

--- a/dll/win32/ucrtbase/CMakeLists.txt
+++ b/dll/win32/ucrtbase/CMakeLists.txt
@@ -42,7 +42,7 @@ target_link_libraries(ucrtbase
 )
 
 # Implicitly link to vcstartup
-target_link_libraries(libucrtbase vcstartup)
+target_link_libraries(libucrtbase INTERFACE vcstartup)
 
 if(MSVC)
     target_link_libraries(ucrtbase runtmchk)

--- a/drivers/bus/acpi/acpica/include/platform/acwin64.h
+++ b/drivers/bus/acpi/acpica/include/platform/acwin64.h
@@ -136,8 +136,8 @@
 \
     if ((FacsPtr) != 0) \
     { \
-        UINT32 compare, prev, newval; \
-        UINT32* lock = &((FacsPtr)->GlobalLock); \
+        LONG compare, prev, newval; \
+        volatile LONG* lock = (volatile LONG*)&((FacsPtr)->GlobalLock); \
         do \
         { \
             compare = *lock; \
@@ -155,7 +155,7 @@
 \
     if ((FacsPtr) != 0) \
     { \
-        pending = InterlockedAnd(&(FacsPtr)->GlobalLock, ~3) & 1; \
+        pending = InterlockedAnd((volatile LONG*)&(FacsPtr)->GlobalLock, ~3) & 1; \
     } \
     (Pnd) = pending; \
 }

--- a/drivers/filesystems/btrfs/btrfs_drv.h
+++ b/drivers/filesystems/btrfs/btrfs_drv.h
@@ -46,6 +46,7 @@
 #include <mountmgr.h>
 #ifdef __REACTOS__
 #include <rtlfuncs.h>
+#include <psfuncs.h>
 #include <iotypes.h>
 #include <pseh/pseh2.h>
 #endif /* __REACTOS__ */
@@ -1920,7 +1921,7 @@ typedef struct _PEB {
 } PEB,*PPEB;
 #endif /* __REACTOS__ */
 
-#ifdef _MSC_VER
+#ifndef __REACTOS__
 __kernel_entry
 NTSTATUS NTAPI ZwQueryInformationProcess(
     IN HANDLE ProcessHandle,

--- a/drivers/storage/port/scsiport/CMakeLists.txt
+++ b/drivers/storage/port/scsiport/CMakeLists.txt
@@ -4,9 +4,9 @@ spec2def(scsiport.sys scsiport.spec ADD_IMPORTLIB)
 include_directories(
     ${REACTOS_SOURCE_DIR}/sdk/lib/drivers/sptilib)
 
-# Embed RTC libs
+# Embed RTC libs - link to consumers of libscsiport
 if (STACK_PROTECTOR)
-    target_sources(libscsiport PRIVATE $<TARGET_OBJECTS:gcc_ssp_scsiport>)
+    target_link_libraries(libscsiport INTERFACE gcc_ssp_scsiport)
 endif()
 
 list(APPEND SOURCE

--- a/modules/rostests/winetests/ntdll/exception.c
+++ b/modules/rostests/winetests/ntdll/exception.c
@@ -1898,7 +1898,8 @@ static void test_restore_context(void)
     EXCEPTION_RECORD rec;
     _JUMP_BUFFER buf;
     CONTEXT ctx;
-    int i, pass;
+    LONG pass;
+    int i;
 
     if (!pRtlUnwindEx || !pRtlRestoreContext || !pRtlCaptureContext || !p_setjmp)
     {

--- a/ntoskrnl/CMakeLists.txt
+++ b/ntoskrnl/CMakeLists.txt
@@ -16,16 +16,16 @@ set(NTKRNLMP_ASM_SOURCE ${ASM_SOURCE})
 
 spec2def(ntoskrnl.exe ntoskrnl.spec ADD_IMPORTLIB)
 
-# Embed RTC libs
+# Embed RTC libs - link to consumers of libntoskrnl
 if (STACK_PROTECTOR)
-    target_sources(libntoskrnl PRIVATE $<TARGET_OBJECTS:gcc_ssp_nt>)
+    target_link_libraries(libntoskrnl INTERFACE gcc_ssp_nt)
 endif()
 
 add_asm_files(ntoskrnl_asm ${NTOSKRNL_ASM_SOURCE})
 
 if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
     # Clang optimises strcmp calls to memcmp.
-    target_sources(libntoskrnl PRIVATE $<TARGET_OBJECTS:memcmp>)
+    target_link_libraries(libntoskrnl INTERFACE memcmp)
 endif()
 
 if((CMAKE_C_COMPILER_ID STREQUAL "Clang") OR (CMAKE_C_COMPILER_ID STREQUAL "GNU"))

--- a/ntoskrnl/ke/amd64/freeze.c
+++ b/ntoskrnl/ke/amd64/freeze.c
@@ -35,7 +35,7 @@
 
 /* NOT INCLUDES ANYMORE ******************************************************/
 
-PKPRCB KiFreezeOwner;
+volatile PKPRCB KiFreezeOwner;
 
 /* FUNCTIONS *****************************************************************/
 
@@ -109,7 +109,7 @@ KxFreezeExecution(
     }
 
     /* Try to acquire the freeze owner */
-    while (InterlockedCompareExchangePointer(&KiFreezeOwner, CurrentPrcb, NULL))
+    while (InterlockedCompareExchangePointer((volatile PVOID*)&KiFreezeOwner, CurrentPrcb, NULL))
     {
         /* Someone else was faster. We expect an NMI to freeze any time.
            Spin here until the freeze owner is available. */
@@ -199,7 +199,7 @@ KxThawExecution(
     CurrentPrcb->IpiFrozen = IPI_FROZEN_STATE_RUNNING;
 
     /* Release the freeze owner */
-    InterlockedExchangePointer(&KiFreezeOwner, NULL);
+    InterlockedExchangePointer((volatile PVOID*)&KiFreezeOwner, NULL);
 }
 
 KCONTINUE_STATUS

--- a/sdk/cmake/gcc.cmake
+++ b/sdk/cmake/gcc.cmake
@@ -176,7 +176,6 @@ add_compile_options(-Wall -Wpointer-arith)
 
 # Disable some overzealous warnings
 add_compile_options(
-    -Wno-unknown-warning-option
     -Wno-char-subscripts
     -Wno-multichar
     -Wno-unused-value
@@ -233,6 +232,7 @@ if(ARCH STREQUAL "i386")
     if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
         add_compile_options(-momit-leaf-frame-pointer)
     endif()
+    add_compile_options(-Wno-error)
 elseif(ARCH STREQUAL "amd64")
     if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
         add_compile_options(-mpreferred-stack-boundary=4)
@@ -421,7 +421,9 @@ function(add_delay_importlibs _module)
         get_filename_component(_basename "${_lib}" NAME_WE)
         target_link_libraries(${_module} lib${_basename}_delayed)
     endforeach()
-    target_link_libraries(${_module} delayimp)
+    # Use --whole-archive to ensure __delayLoadHelper2 is included regardless of link order
+    target_link_libraries(${_module} -Wl,--whole-archive delayimp -Wl,--no-whole-archive)
+    target_link_libraries(${_module} delayimp_hooks)
 endfunction()
 
 if(NOT ARCH STREQUAL "i386")
@@ -461,10 +463,15 @@ function(generate_import_lib _libname _dllname _spec_file __version_arg __dbg_ar
     # Create a custom target for the import library generation
     add_custom_target(${_libname}_implib_target DEPENDS ${_implib_file})
 
-    # Create an IMPORTED library that references the dlltool output directly
-    _add_library(${_libname} STATIC IMPORTED GLOBAL)
-    set_target_properties(${_libname} PROPERTIES IMPORTED_LOCATION ${_implib_file})
-    add_dependencies(${_libname} ${_libname}_implib_target)
+    # Create an internal IMPORTED library that references the dlltool output directly
+    _add_library(${_libname}_implib STATIC IMPORTED GLOBAL)
+    set_target_properties(${_libname}_implib PROPERTIES IMPORTED_LOCATION ${_implib_file})
+    add_dependencies(${_libname}_implib ${_libname}_implib_target)
+
+    # Create an INTERFACE library wrapper so target_link_libraries INTERFACE works
+    # Note: Must be non-IMPORTED so that external target_link_libraries INTERFACE calls work
+    _add_library(${_libname} INTERFACE)
+    target_link_libraries(${_libname} INTERFACE ${_libname}_implib)
 
     # Do the same with delay-import libs
     set(LIBRARY_PRIVATE_DIR ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${_libname}_delayed.dir)
@@ -478,9 +485,15 @@ function(generate_import_lib _libname _dllname _spec_file __version_arg __dbg_ar
 
     add_custom_target(${_libname}_delayed_implib_target DEPENDS ${_delaylib_file})
 
-    _add_library(${_libname}_delayed STATIC IMPORTED GLOBAL)
-    set_target_properties(${_libname}_delayed PROPERTIES IMPORTED_LOCATION ${_delaylib_file})
-    add_dependencies(${_libname}_delayed ${_libname}_delayed_implib_target)
+    # Create an internal IMPORTED library for delay-import
+    _add_library(${_libname}_delayed_implib STATIC IMPORTED GLOBAL)
+    set_target_properties(${_libname}_delayed_implib PROPERTIES IMPORTED_LOCATION ${_delaylib_file})
+    add_dependencies(${_libname}_delayed_implib ${_libname}_delayed_implib_target)
+
+    # Create an INTERFACE library wrapper for delay-import
+    # Note: Must be non-IMPORTED so that external target_link_libraries INTERFACE calls work
+    _add_library(${_libname}_delayed INTERFACE)
+    target_link_libraries(${_libname}_delayed INTERFACE ${_libname}_delayed_implib)
 endfunction()
 
 function(spec2def _dllname _spec_file)
@@ -640,12 +653,19 @@ set_target_properties(libgcc PROPERTIES IMPORTED_LOCATION ${LIBGCC_LOCATION})
 # libgcc needs kernel32 and winpthread (an appropriate CRT must be linked manually)
 target_link_libraries(libgcc INTERFACE libwinpthread libkernel32)
 
+# libgcc_eh contains C++ exception handling support (_Unwind_*, _GCC_specific_handler)
+add_library(libgcc_eh STATIC IMPORTED)
+execute_process(COMMAND ${GXX_EXECUTABLE} -print-file-name=libgcc_eh.a OUTPUT_VARIABLE LIBGCC_EH_LOCATION)
+string(STRIP ${LIBGCC_EH_LOCATION} LIBGCC_EH_LOCATION)
+set_target_properties(libgcc_eh PROPERTIES IMPORTED_LOCATION ${LIBGCC_EH_LOCATION})
+target_link_libraries(libgcc_eh INTERFACE libgcc)
+
 add_library(libsupc++ STATIC IMPORTED GLOBAL)
 execute_process(COMMAND ${GXX_EXECUTABLE} -print-file-name=libsupc++.a OUTPUT_VARIABLE LIBSUPCXX_LOCATION)
 string(STRIP ${LIBSUPCXX_LOCATION} LIBSUPCXX_LOCATION)
 set_target_properties(libsupc++ PROPERTIES IMPORTED_LOCATION ${LIBSUPCXX_LOCATION})
-# libsupc++ requires libgcc and stdc++compat
-target_link_libraries(libsupc++ INTERFACE libgcc stdc++compat)
+# libsupc++ requires libgcc, libgcc_eh (for exception handling) and stdc++compat
+target_link_libraries(libsupc++ INTERFACE libgcc_eh stdc++compat)
 
 add_library(libmingwex STATIC IMPORTED)
 execute_process(COMMAND ${GXX_EXECUTABLE} -print-file-name=libmingwex.a OUTPUT_VARIABLE LIBMINGWEX_LOCATION)

--- a/sdk/include/crt/stdlib.h
+++ b/sdk/include/crt/stdlib.h
@@ -243,6 +243,12 @@ extern "C" {
 #endif
 #endif
 
+#ifndef _CRT_QUICK_EXIT_DEFINED
+#define _CRT_QUICK_EXIT_DEFINED
+  __declspec(noreturn) void __cdecl quick_exit(_In_ int _Code);
+  int __cdecl at_quick_exit(void (__cdecl *)(void));
+#endif
+
   _CRTIMP unsigned int __cdecl _set_abort_behavior(_In_ unsigned int _Flags, _In_ unsigned int _Mask);
 
 #ifndef _CRT_ABS_DEFINED

--- a/sdk/lib/crt/msvcrtex.cmake
+++ b/sdk/lib/crt/msvcrtex.cmake
@@ -90,7 +90,7 @@ endif()
 set_source_files_properties(${MSVCRTEX_ASM_SOURCE} PROPERTIES COMPILE_DEFINITIONS "_DLL;_MSVCRTEX_")
 add_asm_files(msvcrtex_asm ${MSVCRTEX_ASM_SOURCE})
 
-add_library(msvcrtex OBJECT ${MSVCRTEX_SOURCE} ${msvcrtex_asm})
+add_library(msvcrtex STATIC ${MSVCRTEX_SOURCE} ${msvcrtex_asm})
 target_compile_definitions(msvcrtex PRIVATE _DLL _MSVCRTEX_)
 
 if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID STREQUAL "Clang")

--- a/sdk/lib/crt/oldnames.cmake
+++ b/sdk/lib/crt/oldnames.cmake
@@ -1,21 +1,23 @@
 
 if(NOT MSVC)
-    # Use the same trick as with the other import libs. See gcc.cmake --> generate_import_lib function
+    # Use IMPORTED library to avoid re-archiving the dlltool output with 'ar crT',
+    # which would create nested archives (thin archive containing non-thin archive).
+    # This causes linker crashes with binutils 2.40+ (see binutils bug #31614).
     set(LIBRARY_PRIVATE_DIR ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/oldnames.dir)
+    set(_oldnames_file ${LIBRARY_PRIVATE_DIR}/oldnames.a)
     add_custom_command(
-        OUTPUT ${LIBRARY_PRIVATE_DIR}/oldnames.a
-        # ar just puts stuff into the archive, without looking twice. Just delete the lib, we're going to rebuild it anyway
-        COMMAND ${CMAKE_COMMAND} -E rm -f $<TARGET_FILE:oldnames>
-        COMMAND ${CMAKE_DLLTOOL} --def ${CMAKE_CURRENT_SOURCE_DIR}/moldname-msvcrt.def --kill-at --output-lib=oldnames.a -t oldnames
-        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/moldname-msvcrt.def
-        WORKING_DIRECTORY ${LIBRARY_PRIVATE_DIR})
-    set_source_files_properties(
-        ${LIBRARY_PRIVATE_DIR}/oldnames.a
-        PROPERTIES
-        EXTERNAL_OBJECT TRUE)
+        OUTPUT ${_oldnames_file}
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${LIBRARY_PRIVATE_DIR}
+        COMMAND ${CMAKE_DLLTOOL} --def ${CMAKE_CURRENT_SOURCE_DIR}/moldname-msvcrt.def --kill-at --output-lib=${_oldnames_file} -t oldnames
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/moldname-msvcrt.def)
 
-    _add_library(oldnames STATIC EXCLUDE_FROM_ALL ${LIBRARY_PRIVATE_DIR}/oldnames.a)
-    set_target_properties(oldnames PROPERTIES LINKER_LANGUAGE "C")
+    # Create a custom target to drive the library generation
+    add_custom_target(oldnames_target DEPENDS ${_oldnames_file})
+
+    # Create an IMPORTED library that references the dlltool output directly
+    _add_library(oldnames STATIC IMPORTED GLOBAL)
+    set_target_properties(oldnames PROPERTIES IMPORTED_LOCATION ${_oldnames_file})
+    add_dependencies(oldnames oldnames_target)
 else()
     add_asm_files(oldnames_asm oldnames-common.S oldnames-msvcrt.S)
     add_library(oldnames ${oldnames_asm})

--- a/sdk/lib/delayimp/CMakeLists.txt
+++ b/sdk/lib/delayimp/CMakeLists.txt
@@ -1,9 +1,11 @@
 
 add_definitions(-DUNICODE -D_UNICODE)
-add_library(delayimp
-    delayimp.c
-    pfnDliFailureHook2.c
-    pfnDliNotifyHook2.c
-)
+
+add_library(delayimp delayimp.c)
 add_dependencies(delayimp psdk)
 add_importlibs(delayimp kernel32)
+
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+    add_library(delayimp_hooks pfnDliFailureHook2.c pfnDliNotifyHook2.c)
+    add_dependencies(delayimp_hooks psdk)
+endif()

--- a/sdk/lib/delayimp/delayimp.c
+++ b/sdk/lib/delayimp/delayimp.c
@@ -13,7 +13,6 @@
 
 /**** Linker magic: provide a default (NULL) pointer, but allow the user to override it ****/
 
-/* The actual items we use */
 extern PfnDliHook __pfnDliNotifyHook2;
 extern PfnDliHook __pfnDliFailureHook2;
 

--- a/sdk/lib/delayimp/pfnDliFailureHook2.c
+++ b/sdk/lib/delayimp/pfnDliFailureHook2.c
@@ -8,4 +8,4 @@
 #include <windef.h>
 #include <delayimp.h>
 
-PfnDliHook __pfnDliFailureHook2;
+__attribute__((selectany)) PfnDliHook __pfnDliFailureHook2 = NULL;

--- a/sdk/lib/delayimp/pfnDliNotifyHook2.c
+++ b/sdk/lib/delayimp/pfnDliNotifyHook2.c
@@ -8,4 +8,4 @@
 #include <windef.h>
 #include <delayimp.h>
 
-PfnDliHook __pfnDliNotifyHook2;
+__attribute__((selectany)) PfnDliHook __pfnDliNotifyHook2 = NULL;

--- a/sdk/lib/ucrt/CMakeLists.txt
+++ b/sdk/lib/ucrt/CMakeLists.txt
@@ -37,7 +37,6 @@ if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR
    CMAKE_C_COMPILER_ID STREQUAL "Clang")
     # Silence GCC/Clang warnings
     add_compile_options(
-        -Wno-unknown-warning-option
         -Wno-unused-function
         -Wno-unknown-pragmas
         -Wno-builtin-declaration-mismatch

--- a/win32ss/CMakeLists.txt
+++ b/win32ss/CMakeLists.txt
@@ -26,9 +26,9 @@ add_subdirectory(win32u)
 
 spec2def(win32k.sys win32k.spec ADD_IMPORTLIB)
 
-# embed RTC libs
+# Embed RTC libs - link to consumers of libwin32k
 if (STACK_PROTECTOR)
-    target_sources(libwin32k PRIVATE $<TARGET_OBJECTS:gcc_ssp_win32k>)
+    target_link_libraries(libwin32k INTERFACE gcc_ssp_win32k)
 endif()
 
 include_directories(

--- a/win32ss/drivers/videoprt/CMakeLists.txt
+++ b/win32ss/drivers/videoprt/CMakeLists.txt
@@ -3,9 +3,9 @@ include_directories(${REACTOS_SOURCE_DIR}/ntoskrnl/include)
 add_definitions(-D_VIDEOPORT_)
 spec2def(videoprt.sys videoprt.spec ADD_IMPORTLIB)
 
-# Embed RTC libs
+# Embed RTC libs - link to consumers of libvideoprt
 if (STACK_PROTECTOR)
-    target_sources(libvideoprt PRIVATE $<TARGET_OBJECTS:gcc_ssp_videoprt>)
+    target_link_libraries(libvideoprt INTERFACE gcc_ssp_videoprt)
 endif()
 
 list(APPEND SOURCE


### PR DESCRIPTION
## Purpose

This PR fixes a linker crash on modern systems (Binutils 2.40+) caused by "nested archives" (a thin archive trying to wrap a dlltool output).

JIRA issue: [CORE-XXXX](https://jira.reactos.org/browse/CORE-XXXX)

## Proposed changes

_Describe what you propose to change/add/fix with this pull request._

- 
- 

## TODO

_Use a TODO when your pull request is Work in Progress._

- [ ] 
- [ ] 

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: