### PR TITLE
[3DTEXT] Add ability to draw any letter or character

### DIFF
--- a/base/applications/screensavers/3dtext/3dtext.c
+++ b/base/applications/screensavers/3dtext/3dtext.c
@@ -32,7 +32,7 @@
 static HGLRC hRC;       // Permanent Rendering Context
 static HDC hDC;         // Private GDI Device Context
 
-GLuint base;            // Base Display List For The Font Set
+GLuint base;            // Base Display List For The Characters
 GLfloat rot;            // Used To Rotate The Text
 GLfloat extentX = 0.0f;
 GLfloat extentY = 0.0f;
@@ -45,22 +45,20 @@ UINT uTimerID;                                          // SetTimer Actual ID
 #define APP_TIMER             1                         // Graphics Update Timer ID
 #define APP_TIMER_INTERVAL    (USER_TIMER_MINIMUM * 5)  // Graphics Update Interval
 
-// Build Our Bitmap Font
-GLvoid BuildFont(GLvoid)
+GLvoid Build3DCharacters(GLvoid)
 {
-    // Address Buffer For Font Storage
-    GLYPHMETRICSFLOAT gmf[256];
+    // Address Buffer For Character Storage
+    GLYPHMETRICSFLOAT gmf[MAX_TEXT_LENGTH];
     // Windows Font Handle
     HFONT font;
     size_t i;
-    TCHAR c;
     GLfloat cellOriginX = 0.0f;
     GLfloat stringOriginX;
     GLfloat stringExtentX = 0.0f;
     GLfloat stringExtentY = 0.0f;
 
-    // Storage For 256 Characters
-    base = glGenLists(256);
+    // Storage for MAX_TEXT_LENGTH number of characters
+    base = glGenLists(MAX_TEXT_LENGTH);
 
     font = CreateFont(-12,
                       0,                            // Width Of Font
@@ -80,64 +78,49 @@ GLvoid BuildFont(GLvoid)
     // Selects The Font We Created
     SelectObject(hDC, font);
 
-    wglUseFontOutlines(hDC,                     // Select The Current DC
-                       0,                       // Starting Character
-                       255,                     // Number Of Display Lists To Build
-                       base,                    // Starting Display Lists
-                       0.0f,                    // Deviation From The True Outlines
-                       0.2f,                    // Font Thickness In The Z Direction
-                       WGL_FONT_POLYGONS,       // Use Polygons, Not Lines
-                       gmf);                    // Address Of Buffer To Receive Data
-
     // Calculate the string extent
     for (i = 0; i < _tcslen(m_Text); i++)
     {
-        c = m_Text[i];
+        wglUseFontOutlines(hDC,                     // Select The Current DC
+                           m_Text[i],               // Starting Character
+                           1,                       // Number Of Display Lists To Build
+                           base + i,                // Starting Display Lists
+                           0.0f,                    // Deviation From The True Outlines
+                           0.2f,                    // Font Thickness In The Z Direction
+                           WGL_FONT_POLYGONS,       // Use Polygons, Not Lines
+                           gmf + i);                // Address Of Buffer To Receive Data
 
-        stringOriginX = cellOriginX + gmf[c].gmfptGlyphOrigin.x;
+        stringOriginX = cellOriginX + gmf[i].gmfptGlyphOrigin.x;
 
-        stringExtentX = stringOriginX + gmf[c].gmfBlackBoxX;
-        if (gmf[c].gmfBlackBoxY > stringExtentY)
-            stringExtentY = gmf[c].gmfBlackBoxY;
+        stringExtentX = stringOriginX + gmf[i].gmfBlackBoxX;
+        if (gmf[i].gmfBlackBoxY > stringExtentY)
+            stringExtentY = gmf[i].gmfBlackBoxY;
 
-        cellOriginX = cellOriginX + gmf[c].gmfCellIncX;
+        cellOriginX = cellOriginX + gmf[i].gmfCellIncX;
     }
 
     extentX = stringExtentX;
     extentY = stringExtentY;
 }
 
-// Delete The Font
-GLvoid KillFont(GLvoid)
+GLvoid Delete3DCharacters(GLvoid)
 {
-    // Delete all 256 characters
-    glDeleteLists(base, 256);
+    // Delete all MAX_TEXT_LENGTH characters
+    glDeleteLists(base, MAX_TEXT_LENGTH);
 }
 
 // Custom GL "Print" Routine
-GLvoid glPrint(LPTSTR text)
+GLvoid glPrint(GLvoid)
 {
     // If there's no text, do nothing
-    if (text == NULL)
+    if (_tcslen(m_Text) == 0)
         return;
 
-    // Pushes The Display List Bits
-    glPushAttrib(GL_LIST_BIT);
-
-    // Sets The Base Character to 32
-    glListBase(base);
-
     // Draws The Display List Text
-    glCallLists(_tcslen(text),
-#ifdef UNICODE
-                GL_UNSIGNED_SHORT,
-#else
-                GL_UNSIGNED_BYTE,
-#endif
-                text);
-
-    // Pops The Display List Bits
-    glPopAttrib();
+    for (int i = 0; i < _tcslen(m_Text); i++)
+    {
+        glCallList(base + i);
+    }
 }
 
 // Will Be Called Right After The GL Window Is Created
@@ -170,8 +153,8 @@ GLvoid InitGL(GLsizei Width, GLsizei Height)
     // Select The Modelview Matrix
     glMatrixMode(GL_MODELVIEW);
 
-    // Build The Font
-    BuildFont();
+    // Build The 3D Characters
+    Build3DCharacters();
 
     // Enable Default Light (Quick And Dirty)
     glEnable(GL_LIGHT0);
@@ -244,7 +227,7 @@ GLvoid DrawGLScene(GLvoid)
               (1.0f - 0.5f * (GLfloat)(cos(rot / 17.0f))));
 
     // Print GL Text To The Screen
-    glPrint(m_Text);
+    glPrint();
 
     // Make The Text Blue
     glColor3f(0.0f, 0.0f, 1.0f);
@@ -353,8 +336,8 @@ ScreenSaverProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
             // Delete the Update Timer
             KillTimer(hWnd, uTimerID);
 
-            // Deletes The Font Display List
-            KillFont();
+            // Deletes The Character Display Lists
+            Delete3DCharacters();
 
             // Make The DC Current
             wglMakeCurrent(hDC, NULL);
@@ -401,6 +384,7 @@ BOOL CALLBACK ScreenSaverConfigureDialog(HWND hDlg, UINT uMsg, WPARAM wParam, LP
         case WM_INITDIALOG:
             LoadSettings();
             SetDlgItemText(hDlg, IDC_MESSAGE_TEXT, m_Text);
+            SendDlgItemMessage(hDlg, IDC_MESSAGE_TEXT, EM_LIMITTEXT, MAX_TEXT_LENGTH, 0);
             return TRUE;
 
         case WM_COMMAND:

--- a/base/applications/screensavers/3dtext/3dtext.c
+++ b/base/applications/screensavers/3dtext/3dtext.c
@@ -113,7 +113,7 @@ GLvoid Delete3DCharacters(GLvoid)
 GLvoid glPrint(GLvoid)
 {
     // If there's no text, do nothing
-    if (_tcslen(g_Text) == 0)
+    if (!g_Text[0])
         return;
 
     // Draws The Display List Text

--- a/base/applications/screensavers/3dtext/3dtext.c
+++ b/base/applications/screensavers/3dtext/3dtext.c
@@ -78,8 +78,10 @@ GLvoid Build3DCharacters(GLvoid)
     // Selects The Font We Created
     SelectObject(hDC, font);
 
+    size_t g_Text_length = _tcslen(g_Text);
+
     // Calculate the string extent
-    for (i = 0; i < _tcslen(g_Text); i++)
+    for (i = 0; i < g_Text_length; i++)
     {
         wglUseFontOutlines(hDC,                     // Select The Current DC
                            g_Text[i],               // Starting Character
@@ -116,8 +118,10 @@ GLvoid glPrint(GLvoid)
     if (!g_Text[0])
         return;
 
+    size_t g_Text_length = _tcslen(g_Text);
+
     // Draws The Display List Text
-    for (int i = 0; i < _tcslen(g_Text); i++)
+    for (size_t i = 0; i < g_Text_length; i++)
     {
         glCallList(base + i);
     }

--- a/base/applications/screensavers/3dtext/3dtext.c
+++ b/base/applications/screensavers/3dtext/3dtext.c
@@ -79,10 +79,10 @@ GLvoid Build3DCharacters(GLvoid)
     SelectObject(hDC, font);
 
     // Calculate the string extent
-    for (i = 0; i < _tcslen(m_Text); i++)
+    for (i = 0; i < _tcslen(g_Text); i++)
     {
         wglUseFontOutlines(hDC,                     // Select The Current DC
-                           m_Text[i],               // Starting Character
+                           g_Text[i],               // Starting Character
                            1,                       // Number Of Display Lists To Build
                            base + i,                // Starting Display Lists
                            0.0f,                    // Deviation From The True Outlines
@@ -113,11 +113,11 @@ GLvoid Delete3DCharacters(GLvoid)
 GLvoid glPrint(GLvoid)
 {
     // If there's no text, do nothing
-    if (_tcslen(m_Text) == 0)
+    if (_tcslen(g_Text) == 0)
         return;
 
     // Draws The Display List Text
-    for (int i = 0; i < _tcslen(m_Text); i++)
+    for (int i = 0; i < _tcslen(g_Text); i++)
     {
         glCallList(base + i);
     }
@@ -383,7 +383,7 @@ BOOL CALLBACK ScreenSaverConfigureDialog(HWND hDlg, UINT uMsg, WPARAM wParam, LP
     {
         case WM_INITDIALOG:
             LoadSettings();
-            SetDlgItemText(hDlg, IDC_MESSAGE_TEXT, m_Text);
+            SetDlgItemText(hDlg, IDC_MESSAGE_TEXT, g_Text);
             SendDlgItemMessage(hDlg, IDC_MESSAGE_TEXT, EM_LIMITTEXT, MAX_TEXT_LENGTH, 0);
             return TRUE;
 
@@ -391,7 +391,7 @@ BOOL CALLBACK ScreenSaverConfigureDialog(HWND hDlg, UINT uMsg, WPARAM wParam, LP
             switch (LOWORD(wParam))
             {
                 case IDOK:
-                    GetDlgItemText(hDlg, IDC_MESSAGE_TEXT, m_Text, MAX_PATH);
+                    GetDlgItemText(hDlg, IDC_MESSAGE_TEXT, g_Text, MAX_PATH);
                     SaveSettings();
 
                     /* Fall through */

--- a/base/applications/screensavers/3dtext/3dtext.c
+++ b/base/applications/screensavers/3dtext/3dtext.c
@@ -78,10 +78,10 @@ GLvoid Build3DCharacters(GLvoid)
     // Selects The Font We Created
     SelectObject(hDC, font);
 
-    size_t g_Text_length = _tcslen(g_Text);
+    size_t text_length = _tcslen(g_Text);
 
     // Calculate the string extent
-    for (i = 0; i < g_Text_length; i++)
+    for (i = 0; i < text_length; i++)
     {
         wglUseFontOutlines(hDC,                     // Select The Current DC
                            g_Text[i],               // Starting Character
@@ -118,10 +118,10 @@ GLvoid glPrint(GLvoid)
     if (!g_Text[0])
         return;
 
-    size_t g_Text_length = _tcslen(g_Text);
+    size_t text_length = _tcslen(g_Text);
 
     // Draws The Display List Text
-    for (size_t i = 0; i < g_Text_length; i++)
+    for (size_t i = 0; i < text_length; i++)
     {
         glCallList(base + i);
     }

--- a/base/applications/screensavers/3dtext/3dtext.c
+++ b/base/applications/screensavers/3dtext/3dtext.c
@@ -32,10 +32,11 @@
 static HGLRC hRC;       // Permanent Rendering Context
 static HDC hDC;         // Private GDI Device Context
 
-GLuint base;            // Base Display List For The Characters
-GLfloat rot;            // Used To Rotate The Text
-GLfloat extentX = 0.0f;
-GLfloat extentY = 0.0f;
+static GLuint base;                               // Base Display List For The Characters
+static GLuint text_display_list[MAX_TEXT_LENGTH]; // The Display List IDs For The Characters
+static GLfloat rot;                               // Used To Rotate The Text
+static GLfloat extentX = 0.0f;
+static GLfloat extentY = 0.0f;
 
 #define APPNAME _T("3DText")
 
@@ -83,6 +84,8 @@ GLvoid Build3DCharacters(GLvoid)
     // Calculate the string extent
     for (i = 0; i < text_length; i++)
     {
+        text_display_list[i] = base + i;
+
         wglUseFontOutlines(hDC,                     // Select The Current DC
                            g_Text[i],               // Starting Character
                            1,                       // Number Of Display Lists To Build
@@ -121,10 +124,7 @@ GLvoid glPrint(GLvoid)
     size_t text_length = _tcslen(g_Text);
 
     // Draws The Display List Text
-    for (size_t i = 0; i < text_length; i++)
-    {
-        glCallList(base + i);
-    }
+    glCallLists(text_length, GL_UNSIGNED_INT, text_display_list);
 }
 
 // Will Be Called Right After The GL Window Is Created

--- a/base/applications/screensavers/3dtext/3dtext.c
+++ b/base/applications/screensavers/3dtext/3dtext.c
@@ -388,14 +388,14 @@ BOOL CALLBACK ScreenSaverConfigureDialog(HWND hDlg, UINT uMsg, WPARAM wParam, LP
         case WM_INITDIALOG:
             LoadSettings();
             SetDlgItemText(hDlg, IDC_MESSAGE_TEXT, g_Text);
-            SendDlgItemMessage(hDlg, IDC_MESSAGE_TEXT, EM_LIMITTEXT, MAX_TEXT_LENGTH, 0);
+            SendDlgItemMessage(hDlg, IDC_MESSAGE_TEXT, EM_LIMITTEXT, ARRAYSIZE(g_Text) - 1, 0);
             return TRUE;
 
         case WM_COMMAND:
             switch (LOWORD(wParam))
             {
                 case IDOK:
-                    GetDlgItemText(hDlg, IDC_MESSAGE_TEXT, g_Text, MAX_PATH);
+                    GetDlgItemText(hDlg, IDC_MESSAGE_TEXT, g_Text, ARRAYSIZE(g_Text));
                     SaveSettings();
 
                     /* Fall through */

--- a/base/applications/screensavers/3dtext/3dtext.h
+++ b/base/applications/screensavers/3dtext/3dtext.h
@@ -24,7 +24,9 @@
 #include <tchar.h>
 #include <windef.h>
 
-extern TCHAR m_Text[MAX_PATH];
+#define MAX_TEXT_LENGTH 20
+
+extern TCHAR m_Text[MAX_TEXT_LENGTH + 1];
 
 VOID LoadSettings(VOID);
 VOID SaveSettings(VOID);

--- a/base/applications/screensavers/3dtext/3dtext.h
+++ b/base/applications/screensavers/3dtext/3dtext.h
@@ -26,7 +26,7 @@
 
 #define MAX_TEXT_LENGTH 20
 
-extern TCHAR m_Text[MAX_TEXT_LENGTH + 1];
+extern TCHAR g_Text[MAX_TEXT_LENGTH + 1];
 
 VOID LoadSettings(VOID);
 VOID SaveSettings(VOID);

--- a/base/applications/screensavers/3dtext/settings.c
+++ b/base/applications/screensavers/3dtext/settings.c
@@ -22,12 +22,12 @@
 
 #include <winreg.h>
 
-TCHAR m_Text[MAX_PATH] = _T("ReactOS Rocks!");
+TCHAR m_Text[MAX_TEXT_LENGTH + 1] = _T("ReactOS Rocks!");
 
 VOID LoadSettings(VOID)
 {
 	HKEY hkey;
-	DWORD len = MAX_PATH * sizeof(TCHAR);
+	DWORD len = (MAX_TEXT_LENGTH + 1) * sizeof(TCHAR);
 
 	if (RegCreateKeyEx(HKEY_CURRENT_USER, _T("Software\\Microsoft\\ScreenSavers\\Text3D"), 0,
 		_T(""), 0, KEY_READ, NULL, &hkey, NULL) == ERROR_SUCCESS)

--- a/base/applications/screensavers/3dtext/settings.c
+++ b/base/applications/screensavers/3dtext/settings.c
@@ -22,7 +22,7 @@
 
 #include <winreg.h>
 
-TCHAR m_Text[MAX_TEXT_LENGTH + 1] = _T("ReactOS Rocks!");
+TCHAR g_Text[MAX_TEXT_LENGTH + 1] = _T("ReactOS Rocks!");
 
 VOID LoadSettings(VOID)
 {
@@ -32,7 +32,7 @@ VOID LoadSettings(VOID)
 	if (RegCreateKeyEx(HKEY_CURRENT_USER, _T("Software\\Microsoft\\ScreenSavers\\Text3D"), 0,
 		_T(""), 0, KEY_READ, NULL, &hkey, NULL) == ERROR_SUCCESS)
     {
-        RegQueryValueEx(hkey, _T("DisplayString"), NULL, NULL, (LPBYTE)m_Text, &len);
+        RegQueryValueEx(hkey, _T("DisplayString"), NULL, NULL, (LPBYTE)g_Text, &len);
         RegCloseKey(hkey);
     }
 }
@@ -44,7 +44,7 @@ VOID SaveSettings(VOID)
 	if (RegCreateKeyEx(HKEY_CURRENT_USER, _T("Software\\Microsoft\\ScreenSavers\\Text3D"), 0,
 		_T(""), 0, KEY_WRITE, NULL, &hkey, NULL) == ERROR_SUCCESS)
     {
-        RegSetValueEx(hkey, _T("DisplayString"), 0, REG_SZ, (LPBYTE)m_Text, (_tcslen(m_Text) + 1) * sizeof(TCHAR));
+        RegSetValueEx(hkey, _T("DisplayString"), 0, REG_SZ, (LPBYTE)g_Text, (_tcslen(g_Text) + 1) * sizeof(TCHAR));
         RegCloseKey(hkey);
     }
 }

--- a/base/applications/screensavers/3dtext/settings.c
+++ b/base/applications/screensavers/3dtext/settings.c
@@ -27,7 +27,7 @@ TCHAR g_Text[MAX_TEXT_LENGTH + 1] = _T("ReactOS Rocks!");
 VOID LoadSettings(VOID)
 {
 	HKEY hkey;
-	DWORD len = (MAX_TEXT_LENGTH + 1) * sizeof(TCHAR);
+	DWORD len = sizeof(g_Text);
 
 	if (RegCreateKeyEx(HKEY_CURRENT_USER, _T("Software\\Microsoft\\ScreenSavers\\Text3D"), 0,
 		_T(""), 0, KEY_READ, NULL, &hkey, NULL) == ERROR_SUCCESS)


### PR DESCRIPTION
……not just the first 255 from the character set, limit the text length to 20

## Purpose

Currently the 3d text screensaver in ReactOS can only display the first 255 letters from the character set. If you try to enter letters outside of that, e.g. the hungarian ő and ű letters (those are what I noticed) it just skips them, or worst case it crashes. This PR addresses that. 

JIRA issue: none

## Proposed changes

- Generate the 3d shapes not for the first 255 letters, but instead one-by-one for the exact letters the user entered.
- Also limit the string length to 20, that is what windows does.
- I also corrected some comments / function names to better reflect what is happening.
- glListBase() became unnecessary since glCallLists() is replaced with a sequence of glCallList() calls.

Result:

<img width="800" height="600" alt="3dtext_any_character" src="https://github.com/user-attachments/assets/b0e2ad81-399c-4eb8-aec3-6af985c49424" />

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=108831,108833 LGTM
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=108832,108834 LGTM