### PR TITLE
[COMCTL32] Stop show timer when hiding tooltips

### DIFF
--- a/dll/win32/comctl32/tooltips.c
+++ b/dll/win32/comctl32/tooltips.c
@@ -904,6 +904,8 @@ TOOLTIPS_Hide (TOOLTIPS_INFO *infoPtr)
 
     TRACE("Hide tooltip %d, %p.\n", infoPtr->nCurrentTool, infoPtr->hwndSelf);
 
+    KillTimer(infoPtr->hwndSelf, ID_TIMERSHOW);
+
     if (infoPtr->nCurrentTool == -1)
 	return;
 


### PR DESCRIPTION
## Purpose
Add a call to KillTimer for ID_TIMERSHOW at the start of TOOLTIPS_Hide to ensure the show timer is stopped whenever a tooltip is hidden. This prevents tooltips from being shown again unexpectedly after being hidden.
JIRA issue: [CORE-18063](https://jira.reactos.org/browse/CORE-18063)
## Proposed changes
- Add KillTimer call for ID_TIMERSHOW at the beginning of TOOLTIPS_Hide function in dlls/comctl32/tooltips.c
- This ensures the show timer is properly cleaned up when a tooltip is hidden
## Testbot runs
- [ ] KVM x86:
- [ ] KVM x64: