### PR TITLE
[SHELLBTRFS] Fix to_wstring ambiguity with GCC 15

### DIFF
--- a/dll/shellext/shellbtrfs/shellext.h
+++ b/dll/shellext/shellbtrfs/shellext.h
@@ -388,7 +388,7 @@ private:
     string msg;
 };
 
-#if defined(__REACTOS__) && defined(__GNUC__) && __GNUC__ < 15
+#if defined(__REACTOS__) && !(defined(__GNUC__) && __GNUC__ >= 15)
 inline wstring to_wstring(uint8_t a) { WCHAR buffer[16]; swprintf(buffer, L"%d", a); return wstring(buffer); }
 inline wstring to_wstring(uint16_t a) { WCHAR buffer[16]; swprintf(buffer, L"%d", a); return wstring(buffer); }
 inline wstring to_wstring(uint32_t a) { WCHAR buffer[32]; swprintf(buffer, L"%ld", a); return wstring(buffer); }

--- a/dll/shellext/shellbtrfs/shellext.h
+++ b/dll/shellext/shellbtrfs/shellext.h
@@ -388,8 +388,8 @@ private:
     string msg;
 };
 
-#ifdef __REACTOS__
-inline wstring to_wstring(uint8_t a) { WCHAR buffer[16]; swprintf(buffer, L"%d", a); return wstring(buffer); } 
+#if defined(__REACTOS__) && defined(__GNUC__) && __GNUC__ < 15
+inline wstring to_wstring(uint8_t a) { WCHAR buffer[16]; swprintf(buffer, L"%d", a); return wstring(buffer); }
 inline wstring to_wstring(uint16_t a) { WCHAR buffer[16]; swprintf(buffer, L"%d", a); return wstring(buffer); }
 inline wstring to_wstring(uint32_t a) { WCHAR buffer[32]; swprintf(buffer, L"%ld", a); return wstring(buffer); }
 inline wstring to_wstring(uint64_t a) { WCHAR buffer[64]; swprintf(buffer, L"%I64d", a); return wstring(buffer); }


### PR DESCRIPTION
## Purpose

Fix the GCC 15 `shellbtrfs` build by guarding the custom `to_wstring` overloads in `shellext.h` with `__GNUC__ < 15`. 

These overloads were a workaround for older MinGW lacking `std::to_wstring`; GCC 15's libstdc++ now provides it, and `using namespace std` brings both sets into the same scope, causing ambiguous overload errors. 

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: