### PR TITLE
[CRT] Add missing quick_exit declarations to stdlib.h

### DIFF
--- a/sdk/include/crt/stdlib.h
+++ b/sdk/include/crt/stdlib.h
@@ -255,6 +255,11 @@ extern "C" {
   __MINGW_EXTENSION __int64 __cdecl _abs64(__int64);
 #endif
   int __cdecl atexit(void (__cdecl *)(void));
+#if (!defined(__cplusplus) && defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)) || \
+    (defined(__cplusplus) && (__cplusplus >= 201103L))
+  __declspec(noreturn) void __cdecl quick_exit(int);
+  int __cdecl at_quick_exit(void (__cdecl *)(void));
+#endif
 
 #ifndef _CRT_ATOF_DEFINED
 #define _CRT_ATOF_DEFINED


### PR DESCRIPTION
## Purpose

With GCC 15, libstdc++ enables `quick_exit` and `at_quick_exit` support in `<cstdlib>`. Our legacy CRT `stdlib.h` did not declare those symbols, so the build failed while compiling `sdk/lib/gcc-compat/__throw_out_of_range_fmt.cpp`.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: