### PR TITLE
[LIBTIRPC] Fix amd64 pointer type errors for GCC 15

### DIFF
--- a/dll/3rdparty/libtirpc/src/auth_sspi.c
+++ b/dll/3rdparty/libtirpc/src/auth_sspi.c
@@ -422,7 +422,11 @@ authsspi_refresh(AUTH *auth, void *tmp)
                         0, 
                         &gd->ctx, 
                         &out_desc, 
-                        &ret_flags, 
+#ifndef __REACTOS__
+                        &ret_flags,
+#else
+                        (ULONG *)&ret_flags,
+#endif
                         &gd->expiry);
 #endif
 		if (recv_tokenp != SSPI_C_NO_BUFFER) {
@@ -721,7 +725,11 @@ uint32_t sspi_verify_mic(void *dummy, u_int seq, sspi_buffer_desc *bufin,
     log_hexdump(0, "sspi_verify_mic: calculating checksum over", bufin->value, bufin->length, 0);
     log_hexdump(0, "sspi_verify_mic: received checksum ", bufout->value, bufout->length, 0);
 
+#ifndef __REACTOS__
     return VerifySignature(ctx, &desc, seq, qop_state);
+#else
+    return VerifySignature(ctx, &desc, seq, (PULONG)qop_state);
+#endif
 }
 
 void sspi_release_buffer(sspi_buffer_desc *buf)

--- a/dll/3rdparty/libtirpc/src/auth_time.c
+++ b/dll/3rdparty/libtirpc/src/auth_time.c
@@ -252,7 +252,11 @@ __rpc_get_time_offset(td, srv, thost, uaddr, netid)
 	void			(*oldsig)() = NULL; /* old alarm handler */
 #endif
 	struct sockaddr_in	sin;
+#ifndef __REACTOS__
 	SOCKET			s = RPC_ANYSOCK;
+#else
+	int			s = -1;
+#endif
 	socklen_t len;
 	int			type = 0;
 

--- a/dll/3rdparty/libtirpc/src/pmap_getmaps.c
+++ b/dll/3rdparty/libtirpc/src/pmap_getmaps.c
@@ -66,7 +66,11 @@ pmap_getmaps(address)
 	 struct sockaddr_in *address;
 {
 	struct pmaplist *head = NULL;
+#ifndef __REACTOS__
 	SOCKET sock = INVALID_SOCKET;
+#else
+	int sock = -1;
+#endif
 	struct timeval minutetimeout;
 	CLIENT *client;
 

--- a/dll/3rdparty/libtirpc/src/xdr_rec.c
+++ b/dll/3rdparty/libtirpc/src/xdr_rec.c
@@ -421,7 +421,11 @@ xdrrec_getoutbase(xdrs)
 	switch (xdrs->x_op) {
 
 	case XDR_ENCODE:
+#ifndef __REACTOS__
         buf = rstrm->out_base;
+#else
+        buf = (int32_t *)rstrm->out_base;
+#endif
 		break;
 
 	case XDR_DECODE:


### PR DESCRIPTION
## Purpose

this will fix GCC 15 build errors in libtirpc, the 3rdparty package.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: