### PR TITLE
[NTOS:KD64] Prepend timestamps to KD debug output

### DIFF
--- a/ntoskrnl/kd64/kdprint.c
+++ b/ntoskrnl/kd64/kdprint.c
@@ -14,8 +14,45 @@
 #include <debug.h>
 
 #define KD_PRINT_MAX_BYTES 512
+#define KD_TIMESTAMP_MAX_CHARS 32
+#define KD_100NS_PER_SECOND 10000000ULL
+#define KD_100NS_PER_MICROSECOND 10ULL
 
 /* FUNCTIONS *****************************************************************/
+
+static
+USHORT
+NTAPI
+KdpBuildTimestampPrefix(
+    _Out_writes_bytes_(BufferSize) PCHAR Buffer,
+    _In_ SIZE_T BufferSize)
+{
+    ULONGLONG InterruptTime;
+    ULONGLONG Seconds;
+    ULONGLONG Microseconds;
+    LONG Length;
+
+    if (BufferSize == 0)
+        return 0;
+
+    InterruptTime = KeQueryInterruptTime();
+    Seconds = InterruptTime / KD_100NS_PER_SECOND;
+    Microseconds = (InterruptTime % KD_100NS_PER_SECOND) /
+                   KD_100NS_PER_MICROSECOND;
+
+    Length = _snprintf(Buffer,
+                       BufferSize,
+                       "[%5I64u.%06I64u] ",
+                       Seconds,
+                       Microseconds);
+    if (Length < 0)
+    {
+        /* Keep logging functional even if formatting fails. */
+        return 0;
+    }
+
+    return (USHORT)min((SIZE_T)Length, BufferSize - 1);
+}
 
 KIRQL
 NTAPI
@@ -455,6 +492,9 @@ KdpPrint(
     NTSTATUS Status;
     BOOLEAN Enable;
     STRING OutputString;
+    CHAR TimestampPrefix[KD_TIMESTAMP_MAX_CHARS];
+    CHAR OutputBuffer[KD_PRINT_MAX_BYTES];
+    USHORT PrefixLength, OutputLength;
 
     if (NtQueryDebugFilterState(ComponentId, Level) == (NTSTATUS)FALSE)
     {
@@ -488,8 +528,29 @@ KdpPrint(
     }
 
     /* Setup the output string */
-    OutputString.Buffer = String;
-    OutputString.Length = OutputString.MaximumLength = Length;
+    PrefixLength = KdpBuildTimestampPrefix(TimestampPrefix,
+                                           sizeof(TimestampPrefix));
+    PrefixLength = (USHORT)min((SIZE_T)PrefixLength, sizeof(OutputBuffer));
+
+    /* Keep the complete entry in the fixed-size KD print buffer. */
+    OutputLength = Length;
+    if ((PrefixLength + OutputLength) > sizeof(OutputBuffer))
+    {
+        OutputLength = sizeof(OutputBuffer) - PrefixLength;
+    }
+
+    if (PrefixLength != 0)
+    {
+        KdpMoveMemory(OutputBuffer, TimestampPrefix, PrefixLength);
+    }
+
+    if (OutputLength != 0)
+    {
+        KdpMoveMemory(OutputBuffer + PrefixLength, String, OutputLength);
+    }
+
+    OutputString.Buffer = OutputBuffer;
+    OutputString.Length = OutputString.MaximumLength = PrefixLength + OutputLength;
 
     /* Log the print */
     KdLogDbgPrint(&OutputString);
@@ -531,16 +592,38 @@ KdpDprintf(
 {
     STRING String;
     USHORT Length;
+    USHORT PrefixLength;
+    INT FormatLength;
     va_list ap;
     CHAR Buffer[512];
+    CHAR TimestampPrefix[KD_TIMESTAMP_MAX_CHARS];
 
-    /* Format the string */
+    PrefixLength = KdpBuildTimestampPrefix(TimestampPrefix,
+                                           sizeof(TimestampPrefix));
+    PrefixLength = (USHORT)min((SIZE_T)PrefixLength, sizeof(Buffer));
+
+    if (PrefixLength != 0)
+    {
+        KdpMoveMemory(Buffer, TimestampPrefix, PrefixLength);
+    }
+
+    /* Format the string after the timestamp prefix */
     va_start(ap, Format);
-    Length = (USHORT)_vsnprintf(Buffer,
-                                sizeof(Buffer),
-                                Format,
-                                ap);
+    FormatLength = _vsnprintf(Buffer + PrefixLength,
+                              sizeof(Buffer) - PrefixLength,
+                              Format,
+                              ap);
     va_end(ap);
+
+    if (FormatLength < 0)
+    {
+        /* _vsnprintf reports truncation with -1. */
+        Length = sizeof(Buffer) - 1;
+    }
+    else
+    {
+        Length = PrefixLength + (USHORT)FormatLength;
+    }
 
     /* Set it up */
     String.Buffer = Buffer;


### PR DESCRIPTION
This change adds Linux-style timestamp prefixes to kernel debug logs so boot/runtime messages are easier to correlate.

- Adds a shared timestamp prefix builder in ntoskrnl/kd64/kdprint.c based on KeQueryInterruptTime() (IRQL-safe,
  monotonic).
- Prepends [%5I64u.%06I64u]  to the regular KD print path (KdpPrint), which covers DbgPrint/DPRINT/DPRINT1.
- Prepends the same prefix to the early/banner path (KdpDprintf), which covers kdinit.c startup banner lines.
- Keeps existing fixed-size KD buffers and truncation behavior safe.

Why? :
Current logs have no timing context, making ordering/latency analysis hard during early boot and device bring-up.


result : 
```
[    0.000000] (/ntoskrnl/kd64/kdinit.c:94) -----------------------------------------------------
[    0.000000] (/ntoskrnl/kd64/kdinit.c:95) ReactOS 0.4.16-amd64-dev (Build 20260228-bcbf75e) (Commit bcbf75e31876c59bb09d17a12f86ae8400f1780a)
[    0.000000] (/ntoskrnl/kd64/kdinit.c:96) 1 System Processor [6144 MB Memory]
[    0.000000] (/ntoskrnl/kd64/kdinit.c:100) Command Line: DEBUG DEBUGPORT=COM1 BAUDRATE=115200 SOS FASTDETECT MININT
[    0.000000] (/ntoskrnl/kd64/kdinit.c:101) ARC Paths: multi(0)disk(0)rdisk(0)partition(1) \ multi(0)disk(0)rdisk(0)partition(1) \reactos\
[    0.000000] (/ntoskrnl/ke/amd64/kiinit.c:547) Pcr = FFFFF80000666300, Gdt = FFFFF8000009C000, Idt = FFFFF800006592C0, Tss = FFFFF8000009B000
[    0.000000] (/ntoskrnl/ke/amd64/cpu.c:366) Supported CPU features:[    0.000000]  KF_SMEP[    0.000000]  KF_RDTSC[    0.000000]  KF_CR4[    0.000000]  KF_CMOV[    0.000000]  KF_GLOBAL_PAGE[    0.000000]  KF_LARGE_PAGE[    0.000000]  KF_MTRR[    0.000000]  KF_CMPXCHG8B[    0.000000]  KF_MMX[    0.000000]  KF_PAT[    0.000000]  KF_FXSR[    0.000000]  KF_FAST_SYSCALL[    0.000000]  KF_XMMI[    0.000000]  KF_XSAVEOPT[    0.000000]  KF_XMMI64[    0.000000]  KF_SSE3[    0.000000]  KF_CMPXCHG16B[    0.000000]  KF_XSTATE[    0.000000]  KF_GENUINE_INTEL[    0.000000]  KF_SLAT[    0.000000]  KF_RDWRFSGSBASE[    0.000000]  KF_NX_BIT[    0.000000]  KF_NX_ENABLED[    0.000000]  KF_RDRAND[    0.000000]  KF_SMAP[    0.000000]  KF_RDTSCP[    0.000000]  KF_HUGEPAGE[    0.000000]  KF_XSAVES[    0.000000]  KF_SSSE3[    0.000000]  KF_SSE4_1[    0.000000]  KF_SSE4_2[    0.000000]  KF_AVX[    0.000000]  KF_AVX2[    0.000000]  X86_FEATURE_PAE[    0.000000] 
[    0.000000] (/hal/halx86/acpi/halacpi.c:782) ACPI Timer at: 608h (EXT: 0)
[    0.000000] (/hal/halx86/acpi/halacpi.c:928) ACPI v[    0.000000] 1.5-2.0_C[    0.000000]  detected. Tables:[    0.000000]  [RSDT][    0.000000]  [APIC][    0.000000]  [FACP][    0.000000] 
[    0.000000] (/hal/halx86/apic/rtctimer.c:138) Clock initialized
[    0.000000] (/hal/halx86/apic/halinit.c:48) Using HAL: APIC UP DBG
[    0.000000] (/hal/halx86/acpi/madt.c:250) Physical processor count: 1
[    0.000000] (/hal/halx86/acpi/madt.c:253)  Processor 0: ProcessorId 0, LapicId 0, ProcessorStarted 0, BSPCheck 0, ProcessorPrcb 0000000000000000
[    0.062500] (/ntoskrnl/mm/ARM3/mminit.c:1443) HAL I/O Mapping at FFFFFFFFFFFE0000 is unsafe
[    0.062500] (/ntoskrnl/mm/ARM3/mminit.c:1443) HAL I/O Mapping at FFFFFFFFFFFE1000 is unsafe
[    0.062500] (/ntoskrnl/mm/ARM3/largepag.c:37) MiInitializeLargePageSupport: PAE/x64 Not Implemented
[    0.078125] (/hal/halx86/generic/x86bios.c:141) *x86BiosMemoryMapping: F000FF53F000FF53, F000FF53F000E2C3
[    0.078125] (/hal/halx86/generic/x86bios.c:377) Invalid IO port write access (port: 0x1ce, count: 0x2)
[    0.078125] (/hal/halx86/generic/x86bios.c:377) Invalid IO port write access (port: 0x1cf, count: 0x2)
[    0.078125] (/hal/halx86/generic/x86bios.c:353) Invalid IO port read access (port: 0x3c0, count: 0x1)
[    0.078125] (/hal/halx86/generic/x86bios.c:353) Invalid IO port read access (port: 0x3c0, count: 0x1)
[    0.078125] (/hal/halx86/generic/x86bios.c:353) Invalid IO port read access (port: 0x3c0, count: 0x1)
[    0.078125] (/hal/halx86/generic/x86bios.c:353) Invalid IO port read access (port: 0x3c0, count: 0x1)
[    0.078125] (/hal/halx86/generic/x86bios.c:353) Invalid IO port read access (port: 0x3c0, count: 0x1)
[    0.078125] (/hal/halx86/generic/x86bios.c:353) Invalid IO port read access (port: 0x3c0, count: 0x1)
[    0.078125] (/hal/halx86/generic/x86bios.c:353) Invalid IO port read access (port: 0x3c0, count: 0x1)
[    0.078125] (/hal/halx86/generic/x86bios.c:353) Invalid IO port read access (port: 0x3c0, count: 0x1)
[    0.078125] (/hal/halx86/generic/x86bios.c:353) Invalid IO port read access (port: 0x3c0, count: 0x1)
[    0.078125] (/hal/halx86/generic/x86bios.c:353) Invalid IO port read access (port: 0x3c0, count: 0x1)
[    0.078125] (/hal/halx86/generic/x86bios.c:353) Invalid IO port read access (port: 0x3c0, count: 0x1)
[    0.078125] (/hal/halx86/generic/x86bios.c:353) Invalid IO port read access (port: 0x3c0, count: 0x1)
[    0.078125] (/hal/halx86/generic/x86bios.c:353) Invalid IO port read access (port: 0x3c0, count: 0x1)
[    0.078125] (/hal/halx86/generic/x86bios.c:353) Invalid IO port read access (port: 0x3c0, count: 0x1)
[    0.078125] (/hal/halx86/generic/x86bios.c:353) Invalid IO port read access (port: 0x3c0, count: 0x1)
[    0.078125] (/hal/halx86/generic/x86bios.c:353) Invalid IO port read access (port: 0x3c0, count: 0x1)
[    0.078125] (/hal/halx86/generic/x86bios.c:353) Invalid IO port read access (port: 0x3c0, count: 0x1)
[    0.078125] (/hal/halx86/generic/x86bios.c:353) Invalid IO port read access (port: 0x3c0, count: 0x1)
[    0.078125] (/hal/halx86/generic/x86bios.c:353) Invalid IO port read access (port: 0x3c0, count: 0x1)
[    0.078125] (/hal/halx86/generic/x86bios.c:353) Invalid IO port read access (port: 0x3c0, count: 0x1)
[    0.078125] (/hal/halx86/generic/x86bios.c:353) Invalid IO port read access (port: 0x3c0, count: 0x1)
[    0.281250] (/ntoskrnl/mm/mminit.c:135)           0xFFFFF80000000000 - 0xFFFFF80003000000	Boot Loaded Image
[    0.281250] (/ntoskrnl/mm/mminit.c:139)           0xFFFFFA8000000000 - 0xFFFFFA8009001000	PFN Database
[    0.281250] (/ntoskrnl/mm/mminit.c:143)           0xFFFFFA8288048000 - 0xFFFFFA8294060000	ARM3 Non Paged Pool
[    0.296875] (/ntoskrnl/mm/mminit.c:147)           0xFFFFF97FBA000000 - 0xFFFFF97FDA000000	System View Space
[    0.296875] (/ntoskrnl/mm/mminit.c:151)           0xFFFFF97FDA000000 - 0xFFFFF98000000000	Session Space
[    0.296875] (/ntoskrnl/mm/mminit.c:155)           0xFFFFF68000000000 - 0xFFFFF6FFFFFFFFFF	Page Tables
[    0.296875] (/ntoskrnl/mm/mminit.c:158)           0xFFFFF6FB40000000 - 0xFFFFF6FB7FFFFFFF	Page Directories
[    0.296875] (/ntoskrnl/mm/mminit.c:161)           0xFFFFF70000000000 - 0xFFFFF77FFFFFFFFF	Hyperspace
[    0.296875] (/ntoskrnl/mm/mminit.c:164)           0xFFFFF98000000000 - 0xFFFFFA7FFFFFFFFF	System Cache
[    0.296875] (/ntoskrnl/mm/mminit.c:167)           0xFFFFF8A000000000 - 0xFFFFF8A002000000	ARM3 Paged Pool
[    0.296875] (/ntoskrnl/mm/mminit.c:171)           0xFFFFF88000000000 - 0xFFFFFA8294060000	System PTE Space
[    0.296875] (/ntoskrnl/mm/mminit.c:174)           0xFFFFFA8294060000 - 0xFFFFFA831DF54000	Non Paged Pool Expansion PTE Space
[    0.296875] (/ntoskrnl/ex/time.c:55) RtlQueryTimeZoneInformation failed (Status 0xc0000034)
[    0.296875] (/ntoskrnl/ex/time.c:331) ExpGetTimeZoneId failed
[    0.296875] ACPI Compatible Eisa/Isa HAL Detected
[    0.312500] WARNING:  ArbBuildAssignmentOrdering at /sdk/lib/drivers/arbiter/arbiter.c:275 is UNIMPLEMENTED!
[    0.312500] WARNING:  ArbBuildAssignmentOrdering at /sdk/lib/drivers/arbiter/arbiter.c:275 is UNIMPLEMENTED!
[    0.312500] WARNING:  ArbBuildAssignmentOrdering at /sdk/lib/drivers/arbiter/arbiter.c:275 is UNIMPLEMENTED!
[    0.328125] WARNING:  ArbBuildAssignmentOrdering at /sdk/lib/drivers/arbiter/arbiter.c:275 is UNIMPLEMENTED!
[    0.328125] WARNING:  ArbBuildAssignmentOrdering at /sdk/lib/drivers/arbiter/arbiter.c:275 is UNIMPLEMENTED!
[    0.328125] (/ntoskrnl/ex/work.c:759) Requesting a new thread. CurrentCount: 0. MaxCount: 1
[    0.328125] (/ntoskrnl/io/iomgr/driver.c:655) '\Driver\sacdrv' initialization failed, status (0xc0000037)
[    0.328125] (/ntoskrnl/io/iomgr/driver.c:83) Deleting driver object '\Driver\sacdrv'
[    0.343750] (/ntoskrnl/mm/ARM3/sysldr.c:989) Leaking driver: sacdrv.sys
[    0.343750] (/ntoskrnl/io/iomgr/driver.c:920) Driver 'sacdrv.sys' load failed, status (c0000365)
[    0.468750] (/ntoskrnl/io/pnpmgr/pnpres.c:646) Resource conflict: IRQ (0x9 0x9 vs. 0x9 0x9)
[    0.468750] (/ntoskrnl/io/pnpmgr/pnpres.c:646) Resource conflict: IRQ (0x9 0x9 vs. 0x9 0x9)
[    0.468750] (/drivers/bus/acpi/buspdo.c:846) Failed to find a bus number
[    0.609375] (/hal/halx86/legacy/bus/pcibus.c:816) WARNING: PCI Slot Resource Assignment is FOOBAR
[    5.078125] (/drivers/storage/port/scsiport/fdo.c:327) Found device of type 0 at controller 0 bus 0 tid 0 lun 0, PDO: FFFFFA8293F5E8C0
```

note that KeQueryInterruptTime() can still have small hardware/VM drift during fast logging as shown in traces.