### PR TITLE
[ANSI_SYNC_HACKS][NFSD] Small library to winesync ANSI code without kernel32_vista

### DIFF
--- a/base/services/nfsd/CMakeLists.txt
+++ b/base/services/nfsd/CMakeLists.txt
@@ -59,10 +59,10 @@ if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
     target_compile_options(nfsd PRIVATE -Wno-incompatible-function-pointer-types)
 endif()
 
-target_link_libraries(nfsd oldnames)
+target_link_libraries(nfsd ansi_sync_hacks oldnames)
 
 set_module_type(nfsd win32cui)
-add_importlibs(nfsd advapi32 iphlpapi kernel32_vista libtirpc msvcrt shell32 ws2_32 wldap32 kernel32 ntdll)
+add_importlibs(nfsd advapi32 iphlpapi libtirpc msvcrt shell32 ws2_32 wldap32 kernel32 ntdll_vista ntdll)
 add_pch(nfsd precomp.h SOURCE)
 
 add_cd_file(TARGET nfsd DESTINATION reactos/system32 FOR all)

--- a/sdk/lib/CMakeLists.txt
+++ b/sdk/lib/CMakeLists.txt
@@ -6,6 +6,7 @@ add_subdirectory(inflib)
 if(CMAKE_CROSSCOMPILING)
 
 add_subdirectory(3rdparty)
+add_subdirectory(ansi_sync_hacks)
 add_subdirectory(apisets)
 add_subdirectory(comsupp)
 add_subdirectory(conutils)

--- a/sdk/lib/ansi_sync_hacks/CMakeLists.txt
+++ b/sdk/lib/ansi_sync_hacks/CMakeLists.txt
@@ -1,0 +1,13 @@
+
+# This exists purely for syncing code that is compiled as an ANSI exe but depends on
+# Vista+ functionality, Eventually we won't need to maintain a 0x502 build and this
+# will be removed.
+
+remove_definitions(-D_WIN32_WINNT=0x502 -DWINVER=0x502)
+add_definitions(-D_WIN32_WINNT=0x600 -DWINVER=0x600)
+
+list(APPEND SOURCE
+   sync_hacks.c)
+
+add_library(ansi_sync_hacks STATIC ${SOURCE})
+add_dependencies(ansi_sync_hacks psdk)

--- a/sdk/lib/ansi_sync_hacks/sync_hacks.c
+++ b/sdk/lib/ansi_sync_hacks/sync_hacks.c
@@ -1,0 +1,169 @@
+/*
+ * This file exists due to some apps (e.g) nfsd.exe not suporting
+ * UNICODE This provides all the needed ANSI NT6 support while still allowing it to build on
+ * NT5.x builds.
+ */
+#define _KERNEL32_
+
+/* PSDK/NDK Headers */
+#define WIN32_NO_STATUS
+#include <windef.h>
+#include <winbase.h>
+
+/* Redefine NTDDI_VERSION to 2K3 SP1 to get correct NDK definitions */
+#undef NTDDI_VERSION
+#define NTDDI_VERSION NTDDI_WS03SP1
+
+#define NTOS_MODE_USER
+#include <ndk/iofuncs.h>
+#include <ndk/kefuncs.h>
+#include <ndk/obfuncs.h>
+#include <ndk/psfuncs.h>
+#include <ndk/rtlfuncs.h>
+
+#define NDEBUG
+#include <debug.h>
+
+VOID
+WINAPI
+AcquireSRWLockExclusive(PSRWLOCK Lock)
+{
+    RtlAcquireSRWLockExclusive((PRTL_SRWLOCK)Lock);
+}
+
+VOID
+WINAPI
+AcquireSRWLockShared(PSRWLOCK Lock)
+{
+    RtlAcquireSRWLockShared((PRTL_SRWLOCK)Lock);
+}
+
+VOID
+WINAPI
+InitializeConditionVariable(PCONDITION_VARIABLE ConditionVariable)
+{
+    RtlInitializeConditionVariable((PRTL_CONDITION_VARIABLE)ConditionVariable);
+}
+
+VOID
+WINAPI
+InitializeSRWLock(PSRWLOCK Lock)
+{
+    RtlInitializeSRWLock((PRTL_SRWLOCK)Lock);
+}
+
+VOID
+WINAPI
+ReleaseSRWLockExclusive(PSRWLOCK Lock)
+{
+    RtlReleaseSRWLockExclusive((PRTL_SRWLOCK)Lock);
+}
+
+VOID
+WINAPI
+ReleaseSRWLockShared(PSRWLOCK Lock)
+{
+    RtlReleaseSRWLockShared((PRTL_SRWLOCK)Lock);
+}
+
+FORCEINLINE
+PLARGE_INTEGER
+GetNtTimeout(PLARGE_INTEGER Time, DWORD Timeout)
+{
+    if (Timeout == INFINITE) return NULL;
+    Time->QuadPart = (ULONGLONG)Timeout * -10000;
+    return Time;
+}
+
+BOOL
+WINAPI
+SleepConditionVariableCS(PCONDITION_VARIABLE ConditionVariable, PCRITICAL_SECTION CriticalSection, DWORD Timeout)
+{
+    NTSTATUS Status;
+    LARGE_INTEGER Time;
+
+    Status = RtlSleepConditionVariableCS(ConditionVariable, (PRTL_CRITICAL_SECTION)CriticalSection, GetNtTimeout(&Time, Timeout));
+    if (!NT_SUCCESS(Status) || Status == STATUS_TIMEOUT)
+    {
+        SetLastError(RtlNtStatusToDosError(Status));
+        return FALSE;
+    }
+    return TRUE;
+}
+
+BOOL
+WINAPI
+SleepConditionVariableSRW(PCONDITION_VARIABLE ConditionVariable, PSRWLOCK Lock, DWORD Timeout, ULONG Flags)
+{
+    NTSTATUS Status;
+    LARGE_INTEGER Time;
+
+    Status = RtlSleepConditionVariableSRW(ConditionVariable, Lock, GetNtTimeout(&Time, Timeout), Flags);
+    if (!NT_SUCCESS(Status) || Status == STATUS_TIMEOUT)
+    {
+        SetLastError(RtlNtStatusToDosError(Status));
+        return FALSE;
+    }
+    return TRUE;
+}
+
+VOID
+WINAPI
+WakeAllConditionVariable(PCONDITION_VARIABLE ConditionVariable)
+{
+    RtlWakeAllConditionVariable((PRTL_CONDITION_VARIABLE)ConditionVariable);
+}
+
+VOID
+WINAPI
+WakeConditionVariable(PCONDITION_VARIABLE ConditionVariable)
+{
+    RtlWakeConditionVariable((PRTL_CONDITION_VARIABLE)ConditionVariable);
+}
+
+
+/*
+* @implemented
+*/
+BOOL WINAPI InitializeCriticalSectionEx(OUT LPCRITICAL_SECTION lpCriticalSection,
+                                        IN DWORD dwSpinCount,
+                                        IN DWORD flags)
+{
+    NTSTATUS Status;
+
+    /* FIXME: Flags ignored */
+
+    /* Initialize the critical section */
+    Status = RtlInitializeCriticalSectionAndSpinCount(
+        (PRTL_CRITICAL_SECTION)lpCriticalSection,
+        dwSpinCount);
+    if (!NT_SUCCESS(Status))
+    {
+        /* Set failure code */
+        SetLastError(RtlNtStatusToDosError(Status));
+        return FALSE;
+    }
+
+    /* Success */
+    return TRUE;
+}
+
+ULONGLONG
+WINAPI
+GetTickCount64(VOID)
+{
+    ULARGE_INTEGER TickCount;
+
+    while (TRUE)
+    {
+        TickCount.HighPart = (ULONG)SharedUserData->TickCount.High1Time;
+        TickCount.LowPart = SharedUserData->TickCount.LowPart;
+
+        if (TickCount.HighPart == (ULONG)SharedUserData->TickCount.High2Time) break;
+
+        YieldProcessor();
+     }
+
+     return (UInt32x32To64(TickCount.LowPart, SharedUserData->TickCountMultiplier) >> 24) +
+            (UInt32x32To64(TickCount.HighPart, SharedUserData->TickCountMultiplier) << 8);
+}


### PR DESCRIPTION
The point of kernel32_vista was to provide a dll that can be used for winesyncs to still have NT6 APIs.
We're now switching to an architecture where we'll have kernelbase OR a kernel32_win7 depending on NT target compile
but this means that for an ANSI exe such as this, we need an alternative solution.
Thankfully it's pretty much only for this but just in case i made it a library.

The next step to syncing kernelbase

## Testbot runs (Filled in by Devs)

N/A