### PR TITLE
[NTOSKRNL] Kernel changes in preparation for WOW64

### DIFF
--- a/ntoskrnl/ex/sysinfo.c
+++ b/ntoskrnl/ex/sysinfo.c
@@ -2526,7 +2526,34 @@ QSI_DEF(SystemNumaAvailableMemory)
 /* Class 62 - Emulation Basic Information */
 QSI_DEF(SystemEmulationBasicInformation)
 {
+#if defined(_WIN64) && defined(BUILD_WOW64_ENABLED)
+    PSYSTEM_BASIC_INFORMATION Sbi = (PSYSTEM_BASIC_INFORMATION)Buffer;
+
+    *ReqSize = sizeof(SYSTEM_BASIC_INFORMATION);
+
+    /* Check user buffer's size */
+    if (Size != sizeof(SYSTEM_BASIC_INFORMATION))
+    {
+        return STATUS_INFO_LENGTH_MISMATCH;
+    }
+
+    RtlZeroMemory(Sbi, Size);
+    Sbi->Reserved = 0;
+    Sbi->TimerResolution = KeMaximumIncrement;
+    Sbi->PageSize = PAGE_SIZE;
+    Sbi->NumberOfPhysicalPages = MmNumberOfPhysicalPages;
+    Sbi->LowestPhysicalPageNumber = (ULONG)MmLowestPhysicalPage;
+    Sbi->HighestPhysicalPageNumber = (ULONG)MmHighestPhysicalPage;
+    Sbi->AllocationGranularity = MM_VIRTMEM_GRANULARITY; /* hard coded on Intel? */
+    Sbi->MinimumUserModeAddress = 0x10000; /* Top of 64k */
+    Sbi->MaximumUserModeAddress = (ULONG_PTR)0xFFFFFFFF; /* FIXME */
+    Sbi->ActiveProcessorsAffinityMask = KeActiveProcessors;
+    Sbi->NumberOfProcessors = KeNumberProcessors;
+
+    return STATUS_SUCCESS;
+#else
     return QSISystemBasicInformation(Buffer, Size, ReqSize);
+#endif
 }
 
 /* Class 63 - Emulation Processor Information */

--- a/ntoskrnl/include/internal/tag.h
+++ b/ntoskrnl/include/internal/tag.h
@@ -138,6 +138,7 @@
 #define TAG_SHIM                'MIHS'
 #define TAG_QUOTA_BLOCK         'bQsP'
 #define TAG_THREAD_NAME         'mNhT'
+#define TAG_PS_WOW64            'oWsP'
 
 /* Run-Time Library Tags */
 #define TAG_HDTB    'BTDH'

--- a/ntoskrnl/io/iomgr/irp.c
+++ b/ntoskrnl/io/iomgr/irp.c
@@ -233,6 +233,52 @@ IopCleanupIrp(IN PIRP Irp,
     IoFreeIrp(Irp);
 }
 
+static
+VOID
+IopWriteAsyncUserIosb(PIRP Irp)
+{
+    /* Check for UserIos */
+    if (Irp->UserIosb != NULL)
+    {
+        /* Use SEH to make sure we don't write somewhere invalid */
+        _SEH2_TRY
+        {
+#if defined(_WIN64) && defined(BUILD_WOW64_ENABLED)
+            PIO_STATUS_BLOCK32 Iosb32 = (PIO_STATUS_BLOCK32)Irp->UserIosb->Pointer;
+
+            /*
+             * If this is a 32-bit process, and UserIosb falls within the
+             * 32-bit address space, assume UserIosb->Pointer is a 32-bit IOSB
+             * that has to be filled.
+             */
+            if (Irp->RequestorMode == UserMode &&
+                /*
+                 * This is an APC - we're running in the correct thread context,
+                 * and Irp->Tail is trashed. Don't bother with getting the thread
+                 * from the IRP then. The process mode still should be checked.
+                 */
+                IoIs32bitProcess(NULL) &&
+                Iosb32 != NULL && (ULONG_PTR)Iosb32 <= MAXULONG)
+            {
+                InterlockedExchangePointer(&Irp->UserIosb->Pointer, NULL);
+
+                Iosb32->Information = Irp->IoStatus.Information;
+                Iosb32->Status = Irp->IoStatus.Status;
+            }
+            else
+#endif
+            {
+                *Irp->UserIosb = Irp->IoStatus;
+            }
+        }
+        _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+        {
+            /* Ignore any error */
+        }
+        _SEH2_END;
+    }
+}
+
 VOID
 NTAPI
 IopCompleteRequest(IN PKAPC Apc,
@@ -340,21 +386,7 @@ IopCompleteRequest(IN PKAPC Apc,
             Key = FileObject->CompletionContext->Key;
         }
 
-        /* Check for UserIos */
-        if (Irp->UserIosb != NULL)
-        {
-            /* Use SEH to make sure we don't write somewhere invalid */
-            _SEH2_TRY
-            {
-                /*  Save the IOSB Information */
-                *Irp->UserIosb = Irp->IoStatus;
-            }
-            _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
-            {
-                /* Ignore any error */
-            }
-            _SEH2_END;
-        }
+        IopWriteAsyncUserIosb(Irp);
 
         /* Check if we have an event or a file object */
         if (Irp->UserEvent)
@@ -2004,12 +2036,42 @@ IoSetTopLevelIrp(IN PIRP Irp)
 }
 
 #if defined (_WIN64)
+/*
+ * @implemented
+ */
 BOOLEAN
 NTAPI
 IoIs32bitProcess(
     IN PIRP Irp OPTIONAL)
 {
-    UNIMPLEMENTED;
-    return FALSE;
+    PETHREAD pThread;
+    PEPROCESS pProcess;
+
+    if (Irp == NULL)
+    {
+        pThread = PsGetCurrentThread();
+    }
+    else
+    {
+        /* If it's a kernel mode IRP, it could not have originated from WOW64 */
+        if (Irp->RequestorMode == KernelMode ||
+            (PVOID)Irp->UserIosb > MmHighestUserAddress)
+        {
+            return FALSE;
+        }
+
+        pThread = Irp->Tail.Overlay.Thread;
+    }
+
+    pProcess = CONTAINING_RECORD(pThread->Tcb.Process, EPROCESS, Pcb);
+
+    /* FIXME: A two-part hack: delay setting Process->Wow64Process, so 64-bit
+       NTDLL can use IO to init stuff. */
+    if (pProcess->Wow64Process == UlongToPtr(1))
+    {
+        return FALSE;
+    }
+
+    return pProcess->Wow64Process != NULL;
 }
 #endif

--- a/ntoskrnl/ke/amd64/ctxswitch.S
+++ b/ntoskrnl/ke/amd64/ctxswitch.S
@@ -251,4 +251,26 @@ PUBLIC KiSwapContext
     ret
 .ENDP
 
+
+/*!
+ * KiReloadWow64Fs
+ *
+ * \brief
+ *     The KiReloadWow64Fs routine forces the reloading of the cached FS segment data.
+ *
+ * VOID
+ * KiReloadWow64Fs(VOID);
+ *
+ *--*/
+PUBLIC KiReloadWow64Fs
+.PROC KiReloadWow64Fs
+    .endprolog
+
+    /* Force reloading of FS */
+    push fs
+    pop fs
+
+    ret
+.ENDP
+
 END

--- a/ntoskrnl/ke/amd64/thrdini.c
+++ b/ntoskrnl/ke/amd64/thrdini.c
@@ -16,6 +16,9 @@
 extern void KiInvalidSystemThreadStartupExit(void);
 extern void KiUserThreadStartupExit(void);
 extern void KiServiceExit3(void);
+#if defined(_WIN64) && defined(BUILD_WOW64_ENABLED)
+extern void KiReloadWow64Fs();
+#endif
 
 typedef struct _KUINIT_FRAME
 {
@@ -240,6 +243,25 @@ KiSwapContextResume(
     {
        /* This will switch the usermode gs */
        __writemsr(MSR_GS_SWAP, (ULONG64)NewThread->Teb);
+
+#if defined(_WIN64) && defined(BUILD_WOW64_ENABLED)
+       PEPROCESS ENewProcess = (PEPROCESS)NewProcess;
+       
+       if (ENewProcess->Wow64Process != NULL)
+       {
+          ULONG_PTR Base = (ULONG_PTR)PS_GET_TEB32_FROM_TEB(NewThread->Teb);
+
+          PKGDTENTRY64 CmTebEntry = KiGetGdtEntry(Pcr->GdtBase, KGDT64_R3_CMTEB);
+          CmTebEntry->LimitLow = 0xFFFF;
+          CmTebEntry->Bits.LimitHigh = 0xFFFF;
+
+          CmTebEntry->BaseLow = Base & 0xFFFF;
+          CmTebEntry->Bits.BaseMiddle = (Base & 0xFF0000) >> 16;
+          CmTebEntry->Bits.BaseHigh = (Base & 0xFF000000) >> 24;
+
+          KiReloadWow64Fs();
+       }
+#endif
     }
 
     /* Increase context switch count */

--- a/ntoskrnl/mm/ARM3/pagfault.c
+++ b/ntoskrnl/mm/ARM3/pagfault.c
@@ -102,6 +102,14 @@ MiCheckForUserStackOverflow(IN PVOID Address,
         {
             /* Success! */
             Teb->NtTib.StackLimit = NextStackAddress;
+            
+#if defined(_WIN64) && defined(BUILD_WOW64_ENABLED)
+            /* Update WOW64 32-bit TEB stack limit */
+            if (CurrentThread->ThreadsProcess->Wow64Process != NULL)
+            {
+                PS_GET_TEB32_FROM_TEB(Teb)->NtTib.StackLimit = PtrToUlong(Teb->NtTib.StackLimit);
+            }
+#endif
         }
         else
         {
@@ -116,6 +124,14 @@ MiCheckForUserStackOverflow(IN PVOID Address,
 
     /* Update the stack limit */
     Teb->NtTib.StackLimit = (PVOID)((ULONG_PTR)NextStackAddress + GuaranteedSize);
+
+#if defined(_WIN64) && defined(BUILD_WOW64_ENABLED)
+    /* Update WOW64 32-bit TEB stack limit */
+    if (CurrentThread->ThreadsProcess->Wow64Process != NULL)
+    {
+        PS_GET_TEB32_FROM_TEB(Teb)->NtTib.StackLimit = PtrToUlong(Teb->NtTib.StackLimit);
+    }
+#endif
 
     /* Now move the guard page to the next page */
     Status = ZwAllocateVirtualMemory(NtCurrentProcess(),

--- a/ntoskrnl/mm/ARM3/procsup.c
+++ b/ntoskrnl/mm/ARM3/procsup.c
@@ -35,6 +35,13 @@ MiCreatePebOrTeb(IN PEPROCESS Process,
     ULONG_PTR HighestAddress, RandomBase;
     ULONG AlignedSize;
     LARGE_INTEGER CurrentTime;
+#if defined(_WIN64) && defined(BUILD_WOW64_ENABLED)
+    BOOLEAN IsWow64;
+#endif
+    BOOLEAN IsPeb;
+
+    C_ASSERT(sizeof(TEB) != sizeof(PEB));
+    IsPeb = (Size == sizeof(PEB));
 
     Status = PsChargeProcessNonPagedPoolQuota(Process, sizeof(MMVAD_LONG));
     if (!NT_SUCCESS(Status))
@@ -66,23 +73,52 @@ MiCreatePebOrTeb(IN PEPROCESS Process,
     Vad->ControlArea = NULL; // For Memory-Area hack
     Vad->FirstPrototypePte = NULL;
 
-    /* Check if this is a PEB creation */
-    ASSERT(sizeof(TEB) != sizeof(PEB));
-    if (Size == sizeof(PEB))
+    HighestAddress = (ULONG_PTR)MM_HIGHEST_VAD_ADDRESS;
+
+#if defined(_WIN64) && defined(BUILD_WOW64_ENABLED)
+    IsWow64 = FALSE;
+
+    if (Process->SectionBaseAddress != NULL)
     {
+        PIMAGE_NT_HEADERS NtHeader = RtlImageNtHeader(Process->SectionBaseAddress);
+        
+        if (NtHeader != NULL && NtHeader->FileHeader.Machine != IMAGE_FILE_MACHINE_AMD64)
+        {
+            IsWow64 = TRUE;
+        }
+    }
+
+    if (IsWow64)
+    {
+        /* Make sure the structure resides in the 32-bit address space */
+        HighestAddress = MM_HIGHEST_USER_ADDRESS_WOW64;
+    }
+#endif
+
+    /* Check if this is a PEB creation */
+    if (IsPeb)
+    {
+#if defined(_WIN64) && defined(BUILD_WOW64_ENABLED)
+        /* If this is a WOW64 process, allocate enough space for the 32 bit PEB */
+        if (IsWow64)
+        {
+            Size = ROUND_TO_PAGES(Size) + ROUND_TO_PAGES(sizeof(PEB32));
+        }
+#endif
+
         /* Create a random value to select one page in a 64k region */
         KeQueryTickCount(&CurrentTime);
         CurrentTime.LowPart &= (_64K / PAGE_SIZE) - 1;
 
         /* Calculate a random base address */
-        RandomBase = (ULONG_PTR)MM_HIGHEST_VAD_ADDRESS + 1;
+        RandomBase = HighestAddress + 1;
         RandomBase -= CurrentTime.LowPart << PAGE_SHIFT;
 
         /* Make sure the base address is not too high */
         AlignedSize = ROUND_TO_PAGES(Size);
-        if ((RandomBase + AlignedSize) > (ULONG_PTR)MM_HIGHEST_VAD_ADDRESS + 1)
+        if ((RandomBase + AlignedSize) > HighestAddress + 1)
         {
-            RandomBase = (ULONG_PTR)MM_HIGHEST_VAD_ADDRESS + 1 - AlignedSize;
+            RandomBase = HighestAddress + 1 - AlignedSize;
         }
 
         /* Calculate the highest allowed address */
@@ -90,7 +126,13 @@ MiCreatePebOrTeb(IN PEPROCESS Process,
     }
     else
     {
-        HighestAddress = (ULONG_PTR)MM_HIGHEST_VAD_ADDRESS;
+#if defined(_WIN64) && defined(BUILD_WOW64_ENABLED)
+        /* If this is a WOW64 process, allocate enough space for the 32 bit TEB */
+        if (IsWow64)
+        {
+            Size = ROUND_TO_PAGES(Size) + ROUND_TO_PAGES(sizeof(TEB32));
+        }
+#endif
     }
 
     *BaseAddress = 0;
@@ -107,6 +149,12 @@ MiCreatePebOrTeb(IN PEPROCESS Process,
         goto FailPath;
     }
 
+#if defined(_WIN64) && defined(BUILD_WOW64_ENABLED)
+    if (IsPeb && IsWow64)
+    {
+        Process->Wow64Process = UlongToPtr(1);
+    }
+#endif
 
     /* Success */
     return STATUS_SUCCESS;
@@ -130,6 +178,14 @@ MmDeleteTeb(IN PEPROCESS Process,
 
     /* TEB is one page */
     TebEnd = (ULONG_PTR)Teb + ROUND_TO_PAGES(sizeof(TEB)) - 1;
+
+#if defined(_WIN64) && defined(BUILD_WOW64_ENABLED)
+    /* If this is a WOW64 process, the TEB is followed by a TEB32 */
+    if (Process->Wow64Process)
+    {
+        TebEnd += ROUND_TO_PAGES(sizeof(TEB32));
+    }
+#endif
 
     /* Attach to the process */
     KeAttachProcess(&Process->Pcb);

--- a/ntoskrnl/ps/kill.c
+++ b/ntoskrnl/ps/kill.c
@@ -377,6 +377,17 @@ PspDeleteProcess(IN PVOID ObjectBody)
 
     /* Dereference the Device Map */
     ObDereferenceDeviceMap(Process);
+    
+#if defined(_WIN64) && defined(BUILD_WOW64_ENABLED)
+    /* Check if this is a WOW64 process  */
+    if (Process->Wow64Process && !IS_WOW64_PROCESS_INITIALIZING(Process))
+    {
+        /* Free WOW64_PROCESS structure */
+        ExFreePoolWithTag(Process->Wow64Process, TAG_PS_WOW64);
+
+        PsReturnProcessNonPagedPoolQuota(Process, sizeof(WOW64_PROCESS));
+    }
+#endif
 
     /*
      * Dereference the quota block, the function

--- a/ntoskrnl/ps/query.c
+++ b/ntoskrnl/ps/query.c
@@ -1271,12 +1271,44 @@ NtQueryInformationProcess(
                                                NULL);
             if (!NT_SUCCESS(Status)) break;
 
-#ifdef _WIN64
+#if defined(_WIN64) && defined(BUILD_WOW64_ENABLED)
             /* Make sure the process isn't dying */
             if (ExAcquireRundownProtection(&Process->RundownProtect))
             {
+                /* FIXME: A two-part hack: delay setting Process->Wow64Process,
+                   so 64-bit NTDLL can use IO to init stuff. */
+                if (IS_WOW64_PROCESS_INITIALIZING(Process))
+                {
+                    PsChargeProcessNonPagedPoolQuota(Process, sizeof(WOW64_PROCESS));
+                    Process->Wow64Process = ExAllocatePoolWithTag(NonPagedPool, sizeof(WOW64_PROCESS), TAG_PS_WOW64);
+                    if (!Process->Wow64Process)
+                    {
+                        PsReturnProcessNonPagedPoolQuota(Process, sizeof(WOW64_PROCESS));
+
+                        Status = STATUS_NO_MEMORY;
+                        Process->Wow64Process = UlongToPtr(1);
+                    }
+                    else
+                    {
+                        Process->Wow64Process->Wow64 = (PVOID)((ULONG_PTR)(Process->Peb) + ROUND_TO_PAGES(sizeof(PEB)));
+                    }
+                }
+
                 /* Get the WOW64 process structure */
-                Wow64 = (ULONG_PTR)Process->Wow64Process;
+                if (Process->Wow64Process == NULL)
+                {
+                    Wow64 = 0;
+                }
+                /* FIXME */
+                else if (IS_WOW64_PROCESS_INITIALIZING(Process))
+                {
+                    Wow64 = TRUE;
+                }
+                else
+                {
+                    Wow64 = (ULONG_PTR)Process->Wow64Process->Wow64;
+                }
+                
                 /* Release the lock */
                 ExReleaseRundownProtection(&Process->RundownProtect);
             }

--- a/sdk/include/ndk/pstypes.h
+++ b/sdk/include/ndk/pstypes.h
@@ -929,6 +929,18 @@ typedef enum _APPCOMPAT_USERFLAGS_HIGHPART
 #define EXPLICIT_64BIT
 #include "peb_teb.h"
 #undef EXPLICIT_64BIT
+
+// 
+// WOW64 Macros
+//
+#if defined(BUILD_WOW64_ENABLED)
+
+#define PS_GET_TEB32_FROM_TEB(Teb) ((PTEB32)(ROUND_TO_PAGES((Teb) + 1)))
+#define PS_GET_PEB32_FROM_PEB(Peb) ((PPEB32)(ROUND_TO_PAGES((Peb) + 1)))
+
+#define IS_WOW64_PROCESS_INITIALIZING(Process) ((Process)->Wow64Process == UlongToPtr(1))
+#endif
+
 #endif
 
 #ifdef NTOS_MODE_USER


### PR DESCRIPTION
## Purpose

This PR introduces NTOSKRNL changes from my WOW64 branch.

Jira ticket: [CORE-17655](https://jira.reactos.org/browse/CORE-17655)

## Proposed changes

- Implement allocation of 32-bit TEBs and PEBs
- Update 32-bit FS base in the GDT to point to the 32-bit PEB for WOW64 processes
- Implement querying for `SystemEmulationBasicInformation`
- Implement `IoIs32bitProcess`
- Add a way to write 32-bit IOSBs on IRP completion
- Implement querying for `ProcessWow64Information`

## Tests
- [x] Test KVM x86: https://reactos.org/testman/compare.php?ids=109359,109362
- [x] Test KVM x64: https://reactos.org/testman/compare.php?ids=109338,109340