### PR TITLE
[KDBG][SDK] Switch GCC builds to DWARF‑only symbols, harden loader, and fix amd64 lookup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -348,12 +348,10 @@ Enable this if the module uses typeid or dynamic_cast. You will probably need to
 
     if(ARCH MATCHES "64$")
         include(sdk/cmake/baseaddress64.cmake)
-    elseif(NO_ROSSYM)
-        include(sdk/cmake/baseaddress_dwarf.cmake)
     elseif(MSVC)
         include(sdk/cmake/baseaddress_msvc.cmake)
     else()
-        include(sdk/cmake/baseaddress.cmake)
+        include(sdk/cmake/baseaddress_dwarf.cmake)
     endif()
 
     # For MSVC builds, this puts all debug symbols file in the same directory.

--- a/ntoskrnl/kdbg/kdb_symbols.c
+++ b/ntoskrnl/kdbg/kdb_symbols.c
@@ -27,12 +27,120 @@ typedef struct _IMAGE_SYMBOL_INFO_CACHE
 }
 IMAGE_SYMBOL_INFO_CACHE, *PIMAGE_SYMBOL_INFO_CACHE;
 
+#define KDB_SYM_TAG 'bSyK'
+
+typedef struct _KDB_SYMBOL_WORK_ITEM
+{
+    LIST_ENTRY ListEntry;
+    UNICODE_STRING BaseDllName;
+    UNICODE_STRING FullDllName;
+    PVOID DllBase;
+    ULONG SizeOfImage;
+}
+KDB_SYMBOL_WORK_ITEM, *PKDB_SYMBOL_WORK_ITEM;
+
 static BOOLEAN LoadSymbols = FALSE;
 static LIST_ENTRY SymbolsToLoad;
 static KSPIN_LOCK SymbolsToLoadLock;
 static KEVENT SymbolsToLoadEvent;
 
 /* FUNCTIONS ****************************************************************/
+
+static
+BOOLEAN
+KdbpSymDuplicateUnicodeString(
+    _In_ PUNICODE_STRING Source,
+    _Out_ PUNICODE_STRING Destination)
+{
+    Destination->Length = 0;
+    Destination->MaximumLength = 0;
+    Destination->Buffer = NULL;
+
+    if (!Source || !Source->Length)
+        return TRUE;
+
+    Destination->MaximumLength = Source->Length + sizeof(WCHAR);
+    Destination->Buffer = ExAllocatePoolWithTag(NonPagedPool,
+                                                Destination->MaximumLength,
+                                                KDB_SYM_TAG);
+    if (!Destination->Buffer)
+        return FALSE;
+
+    RtlCopyMemory(Destination->Buffer, Source->Buffer, Source->Length);
+    Destination->Buffer[Source->Length / sizeof(WCHAR)] = UNICODE_NULL;
+    Destination->Length = Source->Length;
+    return TRUE;
+}
+
+static
+VOID
+KdbpSymFreeUnicodeString(
+    _Inout_ PUNICODE_STRING String)
+{
+    if (String->Buffer)
+    {
+        ExFreePoolWithTag(String->Buffer, KDB_SYM_TAG);
+        RtlZeroMemory(String, sizeof(*String));
+    }
+}
+
+static
+VOID
+KdbpSymFreeWorkItem(
+    _Inout_ PKDB_SYMBOL_WORK_ITEM WorkItem)
+{
+    if (!WorkItem)
+        return;
+
+    KdbpSymFreeUnicodeString(&WorkItem->BaseDllName);
+    KdbpSymFreeUnicodeString(&WorkItem->FullDllName);
+    ExFreePoolWithTag(WorkItem, KDB_SYM_TAG);
+}
+
+static
+BOOLEAN
+KdbpSymStoreSymbolInfo(
+    _In_ PUNICODE_STRING BaseDllName,
+    _In_opt_ PUNICODE_STRING FullDllName,
+    _In_ PVOID DllBase,
+    _In_ ULONG SizeOfImage,
+    _In_ PROSSYM_INFO RosSymInfo)
+{
+    PLIST_ENTRY CurrentEntry;
+    PLDR_DATA_TABLE_ENTRY LdrEntry;
+    KIRQL OldIrql;
+    BOOLEAN Stored = FALSE;
+
+    if (!BaseDllName || !BaseDllName->Length)
+        return FALSE;
+
+    KeAcquireSpinLock(&PsLoadedModuleSpinLock, &OldIrql);
+
+    CurrentEntry = PsLoadedModuleList.Flink;
+    while (CurrentEntry != &PsLoadedModuleList)
+    {
+        LdrEntry = CONTAINING_RECORD(CurrentEntry, LDR_DATA_TABLE_ENTRY, InLoadOrderLinks);
+
+        if ((!(FullDllName && FullDllName->Length) ||
+             RtlEqualUnicodeString(&LdrEntry->FullDllName, FullDllName, TRUE)) &&
+            RtlEqualUnicodeString(&LdrEntry->BaseDllName, BaseDllName, TRUE) &&
+            LdrEntry->DllBase == DllBase &&
+            LdrEntry->SizeOfImage == SizeOfImage)
+        {
+            if (!LdrEntry->PatchInformation)
+            {
+                LdrEntry->PatchInformation = RosSymInfo;
+                Stored = TRUE;
+            }
+            break;
+        }
+
+        CurrentEntry = CurrentEntry->Flink;
+    }
+
+    KeReleaseSpinLock(&PsLoadedModuleSpinLock, OldIrql);
+    return Stored;
+}
 
 static
 BOOLEAN
@@ -109,6 +217,39 @@ KdbpSymFindModule(
                                    pLdrEntry);
 }
 
+/*! \brief Find symbol info by module name
+ *
+ * \param ModName   Pointer to a UNICODE_STRING containing the module name.
+ *
+ * \retval PROSSYM_INFO    Symbol info for the module, or NULL if not found.
+ */
+PROSSYM_INFO
+KdbpSymFindCachedFile(
+    IN PUNICODE_STRING ModName)
+{
+    PLIST_ENTRY CurrentEntry;
+    PLDR_DATA_TABLE_ENTRY LdrEntry;
+
+    KeAcquireSpinLockAtDpcLevel(&PsLoadedModuleSpinLock);
+
+    CurrentEntry = PsLoadedModuleList.Flink;
+    while (CurrentEntry != &PsLoadedModuleList)
+    {
+        LdrEntry = CONTAINING_RECORD(CurrentEntry, LDR_DATA_TABLE_ENTRY, InLoadOrderLinks);
+
+        if (RtlEqualUnicodeString(&LdrEntry->BaseDllName, ModName, TRUE))
+        {
+            KeReleaseSpinLockFromDpcLevel(&PsLoadedModuleSpinLock);
+            return (PROSSYM_INFO)LdrEntry->PatchInformation;
+        }
+
+        CurrentEntry = CurrentEntry->Flink;
+    }
+
+    KeReleaseSpinLockFromDpcLevel(&PsLoadedModuleSpinLock);
+    return NULL;
+}
+
 static
 PCHAR
 NTAPI
@@ -133,6 +274,8 @@ KdbpSymUnicodeToAnsi(IN PUNICODE_STRING Unicode,
     *p = ANSI_NULL;
     return Ansi;
 }
+
+static volatile LONG KdbSymLookupInProgress = 0;
 
 /*! \brief Print address...
  *
@@ -164,23 +307,69 @@ KdbSymPrintAddress(
                         ModuleNameAnsi,
                         sizeof(ModuleNameAnsi));
 
-    if (LdrEntry->PatchInformation)
+    if (LdrEntry->PatchInformation &&
+        InterlockedCompareExchange(&KdbSymLookupInProgress, 1, 0) == 0)
     {
+#ifdef __ROS_DWARF__
+        ROSSYM_LINEINFO LineInfo = { 0 };
+
+        _SEH2_TRY
+        {
+            if (RosSymGetAddressInformation(LdrEntry->PatchInformation,
+                                            RelativeAddress,
+                                            &LineInfo))
+            {
+                if (LineInfo.DirectoryName && LineInfo.DirectoryName[0])
+                {
+                    KdbPrintf("<%s:%x (%s/%s:%d (%s))>",
+                              ModuleNameAnsi, RelativeAddress,
+                              LineInfo.DirectoryName,
+                              LineInfo.FileName ? LineInfo.FileName : "",
+                              LineInfo.LineNumber,
+                              LineInfo.FunctionName ? LineInfo.FunctionName : "");
+                }
+                else
+                {
+                    KdbPrintf("<%s:%x (%s:%d (%s))>",
+                              ModuleNameAnsi, RelativeAddress,
+                              LineInfo.FileName ? LineInfo.FileName : "",
+                              LineInfo.LineNumber,
+                              LineInfo.FunctionName ? LineInfo.FunctionName : "");
+                }
+                Printed = TRUE;
+                RosSymFreeInfo(&LineInfo);
+            }
+        }
+        _SEH2_FINALLY
+        {
+            InterlockedExchange(&KdbSymLookupInProgress, 0);
+        }
+        _SEH2_END;
+#else
         ULONG LineNumber;
         CHAR FileName[256];
         CHAR FunctionName[256];
 
-        if (RosSymGetAddressInformation(LdrEntry->PatchInformation,
-                                        RelativeAddress,
-                                        &LineNumber,
-                                        FileName,
-                                        FunctionName))
+        _SEH2_TRY
         {
-            KdbPrintf("<%s:%x (%s:%d (%s))>",
-                      ModuleNameAnsi, RelativeAddress,
-                      FileName, LineNumber, FunctionName);
-            Printed = TRUE;
+            if (RosSymGetAddressInformation(LdrEntry->PatchInformation,
+                                            RelativeAddress,
+                                            &LineNumber,
+                                            FileName,
+                                            FunctionName))
+            {
+                KdbPrintf("<%s:%x (%s:%d (%s))>",
+                          ModuleNameAnsi, RelativeAddress,
+                          FileName, LineNumber, FunctionName);
+                Printed = TRUE;
+            }
         }
+        _SEH2_FINALLY
+        {
+            InterlockedExchange(&KdbSymLookupInProgress, 0);
+        }
+        _SEH2_END;
+#endif
     }
 
     if (!Printed)
@@ -216,26 +405,32 @@ LoadSymbolsRoutine(
         NTSTATUS Status = KeWaitForSingleObject(&SymbolsToLoadEvent, WrKernel, KernelMode, FALSE, NULL);
         if (!NT_SUCCESS(Status))
         {
-            DPRINT1("KeWaitForSingleObject failed?! 0x%08x\n", Status);
+            DPRINT("KeWaitForSingleObject failed: 0x%08x\n", Status);
             LoadSymbols = FALSE;
             return;
         }
 
         while ((ListEntry = ExInterlockedRemoveHeadList(&SymbolsToLoad, &SymbolsToLoadLock)))
         {
-            PLDR_DATA_TABLE_ENTRY LdrEntry = CONTAINING_RECORD(ListEntry, LDR_DATA_TABLE_ENTRY, InInitializationOrderLinks);
+            PKDB_SYMBOL_WORK_ITEM WorkItem = CONTAINING_RECORD(ListEntry, KDB_SYMBOL_WORK_ITEM, ListEntry);
+            PROSSYM_INFO RosSymInfo = NULL;
             HANDLE FileHandle;
             OBJECT_ATTRIBUTES Attrib;
             IO_STATUS_BLOCK Iosb;
-            InitializeObjectAttributes(&Attrib, &LdrEntry->FullDllName, OBJ_CASE_INSENSITIVE | OBJ_KERNEL_HANDLE, NULL, NULL);
-            DPRINT1("Trying %wZ\n", &LdrEntry->FullDllName);
-            Status = ZwOpenFile(&FileHandle,
-                                FILE_READ_ACCESS | SYNCHRONIZE,
-                                &Attrib,
-                                &Iosb,
-                                FILE_SHARE_READ,
-                                FILE_SYNCHRONOUS_IO_NONALERT);
-            if (!NT_SUCCESS(Status))
+
+            Status = STATUS_UNSUCCESSFUL;
+            if (WorkItem->FullDllName.Length)
+            {
+                InitializeObjectAttributes(&Attrib, &WorkItem->FullDllName, OBJ_CASE_INSENSITIVE | OBJ_KERNEL_HANDLE, NULL, NULL);
+                Status = ZwOpenFile(&FileHandle,
+                                    FILE_READ_ACCESS | SYNCHRONIZE,
+                                    &Attrib,
+                                    &Iosb,
+                                    FILE_SHARE_READ,
+                                    FILE_SYNCHRONOUS_IO_NONALERT);
+            }
+
+            if (!NT_SUCCESS(Status) && WorkItem->BaseDllName.Length)
             {
                 /* Try system paths */
                 static const UNICODE_STRING System32Dir = RTL_CONSTANT_STRING(L"\\SystemRoot\\system32\\");
@@ -243,9 +438,8 @@ LoadSymbolsRoutine(
                 WCHAR ImagePathBuffer[256];
                 RtlInitEmptyUnicodeString(&ImagePath, ImagePathBuffer, sizeof(ImagePathBuffer));
                 RtlCopyUnicodeString(&ImagePath, &System32Dir);
-                RtlAppendUnicodeStringToString(&ImagePath, &LdrEntry->BaseDllName);
+                RtlAppendUnicodeStringToString(&ImagePath, &WorkItem->BaseDllName);
                 InitializeObjectAttributes(&Attrib, &ImagePath, OBJ_CASE_INSENSITIVE | OBJ_KERNEL_HANDLE, NULL, NULL);
-                DPRINT1("Trying %wZ\n", &ImagePath);
                 Status = ZwOpenFile(&FileHandle,
                                     FILE_READ_ACCESS | SYNCHRONIZE,
                                     &Attrib,
@@ -258,9 +452,8 @@ LoadSymbolsRoutine(
 
                     RtlInitEmptyUnicodeString(&ImagePath, ImagePathBuffer, sizeof(ImagePathBuffer));
                     RtlCopyUnicodeString(&ImagePath, &DriversDir);
-                    RtlAppendUnicodeStringToString(&ImagePath, &LdrEntry->BaseDllName);
+                    RtlAppendUnicodeStringToString(&ImagePath, &WorkItem->BaseDllName);
                     InitializeObjectAttributes(&Attrib, &ImagePath, OBJ_CASE_INSENSITIVE | OBJ_KERNEL_HANDLE, NULL, NULL);
-                    DPRINT1("Trying %wZ\n", &ImagePath);
                     Status = ZwOpenFile(&FileHandle,
                                         FILE_READ_ACCESS | SYNCHRONIZE,
                                         &Attrib,
@@ -272,19 +465,36 @@ LoadSymbolsRoutine(
 
             if (!NT_SUCCESS(Status))
             {
-                DPRINT1("Failed opening file %wZ (%wZ) for reading symbols (0x%08x)\n", &LdrEntry->FullDllName, &LdrEntry->BaseDllName, Status);
-                /* We took a ref previously */
-                MmUnloadSystemImage(LdrEntry);
+                DPRINT("Failed opening file %wZ (%wZ) for symbols (0x%08x)\n",
+                       &WorkItem->FullDllName,
+                       &WorkItem->BaseDllName,
+                       Status);
+                KdbpSymFreeWorkItem(WorkItem);
                 continue;
             }
 
             /* Hand it to Rossym */
-            if (!RosSymCreateFromFile(&FileHandle, (PROSSYM_INFO*)&LdrEntry->PatchInformation))
-                LdrEntry->PatchInformation = NULL;
+            if (!RosSymCreateFromFile(&FileHandle, &RosSymInfo))
+                RosSymInfo = NULL;
 
             /* We're done for this one. */
             NtClose(FileHandle);
-            MmUnloadSystemImage(LdrEntry);
+
+            /* Attach only if the original module is still loaded and matches. */
+            if (RosSymInfo &&
+                KdbpSymStoreSymbolInfo(&WorkItem->BaseDllName,
+                                       &WorkItem->FullDllName,
+                                       WorkItem->DllBase,
+                                       WorkItem->SizeOfImage,
+                                       RosSymInfo))
+            {
+                RosSymInfo = NULL;
+            }
+
+            if (RosSymInfo)
+                RosSymDelete(RosSymInfo);
+
+            KdbpSymFreeWorkItem(WorkItem);
         }
     }
 }
@@ -313,17 +523,42 @@ KdbSymProcessSymbols(
         return;
     }
 
-    if (RosSymCreateFromMem(LdrEntry->DllBase, LdrEntry->SizeOfImage, (PROSSYM_INFO*)&LdrEntry->PatchInformation))
+    /*
+     * For DWARF-based builds, RosSymCreateFromMem allocates memory and does
+     * operations that require PASSIVE_LEVEL. Only try inline loading if we're
+     * at PASSIVE_LEVEL, otherwise always defer to the worker thread.
+     */
+    if (KeGetCurrentIrql() == PASSIVE_LEVEL &&
+        RosSymCreateFromMem(LdrEntry->DllBase, LdrEntry->SizeOfImage, (PROSSYM_INFO*)&LdrEntry->PatchInformation))
     {
         return;
     }
 
-    /* Add a ref until we really process it */
-    LdrEntry->LoadCount++;
-
     /* Tell our worker thread to read from it */
+    PKDB_SYMBOL_WORK_ITEM WorkItem = ExAllocatePoolWithTag(NonPagedPool,
+                                                           sizeof(*WorkItem),
+                                                           KDB_SYM_TAG);
+    if (!WorkItem)
+        return;
+
+    RtlZeroMemory(WorkItem, sizeof(*WorkItem));
+    /*
+     * Copy the names so the worker doesn't dereference a potentially
+     * unloaded LDR entry; we re-lookup under the module list lock before
+     * attaching symbols, so unloadable drivers are not pinned.
+     */
+    if (!KdbpSymDuplicateUnicodeString(&LdrEntry->BaseDllName, &WorkItem->BaseDllName) ||
+        !KdbpSymDuplicateUnicodeString(&LdrEntry->FullDllName, &WorkItem->FullDllName))
+    {
+        KdbpSymFreeWorkItem(WorkItem);
+        return;
+    }
+
+    WorkItem->DllBase = LdrEntry->DllBase;
+    WorkItem->SizeOfImage = LdrEntry->SizeOfImage;
+
     KeAcquireSpinLockAtDpcLevel(&SymbolsToLoadLock);
-    InsertTailList(&SymbolsToLoad, &LdrEntry->InInitializationOrderLinks);
+    InsertTailList(&SymbolsToLoad, &WorkItem->ListEntry);
     KeReleaseSpinLockFromDpcLevel(&SymbolsToLoadLock);
 
     KeSetEvent(&SymbolsToLoadEvent, IO_NO_INCREMENT, FALSE);
@@ -349,16 +584,20 @@ KdbSymInit(
 
     DPRINT("KdbSymInit() BootPhase=%d\n", BootPhase);
 
+#ifdef SEPARATE_DBG
+    DPRINT("KDBG symbols disabled for SEPARATE_DBG builds\n");
+    LoadSymbols = FALSE;
+    return FALSE;
+#endif
+
     if (BootPhase == 0)
     {
         PSTR CommandLine;
         SHORT Found = FALSE;
         CHAR YesNo;
 
-        /* By default, load symbols in DBG builds, but not in REL builds
-           or anything other than x86, because they only work on x86
-           and can cause the system to hang on x64. */
-#if DBG && defined(_M_IX86)
+        /* By default, load symbols in DBG builds on supported architectures */
+#if DBG && (defined(_M_IX86) || defined(_M_AMD64))
         LoadSymbols = TRUE;
 #else
         LoadSymbols = FALSE;
@@ -443,24 +682,66 @@ KdbSymInit(
                                       NULL);
         if (!NT_SUCCESS(Status))
         {
-            DPRINT1("Failed starting symbols loader thread: 0x%08x\n", Status);
+            DPRINT("Failed starting symbols loader thread: 0x%08x\n", Status);
             LoadSymbols = FALSE;
             return LoadSymbols;
         }
 
         RosSymInitKernelMode();
 
-        KeAcquireSpinLock(&PsLoadedModuleSpinLock, &OldIrql);
-
-        for (ListEntry = PsLoadedModuleList.Flink;
-             ListEntry != &PsLoadedModuleList;
-             ListEntry = ListEntry->Flink)
+        /*
+         * For DWARF symbols, we need to process modules at PASSIVE_LEVEL.
+         * Collect all boot modules first while holding the spinlock,
+         * then process them after releasing it.
+         */
         {
-            PLDR_DATA_TABLE_ENTRY LdrEntry = CONTAINING_RECORD(ListEntry, LDR_DATA_TABLE_ENTRY, InLoadOrderLinks);
-            KdbSymProcessSymbols(LdrEntry, TRUE);
-        }
+            PLDR_DATA_TABLE_ENTRY *ModuleArray;
+            ULONG ModuleCount = 0, i;
 
-        KeReleaseSpinLock(&PsLoadedModuleSpinLock, OldIrql);
+            /* Count modules */
+            KeAcquireSpinLock(&PsLoadedModuleSpinLock, &OldIrql);
+            for (ListEntry = PsLoadedModuleList.Flink;
+                 ListEntry != &PsLoadedModuleList;
+                 ListEntry = ListEntry->Flink)
+            {
+                ModuleCount++;
+            }
+            KeReleaseSpinLock(&PsLoadedModuleSpinLock, OldIrql);
+
+            if (ModuleCount == 0)
+                return LoadSymbols;
+
+            /* Allocate array for module pointers */
+            ModuleArray = ExAllocatePoolWithTag(NonPagedPool,
+                                                ModuleCount * sizeof(PLDR_DATA_TABLE_ENTRY),
+                                                'mySK');
+            if (!ModuleArray)
+            {
+                DPRINT("Failed to allocate module array\n");
+                return LoadSymbols;
+            }
+
+            /* Collect module pointers */
+            KeAcquireSpinLock(&PsLoadedModuleSpinLock, &OldIrql);
+            i = 0;
+            for (ListEntry = PsLoadedModuleList.Flink;
+                 ListEntry != &PsLoadedModuleList && i < ModuleCount;
+                 ListEntry = ListEntry->Flink)
+            {
+                PLDR_DATA_TABLE_ENTRY LdrEntry = CONTAINING_RECORD(ListEntry, LDR_DATA_TABLE_ENTRY, InLoadOrderLinks);
+                ModuleArray[i++] = LdrEntry;
+            }
+            ModuleCount = i;
+            KeReleaseSpinLock(&PsLoadedModuleSpinLock, OldIrql);
+
+            /* Now process at PASSIVE_LEVEL */
+            for (i = 0; i < ModuleCount; i++)
+            {
+                KdbSymProcessSymbols(ModuleArray[i], TRUE);
+            }
+
+            ExFreePoolWithTag(ModuleArray, 'mySK');
+        }
     }
 
     return LoadSymbols;

--- a/sdk/include/reactos/rossym.h
+++ b/sdk/include/reactos/rossym.h
@@ -84,6 +84,7 @@ typedef struct _ROSSYM_LINEINFO {
   ROSSYM_LINEINFO_FLAGS Flags;
   ULONG LineNumber;
   char *FileName;
+  char *DirectoryName;
   char *FunctionName;
   ROSSYM_REGISTERS Registers;
   ULONG NumParams;
@@ -128,9 +129,7 @@ typedef struct _ROSSYM_INFO {
 #endif
 
 VOID RosSymInit(PROSSYM_CALLBACKS Callbacks);
-#ifndef __ROS_DWARF__
 VOID RosSymInitKernelMode(VOID);
-#endif
 VOID RosSymInitUserMode(VOID);
 
 BOOLEAN RosSymCreateFromRaw(PVOID RawData, ULONG_PTR DataSize,
@@ -164,4 +163,3 @@ VOID RosSymFreeAggregate(PROSSYM_AGGREGATE Aggregate);
 #endif /* REACTOS_ROSSYM_H_INCLUDED */
 
 /* EOF */
-

--- a/sdk/lib/CMakeLists.txt
+++ b/sdk/lib/CMakeLists.txt
@@ -42,7 +42,7 @@ add_subdirectory(poguid)
 add_subdirectory(pseh)
 
 if(KDBG)
-    add_subdirectory(rossym)
+    add_subdirectory(rossym_new)
 endif()
 
 add_subdirectory(rtl)

--- a/sdk/lib/rossym_new/CMakeLists.txt
+++ b/sdk/lib/rossym_new/CMakeLists.txt
@@ -1,5 +1,6 @@
 
 add_definitions(-D_NTSYSTEM_)
+
 list(APPEND SOURCE
     delete.c
     dwarfabbrev.c
@@ -12,10 +13,15 @@ list(APPEND SOURCE
     dwarfpubnames.c
     find.c
     fromfile.c
+    frommem.c
     init.c
-    initum.c
+    initkm.c
+    iofile.c
     pe.c
-    zwfile.c)
+    zwfile.c
+    precomp.h)
+
 add_library(rossym ${SOURCE})
-add_pch(rossym precomp.h)
+add_pch(rossym precomp.h SOURCE)
 add_dependencies(rossym psdk bugcodes)
+target_compile_definitions(rossym PUBLIC __ROS_DWARF__ __ROS_ROSSYM__)

--- a/sdk/lib/rossym_new/compat.h
+++ b/sdk/lib/rossym_new/compat.h
@@ -32,7 +32,9 @@ RtlRaiseStatus(IN NTSTATUS Status);
         RtlRaiseStatus(STATUS_ASSERTION_FAILURE); \
     } \
     } while (0)
+#ifndef offsetof
 #define offsetof(x,y) FIELD_OFFSET(x,y)
+#endif
 #define nil (0)
 
 #define nelem(arr) (sizeof((arr)[0]) / sizeof((arr)))
@@ -44,19 +46,20 @@ void *RosSymAllocMemZero(ulong num, ulong size);
 void *RosSymRealloc(void *mem, ulong newsize);
 void xfree(void *v);
 
-#define werrstr(str, ...) DPRINT(str "\n" ,##__VA_ARGS__)
-#if 0
-#ifdef NDEBUG
-#define werrstr(x, ...)
+/*
+ * werrstr is disabled in kernel mode because rossym may be called from
+ * inside the kernel debugger, which holds KdpDebuggerLock. Calling DbgPrint
+ * would try to reacquire the lock causing SPIN_LOCK_ALREADY_OWNED.
+ */
+#ifdef _NTSYSTEM_
+#define werrstr(x, ...) ((void)0)
 #else
 #define werrstr(x, ...) printf("(%s:%d) " x "\n",__FILE__,__LINE__,##__VA_ARGS__)
-#endif
 #endif
 
 #define malloc(x) RosSymAllocMem(x)
 #define mallocz(x,y) RosSymAllocMemZero(x,y)
 #define free(x) xfree(x)
 #define USED(x) (*((char *)&(x)) ^= 0)
-#define memset(x,y,z) RtlZeroMemory(x,z)
 
 #endif/*_LIBMACH_COMPAT_H_*/

--- a/sdk/lib/rossym_new/dwarf.h
+++ b/sdk/lib/rossym_new/dwarf.h
@@ -210,9 +210,10 @@ struct DwarfParam
 	char *name;
 	ulong unit;
 	ulong type;
-    ulong loctype;
-	ulong fde, len;
-    ulong value;
+	ulong loctype;
+	ULONG_PTR fde;
+	ulong len;
+	ULONG_PTR value;
 };
 
 /* not for consumer use */
@@ -227,8 +228,8 @@ struct DwarfBuf
 union DwarfVal
 {
 	char *s;
-	ulong c;
-	ulong r;
+	ULONG_PTR c;
+	ULONG_PTR r;
 	DwarfBlock b;
 };
 
@@ -302,66 +303,66 @@ struct DwarfAttrs
 		uchar	vtableelemloc;
 	} have;
 
-	ulong	abstractorigin;
-	ulong	accessibility;
-	ulong	addrclass;
-	ulong	basetypes;
-	ulong	bitoffset;
-	ulong	bitsize;
-	ulong	bytesize;
-	ulong	calling;
-	ulong	commonref;
+	ULONG_PTR	abstractorigin;
+	ULONG_PTR	accessibility;
+	ULONG_PTR	addrclass;
+	ULONG_PTR	basetypes;
+	ULONG_PTR	bitoffset;
+	ULONG_PTR	bitsize;
+	ULONG_PTR	bytesize;
+	ULONG_PTR	calling;
+	ULONG_PTR	commonref;
 	char*	compdir;
 	DwarfVal	constvalue;
-	ulong	containingtype;
-	ulong	count;
+	ULONG_PTR	containingtype;
+	ULONG_PTR	count;
 	DwarfVal	datamemberloc;
-	ulong	declcolumn;
-	ulong	declfile;
-	ulong	declline;
-	ulong	defaultvalue;
-	ulong	discr;
+	ULONG_PTR	declcolumn;
+	ULONG_PTR	declfile;
+	ULONG_PTR	declline;
+	ULONG_PTR	defaultvalue;
+	ULONG_PTR	discr;
 	DwarfBlock	discrlist;
-	ulong	discrvalue;
-	ulong	encoding;
+	ULONG_PTR	discrvalue;
+	ULONG_PTR	encoding;
 	DwarfVal	framebase;
-	ulong	friend;
-	ulong	highpc;
-	ulong   entrypc;
-	ulong	identifiercase;
-	ulong	import;
-	ulong	inlined;
+	ULONG_PTR	friend;
+	ULONG_PTR	highpc;
+	ULONG_PTR   entrypc;
+	ULONG_PTR	identifiercase;
+	ULONG_PTR	import;
+	ULONG_PTR	inlined;
 	uchar	isartificial;
 	uchar	isdeclaration;
 	uchar	isexternal;
 	uchar	isoptional;
 	uchar	isprototyped;
 	uchar	isvarparam;
-	ulong	language;
+	ULONG_PTR	language;
 	DwarfVal	location;
-	ulong	lowerbound;
-	ulong	lowpc;
-	ulong	macroinfo;
+	ULONG_PTR	lowerbound;
+	ULONG_PTR	lowpc;
+	ULONG_PTR	macroinfo;
 	char*	name;
 	DwarfBlock	namelistitem;
-	ulong	ordering;
-	ulong	priority;
+	ULONG_PTR	ordering;
+	ULONG_PTR	priority;
 	char*	producer;
-	ulong	ranges;
+	ULONG_PTR	ranges;
 	DwarfVal	returnaddr;
 	DwarfVal	segment;
-	ulong	sibling;
-	ulong	specification;
-	ulong	startscope;
+	ULONG_PTR	sibling;
+	ULONG_PTR	specification;
+	ULONG_PTR	startscope;
 	DwarfVal	staticlink;
-	ulong	stmtlist;
-	ulong	stridesize;
+	ULONG_PTR	stmtlist;
+	ULONG_PTR	stridesize;
 	DwarfVal	stringlength;
-	ulong	type;
-	ulong	upperbound;
+	ULONG_PTR	type;
+	ULONG_PTR	upperbound;
 	DwarfVal	uselocation;
-	ulong	virtuality;
-	ulong	visibility;
+	ULONG_PTR	virtuality;
+	ULONG_PTR	visibility;
 	DwarfVal	vtableelemloc;
 };
 
@@ -377,7 +378,7 @@ enum
 struct DwarfExpr
 {
 	int type;
-	long offset;
+	LONG_PTR offset;
 	ulong reg;
 	DwarfBlock loc;
 };
@@ -397,8 +398,8 @@ struct DwarfSym
 struct _Pe;
 Dwarf *dwarfopen(struct _Pe *elf);
 void dwarfclose(Dwarf*);
-int dwarfaddrtounit(Dwarf*, ulong, ulong*);
-int dwarflookupfn(Dwarf*, ulong, ulong, DwarfSym*);
+int dwarfaddrtounit(Dwarf*, ULONG_PTR, ulong*);
+int dwarflookupfn(Dwarf*, ulong, ULONG_PTR, DwarfSym*);
 int dwarflookupname(Dwarf*, char*, DwarfSym*);
 int dwarflookupnameinunit(Dwarf*, ulong, char*, DwarfSym*);
 int dwarflookupsubname(Dwarf*, DwarfSym*, char*, DwarfSym*);
@@ -408,24 +409,24 @@ int dwarfseeksym(Dwarf*, ulong, ulong, DwarfSym*);
 int dwarfenum(Dwarf*, DwarfSym*);
 int dwarfnextsym(Dwarf*, DwarfSym*);
 int dwarfnextsymat(Dwarf*, DwarfSym *parent, DwarfSym *child);
-int dwarfpctoline(Dwarf*, DwarfSym *proc, ulong, char**, char**, ulong *);
-int dwarfgetarg(Dwarf *d, const char *name, DwarfBuf *locbuf, ulong cfa, PROSSYM_REGISTERS registers, ulong *value);
+int dwarfpctoline(Dwarf*, DwarfSym *proc, ULONG_PTR, char**, char**, char**, ULONG *);
+int dwarfgetarg(Dwarf *d, const char *name, DwarfBuf *locbuf, ULONG_PTR cfa, PROSSYM_REGISTERS registers, ULONG_PTR *value);
 int dwarfgettype(Dwarf *d, DwarfSym *param, DwarfSym *type);
 
 ulong dwarfget1(DwarfBuf*);
 ulong dwarfget2(DwarfBuf*);
 ulong dwarfget4(DwarfBuf*);
 uvlong dwarfget8(DwarfBuf*);
-ulong dwarfget128(DwarfBuf*);
-long dwarfget128s(DwarfBuf*);
-ulong dwarfgetaddr(DwarfBuf*);
+ULONG_PTR dwarfget128(DwarfBuf*);
+LONG_PTR dwarfget128s(DwarfBuf*);
+ULONG_PTR dwarfgetaddr(DwarfBuf*);
 int dwarfgetn(DwarfBuf*, uchar*, int);
 uchar *dwarfgetnref(DwarfBuf*, ulong);
 char *dwarfgetstring(DwarfBuf*);
-int dwarfcomputecfa(Dwarf *d, DwarfExpr *cfa, PROSSYM_REGISTERS registers, ulong *cfaLocation);
-int dwarfregunwind(Dwarf *d, ulong pc, ulong fde, DwarfExpr *cfa, PROSSYM_REGISTERS registers);
-int dwarfargvalue(Dwarf *d, DwarfSym *proc, ulong pc, ulong cfa, PROSSYM_REGISTERS registers, DwarfParam *parameters);
-int dwarfgetparams(Dwarf *d, DwarfSym *s, ulong pc, int pnum, DwarfParam *paramblocks);
+int dwarfcomputecfa(Dwarf *d, DwarfExpr *cfa, PROSSYM_REGISTERS registers, ULONG_PTR *cfaLocation);
+int dwarfregunwind(Dwarf *d, ULONG_PTR pc, ULONG_PTR fde, DwarfExpr *cfa, PROSSYM_REGISTERS registers);
+int dwarfargvalue(Dwarf *d, DwarfSym *proc, ULONG_PTR pc, ULONG_PTR cfa, PROSSYM_REGISTERS registers, DwarfParam *parameters);
+int dwarfgetparams(Dwarf *d, DwarfSym *s, ULONG_PTR pc, int pnum, DwarfParam *paramblocks);
 
 typedef struct DwarfAbbrev DwarfAbbrev;
 typedef struct DwarfAttr DwarfAttr;
@@ -470,19 +471,23 @@ struct Dwarf
 		DwarfAbbrev *a;
 		int na;
 		ulong off;
+		DwarfAbbrev *buf;
+		DwarfAttr *attrbuf;
+		int maxa;
+		int maxattr;
 	} acache;
 };
 
 struct DwarfStack
 {
-    ulong storage[16]; // own storage
-    ulong *data;
-    ulong length, max;
+    ULONG_PTR storage[16]; // own storage
+    ULONG_PTR *data;
+    ULONG length, max;
 };
 
 DwarfAbbrev *dwarfgetabbrev(Dwarf*, ulong, ulong);
+int dwarfpreallocabbrev(Dwarf*);
 
 int dwarfgetinfounit(Dwarf*, ulong, DwarfBlock*);
-void dwarfdumpsym(Dwarf *d, DwarfSym *s);
 
 #define MAXIMUM_DWARF_NAME_SIZE 64

--- a/sdk/lib/rossym_new/dwarfaranges.c
+++ b/sdk/lib/rossym_new/dwarfaranges.c
@@ -8,11 +8,12 @@
 #include <debug.h>
 
 int
-dwarfaddrtounit(Dwarf *d, ulong addr, ulong *unit)
+dwarfaddrtounit(Dwarf *d, ULONG_PTR addr, ulong *unit)
 {
     DwarfBuf b;
     int segsize, i;
-    ulong len, id, off, base, size;
+    ulong len, id, off;
+    ULONG_PTR base, size;
     uchar *start, *end;
 
     memset(&b, 0, sizeof b);
@@ -58,6 +59,6 @@ dwarfaddrtounit(Dwarf *d, ulong addr, ulong *unit)
             goto underflow;
         b.p = end;
     }
-    werrstr("address 0x%lux is not listed in dwarf debugging symbols", addr);
+    werrstr("address %p is not listed in dwarf debugging symbols", (PVOID)addr);
     return -1;
 }

--- a/sdk/lib/rossym_new/frommem.c
+++ b/sdk/lib/rossym_new/frommem.c
@@ -19,13 +19,16 @@
 #include "dwarf.h"
 #include "pe.h"
 
+#define SYMBOL_SIZE 18
+
 BOOLEAN
 RosSymCreateFromMem(PVOID ImageStart, ULONG_PTR ImageSize, PROSSYM_INFO *RosSymInfo)
 {
-	ANSI_STRING AnsiNameString = { };
+	ANSI_STRING PendingName = { };
 	PIMAGE_DOS_HEADER DosHeader;
 	PIMAGE_NT_HEADERS NtHeaders;
-	PIMAGE_SECTION_HEADER SectionHeaders;
+	PIMAGE_SECTION_HEADER OrigSectionHeaders;
+	PeSect *SectionHeaders;
 	ULONG SectionIndex;
 	unsigned SymbolTable, NumSymbols;
 
@@ -34,7 +37,6 @@ RosSymCreateFromMem(PVOID ImageStart, ULONG_PTR ImageSize, PROSSYM_INFO *RosSymI
 	if (ImageSize < sizeof(IMAGE_DOS_HEADER)
 		|| ! ROSSYM_IS_VALID_DOS_HEADER(DosHeader))
     {
-		DPRINT1("Image doesn't have a valid DOS header\n");
 		return FALSE;
     }
 
@@ -43,111 +45,167 @@ RosSymCreateFromMem(PVOID ImageStart, ULONG_PTR ImageSize, PROSSYM_INFO *RosSymI
 	if (ImageSize < DosHeader->e_lfanew + sizeof(IMAGE_NT_HEADERS)
 		|| ! ROSSYM_IS_VALID_NT_HEADERS(NtHeaders))
     {
-		DPRINT1("Image doesn't have a valid PE header\n");
 		return FALSE;
     }
 
 	SymbolTable = NtHeaders->FileHeader.PointerToSymbolTable;
 	NumSymbols = NtHeaders->FileHeader.NumberOfSymbols;
 
-	/* Search for the section header */
-	ULONG SectionHeaderSize = NtHeaders->FileHeader.NumberOfSections * sizeof(IMAGE_SECTION_HEADER);
-	SectionHeaders = RosSymAllocMem(SectionHeaderSize);
-	RtlCopyMemory(SectionHeaders, IMAGE_FIRST_SECTION(NtHeaders), SectionHeaderSize);
+	/* Allocate PeSect array (extended section headers with name strings) */
+	OrigSectionHeaders = IMAGE_FIRST_SECTION(NtHeaders);
+	SectionHeaders = RosSymAllocMem(NtHeaders->FileHeader.NumberOfSections * sizeof(PeSect));
+	if (!SectionHeaders)
+		return FALSE;
+	RtlZeroMemory(SectionHeaders, NtHeaders->FileHeader.NumberOfSections * sizeof(PeSect));
 
-	// Convert names to ANSI_STRINGs
+	/* Copy section headers and convert names to ANSI_STRINGs */
 	for (SectionIndex = 0; SectionIndex < NtHeaders->FileHeader.NumberOfSections;
 		 SectionIndex++)
 	{
-		if (SectionHeaders[SectionIndex].Name[0] != '/') {
-			AnsiNameString.Buffer = RosSymAllocMem(IMAGE_SIZEOF_SHORT_NAME);
-			RtlCopyMemory(AnsiNameString.Buffer, SectionHeaders[SectionIndex].Name, IMAGE_SIZEOF_SHORT_NAME);
-			AnsiNameString.MaximumLength = IMAGE_SIZEOF_SHORT_NAME;
-			AnsiNameString.Length = GetStrnlen(AnsiNameString.Buffer, IMAGE_SIZEOF_SHORT_NAME);
+		PendingName.Buffer = NULL;
+		PendingName.Length = 0;
+		PendingName.MaximumLength = 0;
+
+		RtlCopyMemory(&SectionHeaders[SectionIndex].hdr,
+		              &OrigSectionHeaders[SectionIndex],
+		              sizeof(IMAGE_SECTION_HEADER));
+
+		if (OrigSectionHeaders[SectionIndex].Name[0] != '/') {
+			PendingName.Buffer = RosSymAllocMem(IMAGE_SIZEOF_SHORT_NAME);
+			if (!PendingName.Buffer) goto freeall;
+			RtlCopyMemory(PendingName.Buffer, OrigSectionHeaders[SectionIndex].Name, IMAGE_SIZEOF_SHORT_NAME);
+			PendingName.MaximumLength = IMAGE_SIZEOF_SHORT_NAME;
+			PendingName.Length = GetStrnlen(PendingName.Buffer, IMAGE_SIZEOF_SHORT_NAME);
 		} else {
+			/*
+			 * Long section name - the name is stored as "/NNN" where NNN is an offset
+			 * into the COFF string table. The string table is NOT mapped in memory,
+			 * so we need to look up the actual name from within the image.
+			 */
 			UNICODE_STRING intConv;
 			NTSTATUS Status;
 			ULONG StringOffset;
+			ULONG VirtualOffset = 0;
+			PCHAR ResolvedName = NULL;
 
-			if (!RtlCreateUnicodeStringFromAsciiz(&intConv, (PCSZ)SectionHeaders[SectionIndex].Name + 1))
-				goto freeall;
-			Status = RtlUnicodeStringToInteger(&intConv, 10, &StringOffset);
-			RtlFreeUnicodeString(&intConv);
-			if (!NT_SUCCESS(Status)) goto freeall;
-			ULONG VirtualOffset = pefindrva(SectionHeaders, NtHeaders->FileHeader.NumberOfSections, SymbolTable+(NumSymbols*SYMBOL_SIZE)+StringOffset);
-			if (!VirtualOffset) goto freeall;
-			AnsiNameString.Buffer = RosSymAllocMem(MAXIMUM_DWARF_NAME_SIZE);
-			if (!AnsiNameString.Buffer) goto freeall;
-			PCHAR StringTarget = ((PCHAR)ImageStart)+VirtualOffset;
-			PCHAR EndOfImage = ((PCHAR)ImageStart) + NtHeaders->OptionalHeader.SizeOfImage;
-			if (StringTarget >= EndOfImage) goto freeall;
-			ULONG PossibleStringLength = EndOfImage - StringTarget;
-			if (PossibleStringLength > MAXIMUM_DWARF_NAME_SIZE)
-				PossibleStringLength = MAXIMUM_DWARF_NAME_SIZE;
-			RtlCopyMemory(AnsiNameString.Buffer, StringTarget, PossibleStringLength);
-			AnsiNameString.Length = strlen(AnsiNameString.Buffer);
-			AnsiNameString.MaximumLength = MAXIMUM_DWARF_NAME_SIZE;
+			if (RtlCreateUnicodeStringFromAsciiz(&intConv, (PCSZ)OrigSectionHeaders[SectionIndex].Name + 1)) {
+				Status = RtlUnicodeStringToInteger(&intConv, 10, &StringOffset);
+				RtlFreeUnicodeString(&intConv);
+				if (NT_SUCCESS(Status)) {
+					/*
+					 * Use a simple linear search through original section headers.
+					 * We can't use pefindrva here because the SectionHeaders array
+					 * isn't fully initialized yet.
+					 */
+					ULONG TargetPhysical = SymbolTable + (NumSymbols * SYMBOL_SIZE) + StringOffset;
+					for (ULONG k = 0; k < NtHeaders->FileHeader.NumberOfSections; k++) {
+						if (TargetPhysical >= OrigSectionHeaders[k].PointerToRawData &&
+							TargetPhysical < OrigSectionHeaders[k].PointerToRawData + OrigSectionHeaders[k].SizeOfRawData) {
+							VirtualOffset = TargetPhysical - OrigSectionHeaders[k].PointerToRawData + OrigSectionHeaders[k].VirtualAddress;
+							break;
+						}
+					}
+
+					/* If we couldn't find it in mapped sections, try using the section characteristics
+					 * to identify DWARF sections by their typical attributes */
+					if (!VirtualOffset) {
+						ULONG chars = OrigSectionHeaders[SectionIndex].Characteristics;
+						/* DWARF sections have IMAGE_SCN_CNT_INITIALIZED_DATA (0x40) and
+						 * IMAGE_SCN_MEM_DISCARDABLE (0x02000000) or IMAGE_SCN_MEM_READ (0x40000000) */
+						if ((chars & 0x40) && (chars & 0x42000000)) {
+							/* Try to identify by order - DWARF sections typically come after .reloc */
+							static const char* DwarfNames[] = {
+								".debug_aranges", ".debug_info", ".debug_abbrev", ".debug_line",
+								".debug_frame", ".debug_str", ".debug_loc", ".debug_ranges", ".debug_pubnames"
+							};
+							/* Find the first DWARF section index by looking for the first section
+							 * with debug characteristics after all regular sections */
+							ULONG FirstDebugSection = 0;
+							for (ULONG k = 0; k < NtHeaders->FileHeader.NumberOfSections; k++) {
+								ULONG kchars = OrigSectionHeaders[k].Characteristics;
+								/* Section with long name and debug-like characteristics */
+								if ((OrigSectionHeaders[k].Name[0] == '/') &&
+									(kchars & 0x40) && (kchars & 0x42000000)) {
+									FirstDebugSection = k;
+									break;
+								}
+							}
+							if (FirstDebugSection && SectionIndex >= FirstDebugSection) {
+								ULONG DebugIndex = SectionIndex - FirstDebugSection;
+								if (DebugIndex < sizeof(DwarfNames)/sizeof(DwarfNames[0])) {
+									ResolvedName = (PCHAR)DwarfNames[DebugIndex];
+								}
+							}
+						}
+					}
+				}
+			}
+
+			if (ResolvedName) {
+				/* Use the resolved DWARF section name */
+				PendingName.Length = strlen(ResolvedName);
+				PendingName.MaximumLength = PendingName.Length + 1;
+				PendingName.Buffer = RosSymAllocMem(PendingName.MaximumLength);
+				if (!PendingName.Buffer) goto freeall;
+				RtlCopyMemory(PendingName.Buffer, ResolvedName, PendingName.MaximumLength);
+			} else if (VirtualOffset) {
+				PendingName.Buffer = RosSymAllocMem(MAXIMUM_DWARF_NAME_SIZE);
+				if (!PendingName.Buffer) goto freeall;
+				PCHAR StringTarget = ((PCHAR)ImageStart)+VirtualOffset;
+				PCHAR EndOfImage = ((PCHAR)ImageStart) + NtHeaders->OptionalHeader.SizeOfImage;
+				if (StringTarget < EndOfImage) {
+					ULONG PossibleStringLength = EndOfImage - StringTarget;
+					if (PossibleStringLength > MAXIMUM_DWARF_NAME_SIZE)
+						PossibleStringLength = MAXIMUM_DWARF_NAME_SIZE;
+					RtlCopyMemory(PendingName.Buffer, StringTarget, PossibleStringLength);
+					PendingName.Length = GetStrnlen(PendingName.Buffer, PossibleStringLength);
+					PendingName.MaximumLength = MAXIMUM_DWARF_NAME_SIZE;
+				} else {
+					/* Can't resolve - use raw offset form */
+					RosSymFreeMem(PendingName.Buffer);
+					PendingName.Buffer = RosSymAllocMem(IMAGE_SIZEOF_SHORT_NAME);
+					if (!PendingName.Buffer) goto freeall;
+					RtlCopyMemory(PendingName.Buffer, OrigSectionHeaders[SectionIndex].Name, IMAGE_SIZEOF_SHORT_NAME);
+					PendingName.MaximumLength = IMAGE_SIZEOF_SHORT_NAME;
+					PendingName.Length = GetStrnlen(PendingName.Buffer, IMAGE_SIZEOF_SHORT_NAME);
+				}
+			} else {
+				/* String table not in memory - use raw name bytes */
+				PendingName.Buffer = RosSymAllocMem(IMAGE_SIZEOF_SHORT_NAME);
+				if (!PendingName.Buffer) goto freeall;
+				RtlCopyMemory(PendingName.Buffer, OrigSectionHeaders[SectionIndex].Name, IMAGE_SIZEOF_SHORT_NAME);
+				PendingName.MaximumLength = IMAGE_SIZEOF_SHORT_NAME;
+				PendingName.Length = GetStrnlen(PendingName.Buffer, IMAGE_SIZEOF_SHORT_NAME);
+			}
 		}
-		memcpy
-			(&SectionHeaders[SectionIndex],
-			 &AnsiNameString,
-			 sizeof(AnsiNameString));
+		*ANSI_NAME_STRING(&SectionHeaders[SectionIndex]) = PendingName;
+		PendingName.Buffer = NULL;
 	}
 
 	Pe *pe = RosSymAllocMem(sizeof(*pe));
+	if (!pe) goto freeall;
 	pe->fd = ImageStart;
 	pe->e2 = peget2;
 	pe->e4 = peget4;
 	pe->e8 = peget8;
-	pe->loadbase = (ULONG)ImageStart;
+	pe->loadbase = (ULONG_PTR)ImageStart;
 	pe->imagebase = NtHeaders->OptionalHeader.ImageBase;
 	pe->imagesize = NtHeaders->OptionalHeader.SizeOfImage;
+	pe->codestart = NtHeaders->OptionalHeader.BaseOfCode;
+#ifdef _WIN64
+	pe->datastart = 0;
+#else
+	pe->datastart = NtHeaders->OptionalHeader.BaseOfData;
+#endif
 	pe->nsections = NtHeaders->FileHeader.NumberOfSections;
 	pe->sect = SectionHeaders;
-	pe->nsymbols = NtHeaders->FileHeader.NumberOfSymbols;
-	pe->symtab = malloc(pe->nsymbols * sizeof(CoffSymbol));
-	PSYMENT SymbolData = (PSYMENT)
-		(((PCHAR)ImageStart) +
-		 pefindrva
-		 (pe->sect,
-		  pe->nsections,
-		  NtHeaders->FileHeader.PointerToSymbolTable));
-	int i, j;
-	for (i = 0, j = 0; i < pe->nsymbols; i++) {
-		if ((SymbolData[i].e_scnum < 1) ||
-			(SymbolData[i].e_sclass != C_EXT &&
-			 SymbolData[i].e_sclass != C_STAT))
-			continue;
-		int section = SymbolData[i].e_scnum - 1;
-		if (SymbolData[i].e.e.e_zeroes) {
-			pe->symtab[j].name = malloc(sizeof(SymbolData[i].e.e_name)+1);
-			strcpy(pe->symtab[j].name, SymbolData[i].e.e_name);
-		} else {
-			PCHAR SymbolName = ((PCHAR)ImageStart) +
-				pefindrva
-				(pe->sect,
-				 pe->nsections,
-				 NtHeaders->FileHeader.PointerToSymbolTable +
-				 (NtHeaders->FileHeader.NumberOfSymbols * 18) +
-				 SymbolData[i].e.e.e_offset);
-			pe->symtab[j].name = malloc(strlen(SymbolName)+1);
-			strcpy(pe->symtab[j].name, SymbolName);
-		}
-		if (pe->symtab[j].name[0] == '.') {
-			free(pe->symtab[j].name);
-			continue;
-		}
-		pe->symtab[j].address = pe->sect[section].VirtualAddress + SymbolData[i].e_value;
-		j++;
-	}
-	pe->nsymbols = j;
 	pe->loadsection = loadmemsection;
 	*RosSymInfo = dwarfopen(pe);
 
 	return !!*RosSymInfo;
 
 freeall:
-	if (AnsiNameString.Buffer) RosSymFreeMem(AnsiNameString.Buffer);
+	if (PendingName.Buffer) RosSymFreeMem(PendingName.Buffer);
 	for (SectionIndex = 0; SectionIndex < NtHeaders->FileHeader.NumberOfSections;
 		 SectionIndex++)
 		RtlFreeAnsiString(ANSI_NAME_STRING(&SectionHeaders[SectionIndex]));

--- a/sdk/lib/rossym_new/initkm.c
+++ b/sdk/lib/rossym_new/initkm.c
@@ -38,8 +38,8 @@ RosSymInitKernelMode(VOID)
     {
       RosSymAllocMemKM,
       RosSymFreeMemKM,
-      RosSymIoReadFile,
-      RosSymIoSeekFile
+      RosSymZwReadFile,
+      RosSymZwSeekFile
     };
 
   RosSymInit(&KmCallbacks);

--- a/sdk/lib/rossym_new/initum.c
+++ b/sdk/lib/rossym_new/initum.c
@@ -7,18 +7,22 @@
  * PROGRAMMERS:     Ge van Geldorp (gvg@reactos.com)
  */
 
-#include <precomp.h>
+#include <stdarg.h>
+#include <windef.h>
+#include <winbase.h>
+#include <reactos/rossym.h>
+#include "rossympriv.h"
 
 static PVOID
 RosSymAllocMemUM(ULONG_PTR Size)
 {
-  return RtlAllocateHeap(RtlGetProcessHeap(), 0, Size);
+  return HeapAlloc(GetProcessHeap(), 0, Size);
 }
 
 static VOID
 RosSymFreeMemUM(PVOID Area)
 {
-  RtlFreeHeap(RtlGetProcessHeap(), 0, Area);
+  HeapFree(GetProcessHeap(), 0, Area);
 }
 
 static BOOLEAN
@@ -30,16 +34,16 @@ RosSymGetMemUM(PVOID FileContext, ULONG_PTR *Target, PVOID SourceMem, ULONG Size
 VOID
 RosSymInitUserMode(VOID)
 {
-  static ROSSYM_CALLBACKS KmCallbacks =
+  static ROSSYM_CALLBACKS UmCallbacks =
     {
       RosSymAllocMemUM,
       RosSymFreeMemUM,
       RosSymZwReadFile,
       RosSymZwSeekFile,
-	  RosSymGetMemUM
+      RosSymGetMemUM
     };
 
-  RosSymInit(&KmCallbacks);
+  RosSymInit(&UmCallbacks);
 }
 
 /* EOF */

--- a/sdk/lib/rossym_new/pe.h
+++ b/sdk/lib/rossym_new/pe.h
@@ -4,29 +4,39 @@
 #include "compat.h"
 
 struct DwarfBlock;
-typedef struct _IMAGE_SECTION_HEADER PeSect;
+
+/*
+ * Extended section header structure for 64-bit compatibility.
+ * On 32-bit, ANSI_STRING fits in 8 bytes, but on 64-bit it needs 16 bytes
+ * due to pointer alignment. We use a separate field for the name string.
+ */
+typedef struct _PeSect {
+    struct _IMAGE_SECTION_HEADER hdr;
+    ANSI_STRING name_str;
+} PeSect;
 
 typedef struct _Pe {
 	void *fd;
 	u16int (*e2)(const unsigned char *data);
 	u32int (*e4)(const unsigned char *data);
 	u64int (*e8)(const unsigned char *data);
-	ulong imagebase, imagesize, loadbase;
-    ulong codestart, datastart;
+	ULONG_PTR imagebase, imagesize, loadbase;
+	ULONG_PTR codestart, datastart;
 	int (*loadsection)(struct _Pe *pe, char *name, struct DwarfBlock *b);
 	int nsections;
-	struct _IMAGE_SECTION_HEADER *sect;
+	PeSect *sect;
 } Pe;
 
 Pe *peopen(const char *name);
 int loaddisksection(struct _Pe *pe, char *name, struct DwarfBlock *b);
+int loadmemsection(struct _Pe *pe, char *name, struct DwarfBlock *b);
 u16int peget2(const unsigned char *ptr);
 u32int peget4(const unsigned char *ptr);
 u64int peget8(const unsigned char *ptr);
 void pefree(struct _Pe *pe);
-ulong pefindrva(struct _IMAGE_SECTION_HEADER *SectionHeader, int NumberOfSections, ulong TargetPhysical);
+ulong pefindrva(PeSect *SectionHeaders, int NumberOfSections, ulong TargetPhysical);
 int GetStrnlen(const char *string, int maxlen);
 
-#define ANSI_NAME_STRING(s) ((PANSI_STRING)((s)->Name))
+#define ANSI_NAME_STRING(s) (&(s)->name_str)
 
 #endif/*_LIBMACH_PE_H_*/

--- a/sdk/lib/rossym_new/rossympriv.h
+++ b/sdk/lib/rossym_new/rossympriv.h
@@ -22,6 +22,9 @@ extern ROSSYM_CALLBACKS RosSymCallbacks;
 extern BOOLEAN RosSymZwReadFile(PVOID FileContext, PVOID Buffer, ULONG Size);
 extern BOOLEAN RosSymZwSeekFile(PVOID FileContext, ULONG_PTR Position);
 
+extern BOOLEAN RosSymIoReadFile(PVOID FileContext, PVOID Buffer, ULONG Size);
+extern BOOLEAN RosSymIoSeekFile(PVOID FileContext, ULONG_PTR Position);
+
 #define ROSSYM_IS_VALID_DOS_HEADER(DosHeader) (IMAGE_DOS_SIGNATURE == (DosHeader)->e_magic \
                                                && 0L != (DosHeader)->e_lfanew)
 #define ROSSYM_IS_VALID_NT_HEADERS(NtHeaders) (IMAGE_NT_SIGNATURE == (NtHeaders)->Signature \


### PR DESCRIPTION
  - Make GCC builds use DWARF‑based rossym_new everywhere (drop rsym/NO_ROSSYM paths, use
    baseaddress_dwarf on non‑MSVC).
  - Rework KDBG symbol loading to queue work items with copied module names, load in the worker thread,
    and re‑attach symbols under PsLoadedModuleSpinLock instead of pinning LdrEntry.
  - Keep PASSIVE_LEVEL restrictions for in‑memory loads and use the existing queue spinlock for producer/
    consumer safety.
  - Widen DWARF address/stack types to pointer size and fix unwind/LEB128/sign handling for amd64
    correctness.
  - Drop COFF symtab parsing for memory‑mapped images; fix teardown leaks and low‑memory cleanup.
  - Restore argument/parameter extraction in RosSymGetAddressInformation; suppress kernel werrstr spam.
  - Disable KDBG symbols for SEPARATE_DBG builds.

in x86 before :

```
<ntoskrnl.exe:1aeefa (/home/ahmed/WorkDir/reactos/debug_asm.S:45 ())>
Frames:
<ntoskrnl.exe:9c6cc (/home/ahmed/WorkDir/reactos/bug.c:1160 (KeBugCheckWithTf))>
<ntoskrnl.exe:9cc42 (/home/ahmed/WorkDir/reactos/bug.c:1420 (KeBugCheckEx))>
<ntoskrnl.exe:261bd5>
<ntoskrnl.exe:262804 (/home/ahmed/WorkDir/reactos/iomgr.c:558 (IoInitSystem))>
<ntoskrnl.exe:25d6af>
<ntoskrnl.exe:341a7 (/home/ahmed/WorkDir/reactos/init.c:2063 (Phase1Initialization))>
<ntoskrnl.exe:14257e (/home/ahmed/WorkDir/reactos/thread.c:156 (PspSystemThreadStartup))>
<ntoskrnl.exe:166b85 (/home/ahmed/WorkDir/reactos/thrdini.c:78 (KiThreadStartup))>
<ntoskrnl.exe:142551 (/home/ahmed/WorkDir/reactos/thread.c:63 (PspUserThreadStartup))>
<ec835356>
```

in x86 after :
```
Entered debugger on embedded INT3 at 0x0008:0x805AE8BA.
[?7h[cEip:
<ntoskrnl.exe:1ae8ba (sdk/lib/rtl/i386/debug_asm.S:45 (RtlpBreakWithStatusInstruction))>
Frames:
<ntoskrnl.exe:9c6cc (ntoskrnl/ke/bug.c:1160 (KeBugCheckWithTf))>
<ntoskrnl.exe:9cc42 (ntoskrnl/ke/bug.c:1420 (KeBugCheckEx))>
<ntoskrnl.exe:25dbd5 (ntoskrnl/io/iomgr/driver.c:1212 (IopInitializeBootDrivers))>
<ntoskrnl.exe:25e804 (ntoskrnl/io/iomgr/iomgr.c:558 (IoInitSystem))>
<ntoskrnl.exe:2596af (ntoskrnl/ex/init.c:1851 (Phase1InitializationDiscard))>
<ntoskrnl.exe:341a7 (ntoskrnl/ex/init.c:2063 (Phase1Initialization))>
<ntoskrnl.exe:14257e (ntoskrnl/ps/thread.c:156 (PspSystemThreadStartup))>
<ntoskrnl.exe:166b85 (ntoskrnl/ke/i386/thrdini.c:78 (KiThreadStartup))>
<ntoskrnl.exe:142551 (ntoskrnl/ps/thread.c:63 (PspUserThreadStartup))>
```

AMD64 before : 


```
Entered debugger on embedded INT3 at 0x0010:0xFFFFF8000059E642.
[?7h[cFrames:
[FFFFF880040BA268] <ntoskrnl.exe:19e642>
[FFFFF880040BA270] <ntoskrnl.exe:97239>
[FFFFF880040BA2E0] <ntoskrnl.exe:97db2>
[FFFFF880040BA8C0] <ntoskrnl.exe:98313>
[FFFFF880040BA900] <ntoskrnl.exe:28f208>
[FFFFF880040BAA40] <ntoskrnl.exe:28fd31>
[FFFFF880040BABA0] <ntoskrnl.exe:28b1c9>
[FFFFF880040BAD30] <ntoskrnl.exe:3441a>
[FFFFF880040BAD60] <ntoskrnl.exe:139a7b>
[FFFFF880040BADD0] <ntoskrnl.exe:265b>
[FFFFF880040BAE00] <ntoskrnl.exe:2660>
[FFFFF880040BAE08] <000000000000027F>
```
AMD64 after : 

```
Entered debugger on embedded INT3 at 0x0010:0xFFFFF8000059EF82.
[?7h[cFrames:
[FFFFF880040B9268] <ntoskrnl.exe:19ef82 (/sdk/lib/rtl/amd64/debug_asm.S:29 ())>
[FFFFF880040B9270] <ntoskrnl.exe:97239 (/ntoskrnl/ke/bug.c:505 (KiBugCheckDebugBreak))>
[FFFFF880040B92E0] <ntoskrnl.exe:97db2 (/ntoskrnl/ke/bug.c:1163 (KeBugCheckWithTf))>
[FFFFF880040B98C0] <ntoskrnl.exe:98340 (/ntoskrnl/ke/bug.c:1437 (KeBugCheck))>
[FFFFF880040B9900] <ntoskrnl.exe:2971ee (/ntoskrnl/io/iomgr/driver.c:1212 (IopInitializeBootDrivers))>
[FFFFF880040B9A40] <ntoskrnl.exe:297d31 (/ntoskrnl/io/iomgr/iomgr.c:561 (IoInitSystem))>
[FFFFF880040B9BA0] <ntoskrnl.exe:2931c9 (/ntoskrnl/ex/init.c:1851 (Phase1InitializationDiscard))>
[FFFFF880040B9D30] <ntoskrnl.exe:3441a (/ntoskrnl/ex/init.c:2066 (Phase1Initialization))>
[FFFFF880040B9D60] <ntoskrnl.exe:139a7b (/ntoskrnl/ps/thread.c:156 (PspSystemThreadStartup))>
[FFFFF880040B9DD0] <ntoskrnl.exe:265b (/ntoskrnl/ke/amd64/ctxswitch.S:103 ())>
[FFFFF880040B9E00] <ntoskrnl.exe:2660 (/ntoskrnl/ke/amd64/ctxswitch.S:112 ())>
[FFFFF880040B9E08] <000000000000027F>
```

to test the changes use this patch : 

```
diff --git a/ntoskrnl/io/iomgr/driver.c b/ntoskrnl/io/iomgr/driver.c
index 34a6b0ca642..9d39a809a53 100644
--- a/ntoskrnl/io/iomgr/driver.c
+++ b/ntoskrnl/io/iomgr/driver.c
@@ -1209,6 +1209,7 @@ IopInitializeBootDrivers(VOID)
     PnPBootDriversLoaded = TRUE;
 
     DbgPrint("BOOT DRIVERS LOADED\n");
+    KeBugCheck(MANUALLY_INITIATED_CRASH);
 
     PiQueueDeviceAction(IopRootDeviceNode->PhysicalDeviceObject,
                         PiActionEnumDeviceTree,

```