### PR TITLE
[CRYPT32] Sync to wine-10.0

### DIFF
--- a/dll/win32/crypt32/CMakeLists.txt
+++ b/dll/win32/crypt32/CMakeLists.txt
@@ -2,11 +2,11 @@
 remove_definitions(-D_WIN32_WINNT=0x502 -DWINVER=0x502)
 add_definitions(-D_WIN32_WINNT=0x600 -DWINVER=0x600)
 
+remove_definitions(-D_CRT_NON_CONFORMING_SWPRINTFS)
+
 add_definitions(
-    -D__ROS_LONG64__
     -D_WINE
     -D_CRYPT32_
-    -Dstrncasecmp=_strnicmp
 )
 
 spec2def(crypt32.dll crypt32.spec ADD_IMPORTLIB)
@@ -27,6 +27,7 @@ list(APPEND SOURCE
     msg.c
     object.c
     oid.c
+    pfx.c
     proplist.c
     protectdata.c
     provstore.c
@@ -35,7 +36,10 @@ list(APPEND SOURCE
     serialize.c
     sip.c
     store.c
-    str.c)
+    str.c
+    reactos/store.c
+    reactos/unixlib.c
+)
 
 list(APPEND PCH_SKIP_SOURCE
     ${CMAKE_CURRENT_BINARY_DIR}/crypt32_stubs.c)
@@ -47,15 +51,17 @@ add_library(crypt32 MODULE
     ${CMAKE_CURRENT_BINARY_DIR}/crypt32.def)
 
 if(MSVC)
-    # Disable warning C4090: 'function': different 'const' qualifiers
-    # Disable warning C4312: 'type cast': conversion from 'unsigned int' to 'void *' of greater size
-    target_compile_options(crypt32 PRIVATE /wd4090 /wd4312)
+    target_compile_options(crypt32 PRIVATE
+        /wd4090 # warning C4090: 'function': different 'const' qualifiers
+        /wd4267 # warning C4267: 'function': conversion from 'size_t' to 'ULONG', possible loss of data
+        /wd4312 # warning C4312: 'type cast': conversion from 'unsigned int' to 'void *' of greater size
+    )
 endif()
 
 set_module_type(crypt32 win32dll)
 target_link_libraries(crypt32 wine ${PSEH_LIB} oldnames)
 add_delay_importlibs(crypt32 cryptnet)
-add_importlibs(crypt32 bcrypt user32 advapi32 advapi32_vista msvcrt kernel32 ntdll)
+add_importlibs(crypt32 bcrypt user32 advapi32 advapi32_vista msvcrt kernel32_vista kernel32 ntdll)
 add_pch(crypt32 precomp.h "${PCH_SKIP_SOURCE}")
 add_cd_file(TARGET crypt32 DESTINATION reactos/system32 FOR all)
 set_wine_module_FIXME(crypt32) # CORE-5743: No ARRAY_SIZE macro

--- a/dll/win32/crypt32/base64.c
+++ b/dll/win32/crypt32/base64.c
@@ -25,7 +25,6 @@
 #include "winerror.h"
 #include "wincrypt.h"
 #include "wine/debug.h"
-#include "wine/unicode.h"
 
 WINE_DEFAULT_DEBUG_CHANNEL(crypt);
 
@@ -39,30 +38,15 @@ WINE_DEFAULT_DEBUG_CHANNEL(crypt);
 #define X509_HEADER          "-----BEGIN X509 CRL-----"
 #define X509_TRAILER         "-----END X509 CRL-----"
 
-static const WCHAR CERT_HEADER_W[] = {
-'-','-','-','-','-','B','E','G','I','N',' ','C','E','R','T','I','F','I','C',
-'A','T','E','-','-','-','-','-',0 };
-static const WCHAR CERT_HEADER_START_W[] = {
-'-','-','-','-','-','B','E','G','I','N',' ',0 };
-static const WCHAR CERT_DELIMITER_W[] = {
-'-','-','-','-','-',0 };
-static const WCHAR CERT_TRAILER_W[] = {
-'-','-','-','-','-','E','N','D',' ','C','E','R','T','I','F','I','C','A','T',
-'E','-','-','-','-','-',0 };
-static const WCHAR CERT_TRAILER_START_W[] = {
-'-','-','-','-','-','E','N','D',' ',0 };
-static const WCHAR CERT_REQUEST_HEADER_W[] = {
-'-','-','-','-','-','B','E','G','I','N',' ','N','E','W',' ','C','E','R','T',
-'I','F','I','C','A','T','E',' ','R','E','Q','U','E','S','T','-','-','-','-','-',0 };
-static const WCHAR CERT_REQUEST_TRAILER_W[] = {
-'-','-','-','-','-','E','N','D',' ','N','E','W',' ','C','E','R','T','I','F',
-'I','C','A','T','E',' ','R','E','Q','U','E','S','T','-','-','-','-','-',0 };
-static const WCHAR X509_HEADER_W[] = {
-'-','-','-','-','-','B','E','G','I','N',' ','X','5','0','9',' ','C','R','L',
-'-','-','-','-','-',0 };
-static const WCHAR X509_TRAILER_W[] = {
-'-','-','-','-','-','E','N','D',' ','X','5','0','9',' ','C','R','L','-','-',
-'-','-','-',0 };
+static const WCHAR CERT_HEADER_W[] = L"-----BEGIN CERTIFICATE-----";
+static const WCHAR CERT_HEADER_START_W[] = L"-----BEGIN ";
+static const WCHAR CERT_DELIMITER_W[] = L"-----";
+static const WCHAR CERT_TRAILER_W[] = L"-----END CERTIFICATE-----";
+static const WCHAR CERT_TRAILER_START_W[] = L"-----END ";
+static const WCHAR CERT_REQUEST_HEADER_W[] = L"-----BEGIN NEW CERTIFICATE REQUEST-----";
+static const WCHAR CERT_REQUEST_TRAILER_W[] = L"-----END NEW CERTIFICATE REQUEST-----";
+static const WCHAR X509_HEADER_W[] = L"-----BEGIN X509 CRL-----";
+static const WCHAR X509_TRAILER_W[] = L"-----END X509 CRL-----";
 
 static const char b64[] =
 "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
@@ -93,84 +77,90 @@ static BOOL EncodeBinaryToBinaryA(const BYTE *pbBinary,
     return ret;
 }
 
-static LONG encodeBase64A(const BYTE *in_buf, int in_len, LPCSTR sep,
+static DWORD stradd(LPSTR ptr, LPCSTR end, LPCSTR s, DWORD slen)
+{
+    if (ptr + slen > end)
+        slen = end - ptr;
+    memcpy(ptr, s, slen);
+    return slen;
+}
+
+static DWORD encodeBase64A(const BYTE *in_buf, int in_len, LPCSTR sep,
  char* out_buf, DWORD *out_len)
 {
     int div, i;
     const BYTE *d = in_buf;
     int bytes = (in_len*8 + 5)/6, pad_bytes = (bytes % 4) ? 4 - (bytes % 4) : 0;
-    DWORD needed;
     LPSTR ptr;
+    LPCSTR end;
+    char chunk[4];
 
-    TRACE("bytes is %d, pad bytes is %d\n", bytes, pad_bytes);
-    needed = bytes + pad_bytes;
-    needed += (needed / 64 + (needed % 64 ? 1 : 0)) * strlen(sep);
-    needed++;
-
-    if (needed > *out_len)
+    if (!out_buf)
     {
-        *out_len = needed;
-        return ERROR_INSUFFICIENT_BUFFER;
+        TRACE("bytes is %d, pad bytes is %d\n", bytes, pad_bytes);
+        *out_len = bytes + pad_bytes;
+        *out_len += (*out_len / 64 + (*out_len % 64 ? 1 : 0)) * strlen(sep) + 1;
+        return 0;
     }
-    else
-        *out_len = needed;
 
     /* Three bytes of input give 4 chars of output */
     div = in_len / 3;
 
     ptr = out_buf;
+    end = ptr + *out_len;
     i = 0;
-    while (div > 0)
+    while (div > 0 && ptr < end)
     {
-        if (i && i % 64 == 0)
-        {
-            strcpy(ptr, sep);
-            ptr += strlen(sep);
-        }
         /* first char is the first 6 bits of the first byte*/
-        *ptr++ = b64[ ( d[0] >> 2) & 0x3f ];
+        chunk[0] = b64[ ( d[0] >> 2) & 0x3f ];
         /* second char is the last 2 bits of the first byte and the first 4
          * bits of the second byte */
-        *ptr++ = b64[ ((d[0] << 4) & 0x30) | (d[1] >> 4 & 0x0f)];
+        chunk[1] = b64[ ((d[0] << 4) & 0x30) | (d[1] >> 4 & 0x0f)];
         /* third char is the last 4 bits of the second byte and the first 2
          * bits of the third byte */
-        *ptr++ = b64[ ((d[1] << 2) & 0x3c) | (d[2] >> 6 & 0x03)];
+        chunk[2] = b64[ ((d[1] << 2) & 0x3c) | (d[2] >> 6 & 0x03)];
         /* fourth char is the remaining 6 bits of the third byte */
-        *ptr++ = b64[   d[2]       & 0x3f];
+        chunk[3] = b64[   d[2]       & 0x3f];
+        ptr += stradd(ptr, end, chunk, 4);
         i += 4;
         d += 3;
         div--;
+
+        if (i && i % 64 == 0)
+            ptr += stradd(ptr, end, sep, strlen(sep));
     }
 
     switch(pad_bytes)
     {
         case 1:
             /* first char is the first 6 bits of the first byte*/
-            *ptr++ = b64[ ( d[0] >> 2) & 0x3f ];
+            chunk[0] = b64[ ( d[0] >> 2) & 0x3f ];
             /* second char is the last 2 bits of the first byte and the first 4
              * bits of the second byte */
-            *ptr++ = b64[ ((d[0] << 4) & 0x30) | (d[1] >> 4 & 0x0f)];
+            chunk[1] = b64[ ((d[0] << 4) & 0x30) | (d[1] >> 4 & 0x0f)];
             /* third char is the last 4 bits of the second byte padded with
              * two zeroes */
-            *ptr++ = b64[ ((d[1] << 2) & 0x3c) ];
+            chunk[2] = b64[ ((d[1] << 2) & 0x3c) ];
             /* fourth char is a = to indicate one byte of padding */
-            *ptr++ = '=';
+            chunk[3] = '=';
+            ptr += stradd(ptr, end, chunk, 4);
             break;
         case 2:
             /* first char is the first 6 bits of the first byte*/
-            *ptr++ = b64[ ( d[0] >> 2) & 0x3f ];
+            chunk[0] = b64[ ( d[0] >> 2) & 0x3f ];
             /* second char is the last 2 bits of the first byte padded with
              * four zeroes*/
-            *ptr++ = b64[ ((d[0] << 4) & 0x30)];
+            chunk[1] = b64[ ((d[0] << 4) & 0x30)];
             /* third char is = to indicate padding */
-            *ptr++ = '=';
+            chunk[2] = '=';
             /* fourth char is = to indicate padding */
-            *ptr++ = '=';
+            chunk[3] = '=';
+            ptr += stradd(ptr, end, chunk, 4);
             break;
     }
-    strcpy(ptr, sep);
+    ptr += stradd(ptr, end, sep, strlen(sep));
 
-    return ERROR_SUCCESS;
+    return ptr - out_buf;
 }
 
 static BOOL BinaryToBase64A(const BYTE *pbBinary,
@@ -215,32 +205,34 @@ static BOOL BinaryToBase64A(const BYTE *pbBinary,
 
     if (pszString)
     {
+        LPSTR ptr = pszString;
+        DWORD size = *pcchString;
+        LPSTR end = ptr + size;
+
+        if (header)
+        {
+            ptr += stradd(ptr, end, header, strlen(header));
+            ptr += stradd(ptr, end, sep, strlen(sep));
+            size = end - ptr;
+        }
+        ptr += encodeBase64A(pbBinary, cbBinary, sep, ptr, &size);
+        if (trailer)
+        {
+            ptr += stradd(ptr, end, trailer, strlen(trailer));
+            ptr += stradd(ptr, end, sep, strlen(sep));
+        }
+
+        if (ptr < end)
+            *ptr = '\0';
+
         if (charsNeeded <= *pcchString)
         {
-            LPSTR ptr = pszString;
-            DWORD size = charsNeeded;
-
-            if (header)
-            {
-                strcpy(ptr, header);
-                ptr += strlen(ptr);
-                strcpy(ptr, sep);
-                ptr += strlen(sep);
-            }
-            encodeBase64A(pbBinary, cbBinary, sep, ptr, &size);
-            ptr += size - 1;
-            if (trailer)
-            {
-                strcpy(ptr, trailer);
-                ptr += strlen(ptr);
-               strcpy(ptr, sep);
-            }
             *pcchString = charsNeeded - 1;
         }
         else
         {
             *pcchString = charsNeeded;
-            SetLastError(ERROR_INSUFFICIENT_BUFFER);
+            SetLastError(ERROR_MORE_DATA);
             ret = FALSE;
         }
     }
@@ -250,12 +242,69 @@ static BOOL BinaryToBase64A(const BYTE *pbBinary,
     return ret;
 }
 
+static BOOL BinaryToHexRawA(const BYTE *bin, DWORD nbin, DWORD flags, char *str, DWORD *nstr)
+{
+    static const char hex[] = "0123456789abcdef";
+    DWORD needed;
+
+    if (flags & CRYPT_STRING_NOCRLF)
+        needed = 0;
+    else if (flags & CRYPT_STRING_NOCR)
+        needed = 1;
+    else
+        needed = 2;
+
+    needed += nbin * 2 + 1;
+
+    if (!str)
+    {
+        *nstr = needed;
+        return TRUE;
+    }
+
+    if (needed > *nstr && *nstr < 3)
+    {
+        SetLastError(ERROR_MORE_DATA);
+        return FALSE;
+    }
+
+    nbin = min(nbin, (*nstr - 1) / 2);
+
+    while (nbin--)
+    {
+        *str++ = hex[(*bin >> 4) & 0xf];
+        *str++ = hex[*bin & 0xf];
+        bin++;
+    }
+
+    if (needed > *nstr)
+    {
+        *str = 0;
+        SetLastError(ERROR_MORE_DATA);
+        return FALSE;
+    }
+
+    if (flags & CRYPT_STRING_NOCR)
+    {
+        *str++ = '\n';
+    }
+    else if (!(flags & CRYPT_STRING_NOCRLF))
+    {
+        *str++ = '\r';
+        *str++ = '\n';
+    }
+
+    *str = 0;
+    *nstr = needed - 1;
+    return TRUE;
+}
+
 BOOL WINAPI CryptBinaryToStringA(const BYTE *pbBinary,
  DWORD cbBinary, DWORD dwFlags, LPSTR pszString, DWORD *pcchString)
 {
     BinaryToStringAFunc encoder = NULL;
 
-    TRACE("(%p, %d, %08x, %p, %p)\n", pbBinary, cbBinary, dwFlags, pszString,
+    TRACE("(%p, %ld, %08lx, %p, %p)\n", pbBinary, cbBinary, dwFlags, pszString,
      pcchString);
 
     if (!pbBinary)
@@ -280,11 +329,14 @@ BOOL WINAPI CryptBinaryToStringA(const BYTE *pbBinary,
     case CRYPT_STRING_BASE64X509CRLHEADER:
         encoder = BinaryToBase64A;
         break;
+    case CRYPT_STRING_HEXRAW:
+        encoder = BinaryToHexRawA;
+        break;
     case CRYPT_STRING_HEX:
     case CRYPT_STRING_HEXASCII:
     case CRYPT_STRING_HEXADDR:
     case CRYPT_STRING_HEXASCIIADDR:
-        FIXME("Unimplemented type %d\n", dwFlags & 0x0fffffff);
+        FIXME("Unimplemented type %ld\n", dwFlags & 0x0fffffff);
         /* fall through */
     default:
         SetLastError(ERROR_INVALID_PARAMETER);
@@ -324,7 +376,7 @@ static LONG encodeBase64W(const BYTE *in_buf, int in_len, LPCWSTR sep,
 
     TRACE("bytes is %d, pad bytes is %d\n", bytes, pad_bytes);
     needed = bytes + pad_bytes;
-    needed += (needed / 64 + (needed % 64 ? 1 : 0)) * strlenW(sep);
+    needed += (needed / 64 + (needed % 64 ? 1 : 0)) * lstrlenW(sep);
     needed++;
 
     if (needed > *out_len)
@@ -342,11 +394,6 @@ static LONG encodeBase64W(const BYTE *in_buf, int in_len, LPCWSTR sep,
     i = 0;
     while (div > 0)
     {
-        if (i && i % 64 == 0)
-        {
-            strcpyW(ptr, sep);
-            ptr += strlenW(sep);
-        }
         /* first char is the first 6 bits of the first byte*/
         *ptr++ = b64[ ( d[0] >> 2) & 0x3f ];
         /* second char is the last 2 bits of the first byte and the first 4
@@ -360,6 +407,12 @@ static LONG encodeBase64W(const BYTE *in_buf, int in_len, LPCWSTR sep,
         i += 4;
         d += 3;
         div--;
+
+        if (i && i % 64 == 0)
+        {
+            lstrcpyW(ptr, sep);
+            ptr += lstrlenW(sep);
+        }
     }
 
     switch(pad_bytes)
@@ -388,7 +441,7 @@ static LONG encodeBase64W(const BYTE *in_buf, int in_len, LPCWSTR sep,
             *ptr++ = '=';
             break;
     }
-    strcpyW(ptr, sep);
+    lstrcpyW(ptr, sep);
 
     return ERROR_SUCCESS;
 }
@@ -396,17 +449,16 @@ static LONG encodeBase64W(const BYTE *in_buf, int in_len, LPCWSTR sep,
 static BOOL BinaryToBase64W(const BYTE *pbBinary,
  DWORD cbBinary, DWORD dwFlags, LPWSTR pszString, DWORD *pcchString)
 {
-    static const WCHAR crlf[] = { '\r','\n',0 }, lf[] = { '\n',0 }, empty[] = {0};
     BOOL ret = TRUE;
     LPCWSTR header = NULL, trailer = NULL, sep;
     DWORD charsNeeded;
 
     if (dwFlags & CRYPT_STRING_NOCR)
-        sep = lf;
+        sep = L"\n";
     else if (dwFlags & CRYPT_STRING_NOCRLF)
-        sep = empty;
+        sep = L"";
     else
-        sep = crlf;
+        sep = L"\r\n";
     switch (dwFlags & 0x0fffffff)
     {
     case CRYPT_STRING_BASE64:
@@ -429,9 +481,9 @@ static BOOL BinaryToBase64W(const BYTE *pbBinary,
     charsNeeded = 0;
     encodeBase64W(pbBinary, cbBinary, sep, NULL, &charsNeeded);
     if (header)
-        charsNeeded += strlenW(header) + strlenW(sep);
+        charsNeeded += lstrlenW(header) + lstrlenW(sep);
     if (trailer)
-        charsNeeded += strlenW(trailer) + strlenW(sep);
+        charsNeeded += lstrlenW(trailer) + lstrlenW(sep);
 
     if (pszString)
     {
@@ -442,25 +494,25 @@ static BOOL BinaryToBase64W(const BYTE *pbBinary,
 
             if (header)
             {
-                strcpyW(ptr, header);
-                ptr += strlenW(ptr);
-                strcpyW(ptr, sep);
-                ptr += strlenW(sep);
+                lstrcpyW(ptr, header);
+                ptr += lstrlenW(ptr);
+                lstrcpyW(ptr, sep);
+                ptr += lstrlenW(sep);
             }
             encodeBase64W(pbBinary, cbBinary, sep, ptr, &size);
             ptr += size - 1;
             if (trailer)
             {
-                strcpyW(ptr, trailer);
-                ptr += strlenW(ptr);
-                strcpyW(ptr, sep);
+                lstrcpyW(ptr, trailer);
+                ptr += lstrlenW(ptr);
+                lstrcpyW(ptr, sep);
             }
             *pcchString = charsNeeded - 1;
         }
         else
         {
             *pcchString = charsNeeded;
-            SetLastError(ERROR_INSUFFICIENT_BUFFER);
+            SetLastError(ERROR_MORE_DATA);
             ret = FALSE;
         }
     }
@@ -470,12 +522,131 @@ static BOOL BinaryToBase64W(const BYTE *pbBinary,
     return ret;
 }
 
+static BOOL BinaryToHexRawW(const BYTE *bin, DWORD nbin, DWORD flags, LPWSTR str, DWORD *nstr)
+{
+    static const WCHAR hex[] = L"0123456789abcdef";
+    DWORD needed;
+
+    if (flags & CRYPT_STRING_NOCRLF)
+        needed = 0;
+    else if (flags & CRYPT_STRING_NOCR)
+        needed = 1;
+    else
+        needed = 2;
+
+    needed += nbin * 2 + 1;
+
+    if (!str)
+    {
+        *nstr = needed;
+        return TRUE;
+    }
+
+    if (needed > *nstr)
+    {
+        SetLastError(ERROR_MORE_DATA);
+        return FALSE;
+    }
+
+    while (nbin--)
+    {
+        *str++ = hex[(*bin >> 4) & 0xf];
+        *str++ = hex[*bin & 0xf];
+        bin++;
+    }
+
+    if (flags & CRYPT_STRING_NOCR)
+        *str++ = '\n';
+    else if (!(flags & CRYPT_STRING_NOCRLF))
+    {
+        *str++ = '\r';
+        *str++ = '\n';
+    }
+
+    *str = 0;
+    *nstr = needed - 1;
+    return TRUE;
+}
+
+static BOOL binary_to_hexW(const BYTE *bin, DWORD nbin, DWORD flags, LPWSTR str, DWORD *nstr)
+{
+    static const WCHAR hex[] = L"0123456789abcdef";
+    DWORD needed, i;
+
+    needed = nbin * 3; /* spaces + terminating \0 */
+
+    if (flags & CRYPT_STRING_NOCR)
+    {
+        needed += (nbin + 7) / 16; /* space every 16 characters */
+        needed += 1; /* terminating \n */
+    }
+    else if (!(flags & CRYPT_STRING_NOCRLF))
+    {
+        needed += (nbin + 7) / 16; /* space every 16 characters */
+        needed += nbin / 16 + 1; /* LF every 16 characters + terminating \r */
+
+        if (nbin % 16)
+            needed += 1; /* terminating \n */
+    }
+
+    if (!str)
+    {
+        *nstr = needed;
+        return TRUE;
+    }
+
+    if (needed > *nstr)
+    {
+        SetLastError(ERROR_MORE_DATA);
+        return FALSE;
+    }
+
+    for (i = 0; i < nbin; i++)
+    {
+        *str++ = hex[(bin[i] >> 4) & 0xf];
+        *str++ = hex[bin[i] & 0xf];
+
+        if (i >= nbin - 1) break;
+
+        if (i && !(flags & CRYPT_STRING_NOCRLF))
+        {
+            if (!((i + 1) % 16))
+            {
+                if (flags & CRYPT_STRING_NOCR)
+                    *str++ = '\n';
+                else
+                {
+                    *str++ = '\r';
+                    *str++ = '\n';
+                }
+                continue;
+            }
+            else if (!((i + 1) % 8))
+                *str++ = ' ';
+        }
+
+        *str++ = ' ';
+    }
+
+    if (flags & CRYPT_STRING_NOCR)
+        *str++ = '\n';
+    else if (!(flags & CRYPT_STRING_NOCRLF))
+    {
+        *str++ = '\r';
+        *str++ = '\n';
+    }
+
+    *str = 0;
+    *nstr = needed - 1;
+    return TRUE;
+}
+
 BOOL WINAPI CryptBinaryToStringW(const BYTE *pbBinary,
  DWORD cbBinary, DWORD dwFlags, LPWSTR pszString, DWORD *pcchString)
 {
     BinaryToStringWFunc encoder = NULL;
 
-    TRACE("(%p, %d, %08x, %p, %p)\n", pbBinary, cbBinary, dwFlags, pszString,
+    TRACE("(%p, %ld, %08lx, %p, %p)\n", pbBinary, cbBinary, dwFlags, pszString,
      pcchString);
 
     if (!pbBinary)
@@ -500,11 +671,16 @@ BOOL WINAPI CryptBinaryToStringW(const BYTE *pbBinary,
     case CRYPT_STRING_BASE64X509CRLHEADER:
         encoder = BinaryToBase64W;
         break;
+    case CRYPT_STRING_HEXRAW:
+        encoder = BinaryToHexRawW;
+        break;
     case CRYPT_STRING_HEX:
+        encoder = binary_to_hexW;
+        break;
     case CRYPT_STRING_HEXASCII:
     case CRYPT_STRING_HEXADDR:
     case CRYPT_STRING_HEXASCIIADDR:
-        FIXME("Unimplemented type %d\n", dwFlags & 0x0fffffff);
+        FIXME("Unimplemented type %ld\n", dwFlags & 0x0fffffff);
         /* fall through */
     default:
         SetLastError(ERROR_INVALID_PARAMETER);
@@ -769,6 +945,120 @@ static LONG DecodeAnyA(LPCSTR pszString, DWORD cchString,
     return ret;
 }
 
+static BOOL is_hex_string_special_char(WCHAR c)
+{
+    switch (c)
+    {
+        case '-':
+        case ',':
+        case ' ':
+        case '\t':
+        case '\r':
+        case '\n':
+            return TRUE;
+
+        default:
+            return FALSE;
+    }
+}
+
+static WCHAR wchar_from_str(BOOL wide, const void **str, DWORD *len)
+{
+    WCHAR c;
+
+    if (!*len)
+        return 0;
+
+    --*len;
+    if (wide)
+        c = *(*(const WCHAR **)str)++;
+    else
+        c = *(*(const char **)str)++;
+
+    return c ? c : 0xffff;
+}
+
+static BYTE digit_from_char(WCHAR c)
+{
+    if (c >= '0' && c <= '9')
+        return c - '0';
+    c = towlower(c);
+    if (c >= 'a' && c <= 'f')
+        return c - 'a' + 0xa;
+    return 0xff;
+}
+
+static LONG string_to_hex(const void* str, BOOL wide, DWORD len, BYTE *hex, DWORD *hex_len,
+        DWORD *skipped, DWORD *ret_flags)
+{
+    unsigned int byte_idx = 0;
+    BYTE d1, d2;
+    WCHAR c;
+
+    if (!str || !hex_len)
+        return ERROR_INVALID_PARAMETER;
+
+    if (!len)
+        len = wide ? wcslen(str) : strlen(str);
+
+    if (wide && !len)
+        return ERROR_INVALID_PARAMETER;
+
+    if (skipped)
+        *skipped = 0;
+    if (ret_flags)
+        *ret_flags = 0;
+
+    while ((c = wchar_from_str(wide, &str, &len)) && is_hex_string_special_char(c))
+        ;
+
+    while ((d1 = digit_from_char(c)) != 0xff)
+    {
+        if ((d2 = digit_from_char(wchar_from_str(wide, &str, &len))) == 0xff)
+        {
+            if (!hex)
+                *hex_len = 0;
+            return ERROR_INVALID_DATA;
+        }
+
+        if (hex && byte_idx < *hex_len)
+            hex[byte_idx] = (d1 << 4) | d2;
+
+        ++byte_idx;
+
+        do
+        {
+            c = wchar_from_str(wide, &str, &len);
+        } while (c == '-' || c == ',');
+    }
+
+    while (c)
+    {
+        if (!is_hex_string_special_char(c))
+        {
+            if (!hex)
+                *hex_len = 0;
+            return ERROR_INVALID_DATA;
+        }
+        c = wchar_from_str(wide, &str, &len);
+    }
+
+    if (hex && byte_idx > *hex_len)
+        return ERROR_MORE_DATA;
+
+    if (ret_flags)
+        *ret_flags = CRYPT_STRING_HEX;
+
+    *hex_len = byte_idx;
+
+    return ERROR_SUCCESS;
+}
+
+static LONG string_to_hexA(const char *str, DWORD len, BYTE *hex, DWORD *hex_len, DWORD *skipped, DWORD *ret_flags)
+{
+    return string_to_hex(str, FALSE, len, hex, hex_len, skipped, ret_flags);
+}
+
 BOOL WINAPI CryptStringToBinaryA(LPCSTR pszString,
  DWORD cchString, DWORD dwFlags, BYTE *pbBinary, DWORD *pcbBinary,
  DWORD *pdwSkip, DWORD *pdwFlags)
@@ -776,7 +1066,7 @@ BOOL WINAPI CryptStringToBinaryA(LPCSTR pszString,
     StringToBinaryAFunc decoder;
     LONG ret;
 
-    TRACE("(%s, %d, %08x, %p, %p, %p, %p)\n", debugstr_an(pszString, cchString ? cchString : -1),
+    TRACE("(%s, %ld, %08lx, %p, %p, %p, %p)\n", debugstr_an(pszString, cchString ? cchString : -1),
      cchString, dwFlags, pbBinary, pcbBinary, pdwSkip, pdwFlags);
 
     if (!pszString)
@@ -814,10 +1104,12 @@ BOOL WINAPI CryptStringToBinaryA(LPCSTR pszString,
         decoder = DecodeAnyA;
         break;
     case CRYPT_STRING_HEX:
+        decoder = string_to_hexA;
+        break;
     case CRYPT_STRING_HEXASCII:
     case CRYPT_STRING_HEXADDR:
     case CRYPT_STRING_HEXASCIIADDR:
-        FIXME("Unimplemented type %d\n", dwFlags & 0x7fffffff);
+        FIXME("Unimplemented type %ld\n", dwFlags & 0x7fffffff);
         /* fall through */
     default:
         SetLastError(ERROR_INVALID_PARAMETER);
@@ -856,27 +1148,27 @@ static LONG Base64WithHeaderAndTrailerToBinaryW(LPCWSTR pszString,
     LPCWSTR trailerBegins;
     size_t dataLength;
 
-    if ((strlenW(header) + strlenW(trailer)) > cchString)
+    if ((lstrlenW(header) + lstrlenW(trailer)) > cchString)
     {
         return ERROR_INVALID_DATA;
     }
 
-    if (!(headerBegins = strstrW(pszString, header)))
+    if (!(headerBegins = wcsstr(pszString, header)))
     {
         TRACE("Can't find %s in %s.\n", debugstr_w(header), debugstr_wn(pszString, cchString));
         return ERROR_INVALID_DATA;
     }
 
-    dataBegins = headerBegins + strlenW(header);
-    if (!(dataBegins = strstrW(dataBegins, CERT_DELIMITER_W)))
+    dataBegins = headerBegins + lstrlenW(header);
+    if (!(dataBegins = wcsstr(dataBegins, CERT_DELIMITER_W)))
     {
         return ERROR_INVALID_DATA;
     }
-    dataBegins += strlenW(CERT_DELIMITER_W);
+    dataBegins += lstrlenW(CERT_DELIMITER_W);
     if (*dataBegins == '\r') dataBegins++;
     if (*dataBegins == '\n') dataBegins++;
 
-    if (!(trailerBegins = strstrW(dataBegins, trailer)))
+    if (!(trailerBegins = wcsstr(dataBegins, trailer)))
     {
         return ERROR_INVALID_DATA;
     }
@@ -980,6 +1272,11 @@ static LONG DecodeAnyW(LPCWSTR pszString, DWORD cchString,
     return ret;
 }
 
+static LONG string_to_hexW(const WCHAR *str, DWORD len, BYTE *hex, DWORD *hex_len, DWORD *skipped, DWORD *ret_flags)
+{
+    return string_to_hex(str, TRUE, len, hex, hex_len, skipped, ret_flags);
+}
+
 BOOL WINAPI CryptStringToBinaryW(LPCWSTR pszString,
  DWORD cchString, DWORD dwFlags, BYTE *pbBinary, DWORD *pcbBinary,
  DWORD *pdwSkip, DWORD *pdwFlags)
@@ -987,7 +1284,7 @@ BOOL WINAPI CryptStringToBinaryW(LPCWSTR pszString,
     StringToBinaryWFunc decoder;
     LONG ret;
 
-    TRACE("(%s, %d, %08x, %p, %p, %p, %p)\n", debugstr_wn(pszString, cchString ? cchString : -1),
+    TRACE("(%s, %ld, %08lx, %p, %p, %p, %p)\n", debugstr_wn(pszString, cchString ? cchString : -1),
      cchString, dwFlags, pbBinary, pcbBinary, pdwSkip, pdwFlags);
 
     if (!pszString)
@@ -1025,17 +1322,19 @@ BOOL WINAPI CryptStringToBinaryW(LPCWSTR pszString,
         decoder = DecodeAnyW;
         break;
     case CRYPT_STRING_HEX:
+        decoder = string_to_hexW;
+        break;
     case CRYPT_STRING_HEXASCII:
     case CRYPT_STRING_HEXADDR:
     case CRYPT_STRING_HEXASCIIADDR:
-        FIXME("Unimplemented type %d\n", dwFlags & 0x7fffffff);
+        FIXME("Unimplemented type %ld\n", dwFlags & 0x7fffffff);
         /* fall through */
     default:
         SetLastError(ERROR_INVALID_PARAMETER);
         return FALSE;
     }
     if (!cchString)
-        cchString = strlenW(pszString);
+        cchString = lstrlenW(pszString);
     ret = decoder(pszString, cchString, pbBinary, pcbBinary, pdwSkip, pdwFlags);
     if (ret)
         SetLastError(ret);

--- a/dll/win32/crypt32/collectionstore.c
+++ b/dll/win32/crypt32/collectionstore.c
@@ -42,7 +42,7 @@ typedef struct _WINE_COLLECTIONSTORE
 static void Collection_addref(WINECRYPT_CERTSTORE *store)
 {
     LONG ref = InterlockedIncrement(&store->ref);
-    TRACE("ref = %d\n", ref);
+    TRACE("ref = %ld\n", ref);
 }
 
 static DWORD Collection_release(WINECRYPT_CERTSTORE *store, DWORD flags)
@@ -52,10 +52,10 @@ static DWORD Collection_release(WINECRYPT_CERTSTORE *store, DWORD flags)
     LONG ref;
 
     if(flags)
-        FIXME("Unimplemented flags %x\n", flags);
+        FIXME("Unimplemented flags %lx\n", flags);
 
     ref = InterlockedDecrement(&cs->hdr.ref);
-    TRACE("(%p) ref=%d\n", store, ref);
+    TRACE("(%p) ref=%ld\n", store, ref);
     if(ref)
         return ERROR_SUCCESS;
 
@@ -411,7 +411,7 @@ static BOOL Collection_control(WINECRYPT_CERTSTORE *cert_store, DWORD dwFlags,
     WINE_COLLECTIONSTORE *store = (WINE_COLLECTIONSTORE*)cert_store;
     WINE_STORE_LIST_ENTRY *entry;
 
-    TRACE("(%p, %08x, %d, %p)\n", cert_store, dwFlags, dwCtrlType, pvCtrlPara);
+    TRACE("(%p, %08lx, %ld, %p)\n", cert_store, dwFlags, dwCtrlType, pvCtrlPara);
 
     if (!store)
         return TRUE;
@@ -478,7 +478,7 @@ WINECRYPT_CERTSTORE *CRYPT_CollectionOpenStore(HCRYPTPROV hCryptProv,
         {
             memset(store, 0, sizeof(WINE_COLLECTIONSTORE));
             CRYPT_InitStore(&store->hdr, dwFlags, StoreTypeCollection, &CollectionStoreVtbl);
-            InitializeCriticalSection(&store->cs);
+            InitializeCriticalSectionEx(&store->cs, 0, RTL_CRITICAL_SECTION_FLAG_FORCE_DEBUG_INFO);
             store->cs.DebugInfo->Spare[0] = (DWORD_PTR)(__FILE__ ": PWINE_COLLECTIONSTORE->cs");
             list_init(&store->stores);
         }
@@ -494,7 +494,7 @@ BOOL WINAPI CertAddStoreToCollection(HCERTSTORE hCollectionStore,
     WINE_STORE_LIST_ENTRY *entry;
     BOOL ret;
 
-    TRACE("(%p, %p, %08x, %d)\n", hCollectionStore, hSiblingStore,
+    TRACE("(%p, %p, %08lx, %ld)\n", hCollectionStore, hSiblingStore,
      dwUpdateFlags, dwPriority);
 
     if (!collection || !sibling)
@@ -519,11 +519,11 @@ BOOL WINAPI CertAddStoreToCollection(HCERTSTORE hCollectionStore,
     if (entry)
     {
         InterlockedIncrement(&sibling->ref);
-        TRACE("sibling %p's ref count is %d\n", sibling, sibling->ref);
+        TRACE("sibling %p's ref count is %ld\n", sibling, sibling->ref);
         entry->store = sibling;
         entry->dwUpdateFlags = dwUpdateFlags;
         entry->dwPriority = dwPriority;
-        TRACE("%p: adding %p, priority %d\n", collection, entry, dwPriority);
+        TRACE("%p: adding %p, priority %ld\n", collection, entry, dwPriority);
         EnterCriticalSection(&collection->cs);
         if (dwPriority)
         {

--- a/dll/win32/crypt32/context.c
+++ b/dll/win32/crypt32/context.c
@@ -79,7 +79,7 @@ void Context_AddRef(context_t *context)
 {
     LONG ref = InterlockedIncrement(&context->ref);
 
-    TRACE("(%p) ref=%d\n", context, context->ref);
+    TRACE("(%p) ref=%ld\n", context, context->ref);
 
     if(ref == 1) {
         /* This is the first external (non-store) reference. Increase store ref cnt. */
@@ -107,7 +107,7 @@ void Context_Release(context_t *context)
 {
     LONG ref = InterlockedDecrement(&context->ref);
 
-    TRACE("(%p) ref=%d\n", context, ref);
+    TRACE("(%p) ref=%ld\n", context, ref);
     assert(ref >= 0);
 
     if (!ref) {

--- a/dll/win32/crypt32/crypt32.spec
+++ b/dll/win32/crypt32/crypt32.spec
@@ -137,12 +137,14 @@
 @ stdcall CryptGetOIDFunctionAddress(long long str long ptr ptr)
 @ stdcall CryptGetOIDFunctionValue(long str str wstr ptr ptr ptr)
 @ stdcall CryptHashCertificate(long long long ptr long ptr ptr)
+@ stdcall -version=0x600+ CryptHashCertificate2(wstr long ptr ptr long ptr ptr)
 @ stdcall CryptHashMessage(ptr long long ptr ptr ptr ptr ptr ptr)
 @ stdcall CryptHashPublicKeyInfo(long long long long ptr ptr ptr)
 @ stdcall CryptHashToBeSigned(ptr long ptr long ptr ptr)
 @ stub CryptImportPKCS8
 @ stdcall CryptImportPublicKeyInfo(long long ptr ptr)
 @ stdcall CryptImportPublicKeyInfoEx(long long ptr long long ptr ptr)
+@ stdcall -version=0x600+ CryptImportPublicKeyInfoEx2(long ptr long ptr ptr)
 @ stdcall CryptInitOIDFunctionSet(str long)
 @ stdcall CryptInstallOIDFunctionAddress(ptr long str long ptr long)
 @ stub CryptLoadSip

--- a/dll/win32/crypt32/ctl.c
+++ b/dll/win32/crypt32/ctl.c
@@ -68,7 +68,7 @@ BOOL WINAPI CertAddCTLContextToStore(HCERTSTORE hCertStore,
     BOOL ret = TRUE;
     PCCTL_CONTEXT toAdd = NULL, existing = NULL;
 
-    TRACE("(%p, %p, %08x, %p)\n", hCertStore, pCtlContext, dwAddDisposition,
+    TRACE("(%p, %p, %08lx, %p)\n", hCertStore, pCtlContext, dwAddDisposition,
      ppStoreContext);
 
     if (dwAddDisposition != CERT_STORE_ADD_ALWAYS)
@@ -150,7 +150,7 @@ BOOL WINAPI CertAddCTLContextToStore(HCERTSTORE hCertStore,
             toAdd = CertDuplicateCTLContext(pCtlContext);
         break;
     default:
-        FIXME("Unimplemented add disposition %d\n", dwAddDisposition);
+        FIXME("Unimplemented add disposition %ld\n", dwAddDisposition);
         ret = FALSE;
     }
 
@@ -182,7 +182,7 @@ BOOL WINAPI CertAddEncodedCTLToStore(HCERTSTORE hCertStore,
      pbCtlEncoded, cbCtlEncoded);
     BOOL ret;
 
-    TRACE("(%p, %08x, %p, %d, %08x, %p)\n", hCertStore,
+    TRACE("(%p, %08lx, %p, %ld, %08lx, %p)\n", hCertStore,
      dwMsgAndCertEncodingType, pbCtlEncoded, cbCtlEncoded, dwAddDisposition,
      ppCtlContext);
 
@@ -295,7 +295,7 @@ PCCTL_CONTEXT WINAPI CertFindCTLInStore(HCERTSTORE hCertStore,
     PCCTL_CONTEXT ret;
     CtlCompareFunc compare;
 
-    TRACE("(%p, %d, %d, %d, %p, %p)\n", hCertStore, dwCertEncodingType,
+    TRACE("(%p, %ld, %ld, %ld, %p, %p)\n", hCertStore, dwCertEncodingType,
 	 dwFindFlags, dwFindType, pvFindPara, pPrevCtlContext);
 
     switch (dwFindType)
@@ -313,7 +313,7 @@ PCCTL_CONTEXT WINAPI CertFindCTLInStore(HCERTSTORE hCertStore,
         compare = compare_ctl_existing;
         break;
     default:
-        FIXME("find type %08x unimplemented\n", dwFindType);
+        FIXME("find type %08lx unimplemented\n", dwFindType);
         compare = NULL;
     }
 
@@ -370,7 +370,7 @@ PCCTL_CONTEXT WINAPI CertCreateCTLContext(DWORD dwMsgAndCertEncodingType,
     DWORD contentSize = 0, size;
     PCTL_INFO ctlInfo = NULL;
 
-    TRACE("(%08x, %p, %d)\n", dwMsgAndCertEncodingType, pbCtlEncoded,
+    TRACE("(%08lx, %p, %ld)\n", dwMsgAndCertEncodingType, pbCtlEncoded,
      cbCtlEncoded);
 
     if (GET_CERT_ENCODING_TYPE(dwMsgAndCertEncodingType) != X509_ASN_ENCODING)
@@ -511,7 +511,7 @@ DWORD WINAPI CertEnumCTLContextProperties(PCCTL_CONTEXT pCTLContext,
     ctl_t *ctl = ctl_from_ptr(pCTLContext);
     DWORD ret;
 
-    TRACE("(%p, %d)\n", pCTLContext, dwPropId);
+    TRACE("(%p, %ld)\n", pCTLContext, dwPropId);
 
     if (ctl->base.properties)
         ret = ContextPropertyList_EnumPropIDs(ctl->base.properties, dwPropId);
@@ -544,7 +544,7 @@ static BOOL CTLContext_GetProperty(ctl_t *ctl, DWORD dwPropId,
     BOOL ret;
     CRYPT_DATA_BLOB blob;
 
-    TRACE("(%p, %d, %p, %p)\n", ctl, dwPropId, pvData, pcbData);
+    TRACE("(%p, %ld, %p, %p)\n", ctl, dwPropId, pvData, pcbData);
 
     if (ctl->base.properties)
         ret = ContextPropertyList_FindProperty(ctl->base.properties, dwPropId, &blob);
@@ -592,7 +592,7 @@ BOOL WINAPI CertGetCTLContextProperty(PCCTL_CONTEXT pCTLContext,
 {
     BOOL ret;
 
-    TRACE("(%p, %d, %p, %p)\n", pCTLContext, dwPropId, pvData, pcbData);
+    TRACE("(%p, %ld, %p, %p)\n", pCTLContext, dwPropId, pvData, pcbData);
 
     switch (dwPropId)
     {
@@ -632,7 +632,7 @@ static BOOL CTLContext_SetProperty(ctl_t *ctl, DWORD dwPropId,
 {
     BOOL ret;
 
-    TRACE("(%p, %d, %08x, %p)\n", ctl, dwPropId, dwFlags, pvData);
+    TRACE("(%p, %ld, %08lx, %p)\n", ctl, dwPropId, dwFlags, pvData);
 
     if (!ctl->base.properties)
         ret = FALSE;
@@ -674,7 +674,7 @@ static BOOL CTLContext_SetProperty(ctl_t *ctl, DWORD dwPropId,
              pvData, sizeof(FILETIME));
             break;
         default:
-            FIXME("%d: stub\n", dwPropId);
+            FIXME("%ld: stub\n", dwPropId);
             ret = FALSE;
         }
     }
@@ -687,7 +687,7 @@ BOOL WINAPI CertSetCTLContextProperty(PCCTL_CONTEXT pCTLContext,
 {
     BOOL ret;
 
-    TRACE("(%p, %d, %08x, %p)\n", pCTLContext, dwPropId, dwFlags, pvData);
+    TRACE("(%p, %ld, %08lx, %p)\n", pCTLContext, dwPropId, dwFlags, pvData);
 
     /* Handle special cases for "read-only"/invalid prop IDs.  Windows just
      * crashes on most of these, I'll be safer.

--- a/dll/win32/crypt32/encode.c
+++ b/dll/win32/crypt32/encode.c
@@ -30,15 +30,10 @@
  * MSDN, especially "Constants for CryptEncodeObject and CryptDecodeObject"
  */
 
-#include "config.h"
-#include "wine/port.h"
-
 #include <assert.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
-
-#define NONAMELESSUNION
 
 #include "windef.h"
 #include "winbase.h"
@@ -46,7 +41,6 @@
 #include "snmp.h"
 #include "wine/debug.h"
 #include "wine/exception.h"
-#include "wine/unicode.h"
 #include "crypt32_private.h"
 
 WINE_DEFAULT_DEBUG_CHANNEL(cryptasn);
@@ -184,7 +178,7 @@ BOOL WINAPI CRYPT_AsnEncodeSequence(DWORD dwCertEncodingType,
     BOOL ret;
     DWORD i, dataLen = 0;
 
-    TRACE("%p, %d, %08x, %p, %p, %d\n", items, cItem, dwFlags, pEncodePara,
+    TRACE("%p, %ld, %08lx, %p, %p, %ld\n", items, cItem, dwFlags, pEncodePara,
      pbEncoded, pbEncoded ? *pcbEncoded : 0);
     for (i = 0, ret = TRUE; ret && i < cItem; i++)
     {
@@ -232,7 +226,7 @@ BOOL WINAPI CRYPT_AsnEncodeSequence(DWORD dwCertEncodingType,
             }
         }
     }
-    TRACE("returning %d (%08x)\n", ret, GetLastError());
+    TRACE("returning %d (%08lx)\n", ret, GetLastError());
     return ret;
 }
 
@@ -580,7 +574,7 @@ static BOOL CRYPT_AsnEncodeCRLEntry(const CRL_ENTRY *entry,
     DWORD cItem = 2;
     BOOL ret;
 
-    TRACE("%p, %p, %d\n", entry, pbEncoded, pbEncoded ? *pcbEncoded : 0);
+    TRACE("%p, %p, %ld\n", entry, pbEncoded, pbEncoded ? *pcbEncoded : 0);
 
     if (entry->cExtension)
     {
@@ -592,7 +586,7 @@ static BOOL CRYPT_AsnEncodeCRLEntry(const CRL_ENTRY *entry,
     ret = CRYPT_AsnEncodeSequence(X509_ASN_ENCODING, items, cItem, 0, NULL,
      pbEncoded, pcbEncoded);
 
-    TRACE("returning %d (%08x)\n", ret, GetLastError());
+    TRACE("returning %d (%08lx)\n", ret, GetLastError());
     return ret;
 }
 
@@ -736,7 +730,7 @@ static BOOL CRYPT_AsnEncodeExtension(CERT_EXTENSION *ext, BYTE *pbEncoded,
     };
     DWORD cItem = 1;
 
-    TRACE("%p, %p, %d\n", ext, pbEncoded, pbEncoded ? *pcbEncoded : 0);
+    TRACE("%p, %p, %ld\n", ext, pbEncoded, pbEncoded ? *pcbEncoded : 0);
 
     if (ext->fCritical)
     {
@@ -750,7 +744,7 @@ static BOOL CRYPT_AsnEncodeExtension(CERT_EXTENSION *ext, BYTE *pbEncoded,
 
     ret = CRYPT_AsnEncodeSequence(X509_ASN_ENCODING, items, cItem, 0, NULL,
      pbEncoded, pcbEncoded);
-    TRACE("returning %d (%08x)\n", ret, GetLastError());
+    TRACE("returning %d (%08lx)\n", ret, GetLastError());
     return ret;
 }
 
@@ -1015,7 +1009,7 @@ static BOOL CRYPT_AsnEncodeUTF8String(const CERT_NAME_VALUE *value,
     if (value->Value.cbData)
         strLen = value->Value.cbData / sizeof(WCHAR);
     else if (str)
-        strLen = strlenW(str);
+        strLen = lstrlenW(str);
     else
         strLen = 0;
     encodedLen = WideCharToMultiByte(CP_UTF8, 0, str, strLen, NULL, 0, NULL,
@@ -1186,7 +1180,7 @@ static BOOL CRYPT_AsnEncodeRdnAttr(DWORD dwCertEncodingType,
     return ret;
 }
 
-static int BLOBComp(const void *l, const void *r)
+static int __cdecl BLOBComp(const void *l, const void *r)
 {
     const CRYPT_DER_BLOB *a = l, *b = r;
     int ret;
@@ -1409,7 +1403,7 @@ static BOOL WINAPI CRYPT_AsnEncodeUnicodeName(DWORD dwCertEncodingType,
         const CERT_NAME_INFO *info = pvStructInfo;
         DWORD bytesNeeded = 0, lenBytes, size, i;
 
-        TRACE("encoding name with %d RDNs\n", info->cRDN);
+        TRACE("encoding name with %ld RDNs\n", info->cRDN);
         ret = TRUE;
         for (i = 0; ret && i < info->cRDN; i++)
         {
@@ -1999,7 +1993,7 @@ static BOOL CRYPT_AsnEncodeUnicodeStringCoerce(const CERT_NAME_VALUE *value,
     if (value->Value.cbData)
         encodedLen = value->Value.cbData / sizeof(WCHAR);
     else if (str)
-        encodedLen = strlenW(str);
+        encodedLen = lstrlenW(str);
     else
         encodedLen = 0;
     CRYPT_EncodeLen(encodedLen, NULL, &lenBytes);
@@ -2036,7 +2030,7 @@ static BOOL CRYPT_AsnEncodeNumericString(const CERT_NAME_VALUE *value,
     if (value->Value.cbData)
         encodedLen = value->Value.cbData / sizeof(WCHAR);
     else if (str)
-        encodedLen = strlenW(str);
+        encodedLen = lstrlenW(str);
     else
         encodedLen = 0;
     CRYPT_EncodeLen(encodedLen, NULL, &lenBytes);
@@ -2060,7 +2054,7 @@ static BOOL CRYPT_AsnEncodeNumericString(const CERT_NAME_VALUE *value,
             ptr += lenBytes;
             for (i = 0; ret && i < encodedLen; i++)
             {
-                if (isdigitW(str[i]))
+                if ('0' <= str[i] && str[i] <= '9')
                     *ptr++ = (BYTE)str[i];
                 else
                 {
@@ -2078,9 +2072,7 @@ static BOOL CRYPT_AsnEncodeNumericString(const CERT_NAME_VALUE *value,
 
 static inline BOOL isprintableW(WCHAR wc)
 {
-    return isalnumW(wc) || isspaceW(wc) || wc == '\'' || wc == '(' ||
-     wc == ')' || wc == '+' || wc == ',' || wc == '-' || wc == '.' ||
-     wc == '/' || wc == ':' || wc == '=' || wc == '?';
+    return wc && wcschr( L"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789 '()+,-./:=?", wc );
 }
 
 static BOOL CRYPT_AsnEncodePrintableString(const CERT_NAME_VALUE *value,
@@ -2094,7 +2086,7 @@ static BOOL CRYPT_AsnEncodePrintableString(const CERT_NAME_VALUE *value,
     if (value->Value.cbData)
         encodedLen = value->Value.cbData / sizeof(WCHAR);
     else if (str)
-        encodedLen = strlenW(str);
+        encodedLen = lstrlenW(str);
     else
         encodedLen = 0;
     CRYPT_EncodeLen(encodedLen, NULL, &lenBytes);
@@ -2145,7 +2137,7 @@ static BOOL CRYPT_AsnEncodeIA5String(const CERT_NAME_VALUE *value,
     if (value->Value.cbData)
         encodedLen = value->Value.cbData / sizeof(WCHAR);
     else if (str)
-        encodedLen = strlenW(str);
+        encodedLen = lstrlenW(str);
     else
         encodedLen = 0;
     CRYPT_EncodeLen(encodedLen, NULL, &lenBytes);
@@ -2197,7 +2189,7 @@ static BOOL CRYPT_AsnEncodeUniversalString(const CERT_NAME_VALUE *value,
     if (value->Value.cbData)
         strLen = value->Value.cbData / sizeof(WCHAR);
     else if (str)
-        strLen = strlenW(str);
+        strLen = lstrlenW(str);
     else
         strLen = 0;
     CRYPT_EncodeLen(strLen * 4, NULL, &lenBytes);
@@ -2312,7 +2304,7 @@ static BOOL WINAPI CRYPT_AsnEncodeName(DWORD dwCertEncodingType,
         const CERT_NAME_INFO *info = pvStructInfo;
         DWORD bytesNeeded = 0, lenBytes, size, i;
 
-        TRACE("encoding name with %d RDNs\n", info->cRDN);
+        TRACE("encoding name with %ld RDNs\n", info->cRDN);
         ret = TRUE;
         for (i = 0; ret && i < info->cRDN; i++)
         {
@@ -2393,7 +2385,7 @@ static BOOL WINAPI CRYPT_AsnEncodeBool(DWORD dwCertEncodingType,
         *pbEncoded++ = val ? 0xff : 0;
         ret = TRUE;
     }
-    TRACE("returning %d (%08x)\n", ret, GetLastError());
+    TRACE("returning %d (%08lx)\n", ret, GetLastError());
     return ret;
 }
 
@@ -2413,15 +2405,15 @@ static BOOL WINAPI CRYPT_AsnEncodeAltNameEntry(DWORD dwCertEncodingType,
     case CERT_ALT_NAME_DNS_NAME:
     case CERT_ALT_NAME_URL:
         tag = ASN_CONTEXT | (entry->dwAltNameChoice - 1);
-        if (entry->u.pwszURL)
+        if (entry->pwszURL)
         {
             DWORD i;
 
             /* Not + 1: don't encode the NULL-terminator */
-            dataLen = lstrlenW(entry->u.pwszURL);
+            dataLen = lstrlenW(entry->pwszURL);
             for (i = 0; ret && i < dataLen; i++)
             {
-                if (entry->u.pwszURL[i] > 0x7f)
+                if (entry->pwszURL[i] > 0x7f)
                 {
                     SetLastError(CRYPT_E_INVALID_IA5_STRING);
                     ret = FALSE;
@@ -2434,23 +2426,23 @@ static BOOL WINAPI CRYPT_AsnEncodeAltNameEntry(DWORD dwCertEncodingType,
         break;
     case CERT_ALT_NAME_DIRECTORY_NAME:
         tag = ASN_CONTEXT | ASN_CONSTRUCTOR | (entry->dwAltNameChoice - 1);
-        dataLen = entry->u.DirectoryName.cbData;
+        dataLen = entry->DirectoryName.cbData;
         break;
     case CERT_ALT_NAME_IP_ADDRESS:
         tag = ASN_CONTEXT | (entry->dwAltNameChoice - 1);
-        dataLen = entry->u.IPAddress.cbData;
+        dataLen = entry->IPAddress.cbData;
         break;
     case CERT_ALT_NAME_REGISTERED_ID:
     {
         struct AsnEncodeTagSwappedItem swapped =
-         { ASN_CONTEXT | (entry->dwAltNameChoice - 1), entry->u.pszRegisteredID,
+         { ASN_CONTEXT | (entry->dwAltNameChoice - 1), entry->pszRegisteredID,
            CRYPT_AsnEncodeOid };
 
         return CRYPT_AsnEncodeSwapTag(0, NULL, &swapped, 0, NULL, pbEncoded,
          pcbEncoded);
     }
     case CERT_ALT_NAME_OTHER_NAME:
-        FIXME("name type %d unimplemented\n", entry->dwAltNameChoice);
+        FIXME("name type %ld unimplemented\n", entry->dwAltNameChoice);
         return FALSE;
     default:
         SetLastError(E_INVALIDARG);
@@ -2484,21 +2476,21 @@ static BOOL WINAPI CRYPT_AsnEncodeAltNameEntry(DWORD dwCertEncodingType,
                 DWORD i;
 
                 for (i = 0; i < dataLen; i++)
-                    *pbEncoded++ = (BYTE)entry->u.pwszURL[i];
+                    *pbEncoded++ = (BYTE)entry->pwszURL[i];
                 break;
             }
             case CERT_ALT_NAME_DIRECTORY_NAME:
-                memcpy(pbEncoded, entry->u.DirectoryName.pbData, dataLen);
+                memcpy(pbEncoded, entry->DirectoryName.pbData, dataLen);
                 break;
             case CERT_ALT_NAME_IP_ADDRESS:
-                memcpy(pbEncoded, entry->u.IPAddress.pbData, dataLen);
+                memcpy(pbEncoded, entry->IPAddress.pbData, dataLen);
                 break;
             }
             if (ret)
                 *pcbEncoded = bytesNeeded;
         }
     }
-    TRACE("returning %d (%08x)\n", ret, GetLastError());
+    TRACE("returning %d (%08lx)\n", ret, GetLastError());
     return ret;
 }
 
@@ -3136,6 +3128,52 @@ static BOOL WINAPI CRYPT_AsnEncodeCertPolicyConstraints(
     return ret;
 }
 
+static BOOL WINAPI CRYPT_AsnEncodeRsaPubKey_Bcrypt(DWORD dwCertEncodingType,
+ LPCSTR lpszStructType, const void *pvStructInfo, DWORD dwFlags,
+ PCRYPT_ENCODE_PARA pEncodePara, BYTE *pbEncoded, DWORD *pcbEncoded)
+{
+    BOOL ret;
+
+    __TRY
+    {
+        const BCRYPT_RSAKEY_BLOB *hdr = pvStructInfo;
+
+        BYTE *pubexp = (BYTE*)pvStructInfo + sizeof(BCRYPT_RSAKEY_BLOB);
+        BYTE *modulus = (BYTE*)pvStructInfo + sizeof(BCRYPT_RSAKEY_BLOB) + hdr->cbPublicExp;
+        BYTE *pubexp_be = CryptMemAlloc(hdr->cbPublicExp);
+        BYTE *modulus_be = CryptMemAlloc(hdr->cbModulus);
+        CRYPT_INTEGER_BLOB pubexp_int = { hdr->cbPublicExp, pubexp_be };
+        CRYPT_INTEGER_BLOB modulus_int = { hdr->cbModulus, modulus_be};
+
+        struct AsnEncodeSequenceItem items[] = {
+         { &modulus_int, CRYPT_AsnEncodeUnsignedInteger, 0 },
+         { &pubexp_int, CRYPT_AsnEncodeInteger, 0 },
+        };
+
+        /* CNG_RSA_PUBLIC_KEY_BLOB stores the exponent and modulus
+         * in big-endian format, so we need to convert them
+         * to little-endian format before encoding
+         */
+        CRYPT_CopyReversed(pubexp_be, pubexp, hdr->cbPublicExp);
+        CRYPT_CopyReversed(modulus_be, modulus, hdr->cbModulus);
+
+        ret = CRYPT_AsnEncodeSequence(dwCertEncodingType, items,
+         ARRAY_SIZE(items), dwFlags, pEncodePara, pbEncoded, pcbEncoded);
+
+        CryptMemFree(pubexp_be);
+        CryptMemFree(modulus_be);
+    }
+    __EXCEPT_PAGE_FAULT
+    {
+        SetLastError(STATUS_ACCESS_VIOLATION);
+        ret = FALSE;
+    }
+    __ENDTRY
+    return ret;
+
+}
+
+
 static BOOL WINAPI CRYPT_AsnEncodeRsaPubKey(DWORD dwCertEncodingType,
  LPCSTR lpszStructType, const void *pvStructInfo, DWORD dwFlags,
  PCRYPT_ENCODE_PARA pEncodePara, BYTE *pbEncoded, DWORD *pcbEncoded)
@@ -3186,7 +3224,7 @@ BOOL WINAPI CRYPT_AsnEncodeOctets(DWORD dwCertEncodingType,
         const CRYPT_DATA_BLOB *blob = pvStructInfo;
         DWORD bytesNeeded, lenBytes;
 
-        TRACE("(%d, %p), %08x, %p, %p, %d\n", blob->cbData, blob->pbData,
+        TRACE("(%ld, %p), %08lx, %p, %p, %ld\n", blob->cbData, blob->pbData,
          dwFlags, pEncodePara, pbEncoded, pbEncoded ? *pcbEncoded : 0);
 
         CRYPT_EncodeLen(blob->cbData, NULL, &lenBytes);
@@ -3217,7 +3255,7 @@ BOOL WINAPI CRYPT_AsnEncodeOctets(DWORD dwCertEncodingType,
         ret = FALSE;
     }
     __ENDTRY
-    TRACE("returning %d (%08x)\n", ret, GetLastError());
+    TRACE("returning %d (%08lx)\n", ret, GetLastError());
     return ret;
 }
 
@@ -3717,7 +3755,7 @@ static BOOL CRYPT_AsnEncodeDistPoint(const CRL_DIST_POINT *distPoint,
         break;
     case CRL_DIST_POINT_FULL_NAME:
         swapped[cSwapped].tag = ASN_CONTEXT | ASN_CONSTRUCTOR | 0;
-        swapped[cSwapped].pvStructInfo = &distPoint->DistPointName.u.FullName;
+        swapped[cSwapped].pvStructInfo = &distPoint->DistPointName.FullName;
         swapped[cSwapped].encodeFunc = CRYPT_AsnEncodeAltName;
         constructed.tag = 0;
         constructed.pvStructInfo = &swapped[cSwapped];
@@ -3932,7 +3970,7 @@ static BOOL WINAPI CRYPT_AsnEncodeIssuingDistPoint(DWORD dwCertEncodingType,
             break;
         case CRL_DIST_POINT_FULL_NAME:
             swapped[cSwapped].tag = ASN_CONTEXT | ASN_CONSTRUCTOR | 0;
-            swapped[cSwapped].pvStructInfo = &point->DistPointName.u.FullName;
+            swapped[cSwapped].pvStructInfo = &point->DistPointName.FullName;
             swapped[cSwapped].encodeFunc = CRYPT_AsnEncodeAltName;
             constructed.tag = 0;
             constructed.pvStructInfo = &swapped[cSwapped];
@@ -4235,7 +4273,7 @@ static BOOL WINAPI CRYPT_AsnEncodeCMSSignerInfo(DWORD dwCertEncodingType,
          info->SignerId.dwIdChoice != CERT_ID_KEY_IDENTIFIER)
             SetLastError(E_INVALIDARG);
         else if (info->SignerId.dwIdChoice == CERT_ID_ISSUER_SERIAL_NUMBER &&
-         !info->SignerId.u.IssuerSerialNumber.Issuer.cbData)
+         !info->SignerId.IssuerSerialNumber.Issuer.cbData)
             SetLastError(E_INVALIDARG);
         else
         {
@@ -4248,7 +4286,7 @@ static BOOL WINAPI CRYPT_AsnEncodeCMSSignerInfo(DWORD dwCertEncodingType,
             if (info->SignerId.dwIdChoice == CERT_ID_ISSUER_SERIAL_NUMBER)
             {
                 items[cItem].pvStructInfo =
-                 &info->SignerId.u.IssuerSerialNumber.Issuer;
+                 &info->SignerId.IssuerSerialNumber.Issuer;
                 items[cItem].encodeFunc =
                  CRYPT_AsnEncodeIssuerSerialNumber;
                 cItem++;
@@ -4256,7 +4294,7 @@ static BOOL WINAPI CRYPT_AsnEncodeCMSSignerInfo(DWORD dwCertEncodingType,
             else
             {
                 swapped[cSwapped].tag = ASN_CONTEXT | 0;
-                swapped[cSwapped].pvStructInfo = &info->SignerId.u.KeyId;
+                swapped[cSwapped].pvStructInfo = &info->SignerId.KeyId;
                 swapped[cSwapped].encodeFunc = CRYPT_AsnEncodeOctets;
                 items[cItem].pvStructInfo = &swapped[cSwapped];
                 items[cItem].encodeFunc = CRYPT_AsnEncodeSwapTag;
@@ -4307,30 +4345,19 @@ static BOOL WINAPI CRYPT_AsnEncodeCMSSignerInfo(DWORD dwCertEncodingType,
 BOOL CRYPT_AsnEncodeCMSSignedInfo(CRYPT_SIGNED_INFO *signedInfo, void *pvData,
  DWORD *pcbData)
 {
+    struct DERSetDescriptor digestAlgorithmsSet = { signedInfo->cSignerInfo,
+     signedInfo->rgSignerInfo, sizeof(CMSG_CMS_SIGNER_INFO),
+     offsetof(CMSG_CMS_SIGNER_INFO, HashAlgorithm),
+     CRYPT_AsnEncodeAlgorithmIdWithNullParams };
     struct AsnEncodeSequenceItem items[7] = {
      { &signedInfo->version, CRYPT_AsnEncodeInt, 0 },
+     { &digestAlgorithmsSet, CRYPT_DEREncodeItemsAsSet, 0 },
+     { &signedInfo->content, CRYPT_AsnEncodePKCSContentInfoInternal, 0 }
     };
-    struct DERSetDescriptor digestAlgorithmsSet = { 0 }, certSet = { 0 };
-    struct DERSetDescriptor crlSet = { 0 }, signerSet = { 0 };
+    struct DERSetDescriptor certSet = { 0 }, crlSet = { 0 }, signerSet = { 0 };
     struct AsnEncodeTagSwappedItem swapped[2] = { { 0 } };
-    DWORD cItem = 1, cSwapped = 0;
-    BOOL ret = TRUE;
+    DWORD cItem = 3, cSwapped = 0;
 
-    if (signedInfo->cSignerInfo)
-    {
-        digestAlgorithmsSet.cItems = signedInfo->cSignerInfo;
-        digestAlgorithmsSet.items = signedInfo->rgSignerInfo;
-        digestAlgorithmsSet.itemSize = sizeof(CMSG_CMS_SIGNER_INFO);
-        digestAlgorithmsSet.itemOffset =
-         offsetof(CMSG_CMS_SIGNER_INFO, HashAlgorithm);
-        digestAlgorithmsSet.encode = CRYPT_AsnEncodeAlgorithmIdWithNullParams;
-        items[cItem].pvStructInfo = &digestAlgorithmsSet;
-        items[cItem].encodeFunc = CRYPT_DEREncodeItemsAsSet;
-        cItem++;
-    }
-    items[cItem].pvStructInfo = &signedInfo->content;
-    items[cItem].encodeFunc = CRYPT_AsnEncodePKCSContentInfoInternal;
-    cItem++;
     if (signedInfo->cCertEncoded)
     {
         certSet.cItems = signedInfo->cCertEncoded;
@@ -4361,22 +4388,17 @@ BOOL CRYPT_AsnEncodeCMSSignedInfo(CRYPT_SIGNED_INFO *signedInfo, void *pvData,
         cSwapped++;
         cItem++;
     }
-    if (ret && signedInfo->cSignerInfo)
-    {
-        signerSet.cItems = signedInfo->cSignerInfo;
-        signerSet.items = signedInfo->rgSignerInfo;
-        signerSet.itemSize = sizeof(CMSG_CMS_SIGNER_INFO);
-        signerSet.itemOffset = 0;
-        signerSet.encode = CRYPT_AsnEncodeCMSSignerInfo;
-        items[cItem].pvStructInfo = &signerSet;
-        items[cItem].encodeFunc = CRYPT_DEREncodeItemsAsSet;
-        cItem++;
-    }
-    if (ret)
-        ret = CRYPT_AsnEncodeSequence(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING,
-         items, cItem, 0, NULL, pvData, pcbData);
+    signerSet.cItems = signedInfo->cSignerInfo;
+    signerSet.items = signedInfo->rgSignerInfo;
+    signerSet.itemSize = sizeof(CMSG_CMS_SIGNER_INFO);
+    signerSet.itemOffset = 0;
+    signerSet.encode = CRYPT_AsnEncodeCMSSignerInfo;
+    items[cItem].pvStructInfo = &signerSet;
+    items[cItem].encodeFunc = CRYPT_DEREncodeItemsAsSet;
+    cItem++;
 
-    return ret;
+    return CRYPT_AsnEncodeSequence(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING,
+     items, cItem, 0, NULL, pvData, pcbData);
 }
 
 static BOOL WINAPI CRYPT_AsnEncodeRecipientInfo(DWORD dwCertEncodingType,
@@ -4386,7 +4408,7 @@ static BOOL WINAPI CRYPT_AsnEncodeRecipientInfo(DWORD dwCertEncodingType,
     const CMSG_KEY_TRANS_RECIPIENT_INFO *info = pvStructInfo;
     struct AsnEncodeSequenceItem items[] = {
      { &info->dwVersion, CRYPT_AsnEncodeInt, 0 },
-     { &info->RecipientId.u.IssuerSerialNumber,
+     { &info->RecipientId.IssuerSerialNumber,
        CRYPT_AsnEncodeIssuerSerialNumber, 0 },
      { &info->KeyEncryptionAlgorithm,
        CRYPT_AsnEncodeAlgorithmIdWithNullParams, 0 },
@@ -4430,6 +4452,225 @@ BOOL CRYPT_AsnEncodePKCSEnvelopedData(const CRYPT_ENVELOPED_DATA *envelopedData,
 
     return CRYPT_AsnEncodeSequence(X509_ASN_ENCODING, items,
      ARRAY_SIZE(items), 0, NULL, pvData, pcbData);
+}
+
+static BOOL WINAPI CRYPT_AsnEncodeCertId(DWORD dwCertEncodingType,
+ LPCSTR lpszStructType, const void *pvStructInfo, DWORD dwFlags,
+ PCRYPT_ENCODE_PARA pEncodePara, BYTE *pbEncoded, DWORD *pcbEncoded)
+{
+    BOOL ret;
+
+    __TRY
+    {
+        const OCSP_CERT_ID *id = pvStructInfo;
+        struct AsnEncodeSequenceItem items[] = {
+         { &id->HashAlgorithm, CRYPT_AsnEncodeAlgorithmIdWithNullParams, 0 },
+         { &id->IssuerNameHash, CRYPT_AsnEncodeOctets, 0 },
+         { &id->IssuerKeyHash, CRYPT_AsnEncodeOctets, 0 },
+         { &id->SerialNumber, CRYPT_AsnEncodeInteger, 0 },
+        };
+
+        ret = CRYPT_AsnEncodeSequence(dwCertEncodingType, items,
+         ARRAY_SIZE(items), dwFlags, pEncodePara, pbEncoded, pcbEncoded);
+    }
+    __EXCEPT_PAGE_FAULT
+    {
+        SetLastError(STATUS_ACCESS_VIOLATION);
+        ret = FALSE;
+    }
+    __ENDTRY
+    return ret;
+}
+
+static BOOL CRYPT_AsnEncodeOCSPRequestEntry(DWORD dwCertEncodingType,
+ LPCSTR lpszStructType, const void *pvStructInfo, DWORD dwFlags,
+ PCRYPT_ENCODE_PARA pEncodePara, BYTE *pbEncoded, DWORD *pcbEncoded)
+{
+    BOOL ret;
+
+    __TRY
+    {
+        const OCSP_REQUEST_ENTRY *info = pvStructInfo;
+        struct AsnEncodeSequenceItem items[] = {
+         { &info->CertId, CRYPT_AsnEncodeCertId, 0 },
+        };
+
+        if (info->cExtension)
+        {
+            FIXME("extensions not supported\n");
+            SetLastError(E_INVALIDARG);
+            ret = FALSE;
+        }
+        else
+        {
+            ret = CRYPT_AsnEncodeSequence(dwCertEncodingType, items,
+             ARRAY_SIZE(items), dwFlags, pEncodePara, pbEncoded, pcbEncoded);
+        }
+    }
+    __EXCEPT_PAGE_FAULT
+    {
+        SetLastError(STATUS_ACCESS_VIOLATION);
+        ret = FALSE;
+    }
+    __ENDTRY
+    return ret;
+}
+
+struct ocsp_request_list
+{
+    DWORD count;
+    OCSP_REQUEST_ENTRY *entry;
+};
+
+static BOOL WINAPI CRYPT_AsnEncodeOCSPRequestEntries(DWORD dwCertEncodingType,
+ LPCSTR lpszStructType, const void *pvStructInfo, DWORD dwFlags,
+ PCRYPT_ENCODE_PARA pEncodePara, BYTE *pbEncoded, DWORD *pcbEncoded)
+{
+    BOOL ret;
+
+    __TRY
+    {
+        DWORD bytesNeeded, dataLen, lenBytes, i;
+        const struct ocsp_request_list *list = pvStructInfo;
+
+        ret = TRUE;
+        for (i = 0, dataLen = 0; ret && i < list->count; i++)
+        {
+            DWORD size;
+            ret = CRYPT_AsnEncodeOCSPRequestEntry(dwCertEncodingType, lpszStructType, &list->entry[i],
+             dwFlags, pEncodePara, NULL, &size);
+            if (ret)
+                dataLen += size;
+        }
+        if (ret)
+        {
+            CRYPT_EncodeLen(dataLen, NULL, &lenBytes);
+            bytesNeeded = 1 + lenBytes + dataLen;
+            if (!pbEncoded)
+                *pcbEncoded = bytesNeeded;
+            else
+            {
+                if ((ret = CRYPT_EncodeEnsureSpace(dwFlags, pEncodePara,
+                 pbEncoded, pcbEncoded, bytesNeeded)))
+                {
+                    BYTE *out;
+
+                    if (dwFlags & CRYPT_ENCODE_ALLOC_FLAG)
+                        pbEncoded = *(BYTE **)pbEncoded;
+                    out = pbEncoded;
+                    *out++ = ASN_SEQUENCEOF;
+                    CRYPT_EncodeLen(dataLen, out, &lenBytes);
+                    out += lenBytes;
+                    for (i = 0; i < list->count; i++)
+                    {
+                        DWORD size = dataLen;
+
+                        ret = CRYPT_AsnEncodeOCSPRequestEntry(dwCertEncodingType, lpszStructType,
+                         &list->entry[i], dwFlags, pEncodePara, out, &size);
+                        out += size;
+                        dataLen -= size;
+                    }
+
+                    if (!ret && (dwFlags & CRYPT_ENCODE_ALLOC_FLAG))
+                        CRYPT_FreeSpace(pEncodePara, pbEncoded);
+                }
+            }
+        }
+    }
+    __EXCEPT_PAGE_FAULT
+    {
+        SetLastError(STATUS_ACCESS_VIOLATION);
+        ret = FALSE;
+    }
+    __ENDTRY
+    return ret;
+}
+
+static BOOL WINAPI CRYPT_AsnEncodeOCSPRequest(DWORD dwCertEncodingType,
+ LPCSTR lpszStructType, const void *pvStructInfo, DWORD dwFlags,
+ PCRYPT_ENCODE_PARA pEncodePara, BYTE *pbEncoded, DWORD *pcbEncoded)
+{
+    BOOL ret;
+
+    __TRY
+    {
+        const OCSP_REQUEST_INFO *info = pvStructInfo;
+
+        if (info->dwVersion != OCSP_REQUEST_V1)
+        {
+            FIXME("version %lu not supported\n", info->dwVersion);
+            SetLastError(E_INVALIDARG);
+            ret = FALSE;
+        }
+        else
+        {
+            if (info->cExtension)
+            {
+                FIXME("extensions not supported\n");
+                SetLastError(E_INVALIDARG);
+                ret = FALSE;
+            }
+            else
+            {
+                struct AsnConstructedItem name;
+                struct AsnEncodeSequenceItem items[2];
+                DWORD count = 0;
+
+                if (info->pRequestorName)
+                {
+                    name.tag = 1;
+                    name.pvStructInfo = info->pRequestorName;
+                    name.encodeFunc = CRYPT_AsnEncodeAltNameEntry;
+                    items[count].pvStructInfo = &name;
+                    items[count].encodeFunc = CRYPT_AsnEncodeConstructed;
+                    count++;
+                }
+                if (info->cRequestEntry)
+                {
+                    items[count].pvStructInfo = &info->cRequestEntry;
+                    items[count].encodeFunc = CRYPT_AsnEncodeOCSPRequestEntries;
+                    count++;
+                }
+
+                ret = CRYPT_AsnEncodeSequence(dwCertEncodingType, items,
+                 count, dwFlags, pEncodePara, pbEncoded, pcbEncoded);
+            }
+        }
+    }
+    __EXCEPT_PAGE_FAULT
+    {
+        SetLastError(STATUS_ACCESS_VIOLATION);
+        ret = FALSE;
+    }
+    __ENDTRY
+    return ret;
+}
+
+static BOOL WINAPI CRYPT_AsnEncodeOCSPSignedRequest(DWORD dwCertEncodingType,
+ LPCSTR lpszStructType, const void *pvStructInfo, DWORD dwFlags,
+ PCRYPT_ENCODE_PARA pEncodePara, BYTE *pbEncoded, DWORD *pcbEncoded)
+{
+    BOOL ret;
+
+    __TRY
+    {
+        const OCSP_SIGNED_REQUEST_INFO *info = pvStructInfo;
+        struct AsnEncodeSequenceItem items[] = {
+         { &info->ToBeSigned, CRYPT_CopyEncodedBlob, 0 },
+        };
+
+        if (info->pOptionalSignatureInfo) FIXME("pOptionalSignatureInfo not supported\n");
+
+        ret = CRYPT_AsnEncodeSequence(dwCertEncodingType, items,
+         ARRAY_SIZE(items), dwFlags, pEncodePara, pbEncoded, pcbEncoded);
+    }
+    __EXCEPT_PAGE_FAULT
+    {
+        SetLastError(STATUS_ACCESS_VIOLATION);
+        ret = FALSE;
+    }
+    __ENDTRY
+    return ret;
 }
 
 static CryptEncodeObjectExFunc CRYPT_GetBuiltinEncoder(DWORD dwCertEncodingType,
@@ -4569,6 +4810,17 @@ static CryptEncodeObjectExFunc CRYPT_GetBuiltinEncoder(DWORD dwCertEncodingType,
         case LOWORD(CMS_SIGNER_INFO):
             encodeFunc = CRYPT_AsnEncodeCMSSignerInfo;
             break;
+        case LOWORD(CNG_RSA_PUBLIC_KEY_BLOB):
+            encodeFunc = CRYPT_AsnEncodeRsaPubKey_Bcrypt;
+            break;
+        case LOWORD(OCSP_REQUEST):
+            encodeFunc = CRYPT_AsnEncodeOCSPRequest;
+            break;
+        case LOWORD(OCSP_SIGNED_REQUEST):
+            encodeFunc = CRYPT_AsnEncodeOCSPSignedRequest;
+            break;
+        default:
+            FIXME("Unimplemented encoder for lpszStructType OID %d\n", LOWORD(lpszStructType));
         }
     }
     else if (!strcmp(lpszStructType, szOID_CERT_EXTENSIONS))
@@ -4623,6 +4875,8 @@ static CryptEncodeObjectExFunc CRYPT_GetBuiltinEncoder(DWORD dwCertEncodingType,
         encodeFunc = CRYPT_AsnEncodePolicyQualifierUserNotice;
     else if (!strcmp(lpszStructType, szOID_CTL))
         encodeFunc = CRYPT_AsnEncodeCTL;
+    else
+        FIXME("Unsupported encoder for lpszStructType %s\n", lpszStructType);
     return encodeFunc;
 }
 
@@ -4660,7 +4914,7 @@ BOOL WINAPI CryptEncodeObject(DWORD dwCertEncodingType, LPCSTR lpszStructType,
     CryptEncodeObjectFunc pCryptEncodeObject = NULL;
     CryptEncodeObjectExFunc pCryptEncodeObjectEx = NULL;
 
-    TRACE_(crypt)("(0x%08x, %s, %p, %p, %p)\n", dwCertEncodingType,
+    TRACE_(crypt)("(0x%08lx, %s, %p, %p, %p)\n", dwCertEncodingType,
      debugstr_a(lpszStructType), pvStructInfo, pbEncoded,
      pcbEncoded);
 
@@ -4701,7 +4955,7 @@ BOOL WINAPI CryptEncodeObjectEx(DWORD dwCertEncodingType, LPCSTR lpszStructType,
     HCRYPTOIDFUNCADDR hFunc = NULL;
     CryptEncodeObjectExFunc encodeFunc = NULL;
 
-    TRACE_(crypt)("(0x%08x, %s, %p, 0x%08x, %p, %p, %p)\n", dwCertEncodingType,
+    TRACE_(crypt)("(0x%08lx, %s, %p, 0x%08lx, %p, %p, %p)\n", dwCertEncodingType,
      debugstr_a(lpszStructType), pvStructInfo, dwFlags, pEncodePara,
      pvEncoded, pcbEncoded);
 
@@ -4758,20 +5012,6 @@ BOOL WINAPI CryptEncodeObjectEx(DWORD dwCertEncodingType, LPCSTR lpszStructType,
     return ret;
 }
 
-BOOL WINAPI PFXExportCertStore(HCERTSTORE hStore, CRYPT_DATA_BLOB *pPFX,
- LPCWSTR szPassword, DWORD dwFlags)
-{
-    return PFXExportCertStoreEx(hStore, pPFX, szPassword, NULL, dwFlags);
-}
-
-BOOL WINAPI PFXExportCertStoreEx(HCERTSTORE hStore, CRYPT_DATA_BLOB *pPFX,
- LPCWSTR szPassword, void *pvReserved, DWORD dwFlags)
-{
-    FIXME_(crypt)("(%p, %p, %p, %p, %08x): stub\n", hStore, pPFX, szPassword,
-     pvReserved, dwFlags);
-    return FALSE;
-}
-
 BOOL WINAPI CryptExportPublicKeyInfo(HCRYPTPROV_OR_NCRYPT_KEY_HANDLE hCryptProv, DWORD dwKeySpec,
  DWORD dwCertEncodingType, PCERT_PUBLIC_KEY_INFO pInfo, DWORD *pcbInfo)
 {
@@ -4791,7 +5031,7 @@ static BOOL WINAPI CRYPT_ExportPublicKeyInfoEx(HCRYPTPROV_OR_NCRYPT_KEY_HANDLE h
     HCRYPTKEY key;
     static CHAR rsa_oid[] = szOID_RSA_RSA;
 
-    TRACE_(crypt)("(%08lx, %d, %08x, %s, %08x, %p, %p, %d)\n", hCryptProv,
+    TRACE_(crypt)("(%08Ix, %ld, %08lx, %s, %08lx, %p, %p, %ld)\n", hCryptProv,
      dwKeySpec, dwCertEncodingType, debugstr_a(pszPublicKeyObjId), dwFlags,
      pvAuxInfo, pInfo, pInfo ? *pcbInfo : 0);
 
@@ -4940,7 +5180,7 @@ BOOL WINAPI CryptExportPublicKeyInfoEx(HCRYPTPROV_OR_NCRYPT_KEY_HANDLE hCryptPro
     ExportPublicKeyInfoExFunc exportFunc = NULL;
     HCRYPTOIDFUNCADDR hFunc = NULL;
 
-    TRACE_(crypt)("(%08lx, %d, %08x, %s, %08x, %p, %p, %d)\n", hCryptProv,
+    TRACE_(crypt)("(%08Ix, %ld, %08lx, %s, %08lx, %p, %p, %ld)\n", hCryptProv,
      dwKeySpec, dwCertEncodingType, debugstr_a(pszPublicKeyObjId), dwFlags,
      pvAuxInfo, pInfo, pInfo ? *pcbInfo : 0);
 
@@ -4989,7 +5229,7 @@ static BOOL WINAPI CRYPT_ImportPublicKeyInfoEx(HCRYPTPROV hCryptProv,
     DWORD pubKeySize;
     LPBYTE pubKey;
 
-    TRACE_(crypt)("(%08lx, %08x, %p, %08x, %08x, %p, %p)\n", hCryptProv,
+    TRACE_(crypt)("(%08Ix, %08lx, %p, %08x, %08lx, %p, %p)\n", hCryptProv,
      dwCertEncodingType, pInfo, aiKeyAlg, dwFlags, pvAuxInfo, phKey);
 
     if (!set)
@@ -5050,7 +5290,7 @@ BOOL WINAPI CryptImportPublicKeyInfoEx(HCRYPTPROV hCryptProv,
     ImportPublicKeyInfoExFunc importFunc = NULL;
     HCRYPTOIDFUNCADDR hFunc = NULL;
 
-    TRACE_(crypt)("(%08lx, %08x, %p, %08x, %08x, %p, %p)\n", hCryptProv,
+    TRACE_(crypt)("(%08Ix, %08lx, %p, %08x, %08lx, %p, %p)\n", hCryptProv,
      dwCertEncodingType, pInfo, aiKeyAlg, dwFlags, pvAuxInfo, phKey);
 
     if (!set)
@@ -5064,4 +5304,17 @@ BOOL WINAPI CryptImportPublicKeyInfoEx(HCRYPTPROV hCryptProv,
     if (hFunc)
         CryptFreeOIDFunctionAddress(hFunc, 0);
     return ret;
+}
+
+BOOL WINAPI CryptImportPublicKeyInfoEx2(DWORD dwCertEncodingType,
+ PCERT_PUBLIC_KEY_INFO pInfo, DWORD dwFlags, void *pvAuxInfo,
+ BCRYPT_KEY_HANDLE *phKey)
+{
+    TRACE_(crypt)("(%ld, %p, %08lx, %p, %p)\n", dwCertEncodingType, pInfo,
+     dwFlags, pvAuxInfo, phKey);
+
+    if (dwFlags)
+        FIXME("flags %#lx ignored\n", dwFlags);
+
+    return CNG_ImportPubKey(pInfo, phKey);
 }

--- a/dll/win32/crypt32/filestore.c
+++ b/dll/win32/crypt32/filestore.c
@@ -21,7 +21,6 @@
 #include "wincrypt.h"
 #include "winnls.h"
 #include "wine/debug.h"
-#include "wine/unicode.h"
 #include "crypt32_private.h"
 
 WINE_DEFAULT_DEBUG_CHANNEL(crypt);
@@ -39,7 +38,7 @@ static void WINAPI CRYPT_FileCloseStore(HCERTSTORE hCertStore, DWORD dwFlags)
 {
     WINE_FILESTOREINFO *store = hCertStore;
 
-    TRACE("(%p, %08x)\n", store, dwFlags);
+    TRACE("(%p, %08lx)\n", store, dwFlags);
     if (store->dirty)
         CertSaveStore(store->memStore, X509_ASN_ENCODING | PKCS_7_ASN_ENCODING,
          store->type, CERT_STORE_SAVE_TO_FILE, store->file, 0);
@@ -52,7 +51,7 @@ static BOOL WINAPI CRYPT_FileWriteCert(HCERTSTORE hCertStore,
 {
     WINE_FILESTOREINFO *store = hCertStore;
 
-    TRACE("(%p, %p, %d)\n", hCertStore, cert, dwFlags);
+    TRACE("(%p, %p, %ld)\n", hCertStore, cert, dwFlags);
     store->dirty = TRUE;
     return TRUE;
 }
@@ -62,7 +61,7 @@ static BOOL WINAPI CRYPT_FileDeleteCert(HCERTSTORE hCertStore,
 {
     WINE_FILESTOREINFO *store = hCertStore;
 
-    TRACE("(%p, %p, %08x)\n", hCertStore, pCertContext, dwFlags);
+    TRACE("(%p, %p, %08lx)\n", hCertStore, pCertContext, dwFlags);
     store->dirty = TRUE;
     return TRUE;
 }
@@ -72,7 +71,7 @@ static BOOL WINAPI CRYPT_FileWriteCRL(HCERTSTORE hCertStore,
 {
     WINE_FILESTOREINFO *store = hCertStore;
 
-    TRACE("(%p, %p, %d)\n", hCertStore, crl, dwFlags);
+    TRACE("(%p, %p, %ld)\n", hCertStore, crl, dwFlags);
     store->dirty = TRUE;
     return TRUE;
 }
@@ -82,7 +81,7 @@ static BOOL WINAPI CRYPT_FileDeleteCRL(HCERTSTORE hCertStore,
 {
     WINE_FILESTOREINFO *store = hCertStore;
 
-    TRACE("(%p, %p, %08x)\n", hCertStore, pCrlContext, dwFlags);
+    TRACE("(%p, %p, %08lx)\n", hCertStore, pCrlContext, dwFlags);
     store->dirty = TRUE;
     return TRUE;
 }
@@ -92,7 +91,7 @@ static BOOL WINAPI CRYPT_FileWriteCTL(HCERTSTORE hCertStore,
 {
     WINE_FILESTOREINFO *store = hCertStore;
 
-    TRACE("(%p, %p, %d)\n", hCertStore, ctl, dwFlags);
+    TRACE("(%p, %p, %ld)\n", hCertStore, ctl, dwFlags);
     store->dirty = TRUE;
     return TRUE;
 }
@@ -102,7 +101,7 @@ static BOOL WINAPI CRYPT_FileDeleteCTL(HCERTSTORE hCertStore,
 {
     WINE_FILESTOREINFO *store = hCertStore;
 
-    TRACE("(%p, %p, %08x)\n", hCertStore, pCtlContext, dwFlags);
+    TRACE("(%p, %p, %08lx)\n", hCertStore, pCtlContext, dwFlags);
     store->dirty = TRUE;
     return TRUE;
 }
@@ -134,7 +133,7 @@ static BOOL WINAPI CRYPT_FileControl(HCERTSTORE hCertStore, DWORD dwFlags,
     WINE_FILESTOREINFO *store = hCertStore;
     BOOL ret;
 
-    TRACE("(%p, %08x, %d, %p)\n", hCertStore, dwFlags, dwCtrlType,
+    TRACE("(%p, %08lx, %ld, %p)\n", hCertStore, dwFlags, dwCtrlType,
      pvCtrlPara);
 
     switch (dwCtrlType)
@@ -174,7 +173,7 @@ static BOOL WINAPI CRYPT_FileControl(HCERTSTORE hCertStore, DWORD dwFlags,
         }
         else
         {
-            WARN("unknown type %d\n", store->type);
+            WARN("unknown type %ld\n", store->type);
             ret = FALSE;
         }
         break;
@@ -192,7 +191,7 @@ static BOOL WINAPI CRYPT_FileControl(HCERTSTORE hCertStore, DWORD dwFlags,
             ret = TRUE;
         break;
     default:
-        FIXME("%d: stub\n", dwCtrlType);
+        FIXME("%ld: stub\n", dwCtrlType);
         ret = FALSE;
     }
     return ret;
@@ -245,7 +244,7 @@ WINECRYPT_CERTSTORE *CRYPT_FileOpenStore(HCRYPTPROV hCryptProv, DWORD dwFlags,
     WINECRYPT_CERTSTORE *store = NULL;
     HANDLE file = (HANDLE)pvPara;
 
-    TRACE("(%ld, %08x, %p)\n", hCryptProv, dwFlags, pvPara);
+    TRACE("(%Id, %08lx, %p)\n", hCryptProv, dwFlags, pvPara);
 
     if (!pvPara)
     {
@@ -297,7 +296,7 @@ WINECRYPT_CERTSTORE *CRYPT_FileNameOpenStoreW(HCRYPTPROV hCryptProv,
     DWORD access, create;
     HANDLE file;
 
-    TRACE("(%ld, %08x, %s)\n", hCryptProv, dwFlags, debugstr_w(fileName));
+    TRACE("(%Id, %08lx, %s)\n", hCryptProv, dwFlags, debugstr_w(fileName));
 
     if (!fileName)
     {
@@ -354,14 +353,12 @@ WINECRYPT_CERTSTORE *CRYPT_FileNameOpenStoreW(HCRYPTPROV hCryptProv,
         }
         else
         {
-            static const WCHAR spc[] = { 's','p','c',0 };
-            static const WCHAR p7c[] = { 'p','7','c',0 };
-            LPCWSTR ext = strrchrW(fileName, '.');
+            LPCWSTR ext = wcsrchr(fileName, '.');
 
             if (ext)
             {
                 ext++;
-                if (!lstrcmpiW(ext, spc) || !lstrcmpiW(ext, p7c))
+                if (!lstrcmpiW(ext, L"spc") || !lstrcmpiW(ext, L"p7c"))
                     type = CERT_STORE_SAVE_AS_PKCS7;
             }
             if (!type)
@@ -386,7 +383,7 @@ WINECRYPT_CERTSTORE *CRYPT_FileNameOpenStoreA(HCRYPTPROV hCryptProv,
     int len;
     WINECRYPT_CERTSTORE *ret = NULL;
 
-    TRACE("(%ld, %08x, %s)\n", hCryptProv, dwFlags,
+    TRACE("(%Id, %08lx, %s)\n", hCryptProv, dwFlags,
      debugstr_a(pvPara));
 
     if (!pvPara)

--- a/dll/win32/crypt32/message.c
+++ b/dll/win32/crypt32/message.c
@@ -31,7 +31,7 @@ HCERTSTORE WINAPI CryptGetMessageCertificates(DWORD dwMsgAndCertEncodingType,
 {
     CRYPT_DATA_BLOB blob = { cbSignedBlob, (LPBYTE)pbSignedBlob };
 
-    TRACE("(%08x, %ld, %d08x %p, %d)\n", dwMsgAndCertEncodingType, hCryptProv,
+    TRACE("(%08lx, %Id, %ld08x %p, %ld)\n", dwMsgAndCertEncodingType, hCryptProv,
      dwFlags, pbSignedBlob, cbSignedBlob);
 
     return CertOpenStore(CERT_STORE_PROV_PKCS7, dwMsgAndCertEncodingType,
@@ -44,7 +44,7 @@ LONG WINAPI CryptGetMessageSignerCount(DWORD dwMsgEncodingType,
     HCRYPTMSG msg;
     LONG count = -1;
 
-    TRACE("(%08x, %p, %d)\n", dwMsgEncodingType, pbSignedBlob, cbSignedBlob);
+    TRACE("(%08lx, %p, %ld)\n", dwMsgEncodingType, pbSignedBlob, cbSignedBlob);
 
     msg = CryptMsgOpenToDecode(dwMsgEncodingType, 0, 0, 0, NULL, NULL);
     if (msg)
@@ -114,7 +114,7 @@ BOOL WINAPI CryptVerifyDetachedMessageSignature(
     BOOL ret = FALSE;
     HCRYPTMSG msg;
 
-    TRACE("(%p, %d, %p, %d, %d, %p, %p, %p)\n", pVerifyPara, dwSignerIndex,
+    TRACE("(%p, %ld, %p, %ld, %ld, %p, %p, %p)\n", pVerifyPara, dwSignerIndex,
      pbDetachedSignBlob, cbDetachedSignBlob, cToBeSigned, rgpbToBeSigned,
      rgcbToBeSigned, ppSignerCert);
 
@@ -188,7 +188,7 @@ BOOL WINAPI CryptVerifyMessageSignature(PCRYPT_VERIFY_MESSAGE_PARA pVerifyPara,
     BOOL ret = FALSE;
     HCRYPTMSG msg;
 
-    TRACE("(%p, %d, %p, %d, %p, %p, %p)\n",
+    TRACE("(%p, %ld, %p, %ld, %p, %p, %p)\n",
      pVerifyPara, dwSignerIndex, pbSignedBlob, cbSignedBlob,
      pbDecoded, pcbDecoded, ppSignerCert);
 
@@ -262,7 +262,7 @@ BOOL WINAPI CryptHashMessage(PCRYPT_HASH_MESSAGE_PARA pHashPara,
     HCRYPTMSG msg;
     CMSG_HASHED_ENCODE_INFO info;
 
-    TRACE("(%p, %d, %d, %p, %p, %p, %p, %p, %p)\n", pHashPara, fDetachedHash,
+    TRACE("(%p, %d, %ld, %p, %p, %p, %p, %p, %p)\n", pHashPara, fDetachedHash,
      cToBeHashed, rgpbToBeHashed, rgcbToBeHashed, pbHashedBlob, pcbHashedBlob,
      pbComputedHash, pcbComputedHash);
 
@@ -314,7 +314,7 @@ BOOL WINAPI CryptVerifyDetachedMessageHash(PCRYPT_HASH_MESSAGE_PARA pHashPara,
     HCRYPTMSG msg;
     BOOL ret = FALSE;
 
-    TRACE("(%p, %p, %d, %d, %p, %p, %p, %p)\n", pHashPara, pbDetachedHashBlob,
+    TRACE("(%p, %p, %ld, %ld, %p, %p, %p, %p)\n", pHashPara, pbDetachedHashBlob,
      cbDetachedHashBlob, cToBeHashed, rgpbToBeHashed, rgcbToBeHashed,
      pbComputedHash, pcbComputedHash);
 
@@ -368,7 +368,7 @@ BOOL WINAPI CryptVerifyMessageHash(PCRYPT_HASH_MESSAGE_PARA pHashPara,
     HCRYPTMSG msg;
     BOOL ret = FALSE;
 
-    TRACE("(%p, %p, %d, %p, %p, %p, %p)\n", pHashPara, pbHashedBlob,
+    TRACE("(%p, %p, %ld, %p, %p, %p, %p)\n", pHashPara, pbHashedBlob,
      cbHashedBlob, pbToBeHashed, pcbToBeHashed, pbComputedHash,
      pcbComputedHash);
 
@@ -416,7 +416,7 @@ BOOL WINAPI CryptSignMessage(PCRYPT_SIGN_MESSAGE_PARA pSignPara,
     CMSG_SIGNER_ENCODE_INFO signer;
     HCRYPTMSG msg = 0;
 
-    TRACE("(%p, %d, %d, %p, %p, %p, %p)\n", pSignPara, fDetachedSignature,
+    TRACE("(%p, %d, %ld, %p, %p, %p, %p)\n", pSignPara, fDetachedSignature,
      cToBeSigned, rgpbToBeSigned, rgcbToBeSigned, pbSignedBlob, pcbSignedBlob);
 
     if (pSignPara->cbSize != sizeof(CRYPT_SIGN_MESSAGE_PARA) ||
@@ -529,7 +529,7 @@ BOOL WINAPI CryptEncryptMessage(PCRYPT_ENCRYPT_MESSAGE_PARA pEncryptPara,
     CMSG_ENVELOPED_ENCODE_INFO envelopedInfo;
     HCRYPTMSG msg = 0;
 
-    TRACE("(%p, %d, %p, %p, %d, %p, %p)\n", pEncryptPara, cRecipientCert,
+    TRACE("(%p, %ld, %p, %p, %ld, %p, %p)\n", pEncryptPara, cRecipientCert,
      rgpRecipientCert, pbToBeEncrypted, cbToBeEncrypted, pbEncryptedBlob,
      pcbEncryptedBlob);
 

--- a/dll/win32/crypt32/oid.c
+++ b/dll/win32/crypt32/oid.c
@@ -18,20 +18,16 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-#include "config.h"
-#include "wine/port.h"
-
 #include <stdio.h>
 #include <stdarg.h>
-#ifdef __REACTOS__
 #include <stdlib.h>
-#endif
-#define NONAMELESSUNION
+
 #include "windef.h"
 #include "winbase.h"
 #define CRYPT_OID_INFO_HAS_EXTRA_FIELDS
 #include "wincrypt.h"
 #include "winreg.h"
+#include "winternl.h"
 #include "winuser.h"
 #include "wine/debug.h"
 #include "wine/list.h"
@@ -39,8 +35,6 @@
 #include "cryptres.h"
 
 WINE_DEFAULT_DEBUG_CHANNEL(crypt);
-
-static const WCHAR DllW[] = { 'D','l','l',0 };
 
 static CRITICAL_SECTION funcSetCS;
 static CRITICAL_SECTION_DEBUG funcSetCSDebug =
@@ -68,21 +62,16 @@ struct OIDFunction
     struct list next;
 };
 
-static const WCHAR ROOT[] = {'R','O','O','T',0};
-static const WCHAR MY[] = {'M','Y',0};
-static const WCHAR CA[] = {'C','A',0};
-static const WCHAR ADDRESSBOOK[] = {'A','D','D','R','E','S','S','B','O','O','K',0};
-static const WCHAR TRUSTEDPUBLISHER[] = {'T','r','u','s','t','e','d','P','u','b','l','i','s','h','e','r',0};
-static const WCHAR DISALLOWED[] = {'D','i','s','a','l','l','o','w','e','d',0};
-static const LPCWSTR LocalizedKeys[] = {ROOT,MY,CA,ADDRESSBOOK,TRUSTEDPUBLISHER,DISALLOWED};
+static const LPCWSTR LocalizedKeys[] =
+{
+    L"ROOT",
+    L"MY",
+    L"CA",
+    L"ADDRESSBOOK",
+    L"TrustedPublisher",
+    L"Disallowed"
+};
 static WCHAR LocalizedNames[ARRAY_SIZE(LocalizedKeys)][256];
-
-static const WCHAR nameW[] = { 'N','a','m','e',0 };
-static const WCHAR algidW[] = { 'A','l','g','i','d',0 };
-static const WCHAR extraW[] = { 'E','x','t','r','a','I','n','f','o',0 };
-static const WCHAR cngalgidW[] = { 'C','N','G','A','l','g','i','d',0 };
-static const WCHAR cngextraalgidW[] = { 'C','N','G','E','x','t','r','a','A','l','g','i','d',0 };
-static const WCHAR flagsW[] = { 'F','l','a','g','s',0 };
 
 static void free_function_sets(void)
 {
@@ -116,12 +105,12 @@ HCRYPTOIDFUNCSET WINAPI CryptInitOIDFunctionSet(LPCSTR pszFuncName,
 {
     struct OIDFunctionSet *cursor, *ret = NULL;
 
-    TRACE("(%s, %x)\n", debugstr_a(pszFuncName), dwFlags);
+    TRACE("(%s, %lx)\n", debugstr_a(pszFuncName), dwFlags);
 
     EnterCriticalSection(&funcSetCS);
     LIST_FOR_EACH_ENTRY(cursor, &funcSets, struct OIDFunctionSet, next)
     {
-        if (!strcasecmp(pszFuncName, cursor->name))
+        if (!stricmp(pszFuncName, cursor->name))
         {
             ret = cursor;
             break;
@@ -136,7 +125,7 @@ HCRYPTOIDFUNCSET WINAPI CryptInitOIDFunctionSet(LPCSTR pszFuncName,
             ret->name = CryptMemAlloc(strlen(pszFuncName) + 1);
             if (ret->name)
             {
-                InitializeCriticalSection(&ret->cs);
+                InitializeCriticalSectionEx(&ret->cs, 0, RTL_CRITICAL_SECTION_FLAG_FORCE_DEBUG_INFO);
                 ret->cs.DebugInfo->Spare[0] = (DWORD_PTR)(__FILE__ ": OIDFunctionSet.cs");
                 list_init(&ret->functions);
                 strcpy(ret->name, pszFuncName);
@@ -158,7 +147,7 @@ static char *CRYPT_GetKeyName(DWORD dwEncodingType, LPCSTR pszFuncName,
  LPCSTR pszOID)
 {
     static const char szEncodingTypeFmt[] =
-     "Software\\Microsoft\\Cryptography\\OID\\EncodingType %d\\%s\\%s";
+     "Software\\Microsoft\\Cryptography\\OID\\EncodingType %ld\\%s\\%s";
     UINT len;
     char numericOID[7]; /* enough for "#65535" */
     const char *oid;
@@ -193,13 +182,12 @@ static char *CRYPT_GetKeyName(DWORD dwEncodingType, LPCSTR pszFuncName,
 BOOL WINAPI CryptGetDefaultOIDDllList(HCRYPTOIDFUNCSET hFuncSet,
  DWORD dwEncodingType, LPWSTR pwszDllList, DWORD *pcchDllList)
 {
-    BOOL ret = TRUE;
     struct OIDFunctionSet *set = hFuncSet;
     char *keyName;
     HKEY key;
     LSTATUS rc;
 
-    TRACE("(%p, %d, %p, %p)\n", hFuncSet, dwEncodingType, pwszDllList,
+    TRACE("(%p, %ld, %p, %p)\n", hFuncSet, dwEncodingType, pwszDllList,
      pcchDllList);
 
     keyName = CRYPT_GetKeyName(dwEncodingType, set->name, "DEFAULT");
@@ -209,7 +197,7 @@ BOOL WINAPI CryptGetDefaultOIDDllList(HCRYPTOIDFUNCSET hFuncSet,
     {
         DWORD size = *pcchDllList * sizeof(WCHAR);
 
-        rc = RegQueryValueExW(key, DllW, NULL, NULL, (LPBYTE)pwszDllList,
+        rc = RegQueryValueExW(key, L"Dll", NULL, NULL, (LPBYTE)pwszDllList,
          &size);
         if (!rc)
             *pcchDllList = size / sizeof(WCHAR);
@@ -231,7 +219,7 @@ BOOL WINAPI CryptGetDefaultOIDDllList(HCRYPTOIDFUNCSET hFuncSet,
     }
     CryptMemFree(keyName);
 
-    return ret;
+    return TRUE;
 }
 
 BOOL WINAPI CryptInstallOIDFunctionAddress(HMODULE hModule,
@@ -241,7 +229,7 @@ BOOL WINAPI CryptInstallOIDFunctionAddress(HMODULE hModule,
     BOOL ret = TRUE;
     struct OIDFunctionSet *set;
 
-    TRACE("(%p, %d, %s, %d, %p, %08x)\n", hModule, dwEncodingType,
+    TRACE("(%p, %ld, %s, %ld, %p, %08lx)\n", hModule, dwEncodingType,
      debugstr_a(pszFuncName), cFuncEntry, rgFuncEntry, dwFlags);
 
     set = CryptInitOIDFunctionSet(pszFuncName, 0);
@@ -319,14 +307,14 @@ static BOOL CRYPT_GetFuncFromReg(DWORD dwEncodingType, LPCSTR pszOID,
         }
         else
             funcName = szFuncName;
-        rc = RegQueryValueExW(key, DllW, NULL, &type, NULL, &size);
+        rc = RegQueryValueExW(key, L"Dll", NULL, &type, NULL, &size);
         if ((!rc || rc == ERROR_MORE_DATA) && type == REG_SZ)
         {
             LPWSTR dllName = CryptMemAlloc(size);
 
             if (dllName)
             {
-                rc = RegQueryValueExW(key, DllW, NULL, NULL,
+                rc = RegQueryValueExW(key, L"Dll", NULL, NULL,
                  (LPBYTE)dllName, &size);
                 if (!rc)
                 {
@@ -391,7 +379,7 @@ BOOL WINAPI CryptGetOIDFunctionAddress(HCRYPTOIDFUNCSET hFuncSet,
     BOOL ret = FALSE;
     struct OIDFunctionSet *set = hFuncSet;
 
-    TRACE("(%p, %d, %s, %08x, %p, %p)\n", hFuncSet, dwEncodingType,
+    TRACE("(%p, %ld, %s, %08lx, %p, %p)\n", hFuncSet, dwEncodingType,
      debugstr_a(pszOID), dwFlags, ppvFuncAddr, phFuncAddr);
 
     *ppvFuncAddr = NULL;
@@ -407,7 +395,7 @@ BOOL WINAPI CryptGetOIDFunctionAddress(HCRYPTOIDFUNCSET hFuncSet,
                 if (!IS_INTOID(pszOID))
                 {
                     if (!IS_INTOID(function->entry.pszOID) &&
-                     !strcasecmp(function->entry.pszOID, pszOID))
+                     !stricmp(function->entry.pszOID, pszOID))
                     {
                         *ppvFuncAddr = function->entry.pvFuncAddr;
                         *phFuncAddr = NULL; /* FIXME: what should it be? */
@@ -468,7 +456,7 @@ static BOOL is_module_registered(HMODULE hModule)
 BOOL WINAPI CryptFreeOIDFunctionAddress(HCRYPTOIDFUNCADDR hFuncAddr,
  DWORD dwFlags)
 {
-    TRACE("(%p, %08x)\n", hFuncAddr, dwFlags);
+    TRACE("(%p, %08lx)\n", hFuncAddr, dwFlags);
 
     /* FIXME: as MSDN states, need to check for DllCanUnloadNow in the DLL,
      * and only unload it if it can be unloaded.  Also need to implement ref
@@ -515,7 +503,7 @@ BOOL WINAPI CryptGetDefaultOIDFunctionAddress(HCRYPTOIDFUNCSET hFuncSet,
     struct OIDFunctionSet *set = hFuncSet;
     BOOL ret = FALSE;
 
-    TRACE("(%p, %d, %s, %08x, %p, %p)\n", hFuncSet, dwEncodingType,
+    TRACE("(%p, %ld, %s, %08lx, %p, %p)\n", hFuncSet, dwEncodingType,
      debugstr_w(pwszDll), dwFlags, ppvFuncAddr, phFuncAddr);
 
     if (pwszDll)
@@ -651,7 +639,7 @@ BOOL WINAPI CryptRegisterOIDFunction(DWORD dwEncodingType, LPCSTR pszFuncName,
     HKEY hKey;
     LPSTR szKey;
 
-    TRACE("(%x, %s, %s, %s, %s)\n", dwEncodingType, debugstr_a(pszFuncName),
+    TRACE("(%lx, %s, %s, %s, %s)\n", dwEncodingType, debugstr_a(pszFuncName),
           debugstr_a(pszOID), debugstr_w(pwszDll), debugstr_a(pszOverrideFuncName));
 
     /* Native does nothing pwszDll is NULL */
@@ -686,7 +674,7 @@ BOOL WINAPI CryptRegisterOIDFunction(DWORD dwEncodingType, LPCSTR pszFuncName,
              (const BYTE*)pszOverrideFuncName, lstrlenA(pszOverrideFuncName) + 1);
         if (r != ERROR_SUCCESS) goto error_close_key;
     }
-    r = RegSetValueExW(hKey, DllW, 0, REG_SZ, (const BYTE*) pwszDll,
+    r = RegSetValueExW(hKey, L"Dll", 0, REG_SZ, (const BYTE*) pwszDll,
          (lstrlenW(pwszDll) + 1) * sizeof (WCHAR));
 
 error_close_key:
@@ -719,7 +707,7 @@ BOOL WINAPI CryptUnregisterOIDInfo(PCCRYPT_OID_INFO info)
         return FALSE;
     }
 
-    err = RegOpenKeyExA(HKEY_LOCAL_MACHINE, "Software\\Microsoft\\Cryptography\\OID\\EncodingType 0\\CryptDllFindOIDInfo", 0, KEY_ALL_ACCESS, &root);
+    err = RegOpenKeyExW(HKEY_LOCAL_MACHINE, L"Software\\Microsoft\\Cryptography\\OID\\EncodingType 0\\CryptDllFindOIDInfo", 0, KEY_ALL_ACCESS, &root);
     if (err != ERROR_SUCCESS)
     {
         SetLastError(err);
@@ -729,7 +717,7 @@ BOOL WINAPI CryptUnregisterOIDInfo(PCCRYPT_OID_INFO info)
     key_name = CryptMemAlloc(strlen(info->pszOID) + 16);
     if (key_name)
     {
-        sprintf(key_name, "%s!%u", info->pszOID, info->dwGroupId);
+        sprintf(key_name, "%s!%lu", info->pszOID, info->dwGroupId);
         err = RegDeleteKeyA(root, key_name);
     }
     else
@@ -753,7 +741,7 @@ BOOL WINAPI CryptRegisterOIDInfo(PCCRYPT_OID_INFO info, DWORD flags)
     HKEY root = 0, key = 0;
     DWORD err;
 
-    TRACE("(%p, %x)\n", info, flags );
+    TRACE("(%p, %lx)\n", info, flags );
 
     if (!info || info->cbSize != sizeof(*info) || !info->pszOID)
     {
@@ -770,47 +758,47 @@ BOOL WINAPI CryptRegisterOIDInfo(PCCRYPT_OID_INFO info, DWORD flags)
         goto done;
     }
 
-    err = RegCreateKeyExA(HKEY_LOCAL_MACHINE, "Software\\Microsoft\\Cryptography\\OID\\EncodingType 0\\CryptDllFindOIDInfo",
+    err = RegCreateKeyExW(HKEY_LOCAL_MACHINE, L"Software\\Microsoft\\Cryptography\\OID\\EncodingType 0\\CryptDllFindOIDInfo",
                           0, NULL, 0, KEY_ALL_ACCESS, NULL, &root, NULL);
     if (err != ERROR_SUCCESS) goto done;
 
-    sprintf(key_name, "%s!%u", info->pszOID, info->dwGroupId);
+    sprintf(key_name, "%s!%lu", info->pszOID, info->dwGroupId);
     err = RegCreateKeyA(root, key_name, &key);
     if (err != ERROR_SUCCESS) goto done;
 
     if (flags)
     {
-        err = RegSetValueExW(key, flagsW, 0, REG_DWORD, (const BYTE *)&flags, sizeof(flags));
+        err = RegSetValueExW(key, L"Flags", 0, REG_DWORD, (const BYTE *)&flags, sizeof(flags));
         if (err != ERROR_SUCCESS) goto done;
     }
 
     if (info->pwszName)
     {
-        err = RegSetValueExW(key, nameW, 0, REG_SZ, (const BYTE *)info->pwszName, (lstrlenW(info->pwszName) + 1) * sizeof(WCHAR));
+        err = RegSetValueExW(key, L"Name", 0, REG_SZ, (const BYTE *)info->pwszName, (lstrlenW(info->pwszName) + 1) * sizeof(WCHAR));
         if (err != ERROR_SUCCESS) goto done;
     }
 
-    if (info->u.Algid)
+    if (info->Algid)
     {
-        err = RegSetValueExW(key, algidW, 0, REG_DWORD, (const BYTE *)&info->u.Algid, sizeof(info->u.Algid));
+        err = RegSetValueExW(key, L"Algid", 0, REG_DWORD, (const BYTE *)&info->Algid, sizeof(info->Algid));
         if (err != ERROR_SUCCESS) goto done;
     }
 
     if (info->ExtraInfo.cbData && info->ExtraInfo.pbData)
     {
-        err = RegSetValueExW(key, extraW, 0, REG_BINARY, info->ExtraInfo.pbData, info->ExtraInfo.cbData);
+        err = RegSetValueExW(key, L"ExtraInfo", 0, REG_BINARY, info->ExtraInfo.pbData, info->ExtraInfo.cbData);
         if (err != ERROR_SUCCESS) goto done;
     }
 
     if (info->pwszCNGAlgid)
     {
-        err = RegSetValueExW(key, cngalgidW, 0, REG_SZ, (const BYTE *)info->pwszCNGAlgid, (lstrlenW(info->pwszCNGAlgid) + 1) * sizeof(WCHAR));
+        err = RegSetValueExW(key, L"CNGAlgid", 0, REG_SZ, (const BYTE *)info->pwszCNGAlgid, (lstrlenW(info->pwszCNGAlgid) + 1) * sizeof(WCHAR));
         if (err != ERROR_SUCCESS) goto done;
     }
 
     if (info->pwszCNGExtraAlgid)
     {
-        err = RegSetValueExW(key, cngextraalgidW, 0, REG_SZ, (const BYTE *)info->pwszCNGExtraAlgid, (lstrlenW(info->pwszCNGExtraAlgid) + 1) * sizeof(WCHAR));
+        err = RegSetValueExW(key, L"CNGExtraAlgid", 0, REG_SZ, (const BYTE *)info->pwszCNGExtraAlgid, (lstrlenW(info->pwszCNGExtraAlgid) + 1) * sizeof(WCHAR));
         if (err != ERROR_SUCCESS) goto done;
     }
 
@@ -834,7 +822,7 @@ BOOL WINAPI CryptUnregisterOIDFunction(DWORD dwEncodingType, LPCSTR pszFuncName,
     LPSTR szKey;
     LONG rc;
 
-    TRACE("%x %s %s\n", dwEncodingType, debugstr_a(pszFuncName),
+    TRACE("%lx %s %s\n", dwEncodingType, debugstr_a(pszFuncName),
      debugstr_a(pszOID));
 
     if (!pszFuncName || !pszOID)
@@ -859,7 +847,7 @@ BOOL WINAPI CryptGetOIDFunctionValue(DWORD dwEncodingType, LPCSTR pszFuncName,
     LONG rc;
     HKEY hKey;
 
-    TRACE("%x %s %s %s %p %p %p\n", dwEncodingType, debugstr_a(pszFuncName),
+    TRACE("%lx %s %s %s %p %p %p\n", dwEncodingType, debugstr_a(pszFuncName),
      debugstr_a(pszOID), debugstr_w(pwszValueName), pdwValueType, pbValueData,
      pcbValueData);
 
@@ -896,7 +884,7 @@ BOOL WINAPI CryptSetOIDFunctionValue(DWORD dwEncodingType, LPCSTR pszFuncName,
     LONG rc;
     HKEY hKey;
 
-    TRACE("%x %s %s %s %d %p %d\n", dwEncodingType, debugstr_a(pszFuncName),
+    TRACE("%lx %s %s %s %ld %p %ld\n", dwEncodingType, debugstr_a(pszFuncName),
      debugstr_a(pszOID), debugstr_w(pwszValueName), dwValueType, pbValueData,
      cbValueData);
 
@@ -1076,11 +1064,11 @@ static LPWSTR CRYPT_GetDefaultOIDDlls(HKEY key)
     DWORD type, size;
     LPWSTR dlls;
 
-    r = RegQueryValueExW(key, DllW, NULL, &type, NULL, &size);
+    r = RegQueryValueExW(key, L"Dll", NULL, &type, NULL, &size);
     if (r == ERROR_SUCCESS && type == REG_MULTI_SZ)
     {
         dlls = CryptMemAlloc(size);
-        r = RegQueryValueExW(key, DllW, NULL, &type, (LPBYTE)dlls, &size);
+        r = RegQueryValueExW(key, L"Dll", NULL, &type, (LPBYTE)dlls, &size);
         if (r != ERROR_SUCCESS)
         {
             CryptMemFree(dlls);
@@ -1097,7 +1085,7 @@ static inline BOOL CRYPT_SetDefaultOIDDlls(HKEY key, LPCWSTR dlls)
     DWORD len = CRYPT_GetMultiStringCharacterLen(dlls);
     LONG r;
 
-    if ((r = RegSetValueExW(key, DllW, 0, REG_MULTI_SZ, (const BYTE *)dlls,
+    if ((r = RegSetValueExW(key, L"Dll", 0, REG_MULTI_SZ, (const BYTE *)dlls,
      len * sizeof (WCHAR))))
         SetLastError(r);
     return r == ERROR_SUCCESS;
@@ -1113,7 +1101,7 @@ BOOL WINAPI CryptRegisterDefaultOIDFunction(DWORD dwEncodingType,
     LPWSTR dlls;
     BOOL ret = FALSE;
 
-    TRACE("(%x, %s, %d, %s)\n", dwEncodingType, debugstr_a(pszFuncName),
+    TRACE("(%lx, %s, %ld, %s)\n", dwEncodingType, debugstr_a(pszFuncName),
      dwIndex, debugstr_w(pwszDll));
 
     if (!pwszDll)
@@ -1146,7 +1134,7 @@ BOOL WINAPI CryptUnregisterDefaultOIDFunction(DWORD dwEncodingType,
     LPWSTR dlls;
     BOOL ret;
 
-    TRACE("(%x, %s, %s)\n", dwEncodingType, debugstr_a(pszFuncName),
+    TRACE("(%lx, %s, %s)\n", dwEncodingType, debugstr_a(pszFuncName),
      debugstr_w(pwszDll));
 
     if (!pwszDll)
@@ -1205,79 +1193,6 @@ static CRITICAL_SECTION_DEBUG oidInfoCSDebug =
 static CRITICAL_SECTION oidInfoCS = { &oidInfoCSDebug, -1, 0, 0, 0, 0 };
 static struct list oidInfo = { &oidInfo, &oidInfo };
 
-static const WCHAR tripledes[] = { '3','d','e','s',0 };
-static const WCHAR cms3deswrap[] = { 'C','M','S','3','D','E','S','w','r','a',
- 'p',0 };
-static const WCHAR cmsrc2wrap[] = { 'C','M','S','R','C','2','w','r','a','p',0 };
-static const WCHAR des[] = { 'd','e','s',0 };
-static const WCHAR md2[] = { 'm','d','2',0 };
-static const WCHAR md4[] = { 'm','d','4',0 };
-static const WCHAR md5[] = { 'm','d','5',0 };
-static const WCHAR rc2[] = { 'r','c','2',0 };
-static const WCHAR rc4[] = { 'r','c','4',0 };
-static const WCHAR sha[] = { 's','h','a',0 };
-static const WCHAR sha1[] = { 's','h','a','1',0 };
-static const WCHAR sha256[] = { 's','h','a','2','5','6',0 };
-static const WCHAR sha384[] = { 's','h','a','3','8','4',0 };
-static const WCHAR sha512[] = { 's','h','a','5','1','2',0 };
-static const WCHAR RSA[] = { 'R','S','A',0 };
-static const WCHAR RSA_KEYX[] = { 'R','S','A','_','K','E','Y','X',0 };
-static const WCHAR RSA_SIGN[] = { 'R','S','A','_','S','I','G','N',0 };
-static const WCHAR DSA[] = { 'D','S','A',0 };
-static const WCHAR DSA_SIGN[] = { 'D','S','A','_','S','I','G','N',0 };
-static const WCHAR DH[] = { 'D','H',0 };
-static const WCHAR DSS[] = { 'D','S','S',0 };
-static const WCHAR mosaicKMandUpdSig[] =
- { 'm','o','s','a','i','c','K','M','a','n','d','U','p','d','S','i','g',0 };
-static const WCHAR ESDH[] = { 'E','S','D','H',0 };
-static const WCHAR NO_SIGN[] = { 'N','O','S','I','G','N',0 };
-static const WCHAR dsaSHA1[] = { 'd','s','a','S','H','A','1',0 };
-static const WCHAR md2RSA[] = { 'm','d','2','R','S','A',0 };
-static const WCHAR md4RSA[] = { 'm','d','4','R','S','A',0 };
-static const WCHAR md5RSA[] = { 'm','d','5','R','S','A',0 };
-static const WCHAR shaDSA[] = { 's','h','a','D','S','A',0 };
-static const WCHAR sha1DSA[] = { 's','h','a','1','D','S','A',0 };
-static const WCHAR shaRSA[] = { 's','h','a','R','S','A',0 };
-static const WCHAR sha1RSA[] = { 's','h','a','1','R','S','A',0 };
-static const WCHAR sha256RSA[] = { 's','h','a','2','5','6','R','S','A',0 };
-static const WCHAR sha384RSA[] = { 's','h','a','3','8','4','R','S','A',0 };
-static const WCHAR sha512RSA[] = { 's','h','a','5','1','2','R','S','A',0 };
-static const WCHAR mosaicUpdatedSig[] =
- { 'm','o','s','a','i','c','U','p','d','a','t','e','d','S','i','g',0 };
-static const WCHAR sha256ECDSA[] = { 's','h','a','2','5','6','E','C','D','S','A',0 };
-static const WCHAR sha384ECDSA[] = { 's','h','a','3','8','4','E','C','D','S','A',0 };
-static const WCHAR CN[] = { 'C','N',0 };
-static const WCHAR L[] = { 'L',0 };
-static const WCHAR O[] = { 'O',0 };
-static const WCHAR OU[] = { 'O','U',0 };
-static const WCHAR E[] = { 'E',0 };
-static const WCHAR C[] = { 'C',0 };
-static const WCHAR S[] = { 'S',0 };
-static const WCHAR ST[] = { 'S','T',0 };
-static const WCHAR STREET[] = { 'S','T','R','E','E','T',0 };
-static const WCHAR T[] = { 'T',0 };
-static const WCHAR Title[] = { 'T','i','t','l','e',0 };
-static const WCHAR G[] = { 'G',0 };
-static const WCHAR GivenName[] = { 'G','i','v','e','n','N','a','m','e',0 };
-static const WCHAR I[] = { 'I',0 };
-static const WCHAR Initials[] = { 'I','n','i','t','i','a','l','s',0 };
-static const WCHAR SN[] = { 'S','N',0 };
-static const WCHAR DC[] = { 'D','C',0 };
-static const WCHAR Description[] =
- { 'D','e','s','c','r','i','p','t','i','o','n',0 };
-static const WCHAR PostalCode[] = { 'P','o','s','t','a','l','C','o','d','e',0 };
-static const WCHAR POBox[] = { 'P','O','B','o','x',0 };
-static const WCHAR Phone[] = { 'P','h','o','n','e',0 };
-static const WCHAR X21Address[] = { 'X','2','1','A','d','d','r','e','s','s',0 };
-static const WCHAR dnQualifier[] =
- { 'd','n','Q','u','a','l','i','f','i','e','r',0 };
-static const WCHAR SpcSpAgencyInfo[] = { 'S','p','c','S','p','A','g','e','n','c','y','I','n','f','o',0 };
-static const WCHAR SpcFinancialCriteria[] = { 'S','p','c','F','i','n','a','n','c','i','a','l','C','r','i','t','e','r','i','a',0 };
-static const WCHAR SpcMinimalCriteria[] = { 'S','p','c','M','i','n','i','m','a','l','C','r','i','t','e','r','i','a',0 };
-static const WCHAR Email[] = { 'E','m','a','i','l',0 };
-static const WCHAR GN[] = { 'G','N',0 };
-static const WCHAR SERIALNUMBER[] = { 'S','E','R','I','A','L','N','U','M','B','E','R',0 };
-
 static const DWORD noNullFlag = CRYPT_OID_NO_NULL_ALGORITHM_PARA_FLAG;
 static const DWORD mosaicFlags = CRYPT_OID_INHIBIT_SIGNATURE_FORMAT_FLAG |
  CRYPT_OID_NO_NULL_ALGORITHM_PARA_FLAG;
@@ -1324,91 +1239,91 @@ static const struct OIDInfoConstructor {
     const WCHAR *pwszCNGAlgid;
     const WCHAR *pwszCNGExtraAlgid;
 } oidInfoConstructors[] = {
- { 1, szOID_OIWSEC_sha1,               CALG_SHA1,     sha1, NULL },
- { 1, szOID_OIWSEC_sha1,               CALG_SHA1,     sha, NULL },
- { 1, szOID_OIWSEC_sha,                CALG_SHA,      sha, NULL },
- { 1, szOID_RSA_MD5,                   CALG_MD5,      md5, NULL },
- { 1, szOID_RSA_MD4,                   CALG_MD4,      md4, NULL },
- { 1, szOID_RSA_MD2,                   CALG_MD2,      md2, NULL },
+ { 1, szOID_OIWSEC_sha1,               CALG_SHA1,     L"sha1", NULL },
+ { 1, szOID_OIWSEC_sha1,               CALG_SHA1,     L"sha", NULL },
+ { 1, szOID_OIWSEC_sha,                CALG_SHA,      L"sha", NULL },
+ { 1, szOID_RSA_MD5,                   CALG_MD5,      L"md5", NULL },
+ { 1, szOID_RSA_MD4,                   CALG_MD4,      L"md4", NULL },
+ { 1, szOID_RSA_MD2,                   CALG_MD2,      L"md2", NULL },
  /* NOTE: Windows Vista+ uses -1 instead of CALG_SHA_* following SHA entries. */
- { 1, szOID_NIST_sha256,               CALG_SHA_256,  sha256, NULL },
- { 1, szOID_NIST_sha384,               CALG_SHA_384,  sha384, NULL },
- { 1, szOID_NIST_sha512,               CALG_SHA_512,  sha512, NULL },
+ { 1, szOID_NIST_sha256,               CALG_SHA_256,  L"sha256", NULL },
+ { 1, szOID_NIST_sha384,               CALG_SHA_384,  L"sha384", NULL },
+ { 1, szOID_NIST_sha512,               CALG_SHA_512,  L"sha512", NULL },
 
- { 2, szOID_OIWSEC_desCBC,             CALG_DES,      des, NULL },
- { 2, szOID_RSA_DES_EDE3_CBC,          CALG_3DES,     tripledes, NULL },
- { 2, szOID_RSA_RC2CBC,                CALG_RC2,      rc2, NULL },
- { 2, szOID_RSA_RC4,                   CALG_RC4,      rc4, NULL },
- { 2, szOID_RSA_SMIMEalgCMS3DESwrap,   CALG_3DES,     cms3deswrap, NULL },
- { 2, szOID_RSA_SMIMEalgCMSRC2wrap,    CALG_RC2,      cmsrc2wrap, NULL },
+ { 2, szOID_OIWSEC_desCBC,             CALG_DES,      L"des", NULL },
+ { 2, szOID_RSA_DES_EDE3_CBC,          CALG_3DES,     L"3des", NULL },
+ { 2, szOID_RSA_RC2CBC,                CALG_RC2,      L"rc2", NULL },
+ { 2, szOID_RSA_RC4,                   CALG_RC4,      L"rc4", NULL },
+ { 2, szOID_RSA_SMIMEalgCMS3DESwrap,   CALG_3DES,     L"CMS3DESwrap", NULL },
+ { 2, szOID_RSA_SMIMEalgCMSRC2wrap,    CALG_RC2,      L"CMSRC2wrap", NULL },
 
- { 3, szOID_RSA_RSA,                   CALG_RSA_KEYX, RSA, NULL },
- { 3, szOID_X957_DSA,                  CALG_DSS_SIGN, DSA, &noNullBlob },
- { 3, szOID_ANSI_X942_DH,              CALG_DH_SF,    DH, &noNullBlob },
- { 3, szOID_RSA_RSA,                   CALG_RSA_KEYX, RSA_KEYX, NULL },
- { 3, szOID_RSA_RSA,                   CALG_RSA_SIGN, RSA, NULL },
- { 3, szOID_RSA_RSA,                   CALG_RSA_SIGN, RSA_SIGN, NULL },
- { 3, szOID_OIWSEC_dsa,                CALG_DSS_SIGN, DSA, &noNullBlob },
- { 3, szOID_OIWSEC_dsa,                CALG_DSS_SIGN, DSS, &noNullBlob },
- { 3, szOID_OIWSEC_dsa,                CALG_DSS_SIGN, DSA_SIGN, &noNullBlob },
- { 3, szOID_RSA_DH,                    CALG_DH_SF,    DH, &noNullBlob },
- { 3, szOID_OIWSEC_rsaXchg,            CALG_RSA_KEYX, RSA_KEYX, NULL },
- { 3, szOID_INFOSEC_mosaicKMandUpdSig, CALG_DSS_SIGN, mosaicKMandUpdSig,
-   &mosaicFlagsBlob },
- { 3, szOID_RSA_SMIMEalgESDH,          CALG_DH_EPHEM, ESDH, &noNullBlob },
- { 3, szOID_PKIX_NO_SIGNATURE,         CALG_NO_SIGN,  NO_SIGN, NULL },
+ { 3, szOID_RSA_RSA,                   CALG_RSA_KEYX, L"RSA", NULL },
+ { 3, szOID_X957_DSA,                  CALG_DSS_SIGN, L"DSA", &noNullBlob },
+ { 3, szOID_ANSI_X942_DH,              CALG_DH_SF,    L"DH", &noNullBlob },
+ { 3, szOID_RSA_RSA,                   CALG_RSA_KEYX, L"RSA_KEYX", NULL },
+ { 3, szOID_RSA_RSA,                   CALG_RSA_SIGN, L"RSA", NULL },
+ { 3, szOID_RSA_RSA,                   CALG_RSA_SIGN, L"RSA_SIGN", NULL },
+ { 3, szOID_OIWSEC_dsa,                CALG_DSS_SIGN, L"DSA", &noNullBlob },
+ { 3, szOID_OIWSEC_dsa,                CALG_DSS_SIGN, L"DSS", &noNullBlob },
+ { 3, szOID_OIWSEC_dsa,                CALG_DSS_SIGN, L"DSA_SIGN", &noNullBlob },
+ { 3, szOID_RSA_DH,                    CALG_DH_SF,    L"DH", &noNullBlob },
+ { 3, szOID_OIWSEC_rsaXchg,            CALG_RSA_KEYX, L"RSA_KEYX", NULL },
+ { 3, szOID_INFOSEC_mosaicKMandUpdSig, CALG_DSS_SIGN, L"mosaicKMandUpdSig", &mosaicFlagsBlob },
+ { 3, szOID_RSA_SMIMEalgESDH,          CALG_DH_EPHEM, L"ESDH", &noNullBlob },
+ { 3, szOID_PKIX_NO_SIGNATURE,         CALG_NO_SIGN,  L"NOSIGN", NULL },
+ { 3, szOID_ECC_PUBLIC_KEY,            CALG_OID_INFO_PARAMETERS, L"ECC", NULL,
+   CRYPT_OID_INFO_ECC_PARAMETERS_ALGORITHM, L"" },
 
- { 4, szOID_RSA_SHA1RSA,               CALG_SHA1,     sha1RSA, &rsaSignBlob },
- { 4, szOID_RSA_SHA256RSA,             CALG_SHA_256,  sha256RSA, &rsaSignBlob },
- { 4, szOID_RSA_SHA384RSA,             CALG_SHA_384,  sha384RSA, &rsaSignBlob },
- { 4, szOID_RSA_SHA512RSA,             CALG_SHA_512,  sha512RSA, &rsaSignBlob },
- { 4, szOID_RSA_MD5RSA,                CALG_MD5,      md5RSA, &rsaSignBlob },
- { 4, szOID_X957_SHA1DSA,              CALG_SHA1,     sha1DSA, &dssSignBlob },
- { 4, szOID_OIWSEC_sha1RSASign,        CALG_SHA1,     sha1RSA, &rsaSignBlob },
- { 4, szOID_OIWSEC_sha1RSASign,        CALG_SHA1,     shaRSA, &rsaSignBlob },
- { 4, szOID_OIWSEC_shaRSA,             CALG_SHA1,     shaRSA, &rsaSignBlob },
- { 4, szOID_OIWSEC_md5RSA,             CALG_MD5,      md5RSA, &rsaSignBlob },
- { 4, szOID_RSA_MD2RSA,                CALG_MD2,      md2RSA, &rsaSignBlob },
- { 4, szOID_RSA_MD4RSA,                CALG_MD4,      md4RSA, &rsaSignBlob },
- { 4, szOID_OIWSEC_md4RSA,             CALG_MD4,      md4RSA, &rsaSignBlob },
- { 4, szOID_OIWSEC_md4RSA2,            CALG_MD4,      md4RSA, &rsaSignBlob },
- { 4, szOID_OIWDIR_md2RSA,             CALG_MD2,      md2RSA, &rsaSignBlob },
- { 4, szOID_OIWSEC_shaDSA,             CALG_SHA1,     sha1DSA, &dssSignBlob },
- { 4, szOID_OIWSEC_shaDSA,             CALG_SHA1,     shaDSA, &dssSignBlob },
- { 4, szOID_OIWSEC_dsaSHA1,            CALG_SHA1,     dsaSHA1, &dssSignBlob },
- { 4, szOID_INFOSEC_mosaicUpdatedSig,  CALG_SHA1,     mosaicUpdatedSig,
-   &mosaicSignBlob },
- { 4, szOID_ECDSA_SHA256,              CALG_OID_INFO_CNG_ONLY, sha256ECDSA, &ecdsaSignBlob,
+ { 4, szOID_RSA_SHA1RSA,               CALG_SHA1,     L"sha1RSA", &rsaSignBlob },
+ { 4, szOID_RSA_SHA256RSA,             CALG_SHA_256,  L"sha256RSA", &rsaSignBlob },
+ { 4, szOID_RSA_SHA384RSA,             CALG_SHA_384,  L"sha384RSA", &rsaSignBlob },
+ { 4, szOID_RSA_SHA512RSA,             CALG_SHA_512,  L"sha512RSA", &rsaSignBlob },
+ { 4, szOID_RSA_MD5RSA,                CALG_MD5,      L"md5RSA", &rsaSignBlob },
+ { 4, szOID_X957_SHA1DSA,              CALG_SHA1,     L"sha1DSA", &dssSignBlob },
+ { 4, szOID_OIWSEC_sha1RSASign,        CALG_SHA1,     L"sha1RSA", &rsaSignBlob },
+ { 4, szOID_OIWSEC_sha1RSASign,        CALG_SHA1,     L"shaRSA", &rsaSignBlob },
+ { 4, szOID_OIWSEC_shaRSA,             CALG_SHA1,     L"shaRSA", &rsaSignBlob },
+ { 4, szOID_OIWSEC_md5RSA,             CALG_MD5,      L"md5RSA", &rsaSignBlob },
+ { 4, szOID_RSA_MD2RSA,                CALG_MD2,      L"md2RSA", &rsaSignBlob },
+ { 4, szOID_RSA_MD4RSA,                CALG_MD4,      L"md4RSA", &rsaSignBlob },
+ { 4, szOID_OIWSEC_md4RSA,             CALG_MD4,      L"md4RSA", &rsaSignBlob },
+ { 4, szOID_OIWSEC_md4RSA2,            CALG_MD4,      L"md4RSA", &rsaSignBlob },
+ { 4, szOID_OIWDIR_md2RSA,             CALG_MD2,      L"md2RSA", &rsaSignBlob },
+ { 4, szOID_OIWSEC_shaDSA,             CALG_SHA1,     L"sha1DSA", &dssSignBlob },
+ { 4, szOID_OIWSEC_shaDSA,             CALG_SHA1,     L"shaDSA", &dssSignBlob },
+ { 4, szOID_OIWSEC_dsaSHA1,            CALG_SHA1,     L"dsaSHA1", &dssSignBlob },
+ { 4, szOID_INFOSEC_mosaicUpdatedSig,  CALG_SHA1,     L"mosaicUpdatedSig", &mosaicSignBlob },
+ { 4, szOID_ECDSA_SHA256,              CALG_OID_INFO_CNG_ONLY, L"sha256ECDSA", &ecdsaSignBlob,
    BCRYPT_SHA256_ALGORITHM, CRYPT_OID_INFO_ECC_PARAMETERS_ALGORITHM },
- { 4, szOID_ECDSA_SHA384,              CALG_OID_INFO_CNG_ONLY, sha384ECDSA, &ecdsaSignBlob,
+ { 4, szOID_ECDSA_SHA384,              CALG_OID_INFO_CNG_ONLY, L"sha384ECDSA", &ecdsaSignBlob,
    BCRYPT_SHA384_ALGORITHM, CRYPT_OID_INFO_ECC_PARAMETERS_ALGORITHM },
 
- { 5, szOID_COMMON_NAME,              0, CN, NULL },
- { 5, szOID_LOCALITY_NAME,            0, L, NULL },
- { 5, szOID_ORGANIZATION_NAME,        0, O, NULL },
- { 5, szOID_ORGANIZATIONAL_UNIT_NAME, 0, OU, NULL },
- { 5, szOID_RSA_emailAddr,            0, E, &ia5StringBlob },
- { 5, szOID_RSA_emailAddr,            0, Email, &ia5StringBlob },
- { 5, szOID_COUNTRY_NAME,             0, C, &printableStringBlob },
- { 5, szOID_STATE_OR_PROVINCE_NAME,   0, S, NULL },
- { 5, szOID_STATE_OR_PROVINCE_NAME,   0, ST, NULL },
- { 5, szOID_STREET_ADDRESS,           0, STREET, NULL },
- { 5, szOID_TITLE,                    0, T, NULL },
- { 5, szOID_TITLE,                    0, Title, NULL },
- { 5, szOID_GIVEN_NAME,               0, G, NULL },
- { 5, szOID_GIVEN_NAME,               0, GN, NULL },
- { 5, szOID_GIVEN_NAME,               0, GivenName, NULL },
- { 5, szOID_INITIALS,                 0, I, NULL },
- { 5, szOID_INITIALS,                 0, Initials, NULL },
- { 5, szOID_SUR_NAME,                 0, SN, NULL },
- { 5, szOID_DOMAIN_COMPONENT,         0, DC, &domainCompTypesBlob },
- { 5, szOID_DESCRIPTION,              0, Description, NULL },
- { 5, szOID_POSTAL_CODE,              0, PostalCode, NULL },
- { 5, szOID_POST_OFFICE_BOX,          0, POBox, NULL },
- { 5, szOID_TELEPHONE_NUMBER,         0, Phone, &printableStringBlob },
- { 5, szOID_X21_ADDRESS,              0, X21Address, &numericStringBlob },
- { 5, szOID_DN_QUALIFIER,             0, dnQualifier, NULL },
- { 5, szOID_DEVICE_SERIAL_NUMBER,     0, SERIALNUMBER, NULL },
+ { 5, szOID_COMMON_NAME,              0, L"CN", NULL },
+ { 5, szOID_LOCALITY_NAME,            0, L"L", NULL },
+ { 5, szOID_ORGANIZATION_NAME,        0, L"O", NULL },
+ { 5, szOID_ORGANIZATIONAL_UNIT_NAME, 0, L"OU", NULL },
+ { 5, szOID_RSA_emailAddr,            0, L"E", &ia5StringBlob },
+ { 5, szOID_RSA_emailAddr,            0, L"Email", &ia5StringBlob },
+ { 5, szOID_COUNTRY_NAME,             0, L"C", &printableStringBlob },
+ { 5, szOID_STATE_OR_PROVINCE_NAME,   0, L"S", NULL },
+ { 5, szOID_STATE_OR_PROVINCE_NAME,   0, L"ST", NULL },
+ { 5, szOID_STREET_ADDRESS,           0, L"STREET", NULL },
+ { 5, szOID_TITLE,                    0, L"T", NULL },
+ { 5, szOID_TITLE,                    0, L"Title", NULL },
+ { 5, szOID_GIVEN_NAME,               0, L"G", NULL },
+ { 5, szOID_GIVEN_NAME,               0, L"GN", NULL },
+ { 5, szOID_GIVEN_NAME,               0, L"GivenName", NULL },
+ { 5, szOID_INITIALS,                 0, L"I", NULL },
+ { 5, szOID_INITIALS,                 0, L"Initials", NULL },
+ { 5, szOID_SUR_NAME,                 0, L"SN", NULL },
+ { 5, szOID_DOMAIN_COMPONENT,         0, L"DC", &domainCompTypesBlob },
+ { 5, szOID_DESCRIPTION,              0, L"Description", NULL },
+ { 5, szOID_POSTAL_CODE,              0, L"PostalCode", NULL },
+ { 5, szOID_POST_OFFICE_BOX,          0, L"POBox", NULL },
+ { 5, szOID_TELEPHONE_NUMBER,         0, L"Phone", &printableStringBlob },
+ { 5, szOID_X21_ADDRESS,              0, L"X21Address", &numericStringBlob },
+ { 5, szOID_DN_QUALIFIER,             0, L"dnQualifier", NULL },
+ { 5, szOID_DEVICE_SERIAL_NUMBER,     0, L"SERIALNUMBER", NULL },
 
  { 6, szOID_AUTHORITY_KEY_IDENTIFIER2, 0, (LPCWSTR)IDS_AUTHORITY_KEY_ID, NULL },
  { 6, szOID_AUTHORITY_KEY_IDENTIFIER, 0, (LPCWSTR)IDS_AUTHORITY_KEY_ID, NULL },
@@ -1456,9 +1371,9 @@ static const struct OIDInfoConstructor {
  { 6, szOID_NETSCAPE_CA_POLICY_URL, 0, (LPCWSTR)IDS_NETSCAPE_CA_POLICY_URL, NULL },
  { 6, szOID_NETSCAPE_SSL_SERVER_NAME, 0, (LPCWSTR)IDS_NETSCAPE_SSL_SERVER_NAME, NULL },
  { 6, szOID_NETSCAPE_COMMENT, 0, (LPCWSTR)IDS_NETSCAPE_COMMENT, NULL },
- { 6, "1.3.6.1.4.1.311.2.1.10", 0, SpcSpAgencyInfo, NULL },
- { 6, "1.3.6.1.4.1.311.2.1.27", 0, SpcFinancialCriteria, NULL },
- { 6, "1.3.6.1.4.1.311.2.1.26", 0, SpcMinimalCriteria, NULL },
+ { 6, "1.3.6.1.4.1.311.2.1.10", 0, L"SpcSpAgencyInfo", NULL },
+ { 6, "1.3.6.1.4.1.311.2.1.27", 0, L"SpcFinancialCriteria", NULL },
+ { 6, "1.3.6.1.4.1.311.2.1.26", 0, L"SpcMinimalCriteria", NULL },
  { 6, szOID_COUNTRY_NAME, 0, (LPCWSTR)IDS_COUNTRY, NULL },
  { 6, szOID_ORGANIZATION_NAME, 0, (LPCWSTR)IDS_ORGANIZATION, NULL },
  { 6, szOID_ORGANIZATIONAL_UNIT_NAME, 0, (LPCWSTR)IDS_ORGANIZATIONAL_UNIT, NULL },
@@ -1587,17 +1502,17 @@ static struct OIDInfo *read_oid_info(HKEY root, char *key_name, DWORD *flags)
 
     oid_len = strlen(key_name) + 1;
 
-    RegQueryValueExW(key, nameW, NULL, NULL, NULL, &name_len);
-    RegQueryValueExW(key, extraW, NULL, NULL, NULL, &extra_len);
-    RegQueryValueExW(key, cngalgidW, NULL, NULL, NULL, &cngalgid_len);
-    RegQueryValueExW(key, cngextraalgidW, NULL, NULL, NULL, &cngextra_len);
+    RegQueryValueExW(key, L"Name", NULL, NULL, NULL, &name_len);
+    RegQueryValueExW(key, L"ExtraInfo", NULL, NULL, NULL, &extra_len);
+    RegQueryValueExW(key, L"CNGAlgid", NULL, NULL, NULL, &cngalgid_len);
+    RegQueryValueExW(key, L"CNGExtraAlgid", NULL, NULL, NULL, &cngextra_len);
 
     info = CryptMemAlloc(sizeof(*info) + oid_len + name_len + extra_len + cngalgid_len + cngextra_len);
     if (info)
     {
         *flags = 0;
         len = sizeof(*flags);
-        RegQueryValueExW(key, flagsW, NULL, NULL, (BYTE *)flags, &len);
+        RegQueryValueExW(key, L"Flags", NULL, NULL, (BYTE *)flags, &len);
 
         memset(info, 0, sizeof(*info));
         info->info.cbSize = sizeof(info->info);
@@ -1611,34 +1526,34 @@ static struct OIDInfo *read_oid_info(HKEY root, char *key_name, DWORD *flags)
         if (name_len)
         {
             info->info.pwszName = (WCHAR *)p;
-            RegQueryValueExW(key, nameW, NULL, NULL, (BYTE *)info->info.pwszName, &name_len);
+            RegQueryValueExW(key, L"Name", NULL, NULL, (BYTE *)info->info.pwszName, &name_len);
             p += name_len;
         }
 
         info->info.dwGroupId = group_id;
 
-        len = sizeof(info->info.u.Algid);
-        RegQueryValueExW(key, algidW, NULL, NULL, (BYTE *)&info->info.u.Algid, &len);
+        len = sizeof(info->info.Algid);
+        RegQueryValueExW(key, L"Algid", NULL, NULL, (BYTE *)&info->info.Algid, &len);
 
         if (extra_len)
         {
             info->info.ExtraInfo.cbData = extra_len;
             info->info.ExtraInfo.pbData = (BYTE *)p;
-            RegQueryValueExW(key, extraW, NULL, NULL, info->info.ExtraInfo.pbData, &extra_len);
+            RegQueryValueExW(key, L"ExtraInfo", NULL, NULL, info->info.ExtraInfo.pbData, &extra_len);
             p += extra_len;
         }
 
         if (cngalgid_len)
         {
             info->info.pwszCNGAlgid = (WCHAR *)p;
-            RegQueryValueExW(key, cngalgidW, NULL, NULL, (BYTE *)info->info.pwszCNGAlgid, &cngalgid_len);
+            RegQueryValueExW(key, L"CNGAlgid", NULL, NULL, (BYTE *)info->info.pwszCNGAlgid, &cngalgid_len);
             p += cngalgid_len;
         }
 
         if (cngextra_len)
         {
             info->info.pwszCNGExtraAlgid = (WCHAR *)p;
-            RegQueryValueExW(key, cngextraalgidW, NULL, NULL, (BYTE *)info->info.pwszCNGExtraAlgid, &cngalgid_len);
+            RegQueryValueExW(key, L"CNGExtraAlgid", NULL, NULL, (BYTE *)info->info.pwszCNGExtraAlgid, &cngalgid_len);
         }
     }
 
@@ -1652,7 +1567,7 @@ static void init_registered_oid_info(void)
     DWORD err, idx;
     HKEY root;
 
-    err = RegOpenKeyExA(HKEY_LOCAL_MACHINE, "Software\\Microsoft\\Cryptography\\OID\\EncodingType 0\\CryptDllFindOIDInfo",
+    err = RegOpenKeyExW(HKEY_LOCAL_MACHINE, L"Software\\Microsoft\\Cryptography\\OID\\EncodingType 0\\CryptDllFindOIDInfo",
                         0, KEY_ALL_ACCESS, &root);
     if (err != ERROR_SUCCESS) return;
 
@@ -1671,9 +1586,9 @@ static void init_registered_oid_info(void)
         {
             if ((info = read_oid_info(root, key_name, &flags)))
             {
-                TRACE("adding oid %s, name %s, groupid %u, algid %u, extra %u, CNG algid %s, CNG extra %s\n",
+                TRACE("adding oid %s, name %s, groupid %lu, algid %u, extra %lu, CNG algid %s, CNG extra %s\n",
                       debugstr_a(info->info.pszOID), debugstr_w(info->info.pwszName),
-                      info->info.dwGroupId, info->info.u.Algid, info->info.ExtraInfo.cbData,
+                      info->info.dwGroupId, info->info.Algid, info->info.ExtraInfo.cbData,
                       debugstr_w(info->info.pwszCNGAlgid), debugstr_w(info->info.pwszCNGExtraAlgid));
 
                 if (flags & CRYPT_INSTALL_OID_INFO_BEFORE_FLAG)
@@ -1707,7 +1622,7 @@ static void init_oid_info(void)
                 info->info.pszOID = oidInfoConstructors[i].pszOID;
                 info->info.pwszName = oidInfoConstructors[i].pwszName;
                 info->info.dwGroupId = oidInfoConstructors[i].dwGroupId;
-                info->info.u.Algid = oidInfoConstructors[i].Algid;
+                info->info.Algid = oidInfoConstructors[i].Algid;
                 if (oidInfoConstructors[i].blob)
                 {
                     info->info.ExtraInfo.cbData =
@@ -1739,7 +1654,7 @@ static void init_oid_info(void)
                     info->info.pszOID = oidInfoConstructors[i].pszOID;
                     info->info.pwszName = (LPWSTR)(info + 1);
                     info->info.dwGroupId = oidInfoConstructors[i].dwGroupId;
-                    info->info.u.Algid = oidInfoConstructors[i].Algid;
+                    info->info.Algid = oidInfoConstructors[i].Algid;
                     memcpy(info + 1, stringresource, len*sizeof(WCHAR));
                     ((LPWSTR)(info + 1))[len] = 0;
                     if (oidInfoConstructors[i].blob)
@@ -1779,7 +1694,7 @@ BOOL WINAPI CryptEnumOIDInfo(DWORD dwGroupId, DWORD dwFlags, void *pvArg,
     BOOL ret = TRUE;
     struct OIDInfo *info;
 
-    TRACE("(%d, %08x, %p, %p)\n", dwGroupId, dwFlags, pvArg,
+    TRACE("(%ld, %08lx, %p, %p)\n", dwGroupId, dwFlags, pvArg,
      pfnEnumOIDInfo);
 
     EnterCriticalSection(&oidInfoCS);
@@ -1801,7 +1716,7 @@ PCCRYPT_OID_INFO WINAPI CryptFindOIDInfo(DWORD dwKeyType, void *pvKey,
 {
     PCCRYPT_OID_INFO ret = NULL;
 
-    TRACE("(%d, %p, %d)\n", dwKeyType, pvKey, dwGroupId);
+    TRACE("(%ld, %p, %ld)\n", dwKeyType, pvKey, dwGroupId);
 
     switch(dwKeyType)
     {
@@ -1809,11 +1724,11 @@ PCCRYPT_OID_INFO WINAPI CryptFindOIDInfo(DWORD dwKeyType, void *pvKey,
     {
         struct OIDInfo *info;
 
-        TRACE("CRYPT_OID_INFO_ALGID_KEY: %d\n", *(DWORD *)pvKey);
+        TRACE("CRYPT_OID_INFO_ALGID_KEY: %ld\n", *(DWORD *)pvKey);
         EnterCriticalSection(&oidInfoCS);
         LIST_FOR_EACH_ENTRY(info, &oidInfo, struct OIDInfo, entry)
         {
-            if (info->info.u.Algid == *(DWORD *)pvKey &&
+            if (info->info.Algid == *(DWORD *)pvKey &&
              (!dwGroupId || info->info.dwGroupId == dwGroupId))
             {
                 ret = &info->info;
@@ -1831,7 +1746,7 @@ PCCRYPT_OID_INFO WINAPI CryptFindOIDInfo(DWORD dwKeyType, void *pvKey,
         EnterCriticalSection(&oidInfoCS);
         LIST_FOR_EACH_ENTRY(info, &oidInfo, struct OIDInfo, entry)
         {
-            if (!lstrcmpW(info->info.pwszName, pvKey) &&
+            if (!wcscmp(info->info.pwszName, pvKey) &&
              (!dwGroupId || info->info.dwGroupId == dwGroupId))
             {
                 ret = &info->info;
@@ -1864,11 +1779,11 @@ PCCRYPT_OID_INFO WINAPI CryptFindOIDInfo(DWORD dwKeyType, void *pvKey,
     {
         struct OIDInfo *info;
 
-        TRACE("CRYPT_OID_INFO_SIGN_KEY: %d\n", *(DWORD *)pvKey);
+        TRACE("CRYPT_OID_INFO_SIGN_KEY: %ld\n", *(DWORD *)pvKey);
         EnterCriticalSection(&oidInfoCS);
         LIST_FOR_EACH_ENTRY(info, &oidInfo, struct OIDInfo, entry)
         {
-            if (info->info.u.Algid == *(DWORD *)pvKey &&
+            if (info->info.Algid == *(DWORD *)pvKey &&
              info->info.ExtraInfo.cbData >= sizeof(DWORD) &&
              *(DWORD *)info->info.ExtraInfo.pbData ==
              *(DWORD *)((LPBYTE)pvKey + sizeof(DWORD)) &&
@@ -1905,7 +1820,7 @@ DWORD WINAPI CertOIDToAlgId(LPCSTR pszObjId)
      (void *)pszObjId, 0);
 
     if (info)
-        ret = info->u.Algid;
+        ret = info->Algid;
     else
         ret = 0;
     return ret;

--- a/dll/win32/crypt32/pfx.c
+++ b/dll/win32/crypt32/pfx.c
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2019 Hans Leidekker for CodeWeavers
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#include <stdarg.h>
+
+#include "ntstatus.h"
+#define WIN32_NO_STATUS
+#include "windef.h"
+#include "winbase.h"
+#include "wincrypt.h"
+#ifdef __REACTOS__
+#include <winnls.h>
+#endif
+#include "snmp.h"
+#include "crypt32_private.h"
+
+#include "wine/debug.h"
+
+WINE_DEFAULT_DEBUG_CHANNEL(crypt);
+
+static HCRYPTPROV import_key( cert_store_data_t data, DWORD flags )
+{
+    HCRYPTPROV prov = 0;
+    HCRYPTKEY cryptkey;
+    DWORD size, acquire_flags;
+    void *key;
+    struct import_store_key_params params = { data, NULL, &size };
+
+    if (CRYPT32_CALL( import_store_key, &params ) != STATUS_BUFFER_TOO_SMALL) return 0;
+
+    acquire_flags = (flags & CRYPT_MACHINE_KEYSET) | CRYPT_NEWKEYSET;
+    if (!CryptAcquireContextW( &prov, NULL, MS_ENHANCED_PROV_W, PROV_RSA_FULL, acquire_flags ))
+    {
+        if (GetLastError() != NTE_EXISTS) return 0;
+
+        acquire_flags &= ~CRYPT_NEWKEYSET;
+        if (!CryptAcquireContextW( &prov, NULL, MS_ENHANCED_PROV_W, PROV_RSA_FULL, acquire_flags ))
+        {
+            WARN( "CryptAcquireContextW failed %08lx\n", GetLastError() );
+            return 0;
+        }
+    }
+
+    params.buf = key = CryptMemAlloc( size );
+    if (CRYPT32_CALL( import_store_key, &params ) ||
+        !CryptImportKey( prov, key, size, 0, flags & CRYPT_EXPORTABLE, &cryptkey ))
+    {
+        WARN( "CryptImportKey failed %08lx\n", GetLastError() );
+        CryptReleaseContext( prov, 0 );
+        CryptMemFree( key );
+        return 0;
+    }
+    CryptDestroyKey( cryptkey );
+    CryptMemFree( key );
+    return prov;
+}
+
+static BOOL set_key_context( const void *ctx, HCRYPTPROV prov )
+{
+    CERT_KEY_CONTEXT key_ctx;
+    key_ctx.cbSize     = sizeof(key_ctx);
+    key_ctx.hCryptProv = prov;
+    key_ctx.dwKeySpec  = AT_KEYEXCHANGE;
+    return CertSetCertificateContextProperty( ctx, CERT_KEY_CONTEXT_PROP_ID, 0, &key_ctx );
+}
+
+static WCHAR *get_provider_property( HCRYPTPROV prov, DWORD prop_id, DWORD *len )
+{
+    DWORD size = 0;
+    WCHAR *ret;
+    char *str;
+
+    CryptGetProvParam( prov, prop_id, NULL, &size, 0 );
+    if (!size) return NULL;
+    if (!(str = CryptMemAlloc( size ))) return NULL;
+    CryptGetProvParam( prov, prop_id, (BYTE *)str, &size, 0 );
+
+    *len = MultiByteToWideChar( CP_ACP, 0, str, -1, NULL, 0 );
+    if ((ret = CryptMemAlloc( *len * sizeof(WCHAR) ))) MultiByteToWideChar( CP_ACP, 0, str, -1, ret, *len );
+    CryptMemFree( str );
+    return ret;
+}
+
+static BOOL set_key_prov_info( const void *ctx, HCRYPTPROV prov )
+{
+    CRYPT_KEY_PROV_INFO *prov_info;
+    DWORD size, len_container, len_name;
+    WCHAR *ptr, *container, *name;
+    BOOL ret;
+
+    if (!(container = get_provider_property( prov, PP_CONTAINER, &len_container ))) return FALSE;
+    if (!(name = get_provider_property( prov, PP_NAME, &len_name )))
+    {
+        CryptMemFree( container );
+        return FALSE;
+    }
+    if (!(prov_info = CryptMemAlloc( sizeof(*prov_info) + (len_container + len_name) * sizeof(WCHAR) )))
+    {
+        CryptMemFree( container );
+        CryptMemFree( name );
+        return FALSE;
+    }
+
+    ptr = (WCHAR *)(prov_info + 1);
+    prov_info->pwszContainerName = ptr;
+    lstrcpyW( prov_info->pwszContainerName, container );
+
+    ptr += len_container;
+    prov_info->pwszProvName = ptr;
+    lstrcpyW( prov_info->pwszProvName, name );
+
+    size = sizeof(prov_info->dwProvType);
+    CryptGetProvParam( prov, PP_PROVTYPE, (BYTE *)&prov_info->dwProvType, &size, 0 );
+
+    prov_info->dwFlags     = 0;
+    prov_info->cProvParam  = 0;
+    prov_info->rgProvParam = NULL;
+    size = sizeof(prov_info->dwKeySpec);
+    CryptGetProvParam( prov, PP_KEYSPEC, (BYTE *)&prov_info->dwKeySpec, &size, 0 );
+
+    ret = CertSetCertificateContextProperty( ctx, CERT_KEY_PROV_INFO_PROP_ID, 0, prov_info );
+
+    CryptMemFree( prov_info );
+    CryptMemFree( name );
+    CryptMemFree( container );
+    return ret;
+}
+
+HCERTSTORE WINAPI PFXImportCertStore( CRYPT_DATA_BLOB *pfx, const WCHAR *password, DWORD flags )
+{
+    DWORD i = 0, size;
+    HCERTSTORE store = NULL;
+    HCRYPTPROV prov = 0;
+    cert_store_data_t data = 0;
+    struct open_cert_store_params open_params = { pfx, password, &data };
+    struct close_cert_store_params close_params;
+
+    if (!pfx)
+    {
+        SetLastError( ERROR_INVALID_PARAMETER );
+        return NULL;
+    }
+    if (flags & ~(CRYPT_EXPORTABLE|CRYPT_USER_KEYSET|CRYPT_MACHINE_KEYSET|PKCS12_NO_PERSIST_KEY))
+    {
+        FIXME( "flags %08lx not supported\n", flags );
+        return NULL;
+    }
+    if (CRYPT32_CALL( open_cert_store, &open_params )) return NULL;
+
+    prov = import_key( data, flags );
+    if (!prov) goto error;
+
+    if (!(store = CertOpenStore( CERT_STORE_PROV_MEMORY, 0, 0, 0, NULL )))
+    {
+        WARN( "CertOpenStore failed %08lx\n", GetLastError() );
+        goto error;
+    }
+
+    for (;;)
+    {
+        const void *ctx = NULL;
+        void *cert;
+        struct import_store_cert_params import_params = { data, i, NULL, &size };
+
+        if (CRYPT32_CALL( import_store_cert, &import_params ) != STATUS_BUFFER_TOO_SMALL) break;
+        import_params.buf = cert = CryptMemAlloc( size );
+        if (!CRYPT32_CALL( import_store_cert, &import_params ))
+            ctx = CertCreateContext( CERT_STORE_CERTIFICATE_CONTEXT, X509_ASN_ENCODING, cert, size, 0, NULL );
+        CryptMemFree( cert );
+        if (!ctx)
+        {
+            WARN( "CertCreateContext failed %08lx\n", GetLastError() );
+            goto error;
+        }
+        if (flags & PKCS12_NO_PERSIST_KEY)
+        {
+            if (!set_key_context( ctx, prov ))
+            {
+                WARN( "failed to set context property %08lx\n", GetLastError() );
+                CertFreeCertificateContext( ctx );
+                goto error;
+            }
+        }
+        else if (!set_key_prov_info( ctx, prov ))
+        {
+            WARN( "failed to set provider info property %08lx\n", GetLastError() );
+            CertFreeCertificateContext( ctx );
+            goto error;
+        }
+        if (!CertAddCertificateContextToStore( store, ctx, CERT_STORE_ADD_ALWAYS, NULL ))
+        {
+            WARN( "CertAddCertificateContextToStore failed %08lx\n", GetLastError() );
+            CertFreeCertificateContext( ctx );
+            goto error;
+        }
+        CertFreeCertificateContext( ctx );
+        i++;
+    }
+    close_params.data = data;
+    CRYPT32_CALL( close_cert_store, &close_params );
+    return store;
+
+error:
+    CryptReleaseContext( prov, 0 );
+    CertCloseStore( store, 0 );
+    close_params.data = data;
+    CRYPT32_CALL( close_cert_store, &close_params );
+    return NULL;
+}
+
+BOOL WINAPI PFXVerifyPassword( CRYPT_DATA_BLOB *pfx, const WCHAR *password, DWORD flags )
+{
+    FIXME( "(%p, %p, %08lx): stub\n", pfx, password, flags );
+    return FALSE;
+}
+
+BOOL WINAPI PFXExportCertStore( HCERTSTORE store, CRYPT_DATA_BLOB *pfx, const WCHAR *password, DWORD flags )
+{
+    return PFXExportCertStoreEx( store, pfx, password, NULL, flags );
+}
+
+BOOL WINAPI PFXExportCertStoreEx( HCERTSTORE store, CRYPT_DATA_BLOB *pfx, const WCHAR *password, void *reserved,
+                                  DWORD flags )
+{
+    FIXME( "(%p, %p, %p, %p, %08lx): stub\n", store, pfx, password, reserved, flags );
+    return FALSE;
+}

--- a/dll/win32/crypt32/precomp.h
+++ b/dll/win32/crypt32/precomp.h
@@ -12,8 +12,6 @@
 #define _INC_WINDOWS
 #define COM_NO_WINDOWS_H
 
-#define NONAMELESSUNION
-
 #include <ntstatus.h>
 #define WIN32_NO_STATUS
 #include <windef.h>

--- a/dll/win32/crypt32/proplist.c
+++ b/dll/win32/crypt32/proplist.c
@@ -46,7 +46,7 @@ CONTEXT_PROPERTY_LIST *ContextPropertyList_Create(void)
 
     if (list)
     {
-        InitializeCriticalSection(&list->cs);
+        InitializeCriticalSectionEx(&list->cs, 0, RTL_CRITICAL_SECTION_FLAG_FORCE_DEBUG_INFO);
         list->cs.DebugInfo->Spare[0] = (DWORD_PTR)(__FILE__ ": PCONTEXT_PROPERTY_LIST->cs");
         list_init(&list->properties);
     }
@@ -75,7 +75,7 @@ BOOL ContextPropertyList_FindProperty(CONTEXT_PROPERTY_LIST *list, DWORD id,
     CONTEXT_PROPERTY *prop;
     BOOL ret = FALSE;
 
-    TRACE("(%p, %d, %p)\n", list, id, blob);
+    TRACE("(%p, %ld, %p)\n", list, id, blob);
 
     EnterCriticalSection(&list->cs);
     LIST_FOR_EACH_ENTRY(prop, &list->properties, CONTEXT_PROPERTY, entry)

--- a/dll/win32/crypt32/provstore.c
+++ b/dll/win32/crypt32/provstore.c
@@ -46,7 +46,7 @@ typedef struct _WINE_PROVIDERSTORE
 static void ProvStore_addref(WINECRYPT_CERTSTORE *store)
 {
     LONG ref = InterlockedIncrement(&store->ref);
-    TRACE("ref = %d\n", ref);
+    TRACE("ref = %ld\n", ref);
 }
 
 static DWORD ProvStore_release(WINECRYPT_CERTSTORE *cert_store, DWORD flags)
@@ -55,10 +55,10 @@ static DWORD ProvStore_release(WINECRYPT_CERTSTORE *cert_store, DWORD flags)
     LONG ref;
 
     if(flags)
-        FIXME("Unimplemented flags %x\n", flags);
+        FIXME("Unimplemented flags %lx\n", flags);
 
     ref = InterlockedDecrement(&store->hdr.ref);
-    TRACE("(%p) ref=%d\n", store, ref);
+    TRACE("(%p) ref=%ld\n", store, ref);
 
     if(ref)
         return ERROR_SUCCESS;
@@ -275,7 +275,7 @@ static BOOL ProvStore_control(WINECRYPT_CERTSTORE *cert_store, DWORD dwFlags, DW
     WINE_PROVIDERSTORE *store = (WINE_PROVIDERSTORE*)cert_store;
     BOOL ret = TRUE;
 
-    TRACE("(%p, %08x, %d, %p)\n", store, dwFlags, dwCtrlType,
+    TRACE("(%p, %08lx, %ld, %p)\n", store, dwFlags, dwCtrlType,
      pvCtrlPara);
 
     if (store->provControl)

--- a/dll/win32/crypt32/reactos/store.c
+++ b/dll/win32/crypt32/reactos/store.c
@@ -1,0 +1,65 @@
+/*
+ * PROJECT:     ReactOS win32 DLLs
+ * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
+ * PURPOSE:     ReactOS store related code for crypt32
+ * COPYRIGHT:   Copyright 2025 Ratin Gao <ratin@knsoft.org>
+ */
+
+#include <windef.h>
+#include <winbase.h>
+#include <wincrypt.h>
+#include <wine/debug.h>
+#include <crypt32_private.h>
+
+WINE_DEFAULT_DEBUG_CHANNEL(crypt);
+
+typedef struct _CERT_SYSTEM_STORE_LOCATION
+{
+    DWORD dwFlags;
+    PCWSTR pwszStoreLocation;
+} CERT_SYSTEM_STORE_LOCATION, *PCERT_SYSTEM_STORE_LOCATION;
+
+static const CERT_SYSTEM_STORE_LOCATION gSystemStoreLocations[] = {
+    { CERT_SYSTEM_STORE_CURRENT_USER, L"CurrentUser" },
+    { CERT_SYSTEM_STORE_LOCAL_MACHINE, L"LocalMachine" },
+    { CERT_SYSTEM_STORE_CURRENT_SERVICE, L"CurrentService" },
+    { CERT_SYSTEM_STORE_SERVICES, L"Services" },
+    { CERT_SYSTEM_STORE_USERS, L"Users" },
+    { CERT_SYSTEM_STORE_CURRENT_USER_GROUP_POLICY, L"CurrentUserGroupPolicy" },
+    { CERT_SYSTEM_STORE_LOCAL_MACHINE_GROUP_POLICY, L"LocalMachineGroupPolicy" },
+    { CERT_SYSTEM_STORE_LOCAL_MACHINE_ENTERPRISE, L"LocalMachineEnterprise" },
+};
+
+BOOL
+WINAPI
+CertEnumSystemStoreLocation(
+    _In_ DWORD dwFlags,
+    _Inout_opt_ void *pvArg,
+    __callback PFN_CERT_ENUM_SYSTEM_STORE_LOCATION pfnEnum)
+{
+    DWORD i;
+
+    /* Check input flags */
+    if (dwFlags != 0)
+    {
+        SetLastError(E_INVALIDARG);
+        return FALSE;
+    }
+
+    /* Return fixed system stores */
+    for (i = 0; i < ARRAYSIZE(gSystemStoreLocations); i++)
+    {
+        if (!pfnEnum(gSystemStoreLocations[i].pwszStoreLocation,
+                     gSystemStoreLocations[i].dwFlags,
+                     NULL,
+                     pvArg))
+        {
+            return FALSE;
+        }
+    }
+
+    /* FIXME: Return registered OID system stores by calling CryptEnumOIDFunction */
+    FIXME("Registered OID system stores is not enumerated\n");
+
+    return TRUE;
+}

--- a/dll/win32/crypt32/reactos/unixlib.c
+++ b/dll/win32/crypt32/reactos/unixlib.c
@@ -1,0 +1,338 @@
+/*
+ * PROJECT:     ReactOS win32 DLLs
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     ReactOS emulation layer for crypt32 unixlib calls
+ * COPYRIGHT:   Copyright 2026 Timo Kreuzer <timo.kreuzer@reactos.org>
+ */
+#include <assert.h>
+#include <windef.h>
+#include <winbase.h>
+#include <winreg.h>
+#include <wincrypt.h>
+#include <wine/debug.h>
+#include "crypt32_private.h"
+
+WINE_DEFAULT_DEBUG_CHANNEL(crypt);
+
+// See https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-gpef/e051aba9-c9df-4f82-a42a-c13012c9d381
+typedef struct _CRYPT_CERT_PROP
+{
+    DWORD dwPropId;
+    DWORD dwReserved;
+    DWORD cbData;
+    BYTE ajData[ANYSIZE_ARRAY];
+} CRYPT_CERT_PROP, *PCRYPT_CERT_PROP;
+
+static
+BOOL
+FindCertInRegBlob(
+    _In_ const CRYPT_DATA_BLOB* RegBlob,
+    _Out_ PCRYPT_DER_BLOB OutCertBlob)
+{
+    PCRYPT_CERT_PROP prop;
+    DWORD offset = 0;
+
+    /* Parse the registry blob */
+    while ((offset + sizeof(CRYPT_CERT_PROP)) < RegBlob->cbData)
+    {
+        prop = (PCRYPT_CERT_PROP)(RegBlob->pbData + offset);
+
+        if (prop->dwReserved != 0x00000001)
+        {
+            /* Invalid reserved field */
+            return FALSE;
+        }
+
+        /* Check for the certificate property (ID 32) */
+        if (prop->dwPropId == 32)
+        {
+            if ((offset + prop->cbData) > RegBlob->cbData)
+            {
+                /* Invalid data size */
+                return FALSE;
+            }
+
+            OutCertBlob->cbData = prop->cbData;
+            OutCertBlob->pbData = prop->ajData;
+            return TRUE;
+        }
+
+        /* Move to the next property */
+        offset += FIELD_OFFSET(CRYPT_CERT_PROP, ajData) + prop->cbData;
+    }
+
+    return FALSE;
+}
+
+static
+BOOL
+LoadCertBlobFromReg(
+    _In_ HKEY hRootKey,
+    _In_z_ PWSTR pwszSubkeyName,
+    _Out_ PCRYPT_DATA_BLOB RegDataBlob)
+{
+    HKEY hCert;
+    DWORD dwLength = 0;
+    DWORD dwType;
+    LSTATUS ret;
+    PVOID pvBuffer = NULL;
+
+    RegDataBlob->cbData = 0;
+    RegDataBlob->pbData = NULL;
+
+    /* Open the certificate subkey */
+    ret = RegOpenKeyExW(hRootKey, pwszSubkeyName, 0, KEY_READ, &hCert);
+    if (ret != ERROR_SUCCESS)
+    {
+        return FALSE;
+    }
+
+    /* Query blob size */
+    ret = RegQueryValueExW(hCert, L"Blob", NULL, &dwType, NULL, &dwLength);
+    if (ret != ERROR_SUCCESS || dwType != REG_BINARY)
+    {
+        RegCloseKey(hCert);
+        return FALSE;
+    }
+
+    /* Allocate the buffer */
+    pvBuffer = HeapAlloc(GetProcessHeap(), 0, dwLength);
+    if (pvBuffer == NULL)
+    {
+        RegCloseKey(hCert);
+        return FALSE;
+    }
+        
+    /* Fetch the registry blob */
+    ret = RegQueryValueExW(hCert, L"Blob", NULL, &dwType, pvBuffer, &dwLength);
+    RegCloseKey(hCert);
+
+    if ((ret != ERROR_SUCCESS) || (dwType != REG_BINARY))
+    {
+        HeapFree(GetProcessHeap(), 0, pvBuffer);
+        return FALSE;
+    }
+
+    RegDataBlob->pbData = pvBuffer;
+    RegDataBlob->cbData = dwLength;
+    return TRUE;
+}
+
+static
+LSTATUS
+LoadCertificateFromStore(
+    HKEY hRoot,
+    DWORD dwIndex,
+    PVOID pvBuffer,
+    DWORD cbBufferSize,
+    PDWORD pcbRequired)
+{
+    WCHAR awcSubkey[64];
+    CRYPT_DATA_BLOB regBlob;
+    CRYPT_DER_BLOB certBlob;
+    LSTATUS ret;
+
+    if (pcbRequired == 0)
+    {
+        return ERROR_INVALID_PARAMETER;
+    }
+
+    /* Enumerate next subkey */
+    ret = RegEnumKeyW(hRoot, dwIndex, awcSubkey, ARRAYSIZE(awcSubkey));
+    if (ret != ERROR_SUCCESS)
+    {
+        return ret;
+    }
+
+    /* Load the registry blob */
+    if (!LoadCertBlobFromReg(hRoot, awcSubkey, &regBlob))
+    {
+        return ERROR_NO_DATA;
+    }
+
+    /* Extract the certificate from the registry blob */
+    if (!FindCertInRegBlob(&regBlob, &certBlob))
+    {
+        HeapFree(GetProcessHeap(), 0, regBlob.pbData);
+        return ERROR_NO_DATA;
+    }
+
+    *pcbRequired = certBlob.cbData;
+
+    /* Check if we have a usable buffer */
+    if ((pvBuffer != NULL) && (cbBufferSize >= certBlob.cbData))
+    {
+        /* Copy the certificate data to the output buffer */
+        memcpy(pvBuffer, certBlob.pbData, certBlob.cbData);
+        ret = ERROR_SUCCESS;
+    }
+    else
+    {
+        ret = SEC_E_BUFFER_TOO_SMALL;
+    }
+
+    /* Free the registry blob buffer */
+    HeapFree(GetProcessHeap(), 0, regBlob.pbData);
+
+    /* Successfully retrieved a certificate */
+    return ret;
+}
+
+// Note: this function is not thread-safe! It is called under a lock in crypt32.
+static
+int
+EnumerateRootCertificates(
+    PVOID pvBuffer,
+    DWORD cbBufferSize,
+    PDWORD pcbRequired)
+{
+    const WCHAR* aszStoreKeyNames[] = {
+        L"Software\\Microsoft\\SystemCertificates\\Root\\Certificates",
+        L"Software\\Microsoft\\SystemCertificates\\AuthRoot\\Certificates"
+    };
+    static DWORD dwStoreIndex = 0;
+    static HKEY hStoreKey = NULL;
+    static DWORD dwCertIndex = 0;
+    LSTATUS ret;
+
+    assert(pcbRequired != NULL);
+
+    /* Root store enumeration loop */
+    for (; dwStoreIndex < ARRAYSIZE(aszStoreKeyNames); dwStoreIndex++)
+    {
+        if (hStoreKey == NULL)
+        {
+            /* Open the key for the root certificates */
+            ret = RegOpenKeyExW(HKEY_LOCAL_MACHINE,
+                                aszStoreKeyNames[dwStoreIndex],
+                                0,
+                                KEY_READ,
+                                &hStoreKey);
+            if (ret != ERROR_SUCCESS)
+                continue;
+        }
+
+        /* Cert enumeration loop */
+        for (; dwCertIndex < MAXDWORD; dwCertIndex++)
+        {
+
+            ret = LoadCertificateFromStore(hStoreKey,
+                                           dwCertIndex,
+                                           pvBuffer,
+                                           cbBufferSize,
+                                           pcbRequired);
+            if (ret == ERROR_SUCCESS)
+            {
+                /* Successfully retrieved a certificate */
+                dwCertIndex++;
+                return 0;
+            }
+
+            if (ret == SEC_E_BUFFER_TOO_SMALL)
+            {
+                /* Buffer too small, return required size, but don't increment index! */
+                return ENOBUFS;
+            }
+
+            if (ret == ERROR_NO_MORE_ITEMS)
+            {
+                /* No more certificates in this store, break to move to next store */
+                break;
+            }
+        }
+
+        /* Move to the next root store */
+        RegCloseKey(hStoreKey);
+        hStoreKey = NULL;
+        dwCertIndex = 0;
+    }
+
+    /* No more certificates in any store */
+    if (hStoreKey != NULL)
+        RegCloseKey(hStoreKey);
+    hStoreKey = NULL;
+    dwStoreIndex = 0;
+    dwCertIndex = 0;
+    return ENOENT;
+}
+
+int __reactos_call_unix_enum_root_certs(void* Args)
+{
+    struct enum_root_certs_params* params = (struct enum_root_certs_params*)Args;
+    return EnumerateRootCertificates(params->buffer,
+                                     params->size,
+                                     params->needed);
+}
+
+static
+int
+OpenCertStore(
+    CRYPT_DATA_BLOB *pfx,
+    const WCHAR *password,
+    cert_store_data_t *data_ret)
+{
+    UNIMPLEMENTED;
+    return -1;
+}
+
+int __reactos_call_unix_open_cert_store(void* Args)
+{
+    struct open_cert_store_params* params = (struct open_cert_store_params*)Args;
+    return OpenCertStore(params->pfx,
+                         params->password,
+                         params->data_ret);
+}
+
+static
+int
+CloseCertStore(cert_store_data_t data)
+{
+    UNIMPLEMENTED;
+    return -1;
+}
+
+int __reactos_call_unix_close_cert_store(void* Args)
+{
+    struct close_cert_store_params* params = (struct close_cert_store_params*)Args;
+    return CloseCertStore(params->data);
+}
+
+static
+int
+ImportStoreKey(
+    cert_store_data_t data,
+    void *buf,
+    DWORD *buf_size)
+{
+    UNIMPLEMENTED;
+    return -1;
+}
+
+int __reactos_call_unix_import_store_key(void* Args)
+{
+    struct import_store_key_params* params = (struct import_store_key_params*)Args;
+    return ImportStoreKey(params->data,
+                          params->buf,
+                          params->buf_size);
+}
+
+static
+int
+ImportStoreCert(
+    cert_store_data_t data,
+    unsigned int index,
+    void *buf,
+    DWORD *buf_size)
+{
+    UNIMPLEMENTED;
+    return -1;
+}
+
+int __reactos_call_unix_import_store_cert(void* Args)
+{
+    struct import_store_cert_params* params = (struct import_store_cert_params*)Args;
+    return ImportStoreCert(params->data,
+                           params->index,
+                           params->buf,
+                           params->buf_size);
+}

--- a/dll/win32/crypt32/rootstore.c
+++ b/dll/win32/crypt32/rootstore.c
@@ -15,196 +15,59 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
-#include "config.h"
+
 #include <stdarg.h>
 #include <stdio.h>
-#include <sys/types.h>
-#ifdef HAVE_SYS_STAT_H
-#include <sys/stat.h>
-#endif
-#ifdef HAVE_DIRENT_H
-#include <dirent.h>
-#endif
-#include <fcntl.h>
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
-#endif
-#include <errno.h>
-#include <limits.h>
-#ifdef HAVE_SECURITY_SECURITY_H
-#include <Security/Security.h>
-#endif
+
 #include "ntstatus.h"
 #define WIN32_NO_STATUS
 #include "windef.h"
 #include "winbase.h"
 #include "winreg.h"
 #include "wincrypt.h"
-#include "wine/winternl.h"
+#include "winternl.h"
 #include "wine/debug.h"
 #include "crypt32_private.h"
 
 WINE_DEFAULT_DEBUG_CHANNEL(crypt);
 
-#define INITIAL_CERT_BUFFER 1024
-
-struct DynamicBuffer
-{
-    DWORD allocated;
-    DWORD used;
-    BYTE *data;
-};
-
-static inline void reset_buffer(struct DynamicBuffer *buffer)
-{
-    buffer->used = 0;
-    if (buffer->data) buffer->data[0] = 0;
-}
-
-static BOOL add_line_to_buffer(struct DynamicBuffer *buffer, LPCSTR line)
-{
-    BOOL ret;
-
-    if (buffer->used + strlen(line) + 1 > buffer->allocated)
-    {
-        if (!buffer->allocated)
-        {
-            buffer->data = CryptMemAlloc(INITIAL_CERT_BUFFER);
-            if (buffer->data)
-            {
-                buffer->data[0] = 0;
-                buffer->allocated = INITIAL_CERT_BUFFER;
-            }
-        }
-        else
-        {
-            DWORD new_size = max(buffer->allocated * 2,
-             buffer->used + strlen(line) + 1);
-
-            buffer->data = CryptMemRealloc(buffer->data, new_size);
-            if (buffer->data)
-                buffer->allocated = new_size;
-        }
-    }
-    if (buffer->data)
-    {
-        strcpy((char *)buffer->data + strlen((char *)buffer->data), line);
-        /* Not strlen + 1, otherwise we'd count the NULL for every line's
-         * addition (but we overwrite the previous NULL character.)  Not an
-         * overrun, we allocate strlen + 1 bytes above.
-         */
-        buffer->used += strlen(line);
-        ret = TRUE;
-    }
-    else
-        ret = FALSE;
-    return ret;
-}
-
-/* Reads any base64-encoded certificates present in fp and adds them to store.
- * Returns TRUE if any certificates were successfully imported.
- */
-static BOOL import_base64_certs_from_fp(FILE *fp, HCERTSTORE store)
-{
-    char line[1024];
-    BOOL in_cert = FALSE;
-    struct DynamicBuffer saved_cert = { 0, 0, NULL };
-    int num_certs = 0;
-
-    TRACE("\n");
-    while (fgets(line, sizeof(line), fp))
-    {
-        static const char header[] = "-----BEGIN CERTIFICATE-----";
-        static const char trailer[] = "-----END CERTIFICATE-----";
-
-        if (!strncmp(line, header, strlen(header)))
-        {
-            TRACE("begin new certificate\n");
-            in_cert = TRUE;
-            reset_buffer(&saved_cert);
-        }
-        else if (!strncmp(line, trailer, strlen(trailer)))
-        {
-            DWORD size;
-
-            TRACE("end of certificate, adding cert\n");
-            in_cert = FALSE;
-            if (CryptStringToBinaryA((char *)saved_cert.data, saved_cert.used,
-             CRYPT_STRING_BASE64, NULL, &size, NULL, NULL))
-            {
-                LPBYTE buf = CryptMemAlloc(size);
-
-                if (buf)
-                {
-                    CryptStringToBinaryA((char *)saved_cert.data,
-                     saved_cert.used, CRYPT_STRING_BASE64, buf, &size, NULL,
-                     NULL);
-                    if (CertAddEncodedCertificateToStore(store,
-                     X509_ASN_ENCODING, buf, size, CERT_STORE_ADD_NEW, NULL))
-                        num_certs++;
-                    CryptMemFree(buf);
-                }
-            }
-        }
-        else if (in_cert)
-            add_line_to_buffer(&saved_cert, line);
-    }
-    CryptMemFree(saved_cert.data);
-    TRACE("Read %d certs\n", num_certs);
-    return num_certs > 0;
-}
-
 static const char *trust_status_to_str(DWORD status)
 {
+    static const struct
+    {
+        DWORD flag;
+        char text[32];
+    }
+    messages[] =
+    {
+        { CERT_TRUST_IS_NOT_TIME_VALID, "expired" },
+        { CERT_TRUST_IS_NOT_TIME_NESTED, "bad time nesting" },
+        { CERT_TRUST_IS_REVOKED, "revoked" },
+        { CERT_TRUST_IS_NOT_SIGNATURE_VALID, "bad signature" },
+        { CERT_TRUST_IS_NOT_VALID_FOR_USAGE, "bad usage" },
+        { CERT_TRUST_IS_UNTRUSTED_ROOT, "untrusted root" },
+        { CERT_TRUST_REVOCATION_STATUS_UNKNOWN, "unknown revocation status" },
+        { CERT_TRUST_IS_CYCLIC, "cyclic chain" },
+        { CERT_TRUST_INVALID_EXTENSION, "unsupported critical extension" },
+        { CERT_TRUST_INVALID_POLICY_CONSTRAINTS, "bad policy" },
+        { CERT_TRUST_INVALID_BASIC_CONSTRAINTS, "bad basic constraints" },
+        { CERT_TRUST_INVALID_NAME_CONSTRAINTS, "bad name constraints" },
+        { CERT_TRUST_HAS_NOT_SUPPORTED_NAME_CONSTRAINT, "unsupported name constraint" },
+        { CERT_TRUST_HAS_NOT_DEFINED_NAME_CONSTRAINT, "undefined name constraint" },
+        { CERT_TRUST_HAS_NOT_PERMITTED_NAME_CONSTRAINT, "disallowed name constraint" },
+        { CERT_TRUST_HAS_EXCLUDED_NAME_CONSTRAINT, "excluded name constraint" },
+        { CERT_TRUST_IS_OFFLINE_REVOCATION, "revocation server offline" },
+        { CERT_TRUST_NO_ISSUANCE_CHAIN_POLICY, "no issuance policy" },
+    };
     static char buf[1024];
-    int pos = 0;
+    int i, pos = 0;
 
-    if (status & CERT_TRUST_IS_NOT_TIME_VALID)
-        pos += snprintf(buf + pos, sizeof(buf) - pos, "\n\texpired");
-    if (status & CERT_TRUST_IS_NOT_TIME_NESTED)
-        pos += snprintf(buf + pos, sizeof(buf) - pos, "\n\tbad time nesting");
-    if (status & CERT_TRUST_IS_REVOKED)
-        pos += snprintf(buf + pos, sizeof(buf) - pos, "\n\trevoked");
-    if (status & CERT_TRUST_IS_NOT_SIGNATURE_VALID)
-        pos += snprintf(buf + pos, sizeof(buf) - pos, "\n\tbad signature");
-    if (status & CERT_TRUST_IS_NOT_VALID_FOR_USAGE)
-        pos += snprintf(buf + pos, sizeof(buf) - pos, "\n\tbad usage");
-    if (status & CERT_TRUST_IS_UNTRUSTED_ROOT)
-        pos += snprintf(buf + pos, sizeof(buf) - pos, "\n\tuntrusted root");
-    if (status & CERT_TRUST_REVOCATION_STATUS_UNKNOWN)
-        pos += snprintf(buf + pos, sizeof(buf) - pos,
-         "\n\tunknown revocation status");
-    if (status & CERT_TRUST_IS_CYCLIC)
-        pos += snprintf(buf + pos, sizeof(buf) - pos, "\n\tcyclic chain");
-    if (status & CERT_TRUST_INVALID_EXTENSION)
-        pos += snprintf(buf + pos, sizeof(buf) - pos,
-         "\n\tunsupported critical extension");
-    if (status & CERT_TRUST_INVALID_POLICY_CONSTRAINTS)
-        pos += snprintf(buf + pos, sizeof(buf) - pos, "\n\tbad policy");
-    if (status & CERT_TRUST_INVALID_BASIC_CONSTRAINTS)
-        pos += snprintf(buf + pos, sizeof(buf) - pos,
-         "\n\tbad basic constraints");
-    if (status & CERT_TRUST_INVALID_NAME_CONSTRAINTS)
-        pos += snprintf(buf + pos, sizeof(buf) - pos,
-         "\n\tbad name constraints");
-    if (status & CERT_TRUST_HAS_NOT_SUPPORTED_NAME_CONSTRAINT)
-        pos += snprintf(buf + pos, sizeof(buf) - pos,
-         "\n\tunsupported name constraint");
-    if (status & CERT_TRUST_HAS_NOT_DEFINED_NAME_CONSTRAINT)
-        pos += snprintf(buf + pos, sizeof(buf) - pos,
-         "\n\tundefined name constraint");
-    if (status & CERT_TRUST_HAS_NOT_PERMITTED_NAME_CONSTRAINT)
-        pos += snprintf(buf + pos, sizeof(buf) - pos,
-         "\n\tdisallowed name constraint");
-    if (status & CERT_TRUST_HAS_EXCLUDED_NAME_CONSTRAINT)
-        pos += snprintf(buf + pos, sizeof(buf) - pos,
-         "\n\texcluded name constraint");
-    if (status & CERT_TRUST_IS_OFFLINE_REVOCATION)
-        pos += snprintf(buf + pos, sizeof(buf) - pos,
-         "\n\trevocation server offline");
-    if (status & CERT_TRUST_NO_ISSUANCE_CHAIN_POLICY)
-        pos += snprintf(buf + pos, sizeof(buf) - pos,
-         "\n\tno issuance policy");
+    for (i = 0; i < ARRAY_SIZE(messages); i++)
+    {
+        if (status & messages[i].flag)
+            pos += sprintf(buf + pos, "\n\t%s", messages[i].text);
+    }
+
     return buf;
 }
 
@@ -235,7 +98,7 @@ static const char *get_cert_common_name(PCCERT_CONTEXT cert)
     return name;
 }
 
-static void check_and_store_certs(HCERTSTORE from, HCERTSTORE to)
+static void check_and_store_certs(HCERTSTORE cached, HCERTSTORE new, HCERTSTORE to)
 {
     DWORD root_count = 0;
     CERT_CHAIN_ENGINE_CONFIG chainEngineConfig =
@@ -251,14 +114,14 @@ static void check_and_store_certs(HCERTSTORE from, HCERTSTORE to)
         PCCERT_CONTEXT cert = NULL;
 
         do {
-            cert = CertEnumCertificatesInStore(from, cert);
+            cert = CertEnumCertificatesInStore(new, cert);
             if (cert)
             {
                 CERT_CHAIN_PARA chainPara = { sizeof(chainPara), { 0 } };
                 PCCERT_CHAIN_CONTEXT chain;
                 BOOL ret;
 
-                ret = CertGetCertificateChain(engine, cert, NULL, from,
+                ret = CertGetCertificateChain(engine, cert, NULL, cached,
                  &chainPara, CERT_CHAIN_CACHE_ONLY_URL_RETRIEVAL, NULL, &chain);
                 if (!ret)
                     TRACE("rejecting %s: %s\n", get_cert_common_name(cert),
@@ -302,201 +165,8 @@ static void check_and_store_certs(HCERTSTORE from, HCERTSTORE to)
         } while (cert);
         CertFreeCertificateChainEngine(engine);
     }
-    TRACE("Added %d root certificates\n", root_count);
+    TRACE("Added %ld root certificates\n", root_count);
 }
-
-/* Reads the file fd, and imports any certificates in it into store.
- * Returns TRUE if any certificates were successfully imported.
- */
-static BOOL import_certs_from_file(int fd, HCERTSTORE store)
-{
-    BOOL ret = FALSE;
-    FILE *fp;
-
-    TRACE("\n");
-
-    fp = fdopen(fd, "r");
-    if (fp)
-    {
-        ret = import_base64_certs_from_fp(fp, store);
-        fclose(fp);
-    }
-    return ret;
-}
-
-static BOOL import_certs_from_path(LPCSTR path, HCERTSTORE store,
- BOOL allow_dir);
-
-#ifdef HAVE_READDIR
-static BOOL check_buffer_resize(char **ptr_buf, size_t *buf_size, size_t check_size)
-{
-    if (check_size > *buf_size)
-    {
-        *buf_size = check_size;
-
-        if (*ptr_buf)
-        {
-            char *realloc_buf = CryptMemRealloc(*ptr_buf, *buf_size);
-
-            if (!realloc_buf)
-                return FALSE;
-
-            *ptr_buf = realloc_buf;
-        }
-        else
-        {
-            *ptr_buf = CryptMemAlloc(*buf_size);
-            if (!*ptr_buf)
-                return FALSE;
-        }
-    }
-
-    return TRUE;
-}
-#endif
-
-/* Opens path, which must be a directory, and imports certificates from every
- * file in the directory into store.
- * Returns TRUE if any certificates were successfully imported.
- */
-static BOOL import_certs_from_dir(LPCSTR path, HCERTSTORE store)
-{
-#ifdef HAVE_READDIR
-    BOOL ret = FALSE;
-    DIR *dir;
-
-    TRACE("(%s, %p)\n", debugstr_a(path), store);
-
-    dir = opendir(path);
-    if (dir)
-    {
-        size_t path_len = strlen(path), bufsize = 0;
-        char *filebuf = NULL;
-
-        struct dirent *entry;
-        while ((entry = readdir(dir)))
-        {
-            if (strcmp(entry->d_name, ".") && strcmp(entry->d_name, ".."))
-            {
-                size_t name_len = strlen(entry->d_name);
-
-                if (!check_buffer_resize(&filebuf, &bufsize, path_len + 1 + name_len + 1))
-                {
-                    ERR("Path buffer (re)allocation failed with out of memory condition\n");
-                    break;
-                }
-                snprintf(filebuf, bufsize, "%s/%s", path, entry->d_name);
-                if (import_certs_from_path(filebuf, store, FALSE) && !ret)
-                    ret = TRUE;
-            }
-        }
-        CryptMemFree(filebuf);
-        closedir(dir);
-    }
-    return ret;
-#else
-    FIXME("not implemented without readdir available\n");
-    return FALSE;
-#endif
-}
-
-/* Opens path, which may be a file or a directory, and imports any certificates
- * it finds into store.
- * Returns TRUE if any certificates were successfully imported.
- */
-static BOOL import_certs_from_path(LPCSTR path, HCERTSTORE store,
- BOOL allow_dir)
-{
-    BOOL ret = FALSE;
-    int fd;
-
-    TRACE("(%s, %p, %d)\n", debugstr_a(path), store, allow_dir);
-
-    fd = open(path, O_RDONLY);
-    if (fd != -1)
-    {
-        struct stat st;
-
-        if (fstat(fd, &st) == 0)
-        {
-            if (S_ISREG(st.st_mode))
-                ret = import_certs_from_file(fd, store);
-            else if (S_ISDIR(st.st_mode))
-            {
-                if (allow_dir)
-                    ret = import_certs_from_dir(path, store);
-                else
-                    WARN("%s is a directory and directories are disallowed\n",
-                     debugstr_a(path));
-            }
-            else
-                ERR("%s: invalid file type\n", path);
-        }
-        close(fd);
-    }
-    return ret;
-}
-
-#ifdef __REACTOS__
-
-static BOOL WINAPI CRYPT_RootWriteCert(HCERTSTORE hCertStore,
- PCCERT_CONTEXT cert, DWORD dwFlags)
-{
-    /* The root store can't have certs added */
-    return FALSE;
-}
-
-static BOOL WINAPI CRYPT_RootDeleteCert(HCERTSTORE hCertStore,
- PCCERT_CONTEXT cert, DWORD dwFlags)
-{
-    /* The root store can't have certs deleted */
-    return FALSE;
-}
-
-static BOOL WINAPI CRYPT_RootWriteCRL(HCERTSTORE hCertStore,
- PCCRL_CONTEXT crl, DWORD dwFlags)
-{
-    /* The root store can have CRLs added.  At worst, a malicious application
-     * can DoS itself, as the changes aren't persisted in any way.
-     */
-    return TRUE;
-}
-
-static BOOL WINAPI CRYPT_RootDeleteCRL(HCERTSTORE hCertStore,
- PCCRL_CONTEXT crl, DWORD dwFlags)
-{
-    /* The root store can't have CRLs deleted */
-    return FALSE;
-}
-
-static void *rootProvFuncs[] = {
-    NULL, /* CERT_STORE_PROV_CLOSE_FUNC */
-    NULL, /* CERT_STORE_PROV_READ_CERT_FUNC */
-    CRYPT_RootWriteCert,
-    CRYPT_RootDeleteCert,
-    NULL, /* CERT_STORE_PROV_SET_CERT_PROPERTY_FUNC */
-    NULL, /* CERT_STORE_PROV_READ_CRL_FUNC */
-    CRYPT_RootWriteCRL,
-    CRYPT_RootDeleteCRL,
-    NULL, /* CERT_STORE_PROV_SET_CRL_PROPERTY_FUNC */
-    NULL, /* CERT_STORE_PROV_READ_CTL_FUNC */
-    NULL, /* CERT_STORE_PROV_WRITE_CTL_FUNC */
-    NULL, /* CERT_STORE_PROV_DELETE_CTL_FUNC */
-    NULL, /* CERT_STORE_PROV_SET_CTL_PROPERTY_FUNC */
-    NULL, /* CERT_STORE_PROV_CONTROL_FUNC */
-};
-
-#endif /* __REACTOS__ */
-
-static const char * const CRYPT_knownLocations[] = {
- "/etc/ssl/certs/ca-certificates.crt",
- "/etc/ssl/certs",
- "/etc/pki/tls/certs/ca-bundle.crt",
- "/usr/share/ca-certificates/ca-bundle.crt",
- "/usr/local/share/certs/",
- "/etc/sfw/openssl/certs",
- "/etc/security/cacerts",  /* Android */
-};
 
 static const BYTE authenticode[] = {
 0x30,0x82,0x03,0xd6,0x30,0x82,0x02,0xbe,0xa0,0x03,0x02,0x01,0x02,0x02,0x01,0x01,
@@ -925,16 +595,28 @@ static const struct CONST_BLOB {
     { rootcertauthority2011, sizeof(rootcertauthority2011) },
 };
 
-static void add_ms_root_certs(HCERTSTORE to)
+static void add_ms_root_certs(HCERTSTORE to, HCERTSTORE cached)
 {
+    PCCERT_CONTEXT cert, existing;
     DWORD i;
 
     TRACE("\n");
 
     for (i = 0; i < ARRAY_SIZE(msRootCerts); i++)
+    {
         if (!CertAddEncodedCertificateToStore(to, X509_ASN_ENCODING,
-         msRootCerts[i].pb, msRootCerts[i].cb, CERT_STORE_ADD_NEW, NULL))
-            WARN("adding root cert %d failed: %08x\n", i, GetLastError());
+            msRootCerts[i].pb, msRootCerts[i].cb, CERT_STORE_ADD_NEW, &cert))
+        {
+            WARN("adding root cert %ld failed: %08lx\n", i, GetLastError());
+            continue;
+        }
+        if ((existing = CertFindCertificateInStore(cached, X509_ASN_ENCODING, 0, CERT_FIND_EXISTING, cert, NULL)))
+        {
+            CertDeleteCertificateFromStore(existing);
+            CertFreeCertificateContext(existing);
+        }
+        CertFreeCertificateContext(cert);
+    }
 }
 
 /* Reads certificates from the list of known locations into store.  Stops when
@@ -942,118 +624,131 @@ static void add_ms_root_certs(HCERTSTORE to)
  * adding redundant certificates, e.g. when both a certificate bundle and
  * individual certificates exist in the same directory.
  */
-static void read_trusted_roots_from_known_locations(HCERTSTORE store)
+static void read_trusted_roots_from_known_locations(HCERTSTORE store, HCERTSTORE cached, BOOL *delete)
 {
-    HCERTSTORE from = CertOpenStore(CERT_STORE_PROV_MEMORY,
-     X509_ASN_ENCODING, 0, CERT_STORE_CREATE_NEW_FLAG, NULL);
+    HCERTSTORE new;
+    DWORD needed, size;
+    struct enum_root_certs_params params = { NULL, 2048, &needed };
+    HCRYPTPROV prov;
+    HCRYPTHASH hash;
+    BYTE hashval[20];
+    DWORD hashlen;
+    CRYPT_HASH_BLOB hash_blob = { sizeof(hashval), hashval };
+    CRYPT_DATA_BLOB exists_blob = { 0, NULL };
+    PCCERT_CONTEXT cert, existing;
+    unsigned int existing_count = 0, new_count = 0;
+    unsigned int cached_count = 0;
 
-    if (from)
+    new = CertOpenStore( CERT_STORE_PROV_MEMORY, X509_ASN_ENCODING, 0, CERT_STORE_CREATE_NEW_FLAG, NULL );
+    if (!new) return;
+
+    existing = NULL;
+    while ((existing = CertEnumCertificatesInStore( cached, existing )))
+        ++cached_count;
+
+    CryptAcquireContextW( &prov, NULL, NULL, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT );
+    params.buffer = CryptMemAlloc( params.size );
+    while (!CRYPT32_CALL( enum_root_certs, &params ))
     {
-        DWORD i;
-        BOOL ret = FALSE;
-
-#ifdef HAVE_SECURITY_SECURITY_H
-        OSStatus status;
-        CFArrayRef rootCerts;
-
-        status = SecTrustCopyAnchorCertificates(&rootCerts);
-        if (status == noErr)
+        if (needed > params.size)
         {
-            int i;
-            for (i = 0; i < CFArrayGetCount(rootCerts); i++)
-            {
-                SecCertificateRef cert = (SecCertificateRef)CFArrayGetValueAtIndex(rootCerts, i);
-                CFDataRef certData;
-                if ((status = SecKeychainItemExport(cert, kSecFormatX509Cert, 0, NULL, &certData)) == noErr)
-                {
-                    if (CertAddEncodedCertificateToStore(store, X509_ASN_ENCODING,
-                            CFDataGetBytePtr(certData), CFDataGetLength(certData),
-                            CERT_STORE_ADD_NEW, NULL))
-                        ret = TRUE;
-                    else
-                        WARN("adding root cert %d failed: %08x\n", i, GetLastError());
-                    CFRelease(certData);
-                }
-                else
-                    WARN("could not export certificate %d to X509 format: 0x%08x\n", i, (unsigned int)status);
-            }
-            CFRelease(rootCerts);
+            CryptMemFree( params.buffer );
+            params.buffer = CryptMemAlloc( needed );
+            params.size = needed;
+            continue;
         }
-#endif
-
-        for (i = 0; !ret && i < ARRAY_SIZE(CRYPT_knownLocations); i++)
-            ret = import_certs_from_path(CRYPT_knownLocations[i], from, TRUE);
-        check_and_store_certs(from, store);
+        CryptCreateHash( prov, CALG_SHA1, 0, 0, &hash );
+        CryptHashData( hash, params.buffer, needed, 0 );
+        hashlen = sizeof(hashval);
+        CryptGetHashParam( hash, HP_HASHVAL, hashval, &hashlen, 0 );
+        CryptDestroyHash( hash );
+        if ((existing = CertFindCertificateInStore( cached, X509_ASN_ENCODING, 0,
+                                                    CERT_FIND_SHA1_HASH, &hash_blob, NULL )))
+        {
+            /* Skip certificate which is already cached. CERT_FIRST_USER_PROP_ID is set once the cached cert
+             * is found among host imports. */
+            if (!CertGetCertificateContextProperty( existing, CERT_FIRST_USER_PROP_ID, NULL, &size ))
+            {
+                if (!CertSetCertificateContextProperty( existing, CERT_FIRST_USER_PROP_ID, 0, &exists_blob ))
+                    ERR( "Failed to set property.\n" );
+                ++existing_count;
+            }
+            CertFreeCertificateContext( existing );
+            continue;
+        }
+        CertAddEncodedCertificateToStore( new, X509_ASN_ENCODING, params.buffer, needed, CERT_STORE_ADD_ALWAYS, &cert );
+        /* Add to cached so we can catch duplicates and check_and_store_certs() has the full chains. */
+        CertAddCertificateContextToStore( cached, cert, CERT_STORE_ADD_ALWAYS, NULL );
+        if (!CertSetCertificateContextProperty( cert, CERT_FIRST_USER_PROP_ID, 0, &exists_blob ))
+            ERR("Failed to set property.\n");
+        CertFreeCertificateContext( cert );
+        ++new_count;
     }
-    CertCloseStore(from, 0);
+    CryptMemFree( params.buffer );
+    CryptReleaseContext( prov, 0 );
+
+    if (existing_count < cached_count)
+    {
+        /* Some certs were removed on host. Clean up the cache and add all the certificates so cert chains
+         * get revalidated. The certs present on host are now in 'cached' store and are marked with
+         * CERT_FIRST_USER_PROP_ID property. */
+        TRACE( "Some keys were removed, reimporting, cached %u, existing %u, new %u.\n",
+                cached_count, existing_count, new_count );
+        *delete = TRUE;
+        existing_count = 0;
+        existing = NULL;
+        while ((existing = CertEnumCertificatesInStore( cached, existing )))
+        {
+            if (!CertGetCertificateContextProperty( existing, CERT_FIRST_USER_PROP_ID, NULL, &size ))
+                continue;
+            CertAddCertificateContextToStore( new, existing, CERT_STORE_ADD_NEW, NULL );
+            ++new_count;
+        }
+    }
+    if (new_count)
+    {
+        /* Clear custom property so it is not serialized and seen by apps. */
+        cert = NULL;
+        while ((cert = CertEnumCertificatesInStore( new, cert )))
+            CertSetCertificateContextProperty( cert, CERT_FIRST_USER_PROP_ID, 0, NULL );
+        check_and_store_certs( cached, new, store );
+    }
+
+    CertCloseStore( new, 0 );
+    TRACE( "existing %u, new %u.\n", existing_count, new_count );
 }
 
-static HCERTSTORE create_root_store(void)
+static HCERTSTORE create_root_store(HCERTSTORE cached, BOOL *delete)
 {
-#ifdef __REACTOS__
-    HCERTSTORE root = NULL;
-#endif
     HCERTSTORE memStore = CertOpenStore(CERT_STORE_PROV_MEMORY,
      X509_ASN_ENCODING, 0, CERT_STORE_CREATE_NEW_FLAG, NULL);
 
+
+    *delete = FALSE;
     if (memStore)
     {
-#ifdef __REACTOS__
-        HCERTSTORE regStore;
-        CERT_STORE_PROV_INFO provInfo = {
-         sizeof(CERT_STORE_PROV_INFO),
-         sizeof(rootProvFuncs) / sizeof(rootProvFuncs[0]),
-         rootProvFuncs,
-         NULL,
-         0,
-         NULL
-        };
-#endif
-
-        read_trusted_roots_from_known_locations(memStore);
-        add_ms_root_certs(memStore);
-#ifdef __REACTOS__
-        root = CRYPT_ProvCreateStore(0, memStore, &provInfo);
-        regStore = CertOpenStore(CERT_STORE_PROV_SYSTEM_W, 0, 0, CERT_SYSTEM_STORE_LOCAL_MACHINE, L"AuthRoot");
-        if (regStore)
-        {
-            HCERTSTORE collStore = CertOpenStore(CERT_STORE_PROV_COLLECTION, 0, 0,
-                CERT_STORE_CREATE_NEW_FLAG, NULL);
-            CertAddStoreToCollection(collStore, regStore, 0, 0);
-            CertAddStoreToCollection(collStore, root, 0, 0);
-            root = collStore;
-        }
-#endif
+        add_ms_root_certs(memStore, cached);
+        read_trusted_roots_from_known_locations(memStore, cached, delete);
     }
-#ifdef __REACTOS__
-    TRACE("returning %p\n", root);
-    return root;
-#else
+
     TRACE("returning %p\n", memStore);
     return memStore;
-#endif
 }
-
-static const WCHAR certs_root_pathW[] =
- {'S','o','f','t','w','a','r','e','\\','M','i','c','r','o','s','o','f','t','\\',
-  'S','y','s','t','e','m','C','e','r','t','i','f','i','c','a','t','e','s','\\',
-  'R','o','o','t','\\', 'C','e','r','t','i','f','i','c','a','t','e','s', 0};
-static const WCHAR semaphoreW[] =
- {'c','r','y','p','t','3','2','_','r','o','o','t','_','s','e','m','a','p','h','o','r','e',0};
 
 void CRYPT_ImportSystemRootCertsToReg(void)
 {
-    HCERTSTORE store = NULL;
-    HKEY key;
+    HCERTSTORE store = NULL, reg = NULL;
+    HKEY key = NULL;
     LONG rc;
     HANDLE hsem;
+    BOOL delete;
 
     static BOOL root_certs_imported = FALSE;
 
     if (root_certs_imported)
         return;
 
-    hsem = CreateSemaphoreW( NULL, 0, 1, semaphoreW);
+    hsem = CreateSemaphoreW( NULL, 0, 1, L"crypt32_root_semaphore");
     if (!hsem)
     {
         ERR("Failed to create semaphore\n");
@@ -1061,24 +756,37 @@ void CRYPT_ImportSystemRootCertsToReg(void)
     }
 
     if(GetLastError() == ERROR_ALREADY_EXISTS)
-        WaitForSingleObject(hsem, INFINITE);
-    else
     {
-        if ((store = create_root_store()))
-        {
-            rc = RegCreateKeyExW(HKEY_LOCAL_MACHINE, certs_root_pathW, 0, NULL, 0,
-                KEY_ALL_ACCESS, NULL, &key, 0);
-            if (!rc)
-            {
-                if (!CRYPT_SerializeContextsToReg(key, REG_OPTION_VOLATILE, pCertInterface, store))
-                    ERR("Failed to import system certs into registry, %08x\n", GetLastError());
-                RegCloseKey(key);
-            }
-            CertCloseStore(store, 0);
-        } else
-            ERR("Failed to create root store\n");
+        WaitForSingleObject(hsem, INFINITE);
+        goto done;
     }
 
+    rc = RegCreateKeyExW(HKEY_LOCAL_MACHINE, L"Software\\Microsoft\\SystemCertificates\\Root\\Certificates", 0, NULL, 0,
+            KEY_ALL_ACCESS, NULL, &key, 0);
+    if (rc)
+        goto done;
+
+    if (!(reg = CertOpenStore(CERT_STORE_PROV_MEMORY, X509_ASN_ENCODING, 0, CERT_STORE_CREATE_NEW_FLAG, NULL)))
+    {
+        ERR("Failed to create memory store.\n");
+        goto done;
+    }
+    CRYPT_RegReadSerializedFromReg(key, CERT_STORE_CERTIFICATE_CONTEXT_FLAG, reg, CERT_STORE_ADD_ALWAYS);
+
+    if (!(store = create_root_store(reg, &delete)))
+    {
+        ERR("Failed to create root store\n");
+        goto done;
+    }
+    if (delete && RegDeleteTreeW(key, NULL))
+        ERR("Error deleting key.\n");
+    if (!CRYPT_SerializeContextsToReg(key, 0, pCertInterface, store))
+        ERR("Failed to import system certs into registry, %08lx\n", GetLastError());
+
+done:
+    RegCloseKey(key);
+    CertCloseStore(store, 0);
+    CertCloseStore(reg, 0);
     root_certs_imported = TRUE;
     ReleaseSemaphore(hsem, 1, NULL);
     CloseHandle(hsem);

--- a/dll/win32/crypt32/sip.c
+++ b/dll/win32/crypt32/sip.c
@@ -35,38 +35,12 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(crypt);
 
-static const WCHAR szOID[] = {
-    'S','o','f','t','w','a','r','e','\\',
-    'M','i','c','r','o','s','o','f','t','\\',
-    'C','r','y','p','t','o','g','r','a','p','h','y','\\',
-    'O','I','D','\\',
-    'E','n','c','o','d','i','n','g','T','y','p','e',' ','0','\\',
-    'C','r','y','p','t','S','I','P','D','l','l', 0 };
-
-static const WCHAR szPutSigned[] = {
-    'P','u','t','S','i','g','n','e','d','D','a','t','a','M','s','g','\\',0};
-static const WCHAR szGetSigned[] = {
-    'G','e','t','S','i','g','n','e','d','D','a','t','a','M','s','g','\\',0};
-static const WCHAR szRemoveSigned[] = {
-    'R','e','m','o','v','e','S','i','g','n','e','d','D','a','t','a','M','s','g','\\',0};
-static const WCHAR szCreate[] = {
-    'C','r','e','a','t','e','I','n','d','i','r','e','c','t','D','a','t','a','\\',0};
-static const WCHAR szVerify[] = {
-    'V','e','r','i','f','y','I','n','d','i','r','e','c','t','D','a','t','a','\\',0};
-static const WCHAR szIsMyFile[] = {
-    'I','s','M','y','F','i','l','e','T','y','p','e','\\',0};
-static const WCHAR szIsMyFile2[] = {
-    'I','s','M','y','F','i','l','e','T','y','p','e','2','\\',0};
-
-static const WCHAR szDllName[] = { 'D','l','l',0 };
-static const WCHAR szFuncName[] = { 'F','u','n','c','N','a','m','e',0 };
-
 /* convert a guid to a wide character string */
 static void CRYPT_guid2wstr( const GUID *guid, LPWSTR wstr )
 {
     char str[40];
 
-    sprintf(str, "{%08X-%04X-%04X-%02X%02X-%02X%02X%02X%02X%02X%02X}",
+    sprintf(str, "{%08lX-%04X-%04X-%02X%02X-%02X%02X%02X%02X%02X%02X}",
            guid->Data1, guid->Data2, guid->Data3,
            guid->Data4[0], guid->Data4[1], guid->Data4[2], guid->Data4[3],
            guid->Data4[4], guid->Data4[5], guid->Data4[6], guid->Data4[7] );
@@ -84,7 +58,7 @@ static LONG CRYPT_SIPDeleteFunction( const GUID *guid, LPCWSTR szKey )
     LONG r = ERROR_SUCCESS;
 
     /* max length of szFullKey depends on our code only, so we won't overrun */
-    lstrcpyW( szFullKey, szOID );
+    lstrcpyW( szFullKey, L"Software\\Microsoft\\Cryptography\\OID\\EncodingType 0\\CryptSIPDll" );
     lstrcatW( szFullKey, szKey );
     CRYPT_guid2wstr( guid, &szFullKey[ lstrlenW( szFullKey ) ] );
 
@@ -127,13 +101,13 @@ BOOL WINAPI CryptSIPRemoveProvider(GUID *pgProv)
     r = CRYPT_SIPDeleteFunction( pgProv, key); \
     if (r != ERROR_SUCCESS) remove_error = r
 
-    CRYPT_SIPREMOVEPROV( szPutSigned);
-    CRYPT_SIPREMOVEPROV( szGetSigned);
-    CRYPT_SIPREMOVEPROV( szRemoveSigned);
-    CRYPT_SIPREMOVEPROV( szCreate);
-    CRYPT_SIPREMOVEPROV( szVerify);
-    CRYPT_SIPREMOVEPROV( szIsMyFile);
-    CRYPT_SIPREMOVEPROV( szIsMyFile2);
+    CRYPT_SIPREMOVEPROV( L"PutSignedDataMsg\\" );
+    CRYPT_SIPREMOVEPROV( L"GetSignedDataMsg\\" );
+    CRYPT_SIPREMOVEPROV( L"RemoveSignedDataMsg\\" );
+    CRYPT_SIPREMOVEPROV( L"CreateIndirectData\\" );
+    CRYPT_SIPREMOVEPROV( L"VerifyIndirectData\\" );
+    CRYPT_SIPREMOVEPROV( L"IsMyFileType\\" );
+    CRYPT_SIPREMOVEPROV( L"IsMyFileType2\\" );
 
 #undef CRYPT_SIPREMOVEPROV
 
@@ -163,7 +137,7 @@ static LONG CRYPT_SIPWriteFunction( const GUID *guid, LPCWSTR szKey,
          return ERROR_SUCCESS;
 
     /* max length of szFullKey depends on our code only, so we won't overrun */
-    lstrcpyW( szFullKey, szOID );
+    lstrcpyW( szFullKey, L"Software\\Microsoft\\Cryptography\\OID\\EncodingType 0\\CryptSIPDll" );
     lstrcatW( szFullKey, szKey );
     CRYPT_guid2wstr( guid, &szFullKey[ lstrlenW( szFullKey ) ] );
 
@@ -173,10 +147,10 @@ static LONG CRYPT_SIPWriteFunction( const GUID *guid, LPCWSTR szKey,
     if( r != ERROR_SUCCESS ) goto error_close_key;
 
     /* write the values */
-    r = RegSetValueExW( hKey, szFuncName, 0, REG_SZ, (const BYTE*) szFunction,
+    r = RegSetValueExW( hKey, L"FuncName", 0, REG_SZ, (const BYTE*) szFunction,
                         ( lstrlenW( szFunction ) + 1 ) * sizeof (WCHAR) );
     if( r != ERROR_SUCCESS ) goto error_close_key;
-    r = RegSetValueExW( hKey, szDllName, 0, REG_SZ, (const BYTE*) szDll,
+    r = RegSetValueExW( hKey, L"Dll", 0, REG_SZ, (const BYTE*) szDll,
                         ( lstrlenW( szDll ) + 1) * sizeof (WCHAR) );
 
 error_close_key:
@@ -234,13 +208,13 @@ BOOL WINAPI CryptSIPAddProvider(SIP_ADD_NEWPROVIDER *psNewProv)
            psNewProv->pwszDLLFileName, psNewProv->field); \
     if (r != ERROR_SUCCESS) goto end_function
 
-    CRYPT_SIPADDPROV( szPutSigned, pwszPutFuncName );
-    CRYPT_SIPADDPROV( szGetSigned, pwszGetFuncName );
-    CRYPT_SIPADDPROV( szRemoveSigned, pwszRemoveFuncName );
-    CRYPT_SIPADDPROV( szCreate, pwszCreateFuncName );
-    CRYPT_SIPADDPROV( szVerify, pwszVerifyFuncName );
-    CRYPT_SIPADDPROV( szIsMyFile, pwszIsFunctionName );
-    CRYPT_SIPADDPROV( szIsMyFile2, pwszIsFunctionNameFmt2 );
+    CRYPT_SIPADDPROV( L"PutSignedDataMsg\\", pwszPutFuncName );
+    CRYPT_SIPADDPROV( L"GetSignedDataMsg\\", pwszGetFuncName );
+    CRYPT_SIPADDPROV( L"RemoveSignedDataMsg\\", pwszRemoveFuncName );
+    CRYPT_SIPADDPROV( L"CreateIndirectData\\", pwszCreateFuncName );
+    CRYPT_SIPADDPROV( L"VerifyIndirectData\\", pwszVerifyFuncName );
+    CRYPT_SIPADDPROV( L"IsMyFileType\\", pwszIsFunctionName );
+    CRYPT_SIPADDPROV( L"IsMyFileType2\\", pwszIsFunctionNameFmt2 );
 
 #undef CRYPT_SIPADDPROV
 
@@ -266,7 +240,7 @@ static void *CRYPT_LoadSIPFuncFromKey(HKEY key, HMODULE *pLib)
 
     /* Read the DLL entry */
     size = sizeof(dllName);
-    r = RegQueryValueExW(key, szDllName, NULL, NULL, (LPBYTE)dllName, &size);
+    r = RegQueryValueExW(key, L"Dll", NULL, NULL, (LPBYTE)dllName, &size);
     if (r) goto end;
 
     /* Read the Function entry */
@@ -320,7 +294,6 @@ BOOL WINAPI CryptSIPRetrieveSubjectGuid
     static const WORD dosHdr = IMAGE_DOS_SIGNATURE;
     static const BYTE cabHdr[] = { 'M','S','C','F' };
     BYTE hdr[SIP_MAX_MAGIC_NUMBER];
-    WCHAR szFullKey[ 0x100 ];
     LONG r = ERROR_SUCCESS;
     HKEY key;
 
@@ -379,7 +352,7 @@ BOOL WINAPI CryptSIPRetrieveSubjectGuid
     {
         DWORD fileLen = GetFileSize(hFile, NULL);
 
-        TRACE("fileLen = %d\n", fileLen);
+        TRACE("fileLen = %ld\n", fileLen);
         /* Sanity-check length */
         if (hdr[1] < 0x80 && fileLen == 2 + hdr[1])
         {
@@ -431,10 +404,7 @@ BOOL WINAPI CryptSIPRetrieveSubjectGuid
     }
 
     /* Check for supported functions using CryptSIPDllIsMyFileType */
-    /* max length of szFullKey depends on our code only, so we won't overrun */
-    lstrcpyW(szFullKey, szOID);
-    lstrcatW(szFullKey, szIsMyFile);
-    r = RegOpenKeyExW(HKEY_LOCAL_MACHINE, szFullKey, 0, KEY_READ, &key);
+    r = RegOpenKeyExW(HKEY_LOCAL_MACHINE, L"Software\\Microsoft\\Cryptography\\OID\\EncodingType 0\\CryptSIPDllIsMyFileType\\", 0, KEY_READ, &key);
     if (r == ERROR_SUCCESS)
     {
         DWORD index = 0, size;
@@ -470,9 +440,7 @@ BOOL WINAPI CryptSIPRetrieveSubjectGuid
     /* Check for supported functions using CryptSIPDllIsMyFileType2 */
     if (!bRet)
     {
-        lstrcpyW(szFullKey, szOID);
-        lstrcatW(szFullKey, szIsMyFile2);
-        r = RegOpenKeyExW(HKEY_LOCAL_MACHINE, szFullKey, 0, KEY_READ, &key);
+        r = RegOpenKeyExW(HKEY_LOCAL_MACHINE, L"Software\\Microsoft\\Cryptography\\OID\\EncodingType 0\\CryptSIPDllIsMyFileType2\\", 0, KEY_READ, &key);
         if (r == ERROR_SUCCESS)
         {
             DWORD index = 0, size;
@@ -526,7 +494,7 @@ static LONG CRYPT_OpenSIPFunctionKey(const GUID *guid, LPCWSTR function,
 {
     WCHAR szFullKey[ 0x100 ];
 
-    lstrcpyW(szFullKey, szOID);
+    lstrcpyW(szFullKey, L"Software\\Microsoft\\Cryptography\\OID\\EncodingType 0\\CryptSIPDll");
     lstrcatW(szFullKey, function);
     CRYPT_guid2wstr(guid, &szFullKey[lstrlenW(szFullKey)]);
     return RegOpenKeyExW(HKEY_LOCAL_MACHINE, szFullKey, 0, KEY_READ, key);
@@ -628,25 +596,25 @@ static BOOL CRYPT_LoadSIP(const GUID *pgSubject)
     SIP_DISPATCH_INFO sip = { 0 };
     HMODULE lib = NULL, temp = NULL;
 
-    sip.pfGet = CRYPT_LoadSIPFunc(pgSubject, szGetSigned, &lib);
+    sip.pfGet = CRYPT_LoadSIPFunc(pgSubject, L"GetSignedDataMsg\\", &lib);
     if (!sip.pfGet)
         goto error;
-    sip.pfPut = CRYPT_LoadSIPFunc(pgSubject, szPutSigned, &temp);
+    sip.pfPut = CRYPT_LoadSIPFunc(pgSubject, L"PutSignedDataMsg\\", &temp);
     if (!sip.pfPut || temp != lib)
         goto error;
     FreeLibrary(temp);
     temp = NULL;
-    sip.pfCreate = CRYPT_LoadSIPFunc(pgSubject, szCreate, &temp);
+    sip.pfCreate = CRYPT_LoadSIPFunc(pgSubject, L"CreateIndirectData\\", &temp);
     if (!sip.pfCreate || temp != lib)
         goto error;
     FreeLibrary(temp);
     temp = NULL;
-    sip.pfVerify = CRYPT_LoadSIPFunc(pgSubject, szVerify, &temp);
+    sip.pfVerify = CRYPT_LoadSIPFunc(pgSubject, L"VerifyIndirectData\\", &temp);
     if (!sip.pfVerify || temp != lib)
         goto error;
     FreeLibrary(temp);
     temp = NULL;
-    sip.pfRemove = CRYPT_LoadSIPFunc(pgSubject, szRemoveSigned, &temp);
+    sip.pfRemove = CRYPT_LoadSIPFunc(pgSubject, L"RemoveSignedDataMsg\\", &temp);
     if (!sip.pfRemove || temp != lib)
         goto error;
     FreeLibrary(temp);
@@ -689,7 +657,7 @@ error:
 BOOL WINAPI CryptSIPLoad
        (const GUID *pgSubject, DWORD dwFlags, SIP_DISPATCH_INFO *pSipDispatch)
 {
-    TRACE("(%s %d %p)\n", debugstr_guid(pgSubject), dwFlags, pSipDispatch);
+    TRACE("(%s %ld %p)\n", debugstr_guid(pgSubject), dwFlags, pSipDispatch);
 
     if (!pgSubject || dwFlags != 0 || !pSipDispatch)
     {
@@ -740,7 +708,7 @@ BOOL WINAPI CryptSIPGetSignedDataMsg(SIP_SUBJECTINFO* pSubjectInfo, DWORD* pdwEn
     WINE_SIP_PROVIDER *sip;
     BOOL ret = FALSE;
 
-    TRACE("(%p %p %d %p %p)\n", pSubjectInfo, pdwEncodingType, dwIndex,
+    TRACE("(%p %p %ld %p %p)\n", pSubjectInfo, pdwEncodingType, dwIndex,
           pcbSignedDataMsg, pbSignedDataMsg);
 
     if ((sip = CRYPT_GetCachedSIP(pSubjectInfo->pgSubjectType)))
@@ -759,7 +727,7 @@ BOOL WINAPI CryptSIPPutSignedDataMsg(SIP_SUBJECTINFO* pSubjectInfo, DWORD pdwEnc
     WINE_SIP_PROVIDER *sip;
     BOOL ret = FALSE;
 
-    TRACE("(%p %d %p %d %p)\n", pSubjectInfo, pdwEncodingType, pdwIndex,
+    TRACE("(%p %ld %p %ld %p)\n", pSubjectInfo, pdwEncodingType, pdwIndex,
           cbSignedDataMsg, pbSignedDataMsg);
 
     if ((sip = CRYPT_GetCachedSIP(pSubjectInfo->pgSubjectType)))
@@ -778,7 +746,7 @@ BOOL WINAPI CryptSIPRemoveSignedDataMsg(SIP_SUBJECTINFO* pSubjectInfo,
     WINE_SIP_PROVIDER *sip;
     BOOL ret = FALSE;
 
-    TRACE("(%p %d)\n", pSubjectInfo, dwIndex);
+    TRACE("(%p %ld)\n", pSubjectInfo, dwIndex);
 
     if ((sip = CRYPT_GetCachedSIP(pSubjectInfo->pgSubjectType)))
         ret = sip->info.pfRemove(pSubjectInfo, dwIndex);

--- a/dll/win32/crypt32/store.c
+++ b/dll/win32/crypt32/store.c
@@ -23,19 +23,16 @@
  * - Many flags, options and whatnot are unimplemented.
  */
 
-#include "config.h"
-#include "wine/port.h"
-
 #include <assert.h>
 #include <stdarg.h>
 #include "windef.h"
 #include "winbase.h"
 #include "winnls.h"
 #include "winreg.h"
+#include "winternl.h"
 #include "winuser.h"
 #include "wincrypt.h"
 #include "wine/debug.h"
-#include "wine/exception.h"
 #include "crypt32_private.h"
 
 WINE_DEFAULT_DEBUG_CHANNEL(crypt);
@@ -114,7 +111,7 @@ BOOL WINAPI I_CertUpdateStore(HCERTSTORE store1, HCERTSTORE store2, DWORD unk0,
      pCRLInterface, pCTLInterface };
     DWORD i;
 
-    TRACE("(%p, %p, %08x, %08x)\n", store1, store2, unk0, unk1);
+    TRACE("(%p, %p, %08lx, %08lx)\n", store1, store2, unk0, unk1);
     if (!warned)
     {
         FIXME("semi-stub\n");
@@ -320,7 +317,7 @@ static BOOL MemStore_deleteCTL(WINECRYPT_CERTSTORE *store, context_t *context)
 static void MemStore_addref(WINECRYPT_CERTSTORE *store)
 {
     LONG ref = InterlockedIncrement(&store->ref);
-    TRACE("ref = %d\n", ref);
+    TRACE("ref = %ld\n", ref);
 }
 
 static DWORD MemStore_release(WINECRYPT_CERTSTORE *cert_store, DWORD flags)
@@ -329,10 +326,10 @@ static DWORD MemStore_release(WINECRYPT_CERTSTORE *cert_store, DWORD flags)
     LONG ref;
 
     if(flags & ~CERT_CLOSE_STORE_CHECK_FLAG)
-        FIXME("Unimplemented flags %x\n", flags);
+        FIXME("Unimplemented flags %lx\n", flags);
 
     ref = InterlockedDecrement(&store->hdr.ref);
-    TRACE("(%p) ref=%d\n", store, ref);
+    TRACE("(%p) ref=%ld\n", store, ref);
     if(ref)
         return (flags & CERT_CLOSE_STORE_CHECK_FLAG) ? CRYPT_E_PENDING_CLOSE : ERROR_SUCCESS;
 
@@ -377,7 +374,7 @@ static WINECRYPT_CERTSTORE *CRYPT_MemOpenStore(HCRYPTPROV hCryptProv,
 {
     WINE_MEMSTORE *store;
 
-    TRACE("(%ld, %08x, %p)\n", hCryptProv, dwFlags, pvPara);
+    TRACE("(%Id, %08lx, %p)\n", hCryptProv, dwFlags, pvPara);
 
     if (dwFlags & CERT_STORE_DELETE_FLAG)
     {
@@ -391,7 +388,7 @@ static WINECRYPT_CERTSTORE *CRYPT_MemOpenStore(HCRYPTPROV hCryptProv,
         {
             memset(store, 0, sizeof(WINE_MEMSTORE));
             CRYPT_InitStore(&store->hdr, dwFlags, StoreTypeMem, &MemStoreVtbl);
-            InitializeCriticalSection(&store->cs);
+            InitializeCriticalSectionEx(&store->cs, 0, RTL_CRITICAL_SECTION_FLAG_FORCE_DEBUG_INFO);
             store->cs.DebugInfo->Spare[0] = (DWORD_PTR)(__FILE__ ": ContextList.cs");
             list_init(&store->certs);
             list_init(&store->crls);
@@ -404,19 +401,16 @@ static WINECRYPT_CERTSTORE *CRYPT_MemOpenStore(HCRYPTPROV hCryptProv,
     return (WINECRYPT_CERTSTORE*)store;
 }
 
-static const WCHAR rootW[] = { 'R','o','o','t',0 };
-
 static WINECRYPT_CERTSTORE *CRYPT_SysRegOpenStoreW(HCRYPTPROV hCryptProv,
  DWORD dwFlags, const void *pvPara)
 {
-    static const WCHAR fmt[] = { '%','s','\\','%','s',0 };
     LPCWSTR storeName = pvPara;
     LPWSTR storePath;
     WINECRYPT_CERTSTORE *store = NULL;
     HKEY root;
     LPCWSTR base;
 
-    TRACE("(%ld, %08x, %s)\n", hCryptProv, dwFlags,
+    TRACE("(%Id, %08lx, %s)\n", hCryptProv, dwFlags,
      debugstr_w(pvPara));
 
     if (!pvPara)
@@ -431,7 +425,7 @@ static WINECRYPT_CERTSTORE *CRYPT_SysRegOpenStoreW(HCRYPTPROV hCryptProv,
         root = HKEY_LOCAL_MACHINE;
         base = CERT_LOCAL_MACHINE_SYSTEM_STORE_REGPATH;
         /* If the HKLM\Root certs are requested, expressing system certs into the registry */
-        if (!lstrcmpiW(storeName, rootW))
+        if (!lstrcmpiW(storeName, L"Root"))
             CRYPT_ImportSystemRootCertsToReg();
         break;
     case CERT_SYSTEM_STORE_CURRENT_USER:
@@ -484,7 +478,7 @@ static WINECRYPT_CERTSTORE *CRYPT_SysRegOpenStoreW(HCRYPTPROV hCryptProv,
         REGSAM sam = dwFlags & CERT_STORE_READONLY_FLAG ? KEY_READ :
             KEY_ALL_ACCESS;
 
-        wsprintfW(storePath, fmt, base, storeName);
+        wsprintfW(storePath, L"%s\\%s", base, storeName);
         if (dwFlags & CERT_STORE_OPEN_EXISTING_FLAG)
             rc = RegOpenKeyExW(root, storePath, 0, sam, &key);
         else
@@ -518,7 +512,7 @@ static WINECRYPT_CERTSTORE *CRYPT_SysRegOpenStoreA(HCRYPTPROV hCryptProv,
     int len;
     WINECRYPT_CERTSTORE *ret = NULL;
 
-    TRACE("(%ld, %08x, %s)\n", hCryptProv, dwFlags,
+    TRACE("(%Id, %08lx, %s)\n", hCryptProv, dwFlags,
      debugstr_a(pvPara));
 
     if (!pvPara)
@@ -547,7 +541,7 @@ static WINECRYPT_CERTSTORE *CRYPT_SysOpenStoreW(HCRYPTPROV hCryptProv,
     HCERTSTORE store = 0;
     BOOL ret;
 
-    TRACE("(%ld, %08x, %s)\n", hCryptProv, dwFlags,
+    TRACE("(%Id, %08lx, %s)\n", hCryptProv, dwFlags,
      debugstr_w(pvPara));
 
     if (!pvPara)
@@ -619,7 +613,7 @@ static WINECRYPT_CERTSTORE *CRYPT_SysOpenStoreA(HCRYPTPROV hCryptProv,
     int len;
     WINECRYPT_CERTSTORE *ret = NULL;
 
-    TRACE("(%ld, %08x, %s)\n", hCryptProv, dwFlags,
+    TRACE("(%Id, %08lx, %s)\n", hCryptProv, dwFlags,
      debugstr_a(pvPara));
 
     if (!pvPara)
@@ -646,7 +640,7 @@ static void WINAPI CRYPT_MsgCloseStore(HCERTSTORE hCertStore, DWORD dwFlags)
 {
     HCRYPTMSG msg = hCertStore;
 
-    TRACE("(%p, %08x)\n", msg, dwFlags);
+    TRACE("(%p, %08lx)\n", msg, dwFlags);
     CryptMsgClose(msg);
 }
 
@@ -661,7 +655,7 @@ static WINECRYPT_CERTSTORE *CRYPT_MsgOpenStore(HCRYPTPROV hCryptProv,
     HCRYPTMSG msg = (HCRYPTMSG)pvPara;
     WINECRYPT_CERTSTORE *memStore;
 
-    TRACE("(%ld, %08x, %p)\n", hCryptProv, dwFlags, pvPara);
+    TRACE("(%Id, %08lx, %p)\n", hCryptProv, dwFlags, pvPara);
 
     memStore = CertOpenStore(CERT_STORE_PROV_MEMORY, 0, 0,
      CERT_STORE_CREATE_NEW_FLAG, NULL);
@@ -742,7 +736,7 @@ static WINECRYPT_CERTSTORE *CRYPT_PKCSOpenStore(HCRYPTPROV hCryptProv,
     DWORD msgOpenFlags = dwFlags & CERT_STORE_NO_CRYPT_RELEASE_FLAG ? 0 :
      CMSG_CRYPT_RELEASE_CONTEXT_FLAG;
 
-    TRACE("(%ld, %08x, %p)\n", hCryptProv, dwFlags, pvPara);
+    TRACE("(%Id, %08lx, %p)\n", hCryptProv, dwFlags, pvPara);
 
     msg = CryptMsgOpenToDecode(PKCS_7_ASN_ENCODING, msgOpenFlags, CMSG_SIGNED,
      hCryptProv, NULL, NULL);
@@ -779,7 +773,7 @@ static WINECRYPT_CERTSTORE *CRYPT_SerializedOpenStore(HCRYPTPROV hCryptProv,
     HCERTSTORE store;
     const CRYPT_DATA_BLOB *data = pvPara;
 
-    TRACE("(%ld, %08x, %p)\n", hCryptProv, dwFlags, pvPara);
+    TRACE("(%Id, %08lx, %p)\n", hCryptProv, dwFlags, pvPara);
 
     if (dwFlags & CERT_STORE_DELETE_FLAG)
     {
@@ -805,9 +799,9 @@ static WINECRYPT_CERTSTORE *CRYPT_PhysOpenStoreW(HCRYPTPROV hCryptProv,
  DWORD dwFlags, const void *pvPara)
 {
     if (dwFlags & CERT_SYSTEM_STORE_RELOCATE_FLAG)
-        FIXME("(%ld, %08x, %p): stub\n", hCryptProv, dwFlags, pvPara);
+        FIXME("(%Id, %08lx, %p): stub\n", hCryptProv, dwFlags, pvPara);
     else
-        FIXME("(%ld, %08x, %s): stub\n", hCryptProv, dwFlags,
+        FIXME("(%Id, %08lx, %s): stub\n", hCryptProv, dwFlags,
          debugstr_w(pvPara));
     return NULL;
 }
@@ -819,7 +813,7 @@ HCERTSTORE WINAPI CertOpenStore(LPCSTR lpszStoreProvider,
     WINECRYPT_CERTSTORE *hcs;
     StoreOpenFunc openFunc = NULL;
 
-    TRACE("(%s, %08x, %08lx, %08x, %p)\n", debugstr_a(lpszStoreProvider),
+    TRACE("(%s, %08lx, %08Ix, %08lx, %p)\n", debugstr_a(lpszStoreProvider),
           dwMsgAndCertEncodingType, hCryptProv, dwFlags, pvPara);
 
     if (IS_INTOID(lpszStoreProvider))
@@ -873,19 +867,19 @@ HCERTSTORE WINAPI CertOpenStore(LPCSTR lpszStoreProvider,
                 FIXME("unimplemented type %d\n", LOWORD(lpszStoreProvider));
         }
     }
-    else if (!strcasecmp(lpszStoreProvider, sz_CERT_STORE_PROV_MEMORY))
+    else if (!stricmp(lpszStoreProvider, sz_CERT_STORE_PROV_MEMORY))
         openFunc = CRYPT_MemOpenStore;
-    else if (!strcasecmp(lpszStoreProvider, sz_CERT_STORE_PROV_FILENAME_W))
+    else if (!stricmp(lpszStoreProvider, sz_CERT_STORE_PROV_FILENAME_W))
         openFunc = CRYPT_FileOpenStore;
-    else if (!strcasecmp(lpszStoreProvider, sz_CERT_STORE_PROV_SYSTEM))
+    else if (!stricmp(lpszStoreProvider, sz_CERT_STORE_PROV_SYSTEM))
         openFunc = CRYPT_SysOpenStoreW;
-    else if (!strcasecmp(lpszStoreProvider, sz_CERT_STORE_PROV_PKCS7))
+    else if (!stricmp(lpszStoreProvider, sz_CERT_STORE_PROV_PKCS7))
         openFunc = CRYPT_PKCSOpenStore;
-    else if (!strcasecmp(lpszStoreProvider, sz_CERT_STORE_PROV_SERIALIZED))
+    else if (!stricmp(lpszStoreProvider, sz_CERT_STORE_PROV_SERIALIZED))
         openFunc = CRYPT_SerializedOpenStore;
-    else if (!strcasecmp(lpszStoreProvider, sz_CERT_STORE_PROV_COLLECTION))
+    else if (!stricmp(lpszStoreProvider, sz_CERT_STORE_PROV_COLLECTION))
         openFunc = CRYPT_CollectionOpenStore;
-    else if (!strcasecmp(lpszStoreProvider, sz_CERT_STORE_PROV_SYSTEM_REGISTRY))
+    else if (!stricmp(lpszStoreProvider, sz_CERT_STORE_PROV_SYSTEM_REGISTRY))
         openFunc = CRYPT_SysRegOpenStoreW;
     else
     {
@@ -965,7 +959,7 @@ BOOL WINAPI CertAddCRLContextToStore(HCERTSTORE hCertStore,
     BOOL ret = TRUE;
     PCCRL_CONTEXT toAdd = NULL, existing = NULL;
 
-    TRACE("(%p, %p, %08x, %p)\n", hCertStore, pCrlContext,
+    TRACE("(%p, %p, %08lx, %p)\n", hCertStore, pCrlContext,
      dwAddDisposition, ppStoreContext);
 
     /* Weird case to pass a test */
@@ -1053,7 +1047,7 @@ BOOL WINAPI CertAddCRLContextToStore(HCERTSTORE hCertStore,
             toAdd = CertDuplicateCRLContext(pCrlContext);
         break;
     default:
-        FIXME("Unimplemented add disposition %d\n", dwAddDisposition);
+        FIXME("Unimplemented add disposition %ld\n", dwAddDisposition);
         ret = FALSE;
     }
 
@@ -1129,7 +1123,7 @@ BOOL WINAPI CertCloseStore(HCERTSTORE hCertStore, DWORD dwFlags)
     WINECRYPT_CERTSTORE *hcs = hCertStore;
     DWORD res;
 
-    TRACE("(%p, %08x)\n", hCertStore, dwFlags);
+    TRACE("(%p, %08lx)\n", hCertStore, dwFlags);
 
     if( ! hCertStore )
         return TRUE;
@@ -1152,7 +1146,7 @@ BOOL WINAPI CertControlStore(HCERTSTORE hCertStore, DWORD dwFlags,
     WINECRYPT_CERTSTORE *hcs = hCertStore;
     BOOL ret;
 
-    TRACE("(%p, %08x, %d, %p)\n", hCertStore, dwFlags, dwCtrlType,
+    TRACE("(%p, %08lx, %ld, %p)\n", hCertStore, dwFlags, dwCtrlType,
      pvCtrlPara);
 
     if (!hcs)
@@ -1175,7 +1169,7 @@ BOOL WINAPI CertGetStoreProperty(HCERTSTORE hCertStore, DWORD dwPropId,
     WINECRYPT_CERTSTORE *store = hCertStore;
     BOOL ret = FALSE;
 
-    TRACE("(%p, %d, %p, %p)\n", hCertStore, dwPropId, pvData, pcbData);
+    TRACE("(%p, %ld, %p, %p)\n", hCertStore, dwPropId, pvData, pcbData);
 
     switch (dwPropId)
     {
@@ -1239,7 +1233,7 @@ BOOL WINAPI CertSetStoreProperty(HCERTSTORE hCertStore, DWORD dwPropId,
     WINECRYPT_CERTSTORE *store = hCertStore;
     BOOL ret = FALSE;
 
-    TRACE("(%p, %d, %08x, %p)\n", hCertStore, dwPropId, dwFlags, pvData);
+    TRACE("(%p, %ld, %08lx, %p)\n", hCertStore, dwPropId, dwFlags, pvData);
 
     if (!store->properties)
         store->properties = ContextPropertyList_Create();
@@ -1271,7 +1265,7 @@ static LONG CRYPT_OpenParentStore(DWORD dwFlags,
     HKEY root;
     LPCWSTR base;
 
-    TRACE("(%08x, %p)\n", dwFlags, pvSystemStoreLocationPara);
+    TRACE("(%08lx, %p)\n", dwFlags, pvSystemStoreLocationPara);
 
     switch (dwFlags & CERT_SYSTEM_STORE_LOCATION_MASK)
     {
@@ -1326,7 +1320,7 @@ BOOL WINAPI CertEnumSystemStore(DWORD dwFlags, void *pvSystemStoreLocationPara,
     HKEY key;
     CERT_SYSTEM_STORE_INFO info = { sizeof(info) };
 
-    TRACE("(%08x, %p, %p, %p)\n", dwFlags, pvSystemStoreLocationPara, pvArg,
+    TRACE("(%08lx, %p, %p, %p)\n", dwFlags, pvSystemStoreLocationPara, pvArg,
         pfnEnum);
 
     rc = CRYPT_OpenParentStore(dwFlags, pvArg, &key);
@@ -1354,73 +1348,18 @@ BOOL WINAPI CertEnumSystemStore(DWORD dwFlags, void *pvSystemStoreLocationPara,
      */
     if (ret && (dwFlags & CERT_SYSTEM_STORE_LOCATION_MASK) ==
      CERT_SYSTEM_STORE_LOCAL_MACHINE)
-        ret = pfnEnum(rootW, dwFlags, &info, NULL, pvArg);
+        ret = pfnEnum(L"Root", dwFlags, &info, NULL, pvArg);
     return ret;
 }
-
-#ifdef __REACTOS__
-
-typedef struct _CERT_SYSTEM_STORE_LOCATION
-{
-    DWORD dwFlags;
-    PCWSTR pwszStoreLocation;
-} CERT_SYSTEM_STORE_LOCATION, *PCERT_SYSTEM_STORE_LOCATION;
-
-static const CERT_SYSTEM_STORE_LOCATION gSystemStoreLocations[] = {
-    { CERT_SYSTEM_STORE_CURRENT_USER, L"CurrentUser" },
-    { CERT_SYSTEM_STORE_LOCAL_MACHINE, L"LocalMachine" },
-    { CERT_SYSTEM_STORE_CURRENT_SERVICE, L"CurrentService" },
-    { CERT_SYSTEM_STORE_SERVICES, L"Services" },
-    { CERT_SYSTEM_STORE_USERS, L"Users" },
-    { CERT_SYSTEM_STORE_CURRENT_USER_GROUP_POLICY, L"CurrentUserGroupPolicy" },
-    { CERT_SYSTEM_STORE_LOCAL_MACHINE_GROUP_POLICY, L"LocalMachineGroupPolicy" },
-    { CERT_SYSTEM_STORE_LOCAL_MACHINE_ENTERPRISE, L"LocalMachineEnterprise" },
-};
-
-BOOL
-WINAPI
-CertEnumSystemStoreLocation(
-    _In_ DWORD dwFlags,
-    _Inout_opt_ void *pvArg,
-    __callback PFN_CERT_ENUM_SYSTEM_STORE_LOCATION pfnEnum)
-{
-    DWORD i;
-
-    /* Check input flags */
-    if (dwFlags != 0)
-    {
-        SetLastError(E_INVALIDARG);
-        return FALSE;
-    }
-
-    /* Return fixed system stores */
-    for (i = 0; i < ARRAYSIZE(gSystemStoreLocations); i++)
-    {
-        if (!pfnEnum(gSystemStoreLocations[i].pwszStoreLocation,
-                     gSystemStoreLocations[i].dwFlags,
-                     NULL,
-                     pvArg))
-        {
-            return FALSE;
-        }
-    }
-
-    /* FIXME: Return registered OID system stores by calling CryptEnumOIDFunction */
-    FIXME("Registered OID system stores is not enumerated\n");
-
-    return TRUE;
-}
-
-#endif /* __REACTOS__ */
 
 BOOL WINAPI CertEnumPhysicalStore(const void *pvSystemStore, DWORD dwFlags,
  void *pvArg, PFN_CERT_ENUM_PHYSICAL_STORE pfnEnum)
 {
     if (dwFlags & CERT_SYSTEM_STORE_RELOCATE_FLAG)
-        FIXME("(%p, %08x, %p, %p): stub\n", pvSystemStore, dwFlags, pvArg,
+        FIXME("(%p, %08lx, %p, %p): stub\n", pvSystemStore, dwFlags, pvArg,
          pfnEnum);
     else
-        FIXME("(%s, %08x, %p, %p): stub\n", debugstr_w(pvSystemStore),
+        FIXME("(%s, %08lx, %p, %p): stub\n", debugstr_w(pvSystemStore),
          dwFlags, pvArg,
          pfnEnum);
     return FALSE;
@@ -1430,10 +1369,10 @@ BOOL WINAPI CertRegisterPhysicalStore(const void *pvSystemStore, DWORD dwFlags,
  LPCWSTR pwszStoreName, PCERT_PHYSICAL_STORE_INFO pStoreInfo, void *pvReserved)
 {
     if (dwFlags & CERT_SYSTEM_STORE_RELOCATE_FLAG)
-        FIXME("(%p, %08x, %s, %p, %p): stub\n", pvSystemStore, dwFlags,
+        FIXME("(%p, %08lx, %s, %p, %p): stub\n", pvSystemStore, dwFlags,
          debugstr_w(pwszStoreName), pStoreInfo, pvReserved);
     else
-        FIXME("(%s, %08x, %s, %p, %p): stub\n", debugstr_w(pvSystemStore),
+        FIXME("(%s, %08lx, %s, %p, %p): stub\n", debugstr_w(pvSystemStore),
          dwFlags, debugstr_w(pwszStoreName), pStoreInfo, pvReserved);
     return FALSE;
 }
@@ -1441,7 +1380,7 @@ BOOL WINAPI CertRegisterPhysicalStore(const void *pvSystemStore, DWORD dwFlags,
 BOOL WINAPI CertUnregisterPhysicalStore(const void *pvSystemStore, DWORD dwFlags,
  LPCWSTR pwszStoreName)
 {
-    FIXME("(%p, %08x, %s): stub\n", pvSystemStore, dwFlags, debugstr_w(pwszStoreName));
+    FIXME("(%p, %08lx, %s): stub\n", pvSystemStore, dwFlags, debugstr_w(pwszStoreName));
     return TRUE;
 }
 
@@ -1452,11 +1391,11 @@ BOOL WINAPI CertRegisterSystemStore(const void *pvSystemStore, DWORD dwFlags,
 
     if (dwFlags & CERT_SYSTEM_STORE_RELOCATE_FLAG )
     {
-        FIXME("(%p, %08x, %p, %p): flag not supported\n", pvSystemStore, dwFlags, pStoreInfo, pvReserved);
+        FIXME("(%p, %08lx, %p, %p): flag not supported\n", pvSystemStore, dwFlags, pStoreInfo, pvReserved);
         return FALSE;
     }
 
-    TRACE("(%s, %08x, %p, %p)\n", debugstr_w(pvSystemStore), dwFlags, pStoreInfo, pvReserved);
+    TRACE("(%s, %08lx, %p, %p)\n", debugstr_w(pvSystemStore), dwFlags, pStoreInfo, pvReserved);
 
     hstore = CertOpenStore(CERT_STORE_PROV_SYSTEM_REGISTRY_W, 0, 0, dwFlags, pvSystemStore);
     if (hstore)
@@ -1474,10 +1413,10 @@ BOOL WINAPI CertUnregisterSystemStore(const void *pvSystemStore, DWORD dwFlags)
 
     if (dwFlags & CERT_SYSTEM_STORE_RELOCATE_FLAG)
     {
-        FIXME("(%p, %08x): flag not supported\n", pvSystemStore, dwFlags);
+        FIXME("(%p, %08lx): flag not supported\n", pvSystemStore, dwFlags);
         return FALSE;
     }
-    TRACE("(%s, %08x)\n", debugstr_w(pvSystemStore), dwFlags);
+    TRACE("(%s, %08lx)\n", debugstr_w(pvSystemStore), dwFlags);
 
     hstore = CertOpenStore(CERT_STORE_PROV_SYSTEM_REGISTRY_W, 0, 0, dwFlags | CERT_STORE_OPEN_EXISTING_FLAG, pvSystemStore);
     if (hstore == NULL)

--- a/dll/win32/crypt32/unixlib.c
+++ b/dll/win32/crypt32/unixlib.c
@@ -1,0 +1,805 @@
+/*
+ * Copyright 2019 Hans Leidekker for CodeWeavers
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#if 0
+#pragma makedep unix
+#endif
+
+#include "config.h"
+
+#include <stdarg.h>
+#include <stdlib.h>
+#include <dirent.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <dlfcn.h>
+#include <sys/stat.h>
+#ifdef __APPLE__
+#include <Security/Security.h>
+#endif
+#ifdef SONAME_LIBGNUTLS
+#include <gnutls/pkcs12.h>
+#endif
+
+#include "ntstatus.h"
+#define WIN32_NO_STATUS
+#include "windef.h"
+#include "winbase.h"
+#include "winternl.h"
+#include "wincrypt.h"
+#include "crypt32_private.h"
+#include "wine/debug.h"
+
+WINE_DEFAULT_DEBUG_CHANNEL(crypt);
+
+#ifdef SONAME_LIBGNUTLS
+
+WINE_DECLARE_DEBUG_CHANNEL(winediag);
+
+/* Not present in gnutls version < 3.0 */
+int gnutls_pkcs12_simple_parse(gnutls_pkcs12_t p12, const char *password,
+    gnutls_x509_privkey_t *key, gnutls_x509_crt_t **chain, unsigned int *chain_len,
+    gnutls_x509_crt_t **extra_certs, unsigned int *extra_certs_len,
+    gnutls_x509_crl_t * crl, unsigned int flags);
+
+int gnutls_x509_privkey_get_pk_algorithm2(gnutls_x509_privkey_t, unsigned int*);
+
+static void *libgnutls_handle;
+#define MAKE_FUNCPTR(f) static typeof(f) * p##f
+MAKE_FUNCPTR(gnutls_global_deinit);
+MAKE_FUNCPTR(gnutls_global_init);
+MAKE_FUNCPTR(gnutls_global_set_log_function);
+MAKE_FUNCPTR(gnutls_global_set_log_level);
+MAKE_FUNCPTR(gnutls_perror);
+MAKE_FUNCPTR(gnutls_pkcs12_deinit);
+MAKE_FUNCPTR(gnutls_pkcs12_import);
+MAKE_FUNCPTR(gnutls_pkcs12_init);
+MAKE_FUNCPTR(gnutls_pkcs12_simple_parse);
+MAKE_FUNCPTR(gnutls_x509_crt_export);
+MAKE_FUNCPTR(gnutls_x509_privkey_export_rsa_raw2);
+MAKE_FUNCPTR(gnutls_x509_privkey_get_pk_algorithm2);
+#undef MAKE_FUNCPTR
+
+static void gnutls_log( int level, const char *msg )
+{
+    TRACE( "<%d> %s", level, msg );
+}
+
+static NTSTATUS process_attach( void *args )
+{
+    const char *env_str;
+    int ret;
+
+    if ((env_str = getenv("GNUTLS_SYSTEM_PRIORITY_FILE")))
+    {
+        WARN("GNUTLS_SYSTEM_PRIORITY_FILE is %s.\n", debugstr_a(env_str));
+    }
+    else
+    {
+        WARN("Setting GNUTLS_SYSTEM_PRIORITY_FILE to \"/dev/null\".\n");
+        setenv("GNUTLS_SYSTEM_PRIORITY_FILE", "/dev/null", 0);
+    }
+
+    if (!(libgnutls_handle = dlopen( SONAME_LIBGNUTLS, RTLD_NOW )))
+    {
+        ERR_(winediag)( "failed to load libgnutls, no support for pfx import/export\n" );
+        return STATUS_DLL_NOT_FOUND;
+    }
+
+#define LOAD_FUNCPTR(f) \
+    if (!(p##f = dlsym( libgnutls_handle, #f ))) \
+    { \
+        ERR( "failed to load %s\n", #f ); \
+        goto fail; \
+    }
+
+    LOAD_FUNCPTR(gnutls_global_deinit)
+    LOAD_FUNCPTR(gnutls_global_init)
+    LOAD_FUNCPTR(gnutls_global_set_log_function)
+    LOAD_FUNCPTR(gnutls_global_set_log_level)
+    LOAD_FUNCPTR(gnutls_perror)
+    LOAD_FUNCPTR(gnutls_pkcs12_deinit)
+    LOAD_FUNCPTR(gnutls_pkcs12_import)
+    LOAD_FUNCPTR(gnutls_pkcs12_init)
+    LOAD_FUNCPTR(gnutls_pkcs12_simple_parse)
+    LOAD_FUNCPTR(gnutls_x509_crt_export)
+    LOAD_FUNCPTR(gnutls_x509_privkey_export_rsa_raw2)
+    LOAD_FUNCPTR(gnutls_x509_privkey_get_pk_algorithm2)
+#undef LOAD_FUNCPTR
+
+    if ((ret = pgnutls_global_init()) != GNUTLS_E_SUCCESS)
+    {
+        pgnutls_perror( ret );
+        goto fail;
+    }
+
+    if (TRACE_ON( crypt ))
+    {
+        char *env = getenv("GNUTLS_DEBUG_LEVEL");
+        int level = env ? atoi(env) : 4;
+        pgnutls_global_set_log_level(level);
+        pgnutls_global_set_log_function( gnutls_log );
+    }
+
+    return TRUE;
+
+fail:
+    dlclose( libgnutls_handle );
+    libgnutls_handle = NULL;
+    return STATUS_DLL_INIT_FAILED;
+}
+
+static NTSTATUS process_detach( void *args )
+{
+    pgnutls_global_deinit();
+    dlclose( libgnutls_handle );
+    libgnutls_handle = NULL;
+    return STATUS_SUCCESS;
+}
+#define RSA_MAGIC_KEY  ('R' | ('S' << 8) | ('A' << 16) | ('2' << 24))
+#define RSA_PUBEXP     65537
+
+struct cert_store_data
+{
+    gnutls_pkcs12_t p12;
+    gnutls_x509_privkey_t key;
+    gnutls_x509_crt_t *chain;
+    unsigned int key_bitlen;
+    unsigned int chain_len;
+};
+
+static struct cert_store_data *get_store_data( cert_store_data_t data )
+{
+    return (struct cert_store_data *)(ULONG_PTR)data;
+}
+
+static NTSTATUS import_store_key( void *args )
+{
+    struct import_store_key_params *params = args;
+    struct cert_store_data *data = get_store_data( params->data );
+    int i, ret;
+    unsigned int bitlen = data->key_bitlen;
+    gnutls_datum_t m, e, d, p, q, u, e1, e2;
+    BLOBHEADER *hdr;
+    RSAPUBKEY *rsakey;
+    BYTE *src, *dst;
+    DWORD size;
+
+    size = sizeof(*hdr) + sizeof(*rsakey) + (bitlen * 9 / 16);
+    if (!params->buf || *params->buf_size < size)
+    {
+        *params->buf_size = size;
+        return STATUS_BUFFER_TOO_SMALL;
+    }
+
+    if ((ret = pgnutls_x509_privkey_export_rsa_raw2( data->key, &m, &e, &d, &p, &q, &u, &e1, &e2 )) < 0)
+    {
+        pgnutls_perror( ret );
+        return STATUS_INVALID_PARAMETER;
+    }
+
+    hdr = params->buf;
+    hdr->bType    = PRIVATEKEYBLOB;
+    hdr->bVersion = CUR_BLOB_VERSION;
+    hdr->reserved = 0;
+    hdr->aiKeyAlg = CALG_RSA_KEYX;
+
+    rsakey = (RSAPUBKEY *)(hdr + 1);
+    rsakey->magic  = RSA_MAGIC_KEY;
+    rsakey->bitlen = bitlen;
+    rsakey->pubexp = RSA_PUBEXP;
+
+    dst = (BYTE *)(rsakey + 1);
+    if (m.size == bitlen / 8 + 1 && !m.data[0]) src = m.data + 1;
+    else if (m.size != bitlen / 8) goto done;
+    else src = m.data;
+    for (i = bitlen / 8 - 1; i >= 0; i--) *dst++ = src[i];
+
+    if (p.size == bitlen / 16 + 1 && !p.data[0]) src = p.data + 1;
+    else if (p.size != bitlen / 16) goto done;
+    else src = p.data;
+    for (i = bitlen / 16 - 1; i >= 0; i--) *dst++ = src[i];
+
+    if (q.size == bitlen / 16 + 1 && !q.data[0]) src = q.data + 1;
+    else if (q.size != bitlen / 16) goto done;
+    else src = q.data;
+    for (i = bitlen / 16 - 1; i >= 0; i--) *dst++ = src[i];
+
+    if (e1.size == bitlen / 16 + 1 && !e1.data[0]) src = e1.data + 1;
+    else if (e1.size != bitlen / 16) goto done;
+    else src = e1.data;
+    for (i = bitlen / 16 - 1; i >= 0; i--) *dst++ = src[i];
+
+    if (e2.size == bitlen / 16 + 1 && !e2.data[0]) src = e2.data + 1;
+    else if (e2.size != bitlen / 16) goto done;
+    else src = e2.data;
+    for (i = bitlen / 16 - 1; i >= 0; i--) *dst++ = src[i];
+
+    if (u.size == bitlen / 16 + 1 && !u.data[0]) src = u.data + 1;
+    else if (u.size != bitlen / 16) goto done;
+    else src = u.data;
+    for (i = bitlen / 16 - 1; i >= 0; i--) *dst++ = src[i];
+
+    if (d.size == bitlen / 8 + 1 && !d.data[0]) src = d.data + 1;
+    else if (d.size != bitlen / 8) goto done;
+    else src = d.data;
+    for (i = bitlen / 8 - 1; i >= 0; i--) *dst++ = src[i];
+
+done:
+    free( m.data );
+    free( e.data );
+    free( d.data );
+    free( p.data );
+    free( q.data );
+    free( u.data );
+    free( e1.data );
+    free( e2.data );
+    return STATUS_SUCCESS;
+}
+
+static char *password_to_ascii( const WCHAR *str )
+{
+    char *ret;
+    unsigned int i = 0;
+
+    if (!(ret = malloc( (lstrlenW(str) + 1) * sizeof(*ret) ))) return NULL;
+    while (*str)
+    {
+        if (*str > 0x7f) WARN( "password contains non-ascii characters\n" );
+        ret[i++] = *str++;
+    }
+    ret[i] = 0;
+    return ret;
+}
+
+static NTSTATUS open_cert_store( void *args )
+{
+    struct open_cert_store_params *params = args;
+    gnutls_pkcs12_t p12;
+    gnutls_datum_t pfx_data;
+    gnutls_x509_privkey_t key;
+    gnutls_x509_crt_t *chain;
+    unsigned int chain_len;
+    unsigned int bitlen;
+    char *pwd = NULL;
+    int ret;
+    struct cert_store_data *store_data;
+
+    if (!libgnutls_handle) return STATUS_DLL_NOT_FOUND;
+    if (params->password && !(pwd = password_to_ascii( params->password ))) return STATUS_NO_MEMORY;
+
+    if ((ret = pgnutls_pkcs12_init( &p12 )) < 0) goto error;
+
+    pfx_data.data = params->pfx->pbData;
+    pfx_data.size = params->pfx->cbData;
+    if ((ret = pgnutls_pkcs12_import( p12, &pfx_data, GNUTLS_X509_FMT_DER, 0 )) < 0) goto error;
+
+    if ((ret = pgnutls_pkcs12_simple_parse( p12, pwd ? pwd : "", &key, &chain, &chain_len, NULL, NULL, NULL, 0 )) < 0)
+        goto error;
+
+    if ((ret = pgnutls_x509_privkey_get_pk_algorithm2( key, &bitlen )) < 0)
+        goto error;
+
+    free( pwd );
+
+    if (ret != GNUTLS_PK_RSA)
+    {
+        FIXME( "key algorithm %u not supported\n", ret );
+        pgnutls_pkcs12_deinit( p12 );
+        return STATUS_INVALID_PARAMETER;
+    }
+
+    store_data = malloc( sizeof(*store_data) );
+    store_data->p12 = p12;
+    store_data->key = key;
+    store_data->chain = chain;
+    store_data->key_bitlen = bitlen;
+    store_data->chain_len = chain_len;
+    *params->data_ret = (ULONG_PTR)store_data;
+    return STATUS_SUCCESS;
+
+error:
+    pgnutls_perror( ret );
+    pgnutls_pkcs12_deinit( p12 );
+    free( pwd );
+    return STATUS_INVALID_PARAMETER;
+}
+
+static NTSTATUS import_store_cert( void *args )
+{
+    struct import_store_cert_params *params = args;
+    struct cert_store_data *data = get_store_data( params->data );
+    size_t size = 0;
+    int ret;
+
+    if (params->index >= data->chain_len) return STATUS_NO_MORE_ENTRIES;
+
+    if ((ret = pgnutls_x509_crt_export( data->chain[params->index], GNUTLS_X509_FMT_DER, NULL, &size )) != GNUTLS_E_SHORT_MEMORY_BUFFER)
+        return STATUS_INVALID_PARAMETER;
+
+    if (!params->buf || *params->buf_size < size)
+    {
+        *params->buf_size = size;
+        return STATUS_BUFFER_TOO_SMALL;
+    }
+    if ((ret = pgnutls_x509_crt_export( data->chain[params->index], GNUTLS_X509_FMT_DER, params->buf, &size )) < 0)
+        return STATUS_INVALID_PARAMETER;
+
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS close_cert_store( void *args )
+{
+    struct close_cert_store_params *params = args;
+    struct cert_store_data *data = get_store_data( params->data );
+
+    if (params->data)
+    {
+        pgnutls_pkcs12_deinit( data->p12 );
+        free( data );
+    }
+    return STATUS_SUCCESS;
+}
+
+#else /* SONAME_LIBGNUTLS */
+
+static NTSTATUS process_attach( void *args ) { return STATUS_SUCCESS; }
+static NTSTATUS process_detach( void *args ) { return STATUS_SUCCESS; }
+static NTSTATUS open_cert_store( void *args ) { return STATUS_DLL_NOT_FOUND; }
+static NTSTATUS import_store_key( void *args ) { return STATUS_DLL_NOT_FOUND; }
+static NTSTATUS import_store_cert( void *args ) { return STATUS_DLL_NOT_FOUND; }
+static NTSTATUS close_cert_store( void *args ) { return STATUS_DLL_NOT_FOUND; }
+
+#endif /* SONAME_LIBGNUTLS */
+
+struct root_cert
+{
+    struct list entry;
+    SIZE_T      size;
+    BYTE        data[1];
+};
+
+static struct list root_cert_list = LIST_INIT(root_cert_list);
+
+static BYTE *add_cert( SIZE_T size )
+{
+    struct root_cert *cert = malloc( offsetof( struct root_cert, data[size] ));
+
+    if (!cert) return NULL;
+    cert->size = size;
+    list_add_tail( &root_cert_list, &cert->entry );
+    return cert->data;
+}
+
+struct DynamicBuffer
+{
+    DWORD allocated;
+    DWORD used;
+    char *data;
+};
+
+static inline void reset_buffer(struct DynamicBuffer *buffer)
+{
+    buffer->used = 0;
+    if (buffer->data) buffer->data[0] = 0;
+}
+
+static void add_line_to_buffer(struct DynamicBuffer *buffer, LPCSTR line)
+{
+    if (buffer->used + strlen(line) + 1 > buffer->allocated)
+    {
+        DWORD new_size = max( max( buffer->allocated * 2, 1024 ), buffer->used + strlen(line) + 1 );
+        void *ptr = realloc( buffer->data, new_size );
+        if (!ptr) return;
+        buffer->data = ptr;
+        buffer->allocated = new_size;
+        if (!buffer->used) buffer->data[0] = 0;
+    }
+    strcpy( buffer->data + buffer->used, line );
+    buffer->used += strlen(line);
+}
+
+#define BASE64_DECODE_PADDING    0x100
+#define BASE64_DECODE_WHITESPACE 0x200
+#define BASE64_DECODE_INVALID    0x300
+
+static inline int decodeBase64Byte(char c)
+{
+    int ret = BASE64_DECODE_INVALID;
+
+    if (c >= 'A' && c <= 'Z')
+        ret = c - 'A';
+    else if (c >= 'a' && c <= 'z')
+        ret = c - 'a' + 26;
+    else if (c >= '0' && c <= '9')
+        ret = c - '0' + 52;
+    else if (c == '+')
+        ret = 62;
+    else if (c == '/')
+        ret = 63;
+    else if (c == '=')
+        ret = BASE64_DECODE_PADDING;
+    else if (c == ' ' || c == '\t' || c == '\r' || c == '\n')
+        ret = BASE64_DECODE_WHITESPACE;
+    return ret;
+}
+
+static BOOL base64_to_cert( const char *str )
+{
+    DWORD i, valid, out, hasPadding;
+    BYTE block[4], *data;
+
+    for (i = valid = out = hasPadding = 0; str[i]; i++)
+    {
+        int d = decodeBase64Byte( str[i] );
+        if (d == BASE64_DECODE_INVALID) return FALSE;
+        if (d == BASE64_DECODE_WHITESPACE) continue;
+
+        /* When padding starts, data is not acceptable */
+        if (hasPadding && d != BASE64_DECODE_PADDING) return FALSE;
+
+        /* Padding after a full block (like "VVVV=") is ok and stops decoding */
+        if (d == BASE64_DECODE_PADDING && (valid & 3) == 0) break;
+
+        valid++;
+        if (d == BASE64_DECODE_PADDING)
+        {
+            hasPadding = 1;
+            /* When padding reaches a full block, stop decoding */
+            if ((valid & 3) == 0) break;
+            continue;
+        }
+
+        /* out is incremented in the 4-char block as follows: "1-23" */
+        if ((valid & 3) != 2) out++;
+    }
+    /* Fail if the block has bad padding; omitting padding is fine */
+    if ((valid & 3) != 0 && hasPadding) return FALSE;
+
+    if (!(data = add_cert( out ))) return FALSE;
+    for (i = valid = out = 0; str[i]; i++)
+    {
+        int d = decodeBase64Byte( str[i] );
+        if (d == BASE64_DECODE_WHITESPACE) continue;
+        if (d == BASE64_DECODE_PADDING) break;
+        block[valid & 3] = d;
+        valid += 1;
+        switch (valid & 3)
+        {
+        case 1:
+            data[out++] = (block[0] << 2);
+            break;
+        case 2:
+            data[out-1] = (block[0] << 2) | (block[1] >> 4);
+            break;
+        case 3:
+            data[out++] = (block[1] << 4) | (block[2] >> 2);
+            break;
+        case 0:
+            data[out++] = (block[2] << 6) | (block[3] >> 0);
+            break;
+        }
+    }
+    return TRUE;
+}
+
+/* Reads the file fd, and imports any certificates in it into store. */
+static void import_certs_from_file( int fd )
+{
+    FILE *fp = fdopen(fd, "r");
+    char line[1024];
+    BOOL in_cert = FALSE;
+    struct DynamicBuffer saved_cert = { 0, 0, NULL };
+    int num_certs = 0;
+
+    if (!fp) return;
+    TRACE("\n");
+    while (fgets(line, sizeof(line), fp))
+    {
+        static const char header[] = "-----BEGIN CERTIFICATE-----";
+        static const char trailer[] = "-----END CERTIFICATE-----";
+
+        if (!strncmp(line, header, strlen(header)))
+        {
+            TRACE("begin new certificate\n");
+            in_cert = TRUE;
+            reset_buffer(&saved_cert);
+        }
+        else if (!strncmp(line, trailer, strlen(trailer)))
+        {
+            TRACE("end of certificate, adding cert\n");
+            in_cert = FALSE;
+            if (base64_to_cert( saved_cert.data )) num_certs++;
+        }
+        else if (in_cert) add_line_to_buffer(&saved_cert, line);
+    }
+    free( saved_cert.data );
+    TRACE("Read %d certs\n", num_certs);
+    fclose(fp);
+}
+
+static void import_certs_from_path(LPCSTR path, BOOL allow_dir);
+
+static BOOL check_buffer_resize(char **ptr_buf, size_t *buf_size, size_t check_size)
+{
+    if (check_size > *buf_size)
+    {
+        void *ptr = realloc(*ptr_buf, check_size);
+
+        if (!ptr) return FALSE;
+        *buf_size = check_size;
+        *ptr_buf = ptr;
+    }
+    return TRUE;
+}
+
+/* Opens path, which must be a directory, and imports certificates from every
+ * file in the directory into store.
+ * Returns TRUE if any certificates were successfully imported.
+ */
+static void import_certs_from_dir( LPCSTR path )
+{
+    DIR *dir;
+
+    dir = opendir(path);
+    if (dir)
+    {
+        size_t path_len = strlen(path), bufsize = 0;
+        char *filebuf = NULL;
+
+        struct dirent *entry;
+        while ((entry = readdir(dir)))
+        {
+            if (strcmp(entry->d_name, ".") && strcmp(entry->d_name, ".."))
+            {
+                size_t name_len = strlen(entry->d_name);
+
+                if (!check_buffer_resize(&filebuf, &bufsize, path_len + 1 + name_len + 1)) break;
+                snprintf(filebuf, bufsize, "%s/%s", path, entry->d_name);
+                import_certs_from_path(filebuf, FALSE);
+            }
+        }
+        free(filebuf);
+        closedir(dir);
+    }
+}
+
+/* Opens path, which may be a file or a directory, and imports any certificates
+ * it finds into store.
+ * Returns TRUE if any certificates were successfully imported.
+ */
+static void import_certs_from_path(LPCSTR path, BOOL allow_dir)
+{
+    int fd;
+
+    TRACE("(%s, %d)\n", debugstr_a(path), allow_dir);
+
+    fd = open(path, O_RDONLY);
+    if (fd != -1)
+    {
+        struct stat st;
+
+        if (fstat(fd, &st) == 0)
+        {
+            if (S_ISREG(st.st_mode))
+                import_certs_from_file(fd);
+            else if (S_ISDIR(st.st_mode))
+            {
+                if (allow_dir)
+                    import_certs_from_dir(path);
+                else
+                    WARN("%s is a directory and directories are disallowed\n",
+                     debugstr_a(path));
+            }
+            else
+                ERR("%s: invalid file type\n", path);
+        }
+        close(fd);
+    }
+}
+
+static const char * const CRYPT_knownLocations[] = {
+ "/etc/ssl/certs/ca-certificates.crt",
+ "/etc/ssl/certs",
+ "/etc/pki/tls/certs/ca-bundle.crt",
+ "/usr/share/ca-certificates/ca-bundle.crt",
+ "/usr/local/share/certs/",
+ "/etc/sfw/openssl/certs",
+ "/etc/security/cacerts",  /* Android */
+};
+
+static void load_root_certs(void)
+{
+    unsigned int i;
+
+#ifdef __APPLE__
+    const SecTrustSettingsDomain domains[] = {
+        kSecTrustSettingsDomainSystem,
+        kSecTrustSettingsDomainAdmin,
+        kSecTrustSettingsDomainUser
+    };
+    OSStatus status;
+    CFArrayRef certs;
+    DWORD domain;
+
+    for (domain = 0; domain < ARRAY_SIZE(domains); domain++)
+    {
+        status = SecTrustSettingsCopyCertificates(domains[domain], &certs);
+        if (status == noErr)
+        {
+            for (i = 0; i < CFArrayGetCount(certs); i++)
+            {
+                SecCertificateRef cert = (SecCertificateRef)CFArrayGetValueAtIndex(certs, i);
+                CFDataRef certData;
+                if ((status = SecItemExport(cert, kSecFormatX509Cert, 0, NULL, &certData)) == noErr)
+                {
+                    BYTE *data = add_cert( CFDataGetLength(certData) );
+                    if (data) memcpy( data, CFDataGetBytePtr(certData), CFDataGetLength(certData) );
+                    CFRelease(certData);
+                }
+                else
+                    WARN("could not export certificate %u to X509 format: 0x%08x\n", i, (unsigned int)status);
+            }
+            CFRelease(certs);
+        }
+    }
+#endif
+
+    for (i = 0; i < ARRAY_SIZE(CRYPT_knownLocations) && list_empty(&root_cert_list); i++)
+        import_certs_from_path( CRYPT_knownLocations[i], TRUE );
+}
+
+static NTSTATUS enum_root_certs( void *args )
+{
+    struct enum_root_certs_params *params = args;
+    static BOOL loaded;
+    struct list *ptr;
+    struct root_cert *cert;
+
+    if (!loaded) load_root_certs();
+    loaded = TRUE;
+
+    if (!(ptr = list_head( &root_cert_list ))) return STATUS_NO_MORE_ENTRIES;
+    cert = LIST_ENTRY( ptr, struct root_cert, entry );
+    *params->needed = cert->size;
+    if (cert->size <= params->size)
+    {
+        memcpy( params->buffer, cert->data, cert->size );
+        list_remove( &cert->entry );
+        free( cert );
+    }
+    return STATUS_SUCCESS;
+}
+
+const unixlib_entry_t __wine_unix_call_funcs[] =
+{
+    process_attach,
+    process_detach,
+    open_cert_store,
+    import_store_key,
+    import_store_cert,
+    close_cert_store,
+    enum_root_certs,
+};
+
+C_ASSERT( ARRAYSIZE(__wine_unix_call_funcs) == unix_funcs_count );
+
+#ifdef _WIN64
+
+typedef ULONG PTR32;
+
+typedef struct
+{
+    DWORD cbData;
+    PTR32 pbData;
+} CRYPT_DATA_BLOB32;
+
+static NTSTATUS wow64_open_cert_store( void *args )
+{
+    struct
+    {
+        PTR32 pfx;
+        PTR32 password;
+        PTR32 data_ret;
+    } const *params32 = args;
+
+    const CRYPT_DATA_BLOB32 *pfx32 = ULongToPtr( params32->pfx );
+    CRYPT_DATA_BLOB pfx = { pfx32->cbData, ULongToPtr( pfx32->pbData ) };
+    struct open_cert_store_params params =
+    {
+        &pfx,
+        ULongToPtr( params32->password ),
+        ULongToPtr( params32->data_ret )
+    };
+
+    return open_cert_store( &params );
+}
+
+static NTSTATUS wow64_import_store_key( void *args )
+{
+    struct
+    {
+        cert_store_data_t data;
+        PTR32 buf;
+        PTR32 buf_size;
+    } const *params32 = args;
+
+    struct import_store_key_params params =
+    {
+        params32->data,
+        ULongToPtr( params32->buf ),
+        ULongToPtr( params32->buf_size )
+    };
+
+    return import_store_key( &params );
+}
+
+static NTSTATUS wow64_import_store_cert( void *args )
+{
+    struct
+    {
+        cert_store_data_t data;
+        unsigned int index;
+        PTR32 buf;
+        PTR32 buf_size;
+    } const *params32 = args;
+
+    struct import_store_cert_params params =
+    {
+        params32->data,
+        params32->index,
+        ULongToPtr( params32->buf ),
+        ULongToPtr( params32->buf_size )
+    };
+
+    return import_store_cert( &params );
+}
+
+static NTSTATUS wow64_enum_root_certs( void *args )
+{
+    struct
+    {
+        PTR32  buffer;
+        DWORD  size;
+        PTR32  needed;
+    } const *params32 = args;
+
+    struct enum_root_certs_params params =
+    {
+        ULongToPtr( params32->buffer ),
+        params32->size,
+        ULongToPtr( params32->needed )
+    };
+
+    return enum_root_certs( &params );
+}
+
+const unixlib_entry_t __wine_unix_call_wow64_funcs[] =
+{
+    process_attach,
+    process_detach,
+    wow64_open_cert_store,
+    wow64_import_store_key,
+    wow64_import_store_cert,
+    close_cert_store,
+    wow64_enum_root_certs,
+};
+
+C_ASSERT( ARRAYSIZE(__wine_unix_call_wow64_funcs) == unix_funcs_count );
+
+#endif  /* _WIN64 */

--- a/dll/win32/crypt32/wine/unixlib.h
+++ b/dll/win32/crypt32/wine/unixlib.h
@@ -1,0 +1,32 @@
+/*
+ * PROJECT:     ReactOS win32 DLLs
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     ReactOS emulation layer for crypt32 unixlib calls
+ * COPYRIGHT:   Copyright 2026 Timo Kreuzer <timo.kreuzer@reactos.org>
+ */
+
+#pragma once
+
+#include "crypt32_private.h"
+#include <winnls.h> // Workaround: Needed by encode.c
+
+#define __wine_init_unix_call() 0
+
+static inline int __reactos_call_unix_process_attach(void* Args)
+{
+    return 0;
+}
+
+static inline int __reactos_call_unix_process_detach(void* Args)
+{
+    return 0;
+}
+
+// Implemented in reactos/unixlib.c
+int __reactos_call_unix_open_cert_store(void* Args);
+int __reactos_call_unix_close_cert_store(void* Args);
+int __reactos_call_unix_import_store_key(void* Args);
+int __reactos_call_unix_import_store_cert(void* Args);
+int __reactos_call_unix_enum_root_certs(void* Args);
+
+#define WINE_UNIX_CALL(code,args) __reactos_call_ ## code(args)

--- a/media/doc/WINESYNC.txt
+++ b/media/doc/WINESYNC.txt
@@ -70,7 +70,7 @@ dll/win32/comdlg32            # Synced to WineStaging-4.18
 dll/win32/coml2               # Synced to Wine-10.0
 dll/win32/compstui            # Synced to WineStaging-4.18
 dll/win32/credui              # Synced to WineStaging-4.18
-dll/win32/crypt32             # Synced to WineStaging-4.0
+dll/win32/crypt32             # Synced to Wine-10.0
 dll/win32/cryptdlg            # Synced to WineStaging-4.18
 dll/win32/cryptdll            # Synced to WineStaging-4.18
 dll/win32/cryptnet            # Synced to Wine-10.0

--- a/modules/rostests/winetests/crypt32/store.c
+++ b/modules/rostests/winetests/crypt32/store.c
@@ -3231,6 +3231,10 @@ static void test_PFXImportCertStore(void)
     pfx.cbData = sizeof(pfxdata);
     store = PFXImportCertStore( &pfx, NULL, CRYPT_EXPORTABLE|CRYPT_USER_KEYSET|PKCS12_NO_PERSIST_KEY );
     ok( store != NULL, "got %lu\n", GetLastError() );
+#ifdef __REACTOS__
+    if (store == NULL)
+        return;
+#endif
     count = countCertsInStore( store );
     ok( count == 1, "got %lu\n", count );
 

--- a/sdk/include/psdk/bcrypt.h
+++ b/sdk/include/psdk/bcrypt.h
@@ -40,44 +40,171 @@ typedef _Return_type_success_(return >= 0) LONG NTSTATUS;
 typedef NTSTATUS *PNTSTATUS;
 #endif
 
-#define BCRYPT_ALGORITHM_NAME L"AlgorithmName"
-#define BCRYPT_AUTH_TAG_LENGTH L"AuthTagLength"
-#define BCRYPT_BLOCK_LENGTH L"BlockLength"
-#define BCRYPT_BLOCK_SIZE_LIST L"BlockSizeList"
-#define BCRYPT_CHAINING_MODE L"ChainingMode"
+#if defined(_MSC_VER) || defined(__MINGW32__)
+#define BCRYPT_ALGORITHM_NAME       L"AlgorithmName"
+#define BCRYPT_AUTH_TAG_LENGTH      L"AuthTagLength"
+#define BCRYPT_BLOCK_LENGTH         L"BlockLength"
+#define BCRYPT_BLOCK_SIZE_LIST      L"BlockSizeList"
+#define BCRYPT_CHAINING_MODE        L"ChainingMode"
 #define BCRYPT_EFFECTIVE_KEY_LENGTH L"EffectiveKeyLength"
-#define BCRYPT_HASH_BLOCK_LENGTH L"HashBlockLength"
-#define BCRYPT_HASH_LENGTH L"HashDigestLength"
-#define BCRYPT_HASH_OID_LIST L"HashOIDList"
-#define BCRYPT_KEY_LENGTH L"KeyLength"
-#define BCRYPT_KEY_LENGTHS L"KeyLengths"
-#define BCRYPT_KEY_OBJECT_LENGTH L"KeyObjectLength"
-#define BCRYPT_KEY_STRENGTH L"KeyStrength"
-#define BCRYPT_OBJECT_LENGTH L"ObjectLength"
-#define BCRYPT_PADDING_SCHEMES L"PaddingSchemes"
-#define BCRYPT_PROVIDER_HANDLE L"ProviderHandle"
-#define BCRYPT_SIGNATURE_LENGTH L"SignatureLength"
+#define BCRYPT_HASH_BLOCK_LENGTH    L"HashBlockLength"
+#define BCRYPT_HASH_LENGTH          L"HashDigestLength"
+#define BCRYPT_HASH_OID_LIST        L"HashOIDList"
+#define BCRYPT_KEY_LENGTH           L"KeyLength"
+#define BCRYPT_KEY_LENGTHS          L"KeyLengths"
+#define BCRYPT_KEY_OBJECT_LENGTH    L"KeyObjectLength"
+#define BCRYPT_KEY_STRENGTH         L"KeyStrength"
+#define BCRYPT_OBJECT_LENGTH        L"ObjectLength"
+#define BCRYPT_PADDING_SCHEMES      L"PaddingSchemes"
+#define BCRYPT_PROVIDER_HANDLE      L"ProviderHandle"
+#define BCRYPT_SIGNATURE_LENGTH     L"SignatureLength"
+#define BCRYPT_PUBLIC_KEY_LENGTH    L"PublicKeyLength"
 
-#define BCRYPT_OPAQUE_KEY_BLOB   L"OpaqueKeyBlob"
-#define BCRYPT_KEY_DATA_BLOB     L"KeyDataBlob"
-#define BCRYPT_AES_WRAP_KEY_BLOB L"Rfc3565KeyWrapBlob"
-#define BCRYPT_ECCPUBLIC_BLOB    L"ECCPUBLICBLOB"
-#define BCRYPT_ECCPRIVATE_BLOB   L"ECCPRIVATEBLOB"
-#define BCRYPT_RSAPUBLIC_BLOB    L"RSAPUBLICBLOB"
-#define BCRYPT_RSAPRIVATE_BLOB   L"RSAPRIVATEBLOB"
+#define BCRYPT_OPAQUE_KEY_BLOB      L"OpaqueKeyBlob"
+#define BCRYPT_KEY_DATA_BLOB        L"KeyDataBlob"
+#define BCRYPT_AES_WRAP_KEY_BLOB    L"Rfc3565KeyWrapBlob"
+#define BCRYPT_ECCPUBLIC_BLOB       L"ECCPUBLICBLOB"
+#define BCRYPT_ECCPRIVATE_BLOB      L"ECCPRIVATEBLOB"
+#define BCRYPT_RSAPUBLIC_BLOB       L"RSAPUBLICBLOB"
+#define BCRYPT_RSAPRIVATE_BLOB      L"RSAPRIVATEBLOB"
+#define BCRYPT_RSAFULLPRIVATE_BLOB  L"RSAFULLPRIVATEBLOB"
+#define BCRYPT_DSA_PUBLIC_BLOB      L"DSAPUBLICBLOB"
+#define BCRYPT_DSA_PRIVATE_BLOB     L"DSAPRIVATEBLOB"
+#define BCRYPT_PUBLIC_KEY_BLOB      L"PUBLICBLOB"
+#define BCRYPT_PRIVATE_KEY_BLOB     L"PRIVATEBLOB"
+#define BCRYPT_DH_PUBLIC_BLOB       L"DHPUBLICBLOB"
+#define BCRYPT_DH_PRIVATE_BLOB      L"DHPRIVATEBLOB"
+#define LEGACY_DSA_PUBLIC_BLOB      L"CAPIDSAPUBLICBLOB"
+#define LEGACY_DSA_PRIVATE_BLOB     L"CAPIDSAPRIVATEBLOB"
+#define LEGACY_DSA_V2_PUBLIC_BLOB   L"V2CAPIDSAPUBLICBLOB"
+#define LEGACY_DSA_V2_PRIVATE_BLOB  L"V2CAPIDSAPRIVATEBLOB"
+#define LEGACY_RSAPUBLIC_BLOB       L"CAPIPUBLICBLOB"
+#define LEGACY_RSAPRIVATE_BLOB      L"CAPIPRIVATEBLOB"
 
-#define MS_PRIMITIVE_PROVIDER L"Microsoft Primitive Provider"
+#define MS_PRIMITIVE_PROVIDER       L"Microsoft Primitive Provider"
 #define MS_PLATFORM_CRYPTO_PROVIDER L"Microsoft Platform Crypto Provider"
 
+#define BCRYPT_3DES_ALGORITHM       L"3DES"
+#define BCRYPT_AES_ALGORITHM        L"AES"
+#define BCRYPT_DES_ALGORITHM        L"DES"
+#define BCRYPT_DH_ALGORITHM         L"DH"
+#define BCRYPT_DSA_ALGORITHM        L"DSA"
+#define BCRYPT_ECDH_P256_ALGORITHM  L"ECDH_P256"
+#define BCRYPT_ECDH_P384_ALGORITHM  L"ECDH_P384"
+#define BCRYPT_ECDSA_P256_ALGORITHM L"ECDSA_P256"
+#define BCRYPT_ECDSA_P384_ALGORITHM L"ECDSA_P384"
+#define BCRYPT_ECDSA_P521_ALGORITHM L"ECDSA_P521"
+#define BCRYPT_MD2_ALGORITHM        L"MD2"
+#define BCRYPT_MD4_ALGORITHM        L"MD4"
 #define BCRYPT_MD5_ALGORITHM        L"MD5"
+#define BCRYPT_RC2_ALGORITHM        L"RC2"
+#define BCRYPT_RC4_ALGORITHM        L"RC4"
 #define BCRYPT_RNG_ALGORITHM        L"RNG"
+#define BCRYPT_RSA_ALGORITHM        L"RSA"
+#define BCRYPT_RSA_SIGN_ALGORITHM   L"RSA_SIGN"
 #define BCRYPT_SHA1_ALGORITHM       L"SHA1"
 #define BCRYPT_SHA256_ALGORITHM     L"SHA256"
 #define BCRYPT_SHA384_ALGORITHM     L"SHA384"
 #define BCRYPT_SHA512_ALGORITHM     L"SHA512"
-#define BCRYPT_ECDSA_P256_ALGORITHM L"ECDSA_P256"
-#define BCRYPT_ECDSA_P384_ALGORITHM L"ECDSA_P384"
-#define BCRYPT_ECDSA_P521_ALGORITHM L"ECDSA_P521"
+
+#define BCRYPT_CHAIN_MODE_NA        L"ChainingModeN/A"
+#define BCRYPT_CHAIN_MODE_CBC       L"ChainingModeCBC"
+#define BCRYPT_CHAIN_MODE_ECB       L"ChainingModeECB"
+#define BCRYPT_CHAIN_MODE_CFB       L"ChainingModeCFB"
+#define BCRYPT_CHAIN_MODE_CCM       L"ChainingModeCCM"
+#define BCRYPT_CHAIN_MODE_GCM       L"ChainingModeGCM"
+
+#define BCRYPT_KDF_HASH             L"HASH"
+#define BCRYPT_KDF_HMAC             L"HMAC"
+#define BCRYPT_KDF_TLS_PRF          L"TLS_PRF"
+#define BCRYPT_KDF_SP80056A_CONCAT  L"SP800_56A_CONCAT"
+#define BCRYPT_KDF_RAW_SECRET       L"TRUNCATE"
+
+#define BCRYPT_DH_PARAMETERS        L"DHParameters"
+#else
+static const WCHAR BCRYPT_ALGORITHM_NAME[] = {'A','l','g','o','r','i','t','h','m','N','a','m','e',0};
+static const WCHAR BCRYPT_AUTH_TAG_LENGTH[] = {'A','u','t','h','T','a','g','L','e','n','g','t','h',0};
+static const WCHAR BCRYPT_BLOCK_LENGTH[] = {'B','l','o','c','k','L','e','n','g','t','h',0};
+static const WCHAR BCRYPT_BLOCK_SIZE_LIST[] = {'B','l','o','c','k','S','i','z','e','L','i','s','t',0};
+static const WCHAR BCRYPT_CHAINING_MODE[] = {'C','h','a','i','n','i','n','g','M','o','d','e',0};
+static const WCHAR BCRYPT_EFFECTIVE_KEY_LENGTH[] = {'E','f','f','e','c','t','i','v','e','K','e','y','L','e','n','g','t','h',0};
+static const WCHAR BCRYPT_HASH_BLOCK_LENGTH[] = {'H','a','s','h','B','l','o','c','k','L','e','n','g','t','h',0};
+static const WCHAR BCRYPT_HASH_LENGTH[] = {'H','a','s','h','D','i','g','e','s','t','L','e','n','g','t','h',0};
+static const WCHAR BCRYPT_HASH_OID_LIST[] = {'H','a','s','h','O','I','D','L','i','s','t',0};
+static const WCHAR BCRYPT_KEY_LENGTH[] = {'K','e','y','L','e','n','g','t','h',0};
+static const WCHAR BCRYPT_KEY_LENGTHS[] = {'K','e','y','L','e','n','g','t','h','s',0};
+static const WCHAR BCRYPT_KEY_OBJECT_LENGTH[] = {'K','e','y','O','b','j','e','c','t','L','e','n','g','t','h',0};
+static const WCHAR BCRYPT_KEY_STRENGTH[] = {'K','e','y','S','t','r','e','n','g','t','h',0};
+static const WCHAR BCRYPT_OBJECT_LENGTH[] = {'O','b','j','e','c','t','L','e','n','g','t','h',0};
+static const WCHAR BCRYPT_PADDING_SCHEMES[] = {'P','a','d','d','i','n','g','S','c','h','e','m','e','s',0};
+static const WCHAR BCRYPT_PROVIDER_HANDLE[] = {'P','r','o','v','i','d','e','r','H','a','n','d','l','e',0};
+static const WCHAR BCRYPT_SIGNATURE_LENGTH[] = {'S','i','g','n','a','t','u','r','e','L','e','n','g','t','h',0};
+static const WCHAR BCRYPT_PUBLIC_KEY_LENGTH[] = {'P','u','b','l','i','c','K','e','y','L','e','n','g','t','h',0};
+
+static const WCHAR BCRYPT_OPAQUE_KEY_BLOB[] = {'O','p','a','q','u','e','K','e','y','B','l','o','b',0};
+static const WCHAR BCRYPT_KEY_DATA_BLOB[] = {'K','e','y','D','a','t','a','B','l','o','b',0};
+static const WCHAR BCRYPT_AES_WRAP_KEY_BLOB[] = {'R','f','c','3','5','6','5','K','e','y','W','r','a','p','B','l','o','b',0};
+static const WCHAR BCRYPT_ECCPUBLIC_BLOB[] = {'E','C','C','P','U','B','L','I','C','B','L','O','B',0};
+static const WCHAR BCRYPT_ECCPRIVATE_BLOB[] = {'E','C','C','P','R','I','V','A','T','E','B','L','O','B',0};
+static const WCHAR BCRYPT_RSAPUBLIC_BLOB[] = {'R','S','A','P','U','B','L','I','C','B','L','O','B',0};
+static const WCHAR BCRYPT_RSAPRIVATE_BLOB[] = {'R','S','A','P','R','I','V','A','T','E','B','L','O','B',0};
+static const WCHAR BCRYPT_RSAFULLPRIVATE_BLOB[] = {'R','S','A','F','U','L','L','P','R','I','V','A','T','E','B','L','O','B',0};
+static const WCHAR BCRYPT_DSA_PUBLIC_BLOB[] = {'D','S','A','P','U','B','L','I','C','B','L','O','B',0};
+static const WCHAR BCRYPT_DSA_PRIVATE_BLOB[] = {'D','S','A','P','R','I','V','A','T','E','B','L','O','B',0};
+static const WCHAR BCRYPT_PUBLIC_KEY_BLOB[] = {'P','U','B','L','I','C','B','L','O','B',0};
+static const WCHAR BCRYPT_PRIVATE_KEY_BLOB[] = {'P','R','I','V','A','T','E','B','L','O','B',0};
+static const WCHAR BCRYPT_DH_PUBLIC_BLOB[] = {'D','H','P','U','B','L','I','C','B','L','O','B',0};
+static const WCHAR BCRYPT_DH_PRIVATE_BLOB[] = {'D','H','P','R','I','V','A','T','E','B','L','O','B',0};
+static const WCHAR LEGACY_DSA_PUBLIC_BLOB[] = {'C','A','P','I','D','S','A','P','U','B','L','I','C','B','L','O','B',0};
+static const WCHAR LEGACY_DSA_PRIVATE_BLOB[] = {'C','A','P','I','D','S','A','P','R','I','V','A','T','E','B','L','O','B',0};
+static const WCHAR LEGACY_DSA_V2_PUBLIC_BLOB[] = {'V','2','C','A','P','I','D','S','A','P','U','B','L','I','C','B','L','O','B',0};
+static const WCHAR LEGACY_DSA_V2_PRIVATE_BLOB[] = {'V','2','C','A','P','I','D','S','A','P','R','I','V','A','T','E','B','L','O','B',0};
+static const WCHAR LEGACY_RSAPUBLIC_BLOB[] = {'C','A','P','I','P','U','B','L','I','C','B','L','O','B',0};
+static const WCHAR LEGACY_RSAPRIVATE_BLOB[] = {'C','A','P','I','P','R','I','V','A','T','E','B','L','O','B',0};
+
+static const WCHAR MS_PRIMITIVE_PROVIDER[] = \
+{'M','i','c','r','o','s','o','f','t',' ','P','r','i','m','i','t','i','v','e',' ','P','r','o','v','i','d','e','r',0};
+static const WCHAR MS_PLATFORM_CRYPTO_PROVIDER[] = \
+{'M','i','c','r','o','s','o','f','t',' ','P','l','a','t','f','o','r','m',' ','C','r','y','p','t','o',' ','P','r','o','v','i','d','e','r',0};
+
+static const WCHAR BCRYPT_3DES_ALGORITHM[] = {'3','D','E','S',0};
+static const WCHAR BCRYPT_AES_ALGORITHM[] = {'A','E','S',0};
+static const WCHAR BCRYPT_DES_ALGORITHM[] = {'D','E','S',0};
+static const WCHAR BCRYPT_DH_ALGORITHM[] = {'D','H',0};
+static const WCHAR BCRYPT_DSA_ALGORITHM[] = {'D','S','A',0};
+static const WCHAR BCRYPT_ECDH_P256_ALGORITHM[] = {'E','C','D','H','_','P','2','5','6',0};
+static const WCHAR BCRYPT_ECDH_P384_ALGORITHM[] = {'E','C','D','H','_','P','3','8','4',0};
+static const WCHAR BCRYPT_ECDSA_P256_ALGORITHM[] = {'E','C','D','S','A','_','P','2','5','6',0};
+static const WCHAR BCRYPT_ECDSA_P384_ALGORITHM[] = {'E','C','D','S','A','_','P','3','8','4',0};
+static const WCHAR BCRYPT_ECDSA_P521_ALGORITHM[] = {'E','C','D','S','A','_','P','5','2','1',0};
+static const WCHAR BCRYPT_MD2_ALGORITHM[] = {'M','D','2',0};
+static const WCHAR BCRYPT_MD4_ALGORITHM[] = {'M','D','4',0};
+static const WCHAR BCRYPT_MD5_ALGORITHM[] = {'M','D','5',0};
+static const WCHAR BCRYPT_RC2_ALGORITHM[] = {'R','C','2',0};
+static const WCHAR BCRYPT_RC4_ALGORITHM[] = {'R','C','4',0};
+static const WCHAR BCRYPT_RNG_ALGORITHM[] = {'R','N','G',0};
+static const WCHAR BCRYPT_RSA_ALGORITHM[] = {'R','S','A',0};
+static const WCHAR BCRYPT_RSA_SIGN_ALGORITHM[] = {'R','S','A','_','S','I','G','N',0};
+static const WCHAR BCRYPT_SHA1_ALGORITHM[] = {'S','H','A','1',0};
+static const WCHAR BCRYPT_SHA256_ALGORITHM[] = {'S','H','A','2','5','6',0};
+static const WCHAR BCRYPT_SHA384_ALGORITHM[] = {'S','H','A','3','8','4',0};
+static const WCHAR BCRYPT_SHA512_ALGORITHM[] = {'S','H','A','5','1','2',0};
+
+static const WCHAR BCRYPT_CHAIN_MODE_NA[] = {'C','h','a','i','n','i','n','g','M','o','d','e','N','/','A',0};
+static const WCHAR BCRYPT_CHAIN_MODE_CBC[] = {'C','h','a','i','n','i','n','g','M','o','d','e','C','B','C',0};
+static const WCHAR BCRYPT_CHAIN_MODE_ECB[] = {'C','h','a','i','n','i','n','g','M','o','d','e','E','C','B',0};
+static const WCHAR BCRYPT_CHAIN_MODE_CFB[] = {'C','h','a','i','n','i','n','g','M','o','d','e','C','F','B',0};
+static const WCHAR BCRYPT_CHAIN_MODE_CCM[] = {'C','h','a','i','n','i','n','g','M','o','d','e','C','C','M',0};
+static const WCHAR BCRYPT_CHAIN_MODE_GCM[] = {'C','h','a','i','n','i','n','g','M','o','d','e','G','C','M',0};
+
+static const WCHAR BCRYPT_KDF_HASH[] = {'H','A','S','H',0};
+static const WCHAR BCRYPT_KDF_HMAC[] = {'H','M','A','C',0};
+static const WCHAR BCRYPT_KDF_TLS_PRF[] = {'T','L','S','_','P','R','F',0};
+static const WCHAR BCRYPT_KDF_SP80056A_CONCAT[] = {'S','P','8','0','0','_','5','6','A','_','C','O','N','C','A','T',0};
+static const WCHAR BCRYPT_KDF_RAW_SECRET[] = {'T','R','U','N','C','A','T','E',0};
+
+static const WCHAR BCRYPT_DH_PARAMETERS[] = {'D','H','P','a','r','a','m','e','t','e','r','s',0};
+#endif
 
 #define BCRYPT_ECDSA_PUBLIC_P256_MAGIC  0x31534345
 #define BCRYPT_ECDSA_PRIVATE_P256_MAGIC 0x32534345
@@ -85,6 +212,34 @@ typedef NTSTATUS *PNTSTATUS;
 #define BCRYPT_ECDSA_PRIVATE_P384_MAGIC 0x34534345
 #define BCRYPT_ECDSA_PUBLIC_P521_MAGIC  0x35534345
 #define BCRYPT_ECDSA_PRIVATE_P521_MAGIC 0x36534345
+
+#define BCRYPT_ECDH_PUBLIC_P256_MAGIC  0x314b4345
+#define BCRYPT_ECDH_PRIVATE_P256_MAGIC 0x324b4345
+#define BCRYPT_ECDH_PUBLIC_P384_MAGIC  0x334b4345
+#define BCRYPT_ECDH_PRIVATE_P384_MAGIC 0x344b4345
+#define BCRYPT_ECDH_PUBLIC_P521_MAGIC  0x354b4345
+#define BCRYPT_ECDH_PRIVATE_P521_MAGIC 0x364b4345
+
+#define BCRYPT_CIPHER_OPERATION                 0x00000001
+#define BCRYPT_HASH_OPERATION                   0x00000002
+#define BCRYPT_ASYMMETRIC_ENCRYPTION_OPERATION  0x00000004
+#define BCRYPT_SECRET_AGREEMENT_OPERATION       0x00000008
+#define BCRYPT_SIGNATURE_OPERATION              0x00000010
+#define BCRYPT_RNG_OPERATION                    0x00000020
+
+#define BCRYPT_CIPHER_INTERFACE                 0x00000001
+#define BCRYPT_HASH_INTERFACE                   0x00000002
+#define BCRYPT_ASYMMETRIC_ENCRYPTION_INTERFACE  0x00000003
+#define BCRYPT_SECRET_AGREEMENT_INTERFACE       0x00000004
+#define BCRYPT_SIGNATURE_INTERFACE              0x00000005
+#define BCRYPT_RNG_INTERFACE                    0x00000006
+#define BCRYPT_KEY_DERIVATION_INTERFACE         0x00000007
+
+#define BCRYPT_SUPPORTED_PAD_ROUTER     0x00000001
+#define BCRYPT_SUPPORTED_PAD_PKCS1_ENC  0x00000002
+#define BCRYPT_SUPPORTED_PAD_PKCS1_SIG  0x00000004
+#define BCRYPT_SUPPORTED_PAD_OAEP       0x00000008
+#define BCRYPT_SUPPORTED_PAD_PSS        0x00000010
 
 typedef struct _BCRYPT_ALGORITHM_IDENTIFIER
 {
@@ -99,13 +254,6 @@ typedef struct __BCRYPT_KEY_LENGTHS_STRUCT
     ULONG dwMaxLength;
     ULONG dwIncrement;
 } BCRYPT_KEY_LENGTHS_STRUCT, BCRYPT_AUTH_TAG_LENGTHS_STRUCT;
-
-typedef struct _BCRYPT_KEY_DATA_BLOB_HEADER
-{
-    ULONG dwMagic;
-    ULONG dwVersion;
-    ULONG cbKeyData;
-} BCRYPT_KEY_DATA_BLOB_HEADER, *PBCRYPT_KEY_DATA_BLOB_HEADER;
 
 typedef struct _BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO
 {
@@ -123,6 +271,11 @@ typedef struct _BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO
     ULONGLONG cbData;
     ULONG dwFlags;
 } BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO, *PBCRYPT_AUTHENTICATED_CIPHER_MODE_INFO;
+
+typedef struct _BCRYPT_KEY_BLOB
+{
+    ULONG Magic;
+} BCRYPT_KEY_BLOB;
 
 typedef struct _BCRYPT_ECCKEY_BLOB
 {
@@ -149,15 +302,136 @@ typedef struct _BCRYPT_PKCS1_PADDING_INFO
     LPCWSTR pszAlgId;
 } BCRYPT_PKCS1_PADDING_INFO;
 
-#define BCRYPT_PAD_NONE   0x00000001
-#define BCRYPT_PAD_PKCS1  0x00000002
-#define BCRYPT_PAD_OAEP   0x00000004
-#define BCRYPT_PAD_PSS    0x00000008
+typedef struct _BCRYPT_PSS_PADDING_INFO
+{
+    LPCWSTR pszAlgId;
+    ULONG   cbSalt;
+} BCRYPT_PSS_PADDING_INFO;
+
+typedef struct _BCRYPT_OAEP_PADDING_INFO
+{
+    LPCWSTR pszAlgId;
+    PUCHAR  pbLabel;
+    ULONG   cbLabel;
+} BCRYPT_OAEP_PADDING_INFO;
+
+#define BCRYPT_PAD_NONE                     0x00000001
+#define BCRYPT_PAD_PKCS1                    0x00000002
+#define BCRYPT_PAD_OAEP                     0x00000004
+#define BCRYPT_PAD_PSS                      0x00000008
+#define BCRYPT_PAD_PKCS1_OPTIONAL_HASH_OID  0x00000010
+
+#define BCRYPT_DSA_PUBLIC_MAGIC     0x42505344
+#define BCRYPT_DSA_PRIVATE_MAGIC    0x56505344
+
+typedef struct _BCRYPT_DSA_KEY_BLOB
+{
+    ULONG dwMagic;
+    ULONG cbKey;
+    UCHAR Count[4];
+    UCHAR Seed[20];
+    UCHAR q[20];
+} BCRYPT_DSA_KEY_BLOB, *PBCRYPT_DSA_KEY_BLOB;
+
+#define BCRYPT_DSA_PUBLIC_MAGIC_V2  0x32425044
+#define BCRYPT_DSA_PRIVATE_MAGIC_V2 0x32565044
+
+typedef enum
+{
+    DSA_HASH_ALGORITHM_SHA1,
+    DSA_HASH_ALGORITHM_SHA256,
+    DSA_HASH_ALGORITHM_SHA512
+} HASHALGORITHM_ENUM;
+
+typedef enum
+{
+    DSA_FIPS186_2,
+    DSA_FIPS186_3
+} DSAFIPSVERSION_ENUM;
+
+typedef struct _BCRYPT_DSA_KEY_BLOB_V2
+{
+    ULONG               dwMagic;
+    ULONG               cbKey;
+    HASHALGORITHM_ENUM  hashAlgorithm;
+    DSAFIPSVERSION_ENUM standardVersion;
+    ULONG               cbSeedLength;
+    ULONG               cbGroupSize;
+    UCHAR               Count[4];
+} BCRYPT_DSA_KEY_BLOB_V2, *PBCRYPT_DSA_KEY_BLOB_V2;
+
+#define BCRYPT_DH_PUBLIC_MAGIC  0x42504844
+#define BCRYPT_DH_PRIVATE_MAGIC 0x56504844
+
+typedef struct _BCRYPT_DH_KEY_BLOB
+{
+    ULONG dwMagic;
+    ULONG cbKey;
+} BCRYPT_DH_KEY_BLOB, *PBCRYPT_DH_KEY_BLOB;
+
+#define BCRYPT_DH_PARAMETERS_MAGIC  0x4d504844
+
+typedef struct _BCRYPT_DH_PARAMETER_HEADER
+{
+    ULONG cbLength;
+    ULONG dwMagic;
+    ULONG cbKeyLength;
+} BCRYPT_DH_PARAMETER_HEADER;
 
 #define BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO_VERSION 1
 
 #define BCRYPT_AUTH_MODE_CHAIN_CALLS_FLAG 0x00000001
 #define BCRYPT_AUTH_MODE_IN_PROGRESS_FLAG 0x00000002
+
+typedef struct _CRYPT_INTERFACE_REG
+{
+    ULONG dwInterface;
+    ULONG dwFlags;
+    ULONG cFunctions;
+    PWSTR *rgpszFunctions;
+} CRYPT_INTERFACE_REG, *PCRYPT_INTERFACE_REG;
+
+typedef struct _CRYPT_IMAGE_REG
+{
+    PWSTR pszImage;
+    ULONG cInterfaces;
+    PCRYPT_INTERFACE_REG *rgpInterfaces;
+} CRYPT_IMAGE_REG, *PCRYPT_IMAGE_REG;
+
+typedef struct _CRYPT_PROVIDER_REG
+{
+    ULONG cAliases;
+    PWSTR *rgpszAliases;
+    PCRYPT_IMAGE_REG pUM;
+    PCRYPT_IMAGE_REG pKM;
+} CRYPT_PROVIDER_REG, *PCRYPT_PROVIDER_REG;
+
+typedef struct _BCRYPT_KEY_DATA_BLOB_HEADER
+{
+    ULONG dwMagic;
+    ULONG dwVersion;
+    ULONG cbKeyData;
+} BCRYPT_KEY_DATA_BLOB_HEADER, *PBCRYPT_KEY_DATA_BLOB_HEADER;
+
+#define KDF_HASH_ALGORITHM 0x00000000
+#define KDF_SECRET_PREPEND 0x00000001
+#define KDF_SECRET_APPEND  0x00000002
+
+typedef struct _BCryptBuffer
+{
+    ULONG cbBuffer;
+    ULONG BufferType;
+    void  *pvBuffer;
+} BCryptBuffer, *PBCryptBuffer;
+
+#define BCRYPTBUFFER_VERSION        0
+
+typedef struct _BCryptBufferDesc
+{
+    ULONG ulVersion;
+    ULONG cBuffers;
+    PBCryptBuffer pBuffers;
+} BCryptBufferDesc, *PBCryptBufferDesc;
 
 #define BCRYPT_KEY_DATA_BLOB_MAGIC    0x4d42444b
 #define BCRYPT_KEY_DATA_BLOB_VERSION1 1
@@ -166,29 +440,123 @@ typedef PVOID BCRYPT_ALG_HANDLE;
 typedef PVOID BCRYPT_KEY_HANDLE;
 typedef PVOID BCRYPT_HANDLE;
 typedef PVOID BCRYPT_HASH_HANDLE;
+typedef PVOID BCRYPT_SECRET_HANDLE;
 
+/* Pseudo handles */
+#define BCRYPT_MD2_ALG_HANDLE               ((BCRYPT_ALG_HANDLE)0x00000001)
+#define BCRYPT_MD4_ALG_HANDLE               ((BCRYPT_ALG_HANDLE)0x00000011)
+#define BCRYPT_MD5_ALG_HANDLE               ((BCRYPT_ALG_HANDLE)0x00000021)
+#define BCRYPT_SHA1_ALG_HANDLE              ((BCRYPT_ALG_HANDLE)0x00000031)
+#define BCRYPT_SHA256_ALG_HANDLE            ((BCRYPT_ALG_HANDLE)0x00000041)
+#define BCRYPT_SHA384_ALG_HANDLE            ((BCRYPT_ALG_HANDLE)0x00000051)
+#define BCRYPT_SHA512_ALG_HANDLE            ((BCRYPT_ALG_HANDLE)0x00000061)
+#define BCRYPT_RC4_ALG_HANDLE               ((BCRYPT_ALG_HANDLE)0x00000071)
+#define BCRYPT_RNG_ALG_HANDLE               ((BCRYPT_ALG_HANDLE)0x00000081)
+#define BCRYPT_HMAC_MD5_ALG_HANDLE          ((BCRYPT_ALG_HANDLE)0x00000091)
+#define BCRYPT_HMAC_SHA1_ALG_HANDLE         ((BCRYPT_ALG_HANDLE)0x000000a1)
+#define BCRYPT_HMAC_SHA256_ALG_HANDLE       ((BCRYPT_ALG_HANDLE)0x000000b1)
+#define BCRYPT_HMAC_SHA384_ALG_HANDLE       ((BCRYPT_ALG_HANDLE)0x000000c1)
+#define BCRYPT_HMAC_SHA512_ALG_HANDLE       ((BCRYPT_ALG_HANDLE)0x000000d1)
+#define BCRYPT_RSA_ALG_HANDLE               ((BCRYPT_ALG_HANDLE)0x000000e1)
+#define BCRYPT_ECDSA_ALG_HANDLE             ((BCRYPT_ALG_HANDLE)0x000000f1)
+#define BCRYPT_AES_CMAC_ALG_HANDLE          ((BCRYPT_ALG_HANDLE)0x00000101)
+#define BCRYPT_AES_GMAC_ALG_HANDLE          ((BCRYPT_ALG_HANDLE)0x00000111)
+#define BCRYPT_HMAC_MD2_ALG_HANDLE          ((BCRYPT_ALG_HANDLE)0x00000121)
+#define BCRYPT_HMAC_MD4_ALG_HANDLE          ((BCRYPT_ALG_HANDLE)0x00000131)
+#define BCRYPT_3DES_CBC_ALG_HANDLE          ((BCRYPT_ALG_HANDLE)0x00000141)
+#define BCRYPT_3DES_ECB_ALG_HANDLE          ((BCRYPT_ALG_HANDLE)0x00000151)
+#define BCRYPT_3DES_CFB_ALG_HANDLE          ((BCRYPT_ALG_HANDLE)0x00000161)
+#define BCRYPT_3DES_112_CBC_ALG_HANDLE      ((BCRYPT_ALG_HANDLE)0x00000171)
+#define BCRYPT_3DES_112_ECB_ALG_HANDLE      ((BCRYPT_ALG_HANDLE)0x00000181)
+#define BCRYPT_3DES_112_CFB_ALG_HANDLE      ((BCRYPT_ALG_HANDLE)0x00000191)
+#define BCRYPT_AES_CBC_ALG_HANDLE           ((BCRYPT_ALG_HANDLE)0x000001a1)
+#define BCRYPT_AES_ECB_ALG_HANDLE           ((BCRYPT_ALG_HANDLE)0x000001b1)
+#define BCRYPT_AES_CFB_ALG_HANDLE           ((BCRYPT_ALG_HANDLE)0x000001c1)
+#define BCRYPT_AES_CCM_ALG_HANDLE           ((BCRYPT_ALG_HANDLE)0x000001d1)
+#define BCRYPT_AES_GCM_ALG_HANDLE           ((BCRYPT_ALG_HANDLE)0x000001e1)
+#define BCRYPT_DES_CBC_ALG_HANDLE           ((BCRYPT_ALG_HANDLE)0x000001f1)
+#define BCRYPT_DES_ECB_ALG_HANDLE           ((BCRYPT_ALG_HANDLE)0x00000201)
+#define BCRYPT_DES_CFB_ALG_HANDLE           ((BCRYPT_ALG_HANDLE)0x00000211)
+#define BCRYPT_DESX_CBC_ALG_HANDLE          ((BCRYPT_ALG_HANDLE)0x00000221)
+#define BCRYPT_DESX_ECB_ALG_HANDLE          ((BCRYPT_ALG_HANDLE)0x00000231)
+#define BCRYPT_DESX_CFB_ALG_HANDLE          ((BCRYPT_ALG_HANDLE)0x00000241)
+#define BCRYPT_RC2_CBC_ALG_HANDLE           ((BCRYPT_ALG_HANDLE)0x00000251)
+#define BCRYPT_RC2_ECB_ALG_HANDLE           ((BCRYPT_ALG_HANDLE)0x00000261)
+#define BCRYPT_RC2_CFB_ALG_HANDLE           ((BCRYPT_ALG_HANDLE)0x00000271)
+#define BCRYPT_DH_ALG_HANDLE                ((BCRYPT_ALG_HANDLE)0x00000281)
+#define BCRYPT_ECDH_ALG_HANDLE              ((BCRYPT_ALG_HANDLE)0x00000291)
+#define BCRYPT_ECDH_P256_ALG_HANDLE         ((BCRYPT_ALG_HANDLE)0x000002a1)
+#define BCRYPT_ECDH_P384_ALG_HANDLE         ((BCRYPT_ALG_HANDLE)0x000002b1)
+#define BCRYPT_ECDH_P521_ALG_HANDLE         ((BCRYPT_ALG_HANDLE)0x000002c1)
+#define BCRYPT_DSA_ALG_HANDLE               ((BCRYPT_ALG_HANDLE)0x000002d1)
+#define BCRYPT_ECDSA_P256_ALG_HANDLE        ((BCRYPT_ALG_HANDLE)0x000002e1)
+#define BCRYPT_ECDSA_P384_ALG_HANDLE        ((BCRYPT_ALG_HANDLE)0x000002f1)
+#define BCRYPT_ECDSA_P521_ALG_HANDLE        ((BCRYPT_ALG_HANDLE)0x00000301)
+#define BCRYPT_RSA_SIGN_ALG_HANDLE          ((BCRYPT_ALG_HANDLE)0x00000311)
+#define BCRYPT_CAPI_KDF_ALG_HANDLE          ((BCRYPT_ALG_HANDLE)0x00000321)
+#define BCRYPT_PBKDF2_ALG_HANDLE            ((BCRYPT_ALG_HANDLE)0x00000331)
+#define BCRYPT_SP800108_CTR_HMAC_ALG_HANDLE ((BCRYPT_ALG_HANDLE)0x00000341)
+#define BCRYPT_SP80056A_CONCAT_ALG_HANDLE   ((BCRYPT_ALG_HANDLE)0x00000351)
+#define BCRYPT_TLS1_1_KDF_ALG_HANDLE        ((BCRYPT_ALG_HANDLE)0x00000361)
+#define BCRYPT_TLS1_2_KDF_ALG_HANDLE        ((BCRYPT_ALG_HANDLE)0x00000371)
+#define BCRYPT_XTS_AES_ALG_HANDLE           ((BCRYPT_ALG_HANDLE)0x00000381)
+#define BCRYPT_HKDF_ALG_HANDLE              ((BCRYPT_ALG_HANDLE)0x00000391)
+
+/* Flags for BCryptGenRandom */
 #define BCRYPT_RNG_USE_ENTROPY_IN_BUFFER 0x00000001
 #define BCRYPT_USE_SYSTEM_PREFERRED_RNG  0x00000002
+
+/* Flags for BCryptOpenAlgorithmProvider */
 #define BCRYPT_ALG_HANDLE_HMAC_FLAG 0x00000008
 
+/* Flags for BCryptEncrypt/BCryptDecrypt */
+#define BCRYPT_BLOCK_PADDING        0x00000001
+
+/* Flags for BCryptCreateHash */
+#define BCRYPT_HASH_REUSABLE_FLAG   0x00000020
+
+#define CRYPT_LOCAL     0x00000001
+#define CRYPT_DOMAIN    0x00000002
+
+typedef struct _CRYPT_CONTEXT_FUNCTIONS
+{
+    ULONG cFunctions;
+    WCHAR **rgpszFunctions;
+} CRYPT_CONTEXT_FUNCTIONS, *PCRYPT_CONTEXT_FUNCTIONS;
+
+NTSTATUS WINAPI BCryptAddContextFunction(ULONG, LPCWSTR, ULONG, LPCWSTR, ULONG);
 NTSTATUS WINAPI BCryptCloseAlgorithmProvider(BCRYPT_ALG_HANDLE, ULONG);
 NTSTATUS WINAPI BCryptCreateHash(BCRYPT_ALG_HANDLE, BCRYPT_HASH_HANDLE *, PUCHAR, ULONG, PUCHAR, ULONG, ULONG);
 NTSTATUS WINAPI BCryptDecrypt(BCRYPT_KEY_HANDLE, PUCHAR, ULONG, VOID *, PUCHAR, ULONG, PUCHAR, ULONG, ULONG *, ULONG);
+NTSTATUS WINAPI BCryptDeriveKey(BCRYPT_SECRET_HANDLE, LPCWSTR, BCryptBufferDesc*, PUCHAR, ULONG, ULONG *, ULONG);
+NTSTATUS WINAPI BCryptDeriveKeyCapi(BCRYPT_HASH_HANDLE, BCRYPT_ALG_HANDLE, PUCHAR, ULONG, ULONG);
+NTSTATUS WINAPI BCryptDeriveKeyPBKDF2(BCRYPT_ALG_HANDLE, PUCHAR, ULONG, PUCHAR, ULONG, ULONGLONG, PUCHAR, ULONG, ULONG);
 NTSTATUS WINAPI BCryptDestroyHash(BCRYPT_HASH_HANDLE);
 NTSTATUS WINAPI BCryptDestroyKey(BCRYPT_KEY_HANDLE);
+NTSTATUS WINAPI BCryptDestroySecret(BCRYPT_SECRET_HANDLE);
+NTSTATUS WINAPI BCryptDuplicateHash(BCRYPT_HASH_HANDLE, BCRYPT_HASH_HANDLE *, UCHAR *, ULONG, ULONG);
+NTSTATUS WINAPI BCryptDuplicateKey(BCRYPT_KEY_HANDLE, BCRYPT_KEY_HANDLE *, PUCHAR, ULONG, ULONG);
 NTSTATUS WINAPI BCryptEncrypt(BCRYPT_KEY_HANDLE, PUCHAR, ULONG, VOID *, PUCHAR, ULONG, PUCHAR, ULONG, ULONG *, ULONG);
 NTSTATUS WINAPI BCryptEnumAlgorithms(ULONG, ULONG *, BCRYPT_ALGORITHM_IDENTIFIER **, ULONG);
+NTSTATUS WINAPI BCryptEnumContextFunctions(ULONG, const WCHAR *, ULONG, ULONG *, CRYPT_CONTEXT_FUNCTIONS **);
+NTSTATUS WINAPI BCryptExportKey(BCRYPT_KEY_HANDLE, BCRYPT_KEY_HANDLE, LPCWSTR, PUCHAR, ULONG, ULONG *, ULONG);
+NTSTATUS WINAPI BCryptFinalizeKeyPair(BCRYPT_KEY_HANDLE, ULONG);
 NTSTATUS WINAPI BCryptFinishHash(BCRYPT_HASH_HANDLE, PUCHAR, ULONG, ULONG);
-NTSTATUS WINAPI BCryptGenerateSymmetricKey(BCRYPT_ALG_HANDLE, BCRYPT_KEY_HANDLE *, PUCHAR, ULONG, PUCHAR, ULONG, ULONG);
+void     WINAPI BCryptFreeBuffer(void *);
 NTSTATUS WINAPI BCryptGenRandom(BCRYPT_ALG_HANDLE, PUCHAR, ULONG, ULONG);
+NTSTATUS WINAPI BCryptGenerateKeyPair(BCRYPT_ALG_HANDLE, BCRYPT_KEY_HANDLE *, ULONG, ULONG);
+NTSTATUS WINAPI BCryptGenerateSymmetricKey(BCRYPT_ALG_HANDLE, BCRYPT_KEY_HANDLE *, PUCHAR, ULONG, PUCHAR, ULONG, ULONG);
 NTSTATUS WINAPI BCryptGetFipsAlgorithmMode(BOOLEAN *);
 NTSTATUS WINAPI BCryptGetProperty(BCRYPT_HANDLE, LPCWSTR, PUCHAR, ULONG, ULONG *, ULONG);
 NTSTATUS WINAPI BCryptHash(BCRYPT_ALG_HANDLE, PUCHAR, ULONG, PUCHAR, ULONG, PUCHAR, ULONG);
 NTSTATUS WINAPI BCryptHashData(BCRYPT_HASH_HANDLE, PUCHAR, ULONG, ULONG);
+NTSTATUS WINAPI BCryptImportKey(BCRYPT_ALG_HANDLE, BCRYPT_KEY_HANDLE, LPCWSTR, BCRYPT_KEY_HANDLE *, PUCHAR, ULONG, PUCHAR, ULONG, ULONG);
 NTSTATUS WINAPI BCryptImportKeyPair(BCRYPT_ALG_HANDLE, BCRYPT_KEY_HANDLE, LPCWSTR, BCRYPT_KEY_HANDLE *, UCHAR *, ULONG, ULONG);
 NTSTATUS WINAPI BCryptOpenAlgorithmProvider(BCRYPT_ALG_HANDLE *, LPCWSTR, LPCWSTR, ULONG);
+NTSTATUS WINAPI BCryptRemoveContextFunction(ULONG, LPCWSTR, ULONG, LPCWSTR);
+NTSTATUS WINAPI BCryptSecretAgreement(BCRYPT_KEY_HANDLE, BCRYPT_KEY_HANDLE, BCRYPT_SECRET_HANDLE *, ULONG);
 NTSTATUS WINAPI BCryptSetProperty(BCRYPT_HANDLE, LPCWSTR, PUCHAR, ULONG, ULONG);
-NTSTATUS WINAPI BCryptDuplicateHash(BCRYPT_HASH_HANDLE, BCRYPT_HASH_HANDLE *, UCHAR *, ULONG, ULONG);
+NTSTATUS WINAPI BCryptSignHash(BCRYPT_KEY_HANDLE, void *, PUCHAR, ULONG, PUCHAR, ULONG, ULONG *, ULONG);
 NTSTATUS WINAPI BCryptVerifySignature(BCRYPT_KEY_HANDLE, void *, UCHAR *, ULONG, UCHAR *, ULONG, ULONG);
 
 #endif  /* __WINE_BCRYPT_H */

--- a/sdk/include/psdk/wincrypt.h
+++ b/sdk/include/psdk/wincrypt.h
@@ -5802,6 +5802,16 @@ CryptImportPublicKeyInfoEx(
   _In_opt_ void *pvAuxInfo,
   _Out_ HCRYPTKEY *phKey);
 
+WINCRYPT32API
+BOOL
+WINAPI
+CryptImportPublicKeyInfoEx2(
+  _In_ DWORD dwCertEncodingType,
+  _In_ PCERT_PUBLIC_KEY_INFO pInfo,
+  _In_ DWORD dwFlags,
+  _In_opt_ void *pvAuxInfo,
+  _Out_ BCRYPT_KEY_HANDLE *phKey);
+
 BOOL
 WINAPI
 CryptAcquireCertificatePrivateKey(


### PR DESCRIPTION
## Purpose

Sync crypt32 to wine-10.0

Jira issue: https://jira.reactos.org/browse/CORE-20591

## Proposed changes
* [KERNEL32] Fix WriteFile optional parameter handling
* [PSDK] Sync bcrypt.h to Wine-10.0
* [PSDK] wincrypt.h: Add missing CryptImportPublicKeyInfoEx2
* [CRYPT32] Sync to wine 10.0
  * Move Reactos specific code from store.c to reactos/store.c
  * Implement "unixlib" emulation layer with a full implementation for `enum_root_certs` and stubs for other cases

## Scope of this PR
* Sync the code to wine-10..0
* Fix tons if bugs in the process
* Avoid regressions as much as reasonably possible

## Not scope of this PR
* Fix Jira ticket CORE-12345
* Implement feature xyz
* "Ackshually... according to ..." - Tests or didn't happen!
* "But this is what Windows does" - You are welcome to write a test and fix the issue.

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=108599,108601,108604
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=108600,108602,108606