### PR TITLE
[NTOS:KE] Fix interlocked pointer types in amd64 freeze.c for GCC 15

### DIFF
--- a/ntoskrnl/ke/amd64/freeze.c
+++ b/ntoskrnl/ke/amd64/freeze.c
@@ -109,7 +109,7 @@ KxFreezeExecution(
     }
 
     /* Try to acquire the freeze owner */
-    while (InterlockedCompareExchangePointer(&KiFreezeOwner, CurrentPrcb, NULL))
+    while (InterlockedCompareExchangePointer((volatile PVOID *)&KiFreezeOwner, CurrentPrcb, NULL))
     {
         /* Someone else was faster. We expect an NMI to freeze any time.
            Spin here until the freeze owner is available. */
@@ -199,7 +199,7 @@ KxThawExecution(
     CurrentPrcb->IpiFrozen = IPI_FROZEN_STATE_RUNNING;
 
     /* Release the freeze owner */
-    InterlockedExchangePointer(&KiFreezeOwner, NULL);
+    InterlockedExchangePointer((volatile PVOID *)&KiFreezeOwner, NULL);
 }
 
 KCONTINUE_STATUS

--- a/ntoskrnl/ke/amd64/freeze.c
+++ b/ntoskrnl/ke/amd64/freeze.c
@@ -109,7 +109,7 @@ KxFreezeExecution(
     }
 
     /* Try to acquire the freeze owner */
-    while (InterlockedCompareExchangePointer((volatile PVOID *)&KiFreezeOwner, CurrentPrcb, NULL))
+    while (InterlockedCompareExchangePointer((PVOID *)&KiFreezeOwner, CurrentPrcb, NULL))
     {
         /* Someone else was faster. We expect an NMI to freeze any time.
            Spin here until the freeze owner is available. */
@@ -199,7 +199,7 @@ KxThawExecution(
     CurrentPrcb->IpiFrozen = IPI_FROZEN_STATE_RUNNING;
 
     /* Release the freeze owner */
-    InterlockedExchangePointer((volatile PVOID *)&KiFreezeOwner, NULL);
+    InterlockedExchangePointer((PVOID *)&KiFreezeOwner, NULL);
 }
 
 KCONTINUE_STATUS


### PR DESCRIPTION
## Purpose

Cast &KiFreezeOwner to volatile PVOID * at interlocked call sites to fix GCC 15 pointer type errors

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: