### PR TITLE
[NFSD] Fix prototype mismatches in service and RPC code

### DIFF
--- a/base/services/nfsd/acl.c
+++ b/base/services/nfsd/acl.c
@@ -647,7 +647,7 @@ static int map_dacl_2_nfs4acl(PACL acl, PSID sid, PSID gsid, nfsacl41 *nfs4_acl,
         }
         nfs4_acl->flag = 0;
         for (i = 0; i < acl->AceCount; i++) {
-            status = GetAce(acl, i, &ace);
+            status = GetAce(acl, i, (PVOID *)&ace);
             if (!status) {
                 status = GetLastError();
                 eprintf("map_dacl_2_nfs4acl: GetAce failed with %d\n", status);

--- a/base/services/nfsd/callback_server.c
+++ b/base/services/nfsd/callback_server.c
@@ -509,12 +509,15 @@ out:
 }
 
 #ifdef __REACTOS__
-int nfs41_handle_callback(void *rpc_clnt, void *cb, void * dummy)
-{
-    struct cb_compound_res **reply = dummy;
+int nfs41_handle_callback(void *rpc_clnt, void *cb, void **reply)
 #else
 int nfs41_handle_callback(void *rpc_clnt, void *cb, struct cb_compound_res **reply)
+#endif
 {
+#ifdef __REACTOS__
+    struct cb_compound_res **compound_reply = (struct cb_compound_res **)reply;
+#else
+    struct cb_compound_res **compound_reply = reply;
 #endif
     nfs41_rpc_clnt *rpc = (nfs41_rpc_clnt *)rpc_clnt;
     cb_req *request = (cb_req *)cb;
@@ -534,7 +537,7 @@ int nfs41_handle_callback(void *rpc_clnt, void *cb, struct cb_compound_res **rep
 
     case CB_COMPOUND:
         dprintf(1, "CB_COMPOUND\n");
-        handle_cb_compound(rpc, request, reply);
+        handle_cb_compound(rpc, request, compound_reply);
         break;
 
     default:

--- a/base/services/nfsd/nfs41_callback.h
+++ b/base/services/nfsd/nfs41_callback.h
@@ -26,6 +26,7 @@
 #include "rpc/rpc.h"
 #include "nfs41_types.h"
 
+struct cb_compound_res;
 
 enum nfs41_callback_proc {
     CB_NULL                 = 0,
@@ -48,7 +49,11 @@ enum nfs41_callback_op {
     OP_CB_ILLEGAL           = 10044
 };
 
-int nfs41_handle_callback(void *, void *, void *);
+#ifdef __REACTOS__
+int nfs41_handle_callback(void *, void *, void **);
+#else
+int nfs41_handle_callback(void *, void *, struct cb_compound_res **);
+#endif
 
 /* OP_CB_LAYOUTRECALL */
 struct cb_recall_file {

--- a/base/services/nfsd/nfs41_rpc.c
+++ b/base/services/nfsd/nfs41_rpc.c
@@ -39,16 +39,6 @@ static enum clnt_stat send_null(CLIENT *client)
                      (xdrproc_t)xdr_void, NULL, timeout);
 }
 
-static int proc_cb_compound_res_adapter(void *xdr, void *res)
-{
-    return proc_cb_compound_res((XDR *)xdr, (struct cb_compound_res *)res);
-}
-
-static int nfs41_handle_callback_adapter(void *rpc_clnt, void *cb, void **reply)
-{
-    return nfs41_handle_callback(rpc_clnt, cb, reply);
-}
-
 static int get_client_for_netaddr(
     IN const netaddr4 *netaddr,
     IN uint32_t wsize,
@@ -77,8 +67,8 @@ static int get_client_for_netaddr(
     dprintf(1, "callback function %p args %p\n", nfs41_handle_callback, rpc);
     client = clnt_tli_create(RPC_ANYFD, nconf, addr, NFS41_RPC_PROGRAM,
         NFS41_RPC_VERSION, wsize, rsize,
-        rpc ? proc_cb_compound_res_adapter : NULL,
-        rpc ? nfs41_handle_callback_adapter : NULL, rpc ? rpc : NULL);
+        rpc ? (int (*)(void *, void *))proc_cb_compound_res : NULL,
+        rpc ? (int (*)(void *, void *, void **))nfs41_handle_callback : NULL, rpc ? rpc : NULL);
     if (client) {
         *client_out = client;
         status = NO_ERROR;

--- a/base/services/nfsd/nfs41_rpc.c
+++ b/base/services/nfsd/nfs41_rpc.c
@@ -68,7 +68,7 @@ static int get_client_for_netaddr(
     client = clnt_tli_create(RPC_ANYFD, nconf, addr, NFS41_RPC_PROGRAM,
         NFS41_RPC_VERSION, wsize, rsize,
         rpc ? (int (*)(void *, void *))proc_cb_compound_res : NULL,
-        rpc ? (int (*)(void *, void *, void **))nfs41_handle_callback : NULL, rpc ? rpc : NULL);
+        rpc ? nfs41_handle_callback : NULL, rpc ? rpc : NULL);
     if (client) {
         *client_out = client;
         status = NO_ERROR;

--- a/base/services/nfsd/nfs41_rpc.c
+++ b/base/services/nfsd/nfs41_rpc.c
@@ -39,6 +39,16 @@ static enum clnt_stat send_null(CLIENT *client)
                      (xdrproc_t)xdr_void, NULL, timeout);
 }
 
+static int proc_cb_compound_res_adapter(void *xdr, void *res)
+{
+    return proc_cb_compound_res((XDR *)xdr, (struct cb_compound_res *)res);
+}
+
+static int nfs41_handle_callback_adapter(void *rpc_clnt, void *cb, void **reply)
+{
+    return nfs41_handle_callback(rpc_clnt, cb, reply);
+}
+
 static int get_client_for_netaddr(
     IN const netaddr4 *netaddr,
     IN uint32_t wsize,
@@ -65,9 +75,10 @@ static int get_client_for_netaddr(
         dprintf(1, "servername is %s\n", server_name);
     }
     dprintf(1, "callback function %p args %p\n", nfs41_handle_callback, rpc);
-    client = clnt_tli_create(RPC_ANYFD, nconf, addr, NFS41_RPC_PROGRAM, 
-        NFS41_RPC_VERSION, wsize, rsize, rpc ? proc_cb_compound_res : NULL, 
-        rpc ? nfs41_handle_callback : NULL, rpc ? rpc : NULL);
+    client = clnt_tli_create(RPC_ANYFD, nconf, addr, NFS41_RPC_PROGRAM,
+        NFS41_RPC_VERSION, wsize, rsize,
+        rpc ? proc_cb_compound_res_adapter : NULL,
+        rpc ? nfs41_handle_callback_adapter : NULL, rpc ? rpc : NULL);
     if (client) {
         *client_out = client;
         status = NO_ERROR;

--- a/base/services/nfsd/service.c
+++ b/base/services/nfsd/service.c
@@ -286,11 +286,11 @@ BOOL ReportStatusToSCMgr(DWORD dwCurrentState,
 //
 //  COMMENTS:
 //
-VOID AddToMessageLog(LPTSTR lpszMsg)
+VOID AddToMessageLog(LPCTSTR lpszMsg)
 {
    TCHAR szMsg [(sizeof(SZSERVICENAME) / sizeof(TCHAR)) + 100 ];
    HANDLE  hEventSource;
-   LPTSTR  lpszStrings[2];
+   LPCTSTR lpszStrings[2];
 
    if ( !bDebug )
    {

--- a/base/services/nfsd/service.h
+++ b/base/services/nfsd/service.h
@@ -116,7 +116,7 @@ extern "C" {
 
 
 //
-//  FUNCTION: AddToMessageLog(LPTSTR lpszMsg)
+//  FUNCTION: AddToMessageLog(LPCTSTR lpszMsg)
 //
 //  PURPOSE: Allows any thread to log an error message
 //
@@ -126,7 +126,7 @@ extern "C" {
 //  RETURN VALUE:
 //    none
 //
-   void AddToMessageLog(LPTSTR lpszMsg);
+   void AddToMessageLog(LPCTSTR lpszMsg);
 //////////////////////////////////////////////////////////////////////////////
 
 


### PR DESCRIPTION
## Purpose

Fix the nfsd amd64 build by aligning local prototypes with the APIs they call.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: