### PR TITLE
[NTOS:KE] Implement priority boosting request

### DIFF
--- a/ntoskrnl/ke/gate.c
+++ b/ntoskrnl/ke/gate.c
@@ -197,7 +197,9 @@ KeSignalGateBoostPriority(IN PKGATE Gate)
             /* Release the thread lock */
             KiReleaseThreadLock(WaitThread);
 
-            /* FIXME: Boosting */
+            /* Request priority boosting from the signaling thread */
+            WaitThread->AdjustIncrement = KeGetCurrentThread()->Priority;
+            WaitThread->AdjustReason = AdjustBoost;
 
             /* Check if we have a queue */
             if (WaitThread->Queue)

--- a/ntoskrnl/ke/gate.c
+++ b/ntoskrnl/ke/gate.c
@@ -138,6 +138,8 @@ KeSignalGateBoostPriority(IN PKGATE Gate)
     PKTHREAD WaitThread;
     PKWAIT_BLOCK WaitBlock;
     KIRQL OldIrql;
+    SCHAR Priority;
+    PKTHREAD CurrentThread = KeGetCurrentThread();
     ASSERT_GATE(Gate);
     ASSERT_IRQL_LESS_OR_EQUAL(DISPATCH_LEVEL);
 
@@ -198,7 +200,8 @@ KeSignalGateBoostPriority(IN PKGATE Gate)
             KiReleaseThreadLock(WaitThread);
 
             /* Request priority boosting from the signaling thread */
-            WaitThread->AdjustIncrement = KeGetCurrentThread()->Priority;
+            Priority = KiComputeNewPriority(CurrentThread, 0);
+            WaitThread->AdjustIncrement = Priority;
             WaitThread->AdjustReason = AdjustBoost;
 
             /* Check if we have a queue */


### PR DESCRIPTION
## Purpose

JIRA issue: None

Implement the request for priority boosting from the signaling thread in KeSignalGateBoostPriority

## Proposed changes

- Implement priority boosting in `KeSignalGateBoostPriority()` by setting `AdjustIncrement` and `AdjustReason` on the woken up thread.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64:

* Note: i didn't do a kmtest because first i dont know much about doing those and second because gates are internal kernel structures not exposed to user tests so to me its trickier