### PR TITLE
[NTGDI][ENG] Fix gradient offset handling

### DIFF
--- a/win32ss/gdi/eng/gradient.c
+++ b/win32ss/gdi/eng/gradient.c
@@ -72,7 +72,6 @@ IntEngGradientFillRect(
     rcGradient.top = min(v1->y, v2->y);
     rcGradient.bottom = max(v1->y, v2->y);
     rcSG = rcGradient;
-    RECTL_vOffsetRect(&rcSG, pptlDitherOrg->x, pptlDitherOrg->y);
 
     if(Horizontal)
     {

--- a/win32ss/gdi/ntgdi/fillshap.c
+++ b/win32ss/gdi/ntgdi/fillshap.c
@@ -954,7 +954,7 @@ GreGradientFill(
     BOOL bRet;
 
     /* Check parameters */
-    if (ulMode & GRADIENT_FILL_TRIANGLE)
+    if (ulMode == GRADIENT_FILL_TRIANGLE)
     {
         PGRADIENT_TRIANGLE pTriangle = (PGRADIENT_TRIANGLE)pMesh;
 
@@ -1018,6 +1018,18 @@ GreGradientFill(
     {
         DC_UnlockDc(pdc);
         return TRUE;
+    }
+
+    /* Offset vertex for rectangles */
+    if (ulMode == GRADIENT_FILL_RECT_H ||
+        ulMode == GRADIENT_FILL_RECT_V)
+    {
+        for (i = 0; i < nVertex; i++)
+        {
+            IntLPtoDP(pdc, (LPPOINT)&pVertex[i], 1);
+            pVertex[i].x += pdc->ptlDCOrig.x;
+            pVertex[i].y += pdc->ptlDCOrig.y;
+        }
     }
 
     ptlDitherOrg.x = ptlDitherOrg.y = 0;


### PR DESCRIPTION
## Purpose

Fix handling of the gradient coordinates position, to avoid drawing the gradients at the top left corner when `DrvGradientFill()` is supported by display/video miniport driver and is used instead of our `EngGradientFill()` implementation.
This avoids incorrect gradient coordinates passed to `DrvGradientFill()` in case it's supported by the display/video driver, so now gradients are drawing at the correct position as they should.
Hence, this fixes broken gradients in window captions (always painted at the top left corner) on real hardware with native video drivers (AMD/ATI/Intel/Nvidia etc.). Tested successfully on Asus-F5R notebook with ATI Radeon XPress 1100 + ATI Catalyst 10.2 video driver at least.

JIRA issue: [CORE-14927](https://jira.reactos.org/browse/CORE-14927), [CORE-15341](https://jira.reactos.org/browse/CORE-15341)

## Proposed changes

[NTGDI]
- Offset vertex array to the current DC's coordinates for rectangular gradients. Don't change anything for triangular gradients. This is more correct regarding to how Windows XP/2003 handles that and debugging analysis shows the same behaviour there.
- Additionally, fix checking mode condition for triangles on parameters validation. It should actually be checked for an equalness, not via bitwise "OR", since only one mode type can be set for ulMode parameter for GradientFill() according to MSDN.

[ENG]
- Fix behaviour of `EngGradientFill()` for rectangles: don't offset the rectangle's top left point to the current dithering point, since it's already done now in Gre part of the function. This fixes broken gradient captions when Drv implementation is not provided by display/video driver and Eng function is used instead.

## TODO

- [x] Fix small regression with Areas "Gradient Fill" test app if possible. Cc @Doug-Lyons for triangle gradients stuff, since he worked on it in the recent past. Hoping for your help. See last 2 screenshots at the bottom. Thanks.
- [x] Test this with more native video drivers. I currently have no any other working test hardware besides mentioned notebook, so cc'ing @DarkFire01 for this too. Does this work better/worse for more/less/all testcases for you than my previous #8552 PR? Thanks.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64:

## Result

Window caption gradients:
Before:
<img width="1280" height="800" alt="1-gradient-before" src="https://github.com/user-attachments/assets/779d8ced-7612-40bb-9771-b231be1d32d4" />

After:
<img width="1280" height="800" alt="2-gradient-after" src="https://github.com/user-attachments/assets/2eaa1edb-9b3d-47d9-9d38-1822dc262666" />

Simple `GradientFill()`/`FillRect()` test from CodeProject:
Before:
<img width="1280" height="800" alt="1-gradient-test-before" src="https://github.com/user-attachments/assets/dcc54bdd-0bad-4db6-a59e-4f2a056509d7" />

After:
<img width="1280" height="800" alt="2-gradient-test-after" src="https://github.com/user-attachments/assets/0eb575bf-f7ec-4cfa-a69d-3ab07e2d22b9" />

Areas "Gradient Fill" test:
Before:
<img width="1280" height="800" alt="1-areas-test-before" src="https://github.com/user-attachments/assets/54b257da-de7c-4712-b462-9ae72577e596" />

After:
<img width="1280" height="800" alt="2-areas-test-after-2" src="https://github.com/user-attachments/assets/2ead6506-6190-4c2d-ba90-837bf2ba01bf" />

As it's visible, the last test has regressed a bit. However I noticed that 1st and 3rd gradient rectangles are drawing better after my changes. Asking Doug for the help.

UPDATE: after the latest improvements, the behaviour of the last test is fixed. Looks even better than before. :smiley: Only two small squares have a bit wrong position now. And in the same time, caption gradients still have correct coordinates.
<img width="1280" height="800" alt="7-improved-areas-test-best" src="https://github.com/user-attachments/assets/ef8b2b6e-376c-43f2-bba3-893c7a8380e5" />

Windows XP SP3 (for comparison):
<img width="1152" height="864" alt="VirtualBox_Windows XP_09_01_2026_22_34_03" src="https://github.com/user-attachments/assets/a4c7078b-0c1f-4152-8e25-7a7d7a734ae7" />
