### PR TITLE
[LIBTIFF] Fix x64 regression

### DIFF
--- a/sdk/include/reactos/libs/libtiff/tiffconf.h
+++ b/sdk/include/reactos/libs/libtiff/tiffconf.h
@@ -28,6 +28,13 @@
 
 /* Signed 64-bit type */
 /* #undef TIFF_INT64_T */
+#ifdef __REACTOS__
+#ifdef __GNUC__
+#define TIFF_INT64_T signed long long
+#else
+#define TIFF_INT64_T signed __int64
+#endif
+#endif
 
 /* Signed 8-bit type */
 /* #undef TIFF_INT8_T */
@@ -45,7 +52,11 @@
 /* #undef TIFF_UINT8_T */
 
 /* Signed size type */
+#if defined(__REACTOS__) && defined(_WIN64)
+#define TIFF_SSIZE_T TIFF_INT64_T
+#else
 #define TIFF_SSIZE_T signed int
+#endif
 
 /* Compatibility stuff. */
 


### PR DESCRIPTION
## Purpose

Fix x64 regression seen at https://reactos.org/testman/compare.php?ids=106703,106708,106714 due to #8808 by reverting some changes

JIRA issues: [CORE-18674](https://jira.reactos.org/browse/CORE-18674)

## Proposed changes

- use signed long long type for x64 to fix libtiff initialization

## Testbot runs (Filled in by Devs)

- [ ] KVM x86: https://reactos.org/testman/compare.php?ids=106871,106874,106876
- [ ] KVM x64: https://reactos.org/testman/compare.php?ids=106872,106875,106877