### PR TITLE
[BTRFS] Add ZwQueryInformationProcess declaration for GCC 15

### DIFF
--- a/drivers/filesystems/btrfs/btrfs_drv.h
+++ b/drivers/filesystems/btrfs/btrfs_drv.h
@@ -1920,7 +1920,7 @@ typedef struct _PEB {
 } PEB,*PPEB;
 #endif /* __REACTOS__ */
 
-#if defined(_MSC_VER) || (defined(__REACTOS__) && __GNUC__ >= 15)
+#if defined(_MSC_VER) || (defined(__REACTOS__) && defined(__GNUC__) && __GNUC__ >= 15)
 __kernel_entry
 NTSTATUS NTAPI ZwQueryInformationProcess(
     IN HANDLE ProcessHandle,

--- a/drivers/filesystems/btrfs/btrfs_drv.h
+++ b/drivers/filesystems/btrfs/btrfs_drv.h
@@ -1920,7 +1920,7 @@ typedef struct _PEB {
 } PEB,*PPEB;
 #endif /* __REACTOS__ */
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || __GNUC__ >= 15
 __kernel_entry
 NTSTATUS NTAPI ZwQueryInformationProcess(
     IN HANDLE ProcessHandle,

--- a/drivers/filesystems/btrfs/btrfs_drv.h
+++ b/drivers/filesystems/btrfs/btrfs_drv.h
@@ -1920,7 +1920,7 @@ typedef struct _PEB {
 } PEB,*PPEB;
 #endif /* __REACTOS__ */
 
-#if defined(_MSC_VER) || __GNUC__ >= 15
+#if defined(_MSC_VER) || (defined(__REACTOS__) && __GNUC__ >= 15)
 __kernel_entry
 NTSTATUS NTAPI ZwQueryInformationProcess(
     IN HANDLE ProcessHandle,

--- a/drivers/filesystems/btrfs/btrfs_drv.h
+++ b/drivers/filesystems/btrfs/btrfs_drv.h
@@ -1920,7 +1920,7 @@ typedef struct _PEB {
 } PEB,*PPEB;
 #endif /* __REACTOS__ */
 
-#if defined(_MSC_VER) || (defined(__REACTOS__) && defined(__GNUC__) && __GNUC__ >= 15)
+#ifdef __REACTOS__
 __kernel_entry
 NTSTATUS NTAPI ZwQueryInformationProcess(
     IN HANDLE ProcessHandle,


### PR DESCRIPTION
## Purpose

Extend the ZwQueryInformationProcess forward declaration to GCC >= 15. The function is not exposed by WDK headers, the declaration was already needed for MSVC, and GCC 15 now also rejects implicit function declarations

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: