### PR TITLE
[USBSTOR] Make USBSTOR_SyncUrbRequest more robust

### DIFF
--- a/drivers/usb/usbstor/usbstor.h
+++ b/drivers/usb/usbstor/usbstor.h
@@ -235,7 +235,7 @@ FreeItem(
 NTSTATUS
 USBSTOR_SyncUrbRequest(
     IN PDEVICE_OBJECT DeviceObject,
-    OUT PURB UrbRequest);
+    IN PURB Urb);
 
 NTSTATUS
 USBSTOR_GetMaxLUN(

--- a/drivers/usb/usbstor_new/usbstor.h
+++ b/drivers/usb/usbstor_new/usbstor.h
@@ -392,7 +392,7 @@ FreeItem(
 NTSTATUS
 USBSTOR_SyncUrbRequest(
     IN PDEVICE_OBJECT DeviceObject,
-    OUT PURB UrbRequest);
+    IN PURB Urb);
 
 NTSTATUS
 USBSTOR_GetMaxLUN(


### PR DESCRIPTION
This change improves the synchronous URB submission path by using a synchronization event, adding a timeout to avoid indefinite waits, and properly canceling stalled IRPs.

Based on a fix observed in vgalnt/reactos and reviewed for upstream use.

## Purpose

While developing an internal tool to help identify potentially valuable fixes in downstream forks, we noticed this commit in `vgalnt/reactos` related to `USBSTOR_SyncUrbRequest()`.

After manual review, the change appears to address real robustness issues in the synchronous URB submission path and aligns with expected WDM driver behavior. This pull request proposes bringing the fix upstream in case it is useful for the project.

No automated changes were submitted; the code was reviewed and validated manually before proposing it here.

JIRA issue: _N/A_

## Proposed changes

- Use a synchronization event instead of a notification event when waiting for IRP completion.
- Add a bounded wait with timeout to prevent indefinite blocking if an IRP never completes.
- Properly cancel and wait for completion of stalled IRPs on timeout.
- Clean up URB argument usage and improve error-handling paths.

## TODO

- [ ] Additional testing on real hardware (if available)
- [ ] Feedback from maintainers on approach and integration

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64:
