### PR TITLE
[FREELDR] Make DiskGetActivePartitionEntry usable for GPT and BRFR

### DIFF
--- a/boot/freeldr/freeldr/disk/part_brfr.c
+++ b/boot/freeldr/freeldr/disk/part_brfr.c
@@ -48,7 +48,8 @@ DiskGetBrfrPartitionEntry(
     _In_ UCHAR DriveNumber,
     _In_ ULONG SectorSize,
     _In_ ULONG PartitionNumber,
-    _Out_ PPARTITION_INFORMATION PartitionEntry)
+    _Out_ PPARTITION_INFORMATION PartitionEntry,
+    _In_ BOOLEAN IgnoreUnusedFlag)
 {
     ASSERT(SectorSize >= 512);
 

--- a/boot/freeldr/freeldr/disk/part_gpt.c
+++ b/boot/freeldr/freeldr/disk/part_gpt.c
@@ -47,7 +47,8 @@ DiskGetGptPartitionEntry(
     _In_ UCHAR DriveNumber,
     _In_ ULONG SectorSize, // BlockSize
     _In_ ULONG PartitionNumber,
-    _Out_ PPARTITION_INFORMATION PartitionEntry)
+    _Out_ PPARTITION_INFORMATION PartitionEntry,
+    _In_ BOOLEAN IgnoreUnusedFlag)
 {
     GPT_TABLE_HEADER GptHeader;
     GPT_PARTITION_ENTRY GptEntry;
@@ -82,10 +83,6 @@ DiskGetGptPartitionEntry(
     /* Extract partition entry */
     RtlCopyMemory(&GptEntry, (PUCHAR)DiskReadBuffer + EntryOffset, sizeof(GptEntry));
 
-    /* Check if partition is unused */
-    if (RtlEqualMemory(&GptEntry.PartitionTypeGuid, &UnusedGuid, sizeof(UnusedGuid)))
-        return FALSE;
-
     /* Calculate partition size in blocks */
     ULONGLONG PartitionSizeBlocks = GptEntry.EndingLba - GptEntry.StartingLba + 1;
 
@@ -94,10 +91,19 @@ DiskGetGptPartitionEntry(
     PartitionEntry->PartitionLength.QuadPart = (PartitionSizeBlocks * SectorSize);
     PartitionEntry->HiddenSectors = 0;
     PartitionEntry->PartitionNumber = PartitionNumber;
-    PartitionEntry->PartitionType = PARTITION_GPT; /* Mark as GPT partition */
+
+    if (RtlEqualMemory(&GptEntry.PartitionTypeGuid, &UnusedGuid, sizeof(UnusedGuid)))
+        PartitionEntry->PartitionType = PARTITION_ENTRY_UNUSED;
+    else
+        PartitionEntry->PartitionType = PARTITION_GPT; /* Mark as GPT partition */
+
     PartitionEntry->BootIndicator = RtlEqualMemory(&GptEntry.PartitionTypeGuid, &SystemGuid, sizeof(SystemGuid));
     PartitionEntry->RecognizedPartition = TRUE;
     PartitionEntry->RewritePartition = FALSE;
+
+    /* Check if partition is unused when the flag is not ignored */
+    if (!IgnoreUnusedFlag && PartitionEntry->PartitionType == PARTITION_ENTRY_UNUSED)
+        return FALSE;
 
     return TRUE;
 }

--- a/boot/freeldr/freeldr/disk/part_mbr.c
+++ b/boot/freeldr/freeldr/disk/part_mbr.c
@@ -74,108 +74,42 @@ DiskMbrPartitionTableEntryToInformation(
 }
 
 BOOLEAN
-DiskGetActivePartitionEntry(
-    _In_ UCHAR DriveNumber,
-    _In_ ULONG SectorSize,
-    _Out_opt_ PPARTITION_INFORMATION PartitionEntry,
-    _Out_ PULONG ActivePartition)
-{
-    MASTER_BOOT_RECORD MasterBootRecord;
-    ULONG BootablePartitionCount = 0;
-    ULONG CurrentPartitionNumber;
-    ULONG Index;
-
-    ASSERT(SectorSize >= 512);
-
-    *ActivePartition = 0;
-
-    /* Read master boot record */
-    if (!DiskReadBootRecord(DriveNumber, 0, &MasterBootRecord))
-        return FALSE;
-
-    CurrentPartitionNumber = 0;
-    for (Index = 0; Index < 4; Index++)
-    {
-        PPARTITION_TABLE_ENTRY PartitionTableEntry = &MasterBootRecord.PartitionTable[Index];
-
-        if (PartitionTableEntry->SystemIndicator != PARTITION_ENTRY_UNUSED &&
-            PartitionTableEntry->SystemIndicator != PARTITION_EXTENDED &&
-            PartitionTableEntry->SystemIndicator != PARTITION_XINT13_EXTENDED)
-        {
-            CurrentPartitionNumber++;
-
-            /* Test if this is the bootable partition */
-            if (PartitionTableEntry->BootIndicator == 0x80)
-            {
-                BootablePartitionCount++;
-                *ActivePartition = CurrentPartitionNumber;
-
-                /* Copy the partition table entry */
-                if (PartitionEntry)
-                {
-                    DiskMbrPartitionTableEntryToInformation(PartitionEntry, PartitionTableEntry,
-                                                            *ActivePartition, SectorSize);
-                }
-            }
-        }
-    }
-
-    /* Make sure there was only one bootable partition */
-    if (BootablePartitionCount == 0)
-    {
-        ERR("No bootable (active) partitions found.\n");
-        return FALSE;
-    }
-    else if (BootablePartitionCount != 1)
-    {
-        ERR("Too many bootable (active) partitions found.\n");
-        return FALSE;
-    }
-
-    return TRUE;
-}
-
-BOOLEAN
 DiskGetMbrPartitionEntry(
     _In_ UCHAR DriveNumber,
     _In_ ULONG SectorSize,
     _In_ ULONG PartitionNumber,
-    _Out_ PPARTITION_INFORMATION PartitionEntry)
+    _Out_ PPARTITION_INFORMATION PartitionEntry,
+    _In_ BOOLEAN IgnoreUnusedFlag)
 {
+    BOOLEAN Result = TRUE;
     MASTER_BOOT_RECORD MasterBootRecord;
     PPARTITION_TABLE_ENTRY PartitionTableEntry;
     ULONG ExtendedPartitionNumber;
     ULONG ExtendedPartitionOffset;
     ULONG Index;
-    ULONG CurrentPartitionNumber;
-
-    ASSERT(SectorSize >= 512);
-
-    /* Validate partition number */
-    if (PartitionNumber < 1) //if (PartitionNumber == 0)
-        return FALSE;
+    PPARTITION_TABLE_ENTRY ThisPartitionTableEntry;
+    PARTITION_TABLE_ENTRY PartitionTableEntry = {0};
 
     /* Read master boot record */
     if (!DiskReadBootRecord(DriveNumber, 0, &MasterBootRecord))
         return FALSE;
 
-    CurrentPartitionNumber = 0;
     for (Index = 0; Index < 4; Index++)
     {
-        PartitionTableEntry = &MasterBootRecord.PartitionTable[Index];
+        ThisPartitionTableEntry = &MasterBootRecord.PartitionTable[Index];
 
-        if (PartitionTableEntry->SystemIndicator != PARTITION_ENTRY_UNUSED &&
-            PartitionTableEntry->SystemIndicator != PARTITION_EXTENDED &&
-            PartitionTableEntry->SystemIndicator != PARTITION_XINT13_EXTENDED)
+        if (PartitionNumber > 4 &&
+            (ThisPartitionTableEntry->SystemIndicator == PARTITION_EXTENDED ||
+             ThisPartitionTableEntry->SystemIndicator == PARTITION_XINT13_EXTENDED))
         {
-            CurrentPartitionNumber++;
+            Result = DiskGetExtendedMbrPartitionEntry(DriveNumber, PartitionNumber, ThisPartitionTableEntry, PartitionEntry);
+            break;
         }
 
-        if (PartitionNumber == CurrentPartitionNumber)
+        if (PartitionNumber == Index + 1)
         {
-            DiskMbrPartitionTableEntryToInformation(PartitionEntry, PartitionTableEntry,
-                                                    PartitionNumber, SectorSize);
-            return TRUE;
+            DiskMbrPartitionTableEntryToInformation(PartitionEntry, ThisPartitionTableEntry, PartitionNumber, SectorSize);
+            break;
         }
     }
 
@@ -184,7 +118,7 @@ DiskGetMbrPartitionEntry(
      * to loop through all the extended partitions on the disk
      * and return the one they want.
      */
-    ExtendedPartitionNumber = PartitionNumber - CurrentPartitionNumber - 1;
+    ExtendedPartitionNumber = PartitionNumber - 4;
 
     /*
      * Set the initial relative starting sector to 0.
@@ -223,11 +157,13 @@ DiskGetMbrPartitionEntry(
         PartitionTableEntry->SectorCountBeforePartition += SectorCountBeforePartition;
     }
 
-    /* When we get here we should have the correct entry already
-     * stored in PartitionTableEntry, so just return TRUE. */
-    DiskMbrPartitionTableEntryToInformation(PartitionEntry, PartitionTableEntry,
-                                            PartitionNumber, SectorSize);
-    return TRUE;
+    /* Check if partition is usable when the flag is not ignored */
+    if (!IgnoreUnusedFlag)
+        Result &= PartitionEntry->PartitionType != PARTITION_ENTRY_UNUSED &&
+                  PartitionEntry->PartitionType != PARTITION_EXTENDED &&
+                  PartitionEntry->PartitionType != PARTITION_XINT13_EXTENDED;
+
+    return Result;
 }
 
 #endif

--- a/boot/freeldr/freeldr/disk/part_mbr.c
+++ b/boot/freeldr/freeldr/disk/part_mbr.c
@@ -13,49 +13,6 @@
 // #include <debug.h>
 // DBG_DEFAULT_CHANNEL(DISK);
 
-static BOOLEAN
-DiskGetFirstPartitionEntry(
-    _In_ PMASTER_BOOT_RECORD MasterBootRecord,
-    _Out_ PPARTITION_TABLE_ENTRY* pPartitionTableEntry)
-{
-    ULONG Index;
-
-    for (Index = 0; Index < 4; Index++)
-    {
-        /* Check the system indicator. If it's not an extended or unused partition then we're done. */
-        if ((MasterBootRecord->PartitionTable[Index].SystemIndicator != PARTITION_ENTRY_UNUSED) &&
-            (MasterBootRecord->PartitionTable[Index].SystemIndicator != PARTITION_EXTENDED) &&
-            (MasterBootRecord->PartitionTable[Index].SystemIndicator != PARTITION_XINT13_EXTENDED))
-        {
-            *pPartitionTableEntry = &MasterBootRecord->PartitionTable[Index];
-            return TRUE;
-        }
-    }
-
-    return FALSE;
-}
-
-static BOOLEAN
-DiskGetFirstExtendedPartitionEntry(
-    _In_ PMASTER_BOOT_RECORD MasterBootRecord,
-    _Out_ PPARTITION_TABLE_ENTRY* pPartitionTableEntry)
-{
-    ULONG Index;
-
-    for (Index = 0; Index < 4; Index++)
-    {
-        /* Check the system indicator. If it an extended partition then we're done. */
-        if ((MasterBootRecord->PartitionTable[Index].SystemIndicator == PARTITION_EXTENDED) ||
-            (MasterBootRecord->PartitionTable[Index].SystemIndicator == PARTITION_XINT13_EXTENDED))
-        {
-            *pPartitionTableEntry = &MasterBootRecord->PartitionTable[Index];
-            return TRUE;
-        }
-    }
-
-    return FALSE;
-}
-
 static VOID
 DiskMbrPartitionTableEntryToInformation(
     _Out_ PPARTITION_INFORMATION PartitionEntry,
@@ -73,6 +30,55 @@ DiskMbrPartitionTableEntryToInformation(
     PartitionEntry->RewritePartition = FALSE;
 }
 
+static BOOLEAN
+DiskGetExtendedMbrPartitionEntry(
+    _In_ UCHAR DriveNumber,
+    _In_ ULONG SectorSize,
+    _In_ ULONG PartitionNumber,
+    _In_ PPARTITION_TABLE_ENTRY ExtendedPartitionTableEntry,
+    _Out_ PPARTITION_INFORMATION PartitionEntry)
+{
+    ULONG EbrIndex;
+    MASTER_BOOT_RECORD ExtendedBootRecord;
+
+    ULONG ExtendedBootRecordBaseSector = ExtendedPartitionTableEntry->SectorCountBeforePartition;
+    ULONG ExtendedBootRecordCurrentSector = ExtendedBootRecordBaseSector;
+    ULONG ExtendedPartitionNumber = PartitionNumber - 5;
+
+    for (EbrIndex = 0; EbrIndex <= ExtendedPartitionNumber; EbrIndex++)
+    {
+        /* Read the partition boot record */
+        if (!DiskReadBootRecord(DriveNumber, ExtendedBootRecordCurrentSector, &ExtendedBootRecord))
+        {
+            return FALSE;
+        }
+
+        TRACE("EbrIndex = %u\n", EbrIndex);
+
+        PPARTITION_TABLE_ENTRY Logical = &ExtendedBootRecord.PartitionTable[0];
+        PPARTITION_TABLE_ENTRY Next = &ExtendedBootRecord.PartitionTable[1];
+
+        if (EbrIndex == ExtendedPartitionNumber)
+        {
+            /* Now correct the start sector of the partition */
+            Logical->SectorCountBeforePartition += ExtendedBootRecordCurrentSector;
+
+            DiskMbrPartitionTableEntryToInformation(PartitionEntry, Logical, PartitionNumber, SectorSize);
+            return TRUE;
+        }
+
+        if (!Next->SectorCountBeforePartition)
+        {
+            return FALSE;
+        }
+
+        /* Move to next EBR (relative to base EBR) */
+        ExtendedBootRecordCurrentSector = ExtendedBootRecordBaseSector + Next->SectorCountBeforePartition;
+    }
+
+    return FALSE;
+}
+
 BOOLEAN
 DiskGetMbrPartitionEntry(
     _In_ UCHAR DriveNumber,
@@ -83,12 +89,8 @@ DiskGetMbrPartitionEntry(
 {
     BOOLEAN Result = TRUE;
     MASTER_BOOT_RECORD MasterBootRecord;
-    PPARTITION_TABLE_ENTRY PartitionTableEntry;
-    ULONG ExtendedPartitionNumber;
-    ULONG ExtendedPartitionOffset;
     ULONG Index;
     PPARTITION_TABLE_ENTRY ThisPartitionTableEntry;
-    PARTITION_TABLE_ENTRY PartitionTableEntry = {0};
 
     /* Read master boot record */
     if (!DiskReadBootRecord(DriveNumber, 0, &MasterBootRecord))
@@ -102,7 +104,7 @@ DiskGetMbrPartitionEntry(
             (ThisPartitionTableEntry->SystemIndicator == PARTITION_EXTENDED ||
              ThisPartitionTableEntry->SystemIndicator == PARTITION_XINT13_EXTENDED))
         {
-            Result = DiskGetExtendedMbrPartitionEntry(DriveNumber, PartitionNumber, ThisPartitionTableEntry, PartitionEntry);
+            Result = DiskGetExtendedMbrPartitionEntry(DriveNumber, SectorSize, PartitionNumber, ThisPartitionTableEntry, PartitionEntry);
             break;
         }
 
@@ -111,50 +113,6 @@ DiskGetMbrPartitionEntry(
             DiskMbrPartitionTableEntryToInformation(PartitionEntry, ThisPartitionTableEntry, PartitionNumber, SectorSize);
             break;
         }
-    }
-
-    /*
-     * They want an extended partition entry so we will need
-     * to loop through all the extended partitions on the disk
-     * and return the one they want.
-     */
-    ExtendedPartitionNumber = PartitionNumber - 4;
-
-    /*
-     * Set the initial relative starting sector to 0.
-     * This is because extended partition starting
-     * sectors a numbered relative to their parent.
-     */
-    ExtendedPartitionOffset = 0;
-
-    for (Index = 0; Index <= ExtendedPartitionNumber; Index++)
-    {
-        PPARTITION_TABLE_ENTRY ExtendedPartitionTableEntry;
-        ULONG SectorCountBeforePartition;
-
-        /* Get the extended partition table entry */
-        if (!DiskGetFirstExtendedPartitionEntry(&MasterBootRecord, &ExtendedPartitionTableEntry))
-            return FALSE;
-
-        /* Adjust the relative starting sector of the partition */
-        ExtendedPartitionTableEntry->SectorCountBeforePartition += ExtendedPartitionOffset;
-        if (ExtendedPartitionOffset == 0)
-        {
-            /* Set the start of the parent extended partition */
-            ExtendedPartitionOffset = ExtendedPartitionTableEntry->SectorCountBeforePartition;
-        }
-        SectorCountBeforePartition = ExtendedPartitionTableEntry->SectorCountBeforePartition;
-
-        /* Read the partition boot record */
-        if (!DiskReadBootRecord(DriveNumber, SectorCountBeforePartition, &MasterBootRecord))
-            return FALSE;
-
-        /* Get the first real partition table entry */
-        if (!DiskGetFirstPartitionEntry(&MasterBootRecord, &PartitionTableEntry))
-            return FALSE;
-
-        /* Now correct the start sector of the partition */
-        PartitionTableEntry->SectorCountBeforePartition += SectorCountBeforePartition;
     }
 
     /* Check if partition is usable when the flag is not ignored */

--- a/boot/freeldr/freeldr/disk/partition.c
+++ b/boot/freeldr/freeldr/disk/partition.c
@@ -19,6 +19,14 @@ static PARTITION_STYLE DiskPartitionType[MaxDriveNumber + 1];
 
 #include "part_mbr.h" // FIXME: For MASTER_BOOT_RECORD
 
+static BOOLEAN
+DiskGetPartitionEntryEx(
+    _In_ UCHAR DriveNumber,
+    _In_opt_ ULONG SectorSize,
+    _In_ ULONG PartitionNumber,
+    _Out_ PPARTITION_INFORMATION PartitionEntry,
+    _In_ BOOLEAN IgnoreUnusedFlag);
+
 BOOLEAN
 DiskReadBootRecord(
     IN UCHAR DriveNumber,
@@ -119,51 +127,73 @@ DiskDetectPartitionType(
 }
 
 // FIXME: This function is specific to BIOS-based PC platform.
+static
+BOOLEAN
+DiskGetActivePartitionEntry(
+    _In_ UCHAR DriveNumber,
+    _Out_ PPARTITION_INFORMATION PartitionEntry,
+    _Out_ PULONG ActivePartition)
+{
+    ULONG SectorSize;
+    ULONG BootablePartitionCount = 0;
+    ULONG PartitionNumber = 0;
+
+    GEOMETRY Geometry;
+    if (!MachDiskGetDriveGeometry(DriveNumber, &Geometry))
+        return FALSE;
+
+    SectorSize = Geometry.BytesPerSector;
+
+    *ActivePartition = 0;
+
+    while (DiskGetPartitionEntryEx(DriveNumber, SectorSize, ++PartitionNumber, PartitionEntry, TRUE))
+    {
+        if (PartitionEntry->PartitionType == PARTITION_XINT13_EXTENDED ||
+            PartitionEntry->PartitionType == PARTITION_EXTENDED ||
+            PartitionEntry->PartitionType == PARTITION_ENTRY_UNUSED)
+            continue;
+
+        if (PartitionEntry->BootIndicator)
+        {
+            *ActivePartition = PartitionNumber;
+            BootablePartitionCount++;
+        }
+    }
+
+    /* Make sure there was only one bootable partition */
+    if (BootablePartitionCount == 0)
+    {
+        ERR("No bootable (active) partitions found.\n");
+        return FALSE;
+    }
+    else if (BootablePartitionCount != 1)
+    {
+        ERR("Too many bootable (active) partitions found.\n");
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+// FIXME: This function is specific to BIOS-based PC platform.
 BOOLEAN
 DiskGetBootPartitionEntry(
     _In_ UCHAR DriveNumber,
     _Out_opt_ PPARTITION_INFORMATION PartitionEntry,
     _Out_ PULONG BootPartition)
 {
-#if 0
-    GEOMETRY Geometry;
-    if (!MachDiskGetDriveGeometry(DriveNumber, &Geometry))
-        return FALSE;
-#endif
-
     switch (DiskPartitionType[DriveNumber])
     {
-        case PARTITION_STYLE_MBR:
-        {
-            return DiskGetActivePartitionEntry(DriveNumber,
-            /* MBR partition table always uses 512-byte sectors per specification */
-                                               512, // Geometry.BytesPerSector
-                                               PartitionEntry, BootPartition);
-        }
-        case PARTITION_STYLE_GPT:
-        {
-            FIXME("DiskGetBootPartitionEntry() unimplemented for GPT\n");
-            return FALSE;
-        }
         case PARTITION_STYLE_RAW:
         {
             FIXME("DiskGetBootPartitionEntry() unimplemented for RAW\n");
             return FALSE;
         }
+        case PARTITION_STYLE_MBR:
+        case PARTITION_STYLE_GPT:
         case PARTITION_STYLE_BRFR:
         {
-            PARTITION_INFORMATION TempPartitionEntry;
-            if (!PartitionEntry)
-                PartitionEntry = &TempPartitionEntry;
-            if (DiskGetBrfrPartitionEntry(DriveNumber,
-                                          512, // Geometry.BytesPerSector
-                                          FATX_DATA_PARTITION,
-                                          PartitionEntry))
-            {
-                *BootPartition = FATX_DATA_PARTITION;
-                return TRUE;
-            }
-            return FALSE;
+            return DiskGetActivePartitionEntry(DriveNumber, PartitionEntry, BootPartition);
         }
         default:
         {
@@ -174,12 +204,13 @@ DiskGetBootPartitionEntry(
     return FALSE;
 }
 
-BOOLEAN
-DiskGetPartitionEntry(
+static BOOLEAN
+DiskGetPartitionEntryEx(
     _In_ UCHAR DriveNumber,
     _In_opt_ ULONG SectorSize,
     _In_ ULONG PartitionNumber,
-    _Out_ PPARTITION_INFORMATION PartitionEntry)
+    _Out_ PPARTITION_INFORMATION PartitionEntry,
+    _In_ BOOLEAN IgnoreUnusedFlag)
 {
     if (SectorSize == 0)
     {
@@ -198,18 +229,11 @@ DiskGetPartitionEntry(
     {
         case PARTITION_STYLE_MBR:
         {
-            return DiskGetMbrPartitionEntry(DriveNumber,
-            /* MBR partition table always uses 512-byte sectors per specification */
-                                            512, // SectorSize
-                                            PartitionNumber,
-                                            PartitionEntry);
+            return DiskGetMbrPartitionEntry(DriveNumber, SectorSize, PartitionNumber, PartitionEntry, IgnoreUnusedFlag);
         }
         case PARTITION_STYLE_GPT:
         {
-            return DiskGetGptPartitionEntry(DriveNumber,
-                                            SectorSize,
-                                            PartitionNumber,
-                                            PartitionEntry);
+            return DiskGetGptPartitionEntry(DriveNumber, SectorSize, PartitionNumber, PartitionEntry, IgnoreUnusedFlag);
         }
         case PARTITION_STYLE_RAW:
         {
@@ -218,10 +242,7 @@ DiskGetPartitionEntry(
         }
         case PARTITION_STYLE_BRFR:
         {
-            return DiskGetBrfrPartitionEntry(DriveNumber,
-                                             512, // SectorSize
-                                             PartitionNumber,
-                                             PartitionEntry);
+            return DiskGetBrfrPartitionEntry(DriveNumber, SectorSize, PartitionNumber, PartitionEntry, IgnoreUnusedFlag);
         }
         default:
         {
@@ -230,6 +251,16 @@ DiskGetPartitionEntry(
         }
     }
     return FALSE;
+}
+
+BOOLEAN
+DiskGetPartitionEntry(
+    _In_ UCHAR DriveNumber,
+    _In_opt_ ULONG SectorSize,
+    _In_ ULONG PartitionNumber,
+    _Out_ PPARTITION_INFORMATION PartitionEntry)
+{
+    return DiskGetPartitionEntryEx(DriveNumber, SectorSize, PartitionNumber, PartitionEntry, FALSE);
 }
 
 #endif


### PR DESCRIPTION
## Purpose

Make it possible to boot freeldr with GPT partition style on legacy freeldr!
And refactor extended partition logic.

JIRA issue: [CORE-XXXX](https://jira.reactos.org/browse/CORE-XXXX)

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: