### PR TITLE
[FREELDR:UEFI] Improve GPT partition detection logic

### DIFF
--- a/boot/freeldr/freeldr/arch/uefi/uefidisk.c
+++ b/boot/freeldr/freeldr/arch/uefi/uefidisk.c
@@ -370,8 +370,20 @@ UefiGetGptPartitionEntry(
     ULONGLONG StartSector = (StartLba * BlockSize) / 512;
     ULONGLONG SectorCount512 = (SectorCount * BlockSize) / 512;
 
+    /* saturate to ULONG MAX before casting because partitions >2TB silently get truncated if not */
+    if (StartSector > (ULONGLONG)MAXULONG)
+    {
+        WARN("GPT StartSector %llu exceeds ULONG, clamping\n", StartSector);
+        StartSector = (ULONGLONG)MAXULONG;
+    }
+
+    if (SectorCount512 > (ULONGLONG)MAXULONG)
+    {
+        WARN("GPT SectorCount512 %llu exceeds ULONG, clamping\n", SectorCount512);
+        SectorCount512 = (ULONGLONG)MAXULONG;
+    }
     PartitionTableEntry->SectorCountBeforePartition = (ULONG)StartSector;
-    PartitionTableEntry->PartitionSectorCount = (ULONG)SectorCount512;
+    PartitionTableEntry->PartitionSectorCount       = (ULONG)SectorCount512;
     PartitionTableEntry->SystemIndicator = PARTITION_GPT; /* Mark as GPT partition */
 
     return TRUE;
@@ -380,16 +392,16 @@ UefiGetGptPartitionEntry(
 static
 BOOLEAN
 UefiGetBootPartitionEntry(
-    IN UCHAR DriveNumber,
-    OUT PPARTITION_TABLE_ENTRY PartitionTableEntry,
-    OUT PULONG BootPartition)
+    IN  UCHAR                   DriveNumber,
+    OUT PPARTITION_TABLE_ENTRY  PartitionTableEntry,
+    OUT PULONG                  BootPartition)
 {
-    ULONG PartitionNum;
-    ULONG ArcDriveIndex;
-    EFI_BLOCK_IO* BootBlockIo;
-    EFI_STATUS Status;
-    ULONGLONG BootPartitionSize;
-    PARTITION_TABLE_ENTRY TempPartitionEntry;
+    ULONG                   PartitionNum;
+    ULONG                   ArcDriveIndex;
+    EFI_BLOCK_IO*           BootBlockIo;
+    EFI_STATUS              Status;
+    ULONGLONG               BootPartitionSize;
+    PARTITION_TABLE_ENTRY   TempPartitionEntry;
 
     TRACE("UefiGetBootPartitionEntry: DriveNumber: %d\n", DriveNumber - FIRST_BIOS_DISK);
 
@@ -412,8 +424,6 @@ UefiGetBootPartitionEntry(
         return FALSE;
     }
 
-    /* For logical partitions, UEFI Block I/O protocol starts at block 0 */
-    /* We need to find which partition it corresponds to by comparing sizes */
     BootPartitionSize = BootBlockIo->Media->LastBlock + 1;
 
     TRACE("Boot partition: Size=%llu blocks, BlockSize=%lu\n",
@@ -425,9 +435,7 @@ UefiGetBootPartitionEntry(
         TRACE("Boot handle is root device, using partition 0\n");
         *BootPartition = 0;
         if (PartitionTableEntry != NULL)
-        {
             RtlZeroMemory(PartitionTableEntry, sizeof(*PartitionTableEntry));
-        }
         return TRUE;
     }
 
@@ -438,23 +446,15 @@ UefiGetBootPartitionEntry(
 
     if (IsGpt)
     {
-        /* For GPT, iterate through GPT partition entries */
-        GPT_TABLE_HEADER GptHeader;
-        GPT_PARTITION_ENTRY GptEntry;
-        ULONG ArcDriveIndex = DriveNumber - FIRST_BIOS_DISK;
-        EFI_BLOCK_IO* RootBlockIo;
-        ULONG BlockSize;
-        ULONGLONG EntryLba;
-        ULONG EntryOffset;
-        ULONG EntriesPerBlock;
-        EFI_STATUS Status;
-        EFI_GUID UnusedGuid = EFI_PART_TYPE_UNUSED_GUID;
-
-        if (!UefiReadGptHeader(DriveNumber, &GptHeader))
-        {
-            ERR("Failed to read GPT header\n");
-            return FALSE;
-        }
+        /* FIX: No redundant second UefiReadGptHeader() call, no shadowed locals.
+         * GptHeader and ArcDriveIndex from the outer scope are reused directly. */
+        GPT_PARTITION_ENTRY  GptEntry;
+        EFI_BLOCK_IO*        RootBlockIo;
+        ULONG                BlockSize;
+        ULONGLONG            EntryLba;
+        ULONG                EntryOffset, EntriesPerBlock;
+        EFI_STATUS           GptStatus;
+        EFI_GUID             UnusedGuid = EFI_PART_TYPE_UNUSED_GUID;
 
         Status = GlobalSystemTable->BootServices->HandleProtocol(
             InternalUefiDisk[ArcDriveIndex].Handle,
@@ -464,48 +464,66 @@ UefiGetBootPartitionEntry(
         if (EFI_ERROR(Status) || RootBlockIo == NULL)
             return FALSE;
 
-        BlockSize = RootBlockIo->Media->BlockSize;
+        BlockSize       = RootBlockIo->Media->BlockSize;
         EntriesPerBlock = BlockSize / GptHeader.SizeOfPartitionEntry;
 
-        /* Iterate through GPT partition entries */
+        UCHAR   BootSector0[512];
+        BOOLEAN HaveBootSector0 = FALSE;
+        if (BootBlockIo->Media->BlockSize <= sizeof(BootSector0))
+        {
+            EFI_STATUS Bs = BootBlockIo->ReadBlocks(
+                BootBlockIo, BootBlockIo->Media->MediaId,
+                0, BootBlockIo->Media->BlockSize, BootSector0);
+            HaveBootSector0 = !EFI_ERROR(Bs);
+        }
+
         for (ULONG i = 0; i < GptHeader.NumberOfPartitionEntries; i++)
         {
-            EntryLba = GptHeader.PartitionEntryLba + (i / EntriesPerBlock);
+            EntryLba    = GptHeader.PartitionEntryLba + (i / EntriesPerBlock);
             EntryOffset = (i % EntriesPerBlock) * GptHeader.SizeOfPartitionEntry;
 
-            /* Read the block containing the partition entry */
-            Status = RootBlockIo->ReadBlocks(
-                RootBlockIo,
-                RootBlockIo->Media->MediaId,
-                EntryLba,
-                BlockSize,
-                DiskReadBuffer);
-
-            if (EFI_ERROR(Status))
+            GptStatus = RootBlockIo->ReadBlocks(
+                RootBlockIo, RootBlockIo->Media->MediaId,
+                EntryLba, BlockSize, DiskReadBuffer);
+            if (EFI_ERROR(GptStatus))
                 continue;
 
-            /* Extract partition entry */
-            RtlCopyMemory(&GptEntry, (PUCHAR)DiskReadBuffer + EntryOffset, sizeof(GPT_PARTITION_ENTRY));
+            RtlCopyMemory(&GptEntry, (PUCHAR)DiskReadBuffer + EntryOffset,
+                          sizeof(GPT_PARTITION_ENTRY));
 
-            /* Skip unused partitions */
             if (memcmp(&GptEntry.PartitionTypeGuid, &UnusedGuid, sizeof(EFI_GUID)) == 0)
                 continue;
 
-            /* Calculate partition size in blocks */
             ULONGLONG PartitionSizeBlocks = GptEntry.EndingLba - GptEntry.StartingLba + 1;
 
             TRACE("GPT Partition %lu: StartLba=%llu, EndLba=%llu, SizeBlocks=%llu\n",
                 i + 1, GptEntry.StartingLba, GptEntry.EndingLba, PartitionSizeBlocks);
 
-            /* Match partition by size (within 1 block tolerance for rounding) */
-            if (PartitionSizeBlocks == BootPartitionSize ||
-                (PartitionSizeBlocks > 0 && 
-                 (PartitionSizeBlocks - 1 <= BootPartitionSize && 
-                  BootPartitionSize <= PartitionSizeBlocks + 1)))
+            BOOLEAN LbaMatch = FALSE;
+            if (HaveBootSector0)
             {
-                TRACE("Found matching GPT partition %lu: Size matches (%llu blocks)\n",
-                    i + 1, BootPartitionSize);
+                UCHAR PartSector0[512];
+                GptStatus = RootBlockIo->ReadBlocks(
+                    RootBlockIo, RootBlockIo->Media->MediaId,
+                    GptEntry.StartingLba, BlockSize, PartSector0);
+                if (!EFI_ERROR(GptStatus) &&
+                    memcmp(BootSector0, PartSector0, BootBlockIo->Media->BlockSize) == 0)
+                {
+                    LbaMatch = TRUE;
+                    TRACE("GPT partition %lu matched by first-sector compare\n", i + 1);
+                }
+            }
 
+            BOOLEAN SizeMatch =
+                !HaveBootSector0 &&
+                (PartitionSizeBlocks == BootPartitionSize ||
+                 (PartitionSizeBlocks > 0 &&
+                  PartitionSizeBlocks - 1 <= BootPartitionSize &&
+                  BootPartitionSize       <= PartitionSizeBlocks + 1));
+
+            if (LbaMatch || SizeMatch)
+            {
+                TRACE("Found matching GPT partition %lu\n", i + 1);
                 *BootPartition = i + 1; /* GPT partitions are 1-indexed */
 
                 /* Convert GPT entry to MBR-style entry for compatibility */
@@ -513,9 +531,9 @@ UefiGetBootPartitionEntry(
                 {
                     RtlZeroMemory(PartitionTableEntry, sizeof(*PartitionTableEntry));
                     ULONGLONG StartSector = (GptEntry.StartingLba * BlockSize) / 512;
-                    ULONGLONG SectorCount = (PartitionSizeBlocks * BlockSize) / 512;
+                    ULONGLONG SectorCount  = (PartitionSizeBlocks * BlockSize) / 512;
                     PartitionTableEntry->SectorCountBeforePartition = (ULONG)StartSector;
-                    PartitionTableEntry->PartitionSectorCount = (ULONG)SectorCount;
+                    PartitionTableEntry->PartitionSectorCount       = (ULONG)SectorCount;
                     PartitionTableEntry->SystemIndicator = PARTITION_GPT;
                 }
                 return TRUE;
@@ -524,40 +542,28 @@ UefiGetBootPartitionEntry(
     }
     else
     {
-        /* MBR partition matching */
         PartitionNum = FIRST_PARTITION;
         while (DiskGetPartitionEntry(DriveNumber, PartitionNum, &TempPartitionEntry))
         {
             ULONGLONG PartitionSizeSectors = TempPartitionEntry.PartitionSectorCount;
-            ULONGLONG PartitionSizeBlocks;
-
-            /* Convert partition size from MBR sectors (always 512 bytes) to UEFI blocks */
-            /* MBR partition table always uses 512-byte sectors per specification */
-            /* UEFI Block I/O protocol reports sizes in device's BlockSize bytes */
-            /* Compare in bytes to avoid rounding issues, then convert to boot partition's block size */
-            ULONGLONG PartitionSizeBytes = PartitionSizeSectors * 512ULL;
-            PartitionSizeBlocks = PartitionSizeBytes / BootBlockIo->Media->BlockSize;
+            ULONGLONG PartitionSizeBytes   = PartitionSizeSectors * 512ULL;
+            ULONGLONG PartitionSizeBlocks  = PartitionSizeBytes / BootBlockIo->Media->BlockSize;
 
             TRACE("Partition %lu: SizeSectors=%llu, SizeBlocks=%llu\n",
                 PartitionNum, PartitionSizeSectors, PartitionSizeBlocks);
 
-            /* Match partition by size (within 1 block tolerance for rounding) */
             if (PartitionSizeBlocks == BootPartitionSize ||
-                (PartitionSizeBlocks > 0 && 
-                 (PartitionSizeBlocks - 1 <= BootPartitionSize && 
-                  BootPartitionSize <= PartitionSizeBlocks + 1)))
+                (PartitionSizeBlocks > 0 &&
+                 (PartitionSizeBlocks - 1 <= BootPartitionSize &&
+                  BootPartitionSize       <= PartitionSizeBlocks + 1)))
             {
                 TRACE("Found matching partition %lu: Size matches (%llu blocks)\n",
                     PartitionNum, BootPartitionSize);
-
                 *BootPartition = PartitionNum;
                 if (PartitionTableEntry != NULL)
-                {
                     RtlCopyMemory(PartitionTableEntry, &TempPartitionEntry, sizeof(*PartitionTableEntry));
-                }
                 return TRUE;
             }
-
             PartitionNum++;
         }
     }
@@ -568,9 +574,7 @@ UefiGetBootPartitionEntry(
         TRACE("Boot device is CD-ROM, using partition 0xFF\n");
         *BootPartition = 0xFF;
         if (PartitionTableEntry != NULL)
-        {
             RtlZeroMemory(PartitionTableEntry, sizeof(*PartitionTableEntry));
-        }
         return TRUE;
     }
 
@@ -581,9 +585,7 @@ UefiGetBootPartitionEntry(
     {
         *BootPartition = PartitionNum;
         if (PartitionTableEntry != NULL)
-        {
             RtlCopyMemory(PartitionTableEntry, &TempPartitionEntry, sizeof(*PartitionTableEntry));
-        }
         return TRUE;
     }
 

--- a/boot/freeldr/freeldr/arch/uefi/uefidisk.c
+++ b/boot/freeldr/freeldr/arch/uefi/uefidisk.c
@@ -446,7 +446,6 @@ UefiGetBootPartitionEntry(
 
     if (IsGpt)
     {
-        /* no more redundant second UefiReadGptHeader() call = no shadowed locals */
         GPT_PARTITION_ENTRY  GptEntry;
         EFI_BLOCK_IO*        RootBlockIo;
         ULONG                BlockSize;

--- a/boot/freeldr/freeldr/arch/uefi/uefidisk.c
+++ b/boot/freeldr/freeldr/arch/uefi/uefidisk.c
@@ -439,15 +439,14 @@ UefiGetBootPartitionEntry(
         return TRUE;
     }
 
-    /* Boot handle is a logical partition - find matching partition entry */
+    /* the boot handle is a logical partition so let's find a matching partition entry */
     /* Try to detect GPT first by reading GPT header */
     GPT_TABLE_HEADER GptHeader;
     BOOLEAN IsGpt = UefiReadGptHeader(DriveNumber, &GptHeader);
 
     if (IsGpt)
     {
-        /* FIX: No redundant second UefiReadGptHeader() call, no shadowed locals.
-         * GptHeader and ArcDriveIndex from the outer scope are reused directly. */
+        /* no more redundant second UefiReadGptHeader() call = no shadowed locals */
         GPT_PARTITION_ENTRY  GptEntry;
         EFI_BLOCK_IO*        RootBlockIo;
         ULONG                BlockSize;

--- a/boot/freeldr/freeldr/arch/uefi/uefidisk.c
+++ b/boot/freeldr/freeldr/arch/uefi/uefidisk.c
@@ -396,12 +396,12 @@ UefiGetBootPartitionEntry(
     OUT PPARTITION_TABLE_ENTRY  PartitionTableEntry,
     OUT PULONG                  BootPartition)
 {
-    ULONG                   PartitionNum;
-    ULONG                   ArcDriveIndex;
-    EFI_BLOCK_IO*           BootBlockIo;
-    EFI_STATUS              Status;
-    ULONGLONG               BootPartitionSize;
-    PARTITION_TABLE_ENTRY   TempPartitionEntry;
+    ULONG PartitionNum;
+    ULONG ArcDriveIndex;
+    EFI_BLOCK_IO* BootBlockIo;
+    EFI_STATUS Status;
+    ULONGLONG BootPartitionSize;
+    PARTITION_TABLE_ENTRY TempPartitionEntry;
 
     TRACE("UefiGetBootPartitionEntry: DriveNumber: %d\n", DriveNumber - FIRST_BIOS_DISK);
 
@@ -424,6 +424,8 @@ UefiGetBootPartitionEntry(
         return FALSE;
     }
 
+    /* For logical partitions, UEFI Block I/O protocol starts at block 0 */
+    /* We need to find which partition it corresponds to by comparing sizes */
     BootPartitionSize = BootBlockIo->Media->LastBlock + 1;
 
     TRACE("Boot partition: Size=%llu blocks, BlockSize=%lu\n",
@@ -446,13 +448,13 @@ UefiGetBootPartitionEntry(
 
     if (IsGpt)
     {
-        GPT_PARTITION_ENTRY  GptEntry;
-        EFI_BLOCK_IO*        RootBlockIo;
-        ULONG                BlockSize;
-        ULONGLONG            EntryLba;
-        ULONG                EntryOffset, EntriesPerBlock;
-        EFI_STATUS           GptStatus;
-        EFI_GUID             UnusedGuid = EFI_PART_TYPE_UNUSED_GUID;
+        GPT_PARTITION_ENTRY GptEntry;
+        EFI_BLOCK_IO* RootBlockIo;
+        ULONG BlockSize;
+        ULONGLONG EntryLba;
+        ULONG EntryOffset, EntriesPerBlock;
+        EFI_STATUS Status;
+        EFI_GUID UnusedGuid = EFI_PART_TYPE_UNUSED_GUID;
 
         Status = GlobalSystemTable->BootServices->HandleProtocol(
             InternalUefiDisk[ArcDriveIndex].Handle,
@@ -480,10 +482,10 @@ UefiGetBootPartitionEntry(
             EntryLba    = GptHeader.PartitionEntryLba + (i / EntriesPerBlock);
             EntryOffset = (i % EntriesPerBlock) * GptHeader.SizeOfPartitionEntry;
 
-            GptStatus = RootBlockIo->ReadBlocks(
+            Status = RootBlockIo->ReadBlocks(
                 RootBlockIo, RootBlockIo->Media->MediaId,
                 EntryLba, BlockSize, DiskReadBuffer);
-            if (EFI_ERROR(GptStatus))
+            if (EFI_ERROR(Status))
                 continue;
 
             RtlCopyMemory(&GptEntry, (PUCHAR)DiskReadBuffer + EntryOffset,
@@ -501,10 +503,10 @@ UefiGetBootPartitionEntry(
             if (HaveBootSector0)
             {
                 UCHAR PartSector0[512];
-                GptStatus = RootBlockIo->ReadBlocks(
+                Status = RootBlockIo->ReadBlocks(
                     RootBlockIo, RootBlockIo->Media->MediaId,
                     GptEntry.StartingLba, BlockSize, PartSector0);
-                if (!EFI_ERROR(GptStatus) &&
+                if (!EFI_ERROR(Status) &&
                     memcmp(BootSector0, PartSector0, BootBlockIo->Media->BlockSize) == 0)
                 {
                     LbaMatch = TRUE;

--- a/boot/freeldr/freeldr/arch/uefi/uefidisk.c
+++ b/boot/freeldr/freeldr/arch/uefi/uefidisk.c
@@ -392,9 +392,9 @@ UefiGetGptPartitionEntry(
 static
 BOOLEAN
 UefiGetBootPartitionEntry(
-    IN  UCHAR                   DriveNumber,
-    OUT PPARTITION_TABLE_ENTRY  PartitionTableEntry,
-    OUT PULONG                  BootPartition)
+    IN  UCHAR DriveNumber,
+    OUT PPARTITION_TABLE_ENTRY PartitionTableEntry,
+    OUT PULONG BootPartition)
 {
     ULONG PartitionNum;
     ULONG ArcDriveIndex;

--- a/boot/freeldr/freeldr/arch/uefi/uefidisk.c
+++ b/boot/freeldr/freeldr/arch/uefi/uefidisk.c
@@ -370,7 +370,6 @@ UefiGetGptPartitionEntry(
     ULONGLONG StartSector = (StartLba * BlockSize) / 512;
     ULONGLONG SectorCount512 = (SectorCount * BlockSize) / 512;
 
-    /* saturate to ULONG MAX before casting because partitions >2TB silently get truncated if not */
     if (StartSector > (ULONGLONG)MAXULONG)
     {
         WARN("GPT StartSector %llu exceeds ULONG, clamping\n", StartSector);
@@ -383,16 +382,15 @@ UefiGetGptPartitionEntry(
         SectorCount512 = (ULONGLONG)MAXULONG;
     }
     PartitionTableEntry->SectorCountBeforePartition = (ULONG)StartSector;
-    PartitionTableEntry->PartitionSectorCount       = (ULONG)SectorCount512;
+    PartitionTableEntry->PartitionSectorCount = (ULONG)SectorCount512;
     PartitionTableEntry->SystemIndicator = PARTITION_GPT; /* Mark as GPT partition */
 
     return TRUE;
 }
-
 static
 BOOLEAN
 UefiGetBootPartitionEntry(
-    IN  UCHAR DriveNumber,
+    IN UCHAR DriveNumber,
     OUT PPARTITION_TABLE_ENTRY PartitionTableEntry,
     OUT PULONG BootPartition)
 {
@@ -437,11 +435,13 @@ UefiGetBootPartitionEntry(
         TRACE("Boot handle is root device, using partition 0\n");
         *BootPartition = 0;
         if (PartitionTableEntry != NULL)
+        {
             RtlZeroMemory(PartitionTableEntry, sizeof(*PartitionTableEntry));
+        }
         return TRUE;
     }
 
-    /* the boot handle is a logical partition so let's find a matching partition entry */
+    /* Boot handle is a logical partition - find matching partition entry */
     /* Try to detect GPT first by reading GPT header */
     GPT_TABLE_HEADER GptHeader;
     BOOLEAN IsGpt = UefiReadGptHeader(DriveNumber, &GptHeader);
@@ -452,7 +452,8 @@ UefiGetBootPartitionEntry(
         EFI_BLOCK_IO* RootBlockIo;
         ULONG BlockSize;
         ULONGLONG EntryLba;
-        ULONG EntryOffset, EntriesPerBlock;
+        ULONG EntryOffset;
+        ULONG EntriesPerBlock;
         EFI_STATUS Status;
         EFI_GUID UnusedGuid = EFI_PART_TYPE_UNUSED_GUID;
 
@@ -464,10 +465,10 @@ UefiGetBootPartitionEntry(
         if (EFI_ERROR(Status) || RootBlockIo == NULL)
             return FALSE;
 
-        BlockSize       = RootBlockIo->Media->BlockSize;
+        BlockSize = RootBlockIo->Media->BlockSize;
         EntriesPerBlock = BlockSize / GptHeader.SizeOfPartitionEntry;
 
-        UCHAR   BootSector0[512];
+        UCHAR BootSector0[512];
         BOOLEAN HaveBootSector0 = FALSE;
         if (BootBlockIo->Media->BlockSize <= sizeof(BootSector0))
         {
@@ -477,23 +478,31 @@ UefiGetBootPartitionEntry(
             HaveBootSector0 = !EFI_ERROR(Bs);
         }
 
+        /* Iterate through GPT partition entries */
         for (ULONG i = 0; i < GptHeader.NumberOfPartitionEntries; i++)
         {
-            EntryLba    = GptHeader.PartitionEntryLba + (i / EntriesPerBlock);
+            EntryLba = GptHeader.PartitionEntryLba + (i / EntriesPerBlock);
             EntryOffset = (i % EntriesPerBlock) * GptHeader.SizeOfPartitionEntry;
 
+            /* Read the block containing the partition entry */
             Status = RootBlockIo->ReadBlocks(
-                RootBlockIo, RootBlockIo->Media->MediaId,
-                EntryLba, BlockSize, DiskReadBuffer);
+                RootBlockIo,
+                RootBlockIo->Media->MediaId,
+                EntryLba,
+                BlockSize,
+                DiskReadBuffer);
+
             if (EFI_ERROR(Status))
                 continue;
 
-            RtlCopyMemory(&GptEntry, (PUCHAR)DiskReadBuffer + EntryOffset,
-                          sizeof(GPT_PARTITION_ENTRY));
+            /* Extract partition entry */
+            RtlCopyMemory(&GptEntry, (PUCHAR)DiskReadBuffer + EntryOffset, sizeof(GPT_PARTITION_ENTRY));
 
+            /* Skip unused partitions */
             if (memcmp(&GptEntry.PartitionTypeGuid, &UnusedGuid, sizeof(EFI_GUID)) == 0)
                 continue;
 
+            /* Calculate partition size in blocks */
             ULONGLONG PartitionSizeBlocks = GptEntry.EndingLba - GptEntry.StartingLba + 1;
 
             TRACE("GPT Partition %lu: StartLba=%llu, EndLba=%llu, SizeBlocks=%llu\n",
@@ -514,12 +523,12 @@ UefiGetBootPartitionEntry(
                 }
             }
 
+            /* Match partition by size (within 1 block tolerance for rounding) */
             BOOLEAN SizeMatch =
-                !HaveBootSector0 &&
-                (PartitionSizeBlocks == BootPartitionSize ||
-                 (PartitionSizeBlocks > 0 &&
-                  PartitionSizeBlocks - 1 <= BootPartitionSize &&
-                  BootPartitionSize       <= PartitionSizeBlocks + 1));
+                PartitionSizeBlocks == BootPartitionSize ||
+                (PartitionSizeBlocks > 0 &&
+                 PartitionSizeBlocks - 1 <= BootPartitionSize &&
+                 BootPartitionSize <= PartitionSizeBlocks + 1);
 
             if (LbaMatch || SizeMatch)
             {
@@ -531,9 +540,9 @@ UefiGetBootPartitionEntry(
                 {
                     RtlZeroMemory(PartitionTableEntry, sizeof(*PartitionTableEntry));
                     ULONGLONG StartSector = (GptEntry.StartingLba * BlockSize) / 512;
-                    ULONGLONG SectorCount  = (PartitionSizeBlocks * BlockSize) / 512;
+                    ULONGLONG SectorCount = (PartitionSizeBlocks * BlockSize) / 512;
                     PartitionTableEntry->SectorCountBeforePartition = (ULONG)StartSector;
-                    PartitionTableEntry->PartitionSectorCount       = (ULONG)SectorCount;
+                    PartitionTableEntry->PartitionSectorCount = (ULONG)SectorCount;
                     PartitionTableEntry->SystemIndicator = PARTITION_GPT;
                 }
                 return TRUE;
@@ -542,26 +551,30 @@ UefiGetBootPartitionEntry(
     }
     else
     {
+        /* MBR partition matching */
         PartitionNum = FIRST_PARTITION;
         while (DiskGetPartitionEntry(DriveNumber, PartitionNum, &TempPartitionEntry))
         {
             ULONGLONG PartitionSizeSectors = TempPartitionEntry.PartitionSectorCount;
-            ULONGLONG PartitionSizeBytes   = PartitionSizeSectors * 512ULL;
-            ULONGLONG PartitionSizeBlocks  = PartitionSizeBytes / BootBlockIo->Media->BlockSize;
+            ULONGLONG PartitionSizeBytes = PartitionSizeSectors * 512ULL;
+            ULONGLONG PartitionSizeBlocks = PartitionSizeBytes / BootBlockIo->Media->BlockSize;
 
             TRACE("Partition %lu: SizeSectors=%llu, SizeBlocks=%llu\n",
                 PartitionNum, PartitionSizeSectors, PartitionSizeBlocks);
 
+            /* Match partition by size (within 1 block tolerance for rounding) */
             if (PartitionSizeBlocks == BootPartitionSize ||
                 (PartitionSizeBlocks > 0 &&
                  (PartitionSizeBlocks - 1 <= BootPartitionSize &&
-                  BootPartitionSize       <= PartitionSizeBlocks + 1)))
+                  BootPartitionSize <= PartitionSizeBlocks + 1)))
             {
                 TRACE("Found matching partition %lu: Size matches (%llu blocks)\n",
                     PartitionNum, BootPartitionSize);
                 *BootPartition = PartitionNum;
                 if (PartitionTableEntry != NULL)
+                {
                     RtlCopyMemory(PartitionTableEntry, &TempPartitionEntry, sizeof(*PartitionTableEntry));
+                }
                 return TRUE;
             }
             PartitionNum++;
@@ -574,7 +587,9 @@ UefiGetBootPartitionEntry(
         TRACE("Boot device is CD-ROM, using partition 0xFF\n");
         *BootPartition = 0xFF;
         if (PartitionTableEntry != NULL)
+        {
             RtlZeroMemory(PartitionTableEntry, sizeof(*PartitionTableEntry));
+        }
         return TRUE;
     }
 
@@ -585,7 +600,9 @@ UefiGetBootPartitionEntry(
     {
         *BootPartition = PartitionNum;
         if (PartitionTableEntry != NULL)
+        {
             RtlCopyMemory(PartitionTableEntry, &TempPartitionEntry, sizeof(*PartitionTableEntry));
+        }
         return TRUE;
     }
 


### PR DESCRIPTION
## Purpose

_Do a quick recap of your work here._

JIRA issue: None

Cleaned up a few things in the UEFI disk code that were giving me the itch.
## Proposed changes

_Describe what you propose to change/add/fix with this pull request._

- UefiGetBootPartitionEntry: it was calling UefiReadGptHeader twice and the second call shadowed the outer GptHeader and ArcDriveIndex vars with new locals so the first read was basically wasted. Collapsed it into one. Also swapped the partition matching logic from only size (which can break if two partitions happen to be the same size) to a first-sector byte comparison against the boot handle, with the old size logic now used as a fallback in case the read fails
- UefiGetGptPartitionEntry: the GPT start sector and sector count were compiuted as ULONGLONG then cast straight to ULONG with no check so i added saturation guards so disks over like aprox 2TB dont silently corrupt the partition entry, just WARNs and clamps instead

## TODO

_Use a TODO when your pull request is Work in Progress._

- [ ] Boot test on qemu x86 with gpt disk 
- [ ] Boot test on qemu x64 with gpt disk
- [ ] Check behaviour when two equal sized partitions exist on the same disk

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: