### PR TITLE
[WIN32K:ENG] Relax surface parameter validation

### DIFF
--- a/win32ss/gdi/eng/surface.c
+++ b/win32ss/gdi/eng/surface.c
@@ -157,17 +157,17 @@ SURFACE_AllocSurface(
     /* Is this an uncompressed format? */
     if (iFormat <= BMF_32BPP)
     {
-        /* Calculate the correct bitmap size in bytes */
-        if (!NT_SUCCESS(RtlULongMult(cjWidth, cy, &cjBits)))
-        {
-            DPRINT1("Overflow calculating size: cjWidth %lu, cy %lu\n",
-                    cjWidth, cy);
-            return NULL;
-        }
-
         /* Did we get a buffer and size? */
         if ((pvBits != NULL) && (cjBufSize != 0))
         {
+            /* Calculate and validate the bitmap size in bytes */
+            if (!NT_SUCCESS(RtlULongMult(cjWidth, cy, &cjBits)))
+            {
+                DPRINT1("Overflow calculating size: cjWidth %lu, cy %lu\n",
+                        cjWidth, cy);
+                return NULL;
+            }
+
             /* Make sure the buffer is large enough */
             if (cjBufSize < cjBits)
             {
@@ -175,6 +175,13 @@ SURFACE_AllocSurface(
                         cjBits, cjBufSize);
                 return NULL;
             }
+        }
+        else
+        {
+            /* Do a dumb calculation. Windows doesn't validate this either and
+               some drivers (e.g. Radeon IGP 320M) explicitly pass bogus values.
+               See CORE-13036. */
+            cjBits = cjWidth * cy;
         }
     }
     else


### PR DESCRIPTION
## Purpose

Relax surface parameter validation

If no bitmap buffer size is provided (e.g. allocation path from EngCreateBitmap), do not validate that the size calculation is valid. Should fix some display drivers, like Radeon IGP 320M.

JIRA issues: [CORE-13036](https://jira.reactos.org/browse/CORE-13036),  [CORE-11676](https://jira.reactos.org/browse/CORE-11676) [CORE-19951](https://jira.reactos.org/browse/CORE-19951)

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=108758,108760,108750
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=108761,108763,108757
