### PR TITLE
[NTOSKRNL][SDK][CRT] Fix compiler warnings for amd64 build

### DIFF
--- a/dll/win32/msafd/misc/sndrcv.c
+++ b/dll/win32/msafd/misc/sndrcv.c
@@ -37,7 +37,7 @@ WSPAsyncSelect(IN  SOCKET Handle,
     if (!AsyncData)
     {
         MsafdReturnWithErrno( STATUS_INSUFFICIENT_RESOURCES, lpErrno, 0, NULL );
-        return INVALID_SOCKET;
+        return SOCKET_ERROR;
     }
 
     /* Change the Socket to Non Blocking */
@@ -909,7 +909,7 @@ WSPSendTo(SOCKET Handle,
         if (!BindAddress)
         {
             MsafdReturnWithErrno(STATUS_INSUFFICIENT_RESOURCES, lpErrno, 0, NULL);
-            return INVALID_SOCKET;
+            return SOCKET_ERROR;
         }
 
         Socket->HelperData->WSHGetWildcardSockaddr(Socket->HelperContext,

--- a/ntoskrnl/config/i386/cmhardwr.c
+++ b/ntoskrnl/config/i386/cmhardwr.c
@@ -530,7 +530,7 @@ CmpInitializeMachineDependentConfiguration(IN PLOADER_PARAMETER_BLOCK LoaderBloc
                 if (Prcb->VendorString[0])
                 {
                     /* Convert it to Unicode */
-                    RtlInitAnsiString(&TempString, Prcb->VendorString);
+                    RtlInitAnsiString(&TempString, (PCSZ)Prcb->VendorString);
                     if (NT_SUCCESS(RtlAnsiStringToUnicodeString(&Data, &TempString, TRUE)))
                     {
                         /* Add it to the registry */

--- a/ntoskrnl/ex/dbgctrl.c
+++ b/ntoskrnl/ex/dbgctrl.c
@@ -417,4 +417,7 @@ NtSystemDebugControl(
         _SEH2_YIELD(return _SEH2_GetExceptionCode());
     }
     _SEH2_END;
+
+    /* Unreachable */
+    return STATUS_UNSUCCESSFUL;
 }

--- a/ntoskrnl/include/internal/probe.h
+++ b/ntoskrnl/include/internal/probe.h
@@ -64,6 +64,7 @@
  * STATUS_DATATYPE_MISALIGNMENT -- Indicates the address of the buffer in memory is
  * not aligned to the required alignment set.
  */
+__attribute__((unused))
 static
 __inline
 NTSTATUS
@@ -213,6 +214,7 @@ DefaultSetInfoBufferCheck(
  * from an object. This is typically with query NT syscalls where a caller has to query the actual
  * buffer length needed to store the queried information before doing a "real" query in the first place.
  */
+__attribute__((unused))
 static
 __inline
 NTSTATUS

--- a/ntoskrnl/kdbg/kdb.c
+++ b/ntoskrnl/kdbg/kdb.c
@@ -124,6 +124,7 @@ KdbpKdbTrapFrameFromKernelStack(
 
     RtlZeroMemory(KdbTrapFrame, sizeof(KDB_KTRAP_FRAME));
     StackPtr = (ULONG_PTR *) KernelStack;
+    UNREFERENCED_PARAMETER(StackPtr);
 #ifdef _M_IX86
     KdbTrapFrame->Ebp = StackPtr[3];
     KdbTrapFrame->Edi = StackPtr[4];

--- a/ntoskrnl/kdbg/kdb_cli.c
+++ b/ntoskrnl/kdbg/kdb_cli.c
@@ -988,7 +988,7 @@ KdbpCmdRegs(
     else if (Argv[0][0] == 'c') /* cregs */
     {
         ULONG Cr0, Cr2, Cr3, Cr4;
-        KDESCRIPTOR Gdtr = {0, 0, 0}, Idtr = {0, 0, 0};
+        KDESCRIPTOR Gdtr = {{0}}, Idtr = {{0}};
         USHORT Ldtr, Tr;
         static const PCHAR Cr0Bits[32] = { " PE", " MP", " EM", " TS", " ET", " NE", NULL, NULL,
                                            NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,

--- a/ntoskrnl/kdbg/kdb_cli.c
+++ b/ntoskrnl/kdbg/kdb_cli.c
@@ -988,7 +988,7 @@ KdbpCmdRegs(
     else if (Argv[0][0] == 'c') /* cregs */
     {
         ULONG Cr0, Cr2, Cr3, Cr4;
-        KDESCRIPTOR Gdtr = {{0}}, Idtr = {{0}};
+        KDESCRIPTOR Gdtr = {0}, Idtr = {0};
         USHORT Ldtr, Tr;
         static const PCHAR Cr0Bits[32] = { " PE", " MP", " EM", " TS", " ET", " NE", NULL, NULL,
                                            NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,

--- a/sdk/include/reactos/probe.h
+++ b/sdk/include/reactos/probe.h
@@ -137,6 +137,7 @@ ProbeArrayForWrite(IN OUT PVOID ArrayPtr,
 }
 #endif /* _WIN32K_ */
 
+__attribute__((unused))
 static __inline
 NTSTATUS
 ProbeAndCaptureUnicodeString(OUT PUNICODE_STRING Dest,

--- a/sdk/lib/crt/math/libm_sse2/fma3_available.c
+++ b/sdk/lib/crt/math/libm_sse2/fma3_available.c
@@ -51,7 +51,7 @@ int __cdecl _set_FMA3_enable(int flag)
 
 int __fma3_lib_init(void);
 
-_CRTALLOC(".CRT$XIC") static _PIFV init_fma3 = __fma3_lib_init;
+_CRTALLOC(".CRT$XIC") static __attribute__((used)) _PIFV init_fma3 = __fma3_lib_init;
 
 int __fma3_lib_init(void)
 {

--- a/sdk/lib/ucrt/heap/heapwalk.cpp
+++ b/sdk/lib/ucrt/heap/heapwalk.cpp
@@ -29,6 +29,9 @@ static int __cdecl try_walk(PROCESS_HEAP_ENTRY* const win32_entry) throw()
         return _HEAPBADNODE;
     }
     __endtry
+
+    /* Unreachable */
+    return _HEAPBADNODE;
 }
 
 // Walks the heap, returning information on one entry at a time.  If there are


### PR DESCRIPTION
## Purpose

Fix some compiler warnings for amd64 build.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: