### PR TITLE
[FREETYPE] Make FT_Library_SetLcdGeometry consistently pointer-typed

### DIFF
--- a/sdk/lib/3rdparty/freetype/include/freetype/ftlcdfil.h
+++ b/sdk/lib/3rdparty/freetype/include/freetype/ftlcdfil.h
@@ -311,7 +311,7 @@ FT_BEGIN_HEADER
    */
   FT_EXPORT( FT_Error )
   FT_Library_SetLcdGeometry( FT_Library  library,
-                             FT_Vector*  sub );
+                             FT_Vector   sub[3] );
 
   /* */
 

--- a/sdk/lib/3rdparty/freetype/include/freetype/ftlcdfil.h
+++ b/sdk/lib/3rdparty/freetype/include/freetype/ftlcdfil.h
@@ -311,7 +311,7 @@ FT_BEGIN_HEADER
    */
   FT_EXPORT( FT_Error )
   FT_Library_SetLcdGeometry( FT_Library  library,
-                             FT_Vector   sub[3] );
+                             FT_Vector*  sub );
 
   /* */
 

--- a/sdk/lib/3rdparty/freetype/src/base/ftlcdfil.c
+++ b/sdk/lib/3rdparty/freetype/src/base/ftlcdfil.c
@@ -418,7 +418,7 @@
 
   FT_EXPORT_DEF( FT_Error )
   FT_Library_SetLcdGeometry( FT_Library  library,
-                             FT_Vector   sub[3] )
+                             FT_Vector*  sub )
   {
     if ( !library )
       return FT_THROW( Invalid_Library_Handle );

--- a/sdk/lib/3rdparty/freetype/src/base/ftlcdfil.c
+++ b/sdk/lib/3rdparty/freetype/src/base/ftlcdfil.c
@@ -357,10 +357,10 @@
 
   FT_EXPORT_DEF( FT_Error )
   FT_Library_SetLcdGeometry( FT_Library  library,
-#ifndef __REACTOS__
-                             FT_Vector*  sub )
-#else
+#ifdef __REACTOS__
                              FT_Vector   sub[3] )
+#else
+                             FT_Vector*  sub )
 #endif
   {
     FT_UNUSED( library );
@@ -422,10 +422,10 @@
 
   FT_EXPORT_DEF( FT_Error )
   FT_Library_SetLcdGeometry( FT_Library  library,
-#ifndef __REACTOS__
-                             FT_Vector*  sub )
-#else
+#ifdef __REACTOS__
                              FT_Vector   sub[3] )
+#else
+                             FT_Vector*  sub )
 #endif
   {
     if ( !library )

--- a/sdk/lib/3rdparty/freetype/src/base/ftlcdfil.c
+++ b/sdk/lib/3rdparty/freetype/src/base/ftlcdfil.c
@@ -357,7 +357,11 @@
 
   FT_EXPORT_DEF( FT_Error )
   FT_Library_SetLcdGeometry( FT_Library  library,
+#ifndef __REACTOS__
                              FT_Vector*  sub )
+#else
+                             FT_Vector   sub[3] )
+#endif
   {
     FT_UNUSED( library );
     FT_UNUSED( sub );
@@ -418,7 +422,11 @@
 
   FT_EXPORT_DEF( FT_Error )
   FT_Library_SetLcdGeometry( FT_Library  library,
+#ifndef __REACTOS__
                              FT_Vector*  sub )
+#else
+                             FT_Vector   sub[3] )
+#endif
   {
     if ( !library )
       return FT_THROW( Invalid_Library_Handle );


### PR DESCRIPTION
## Purpose

Update FT_Library_SetLcdGeometry to use FT_Vector *sub in the public declaration and both source definitions.

This removes the GCC -Warray-parameter warning caused by mixing FT_Vector sub[3] and FT_Vector *sub in the same API signature.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: