### PR TITLE
[GCC-COMPAT] Add mbsrtowcs shim for GCC 15

### DIFF
--- a/sdk/lib/gcc-compat/CMakeLists.txt
+++ b/sdk/lib/gcc-compat/CMakeLists.txt
@@ -9,6 +9,7 @@ list(APPEND SOURCE
 
 if(DLL_EXPORT_VERSION LESS 0x600)
     list(APPEND SOURCE
+        mbsrtowcs_compat.c
         rand_s.c)
 endif()
 

--- a/sdk/lib/gcc-compat/mbsrtowcs_compat.c
+++ b/sdk/lib/gcc-compat/mbsrtowcs_compat.c
@@ -32,7 +32,8 @@ size_t __cdecl mbsrtowcs(wchar_t *dst, const char **src, size_t len, void *ps)
     if (ret == (size_t)-1)
         return (size_t)-1;
 
-    if (dst) {
+    if (dst)
+    {
         if (ret < len)
             *src = NULL; /* null terminator was converted */
         else

--- a/sdk/lib/gcc-compat/mbsrtowcs_compat.c
+++ b/sdk/lib/gcc-compat/mbsrtowcs_compat.c
@@ -1,0 +1,49 @@
+/*
+ * PROJECT:     GCC C++ support library
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     mbsrtowcs shim for GCC 15 libwinpthread
+ * COPYRIGHT:   Copyright 2026 ReactOS Team
+ *
+ * GCC 15's libwinpthread references mbsrtowcs, which is only exported by
+ * ReactOS msvcrt for DLL_EXPORT_VERSION >= 0x600. Provide a shim that
+ * delegates to mbstowcs (always available).
+ *
+ * ReactOS CRT uses mbstate_t = int and only supports single-byte locales,
+ * so the state parameter is effectively unused.
+ */
+
+#include <stdlib.h>
+
+#undef mbsrtowcs
+
+size_t __cdecl mbsrtowcs(wchar_t *dst, const char **src, size_t len, void *ps)
+{
+    size_t ret;
+    const char *s;
+
+    (void)ps;
+
+    if (!src || !*src)
+        return 0;
+
+    s = *src;
+    ret = mbstowcs(dst, s, len);
+
+    if (ret == (size_t)-1)
+        return (size_t)-1;
+
+    if (dst) {
+        if (ret < len)
+            *src = NULL; /* null terminator was converted */
+        else
+            *src = s + ret;
+    }
+
+    return ret;
+}
+
+#ifdef _M_IX86
+void *_imp__mbsrtowcs = mbsrtowcs;
+#else
+void *__imp_mbsrtowcs = mbsrtowcs;
+#endif


### PR DESCRIPTION
## Purpose

this adds mbsrtowcs shim to gcc-compat for libwinpthread link failures in 0x502, needed for GCC15.2/mingw

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: