### PR TITLE
[USER32_WINETEST] Fix usage of non-conforming swprintf

### DIFF
--- a/modules/rostests/winetests/user32/CMakeLists.txt
+++ b/modules/rostests/winetests/user32/CMakeLists.txt
@@ -2,6 +2,8 @@
 remove_definitions(-DWINVER=0x502 -D_WIN32_WINNT=0x502)
 add_definitions(-DWINVER=0x0A00 -D_WIN32_WINNT=0x0A00 -DNTDDI_VERSION=0x0A000005)
 
+remove_definitions(-D_CRT_NON_CONFORMING_SWPRINTFS)
+
 list(APPEND SOURCE
     broadcast.c
     class.c

--- a/modules/rostests/winetests/user32/input.c
+++ b/modules/rostests/winetests/user32/input.c
@@ -1853,6 +1853,15 @@ static void test_GetMouseMovePointsEx_process(void)
     HDESK desk0, desk1;
     HWINSTA winstation0, winstation1;
 
+#ifdef __REACTOS__
+    if (is_reactos())
+    {
+        ok(FALSE, "Broken on ReactOS\n");
+        skip("Skipping test_GetMouseMovePointsEx_process due to CORE-20552\n");
+        return;
+    }
+#endif
+
     memset( out, 0, sizeof(out) );
     memset( out2, 0, sizeof(out2) );
 

--- a/modules/rostests/winetests/user32/input.c
+++ b/modules/rostests/winetests/user32/input.c
@@ -3637,7 +3637,11 @@ static void test_keyboard_layout_name(void)
 
         for (j = 0; layouts_preload[j]; ++j)
         {
+#ifdef __REACTOS__
+            swprintf( tmpklid, KL_NAMELENGTH, L"%08X", HandleToUlong(layouts_preload[j]) );
+#else
             swprintf( tmpklid, KL_NAMELENGTH, L"%08X", layouts_preload[j] );
+#endif
             if (!wcscmp( tmpklid, klid )) break;
         }
         ok(j < len, "Could not find keyboard layout %s in preload list\n", wine_dbgstr_w(klid));


### PR DESCRIPTION
## Purpose

The code is using the conforming version, but _CRT_NON_CONFORMING_SWPRINTFS was defined, which caused it to crash. After removing the definition, MSVC throws a warning about an invalid argument for the format string, so fix that as well.
Now with those fixes more tests run and one of them (test_GetMouseMovePointsEx_process) causes a desktop leak, which breaks further tests down the line, so disable that test. See CORE-20552.

## Proposed changes

- remove definition of _CRT_NON_CONFORMING_SWPRINTFS
- Fix an MSVC format string warning
- Disable a test that breaks ReactOS

## Testbot runs (Filled in by Devs)

- [x] KVM x86: https://reactos.org/testman/compare.php?ids=106885,106888,106893
- [x] KVM x64: https://reactos.org/testman/compare.php?ids=106864,106866,106870