### PR TITLE
[GCC-COMPAT] Add strnlen/wcsnlen/wctype/wctob/btowc/fseeki64/ftelli64 shims for gcc 15

### DIFF
--- a/sdk/lib/gcc-compat/CMakeLists.txt
+++ b/sdk/lib/gcc-compat/CMakeLists.txt
@@ -9,7 +9,10 @@ list(APPEND SOURCE
 
 if(DLL_EXPORT_VERSION LESS 0x600)
     list(APPEND SOURCE
-        rand_s.c)
+        fseeki64_compat.c
+        rand_s.c
+        strnlen_compat.c
+        wchar_compat.c)
 endif()
 
 add_library(stdc++compat ${SOURCE})

--- a/sdk/lib/gcc-compat/fseeki64_compat.c
+++ b/sdk/lib/gcc-compat/fseeki64_compat.c
@@ -1,0 +1,36 @@
+/*
+ * PROJECT:     GCC C++ support library
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     _fseeki64/_ftelli64 shims for GCC 15 libstdc++
+ * COPYRIGHT:   Copyright 2026 ReactOS Team
+ *
+ * GCC 15's libstdc++ ext11-inst.o references _fseeki64 and _ftelli64 as
+ * DLL imports. _fseeki64 is version-gated to >= 0x600; _ftelli64 is not
+ * exported from msvcrt at all. Delegate to fseek/ftell (32-bit offset).
+ */
+
+/*
+ * Avoid including <stdio.h> — the CRT headers declare _fseeki64/_ftelli64
+ * with __declspec(dllimport), which conflicts with our local definitions.
+ */
+typedef struct _iobuf FILE;
+int __cdecl fseek(FILE *, long, int);
+long __cdecl ftell(FILE *);
+
+int __cdecl _fseeki64(FILE *stream, long long offset, int origin)
+{
+    return fseek(stream, (long)offset, origin);
+}
+
+long long __cdecl _ftelli64(FILE *stream)
+{
+    return (long long)ftell(stream);
+}
+
+#ifdef _M_IX86
+void *_imp___fseeki64 = _fseeki64;
+void *_imp___ftelli64 = _ftelli64;
+#else
+void *__imp__fseeki64 = _fseeki64;
+void *__imp__ftelli64 = _ftelli64;
+#endif

--- a/sdk/lib/gcc-compat/strnlen_compat.c
+++ b/sdk/lib/gcc-compat/strnlen_compat.c
@@ -1,0 +1,38 @@
+/*
+ * PROJECT:     GCC C++ support library
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     strnlen/wcsnlen shims for GCC 15 libmingwex
+ * COPYRIGHT:   Copyright 2026 ReactOS Team
+ *
+ * GCC 15's libmingwex references strnlen and wcsnlen, which ReactOS msvcrt
+ * only exports for DLL_EXPORT_VERSION >= 0x600.
+ */
+
+#include <stddef.h>
+
+#undef strnlen
+#undef wcsnlen
+
+size_t __cdecl strnlen(const char *s, size_t maxlen)
+{
+    size_t i;
+    for (i = 0; i < maxlen && s[i]; i++)
+        ;
+    return i;
+}
+
+size_t __cdecl wcsnlen(const wchar_t *s, size_t maxlen)
+{
+    size_t i;
+    for (i = 0; i < maxlen && s[i]; i++)
+        ;
+    return i;
+}
+
+#ifdef _M_IX86
+void *_imp__strnlen = strnlen;
+void *_imp__wcsnlen = wcsnlen;
+#else
+void *__imp_strnlen = strnlen;
+void *__imp_wcsnlen = wcsnlen;
+#endif

--- a/sdk/lib/gcc-compat/wchar_compat.c
+++ b/sdk/lib/gcc-compat/wchar_compat.c
@@ -1,0 +1,92 @@
+/*
+ * PROJECT:     GCC C++ support library
+ * LICENSE:     MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:     wctype/wctob/btowc shims for GCC 15 libstdc++
+ * COPYRIGHT:   Copyright 2026 ReactOS Team
+ *
+ * GCC 15's libstdc++ ctype_members.o references wctype, wctob, and btowc.
+ * wctype is only in MSVCR120 (not msvcrt at all); wctob and btowc are
+ * version-gated to DLL_EXPORT_VERSION >= 0x600.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#undef wctype
+#undef wctob
+#undef btowc
+
+/*
+ * MSVC CRT character classification bitmasks (used by iswctype).
+ */
+#define CRT_UPPER   0x0001
+#define CRT_LOWER   0x0002
+#define CRT_DIGIT   0x0004
+#define CRT_SPACE   0x0008
+#define CRT_PUNCT   0x0010
+#define CRT_CONTROL 0x0020
+#define CRT_BLANK   0x0040
+#define CRT_HEX     0x0080
+#define CRT_ALPHA   0x0103
+
+typedef unsigned short wctype_t;
+
+wctype_t __cdecl wctype(const char *property)
+{
+    static const struct {
+        const char *name;
+        wctype_t mask;
+    } props[] = {
+        { "alnum",  CRT_DIGIT | CRT_ALPHA },
+        { "alpha",  CRT_ALPHA },
+        { "cntrl",  CRT_CONTROL },
+        { "digit",  CRT_DIGIT },
+        { "graph",  CRT_DIGIT | CRT_PUNCT | CRT_ALPHA },
+        { "lower",  CRT_LOWER },
+        { "print",  CRT_DIGIT | CRT_PUNCT | CRT_BLANK | CRT_ALPHA },
+        { "punct",  CRT_PUNCT },
+        { "space",  CRT_SPACE },
+        { "upper",  CRT_UPPER },
+        { "xdigit", CRT_HEX },
+    };
+    unsigned int i;
+
+    for (i = 0; i < sizeof(props) / sizeof(props[0]); i++)
+    {
+        if (strcmp(property, props[i].name) == 0)
+            return props[i].mask;
+    }
+    return 0;
+}
+
+int __cdecl wctob(unsigned int c)
+{
+    char buf;
+    if (wctomb(&buf, (wchar_t)c) == 1)
+        return (unsigned char)buf;
+    return -1; /* EOF */
+}
+
+unsigned int __cdecl btowc(int c)
+{
+    wchar_t wc;
+    unsigned char uc;
+
+    if (c == -1)
+        return (unsigned int)-1; /* WEOF */
+
+    uc = (unsigned char)c;
+    if (mbtowc(&wc, (const char *)&uc, 1) == 1)
+        return (unsigned int)wc;
+    return (unsigned int)-1; /* WEOF */
+}
+
+#ifdef _M_IX86
+void *_imp__wctype = wctype;
+void *_imp__wctob = wctob;
+void *_imp__btowc = btowc;
+#else
+void *__imp_wctype = wctype;
+void *__imp_wctob = wctob;
+void *__imp_btowc = btowc;
+#endif


### PR DESCRIPTION
## Purpose

add strnlen/wcsnlen/wctype/wctob/btowc/fseeki64/ftelli64 shims to gcc-compat for gcc 15 libstdc++/libmingwex on i386 < 0x600 targets.
this is the last PR needed for GCC15 support 


result : 
<img width="400" height="303" alt="Screenshot From 2026-03-26 15-11-22" src="https://github.com/user-attachments/assets/6bfe59b5-4ff5-47cf-8231-e4564d9a6a04" />

<img width="400" height="303" alt="Screenshot From 2026-03-26 10-42-06" src="https://github.com/user-attachments/assets/62ceb58c-465b-4059-965d-cb8846d756b1" />

## TODO

_Use a TODO when your pull request is Work in Progress._

- [ ] 
- [ ] 

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: