### PR TITLE
[NTOS:CM] Implement NtNotifyChangeMultipleKeys (retry of #7914)

### DIFF
--- a/modules/rostests/apitests/ntdll/CMakeLists.txt
+++ b/modules/rostests/apitests/ntdll/CMakeLists.txt
@@ -144,6 +144,7 @@ list(APPEND SOURCE
     SystemInfo.c
     UserModeException.c
     Timer.c
+    NtNotifyChangeMultipleKeys.c
     precomp.h)
 
 if(ARCH STREQUAL "i386")

--- a/modules/rostests/apitests/ntdll/NtNotifyChangeMultipleKeys.c
+++ b/modules/rostests/apitests/ntdll/NtNotifyChangeMultipleKeys.c
@@ -1,0 +1,479 @@
+/*
+ * PROJECT:          ReactOS api tests
+ * LICENSE:          See COPYING in the top level directory
+ * PURPOSE:          Test for NtNotifyChangeMultipleKeys
+ * PROGRAMMER:       Mohammad Amin Mollazadeh (madamin@pm.me)
+ */
+
+#include "precomp.h"
+#include "winreg.h"
+
+/* Test state holder */
+
+typedef struct _CHANGE_NOTIFY_TEST_STATE
+{
+    /* Registry key handles */
+    HANDLE KeyHandle;
+    HANDLE SubKeyHandle;
+
+    /* Registry key object attributes */
+    UNICODE_STRING KeyName;
+    UNICODE_STRING SubKeyName;
+    UNICODE_STRING SecondaryKeyName;
+    OBJECT_ATTRIBUTES ObjectAttributes;
+    OBJECT_ATTRIBUTES SubKeyObjectAttributes;
+    OBJECT_ATTRIBUTES SecondaryObjectAttributes;
+
+    /* Watcher thread */
+    HANDLE ThreadHandle;
+
+    /* Notification event handle */
+    HANDLE EventHandle;
+
+    /* IoStatusBlock for NtNotifyChangeMultipleKeys */
+    IO_STATUS_BLOCK IoStatusBlock;
+
+    /* A flag to check if ApcRoutine is ran */
+    BOOLEAN ApcRan;
+} CHANGE_NOTIFY_TEST_STATE, *PCHANGE_NOTIFY_TEST_STATE;
+
+#define TState CHANGE_NOTIFY_TEST_STATE
+#define PState PCHANGE_NOTIFY_TEST_STATE
+
+/* Registry watcher thread for testing synchronous mode */
+typedef struct _WATCH_KEY_PARAMETERS
+{
+    NTSTATUS Status;
+    HANDLE KeyHandle;
+    PIO_STATUS_BLOCK IoStatusBlock;
+} WATCH_KEY_PARAMETERS, *PWATCH_KEY_PARAMETERS;
+
+DWORD WINAPI NtNotifyChangeMultipleKeys_WatchThread(LPVOID lpParameter)
+{
+    PWATCH_KEY_PARAMETERS State = (PWATCH_KEY_PARAMETERS)lpParameter;
+    
+    State->Status = NtNotifyChangeMultipleKeys(State->KeyHandle, 0, NULL, NULL, NULL, NULL, State->IoStatusBlock, REG_NOTIFY_CHANGE_LAST_SET, FALSE, NULL, 0, FALSE);
+
+    return 0;
+}
+
+/* APC Routine for testing asynchronous mode */
+
+VOID WINAPI NtNotifyChangeMultipleKeys_ApcRoutine(PVOID ApcContext, PIO_STATUS_BLOCK IoStatusBlock, ULONG Reserved)
+{
+    UNREFERENCED_PARAMETER(IoStatusBlock);
+    UNREFERENCED_PARAMETER(Reserved);
+
+    PState State = (PState)ApcContext;
+    State->ApcRan = TRUE;
+}
+
+/* Helper functions */
+
+#define CLEANUP(state) NtNotifyChangeMultipleKeys_Cleanup(state)
+#define CHECK_ERROR(state, Status) if (!NT_SUCCESS(Status)) { ok(FALSE, "Internal error, Status=0x%lx\n", Status); CLEANUP(state); return Status; }
+#define TEST_ERROR(state, Status, Expected)  ok_ntstatus(Status, Expected); if (Status != Expected) { CLEANUP(state); return Status; }
+#define INIT_TEST(state, Status) Status = NtNotifyChangeMultipleKeys_InitializePerTest(state); CHECK_ERROR(state, Status)
+#define FINALIZE_TEST(state) CLEANUP(state); return STATUS_SUCCESS
+#define RUN_TEST(state, Status, TestName) Status = NtNotifyChangeMultipleKeys_TEST_##TestName(state); ok(Status == STATUS_SUCCESS, "Subtest "#TestName" failed.\n")
+#define START_SUBTEST(TestName) NTSTATUS WINAPI NtNotifyChangeMultipleKeys_TEST_##TestName(PState state)
+
+VOID WINAPI NtNotifyChangeMultipleKeys_Cleanup(PState state)
+{
+    if (state->EventHandle)
+    {
+        CloseHandle(state->EventHandle);
+        state->EventHandle = NULL;
+    }
+    if (state->ThreadHandle)
+    {
+        CloseHandle(state->ThreadHandle);
+        state->ThreadHandle = NULL;
+    }
+    if (state->SubKeyHandle)
+    {
+        CloseHandle(state->SubKeyHandle);
+        state->SubKeyHandle = NULL;
+    }
+    if (state->KeyHandle)
+    {
+        CloseHandle(state->KeyHandle);
+        state->KeyHandle = NULL;
+    }
+}
+
+NTSTATUS WINAPI NtNotifyChangeMultipleKeys_Initialize(PState state)
+{
+    NTSTATUS Status;
+
+    HANDLE SecondaryKeyHandle;
+
+    state->KeyHandle = NULL;
+    state->SubKeyHandle = NULL;
+    state->ThreadHandle = NULL;
+    state->EventHandle = NULL;
+
+    /* Setup object attributes */
+    RtlInitUnicodeString(&state->KeyName, L"\\Registry\\Machine\\SOFTWARE\\TestKey");
+    InitializeObjectAttributes(&state->ObjectAttributes, &state->KeyName, OBJ_CASE_INSENSITIVE, NULL, NULL);
+
+    RtlInitUnicodeString(&state->SubKeyName, L"\\Registry\\Machine\\SOFTWARE\\TestKey\\TestSubKey");
+    InitializeObjectAttributes(&state->SubKeyObjectAttributes, &state->SubKeyName, OBJ_CASE_INSENSITIVE, NULL, NULL);
+
+    RtlInitUnicodeString(&state->SecondaryKeyName, L"\\Registry\\User\\.DEFAULT\\SOFTWARE\\TestKey");
+    InitializeObjectAttributes(&state->SecondaryObjectAttributes, &state->SecondaryKeyName, OBJ_CASE_INSENSITIVE, NULL, NULL);
+
+    /* Create registry keys */
+    Status = NtCreateKey(&state->KeyHandle, KEY_ALL_ACCESS, &state->ObjectAttributes, 0, NULL, REG_OPTION_NON_VOLATILE, NULL);
+    CHECK_ERROR(state, Status);
+
+    Status = NtCreateKey(&state->SubKeyHandle, KEY_ALL_ACCESS, &state->SubKeyObjectAttributes, 0, NULL, REG_OPTION_NON_VOLATILE, NULL);
+    CHECK_ERROR(state, Status);
+
+    Status = NtCreateKey(&SecondaryKeyHandle, KEY_ALL_ACCESS, &state->SecondaryObjectAttributes, 0, NULL, REG_OPTION_NON_VOLATILE, NULL);
+    CHECK_ERROR(state, Status);
+    CloseHandle(SecondaryKeyHandle);
+
+    FINALIZE_TEST(state);
+}
+
+NTSTATUS WINAPI NtNotifyChangeMultipleKeys_CleanupTestKeys(PState state)
+{
+    NTSTATUS Status;
+    HANDLE SecondaryKey;
+
+    Status = NtOpenKey(&state->KeyHandle, DELETE, &state->ObjectAttributes);
+    if (NT_SUCCESS(Status))
+    {
+        NtDeleteKey(state->KeyHandle);
+        CloseHandle(state->KeyHandle);
+    }
+
+    Status = NtOpenKey(&SecondaryKey, DELETE, &state->SecondaryObjectAttributes);
+    if (NT_SUCCESS(Status))
+    {
+        NtDeleteKey(SecondaryKey);   
+        CloseHandle(SecondaryKey);
+    }
+
+    return STATUS_SUCCESS;
+}
+
+NTSTATUS WINAPI NtNotifyChangeMultipleKeys_InitializePerTest(PState state)
+{
+    NTSTATUS Status;
+
+    Status = NtOpenKey(&state->KeyHandle, KEY_SET_VALUE | KEY_NOTIFY | DELETE, &state->ObjectAttributes);
+    CHECK_ERROR(state, Status);
+
+    Status = NtOpenKey(&state->SubKeyHandle, KEY_SET_VALUE | KEY_NOTIFY | DELETE, &state->SubKeyObjectAttributes);
+    CHECK_ERROR(state, Status);
+
+    return STATUS_SUCCESS;
+}
+
+/* Tests */
+
+START_SUBTEST(Synchronous)
+{
+    NTSTATUS Status;
+
+    UNICODE_STRING ValueName;
+    RtlInitUnicodeString(&ValueName, L"TestValue");
+
+    DWORD ValueData = 0x87654321;
+
+    INIT_TEST(state, Status);
+
+    /* Reset value */
+    DWORD ValuePreData = 0x12345678;
+    Status = NtSetValueKey(state->KeyHandle, &ValueName, 0, REG_DWORD, &ValuePreData, sizeof(ValuePreData));
+    CHECK_ERROR(state, Status);
+    
+    /* Create a thread */
+    WATCH_KEY_PARAMETERS Params;
+    Params.KeyHandle = state->KeyHandle;
+    Params.IoStatusBlock = &state->IoStatusBlock;
+    state->ThreadHandle = CreateThread(NULL, 0, NtNotifyChangeMultipleKeys_WatchThread, &Params, 0, NULL);
+    if (!state->ThreadHandle)
+    {
+        CLEANUP(state);
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+
+    /* Verify the thread is still running */
+    Status = WaitForSingleObject(state->ThreadHandle, 100);
+    TEST_ERROR(state, Status, WAIT_TIMEOUT);
+
+    /* Make change to the registry key */
+    Status = NtSetValueKey(state->KeyHandle, &ValueName, 0, REG_DWORD, &ValueData, sizeof(ValueData));
+    CHECK_ERROR(state, Status);
+
+    /* Verify that the thread is notified */
+    Status = WaitForSingleObject(state->ThreadHandle, 100);
+    TEST_ERROR(state, Status, WAIT_OBJECT_0);
+
+    /* Verify the status code */
+    ok_ntstatus(Params.Status, STATUS_NOTIFY_ENUM_DIR);
+    ok_ntstatus(Params.IoStatusBlock->Status, STATUS_NOTIFY_ENUM_DIR);
+
+    /* Watch again, but this time close the handle without making any change */
+    state->ThreadHandle = CreateThread(NULL, 0, NtNotifyChangeMultipleKeys_WatchThread, &Params, 0, NULL);
+    if (!state->ThreadHandle)
+    {
+        CLEANUP(state);
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+    Status = WaitForSingleObject(state->ThreadHandle, 100);
+    TEST_ERROR(state, Status, WAIT_TIMEOUT);
+    NtClose(state->KeyHandle);
+    state->KeyHandle = NULL;
+    Status = WaitForSingleObject(state->ThreadHandle, 100);
+    TEST_ERROR(state, Status, WAIT_OBJECT_0);
+    ok_ntstatus(Params.Status, STATUS_NOTIFY_CLEANUP);
+    ok_ntstatus(Params.IoStatusBlock->Status, STATUS_NOTIFY_CLEANUP);
+
+    FINALIZE_TEST(state);
+}
+
+START_SUBTEST(Asynchronous)
+{
+    NTSTATUS Status;
+
+    UNICODE_STRING ValueName;
+    RtlInitUnicodeString(&ValueName, L"AsyncTestValue");
+
+    DWORD ValueData = 0x12345678;
+    
+    INIT_TEST(state, Status);
+    
+    /* Reset value */
+    DWORD ValuePreData = 0x87654321;
+    Status = NtSetValueKey(state->KeyHandle, &ValueName, 0, REG_DWORD, &ValuePreData, sizeof(ValuePreData));
+    CHECK_ERROR(state, Status);
+
+    /* Create event */
+    state->EventHandle = CreateEvent(NULL, FALSE, FALSE, NULL);
+    if (!state->EventHandle)
+    {
+        CLEANUP(state);
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+
+    /* Start watching for changes */
+    Status = NtNotifyChangeMultipleKeys(state->KeyHandle, 0, NULL, state->EventHandle, NULL, NULL, &state->IoStatusBlock, REG_NOTIFY_CHANGE_LAST_SET, FALSE, NULL, 0, TRUE);
+    TEST_ERROR(state, Status, STATUS_PENDING);
+
+    /* Check event state */
+    Status = WaitForSingleObject(state->EventHandle, 0);
+    TEST_ERROR(state, Status, WAIT_TIMEOUT);
+
+    /* Make change to the registry key */
+    Status = NtSetValueKey(state->KeyHandle, &ValueName, 0, REG_DWORD, &ValueData, sizeof(ValueData));
+    TEST_ERROR(state, Status, STATUS_SUCCESS);
+    
+    /* Verify that the event is signaled */
+    NtTestAlert();
+    Status = WaitForSingleObject(state->EventHandle, 100);
+    TEST_ERROR(state, Status, WAIT_OBJECT_0);
+
+    /* Verify the status code */
+    ok_ntstatus(state->IoStatusBlock.Status, STATUS_NOTIFY_ENUM_DIR);
+
+    /* Watch again, but this time close the handle without making any change */
+    Status = NtNotifyChangeMultipleKeys(state->KeyHandle, 0, NULL, state->EventHandle, NULL, NULL, &state->IoStatusBlock, REG_NOTIFY_CHANGE_LAST_SET, FALSE, NULL, 0, TRUE);
+    TEST_ERROR(state, Status, STATUS_PENDING);
+    Status = WaitForSingleObject(state->EventHandle, 0);
+    TEST_ERROR(state, Status, WAIT_TIMEOUT);
+    NtClose(state->KeyHandle);
+    state->KeyHandle = NULL;
+    NtTestAlert();
+    Status = WaitForSingleObject(state->EventHandle, 100);
+    TEST_ERROR(state, Status, WAIT_OBJECT_0);
+    ok_ntstatus(state->IoStatusBlock.Status, STATUS_NOTIFY_CLEANUP);
+
+    FINALIZE_TEST(state);
+}
+
+START_SUBTEST(WatchSubtree)
+{
+    NTSTATUS Status;
+
+    UNICODE_STRING ValueName;
+    RtlInitUnicodeString(&ValueName, L"SubtreeTestValue");
+
+    DWORD ValueData = 0x12345678;
+    
+    INIT_TEST(state, Status);
+    
+    /* Reset value */
+    DWORD ValuePreData = 0x87654321;
+    Status = NtSetValueKey(state->SubKeyHandle, &ValueName, 0, REG_DWORD, &ValuePreData, sizeof(ValuePreData));
+    CHECK_ERROR(state, Status);
+
+    /* Create event */
+    state->EventHandle = CreateEvent(NULL, FALSE, FALSE, NULL);
+    if (!state->EventHandle)
+    {
+        CLEANUP(state);
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+
+    /* Start watching for changes */
+    Status = NtNotifyChangeMultipleKeys(state->KeyHandle, 0, NULL, state->EventHandle, NULL, NULL, &state->IoStatusBlock, REG_NOTIFY_CHANGE_LAST_SET, TRUE, NULL, 0, TRUE);
+    TEST_ERROR(state, Status, STATUS_PENDING);
+
+    /* Check event state */
+    Status = WaitForSingleObject(state->EventHandle, 0);
+    TEST_ERROR(state, Status, WAIT_TIMEOUT);
+
+    /* Make change to the subkey */
+    Status = NtSetValueKey(state->SubKeyHandle, &ValueName, 0, REG_DWORD, &ValueData, sizeof(ValueData));
+    TEST_ERROR(state, Status, STATUS_SUCCESS);
+
+    /* Verify that the event is signaled */
+    NtTestAlert();
+    Status = WaitForSingleObject(state->EventHandle, 100);
+    TEST_ERROR(state, Status, WAIT_OBJECT_0);
+
+    FINALIZE_TEST(state);
+}
+
+START_SUBTEST(WatchSecondaryKey)
+{
+    NTSTATUS Status;
+
+    UNICODE_STRING ValueName;
+    RtlInitUnicodeString(&ValueName, L"SecondaryKeyTestValue");
+
+    DWORD ValueData = 0x12345678;
+    
+    HANDLE SecondaryKey;
+    
+    INIT_TEST(state, Status);
+    
+    /* Reset value */
+    DWORD ValuePreData = 0x87654321;
+    Status = NtOpenKey(&SecondaryKey, KEY_SET_VALUE | KEY_NOTIFY | DELETE, &state->SecondaryObjectAttributes);
+    CHECK_ERROR(state, Status);
+    Status = NtSetValueKey(SecondaryKey, &ValueName, 0, REG_DWORD, &ValuePreData, sizeof(ValuePreData));
+    CHECK_ERROR(state, Status);
+    CloseHandle(SecondaryKey);
+
+    /* Create event */
+    state->EventHandle = CreateEvent(NULL, FALSE, FALSE, NULL);
+    if (!state->EventHandle)
+    {
+        CLEANUP(state);
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+
+    /* Start watching for changes */
+    OBJECT_ATTRIBUTES SubordinateObjects[1];
+    InitializeObjectAttributes(&SubordinateObjects[0], &state->SecondaryKeyName, OBJ_CASE_INSENSITIVE, NULL, NULL);
+    Status = NtNotifyChangeMultipleKeys(state->KeyHandle,
+                                        _countof(SubordinateObjects),
+                                        SubordinateObjects,
+                                        state->EventHandle,
+                                        NULL,
+                                        NULL,
+                                        &state->IoStatusBlock,
+                                        REG_NOTIFY_CHANGE_LAST_SET,
+                                        TRUE,
+                                        NULL,
+                                        0,
+                                        TRUE);
+    TEST_ERROR(state, Status, STATUS_PENDING);
+
+    /* Check event state */
+    Status = WaitForSingleObject(state->EventHandle, 0);
+    TEST_ERROR(state, Status, WAIT_TIMEOUT);
+
+    /* Make change to the secondary key */
+    Status = NtOpenKey(&SecondaryKey, KEY_SET_VALUE | KEY_NOTIFY | DELETE, &state->SecondaryObjectAttributes);
+    CHECK_ERROR(state, Status);
+    Status = NtSetValueKey(SecondaryKey, &ValueName, 0, REG_DWORD, &ValueData, sizeof(ValueData));
+    TEST_ERROR(state, Status, STATUS_SUCCESS);
+    CloseHandle(SecondaryKey);
+
+    /* Verify that the event is signaled */
+    NtTestAlert();
+    Status = WaitForSingleObject(state->EventHandle, 100);
+    TEST_ERROR(state, Status, WAIT_OBJECT_0);
+
+    /* Test if the function gives error if the given subordinate key is same with master key */
+    InitializeObjectAttributes(&SubordinateObjects[0], &state->KeyName, OBJ_CASE_INSENSITIVE, NULL, NULL);
+    Status = NtNotifyChangeMultipleKeys(state->KeyHandle,
+                                        _countof(SubordinateObjects),
+                                        SubordinateObjects,
+                                        state->EventHandle,
+                                        NULL,
+                                        NULL,
+                                        &state->IoStatusBlock,
+                                        REG_NOTIFY_CHANGE_LAST_SET,
+                                        TRUE,
+                                        NULL,
+                                        0,
+                                        TRUE);
+    /* The status is STATUS_INVALID_PARAMETER on Windows Server 2003 and STATUS_INVALID_OBJECT_NAME on Windows 10 */
+    ok(!NT_SUCCESS(Status), "NtNotifyChangeMultipleKeys succeeded unexpectedly.\n");
+
+    FINALIZE_TEST(state);
+}
+
+START_SUBTEST(ApcRoutine)
+{
+    NTSTATUS Status;
+
+    UNICODE_STRING ValueName;
+    RtlInitUnicodeString(&ValueName, L"ApcRoutineTestValue");
+
+    DWORD ValueData = 0x12345678;
+    
+    INIT_TEST(state, Status);
+    
+    state->ApcRan = FALSE;
+    
+    /* Reset value */
+    DWORD ValuePreData = 0x87654321;
+    Status = NtSetValueKey(state->KeyHandle, &ValueName, 0, REG_DWORD, &ValuePreData, sizeof(ValuePreData));
+    CHECK_ERROR(state, Status);
+
+    /* Start watching for changes */
+    Status = NtNotifyChangeMultipleKeys(state->KeyHandle, 0, NULL, NULL, NtNotifyChangeMultipleKeys_ApcRoutine, state, &state->IoStatusBlock, REG_NOTIFY_CHANGE_LAST_SET, FALSE, NULL, 0, TRUE);
+    TEST_ERROR(state, Status, STATUS_PENDING);
+
+    /* Make change to the registry key */
+    Status = NtSetValueKey(state->KeyHandle, &ValueName, 0, REG_DWORD, &ValueData, sizeof(ValueData));
+    TEST_ERROR(state, Status, STATUS_SUCCESS);
+
+    /* Force system to run queued APC routines */
+    NtTestAlert();
+    ok(state->ApcRan == TRUE, "The APC routine did not ran.\n");
+    if (!state->ApcRan)
+    {
+        CLEANUP(state);
+        return STATUS_UNSUCCESSFUL;
+    }
+
+    FINALIZE_TEST(state);
+}
+
+/* Main */
+
+START_TEST(NtNotifyChangeMultipleKeys)
+{
+    NTSTATUS Status;
+    TState State;
+    
+    Status = NtNotifyChangeMultipleKeys_Initialize(&State);
+    ASSERT(NT_SUCCESS(Status));
+
+    RUN_TEST(&State, Status, Synchronous);
+    RUN_TEST(&State, Status, Asynchronous);
+    RUN_TEST(&State, Status, WatchSubtree);
+    RUN_TEST(&State, Status, WatchSecondaryKey);
+    RUN_TEST(&State, Status, ApcRoutine);
+
+    NtNotifyChangeMultipleKeys_CleanupTestKeys(&State);
+}

--- a/modules/rostests/apitests/ntdll/NtNotifyChangeMultipleKeys.c
+++ b/modules/rostests/apitests/ntdll/NtNotifyChangeMultipleKeys.c
@@ -459,6 +459,328 @@ START_SUBTEST(ApcRoutine)
     FINALIZE_TEST(state);
 }
 
+START_SUBTEST(BufferFullName)
+{
+    NTSTATUS Status;
+ 
+    UNICODE_STRING ValueName;
+    RtlInitUnicodeString(&ValueName, L"BufFullNameValue");
+ 
+    DWORD ValueData = 0xAABBCCDD;
+ 
+    INIT_TEST(state, Status);
+
+    DWORD ValuePreData = 0x11223344;
+    Status = NtSetValueKey(state->KeyHandle, &ValueName, 0, REG_DWORD, &ValuePreData, sizeof(ValuePreData));
+    CHECK_ERROR(state, Status);
+ 
+    state->EventHandle = CreateEvent(NULL, FALSE, FALSE, NULL);
+    if (!state->EventHandle)
+    {
+        CLEANUP(state);
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+
+    WCHAR PathBuffer[MAX_PATH];
+    ULONG BufferLength = sizeof(PathBuffer);
+    RtlZeroMemory(PathBuffer, BufferLength);
+ 
+    Status = NtNotifyChangeMultipleKeys(state->KeyHandle,
+                                        0, NULL,
+                                        state->EventHandle,
+                                        NULL, NULL,
+                                        &state->IoStatusBlock,
+                                        REG_NOTIFY_CHANGE_LAST_SET,
+                                        FALSE,
+                                        PathBuffer,
+                                        BufferLength,
+                                        TRUE);
+    TEST_ERROR(state, Status, STATUS_PENDING);
+
+    Status = NtSetValueKey(state->KeyHandle, &ValueName, 0, REG_DWORD, &ValueData, sizeof(ValueData));
+    CHECK_ERROR(state, Status);
+ 
+    NtTestAlert();
+    Status = WaitForSingleObject(state->EventHandle, 100);
+    TEST_ERROR(state, Status, WAIT_OBJECT_0);
+
+    ok_ntstatus(state->IoStatusBlock.Status, STATUS_SUCCESS);
+ 
+    UNICODE_STRING ExpectedPath;
+    RtlInitUnicodeString(&ExpectedPath, L"\\REGISTRY\\MACHINE\\SOFTWARE\\TestKey");
+ 
+    ULONG ExpectedBytes = ExpectedPath.Length + sizeof(WCHAR); /* include NUL */
+    ok(state->IoStatusBlock.Information == ExpectedBytes,
+       "Information=%lu, expected %lu\n",
+       (ULONG)state->IoStatusBlock.Information, ExpectedBytes);
+ 
+    ok(wcsncmp(PathBuffer, ExpectedPath.Buffer, ExpectedPath.Length / sizeof(WCHAR)) == 0,
+       "Buffer contained wrong path: '%ls'\n", PathBuffer);
+ 
+    ok(PathBuffer[ExpectedPath.Length / sizeof(WCHAR)] == UNICODE_NULL,
+       "Buffer is not NUL-terminated\n");
+ 
+    FINALIZE_TEST(state);
+}
+
+START_SUBTEST(BufferTooSmall)
+{
+    NTSTATUS Status;
+
+    UNICODE_STRING ValueName;
+    RtlInitUnicodeString(&ValueName, L"BufTooSmallValue");
+
+    DWORD ValueData = 0xDEADBEEF;
+
+    INIT_TEST(state, Status);
+
+    DWORD ValuePreData = 0xCAFEBABE;
+    Status = NtSetValueKey(state->KeyHandle, &ValueName, 0, REG_DWORD, &ValuePreData, sizeof(ValuePreData));
+    CHECK_ERROR(state, Status);
+
+    state->EventHandle = CreateEvent(NULL, FALSE, FALSE, NULL);
+    if (!state->EventHandle)
+    {
+        CLEANUP(state);
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+
+    WCHAR SmallBuffer[4];
+    ULONG SmallBufferLength = sizeof(SmallBuffer); /* 8 bytes */
+    RtlZeroMemory(SmallBuffer, SmallBufferLength);
+
+    Status = NtNotifyChangeMultipleKeys(state->KeyHandle,
+                                        0, NULL,
+                                        state->EventHandle,
+                                        NULL, NULL,
+                                        &state->IoStatusBlock,
+                                        REG_NOTIFY_CHANGE_LAST_SET,
+                                        FALSE,
+                                        SmallBuffer,
+                                        SmallBufferLength,
+                                        TRUE);
+    TEST_ERROR(state, Status, STATUS_PENDING);
+
+    Status = NtSetValueKey(state->KeyHandle, &ValueName, 0, REG_DWORD, &ValueData, sizeof(ValueData));
+    CHECK_ERROR(state, Status);
+
+    NtTestAlert();
+    Status = WaitForSingleObject(state->EventHandle, 100);
+    TEST_ERROR(state, Status, WAIT_OBJECT_0);
+
+    ok_ntstatus(state->IoStatusBlock.Status, STATUS_BUFFER_OVERFLOW);
+
+    UNICODE_STRING ExpectedPath;
+    RtlInitUnicodeString(&ExpectedPath, L"\\REGISTRY\\MACHINE\\SOFTWARE\\TestKey");
+    ULONG ExpectedBytes = ExpectedPath.Length + sizeof(WCHAR);
+
+    ok(state->IoStatusBlock.Information == ExpectedBytes,
+       "Information=%lu, expected full path size %lu\n",
+       (ULONG)state->IoStatusBlock.Information, ExpectedBytes);
+
+    ULONG CharsFit = (SmallBufferLength / sizeof(WCHAR)) - 1;
+    ok(SmallBuffer[CharsFit] == UNICODE_NULL,
+       "Small buffer is not NUL-terminated at position %lu\n", CharsFit);
+
+    FINALIZE_TEST(state);
+}
+
+START_SUBTEST(BufferSubtreeName)
+{
+    NTSTATUS Status;
+ 
+    UNICODE_STRING ValueName;
+    RtlInitUnicodeString(&ValueName, L"BufSubtreeValue");
+ 
+    DWORD ValueData = 0x12345678;
+ 
+    INIT_TEST(state, Status);
+ 
+    DWORD ValuePreData = 0x87654321;
+    Status = NtSetValueKey(state->SubKeyHandle, &ValueName, 0, REG_DWORD, &ValuePreData, sizeof(ValuePreData));
+    CHECK_ERROR(state, Status);
+ 
+    state->EventHandle = CreateEvent(NULL, FALSE, FALSE, NULL);
+    if (!state->EventHandle)
+    {
+        CLEANUP(state);
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+ 
+    WCHAR PathBuffer[MAX_PATH];
+    ULONG BufferLength = sizeof(PathBuffer);
+    RtlZeroMemory(PathBuffer, BufferLength);
+
+    Status = NtNotifyChangeMultipleKeys(state->KeyHandle,
+                                        0, NULL,
+                                        state->EventHandle,
+                                        NULL, NULL,
+                                        &state->IoStatusBlock,
+                                        REG_NOTIFY_CHANGE_LAST_SET,
+                                        TRUE,
+                                        PathBuffer,
+                                        BufferLength,
+                                        TRUE);
+    TEST_ERROR(state, Status, STATUS_PENDING);
+
+    Status = NtSetValueKey(state->SubKeyHandle, &ValueName, 0, REG_DWORD, &ValueData, sizeof(ValueData));
+    CHECK_ERROR(state, Status);
+ 
+    NtTestAlert();
+    Status = WaitForSingleObject(state->EventHandle, 100);
+    TEST_ERROR(state, Status, WAIT_OBJECT_0);
+ 
+    ok_ntstatus(state->IoStatusBlock.Status, STATUS_SUCCESS);
+
+    UNICODE_STRING ExpectedSubPath;
+    RtlInitUnicodeString(&ExpectedSubPath,
+                         L"\\REGISTRY\\MACHINE\\SOFTWARE\\TestKey\\TestSubKey");
+ 
+    ULONG ExpectedBytes = ExpectedSubPath.Length + sizeof(WCHAR);
+    ok(state->IoStatusBlock.Information == ExpectedBytes,
+       "Information=%lu, expected %lu (subkey path)\n",
+       (ULONG)state->IoStatusBlock.Information, ExpectedBytes);
+ 
+    ok(wcsncmp(PathBuffer, ExpectedSubPath.Buffer,
+               ExpectedSubPath.Length / sizeof(WCHAR)) == 0,
+       "Buffer should contain subkey path but got: '%ls'\n", PathBuffer);
+ 
+    FINALIZE_TEST(state);
+}
+
+START_SUBTEST(BufferSecondaryKeyName)
+{
+    NTSTATUS Status;
+ 
+    UNICODE_STRING ValueName;
+    RtlInitUnicodeString(&ValueName, L"BufSecondaryValue");
+ 
+    DWORD ValueData = 0xFEEDFACE;
+ 
+    HANDLE SecondaryKey;
+ 
+    INIT_TEST(state, Status);
+ 
+    DWORD ValuePreData = 0xACEDBEEF;
+    Status = NtOpenKey(&SecondaryKey, KEY_SET_VALUE | KEY_NOTIFY,
+                       &state->SecondaryObjectAttributes);
+    CHECK_ERROR(state, Status);
+    Status = NtSetValueKey(SecondaryKey, &ValueName, 0, REG_DWORD,
+                           &ValuePreData, sizeof(ValuePreData));
+    CHECK_ERROR(state, Status);
+    CloseHandle(SecondaryKey);
+ 
+    state->EventHandle = CreateEvent(NULL, FALSE, FALSE, NULL);
+    if (!state->EventHandle)
+    {
+        CLEANUP(state);
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+ 
+    WCHAR PathBuffer[MAX_PATH];
+    ULONG BufferLength = sizeof(PathBuffer);
+    RtlZeroMemory(PathBuffer, BufferLength);
+ 
+    OBJECT_ATTRIBUTES SubordinateObjects[1];
+    InitializeObjectAttributes(&SubordinateObjects[0],
+                                &state->SecondaryKeyName,
+                                OBJ_CASE_INSENSITIVE, NULL, NULL);
+ 
+    Status = NtNotifyChangeMultipleKeys(state->KeyHandle,
+                                        _countof(SubordinateObjects),
+                                        SubordinateObjects,
+                                        state->EventHandle,
+                                        NULL, NULL,
+                                        &state->IoStatusBlock,
+                                        REG_NOTIFY_CHANGE_LAST_SET,
+                                        TRUE,
+                                        PathBuffer,
+                                        BufferLength,
+                                        TRUE);
+    TEST_ERROR(state, Status, STATUS_PENDING);
+ 
+    /* Trigger via the secondary key */
+    Status = NtOpenKey(&SecondaryKey, KEY_SET_VALUE | KEY_NOTIFY,
+                       &state->SecondaryObjectAttributes);
+    CHECK_ERROR(state, Status);
+    Status = NtSetValueKey(SecondaryKey, &ValueName, 0, REG_DWORD,
+                           &ValueData, sizeof(ValueData));
+    CHECK_ERROR(state, Status);
+    CloseHandle(SecondaryKey);
+ 
+    NtTestAlert();
+    Status = WaitForSingleObject(state->EventHandle, 100);
+    TEST_ERROR(state, Status, WAIT_OBJECT_0);
+ 
+    ok_ntstatus(state->IoStatusBlock.Status, STATUS_SUCCESS);
+
+    UNICODE_STRING ExpectedSecondaryPath;
+    RtlInitUnicodeString(&ExpectedSecondaryPath,
+                         L"\\REGISTRY\\USER\\.DEFAULT\\SOFTWARE\\TestKey");
+ 
+    ULONG ExpectedBytes = ExpectedSecondaryPath.Length + sizeof(WCHAR);
+    ok(state->IoStatusBlock.Information == ExpectedBytes,
+       "Information=%lu, expected %lu (secondary key path)\n",
+       (ULONG)state->IoStatusBlock.Information, ExpectedBytes);
+ 
+    ok(wcsncmp(PathBuffer, ExpectedSecondaryPath.Buffer,
+               ExpectedSecondaryPath.Length / sizeof(WCHAR)) == 0,
+       "Buffer should contain secondary key path but got: '%ls'\n", PathBuffer);
+ 
+    FINALIZE_TEST(state);
+}
+
+START_SUBTEST(BufferNullSkipped)
+{
+    NTSTATUS Status;
+ 
+    UNICODE_STRING ValueName;
+    RtlInitUnicodeString(&ValueName, L"BufNullSkipValue");
+ 
+    DWORD ValueData = 0x55AA55AA;
+ 
+    INIT_TEST(state, Status);
+ 
+    DWORD ValuePreData = 0xAA55AA55;
+    Status = NtSetValueKey(state->KeyHandle, &ValueName, 0, REG_DWORD,
+                           &ValuePreData, sizeof(ValuePreData));
+    CHECK_ERROR(state, Status);
+ 
+    state->EventHandle = CreateEvent(NULL, FALSE, FALSE, NULL);
+    if (!state->EventHandle)
+    {
+        CLEANUP(state);
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+
+    Status = NtNotifyChangeMultipleKeys(state->KeyHandle,
+                                        0, NULL,
+                                        state->EventHandle,
+                                        NULL, NULL,
+                                        &state->IoStatusBlock,
+                                        REG_NOTIFY_CHANGE_LAST_SET,
+                                        FALSE,
+                                        NULL,
+                                        0,
+                                        TRUE);
+    TEST_ERROR(state, Status, STATUS_PENDING);
+ 
+    Status = NtSetValueKey(state->KeyHandle, &ValueName, 0, REG_DWORD,
+                           &ValueData, sizeof(ValueData));
+    CHECK_ERROR(state, Status);
+ 
+    NtTestAlert();
+    Status = WaitForSingleObject(state->EventHandle, 100);
+    TEST_ERROR(state, Status, WAIT_OBJECT_0);
+
+    ok_ntstatus(state->IoStatusBlock.Status, STATUS_NOTIFY_ENUM_DIR);
+    ok(state->IoStatusBlock.Information == 0,
+       "Information should be 0 when no buffer supplied, got %lu\n",
+       (ULONG)state->IoStatusBlock.Information);
+ 
+    FINALIZE_TEST(state);
+}
+
 /* Main */
 
 START_TEST(NtNotifyChangeMultipleKeys)
@@ -474,6 +796,11 @@ START_TEST(NtNotifyChangeMultipleKeys)
     RUN_TEST(&State, Status, WatchSubtree);
     RUN_TEST(&State, Status, WatchSecondaryKey);
     RUN_TEST(&State, Status, ApcRoutine);
+    RUN_TEST(&State, Status, BufferFullName);
+    RUN_TEST(&State, Status, BufferTooSmall);
+    RUN_TEST(&State, Status, BufferSubtreeName);
+    RUN_TEST(&State, Status, BufferSecondaryKeyName);
+    RUN_TEST(&State, Status, BufferNullSkipped);
 
     NtNotifyChangeMultipleKeys_CleanupTestKeys(&State);
 }

--- a/modules/rostests/apitests/ntdll/testlist.c
+++ b/modules/rostests/apitests/ntdll/testlist.c
@@ -271,6 +271,7 @@ const struct test winetest_testlist[] =
 #ifdef _M_AMD64
     { "RtlCaptureContext",              func_RtlCaptureContext },
 #endif
+
     { "NtNotifyChangeMultipleKeys", func_NtNotifyChangeMultipleKeys },
     { 0, 0 }
 };

--- a/modules/rostests/apitests/ntdll/testlist.c
+++ b/modules/rostests/apitests/ntdll/testlist.c
@@ -132,6 +132,7 @@ extern void func_RtlxUnicodeStringToOemSize(void);
 extern void func_StackOverflow(void);
 extern void func_TimerResolution(void);
 extern void func_UserModeException(void);
+extern void func_NtNotifyChangeMultipleKeys(void);
 
 const struct test winetest_testlist[] =
 {
@@ -270,6 +271,6 @@ const struct test winetest_testlist[] =
 #ifdef _M_AMD64
     { "RtlCaptureContext",              func_RtlCaptureContext },
 #endif
-
+    { "NtNotifyChangeMultipleKeys", func_NtNotifyChangeMultipleKeys },
     { 0, 0 }
 };

--- a/modules/rostests/kmtests/CMakeLists.txt
+++ b/modules/rostests/kmtests/CMakeLists.txt
@@ -57,6 +57,7 @@ list(APPEND KMTEST_DRV_SOURCE
     npfs/NpfsVolumeInfo.c
     novp_fsrtl/FsRtlRemoveDotsFromPath.c
     ntos_cm/CmSecurity.c
+    ntos_cm/CmNotify.c
     ntos_ex/ExCallback.c
     ntos_ex/ExDoubleList.c
     ntos_ex/ExFastMutex.c

--- a/modules/rostests/kmtests/kmtest_drv/testlist.c
+++ b/modules/rostests/kmtests/kmtest_drv/testlist.c
@@ -90,6 +90,7 @@ KMT_TESTFUNC Test_ZwAllocateVirtualMemory;
 KMT_TESTFUNC Test_ZwCreateSection;
 KMT_TESTFUNC Test_ZwMapViewOfSection;
 KMT_TESTFUNC Test_ZwWaitForMultipleObjects;
+KMT_TESTFUNC Test_ZwNotifyChangeKey;
 
 const KMT_TEST TestList[] =
 {
@@ -179,5 +180,6 @@ const KMT_TEST TestList[] =
 #ifdef _M_AMD64
     { "RtlCaptureContextKM",                Test_RtlCaptureContext },
 #endif
+    { "ZwNotifyChangeKey",                  Test_ZwNotifyChangeKey },
     { NULL,                                 NULL }
 };

--- a/modules/rostests/kmtests/ntos_cm/CmNotify.c
+++ b/modules/rostests/kmtests/ntos_cm/CmNotify.c
@@ -1,0 +1,281 @@
+/*
+ * PROJECT:         ReactOS kernel-mode tests
+ * LICENSE:         See COPYING in the top level directory
+ * PURPOSE:         Kernel-Mode Test Suite, Registry change notification
+ * PROGRAMMER:      Mohammad Amin Mollazadeh <madamin@pm.me>
+ */
+
+#include <kmt_test.h>
+
+/* Helper functions */
+
+#define ok_ntstatus(svar, sexpected) ok_eq_hex(svar, sexpected)
+#define CLEANUP(state) ZwNotifyChangeKey_Cleanup(state)
+#define CHECK_ERROR(state, Status) if (!NT_SUCCESS(Status)) { ok(FALSE, "Internal error, Status=0x%lx\n", Status); CLEANUP(state); return Status; }
+#define TEST_ERROR(state, Status, Expected)  ok_ntstatus(Status, Expected); if (Status != Expected) { CLEANUP(state); return Status; }
+#define INIT_TEST(state, Status) Status = ZwNotifyChangeKey_InitializePerTest(state); CHECK_ERROR(state, Status)
+#define FINALIZE_TEST(state) CLEANUP(state); return STATUS_SUCCESS
+#define RUN_TEST(state, Status, TestName) Status = ZwNotifyChangeKey_TEST_##TestName(state); ok(Status == STATUS_SUCCESS, "Subtest "#TestName" failed.\n")
+#define START_SUBTEST(TestName) NTSTATUS NTAPI ZwNotifyChangeKey_TEST_##TestName(PWATCH_REG_TEST_STATE state)
+
+typedef struct _WATCH_REG_TEST_STATE
+{
+    NTSTATUS Status;
+    HANDLE KeyHandle;
+    UNICODE_STRING KeyName;
+    OBJECT_ATTRIBUTES ObjectAttributes;
+    IO_STATUS_BLOCK IoStatusBlock;
+    UNICODE_STRING ValueName;
+    /* Thread */
+    LARGE_INTEGER WaitTimeout;
+    HANDLE WatchThreadHandle;
+    PKTHREAD WatchThreadObject;
+    /* Event */
+    HANDLE EventHandle;
+    PKEVENT EventObject;
+    /* Work queue item */
+    WORK_QUEUE_ITEM WorkQueueItem;
+
+} WATCH_REG_TEST_STATE, *PWATCH_REG_TEST_STATE;
+
+VOID NTAPI ZwNotifyChangeKey_Cleanup(PWATCH_REG_TEST_STATE state)
+{
+    if (state->EventObject)
+    {
+        ObDereferenceObject(state->EventObject);
+        state->EventObject = NULL;
+    }
+    if (state->EventHandle)
+    {
+        ObCloseHandle(state->EventHandle, KernelMode);
+        state->EventHandle = NULL;
+    }
+    if (state->WatchThreadObject)
+    {
+        ObDereferenceObject(state->WatchThreadObject);
+        state->WatchThreadObject = NULL;
+    }
+    if (state->WatchThreadHandle)
+    {
+        ObCloseHandle(state->WatchThreadHandle, KernelMode);
+        state->WatchThreadHandle = NULL;
+    }
+    if (state->KeyHandle)
+    {
+        ObCloseHandle(state->KeyHandle, KernelMode);
+        state->KeyHandle = NULL;
+    }
+}
+
+NTSTATUS NTAPI ZwNotifyChangeKey_Initialize(PWATCH_REG_TEST_STATE state)
+{
+    NTSTATUS Status;
+
+    state->WaitTimeout.QuadPart = -1 * 100 * 1000 * 10;
+
+    state->KeyHandle = NULL;
+    state->WatchThreadHandle = NULL;
+    state->WatchThreadObject = NULL;
+    state->EventHandle = NULL;
+    state->EventObject = NULL;
+
+    /* Setup object attributes */
+    RtlInitUnicodeString(&state->KeyName, L"\\Registry\\Machine\\SOFTWARE\\TestKey");
+    InitializeObjectAttributes(&state->ObjectAttributes, &state->KeyName, OBJ_CASE_INSENSITIVE | OBJ_KERNEL_HANDLE, NULL, NULL);
+    RtlInitUnicodeString(&state->ValueName, L"TestValue");
+
+    /* Create registry keys */
+    Status = ZwCreateKey(&state->KeyHandle, KEY_ALL_ACCESS, &state->ObjectAttributes, 0, NULL, REG_OPTION_NON_VOLATILE, NULL);
+    CHECK_ERROR(state, Status);
+
+    FINALIZE_TEST(state);
+}
+
+NTSTATUS NTAPI ZwNotifyChangeKey_CleanupTestKeys(PWATCH_REG_TEST_STATE state)
+{
+    NTSTATUS Status;
+
+    Status = ZwOpenKey(&state->KeyHandle, DELETE, &state->ObjectAttributes);
+    if (NT_SUCCESS(Status))
+    {
+        ZwDeleteKey(state->KeyHandle);
+        ObCloseHandle(state->KeyHandle, KernelMode);
+    }
+
+    return Status;
+}
+
+NTSTATUS NTAPI ZwNotifyChangeKey_InitializePerTest(PWATCH_REG_TEST_STATE state)
+{
+    NTSTATUS Status;
+
+    Status = ZwOpenKey(&state->KeyHandle, KEY_SET_VALUE | KEY_NOTIFY | DELETE, &state->ObjectAttributes);
+    CHECK_ERROR(state, Status);
+
+    DWORD32 DefaultValue = 0x12345678;
+    Status = ZwSetValueKey(state->KeyHandle, &state->ValueName, 0, REG_DWORD, &DefaultValue, sizeof(DefaultValue));
+    CHECK_ERROR(state, Status);
+
+    state->IoStatusBlock.Status = 0xdeadbeef;
+
+    return STATUS_SUCCESS;
+}
+
+/* Sync test watch thread */
+
+_Function_class_(KSTART_ROUTINE)
+VOID NTAPI ZwNotifyChangeKey_WatchThread(_In_ PVOID lpParameter)
+{
+    PWATCH_REG_TEST_STATE State = (PWATCH_REG_TEST_STATE)lpParameter;
+    
+    State->Status = ZwNotifyChangeKey(State->KeyHandle, NULL, NULL, NULL, &State->IoStatusBlock, REG_NOTIFY_CHANGE_LAST_SET, FALSE, NULL, 0, FALSE);
+}
+
+/* Async test queue worker item */
+
+_Function_class_(WORKER_THREAD_ROUTINE)
+VOID NTAPI ZwNotifyChangeKey_ItemWorker(_In_ PVOID pParameter)
+{
+    PWATCH_REG_TEST_STATE ctx = (PWATCH_REG_TEST_STATE)pParameter;
+
+    /* Signal that we received a notification */
+    KeSetEvent(ctx->EventObject, 1, FALSE);
+}
+
+/* Tests */
+
+START_SUBTEST(Synchronous)
+{
+    NTSTATUS Status;
+    DWORD32 ValueData = 0x87654321;
+
+    INIT_TEST(state, Status);
+
+    /* Create a thread */
+    Status = PsCreateSystemThread(&state->WatchThreadHandle, THREAD_ALL_ACCESS, NULL, NULL, NULL, ZwNotifyChangeKey_WatchThread, state);
+    CHECK_ERROR(state, Status);
+    Status = ObReferenceObjectByHandle(state->WatchThreadHandle, THREAD_ALL_ACCESS, NULL, KernelMode, (PVOID*)&state->WatchThreadObject, NULL);
+    CHECK_ERROR(state, Status);
+
+    /* Verify the thread is still running */
+    Status = KeWaitForSingleObject(state->WatchThreadObject, Executive, KernelMode, FALSE, &state->WaitTimeout);
+    if (Status != STATUS_TIMEOUT)
+    {
+        ok(FALSE, "Thread terminated soon unexpectedly (0x%lx, 0x%lx)\n", state->Status, Status);
+        CLEANUP(state);
+        return STATUS_UNSUCCESSFUL;
+    }
+
+    /* Make change to the registry key */
+    Status = ZwSetValueKey(state->KeyHandle, &state->ValueName, 0, REG_DWORD, &ValueData, sizeof(ValueData));
+    CHECK_ERROR(state, Status);
+    /* Give system some time to process the change and notify our watch thread */
+    KeDelayExecutionThread(KernelMode, FALSE, &state->WaitTimeout);
+    /* Verify that the thread is notified */
+    Status = KeWaitForSingleObject(state->WatchThreadObject, Executive, KernelMode, FALSE, &state->WaitTimeout);
+    ok_ntstatus(Status, STATUS_WAIT_0);
+
+    /* Verify thread's return value */
+    ok_ntstatus(state->Status, STATUS_NOTIFY_ENUM_DIR);
+    ok_ntstatus(state->IoStatusBlock.Status, STATUS_NOTIFY_ENUM_DIR);
+
+    FINALIZE_TEST(state);
+}
+
+START_SUBTEST(AsynchronousEvent)
+{
+    NTSTATUS Status;
+    DWORD32 ValueData = 0x87654321;
+
+    INIT_TEST(state, Status);
+
+    /* Initialize event */
+    Status = ZwCreateEvent(&state->EventHandle, EVENT_ALL_ACCESS, NULL, NotificationEvent, FALSE);
+    CHECK_ERROR(state, Status);
+    Status = ObReferenceObjectByHandle(state->EventHandle, EVENT_ALL_ACCESS, NULL, KernelMode, (PVOID*)&state->EventObject, NULL);
+    CHECK_ERROR(state, Status);
+
+    /* Listen for notification */
+    Status = ZwNotifyChangeKey(state->KeyHandle, state->EventHandle, NULL, NULL, &state->IoStatusBlock, REG_NOTIFY_CHANGE_LAST_SET, FALSE, NULL, 0, TRUE);
+    ok_ntstatus(Status, STATUS_PENDING);
+
+    /* Check event state */
+    Status = KeWaitForSingleObject(state->EventObject, Executive, KernelMode, FALSE, &state->WaitTimeout);
+    if (Status != STATUS_TIMEOUT)
+    {
+        CLEANUP(state);
+        return STATUS_UNSUCCESSFUL;
+    }
+
+    /* Make change to the registry key */
+    Status = ZwSetValueKey(state->KeyHandle, &state->ValueName, 0, REG_DWORD, &ValueData, sizeof(ValueData));
+    CHECK_ERROR(state, Status);
+
+    /* Verify that the event is signaled */
+    Status = KeWaitForSingleObject(state->EventObject, Executive, KernelMode, FALSE, &state->WaitTimeout);
+    ok_ntstatus(Status, STATUS_WAIT_0);
+    
+    /* Windows ignores IO_STATUS_BLOCK on Aynchronous kernel-mode calls */
+
+    FINALIZE_TEST(state);
+}
+
+START_SUBTEST(AsynchronousWqi)
+{
+    NTSTATUS Status;
+    DWORD32 ValueData = 0x87654321;
+
+    INIT_TEST(state, Status);
+
+    /* Initialize event */
+    Status = ZwCreateEvent(&state->EventHandle, EVENT_ALL_ACCESS, NULL, NotificationEvent, FALSE);
+    CHECK_ERROR(state, Status);
+    Status = ObReferenceObjectByHandle(state->EventHandle, EVENT_ALL_ACCESS, NULL, KernelMode, (PVOID*)&state->EventObject, NULL);
+    CHECK_ERROR(state, Status);
+
+    /* Initialize Work Queue Item */
+    ExInitializeWorkItem(&state->WorkQueueItem, ZwNotifyChangeKey_ItemWorker, state);
+
+    /* Listen for notification */
+    Status = ZwNotifyChangeKey(state->KeyHandle, NULL, (PVOID)&state->WorkQueueItem, (PVOID)DelayedWorkQueue, &state->IoStatusBlock, REG_NOTIFY_CHANGE_LAST_SET, FALSE, NULL, 0, TRUE);
+    ok_ntstatus(Status, STATUS_PENDING);
+
+    /* Check event state */
+    Status = KeWaitForSingleObject(state->EventObject, Executive, KernelMode, FALSE, &state->WaitTimeout);
+    if (Status != STATUS_TIMEOUT)
+    {
+        CLEANUP(state);
+        return STATUS_UNSUCCESSFUL;
+    }
+
+    /* Make change to the registry key */
+    Status = ZwSetValueKey(state->KeyHandle, &state->ValueName, 0, REG_DWORD, &ValueData, sizeof(ValueData));
+    CHECK_ERROR(state, Status);
+
+    /* Verify that the event is signaled */
+    Status = KeWaitForSingleObject(state->EventObject, Executive, KernelMode, FALSE, &state->WaitTimeout);
+    ok_ntstatus(Status, STATUS_WAIT_0);
+
+    /* Windows ignores IO_STATUS_BLOCK on Aynchronous kernel-mode calls */
+
+    FINALIZE_TEST(state);
+}
+
+
+/* Main */
+
+START_TEST(ZwNotifyChangeKey)
+{
+    NTSTATUS Status;
+    WATCH_REG_TEST_STATE State;
+
+    ZwNotifyChangeKey_Initialize(&State);
+    
+    /* See also: modules/rostests/apitests/ntdll/NtNotifyChangeMultipleKeys */
+
+    RUN_TEST(&State, Status, Synchronous);
+    RUN_TEST(&State, Status, AsynchronousEvent);
+    RUN_TEST(&State, Status, AsynchronousWqi);
+    
+    ZwNotifyChangeKey_CleanupTestKeys(&State);
+}

--- a/ntoskrnl/config/cminit.c
+++ b/ntoskrnl/config/cminit.c
@@ -105,8 +105,6 @@ CmpInitializeHive(
     Hive->UseCountLog.Next = 0;
     Hive->LockHiveLog.Next = 0;
     Hive->FileObject = NULL;
-    Hive->NotifyList.Flink = NULL;
-    Hive->NotifyList.Blink = NULL;
 
     /* Set the loading flag */
     Hive->HiveIsLoading = TRUE;
@@ -118,6 +116,7 @@ CmpInitializeHive(
     InitializeListHead(&Hive->KcbConvertListHead);
     InitializeListHead(&Hive->KnodeConvertListHead);
     InitializeListHead(&Hive->TrustClassEntry);
+    InitializeListHead(&Hive->NotifyList);
 
     /* Allocate the view log */
     Hive->ViewLock = ExAllocatePoolWithTag(NonPagedPool,

--- a/ntoskrnl/config/cmnotify.c
+++ b/ntoskrnl/config/cmnotify.c
@@ -12,8 +12,250 @@
 #define NDEBUG
 #include "debug.h"
 
+/* NOTIFICATION LOCK *********************************************************/
+
+ERESOURCE CmpNotificationLock;
+
+VOID
+NTAPI
+CmpLockNotifyShared()
+{
+    KeEnterCriticalRegion();
+    ExAcquireResourceSharedLite(&CmpNotificationLock, TRUE);
+}
+
+VOID
+NTAPI
+CmpLockNotifyExclusive()
+{
+    KeEnterCriticalRegion();
+    ExAcquireResourceExclusiveLite(&CmpNotificationLock, TRUE);
+}
+
+VOID
+NTAPI
+CmpUnlockNotify()
+{
+    ExReleaseResourceLite(&CmpNotificationLock);
+    KeLeaveCriticalRegion();
+}
+
+/* INTERNAL FUNCTIONS ********************************************************/
+
+/**
+ * @brief
+ * Checks if SubKey is part of ParentKey's tree.
+ * 
+ * @param[in] ParentKey
+ * KeyControlBlock for the parent key.
+ * 
+ * @param[in] SubKey
+ * KeyControlBlock for the potential subkey of ParentKey.
+ * 
+ * @return
+ * TRUE is ParentKey is found while walking SubKey's parents, FALSE if not.
+ */
+BOOLEAN
+NTAPI
+CmpIsKcbSubKey(_In_ PCM_KEY_CONTROL_BLOCK ParentKey,
+               _In_ PCM_KEY_CONTROL_BLOCK SubKey)
+{
+    ULONG Depth;
+    PCM_KEY_CONTROL_BLOCK SubKeyParent;
+
+    /* This helps to optimize our search for our parents */
+    Depth = SubKey->TotalLevels - ParentKey->TotalLevels;
+    /* A subkey must be deeper than its parent */
+    if (Depth <= 0)
+        return FALSE;
+
+    /* Walk the parents tree, either it reaches to the root or it reaches to the NotifyBlock's KCB */
+    SubKeyParent = SubKey->ParentKcb;
+    while (SubKeyParent != NULL && SubKeyParent != ParentKey && Depth >= 0)
+    {
+        SubKeyParent = SubKeyParent->ParentKcb;
+        Depth--;
+    }
+    return SubKeyParent == ParentKey;
+}
+
+/**
+ * @brief
+ * Helper function for releasing resources allocated for Subordinate objects in a NotifyBlock
+ */
+VOID
+NTAPI
+CmpPostBlockFreeSubordinates(_In_ ULONG Count,
+                             _In_ PCM_NOTIFY_BLOCK* Subordinates)
+{
+    PCM_POST_BLOCK PostBlock;
+
+    if (Count <= 0) return;
+
+    for (int i = 0; i < Count; i++)
+    {
+        /* Every subordinate has one PostBlock, because the KeyBody is allocated internally just for us and we didn't allocate more */
+        PostBlock = CONTAINING_RECORD(Subordinates[i]->PostList.Flink, CM_POST_BLOCK, NotifyList);
+        RemoveEntryList(&PostBlock->NotifyList);
+        ExFreePoolWithTag(PostBlock, TAG_CM);
+    }
+
+    /* At last free the array itself */
+    ExFreePoolWithTag(Subordinates, TAG_CM);
+}
+
+/**
+ * @brief
+ * Helper function for sending change notification to a PostBlock
+ */
+VOID
+NTAPI
+CmpNotifyPostBlock(_In_ PCM_POST_BLOCK PostBlock)
+{
+    if (PostBlock->IoStatusBlock /* && !PostBlock->Buffer */)
+    {
+        KAPC_STATE ApcState;
+        BOOLEAN IsSameProcess = PostBlock->Process == &PsGetCurrentProcess()->Pcb;
+
+        if (!IsSameProcess)
+            KeStackAttachProcess(PostBlock->Process, &ApcState);
+
+        _SEH2_TRY
+        {
+            PostBlock->IoStatusBlock->Status = STATUS_NOTIFY_ENUM_DIR;
+        }
+        _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+        {
+            NTSTATUS Status = _SEH2_GetExceptionCode();
+            DPRINT1("CmpNotifyPostBlock: Writing to IO_STATUS_BLOCK failed with %lx. Process=0x%lx, IoStatusBlock=0x%lx\n", Status, PostBlock->Process, PostBlock->IoStatusBlock);
+        }
+        _SEH2_END;
+
+        if (!IsSameProcess)
+            KeUnstackDetachProcess(&ApcState);
+    }
+
+    /* FIXME: Return the name of updated registry key in PostBlock->Buffer */
+
+    /* Signal the event */
+    if (PostBlock->Event)
+        KeSetEvent(PostBlock->Event, 1, FALSE);
+
+    /* Queue the Work Item */
+    if (PostBlock->WorkQueueItem)
+        ExQueueWorkItem(PostBlock->WorkQueueItem, PostBlock->WorkQueueType);
+
+    /* Queue the APC routine */
+    if (PostBlock->UserApc)
+    {
+        KeInsertQueueApc(PostBlock->UserApc, PostBlock, (PVOID)STATUS_NOTIFY_ENUM_DIR, 0);
+
+        /* We can't free the resource, yet
+         * There's an APC routine to be called so we still need them
+         * Let the CmpApcKernelRoutine handle it for us
+         */
+
+        /* Even though we are not freeing the resources, we don't want the PostBlock be triggered twice 
+         * Remove it from the post list
+         */
+        RemoveEntryList(&(PostBlock->NotifyList));
+        CmpPostBlockFreeSubordinates(PostBlock->SubCount, PostBlock->SubNotifyBlocks);
+        PostBlock->SubCount = 0;
+        PostBlock->SubNotifyBlocks = NULL;
+
+        return;
+    }
+
+    /* Cleanup resources */
+    if (PostBlock->Event)
+        ObDereferenceObject(PostBlock->Event);
+
+    /* WorkQueueItem should be handled by the caller, not us */
+
+    /* Remove post block entry */
+    RemoveEntryList(&(PostBlock->NotifyList));
+
+    /* Release subordinate NotifyBlocks */
+    CmpPostBlockFreeSubordinates(PostBlock->SubCount, PostBlock->SubNotifyBlocks);
+
+    /* Free the memory */
+    ExFreePoolWithTag(PostBlock, TAG_CM);
+}
+
+/* APC ROUTINES **************************************************************/
+
+VOID
+NTAPI 
+CmpApcKernelRoutine(_In_ PKAPC Apc,
+                    _Inout_ PKNORMAL_ROUTINE *NormalRoutine OPTIONAL,
+                    _Inout_ PVOID *NormalContext OPTIONAL,
+                    _Inout_ PVOID *SystemArgument1 OPTIONAL,
+                    _Inout_ PVOID *SystemArgument2 OPTIONAL)
+{
+    PCM_POST_BLOCK PostBlock = (PCM_POST_BLOCK)*SystemArgument1;
+
+    /* TODO: Set IO_STATUS_BLOCK */
+    /* NTSTATUS Status = (NTSTATUS)SystemArgument2; */
+
+    /* Cleanup resources */
+    if (PostBlock->Event)
+    {
+        ObDereferenceObject(PostBlock->Event);
+        PostBlock->Event = NULL;
+    }
+
+    /* We released subordinates resources before queueing the APC, so there's no need to release them here again */
+
+    /* it's safe to release the KAPC here */
+    ExFreePoolWithTag(PostBlock->UserApc, TAG_CM);
+    PostBlock->UserApc = NULL;
+
+    ExFreePoolWithTag(PostBlock, TAG_CM);
+    SystemArgument1 = NULL;
+}
+
+VOID
+NTAPI 
+CmpApcRoutineRundown(_In_ PKAPC Apc)
+{
+    if (!Apc->SystemArgument1) return;
+
+    PCM_POST_BLOCK PostBlock = (PCM_POST_BLOCK)Apc->SystemArgument1;
+
+    /* TODO: Set IO_STATUS_BLOCK */
+    /* NTSTATUS Status = (NTSTATUS)SystemArgument2; */
+
+    /* Cleanup resources */
+    if (PostBlock->Event)
+    {
+        ObDereferenceObject(PostBlock->Event);
+        PostBlock->Event = NULL;
+    }
+    
+    ExFreePoolWithTag(PostBlock->UserApc, TAG_CM);
+    PostBlock->UserApc = NULL;
+
+    ExFreePoolWithTag(PostBlock, TAG_CM);
+}
+
 /* FUNCTIONS *****************************************************************/
 
+/**
+ * @brief
+ * Report a change notifications to its listeners
+ * 
+ * @param[in] Kcb
+ * The KeyControlBlock of the changed registry key
+ * 
+ * @param[in] Hive
+ * The registry hive containing the KCB, this is used for enumerating NotifyBlocks
+ * 
+ * @param[in] Cell
+ * This parameter is unused.
+ * 
+ * @param[in] Filter
+ * The notification type, one of REG_CHANGE_FILTER_* enum values.
+ */
 VOID
 NTAPI
 CmpReportNotify(IN PCM_KEY_CONTROL_BLOCK Kcb,
@@ -21,16 +263,319 @@ CmpReportNotify(IN PCM_KEY_CONTROL_BLOCK Kcb,
                 IN HCELL_INDEX Cell,
                 IN ULONG Filter)
 {
-    /* FIXME: TODO */
-    return;
+    PCMHIVE KeyHive;
+    PLIST_ENTRY ListHead, NextEntry;
+    PLIST_ENTRY PostListHead, PostNextEntry;
+    PCM_NOTIFY_BLOCK NotifyBlock;
+    PCM_POST_BLOCK PostBlock;
+
+    /* Acquire notification lock */
+    CmpLockNotifyShared();
+
+    /* Find the CMHIVE linked to this Hive */
+    KeyHive = CONTAINING_RECORD(Hive, CMHIVE, Hive);
+    
+    /* Get NotifyBlock list on the Hive */
+    ListHead = &(KeyHive->NotifyList);
+    if (IsListEmpty(ListHead))
+    {
+        CmpUnlockNotify();
+        return;
+    }
+
+    /* Enumerate through CMHIVE->NotifyList */
+    NextEntry = ListHead->Flink;
+    while (NextEntry != ListHead)
+    {
+        NotifyBlock = CONTAINING_RECORD(NextEntry, CM_NOTIFY_BLOCK, HiveList);
+        NextEntry = NextEntry->Flink;
+
+        /* Check if this KCB matches to this NotifyBlock */
+        if (NotifyBlock->KeyControlBlock != Kcb && 
+            !(NotifyBlock->WatchTree && CmpIsKcbSubKey(NotifyBlock->KeyControlBlock, Kcb)))
+            continue;
+
+        /* Check the notification filter */
+        if ((NotifyBlock->Filter & Filter) != Filter) 
+            continue;
+
+        /* Enumerate PostBlocks */
+        PostListHead = &(NotifyBlock->PostList);
+        if (IsListEmpty(PostListHead))
+        {
+            /* A notification block is allocated but no one is watching, so this is a pending notification */
+            NotifyBlock->NotifyPending = TRUE;
+            continue;
+        }
+        PostNextEntry = PostListHead->Flink;
+        while (PostNextEntry != PostListHead)
+        {
+            PostBlock = CONTAINING_RECORD(PostNextEntry, CM_POST_BLOCK, NotifyList);
+            PostNextEntry = PostNextEntry->Flink;
+
+            if (PostBlock->IsMasterPostBlock)
+            {
+                CmpNotifyPostBlock(PostBlock);
+            }
+            else
+            {
+                /* Let the master handle the notification */
+
+                /* Hold a copy of the master KCB because we might get freed later */
+                PCM_KEY_CONTROL_BLOCK MasterKcb = PostBlock->MasterNotifyBlock->KeyControlBlock;
+                /* Lock the master KCB before we do anything with its NotifyBlock */
+                CmpAcquireKcbLockShared(MasterKcb);
+                
+                CmpNotifyPostBlock(PostBlock->MasterPostBlock);
+                
+                CmpReleaseKcbLock(MasterKcb);
+            }
+        }
+    }
+
+    CmpUnlockNotify();
 }
 
+/**
+ * @brief
+ * Free the resources allocated for a NotifyBlock on a KeyBody. 
+ * This is called when system is deleting a key body object, or it's closing a handle to a registry key.
+ * 
+ * @param[in] LockHeld
+ * TRUE if calling while the KCB is already locked, FALSE if it not
+ */
 VOID
 NTAPI
 CmpFlushNotify(IN PCM_KEY_BODY KeyBody,
                IN BOOLEAN LockHeld)
 {
-    /* FIXME: TODO */
-    return;
+    PLIST_ENTRY ListHead, NextEntry;
+    PCM_POST_BLOCK PostBlock;
+
+    /* Lock the KCB so no one would try to make changes
+     * to NotifyBlock while we are releasing its resources
+     */
+    if (!LockHeld)
+        CmpAcquireKcbLockExclusive(KeyBody->KeyControlBlock);
+
+    /* Enumerate PostBlocks */
+    ListHead = &(KeyBody->NotifyBlock->PostList);
+    NextEntry = ListHead->Flink;
+    while (NextEntry != ListHead)
+    {
+        PostBlock = CONTAINING_RECORD(NextEntry, CM_POST_BLOCK, NotifyList);
+        NextEntry = NextEntry->Flink;
+
+        /* This shouldn't happen, We don't assign subordinate NotifyBlocks to a KeyBody */
+        ASSERT(PostBlock->IsMasterPostBlock);
+
+        if (PostBlock->IoStatusBlock)
+        {
+            /* No need to KeStackAttachProcess, the handle is closed on in the context of the same process as the original caller */
+            _SEH2_TRY
+            {
+                /* We are ending the notification session without signalling the caller for any change */
+                PostBlock->IoStatusBlock->Status = STATUS_NOTIFY_CLEANUP;
+            }
+            _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+            {
+                NTSTATUS Status = _SEH2_GetExceptionCode();
+                DPRINT1("CmpFlushNotify: Writing to IO_STATUS_BLOCK failed with %lx. Process=0x%lx, IoStatusBlock=0x%lx\n", Status, PostBlock->Process, PostBlock->IoStatusBlock);
+            }   
+            _SEH2_END;
+        }
+
+        if (PostBlock->Event)
+        {
+            /* Signal the event in case somebody is waiting, the notification session is ending and there won't be any notifications */
+            KeSetEvent(PostBlock->Event, 1, FALSE);
+
+            ObDereferenceObject(PostBlock->Event);
+        }
+
+        if (PostBlock->UserApc)
+            ExFreePoolWithTag(PostBlock->UserApc, TAG_CM);
+
+        RemoveEntryList(&(PostBlock->NotifyList));
+        CmpPostBlockFreeSubordinates(PostBlock->SubCount, PostBlock->SubNotifyBlocks);
+        ExFreePoolWithTag(PostBlock, TAG_CM);
+    }
+
+    /* Free the NotifyBlock */
+    RemoveEntryList(&(KeyBody->NotifyBlock->HiveList));
+    ExFreePoolWithTag(KeyBody->NotifyBlock, TAG_CM);
+    KeyBody->NotifyBlock = NULL;
+
+    /* Unlock the Kcb if we locked it previously */
+    if (!LockHeld)
+        CmpReleaseKcbLock(KeyBody->KeyControlBlock);
 }
 
+/**
+ * @brief
+ * Allocate a NotifyBlock for a registry key, and attach it to the hive.
+ * KeyBody->NotifyBlock should be set manually.
+ * 
+ * @param[in] KeyBody
+ * The registry key to be watched for notifications
+ * 
+ * @param[in] Filter
+ * The desired notification type, a bit flag of REG_CHANGE_FILTER_* enum values
+ */
+NTSTATUS
+NTAPI
+CmpInsertNotifyBlock(_In_ PCM_KEY_BODY KeyBody,
+                     _In_ ULONG Filter,
+                     _In_ BOOLEAN WatchTree,
+                     _Out_ PCM_NOTIFY_BLOCK *Result)
+{
+    PCM_NOTIFY_BLOCK NotifyBlock;
+    PCMHIVE Hive;
+
+    /* Allocate memory */
+    NotifyBlock = ExAllocatePoolWithTag(NonPagedPool, sizeof(CM_NOTIFY_BLOCK), TAG_CM);
+    if (!NotifyBlock)
+    {
+        *Result = NULL;
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+    RtlZeroMemory(NotifyBlock, sizeof(CM_NOTIFY_BLOCK));Expand commentComment on lines R436 to R443Resolved
+
+    /* Initialize list heads */
+    InitializeListHead(&NotifyBlock->HiveList);
+    InitializeListHead(&NotifyBlock->PostList);
+
+    /* Initialize fields */
+    NotifyBlock->Filter = Filter;
+    NotifyBlock->WatchTree = WatchTree;
+
+    /* Attach to the key object */
+    NotifyBlock->KeyControlBlock = KeyBody->KeyControlBlock;
+    NotifyBlock->KeyBody = KeyBody;
+    /* Let the caller attach us to the KeyBody, because if this is a subordinate our owner would be the master not the KeyBody */
+    /*KeyBody->NotifyBlock = NotifyBlock;*/
+
+    /* Attach to the hive */
+    Hive = CONTAINING_RECORD(KeyBody->KeyControlBlock->KeyHive, CMHIVE, Hive);
+    InsertHeadList(&(Hive->NotifyList), &(NotifyBlock->HiveList));
+
+    *Result = NotifyBlock;
+    return STATUS_SUCCESS;
+}
+
+/**
+ * @brief
+ * Allocate a PostBlock and insert it to a NotifyBlock.
+ * A PostBlock holds information for a notification callback.
+ * 
+ * @param[in] NotifyBlock
+ * The NotifyBlock for attaching the PostBlock to.
+ * 
+ * @param[in] EventObject
+ * The event object to signal when a notification occured, will be dereferenced after signalling the event.
+ * 
+ * @param[in] ApcRoutine
+ * The user-mode APC routine to be queued when a notification occured
+ * 
+ * @param[in] ApcContext
+ * The parameter to be passed to the ApcRoutine
+ */
+NTSTATUS
+NTAPI
+CmpInsertPostBlock(_In_      PCM_NOTIFY_BLOCK NotifyBlock,
+                   _In_opt_  PKEVENT EventObject,
+                   _In_opt_  PIO_APC_ROUTINE ApcRoutine,
+                   _In_opt_  PVOID ApcContext,
+                   _Out_     PCM_POST_BLOCK *Result)
+{
+    PKAPC LocalApc;
+    PCM_POST_BLOCK PostBlock;
+
+    /* Initialize KAPC if an APC routine provided */
+    if (ApcRoutine)
+    {
+        PETHREAD CurrentThread = PsGetCurrentThread();
+        LocalApc = ExAllocatePoolWithTag(NonPagedPool, sizeof(KAPC), TAG_CM);
+        if (!LocalApc)
+            return STATUS_INSUFFICIENT_RESOURCES;
+
+        KeInitializeApc(LocalApc,
+                        &CurrentThread->Tcb,
+                        CurrentApcEnvironment,
+                        CmpApcKernelRoutine,
+                        CmpApcRoutineRundown,
+                        (PKNORMAL_ROUTINE)ApcRoutine,
+                        UserMode,
+                        ApcContext);
+    }
+    else
+    {
+        LocalApc = NULL;
+    }
+
+    /* Allocate memory */
+    PostBlock = ExAllocatePoolZero(NonPagedPool, sizeof(CM_POST_BLOCK), TAG_CM);
+    if (!PostBlock)
+    {
+        ExFreePoolWithTag(LocalApc, TAG_CM);
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+
+    /* Initialize list heads */
+    InitializeListHead(&(PostBlock->NotifyList));
+
+    /* Fill fields */
+    PostBlock->IsMasterPostBlock = TRUE;
+    PostBlock->Event = EventObject;
+    PostBlock->UserApc = LocalApc;
+
+    /* Insert to NotifyBlock */
+    InsertHeadList(&(NotifyBlock->PostList), &(PostBlock->NotifyList));
+
+    *Result = PostBlock;
+    return STATUS_SUCCESS;
+}
+
+/**
+ * @brief
+ * Allocate a PostBlock and insert it to a NotifyBlock for a subordinate object.
+ * The PostBlock will be released by the master NotifyBlock.
+ * 
+ * @param[in] NotifyBlock
+ * The subordinate NotifyBlock to insert the PostBlock to.
+ * 
+ * @param[in] MasterNotifyBlock
+ * The NotifyBlock for the master registry key
+ * 
+ * @param[in] MasterPostBlock
+ * The PostBlock allocated for the master registry key
+ */
+NTSTATUS
+NTAPI
+CmpInsertSubPostBlock(_In_  PCM_NOTIFY_BLOCK NotifyBlock,
+                      _In_  PCM_NOTIFY_BLOCK MasterNotifyBlock,
+                      _In_  PCM_POST_BLOCK MasterPostBlock,
+                      _Out_ PCM_POST_BLOCK *Result)
+{
+    PCM_POST_BLOCK PostBlock;
+
+    /* Allocate memory */
+    PostBlock = ExAllocatePoolZero(NonPagedPool, sizeof(CM_POST_BLOCK), TAG_CM);
+    if (!PostBlock)
+    {
+        *Result = NULL;
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+
+    PostBlock->IsMasterPostBlock = FALSE;
+
+    /* Attach to master NotifyBlock */
+    PostBlock->MasterNotifyBlock = MasterNotifyBlock;
+    PostBlock->MasterPostBlock = MasterPostBlock;
+
+    /* Attach to our NotifyBlock */
+    InsertHeadList(&(NotifyBlock->PostList), &(PostBlock->NotifyList));
+
+    *Result = PostBlock;
+    return STATUS_SUCCESS;
+}

--- a/ntoskrnl/config/cmnotify.c
+++ b/ntoskrnl/config/cmnotify.c
@@ -439,7 +439,7 @@ CmpInsertNotifyBlock(_In_ PCM_KEY_BODY KeyBody,
         *Result = NULL;
         return STATUS_INSUFFICIENT_RESOURCES;
     }
-    RtlZeroMemory(NotifyBlock, sizeof(CM_NOTIFY_BLOCK));Expand commentComment on lines R436 to R443Resolved
+    RtlZeroMemory(NotifyBlock, sizeof(CM_NOTIFY_BLOCK));
 
     /* Initialize list heads */
     InitializeListHead(&NotifyBlock->HiveList);

--- a/ntoskrnl/config/cmnotify.c
+++ b/ntoskrnl/config/cmnotify.c
@@ -238,6 +238,7 @@ CmpApcRoutineRundown(_In_ PKAPC Apc)
     ExFreePoolWithTag(PostBlock, TAG_CM);
 }
 
+
 /* FUNCTIONS *****************************************************************/
 
 /**
@@ -439,7 +440,7 @@ CmpInsertNotifyBlock(_In_ PCM_KEY_BODY KeyBody,
         *Result = NULL;
         return STATUS_INSUFFICIENT_RESOURCES;
     }
-    RtlZeroMemory(NotifyBlock, sizeof(CM_NOTIFY_BLOCK));Expand commentComment on lines R436 to R443Resolved
+    RtlZeroMemory(NotifyBlock, sizeof(CM_NOTIFY_BLOCK));
 
     /* Initialize list heads */
     InitializeListHead(&NotifyBlock->HiveList);

--- a/ntoskrnl/config/cmnotify.c
+++ b/ntoskrnl/config/cmnotify.c
@@ -212,7 +212,7 @@ CmpNotifyPostBlock(_In_ PCM_POST_BLOCK PostBlock,
     /* Queue the APC routine */
     if (PostBlock->UserApc)
     {
-        KeInsertQueueApc(PostBlock->UserApc, PostBlock, (PVOID)Status, 0);
+        KeInsertQueueApc(PostBlock->UserApc, PostBlock, (PVOID)(ULONG_PTR)Status, 0);
 
         /* We can't free the resource, yet
          * There's an APC routine to be called so we still need them
@@ -257,7 +257,7 @@ CmpApcKernelRoutine(_In_ PKAPC Apc,
                     _Inout_ PVOID *SystemArgument2 OPTIONAL)
 {
     PCM_POST_BLOCK PostBlock = (PCM_POST_BLOCK)*SystemArgument1;
-    NTSTATUS Status = (NTSTATUS)(*SystemArgument2);
+    NTSTATUS Status = (NTSTATUS)(ULONG_PTR)(*SystemArgument2);
 
     if (PostBlock && PostBlock->IoStatusBlock)
     {

--- a/ntoskrnl/config/cmnotify.c
+++ b/ntoskrnl/config/cmnotify.c
@@ -106,13 +106,62 @@ CmpPostBlockFreeSubordinates(_In_ ULONG Count,
 
 /**
  * @brief
+ * Fills the user buffer with the full name of the changed registry key.
+ */
+static
+NTSTATUS
+CmpFillChangedKeyName(
+    _In_ PCM_KEY_CONTROL_BLOCK Kcb,
+    _In_ PVOID Buffer,
+    _In_ ULONG BufferSize,
+    _Out_ PULONG ReturnLength)
+{
+    PUNICODE_STRING KeyName;
+    ULONG BytesToCopy;
+
+    *ReturnLength = 0;
+
+    if (!Buffer || BufferSize == 0 || !Kcb)
+        return STATUS_SUCCESS;
+
+    KeyName = CmpConstructName(Kcb);
+    if (!KeyName)
+        return STATUS_INSUFFICIENT_RESOURCES;
+
+    *ReturnLength = KeyName->Length + sizeof(WCHAR);
+
+    if (BufferSize < *ReturnLength)
+    {
+        /* If the buffer is too small, we truncate and null terminate */
+        BytesToCopy = BufferSize - sizeof(WCHAR);
+        RtlCopyMemory(Buffer, KeyName->Buffer, BytesToCopy);
+        ((PWCHAR)Buffer)[BytesToCopy / sizeof(WCHAR)] = UNICODE_NULL;
+
+        ExFreePoolWithTag(KeyName, TAG_CM);
+        return STATUS_BUFFER_OVERFLOW;
+    }
+
+    /* Copy the name and write the NUL terminator explicitly */
+    RtlCopyMemory(Buffer, KeyName->Buffer, KeyName->Length);
+    ((PWCHAR)Buffer)[KeyName->Length / sizeof(WCHAR)] = UNICODE_NULL;
+
+    ExFreePoolWithTag(KeyName, TAG_CM);
+    return STATUS_SUCCESS;
+}
+
+/**
+ * @brief
  * Helper function for sending change notification to a PostBlock
  */
 VOID
 NTAPI
-CmpNotifyPostBlock(_In_ PCM_POST_BLOCK PostBlock)
+CmpNotifyPostBlock(_In_ PCM_POST_BLOCK PostBlock,
+                   _In_opt_ PCM_KEY_CONTROL_BLOCK ChangedKcb)
 {
-    if (PostBlock->IoStatusBlock /* && !PostBlock->Buffer */)
+    NTSTATUS Status = STATUS_NOTIFY_ENUM_DIR;
+    ULONG ReturnedLength = 0;
+
+    if (PostBlock->IoStatusBlock)
     {
         KAPC_STATE ApcState;
         BOOLEAN IsSameProcess = PostBlock->Process == &PsGetCurrentProcess()->Pcb;
@@ -122,20 +171,35 @@ CmpNotifyPostBlock(_In_ PCM_POST_BLOCK PostBlock)
 
         _SEH2_TRY
         {
-            PostBlock->IoStatusBlock->Status = STATUS_NOTIFY_ENUM_DIR;
+            if (PostBlock->Buffer && PostBlock->BufferSize > 0)
+            {
+                PCM_KEY_CONTROL_BLOCK FillKcb = ChangedKcb ? ChangedKcb : PostBlock->Kcb;
+                if (FillKcb)
+                {
+                    Status = CmpFillChangedKeyName(FillKcb,
+                                                   PostBlock->Buffer,
+                                                   PostBlock->BufferSize,
+                                                   &ReturnedLength);
+                }
+            }
+
+            PostBlock->IoStatusBlock->Status = Status;
+            PostBlock->IoStatusBlock->Information = ReturnedLength;
         }
         _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
         {
-            NTSTATUS Status = _SEH2_GetExceptionCode();
-            DPRINT1("CmpNotifyPostBlock: Writing to IO_STATUS_BLOCK failed with %lx. Process=0x%lx, IoStatusBlock=0x%lx\n", Status, PostBlock->Process, PostBlock->IoStatusBlock);
+            NTSTATUS ExceptCode = _SEH2_GetExceptionCode();
+            DPRINT1("CmpNotifyPostBlock: Writing to IO_STATUS_BLOCK failed with 0x%lx. Process=0x%lx, IoStatusBlock=0x%lx\n",
+                    ExceptCode, PostBlock->Process, PostBlock->IoStatusBlock);
+
+            PostBlock->IoStatusBlock->Status = ExceptCode;
+            PostBlock->IoStatusBlock->Information = 0;
         }
         _SEH2_END;
 
         if (!IsSameProcess)
             KeUnstackDetachProcess(&ApcState);
     }
-
-    /* FIXME: Return the name of updated registry key in PostBlock->Buffer */
 
     /* Signal the event */
     if (PostBlock->Event)
@@ -148,7 +212,7 @@ CmpNotifyPostBlock(_In_ PCM_POST_BLOCK PostBlock)
     /* Queue the APC routine */
     if (PostBlock->UserApc)
     {
-        KeInsertQueueApc(PostBlock->UserApc, PostBlock, (PVOID)STATUS_NOTIFY_ENUM_DIR, 0);
+        KeInsertQueueApc(PostBlock->UserApc, PostBlock, (PVOID)Status, 0);
 
         /* We can't free the resource, yet
          * There's an APC routine to be called so we still need them
@@ -193,9 +257,14 @@ CmpApcKernelRoutine(_In_ PKAPC Apc,
                     _Inout_ PVOID *SystemArgument2 OPTIONAL)
 {
     PCM_POST_BLOCK PostBlock = (PCM_POST_BLOCK)*SystemArgument1;
+    NTSTATUS Status = (NTSTATUS)(*SystemArgument2);
 
-    /* TODO: Set IO_STATUS_BLOCK */
-    /* NTSTATUS Status = (NTSTATUS)SystemArgument2; */
+    if (PostBlock && PostBlock->IoStatusBlock)
+    {
+        /* Set the real status we decided in CmpNotifyPostBlock */
+        PostBlock->IoStatusBlock->Status = Status;
+        /* Information already set in CmpNotifyPostBlock */
+    }
 
     /* Cleanup resources */
     if (PostBlock->Event)
@@ -225,13 +294,19 @@ CmpApcRoutineRundown(_In_ PKAPC Apc)
     /* TODO: Set IO_STATUS_BLOCK */
     /* NTSTATUS Status = (NTSTATUS)SystemArgument2; */
 
+    if (PostBlock && PostBlock->IoStatusBlock)
+    {
+        PostBlock->IoStatusBlock->Status = STATUS_NOTIFY_CLEANUP;
+        PostBlock->IoStatusBlock->Information = 0;
+    }
+
     /* Cleanup resources */
     if (PostBlock->Event)
     {
         ObDereferenceObject(PostBlock->Event);
         PostBlock->Event = NULL;
     }
-    
+
     ExFreePoolWithTag(PostBlock->UserApc, TAG_CM);
     PostBlock->UserApc = NULL;
 
@@ -275,7 +350,7 @@ CmpReportNotify(IN PCM_KEY_CONTROL_BLOCK Kcb,
 
     /* Find the CMHIVE linked to this Hive */
     KeyHive = CONTAINING_RECORD(Hive, CMHIVE, Hive);
-    
+
     /* Get NotifyBlock list on the Hive */
     ListHead = &(KeyHive->NotifyList);
     if (IsListEmpty(ListHead))
@@ -316,7 +391,13 @@ CmpReportNotify(IN PCM_KEY_CONTROL_BLOCK Kcb,
 
             if (PostBlock->IsMasterPostBlock)
             {
-                CmpNotifyPostBlock(PostBlock);
+                /*
+                 * Pass the KCB of the key that actually changed so that
+                 * CmpNotifyPostBlock can write the right name into the
+                 * caller's buffer instead of always writing the name of the
+                 * root watched key.
+                 */
+                CmpNotifyPostBlock(PostBlock, Kcb);
             }
             else
             {
@@ -326,9 +407,14 @@ CmpReportNotify(IN PCM_KEY_CONTROL_BLOCK Kcb,
                 PCM_KEY_CONTROL_BLOCK MasterKcb = PostBlock->MasterNotifyBlock->KeyControlBlock;
                 /* Lock the master KCB before we do anything with its NotifyBlock */
                 CmpAcquireKcbLockShared(MasterKcb);
-                
-                CmpNotifyPostBlock(PostBlock->MasterPostBlock);
-                
+
+                /*
+                 * Forward the changed KCB to the master PostBlock as well so
+                 * that subordinate-triggered notifications also report the
+                 * correct key name.
+                 */
+                CmpNotifyPostBlock(PostBlock->MasterPostBlock, Kcb);
+
                 CmpReleaseKcbLock(MasterKcb);
             }
         }
@@ -377,6 +463,7 @@ CmpFlushNotify(IN PCM_KEY_BODY KeyBody,
             {
                 /* We are ending the notification session without signalling the caller for any change */
                 PostBlock->IoStatusBlock->Status = STATUS_NOTIFY_CLEANUP;
+                PostBlock->IoStatusBlock->Information = 0;   // No name returned on cleanup
             }
             _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
             {
@@ -529,6 +616,11 @@ CmpInsertPostBlock(_In_      PCM_NOTIFY_BLOCK NotifyBlock,
     PostBlock->IsMasterPostBlock = TRUE;
     PostBlock->Event = EventObject;
     PostBlock->UserApc = LocalApc;
+    PostBlock->Kcb = NotifyBlock->KeyControlBlock;
+    PostBlock->Process = &PsGetCurrentProcess()->Pcb;
+    PostBlock->Buffer = NULL;
+    PostBlock->BufferSize = 0;
+    PostBlock->IoStatusBlock = NULL;
 
     /* Insert to NotifyBlock */
     InsertHeadList(&(NotifyBlock->PostList), &(PostBlock->NotifyList));

--- a/ntoskrnl/config/cmsysini.c
+++ b/ntoskrnl/config/cmsysini.c
@@ -16,6 +16,7 @@ POBJECT_TYPE CmpKeyObjectType;
 PCMHIVE CmiVolatileHive;
 LIST_ENTRY CmpHiveListHead;
 ERESOURCE CmpRegistryLock;
+extern ERESOURCE CmpNotificationLock;
 KGUARDED_MUTEX CmpSelfHealQueueLock;
 LIST_ENTRY CmpSelfHealQueueListHead;
 KEVENT CmpLoadWorkerEvent;
@@ -177,8 +178,9 @@ CmpCloseKeyObject(IN PEPROCESS Process OPTIONAL,
         /* Don't do anything if we don't have a notify block */
         if (!KeyBody->NotifyBlock) return;
 
-        /* This shouldn't happen yet */
-        ASSERT(FALSE);
+        /* Flush NotifyBlock */
+        CmpFlushNotify(KeyBody, FALSE);
+        ASSERT(KeyBody->NotifyBlock == NULL);
     }
 }
 
@@ -1647,6 +1649,9 @@ CmInitSystem1(VOID)
 
     /* Initialize registry lock */
     ExInitializeResourceLite(&CmpRegistryLock);
+
+    /* Initialize notification lock */
+    ExInitializeResourceLite(&CmpNotificationLock);
 
     /* Initialize the cache */
     CmpInitializeCache();

--- a/ntoskrnl/config/ntapi.c
+++ b/ntoskrnl/config/ntapi.c
@@ -1682,7 +1682,7 @@ NtNotifyChangeMultipleKeys(_In_ HANDLE MasterKeyHandle,
             }
 
             /* Check if this is a duplicate object */
-            if (LocalSubObjectsKeyBody[i]->KeyControlBlock == KeyObject->KeyControlBlock)Expand commentComment on line R1685Resolved
+            if (LocalSubObjectsKeyBody[i]->KeyControlBlock == KeyObject->KeyControlBlock)
             {
                 DPRINT1("NtNotifyChangeMultipleKeys: Duplicate subordinate object found.\n");
                 Status = STATUS_INVALID_PARAMETER;

--- a/ntoskrnl/config/ntapi.c
+++ b/ntoskrnl/config/ntapi.c
@@ -1452,23 +1452,516 @@ NtLockRegistryKey(IN HANDLE KeyHandle)
     return STATUS_NOT_IMPLEMENTED;
 }
 
+/**
+ * @brief
+ * NtNotifyChangeMultipleKeys can notify the caller about a change in a registry key
+ * 
+ * @param[in] MasterKeyHandle
+ * A handle to a registry key to watch for changes
+ * 
+ * @param[in] Count
+ * Count of objects in _SubordinateObjects_ array
+ * 
+ * @param[in] SubordinateObjects
+ * An array of additional registry key object names to watch alongside the _MasterKeyHandle_.
+ * The array can't contain more than 1 object and the object can't be in the same hive as the _MasterKeyHandle_.
+ * 
+ * @param[in] Event
+ * A handle to an event object to signal when a change detected.
+ * 
+ * @param[in] ApcRoutine
+ * An APC routine to queue when a change detected. Can be NULL.
+ * 
+ * @param[in] ApcContext
+ * The parameter to be passed to _ApcRoutine_.
+ * 
+ * @param[out] IoStatusBlock
+ * An IO_STATUS_BLOCK to report the notification session's status.
+ * This contains number of bytes written to the buffer and operation status.
+ * This parameter is required.
+ * 
+ * @param[in] CompletionFilter
+ * Filter the notification types you want to recieve.
+ * Can be REG_NOTIFY_CHANGE_NAME, REG_NOTIFY_CHANGE_ATTRIBUTES, REG_NOTIFY_CHANGE_LAST_SET and REG_NOTIFY_CHANGE_SECURITY.
+ * This parameter is only used on the first call to the NtNotifyChangeMultipleKeys and new calls use the value previously provided.
+ * You need to close your handle to the _MasterKeyHandle_ and open a new one if you want to change this.
+ * 
+ * @param[in] WatchTree
+ * Set to TRUE to watch the whole subtree of _MasterKeyHandle_ or _SubordinateObjects_.
+ * This parameter is only used on the first call to the NtNotifyChangeMultipleKeys and new calls use the value previously provided.
+ * You need to close your handle to the _MasterKeyHandle_ and open a new one if you want to change this.
+ * 
+ * @param[out] Buffer
+ * A buffer to return the name of changed registry key. Currently unimplemented and can be NULL.
+ * 
+ * @param[in] Length
+ * The size of the _Buffer_.
+ * 
+ * @param[in] Asynchronous
+ * TRUE to call in asynchronous mode, FALSE to not. 
+ * If TRUE, one of _Event_ parameter or _ApcRoutine_ should be provided, 
+ * then function immediately returns STATUS_PENDING and reports the change using these parameters.
+ * The final status can be retrived from _IoStatusBlock_ parameter.
+ * If FALSE, the function blocks current thread until it detects a change.
+ * 
+ * @return
+ * STATUS_SUCCESS if the name of changed key is written in Buffer, STATUS_NOTIFY_ENUM_DIR if not, or an error code.
+ */
 NTSTATUS
 NTAPI
-NtNotifyChangeMultipleKeys(IN HANDLE MasterKeyHandle,
-                           IN ULONG Count,
-                           IN POBJECT_ATTRIBUTES SlaveObjects,
-                           IN HANDLE Event,
-                           IN PIO_APC_ROUTINE ApcRoutine OPTIONAL,
-                           IN PVOID ApcContext OPTIONAL,
-                           OUT PIO_STATUS_BLOCK IoStatusBlock,
-                           IN ULONG CompletionFilter,
-                           IN BOOLEAN WatchTree,
-                           OUT PVOID Buffer,
-                           IN ULONG Length,
-                           IN BOOLEAN Asynchronous)
+NtNotifyChangeMultipleKeys(_In_ HANDLE MasterKeyHandle,
+                           _In_opt_ ULONG Count,
+                           _In_reads_opt_(Count) OBJECT_ATTRIBUTES SubordinateObjects[],
+                           _In_opt_ HANDLE Event,
+                           _In_opt_ PIO_APC_ROUTINE ApcRoutine,
+                           _In_opt_ PVOID ApcContext,
+                           _Out_ PIO_STATUS_BLOCK IoStatusBlock,
+                           _In_ ULONG CompletionFilter,
+                           _In_ BOOLEAN WatchTree,
+                           _Out_writes_bytes_opt_(Length) PVOID Buffer,
+                           _In_ ULONG Length,
+                           _In_ BOOLEAN Asynchronous)
 {
-    UNIMPLEMENTED_ONCE;
-    return STATUS_NOT_IMPLEMENTED;
+    NTSTATUS Status;
+    KPROCESSOR_MODE PreviousMode = ExGetPreviousMode();
+    PCM_KEY_BODY KeyObject = NULL;
+    PCM_NOTIFY_BLOCK NotifyBlock = NULL;
+    PCM_POST_BLOCK PostBlock = NULL;
+    HANDLE LocalEventHandle = NULL;
+    PKEVENT LocalEventObject = NULL;
+    OBJECT_ATTRIBUTES* LocalSubObjects = NULL;
+    UNICODE_STRING* SubNames = NULL;
+    PCM_KEY_BODY* LocalSubObjectsKeyBody = NULL;
+    PCM_NOTIFY_BLOCK* SubNotifyBlocks = NULL;
+
+    PAGED_CODE();
+
+    DPRINT("NtNotifyChangeMultipleKeys(MasterKeyHandle=%p, Subordinate[%d]=%p, Event=%p, ApcRoutine=%p, ApcContext=%p, IoStatusBlock=%p, CompletionFilter=%d, WatchTree=%d, Buffer[%d]=%p, Asynchronous=%d)\n",
+        MasterKeyHandle, Count, SubordinateObjects, Event, ApcRoutine, ApcContext, IoStatusBlock, CompletionFilter, WatchTree, Buffer, Length, Asynchronous);
+
+    /* Validate flags */
+    if ((CompletionFilter & REG_LEGAL_CHANGE_FILTER) != CompletionFilter)
+        return STATUS_INVALID_PARAMETER;
+
+    /* For asynchronous calls, either Event or APC routine should be provided */
+    if (Asynchronous && (Event == NULL && ApcRoutine == NULL))
+        return STATUS_INVALID_PARAMETER;
+
+    /* ApcContext can't be null when ApcRoutine is not */
+    if (PreviousMode != KernelMode && ApcRoutine != NULL && ApcContext == NULL)
+        return STATUS_INVALID_PARAMETER;
+
+    /* IoStatusBlock is required */
+    if (IoStatusBlock == NULL)
+        return STATUS_INVALID_PARAMETER;
+
+    /* Windows doesn't support more than one subordinate */
+    if (Count > 1)
+        return STATUS_INVALID_PARAMETER;
+
+    /* Verify the handle is valid and has sufficient permissions */
+    Status = ObReferenceObjectByHandle(MasterKeyHandle,
+                                       KEY_NOTIFY,
+                                       CmpKeyObjectType,
+                                       PreviousMode,
+                                       (PVOID*)&KeyObject,
+                                       NULL);
+
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("NtNotifyChangeMultipleKeys: failed to open MasterKeyHandle. (0x%lx)\n", Status);
+        return Status;
+    }
+
+    /* Block APCs */
+    KeEnterCriticalRegion();
+
+    /* Block registry notifications */
+    CmpLockNotifyExclusive();
+
+    /* Check for user-mode caller */
+    if (PreviousMode != KernelMode)
+    {
+        _SEH2_TRY
+        {
+            ProbeForWrite(IoStatusBlock, sizeof(IO_STATUS_BLOCK), sizeof(ULONG));
+            ProbeForWrite(Buffer, Length, sizeof(ULONG));
+
+            /* Probe and capture subordinate objects */
+            if (Count > 0)
+            {
+                LocalSubObjects = ExAllocatePoolZero(NonPagedPool, Count * sizeof(OBJECT_ATTRIBUTES), TAG_CM);
+                if (!LocalSubObjects)
+                {
+                    ObDereferenceObject(KeyObject);
+                    Status = STATUS_INSUFFICIENT_RESOURCES;
+                    _SEH2_YIELD(goto Quit);
+                }
+
+                SubNames = ExAllocatePoolZero(NonPagedPool, Count * sizeof(UNICODE_STRING), TAG_CM);
+                if (!SubNames)
+                {
+                    ObDereferenceObject(KeyObject);
+                    ExFreePoolWithTag(LocalSubObjects, TAG_CM);
+                    Status = STATUS_INSUFFICIENT_RESOURCES;
+                    _SEH2_YIELD(goto Quit);
+                }
+
+                for (int i = 0; i < Count; i++)
+                {
+                    Status = ProbeAndCaptureObjectAttributes(&LocalSubObjects[i],
+                                                             &SubNames[i],
+                                                             PreviousMode,
+                                                             &SubordinateObjects[i],
+                                                             FALSE);
+                    if (!NT_SUCCESS(Status))
+                        break;
+                }
+            }
+        }
+        _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+        {
+            /* Return the exception code */
+            Status = _SEH2_GetExceptionCode();
+        }
+        _SEH2_END;
+
+        if (!NT_SUCCESS(Status))
+        {
+            DPRINT1("NtNotifyChangeMultipleKeys: Probing buffers failed. (0x%lx)\n", Status);
+            if (KeyObject)
+                ObDereferenceObject(KeyObject);
+            if (LocalSubObjects)
+                ExFreePoolWithTag(LocalSubObjects, TAG_CM);
+            if (SubNames)
+                ExFreePoolWithTag(SubNames, TAG_CM);
+            goto Quit;
+        }
+    }
+
+    /* Open subordinate objects */
+    if (Count > 0)
+    {
+        LocalSubObjectsKeyBody = ExAllocatePoolZero(NonPagedPool, Count * sizeof(PCM_KEY_BODY), TAG_CM);
+        if (!LocalSubObjectsKeyBody)
+        {
+            Status = STATUS_INSUFFICIENT_RESOURCES;
+            goto Failure;
+        }
+
+        for (int i = 0; i < Count; i++)
+        {
+            /* Open a kernel-mode handle, since we're using it internally without returning it to the user */
+            HANDLE SubHandle;
+            LocalSubObjects[i].Attributes |= OBJ_KERNEL_HANDLE;
+            Status = ObOpenObjectByName(&LocalSubObjects[i],
+                                        CmpKeyObjectType,
+                                        KernelMode,
+                                        NULL,
+                                        KEY_NOTIFY,
+                                        NULL,
+                                        &SubHandle);
+            if (!NT_SUCCESS(Status))
+            {
+                DPRINT1("NtNotifyChangeMultipleKeys: Failed to open subordinate object handle. (0x%lx)\n", Status);
+                goto Failure;
+            }
+
+            Status = ObReferenceObjectByHandle(SubHandle,
+                                               KEY_NOTIFY,
+                                               CmpKeyObjectType,
+                                               KernelMode,
+                                               (PVOID*)&LocalSubObjectsKeyBody[i],
+                                               NULL);
+            /* clsoe the handle as we don't need it anymore */
+            ZwClose(SubHandle);
+            if (!NT_SUCCESS(Status))
+            {
+                DPRINT1("NtNotifyChangeMultipleKeys: Failed to reference subordinate object. (0x%lx)\n", Status);
+                goto Failure;
+            }
+
+            /* Check if this is a duplicate object */
+            if (LocalSubObjectsKeyBody[i]->KeyControlBlock == KeyObject->KeyControlBlock)Expand commentComment on line R1685Resolved
+            {
+                DPRINT1("NtNotifyChangeMultipleKeys: Duplicate subordinate object found.\n");
+                Status = STATUS_INVALID_PARAMETER;
+                goto Failure;
+            }
+
+            for (int j = 0; j < i; j++)
+            {
+                if (LocalSubObjectsKeyBody[i]->KeyControlBlock == LocalSubObjectsKeyBody[j]->KeyControlBlock)
+                {
+                    DPRINT1("NtNotifyChangeMultipleKeys: Duplicate subordinate object found.\n");
+                    Status = STATUS_INVALID_PARAMETER;
+                    goto Failure;
+                }
+            }
+
+            /* Lock KCB for Subordinate objects */
+            CmpAcquireKcbLockShared(LocalSubObjectsKeyBody[i]->KeyControlBlock);
+        }
+
+        /* The name is no longer needed */
+        ExFreePoolWithTag(LocalSubObjects, TAG_CM);
+        ExFreePoolWithTag(SubNames, TAG_CM);
+    }
+
+    /* Lock master key's KCB */
+    CmpAcquireKcbLockShared(KeyObject->KeyControlBlock);
+
+    /* Check if the registry key is deleted */
+    if (KeyObject->KeyControlBlock->Delete)
+    {
+        DPRINT("NtNotifyChangeMultipleKeys: MasterKeyHandle is marked for deletion.\n");
+        Status = STATUS_KEY_DELETED;
+        goto Failure2;
+    }
+
+    /* Early return if there's a notification pending */
+    if (KeyObject->NotifyBlock && KeyObject->NotifyBlock->NotifyPending)
+    {
+        DPRINT("NtNotifyChangeMultipleKeys: Early-return on pending notification.\n");
+        KeyObject->NotifyBlock->NotifyPending = FALSE;
+        Status = STATUS_NOTIFY_ENUM_DIR;
+        goto Failure2;
+    }
+
+    /* Allocate and initialize master NotifyBlock */
+    if (KeyObject->NotifyBlock == NULL)
+    {
+        Status = CmpInsertNotifyBlock(KeyObject, CompletionFilter, WatchTree, &NotifyBlock);
+        if (!NT_SUCCESS(Status))
+        {
+            DPRINT1("NtNotifyChangeMultipleKeys: Failed to allocate and insert NotifyBlock. (0x%lx)\n", Status);
+            goto Failure2;
+        }
+        KeyObject->NotifyBlock = NotifyBlock;
+    }
+
+    /* Allocate and initialize local event object */
+    if (Event)
+    {
+        /* Convert the user event handle to a kernel event handle,
+         * or duplicate a kernel handle so we won't close the caller's handle
+         * when flushing post blocks
+         */
+        Status = CmpConvertHandleToKernelHandle(Event,
+                                                ExEventObjectType, 
+                                                EVENT_MODIFY_STATE, 
+                                                PreviousMode, 
+                                                &LocalEventHandle);
+        if (!NT_SUCCESS(Status))
+        {
+            DPRINT1("NtNotifyChangeMultipleKeys: CmpConvertHandleToKernelHandle failed. (0x%lx)\n", Status);
+            goto Failure2;
+        }
+
+        Status = ObReferenceObjectByHandle(LocalEventHandle,
+                                           EVENT_MODIFY_STATE,
+                                           NULL,
+                                           KernelMode,
+                                           (PVOID*)&LocalEventObject,
+                                           NULL);
+        if (!NT_SUCCESS(Status))
+        {
+            DPRINT1("NtNotifyChangeMultipleKeys: Failed to reference event object. (0x%lx)\n", Status);
+            goto Failure2;
+        }
+        ZwClose(LocalEventHandle);
+        LocalEventHandle = NULL;
+    }
+    else if (!Asynchronous)
+    {
+        /* Create a local event object so we can wait on it in synchronous mode */
+        Status = CmpCreateEvent(NotificationEvent, &LocalEventHandle, &LocalEventObject);
+        if (!NT_SUCCESS(Status))
+        {
+            DPRINT1("NtNotifyChangeMultipleKeys: Failed to create event object for synchronous call. (0x%lx)\n", Status);
+            goto Failure2;
+        }
+        ZwClose(LocalEventHandle);
+        LocalEventHandle = NULL;
+    }
+
+    /* Register for receiving notifications */
+    Status = CmpInsertPostBlock(KeyObject->NotifyBlock,
+                                LocalEventObject,
+                                PreviousMode != KernelMode ? ApcRoutine : NULL, /* APC routine is not supported for kernel-mode callers */
+                                PreviousMode != KernelMode ? ApcContext : NULL,
+                                &PostBlock);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("NtNotifyChangeMultipleKeys: Failed to allocate and insert master PostBlock. (0x%lx)\n", Status);
+        goto Failure2;
+    }
+
+    /* Windows ignores the IO_STATUS_BLOCK with KernelMode Asynchronous callers */
+    if (!Asynchronous || PreviousMode != KernelMode)
+    {
+        /* Attach the IO_STATUS_BLOCK */
+        PostBlock->Process = &PsGetCurrentProcess()->Pcb;
+        PostBlock->IoStatusBlock = IoStatusBlock;
+    }
+    
+    if (PreviousMode == KernelMode)
+    {
+        /* A kernel-mode caller should provide a WorkQueueItem instead of APC routine
+         * ref: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ntifs/nf-ntifs-zwnotifychangekey
+         */
+        PostBlock->WorkQueueItem = (PWORK_QUEUE_ITEM)ApcRoutine;
+        PostBlock->WorkQueueType = (WORK_QUEUE_TYPE)ApcContext;
+    }
+
+    /* Allocate NotifyBlock for Subordinate objects */
+    if (Count > 0)
+    {
+        /* Allocate a storage array */
+        SubNotifyBlocks = ExAllocatePoolZero(NonPagedPool, Count * sizeof(PCM_NOTIFY_BLOCK), TAG_CM);
+        if (!SubNotifyBlocks)
+        {
+            Status = STATUS_INSUFFICIENT_RESOURCES;
+            goto Failure2;
+        }
+
+        /* Initialize a NotifyBlock and PostBlock for each subordinate */
+        for (int i = 0; i < Count; i++)
+        {
+            Status = CmpInsertNotifyBlock(LocalSubObjectsKeyBody[i],
+                                          CompletionFilter,
+                                          WatchTree,
+                                          &SubNotifyBlocks[i]);
+            if (!NT_SUCCESS(Status))
+            {
+                DPRINT1("NtNotifyChangeMultipleKeys: Failed to allocate and insert subordinate NotifyBlock. (0x%lx)\n", Status);
+                goto Failure2;
+            }
+
+            /* Allocate PostBlock */
+            PCM_POST_BLOCK SubPostBlock;
+            Status = CmpInsertSubPostBlock(SubNotifyBlocks[i],
+                                           NotifyBlock,
+                                           PostBlock,
+                                           &SubPostBlock);
+            if (!NT_SUCCESS(Status))
+            {
+                DPRINT1("NtNotifyChangeMultipleKeys: Failed to allocate and insert subordinate PostBlock. (0x%lx)\n", Status);
+                goto Failure2;
+            }
+            
+            /* The object is no longer needed */
+            CmpReleaseKcbLock(LocalSubObjectsKeyBody[i]->KeyControlBlock);
+            ObDereferenceObject(LocalSubObjectsKeyBody[i]);
+            LocalSubObjectsKeyBody[i] = NULL;
+
+            /* CmpInsertSubPostBlock adds a reference of PostBlock to NotifyBlock->PostList */
+        }
+
+        /* We don't need an array for storing KeyBody objects */
+        ExFreePoolWithTag(LocalSubObjectsKeyBody, TAG_CM);
+        LocalSubObjectsKeyBody = NULL;
+    }
+
+    /* Attach subordinate NotifyBlocks to the master's PostBlock */
+    PostBlock->SubCount = Count;
+    PostBlock->SubNotifyBlocks = SubNotifyBlocks;
+
+    /* We are done with the NotifyBlock, unlock the KCB so now user can change registry keys */
+    CmpReleaseKcbLock(KeyObject->KeyControlBlock);
+    CmpUnlockNotify();
+    KeLeaveCriticalRegion();
+
+    /* Initialize IO_STATUS_BLOCK */
+    if (!Asynchronous || PreviousMode != KernelMode)
+    {
+        IoStatusBlock->Status = STATUS_PENDING;
+        IoStatusBlock->Information = 0;
+    }
+
+    if (Asynchronous)
+    {
+        /* This is an asynchronous call, we set the notification up, return NOW and notify later */
+        /* The allocated resources will be freed later when notification session ended */
+        Status = STATUS_PENDING;
+        goto Cleanup;
+
+        /* FIXME: Update IoStatusBlock when a notification is sent, and report back the relative name of the changed key using the buffer */
+    }
+    else
+    {
+        /* Wait for event to be signaled */
+        KeWaitForSingleObject(PostBlock->Event, Executive, PreviousMode, FALSE, NULL);
+
+        /* FIXME: Report back the relative name of the changed using the Buffer */
+
+        /* PostBlock is freed automatically when the event is signaled */
+
+        Status = PostBlock->IoStatusBlock->Status;
+        goto Cleanup;
+    }
+
+Failure2:
+    CmpReleaseKcbLock(KeyObject->KeyControlBlock);
+
+    if (LocalEventObject)
+        ObDereferenceObject(LocalEventObject);
+
+    if (LocalEventHandle)
+        ZwClose(LocalEventHandle);
+
+    if (NotifyBlock)
+    {
+        if (KeyObject->NotifyBlock == NotifyBlock)
+        {
+            RemoveEntryList(&(NotifyBlock->HiveList));
+            KeyObject->NotifyBlock = NULL;
+        }
+
+        ExFreePoolWithTag(NotifyBlock, TAG_CM);
+    }
+
+    if (PostBlock)
+        ExFreePoolWithTag(PostBlock, TAG_CM);
+
+Failure:
+    if (LocalSubObjects)
+        ExFreePoolWithTag(LocalSubObjects, TAG_CM);
+    if (SubNames)
+        ExFreePoolWithTag(SubNames, TAG_CM);
+
+    if (LocalSubObjectsKeyBody)
+    {
+        for (int i = 0; i < Count; i++)
+        {
+            if (LocalSubObjectsKeyBody[i])
+                ObDereferenceObject(LocalSubObjectsKeyBody[i]);
+        }
+
+        ExFreePoolWithTag(LocalSubObjectsKeyBody, TAG_CM);
+    }
+
+    if (SubNotifyBlocks)
+    {
+        for (int i = 0; i < Count; i++)
+        {
+            if (SubNotifyBlocks[i])
+                ExFreePoolWithTag(SubNotifyBlocks[i], TAG_CM);
+        }
+
+        ExFreePoolWithTag(SubNotifyBlocks, TAG_CM);
+    }
+
+    KeLeaveCriticalRegion();
+
+    CmpUnlockNotify();
+
+Cleanup:
+    if (KeyObject)
+        ObDereferenceObject(KeyObject);
+
+Quit:
+    return Status;
 }
 
 NTSTATUS

--- a/ntoskrnl/config/ntapi.c
+++ b/ntoskrnl/config/ntapi.c
@@ -1681,19 +1681,21 @@ NtNotifyChangeMultipleKeys(_In_ HANDLE MasterKeyHandle,
                 goto Failure;
             }
 
-            /* Check if this is a duplicate object */
-            if (LocalSubObjectsKeyBody[i]->KeyControlBlock == KeyObject->KeyControlBlock)
+            /* Subordinate must be in a different hive from the master */
+            if (LocalSubObjectsKeyBody[i]->KeyControlBlock->KeyHive ==
+               KeyObject->KeyControlBlock->KeyHive)
             {
-                DPRINT1("NtNotifyChangeMultipleKeys: Duplicate subordinate object found.\n");
+                DPRINT1("NtNotifyChangeMultipleKeys: Subordinate object is in the same hive as master.\n");
                 Status = STATUS_INVALID_PARAMETER;
                 goto Failure;
             }
 
             for (int j = 0; j < i; j++)
             {
-                if (LocalSubObjectsKeyBody[i]->KeyControlBlock == LocalSubObjectsKeyBody[j]->KeyControlBlock)
+                if (LocalSubObjectsKeyBody[i]->KeyControlBlock->KeyHive ==
+                    LocalSubObjectsKeyBody[j]->KeyControlBlock->KeyHive)
                 {
-                    DPRINT1("NtNotifyChangeMultipleKeys: Duplicate subordinate object found.\n");
+                    DPRINT1("NtNotifyChangeMultipleKeys: Duplicate subordinate object found in same hive.\n");
                     Status = STATUS_INVALID_PARAMETER;
                     goto Failure;
                 }
@@ -1796,6 +1798,10 @@ NtNotifyChangeMultipleKeys(_In_ HANDLE MasterKeyHandle,
         DPRINT1("NtNotifyChangeMultipleKeys: Failed to allocate and insert master PostBlock. (0x%lx)\n", Status);
         goto Failure2;
     }
+
+    PostBlock->Buffer = Buffer;
+    PostBlock->BufferSize = Length;
+    PostBlock->Kcb = KeyObject->KeyControlBlock;   // master key
 
     /* Windows ignores the IO_STATUS_BLOCK with KernelMode Asynchronous callers */
     if (!Asynchronous || PreviousMode != KernelMode)

--- a/ntoskrnl/include/internal/cm.h
+++ b/ntoskrnl/include/internal/cm.h
@@ -337,7 +337,7 @@ typedef struct _CM_NOTIFY_BLOCK
 //
 // Post Block
 //
-typedef struct _CM_POST_BLOCK
+typedef struct _CMP_POST_BLOCK
 {
     LIST_ENTRY NotifyList; /* link to CM_NOTIFY_BLOCK->PostList */
     BOOLEAN IsMasterPostBlock;
@@ -357,13 +357,17 @@ typedef struct _CM_POST_BLOCK
 
             PKPROCESS Process;
             PIO_STATUS_BLOCK IoStatusBlock;
+
+            PVOID Buffer; /* Caller gives us this buffer to receive the name of the changed key */
+            ULONG BufferSize; /* Size of Buffer in bytes */
+            PCM_KEY_CONTROL_BLOCK Kcb; /* KCB of the watched key */
         };
 
         /* Subordinate-specific fields */
         struct
         {
             PCM_NOTIFY_BLOCK MasterNotifyBlock; /* Hold a reference to the master key's notify block */
-            struct _CM_POST_BLOCK* MasterPostBlock; /* Hold a reference to master key's post block for forwarding notifications */
+            struct _CMP_POST_BLOCK* MasterPostBlock; /* Hold a reference to master key's post block for forwarding notifications */
         };
     };
 } CM_POST_BLOCK, *PCM_POST_BLOCK;

--- a/ntoskrnl/include/internal/cm.h
+++ b/ntoskrnl/include/internal/cm.h
@@ -337,7 +337,7 @@ typedef struct _CM_NOTIFY_BLOCK
 //
 // Post Block
 //
-typedef struct _CM_POST_BLOCK
+typedef struct _CMP_POST_BLOCK
 {
     LIST_ENTRY NotifyList; /* link to CM_NOTIFY_BLOCK->PostList */
     BOOLEAN IsMasterPostBlock;


### PR DESCRIPTION
## Purpose

This PR's a continuation of #7914.

JIRA issue: [CORE-11865](https://jira.reactos.org/browse/CORE-11865)

Related documentations:
https://learn.microsoft.com/en-us/windows/win32/api/winternl/nf-winternl-ntnotifychangemultiplekeys
https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ntifs/nf-ntifs-zwnotifychangekey
https://learn.microsoft.com/en-us/windows-hardware/drivers/kernel/using-nt-and-zw-versions-of-the-native-system-services-routines

## Proposed changes

- ~~Size of the output buffer in `ListTests` in KM test is increased, since it wasn't enough to store names of the tests after adding the new test.~~ (Fixed in https://github.com/reactos/reactos/commit/21d02b82668477ddafd24f204e3ecb3a4740a7dd)
- Previously `CmpInitializeHive` used to initialize `CMHive->NotifyList` by setting its Flink and Blink to NULL, I updated this to use `InitializeListHead` so I can insert NotifyBlocks to the hive.
- An implementation for `CmpReportNotify` is added, it works by searching CMHive->NotifyList for a NotifyBlock that's attached to the given KCB. I couldn't understand how does this works on Windows but this is a solution I could came by. I tried checking the KeyBody for NotifyBlock but it didn't work.
- An implementation for `CmpFlushNotify`, this releases all the resources used by the NotifyBlock, and system calls it when it wants to free a registry key handle
- Helper functions added to support the functionality: `CmpIsKcbSubKey`, `CmpPostBlockFreeSubordinates`, `CmpNotifyPostBlock`, `CmpInsertNotifyBlock`, `CmpInsertPostBlock`, `CmpInsertSubPostBlock`
- `CmpCloseKeyObject` is updated to call `CmpFlushNotify` instead of asserting when it finds a NotifyBlock
- A new internal structure called `CM_POST_BLOCK` is added

The whole thing works by inserting a NotifyBlock to the KeyBody when users calls `NtNotifyChangeMultipleKeys`. NotifyBlock represents the "notification session" for a key handle. Also another internal structure called `CM_POST_BLOCK` is allocated and attached to the NotifyBlock->PostList which represents a "notification listener". With every change in the registry, our CM functions call `CmpReportNotify`, signals each PostBlock on each NotifyBlock for the updated registry key. The signal can be sent using an "Event" object, a "KAPC", or a "QUEUE_WORK_ITEM".

## TODO
- [x] apitests: user-mode
   - [x] Synchronous
   - [x] Asynchronous
   - [x] Multiple keys and watching subtree
- [x] apitests: kernel-mode
- [x] User-mode implementation
   - [x] Synchronous
   - [x] Event-based Asynchronous
   - [x] APC-based Asynchronous
   - [x] Watch subtree
   - [x] Multiple keys
- [x] Kernel-mode WORK_QUEUE_ITEM-based asynchronous
- [x] Sending change notifications
- [x] Return IoStatusBlock for user-mode callers
- [x] Return name of changed key in Buffer (unimplemented on Windows)

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: