### PR TITLE
[NTOS][FREELDR] Expand amd64 physical memory support to 64GB

### DIFF
--- a/boot/freeldr/freeldr/arch/realmode/amd64.S
+++ b/boot/freeldr/freeldr/arch/realmode/amd64.S
@@ -204,33 +204,41 @@ BuildPageTables:
     xor di, di
 
     /* One entry in the PML4 pointing to PDP */
-    mov eax, PDP_ADDRESS
-    or eax, HEX(0F)
+    mov eax, PDP_ADDRESS + HEX(0F)
     stosd
 
-    /* clear rest */
+    /* clear rest of PML4 */
     xor eax, eax
     mov cx, 1023
     rep stosd
 
-    /* One entry in the PDP pointing to PD */
-    mov eax, PD_ADDRESS
-    or eax, HEX(0F)
+    /* Four entries in the PDP pointing to PD0 through PD3 (4GB identity map).
+     * eax upper 16 bits are 0 from the PML4 clear above. */
+    mov ax, PD_ADDRESS + HEX(0F)
+    mov cx, 4
+.FillPDP:
     stosd
+    push ax
+    xor ax, ax
+    stosd
+    pop ax
+    add ax, HEX(1000)
+    dec cx
+    jnz .FillPDP
 
-    /* clear rest */
+    /* clear rest of PDP (508 entries * 2 dwords = 1016 dwords) */
     xor eax, eax
-    mov ecx, 1023
+    mov ecx, 1016
     rep stosd
 
-    /* 512 entries in the PD, each defining a 2MB page each */
-    mov ecx, 512
+    /* 2048 entries across 4 PD pages (PD0-PD3), each defining a 2MB large page */
+    mov ecx, 2048
     mov eax, HEX(008f)
 
 .Bpt2:
     mov es:[di], eax
     mov dword ptr es:[di + 4], 0
-    add eax, 512 * 4096 // add 512 4k pages
+    add eax, 512 * 4096 // add 2MB per entry
     add di, 8
 
     /* Loop all PDEs */

--- a/boot/freeldr/freeldr/include/arch/pc/x86common.h
+++ b/boot/freeldr/freeldr/include/arch/pc/x86common.h
@@ -7,11 +7,15 @@
 #ifdef _M_AMD64
 #define PML4_ADDRESS        HEX(1000) /* One page PML4 page table */
 #define PDP_ADDRESS         HEX(2000) /* One page PDP page table */
-#define PD_ADDRESS          HEX(3000) /* One page PD page table */
-#endif
+#define PD_ADDRESS          HEX(3000) /* Four pages PD page tables (0x3000-0x6FFF) for 4GB identity map */
+#define BIOSCALLBUFFER      HEX(7000) /* After page tables; reuses dead TEMP* area (temporal non-overlap) */
+#define STACK16ADDR         HEX(7F00) /* The 16-bit stack top will be at 0000:7F00 */
+#define BSS_START           HEX(7F00)
+#else
 #define BIOSCALLBUFFER      HEX(4000) /* Buffer to store temporary data for any Int386() call */
 #define STACK16ADDR         HEX(6F00) /* The 16-bit stack top will be at 0000:6F00 */
 #define BSS_START           HEX(6F00)
+#endif
 #define STACKLOW            HEX(8000)
 #define STACKADDR           HEX(F000) /* The 32/64-bit stack top will be at 0000:F000, or 0xF000 */
 #define FREELDR_BASE        HEX(F800)

--- a/boot/freeldr/freeldr/include/mm.h
+++ b/boot/freeldr/freeldr/include/mm.h
@@ -68,10 +68,12 @@ typedef struct _FREELDR_MEMORY_DESCRIPTOR
 #define MM_PAGE_SIZE    4096
 #define MM_PAGE_MASK    0xFFF
 #define MM_PAGE_SHIFT    12
-//HACK: ReactOS AMD64 can't handle the full memory range yet CORE-20265
+// CORE-20265: Expanded from 0x1FFFFF (8GB) to 0xFFFFFF (64GB).
+// The original 36-bit value (0xFFFFFFFFF = 262TB) produces impractically
+// large page lookup tables. 64GB is sufficient for typical VMs/hardware.
 //#define MM_MAX_PAGE        0xFFFFFFFFF /* 36 bits for the PFN */
-#define MM_MAX_PAGE        0x1FFFFF
-#define MM_MAX_PAGE_LOADER 0x3FFFF /* on x64 freeldr only maps 1 GB */
+#define MM_MAX_PAGE        0xFFFFFF
+#define MM_MAX_PAGE_LOADER 0xFFFFF /* on x64 freeldr maps 4 GB */
 
 #define MM_SIZE_TO_PAGES(a)  \
     ( ((a) >> MM_PAGE_SHIFT) + ((a) & MM_PAGE_MASK ? 1 : 0) )

--- a/boot/freeldr/freeldr/ntldr/wlmemory.c
+++ b/boot/freeldr/freeldr/ntldr/wlmemory.c
@@ -63,8 +63,7 @@ MempAddMemoryBlock(IN OUT PLOADER_PARAMETER_BLOCK LoaderBlock,
     TRACE("MempAddMemoryBlock(BasePage=0x%lx, PageCount=0x%lx, Type=%ld)\n",
           BasePage, PageCount, Type);
 
-    /* Check for memory block after 4GB - we don't support it yet
-       Note: Even last page before 4GB limit is not supported */
+    /* Check for memory block beyond the supported range */
     if (BasePage >= MM_MAX_PAGE)
     {
         /* Just skip this, without even adding to MAD list */
@@ -312,13 +311,13 @@ WinLdrSetupMemoryLayout(IN OUT PLOADER_PARAMETER_BLOCK LoaderBlock)
     for (i = 0; i < BiosMemoryMapEntryCount; i++)
     {
         /* Check if its higher than the lookup table */
-        if (BiosMemoryMap->BasePage > MmGetHighestPhysicalPage())
+        if (BiosMemoryMap[i].BasePage > MmGetHighestPhysicalPage())
         {
             /* Copy this descriptor */
             MempAddMemoryBlock(LoaderBlock,
-                               BiosMemoryMap->BasePage,
-                               BiosMemoryMap->PageCount,
-                               BiosMemoryMap->MemoryType);
+                               BiosMemoryMap[i].BasePage,
+                               BiosMemoryMap[i].PageCount,
+                               BiosMemoryMap[i].MemoryType);
         }
     }
 

--- a/dll/win32/kernel32/client/heapmem.c
+++ b/dll/win32/kernel32/client/heapmem.c
@@ -1300,12 +1300,12 @@ GlobalMemoryStatusEx(LPMEMORYSTATUSEX lpBuffer)
                                       BaseStaticServerData->SysInfo.NumberOfPhysicalPages;
 
     /* Save physical memory */
-    PhysicalMemory = BaseStaticServerData->SysInfo.NumberOfPhysicalPages *
+    PhysicalMemory = (ULONGLONG)BaseStaticServerData->SysInfo.NumberOfPhysicalPages *
                      BaseStaticServerData->SysInfo.PageSize;
     lpBuffer->ullTotalPhys = PhysicalMemory;
 
     /* Now save available physical memory */
-    PhysicalMemory = PerformanceInfo.AvailablePages *
+    PhysicalMemory = (ULONGLONG)PerformanceInfo.AvailablePages *
                      BaseStaticServerData->SysInfo.PageSize;
     lpBuffer->ullAvailPhys = PhysicalMemory;
 

--- a/ntoskrnl/ex/init.c
+++ b/ntoskrnl/ex/init.c
@@ -1632,7 +1632,7 @@ Phase1InitializationDiscard(IN PVOID Context)
 
     /* Get total RAM size, in MiB */
     /* Round size up. Assumed to better match actual physical RAM size */
-    Size = ALIGN_UP_BY(MmNumberOfPhysicalPages * PAGE_SIZE, 1024 * 1024) / (1024 * 1024);
+    Size = ALIGN_UP_BY((SIZE_T)MmNumberOfPhysicalPages * PAGE_SIZE, 1024 * 1024) / (1024 * 1024);
 
     /* Create the string */
     StringBuffer = InitBuffer->VersionBuffer;

--- a/ntoskrnl/mm/amd64/init.c
+++ b/ntoskrnl/mm/amd64/init.c
@@ -308,8 +308,8 @@ MiBuildNonPagedPool(VOID)
     {
         /* Start with the minimum (256 KB) and add 32 KB for each MB above 4 */
         MmSizeOfNonPagedPoolInBytes = MmMinimumNonPagedPoolSize;
-        MmSizeOfNonPagedPoolInBytes += (MmNumberOfPhysicalPages - 1024) /
-                                       256 * MmMinAdditionNonPagedPoolPerMb;
+        MmSizeOfNonPagedPoolInBytes += (SIZE_T)((MmNumberOfPhysicalPages - 1024) /
+                                       256) * MmMinAdditionNonPagedPoolPerMb;
     }
 
     /* Check if the registy setting or our dynamic calculation was too high */
@@ -334,8 +334,8 @@ MiBuildNonPagedPool(VOID)
     {
         /* Start with the default (1MB) and add 400 KB for each MB above 4 */
         MmMaximumNonPagedPoolInBytes = MmDefaultMaximumNonPagedPool;
-        MmMaximumNonPagedPoolInBytes += (MmNumberOfPhysicalPages - 1024) /
-                                         256 * MmMaxAdditionNonPagedPoolPerMb;
+        MmMaximumNonPagedPoolInBytes += (SIZE_T)((MmNumberOfPhysicalPages - 1024) /
+                                         256) * MmMaxAdditionNonPagedPoolPerMb;
     }
 
     /* Don't let the maximum go too high */

--- a/ntoskrnl/mm/amd64/init.c
+++ b/ntoskrnl/mm/amd64/init.c
@@ -349,7 +349,7 @@ MiBuildNonPagedPool(VOID)
     MmMaximumNonPagedPoolInPages = MmMaximumNonPagedPoolInBytes >> PAGE_SHIFT;
 
     /* Non paged pool starts after the PFN database */
-    MmNonPagedPoolStart = MmPfnDatabase + MxPfnAllocation * PAGE_SIZE;
+    MmNonPagedPoolStart = (PUCHAR)MmPfnDatabase + MxPfnAllocation * PAGE_SIZE;
 
     /* Calculate the nonpaged pool expansion start region */
     MmNonPagedPoolExpansionStart = (PCHAR)MmNonPagedPoolStart +


### PR DESCRIPTION
## Purpose

On amd64, FreeLDR still capped physical memory at 0x1FFFFF pages (8GB), and its early page tables only identity-mapped the first 1GB. That is too restrictive for modern VMs and higher-memory test systems

This change raises the amd64 physical page limit to 0xFFFFFF pages (64GB), which keeps the page lookup table at a practical size while covering common real-world configurations. It also expands the loader mapping limit to 4GB and updates the amd64 real-mode page-table layout accordingly, including moving the low-memory scratch/buffer area so it does not overlap the additional page-directory pages.

related Links:
https://jira.reactos.org/browse/CORE-20265
https://github.com/reactos/reactos/pull/8226

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: