### PR TITLE
[RAMDISK] Add writable FAT ramdisk boot support for LiveCD/UEFI

### DIFF
--- a/boot/bootdata/livecd.ini
+++ b/boot/bootdata/livecd.ini
@@ -9,6 +9,7 @@ MinimalUI=Yes
 [Operating Systems]
 LiveCD="LiveCD"
 LiveCD_Debug="LiveCD (Debug)"
+LiveCD_RamFs_Debug="LiveCD RamFS (Debug)"
 LiveCD_Macpi="LiveCD ACPI SMP (Debug)"
 LiveCD_Aacpi="LiveCD ACPI APIC (Debug)"
 LiveCD_VBoxDebug="LiveCD (VBox Debug)"
@@ -24,6 +25,11 @@ Options=/FASTDETECT /MININT
 BootType=Windows2003
 SystemPath=\reactos
 Options=/DEBUG /DEBUGPORT=COM1 /BAUDRATE=115200 /SOS /FASTDETECT /MININT
+
+[LiveCD_RamFs_Debug]
+BootType=Windows2003
+SystemPath=ramdisk(0)\reactos
+Options=/DEBUG /DEBUGPORT=COM1 /BAUDRATE=115200 /SOS /FASTDETECT /MININT /RDRAMSIZE=100M
 
 [LiveCD_Macpi]
 BootType=Windows2003

--- a/boot/freeldr/freeldr/CMakeLists.txt
+++ b/boot/freeldr/freeldr/CMakeLists.txt
@@ -49,6 +49,8 @@ list(APPEND FREELDR_BOOTLIB_SOURCE
     lib/fs/fs.c
     lib/fs/iso.c
     lib/fs/ntfs.c
+    lib/ramdisk_format.c
+    lib/ramdisk_fatwrite.c
     lib/inifile/ini_init.c
     lib/inifile/inifile.c
     lib/inifile/parse.c

--- a/boot/freeldr/freeldr/disk/ramdisk.c
+++ b/boot/freeldr/freeldr/disk/ramdisk.c
@@ -10,10 +10,99 @@
 /* INCLUDES *******************************************************************/
 
 #include <freeldr.h>
+#include <debug.h>
+#include <ctype.h>
+#include <limits.h>
+#include <stddef.h>
+#include <string.h>
+#include <ntstrsafe.h>
+#include <fs/iso.h>
+#include <fs/fat.h>
+#include <disk.h>
+#include <arch/archwsup.h>
+
+#if defined(__GNUC__)
+extern VOID
+AddReactOSArcDiskInfo(
+    IN PSTR ArcName,
+    IN ULONG Signature,
+    IN ULONG Checksum,
+    IN BOOLEAN ValidPartitionTable) __attribute__((weak));
+#elif defined(_MSC_VER)
+VOID
+AddReactOSArcDiskInfoStub(
+    IN PSTR ArcName,
+    IN ULONG Signature,
+    IN ULONG Checksum,
+    IN BOOLEAN ValidPartitionTable)
+{
+    UNREFERENCED_PARAMETER(ArcName);
+    UNREFERENCED_PARAMETER(Signature);
+    UNREFERENCED_PARAMETER(Checksum);
+    UNREFERENCED_PARAMETER(ValidPartitionTable);
+}
+
+#if defined(_M_IX86)
+#pragma comment(linker, "/alternatename:_AddReactOSArcDiskInfo=_AddReactOSArcDiskInfoStub")
+#else
+#pragma comment(linker, "/alternatename:AddReactOSArcDiskInfo=AddReactOSArcDiskInfoStub")
+#endif
+#endif
+
+#if defined(__GNUC__)
+VOID FatFlushCache(VOID) __attribute__((weak));
+#else
+VOID FatFlushCache(VOID);
+#if defined(_MSC_VER)
+VOID FatFlushCacheStub(VOID)
+{
+    /* Optional legacy FAT cache flush is unavailable; nothing to do. */
+}
+#if defined(_M_IX86)
+#pragma comment(linker, "/alternatename:_FatFlushCache=_FatFlushCacheStub")
+#else
+#pragma comment(linker, "/alternatename:FatFlushCache=FatFlushCacheStub")
+#endif
+#endif
+#endif
+#include <ramdisk_fatwrite.h>
+#include <ramdisk_signature.h>
 #include "../ntldr/ntldropts.h"
 
-#include <debug.h>
 DBG_DEFAULT_CHANNEL(DISK);
+
+#if DBG
+static
+VOID
+RamDiskTraceSample(IN PCSTR Label,
+                   IN const VOID *Address)
+{
+    const UCHAR *Bytes;
+
+    if (!Label || !Address)
+    {
+        return;
+    }
+
+    Bytes = (const UCHAR *)Address;
+    TRACE("%s [%p]: %02X %02X %02X %02X %02X %02X %02X %02X\n",
+          Label,
+          Address,
+          Bytes[0], Bytes[1], Bytes[2], Bytes[3],
+          Bytes[4], Bytes[5], Bytes[6], Bytes[7]);
+}
+
+static
+PFN_NUMBER
+RamDiskPointerToPfn(IN const VOID *Address)
+{
+    return Address ? (PFN_NUMBER)(((ULONG_PTR)Address) >> MM_PAGE_SHIFT) : 0;
+}
+#endif
+
+#define RAMDISK_ALLOCATION_ALIGNMENT 0x1000ULL
+#define ALIGN_UP_BY_ULL(Value, Alignment) \
+    (((Value) + ((Alignment) - 1ULL)) & ~((Alignment) - 1ULL))
 
 /* GLOBALS ********************************************************************/
 
@@ -23,11 +112,1733 @@ ULONG gInitRamDiskSize = 0;
 static BOOLEAN   RamDiskDeviceRegistered = FALSE;
 static PVOID     RamDiskBase;
 static ULONGLONG RamDiskFileSize;    // FIXME: RAM disks currently limited to 4GB.
-static ULONGLONG RamDiskImageLength; // Size of valid data in the Ramdisk (usually == RamDiskFileSize - RamDiskImageOffset)
+static ULONGLONG RamDiskImageLength; // Total bytes populated in the backing store from the start of the allocation
 static ULONG     RamDiskImageOffset; // Starting offset from the Ramdisk base.
+static ULONGLONG RamDiskVolumeOffset; // Offset where the FAT volume starts (typically after the MBR)
+static ULONGLONG RamDiskVolumeLength; // Length of the exposed FAT volume
 static ULONGLONG RamDiskOffset;      // Current position in the Ramdisk.
+static ULONGLONG RamDiskRequestedSize = 0;
+static PVOID     RamDiskWritableBase = NULL;
+static ULONGLONG RamDiskWritableSize = 0;
+static BOOLEAN   RamDiskErrorShown = FALSE;
+
+#if defined(_M_AMD64) || defined(__x86_64__)
+#ifndef MM_MAX_PAGE_LOADER_MAPPED
+#define MM_MAX_PAGE_LOADER_MAPPED MM_MAX_PAGE_LOADER
+#endif
+#define RAMDISK_MAX_LOW_BYTES     ((ULONGLONG)MM_MAX_PAGE_LOADER_MAPPED << MM_PAGE_SHIFT)
+#else
+#define RAMDISK_MAX_LOW_BYTES     (0x40000000ULL) /* 1 GiB on 32-bit */
+#endif
+
+#define RAMDISK_LOW_ALLOC_MAX        RAMDISK_MAX_LOW_BYTES
+#define RAMDISK_MINIMUM_EXTRA_SPACE  (64ULL * 1024ULL * 1024ULL)
+#define RAMDISK_SAFETY_SLACK         RAMDISK_MINIMUM_EXTRA_SPACE
+
+static
+BOOLEAN
+RamDiskComputeMbrMetadata(IN PVOID BaseAddress,
+                          IN ULONGLONG DiskSize,
+                          OUT PULONG Signature,
+                          OUT PULONG Checksum,
+                          OUT PBOOLEAN ValidPartition)
+{
+    PMASTER_BOOT_RECORD MasterBootRecord;
+    ULONG Sum = 0;
+    ULONG WordCount;
+    PULONG Words;
+    ULONG Index;
+
+    if (!BaseAddress || DiskSize < sizeof(MASTER_BOOT_RECORD))
+        return FALSE;
+
+    MasterBootRecord = (PMASTER_BOOT_RECORD)BaseAddress;
+    if (MasterBootRecord->MasterBootRecordMagic != 0xAA55)
+        return FALSE;
+
+    WordCount = (ULONG)(sizeof(MASTER_BOOT_RECORD) / sizeof(ULONG));
+    Words = (PULONG)MasterBootRecord;
+    for (Index = 0; Index < WordCount; ++Index)
+    {
+        Sum += Words[Index];
+    }
+
+    if (MasterBootRecord->Signature == 0 || MasterBootRecord->Signature == 0xFFFFFFFFu)
+    {
+        MasterBootRecord->Signature = RamDiskDeriveDiskSignature(BaseAddress, DiskSize);
+
+        /* Recalculate the checksum after updating the signature. */
+        Sum = 0;
+        for (Index = 0; Index < WordCount; ++Index)
+        {
+            Sum += Words[Index];
+        }
+    }
+
+    if (Signature)
+        *Signature = MasterBootRecord->Signature;
+
+    if (Checksum)
+        *Checksum = (~Sum) + 1;
+
+    if (ValidPartition)
+    {
+        BOOLEAN Found = FALSE;
+        ULONG EntryIndex;
+        const PARTITION_TABLE_ENTRY *Entry;
+
+        for (EntryIndex = 0; EntryIndex < RTL_NUMBER_OF(MasterBootRecord->PartitionTable); ++EntryIndex)
+        {
+            Entry = &MasterBootRecord->PartitionTable[EntryIndex];
+
+            if (Entry->SystemIndicator != PARTITION_ENTRY_UNUSED &&
+                Entry->PartitionSectorCount != 0)
+            {
+                Found = TRUE;
+                break;
+            }
+        }
+
+        *ValidPartition = Found;
+    }
+
+    return TRUE;
+}
+
+static
+VOID
+RamDiskRegisterArcDevice(VOID)
+{
+    static BOOLEAN ArcRegistered = FALSE;
+    ULONG Signature;
+    ULONG Checksum;
+    BOOLEAN ValidPartition;
+
+    if (ArcRegistered)
+        return;
+
+    if (!RamDiskBase || RamDiskFileSize < sizeof(MASTER_BOOT_RECORD))
+        return;
+
+    if (!RamDiskComputeMbrMetadata(RamDiskBase,
+                                   RamDiskFileSize,
+                                   &Signature,
+                                   &Checksum,
+                                   &ValidPartition))
+    {
+        return;
+    }
+
+    if (AddReactOSArcDiskInfo)
+    {
+        AddReactOSArcDiskInfo("ramdisk(0)", Signature, Checksum, ValidPartition);
+    }
+    ArcRegistered = TRUE;
+}
+
+static BOOLEAN RamDiskReserveWritableBuffer(ULONGLONG RequestedSize, BOOLEAN OptionalRamDisk);
+
+static VOID
+RamDiskSetVisibleRegion(IN ULONGLONG Offset,
+                        IN ULONGLONG Length)
+{
+    RamDiskVolumeOffset = Offset;
+    RamDiskVolumeLength = Length;
+    /* Note: Caller must call RamDiskInvalidateFatCache() after changing visible LBA window,
+       as the FAT mount state is invalidated when the underlying disk region changes */
+}
+
+static VOID
+RamDiskResetVisibleRegion(VOID)
+{
+    ULONGLONG VisibleLength = 0;
+
+    if (RamDiskImageLength > RamDiskImageOffset)
+        VisibleLength = RamDiskImageLength - RamDiskImageOffset;
+
+    RamDiskSetVisibleRegion(RamDiskImageOffset, VisibleLength);
+}
+
+static VOID
+RamDiskInvalidateFatCache(VOID)
+{
+#if defined(__GNUC__)
+    if (FatFlushCache)
+        FatFlushCache();
+#else
+    FatFlushCache();
+#endif
+}
+
+static
+ULONGLONG
+RamDiskWritableAllocationLimit(VOID)
+{
+    if (RAMDISK_LOW_ALLOC_MAX > RAMDISK_SAFETY_SLACK)
+        return RAMDISK_LOW_ALLOC_MAX - RAMDISK_SAFETY_SLACK;
+
+    return RAMDISK_LOW_ALLOC_MAX;
+}
+
+#define ISO_SECTOR_SIZE 2048
+#define ISO_DIRECTORY_MAX_SIZE    (32 * 1024 * 1024)
+#define ISO_NAME_BUFFER_SIZE      256
+
+typedef struct _ISO_SOURCE
+{
+    const UCHAR *MemoryBase;
+    ULONGLONG Size;
+    ULONG ArcFileId;
+    ULONGLONG ArcOffset;
+    ULONGLONG ArcPosition;
+} ISO_SOURCE, *PISO_SOURCE;
+
+typedef struct _ISO_COPY_CONTEXT
+{
+    PISO_SOURCE Source;
+    FAT32_WRITER Writer;
+    PUCHAR ScratchBuffer;
+    ULONG ScratchBufferSize;
+    ULONG ScratchPreferred;
+    PUCHAR DirectoryBuffer;
+    ULONG DirectoryBufferSize;
+    BOOLEAN DirectoryBufferBusy;
+    BOOLEAN ProgressActive;
+    ULONGLONG TotalBytes;
+    ULONGLONG BytesCopied;
+    ULONG LastPercentShown;
+    CHAR ProgressMessage[128];
+    ULONG ProgressStartSeconds;
+    ULONG LastDisplaySeconds;
+    ULONG LastSpeedKBs;
+    ULONG LastSecsLeft;
+} ISO_COPY_CONTEXT, *PISO_COPY_CONTEXT;
+
+#define ISO_SCRATCH_MIN_SIZE     (1024 * 1024)
+#define ISO_SCRATCH_MAX_SIZE     (8 * 1024 * 1024)
+#define ISO_SCRATCH_FLOOR_SIZE   (128 * 1024)
+#define ISO_STREAM_FALLBACK_CHUNK (1024 * 1024)
+#define TAG_ISO_BUFFER 'BosI'
+
+static
+ULONG
+RamDiskGetRelativeTime(VOID)
+{
+    return ArcGetRelativeTime();
+}
+
+static
+ULONG
+IsoGetPreferredChunkSize(VOID)
+{
+    ULONGLONG Preferred = ISO_STREAM_FALLBACK_CHUNK;
+
+    if (DiskReadBufferSize != 0)
+    {
+        ULONGLONG Candidate = (ULONGLONG)DiskReadBufferSize;
+        if (Candidate > ISO_SCRATCH_MAX_SIZE)
+            Candidate = ISO_SCRATCH_MAX_SIZE;
+        Preferred = Candidate;
+    }
+
+    if (Preferred < ISO_SCRATCH_MIN_SIZE)
+        Preferred = ISO_SCRATCH_MIN_SIZE;
+
+    if (Preferred > ISO_SCRATCH_MAX_SIZE)
+        Preferred = ISO_SCRATCH_MAX_SIZE;
+
+    Preferred = ALIGN_UP_BY_ULL(Preferred, ISO_SECTOR_SIZE);
+    Preferred = ALIGN_UP_BY_ULL(Preferred, MM_PAGE_SIZE);
+
+    if (Preferred > ISO_SCRATCH_MAX_SIZE)
+        Preferred = ISO_SCRATCH_MAX_SIZE;
+
+    return (ULONG)Preferred;
+}
+
+static
+ULONG
+IsoAlignScratchSize(
+    _In_ ULONGLONG Value)
+{
+    ULONGLONG Result;
+
+    if (Value < ISO_SECTOR_SIZE)
+        Value = ISO_SECTOR_SIZE;
+
+    Result = ALIGN_UP_BY_ULL(Value, ISO_SECTOR_SIZE);
+    Result = ALIGN_UP_BY_ULL(Result, MM_PAGE_SIZE);
+
+    if (Result > ISO_SCRATCH_MAX_SIZE)
+        Result = ISO_SCRATCH_MAX_SIZE;
+
+    return (ULONG)Result;
+}
+
+static
+BOOLEAN
+IsoEnsureScratchBuffer(
+    _Inout_ PISO_COPY_CONTEXT Context,
+    _In_ ULONGLONG RequiredSize)
+{
+    ULONG Preferred;
+    ULONG Floor;
+    ULONG Target;
+    ULONG Attempt;
+    ULONG Previous;
+    PVOID NewBuffer = NULL;
+
+    if (!Context)
+        return FALSE;
+
+    Preferred = IsoGetPreferredChunkSize();
+    Floor = IsoAlignScratchSize(ISO_SCRATCH_FLOOR_SIZE);
+
+    if (Context->ScratchPreferred != 0 && Preferred > Context->ScratchPreferred)
+        Preferred = Context->ScratchPreferred;
+
+    if (Context->ScratchBuffer && Context->ScratchBufferSize > Preferred)
+        Preferred = Context->ScratchBufferSize;
+
+    if (Preferred < Floor)
+        Preferred = Floor;
+
+    if (RequiredSize == 0)
+        RequiredSize = ISO_SECTOR_SIZE;
+
+    if (RequiredSize > ISO_SCRATCH_MAX_SIZE)
+        RequiredSize = ISO_SCRATCH_MAX_SIZE;
+
+    Target = IsoAlignScratchSize(RequiredSize);
+
+    if (Target < Floor)
+        Target = Floor;
+
+    if (Target > Preferred)
+        Target = Preferred;
+
+    if (Context->ScratchBuffer && Context->ScratchBufferSize >= Target)
+    {
+        Context->ScratchPreferred = Context->ScratchBufferSize;
+        return TRUE;
+    }
+
+    Attempt = Target;
+    Previous = 0;
+
+    while (Attempt >= Floor && Attempt != Previous)
+    {
+        if (Context->ScratchBuffer && Context->ScratchBufferSize >= Attempt)
+            return TRUE;
+
+        NewBuffer = FrLdrTempAlloc(Attempt, TAG_ISO_BUFFER);
+        if (NewBuffer)
+            break;
+
+        Previous = Attempt;
+
+        if (Attempt == Floor)
+            break;
+
+        Attempt /= 2;
+        if (Attempt < Floor)
+            Attempt = Floor;
+
+        Attempt = IsoAlignScratchSize(Attempt);
+    }
+
+    if (!NewBuffer)
+    {
+        if (Context->ScratchBuffer && Context->ScratchBufferSize >= Floor)
+        {
+            Context->ScratchPreferred = Context->ScratchBufferSize;
+            return TRUE;
+        }
+
+        return FALSE;
+    }
+
+    if (Context->ScratchBuffer)
+    {
+        FrLdrTempFree(Context->ScratchBuffer, TAG_ISO_BUFFER);
+    }
+
+    Context->ScratchBuffer = NewBuffer;
+    Context->ScratchBufferSize = Attempt;
+    Context->ScratchPreferred = Attempt;
+    return TRUE;
+}
+
+static
+VOID
+IsoProgressDisplay(
+    _Inout_ PISO_COPY_CONTEXT Context,
+    _In_ ULONG Percent)
+{
+    if (!Context)
+        return;
+
+    UiUpdateProgressBar(Percent, Context->ProgressMessage);
+}
+
+static
+VOID
+IsoProgressInitialize(
+    _Inout_ PISO_COPY_CONTEXT Context)
+{
+    if (!Context || !Context->Source || Context->Source->Size == 0)
+        return;
+
+    Context->TotalBytes = Context->Source->Size;
+    Context->BytesCopied = 0;
+    Context->LastPercentShown = 0;
+    Context->ProgressActive = TRUE;
+    Context->ProgressStartSeconds = RamDiskGetRelativeTime();
+    Context->LastDisplaySeconds = Context->ProgressStartSeconds;
+    Context->LastSpeedKBs = 0;
+    Context->LastSecsLeft = 0;
+
+    UiDrawProgressBarCenter("Copying files...");
+
+    RtlStringCbPrintfA(Context->ProgressMessage,
+                       sizeof(Context->ProgressMessage),
+                       "Copying files...");
+    IsoProgressDisplay(Context, 0);
+}
+
+static
+VOID
+IsoProgressAdvance(
+    _Inout_ PISO_COPY_CONTEXT Context,
+    _In_ ULONGLONG Bytes)
+{
+    ULONG Percent;
+    ULONG NowSeconds;
+
+    if (!Context || !Context->ProgressActive || Context->TotalBytes == 0)
+        return;
+
+    Context->BytesCopied += Bytes;
+    if (Context->BytesCopied > Context->TotalBytes)
+        Context->BytesCopied = Context->TotalBytes;
+
+    Percent = (ULONG)((Context->BytesCopied * 100ULL) / Context->TotalBytes);
+    if (Percent > 100)
+        Percent = 100;
+
+    NowSeconds = RamDiskGetRelativeTime();
+
+    /*
+     * Recompute speed and ETA only when the seconds counter changes.
+     * ArcGetRelativeTime has 1-second resolution; recomputing between
+     * ticks would cause the displayed rate to jump wildly because
+     * elapsed stays frozen while BytesCopied grows.
+     */
+    if (NowSeconds != Context->LastDisplaySeconds)
+    {
+        ULONG ElapsedSeconds = NowSeconds - Context->ProgressStartSeconds;
+
+        if (ElapsedSeconds > 0)
+        {
+            ULONGLONG CopiedKB = Context->BytesCopied / 1024ULL;
+
+            Context->LastSpeedKBs = (ULONG)(CopiedKB / (ULONGLONG)ElapsedSeconds);
+            if (Context->LastSpeedKBs == 0)
+                Context->LastSpeedKBs = 1;
+
+            if (Context->BytesCopied < Context->TotalBytes)
+            {
+                ULONGLONG Remaining = Context->TotalBytes - Context->BytesCopied;
+                /* seconds = remaining_bytes / (total_bytes_done / elapsed_s) */
+                Context->LastSecsLeft = (ULONG)((Remaining * (ULONGLONG)ElapsedSeconds) /
+                                                 Context->BytesCopied);
+            }
+            else
+            {
+                Context->LastSecsLeft = 0;
+            }
+        }
+
+        Context->LastDisplaySeconds = NowSeconds;
+    }
+
+    /* Update the bar and message on every percent change */
+    if (Percent != Context->LastPercentShown)
+    {
+        ULONGLONG CopiedKB = Context->BytesCopied / 1024ULL;
+        ULONGLONG TotalKB = (Context->TotalBytes + 1023ULL) / 1024ULL;
+
+        if (Percent >= 100)
+        {
+            RtlStringCbPrintfA(Context->ProgressMessage,
+                               sizeof(Context->ProgressMessage),
+                               "Copy complete");
+        }
+        else
+        {
+            RtlStringCbPrintfA(Context->ProgressMessage,
+                               sizeof(Context->ProgressMessage),
+                               "Ramdisk %u%% (%llu/%llu KB, %u KB/s, %us left)",
+                               Percent,
+                               CopiedKB,
+                               TotalKB,
+                               Context->LastSpeedKBs,
+                               Context->LastSecsLeft);
+        }
+
+        IsoProgressDisplay(Context, Percent);
+        TRACE("IsoProgress: %s\n", Context->ProgressMessage);
+        Context->LastPercentShown = Percent;
+    }
+}
+
+static
+VOID
+IsoProgressComplete(
+    _Inout_ PISO_COPY_CONTEXT Context)
+{
+    if (!Context || !Context->ProgressActive)
+        return;
+
+    Context->BytesCopied = Context->TotalBytes;
+    Context->ProgressActive = FALSE;
+    Context->LastPercentShown = 100;
+
+    RtlStringCbPrintfA(Context->ProgressMessage,
+                       sizeof(Context->ProgressMessage),
+                       "Copy complete");
+    IsoProgressDisplay(Context, 100);
+}
+
+static
+BOOLEAN
+IsoSourceRead(
+    _Inout_ PISO_SOURCE Source,
+    _In_ ULONGLONG Offset,
+    _Out_writes_(Size) PVOID Buffer,
+    _In_ ULONG Size)
+{
+    ULONGLONG AbsoluteStart;
+    const ULONG SectorMask = ISO_SECTOR_SIZE - 1;
+    ULONG MaxChunkBytesTmp;
+    ULONG MaxChunkBytes;
+    PUCHAR Out;
+    ULONG Remaining;
+    ARC_STATUS Status;
+    ULONG BytesRead;
+    LARGE_INTEGER Position;
+    UCHAR Bounce[ISO_SECTOR_SIZE];
+    ULONGLONG CurrentPos;
+
+    if (Size == 0)
+        return TRUE;
+
+    if (!Source || !Buffer)
+        return FALSE;
+
+    if (Source->MemoryBase)
+    {
+        if (Offset + Size > Source->Size)
+            return FALSE;
+
+        RtlCopyMemory(Buffer, Source->MemoryBase + Offset, Size);
+        return TRUE;
+    }
+
+    if (Source->ArcFileId == INVALID_FILE_ID)
+        return FALSE;
+
+    if (Offset > Source->Size || Offset + Size > Source->Size)
+        return FALSE;
+
+    AbsoluteStart = Source->ArcOffset + Offset;
+    MaxChunkBytesTmp = IsoGetPreferredChunkSize();
+
+    if (Size > MaxChunkBytesTmp)
+    {
+        ULONGLONG Candidate = ALIGN_UP_BY_ULL(Size, ISO_SECTOR_SIZE);
+
+        if (Candidate > ISO_SCRATCH_MAX_SIZE)
+            Candidate = ISO_SCRATCH_MAX_SIZE;
+
+        if (Candidate > ULONG_MAX)
+            Candidate = ULONG_MAX & ~((ULONGLONG)ISO_SECTOR_SIZE - 1ULL);
+
+        if (Candidate > MaxChunkBytesTmp)
+            MaxChunkBytesTmp = (ULONG)Candidate;
+    }
+
+    MaxChunkBytesTmp &= ~SectorMask;
+    MaxChunkBytes = (MaxChunkBytesTmp == 0) ? ISO_SECTOR_SIZE : MaxChunkBytesTmp;
+
+    Out = (PUCHAR)Buffer;
+    Remaining = Size;
+    CurrentPos = Source->ArcPosition;
+
+    /* Handle head misalignment */
+    if ((AbsoluteStart & SectorMask) != 0)
+    {
+        ULONG CopyLength;
+        ULONGLONG SectorStart;
+
+        CopyLength = ISO_SECTOR_SIZE - (ULONG)(AbsoluteStart & SectorMask);
+        if (CopyLength > Remaining)
+            CopyLength = Remaining;
+
+        SectorStart = AbsoluteStart - (AbsoluteStart & SectorMask);
+        if (CurrentPos != SectorStart)
+        {
+            Position.QuadPart = SectorStart;
+            Status = ArcSeek(Source->ArcFileId, &Position, SeekAbsolute);
+            if (Status != ESUCCESS)
+            {
+                WARN("IsoSourceRead: ArcSeek failed (status %lu) at offset %I64u\n",
+                     Status,
+                     Position.QuadPart);
+                return FALSE;
+            }
+            CurrentPos = SectorStart;
+        }
+
+        Status = ArcRead(Source->ArcFileId, Bounce, ISO_SECTOR_SIZE, &BytesRead);
+        if (Status != ESUCCESS || BytesRead != ISO_SECTOR_SIZE)
+        {
+            WARN("IsoSourceRead: ArcRead failed (status %lu) at offset %I64u (head)\n",
+                 Status,
+                 SectorStart);
+            return FALSE;
+        }
+
+        CurrentPos += ISO_SECTOR_SIZE;
+        RtlCopyMemory(Out, Bounce + (AbsoluteStart & SectorMask), CopyLength);
+        Out += CopyLength;
+        Remaining -= CopyLength;
+    }
+
+    /* Handle middle aligned region */
+    if (Remaining >= ISO_SECTOR_SIZE)
+    {
+        ULONGLONG Consumed;
+        ULONGLONG AlignedOffset;
+        ULONG AlignedBytes;
+
+        Consumed = Size - Remaining;
+        AlignedOffset = (AbsoluteStart + Consumed) & ~((ULONGLONG)SectorMask);
+        AlignedBytes = Remaining & ~SectorMask;
+
+        if (AlignedBytes)
+        {
+            if (CurrentPos != AlignedOffset)
+            {
+                Position.QuadPart = AlignedOffset;
+                Status = ArcSeek(Source->ArcFileId, &Position, SeekAbsolute);
+                if (Status != ESUCCESS)
+                {
+                    WARN("IsoSourceRead: ArcSeek failed (status %lu) at offset %I64u\n",
+                         Status,
+                         Position.QuadPart);
+                    return FALSE;
+                }
+                CurrentPos = AlignedOffset;
+            }
+
+            while (AlignedBytes > 0)
+            {
+                ULONG Chunk = (AlignedBytes > MaxChunkBytes) ? MaxChunkBytes : AlignedBytes;
+
+                Status = ArcRead(Source->ArcFileId, Out, Chunk, &BytesRead);
+                if (Status != ESUCCESS || BytesRead != Chunk)
+                {
+                    WARN("IsoSourceRead: ArcRead failed (status %lu) at offset %I64u (aligned chunk %lu)\n",
+                         Status,
+                         CurrentPos,
+                         Chunk);
+                    return FALSE;
+                }
+
+                Out += Chunk;
+                AlignedBytes -= Chunk;
+                CurrentPos += Chunk;
+            }
+
+            Remaining &= SectorMask;
+        }
+    }
+
+    /* Handle tail */
+    if (Remaining > 0)
+    {
+        ULONGLONG TailStart;
+        ULONGLONG SectorStart;
+        ULONG OffsetInSector;
+
+        TailStart = AbsoluteStart + Size - Remaining;
+        SectorStart = TailStart & ~((ULONGLONG)SectorMask);
+        OffsetInSector = (ULONG)(TailStart & SectorMask);
+
+        if (CurrentPos != SectorStart)
+        {
+            Position.QuadPart = SectorStart;
+            Status = ArcSeek(Source->ArcFileId, &Position, SeekAbsolute);
+            if (Status != ESUCCESS)
+            {
+                WARN("IsoSourceRead: ArcSeek failed (status %lu) at offset %I64u (tail)\n",
+                     Status,
+                     Position.QuadPart);
+                return FALSE;
+            }
+            CurrentPos = SectorStart;
+        }
+
+        Status = ArcRead(Source->ArcFileId, Bounce, ISO_SECTOR_SIZE, &BytesRead);
+        if (Status != ESUCCESS || BytesRead != ISO_SECTOR_SIZE)
+        {
+            WARN("IsoSourceRead: ArcRead failed (status %lu) at offset %I64u (tail)\n",
+                 Status,
+                 SectorStart);
+            return FALSE;
+        }
+
+        CurrentPos += ISO_SECTOR_SIZE;
+        RtlCopyMemory(Out, Bounce + OffsetInSector, Remaining);
+    }
+
+    Source->ArcPosition = CurrentPos;
+    return TRUE;
+}
+
+static
+ARC_STATUS
+RamDiskOpenIsoSource(
+    _In_ PCSTR FileName,
+    _In_opt_ PCSTR DefaultPath,
+    _In_ ULONGLONG ImageOffset,
+    _In_ ULONGLONG ImageLength,
+    _Out_ PISO_SOURCE Source)
+{
+    ARC_STATUS Status;
+    ULONG FileId;
+    FILEINFORMATION Information;
+    ULONGLONG FileSize;
+    ULONGLONG EffectiveLength;
+    UCHAR Descriptor[ISO_SECTOR_SIZE];
+    LARGE_INTEGER Position;
+    ULONG BytesRead;
+    BOOLEAN OpenedRawDevice = FALSE;
+
+    if (!Source)
+        return EINVAL;
+
+    RtlZeroMemory(Source, sizeof(*Source));
+    Source->ArcFileId = INVALID_FILE_ID;
+
+    Status = FsOpenFile((PCHAR)FileName, DefaultPath, OpenReadOnly, &FileId);
+    if (Status != ESUCCESS)
+    {
+        /* Fall back to opening the ARC device directly (e.g. CD/DVD handle) */
+        if (FileName && strchr(FileName, ')'))
+        {
+            Status = ArcOpen((PCHAR)FileName, OpenReadOnly, &FileId);
+            if (Status == ESUCCESS)
+            {
+                OpenedRawDevice = TRUE;
+            }
+        }
+
+        if (Status != ESUCCESS)
+            return Status;
+    }
+
+    Status = ArcGetFileInformation(FileId, &Information);
+    if (Status != ESUCCESS)
+    {
+        ArcClose(FileId);
+        return Status;
+    }
+
+    FileSize = Information.EndingAddress.QuadPart;
+
+    /*
+     * Some firmware/device paths report the raw device capacity here,
+     * which for 2KiB-block optical media can be 4x the ISO size when
+     * combined with 512-byte sector-based partition metadata. Read the
+     * ISO9660 Primary Volume Descriptor to obtain an authoritative size
+     * and prefer it when available.
+     */
+    {
+        ULONGLONG PvdOffset = ImageOffset + (ULONGLONG)16 * ISO_SECTOR_SIZE;
+
+        Position.QuadPart = PvdOffset;
+        if (ArcSeek(FileId, &Position, SeekAbsolute) == ESUCCESS)
+        {
+            if (ArcRead(FileId, Descriptor, ISO_SECTOR_SIZE, &BytesRead) == ESUCCESS &&
+                BytesRead == ISO_SECTOR_SIZE)
+            {
+                PPVD Pvd = (PPVD)Descriptor;
+                if (Pvd->VdType == 1 &&
+                    RtlEqualMemory(Pvd->StandardId, "CD001", 5) &&
+                    Pvd->VdVersion == 1)
+                {
+                    USHORT LogicalBlockSize = Pvd->LogicalBlockSizeL;
+                    if (LogicalBlockSize == 0)
+                        LogicalBlockSize = ISO_SECTOR_SIZE; /* Fallback to default */
+
+                    /* Compute the ISO byte length from the PVD */
+                    ULONGLONG IsoLength = (ULONGLONG)Pvd->VolumeSpaceSizeL * LogicalBlockSize;
+
+                    /* Prefer the PVD-declared size when sensible (never larger than reported file size if nonzero). */
+                    if (IsoLength != 0 && (FileSize == 0 || IsoLength <= FileSize))
+                        FileSize = IsoLength;
+                }
+            }
+        }
+
+        /* Restore the caller's requested starting position */
+        Position.QuadPart = ImageOffset;
+        ArcSeek(FileId, &Position, SeekAbsolute);
+    }
+
+    if (FileSize == 0 && ImageLength != 0)
+    {
+        /* Some firmware return 0 for raw devices; use the supplied length as a hint */
+        FileSize = ImageOffset + ImageLength;
+    }
+
+    if (FileSize != 0 && ImageOffset >= FileSize)
+    {
+        ArcClose(FileId);
+        return EINVAL;
+    }
+
+    EffectiveLength = (FileSize != 0) ? (FileSize - ImageOffset) : ImageLength;
+    if (FileSize != 0 && ImageLength != 0 && ImageLength < EffectiveLength)
+        EffectiveLength = ImageLength;
+    if (EffectiveLength == 0)
+    {
+        ArcClose(FileId);
+        return EINVAL;
+    }
+
+    Source->MemoryBase = NULL;
+    Source->ArcFileId = FileId;
+    Source->ArcOffset = ImageOffset;
+    Source->Size = EffectiveLength;
+    Source->ArcPosition = OpenedRawDevice ? ImageOffset : 0;
+
+    return ESUCCESS;
+}
+
+static
+VOID
+RamDiskCloseIsoSource(
+    _Inout_ PISO_SOURCE Source)
+{
+    if (!Source)
+        return;
+
+    if (Source->ArcFileId != INVALID_FILE_ID)
+    {
+        ArcClose(Source->ArcFileId);
+        Source->ArcFileId = INVALID_FILE_ID;
+    }
+}
+
+
+static
+BOOLEAN
+IsoExtractName(
+    _In_ PDIR_RECORD Record,
+    _Out_writes_(NameBufferSize) PCHAR NameBuffer,
+    _In_ SIZE_T NameBufferSize)
+{
+    SIZE_T Index;
+
+    if (!Record || !NameBuffer || NameBufferSize == 0)
+        return FALSE;
+
+    /* Skip '.' and '..' entries early */
+    if (Record->FileIdLength == 1 && (Record->FileId[0] == 0 || Record->FileId[0] == 1))
+        return FALSE;
+
+    for (Index = 0; Index < Record->FileIdLength && Index < NameBufferSize - 1; ++Index)
+    {
+        CHAR Character = Record->FileId[Index];
+
+        if (Character == ';')
+            break;
+
+        NameBuffer[Index] = Character;
+    }
+
+    NameBuffer[Index] = '\0';
+
+    /* Remove trailing dot, if any (appears on directory records) */
+    while (Index > 0 && NameBuffer[Index - 1] == '.')
+    {
+        NameBuffer[Index - 1] = '\0';
+        --Index;
+    }
+
+    if (Index == 0)
+        return FALSE;
+
+    return TRUE;
+}
+
+static
+BOOLEAN
+FatEnsureDirectoryExists(
+    _In_ PFAT32_WRITER Writer,
+    _In_ PCSTR Path)
+{
+    if (!Writer || !Path)
+        return FALSE;
+
+    return Fat32CreateDirectory(Writer, Path);
+}
+
+static
+BOOLEAN
+FatCopyFileFromIso(
+    _In_ PISO_COPY_CONTEXT Context,
+    _In_ PDIR_RECORD Record,
+    _In_ PCSTR DestinationPath)
+{
+    ULONGLONG Remaining;
+    ULONGLONG FileOffset;
+    PUCHAR DataDest;
+
+    if (!Context || !Context->Source || !Record || !DestinationPath)
+        return FALSE;
+
+    if (Record->FileFlags & 0x02)
+        return FALSE;
+
+    FileOffset = (ULONGLONG)Record->ExtentLocationL * ISO_SECTOR_SIZE;
+    Remaining = Record->DataLengthL;
+
+    if (FileOffset + Remaining > Context->Source->Size)
+        return FALSE;
+
+    if (Remaining > ULONG_MAX)
+    {
+        WARN("FatCopyFileFromIso: file '%s' too large (%llu bytes)\n",
+             DestinationPath, Remaining);
+        return FALSE;
+    }
+
+    if (!IsoEnsureScratchBuffer(Context, Remaining))
+    {
+        WARN("IsoEnsureScratchBuffer failed for '%s' size %lu\n",
+             DestinationPath,
+             Record->DataLengthL);
+        return FALSE;
+    }
+
+    /* Allocate clusters and create directory entry in one call */
+    if (!Fat32CreateFileEx(&Context->Writer, DestinationPath,
+                           (ULONG)Remaining, &DataDest))
+    {
+        WARN("Fat32CreateFileEx failed for '%s'\n", DestinationPath);
+
+        if (strstr(DestinationPath, "/efi/boot/BCD"))
+        {
+            WARN("FatCopyFileFromIso: skipping '%s' on legacy BIOS path\n",
+                 DestinationPath);
+            return TRUE;
+        }
+
+        return FALSE;
+    }
+
+    /* Copy file data in chunks from ISO source directly into cluster memory */
+    while (Remaining > 0)
+    {
+        ULONG Chunk = (Remaining > Context->ScratchBufferSize)
+                        ? Context->ScratchBufferSize
+                        : (ULONG)Remaining;
+
+        if (!IsoSourceRead(Context->Source, FileOffset, DataDest, Chunk))
+        {
+            WARN("IsoSourceRead failed while copying '%s' at offset %I64u len %lu\n",
+                 DestinationPath,
+                 FileOffset,
+                 Chunk);
+            return FALSE;
+        }
+
+        DataDest += Chunk;
+        FileOffset += Chunk;
+        Remaining -= Chunk;
+
+        IsoProgressAdvance(Context, Chunk);
+    }
+
+    return TRUE;
+}
+
+static
+BOOLEAN
+IsoCopyDirectoryRecursive(
+    _In_ PISO_COPY_CONTEXT Context,
+    _In_ ULONG StartSector,
+    _In_ ULONG DirectoryLength,
+    _In_ PCSTR DestinationPath)
+{
+    ULONGLONG DirectoryOffset;
+    ULONG Offset = 0;
+    PUCHAR DirectoryBuffer = NULL;
+    PCHAR NameBuffer = NULL;
+    PCHAR ChildPath = NULL;
+    SIZE_T ChildPathCapacity = 0;
+    BOOLEAN UseSharedBuffer = FALSE;
+    BOOLEAN AllocatedBuffer = FALSE;
+    BOOLEAN Result = FALSE;
+
+    if (!Context || !Context->Source || !DestinationPath)
+        return FALSE;
+
+    DirectoryOffset = (ULONGLONG)StartSector * ISO_SECTOR_SIZE;
+
+    if (DirectoryOffset >= Context->Source->Size ||
+        DirectoryOffset + DirectoryLength > Context->Source->Size)
+        return FALSE;
+
+    if (DirectoryLength > ISO_DIRECTORY_MAX_SIZE)
+    {
+        WARN("IsoCopyDirectoryRecursive: directory length %lu exceeds safety cap\n",
+             DirectoryLength);
+        return FALSE;
+    }
+
+    if (!Context->DirectoryBufferBusy)
+    {
+        if (!Context->DirectoryBuffer ||
+            Context->DirectoryBufferSize < DirectoryLength)
+        {
+            if (Context->DirectoryBuffer)
+            {
+                FrLdrTempFree(Context->DirectoryBuffer, TAG_ISO_BUFFER);
+                Context->DirectoryBuffer = NULL;
+                Context->DirectoryBufferSize = 0;
+            }
+
+            Context->DirectoryBuffer = FrLdrTempAlloc(DirectoryLength, TAG_ISO_BUFFER);
+            if (!Context->DirectoryBuffer)
+                return FALSE;
+
+            Context->DirectoryBufferSize = DirectoryLength;
+        }
+
+        DirectoryBuffer = Context->DirectoryBuffer;
+        Context->DirectoryBufferBusy = TRUE;
+        UseSharedBuffer = TRUE;
+    }
+    else
+    {
+        DirectoryBuffer = FrLdrTempAlloc(DirectoryLength, TAG_ISO_BUFFER);
+        if (!DirectoryBuffer)
+            return FALSE;
+
+        AllocatedBuffer = TRUE;
+    }
+
+    NameBuffer = FrLdrTempAlloc(ISO_NAME_BUFFER_SIZE, TAG_ISO_BUFFER);
+    if (!NameBuffer)
+        goto Cleanup;
+
+    if (!IsoSourceRead(Context->Source, DirectoryOffset, DirectoryBuffer, DirectoryLength))
+    {
+        WARN("IsoSourceRead failed reading directory at sector %lu length %lu\n",
+             StartSector,
+             DirectoryLength);
+        goto Cleanup;
+    }
+
+    TRACE("IsoCopyDirectoryRecursive: sector %lu length %lu -> %s\n",
+          StartSector,
+          DirectoryLength,
+          DestinationPath);
+
+    while (Offset < DirectoryLength)
+    {
+        PDIR_RECORD Record;
+        ULONG NextOffset;
+        BOOLEAN IsDirectory;
+
+        /* Ensure at least the fixed portion of a directory record fits */
+        if (Offset + FIELD_OFFSET(DIR_RECORD, FileId) > DirectoryLength)
+            break;
+
+        Record = (PDIR_RECORD)(DirectoryBuffer + Offset);
+
+        if (Record->RecordLength == 0)
+        {
+            Offset = ROUND_UP(Offset, ISO_SECTOR_SIZE);
+            continue;
+        }
+
+        /* Validate that the full record (including FileId) fits in the buffer */
+        if (Record->RecordLength < FIELD_OFFSET(DIR_RECORD, FileId) ||
+            Offset + Record->RecordLength > DirectoryLength)
+        {
+            WARN("IsoCopyDirectoryRecursive: invalid RecordLength %u at offset %lu\n",
+                 Record->RecordLength, Offset);
+            break;
+        }
+
+        NextOffset = Offset + Record->RecordLength;
+
+        IsDirectory = !!(Record->FileFlags & 0x02);
+        if (!IsoExtractName(Record, NameBuffer, ISO_NAME_BUFFER_SIZE))
+        {
+            Offset = NextOffset;
+            continue;
+        }
+
+        {
+            size_t Need = strlen(DestinationPath) + 1 + strlen(NameBuffer) + 1;
+
+            if (Need > ChildPathCapacity)
+            {
+                PCHAR NewChildPath = FrLdrTempAlloc(Need, TAG_ISO_BUFFER);
+                if (!NewChildPath)
+                {
+                    WARN("IsoCopyDirectoryRecursive: unable to allocate %zu bytes for '%s/%s'\n",
+                         Need,
+                         DestinationPath,
+                         NameBuffer);
+                    goto Cleanup;
+                }
+
+                if (ChildPath)
+                    FrLdrTempFree(ChildPath, TAG_ISO_BUFFER);
+
+                ChildPath = NewChildPath;
+                ChildPathCapacity = Need;
+            }
+
+            if (!NT_SUCCESS(RtlStringCbPrintfA(ChildPath,
+                                               ChildPathCapacity,
+                                               "%s/%s",
+                                               DestinationPath,
+                                               NameBuffer)))
+            {
+                WARN("RtlStringCbPrintfA failed while building path '%s/%s'\n",
+                     DestinationPath,
+                     NameBuffer);
+                goto Cleanup;
+            }
+        }
+
+#ifndef UEFIBOOT
+        {
+            /* Skip EFI boot paths on legacy BIOS */
+            PCSTR p = ChildPath;
+            while (*p == '/') p++;
+            if (strlen(p) >= 3 &&
+                (p[0] == 'e' || p[0] == 'E') &&
+                (p[1] == 'f' || p[1] == 'F') &&
+                (p[2] == 'i' || p[2] == 'I') &&
+                (p[3] == '/' || p[3] == '\0'))
+            {
+                TRACE("IsoCopyDirectoryRecursive: skipping legacy-only path %s\n", ChildPath);
+                Offset = NextOffset;
+                continue;
+            }
+        }
+#endif
+
+        if (IsDirectory)
+        {
+            if (!FatEnsureDirectoryExists(&Context->Writer, ChildPath))
+            {
+                goto Cleanup;
+            }
+
+            if (!IsoCopyDirectoryRecursive(Context,
+                                           Record->ExtentLocationL,
+                                           Record->DataLengthL,
+                                           ChildPath))
+            {
+                WARN("IsoCopyDirectoryRecursive failed for '%s' (sector %lu length %lu)\n",
+                     ChildPath,
+                     Record->ExtentLocationL,
+                     Record->DataLengthL);
+                goto Cleanup;
+            }
+        }
+        else
+        {
+            // TRACE("IsoCopyDirectoryRecursive: copying file %s (%lu bytes, %lu KB)\n",
+            //       ChildPath,
+            //       Record->DataLengthL,
+            //       (Record->DataLengthL + 1023UL) / 1024UL);
+            if (!FatCopyFileFromIso(Context, Record, ChildPath))
+            {
+                WARN("FatCopyFileFromIso failed for '%s'\n", ChildPath);
+                goto Cleanup;
+            }
+
+        }
+
+        Offset = NextOffset;
+    }
+
+    Result = TRUE;
+
+Cleanup:
+    if (ChildPath)
+        FrLdrTempFree(ChildPath, TAG_ISO_BUFFER);
+
+    if (NameBuffer)
+        FrLdrTempFree(NameBuffer, TAG_ISO_BUFFER);
+
+    if (UseSharedBuffer)
+    {
+        Context->DirectoryBufferBusy = FALSE;
+    }
+    else if (AllocatedBuffer && DirectoryBuffer)
+    {
+        FrLdrTempFree(DirectoryBuffer, TAG_ISO_BUFFER);
+    }
+
+    return Result;
+}
+
+static
+BOOLEAN
+RamDiskPopulateFatFromIso(
+    _In_ PVOID FatBase,
+    _In_ ULONGLONG FatSize,
+    _Inout_ PISO_SOURCE Source,
+    _In_ PRAMDISK_FAT32_LAYOUT Layout)
+{
+    ISO_COPY_CONTEXT Context;
+    PPVD PrimaryVolumeDescriptor;
+    UCHAR DescriptorBuffer[ISO_SECTOR_SIZE];
+
+    if (!FatBase || !Source || Source->Size < (16 * ISO_SECTOR_SIZE) || !Layout)
+        return FALSE;
+
+    if (!IsoSourceRead(Source,
+                       (ULONGLONG)16 * ISO_SECTOR_SIZE,
+                       DescriptorBuffer,
+                       sizeof(DescriptorBuffer)))
+        return FALSE;
+
+    PrimaryVolumeDescriptor = (PPVD)DescriptorBuffer;
+
+    if (PrimaryVolumeDescriptor->VdType != 1 ||
+        !RtlEqualMemory(PrimaryVolumeDescriptor->StandardId, "CD001", 5) ||
+        PrimaryVolumeDescriptor->VdVersion != 1)
+    {
+        return FALSE;
+    }
+
+    TRACE("RamDiskPopulateFatFromIso: FAT size %llu bytes, ISO size %llu bytes\n",
+          FatSize,
+          Source->Size);
+
+    RtlZeroMemory(&Context, sizeof(Context));
+    Context.Source = Source;
+
+    if (!Fat32WriterInit(&Context.Writer, FatBase, FatSize, Layout))
+    {
+        WARN("RamDiskPopulateFatFromIso: Fat32WriterInit failed\n");
+        return FALSE;
+    }
+
+    IsoProgressInitialize(&Context);
+
+    TRACE("RamDiskPopulateFatFromIso: traversing ISO root (sector %lu size %lu)\n",
+          PrimaryVolumeDescriptor->RootDirRecord.ExtentLocationL,
+          PrimaryVolumeDescriptor->RootDirRecord.DataLengthL);
+
+    if (!IsoCopyDirectoryRecursive(&Context,
+                                   PrimaryVolumeDescriptor->RootDirRecord.ExtentLocationL,
+                                   PrimaryVolumeDescriptor->RootDirRecord.DataLengthL,
+                                   ""))
+    {
+        if (Context.ScratchBuffer)
+            FrLdrTempFree(Context.ScratchBuffer, TAG_ISO_BUFFER);
+        if (Context.DirectoryBuffer)
+            FrLdrTempFree(Context.DirectoryBuffer, TAG_ISO_BUFFER);
+        return FALSE;
+    }
+
+    IsoProgressComplete(&Context);
+
+    if (Context.ScratchBuffer)
+        FrLdrTempFree(Context.ScratchBuffer, TAG_ISO_BUFFER);
+    if (Context.DirectoryBuffer)
+        FrLdrTempFree(Context.DirectoryBuffer, TAG_ISO_BUFFER);
+
+    TRACE("RamDiskPopulateFatFromIso: copy complete\n");
+    return TRUE;
+}
+
+BOOLEAN
+RamDiskBuildWritableImage(
+    IN PISO_SOURCE Source,
+    IN ULONGLONG RequestedSize,
+    OUT PVOID *NewBase,
+    OUT PULONGLONG NewSize,
+    IN BOOLEAN OptionalRamDisk)
+{
+    PVOID WritableBase = NULL;
+    ULONGLONG WritableSize = 0;
+    ULONGLONG RequiredSize;
+    ULONGLONG IsoSize;
+    ULONGLONG ResidentIsoBytes = 0;
+    RAMDISK_FAT32_LAYOUT Layout;
+
+    if (!Source || !NewBase || !NewSize || Source->Size == 0)
+        return FALSE;
+
+    IsoSize = Source->Size;
+
+    /* Leave some slack to account for ISO9660 metadata and future writes */
+    RequiredSize = RequestedSize;
+    if (RequiredSize < IsoSize + RAMDISK_MINIMUM_EXTRA_SPACE)
+        RequiredSize = IsoSize + RAMDISK_MINIMUM_EXTRA_SPACE;
+
+    if (RequiredSize + RAMDISK_SAFETY_SLACK > RAMDISK_LOW_ALLOC_MAX)
+    {
+        WARN("RamDiskBuildWritableImage: requested size %llu exceeds low-memory limit %llu\n",
+             RequiredSize,
+             RAMDISK_LOW_ALLOC_MAX);
+        if (!RamDiskErrorShown && !OptionalRamDisk)
+        {
+            UiMessageBox("Requested writable RAM disk size exceeds available low memory.");
+            RamDiskErrorShown = TRUE;
+        }
+        return FALSE;
+    }
+
+    if (Source->MemoryBase)
+        ResidentIsoBytes = ALIGN_UP_BY_ULL(IsoSize, RAMDISK_ALLOCATION_ALIGNMENT);
+
+    if ((RequiredSize + ResidentIsoBytes + RAMDISK_SAFETY_SLACK) > RAMDISK_LOW_ALLOC_MAX)
+    {
+        WARN("RamDiskBuildWritableImage: %llu-byte ISO plus %llu-byte writable buffer exceed low-memory budget %llu\n",
+             IsoSize,
+             RequiredSize,
+             RAMDISK_LOW_ALLOC_MAX);
+        if (!RamDiskErrorShown && !OptionalRamDisk)
+        {
+            UiMessageBox("Writable RAM disk request uses too much low memory to keep the ISO resident.");
+            RamDiskErrorShown = TRUE;
+        }
+        return FALSE;
+    }
+
+    RequiredSize = ALIGN_UP_BY_ULL(RequiredSize, RAMDISK_ALLOCATION_ALIGNMENT);
+    if (RequiredSize == 0 || RequiredSize > MAXULONG)
+        return FALSE;
+
+    TRACE("RamDiskBuildWritableImage: ISO=%llu requested=%llu align=%llu\n",
+          IsoSize,
+          RequestedSize,
+          RequiredSize);
+
+    if (!RamDiskReserveWritableBuffer(RequiredSize, OptionalRamDisk))
+        return FALSE;
+
+    if (!RamDiskGetReservedBuffer(RequiredSize, &WritableBase, &WritableSize))
+        return FALSE;
+
+    if (WritableSize > MAXULONG)
+        WritableSize = MAXULONG;
+
+    TRACE("RamDiskBuildWritableImage: formatting FAT32 (%llu bytes)\n", WritableSize);
+
+    if (!RamDiskFormatFat32(WritableBase, WritableSize, &Layout))
+    {
+        MmFreeMemory(WritableBase);
+        return FALSE;
+    }
+
+    TRACE("RamDiskBuildWritableImage: populating ramdisk from ISO\n");
+
+    {
+        ULONGLONG VolumeOffset;
+        PVOID VolumeBase;
+        ULONGLONG VolumeSize;
+
+        VolumeOffset = (ULONGLONG)Layout.HiddenSectors * Layout.BytesPerSector;
+        if (VolumeOffset >= WritableSize)
+        {
+            MmFreeMemory(WritableBase);
+            return FALSE;
+        }
+
+        VolumeBase = (PUCHAR)WritableBase + VolumeOffset;
+        VolumeSize = WritableSize - VolumeOffset;
+
+        if (!RamDiskPopulateFatFromIso(VolumeBase,
+                                       VolumeSize,
+                                       Source,
+                                       &Layout))
+        {
+            MmFreeMemory(WritableBase);
+            return FALSE;
+        }
+
+        RamDiskSetVisibleRegion(VolumeOffset, VolumeSize);
+
+#if DBG
+        {
+            PFN_NUMBER BasePfn = RamDiskPointerToPfn(WritableBase);
+            PFN_NUMBER EndPfn = RamDiskPointerToPfn((const VOID *)((ULONG_PTR)WritableBase + (ULONG_PTR)(WritableSize - 1)));
+            PVOID VolumePointer = (PUCHAR)WritableBase + VolumeOffset;
+            TRACE("RamDiskBuildWritableImage: PFN span %lx-%lx hidden=%lu reserved=%lu fat=%lu data=%lu\n",
+                  BasePfn,
+                  EndPfn,
+                  Layout.HiddenSectors,
+                  Layout.ReservedSectors,
+                  Layout.FatSizeSectors,
+                  Layout.FirstDataSector);
+            RamDiskTraceSample("  writable[boot]", WritableBase);
+            RamDiskTraceSample("  writable[volume]", VolumePointer);
+
+            if (Layout.ReservedSectors < WritableSize / Layout.BytesPerSector)
+            {
+                ULONGLONG FatOffset = VolumeOffset + ((ULONGLONG)Layout.ReservedSectors * Layout.BytesPerSector);
+                if (FatOffset + (16 * sizeof(ULONG)) <= WritableSize)
+                {
+                    const ULONG *FatWords = (const ULONG *)((PUCHAR)WritableBase + FatOffset);
+                    TRACE("  writable[FAT0..7]=%08lX %08lX %08lX %08lX %08lX %08lX %08lX %08lX\n",
+                          FatWords[0], FatWords[1], FatWords[2], FatWords[3],
+                          FatWords[4], FatWords[5], FatWords[6], FatWords[7]);
+                }
+            }
+
+            if (Source->MemoryBase)
+            {
+                PFN_NUMBER SourceBasePfn = RamDiskPointerToPfn(Source->MemoryBase);
+                TRACE("  source: base=%p size=%llu basePFN=%lx\n",
+                      Source->MemoryBase,
+                      Source->Size,
+                      SourceBasePfn);
+                RamDiskTraceSample("  source[0]", Source->MemoryBase);
+            }
+        }
+#endif
+    }
+
+    *NewBase = WritableBase;
+    *NewSize = WritableSize;
+    TRACE("RamDiskBuildWritableImage: writable ramdisk ready at %p (%llu bytes)\n",
+          WritableBase,
+          WritableSize);
+    return TRUE;
+}
+
+static
+ULONGLONG
+RamDiskParseSizeString(
+    PCSTR ValueString,
+    ULONG ValueLength)
+{
+    ULONGLONG Value = 0;
+    ULONGLONG Multiplier = 1;
+    BOOLEAN SawDigit = FALSE;
+    ULONG Index = 0;
+
+    if (!ValueString || ValueLength == 0)
+        return 0;
+
+    /* Skip leading whitespace */
+    while (Index < ValueLength && isspace((unsigned char)ValueString[Index]))
+        ++Index;
+
+    /* Parse the numeric component */
+    while (Index < ValueLength && isdigit((unsigned char)ValueString[Index]))
+    {
+        int Digit = ValueString[Index] - '0';
+
+        if (Value > (ULLONG_MAX - Digit) / 10ULL)
+            return 0;
+
+        Value = Value * 10ULL + (ULONGLONG)Digit;
+        SawDigit = TRUE;
+        ++Index;
+    }
+
+    if (!SawDigit)
+        return 0;
+
+    /* Skip any whitespace between the number and the optional suffix */
+    while (Index < ValueLength && isspace((unsigned char)ValueString[Index]))
+        ++Index;
+
+    if (Index < ValueLength)
+    {
+        char Suffix = (char)toupper((unsigned char)ValueString[Index]);
+
+        switch (Suffix)
+        {
+            case 'B':
+                Multiplier = 1ULL;
+                ++Index;
+                break;
+
+            case 'K':
+                Multiplier = 1024ULL;
+                ++Index;
+                break;
+
+            case 'M':
+                Multiplier = 1024ULL * 1024ULL;
+                ++Index;
+                break;
+
+            case 'G':
+                Multiplier = 1024ULL * 1024ULL * 1024ULL;
+                ++Index;
+                break;
+
+            case 'T':
+                Multiplier = 1024ULL * 1024ULL * 1024ULL * 1024ULL;
+                ++Index;
+                break;
+
+            default:
+                return 0;
+        }
+
+        /* Optional trailing 'B' (e.g. "MB", "GiB") */
+        if (Index < ValueLength)
+        {
+            char SecondSuffix = (char)toupper((unsigned char)ValueString[Index]);
+
+            if (SecondSuffix == 'I')
+            {
+                /* Accept IEC-style suffixes like MiB/GiB */
+                ++Index;
+                if (Index < ValueLength)
+                {
+                    SecondSuffix = (char)toupper((unsigned char)ValueString[Index]);
+                }
+                else
+                {
+                    SecondSuffix = '\0';
+                }
+            }
+
+            if (SecondSuffix == 'B')
+            {
+                ++Index;
+            }
+        }
+
+        while (Index < ValueLength && isspace((unsigned char)ValueString[Index]))
+            ++Index;
+
+        /* Reject unknown trailing characters */
+        if (Index < ValueLength)
+            return 0;
+
+        if (Multiplier != 1ULL && Value > ULLONG_MAX / Multiplier)
+            return 0;
+
+        Value *= Multiplier;
+    }
+
+    return Value;
+}
+
+ULONGLONG
+RamDiskGetRequestedSize(VOID)
+{
+    return RamDiskRequestedSize;
+}
+
+ULONGLONG
+RamDiskGetImageLength(VOID)
+{
+    return RamDiskImageLength;
+}
+
+ULONG
+RamDiskGetImageOffset(VOID)
+{
+    return RamDiskImageOffset;
+}
+
+ULONGLONG
+RamDiskGetVolumeOffset(VOID)
+{
+    return RamDiskVolumeOffset;
+}
+
+static
+BOOLEAN
+RamDiskReserveWritableBuffer(ULONGLONG RequestedSize, BOOLEAN OptionalRamDisk)
+{
+    ULONGLONG AllocationSize;
+    PVOID Base;
+    ULONGLONG AllocationLimit;
+
+    if (RequestedSize == 0)
+        return FALSE;
+
+    AllocationSize = ALIGN_UP_BY_ULL(RequestedSize, RAMDISK_ALLOCATION_ALIGNMENT);
+    if (AllocationSize == 0 || AllocationSize < RequestedSize)
+        return FALSE;
+
+    AllocationLimit = RamDiskWritableAllocationLimit();
+
+    if (AllocationSize > AllocationLimit)
+    {
+        WARN("Requested ramdisk buffer %llu bytes exceeds low-memory limit %llu bytes\n",
+             AllocationSize,
+             AllocationLimit);
+        if (!RamDiskErrorShown && !OptionalRamDisk)
+        {
+            UiMessageBox("Requested writable RAM disk size exceeds available low memory.");
+            RamDiskErrorShown = TRUE;
+        }
+        return FALSE;
+    }
+
+    if (RamDiskWritableBase &&
+        RamDiskWritableSize >= AllocationSize &&
+        ((ULONGLONG)(ULONG_PTR)RamDiskWritableBase + AllocationSize) <= AllocationLimit)
+        return TRUE;
+
+    if (RamDiskWritableBase)
+    {
+        MmFreeMemory(RamDiskWritableBase);
+        RamDiskWritableBase = NULL;
+        RamDiskWritableSize = 0;
+    }
+
+    if ((ULONGLONG)(SIZE_T)AllocationSize != AllocationSize)
+    {
+        WARN("Requested ramdisk size (%llu) exceeds allocator limits\n", AllocationSize);
+        return FALSE;
+    }
+
+    /*
+     * Allocate ramdisk memory as LoaderXIPRom.
+     *
+     * Using LoaderXIPRom ensures the ramdisk descriptor is uniquely identifiable
+     * by the kernel's IopStartRamdisk function. Other allocations use LoaderMemoryData,
+     * which can cause descriptor coalescing and misidentification when adjacent
+     * LoaderMemoryData regions exist.
+     *
+     * The kernel's memory manager will mark LoaderXIPRom pages as ROM, preventing
+     * reclamation.
+     */
+    Base = MmAllocateHighestMemoryBelowAddress((SIZE_T)AllocationSize,
+                                               (PVOID)(ULONG_PTR)AllocationLimit,
+                                               LoaderXIPRom);
+    if (!Base)
+    {
+        WARN("Failed to reserve writable ramdisk buffer (%llu bytes)\n", AllocationSize);
+        if (!RamDiskErrorShown && !OptionalRamDisk)
+        {
+            UiMessageBox("Unable to allocate low-memory buffer for writable RAM disk.");
+            RamDiskErrorShown = TRUE;
+        }
+        return FALSE;
+    }
+
+    if (((ULONGLONG)(ULONG_PTR)Base + AllocationSize) > AllocationLimit)
+    {
+        WARN("Writable ramdisk buffer %p-%p exceeds limit %p\n",
+             Base,
+             (PVOID)(ULONG_PTR)((ULONG_PTR)Base + (ULONG_PTR)AllocationSize),
+             (PVOID)(ULONG_PTR)AllocationLimit);
+        MmFreeMemory(Base);
+        if (!RamDiskErrorShown && !OptionalRamDisk)
+        {
+            UiMessageBox("Unable to allocate low-memory buffer for writable RAM disk.");
+            RamDiskErrorShown = TRUE;
+        }
+        return FALSE;
+    }
+
+    RamDiskWritableBase = Base;
+    RamDiskWritableSize = AllocationSize;
+    TRACE("Reserved writable ramdisk buffer at %p (%llu bytes)\n", Base, AllocationSize);
+    return TRUE;
+}
+
+BOOLEAN
+RamDiskGetReservedBuffer(
+    IN ULONGLONG MinimumSize,
+    OUT PVOID *BaseAddress,
+    OUT PULONGLONG ActualSize)
+{
+    if (!BaseAddress || !ActualSize)
+        return FALSE;
+
+    if (RamDiskWritableBase && RamDiskWritableSize >= MinimumSize)
+    {
+        *BaseAddress = RamDiskWritableBase;
+        *ActualSize = RamDiskWritableSize;
+
+        RamDiskWritableBase = NULL;
+        RamDiskWritableSize = 0;
+        return TRUE;
+    }
+
+    return FALSE;
+}
+
+/*
+ * RamDiskGetBackingStore - Get ramdisk backing store information for kernel.
+ *
+ * Returns the base page and page count of the ramdisk backing store.
+ * This information is used by the kernel's memory manager to mark these
+ * pages as non-reclaimable (ROM) in the PFN database.
+ */
+BOOLEAN
+RamDiskGetBackingStore(
+    OUT PFN_NUMBER *BasePage,
+    OUT PFN_NUMBER *PageCount)
+{
+    ULONGLONG TotalSize;
+    PFN_NUMBER Pages;
+
+    if (!BasePage || !PageCount)
+        return FALSE;
+
+    /* Check if ramdisk is active */
+    if (!RamDiskBase || RamDiskFileSize == 0)
+    {
+        *BasePage = 0;
+        *PageCount = 0;
+        return FALSE;
+    }
+
+    /* Calculate the base page and page count */
+    *BasePage = (PFN_NUMBER)((ULONG_PTR)RamDiskBase >> PAGE_SHIFT);
+
+    /* Calculate total size including image offset for proper page coverage */
+    TotalSize = RamDiskFileSize;
+    Pages = (PFN_NUMBER)((TotalSize + PAGE_SIZE - 1) >> PAGE_SHIFT);
+    *PageCount = Pages;
+
+    TRACE("RamDiskGetBackingStore: Base=%p BasePage=%lu PageCount=%lu Size=%llu\n",
+          RamDiskBase, (ULONG)*BasePage, (ULONG)*PageCount, TotalSize);
+
+    return TRUE;
+}
 
 /* FUNCTIONS ******************************************************************/
+
+static ULONGLONG RamDiskGetVisibleLength(VOID)
+{
+    return (RamDiskVolumeLength != 0)
+           ? RamDiskVolumeLength
+           : (RamDiskImageLength > RamDiskVolumeOffset)
+               ? RamDiskImageLength - RamDiskVolumeOffset
+               : 0;
+}
 
 static ARC_STATUS RamDiskClose(ULONG FileId)
 {
@@ -37,10 +1848,13 @@ static ARC_STATUS RamDiskClose(ULONG FileId)
 
 static ARC_STATUS RamDiskGetFileInformation(ULONG FileId, FILEINFORMATION* Information)
 {
+    ULONGLONG VisibleLength;
+
     RtlZeroMemory(Information, sizeof(*Information));
-    Information->EndingAddress.QuadPart = RamDiskImageLength;
+    VisibleLength = RamDiskGetVisibleLength();
+
+    Information->EndingAddress.QuadPart = VisibleLength;
     Information->CurrentAddress.QuadPart = RamDiskOffset;
-    Information->Type = DiskPeripheral;
 
     return ESUCCESS;
 }
@@ -54,17 +1868,32 @@ static ARC_STATUS RamDiskOpen(CHAR* Path, OPENMODE OpenMode, ULONG* FileId)
 static ARC_STATUS RamDiskRead(ULONG FileId, VOID* Buffer, ULONG N, ULONG* Count)
 {
     PVOID StartAddress;
+    ULONGLONG VisibleLength;
 
     /* Don't allow reads past our image */
-    if (RamDiskOffset >= RamDiskImageLength || RamDiskOffset + N > RamDiskImageLength)
+    VisibleLength = RamDiskGetVisibleLength();
+
+    if ((RamDiskOffset >= VisibleLength) || (RamDiskOffset + N > VisibleLength))
     {
         *Count = 0;
         return EIO;
     }
-    // N = min(N, RamdiskImageLength - RamDiskOffset);
 
-    /* Get actual pointer */
-    StartAddress = (PVOID)((ULONG_PTR)RamDiskBase + RamDiskImageOffset + (ULONG_PTR)RamDiskOffset);
+    /* Get actual pointer without truncating offsets on 32-bit builds. */
+    {
+        ULONGLONG TotalOffset = RamDiskVolumeOffset + RamDiskOffset;
+        ULONG_PTR BaseAddress = (ULONG_PTR)RamDiskBase;
+        ULONGLONG MaxOffset = ((ULONGLONG)~(ULONG_PTR)0);
+
+        if (TotalOffset > (MaxOffset - (ULONGLONG)BaseAddress))
+        {
+            WARN("RamDiskRead: offset overflow (total=%I64u base=%p)\n", TotalOffset, RamDiskBase);
+            *Count = 0;
+            return EIO;
+        }
+
+        StartAddress = (PVOID)(BaseAddress + (ULONG_PTR)TotalOffset);
+    }
 
     /* Do the read */
     RtlCopyMemory(Buffer, StartAddress, N);
@@ -77,6 +1906,7 @@ static ARC_STATUS RamDiskRead(ULONG FileId, VOID* Buffer, ULONG N, ULONG* Count)
 static ARC_STATUS RamDiskSeek(ULONG FileId, LARGE_INTEGER* Position, SEEKMODE SeekMode)
 {
     LARGE_INTEGER NewPosition = *Position;
+    ULONGLONG VisibleLength;
 
     switch (SeekMode)
     {
@@ -90,7 +1920,12 @@ static ARC_STATUS RamDiskSeek(ULONG FileId, LARGE_INTEGER* Position, SEEKMODE Se
             return EINVAL;
     }
 
-    if (NewPosition.QuadPart >= RamDiskImageLength)
+    if (NewPosition.QuadPart < 0)
+        return EINVAL;
+
+    VisibleLength = RamDiskGetVisibleLength();
+
+    if ((ULONGLONG)NewPosition.QuadPart > VisibleLength)
         return EINVAL;
 
     RamDiskOffset = NewPosition.QuadPart;
@@ -109,120 +1944,217 @@ static const DEVVTBL RamDiskVtbl =
 static ARC_STATUS
 RamDiskLoadVirtualFile(
     IN PCSTR FileName,
-    IN PCSTR DefaultPath OPTIONAL)
+    IN PCSTR DefaultPath OPTIONAL,
+    IN BOOLEAN OptionalRamDisk)
 {
     ARC_STATUS Status;
     ULONG RamFileId;
     ULONG ChunkSize, Count;
     ULONGLONG TotalRead;
-    ULONG PercentPerChunk, Percent;
+    ULONG LastPercent;
     FILEINFORMATION Information;
     LARGE_INTEGER Position;
 
     /* Display progress */
     UiDrawProgressBarCenter("Loading RamDisk...");
 
+    /*
+     * If the firmware or a previous boot stage already provided the ramdisk
+     * image in memory, skip the expensive readback and reuse the cached data.
+     */
+    if (gInitRamDiskBase && gInitRamDiskSize != 0)
+    {
+        BOOLEAN UseResidentImage = FALSE;
+        ULONGLONG ResidentSize = (ULONGLONG)gInitRamDiskSize;
+
+        if ((ULONGLONG)RamDiskImageOffset < ResidentSize)
+        {
+            ULONGLONG Available = ResidentSize - (ULONGLONG)RamDiskImageOffset;
+            ULONGLONG Required = (RamDiskImageLength != 0)
+                                  ? RamDiskImageLength
+                                  : Available;
+
+            if (Required <= Available)
+                UseResidentImage = TRUE;
+            else
+                WARN("RamDiskLoadVirtualFile: resident image too small (offset=%lu required=%llu available=%llu)\n",
+                     (ULONG)RamDiskImageOffset,
+                     Required,
+                     Available);
+        }
+
+        if (UseResidentImage)
+        {
+            RamDiskBase = gInitRamDiskBase;
+            RamDiskFileSize = ResidentSize;
+            RamDiskImageOffset = 0;
+            RamDiskImageLength = RamDiskFileSize;
+            RamDiskResetVisibleRegion();
+            UiUpdateProgressBar(100, NULL);
+            TRACE("RamDiskLoadVirtualFile: using resident ramdisk image (%llu bytes)\n",
+                  ResidentSize);
+            return ESUCCESS;
+        }
+    }
+
     /* Try opening the Ramdisk file */
-    TRACE("RamDiskLoadVirtualFile: Opening '%s', '%s'\n",
-          FileName, DefaultPath ? DefaultPath : "n/a");
     Status = FsOpenFile(FileName, DefaultPath, OpenReadOnly, &RamFileId);
     if (Status != ESUCCESS)
         return Status;
 
-    /* Get the file or device size */
+    /* Get the file size */
     Status = ArcGetFileInformation(RamFileId, &Information);
     if (Status != ESUCCESS)
     {
         ArcClose(RamFileId);
         return Status;
     }
-    /* NOTE: For partitions, StartingAddress/EndingAddress are the start/end
-     * positions of the partition as byte offsets from the start of the disk */
-    Information.EndingAddress.QuadPart -= Information.StartingAddress.QuadPart;
-    Information.StartingAddress.QuadPart = 0ULL;
 
-    /* If we are actually opening a RAW device, retrieve instead its usable volume size */
-    if (Information.FileNameLength == 0 && Information.FileName[0] == ANSI_NULL &&
-        (Information.Type == DiskPeripheral || Information.Type == FloppyDiskPeripheral))
-    {
-        ULONGLONG VolumeSize;
-        Status = FsGetVolumeSize(RamFileId, &VolumeSize);
-        if (Status != ESUCCESS)
-            ERR("Couldn't retrieve volume size on device '%s', falling back to RAW size\n", FileName);
-        else
-            Information.EndingAddress.QuadPart = VolumeSize;
-    }
-
-    TRACE("RAMDISK size: %I64u (High: %lu ; Low: %lu)\n",
-          Information.EndingAddress.QuadPart,
-          Information.EndingAddress.HighPart,
-          Information.EndingAddress.LowPart);
-
-    /* FIXME: For now, limit RAM disks to 4GB */
-    if (Information.EndingAddress.HighPart != 0) // (RamDiskFileSize >= 0x100000000ULL)
+    /* Enforce the legacy 4GB limit on 32-bit builds */
+#if !defined(_M_AMD64) && !defined(__x86_64__)
+    if (Information.EndingAddress.HighPart != 0)
     {
         ArcClose(RamFileId);
-        UiMessageBox("RAM disk too big.");
+        if (!OptionalRamDisk)
+            UiMessageBox("RAM disk too big.");
         return ENOMEM;
     }
+#endif
+
     RamDiskFileSize = Information.EndingAddress.QuadPart;
+#if !defined(_M_AMD64) && !defined(__x86_64__)
+    ASSERT(RamDiskFileSize < 0x100000000); // Legacy limit on 32-bit builds.
+#endif
 
     /* Allocate memory for it */
     ChunkSize = 8 * 1024 * 1024;
-    if (RamDiskFileSize < ChunkSize)
-        PercentPerChunk = 0;
-    else
-        PercentPerChunk = 100 * ChunkSize / RamDiskFileSize;
+    if (DiskReadBufferSize != 0 && DiskReadBufferSize <= ULONG_MAX)
+    {
+        ULONG PreferredChunk = (ULONG)DiskReadBufferSize;
+        if (PreferredChunk > ChunkSize)
+            ChunkSize = PreferredChunk;
+    }
+
+    if (RamDiskFileSize < ChunkSize && RamDiskFileSize <= ULONG_MAX)
+        ChunkSize = (ULONG)RamDiskFileSize;
+
+    ChunkSize &= ~(ISO_SECTOR_SIZE - 1);
+    if (ChunkSize == 0)
+        ChunkSize = ISO_SECTOR_SIZE;
+
+#if defined(_M_AMD64) || defined(__x86_64__)
+    /* Use LoaderXIPRom for unique identification by IopStartRamdisk */
     RamDiskBase = MmAllocateMemoryWithType(RamDiskFileSize, LoaderXIPRom);
     if (!RamDiskBase)
     {
         RamDiskFileSize = 0;
         ArcClose(RamFileId);
-        UiMessageBox("Failed to allocate memory for RAM disk.");
+        if (!OptionalRamDisk)
+            UiMessageBox("Failed to allocate memory for RAM disk.");
         return ENOMEM;
     }
+#else
+    {
+        ULONGLONG AllocationLimit = RamDiskWritableAllocationLimit();
 
-    /*
-     * Read it in chunks, starting at the beginning
-     */
+        if (RamDiskFileSize > AllocationLimit)
+        {
+            RamDiskFileSize = 0;
+            ArcClose(RamFileId);
+            if (!OptionalRamDisk)
+                UiMessageBox("RAM disk image is larger than available low memory.");
+            return ENOMEM;
+        }
+
+        /* Use LoaderXIPRom for unique identification by IopStartRamdisk */
+        RamDiskBase = MmAllocateHighestMemoryBelowAddress((SIZE_T)RamDiskFileSize,
+                                                          (PVOID)(ULONG_PTR)AllocationLimit,
+                                                          LoaderXIPRom);
+        if (!RamDiskBase)
+        {
+            RamDiskFileSize = 0;
+            ArcClose(RamFileId);
+            if (!OptionalRamDisk)
+                UiMessageBox("Failed to allocate low memory for RAM disk.");
+            return ENOMEM;
+        }
+    }
+#endif
+
     Position.QuadPart = 0;
     Status = ArcSeek(RamFileId, &Position, SeekAbsolute);
     if (Status != ESUCCESS)
-        goto ReadFailure;
-
-    for (TotalRead = 0, Percent = 0;
-         TotalRead < RamDiskFileSize;
-         TotalRead += ChunkSize, Percent += PercentPerChunk)
     {
-        /* If we are at the last chunk, read only what's remaining */
-        if ((RamDiskFileSize - TotalRead) < ChunkSize)
-            ChunkSize = (ULONG)(RamDiskFileSize - TotalRead);
+        MmFreeMemory(RamDiskBase);
+        RamDiskBase = NULL;
+        RamDiskFileSize = 0;
+        ArcClose(RamFileId);
+        if (!OptionalRamDisk)
+            UiMessageBox("Failed to read RAM disk.");
+        return Status;
+    }
 
-        /* Update progress */
-        UiUpdateProgressBar(Percent, NULL);
+    /*
+     * Read it in chunks
+     */
+    LastPercent = 0;
+    for (TotalRead = 0; TotalRead < RamDiskFileSize; )
+    {
+        ULONG CurrentChunk = ChunkSize;
 
-        /* Copy the data */
+        /* Check if we're at the last chunk */
+        if ((RamDiskFileSize - TotalRead) < CurrentChunk)
+        {
+            /* Only need the actual data required */
+            CurrentChunk = (ULONG)(RamDiskFileSize - TotalRead);
+        }
+
+        if (CurrentChunk == 0)
+            break;
+
+        /* Update progress no more than once per percent change */
+        if (RamDiskFileSize != 0)
+        {
+            ULONGLONG Completed = TotalRead + CurrentChunk;
+            ULONG NewPercent = (ULONG)((Completed * 100ULL) / RamDiskFileSize);
+            if (NewPercent > 100)
+                NewPercent = 100;
+
+            if ((NewPercent >= LastPercent + 1) ||
+                (NewPercent == 100 && NewPercent != LastPercent))
+            {
+                UiUpdateProgressBar(NewPercent, NULL);
+                LastPercent = NewPercent;
+            }
+        }
+
+        /* Copy the contents */
         Status = ArcRead(RamFileId,
                          (PVOID)((ULONG_PTR)RamDiskBase + (ULONG_PTR)TotalRead),
-                         ChunkSize,
+                         CurrentChunk,
                          &Count);
-        if ((Status != ESUCCESS) || (Count != ChunkSize))
-        {
-            Status = ((Status != ESUCCESS) ? Status : EIO);
-            goto ReadFailure;
-        }
-    }
-    UiUpdateProgressBar(100, NULL);
-    ArcClose(RamFileId);
-    return ESUCCESS;
 
-ReadFailure:
-    MmFreeMemory(RamDiskBase);
-    RamDiskBase = NULL;
-    RamDiskFileSize = 0;
+        /* Check for success */
+        if ((Status != ESUCCESS) || (Count != CurrentChunk))
+        {
+            MmFreeMemory(RamDiskBase);
+            RamDiskBase = NULL;
+            RamDiskFileSize = 0;
+            ArcClose(RamFileId);
+            if (!OptionalRamDisk)
+                UiMessageBox("Failed to read RAM disk.");
+            return ((Status != ESUCCESS) ? Status : EIO);
+        }
+
+        TotalRead += CurrentChunk;
+    }
+
+    if (LastPercent < 100)
+        UiUpdateProgressBar(100, NULL);
+
     ArcClose(RamFileId);
-    UiMessageBox("Failed to read RAM disk.");
-    return Status;
+
+    return ESUCCESS;
 }
 
 ARC_STATUS
@@ -231,15 +2163,12 @@ RamDiskInitialize(
     IN PCSTR LoadOptions OPTIONAL,
     IN PCSTR DefaultPath OPTIONAL)
 {
-    TRACE("RamDiskInitialize(%s, '%s', '%s')\n",
-          InitRamDisk ? "INIT" : "REGULAR",
-          LoadOptions ? LoadOptions : "n/a",
-          DefaultPath ? DefaultPath : "n/a");
+    RamDiskErrorShown = FALSE;
+
+    TRACE("RamDiskInitialize: Begin (Init=%s)\n", InitRamDisk ? "true" : "false");
 
     /* Reset the RAMDISK device */
-    if ((RamDiskBase != gInitRamDiskBase) &&
-        (RamDiskFileSize != gInitRamDiskSize) &&
-        (gInitRamDiskSize != 0))
+    if (RamDiskBase && RamDiskBase != gInitRamDiskBase)
     {
         /* This is not the initial Ramdisk, so we can free the allocated memory */
         MmFreeMemory(RamDiskBase);
@@ -249,6 +2178,9 @@ RamDiskInitialize(
     RamDiskImageLength = 0;
     RamDiskImageOffset = 0;
     RamDiskOffset = 0;
+    RamDiskRequestedSize = 0;
+    RamDiskVolumeOffset = 0;
+    RamDiskVolumeLength = 0;
 
     if (InitRamDisk)
     {
@@ -261,18 +2193,54 @@ RamDiskInitialize(
         RamDiskBase = gInitRamDiskBase;
         RamDiskFileSize = gInitRamDiskSize;
         ASSERT(RamDiskFileSize < 0x100000000); // See FIXME about 4GB support in RamDiskLoadVirtualFile().
+
+        if ((ULONGLONG)RamDiskImageOffset >= RamDiskFileSize)
+            RamDiskImageOffset = 0;
+
+        if (RamDiskImageLength == 0 ||
+            RamDiskImageLength > RamDiskFileSize - RamDiskImageOffset)
+        {
+            RamDiskImageLength = RamDiskFileSize - RamDiskImageOffset;
+        }
+
+        RamDiskResetVisibleRegion();
     }
     else
     {
         /* We initialize the Ramdisk from the load options */
         ARC_STATUS Status;
         CHAR FileName[MAX_PATH] = "";
+        PVOID OriginalBase;
+        BOOLEAN StreamingSucceeded = FALSE;
+        ULONGLONG StreamIsoSize = 0;
+        BOOLEAN OptionalRamDisk;
 
         /* If we don't have any load options, initialize an empty Ramdisk */
         if (LoadOptions)
         {
             PCSTR Option;
             ULONG FileNameLength;
+            ULONG OptionLength;
+
+            Option = NtLdrGetOptionEx(LoadOptions, "RDRAMSIZE=", &OptionLength);
+            if (Option && OptionLength > (sizeof("RDRAMSIZE=") - 1))
+            {
+                ULONGLONG ParsedSize;
+
+                ParsedSize = RamDiskParseSizeString(
+                                Option + (sizeof("RDRAMSIZE=") - 1),
+                                OptionLength - (sizeof("RDRAMSIZE=") - 1));
+                if (ParsedSize != 0)
+                {
+                    RamDiskRequestedSize = ParsedSize;
+                    TRACE("Requested writable ramdisk size: %llu bytes\n",
+                          RamDiskRequestedSize);
+                }
+                else
+                {
+                    WARN("Ignoring invalid RDRAMSIZE option value\n");
+                }
+            }
 
             /* Ramdisk image file name */
             Option = NtLdrGetOptionEx(LoadOptions, "RDPATH=", &FileNameLength);
@@ -299,17 +2267,265 @@ RamDiskInitialize(
             }
         }
 
+        OptionalRamDisk = (RamDiskRequestedSize != 0 && !*FileName);
+
+        if (RamDiskRequestedSize != 0)
+        {
+            ISO_SOURCE StreamSource;
+            PVOID WritableBase;
+            ULONGLONG WritableSize;
+            ARC_STATUS StreamStatus;
+            PCSTR StreamFileName = NULL;
+            PCSTR StreamDefaultPath = NULL;
+
+            if (*FileName)
+            {
+                StreamFileName = FileName;
+                StreamDefaultPath = DefaultPath;
+            }
+            else if (DefaultPath)
+            {
+                StreamFileName = DefaultPath;
+                StreamDefaultPath = NULL;
+            }
+
+            if (StreamFileName)
+            {
+                StreamStatus = RamDiskOpenIsoSource(StreamFileName,
+                                                    StreamDefaultPath,
+                                                    RamDiskImageOffset,
+                                                    RamDiskImageLength,
+                                                    &StreamSource);
+                if (StreamStatus != ESUCCESS)
+                {
+                    /* BIOS/legacy fallback: if opening by file/path failed (e.g. DefaultPath
+                     * is 'ramdisk(0)' or not a real ISO path), try raw firmware CD devices. */
+                    static const PCSTR CdCandidates[] = { "cdrom(0)", "cdrom(1)", NULL };
+                    ULONG i;
+                    for (i = 0; CdCandidates[i]; ++i)
+                    {
+                        StreamStatus = RamDiskOpenIsoSource(CdCandidates[i],
+                                                            NULL,
+                                                            0, /* ISO starts at LBA 0 */
+                                                            0,
+                                                            &StreamSource);
+                        if (StreamStatus == ESUCCESS)
+                            break;
+                    }
+                }
+
+                if (StreamStatus == ESUCCESS)
+                {
+                    StreamIsoSize = StreamSource.Size;
+                    {
+                        ULONGLONG ExtraBytes = RamDiskRequestedSize;
+                        if (ExtraBytes < RAMDISK_MINIMUM_EXTRA_SPACE)
+                            ExtraBytes = RAMDISK_MINIMUM_EXTRA_SPACE;
+                        ULONGLONG TotalTarget = StreamIsoSize + ExtraBytes;
+
+                        if (RamDiskBuildWritableImage(&StreamSource,
+                                                       TotalTarget,
+                                                       &WritableBase,
+                                                       &WritableSize,
+                                                       OptionalRamDisk))
+                        {
+                            RamDiskCloseIsoSource(&StreamSource);
+                            RamDiskBase = WritableBase;
+                            RamDiskFileSize = WritableSize;
+                            RamDiskImageOffset = 0;
+                            RamDiskImageLength = WritableSize;
+                            StreamingSucceeded = TRUE;
+                            TRACE("RamDiskInitialize: writable ramdisk ready from streaming (%llu bytes, ISO=%llu extra=%llu)\n",
+                                  RamDiskFileSize, StreamIsoSize, ExtraBytes);
+                        }
+                        else
+                        {
+                            /* Try to adaptively shrink the extra overlay to fit the low-memory budget. */
+                            ULONGLONG AllocationLimit = RamDiskWritableAllocationLimit();
+                            ULONGLONG MaxExtra = (AllocationLimit > StreamIsoSize)
+                                                   ? (AllocationLimit - StreamIsoSize)
+                                                   : 0;
+                            if (MaxExtra >= RAMDISK_MINIMUM_EXTRA_SPACE && MaxExtra < ExtraBytes)
+                            {
+                                ULONGLONG ShrunkTotal = StreamIsoSize + MaxExtra;
+                                TRACE("RamDiskInitialize: streaming expansion failed; retrying with shrunk extra %llu (total %llu)\n",
+                                      MaxExtra, ShrunkTotal);
+
+                                if (RamDiskBuildWritableImage(&StreamSource,
+                                                               ShrunkTotal,
+                                                               &WritableBase,
+                                                               &WritableSize,
+                                                               OptionalRamDisk))
+                                {
+                                    RamDiskCloseIsoSource(&StreamSource);
+                                    RamDiskBase = WritableBase;
+                                    RamDiskFileSize = WritableSize;
+                                    RamDiskImageOffset = 0;
+                                    RamDiskImageLength = WritableSize;
+                                    /* Record the effective requested size so boot path gets retargeted. */
+                                    RamDiskRequestedSize = MaxExtra;
+                                    StreamingSucceeded = TRUE;
+                                    TRACE("RamDiskInitialize: writable ramdisk ready from streaming after shrink (%llu bytes, ISO=%llu extra=%llu)\n",
+                                          RamDiskFileSize, StreamIsoSize, MaxExtra);
+                                }
+                                else
+                                {
+                                    RamDiskCloseIsoSource(&StreamSource);
+                                    TRACE("RamDiskInitialize: streaming expansion failed even after shrink; falling back to in-memory copy\n");
+                                }
+                            }
+                            else
+                            {
+                                RamDiskCloseIsoSource(&StreamSource);
+                                TRACE("RamDiskInitialize: streaming writable expansion failed, falling back to in-memory copy\n");
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (StreamingSucceeded)
+                goto WritableReady;
+
+            if (RamDiskRequestedSize != 0 && StreamIsoSize != 0)
+            {
+                ULONGLONG IsoSize = StreamIsoSize;
+                ULONGLONG ResidentIsoBytes;
+                ULONGLONG AllocationLimit = RamDiskWritableAllocationLimit();
+                ULONGLONG ExtraBytes = RamDiskRequestedSize;
+                ULONGLONG RequiredSize;
+
+                /* New semantics: RDRAMSIZE denotes extra writable bytes
+                   beyond the ISO contents. Enforce a minimum of 64 MiB
+                   headroom if the request is smaller. */
+                if (ExtraBytes < RAMDISK_MINIMUM_EXTRA_SPACE)
+                    ExtraBytes = RAMDISK_MINIMUM_EXTRA_SPACE;
+
+                RequiredSize = IsoSize + ExtraBytes;
+
+                if (RequiredSize > AllocationLimit)
+                {
+                    WARN("RamDiskInitialize: writable overlay request (%llu) exceeds low-memory limit before staging ISO (%llu)\n",
+                         RequiredSize,
+                         (ULONGLONG)RAMDISK_LOW_ALLOC_MAX);
+                    if (!RamDiskErrorShown && !OptionalRamDisk)
+                    {
+                        UiMessageBox("Writable RAM disk request exceeds available low memory. Continuing with read-only media.");
+                        RamDiskErrorShown = TRUE;
+                    }
+                    RamDiskRequestedSize = 0;
+                }
+                else
+                {
+                    ResidentIsoBytes = ALIGN_UP_BY_ULL(IsoSize, RAMDISK_ALLOCATION_ALIGNMENT);
+
+                    if (ResidentIsoBytes > AllocationLimit ||
+                        RequiredSize > AllocationLimit - ResidentIsoBytes)
+                    {
+                        WARN("RamDiskInitialize: ISO (%llu) + writable extra (%llu) would exceed low-memory budget %llu\n",
+                             IsoSize,
+                             ExtraBytes,
+                             (ULONGLONG)RAMDISK_LOW_ALLOC_MAX);
+                        if (!RamDiskErrorShown && !OptionalRamDisk)
+                        {
+                            UiMessageBox("Writable RAM disk request leaves insufficient low memory once the ISO is cached. Continuing with read-only media.");
+                            RamDiskErrorShown = TRUE;
+                        }
+                        RamDiskRequestedSize = 0;
+                    }
+                }
+            }
+        }
+
         if (*FileName)
-            Status = RamDiskLoadVirtualFile(FileName, DefaultPath);
+            Status = RamDiskLoadVirtualFile(FileName, DefaultPath, OptionalRamDisk);
         else
-            Status = RamDiskLoadVirtualFile(DefaultPath, NULL);
+            Status = RamDiskLoadVirtualFile(DefaultPath, NULL, OptionalRamDisk);
         if (Status != ESUCCESS)
             return Status;
+
+        OriginalBase = RamDiskBase;
+        if (RamDiskRequestedSize != 0)
+        {
+            PVOID WritableBase;
+            ULONGLONG WritableSize;
+            PVOID IsoImageBase;
+            ULONGLONG IsoImageLength;
+            ISO_SOURCE MemorySource;
+            ULONGLONG ExtraBytes;
+            ULONGLONG TotalTarget;
+
+            TRACE("RamDiskInitialize: expanding to writable RAMFS (extra %llu bytes requested)\n",
+                  RamDiskRequestedSize);
+
+            IsoImageBase = (PVOID)((ULONG_PTR)OriginalBase + RamDiskImageOffset);
+            IsoImageLength = RamDiskFileSize - RamDiskImageOffset;
+
+            MemorySource.MemoryBase = IsoImageBase;
+            MemorySource.Size = (RamDiskImageLength != 0 &&
+                                 RamDiskImageLength <= IsoImageLength)
+                                ? RamDiskImageLength
+                                : IsoImageLength;
+            MemorySource.ArcFileId = INVALID_FILE_ID;
+            MemorySource.ArcOffset = 0;
+            MemorySource.ArcPosition = 0;
+
+            /* New semantics: total target = ISO length + extra (>=64MiB) */
+            ExtraBytes = RamDiskRequestedSize;
+            if (ExtraBytes < RAMDISK_MINIMUM_EXTRA_SPACE)
+                ExtraBytes = RAMDISK_MINIMUM_EXTRA_SPACE;
+            TotalTarget = MemorySource.Size + ExtraBytes;
+
+            if (!RamDiskBuildWritableImage(&MemorySource,
+                                           TotalTarget,
+                                           &WritableBase,
+                                           &WritableSize,
+                                           OptionalRamDisk))
+            {
+                if (!RamDiskErrorShown && !OptionalRamDisk)
+                {
+                    UiMessageBox("Failed to expand LiveCD into writable RAM.");
+                    RamDiskErrorShown = TRUE;
+                }
+                RamDiskRequestedSize = 0;
+                TRACE("RamDiskInitialize: continuing with read-only ISO because writable buffer allocation failed\n");
+                RamDiskBase = OriginalBase;
+                RamDiskVolumeOffset = 0;
+                RamDiskVolumeLength = 0;
+                goto WritableFallback;
+            }
+
+            if ((OriginalBase != gInitRamDiskBase) &&
+                (OriginalBase != WritableBase))
+            {
+                MmFreeMemory(OriginalBase);
+            }
+
+            RamDiskBase = WritableBase;
+            RamDiskFileSize = WritableSize;
+            RamDiskImageOffset = 0;
+            RamDiskImageLength = WritableSize;
+            TRACE("RamDiskInitialize: writable ramdisk ready (%llu bytes)\n",
+                  RamDiskFileSize);
+        }
     }
 
+WritableReady:
     /* Adjust the Ramdisk image length if needed */
     if (!RamDiskImageLength || (RamDiskImageLength > RamDiskFileSize - RamDiskImageOffset))
         RamDiskImageLength = RamDiskFileSize - RamDiskImageOffset;
+
+WritableFallback:
+
+    /* Ensure a fresh filesystem mount the next time ramdisk(0) is accessed. */
+    if (RamDiskVolumeLength == 0)
+    {
+        RamDiskResetVisibleRegion();
+    }
+    /* Changing the exposed LBA window invalidates any cached FAT mount state. */
+    RamDiskInvalidateFatCache();
+
+    RamDiskRegisterArcDevice();
 
     /* Register the RAMDISK device */
     if (!RamDiskDeviceRegistered)
@@ -317,6 +2533,33 @@ RamDiskInitialize(
         FsRegisterDevice("ramdisk(0)", &RamDiskVtbl);
         RamDiskDeviceRegistered = TRUE;
     }
+
+#if DBG
+    if (RamDiskBase && RamDiskFileSize != 0)
+    {
+        PFN_NUMBER BasePfn = RamDiskPointerToPfn(RamDiskBase);
+        PFN_NUMBER EndPfn = RamDiskPointerToPfn((const VOID *)((ULONG_PTR)RamDiskBase + (ULONG_PTR)(RamDiskFileSize - 1)));
+        TRACE("RamDiskInitialize: base=%p size=%llu basePFN=%lx endPFN=%lx imageOffset=%lu imageLength=%llu volumeOffset=%llu volumeLength=%llu requested=%llu\n",
+              RamDiskBase,
+              RamDiskFileSize,
+              BasePfn,
+              EndPfn,
+              RamDiskImageOffset,
+              RamDiskImageLength,
+              RamDiskVolumeOffset,
+              RamDiskVolumeLength,
+              RamDiskRequestedSize);
+        RamDiskTraceSample("  disk[0]", RamDiskBase);
+        if (RamDiskImageOffset < RamDiskFileSize)
+        {
+            RamDiskTraceSample("  disk[image]", (PUCHAR)RamDiskBase + RamDiskImageOffset);
+        }
+        if (RamDiskVolumeOffset < RamDiskFileSize)
+        {
+            RamDiskTraceSample("  disk[volume]", (PUCHAR)RamDiskBase + RamDiskVolumeOffset);
+        }
+    }
+#endif
 
     return ESUCCESS;
 }

--- a/boot/freeldr/freeldr/include/ramdisk.h
+++ b/boot/freeldr/freeldr/include/ramdisk.h
@@ -9,11 +9,65 @@
 
 #pragma once
 
+typedef struct _RAMDISK_FAT32_LAYOUT
+{
+    ULONG BytesPerSector;
+    ULONG SectorsPerCluster;
+    ULONG ReservedSectors;
+    ULONG NumberOfFats;
+    ULONG FatSizeSectors;
+    ULONG FirstDataSector;
+    ULONG RootDirFirstCluster;
+    ULONG TotalSectors;
+    ULONG HiddenSectors;
+    ULONGLONG VolumeSizeBytes;
+} RAMDISK_FAT32_LAYOUT, *PRAMDISK_FAT32_LAYOUT;
+
 ARC_STATUS
 RamDiskInitialize(
     IN BOOLEAN InitRamDisk,
     IN PCSTR LoadOptions OPTIONAL,
     IN PCSTR DefaultPath OPTIONAL);
 
+ULONGLONG
+RamDiskGetRequestedSize(VOID);
+
+BOOLEAN
+RamDiskGetReservedBuffer(IN ULONGLONG MinimumSize,
+                         OUT PVOID *BaseAddress,
+                         OUT PULONGLONG ActualSize);
+
+ULONGLONG
+RamDiskGetImageLength(VOID);
+
+ULONG
+RamDiskGetImageOffset(VOID);
+
+ULONGLONG
+RamDiskGetVolumeOffset(VOID);
+
+BOOLEAN
+RamDiskFormatFat32(IN PVOID BaseAddress,
+                   IN ULONGLONG DiskSize,
+                   OUT PRAMDISK_FAT32_LAYOUT Layout OPTIONAL);
+
 extern PVOID gInitRamDiskBase;
 extern ULONG gInitRamDiskSize;
+
+/*
+ * RamDiskGetBackingStore - Get ramdisk backing store information for kernel.
+ *
+ * Returns the base page and page count of the ramdisk backing store.
+ * This information is used by the kernel's memory manager to mark these
+ * pages as non-reclaimable (ROM) in the PFN database, ensuring the ramdisk
+ * backing store remains stable throughout the system lifetime.
+ *
+ * @param BasePage - Receives the base page frame number of the ramdisk.
+ * @param PageCount - Receives the number of pages in the ramdisk.
+ *
+ * @return TRUE if ramdisk is active and parameters are set, FALSE otherwise.
+ */
+BOOLEAN
+RamDiskGetBackingStore(
+    OUT PFN_NUMBER *BasePage,
+    OUT PFN_NUMBER *PageCount);

--- a/boot/freeldr/freeldr/include/ramdisk_fatwrite.h
+++ b/boot/freeldr/freeldr/include/ramdisk_fatwrite.h
@@ -1,0 +1,60 @@
+/*
+ * PROJECT:     FreeLoader
+ * LICENSE:     BSD - See COPYING.ARM in the top level directory
+ * PURPOSE:     Minimal write-only FAT32 populator for in-memory ramdisks
+ * COPYRIGHT:   Copyright 2025 Ahmed Arif <arif.ing@outlook.com>
+ */
+
+#ifndef _RAMDISK_FATWRITE_H_
+#define _RAMDISK_FATWRITE_H_
+
+#include <ramdisk.h>
+
+typedef struct _FAT32_WRITER
+{
+    PUCHAR VolumeBase;          /* Base pointer of the FAT32 volume (after MBR) */
+    ULONGLONG VolumeSize;       /* Size in bytes */
+
+    /* Geometry (from RAMDISK_FAT32_LAYOUT) */
+    ULONG BytesPerSector;       /* Always 512 */
+    ULONG SectorsPerCluster;
+    ULONG BytesPerCluster;      /* Cached: BytesPerSector * SectorsPerCluster */
+    ULONG ReservedSectors;
+    ULONG NumberOfFats;
+    ULONG FatSizeSectors;
+    ULONG FirstDataSector;      /* ReservedSectors + NumberOfFats * FatSizeSectors */
+    ULONG RootDirCluster;       /* Always 2 */
+    ULONG TotalClusters;
+
+    /* Direct FAT pointers */
+    PULONG Fat0;                /* First FAT table in memory */
+    PULONG Fat1;                /* Second FAT table (NULL if NumberOfFats < 2) */
+
+    /* Sequential allocator state */
+    ULONG NextFreeCluster;      /* Next cluster to allocate (starts at 3) */
+
+    /* Fixed timestamp for all entries */
+    USHORT FatDate;
+    USHORT FatTime;
+} FAT32_WRITER, *PFAT32_WRITER;
+
+BOOLEAN
+Fat32WriterInit(
+    _Out_ PFAT32_WRITER Writer,
+    _In_ PVOID VolumeBase,
+    _In_ ULONGLONG VolumeSize,
+    _In_ PRAMDISK_FAT32_LAYOUT Layout);
+
+BOOLEAN
+Fat32CreateDirectory(
+    _Inout_ PFAT32_WRITER Writer,
+    _In_ PCSTR Path);
+
+BOOLEAN
+Fat32CreateFileEx(
+    _Inout_ PFAT32_WRITER Writer,
+    _In_ PCSTR Path,
+    _In_ ULONG FileSize,
+    _Out_ PUCHAR *DataPointer);
+
+#endif /* _RAMDISK_FATWRITE_H_ */

--- a/boot/freeldr/freeldr/include/ramdisk_signature.h
+++ b/boot/freeldr/freeldr/include/ramdisk_signature.h
@@ -1,0 +1,31 @@
+/*
+ * PROJECT:     FreeLoader
+ * LICENSE:     BSD - See COPYING.ARM in the top level directory
+ * PURPOSE:     Shared helper for deriving stable RAM disk signatures
+ * COPYRIGHT:   Copyright 2025 Ahmed Arif <arif.ing@outlook.com>
+ */
+
+#pragma once
+
+#include <freeldr.h>
+
+static inline ULONG
+RamDiskDeriveDiskSignature(IN PVOID BaseAddress,
+                           IN ULONGLONG DiskSize)
+{
+    ULONG_PTR Address = (ULONG_PTR)BaseAddress;
+    ULONG Signature = 0x52444B58u; /* 'RDKX' */
+
+    Signature ^= (ULONG)(Address & 0xFFFFFFFFu);
+#if defined(_M_AMD64) || defined(__x86_64__) || defined(_M_ARM64) || defined(__aarch64__)
+    Signature ^= (ULONG)(Address >> 32);
+#endif
+    Signature ^= (ULONG)(DiskSize & 0xFFFFFFFFu);
+    Signature ^= (ULONG)(DiskSize >> 32);
+
+    if (Signature == 0 || Signature == 0xFFFFFFFFu)
+        Signature ^= 0xA5A5A5A5u;
+
+    return Signature;
+}
+

--- a/boot/freeldr/freeldr/lib/mm/mm.c
+++ b/boot/freeldr/freeldr/lib/mm/mm.c
@@ -74,9 +74,12 @@ PVOID MmAllocateMemoryWithType(SIZE_T MemorySize, TYPE_OF_MEMORY MemoryType)
           MemorySize, PagesNeeded, MemoryType, FirstFreePageFromEnd);
     TRACE("Memory allocation pointer: 0x%x\n", MemPointer);
 
-    // Update LoaderPagesSpanned count
-    if ((((ULONG_PTR)MemPointer + MemorySize + PAGE_SIZE - 1) >> PAGE_SHIFT) > LoaderPagesSpanned)
+    /* LoaderXIPRom identifies the retained boot ramdisk and must not define the boot image mapping span. */
+    if ((MemoryType != LoaderXIPRom) &&
+        ((((ULONG_PTR)MemPointer + MemorySize + PAGE_SIZE - 1) >> PAGE_SHIFT) > LoaderPagesSpanned))
+    {
         LoaderPagesSpanned = (((ULONG_PTR)MemPointer + MemorySize + PAGE_SIZE - 1) >> PAGE_SHIFT);
+    }
 
     // Now return the pointer
     return MemPointer;
@@ -133,9 +136,12 @@ PVOID MmAllocateMemoryAtAddress(SIZE_T MemorySize, PVOID DesiredAddress, TYPE_OF
     TRACE("Allocated %d bytes (%d pages) of memory starting at page %d.\n", MemorySize, PagesNeeded, StartPageNumber);
     TRACE("Memory allocation pointer: 0x%x\n", MemPointer);
 
-    // Update LoaderPagesSpanned count
-    if ((((ULONG_PTR)MemPointer + MemorySize + PAGE_SIZE - 1) >> PAGE_SHIFT) > LoaderPagesSpanned)
+    /* LoaderXIPRom identifies the retained boot ramdisk and must not define the boot image mapping span. */
+    if ((MemoryType != LoaderXIPRom) &&
+        ((((ULONG_PTR)MemPointer + MemorySize + PAGE_SIZE - 1) >> PAGE_SHIFT) > LoaderPagesSpanned))
+    {
         LoaderPagesSpanned = (((ULONG_PTR)MemPointer + MemorySize + PAGE_SIZE - 1) >> PAGE_SHIFT);
+    }
 
     // Now return the pointer
     return MemPointer;
@@ -204,9 +210,12 @@ PVOID MmAllocateHighestMemoryBelowAddress(SIZE_T MemorySize, PVOID DesiredAddres
     TRACE("Allocated %d bytes (%d pages) of memory starting at page %d.\n", MemorySize, PagesNeeded, FirstFreePageFromEnd);
     TRACE("Memory allocation pointer: 0x%x\n", MemPointer);
 
-    // Update LoaderPagesSpanned count
-    if ((((ULONG_PTR)MemPointer + MemorySize) >> PAGE_SHIFT) > LoaderPagesSpanned)
+    /* LoaderXIPRom identifies the retained boot ramdisk and must not define the boot image mapping span. */
+    if ((MemoryType != LoaderXIPRom) &&
+        ((((ULONG_PTR)MemPointer + MemorySize) >> PAGE_SHIFT) > LoaderPagesSpanned))
+    {
         LoaderPagesSpanned = (((ULONG_PTR)MemPointer + MemorySize) >> PAGE_SHIFT);
+    }
 
     // Now return the pointer
     return MemPointer;

--- a/boot/freeldr/freeldr/lib/ramdisk_fatwrite.c
+++ b/boot/freeldr/freeldr/lib/ramdisk_fatwrite.c
@@ -1,0 +1,1035 @@
+/*
+ * PROJECT:     FreeLoader
+ * LICENSE:     BSD - See COPYING.ARM in the top level directory
+ * PURPOSE:     Minimal write-only FAT32 populator for in-memory ramdisks
+ * COPYRIGHT:   Copyright 2025 Ahmed Arif <arif.ing@outlook.com>
+ *
+ * This module provides a lightweight FAT32 writer that operates directly on
+ * an in-memory buffer that has already been formatted by RamDiskFormatFat32().
+ * It replaces the third-party FatFs library for the specific use case of
+ * sequentially populating a FAT32 volume from an ISO source.
+ *
+ * Key assumptions:
+ *   - Single-threaded, write-once population (no concurrent access)
+ *   - Volume is already formatted (boot sector, FAT tables, FSINFO present)
+ *   - Files are written sequentially and never modified after creation
+ *   - Cluster allocation is sequential (no fragmentation)
+ */
+
+#include <freeldr.h>
+#include <debug.h>
+#include <ctype.h>
+#include <string.h>
+#include <fs/fat.h>
+#include <ramdisk_fatwrite.h>
+
+DBG_DEFAULT_CHANNEL(DISK);
+
+/* ========================================================================== */
+/*  Internal helpers                                                          */
+/* ========================================================================== */
+
+/*
+ * Convert a cluster number to a direct memory pointer within the volume.
+ */
+static
+PUCHAR
+Fat32ClusterToPointer(
+    _In_ PFAT32_WRITER Writer,
+    _In_ ULONG Cluster)
+{
+    ULONGLONG Offset;
+    ASSERT(Cluster >= 2);
+    Offset = ((ULONGLONG)Writer->FirstDataSector +
+                       (ULONGLONG)(Cluster - 2) * Writer->SectorsPerCluster) *
+                       Writer->BytesPerSector;
+    return Writer->VolumeBase + Offset;
+}
+
+/*
+ * Allocate a contiguous run of clusters. Returns the first cluster number.
+ * Since we always allocate sequentially from NextFreeCluster, the clusters
+ * are guaranteed to be contiguous in the data area.
+ */
+static
+BOOLEAN
+Fat32AllocateClusters(
+    _Inout_ PFAT32_WRITER Writer,
+    _In_ ULONG Count,
+    _Out_ PULONG FirstCluster)
+{
+    ULONG Start;
+    ULONG i;
+
+    if (Count == 0)
+    {
+        *FirstCluster = 0;
+        return TRUE;
+    }
+
+    Start = Writer->NextFreeCluster;
+
+    /* Check we have enough free clusters (cluster numbers are 2-based) */
+    if (Start + Count - 1 > Writer->TotalClusters + 1)
+    {
+        WARN("Fat32AllocateClusters: need %lu clusters at %lu but only %lu total\n",
+             Count, Start, Writer->TotalClusters);
+        return FALSE;
+    }
+
+    /* Build the cluster chain in both FAT copies */
+    for (i = 0; i < Count; i++)
+    {
+        ULONG Cluster = Start + i;
+        ULONG Value = (i < Count - 1) ? (Cluster + 1) : 0x0FFFFFFF;
+
+        Writer->Fat0[Cluster] = Value;
+        if (Writer->Fat1)
+            Writer->Fat1[Cluster] = Value;
+    }
+
+    Writer->NextFreeCluster = Start + Count;
+    *FirstCluster = Start;
+    return TRUE;
+}
+
+/*
+ * Characters invalid in FAT 8.3 short names.
+ */
+static const CHAR InvalidShortNameChars[] = "\"*+,./:;<=>?[\\]| ";
+
+static
+BOOLEAN
+IsValidShortNameChar(CHAR c)
+{
+    if ((UCHAR)c < 0x21 || (UCHAR)c > 0x7E)
+        return FALSE;
+    if (strchr(InvalidShortNameChars, c))
+        return FALSE;
+    return TRUE;
+}
+
+/*
+ * Generate a FAT 8.3 short name from a leaf filename.
+ *
+ * Returns TRUE if the name fits in 8.3 format (possibly with case folding).
+ * Sets *NeedsLfn to TRUE if an LFN entry is required.
+ * Sets *CaseFlags for the ReservedNT byte (0x08 = base lowercase, 0x10 = ext lowercase).
+ */
+static
+BOOLEAN
+Fat32GenerateShortName(
+    _In_ PCSTR LeafName,
+    _Out_writes_(11) PUCHAR ShortName,
+    _Out_ PBOOLEAN NeedsLfn,
+    _Out_ PUCHAR CaseFlags)
+{
+    const CHAR *Dot = NULL;
+    const CHAR *p;
+    SIZE_T BaseLen, ExtLen;
+    SIZE_T i;
+    BOOLEAN BaseLower = FALSE, BaseUpper = FALSE;
+    BOOLEAN ExtLower = FALSE, ExtUpper = FALSE;
+
+    *NeedsLfn = FALSE;
+    *CaseFlags = 0;
+    RtlFillMemory(ShortName, 11, ' ');
+
+    if (!LeafName || !*LeafName)
+        return FALSE;
+
+    /* Find the last dot (not leading dot) */
+    for (p = LeafName; *p; p++)
+    {
+        if (*p == '.' && p != LeafName)
+            Dot = p;
+    }
+
+    BaseLen = Dot ? (SIZE_T)(Dot - LeafName) : strlen(LeafName);
+    ExtLen = Dot ? strlen(Dot + 1) : 0;
+
+    /* Check if it fits 8.3 with only case folding needed */
+    if (BaseLen >= 1 && BaseLen <= 8 && ExtLen <= 3)
+    {
+        BOOLEAN AllValid = TRUE;
+
+        /* Check base characters */
+        for (i = 0; i < BaseLen; i++)
+        {
+            CHAR c = LeafName[i];
+            if (!IsValidShortNameChar(c) && !(c >= 'a' && c <= 'z'))
+            {
+                AllValid = FALSE;
+                break;
+            }
+            if (c >= 'a' && c <= 'z') BaseLower = TRUE;
+            if (c >= 'A' && c <= 'Z') BaseUpper = TRUE;
+        }
+
+        /* Check extension characters */
+        if (AllValid && Dot)
+        {
+            for (i = 0; i < ExtLen; i++)
+            {
+                CHAR c = Dot[1 + i];
+                if (!IsValidShortNameChar(c) && !(c >= 'a' && c <= 'z'))
+                {
+                    AllValid = FALSE;
+                    break;
+                }
+                if (c >= 'a' && c <= 'z') ExtLower = TRUE;
+                if (c >= 'A' && c <= 'Z') ExtUpper = TRUE;
+            }
+        }
+
+        if (AllValid)
+        {
+            /* Mixed case in base or extension requires LFN */
+            BOOLEAN BaseMixed = BaseLower && BaseUpper;
+            BOOLEAN ExtMixed = ExtLower && ExtUpper;
+
+            if (!BaseMixed && !ExtMixed)
+            {
+                /* Pure 8.3 — use case bits in ReservedNT */
+                for (i = 0; i < BaseLen; i++)
+                    ShortName[i] = (UCHAR)toupper((UCHAR)LeafName[i]);
+                for (i = 0; i < ExtLen; i++)
+                    ShortName[8 + i] = (UCHAR)toupper((UCHAR)Dot[1 + i]);
+
+                if (BaseLower) *CaseFlags |= 0x08;
+                if (ExtLower) *CaseFlags |= 0x10;
+
+                *NeedsLfn = FALSE;
+                return TRUE;
+            }
+        }
+    }
+
+    /* Name needs LFN — generate a lossy 8.3 basis name */
+    *NeedsLfn = TRUE;
+    {
+        SIZE_T Pos = 0;
+
+        /* Take up to 6 valid uppercase characters from the base */
+        for (i = 0; i < BaseLen && Pos < 6; i++)
+        {
+            CHAR c = LeafName[i];
+            if (c == ' ' || c == '.')
+                continue;
+            if (IsValidShortNameChar(c))
+                ShortName[Pos++] = (UCHAR)toupper((UCHAR)c);
+            else if (c >= 'a' && c <= 'z')
+                ShortName[Pos++] = (UCHAR)toupper((UCHAR)c);
+        }
+
+        /* Pad with underscores if too short */
+        while (Pos < 6)
+            ShortName[Pos++] = '_';
+
+        /* Append ~1 (caller will handle collisions) */
+        ShortName[6] = '~';
+        ShortName[7] = '1';
+
+        /* Extension: up to 3 valid uppercase characters */
+        if (Dot)
+        {
+            for (i = 0; i < ExtLen && i < 3; i++)
+            {
+                CHAR c = Dot[1 + i];
+                if (IsValidShortNameChar(c) || (c >= 'a' && c <= 'z'))
+                    ShortName[8 + i] = (UCHAR)toupper((UCHAR)c);
+                else
+                    ShortName[8 + i] = '_';
+            }
+        }
+    }
+
+    return TRUE;
+}
+
+/*
+ * Compute the LFN checksum from an 11-byte short name.
+ */
+static
+UCHAR
+Fat32LfnChecksum(
+    _In_reads_(11) const UCHAR *ShortName)
+{
+    UCHAR Sum = 0;
+    int i;
+    for (i = 0; i < 11; i++)
+        Sum = ((Sum & 1) ? 0x80 : 0) + (Sum >> 1) + ShortName[i];
+    return Sum;
+}
+
+/*
+ * Get the next cluster in a chain. Returns 0 if end-of-chain or invalid.
+ */
+static
+ULONG
+Fat32GetNextCluster(
+    _In_ PFAT32_WRITER Writer,
+    _In_ ULONG Cluster)
+{
+    ULONG Value;
+
+    if (Cluster < 2 || Cluster > Writer->TotalClusters + 1)
+        return 0;
+
+    Value = Writer->Fat0[Cluster] & 0x0FFFFFFF;
+    if (Value >= 0x0FFFFFF8)
+        return 0; /* End of chain */
+    return Value;
+}
+
+/*
+ * Compare a short name entry's 11-byte name against a target leaf name.
+ * Reconstructs "BASE.EXT" and does case-insensitive comparison.
+ */
+static
+BOOLEAN
+Fat32MatchShortName(
+    _In_ const DIRENTRY *Entry,
+    _In_ PCSTR LeafName)
+{
+    CHAR Reconstructed[13]; /* "FILENAME.EXT" + null */
+    SIZE_T Pos = 0;
+    SIZE_T i;
+
+    for (i = 0; i < 8 && Entry->FileName[i] != ' '; i++)
+        Reconstructed[Pos++] = Entry->FileName[i];
+
+    if (Entry->FileName[8] != ' ')
+    {
+        Reconstructed[Pos++] = '.';
+        for (i = 8; i < 11 && Entry->FileName[i] != ' '; i++)
+            Reconstructed[Pos++] = Entry->FileName[i];
+    }
+    Reconstructed[Pos] = '\0';
+
+    return (_stricmp(Reconstructed, LeafName) == 0);
+}
+
+/*
+ * Reconstruct a long filename from collected LFN entries and compare
+ * against a target name. LFN entries are stored in reverse order
+ * (highest sequence first), but we collected them in directory order
+ * (lowest sequence first in our buffer).
+ */
+static
+BOOLEAN
+Fat32MatchLfnName(
+    _In_ const LFN_DIRENTRY *LfnEntries,
+    _In_ ULONG LfnCount,
+    _In_ PCSTR LeafName)
+{
+    CHAR Reconstructed[256];
+    SIZE_T Pos = 0;
+    ULONG Seq;
+
+    for (Seq = 0; Seq < LfnCount; Seq++)
+    {
+        const LFN_DIRENTRY *Lfn = &LfnEntries[Seq];
+        ULONG j;
+        WCHAR Chars[13];
+
+        /* Extract 13 UTF-16LE characters from the LFN entry */
+        for (j = 0; j < 5; j++) Chars[j] = Lfn->Name0_4[j];
+        for (j = 0; j < 6; j++) Chars[5 + j] = Lfn->Name5_10[j];
+        for (j = 0; j < 2; j++) Chars[11 + j] = Lfn->Name11_12[j];
+
+        for (j = 0; j < 13; j++)
+        {
+            if (Chars[j] == 0x0000)
+                goto done_reconstructing;
+            if (Chars[j] == 0xFFFF)
+                goto done_reconstructing;
+            if (Pos >= sizeof(Reconstructed) - 1)
+                return FALSE; /* Name too long */
+            /* Simple UTF-16 to ASCII (our names are ASCII) */
+            Reconstructed[Pos++] = (CHAR)(Chars[j] & 0xFF);
+        }
+    }
+
+done_reconstructing:
+    Reconstructed[Pos] = '\0';
+    return (_stricmp(Reconstructed, LeafName) == 0);
+}
+
+/*
+ * Search a directory's cluster chain for an entry matching LeafName.
+ * Matches against both the short name and the reconstructed long name.
+ * Returns the starting cluster of the found entry, or 0 if not found.
+ * If IsDir is not NULL, sets it to TRUE if the found entry is a directory.
+ */
+static
+ULONG
+Fat32FindEntryInDirectory(
+    _In_ PFAT32_WRITER Writer,
+    _In_ ULONG DirCluster,
+    _In_ PCSTR LeafName,
+    _Out_opt_ PBOOLEAN IsDir)
+{
+    ULONG Cluster = DirCluster;
+    /* Buffer to collect LFN entries for the current sequence */
+    LFN_DIRENTRY LfnBuffer[20]; /* Max 20 LFN entries = 260 chars */
+    ULONG LfnCount = 0;
+
+    while (Cluster != 0)
+    {
+        PDIRENTRY Entries = (PDIRENTRY)Fat32ClusterToPointer(Writer, Cluster);
+        ULONG Count = Writer->BytesPerCluster / sizeof(DIRENTRY);
+        ULONG i;
+
+        for (i = 0; i < Count; i++)
+        {
+            PDIRENTRY Entry = &Entries[i];
+
+            /* End of directory */
+            if ((UCHAR)Entry->FileName[0] == 0x00)
+                return 0;
+
+            /* Deleted entry */
+            if ((UCHAR)Entry->FileName[0] == 0xE5)
+            {
+                LfnCount = 0;
+                continue;
+            }
+
+            /* Collect LFN entries */
+            if (Entry->Attr == FAT_ATTR_LONG_NAME)
+            {
+                PLFN_DIRENTRY Lfn = (PLFN_DIRENTRY)Entry;
+                UCHAR SeqNum = Lfn->SequenceNumber & 0x3F;
+
+                if (Lfn->SequenceNumber & 0x40)
+                {
+                    /* First LFN entry (highest sequence number) — start fresh */
+                    LfnCount = 0;
+                }
+
+                if (SeqNum >= 1 && SeqNum <= 20)
+                {
+                    /* Store in order: sequence 1 at index 0, sequence 2 at index 1, etc. */
+                    if (SeqNum - 1 < 20)
+                    {
+                        RtlCopyMemory(&LfnBuffer[SeqNum - 1], Lfn, sizeof(LFN_DIRENTRY));
+                        if (SeqNum > LfnCount)
+                            LfnCount = SeqNum;
+                    }
+                }
+                continue;
+            }
+
+            /* Skip volume label */
+            if (Entry->Attr & FAT_ATTR_VOLUMENAME)
+            {
+                LfnCount = 0;
+                continue;
+            }
+
+            /* This is a short name entry — try matching */
+            {
+                BOOLEAN Matched = FALSE;
+
+                /* First try matching the long name if we have LFN entries */
+                if (LfnCount > 0)
+                    Matched = Fat32MatchLfnName(LfnBuffer, LfnCount, LeafName);
+
+                /* Also try matching the short name */
+                if (!Matched)
+                    Matched = Fat32MatchShortName(Entry, LeafName);
+
+                LfnCount = 0;
+
+                if (Matched)
+                {
+                    ULONG StartCluster = ((ULONG)Entry->ClusterHigh << 16) |
+                                         (ULONG)Entry->ClusterLow;
+                    if (IsDir)
+                        *IsDir = !!(Entry->Attr & FAT_ATTR_DIRECTORY);
+                    return StartCluster;
+                }
+            }
+        }
+
+        Cluster = Fat32GetNextCluster(Writer, Cluster);
+    }
+
+    return 0;
+}
+
+/*
+ * Check if a specific 11-byte short name already exists in a directory.
+ */
+static
+BOOLEAN
+Fat32ShortNameExists(
+    _In_ PFAT32_WRITER Writer,
+    _In_ ULONG DirCluster,
+    _In_reads_(11) const UCHAR *ShortName)
+{
+    ULONG Cluster = DirCluster;
+
+    while (Cluster != 0)
+    {
+        PDIRENTRY Entries = (PDIRENTRY)Fat32ClusterToPointer(Writer, Cluster);
+        ULONG Count = Writer->BytesPerCluster / sizeof(DIRENTRY);
+        ULONG i;
+
+        for (i = 0; i < Count; i++)
+        {
+            PDIRENTRY Entry = &Entries[i];
+
+            if ((UCHAR)Entry->FileName[0] == 0x00)
+                return FALSE;
+            if ((UCHAR)Entry->FileName[0] == 0xE5)
+                continue;
+            if (Entry->Attr == FAT_ATTR_LONG_NAME)
+                continue;
+            if (Entry->Attr & FAT_ATTR_VOLUMENAME)
+                continue;
+
+            if (RtlEqualMemory(Entry->FileName, ShortName, 11))
+                return TRUE;
+        }
+
+        Cluster = Fat32GetNextCluster(Writer, Cluster);
+    }
+
+    return FALSE;
+}
+
+/*
+ * Find N consecutive free directory entry slots in a directory's cluster chain.
+ * If not enough space, extends the chain by allocating a new cluster.
+ *
+ * Returns a pointer to the first free slot, or NULL on failure.
+ * The slots are guaranteed to be consecutive within the same cluster.
+ *
+ * Note: If the required slots span a cluster boundary, we start from the
+ * beginning of a new cluster rather than splitting across clusters for
+ * simplicity (LFN + short name entries should stay together when possible).
+ */
+static
+PDIRENTRY
+Fat32FindFreeSlots(
+    _Inout_ PFAT32_WRITER Writer,
+    _In_ ULONG DirCluster,
+    _In_ ULONG SlotsNeeded)
+{
+    ULONG Cluster = DirCluster;
+    ULONG PrevCluster = 0;
+
+    while (Cluster != 0)
+    {
+        PDIRENTRY Entries = (PDIRENTRY)Fat32ClusterToPointer(Writer, Cluster);
+        ULONG Count = Writer->BytesPerCluster / sizeof(DIRENTRY);
+        ULONG i;
+        ULONG RunStart = 0;
+        ULONG RunLength = 0;
+
+        for (i = 0; i < Count; i++)
+        {
+            if ((UCHAR)Entries[i].FileName[0] == 0x00 ||
+                (UCHAR)Entries[i].FileName[0] == 0xE5)
+            {
+                if (RunLength == 0)
+                    RunStart = i;
+                RunLength++;
+
+                if (RunLength >= SlotsNeeded)
+                    return &Entries[RunStart];
+
+                /* If this is the end-of-directory marker (0x00), all remaining
+                 * slots in this cluster are also free */
+                if ((UCHAR)Entries[i].FileName[0] == 0x00)
+                {
+                    ULONG Remaining = Count - RunStart;
+                    if (Remaining >= SlotsNeeded)
+                        return &Entries[RunStart];
+                    /* Not enough in this cluster, need a new one */
+                    break;
+                }
+            }
+            else
+            {
+                RunLength = 0;
+            }
+        }
+
+        PrevCluster = Cluster;
+        Cluster = Fat32GetNextCluster(Writer, Cluster);
+    }
+
+    /* Need to extend the directory with a new cluster */
+    {
+        ULONG NewCluster;
+
+        if (!Fat32AllocateClusters(Writer, 1, &NewCluster))
+            return NULL;
+
+        RtlZeroMemory(Fat32ClusterToPointer(Writer, NewCluster),
+                       Writer->BytesPerCluster);
+
+        /* Chain the new cluster to the end */
+        if (PrevCluster != 0)
+        {
+            Writer->Fat0[PrevCluster] = NewCluster;
+            if (Writer->Fat1)
+                Writer->Fat1[PrevCluster] = NewCluster;
+
+            /*
+             * Convert any trailing 0x00 (end-of-directory) entries in the
+             * previous cluster to 0xE5 (deleted).  Per the FAT specification,
+             * a 0x00 entry means "no more entries follow", so the FAT driver
+             * would stop scanning at that point and never see entries written
+             * in the newly chained cluster.  Changing them to 0xE5 lets the
+             * scan continue through the entire cluster chain.
+             */
+            {
+                PDIRENTRY PrevEntries = (PDIRENTRY)Fat32ClusterToPointer(Writer, PrevCluster);
+                ULONG PrevCount = Writer->BytesPerCluster / sizeof(DIRENTRY);
+                ULONG j;
+
+                for (j = 0; j < PrevCount; j++)
+                {
+                    if ((UCHAR)PrevEntries[j].FileName[0] == 0x00)
+                        PrevEntries[j].FileName[0] = (CHAR)0xE5;
+                }
+            }
+        }
+
+        /* The new cluster FAT entry is already set to 0x0FFFFFFF by Fat32AllocateClusters */
+
+        if (Writer->BytesPerCluster / sizeof(DIRENTRY) >= SlotsNeeded)
+            return (PDIRENTRY)Fat32ClusterToPointer(Writer, NewCluster);
+
+        /* This should never happen for reasonable slot counts */
+        WARN("Fat32FindFreeSlots: cluster too small for %lu slots\n", SlotsNeeded);
+        return NULL;
+    }
+}
+
+/*
+ * Write a complete directory entry (LFN entries + short name entry)
+ * into a parent directory.
+ */
+static
+BOOLEAN
+Fat32AddDirectoryEntry(
+    _Inout_ PFAT32_WRITER Writer,
+    _In_ ULONG DirCluster,
+    _In_ PCSTR LeafName,
+    _In_ ULONG StartCluster,
+    _In_ ULONG FileSize,
+    _In_ UCHAR Attributes)
+{
+    UCHAR ShortName[11];
+    BOOLEAN NeedsLfn;
+    UCHAR CaseFlags;
+    ULONG SlotsNeeded;
+    PDIRENTRY Slots;
+
+    if (!Fat32GenerateShortName(LeafName, ShortName, &NeedsLfn, &CaseFlags))
+        return FALSE;
+
+    /* Handle short name collisions */
+    if (NeedsLfn)
+    {
+        CHAR Digit;
+        for (Digit = '1'; Digit <= '9'; Digit++)
+        {
+            if (!Fat32ShortNameExists(Writer, DirCluster, ShortName))
+                break;
+            ShortName[7] = (UCHAR)Digit;
+        }
+
+        if (Digit > '9')
+        {
+            WARN("Fat32AddDirectoryEntry: too many short name collisions for '%s'\n",
+                 LeafName);
+            return FALSE;
+        }
+    }
+
+    /* Calculate how many LFN entries we need */
+    if (NeedsLfn)
+    {
+        SIZE_T NameLen = strlen(LeafName);
+        SlotsNeeded = (ULONG)((NameLen + 12) / 13) + 1; /* LFN entries + 1 short name entry */
+    }
+    else
+    {
+        SlotsNeeded = 1; /* Just the short name entry */
+    }
+
+    /* Find free slots in the directory */
+    Slots = Fat32FindFreeSlots(Writer, DirCluster, SlotsNeeded);
+    if (!Slots)
+    {
+        WARN("Fat32AddDirectoryEntry: no free slots for '%s'\n", LeafName);
+        return FALSE;
+    }
+
+    /* Write LFN entries (if needed), in order from highest sequence to lowest */
+    if (NeedsLfn)
+    {
+        UCHAR Checksum = Fat32LfnChecksum(ShortName);
+        SIZE_T NameLen = strlen(LeafName);
+        ULONG LfnCount = SlotsNeeded - 1;
+        ULONG Seq;
+
+        for (Seq = LfnCount; Seq >= 1; Seq--)
+        {
+            PLFN_DIRENTRY Lfn = (PLFN_DIRENTRY)&Slots[LfnCount - Seq];
+            SIZE_T CharOffset = (Seq - 1) * 13;
+            ULONG j;
+
+            RtlZeroMemory(Lfn, sizeof(LFN_DIRENTRY));
+
+            Lfn->SequenceNumber = (UCHAR)Seq;
+            if (Seq == LfnCount)
+                Lfn->SequenceNumber |= 0x40; /* Last LFN entry marker */
+
+            Lfn->EntryAttributes = FAT_ATTR_LONG_NAME;
+            Lfn->AliasChecksum = Checksum;
+            Lfn->StartCluster = 0;
+
+            /* Fill the 13 UTF-16LE characters across the three name fields */
+            for (j = 0; j < 5; j++)
+            {
+                SIZE_T Idx = CharOffset + j;
+                if (Idx < NameLen)
+                    Lfn->Name0_4[j] = (WCHAR)(UCHAR)LeafName[Idx];
+                else if (Idx == NameLen)
+                    Lfn->Name0_4[j] = 0x0000;
+                else
+                    Lfn->Name0_4[j] = 0xFFFF;
+            }
+            for (j = 0; j < 6; j++)
+            {
+                SIZE_T Idx = CharOffset + 5 + j;
+                if (Idx < NameLen)
+                    Lfn->Name5_10[j] = (WCHAR)(UCHAR)LeafName[Idx];
+                else if (Idx == NameLen)
+                    Lfn->Name5_10[j] = 0x0000;
+                else
+                    Lfn->Name5_10[j] = 0xFFFF;
+            }
+            for (j = 0; j < 2; j++)
+            {
+                SIZE_T Idx = CharOffset + 11 + j;
+                if (Idx < NameLen)
+                    Lfn->Name11_12[j] = (WCHAR)(UCHAR)LeafName[Idx];
+                else if (Idx == NameLen)
+                    Lfn->Name11_12[j] = 0x0000;
+                else
+                    Lfn->Name11_12[j] = 0xFFFF;
+            }
+        }
+    }
+
+    /* Write the short name entry */
+    {
+        PDIRENTRY ShortEntry = &Slots[SlotsNeeded - 1];
+
+        RtlZeroMemory(ShortEntry, sizeof(DIRENTRY));
+        RtlCopyMemory(ShortEntry->FileName, ShortName, 11);
+        ShortEntry->Attr = Attributes;
+        ShortEntry->ReservedNT = CaseFlags;
+        ShortEntry->CreateTime = Writer->FatTime;
+        ShortEntry->CreateDate = Writer->FatDate;
+        ShortEntry->LastAccessDate = Writer->FatDate;
+        ShortEntry->Time = Writer->FatTime;
+        ShortEntry->Date = Writer->FatDate;
+        ShortEntry->ClusterHigh = (USHORT)(StartCluster >> 16);
+        ShortEntry->ClusterLow = (USHORT)(StartCluster & 0xFFFF);
+        ShortEntry->Size = FileSize;
+    }
+
+    return TRUE;
+}
+
+/*
+ * Resolve a path like "/reactos/system32/file.exe" to find the parent
+ * directory cluster and extract the leaf name.
+ *
+ * The path components are separated by '/'. Leading '/' is stripped.
+ */
+static
+BOOLEAN
+Fat32ResolvePath(
+    _In_ PFAT32_WRITER Writer,
+    _In_ PCSTR Path,
+    _Out_ PULONG ParentCluster,
+    _Out_writes_(LeafNameSize) PCHAR LeafName,
+    _In_ SIZE_T LeafNameSize)
+{
+    CHAR Component[256];
+    PCSTR p = Path;
+    PCSTR SlashPos;
+    ULONG CurrentCluster;
+
+    /* Skip leading slashes */
+    while (*p == '/')
+        p++;
+
+    /* Empty path means root directory itself */
+    if (*p == '\0')
+    {
+        *ParentCluster = Writer->RootDirCluster;
+        LeafName[0] = '\0';
+        return TRUE;
+    }
+
+    CurrentCluster = Writer->RootDirCluster;
+
+    while (*p)
+    {
+        SIZE_T Len;
+
+        /* Find next slash or end */
+        SlashPos = strchr(p, '/');
+        if (SlashPos)
+            Len = (SIZE_T)(SlashPos - p);
+        else
+            Len = strlen(p);
+
+        if (Len == 0)
+        {
+            p++;
+            continue;
+        }
+
+        if (Len >= sizeof(Component))
+            return FALSE;
+
+        RtlCopyMemory(Component, p, Len);
+        Component[Len] = '\0';
+
+        if (SlashPos)
+        {
+            /* This is an intermediate directory — look it up */
+            BOOLEAN IsDir = FALSE;
+            ULONG ChildCluster = Fat32FindEntryInDirectory(Writer, CurrentCluster,
+                                                            Component, &IsDir);
+            if (ChildCluster == 0 || !IsDir)
+            {
+                WARN("Fat32ResolvePath: component '%s' not found or not a directory\n",
+                     Component);
+                return FALSE;
+            }
+            CurrentCluster = ChildCluster;
+            p = SlashPos + 1;
+        }
+        else
+        {
+            /* This is the leaf name */
+            if (Len >= LeafNameSize)
+                return FALSE;
+            RtlCopyMemory(LeafName, Component, Len);
+            LeafName[Len] = '\0';
+            *ParentCluster = CurrentCluster;
+            return TRUE;
+        }
+    }
+
+    /* Path ended with a slash — treat as directory reference */
+    *ParentCluster = CurrentCluster;
+    LeafName[0] = '\0';
+    return TRUE;
+}
+
+/* ========================================================================== */
+/*  Public API                                                                */
+/* ========================================================================== */
+
+BOOLEAN
+Fat32WriterInit(
+    _Out_ PFAT32_WRITER Writer,
+    _In_ PVOID VolumeBase,
+    _In_ ULONGLONG VolumeSize,
+    _In_ PRAMDISK_FAT32_LAYOUT Layout)
+{
+    ULONGLONG DataSectors;
+
+    if (!Writer || !VolumeBase || VolumeSize == 0 || !Layout)
+        return FALSE;
+
+    RtlZeroMemory(Writer, sizeof(*Writer));
+
+    Writer->VolumeBase = (PUCHAR)VolumeBase;
+    Writer->VolumeSize = VolumeSize;
+    Writer->BytesPerSector = Layout->BytesPerSector;
+    Writer->SectorsPerCluster = Layout->SectorsPerCluster;
+    Writer->BytesPerCluster = Layout->BytesPerSector * Layout->SectorsPerCluster;
+    Writer->ReservedSectors = Layout->ReservedSectors;
+    Writer->NumberOfFats = Layout->NumberOfFats;
+    Writer->FatSizeSectors = Layout->FatSizeSectors;
+    Writer->FirstDataSector = Layout->FirstDataSector;
+    Writer->RootDirCluster = Layout->RootDirFirstCluster;
+
+    /* Calculate total data clusters */
+    DataSectors = (ULONGLONG)Layout->TotalSectors - Layout->FirstDataSector;
+    Writer->TotalClusters = (ULONG)(DataSectors / Layout->SectorsPerCluster);
+
+    /* Set up direct FAT pointers */
+    Writer->Fat0 = (PULONG)(Writer->VolumeBase +
+                   (ULONGLONG)Layout->ReservedSectors * Layout->BytesPerSector);
+
+    if (Layout->NumberOfFats >= 2)
+    {
+        Writer->Fat1 = (PULONG)((PUCHAR)Writer->Fat0 +
+                       (ULONGLONG)Layout->FatSizeSectors * Layout->BytesPerSector);
+    }
+
+    /* Cluster 2 is root dir (already allocated by format), start at 3 */
+    Writer->NextFreeCluster = 3;
+
+    /* Fixed timestamp: 2025-01-01 00:00:00 */
+    Writer->FatDate = (USHORT)(((2025 - 1980) << 9) | (1 << 5) | 1);
+    Writer->FatTime = 0;
+
+    TRACE("Fat32WriterInit: %lu clusters, %lu bytes/cluster, first data sector %lu\n",
+          Writer->TotalClusters, Writer->BytesPerCluster, Writer->FirstDataSector);
+
+    return TRUE;
+}
+
+BOOLEAN
+Fat32CreateDirectory(
+    _Inout_ PFAT32_WRITER Writer,
+    _In_ PCSTR Path)
+{
+    CHAR LeafName[256];
+    ULONG ParentCluster;
+    ULONG NewCluster;
+    PDIRENTRY DotEntries;
+    BOOLEAN IsDir;
+
+    if (!Writer || !Path)
+        return FALSE;
+
+    /* Resolve the path to get parent cluster and leaf name */
+    if (!Fat32ResolvePath(Writer, Path, &ParentCluster, LeafName, sizeof(LeafName)))
+        return FALSE;
+
+    /* Empty leaf means the directory already exists (it's the root or trailing slash) */
+    if (LeafName[0] == '\0')
+        return TRUE;
+
+    /* Check if it already exists */
+    {
+        ULONG Existing = Fat32FindEntryInDirectory(Writer, ParentCluster,
+                                                    LeafName, &IsDir);
+        if (Existing != 0)
+        {
+            if (IsDir)
+                return TRUE; /* Already exists as a directory */
+            WARN("Fat32CreateDirectory: '%s' exists as a file\n", Path);
+            return FALSE;
+        }
+    }
+
+    /* Allocate one cluster for the new directory */
+    if (!Fat32AllocateClusters(Writer, 1, &NewCluster))
+        return FALSE;
+
+    /* Zero-fill and write . and .. entries */
+    RtlZeroMemory(Fat32ClusterToPointer(Writer, NewCluster), Writer->BytesPerCluster);
+
+    DotEntries = (PDIRENTRY)Fat32ClusterToPointer(Writer, NewCluster);
+
+    /* "." entry — points to itself */
+    RtlFillMemory(DotEntries[0].FileName, 11, ' ');
+    DotEntries[0].FileName[0] = '.';
+    DotEntries[0].Attr = FAT_ATTR_DIRECTORY;
+    DotEntries[0].CreateTime = Writer->FatTime;
+    DotEntries[0].CreateDate = Writer->FatDate;
+    DotEntries[0].LastAccessDate = Writer->FatDate;
+    DotEntries[0].Time = Writer->FatTime;
+    DotEntries[0].Date = Writer->FatDate;
+    DotEntries[0].ClusterHigh = (USHORT)(NewCluster >> 16);
+    DotEntries[0].ClusterLow = (USHORT)(NewCluster & 0xFFFF);
+    DotEntries[0].Size = 0;
+
+    /* ".." entry — points to parent (0 if parent is root) */
+    RtlFillMemory(DotEntries[1].FileName, 11, ' ');
+    DotEntries[1].FileName[0] = '.';
+    DotEntries[1].FileName[1] = '.';
+    DotEntries[1].Attr = FAT_ATTR_DIRECTORY;
+    DotEntries[1].CreateTime = Writer->FatTime;
+    DotEntries[1].CreateDate = Writer->FatDate;
+    DotEntries[1].LastAccessDate = Writer->FatDate;
+    DotEntries[1].Time = Writer->FatTime;
+    DotEntries[1].Date = Writer->FatDate;
+    {
+        /* FAT spec: ".." cluster is 0 when parent is root */
+        ULONG ParentRef = (ParentCluster == Writer->RootDirCluster) ? 0 : ParentCluster;
+        DotEntries[1].ClusterHigh = (USHORT)(ParentRef >> 16);
+        DotEntries[1].ClusterLow = (USHORT)(ParentRef & 0xFFFF);
+    }
+    DotEntries[1].Size = 0;
+
+    /* Add directory entry in parent */
+    return Fat32AddDirectoryEntry(Writer, ParentCluster, LeafName,
+                                  NewCluster, 0, FAT_ATTR_DIRECTORY);
+}
+
+BOOLEAN
+Fat32CreateFileEx(
+    _Inout_ PFAT32_WRITER Writer,
+    _In_ PCSTR Path,
+    _In_ ULONG FileSize,
+    _Out_ PUCHAR *DataPointer)
+{
+    CHAR LeafName[256];
+    ULONG ParentCluster;
+    ULONG FirstCluster = 0;
+    ULONG ClustersNeeded;
+
+    if (!Writer || !Path || !DataPointer)
+        return FALSE;
+
+    *DataPointer = NULL;
+
+    if (!Fat32ResolvePath(Writer, Path, &ParentCluster, LeafName, sizeof(LeafName)))
+        return FALSE;
+
+    if (LeafName[0] == '\0')
+    {
+        WARN("Fat32CreateFileEx: empty leaf name for path '%s'\n", Path);
+        return FALSE;
+    }
+
+    /* Allocate clusters for file data */
+    if (FileSize > 0)
+    {
+        ClustersNeeded = (FileSize + Writer->BytesPerCluster - 1) / Writer->BytesPerCluster;
+        if (!Fat32AllocateClusters(Writer, ClustersNeeded, &FirstCluster))
+            return FALSE;
+
+        /* Zero-fill the last cluster's tail to avoid leaking stale data */
+        {
+            ULONG TailPadding = (ClustersNeeded * Writer->BytesPerCluster) - FileSize;
+            if (TailPadding > 0)
+            {
+                PUCHAR TailStart = Fat32ClusterToPointer(Writer, FirstCluster) + FileSize;
+                RtlZeroMemory(TailStart, TailPadding);
+            }
+        }
+
+        *DataPointer = Fat32ClusterToPointer(Writer, FirstCluster);
+    }
+
+    /* Add directory entry */
+    if (!Fat32AddDirectoryEntry(Writer, ParentCluster, LeafName,
+                                FirstCluster, FileSize, FAT_ATTR_ARCHIVE))
+    {
+        /* Note: clusters are "leaked" but this is a fatal error path anyway */
+        return FALSE;
+    }
+
+    return TRUE;
+}

--- a/boot/freeldr/freeldr/lib/ramdisk_format.c
+++ b/boot/freeldr/freeldr/lib/ramdisk_format.c
@@ -1,0 +1,297 @@
+/*
+ * PROJECT:     FreeLoader
+ * LICENSE:     BSD - See COPYING.ARM in the top level directory
+ * PURPOSE:     Helpers to create a writable FAT32 ramdisk image in memory
+ * COPYRIGHT:   Copyright 2025 Ahmed Arif <arif.ing@outlook.com>
+ */
+
+#include <freeldr.h>
+#include <debug.h>
+#include <fs/fat.h>
+#include <disk.h>
+#include "ramdisk.h"
+#include "ramdisk_signature.h"
+
+#ifndef ARRAYSIZE
+#define ARRAYSIZE(x) (sizeof(x) / sizeof((x)[0]))
+#endif
+#define DEFAULT_BYTES_PER_SECTOR    512U
+#define DEFAULT_RESERVED_SECTORS    32U
+#define DEFAULT_NUM_FATS            2U
+#define DEFAULT_MEDIA_DESCRIPTOR    0xF8U
+#define DEFAULT_SECTORS_PER_TRACK   63U
+#define DEFAULT_NUMBER_OF_HEADS     255U
+#define DEFAULT_ROOT_DIR_CLUSTER    2U
+#define DEFAULT_BACKUP_BOOT_SECTOR  6U
+
+#define FAT32_MIN_CLUSTERS          65525U
+#define FAT32_MAX_CLUSTERS          0x0FFFFFF5U
+
+typedef struct _FAT32_FSINFO_RECORD
+{
+    ULONG LeadSignature;
+    UCHAR Reserved1[480];
+    ULONG StructSignature;
+    ULONG FreeCount;
+    ULONG NextFree;
+    UCHAR Reserved2[12];
+    ULONG TrailSignature;
+} FAT32_FSINFO_RECORD, *PFAT32_FSINFO_RECORD;
+
+static
+BOOLEAN
+ComputeFatLayout(IN ULONG TotalSectors,
+                 IN ULONG ReservedSectors,
+                 IN ULONG BytesPerSector,
+                 IN ULONG NumberOfFats,
+                 IN ULONG SectorsPerCluster,
+                 OUT ULONG *FatSizeSectors,
+                 OUT ULONG *DataSectors,
+                 OUT ULONG *ClusterCount)
+{
+    ULONGLONG FatSize = 0;
+    ULONG Iteration;
+
+    for (Iteration = 0; Iteration < 128; ++Iteration)
+    {
+        ULONGLONG CalcDataSectors;
+        ULONGLONG TotalClusters;
+        ULONGLONG RequiredEntries;
+        ULONGLONG FatBytes;
+        ULONGLONG NewFatSize;
+
+        if (TotalSectors < ReservedSectors)
+            return FALSE;
+
+        CalcDataSectors = (ULONGLONG)TotalSectors - ReservedSectors - NumberOfFats * FatSize;
+        if ((LONGLONG)CalcDataSectors <= 0)
+            return FALSE;
+
+        TotalClusters = CalcDataSectors / SectorsPerCluster;
+        if (TotalClusters > FAT32_MAX_CLUSTERS)
+            return FALSE;
+
+        RequiredEntries = TotalClusters + 2ULL;
+        FatBytes = RequiredEntries * sizeof(ULONG);
+        NewFatSize = (FatBytes + BytesPerSector - 1) / BytesPerSector;
+        if (NewFatSize == FatSize)
+        {
+            *FatSizeSectors = (ULONG)FatSize;
+            *DataSectors = (ULONG)CalcDataSectors;
+            *ClusterCount = (ULONG)TotalClusters;
+            return TRUE;
+        }
+
+        if (NewFatSize == 0 || NewFatSize > 0xFFFFFFFFULL)
+            return FALSE;
+
+        FatSize = NewFatSize;
+    }
+
+    return FALSE;
+}
+
+static
+BOOLEAN
+FormatFat32Volume(IN PUCHAR VolumeBase,
+                  IN ULONGLONG VolumeSize,
+                  IN ULONG HiddenSectors,
+                  OUT PRAMDISK_FAT32_LAYOUT Layout)
+{
+    static const UCHAR ClusterCandidates[] = { 128, 64, 32, 16, 8, 4, 2, 1 };
+    PFAT32_BOOTSECTOR BootSector;
+    PFAT32_FSINFO_RECORD FsInfo;
+    ULONG BytesPerSector = DEFAULT_BYTES_PER_SECTOR;
+    ULONG ReservedSectors = DEFAULT_RESERVED_SECTORS;
+    ULONG NumberOfFats = DEFAULT_NUM_FATS;
+    ULONG TotalSectors;
+    ULONG FatSize = 0;
+    ULONG DataSectors = 0;
+    ULONG ClusterCount = 0;
+    ULONG SectorsPerCluster = 0;
+    ULONG FirstDataSector;
+    ULONG CandidateIndex;
+    SIZE_T ByteSize;
+    PUCHAR Buffer;
+    PULONG FatTable;
+
+    if (!VolumeBase)
+        return FALSE;
+
+    if (VolumeSize == 0 || VolumeSize > MAXULONG)
+        return FALSE;
+
+    if ((VolumeSize % BytesPerSector) != 0)
+        return FALSE;
+
+    TotalSectors = (ULONG)(VolumeSize / BytesPerSector);
+    if (TotalSectors <= (ReservedSectors + NumberOfFats))
+        return FALSE;
+
+    for (CandidateIndex = 0; CandidateIndex < ARRAYSIZE(ClusterCandidates); ++CandidateIndex)
+    {
+        ULONG Candidate = ClusterCandidates[CandidateIndex];
+
+        if (!ComputeFatLayout(TotalSectors,
+                              ReservedSectors,
+                              BytesPerSector,
+                              NumberOfFats,
+                              Candidate,
+                              &FatSize,
+                              &DataSectors,
+                              &ClusterCount))
+        {
+            continue;
+        }
+
+        if (ClusterCount >= FAT32_MIN_CLUSTERS && ClusterCount < FAT32_MAX_CLUSTERS)
+        {
+            SectorsPerCluster = Candidate;
+            break;
+        }
+    }
+
+    if (SectorsPerCluster == 0)
+        return FALSE;
+
+    ByteSize = (SIZE_T)VolumeSize;
+    /* Zero the entire volume to prevent information leaks from prior boot
+     * memory contents and to ensure all FAT/directory regions start clean. */
+    RtlZeroMemory(VolumeBase, ByteSize);
+
+    BootSector = (PFAT32_BOOTSECTOR)VolumeBase;
+    BootSector->JumpBoot[0] = 0xEB;
+    BootSector->JumpBoot[1] = 0x58;
+    BootSector->JumpBoot[2] = 0x90;
+    RtlCopyMemory(BootSector->OemName, "MSWIN4.1", sizeof(BootSector->OemName));
+    BootSector->BytesPerSector = BytesPerSector;
+    BootSector->SectorsPerCluster = (UCHAR)SectorsPerCluster;
+    BootSector->ReservedSectors = ReservedSectors;
+    BootSector->NumberOfFats = (UCHAR)NumberOfFats;
+    BootSector->RootDirEntries = 0;
+    BootSector->TotalSectors = 0;
+    BootSector->MediaDescriptor = DEFAULT_MEDIA_DESCRIPTOR;
+    BootSector->SectorsPerFat = 0;
+    BootSector->SectorsPerTrack = DEFAULT_SECTORS_PER_TRACK;
+    BootSector->NumberOfHeads = DEFAULT_NUMBER_OF_HEADS;
+    BootSector->HiddenSectors = HiddenSectors;
+    BootSector->TotalSectorsBig = TotalSectors;
+    BootSector->SectorsPerFatBig = FatSize;
+    BootSector->ExtendedFlags = 0;
+    BootSector->FileSystemVersion = 0;
+    BootSector->RootDirStartCluster = DEFAULT_ROOT_DIR_CLUSTER;
+    BootSector->FsInfo = 1;
+    BootSector->BackupBootSector = DEFAULT_BACKUP_BOOT_SECTOR;
+    RtlZeroMemory(BootSector->Reserved, sizeof(BootSector->Reserved));
+    BootSector->DriveNumber = 0x80;
+    BootSector->Reserved1 = 0;
+    BootSector->BootSignature = 0x29;
+    BootSector->VolumeSerialNumber = 0x20250101;
+    RtlCopyMemory(BootSector->VolumeLabel, "REACTOS    ", sizeof(BootSector->VolumeLabel));
+    RtlCopyMemory(BootSector->FileSystemType, "FAT32   ", sizeof(BootSector->FileSystemType));
+    BootSector->BootSectorMagic = 0xAA55;
+
+    FsInfo = (PFAT32_FSINFO_RECORD)(VolumeBase + BytesPerSector * BootSector->FsInfo);
+    FsInfo->LeadSignature = 0x41615252;
+    RtlZeroMemory(FsInfo->Reserved1, sizeof(FsInfo->Reserved1));
+    FsInfo->StructSignature = 0x61417272;
+    FsInfo->FreeCount = 0xFFFFFFFF;
+    FsInfo->NextFree = 0xFFFFFFFF;
+    RtlZeroMemory(FsInfo->Reserved2, sizeof(FsInfo->Reserved2));
+    FsInfo->TrailSignature = 0xAA550000;
+
+    /* Create backup copies of the boot sector and FSINFO if they fit in the reserved region. */
+    if (BootSector->BackupBootSector < ReservedSectors)
+    {
+        PUCHAR BackupBoot = VolumeBase + BytesPerSector * BootSector->BackupBootSector;
+        RtlCopyMemory(BackupBoot, BootSector, BytesPerSector);
+
+        if (BootSector->BackupBootSector + 1U < ReservedSectors)
+        {
+            PUCHAR BackupFsInfo = VolumeBase + BytesPerSector * (BootSector->BackupBootSector + 1U);
+            RtlCopyMemory(BackupFsInfo, FsInfo, BytesPerSector);
+        }
+    }
+
+    /* Initialize both FATs. */
+    Buffer = VolumeBase + (ReservedSectors * BytesPerSector);
+    ULONG FatIndex;
+    for (FatIndex = 0; FatIndex < NumberOfFats; ++FatIndex)
+    {
+        FatTable = (PULONG)(Buffer + ((ULONGLONG)FatIndex * FatSize * BytesPerSector));
+        RtlZeroMemory(FatTable, (ULONGLONG)FatSize * BytesPerSector);
+        FatTable[0] = 0x0FFFFFF8 | DEFAULT_MEDIA_DESCRIPTOR;
+        FatTable[1] = 0xFFFFFFFF;
+        FatTable[2] = 0x0FFFFFFF; /* Root directory cluster */
+    }
+
+    FirstDataSector = ReservedSectors + (NumberOfFats * FatSize);
+
+    if (Layout)
+    {
+        Layout->BytesPerSector = BytesPerSector;
+        Layout->SectorsPerCluster = SectorsPerCluster;
+        Layout->ReservedSectors = ReservedSectors;
+        Layout->NumberOfFats = NumberOfFats;
+        Layout->FatSizeSectors = FatSize;
+        Layout->FirstDataSector = FirstDataSector;
+        Layout->RootDirFirstCluster = DEFAULT_ROOT_DIR_CLUSTER;
+        Layout->TotalSectors = TotalSectors;
+        Layout->HiddenSectors = HiddenSectors;
+        Layout->VolumeSizeBytes = VolumeSize;
+    }
+
+    return TRUE;
+}
+
+BOOLEAN
+RamDiskFormatFat32(IN PVOID BaseAddress,
+                   IN ULONGLONG DiskSize,
+                   OUT PRAMDISK_FAT32_LAYOUT Layout)
+{
+    const ULONG BytesPerSector = DEFAULT_BYTES_PER_SECTOR;
+    ULONGLONG MinimumSize;
+    PUCHAR VolumeBase;
+    ULONGLONG VolumeSize;
+    RAMDISK_FAT32_LAYOUT LocalLayout;
+    PRAMDISK_FAT32_LAYOUT LayoutOut;
+    PMASTER_BOOT_RECORD MasterBootRecord;
+    ULONG PartitionSectors;
+
+    if (!BaseAddress)
+        return FALSE;
+
+    MinimumSize = (ULONGLONG)BytesPerSector * 2ULL;
+    if (DiskSize < MinimumSize || (DiskSize % BytesPerSector) != 0)
+        return FALSE;
+
+    VolumeBase = (PUCHAR)BaseAddress + BytesPerSector;
+    VolumeSize = DiskSize - BytesPerSector;
+    LayoutOut = Layout ? Layout : &LocalLayout;
+
+    if (!FormatFat32Volume(VolumeBase, VolumeSize, 1, LayoutOut))
+        return FALSE;
+
+    MasterBootRecord = (PMASTER_BOOT_RECORD)BaseAddress;
+    RtlZeroMemory(MasterBootRecord, BytesPerSector);
+
+    MasterBootRecord->Signature = RamDiskDeriveDiskSignature(BaseAddress, DiskSize);
+    MasterBootRecord->PartitionTable[0].BootIndicator = 0x80;
+    MasterBootRecord->PartitionTable[0].StartHead = 0x00;
+    MasterBootRecord->PartitionTable[0].StartSector = 0x02; /* LBA 1 */
+    MasterBootRecord->PartitionTable[0].StartCylinder = 0x00;
+    MasterBootRecord->PartitionTable[0].SystemIndicator = PARTITION_FAT32_XINT13;
+    MasterBootRecord->PartitionTable[0].EndHead = 0xFE;
+    MasterBootRecord->PartitionTable[0].EndSector = 0xFF;
+    MasterBootRecord->PartitionTable[0].EndCylinder = 0xFF;
+    MasterBootRecord->PartitionTable[0].SectorCountBeforePartition = 1;
+
+    PartitionSectors = LayoutOut->TotalSectors;
+    if (PartitionSectors == 0)
+        return FALSE;
+
+    MasterBootRecord->PartitionTable[0].PartitionSectorCount = PartitionSectors;
+    MasterBootRecord->MasterBootRecordMagic = 0xAA55;
+
+    return TRUE;
+}

--- a/boot/freeldr/freeldr/ntldr/setupldr.c
+++ b/boot/freeldr/freeldr/ntldr/setupldr.c
@@ -609,17 +609,28 @@ LoadReactOSSetup(
 
     TRACE("BootOptions: '%s'\n", BootOptions);
 
-    /* Check if a RAM disk file was given */
+    /* Check if a RAM disk is needed: either an explicit RDPATH= file,
+     * a writable ramdisk size request (RDRAMSIZE=), or the boot path
+     * itself targets the ramdisk device. */
     FileName = (PSTR)NtLdrGetOptionEx(BootOptions, "RDPATH=", &FileNameLength);
-    if (FileName && (FileNameLength >= 7))
+    if ((FileName && (FileNameLength >= 7)) ||
+        NtLdrGetOption(BootOptions, "RDRAMSIZE=") ||
+        _strnicmp(BootPath, "ramdisk(", 8) == 0)
     {
         /* Load the RAM disk */
         Status = RamDiskInitialize(FALSE, BootOptions, SystemPartition);
         if (Status != ESUCCESS)
         {
-            FileName += 7; FileNameLength -= 7;
-            UiMessageBox("Failed to load RAM disk file '%.*s'",
-                         FileNameLength, FileName);
+            if (FileName && (FileNameLength >= 7))
+            {
+                FileName += 7; FileNameLength -= 7;
+                UiMessageBox("Failed to load RAM disk file '%.*s'",
+                             FileNameLength, FileName);
+            }
+            else
+            {
+                UiMessageBox("Failed to initialize RAM disk");
+            }
             return Status;
         }
     }

--- a/boot/freeldr/freeldr/ntldr/winldr.c
+++ b/boot/freeldr/freeldr/ntldr/winldr.c
@@ -28,7 +28,7 @@ extern BOOLEAN WinLdrTerminalConnected;
 extern VOID WinLdrSetupEms(_In_ PCSTR BootOptions);
 
 PLOADER_SYSTEM_BLOCK WinLdrSystemBlock;
-/**/PCWSTR BootFileSystem = NULL;/**/
+PCWSTR BootFileSystem = NULL;
 
 BOOLEAN VirtualBias = FALSE;
 BOOLEAN SosEnabled = FALSE;
@@ -59,7 +59,6 @@ NtLdrOutputLoadMsg(
     if (SosEnabled)
     {
         printf("  %s\n", FileName);
-        TRACE("Loading: %s\n", FileName);
     }
     else
     {
@@ -1272,17 +1271,28 @@ LoadAndBootWindows(
 
     TRACE("BootOptions: '%s'\n", BootOptions);
 
-    /* Check if a RAM disk file was given */
+    /* Check if a RAM disk is needed: either an explicit RDPATH= file,
+     * a writable ramdisk size request (RDRAMSIZE=), or the boot path
+     * itself targets the ramdisk device. */
     FileName = NtLdrGetOptionEx(BootOptions, "RDPATH=", &FileNameLength);
-    if (FileName && (FileNameLength >= 7))
+    if ((FileName && (FileNameLength >= 7)) ||
+        NtLdrGetOption(BootOptions, "RDRAMSIZE=") ||
+        _strnicmp(BootPath, "ramdisk(", 8) == 0)
     {
         /* Load the RAM disk */
         Status = RamDiskInitialize(FALSE, BootOptions, SystemPartition);
         if (Status != ESUCCESS)
         {
-            FileName += 7; FileNameLength -= 7;
-            UiMessageBox("Failed to load RAM disk file '%.*s'",
-                         FileNameLength, FileName);
+            if (FileName && (FileNameLength >= 7))
+            {
+                FileName += 7; FileNameLength -= 7;
+                UiMessageBox("Failed to load RAM disk file '%.*s'",
+                             FileNameLength, FileName);
+            }
+            else
+            {
+                UiMessageBox("Failed to initialize RAM disk");
+            }
             return Status;
         }
     }

--- a/boot/freeldr/freeldr/ui/ui.c
+++ b/boot/freeldr/freeldr/ui/ui.c
@@ -515,7 +515,7 @@ UiEscapeString(PCHAR String)
             String[Idx] = '\n';
 
             // Move the rest of the string up
-            strcpy(&String[Idx+1], &String[Idx+2]);
+            memmove(&String[Idx+1], &String[Idx+2], strlen(&String[Idx+2]) + 1);
         }
     }
 }

--- a/drivers/storage/class/ramdisk/ramdisk.c
+++ b/drivers/storage/class/ramdisk/ramdisk.c
@@ -4,6 +4,7 @@
  * FILE:            drivers/storage/class/ramdisk/ramdisk.c
  * PURPOSE:         Main Driver Routines
  * PROGRAMMERS:     ReactOS Portable Systems Group
+ *                  Ahmed ARIF 2025 <arif193@gmail.com>
  */
 
 /* INCLUDES *******************************************************************/
@@ -13,6 +14,7 @@
 #include <ntifs.h>
 #include <ntdddisk.h>
 #include <ntddcdrm.h>
+#include <ntddstor.h>
 #include <scsi.h>
 #include <ntddscsi.h>
 #include <ntddvol.h>
@@ -25,10 +27,61 @@
 #include <reactos/drivers/ntddrdsk.h>
 #include "../../../filesystems/fs_rec/fs_rec.h"
 #include <stdio.h>
+#include <limits.h>
+#include <wchar.h>
 #define NDEBUG
 #include <debug.h>
 
 #define DO_XIP   0x00020000
+
+#define ISO9660_PRIMARY_VOLUME_DESCRIPTOR_OFFSET  0x8000
+#define ISO9660_PRIMARY_VOLUME_DESCRIPTOR_TYPE    0x01
+#define ISO9660_PRIMARY_VOLUME_DESCRIPTOR_VERSION 0x01
+#define ISO9660_SIGNATURE                         "CD001"
+#define ISO9660_SIGNATURE_LENGTH                  5
+#define ISO9660_PROBE_LENGTH                      2048
+
+#include <pshpack1.h>
+typedef struct _RAMDISK_MBR_PARTITION_ENTRY
+{
+    UCHAR BootIndicator;
+    UCHAR StartHead;
+    UCHAR StartSector;
+    UCHAR StartCylinder;
+    UCHAR SystemIndicator;
+    UCHAR EndHead;
+    UCHAR EndSector;
+    UCHAR EndCylinder;
+    ULONG SectorCountBeforePartition;
+    ULONG PartitionSectorCount;
+} RAMDISK_MBR_PARTITION_ENTRY, *PRAMDISK_MBR_PARTITION_ENTRY;
+
+typedef struct _RAMDISK_MASTER_BOOT_RECORD
+{
+    UCHAR BootCode[0x1B8];
+    ULONG Signature;
+    USHORT Reserved;
+    RAMDISK_MBR_PARTITION_ENTRY PartitionTable[4];
+    USHORT Magic;
+} RAMDISK_MASTER_BOOT_RECORD, *PRAMDISK_MASTER_BOOT_RECORD;
+#include <poppack.h>
+
+_IRQL_requires_max_(DISPATCH_LEVEL)
+static __inline BOOLEAN
+RamdiskBootSectorHasSignature(IN PPACKED_BOOT_SECTOR BootSector)
+{
+    return *((PUSHORT)((PUCHAR)BootSector + 0x1FE)) == 0xAA55;
+}
+
+#ifndef IOCTL_MOUNTDEV_QUERY_DEVICE_RELATIONS
+#define IOCTL_MOUNTDEV_QUERY_DEVICE_RELATIONS \
+    CTL_CODE(MOUNTDEVCONTROLTYPE, 7, METHOD_BUFFERED, FILE_ANY_ACCESS)
+typedef struct _MOUNTDEV_DEVICE_RELATIONS
+{
+    ULONG NumberOfObjects;
+    PDEVICE_OBJECT Objects[1];
+} MOUNTDEV_DEVICE_RELATIONS, *PMOUNTDEV_DEVICE_RELATIONS;
+#endif
 
 /* GLOBALS ********************************************************************/
 
@@ -97,12 +150,14 @@ typedef struct _RAMDISK_DRIVE_EXTENSION
     GUID DiskGuid;
     UNICODE_STRING GuidString;
     UNICODE_STRING SymbolicLinkName;
+    UNICODE_STRING DeviceObjectName;
     ULONG DiskType;
     RAMDISK_CREATE_OPTIONS DiskOptions;
     LARGE_INTEGER DiskLength;
     LONG DiskOffset;
     WCHAR DriveLetter;
-    ULONG BasePage;
+    ULONG_PTR BasePage;
+    ULONG DiskNumber;
 
     /* Data we get from the disk */
     ULONG BytesPerSector;
@@ -110,6 +165,28 @@ typedef struct _RAMDISK_DRIVE_EXTENSION
     ULONG NumberOfHeads;
     ULONG Cylinders;
     ULONG HiddenSectors;
+    BOOLEAN VolumeOffline;
+    ULONG MountdevLinkCount;
+
+    /* Boot PFN mapping state */
+    PVOID BootPfnMappingBase;
+    PULONG BootPfnArray;
+    SIZE_T BootPfnMappingSize;
+    ULONG BootPfnCount;
+    ULONG BootPfnTableOffset;
+    BOOLEAN BootPfnUsesList;
+    BOOLEAN BootPfnInitialized;
+    BOOLEAN BootPfnMappingOwned;
+    PVOID BootZeroPage;
+
+    /* Two-level PFN mapping state (map pages -> data pages) */
+    BOOLEAN BootPfnIsTwoLevel;      /* TRUE if using two-level mapping */
+    ULONG BootPfnMapPageCount;      /* Number of map pages */
+    PULONG *BootPfnMapPages;        /* Array of pointers to mapped PFN tables */
+    SIZE_T *BootPfnMapSizes;        /* Size of each mapped table for cleanup */
+
+    /* MountMgr unique ID change notify support */
+    PIRP PendingUniqueIdNotifyIrp;
 } RAMDISK_DRIVE_EXTENSION, *PRAMDISK_DRIVE_EXTENSION;
 
 ULONG MaximumViewLength;
@@ -117,6 +194,1018 @@ ULONG MaximumPerDiskViewLength;
 ULONG ReportDetectedDevice;
 ULONG MarkRamdisksAsRemovable;
 ULONG MinimumViewCount;
+LONG RamdiskDiskNumberSeed;
+NTSTATUS
+NTAPI
+RamdiskReadWriteReal(IN PIRP Irp,
+                     IN PRAMDISK_DRIVE_EXTENSION DeviceExtension);
+
+static
+BOOLEAN
+RamdiskEnsureBootPfnTable(IN PRAMDISK_DRIVE_EXTENSION DriveExtension);
+
+static
+VOID
+RamdiskReleaseBootPfnTable(IN PRAMDISK_DRIVE_EXTENSION DriveExtension);
+
+static
+PVOID
+RamdiskMapBootPfn(IN PRAMDISK_DRIVE_EXTENSION DeviceExtension,
+                  IN LARGE_INTEGER Offset,
+                  IN ULONG Length,
+                  OUT PULONG OutputLength,
+                  OUT PULONG MappingLength);
+
+static
+NTSTATUS
+RamdiskBuildRegistrySubKey(IN PRAMDISK_DRIVE_EXTENSION DriveExtension,
+                           _Out_writes_(BufferChars) PWSTR Buffer,
+                           _In_ ULONG BufferChars);
+
+static
+VOID
+RamdiskPersistDiskState(IN PRAMDISK_DRIVE_EXTENSION DriveExtension);
+
+static
+VOID
+RamdiskRestoreDiskState(IN PRAMDISK_DRIVE_EXTENSION DriveExtension);
+
+static
+ULONGLONG
+RamdiskQueryGptAttributes(IN PRAMDISK_DRIVE_EXTENSION DriveExtension);
+
+static
+VOID
+RamdiskApplyGptAttributes(IN PRAMDISK_DRIVE_EXTENSION DriveExtension,
+                          ULONGLONG Attributes);
+
+static
+VOID
+NTAPI
+RamdiskCancelUniqueIdNotify(IN PDEVICE_OBJECT DeviceObject,
+                            IN PIRP Irp)
+{
+    PRAMDISK_DRIVE_EXTENSION DriveExtension = (PRAMDISK_DRIVE_EXTENSION)DeviceObject->DeviceExtension;
+    KIRQL CancelIrql = Irp->CancelIrql;
+
+    /* Cancel spin lock is held on entry; clear our pending pointer */
+    if (DriveExtension && DriveExtension->PendingUniqueIdNotifyIrp == Irp)
+    {
+        DriveExtension->PendingUniqueIdNotifyIrp = NULL;
+    }
+
+    /* Release the remove lock while cancel spin lock is still held to prevent
+     * a race with RamdiskDeleteDiskDevice freeing the extension. */
+    if (DriveExtension)
+    {
+        IoReleaseRemoveLock(&DriveExtension->RemoveLock, Irp);
+    }
+
+    IoReleaseCancelSpinLock(CancelIrql);
+
+    Irp->IoStatus.Status = STATUS_CANCELLED;
+    Irp->IoStatus.Information = 0;
+    IoCompleteRequest(Irp, IO_NO_INCREMENT);
+}
+
+static
+VOID
+RamdiskEnsureRegistryPath(IN PRAMDISK_DRIVE_EXTENSION DriveExtension)
+{
+    WCHAR KeyBuffer[128];
+    NTSTATUS Status;
+
+    RtlCreateRegistryKey(RTL_REGISTRY_SERVICES, L"Ramdisk");
+    RtlCreateRegistryKey(RTL_REGISTRY_SERVICES, L"Ramdisk\\Parameters");
+    RtlCreateRegistryKey(RTL_REGISTRY_SERVICES, L"Ramdisk\\Parameters\\Disks");
+
+    Status = RamdiskBuildRegistrySubKey(DriveExtension, KeyBuffer, RTL_NUMBER_OF(KeyBuffer));
+    if (NT_SUCCESS(Status))
+    {
+        RtlCreateRegistryKey(RTL_REGISTRY_SERVICES, KeyBuffer);
+    }
+}
+
+static
+BOOLEAN
+RamdiskEnsureBootPfnTable(IN PRAMDISK_DRIVE_EXTENSION DriveExtension)
+{
+    PHYSICAL_ADDRESS TablePhysical;
+    PULONG Table;
+    ULONGLONG TotalBytes;
+    ULONG EntryCount;
+    SIZE_T TableBytes;
+    SIZE_T MapBytes;
+    SIZE_T SpanBytes;
+    ULONG SpanWords;
+    ULONG Index;
+    const ULONG RequiredRun = 4;
+
+    if (DriveExtension->BootPfnInitialized)
+    {
+        return TRUE;
+    }
+
+    DriveExtension->BootPfnMappingBase = NULL;
+    DriveExtension->BootPfnArray = NULL;
+    DriveExtension->BootPfnMappingSize = 0;
+    DriveExtension->BootPfnCount = 0;
+    DriveExtension->BootPfnTableOffset = 0;
+    DriveExtension->BootPfnUsesList = FALSE;
+    DriveExtension->BootPfnMappingOwned = FALSE;
+    DriveExtension->BootZeroPage = NULL;
+    DriveExtension->BootPfnIsTwoLevel = FALSE;
+    DriveExtension->BootPfnMapPageCount = 0;
+    DriveExtension->BootPfnMapPages = NULL;
+    DriveExtension->BootPfnMapSizes = NULL;
+
+    if (DriveExtension->DiskType != RAMDISK_BOOT_DISK)
+    {
+        DriveExtension->BootPfnInitialized = TRUE;
+        return TRUE;
+    }
+
+    /* Writable boot ramdisk (overlay) uses a contiguous allocation built by FreeLdr.
+       Avoid PFN table heuristics and map directly from BasePage + DiskOffset. */
+    if (!DriveExtension->DiskOptions.Readonly)
+    {
+        DriveExtension->BootPfnInitialized = TRUE;
+        DriveExtension->BootPfnUsesList = FALSE;
+        DriveExtension->BootPfnMappingOwned = FALSE;
+        DriveExtension->BootPfnArray = NULL;
+        DriveExtension->BootPfnCount = 0;
+        return TRUE;
+    }
+
+    TotalBytes = DriveExtension->DiskOffset + DriveExtension->DiskLength.QuadPart;
+    EntryCount = (ULONG)(TotalBytes >> PAGE_SHIFT);
+    if (TotalBytes & (PAGE_SIZE - 1)) EntryCount++;
+    if (EntryCount == 0) EntryCount = 1;
+
+    TableBytes = (SIZE_T)EntryCount * sizeof(ULONG);
+    MapBytes = TableBytes + 0x20000;
+    if (MapBytes < TableBytes)
+    {
+        return FALSE;
+    }
+    TablePhysical.QuadPart = (ULONGLONG)DriveExtension->BasePage << PAGE_SHIFT;
+    SpanBytes = ADDRESS_AND_SIZE_TO_SPAN_PAGES(TablePhysical.QuadPart, MapBytes) << PAGE_SHIFT;
+    Table = MmMapIoSpace(TablePhysical, SpanBytes, MmCached);
+    if (!Table)
+    {
+        return FALSE;
+    }
+
+    SpanWords = (ULONG)(SpanBytes / sizeof(ULONG));
+    DriveExtension->BootPfnMappingBase = Table;
+    DriveExtension->BootPfnMappingSize = SpanBytes;
+    DriveExtension->BootPfnCount = EntryCount;
+    DriveExtension->BootPfnTableOffset = 0;
+    DriveExtension->BootPfnMappingOwned = TRUE;
+
+    for (Index = 0; Index + RequiredRun < SpanWords; Index++)
+    {
+        ULONG Value = Table[Index];
+        ULONG Run;
+
+        if (Value == 0)
+        {
+            continue;
+        }
+
+        for (Run = 1; Run < RequiredRun; Run++)
+        {
+            if (Table[Index + Run] != Value + Run)
+            {
+                break;
+            }
+        }
+
+        if (Run == RequiredRun)
+        {
+            DriveExtension->BootPfnArray = &Table[Index];
+            DriveExtension->BootPfnTableOffset = Index;
+            DriveExtension->BootPfnUsesList = TRUE;
+            break;
+        }
+    }
+
+    if (!DriveExtension->BootPfnArray)
+    {
+#if DBG
+        DbgPrintEx(DPFLTR_DEFAULT_ID,
+                   DPFLTR_ERROR_LEVEL,
+                   "RamdiskEnsureBootPfnTable: failed to locate PFN table (entries=%lu)\n",
+                   EntryCount);
+#endif
+        RamdiskReleaseBootPfnTable(DriveExtension);
+        return FALSE;
+    }
+
+#if DBG
+    if (DriveExtension->BootPfnTableOffset >= SpanWords)
+    {
+        DbgPrintEx(DPFLTR_DEFAULT_ID,
+                   DPFLTR_ERROR_LEVEL,
+                   "RamdiskEnsureBootPfnTable: PFN offset %lu exceeds span %lu\n",
+                   DriveExtension->BootPfnTableOffset,
+                   SpanWords);
+    }
+#endif
+    if (DriveExtension->BootPfnTableOffset >= SpanWords)
+    {
+        RamdiskReleaseBootPfnTable(DriveExtension);
+        return FALSE;
+    }
+
+    {
+        ULONG AvailableEntries = SpanWords - DriveExtension->BootPfnTableOffset;
+        if (AvailableEntries < EntryCount)
+        {
+            SIZE_T TableOffsetBytes = (SIZE_T)DriveExtension->BootPfnTableOffset * sizeof(ULONG);
+            SIZE_T GuardBytes = PAGE_SIZE;
+            SIZE_T RequiredBytes;
+            SIZE_T RequiredSpanBytes;
+
+            if (TableOffsetBytes > (SIZE_T)-1 - TableBytes - GuardBytes)
+            {
+                RamdiskReleaseBootPfnTable(DriveExtension);
+                return FALSE;
+            }
+
+            RequiredBytes = TableOffsetBytes + TableBytes + GuardBytes;
+            RequiredSpanBytes = ADDRESS_AND_SIZE_TO_SPAN_PAGES(TablePhysical.QuadPart,
+                                                               RequiredBytes) << PAGE_SHIFT;
+
+            if (RequiredSpanBytes > SpanBytes)
+            {
+                PULONG OldTable = Table;
+                SIZE_T OldSpanBytes = SpanBytes;
+                PULONG NewTable;
+
+                NewTable = MmMapIoSpace(TablePhysical, RequiredSpanBytes, MmCached);
+                if (!NewTable)
+                {
+                    RamdiskReleaseBootPfnTable(DriveExtension);
+                    return FALSE;
+                }
+
+                MmUnmapIoSpace(OldTable, OldSpanBytes);
+
+                Table = NewTable;
+                SpanBytes = RequiredSpanBytes;
+                SpanWords = (ULONG)(SpanBytes / sizeof(ULONG));
+                DriveExtension->BootPfnMappingBase = Table;
+                DriveExtension->BootPfnMappingSize = SpanBytes;
+                DriveExtension->BootPfnArray = &Table[DriveExtension->BootPfnTableOffset];
+                AvailableEntries = SpanWords - DriveExtension->BootPfnTableOffset;
+            }
+
+            if (AvailableEntries < EntryCount)
+            {
+#if DBG
+                DbgPrintEx(DPFLTR_DEFAULT_ID,
+                           DPFLTR_ERROR_LEVEL,
+                           "RamdiskEnsureBootPfnTable: PFN table truncated (offset=%lu span=%lu entries=%lu required=%lu)\n",
+                           DriveExtension->BootPfnTableOffset,
+                           SpanWords,
+                           AvailableEntries,
+                           EntryCount);
+#endif
+                RamdiskReleaseBootPfnTable(DriveExtension);
+                return FALSE;
+            }
+        }
+    }
+
+    if ((DriveExtension->BootPfnArray < Table) ||
+        ((ULONG_PTR)(DriveExtension->BootPfnArray - Table) >= SpanWords))
+    {
+        RamdiskReleaseBootPfnTable(DriveExtension);
+        return FALSE;
+    }
+
+#if DBG
+    DbgPrintEx(DPFLTR_DEFAULT_ID,
+               DPFLTR_ERROR_LEVEL,
+               "RamdiskEnsureBootPfnTable: tableOffset=%lu span=%lu firstPFN=%lX entries=%lu\n",
+               DriveExtension->BootPfnTableOffset,
+               SpanWords,
+               DriveExtension->BootPfnArray[0],
+               DriveExtension->BootPfnCount);
+#endif
+
+    /*
+     * Detect two-level PFN mapping format:
+     * In the new format, BootPfnArray contains map page PFNs (e.g., 0x54, 0x55...)
+     * which are much smaller than BasePage. Each map page is a 4KiB table of 1024
+     * PFNs pointing to actual data pages. Entries may be separated by 0x0FFFFFFF
+     * markers for zero pages.
+     */
+    {
+        const ULONG InvalidPfnMarker = 0x0FFFFFFF;
+        const ULONG PfnsPerMapPage = PAGE_SIZE / sizeof(ULONG);  /* 1024 */
+        BOOLEAN IsTwoLevel = FALSE;
+        ULONG MapPageCount = 0;
+        ULONG i;
+
+        /* Check if first PFN is much smaller than BasePage (heuristic for two-level) */
+        if (DriveExtension->BootPfnArray[0] != 0 &&
+            DriveExtension->BootPfnArray[0] < InvalidPfnMarker &&
+            DriveExtension->BootPfnArray[0] < DriveExtension->BasePage)
+        {
+            IsTwoLevel = TRUE;
+        }
+
+        if (IsTwoLevel)
+        {
+            /* Count map pages (non-zero, non-marker entries) */
+            for (i = 0; i < DriveExtension->BootPfnCount && i < 256; i++)
+            {
+                ULONG Pfn = DriveExtension->BootPfnArray[i];
+                if (Pfn != 0 && Pfn < InvalidPfnMarker)
+                {
+                    MapPageCount++;
+                }
+            }
+
+            if (MapPageCount == 0)
+            {
+                IsTwoLevel = FALSE;
+            }
+        }
+
+        if (IsTwoLevel)
+        {
+#if DBG
+            DbgPrintEx(DPFLTR_DEFAULT_ID,
+                       DPFLTR_ERROR_LEVEL,
+                       "RamdiskEnsureBootPfnTable: detected two-level mapping, mapPages=%lu\n",
+                       MapPageCount);
+#endif
+
+            /* Allocate array of pointers to map pages */
+            DriveExtension->BootPfnMapPages = ExAllocatePoolWithTag(
+                NonPagedPool,
+                MapPageCount * sizeof(PULONG),
+                'fmRd');
+            if (!DriveExtension->BootPfnMapPages)
+            {
+                RamdiskReleaseBootPfnTable(DriveExtension);
+                return FALSE;
+            }
+            RtlZeroMemory(DriveExtension->BootPfnMapPages, MapPageCount * sizeof(PULONG));
+
+            DriveExtension->BootPfnMapSizes = ExAllocatePoolWithTag(
+                NonPagedPool,
+                MapPageCount * sizeof(SIZE_T),
+                'smRd');
+            if (!DriveExtension->BootPfnMapSizes)
+            {
+                RamdiskReleaseBootPfnTable(DriveExtension);
+                return FALSE;
+            }
+            RtlZeroMemory(DriveExtension->BootPfnMapSizes, MapPageCount * sizeof(SIZE_T));
+
+            /* Map each map page */
+            {
+                ULONG MapIdx = 0;
+                for (i = 0; i < DriveExtension->BootPfnCount && MapIdx < MapPageCount; i++)
+                {
+                    ULONG MapPfn = DriveExtension->BootPfnArray[i];
+                    PHYSICAL_ADDRESS MapPhysical;
+                    PULONG MapPage;
+
+                    if (MapPfn == 0 || MapPfn >= InvalidPfnMarker)
+                    {
+                        continue;
+                    }
+
+                    /* Map PFNs are relative to BasePage, just like single-level PFNs */
+                    MapPhysical.QuadPart = (ULONGLONG)(DriveExtension->BasePage + MapPfn) << PAGE_SHIFT;
+                    MapPage = MmMapIoSpace(MapPhysical, PAGE_SIZE, MmCached);
+                    if (!MapPage)
+                    {
+#if DBG
+                        DbgPrintEx(DPFLTR_DEFAULT_ID,
+                                   DPFLTR_ERROR_LEVEL,
+                                   "RamdiskEnsureBootPfnTable: failed to map page %lu (PFN=%lX)\n",
+                                   MapIdx,
+                                   MapPfn);
+#endif
+                        RamdiskReleaseBootPfnTable(DriveExtension);
+                        return FALSE;
+                    }
+
+                    DriveExtension->BootPfnMapPages[MapIdx] = MapPage;
+                    DriveExtension->BootPfnMapSizes[MapIdx] = PAGE_SIZE;
+                    MapIdx++;
+
+#if DBG
+                    if (MapIdx <= 2)
+                    {
+                        ULONG j;
+                        DbgPrintEx(DPFLTR_DEFAULT_ID,
+                                   DPFLTR_ERROR_LEVEL,
+                                   "  Map[%lu] PFN=%lX -> first 8 PFNs:\n",
+                                   MapIdx - 1,
+                                   MapPfn);
+                        for (j = 0; j < 8 && j < PAGE_SIZE/sizeof(ULONG); j++)
+                        {
+                            DbgPrintEx(DPFLTR_DEFAULT_ID,
+                                       DPFLTR_ERROR_LEVEL,
+                                       "    [%lu]=%lX",
+                                       j,
+                                       MapPage[j]);
+                            if ((j + 1) % 4 == 0)
+                                DbgPrintEx(DPFLTR_DEFAULT_ID, DPFLTR_ERROR_LEVEL, "\n");
+                        }
+                        if (j % 4 != 0)
+                            DbgPrintEx(DPFLTR_DEFAULT_ID, DPFLTR_ERROR_LEVEL, "\n");
+                    }
+#endif
+                }
+            }
+
+            DriveExtension->BootPfnIsTwoLevel = TRUE;
+            DriveExtension->BootPfnMapPageCount = MapPageCount;
+
+            /* Update BootPfnCount to reflect total data pages available */
+            DriveExtension->BootPfnCount = MapPageCount * PfnsPerMapPage;
+        }
+        else
+        {
+            /* Single-level mapping: BootPfnArray directly contains data page PFNs */
+            DriveExtension->BootPfnIsTwoLevel = FALSE;
+        }
+    }
+
+    DriveExtension->BootPfnInitialized = TRUE;
+    return TRUE;
+}
+
+static
+VOID
+RamdiskReleaseBootPfnTable(IN PRAMDISK_DRIVE_EXTENSION DriveExtension)
+{
+    /* Clean up two-level mapping resources */
+    if (DriveExtension->BootPfnMapPages)
+    {
+        ULONG i;
+        for (i = 0; i < DriveExtension->BootPfnMapPageCount; i++)
+        {
+            if (DriveExtension->BootPfnMapPages[i] &&
+                DriveExtension->BootPfnMapSizes &&
+                DriveExtension->BootPfnMapSizes[i])
+            {
+                MmUnmapIoSpace(DriveExtension->BootPfnMapPages[i],
+                               DriveExtension->BootPfnMapSizes[i]);
+            }
+        }
+        ExFreePoolWithTag(DriveExtension->BootPfnMapPages, 'fmRd');
+        DriveExtension->BootPfnMapPages = NULL;
+    }
+
+    if (DriveExtension->BootPfnMapSizes)
+    {
+        ExFreePoolWithTag(DriveExtension->BootPfnMapSizes, 'smRd');
+        DriveExtension->BootPfnMapSizes = NULL;
+    }
+
+    /* Clean up single-level mapping resources */
+    if (DriveExtension->BootPfnMappingOwned &&
+        DriveExtension->BootPfnMappingBase &&
+        DriveExtension->BootPfnMappingSize)
+    {
+        MmUnmapIoSpace(DriveExtension->BootPfnMappingBase,
+                       DriveExtension->BootPfnMappingSize);
+    }
+
+    if (DriveExtension->BootZeroPage)
+    {
+        ExFreePoolWithTag(DriveExtension->BootZeroPage, '0dma');
+        DriveExtension->BootZeroPage = NULL;
+    }
+
+    DriveExtension->BootPfnMappingBase = NULL;
+    DriveExtension->BootPfnArray = NULL;
+    DriveExtension->BootPfnMappingSize = 0;
+    DriveExtension->BootPfnCount = 0;
+    DriveExtension->BootPfnTableOffset = 0;
+    DriveExtension->BootPfnUsesList = FALSE;
+    DriveExtension->BootPfnInitialized = FALSE;
+    DriveExtension->BootPfnMappingOwned = FALSE;
+    DriveExtension->BootPfnIsTwoLevel = FALSE;
+    DriveExtension->BootPfnMapPageCount = 0;
+}
+
+static
+PVOID
+RamdiskMapBootPfn(IN PRAMDISK_DRIVE_EXTENSION DeviceExtension,
+                  IN LARGE_INTEGER Offset,
+                  IN ULONG Length,
+                  OUT PULONG OutputLength,
+                  OUT PULONG MappingLength)
+{
+    const ULONG InvalidPfnMarker = 0x0FFFFFFF;
+    ULONGLONG AbsoluteStart;
+    ULONGLONG AbsoluteEnd;
+    ULONGLONG Remaining;
+    ULONG EffectiveLength;
+    ULONG PageIndex;
+    ULONG PageOffset;
+    ULONG BytesToCopy;
+    ULONG PfnEntry;
+    PHYSICAL_ADDRESS PagePhysical;
+    SIZE_T SpanBytes;
+    PVOID MappingBase;
+
+    *OutputLength = 0;
+    if (MappingLength) *MappingLength = 0;
+
+    AbsoluteStart = DeviceExtension->DiskOffset + Offset.QuadPart;
+    AbsoluteEnd = DeviceExtension->DiskOffset + DeviceExtension->DiskLength.QuadPart;
+    if (AbsoluteStart >= AbsoluteEnd)
+    {
+        return NULL;
+    }
+
+    Remaining = AbsoluteEnd - AbsoluteStart;
+    EffectiveLength = Length;
+    if ((ULONGLONG)EffectiveLength > Remaining)
+    {
+        EffectiveLength = (Remaining > (ULONGLONG)ULONG_MAX) ? ULONG_MAX : (ULONG)Remaining;
+    }
+    if (EffectiveLength == 0)
+    {
+        return NULL;
+    }
+
+    PageIndex = (ULONG)(AbsoluteStart >> PAGE_SHIFT);
+    PageOffset = (ULONG)(AbsoluteStart & (PAGE_SIZE - 1));
+    if (PageIndex >= DeviceExtension->BootPfnCount)
+    {
+        return NULL;
+    }
+
+    BytesToCopy = EffectiveLength;
+    if (BytesToCopy > (PAGE_SIZE - PageOffset))
+    {
+        BytesToCopy = PAGE_SIZE - PageOffset;
+    }
+
+    /* Get the PFN entry from the table */
+    BOOLEAN UseDirectMapping = FALSE;
+
+    if (DeviceExtension->BootPfnIsTwoLevel)
+    {
+        /* Two-level mapping */
+        const ULONG PfnsPerMapPage = PAGE_SIZE / sizeof(ULONG);  /* 1024 */
+        ULONG MapIndex = PageIndex / PfnsPerMapPage;
+        ULONG EntryIndex = PageIndex % PfnsPerMapPage;
+
+        if (MapIndex >= DeviceExtension->BootPfnMapPageCount)
+        {
+            return NULL;
+        }
+
+        /* Read data page PFN from the appropriate map page */
+        PfnEntry = DeviceExtension->BootPfnMapPages[MapIndex][EntryIndex];
+
+#if DBG
+        /* Debug: trace first few lookups */
+        if (PageIndex < 4)
+        {
+            DbgPrintEx(DPFLTR_DEFAULT_ID,
+                       DPFLTR_ERROR_LEVEL,
+                       "RamdiskMapBootPfn: page[%lu] map[%lu][%lu] -> PFN=0x%lX\n",
+                       PageIndex,
+                       MapIndex,
+                       EntryIndex,
+                       PfnEntry);
+
+            /* Dump raw bytes from map page for first access */
+            if (PageIndex == 0 && MapIndex == 0 && EntryIndex == 0)
+            {
+                PUCHAR bytes = (PUCHAR)DeviceExtension->BootPfnMapPages[0];
+                DbgPrintEx(DPFLTR_DEFAULT_ID,
+                           DPFLTR_ERROR_LEVEL,
+                           "  Map[0] raw bytes: %02X %02X %02X %02X %02X %02X %02X %02X\n",
+                           bytes[0], bytes[1], bytes[2], bytes[3],
+                           bytes[4], bytes[5], bytes[6], bytes[7]);
+            }
+        }
+#endif
+
+        /* Check if PFN table is empty (all zeros) - use direct mapping for writable ramdisks */
+        if (PfnEntry == 0)
+        {
+            /* For writable ramdisks, the bootloader doesn't populate the PFN table */
+            /* The data is contiguous starting at BasePage */
+            UseDirectMapping = TRUE;
+            PfnEntry = PageIndex;
+#if DBG
+            if (PageIndex < 4)
+            {
+                DbgPrintEx(DPFLTR_DEFAULT_ID,
+                           DPFLTR_ERROR_LEVEL,
+                           "RamdiskMapBootPfn: PFN=0 detected, using direct mapping for page %lu\n",
+                           PageIndex);
+            }
+#endif
+        }
+    }
+    else
+    {
+        /* Single-level: direct lookup */
+        PfnEntry = DeviceExtension->BootPfnArray[PageIndex];
+    }
+
+    /* Check for invalid PFN */
+    if (!UseDirectMapping && (PfnEntry == 0 || PfnEntry >= InvalidPfnMarker))
+    {
+        /* Invalid PFN - return zero page */
+        if (!DeviceExtension->BootZeroPage)
+        {
+            PVOID NewPage = ExAllocatePoolWithTag(NonPagedPool, PAGE_SIZE, '0dma');
+            if (!NewPage)
+            {
+                return NULL;
+            }
+            RtlZeroMemory(NewPage, PAGE_SIZE);
+            if (InterlockedCompareExchangePointer(&DeviceExtension->BootZeroPage,
+                                                   NewPage, NULL) != NULL)
+            {
+                /* Another thread already allocated it */
+                ExFreePoolWithTag(NewPage, '0dma');
+            }
+        }
+
+        *OutputLength = BytesToCopy;
+        if (MappingLength) *MappingLength = 0;
+        return (PUCHAR)DeviceExtension->BootZeroPage + PageOffset;
+    }
+
+    /* Convert PFN to physical address */
+    /* All PFNs are relative to BasePage */
+    PagePhysical.QuadPart = ((ULONGLONG)DeviceExtension->BasePage +
+                              (ULONGLONG)PfnEntry) << PAGE_SHIFT;
+
+#if DBG
+    /* Debug: trace physical address calculation for first few pages */
+    if (PageIndex < 4)
+    {
+        DbgPrintEx(DPFLTR_DEFAULT_ID,
+                   DPFLTR_ERROR_LEVEL,
+                   "  -> PhysAddr=%llX (BasePage=%lX + PFN=%lX)\n",
+                   PagePhysical.QuadPart,
+                   DeviceExtension->BasePage,
+                   PfnEntry);
+    }
+#endif
+
+    SpanBytes = ADDRESS_AND_SIZE_TO_SPAN_PAGES(PagePhysical.QuadPart + PageOffset,
+                                               BytesToCopy) << PAGE_SHIFT;
+    if (SpanBytes == 0) SpanBytes = PAGE_SIZE;
+
+    MappingBase = MmMapIoSpace(PagePhysical, SpanBytes, MmCached);
+    if (!MappingBase)
+    {
+        return NULL;
+    }
+
+#if DBG
+    /* Debug: Check if we're getting the right data for first page */
+    if (PageIndex == 0 && PageOffset == 0)
+    {
+        PUCHAR Data = (PUCHAR)MappingBase;
+        DbgPrintEx(DPFLTR_DEFAULT_ID,
+                   DPFLTR_ERROR_LEVEL,
+                   "  Mapped %llX -> VA %p, first 16 bytes: %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X\n",
+                   PagePhysical.QuadPart,
+                   MappingBase,
+                   Data[0], Data[1], Data[2], Data[3], Data[4], Data[5], Data[6], Data[7],
+                   Data[8], Data[9], Data[10], Data[11], Data[12], Data[13], Data[14], Data[15]);
+    }
+#endif
+
+    *OutputLength = BytesToCopy;
+    if (MappingLength)
+    {
+        *MappingLength = (SpanBytes > (SIZE_T)ULONG_MAX) ? ULONG_MAX : (ULONG)SpanBytes;
+    }
+
+    return (PUCHAR)MappingBase + PageOffset;
+}
+
+static
+NTSTATUS
+RamdiskBuildPartitionInfo(IN PRAMDISK_DRIVE_EXTENSION DeviceExtension,
+                          OUT PPARTITION_INFORMATION PartitionInfo);
+
+static
+VOID
+RamdiskQueryLogicalVolumeExtent(IN PRAMDISK_DRIVE_EXTENSION DriveExtension,
+                                OUT PLARGE_INTEGER StartingOffset,
+                                OUT PLARGE_INTEGER PartitionLength)
+{
+    PARTITION_INFORMATION PartitionInfo;
+    NTSTATUS Status;
+    ULONGLONG DiskLength;
+    ULONGLONG PartitionOffset;
+
+    StartingOffset->QuadPart = 0;
+    *PartitionLength = DriveExtension->DiskLength;
+    DiskLength = (ULONGLONG)DriveExtension->DiskLength.QuadPart;
+
+    if (DriveExtension->HiddenSectors != 0 && DriveExtension->BytesPerSector != 0)
+    {
+        PartitionOffset = (ULONGLONG)DriveExtension->HiddenSectors * DriveExtension->BytesPerSector;
+        if (PartitionOffset <= DiskLength)
+        {
+            StartingOffset->QuadPart = PartitionOffset;
+            PartitionLength->QuadPart = DiskLength - PartitionOffset;
+        }
+    }
+
+    Status = RamdiskBuildPartitionInfo(DriveExtension, &PartitionInfo);
+    if (!NT_SUCCESS(Status))
+    {
+        return;
+    }
+
+    if ((PartitionInfo.StartingOffset.QuadPart < 0) ||
+        (PartitionInfo.PartitionLength.QuadPart < 0))
+    {
+        return;
+    }
+
+    PartitionOffset = (ULONGLONG)PartitionInfo.StartingOffset.QuadPart;
+    if ((PartitionOffset > DiskLength) ||
+        ((ULONGLONG)PartitionInfo.PartitionLength.QuadPart > (DiskLength - PartitionOffset)))
+    {
+        return;
+    }
+
+    *StartingOffset = PartitionInfo.StartingOffset;
+    *PartitionLength = PartitionInfo.PartitionLength;
+}
+
+static
+LARGE_INTEGER
+RamdiskQueryLogicalVolumeLength(IN PRAMDISK_DRIVE_EXTENSION DriveExtension)
+{
+    LARGE_INTEGER StartingOffset;
+    LARGE_INTEGER PartitionLength;
+
+    RamdiskQueryLogicalVolumeExtent(DriveExtension,
+                                    &StartingOffset,
+                                    &PartitionLength);
+    return PartitionLength;
+}
+
+static
+ULONGLONG
+RamdiskQueryGptAttributes(IN PRAMDISK_DRIVE_EXTENSION DriveExtension)
+{
+    ULONGLONG Attributes = 0;
+
+    if (DriveExtension->DiskOptions.Readonly)
+        Attributes |= GPT_BASIC_DATA_ATTRIBUTE_READ_ONLY;
+
+    if (DriveExtension->DiskOptions.Hidden)
+        Attributes |= GPT_BASIC_DATA_ATTRIBUTE_HIDDEN;
+
+    if (DriveExtension->DiskOptions.NoDriveLetter)
+        Attributes |= GPT_BASIC_DATA_ATTRIBUTE_NO_DRIVE_LETTER;
+
+    return Attributes;
+}
+
+static
+VOID
+RamdiskApplyGptAttributes(IN PRAMDISK_DRIVE_EXTENSION DriveExtension,
+                          ULONGLONG Attributes)
+{
+    DriveExtension->DiskOptions.Readonly = (Attributes & GPT_BASIC_DATA_ATTRIBUTE_READ_ONLY) != 0;
+    DriveExtension->DiskOptions.Hidden = (Attributes & GPT_BASIC_DATA_ATTRIBUTE_HIDDEN) != 0;
+    DriveExtension->DiskOptions.NoDriveLetter = (Attributes & GPT_BASIC_DATA_ATTRIBUTE_NO_DRIVE_LETTER) != 0;
+}
+
+static
+VOID
+RamdiskLogBufferedReply(
+    _In_ PCSTR IoctlName,
+    _In_ PVOID Buffer,
+    _In_ ULONG OutputLength,
+    _In_ ULONG HeaderLength,
+    _In_ ULONG DataLength,
+    _In_ ULONG RequiredLength,
+    _In_ ULONG CopyLength,
+    _In_ NTSTATUS Status);
+
+#if DBG
+static
+VOID
+RamdiskAssertIoctlCoverage(VOID);
+#endif
+
+static
+PCSTR
+RamdiskGetIoctlName(ULONG IoControlCode);
+
+static
+VOID
+RamdiskLogBufferedReply(
+    _In_ PCSTR IoctlName,
+    _In_ PVOID Buffer,
+    _In_ ULONG OutputLength,
+    _In_ ULONG HeaderLength,
+    _In_ ULONG DataLength,
+    _In_ ULONG RequiredLength,
+    _In_ ULONG CopyLength,
+    _In_ NTSTATUS Status)
+{
+#if DBG
+    DbgPrintEx(DPFLTR_DEFAULT_ID,
+               DPFLTR_TRACE_LEVEL,
+               "RamdiskDeviceControl[%s]: buf=%p out=%lu hdr=%lu data=%lu copy=%lu req=%lu status=0x%lx\n",
+               IoctlName,
+               Buffer,
+               OutputLength,
+               HeaderLength,
+               DataLength,
+               CopyLength,
+               RequiredLength,
+               Status);
+
+    ASSERT(RequiredLength >= HeaderLength);
+    if (OutputLength >= HeaderLength)
+    {
+        ASSERT(CopyLength <= DataLength);
+    }
+
+    if (OutputLength < HeaderLength)
+    {
+        ASSERT(Status == STATUS_BUFFER_TOO_SMALL);
+    }
+    else if (OutputLength < RequiredLength)
+    {
+        ASSERT(Status == STATUS_BUFFER_OVERFLOW);
+    }
+    else
+    {
+        ASSERT(NT_SUCCESS(Status));
+    }
+#else
+    UNREFERENCED_PARAMETER(IoctlName);
+    UNREFERENCED_PARAMETER(Buffer);
+    UNREFERENCED_PARAMETER(OutputLength);
+    UNREFERENCED_PARAMETER(HeaderLength);
+    UNREFERENCED_PARAMETER(DataLength);
+    UNREFERENCED_PARAMETER(RequiredLength);
+    UNREFERENCED_PARAMETER(CopyLength);
+    UNREFERENCED_PARAMETER(Status);
+#endif
+}
+
+#if DBG
+static
+VOID
+RamdiskAssertIoctlCoverage(VOID)
+{
+    static const ULONG RequiredIoctls[] =
+    {
+        IOCTL_DISK_GET_DRIVE_GEOMETRY,
+        IOCTL_DISK_GET_DRIVE_GEOMETRY_EX,
+        IOCTL_DISK_GET_PARTITION_INFO,
+        IOCTL_DISK_GET_PARTITION_INFO_EX,
+        IOCTL_DISK_GET_DRIVE_LAYOUT,
+        IOCTL_DISK_GET_DRIVE_LAYOUT_EX,
+        IOCTL_DISK_GET_LENGTH_INFO,
+        IOCTL_DISK_SET_PARTITION_INFO,
+        IOCTL_DISK_IS_WRITABLE,
+        IOCTL_STORAGE_QUERY_PROPERTY,
+        IOCTL_STORAGE_GET_DEVICE_NUMBER,
+        IOCTL_STORAGE_GET_HOTPLUG_INFO,
+        IOCTL_VOLUME_GET_GPT_ATTRIBUTES,
+        IOCTL_VOLUME_SET_GPT_ATTRIBUTES,
+        IOCTL_VOLUME_GET_VOLUME_DISK_EXTENTS,
+        IOCTL_VOLUME_QUERY_FAILOVER_SET,
+        IOCTL_MOUNTDEV_QUERY_DEVICE_NAME,
+        IOCTL_MOUNTDEV_QUERY_UNIQUE_ID,
+        IOCTL_MOUNTDEV_QUERY_SUGGESTED_LINK_NAME,
+        IOCTL_MOUNTDEV_QUERY_STABLE_GUID,
+        IOCTL_MOUNTDEV_LINK_CREATED,
+        IOCTL_MOUNTDEV_LINK_DELETED,
+        IOCTL_MOUNTDEV_UNIQUE_ID_CHANGE_NOTIFY
+    };
+
+    for (ULONG Index = 0; Index < RTL_NUMBER_OF(RequiredIoctls); ++Index)
+    {
+        ULONG Ioctl = RequiredIoctls[Index];
+        PCSTR Name = RamdiskGetIoctlName(Ioctl);
+        ASSERTMSG("Missing IOCTL coverage in RamdiskGetIoctlName", Name != NULL);
+    }
+}
+#endif /* DBG */
+
+#define IOCTL_ACCESS_MASK (3u << 14)
+#define IOCTL_NORMALIZE_ACCESS(code) ((code) & ~IOCTL_ACCESS_MASK)
+
+static
+PCSTR
+RamdiskGetIoctlName(ULONG IoControlCode)
+{
+    if (IoControlCode == IOCTL_STORAGE_CHECK_VERIFY2)
+    {
+        return "IOCTL_STORAGE_CHECK_VERIFY2";
+    }
+
+    ULONG Normalized = IOCTL_NORMALIZE_ACCESS(IoControlCode);
+
+    switch (Normalized)
+    {
+        case IOCTL_NORMALIZE_ACCESS(FSCTL_CREATE_RAM_DISK):
+            return "FSCTL_CREATE_RAM_DISK";
+        case IOCTL_NORMALIZE_ACCESS(IOCTL_CDROM_CHECK_VERIFY):
+            return "IOCTL_CDROM_CHECK_VERIFY";
+        case IOCTL_NORMALIZE_ACCESS(IOCTL_CDROM_GET_DRIVE_GEOMETRY):
+            return "IOCTL_CDROM_GET_DRIVE_GEOMETRY";
+        case IOCTL_NORMALIZE_ACCESS(IOCTL_CDROM_READ_TOC):
+            return "IOCTL_CDROM_READ_TOC";
+        case IOCTL_NORMALIZE_ACCESS(IOCTL_DISK_CHECK_VERIFY):
+            return "IOCTL_DISK_CHECK_VERIFY";
+        case IOCTL_NORMALIZE_ACCESS(IOCTL_DISK_GET_DRIVE_GEOMETRY):
+            return "IOCTL_DISK_GET_DRIVE_GEOMETRY";
+        case IOCTL_NORMALIZE_ACCESS(IOCTL_DISK_GET_DRIVE_GEOMETRY_EX):
+            return "IOCTL_DISK_GET_DRIVE_GEOMETRY_EX";
+        case IOCTL_NORMALIZE_ACCESS(IOCTL_DISK_GET_DRIVE_LAYOUT):
+            return "IOCTL_DISK_GET_DRIVE_LAYOUT";
+        case IOCTL_NORMALIZE_ACCESS(IOCTL_DISK_GET_DRIVE_LAYOUT_EX):
+            return "IOCTL_DISK_GET_DRIVE_LAYOUT_EX";
+        case IOCTL_NORMALIZE_ACCESS(IOCTL_DISK_GET_LENGTH_INFO):
+            return "IOCTL_DISK_GET_LENGTH_INFO";
+        case IOCTL_NORMALIZE_ACCESS(IOCTL_DISK_GET_MEDIA_TYPES):
+            return "IOCTL_DISK_GET_MEDIA_TYPES";
+        case IOCTL_NORMALIZE_ACCESS(IOCTL_DISK_GET_PARTITION_INFO):
+            return "IOCTL_DISK_GET_PARTITION_INFO";
+        case IOCTL_NORMALIZE_ACCESS(IOCTL_DISK_GET_PARTITION_INFO_EX):
+            return "IOCTL_DISK_GET_PARTITION_INFO_EX";
+        case IOCTL_NORMALIZE_ACCESS(IOCTL_DISK_IS_WRITABLE):
+            return "IOCTL_DISK_IS_WRITABLE";
+        case IOCTL_NORMALIZE_ACCESS(IOCTL_DISK_SET_PARTITION_INFO):
+            return "IOCTL_DISK_SET_PARTITION_INFO";
+        case IOCTL_NORMALIZE_ACCESS(IOCTL_MOUNTDEV_QUERY_STABLE_GUID):
+            return "IOCTL_MOUNTDEV_QUERY_STABLE_GUID";
+        case IOCTL_NORMALIZE_ACCESS(IOCTL_MOUNTDEV_QUERY_SUGGESTED_LINK_NAME):
+            return "IOCTL_MOUNTDEV_QUERY_SUGGESTED_LINK_NAME";
+        case IOCTL_NORMALIZE_ACCESS(IOCTL_MOUNTDEV_LINK_CREATED):
+            return "IOCTL_MOUNTDEV_LINK_CREATED";
+        case IOCTL_NORMALIZE_ACCESS(IOCTL_MOUNTDEV_LINK_DELETED):
+            return "IOCTL_MOUNTDEV_LINK_DELETED";
+        case IOCTL_NORMALIZE_ACCESS(IOCTL_MOUNTDEV_UNIQUE_ID_CHANGE_NOTIFY):
+            return "IOCTL_MOUNTDEV_UNIQUE_ID_CHANGE_NOTIFY";
+        case IOCTL_NORMALIZE_ACCESS(IOCTL_MOUNTDEV_QUERY_DEVICE_NAME):
+            return "IOCTL_MOUNTDEV_QUERY_DEVICE_NAME";
+        case IOCTL_NORMALIZE_ACCESS(IOCTL_MOUNTDEV_QUERY_DEVICE_RELATIONS):
+            return "IOCTL_MOUNTDEV_QUERY_DEVICE_RELATIONS";
+        case IOCTL_NORMALIZE_ACCESS(IOCTL_MOUNTDEV_QUERY_UNIQUE_ID):
+            return "IOCTL_MOUNTDEV_QUERY_UNIQUE_ID";
+        case IOCTL_NORMALIZE_ACCESS(IOCTL_SCSI_MINIPORT):
+            return "IOCTL_SCSI_MINIPORT";
+        case IOCTL_NORMALIZE_ACCESS(IOCTL_STORAGE_CHECK_VERIFY):
+            return "IOCTL_STORAGE_CHECK_VERIFY";
+        case IOCTL_NORMALIZE_ACCESS(IOCTL_STORAGE_GET_MEDIA_TYPES):
+            return "IOCTL_STORAGE_GET_MEDIA_TYPES";
+        case IOCTL_NORMALIZE_ACCESS(IOCTL_STORAGE_GET_DEVICE_NUMBER):
+            return "IOCTL_STORAGE_GET_DEVICE_NUMBER";
+        case IOCTL_NORMALIZE_ACCESS(IOCTL_STORAGE_GET_HOTPLUG_INFO):
+            return "IOCTL_STORAGE_GET_HOTPLUG_INFO";
+        case IOCTL_NORMALIZE_ACCESS(IOCTL_STORAGE_QUERY_PROPERTY):
+            return "IOCTL_STORAGE_QUERY_PROPERTY";
+        case IOCTL_NORMALIZE_ACCESS(IOCTL_VOLUME_GET_GPT_ATTRIBUTES):
+            return "IOCTL_VOLUME_GET_GPT_ATTRIBUTES";
+        case IOCTL_NORMALIZE_ACCESS(IOCTL_VOLUME_GET_VOLUME_DISK_EXTENTS):
+            return "IOCTL_VOLUME_GET_VOLUME_DISK_EXTENTS";
+        case IOCTL_NORMALIZE_ACCESS(IOCTL_VOLUME_QUERY_FAILOVER_SET):
+            return "IOCTL_VOLUME_QUERY_FAILOVER_SET";
+        case IOCTL_NORMALIZE_ACCESS(IOCTL_VOLUME_OFFLINE):
+            return "IOCTL_VOLUME_OFFLINE";
+        case IOCTL_NORMALIZE_ACCESS(IOCTL_VOLUME_ONLINE):
+            return "IOCTL_VOLUME_ONLINE";
+        case IOCTL_NORMALIZE_ACCESS(IOCTL_VOLUME_SET_GPT_ATTRIBUTES):
+            return "IOCTL_VOLUME_SET_GPT_ATTRIBUTES";
+        case IOCTL_NORMALIZE_ACCESS(IOCTL_SCSI_PASS_THROUGH):
+            return "IOCTL_SCSI_PASS_THROUGH";
+        case IOCTL_NORMALIZE_ACCESS(IOCTL_SCSI_PASS_THROUGH_DIRECT):
+            return "IOCTL_SCSI_PASS_THROUGH_DIRECT";
+        case IOCTL_NORMALIZE_ACCESS(IOCTL_SCSI_GET_ADDRESS):
+            return "IOCTL_SCSI_GET_ADDRESS";
+        default:
+            return NULL;
+    }
+}
 ULONG DefaultViewCount;
 ULONG MaximumViewCount;
 ULONG MinimumViewLength;
@@ -148,35 +1237,44 @@ QueryParameters(IN PUNICODE_STRING RegistryPath)
 
     /* Setup the query table and query the registry */
     RtlZeroMemory(QueryTable, sizeof(QueryTable));
-    QueryTable[0].Flags = 1;
+    QueryTable[0].Flags = RTL_QUERY_REGISTRY_SUBKEY;
     QueryTable[0].Name = L"Parameters";
-    QueryTable[1].Flags = 32;
+    QueryTable[1].Flags = RTL_QUERY_REGISTRY_DIRECT | RTL_QUERY_REGISTRY_TYPECHECK;
     QueryTable[1].Name = L"ReportDetectedDevice";
     QueryTable[1].EntryContext = &ReportDetectedDevice;
-    QueryTable[2].Flags = 32;
+    QueryTable[1].DefaultType = REG_DWORD;
+    QueryTable[2].Flags = RTL_QUERY_REGISTRY_DIRECT | RTL_QUERY_REGISTRY_TYPECHECK;
     QueryTable[2].Name = L"MarkRamdisksAsRemovable";
     QueryTable[2].EntryContext = &MarkRamdisksAsRemovable;
-    QueryTable[3].Flags = 32;
+    QueryTable[2].DefaultType = REG_DWORD;
+    QueryTable[3].Flags = RTL_QUERY_REGISTRY_DIRECT | RTL_QUERY_REGISTRY_TYPECHECK;
     QueryTable[3].Name = L"MinimumViewCount";
     QueryTable[3].EntryContext = &MinimumViewCount;
-    QueryTable[4].Flags = 32;
+    QueryTable[3].DefaultType = REG_DWORD;
+    QueryTable[4].Flags = RTL_QUERY_REGISTRY_DIRECT | RTL_QUERY_REGISTRY_TYPECHECK;
     QueryTable[4].Name = L"DefaultViewCount";
     QueryTable[4].EntryContext = &DefaultViewCount;
-    QueryTable[5].Flags = 32;
+    QueryTable[4].DefaultType = REG_DWORD;
+    QueryTable[5].Flags = RTL_QUERY_REGISTRY_DIRECT | RTL_QUERY_REGISTRY_TYPECHECK;
     QueryTable[5].Name = L"MaximumViewCount";
     QueryTable[5].EntryContext = &MaximumViewCount;
-    QueryTable[6].Flags = 32;
+    QueryTable[5].DefaultType = REG_DWORD;
+    QueryTable[6].Flags = RTL_QUERY_REGISTRY_DIRECT | RTL_QUERY_REGISTRY_TYPECHECK;
     QueryTable[6].Name = L"MinimumViewLength";
     QueryTable[6].EntryContext = &MinimumViewLength;
-    QueryTable[7].Flags = 32;
+    QueryTable[6].DefaultType = REG_DWORD;
+    QueryTable[7].Flags = RTL_QUERY_REGISTRY_DIRECT | RTL_QUERY_REGISTRY_TYPECHECK;
     QueryTable[7].Name = L"DefaultViewLength";
     QueryTable[7].EntryContext = &DefaultViewLength;
-    QueryTable[8].Flags = 32;
+    QueryTable[7].DefaultType = REG_DWORD;
+    QueryTable[8].Flags = RTL_QUERY_REGISTRY_DIRECT | RTL_QUERY_REGISTRY_TYPECHECK;
     QueryTable[8].Name = L"MaximumViewLength";
     QueryTable[8].EntryContext = &MaximumViewLength;
-    QueryTable[9].Flags = 32;
+    QueryTable[8].DefaultType = REG_DWORD;
+    QueryTable[9].Flags = RTL_QUERY_REGISTRY_DIRECT | RTL_QUERY_REGISTRY_TYPECHECK;
     QueryTable[9].Name = L"MaximumPerDiskViewLength";
     QueryTable[9].EntryContext = &MaximumPerDiskViewLength;
+    QueryTable[9].DefaultType = REG_DWORD;
     RtlQueryRegistryValues(RTL_REGISTRY_OPTIONAL,
                            RegistryPath->Buffer,
                            QueryTable,
@@ -269,17 +1367,92 @@ NTAPI
 RamdiskMapPages(IN PRAMDISK_DRIVE_EXTENSION DeviceExtension,
                 IN LARGE_INTEGER Offset,
                 IN ULONG Length,
-                OUT PULONG OutputLength)
+                OUT PULONG OutputLength,
+                OUT PULONG MappingLength)
 {
     PHYSICAL_ADDRESS PhysicalAddress;
     PVOID MappedBase;
     ULONG PageOffset;
     SIZE_T ActualLength;
+    SIZE_T SpanLength;
     LARGE_INTEGER ActualOffset;
     LARGE_INTEGER ActualPages;
+    ULONGLONG DiskLength;
+    ULONGLONG RequestOffset;
+    ULONG OriginalLength;
 
-    /* We only support boot disks for now */
-    ASSERT(DeviceExtension->DiskType == RAMDISK_BOOT_DISK);
+    /* For non-boot disks, we need different implementation */
+    if (DeviceExtension->DiskType != RAMDISK_BOOT_DISK)
+    {
+        /* TODO: Implement memory-mapped and registry disk support */
+        DPRINT1("RamdiskMapPages: Non-boot disk type %d not yet implemented\n", DeviceExtension->DiskType);
+        return NULL;
+    }
+
+    /* Default to zero bytes mapped */
+    *OutputLength = 0;
+    if (MappingLength) *MappingLength = 0;
+    SpanLength = 0;
+
+    if (DeviceExtension->DiskType == RAMDISK_BOOT_DISK)
+    {
+        if (!RamdiskEnsureBootPfnTable(DeviceExtension))
+        {
+            return NULL;
+        }
+
+        if (DeviceExtension->BootPfnUsesList)
+        {
+            return RamdiskMapBootPfn(DeviceExtension,
+                                     Offset,
+                                     Length,
+                                     OutputLength,
+                                     MappingLength);
+        }
+    }
+
+    if (Offset.QuadPart < 0)
+    {
+        return NULL;
+    }
+
+    DiskLength = DeviceExtension->DiskLength.QuadPart;
+    RequestOffset = (ULONGLONG)Offset.QuadPart;
+
+    if (RequestOffset >= DiskLength)
+    {
+        return NULL;
+    }
+
+    OriginalLength = Length;
+    if ((ULONGLONG)Length > (DiskLength - RequestOffset))
+    {
+        ULONGLONG BytesAvailable = DiskLength - RequestOffset;
+
+        if (BytesAvailable > (ULONGLONG)ULONG_MAX)
+        {
+            Length = ULONG_MAX;
+        }
+        else
+        {
+            Length = (ULONG)BytesAvailable;
+        }
+
+        if (Length == 0)
+        {
+            return NULL;
+        }
+
+#if DBG
+        DbgPrintEx(DPFLTR_DEFAULT_ID,
+                   DPFLTR_WARNING_LEVEL,
+                   "RamdiskMapPages: trimming request len=%lu to=%lu at offset=%I64u (disk=%I64u)\n",
+                   OriginalLength,
+                   Length,
+                   RequestOffset,
+                   DiskLength);
+#endif
+    }
 
     /* Calculate the actual offset in the drive */
     ActualOffset.QuadPart = DeviceExtension->DiskOffset + Offset.QuadPart;
@@ -298,16 +1471,45 @@ RamdiskMapPages(IN PRAMDISK_DRIVE_EXTENSION DeviceExtension,
 
     /* And convert this back to bytes */
     ActualLength <<= PAGE_SHIFT;
+    SpanLength = ActualLength;
 
     /* Get the offset within the page */
     PageOffset = BYTE_OFFSET(ActualOffset.QuadPart);
 
+    DbgPrintEx(DPFLTR_DEFAULT_ID,
+               DPFLTR_TRACE_LEVEL,
+               "RamdiskMapPages: basePage=%lu offset=%I64x length=%lu phys=%I64x spanBytes=%Ix\n",
+               DeviceExtension->BasePage,
+               Offset.QuadPart,
+               Length,
+               PhysicalAddress.QuadPart,
+               ActualLength);
+
     /* Map the I/O Space from the loader */
+#if DBG
+    DbgPrintEx(DPFLTR_DEFAULT_ID,
+               DPFLTR_TRACE_LEVEL,
+               "RamdiskMapPages: len=%lu spanBytes=%Ix phys=%I64x offset=%I64x basePage=%lu\n",
+               Length,
+               ActualLength,
+               PhysicalAddress.QuadPart,
+               ActualOffset.QuadPart,
+               DeviceExtension->BasePage);
+#endif
     MappedBase = MmMapIoSpace(PhysicalAddress, ActualLength, MmCached);
 
     /* Return actual offset within the page as well as the length */
     if (MappedBase) MappedBase = (PVOID)((ULONG_PTR)MappedBase + PageOffset);
-    *OutputLength = Length;
+
+    if (ActualLength > Length)
+    {
+        ActualLength = Length;
+    }
+
+    ASSERT(ActualLength <= Length);
+    ASSERT(SpanLength <= MAXULONG);
+    *OutputLength = (ULONG)ActualLength;
+    if (MappingLength) *MappingLength = (ULONG)SpanLength;
     return MappedBase;
 }
 
@@ -316,23 +1518,48 @@ NTAPI
 RamdiskUnmapPages(IN PRAMDISK_DRIVE_EXTENSION DeviceExtension,
                   IN PVOID BaseAddress,
                   IN LARGE_INTEGER Offset,
-                  IN ULONG Length)
+                  IN ULONG MappingLength)
 {
     LARGE_INTEGER ActualOffset;
     SIZE_T ActualLength;
     ULONG PageOffset;
 
-    /* We only support boot disks for now */
-    ASSERT(DeviceExtension->DiskType == RAMDISK_BOOT_DISK);
+    if (DeviceExtension->DiskType == RAMDISK_BOOT_DISK &&
+        DeviceExtension->BootPfnUsesList)
+    {
+        if (!MappingLength)
+        {
+            return;
+        }
+
+        if (!BaseAddress)
+        {
+            return;
+        }
+
+        ActualOffset.QuadPart = DeviceExtension->DiskOffset + Offset.QuadPart;
+        PageOffset = BYTE_OFFSET(ActualOffset.QuadPart);
+
+        BaseAddress = (PVOID)((ULONG_PTR)BaseAddress - PageOffset);
+        MmUnmapIoSpace(BaseAddress, MappingLength);
+        return;
+    }
+
+    /* For non-boot disks, we need different implementation */
+    if (DeviceExtension->DiskType != RAMDISK_BOOT_DISK)
+    {
+        /* TODO: Implement memory-mapped and registry disk support */
+        DPRINT1("RamdiskUnmapPages: Non-boot disk type %d not yet implemented\n", DeviceExtension->DiskType);
+        return;
+    }
 
     /* Calculate the actual offset in the drive */
     ActualOffset.QuadPart = DeviceExtension->DiskOffset + Offset.QuadPart;
 
-    /* Calculate pages spanned for the mapping */
-    ActualLength = ADDRESS_AND_SIZE_TO_SPAN_PAGES(ActualOffset.QuadPart, Length);
-
-    /* And convert this back to bytes */
-    ActualLength <<= PAGE_SHIFT;
+    /* Use the original span length supplied by the caller */
+    ActualLength = MappingLength;
+    if (ActualLength == 0) return;
+    ASSERT((ActualLength & (PAGE_SIZE - 1)) == 0);
 
     /* Get the offset within the page */
     PageOffset = BYTE_OFFSET(ActualOffset.QuadPart);
@@ -341,7 +1568,101 @@ RamdiskUnmapPages(IN PRAMDISK_DRIVE_EXTENSION DeviceExtension,
     BaseAddress = (PVOID)((ULONG_PTR)BaseAddress - PageOffset);
 
     /* Unmap the I/O space we got from the loader */
+    DbgPrintEx(DPFLTR_DEFAULT_ID,
+               DPFLTR_TRACE_LEVEL,
+               "RamdiskUnmapPages: basePage=%lu offset=%I64x length=%lu spanBytes=%Ix\n",
+               DeviceExtension->BasePage,
+               Offset.QuadPart,
+               MappingLength,
+               ActualLength);
     MmUnmapIoSpace(BaseAddress, ActualLength);
+}
+
+static
+BOOLEAN
+RamdiskBootImageLooksLikeIso(
+    _In_ const RAMDISK_CREATE_INPUT *Input)
+{
+    RAMDISK_DRIVE_EXTENSION ProbeExtension;
+    LARGE_INTEGER Offset;
+    PVOID BaseAddress = NULL;
+    ULONG BytesRead = 0;
+    ULONG MapSpan = 0;
+    BOOLEAN Result = FALSE;
+
+    DbgPrintEx(DPFLTR_DEFAULT_ID,
+               DPFLTR_TRACE_LEVEL,
+               "RamdiskBootImageLooksLikeIso: BasePage=%lu Offset=%ld Length=%I64u\n",
+               Input->BasePage,
+               Input->DiskOffset,
+               Input->DiskLength.QuadPart);
+
+    if (!Input->BasePage)
+    {
+        return FALSE;
+    }
+
+    if (Input->DiskLength.QuadPart <= ISO9660_PRIMARY_VOLUME_DESCRIPTOR_OFFSET)
+    {
+        return FALSE;
+    }
+
+    RtlZeroMemory(&ProbeExtension, sizeof(ProbeExtension));
+    ProbeExtension.DiskType = Input->DiskType;
+    ProbeExtension.BasePage = Input->BasePage;
+    ProbeExtension.DiskOffset = Input->DiskOffset;
+    ProbeExtension.DiskLength = Input->DiskLength;
+
+    Offset.QuadPart = ISO9660_PRIMARY_VOLUME_DESCRIPTOR_OFFSET;
+
+    BaseAddress = RamdiskMapPages(&ProbeExtension,
+                                  Offset,
+                                  ISO9660_PROBE_LENGTH,
+                                  &BytesRead,
+                                  &MapSpan);
+    if (BaseAddress && BytesRead >= (ISO9660_SIGNATURE_LENGTH + 2))
+    {
+        const UCHAR *VolumeDescriptor = BaseAddress;
+
+        if (VolumeDescriptor[0] == ISO9660_PRIMARY_VOLUME_DESCRIPTOR_TYPE &&
+            VolumeDescriptor[6] == ISO9660_PRIMARY_VOLUME_DESCRIPTOR_VERSION &&
+            RtlCompareMemory(&VolumeDescriptor[1],
+                             ISO9660_SIGNATURE,
+                             ISO9660_SIGNATURE_LENGTH) == ISO9660_SIGNATURE_LENGTH)
+        {
+            Result = TRUE;
+        }
+        else
+        {
+            DbgPrintEx(DPFLTR_DEFAULT_ID,
+                       DPFLTR_TRACE_LEVEL,
+                       "RamdiskBootImageLooksLikeIso: signature mismatch type=%02X sig='%c%c%c%c%c' ver=%02X\n",
+                       VolumeDescriptor[0],
+                       VolumeDescriptor[1],
+                       VolumeDescriptor[2],
+                       VolumeDescriptor[3],
+                       VolumeDescriptor[4],
+                       VolumeDescriptor[5],
+                       VolumeDescriptor[6]);
+        }
+    }
+    else
+    {
+        DbgPrintEx(DPFLTR_DEFAULT_ID,
+                   DPFLTR_TRACE_LEVEL,
+                   "RamdiskBootImageLooksLikeIso: probe failed (mapped=%p bytes=%lu)\n",
+                   BaseAddress,
+                   BytesRead);
+    }
+
+    if (BaseAddress)
+    {
+        RamdiskUnmapPages(&ProbeExtension, BaseAddress, Offset, MapSpan);
+    }
+
+    RamdiskReleaseBootPfnTable(&ProbeExtension);
+
+    return Result;
 }
 
 NTSTATUS
@@ -351,39 +1672,81 @@ RamdiskCreateDiskDevice(IN PRAMDISK_BUS_EXTENSION DeviceExtension,
                         IN BOOLEAN ValidateOnly,
                         OUT PRAMDISK_DRIVE_EXTENSION *NewDriveExtension)
 {
-    ULONG BasePage, DiskType, Length;
+    ULONG_PTR BasePage;
+    ULONG DiskType, Length;
     //ULONG ViewCount;
-    NTSTATUS Status;
+    NTSTATUS Status = STATUS_SUCCESS;
     PDEVICE_OBJECT DeviceObject;
     PRAMDISK_DRIVE_EXTENSION DriveExtension;
     PVOID Buffer;
-    WCHAR LocalBuffer[16];
-    UNICODE_STRING SymbolicLinkName, DriveString, GuidString, DeviceName;
+    UNICODE_STRING SymbolicLinkName, GuidString, DeviceName;
     PPACKED_BOOT_SECTOR BootSector;
     BIOS_PARAMETER_BLOCK BiosBlock;
-    ULONG BytesPerSector, SectorsPerTrack, Heads, BytesRead;
-    PVOID BaseAddress;
+    ULONG BytesRead;
+    ULONG MapSpan = 0;
+    PVOID BaseAddress = NULL;
     LARGE_INTEGER CurrentOffset, CylinderSize, DiskLength;
     ULONG CylinderCount, SizeByCylinders;
+    BOOLEAN IsoImage = FALSE;
+
+    CurrentOffset.QuadPart = 0;
+    RtlZeroMemory(&SymbolicLinkName, sizeof(SymbolicLinkName));
+    RtlZeroMemory(&GuidString, sizeof(GuidString));
+    RtlZeroMemory(&DeviceName, sizeof(DeviceName));
+
+    DbgPrintEx(DPFLTR_DEFAULT_ID,
+               DPFLTR_INFO_LEVEL,
+               "RamdiskCreateDiskDevice: type %lu base %lu length %I64u letter %wc options 0x%08lx basePage=%lu offset=%ld\n",
+               Input->DiskType,
+               Input->BasePage,
+               Input->DiskLength.QuadPart,
+               Input->DriveLetter ? Input->DriveLetter : L'-',
+               *(PULONG)&Input->Options,
+               Input->BasePage,
+               Input->DiskOffset);
 
     /* Check if we're a boot RAM disk */
     DiskType = Input->DiskType;
+    DPRINT1("RamdiskCreateDiskDevice: DiskType=%lu ExportAsCd=%u\n",
+            DiskType,
+            Input->Options.ExportAsCd);
     if (DiskType >= RAMDISK_BOOT_DISK)
     {
         /* Check if we're an ISO */
         if (DiskType == RAMDISK_BOOT_DISK)
         {
+            IsoImage = RamdiskBootImageLooksLikeIso(Input);
+
+            DbgPrintEx(DPFLTR_DEFAULT_ID,
+                       DPFLTR_TRACE_LEVEL,
+                       "RamdiskCreateDiskDevice: boot disk incoming ExportAsCd=%u length=%I64u offset=%ld iso=%u\n",
+                       Input->Options.ExportAsCd,
+                       Input->DiskLength.QuadPart,
+                       Input->DiskOffset,
+                       IsoImage);
+
+            if (!Input->Options.ExportAsCd && IsoImage)
+            {
+                DbgPrintEx(DPFLTR_DEFAULT_ID,
+                           DPFLTR_INFO_LEVEL,
+                           "RamdiskCreateDiskDevice: detected ISO-9660 image, exporting as CD\n");
+                Input->Options.ExportAsCd = TRUE;
+            }
+
             /* NTLDR mounted us somewhere */
             BasePage = Input->BasePage;
             if (!BasePage) return STATUS_INVALID_PARAMETER;
 
             /* Sanitize disk options */
-            Input->Options.Fixed = TRUE;
+            Input->Options.Fixed = !Input->Options.ExportAsCd;
             Input->Options.Readonly = Input->Options.ExportAsCd |
                                       Input->Options.Readonly;
             Input->Options.Hidden = FALSE;
             Input->Options.NoDosDevice = FALSE;
-            Input->Options.NoDriveLetter = IsWinPEBoot ? TRUE : FALSE;
+            if (Input->DriveLetter == 0 && IsWinPEBoot)
+            {
+                Input->Options.NoDriveLetter = TRUE;
+            }
         }
         else
         {
@@ -431,8 +1794,10 @@ RamdiskCreateDiskDevice(IN PRAMDISK_BUS_EXTENSION DeviceExtension,
         DeviceName.Buffer = Buffer;
         DeviceName.Length = Length - 2;
         DeviceName.MaximumLength = Length;
-        wcsncpy(Buffer, L"\\Device\\Ramdisk", Length / sizeof(WCHAR));
-        wcsncat(Buffer, GuidString.Buffer, Length / sizeof(WCHAR));
+        PWSTR DeviceNameBuffer = Buffer;
+        wcsncpy(DeviceNameBuffer, L"\\Device\\Ramdisk", Length / sizeof(WCHAR));
+        wcsncat(DeviceNameBuffer, GuidString.Buffer, Length / sizeof(WCHAR));
+        DeviceNameBuffer[(Length / sizeof(WCHAR)) - 1] = UNICODE_NULL;
 
         /* Create the drive device */
         Status = IoCreateDevice(DeviceExtension->DeviceObject->DriverObject,
@@ -447,6 +1812,15 @@ RamdiskCreateDiskDevice(IN PRAMDISK_BUS_EXTENSION DeviceExtension,
 
         /* Grab the drive extension */
         DriveExtension = DeviceObject->DeviceExtension;
+
+        if (Input->Options.ExportAsCd)
+        {
+            DeviceObject->Characteristics |= FILE_READ_ONLY_DEVICE | FILE_REMOVABLE_MEDIA;
+        }
+        else if (!Input->Options.Fixed)
+        {
+            DeviceObject->Characteristics |= FILE_REMOVABLE_MEDIA;
+        }
 
         /* Check if we need a DOS device */
         if (!Input->Options.NoDosDevice)
@@ -482,25 +1856,9 @@ RamdiskCreateDiskDevice(IN PRAMDISK_BUS_EXTENSION DeviceExtension,
                 Input->Options.NoDosDevice = TRUE;
             }
 
-            /* Is this an ISO boot ramdisk? */
-            if (Input->DiskType == RAMDISK_BOOT_DISK)
-            {
-                /* Does it need a drive letter? */
-                if (!Input->Options.NoDriveLetter)
-                {
-                    /* Build it and take over the existing symbolic link */
-                    _snwprintf(LocalBuffer,
-                               30,
-                               L"\\DosDevices\\%wc:",
-                               Input->DriveLetter);
-                    RtlInitUnicodeString(&DriveString, LocalBuffer);
-                    IoDeleteSymbolicLink(&DriveString);
-                    IoCreateSymbolicLink(&DriveString, &DeviceName);
-
-                    /* Save the drive letter */
-                    DriveExtension->DriveLetter = Input->DriveLetter;
-                }
-            }
+            /* For boot ramdisks, do NOT create a DOS drive-letter link here.
+               Let mountmgr assign letters based on our suggested link name.
+               We still keep DriveLetter in the extension so the suggestion can use it. */
 
         }
 
@@ -514,7 +1872,9 @@ RamdiskCreateDiskDevice(IN PRAMDISK_BUS_EXTENSION DeviceExtension,
         DiskLength = Input->DiskLength;
         ExInitializeFastMutex(&DriveExtension->DiskListLock);
         IoInitializeRemoveLock(&DriveExtension->RemoveLock, 'dmaR', 1, 0);
-        DriveExtension->DriveDeviceName = DeviceName;
+        DriveExtension->DeviceObjectName = DeviceName;
+        RtlZeroMemory(&DriveExtension->DriveDeviceName,
+                      sizeof(DriveExtension->DriveDeviceName));
         DriveExtension->SymbolicLinkName = SymbolicLinkName;
         DriveExtension->GuidString = GuidString;
         DriveExtension->DiskGuid = Input->DiskGuid;
@@ -526,75 +1886,273 @@ RamdiskCreateDiskDevice(IN PRAMDISK_BUS_EXTENSION DeviceExtension,
         DriveExtension->DiskLength = DiskLength;
         DriveExtension->DiskOffset = Input->DiskOffset;
         DriveExtension->BasePage = Input->BasePage;
+        DriveExtension->DriveLetter = Input->DriveLetter;
         DriveExtension->BytesPerSector = 0;
         DriveExtension->SectorsPerTrack = 0;
         DriveExtension->NumberOfHeads = 0;
+        DriveExtension->DiskNumber = (ULONG)(InterlockedIncrement(&RamdiskDiskNumberSeed) - 1);
+        DriveExtension->HiddenSectors = 0;
+        DriveExtension->VolumeOffline = FALSE;
+        DriveExtension->MountdevLinkCount = 0;
+        DriveExtension->PendingUniqueIdNotifyIrp = NULL;
 
         /* Make sure we don't free it later */
         DeviceName.Buffer = NULL;
         SymbolicLinkName.Buffer = NULL;
         GuidString.Buffer = NULL;
 
+        /* Do not create the \ArcName\ramdisk(0) alias here; kernel boot
+           code sets it up in IopStartRamdisk and tolerates collisions.
+           Creating it here can race and cause STATUS_OBJECT_NAME_COLLISION
+           to be raised as fatal there. */
+
         /* Check if this is a boot disk, or a registry ram drive */
-        if (!(Input->Options.ExportAsCd) &&
-            (Input->DiskType == RAMDISK_BOOT_DISK))
+        if (Input->DiskType == RAMDISK_BOOT_DISK)
         {
-            /* Not an ISO boot, but it's a boot FS -- map it to figure out the
-             * drive settings */
+            if (IsoImage && !DriveExtension->DiskOptions.ExportAsCd)
+            {
+                DbgPrintEx(DPFLTR_DEFAULT_ID,
+                           DPFLTR_ERROR_LEVEL,
+                           "RamdiskCreateDiskDevice: enabling ExportAsCd for ISO boot ramdisk\n");
+                DriveExtension->DiskOptions.ExportAsCd = TRUE;
+                Input->Options.ExportAsCd = TRUE;
+            }
+
+            ULONGLONG PartitionStartLba = 0;
+            UCHAR PartitionType = 0;
+            ULONG PartitionSectorCount = 0;
+            BOOLEAN BootSectorValid = FALSE;
+
+            if (!DriveExtension->DiskOptions.ExportAsCd && BaseAddress)
+            {
+                /* Nothing more to do */
+                RamdiskUnmapPages(DriveExtension,
+                                  BaseAddress,
+                                  CurrentOffset,
+                                  MapSpan);
+                BaseAddress = NULL;
+            }
+
+            if (DriveExtension->DiskOptions.ExportAsCd)
+            {
+                /* No need to parse FAT boot data when we know it's a CD image */
+                goto SkipBootSectorProbe;
+            }
+
+            DriveExtension->HiddenSectors = 0;
             CurrentOffset.QuadPart = 0;
             BaseAddress = RamdiskMapPages(DriveExtension,
                                           CurrentOffset,
                                           PAGE_SIZE,
-                                          &BytesRead);
-            if (BaseAddress)
+                                          &BytesRead,
+                                          &MapSpan);
+            if (!BaseAddress)
             {
-                /* Get the data */
-                BootSector = (PPACKED_BOOT_SECTOR)BaseAddress;
-                FatUnpackBios(&BiosBlock, &BootSector->PackedBpb);
-                BytesPerSector = BiosBlock.BytesPerSector;
-                SectorsPerTrack = BiosBlock.SectorsPerTrack;
-                Heads = BiosBlock.Heads;
-
-                /* Save it */
-                DriveExtension->BytesPerSector = BytesPerSector;
-                DriveExtension->SectorsPerTrack = SectorsPerTrack;
-                DriveExtension->NumberOfHeads = Heads;
-
-                /* Unmap now */
-                CurrentOffset.QuadPart = 0;
-                RamdiskUnmapPages(DriveExtension,
-                                  BaseAddress,
-                                  CurrentOffset,
-                                  BytesRead);
-            }
-            else
-            {
-                /* Fail */
                 Status = STATUS_INSUFFICIENT_RESOURCES;
                 goto FailCreate;
             }
-        }
 
-        /* Check if the drive settings haven't been set yet */
-        if ((DriveExtension->BytesPerSector == 0) ||
-            (DriveExtension->SectorsPerTrack == 0) ||
-            (DriveExtension->NumberOfHeads == 0))
-        {
-            /* Check if this is a CD */
-            if (Input->Options.ExportAsCd)
+            BootSector = (PPACKED_BOOT_SECTOR)BaseAddress;
+            FatUnpackBios(&BiosBlock, &BootSector->PackedBpb);
+
+            if (RamdiskBootSectorHasSignature(BootSector) &&
+                (BiosBlock.BytesPerSector >= 512) &&
+                (BiosBlock.BytesPerSector <= 4096) &&
+                (BiosBlock.SectorsPerTrack != 0) &&
+                (BiosBlock.Heads != 0))
             {
-                /* Setup partition parameters default for ISO 9660 */
-                DriveExtension->BytesPerSector = 2048;
-                DriveExtension->SectorsPerTrack = 32;
-                DriveExtension->NumberOfHeads = 64;
+                BootSectorValid = TRUE;
             }
             else
             {
-                /* Setup partition parameters default for FAT */
-                DriveExtension->BytesPerSector = 512;
-                DriveExtension->SectorsPerTrack = 128;
-                DriveExtension->NumberOfHeads = 16;
+                PRAMDISK_MASTER_BOOT_RECORD MasterBootRecord = (PRAMDISK_MASTER_BOOT_RECORD)BaseAddress;
+                PUCHAR MbrBytes = (PUCHAR)BaseAddress;
+
+                DbgPrintEx(DPFLTR_DEFAULT_ID,
+                           DPFLTR_ERROR_LEVEL,
+                           "RamdiskCreateDiskDevice: MBR check - Magic=0x%04X, bytes at 0x1FE: %02X %02X\n",
+                           MasterBootRecord->Magic,
+                           MbrBytes[0x1FE], MbrBytes[0x1FF]);
+
+                if (MasterBootRecord->Magic == 0xAA55)
+                {
+                    DbgPrintEx(DPFLTR_DEFAULT_ID,
+                               DPFLTR_ERROR_LEVEL,
+                               "RamdiskCreateDiskDevice: MBR magic matched, examining partitions\n");
+                    for (ULONG PartitionIndex = 0;
+                         PartitionIndex < RTL_NUMBER_OF(MasterBootRecord->PartitionTable);
+                         ++PartitionIndex)
+                    {
+                        const RAMDISK_MBR_PARTITION_ENTRY *Entry = &MasterBootRecord->PartitionTable[PartitionIndex];
+
+                        if (Entry->SystemIndicator != 0)
+                        {
+                            DbgPrintEx(DPFLTR_DEFAULT_ID,
+                                       DPFLTR_ERROR_LEVEL,
+                                       "  MBR[%lu]: type=0x%02X start=%lu count=%lu\n",
+                                       PartitionIndex,
+                                       Entry->SystemIndicator,
+                                       Entry->SectorCountBeforePartition,
+                                       Entry->PartitionSectorCount);
+                        }
+
+                        if ((Entry->PartitionSectorCount != 0) &&
+                            (Entry->SystemIndicator != 0))
+                        {
+                            PartitionStartLba = Entry->SectorCountBeforePartition;
+                            PartitionType = Entry->SystemIndicator;
+                            PartitionSectorCount = Entry->PartitionSectorCount;
+                            break;
+                        }
+                    }
+                }
+                else
+                {
+                    DbgPrintEx(DPFLTR_DEFAULT_ID,
+                               DPFLTR_ERROR_LEVEL,
+                               "RamdiskCreateDiskDevice: MBR magic mismatch (value=0x%04X)\n",
+                               MasterBootRecord->Magic);
+                }
+
+                                if ((PartitionType == PARTITION_ISO9660) &&
+                    !DriveExtension->DiskOptions.ExportAsCd)
+                {
+                    /* Probe for a true ISO9660 volume by checking for the
+                     * Primary Volume Descriptor signature "CD001" at LBA 16.
+                     * If not present, avoid forcing ExportAsCd=TRUE so FAT-based
+                     * live images with a nonstandard type aren't misclassified. */
+                    BOOLEAN IsIso = FALSE;
+                    ULONGLONG ProbeOffset = (ULONGLONG)PartitionStartLba * 512ULL + (ULONGLONG)16 * 2048ULL;
+                    ULONG ProbeSpan = 0;
+                    PVOID ProbeBase = RamdiskMapPages(DriveExtension,
+                                                     *(PLARGE_INTEGER)&ProbeOffset,
+                                                     2048,
+                                                     &BytesRead,
+                                                     &ProbeSpan);
+                    if (ProbeBase && BytesRead >= 6)
+                    {
+                        const UCHAR *p = (const UCHAR *)ProbeBase;
+                        if (p[1] == 'C' && p[2] == 'D' && p[3] == '0' && p[4] == '0' && p[5] == '1')
+                        {
+                            IsIso = TRUE;
+                        }
+                    }
+                    if (ProbeBase)
+                    {
+                        RamdiskUnmapPages(DriveExtension,
+                                          ProbeBase,
+                                          *(PLARGE_INTEGER)&ProbeOffset,
+                                          ProbeSpan);
+                    }
+
+                    if (IsIso)
+                    {
+                        DbgPrintEx(DPFLTR_DEFAULT_ID,
+                                   DPFLTR_ERROR_LEVEL,
+                                   "RamdiskCreateDiskDevice: detected El-Torito ISO9660 (0x96) -> exporting as CD (startLba=%I64u len=%lu)\n",
+                                   PartitionStartLba,
+                                   PartitionSectorCount);
+                        DriveExtension->DiskOptions.ExportAsCd = TRUE;
+                        Input->Options.ExportAsCd = TRUE;
+                    }
+                    else
+                    {
+                        DbgPrintEx(DPFLTR_DEFAULT_ID,
+                                   DPFLTR_ERROR_LEVEL,
+                                   "RamdiskCreateDiskDevice: 0x96 partition does not look like ISO (no CD001 at LBA16); keeping disk semantics\n");
+                    }
+                }
+
+                if (PartitionStartLba != 0)
+                {
+                    LARGE_INTEGER BootOffset;
+
+                    BootOffset.QuadPart = (ULONGLONG)PartitionStartLba * 512ULL;
+
+                    RamdiskUnmapPages(DriveExtension,
+                                      BaseAddress,
+                                      CurrentOffset,
+                                      MapSpan);
+
+                    CurrentOffset = BootOffset;
+                    BaseAddress = RamdiskMapPages(DriveExtension,
+                                                  CurrentOffset,
+                                                  PAGE_SIZE,
+                                                  &BytesRead,
+                                                  &MapSpan);
+                    if (!BaseAddress)
+                    {
+                        Status = STATUS_INSUFFICIENT_RESOURCES;
+                        goto FailCreate;
+                    }
+
+                    BootSector = (PPACKED_BOOT_SECTOR)BaseAddress;
+                    FatUnpackBios(&BiosBlock, &BootSector->PackedBpb);
+
+                    if (RamdiskBootSectorHasSignature(BootSector) &&
+                        (BiosBlock.BytesPerSector >= 512) &&
+                        (BiosBlock.BytesPerSector <= 4096) &&
+                        (BiosBlock.SectorsPerTrack != 0) &&
+                        (BiosBlock.Heads != 0))
+                    {
+                        BootSectorValid = TRUE;
+                        DriveExtension->HiddenSectors = (ULONG)PartitionStartLba;
+                    }
+                }
             }
+
+            if (BootSectorValid)
+            {
+                DriveExtension->BytesPerSector = BiosBlock.BytesPerSector;
+                DriveExtension->SectorsPerTrack = BiosBlock.SectorsPerTrack;
+                DriveExtension->NumberOfHeads = BiosBlock.Heads;
+
+                /* Only overwrite HiddenSectors from BPB if it matches the MBR-derived value,
+                   or if we didn't find an MBR partition table */
+                if (PartitionStartLba == 0 || BiosBlock.HiddenSectors == (ULONG)PartitionStartLba)
+                {
+                    DriveExtension->HiddenSectors = BiosBlock.HiddenSectors;
+                }
+                /* Otherwise keep the MBR-derived value already set in DriveExtension->HiddenSectors */
+            }
+
+SkipBootSectorProbe:
+            if (BaseAddress)
+            {
+                RamdiskUnmapPages(DriveExtension,
+                                  BaseAddress,
+                                  CurrentOffset,
+                                  MapSpan);
+            }
+        }
+
+        if (DriveExtension->DiskOptions.ExportAsCd)
+        {
+            /* Force ISO defaults regardless of what the boot sector reported */
+            DriveExtension->BytesPerSector = 2048;
+            DriveExtension->SectorsPerTrack = 32;
+            DriveExtension->NumberOfHeads = 64;
+        }
+        else if ((DriveExtension->BytesPerSector == 0) ||
+                 (DriveExtension->SectorsPerTrack == 0) ||
+                 (DriveExtension->NumberOfHeads == 0))
+        {
+            /* Setup partition parameters default for FAT */
+            DriveExtension->BytesPerSector = 512;
+            DriveExtension->SectorsPerTrack = 128;
+            DriveExtension->NumberOfHeads = 16;
+        }
+
+        DPRINT1("RamdiskCreateDiskDevice: geometry BPS=%lu SPT=%lu Heads=%lu ExportAsCd=%u HiddenSectors=%lu\n",
+                DriveExtension->BytesPerSector,
+                DriveExtension->SectorsPerTrack,
+                DriveExtension->NumberOfHeads,
+                Input->Options.ExportAsCd,
+                DriveExtension->HiddenSectors);
+
+        if (DriveExtension->BytesPerSector > 0)
+        {
+            DeviceObject->AlignmentRequirement = (ULONG)(DriveExtension->BytesPerSector - 1);
         }
 
         /* Calculate the cylinder size */
@@ -621,14 +2179,48 @@ RamdiskCreateDiskDevice(IN PRAMDISK_BUS_EXTENSION DeviceExtension,
         ExReleaseFastMutex(&DeviceExtension->DiskListLock);
         KeLeaveCriticalRegion();
 
+        if (DriveExtension->DiskOptions.ExportAsCd)
+        {
+            PARTITION_INFORMATION DebugPartition;
+            NTSTATUS partStatus = RamdiskBuildPartitionInfo(DriveExtension, &DebugPartition);
+            if (NT_SUCCESS(partStatus))
+            {
+                DbgPrintEx(DPFLTR_DEFAULT_ID,
+                           DPFLTR_ERROR_LEVEL,
+                           "RamdiskCreateDiskDevice: partition start=%I64u length=%I64u type=0x%02X\n",
+                           DebugPartition.StartingOffset.QuadPart,
+                           DebugPartition.PartitionLength.QuadPart,
+                           DebugPartition.PartitionType);
+            }
+            else
+            {
+                DbgPrintEx(DPFLTR_DEFAULT_ID,
+                           DPFLTR_ERROR_LEVEL,
+                           "RamdiskCreateDiskDevice: partition info unavailable status=0x%08X\n",
+                           partStatus);
+            }
+        }
+
+        /* Load any persisted state (must occur after list insertion) */
+        RamdiskRestoreDiskState(DriveExtension);
+        RamdiskPersistDiskState(DriveExtension);
+
         /* Clear init flag */
         DeviceObject->Flags &= ~DO_DEVICE_INITIALIZING;
+        DbgPrintEx(DPFLTR_DEFAULT_ID,
+                   DPFLTR_TRACE_LEVEL,
+                   "RamdiskCreateDiskDevice: GUID %wZ assigned drive %wc\n",
+                   &DriveExtension->GuidString,
+                   DriveExtension->DriveLetter ? DriveExtension->DriveLetter : L'-');
         return STATUS_SUCCESS;
     }
 
 FailCreate:
-    UNIMPLEMENTED_DBGBREAK();
-    return STATUS_SUCCESS;
+    DbgPrintEx(DPFLTR_DEFAULT_ID,
+               DPFLTR_WARNING_LEVEL,
+               "RamdiskCreateDiskDevice: failing create with status 0x%lx\n",
+               Status);
+    return Status;
 }
 
 NTSTATUS
@@ -658,6 +2250,14 @@ RamdiskCreateRamdisk(IN PDEVICE_OBJECT DeviceObject,
         return STATUS_INVALID_PARAMETER;
     }
 
+    DbgPrintEx(DPFLTR_DEFAULT_ID,
+               DPFLTR_TRACE_LEVEL,
+               "RamdiskCreateRamdisk: create request type %lu length %lu letter %wc options 0x%08lx\n",
+               Input->DiskType,
+               Length,
+               Input->DriveLetter ? Input->DriveLetter : L'-',
+               *(PULONG)&Input->Options);
+
     /* Validate the disk type */
     DiskType = Input->DiskType;
     if (DiskType == RAMDISK_WIM_DISK) return STATUS_INVALID_PARAMETER;
@@ -670,7 +2270,8 @@ RamdiskCreateRamdisk(IN PDEVICE_OBJECT DeviceObject,
 
         /* Save command-line flags */
         if (ExportBootDiskAsCd) Input->Options.ExportAsCd = TRUE;
-        if (IsWinPEBoot) Input->Options.NoDriveLetter = TRUE;
+        if (Input->DriveLetter == 0 && IsWinPEBoot)
+            Input->Options.NoDriveLetter = TRUE;
     }
 
     /* Validate the disk type */
@@ -699,11 +2300,144 @@ RamdiskCreateRamdisk(IN PDEVICE_OBJECT DeviceObject,
     {
         /* Invalidate and set success */
         IoInvalidateDeviceRelations(DeviceExtension->PhysicalDeviceObject, 0);
-        Irp->IoStatus.Information = STATUS_SUCCESS;
+        Irp->IoStatus.Information = 0;
+        DbgPrintEx(DPFLTR_DEFAULT_ID,
+                   DPFLTR_TRACE_LEVEL,
+                   "RamdiskCreateRamdisk: device creation succeeded\n");
     }
 
     /* We are done */
     return Status;
+}
+
+static
+NTSTATUS
+RamdiskBuildPartitionInfo(IN PRAMDISK_DRIVE_EXTENSION DeviceExtension,
+                          OUT PPARTITION_INFORMATION PartitionInfo)
+{
+    LARGE_INTEGER Zero = {{0, 0}};
+    PVOID BaseAddress;
+    ULONG BytesRead;
+    ULONG MapSpan;
+
+    RtlZeroMemory(PartitionInfo, sizeof(*PartitionInfo));
+
+    BaseAddress = RamdiskMapPages(DeviceExtension, Zero, PAGE_SIZE, &BytesRead, &MapSpan);
+    if (BaseAddress == NULL)
+    {
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+
+    PartitionInfo->PartitionNumber = 1;
+    PartitionInfo->RewritePartition = FALSE;
+
+    if (BytesRead >= 0x200 && DeviceExtension->BytesPerSector != 0)
+    {
+        USHORT Signature = *((PUSHORT)((PUCHAR)BaseAddress + 0x1FE));
+        if (Signature == 0xAA55)
+        {
+            PUCHAR Entry = (PUCHAR)BaseAddress + 0x1BE;
+            UCHAR BootIndicator = Entry[0];
+            UCHAR Type = Entry[4];
+            ULONG StartLba = *(PULONG)(Entry + 8);
+            ULONG SectorCount = *(PULONG)(Entry + 12);
+
+            if (Type != 0 && SectorCount != 0)
+            {
+                ULONG effectiveSectorSize = DeviceExtension->BytesPerSector;
+
+                if (DeviceExtension->DiskOptions.ExportAsCd && Type == 0x96)
+                {
+                    effectiveSectorSize = 512;
+                }
+
+                PartitionInfo->StartingOffset.QuadPart = ((ULONGLONG)StartLba) * effectiveSectorSize;
+                PartitionInfo->PartitionLength.QuadPart = ((ULONGLONG)SectorCount) * effectiveSectorSize;
+                PartitionInfo->HiddenSectors = StartLba;
+                PartitionInfo->PartitionType = Type;
+                PartitionInfo->BootIndicator = (BootIndicator == 0x80) ? TRUE : FALSE;
+                PartitionInfo->RecognizedPartition = IsRecognizedPartition(Type);
+
+                if (DeviceExtension->DiskOptions.ExportAsCd)
+                {
+                    PartitionInfo->StartingOffset.QuadPart = 0;
+                    PartitionInfo->PartitionLength = DeviceExtension->DiskLength;
+                    PartitionInfo->HiddenSectors = 0;
+                    PartitionInfo->PartitionType = PARTITION_ISO9660;
+                    PartitionInfo->BootIndicator = TRUE;
+                    PartitionInfo->RecognizedPartition = TRUE;
+                }
+
+                DPRINT1("RamdiskBuildPartitionInfo: type=0x%02X LBA=%lu sectors=%lu effBPS=%lu start=%I64u len=%I64u\n",
+                        Type,
+                        StartLba,
+                        SectorCount,
+                        effectiveSectorSize,
+                        PartitionInfo->StartingOffset.QuadPart,
+                        PartitionInfo->PartitionLength.QuadPart);
+
+                RamdiskUnmapPages(DeviceExtension, BaseAddress, Zero, MapSpan);
+                return STATUS_SUCCESS;
+            }
+        }
+    }
+
+    PartitionInfo->StartingOffset.QuadPart = 0;
+    PartitionInfo->PartitionLength = DeviceExtension->DiskLength;
+    PartitionInfo->HiddenSectors = 0;
+    if (DeviceExtension->DiskOptions.ExportAsCd)
+    {
+        PartitionInfo->PartitionType = PARTITION_ISO9660;
+        PartitionInfo->BootIndicator = TRUE;
+        PartitionInfo->RecognizedPartition = TRUE;
+    }
+    else
+    {
+        PartitionInfo->PartitionType = PARTITION_IFS;
+        PartitionInfo->BootIndicator = (DeviceExtension->DiskType == RAMDISK_BOOT_DISK) ? TRUE : FALSE;
+        PartitionInfo->RecognizedPartition = IsRecognizedPartition(PartitionInfo->PartitionType);
+    }
+
+    RamdiskUnmapPages(DeviceExtension, BaseAddress, Zero, MapSpan);
+    return STATUS_SUCCESS;
+}
+
+static
+NTSTATUS
+RamdiskBuildPartitionInfoEx(IN PRAMDISK_DRIVE_EXTENSION DeviceExtension,
+                            OUT PPARTITION_INFORMATION_EX PartitionInfoEx)
+{
+    PARTITION_INFORMATION LegacyInfo;
+    NTSTATUS Status;
+
+    Status = RamdiskBuildPartitionInfo(DeviceExtension, &LegacyInfo);
+    if (!NT_SUCCESS(Status))
+    {
+        return Status;
+    }
+
+    RtlZeroMemory(PartitionInfoEx, sizeof(*PartitionInfoEx));
+    PartitionInfoEx->PartitionStyle = PARTITION_STYLE_MBR;
+    PartitionInfoEx->StartingOffset = LegacyInfo.StartingOffset;
+    PartitionInfoEx->PartitionLength = LegacyInfo.PartitionLength;
+    PartitionInfoEx->PartitionNumber = LegacyInfo.PartitionNumber;
+    PartitionInfoEx->RewritePartition = LegacyInfo.RewritePartition;
+    if (DeviceExtension->DiskOptions.ExportAsCd)
+    {
+        PartitionInfoEx->Mbr.PartitionType = PARTITION_ISO9660;
+        PartitionInfoEx->Mbr.BootIndicator = TRUE;
+        PartitionInfoEx->Mbr.RecognizedPartition = TRUE;
+        PartitionInfoEx->Mbr.HiddenSectors = 0;
+    }
+    else
+    {
+        PartitionInfoEx->Mbr.PartitionType = LegacyInfo.PartitionType;
+        PartitionInfoEx->Mbr.BootIndicator = LegacyInfo.BootIndicator;
+        PartitionInfoEx->Mbr.RecognizedPartition = LegacyInfo.RecognizedPartition;
+        PartitionInfoEx->Mbr.HiddenSectors = LegacyInfo.HiddenSectors;
+    }
+
+    return STATUS_SUCCESS;
 }
 
 NTSTATUS
@@ -712,58 +2446,64 @@ RamdiskGetPartitionInfo(IN PIRP Irp,
                         IN PRAMDISK_DRIVE_EXTENSION DeviceExtension)
 {
     NTSTATUS Status;
-    PPARTITION_INFORMATION PartitionInfo;
-    PVOID BaseAddress;
-    LARGE_INTEGER Zero = {{0, 0}};
-    ULONG Length;
     PIO_STACK_LOCATION IoStackLocation;
+    PPARTITION_INFORMATION PartitionInfo;
 
-    /* Validate the length */
     IoStackLocation = IoGetCurrentIrpStackLocation(Irp);
-    if (IoStackLocation->Parameters.DeviceIoControl.
-        OutputBufferLength < sizeof(PARTITION_INFORMATION))
+    if (IoStackLocation->Parameters.DeviceIoControl.OutputBufferLength < sizeof(PARTITION_INFORMATION))
     {
-        /* Invalid length */
-        Status = STATUS_BUFFER_TOO_SMALL;
-        Irp->IoStatus.Status = Status;
+        Irp->IoStatus.Status = STATUS_BUFFER_TOO_SMALL;
         Irp->IoStatus.Information = 0;
-        return Status;
+        return STATUS_BUFFER_TOO_SMALL;
     }
 
-    /* Map the partition table */
-    BaseAddress = RamdiskMapPages(DeviceExtension, Zero, PAGE_SIZE, &Length);
-    if (!BaseAddress)
-    {
-        /* No memory */
-        Status = STATUS_INSUFFICIENT_RESOURCES;
-        Irp->IoStatus.Status = Status;
-        Irp->IoStatus.Information = 0;
-        return Status;
-    }
-
-    /* Fill out the information */
     PartitionInfo = Irp->AssociatedIrp.SystemBuffer;
-    PartitionInfo->StartingOffset.QuadPart = DeviceExtension->BytesPerSector;
-    PartitionInfo->PartitionLength.QuadPart = DeviceExtension->BytesPerSector *
-                                              DeviceExtension->SectorsPerTrack *
-                                              DeviceExtension->NumberOfHeads *
-                                              DeviceExtension->Cylinders;
-    PartitionInfo->HiddenSectors = DeviceExtension->HiddenSectors;
-    PartitionInfo->PartitionNumber = 0;
-    PartitionInfo->PartitionType = *((PCHAR)BaseAddress + 450);
-    PartitionInfo->BootIndicator = (DeviceExtension->DiskType ==
-                                    RAMDISK_BOOT_DISK) ? TRUE: FALSE;
-    PartitionInfo->RecognizedPartition = IsRecognizedPartition(PartitionInfo->
-                                                               PartitionType);
-    PartitionInfo->RewritePartition = FALSE;
+    Status = RamdiskBuildPartitionInfo(DeviceExtension, PartitionInfo);
+    if (NT_SUCCESS(Status))
+    {
+        Irp->IoStatus.Status = STATUS_SUCCESS;
+        Irp->IoStatus.Information = sizeof(PARTITION_INFORMATION);
+    }
+    else
+    {
+        Irp->IoStatus.Status = Status;
+        Irp->IoStatus.Information = 0;
+    }
 
-    /* Unmap the partition table */
-    RamdiskUnmapPages(DeviceExtension, BaseAddress, Zero, Length);
+    return Status;
+}
 
-    /* Done */
-    Irp->IoStatus.Status = STATUS_SUCCESS;
-    Irp->IoStatus.Information = sizeof(PARTITION_INFORMATION);
-    return STATUS_SUCCESS;
+NTSTATUS
+NTAPI
+RamdiskGetPartitionInfoEx(IN PIRP Irp,
+                          IN PRAMDISK_DRIVE_EXTENSION DeviceExtension)
+{
+    PIO_STACK_LOCATION IoStackLocation;
+    PPARTITION_INFORMATION_EX PartitionInfo;
+    NTSTATUS Status;
+
+    IoStackLocation = IoGetCurrentIrpStackLocation(Irp);
+    if (IoStackLocation->Parameters.DeviceIoControl.OutputBufferLength < sizeof(PARTITION_INFORMATION_EX))
+    {
+        Irp->IoStatus.Status = STATUS_BUFFER_TOO_SMALL;
+        Irp->IoStatus.Information = 0;
+        return STATUS_BUFFER_TOO_SMALL;
+    }
+
+    PartitionInfo = Irp->AssociatedIrp.SystemBuffer;
+    Status = RamdiskBuildPartitionInfoEx(DeviceExtension, PartitionInfo);
+    if (NT_SUCCESS(Status))
+    {
+        Irp->IoStatus.Status = STATUS_SUCCESS;
+        Irp->IoStatus.Information = sizeof(PARTITION_INFORMATION_EX);
+    }
+    else
+    {
+        Irp->IoStatus.Status = Status;
+        Irp->IoStatus.Information = 0;
+    }
+
+    return Status;
 }
 
 NTSTATUS
@@ -772,6 +2512,7 @@ RamdiskSetPartitionInfo(IN PIRP Irp,
                         IN PRAMDISK_DRIVE_EXTENSION DeviceExtension)
 {
     ULONG BytesRead;
+    ULONG MapSpan;
     NTSTATUS Status;
     PVOID BaseAddress;
     PIO_STACK_LOCATION Stack;
@@ -787,7 +2528,7 @@ RamdiskSetPartitionInfo(IN PIRP Irp,
     }
 
     /* Map to get MBR */
-    BaseAddress = RamdiskMapPages(DeviceExtension, Zero, PAGE_SIZE, &BytesRead);
+    BaseAddress = RamdiskMapPages(DeviceExtension, Zero, PAGE_SIZE, &BytesRead, &MapSpan);
     if (BaseAddress == NULL)
     {
         Status = STATUS_INSUFFICIENT_RESOURCES;
@@ -799,13 +2540,317 @@ RamdiskSetPartitionInfo(IN PIRP Irp,
     *((PCHAR)BaseAddress + 450) = PartitionInfo->PartitionType;
 
     /* And unmap */
-    RamdiskUnmapPages(DeviceExtension, BaseAddress, Zero, BytesRead);
+    RamdiskUnmapPages(DeviceExtension, BaseAddress, Zero, MapSpan);
     Status = STATUS_SUCCESS;
 
 SetAndQuit:
     Irp->IoStatus.Status = Status;
     Irp->IoStatus.Information = 0;
     return Status;
+}
+
+static
+NTSTATUS
+RamdiskHandleStorageQueryProperty(IN PRAMDISK_DRIVE_EXTENSION DeviceExtension,
+                                  IN PIRP Irp,
+                                  IN PIO_STACK_LOCATION IoStackLocation,
+                                  OUT PULONG Information)
+{
+    PSTORAGE_PROPERTY_QUERY Query;
+    ULONG OutputLength;
+
+    if (IoStackLocation->Parameters.DeviceIoControl.InputBufferLength < sizeof(STORAGE_PROPERTY_QUERY))
+    {
+        return STATUS_INVALID_PARAMETER;
+    }
+
+    Query = Irp->AssociatedIrp.SystemBuffer;
+    if (!Query)
+    {
+        return STATUS_INVALID_PARAMETER;
+    }
+    OutputLength = IoStackLocation->Parameters.DeviceIoControl.OutputBufferLength;
+
+    switch (Query->PropertyId)
+    {
+        case StorageDeviceProperty:
+        {
+            switch (Query->QueryType)
+            {
+                case PropertyStandardQuery:
+                {
+                    PSTORAGE_DEVICE_DESCRIPTOR Descriptor;
+
+                    if (OutputLength < sizeof(STORAGE_DESCRIPTOR_HEADER))
+                    {
+                        *Information = sizeof(STORAGE_DESCRIPTOR_HEADER);
+                        return STATUS_BUFFER_TOO_SMALL;
+                    }
+
+                    if (OutputLength < sizeof(STORAGE_DEVICE_DESCRIPTOR))
+                    {
+                        *Information = sizeof(STORAGE_DEVICE_DESCRIPTOR);
+                        return STATUS_BUFFER_TOO_SMALL;
+                    }
+
+                    Descriptor = Irp->AssociatedIrp.SystemBuffer;
+                    RtlZeroMemory(Descriptor, sizeof(STORAGE_DEVICE_DESCRIPTOR));
+                    Descriptor->Version = sizeof(STORAGE_DEVICE_DESCRIPTOR);
+                    Descriptor->Size = sizeof(STORAGE_DEVICE_DESCRIPTOR);
+                    Descriptor->DeviceType = DeviceExtension->DiskOptions.ExportAsCd ? READ_ONLY_DIRECT_ACCESS_DEVICE : DIRECT_ACCESS_DEVICE;
+                    Descriptor->RemovableMedia = !DeviceExtension->DiskOptions.Fixed;
+                    Descriptor->CommandQueueing = FALSE;
+                    Descriptor->BusType = BusTypeVirtual;
+                    Descriptor->RawPropertiesLength = 0;
+
+                    *Information = sizeof(STORAGE_DEVICE_DESCRIPTOR);
+                    return STATUS_SUCCESS;
+                }
+
+                case PropertyExistsQuery:
+                {
+                    *Information = 0;
+                    return STATUS_SUCCESS;
+                }
+
+                default:
+                    return STATUS_NOT_SUPPORTED;
+            }
+        }
+
+        case StorageAccessAlignmentProperty:
+        {
+            switch (Query->QueryType)
+            {
+                case PropertyStandardQuery:
+                {
+                    PSTORAGE_ACCESS_ALIGNMENT_DESCRIPTOR Alignment;
+
+                    if (OutputLength < sizeof(STORAGE_ACCESS_ALIGNMENT_DESCRIPTOR))
+                    {
+                        *Information = sizeof(STORAGE_ACCESS_ALIGNMENT_DESCRIPTOR);
+                        return STATUS_BUFFER_TOO_SMALL;
+                    }
+
+                    Alignment = Irp->AssociatedIrp.SystemBuffer;
+                    RtlZeroMemory(Alignment, sizeof(STORAGE_ACCESS_ALIGNMENT_DESCRIPTOR));
+                    Alignment->Version = sizeof(STORAGE_ACCESS_ALIGNMENT_DESCRIPTOR);
+                    Alignment->Size = sizeof(STORAGE_ACCESS_ALIGNMENT_DESCRIPTOR);
+                    Alignment->BytesPerCacheLine = 0;
+                    Alignment->BytesOffsetForCacheAlignment = 0;
+                    Alignment->BytesPerLogicalSector = DeviceExtension->BytesPerSector;
+                    Alignment->BytesPerPhysicalSector = DeviceExtension->BytesPerSector;
+                    Alignment->BytesOffsetForSectorAlignment = 0;
+
+                    *Information = sizeof(STORAGE_ACCESS_ALIGNMENT_DESCRIPTOR);
+                    return STATUS_SUCCESS;
+                }
+
+                case PropertyExistsQuery:
+                {
+                    *Information = 0;
+                    return STATUS_SUCCESS;
+                }
+
+                default:
+                    return STATUS_NOT_SUPPORTED;
+            }
+        }
+
+        default:
+            return STATUS_NOT_SUPPORTED;
+    }
+}
+
+static
+NTSTATUS
+RamdiskBuildRegistrySubKey(IN PRAMDISK_DRIVE_EXTENSION DriveExtension,
+                           _Out_writes_(BufferChars) PWSTR Buffer,
+                           _In_ ULONG BufferChars)
+{
+    INT Count;
+
+    if (BufferChars == 0)
+    {
+        return STATUS_BUFFER_TOO_SMALL;
+    }
+
+    Count = _snwprintf(Buffer,
+                       BufferChars,
+                       L"Ramdisk\\Parameters\\Disks\\%wZ",
+                       &DriveExtension->GuidString);
+
+    if (Count < 0 || (ULONG)Count >= BufferChars)
+    {
+        Buffer[BufferChars - 1] = UNICODE_NULL;
+        return STATUS_BUFFER_TOO_SMALL;
+    }
+
+    Buffer[Count] = UNICODE_NULL;
+    return STATUS_SUCCESS;
+}
+
+static
+VOID
+RamdiskPersistDiskState(IN PRAMDISK_DRIVE_EXTENSION DriveExtension)
+{
+    WCHAR SubKey[128];
+    NTSTATUS Status;
+    ULONG LinkCount;
+
+    RamdiskEnsureRegistryPath(DriveExtension);
+
+    Status = RamdiskBuildRegistrySubKey(DriveExtension, SubKey, RTL_NUMBER_OF(SubKey));
+    if (!NT_SUCCESS(Status))
+    {
+        return;
+    }
+
+    LinkCount = DriveExtension->MountdevLinkCount;
+    RtlWriteRegistryValue(RTL_REGISTRY_SERVICES,
+                          SubKey,
+                          L"MountdevLinkCount",
+                          REG_DWORD,
+                          &LinkCount,
+                          sizeof(LinkCount));
+
+    if (DriveExtension->GuidString.Buffer != NULL)
+    {
+        RtlWriteRegistryValue(RTL_REGISTRY_SERVICES,
+                              SubKey,
+                              L"DiskGuid",
+                              REG_BINARY,
+                              &DriveExtension->DiskGuid,
+                              sizeof(GUID));
+    }
+
+    if (DriveExtension->DriveLetter != 0)
+    {
+        ULONG Letter = (ULONG)DriveExtension->DriveLetter;
+        RtlWriteRegistryValue(RTL_REGISTRY_SERVICES,
+                              SubKey,
+                              L"DriveLetter",
+                              REG_DWORD,
+                              &Letter,
+                              sizeof(Letter));
+    }
+
+    {
+        ULONGLONG Attributes = RamdiskQueryGptAttributes(DriveExtension);
+        RtlWriteRegistryValue(RTL_REGISTRY_SERVICES,
+                              SubKey,
+                              L"GptAttributes",
+                              REG_QWORD,
+                              &Attributes,
+                              sizeof(Attributes));
+    }
+
+    {
+        ULONG OfflineValue = DriveExtension->VolumeOffline ? 1u : 0u;
+        RtlWriteRegistryValue(RTL_REGISTRY_SERVICES,
+                              SubKey,
+                              L"VolumeOffline",
+                              REG_DWORD,
+                              &OfflineValue,
+                              sizeof(OfflineValue));
+    }
+}
+
+static
+VOID
+RamdiskRestoreDiskState(IN PRAMDISK_DRIVE_EXTENSION DriveExtension)
+{
+    WCHAR SubKey[128];
+    NTSTATUS Status;
+    RTL_QUERY_REGISTRY_TABLE QueryTable[6];
+    ULONG LinkCount = DriveExtension->MountdevLinkCount;
+    ULONG Letter = 0;
+    GUID GuidValue = DriveExtension->DiskGuid;
+    ULONGLONG Attributes = RamdiskQueryGptAttributes(DriveExtension);
+    ULONG OfflineValue = DriveExtension->VolumeOffline ? 1u : 0u;
+    ULONG DefaultOffline = OfflineValue;
+
+    RamdiskEnsureRegistryPath(DriveExtension);
+
+    Status = RamdiskBuildRegistrySubKey(DriveExtension, SubKey, RTL_NUMBER_OF(SubKey));
+    if (!NT_SUCCESS(Status))
+    {
+        return;
+    }
+
+    RtlZeroMemory(QueryTable, sizeof(QueryTable));
+
+    QueryTable[0].Flags = RTL_QUERY_REGISTRY_DIRECT | RTL_QUERY_REGISTRY_TYPECHECK;
+    QueryTable[0].Name = L"MountdevLinkCount";
+    QueryTable[0].EntryContext = &LinkCount;
+    QueryTable[0].DefaultType = REG_DWORD;
+    QueryTable[0].DefaultData = &DriveExtension->MountdevLinkCount;
+    QueryTable[0].DefaultLength = sizeof(DriveExtension->MountdevLinkCount);
+
+    QueryTable[1].Flags = RTL_QUERY_REGISTRY_DIRECT | RTL_QUERY_REGISTRY_TYPECHECK;
+    QueryTable[1].Name = L"DriveLetter";
+    QueryTable[1].EntryContext = &Letter;
+    QueryTable[1].DefaultType = REG_NONE;
+
+    QueryTable[2].Flags = RTL_QUERY_REGISTRY_DIRECT | RTL_QUERY_REGISTRY_TYPECHECK;
+    QueryTable[2].Name = L"DiskGuid";
+    QueryTable[2].EntryContext = &GuidValue;
+    QueryTable[2].DefaultType = REG_BINARY;
+    QueryTable[2].DefaultData = &DriveExtension->DiskGuid;
+    QueryTable[2].DefaultLength = sizeof(GUID);
+
+    QueryTable[3].Flags = RTL_QUERY_REGISTRY_DIRECT | RTL_QUERY_REGISTRY_TYPECHECK;
+    QueryTable[3].Name = L"GptAttributes";
+    QueryTable[3].EntryContext = &Attributes;
+    QueryTable[3].DefaultType = REG_QWORD;
+    QueryTable[3].DefaultData = &Attributes;
+    QueryTable[3].DefaultLength = sizeof(Attributes);
+
+    QueryTable[4].Flags = RTL_QUERY_REGISTRY_DIRECT | RTL_QUERY_REGISTRY_TYPECHECK;
+    QueryTable[4].Name = L"VolumeOffline";
+    QueryTable[4].EntryContext = &OfflineValue;
+    QueryTable[4].DefaultType = REG_DWORD;
+    QueryTable[4].DefaultData = &DefaultOffline;
+    QueryTable[4].DefaultLength = sizeof(DefaultOffline);
+
+    RtlQueryRegistryValues(RTL_REGISTRY_SERVICES,
+                           SubKey,
+                           QueryTable,
+                           NULL,
+                           NULL);
+
+    DriveExtension->MountdevLinkCount = LinkCount;
+
+    if (Letter != 0)
+    {
+        DriveExtension->DriveLetter = (WCHAR)Letter;
+    }
+
+    RamdiskApplyGptAttributes(DriveExtension, Attributes);
+    DriveExtension->VolumeOffline = (OfflineValue != 0);
+
+    if (RtlCompareMemory(&GuidValue, &DriveExtension->DiskGuid, sizeof(GUID)) != sizeof(GUID))
+    {
+        NTSTATUS GuidStatus;
+
+        DriveExtension->DiskGuid = GuidValue;
+
+        if (DriveExtension->GuidString.Buffer)
+        {
+            RtlFreeUnicodeString(&DriveExtension->GuidString);
+            DriveExtension->GuidString.Buffer = NULL;
+            DriveExtension->GuidString.Length = 0;
+            DriveExtension->GuidString.MaximumLength = 0;
+        }
+
+        GuidStatus = RtlStringFromGUID(&DriveExtension->DiskGuid, &DriveExtension->GuidString);
+        if (!NT_SUCCESS(GuidStatus))
+        {
+            DriveExtension->GuidString.Buffer = NULL;
+            DriveExtension->GuidString.Length = 0;
+            DriveExtension->GuidString.MaximumLength = 0;
+        }
+    }
 }
 
 VOID
@@ -836,35 +2881,50 @@ RamdiskWorkerThread(IN PDEVICE_OBJECT DeviceObject,
             case IRP_MJ_DEVICE_CONTROL:
             {
                 /* Let's take a look at the IOCTL */
-                switch (IoStackLocation->Parameters.DeviceIoControl.IoControlCode)
+                ULONG NormalizedIoctl = IOCTL_NORMALIZE_ACCESS(IoStackLocation->Parameters.DeviceIoControl.IoControlCode);
+                switch (NormalizedIoctl)
                 {
                     /* Ramdisk create request */
-                    case FSCTL_CREATE_RAM_DISK:
+                    case IOCTL_NORMALIZE_ACCESS(FSCTL_CREATE_RAM_DISK):
                     {
                         /* This time we'll do it for real */
                         Status = RamdiskCreateRamdisk(DeviceObject, Irp, FALSE);
                         break;
                     }
 
-                    case IOCTL_DISK_SET_PARTITION_INFO:
+                    case IOCTL_NORMALIZE_ACCESS(IOCTL_DISK_SET_PARTITION_INFO):
                     {
                         Status = RamdiskSetPartitionInfo(Irp, (PRAMDISK_DRIVE_EXTENSION)DeviceExtension);
                         break;
                     }
 
-                    case IOCTL_DISK_GET_DRIVE_LAYOUT:
-                        UNIMPLEMENTED_DBGBREAK("Get drive layout request\n");
+                    case IOCTL_NORMALIZE_ACCESS(IOCTL_DISK_GET_DRIVE_LAYOUT):
+                    {
+                        Status = STATUS_NOT_SUPPORTED;
                         break;
+                    }
 
-                    case IOCTL_DISK_GET_PARTITION_INFO:
+                    case IOCTL_NORMALIZE_ACCESS(IOCTL_DISK_GET_PARTITION_INFO):
                     {
                         Status = RamdiskGetPartitionInfo(Irp, (PRAMDISK_DRIVE_EXTENSION)DeviceExtension);
                         break;
                     }
 
-                    default:
-                        UNIMPLEMENTED_DBGBREAK("Invalid request\n");
+                    case IOCTL_NORMALIZE_ACCESS(IOCTL_DISK_GET_PARTITION_INFO_EX):
+                    {
+                        Status = RamdiskGetPartitionInfoEx(Irp, (PRAMDISK_DRIVE_EXTENSION)DeviceExtension);
                         break;
+                    }
+
+                    default:
+                    {
+                        DbgPrintEx(DPFLTR_DEFAULT_ID,
+                                   DPFLTR_WARNING_LEVEL,
+                                   "RamdiskWorkerThread: unsupported IOCTL 0x%lx\n",
+                                   IoStackLocation->Parameters.DeviceIoControl.IoControlCode);
+                        Status = STATUS_INVALID_DEVICE_REQUEST;
+                        break;
+                    }
                 }
 
                 /* We're here */
@@ -874,30 +2934,75 @@ RamdiskWorkerThread(IN PDEVICE_OBJECT DeviceObject,
             /* Read or write request */
             case IRP_MJ_READ:
             case IRP_MJ_WRITE:
-                UNIMPLEMENTED_DBGBREAK("Read/Write request\n");
+            {
+                PRAMDISK_DRIVE_EXTENSION DriveExtension = (PRAMDISK_DRIVE_EXTENSION)DeviceExtension;
+
+                if (DriveExtension->Type != RamdiskDrive)
+                {
+                    Status = STATUS_INVALID_DEVICE_REQUEST;
+                    break;
+                }
+
+                Status = RamdiskReadWriteReal(Irp, DriveExtension);
                 break;
+            }
 
             /* Internal request (SCSI?) */
             case IRP_MJ_INTERNAL_DEVICE_CONTROL:
-                UNIMPLEMENTED_DBGBREAK("SCSI request\n");
+            {
+                Status = STATUS_NOT_SUPPORTED;
                 break;
+            }
 
             /* Flush request */
             case IRP_MJ_FLUSH_BUFFERS:
-                UNIMPLEMENTED_DBGBREAK("Flush request\n");
+            {
+                Status = STATUS_SUCCESS;
                 break;
+            }
 
             /* Anything else */
             default:
-                UNIMPLEMENTED_DBGBREAK("Invalid request: %lx\n",
-                                       IoStackLocation->MajorFunction);
+            {
+                DbgPrintEx(DPFLTR_DEFAULT_ID,
+                           DPFLTR_WARNING_LEVEL,
+                           "RamdiskWorkerThread: unsupported major function 0x%lx\n",
+                           IoStackLocation->MajorFunction);
+                Status = STATUS_INVALID_DEVICE_REQUEST;
                 break;
+            }
+        }
+
+        if (IoStackLocation->MajorFunction == IRP_MJ_DEVICE_CONTROL)
+        {
+            ULONG IoControlCode = IoStackLocation->Parameters.DeviceIoControl.IoControlCode;
+            PCSTR IoctlName = RamdiskGetIoctlName(IoControlCode);
+
+            DbgPrintEx(DPFLTR_DEFAULT_ID,
+                       NT_SUCCESS(Status) ? DPFLTR_TRACE_LEVEL : DPFLTR_WARNING_LEVEL,
+                       "RamdiskWorkerThread: completed %s (0x%lx) -> 0x%lx info=%lu\n",
+                       IoctlName ? IoctlName : "IOCTL",
+                       IoControlCode,
+                       Status,
+                       Irp->IoStatus.Information);
+        }
+        else
+        {
+            DbgPrintEx(DPFLTR_DEFAULT_ID,
+                       NT_SUCCESS(Status) ? DPFLTR_TRACE_LEVEL : DPFLTR_WARNING_LEVEL,
+                       "RamdiskWorkerThread: completed major 0x%lx -> 0x%lx info=%lu\n",
+                       IoStackLocation->MajorFunction,
+                       Status,
+                       Irp->IoStatus.Information);
         }
 
         /* Complete the I/O */
         IoReleaseRemoveLock(&DeviceExtension->RemoveLock, Irp);
         Irp->IoStatus.Status = Status;
-        Irp->IoStatus.Information = 0;
+        if (!NT_SUCCESS(Status))
+        {
+            Irp->IoStatus.Information = 0;
+        }
         IoCompleteRequest(Irp, IO_DISK_INCREMENT);
         return;
     }
@@ -943,31 +3048,24 @@ RamdiskReadWriteReal(IN PIRP Irp,
     PVOID CurrentBase, SystemVa, BaseAddress;
     PIO_STACK_LOCATION IoStackLocation;
     LARGE_INTEGER CurrentOffset;
-    ULONG BytesRead, BytesLeft, CopyLength;
+    ULONG TransferLength;
+    ULONG BytesRead, BytesLeft, CopyLength, MapSpan, BufferLength;
     PVOID Source, Destination;
     NTSTATUS Status;
+    ULONGLONG DiskLength;
+    ULONGLONG RequestOffset;
+    BOOLEAN Truncated = FALSE;
+    NTSTATUS TerminalStatus = STATUS_SUCCESS;
 
-    /* Get the MDL and check if it's mapped */
+    /* Get the MDL and map it into system space */
     Mdl = Irp->MdlAddress;
-    if (Mdl->MdlFlags & (MDL_MAPPED_TO_SYSTEM_VA | MDL_SOURCE_IS_NONPAGED_POOL))
+    if (!Mdl)
     {
-        /* Use the mapped address */
-        SystemVa = Mdl->MappedSystemVa;
+        return STATUS_INVALID_PARAMETER;
     }
-    else
-    {
-        /* Map it ourselves */
-        SystemVa = MmMapLockedPagesSpecifyCache(Mdl,
-                                                0,
-                                                MmCached,
-                                                NULL,
-                                                0,
-                                                NormalPagePriority);
-    }
-
-    /* Make sure we were able to map it */
-    CurrentBase = SystemVa;
+    SystemVa = MmGetSystemAddressForMdlSafe(Mdl, NormalPagePriority);
     if (!SystemVa) return STATUS_INSUFFICIENT_RESOURCES;
+    CurrentBase = SystemVa;
 
     /* Initialize default */
     Irp->IoStatus.Information = 0;
@@ -975,59 +3073,189 @@ RamdiskReadWriteReal(IN PIRP Irp,
     /* Get the I/O Stack Location and capture the data */
     IoStackLocation = IoGetCurrentIrpStackLocation(Irp);
     CurrentOffset = IoStackLocation->Parameters.Read.ByteOffset;
-    BytesLeft = IoStackLocation->Parameters.Read.Length;
+    TransferLength = IoStackLocation->Parameters.Read.Length;
+    BytesLeft = TransferLength;
+
+    /* Add the MBR partition offset so filesystem I/O lands on the
+     * partition data (BPB at LBA 0 of the partition) rather than
+     * the raw disk MBR. */
+    if (DeviceExtension->HiddenSectors > 0 && DeviceExtension->BytesPerSector > 0)
+    {
+        ULONGLONG PartitionOffset = (ULONGLONG)DeviceExtension->HiddenSectors * DeviceExtension->BytesPerSector;
+        CurrentOffset.QuadPart += PartitionOffset;
+    }
+    if (IoStackLocation->MajorFunction == IRP_MJ_WRITE &&
+        (DeviceExtension->DiskOptions.Readonly || DeviceExtension->DiskOptions.ExportAsCd))
+    {
+        return STATUS_MEDIA_WRITE_PROTECTED;
+    }
+
+    if (DeviceExtension->DiskType != RAMDISK_BOOT_DISK)
+    {
+        /* TODO: implement backing store for non-boot RAM disks */
+        return STATUS_NOT_SUPPORTED;
+    }
+
+    if (DeviceExtension->BytesPerSector == 0)
+    {
+        return STATUS_INVALID_DEVICE_STATE;
+    }
+
+    /* Validate sector alignment */
+    if ((CurrentOffset.QuadPart % DeviceExtension->BytesPerSector) ||
+        (TransferLength % DeviceExtension->BytesPerSector))
+    {
+        DPRINT1("RamdiskReadWriteReal: Unaligned I/O - offset=%I64x, length=%lu, sector=%lu\n",
+                CurrentOffset.QuadPart, TransferLength, DeviceExtension->BytesPerSector);
+        return STATUS_INVALID_PARAMETER;
+    }
+
+    BufferLength = MmGetMdlByteCount(Mdl);
+    if (BytesLeft > BufferLength)
+    {
+        DPRINT1("RamdiskReadWriteReal: truncating transfer len=%lu to MDL=%lu\n",
+                BytesLeft, BufferLength);
+        BytesLeft = BufferLength;
+        TransferLength = BufferLength;
+    }
+
     if (!BytesLeft) return STATUS_INVALID_PARAMETER;
 
+    if (CurrentOffset.QuadPart < 0)
+    {
+        return STATUS_INVALID_PARAMETER;
+    }
+
+    DiskLength = DeviceExtension->DiskLength.QuadPart;
+    RequestOffset = (ULONGLONG)CurrentOffset.QuadPart;
+
+    if (RequestOffset >= DiskLength)
+    {
+        return (IoStackLocation->MajorFunction == IRP_MJ_READ) ? STATUS_END_OF_FILE : STATUS_DISK_FULL;
+    }
+
+    if ((ULONGLONG)BytesLeft > (DiskLength - RequestOffset))
+    {
+        ULONGLONG BytesAvailable = DiskLength - RequestOffset;
+
+        if (BytesAvailable > (ULONGLONG)ULONG_MAX)
+        {
+            BytesLeft = ULONG_MAX;
+        }
+        else
+        {
+            BytesLeft = (ULONG)BytesAvailable;
+        }
+
+        Truncated = TRUE;
+        TerminalStatus = (IoStackLocation->MajorFunction == IRP_MJ_READ) ? STATUS_END_OF_FILE : STATUS_DISK_FULL;
+
+#if DBG
+        DbgPrintEx(DPFLTR_DEFAULT_ID,
+                   DPFLTR_WARNING_LEVEL,
+                   "RamdiskReadWriteReal: trimming request len=%lu to=%lu at offset=%I64u (disk=%I64u)\n",
+                   TransferLength,
+                   BytesLeft,
+                   RequestOffset,
+                   DiskLength);
+#endif
+
+        if (BytesLeft == 0)
+        {
+            return TerminalStatus;
+        }
+    }
+
     /* Do the copy loop */
-    while (TRUE)
+    while (BytesLeft > 0)
     {
         /* Map the pages */
         BaseAddress = RamdiskMapPages(DeviceExtension,
                                       CurrentOffset,
                                       BytesLeft,
-                                      &BytesRead);
-        if (!BaseAddress) return STATUS_INSUFFICIENT_RESOURCES;
+                                      &BytesRead,
+                                      &MapSpan);
+        if (!BaseAddress)
+        {
+            Status = STATUS_INSUFFICIENT_RESOURCES;
+            break;
+        }
 
-        /* Update our lengths */
-        Irp->IoStatus.Information += BytesRead;
         CopyLength = BytesRead;
+        if (CopyLength > BytesLeft)
+        {
+            CopyLength = BytesLeft;
+        }
+        Status = STATUS_SUCCESS;
+
+        /* MapSpan==0 means the mapping returned a shared zero-fill page
+         * (BootZeroPage) for an invalid PFN. Reads return zeroes; writes
+         * must be skipped to avoid corrupting the shared page. */
+        if (MapSpan == 0 && IoStackLocation->MajorFunction == IRP_MJ_WRITE)
+        {
+            RamdiskUnmapPages(DeviceExtension, BaseAddress, CurrentOffset, MapSpan);
+            Irp->IoStatus.Information += CopyLength;
+            BytesLeft -= CopyLength;
+            CurrentOffset.QuadPart += CopyLength;
+            CurrentBase = (PVOID)((ULONG_PTR)CurrentBase + CopyLength);
+            continue;
+        }
 
         /* Check if this was a read or write */
-        Status = STATUS_SUCCESS;
         if (IoStackLocation->MajorFunction == IRP_MJ_READ)
         {
-            /* Set our copy parameters */
             Destination = CurrentBase;
             Source = BaseAddress;
-            goto DoCopy;
+            RtlCopyMemory(Destination, Source, CopyLength);
         }
         else if (IoStackLocation->MajorFunction == IRP_MJ_WRITE)
         {
-            /* Set our copy parameters */
             Destination = BaseAddress;
             Source = CurrentBase;
-DoCopy:
-            /* Copy the data */
             RtlCopyMemory(Destination, Source, CopyLength);
+
         }
         else
         {
-            /* Prepare us for failure */
-            BytesLeft = CopyLength;
             Status = STATUS_INVALID_PARAMETER;
         }
 
         /* Unmap the pages */
-        RamdiskUnmapPages(DeviceExtension, BaseAddress, CurrentOffset, BytesRead);
+        RamdiskUnmapPages(DeviceExtension, BaseAddress, CurrentOffset, MapSpan);
+
+        if (!NT_SUCCESS(Status))
+        {
+            break;
+        }
 
         /* Update offset and bytes left */
-        BytesLeft -= BytesRead;
-        CurrentOffset.QuadPart += BytesRead;
-        CurrentBase = (PVOID)((ULONG_PTR)CurrentBase + BytesRead);
-
-        /* Check if we are done */
-        if (!BytesLeft) return Status;
+        Irp->IoStatus.Information += CopyLength;
+        BytesLeft -= CopyLength;
+        CurrentOffset.QuadPart += CopyLength;
+        CurrentBase = (PVOID)((ULONG_PTR)CurrentBase + CopyLength);
     }
+
+    if (!NT_SUCCESS(Status))
+    {
+        if (Irp->IoStatus.Information == 0)
+        {
+            return Status;
+        }
+
+        Status = STATUS_SUCCESS;
+    }
+
+    if (Truncated)
+    {
+        if (IoStackLocation->MajorFunction == IRP_MJ_READ)
+        {
+            return (Irp->IoStatus.Information > 0) ? STATUS_SUCCESS : STATUS_END_OF_FILE;
+        }
+
+        return TerminalStatus;
+    }
+
+    return Status;
 }
 
 NTSTATUS
@@ -1035,9 +3263,35 @@ NTAPI
 RamdiskOpenClose(IN PDEVICE_OBJECT DeviceObject,
                  IN PIRP Irp)
 {
+    PRAMDISK_DRIVE_EXTENSION DeviceExtension;
+    NTSTATUS Status;
+
+    /* Get the device extension */
+    DeviceExtension = DeviceObject->DeviceExtension;
+
+    /* Acquire the remove lock if this is a drive */
+    if (DeviceExtension->Type == RamdiskDrive)
+    {
+        Status = IoAcquireRemoveLock(&DeviceExtension->RemoveLock, Irp);
+        if (!NT_SUCCESS(Status))
+        {
+            /* Fail the IRP */
+            Irp->IoStatus.Status = Status;
+            IoCompleteRequest(Irp, IO_NO_INCREMENT);
+            return Status;
+        }
+    }
+
     /* Complete the IRP */
-    Irp->IoStatus.Information = 1;
+    Irp->IoStatus.Information = 0;  /* Conventionally return 0 for create/close */
     Irp->IoStatus.Status = STATUS_SUCCESS;
+
+    /* Release the remove lock if this is a drive before completing */
+    if (DeviceExtension->Type == RamdiskDrive)
+    {
+        IoReleaseRemoveLock(&DeviceExtension->RemoveLock, Irp);
+    }
+
     IoCompleteRequest(Irp, IO_NO_INCREMENT);
     return STATUS_SUCCESS;
 }
@@ -1118,6 +3372,9 @@ RamdiskDeviceControl(IN PDEVICE_OBJECT DeviceObject,
     ULONG Information;
     PCDROM_TOC Toc;
     PDISK_GEOMETRY DiskGeometry;
+    ULONG IoControlCode;
+    PCSTR IoctlName;
+    PCSTR DeviceTypeName;
 
     /* Grab the remove lock */
     Status = IoAcquireRemoveLock(&DeviceExtension->RemoveLock, Irp);
@@ -1134,14 +3391,37 @@ RamdiskDeviceControl(IN PDEVICE_OBJECT DeviceObject,
     Status = STATUS_INVALID_DEVICE_REQUEST;
     Information = 0;
 
+    IoControlCode = IoStackLocation->Parameters.DeviceIoControl.IoControlCode;
+    IoctlName = RamdiskGetIoctlName(IoControlCode);
+    DeviceTypeName = (DeviceExtension->Type == RamdiskBus) ? "Bus" : "Drive";
+    ULONG NormalizedIoctl = IOCTL_NORMALIZE_ACCESS(IoControlCode);
+
+    if (IoctlName)
+    {
+        DPRINT("RamdiskDeviceControl[%s]: request %s (0x%lx) in=%lu out=%lu\n",
+               DeviceTypeName,
+               IoctlName,
+               IoControlCode,
+               IoStackLocation->Parameters.DeviceIoControl.InputBufferLength,
+               IoStackLocation->Parameters.DeviceIoControl.OutputBufferLength);
+    }
+    else
+    {
+        DPRINT("RamdiskDeviceControl[%s]: request 0x%lx in=%lu out=%lu\n",
+               DeviceTypeName,
+               IoControlCode,
+               IoStackLocation->Parameters.DeviceIoControl.InputBufferLength,
+               IoStackLocation->Parameters.DeviceIoControl.OutputBufferLength);
+    }
+
     /* Check if this is an bus device or the drive */
     if (DeviceExtension->Type == RamdiskBus)
     {
         /* Check what the request is */
-        switch (IoStackLocation->Parameters.DeviceIoControl.IoControlCode)
+        switch (NormalizedIoctl)
         {
             /* Request to create a ramdisk */
-            case FSCTL_CREATE_RAM_DISK:
+            case IOCTL_NORMALIZE_ACCESS(FSCTL_CREATE_RAM_DISK):
             {
                 /* Do it */
                 Status = RamdiskCreateRamdisk(DeviceObject, Irp, TRUE);
@@ -1152,30 +3432,34 @@ RamdiskDeviceControl(IN PDEVICE_OBJECT DeviceObject,
             default:
             {
                 /* We don't handle anything else yet */
-                UNIMPLEMENTED_DBGBREAK("FSCTL: 0x%lx is UNSUPPORTED!\n",
-                                       IoStackLocation->Parameters.DeviceIoControl.IoControlCode);
+                DbgPrintEx(DPFLTR_DEFAULT_ID,
+                           DPFLTR_WARNING_LEVEL,
+                           "RamdiskDeviceControl[%s]: unsupported FSCTL 0x%lx\n",
+                           DeviceTypeName,
+                           IoControlCode);
+                Status = STATUS_INVALID_DEVICE_REQUEST;
+                goto CompleteRequest;
             }
         }
     }
     else
     {
         /* Check what the request is */
-        switch (IoStackLocation->Parameters.DeviceIoControl.IoControlCode)
+        switch (NormalizedIoctl)
         {
-            case IOCTL_DISK_CHECK_VERIFY:
-            case IOCTL_STORAGE_CHECK_VERIFY:
-            case IOCTL_STORAGE_CHECK_VERIFY2:
-            case IOCTL_CDROM_CHECK_VERIFY:
+            case IOCTL_NORMALIZE_ACCESS(IOCTL_STORAGE_CHECK_VERIFY):
+            case IOCTL_NORMALIZE_ACCESS(IOCTL_DISK_CHECK_VERIFY):
+            case IOCTL_NORMALIZE_ACCESS(IOCTL_CDROM_CHECK_VERIFY):
             {
                 /* Just pretend it's OK, don't do more */
                 Status = STATUS_SUCCESS;
                 break;
             }
 
-            case IOCTL_STORAGE_GET_MEDIA_TYPES:
-            case IOCTL_DISK_GET_MEDIA_TYPES:
-            case IOCTL_DISK_GET_DRIVE_GEOMETRY:
-            case IOCTL_CDROM_GET_DRIVE_GEOMETRY:
+            case IOCTL_NORMALIZE_ACCESS(IOCTL_STORAGE_GET_MEDIA_TYPES):
+            case IOCTL_NORMALIZE_ACCESS(IOCTL_DISK_GET_MEDIA_TYPES):
+            case IOCTL_NORMALIZE_ACCESS(IOCTL_DISK_GET_DRIVE_GEOMETRY):
+            case IOCTL_NORMALIZE_ACCESS(IOCTL_CDROM_GET_DRIVE_GEOMETRY):
             {
                 /* Validate the length */
                 if (IoStackLocation->Parameters.DeviceIoControl.
@@ -1192,8 +3476,9 @@ RamdiskDeviceControl(IN PDEVICE_OBJECT DeviceObject,
                 DiskGeometry->BytesPerSector = DriveExtension->BytesPerSector;
                 DiskGeometry->SectorsPerTrack = DriveExtension->SectorsPerTrack;
                 DiskGeometry->TracksPerCylinder = DriveExtension->NumberOfHeads;
-                DiskGeometry->MediaType = DriveExtension->DiskOptions.Fixed ?
-                                          FixedMedia : RemovableMedia;
+                DiskGeometry->MediaType = DriveExtension->DiskOptions.ExportAsCd ?
+                                          RemovableMedia :
+                                          (DriveExtension->DiskOptions.Fixed ? FixedMedia : RemovableMedia);
 
                 /* We are done */
                 Status = STATUS_SUCCESS;
@@ -1201,7 +3486,34 @@ RamdiskDeviceControl(IN PDEVICE_OBJECT DeviceObject,
                 break;
             }
 
-            case IOCTL_CDROM_READ_TOC:
+            case IOCTL_NORMALIZE_ACCESS(IOCTL_DISK_GET_DRIVE_GEOMETRY_EX):
+            {
+                PDISK_GEOMETRY_EX GeometryEx;
+
+                if (IoStackLocation->Parameters.DeviceIoControl.OutputBufferLength < sizeof(DISK_GEOMETRY_EX))
+                {
+                    Status = STATUS_BUFFER_TOO_SMALL;
+                    Information = sizeof(DISK_GEOMETRY_EX);
+                    break;
+                }
+
+                GeometryEx = Irp->AssociatedIrp.SystemBuffer;
+                RtlZeroMemory(GeometryEx, sizeof(DISK_GEOMETRY_EX));
+                GeometryEx->Geometry.Cylinders.QuadPart = DriveExtension->Cylinders;
+                GeometryEx->Geometry.BytesPerSector = DriveExtension->BytesPerSector;
+                GeometryEx->Geometry.SectorsPerTrack = DriveExtension->SectorsPerTrack;
+                GeometryEx->Geometry.TracksPerCylinder = DriveExtension->NumberOfHeads;
+                GeometryEx->Geometry.MediaType = DriveExtension->DiskOptions.ExportAsCd ?
+                                                   RemovableMedia :
+                                                   (DriveExtension->DiskOptions.Fixed ? FixedMedia : RemovableMedia);
+                GeometryEx->DiskSize = RamdiskQueryLogicalVolumeLength(DriveExtension);
+
+                Status = STATUS_SUCCESS;
+                Information = sizeof(DISK_GEOMETRY_EX);
+                break;
+            }
+
+            case IOCTL_NORMALIZE_ACCESS(IOCTL_CDROM_READ_TOC):
             {
                 /* Validate the length */
                 if (IoStackLocation->Parameters.DeviceIoControl.
@@ -1209,6 +3521,7 @@ RamdiskDeviceControl(IN PDEVICE_OBJECT DeviceObject,
                 {
                     /* Invalid length */
                     Status = STATUS_BUFFER_TOO_SMALL;
+                    Information = RAMDISK_TOC_SIZE;
                     break;
                 }
 
@@ -1231,13 +3544,13 @@ RamdiskDeviceControl(IN PDEVICE_OBJECT DeviceObject,
                 break;
             }
 
-            case IOCTL_DISK_SET_PARTITION_INFO:
+            case IOCTL_NORMALIZE_ACCESS(IOCTL_DISK_SET_PARTITION_INFO):
             {
                 Status = RamdiskSetPartitionInfo(Irp, DriveExtension);
                 break;
             }
 
-            case IOCTL_DISK_GET_PARTITION_INFO:
+            case IOCTL_NORMALIZE_ACCESS(IOCTL_DISK_GET_PARTITION_INFO):
             {
                 /* Validate the length */
                 if (IoStackLocation->Parameters.DeviceIoControl.
@@ -1245,6 +3558,7 @@ RamdiskDeviceControl(IN PDEVICE_OBJECT DeviceObject,
                 {
                     /* Invalid length */
                     Status = STATUS_BUFFER_TOO_SMALL;
+                    Information = sizeof(PARTITION_INFORMATION);
                     break;
                 }
 
@@ -1265,7 +3579,21 @@ RamdiskDeviceControl(IN PDEVICE_OBJECT DeviceObject,
                 break;
             }
 
-            case IOCTL_DISK_GET_LENGTH_INFO:
+            case IOCTL_NORMALIZE_ACCESS(IOCTL_DISK_GET_PARTITION_INFO_EX):
+            {
+                if (DriveExtension->DiskType > RAMDISK_MEMORY_MAPPED_DISK)
+                {
+                    Status = RamdiskGetPartitionInfoEx(Irp, DriveExtension);
+                    Information = Irp->IoStatus.Information;
+                }
+                else
+                {
+                    goto CallWorker;
+                }
+                break;
+            }
+
+            case IOCTL_NORMALIZE_ACCESS(IOCTL_DISK_GET_LENGTH_INFO):
             {
                 PGET_LENGTH_INFORMATION LengthInformation = Irp->AssociatedIrp.SystemBuffer;
 
@@ -1274,18 +3602,94 @@ RamdiskDeviceControl(IN PDEVICE_OBJECT DeviceObject,
                 {
                     /* Invalid length */
                     Status = STATUS_BUFFER_TOO_SMALL;
+                    Information = sizeof(GET_LENGTH_INFORMATION);
                     break;
                 }
 
                 /* Fill it out */
-                LengthInformation->Length = DriveExtension->DiskLength;
+                LengthInformation->Length = RamdiskQueryLogicalVolumeLength(DriveExtension);
 
                 /* We are done */
                 Status = STATUS_SUCCESS;
                 Information = sizeof(GET_LENGTH_INFORMATION);
                 break;
             }
-            case IOCTL_VOLUME_GET_GPT_ATTRIBUTES:
+
+            case IOCTL_NORMALIZE_ACCESS(IOCTL_DISK_GET_DRIVE_LAYOUT):
+            {
+                ULONG RequiredLength;
+                PDRIVE_LAYOUT_INFORMATION LayoutInformation;
+
+                RequiredLength = FIELD_OFFSET(DRIVE_LAYOUT_INFORMATION, PartitionEntry) + sizeof(PARTITION_INFORMATION);
+                if (IoStackLocation->Parameters.DeviceIoControl.OutputBufferLength < RequiredLength)
+                {
+                    Status = STATUS_BUFFER_OVERFLOW;
+                    Information = RequiredLength;
+                    break;
+                }
+
+                LayoutInformation = Irp->AssociatedIrp.SystemBuffer;
+                RtlZeroMemory(LayoutInformation, RequiredLength);
+                LayoutInformation->PartitionCount = 1;
+                Status = RamdiskBuildPartitionInfo(DriveExtension, &LayoutInformation->PartitionEntry[0]);
+                if (!NT_SUCCESS(Status))
+                {
+                    Information = 0;
+                    break;
+                }
+
+                Information = RequiredLength;
+                Status = STATUS_SUCCESS;
+                break;
+            }
+
+            case IOCTL_NORMALIZE_ACCESS(IOCTL_DISK_GET_DRIVE_LAYOUT_EX):
+            {
+                ULONG RequiredLength;
+                PDRIVE_LAYOUT_INFORMATION_EX LayoutInformation;
+                PARTITION_INFORMATION_EX PartitionEntry;
+                ULONG Signature;
+
+                RequiredLength = FIELD_OFFSET(DRIVE_LAYOUT_INFORMATION_EX, PartitionEntry) + sizeof(PARTITION_INFORMATION_EX);
+                if (IoStackLocation->Parameters.DeviceIoControl.OutputBufferLength < RequiredLength)
+                {
+                    Status = STATUS_BUFFER_OVERFLOW;
+                    Information = RequiredLength;
+                    break;
+                }
+
+                Status = RamdiskBuildPartitionInfoEx(DriveExtension, &PartitionEntry);
+                if (!NT_SUCCESS(Status))
+                {
+                    Information = 0;
+                    break;
+                }
+
+                LayoutInformation = Irp->AssociatedIrp.SystemBuffer;
+                RtlZeroMemory(LayoutInformation, RequiredLength);
+                LayoutInformation->PartitionStyle = PARTITION_STYLE_MBR;
+                LayoutInformation->PartitionCount = 1;
+                Signature = DriveExtension->DiskGuid.Data1;
+                if (Signature == 0)
+                {
+                    Signature = 'ROSD'; /* Provide a stable non-zero fallback */
+                }
+                LayoutInformation->Mbr.Signature = Signature;
+                LayoutInformation->PartitionEntry[0] = PartitionEntry;
+
+                Information = RequiredLength;
+                Status = STATUS_SUCCESS;
+                break;
+            }
+
+            case IOCTL_NORMALIZE_ACCESS(IOCTL_DISK_IS_WRITABLE):
+            {
+                Status = DriveExtension->DiskOptions.Readonly ? STATUS_MEDIA_WRITE_PROTECTED : STATUS_SUCCESS;
+                Information = 0;
+                break;
+            }
+
+            case IOCTL_NORMALIZE_ACCESS(IOCTL_VOLUME_GET_GPT_ATTRIBUTES):
             {
                 PVOLUME_GET_GPT_ATTRIBUTES_INFORMATION GptInformation;
 
@@ -1294,20 +3698,13 @@ RamdiskDeviceControl(IN PDEVICE_OBJECT DeviceObject,
                 {
                     /* Invalid length */
                     Status = STATUS_BUFFER_TOO_SMALL;
+                    Information = sizeof(VOLUME_GET_GPT_ATTRIBUTES_INFORMATION);
                     break;
                 }
 
                 /* Fill it out */
                 GptInformation = Irp->AssociatedIrp.SystemBuffer;
-                GptInformation->GptAttributes = 0;
-
-                /* Translate the Attributes */
-                if (DriveExtension->DiskOptions.Readonly)
-                    GptInformation->GptAttributes |= GPT_BASIC_DATA_ATTRIBUTE_READ_ONLY;
-                if (DriveExtension->DiskOptions.Hidden)
-                    GptInformation->GptAttributes |= GPT_BASIC_DATA_ATTRIBUTE_HIDDEN;
-                if (DriveExtension->DiskOptions.NoDriveLetter)
-                    GptInformation->GptAttributes |= GPT_BASIC_DATA_ATTRIBUTE_NO_DRIVE_LETTER;
+                GptInformation->GptAttributes = RamdiskQueryGptAttributes(DriveExtension);
 
                 /* We are done */
                 Status = STATUS_SUCCESS;
@@ -1315,26 +3712,754 @@ RamdiskDeviceControl(IN PDEVICE_OBJECT DeviceObject,
                 break;
             }
 
-            case IOCTL_DISK_GET_DRIVE_LAYOUT:
-            case IOCTL_DISK_IS_WRITABLE:
-            case IOCTL_SCSI_MINIPORT:
-            case IOCTL_STORAGE_QUERY_PROPERTY:
-            case IOCTL_MOUNTDEV_QUERY_UNIQUE_ID:
-            case IOCTL_MOUNTDEV_QUERY_STABLE_GUID:
-            case IOCTL_VOLUME_GET_VOLUME_DISK_EXTENTS:
-            case IOCTL_VOLUME_SET_GPT_ATTRIBUTES:
-            case IOCTL_VOLUME_OFFLINE:
+            case IOCTL_NORMALIZE_ACCESS(IOCTL_STORAGE_GET_DEVICE_NUMBER):
             {
-                UNIMPLEMENTED_DBGBREAK("IOCTL: 0x%lx is UNIMPLEMENTED!\n",
-                                       IoStackLocation->Parameters.DeviceIoControl.IoControlCode);
+                PSTORAGE_DEVICE_NUMBER DeviceNumber;
+
+                if (IoStackLocation->Parameters.DeviceIoControl.OutputBufferLength < sizeof(STORAGE_DEVICE_NUMBER))
+                {
+                    Status = STATUS_BUFFER_TOO_SMALL;
+                    Information = sizeof(STORAGE_DEVICE_NUMBER);
+                    break;
+                }
+
+                DeviceNumber = Irp->AssociatedIrp.SystemBuffer;
+                DeviceNumber->DeviceType = DriveExtension->DiskOptions.ExportAsCd ? FILE_DEVICE_CD_ROM : FILE_DEVICE_DISK;
+                DeviceNumber->DeviceNumber = DriveExtension->DiskNumber;
+                DeviceNumber->PartitionNumber = 0;
+                Status = STATUS_SUCCESS;
+                Information = sizeof(STORAGE_DEVICE_NUMBER);
+                break;
+            }
+
+            case IOCTL_NORMALIZE_ACCESS(IOCTL_STORAGE_GET_HOTPLUG_INFO):
+            {
+                PSTORAGE_HOTPLUG_INFO HotplugInfo;
+
+                if (IoStackLocation->Parameters.DeviceIoControl.OutputBufferLength < sizeof(STORAGE_HOTPLUG_INFO))
+                {
+                    Status = STATUS_BUFFER_TOO_SMALL;
+                    Information = sizeof(STORAGE_HOTPLUG_INFO);
+                    break;
+                }
+
+                HotplugInfo = Irp->AssociatedIrp.SystemBuffer;
+                RtlZeroMemory(HotplugInfo, sizeof(*HotplugInfo));
+                HotplugInfo->Size = sizeof(STORAGE_HOTPLUG_INFO);
+                HotplugInfo->MediaRemovable = !DriveExtension->DiskOptions.Fixed;
+                HotplugInfo->MediaHotplug = FALSE;
+                HotplugInfo->DeviceHotplug = FALSE;
+                HotplugInfo->WriteCacheEnableOverride = 0;
+                Status = STATUS_SUCCESS;
+                Information = sizeof(STORAGE_HOTPLUG_INFO);
+                break;
+            }
+
+            case IOCTL_NORMALIZE_ACCESS(IOCTL_STORAGE_QUERY_PROPERTY):
+            {
+                Status = RamdiskHandleStorageQueryProperty(DriveExtension, Irp, IoStackLocation, &Information);
+                break;
+            }
+
+            case IOCTL_NORMALIZE_ACCESS(IOCTL_VOLUME_GET_VOLUME_DISK_EXTENTS):
+            {
+                PVOLUME_DISK_EXTENTS Extents;
+                ULONG RequiredLength;
+                LARGE_INTEGER StartingOffset;
+                LARGE_INTEGER PartitionLength;
+
+                RequiredLength = FIELD_OFFSET(VOLUME_DISK_EXTENTS, Extents) + sizeof(DISK_EXTENT);
+                if (IoStackLocation->Parameters.DeviceIoControl.OutputBufferLength < RequiredLength)
+                {
+                    Status = STATUS_BUFFER_TOO_SMALL;
+                    Information = RequiredLength;
+                    break;
+                }
+
+                Extents = Irp->AssociatedIrp.SystemBuffer;
+                RamdiskQueryLogicalVolumeExtent(DriveExtension,
+                                                &StartingOffset,
+                                                &PartitionLength);
+                Extents->NumberOfDiskExtents = 1;
+                Extents->Extents[0].DiskNumber = DriveExtension->DiskNumber;
+                Extents->Extents[0].StartingOffset = StartingOffset;
+                Extents->Extents[0].ExtentLength = PartitionLength;
+                Status = STATUS_SUCCESS;
+                Information = RequiredLength;
+                break;
+            }
+
+            case IOCTL_NORMALIZE_ACCESS(IOCTL_VOLUME_QUERY_FAILOVER_SET):
+            {
+                PVOLUME_FAILOVER_SET FailoverSet;
+                ULONG RequiredLength;
+
+                RequiredLength = FIELD_OFFSET(VOLUME_FAILOVER_SET, DiskNumbers) + sizeof(ULONG);
+                if (IoStackLocation->Parameters.DeviceIoControl.OutputBufferLength < RequiredLength)
+                {
+                    Status = STATUS_BUFFER_TOO_SMALL;
+                    Information = RequiredLength;
+                    break;
+                }
+
+                FailoverSet = Irp->AssociatedIrp.SystemBuffer;
+                FailoverSet->NumberOfDisks = 1;
+                FailoverSet->DiskNumbers[0] = DriveExtension->DiskNumber;
+                Status = STATUS_SUCCESS;
+                Information = RequiredLength;
+                break;
+            }
+
+            case IOCTL_NORMALIZE_ACCESS(IOCTL_VOLUME_IS_OFFLINE):
+            {
+                if (IoStackLocation->Parameters.DeviceIoControl.OutputBufferLength < sizeof(BOOLEAN))
+                {
+                    Status = STATUS_BUFFER_TOO_SMALL;
+                    Information = sizeof(BOOLEAN);
+                    break;
+                }
+
+                *(PBOOLEAN)Irp->AssociatedIrp.SystemBuffer = DriveExtension->VolumeOffline;
+                Status = STATUS_SUCCESS;
+                Information = sizeof(BOOLEAN);
+                break;
+            }
+
+            case IOCTL_NORMALIZE_ACCESS(IOCTL_VOLUME_IS_IO_CAPABLE):
+            {
+                if (IoStackLocation->Parameters.DeviceIoControl.OutputBufferLength < sizeof(BOOLEAN))
+                {
+                    Status = STATUS_BUFFER_TOO_SMALL;
+                    Information = sizeof(BOOLEAN);
+                    break;
+                }
+
+                *(PBOOLEAN)Irp->AssociatedIrp.SystemBuffer = TRUE;
+                Status = STATUS_SUCCESS;
+                Information = sizeof(BOOLEAN);
+                break;
+            }
+
+            case IOCTL_NORMALIZE_ACCESS(IOCTL_VOLUME_QUERY_VOLUME_NUMBER):
+            {
+                PVOLUME_NUMBER VolumeNumber;
+
+                if (IoStackLocation->Parameters.DeviceIoControl.OutputBufferLength < sizeof(VOLUME_NUMBER))
+                {
+                    Status = STATUS_BUFFER_TOO_SMALL;
+                    Information = sizeof(VOLUME_NUMBER);
+                    break;
+                }
+
+                VolumeNumber = Irp->AssociatedIrp.SystemBuffer;
+                VolumeNumber->VolumeNumber = DriveExtension->DiskNumber;
+                RtlZeroMemory(VolumeNumber->VolumeManagerName, sizeof(VolumeNumber->VolumeManagerName));
+                {
+                    static const WCHAR ManagerName[] = L"RAMDISK";
+                    SIZE_T CopyChars = RTL_NUMBER_OF(ManagerName) - 1;
+                    SIZE_T MaxChars = RTL_NUMBER_OF(VolumeNumber->VolumeManagerName) - 1;
+                    if (CopyChars > MaxChars)
+                    {
+                        CopyChars = MaxChars;
+                    }
+                    RtlCopyMemory(VolumeNumber->VolumeManagerName,
+                                  ManagerName,
+                                  CopyChars * sizeof(WCHAR));
+                    VolumeNumber->VolumeManagerName[CopyChars] = L'\0';
+                }
+                Status = STATUS_SUCCESS;
+                Information = sizeof(VOLUME_NUMBER);
+                break;
+            }
+
+            case IOCTL_NORMALIZE_ACCESS(IOCTL_VOLUME_LOGICAL_TO_PHYSICAL):
+            {
+                PVOLUME_LOGICAL_OFFSET LogicalOffset;
+                PVOLUME_PHYSICAL_OFFSETS PhysicalOffsets;
+                ULONG RequiredLength;
+
+                if (IoStackLocation->Parameters.DeviceIoControl.InputBufferLength < sizeof(VOLUME_LOGICAL_OFFSET))
+                {
+                    Status = STATUS_INVALID_PARAMETER;
+                    break;
+                }
+
+                RequiredLength = FIELD_OFFSET(VOLUME_PHYSICAL_OFFSETS, PhysicalOffset) + sizeof(VOLUME_PHYSICAL_OFFSET);
+                if (IoStackLocation->Parameters.DeviceIoControl.OutputBufferLength < RequiredLength)
+                {
+                    Status = STATUS_BUFFER_TOO_SMALL;
+                    Information = RequiredLength;
+                    break;
+                }
+
+                LogicalOffset = Irp->AssociatedIrp.SystemBuffer;
+                PhysicalOffsets = Irp->AssociatedIrp.SystemBuffer;
+                LONGLONG LogicalPosition = LogicalOffset->LogicalOffset;
+                PhysicalOffsets->NumberOfPhysicalOffsets = 1;
+                PhysicalOffsets->PhysicalOffset[0].DiskNumber = DriveExtension->DiskNumber;
+                PhysicalOffsets->PhysicalOffset[0].Offset = LogicalPosition;
+                Status = STATUS_SUCCESS;
+                Information = RequiredLength;
+                break;
+            }
+
+            case IOCTL_NORMALIZE_ACCESS(IOCTL_VOLUME_PHYSICAL_TO_LOGICAL):
+            {
+                PVOLUME_PHYSICAL_OFFSET PhysicalOffset;
+                PVOLUME_LOGICAL_OFFSET LogicalOffset;
+
+                if (IoStackLocation->Parameters.DeviceIoControl.InputBufferLength < sizeof(VOLUME_PHYSICAL_OFFSET) ||
+                    IoStackLocation->Parameters.DeviceIoControl.OutputBufferLength < sizeof(VOLUME_LOGICAL_OFFSET))
+                {
+                    Status = STATUS_INVALID_PARAMETER;
+                    break;
+                }
+
+                PhysicalOffset = Irp->AssociatedIrp.SystemBuffer;
+                LogicalOffset = Irp->AssociatedIrp.SystemBuffer;
+
+                if (PhysicalOffset->DiskNumber != DriveExtension->DiskNumber)
+                {
+                    Status = STATUS_INVALID_PARAMETER;
+                    break;
+                }
+
+                LogicalOffset->LogicalOffset = PhysicalOffset->Offset;
+                Status = STATUS_SUCCESS;
+                Information = sizeof(VOLUME_LOGICAL_OFFSET);
+                break;
+            }
+
+            case IOCTL_NORMALIZE_ACCESS(IOCTL_VOLUME_IS_PARTITION):
+            {
+                if (IoStackLocation->Parameters.DeviceIoControl.OutputBufferLength < sizeof(BOOLEAN))
+                {
+                    Status = STATUS_BUFFER_TOO_SMALL;
+                    Information = sizeof(BOOLEAN);
+                    break;
+                }
+
+                *(PBOOLEAN)Irp->AssociatedIrp.SystemBuffer = TRUE;
+                Status = STATUS_SUCCESS;
+                Information = sizeof(BOOLEAN);
+                break;
+            }
+
+            case IOCTL_NORMALIZE_ACCESS(IOCTL_MOUNTDEV_QUERY_DEVICE_NAME):
+            {
+                PMOUNTDEV_NAME Name;
+                USHORT NameLength;
+                ULONG RequiredLength;
+                ULONG OutputLength;
+                ULONG CopyLength;
+
+                if (DriveExtension->DeviceObjectName.Buffer == NULL)
+                {
+                    Status = STATUS_INVALID_DEVICE_STATE;
+                    Information = 0;
+                    break;
+                }
+
+                DbgPrintEx(DPFLTR_DEFAULT_ID,
+                           DPFLTR_TRACE_LEVEL,
+                           "RamdiskDeviceControl: IOCTL_MOUNTDEV_QUERY_DEVICE_NAME -> %wZ\n",
+                           &DriveExtension->DeviceObjectName);
+
+                NameLength = DriveExtension->DeviceObjectName.Length;
+                RequiredLength = FIELD_OFFSET(MOUNTDEV_NAME, Name) + NameLength;
+                OutputLength = IoStackLocation->Parameters.DeviceIoControl.OutputBufferLength;
+
+                if (OutputLength < sizeof(USHORT))
+                {
+                    Status = STATUS_BUFFER_TOO_SMALL;
+                    Information = sizeof(USHORT);
+                RamdiskLogBufferedReply("IOCTL_MOUNTDEV_QUERY_DEVICE_NAME",
+                                         Irp->AssociatedIrp.SystemBuffer,
+                                         OutputLength,
+                                         FIELD_OFFSET(MOUNTDEV_NAME, Name),
+                                         NameLength,
+                                         RequiredLength,
+                                         0,
+                                         Status);
+                    break;
+                }
+
+                Name = Irp->AssociatedIrp.SystemBuffer;
+                Name->NameLength = NameLength;
+                CopyLength = 0;
+
+                if (OutputLength > FIELD_OFFSET(MOUNTDEV_NAME, Name))
+                {
+                    CopyLength = OutputLength - FIELD_OFFSET(MOUNTDEV_NAME, Name);
+                    if (CopyLength > NameLength) CopyLength = NameLength;
+                    if (CopyLength)
+                    {
+#if DBG
+                        ASSERT(FIELD_OFFSET(MOUNTDEV_NAME, Name) + CopyLength <= OutputLength);
+#endif
+                        RtlCopyMemory(Name->Name,
+                                      DriveExtension->DeviceObjectName.Buffer,
+                                      CopyLength);
+                    }
+                }
+
+                if (OutputLength >= RequiredLength)
+                {
+                    Status = STATUS_SUCCESS;
+                    Information = RequiredLength;
+                }
+                else
+                {
+                    Status = STATUS_BUFFER_OVERFLOW;
+                    Information = FIELD_OFFSET(MOUNTDEV_NAME, Name) + CopyLength;
+                }
+                RamdiskLogBufferedReply("IOCTL_MOUNTDEV_QUERY_DEVICE_NAME",
+                                         Irp->AssociatedIrp.SystemBuffer,
+                                         OutputLength,
+                                         FIELD_OFFSET(MOUNTDEV_NAME, Name),
+                                         NameLength,
+                                         RequiredLength,
+                                         CopyLength,
+                                         Status);
+                break;
+            }
+
+            case IOCTL_NORMALIZE_ACCESS(IOCTL_MOUNTDEV_QUERY_DEVICE_RELATIONS):
+            {
+                PMOUNTDEV_DEVICE_RELATIONS Relations;
+                ULONG RequiredLength;
+
+                if (DriveExtension->PhysicalDeviceObject == NULL)
+                {
+                    Status = STATUS_INVALID_DEVICE_STATE;
+                    Information = 0;
+                    break;
+                }
+
+                RequiredLength = FIELD_OFFSET(MOUNTDEV_DEVICE_RELATIONS, Objects) + sizeof(PDEVICE_OBJECT);
+                if (IoStackLocation->Parameters.DeviceIoControl.OutputBufferLength < RequiredLength)
+                {
+                    Status = STATUS_BUFFER_TOO_SMALL;
+                    Information = RequiredLength;
+                    break;
+                }
+
+                Relations = Irp->AssociatedIrp.SystemBuffer;
+                Relations->NumberOfObjects = 1;
+                ObReferenceObject(DriveExtension->PhysicalDeviceObject);
+                Relations->Objects[0] = DriveExtension->PhysicalDeviceObject;
+                Status = STATUS_SUCCESS;
+                Information = RequiredLength;
+                break;
+            }
+
+            case IOCTL_NORMALIZE_ACCESS(IOCTL_MOUNTDEV_QUERY_UNIQUE_ID):
+            {
+                PMOUNTDEV_UNIQUE_ID UniqueId;
+                USHORT IdLength;
+                ULONG RequiredLength;
+                ULONG OutputLength;
+                ULONG CopyLength;
+
+                IdLength = sizeof(GUID);
+                RequiredLength = FIELD_OFFSET(MOUNTDEV_UNIQUE_ID, UniqueId) + IdLength;
+                OutputLength = IoStackLocation->Parameters.DeviceIoControl.OutputBufferLength;
+
+                DbgPrintEx(DPFLTR_DEFAULT_ID,
+                           DPFLTR_TRACE_LEVEL,
+                           "RamdiskDeviceControl: IOCTL_MOUNTDEV_QUERY_UNIQUE_ID\n");
+
+                if (OutputLength < sizeof(USHORT))
+                {
+                    Status = STATUS_BUFFER_TOO_SMALL;
+                    Information = sizeof(USHORT);
+                RamdiskLogBufferedReply("IOCTL_MOUNTDEV_QUERY_UNIQUE_ID",
+                                         Irp->AssociatedIrp.SystemBuffer,
+                                         OutputLength,
+                                         FIELD_OFFSET(MOUNTDEV_UNIQUE_ID, UniqueId),
+                                         IdLength,
+                                         RequiredLength,
+                                         0,
+                                         Status);
+                    break;
+                }
+
+                UniqueId = Irp->AssociatedIrp.SystemBuffer;
+                UniqueId->UniqueIdLength = IdLength;
+                CopyLength = 0;
+
+                if (OutputLength > FIELD_OFFSET(MOUNTDEV_UNIQUE_ID, UniqueId))
+                {
+                    CopyLength = OutputLength - FIELD_OFFSET(MOUNTDEV_UNIQUE_ID, UniqueId);
+                    if (CopyLength > IdLength) CopyLength = IdLength;
+                    if (CopyLength)
+                    {
+#if DBG
+                        ASSERT(FIELD_OFFSET(MOUNTDEV_UNIQUE_ID, UniqueId) + CopyLength <= OutputLength);
+#endif
+                        RtlCopyMemory(UniqueId->UniqueId, &DriveExtension->DiskGuid, CopyLength);
+                    }
+                }
+
+                if (OutputLength >= RequiredLength)
+                {
+                    Status = STATUS_SUCCESS;
+                    Information = RequiredLength;
+                }
+                else
+                {
+                    Status = STATUS_BUFFER_OVERFLOW;
+                    Information = FIELD_OFFSET(MOUNTDEV_UNIQUE_ID, UniqueId) + CopyLength;
+                }
+                RamdiskLogBufferedReply("IOCTL_MOUNTDEV_QUERY_UNIQUE_ID",
+                                         Irp->AssociatedIrp.SystemBuffer,
+                                         OutputLength,
+                                         FIELD_OFFSET(MOUNTDEV_UNIQUE_ID, UniqueId),
+                                         IdLength,
+                                         RequiredLength,
+                                         CopyLength,
+                                         Status);
+                break;
+            }
+
+            case IOCTL_NORMALIZE_ACCESS(IOCTL_MOUNTDEV_QUERY_STABLE_GUID):
+            {
+                PMOUNTDEV_STABLE_GUID StableGuid;
+                ULONG OutputLength = IoStackLocation->Parameters.DeviceIoControl.OutputBufferLength;
+
+                Information = sizeof(MOUNTDEV_STABLE_GUID);
+
+                if (OutputLength < sizeof(MOUNTDEV_STABLE_GUID))
+                {
+                    Status = STATUS_BUFFER_TOO_SMALL;
+                RamdiskLogBufferedReply("IOCTL_MOUNTDEV_QUERY_STABLE_GUID",
+                                         Irp->AssociatedIrp.SystemBuffer,
+                                         OutputLength,
+                                         0,
+                                         sizeof(MOUNTDEV_STABLE_GUID),
+                                         sizeof(MOUNTDEV_STABLE_GUID),
+                                         0,
+                                         Status);
+                    break;
+                }
+
+                DbgPrintEx(DPFLTR_DEFAULT_ID,
+                           DPFLTR_TRACE_LEVEL,
+                           "RamdiskDeviceControl: IOCTL_MOUNTDEV_QUERY_STABLE_GUID\n");
+
+                StableGuid = Irp->AssociatedIrp.SystemBuffer;
+#if DBG
+                ASSERT(OutputLength >= sizeof(MOUNTDEV_STABLE_GUID));
+#endif
+                StableGuid->StableGuid = DriveExtension->DiskGuid;
+                Status = STATUS_SUCCESS;
+                RamdiskLogBufferedReply("IOCTL_MOUNTDEV_QUERY_STABLE_GUID",
+                                         Irp->AssociatedIrp.SystemBuffer,
+                                         OutputLength,
+                                         0,
+                                         sizeof(MOUNTDEV_STABLE_GUID),
+                                         sizeof(MOUNTDEV_STABLE_GUID),
+                                         sizeof(MOUNTDEV_STABLE_GUID),
+                                         Status);
+                break;
+            }
+
+            case IOCTL_NORMALIZE_ACCESS(IOCTL_MOUNTDEV_QUERY_SUGGESTED_LINK_NAME):
+            {
+                PMOUNTDEV_SUGGESTED_LINK_NAME LinkName;
+                WCHAR SuggestedName[16];
+                WCHAR Letter;
+                USHORT NameLength;
+                ULONG RequiredLength;
+                ULONG OutputLength;
+                ULONG CopyLength;
+                ULONG HeaderLength;
+
+                Letter = DriveExtension->DriveLetter ? DriveExtension->DriveLetter : L'X';
+                _snwprintf(SuggestedName,
+                           RTL_NUMBER_OF(SuggestedName),
+                           L"\\DosDevices\\%wc:",
+                           Letter);
+                NameLength = (USHORT)(wcslen(SuggestedName) * sizeof(WCHAR));
+                RequiredLength = FIELD_OFFSET(MOUNTDEV_SUGGESTED_LINK_NAME, Name) + NameLength;
+                OutputLength = IoStackLocation->Parameters.DeviceIoControl.OutputBufferLength;
+                HeaderLength = FIELD_OFFSET(MOUNTDEV_SUGGESTED_LINK_NAME, Name);
+
+                DbgPrintEx(DPFLTR_DEFAULT_ID,
+                           DPFLTR_TRACE_LEVEL,
+                           "RamdiskDeviceControl: IOCTL_MOUNTDEV_QUERY_SUGGESTED_LINK_NAME -> %S\n",
+                           SuggestedName);
+
+                if (OutputLength < HeaderLength)
+                {
+                    Status = STATUS_BUFFER_TOO_SMALL;
+                    Information = HeaderLength;
+                RamdiskLogBufferedReply("IOCTL_MOUNTDEV_QUERY_SUGGESTED_LINK_NAME",
+                                         Irp->AssociatedIrp.SystemBuffer,
+                                         OutputLength,
+                                         HeaderLength,
+                                         NameLength,
+                                         RequiredLength,
+                                         0,
+                                         Status);
+                    break;
+                }
+
+                LinkName = Irp->AssociatedIrp.SystemBuffer;
+                RtlZeroMemory(LinkName, OutputLength);
+                LinkName->UseOnlyIfThereAreNoOtherLinks = FALSE;
+                LinkName->NameLength = NameLength;
+                CopyLength = 0;
+
+                if (OutputLength > HeaderLength)
+                {
+                    CopyLength = OutputLength - HeaderLength;
+                    if (CopyLength > NameLength) CopyLength = NameLength;
+                    CopyLength &= ~1UL;
+                    if (CopyLength)
+                    {
+#if DBG
+                        ASSERT(HeaderLength + CopyLength <= OutputLength);
+#endif
+                        RtlCopyMemory(LinkName->Name, SuggestedName, CopyLength);
+                    }
+                }
+
+                if (OutputLength >= RequiredLength)
+                {
+                    LinkName->Name[NameLength / sizeof(WCHAR)] = UNICODE_NULL;
+                    Status = STATUS_SUCCESS;
+                    Information = RequiredLength;
+                }
+                else
+                {
+                    if (OutputLength > HeaderLength)
+                    {
+                        ULONG DestChars = (OutputLength - HeaderLength) / sizeof(WCHAR);
+                        if (DestChars > 0)
+                        {
+                            LinkName->Name[DestChars - 1] = UNICODE_NULL;
+                        }
+                    }
+                    Status = STATUS_BUFFER_OVERFLOW;
+                    Information = HeaderLength + CopyLength;
+                }
+                RamdiskLogBufferedReply("IOCTL_MOUNTDEV_QUERY_SUGGESTED_LINK_NAME",
+                                         Irp->AssociatedIrp.SystemBuffer,
+                                         OutputLength,
+                                         FIELD_OFFSET(MOUNTDEV_SUGGESTED_LINK_NAME, Name),
+                                         NameLength,
+                                         RequiredLength,
+                                         CopyLength,
+                                         Status);
+                break;
+            }
+
+            case IOCTL_NORMALIZE_ACCESS(IOCTL_SCSI_PASS_THROUGH):
+            case IOCTL_NORMALIZE_ACCESS(IOCTL_SCSI_PASS_THROUGH_DIRECT):
+            case IOCTL_NORMALIZE_ACCESS(IOCTL_SCSI_GET_ADDRESS):
+            {
+                Status = STATUS_INVALID_DEVICE_REQUEST;
+                Information = 0;
+                break;
+            }
+
+            case IOCTL_NORMALIZE_ACCESS(IOCTL_MOUNTDEV_LINK_CREATED):
+            {
+                InterlockedIncrement((volatile LONG*)&DriveExtension->MountdevLinkCount);
+                RamdiskPersistDiskState(DriveExtension);
+                Status = STATUS_SUCCESS;
+                Information = 0;
+                break;
+            }
+
+            case IOCTL_NORMALIZE_ACCESS(IOCTL_MOUNTDEV_LINK_DELETED):
+            {
+                if (DriveExtension->MountdevLinkCount > 0)
+                {
+                    InterlockedDecrement((volatile LONG*)&DriveExtension->MountdevLinkCount);
+                }
+
+                RamdiskPersistDiskState(DriveExtension);
+                Status = STATUS_SUCCESS;
+                Information = 0;
+                break;
+            }
+
+            case IOCTL_NORMALIZE_ACCESS(IOCTL_MOUNTDEV_UNIQUE_ID_CHANGE_NOTIFY):
+            {
+                PMOUNTDEV_UNIQUE_ID InputUniqueId;
+                GUID InputGuid;
+                ULONG OutputLength = IoStackLocation->Parameters.DeviceIoControl.OutputBufferLength;
+                ULONG InputLength = IoStackLocation->Parameters.DeviceIoControl.InputBufferLength;
+
+                Information = 0;
+
+                /* Validate the input unique ID buffer */
+                if (InputLength < FIELD_OFFSET(MOUNTDEV_UNIQUE_ID, UniqueId) + sizeof(GUID))
+                {
+                    Status = STATUS_INVALID_PARAMETER;
+                    break;
+                }
+
+                InputUniqueId = Irp->AssociatedIrp.SystemBuffer;
+                if (InputUniqueId->UniqueIdLength != sizeof(GUID) ||
+                    InputLength < FIELD_OFFSET(MOUNTDEV_UNIQUE_ID, UniqueId) + InputUniqueId->UniqueIdLength)
+                {
+                    Status = STATUS_NOT_SUPPORTED;
+                    break;
+                }
+
+                RtlCopyMemory(&InputGuid, InputUniqueId->UniqueId, sizeof(GUID));
+
+                /* If the caller's idea of the ID differs from ours, complete immediately
+                   with old/new. Otherwise, pend this IRP until an ID change occurs. */
+                if (RtlCompareMemory(&InputGuid, &DriveExtension->DiskGuid, sizeof(GUID)) != sizeof(GUID))
+                {
+                    PMOUNTDEV_UNIQUE_ID_CHANGE_NOTIFY_OUTPUT Output;
+                    ULONG RequiredLength = sizeof(MOUNTDEV_UNIQUE_ID_CHANGE_NOTIFY_OUTPUT) + (2 * sizeof(GUID));
+                    ULONG Offset;
+
+                    if (OutputLength < RequiredLength)
+                    {
+                        Status = STATUS_BUFFER_TOO_SMALL;
+                        Information = RequiredLength;
+                        break;
+                    }
+
+                    Output = Irp->AssociatedIrp.SystemBuffer;
+                    RtlZeroMemory(Output, RequiredLength);
+                    Output->Size = sizeof(*Output);
+                    Offset = sizeof(*Output);
+                    Output->OldUniqueIdOffset = (USHORT)Offset;
+                    Output->OldUniqueIdLength = sizeof(GUID);
+                    RtlCopyMemory((PUCHAR)Output + Offset, &InputGuid, sizeof(GUID));
+                    Offset += sizeof(GUID);
+                    Output->NewUniqueIdOffset = (USHORT)Offset;
+                    Output->NewUniqueIdLength = sizeof(GUID);
+                    RtlCopyMemory((PUCHAR)Output + Offset, &DriveExtension->DiskGuid, sizeof(GUID));
+                    Offset += sizeof(GUID);
+
+                    Status = STATUS_SUCCESS;
+                    Information = Offset;
+                    break;
+                }
+                else
+                {
+                    KIRQL oldIrql;
+
+                    /* Only one pending notify at a time; cancel any previous */
+                    IoAcquireCancelSpinLock(&oldIrql);
+                    if (DriveExtension->PendingUniqueIdNotifyIrp)
+                    {
+                        PIRP OldIrp = DriveExtension->PendingUniqueIdNotifyIrp;
+                        DriveExtension->PendingUniqueIdNotifyIrp = NULL;
+                        if (IoSetCancelRoutine(OldIrp, NULL) != NULL)
+                        {
+                            IoReleaseCancelSpinLock(oldIrql);
+                            /* Release remove lock and complete old */
+                            IoReleaseRemoveLock(&DriveExtension->RemoveLock, OldIrp);
+                            OldIrp->IoStatus.Status = STATUS_CANCELLED;
+                            OldIrp->IoStatus.Information = 0;
+                            IoCompleteRequest(OldIrp, IO_NO_INCREMENT);
+                            IoAcquireCancelSpinLock(&oldIrql);
+                        }
+                        /* else: cancel routine is running; let it complete OldIrp */
+                    }
+
+                    /* Pend this IRP */
+                    IoMarkIrpPending(Irp);
+                    if (IoSetCancelRoutine(Irp, RamdiskCancelUniqueIdNotify) == NULL && Irp->Cancel)
+                    {
+                        /* Already canceled */
+                        IoReleaseCancelSpinLock(oldIrql);
+                        Status = STATUS_CANCELLED;
+                        Information = 0;
+                        break;
+                    }
+
+                    DriveExtension->PendingUniqueIdNotifyIrp = Irp;
+                    IoReleaseCancelSpinLock(oldIrql);
+
+                    Status = STATUS_PENDING;
+                    Information = 0;
+                    goto CompleteRequest; /* Will skip completion because PENDING */
+                }
+            }
+
+            case IOCTL_NORMALIZE_ACCESS(IOCTL_VOLUME_OFFLINE):
+            {
+                DriveExtension->VolumeOffline = TRUE;
+                RamdiskPersistDiskState(DriveExtension);
+                Status = STATUS_SUCCESS;
+                Information = 0;
+                break;
+            }
+
+            case IOCTL_NORMALIZE_ACCESS(IOCTL_VOLUME_ONLINE):
+            {
+                DriveExtension->VolumeOffline = FALSE;
+                RamdiskPersistDiskState(DriveExtension);
+                Status = STATUS_SUCCESS;
+                Information = 0;
+                break;
+            }
+
+            case IOCTL_NORMALIZE_ACCESS(IOCTL_SCSI_MINIPORT):
+            {
+                DbgPrintEx(DPFLTR_DEFAULT_ID,
+                           DPFLTR_WARNING_LEVEL,
+                           "RamdiskDeviceControl[%s]: IOCTL 0x%lx not yet supported\n",
+                           DeviceTypeName,
+                           IoControlCode);
+                Status = STATUS_NOT_SUPPORTED;
+                break;
+            }
+
+            case IOCTL_NORMALIZE_ACCESS(IOCTL_VOLUME_SET_GPT_ATTRIBUTES):
+            {
+                PVOLUME_SET_GPT_ATTRIBUTES_INFORMATION SetInformation;
+                ULONGLONG SupportedMask;
+
+                if (IoStackLocation->Parameters.DeviceIoControl.InputBufferLength < sizeof(VOLUME_SET_GPT_ATTRIBUTES_INFORMATION))
+                {
+                    Status = STATUS_BUFFER_TOO_SMALL;
+                    break;
+                }
+
+                SetInformation = Irp->AssociatedIrp.SystemBuffer;
+
+                SupportedMask = GPT_BASIC_DATA_ATTRIBUTE_READ_ONLY |
+                                GPT_BASIC_DATA_ATTRIBUTE_HIDDEN |
+                                GPT_BASIC_DATA_ATTRIBUTE_NO_DRIVE_LETTER;
+
+                if ((SetInformation->GptAttributes & ~SupportedMask) != 0)
+                {
+                    Status = STATUS_INVALID_PARAMETER;
+                    break;
+                }
+
+                RamdiskApplyGptAttributes(DriveExtension, SetInformation->GptAttributes);
+
+                if (!SetInformation->RevertOnClose)
+                {
+                    RamdiskPersistDiskState(DriveExtension);
+                }
+
+                Status = STATUS_SUCCESS;
+                Information = 0;
                 break;
             }
 
             default:
             {
                 /* Drive code not emulated */
-                DPRINT1("IOCTL: 0x%lx is UNSUPPORTED!\n",
-                        IoStackLocation->Parameters.DeviceIoControl.IoControlCode);
+                DbgPrintEx(DPFLTR_DEFAULT_ID,
+                           DPFLTR_WARNING_LEVEL,
+                           "RamdiskDeviceControl[%s]: unknown IOCTL 0x%lx\n",
+                           DeviceTypeName,
+                           IoControlCode);
+                Status = STATUS_INVALID_DEVICE_REQUEST;
                 break;
             }
         }
@@ -1345,13 +4470,18 @@ RamdiskDeviceControl(IN PDEVICE_OBJECT DeviceObject,
 
     /* Queue the request to our worker thread */
 CallWorker:
+    DbgPrintEx(DPFLTR_DEFAULT_ID,
+               DPFLTR_INFO_LEVEL,
+               "RamdiskDeviceControl[%s]: queueing IOCTL 0x%lx\n",
+               DeviceTypeName,
+               IoControlCode);
     Status = SendIrpToThread(DeviceObject, Irp);
 
 CompleteRequest:
-    /* Release the lock */
-    IoReleaseRemoveLock(&DeviceExtension->RemoveLock, Irp);
     if (Status != STATUS_PENDING)
     {
+        /* Release the lock before completing non-pended IRPs */
+        IoReleaseRemoveLock(&DeviceExtension->RemoveLock, Irp);
         /* Complete the request */
         Irp->IoStatus.Status = Status;
         Irp->IoStatus.Information = Information;
@@ -1373,7 +4503,6 @@ RamdiskQueryDeviceRelations(IN DEVICE_RELATION_TYPE Type,
     PDEVICE_RELATIONS DeviceRelations, OurDeviceRelations;
     ULONG Count, DiskCount, FinalCount;
     PLIST_ENTRY ListHead, NextEntry;
-    PDEVICE_OBJECT* DriveDeviceObject;
     RAMDISK_DEVICE_STATE State;
 
     /* Get the device extension and check if this is a drive */
@@ -1486,11 +4615,11 @@ RamdiskQueryDeviceRelations(IN DEVICE_RELATION_TYPE Type,
     /* Now loop our drives again */
     ListHead = &DeviceExtension->DiskList;
     NextEntry = ListHead->Flink;
+    /* Initialize output index */
+    ULONG OutputIndex = Count;
+
     while (NextEntry != ListHead)
     {
-        /* Go to the end of the list */
-        DriveDeviceObject = &OurDeviceRelations->Objects[Count];
-
         /* Get the drive state */
         DriveExtension = CONTAINING_RECORD(NextEntry,
                                            RAMDISK_DRIVE_EXTENSION,
@@ -1509,11 +4638,9 @@ RamdiskQueryDeviceRelations(IN DEVICE_RELATION_TYPE Type,
         }
         else
         {
-            /* First time it's enumerated, reference the device object */
-            ObReferenceObject(DriveExtension->DeviceObject);
-
-            /* Save the object pointer and move on */
-            *DriveDeviceObject++ = DriveExtension->PhysicalDeviceObject;
+            /* First time it's enumerated, reference and return the PDO */
+            ObReferenceObject(DriveExtension->PhysicalDeviceObject);
+            OurDeviceRelations->Objects[OutputIndex++] = DriveExtension->PhysicalDeviceObject;
         }
 
         if (DriveExtension->State < RamdiskStateBusRemoved) DiskCount++;
@@ -1521,6 +4648,9 @@ RamdiskQueryDeviceRelations(IN DEVICE_RELATION_TYPE Type,
         /* Move to the next one */
         NextEntry = NextEntry->Flink;
     }
+
+    /* Update the final count with the actual number of objects added */
+    OurDeviceRelations->Count = OutputIndex;
 
     /* Release the lock */
     ExReleaseFastMutex(&DeviceExtension->DiskListLock);
@@ -1544,8 +4674,115 @@ NTAPI
 RamdiskDeleteDiskDevice(IN PDEVICE_OBJECT DeviceObject,
                         IN PIRP Irp)
 {
-    UNIMPLEMENTED_DBGBREAK();
-    return STATUS_SUCCESS;
+    PRAMDISK_DRIVE_EXTENSION DriveExtension;
+    PRAMDISK_BUS_EXTENSION BusExtension = NULL;
+    NTSTATUS Status = STATUS_SUCCESS;
+    PVOID RemoveContext;
+
+    /* Validate the device object */
+    if (DeviceObject == NULL)
+    {
+        return STATUS_INVALID_PARAMETER;
+    }
+
+    DriveExtension = DeviceObject->DeviceExtension;
+    if (DriveExtension->Type != RamdiskDrive)
+    {
+        return STATUS_INVALID_DEVICE_REQUEST;
+    }
+
+    if (DriveExtension->DeviceObject && DriveExtension->DeviceObject->DeviceExtension)
+    {
+        BusExtension = DriveExtension->DeviceObject->DeviceExtension;
+    }
+
+    /* Remove from the bus list */
+    if (BusExtension)
+    {
+        KeEnterCriticalRegion();
+        ExAcquireFastMutex(&BusExtension->DiskListLock);
+        if (!IsListEmpty(&DriveExtension->DiskList))
+        {
+            RemoveEntryList(&DriveExtension->DiskList);
+            InitializeListHead(&DriveExtension->DiskList);
+        }
+        ExReleaseFastMutex(&BusExtension->DiskListLock);
+        KeLeaveCriticalRegion();
+    }
+
+    /* Disable any published interfaces */
+    if (DriveExtension->DriveDeviceName.Buffer)
+    {
+        NTSTATUS interfaceStatus = IoSetDeviceInterfaceState(&DriveExtension->DriveDeviceName, FALSE);
+        UNREFERENCED_PARAMETER(interfaceStatus);
+        RtlFreeUnicodeString(&DriveExtension->DriveDeviceName);
+    }
+
+    /* Drop the DOS symbolic link if one was created */
+    if (DriveExtension->SymbolicLinkName.Buffer)
+    {
+        IoDeleteSymbolicLink(&DriveExtension->SymbolicLinkName);
+        ExFreePoolWithTag(DriveExtension->SymbolicLinkName.Buffer, 'dmaR');
+        DriveExtension->SymbolicLinkName.Buffer = NULL;
+    }
+
+    /* Release the device name that backs IOCTL_MOUNTDEV_QUERY_DEVICE_NAME */
+    if (DriveExtension->DeviceObjectName.Buffer)
+    {
+        ExFreePoolWithTag(DriveExtension->DeviceObjectName.Buffer, 'dmaR');
+        DriveExtension->DeviceObjectName.Buffer = NULL;
+    }
+
+    /* Free the persistent GUID string */
+    if (DriveExtension->GuidString.Buffer)
+    {
+        RtlFreeUnicodeString(&DriveExtension->GuidString);
+    }
+
+    /* Cancel any pending unique ID notify IRP before releasing the remove lock */
+    {
+        KIRQL oldIrql;
+        IoAcquireCancelSpinLock(&oldIrql);
+        if (DriveExtension->PendingUniqueIdNotifyIrp)
+        {
+            PIRP PendingIrp = DriveExtension->PendingUniqueIdNotifyIrp;
+            DriveExtension->PendingUniqueIdNotifyIrp = NULL;
+            if (IoSetCancelRoutine(PendingIrp, NULL) != NULL)
+            {
+                IoReleaseCancelSpinLock(oldIrql);
+                IoReleaseRemoveLock(&DriveExtension->RemoveLock, PendingIrp);
+                PendingIrp->IoStatus.Status = STATUS_CANCELLED;
+                PendingIrp->IoStatus.Information = 0;
+                IoCompleteRequest(PendingIrp, IO_NO_INCREMENT);
+            }
+            else
+            {
+                /* Cancel routine will complete it */
+                IoReleaseCancelSpinLock(oldIrql);
+            }
+        }
+        else
+        {
+            IoReleaseCancelSpinLock(oldIrql);
+        }
+    }
+
+    RamdiskReleaseBootPfnTable(DriveExtension);
+
+    DriveExtension->VolumeOffline = FALSE;
+    DriveExtension->MountdevLinkCount = 0;
+    DriveExtension->State = RamdiskStateRemoved;
+
+    RamdiskPersistDiskState(DriveExtension);
+
+    /* Release the remove lock now that no more IRPs will arrive */
+    RemoveContext = Irp ? (PVOID)Irp : (PVOID)DeviceObject;
+    IoReleaseRemoveLockAndWait(&DriveExtension->RemoveLock, RemoveContext);
+
+    /* Delete the device object */
+    IoDeleteDevice(DeviceObject);
+
+    return Status;
 }
 
 NTSTATUS
@@ -1564,20 +4801,26 @@ RamdiskRemoveBusDevice(IN PDEVICE_OBJECT DeviceObject,
     KeEnterCriticalRegion();
     ExAcquireFastMutex(&DeviceExtension->DiskListLock);
 
-    /* Loop over drives */
+    /* Loop over drives -- restart from list head after each deletion.
+     * Release the list lock before calling RamdiskDeleteDiskDevice,
+     * because it also acquires DiskListLock internally. */
     ListHead = &DeviceExtension->DiskList;
-    NextEntry = ListHead->Flink;
-    while (NextEntry != ListHead)
+    while (!IsListEmpty(ListHead))
     {
+        NextEntry = ListHead->Flink;
         DriveExtension = CONTAINING_RECORD(NextEntry,
                                            RAMDISK_DRIVE_EXTENSION,
                                            DiskList);
 
-        /* Delete the disk */
+        /* Take a reference, then release the lock before deletion */
         IoAcquireRemoveLock(&DriveExtension->RemoveLock, NULL);
+        ExReleaseFastMutex(&DeviceExtension->DiskListLock);
+        KeLeaveCriticalRegion();
+
+        /* Delete the disk (acquires DiskListLock internally) */
         RamdiskDeleteDiskDevice(DriveExtension->PhysicalDeviceObject, NULL);
 
-        /* RamdiskDeleteDiskDevice releases list lock, so reacquire it */
+        /* Reacquire the lock for the next iteration */
         KeEnterCriticalRegion();
         ExAcquireFastMutex(&DeviceExtension->DiskListLock);
     }
@@ -1605,7 +4848,8 @@ RamdiskRemoveBusDevice(IN PDEVICE_OBJECT DeviceObject,
     if (DeviceExtension->DriveDeviceName.Buffer)
     {
         /* Inform it's going to be disabled and free the drive name */
-        IoSetDeviceInterfaceState(&DeviceExtension->DriveDeviceName, FALSE);
+        NTSTATUS status = IoSetDeviceInterfaceState(&DeviceExtension->DriveDeviceName, FALSE);
+        UNREFERENCED_PARAMETER(status);
         RtlFreeUnicodeString(&DeviceExtension->DriveDeviceName);
     }
 
@@ -1891,6 +5135,7 @@ RamdiskPnp(IN PDEVICE_OBJECT DeviceObject,
     DeviceExtension = DeviceObject->DeviceExtension;
     IoStackLocation = IoGetCurrentIrpStackLocation(Irp);
     Minor = IoStackLocation->MinorFunction;
+    Irp->IoStatus.Information = 0;
 
     /* Check if the bus is removed */
     if (DeviceExtension->State == RamdiskStateBusRemoved)
@@ -1917,6 +5162,9 @@ RamdiskPnp(IN PDEVICE_OBJECT DeviceObject,
         return Status;
     }
 
+    /* Default to existing status */
+    Status = Irp->IoStatus.Status;
+
     /* Query the IRP type */
     switch (Minor)
     {
@@ -1928,14 +5176,22 @@ RamdiskPnp(IN PDEVICE_OBJECT DeviceObject,
                 DEVICE_INSTALL_STATE InstallState;
                 PRAMDISK_DRIVE_EXTENSION DriveExtension = (PRAMDISK_DRIVE_EXTENSION)DeviceExtension;
 
-                /* If we already have a drive name, free it */
+                /* Free any bootstrap name (e.g. \Device\Ramdisk{GUID}) and register the interface */
                 if (DriveExtension->DriveDeviceName.Buffer)
                 {
                     ExFreePool(DriveExtension->DriveDeviceName.Buffer);
+                    RtlZeroMemory(&DriveExtension->DriveDeviceName, sizeof(DriveExtension->DriveDeviceName));
                 }
 
-                /* Register our device interface */
-                if (DriveExtension->DiskType != RAMDISK_REGISTRY_DISK)
+                if (DriveExtension->DiskType == RAMDISK_BOOT_DISK)
+                {
+                    /* Register as a standard volume so Windows apps/drivers can discover it. */
+                    Status = IoRegisterDeviceInterface(DeviceObject,
+                                                       &GUID_DEVINTERFACE_VOLUME,
+                                                       NULL,
+                                                       &DriveExtension->DriveDeviceName);
+                }
+                else if (DriveExtension->DiskType != RAMDISK_REGISTRY_DISK)
                 {
                     Status = IoRegisterDeviceInterface(DeviceObject,
                                                        &GUID_DEVINTERFACE_VOLUME,
@@ -2011,12 +5267,54 @@ RamdiskPnp(IN PDEVICE_OBJECT DeviceObject,
         }
 
         case IRP_MN_QUERY_STOP_DEVICE:
-        case IRP_MN_CANCEL_STOP_DEVICE:
-        case IRP_MN_STOP_DEVICE:
         case IRP_MN_QUERY_REMOVE_DEVICE:
+        {
+            /* Flag that we are preparing for a pause */
+            if (DeviceExtension->State == RamdiskStateStarted)
+            {
+                DeviceExtension->State = RamdiskStatePaused;
+            }
+
+            Status = STATUS_SUCCESS;
+            Irp->IoStatus.Status = Status;
+            break;
+        }
+
+        case IRP_MN_CANCEL_STOP_DEVICE:
         case IRP_MN_CANCEL_REMOVE_DEVICE:
         {
-            UNIMPLEMENTED_DBGBREAK("PnP IRP: %lx\n", Minor);
+            /* Undo any pending pause */
+            DeviceExtension->State = RamdiskStateStarted;
+
+            Status = STATUS_SUCCESS;
+            Irp->IoStatus.Status = Status;
+            break;
+        }
+
+        case IRP_MN_STOP_DEVICE:
+        {
+            /* Disable the interface while we are stopped */
+            if (DeviceExtension->Type == RamdiskDrive)
+            {
+                PRAMDISK_DRIVE_EXTENSION DriveExtension = (PRAMDISK_DRIVE_EXTENSION)DeviceExtension;
+
+                if (!DriveExtension->DiskOptions.NoDriveLetter &&
+                    DriveExtension->DriveDeviceName.Buffer != NULL)
+                {
+                    NTSTATUS setStatus = IoSetDeviceInterfaceState(&DriveExtension->DriveDeviceName, FALSE);
+                    UNREFERENCED_PARAMETER(setStatus);
+                }
+            }
+            else if (DeviceExtension->DriveDeviceName.Buffer != NULL)
+            {
+                NTSTATUS setStatus = IoSetDeviceInterfaceState(&DeviceExtension->DriveDeviceName, FALSE);
+                UNREFERENCED_PARAMETER(setStatus);
+            }
+
+            DeviceExtension->State = RamdiskStateStopped;
+
+            Status = STATUS_SUCCESS;
+            Irp->IoStatus.Status = Status;
             break;
         }
 
@@ -2045,15 +5343,39 @@ RamdiskPnp(IN PDEVICE_OBJECT DeviceObject,
         }
 
         case IRP_MN_SURPRISE_REMOVAL:
-            UNIMPLEMENTED_DBGBREAK("PnP IRP: %lx\n", Minor);
+        {
+            if (DeviceExtension->Type == RamdiskDrive)
+            {
+                PRAMDISK_DRIVE_EXTENSION DriveExtension = (PRAMDISK_DRIVE_EXTENSION)DeviceExtension;
+
+                if (!DriveExtension->DiskOptions.NoDriveLetter &&
+                    DriveExtension->DriveDeviceName.Buffer != NULL)
+                {
+                    NTSTATUS setStatus = IoSetDeviceInterfaceState(&DriveExtension->DriveDeviceName, FALSE);
+                    UNREFERENCED_PARAMETER(setStatus);
+                }
+            }
+            else if (DeviceExtension->DriveDeviceName.Buffer != NULL)
+            {
+                NTSTATUS setStatus = IoSetDeviceInterfaceState(&DeviceExtension->DriveDeviceName, FALSE);
+                UNREFERENCED_PARAMETER(setStatus);
+            }
+
+            DeviceExtension->State = RamdiskStateRemoved;
+
+            Status = STATUS_SUCCESS;
+            Irp->IoStatus.Status = Status;
             break;
+        }
 
         case IRP_MN_QUERY_ID:
         {
             /* Are we a drive? */
             if (DeviceExtension->Type == RamdiskDrive)
             {
+                /* Handler completes the IRP internally */
                 Status = RamdiskQueryId((PRAMDISK_DRIVE_EXTENSION)DeviceExtension, Irp);
+                goto ReleaseAndReturn;
             }
             break;
         }
@@ -2063,21 +5385,28 @@ RamdiskPnp(IN PDEVICE_OBJECT DeviceObject,
             /* Are we a drive? */
             if (DeviceExtension->Type == RamdiskDrive)
             {
+                /* Handler completes the IRP internally */
                 Status = RamdiskQueryBusInformation(DeviceObject, Irp);
+                goto ReleaseAndReturn;
             }
             break;
         }
 
         case IRP_MN_EJECT:
-            UNIMPLEMENTED_DBGBREAK("PnP IRP: %lx\n", Minor);
+        {
+            Status = STATUS_NOT_SUPPORTED;
+            Irp->IoStatus.Status = Status;
             break;
+        }
 
         case IRP_MN_QUERY_DEVICE_TEXT:
         {
             /* Are we a drive? */
             if (DeviceExtension->Type == RamdiskDrive)
             {
+                /* Handler completes the IRP internally */
                 Status = RamdiskQueryDeviceText((PRAMDISK_DRIVE_EXTENSION)DeviceExtension, Irp);
+                goto ReleaseAndReturn;
             }
             break;
         }
@@ -2105,14 +5434,44 @@ RamdiskPnp(IN PDEVICE_OBJECT DeviceObject,
 
         case IRP_MN_QUERY_RESOURCES:
         case IRP_MN_QUERY_RESOURCE_REQUIREMENTS:
+        case IRP_MN_FILTER_RESOURCE_REQUIREMENTS:
         {
             /* Complete immediately without touching it */
             IoCompleteRequest(Irp, IO_NO_INCREMENT);
             goto ReleaseAndReturn;
         }
 
+        case IRP_MN_QUERY_PNP_DEVICE_STATE:
+        {
+            Irp->IoStatus.Information = 0;
+            Status = STATUS_SUCCESS;
+            Irp->IoStatus.Status = Status;
+            break;
+        }
+
+        case IRP_MN_DEVICE_USAGE_NOTIFICATION:
+        {
+            /* We do not need to react; just report success */
+            Status = STATUS_SUCCESS;
+            Irp->IoStatus.Status = Status;
+            break;
+        }
+
+        case IRP_MN_QUERY_INTERFACE:
+        case IRP_MN_READ_CONFIG:
+        case IRP_MN_WRITE_CONFIG:
+        case IRP_MN_SET_LOCK:
+        {
+            Status = STATUS_NOT_SUPPORTED;
+            Irp->IoStatus.Status = Status;
+            break;
+        }
+
         default:
-            DPRINT1("Illegal IRP: %lx\n", Minor);
+            if (DeviceExtension->Type != RamdiskBus)
+            {
+                DPRINT1("Illegal IRP: %lx\n", Minor);
+            }
             break;
     }
 
@@ -2140,16 +5499,17 @@ RamdiskPower(IN PDEVICE_OBJECT DeviceObject,
              IN PIRP Irp)
 {
     NTSTATUS Status;
-    PIO_STACK_LOCATION IoStackLocation;
     PRAMDISK_BUS_EXTENSION DeviceExtension;
 
     DeviceExtension = DeviceObject->DeviceExtension;
 
-    /* If we have a device extension, take extra caution with the lower driver */
-    if (DeviceExtension != NULL)
+    /* Check if this is a bus FDO or a disk PDO */
+    if (DeviceExtension != NULL && DeviceExtension->Type == RamdiskBus)
     {
+        /* FDO: allow the next power IRP to proceed before passing down */
         PoStartNextPowerIrp(Irp);
 
+        /* Bus FDO: forward to lower driver */
         /* Device has not been removed yet, so pass to the attached/lower driver */
         if (DeviceExtension->State < RamdiskStateBusRemoved)
         {
@@ -2164,46 +5524,16 @@ RamdiskPower(IN PDEVICE_OBJECT DeviceObject,
             return STATUS_DELETE_PENDING;
         }
     }
-
-    /* Get stack and deal with minor functions */
-    IoStackLocation = IoGetCurrentIrpStackLocation(Irp);
-    switch (IoStackLocation->MinorFunction)
+    else
     {
-        case IRP_MN_SET_POWER:
-        {
-            /* If setting device power state it's all fine and return success */
-            if (DevicePowerState)
-            {
-                Irp->IoStatus.Status = STATUS_SUCCESS;
-            }
-
-            /* Get appropriate status for return */
-            Status = Irp->IoStatus.Status;
-            PoStartNextPowerIrp(Irp);
-            IoCompleteRequest(Irp, IO_NO_INCREMENT);
-            break;
-        }
-
-        case IRP_MN_QUERY_POWER:
-        {
-            /* We can obviously accept all states so just return success */
-            Status = Irp->IoStatus.Status = STATUS_SUCCESS;
-            PoStartNextPowerIrp(Irp);
-            IoCompleteRequest(Irp, IO_NO_INCREMENT);
-            break;
-        }
-
-        default:
-        {
-            /* Just complete and save status for return */
-            Status = Irp->IoStatus.Status;
-            PoStartNextPowerIrp(Irp);
-            IoCompleteRequest(Irp, IO_NO_INCREMENT);
-            break;
-        }
+        /* PDO (disk device): handle power locally */
+        PoStartNextPowerIrp(Irp);
+        /* We don't need to do anything special for RAM disks - just succeed all power requests */
+        Irp->IoStatus.Status = STATUS_SUCCESS;
+        Status = STATUS_SUCCESS;
+        IoCompleteRequest(Irp, IO_NO_INCREMENT);
+        return Status;
     }
-
-    return Status;
 }
 
 NTSTATUS
@@ -2382,7 +5712,8 @@ RamdiskAddDevice(IN PDRIVER_OBJECT DriverObject,
         if (!AttachedDevice)
         {
             /* Fail */
-            IoSetDeviceInterfaceState(&DeviceExtension->BusDeviceName, 0);
+            NTSTATUS interfaceStatus = IoSetDeviceInterfaceState(&DeviceExtension->BusDeviceName, 0);
+            UNREFERENCED_PARAMETER(interfaceStatus);
             RtlFreeUnicodeString(&DeviceExtension->BusDeviceName);
             IoDeleteDevice(DeviceObject);
             return STATUS_NO_SUCH_DEVICE;
@@ -2401,7 +5732,7 @@ RamdiskAddDevice(IN PDRIVER_OBJECT DriverObject,
         }
 
         /* All done */
-        DeviceObject->Flags &= DO_DEVICE_INITIALIZING;
+        DeviceObject->Flags &= ~DO_DEVICE_INITIALIZING;
         Status = STATUS_SUCCESS;
     }
 
@@ -2418,6 +5749,9 @@ DriverEntry(IN PDRIVER_OBJECT DriverObject,
     PDEVICE_OBJECT PhysicalDeviceObject = NULL;
     NTSTATUS Status;
     DPRINT("RAM Disk Driver Initialized\n");
+    DPRINT1("RAMDISK DriverEntry: DriverObject=%p RegistryPath=%wZ\n",
+            DriverObject,
+            RegistryPath);
 
     /* Save the registry path */
     DriverRegistryPath.MaximumLength = RegistryPath->Length + sizeof(UNICODE_NULL);
@@ -2432,6 +5766,10 @@ DriverEntry(IN PDRIVER_OBJECT DriverObject,
 
     /* Query ramdisk parameters */
     QueryParameters(&DriverRegistryPath);
+
+#if DBG
+    RamdiskAssertIoctlCoverage();
+#endif
 
     /* Set device routines */
     DriverObject->MajorFunction[IRP_MJ_CREATE] = RamdiskOpenClose;

--- a/drivers/storage/class/ramdisk/ramdisk.inf
+++ b/drivers/storage/class/ramdisk/ramdisk.inf
@@ -26,6 +26,7 @@ HKR, , Icon,           0, "-5"
 [RamdiskDevice]
 %RamdiskBus.Desc% = RamdiskBus_Inst, Ramdisk, DetectedInternal\Ramdisk, Detected\Ramdisk
 %RamdiskVolume.Desc% = RamdiskVolume_Inst, Ramdisk\RamVolume
+%RamdiskRoot.Desc% = RamdiskRoot_Inst, Root\RamDisk
 
 ;----------------------------- RAMDISK BUS -----------------------------
 
@@ -52,6 +53,14 @@ ramdisk.sys
 [RamdiskVolume_Inst.NT.Services]
 AddService = , 2
 
+;----------------------------- ROOT ENUMERATED RAMDISK -----------------------------
+
+[RamdiskRoot_Inst.NT]
+CopyFiles = RamdiskBus_CopyFiles.NT
+
+[RamdiskRoot_Inst.NT.Services]
+AddService = ramdisk, 2, RamdiskBus_Service_Inst
+
 ;-------------------------------- STRINGS -------------------------------
 
 [Strings]
@@ -62,22 +71,26 @@ ReactOS = "ReactOS Project"
 RamdiskClassName = "Ramdisk"
 RamdiskBus.Desc = "RAM disk controller"
 RamdiskVolume.Desc = "RAM disk device (volume)"
+RamdiskRoot.Desc = "RAM disk boot device"
 Ramdisk.ServiceDesc = "ReactOS RAM Disk Driver"
 
 [Strings.040C]
 RamdiskClassName = "Ramdisk"
 RamdiskBus.Desc = "Controleur de disque virtuel"
 RamdiskVolume.Desc = "Disque virtuel (volume)"
+RamdiskRoot.Desc = "Disque virtuel d'amorçage"
 Ramdisk.ServiceDesc = "Pilote de disque virtuel ReactOS"
 
 [Strings.0415]
 RamdiskClassName = "Ramdisk"
 RamdiskBus.Desc = "Kontroler dysku RAM"
 RamdiskVolume.Desc = "Urządzenie dysku RAM (wolumin)"
+RamdiskRoot.Desc = "Rozruchowe urządzenie dysku RAM"
 Ramdisk.ServiceDesc = "Sterownik dysku RAM systemu ReactOS"
 
 [Strings.0419]
 RamdiskClassName = "RAM-диски"
 RamdiskBus.Desc = "Контроллер RAM-диска"
 RamdiskVolume.Desc = "Устройство RAM-диска (том)"
+RamdiskRoot.Desc = "Загрузочное устройство RAM-диска"
 Ramdisk.ServiceDesc = "Драйвер RAM-диска ReactOS"

--- a/drivers/storage/mountmgr/mountmgr.c
+++ b/drivers/storage/mountmgr/mountmgr.c
@@ -31,6 +31,7 @@
 
 /* FIXME */
 GUID MountedDevicesGuid = {0x53F5630D, 0xB6BF, 0x11D0, {0x94, 0xF2, 0x00, 0xA0, 0xC9, 0x1E, 0xFB, 0x8B}};
+static const GUID MountMgrBootRamdiskGuid = {0xD9B257FC, 0x684E, 0x4DCB, {0xAB, 0x79, 0x03, 0xCF, 0xA2, 0xF6, 0xB7, 0x50}};
 
 PDEVICE_OBJECT gdeviceObject;
 KEVENT UnloadEvent;
@@ -38,6 +39,11 @@ LONG Unloading;
 
 static const WCHAR Cunc[] = L"\\??\\C:";
 #define Cunc_LETTER_POSITION 4
+
+static
+VOID
+MountMgrLoadBootRamdiskInformation(
+    _Inout_ PDEVICE_EXTENSION DeviceExtension);
 
 /**
  * @brief
@@ -121,6 +127,161 @@ MountMgrSendSyncDeviceIoCtl(
     }
 
     return Status;
+}
+
+static
+VOID
+MountMgrLoadBootRamdiskInformation(
+    _Inout_ PDEVICE_EXTENSION DeviceExtension)
+{
+    NTSTATUS Status;
+    HANDLE DisksKey;
+    ULONG Index;
+    OBJECT_ATTRIBUTES ObjectAttributes;
+    UNICODE_STRING KeyPath;
+
+    RtlInitUnicodeString(&KeyPath,
+                         L"\\Registry\\Machine\\System\\CurrentControlSet\\Services\\Ramdisk\\Parameters\\Disks");
+    InitializeObjectAttributes(&ObjectAttributes,
+                               &KeyPath,
+                               OBJ_CASE_INSENSITIVE | OBJ_KERNEL_HANDLE,
+                               NULL,
+                               NULL);
+
+    Status = ZwOpenKey(&DisksKey, KEY_READ, &ObjectAttributes);
+    if (!NT_SUCCESS(Status))
+    {
+        return;
+    }
+
+    for (Index = 0; Index < 256 && DeviceExtension->DriveLetterData == NULL; Index++)
+    {
+        ULONG Length;
+        PKEY_BASIC_INFORMATION BasicInfo;
+
+        Status = ZwEnumerateKey(DisksKey,
+                                 Index,
+                                 KeyBasicInformation,
+                                 NULL,
+                                 0,
+                                 &Length);
+        if (Status == STATUS_NO_MORE_ENTRIES)
+        {
+            break;
+        }
+
+        if (Status != STATUS_BUFFER_OVERFLOW && Status != STATUS_BUFFER_TOO_SMALL)
+        {
+            continue;
+        }
+
+        BasicInfo = AllocatePool(Length);
+        if (!BasicInfo)
+        {
+            break;
+        }
+
+        Status = ZwEnumerateKey(DisksKey,
+                                 Index,
+                                 KeyBasicInformation,
+                                 BasicInfo,
+                                 Length,
+                                 &Length);
+        if (!NT_SUCCESS(Status))
+        {
+            FreePool(BasicInfo);
+            continue;
+        }
+
+        {
+            HANDLE DiskKey;
+            UNICODE_STRING SubName;
+            OBJECT_ATTRIBUTES SubAttributes;
+
+            if (BasicInfo->NameLength > MAXUSHORT - sizeof(WCHAR))
+            {
+                FreePool(BasicInfo);
+                continue;
+            }
+            SubName.MaximumLength = (USHORT)(BasicInfo->NameLength + sizeof(WCHAR));
+            SubName.Buffer = AllocatePool(SubName.MaximumLength);
+            if (!SubName.Buffer)
+            {
+                FreePool(BasicInfo);
+                break;
+            }
+
+            SubName.Length = (USHORT)BasicInfo->NameLength;
+            RtlCopyMemory(SubName.Buffer, BasicInfo->Name, BasicInfo->NameLength);
+            SubName.Buffer[SubName.Length / sizeof(WCHAR)] = UNICODE_NULL;
+
+            InitializeObjectAttributes(&SubAttributes,
+                                       &SubName,
+                                       OBJ_CASE_INSENSITIVE | OBJ_KERNEL_HANDLE,
+                                       DisksKey,
+                                       NULL);
+
+            Status = ZwOpenKey(&DiskKey, KEY_READ, &SubAttributes);
+
+            FreePool(SubName.Buffer);
+            FreePool(BasicInfo);
+
+            if (!NT_SUCCESS(Status))
+            {
+                continue;
+            }
+
+            {
+                ULONG ValueLength;
+                PKEY_VALUE_PARTIAL_INFORMATION ValueInfo;
+                UNICODE_STRING ValueName;
+
+                RtlInitUnicodeString(&ValueName, L"DiskGuid");
+                Status = ZwQueryValueKey(DiskKey,
+                                          &ValueName,
+                                          KeyValuePartialInformation,
+                                          NULL,
+                                          0,
+                                          &ValueLength);
+                if (Status == STATUS_BUFFER_OVERFLOW || Status == STATUS_BUFFER_TOO_SMALL)
+                {
+                    ValueInfo = AllocatePool(ValueLength);
+                    if (ValueInfo)
+                    {
+                        Status = ZwQueryValueKey(DiskKey,
+                                                  &ValueName,
+                                                  KeyValuePartialInformation,
+                                                  ValueInfo,
+                                                  ValueLength,
+                                                  &ValueLength);
+                        if (NT_SUCCESS(Status) &&
+                            ValueInfo->Type == REG_BINARY &&
+                            ValueInfo->DataLength == sizeof(GUID) &&
+                            RtlCompareMemory(ValueInfo->Data,
+                                             &MountMgrBootRamdiskGuid,
+                                             sizeof(GUID)) == sizeof(GUID))
+                        {
+                            PMOUNTDEV_UNIQUE_ID UniqueId;
+
+                            UniqueId = AllocatePool(sizeof(MOUNTDEV_UNIQUE_ID) + sizeof(GUID));
+                            if (UniqueId)
+                            {
+                                UniqueId->UniqueIdLength = sizeof(GUID);
+                                RtlCopyMemory(UniqueId->UniqueId, ValueInfo->Data, sizeof(GUID));
+                                DeviceExtension->DriveLetterData = UniqueId;
+                            }
+                        }
+
+                        FreePool(ValueInfo);
+                    }
+                }
+
+                ZwClose(DiskKey);
+            }
+        }
+    }
+
+    ZwClose(DisksKey);
 }
 
 /*
@@ -681,6 +842,7 @@ MountMgrFreeMountedDeviceInfo(IN PDEVICE_INFORMATION DeviceInformation)
     if (DeviceInformation->TargetDeviceNotificationEntry)
     {
         IoUnregisterPlugPlayNotification(DeviceInformation->TargetDeviceNotificationEntry);
+        DeviceInformation->TargetDeviceNotificationEntry = NULL;
     }
 }
 
@@ -1128,7 +1290,7 @@ MountMgrMountedDeviceArrival(IN PDEVICE_EXTENSION DeviceExtension,
             }
         }
 
-        /* And recreate the symlink to our device */
+        /* Recreate the symlink to our device */
         Status = GlobalCreateSymbolicLink(&(SymLinks[i]), &TargetDeviceName);
         if (!NT_SUCCESS(Status))
         {
@@ -1490,6 +1652,7 @@ MountMgrMountedDeviceRemoval(IN PDEVICE_EXTENSION DeviceExtension,
         if (DeviceInformation->TargetDeviceNotificationEntry)
         {
             IoUnregisterPlugPlayNotification(DeviceInformation->TargetDeviceNotificationEntry);
+            DeviceInformation->TargetDeviceNotificationEntry = NULL;
         }
 
         /*  And leave */
@@ -1766,6 +1929,30 @@ DriverEntry(IN PDRIVER_OBJECT DriverObject,
     RtlCopyUnicodeString(&(DeviceExtension->RegistryPath), RegistryPath);
 
     DeviceExtension->NoAutoMount = MountmgrReadNoAutoMount(&(DeviceExtension->RegistryPath));
+
+    /* In WinPE / LiveCD mode the kernel creates a volatile MiniNT key before
+     * boot drivers are loaded.  When present, force NoAutoMount so that only
+     * volumes with a pre-registered link (e.g. ramdisk X:) get a letter. */
+    if (!DeviceExtension->NoAutoMount)
+    {
+        UNICODE_STRING MiniNTKeyName = RTL_CONSTANT_STRING(
+            L"\\Registry\\Machine\\System\\CurrentControlSet\\Control\\MiniNT");
+        OBJECT_ATTRIBUTES MiniNTAttributes;
+        HANDLE MiniNTKeyHandle;
+
+        InitializeObjectAttributes(&MiniNTAttributes,
+                                   &MiniNTKeyName,
+                                   OBJ_CASE_INSENSITIVE | OBJ_KERNEL_HANDLE,
+                                   NULL,
+                                   NULL);
+        if (NT_SUCCESS(ZwOpenKey(&MiniNTKeyHandle, KEY_READ, &MiniNTAttributes)))
+        {
+            ZwClose(MiniNTKeyHandle);
+            DeviceExtension->NoAutoMount = TRUE;
+        }
+    }
+
+    MountMgrLoadBootRamdiskInformation(DeviceExtension);
 
     GlobalCreateSymbolicLink(&DosDevicesMount, &DeviceMount);
 

--- a/ntoskrnl/ex/init.c
+++ b/ntoskrnl/ex/init.c
@@ -1847,6 +1847,42 @@ Phase1InitializationDiscard(IN PVOID Context)
     /* Set maximum update to 75% */
     InbvSetProgressBarSubset(25, 75);
 
+    /* Create the MiniNT key before I/O init so that boot drivers
+     * (e.g. mountmgr) can detect WinPE mode during DriverEntry */
+    if (InitIsWinPEMode)
+    {
+        RtlInitUnicodeString(&KeyName,
+                             L"\\REGISTRY\\MACHINE\\SYSTEM\\CURRENTCONTROLSET"
+                             L"\\CONTROL");
+        InitializeObjectAttributes(&ObjectAttributes,
+                                   &KeyName,
+                                   OBJ_CASE_INSENSITIVE,
+                                   NULL,
+                                   NULL);
+        Status = ZwOpenKey(&KeyHandle, KEY_ALL_ACCESS, &ObjectAttributes);
+        if (NT_SUCCESS(Status))
+        {
+            RtlInitUnicodeString(&KeyName, L"MiniNT");
+            InitializeObjectAttributes(&ObjectAttributes,
+                                       &KeyName,
+                                       OBJ_CASE_INSENSITIVE,
+                                       KeyHandle,
+                                       NULL);
+            Status = ZwCreateKey(&OptionHandle,
+                                KEY_ALL_ACCESS,
+                                &ObjectAttributes,
+                                0,
+                                NULL,
+                                REG_OPTION_VOLATILE,
+                                &Disposition);
+            if (NT_SUCCESS(Status))
+            {
+                NtClose(OptionHandle);
+            }
+            NtClose(KeyHandle);
+        }
+    }
+
     /* Initialize the I/O Subsystem */
     if (!IoInitSystem(LoaderBlock)) KeBugCheck(IO1_INITIALIZATION_FAILED);
 
@@ -1933,49 +1969,6 @@ Phase1InitializationDiscard(IN PVOID Context)
         }
     }
 
-    /* Are we in Win PE mode? */
-    if (InitIsWinPEMode)
-    {
-        /* Open the safe control key */
-        RtlInitUnicodeString(&KeyName,
-                             L"\\REGISTRY\\MACHINE\\SYSTEM\\CURRENTCONTROLSET"
-                             L"\\CONTROL");
-        InitializeObjectAttributes(&ObjectAttributes,
-                                   &KeyName,
-                                   OBJ_CASE_INSENSITIVE,
-                                   NULL,
-                                   NULL);
-        Status = ZwOpenKey(&KeyHandle, KEY_ALL_ACCESS, &ObjectAttributes);
-        if (!NT_SUCCESS(Status))
-        {
-            /* Bugcheck */
-            KeBugCheckEx(PHASE1_INITIALIZATION_FAILED, Status, 6, 0, 0);
-        }
-
-        /* Create the MiniNT key */
-        RtlInitUnicodeString(&KeyName, L"MiniNT");
-        InitializeObjectAttributes(&ObjectAttributes,
-                                   &KeyName,
-                                   OBJ_CASE_INSENSITIVE,
-                                   KeyHandle,
-                                   NULL);
-        Status = ZwCreateKey(&OptionHandle,
-                             KEY_ALL_ACCESS,
-                             &ObjectAttributes,
-                             0,
-                             NULL,
-                             REG_OPTION_VOLATILE,
-                             &Disposition);
-        if (!NT_SUCCESS(Status))
-        {
-            /* Bugcheck */
-            KeBugCheckEx(PHASE1_INITIALIZATION_FAILED, Status, 6, 0, 0);
-        }
-
-        /* Close the handles */
-        NtClose(KeyHandle);
-        NtClose(OptionHandle);
-    }
 
     /* FIXME: This doesn't do anything for now */
     MmArmInitSystem(2, LoaderBlock);

--- a/ntoskrnl/include/internal/io.h
+++ b/ntoskrnl/include/internal/io.h
@@ -84,6 +84,14 @@
 // Unable to create system root path when creating the RAM disk
 //
 #define RD_SYSROOT_INIT_FAILED 6
+//
+// Invalid RDIMAGEOFFSET command-line parameter supplied
+//
+#define RD_INVALID_OFFSET 7
+//
+// Invalid RDIMAGELENGTH command-line parameter supplied
+//
+#define RD_INVALID_LENGTH 8
 
 //
 // Max traversal of reparse points for a single open in IoParseDevice

--- a/ntoskrnl/io/iomgr/arcname.c
+++ b/ntoskrnl/io/iomgr/arcname.c
@@ -46,6 +46,7 @@ IopCreateArcNames(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
     UNICODE_STRING SystemDevice, LoaderPathNameW, BootDeviceName;
     PARC_DISK_INFORMATION ArcDiskInfo = LoaderBlock->ArcDiskInformation;
     ANSI_STRING ArcSystemString, ArcString, LanmanRedirector, LoaderPathNameA;
+    BOOLEAN RamdiskBoot = (_strnicmp(LoaderBlock->ArcBootDeviceName, "ramdisk(0)", 10) == 0);
 
     /* Check if we only have one disk on the machine */
     SingleDisk = (ArcDiskInfo->DiskSignatureListHead.Flink->Flink ==
@@ -142,6 +143,13 @@ IopCreateArcNames(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
     if (NT_SUCCESS(Status) && !FoundBoot)
     {
         Status = IopCreateArcNamesCd(LoaderBlock);
+    }
+
+    /* For ramdisk boots, the ARC name symlink was already created by IopStartRamdisk,
+     * so disk/CD enumeration failure is acceptable */
+    if (!FoundBoot && RamdiskBoot)
+    {
+        Status = STATUS_SUCCESS;
     }
 
     /* Return success */

--- a/ntoskrnl/io/iomgr/ramdisk.c
+++ b/ntoskrnl/io/iomgr/ramdisk.c
@@ -37,35 +37,41 @@ IopStartRamdisk(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
     WCHAR SourceString[54];
 
     //
-    // Scan memory descriptors
+    // Scan memory descriptors.
+    // Prefer LoaderXIPRom (legacy BIOS ramdisk), fall back to the largest
+    // LoaderMemoryData descriptor (UEFI). FreeLoader tags the ramdisk as
+    // LoaderXIPRom, so the fallback is a safety net only.
     //
     MemoryDescriptor = NULL;
     ListHead = &LoaderBlock->MemoryDescriptorListHead;
     NextEntry = ListHead->Flink;
     while (NextEntry != ListHead)
     {
-        //
-        // Get the descriptor
-        //
-        MemoryDescriptor = CONTAINING_RECORD(NextEntry,
-                                             MEMORY_ALLOCATION_DESCRIPTOR,
-                                             ListEntry);
+        PMEMORY_ALLOCATION_DESCRIPTOR Current;
 
-        //
-        // Needs to be a ROM/RAM descriptor
-        //
-        if (MemoryDescriptor->MemoryType == LoaderXIPRom) break;
+        Current = CONTAINING_RECORD(NextEntry,
+                                    MEMORY_ALLOCATION_DESCRIPTOR,
+                                    ListEntry);
 
-        //
-        // Keep trying
-        //
+        if (Current->MemoryType == LoaderXIPRom)
+        {
+            MemoryDescriptor = Current;
+            break;
+        }
+
+        if (Current->MemoryType == LoaderMemoryData &&
+            (!MemoryDescriptor || Current->PageCount > MemoryDescriptor->PageCount))
+        {
+            MemoryDescriptor = Current;
+        }
+
         NextEntry = NextEntry->Flink;
     }
 
     //
     // Nothing found?
     //
-    if (NextEntry == ListHead)
+    if (!MemoryDescriptor)
     {
         //
         // Bugcheck -- no data
@@ -87,7 +93,7 @@ IopStartRamdisk(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
     RamdiskCreate.DiskOffset = 0;
     RamdiskCreate.DiskLength.QuadPart = MemoryDescriptor->PageCount << PAGE_SHIFT;
     RamdiskCreate.DiskGuid = RAMDISK_BOOTDISK_GUID;
-    RamdiskCreate.DriveLetter = L'C';
+    RamdiskCreate.DriveLetter = L'X';
     RamdiskCreate.Options.Fixed = TRUE;
 
     //


### PR DESCRIPTION

## Purpose
                                                                                                                       
Adds end-to-end support for booting ReactOS from a writable in-memory FAT ramdisk, targeting UEFI LiveCD scenarios where the ISO is loaded into RAM by the firmware or bootloader.

<img width="1003" height="828" alt="Screenshot From 2026-03-02 13-06-35" src="https://github.com/user-attachments/assets/a58cdd9a-3c68-467b-ada3-35941f3817af" />

<img width="902" height="590" alt="Screenshot From 2026-03-02 13-06-01" src="https://github.com/user-attachments/assets/06d3fb0b-875f-48e9-9132-ff63dd345950" />

## TODO

_Use a TODO when your pull request is Work in Progress._

- [ ] 
- [ ] 

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: