### PR TITLE
[VFATLIB] Fix the aligned read and write operations

### DIFF
--- a/sdk/lib/fslib/vfatlib/check/io.c
+++ b/sdk/lib/fslib/vfatlib/check/io.c
@@ -54,6 +54,11 @@ static int did_change = 0;
 static HANDLE fd;
 static LARGE_INTEGER CurrentOffset;
 
+#define ROUND_DOWN(n, align) ((n) & ~((align) - 1))
+#define ROUND_UP(n, align) ROUND_DOWN((n) + (align) - 1, (align))
+
+#define IS_ALIGNED(n, align) (((n) & ((align) - 1)) == 0)
+
 
 /**** Win32 / NT support ******************************************************/
 
@@ -285,20 +290,61 @@ void fs_read(off_t pos, int size, void *data)
     int got;
 
 #ifdef __REACTOS__
-	const size_t readsize_aligned = (size % 512) ? (size + (512 - (size % 512))) : size;
- 	const off_t seekpos_aligned = pos - (pos % 512);
- 	const size_t seek_delta = (size_t)(pos - seekpos_aligned);
-#if DBG
-	const size_t readsize = (size_t)(pos - seekpos_aligned) + readsize_aligned;
-#endif
-	char* tmpBuf = alloc(readsize_aligned);
-    if (lseek(fd, seekpos_aligned, 0) != seekpos_aligned) pdie("Seek to %lld",pos);
-    if ((got = read(fd, tmpBuf, readsize_aligned)) < 0) pdie("Read %d bytes at %lld",size,pos);
-	assert(got >= size);
-	got = size;
-	assert(seek_delta + size <= readsize);
-	memcpy(data, tmpBuf+seek_delta, size);
-	free(tmpBuf);
+    void *data_aligned = NULL;
+    off_t seekpos_aligned = pos;
+    size_t size_aligned = (size_t)size;
+
+    /* If the output buffer & lengths are not aligned, align those */
+    if (// !IS_ALIGNED(data, 512) ||
+        !IS_ALIGNED(size, (size_t)512) || !IS_ALIGNED(pos, (off_t)512))
+    {
+        /*
+         * Align the offset and the buffer length to sector boundaries,
+         * taking into account for cross-sector regions.
+         */
+        seekpos_aligned = ROUND_DOWN(pos, (off_t)512);
+        size_aligned = (size_t)(ROUND_UP(pos + size, (size_t)512) - seekpos_aligned);
+
+        data_aligned = alloc(size_aligned);
+        if (!data_aligned)
+            pdie("Not enough memory to allocate aligned buffer %d bytes for read", size_aligned);
+    }
+
+    /* Read it */
+    if (lseek(fd, seekpos_aligned, 0) != seekpos_aligned)
+        pdie("Seek to %lld", (long long)seekpos_aligned);
+    got = read(fd, data_aligned ? data_aligned : data, size_aligned);
+    if (got < 0)
+        pdie("Read %d bytes at %lld", size, (long long)pos);
+    assert(got >= size);
+    got = size;
+
+    /*
+     * If an aligned buffer was used, copy its contents
+     * back into the user buffer and free it.
+     */
+    if (data_aligned)
+    {
+        /*
+         * Compute the offset between the user's buffer start and
+         * its aligned value, and store it in 'seekpos_aligned'.
+         */
+        seekpos_aligned = pos - seekpos_aligned;
+
+        /* Be sure the read data actually intersects the user's buffer area */
+        if (size_aligned > seekpos_aligned)
+        {
+            size_aligned = min(size_aligned - seekpos_aligned, size);
+            memcpy(data, (char*)data_aligned + seekpos_aligned, size_aligned);
+        }
+        else
+        {
+            size_aligned = 0;
+        }
+
+        free(data_aligned);
+    }
+
 #else
     if (lseek(fd, pos, 0) != pos)
 	pdie("Seek to %lld", (long long)pos);
@@ -325,11 +371,23 @@ int fs_test(off_t pos, int size)
     int okay;
 
 #ifdef __REACTOS__
-	const size_t readsize_aligned = (size % 512) ? (size + (512 - (size % 512))) : size;        // TMN:
-	const off_t seekpos_aligned = pos - (pos % 512);                   // TMN:
-    scratch = alloc(readsize_aligned);
-    if (lseek(fd, seekpos_aligned, 0) != seekpos_aligned) pdie("Seek to %lld",pos);
-    okay = read(fd, scratch, readsize_aligned) == (int)readsize_aligned;
+    /*
+     * Align the offset and the buffer length to sector boundaries,
+     * taking into account for cross-sector regions.
+     */
+    const off_t seekpos_aligned = ROUND_DOWN(pos, (off_t)512);
+    const size_t size_aligned = (size_t)(ROUND_UP(pos + size, (size_t)512) - seekpos_aligned);
+
+    scratch = alloc(size_aligned);
+    if (!scratch)
+        pdie("Not enough memory to allocate aligned buffer %d bytes for read", size_aligned);
+
+    /* Read it */
+    if (lseek(fd, seekpos_aligned, 0) != seekpos_aligned)
+        pdie("Seek to %lld", (long long)pos);
+    okay = (read(fd, scratch, size_aligned) == (int)size_aligned);
+
+    /* Free the aligned buffer */
     free(scratch);
 #else
     if (lseek(fd, pos, 0) != pos)
@@ -349,39 +407,55 @@ void fs_write(off_t pos, int size, void *data)
 #ifdef __REACTOS__
     assert(interactive || rw);
 
-    if (FsCheckFlags & FSCHECK_IMMEDIATE_WRITE) {
-        void *scratch;
-        const size_t readsize_aligned = (size % 512) ? (size + (512 - (size % 512))) : size;
-        const off_t seekpos_aligned = pos - (pos % 512);
-        const size_t seek_delta = (size_t)(pos - seekpos_aligned);
-        BOOLEAN use_read = (seek_delta != 0) || ((readsize_aligned-size) != 0);
+    if (FsCheckFlags & FSCHECK_IMMEDIATE_WRITE)
+    {
+        void *data_aligned = NULL;
+        off_t seekpos_aligned = pos;
+        size_t size_aligned = (size_t)size;
 
-        /* Aloc temp buffer if write is not aligned */
-        if (use_read)
-            scratch = alloc(readsize_aligned);
-        else
-            scratch = data;
-
-        did_change = 1;
-        if (lseek(fd, seekpos_aligned, 0) != seekpos_aligned) pdie("Seek to %lld",seekpos_aligned);
-
-        if (use_read)
+        /* If the input buffer & lengths are not aligned, align those */
+        if (// !IS_ALIGNED(data, 512) ||
+            !IS_ALIGNED(size, (size_t)512) || !IS_ALIGNED(pos, (off_t)512))
         {
-            /* Read aligned data */
-            if (read(fd, scratch, readsize_aligned) < 0) pdie("Read %d bytes at %lld",size,pos);
+            /*
+             * Align the offset and the buffer length to sector boundaries,
+             * taking into account for cross-sector regions.
+             */
+            seekpos_aligned = ROUND_DOWN(pos, (off_t)512);
+            size_aligned = (size_t)(ROUND_UP(pos + size, (size_t)512) - seekpos_aligned);
 
-            /* Patch data in memory */
-            memcpy((char *)scratch + seek_delta, data, size);
+            data_aligned = alloc(size_aligned);
+            if (!data_aligned)
+                pdie("Not enough memory to allocate aligned buffer %d bytes for write", size_aligned);
+
+            /*
+             * Fetch full sectors into the aligned buffer,
+             * then patch it with user data.
+             */
+            did_change = 1;
+            if (lseek(fd, seekpos_aligned, 0) != seekpos_aligned)
+                pdie("Seek to %lld", (long long)seekpos_aligned);
+            if (read(fd, data_aligned, size_aligned) < 0)
+                pdie("Read %d bytes at %lld", size, (long long)pos);
+
+            memcpy((char *)data_aligned + pos - seekpos_aligned, data, size);
         }
 
         /* Write it back */
-        if ((did = write(fd, scratch, readsize_aligned)) == (int)readsize_aligned)
-        {
-            if (use_read) free(scratch);
+        did_change = 1;
+        if (lseek(fd, seekpos_aligned, 0) != seekpos_aligned)
+            pdie("Seek to %lld", (long long)seekpos_aligned);
+        did = write(fd, data_aligned ? data_aligned : data, size_aligned);
+
+        /* Free the aligned buffer */
+        if (data_aligned)
+            free(data_aligned);
+
+        if (did == (int)size_aligned)
             return;
-        }
-        if (did < 0) pdie("Write %d bytes at %lld", size, pos);
-        die("Wrote %d bytes instead of %d at %lld", did, size, pos);
+
+        if (did < 0) pdie("Write %d bytes at %lld", size, (long long)pos);
+        die("Wrote %d bytes instead of %d at %lld", did, size, (long long)pos);
     }
 #else
     if (write_immed) {

--- a/sdk/lib/fslib/vfatlib/check/io.c
+++ b/sdk/lib/fslib/vfatlib/check/io.c
@@ -33,11 +33,12 @@
 
 #include "vfatlib.h"
 
-#define NDEBUG
-#include <debug.h>
+//#define NDEBUG
+//#include <debug.h>
 
-
-#define FSCTL_IS_VOLUME_DIRTY   CTL_CODE(FILE_DEVICE_FILE_SYSTEM, 30, METHOD_BUFFERED, FILE_ANY_ACCESS)
+#define DPRINT1(msg, ...) \
+    VfatPrint("** (%s:%d) " msg "\n", __RELFILE__, __LINE__, ##__VA_ARGS__)
+#define DPRINT DPRINT1
 
 typedef struct _change {
     void *data;
@@ -54,13 +55,20 @@ static int did_change = 0;
 static HANDLE fd;
 static LARGE_INTEGER CurrentOffset;
 
+
+// Enable this to use aligned IO
+// #define PREFORM_ALIGNED_IO
+
+#ifdef PREFORM_ALIGNED_IO
 #define ROUND_DOWN(n, align) ((n) & ~((align) - 1))
-#define ROUND_UP(n, align) ROUND_DOWN((n) + (align) - 1, (align))
-
+#define ROUND_UP(n, align)   ROUND_DOWN((n) + (align) - 1, (align))
 #define IS_ALIGNED(n, align) (((n) & ((align) - 1)) == 0)
-
+#endif
 
 /**** Win32 / NT support ******************************************************/
+
+#define FSCTL_IS_VOLUME_DIRTY           CTL_CODE(FILE_DEVICE_FILE_SYSTEM, 30, METHOD_BUFFERED, FILE_ANY_ACCESS)
+#define FSCTL_ALLOW_EXTENDED_DASD_IO    CTL_CODE(FILE_DEVICE_FILE_SYSTEM, 32, METHOD_NEITHER,  FILE_ANY_ACCESS)
 
 static int WIN32close(HANDLE FileHandle)
 {
@@ -161,7 +169,7 @@ static off_t WIN32lseek(HANDLE fd, off_t offset, int whence)
 #define lseek	WIN32lseek
 
 /******************************************************************************/
-#endif
+#endif // __REACTOS__
 
 
 #ifndef __REACTOS__
@@ -177,7 +185,7 @@ void fs_open(char *path, int rw)
 #else
 NTSTATUS fs_open(PUNICODE_STRING DriveRoot, int read_write)
 {
-    NTSTATUS Status;
+    NTSTATUS Status, Status2;
     OBJECT_ATTRIBUTES ObjectAttributes;
     IO_STATUS_BLOCK Iosb;
 
@@ -191,12 +199,20 @@ NTSTATUS fs_open(PUNICODE_STRING DriveRoot, int read_write)
                         FILE_GENERIC_READ | (read_write ? FILE_GENERIC_WRITE : 0),
                         &ObjectAttributes,
                         &Iosb,
-                        read_write ? FILE_SHARE_READ : (FILE_SHARE_READ | FILE_SHARE_WRITE),
+                        FILE_SHARE_READ | (read_write ? 0 : FILE_SHARE_WRITE),
                         FILE_SYNCHRONOUS_IO_ALERT);
     if (!NT_SUCCESS(Status))
     {
         DPRINT1("NtOpenFile() failed with status 0x%.08x\n", Status);
         return Status;
+    }
+
+    Status2 = NtFsControlFile(fd, NULL, NULL, NULL,
+                              &IoStatusBlock, FSCTL_ALLOW_EXTENDED_DASD_IO,
+                              NULL, 0, NULL, 0);
+    if (!NT_SUCCESS(Status2))
+    {
+        DPRINT1("Warning: NtFsControlFile(FSCTL_ALLOW_EXTENDED_DASD_IO) failed with status 0x%.08x\n", Status2);
     }
 
     // If read_write is specified, then the volume should be exclusively locked
@@ -290,13 +306,13 @@ void fs_read(off_t pos, int size, void *data)
     int got;
 
 #ifdef __REACTOS__
+#ifdef PREFORM_ALIGNED_IO
     void *data_aligned = NULL;
     off_t seekpos_aligned = pos;
     size_t size_aligned = (size_t)size;
 
     /* If the output buffer & lengths are not aligned, align those */
-    if (// !IS_ALIGNED(data, 512) ||
-        !IS_ALIGNED(size, (size_t)512) || !IS_ALIGNED(pos, (off_t)512))
+    if (!IS_ALIGNED(pos, (off_t)512) || !IS_ALIGNED(size, (size_t)512))
     {
         /*
          * Align the offset and the buffer length to sector boundaries,
@@ -344,6 +360,16 @@ void fs_read(off_t pos, int size, void *data)
 
         free(data_aligned);
     }
+#else // !PREFORM_ALIGNED_IO
+    /* Read it */
+    if (lseek(fd, pos, 0) != pos)
+        pdie("Seek to %lld", (long long)pos);
+    got = read(fd, data, (size_t)size);
+    if (got < 0)
+        pdie("Read %d bytes at %lld", size, (long long)pos);
+    assert(got >= size);
+    got = size;
+#endif // PREFORM_ALIGNED_IO
 
 #else
     if (lseek(fd, pos, 0) != pos)
@@ -370,7 +396,7 @@ int fs_test(off_t pos, int size)
     void *scratch;
     int okay;
 
-#ifdef __REACTOS__
+#if defined(__REACTOS__) && defined(PREFORM_ALIGNED_IO)
     /*
      * Align the offset and the buffer length to sector boundaries,
      * taking into account for cross-sector regions.
@@ -392,8 +418,8 @@ int fs_test(off_t pos, int size)
 #else
     if (lseek(fd, pos, 0) != pos)
 	pdie("Seek to %lld", (long long)pos);
-    scratch = alloc(size);
-    okay = read(fd, scratch, size) == size;
+    scratch = alloc((size_t)size);
+    okay = read(fd, scratch, (size_t)size) == size;
     free(scratch);
 #endif
     return okay;
@@ -409,13 +435,13 @@ void fs_write(off_t pos, int size, void *data)
 
     if (FsCheckFlags & FSCHECK_IMMEDIATE_WRITE)
     {
+#ifdef PREFORM_ALIGNED_IO
         void *data_aligned = NULL;
         off_t seekpos_aligned = pos;
         size_t size_aligned = (size_t)size;
 
         /* If the input buffer & lengths are not aligned, align those */
-        if (// !IS_ALIGNED(data, 512) ||
-            !IS_ALIGNED(size, (size_t)512) || !IS_ALIGNED(pos, (off_t)512))
+        if (!IS_ALIGNED(pos, (off_t)512) || !IS_ALIGNED(size, (size_t)512))
         {
             /*
              * Align the offset and the buffer length to sector boundaries,
@@ -454,6 +480,16 @@ void fs_write(off_t pos, int size, void *data)
         if (did == (int)size_aligned)
             return;
 
+#else // !PREFORM_ALIGNED_IO
+        /* Write it back */
+        did_change = 1;
+        if (lseek(fd, pos, 0) != pos)
+            pdie("Seek to %lld", (long long)pos);
+        did = write(fd, data, (size_t)size);
+        if (did == (int)size)
+            return;
+#endif // PREFORM_ALIGNED_IO
+
         if (did < 0) pdie("Write %d bytes at %lld", size, (long long)pos);
         die("Wrote %d bytes instead of %d at %lld", did, size, (long long)pos);
     }
@@ -483,7 +519,6 @@ void fs_write(off_t pos, int size, void *data)
 static void fs_flush(void)
 {
 #ifdef __REACTOS__
-
     CHANGE *this;
     int old_write_immed = (FsCheckFlags & FSCHECK_IMMEDIATE_WRITE);
 


### PR DESCRIPTION
# _Retrial of PR #184_

## Purpose

Correctly read or write data on aligned boundaries, taking cross-sector regions into account.
This fixes potential data corruptions.

As seen in PR #184 Pierre was "skeptical" about the fix, but the point of these fixes was to _**fix**_ the existing manually-done aligned read/write operations, that, according to my analysis https://github.com/reactos/reactos/pull/184#issuecomment-350554668 , were corrupting data.

JIRA issue: [CORE-14638](https://jira.reactos.org/browse/CORE-14638) Closed, but still applies.

## Proposed changes

Fix the aligned read/write operations that were (and still are) done manually.
