### PR TITLE
[NTOS:AMD64] Stop recursive page faults on exhausted kernel stacks

### DIFF
--- a/ntoskrnl/ke/amd64/trap.S
+++ b/ntoskrnl/ke/amd64/trap.S
@@ -430,9 +430,28 @@ FUNC KiPageFault
     /* We have an error code */
     EnterTrap (TF_HAS_ERROR_CODE OR TF_SAVE_ALL)
 
+    /* Link this frame so nested faults can recover the previous active trap */
+    mov rax, gs:[PcCurrentThread]
+    mov rcx, [rax + ThTrapFrame]
+    mov [rbp + KTRAP_FRAME_TrapFrame], rcx
+    mov [rax + ThTrapFrame], rbp
+
     /* Save page fault address */
     mov rdx, cr2
     mov [rbp  + KTRAP_FRAME_FaultAddress], rdx
+
+    /* Nested kernel page faults on an exhausted stack will recurse forever */
+    test byte ptr [rbp + KTRAP_FRAME_SegCs], 1
+    jnz SkipStackCheck
+    test rcx, rcx
+    jz SkipStackCheck
+    cmp rcx, rbp
+    jbe KernelStackOverflow
+    sub rcx, rbp
+    cmp rcx, KTRAP_FRAME_LENGTH
+    jbe KernelStackOverflow
+
+SkipStackCheck:
 
     /* If interrupts are off, do not enable them */
     test dword ptr [rbp + KTRAP_FRAME_EFlags], EFLAGS_IF_MASK
@@ -496,12 +515,25 @@ SpecialCode:
     call InternalDispatchException
 
 PageFaultReturn:
-
     /* Disable interrupts for the return */
     cli
 
+    /* Restore the previous active trap frame */
+    mov rcx, gs:[PcCurrentThread]
+    mov rdx, [rbp + KTRAP_FRAME_TrapFrame]
+    mov [rcx + ThTrapFrame], rdx
+
     /* Return */
     ExitTrap (TF_SAVE_ALL or TF_CHECKUSERAPC)
+
+KernelStackOverflow:
+    /* Use the original faulting frame so the bugcheck points at the real cause */
+    mov rax, gs:[PcCurrentThread]
+    mov rdx, [rbp + KTRAP_FRAME_TrapFrame]
+    mov [rax + ThTrapFrame], rdx
+    mov ecx, HEX(0E)
+    call KiSystemFatalException
+    jmp $
 ENDFUNC
 
 


### PR DESCRIPTION
## Purpose

Prevent recursive amd64 page-fault handling when the kernel stack is already exhausted.

Today, a kernel-mode page fault can re-enter KiPageFault while exception dispatch is trying to unwind on the same nearly-full stack, eventually ending in a double fault. This change makes that failure stop at the first nested overlapping page fault, so the system bugchecks with the original fault context instead of recursing into a less useful secondary failure.

## Proposed changes

Link amd64 KiPageFault trap frames to the previously active trap frame while the handler is running.

Add a nested kernel-mode trap-frame overlap check in KiPageFault before exception dispatch continues.

Treat overlapping nested page-fault trap frames as fatal and call KiSystemFatalException instead of entering the recursive dispatch/unwind path again.

Restore the previous active trap frame on page-fault exit and on the fatal path to keep thread trap-frame state consistent.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: