### PR TITLE
[CONFIGURE] Append build type to output directory name

### DIFF
--- a/configure.cmd
+++ b/configure.cmd
@@ -76,6 +76,7 @@ if not defined ARCH (
 )
 
 set USE_CLANG_CL=0
+set BUILD_TYPE=Debug
 
 REM Parse command line parameters
 set CMAKE_PARAMS=
@@ -104,6 +105,9 @@ set REMAINING=%*
         ) else if /I "!PARAM:~0,2!" == "-D" (
             REM User is passing a switch to CMake
             set "CMAKE_PARAMS=%CMAKE_PARAMS% !PARAM!"
+            if /I "!PARAM:CMAKE_BUILD_TYPE=!" NEQ "!PARAM!" (
+                for /f "tokens=2 delims==" %%v in ("!PARAM!") do set "BUILD_TYPE=%%v"
+            )
         ) else (
             echo. & echo   Warning: Unrecognized switch "!PARAM!" & echo.
         )
@@ -145,6 +149,9 @@ set REMAINING=%*
         ) else if /I "!PARAM:~0,2!" == "-D" (
             REM User is passing a switch to CMake
             set "CMAKE_PARAMS=%CMAKE_PARAMS% !PARAM!"
+            if /I "!PARAM:CMAKE_BUILD_TYPE=!" NEQ "!PARAM!" (
+                for /f "tokens=2 delims==" %%v in ("!PARAM!") do set "BUILD_TYPE=%%v"
+            )
         ) else (
             echo. & echo   Warning: Unrecognized switch "!PARAM!" & echo.
         )
@@ -163,7 +170,7 @@ echo Configuring a new ReactOS build on:
 (for /f "delims=" %%x in ('ver') do @echo %%x) & echo.
 
 REM Create directories
-set REACTOS_OUTPUT_PATH=output-%BUILD_ENVIRONMENT%-%ARCH%
+set REACTOS_OUTPUT_PATH=output-%BUILD_ENVIRONMENT%-%ARCH%-%BUILD_TYPE%
 
 if "%VS_SOLUTION%" == "1" (
     set REACTOS_OUTPUT_PATH=%REACTOS_OUTPUT_PATH%-sln

--- a/configure.sh
+++ b/configure.sh
@@ -8,7 +8,7 @@ fi
 BUILD_ENVIRONMENT=MinGW
 ARCH=$ROS_ARCH
 REACTOS_SOURCE_DIR=$(cd `dirname $0` && pwd)
-REACTOS_OUTPUT_PATH=output-$BUILD_ENVIRONMENT-$ARCH
+BUILD_TYPE=Debug
 
 usage() {
 	echo "Invalid parameter given."
@@ -22,6 +22,11 @@ while [ $# -gt 0 ]; do
 			shift
 			if echo "x$1" | grep 'x?*=*' > /dev/null; then
 				ROS_CMAKEOPTS=$ROS_CMAKEOPTS" -D $1"
+				case "$1" in
+					CMAKE_BUILD_TYPE=*|CMAKE_BUILD_TYPE:*=*)
+						BUILD_TYPE="${1#*=}"
+					;;
+				esac
 			else
 				usage
 			fi
@@ -29,6 +34,11 @@ while [ $# -gt 0 ]; do
 
 		-D?*=*|-D?*)
 			ROS_CMAKEOPTS=$ROS_CMAKEOPTS" $1"
+			case "$1" in
+				-DCMAKE_BUILD_TYPE=*|-DCMAKE_BUILD_TYPE:*=*)
+					BUILD_TYPE="${1#*=}"
+				;;
+			esac
 		;;
 		makefiles|Makefiles)
 			CMAKE_GENERATOR="Unix Makefiles"
@@ -39,6 +49,8 @@ while [ $# -gt 0 ]; do
 
 	shift
 done
+
+REACTOS_OUTPUT_PATH=output-$BUILD_ENVIRONMENT-$ARCH-$BUILD_TYPE
 
 echo "Configuring a new ReactOS build on:"
 echo $(uname -srvpio); echo


### PR DESCRIPTION
## Purpose

Produces directories like `output-MinGW-i386-Debug` or `output-MinGW-amd64-Release`, preventing Debug and Release builds from colliding in the same folder.

Append the CMake build type (Debug/Release/etc.) to the auto-generated output directory name in both `configure.sh` and `configure.cmd`.

Defaults to `Debug` when no `-DCMAKE_BUILD_TYPE` is specified.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: