### PR TITLE
[NTUSER] Fix syscalls returning sub-32-bit types leaking EAX to usermode

### DIFF
--- a/win32ss/include/ntuser.h
+++ b/win32ss/include/ntuser.h
@@ -7,6 +7,18 @@ struct _DESKTOP;
 struct _WND;
 struct tagPOPUPMENU;
 
+#ifdef _WIN32K_
+/* Kernel mode: force pointer-sized return to prevent EAX upper-bits leaking to usermode */
+#define SYSCALL_RETURN(type)       C_ASSERT(sizeof(type) == 4); type
+#define SYSCALL_RETURN_SMALL(type) C_ASSERT(sizeof(type) < 4); ULONG_PTR
+#define SYSCALL_RETURN_VOID        ULONG_PTR
+#else
+/* User mode: expose the real type for Windows ABI compatibility */
+#define SYSCALL_RETURN(type)       type
+#define SYSCALL_RETURN_SMALL(type) type
+#define SYSCALL_RETURN_VOID        VOID
+#endif
+
 #define FIRST_USER_HANDLE 0x0020 /* first possible value for low word of user handle */
 #define LAST_USER_HANDLE 0xffef /* last possible value for low word of user handle */
 
@@ -1953,7 +1965,7 @@ NtUserDefSetText(
     HWND WindowHandle,
     PLARGE_STRING WindowText);
 
-BOOLEAN
+SYSCALL_RETURN_SMALL(BOOLEAN)
 NTAPI
 NtUserDestroyAcceleratorTable(
     HACCEL Table);
@@ -1968,7 +1980,7 @@ BOOL
 NTAPI
 NtUserDestroyInputContext(_In_ HIMC hIMC);
 
-BOOLEAN
+SYSCALL_RETURN_SMALL(BOOLEAN)
 NTAPI
 NtUserDestroyWindow(
     HWND Wnd);
@@ -2161,7 +2173,7 @@ DWORD
 NTAPI
 NtUserGetAppImeLevel(_In_ HWND hWnd);
 
-SHORT
+SYSCALL_RETURN_SMALL(SHORT)
 NTAPI
 NtUserGetAsyncKeyState(
     INT Key);
@@ -2375,7 +2387,7 @@ NtUserGetKeyNameText(
     LPWSTR lpString,
     int nSize);
 
-SHORT
+SYSCALL_RETURN_SMALL(SHORT)
 NTAPI
 NtUserGetKeyState(
     INT VirtKey);
@@ -2514,7 +2526,7 @@ NTAPI
 NtUserGetThreadState(
     DWORD Routine);
 
-BOOLEAN
+SYSCALL_RETURN_SMALL(BOOLEAN)
 NTAPI
 NtUserGetTitleBarInfo(
     HWND hwnd,
@@ -2728,7 +2740,7 @@ NtUserNotifyProcessCreate(
     ULONG dwUnknown,
     ULONG CreateFlags);
 
-VOID
+SYSCALL_RETURN_VOID
 NTAPI
 NtUserNotifyWinEvent(
     DWORD Event,
@@ -2892,7 +2904,7 @@ NtUserRedrawWindow(
     HRGN hrgnUpdate,
     UINT flags);
 
-RTL_ATOM
+SYSCALL_RETURN_SMALL(RTL_ATOM)
 NTAPI
 NtUserRegisterClassExWOW(
     WNDCLASSEXW* lpwcx,
@@ -3051,7 +3063,7 @@ NtUserSetClassLongPtr(
     _In_ BOOL Ansi);
 
 #endif // _WIN64
-WORD
+SYSCALL_RETURN_SMALL(WORD)
 NTAPI
 NtUserSetClassWord(
     HWND hWnd,
@@ -3359,7 +3371,7 @@ NtUserSetWindowStationUser(
     IN PSID psid OPTIONAL,
     IN DWORD size);
 
-WORD
+SYSCALL_RETURN_SMALL(WORD)
 NTAPI
 NtUserSetWindowWord(
     HWND hWnd,

--- a/win32ss/user/ntuser/accelerator.c
+++ b/win32ss/user/ntuser/accelerator.c
@@ -335,7 +335,7 @@ UserDestroyAccelTable(PVOID Object)
     return TRUE;
 }
 
-BOOLEAN
+SYSCALL_RETURN_SMALL(BOOLEAN)
 APIENTRY
 NtUserDestroyAcceleratorTable(
     HACCEL hAccel)
@@ -359,7 +359,7 @@ NtUserDestroyAcceleratorTable(
 
     TRACE("Leave NtUserDestroyAcceleratorTable(Table %p) = %u\n", hAccel, Ret);
     UserLeave();
-    return Ret;
+    return (ULONG)Ret;
 }
 
 int

--- a/win32ss/user/ntuser/class.c
+++ b/win32ss/user/ntuser/class.c
@@ -2439,7 +2439,7 @@ UserRegisterSystemClasses(VOID)
 
 /* SYSCALLS *****************************************************************/
 
-RTL_ATOM
+SYSCALL_RETURN_SMALL(RTL_ATOM)
 APIENTRY
 NtUserRegisterClassExWOW(
     WNDCLASSEXW* lpwcx,
@@ -2462,7 +2462,7 @@ NtUserRegisterClassExWOW(
 {
     WNDCLASSEXW CapturedClassInfo = {0};
     UNICODE_STRING CapturedName = {0}, CapturedMenuName = {0}, CapturedVersion = {0};
-    RTL_ATOM Ret = (RTL_ATOM)0;
+    DWORD Ret = 0;
     PPROCESSINFO ppi = GetW32ProcessInfo();
     BOOL Exception = FALSE;
 
@@ -2599,7 +2599,7 @@ InvalidParameter:
 
     UserLeave();
 
-    return Ret;
+    return (DWORD)Ret;
 }
 
 ULONG_PTR APIENTRY
@@ -2727,7 +2727,7 @@ NtUserSetClassLongPtr(
 
 #endif // _WIN64
 
-WORD
+SYSCALL_RETURN_SMALL(WORD)
 APIENTRY
 NtUserSetClassWord(
   HWND hWnd,
@@ -2737,7 +2737,7 @@ NtUserSetClassWord(
 /*
  * NOTE: Obsoleted in 32-bit windows
  */
-   return(0);
+   return 0;
 }
 
 BOOL

--- a/win32ss/user/ntuser/event.c
+++ b/win32ss/user/ntuser/event.c
@@ -249,7 +249,7 @@ IntNotifyWinEvent(
    }
 }
 
-VOID
+SYSCALL_RETURN_VOID
 APIENTRY
 NtUserNotifyWinEvent(
    DWORD Event,
@@ -268,7 +268,7 @@ NtUserNotifyWinEvent(
      if (!Window)
      {
        UserLeave();
-       return;
+       return 0;
      }
    }
 
@@ -279,6 +279,7 @@ NtUserNotifyWinEvent(
       if (Window) UserDerefObjectCo(Window);
    }
    UserLeave();
+   return 0;
 }
 
 HWINEVENTHOOK

--- a/win32ss/user/ntuser/keyboard.c
+++ b/win32ss/user/ntuser/keyboard.c
@@ -644,7 +644,7 @@ IntVkToChar(WORD wVk, PKBDTABLES pKbdTbl)
  *
  * Gets key state from global bitmap
  */
-SHORT
+SYSCALL_RETURN_SMALL(SHORT)
 APIENTRY
 NtUserGetAsyncKeyState(INT Key)
 {
@@ -670,7 +670,7 @@ NtUserGetAsyncKeyState(INT Key)
     UserLeave();
 
     TRACE("Leave NtUserGetAsyncKeyState, ret=%u\n", wRet);
-    return wRet;
+    return (DWORD)(USHORT)wRet;
 }
 
 /*

--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -5755,7 +5755,7 @@ Exit:
 /*
  * @implemented
  */
-BOOLEAN APIENTRY
+SYSCALL_RETURN_SMALL(BOOLEAN) APIENTRY
 NtUserGetTitleBarInfo(
     HWND hwnd,
     PTITLEBARINFO bti)
@@ -5811,7 +5811,7 @@ NtUserGetTitleBarInfo(
 Exit:
     UserLeave();
     TRACE("Leave NtUserGetTitleBarInfo, ret=%u\n", retValue);
-    return retValue;
+    return (ULONG)retValue;
 }
 
 /*

--- a/win32ss/user/ntuser/msgqueue.c
+++ b/win32ss/user/ntuser/msgqueue.c
@@ -2557,7 +2557,7 @@ MsqReleaseModifierKeys(PUSER_MESSAGE_QUEUE MessageQueue)
     }
 }
 
-SHORT
+SYSCALL_RETURN_SMALL(SHORT)
 APIENTRY
 NtUserGetKeyState(INT key)
 {
@@ -2569,7 +2569,7 @@ NtUserGetKeyState(INT key)
 
    UserLeave();
 
-   return (SHORT)Ret;
+   return (DWORD)(USHORT)Ret;
 }
 
 

--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -3053,7 +3053,7 @@ BOOLEAN co_UserDestroyWindow(PVOID Object)
 /*
  * @implemented
  */
-BOOLEAN APIENTRY
+SYSCALL_RETURN_SMALL(BOOLEAN) APIENTRY
 NtUserDestroyWindow(HWND Wnd)
 {
    PWND Window;
@@ -3073,7 +3073,7 @@ NtUserDestroyWindow(HWND Wnd)
 
    TRACE("Leave NtUserDestroyWindow, ret=%u\n", ret);
    UserLeave();
-   return ret;
+   return (ULONG)ret;
 }
 
 
@@ -4135,7 +4135,7 @@ NtUserAlterWindowStyle(HWND hWnd, DWORD Index, LONG NewValue)
  *    @implemented
  */
 
-WORD APIENTRY
+SYSCALL_RETURN_SMALL(WORD) APIENTRY
 NtUserSetWindowWord(HWND hWnd, INT Index, WORD NewValue)
 {
    PWND Window;
@@ -4161,7 +4161,7 @@ NtUserSetWindowWord(HWND hWnd, INT Index, WORD NewValue)
       case GWL_ID:
       case GWL_HINSTANCE:
       case GWL_HWNDPARENT:
-         Ret = (WORD)co_UserSetWindowLong(UserHMGetHandle(Window), Index, (UINT)NewValue, TRUE);
+         Ret = (DWORD)(WORD)co_UserSetWindowLong(UserHMGetHandle(Window), Index, (UINT)NewValue, TRUE);
          goto Exit;
 
       default:
@@ -4181,12 +4181,12 @@ NtUserSetWindowWord(HWND hWnd, INT Index, WORD NewValue)
    OldValue = *((WORD *)((PCHAR)(Window + 1) + Index));
    *((WORD *)((PCHAR)(Window + 1) + Index)) = NewValue;
 
-   Ret = OldValue;
+   Ret = (DWORD)(WORD)OldValue;
 
 Exit:
    TRACE("Leave NtUserSetWindowWord, ret=%u\n", Ret);
    UserLeave();
-   return Ret;
+   return (DWORD)(WORD)Ret;
 }
 
 /*


### PR DESCRIPTION
## Purpose
Widen the return types of NtUser syscalls that return sub-32-bit values to their 32-bit equivalents, preventing the upper bits of the EAX register from being left uninitialized and leaking privileged kernel data to usermode.

JIRA issue: [CORE-14270](https://jira.reactos.org/browse/CORE-14270)

## Proposed changes
- Widen return types in `win32ss/include/ntuser.h` and their kernel implementations to 32-bit equivalents.
- Functions returning `BOOLEAN` are changed to `BOOL`, functions returning `SHORT` or `WORD` are changed to `DWORD`, and `RTL_ATOM` is widened to `DWORD`.
- `NtUserNotifyWinEvent` is changed from `VOID` to `DWORD` with an explicit `return 0`.
- 16-bit return values are zero-extended using a `(DWORD)(USHORT)` cast to prevent sign-extension from corrupting the upper bits.