### PR TITLE
[IMM32] Implement WINNLSTranslateMessage

### DIFF
--- a/win32ss/user/imm32/keymsg.c
+++ b/win32ss/user/imm32/keymsg.c
@@ -876,7 +876,7 @@ ImmGenerateMessage(_In_ HIMC hIMC)
 {
     PCLIENTIMC pClientImc;
     LPINPUTCONTEXT pIC;
-    LPTRANSMSG pMsgs, pTrans = NULL, pItem;
+    LPTRANSMSG pMsgs = NULL, pTrans = NULL, pItem;
     HWND hWnd;
     DWORD dwIndex, dwCount, cbTrans;
     HIMCC hMsgBuf = NULL;
@@ -941,7 +941,7 @@ ImmGenerateMessage(_In_ HIMC hIMC)
 
 Quit:
     ImmLocalFree(pTrans);
-    if (hMsgBuf)
+    if (hMsgBuf && pMsgs)
         ImmUnlockIMCC(hMsgBuf);
     pIC->dwNumMsgBuf = 0; /* done */
     ImmUnlockIMC(hIMC);
@@ -1102,14 +1102,9 @@ ImmTranslateMessage(
             if (kret > 0)
             {
                 if ((BYTE)vk == VK_PACKET)
-                {
-                    vk &= 0xFF;
                     vk |= (wChar << 8);
-                }
                 else
-                {
                     vk = MAKEWORD(vk, wChar);
-                }
             }
         }
     }

--- a/win32ss/user/imm32/precomp.h
+++ b/win32ss/user/imm32/precomp.h
@@ -189,7 +189,7 @@ CtfImmSetLangBand(
     _In_ BOOL fSet);
 
 DWORD
-WINNLSTranslateMessage(DWORD dwCount, LPTRANSMSG pEntries, HIMC hIMC, BOOL bAnsi, WORD wLang);
+WINNLSTranslateMessage(DWORD dwCount, PTRANSMSG pEntries, HIMC hIMC, BOOL bAnsi, WORD wLang);
 
 HIMC
 ImmGetSaveContext(

--- a/win32ss/user/imm32/precomp.h
+++ b/win32ss/user/imm32/precomp.h
@@ -189,7 +189,12 @@ CtfImmSetLangBand(
     _In_ BOOL fSet);
 
 DWORD
-WINNLSTranslateMessage(DWORD dwCount, PTRANSMSG pEntries, HIMC hIMC, BOOL bAnsi, WORD wLang);
+WINNLSTranslateMessage(
+    _In_ INT cEntries,
+    _Inout_ PTRANSMSG pEntries,
+    _In_ HIMC hIMC,
+    _In_ BOOL bAnsi,
+    _In_ WORD wLang);
 
 HIMC
 ImmGetSaveContext(

--- a/win32ss/user/imm32/win3.c
+++ b/win32ss/user/imm32/win3.c
@@ -22,12 +22,17 @@ WINE_DEFAULT_DEBUG_CHANNEL(imm);
 #define KOR_IS_LEAD_BYTE(ch) \
     (KOR_LEAD_BYTE_FIRST <= (BYTE)(ch) && (BYTE)(ch) <= KOR_LEAD_BYTE_LAST)
 
+#define KOR_SCAN_CODE_SBCS 0xFFF10001 /* Korean single-byte character string */
+#define KOR_SCAN_CODE_DBCS 0xFFF20001 /* Korean double-byte character string */
+#define KOR_KEYDOWN_FLAGS 0xE0001
+#define KOR_INTERIM_FLAGS 0xF00001
+
 static inline INT Imm32WideToAnsi(PCWCH pchWide, INT cchWide, PSTR pszAnsi, INT cchAnsi)
 {
     BOOL usedDefaultChar = FALSE;
     INT len = WideCharToMultiByte(CP_ACP, 0, pchWide, cchWide, pszAnsi, cchAnsi,
                                   NULL, &usedDefaultChar);
-    if (pszAnsi && len >= 0)
+    if (pszAnsi && len >= 0 && len < cchAnsi)
         pszAnsi[len] = ANSI_NULL;
     return len;
 }
@@ -35,7 +40,7 @@ static inline INT Imm32WideToAnsi(PCWCH pchWide, INT cchWide, PSTR pszAnsi, INT 
 static inline INT Imm32AnsiToWide(PCCH pchAnsi, INT cchAnsi, PWSTR pszWide, INT cchWide)
 {
     INT len = MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, pchAnsi, cchAnsi, pszWide, cchWide);
-    if (pszWide && len >= 0)
+    if (pszWide && len >= 0 && len < cchWide)
         pszWide[len] = UNICODE_NULL;
     return len;
 }
@@ -525,7 +530,8 @@ Imm32CompStrAToUndetA(
     if ((dwGCS & GCS_RESULTREADCLAUSE) && pCS->dwResultReadClauseLen)
     {
         pDet->uYomiDelimPos = ib;
-        RtlCopyMemory(pbDet + ib, pbCS + pCS->dwResultReadClauseOffset, pCS->dwResultReadClauseLen);
+        RtlCopyMemory(pbDet + ib, pbCS + pCS->dwResultReadClauseOffset,
+                      pCS->dwResultReadClauseLen);
 
         //ib += ALIGN_DWORD(pCS->dwResultReadClauseLen); // The last one (ineffective)
     }
@@ -1267,8 +1273,8 @@ Imm32JTransCompositionW(
                                 goto FINALIZE;
                             }
                         }
-                        GlobalFree(hEx);
                     }
+                    GlobalFree(hEx);
                 }
             }
         }
@@ -1374,7 +1380,7 @@ WINNLSTranslateMessageJ(
         {
             // Move WM_IME_ENDCOMPOSITION to the end of the list
             PTRANSMSG pSrc = pEndComp + 1, pDest = pEndComp;
-            while (pSrc->message)
+            for (INT iEntry = 0; iEntry < cEntries - 1 && pSrc->message; ++iEntry)
                 *pDest++ = *pSrc++;
 
             pDest->message = WM_IME_ENDCOMPOSITION;
@@ -1559,9 +1565,9 @@ WINNLSTranslateMessageK(
                                         if (IsDBCSLeadByte(bChar))
                                         {
                                             if (KOR_IS_LEAD_BYTE(bChar))
-                                                lKeyData = 0xFFF20001; /* Scan code differs */
+                                                lKeyData = KOR_SCAN_CODE_DBCS;
                                             else
-                                                lKeyData = 0xFFF10001;
+                                                lKeyData = KOR_SCAN_CODE_SBCS;
 
                                             PostMessageA(hWnd, WM_CHAR, bChar, lKeyData);
                                             dwProcessedLen++;
@@ -1586,9 +1592,9 @@ WINNLSTranslateMessageK(
                                         if (IsDBCSLeadByte(bLead))
                                         {
                                             if (KOR_IS_LEAD_BYTE(bLead))
-                                                lKeyData = 0xFFF20001; /* Scan code differs */
+                                                lKeyData = KOR_SCAN_CODE_DBCS;
                                             else
-                                                lKeyData = 0xFFF10001;
+                                                lKeyData = KOR_SCAN_CODE_SBCS;
 
                                             PostMessageA(hWnd, WM_CHAR, bLead, lKeyData);
                                             bChar = (BYTE)szMBStr[1];
@@ -1621,27 +1627,27 @@ WINNLSTranslateMessageK(
                                 CHAR szTmp[2] = { (CHAR)bLow, (CHAR)bHigh };
                                 WCHAR wTmp[2];
                                 if (Imm32AnsiToWide(szTmp, 2, wTmp, _countof(wTmp)))
-                                    PostMessageW(hWnd, WM_INTERIM, wTmp[0], 0xF00001);
+                                    PostMessageW(hWnd, WM_INTERIM, wTmp[0], KOR_INTERIM_FLAGS);
                             }
                             else
                             {
-                                PostMessageA(hWnd, WM_INTERIM, bLow, 0xF00001);
-                                PostMessageA(hWnd, WM_INTERIM, bHigh, 0xF00001);
+                                PostMessageA(hWnd, WM_INTERIM, bLow, KOR_INTERIM_FLAGS);
+                                PostMessageA(hWnd, WM_INTERIM, bHigh, KOR_INTERIM_FLAGS);
                             }
                         }
                         else
                         {
                             if (bDestIsUnicode)
                             {
-                                PostMessageW(hWnd, WM_INTERIM, wParam, 0xF00001);
+                                PostMessageW(hWnd, WM_INTERIM, wParam, KOR_INTERIM_FLAGS);
                             }
                             else
                             {
                                 WCHAR wTmp[2] = { (WCHAR)wParam, 0 };
                                 CHAR szTmp[2];
                                 Imm32WideToAnsi(wTmp, 1, szTmp, _countof(szTmp));
-                                PostMessageA(hWnd, WM_INTERIM, (BYTE)szTmp[0], 0xF00001);
-                                PostMessageA(hWnd, WM_INTERIM, (BYTE)szTmp[1], 0xF00001);
+                                PostMessageA(hWnd, WM_INTERIM, (BYTE)szTmp[0], KOR_INTERIM_FLAGS);
+                                PostMessageA(hWnd, WM_INTERIM, (BYTE)szTmp[1], KOR_INTERIM_FLAGS);
                             }
                         }
 
@@ -1664,35 +1670,37 @@ WINNLSTranslateMessageK(
                                 szTmp[1] = HIBYTE(s_chKorean);
                                 WCHAR wTmp[2];
                                 if (Imm32AnsiToWide(szTmp, 2, wTmp, _countof(wTmp)))
-                                    PostMessageW(hWnd, WM_CHAR, wTmp[0], 0xFFF10001);
+                                    PostMessageW(hWnd, WM_CHAR, wTmp[0], KOR_SCAN_CODE_SBCS);
                                 PostMessageW(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
-                                PostMessageW(hWnd, WM_KEYDOWN, VK_BACK, 0xE0001);
+                                PostMessageW(hWnd, WM_KEYDOWN, VK_BACK, KOR_KEYDOWN_FLAGS);
                             }
                             else
                             {
-                                PostMessageA(hWnd, WM_CHAR, LOBYTE(s_chKorean), 0xFFF10001);
-                                PostMessageA(hWnd, WM_CHAR, HIBYTE(s_chKorean), 0xFFF10001);
+                                PostMessageA(hWnd, WM_CHAR, LOBYTE(s_chKorean),
+                                             KOR_SCAN_CODE_SBCS);
+                                PostMessageA(hWnd, WM_CHAR, HIBYTE(s_chKorean),
+                                             KOR_SCAN_CODE_SBCS);
                                 PostMessageA(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
-                                PostMessageA(hWnd, WM_KEYDOWN, VK_BACK, 0xE0001);
+                                PostMessageA(hWnd, WM_KEYDOWN, VK_BACK, KOR_KEYDOWN_FLAGS);
                             }
                         }
                         else
                         {
                             if (bDestIsUnicode)
                             {
-                                PostMessageW(hWnd, WM_CHAR, (WCHAR)s_chKorean, 0xFFF10001);
+                                PostMessageW(hWnd, WM_CHAR, (WCHAR)s_chKorean, KOR_SCAN_CODE_SBCS);
                                 PostMessageW(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
-                                PostMessageW(hWnd, WM_KEYDOWN, VK_BACK, 917505);
+                                PostMessageW(hWnd, WM_KEYDOWN, VK_BACK, KOR_KEYDOWN_FLAGS);
                             }
                             else
                             {
                                 CHAR szTmp[2];
                                 WCHAR wTmp[2] = { (WCHAR)s_chKorean, 0 };
                                 Imm32WideToAnsi(wTmp, 1, szTmp, _countof(szTmp));
-                                PostMessageA(hWnd, WM_CHAR, (BYTE)szTmp[0], 0xFFF10001);
-                                PostMessageA(hWnd, WM_CHAR, (BYTE)szTmp[1], 0xFFF10001);
+                                PostMessageA(hWnd, WM_CHAR, (BYTE)szTmp[0], KOR_SCAN_CODE_SBCS);
+                                PostMessageA(hWnd, WM_CHAR, (BYTE)szTmp[1], KOR_SCAN_CODE_SBCS);
                                 PostMessageA(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
-                                PostMessageA(hWnd, WM_KEYDOWN, VK_BACK, 917505);
+                                PostMessageA(hWnd, WM_KEYDOWN, VK_BACK, KOR_KEYDOWN_FLAGS);
                             }
                         }
                     }

--- a/win32ss/user/imm32/win3.c
+++ b/win32ss/user/imm32/win3.c
@@ -1229,7 +1229,7 @@ Imm32JTransCompositionW(
     if (pIC->dwUIFlags & _IME_UI_HIDDEN)
     {
         HGLOBAL hGlobal = NULL;
-        SIZE_T dataSize = 0;
+        DWORD dataSize = 0;
 
         if (!bIsUnicodeWnd)
         {
@@ -1240,11 +1240,18 @@ Imm32JTransCompositionW(
                 if (hGlobal)
                 {
                     PUNDETERMINESTRUCT pUndet = GlobalLock(hGlobal);
-                    if (Imm32CompStrWToUndetA(dwGCS, pCS, pUndet, (DWORD)dataSize))
+                    if (pUndet)
                     {
+                        dataSize = Imm32CompStrWToUndetA(dwGCS, pCS, pUndet, dataSize);
                         GlobalUnlock(hGlobal);
-                        if (SendMessageA(hWnd, WM_IME_REPORT, IR_UNDETERMINE, (LPARAM)hGlobal) == 0)
-                            bUndeterminedProcessed = TRUE;
+                        if (dataSize)
+                        {
+                            if (SendMessageA(hWnd, WM_IME_REPORT, IR_UNDETERMINE,
+                                             (LPARAM)hGlobal) == 0)
+                            {
+                                bUndeterminedProcessed = TRUE;
+                            }
+                        }
                     }
                 }
             }
@@ -1258,34 +1265,34 @@ Imm32JTransCompositionW(
                 if (hGlobal)
                 {
                     PUNDETERMINESTRUCT pUndet = GlobalLock(hGlobal);
-                    if (Imm32CompStrWToUndetW(dwGCS, pCS, pUndet, (DWORD)dataSize))
+                    if (pUndet)
                     {
+                        dataSize = Imm32CompStrWToUndetW(dwGCS, pCS, pUndet, dataSize);
                         GlobalUnlock(hGlobal);
-                        if (SendMessageW(hWnd, WM_IME_REPORT, IR_UNDETERMINE, (LPARAM)hGlobal) == 0)
-                            bUndeterminedProcessed = TRUE;
+                        if (dataSize)
+                        {
+                            if (SendMessageW(hWnd, WM_IME_REPORT, IR_UNDETERMINE,
+                                             (LPARAM)hGlobal) == 0)
+                            {
+                                bUndeterminedProcessed = TRUE;
+                            }
+                        }
                     }
                 }
             }
         }
 
-        if (hGlobal && !bUndeterminedProcessed)
-        {
-            GlobalUnlock(hGlobal);
+        if (hGlobal)
             GlobalFree(hGlobal);
-        }
-        else if (hGlobal && bUndeterminedProcessed)
-        {
-            GlobalFree(hGlobal);
+        if (bUndeterminedProcessed)
             return 0;
-        }
     }
 
-    SIZE_T exSize;
     HGLOBAL hEx, hStr;
     PVOID pEx, pStr;
-    BOOL bExSuccess, bStrSuccess;
+    BOOL bExSuccess = FALSE, bStrSuccess = FALSE;
     LRESULT res;
-    SIZE_T strSize;
+    DWORD exSize, strSize;
 
     if (dwGCS & GCS_RESULTSTR)
     {
@@ -1300,23 +1307,26 @@ Imm32JTransCompositionW(
                 if (hEx)
                 {
                     pEx = GlobalLock(hEx);
-                    bExSuccess = bIsUnicodeWnd
-                        ? Imm32CompStrWToStringExW(dwGCS, pCS, pEx, (DWORD)exSize)
-                        : Imm32CompStrWToStringExA(dwGCS, pCS, pEx, (DWORD)exSize);
-                    GlobalUnlock(hEx);
-                    if (bExSuccess)
+                    if (pEx)
                     {
-                        res = bIsUnicodeWnd
-                            ? SendMessageW(hWnd, WM_IME_REPORT, IR_STRINGEX, (LPARAM)hEx)
-                            : SendMessageA(hWnd, WM_IME_REPORT, IR_STRINGEX, (LPARAM)hEx);
-                        if (res)
+                        bExSuccess = bIsUnicodeWnd
+                            ? Imm32CompStrWToStringExW(dwGCS, pCS, pEx, exSize)
+                            : Imm32CompStrWToStringExA(dwGCS, pCS, pEx, exSize);
+                        GlobalUnlock(hEx);
+                        if (bExSuccess)
                         {
-                            GlobalFree(hEx);
-                            bResultProcessed = TRUE;
-                            goto FINALIZE;
+                            res = bIsUnicodeWnd
+                                ? SendMessageW(hWnd, WM_IME_REPORT, IR_STRINGEX, (LPARAM)hEx)
+                                : SendMessageA(hWnd, WM_IME_REPORT, IR_STRINGEX, (LPARAM)hEx);
+                            if (res)
+                            {
+                                GlobalFree(hEx);
+                                bResultProcessed = TRUE;
+                                goto FINALIZE;
+                            }
                         }
+                        GlobalFree(hEx);
                     }
-                    GlobalFree(hEx);
                 }
             }
         }
@@ -1330,19 +1340,22 @@ Imm32JTransCompositionW(
             if (hStr)
             {
                 pStr = GlobalLock(hStr);
-                bStrSuccess = bIsUnicodeWnd ? Imm32CompStrWToStringW(pCS, pStr)
-                                            : Imm32CompStrWToStringA(pCS, pStr);
-                GlobalUnlock(hStr);
-                if (bStrSuccess)
+                if (pStr)
                 {
-                    res = bIsUnicodeWnd
-                        ? SendMessageW(hWnd, WM_IME_REPORT, IR_STRING, (LPARAM)hStr)
-                        : SendMessageA(hWnd, WM_IME_REPORT, IR_STRING, (LPARAM)hStr);
-                    if (res)
+                    bStrSuccess = bIsUnicodeWnd ? Imm32CompStrWToStringW(pCS, pStr)
+                                                : Imm32CompStrWToStringA(pCS, pStr);
+                    GlobalUnlock(hStr);
+                    if (bStrSuccess)
                     {
-                        GlobalFree(hStr);
-                        bResultProcessed = TRUE;
-                        goto FINALIZE;
+                        res = bIsUnicodeWnd
+                            ? SendMessageW(hWnd, WM_IME_REPORT, IR_STRING, (LPARAM)hStr)
+                            : SendMessageA(hWnd, WM_IME_REPORT, IR_STRING, (LPARAM)hStr);
+                        if (res)
+                        {
+                            GlobalFree(hStr);
+                            bResultProcessed = TRUE;
+                            goto FINALIZE;
+                        }
                     }
                 }
                 GlobalFree(hStr);

--- a/win32ss/user/imm32/win3.c
+++ b/win32ss/user/imm32/win3.c
@@ -20,7 +20,8 @@ static DWORD
 Imm32CompStrWToUndetW(
     DWORD dwGCS,
     const COMPOSITIONSTRING *pCS,
-    PUNDETERMINESTRUCT pDet)
+    PUNDETERMINESTRUCT pDet,
+    DWORD dwSize)
 {
     DWORD dwRequiredSize =
         sizeof(UNDETERMINESTRUCT) +
@@ -34,7 +35,7 @@ Imm32CompStrWToUndetW(
     if (!pDet)
         return dwRequiredSize;
 
-    if (dwRequiredSize == 0)
+    if (dwSize < dwRequiredSize)
         return 0;
 
     RtlZeroMemory(pDet, sizeof(UNDETERMINESTRUCT));
@@ -115,7 +116,8 @@ static DWORD
 Imm32CompStrWToUndetA(
     DWORD dwGCS,
     const COMPOSITIONSTRING *pCS,
-    PUNDETERMINESTRUCT pDet)
+    PUNDETERMINESTRUCT pDet,
+    DWORD dwSize)
 {
     DWORD dwRequiredSize =
         sizeof(UNDETERMINESTRUCT) +
@@ -129,7 +131,7 @@ Imm32CompStrWToUndetA(
     if (!pDet)
         return dwRequiredSize;
 
-    if (dwRequiredSize == 0)
+    if (dwSize < dwRequiredSize)
         return 0;
 
     RtlZeroMemory(pDet, sizeof(UNDETERMINESTRUCT));
@@ -142,8 +144,7 @@ Imm32CompStrWToUndetA(
 
     if ((dwGCS & GCS_COMPSTR) && (pCS->dwCompStrLen > 0))
     {
-        INT nAnsiLen = WideCharToMultiByte(
-            CP_ACP, 0,
+        INT nAnsiLen = WideCharToMultiByte(CP_ACP, 0,
             (PCWSTR)(pSrcBase + pCS->dwCompStrOffset), pCS->dwCompStrLen,
             (PSTR)(pBase + dwCurrentOffset), dwRequiredSize - dwCurrentOffset,
             NULL, &bUsedDef);
@@ -793,8 +794,8 @@ Imm32CompStrAToStringExW(
         pCS->dwResultClauseLen ? ALIGN_DWORD(pCS->dwResultClauseLen + 4) : 0;
     DWORD dwResultReadStrSize =
         pCS->dwResultReadStrLen ? ALIGN_DWORD(2 * pCS->dwResultReadStrLen + 5) : 0;
-    DWORD dwReadClauseSize
-        = pCS->dwResultReadClauseLen ? ALIGN_DWORD(pCS->dwResultReadClauseLen + 4) : 0;
+    DWORD dwReadClauseSize =
+        pCS->dwResultReadClauseLen ? ALIGN_DWORD(pCS->dwResultReadClauseLen + 4) : 0;
     DWORD dwRequiredSize = sizeof(STRINGEXSTRUCT) + dwResultStrSize + dwResultClauseSize +
                            dwResultReadStrSize + dwReadClauseSize;
 
@@ -875,7 +876,7 @@ Imm32CompStrAToStringA(const COMPOSITIONSTRING *pCS, PSTR pszString, DWORD dwSiz
     DWORD dwResultStrLen = pCS->dwResultStrLen;
     if (!pszString)
         return dwResultStrLen + 1;
-    if (dwResultStrLen > dwSize)
+    if (dwSize < dwResultStrLen)
         return 0;
     RtlCopyMemory(pszString, (PBYTE)pCS + pCS->dwResultStrOffset, dwResultStrLen);
     pszString[dwResultStrLen] = ANSI_NULL;
@@ -891,7 +892,7 @@ Imm32CompStrAToStringW(const COMPOSITIONSTRING *pCS, PWSTR pszString, DWORD dwSi
     DWORD dwResultStrLen = (cchWide + 1) * sizeof(WCHAR);
     if (!pszString)
         return dwResultStrLen;
-    if (dwResultStrLen > dwSize)
+    if (dwSize < dwResultStrLen)
         return 0;
     INT cch = MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, pch, pCS->dwResultStrLen,
                                   pszString, cchWide);
@@ -1217,14 +1218,14 @@ Imm32JTransCompositionW(
 
         if (!bIsUnicodeWnd)
         {
-            dataSize = Imm32CompStrWToUndetA(dwGCS, pCS, NULL);
+            dataSize = Imm32CompStrWToUndetA(dwGCS, pCS, NULL, 0);
             if (dataSize)
             {
                 hGlobal = GlobalAlloc(GHND, dataSize);
                 if (hGlobal)
                 {
                     PUNDETERMINESTRUCT pUndet = (PUNDETERMINESTRUCT)GlobalLock(hGlobal);
-                    if (Imm32CompStrWToUndetA(dwGCS, pCS, pUndet))
+                    if (Imm32CompStrWToUndetA(dwGCS, pCS, pUndet, (DWORD)dataSize))
                     {
                         GlobalUnlock(hGlobal);
                         if (SendMessageA(hWnd, WM_IME_REPORT, IR_UNDETERMINE, (LPARAM)hGlobal) == 0)
@@ -1235,14 +1236,14 @@ Imm32JTransCompositionW(
         }
         else
         {
-            dataSize = Imm32CompStrWToUndetW(dwGCS, pCS, NULL);
+            dataSize = Imm32CompStrWToUndetW(dwGCS, pCS, NULL, 0);
             if (dataSize)
             {
                 hGlobal = GlobalAlloc(GHND, dataSize);
                 if (hGlobal)
                 {
                     PUNDETERMINESTRUCT pUndet = (PUNDETERMINESTRUCT)GlobalLock(hGlobal);
-                    if (Imm32CompStrWToUndetW(dwGCS, pCS, pUndet))
+                    if (Imm32CompStrWToUndetW(dwGCS, pCS, pUndet, (DWORD)dataSize))
                     {
                         GlobalUnlock(hGlobal);
                         if (SendMessageW(hWnd, WM_IME_REPORT, IR_UNDETERMINE, (LPARAM)hGlobal) == 0)

--- a/win32ss/user/imm32/win3.c
+++ b/win32ss/user/imm32/win3.c
@@ -14,7 +14,7 @@ WINE_DEFAULT_DEBUG_CHANNEL(imm);
 
 #define ALIGN_DWORD(len) (((len) + 3) & ~3)
 
-WORD g_dchKorean = 0; /* One or two Korean character(s) */
+static WORD g_dchKorean = 0; /* One or two Korean character(s) */
 
 static DWORD
 Imm32CompStrWToUndetW(

--- a/win32ss/user/imm32/win3.c
+++ b/win32ss/user/imm32/win3.c
@@ -16,7 +16,7 @@ WINE_DEFAULT_DEBUG_CHANNEL(imm);
 
 static DWORD Imm32CompStrWToStringA(const COMPOSITIONSTRING *pCS, PCHAR pch)
 {
-    const WCHAR *pwch = (const WCHAR *)((PBYTE)pCS + pCS->dwResultStrOffset);
+    PCWSTR pwch = (PCWSTR)((const BYTE*)pCS + pCS->dwResultStrOffset);
     BOOL bUsedDef;
     INT cchNeed = WideCharToMultiByte(CP_ACP, 0, pwch, pCS->dwResultStrLen,
                                       pch, 0, NULL, &bUsedDef) + 1;
@@ -184,7 +184,7 @@ Imm32CompStrWToUndetA(
         pDet->uUndetAttrPos = dwCurrentOffset;
         const BYTE *pSrcAttr = pSrcBase + pCS->dwCompAttrOffset;
         PBYTE pDestAttr = pBase + dwCurrentOffset;
-        const WCHAR *pWStr = (const WCHAR *)(pSrcBase + pCS->dwCompStrOffset);
+        PCWSTR pWStr = (PCWSTR)(pSrcBase + pCS->dwCompStrOffset);
         UINT ibIndex = 0;
 
         for (UINT i = 0; i < pCS->dwCompAttrLen; ++i)
@@ -255,7 +255,7 @@ Imm32CompStrWToUndetA(
         const DWORD *pSrcClause = (const DWORD *)(pSrcBase + pCS->dwResultClauseOffset);
         PDWORD pDestClause = (PDWORD)(pBase + dwCurrentOffset);
         DWORD nClauses = pCS->dwResultClauseLen / sizeof(DWORD);
-        const WCHAR *pResultW = (const WCHAR *)(pSrcBase + pCS->dwResultStrOffset);
+        PCWSTR pResultW = (PCWSTR)(pSrcBase + pCS->dwResultStrOffset);
 
         for (DWORD i = 0; i < nClauses; ++i)
             pDestClause[i] = IchAnsiFromWide(pSrcClause[i], pResultW, CP_ACP);
@@ -286,7 +286,7 @@ Imm32CompStrWToUndetA(
         const DWORD *pSrcClause = (const DWORD *)(pSrcBase + pCS->dwResultReadClauseOffset);
         PDWORD pDestClause = (PDWORD)(pBase + dwCurrentOffset);
         DWORD nClauses = pCS->dwResultReadClauseLen / sizeof(DWORD);
-        const WCHAR *pReadW = (const WCHAR *)(pSrcBase + pCS->dwResultReadStrOffset);
+        PCWSTR pReadW = (PCWSTR)(pSrcBase + pCS->dwResultReadStrOffset);
 
         for (DWORD i = 0; i < nClauses; i++)
             pDestClause[i] = IchAnsiFromWide(pSrcClause[i], pReadW, CP_ACP);
@@ -409,7 +409,7 @@ Imm32CompStrWToStringExA(
         const DWORD *pSrcClause = (const DWORD *)(pSrcBase + pCS->dwResultClauseOffset);
         PDWORD pDestClause = (PDWORD)(pBase + dwCurrentOffset);
         DWORD nClauses = pCS->dwResultClauseLen / sizeof(DWORD);
-        const WCHAR *pResultW = (const WCHAR *)(pSrcBase + pCS->dwResultStrOffset);
+        PCWSTR pResultW = (PCWSTR)(pSrcBase + pCS->dwResultStrOffset);
 
         for (DWORD i = 0; i < nClauses; i++)
             pDestClause[i] = IchAnsiFromWide(pSrcClause[i], pResultW, CP_ACP);
@@ -436,7 +436,7 @@ Imm32CompStrWToStringExA(
         const DWORD *pSrcClause = (const DWORD *)(pSrcBase + pCS->dwResultReadClauseOffset);
         PDWORD pDestClause = (PDWORD)(pBase + dwCurrentOffset);
         DWORD nClauses = pCS->dwResultReadClauseLen / sizeof(DWORD);
-        const WCHAR *pReadW = (const WCHAR *)(pSrcBase + pCS->dwResultReadStrOffset);
+        PCWSTR pReadW = (PCWSTR)(pSrcBase + pCS->dwResultReadStrOffset);
 
         for (DWORD i = 0; i < nClauses; i++)
             pDestClause[i] = IchAnsiFromWide(pSrcClause[i], pReadW, CP_ACP);
@@ -843,14 +843,14 @@ static DWORD Imm32CompStrAToStringA(const COMPOSITIONSTRING *pCS, PSTR pszString
         return dwResultStrLen + 1;
     if (dwSize < dwResultStrLen + 1)
         return 0;
-    RtlCopyMemory(pszString, (PBYTE)pCS + pCS->dwResultStrOffset, dwResultStrLen);
+    RtlCopyMemory(pszString, (const BYTE*)pCS + pCS->dwResultStrOffset, dwResultStrLen);
     pszString[dwResultStrLen] = ANSI_NULL;
     return dwResultStrLen + 1;
 }
 
 static DWORD Imm32CompStrAToStringW(const COMPOSITIONSTRING *pCS, PWSTR pszString, DWORD dwSize)
 {
-    const CHAR *pch = (const CHAR *)pCS + pCS->dwResultStrOffset;
+    PCSTR pch = (PCSTR)pCS + pCS->dwResultStrOffset;
     INT cchWide = MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, pch, pCS->dwResultStrLen,
                                       pszString, 0);
     DWORD dwResultStrLen = (cchWide + 1) * sizeof(WCHAR);
@@ -868,7 +868,7 @@ static DWORD Imm32CompStrAToStringW(const COMPOSITIONSTRING *pCS, PWSTR pszStrin
 
 static VOID Imm32CompStrAToCharA(HWND hWnd, const COMPOSITIONSTRING *pCS)
 {
-    const CHAR *pch = (const CHAR *)((PBYTE)pCS + pCS->dwResultStrOffset);
+    PCSTR pch = (PCSTR)((const BYTE*)pCS + pCS->dwResultStrOffset);
 
     BOOL bImeSupportDBCS = FALSE;
     if (GetWin32ClientInfo()->dwExpWinVer >= 0x30A)
@@ -879,7 +879,7 @@ static VOID Imm32CompStrAToCharA(HWND hWnd, const COMPOSITIONSTRING *pCS)
     if (*pch == ANSI_NULL)
         return;
 
-    const CHAR *pNext;
+    PCSTR pNext;
     for (; *pch; pch = pNext)
     {
         BYTE bFirst = (BYTE)(*pch);
@@ -910,7 +910,7 @@ static VOID Imm32CompStrAToCharA(HWND hWnd, const COMPOSITIONSTRING *pCS)
 
 static VOID Imm32CompStrAToCharW(HWND hWnd, const COMPOSITIONSTRING *pCS)
 {
-    const CHAR *pCurrent = (const CHAR *)((PBYTE)pCS + pCS->dwResultStrOffset);
+    PCSTR pCurrent = (PCSTR)((const BYTE*)pCS + pCS->dwResultStrOffset);
 
     PostMessageW(hWnd, WM_IME_REPORT, IR_STRINGSTART, 0);
 
@@ -938,7 +938,7 @@ static VOID Imm32CompStrAToCharW(HWND hWnd, const COMPOSITIONSTRING *pCS)
 
 static VOID Imm32CompStrWToCharA(HWND hWnd, const COMPOSITIONSTRING *pCS)
 {
-    const WCHAR *pCurrent = (const WCHAR *)((const BYTE *)pCS + pCS->dwResultStrOffset);
+    PCWSTR pCurrent = (PCWSTR)((const BYTE *)pCS + pCS->dwResultStrOffset);
 
     BOOL bSupportDBCSReport = FALSE;
     if (GetWin32ClientInfo()->dwExpWinVer >= 0x30A)
@@ -946,14 +946,14 @@ static VOID Imm32CompStrWToCharA(HWND hWnd, const COMPOSITIONSTRING *pCS)
 
     PostMessageA(hWnd, WM_IME_REPORT, IR_STRINGSTART, 0);
 
-    const WCHAR *pNext;
+    PCWSTR pNext;
     for (; *pCurrent != UNICODE_NULL; pCurrent = pNext)
     {
         pNext = CharNextW(pCurrent);
         if (!*pNext)
             PostMessageA(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
 
-        char szAnsi[3] = {0};
+        CHAR szAnsi[3] = {0};
         BOOL bUsedDef = FALSE;
         if (!WideCharToMultiByte(CP_ACP, 0, pCurrent, 1, szAnsi, sizeof(szAnsi), NULL, &bUsedDef))
             continue;
@@ -979,11 +979,11 @@ static VOID Imm32CompStrWToCharA(HWND hWnd, const COMPOSITIONSTRING *pCS)
 
 static VOID Imm32CompStrWToCharW(HWND hWnd, const COMPOSITIONSTRING *pCS)
 {
-    const WCHAR *pCurrent = (const WCHAR *)((const BYTE *)pCS + pCS->dwResultStrOffset);
+    PCWSTR pCurrent = (PCWSTR )((const BYTE *)pCS + pCS->dwResultStrOffset);
 
     PostMessageW(hWnd, WM_IME_REPORT, IR_STRINGSTART, 0);
 
-    const WCHAR *pNext;
+    PCWSTR pNext;
     for (; *pCurrent; pCurrent = pNext)
     {
         pNext = CharNextW(pCurrent);

--- a/win32ss/user/imm32/win3.c
+++ b/win32ss/user/imm32/win3.c
@@ -877,7 +877,10 @@ static VOID Imm32CompStrAToCharA(HWND hWnd, const COMPOSITIONSTRING *pCS)
     PostMessageA(hWnd, WM_IME_REPORT, IR_STRINGSTART, 0);
 
     if (*pch == ANSI_NULL)
+    {
+        PostMessageA(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
         return;
+    }
 
     PCSTR pNext;
     for (; *pch; pch = pNext)

--- a/win32ss/user/imm32/win3.c
+++ b/win32ss/user/imm32/win3.c
@@ -1104,12 +1104,11 @@ Imm32JTransCompositionA(
             return 0;
     }
 
-    SIZE_T exSize;
     HGLOBAL hEx, hStr;
-    PVOID pEx, pStr;
-    BOOL bExSuccess, bStrSuccess;
+    PVOID pEx = NULL, pStr = NULL;
+    BOOL bExSuccess = FALSE, bStrSuccess = FALSE;
     LRESULT res;
-    SIZE_T strSize;
+    DWORD exSize, strSize;
 
     if (dwGCS & GCS_RESULTSTR)
     {
@@ -1123,23 +1122,26 @@ Imm32JTransCompositionA(
                 if (hEx)
                 {
                     pEx = GlobalLock(hEx);
-                    bExSuccess = bIsUnicodeWnd
-                        ? Imm32CompStrAToStringExW(dwGCS, pCS, pEx, (DWORD)exSize)
-                        : Imm32CompStrAToStringExA(dwGCS, pCS, pEx, (DWORD)exSize);
-                    GlobalUnlock(hEx);
-                    if (bExSuccess)
+                    if (pEx)
                     {
-                        res = bIsUnicodeWnd
-                            ? SendMessageW(hWnd, WM_IME_REPORT, IR_STRINGEX, (LPARAM)hEx)
-                            : SendMessageA(hWnd, WM_IME_REPORT, IR_STRINGEX, (LPARAM)hEx);
-                        if (res)
+                        bExSuccess = bIsUnicodeWnd
+                            ? Imm32CompStrAToStringExW(dwGCS, pCS, pEx, exSize)
+                            : Imm32CompStrAToStringExA(dwGCS, pCS, pEx, exSize);
+                        GlobalUnlock(hEx);
+                        if (bExSuccess)
                         {
-                            GlobalFree(hEx);
-                            bResultProcessed = TRUE;
-                            goto FINALIZE;
+                            res = bIsUnicodeWnd
+                                ? SendMessageW(hWnd, WM_IME_REPORT, IR_STRINGEX, (LPARAM)hEx)
+                                : SendMessageA(hWnd, WM_IME_REPORT, IR_STRINGEX, (LPARAM)hEx);
+                            if (res)
+                            {
+                                GlobalFree(hEx);
+                                bResultProcessed = TRUE;
+                                goto FINALIZE;
+                            }
                         }
+                        GlobalFree(hEx);
                     }
-                    GlobalFree(hEx);
                 }
             }
         }
@@ -1151,20 +1153,23 @@ Imm32JTransCompositionA(
             if (hStr)
             {
                 pStr = GlobalLock(hStr);
-                bStrSuccess = bIsUnicodeWnd
-                    ? Imm32CompStrAToStringW(pCS, pStr, (DWORD)strSize)
-                    : Imm32CompStrAToStringA(pCS, pStr, (DWORD)strSize);
-                GlobalUnlock(hStr);
-                if (bStrSuccess)
+                if (pStr)
                 {
-                    res = bIsUnicodeWnd
-                        ? SendMessageW(hWnd, WM_IME_REPORT, IR_STRING, (LPARAM)hStr)
-                        : SendMessageA(hWnd, WM_IME_REPORT, IR_STRING, (LPARAM)hStr);
-                    if (res)
+                    bStrSuccess = bIsUnicodeWnd
+                        ? Imm32CompStrAToStringW(pCS, pStr, strSize)
+                        : Imm32CompStrAToStringA(pCS, pStr, strSize);
+                    GlobalUnlock(hStr);
+                    if (bStrSuccess)
                     {
-                        GlobalFree(hStr);
-                        bResultProcessed = TRUE;
-                        goto FINALIZE;
+                        res = bIsUnicodeWnd
+                            ? SendMessageW(hWnd, WM_IME_REPORT, IR_STRING, (LPARAM)hStr)
+                            : SendMessageA(hWnd, WM_IME_REPORT, IR_STRING, (LPARAM)hStr);
+                        if (res)
+                        {
+                            GlobalFree(hStr);
+                            bResultProcessed = TRUE;
+                            goto FINALIZE;
+                        }
                     }
                 }
                 GlobalFree(hStr);

--- a/win32ss/user/imm32/win3.c
+++ b/win32ss/user/imm32/win3.c
@@ -14,8 +14,6 @@ WINE_DEFAULT_DEBUG_CHANNEL(imm);
 
 #define ALIGN_DWORD(len) (((len) + 3) & ~3)
 
-static WORD g_chKorean = 0; /* One or two Korean character(s) */
-
 static DWORD Imm32CompStrWToStringA(const COMPOSITIONSTRING *pCS, PCHAR pch)
 {
     const WCHAR *pwch = (const WCHAR *)((PBYTE)pCS + pCS->dwResultStrOffset);
@@ -26,7 +24,7 @@ static DWORD Imm32CompStrWToStringA(const COMPOSITIONSTRING *pCS, PCHAR pch)
         return cchNeed;
     INT cch = WideCharToMultiByte(CP_ACP, 0, pwch, pCS->dwResultStrLen,
                                   pch, cchNeed, NULL, &bUsedDef);
-    pch[cch] = 0;
+    pch[cch] = ANSI_NULL;
     return cch + 1;
 }
 
@@ -1537,6 +1535,7 @@ WINNLSTranslateMessageK(
     BOOL bDestIsAnsi = !bDestIsUnicode;
     FN_PostMessage pPostMessage = bDestIsUnicode ? PostMessageW : PostMessageA;
     FN_SendMessage pSendMessage = bDestIsUnicode ? SendMessageW : SendMessageA;
+    static WORD s_chKorean = 0; /* One or two Korean character(s) */
 
     if ((LONG)dwCount <= 0)
         return 0;
@@ -1641,7 +1640,7 @@ WINNLSTranslateMessageK(
                     pPostMessage(hWnd, WM_IME_REPORT, IR_STRINGSTART, 0);
 
                     BYTE bLow = HIBYTE(wParam), bHigh = LOBYTE(wParam);
-                    g_chKorean = MAKEWORD(bLow, bHigh);
+                    s_chKorean = MAKEWORD(bLow, bHigh);
 
                     if (bSrcIsAnsi)
                     {
@@ -1688,16 +1687,16 @@ WINNLSTranslateMessageK(
                     {
                         if (bDestIsAnsi)
                         {
-                            PostMessageA(hWnd, WM_CHAR, LOBYTE(g_chKorean), 0xFFF10001);
-                            PostMessageA(hWnd, WM_CHAR, HIBYTE(g_chKorean), 0xFFF10001);
+                            PostMessageA(hWnd, WM_CHAR, LOBYTE(s_chKorean), 0xFFF10001);
+                            PostMessageA(hWnd, WM_CHAR, HIBYTE(s_chKorean), 0xFFF10001);
                             PostMessageA(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
                             PostMessageA(hWnd, WM_KEYDOWN, VK_BACK, 917505);
                         }
                         else
                         {
                             CHAR szTmp[2];
-                            szTmp[0] = LOBYTE(g_chKorean);
-                            szTmp[1] = HIBYTE(g_chKorean);
+                            szTmp[0] = LOBYTE(s_chKorean);
+                            szTmp[1] = HIBYTE(s_chKorean);
                             WCHAR wTmp[2];
                             if (MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, szTmp, 2, wTmp, 1))
                             {
@@ -1711,7 +1710,7 @@ WINNLSTranslateMessageK(
                     {
                         if (bDestIsAnsi)
                         {
-                            WCHAR wTmp[2] = { (WCHAR)g_chKorean, 0 };
+                            WCHAR wTmp[2] = { (WCHAR)s_chKorean, 0 };
                             CHAR  szTmp[2];
                             WideCharToMultiByte(CP_ACP, 0, wTmp, 1, szTmp, 2, NULL, NULL);
                             PostMessageA(hWnd, WM_CHAR, (BYTE)szTmp[0], 0xFFF10001);
@@ -1721,7 +1720,7 @@ WINNLSTranslateMessageK(
                         }
                         else
                         {
-                            PostMessageW(hWnd, WM_CHAR, (WCHAR)g_chKorean, 0xFFF10001);
+                            PostMessageW(hWnd, WM_CHAR, (WCHAR)s_chKorean, 0xFFF10001);
                             PostMessageW(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
                             PostMessageW(hWnd, WM_KEYDOWN, VK_BACK, 917505);
                         }

--- a/win32ss/user/imm32/win3.c
+++ b/win32ss/user/imm32/win3.c
@@ -287,7 +287,7 @@ Imm32CompStrWToUndetA(
             DWORD nClauses = pCS->dwResultReadClauseLen / sizeof(DWORD);
             PCWSTR pReadW = (PCWSTR)(pbCS + pCS->dwResultReadStrOffset);
 
-            for (DWORD i = 0; i < nClauses; i++)
+            for (DWORD i = 0; i < nClauses; ++i)
                 pDestClause[i] = IchAnsiFromWide(pSrcClause[i], pReadW, CP_ACP);
 
             //ib += ALIGN_DWORD(pCS->dwResultReadClauseLen); // The last one (ineffective)
@@ -407,7 +407,7 @@ Imm32CompStrWToStringExA(
             DWORD nClauses = pCS->dwResultClauseLen / sizeof(DWORD);
             PCWSTR pResultW = (PCWSTR)(pbCS + pCS->dwResultStrOffset);
 
-            for (DWORD i = 0; i < nClauses; i++)
+            for (DWORD i = 0; i < nClauses; ++i)
                 pDestClause[i] = IchAnsiFromWide(pSrcClause[i], pResultW, CP_ACP);
 
             ib += ALIGN_DWORD(pCS->dwResultClauseLen);
@@ -432,7 +432,7 @@ Imm32CompStrWToStringExA(
             DWORD nClauses = pCS->dwResultReadClauseLen / sizeof(DWORD);
             PCWSTR pReadW = (PCWSTR)(pbCS + pCS->dwResultReadStrOffset);
 
-            for (DWORD i = 0; i < nClauses; i++)
+            for (DWORD i = 0; i < nClauses; ++i)
                 pDestClause[i] = IchAnsiFromWide(pSrcClause[i], pReadW, CP_ACP);
 
             //ib += ALIGN_DWORD(pCS->dwResultReadClauseLen); // The last one (ineffective)
@@ -633,7 +633,7 @@ Imm32CompStrAToUndetW(
                 PDWORD pDestClause = (PDWORD)(pbUndet + ib);
                 DWORD nClauses = pCS->dwResultClauseLen / sizeof(DWORD);
 
-                for (DWORD i = 0; i < nClauses; i++)
+                for (DWORD i = 0; i < nClauses; ++i)
                     pDestClause[i] = IchWideFromAnsi(pSrcClause[i], pResultStr, CP_ACP);
 
                 ib += ALIGN_DWORD(pCS->dwResultClauseLen);
@@ -659,7 +659,7 @@ Imm32CompStrAToUndetW(
                 PDWORD pDestClause = (PDWORD)(pbUndet + ib);
                 DWORD nClauses = pCS->dwResultReadClauseLen / sizeof(DWORD);
 
-                for (DWORD i = 0; i < nClauses; i++)
+                for (DWORD i = 0; i < nClauses; ++i)
                     pDestClause[i] = IchWideFromAnsi(pSrcClause[i], pResultReadStr, CP_ACP);
 
                 //ib += ALIGN_DWORD(pCS->dwResultReadClauseLen); // The last one (ineffective)
@@ -776,7 +776,7 @@ Imm32CompStrAToStringExW(
             PDWORD pDestClause = (PDWORD)(pbSX + ib);
             DWORD nClauses = pCS->dwResultClauseLen / sizeof(DWORD);
 
-            for (DWORD i = 0; i < nClauses; i++)
+            for (DWORD i = 0; i < nClauses; ++i)
             {
                 pDestClause[i] = IchWideFromAnsi(pSrcClause[i],
                     (PCSTR)(pbCS + pCS->dwResultStrOffset), CP_ACP);
@@ -802,7 +802,7 @@ Imm32CompStrAToStringExW(
             const DWORD* pSrcClause = (const DWORD*)(pbCS + pCS->dwResultReadClauseOffset);
             PDWORD pDestClause = (PDWORD)(pbSX + ib);
             DWORD nClauses = pCS->dwResultReadClauseLen / sizeof(DWORD);
-            for (DWORD i = 0; i < nClauses; i++)
+            for (DWORD i = 0; i < nClauses; ++i)
                 pDestClause[i] = IchWideFromAnsi(pSrcClause[i], pResultReadStr, CP_ACP);
 
             //ib += ALIGN_DWORD(pCS->dwResultReadClauseLen); // The last one (ineffective)
@@ -1364,7 +1364,7 @@ WINNLSTranslateMessageJ(
     {
         // Find WM_IME_ENDCOMPOSITION
         PTRANSMSG pEndComp = NULL;
-        for (INT i = 0; i < cEntries; i++)
+        for (INT i = 0; i < cEntries; ++i)
         {
             if (pBuf[i].message == WM_IME_ENDCOMPOSITION)
             {
@@ -1519,206 +1519,197 @@ WINNLSTranslateMessageK(
         WPARAM wParam = pEntries[i].wParam;
         LPARAM lParam = pEntries[i].lParam;
 
-        if (uMsg < WM_IME_STARTCOMPOSITION || uMsg > WM_IME_ENDCOMPOSITION)
+        switch (uMsg)
         {
-            switch (uMsg)
-            {
-                case WM_IME_COMPOSITION:
-                    if (lParam & GCS_RESULTSTR)
+            case WM_IME_COMPOSITION:
+                if (lParam & GCS_RESULTSTR)
+                {
+                    pPostMessage(hWnd, WM_IME_REPORT, IR_STRINGSTART, 0);
+
+                    if (pCS->dwResultStrLen)
                     {
-                        pPostMessage(hWnd, WM_IME_REPORT, IR_STRINGSTART, 0);
-
-                        if (pCS->dwResultStrLen)
+                        DWORD dwProcessedLen = 0;
+                        while (dwProcessedLen < pCS->dwResultStrLen)
                         {
-                            DWORD dwProcessedLen = 0;
-                            while (dwProcessedLen < pCS->dwResultStrLen)
+                            LPARAM lKeyData = 1; /* WM_CHAR lParam */
+                            WCHAR szWide[2] = {0};
+                            CHAR  szMBStr[4]  = {0};
+
+                            if (bSrcIsAnsi)
                             {
-                                LPARAM lKeyData = 1; /* WM_CHAR lParam */
-                                WCHAR szWide[2] = {0};
-                                CHAR  szMBStr[4]  = {0};
+                                PSTR pResStr = (LPSTR)((BYTE*)pCS + pCS->dwResultStrOffset);
+                                BYTE bChar = pResStr[dwProcessedLen];
 
-                                if (bSrcIsAnsi)
+                                if (bDestIsUnicode)
                                 {
-                                    PSTR pResStr = (LPSTR)((BYTE*)pCS + pCS->dwResultStrOffset);
-                                    BYTE bChar = (BYTE)pResStr[dwProcessedLen];
+                                    INT cbMB = 1;
 
-                                    if (bDestIsUnicode)
+                                    szMBStr[0] = bChar;
+                                    if (IsDBCSLeadByte(bChar) &&
+                                        dwProcessedLen + 1 < pCS->dwResultStrLen)
                                     {
-                                        INT cbMB = 1;
-
-                                        szMBStr[0] = bChar;
-                                        if (IsDBCSLeadByte(bChar) &&
-                                            (dwProcessedLen + 1) < pCS->dwResultStrLen)
-                                        {
-                                            szMBStr[1] = pResStr[dwProcessedLen + 1];
-                                            cbMB = 2;
-                                            ++dwProcessedLen;
-                                        }
-                                        Imm32AnsiToWide(szMBStr, cbMB, szWide, _countof(szWide));
-                                        PostMessageW(hWnd, WM_CHAR, szWide[0], 1);
+                                        szMBStr[1] = pResStr[dwProcessedLen + 1];
+                                        cbMB = 2;
+                                        ++dwProcessedLen;
                                     }
-                                    else
-                                    {
-                                        if (IsDBCSLeadByte(bChar))
-                                        {
-                                            if (KOR_IS_LEAD_BYTE(bChar))
-                                                lKeyData = KOR_SCAN_CODE_DBCS;
-                                            else
-                                                lKeyData = KOR_SCAN_CODE_SBCS;
-
-                                            PostMessageA(hWnd, WM_CHAR, bChar, lKeyData);
-                                            dwProcessedLen++;
-                                            bChar = (BYTE)pResStr[dwProcessedLen];
-                                        }
-                                        PostMessageA(hWnd, WM_CHAR, bChar, lKeyData);
-                                    }
+                                    Imm32AnsiToWide(szMBStr, cbMB, szWide, _countof(szWide));
+                                    PostMessageW(hWnd, WM_CHAR, szWide[0], 1);
                                 }
                                 else
                                 {
-                                    PWSTR pResStrW = (PWSTR)((PBYTE)pCS + pCS->dwResultStrOffset);
-                                    szWide[0] = pResStrW[dwProcessedLen];
-
-                                    if (bDestIsUnicode)
+                                    if (IsDBCSLeadByte(bChar))
                                     {
-                                        PostMessageW(hWnd, WM_CHAR, szWide[0], 1);
+                                        if (KOR_IS_LEAD_BYTE(bChar))
+                                            lKeyData = KOR_SCAN_CODE_DBCS;
+                                        else
+                                            lKeyData = KOR_SCAN_CODE_SBCS;
+
+                                        PostMessageA(hWnd, WM_CHAR, bChar, lKeyData);
+                                        ++dwProcessedLen;
+                                        bChar = pResStr[dwProcessedLen];
+                                    }
+                                    PostMessageA(hWnd, WM_CHAR, bChar, lKeyData);
+                                }
+                            }
+                            else
+                            {
+                                PWSTR pResStrW = (PWSTR)((PBYTE)pCS + pCS->dwResultStrOffset);
+                                szWide[0] = pResStrW[dwProcessedLen];
+
+                                if (bDestIsUnicode)
+                                {
+                                    PostMessageW(hWnd, WM_CHAR, szWide[0], 1);
+                                }
+                                else
+                                {
+                                    Imm32WideToAnsi(szWide, 1, szMBStr, _countof(szMBStr));
+                                    BYTE bLead = (BYTE)szMBStr[0], bChar;
+                                    if (IsDBCSLeadByte(bLead))
+                                    {
+                                        if (KOR_IS_LEAD_BYTE(bLead))
+                                            lKeyData = KOR_SCAN_CODE_DBCS;
+                                        else
+                                            lKeyData = KOR_SCAN_CODE_SBCS;
+
+                                        PostMessageA(hWnd, WM_CHAR, bLead, lKeyData);
+                                        bChar = szMBStr[1];
                                     }
                                     else
                                     {
-                                        Imm32WideToAnsi(szWide, 1, szMBStr, _countof(szMBStr));
-                                        BYTE bLead = (BYTE)szMBStr[0], bChar;
-                                        if (IsDBCSLeadByte(bLead))
-                                        {
-                                            if (KOR_IS_LEAD_BYTE(bLead))
-                                                lKeyData = KOR_SCAN_CODE_DBCS;
-                                            else
-                                                lKeyData = KOR_SCAN_CODE_SBCS;
-
-                                            PostMessageA(hWnd, WM_CHAR, bLead, lKeyData);
-                                            bChar = (BYTE)szMBStr[1];
-                                        }
-                                        else
-                                        {
-                                            bChar = (BYTE)szMBStr[0];
-                                        }
-
-                                        PostMessageA(hWnd, WM_CHAR, bChar, lKeyData);
+                                        bChar = szMBStr[0];
                                     }
+
+                                    PostMessageA(hWnd, WM_CHAR, bChar, lKeyData);
                                 }
-                                dwProcessedLen++;
                             }
+                            ++dwProcessedLen;
                         }
-                        pPostMessage(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
                     }
+                    pPostMessage(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
+                }
 
-                    if (wParam != 0)
+                if (wParam)
+                {
+                    pPostMessage(hWnd, WM_IME_REPORT, IR_STRINGSTART, 0);
+
+                    BYTE bFirst = HIBYTE(wParam), bSecond = LOBYTE(wParam);
+                    s_chKorean = MAKEWORD(bFirst, bSecond);
+
+                    if (bSrcIsAnsi)
                     {
-                        pPostMessage(hWnd, WM_IME_REPORT, IR_STRINGSTART, 0);
-
-                        BYTE bFirst = HIBYTE(wParam), bSecond = LOBYTE(wParam);
-                        s_chKorean = MAKEWORD(bFirst, bSecond);
-
-                        if (bSrcIsAnsi)
-                        {
-                            if (bDestIsUnicode)
-                            {
-                                CHAR szTmp[2] = { (CHAR)bFirst, (CHAR)bSecond };
-                                WCHAR wTmp[2];
-                                if (Imm32AnsiToWide(szTmp, 2, wTmp, _countof(wTmp)))
-                                    PostMessageW(hWnd, WM_INTERIM, wTmp[0], KOR_INTERIM_FLAGS);
-                            }
-                            else
-                            {
-                                PostMessageA(hWnd, WM_INTERIM, bFirst, KOR_INTERIM_FLAGS);
-                                PostMessageA(hWnd, WM_INTERIM, bSecond, KOR_INTERIM_FLAGS);
-                            }
-                        }
-                        else
-                        {
-                            if (bDestIsUnicode)
-                            {
-                                PostMessageW(hWnd, WM_INTERIM, wParam, KOR_INTERIM_FLAGS);
-                            }
-                            else
-                            {
-                                WCHAR wTmp[2] = { (WCHAR)wParam, 0 };
-                                CHAR szTmp[2];
-                                Imm32WideToAnsi(wTmp, 1, szTmp, _countof(szTmp));
-                                PostMessageA(hWnd, WM_INTERIM, (BYTE)szTmp[0], KOR_INTERIM_FLAGS);
-                                PostMessageA(hWnd, WM_INTERIM, (BYTE)szTmp[1], KOR_INTERIM_FLAGS);
-                            }
-                        }
-
                         if (bDestIsUnicode)
-                            PostMessageW(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
+                        {
+                            CHAR szTmp[2] = { (CHAR)bFirst, (CHAR)bSecond };
+                            WCHAR wTmp[2];
+                            if (Imm32AnsiToWide(szTmp, 2, wTmp, _countof(wTmp)))
+                                PostMessageW(hWnd, WM_INTERIM, wTmp[0], KOR_INTERIM_FLAGS);
+                        }
                         else
-                            PostMessageA(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
-
-                        pSendMessage(hwndIme, WM_IME_ENDCOMPOSITION, 0, 0);
+                        {
+                            PostMessageA(hWnd, WM_INTERIM, bFirst, KOR_INTERIM_FLAGS);
+                            PostMessageA(hWnd, WM_INTERIM, bSecond, KOR_INTERIM_FLAGS);
+                        }
                     }
                     else
                     {
-                        pPostMessage(hWnd, WM_IME_REPORT, IR_STRINGSTART, 0);
-                        if (bSrcIsAnsi)
+                        if (bDestIsUnicode)
                         {
-                            if (bDestIsUnicode)
-                            {
-                                CHAR szTmp[2];
-                                szTmp[0] = LOBYTE(s_chKorean);
-                                szTmp[1] = HIBYTE(s_chKorean);
-                                WCHAR wTmp[2];
-                                if (Imm32AnsiToWide(szTmp, 2, wTmp, _countof(wTmp)))
-                                    PostMessageW(hWnd, WM_CHAR, wTmp[0], KOR_SCAN_CODE_SBCS);
-                                PostMessageW(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
-                                PostMessageW(hWnd, WM_KEYDOWN, VK_BACK, KOR_KEYDOWN_FLAGS);
-                            }
-                            else
-                            {
-                                PostMessageA(hWnd, WM_CHAR, LOBYTE(s_chKorean),
-                                             KOR_SCAN_CODE_SBCS);
-                                PostMessageA(hWnd, WM_CHAR, HIBYTE(s_chKorean),
-                                             KOR_SCAN_CODE_SBCS);
-                                PostMessageA(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
-                                PostMessageA(hWnd, WM_KEYDOWN, VK_BACK, KOR_KEYDOWN_FLAGS);
-                            }
+                            PostMessageW(hWnd, WM_INTERIM, wParam, KOR_INTERIM_FLAGS);
                         }
                         else
                         {
-                            if (bDestIsUnicode)
-                            {
-                                PostMessageW(hWnd, WM_CHAR, (WCHAR)s_chKorean, KOR_SCAN_CODE_SBCS);
-                                PostMessageW(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
-                                PostMessageW(hWnd, WM_KEYDOWN, VK_BACK, KOR_KEYDOWN_FLAGS);
-                            }
-                            else
-                            {
-                                CHAR szTmp[2];
-                                WCHAR wTmp[2] = { (WCHAR)s_chKorean, 0 };
-                                Imm32WideToAnsi(wTmp, 1, szTmp, _countof(szTmp));
-                                PostMessageA(hWnd, WM_CHAR, (BYTE)szTmp[0], KOR_SCAN_CODE_SBCS);
-                                PostMessageA(hWnd, WM_CHAR, (BYTE)szTmp[1], KOR_SCAN_CODE_SBCS);
-                                PostMessageA(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
-                                PostMessageA(hWnd, WM_KEYDOWN, VK_BACK, KOR_KEYDOWN_FLAGS);
-                            }
+                            WCHAR wTmp[2] = { (WCHAR)wParam, 0 };
+                            CHAR szTmp[2];
+                            Imm32WideToAnsi(wTmp, 1, szTmp, _countof(szTmp));
+                            PostMessageA(hWnd, WM_INTERIM, (BYTE)szTmp[0], KOR_INTERIM_FLAGS);
+                            PostMessageA(hWnd, WM_INTERIM, (BYTE)szTmp[1], KOR_INTERIM_FLAGS);
                         }
                     }
-                    break;
 
-                case WM_IMEKEYDOWN:
-                    pPostMessage(hWnd, WM_KEYDOWN, (WPARAM)(LOWORD(wParam)), lParam);
-                    break;
+                    if (bDestIsUnicode)
+                        PostMessageW(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
+                    else
+                        PostMessageA(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
 
-                case WM_IMEKEYUP:
-                    pPostMessage(hWnd, WM_KEYUP, (WPARAM)(LOWORD(wParam)), lParam);
-                    break;
+                    pSendMessage(hwndIme, WM_IME_ENDCOMPOSITION, 0, 0);
+                }
+                else
+                {
+                    pPostMessage(hWnd, WM_IME_REPORT, IR_STRINGSTART, 0);
+                    if (bSrcIsAnsi)
+                    {
+                        if (bDestIsUnicode)
+                        {
+                            CHAR szTmp[2];
+                            szTmp[0] = LOBYTE(s_chKorean);
+                            szTmp[1] = HIBYTE(s_chKorean);
+                            WCHAR wTmp[2];
+                            if (Imm32AnsiToWide(szTmp, 2, wTmp, _countof(wTmp)))
+                                PostMessageW(hWnd, WM_CHAR, wTmp[0], KOR_SCAN_CODE_SBCS);
+                            PostMessageW(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
+                            PostMessageW(hWnd, WM_KEYDOWN, VK_BACK, KOR_KEYDOWN_FLAGS);
+                        }
+                        else
+                        {
+                            PostMessageA(hWnd, WM_CHAR, LOBYTE(s_chKorean), KOR_SCAN_CODE_SBCS);
+                            PostMessageA(hWnd, WM_CHAR, HIBYTE(s_chKorean), KOR_SCAN_CODE_SBCS);
+                            PostMessageA(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
+                            PostMessageA(hWnd, WM_KEYDOWN, VK_BACK, KOR_KEYDOWN_FLAGS);
+                        }
+                    }
+                    else
+                    {
+                        if (bDestIsUnicode)
+                        {
+                            PostMessageW(hWnd, WM_CHAR, (WCHAR)s_chKorean, KOR_SCAN_CODE_SBCS);
+                            PostMessageW(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
+                            PostMessageW(hWnd, WM_KEYDOWN, VK_BACK, KOR_KEYDOWN_FLAGS);
+                        }
+                        else
+                        {
+                            CHAR szTmp[2];
+                            WCHAR wTmp[2] = { (WCHAR)s_chKorean, 0 };
+                            Imm32WideToAnsi(wTmp, 1, szTmp, _countof(szTmp));
+                            PostMessageA(hWnd, WM_CHAR, (BYTE)szTmp[0], KOR_SCAN_CODE_SBCS);
+                            PostMessageA(hWnd, WM_CHAR, (BYTE)szTmp[1], KOR_SCAN_CODE_SBCS);
+                            PostMessageA(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
+                            PostMessageA(hWnd, WM_KEYDOWN, VK_BACK, KOR_KEYDOWN_FLAGS);
+                        }
+                    }
+                }
+                break;
 
-                default:
-                    pSendMessage(hwndIme, uMsg, wParam, lParam);
-                    break;
-            }
-        }
-        else
-        {
-            pSendMessage(hwndIme, uMsg, wParam, lParam);
+            case WM_IMEKEYDOWN:
+                pPostMessage(hWnd, WM_KEYDOWN, (WPARAM)LOWORD(wParam), lParam);
+                break;
+
+            case WM_IMEKEYUP:
+                pPostMessage(hWnd, WM_KEYUP, (WPARAM)LOWORD(wParam), lParam);
+                break;
+
+            default:
+                pSendMessage(hwndIme, uMsg, wParam, lParam);
+                break;
         }
     }
 

--- a/win32ss/user/imm32/win3.c
+++ b/win32ss/user/imm32/win3.c
@@ -20,7 +20,7 @@ static DWORD
 Imm32CompStrWToUndetW(
     DWORD dwGCS,
     const COMPOSITIONSTRING *pCS,
-    PUNDETERMINESTRUCT pDeter)
+    PUNDETERMINESTRUCT pDet)
 {
     DWORD dwRequiredSize =
         sizeof(UNDETERMINESTRUCT) +
@@ -31,47 +31,47 @@ Imm32CompStrWToUndetW(
         ALIGN_DWORD((pCS->dwResultReadStrLen + 1) * sizeof(WCHAR)) +
         ALIGN_DWORD(pCS->dwResultReadClauseLen);
 
-    if (!pDeter)
+    if (!pDet)
         return dwRequiredSize;
 
     if (dwRequiredSize == 0)
         return 0;
 
-    RtlZeroMemory(pDeter, sizeof(UNDETERMINESTRUCT));
-    pDeter->dwSize = dwRequiredSize;
+    RtlZeroMemory(pDet, sizeof(UNDETERMINESTRUCT));
+    pDet->dwSize = dwRequiredSize;
 
     DWORD dwCurrentOffset = sizeof(UNDETERMINESTRUCT);
-    PBYTE pBase = (PBYTE)pDeter;
+    PBYTE pBase = (PBYTE)pDet;
     const BYTE *pSrcBase = (const BYTE *)pCS;
 
     if ((dwGCS & GCS_COMPSTR) && (pCS->dwCompStrLen > 0))
     {
-        pDeter->uUndetTextPos = dwCurrentOffset;
-        pDeter->uUndetTextLen = pCS->dwCompStrLen;
+        pDet->uUndetTextPos = dwCurrentOffset;
+        pDet->uUndetTextLen = pCS->dwCompStrLen;
         DWORD cb = pCS->dwCompStrLen * sizeof(WCHAR);
         RtlCopyMemory(pBase + dwCurrentOffset, pSrcBase + pCS->dwCompStrOffset, cb);
         ((PWCHAR)(pBase + dwCurrentOffset))[pCS->dwCompStrLen] = UNICODE_NULL;
         dwCurrentOffset += ALIGN_DWORD((pCS->dwCompStrLen + 1) * sizeof(WCHAR));
     }
 
-    if ((dwGCS & GCS_COMPATTR) && (pCS->dwCompAttrLen > 0) && (pDeter->uUndetTextLen > 0))
+    if ((dwGCS & GCS_COMPATTR) && (pCS->dwCompAttrLen > 0) && (pDet->uUndetTextLen > 0))
     {
-        pDeter->uUndetAttrPos = dwCurrentOffset;
+        pDet->uUndetAttrPos = dwCurrentOffset;
         RtlCopyMemory(pBase + dwCurrentOffset, pSrcBase + pCS->dwCompAttrOffset,
                       pCS->dwCompAttrLen);
         dwCurrentOffset += ALIGN_DWORD(pCS->dwCompAttrLen);
     }
 
     if (dwGCS & GCS_CURSORPOS)
-        pDeter->uCursorPos = pCS->dwCursorPos;
+        pDet->uCursorPos = pCS->dwCursorPos;
 
     if (dwGCS & GCS_DELTASTART)
-        pDeter->uDeltaStart = pCS->dwDeltaStart;
+        pDet->uDeltaStart = pCS->dwDeltaStart;
 
     if ((dwGCS & GCS_RESULTSTR) && (pCS->dwResultStrLen > 0))
     {
-        pDeter->uDetermineTextPos = dwCurrentOffset;
-        pDeter->uDetermineTextLen = pCS->dwResultStrLen;
+        pDet->uDetermineTextPos = dwCurrentOffset;
+        pDet->uDetermineTextLen = pCS->dwResultStrLen;
         DWORD cb = pCS->dwResultStrLen * sizeof(WCHAR);
         RtlCopyMemory(pBase + dwCurrentOffset, pSrcBase + pCS->dwResultStrOffset, cb);
         ((PWCHAR)(pBase + dwCurrentOffset))[pCS->dwResultStrLen] = UNICODE_NULL;
@@ -79,9 +79,9 @@ Imm32CompStrWToUndetW(
     }
 
     if ((dwGCS & GCS_RESULTCLAUSE) && (pCS->dwResultClauseLen > 0) &&
-        (pDeter->uDetermineTextLen > 0))
+        (pDet->uDetermineTextLen > 0))
     {
-        pDeter->uDetermineDelimPos = dwCurrentOffset;
+        pDet->uDetermineDelimPos = dwCurrentOffset;
         RtlCopyMemory(pBase + dwCurrentOffset,
                       pSrcBase + pCS->dwResultClauseOffset,
                       pCS->dwResultClauseLen);
@@ -90,8 +90,8 @@ Imm32CompStrWToUndetW(
 
     if ((dwGCS & GCS_RESULTREADSTR) && (pCS->dwResultReadStrLen > 0))
     {
-        pDeter->uYomiTextPos = dwCurrentOffset;
-        pDeter->uYomiTextLen = pCS->dwResultReadStrLen;
+        pDet->uYomiTextPos = dwCurrentOffset;
+        pDet->uYomiTextLen = pCS->dwResultReadStrLen;
         DWORD cb = pCS->dwResultReadStrLen * sizeof(WCHAR);
         RtlCopyMemory(pBase + dwCurrentOffset, pSrcBase + pCS->dwResultReadStrOffset, cb);
         ((PWCHAR)(pBase + dwCurrentOffset))[pCS->dwResultReadStrLen] = UNICODE_NULL;
@@ -99,9 +99,9 @@ Imm32CompStrWToUndetW(
     }
 
     if ((dwGCS & GCS_RESULTREADCLAUSE) && (pCS->dwResultReadClauseLen > 0) &&
-        (pDeter->uYomiTextLen > 0))
+        (pDet->uYomiTextLen > 0))
     {
-        pDeter->uYomiDelimPos = dwCurrentOffset;
+        pDet->uYomiDelimPos = dwCurrentOffset;
         RtlCopyMemory(pBase + dwCurrentOffset,
                       pSrcBase + pCS->dwResultReadClauseOffset,
                       pCS->dwResultReadClauseLen);
@@ -115,7 +115,7 @@ static DWORD
 Imm32CompStrWToUndetA(
     DWORD dwGCS,
     const COMPOSITIONSTRING *pCS,
-    PUNDETERMINESTRUCT pDeter)
+    PUNDETERMINESTRUCT pDet)
 {
     DWORD dwRequiredSize =
         sizeof(UNDETERMINESTRUCT) +
@@ -126,17 +126,17 @@ Imm32CompStrWToUndetA(
         ALIGN_DWORD(2 * pCS->dwResultReadStrLen + 3) +
         ALIGN_DWORD(pCS->dwResultReadClauseLen) + 60;
 
-    if (!pDeter)
+    if (!pDet)
         return dwRequiredSize;
 
     if (dwRequiredSize == 0)
         return 0;
 
-    RtlZeroMemory(pDeter, sizeof(UNDETERMINESTRUCT));
-    pDeter->dwSize = dwRequiredSize;
+    RtlZeroMemory(pDet, sizeof(UNDETERMINESTRUCT));
+    pDet->dwSize = dwRequiredSize;
 
     DWORD dwCurrentOffset = sizeof(UNDETERMINESTRUCT);
-    PBYTE pBase = (PBYTE)pDeter;
+    PBYTE pBase = (PBYTE)pDet;
     const BYTE *pSrcBase = (const BYTE *)pCS;
     BOOL bUsedDef;
 
@@ -149,15 +149,15 @@ Imm32CompStrWToUndetA(
             NULL, &bUsedDef);
         if (nAnsiLen <= 0)
             return 0;
-        pDeter->uUndetTextPos = dwCurrentOffset;
-        pDeter->uUndetTextLen = nAnsiLen;
+        pDet->uUndetTextPos = dwCurrentOffset;
+        pDet->uUndetTextLen = nAnsiLen;
         (pBase + dwCurrentOffset)[nAnsiLen] = ANSI_NULL;
         dwCurrentOffset += ALIGN_DWORD(nAnsiLen + 1);
     }
 
-    if ((dwGCS & GCS_COMPATTR) && (pCS->dwCompAttrLen > 0) && (pDeter->uUndetTextLen > 0))
+    if ((dwGCS & GCS_COMPATTR) && (pCS->dwCompAttrLen > 0) && (pDet->uUndetTextLen > 0))
     {
-        pDeter->uUndetAttrPos = dwCurrentOffset;
+        pDet->uUndetAttrPos = dwCurrentOffset;
         const BYTE *pSrcAttr = pSrcBase + pCS->dwCompAttrOffset;
         PBYTE pDestAttr = pBase + dwCurrentOffset;
         const WCHAR *pWStr = (const WCHAR *)(pSrcBase + pCS->dwCompStrOffset);
@@ -185,11 +185,11 @@ Imm32CompStrWToUndetA(
     {
         if (pCS->dwCursorPos == (DWORD)-1)
         {
-            pDeter->uCursorPos = (UINT)-1;
+            pDet->uCursorPos = (UINT)-1;
         }
         else
         {
-            pDeter->uCursorPos = IchAnsiFromWide(pCS->dwCursorPos,
+            pDet->uCursorPos = IchAnsiFromWide(pCS->dwCursorPos,
                 (PCWSTR)(pSrcBase + pCS->dwCompStrOffset), CP_ACP);
         }
     }
@@ -198,11 +198,11 @@ Imm32CompStrWToUndetA(
     {
         if (pCS->dwDeltaStart == (DWORD)-1)
         {
-            pDeter->uDeltaStart = (UINT)-1;
+            pDet->uDeltaStart = (UINT)-1;
         }
         else
         {
-            pDeter->uDeltaStart = IchAnsiFromWide(pCS->dwDeltaStart,
+            pDet->uDeltaStart = IchAnsiFromWide(pCS->dwDeltaStart,
                 (PCWSTR)(pSrcBase + pCS->dwCompStrOffset), CP_ACP);
         }
     }
@@ -216,17 +216,17 @@ Imm32CompStrWToUndetA(
             NULL, &bUsedDef);
         if (nAnsiLen > 0)
         {
-            pDeter->uDetermineTextPos = dwCurrentOffset;
-            pDeter->uDetermineTextLen = nAnsiLen;
+            pDet->uDetermineTextPos = dwCurrentOffset;
+            pDet->uDetermineTextLen = nAnsiLen;
             (pBase + dwCurrentOffset)[nAnsiLen] = ANSI_NULL;
             dwCurrentOffset += ALIGN_DWORD(nAnsiLen + 1);
         }
     }
 
     if ((dwGCS & GCS_RESULTCLAUSE) && (pCS->dwResultClauseLen > 0) &&
-        (pDeter->uDetermineTextLen > 0))
+        (pDet->uDetermineTextLen > 0))
     {
-        pDeter->uDetermineDelimPos = dwCurrentOffset;
+        pDet->uDetermineDelimPos = dwCurrentOffset;
         const DWORD *pSrcClause = (const DWORD *)(pSrcBase + pCS->dwResultClauseOffset);
         PDWORD pDestClause = (PDWORD)(pBase + dwCurrentOffset);
         DWORD nClauses = pCS->dwResultClauseLen / sizeof(DWORD);
@@ -247,17 +247,17 @@ Imm32CompStrWToUndetA(
             NULL, &bUsedDef);
         if (nAnsiLen > 0)
         {
-            pDeter->uYomiTextPos = dwCurrentOffset;
-            pDeter->uYomiTextLen = nAnsiLen;
+            pDet->uYomiTextPos = dwCurrentOffset;
+            pDet->uYomiTextLen = nAnsiLen;
             (pBase + dwCurrentOffset)[nAnsiLen] = ANSI_NULL;
             dwCurrentOffset += ALIGN_DWORD(nAnsiLen + 1);
         }
     }
 
     if ((dwGCS & GCS_RESULTREADCLAUSE) && (pCS->dwResultReadClauseLen > 0) &&
-        (pDeter->uYomiTextLen > 0))
+        (pDet->uYomiTextLen > 0))
     {
-        pDeter->uYomiDelimPos = dwCurrentOffset;
+        pDet->uYomiDelimPos = dwCurrentOffset;
         const DWORD *pSrcClause = (const DWORD *)(pSrcBase + pCS->dwResultReadClauseOffset);
         PDWORD pDestClause = (PDWORD)(pBase + dwCurrentOffset);
         DWORD nClauses = pCS->dwResultReadClauseLen / sizeof(DWORD);
@@ -481,7 +481,7 @@ static DWORD
 Imm32CompStrAToUndetA(
     DWORD dwGCS,
     const COMPOSITIONSTRING *pCS,
-    PUNDETERMINESTRUCT pDeter,
+    PUNDETERMINESTRUCT pDet,
     DWORD dwSize)
 {
     DWORD dwRequiredSize =
@@ -493,22 +493,22 @@ Imm32CompStrAToUndetA(
         ALIGN_DWORD(pCS->dwResultReadStrLen) +
         ALIGN_DWORD(pCS->dwResultReadClauseLen);
 
-    if (!pDeter)
+    if (!pDet)
         return dwRequiredSize;
 
     if (dwSize < dwRequiredSize)
         return 0;
 
-    RtlZeroMemory(pDeter, sizeof(UNDETERMINESTRUCT));
-    pDeter->dwSize = dwSize;
+    RtlZeroMemory(pDet, sizeof(UNDETERMINESTRUCT));
+    pDet->dwSize = dwSize;
 
     DWORD dwCurrentOffset = sizeof(UNDETERMINESTRUCT);
-    PBYTE pBase = (PBYTE)pDeter, pSrcBase = (PBYTE)pCS;
+    PBYTE pBase = (PBYTE)pDet, pSrcBase = (PBYTE)pCS;
 
     if ((dwGCS & GCS_COMPSTR) && (pCS->dwCompStrLen > 0))
     {
-        pDeter->uUndetTextPos = dwCurrentOffset;
-        pDeter->uUndetTextLen = pCS->dwCompStrLen;
+        pDet->uUndetTextPos = dwCurrentOffset;
+        pDet->uUndetTextLen = pCS->dwCompStrLen;
         RtlCopyMemory(pBase + dwCurrentOffset, pSrcBase + pCS->dwCompStrOffset, pCS->dwCompStrLen);
         pBase[dwCurrentOffset + pCS->dwCompStrLen] = ANSI_NULL;
         dwCurrentOffset += ALIGN_DWORD(pCS->dwCompStrLen + 1);
@@ -516,22 +516,22 @@ Imm32CompStrAToUndetA(
 
     if ((dwGCS & GCS_COMPATTR) && (pCS->dwCompAttrLen > 0))
     {
-        pDeter->uUndetAttrPos = dwCurrentOffset;
+        pDet->uUndetAttrPos = dwCurrentOffset;
         RtlCopyMemory(pBase + dwCurrentOffset, pSrcBase + pCS->dwCompAttrOffset,
                       pCS->dwCompAttrLen);
         dwCurrentOffset += ALIGN_DWORD(pCS->dwCompAttrLen);
     }
 
     if (dwGCS & GCS_CURSORPOS)
-        pDeter->uCursorPos = pCS->dwCursorPos;
+        pDet->uCursorPos = pCS->dwCursorPos;
 
     if (dwGCS & GCS_DELTASTART)
-        pDeter->uDeltaStart = pCS->dwDeltaStart;
+        pDet->uDeltaStart = pCS->dwDeltaStart;
 
     if ((dwGCS & GCS_RESULTSTR) && (pCS->dwResultStrLen > 0))
     {
-        pDeter->uDetermineTextPos = dwCurrentOffset;
-        pDeter->uDetermineTextLen = pCS->dwResultStrLen;
+        pDet->uDetermineTextPos = dwCurrentOffset;
+        pDet->uDetermineTextLen = pCS->dwResultStrLen;
         RtlCopyMemory(pBase + dwCurrentOffset, pSrcBase + pCS->dwResultStrOffset,
                       pCS->dwResultStrLen);
         pBase[dwCurrentOffset + pCS->dwResultStrLen] = ANSI_NULL;
@@ -540,7 +540,7 @@ Imm32CompStrAToUndetA(
 
     if ((dwGCS & GCS_RESULTCLAUSE) && (pCS->dwResultClauseLen > 0))
     {
-        pDeter->uDetermineDelimPos = dwCurrentOffset;
+        pDet->uDetermineDelimPos = dwCurrentOffset;
         RtlCopyMemory(pBase + dwCurrentOffset, pSrcBase + pCS->dwResultClauseOffset,
                       pCS->dwResultClauseLen);
         dwCurrentOffset += ALIGN_DWORD(pCS->dwResultClauseLen);
@@ -548,8 +548,8 @@ Imm32CompStrAToUndetA(
 
     if ((dwGCS & GCS_RESULTREADSTR) && (pCS->dwResultReadStrLen > 0))
     {
-        pDeter->uYomiTextPos = dwCurrentOffset;
-        pDeter->uYomiTextLen = pCS->dwResultReadStrLen;
+        pDet->uYomiTextPos = dwCurrentOffset;
+        pDet->uYomiTextLen = pCS->dwResultReadStrLen;
         RtlCopyMemory(pBase + dwCurrentOffset, pSrcBase + pCS->dwResultReadStrOffset,
                       pCS->dwResultReadStrLen);
         pBase[dwCurrentOffset + pCS->dwResultReadStrLen] = ANSI_NULL;
@@ -558,7 +558,7 @@ Imm32CompStrAToUndetA(
 
     if ((dwGCS & GCS_RESULTREADCLAUSE) && (pCS->dwResultReadClauseLen > 0))
     {
-        pDeter->uYomiDelimPos = dwCurrentOffset;
+        pDet->uYomiDelimPos = dwCurrentOffset;
         RtlCopyMemory(pBase + dwCurrentOffset, pSrcBase + pCS->dwResultReadClauseOffset,
                       pCS->dwResultReadClauseLen);
         dwCurrentOffset += ALIGN_DWORD(pCS->dwResultReadClauseLen);
@@ -1026,9 +1026,9 @@ static CHAR Imm32CompStrAToCharW(HWND hWnd, const COMPOSITIONSTRING *pCS)
 
 static DWORD
 Imm32JTransCompositionA(
-    PINPUTCONTEXTDX pIC,
-    PCOMPOSITIONSTRING pCS,
-    PTRANSMSG pCurrent,
+    const INPUTCONTEXTDX *pIC,
+    const COMPOSITIONSTRING *pCS,
+    const TRANSMSG *pCurrent,
     PTRANSMSG pEntries)
 {
     HWND hWnd = pIC->hWnd;
@@ -1193,11 +1193,11 @@ FINALIZE:
     return msgCount;
 }
 
-DWORD
+static DWORD
 Imm32JTransCompositionW(
-    PINPUTCONTEXTDX pIC,
-    PCOMPOSITIONSTRING pCS,
-    PTRANSMSG pCurrent,
+    const INPUTCONTEXTDX *pIC,
+    const COMPOSITIONSTRING *pCS,
+    const TRANSMSG *pCurrent,
     PTRANSMSG pEntries)
 {
     HWND hWnd = pIC->hWnd;
@@ -1368,8 +1368,12 @@ FINALIZE:
 
 /* Japanese */
 static DWORD
-WINNLSTranslateMessageJ(DWORD dwCount, PTRANSMSG pEntries, PINPUTCONTEXTDX pIC,
-                        PCOMPOSITIONSTRING pCS, BOOL bAnsi)
+WINNLSTranslateMessageJ(
+    DWORD dwCount,
+    PTRANSMSG pEntries,
+    const INPUTCONTEXTDX *pIC,
+    const COMPOSITIONSTRING *pCS,
+    BOOL bAnsi)
 {
     // Clone the message list with growing
     SIZE_T dwBufSize = (dwCount + 1) * sizeof(TRANSMSG);
@@ -1519,8 +1523,8 @@ static DWORD
 WINNLSTranslateMessageK(
     DWORD dwCount,
     PTRANSMSG pEntries,
-    PINPUTCONTEXTDX pIC,
-    PCOMPOSITIONSTRING pCS,
+    const INPUTCONTEXTDX *pIC,
+    const COMPOSITIONSTRING *pCS,
     BOOL bSrcIsAnsi)
 {
     HWND hWnd = pIC->hWnd;

--- a/win32ss/user/imm32/win3.c
+++ b/win32ss/user/imm32/win3.c
@@ -1043,7 +1043,7 @@ Imm32JTransCompositionA(
     BOOL bUndeterminedProcessed = FALSE;
     BOOL bResultProcessed = FALSE;
     HGLOBAL hGlobal = NULL;
-    SIZE_T dataSize = 0;
+    DWORD dataSize = 0;
 
     if (pIC->dwUIFlags & _IME_UI_HIDDEN)
     {
@@ -1056,11 +1056,18 @@ Imm32JTransCompositionA(
                 if (hGlobal)
                 {
                     PUNDETERMINESTRUCT pUndet = GlobalLock(hGlobal);
-                    if (Imm32CompStrAToUndetA(dwGCS, pCS, pUndet, (DWORD)dataSize))
+                    if (pUndet)
                     {
+                        dataSize = Imm32CompStrAToUndetA(dwGCS, pCS, pUndet, dataSize);
                         GlobalUnlock(hGlobal);
-                        if (SendMessageA(hWnd, WM_IME_REPORT, IR_UNDETERMINE, (LPARAM)hGlobal) == 0)
-                            bUndeterminedProcessed = TRUE;
+                        if (dataSize)
+                        {
+                            if (SendMessageA(hWnd, WM_IME_REPORT, IR_UNDETERMINE,
+                                             (LPARAM)hGlobal) == 0)
+                            {
+                                bUndeterminedProcessed = TRUE;
+                            }
+                        }
                     }
                 }
             }
@@ -1074,26 +1081,27 @@ Imm32JTransCompositionA(
                 if (hGlobal)
                 {
                     PUNDETERMINESTRUCT pUndet = GlobalLock(hGlobal);
-                    if (Imm32CompStrAToUndetW(dwGCS, pCS, pUndet, (DWORD)dataSize))
+                    if (pUndet)
                     {
+                        dataSize = Imm32CompStrAToUndetW(dwGCS, pCS, pUndet, dataSize);
                         GlobalUnlock(hGlobal);
-                        if (SendMessageW(hWnd, WM_IME_REPORT, IR_UNDETERMINE, (LPARAM)hGlobal) == 0)
-                            bUndeterminedProcessed = TRUE;
+                        if (dataSize)
+                        {
+                            if (SendMessageW(hWnd, WM_IME_REPORT, IR_UNDETERMINE,
+                                             (LPARAM)hGlobal) == 0)
+                            {
+                                bUndeterminedProcessed = TRUE;
+                            }
+                        }
                     }
                 }
             }
         }
 
-        if (hGlobal && !bUndeterminedProcessed)
-        {
-            GlobalUnlock(hGlobal);
+        if (hGlobal)
             GlobalFree(hGlobal);
-        }
-        else if (hGlobal && bUndeterminedProcessed)
-        {
-            GlobalFree(hGlobal);
+        if (bUndeterminedProcessed)
             return 0;
-        }
     }
 
     SIZE_T exSize;

--- a/win32ss/user/imm32/win3.c
+++ b/win32ss/user/imm32/win3.c
@@ -16,6 +16,31 @@ WINE_DEFAULT_DEBUG_CHANNEL(imm);
 
 static WORD g_dchKorean = 0; /* One or two Korean character(s) */
 
+static DWORD Imm32CompStrWToStringA(const COMPOSITIONSTRING *pCS, PCHAR pch)
+{
+    const WCHAR *pwch = (const WCHAR *)((PBYTE)pCS + pCS->dwResultStrOffset);
+    BOOL bUsedDef;
+    INT cchNeed = WideCharToMultiByte(CP_ACP, 0, pwch, pCS->dwResultStrLen,
+                                      pch, 0, NULL, &bUsedDef) + 1;
+    if (!pch)
+        return cchNeed;
+    INT cch = WideCharToMultiByte(CP_ACP, 0, pwch, pCS->dwResultStrLen,
+                                  pch, cchNeed, NULL, &bUsedDef);
+    pch[cch] = 0;
+    return cch + 1;
+}
+
+static DWORD Imm32CompStrWToStringW(const COMPOSITIONSTRING *pCS, PWCHAR pch)
+{
+    DWORD dwResultStrLen = pCS->dwResultStrLen;
+    if (!pch)
+        return (dwResultStrLen + 1) * sizeof(WCHAR);
+    DWORD cb = dwResultStrLen * sizeof(WCHAR);
+    RtlCopyMemory(pch, (const BYTE*)pCS + pCS->dwResultStrOffset, cb);
+    pch[cb / sizeof(WCHAR)] = UNICODE_NULL;
+    return cb + sizeof(UNICODE_NULL);
+}
+
 static DWORD
 Imm32CompStrWToUndetW(
     DWORD dwGCS,
@@ -23,13 +48,13 @@ Imm32CompStrWToUndetW(
     PUNDETERMINESTRUCT pDet,
     DWORD dwSize)
 {
-    DWORD dwRequiredSize =
+    const DWORD dwRequiredSize =
         sizeof(UNDETERMINESTRUCT) +
-        ALIGN_DWORD((pCS->dwCompStrLen + 1) * sizeof(WCHAR)) +
+        ALIGN_DWORD(pCS->dwCompStrLen * sizeof(WCHAR) + sizeof(UNICODE_NULL)) +
         ALIGN_DWORD(pCS->dwCompAttrLen) +
-        ALIGN_DWORD((pCS->dwResultStrLen + 1) * sizeof(WCHAR)) +
+        ALIGN_DWORD(pCS->dwResultStrLen * sizeof(WCHAR) + sizeof(UNICODE_NULL)) +
         ALIGN_DWORD(pCS->dwResultClauseLen) +
-        ALIGN_DWORD((pCS->dwResultReadStrLen + 1) * sizeof(WCHAR)) +
+        ALIGN_DWORD(pCS->dwResultReadStrLen * sizeof(WCHAR) + sizeof(UNICODE_NULL)) +
         ALIGN_DWORD(pCS->dwResultReadClauseLen);
 
     if (!pDet)
@@ -119,14 +144,14 @@ Imm32CompStrWToUndetA(
     PUNDETERMINESTRUCT pDet,
     DWORD dwSize)
 {
-    DWORD dwRequiredSize =
+    const DWORD dwRequiredSize =
         sizeof(UNDETERMINESTRUCT) +
-        ALIGN_DWORD(2 * pCS->dwCompStrLen + 3) +
-        ALIGN_DWORD(pCS->dwCompAttrLen) +
-        ALIGN_DWORD(2 * pCS->dwResultStrLen + 3) +
+        ALIGN_DWORD(2 * pCS->dwCompStrLen + sizeof(ANSI_NULL)) +
+        ALIGN_DWORD(2 * pCS->dwCompAttrLen + 1) +
+        ALIGN_DWORD(2 * pCS->dwResultStrLen + sizeof(ANSI_NULL)) +
         ALIGN_DWORD(pCS->dwResultClauseLen) +
-        ALIGN_DWORD(2 * pCS->dwResultReadStrLen + 3) +
-        ALIGN_DWORD(pCS->dwResultReadClauseLen) + 60;
+        ALIGN_DWORD(2 * pCS->dwResultReadStrLen + sizeof(ANSI_NULL)) +
+        ALIGN_DWORD(pCS->dwResultReadClauseLen);
 
     if (!pDet)
         return dwRequiredSize;
@@ -146,10 +171,10 @@ Imm32CompStrWToUndetA(
     {
         INT nAnsiLen = WideCharToMultiByte(CP_ACP, 0,
             (PCWSTR)(pSrcBase + pCS->dwCompStrOffset), pCS->dwCompStrLen,
-            (PSTR)(pBase + dwCurrentOffset), dwRequiredSize - dwCurrentOffset,
-            NULL, &bUsedDef);
+            (PSTR)(pBase + dwCurrentOffset), dwRequiredSize - dwCurrentOffset, NULL, &bUsedDef);
         if (nAnsiLen <= 0)
             return 0;
+
         pDet->uUndetTextPos = dwCurrentOffset;
         pDet->uUndetTextLen = nAnsiLen;
         (pBase + dwCurrentOffset)[nAnsiLen] = ANSI_NULL;
@@ -162,24 +187,25 @@ Imm32CompStrWToUndetA(
         const BYTE *pSrcAttr = pSrcBase + pCS->dwCompAttrOffset;
         PBYTE pDestAttr = pBase + dwCurrentOffset;
         const WCHAR *pWStr = (const WCHAR *)(pSrcBase + pCS->dwCompStrOffset);
-        UINT nDestIdx = 0;
+        UINT ibIndex = 0;
 
-        for (UINT i = 0; i < pCS->dwCompAttrLen; i++)
+        for (UINT i = 0; i < pCS->dwCompAttrLen; ++i)
         {
             ULONG cbMultiByte = 0;
             USHORT wChar = pWStr[i];
             RtlUnicodeToMultiByteSize(&cbMultiByte, &wChar, sizeof(WCHAR));
             if (cbMultiByte == 2)
             {
-                pDestAttr[nDestIdx++] = pSrcAttr[i];
-                pDestAttr[nDestIdx++] = pSrcAttr[i];
+                pDestAttr[ibIndex++] = pSrcAttr[i];
+                pDestAttr[ibIndex++] = pSrcAttr[i];
             }
             else
             {
-                pDestAttr[nDestIdx++] = pSrcAttr[i];
+                pDestAttr[ibIndex++] = pSrcAttr[i];
             }
         }
-        dwCurrentOffset += ALIGN_DWORD(nDestIdx);
+
+        dwCurrentOffset += ALIGN_DWORD(ibIndex);
     }
 
     if (dwGCS & GCS_CURSORPOS)
@@ -233,7 +259,7 @@ Imm32CompStrWToUndetA(
         DWORD nClauses = pCS->dwResultClauseLen / sizeof(DWORD);
         const WCHAR *pResultW = (const WCHAR *)(pSrcBase + pCS->dwResultStrOffset);
 
-        for (DWORD i = 0; i < nClauses; i++)
+        for (DWORD i = 0; i < nClauses; ++i)
             pDestClause[i] = IchAnsiFromWide(pSrcClause[i], pResultW, CP_ACP);
 
         dwCurrentOffset += ALIGN_DWORD(pCS->dwResultClauseLen);
@@ -280,16 +306,12 @@ Imm32CompStrWToStringExW(
     LPSTRINGEXSTRUCT pSX,
     DWORD dwSize)
 {
-    DWORD dwResultStrSize    = pCS->dwResultStrLen
-        ? ALIGN_DWORD((pCS->dwResultStrLen + 1) * sizeof(WCHAR)) : 0;
-    DWORD dwResultClauseSize = pCS->dwResultClauseLen
-        ? ALIGN_DWORD(pCS->dwResultClauseLen) : 0;
-    DWORD dwResultReadStrSize = pCS->dwResultReadStrLen
-        ? ALIGN_DWORD((pCS->dwResultReadStrLen + 1) * sizeof(WCHAR)) : 0;
-    DWORD dwReadClauseSize   = pCS->dwResultReadClauseLen
-        ? ALIGN_DWORD(pCS->dwResultReadClauseLen) : 0;
-    DWORD dwRequiredSize = sizeof(STRINGEXSTRUCT) + dwResultStrSize + dwResultClauseSize +
-                           dwResultReadStrSize + dwReadClauseSize;
+    const DWORD dwRequiredSize =
+        sizeof(STRINGEXSTRUCT) +
+        ALIGN_DWORD(pCS->dwResultStrLen * sizeof(WCHAR) + sizeof(UNICODE_NULL)) +
+        ALIGN_DWORD(pCS->dwResultClauseLen) +
+        ALIGN_DWORD(pCS->dwResultReadStrLen * sizeof(WCHAR) + sizeof(UNICODE_NULL)) +
+        ALIGN_DWORD(pCS->dwResultReadClauseLen);
 
     if (!pSX)
         return dwRequiredSize;
@@ -348,16 +370,12 @@ Imm32CompStrWToStringExA(
     LPSTRINGEXSTRUCT pSX,
     DWORD dwSize)
 {
-    DWORD dwResultStrSize = pCS->dwResultStrLen
-        ? ALIGN_DWORD(2 * pCS->dwResultStrLen + 5) : 0;
-    DWORD dwResultClauseSize = pCS->dwResultClauseLen
-        ? ALIGN_DWORD(pCS->dwResultClauseLen + 4) : 0;
-    DWORD dwResultReadStrSize = pCS->dwResultReadStrLen
-        ? ALIGN_DWORD(2 * pCS->dwResultReadStrLen + 5) : 0;
-    DWORD dwReadClauseSize = pCS->dwResultReadClauseLen
-        ? ALIGN_DWORD(pCS->dwResultReadClauseLen + 4) : 0;
-    DWORD dwRequiredSize = sizeof(STRINGEXSTRUCT) + dwResultStrSize + dwResultClauseSize +
-                           dwResultReadStrSize + dwReadClauseSize;
+    const DWORD dwRequiredSize =
+        sizeof(STRINGEXSTRUCT) +
+        ALIGN_DWORD(2 * pCS->dwResultStrLen + sizeof(ANSI_NULL)) +
+        ALIGN_DWORD(pCS->dwResultClauseLen) +
+        ALIGN_DWORD(2 * pCS->dwResultReadStrLen + sizeof(ANSI_NULL)) +
+        ALIGN_DWORD(pCS->dwResultReadClauseLen);
 
     if (!pSX)
         return dwRequiredSize;
@@ -380,8 +398,7 @@ Imm32CompStrWToStringExA(
         nAnsiResultLen = WideCharToMultiByte(
             CP_ACP, 0,
             (PCWSTR)(pSrcBase + pCS->dwResultStrOffset), pCS->dwResultStrLen,
-            (PSTR)(pBase + dwCurrentOffset), dwSize - dwCurrentOffset,
-            NULL, &bUsedDef);
+            (PSTR)(pBase + dwCurrentOffset), dwSize - dwCurrentOffset, NULL, &bUsedDef);
         if (nAnsiResultLen <= 0)
             return 0;
         (pBase + dwCurrentOffset)[nAnsiResultLen] = ANSI_NULL;
@@ -408,8 +425,7 @@ Imm32CompStrWToStringExA(
         nAnsiReadLen = WideCharToMultiByte(
             CP_ACP, 0,
             (PCWSTR)(pSrcBase + pCS->dwResultReadStrOffset), pCS->dwResultReadStrLen,
-            (PSTR)(pBase + dwCurrentOffset), dwSize - dwCurrentOffset,
-            NULL, &bUsedDef);
+            (PSTR)(pBase + dwCurrentOffset), dwSize - dwCurrentOffset, NULL, &bUsedDef);
         if (nAnsiReadLen <= 0)
             return 0;
         (pBase + dwCurrentOffset)[nAnsiReadLen] = ANSI_NULL;
@@ -431,51 +447,6 @@ Imm32CompStrWToStringExA(
     }
 
     return dwSize;
-}
-
-static DWORD Imm32CompStrWToStringW(const COMPOSITIONSTRING *pCS, PWCHAR pch)
-{
-    DWORD dwResultStrLen = pCS->dwResultStrLen;
-    if (!pch)
-        return (dwResultStrLen + 1) * sizeof(WCHAR);
-    DWORD cb = dwResultStrLen * sizeof(WCHAR);
-    RtlCopyMemory(pch, (const BYTE*)pCS + pCS->dwResultStrOffset, cb);
-    pch[cb / sizeof(WCHAR)] = UNICODE_NULL;
-    return cb + sizeof(UNICODE_NULL);
-}
-
-static DWORD Imm32CompStrWToStringA(const COMPOSITIONSTRING *pCS, PCHAR pch)
-{
-    const WCHAR *pwch = (const WCHAR *)((PBYTE)pCS + pCS->dwResultStrOffset);
-    BOOL bUsedDef;
-    INT cchNeed = WideCharToMultiByte(CP_ACP, 0, pwch, pCS->dwResultStrLen,
-                                      pch, 0, NULL, &bUsedDef) + 1;
-    if (!pch)
-        return cchNeed;
-    INT cch = WideCharToMultiByte(CP_ACP, 0, pwch, pCS->dwResultStrLen,
-                                  pch, cchNeed, NULL, &bUsedDef);
-    pch[cch] = 0;
-    return cch + 1;
-}
-
-const WCHAR *Imm32CompStrWToCharW(HWND hWnd, const COMPOSITIONSTRING *pCS)
-{
-    const WCHAR *pCurrent = (const WCHAR *)((const BYTE *)pCS + pCS->dwResultStrOffset);
-
-    PostMessageW(hWnd, WM_IME_REPORT, IR_STRINGSTART, 0);
-
-    const WCHAR *pNext;
-    for (; *pCurrent; pCurrent = pNext)
-    {
-        pNext = CharNextW(pCurrent);
-
-        if (!*pNext)
-            PostMessageW(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
-
-        PostMessageW(hWnd, WM_CHAR, *pCurrent, 1);
-    }
-
-    return pCurrent;
 }
 
 static DWORD
@@ -572,29 +543,29 @@ static DWORD
 Imm32CompStrAToUndetW(
     DWORD dwGCS,
     const COMPOSITIONSTRING *pCS,
-    PUNDETERMINESTRUCT pUndeter,
+    PUNDETERMINESTRUCT pUndet,
     DWORD dwSize)
 {
-    DWORD dwRequiredSize =
+    const DWORD dwRequiredSize =
         sizeof(UNDETERMINESTRUCT) +
         ALIGN_DWORD(pCS->dwResultClauseLen) +
-        ALIGN_DWORD(2 * pCS->dwCompAttrLen + 3) +
-        ALIGN_DWORD(2 * pCS->dwResultStrLen + 5) +
-        ALIGN_DWORD(2 * pCS->dwCompStrLen + 5) +
-        ALIGN_DWORD(2 * pCS->dwResultReadStrLen + 5) +
-        ALIGN_DWORD(pCS->dwResultReadClauseLen) + 60;
+        ALIGN_DWORD(pCS->dwCompAttrLen * sizeof(WCHAR) + sizeof(UNICODE_NULL)) +
+        ALIGN_DWORD(pCS->dwResultStrLen * sizeof(WCHAR) + sizeof(UNICODE_NULL)) +
+        ALIGN_DWORD(pCS->dwCompStrLen * sizeof(WCHAR) + sizeof(UNICODE_NULL)) +
+        ALIGN_DWORD(pCS->dwResultReadStrLen * sizeof(WCHAR) + sizeof(UNICODE_NULL)) +
+        ALIGN_DWORD(pCS->dwResultReadClauseLen);
 
-    if (!pUndeter)
+    if (!pUndet)
         return dwRequiredSize;
 
     if (dwSize < dwRequiredSize)
         return 0;
 
-    RtlZeroMemory(pUndeter, sizeof(UNDETERMINESTRUCT));
-    pUndeter->dwSize = dwSize;
+    RtlZeroMemory(pUndet, sizeof(UNDETERMINESTRUCT));
+    pUndet->dwSize = dwSize;
 
     DWORD dwCurrentOffset = sizeof(UNDETERMINESTRUCT);
-    PBYTE pBase = (PBYTE)pUndeter;
+    PBYTE pBase = (PBYTE)pUndet;
     const BYTE* pSrcBase = (const BYTE*)pCS;
 
     if ((dwGCS & GCS_COMPSTR) && (pCS->dwCompStrLen > 0))
@@ -604,20 +575,20 @@ Imm32CompStrAToUndetW(
             (PWSTR)(pBase + dwCurrentOffset), (dwSize - dwCurrentOffset) / sizeof(WCHAR));
         if (nWideLen <= 0)
             return 0;
-        pUndeter->uUndetTextPos = dwCurrentOffset;
-        pUndeter->uUndetTextLen = nWideLen;
+        pUndet->uUndetTextPos = dwCurrentOffset;
+        pUndet->uUndetTextLen = nWideLen;
         ((PWCHAR)(pBase + dwCurrentOffset))[nWideLen] = UNICODE_NULL;
         dwCurrentOffset += ALIGN_DWORD((nWideLen + 1) * sizeof(WCHAR));
     }
 
-    if ((dwGCS & GCS_COMPATTR) && pCS->dwCompAttrLen > 0 && (pUndeter->uUndetTextLen > 0))
+    if ((dwGCS & GCS_COMPATTR) && pCS->dwCompAttrLen > 0 && (pUndet->uUndetTextLen > 0))
     {
-        pUndeter->uUndetAttrPos = dwCurrentOffset;
+        pUndet->uUndetAttrPos = dwCurrentOffset;
         const BYTE* pSrcAttr = pSrcBase + pCS->dwCompAttrOffset;
         PBYTE pDestAttr = pBase + dwCurrentOffset;
-        PCWSTR pWStr = (PCWSTR)(pBase + pUndeter->uUndetTextPos);
+        PCWSTR pWStr = (PCWSTR)(pBase + pUndet->uUndetTextPos);
 
-        for (UINT i = 0; i < pUndeter->uUndetTextLen; i++)
+        for (UINT i = 0; i < pUndet->uUndetTextLen; i++)
         {
             pDestAttr[i] = *pSrcAttr;
             USHORT wChar = pWStr[i];
@@ -625,18 +596,19 @@ Imm32CompStrAToUndetW(
             RtlUnicodeToMultiByteSize(&cbMultiByte, &wChar, sizeof(WCHAR));
             pSrcAttr += (cbMultiByte == 2) ? 2 : 1;
         }
-        dwCurrentOffset += ALIGN_DWORD(pUndeter->uUndetTextLen);
+
+        dwCurrentOffset += ALIGN_DWORD(pUndet->uUndetTextLen);
     }
 
     if (dwGCS & GCS_CURSORPOS)
     {
         if (pCS->dwCursorPos == (DWORD)-1)
         {
-            pUndeter->uCursorPos = (UINT)-1;
+            pUndet->uCursorPos = (UINT)-1;
         }
         else
         {
-            pUndeter->uCursorPos = IchWideFromAnsi(
+            pUndet->uCursorPos = IchWideFromAnsi(
                 pCS->dwCursorPos, (PCSTR)(pSrcBase + pCS->dwCompStrOffset), CP_ACP);
         }
     }
@@ -645,11 +617,11 @@ Imm32CompStrAToUndetW(
     {
         if (pCS->dwDeltaStart == (DWORD)-1)
         {
-            pUndeter->uDeltaStart = (UINT)-1;
+            pUndet->uDeltaStart = (UINT)-1;
         }
         else
         {
-            pUndeter->uDeltaStart = IchWideFromAnsi(
+            pUndet->uDeltaStart = IchWideFromAnsi(
                 pCS->dwDeltaStart, (PCSTR)(pSrcBase + pCS->dwCompStrOffset), CP_ACP);
         }
     }
@@ -661,17 +633,17 @@ Imm32CompStrAToUndetW(
             (PWSTR)(pBase + dwCurrentOffset), (dwSize - dwCurrentOffset) / sizeof(WCHAR));
         if (nWideLen > 0)
         {
-            pUndeter->uDetermineTextPos = dwCurrentOffset;
-            pUndeter->uDetermineTextLen = nWideLen;
+            pUndet->uDetermineTextPos = dwCurrentOffset;
+            pUndet->uDetermineTextLen = nWideLen;
             ((PWSTR)(pBase + dwCurrentOffset))[nWideLen] = UNICODE_NULL;
             dwCurrentOffset += ALIGN_DWORD((nWideLen + 1) * sizeof(WCHAR));
         }
     }
 
     if ((dwGCS & GCS_RESULTCLAUSE) && (pCS->dwResultClauseLen > 0) &&
-        (pUndeter->uDetermineTextLen > 0))
+        (pUndet->uDetermineTextLen > 0))
     {
-        pUndeter->uDetermineDelimPos = dwCurrentOffset;
+        pUndet->uDetermineDelimPos = dwCurrentOffset;
         PDWORD pSrcClause = (PDWORD)(pSrcBase + pCS->dwResultClauseOffset);
         PDWORD pDestClause = (PDWORD)(pBase + dwCurrentOffset);
         DWORD nClauses = pCS->dwResultClauseLen / sizeof(DWORD);
@@ -691,17 +663,17 @@ Imm32CompStrAToUndetW(
             (PWSTR)(pBase + dwCurrentOffset), (dwSize - dwCurrentOffset) / sizeof(WCHAR));
         if (nWideLen > 0)
         {
-            pUndeter->uYomiTextPos = dwCurrentOffset;
-            pUndeter->uYomiTextLen = nWideLen;
+            pUndet->uYomiTextPos = dwCurrentOffset;
+            pUndet->uYomiTextLen = nWideLen;
             ((PWSTR)(pBase + dwCurrentOffset))[nWideLen] = UNICODE_NULL;
             dwCurrentOffset += ALIGN_DWORD((nWideLen + 1) * sizeof(WCHAR));
         }
     }
 
     if ((dwGCS & GCS_RESULTREADCLAUSE) && (pCS->dwResultReadClauseLen > 0) &&
-        (pUndeter->uYomiTextLen > 0))
+        (pUndet->uYomiTextLen > 0))
     {
-        pUndeter->uYomiDelimPos = dwCurrentOffset;
+        pUndet->uYomiDelimPos = dwCurrentOffset;
         PDWORD pSrcClause = (PDWORD)(pSrcBase + pCS->dwResultReadClauseOffset);
         PDWORD pDestClause = (PDWORD)(pBase + dwCurrentOffset);
         DWORD nClauses = pCS->dwResultReadClauseLen / sizeof(DWORD);
@@ -788,16 +760,12 @@ Imm32CompStrAToStringExW(
     LPSTRINGEXSTRUCT pSX,
     DWORD dwSize)
 {
-    DWORD dwResultStrSize =
-        pCS->dwResultStrLen ? ALIGN_DWORD(2 * pCS->dwResultStrLen + 5) : 0;
-    DWORD dwResultClauseSize =
-        pCS->dwResultClauseLen ? ALIGN_DWORD(pCS->dwResultClauseLen + 4) : 0;
-    DWORD dwResultReadStrSize =
-        pCS->dwResultReadStrLen ? ALIGN_DWORD(2 * pCS->dwResultReadStrLen + 5) : 0;
-    DWORD dwReadClauseSize =
-        pCS->dwResultReadClauseLen ? ALIGN_DWORD(pCS->dwResultReadClauseLen + 4) : 0;
-    DWORD dwRequiredSize = sizeof(STRINGEXSTRUCT) + dwResultStrSize + dwResultClauseSize +
-                           dwResultReadStrSize + dwReadClauseSize;
+    const DWORD dwRequiredSize =
+        sizeof(STRINGEXSTRUCT) +
+        ALIGN_DWORD(pCS->dwResultStrLen * sizeof(WCHAR) + sizeof(UNICODE_NULL)) +
+        ALIGN_DWORD(pCS->dwResultClauseLen) +
+        ALIGN_DWORD(pCS->dwResultReadStrLen * sizeof(WCHAR) + sizeof(UNICODE_NULL)) +
+        ALIGN_DWORD(pCS->dwResultReadClauseLen);
 
     if (pSX == NULL)
         return dwRequiredSize;
@@ -817,8 +785,7 @@ Imm32CompStrAToStringExW(
     if (pCS->dwResultStrLen > 0)
     {
         pSX->uDeterminePos = dwCurrentOffset;
-        nWideResultLen = MultiByteToWideChar(
-            CP_ACP, 0,
+        nWideResultLen = MultiByteToWideChar(CP_ACP, 0,
             (PCSTR)(pSrcBase + pCS->dwResultStrOffset), pCS->dwResultStrLen,
             (PWSTR)(pBase + dwCurrentOffset), (dwSize - dwCurrentOffset) / sizeof(WCHAR));
         if (nWideResultLen <= 0)
@@ -871,8 +838,7 @@ Imm32CompStrAToStringExW(
     return dwSize;
 }
 
-static DWORD
-Imm32CompStrAToStringA(const COMPOSITIONSTRING *pCS, PSTR pszString, DWORD dwSize)
+static DWORD Imm32CompStrAToStringA(const COMPOSITIONSTRING *pCS, PSTR pszString, DWORD dwSize)
 {
     DWORD dwResultStrLen = pCS->dwResultStrLen;
     if (!pszString)
@@ -884,8 +850,7 @@ Imm32CompStrAToStringA(const COMPOSITIONSTRING *pCS, PSTR pszString, DWORD dwSiz
     return dwResultStrLen + 1;
 }
 
-static DWORD
-Imm32CompStrAToStringW(const COMPOSITIONSTRING *pCS, PWSTR pszString, DWORD dwSize)
+static DWORD Imm32CompStrAToStringW(const COMPOSITIONSTRING *pCS, PWSTR pszString, DWORD dwSize)
 {
     const CHAR *pch = (const CHAR *)pCS + pCS->dwResultStrOffset;
     INT cchWide = MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, pch, pCS->dwResultStrLen,
@@ -903,7 +868,77 @@ Imm32CompStrAToStringW(const COMPOSITIONSTRING *pCS, PWSTR pszString, DWORD dwSi
     return (cch + 1) * sizeof(WCHAR);
 }
 
-const WCHAR* Imm32CompStrWToCharA(HWND hWnd, const COMPOSITIONSTRING *pCS)
+static VOID Imm32CompStrAToCharA(HWND hWnd, const COMPOSITIONSTRING *pCS)
+{
+    const CHAR *pch = (const CHAR *)((PBYTE)pCS + pCS->dwResultStrOffset);
+
+    BOOL bImeSupportDBCS = FALSE;
+    if (GetWin32ClientInfo()->dwExpWinVer >= 0x30A)
+        bImeSupportDBCS = (BOOL)SendMessageA(hWnd, WM_IME_REPORT, IR_DBCSCHAR, 0);
+
+    PostMessageA(hWnd, WM_IME_REPORT, IR_STRINGSTART, 0);
+
+    if (*pch == ANSI_NULL)
+        return;
+
+    const CHAR *pNext;
+    for (; *pch; pch = pNext)
+    {
+        BYTE bFirst = (BYTE)(*pch);
+        pNext = CharNextA(pch);
+
+        if (*pNext == ANSI_NULL)
+            PostMessageA(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
+
+        if (!IsDBCSLeadByte(bFirst))
+        {
+            PostMessageA(hWnd, WM_CHAR, bFirst, 1);
+            continue;
+        }
+
+        BYTE bSecond = pch[1];
+        if (bImeSupportDBCS)
+        {
+            WPARAM wParamDBCS = 0x80000000 | MAKEWORD(bSecond, bFirst);
+            PostMessageA(hWnd, WM_CHAR, wParamDBCS, 1);
+        }
+        else
+        {
+            PostMessageA(hWnd, WM_CHAR, bFirst, 1);
+            PostMessageA(hWnd, WM_CHAR, bSecond, 1);
+        }
+    }
+}
+
+static VOID Imm32CompStrAToCharW(HWND hWnd, const COMPOSITIONSTRING *pCS)
+{
+    const CHAR *pCurrent = (const CHAR *)((PBYTE)pCS + pCS->dwResultStrOffset);
+
+    PostMessageW(hWnd, WM_IME_REPORT, IR_STRINGSTART, 0);
+
+    while (*pCurrent)
+    {
+        BYTE bTestChar = *pCurrent;
+        PCHAR pNext = CharNextA(pCurrent);
+
+        if (*pNext == ANSI_NULL)
+            PostMessageW(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
+
+        WCHAR wCharBuffer = UNICODE_NULL;
+        INT nConverted = 0;
+        if (IsDBCSLeadByte(bTestChar))
+            nConverted = MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, pCurrent, 2, &wCharBuffer, 1);
+        else
+            nConverted = MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, pCurrent, 1, &wCharBuffer, 1);
+
+        if (nConverted > 0)
+            PostMessageW(hWnd, WM_CHAR, wCharBuffer, 1);
+
+        pCurrent = pNext;
+    }
+}
+
+static VOID Imm32CompStrWToCharA(HWND hWnd, const COMPOSITIONSTRING *pCS)
 {
     const WCHAR *pCurrent = (const WCHAR *)((const BYTE *)pCS + pCS->dwResultStrOffset);
 
@@ -925,7 +960,7 @@ const WCHAR* Imm32CompStrWToCharA(HWND hWnd, const COMPOSITIONSTRING *pCS)
         if (!WideCharToMultiByte(CP_ACP, 0, pCurrent, 1, szAnsi, sizeof(szAnsi), NULL, &bUsedDef))
             continue;
 
-        if (!IsDBCSLeadByte((BYTE)szAnsi[0]))
+        if (!IsDBCSLeadByte(szAnsi[0]))
         {
             PostMessageA(hWnd, WM_CHAR, (BYTE)szAnsi[0], 1);
             continue;
@@ -942,88 +977,24 @@ const WCHAR* Imm32CompStrWToCharA(HWND hWnd, const COMPOSITIONSTRING *pCS)
             PostMessageA(hWnd, WM_CHAR, (BYTE)szAnsi[1], 1);
         }
     }
-
-    return pCurrent;
 }
 
-static CHAR Imm32CompStrAToCharA(HWND hWnd, const COMPOSITIONSTRING *pCS)
+static VOID Imm32CompStrWToCharW(HWND hWnd, const COMPOSITIONSTRING *pCS)
 {
-    const CHAR *pch = (const CHAR *)((PBYTE)pCS + pCS->dwResultStrOffset);
-
-    BOOL bImeSupportDBCS = FALSE;
-    if (GetWin32ClientInfo()->dwExpWinVer >= 0x30A)
-        bImeSupportDBCS = (BOOL)SendMessageA(hWnd, WM_IME_REPORT, IR_DBCSCHAR, 0);
-
-    PostMessageA(hWnd, WM_IME_REPORT, IR_STRINGSTART, 0);
-
-    CHAR ch = *pch;
-    if (*pch == ANSI_NULL)
-        return ch;
-
-    while (*pch)
-    {
-        BYTE bFirst = (BYTE)(*pch);
-        const CHAR *pNext = CharNextA(pch);
-
-        if (*pNext == ANSI_NULL)
-            PostMessageA(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
-
-        if (IsDBCSLeadByte(bFirst))
-        {
-            BYTE bSecond = pch[1];
-            if (bImeSupportDBCS)
-            {
-                WPARAM wParamDBCS = 0x80000000 | MAKEWORD(bSecond, bFirst);
-                PostMessageA(hWnd, WM_CHAR, wParamDBCS, 1);
-            }
-            else
-            {
-                PostMessageA(hWnd, WM_CHAR, bFirst, 1);
-                PostMessageA(hWnd, WM_CHAR, bSecond, 1);
-            }
-        }
-        else
-        {
-            PostMessageA(hWnd, WM_CHAR, bFirst, 1);
-        }
-
-        pch = pNext;
-        ch = *pch;
-    }
-
-    return ch;
-}
-
-static CHAR Imm32CompStrAToCharW(HWND hWnd, const COMPOSITIONSTRING *pCS)
-{
-    const CHAR *pCurrent = (const CHAR *)((PBYTE)pCS + pCS->dwResultStrOffset);
-    CHAR ch = *pCurrent;
+    const WCHAR *pCurrent = (const WCHAR *)((const BYTE *)pCS + pCS->dwResultStrOffset);
 
     PostMessageW(hWnd, WM_IME_REPORT, IR_STRINGSTART, 0);
 
-    while (*pCurrent)
+    const WCHAR *pNext;
+    for (; *pCurrent; pCurrent = pNext)
     {
-        ch = *pCurrent;
-        BYTE bTestChar = *pCurrent;
-        PCHAR pNext = CharNextA(pCurrent);
+        pNext = CharNextW(pCurrent);
 
-        if (*pNext == ANSI_NULL)
+        if (!*pNext)
             PostMessageW(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
 
-        WCHAR wCharBuffer = UNICODE_NULL;
-        INT nConverted = 0;
-        if (IsDBCSLeadByte(bTestChar))
-            nConverted = MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, pCurrent, 2, &wCharBuffer, 1);
-        else
-            nConverted = MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, pCurrent, 1, &wCharBuffer, 1);
-
-        if (nConverted > 0)
-            PostMessageW(hWnd, WM_CHAR, wCharBuffer, 1);
-
-        pCurrent = pNext;
+        PostMessageW(hWnd, WM_CHAR, *pCurrent, 1);
     }
-
-    return ch;
 }
 
 static DWORD
@@ -1443,11 +1414,6 @@ WINNLSTranslateMessageJ(
         pCurrent = pBuf;
     }
 
-#define EMIT_ENTRY_J() do { \
-    *pEntries++ = *pCurrent; \
-    dwResult++; \
-} while (0)
-
     while (pCurrent->message)
     {
         switch (pCurrent->message)
@@ -1458,7 +1424,9 @@ WINNLSTranslateMessageJ(
                     // Send IR_OPENCONVERT
                     if (pIC->cfCompForm.dwStyle)
                         SendMessageW(hWnd, WM_IME_REPORT, IR_OPENCONVERT, 0);
-                    EMIT_ENTRY_J();
+
+                    *pEntries++ = *pCurrent;
+                    ++dwResult;
                 }
                 break;
 
@@ -1468,7 +1436,9 @@ WINNLSTranslateMessageJ(
                     // Send IR_CLOSECONVERT
                     if (pIC->cfCompForm.dwStyle)
                         SendMessageW(hWnd, WM_IME_REPORT, IR_CLOSECONVERT, 0);
-                    EMIT_ENTRY_J();
+
+                    *pEntries++ = *pCurrent;
+                    ++dwResult;
                 }
                 else
                 {
@@ -1526,20 +1496,25 @@ WINNLSTranslateMessageJ(
                 }
 
                 if (!(pIC->dwUIFlags & _IME_UI_HIDDEN))
-                    EMIT_ENTRY_J();
+                {
+                    *pEntries++ = *pCurrent;
+                    ++dwResult;
+                }
                 else
+                {
                     SendMessageW(hwndIme, pCurrent->message, pCurrent->wParam, pCurrent->lParam);
+                }
                 break;
 
             default:
-                EMIT_ENTRY_J();
+                *pEntries++ = *pCurrent;
+                ++dwResult;
                 break;
         }
 
         pCurrent++;
     }
 
-#undef EMIT_ENTRY_J
     ImmLocalFree(pBuf);
     return dwResult;
 }
@@ -1560,8 +1535,8 @@ WINNLSTranslateMessageK(
     HWND hwndIme = ImmGetDefaultIMEWnd(hWnd);
     BOOL bDestIsUnicode = IsWindowUnicode(hWnd);
     BOOL bDestIsAnsi = !bDestIsUnicode;
-    FN_PostMessage pfnPostMessage = bDestIsUnicode ? PostMessageW : PostMessageA;
-    FN_SendMessage pfnSendMessage = bDestIsUnicode ? SendMessageW : SendMessageA;
+    FN_PostMessage pPostMessage = bDestIsUnicode ? PostMessageW : PostMessageA;
+    FN_SendMessage pSendMessage = bDestIsUnicode ? SendMessageW : SendMessageA;
 
     if ((LONG)dwCount <= 0)
         return 0;
@@ -1577,16 +1552,16 @@ WINNLSTranslateMessageK(
             switch (uMsg)
             {
             case WM_IME_COMPOSITION:
-                if (wParam & 0x8000000)
+                if (lParam & GCS_RESULTSTR)
                 {
-                    pfnPostMessage(hWnd, WM_IME_REPORT, IR_STRINGSTART, 0);
+                    pPostMessage(hWnd, WM_IME_REPORT, IR_STRINGSTART, 0);
 
                     if ((LONG)pCS->dwResultStrLen > 0)
                     {
                         DWORD dwProcessedLen = 0;
                         while (dwProcessedLen < pCS->dwResultStrLen)
                         {
-                            LPARAM charLParam = 1;
+                            LPARAM lKeyData = 1; /* WM_CHAR lParam */
                             WCHAR wCharStr[2] = {0};
                             CHAR  szMBStr[4]  = {0};
 
@@ -1599,16 +1574,16 @@ WINNLSTranslateMessageK(
                                 {
                                     if (IsDBCSLeadByte(bChar))
                                     {
-                                        if (bChar < 0xB0 || bChar > 0xC8)
-                                            charLParam = 0xFFF10001; 
+                                        if (0xB0 <= bChar && bChar <= 0xC8)
+                                            lKeyData = 0xFFF20001;
                                         else
-                                            charLParam = 0xFFF20001;
+                                            lKeyData = 0xFFF10001;
 
-                                        PostMessageA(hWnd, WM_CHAR, bChar, charLParam);
+                                        PostMessageA(hWnd, WM_CHAR, bChar, lKeyData);
                                         dwProcessedLen++;
                                         bChar = (BYTE)pResStr[dwProcessedLen];
                                     }
-                                    PostMessageA(hWnd, WM_CHAR, bChar, charLParam);
+                                    PostMessageA(hWnd, WM_CHAR, bChar, lKeyData);
                                 }
                                 else
                                 {
@@ -1635,29 +1610,31 @@ WINNLSTranslateMessageK(
                                     BYTE bLead = (BYTE)szMBStr[0], bChar;
                                     if (IsDBCSLeadByte(bLead))
                                     {
-                                        charLParam = (bLead < 0xB0 || bLead > 0xC8)
-                                            ? 0xFFF10001
-                                            : 0xFFF20001;
-                                        PostMessageA(hWnd, WM_CHAR, bLead, charLParam);
+                                        if (0xB0 <= bLead && bLead <= 0xC8)
+                                            lKeyData = 0xFFF20001;
+                                        else
+                                            lKeyData = 0xFFF10001;
+
+                                        PostMessageA(hWnd, WM_CHAR, bLead, lKeyData);
                                         bChar = (BYTE)szMBStr[1];
                                     }
                                     else
                                     {
                                         bChar = (BYTE)szMBStr[0];
                                     }
-                                    PostMessageA(hWnd, WM_CHAR, bChar, charLParam);
+
+                                    PostMessageA(hWnd, WM_CHAR, bChar, lKeyData);
                                 }
                             }
                             dwProcessedLen++;
                         }
                     }
-                    pfnPostMessage(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
+                    pPostMessage(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
                 }
-                
 
                 if (wParam != 0)
                 {
-                    pfnPostMessage(hWnd, WM_IME_REPORT, IR_STRINGSTART, 0);
+                    pPostMessage(hWnd, WM_IME_REPORT, IR_STRINGSTART, 0);
 
                     BYTE bLow = HIBYTE(wParam), bHigh = LOBYTE(wParam);
                     g_dchKorean = MAKEWORD(bLow, bHigh);
@@ -1698,11 +1675,11 @@ WINNLSTranslateMessageK(
                     else
                         PostMessageA(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
 
-                    pfnSendMessage(hwndIme, WM_IME_ENDCOMPOSITION, 0, 0);
+                    pSendMessage(hwndIme, WM_IME_ENDCOMPOSITION, 0, 0);
                 }
                 else
                 {
-                    pfnPostMessage(hWnd, WM_IME_REPORT, IR_STRINGSTART, 0);
+                    pPostMessage(hWnd, WM_IME_REPORT, IR_STRINGSTART, 0);
                     if (bSrcIsAnsi)
                     {
                         if (bDestIsAnsi)
@@ -1749,21 +1726,21 @@ WINNLSTranslateMessageK(
                 break;
 
             case WM_IMEKEYDOWN:
-                pfnPostMessage(hWnd, WM_KEYDOWN, (WPARAM)(LOWORD(wParam)), lParam);
+                pPostMessage(hWnd, WM_KEYDOWN, (WPARAM)(LOWORD(wParam)), lParam);
                 break;
 
             case WM_IMEKEYUP:
-                pfnPostMessage(hWnd, WM_KEYUP, (WPARAM)(LOWORD(wParam)), lParam);
+                pPostMessage(hWnd, WM_KEYUP, (WPARAM)(LOWORD(wParam)), lParam);
                 break;
 
             default:
-                pfnSendMessage(hwndIme, uMsg, wParam, lParam);
+                pSendMessage(hwndIme, uMsg, wParam, lParam);
                 break;
             }
         }
         else
         {
-            pfnSendMessage(hwndIme, uMsg, wParam, lParam);
+            pSendMessage(hwndIme, uMsg, wParam, lParam);
         }
     }
 

--- a/win32ss/user/imm32/win3.c
+++ b/win32ss/user/imm32/win3.c
@@ -1088,8 +1088,8 @@ Imm32JTransCompositionA(
                                 goto FINALIZE;
                             }
                         }
-                        GlobalFree(hEx);
                     }
+                    GlobalFree(hEx);
                 }
             }
         }

--- a/win32ss/user/imm32/win3.c
+++ b/win32ss/user/imm32/win3.c
@@ -14,7 +14,7 @@ WINE_DEFAULT_DEBUG_CHANNEL(imm);
 
 #define ALIGN_DWORD(len) (((len) + 3) & ~3)
 
-static WORD g_dchKorean = 0; /* One or two Korean character(s) */
+static WORD g_chKorean = 0; /* One or two Korean character(s) */
 
 static DWORD Imm32CompStrWToStringA(const COMPOSITIONSTRING *pCS, PCHAR pch)
 {
@@ -1637,7 +1637,7 @@ WINNLSTranslateMessageK(
                     pPostMessage(hWnd, WM_IME_REPORT, IR_STRINGSTART, 0);
 
                     BYTE bLow = HIBYTE(wParam), bHigh = LOBYTE(wParam);
-                    g_dchKorean = MAKEWORD(bLow, bHigh);
+                    g_chKorean = MAKEWORD(bLow, bHigh);
 
                     if (bSrcIsAnsi)
                     {
@@ -1684,16 +1684,16 @@ WINNLSTranslateMessageK(
                     {
                         if (bDestIsAnsi)
                         {
-                            PostMessageA(hWnd, WM_CHAR, (BYTE)g_dchKorean, 0xFFF10001);
-                            PostMessageA(hWnd, WM_CHAR, HIBYTE(g_dchKorean), 0xFFF10001);
+                            PostMessageA(hWnd, WM_CHAR, LOBYTE(g_chKorean), 0xFFF10001);
+                            PostMessageA(hWnd, WM_CHAR, HIBYTE(g_chKorean), 0xFFF10001);
                             PostMessageA(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
                             PostMessageA(hWnd, WM_KEYDOWN, VK_BACK, 917505);
                         }
                         else
                         {
                             CHAR szTmp[2];
-                            szTmp[0] = (CHAR)LOBYTE(g_dchKorean);
-                            szTmp[1] = (CHAR)HIBYTE(g_dchKorean);
+                            szTmp[0] = LOBYTE(g_chKorean);
+                            szTmp[1] = HIBYTE(g_chKorean);
                             WCHAR wTmp[2];
                             if (MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, szTmp, 2, wTmp, 1))
                             {
@@ -1707,7 +1707,7 @@ WINNLSTranslateMessageK(
                     {
                         if (bDestIsAnsi)
                         {
-                            WCHAR wTmp[2] = { (WCHAR)g_dchKorean, 0 };
+                            WCHAR wTmp[2] = { (WCHAR)g_chKorean, 0 };
                             CHAR  szTmp[2];
                             WideCharToMultiByte(CP_ACP, 0, wTmp, 1, szTmp, 2, NULL, NULL);
                             PostMessageA(hWnd, WM_CHAR, (BYTE)szTmp[0], 0xFFF10001);
@@ -1717,7 +1717,7 @@ WINNLSTranslateMessageK(
                         }
                         else
                         {
-                            PostMessageW(hWnd, WM_CHAR, (WCHAR)g_dchKorean, 0xFFF10001);
+                            PostMessageW(hWnd, WM_CHAR, (WCHAR)g_chKorean, 0xFFF10001);
                             PostMessageW(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
                             PostMessageW(hWnd, WM_KEYDOWN, VK_BACK, 917505);
                         }

--- a/win32ss/user/imm32/win3.c
+++ b/win32ss/user/imm32/win3.c
@@ -1234,7 +1234,7 @@ Imm32JTransCompositionW(
     }
 
     HGLOBAL hEx, hStr;
-    PVOID pEx, pStr;
+    PVOID pEx = NULL, pStr = NULL;
     BOOL bExSuccess = FALSE, bStrSuccess = FALSE;
     LRESULT res;
     DWORD exSize, strSize;
@@ -1377,7 +1377,7 @@ WINNLSTranslateMessageJ(
         {
             // Move WM_IME_ENDCOMPOSITION to the end of the list
             PTRANSMSG pSrc = pEndComp + 1, pDest = pEndComp;
-            for (INT iEntry = 0; iEntry < cEntries - 1 && pSrc->message; ++iEntry)
+            for (INT iEntry = 0; iEntry < cEntries - 1 && pSrc->message != WM_NULL; ++iEntry)
                 *pDest++ = *pSrc++;
 
             pDest->message = WM_IME_ENDCOMPOSITION;
@@ -1614,22 +1614,22 @@ WINNLSTranslateMessageK(
                     {
                         pPostMessage(hWnd, WM_IME_REPORT, IR_STRINGSTART, 0);
 
-                        BYTE bLow = HIBYTE(wParam), bHigh = LOBYTE(wParam);
-                        s_chKorean = MAKEWORD(bLow, bHigh);
+                        BYTE bFirst = HIBYTE(wParam), bSecond = LOBYTE(wParam);
+                        s_chKorean = MAKEWORD(bFirst, bSecond);
 
                         if (bSrcIsAnsi)
                         {
                             if (bDestIsUnicode)
                             {
-                                CHAR szTmp[2] = { (CHAR)bLow, (CHAR)bHigh };
+                                CHAR szTmp[2] = { (CHAR)bFirst, (CHAR)bSecond };
                                 WCHAR wTmp[2];
                                 if (Imm32AnsiToWide(szTmp, 2, wTmp, _countof(wTmp)))
                                     PostMessageW(hWnd, WM_INTERIM, wTmp[0], KOR_INTERIM_FLAGS);
                             }
                             else
                             {
-                                PostMessageA(hWnd, WM_INTERIM, bLow, KOR_INTERIM_FLAGS);
-                                PostMessageA(hWnd, WM_INTERIM, bHigh, KOR_INTERIM_FLAGS);
+                                PostMessageA(hWnd, WM_INTERIM, bFirst, KOR_INTERIM_FLAGS);
+                                PostMessageA(hWnd, WM_INTERIM, bSecond, KOR_INTERIM_FLAGS);
                             }
                         }
                         else

--- a/win32ss/user/imm32/win3.c
+++ b/win32ss/user/imm32/win3.c
@@ -1116,7 +1116,7 @@ Imm32JTransCompositionA(
         }
 
         strSize = bIsUnicodeWnd ? Imm32CompStrAToStringW(pCS, NULL, 0) : (pCS->dwResultStrLen + 1);
-        if (strSize && strSize != (SIZE_T)-1)
+        if (strSize && strSize != (DWORD)-1)
         {
             hStr = GlobalAlloc(GHND, strSize);
             if (hStr)
@@ -1303,7 +1303,7 @@ Imm32JTransCompositionW(
         strSize = bIsUnicodeWnd
             ? Imm32CompStrWToStringW(pCS, NULL)
             : Imm32CompStrWToStringA(pCS, NULL);
-        if (strSize && strSize != (SIZE_T)-1)
+        if (strSize && strSize != (DWORD)-1)
         {
             hStr = GlobalAlloc(GHND, strSize);
             if (hStr)
@@ -1374,7 +1374,7 @@ WINNLSTranslateMessageJ(
     BOOL bAnsi)
 {
     // Clone the message list with growing
-    SIZE_T dwBufSize = (dwCount + 1) * sizeof(TRANSMSG);
+    DWORD dwBufSize = (DWORD)((dwCount + 1) * sizeof(TRANSMSG));
     PTRANSMSG pBuf = ImmLocalAlloc(HEAP_ZERO_MEMORY, dwBufSize);
     if (!pBuf)
         return 0;

--- a/win32ss/user/imm32/win3.c
+++ b/win32ss/user/imm32/win3.c
@@ -877,7 +877,7 @@ Imm32CompStrAToStringA(const COMPOSITIONSTRING *pCS, PSTR pszString, DWORD dwSiz
     DWORD dwResultStrLen = pCS->dwResultStrLen;
     if (!pszString)
         return dwResultStrLen + 1;
-    if (dwSize < dwResultStrLen)
+    if (dwSize < dwResultStrLen + 1)
         return 0;
     RtlCopyMemory(pszString, (PBYTE)pCS + pCS->dwResultStrOffset, dwResultStrLen);
     pszString[dwResultStrLen] = ANSI_NULL;

--- a/win32ss/user/imm32/win3.c
+++ b/win32ss/user/imm32/win3.c
@@ -14,6 +14,8 @@ WINE_DEFAULT_DEBUG_CHANNEL(imm);
 
 #define ALIGN_DWORD(len) (((len) + 3) & ~3)
 
+WORD g_dchKorean = 0; /* One or two Korean character(s) */
+
 static DWORD
 Imm32CompStrWToUndetW(
     DWORD dwGCS,
@@ -187,10 +189,8 @@ Imm32CompStrWToUndetA(
         }
         else
         {
-            pDeter->uCursorPos = IchAnsiFromWide(
-                (LONG)pCS->dwCursorPos,
-                (PCWSTR)(pSrcBase + pCS->dwCompStrOffset),
-                CP_ACP);
+            pDeter->uCursorPos = IchAnsiFromWide(pCS->dwCursorPos,
+                (PCWSTR)(pSrcBase + pCS->dwCompStrOffset), CP_ACP);
         }
     }
 
@@ -202,10 +202,8 @@ Imm32CompStrWToUndetA(
         }
         else
         {
-            pDeter->uDeltaStart = IchAnsiFromWide(
-                (LONG)pCS->dwDeltaStart,
-                (PCWSTR)(pSrcBase + pCS->dwCompStrOffset),
-                CP_ACP);
+            pDeter->uDeltaStart = IchAnsiFromWide(pCS->dwDeltaStart,
+                (PCWSTR)(pSrcBase + pCS->dwCompStrOffset), CP_ACP);
         }
     }
 
@@ -235,9 +233,8 @@ Imm32CompStrWToUndetA(
         const WCHAR *pResultW = (const WCHAR *)(pSrcBase + pCS->dwResultStrOffset);
 
         for (DWORD i = 0; i < nClauses; i++)
-        {
             pDestClause[i] = IchAnsiFromWide(pSrcClause[i], pResultW, CP_ACP);
-        }
+
         dwCurrentOffset += ALIGN_DWORD(pCS->dwResultClauseLen);
     }
 
@@ -267,9 +264,8 @@ Imm32CompStrWToUndetA(
         const WCHAR *pReadW = (const WCHAR *)(pSrcBase + pCS->dwResultReadStrOffset);
 
         for (DWORD i = 0; i < nClauses; i++)
-        {
             pDestClause[i] = IchAnsiFromWide(pSrcClause[i], pReadW, CP_ACP);
-        }
+
         dwCurrentOffset += ALIGN_DWORD(pCS->dwResultReadClauseLen);
     }
 
@@ -400,9 +396,8 @@ Imm32CompStrWToStringExA(
         const WCHAR *pResultW = (const WCHAR *)(pSrcBase + pCS->dwResultStrOffset);
 
         for (DWORD i = 0; i < nClauses; i++)
-        {
             pDestClause[i] = IchAnsiFromWide(pSrcClause[i], pResultW, CP_ACP);
-        }
+
         dwCurrentOffset += ALIGN_DWORD(pCS->dwResultClauseLen);
     }
 
@@ -429,9 +424,8 @@ Imm32CompStrWToStringExA(
         const WCHAR *pReadW = (const WCHAR *)(pSrcBase + pCS->dwResultReadStrOffset);
 
         for (DWORD i = 0; i < nClauses; i++)
-        {
             pDestClause[i] = IchAnsiFromWide(pSrcClause[i], pReadW, CP_ACP);
-        }
+
         dwCurrentOffset += ALIGN_DWORD(pCS->dwResultReadClauseLen);
     }
 
@@ -713,10 +707,10 @@ Imm32CompStrAToUndetW(
 
         for (DWORD i = 0; i < nClauses; i++)
         {
-            pDestClause[i] = IchWideFromAnsi(
-                pSrcClause[i], (PCSTR)(pSrcBase + pCS->dwResultReadStrOffset), 0);
-            dwCurrentOffset += ALIGN_DWORD(pCS->dwResultReadClauseLen);
+            pDestClause[i] = IchWideFromAnsi(pSrcClause[i],
+                (PCSTR)(pSrcBase + pCS->dwResultReadStrOffset), CP_ACP);
         }
+        dwCurrentOffset += ALIGN_DWORD(pCS->dwResultReadClauseLen);
     }
 
     return dwSize;
@@ -1517,137 +1511,230 @@ WINNLSTranslateMessageJ(DWORD dwCount, PTRANSMSG pEntries, PINPUTCONTEXTDX pIC,
     return dwResult;
 }
 
+typedef LRESULT (WINAPI *FN_SendMessage)(HWND, UINT, WPARAM, LPARAM);
+typedef BOOL (WINAPI *FN_PostMessage)(HWND, UINT, WPARAM, LPARAM);
+
 /* Korean */
 static DWORD
-WINNLSTranslateMessageK(DWORD dwCount, PTRANSMSG pEntries, PINPUTCONTEXTDX pIC,
-                        PCOMPOSITIONSTRING pCS, BOOL bAnsi)
+WINNLSTranslateMessageK(
+    DWORD dwCount,
+    PTRANSMSG pEntries,
+    PINPUTCONTEXTDX pIC,
+    PCOMPOSITIONSTRING pCS,
+    BOOL bSrcIsAnsi)
 {
     HWND hWnd = pIC->hWnd;
     HWND hwndIme = ImmGetDefaultIMEWnd(hWnd);
+    BOOL bDestIsUnicode = IsWindowUnicode(hWnd);
+    BOOL bDestIsAnsi = !bDestIsUnicode;
+    FN_PostMessage pfnPostMessage = bDestIsUnicode ? PostMessageW : PostMessageA;
+    FN_SendMessage pfnSendMessage = bDestIsUnicode ? SendMessageW : SendMessageA;
 
-    SIZE_T dwBufSize = (dwCount + 1) * sizeof(TRANSMSG);
-    PTRANSMSG pBuf = ImmLocalAlloc(HEAP_ZERO_MEMORY, dwBufSize);
-    if (!pBuf)
+    if ((LONG)dwCount <= 0)
         return 0;
-    RtlCopyMemory(pBuf, pEntries, dwCount * sizeof(TRANSMSG));
 
-    DWORD dwResult = 0;
-
-    if (pIC->dwUIFlags & _IME_UI_HIDDEN)
+    for (DWORD i = 0; i < dwCount; ++i)
     {
-        PTRANSMSG pEnd = NULL;
-        for (DWORD i = 0; i < dwCount; i++)
+        UINT   uMsg   = pEntries[i].message;
+        WPARAM wParam = pEntries[i].wParam;
+        LPARAM lParam = pEntries[i].lParam;
+
+        if (uMsg < WM_IME_STARTCOMPOSITION || uMsg > WM_IME_ENDCOMPOSITION)
         {
-            if (pBuf[i].message == WM_IME_ENDCOMPOSITION)
+            switch (uMsg)
             {
-                pEnd = &pBuf[i];
-                break;
-            }
-        }
-        if (pEnd)
-        {
-            PTRANSMSG pSrc = pEnd + 1, pDst = pEnd;
-            while (pSrc->message)
-                *pDst++ = *pSrc++;
-            pDst->message = WM_IME_ENDCOMPOSITION;
-            pDst->wParam  = 0;
-            pDst->lParam  = 0;
-        }
-    }
-
-#define EMIT_ENTRY_K() do { \
-    *pEntries++ = *pCurrent; \
-    dwResult++; \
-} while (0)
-
-    PTRANSMSG pCurrent = pBuf;
-    while (pCurrent->message)
-    {
-        switch (pCurrent->message)
-        {
-            case WM_IME_STARTCOMPOSITION:
-                if (!(pIC->dwUIFlags & _IME_UI_HIDDEN))
-                {
-                    if (pIC->cfCompForm.dwStyle)
-                        SendMessageW(hWnd, WM_IME_REPORT, IR_OPENCONVERT, 0);
-                    EMIT_ENTRY_K();
-                }
-                break;
-
-            case WM_IME_ENDCOMPOSITION:
-                if (!(pIC->dwUIFlags & _IME_UI_HIDDEN))
-                {
-                    if (pIC->cfCompForm.dwStyle)
-                        SendMessageW(hWnd, WM_IME_REPORT, IR_CLOSECONVERT, 0);
-                    EMIT_ENTRY_K();
-                }
-                else
-                {
-                    HGLOBAL hMem = GlobalAlloc(GHND | GMEM_SHARE, sizeof(UNDETERMINESTRUCT));
-                    if (hMem)
-                    {
-                        if (IsWindowUnicode(hWnd))
-                            SendMessageW(hWnd, WM_IME_REPORT, IR_UNDETERMINE, (LPARAM)hMem);
-                        else
-                            SendMessageA(hWnd, WM_IME_REPORT, IR_UNDETERMINE, (LPARAM)hMem);
-                        GlobalFree(hMem);
-                    }
-                }
-                break;
-
             case WM_IME_COMPOSITION:
-            {
-                DWORD dwWritten;
-                if (bAnsi)
-                    dwWritten = Imm32JTransCompositionA(pIC, pCS, pCurrent, pEntries);
-                else
-                    dwWritten = Imm32JTransCompositionW(pIC, pCS, pCurrent, pEntries);
-
-                dwResult  += dwWritten;
-                pEntries  += dwWritten;
-
-                if (!(pIC->dwUIFlags & _IME_UI_HIDDEN) && pIC->cfCompForm.dwStyle)
-                    SendMessageW(hWnd, WM_IME_REPORT, IR_CHANGECONVERT, 0);
-                break;
-            }
-
-            case WM_IME_NOTIFY:
-                if (pCurrent->wParam == IMN_OPENCANDIDATE)
+                if (wParam & 0x8000000)
                 {
-                    if (IsWindow(hWnd) && (pIC->dwUIFlags & _IME_UI_HIDDEN))
+                    pfnPostMessage(hWnd, WM_IME_REPORT, IR_STRINGSTART, 0);
+
+                    if ((LONG)pCS->dwResultStrLen > 0)
                     {
-                        CANDIDATEFORM CandForm;
-                        LPARAM lParam = pCurrent->lParam;
-                        for (DWORD iCandForm = 0; iCandForm < MAX_CANDIDATEFORM; ++iCandForm)
+                        DWORD dwProcessedLen = 0;
+                        while (dwProcessedLen < pCS->dwResultStrLen)
                         {
-                            if (!(lParam & (1 << iCandForm)))
-                                continue;
-                            CandForm.dwIndex     = iCandForm;
-                            CandForm.dwStyle     = CFS_EXCLUDE;
-                            CandForm.ptCurrentPos = pIC->cfCompForm.ptCurrentPos;
-                            CandForm.rcArea      = pIC->cfCompForm.rcArea;
-                            SendMessageW(hwndIme, WM_IME_CONTROL, IMC_SETCANDIDATEPOS,
-                                         (LPARAM)&CandForm);
+                            LPARAM charLParam = 1;
+                            WCHAR wCharStr[2] = {0};
+                            CHAR  szMBStr[4]  = {0};
+
+                            if (bSrcIsAnsi)
+                            {
+                                PSTR pResStr = (LPSTR)((BYTE*)pCS + pCS->dwResultStrOffset);
+                                BYTE bChar = (BYTE)pResStr[dwProcessedLen];
+
+                                if (bDestIsAnsi)
+                                {
+                                    if (IsDBCSLeadByte(bChar))
+                                    {
+                                        if (bChar < 0xB0 || bChar > 0xC8)
+                                            charLParam = 0xFFF10001; 
+                                        else
+                                            charLParam = 0xFFF20001;
+
+                                        PostMessageA(hWnd, WM_CHAR, bChar, charLParam);
+                                        dwProcessedLen++;
+                                        bChar = (BYTE)pResStr[dwProcessedLen];
+                                    }
+                                    PostMessageA(hWnd, WM_CHAR, bChar, charLParam);
+                                }
+                                else
+                                {
+                                    szMBStr[0] = bChar;
+                                    szMBStr[1] = pResStr[++dwProcessedLen];
+                                    MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, szMBStr, 2,
+                                                        wCharStr, 1);
+                                    PostMessageW(hWnd, WM_CHAR, wCharStr[0], 1);
+                                }
+                            }
+                            else
+                            {
+                                PWSTR pResStrW = (PWSTR)((PBYTE)pCS + pCS->dwResultStrOffset);
+                                wCharStr[0] = pResStrW[dwProcessedLen];
+
+                                if (!bDestIsAnsi)
+                                {
+                                    PostMessageW(hWnd, WM_CHAR, wCharStr[0], 1);
+                                }
+                                else
+                                {
+                                    WideCharToMultiByte(CP_ACP, 0, wCharStr, 1, szMBStr, 2,
+                                                        NULL, NULL);
+                                    BYTE bLead = (BYTE)szMBStr[0], bChar;
+                                    if (IsDBCSLeadByte(bLead))
+                                    {
+                                        charLParam = (bLead < 0xB0 || bLead > 0xC8)
+                                            ? 0xFFF10001
+                                            : 0xFFF20001;
+                                        PostMessageA(hWnd, WM_CHAR, bLead, charLParam);
+                                        bChar = (BYTE)szMBStr[1];
+                                    }
+                                    else
+                                    {
+                                        bChar = (BYTE)szMBStr[0];
+                                    }
+                                    PostMessageA(hWnd, WM_CHAR, bChar, charLParam);
+                                }
+                            }
+                            dwProcessedLen++;
+                        }
+                    }
+                    pfnPostMessage(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
+                }
+                
+
+                if (wParam != 0)
+                {
+                    pfnPostMessage(hWnd, WM_IME_REPORT, IR_STRINGSTART, 0);
+
+                    BYTE bLow = HIBYTE(wParam), bHigh = LOBYTE(wParam);
+                    g_dchKorean = MAKEWORD(bLow, bHigh);
+
+                    if (bSrcIsAnsi)
+                    {
+                        if (bDestIsAnsi)
+                        {
+                            PostMessageA(hWnd, WM_INTERIM, bLow, 0xF00001);
+                            PostMessageA(hWnd, WM_INTERIM, bHigh, 0xF00001);
+                        }
+                        else
+                        {
+                            CHAR szTmp[2] = { (CHAR)bLow, (CHAR)bHigh };
+                            WCHAR wTmp[2];
+                            if (MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, szTmp, 2, wTmp, 1))
+                                PostMessageW(hWnd, WM_INTERIM, wTmp[0], 0xF00001);
+                        }
+                    }
+                    else
+                    {
+                        if (!bDestIsAnsi)
+                        {
+                            PostMessageW(hWnd, WM_INTERIM, wParam, 0xF00001);
+                        }
+                        else
+                        {
+                            WCHAR wTmp[2] = { (WCHAR)wParam, 0 };
+                            CHAR  szTmp[2];
+                            WideCharToMultiByte(CP_ACP, 0, wTmp, 1, szTmp, 2, NULL, NULL);
+                            PostMessageA(hWnd, WM_INTERIM, (BYTE)szTmp[0], 0xF00001);
+                            PostMessageA(hWnd, WM_INTERIM, (BYTE)szTmp[1], 0xF00001);
+                        }
+                    }
+
+                    if (bDestIsUnicode)
+                        PostMessageW(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
+                    else
+                        PostMessageA(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
+
+                    pfnSendMessage(hwndIme, WM_IME_ENDCOMPOSITION, 0, 0);
+                }
+                else
+                {
+                    pfnPostMessage(hWnd, WM_IME_REPORT, IR_STRINGSTART, 0);
+                    if (bSrcIsAnsi)
+                    {
+                        if (bDestIsAnsi)
+                        {
+                            PostMessageA(hWnd, WM_CHAR, (BYTE)g_dchKorean, 0xFFF10001);
+                            PostMessageA(hWnd, WM_CHAR, HIBYTE(g_dchKorean), 0xFFF10001);
+                            PostMessageA(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
+                            PostMessageA(hWnd, WM_KEYDOWN, VK_BACK, 917505);
+                        }
+                        else
+                        {
+                            CHAR szTmp[2];
+                            szTmp[0] = (CHAR)LOBYTE(g_dchKorean);
+                            szTmp[1] = (CHAR)HIBYTE(g_dchKorean);
+                            WCHAR wTmp[2];
+                            if (MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, szTmp, 2, wTmp, 1))
+                            {
+                                PostMessageW(hWnd, WM_CHAR, wTmp[0], 0xFFF10001);
+                            }
+                            PostMessageW(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
+                            PostMessageW(hWnd, WM_KEYDOWN, VK_BACK, 917505);
+                        }
+                    }
+                    else
+                    {
+                        if (bDestIsAnsi)
+                        {
+                            WCHAR wTmp[2] = { (WCHAR)g_dchKorean, 0 };
+                            CHAR  szTmp[2];
+                            WideCharToMultiByte(CP_ACP, 0, wTmp, 1, szTmp, 2, NULL, NULL);
+                            PostMessageA(hWnd, WM_CHAR, (BYTE)szTmp[0], 0xFFF10001);
+                            PostMessageA(hWnd, WM_CHAR, (BYTE)szTmp[1], 0xFFF10001);
+                            PostMessageA(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
+                            PostMessageA(hWnd, WM_KEYDOWN, VK_BACK, 917505);
+                        }
+                        else
+                        {
+                            PostMessageW(hWnd, WM_CHAR, (WCHAR)g_dchKorean, 0xFFF10001);
+                            PostMessageW(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
+                            PostMessageW(hWnd, WM_KEYDOWN, VK_BACK, 917505);
                         }
                     }
                 }
-                if (!(pIC->dwUIFlags & _IME_UI_HIDDEN))
-                    EMIT_ENTRY_K();
-                else
-                    SendMessageW(hwndIme, pCurrent->message, pCurrent->wParam, pCurrent->lParam);
+                break;
+
+            case WM_IMEKEYDOWN:
+                pfnPostMessage(hWnd, WM_KEYDOWN, (WPARAM)(LOWORD(wParam)), lParam);
+                break;
+
+            case WM_IMEKEYUP:
+                pfnPostMessage(hWnd, WM_KEYUP, (WPARAM)(LOWORD(wParam)), lParam);
                 break;
 
             default:
-                EMIT_ENTRY_K();
+                pfnSendMessage(hwndIme, uMsg, wParam, lParam);
                 break;
+            }
         }
-
-        pCurrent++;
+        else
+        {
+            pfnSendMessage(hwndIme, uMsg, wParam, lParam);
+        }
     }
 
-#undef EMIT_ENTRY_K
-    ImmLocalFree(pBuf);
-    return dwResult;
+    return 0;
 }
 
 #endif /* def IMM_WIN3_SUPPORT */

--- a/win32ss/user/imm32/win3.c
+++ b/win32ss/user/imm32/win3.c
@@ -12,12 +12,38 @@ WINE_DEFAULT_DEBUG_CHANNEL(imm);
 
 #ifdef IMM_WIN3_SUPPORT /* 3.x support */
 
-#define ALIGN_DWORD(len) (((len) + 3) & ~3)
+#define ALIGN_DWORD(len)      (((len) + 3) & ~3)
+#define ALIGN_ASTR_SIZE(len)  ALIGN_DWORD(2 * (len) + sizeof(ANSI_NULL))
+#define ALIGN_WSTR_SIZE(len)  ALIGN_DWORD((len) * sizeof(WCHAR) + sizeof(UNICODE_NULL))
+
+/* Korean lead byte */
+#define KOR_LEAD_BYTE_FIRST  ((BYTE)0xB0)
+#define KOR_LEAD_BYTE_LAST   ((BYTE)0xC8)
+#define KOR_IS_LEAD_BYTE(ch) \
+    (KOR_LEAD_BYTE_FIRST <= (BYTE)(ch) && (BYTE)(ch) <= KOR_LEAD_BYTE_LAST)
+
+static inline INT Imm32WideToAnsi(PCWCH pchWide, INT cchWide, PSTR pszAnsi, INT cchAnsi)
+{
+    BOOL usedDefaultChar = FALSE;
+    INT len = WideCharToMultiByte(CP_ACP, 0, pchWide, cchWide, pszAnsi, cchAnsi,
+                                  NULL, &usedDefaultChar);
+    if (pszAnsi && len >= 0)
+        pszAnsi[len] = ANSI_NULL;
+    return len;
+}
+
+static inline INT Imm32AnsiToWide(PCCH pchAnsi, INT cchAnsi, PWSTR pszWide, INT cchWide)
+{
+    INT len = MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, pchAnsi, cchAnsi, pszWide, cchWide);
+    if (pszWide && len >= 0)
+        pszWide[len] = UNICODE_NULL;
+    return len;
+}
 
 static DWORD Imm32CompStrWToStringA(const COMPOSITIONSTRING *pCS, PCHAR pch)
 {
-    PCWSTR pwch = (PCWSTR)((const BYTE*)pCS + pCS->dwResultStrOffset);
     BOOL bUsedDef;
+    PCWSTR pwch = (PCWSTR)((const BYTE*)pCS + pCS->dwResultStrOffset);
     INT cchNeed = WideCharToMultiByte(CP_ACP, 0, pwch, pCS->dwResultStrLen,
                                       pch, 0, NULL, &bUsedDef) + 1;
     if (!pch)
@@ -31,12 +57,13 @@ static DWORD Imm32CompStrWToStringA(const COMPOSITIONSTRING *pCS, PCHAR pch)
 static DWORD Imm32CompStrWToStringW(const COMPOSITIONSTRING *pCS, PWCHAR pch)
 {
     DWORD dwResultStrLen = pCS->dwResultStrLen;
-    if (!pch)
-        return (dwResultStrLen + 1) * sizeof(WCHAR);
-    DWORD cb = dwResultStrLen * sizeof(WCHAR);
-    RtlCopyMemory(pch, (const BYTE*)pCS + pCS->dwResultStrOffset, cb);
-    pch[cb / sizeof(WCHAR)] = UNICODE_NULL;
-    return cb + sizeof(UNICODE_NULL);
+    if (pch)
+    {
+        DWORD cb = dwResultStrLen * sizeof(WCHAR);
+        RtlCopyMemory(pch, (const BYTE*)pCS + pCS->dwResultStrOffset, cb);
+        pch[dwResultStrLen] = UNICODE_NULL;
+    }
+    return (dwResultStrLen + 1) * sizeof(WCHAR);
 }
 
 static DWORD
@@ -46,44 +73,44 @@ Imm32CompStrWToUndetW(
     PUNDETERMINESTRUCT pDet,
     DWORD dwSize)
 {
-    const DWORD dwRequiredSize =
+    const DWORD cbRequired =
         sizeof(UNDETERMINESTRUCT) +
-        ALIGN_DWORD(pCS->dwCompStrLen * sizeof(WCHAR) + sizeof(UNICODE_NULL)) +
+        ALIGN_WSTR_SIZE(pCS->dwCompStrLen) +
         ALIGN_DWORD(pCS->dwCompAttrLen) +
-        ALIGN_DWORD(pCS->dwResultStrLen * sizeof(WCHAR) + sizeof(UNICODE_NULL)) +
+        ALIGN_WSTR_SIZE(pCS->dwResultStrLen) +
         ALIGN_DWORD(pCS->dwResultClauseLen) +
-        ALIGN_DWORD(pCS->dwResultReadStrLen * sizeof(WCHAR) + sizeof(UNICODE_NULL)) +
+        ALIGN_WSTR_SIZE(pCS->dwResultReadStrLen) +
         ALIGN_DWORD(pCS->dwResultReadClauseLen);
 
     if (!pDet)
-        return dwRequiredSize;
+        return cbRequired;
 
-    if (dwSize < dwRequiredSize)
+    if (dwSize < cbRequired)
         return 0;
 
-    RtlZeroMemory(pDet, sizeof(UNDETERMINESTRUCT));
-    pDet->dwSize = dwRequiredSize;
+    pDet->dwSize = cbRequired;
 
-    DWORD dwCurrentOffset = sizeof(UNDETERMINESTRUCT);
-    PBYTE pBase = (PBYTE)pDet;
-    const BYTE *pSrcBase = (const BYTE *)pCS;
+    PBYTE pbDet = (PBYTE)pDet;
+    DWORD ib = sizeof(UNDETERMINESTRUCT);
+    const BYTE* pbCS = (const BYTE*)pCS;
 
-    if ((dwGCS & GCS_COMPSTR) && (pCS->dwCompStrLen > 0))
+    if (dwGCS & GCS_COMPSTR)
     {
-        pDet->uUndetTextPos = dwCurrentOffset;
+        pDet->uUndetTextPos = ib;
         pDet->uUndetTextLen = pCS->dwCompStrLen;
         DWORD cb = pCS->dwCompStrLen * sizeof(WCHAR);
-        RtlCopyMemory(pBase + dwCurrentOffset, pSrcBase + pCS->dwCompStrOffset, cb);
-        ((PWCHAR)(pBase + dwCurrentOffset))[pCS->dwCompStrLen] = UNICODE_NULL;
-        dwCurrentOffset += ALIGN_DWORD((pCS->dwCompStrLen + 1) * sizeof(WCHAR));
+        RtlCopyMemory(pbDet + ib, pbCS + pCS->dwCompStrOffset, cb);
+        ((PWCHAR)(pbDet + ib))[pCS->dwCompStrLen] = UNICODE_NULL;
+
+        ib += ALIGN_WSTR_SIZE(pCS->dwCompStrLen);
     }
 
-    if ((dwGCS & GCS_COMPATTR) && (pCS->dwCompAttrLen > 0) && (pDet->uUndetTextLen > 0))
+    if ((dwGCS & GCS_COMPATTR) || pCS->dwCompAttrLen)
     {
-        pDet->uUndetAttrPos = dwCurrentOffset;
-        RtlCopyMemory(pBase + dwCurrentOffset, pSrcBase + pCS->dwCompAttrOffset,
-                      pCS->dwCompAttrLen);
-        dwCurrentOffset += ALIGN_DWORD(pCS->dwCompAttrLen);
+        pDet->uUndetAttrPos = ib;
+        RtlCopyMemory(pbDet + ib, pbCS + pCS->dwCompAttrOffset, pCS->dwCompAttrLen);
+
+        ib += ALIGN_DWORD(pCS->dwCompAttrLen);
     }
 
     if (dwGCS & GCS_CURSORPOS)
@@ -92,47 +119,46 @@ Imm32CompStrWToUndetW(
     if (dwGCS & GCS_DELTASTART)
         pDet->uDeltaStart = pCS->dwDeltaStart;
 
-    if ((dwGCS & GCS_RESULTSTR) && (pCS->dwResultStrLen > 0))
+    if (dwGCS & GCS_RESULTSTR)
     {
-        pDet->uDetermineTextPos = dwCurrentOffset;
+        pDet->uDetermineTextPos = ib;
         pDet->uDetermineTextLen = pCS->dwResultStrLen;
         DWORD cb = pCS->dwResultStrLen * sizeof(WCHAR);
-        RtlCopyMemory(pBase + dwCurrentOffset, pSrcBase + pCS->dwResultStrOffset, cb);
-        ((PWCHAR)(pBase + dwCurrentOffset))[pCS->dwResultStrLen] = UNICODE_NULL;
-        dwCurrentOffset += ALIGN_DWORD((pCS->dwResultStrLen + 1) * sizeof(WCHAR));
+        RtlCopyMemory(pbDet + ib, pbCS + pCS->dwResultStrOffset, cb);
+        ((PWCHAR)(pbDet + ib))[pCS->dwResultStrLen] = UNICODE_NULL;
+
+        ib += ALIGN_WSTR_SIZE(pCS->dwResultStrLen);
     }
 
-    if ((dwGCS & GCS_RESULTCLAUSE) && (pCS->dwResultClauseLen > 0) &&
-        (pDet->uDetermineTextLen > 0))
+    if ((dwGCS & GCS_RESULTCLAUSE) && pCS->dwResultClauseLen)
     {
-        pDet->uDetermineDelimPos = dwCurrentOffset;
-        RtlCopyMemory(pBase + dwCurrentOffset,
-                      pSrcBase + pCS->dwResultClauseOffset,
-                      pCS->dwResultClauseLen);
-        dwCurrentOffset += ALIGN_DWORD(pCS->dwResultClauseLen);
+        pDet->uDetermineDelimPos = ib;
+        RtlCopyMemory(pbDet + ib, pbCS + pCS->dwResultClauseOffset, pCS->dwResultClauseLen);
+
+        ib += ALIGN_DWORD(pCS->dwResultClauseLen);
     }
 
-    if ((dwGCS & GCS_RESULTREADSTR) && (pCS->dwResultReadStrLen > 0))
+    if (dwGCS & GCS_RESULTREADSTR)
     {
-        pDet->uYomiTextPos = dwCurrentOffset;
+        pDet->uYomiTextPos = ib;
         pDet->uYomiTextLen = pCS->dwResultReadStrLen;
         DWORD cb = pCS->dwResultReadStrLen * sizeof(WCHAR);
-        RtlCopyMemory(pBase + dwCurrentOffset, pSrcBase + pCS->dwResultReadStrOffset, cb);
-        ((PWCHAR)(pBase + dwCurrentOffset))[pCS->dwResultReadStrLen] = UNICODE_NULL;
-        dwCurrentOffset += ALIGN_DWORD((pCS->dwResultReadStrLen + 1) * sizeof(WCHAR));
+        RtlCopyMemory(pbDet + ib, pbCS + pCS->dwResultReadStrOffset, cb);
+        ((PWCHAR)(pbDet + ib))[pCS->dwResultReadStrLen] = UNICODE_NULL;
+
+        ib += ALIGN_WSTR_SIZE(pCS->dwResultReadStrLen);
     }
 
-    if ((dwGCS & GCS_RESULTREADCLAUSE) && (pCS->dwResultReadClauseLen > 0) &&
-        (pDet->uYomiTextLen > 0))
+    if ((dwGCS & GCS_RESULTREADCLAUSE) && pCS->dwResultReadClauseLen)
     {
-        pDet->uYomiDelimPos = dwCurrentOffset;
-        RtlCopyMemory(pBase + dwCurrentOffset,
-                      pSrcBase + pCS->dwResultReadClauseOffset,
+        pDet->uYomiDelimPos = ib;
+        RtlCopyMemory(pbDet + ib, pbCS + pCS->dwResultReadClauseOffset,
                       pCS->dwResultReadClauseLen);
-        dwCurrentOffset += ALIGN_DWORD(pCS->dwResultReadClauseLen);
+
+        //ib += ALIGN_DWORD(pCS->dwResultReadClauseLen); // The last one (ineffective)
     }
 
-    return dwRequiredSize;
+    return cbRequired;
 }
 
 static DWORD
@@ -142,159 +168,131 @@ Imm32CompStrWToUndetA(
     PUNDETERMINESTRUCT pDet,
     DWORD dwSize)
 {
-    const DWORD dwRequiredSize =
+    const DWORD cbRequired =
         sizeof(UNDETERMINESTRUCT) +
-        ALIGN_DWORD(2 * pCS->dwCompStrLen + sizeof(ANSI_NULL)) +
-        ALIGN_DWORD(2 * pCS->dwCompAttrLen + 1) +
-        ALIGN_DWORD(2 * pCS->dwResultStrLen + sizeof(ANSI_NULL)) +
+        ALIGN_ASTR_SIZE(pCS->dwCompStrLen) +
+        ALIGN_ASTR_SIZE(pCS->dwCompAttrLen) +
+        ALIGN_ASTR_SIZE(pCS->dwResultStrLen) +
         ALIGN_DWORD(pCS->dwResultClauseLen) +
-        ALIGN_DWORD(2 * pCS->dwResultReadStrLen + sizeof(ANSI_NULL)) +
+        ALIGN_ASTR_SIZE(pCS->dwResultReadStrLen) +
         ALIGN_DWORD(pCS->dwResultReadClauseLen);
 
     if (!pDet)
-        return dwRequiredSize;
+        return cbRequired;
 
-    if (dwSize < dwRequiredSize)
+    if (dwSize < cbRequired)
         return 0;
 
-    RtlZeroMemory(pDet, sizeof(UNDETERMINESTRUCT));
-    pDet->dwSize = dwRequiredSize;
+    pDet->dwSize = cbRequired;
 
-    DWORD dwCurrentOffset = sizeof(UNDETERMINESTRUCT);
-    PBYTE pBase = (PBYTE)pDet;
-    const BYTE *pSrcBase = (const BYTE *)pCS;
-    BOOL bUsedDef;
+    DWORD ib = sizeof(UNDETERMINESTRUCT);
+    PBYTE pbDet = (PBYTE)pDet;
+    const BYTE* pbCS = (const BYTE*)pCS;
+    PCWSTR pCompStrW = (PCWSTR)(pbCS + pCS->dwCompStrOffset);
+    PCWSTR pResultStr = (PCWSTR)(pbCS + pCS->dwResultStrOffset);
+    PCWSTR pResultReadStr = (PCWSTR)(pbCS + pCS->dwResultReadStrOffset);
 
-    if ((dwGCS & GCS_COMPSTR) && (pCS->dwCompStrLen > 0))
+    if (dwGCS & GCS_COMPSTR)
     {
-        INT nAnsiLen = WideCharToMultiByte(CP_ACP, 0,
-            (PCWSTR)(pSrcBase + pCS->dwCompStrOffset), pCS->dwCompStrLen,
-            (PSTR)(pBase + dwCurrentOffset), dwRequiredSize - dwCurrentOffset, NULL, &bUsedDef);
-        if (nAnsiLen <= 0)
-            return 0;
+        INT cchAnsi = Imm32WideToAnsi(pCompStrW, pCS->dwCompStrLen,
+                                      (PSTR)(pbDet + ib), cbRequired - ib);
+        pDet->uUndetTextPos = ib;
+        pDet->uUndetTextLen = cchAnsi;
+        (pbDet + ib)[cchAnsi] = ANSI_NULL;
 
-        pDet->uUndetTextPos = dwCurrentOffset;
-        pDet->uUndetTextLen = nAnsiLen;
-        (pBase + dwCurrentOffset)[nAnsiLen] = ANSI_NULL;
-        dwCurrentOffset += ALIGN_DWORD(nAnsiLen + 1);
-    }
+        ib += ALIGN_DWORD(cchAnsi + 1);
 
-    if ((dwGCS & GCS_COMPATTR) && (pCS->dwCompAttrLen > 0) && (pDet->uUndetTextLen > 0))
-    {
-        pDet->uUndetAttrPos = dwCurrentOffset;
-        const BYTE *pSrcAttr = pSrcBase + pCS->dwCompAttrOffset;
-        PBYTE pDestAttr = pBase + dwCurrentOffset;
-        PCWSTR pWStr = (PCWSTR)(pSrcBase + pCS->dwCompStrOffset);
-        UINT ibIndex = 0;
+        if (pCS->dwCompAttrLen)
+            dwGCS |= GCS_COMPATTR;
 
-        for (UINT i = 0; i < pCS->dwCompAttrLen; ++i)
+        if ((dwGCS & GCS_COMPATTR) || pCS->dwCompAttrLen)
         {
-            ULONG cbMultiByte = 0;
-            USHORT wChar = pWStr[i];
-            RtlUnicodeToMultiByteSize(&cbMultiByte, &wChar, sizeof(WCHAR));
-            if (cbMultiByte == 2)
-            {
-                pDestAttr[ibIndex++] = pSrcAttr[i];
-                pDestAttr[ibIndex++] = pSrcAttr[i];
-            }
-            else
-            {
-                pDestAttr[ibIndex++] = pSrcAttr[i];
-            }
-        }
+            pDet->uUndetAttrPos = ib;
 
-        dwCurrentOffset += ALIGN_DWORD(ibIndex);
+            const BYTE *pSrcAttr = pbCS + pCS->dwCompAttrOffset;
+            PBYTE pDestAttr = pbDet + ib;
+
+            UINT ibIndex = 0;
+            for (UINT i = 0; i < pCS->dwCompAttrLen; ++i)
+            {
+                if (IsDBCSLeadByte(pbDet[pDet->uUndetTextPos + i]))
+                {
+                    pDestAttr[ibIndex++] = pSrcAttr[i];
+                    pDestAttr[ibIndex++] = pSrcAttr[i];
+                }
+                else
+                {
+                    pDestAttr[ibIndex++] = pSrcAttr[i];
+                }
+            }
+
+            ib += ALIGN_DWORD(ibIndex);
+        }
     }
 
     if (dwGCS & GCS_CURSORPOS)
     {
         if (pCS->dwCursorPos == (DWORD)-1)
-        {
             pDet->uCursorPos = (UINT)-1;
-        }
         else
-        {
-            pDet->uCursorPos = IchAnsiFromWide(pCS->dwCursorPos,
-                (PCWSTR)(pSrcBase + pCS->dwCompStrOffset), CP_ACP);
-        }
+            pDet->uCursorPos = IchAnsiFromWide(pCS->dwCursorPos, pCompStrW, CP_ACP);
     }
 
     if (dwGCS & GCS_DELTASTART)
     {
         if (pCS->dwDeltaStart == (DWORD)-1)
-        {
             pDet->uDeltaStart = (UINT)-1;
-        }
         else
+            pDet->uDeltaStart = IchAnsiFromWide(pCS->dwDeltaStart, pCompStrW, CP_ACP);
+    }
+
+    if (dwGCS & GCS_RESULTSTR)
+    {
+        INT cchAnsi = Imm32WideToAnsi(pResultStr, pCS->dwResultStrLen,
+                                      (PSTR)(pbDet + ib), cbRequired - ib);
+        pDet->uDetermineTextPos = ib;
+        pDet->uDetermineTextLen = cchAnsi;
+
+        ib += ALIGN_DWORD(cchAnsi + sizeof(ANSI_NULL));
+
+        if ((dwGCS & GCS_RESULTCLAUSE) && pCS->dwResultClauseLen)
         {
-            pDet->uDeltaStart = IchAnsiFromWide(pCS->dwDeltaStart,
-                (PCWSTR)(pSrcBase + pCS->dwCompStrOffset), CP_ACP);
+            pDet->uDetermineDelimPos = ib;
+            const DWORD *pSrcClause = (const DWORD *)(pbCS + pCS->dwResultClauseOffset);
+            PDWORD pDestClause = (PDWORD)(pbDet + ib);
+            DWORD nClauses = pCS->dwResultClauseLen / sizeof(DWORD);
+
+            for (DWORD i = 0; i < nClauses; ++i)
+                pDestClause[i] = IchAnsiFromWide(pSrcClause[i], pResultStr, CP_ACP);
+
+            ib += ALIGN_DWORD(pCS->dwResultClauseLen);
         }
     }
 
-    if ((dwGCS & GCS_RESULTSTR) && (pCS->dwResultStrLen > 0))
+    if (dwGCS & GCS_RESULTREADSTR)
     {
-        INT nAnsiLen = WideCharToMultiByte(
-            CP_ACP, 0,
-            (PCWSTR)(pSrcBase + pCS->dwResultStrOffset), pCS->dwResultStrLen,
-            (PSTR)(pBase + dwCurrentOffset), dwRequiredSize - dwCurrentOffset,
-            NULL, &bUsedDef);
-        if (nAnsiLen > 0)
+        INT cchAnsi = Imm32WideToAnsi(pResultReadStr, pCS->dwResultReadStrLen,
+                                      (PSTR)(pbDet + ib), cbRequired - ib);
+        pDet->uYomiTextPos = ib;
+        pDet->uYomiTextLen = cchAnsi;
+        ib += ALIGN_DWORD(cchAnsi + sizeof(ANSI_NULL));
+
+        if ((dwGCS & GCS_RESULTREADCLAUSE) && pCS->dwResultReadClauseLen)
         {
-            pDet->uDetermineTextPos = dwCurrentOffset;
-            pDet->uDetermineTextLen = nAnsiLen;
-            (pBase + dwCurrentOffset)[nAnsiLen] = ANSI_NULL;
-            dwCurrentOffset += ALIGN_DWORD(nAnsiLen + 1);
+            pDet->uYomiDelimPos = ib;
+            const DWORD *pSrcClause = (const DWORD *)(pbCS + pCS->dwResultReadClauseOffset);
+            PDWORD pDestClause = (PDWORD)(pbDet + ib);
+            DWORD nClauses = pCS->dwResultReadClauseLen / sizeof(DWORD);
+            PCWSTR pReadW = (PCWSTR)(pbCS + pCS->dwResultReadStrOffset);
+
+            for (DWORD i = 0; i < nClauses; i++)
+                pDestClause[i] = IchAnsiFromWide(pSrcClause[i], pReadW, CP_ACP);
+
+            //ib += ALIGN_DWORD(pCS->dwResultReadClauseLen); // The last one (ineffective)
         }
     }
 
-    if ((dwGCS & GCS_RESULTCLAUSE) && (pCS->dwResultClauseLen > 0) &&
-        (pDet->uDetermineTextLen > 0))
-    {
-        pDet->uDetermineDelimPos = dwCurrentOffset;
-        const DWORD *pSrcClause = (const DWORD *)(pSrcBase + pCS->dwResultClauseOffset);
-        PDWORD pDestClause = (PDWORD)(pBase + dwCurrentOffset);
-        DWORD nClauses = pCS->dwResultClauseLen / sizeof(DWORD);
-        PCWSTR pResultW = (PCWSTR)(pSrcBase + pCS->dwResultStrOffset);
-
-        for (DWORD i = 0; i < nClauses; ++i)
-            pDestClause[i] = IchAnsiFromWide(pSrcClause[i], pResultW, CP_ACP);
-
-        dwCurrentOffset += ALIGN_DWORD(pCS->dwResultClauseLen);
-    }
-
-    if ((dwGCS & GCS_RESULTREADSTR) && (pCS->dwResultReadStrLen > 0))
-    {
-        INT nAnsiLen = WideCharToMultiByte(
-            CP_ACP, 0,
-            (PCWSTR)(pSrcBase + pCS->dwResultReadStrOffset), pCS->dwResultReadStrLen,
-            (PSTR)(pBase + dwCurrentOffset), dwRequiredSize - dwCurrentOffset,
-            NULL, &bUsedDef);
-        if (nAnsiLen > 0)
-        {
-            pDet->uYomiTextPos = dwCurrentOffset;
-            pDet->uYomiTextLen = nAnsiLen;
-            (pBase + dwCurrentOffset)[nAnsiLen] = ANSI_NULL;
-            dwCurrentOffset += ALIGN_DWORD(nAnsiLen + 1);
-        }
-    }
-
-    if ((dwGCS & GCS_RESULTREADCLAUSE) && (pCS->dwResultReadClauseLen > 0) &&
-        (pDet->uYomiTextLen > 0))
-    {
-        pDet->uYomiDelimPos = dwCurrentOffset;
-        const DWORD *pSrcClause = (const DWORD *)(pSrcBase + pCS->dwResultReadClauseOffset);
-        PDWORD pDestClause = (PDWORD)(pBase + dwCurrentOffset);
-        DWORD nClauses = pCS->dwResultReadClauseLen / sizeof(DWORD);
-        PCWSTR pReadW = (PCWSTR)(pSrcBase + pCS->dwResultReadStrOffset);
-
-        for (DWORD i = 0; i < nClauses; i++)
-            pDestClause[i] = IchAnsiFromWide(pSrcClause[i], pReadW, CP_ACP);
-
-        dwCurrentOffset += ALIGN_DWORD(pCS->dwResultReadClauseLen);
-    }
-
-    return dwRequiredSize;
+    return cbRequired;
 }
 
 static DWORD
@@ -304,58 +302,58 @@ Imm32CompStrWToStringExW(
     LPSTRINGEXSTRUCT pSX,
     DWORD dwSize)
 {
-    const DWORD dwRequiredSize =
+    const DWORD cbRequired =
         sizeof(STRINGEXSTRUCT) +
-        ALIGN_DWORD(pCS->dwResultStrLen * sizeof(WCHAR) + sizeof(UNICODE_NULL)) +
+        ALIGN_WSTR_SIZE(pCS->dwResultStrLen) +
         ALIGN_DWORD(pCS->dwResultClauseLen) +
-        ALIGN_DWORD(pCS->dwResultReadStrLen * sizeof(WCHAR) + sizeof(UNICODE_NULL)) +
+        ALIGN_WSTR_SIZE(pCS->dwResultReadStrLen) +
         ALIGN_DWORD(pCS->dwResultReadClauseLen);
 
     if (!pSX)
-        return dwRequiredSize;
+        return cbRequired;
 
-    if (dwSize < dwRequiredSize)
+    if (dwSize < cbRequired)
         return 0;
 
-    RtlZeroMemory(pSX, sizeof(STRINGEXSTRUCT));
     pSX->dwSize = dwSize;
 
-    DWORD dwCurrentOffset = sizeof(STRINGEXSTRUCT);
+    DWORD ib = sizeof(STRINGEXSTRUCT);
     PBYTE pBase = (PBYTE)pSX;
-    const BYTE *pSrcBase = (const BYTE *)pCS;
+    const BYTE* pbCS = (const BYTE*)pCS;
 
-    if (pCS->dwResultStrLen > 0)
     {
-        pSX->uDeterminePos = dwCurrentOffset;
-        DWORD cb = pCS->dwResultStrLen * sizeof(WCHAR);
-        RtlCopyMemory(pBase + dwCurrentOffset, pSrcBase + pCS->dwResultStrOffset, cb);
-        ((PWSTR)(pBase + dwCurrentOffset))[pCS->dwResultStrLen] = UNICODE_NULL;
-        dwCurrentOffset += ALIGN_DWORD(cb + sizeof(WCHAR));
+        pSX->uDeterminePos = ib;
+        DWORD cbResultStr = pCS->dwResultStrLen * sizeof(WCHAR);
+        RtlCopyMemory(pBase + ib, pbCS + pCS->dwResultStrOffset, cbResultStr);
+        ((PWSTR)(pBase + ib))[pCS->dwResultStrLen] = UNICODE_NULL;
+
+        ib += ALIGN_WSTR_SIZE(pCS->dwResultStrLen);
     }
 
-    if ((dwGCS & GCS_RESULTCLAUSE) && pCS->dwResultClauseLen > 0 && pSX->uDeterminePos)
+    if ((dwGCS & GCS_RESULTCLAUSE) && pCS->dwResultClauseLen)
     {
-        pSX->uDetermineDelimPos = dwCurrentOffset;
-        RtlCopyMemory(pBase + dwCurrentOffset, pSrcBase + pCS->dwResultClauseOffset,
-                      pCS->dwResultClauseLen);
-        dwCurrentOffset += ALIGN_DWORD(pCS->dwResultClauseLen);
+        pSX->uDetermineDelimPos = ib;
+        RtlCopyMemory(pBase + ib, pbCS + pCS->dwResultClauseOffset, pCS->dwResultClauseLen);
+
+        ib += ALIGN_DWORD(pCS->dwResultClauseLen);
     }
 
-    if (pCS->dwResultReadStrLen > 0)
     {
-        pSX->uYomiPos = dwCurrentOffset;
-        DWORD cb = pCS->dwResultReadStrLen * sizeof(WCHAR);
-        RtlCopyMemory(pBase + dwCurrentOffset, pSrcBase + pCS->dwResultReadStrOffset, cb);
-        ((PWSTR)(pBase + dwCurrentOffset))[pCS->dwResultReadStrLen] = UNICODE_NULL;
-        dwCurrentOffset += ALIGN_DWORD(cb + sizeof(WCHAR));
+        pSX->uYomiPos = ib;
+        DWORD cbResultReadStr = pCS->dwResultReadStrLen * sizeof(WCHAR);
+        RtlCopyMemory(pBase + ib, pbCS + pCS->dwResultReadStrOffset, cbResultReadStr);
+        ((PWSTR)(pBase + ib))[pCS->dwResultReadStrLen] = UNICODE_NULL;
+
+        ib += ALIGN_WSTR_SIZE(pCS->dwResultReadStrLen);
     }
 
-    if ((dwGCS & GCS_RESULTREADCLAUSE) && pCS->dwResultReadClauseLen > 0 && pSX->uYomiPos)
+    if ((dwGCS & GCS_RESULTREADCLAUSE) && pCS->dwResultReadClauseLen)
     {
-        pSX->uYomiDelimPos = dwCurrentOffset;
-        RtlCopyMemory(pBase + dwCurrentOffset, pSrcBase + pCS->dwResultReadClauseOffset,
+        pSX->uYomiDelimPos = ib;
+        RtlCopyMemory(pBase + ib, pbCS + pCS->dwResultReadClauseOffset,
                       pCS->dwResultReadClauseLen);
-        dwCurrentOffset += ALIGN_DWORD(pCS->dwResultReadClauseLen);
+
+        //ib += ALIGN_DWORD(pCS->dwResultReadClauseLen); // The last one (ineffective)
     }
 
     return dwSize;
@@ -368,80 +366,75 @@ Imm32CompStrWToStringExA(
     LPSTRINGEXSTRUCT pSX,
     DWORD dwSize)
 {
-    const DWORD dwRequiredSize =
+    const DWORD cbRequired =
         sizeof(STRINGEXSTRUCT) +
-        ALIGN_DWORD(2 * pCS->dwResultStrLen + sizeof(ANSI_NULL)) +
+        ALIGN_ASTR_SIZE(pCS->dwResultStrLen) +
         ALIGN_DWORD(pCS->dwResultClauseLen) +
-        ALIGN_DWORD(2 * pCS->dwResultReadStrLen + sizeof(ANSI_NULL)) +
+        ALIGN_ASTR_SIZE(pCS->dwResultReadStrLen) +
         ALIGN_DWORD(pCS->dwResultReadClauseLen);
 
     if (!pSX)
-        return dwRequiredSize;
+        return cbRequired;
 
-    if (dwSize < dwRequiredSize)
+    if (dwSize < cbRequired)
         return 0;
 
-    RtlZeroMemory(pSX, sizeof(STRINGEXSTRUCT));
     pSX->dwSize = dwSize;
 
-    DWORD dwCurrentOffset = sizeof(STRINGEXSTRUCT);
-    PBYTE pBase = (PBYTE)pSX;
-    const BYTE *pSrcBase = (const BYTE *)pCS;
-    BOOL bUsedDef;
-    INT nAnsiResultLen = 0, nAnsiReadLen = 0;
+    DWORD ib = sizeof(STRINGEXSTRUCT);
+    PBYTE pbSX = (PBYTE)pSX;
+    const BYTE* pbCS = (const BYTE*)pCS;
+    PCWSTR pResultStr = (PCWSTR)(pbCS + pCS->dwResultStrOffset);
+    PCWSTR pResultReadStr = (PCWSTR)(pbCS + pCS->dwResultReadStrOffset);
 
-    if (pCS->dwResultStrLen > 0)
+    if (pCS->dwResultStrLen)
     {
-        pSX->uDeterminePos = dwCurrentOffset;
-        nAnsiResultLen = WideCharToMultiByte(
-            CP_ACP, 0,
-            (PCWSTR)(pSrcBase + pCS->dwResultStrOffset), pCS->dwResultStrLen,
-            (PSTR)(pBase + dwCurrentOffset), dwSize - dwCurrentOffset, NULL, &bUsedDef);
+        pSX->uDeterminePos = ib;
+        INT nAnsiResultLen = Imm32WideToAnsi(pResultStr, pCS->dwResultStrLen,
+                                             (PSTR)(pbSX + ib), dwSize - ib);
         if (nAnsiResultLen <= 0)
             return 0;
-        (pBase + dwCurrentOffset)[nAnsiResultLen] = ANSI_NULL;
-        dwCurrentOffset += ALIGN_DWORD(nAnsiResultLen + 1);
+
+        ib += ALIGN_DWORD(nAnsiResultLen + 1);
+
+        if ((dwGCS & GCS_RESULTCLAUSE) && pCS->dwResultClauseLen)
+        {
+            pSX->uDetermineDelimPos = ib;
+            const DWORD *pSrcClause = (const DWORD *)(pbCS + pCS->dwResultClauseOffset);
+            PDWORD pDestClause = (PDWORD)(pbSX + ib);
+            DWORD nClauses = pCS->dwResultClauseLen / sizeof(DWORD);
+            PCWSTR pResultW = (PCWSTR)(pbCS + pCS->dwResultStrOffset);
+
+            for (DWORD i = 0; i < nClauses; i++)
+                pDestClause[i] = IchAnsiFromWide(pSrcClause[i], pResultW, CP_ACP);
+
+            ib += ALIGN_DWORD(pCS->dwResultClauseLen);
+        }
     }
 
-    if ((dwGCS & GCS_RESULTCLAUSE) && pCS->dwResultClauseLen > 0 && nAnsiResultLen > 0)
+    if (pCS->dwResultReadStrLen)
     {
-        pSX->uDetermineDelimPos = dwCurrentOffset;
-        const DWORD *pSrcClause = (const DWORD *)(pSrcBase + pCS->dwResultClauseOffset);
-        PDWORD pDestClause = (PDWORD)(pBase + dwCurrentOffset);
-        DWORD nClauses = pCS->dwResultClauseLen / sizeof(DWORD);
-        PCWSTR pResultW = (PCWSTR)(pSrcBase + pCS->dwResultStrOffset);
-
-        for (DWORD i = 0; i < nClauses; i++)
-            pDestClause[i] = IchAnsiFromWide(pSrcClause[i], pResultW, CP_ACP);
-
-        dwCurrentOffset += ALIGN_DWORD(pCS->dwResultClauseLen);
-    }
-
-    if (pCS->dwResultReadStrLen > 0)
-    {
-        pSX->uYomiPos = dwCurrentOffset;
-        nAnsiReadLen = WideCharToMultiByte(
-            CP_ACP, 0,
-            (PCWSTR)(pSrcBase + pCS->dwResultReadStrOffset), pCS->dwResultReadStrLen,
-            (PSTR)(pBase + dwCurrentOffset), dwSize - dwCurrentOffset, NULL, &bUsedDef);
+        pSX->uYomiPos = ib;
+        INT nAnsiReadLen = Imm32WideToAnsi(pResultReadStr, pCS->dwResultReadStrLen,
+                                           (PSTR)(pbSX + ib), dwSize - ib);
         if (nAnsiReadLen <= 0)
             return 0;
-        (pBase + dwCurrentOffset)[nAnsiReadLen] = ANSI_NULL;
-        dwCurrentOffset += ALIGN_DWORD(nAnsiReadLen + 1);
-    }
 
-    if ((dwGCS & GCS_RESULTREADCLAUSE) && pCS->dwResultReadClauseLen > 0 && nAnsiReadLen > 0)
-    {
-        pSX->uYomiDelimPos = dwCurrentOffset;
-        const DWORD *pSrcClause = (const DWORD *)(pSrcBase + pCS->dwResultReadClauseOffset);
-        PDWORD pDestClause = (PDWORD)(pBase + dwCurrentOffset);
-        DWORD nClauses = pCS->dwResultReadClauseLen / sizeof(DWORD);
-        PCWSTR pReadW = (PCWSTR)(pSrcBase + pCS->dwResultReadStrOffset);
+        ib += ALIGN_DWORD(nAnsiReadLen + 1);
 
-        for (DWORD i = 0; i < nClauses; i++)
-            pDestClause[i] = IchAnsiFromWide(pSrcClause[i], pReadW, CP_ACP);
+        if ((dwGCS & GCS_RESULTREADCLAUSE) && pCS->dwResultReadClauseLen)
+        {
+            pSX->uYomiDelimPos = ib;
+            const DWORD *pSrcClause = (const DWORD *)(pbCS + pCS->dwResultReadClauseOffset);
+            PDWORD pDestClause = (PDWORD)(pbSX + ib);
+            DWORD nClauses = pCS->dwResultReadClauseLen / sizeof(DWORD);
+            PCWSTR pReadW = (PCWSTR)(pbCS + pCS->dwResultReadStrOffset);
 
-        dwCurrentOffset += ALIGN_DWORD(pCS->dwResultReadClauseLen);
+            for (DWORD i = 0; i < nClauses; i++)
+                pDestClause[i] = IchAnsiFromWide(pSrcClause[i], pReadW, CP_ACP);
+
+            //ib += ALIGN_DWORD(pCS->dwResultReadClauseLen); // The last one (ineffective)
+        }
     }
 
     return dwSize;
@@ -454,7 +447,7 @@ Imm32CompStrAToUndetA(
     PUNDETERMINESTRUCT pDet,
     DWORD dwSize)
 {
-    const DWORD dwRequiredSize =
+    const DWORD cbRequired =
         sizeof(UNDETERMINESTRUCT) +
         ALIGN_DWORD(pCS->dwCompStrLen + sizeof(ANSI_NULL)) +
         ALIGN_DWORD(pCS->dwCompAttrLen) +
@@ -464,32 +457,35 @@ Imm32CompStrAToUndetA(
         ALIGN_DWORD(pCS->dwResultReadClauseLen);
 
     if (!pDet)
-        return dwRequiredSize;
+        return cbRequired;
 
-    if (dwSize < dwRequiredSize)
+    if (dwSize < cbRequired)
         return 0;
 
-    RtlZeroMemory(pDet, sizeof(UNDETERMINESTRUCT));
     pDet->dwSize = dwSize;
 
-    DWORD dwCurrentOffset = sizeof(UNDETERMINESTRUCT);
-    PBYTE pBase = (PBYTE)pDet, pSrcBase = (PBYTE)pCS;
+    DWORD ib = sizeof(UNDETERMINESTRUCT);
+    PBYTE pbDet = (PBYTE)pDet, pbCS = (PBYTE)pCS;
 
-    if ((dwGCS & GCS_COMPSTR) && (pCS->dwCompStrLen > 0))
+    if (dwGCS & GCS_COMPSTR)
     {
-        pDet->uUndetTextPos = dwCurrentOffset;
+        pDet->uUndetTextPos = ib;
         pDet->uUndetTextLen = pCS->dwCompStrLen;
-        RtlCopyMemory(pBase + dwCurrentOffset, pSrcBase + pCS->dwCompStrOffset, pCS->dwCompStrLen);
-        pBase[dwCurrentOffset + pCS->dwCompStrLen] = ANSI_NULL;
-        dwCurrentOffset += ALIGN_DWORD(pCS->dwCompStrLen + 1);
+        RtlCopyMemory(pbDet + ib, pbCS + pCS->dwCompStrOffset, pCS->dwCompStrLen);
+        pbDet[ib + pCS->dwCompStrLen] = ANSI_NULL;
+
+        ib += ALIGN_DWORD(pCS->dwCompStrLen + 1);
+
+        if (pCS->dwCompAttrLen)
+            dwGCS |= GCS_COMPATTR;
     }
 
-    if ((dwGCS & GCS_COMPATTR) && (pCS->dwCompAttrLen > 0))
+    if (dwGCS & GCS_COMPATTR)
     {
-        pDet->uUndetAttrPos = dwCurrentOffset;
-        RtlCopyMemory(pBase + dwCurrentOffset, pSrcBase + pCS->dwCompAttrOffset,
-                      pCS->dwCompAttrLen);
-        dwCurrentOffset += ALIGN_DWORD(pCS->dwCompAttrLen);
+        pDet->uUndetAttrPos = ib;
+        RtlCopyMemory(pbDet + ib, pbCS + pCS->dwCompAttrOffset, pCS->dwCompAttrLen);
+
+        ib += ALIGN_DWORD(pCS->dwCompAttrLen);
     }
 
     if (dwGCS & GCS_CURSORPOS)
@@ -498,40 +494,40 @@ Imm32CompStrAToUndetA(
     if (dwGCS & GCS_DELTASTART)
         pDet->uDeltaStart = pCS->dwDeltaStart;
 
-    if ((dwGCS & GCS_RESULTSTR) && (pCS->dwResultStrLen > 0))
+    if (dwGCS & GCS_RESULTSTR)
     {
-        pDet->uDetermineTextPos = dwCurrentOffset;
+        pDet->uDetermineTextPos = ib;
         pDet->uDetermineTextLen = pCS->dwResultStrLen;
-        RtlCopyMemory(pBase + dwCurrentOffset, pSrcBase + pCS->dwResultStrOffset,
-                      pCS->dwResultStrLen);
-        pBase[dwCurrentOffset + pCS->dwResultStrLen] = ANSI_NULL;
-        dwCurrentOffset += ALIGN_DWORD(pCS->dwResultStrLen + 1);
+        RtlCopyMemory(pbDet + ib, pbCS + pCS->dwResultStrOffset, pCS->dwResultStrLen);
+        pbDet[ib + pCS->dwResultStrLen] = ANSI_NULL;
+
+        ib += ALIGN_DWORD(pCS->dwResultStrLen + 1);
     }
 
-    if ((dwGCS & GCS_RESULTCLAUSE) && (pCS->dwResultClauseLen > 0))
+    if ((dwGCS & GCS_RESULTCLAUSE) && pCS->dwResultClauseLen)
     {
-        pDet->uDetermineDelimPos = dwCurrentOffset;
-        RtlCopyMemory(pBase + dwCurrentOffset, pSrcBase + pCS->dwResultClauseOffset,
-                      pCS->dwResultClauseLen);
-        dwCurrentOffset += ALIGN_DWORD(pCS->dwResultClauseLen);
+        pDet->uDetermineDelimPos = ib;
+        RtlCopyMemory(pbDet + ib, pbCS + pCS->dwResultClauseOffset, pCS->dwResultClauseLen);
+
+        ib += ALIGN_DWORD(pCS->dwResultClauseLen);
     }
 
-    if ((dwGCS & GCS_RESULTREADSTR) && (pCS->dwResultReadStrLen > 0))
+    if (dwGCS & GCS_RESULTREADSTR)
     {
-        pDet->uYomiTextPos = dwCurrentOffset;
+        pDet->uYomiTextPos = ib;
         pDet->uYomiTextLen = pCS->dwResultReadStrLen;
-        RtlCopyMemory(pBase + dwCurrentOffset, pSrcBase + pCS->dwResultReadStrOffset,
-                      pCS->dwResultReadStrLen);
-        pBase[dwCurrentOffset + pCS->dwResultReadStrLen] = ANSI_NULL;
-        dwCurrentOffset += ALIGN_DWORD(pCS->dwResultReadStrLen + 1);
+        RtlCopyMemory(pbDet + ib, pbCS + pCS->dwResultReadStrOffset, pCS->dwResultReadStrLen);
+        pbDet[ib + pCS->dwResultReadStrLen] = ANSI_NULL;
+
+        ib += ALIGN_DWORD(pCS->dwResultReadStrLen + 1);
     }
 
-    if ((dwGCS & GCS_RESULTREADCLAUSE) && (pCS->dwResultReadClauseLen > 0))
+    if ((dwGCS & GCS_RESULTREADCLAUSE) && pCS->dwResultReadClauseLen)
     {
-        pDet->uYomiDelimPos = dwCurrentOffset;
-        RtlCopyMemory(pBase + dwCurrentOffset, pSrcBase + pCS->dwResultReadClauseOffset,
-                      pCS->dwResultReadClauseLen);
-        dwCurrentOffset += ALIGN_DWORD(pCS->dwResultReadClauseLen);
+        pDet->uYomiDelimPos = ib;
+        RtlCopyMemory(pbDet + ib, pbCS + pCS->dwResultReadClauseOffset, pCS->dwResultReadClauseLen);
+
+        //ib += ALIGN_DWORD(pCS->dwResultReadClauseLen); // The last one (ineffective)
     }
 
     return dwSize;
@@ -544,144 +540,128 @@ Imm32CompStrAToUndetW(
     PUNDETERMINESTRUCT pUndet,
     DWORD dwSize)
 {
-    const DWORD dwRequiredSize =
+    const DWORD cbRequired =
         sizeof(UNDETERMINESTRUCT) +
         ALIGN_DWORD(pCS->dwResultClauseLen) +
         ALIGN_DWORD(pCS->dwCompAttrLen) +
-        ALIGN_DWORD(pCS->dwResultStrLen * sizeof(WCHAR) + sizeof(UNICODE_NULL)) +
-        ALIGN_DWORD(pCS->dwCompStrLen * sizeof(WCHAR) + sizeof(UNICODE_NULL)) +
-        ALIGN_DWORD(pCS->dwResultReadStrLen * sizeof(WCHAR) + sizeof(UNICODE_NULL)) +
+        ALIGN_WSTR_SIZE(pCS->dwResultStrLen) +
+        ALIGN_WSTR_SIZE(pCS->dwCompStrLen) +
+        ALIGN_WSTR_SIZE(pCS->dwResultReadStrLen) +
         ALIGN_DWORD(pCS->dwResultReadClauseLen);
 
     if (!pUndet)
-        return dwRequiredSize;
+        return cbRequired;
 
-    if (dwSize < dwRequiredSize)
+    if (dwSize < cbRequired)
         return 0;
 
-    RtlZeroMemory(pUndet, sizeof(UNDETERMINESTRUCT));
     pUndet->dwSize = dwSize;
 
-    DWORD dwCurrentOffset = sizeof(UNDETERMINESTRUCT);
-    PBYTE pBase = (PBYTE)pUndet;
-    const BYTE* pSrcBase = (const BYTE*)pCS;
+    DWORD ib = sizeof(UNDETERMINESTRUCT);
+    PBYTE pbUndet = (PBYTE)pUndet;
+    const BYTE* pbCS = (const BYTE*)pCS;
+    PCSTR pCompStrA = (PCSTR)(pbCS + pCS->dwCompStrOffset);
+    PCSTR pResultStr = (PCSTR)(pbCS + pCS->dwResultStrOffset);
+    PCSTR pResultReadStr = (PCSTR)(pbCS + pCS->dwResultReadStrOffset);
 
-    if ((dwGCS & GCS_COMPSTR) && (pCS->dwCompStrLen > 0))
+    if (dwGCS & GCS_COMPSTR)
     {
-        INT nWideLen = MultiByteToWideChar(CP_ACP, 0,
-            (PCSTR)(pSrcBase + pCS->dwCompStrOffset), pCS->dwCompStrLen,
-            (PWSTR)(pBase + dwCurrentOffset), (dwSize - dwCurrentOffset) / sizeof(WCHAR));
+        INT nWideLen = Imm32AnsiToWide(pCompStrA, pCS->dwCompStrLen,
+                                       (PWSTR)(pbUndet + ib), (dwSize - ib) / sizeof(WCHAR));
         if (nWideLen <= 0)
             return 0;
-        pUndet->uUndetTextPos = dwCurrentOffset;
+
+        pUndet->uUndetTextPos = ib;
         pUndet->uUndetTextLen = nWideLen;
-        ((PWCHAR)(pBase + dwCurrentOffset))[nWideLen] = UNICODE_NULL;
-        dwCurrentOffset += ALIGN_DWORD((nWideLen + 1) * sizeof(WCHAR));
-    }
 
-    if ((dwGCS & GCS_COMPATTR) && pCS->dwCompAttrLen > 0 && (pUndet->uUndetTextLen > 0))
-    {
-        pUndet->uUndetAttrPos = dwCurrentOffset;
-        const BYTE* pSrcAttr = pSrcBase + pCS->dwCompAttrOffset;
-        PBYTE pDestAttr = pBase + dwCurrentOffset;
-        PCWSTR pWStr = (PCWSTR)(pBase + pUndet->uUndetTextPos);
+        ib += ALIGN_DWORD((nWideLen + 1) * sizeof(WCHAR));
 
-        for (UINT i = 0; i < pUndet->uUndetTextLen; i++)
+        if ((dwGCS & GCS_COMPATTR) || pCS->dwCompAttrLen)
         {
-            pDestAttr[i] = *pSrcAttr;
-            USHORT wChar = pWStr[i];
-            ULONG cbMultiByte = 0;
-            RtlUnicodeToMultiByteSize(&cbMultiByte, &wChar, sizeof(WCHAR));
-            pSrcAttr += (cbMultiByte == 2) ? 2 : 1;
-        }
+            pUndet->uUndetAttrPos = ib;
+            const BYTE* pSrcAttr = pbCS + pCS->dwCompAttrOffset;
+            PBYTE pDestAttr = pbUndet + ib;
+            PCWSTR pWStr = (PCWSTR)(pbUndet + pUndet->uUndetTextPos);
 
-        dwCurrentOffset += ALIGN_DWORD(pUndet->uUndetTextLen);
+            for (UINT i = 0; i < pUndet->uUndetTextLen; ++i)
+            {
+                pDestAttr[i] = *pSrcAttr;
+                USHORT wChar = pWStr[i];
+                ULONG cbMultiByte = 0;
+                RtlUnicodeToMultiByteSize(&cbMultiByte, &wChar, sizeof(WCHAR));
+                pSrcAttr += (cbMultiByte == 2) ? 2 : 1;
+            }
+
+            ib += ALIGN_DWORD(pUndet->uUndetTextLen);
+        }
     }
 
     if (dwGCS & GCS_CURSORPOS)
     {
         if (pCS->dwCursorPos == (DWORD)-1)
-        {
             pUndet->uCursorPos = (UINT)-1;
-        }
         else
-        {
-            pUndet->uCursorPos = IchWideFromAnsi(
-                pCS->dwCursorPos, (PCSTR)(pSrcBase + pCS->dwCompStrOffset), CP_ACP);
-        }
+            pUndet->uCursorPos = IchWideFromAnsi(pCS->dwCursorPos, pCompStrA, CP_ACP);
     }
 
     if (dwGCS & GCS_DELTASTART)
     {
         if (pCS->dwDeltaStart == (DWORD)-1)
-        {
             pUndet->uDeltaStart = (UINT)-1;
-        }
         else
-        {
-            pUndet->uDeltaStart = IchWideFromAnsi(
-                pCS->dwDeltaStart, (PCSTR)(pSrcBase + pCS->dwCompStrOffset), CP_ACP);
-        }
+            pUndet->uDeltaStart = IchWideFromAnsi(pCS->dwDeltaStart, pCompStrA, CP_ACP);
     }
 
     if (dwGCS & GCS_RESULTSTR)
     {
-        INT nWideLen = MultiByteToWideChar(CP_ACP, 0,
-            (PCSTR)(pSrcBase + pCS->dwResultStrOffset), pCS->dwResultStrLen,
-            (PWSTR)(pBase + dwCurrentOffset), (dwSize - dwCurrentOffset) / sizeof(WCHAR));
+        INT nWideLen = Imm32AnsiToWide(pResultStr, pCS->dwResultStrLen,
+                                       (PWSTR)(pbUndet + ib), (dwSize - ib) / sizeof(WCHAR));
         if (nWideLen > 0)
         {
-            pUndet->uDetermineTextPos = dwCurrentOffset;
+            pUndet->uDetermineTextPos = ib;
             pUndet->uDetermineTextLen = nWideLen;
-            ((PWSTR)(pBase + dwCurrentOffset))[nWideLen] = UNICODE_NULL;
-            dwCurrentOffset += ALIGN_DWORD((nWideLen + 1) * sizeof(WCHAR));
-        }
-    }
 
-    if ((dwGCS & GCS_RESULTCLAUSE) && (pCS->dwResultClauseLen > 0) &&
-        (pUndet->uDetermineTextLen > 0))
-    {
-        pUndet->uDetermineDelimPos = dwCurrentOffset;
-        PDWORD pSrcClause = (PDWORD)(pSrcBase + pCS->dwResultClauseOffset);
-        PDWORD pDestClause = (PDWORD)(pBase + dwCurrentOffset);
-        DWORD nClauses = pCS->dwResultClauseLen / sizeof(DWORD);
+            ib += ALIGN_DWORD((nWideLen + 1) * sizeof(WCHAR));
 
-        for (DWORD i = 0; i < nClauses; i++)
-        {
-            pDestClause[i] = IchWideFromAnsi(pSrcClause[i],
-                (PCSTR)(pSrcBase + pCS->dwResultStrOffset), CP_ACP);
+            if ((dwGCS & GCS_RESULTCLAUSE) && pCS->dwResultClauseLen)
+            {
+                pUndet->uDetermineDelimPos = ib;
+                PDWORD pSrcClause = (PDWORD)(pbCS + pCS->dwResultClauseOffset);
+                PDWORD pDestClause = (PDWORD)(pbUndet + ib);
+                DWORD nClauses = pCS->dwResultClauseLen / sizeof(DWORD);
+
+                for (DWORD i = 0; i < nClauses; i++)
+                    pDestClause[i] = IchWideFromAnsi(pSrcClause[i], pResultStr, CP_ACP);
+
+                ib += ALIGN_DWORD(pCS->dwResultClauseLen);
+            }
         }
-        dwCurrentOffset += ALIGN_DWORD(pCS->dwResultClauseLen);
     }
 
     if (dwGCS & GCS_RESULTREADSTR)
     {
-        INT nWideLen = MultiByteToWideChar(CP_ACP, 0,
-            (PCSTR)(pSrcBase + pCS->dwResultReadStrOffset), pCS->dwResultReadStrLen,
-            (PWSTR)(pBase + dwCurrentOffset), (dwSize - dwCurrentOffset) / sizeof(WCHAR));
+        INT nWideLen = Imm32AnsiToWide(pResultReadStr, pCS->dwResultReadStrLen,
+                                       (PWSTR)(pbUndet + ib), (dwSize - ib) / sizeof(WCHAR));
         if (nWideLen > 0)
         {
-            pUndet->uYomiTextPos = dwCurrentOffset;
+            pUndet->uYomiTextPos = ib;
             pUndet->uYomiTextLen = nWideLen;
-            ((PWSTR)(pBase + dwCurrentOffset))[nWideLen] = UNICODE_NULL;
-            dwCurrentOffset += ALIGN_DWORD((nWideLen + 1) * sizeof(WCHAR));
-        }
-    }
 
-    if ((dwGCS & GCS_RESULTREADCLAUSE) && (pCS->dwResultReadClauseLen > 0) &&
-        (pUndet->uYomiTextLen > 0))
-    {
-        pUndet->uYomiDelimPos = dwCurrentOffset;
-        PDWORD pSrcClause = (PDWORD)(pSrcBase + pCS->dwResultReadClauseOffset);
-        PDWORD pDestClause = (PDWORD)(pBase + dwCurrentOffset);
-        DWORD nClauses = pCS->dwResultReadClauseLen / sizeof(DWORD);
+            ib += ALIGN_DWORD((nWideLen + 1) * sizeof(WCHAR));
 
-        for (DWORD i = 0; i < nClauses; i++)
-        {
-            pDestClause[i] = IchWideFromAnsi(pSrcClause[i],
-                (PCSTR)(pSrcBase + pCS->dwResultReadStrOffset), CP_ACP);
+            if ((dwGCS & GCS_RESULTREADCLAUSE) && pCS->dwResultReadClauseLen)
+            {
+                pUndet->uYomiDelimPos = ib;
+                PDWORD pSrcClause = (PDWORD)(pbCS + pCS->dwResultReadClauseOffset);
+                PDWORD pDestClause = (PDWORD)(pbUndet + ib);
+                DWORD nClauses = pCS->dwResultReadClauseLen / sizeof(DWORD);
+
+                for (DWORD i = 0; i < nClauses; i++)
+                    pDestClause[i] = IchWideFromAnsi(pSrcClause[i], pResultReadStr, CP_ACP);
+
+                //ib += ALIGN_DWORD(pCS->dwResultReadClauseLen); // The last one (ineffective)
+            }
         }
-        dwCurrentOffset += ALIGN_DWORD(pCS->dwResultReadClauseLen);
     }
 
     return dwSize;
@@ -694,58 +674,55 @@ Imm32CompStrAToStringExA(
     LPSTRINGEXSTRUCT pSX,
     DWORD dwSize)
 {
-    DWORD dwRequiredSize =
+    DWORD cbRequired =
         sizeof(STRINGEXSTRUCT) +
-        ALIGN_DWORD(pCS->dwResultStrLen + 1) +
+        ALIGN_DWORD(pCS->dwResultStrLen + sizeof(ANSI_NULL)) +
         ALIGN_DWORD(pCS->dwResultClauseLen) +
-        ALIGN_DWORD(pCS->dwResultReadStrLen + 1) +
+        ALIGN_DWORD(pCS->dwResultReadStrLen + sizeof(ANSI_NULL)) +
         ALIGN_DWORD(pCS->dwResultReadClauseLen);
 
     if (!pSX)
-        return dwRequiredSize;
+        return cbRequired;
 
-    if (dwSize < dwRequiredSize)
+    if (dwSize < cbRequired)
         return 0;
 
-    RtlZeroMemory(pSX, sizeof(STRINGEXSTRUCT));
     pSX->dwSize = dwSize;
 
-    DWORD dwCurrentOffset = sizeof(STRINGEXSTRUCT);
-    PBYTE pBase = (PBYTE)pSX;
-    const BYTE* pSrcBase = (const BYTE*)pCS;
+    DWORD ib = sizeof(STRINGEXSTRUCT);
+    PBYTE pbSX = (PBYTE)pSX;
+    const BYTE* pbCS = (const BYTE*)pCS;
 
-    if (pCS->dwResultStrLen > 0)
     {
-        pSX->uDeterminePos = dwCurrentOffset;
-        RtlCopyMemory(pBase + dwCurrentOffset, pSrcBase + pCS->dwResultStrOffset,
-                      pCS->dwResultStrLen);
-        pBase[dwCurrentOffset + pCS->dwResultStrLen] = ANSI_NULL;
-        dwCurrentOffset += ALIGN_DWORD(pCS->dwResultStrLen + 1);
+        pSX->uDeterminePos = ib;
+        RtlCopyMemory(pbSX + ib, pbCS + pCS->dwResultStrOffset, pCS->dwResultStrLen);
+        pbSX[ib + pCS->dwResultStrLen] = ANSI_NULL;
+
+        ib += ALIGN_DWORD(pCS->dwResultStrLen + 1);
     }
 
-    if ((dwGCS & GCS_RESULTCLAUSE) && pCS->dwResultClauseLen > 0)
+    if ((dwGCS & GCS_RESULTCLAUSE) && pCS->dwResultClauseLen)
     {
-        pSX->uDetermineDelimPos = dwCurrentOffset;
-        RtlCopyMemory(pBase + dwCurrentOffset, pSrcBase + pCS->dwResultClauseOffset,
-                      pCS->dwResultClauseLen);
-        dwCurrentOffset += ALIGN_DWORD(pCS->dwResultClauseLen);
+        pSX->uDetermineDelimPos = ib;
+        RtlCopyMemory(pbSX + ib, pbCS + pCS->dwResultClauseOffset, pCS->dwResultClauseLen);
+
+        ib += ALIGN_DWORD(pCS->dwResultClauseLen);
     }
 
-    if (pCS->dwResultReadStrLen > 0)
     {
-        pSX->uYomiPos = dwCurrentOffset;
-        RtlCopyMemory(pBase + dwCurrentOffset, pSrcBase + pCS->dwResultReadStrOffset,
-                      pCS->dwResultReadStrLen);
-        pBase[dwCurrentOffset + pCS->dwResultReadStrLen] = ANSI_NULL;
-        dwCurrentOffset += ALIGN_DWORD(pCS->dwResultReadStrLen + 1);
+        pSX->uYomiPos = ib;
+        RtlCopyMemory(pbSX + ib, pbCS + pCS->dwResultReadStrOffset, pCS->dwResultReadStrLen);
+        pbSX[ib + pCS->dwResultReadStrLen] = ANSI_NULL;
+
+        ib += ALIGN_DWORD(pCS->dwResultReadStrLen + 1);
     }
 
-    if ((dwGCS & GCS_RESULTREADCLAUSE) && pCS->dwResultReadClauseLen > 0)
+    if ((dwGCS & GCS_RESULTREADCLAUSE) && pCS->dwResultReadClauseLen)
     {
-        pSX->uYomiDelimPos = dwCurrentOffset;
-        RtlCopyMemory(pBase + dwCurrentOffset, pSrcBase + pCS->dwResultReadClauseOffset,
-                      pCS->dwResultReadClauseLen);
-        dwCurrentOffset += ALIGN_DWORD(pCS->dwResultReadClauseLen);
+        pSX->uYomiDelimPos = ib;
+        RtlCopyMemory(pbSX + ib, pbCS + pCS->dwResultReadClauseOffset, pCS->dwResultReadClauseLen);
+
+        //ib += ALIGN_DWORD(pCS->dwResultReadClauseLen); // The last one (ineffective)
     }
 
     return dwSize;
@@ -758,78 +735,74 @@ Imm32CompStrAToStringExW(
     LPSTRINGEXSTRUCT pSX,
     DWORD dwSize)
 {
-    const DWORD dwRequiredSize =
+    const DWORD cbRequired =
         sizeof(STRINGEXSTRUCT) +
-        ALIGN_DWORD(pCS->dwResultStrLen * sizeof(WCHAR) + sizeof(UNICODE_NULL)) +
+        ALIGN_WSTR_SIZE(pCS->dwResultStrLen) +
         ALIGN_DWORD(pCS->dwResultClauseLen) +
-        ALIGN_DWORD(pCS->dwResultReadStrLen * sizeof(WCHAR) + sizeof(UNICODE_NULL)) +
+        ALIGN_WSTR_SIZE(pCS->dwResultReadStrLen) +
         ALIGN_DWORD(pCS->dwResultReadClauseLen);
 
     if (pSX == NULL)
-        return dwRequiredSize;
+        return cbRequired;
 
-    if (dwSize < dwRequiredSize)
+    if (dwSize < cbRequired)
         return 0;
 
-    RtlZeroMemory(pSX, sizeof(STRINGEXSTRUCT));
     pSX->dwSize = dwSize;
 
-    DWORD dwCurrentOffset = sizeof(STRINGEXSTRUCT);
-    PBYTE pBase = (PBYTE)pSX;
-    const BYTE* pSrcBase = (const BYTE*)pCS;
+    DWORD ib = sizeof(STRINGEXSTRUCT);
+    PBYTE pbSX = (PBYTE)pSX;
+    const BYTE* pbCS = (const BYTE*)pCS;
+    PCSTR pResultStr = (PCSTR)(pbCS + pCS->dwResultStrOffset);
+    PCSTR pResultReadStr = (PCSTR)(pbCS + pCS->dwResultReadStrOffset);
 
-    INT nWideResultLen = 0, nWideReadLen = 0;
-
-    if (pCS->dwResultStrLen > 0)
+    if (pCS->dwResultStrLen)
     {
-        pSX->uDeterminePos = dwCurrentOffset;
-        nWideResultLen = MultiByteToWideChar(CP_ACP, 0,
-            (PCSTR)(pSrcBase + pCS->dwResultStrOffset), pCS->dwResultStrLen,
-            (PWSTR)(pBase + dwCurrentOffset), (dwSize - dwCurrentOffset) / sizeof(WCHAR));
+        pSX->uDeterminePos = ib;
+        INT nWideResultLen = Imm32AnsiToWide(pResultStr, pCS->dwResultStrLen,
+                                             (PWSTR)(pbSX + ib), (dwSize - ib) / sizeof(WCHAR));
         if (nWideResultLen <= 0)
             return 0;
-        ((PWSTR)(pBase + dwCurrentOffset))[nWideResultLen] = UNICODE_NULL;
-        dwCurrentOffset += ALIGN_DWORD((nWideResultLen + 1) * sizeof(WCHAR));
-    }
 
-    if ((dwGCS & GCS_RESULTCLAUSE) && pCS->dwResultClauseLen > 0 && nWideResultLen > 0)
-    {
-        pSX->uDetermineDelimPos = dwCurrentOffset;
-        const DWORD* pSrcClause = (const DWORD*)(pSrcBase + pCS->dwResultClauseOffset);
-        PDWORD pDestClause = (PDWORD)(pBase + dwCurrentOffset);
-        DWORD nClauses = pCS->dwResultClauseLen / sizeof(DWORD);
+        ib += ALIGN_DWORD((nWideResultLen + 1) * sizeof(WCHAR));
 
-        for (DWORD i = 0; i < nClauses; i++)
+        if ((dwGCS & GCS_RESULTCLAUSE) && pCS->dwResultClauseLen)
         {
-            pDestClause[i] = IchWideFromAnsi(pSrcClause[i],
-                (PCSTR)(pSrcBase + pCS->dwResultStrOffset), CP_ACP);
+            pSX->uDetermineDelimPos = ib;
+            const DWORD* pSrcClause = (const DWORD*)(pbCS + pCS->dwResultClauseOffset);
+            PDWORD pDestClause = (PDWORD)(pbSX + ib);
+            DWORD nClauses = pCS->dwResultClauseLen / sizeof(DWORD);
+
+            for (DWORD i = 0; i < nClauses; i++)
+            {
+                pDestClause[i] = IchWideFromAnsi(pSrcClause[i],
+                    (PCSTR)(pbCS + pCS->dwResultStrOffset), CP_ACP);
+            }
+
+            ib += ALIGN_DWORD(pCS->dwResultClauseLen);
         }
-        dwCurrentOffset += ALIGN_DWORD(pCS->dwResultClauseLen);
     }
 
-    if (pCS->dwResultReadStrLen > 0)
+    if (pCS->dwResultReadStrLen)
     {
-        pSX->uYomiPos = dwCurrentOffset;
-        nWideReadLen = MultiByteToWideChar(CP_ACP, 0,
-            (PCSTR)(pSrcBase + pCS->dwResultReadStrOffset), pCS->dwResultReadStrLen,
-            (PWSTR)(pBase + dwCurrentOffset), (dwSize - dwCurrentOffset) / sizeof(WCHAR));
+        pSX->uYomiPos = ib;
+        INT nWideReadLen = Imm32AnsiToWide(pResultReadStr, pCS->dwResultReadStrLen,
+                                           (PWSTR)(pbSX + ib), (dwSize - ib) / sizeof(WCHAR));
         if (nWideReadLen <= 0)
             return 0;
 
-        ((PWSTR)(pBase + dwCurrentOffset))[nWideReadLen] = UNICODE_NULL;
-        dwCurrentOffset += ALIGN_DWORD((nWideReadLen + 1) * sizeof(WCHAR));
-    }
+        ib += ALIGN_DWORD((nWideReadLen + 1) * sizeof(WCHAR));
 
-    if ((dwGCS & GCS_RESULTREADCLAUSE) && pCS->dwResultReadClauseLen > 0 && nWideReadLen > 0)
-    {
-        pSX->uYomiDelimPos = dwCurrentOffset;
-        const DWORD* pSrcClause = (const DWORD*)(pSrcBase + pCS->dwResultReadClauseOffset);
-        PDWORD pDestClause = (PDWORD)(pBase + dwCurrentOffset);
-        DWORD nClauses = pCS->dwResultReadClauseLen / sizeof(DWORD);
-        for (DWORD i = 0; i < nClauses; i++)
+        if ((dwGCS & GCS_RESULTREADCLAUSE) && pCS->dwResultReadClauseLen)
         {
-            pDestClause[i] = IchWideFromAnsi(pSrcClause[i],
-                (PCSTR)(pSrcBase + pCS->dwResultReadStrOffset), CP_ACP);
+            pSX->uYomiDelimPos = ib;
+            const DWORD* pSrcClause = (const DWORD*)(pbCS + pCS->dwResultReadClauseOffset);
+            PDWORD pDestClause = (PDWORD)(pbSX + ib);
+            DWORD nClauses = pCS->dwResultReadClauseLen / sizeof(DWORD);
+            for (DWORD i = 0; i < nClauses; i++)
+                pDestClause[i] = IchWideFromAnsi(pSrcClause[i], pResultReadStr, CP_ACP);
+
+            //ib += ALIGN_DWORD(pCS->dwResultReadClauseLen); // The last one (ineffective)
         }
     }
 
@@ -851,15 +824,13 @@ static DWORD Imm32CompStrAToStringA(const COMPOSITIONSTRING *pCS, PSTR pszString
 static DWORD Imm32CompStrAToStringW(const COMPOSITIONSTRING *pCS, PWSTR pszString, DWORD dwSize)
 {
     PCSTR pch = (PCSTR)pCS + pCS->dwResultStrOffset;
-    INT cchWide = MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, pch, pCS->dwResultStrLen,
-                                      pszString, 0);
+    INT cchWide = Imm32AnsiToWide(pch, pCS->dwResultStrLen, pszString, 0);
     DWORD dwResultStrLen = (cchWide + 1) * sizeof(WCHAR);
     if (!pszString)
         return dwResultStrLen;
     if (dwSize < dwResultStrLen)
         return 0;
-    INT cch = MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, pch, pCS->dwResultStrLen,
-                                  pszString, cchWide);
+    INT cch = Imm32AnsiToWide(pch, pCS->dwResultStrLen, pszString, cchWide);
     if (cch < cchWide)
         return 0;
     pszString[cch] = UNICODE_NULL;
@@ -876,7 +847,7 @@ static VOID Imm32CompStrAToCharA(HWND hWnd, const COMPOSITIONSTRING *pCS)
 
     PostMessageA(hWnd, WM_IME_REPORT, IR_STRINGSTART, 0);
 
-    if (*pch == ANSI_NULL)
+    if (!*pch)
     {
         PostMessageA(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
         return;
@@ -888,7 +859,7 @@ static VOID Imm32CompStrAToCharA(HWND hWnd, const COMPOSITIONSTRING *pCS)
         BYTE bFirst = (BYTE)(*pch);
         pNext = CharNextA(pch);
 
-        if (*pNext == ANSI_NULL)
+        if (!*pNext)
             PostMessageA(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
 
         if (!IsDBCSLeadByte(bFirst))
@@ -922,18 +893,18 @@ static VOID Imm32CompStrAToCharW(HWND hWnd, const COMPOSITIONSTRING *pCS)
         BYTE bTestChar = *pCurrent;
         PCHAR pNext = CharNextA(pCurrent);
 
-        if (*pNext == ANSI_NULL)
+        if (!*pNext)
             PostMessageW(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
 
-        WCHAR wCharBuffer = UNICODE_NULL;
+        WCHAR szWide[2] = L"";
         INT nConverted = 0;
         if (IsDBCSLeadByte(bTestChar))
-            nConverted = MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, pCurrent, 2, &wCharBuffer, 1);
+            nConverted = Imm32AnsiToWide(pCurrent, 2, szWide, _countof(szWide));
         else
-            nConverted = MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, pCurrent, 1, &wCharBuffer, 1);
+            nConverted = Imm32AnsiToWide(pCurrent, 1, szWide, _countof(szWide));
 
         if (nConverted > 0)
-            PostMessageW(hWnd, WM_CHAR, wCharBuffer, 1);
+            PostMessageW(hWnd, WM_CHAR, szWide[0], 1);
 
         pCurrent = pNext;
     }
@@ -941,7 +912,7 @@ static VOID Imm32CompStrAToCharW(HWND hWnd, const COMPOSITIONSTRING *pCS)
 
 static VOID Imm32CompStrWToCharA(HWND hWnd, const COMPOSITIONSTRING *pCS)
 {
-    PCWSTR pCurrent = (PCWSTR)((const BYTE *)pCS + pCS->dwResultStrOffset);
+    PCWSTR pCurrent = (PCWSTR)((const BYTE*)pCS + pCS->dwResultStrOffset);
 
     BOOL bSupportDBCSReport = FALSE;
     if (GetWin32ClientInfo()->dwExpWinVer >= 0x30A)
@@ -950,15 +921,14 @@ static VOID Imm32CompStrWToCharA(HWND hWnd, const COMPOSITIONSTRING *pCS)
     PostMessageA(hWnd, WM_IME_REPORT, IR_STRINGSTART, 0);
 
     PCWSTR pNext;
-    for (; *pCurrent != UNICODE_NULL; pCurrent = pNext)
+    for (; *pCurrent; pCurrent = pNext)
     {
         pNext = CharNextW(pCurrent);
         if (!*pNext)
             PostMessageA(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
 
         CHAR szAnsi[3] = {0};
-        BOOL bUsedDef = FALSE;
-        if (!WideCharToMultiByte(CP_ACP, 0, pCurrent, 1, szAnsi, sizeof(szAnsi), NULL, &bUsedDef))
+        if (!Imm32WideToAnsi(pCurrent, 1, szAnsi, _countof(szAnsi)))
             continue;
 
         if (!IsDBCSLeadByte(szAnsi[0]))
@@ -982,7 +952,7 @@ static VOID Imm32CompStrWToCharA(HWND hWnd, const COMPOSITIONSTRING *pCS)
 
 static VOID Imm32CompStrWToCharW(HWND hWnd, const COMPOSITIONSTRING *pCS)
 {
-    PCWSTR pCurrent = (PCWSTR )((const BYTE *)pCS + pCS->dwResultStrOffset);
+    PCWSTR pCurrent = (PCWSTR)((const BYTE*)pCS + pCS->dwResultStrOffset);
 
     PostMessageW(hWnd, WM_IME_REPORT, IR_STRINGSTART, 0);
 
@@ -998,7 +968,7 @@ static VOID Imm32CompStrWToCharW(HWND hWnd, const COMPOSITIONSTRING *pCS)
     }
 }
 
-static DWORD
+static INT
 Imm32JTransCompositionA(
     const INPUTCONTEXTDX *pIC,
     const COMPOSITIONSTRING *pCS,
@@ -1011,31 +981,31 @@ Imm32JTransCompositionA(
 
     BOOL bIsUnicodeWnd = IsWindowUnicode(hWnd);
     DWORD dwGCS = (DWORD)pCurrent->lParam;
-    int msgCount = 0;
+    INT cMessages = 0;
     BOOL bUndeterminedProcessed = FALSE;
     BOOL bResultProcessed = FALSE;
-    HGLOBAL hGlobal = NULL;
-    DWORD dataSize = 0;
+    HGLOBAL hUndet = NULL;
+    DWORD cbUndet = 0;
 
     if (pIC->dwUIFlags & _IME_UI_HIDDEN)
     {
         if (!bIsUnicodeWnd)
         {
-            dataSize = Imm32CompStrAToUndetA(dwGCS, pCS, NULL, 0);
-            if (dataSize)
+            cbUndet = Imm32CompStrAToUndetA(dwGCS, pCS, NULL, 0);
+            if (cbUndet)
             {
-                hGlobal = GlobalAlloc(GHND, dataSize);
-                if (hGlobal)
+                hUndet = GlobalAlloc(GHND | GMEM_SHARE, cbUndet);
+                if (hUndet)
                 {
-                    PUNDETERMINESTRUCT pUndet = GlobalLock(hGlobal);
+                    PUNDETERMINESTRUCT pUndet = GlobalLock(hUndet);
                     if (pUndet)
                     {
-                        dataSize = Imm32CompStrAToUndetA(dwGCS, pCS, pUndet, dataSize);
-                        GlobalUnlock(hGlobal);
-                        if (dataSize)
+                        cbUndet = Imm32CompStrAToUndetA(dwGCS, pCS, pUndet, cbUndet);
+                        GlobalUnlock(hUndet);
+                        if (cbUndet)
                         {
                             if (SendMessageA(hWnd, WM_IME_REPORT, IR_UNDETERMINE,
-                                             (LPARAM)hGlobal) == 0)
+                                             (LPARAM)hUndet) == 0)
                             {
                                 bUndeterminedProcessed = TRUE;
                             }
@@ -1046,21 +1016,21 @@ Imm32JTransCompositionA(
         }
         else
         {
-            dataSize = Imm32CompStrAToUndetW(dwGCS, pCS, NULL, 0);
-            if (dataSize)
+            cbUndet = Imm32CompStrAToUndetW(dwGCS, pCS, NULL, 0);
+            if (cbUndet)
             {
-                hGlobal = GlobalAlloc(GHND, dataSize);
-                if (hGlobal)
+                hUndet = GlobalAlloc(GHND | GMEM_SHARE, cbUndet);
+                if (hUndet)
                 {
-                    PUNDETERMINESTRUCT pUndet = GlobalLock(hGlobal);
+                    PUNDETERMINESTRUCT pUndet = GlobalLock(hUndet);
                     if (pUndet)
                     {
-                        dataSize = Imm32CompStrAToUndetW(dwGCS, pCS, pUndet, dataSize);
-                        GlobalUnlock(hGlobal);
-                        if (dataSize)
+                        cbUndet = Imm32CompStrAToUndetW(dwGCS, pCS, pUndet, cbUndet);
+                        GlobalUnlock(hUndet);
+                        if (cbUndet)
                         {
                             if (SendMessageW(hWnd, WM_IME_REPORT, IR_UNDETERMINE,
-                                             (LPARAM)hGlobal) == 0)
+                                             (LPARAM)hUndet) == 0)
                             {
                                 bUndeterminedProcessed = TRUE;
                             }
@@ -1070,8 +1040,8 @@ Imm32JTransCompositionA(
             }
         }
 
-        if (hGlobal)
-            GlobalFree(hGlobal);
+        if (hUndet)
+            GlobalFree(hUndet);
         if (bUndeterminedProcessed)
             return 0;
     }
@@ -1090,7 +1060,7 @@ Imm32JTransCompositionA(
                                    : Imm32CompStrAToStringExA(dwGCS, pCS, NULL, 0);
             if (exSize)
             {
-                hEx = GlobalAlloc(GHND, exSize);
+                hEx = GlobalAlloc(GHND | GMEM_SHARE, exSize);
                 if (hEx)
                 {
                     pEx = GlobalLock(hEx);
@@ -1121,7 +1091,7 @@ Imm32JTransCompositionA(
         strSize = bIsUnicodeWnd ? Imm32CompStrAToStringW(pCS, NULL, 0) : (pCS->dwResultStrLen + 1);
         if (strSize && strSize != (DWORD)-1)
         {
-            hStr = GlobalAlloc(GHND, strSize);
+            hStr = GlobalAlloc(GHND | GMEM_SHARE, strSize);
             if (hStr)
             {
                 pStr = GlobalLock(hStr);
@@ -1168,20 +1138,20 @@ FINALIZE:
                 pEntries->lParam =
                     dwGCS & ~(GCS_RESULTCLAUSE | GCS_RESULTSTR | GCS_RESULTREADCLAUSE |
                               GCS_RESULTREADSTR);
-                msgCount = 1;
+                cMessages = 1;
             }
         }
         else
         {
             *pEntries = *pCurrent;
-            msgCount = 1;
+            cMessages = 1;
         }
     }
 
-    return msgCount;
+    return cMessages;
 }
 
-static DWORD
+static INT
 Imm32JTransCompositionW(
     const INPUTCONTEXTDX *pIC,
     const COMPOSITIONSTRING *pCS,
@@ -1194,32 +1164,32 @@ Imm32JTransCompositionW(
 
     BOOL bIsUnicodeWnd = IsWindowUnicode(hWnd);
     DWORD dwGCS = (DWORD)pCurrent->lParam;
-    int msgCount = 0;
+    INT cMessages = 0;
     BOOL bUndeterminedProcessed = FALSE;
     BOOL bResultProcessed = FALSE;
 
     if (pIC->dwUIFlags & _IME_UI_HIDDEN)
     {
-        HGLOBAL hGlobal = NULL;
-        DWORD dataSize = 0;
+        HGLOBAL hUndet = NULL;
+        DWORD cbUndet = 0;
 
         if (!bIsUnicodeWnd)
         {
-            dataSize = Imm32CompStrWToUndetA(dwGCS, pCS, NULL, 0);
-            if (dataSize)
+            cbUndet = Imm32CompStrWToUndetA(dwGCS, pCS, NULL, 0);
+            if (cbUndet)
             {
-                hGlobal = GlobalAlloc(GHND, dataSize);
-                if (hGlobal)
+                hUndet = GlobalAlloc(GHND | GMEM_SHARE, cbUndet);
+                if (hUndet)
                 {
-                    PUNDETERMINESTRUCT pUndet = GlobalLock(hGlobal);
+                    PUNDETERMINESTRUCT pUndet = GlobalLock(hUndet);
                     if (pUndet)
                     {
-                        dataSize = Imm32CompStrWToUndetA(dwGCS, pCS, pUndet, dataSize);
-                        GlobalUnlock(hGlobal);
-                        if (dataSize)
+                        cbUndet = Imm32CompStrWToUndetA(dwGCS, pCS, pUndet, cbUndet);
+                        GlobalUnlock(hUndet);
+                        if (cbUndet)
                         {
                             if (SendMessageA(hWnd, WM_IME_REPORT, IR_UNDETERMINE,
-                                             (LPARAM)hGlobal) == 0)
+                                             (LPARAM)hUndet) == 0)
                             {
                                 bUndeterminedProcessed = TRUE;
                             }
@@ -1230,21 +1200,21 @@ Imm32JTransCompositionW(
         }
         else
         {
-            dataSize = Imm32CompStrWToUndetW(dwGCS, pCS, NULL, 0);
-            if (dataSize)
+            cbUndet = Imm32CompStrWToUndetW(dwGCS, pCS, NULL, 0);
+            if (cbUndet)
             {
-                hGlobal = GlobalAlloc(GHND, dataSize);
-                if (hGlobal)
+                hUndet = GlobalAlloc(GHND | GMEM_SHARE, cbUndet);
+                if (hUndet)
                 {
-                    PUNDETERMINESTRUCT pUndet = GlobalLock(hGlobal);
+                    PUNDETERMINESTRUCT pUndet = GlobalLock(hUndet);
                     if (pUndet)
                     {
-                        dataSize = Imm32CompStrWToUndetW(dwGCS, pCS, pUndet, dataSize);
-                        GlobalUnlock(hGlobal);
-                        if (dataSize)
+                        cbUndet = Imm32CompStrWToUndetW(dwGCS, pCS, pUndet, cbUndet);
+                        GlobalUnlock(hUndet);
+                        if (cbUndet)
                         {
                             if (SendMessageW(hWnd, WM_IME_REPORT, IR_UNDETERMINE,
-                                             (LPARAM)hGlobal) == 0)
+                                             (LPARAM)hUndet) == 0)
                             {
                                 bUndeterminedProcessed = TRUE;
                             }
@@ -1254,8 +1224,8 @@ Imm32JTransCompositionW(
             }
         }
 
-        if (hGlobal)
-            GlobalFree(hGlobal);
+        if (hUndet)
+            GlobalFree(hUndet);
         if (bUndeterminedProcessed)
             return 0;
     }
@@ -1275,7 +1245,7 @@ Imm32JTransCompositionW(
                 : Imm32CompStrWToStringExA(dwGCS, pCS, NULL, 0);
             if (exSize)
             {
-                hEx = GlobalAlloc(GHND, exSize);
+                hEx = GlobalAlloc(GHND | GMEM_SHARE, exSize);
                 if (hEx)
                 {
                     pEx = GlobalLock(hEx);
@@ -1308,7 +1278,7 @@ Imm32JTransCompositionW(
             : Imm32CompStrWToStringA(pCS, NULL);
         if (strSize && strSize != (DWORD)-1)
         {
-            hStr = GlobalAlloc(GHND, strSize);
+            hStr = GlobalAlloc(GHND | GMEM_SHARE, strSize);
             if (hStr)
             {
                 pStr = GlobalLock(hStr);
@@ -1354,68 +1324,68 @@ FINALIZE:
                 pEntries->lParam =
                     dwGCS & ~(GCS_RESULTCLAUSE | GCS_RESULTSTR | GCS_RESULTREADCLAUSE |
                               GCS_RESULTREADSTR);
-                msgCount = 1;
+                cMessages = 1;
             }
         }
         else
         {
             *pEntries = *pCurrent;
-            msgCount = 1;
+            cMessages = 1;
         }
     }
 
-    return msgCount;
+    return cMessages;
 }
 
 /* Japanese */
 static DWORD
 WINNLSTranslateMessageJ(
-    DWORD dwCount,
+    INT cEntries,
     PTRANSMSG pEntries,
     const INPUTCONTEXTDX *pIC,
     const COMPOSITIONSTRING *pCS,
     BOOL bAnsi)
 {
     // Clone the message list with growing
-    DWORD dwBufSize = (DWORD)((dwCount + 1) * sizeof(TRANSMSG));
+    DWORD dwBufSize = (cEntries + 1) * sizeof(TRANSMSG);
     PTRANSMSG pBuf = ImmLocalAlloc(HEAP_ZERO_MEMORY, dwBufSize);
     if (!pBuf)
         return 0;
-    RtlCopyMemory(pBuf, pEntries, dwCount * sizeof(TRANSMSG));
+    RtlCopyMemory(pBuf, pEntries, cEntries * sizeof(TRANSMSG));
 
     HWND hWnd = pIC->hWnd;
     HWND hwndIme = ImmGetDefaultIMEWnd(hWnd);
-    PTRANSMSG pCurrent = pBuf;
-    DWORD dwResult = 0;
 
+    PTRANSMSG pCurrent = pBuf;
     if (pIC->dwUIFlags & _IME_UI_HIDDEN)
     {
         // Find WM_IME_ENDCOMPOSITION
-        PTRANSMSG pEnd = NULL;
-        for (DWORD i = 0; i < dwCount; i++)
+        PTRANSMSG pEndComp = NULL;
+        for (INT i = 0; i < cEntries; i++)
         {
             if (pBuf[i].message == WM_IME_ENDCOMPOSITION)
             {
-                pEnd = &pBuf[i];
+                pEndComp = &pBuf[i];
                 break;
             }
         }
 
-        if (pEnd)
+        if (pEndComp)
         {
             // Move WM_IME_ENDCOMPOSITION to the end of the list
-            PTRANSMSG pSrc = pEnd + 1, pDst = pEnd;
+            PTRANSMSG pSrc = pEndComp + 1, pDest = pEndComp;
             while (pSrc->message)
-                *pDst++ = *pSrc++;
+                *pDest++ = *pSrc++;
 
-            pDst->message = WM_IME_ENDCOMPOSITION;
-            pDst->wParam = pDst->lParam = 0;
+            pDest->message = WM_IME_ENDCOMPOSITION;
+            pDest->wParam = pDest->lParam = 0;
         }
 
         pCurrent = pBuf;
     }
 
-    while (pCurrent->message)
+    DWORD dwResult;
+    for (dwResult = 0; pCurrent->message; ++pCurrent)
     {
         switch (pCurrent->message)
         {
@@ -1458,14 +1428,14 @@ WINNLSTranslateMessageJ(
 
             case WM_IME_COMPOSITION:
             {
-                DWORD dwWritten;
+                INT cMessages;
                 if (bAnsi)
-                    dwWritten = Imm32JTransCompositionA(pIC, pCS, pCurrent, pEntries);
+                    cMessages = Imm32JTransCompositionA(pIC, pCS, pCurrent, pEntries);
                 else
-                    dwWritten = Imm32JTransCompositionW(pIC, pCS, pCurrent, pEntries);
+                    cMessages = Imm32JTransCompositionW(pIC, pCS, pCurrent, pEntries);
 
-                dwResult += dwWritten;
-                pEntries += dwWritten;
+                dwResult += cMessages;
+                pEntries += cMessages;
 
                 // Send IR_CHANGECONVERT
                 if (!(pIC->dwUIFlags & _IME_UI_HIDDEN) && pIC->cfCompForm.dwStyle)
@@ -1512,8 +1482,6 @@ WINNLSTranslateMessageJ(
                 ++dwResult;
                 break;
         }
-
-        pCurrent++;
     }
 
     ImmLocalFree(pBuf);
@@ -1526,7 +1494,7 @@ typedef BOOL (WINAPI *FN_PostMessage)(HWND, UINT, WPARAM, LPARAM);
 /* Korean */
 static DWORD
 WINNLSTranslateMessageK(
-    DWORD dwCount,
+    INT cEntries,
     PTRANSMSG pEntries,
     const INPUTCONTEXTDX *pIC,
     const COMPOSITIONSTRING *pCS,
@@ -1535,15 +1503,14 @@ WINNLSTranslateMessageK(
     HWND hWnd = pIC->hWnd;
     HWND hwndIme = ImmGetDefaultIMEWnd(hWnd);
     BOOL bDestIsUnicode = IsWindowUnicode(hWnd);
-    BOOL bDestIsAnsi = !bDestIsUnicode;
     FN_PostMessage pPostMessage = bDestIsUnicode ? PostMessageW : PostMessageA;
     FN_SendMessage pSendMessage = bDestIsUnicode ? SendMessageW : SendMessageA;
     static WORD s_chKorean = 0; /* One or two Korean character(s) */
 
-    if ((LONG)dwCount <= 0)
+    if (cEntries <= 0)
         return 0;
 
-    for (DWORD i = 0; i < dwCount; ++i)
+    for (INT i = 0; i < cEntries; ++i)
     {
         UINT   uMsg   = pEntries[i].message;
         WPARAM wParam = pEntries[i].wParam;
@@ -1553,203 +1520,195 @@ WINNLSTranslateMessageK(
         {
             switch (uMsg)
             {
-            case WM_IME_COMPOSITION:
-                if (lParam & GCS_RESULTSTR)
-                {
-                    pPostMessage(hWnd, WM_IME_REPORT, IR_STRINGSTART, 0);
-
-                    if ((LONG)pCS->dwResultStrLen > 0)
+                case WM_IME_COMPOSITION:
+                    if (lParam & GCS_RESULTSTR)
                     {
-                        DWORD dwProcessedLen = 0;
-                        while (dwProcessedLen < pCS->dwResultStrLen)
+                        pPostMessage(hWnd, WM_IME_REPORT, IR_STRINGSTART, 0);
+
+                        if (pCS->dwResultStrLen)
                         {
-                            LPARAM lKeyData = 1; /* WM_CHAR lParam */
-                            WCHAR wCharStr[2] = {0};
-                            CHAR  szMBStr[4]  = {0};
-
-                            if (bSrcIsAnsi)
+                            DWORD dwProcessedLen = 0;
+                            while (dwProcessedLen < pCS->dwResultStrLen)
                             {
-                                PSTR pResStr = (LPSTR)((BYTE*)pCS + pCS->dwResultStrOffset);
-                                BYTE bChar = (BYTE)pResStr[dwProcessedLen];
+                                LPARAM lKeyData = 1; /* WM_CHAR lParam */
+                                WCHAR szWide[2] = {0};
+                                CHAR  szMBStr[4]  = {0};
 
-                                if (bDestIsAnsi)
+                                if (bSrcIsAnsi)
                                 {
-                                    if (IsDBCSLeadByte(bChar))
+                                    PSTR pResStr = (LPSTR)((BYTE*)pCS + pCS->dwResultStrOffset);
+                                    BYTE bChar = (BYTE)pResStr[dwProcessedLen];
+
+                                    if (bDestIsUnicode)
                                     {
-#define KOR_LEAD_BYTE_FIRST ((BYTE)0xB0)
-#define KOR_LEAD_BYTE_LAST  ((BYTE)0xC8)
-#define KOR_IS_LEAD_BYTE(ch) \
-    (KOR_LEAD_BYTE_FIRST <= (BYTE)(ch) && (BYTE)(ch) <= KOR_LEAD_BYTE_LAST)
-                                        if (KOR_IS_LEAD_BYTE(bChar))
-                                            lKeyData = 0xFFF20001; /* Scan code differs */
-                                        else
-                                            lKeyData = 0xFFF10001;
+                                        INT cbMB = 1;
 
-                                        PostMessageA(hWnd, WM_CHAR, bChar, lKeyData);
-                                        dwProcessedLen++;
-                                        bChar = (BYTE)pResStr[dwProcessedLen];
-                                    }
-                                    PostMessageA(hWnd, WM_CHAR, bChar, lKeyData);
-                                }
-                                else
-                                {
-                                    INT cbMB = 1;
-
-                                    szMBStr[0] = bChar;
-                                    if (IsDBCSLeadByte(bChar) &&
-                                        (dwProcessedLen + 1) < pCS->dwResultStrLen)
-                                    {
-                                        szMBStr[1] = pResStr[dwProcessedLen + 1];
-                                        cbMB = 2;
-                                        ++dwProcessedLen;
-                                    }
-                                    MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, szMBStr, cbMB,
-                                                        wCharStr, 1);
-                                    PostMessageW(hWnd, WM_CHAR, wCharStr[0], 1);
-                                }
-                            }
-                            else
-                            {
-                                PWSTR pResStrW = (PWSTR)((PBYTE)pCS + pCS->dwResultStrOffset);
-                                wCharStr[0] = pResStrW[dwProcessedLen];
-
-                                if (!bDestIsAnsi)
-                                {
-                                    PostMessageW(hWnd, WM_CHAR, wCharStr[0], 1);
-                                }
-                                else
-                                {
-                                    WideCharToMultiByte(CP_ACP, 0, wCharStr, 1, szMBStr, 2,
-                                                        NULL, NULL);
-                                    BYTE bLead = (BYTE)szMBStr[0], bChar;
-                                    if (IsDBCSLeadByte(bLead))
-                                    {
-                                        if (KOR_IS_LEAD_BYTE(bLead))
-                                            lKeyData = 0xFFF20001; /* Scan code differs */
-                                        else
-                                            lKeyData = 0xFFF10001;
-
-                                        PostMessageA(hWnd, WM_CHAR, bLead, lKeyData);
-                                        bChar = (BYTE)szMBStr[1];
+                                        szMBStr[0] = bChar;
+                                        if (IsDBCSLeadByte(bChar) &&
+                                            (dwProcessedLen + 1) < pCS->dwResultStrLen)
+                                        {
+                                            szMBStr[1] = pResStr[dwProcessedLen + 1];
+                                            cbMB = 2;
+                                            ++dwProcessedLen;
+                                        }
+                                        Imm32AnsiToWide(szMBStr, cbMB, szWide, _countof(szWide));
+                                        PostMessageW(hWnd, WM_CHAR, szWide[0], 1);
                                     }
                                     else
                                     {
-                                        bChar = (BYTE)szMBStr[0];
+                                        if (IsDBCSLeadByte(bChar))
+                                        {
+                                            if (KOR_IS_LEAD_BYTE(bChar))
+                                                lKeyData = 0xFFF20001; /* Scan code differs */
+                                            else
+                                                lKeyData = 0xFFF10001;
+
+                                            PostMessageA(hWnd, WM_CHAR, bChar, lKeyData);
+                                            dwProcessedLen++;
+                                            bChar = (BYTE)pResStr[dwProcessedLen];
+                                        }
+                                        PostMessageA(hWnd, WM_CHAR, bChar, lKeyData);
                                     }
-
-                                    PostMessageA(hWnd, WM_CHAR, bChar, lKeyData);
                                 }
+                                else
+                                {
+                                    PWSTR pResStrW = (PWSTR)((PBYTE)pCS + pCS->dwResultStrOffset);
+                                    szWide[0] = pResStrW[dwProcessedLen];
+
+                                    if (bDestIsUnicode)
+                                    {
+                                        PostMessageW(hWnd, WM_CHAR, szWide[0], 1);
+                                    }
+                                    else
+                                    {
+                                        Imm32WideToAnsi(szWide, 1, szMBStr, _countof(szMBStr));
+                                        BYTE bLead = (BYTE)szMBStr[0], bChar;
+                                        if (IsDBCSLeadByte(bLead))
+                                        {
+                                            if (KOR_IS_LEAD_BYTE(bLead))
+                                                lKeyData = 0xFFF20001; /* Scan code differs */
+                                            else
+                                                lKeyData = 0xFFF10001;
+
+                                            PostMessageA(hWnd, WM_CHAR, bLead, lKeyData);
+                                            bChar = (BYTE)szMBStr[1];
+                                        }
+                                        else
+                                        {
+                                            bChar = (BYTE)szMBStr[0];
+                                        }
+
+                                        PostMessageA(hWnd, WM_CHAR, bChar, lKeyData);
+                                    }
+                                }
+                                dwProcessedLen++;
                             }
-                            dwProcessedLen++;
                         }
-                    }
-                    pPostMessage(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
-                }
-
-                if (wParam != 0)
-                {
-                    pPostMessage(hWnd, WM_IME_REPORT, IR_STRINGSTART, 0);
-
-                    BYTE bLow = HIBYTE(wParam), bHigh = LOBYTE(wParam);
-                    s_chKorean = MAKEWORD(bLow, bHigh);
-
-                    if (bSrcIsAnsi)
-                    {
-                        if (bDestIsAnsi)
-                        {
-                            PostMessageA(hWnd, WM_INTERIM, bLow, 0xF00001);
-                            PostMessageA(hWnd, WM_INTERIM, bHigh, 0xF00001);
-                        }
-                        else
-                        {
-                            CHAR szTmp[2] = { (CHAR)bLow, (CHAR)bHigh };
-                            WCHAR wTmp[2];
-                            if (MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, szTmp, 2, wTmp, 1))
-                                PostMessageW(hWnd, WM_INTERIM, wTmp[0], 0xF00001);
-                        }
-                    }
-                    else
-                    {
-                        if (!bDestIsAnsi)
-                        {
-                            PostMessageW(hWnd, WM_INTERIM, wParam, 0xF00001);
-                        }
-                        else
-                        {
-                            WCHAR wTmp[2] = { (WCHAR)wParam, 0 };
-                            CHAR  szTmp[2];
-                            WideCharToMultiByte(CP_ACP, 0, wTmp, 1, szTmp, 2, NULL, NULL);
-                            PostMessageA(hWnd, WM_INTERIM, (BYTE)szTmp[0], 0xF00001);
-                            PostMessageA(hWnd, WM_INTERIM, (BYTE)szTmp[1], 0xF00001);
-                        }
+                        pPostMessage(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
                     }
 
-                    if (bDestIsUnicode)
-                        PostMessageW(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
-                    else
-                        PostMessageA(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
-
-                    pSendMessage(hwndIme, WM_IME_ENDCOMPOSITION, 0, 0);
-                }
-                else
-                {
-                    pPostMessage(hWnd, WM_IME_REPORT, IR_STRINGSTART, 0);
-                    if (bSrcIsAnsi)
+                    if (wParam != 0)
                     {
-                        if (bDestIsAnsi)
+                        pPostMessage(hWnd, WM_IME_REPORT, IR_STRINGSTART, 0);
+
+                        BYTE bLow = HIBYTE(wParam), bHigh = LOBYTE(wParam);
+                        s_chKorean = MAKEWORD(bLow, bHigh);
+
+                        if (bSrcIsAnsi)
                         {
-                            PostMessageA(hWnd, WM_CHAR, LOBYTE(s_chKorean), 0xFFF10001);
-                            PostMessageA(hWnd, WM_CHAR, HIBYTE(s_chKorean), 0xFFF10001);
-                            PostMessageA(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
-                            PostMessageA(hWnd, WM_KEYDOWN, VK_BACK, 917505);
-                        }
-                        else
-                        {
-                            CHAR szTmp[2];
-                            szTmp[0] = LOBYTE(s_chKorean);
-                            szTmp[1] = HIBYTE(s_chKorean);
-                            WCHAR wTmp[2];
-                            if (MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, szTmp, 2, wTmp, 1))
+                            if (bDestIsUnicode)
                             {
-                                PostMessageW(hWnd, WM_CHAR, wTmp[0], 0xFFF10001);
+                                CHAR szTmp[2] = { (CHAR)bLow, (CHAR)bHigh };
+                                WCHAR wTmp[2];
+                                if (Imm32AnsiToWide(szTmp, 2, wTmp, _countof(wTmp)))
+                                    PostMessageW(hWnd, WM_INTERIM, wTmp[0], 0xF00001);
                             }
-                            PostMessageW(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
-                            PostMessageW(hWnd, WM_KEYDOWN, VK_BACK, 917505);
-                        }
-                    }
-                    else
-                    {
-                        if (bDestIsAnsi)
-                        {
-                            WCHAR wTmp[2] = { (WCHAR)s_chKorean, 0 };
-                            CHAR  szTmp[2];
-                            WideCharToMultiByte(CP_ACP, 0, wTmp, 1, szTmp, 2, NULL, NULL);
-                            PostMessageA(hWnd, WM_CHAR, (BYTE)szTmp[0], 0xFFF10001);
-                            PostMessageA(hWnd, WM_CHAR, (BYTE)szTmp[1], 0xFFF10001);
-                            PostMessageA(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
-                            PostMessageA(hWnd, WM_KEYDOWN, VK_BACK, 917505);
+                            else
+                            {
+                                PostMessageA(hWnd, WM_INTERIM, bLow, 0xF00001);
+                                PostMessageA(hWnd, WM_INTERIM, bHigh, 0xF00001);
+                            }
                         }
                         else
                         {
-                            PostMessageW(hWnd, WM_CHAR, (WCHAR)s_chKorean, 0xFFF10001);
+                            if (bDestIsUnicode)
+                            {
+                                PostMessageW(hWnd, WM_INTERIM, wParam, 0xF00001);
+                            }
+                            else
+                            {
+                                WCHAR wTmp[2] = { (WCHAR)wParam, 0 };
+                                CHAR szTmp[2];
+                                Imm32WideToAnsi(wTmp, 1, szTmp, _countof(szTmp));
+                                PostMessageA(hWnd, WM_INTERIM, (BYTE)szTmp[0], 0xF00001);
+                                PostMessageA(hWnd, WM_INTERIM, (BYTE)szTmp[1], 0xF00001);
+                            }
+                        }
+
+                        if (bDestIsUnicode)
                             PostMessageW(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
-                            PostMessageW(hWnd, WM_KEYDOWN, VK_BACK, 917505);
+                        else
+                            PostMessageA(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
+
+                        pSendMessage(hwndIme, WM_IME_ENDCOMPOSITION, 0, 0);
+                    }
+                    else
+                    {
+                        pPostMessage(hWnd, WM_IME_REPORT, IR_STRINGSTART, 0);
+                        if (bSrcIsAnsi)
+                        {
+                            if (bDestIsUnicode)
+                            {
+                                CHAR szTmp[2];
+                                szTmp[0] = LOBYTE(s_chKorean);
+                                szTmp[1] = HIBYTE(s_chKorean);
+                                WCHAR wTmp[2];
+                                if (Imm32AnsiToWide(szTmp, 2, wTmp, _countof(wTmp)))
+                                    PostMessageW(hWnd, WM_CHAR, wTmp[0], 0xFFF10001);
+                                PostMessageW(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
+                                PostMessageW(hWnd, WM_KEYDOWN, VK_BACK, 0xE0001);
+                            }
+                            else
+                            {
+                                PostMessageA(hWnd, WM_CHAR, LOBYTE(s_chKorean), 0xFFF10001);
+                                PostMessageA(hWnd, WM_CHAR, HIBYTE(s_chKorean), 0xFFF10001);
+                                PostMessageA(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
+                                PostMessageA(hWnd, WM_KEYDOWN, VK_BACK, 0xE0001);
+                            }
+                        }
+                        else
+                        {
+                            if (bDestIsUnicode)
+                            {
+                                PostMessageW(hWnd, WM_CHAR, (WCHAR)s_chKorean, 0xFFF10001);
+                                PostMessageW(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
+                                PostMessageW(hWnd, WM_KEYDOWN, VK_BACK, 917505);
+                            }
+                            else
+                            {
+                                CHAR szTmp[2];
+                                WCHAR wTmp[2] = { (WCHAR)s_chKorean, 0 };
+                                Imm32WideToAnsi(wTmp, 1, szTmp, _countof(szTmp));
+                                PostMessageA(hWnd, WM_CHAR, (BYTE)szTmp[0], 0xFFF10001);
+                                PostMessageA(hWnd, WM_CHAR, (BYTE)szTmp[1], 0xFFF10001);
+                                PostMessageA(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
+                                PostMessageA(hWnd, WM_KEYDOWN, VK_BACK, 917505);
+                            }
                         }
                     }
-                }
-                break;
+                    break;
 
-            case WM_IMEKEYDOWN:
-                pPostMessage(hWnd, WM_KEYDOWN, (WPARAM)(LOWORD(wParam)), lParam);
-                break;
+                case WM_IMEKEYDOWN:
+                    pPostMessage(hWnd, WM_KEYDOWN, (WPARAM)(LOWORD(wParam)), lParam);
+                    break;
 
-            case WM_IMEKEYUP:
-                pPostMessage(hWnd, WM_KEYUP, (WPARAM)(LOWORD(wParam)), lParam);
-                break;
+                case WM_IMEKEYUP:
+                    pPostMessage(hWnd, WM_KEYUP, (WPARAM)(LOWORD(wParam)), lParam);
+                    break;
 
-            default:
-                pSendMessage(hwndIme, uMsg, wParam, lParam);
-                break;
+                default:
+                    pSendMessage(hwndIme, uMsg, wParam, lParam);
+                    break;
             }
         }
         else
@@ -1765,7 +1724,12 @@ WINNLSTranslateMessageK(
 
 /* This function is used in ImmGenerateMessage and ImmTranslateMessage */
 DWORD
-WINNLSTranslateMessage(DWORD dwCount, PTRANSMSG pEntries, HIMC hIMC, BOOL bAnsi, WORD wLang)
+WINNLSTranslateMessage(
+    _In_ INT cEntries,
+    _Inout_ PTRANSMSG pEntries,
+    _In_ HIMC hIMC,
+    _In_ BOOL bAnsi,
+    _In_ WORD wLang)
 {
 #ifdef IMM_WIN3_SUPPORT
     PINPUTCONTEXTDX pIC = (PINPUTCONTEXTDX)ImmLockIMC(hIMC);
@@ -1781,9 +1745,9 @@ WINNLSTranslateMessage(DWORD dwCount, PTRANSMSG pEntries, HIMC hIMC, BOOL bAnsi,
 
     DWORD ret;
     if (wLang == LANG_KOREAN)
-        ret = WINNLSTranslateMessageK(dwCount, pEntries, pIC, pCompStr, bAnsi);
+        ret = WINNLSTranslateMessageK(cEntries, pEntries, pIC, pCompStr, bAnsi);
     else if (wLang == LANG_JAPANESE)
-        ret = WINNLSTranslateMessageJ(dwCount, pEntries, pIC, pCompStr, bAnsi);
+        ret = WINNLSTranslateMessageJ(cEntries, pEntries, pIC, pCompStr, bAnsi);
     else
         ret = 0;
 

--- a/win32ss/user/imm32/win3.c
+++ b/win32ss/user/imm32/win3.c
@@ -1574,8 +1574,12 @@ WINNLSTranslateMessageK(
                                 {
                                     if (IsDBCSLeadByte(bChar))
                                     {
-                                        if (0xB0 <= bChar && bChar <= 0xC8)
-                                            lKeyData = 0xFFF20001;
+#define KOR_LEAD_BYTE_FIRST ((BYTE)0xB0)
+#define KOR_LEAD_BYTE_LAST  ((BYTE)0xC8)
+#define KOR_IS_LEAD_BYTE(ch) \
+    (KOR_LEAD_BYTE_FIRST <= (BYTE)(ch) && (BYTE)(ch) <= KOR_LEAD_BYTE_LAST)
+                                        if (KOR_IS_LEAD_BYTE(bChar))
+                                            lKeyData = 0xFFF20001; /* Scan code differs */
                                         else
                                             lKeyData = 0xFFF10001;
 
@@ -1610,8 +1614,8 @@ WINNLSTranslateMessageK(
                                     BYTE bLead = (BYTE)szMBStr[0], bChar;
                                     if (IsDBCSLeadByte(bLead))
                                     {
-                                        if (0xB0 <= bLead && bLead <= 0xC8)
-                                            lKeyData = 0xFFF20001;
+                                        if (KOR_IS_LEAD_BYTE(bLead))
+                                            lKeyData = 0xFFF20001; /* Scan code differs */
                                         else
                                             lKeyData = 0xFFF10001;
 

--- a/win32ss/user/imm32/win3.c
+++ b/win32ss/user/imm32/win3.c
@@ -814,7 +814,8 @@ Imm32CompStrAToStringExW(
 
     INT nWideResultLen = 0, nWideReadLen = 0;
 
-    if (pCS->dwResultStrLen > 0) {
+    if (pCS->dwResultStrLen > 0)
+    {
         pSX->uDeterminePos = dwCurrentOffset;
         nWideResultLen = MultiByteToWideChar(
             CP_ACP, 0,
@@ -1052,8 +1053,9 @@ Imm32JTransCompositionA(
             if (dataSize)
             {
                 hGlobal = GlobalAlloc(GHND, dataSize);
-                if (hGlobal) {
-                    PUNDETERMINESTRUCT pUndet = (PUNDETERMINESTRUCT)GlobalLock(hGlobal);
+                if (hGlobal)
+                {
+                    PUNDETERMINESTRUCT pUndet = GlobalLock(hGlobal);
                     if (Imm32CompStrAToUndetA(dwGCS, pCS, pUndet, (DWORD)dataSize))
                     {
                         GlobalUnlock(hGlobal);
@@ -1071,7 +1073,7 @@ Imm32JTransCompositionA(
                 hGlobal = GlobalAlloc(GHND, dataSize);
                 if (hGlobal)
                 {
-                    PUNDETERMINESTRUCT pUndet = (PUNDETERMINESTRUCT)GlobalLock(hGlobal);
+                    PUNDETERMINESTRUCT pUndet = GlobalLock(hGlobal);
                     if (Imm32CompStrAToUndetW(dwGCS, pCS, pUndet, (DWORD)dataSize))
                     {
                         GlobalUnlock(hGlobal);
@@ -1224,7 +1226,7 @@ Imm32JTransCompositionW(
                 hGlobal = GlobalAlloc(GHND, dataSize);
                 if (hGlobal)
                 {
-                    PUNDETERMINESTRUCT pUndet = (PUNDETERMINESTRUCT)GlobalLock(hGlobal);
+                    PUNDETERMINESTRUCT pUndet = GlobalLock(hGlobal);
                     if (Imm32CompStrWToUndetA(dwGCS, pCS, pUndet, (DWORD)dataSize))
                     {
                         GlobalUnlock(hGlobal);
@@ -1242,7 +1244,7 @@ Imm32JTransCompositionW(
                 hGlobal = GlobalAlloc(GHND, dataSize);
                 if (hGlobal)
                 {
-                    PUNDETERMINESTRUCT pUndet = (PUNDETERMINESTRUCT)GlobalLock(hGlobal);
+                    PUNDETERMINESTRUCT pUndet = GlobalLock(hGlobal);
                     if (Imm32CompStrWToUndetW(dwGCS, pCS, pUndet, (DWORD)dataSize))
                     {
                         GlobalUnlock(hGlobal);

--- a/win32ss/user/imm32/win3.c
+++ b/win32ss/user/imm32/win3.c
@@ -1593,9 +1593,17 @@ WINNLSTranslateMessageK(
                                 }
                                 else
                                 {
+                                    INT cbMB = 1;
+
                                     szMBStr[0] = bChar;
-                                    szMBStr[1] = pResStr[++dwProcessedLen];
-                                    MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, szMBStr, 2,
+                                    if (IsDBCSLeadByte(bChar) &&
+                                        (dwProcessedLen + 1) < pCS->dwResultStrLen)
+                                    {
+                                        szMBStr[1] = pResStr[dwProcessedLen + 1];
+                                        cbMB = 2;
+                                        ++dwProcessedLen;
+                                    }
+                                    MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, szMBStr, cbMB,
                                                         wCharStr, 1);
                                     PostMessageW(hWnd, WM_CHAR, wCharStr[0], 1);
                                 }

--- a/win32ss/user/imm32/win3.c
+++ b/win32ss/user/imm32/win3.c
@@ -1388,7 +1388,7 @@ WINNLSTranslateMessageJ(
     }
 
     DWORD dwResult;
-    for (dwResult = 0; pCurrent->message; ++pCurrent)
+    for (dwResult = 0; pCurrent->message != WM_NULL; ++pCurrent)
     {
         switch (pCurrent->message)
         {

--- a/win32ss/user/imm32/win3.c
+++ b/win32ss/user/imm32/win3.c
@@ -12,199 +12,1669 @@ WINE_DEFAULT_DEBUG_CHANNEL(imm);
 
 #ifdef IMM_WIN3_SUPPORT /* 3.x support */
 
-DWORD
-Imm32JTransCompA(LPINPUTCONTEXTDX pIC, LPCOMPOSITIONSTRING pCS,
-                 const TRANSMSG *pSrc, LPTRANSMSG pDest)
+#define ALIGN_DWORD(len) (((len) + 3) & ~3)
+
+static DWORD
+Imm32CompStrWToUndetW(
+    DWORD dwGCS,
+    const COMPOSITIONSTRING *pCS,
+    PUNDETERMINESTRUCT pDeter)
 {
-    FIXME("\n");
-    *pDest = *pSrc;
-    return 1;
-}
+    DWORD dwRequiredSize =
+        sizeof(UNDETERMINESTRUCT) +
+        ALIGN_DWORD((pCS->dwCompStrLen + 1) * sizeof(WCHAR)) +
+        ALIGN_DWORD(pCS->dwCompAttrLen) +
+        ALIGN_DWORD((pCS->dwResultStrLen + 1) * sizeof(WCHAR)) +
+        ALIGN_DWORD(pCS->dwResultClauseLen) +
+        ALIGN_DWORD((pCS->dwResultReadStrLen + 1) * sizeof(WCHAR)) +
+        ALIGN_DWORD(pCS->dwResultReadClauseLen);
 
-DWORD
-Imm32JTransCompW(LPINPUTCONTEXTDX pIC, LPCOMPOSITIONSTRING pCS,
-                 const TRANSMSG *pSrc, LPTRANSMSG pDest)
-{
-    FIXME("\n");
-    *pDest = *pSrc;
-    return 1;
-}
+    if (!pDeter)
+        return dwRequiredSize;
 
-typedef LRESULT (WINAPI *FN_SendMessage)(HWND, UINT, WPARAM, LPARAM);
-
-DWORD
-WINNLSTranslateMessageJ(DWORD dwCount, LPTRANSMSG pTrans, LPINPUTCONTEXTDX pIC,
-                        LPCOMPOSITIONSTRING pCS, BOOL bAnsi)
-{
-    DWORD ret = 0;
-    HWND hWnd, hwndDefIME;
-    LPTRANSMSG pTempList, pEntry, pNext;
-    DWORD dwIndex, iCandForm, dwNumber, cbTempList;
-    HGLOBAL hGlobal;
-    CANDIDATEFORM CandForm;
-    FN_SendMessage pSendMessage;
-
-    hWnd = pIC->hWnd;
-    hwndDefIME = ImmGetDefaultIMEWnd(hWnd);
-    pSendMessage = (IsWindowUnicode(hWnd) ? SendMessageW : SendMessageA);
-
-    // clone the message list
-    cbTempList = (dwCount + 1) * sizeof(TRANSMSG);
-    pTempList = ImmLocalAlloc(HEAP_ZERO_MEMORY, cbTempList);
-    if (IS_NULL_UNEXPECTEDLY(pTempList))
+    if (dwRequiredSize == 0)
         return 0;
-    RtlCopyMemory(pTempList, pTrans, dwCount * sizeof(TRANSMSG));
 
-    if (pIC->dwUIFlags & _IME_UI_HIDDEN)
+    RtlZeroMemory(pDeter, sizeof(UNDETERMINESTRUCT));
+    pDeter->dwSize = dwRequiredSize;
+
+    DWORD dwCurrentOffset = sizeof(UNDETERMINESTRUCT);
+    PBYTE pBase = (PBYTE)pDeter;
+    const BYTE *pSrcBase = (const BYTE *)pCS;
+
+    if ((dwGCS & GCS_COMPSTR) && (pCS->dwCompStrLen > 0))
     {
-        // find WM_IME_ENDCOMPOSITION
-        pEntry = pTempList;
-        for (dwIndex = 0; dwIndex < dwCount; ++dwIndex, ++pEntry)
+        pDeter->uUndetTextPos = dwCurrentOffset;
+        pDeter->uUndetTextLen = pCS->dwCompStrLen;
+        DWORD cb = pCS->dwCompStrLen * sizeof(WCHAR);
+        RtlCopyMemory(pBase + dwCurrentOffset, pSrcBase + pCS->dwCompStrOffset, cb);
+        ((PWCHAR)(pBase + dwCurrentOffset))[pCS->dwCompStrLen] = UNICODE_NULL;
+        dwCurrentOffset += ALIGN_DWORD((pCS->dwCompStrLen + 1) * sizeof(WCHAR));
+    }
+
+    if ((dwGCS & GCS_COMPATTR) && (pCS->dwCompAttrLen > 0) && (pDeter->uUndetTextLen > 0))
+    {
+        pDeter->uUndetAttrPos = dwCurrentOffset;
+        RtlCopyMemory(pBase + dwCurrentOffset, pSrcBase + pCS->dwCompAttrOffset,
+                      pCS->dwCompAttrLen);
+        dwCurrentOffset += ALIGN_DWORD(pCS->dwCompAttrLen);
+    }
+
+    if (dwGCS & GCS_CURSORPOS)
+        pDeter->uCursorPos = pCS->dwCursorPos;
+
+    if (dwGCS & GCS_DELTASTART)
+        pDeter->uDeltaStart = pCS->dwDeltaStart;
+
+    if ((dwGCS & GCS_RESULTSTR) && (pCS->dwResultStrLen > 0))
+    {
+        pDeter->uDetermineTextPos = dwCurrentOffset;
+        pDeter->uDetermineTextLen = pCS->dwResultStrLen;
+        DWORD cb = pCS->dwResultStrLen * sizeof(WCHAR);
+        RtlCopyMemory(pBase + dwCurrentOffset, pSrcBase + pCS->dwResultStrOffset, cb);
+        ((PWCHAR)(pBase + dwCurrentOffset))[pCS->dwResultStrLen] = UNICODE_NULL;
+        dwCurrentOffset += ALIGN_DWORD((pCS->dwResultStrLen + 1) * sizeof(WCHAR));
+    }
+
+    if ((dwGCS & GCS_RESULTCLAUSE) && (pCS->dwResultClauseLen > 0) &&
+        (pDeter->uDetermineTextLen > 0))
+    {
+        pDeter->uDetermineDelimPos = dwCurrentOffset;
+        RtlCopyMemory(pBase + dwCurrentOffset,
+                      pSrcBase + pCS->dwResultClauseOffset,
+                      pCS->dwResultClauseLen);
+        dwCurrentOffset += ALIGN_DWORD(pCS->dwResultClauseLen);
+    }
+
+    if ((dwGCS & GCS_RESULTREADSTR) && (pCS->dwResultReadStrLen > 0))
+    {
+        pDeter->uYomiTextPos = dwCurrentOffset;
+        pDeter->uYomiTextLen = pCS->dwResultReadStrLen;
+        DWORD cb = pCS->dwResultReadStrLen * sizeof(WCHAR);
+        RtlCopyMemory(pBase + dwCurrentOffset, pSrcBase + pCS->dwResultReadStrOffset, cb);
+        ((PWCHAR)(pBase + dwCurrentOffset))[pCS->dwResultReadStrLen] = UNICODE_NULL;
+        dwCurrentOffset += ALIGN_DWORD((pCS->dwResultReadStrLen + 1) * sizeof(WCHAR));
+    }
+
+    if ((dwGCS & GCS_RESULTREADCLAUSE) && (pCS->dwResultReadClauseLen > 0) &&
+        (pDeter->uYomiTextLen > 0))
+    {
+        pDeter->uYomiDelimPos = dwCurrentOffset;
+        RtlCopyMemory(pBase + dwCurrentOffset,
+                      pSrcBase + pCS->dwResultReadClauseOffset,
+                      pCS->dwResultReadClauseLen);
+        dwCurrentOffset += ALIGN_DWORD(pCS->dwResultReadClauseLen);
+    }
+
+    return dwRequiredSize;
+}
+
+static DWORD
+Imm32CompStrWToUndetA(
+    DWORD dwGCS,
+    const COMPOSITIONSTRING *pCS,
+    PUNDETERMINESTRUCT pDeter)
+{
+    DWORD dwRequiredSize =
+        sizeof(UNDETERMINESTRUCT) +
+        ALIGN_DWORD(2 * pCS->dwCompStrLen + 3) +
+        ALIGN_DWORD(pCS->dwCompAttrLen) +
+        ALIGN_DWORD(2 * pCS->dwResultStrLen + 3) +
+        ALIGN_DWORD(pCS->dwResultClauseLen) +
+        ALIGN_DWORD(2 * pCS->dwResultReadStrLen + 3) +
+        ALIGN_DWORD(pCS->dwResultReadClauseLen) + 60;
+
+    if (!pDeter)
+        return dwRequiredSize;
+
+    if (dwRequiredSize == 0)
+        return 0;
+
+    RtlZeroMemory(pDeter, sizeof(UNDETERMINESTRUCT));
+    pDeter->dwSize = dwRequiredSize;
+
+    DWORD dwCurrentOffset = sizeof(UNDETERMINESTRUCT);
+    PBYTE pBase = (PBYTE)pDeter;
+    const BYTE *pSrcBase = (const BYTE *)pCS;
+    BOOL bUsedDef;
+
+    if ((dwGCS & GCS_COMPSTR) && (pCS->dwCompStrLen > 0))
+    {
+        INT nAnsiLen = WideCharToMultiByte(
+            CP_ACP, 0,
+            (PCWSTR)(pSrcBase + pCS->dwCompStrOffset), pCS->dwCompStrLen,
+            (PSTR)(pBase + dwCurrentOffset), dwRequiredSize - dwCurrentOffset,
+            NULL, &bUsedDef);
+        if (nAnsiLen <= 0)
+            return 0;
+        pDeter->uUndetTextPos = dwCurrentOffset;
+        pDeter->uUndetTextLen = nAnsiLen;
+        (pBase + dwCurrentOffset)[nAnsiLen] = ANSI_NULL;
+        dwCurrentOffset += ALIGN_DWORD(nAnsiLen + 1);
+    }
+
+    if ((dwGCS & GCS_COMPATTR) && (pCS->dwCompAttrLen > 0) && (pDeter->uUndetTextLen > 0))
+    {
+        pDeter->uUndetAttrPos = dwCurrentOffset;
+        const BYTE *pSrcAttr = pSrcBase + pCS->dwCompAttrOffset;
+        PBYTE pDestAttr = pBase + dwCurrentOffset;
+        const WCHAR *pWStr = (const WCHAR *)(pSrcBase + pCS->dwCompStrOffset);
+        UINT nDestIdx = 0;
+
+        for (UINT i = 0; i < pCS->dwCompAttrLen; i++)
         {
-            if (pEntry->message == WM_IME_ENDCOMPOSITION)
-                break;
+            ULONG cbMultiByte = 0;
+            USHORT wChar = pWStr[i];
+            RtlUnicodeToMultiByteSize(&cbMultiByte, &wChar, sizeof(WCHAR));
+            if (cbMultiByte == 2)
+            {
+                pDestAttr[nDestIdx++] = pSrcAttr[i];
+                pDestAttr[nDestIdx++] = pSrcAttr[i];
+            }
+            else
+            {
+                pDestAttr[nDestIdx++] = pSrcAttr[i];
+            }
         }
+        dwCurrentOffset += ALIGN_DWORD(nDestIdx);
+    }
 
-        if (pEntry->message == WM_IME_ENDCOMPOSITION) // if found
+    if (dwGCS & GCS_CURSORPOS)
+    {
+        if (pCS->dwCursorPos == (DWORD)-1)
         {
-            // move WM_IME_ENDCOMPOSITION to the end of the list
-            for (pNext = pEntry + 1; pNext->message != 0; ++pEntry, ++pNext)
-                *pEntry = *pNext;
-
-            pEntry->message = WM_IME_ENDCOMPOSITION;
-            pEntry->wParam = 0;
-            pEntry->lParam = 0;
+            pDeter->uCursorPos = (UINT)-1;
+        }
+        else
+        {
+            pDeter->uCursorPos = IchAnsiFromWide(
+                (LONG)pCS->dwCursorPos,
+                (PCWSTR)(pSrcBase + pCS->dwCompStrOffset),
+                CP_ACP);
         }
     }
 
-    for (pEntry = pTempList; pEntry->message != 0; ++pEntry)
+    if (dwGCS & GCS_DELTASTART)
     {
-        switch (pEntry->message)
+        if (pCS->dwDeltaStart == (DWORD)-1)
+        {
+            pDeter->uDeltaStart = (UINT)-1;
+        }
+        else
+        {
+            pDeter->uDeltaStart = IchAnsiFromWide(
+                (LONG)pCS->dwDeltaStart,
+                (PCWSTR)(pSrcBase + pCS->dwCompStrOffset),
+                CP_ACP);
+        }
+    }
+
+    if ((dwGCS & GCS_RESULTSTR) && (pCS->dwResultStrLen > 0))
+    {
+        INT nAnsiLen = WideCharToMultiByte(
+            CP_ACP, 0,
+            (PCWSTR)(pSrcBase + pCS->dwResultStrOffset), pCS->dwResultStrLen,
+            (PSTR)(pBase + dwCurrentOffset), dwRequiredSize - dwCurrentOffset,
+            NULL, &bUsedDef);
+        if (nAnsiLen > 0)
+        {
+            pDeter->uDetermineTextPos = dwCurrentOffset;
+            pDeter->uDetermineTextLen = nAnsiLen;
+            (pBase + dwCurrentOffset)[nAnsiLen] = ANSI_NULL;
+            dwCurrentOffset += ALIGN_DWORD(nAnsiLen + 1);
+        }
+    }
+
+    if ((dwGCS & GCS_RESULTCLAUSE) && (pCS->dwResultClauseLen > 0) &&
+        (pDeter->uDetermineTextLen > 0))
+    {
+        pDeter->uDetermineDelimPos = dwCurrentOffset;
+        const DWORD *pSrcClause = (const DWORD *)(pSrcBase + pCS->dwResultClauseOffset);
+        PDWORD pDestClause = (PDWORD)(pBase + dwCurrentOffset);
+        DWORD nClauses = pCS->dwResultClauseLen / sizeof(DWORD);
+        const WCHAR *pResultW = (const WCHAR *)(pSrcBase + pCS->dwResultStrOffset);
+
+        for (DWORD i = 0; i < nClauses; i++)
+        {
+            pDestClause[i] = IchAnsiFromWide(pSrcClause[i], pResultW, CP_ACP);
+        }
+        dwCurrentOffset += ALIGN_DWORD(pCS->dwResultClauseLen);
+    }
+
+    if ((dwGCS & GCS_RESULTREADSTR) && (pCS->dwResultReadStrLen > 0))
+    {
+        INT nAnsiLen = WideCharToMultiByte(
+            CP_ACP, 0,
+            (PCWSTR)(pSrcBase + pCS->dwResultReadStrOffset), pCS->dwResultReadStrLen,
+            (PSTR)(pBase + dwCurrentOffset), dwRequiredSize - dwCurrentOffset,
+            NULL, &bUsedDef);
+        if (nAnsiLen > 0)
+        {
+            pDeter->uYomiTextPos = dwCurrentOffset;
+            pDeter->uYomiTextLen = nAnsiLen;
+            (pBase + dwCurrentOffset)[nAnsiLen] = ANSI_NULL;
+            dwCurrentOffset += ALIGN_DWORD(nAnsiLen + 1);
+        }
+    }
+
+    if ((dwGCS & GCS_RESULTREADCLAUSE) && (pCS->dwResultReadClauseLen > 0) &&
+        (pDeter->uYomiTextLen > 0))
+    {
+        pDeter->uYomiDelimPos = dwCurrentOffset;
+        const DWORD *pSrcClause = (const DWORD *)(pSrcBase + pCS->dwResultReadClauseOffset);
+        PDWORD pDestClause = (PDWORD)(pBase + dwCurrentOffset);
+        DWORD nClauses = pCS->dwResultReadClauseLen / sizeof(DWORD);
+        const WCHAR *pReadW = (const WCHAR *)(pSrcBase + pCS->dwResultReadStrOffset);
+
+        for (DWORD i = 0; i < nClauses; i++)
+        {
+            pDestClause[i] = IchAnsiFromWide(pSrcClause[i], pReadW, CP_ACP);
+        }
+        dwCurrentOffset += ALIGN_DWORD(pCS->dwResultReadClauseLen);
+    }
+
+    return dwRequiredSize;
+}
+
+static DWORD
+Imm32CompStrWToStringExW(
+    DWORD dwGCS,
+    const COMPOSITIONSTRING *pCS,
+    LPSTRINGEXSTRUCT pSX,
+    DWORD dwSize)
+{
+    DWORD dwResultStrSize    = pCS->dwResultStrLen
+        ? ALIGN_DWORD((pCS->dwResultStrLen + 1) * sizeof(WCHAR)) : 0;
+    DWORD dwResultClauseSize = pCS->dwResultClauseLen
+        ? ALIGN_DWORD(pCS->dwResultClauseLen) : 0;
+    DWORD dwResultReadStrSize = pCS->dwResultReadStrLen
+        ? ALIGN_DWORD((pCS->dwResultReadStrLen + 1) * sizeof(WCHAR)) : 0;
+    DWORD dwReadClauseSize   = pCS->dwResultReadClauseLen
+        ? ALIGN_DWORD(pCS->dwResultReadClauseLen) : 0;
+    DWORD dwRequiredSize = sizeof(STRINGEXSTRUCT) + dwResultStrSize + dwResultClauseSize +
+                           dwResultReadStrSize + dwReadClauseSize;
+
+    if (!pSX)
+        return dwRequiredSize;
+
+    if (dwSize < dwRequiredSize)
+        return 0;
+
+    RtlZeroMemory(pSX, sizeof(STRINGEXSTRUCT));
+    pSX->dwSize = dwSize;
+
+    DWORD dwCurrentOffset = sizeof(STRINGEXSTRUCT);
+    PBYTE pBase = (PBYTE)pSX;
+    const BYTE *pSrcBase = (const BYTE *)pCS;
+
+    if (pCS->dwResultStrLen > 0)
+    {
+        pSX->uDeterminePos = dwCurrentOffset;
+        DWORD cb = pCS->dwResultStrLen * sizeof(WCHAR);
+        RtlCopyMemory(pBase + dwCurrentOffset, pSrcBase + pCS->dwResultStrOffset, cb);
+        ((PWSTR)(pBase + dwCurrentOffset))[pCS->dwResultStrLen] = UNICODE_NULL;
+        dwCurrentOffset += ALIGN_DWORD(cb + sizeof(WCHAR));
+    }
+
+    if ((dwGCS & GCS_RESULTCLAUSE) && pCS->dwResultClauseLen > 0 && pSX->uDeterminePos)
+    {
+        pSX->uDetermineDelimPos = dwCurrentOffset;
+        RtlCopyMemory(pBase + dwCurrentOffset, pSrcBase + pCS->dwResultClauseOffset,
+                      pCS->dwResultClauseLen);
+        dwCurrentOffset += ALIGN_DWORD(pCS->dwResultClauseLen);
+    }
+
+    if (pCS->dwResultReadStrLen > 0)
+    {
+        pSX->uYomiPos = dwCurrentOffset;
+        DWORD cb = pCS->dwResultReadStrLen * sizeof(WCHAR);
+        RtlCopyMemory(pBase + dwCurrentOffset, pSrcBase + pCS->dwResultReadStrOffset, cb);
+        ((PWSTR)(pBase + dwCurrentOffset))[pCS->dwResultReadStrLen] = UNICODE_NULL;
+        dwCurrentOffset += ALIGN_DWORD(cb + sizeof(WCHAR));
+    }
+
+    if ((dwGCS & GCS_RESULTREADCLAUSE) && pCS->dwResultReadClauseLen > 0 && pSX->uYomiPos)
+    {
+        pSX->uYomiDelimPos = dwCurrentOffset;
+        RtlCopyMemory(pBase + dwCurrentOffset, pSrcBase + pCS->dwResultReadClauseOffset,
+                      pCS->dwResultReadClauseLen);
+        dwCurrentOffset += ALIGN_DWORD(pCS->dwResultReadClauseLen);
+    }
+
+    return dwSize;
+}
+
+static DWORD
+Imm32CompStrWToStringExA(
+    DWORD dwGCS,
+    const COMPOSITIONSTRING *pCS,
+    LPSTRINGEXSTRUCT pSX,
+    DWORD dwSize)
+{
+    DWORD dwResultStrSize = pCS->dwResultStrLen
+        ? ALIGN_DWORD(2 * pCS->dwResultStrLen + 5) : 0;
+    DWORD dwResultClauseSize = pCS->dwResultClauseLen
+        ? ALIGN_DWORD(pCS->dwResultClauseLen + 4) : 0;
+    DWORD dwResultReadStrSize = pCS->dwResultReadStrLen
+        ? ALIGN_DWORD(2 * pCS->dwResultReadStrLen + 5) : 0;
+    DWORD dwReadClauseSize = pCS->dwResultReadClauseLen
+        ? ALIGN_DWORD(pCS->dwResultReadClauseLen + 4) : 0;
+    DWORD dwRequiredSize = sizeof(STRINGEXSTRUCT) + dwResultStrSize + dwResultClauseSize +
+                           dwResultReadStrSize + dwReadClauseSize;
+
+    if (!pSX)
+        return dwRequiredSize;
+
+    if (dwSize < dwRequiredSize)
+        return 0;
+
+    RtlZeroMemory(pSX, sizeof(STRINGEXSTRUCT));
+    pSX->dwSize = dwSize;
+
+    DWORD dwCurrentOffset = sizeof(STRINGEXSTRUCT);
+    PBYTE pBase = (PBYTE)pSX;
+    const BYTE *pSrcBase = (const BYTE *)pCS;
+    BOOL bUsedDef;
+    INT nAnsiResultLen = 0, nAnsiReadLen = 0;
+
+    if (pCS->dwResultStrLen > 0)
+    {
+        pSX->uDeterminePos = dwCurrentOffset;
+        nAnsiResultLen = WideCharToMultiByte(
+            CP_ACP, 0,
+            (PCWSTR)(pSrcBase + pCS->dwResultStrOffset), pCS->dwResultStrLen,
+            (PSTR)(pBase + dwCurrentOffset), dwSize - dwCurrentOffset,
+            NULL, &bUsedDef);
+        if (nAnsiResultLen <= 0)
+            return 0;
+        (pBase + dwCurrentOffset)[nAnsiResultLen] = ANSI_NULL;
+        dwCurrentOffset += ALIGN_DWORD(nAnsiResultLen + 1);
+    }
+
+    if ((dwGCS & GCS_RESULTCLAUSE) && pCS->dwResultClauseLen > 0 && nAnsiResultLen > 0)
+    {
+        pSX->uDetermineDelimPos = dwCurrentOffset;
+        const DWORD *pSrcClause = (const DWORD *)(pSrcBase + pCS->dwResultClauseOffset);
+        PDWORD pDestClause = (PDWORD)(pBase + dwCurrentOffset);
+        DWORD nClauses = pCS->dwResultClauseLen / sizeof(DWORD);
+        const WCHAR *pResultW = (const WCHAR *)(pSrcBase + pCS->dwResultStrOffset);
+
+        for (DWORD i = 0; i < nClauses; i++)
+        {
+            pDestClause[i] = IchAnsiFromWide(pSrcClause[i], pResultW, CP_ACP);
+        }
+        dwCurrentOffset += ALIGN_DWORD(pCS->dwResultClauseLen);
+    }
+
+    if (pCS->dwResultReadStrLen > 0)
+    {
+        pSX->uYomiPos = dwCurrentOffset;
+        nAnsiReadLen = WideCharToMultiByte(
+            CP_ACP, 0,
+            (PCWSTR)(pSrcBase + pCS->dwResultReadStrOffset), pCS->dwResultReadStrLen,
+            (PSTR)(pBase + dwCurrentOffset), dwSize - dwCurrentOffset,
+            NULL, &bUsedDef);
+        if (nAnsiReadLen <= 0)
+            return 0;
+        (pBase + dwCurrentOffset)[nAnsiReadLen] = ANSI_NULL;
+        dwCurrentOffset += ALIGN_DWORD(nAnsiReadLen + 1);
+    }
+
+    if ((dwGCS & GCS_RESULTREADCLAUSE) && pCS->dwResultReadClauseLen > 0 && nAnsiReadLen > 0)
+    {
+        pSX->uYomiDelimPos = dwCurrentOffset;
+        const DWORD *pSrcClause = (const DWORD *)(pSrcBase + pCS->dwResultReadClauseOffset);
+        PDWORD pDestClause = (PDWORD)(pBase + dwCurrentOffset);
+        DWORD nClauses = pCS->dwResultReadClauseLen / sizeof(DWORD);
+        const WCHAR *pReadW = (const WCHAR *)(pSrcBase + pCS->dwResultReadStrOffset);
+
+        for (DWORD i = 0; i < nClauses; i++)
+        {
+            pDestClause[i] = IchAnsiFromWide(pSrcClause[i], pReadW, CP_ACP);
+        }
+        dwCurrentOffset += ALIGN_DWORD(pCS->dwResultReadClauseLen);
+    }
+
+    return dwSize;
+}
+
+static DWORD Imm32CompStrWToStringW(const COMPOSITIONSTRING *pCS, PWCHAR pch)
+{
+    DWORD dwResultStrLen = pCS->dwResultStrLen;
+    if (!pch)
+        return (dwResultStrLen + 1) * sizeof(WCHAR);
+    DWORD cb = dwResultStrLen * sizeof(WCHAR);
+    RtlCopyMemory(pch, (const BYTE*)pCS + pCS->dwResultStrOffset, cb);
+    pch[cb / sizeof(WCHAR)] = UNICODE_NULL;
+    return cb + sizeof(UNICODE_NULL);
+}
+
+static DWORD Imm32CompStrWToStringA(const COMPOSITIONSTRING *pCS, PCHAR pch)
+{
+    const WCHAR *pwch = (const WCHAR *)((PBYTE)pCS + pCS->dwResultStrOffset);
+    BOOL bUsedDef;
+    INT cchNeed = WideCharToMultiByte(CP_ACP, 0, pwch, pCS->dwResultStrLen,
+                                      pch, 0, NULL, &bUsedDef) + 1;
+    if (!pch)
+        return cchNeed;
+    INT cch = WideCharToMultiByte(CP_ACP, 0, pwch, pCS->dwResultStrLen,
+                                  pch, cchNeed, NULL, &bUsedDef);
+    pch[cch] = 0;
+    return cch + 1;
+}
+
+const WCHAR *Imm32CompStrWToCharW(HWND hWnd, const COMPOSITIONSTRING *pCS)
+{
+    const WCHAR *pCurrent = (const WCHAR *)((const BYTE *)pCS + pCS->dwResultStrOffset);
+
+    PostMessageW(hWnd, WM_IME_REPORT, IR_STRINGSTART, 0);
+
+    const WCHAR *pNext;
+    for (; *pCurrent; pCurrent = pNext)
+    {
+        pNext = CharNextW(pCurrent);
+
+        if (!*pNext)
+            PostMessageW(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
+
+        PostMessageW(hWnd, WM_CHAR, *pCurrent, 1);
+    }
+
+    return pCurrent;
+}
+
+static DWORD
+Imm32CompStrAToUndetA(
+    DWORD dwGCS,
+    const COMPOSITIONSTRING *pCS,
+    PUNDETERMINESTRUCT pDeter,
+    DWORD dwSize)
+{
+    DWORD dwRequiredSize =
+        sizeof(UNDETERMINESTRUCT) +
+        ALIGN_DWORD(pCS->dwCompStrLen) +
+        ALIGN_DWORD(pCS->dwCompAttrLen) +
+        ALIGN_DWORD(pCS->dwResultStrLen) +
+        ALIGN_DWORD(pCS->dwResultClauseLen) +
+        ALIGN_DWORD(pCS->dwResultReadStrLen) +
+        ALIGN_DWORD(pCS->dwResultReadClauseLen);
+
+    if (!pDeter)
+        return dwRequiredSize;
+
+    if (dwSize < dwRequiredSize)
+        return 0;
+
+    RtlZeroMemory(pDeter, sizeof(UNDETERMINESTRUCT));
+    pDeter->dwSize = dwSize;
+
+    DWORD dwCurrentOffset = sizeof(UNDETERMINESTRUCT);
+    PBYTE pBase = (PBYTE)pDeter, pSrcBase = (PBYTE)pCS;
+
+    if ((dwGCS & GCS_COMPSTR) && (pCS->dwCompStrLen > 0))
+    {
+        pDeter->uUndetTextPos = dwCurrentOffset;
+        pDeter->uUndetTextLen = pCS->dwCompStrLen;
+        RtlCopyMemory(pBase + dwCurrentOffset, pSrcBase + pCS->dwCompStrOffset, pCS->dwCompStrLen);
+        pBase[dwCurrentOffset + pCS->dwCompStrLen] = ANSI_NULL;
+        dwCurrentOffset += ALIGN_DWORD(pCS->dwCompStrLen + 1);
+    }
+
+    if ((dwGCS & GCS_COMPATTR) && (pCS->dwCompAttrLen > 0))
+    {
+        pDeter->uUndetAttrPos = dwCurrentOffset;
+        RtlCopyMemory(pBase + dwCurrentOffset, pSrcBase + pCS->dwCompAttrOffset,
+                      pCS->dwCompAttrLen);
+        dwCurrentOffset += ALIGN_DWORD(pCS->dwCompAttrLen);
+    }
+
+    if (dwGCS & GCS_CURSORPOS)
+        pDeter->uCursorPos = pCS->dwCursorPos;
+
+    if (dwGCS & GCS_DELTASTART)
+        pDeter->uDeltaStart = pCS->dwDeltaStart;
+
+    if ((dwGCS & GCS_RESULTSTR) && (pCS->dwResultStrLen > 0))
+    {
+        pDeter->uDetermineTextPos = dwCurrentOffset;
+        pDeter->uDetermineTextLen = pCS->dwResultStrLen;
+        RtlCopyMemory(pBase + dwCurrentOffset, pSrcBase + pCS->dwResultStrOffset,
+                      pCS->dwResultStrLen);
+        pBase[dwCurrentOffset + pCS->dwResultStrLen] = ANSI_NULL;
+        dwCurrentOffset += ALIGN_DWORD(pCS->dwResultStrLen + 1);
+    }
+
+    if ((dwGCS & GCS_RESULTCLAUSE) && (pCS->dwResultClauseLen > 0))
+    {
+        pDeter->uDetermineDelimPos = dwCurrentOffset;
+        RtlCopyMemory(pBase + dwCurrentOffset, pSrcBase + pCS->dwResultClauseOffset,
+                      pCS->dwResultClauseLen);
+        dwCurrentOffset += ALIGN_DWORD(pCS->dwResultClauseLen);
+    }
+
+    if ((dwGCS & GCS_RESULTREADSTR) && (pCS->dwResultReadStrLen > 0))
+    {
+        pDeter->uYomiTextPos = dwCurrentOffset;
+        pDeter->uYomiTextLen = pCS->dwResultReadStrLen;
+        RtlCopyMemory(pBase + dwCurrentOffset, pSrcBase + pCS->dwResultReadStrOffset,
+                      pCS->dwResultReadStrLen);
+        pBase[dwCurrentOffset + pCS->dwResultReadStrLen] = ANSI_NULL;
+        dwCurrentOffset += ALIGN_DWORD(pCS->dwResultReadStrLen + 1);
+    }
+
+    if ((dwGCS & GCS_RESULTREADCLAUSE) && (pCS->dwResultReadClauseLen > 0))
+    {
+        pDeter->uYomiDelimPos = dwCurrentOffset;
+        RtlCopyMemory(pBase + dwCurrentOffset, pSrcBase + pCS->dwResultReadClauseOffset,
+                      pCS->dwResultReadClauseLen);
+        dwCurrentOffset += ALIGN_DWORD(pCS->dwResultReadClauseLen);
+    }
+
+    return dwSize;
+}
+
+static DWORD
+Imm32CompStrAToUndetW(
+    DWORD dwGCS,
+    const COMPOSITIONSTRING *pCS,
+    PUNDETERMINESTRUCT pUndeter,
+    DWORD dwSize)
+{
+    DWORD dwRequiredSize =
+        sizeof(UNDETERMINESTRUCT) +
+        ALIGN_DWORD(pCS->dwResultClauseLen) +
+        ALIGN_DWORD(2 * pCS->dwCompAttrLen + 3) +
+        ALIGN_DWORD(2 * pCS->dwResultStrLen + 5) +
+        ALIGN_DWORD(2 * pCS->dwCompStrLen + 5) +
+        ALIGN_DWORD(2 * pCS->dwResultReadStrLen + 5) +
+        ALIGN_DWORD(pCS->dwResultReadClauseLen) + 60;
+
+    if (!pUndeter)
+        return dwRequiredSize;
+
+    if (dwSize < dwRequiredSize)
+        return 0;
+
+    RtlZeroMemory(pUndeter, sizeof(UNDETERMINESTRUCT));
+    pUndeter->dwSize = dwSize;
+
+    DWORD dwCurrentOffset = sizeof(UNDETERMINESTRUCT);
+    PBYTE pBase = (PBYTE)pUndeter;
+    const BYTE* pSrcBase = (const BYTE*)pCS;
+
+    if ((dwGCS & GCS_COMPSTR) && (pCS->dwCompStrLen > 0))
+    {
+        INT nWideLen = MultiByteToWideChar(CP_ACP, 0,
+            (PCSTR)(pSrcBase + pCS->dwCompStrOffset), pCS->dwCompStrLen,
+            (PWSTR)(pBase + dwCurrentOffset), (dwSize - dwCurrentOffset) / sizeof(WCHAR));
+        if (nWideLen <= 0)
+            return 0;
+        pUndeter->uUndetTextPos = dwCurrentOffset;
+        pUndeter->uUndetTextLen = nWideLen;
+        ((PWCHAR)(pBase + dwCurrentOffset))[nWideLen] = UNICODE_NULL;
+        dwCurrentOffset += ALIGN_DWORD((nWideLen + 1) * sizeof(WCHAR));
+    }
+
+    if ((dwGCS & GCS_COMPATTR) && pCS->dwCompAttrLen > 0 && (pUndeter->uUndetTextLen > 0))
+    {
+        pUndeter->uUndetAttrPos = dwCurrentOffset;
+        const BYTE* pSrcAttr = pSrcBase + pCS->dwCompAttrOffset;
+        PBYTE pDestAttr = pBase + dwCurrentOffset;
+        PCWSTR pWStr = (PCWSTR)(pBase + pUndeter->uUndetTextPos);
+
+        for (UINT i = 0; i < pUndeter->uUndetTextLen; i++)
+        {
+            pDestAttr[i] = *pSrcAttr;
+            USHORT wChar = pWStr[i];
+            ULONG cbMultiByte = 0;
+            RtlUnicodeToMultiByteSize(&cbMultiByte, &wChar, sizeof(WCHAR));
+            pSrcAttr += (cbMultiByte == 2) ? 2 : 1;
+        }
+        dwCurrentOffset += ALIGN_DWORD(pUndeter->uUndetTextLen);
+    }
+
+    if (dwGCS & GCS_CURSORPOS)
+    {
+        if (pCS->dwCursorPos == (DWORD)-1)
+        {
+            pUndeter->uCursorPos = (UINT)-1;
+        }
+        else
+        {
+            pUndeter->uCursorPos = IchWideFromAnsi(
+                pCS->dwCursorPos, (PCSTR)(pSrcBase + pCS->dwCompStrOffset), CP_ACP);
+        }
+    }
+
+    if (dwGCS & GCS_DELTASTART)
+    {
+        if (pCS->dwDeltaStart == (DWORD)-1)
+        {
+            pUndeter->uDeltaStart = (UINT)-1;
+        }
+        else
+        {
+            pUndeter->uDeltaStart = IchWideFromAnsi(
+                pCS->dwDeltaStart, (PCSTR)(pSrcBase + pCS->dwCompStrOffset), CP_ACP);
+        }
+    }
+
+    if (dwGCS & GCS_RESULTSTR)
+    {
+        INT nWideLen = MultiByteToWideChar(CP_ACP, 0,
+            (PCSTR)(pSrcBase + pCS->dwResultStrOffset), pCS->dwResultStrLen,
+            (PWSTR)(pBase + dwCurrentOffset), (dwSize - dwCurrentOffset) / sizeof(WCHAR));
+        if (nWideLen > 0)
+        {
+            pUndeter->uDetermineTextPos = dwCurrentOffset;
+            pUndeter->uDetermineTextLen = nWideLen;
+            ((PWSTR)(pBase + dwCurrentOffset))[nWideLen] = UNICODE_NULL;
+            dwCurrentOffset += ALIGN_DWORD((nWideLen + 1) * sizeof(WCHAR));
+        }
+    }
+
+    if ((dwGCS & GCS_RESULTCLAUSE) && (pCS->dwResultClauseLen > 0) &&
+        (pUndeter->uDetermineTextLen > 0))
+    {
+        pUndeter->uDetermineDelimPos = dwCurrentOffset;
+        PDWORD pSrcClause = (PDWORD)(pSrcBase + pCS->dwResultClauseOffset);
+        PDWORD pDestClause = (PDWORD)(pBase + dwCurrentOffset);
+        DWORD nClauses = pCS->dwResultClauseLen / sizeof(DWORD);
+
+        for (DWORD i = 0; i < nClauses; i++)
+        {
+            pDestClause[i] = IchWideFromAnsi(pSrcClause[i],
+                (PCSTR)(pSrcBase + pCS->dwResultStrOffset), CP_ACP);
+        }
+        dwCurrentOffset += ALIGN_DWORD(pCS->dwResultClauseLen);
+    }
+
+    if (dwGCS & GCS_RESULTREADSTR)
+    {
+        INT nWideLen = MultiByteToWideChar(CP_ACP, 0,
+            (PCSTR)(pSrcBase + pCS->dwResultReadStrOffset), pCS->dwResultReadStrLen,
+            (PWSTR)(pBase + dwCurrentOffset), (dwSize - dwCurrentOffset) / sizeof(WCHAR));
+        if (nWideLen > 0)
+        {
+            pUndeter->uYomiTextPos = dwCurrentOffset;
+            pUndeter->uYomiTextLen = nWideLen;
+            ((PWSTR)(pBase + dwCurrentOffset))[nWideLen] = UNICODE_NULL;
+            dwCurrentOffset += ALIGN_DWORD((nWideLen + 1) * sizeof(WCHAR));
+        }
+    }
+
+    if ((dwGCS & GCS_RESULTREADCLAUSE) && (pCS->dwResultReadClauseLen > 0) &&
+        (pUndeter->uYomiTextLen > 0))
+    {
+        pUndeter->uYomiDelimPos = dwCurrentOffset;
+        PDWORD pSrcClause = (PDWORD)(pSrcBase + pCS->dwResultReadClauseOffset);
+        PDWORD pDestClause = (PDWORD)(pBase + dwCurrentOffset);
+        DWORD nClauses = pCS->dwResultReadClauseLen / sizeof(DWORD);
+
+        for (DWORD i = 0; i < nClauses; i++)
+        {
+            pDestClause[i] = IchWideFromAnsi(
+                pSrcClause[i], (PCSTR)(pSrcBase + pCS->dwResultReadStrOffset), 0);
+            dwCurrentOffset += ALIGN_DWORD(pCS->dwResultReadClauseLen);
+        }
+    }
+
+    return dwSize;
+}
+
+static DWORD
+Imm32CompStrAToStringExA(
+    DWORD dwGCS,
+    const COMPOSITIONSTRING *pCS,
+    LPSTRINGEXSTRUCT pSX,
+    DWORD dwSize)
+{
+    DWORD dwRequiredSize =
+        sizeof(STRINGEXSTRUCT) +
+        ALIGN_DWORD(pCS->dwResultStrLen + 1) +
+        ALIGN_DWORD(pCS->dwResultClauseLen) +
+        ALIGN_DWORD(pCS->dwResultReadStrLen + 1) +
+        ALIGN_DWORD(pCS->dwResultReadClauseLen);
+
+    if (!pSX)
+        return dwRequiredSize;
+
+    if (dwSize < dwRequiredSize)
+        return 0;
+
+    RtlZeroMemory(pSX, sizeof(STRINGEXSTRUCT));
+    pSX->dwSize = dwSize;
+
+    DWORD dwCurrentOffset = sizeof(STRINGEXSTRUCT);
+    PBYTE pBase = (PBYTE)pSX;
+    const BYTE* pSrcBase = (const BYTE*)pCS;
+
+    if (pCS->dwResultStrLen > 0)
+    {
+        pSX->uDeterminePos = dwCurrentOffset;
+        RtlCopyMemory(pBase + dwCurrentOffset, pSrcBase + pCS->dwResultStrOffset,
+                      pCS->dwResultStrLen);
+        pBase[dwCurrentOffset + pCS->dwResultStrLen] = ANSI_NULL;
+        dwCurrentOffset += ALIGN_DWORD(pCS->dwResultStrLen + 1);
+    }
+
+    if ((dwGCS & GCS_RESULTCLAUSE) && pCS->dwResultClauseLen > 0)
+    {
+        pSX->uDetermineDelimPos = dwCurrentOffset;
+        RtlCopyMemory(pBase + dwCurrentOffset, pSrcBase + pCS->dwResultClauseOffset,
+                      pCS->dwResultClauseLen);
+        dwCurrentOffset += ALIGN_DWORD(pCS->dwResultClauseLen);
+    }
+
+    if (pCS->dwResultReadStrLen > 0)
+    {
+        pSX->uYomiPos = dwCurrentOffset;
+        RtlCopyMemory(pBase + dwCurrentOffset, pSrcBase + pCS->dwResultReadStrOffset,
+                      pCS->dwResultReadStrLen);
+        pBase[dwCurrentOffset + pCS->dwResultReadStrLen] = ANSI_NULL;
+        dwCurrentOffset += ALIGN_DWORD(pCS->dwResultReadStrLen + 1);
+    }
+
+    if ((dwGCS & GCS_RESULTREADCLAUSE) && pCS->dwResultReadClauseLen > 0)
+    {
+        pSX->uYomiDelimPos = dwCurrentOffset;
+        RtlCopyMemory(pBase + dwCurrentOffset, pSrcBase + pCS->dwResultReadClauseOffset,
+                      pCS->dwResultReadClauseLen);
+        dwCurrentOffset += ALIGN_DWORD(pCS->dwResultReadClauseLen);
+    }
+
+    return dwSize;
+}
+
+static DWORD
+Imm32CompStrAToStringExW(
+    DWORD dwGCS,
+    const COMPOSITIONSTRING *pCS,
+    LPSTRINGEXSTRUCT pSX,
+    DWORD dwSize)
+{
+    DWORD dwResultStrSize =
+        pCS->dwResultStrLen ? ALIGN_DWORD(2 * pCS->dwResultStrLen + 5) : 0;
+    DWORD dwResultClauseSize =
+        pCS->dwResultClauseLen ? ALIGN_DWORD(pCS->dwResultClauseLen + 4) : 0;
+    DWORD dwResultReadStrSize =
+        pCS->dwResultReadStrLen ? ALIGN_DWORD(2 * pCS->dwResultReadStrLen + 5) : 0;
+    DWORD dwReadClauseSize
+        = pCS->dwResultReadClauseLen ? ALIGN_DWORD(pCS->dwResultReadClauseLen + 4) : 0;
+    DWORD dwRequiredSize = sizeof(STRINGEXSTRUCT) + dwResultStrSize + dwResultClauseSize +
+                           dwResultReadStrSize + dwReadClauseSize;
+
+    if (pSX == NULL)
+        return dwRequiredSize;
+
+    if (dwSize < dwRequiredSize)
+        return 0;
+
+    RtlZeroMemory(pSX, sizeof(STRINGEXSTRUCT));
+    pSX->dwSize = dwSize;
+
+    DWORD dwCurrentOffset = sizeof(STRINGEXSTRUCT);
+    PBYTE pBase = (PBYTE)pSX;
+    const BYTE* pSrcBase = (const BYTE*)pCS;
+
+    INT nWideResultLen = 0, nWideReadLen = 0;
+
+    if (pCS->dwResultStrLen > 0) {
+        pSX->uDeterminePos = dwCurrentOffset;
+        nWideResultLen = MultiByteToWideChar(
+            CP_ACP, 0,
+            (PCSTR)(pSrcBase + pCS->dwResultStrOffset), pCS->dwResultStrLen,
+            (PWSTR)(pBase + dwCurrentOffset), (dwSize - dwCurrentOffset) / sizeof(WCHAR));
+        if (nWideResultLen <= 0)
+            return 0;
+        ((PWSTR)(pBase + dwCurrentOffset))[nWideResultLen] = UNICODE_NULL;
+        dwCurrentOffset += ALIGN_DWORD(nWideResultLen * sizeof(WCHAR) + sizeof(WCHAR));
+    }
+
+    if ((dwGCS & GCS_RESULTCLAUSE) && pCS->dwResultClauseLen > 0 && nWideResultLen > 0)
+    {
+        pSX->uDetermineDelimPos = dwCurrentOffset;
+        const DWORD* pSrcClause = (const DWORD*)(pSrcBase + pCS->dwResultClauseOffset);
+        PDWORD pDestClause = (PDWORD)(pBase + dwCurrentOffset);
+        DWORD nClauses = pCS->dwResultClauseLen / sizeof(DWORD);
+
+        for (DWORD i = 0; i < nClauses; i++)
+        {
+            pDestClause[i] = IchWideFromAnsi(pSrcClause[i],
+                (PCSTR)(pSrcBase + pCS->dwResultStrOffset), CP_ACP);
+        }
+        dwCurrentOffset += ALIGN_DWORD(pCS->dwResultClauseLen);
+    }
+
+    if (pCS->dwResultReadStrLen > 0)
+    {
+        pSX->uYomiPos = dwCurrentOffset;
+        nWideReadLen = MultiByteToWideChar(CP_ACP, 0,
+            (PCSTR)(pSrcBase + pCS->dwResultReadStrOffset), pCS->dwResultReadStrLen,
+            (PWSTR)(pBase + dwCurrentOffset), (dwSize - dwCurrentOffset) / sizeof(WCHAR));
+        if (nWideReadLen <= 0)
+            return 0;
+
+        ((PWSTR)(pBase + dwCurrentOffset))[nWideReadLen] = UNICODE_NULL;
+        dwCurrentOffset += ALIGN_DWORD(nWideReadLen * sizeof(WCHAR) + sizeof(WCHAR));
+    }
+
+    if ((dwGCS & GCS_RESULTREADCLAUSE) && pCS->dwResultReadClauseLen > 0 && nWideReadLen > 0)
+    {
+        pSX->uYomiDelimPos = dwCurrentOffset;
+        const DWORD* pSrcClause = (const DWORD*)(pSrcBase + pCS->dwResultReadClauseOffset);
+        PDWORD pDestClause = (PDWORD)(pBase + dwCurrentOffset);
+        DWORD nClauses = pCS->dwResultReadClauseLen / sizeof(DWORD);
+        for (DWORD i = 0; i < nClauses; i++)
+        {
+            pDestClause[i] = IchWideFromAnsi(pSrcClause[i],
+                (PCSTR)(pSrcBase + pCS->dwResultReadStrOffset), CP_ACP);
+        }
+    }
+
+    return dwSize;
+}
+
+static DWORD
+Imm32CompStrAToStringA(const COMPOSITIONSTRING *pCS, PSTR pszString, DWORD dwSize)
+{
+    DWORD dwResultStrLen = pCS->dwResultStrLen;
+    if (!pszString)
+        return dwResultStrLen + 1;
+    if (dwResultStrLen > dwSize)
+        return 0;
+    RtlCopyMemory(pszString, (PBYTE)pCS + pCS->dwResultStrOffset, dwResultStrLen);
+    pszString[dwResultStrLen] = ANSI_NULL;
+    return dwResultStrLen + 1;
+}
+
+static DWORD
+Imm32CompStrAToStringW(const COMPOSITIONSTRING *pCS, PWSTR pszString, DWORD dwSize)
+{
+    const CHAR *pch = (const CHAR *)pCS + pCS->dwResultStrOffset;
+    INT cchWide = MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, pch, pCS->dwResultStrLen,
+                                      pszString, 0);
+    DWORD dwResultStrLen = (cchWide + 1) * sizeof(WCHAR);
+    if (!pszString)
+        return dwResultStrLen;
+    if (dwResultStrLen > dwSize)
+        return 0;
+    INT cch = MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, pch, pCS->dwResultStrLen,
+                                  pszString, cchWide);
+    if (cch < cchWide)
+        return 0;
+    pszString[cch] = UNICODE_NULL;
+    return (cch + 1) * sizeof(WCHAR);
+}
+
+const WCHAR* Imm32CompStrWToCharA(HWND hWnd, const COMPOSITIONSTRING *pCS)
+{
+    const WCHAR *pCurrent = (const WCHAR *)((const BYTE *)pCS + pCS->dwResultStrOffset);
+
+    BOOL bSupportDBCSReport = FALSE;
+    if (GetWin32ClientInfo()->dwExpWinVer >= 0x30A)
+        bSupportDBCSReport = (BOOL)SendMessageA(hWnd, WM_IME_REPORT, IR_DBCSCHAR, 0);
+
+    PostMessageA(hWnd, WM_IME_REPORT, IR_STRINGSTART, 0);
+
+    const WCHAR *pNext;
+    for (; *pCurrent != UNICODE_NULL; pCurrent = pNext)
+    {
+        pNext = CharNextW(pCurrent);
+        if (!*pNext)
+            PostMessageA(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
+
+        char szAnsi[3] = {0};
+        BOOL bUsedDef = FALSE;
+        if (!WideCharToMultiByte(CP_ACP, 0, pCurrent, 1, szAnsi, sizeof(szAnsi), NULL, &bUsedDef))
+            continue;
+
+        if (!IsDBCSLeadByte((BYTE)szAnsi[0]))
+        {
+            PostMessageA(hWnd, WM_CHAR, (BYTE)szAnsi[0], 1);
+            continue;
+        }
+
+        if (bSupportDBCSReport)
+        {
+            WPARAM wParam = 0x80000000 | MAKEWORD(szAnsi[1], szAnsi[0]);
+            PostMessageA(hWnd, WM_CHAR, wParam, 1);
+        }
+        else
+        {
+            PostMessageA(hWnd, WM_CHAR, (BYTE)szAnsi[0], 1);
+            PostMessageA(hWnd, WM_CHAR, (BYTE)szAnsi[1], 1);
+        }
+    }
+
+    return pCurrent;
+}
+
+static CHAR Imm32CompStrAToCharA(HWND hWnd, const COMPOSITIONSTRING *pCS)
+{
+    const CHAR *pch = (const CHAR *)((PBYTE)pCS + pCS->dwResultStrOffset);
+
+    BOOL bImeSupportDBCS = FALSE;
+    if (GetWin32ClientInfo()->dwExpWinVer >= 0x30A)
+        bImeSupportDBCS = (BOOL)SendMessageA(hWnd, WM_IME_REPORT, IR_DBCSCHAR, 0);
+
+    PostMessageA(hWnd, WM_IME_REPORT, IR_STRINGSTART, 0);
+
+    CHAR ch = *pch;
+    if (*pch == ANSI_NULL)
+        return ch;
+
+    while (*pch)
+    {
+        BYTE bFirst = (BYTE)(*pch);
+        const CHAR *pNext = CharNextA(pch);
+
+        if (*pNext == ANSI_NULL)
+            PostMessageA(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
+
+        if (IsDBCSLeadByte(bFirst))
+        {
+            BYTE bSecond = pch[1];
+            if (bImeSupportDBCS)
+            {
+                WPARAM wParamDBCS = 0x80000000 | MAKEWORD(bSecond, bFirst);
+                PostMessageA(hWnd, WM_CHAR, wParamDBCS, 1);
+            }
+            else
+            {
+                PostMessageA(hWnd, WM_CHAR, bFirst, 1);
+                PostMessageA(hWnd, WM_CHAR, bSecond, 1);
+            }
+        }
+        else
+        {
+            PostMessageA(hWnd, WM_CHAR, bFirst, 1);
+        }
+
+        pch = pNext;
+        ch = *pch;
+    }
+
+    return ch;
+}
+
+static CHAR Imm32CompStrAToCharW(HWND hWnd, const COMPOSITIONSTRING *pCS)
+{
+    const CHAR *pCurrent = (const CHAR *)((PBYTE)pCS + pCS->dwResultStrOffset);
+    CHAR ch = *pCurrent;
+
+    PostMessageW(hWnd, WM_IME_REPORT, IR_STRINGSTART, 0);
+
+    while (*pCurrent)
+    {
+        ch = *pCurrent;
+        BYTE bTestChar = *pCurrent;
+        PCHAR pNext = CharNextA(pCurrent);
+
+        if (*pNext == ANSI_NULL)
+            PostMessageW(hWnd, WM_IME_REPORT, IR_STRINGEND, 0);
+
+        WCHAR wCharBuffer = UNICODE_NULL;
+        INT nConverted = 0;
+        if (IsDBCSLeadByte(bTestChar))
+            nConverted = MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, pCurrent, 2, &wCharBuffer, 1);
+        else
+            nConverted = MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, pCurrent, 1, &wCharBuffer, 1);
+
+        if (nConverted > 0)
+            PostMessageW(hWnd, WM_CHAR, wCharBuffer, 1);
+
+        pCurrent = pNext;
+    }
+
+    return ch;
+}
+
+static DWORD
+Imm32JTransCompositionA(
+    PINPUTCONTEXTDX pIC,
+    PCOMPOSITIONSTRING pCS,
+    PTRANSMSG pCurrent,
+    PTRANSMSG pEntries)
+{
+    HWND hWnd = pIC->hWnd;
+    if (!IsWindow(hWnd))
+        return 0;
+
+    BOOL bIsUnicodeWnd = IsWindowUnicode(hWnd);
+    DWORD dwGCS = (DWORD)pCurrent->lParam;
+    int msgCount = 0;
+    BOOL bUndeterminedProcessed = FALSE;
+    BOOL bResultProcessed = FALSE;
+    HGLOBAL hGlobal = NULL;
+    SIZE_T dataSize = 0;
+
+    if (pIC->dwUIFlags & _IME_UI_HIDDEN)
+    {
+        if (!bIsUnicodeWnd)
+        {
+            dataSize = Imm32CompStrAToUndetA(dwGCS, pCS, NULL, 0);
+            if (dataSize)
+            {
+                hGlobal = GlobalAlloc(GHND, dataSize);
+                if (hGlobal) {
+                    PUNDETERMINESTRUCT pUndet = (PUNDETERMINESTRUCT)GlobalLock(hGlobal);
+                    if (Imm32CompStrAToUndetA(dwGCS, pCS, pUndet, (DWORD)dataSize))
+                    {
+                        GlobalUnlock(hGlobal);
+                        if (SendMessageA(hWnd, WM_IME_REPORT, IR_UNDETERMINE, (LPARAM)hGlobal) == 0)
+                            bUndeterminedProcessed = TRUE;
+                    }
+                }
+            }
+        }
+        else
+        {
+            dataSize = Imm32CompStrAToUndetW(dwGCS, pCS, NULL, 0);
+            if (dataSize)
+            {
+                hGlobal = GlobalAlloc(GHND, dataSize);
+                if (hGlobal)
+                {
+                    PUNDETERMINESTRUCT pUndet = (PUNDETERMINESTRUCT)GlobalLock(hGlobal);
+                    if (Imm32CompStrAToUndetW(dwGCS, pCS, pUndet, (DWORD)dataSize))
+                    {
+                        GlobalUnlock(hGlobal);
+                        if (SendMessageW(hWnd, WM_IME_REPORT, IR_UNDETERMINE, (LPARAM)hGlobal) == 0)
+                            bUndeterminedProcessed = TRUE;
+                    }
+                }
+            }
+        }
+
+        if (hGlobal && !bUndeterminedProcessed)
+        {
+            GlobalUnlock(hGlobal);
+            GlobalFree(hGlobal);
+        }
+        else if (hGlobal && bUndeterminedProcessed)
+        {
+            GlobalFree(hGlobal);
+            return 0;
+        }
+    }
+
+    SIZE_T exSize;
+    HGLOBAL hEx, hStr;
+    PVOID pEx, pStr;
+    BOOL bExSuccess, bStrSuccess;
+    LRESULT res;
+    SIZE_T strSize;
+
+    if (dwGCS & GCS_RESULTSTR)
+    {
+        if (dwGCS & GCS_RESULTREADSTR)
+        {
+            exSize = bIsUnicodeWnd ? Imm32CompStrAToStringExW(dwGCS, pCS, NULL, 0)
+                                   : Imm32CompStrAToStringExA(dwGCS, pCS, NULL, 0);
+            if (exSize)
+            {
+                hEx = GlobalAlloc(GHND, exSize);
+                if (hEx)
+                {
+                    pEx = GlobalLock(hEx);
+                    bExSuccess = bIsUnicodeWnd
+                        ? Imm32CompStrAToStringExW(dwGCS, pCS, pEx, (DWORD)exSize)
+                        : Imm32CompStrAToStringExA(dwGCS, pCS, pEx, (DWORD)exSize);
+                    GlobalUnlock(hEx);
+                    if (bExSuccess)
+                    {
+                        res = bIsUnicodeWnd
+                            ? SendMessageW(hWnd, WM_IME_REPORT, IR_STRINGEX, (LPARAM)hEx)
+                            : SendMessageA(hWnd, WM_IME_REPORT, IR_STRINGEX, (LPARAM)hEx);
+                        if (res)
+                        {
+                            GlobalFree(hEx);
+                            bResultProcessed = TRUE;
+                            goto FINALIZE;
+                        }
+                    }
+                    GlobalFree(hEx);
+                }
+            }
+        }
+
+        strSize = bIsUnicodeWnd ? Imm32CompStrAToStringW(pCS, NULL, 0) : (pCS->dwResultStrLen + 1);
+        if (strSize && strSize != (SIZE_T)-1)
+        {
+            hStr = GlobalAlloc(GHND, strSize);
+            if (hStr)
+            {
+                pStr = GlobalLock(hStr);
+                bStrSuccess = bIsUnicodeWnd
+                    ? Imm32CompStrAToStringW(pCS, pStr, (DWORD)strSize)
+                    : Imm32CompStrAToStringA(pCS, pStr, (DWORD)strSize);
+                GlobalUnlock(hStr);
+                if (bStrSuccess)
+                {
+                    res = bIsUnicodeWnd
+                        ? SendMessageW(hWnd, WM_IME_REPORT, IR_STRING, (LPARAM)hStr)
+                        : SendMessageA(hWnd, WM_IME_REPORT, IR_STRING, (LPARAM)hStr);
+                    if (res)
+                    {
+                        GlobalFree(hStr);
+                        bResultProcessed = TRUE;
+                        goto FINALIZE;
+                    }
+                }
+                GlobalFree(hStr);
+            }
+        }
+
+        if (bIsUnicodeWnd)
+            Imm32CompStrAToCharW(hWnd, pCS);
+        else
+            Imm32CompStrAToCharA(hWnd, pCS);
+
+        bResultProcessed = TRUE;
+    }
+
+FINALIZE:
+    if (!bUndeterminedProcessed)
+    {
+        if (bResultProcessed)
+        {
+            if (dwGCS & GCS_COMPSTR)
+            {
+                pEntries->message = pCurrent->message;
+                pEntries->wParam = pCurrent->wParam;
+                pEntries->lParam =
+                    dwGCS & ~(GCS_RESULTCLAUSE | GCS_RESULTSTR | GCS_RESULTREADCLAUSE |
+                              GCS_RESULTREADSTR);
+                msgCount = 1;
+            }
+        }
+        else
+        {
+            *pEntries = *pCurrent;
+            msgCount = 1;
+        }
+    }
+
+    return msgCount;
+}
+
+DWORD
+Imm32JTransCompositionW(
+    PINPUTCONTEXTDX pIC,
+    PCOMPOSITIONSTRING pCS,
+    PTRANSMSG pCurrent,
+    PTRANSMSG pEntries)
+{
+    HWND hWnd = pIC->hWnd;
+    if (!IsWindow(hWnd))
+        return 0;
+
+    BOOL bIsUnicodeWnd = IsWindowUnicode(hWnd);
+    DWORD dwGCS = (DWORD)pCurrent->lParam;
+    int msgCount = 0;
+    BOOL bUndeterminedProcessed = FALSE;
+    BOOL bResultProcessed = FALSE;
+
+    if (pIC->dwUIFlags & _IME_UI_HIDDEN)
+    {
+        HGLOBAL hGlobal = NULL;
+        SIZE_T dataSize = 0;
+
+        if (!bIsUnicodeWnd)
+        {
+            dataSize = Imm32CompStrWToUndetA(dwGCS, pCS, NULL);
+            if (dataSize)
+            {
+                hGlobal = GlobalAlloc(GHND, dataSize);
+                if (hGlobal)
+                {
+                    PUNDETERMINESTRUCT pUndet = (PUNDETERMINESTRUCT)GlobalLock(hGlobal);
+                    if (Imm32CompStrWToUndetA(dwGCS, pCS, pUndet))
+                    {
+                        GlobalUnlock(hGlobal);
+                        if (SendMessageA(hWnd, WM_IME_REPORT, IR_UNDETERMINE, (LPARAM)hGlobal) == 0)
+                            bUndeterminedProcessed = TRUE;
+                    }
+                }
+            }
+        }
+        else
+        {
+            dataSize = Imm32CompStrWToUndetW(dwGCS, pCS, NULL);
+            if (dataSize)
+            {
+                hGlobal = GlobalAlloc(GHND, dataSize);
+                if (hGlobal)
+                {
+                    PUNDETERMINESTRUCT pUndet = (PUNDETERMINESTRUCT)GlobalLock(hGlobal);
+                    if (Imm32CompStrWToUndetW(dwGCS, pCS, pUndet))
+                    {
+                        GlobalUnlock(hGlobal);
+                        if (SendMessageW(hWnd, WM_IME_REPORT, IR_UNDETERMINE, (LPARAM)hGlobal) == 0)
+                            bUndeterminedProcessed = TRUE;
+                    }
+                }
+            }
+        }
+
+        if (hGlobal && !bUndeterminedProcessed)
+        {
+            GlobalUnlock(hGlobal);
+            GlobalFree(hGlobal);
+        }
+        else if (hGlobal && bUndeterminedProcessed)
+        {
+            GlobalFree(hGlobal);
+            return 0;
+        }
+    }
+
+    SIZE_T exSize;
+    HGLOBAL hEx, hStr;
+    PVOID pEx, pStr;
+    BOOL bExSuccess, bStrSuccess;
+    LRESULT res;
+    SIZE_T strSize;
+
+    if (dwGCS & GCS_RESULTSTR)
+    {
+        if (dwGCS & GCS_RESULTREADSTR)
+        {
+            exSize = bIsUnicodeWnd
+                ? Imm32CompStrWToStringExW(dwGCS, pCS, NULL, 0)
+                : Imm32CompStrWToStringExA(dwGCS, pCS, NULL, 0);
+            if (exSize)
+            {
+                hEx = GlobalAlloc(GHND, exSize);
+                if (hEx)
+                {
+                    pEx = GlobalLock(hEx);
+                    bExSuccess = bIsUnicodeWnd
+                        ? Imm32CompStrWToStringExW(dwGCS, pCS, pEx, (DWORD)exSize)
+                        : Imm32CompStrWToStringExA(dwGCS, pCS, pEx, (DWORD)exSize);
+                    GlobalUnlock(hEx);
+                    if (bExSuccess)
+                    {
+                        res = bIsUnicodeWnd
+                            ? SendMessageW(hWnd, WM_IME_REPORT, IR_STRINGEX, (LPARAM)hEx)
+                            : SendMessageA(hWnd, WM_IME_REPORT, IR_STRINGEX, (LPARAM)hEx);
+                        if (res)
+                        {
+                            GlobalFree(hEx);
+                            bResultProcessed = TRUE;
+                            goto FINALIZE;
+                        }
+                    }
+                    GlobalFree(hEx);
+                }
+            }
+        }
+
+        strSize = bIsUnicodeWnd
+            ? Imm32CompStrWToStringW(pCS, NULL)
+            : Imm32CompStrWToStringA(pCS, NULL);
+        if (strSize && strSize != (SIZE_T)-1)
+        {
+            hStr = GlobalAlloc(GHND, strSize);
+            if (hStr)
+            {
+                pStr = GlobalLock(hStr);
+                bStrSuccess = bIsUnicodeWnd ? Imm32CompStrWToStringW(pCS, pStr)
+                                            : Imm32CompStrWToStringA(pCS, pStr);
+                GlobalUnlock(hStr);
+                if (bStrSuccess)
+                {
+                    res = bIsUnicodeWnd
+                        ? SendMessageW(hWnd, WM_IME_REPORT, IR_STRING, (LPARAM)hStr)
+                        : SendMessageA(hWnd, WM_IME_REPORT, IR_STRING, (LPARAM)hStr);
+                    if (res)
+                    {
+                        GlobalFree(hStr);
+                        bResultProcessed = TRUE;
+                        goto FINALIZE;
+                    }
+                }
+                GlobalFree(hStr);
+            }
+        }
+
+        if (bIsUnicodeWnd)
+            Imm32CompStrWToCharW(hWnd, pCS);
+        else
+            Imm32CompStrWToCharA(hWnd, pCS);
+
+        bResultProcessed = TRUE;
+    }
+
+FINALIZE:
+    if (!bUndeterminedProcessed)
+    {
+        if (bResultProcessed)
+        {
+            if (dwGCS & GCS_COMPSTR)
+            {
+                pEntries->message = pCurrent->message;
+                pEntries->wParam = pCurrent->wParam;
+                pEntries->lParam =
+                    dwGCS & ~(GCS_RESULTCLAUSE | GCS_RESULTSTR | GCS_RESULTREADCLAUSE |
+                              GCS_RESULTREADSTR);
+                msgCount = 1;
+            }
+        }
+        else
+        {
+            *pEntries = *pCurrent;
+            msgCount = 1;
+        }
+    }
+
+    return msgCount;
+}
+
+/* Japanese */
+static DWORD
+WINNLSTranslateMessageJ(DWORD dwCount, PTRANSMSG pEntries, PINPUTCONTEXTDX pIC,
+                        PCOMPOSITIONSTRING pCS, BOOL bAnsi)
+{
+    // Clone the message list with growing
+    SIZE_T dwBufSize = (dwCount + 1) * sizeof(TRANSMSG);
+    PTRANSMSG pBuf = ImmLocalAlloc(HEAP_ZERO_MEMORY, dwBufSize);
+    if (!pBuf)
+        return 0;
+    RtlCopyMemory(pBuf, pEntries, dwCount * sizeof(TRANSMSG));
+
+    HWND hWnd = pIC->hWnd;
+    HWND hwndIme = ImmGetDefaultIMEWnd(hWnd);
+    PTRANSMSG pCurrent = pBuf;
+    DWORD dwResult = 0;
+
+    if (pIC->dwUIFlags & _IME_UI_HIDDEN)
+    {
+        // Find WM_IME_ENDCOMPOSITION
+        PTRANSMSG pEnd = NULL;
+        for (DWORD i = 0; i < dwCount; i++)
+        {
+            if (pBuf[i].message == WM_IME_ENDCOMPOSITION)
+            {
+                pEnd = &pBuf[i];
+                break;
+            }
+        }
+
+        if (pEnd)
+        {
+            // Move WM_IME_ENDCOMPOSITION to the end of the list
+            PTRANSMSG pSrc = pEnd + 1, pDst = pEnd;
+            while (pSrc->message)
+                *pDst++ = *pSrc++;
+
+            pDst->message = WM_IME_ENDCOMPOSITION;
+            pDst->wParam = pDst->lParam = 0;
+        }
+
+        pCurrent = pBuf;
+    }
+
+#define EMIT_ENTRY_J() do { \
+    *pEntries++ = *pCurrent; \
+    dwResult++; \
+} while (0)
+
+    while (pCurrent->message)
+    {
+        switch (pCurrent->message)
         {
             case WM_IME_STARTCOMPOSITION:
                 if (!(pIC->dwUIFlags & _IME_UI_HIDDEN))
                 {
-                    // send IR_OPENCONVERT
-                    if (pIC->cfCompForm.dwStyle != CFS_DEFAULT)
-                        pSendMessage(hWnd, WM_IME_REPORT, IR_OPENCONVERT, 0);
-
-                    goto DoDefault;
+                    // Send IR_OPENCONVERT
+                    if (pIC->cfCompForm.dwStyle)
+                        SendMessageW(hWnd, WM_IME_REPORT, IR_OPENCONVERT, 0);
+                    EMIT_ENTRY_J();
                 }
                 break;
 
             case WM_IME_ENDCOMPOSITION:
-                if (pIC->dwUIFlags & _IME_UI_HIDDEN)
+                if (!(pIC->dwUIFlags & _IME_UI_HIDDEN))
                 {
-                    // send IR_UNDETERMINE
-                    hGlobal = GlobalAlloc(GHND | GMEM_SHARE, sizeof(UNDETERMINESTRUCT));
-                    if (hGlobal)
-                    {
-                        pSendMessage(hWnd, WM_IME_REPORT, IR_UNDETERMINE, (LPARAM)hGlobal);
-                        GlobalFree(hGlobal);
-                    }
+                    // Send IR_CLOSECONVERT
+                    if (pIC->cfCompForm.dwStyle)
+                        SendMessageW(hWnd, WM_IME_REPORT, IR_CLOSECONVERT, 0);
+                    EMIT_ENTRY_J();
                 }
                 else
                 {
-                    // send IR_CLOSECONVERT
-                    if (pIC->cfCompForm.dwStyle != CFS_DEFAULT)
-                        pSendMessage(hWnd, WM_IME_REPORT, IR_CLOSECONVERT, 0);
-
-                    goto DoDefault;
+                    // Send IR_UNDETERMINE
+                    HGLOBAL hMem = GlobalAlloc(GHND | GMEM_SHARE, sizeof(UNDETERMINESTRUCT));
+                    if (hMem)
+                    {
+                        if (IsWindowUnicode(hWnd))
+                            SendMessageW(hWnd, WM_IME_REPORT, IR_UNDETERMINE, (LPARAM)hMem);
+                        else
+                            SendMessageA(hWnd, WM_IME_REPORT, IR_UNDETERMINE, (LPARAM)hMem);
+                        GlobalFree(hMem);
+                    }
                 }
                 break;
 
             case WM_IME_COMPOSITION:
+            {
+                DWORD dwWritten;
                 if (bAnsi)
-                    dwNumber = Imm32JTransCompA(pIC, pCS, pEntry, pTrans);
+                    dwWritten = Imm32JTransCompositionA(pIC, pCS, pCurrent, pEntries);
                 else
-                    dwNumber = Imm32JTransCompW(pIC, pCS, pEntry, pTrans);
+                    dwWritten = Imm32JTransCompositionW(pIC, pCS, pCurrent, pEntries);
 
-                ret += dwNumber;
-                pTrans += dwNumber;
+                dwResult += dwWritten;
+                pEntries += dwWritten;
 
-                // send IR_CHANGECONVERT
-                if (!(pIC->dwUIFlags & _IME_UI_HIDDEN))
-                {
-                    if (pIC->cfCompForm.dwStyle != CFS_DEFAULT)
-                        pSendMessage(hWnd, WM_IME_REPORT, IR_CHANGECONVERT, 0);
-                }
+                // Send IR_CHANGECONVERT
+                if (!(pIC->dwUIFlags & _IME_UI_HIDDEN) && pIC->cfCompForm.dwStyle)
+                    SendMessageW(hWnd, WM_IME_REPORT, IR_CHANGECONVERT, 0);
                 break;
+            }
 
             case WM_IME_NOTIFY:
-                if (pEntry->wParam == IMN_OPENCANDIDATE)
+                if (pCurrent->wParam == IMN_OPENCANDIDATE)
                 {
                     if (IsWindow(hWnd) && (pIC->dwUIFlags & _IME_UI_HIDDEN))
                     {
-                        // send IMC_SETCANDIDATEPOS
-                        for (iCandForm = 0; iCandForm < MAX_CANDIDATEFORM; ++iCandForm)
+                        // Send IMC_SETCANDIDATEPOS
+                        CANDIDATEFORM CandForm;
+                        LPARAM lParam = pCurrent->lParam;
+                        for (DWORD iCandForm = 0; iCandForm < MAX_CANDIDATEFORM; ++iCandForm)
                         {
-                            if (!(pEntry->lParam & (1 << iCandForm)))
+                            if (!(lParam & (1 << iCandForm)))
                                 continue;
 
                             CandForm.dwIndex = iCandForm;
                             CandForm.dwStyle = CFS_EXCLUDE;
                             CandForm.ptCurrentPos = pIC->cfCompForm.ptCurrentPos;
                             CandForm.rcArea = pIC->cfCompForm.rcArea;
-                            pSendMessage(hwndDefIME, WM_IME_CONTROL, IMC_SETCANDIDATEPOS,
+                            SendMessageW(hwndIme, WM_IME_CONTROL, IMC_SETCANDIDATEPOS,
                                          (LPARAM)&CandForm);
                         }
                     }
                 }
 
                 if (!(pIC->dwUIFlags & _IME_UI_HIDDEN))
-                    goto DoDefault;
-
-                // send a WM_IME_NOTIFY notification to the default ime window
-                pSendMessage(hwndDefIME, pEntry->message, pEntry->wParam, pEntry->lParam);
+                    EMIT_ENTRY_J();
+                else
+                    SendMessageW(hwndIme, pCurrent->message, pCurrent->wParam, pCurrent->lParam);
                 break;
 
-DoDefault:
             default:
-                // default processing
-                *pTrans++ = *pEntry;
-                ++ret;
+                EMIT_ENTRY_J();
                 break;
+        }
+
+        pCurrent++;
+    }
+
+#undef EMIT_ENTRY_J
+    ImmLocalFree(pBuf);
+    return dwResult;
+}
+
+/* Korean */
+static DWORD
+WINNLSTranslateMessageK(DWORD dwCount, PTRANSMSG pEntries, PINPUTCONTEXTDX pIC,
+                        PCOMPOSITIONSTRING pCS, BOOL bAnsi)
+{
+    HWND hWnd = pIC->hWnd;
+    HWND hwndIme = ImmGetDefaultIMEWnd(hWnd);
+
+    SIZE_T dwBufSize = (dwCount + 1) * sizeof(TRANSMSG);
+    PTRANSMSG pBuf = ImmLocalAlloc(HEAP_ZERO_MEMORY, dwBufSize);
+    if (!pBuf)
+        return 0;
+    RtlCopyMemory(pBuf, pEntries, dwCount * sizeof(TRANSMSG));
+
+    DWORD dwResult = 0;
+
+    if (pIC->dwUIFlags & _IME_UI_HIDDEN)
+    {
+        PTRANSMSG pEnd = NULL;
+        for (DWORD i = 0; i < dwCount; i++)
+        {
+            if (pBuf[i].message == WM_IME_ENDCOMPOSITION)
+            {
+                pEnd = &pBuf[i];
+                break;
+            }
+        }
+        if (pEnd)
+        {
+            PTRANSMSG pSrc = pEnd + 1, pDst = pEnd;
+            while (pSrc->message)
+                *pDst++ = *pSrc++;
+            pDst->message = WM_IME_ENDCOMPOSITION;
+            pDst->wParam  = 0;
+            pDst->lParam  = 0;
         }
     }
 
-    ImmLocalFree(pTempList);
-    return ret;
-}
+#define EMIT_ENTRY_K() do { \
+    *pEntries++ = *pCurrent; \
+    dwResult++; \
+} while (0)
 
-DWORD
-WINNLSTranslateMessageK(DWORD dwCount, LPTRANSMSG pEntries, LPINPUTCONTEXTDX pIC,
-                        LPCOMPOSITIONSTRING pCS, BOOL bAnsi)
-{
-    FIXME("(0x%X, %p, %p, %p, %d)\n", dwCount, pEntries, pIC, pCS, bAnsi);
-    return dwCount;
+    PTRANSMSG pCurrent = pBuf;
+    while (pCurrent->message)
+    {
+        switch (pCurrent->message)
+        {
+            case WM_IME_STARTCOMPOSITION:
+                if (!(pIC->dwUIFlags & _IME_UI_HIDDEN))
+                {
+                    if (pIC->cfCompForm.dwStyle)
+                        SendMessageW(hWnd, WM_IME_REPORT, IR_OPENCONVERT, 0);
+                    EMIT_ENTRY_K();
+                }
+                break;
+
+            case WM_IME_ENDCOMPOSITION:
+                if (!(pIC->dwUIFlags & _IME_UI_HIDDEN))
+                {
+                    if (pIC->cfCompForm.dwStyle)
+                        SendMessageW(hWnd, WM_IME_REPORT, IR_CLOSECONVERT, 0);
+                    EMIT_ENTRY_K();
+                }
+                else
+                {
+                    HGLOBAL hMem = GlobalAlloc(GHND | GMEM_SHARE, sizeof(UNDETERMINESTRUCT));
+                    if (hMem)
+                    {
+                        if (IsWindowUnicode(hWnd))
+                            SendMessageW(hWnd, WM_IME_REPORT, IR_UNDETERMINE, (LPARAM)hMem);
+                        else
+                            SendMessageA(hWnd, WM_IME_REPORT, IR_UNDETERMINE, (LPARAM)hMem);
+                        GlobalFree(hMem);
+                    }
+                }
+                break;
+
+            case WM_IME_COMPOSITION:
+            {
+                DWORD dwWritten;
+                if (bAnsi)
+                    dwWritten = Imm32JTransCompositionA(pIC, pCS, pCurrent, pEntries);
+                else
+                    dwWritten = Imm32JTransCompositionW(pIC, pCS, pCurrent, pEntries);
+
+                dwResult  += dwWritten;
+                pEntries  += dwWritten;
+
+                if (!(pIC->dwUIFlags & _IME_UI_HIDDEN) && pIC->cfCompForm.dwStyle)
+                    SendMessageW(hWnd, WM_IME_REPORT, IR_CHANGECONVERT, 0);
+                break;
+            }
+
+            case WM_IME_NOTIFY:
+                if (pCurrent->wParam == IMN_OPENCANDIDATE)
+                {
+                    if (IsWindow(hWnd) && (pIC->dwUIFlags & _IME_UI_HIDDEN))
+                    {
+                        CANDIDATEFORM CandForm;
+                        LPARAM lParam = pCurrent->lParam;
+                        for (DWORD iCandForm = 0; iCandForm < MAX_CANDIDATEFORM; ++iCandForm)
+                        {
+                            if (!(lParam & (1 << iCandForm)))
+                                continue;
+                            CandForm.dwIndex     = iCandForm;
+                            CandForm.dwStyle     = CFS_EXCLUDE;
+                            CandForm.ptCurrentPos = pIC->cfCompForm.ptCurrentPos;
+                            CandForm.rcArea      = pIC->cfCompForm.rcArea;
+                            SendMessageW(hwndIme, WM_IME_CONTROL, IMC_SETCANDIDATEPOS,
+                                         (LPARAM)&CandForm);
+                        }
+                    }
+                }
+                if (!(pIC->dwUIFlags & _IME_UI_HIDDEN))
+                    EMIT_ENTRY_K();
+                else
+                    SendMessageW(hwndIme, pCurrent->message, pCurrent->wParam, pCurrent->lParam);
+                break;
+
+            default:
+                EMIT_ENTRY_K();
+                break;
+        }
+
+        pCurrent++;
+    }
+
+#undef EMIT_ENTRY_K
+    ImmLocalFree(pBuf);
+    return dwResult;
 }
 
 #endif /* def IMM_WIN3_SUPPORT */
 
 /* This function is used in ImmGenerateMessage and ImmTranslateMessage */
 DWORD
-WINNLSTranslateMessage(DWORD dwCount, LPTRANSMSG pEntries, HIMC hIMC, BOOL bAnsi, WORD wLang)
+WINNLSTranslateMessage(DWORD dwCount, PTRANSMSG pEntries, HIMC hIMC, BOOL bAnsi, WORD wLang)
 {
 #ifdef IMM_WIN3_SUPPORT
-    DWORD ret = 0;
-    LPINPUTCONTEXTDX pIC;
-    LPCOMPOSITIONSTRING pCS;
-
-    pIC = (LPINPUTCONTEXTDX)ImmLockIMC(hIMC);
-    if (IS_NULL_UNEXPECTEDLY(pIC))
+    PINPUTCONTEXTDX pIC = (PINPUTCONTEXTDX)ImmLockIMC(hIMC);
+    if (!pIC)
         return 0;
 
-    pCS = ImmLockIMCC(pIC->hCompStr);
-    if (IS_NULL_UNEXPECTEDLY(pCS))
+    PCOMPOSITIONSTRING pCompStr = ImmLockIMCC(pIC->hCompStr);
+    if (!pCompStr)
     {
         ImmUnlockIMC(hIMC);
         return 0;
     }
 
-    if (wLang == LANG_JAPANESE)
-        ret = WINNLSTranslateMessageJ(dwCount, pEntries, pIC, pCS, bAnsi);
-    else if (wLang == LANG_KOREAN)
-        ret = WINNLSTranslateMessageK(dwCount, pEntries, pIC, pCS, bAnsi);
+    DWORD ret;
+    if (wLang == LANG_KOREAN)
+        ret = WINNLSTranslateMessageK(dwCount, pEntries, pIC, pCompStr, bAnsi);
+    else if (wLang == LANG_JAPANESE)
+        ret = WINNLSTranslateMessageJ(dwCount, pEntries, pIC, pCompStr, bAnsi);
+    else
+        ret = 0;
 
     ImmUnlockIMCC(pIC->hCompStr);
     ImmUnlockIMC(hIMC);

--- a/win32ss/user/imm32/win3.c
+++ b/win32ss/user/imm32/win3.c
@@ -199,16 +199,13 @@ Imm32CompStrWToUndetA(
 
     if (dwGCS & GCS_COMPSTR)
     {
-        INT cchAnsi = Imm32WideToAnsi(pCompStrW, pCS->dwCompStrLen,
-                                      (PSTR)(pbDet + ib), cbRequired - ib);
+        PSTR pchA = (PSTR)(pbDet + ib);
+        INT cchAnsi = Imm32WideToAnsi(pCompStrW, pCS->dwCompStrLen, pchA, cbRequired - ib);
         pDet->uUndetTextPos = ib;
         pDet->uUndetTextLen = cchAnsi;
         (pbDet + ib)[cchAnsi] = ANSI_NULL;
 
         ib += ALIGN_DWORD(cchAnsi + 1);
-
-        if (pCS->dwCompAttrLen)
-            dwGCS |= GCS_COMPATTR;
 
         if ((dwGCS & GCS_COMPATTR) || pCS->dwCompAttrLen)
         {
@@ -220,7 +217,7 @@ Imm32CompStrWToUndetA(
             UINT ibIndex = 0;
             for (UINT i = 0; i < pCS->dwCompAttrLen; ++i)
             {
-                if (IsDBCSLeadByte(pbDet[pDet->uUndetTextPos + i]))
+                if (IsDBCSLeadByte(pchA[ibIndex]))
                 {
                     pDestAttr[ibIndex++] = pSrcAttr[i];
                     pDestAttr[ibIndex++] = pSrcAttr[i];

--- a/win32ss/user/imm32/win3.c
+++ b/win32ss/user/imm32/win3.c
@@ -456,13 +456,13 @@ Imm32CompStrAToUndetA(
     PUNDETERMINESTRUCT pDet,
     DWORD dwSize)
 {
-    DWORD dwRequiredSize =
+    const DWORD dwRequiredSize =
         sizeof(UNDETERMINESTRUCT) +
-        ALIGN_DWORD(pCS->dwCompStrLen) +
+        ALIGN_DWORD(pCS->dwCompStrLen + sizeof(ANSI_NULL)) +
         ALIGN_DWORD(pCS->dwCompAttrLen) +
-        ALIGN_DWORD(pCS->dwResultStrLen) +
+        ALIGN_DWORD(pCS->dwResultStrLen + sizeof(ANSI_NULL)) +
         ALIGN_DWORD(pCS->dwResultClauseLen) +
-        ALIGN_DWORD(pCS->dwResultReadStrLen) +
+        ALIGN_DWORD(pCS->dwResultReadStrLen + sizeof(ANSI_NULL)) +
         ALIGN_DWORD(pCS->dwResultReadClauseLen);
 
     if (!pDet)
@@ -549,7 +549,7 @@ Imm32CompStrAToUndetW(
     const DWORD dwRequiredSize =
         sizeof(UNDETERMINESTRUCT) +
         ALIGN_DWORD(pCS->dwResultClauseLen) +
-        ALIGN_DWORD(pCS->dwCompAttrLen * sizeof(WCHAR) + sizeof(UNICODE_NULL)) +
+        ALIGN_DWORD(pCS->dwCompAttrLen) +
         ALIGN_DWORD(pCS->dwResultStrLen * sizeof(WCHAR) + sizeof(UNICODE_NULL)) +
         ALIGN_DWORD(pCS->dwCompStrLen * sizeof(WCHAR) + sizeof(UNICODE_NULL)) +
         ALIGN_DWORD(pCS->dwResultReadStrLen * sizeof(WCHAR) + sizeof(UNICODE_NULL)) +
@@ -791,7 +791,7 @@ Imm32CompStrAToStringExW(
         if (nWideResultLen <= 0)
             return 0;
         ((PWSTR)(pBase + dwCurrentOffset))[nWideResultLen] = UNICODE_NULL;
-        dwCurrentOffset += ALIGN_DWORD(nWideResultLen * sizeof(WCHAR) + sizeof(WCHAR));
+        dwCurrentOffset += ALIGN_DWORD((nWideResultLen + 1) * sizeof(WCHAR));
     }
 
     if ((dwGCS & GCS_RESULTCLAUSE) && pCS->dwResultClauseLen > 0 && nWideResultLen > 0)
@@ -819,7 +819,7 @@ Imm32CompStrAToStringExW(
             return 0;
 
         ((PWSTR)(pBase + dwCurrentOffset))[nWideReadLen] = UNICODE_NULL;
-        dwCurrentOffset += ALIGN_DWORD(nWideReadLen * sizeof(WCHAR) + sizeof(WCHAR));
+        dwCurrentOffset += ALIGN_DWORD((nWideReadLen + 1) * sizeof(WCHAR));
     }
 
     if ((dwGCS & GCS_RESULTREADCLAUSE) && pCS->dwResultReadClauseLen > 0 && nWideReadLen > 0)


### PR DESCRIPTION
## Purpose
Completing the IME messaging framework.
JIRA issue: [CORE-19268](https://jira.reactos.org/browse/CORE-19268)

## Proposed changes

- Fix corner cases at `ImmGenerateMessage` and `ImmTranslateMessage` functions.
- Implement `WINNLSTranslateMessage` function.

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64: