### PR TITLE
[GITIGNORE] Add .idea directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,8 @@ modules/[Aa][Hh][Kk]_[Tt]ests
 .cache
 .cproject
 .DS_Store
+.idea
 .project
 .settings
 .vscode
-.idea
 sdk/tools/winesync/winesync.cfg

--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ modules/[Aa][Hh][Kk]_[Tt]ests
 .project
 .settings
 .vscode
+.idea
 sdk/tools/winesync/winesync.cfg


### PR DESCRIPTION
## Purpose

This prevents the .idea directory for IntelliJ IDEA/CLion from being synced to git.

JIRA issue: [CORE-XXXX](https://jira.reactos.org/browse/CORE-XXXX)

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: