### PR TITLE
[SDK] Fix newer MinGW-w64 GCC runtime compatibility for NT 5.2 AMD64 builds

### DIFF
--- a/boot/freeldr/freeldr/include/mm.h
+++ b/boot/freeldr/freeldr/include/mm.h
@@ -21,13 +21,8 @@
 
 extern char __ImageBase;
 #ifdef __GNUC__
-#if defined(_M_AMD64) && (__GNUC__ < 13)
-/* .text/.data/.rdata, and .bss */
-#define FREELDR_SECTION_COUNT 2
-#else
 /* .text/.data/.rdata, .edata and .bss */
 #define FREELDR_SECTION_COUNT 3
-#endif
 #else
 #ifdef _M_AMD64
 /* .text, .rdata/.edata, .pdata and .data/.bss */

--- a/boot/freeldr/freeldr/include/mm.h
+++ b/boot/freeldr/freeldr/include/mm.h
@@ -21,13 +21,13 @@
 
 extern char __ImageBase;
 #ifdef __GNUC__
-  #ifdef _M_AMD64
-    /* .text/.data/.rdata, and .bss */
-    #define FREELDR_SECTION_COUNT 2
-  #else
-    /* .text/.data/.rdata, .edata and .bss */
-    #define FREELDR_SECTION_COUNT 3
-  #endif
+#if defined(_M_AMD64) && (__GNUC__ < 13)
+/* .text/.data/.rdata, and .bss */
+#define FREELDR_SECTION_COUNT 2
+#else
+/* .text/.data/.rdata, .edata and .bss */
+#define FREELDR_SECTION_COUNT 3
+#endif
 #else
 #ifdef _M_AMD64
 /* .text, .rdata/.edata, .pdata and .data/.bss */

--- a/sdk/cmake/gcc.cmake
+++ b/sdk/cmake/gcc.cmake
@@ -660,6 +660,13 @@ string(STRIP ${LIBSUPCXX_LOCATION} LIBSUPCXX_LOCATION)
 set_target_properties(libsupc++ PROPERTIES IMPORTED_LOCATION ${LIBSUPCXX_LOCATION})
 # libsupc++ requires libgcc and stdc++compat
 target_link_libraries(libsupc++ INTERFACE libgcc stdc++compat)
+execute_process(COMMAND ${GXX_EXECUTABLE} -print-file-name=libgcc_eh.a OUTPUT_VARIABLE LIBGCC_EH_LOCATION)
+string(STRIP ${LIBGCC_EH_LOCATION} LIBGCC_EH_LOCATION)
+if(EXISTS "${LIBGCC_EH_LOCATION}" AND NOT LIBGCC_EH_LOCATION STREQUAL "libgcc_eh.a")
+    # Newer MinGW-w64 GCC toolchains separate the C++ exception handling
+    # runtime into libgcc_eh.a, while older ones keep it in libgcc.a.
+    target_link_libraries(libsupc++ INTERFACE ${LIBGCC_EH_LOCATION})
+endif()
 
 add_library(libmingwex STATIC IMPORTED)
 execute_process(COMMAND ${GXX_EXECUTABLE} -print-file-name=libmingwex.a OUTPUT_VARIABLE LIBMINGWEX_LOCATION)

--- a/sdk/lib/gcc-compat/CMakeLists.txt
+++ b/sdk/lib/gcc-compat/CMakeLists.txt
@@ -9,6 +9,7 @@ list(APPEND SOURCE
 
 if(DLL_EXPORT_VERSION LESS 0x600)
     list(APPEND SOURCE
+        condvar_compat.c
         rand_s.c)
 endif()
 

--- a/sdk/lib/gcc-compat/condvar_compat.c
+++ b/sdk/lib/gcc-compat/condvar_compat.c
@@ -1,0 +1,51 @@
+/*
+ * GCC 15's MinGW libgcc pulls in gthr-win32-cond.o, which imports the
+ * Vista-era condition-variable entry points from kernel32. For 0x502-targeted
+ * images linked against this runtime, provide local stubs that satisfy the
+ * linker without widening the runtime API contract.
+ */
+
+#include <windef.h>
+#include <winbase.h>
+
+static VOID WINAPI CondVar_Initialize(PRTL_CONDITION_VARIABLE ConditionVariable)
+{
+    ConditionVariable->Ptr = NULL;
+}
+
+static VOID WINAPI CondVar_Wake(PRTL_CONDITION_VARIABLE ConditionVariable)
+{
+    (void)ConditionVariable;
+}
+
+static VOID WINAPI CondVar_WakeAll(PRTL_CONDITION_VARIABLE ConditionVariable)
+{
+    (void)ConditionVariable;
+}
+
+static BOOL WINAPI CondVar_SleepCS(
+    PRTL_CONDITION_VARIABLE ConditionVariable,
+    PRTL_CRITICAL_SECTION CriticalSection,
+    DWORD Timeout)
+{
+    (void)ConditionVariable;
+    (void)CriticalSection;
+    (void)Timeout;
+    return FALSE;
+}
+
+#ifdef _M_IX86
+VOID (WINAPI *__imp_InitializeConditionVariable)(PRTL_CONDITION_VARIABLE)
+    __asm__("__imp__InitializeConditionVariable@4") = CondVar_Initialize;
+VOID (WINAPI *__imp_WakeConditionVariable)(PRTL_CONDITION_VARIABLE)
+    __asm__("__imp__WakeConditionVariable@4") = CondVar_Wake;
+VOID (WINAPI *__imp_WakeAllConditionVariable)(PRTL_CONDITION_VARIABLE)
+    __asm__("__imp__WakeAllConditionVariable@4") = CondVar_WakeAll;
+BOOL (WINAPI *__imp_SleepConditionVariableCS)(PRTL_CONDITION_VARIABLE, PRTL_CRITICAL_SECTION, DWORD)
+    __asm__("__imp__SleepConditionVariableCS@12") = CondVar_SleepCS;
+#else
+VOID (WINAPI *__imp_InitializeConditionVariable)(PRTL_CONDITION_VARIABLE) = CondVar_Initialize;
+VOID (WINAPI *__imp_WakeConditionVariable)(PRTL_CONDITION_VARIABLE) = CondVar_Wake;
+VOID (WINAPI *__imp_WakeAllConditionVariable)(PRTL_CONDITION_VARIABLE) = CondVar_WakeAll;
+BOOL (WINAPI *__imp_SleepConditionVariableCS)(PRTL_CONDITION_VARIABLE, PRTL_CRITICAL_SECTION, DWORD) = CondVar_SleepCS;
+#endif

--- a/sdk/lib/gcc-compat/condvar_compat.c
+++ b/sdk/lib/gcc-compat/condvar_compat.c
@@ -6,20 +6,24 @@
  */
 
 #include <windef.h>
+#include <intrin.h>
 #include <winbase.h>
 
 static VOID WINAPI CondVar_Initialize(PRTL_CONDITION_VARIABLE ConditionVariable)
 {
+    __debugbreak();
     ConditionVariable->Ptr = NULL;
 }
 
 static VOID WINAPI CondVar_Wake(PRTL_CONDITION_VARIABLE ConditionVariable)
 {
+    __debugbreak();
     (void)ConditionVariable;
 }
 
 static VOID WINAPI CondVar_WakeAll(PRTL_CONDITION_VARIABLE ConditionVariable)
 {
+    __debugbreak();
     (void)ConditionVariable;
 }
 
@@ -28,9 +32,11 @@ static BOOL WINAPI CondVar_SleepCS(
     PRTL_CRITICAL_SECTION CriticalSection,
     DWORD Timeout)
 {
+    __debugbreak();
     (void)ConditionVariable;
     (void)CriticalSection;
     (void)Timeout;
+    SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
     return FALSE;
 }
 


### PR DESCRIPTION
## Purpose

Newer MinGW-w64 GCC toolchains no longer match the older RosBE GCC runtime layout used by our 5.02-target, with the AMD64 images.

like other gcc-compat schemes, this one is needed for gcc15, including this we can build reactos on ubuntu25/WSL2 with it native toolchain

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: