### PR TITLE
[GCC-COMPAT] Add snprintf shim for GCC 15 libmsvcrt import

### DIFF
--- a/sdk/lib/gcc-compat/CMakeLists.txt
+++ b/sdk/lib/gcc-compat/CMakeLists.txt
@@ -9,7 +9,8 @@ list(APPEND SOURCE
 
 if(DLL_EXPORT_VERSION LESS 0x600)
     list(APPEND SOURCE
-        rand_s.c)
+        rand_s.c
+        snprintf_compat.c)
 endif()
 
 add_library(stdc++compat ${SOURCE})

--- a/sdk/lib/gcc-compat/snprintf_compat.c
+++ b/sdk/lib/gcc-compat/snprintf_compat.c
@@ -1,0 +1,29 @@
+/*
+ * PROJECT:     GCC C++ support library
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     Local snprintf to override GCC 15 libmsvcrt import stub
+ * COPYRIGHT:   Copyright 2026 ReactOS Team
+ */
+
+#include <stdio.h>
+#include <stdarg.h>
+
+#undef snprintf
+
+int __cdecl snprintf(char *s, size_t n, const char *fmt, ...)
+{
+    int ret;
+    va_list ap;
+    va_start(ap, fmt);
+    ret = _vsnprintf(s, n, fmt, ap);
+    va_end(ap);
+    if (s && n > 0)
+        s[n - 1] = '\0';
+    return ret;
+}
+
+#ifdef _M_IX86
+void *_imp__snprintf = snprintf;
+#else
+void *__imp_snprintf = snprintf;
+#endif


### PR DESCRIPTION
## Purpose

Provide a local snprintf in the gcc-compat layer to override the import stub that GCC 15's libmsvcrt.a now introduces via UCRT extra objects. ReactOS's 0x502 msvcrt.dll does not export snprintf, the compat shim wraps _vsnprintf and prevents C++ binaries from failing at runtime with "procedure entry point snprintf could not be located"

<img width="1002" height="823" alt="Screenshot From 2026-03-26 01-47-44" src="https://github.com/user-attachments/assets/a184b2d4-c81f-4214-832b-5b6d10abd04f" />

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: